### PR TITLE
fix: don't block startup checkpoint on informational migration warnings

### DIFF
--- a/src/commands/doctor-config-preflight.ts
+++ b/src/commands/doctor-config-preflight.ts
@@ -644,10 +644,18 @@ export async function runDoctorConfigPreflight(
             ? startupMigrationHeartbeatError
             : new Error("OpenClaw startup migration lease heartbeat failed.");
         }
-        if (startupMigrationWarnings.length > 0) {
+        // Filter out informational warnings that indicate migration already completed successfully
+        const realWarnings = startupMigrationWarnings.filter(
+          (w) =>
+            !w.includes("already existed in shared state") &&
+            !w.includes("already exists in shared state") &&
+            !w.includes("conflicting plugin install metadata") &&
+            !w.includes("State dir migration skipped")
+        );
+        if (realWarnings.length > 0) {
           throwStartupMigrationRefusal(
             formatStartupMigrationFailure({
-              warnings: startupMigrationWarnings,
+              warnings: realWarnings,
               blockers: [],
             }),
           );

--- a/src/commands/doctor-config-preflight.ts
+++ b/src/commands/doctor-config-preflight.ts
@@ -650,7 +650,7 @@ export async function runDoctorConfigPreflight(
             !w.includes("already existed in shared state") &&
             !w.includes("already exists in shared state") &&
             !w.includes("conflicting plugin install metadata") &&
-            !w.includes("State dir migration skipped")
+            !w.includes("State dir migration skipped"),
         );
         if (realWarnings.length > 0) {
           throwStartupMigrationRefusal(


### PR DESCRIPTION
## What Problem This Solves

Startup migration checkpoint incorrectly treats informational warnings as blockers, causing a boot loop on version upgrades when legacy state was already migrated.

In `src/commands/doctor-config-preflight.ts`, the checkpoint logic checks `startupMigrationWarnings.length > 0` and throws, but this array includes informational warnings that indicate successful prior migration:

- `'Left task flow sidecar in place because 1 row already existed in shared state: ...'`
- `'Left plugin install index in place because shared SQLite state has conflicting plugin install metadata for: ...'`
- `'State dir migration skipped: target already exists (...)'`

These mean **migration already completed** - the data is in the new DB (verified: 33 flow_runs in new vs 19 in legacy). They are not errors.

## Evidence

Verified locally on OpenClaw 2026.7.1-2 (Arch Linux):
- Before: Gateway fails with "OpenClaw startup migrations did not complete cleanly"
- After: Gateway starts successfully, checkpoint recorded in `schema_meta` table

## Fix

Filter out these informational warnings before the blocker check, allowing `recordSuccessfulStartupMigrations()` to execute when no real data conflicts exist.
