### PR TITLE
fix(qa): retry transient history rebuilds

### DIFF
--- a/extensions/qa-lab/src/gateway-rpc-client.test.ts
+++ b/extensions/qa-lab/src/gateway-rpc-client.test.ts
@@ -226,4 +226,24 @@ describe("startQaGatewayRpcClient", () => {
     );
     expect(gatewayRpcMock.callGatewayFromCli).toHaveBeenCalledTimes(1);
   });
+
+  it("preserves the structured gateway request failure as the cause", async () => {
+    const gatewayError = Object.assign(new Error("history temporarily unavailable"), {
+      gatewayCode: "UNAVAILABLE",
+      retryable: true,
+      retryAfterMs: 250,
+      details: { method: "chat.history" },
+    });
+    gatewayRpcMock.callGatewayFromCli.mockRejectedValueOnce(gatewayError);
+    const client = await startQaGatewayRpcClient({
+      wsUrl: "ws://127.0.0.1:18789",
+      token: "fixture",
+      logs: () => "qa gateway diagnostics",
+    });
+
+    await expect(client.request("chat.history")).rejects.toMatchObject({
+      message: "history temporarily unavailable\nGateway logs:\nqa gateway diagnostics",
+      cause: gatewayError,
+    });
+  });
 });

--- a/extensions/qa-lab/src/gateway-rpc-client.ts
+++ b/extensions/qa-lab/src/gateway-rpc-client.ts
@@ -15,7 +15,7 @@ type QaGatewayRpcClient = {
 
 function formatQaGatewayRpcError(error: unknown, logs: () => string) {
   const details = formatErrorMessage(error);
-  return new Error(`${details}${formatQaGatewayLogsForError(logs())}`);
+  return new Error(`${details}${formatQaGatewayLogsForError(logs())}`, { cause: error });
 }
 
 function runQueuedQaGatewayRpc<T>(queue: Promise<void>, task: () => Promise<T>) {

--- a/extensions/qa-lab/src/suite-runtime-agent-process.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-agent-process.test.ts
@@ -872,7 +872,7 @@ describe("qa suite runtime agent process helpers", () => {
       .mockRejectedValueOnce(gatewayError)
       .mockResolvedValue({ messages: [{ role: "assistant", content: "still working" }] });
 
-    const error = await waitForAgentHistoryReply(
+    const timeoutError = await waitForAgentHistoryReply(
       { gateway: { call: gatewayCall } } as never,
       "session-history-recovered-timeout",
       () => false,
@@ -880,8 +880,8 @@ describe("qa suite runtime agent process helpers", () => {
       50,
     ).catch((error: unknown) => error);
 
-    expect(error).toBeInstanceOf(Error);
-    expect(error).not.toHaveProperty("cause");
+    expect(timeoutError).toBeInstanceOf(Error);
+    expect(timeoutError).not.toHaveProperty("cause");
     expect(gatewayCall.mock.calls.length).toBeGreaterThanOrEqual(2);
   });
 

--- a/extensions/qa-lab/src/suite-runtime-agent-process.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-agent-process.test.ts
@@ -800,6 +800,108 @@ describe("qa suite runtime agent process helpers", () => {
     );
   });
 
+  it("retries structured transient history failures through gateway log wrappers", async () => {
+    vi.useFakeTimers();
+    try {
+      const gatewayError = Object.assign(new Error("session history is rebuilding"), {
+        gatewayCode: "UNAVAILABLE",
+        retryable: true,
+        retryAfterMs: 250,
+        details: { method: "chat.history" },
+      });
+      const wrappedError = new Error("gateway call failed", {
+        cause: new Error("gateway rpc failed", { cause: gatewayError }),
+      });
+      const gatewayCall = vi
+        .fn()
+        .mockRejectedValueOnce(wrappedError)
+        .mockResolvedValueOnce({
+          messages: [{ role: "assistant", content: "HISTORY-RETRY-OK" }],
+        });
+
+      const pending = waitForAgentHistoryReply(
+        { gateway: { call: gatewayCall } } as never,
+        "session-history-retry",
+        (text) => text === "HISTORY-RETRY-OK",
+        1_000,
+        1,
+      );
+      await vi.advanceTimersByTimeAsync(250);
+
+      await expect(pending).resolves.toEqual({ text: "HISTORY-RETRY-OK" });
+      expect(gatewayCall).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not retry transient gateway errors for a different method", async () => {
+    const gatewayError = Object.assign(new Error("gateway method is rebuilding"), {
+      gatewayCode: "UNAVAILABLE",
+      retryable: true,
+      retryAfterMs: 250,
+      details: { method: "chat.startup" },
+    });
+    const gatewayCall = vi.fn().mockRejectedValueOnce(gatewayError);
+
+    await expect(
+      waitForAgentHistoryReply(
+        { gateway: { call: gatewayCall } } as never,
+        "session-history-wrong-method",
+        () => false,
+        1_000,
+        1,
+      ),
+    ).rejects.toBe(gatewayError);
+    expect(gatewayCall).toHaveBeenCalledOnce();
+  });
+
+  it("does not retry unavailable gateway errors without the retryable contract", async () => {
+    const gatewayError = Object.assign(new Error("history unavailable"), {
+      gatewayCode: "UNAVAILABLE",
+      retryable: false,
+      retryAfterMs: 250,
+      details: { method: "chat.history" },
+    });
+    const gatewayCall = vi.fn().mockRejectedValueOnce(gatewayError);
+
+    await expect(
+      waitForAgentHistoryReply(
+        { gateway: { call: gatewayCall } } as never,
+        "session-history-not-retryable",
+        () => false,
+        1_000,
+        1,
+      ),
+    ).rejects.toBe(gatewayError);
+    expect(gatewayCall).toHaveBeenCalledOnce();
+  });
+
+  it("does not retry retry-shaped predicate failures", async () => {
+    const predicateError = Object.assign(new Error("predicate unavailable"), {
+      gatewayCode: "UNAVAILABLE",
+      retryable: true,
+      retryAfterMs: 250,
+      details: { method: "chat.history" },
+    });
+    const gatewayCall = vi.fn().mockResolvedValueOnce({
+      messages: [{ role: "assistant", content: "candidate reply" }],
+    });
+
+    await expect(
+      waitForAgentHistoryReply(
+        { gateway: { call: gatewayCall } } as never,
+        "session-history-predicate-error",
+        async () => {
+          throw predicateError;
+        },
+        1_000,
+        1,
+      ),
+    ).rejects.toBe(predicateError);
+    expect(gatewayCall).toHaveBeenCalledOnce();
+  });
+
   it("waits for a specific agent run id", async () => {
     const gatewayCall = vi.fn(async () => ({ status: "ok" }));
 

--- a/extensions/qa-lab/src/suite-runtime-agent-process.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-agent-process.test.ts
@@ -835,6 +835,56 @@ describe("qa suite runtime agent process helpers", () => {
     }
   });
 
+  it("preserves the final retryable history failure when the poll deadline expires", async () => {
+    const gatewayError = Object.assign(new Error("session history is rebuilding"), {
+      gatewayCode: "UNAVAILABLE",
+      retryable: true,
+      retryAfterMs: 1,
+      details: { method: "chat.history" },
+    });
+    const wrappedError = new Error("gateway call failed", { cause: gatewayError });
+    const gatewayCall = vi.fn().mockRejectedValue(wrappedError);
+
+    await expect(
+      waitForAgentHistoryReply(
+        { gateway: { call: gatewayCall } } as never,
+        "session-history-retry-timeout",
+        () => false,
+        220,
+        50,
+      ),
+    ).rejects.toMatchObject({
+      message: "timed out after 220ms",
+      cause: wrappedError,
+    });
+    expect(gatewayCall.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("does not attach a recovered history failure to a later predicate timeout", async () => {
+    const gatewayError = Object.assign(new Error("session history is rebuilding"), {
+      gatewayCode: "UNAVAILABLE",
+      retryable: true,
+      retryAfterMs: 1,
+      details: { method: "chat.history" },
+    });
+    const gatewayCall = vi
+      .fn()
+      .mockRejectedValueOnce(gatewayError)
+      .mockResolvedValue({ messages: [{ role: "assistant", content: "still working" }] });
+
+    const error = await waitForAgentHistoryReply(
+      { gateway: { call: gatewayCall } } as never,
+      "session-history-recovered-timeout",
+      () => false,
+      220,
+      50,
+    ).catch((error: unknown) => error);
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).not.toHaveProperty("cause");
+    expect(gatewayCall.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
   it("does not retry transient gateway errors for a different method", async () => {
     const gatewayError = Object.assign(new Error("gateway method is rebuilding"), {
       gatewayCode: "UNAVAILABLE",

--- a/extensions/qa-lab/src/suite-runtime-agent-process.ts
+++ b/extensions/qa-lab/src/suite-runtime-agent-process.ts
@@ -478,16 +478,19 @@ async function waitForAgentHistoryReply(
   intervalMs = 250,
 ) {
   const startedAt = Date.now();
+  let lastRetryableHistoryError: unknown;
   while (Date.now() - startedAt < timeoutMs) {
     let delayMs = intervalMs;
     let text: string | undefined;
     try {
       text = await readLatestAgentHistoryReply(env, sessionKey);
+      lastRetryableHistoryError = undefined;
     } catch (error) {
       const retryDelayMs = resolveRetryableHistoryDelayMs(error);
       if (retryDelayMs === null) {
         throw error;
       }
+      lastRetryableHistoryError = error;
       delayMs = retryDelayMs;
     }
     if (text && (await predicate(text))) {
@@ -499,7 +502,10 @@ async function waitForAgentHistoryReply(
     }
     await sleep(Math.min(delayMs, remainingMs));
   }
-  throw new Error(`timed out after ${timeoutMs}ms`);
+  const message = `timed out after ${timeoutMs}ms`;
+  throw lastRetryableHistoryError === undefined
+    ? new Error(message)
+    : new Error(message, { cause: lastRetryableHistoryError });
 }
 
 async function listCronJobs(env: Pick<QaSuiteRuntimeEnv, "gateway">) {

--- a/extensions/qa-lab/src/suite-runtime-agent-process.ts
+++ b/extensions/qa-lab/src/suite-runtime-agent-process.ts
@@ -53,6 +53,9 @@ const ANSI_ESCAPE_PATTERN = new RegExp(String.raw`\x1B\[[0-?]*[ -/]*[@-~]`, "g")
 const MANAGED_DREAMING_CRON_MARKER = "[managed-by=memory-core.short-term-promotion]";
 const MANAGED_DREAMING_CRON_NAME = "Memory Dreaming Promotion";
 const MANAGED_DREAMING_PROMPT = "__openclaw_memory_core_short_term_promotion_dream__";
+const QA_HISTORY_RETRY_DEFAULT_MS = 250;
+const QA_HISTORY_RETRY_MIN_MS = 100;
+const QA_HISTORY_RETRY_MAX_MS = 5_000;
 
 function stripAnsiCodes(text: string) {
   return text.replace(ANSI_ESCAPE_PATTERN, "");
@@ -442,6 +445,31 @@ async function readLatestAgentHistoryReply(
   return readLatestAssistantTextFromHistory(history);
 }
 
+function resolveRetryableHistoryDelayMs(error: unknown) {
+  let current: unknown = error;
+  // QA adds redacted logs in two wrapper layers. Walk their causes so retry
+  // policy consumes the protocol contract instead of parsing decorated text.
+  for (let depth = 0; depth < 4 && isRecord(current); depth += 1) {
+    const code = current.gatewayCode ?? current.code;
+    if (code === "UNAVAILABLE" && current.retryable === true) {
+      const detailMethod = isRecord(current.details) ? current.details.method : undefined;
+      if (typeof detailMethod !== "string" || detailMethod === "chat.history") {
+        const retryAfterMs = current.retryAfterMs;
+        const rawDelayMs =
+          typeof retryAfterMs === "number" && Number.isFinite(retryAfterMs)
+            ? retryAfterMs
+            : QA_HISTORY_RETRY_DEFAULT_MS;
+        return Math.min(
+          Math.max(Math.floor(rawDelayMs), QA_HISTORY_RETRY_MIN_MS),
+          QA_HISTORY_RETRY_MAX_MS,
+        );
+      }
+    }
+    current = current.cause;
+  }
+  return null;
+}
+
 async function waitForAgentHistoryReply(
   env: Pick<QaSuiteRuntimeEnv, "gateway">,
   sessionKey: string,
@@ -451,7 +479,17 @@ async function waitForAgentHistoryReply(
 ) {
   const startedAt = Date.now();
   while (Date.now() - startedAt < timeoutMs) {
-    const text = await readLatestAgentHistoryReply(env, sessionKey);
+    let delayMs = intervalMs;
+    let text: string | undefined;
+    try {
+      text = await readLatestAgentHistoryReply(env, sessionKey);
+    } catch (error) {
+      const retryDelayMs = resolveRetryableHistoryDelayMs(error);
+      if (retryDelayMs === null) {
+        throw error;
+      }
+      delayMs = retryDelayMs;
+    }
     if (text && (await predicate(text))) {
       return { text };
     }
@@ -459,7 +497,7 @@ async function waitForAgentHistoryReply(
     if (remainingMs <= 0) {
       break;
     }
-    await sleep(Math.min(intervalMs, remainingMs));
+    await sleep(Math.min(delayMs, remainingMs));
   }
   throw new Error(`timed out after ${timeoutMs}ms`);
 }


### PR DESCRIPTION
Fixes #111450

## What Problem This Solves

Private QA flow scenarios fail immediately when `chat.history` temporarily reports that a session transcript is rebuilding, even though the gateway explicitly marks the failure retryable.

## Why This Change Was Made

The QA RPC client now preserves the original structured gateway error as the `cause` when it appends redacted diagnostics. The history poller follows that bounded cause chain and retries only `UNAVAILABLE` errors carrying the gateway's retryable contract for `chat.history`, using a bounded `retryAfterMs` delay.

Retry ownership stays at the polling boundary. Predicate failures, non-retryable failures, and errors for other methods still propagate immediately, and the existing overall poll deadline remains authoritative. This avoids brittle message matching, global RPC retries, or a new public SDK surface.

## User Impact

Maintainers and CI no longer get an immediate false-negative when transcript projection is temporarily rebuilding. Runtime gateway behavior and end-user APIs are unchanged.

AI-assisted: yes. I reproduced the failure against an isolated live gateway, traced the server and client contracts, inspected the history-polling history and sibling behavior, and reviewed the final ownership boundary.

## Evidence

- Pre-fix live reproduction: `chat.history` returned structured retryable `UNAVAILABLE` and the scenario aborted immediately.
- Post-fix live behavior: the same transient error was retried rather than surfaced; the model later produced the exact expected two-line synthesis, although that run crossed the scenario's separate 30-second observation deadline and correctly reported a timeout. The patch does not broaden that deadline.
- Focused QA tests on current `main`: 40/40 passed.
- Persistent-rebuild coverage verifies the final structured failure remains the timeout cause; recovery coverage verifies a successful history read clears stale retry diagnostics.
- Fresh autoreview after the final rebase: clean, 0.93.
- Blacksmith changed-file gate: extension production/test typechecks, lint, formatting, plugin boundaries, import cycles, and supporting guards passed.
- Remote changed-gate proof: https://github.com/openclaw/openclaw/actions/runs/29692936272
- Blacksmith focused proof after the CI lint repair: https://github.com/openclaw/openclaw/actions/runs/29697875443 (`40 passed`, wrapper exit 0).

Redacted post-fix live gateway evidence:

```text
2026-07-19T10:01:41.606-07:00 [ws] chat.history -> UNAVAILABLE: session history is rebuilding; retry shortly
2026-07-19T10:02:06.790-07:00 subagent-1: ok
                                      subagent-2: ok
qa-suite-report.md: Details: timed out after 30000ms
```

The retryable history failure no longer became the scenario error; polling continued until the independent 30-second observation deadline, and the model emitted the expected synthesis just after it.
