### PR TITLE
fix: preserve message-only terminal output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Control UI terminal error messages:** preserve message-only assistant output beginning with `Error:` or a warning marker instead of treating text prefixes as synthetic failures. Thanks @shakkernerd.
 - **Channel outbound echo suppression:** drop recently emitted platform message and source identities at shared inbound admission and migrate Discord thread unbinds off channel-local expiry state, preventing delayed webhook copies from re-entering agents.
 - **Reef startup reconciliation:** contain retryable relay failures during startup without supervisor restart loops, while preserving definitive-error and cancellation handling. Thanks @Yigtwxx.
 - **Codex stale-session replies:** stop model fallback after another gateway supersedes a Codex session generation and deliver a safe retry notice instead of abandoning the message silently.

--- a/ui/src/pages/chat/chat-gateway.test.ts
+++ b/ui/src/pages/chat/chat-gateway.test.ts
@@ -2049,26 +2049,28 @@ describe("handleChatGatewayEvent", () => {
     expect(state.chatRunError).toEqual({ summary: "Error: raw gateway error" });
   });
 
-  it("uses a legacy error payload message as alert text when errorMessage is absent", () => {
-    const state = createState({
-      sessionKey: "main",
-      chatRunId: "run-1",
-    });
+  it.each([
+    "Error: the configuration uses an unsupported field.",
+    "⚠️ This operation may require additional review.",
+  ])("preserves message-only terminal output beginning with %s", (text) => {
+    const state = createState({ sessionKey: "main", chatRunId: "run-1" });
+    const message = {
+      role: "assistant",
+      content: [{ type: "text", text }],
+      timestamp: 10,
+    };
+
     const payload: ChatEventPayload = {
       runId: "run-1",
       sessionKey: "main",
       state: "error",
-      message: {
-        role: "assistant",
-        content: [{ type: "text", text: "Error: legacy gateway failure" }],
-        timestamp: 10,
-      },
+      message,
     };
 
     expect(handleChatGatewayEvent(state, payload)).toBe("error");
-    expect(state.chatMessages).toEqual([]);
+    expect(state.chatMessages).toEqual([message]);
     expect(state.lastError).toBeNull();
-    expect(state.chatRunError).toEqual({ summary: "Error: legacy gateway failure" });
+    expect(state.chatRunError).toEqual({ summary: "chat error" });
   });
 
   it("preserves a legacy terminal message that completes streamed assistant content", () => {

--- a/ui/src/pages/chat/chat-gateway.ts
+++ b/ui/src/pages/chat/chat-gateway.ts
@@ -158,7 +158,7 @@ function payloadMessageIsErrorProjection(
   }
   const errorText = payload.errorMessage?.trim();
   if (!errorText) {
-    return messageText.startsWith("⚠️") || /^Error:\s*/iu.test(messageText);
+    return false;
   }
   return (
     normalizeChatErrorComparisonText(messageText) === normalizeChatErrorComparisonText(errorText)


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where genuine terminal assistant output could be removed when an error event omitted `errorMessage` and its message began with `Error:` or a warning marker.

## Why This Change Was Made

Message text is no longer classified as an error projection by prefix alone. The Control UI suppresses a terminal message only when a present `errorMessage` normalizes to the same text; message-only output remains in history while the run shows a generic error alert.

## User Impact

Genuine assistant output remains visible after terminal failures, including messages that legitimately begin with `Error:` or a warning marker.

## Evidence

- Blacksmith Testbox: `pnpm test ui/src/pages/chat/chat-gateway.test.ts` — 140 passed.
- Blacksmith Testbox: `pnpm check:changed` — passed.
- `oxfmt --check` and `git diff --check` — passed.
- Auto-review: clean, no actionable findings (0.93 confidence).

AI-assisted: yes. No agent transcript is attached.
