### PR TITLE
fix(teams-meetings): listening probe accepts timeout option

### DIFF
--- a/extensions/teams-meetings/src/cli.test.ts
+++ b/extensions/teams-meetings/src/cli.test.ts
@@ -1,0 +1,54 @@
+import { Command } from "commander";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const callGatewayFromCliMock = vi.hoisted(() => vi.fn());
+
+vi.mock("openclaw/plugin-sdk/gateway-runtime", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("openclaw/plugin-sdk/gateway-runtime")>()),
+  callGatewayFromCli: callGatewayFromCliMock,
+}));
+
+import { registerTeamsMeetingsCli } from "./cli.js";
+import { resolveTeamsMeetingsConfig } from "./config.js";
+
+const MEETING_URL =
+  "https://teams.microsoft.com/l/meetup-join/19%3ameeting_cli_probe%40thread.v2/0";
+
+afterEach(() => {
+  callGatewayFromCliMock.mockReset();
+  vi.restoreAllMocks();
+});
+
+function createProgram(): Command {
+  const program = new Command();
+  registerTeamsMeetingsCli({ program, config: resolveTeamsMeetingsConfig({}) });
+  return program;
+}
+
+describe("Microsoft Teams meetings CLI", () => {
+  it("exposes the same bounded timeout on both live probes", () => {
+    const root = createProgram().commands.find((command) => command.name() === "teamsmeetings");
+
+    for (const name of ["test-speech", "test-listen"]) {
+      const probe = root?.commands.find((command) => command.name() === name);
+      expect(probe?.options.map((option) => option.long)).toContain("--timeout-ms");
+    }
+  });
+
+  it("forwards the listening probe timeout to the gateway operation", async () => {
+    callGatewayFromCliMock.mockResolvedValue({ ok: true });
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    await createProgram().parseAsync(
+      ["teamsmeetings", "test-listen", MEETING_URL, "--timeout-ms", "90000"],
+      { from: "user" },
+    );
+
+    expect(callGatewayFromCliMock).toHaveBeenCalledWith(
+      "teamsmeetings.testListen",
+      { json: true, timeout: "120000" },
+      { url: MEETING_URL, timeoutMs: 90_000 },
+      { progress: false, scopes: ["operator.admin"] },
+    );
+  });
+});

--- a/extensions/teams-meetings/src/cli.ts
+++ b/extensions/teams-meetings/src/cli.ts
@@ -158,10 +158,8 @@ export function registerTeamsMeetingsCli(params: {
     ],
   ] as const) {
     const command = root.command(`${name} <url>`).description(description);
-    (name === "test-speech" ? addProbeOptions(command) : addJoinOptions(command)).action(
-      async (url: string, options: JoinOptions) => {
-        await call({ config: params.config, method, payload: joinPayload(url, options) });
-      },
-    );
+    addProbeOptions(command).action(async (url: string, options: JoinOptions) => {
+      await call({ config: params.config, method, payload: joinPayload(url, options) });
+    });
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running the Microsoft Teams listening probe from the CLI could not set `--timeout-ms`. Commander rejected the option even though the gateway and listening runtime already support a per-request probe timeout.

## Why This Change Was Made

Both Teams live-probe commands now use the shared probe option registration. This exposes the existing timeout parser and gateway deadline behavior for `test-listen` without changing runtime defaults or adding configuration.

## User Impact

Teams users can bound how long `teamsmeetings test-listen` waits for caption activity, matching the existing `test-speech` CLI behavior.

## Evidence

- Exact head: `c01af75c98d66d2fe00731f5cddaea37d5ced166`.
- Real behavior proof used a temporary isolated checkout at that exact head, with an isolated HOME/state/config and a loopback Gateway. It did not use a mocked `callGatewayFromCli`.
- Real CLI help exited 0 and listed `--timeout-ms <ms>` for `teamsmeetings test-listen`.
- Real command executed:

```text
openclaw teamsmeetings test-listen <redacted-teams-url> --timeout-ms 1234
```

- The command exited 0. Gateway logs confirmed that the `teams-meetings` plugin loaded, and the real plugin handler returned a probe result rather than a Commander error:

```json
{
  "createdSession": true,
  "inCall": false,
  "manualActionRequired": true,
  "manualActionReason": "browser-control-unavailable",
  "listenVerified": false,
  "listenTimedOut": false,
  "session": {
    "transport": "chrome",
    "mode": "transcribe"
  }
}
```

- `browser-control-unavailable` is the expected runtime result for this isolated proof because no authenticated Teams browser session was attached. It proves the option was accepted and the request reached the real Gateway/plugin probe path.
- `node scripts/run-vitest.mjs extensions/teams-meetings/src/cli.test.ts extensions/teams-meetings/src/runtime-probes.test.ts extensions/teams-meetings/index.test.ts` — 3 files, 13 tests passed.
- Targeted Oxfmt and Oxlint checks passed for the two changed files.
- `git diff origin/main...HEAD --check` passed.
