### PR TITLE
fix(ui): stop chat normalizers throwing on null/undefined message entries

### DIFF
--- a/ui/src/lib/chat/message-normalizer.test.ts
+++ b/ui/src/lib/chat/message-normalizer.test.ts
@@ -1,12 +1,41 @@
 // @vitest-environment node
 // Control UI tests cover message normalizer behavior.
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { normalizeMessage } from "./message-normalizer.ts";
+import {
+  isStandaloneToolMessageForDisplay,
+  isToolResultMessage,
+  normalizeMessage,
+} from "./message-normalizer.ts";
 
 const SENDER_METADATA_BLOCK =
   'Sender (untrusted metadata):\n```json\n{"label":"openclaw-control-ui","id":"openclaw-control-ui"}\n```';
 
 describe("message-normalizer", () => {
+  // Regression: gateway/transcript events can carry a null/undefined or
+  // non-object entry (e.g. a transcript row without a `message`). `typeof
+  // m.role` still reads `.role` off the object, so an undefined entry threw
+  // "Cannot read properties of undefined (reading 'role')" inside the gateway
+  // event handler. These entry points must degrade to a safe default instead.
+  describe("malformed input never throws", () => {
+    it.each([undefined, null, "raw string", 42, true])(
+      "normalizeMessage(%o) yields role 'unknown' without throwing",
+      (input) => {
+        expect(() => normalizeMessage(input)).not.toThrow();
+        expect(normalizeMessage(input).role).toBe("unknown");
+      },
+    );
+
+    it.each([undefined, null, "raw string", 42, true])(
+      "tool-message predicates return false for %o without throwing",
+      (input) => {
+        expect(() => isToolResultMessage(input)).not.toThrow();
+        expect(() => isStandaloneToolMessageForDisplay(input)).not.toThrow();
+        expect(isToolResultMessage(input)).toBe(false);
+        expect(isStandaloneToolMessageForDisplay(input)).toBe(false);
+      },
+    );
+  });
+
   describe("normalizeMessage", () => {
     beforeEach(() => {
       vi.useFakeTimers();

--- a/ui/src/lib/chat/message-normalizer.ts
+++ b/ui/src/lib/chat/message-normalizer.ts
@@ -16,6 +16,16 @@ import { getMediaFileExtension } from "../media-file-extension.ts";
 import type { NormalizedMessage, MessageContentItem } from "./chat-types.ts";
 import { formatSenderLabel, normalizeSenderIdentity } from "./sender-label.ts";
 
+// These normalizers take `unknown` gateway/transcript data. A malformed or
+// absent entry can arrive as null/undefined (e.g. a transcript row without a
+// `message`), and `typeof m.role` still throws "reading 'role'" when `m` itself
+// is undefined — the typeof only guards the property, not the object. Coercing
+// a non-object to `{}` keeps every downstream `typeof m.<field>` check working
+// and yields role "unknown" instead of crashing the gateway event handler.
+function asMessageRecord(message: unknown): Record<string, unknown> {
+  return message && typeof message === "object" ? (message as Record<string, unknown>) : {};
+}
+
 export function normalizeRoleForGrouping(role: string): string {
   const lower = role.toLowerCase();
   if (lower === "user") {
@@ -39,13 +49,13 @@ export function normalizeRoleForGrouping(role: string): string {
 }
 
 export function isToolResultMessage(message: unknown): boolean {
-  const m = message as Record<string, unknown>;
+  const m = asMessageRecord(message);
   const role = typeof m.role === "string" ? m.role.toLowerCase() : "";
   return role === "toolresult" || role === "tool_result";
 }
 
 export function isStandaloneToolMessageForDisplay(message: unknown): boolean {
-  const m = message as Record<string, unknown>;
+  const m = asMessageRecord(message);
   const role = typeof m.role === "string" ? normalizeRoleForGrouping(m.role) : "unknown";
   return (
     role === "tool" ||
@@ -363,7 +373,7 @@ function expandTextContent(text: string): {
  * Normalize a raw message object into a consistent structure.
  */
 export function normalizeMessage(message: unknown): NormalizedMessage {
-  const m = message as Record<string, unknown>;
+  const m = asMessageRecord(message);
   let role = typeof m.role === "string" ? m.role : "unknown";
 
   // Detect tool messages by common gateway shapes.


### PR DESCRIPTION
## Problem

On the live team instance the Control UI throws a recurring **caught** error on nearly every gateway WebSocket event:

```
[gateway] event listener handler error: TypeError: Cannot read properties of undefined (reading 'role')
  at ... chat-message chunk <- chat-page event handler <- Ce.handleMessage <- WebSocket
```

It's caught by the gateway event dispatcher (no white-screen — Model Setup and avatars render fine), but it floods the console and some chat/transcript updates can fail to process.

## Root cause

`normalizeMessage`, `isToolResultMessage`, and `isStandaloneToolMessageForDisplay` take `unknown` input, cast it to `Record<string, unknown>`, then read `typeof m.role`. `typeof` guards the *property value*, not the *object* — `typeof m.role` still evaluates `m.role`, so when `m` itself is `undefined` it throws `reading 'role'`.

`groupMessages` calls the raw `normalizeMessage(item.message)` (chat-thread.ts:396), and `item.message` is `unknown` — absent for a pending send or a malformed transcript row (this path grew with the durable-rolling-transcript work + author-avatar grouping). The codebase already had a `safeNormalizeMessage` try/catch wrapper acknowledging this hazard, but the grouping path used the unguarded entry point.

## Fix

Coerce non-object input to `{}` at the source (`asMessageRecord`), so every downstream `typeof m.<field>` check works and role degrades to `"unknown"` instead of crashing. Behavior is byte-identical for valid object input.

## Test

Added a regression block asserting the three entry points never throw and return safe defaults for `undefined | null | string | number | boolean`. Full UI vitest project green (the one failing `chat-responsive.browser.test.ts` is an unrelated ~40s timeout flake under full-file load — it passes in isolation and doesn't reference the normalizer).
