### PR TITLE
test(signal): make status reaction timing deterministic

### DIFF
--- a/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
+++ b/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
@@ -640,6 +640,13 @@ describe("signal createSignalEventHandler inbound context", () => {
             },
             channels: { signal: { dmPolicy: "open", allowFrom: ["*"] } },
           } as OpenClawConfig,
+          statusReactionTiming: {
+            debounceMs: 0,
+            doneHoldMs: 0,
+            errorHoldMs: 0,
+            stallSoftMs: 5_000,
+            stallHardMs: 15_000,
+          },
           historyLimit: 0,
         }),
       );
@@ -715,6 +722,13 @@ describe("signal createSignalEventHandler inbound context", () => {
             },
             channels: { signal: { dmPolicy: "open", allowFrom: ["*"] } },
           } as OpenClawConfig,
+          statusReactionTiming: {
+            debounceMs: 0,
+            doneHoldMs: 0,
+            errorHoldMs: 0,
+            stallSoftMs: 5_000,
+            stallHardMs: 15_000,
+          },
           historyLimit: 0,
         }),
       );

--- a/extensions/signal/src/monitor/event-handler.test-harness.ts
+++ b/extensions/signal/src/monitor/event-handler.test-harness.ts
@@ -6,6 +6,13 @@ export function createBaseSignalEventHandlerDeps(
 ): SignalEventHandlerDeps {
   return {
     runtime: { log: () => {}, error: () => {} } as SignalEventHandlerDeps["runtime"],
+    statusReactionTiming: {
+      debounceMs: 0,
+      doneHoldMs: 0,
+      errorHoldMs: 0,
+      stallSoftMs: 60_000,
+      stallHardMs: 120_000,
+    },
     cfg: {},
     baseUrl: "http://localhost",
     accountId: "default",

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -218,6 +218,7 @@ async function finalizeSignalStatusReaction(params: {
 }
 
 export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
+  const statusReactionTiming = deps.statusReactionTiming ?? DEFAULT_TIMING;
   const activeEnqueueEntries = new WeakSet<SignalInboundEntry>();
 
   async function handleSignalInboundMessage(entry: SignalInboundEntry) {
@@ -444,7 +445,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
             },
             initialEmoji: ackReaction,
             emojis: resolveSignalStatusReactionEmojis(statusReactionsConfig.emojis),
-            timing: DEFAULT_TIMING,
+            timing: statusReactionTiming,
             onError: (err) => {
               logAckFailure({
                 log: logVerbose,
@@ -455,7 +456,6 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
             },
           })
         : null;
-    const statusReactionTiming = DEFAULT_TIMING;
     if (statusReactionController) {
       void statusReactionController.setQueued();
     }

--- a/extensions/signal/src/monitor/event-handler.types.ts
+++ b/extensions/signal/src/monitor/event-handler.types.ts
@@ -1,3 +1,4 @@
+import type { StatusReactionTiming } from "openclaw/plugin-sdk/channel-feedback";
 // Signal type declarations define plugin contracts.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type {
@@ -91,6 +92,7 @@ export type SignalNativeReplyContext = {
 
 export type SignalEventHandlerDeps = {
   runtime: RuntimeEnv;
+  statusReactionTiming?: Required<StatusReactionTiming>;
   abortSignal?: AbortSignal;
   runTrackedTask?: (task: () => Promise<void>) => void;
   cfg: OpenClawConfig;


### PR DESCRIPTION
## Summary

- inject deterministic Signal status-reaction timing through the internal handler dependency surface
- preserve built-in production defaults after numeric config tuning removal
- restore Signal extension shard coverage for lifecycle, stall, and reaction cleanup behavior

## Proof

- `node scripts/run-vitest.mjs extensions/signal/src/monitor/event-handler.inbound-context.test.ts` (47 passed)
- `node scripts/run-vitest.mjs extensions/signal/src` (577 passed)
- autoreview clean

Repairs the deterministic Signal failures in Full Release Validation child run https://github.com/openclaw/openclaw/actions/runs/29692820587.
