### PR TITLE
fix: honor provider token defaults for custom models

### DIFF
--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -181,6 +181,12 @@ export function applyModelDefaults(
       }
       const providerApi = normalizedProvider.api;
       const nextProvider = normalizedProvider;
+      const providerContextWindow = isPositiveNumber(nextProvider.contextWindow)
+        ? nextProvider.contextWindow
+        : undefined;
+      const providerMaxTokens = isPositiveNumber(nextProvider.maxTokens)
+        ? nextProvider.maxTokens
+        : undefined;
       if (nextProvider !== provider) {
         mutated = true;
       }
@@ -220,13 +226,15 @@ export function applyModelDefaults(
 
         const contextWindow = isPositiveNumber(raw.contextWindow)
           ? raw.contextWindow
-          : DEFAULT_CONTEXT_TOKENS;
+          : (providerContextWindow ?? DEFAULT_CONTEXT_TOKENS);
         if (raw.contextWindow !== contextWindow) {
           modelMutated = true;
         }
 
         const defaultMaxTokens = Math.min(DEFAULT_MODEL_MAX_TOKENS, contextWindow);
-        const rawMaxTokens = isPositiveNumber(raw.maxTokens) ? raw.maxTokens : defaultMaxTokens;
+        const rawMaxTokens = isPositiveNumber(raw.maxTokens)
+          ? raw.maxTokens
+          : (providerMaxTokens ?? defaultMaxTokens);
         const maxTokens = resolveNormalizedProviderModelMaxTokens({
           providerId,
           modelId: id,

--- a/src/config/model-alias-defaults.test.ts
+++ b/src/config/model-alias-defaults.test.ts
@@ -22,6 +22,14 @@ vi.mock("./provider-policy.js", () => ({
 
 const emptyManifestRegistry = { plugins: [] } satisfies Pick<PluginManifestRegistry, "plugins">;
 
+type ProxyProviderConfig = OpenClawConfig & {
+  models: {
+    providers: {
+      myproxy: ModelProviderConfig;
+    };
+  };
+};
+
 function applyModelDefaults(
   cfg: OpenClawConfig,
   options?: Parameters<typeof applyModelDefaultsWithPolicy>[1],
@@ -41,7 +49,10 @@ describe("applyModelDefaults", () => {
     providerPolicyMocks.normalizeProviderConfigForConfigDefaults.mockReturnValueOnce(provider);
   }
 
-  function buildProxyProviderConfig(overrides?: { contextWindow?: number; maxTokens?: number }) {
+  function buildProxyProviderConfig(overrides?: {
+    contextWindow?: number;
+    maxTokens?: number;
+  }): ProxyProviderConfig {
     return {
       models: {
         providers: {
@@ -63,7 +74,7 @@ describe("applyModelDefaults", () => {
           },
         },
       },
-    } satisfies OpenClawConfig;
+    } satisfies ProxyProviderConfig;
   }
 
   function buildProviderLevelDefaultsConfig(overrides?: {

--- a/src/config/model-alias-defaults.test.ts
+++ b/src/config/model-alias-defaults.test.ts
@@ -5,7 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { DEFAULT_CONTEXT_TOKENS } from "../agents/defaults.js";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import { applyModelDefaults as applyModelDefaultsWithPolicy } from "./defaults.js";
-import type { ModelProviderConfig, OpenClawConfig } from "./types.js";
+import type { ModelDefinitionConfig, ModelProviderConfig, OpenClawConfig } from "./types.js";
 
 const providerPolicyMocks = vi.hoisted(() => ({
   normalizeProviderConfigForConfigDefaults: vi.fn(
@@ -64,6 +64,26 @@ describe("applyModelDefaults", () => {
         },
       },
     } satisfies OpenClawConfig;
+  }
+
+  function buildProviderLevelDefaultsConfig(overrides?: {
+    contextWindow?: number;
+    maxTokens?: number;
+  }) {
+    const cfg = buildProxyProviderConfig();
+    const provider = cfg.models.providers.myproxy;
+    provider.contextWindow = overrides?.contextWindow ?? 50_000;
+    provider.maxTokens = overrides?.maxTokens ?? 4_096;
+
+    const model = expectDefined(
+      provider.models[0],
+      "cfg.models.providers.myproxy.models[0] test invariant",
+    );
+    const modelInput: Partial<ModelDefinitionConfig> = model;
+    delete modelInput.contextWindow;
+    delete modelInput.maxTokens;
+
+    return cfg;
   }
 
   function buildMistralProviderConfig(overrides?: {
@@ -430,33 +450,39 @@ describe("applyModelDefaults", () => {
   });
 
   it("inherits provider-level context and output token defaults", () => {
-    const cfg = {
-      models: {
-        providers: {
-          myproxy: {
-            baseUrl: "https://proxy.example/v1",
-            api: "openai-completions",
-            contextWindow: 50_000,
-            maxTokens: 4_096,
-            models: [
-              {
-                id: "custom-model",
-                name: "Custom",
-                reasoning: false,
-                input: ["text"],
-                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-              },
-            ],
-          },
-        },
-      },
-    } satisfies OpenClawConfig;
+    const cfg = buildProviderLevelDefaultsConfig();
 
     const next = applyModelDefaults(cfg);
     const model = next.models?.providers?.myproxy?.models?.[0];
 
     expect(model?.contextWindow).toBe(50_000);
     expect(model?.maxTokens).toBe(4_096);
+  });
+
+  it("preserves model-level token limits over provider defaults", () => {
+    const cfg = buildProxyProviderConfig({ contextWindow: 32_000, maxTokens: 2_048 });
+    const provider = cfg.models.providers.myproxy;
+    provider.contextWindow = 50_000;
+    provider.maxTokens = 4_096;
+
+    const next = applyModelDefaults(cfg);
+    const model = next.models?.providers?.myproxy?.models?.[0];
+
+    expect(model?.contextWindow).toBe(32_000);
+    expect(model?.maxTokens).toBe(2_048);
+  });
+
+  it("clamps inherited provider maxTokens to the inherited context window", () => {
+    const cfg = buildProviderLevelDefaultsConfig({
+      contextWindow: 32_768,
+      maxTokens: 40_960,
+    });
+
+    const next = applyModelDefaults(cfg);
+    const model = next.models?.providers?.myproxy?.models?.[0];
+
+    expect(model?.contextWindow).toBe(32_768);
+    expect(model?.maxTokens).toBe(32_768);
   });
 
   it("clamps maxTokens to contextWindow", () => {

--- a/src/config/model-alias-defaults.test.ts
+++ b/src/config/model-alias-defaults.test.ts
@@ -429,6 +429,36 @@ describe("applyModelDefaults", () => {
     expect(model?.maxTokens).toBe(8192);
   });
 
+  it("inherits provider-level context and output token defaults", () => {
+    const cfg = {
+      models: {
+        providers: {
+          myproxy: {
+            baseUrl: "https://proxy.example/v1",
+            api: "openai-completions",
+            contextWindow: 50_000,
+            maxTokens: 4_096,
+            models: [
+              {
+                id: "custom-model",
+                name: "Custom",
+                reasoning: false,
+                input: ["text"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+              },
+            ],
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    const next = applyModelDefaults(cfg);
+    const model = next.models?.providers?.myproxy?.models?.[0];
+
+    expect(model?.contextWindow).toBe(50_000);
+    expect(model?.maxTokens).toBe(4_096);
+  });
+
   it("clamps maxTokens to contextWindow", () => {
     const cfg = buildProxyProviderConfig({ contextWindow: 32768, maxTokens: 40960 });
 


### PR DESCRIPTION
Closes #105803

## What Problem This Solves

Fixes an issue where users configuring provider-level `contextWindow` or `maxTokens` for custom models would have those values ignored when model defaults were applied.

## Why This Change Was Made

Model defaulting now inherits positive provider-level context and output token limits when the individual model omits them, before falling back to built-in defaults. Explicit model values and the existing max-token normalization and clamping behavior remain unchanged.

## User Impact

Custom provider configurations can define shared token limits once at the provider level, and models without their own overrides now receive those intended values.

## Evidence

- `node scripts/run-vitest.mjs src/config/model-alias-defaults.test.ts` — 21 tests passed.
- New regression coverage verifies provider inheritance, explicit model-level override precedence, and clamping an inherited provider `maxTokens` value to the inherited context window.
- `oxfmt --check src/config/defaults.ts src/config/model-alias-defaults.test.ts` — passed.
- `git diff --check` — passed.
- AI-assisted: Codex helped implement and validate this change; the author reviewed and understands the resulting code.
- The repository `autoreview` helper was attempted, but its isolated Codex runtime could not initialize PATH aliases on native Windows.