### PR TITLE
fix(nextcloud-talk): stabilize room timeout validation

### DIFF
--- a/extensions/nextcloud-talk/src/room-info.fetch-timeout.test.ts
+++ b/extensions/nextcloud-talk/src/room-info.fetch-timeout.test.ts
@@ -3,6 +3,8 @@ import { withServer } from "openclaw/plugin-sdk/test-env";
 import { describe, expect, it, vi } from "vitest";
 import { resolveNextcloudTalkRoomKind } from "./room-info.js";
 
+const REQUEST_TIMEOUT_MS = 500;
+
 describe("nextcloud talk room info fetch timeout", () => {
   it("bounds hanging room info GET requests", async () => {
     let received = false;
@@ -32,7 +34,7 @@ describe("nextcloud talk room info fetch timeout", () => {
             exit: vi.fn(),
             log: vi.fn(),
           },
-          timeoutMs: 50,
+          timeoutMs: REQUEST_TIMEOUT_MS,
         });
 
         expect(kind).toBeUndefined();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the Nextcloud Talk real-HTTP timeout proof could expire before the local test server received the request under loaded CI runners.

## Why This Change Was Made

The test keeps its hanging-request timeout contract but uses a 500 ms bound, leaving scheduling and server-startup headroom while remaining far below the production timeout.

## User Impact

No product behavior changes. Plugin prerelease validation no longer fails because a 50 ms test-only deadline elapsed before request dispatch.

## Evidence

- Failed release child: [run 29695677729](https://github.com/openclaw/openclaw/actions/runs/29695677729), `received` remained false after two attempts.
- Focused real-HTTP timeout test: 10 consecutive passes.
- Formatting and diff checks: green.
- `autoreview`: no accepted or actionable findings.
