### PR TITLE
feat(control-ui): relative commit age + hover-only copy button on About

### DIFF
--- a/scripts/control-ui-mock-dev.ts
+++ b/scripts/control-ui-mock-dev.ts
@@ -1628,6 +1628,7 @@ const server = await createServer({
     "globalThis.OPENCLAW_CONTROL_UI_BUILD_INFO": JSON.stringify({
       version: "2026.7.10",
       commit: "0123456789abcdef0123456789abcdef01234567",
+      commitAt: "2026-07-10T11:22:33.000Z",
       builtAt: "2026-07-10T12:34:56.000Z",
       buildId: "mock",
     }),

--- a/ui/src/app/vite-config.node.test.ts
+++ b/ui/src/app/vite-config.node.test.ts
@@ -42,6 +42,7 @@ describe("Control UI Vite config", () => {
 
   it("embeds one canonical artifact identity from explicit build inputs", () => {
     const readGitCommit = vi.fn(() => "f".repeat(40));
+    const readGitCommitTimestamp = vi.fn(() => "2026-07-10T10:11:12.000Z");
     expect(
       resolveControlUiBuildInfo({
         env: {
@@ -49,6 +50,7 @@ describe("Control UI Vite config", () => {
           OPENCLAW_BUILD_TIMESTAMP: "2026-07-10T12:34:56Z",
         },
         readGitCommit,
+        readGitCommitTimestamp,
         readGitBranch: () => null,
         readGitDirty: () => null,
         readPackageVersion: () => "2026.7.10",
@@ -56,12 +58,14 @@ describe("Control UI Vite config", () => {
     ).toEqual({
       version: "2026.7.10",
       commit: "0123456789abcdef0123456789abcdef01234567",
+      commitAt: "2026-07-10T10:11:12.000Z",
       builtAt: "2026-07-10T12:34:56.000Z",
       branch: null,
       dirty: null,
       buildId: "2026.7.10-0123456789ab-2026-07-10T12-34-56.000Z",
     });
     expect(readGitCommit).not.toHaveBeenCalled();
+    expect(readGitCommitTimestamp).toHaveBeenCalledWith("0123456789abcdef0123456789abcdef01234567");
   });
 
   it("falls back to Git and the current UTC time only when inputs are absent", () => {
@@ -70,6 +74,7 @@ describe("Control UI Vite config", () => {
         env: {},
         now: () => new Date("2026-07-10T13:14:15.000Z"),
         readGitCommit: () => "a".repeat(40),
+        readGitCommitTimestamp: () => null,
         readGitBranch: () => null,
         readGitDirty: () => null,
         readPackageVersion: () => null,
@@ -77,6 +82,7 @@ describe("Control UI Vite config", () => {
     ).toEqual({
       version: null,
       commit: "a".repeat(40),
+      commitAt: null,
       builtAt: "2026-07-10T13:14:15.000Z",
       branch: null,
       dirty: null,

--- a/ui/src/build-info-normalizers.ts
+++ b/ui/src/build-info-normalizers.ts
@@ -60,6 +60,7 @@ export function normalizeControlUiBuildInfo(value: unknown): ControlUiBuildInfo 
   const metadata = { version, commit, builtAt };
   return {
     ...metadata,
+    commitAt: normalizeControlUiBuildTimestamp(record.commitAt),
     branch: normalizeControlUiBranch(record.branch),
     dirty: typeof record.dirty === "boolean" ? record.dirty : null,
     buildId: normalizeControlUiBuildId(record.buildId ?? deriveControlUiBuildId(metadata)),

--- a/ui/src/build-info-types.ts
+++ b/ui/src/build-info-types.ts
@@ -1,6 +1,7 @@
 export type ControlUiBuildInfo = Readonly<{
   version: string | null;
   commit: string | null;
+  commitAt: string | null;
   builtAt: string | null;
   branch: string | null;
   dirty: boolean | null;

--- a/ui/src/build-info.test.ts
+++ b/ui/src/build-info.test.ts
@@ -42,6 +42,12 @@ describe("Control UI build info", () => {
     expect(
       normalizeControlUiBuildInfo({ builtAt: "2026-07-10T12:34:56+00:00" }).builtAt,
     ).toBeNull();
+    expect(normalizeControlUiBuildInfo({ commitAt: "2026-07-10T11:22:33Z" }).commitAt).toBe(
+      "2026-07-10T11:22:33.000Z",
+    );
+    expect(
+      normalizeControlUiBuildInfo({ commitAt: "2026-07-10T11:22:33+02:00" }).commitAt,
+    ).toBeNull();
   });
 
   it("renders invalid injected metadata as unavailable instead of inventing identity", () => {
@@ -49,6 +55,7 @@ describe("Control UI build info", () => {
       normalizeControlUiBuildInfo({
         version: "  ",
         commit: "deadbeef",
+        commitAt: "later",
         builtAt: "later",
         branch: "HEAD",
         dirty: "yes",
@@ -57,6 +64,7 @@ describe("Control UI build info", () => {
     ).toEqual({
       version: null,
       commit: null,
+      commitAt: null,
       builtAt: null,
       branch: null,
       dirty: null,

--- a/ui/src/components/sidebar-build-chip.node.test.ts
+++ b/ui/src/components/sidebar-build-chip.node.test.ts
@@ -9,6 +9,7 @@ function buildInfo(overrides: Partial<ControlUiBuildInfo> = {}): ControlUiBuildI
   return {
     version: "2026.7.10",
     commit: COMMIT,
+    commitAt: null,
     builtAt: BUILT_AT,
     branch: "main",
     dirty: false,

--- a/ui/src/e2e/build-info-unicode.e2e.test.ts
+++ b/ui/src/e2e/build-info-unicode.e2e.test.ts
@@ -81,6 +81,7 @@ describeControlUiE2e("Control UI Unicode build identity mocked Gateway E2E", () 
     server = await startControlUiE2eServer({
       version: "2026.7.10",
       commit: "0123456789abcdef0123456789abcdef01234567",
+      commitAt: "2026-07-10T11:22:33.000Z",
       builtAt: "2026-07-10T12:34:56.000Z",
       branch: RAW_BRANCH,
       dirty: true,

--- a/ui/src/pages/about/view.test.ts
+++ b/ui/src/pages/about/view.test.ts
@@ -8,6 +8,7 @@ import { renderAbout } from "./view.ts";
 type AboutProps = Parameters<typeof renderAbout>[0];
 
 const COMMIT = "0123456789abcdef0123456789abcdef01234567";
+const COMMIT_AT = "2026-07-10T11:22:33.000Z";
 const BUILT_AT = "2026-07-10T12:34:56.000Z";
 
 function createProps(overrides: Partial<AboutProps> = {}): AboutProps {
@@ -15,6 +16,7 @@ function createProps(overrides: Partial<AboutProps> = {}): AboutProps {
     buildInfo: {
       version: "2026.7.10",
       commit: COMMIT,
+      commitAt: COMMIT_AT,
       builtAt: BUILT_AT,
       branch: "feature/build-chip",
       dirty: true,
@@ -91,6 +93,15 @@ describe("renderAbout", () => {
     expect(values?.[1]?.querySelector("code")?.getAttribute("title")).toBe(COMMIT);
     expect(values?.[1]?.querySelector("code")?.getAttribute("dir")).toBe("ltr");
 
+    const commitAge = values?.[1]?.querySelector("time.about-commit__age");
+    expect(commitAge?.getAttribute("datetime")).toBe(COMMIT_AT);
+    expect(commitAge?.textContent?.trim()).not.toBe("");
+    expect(commitAge?.getAttribute("title")).toBe(
+      new Intl.DateTimeFormat("en", { dateStyle: "medium", timeStyle: "short" }).format(
+        new Date(COMMIT_AT),
+      ),
+    );
+
     expect(values?.[2]?.textContent).toContain("feature/build-chip*");
 
     const time = values?.[3]?.querySelector("time");
@@ -102,6 +113,15 @@ describe("renderAbout", () => {
         new Date(BUILT_AT),
       ),
     );
+  });
+
+  it("keeps the commit hash without an age when no commit timestamp is embedded", () => {
+    const container = document.createElement("div");
+    const props = createProps();
+    render(renderAbout({ ...props, buildInfo: { ...props.buildInfo, commitAt: null } }), container);
+
+    expect(container.querySelector(".about-commit code")?.textContent).toBe(COMMIT.slice(0, 12));
+    expect(container.querySelector(".about-commit__age")).toBeNull();
   });
 
   it("keeps the connected Gateway version separate from the browser artifact", () => {
@@ -136,6 +156,7 @@ describe("renderAbout", () => {
           buildInfo: {
             version: null,
             commit: null,
+            commitAt: null,
             builtAt: null,
             branch: null,
             dirty: null,

--- a/ui/src/pages/about/view.ts
+++ b/ui/src/pages/about/view.ts
@@ -17,6 +17,7 @@ import {
 import "../../components/tooltip.ts";
 import { i18n, t } from "../../i18n/index.ts";
 import { buildExternalLinkRel, EXTERNAL_LINK_TARGET } from "../../lib/external-link.ts";
+import { formatRelativeTimestamp } from "../../lib/format.ts";
 import "../../styles/about.css";
 import { brandIcons } from "./brand-icons.ts";
 
@@ -102,6 +103,27 @@ function renderUnavailable() {
   return html`<span class="muted">${t("aboutPage.unavailable")}</span>`;
 }
 
+// Always-relative commit age; the exact localized timestamp lives on hover
+// (title) so the row stays compact for any artifact age.
+function renderCommitAge(commitAt: string | null) {
+  if (!commitAt) {
+    return nothing;
+  }
+  const timestamp = Date.parse(commitAt);
+  if (!Number.isFinite(timestamp)) {
+    return nothing;
+  }
+  const exact = new Intl.DateTimeFormat(i18n.getLocale(), {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(timestamp));
+  return html`
+    <time class="about-commit__age" dir="auto" datetime=${commitAt} title=${exact}
+      >${formatRelativeTimestamp(timestamp, { fallback: "" })}</time
+    >
+  `;
+}
+
 function renderCommit(props: AboutProps) {
   const commit = props.buildInfo.commit;
   if (!commit) {
@@ -114,7 +136,7 @@ function renderCommit(props: AboutProps) {
       <openclaw-tooltip .content=${label}>
         <button
           type="button"
-          class="btn btn--icon"
+          class="about-commit__copy"
           aria-label=${label}
           aria-busy=${props.copyState === "copying" ? "true" : nothing}
           ?disabled=${props.copyState === "copying"}
@@ -123,6 +145,7 @@ function renderCommit(props: AboutProps) {
           <span aria-hidden="true">${props.copyState === "copied" ? icons.check : icons.copy}</span>
         </button>
       </openclaw-tooltip>
+      ${renderCommitAge(props.buildInfo.commitAt)}
       <span class="about-sr-only" role="status" aria-live="polite"
         >${copyStatus(props.copyState)}</span
       >

--- a/ui/src/styles/about.css
+++ b/ui/src/styles/about.css
@@ -233,6 +233,59 @@
   user-select: all;
 }
 
+/* Borderless inline copy affordance; kept tiny so the hash stays the focus. */
+.about-commit__copy {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 3px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  transition:
+    opacity var(--duration-fast, 120ms) ease,
+    color var(--duration-fast, 120ms) ease,
+    background var(--duration-fast, 120ms) ease;
+}
+
+.about-commit__copy:hover,
+.about-commit__copy:focus-visible {
+  color: var(--text-strong);
+  background: var(--bg-hover);
+}
+
+.about-commit__copy svg {
+  display: block;
+  width: 14px;
+  height: 14px;
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 1.5px;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+/* Hover-revealed only where hover exists; touch/keyboard keep it visible
+   (focus-within covers tabbing, coarse pointers never match the media query). */
+@media (hover: hover) and (pointer: fine) {
+  .about-commit .about-commit__copy {
+    opacity: 0;
+  }
+
+  .about-commit:hover .about-commit__copy,
+  .about-commit:focus-within .about-commit__copy {
+    opacity: 1;
+  }
+}
+
+.about-commit__age {
+  color: var(--muted);
+  font-size: var(--control-ui-text-xs, 12px);
+  white-space: nowrap;
+}
+
 /* Screen-reader-only live region for copy feedback (no shared utility yet). */
 .about-sr-only {
   position: absolute;

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -157,6 +157,7 @@ export async function startControlUiE2eServer(
   buildInfo: ControlUiBuildInfo = {
     version: "2026.7.10",
     commit: "0123456789abcdef0123456789abcdef01234567",
+    commitAt: "2026-07-10T11:22:33.000Z",
     builtAt: "2026-07-10T12:34:56.000Z",
     branch: null,
     dirty: false,

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -123,6 +123,20 @@ function readGitBranch(): string | null {
   }
 }
 
+function readGitCommitTimestamp(commit: string): string | null {
+  try {
+    const raw = execFileSync("git", ["-C", repoRoot, "show", "-s", "--format=%ct", commit], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    const seconds = Number.parseInt(raw.trim(), 10);
+    const date = new Date(seconds * 1000);
+    return Number.isNaN(date.getTime()) ? null : date.toISOString();
+  } catch {
+    return null;
+  }
+}
+
 function readGitDirty(): boolean | null {
   try {
     const raw = execFileSync("git", ["-C", repoRoot, "status", "--porcelain"], {
@@ -140,6 +154,7 @@ type ControlUiBuildInfoSources = {
   now?: () => Date;
   readPackageVersion?: () => string | null;
   readGitCommit?: () => string | null;
+  readGitCommitTimestamp?: (commit: string) => string | null;
   readGitBranch?: () => string | null;
   readGitDirty?: () => boolean | null;
 };
@@ -187,6 +202,14 @@ export function resolveControlUiBuildInfo(
     throw new Error("GITHUB_SHA must be a full 40-character hexadecimal SHA");
   }
   const commit = envCommit ?? normalizedGitCommit ?? normalizedGithubCommit;
+  // Commit time is advisory identity like branch/dirty: read from the local
+  // object store for the exact embedded commit, null when no checkout has it
+  // (e.g. GITHUB_SHA-only builds). It must never block a build.
+  const commitAt = commit
+    ? normalizeControlUiBuildInfo({
+        commitAt: (sources.readGitCommitTimestamp ?? readGitCommitTimestamp)(commit),
+      }).commitAt
+    : null;
   const builtAt = normalizeBuildTimestamp(
     env.OPENCLAW_BUILD_TIMESTAMP,
     sources.now ?? (() => new Date()),
@@ -204,6 +227,7 @@ export function resolveControlUiBuildInfo(
   const explicitBuildId = env.OPENCLAW_CONTROL_UI_BUILD_ID?.trim();
   return {
     ...metadata,
+    commitAt,
     branch,
     dirty,
     buildId: normalizeControlUiBuildInfo(


### PR DESCRIPTION
## What Problem This Solves

On Settings → About, the commit row's copy button is a full-size bordered icon button that visually dominates the commit hash, and there is no way to tell how old the running artifact's commit is without resolving the hash manually.

## Why This Change Was Made

Requested by the maintainer: make the copy affordance small, borderless, and hover-revealed, and show a relative commit date ("1h ago", "3d ago") with the exact timestamp on hover.

- The build identity now embeds `commitAt` (committer time of the exact embedded commit, read via `git show -s --format=%ct <commit>` at build time). It is advisory like `branch`/`dirty`: `null` never blocks a build (e.g. `GITHUB_SHA`-only builds without a checkout), and the row simply omits the age.
- The About page renders the age with the shared `formatRelativeTimestamp` helper (always relative, matching the rest of Control UI) inside a `<time>` element whose `title` carries the exact localized date+time.
- The copy button drops `btn btn--icon` for a compact borderless `about-commit__copy` style; it is hover/focus-revealed only where hover exists (`@media (hover: hover) and (pointer: fine)`), so touch devices keep it visible and keyboard users get it via `:focus-within`.

## User Impact

The About commit row shows `f8e35afecc67 · 3d ago` with a tiny copy icon appearing on hover; hovering the age shows the exact commit timestamp. No config or API surface changes; `ControlUiBuildInfo` gains one nullable field that normalizes to `null` for older injected payloads.

Before / after (idle) / after (hover):

![before](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/about-commit-date-copy-hover/before.png)
![after idle](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/about-commit-date-copy-hover/after-idle.png)
![after hover](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/about-commit-date-copy-hover/after-hover.png)

## Evidence

- `node scripts/run-vitest.mjs ui/src/pages/about/view.test.ts ui/src/build-info.test.ts ui/src/app/vite-config.node.test.ts ui/src/components/sidebar-build-chip.node.test.ts` — 37 tests pass, including new coverage for the age element, missing-`commitAt` fallback, normalizer rejection of non-UTC timestamps, and the vite resolver wiring.
- Live-verified in the Control UI mock-dev harness (screenshots above): age renders "9d ago" for the mock's Jul 10 commit, copy button hidden at rest and revealed on hover.
- Codex autoreview clean on the final diff.
