### PR TITLE
fix(workboard): keep completed artifacts after run cleanup

### DIFF
--- a/docs/plugins/sdk-runtime.md
+++ b/docs/plugins/sdk-runtime.md
@@ -36,7 +36,7 @@ register(api) {
 - [Background work](/plugins/sdk-runtime/background-work) — hook agent turns, subagent runs, and Task Flow record binding.
 - [Gateway and nodes](/plugins/sdk-runtime/gateway-and-nodes) — in-process Gateway requests, paired node invocation, and Gateway service events.
 - [Media helpers](/plugins/sdk-runtime/media) — speech, media understanding, image/video/music generation, web search, and media utilities.
-- [State and system](/plugins/sdk-runtime/state-and-system) — config snapshot, SQLite-backed plugin state, system utilities, events, and logging.
+- [State and system](/plugins/sdk-runtime/state-and-system) — config snapshot, SQLite-backed plugin state, worktree retention, system utilities, events, and logging.
 - [Channel helpers](/plugins/sdk-runtime/channel) — channel-specific runtime helper groups for chunking, routing, pairing, media, and mentions.
 
 ## Runtime namespaces
@@ -68,6 +68,7 @@ Every `api.runtime` namespace and the page that documents it.
 | `api.runtime.modelConfig`        | [Model helpers](/plugins/sdk-runtime/models#api-runtime-modelconfig)            |
 | `api.runtime.modelAuth`          | [Model helpers](/plugins/sdk-runtime/models#api-runtime-modelauth)              |
 | `api.runtime.state`              | [State and system](/plugins/sdk-runtime/state-and-system#api-runtime-state)     |
+| `api.runtime.worktrees`          | [State and system](/plugins/sdk-runtime/state-and-system#api-runtime-worktrees) |
 | `api.runtime.channel`            | [Channel helpers](/plugins/sdk-runtime/channel#api-runtime-channel)             |
 
 ## Storing runtime references

--- a/docs/plugins/sdk-runtime/state-and-system.md
+++ b/docs/plugins/sdk-runtime/state-and-system.md
@@ -162,8 +162,9 @@ The runtime config snapshot, durable plugin-scoped storage, worktree retention, 
     }
     ```
 
-    This read-only lookup returns the immutable registry ID, or `undefined` if the path
-    is not a live worktree owned by that card. Persist that ID and a fresh `claimId` in
+    This read-only lookup returns the immutable registry ID for a card-owned live worktree
+    or a removed worktree with a recorded snapshot reference; otherwise it returns
+    `undefined`. Persist that ID and a fresh `claimId` in
     the card owner's prepared generation before acquisition. Claim IDs must be nonempty.
     The following `generation` values must come from that durable record; replaying the
     same preparation uses the same ID, while retrying a cancelled mutation needs a new one:
@@ -192,12 +193,17 @@ The runtime config snapshot, durable plugin-scoped storage, worktree retention, 
     Claims are keyed by worktree ID and claim ID. Release is idempotent and terminal,
     even if it arrives before acquisition: that generation can never become active again.
     A later reference uses a new generation; an ordinary card edit can reuse its still-active
-    generation. Acquisition returns `false` for a released claim, removed worktree, or
-    owner mismatch, and throws if removal is in progress. Release of a permanently deleted
+    generation. Acquisition returns `false` for a released claim, unknown registry ID,
+    removed worktree without a recorded snapshot reference, or owner mismatch, and throws
+    if removal is in progress. Release of a permanently deleted
     registry ID succeeds without recreating a row; an owner mismatch returns `false`.
 
     Active claims survive Gateway restarts and protect automatic run-end, idle, count,
-    and size cleanup. Explicit operator removal still applies. Released records remain
+    and size cleanup. An existing reference can enroll while its checkout is removed,
+    protecting the same identity if it is restored. Enrollment does not verify Git objects,
+    provisioning metadata, repository availability, or successful recovery; restore owns
+    those checks. Explicit operator removal and existing removed-snapshot expiry still
+    apply. Released records remain
     through checkout removal and restore, and are pruned with their registry identity.
     See [Workboard artifact retention](/reference/database-schemas#workboard-artifact-retention)
     for recovery and downgrade boundaries.

--- a/docs/plugins/sdk-runtime/state-and-system.md
+++ b/docs/plugins/sdk-runtime/state-and-system.md
@@ -1,14 +1,15 @@
 ---
-summary: "Config snapshot, SQLite-backed plugin state, system utilities, events, and logging"
+summary: "Config snapshot, SQLite-backed plugin state, worktree retention, system utilities, events, and logging"
 read_when:
   - You need durable keyed or blob storage scoped to your plugin
+  - You need to retain managed worktrees for durable artifact references
   - You are buffering channel ingress across restarts
   - You need the config snapshot, system utilities, events, or a scoped logger
 title: "Plugin runtime state and system"
 sidebarTitle: "State and system"
 ---
 
-The runtime config snapshot, durable plugin-scoped storage, system utilities, event subscriptions, and logging. Part of the [Plugin runtime helpers](/plugins/sdk-runtime) reference; [Config and utilities](/plugins/sdk-runtime/config-and-utilities#config-loading-and-writes) covers the wider config read and write guidance.
+The runtime config snapshot, durable plugin-scoped storage, worktree retention, system utilities, event subscriptions, and logging. Part of the [Plugin runtime helpers](/plugins/sdk-runtime) reference; [Config and utilities](/plugins/sdk-runtime/config-and-utilities#config-loading-and-writes) covers the wider config read and write guidance.
 
 ## State, config, and system namespaces
 
@@ -143,6 +144,63 @@ The runtime config snapshot, durable plugin-scoped storage, system utilities, ev
     <Warning>
     `openBlobStore`, `openKeyedStore`, `openSyncKeyedStore`, `openChannelIngressQueue`, and `openChannelIngressDrain` are available only to bundled plugins and trusted official plugin installations in this release. Refusals include the recorded reason, registry database path, origin, and install source/spec; `plugins inspect` reports the same trust facts. A load path selecting the recorded official installation preserves trust; an untracked local copy does not. See [Trusted plugin state refused](/tools/plugin#trusted-plugin-state-refused) for doctor migrations and cause-specific remedies. An untrusted channel's ingress monitor fails channel start instead of running without a durable queue.
     </Warning>
+
+  </Accordion>
+  <Accordion title="api.runtime.worktrees">
+    Manage Workboard-owned Git worktrees without importing core worktree internals.
+
+    Resolve the exact card-owned worktree before preparing a durable artifact reference:
+
+    ```typescript
+    const worktreeId = await api.runtime.worktrees.resolveRetentionTarget({
+      path: workspace.path,
+      ownerKind: "workboard",
+      ownerId: card.id,
+    });
+    if (!worktreeId) {
+      throw new Error("The card's managed worktree is unavailable");
+    }
+    ```
+
+    This read-only lookup returns the immutable registry ID, or `undefined` if the path
+    is not a live worktree owned by that card. Persist that ID and a fresh `claimId` in
+    the card owner's prepared generation before acquisition. Claim IDs must be nonempty.
+    The following `generation` values must come from that durable record; replaying the
+    same preparation uses the same ID, while retrying a cancelled mutation needs a new one:
+
+    ```typescript
+    const claim = {
+      worktreeId: generation.worktreeId,
+      ownerKind: "workboard" as const,
+      ownerId: card.id,
+      claimId: generation.claimId,
+    };
+    const retained = await api.runtime.worktrees.setRetentionClaim({
+      ...claim,
+      active: true,
+    });
+    if (!retained) {
+      throw new Error("Retention was cancelled or the worktree is unavailable");
+    }
+    ```
+
+    Acquire before publishing the reference. Commit the card, its active generation, and
+    any previous generation's cleanup obligation in one transaction in the card owner's
+    database. Only then release an obsolete generation with
+    `setRetentionClaim({ ...claim, active: false })`. Do not keep cleanup only in memory.
+
+    Claims are keyed by worktree ID and claim ID. Release is idempotent and terminal,
+    even if it arrives before acquisition: that generation can never become active again.
+    A later reference uses a new generation; an ordinary card edit can reuse its still-active
+    generation. Acquisition returns `false` for a released claim, removed worktree, or
+    owner mismatch, and throws if removal is in progress. Release of a permanently deleted
+    registry ID succeeds without recreating a row; an owner mismatch returns `false`.
+
+    Active claims survive Gateway restarts and protect automatic run-end, idle, count,
+    and size cleanup. Explicit operator removal still applies. Released records remain
+    through checkout removal and restore, and are pruned with their registry identity.
+    See [Workboard artifact retention](/reference/database-schemas#workboard-artifact-retention)
+    for recovery and downgrade boundaries.
 
   </Accordion>
 </AccordionGroup>

--- a/docs/reference/database-schemas.md
+++ b/docs/reference/database-schemas.md
@@ -274,7 +274,8 @@ deliberately has no cascading card foreign key: deleting the card must not erase
 unfinished cleanup. Only one generation per card can be active. Startup cancels
 unfinished preparations, enrolls existing cards, and retries pending releases;
 normal mutations also retry cleanup, and the running Workboard service retries
-on its 60-second maintenance cadence. A cleanup outage retains its obligation
+on its 60-second maintenance cadence. A startup reconciliation failure is logged
+without disabling change events or this retry. A cleanup outage retains its obligation
 without reporting an already committed card write as failed. A concurrent
 cancellation prevents that prepared generation from
 publishing; the caller must retry the mutation.
@@ -284,14 +285,17 @@ means active protection. Release records a terminal timestamp even when it
 arrives before acquisition, so delayed work cannot resurrect a cancelled claim.
 Released generations do not block collection. Their records remain until the
 immutable worktree registry row is deleted, including across explicit checkout
-removal and restore. There is no timer-based expiry for an active claim or its
-terminal receipt. See [Worktree runtime helpers](/plugins/sdk-runtime/state-and-system#api-runtime-worktrees)
+removal and restore. Claims and terminal receipts have no independent expiry;
+they are deleted with the registry identity, including its existing removed-snapshot
+expiry. See [Worktree runtime helpers](/plugins/sdk-runtime/state-and-system#api-runtime-worktrees)
 for the API.
 
 Both retention tables are same-version additive surfaces: the Workboard schema
 ensures its journal when opened, and the shared service lazily ensures its claim
-table on first use. Existing cards can acquire protection during enrollment, but
-enrollment cannot restore files that an older build already deleted. Stable
+table on first use. Existing cards can enroll live worktrees or removed identities
+with recorded snapshot references, protecting the same identity after restore.
+Enrollment neither restores files nor verifies that the snapshot is recoverable.
+Explicit removal and removed-snapshot expiry are unchanged. Stable
 builds predating retention do not enforce these claims; unchanged numeric schema
 versions do not make rollback artifact-safe. Preserve needed artifacts outside
 managed worktrees before running such a build.

--- a/docs/reference/database-schemas.md
+++ b/docs/reference/database-schemas.md
@@ -255,6 +255,55 @@ Checkpoint Git artifacts live under `state/repository-workspaces/<workspace-id>.
 
 Accepted checkpoint history and publication source artifacts remain until explicit session deletion, including after Stop, archive, reset, or Gateway restart. There is no timed checkpoint expiry. Deletion retires publication requests and source ownership before removing their artifact repository; failed cleanup is reported. The managed-worktree idle cleanup and snapshot retention rules do not apply to these checkpoints.
 
+### Workboard artifact retention
+
+Workboard keeps artifact-reference decisions in
+`~/.openclaw/plugins/workboard/workboard.sqlite`. The managed-worktree service
+enforces them through `worktree_retention_claims` in the shared
+`state/openclaw.sqlite` database. Core does not read Workboard cards.
+
+The Workboard-owned `workboard_artifact_retention` table records a unique
+`claim_id`, `card_id`, immutable `worktree_id`, and one lifecycle state:
+
+- `prepared`: intent persisted before acquiring protection in the shared database.
+- `active`: protection published with the card reference in the same Workboard transaction.
+- `release_pending`: an obsolete or cancelled generation awaiting terminal release.
+
+Card update or deletion and its cleanup obligation commit together. The journal
+deliberately has no cascading card foreign key: deleting the card must not erase
+unfinished cleanup. Only one generation per card can be active. Startup cancels
+unfinished preparations, enrolls existing cards, and retries pending releases;
+normal mutations also retry cleanup, and the running Workboard service retries
+on its 60-second maintenance cadence. A cleanup outage retains its obligation
+without reporting an already committed card write as failed. A concurrent
+cancellation prevents that prepared generation from
+publishing; the caller must retry the mutation.
+
+Shared claims use `(worktree_id, claim_id)` as their key. `released_at IS NULL`
+means active protection. Release records a terminal timestamp even when it
+arrives before acquisition, so delayed work cannot resurrect a cancelled claim.
+Released generations do not block collection. Their records remain until the
+immutable worktree registry row is deleted, including across explicit checkout
+removal and restore. There is no timer-based expiry for an active claim or its
+terminal receipt. See [Worktree runtime helpers](/plugins/sdk-runtime/state-and-system#api-runtime-worktrees)
+for the API.
+
+Both retention tables are same-version additive surfaces: the Workboard schema
+ensures its journal when opened, and the shared service lazily ensures its claim
+table on first use. Existing cards can acquire protection during enrollment, but
+enrollment cannot restore files that an older build already deleted. Stable
+builds predating retention do not enforce these claims; unchanged numeric schema
+versions do not make rollback artifact-safe. Preserve needed artifacts outside
+managed worktrees before running such a build.
+
+Earlier unmerged previews used fixed claim IDs and a different claim-table shape.
+Automatic migration or adoption of those preview records is not implemented.
+Operators with preview state must preserve their artifacts and arrange an
+explicit migration or a disposable-state reset before switching; do not delete
+the shared state database to repair one feature. The
+[contributor design discussion](https://github.com/openclaw/openclaw/pull/111497#issuecomment-5575236708)
+records this proposal's boundaries, not maintainer approval or release availability.
+
 ## Versioning contract
 
 Each database records its published schema in two places:

--- a/extensions/workboard/index.ts
+++ b/extensions/workboard/index.ts
@@ -23,7 +23,7 @@ export default definePluginEntry({
   name: "Workboard",
   description: "Dashboard workboard for agent-owned issues and sessions.",
   register(api) {
-    const store = WorkboardStore.openSqlite();
+    const store = WorkboardStore.openSqlite({ worktrees: api.runtime.worktrees });
     const resourceServices: Array<{ stop(): void }> = [];
     registerWorkboardStoreLifecycle(api, store, () => {
       for (const service of resourceServices) {

--- a/extensions/workboard/src/artifact-retention.test.ts
+++ b/extensions/workboard/src/artifact-retention.test.ts
@@ -1,0 +1,310 @@
+import { execFile } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
+import { closeOpenClawStateDatabaseForTest } from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { IDLE_GC_MS, ManagedWorktreeService } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { withWorkboardArtifactRetention } from "./artifact-retention.js";
+import { cleanupWorkboardCardWorktree } from "./dispatcher-workspace.js";
+import { isWorkboardCardStore } from "./persistence-types.js";
+import { createWorkboardSqliteStores } from "./sqlite-store.js";
+import { WorkboardStore } from "./store.js";
+
+const execFileAsync = promisify(execFile);
+
+async function git(cwd: string, ...args: string[]): Promise<void> {
+  await execFileAsync("git", ["-C", cwd, ...args]);
+}
+
+describe("Workboard artifact worktree retention", () => {
+  let root: string;
+  let repo: string;
+  let env: NodeJS.ProcessEnv;
+  let now: number;
+  let service: ManagedWorktreeService;
+  let sqlite: ReturnType<typeof createWorkboardSqliteStores>;
+  let store: WorkboardStore;
+
+  beforeEach(async () => {
+    // openclaw-temp-dir: allow extension tests cannot import the core-only tracker.
+    root = await fs.mkdtemp(path.join(await fs.realpath(os.tmpdir()), "workboard-retention-"));
+    repo = path.join(root, "repo");
+    await fs.mkdir(repo);
+    await git(repo, "init", "-b", "main");
+    await git(repo, "config", "user.name", "OpenClaw Test");
+    await git(repo, "config", "user.email", "openclaw-test@example.invalid");
+    await fs.writeFile(path.join(repo, "README.md"), "base\n");
+    await fs.writeFile(path.join(repo, ".gitignore"), "dist/\n");
+    await git(repo, "add", "README.md", ".gitignore");
+    await git(repo, "commit", "-m", "initial");
+    const remote = path.join(root, "remote.git");
+    await execFileAsync("git", ["clone", "--bare", repo, remote]);
+    await git(repo, "remote", "add", "origin", remote);
+    await git(repo, "push", "-u", "origin", "main");
+    repo = await fs.realpath(repo);
+    env = { ...process.env, OPENCLAW_STATE_DIR: path.join(root, "state") };
+    now = 1_700_000_000_000;
+    service = new ManagedWorktreeService({ env, now: () => now });
+    sqlite = createWorkboardSqliteStores({ env });
+    const cards = withWorkboardArtifactRetention(sqlite.cards, retentionWorktrees());
+    expect(isWorkboardCardStore(cards)).toBe(true);
+    store = new WorkboardStore(cards, {
+      boards: sqlite.boards,
+      subscriptions: sqlite.subscriptions,
+      attachments: sqlite.attachments,
+      dataVersion: sqlite.dataVersion,
+    });
+  });
+
+  afterEach(async () => {
+    sqlite.close();
+    closeOpenClawStateDatabaseForTest();
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  async function createCardWorktree(name: string) {
+    const card = await store.create({
+      title: name,
+      status: "done",
+      runId: `run-${name}`,
+    });
+    const worktree = await service.create({
+      repoRoot: repo,
+      name,
+      ownerKind: "workboard",
+      ownerId: card.id,
+    });
+    await service.acquire(worktree.id);
+    await store.update(card.id, {
+      workspace: {
+        kind: "worktree",
+        path: worktree.path,
+        branch: worktree.branch,
+        sourcePath: repo,
+        sourceBranch: "main",
+      },
+      workspaceAccess: { unrestricted: true },
+    });
+    return { card, worktree };
+  }
+
+  function retentionWorktrees(
+    activeService = service,
+  ): Pick<PluginRuntime["worktrees"], "setRetentionClaim"> {
+    return {
+      setRetentionClaim: async (params) =>
+        activeService.setRetentionClaimByPath(
+          params.path,
+          { ownerKind: params.ownerKind, ownerId: params.ownerId },
+          { claimId: params.claimId, active: params.active },
+        ),
+    };
+  }
+
+  function runtimeWorktrees(activeService = service) {
+    return {
+      release: async ({ path: worktreePath }: { path: string }) => {
+        await activeService.releaseByPath(worktreePath);
+      },
+      removeIfLossless: async (params: { path: string; ownerKind: "workboard"; ownerId: string }) =>
+        await activeService.removeIfLosslessByPath(params.path, {
+          ownerKind: params.ownerKind,
+          ownerId: params.ownerId,
+        }),
+    };
+  }
+
+  function restartWithRetentionStore() {
+    sqlite.close();
+    closeOpenClawStateDatabaseForTest();
+    service = new ManagedWorktreeService({ env, now: () => now });
+    sqlite = createWorkboardSqliteStores({ env });
+    const cards = withWorkboardArtifactRetention(sqlite.cards, retentionWorktrees());
+    store = new WorkboardStore(cards, {
+      boards: sqlite.boards,
+      subscriptions: sqlite.subscriptions,
+      attachments: sqlite.attachments,
+      dataVersion: sqlite.dataVersion,
+    });
+    return cards;
+  }
+
+  async function cleanupCardWorktree(cardId: string, activeService = service) {
+    const card = await store.get(cardId);
+    if (!card) {
+      throw new Error(`card not found: ${cardId}`);
+    }
+    await cleanupWorkboardCardWorktree({
+      store,
+      worktrees: runtimeWorktrees(activeService),
+      card,
+    });
+  }
+
+  async function createLegacyArtifactCard(name: string) {
+    const legacyStore = new WorkboardStore(sqlite.cards, {
+      boards: sqlite.boards,
+      subscriptions: sqlite.subscriptions,
+      attachments: sqlite.attachments,
+      dataVersion: sqlite.dataVersion,
+    });
+    const card = await legacyStore.create({ title: name, status: "done", runId: `run-${name}` });
+    const worktree = await service.create({
+      repoRoot: repo,
+      name,
+      ownerKind: "workboard",
+      ownerId: card.id,
+    });
+    await service.acquire(worktree.id);
+    await legacyStore.update(card.id, {
+      workspace: {
+        kind: "worktree",
+        path: worktree.path,
+        branch: worktree.branch,
+        sourcePath: repo,
+        sourceBranch: "main",
+      },
+      workspaceAccess: { unrestricted: true },
+    });
+    await fs.mkdir(path.join(worktree.path, "dist"));
+    await fs.writeFile(path.join(worktree.path, "dist", "report.txt"), "report\n");
+    await legacyStore.addArtifact(card.id, { path: "dist/report.txt" });
+    return { card, worktree };
+  }
+
+  it("persists an aliased local artifact claim until the reference is externalized", async () => {
+    const { card, worktree } = await createCardWorktree("aliased-artifact");
+    const artifactDir = path.join(worktree.path, "dist");
+    const alias = path.join(root, "artifact-alias");
+    await fs.mkdir(artifactDir);
+    await fs.writeFile(path.join(artifactDir, "report.txt"), "report\n");
+    await fs.symlink(worktree.path, alias, process.platform === "win32" ? "junction" : "dir");
+    await store.addArtifact(card.id, { path: path.join(alias, "dist", "report.txt") });
+    expect((await sqlite.cards.lookup(card.id))?.card.metadata?.artifacts).toHaveLength(1);
+
+    const restarted = new ManagedWorktreeService({ env, now: () => now });
+    await cleanupCardWorktree(card.id, restarted);
+    await expect(fs.stat(worktree.path)).resolves.toBeDefined();
+    now += IDLE_GC_MS + 1;
+    expect((await restarted.gc()).removed).toEqual([]);
+    expect((await restarted.gc({ limits: { maxCount: 0 } })).removed).toEqual([]);
+    expect((await restarted.gc({ limits: { maxTotalSizeBytes: 1 } })).removed).toEqual([]);
+
+    const persisted = await store.get(card.id);
+    await store.update(card.id, {
+      metadata: {
+        ...persisted?.metadata,
+        artifacts: [{ url: "https://example.invalid/report.txt" }],
+      },
+    });
+    expect((await restarted.gc({ limits: { maxCount: 0 } })).removed).toEqual([worktree.id]);
+    await expect(fs.stat(worktree.path)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("reconciles artifacts persisted before retention claims existed", async () => {
+    const { card, worktree } = await createLegacyArtifactCard("legacy-artifact");
+
+    restartWithRetentionStore();
+
+    await cleanupCardWorktree(card.id);
+    await expect(fs.stat(worktree.path)).resolves.toBeDefined();
+    now += IDLE_GC_MS + 1;
+    expect((await service.gc()).removed).toEqual([]);
+    expect((await service.gc({ limits: { maxCount: 0 } })).removed).toEqual([]);
+    expect((await service.gc({ limits: { maxTotalSizeBytes: 1 } })).removed).toEqual([]);
+
+    const persisted = await store.get(card.id);
+    await store.update(card.id, {
+      metadata: {
+        ...persisted?.metadata,
+        artifacts: [{ url: "https://example.invalid/report.txt" }],
+      },
+    });
+    expect((await service.gc({ limits: { maxCount: 0 } })).removed).toEqual([worktree.id]);
+    await expect(fs.stat(worktree.path)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("skips legacy cards whose worktrees were already removed", async () => {
+    const { card, worktree } = await createLegacyArtifactCard("removed-legacy-artifact");
+    await service.release(worktree.id);
+    await expect(service.removeIfLossless(worktree.id)).resolves.toBe(true);
+
+    const cards = restartWithRetentionStore();
+
+    await expect(cards.reconcileArtifactRetention()).resolves.toBeUndefined();
+    await expect(store.get(card.id)).resolves.toMatchObject({ id: card.id });
+    await expect(store.addArtifact(card.id, { path: "dist/new.txt" })).rejects.toThrow(
+      "managed worktree is unavailable for artifact retention",
+    );
+    await expect(store.get(card.id)).resolves.toMatchObject({
+      metadata: { artifacts: [{ path: "dist/report.txt" }] },
+    });
+  });
+
+  it("retries a transient retention release failure in the same process", async () => {
+    const delegate = retentionWorktrees();
+    let failNextRelease = true;
+    const cards = withWorkboardArtifactRetention(sqlite.cards, {
+      async setRetentionClaim(params) {
+        if (!params.active && failNextRelease) {
+          failNextRelease = false;
+          throw new Error("transient retention release failure");
+        }
+        return await delegate.setRetentionClaim(params);
+      },
+    });
+    store = new WorkboardStore(cards, {
+      boards: sqlite.boards,
+      subscriptions: sqlite.subscriptions,
+      attachments: sqlite.attachments,
+      dataVersion: sqlite.dataVersion,
+    });
+    const { card, worktree } = await createCardWorktree("retry-release");
+    await fs.mkdir(path.join(worktree.path, "dist"));
+    await fs.writeFile(path.join(worktree.path, "dist", "report.txt"), "report\n");
+    await store.addArtifact(card.id, { path: "dist/report.txt" });
+    const persisted = await store.get(card.id);
+
+    await expect(
+      store.update(card.id, {
+        metadata: {
+          ...persisted?.metadata,
+          artifacts: [{ url: "https://example.invalid/report.txt" }],
+        },
+      }),
+    ).rejects.toThrow("transient retention release failure");
+
+    await expect(store.get(card.id)).resolves.toMatchObject({
+      metadata: { artifacts: [{ url: "https://example.invalid/report.txt" }] },
+    });
+    await service.release(worktree.id);
+    expect((await service.gc({ limits: { maxCount: 0 } })).removed).toEqual([worktree.id]);
+  });
+
+  it("does not claim URL-only or outside-worktree artifacts", async () => {
+    for (const [name, artifact] of [
+      ["url-artifact", { url: "https://example.invalid/report.txt" }],
+      ["outside-artifact", { path: path.join(root, "shared", "report.txt") }],
+    ] as const) {
+      const { card, worktree } = await createCardWorktree(name);
+      await store.addArtifact(card.id, artifact);
+      await cleanupCardWorktree(card.id);
+      await expect(fs.stat(worktree.path)).rejects.toMatchObject({ code: "ENOENT" });
+    }
+  });
+
+  it("releases the claim after the card is archived", async () => {
+    const { card, worktree } = await createCardWorktree("archived-artifact");
+    await fs.mkdir(path.join(worktree.path, "dist"));
+    await fs.writeFile(path.join(worktree.path, "dist", "report.txt"), "report\n");
+    await store.addArtifact(card.id, { path: "dist/report.txt" });
+    await store.archive(card.id, true);
+
+    await cleanupCardWorktree(card.id);
+
+    await expect(fs.stat(worktree.path)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+});

--- a/extensions/workboard/src/artifact-retention.test.ts
+++ b/extensions/workboard/src/artifact-retention.test.ts
@@ -1,4 +1,5 @@
 import { execFile } from "node:child_process";
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -6,14 +7,17 @@ import { promisify } from "node:util";
 import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
 import { closeOpenClawStateDatabaseForTest } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { IDLE_GC_MS, ManagedWorktreeService } from "openclaw/plugin-sdk/plugin-test-runtime";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { withWorkboardArtifactRetention } from "./artifact-retention.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { cleanupWorkboardCardWorktree } from "./dispatcher-workspace.js";
 import { isWorkboardCardStore } from "./persistence-types.js";
 import { createWorkboardSqliteStores } from "./sqlite-store.js";
 import { WorkboardStore } from "./store.js";
 
 const execFileAsync = promisify(execFile);
+type RetentionWorktrees = Pick<
+  PluginRuntime["worktrees"],
+  "resolveRetentionTarget" | "setRetentionClaim"
+>;
 
 async function git(cwd: string, ...args: string[]): Promise<void> {
   await execFileAsync("git", ["-C", cwd, ...args]);
@@ -31,6 +35,11 @@ describe("Workboard artifact worktree retention", () => {
   beforeEach(async () => {
     // openclaw-temp-dir: allow extension tests cannot import the core-only tracker.
     root = await fs.mkdtemp(path.join(await fs.realpath(os.tmpdir()), "workboard-retention-"));
+    // Disk admission has separate capacity tests; these tiny fixtures exercise retention owners.
+    const disk = fsSync.statfsSync(root);
+    disk.bavail = 100_000_000;
+    disk.bfree = 100_000_000;
+    vi.spyOn(fsSync, "statfsSync").mockReturnValue(disk);
     repo = path.join(root, "repo");
     await fs.mkdir(repo);
     await git(repo, "init", "-b", "main");
@@ -48,18 +57,12 @@ describe("Workboard artifact worktree retention", () => {
     env = { ...process.env, OPENCLAW_STATE_DIR: path.join(root, "state") };
     now = 1_700_000_000_000;
     service = new ManagedWorktreeService({ env, now: () => now });
-    sqlite = createWorkboardSqliteStores({ env });
-    const cards = withWorkboardArtifactRetention(sqlite.cards, retentionWorktrees());
-    expect(isWorkboardCardStore(cards)).toBe(true);
-    store = new WorkboardStore(cards, {
-      boards: sqlite.boards,
-      subscriptions: sqlite.subscriptions,
-      attachments: sqlite.attachments,
-      dataVersion: sqlite.dataVersion,
-    });
+    openRetentionStore();
+    expect(isWorkboardCardStore(sqlite.cards)).toBe(true);
   });
 
   afterEach(async () => {
+    vi.restoreAllMocks();
     sqlite.close();
     closeOpenClawStateDatabaseForTest();
     await fs.rm(root, { recursive: true, force: true });
@@ -91,13 +94,16 @@ describe("Workboard artifact worktree retention", () => {
     return { card, worktree };
   }
 
-  function retentionWorktrees(
-    activeService = service,
-  ): Pick<PluginRuntime["worktrees"], "setRetentionClaim"> {
+  function retentionWorktrees(activeService = service): RetentionWorktrees {
     return {
+      resolveRetentionTarget: async (params) =>
+        activeService.resolveRetentionTargetByPath(params.path, {
+          ownerKind: params.ownerKind,
+          ownerId: params.ownerId,
+        }),
       setRetentionClaim: async (params) =>
-        activeService.setRetentionClaimByPath(
-          params.path,
+        activeService.setRetentionClaim(
+          params.worktreeId,
           { ownerKind: params.ownerKind, ownerId: params.ownerId },
           { claimId: params.claimId, active: params.active },
         ),
@@ -117,19 +123,70 @@ describe("Workboard artifact worktree retention", () => {
     };
   }
 
-  function restartWithRetentionStore() {
-    sqlite.close();
-    closeOpenClawStateDatabaseForTest();
-    service = new ManagedWorktreeService({ env, now: () => now });
-    sqlite = createWorkboardSqliteStores({ env });
-    const cards = withWorkboardArtifactRetention(sqlite.cards, retentionWorktrees());
-    store = new WorkboardStore(cards, {
+  function openRetentionStore(worktrees = retentionWorktrees()) {
+    sqlite = createWorkboardSqliteStores({ env, worktrees });
+    store = new WorkboardStore(sqlite.cards, {
       boards: sqlite.boards,
       subscriptions: sqlite.subscriptions,
       attachments: sqlite.attachments,
       dataVersion: sqlite.dataVersion,
     });
-    return cards;
+    return sqlite.cards;
+  }
+
+  function restartWithRetentionStore() {
+    sqlite.close();
+    closeOpenClawStateDatabaseForTest();
+    service = new ManagedWorktreeService({ env, now: () => now });
+    return openRetentionStore();
+  }
+
+  function replaceRetentionRuntime(worktrees: RetentionWorktrees) {
+    sqlite.close();
+    return openRetentionStore(worktrees);
+  }
+
+  async function writeArtifact(worktreePath: string) {
+    await fs.mkdir(path.join(worktreePath, "dist"), { recursive: true });
+    await fs.writeFile(path.join(worktreePath, "dist", "report.txt"), "report\n");
+  }
+
+  async function referenceWorktree(
+    cardId: string,
+    worktree: { path: string; branch: string },
+    activeStore = store,
+  ) {
+    const persisted = await activeStore.get(cardId);
+    return await activeStore.update(cardId, {
+      workspace: {
+        kind: "worktree",
+        path: worktree.path,
+        branch: worktree.branch,
+        sourcePath: repo,
+        sourceBranch: "main",
+      },
+      workspaceAccess: { unrestricted: true },
+      metadata: { ...persisted?.metadata, artifacts: [{ path: "dist/report.txt" }] },
+    });
+  }
+
+  async function createSecondWorktree(cardId: string, previousId: string, name: string) {
+    // create() reuses a live owner's checkout. An explicit remove followed by a
+    // later restore is the supported path to two identities for the same card.
+    await service.release(previousId);
+    await service.remove({ id: previousId, reason: "retention-test-operator-remove" });
+    const worktree = await service.create({
+      repoRoot: repo,
+      name,
+      ownerKind: "workboard",
+      ownerId: cardId,
+    });
+    expect(worktree.id).not.toBe(previousId);
+    const restored = await service.restore({ id: previousId });
+    await writeArtifact(restored.path);
+    await service.acquire(worktree.id);
+    await writeArtifact(worktree.path);
+    return worktree;
   }
 
   async function cleanupCardWorktree(cardId: string, activeService = service) {
@@ -145,34 +202,38 @@ describe("Workboard artifact worktree retention", () => {
   }
 
   async function createLegacyArtifactCard(name: string) {
-    const legacyStore = new WorkboardStore(sqlite.cards, {
-      boards: sqlite.boards,
-      subscriptions: sqlite.subscriptions,
-      attachments: sqlite.attachments,
-      dataVersion: sqlite.dataVersion,
-    });
-    const card = await legacyStore.create({ title: name, status: "done", runId: `run-${name}` });
-    const worktree = await service.create({
-      repoRoot: repo,
-      name,
-      ownerKind: "workboard",
-      ownerId: card.id,
-    });
-    await service.acquire(worktree.id);
-    await legacyStore.update(card.id, {
-      workspace: {
-        kind: "worktree",
-        path: worktree.path,
-        branch: worktree.branch,
-        sourcePath: repo,
-        sourceBranch: "main",
-      },
-      workspaceAccess: { unrestricted: true },
-    });
-    await fs.mkdir(path.join(worktree.path, "dist"));
-    await fs.writeFile(path.join(worktree.path, "dist", "report.txt"), "report\n");
-    await legacyStore.addArtifact(card.id, { path: "dist/report.txt" });
-    return { card, worktree };
+    const legacySqlite = createWorkboardSqliteStores({ env });
+    try {
+      const legacyStore = new WorkboardStore(legacySqlite.cards, {
+        boards: legacySqlite.boards,
+        subscriptions: legacySqlite.subscriptions,
+        attachments: legacySqlite.attachments,
+        dataVersion: legacySqlite.dataVersion,
+      });
+      const card = await legacyStore.create({ title: name, status: "done", runId: `run-${name}` });
+      const worktree = await service.create({
+        repoRoot: repo,
+        name,
+        ownerKind: "workboard",
+        ownerId: card.id,
+      });
+      await service.acquire(worktree.id);
+      await legacyStore.update(card.id, {
+        workspace: {
+          kind: "worktree",
+          path: worktree.path,
+          branch: worktree.branch,
+          sourcePath: repo,
+          sourceBranch: "main",
+        },
+        workspaceAccess: { unrestricted: true },
+      });
+      await writeArtifact(worktree.path);
+      await legacyStore.addArtifact(card.id, { path: "dist/report.txt" });
+      return { card, worktree };
+    } finally {
+      legacySqlite.close();
+    }
   }
 
   it("persists an aliased local artifact claim until the reference is externalized", async () => {
@@ -244,27 +305,50 @@ describe("Workboard artifact worktree retention", () => {
     });
   });
 
-  it("retries a transient retention release failure in the same process", async () => {
+  it("keeps a referenced worktree protected when restored after startup reconciliation", async () => {
+    const { card, worktree } = await createCardWorktree("restored-after-restart");
+    // Explicit removal snapshots non-ignored files; use one that restore actually recovers.
+    const artifact = path.join(worktree.path, "report.txt");
+    await fs.writeFile(artifact, "report");
+    await store.addArtifact(card.id, { path: "report.txt" });
+    await service.release(worktree.id);
+    await service.remove({ id: worktree.id, reason: "retention-test-operator-remove" });
+    await expect(fs.stat(worktree.path)).rejects.toMatchObject({ code: "ENOENT" });
+
+    await restartWithRetentionStore().reconcileArtifactRetention();
+    await expect(store.get(card.id)).resolves.toMatchObject({
+      metadata: { artifacts: [{ path: "report.txt" }] },
+    });
+    const restored = await service.restore({ id: worktree.id });
+    expect(restored.id).toBe(worktree.id);
+    await expect(fs.readFile(artifact, "utf8")).resolves.toBe("report");
+    expect((await service.gc({ limits: { maxCount: 0 } })).removed).toEqual([]);
+    await expect(fs.readFile(artifact, "utf8")).resolves.toBe("report");
+
+    const persisted = await store.get(card.id);
+    await store.update(card.id, {
+      metadata: {
+        ...persisted?.metadata,
+        artifacts: [{ url: "https://example.invalid/report.txt" }],
+      },
+    });
+    expect((await service.gc({ limits: { maxCount: 0 } })).removed).toEqual([worktree.id]);
+  });
+
+  it("reports a committed mutation while release remains durably retryable", async () => {
     const delegate = retentionWorktrees();
-    let failNextRelease = true;
-    const cards = withWorkboardArtifactRetention(sqlite.cards, {
+    let releaseUnavailable = true;
+    replaceRetentionRuntime({
+      ...delegate,
       async setRetentionClaim(params) {
-        if (!params.active && failNextRelease) {
-          failNextRelease = false;
+        if (!params.active && releaseUnavailable) {
           throw new Error("transient retention release failure");
         }
         return await delegate.setRetentionClaim(params);
       },
     });
-    store = new WorkboardStore(cards, {
-      boards: sqlite.boards,
-      subscriptions: sqlite.subscriptions,
-      attachments: sqlite.attachments,
-      dataVersion: sqlite.dataVersion,
-    });
     const { card, worktree } = await createCardWorktree("retry-release");
-    await fs.mkdir(path.join(worktree.path, "dist"));
-    await fs.writeFile(path.join(worktree.path, "dist", "report.txt"), "report\n");
+    await writeArtifact(worktree.path);
     await store.addArtifact(card.id, { path: "dist/report.txt" });
     const persisted = await store.get(card.id);
 
@@ -275,86 +359,71 @@ describe("Workboard artifact worktree retention", () => {
           artifacts: [{ url: "https://example.invalid/report.txt" }],
         },
       }),
-    ).rejects.toThrow("transient retention release failure");
+    ).resolves.toMatchObject({ id: card.id });
 
-    await expect(store.get(card.id)).resolves.toMatchObject({
-      metadata: { artifacts: [{ url: "https://example.invalid/report.txt" }] },
+    await expect(sqlite.cards.lookup(card.id)).resolves.toMatchObject({
+      card: { metadata: { artifacts: [{ url: "https://example.invalid/report.txt" }] } },
     });
+    await service.release(worktree.id);
+    expect((await service.gc({ limits: { maxCount: 0 } })).removed).toEqual([]);
+    await expect(sqlite.cards.reconcileArtifactRetention()).rejects.toThrow(
+      "transient retention release failure",
+    );
+    releaseUnavailable = false;
+    await sqlite.cards.reconcileArtifactRetention();
+    expect((await service.gc({ limits: { maxCount: 0 } })).removed).toEqual([worktree.id]);
+  });
+
+  it("recovers a failed release after deleting the card and restarting", async () => {
+    const { card, worktree } = await createCardWorktree("deleted-release-restart");
+    await writeArtifact(worktree.path);
+    await store.addArtifact(card.id, { path: "dist/report.txt" });
+    const delegate = retentionWorktrees();
+    const cards = replaceRetentionRuntime({
+      ...delegate,
+      async setRetentionClaim(params) {
+        if (!params.active) {
+          throw new Error("transient retention release failure");
+        }
+        return await delegate.setRetentionClaim(params);
+      },
+    });
+    await expect(cards.delete(card.id)).resolves.toBe(true);
+    await expect(sqlite.cards.lookup(card.id)).resolves.toBeUndefined();
+
+    const restarted = restartWithRetentionStore();
+    await restarted.reconcileArtifactRetention();
     await service.release(worktree.id);
     expect((await service.gc({ limits: { maxCount: 0 } })).removed).toEqual([worktree.id]);
   });
 
-  it("keeps the new claim when releasing the previous worktree fails", async () => {
-    const previousPath = path.join(root, "previous-worktree");
-    const nextPath = path.join(root, "next-worktree");
-    for (const workspacePath of [previousPath, nextPath]) {
-      await fs.mkdir(path.join(workspacePath, "dist"), { recursive: true });
-      await fs.writeFile(path.join(workspacePath, "dist", "report.txt"), "report\n");
-    }
-    const activeClaims = new Set<string>();
-    let failPreviousRelease = true;
-    const cards = withWorkboardArtifactRetention(sqlite.cards, {
+  it("releases obsolete A after restart while the committed B stays protected", async () => {
+    const { card, worktree: previous } = await createCardWorktree("previous-artifact");
+    await writeArtifact(previous.path);
+    await store.addArtifact(card.id, { path: "dist/report.txt" });
+    const next = await createSecondWorktree(card.id, previous.id, "next-artifact");
+    const delegate = retentionWorktrees();
+    replaceRetentionRuntime({
+      ...delegate,
       async setRetentionClaim(params) {
-        if (!params.active && params.path === previousPath && failPreviousRelease) {
-          failPreviousRelease = false;
+        if (!params.active && params.worktreeId === previous.id) {
           throw new Error("transient previous retention release failure");
         }
-        if (params.active) {
-          activeClaims.add(params.path);
-        } else {
-          activeClaims.delete(params.path);
-        }
-        return true;
+        return await delegate.setRetentionClaim(params);
       },
     });
-    store = new WorkboardStore(cards, {
-      boards: sqlite.boards,
-      subscriptions: sqlite.subscriptions,
-      attachments: sqlite.attachments,
-      dataVersion: sqlite.dataVersion,
-    });
-    const card = await store.create({ title: "transition artifact", status: "done" });
-    await store.update(card.id, {
-      workspace: {
-        kind: "worktree",
-        path: previousPath,
-        branch: "previous",
-        sourcePath: repo,
-        sourceBranch: "main",
-      },
-      workspaceAccess: { unrestricted: true },
-      metadata: { artifacts: [{ path: "dist/report.txt" }] },
-    });
-    const persisted = await store.get(card.id);
 
-    await expect(
-      store.update(card.id, {
-        workspace: {
-          kind: "worktree",
-          path: nextPath,
-          branch: "next",
-          sourcePath: repo,
-          sourceBranch: "main",
-        },
-        metadata: {
-          ...persisted?.metadata,
-          artifacts: [{ path: "dist/report.txt" }],
-        },
-      }),
-    ).rejects.toThrow("transient previous retention release failure");
+    await expect(referenceWorktree(card.id, next)).resolves.toMatchObject({ id: card.id });
     await expect(sqlite.cards.lookup(card.id)).resolves.toMatchObject({
-      card: {
-        metadata: {
-          automation: { workspace: { path: nextPath } },
-          artifacts: [{ path: "dist/report.txt" }],
-        },
-      },
+      card: { metadata: { automation: { workspace: { path: next.path } } } },
     });
-    expect([...activeClaims].toSorted()).toEqual([nextPath, previousPath].toSorted());
+    await service.release(previous.id);
+    await service.release(next.id);
+    expect((await service.gc({ limits: { maxCount: 0 } })).removed).toEqual([]);
 
-    await expect(store.get(card.id)).resolves.toMatchObject({ id: card.id });
-    expect([...activeClaims]).toEqual([nextPath]);
-
+    await restartWithRetentionStore().reconcileArtifactRetention();
+    expect((await service.gc({ limits: { maxCount: 0 } })).removed).toEqual([previous.id]);
+    await expect(fs.stat(next.path)).resolves.toBeDefined();
     const transitioned = await store.get(card.id);
     await store.update(card.id, {
       metadata: {
@@ -362,7 +431,182 @@ describe("Workboard artifact worktree retention", () => {
         artifacts: [{ url: "https://example.invalid/report.txt" }],
       },
     });
-    expect([...activeClaims]).toEqual([]);
+    expect((await service.gc({ limits: { maxCount: 0 } })).removed).toEqual([next.id]);
+  });
+
+  it("does not let an old A release remove the later A generation", async () => {
+    const { card, worktree: previous } = await createCardWorktree("returning-artifact");
+    await writeArtifact(previous.path);
+    await store.addArtifact(card.id, { path: "dist/report.txt" });
+    const next = await createSecondWorktree(card.id, previous.id, "intermediate-artifact");
+    const delegate = retentionWorktrees();
+    const releaseStarted = Promise.withResolvers<void>();
+    const resumeRelease = Promise.withResolvers<void>();
+    let pauseFirstRelease = true;
+    replaceRetentionRuntime({
+      ...delegate,
+      async setRetentionClaim(params) {
+        if (!params.active && params.worktreeId === previous.id && pauseFirstRelease) {
+          pauseFirstRelease = false;
+          releaseStarted.resolve();
+          await resumeRelease.promise;
+        }
+        return await delegate.setRetentionClaim(params);
+      },
+    });
+    const movingToB = referenceWorktree(card.id, next);
+    const movingResult = movingToB.then(
+      () => ({ applied: true }),
+      () => ({ applied: false }),
+    );
+    await releaseStarted.promise;
+    const other = createWorkboardSqliteStores({ env, worktrees: retentionWorktrees() });
+    try {
+      const otherStore = new WorkboardStore(other.cards, { dataVersion: other.dataVersion });
+      await referenceWorktree(card.id, previous, otherStore);
+      resumeRelease.resolve();
+      await expect(movingResult).resolves.toEqual({ applied: true });
+      await other.cards.reconcileArtifactRetention();
+      await service.release(previous.id);
+      await service.release(next.id);
+      expect((await service.gc({ limits: { maxCount: 0 } })).removed).toEqual([next.id]);
+      await expect(fs.stat(previous.path)).resolves.toBeDefined();
+      await expect(other.cards.lookup(card.id)).resolves.toMatchObject({
+        card: { metadata: { automation: { workspace: { path: previous.path } } } },
+      });
+    } finally {
+      resumeRelease.resolve();
+      await movingResult;
+      other.close();
+    }
+  });
+
+  it.each(["before", "after"] as const)(
+    "fences a prepared write cancelled %s its delayed acquisition",
+    async (pauseAt) => {
+      const { card, worktree } = await createCardWorktree("cancelled-preparation");
+      await writeArtifact(worktree.path);
+      const original = await sqlite.cards.lookup(card.id);
+      if (!original) {
+        throw new Error("expected persisted card");
+      }
+      const delegate = retentionWorktrees();
+      const acquisitionStarted = Promise.withResolvers<void>();
+      const resumeAcquisition = Promise.withResolvers<void>();
+      replaceRetentionRuntime({
+        ...delegate,
+        async setRetentionClaim(params) {
+          if (!params.active) {
+            return await delegate.setRetentionClaim(params);
+          }
+          const accepted =
+            pauseAt === "after" ? await delegate.setRetentionClaim(params) : undefined;
+          acquisitionStarted.resolve();
+          await resumeAcquisition.promise;
+          return accepted ?? (await delegate.setRetentionClaim(params));
+        },
+      });
+      const writing = sqlite.cards.registerIfUpdatedAt(
+        card.id,
+        {
+          version: 1,
+          card: {
+            ...original.card,
+            updatedAt: original.card.updatedAt + 1,
+            metadata: { ...original.card.metadata, artifacts: [{ path: "dist/report.txt" }] },
+          },
+        },
+        original.card.updatedAt,
+      );
+      const writeResult = writing.then(
+        (applied) => ({ applied }),
+        () => ({ applied: false }),
+      );
+      await acquisitionStarted.promise;
+      const recovering = createWorkboardSqliteStores({ env, worktrees: retentionWorktrees() });
+      try {
+        await recovering.cards.reconcileArtifactRetention();
+        resumeAcquisition.resolve();
+        await expect(writeResult).resolves.toEqual({ applied: false });
+        expect((await recovering.cards.lookup(card.id))?.card.metadata?.artifacts).toBeUndefined();
+        await recovering.cards.reconcileArtifactRetention();
+        await service.release(worktree.id);
+        expect((await service.gc({ limits: { maxCount: 0 } })).removed).toEqual([worktree.id]);
+      } finally {
+        resumeAcquisition.resolve();
+        await writeResult;
+        recovering.close();
+      }
+    },
+  );
+
+  it("releases a newly acquired generation when another connection wins the card CAS", async () => {
+    const { card, worktree } = await createCardWorktree("conflicting-artifact");
+    await writeArtifact(worktree.path);
+    const original = await sqlite.cards.lookup(card.id);
+    if (!original) {
+      throw new Error("expected persisted card");
+    }
+    const delegate = retentionWorktrees();
+    const acquisitionFinished = Promise.withResolvers<void>();
+    const resumeCommit = Promise.withResolvers<void>();
+    replaceRetentionRuntime({
+      ...delegate,
+      async setRetentionClaim(params) {
+        const accepted = await delegate.setRetentionClaim(params);
+        if (params.active) {
+          acquisitionFinished.resolve();
+          await resumeCommit.promise;
+        }
+        return accepted;
+      },
+    });
+    const updating = sqlite.cards.registerIfUpdatedAt(
+      card.id,
+      {
+        version: 1,
+        card: {
+          ...original.card,
+          updatedAt: original.card.updatedAt + 1,
+          metadata: { ...original.card.metadata, artifacts: [{ path: "dist/report.txt" }] },
+        },
+      },
+      original.card.updatedAt,
+    );
+    const updateResult = updating.then(
+      (applied) => ({ applied }),
+      () => ({ applied: false }),
+    );
+    await acquisitionFinished.promise;
+    const competing = createWorkboardSqliteStores({ env });
+    try {
+      await expect(
+        competing.cards.registerIfUpdatedAt(
+          card.id,
+          {
+            version: 1,
+            card: {
+              ...original.card,
+              title: "concurrent winner",
+              updatedAt: original.card.updatedAt + 2,
+            },
+          },
+          original.card.updatedAt,
+        ),
+      ).resolves.toBe(true);
+      resumeCommit.resolve();
+      await expect(updateResult).resolves.toEqual({ applied: false });
+      await sqlite.cards.reconcileArtifactRetention();
+      await expect(competing.cards.lookup(card.id)).resolves.toMatchObject({
+        card: { title: "concurrent winner" },
+      });
+      await service.release(worktree.id);
+      expect((await service.gc({ limits: { maxCount: 0 } })).removed).toEqual([worktree.id]);
+    } finally {
+      resumeCommit.resolve();
+      await updateResult;
+      competing.close();
+    }
   });
 
   it("does not claim URL-only or outside-worktree artifacts", async () => {

--- a/extensions/workboard/src/artifact-retention.test.ts
+++ b/extensions/workboard/src/artifact-retention.test.ts
@@ -284,6 +284,87 @@ describe("Workboard artifact worktree retention", () => {
     expect((await service.gc({ limits: { maxCount: 0 } })).removed).toEqual([worktree.id]);
   });
 
+  it("keeps the new claim when releasing the previous worktree fails", async () => {
+    const previousPath = path.join(root, "previous-worktree");
+    const nextPath = path.join(root, "next-worktree");
+    for (const workspacePath of [previousPath, nextPath]) {
+      await fs.mkdir(path.join(workspacePath, "dist"), { recursive: true });
+      await fs.writeFile(path.join(workspacePath, "dist", "report.txt"), "report\n");
+    }
+    const activeClaims = new Set<string>();
+    let failPreviousRelease = true;
+    const cards = withWorkboardArtifactRetention(sqlite.cards, {
+      async setRetentionClaim(params) {
+        if (!params.active && params.path === previousPath && failPreviousRelease) {
+          failPreviousRelease = false;
+          throw new Error("transient previous retention release failure");
+        }
+        if (params.active) {
+          activeClaims.add(params.path);
+        } else {
+          activeClaims.delete(params.path);
+        }
+        return true;
+      },
+    });
+    store = new WorkboardStore(cards, {
+      boards: sqlite.boards,
+      subscriptions: sqlite.subscriptions,
+      attachments: sqlite.attachments,
+      dataVersion: sqlite.dataVersion,
+    });
+    const card = await store.create({ title: "transition artifact", status: "done" });
+    await store.update(card.id, {
+      workspace: {
+        kind: "worktree",
+        path: previousPath,
+        branch: "previous",
+        sourcePath: repo,
+        sourceBranch: "main",
+      },
+      workspaceAccess: { unrestricted: true },
+      metadata: { artifacts: [{ path: "dist/report.txt" }] },
+    });
+    const persisted = await store.get(card.id);
+
+    await expect(
+      store.update(card.id, {
+        workspace: {
+          kind: "worktree",
+          path: nextPath,
+          branch: "next",
+          sourcePath: repo,
+          sourceBranch: "main",
+        },
+        metadata: {
+          ...persisted?.metadata,
+          artifacts: [{ path: "dist/report.txt" }],
+        },
+      }),
+    ).rejects.toThrow("transient previous retention release failure");
+    await expect(sqlite.cards.lookup(card.id)).resolves.toMatchObject({
+      card: {
+        metadata: {
+          automation: { workspace: { path: nextPath } },
+          artifacts: [{ path: "dist/report.txt" }],
+        },
+      },
+    });
+    expect([...activeClaims].toSorted()).toEqual([nextPath, previousPath].toSorted());
+
+    await expect(store.get(card.id)).resolves.toMatchObject({ id: card.id });
+    expect([...activeClaims]).toEqual([nextPath]);
+
+    const transitioned = await store.get(card.id);
+    await store.update(card.id, {
+      metadata: {
+        ...transitioned?.metadata,
+        artifacts: [{ url: "https://example.invalid/report.txt" }],
+      },
+    });
+    expect([...activeClaims]).toEqual([]);
+  });
+
   it("does not claim URL-only or outside-worktree artifacts", async () => {
     for (const [name, artifact] of [
       ["url-artifact", { url: "https://example.invalid/report.txt" }],

--- a/extensions/workboard/src/artifact-retention.test.ts
+++ b/extensions/workboard/src/artifact-retention.test.ts
@@ -4,6 +4,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
 import { closeOpenClawStateDatabaseForTest } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { IDLE_GC_MS, ManagedWorktreeService } from "openclaw/plugin-sdk/plugin-test-runtime";
@@ -201,7 +202,7 @@ describe("Workboard artifact worktree retention", () => {
     });
   }
 
-  async function createLegacyArtifactCard(name: string) {
+  async function createLegacyArtifactCard(name: string, artifactPath = "dist/report.txt") {
     const legacySqlite = createWorkboardSqliteStores({ env });
     try {
       const legacyStore = new WorkboardStore(legacySqlite.cards, {
@@ -228,8 +229,9 @@ describe("Workboard artifact worktree retention", () => {
         },
         workspaceAccess: { unrestricted: true },
       });
-      await writeArtifact(worktree.path);
-      await legacyStore.addArtifact(card.id, { path: "dist/report.txt" });
+      await fs.mkdir(path.dirname(path.join(worktree.path, artifactPath)), { recursive: true });
+      await fs.writeFile(path.join(worktree.path, artifactPath), "report");
+      await legacyStore.addArtifact(card.id, { path: artifactPath });
       return { card, worktree };
     } finally {
       legacySqlite.close();
@@ -288,10 +290,11 @@ describe("Workboard artifact worktree retention", () => {
     await expect(fs.stat(worktree.path)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
-  it("skips legacy cards whose worktrees were already removed", async () => {
+  it("skips legacy worktrees missing without a recovery snapshot", async () => {
     const { card, worktree } = await createLegacyArtifactCard("removed-legacy-artifact");
     await service.release(worktree.id);
-    await expect(service.removeIfLossless(worktree.id)).resolves.toBe(true);
+    await fs.rm(worktree.path, { recursive: true, force: true });
+    await service.gc();
 
     const cards = restartWithRetentionStore();
 
@@ -305,35 +308,42 @@ describe("Workboard artifact worktree retention", () => {
     });
   });
 
-  it("keeps a referenced worktree protected when restored after startup reconciliation", async () => {
-    const { card, worktree } = await createCardWorktree("restored-after-restart");
-    // Explicit removal snapshots non-ignored files; use one that restore actually recovers.
-    const artifact = path.join(worktree.path, "report.txt");
-    await fs.writeFile(artifact, "report");
-    await store.addArtifact(card.id, { path: "report.txt" });
-    await service.release(worktree.id);
-    await service.remove({ id: worktree.id, reason: "retention-test-operator-remove" });
-    await expect(fs.stat(worktree.path)).rejects.toMatchObject({ code: "ENOENT" });
+  it.each([false, true])(
+    "protects restored artifacts when first enrollment was before removal: %s",
+    async (enrolled) => {
+      const { card, worktree } = enrolled
+        ? await createCardWorktree("restored-after-restart")
+        : await createLegacyArtifactCard("restored-after-restart", "report.txt");
+      // Explicit removal snapshots non-ignored files; use one that restore actually recovers.
+      const artifact = path.join(worktree.path, "report.txt");
+      await fs.writeFile(artifact, "report");
+      if (enrolled) {
+        await store.addArtifact(card.id, { path: "report.txt" });
+      }
+      await service.release(worktree.id);
+      await service.remove({ id: worktree.id, reason: "retention-test-operator-remove" });
+      await expect(fs.stat(worktree.path)).rejects.toMatchObject({ code: "ENOENT" });
 
-    await restartWithRetentionStore().reconcileArtifactRetention();
-    await expect(store.get(card.id)).resolves.toMatchObject({
-      metadata: { artifacts: [{ path: "report.txt" }] },
-    });
-    const restored = await service.restore({ id: worktree.id });
-    expect(restored.id).toBe(worktree.id);
-    await expect(fs.readFile(artifact, "utf8")).resolves.toBe("report");
-    expect((await service.gc({ limits: { maxCount: 0 } })).removed).toEqual([]);
-    await expect(fs.readFile(artifact, "utf8")).resolves.toBe("report");
+      await restartWithRetentionStore().reconcileArtifactRetention();
+      await expect(store.get(card.id)).resolves.toMatchObject({
+        metadata: { artifacts: [{ path: "report.txt" }] },
+      });
+      const restored = await service.restore({ id: worktree.id });
+      expect(restored.id).toBe(worktree.id);
+      await expect(fs.readFile(artifact, "utf8")).resolves.toBe("report");
+      expect((await service.gc({ limits: { maxCount: 0 } })).removed).toEqual([]);
+      await expect(fs.readFile(artifact, "utf8")).resolves.toBe("report");
 
-    const persisted = await store.get(card.id);
-    await store.update(card.id, {
-      metadata: {
-        ...persisted?.metadata,
-        artifacts: [{ url: "https://example.invalid/report.txt" }],
-      },
-    });
-    expect((await service.gc({ limits: { maxCount: 0 } })).removed).toEqual([worktree.id]);
-  });
+      const persisted = await store.get(card.id);
+      await store.update(card.id, {
+        metadata: {
+          ...persisted?.metadata,
+          artifacts: [{ url: "https://example.invalid/report.txt" }],
+        },
+      });
+      expect((await service.gc({ limits: { maxCount: 0 } })).removed).toEqual([worktree.id]);
+    },
+  );
 
   it("reports a committed mutation while release remains durably retryable", async () => {
     const delegate = retentionWorktrees();
@@ -440,8 +450,8 @@ describe("Workboard artifact worktree retention", () => {
     await store.addArtifact(card.id, { path: "dist/report.txt" });
     const next = await createSecondWorktree(card.id, previous.id, "intermediate-artifact");
     const delegate = retentionWorktrees();
-    const releaseStarted = Promise.withResolvers<void>();
-    const resumeRelease = Promise.withResolvers<void>();
+    const releaseStarted = createDeferred<void>();
+    const resumeRelease = createDeferred<void>();
     let pauseFirstRelease = true;
     replaceRetentionRuntime({
       ...delegate,
@@ -491,8 +501,8 @@ describe("Workboard artifact worktree retention", () => {
         throw new Error("expected persisted card");
       }
       const delegate = retentionWorktrees();
-      const acquisitionStarted = Promise.withResolvers<void>();
-      const resumeAcquisition = Promise.withResolvers<void>();
+      const acquisitionStarted = createDeferred<void>();
+      const resumeAcquisition = createDeferred<void>();
       replaceRetentionRuntime({
         ...delegate,
         async setRetentionClaim(params) {
@@ -513,7 +523,10 @@ describe("Workboard artifact worktree retention", () => {
           card: {
             ...original.card,
             updatedAt: original.card.updatedAt + 1,
-            metadata: { ...original.card.metadata, artifacts: [{ path: "dist/report.txt" }] },
+            metadata: {
+              ...original.card.metadata,
+              artifacts: [{ id: "report", createdAt: now, path: "dist/report.txt" }],
+            },
           },
         },
         original.card.updatedAt,
@@ -548,8 +561,8 @@ describe("Workboard artifact worktree retention", () => {
       throw new Error("expected persisted card");
     }
     const delegate = retentionWorktrees();
-    const acquisitionFinished = Promise.withResolvers<void>();
-    const resumeCommit = Promise.withResolvers<void>();
+    const acquisitionFinished = createDeferred<void>();
+    const resumeCommit = createDeferred<void>();
     replaceRetentionRuntime({
       ...delegate,
       async setRetentionClaim(params) {
@@ -568,7 +581,10 @@ describe("Workboard artifact worktree retention", () => {
         card: {
           ...original.card,
           updatedAt: original.card.updatedAt + 1,
-          metadata: { ...original.card.metadata, artifacts: [{ path: "dist/report.txt" }] },
+          metadata: {
+            ...original.card.metadata,
+            artifacts: [{ id: "report", createdAt: now, path: "dist/report.txt" }],
+          },
         },
       },
       original.card.updatedAt,

--- a/extensions/workboard/src/artifact-retention.test.ts
+++ b/extensions/workboard/src/artifact-retention.test.ts
@@ -47,7 +47,7 @@ describe("Workboard artifact worktree retention", () => {
     await git(repo, "config", "user.name", "OpenClaw Test");
     await git(repo, "config", "user.email", "openclaw-test@example.invalid");
     await fs.writeFile(path.join(repo, "README.md"), "base\n");
-    await fs.writeFile(path.join(repo, ".gitignore"), "dist/\n");
+    await fs.writeFile(path.join(repo, ".gitignore"), "/dist\n");
     await git(repo, "add", "README.md", ".gitignore");
     await git(repo, "commit", "-m", "initial");
     const remote = path.join(root, "remote.git");
@@ -247,6 +247,10 @@ describe("Workboard artifact worktree retention", () => {
     await fs.symlink(worktree.path, alias, process.platform === "win32" ? "junction" : "dir");
     await store.addArtifact(card.id, { path: path.join(alias, "dist", "report.txt") });
     expect((await sqlite.cards.lookup(card.id))?.card.metadata?.artifacts).toHaveLength(1);
+    const edited = await store.update(card.id, {
+      workspace: { kind: "worktree", path: worktree.path },
+    });
+    expect(edited.metadata?.automation?.workspace?.sourcePath).toBe(repo);
 
     const restarted = new ManagedWorktreeService({ env, now: () => now });
     await cleanupCardWorktree(card.id, restarted);
@@ -623,6 +627,57 @@ describe("Workboard artifact worktree retention", () => {
       await updateResult;
       competing.close();
     }
+  });
+
+  it("allows local artifacts on the source checkout before worktree materialization", async () => {
+    const card = await store.create({
+      title: "Source checkout artifact",
+      workspace: { kind: "worktree", path: repo, branch: "main" },
+      workspaceAccess: { unrestricted: true },
+    });
+
+    await expect(store.addArtifact(card.id, { path: "README.md" })).resolves.toMatchObject({
+      metadata: { artifacts: [{ path: "README.md" }] },
+    });
+    expect(await fs.readFile(path.join(repo, "README.md"), "utf8")).toBe("base\n");
+  });
+
+  it("returns to the source checkout after cleaning an outbound artifact alias", async () => {
+    const { card, worktree } = await createCardWorktree("outbound-artifact-alias");
+    const outsideDir = path.join(root, "shared");
+    const outsideFile = path.join(outsideDir, "report.txt");
+    await fs.mkdir(outsideDir);
+    await fs.writeFile(outsideFile, "outside report\n");
+    await fs.symlink(
+      outsideDir,
+      path.join(worktree.path, "dist"),
+      process.platform === "win32" ? "junction" : "dir",
+    );
+    await store.addArtifact(card.id, { path: "dist/report.txt" });
+
+    const { stdout } = await execFileAsync("git", ["-C", worktree.path, "status", "--porcelain"]);
+    expect(stdout.trim()).toBe("");
+    await expect(cleanupCardWorktree(card.id)).resolves.toBeUndefined();
+    expect(
+      service.listRegistryRecords().find((record) => record.id === worktree.id)?.removedAt,
+    ).toBe(now);
+    await expect(fs.stat(path.join(worktree.path, ".git"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    // Git for Windows can leave an ignored junction directory after deregistering the worktree.
+    if (process.platform !== "win32") {
+      await expect(fs.stat(worktree.path)).rejects.toMatchObject({ code: "ENOENT" });
+    }
+    expect(await fs.readFile(outsideFile, "utf8")).toBe("outside report\n");
+    const cleaned = await store.get(card.id);
+    expect(cleaned?.metadata?.automation?.workspace).toEqual({
+      kind: "worktree",
+      path: repo,
+      branch: "main",
+    });
+    expect(cleaned?.metadata?.artifacts).toEqual([
+      expect.objectContaining({ path: "dist/report.txt" }),
+    ]);
   });
 
   it("does not claim URL-only or outside-worktree artifacts", async () => {

--- a/extensions/workboard/src/artifact-retention.ts
+++ b/extensions/workboard/src/artifact-retention.ts
@@ -1,0 +1,273 @@
+import path from "node:path";
+import type { WorkboardCard } from "@openclaw/workboard-contract";
+import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
+import {
+  canonicalPathFromExistingAncestor,
+  isPathInside,
+} from "openclaw/plugin-sdk/security-runtime";
+import {
+  isWorkboardCardStore,
+  type PersistedWorkboardCard,
+  type WorkboardCardStore,
+  type WorkboardKeyedStore,
+} from "./persistence-types.js";
+
+const ARTIFACT_RETENTION_CLAIM_ID = "persisted-local-artifacts";
+
+type WorktreeRetentionRuntime = Pick<PluginRuntime["worktrees"], "setRetentionClaim">;
+
+export type WorkboardArtifactRetentionStore = WorkboardKeyedStore & {
+  reconcileArtifactRetention(): Promise<void>;
+};
+
+function worktreeWorkspacePath(card: WorkboardCard | undefined): string | undefined {
+  const workspace = card?.metadata?.automation?.workspace;
+  return workspace?.kind === "worktree" && workspace.path ? workspace.path : undefined;
+}
+
+async function retainedWorkspacePath(card: WorkboardCard | undefined): Promise<string | undefined> {
+  const workspacePath = worktreeWorkspacePath(card);
+  if (!card || card.metadata?.archivedAt || !workspacePath) {
+    return undefined;
+  }
+  const artifactPaths = (card.metadata?.artifacts ?? []).flatMap((artifact) =>
+    artifact.path ? [artifact.path] : [],
+  );
+  if (artifactPaths.length === 0) {
+    return undefined;
+  }
+  const workspaceRoot = path.resolve(workspacePath);
+  try {
+    const canonicalWorkspaceRoot = await canonicalPathFromExistingAncestor(workspaceRoot);
+    for (const artifact of artifactPaths) {
+      const artifactPath = path.resolve(workspaceRoot, artifact);
+      const canonicalArtifactPath = await canonicalPathFromExistingAncestor(artifactPath);
+      if (isPathInside(canonicalWorkspaceRoot, canonicalArtifactPath)) {
+        return workspacePath;
+      }
+    }
+  } catch {
+    // A path-resolution failure must not turn persisted local state into an unprotected tree.
+    return workspacePath;
+  }
+  return undefined;
+}
+
+async function setArtifactRetentionClaim(params: {
+  worktrees: WorktreeRetentionRuntime;
+  card: WorkboardCard;
+  workspacePath: string;
+  active: boolean;
+  allowUnavailable?: boolean;
+}): Promise<void> {
+  const accepted = await params.worktrees.setRetentionClaim({
+    path: params.workspacePath,
+    ownerKind: "workboard",
+    ownerId: params.card.id,
+    claimId: ARTIFACT_RETENTION_CLAIM_ID,
+    active: params.active,
+  });
+  if (params.active && !accepted && !params.allowUnavailable) {
+    throw new Error(
+      `managed worktree is unavailable for artifact retention: ${params.workspacePath}`,
+    );
+  }
+}
+
+export function withWorkboardArtifactRetention(
+  store: WorkboardKeyedStore,
+  worktrees: WorktreeRetentionRuntime,
+): WorkboardArtifactRetentionStore {
+  let reconciliation: Promise<void> | undefined;
+  const pendingReleases = new Map<string, { card: WorkboardCard; workspacePath: string }>();
+  const releaseClaim = async (card: WorkboardCard, workspacePath: string): Promise<void> => {
+    const key = `${card.id}\0${workspacePath}`;
+    try {
+      await setArtifactRetentionClaim({
+        worktrees,
+        card,
+        workspacePath,
+        active: false,
+      });
+      pendingReleases.delete(key);
+    } catch (error) {
+      pendingReleases.set(key, { card, workspacePath });
+      reconciliation = undefined;
+      throw error;
+    }
+  };
+  const reconcileArtifactRetention = () => {
+    reconciliation ??= (async () => {
+      for (const { card, workspacePath } of pendingReleases.values()) {
+        await releaseClaim(card, workspacePath);
+      }
+      for (const entry of await store.entries()) {
+        const card = entry.value?.version === 1 ? entry.value.card : undefined;
+        const workspacePath = worktreeWorkspacePath(card);
+        if (!card || !workspacePath) {
+          continue;
+        }
+        const active = Boolean(await retainedWorkspacePath(card));
+        if (active) {
+          await setArtifactRetentionClaim({
+            worktrees,
+            card,
+            workspacePath,
+            active: true,
+            // Pre-retention cards can outlive worktrees that old cleanup already removed.
+            allowUnavailable: true,
+          });
+        } else {
+          await releaseClaim(card, workspacePath);
+        }
+      }
+    })().catch((error: unknown) => {
+      reconciliation = undefined;
+      throw error;
+    });
+    return reconciliation;
+  };
+
+  type CardTransition = {
+    nextCard: WorkboardCard;
+    nextPath?: string;
+    previousCard?: WorkboardCard;
+    previousPath?: string;
+  };
+
+  const prepareCardTransition = async (
+    key: string,
+    value: PersistedWorkboardCard,
+  ): Promise<CardTransition> => {
+    await reconcileArtifactRetention();
+    const previous = await store.lookup(key);
+    const previousCard = previous?.version === 1 ? previous.card : undefined;
+    const nextPath = await retainedWorkspacePath(value.card);
+    const previousPath = await retainedWorkspacePath(previousCard);
+    if (nextPath) {
+      await setArtifactRetentionClaim({
+        worktrees,
+        card: value.card,
+        workspacePath: nextPath,
+        active: true,
+      });
+    }
+    return { nextCard: value.card, nextPath, previousCard, previousPath };
+  };
+
+  const settleCardTransition = async (
+    transition: CardTransition,
+    applied: boolean,
+  ): Promise<void> => {
+    if (!applied) {
+      if (transition.nextPath && transition.nextPath !== transition.previousPath) {
+        await releaseClaim(transition.nextCard, transition.nextPath).catch(() => undefined);
+      }
+      return;
+    }
+    if (
+      transition.previousCard &&
+      transition.previousPath &&
+      transition.previousPath !== transition.nextPath
+    ) {
+      await releaseClaim(transition.previousCard, transition.previousPath);
+    }
+  };
+
+  const updateWithRetention = async <T>(
+    key: string,
+    value: PersistedWorkboardCard,
+    update: () => Promise<T>,
+    wasApplied: (result: T) => boolean,
+  ): Promise<T> => {
+    const transition = await prepareCardTransition(key, value);
+    try {
+      const result = await update();
+      await settleCardTransition(transition, wasApplied(result));
+      return result;
+    } catch (error) {
+      await settleCardTransition(transition, false);
+      throw error;
+    }
+  };
+
+  const deleteWithRetention = async (
+    key: string,
+    remove: () => Promise<boolean>,
+  ): Promise<boolean> => {
+    await reconcileArtifactRetention();
+    const previous = await store.lookup(key);
+    const previousCard = previous?.version === 1 ? previous.card : undefined;
+    const previousPath = await retainedWorkspacePath(previousCard);
+    const deleted = await remove();
+    if (deleted && previousCard && previousPath) {
+      await releaseClaim(previousCard, previousPath);
+    }
+    return deleted;
+  };
+
+  const decorated: WorkboardArtifactRetentionStore = {
+    reconcileArtifactRetention,
+    async register(key, value) {
+      await updateWithRetention(
+        key,
+        value,
+        async () => await store.register(key, value),
+        () => true,
+      );
+    },
+    async lookup(key) {
+      await reconcileArtifactRetention();
+      return await store.lookup(key);
+    },
+    async delete(key) {
+      return await deleteWithRetention(key, async () => await store.delete(key));
+    },
+    async entries() {
+      await reconcileArtifactRetention();
+      return await store.entries();
+    },
+  };
+
+  if (!isWorkboardCardStore(store)) {
+    return decorated;
+  }
+  const cardStore: WorkboardCardStore = store;
+  return {
+    ...decorated,
+    async registerIfAbsent(key, value) {
+      return await updateWithRetention(
+        key,
+        value,
+        async () => await cardStore.registerIfAbsent(key, value),
+        (applied) => applied,
+      );
+    },
+    async registerIfUpdatedAt(key, value, expectedUpdatedAt) {
+      return await updateWithRetention(
+        key,
+        value,
+        async () => await cardStore.registerIfUpdatedAt(key, value, expectedUpdatedAt),
+        (applied) => applied,
+      );
+    },
+    async claimIfOwnerAvailable(key, value, expectedUpdatedAt, ownerId, now) {
+      return await updateWithRetention(
+        key,
+        value,
+        async () =>
+          await cardStore.claimIfOwnerAvailable(key, value, expectedUpdatedAt, ownerId, now),
+        (result) => result === "updated",
+      );
+    },
+    async deleteIfUpdatedAt(key, expectedUpdatedAt) {
+      return await deleteWithRetention(
+        key,
+        async () => await cardStore.deleteIfUpdatedAt(key, expectedUpdatedAt),
+      );
+    },
+    async listBoardAggregates() {
+      return await cardStore.listBoardAggregates();
+    },
+  } as WorkboardArtifactRetentionStore & WorkboardCardStore;
+}

--- a/extensions/workboard/src/artifact-retention.ts
+++ b/extensions/workboard/src/artifact-retention.ts
@@ -1,4 +1,6 @@
+import { randomUUID } from "node:crypto";
 import path from "node:path";
+import type { DatabaseSync } from "node:sqlite";
 import type { WorkboardCard } from "@openclaw/workboard-contract";
 import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
 import {
@@ -6,28 +8,43 @@ import {
   isPathInside,
 } from "openclaw/plugin-sdk/security-runtime";
 import {
-  isWorkboardCardStore,
-  type PersistedWorkboardCard,
-  type WorkboardCardStore,
-  type WorkboardKeyedStore,
-} from "./persistence-types.js";
+  executeSqliteQuerySync,
+  getNodeSqliteKysely,
+  runSqliteImmediateTransactionSync,
+} from "openclaw/plugin-sdk/sqlite-runtime";
 
-const ARTIFACT_RETENTION_CLAIM_ID = "persisted-local-artifacts";
+export type WorktreeRetentionRuntime = Pick<
+  PluginRuntime["worktrees"],
+  "resolveRetentionTarget" | "setRetentionClaim"
+>;
 
-type WorktreeRetentionRuntime = Pick<PluginRuntime["worktrees"], "setRetentionClaim">;
-
-export type WorkboardArtifactRetentionStore = WorkboardKeyedStore & {
+export type WorkboardArtifactRetentionStore = {
   reconcileArtifactRetention(): Promise<void>;
 };
 
-function worktreeWorkspacePath(card: WorkboardCard | undefined): string | undefined {
-  const workspace = card?.metadata?.automation?.workspace;
-  return workspace?.kind === "worktree" && workspace.path ? workspace.path : undefined;
-}
+type RetentionGeneration = {
+  claim_id: string;
+  card_id: string;
+  worktree_id: string;
+  state: "prepared" | "active" | "release_pending";
+};
+
+export const WORKBOARD_ARTIFACT_RETENTION_SCHEMA = `
+  CREATE TABLE IF NOT EXISTS workboard_artifact_retention (
+    claim_id TEXT PRIMARY KEY,
+    card_id TEXT NOT NULL,
+    worktree_id TEXT NOT NULL,
+    state TEXT NOT NULL CHECK (state IN ('prepared', 'active', 'release_pending'))
+  ) STRICT;
+  CREATE UNIQUE INDEX IF NOT EXISTS workboard_artifact_retention_active_idx
+    ON workboard_artifact_retention(card_id) WHERE state = 'active';
+  CREATE INDEX IF NOT EXISTS workboard_artifact_retention_pending_idx
+    ON workboard_artifact_retention(state);
+`;
 
 async function retainedWorkspacePath(card: WorkboardCard | undefined): Promise<string | undefined> {
-  const workspacePath = worktreeWorkspacePath(card);
-  if (!card || card.metadata?.archivedAt || !workspacePath) {
+  const workspace = card?.metadata?.automation?.workspace;
+  if (!card || card.metadata?.archivedAt || workspace?.kind !== "worktree" || !workspace.path) {
     return undefined;
   }
   const artifactPaths = (card.metadata?.artifacts ?? []).flatMap((artifact) =>
@@ -36,239 +53,199 @@ async function retainedWorkspacePath(card: WorkboardCard | undefined): Promise<s
   if (artifactPaths.length === 0) {
     return undefined;
   }
-  const workspaceRoot = path.resolve(workspacePath);
+  const workspaceRoot = path.resolve(workspace.path);
   try {
     const canonicalWorkspaceRoot = await canonicalPathFromExistingAncestor(workspaceRoot);
     for (const artifact of artifactPaths) {
-      const artifactPath = path.resolve(workspaceRoot, artifact);
-      const canonicalArtifactPath = await canonicalPathFromExistingAncestor(artifactPath);
+      const canonicalArtifactPath = await canonicalPathFromExistingAncestor(
+        path.resolve(workspaceRoot, artifact),
+      );
       if (isPathInside(canonicalWorkspaceRoot, canonicalArtifactPath)) {
-        return workspacePath;
+        return workspace.path;
       }
     }
   } catch {
-    // A path-resolution failure must not turn persisted local state into an unprotected tree.
-    return workspacePath;
+    // Resolution failure must not turn a persisted local reference into an unprotected tree.
+    return workspace.path;
   }
   return undefined;
 }
 
-async function setArtifactRetentionClaim(params: {
-  worktrees: WorktreeRetentionRuntime;
-  card: WorkboardCard;
-  workspacePath: string;
-  active: boolean;
-  allowUnavailable?: boolean;
-}): Promise<void> {
-  const accepted = await params.worktrees.setRetentionClaim({
-    path: params.workspacePath,
-    ownerKind: "workboard",
-    ownerId: params.card.id,
-    claimId: ARTIFACT_RETENTION_CLAIM_ID,
-    active: params.active,
-  });
-  if (params.active && !accepted && !params.allowUnavailable) {
-    throw new Error(
-      `managed worktree is unavailable for artifact retention: ${params.workspacePath}`,
+/** Shares the card owner's database/commit boundary, never a second persistence transaction. */
+export class WorkboardArtifactRetention {
+  private readonly k;
+
+  constructor(
+    private readonly db: DatabaseSync,
+    private readonly worktrees: WorktreeRetentionRuntime,
+  ) {
+    this.k = getNodeSqliteKysely<{ workboard_artifact_retention: RetentionGeneration }>(db);
+  }
+
+  private current(cardId: string): RetentionGeneration | undefined {
+    return executeSqliteQuerySync(
+      this.db,
+      this.k
+        .selectFrom("workboard_artifact_retention")
+        .selectAll()
+        .where("card_id", "=", cardId)
+        .where("state", "=", "active"),
+    ).rows[0];
+  }
+
+  private cancel(claimId: string): void {
+    executeSqliteQuerySync(
+      this.db,
+      this.k
+        .updateTable("workboard_artifact_retention")
+        .set({ state: "release_pending" })
+        .where("claim_id", "=", claimId)
+        .where("state", "=", "prepared"),
     );
   }
-}
 
-export function withWorkboardArtifactRetention(
-  store: WorkboardKeyedStore,
-  worktrees: WorktreeRetentionRuntime,
-): WorkboardArtifactRetentionStore {
-  let reconciliation: Promise<void> | undefined;
-  const pendingReleases = new Map<string, { card: WorkboardCard; workspacePath: string }>();
-  const releaseClaim = async (card: WorkboardCard, workspacePath: string): Promise<void> => {
-    const key = `${card.id}\0${workspacePath}`;
-    try {
-      await setArtifactRetentionClaim({
-        worktrees,
-        card,
-        workspacePath,
+  cancelPrepared(): void {
+    // Cancellation and card publication compete in this same SQLite commit domain.
+    // A delayed writer must still find its exact prepared generation before publishing.
+    executeSqliteQuerySync(
+      this.db,
+      this.k
+        .updateTable("workboard_artifact_retention")
+        .set({ state: "release_pending" })
+        .where("state", "=", "prepared"),
+    );
+  }
+
+  async drainReleases(): Promise<void> {
+    const pending = executeSqliteQuerySync(
+      this.db,
+      this.k
+        .selectFrom("workboard_artifact_retention")
+        .selectAll()
+        .where("state", "=", "release_pending"),
+    ).rows;
+    for (const generation of pending) {
+      const released = await this.worktrees.setRetentionClaim({
+        worktreeId: generation.worktree_id,
+        ownerKind: "workboard",
+        ownerId: generation.card_id,
+        claimId: generation.claim_id,
         active: false,
       });
-      pendingReleases.delete(key);
-    } catch (error) {
-      pendingReleases.set(key, { card, workspacePath });
-      reconciliation = undefined;
-      throw error;
-    }
-  };
-  const reconcileArtifactRetention = () => {
-    reconciliation ??= (async () => {
-      for (const { card, workspacePath } of pendingReleases.values()) {
-        await releaseClaim(card, workspacePath);
+      if (!released) {
+        throw new Error("managed worktree rejected artifact retention release");
       }
-      for (const entry of await store.entries()) {
-        const card = entry.value?.version === 1 ? entry.value.card : undefined;
-        const workspacePath = worktreeWorkspacePath(card);
-        if (!card || !workspacePath) {
-          continue;
-        }
-        const active = Boolean(await retainedWorkspacePath(card));
-        if (active) {
-          await setArtifactRetentionClaim({
-            worktrees,
-            card,
-            workspacePath,
-            active: true,
-            // Pre-retention cards can outlive worktrees that old cleanup already removed.
-            allowUnavailable: true,
-          });
-        } else {
-          await releaseClaim(card, workspacePath);
-        }
-      }
-    })().catch((error: unknown) => {
-      reconciliation = undefined;
-      throw error;
-    });
-    return reconciliation;
-  };
-
-  type CardTransition = {
-    nextCard: WorkboardCard;
-    nextPath?: string;
-    previousCard?: WorkboardCard;
-    previousPath?: string;
-  };
-
-  const prepareCardTransition = async (
-    key: string,
-    value: PersistedWorkboardCard,
-  ): Promise<CardTransition> => {
-    await reconcileArtifactRetention();
-    const previous = await store.lookup(key);
-    const previousCard = previous?.version === 1 ? previous.card : undefined;
-    const nextPath = await retainedWorkspacePath(value.card);
-    const previousPath = await retainedWorkspacePath(previousCard);
-    if (nextPath) {
-      await setArtifactRetentionClaim({
-        worktrees,
-        card: value.card,
-        workspacePath: nextPath,
-        active: true,
-      });
-    }
-    return { nextCard: value.card, nextPath, previousCard, previousPath };
-  };
-
-  const settleCardTransition = async (
-    transition: CardTransition,
-    applied: boolean,
-  ): Promise<void> => {
-    if (!applied) {
-      if (transition.nextPath && transition.nextPath !== transition.previousPath) {
-        await releaseClaim(transition.nextCard, transition.nextPath).catch(() => undefined);
-      }
-      return;
-    }
-    if (
-      transition.previousCard &&
-      transition.previousPath &&
-      transition.previousPath !== transition.nextPath
-    ) {
-      await releaseClaim(transition.previousCard, transition.previousPath);
-    }
-  };
-
-  const updateWithRetention = async <T>(
-    key: string,
-    value: PersistedWorkboardCard,
-    update: () => Promise<T>,
-    wasApplied: (result: T) => boolean,
-  ): Promise<T> => {
-    const transition = await prepareCardTransition(key, value);
-    let result: T;
-    try {
-      result = await update();
-    } catch (error) {
-      await settleCardTransition(transition, false);
-      throw error;
-    }
-    await settleCardTransition(transition, wasApplied(result));
-    return result;
-  };
-
-  const deleteWithRetention = async (
-    key: string,
-    remove: () => Promise<boolean>,
-  ): Promise<boolean> => {
-    await reconcileArtifactRetention();
-    const previous = await store.lookup(key);
-    const previousCard = previous?.version === 1 ? previous.card : undefined;
-    const previousPath = await retainedWorkspacePath(previousCard);
-    const deleted = await remove();
-    if (deleted && previousCard && previousPath) {
-      await releaseClaim(previousCard, previousPath);
-    }
-    return deleted;
-  };
-
-  const decorated: WorkboardArtifactRetentionStore = {
-    reconcileArtifactRetention,
-    async register(key, value) {
-      await updateWithRetention(
-        key,
-        value,
-        async () => await store.register(key, value),
-        () => true,
+      // Acknowledge only after terminal release; replay after a crash is idempotent.
+      executeSqliteQuerySync(
+        this.db,
+        this.k
+          .deleteFrom("workboard_artifact_retention")
+          .where("claim_id", "=", generation.claim_id)
+          .where("state", "=", "release_pending"),
       );
-    },
-    async lookup(key) {
-      await reconcileArtifactRetention();
-      return await store.lookup(key);
-    },
-    async delete(key) {
-      return await deleteWithRetention(key, async () => await store.delete(key));
-    },
-    async entries() {
-      await reconcileArtifactRetention();
-      return await store.entries();
-    },
-  };
-
-  if (!isWorkboardCardStore(store)) {
-    return decorated;
+    }
   }
-  const cardStore: WorkboardCardStore = store;
-  return {
-    ...decorated,
-    async registerIfAbsent(key, value) {
-      return await updateWithRetention(
-        key,
-        value,
-        async () => await cardStore.registerIfAbsent(key, value),
-        (applied) => applied,
+
+  async mutate<T>(
+    cardId: string,
+    next: WorkboardCard | undefined,
+    commit: () => T,
+    applied: (result: T) => boolean,
+    allowUnavailable = false,
+  ): Promise<T> {
+    const workspacePath = await retainedWorkspacePath(next);
+    const worktreeId = workspacePath
+      ? await this.worktrees.resolveRetentionTarget({
+          path: workspacePath,
+          ownerKind: "workboard",
+          ownerId: cardId,
+        })
+      : undefined;
+    if (workspacePath && !worktreeId) {
+      if (!allowUnavailable) {
+        throw new Error(`managed worktree is unavailable for artifact retention: ${workspacePath}`);
+      }
+      // Startup cannot interpret temporary removal as removal of the persisted reference.
+      // Preserve an enrolled generation so restoring that identity retains its protection.
+      return runSqliteImmediateTransactionSync(this.db, commit);
+    }
+
+    const previous = this.current(cardId);
+    const reused = worktreeId && previous?.worktree_id === worktreeId ? previous : undefined;
+    const prepared: RetentionGeneration | undefined =
+      worktreeId && !reused
+        ? { claim_id: randomUUID(), card_id: cardId, worktree_id: worktreeId, state: "prepared" }
+        : undefined;
+    if (prepared) {
+      // Persist intent before the other store can acquire anything we must later release.
+      executeSqliteQuerySync(
+        this.db,
+        this.k.insertInto("workboard_artifact_retention").values(prepared),
       );
-    },
-    async registerIfUpdatedAt(key, value, expectedUpdatedAt) {
-      return await updateWithRetention(
-        key,
-        value,
-        async () => await cardStore.registerIfUpdatedAt(key, value, expectedUpdatedAt),
-        (applied) => applied,
-      );
-    },
-    async claimIfOwnerAvailable(key, value, expectedUpdatedAt, ownerId, now) {
-      return await updateWithRetention(
-        key,
-        value,
-        async () =>
-          await cardStore.claimIfOwnerAvailable(key, value, expectedUpdatedAt, ownerId, now),
-        (result) => result === "updated",
-      );
-    },
-    async deleteIfUpdatedAt(key, expectedUpdatedAt) {
-      return await deleteWithRetention(
-        key,
-        async () => await cardStore.deleteIfUpdatedAt(key, expectedUpdatedAt),
-      );
-    },
-    async listBoardAggregates() {
-      return await cardStore.listBoardAggregates();
-    },
-  } as WorkboardArtifactRetentionStore & WorkboardCardStore; // SAFETY: isWorkboardCardStore proves every spread card-store method exists.
+    }
+    const generation = prepared ?? reused;
+    try {
+      if (generation) {
+        const acquired = await this.worktrees.setRetentionClaim({
+          worktreeId: generation.worktree_id,
+          ownerKind: "workboard",
+          ownerId: cardId,
+          claimId: generation.claim_id,
+          active: true,
+        });
+        if (!acquired) {
+          throw new Error(
+            "artifact retention preparation was cancelled or the worktree is unavailable; retry the mutation",
+          );
+        }
+      }
+      return runSqliteImmediateTransactionSync(this.db, () => {
+        if (generation) {
+          const current = executeSqliteQuerySync(
+            this.db,
+            this.k
+              .selectFrom("workboard_artifact_retention")
+              .select("state")
+              .where("claim_id", "=", generation.claim_id),
+          ).rows[0];
+          if (current?.state !== (prepared ? "prepared" : "active")) {
+            throw new Error("artifact retention preparation was cancelled; retry the mutation");
+          }
+        }
+        const result = commit();
+        if (applied(result)) {
+          let obsolete = this.k
+            .updateTable("workboard_artifact_retention")
+            .set({ state: "release_pending" })
+            .where("card_id", "=", cardId)
+            .where("state", "=", "active");
+          if (generation) {
+            obsolete = obsolete.where("claim_id", "!=", generation.claim_id);
+          }
+          executeSqliteQuerySync(this.db, obsolete);
+          if (prepared) {
+            executeSqliteQuerySync(
+              this.db,
+              this.k
+                .updateTable("workboard_artifact_retention")
+                .set({ state: "active" })
+                .where("claim_id", "=", prepared.claim_id),
+            );
+          }
+        } else if (prepared) {
+          this.cancel(prepared.claim_id);
+        }
+        return result;
+      });
+    } catch (error) {
+      if (prepared) {
+        this.cancel(prepared.claim_id);
+      }
+      throw error;
+    } finally {
+      // The durable obligation owns retry. A cleanup outage must not turn a committed
+      // card write into a reported write failure (and trigger incorrect compensation).
+      await this.drainReleases().catch(() => undefined);
+    }
+  }
 }

--- a/extensions/workboard/src/artifact-retention.ts
+++ b/extensions/workboard/src/artifact-retention.ts
@@ -269,5 +269,5 @@ export function withWorkboardArtifactRetention(
     async listBoardAggregates() {
       return await cardStore.listBoardAggregates();
     },
-  } as WorkboardArtifactRetentionStore & WorkboardCardStore;
+  } as WorkboardArtifactRetentionStore & WorkboardCardStore; // SAFETY: isWorkboardCardStore proves every spread card-store method exists.
 }

--- a/extensions/workboard/src/artifact-retention.ts
+++ b/extensions/workboard/src/artifact-retention.ts
@@ -181,14 +181,15 @@ export function withWorkboardArtifactRetention(
     wasApplied: (result: T) => boolean,
   ): Promise<T> => {
     const transition = await prepareCardTransition(key, value);
+    let result: T;
     try {
-      const result = await update();
-      await settleCardTransition(transition, wasApplied(result));
-      return result;
+      result = await update();
     } catch (error) {
       await settleCardTransition(transition, false);
       throw error;
     }
+    await settleCardTransition(transition, wasApplied(result));
+    return result;
   };
 
   const deleteWithRetention = async (

--- a/extensions/workboard/src/artifact-retention.ts
+++ b/extensions/workboard/src/artifact-retention.ts
@@ -44,7 +44,15 @@ export const WORKBOARD_ARTIFACT_RETENTION_SCHEMA = `
 
 async function retainedWorkspacePath(card: WorkboardCard | undefined): Promise<string | undefined> {
   const workspace = card?.metadata?.automation?.workspace;
-  if (!card || card.metadata?.archivedAt || workspace?.kind !== "worktree" || !workspace.path) {
+  // A worktree request also names its source checkout before/after materialization.
+  // Only materialized managed workspaces carry sourcePath; owner/identity checks still follow.
+  if (
+    !card ||
+    card.metadata?.archivedAt ||
+    workspace?.kind !== "worktree" ||
+    !workspace.path ||
+    !workspace.sourcePath
+  ) {
     return undefined;
   }
   const artifactPaths = (card.metadata?.artifacts ?? []).flatMap((artifact) =>

--- a/extensions/workboard/src/change-events.test.ts
+++ b/extensions/workboard/src/change-events.test.ts
@@ -6,6 +6,31 @@ import type { WorkboardStore } from "./store.js";
 afterEach(() => vi.useRealTimers());
 
 describe("createWorkboardChangeEventService", () => {
+  it("does not restart event producers after stop cancels pending startup", async () => {
+    vi.useFakeTimers();
+    const ready = Promise.withResolvers<void>();
+    const subscribeChanges = vi.fn(() => vi.fn());
+    const store = {
+      reconcileArtifactRetention: vi.fn(() => ready.promise),
+      subscribeChanges,
+      announceChangeEpoch: vi.fn(),
+      reconcileExternalChanges: vi.fn(),
+    } as unknown as WorkboardStore;
+    const service = createWorkboardChangeEventService(store);
+    const context = {
+      config: {},
+      stateDir: "/tmp/workboard-start-stop-test",
+      gatewayEvents: { emit: vi.fn(), onSessionsChanged: () => () => undefined },
+      logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    } satisfies Parameters<typeof service.start>[0];
+    const starting = service.start(context);
+    service.stop();
+    ready.resolve();
+    await starting;
+    expect(subscribeChanges).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
   it("keeps repeated starts on one change subscription and reconciliation timer", async () => {
     vi.useFakeTimers();
     const listeners = new Set<(change: WorkboardChange) => void>();
@@ -126,5 +151,30 @@ describe("createWorkboardChangeEventService", () => {
     expect(reconcileExternalChanges).toHaveBeenCalledTimes(2);
     expect(warn).toHaveBeenCalledTimes(2);
     await service.stop?.(context);
+  });
+
+  it("retries deferred retention cleanup without gateway event subscribers", async () => {
+    vi.useFakeTimers();
+    const reconcileArtifactRetention = vi.fn().mockResolvedValue(undefined);
+    const store = {
+      reconcileExternalChanges: vi.fn(),
+      reconcileArtifactRetention,
+    } as unknown as WorkboardStore;
+    const service = createWorkboardChangeEventService(store);
+    const warn = vi.fn();
+    const context = {
+      config: {},
+      stateDir: "/tmp/workboard-retention-retry-test",
+      logger: { debug: vi.fn(), info: vi.fn(), warn, error: vi.fn() },
+    } satisfies Parameters<typeof service.start>[0];
+    await service.start(context);
+    reconcileArtifactRetention.mockRejectedValueOnce(new Error("release unavailable"));
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("release unavailable"));
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(reconcileArtifactRetention).toHaveBeenCalledTimes(3);
+    await service.stop?.(context);
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(reconcileArtifactRetention).toHaveBeenCalledTimes(3);
   });
 });

--- a/extensions/workboard/src/change-events.test.ts
+++ b/extensions/workboard/src/change-events.test.ts
@@ -18,10 +18,12 @@ describe("createWorkboardChangeEventService", () => {
       return () => unsubscribe(listener);
     });
     const announceChangeEpoch = vi.fn();
+    const reconcileArtifactRetention = vi.fn();
     const store = {
       subscribeChanges,
       announceChangeEpoch,
       reconcileExternalChanges,
+      reconcileArtifactRetention,
     } as unknown as WorkboardStore;
     const emit = vi.fn();
     const service = createWorkboardChangeEventService(store);
@@ -38,6 +40,7 @@ describe("createWorkboardChangeEventService", () => {
 
     expect(subscribeChanges).toHaveBeenCalledOnce();
     expect(announceChangeEpoch).toHaveBeenCalledOnce();
+    expect(reconcileArtifactRetention).toHaveBeenCalledOnce();
     expect(listeners.size).toBe(1);
 
     for (const listener of listeners) {
@@ -61,6 +64,7 @@ describe("createWorkboardChangeEventService", () => {
     let listener: ((change: WorkboardChange) => void) | undefined;
     const unsubscribe = vi.fn();
     const reconcileExternalChanges = vi.fn();
+    const reconcileArtifactRetention = vi.fn();
     const store = {
       subscribeChanges: vi.fn((next) => {
         listener = next;
@@ -68,6 +72,7 @@ describe("createWorkboardChangeEventService", () => {
       }),
       announceChangeEpoch: vi.fn(() => listener?.({ epoch: "epoch-a", revision: 1 })),
       reconcileExternalChanges,
+      reconcileArtifactRetention,
     } as unknown as WorkboardStore;
     const emit = vi.fn();
     const warn = vi.fn();
@@ -88,6 +93,7 @@ describe("createWorkboardChangeEventService", () => {
       ["changed", { epoch: "epoch-a", revision: 2 }, { scope: "operator.read" }],
     ]);
     expect(reconcileExternalChanges).toHaveBeenCalledOnce();
+    expect(reconcileArtifactRetention).toHaveBeenCalledOnce();
     await service.stop?.(context);
     await vi.advanceTimersByTimeAsync(1000);
     expect(reconcileExternalChanges).toHaveBeenCalledOnce();
@@ -104,6 +110,7 @@ describe("createWorkboardChangeEventService", () => {
       subscribeChanges: vi.fn(() => vi.fn()),
       announceChangeEpoch: vi.fn(),
       reconcileExternalChanges,
+      reconcileArtifactRetention: vi.fn(),
     } as unknown as WorkboardStore;
     const warn = vi.fn();
     const service = createWorkboardChangeEventService(store);

--- a/extensions/workboard/src/change-events.test.ts
+++ b/extensions/workboard/src/change-events.test.ts
@@ -1,4 +1,5 @@
 import type { WorkboardChange } from "@openclaw/workboard-contract";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createWorkboardChangeEventService } from "./change-events.js";
 import type { WorkboardStore } from "./store.js";
@@ -6,30 +7,37 @@ import type { WorkboardStore } from "./store.js";
 afterEach(() => vi.useRealTimers());
 
 describe("createWorkboardChangeEventService", () => {
-  it("does not restart event producers after stop cancels pending startup", async () => {
-    vi.useFakeTimers();
-    const ready = Promise.withResolvers<void>();
-    const subscribeChanges = vi.fn(() => vi.fn());
-    const store = {
-      reconcileArtifactRetention: vi.fn(() => ready.promise),
-      subscribeChanges,
-      announceChangeEpoch: vi.fn(),
-      reconcileExternalChanges: vi.fn(),
-    } as unknown as WorkboardStore;
-    const service = createWorkboardChangeEventService(store);
-    const context = {
-      config: {},
-      stateDir: "/tmp/workboard-start-stop-test",
-      gatewayEvents: { emit: vi.fn(), onSessionsChanged: () => () => undefined },
-      logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-    } satisfies Parameters<typeof service.start>[0];
-    const starting = service.start(context);
-    service.stop();
-    ready.resolve();
-    await starting;
-    expect(subscribeChanges).not.toHaveBeenCalled();
-    expect(vi.getTimerCount()).toBe(0);
-  });
+  it.each([false, true])(
+    "does not restart event producers after stop cancels pending startup (failed: %s)",
+    async (failed) => {
+      vi.useFakeTimers();
+      const ready = createDeferred<void>();
+      const subscribeChanges = vi.fn(() => vi.fn());
+      const store = {
+        reconcileArtifactRetention: vi.fn(() => ready.promise),
+        subscribeChanges,
+        announceChangeEpoch: vi.fn(),
+        reconcileExternalChanges: vi.fn(),
+      } as unknown as WorkboardStore;
+      const service = createWorkboardChangeEventService(store);
+      const context = {
+        config: {},
+        stateDir: "/tmp/workboard-start-stop-test",
+        gatewayEvents: { emit: vi.fn(), onSessionsChanged: () => () => undefined },
+        logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      } satisfies Parameters<typeof service.start>[0];
+      const starting = service.start(context);
+      service.stop();
+      if (failed) {
+        ready.reject(new Error("release unavailable"));
+      } else {
+        ready.resolve();
+      }
+      await expect(starting).resolves.toBeUndefined();
+      expect(subscribeChanges).not.toHaveBeenCalled();
+      expect(vi.getTimerCount()).toBe(0);
+    },
+  );
 
   it("keeps repeated starts on one change subscription and reconciliation timer", async () => {
     vi.useFakeTimers();
@@ -153,28 +161,67 @@ describe("createWorkboardChangeEventService", () => {
     await service.stop?.(context);
   });
 
-  it("retries deferred retention cleanup without gateway event subscribers", async () => {
-    vi.useFakeTimers();
-    const reconcileArtifactRetention = vi.fn().mockResolvedValue(undefined);
-    const store = {
-      reconcileExternalChanges: vi.fn(),
-      reconcileArtifactRetention,
-    } as unknown as WorkboardStore;
-    const service = createWorkboardChangeEventService(store);
-    const warn = vi.fn();
-    const context = {
-      config: {},
-      stateDir: "/tmp/workboard-retention-retry-test",
-      logger: { debug: vi.fn(), info: vi.fn(), warn, error: vi.fn() },
-    } satisfies Parameters<typeof service.start>[0];
-    await service.start(context);
-    reconcileArtifactRetention.mockRejectedValueOnce(new Error("release unavailable"));
-    await vi.advanceTimersByTimeAsync(60_000);
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining("release unavailable"));
-    await vi.advanceTimersByTimeAsync(60_000);
-    expect(reconcileArtifactRetention).toHaveBeenCalledTimes(3);
-    await service.stop?.(context);
-    await vi.advanceTimersByTimeAsync(60_000);
-    expect(reconcileArtifactRetention).toHaveBeenCalledTimes(3);
-  });
+  it.each([false, true])(
+    "keeps change events and retries after startup retention fails (gateway events: %s)",
+    async (withGatewayEvents) => {
+      vi.useFakeTimers();
+      const reconcileArtifactRetention = vi
+        .fn()
+        .mockRejectedValueOnce(new Error("release unavailable during startup"))
+        .mockRejectedValueOnce(new Error("release unavailable during retry"))
+        .mockResolvedValue(undefined);
+      let listener: ((change: WorkboardChange) => void) | undefined;
+      const unsubscribe = vi.fn();
+      const subscribeChanges = vi.fn((next: (change: WorkboardChange) => void) => {
+        listener = next;
+        return unsubscribe;
+      });
+      const announceChangeEpoch = vi.fn(() => listener?.({ epoch: "epoch-a", revision: 1 }));
+      const reconcileExternalChanges = vi.fn();
+      const store = {
+        subscribeChanges,
+        announceChangeEpoch,
+        reconcileExternalChanges,
+        reconcileArtifactRetention,
+      } as unknown as WorkboardStore;
+      const service = createWorkboardChangeEventService(store);
+      const warn = vi.fn();
+      const emit = vi.fn();
+      const context = {
+        config: {},
+        stateDir: "/tmp/workboard-retention-retry-test",
+        ...(withGatewayEvents
+          ? { gatewayEvents: { emit, onSessionsChanged: () => () => undefined } }
+          : {}),
+        logger: { debug: vi.fn(), info: vi.fn(), warn, error: vi.fn() },
+      } satisfies Parameters<typeof service.start>[0];
+      await expect(service.start(context)).resolves.toBeUndefined();
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining("release unavailable during startup"),
+      );
+      if (withGatewayEvents) {
+        expect(subscribeChanges).toHaveBeenCalledOnce();
+        expect(announceChangeEpoch).toHaveBeenCalledOnce();
+        listener?.({ epoch: "epoch-a", revision: 2 });
+        expect(emit.mock.calls).toEqual([
+          ["changed", { epoch: "epoch-a", revision: 1 }, { scope: "operator.read" }],
+          ["changed", { epoch: "epoch-a", revision: 2 }, { scope: "operator.read" }],
+        ]);
+      } else {
+        expect(subscribeChanges).not.toHaveBeenCalled();
+      }
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(reconcileExternalChanges).toHaveBeenCalled();
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining("release unavailable during retry"),
+      );
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(reconcileArtifactRetention).toHaveBeenCalledTimes(3);
+      await service.stop?.(context);
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(reconcileArtifactRetention).toHaveBeenCalledTimes(3);
+      expect(unsubscribe).toHaveBeenCalledTimes(withGatewayEvents ? 1 : 0);
+      expect(vi.getTimerCount()).toBe(0);
+    },
+  );
 });

--- a/extensions/workboard/src/change-events.ts
+++ b/extensions/workboard/src/change-events.ts
@@ -3,41 +3,69 @@ import type { OpenClawPluginService } from "../api.js";
 import type { WorkboardStore } from "./store.js";
 
 const WORKBOARD_EXTERNAL_CHANGE_CHECK_MS = 1000;
+const WORKBOARD_RETENTION_RETRY_MS = 60_000;
 
 export function createWorkboardChangeEventService(
   store: WorkboardStore,
 ): OpenClawPluginService & { stop: () => void } {
   let unsubscribe: (() => void) | undefined;
   let timer: ReturnType<typeof setInterval> | undefined;
+  let starting: symbol | undefined;
+  let retentionRunning = false;
 
   return {
     id: "workboard-change-events",
     async start(ctx) {
-      if (unsubscribe) {
+      if (timer || starting) {
         return;
       }
-      await store.reconcileArtifactRetention();
+      const generation = Symbol("workboard-change-events-start");
+      starting = generation;
+      try {
+        await store.reconcileArtifactRetention();
+      } catch (error) {
+        if (starting === generation) {
+          starting = undefined;
+        }
+        throw error;
+      }
+      // stop() revokes pending startup before the owning SQLite store is closed.
+      if (starting !== generation) {
+        return;
+      }
+      starting = undefined;
       const gatewayEvents = ctx.gatewayEvents;
-      if (!gatewayEvents) {
-        return;
+      if (gatewayEvents) {
+        const emit = (change: WorkboardChange) => {
+          gatewayEvents.emit("changed", change, { scope: "operator.read" });
+        };
+        unsubscribe = store.subscribeChanges(emit);
+        store.announceChangeEpoch();
       }
-      const emit = (change: WorkboardChange) => {
-        gatewayEvents.emit("changed", change, {
-          scope: "operator.read",
-        });
-      };
-      unsubscribe = store.subscribeChanges(emit);
-      store.announceChangeEpoch();
+      let nextRetentionAt = Date.now() + WORKBOARD_RETENTION_RETRY_MS;
       timer = setInterval(() => {
         try {
           store.reconcileExternalChanges();
         } catch (error) {
           ctx.logger.warn(`workboard external change check failed: ${String(error)}`);
         }
+        if (!retentionRunning && Date.now() >= nextRetentionAt) {
+          nextRetentionAt = Date.now() + WORKBOARD_RETENTION_RETRY_MS;
+          retentionRunning = true;
+          void store
+            .reconcileArtifactRetention()
+            .catch((error: unknown) => {
+              ctx.logger.warn(`workboard artifact retention retry failed: ${String(error)}`);
+            })
+            .finally(() => {
+              retentionRunning = false;
+            });
+        }
       }, WORKBOARD_EXTERNAL_CHANGE_CHECK_MS);
       timer.unref?.();
     },
     stop() {
+      starting = undefined;
       unsubscribe?.();
       unsubscribe = undefined;
       if (timer) {

--- a/extensions/workboard/src/change-events.ts
+++ b/extensions/workboard/src/change-events.ts
@@ -12,9 +12,13 @@ export function createWorkboardChangeEventService(
 
   return {
     id: "workboard-change-events",
-    start(ctx) {
+    async start(ctx) {
+      if (unsubscribe) {
+        return;
+      }
+      await store.reconcileArtifactRetention();
       const gatewayEvents = ctx.gatewayEvents;
-      if (!gatewayEvents || unsubscribe) {
+      if (!gatewayEvents) {
         return;
       }
       const emit = (change: WorkboardChange) => {

--- a/extensions/workboard/src/change-events.ts
+++ b/extensions/workboard/src/change-events.ts
@@ -24,10 +24,13 @@ export function createWorkboardChangeEventService(
       try {
         await store.reconcileArtifactRetention();
       } catch (error) {
-        if (starting === generation) {
-          starting = undefined;
+        if (starting !== generation) {
+          return;
         }
-        throw error;
+        // Deferred cleanup must not disable change events or the retry that can recover it.
+        ctx.logger.warn(
+          `workboard artifact retention startup reconciliation failed; will retry: ${String(error)}`,
+        );
       }
       // stop() revokes pending startup before the owning SQLite store is closed.
       if (starting !== generation) {

--- a/extensions/workboard/src/dispatcher-workspace.test.ts
+++ b/extensions/workboard/src/dispatcher-workspace.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from "vitest";
+import { cleanupWorkboardCardWorktree } from "./dispatcher-workspace.js";
+import type { PersistedWorkboardCard, WorkboardKeyedStore } from "./persistence-types.js";
+import { WorkboardStore } from "./store.js";
+
+function createMemoryStore(): WorkboardKeyedStore {
+  const entries = new Map<string, PersistedWorkboardCard>();
+  return {
+    async register(key, value) {
+      entries.set(key, value);
+    },
+    async lookup(key) {
+      return entries.get(key);
+    },
+    async delete(key) {
+      return entries.delete(key);
+    },
+    async entries() {
+      return [...entries].map(([key, value]) => ({ key, value }));
+    },
+  };
+}
+
+describe("cleanupWorkboardCardWorktree", () => {
+  it("releases the run lock before requesting lossless cleanup", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const card = await store.create({
+      title: "Artifact-producing worker",
+      status: "done",
+      runId: "run-artifact",
+      workspace: {
+        kind: "worktree",
+        path: "/tmp/worktree",
+        branch: "openclaw/wb-card",
+        sourcePath: "/repo",
+        sourceBranch: "main",
+      },
+      workspaceAccess: { unrestricted: true },
+    });
+    const worktrees = {
+      release: vi.fn(),
+      removeIfLossless: vi.fn().mockResolvedValue(false),
+    };
+
+    await cleanupWorkboardCardWorktree({ store, worktrees, card });
+
+    expect(worktrees.release).toHaveBeenCalledWith({ path: "/tmp/worktree" });
+    expect(worktrees.removeIfLossless).toHaveBeenCalledWith({
+      path: "/tmp/worktree",
+      ownerKind: "workboard",
+      ownerId: card.id,
+    });
+    expect(worktrees.release.mock.invocationCallOrder[0]!).toBeLessThan(
+      worktrees.removeIfLossless.mock.invocationCallOrder[0]!,
+    );
+  });
+
+  it("ignores runs without a persisted managed-worktree workspace", async () => {
+    const store = new WorkboardStore(createMemoryStore());
+    const card = await store.create({ title: "No worktree", status: "done", runId: "run-local" });
+    const worktrees = {
+      release: vi.fn(),
+      removeIfLossless: vi.fn(),
+    };
+
+    await cleanupWorkboardCardWorktree({ store, worktrees, card });
+
+    expect(worktrees.release).not.toHaveBeenCalled();
+    expect(worktrees.removeIfLossless).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/workboard/src/dispatcher-workspace.ts
+++ b/extensions/workboard/src/dispatcher-workspace.ts
@@ -30,7 +30,10 @@ export function managedWorktreeName(cardId: string): string {
   return `wb-${suffix}`.slice(0, 64).replace(/-$/, "");
 }
 
-export type WorkboardWorktreeCleanupRuntime = Pick<PluginRuntime["worktrees"], "removeIfLossless">;
+export type WorkboardWorktreeCleanupRuntime = Pick<
+  PluginRuntime["worktrees"],
+  "release" | "removeIfLossless"
+>;
 
 type WorkboardWorkspaceMutation = {
   before: WorkboardCard;
@@ -58,6 +61,7 @@ export async function cleanupWorkboardCardWorktree(params: {
   card: WorkboardCard;
   workspaceMutation?: WorkboardWorkspaceMutation;
 }): Promise<void> {
+  await params.store.reconcileArtifactRetention();
   const current = await params.store.get(params.card.id);
   const workspace = (params.workspaceMutation?.after ?? current)?.metadata?.automation?.workspace;
   if (
@@ -69,6 +73,7 @@ export async function cleanupWorkboardCardWorktree(params: {
   ) {
     return;
   }
+  await params.worktrees.release({ path: workspace.path });
   const removed = await params.worktrees.removeIfLossless({
     path: workspace.path,
     ownerKind: "workboard",

--- a/extensions/workboard/src/dispatcher.ts
+++ b/extensions/workboard/src/dispatcher.ts
@@ -34,7 +34,14 @@ import {
 const DEFAULT_DISPATCH_MAX_STARTS = 3;
 
 export type WorkboardSubagentRuntime = Pick<PluginRuntime["subagent"], "run">;
-export type WorkboardWorktreeRuntime = PluginRuntime["worktrees"];
+export type WorkboardWorktreeRuntime = Pick<
+  PluginRuntime["worktrees"],
+  | "resolveCheckoutRoot"
+  | "hasSelfContainedCheckoutMetadata"
+  | "create"
+  | "release"
+  | "removeIfLossless"
+>;
 
 export type WorkboardDispatchStartOptions = {
   cardId?: string;

--- a/extensions/workboard/src/gateway.ts
+++ b/extensions/workboard/src/gateway.ts
@@ -41,7 +41,7 @@ export function registerWorkboardGatewayMethods(params: {
   store?: WorkboardStore;
 }) {
   const { api: hostApi } = params;
-  const store = params.store ?? WorkboardStore.openSqlite();
+  const store = params.store ?? WorkboardStore.openSqlite({ worktrees: hostApi.runtime.worktrees });
   if (!params.store) {
     registerWorkboardStoreLifecycle(hostApi, store);
   }

--- a/extensions/workboard/src/lifecycle-sync.cleanup-recovery.test.ts
+++ b/extensions/workboard/src/lifecycle-sync.cleanup-recovery.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import type { WorkboardExecution } from "@openclaw/workboard-contract";
 import { describe, expect, it, vi } from "vitest";
+import type { WorkboardWorktreeCleanupRuntime } from "./dispatcher-workspace.js";
 import { createWorkboardLifecycleService, syncWorkboardSubagentEnded } from "./lifecycle-sync.js";
 import { createWorkboardSqliteStores } from "./sqlite-store.js";
 import { WorkboardStore } from "./store.js";
@@ -80,6 +81,15 @@ function doneSessionSnapshot(updatedAt: number) {
 
 const context = { logger: { warn: vi.fn() } } as never;
 
+function cleanupWorktrees(
+  removeIfLossless: WorkboardWorktreeCleanupRuntime["removeIfLossless"],
+): WorkboardWorktreeCleanupRuntime {
+  return {
+    release: vi.fn().mockResolvedValue(undefined),
+    removeIfLossless,
+  };
+}
+
 describe("Workboard managed-worktree cleanup recovery", () => {
   it("retries cleanup after a hook failure and process restart", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-workboard-cleanup-recovery-"));
@@ -90,7 +100,7 @@ describe("Workboard managed-worktree cleanup recovery", () => {
       .fn()
       .mockRejectedValueOnce(new Error("worktree registry unavailable"))
       .mockResolvedValueOnce(true);
-    const worktrees = { removeIfLossless };
+    const worktrees = cleanupWorktrees(removeIfLossless);
 
     await expect(
       syncWorkboardSubagentEnded({
@@ -150,7 +160,7 @@ describe("Workboard managed-worktree cleanup recovery", () => {
     const service = createWorkboardLifecycleService({
       store: restarted.store,
       readSessions: doneSessionSnapshot(card.updatedAt + 1),
-      worktrees: { removeIfLossless },
+      worktrees: cleanupWorktrees(removeIfLossless),
     });
 
     try {
@@ -191,7 +201,7 @@ describe("Workboard managed-worktree cleanup recovery", () => {
     const firstService = createWorkboardLifecycleService({
       store: retained.store,
       readSessions: doneSessionSnapshot(card.updatedAt),
-      worktrees: { removeIfLossless },
+      worktrees: cleanupWorktrees(removeIfLossless),
     });
     await firstService.start(context);
     firstService.onGatewayStart();
@@ -208,7 +218,7 @@ describe("Workboard managed-worktree cleanup recovery", () => {
     const secondService = createWorkboardLifecycleService({
       store: restarted.store,
       readSessions: doneSessionSnapshot(card.updatedAt),
-      worktrees: { removeIfLossless },
+      worktrees: cleanupWorktrees(removeIfLossless),
     });
     try {
       await secondService.start(context);
@@ -243,7 +253,7 @@ describe("Workboard managed-worktree cleanup recovery", () => {
     const service = createWorkboardLifecycleService({
       store: restarted.store,
       readSessions,
-      worktrees: { removeIfLossless },
+      worktrees: cleanupWorktrees(removeIfLossless),
     });
     try {
       await service.start(context);
@@ -285,7 +295,7 @@ describe("Workboard managed-worktree cleanup recovery", () => {
       await expect(
         syncWorkboardSubagentEnded({
           store: initial.store,
-          worktrees: { removeIfLossless },
+          worktrees: cleanupWorktrees(removeIfLossless),
           event: {
             targetSessionKey: SESSION_KEY,
             runId: RUN_ID,

--- a/extensions/workboard/src/sqlite-store.ts
+++ b/extensions/workboard/src/sqlite-store.ts
@@ -30,6 +30,12 @@ import {
 } from "openclaw/plugin-sdk/sqlite-runtime";
 import { resolveStateDir } from "openclaw/plugin-sdk/state-paths";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import {
+  WORKBOARD_ARTIFACT_RETENTION_SCHEMA,
+  WorkboardArtifactRetention,
+  type WorkboardArtifactRetentionStore,
+  type WorktreeRetentionRuntime,
+} from "./artifact-retention.js";
 import type {
   PersistedWorkboardAttachment,
   PersistedWorkboardBoard,
@@ -47,7 +53,7 @@ const WORKBOARD_SQLITE_DIR_MODE = 0o700;
 const WORKBOARD_SQLITE_FILE_MODE = 0o600;
 type Row = Record<string, unknown>;
 type WorkboardSqliteStores = {
-  cards: WorkboardCardStore;
+  cards: WorkboardCardStore & WorkboardArtifactRetentionStore;
   boards: WorkboardKeyedStore<PersistedWorkboardBoard>;
   subscriptions: WorkboardKeyedStore<PersistedWorkboardNotificationSubscription>;
   attachments: WorkboardKeyedStore<PersistedWorkboardAttachment>;
@@ -365,6 +371,7 @@ const WORKBOARD_SCHEMA_SQL = `
       created_at INTEGER NOT NULL,
       updated_at INTEGER NOT NULL
     ) STRICT;
+    ${WORKBOARD_ARTIFACT_RETENTION_SCHEMA}
   `;
 
 function ensureWorkboardSchema(db: DatabaseSync): void {
@@ -1208,7 +1215,62 @@ function insertCard(db: DatabaseSync, card: WorkboardCard): void {
 }
 
 class WorkboardSqliteCardStore implements WorkboardCardStore {
-  constructor(private readonly db: DatabaseSync) {}
+  private readonly retention?: WorkboardArtifactRetention;
+  private retentionReady?: Promise<void>;
+
+  constructor(
+    private readonly db: DatabaseSync,
+    worktrees?: WorktreeRetentionRuntime,
+  ) {
+    if (worktrees) {
+      this.retention = new WorkboardArtifactRetention(db, worktrees);
+    }
+  }
+
+  private initializeRetention(): Promise<void> {
+    const retention = this.retention;
+    if (!retention) {
+      return Promise.resolve();
+    }
+    this.retentionReady ??= (async () => {
+      retention.cancelPrepared();
+      // Doctor imports and pre-retention cards are enrolled once per owner startup.
+      // Revalidate the row after async path/claim work; never publish a stale snapshot.
+      for (const { key, value } of this.readEntries()) {
+        await retention.mutate(
+          key,
+          value.card,
+          () => {
+            return this.matchesUpdatedAt(key, value.card.updatedAt);
+          },
+          (unchanged) => unchanged,
+          true,
+        );
+      }
+    })().catch((error: unknown) => {
+      this.retentionReady = undefined;
+      throw error;
+    });
+    return this.retentionReady;
+  }
+
+  async reconcileArtifactRetention(): Promise<void> {
+    await this.initializeRetention();
+    this.retention?.cancelPrepared();
+    await this.retention?.drainReleases();
+  }
+
+  private async mutate<T>(
+    key: string,
+    next: WorkboardCard | undefined,
+    commit: () => T,
+    applied: (result: T) => boolean,
+  ): Promise<T> {
+    await this.initializeRetention();
+    return this.retention
+      ? await this.retention.mutate(key, next, commit, applied)
+      : runSqliteImmediateTransactionSync(this.db, commit);
+  }
 
   private matchesUpdatedAt(key: string, expectedUpdatedAt: number): boolean {
     const { compiled, bind } = compileSqliteQueryBindings<string>((parameter) =>
@@ -1233,18 +1295,28 @@ class WorkboardSqliteCardStore implements WorkboardCardStore {
 
   async register(key: string, value: PersistedWorkboardCard): Promise<void> {
     this.validatePayload(key, value);
-    runSqliteImmediateTransactionSync(this.db, () => insertCard(this.db, value.card));
+    await this.mutate(
+      key,
+      value.card,
+      () => insertCard(this.db, value.card),
+      () => true,
+    );
   }
 
   async registerIfAbsent(key: string, value: PersistedWorkboardCard): Promise<boolean> {
     this.validatePayload(key, value);
-    return runSqliteImmediateTransactionSync(this.db, () => {
-      if (this.db.prepare("SELECT 1 FROM workboard_cards WHERE id = ?").get(key)) {
-        return false;
-      }
-      insertCard(this.db, value.card);
-      return true;
-    });
+    return await this.mutate(
+      key,
+      value.card,
+      () => {
+        if (this.db.prepare("SELECT 1 FROM workboard_cards WHERE id = ?").get(key)) {
+          return false;
+        }
+        insertCard(this.db, value.card);
+        return true;
+      },
+      (applied) => applied,
+    );
   }
 
   async registerIfUpdatedAt(
@@ -1253,13 +1325,18 @@ class WorkboardSqliteCardStore implements WorkboardCardStore {
     expectedUpdatedAt: number,
   ): Promise<boolean> {
     this.validatePayload(key, value);
-    return runSqliteImmediateTransactionSync(this.db, () => {
-      if (!this.matchesUpdatedAt(key, expectedUpdatedAt)) {
-        return false;
-      }
-      insertCard(this.db, value.card);
-      return true;
-    });
+    return await this.mutate(
+      key,
+      value.card,
+      () => {
+        if (!this.matchesUpdatedAt(key, expectedUpdatedAt)) {
+          return false;
+        }
+        insertCard(this.db, value.card);
+        return true;
+      },
+      (applied) => applied,
+    );
   }
 
   async claimIfOwnerAvailable(
@@ -1270,34 +1347,48 @@ class WorkboardSqliteCardStore implements WorkboardCardStore {
     now: number,
   ): Promise<WorkboardOwnerClaimResult> {
     this.validatePayload(key, value);
-    return runSqliteImmediateTransactionSync(this.db, () => {
-      if (!this.matchesUpdatedAt(key, expectedUpdatedAt)) {
-        return "conflict";
-      }
-      const rows: Row[] = this.db.prepare("SELECT * FROM workboard_cards WHERE id <> ?").all(key);
-      const preloaded = loadCardChildRows(this.db);
-      for (const row of rows) {
-        const card = readCard(this.db, row, preloaded);
-        if (workboardCardConsumesOwnerSlot(card, now) && workboardCardSlotOwner(card) === ownerId) {
-          return "owner_busy";
+    return await this.mutate(
+      key,
+      value.card,
+      () => {
+        if (!this.matchesUpdatedAt(key, expectedUpdatedAt)) {
+          return "conflict";
         }
-      }
-      insertCard(this.db, value.card);
-      return "updated";
-    });
+        const rows: Row[] = this.db.prepare("SELECT * FROM workboard_cards WHERE id <> ?").all(key);
+        const preloaded = loadCardChildRows(this.db);
+        for (const row of rows) {
+          const card = readCard(this.db, row, preloaded);
+          if (
+            workboardCardConsumesOwnerSlot(card, now) &&
+            workboardCardSlotOwner(card) === ownerId
+          ) {
+            return "owner_busy";
+          }
+        }
+        insertCard(this.db, value.card);
+        return "updated";
+      },
+      (result) => result === "updated",
+    );
   }
 
   async deleteIfUpdatedAt(key: string, expectedUpdatedAt: number): Promise<boolean> {
-    return runSqliteImmediateTransactionSync(this.db, () => {
-      if (!this.matchesUpdatedAt(key, expectedUpdatedAt)) {
-        return false;
-      }
-      this.deleteCard(key);
-      return true;
-    });
+    return await this.mutate(
+      key,
+      undefined,
+      () => {
+        if (!this.matchesUpdatedAt(key, expectedUpdatedAt)) {
+          return false;
+        }
+        this.deleteCard(key);
+        return true;
+      },
+      (deleted) => deleted,
+    );
   }
 
   async lookup(key: string): Promise<PersistedWorkboardCard | undefined> {
+    await this.initializeRetention();
     const row = this.db.prepare("SELECT * FROM workboard_cards WHERE id = ?").get(key) as
       | Row
       | undefined;
@@ -1305,7 +1396,12 @@ class WorkboardSqliteCardStore implements WorkboardCardStore {
   }
 
   async delete(key: string): Promise<boolean> {
-    const result = runSqliteImmediateTransactionSync(this.db, () => this.deleteCard(key));
+    const result = await this.mutate(
+      key,
+      undefined,
+      () => this.deleteCard(key),
+      (deleted) => deleted.changes > 0,
+    );
     return result.changes > 0;
   }
 
@@ -1324,6 +1420,11 @@ class WorkboardSqliteCardStore implements WorkboardCardStore {
   }
 
   async entries(): Promise<Array<{ key: string; value: PersistedWorkboardCard }>> {
+    await this.initializeRetention();
+    return this.readEntries();
+  }
+
+  private readEntries(): Array<{ key: string; value: PersistedWorkboardCard }> {
     const rows = this.db
       .prepare("SELECT * FROM workboard_cards ORDER BY created_at ASC, id ASC")
       .all() as Row[];
@@ -1645,13 +1746,14 @@ export function createWorkboardSqliteStores(
   options: {
     dbPath?: string;
     env?: NodeJS.ProcessEnv;
+    worktrees?: WorktreeRetentionRuntime;
   } = {},
 ): WorkboardSqliteStores {
   const { db, maintenance } = createDatabase(
     options.dbPath ?? resolveWorkboardSqlitePath(options.env),
   );
   return {
-    cards: new WorkboardSqliteCardStore(db),
+    cards: new WorkboardSqliteCardStore(db, options.worktrees),
     boards: new WorkboardSqliteBoardStore(db),
     subscriptions: new WorkboardSqliteSubscriptionStore(db),
     attachments: new WorkboardSqliteAttachmentStore(db),

--- a/extensions/workboard/src/store.ts
+++ b/extensions/workboard/src/store.ts
@@ -212,6 +212,7 @@ export class WorkboardStore extends WorkboardNotificationStore {
     } = {},
   ) {
     super(store, stores);
+    // SAFETY: retention decoration is optional and identified by its unique reconciliation method.
     const retentionStore = store as Partial<WorkboardArtifactRetentionStore>;
     if (typeof retentionStore.reconcileArtifactRetention === "function") {
       this.reconcileArtifactRetentionStore =

--- a/extensions/workboard/src/store.ts
+++ b/extensions/workboard/src/store.ts
@@ -11,10 +11,9 @@ import type {
   WorkboardStaleState,
   WorkboardStatus,
 } from "@openclaw/workboard-contract";
-import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
-import {
-  type WorkboardArtifactRetentionStore,
-  withWorkboardArtifactRetention,
+import type {
+  WorkboardArtifactRetentionStore,
+  WorktreeRetentionRuntime,
 } from "./artifact-retention.js";
 import type {
   PersistedWorkboardAttachment,
@@ -209,10 +208,11 @@ export class WorkboardStore extends WorkboardNotificationStore {
       subscriptions?: WorkboardKeyedStore<PersistedWorkboardNotificationSubscription>;
       attachments?: WorkboardKeyedStore<PersistedWorkboardAttachment>;
       dataVersion?: () => number;
+      close?: () => void;
     } = {},
   ) {
     super(store, stores);
-    // SAFETY: retention decoration is optional and identified by its unique reconciliation method.
+    // SAFETY: internal injected stores may omit managed-worktree retention.
     const retentionStore = store as Partial<WorkboardArtifactRetentionStore>;
     if (typeof retentionStore.reconcileArtifactRetention === "function") {
       this.reconcileArtifactRetentionStore =
@@ -676,13 +676,8 @@ export class WorkboardStore extends WorkboardNotificationStore {
     return buildWorkerContext(card, await this.list());
   }
 
-  static openSqlite(
-    options: { worktrees?: Pick<PluginRuntime["worktrees"], "setRetentionClaim"> } = {},
-  ) {
-    const stores = createWorkboardSqliteStores();
-    const cards = options.worktrees
-      ? withWorkboardArtifactRetention(stores.cards, options.worktrees)
-      : stores.cards;
-    return new WorkboardStore(cards, stores);
+  static openSqlite(options: { worktrees?: WorktreeRetentionRuntime } = {}) {
+    const stores = createWorkboardSqliteStores(options);
+    return new WorkboardStore(stores.cards, stores);
   }
 }

--- a/extensions/workboard/src/store.ts
+++ b/extensions/workboard/src/store.ts
@@ -11,6 +11,17 @@ import type {
   WorkboardStaleState,
   WorkboardStatus,
 } from "@openclaw/workboard-contract";
+import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
+import {
+  type WorkboardArtifactRetentionStore,
+  withWorkboardArtifactRetention,
+} from "./artifact-retention.js";
+import type {
+  PersistedWorkboardAttachment,
+  PersistedWorkboardBoard,
+  PersistedWorkboardNotificationSubscription,
+  WorkboardKeyedStore,
+} from "./persistence-types.js";
 import { createWorkboardSqliteStores } from "./sqlite-store.js";
 import {
   buildWorkerContext,
@@ -189,6 +200,33 @@ function lifecycleExecution(params: {
 
 // Capability layers split review boundaries only; the core still owns persistence and mutation order.
 export class WorkboardStore extends WorkboardNotificationStore {
+  private readonly reconcileArtifactRetentionStore?: () => Promise<void>;
+
+  constructor(
+    store: WorkboardKeyedStore,
+    stores: {
+      boards?: WorkboardKeyedStore<PersistedWorkboardBoard>;
+      subscriptions?: WorkboardKeyedStore<PersistedWorkboardNotificationSubscription>;
+      attachments?: WorkboardKeyedStore<PersistedWorkboardAttachment>;
+      dataVersion?: () => number;
+    } = {},
+  ) {
+    super(store, stores);
+    const retentionStore = store as Partial<WorkboardArtifactRetentionStore>;
+    if (typeof retentionStore.reconcileArtifactRetention === "function") {
+      this.reconcileArtifactRetentionStore =
+        retentionStore.reconcileArtifactRetention.bind(retentionStore);
+    }
+  }
+
+  async reconcileArtifactRetention(): Promise<void> {
+    if (!this.reconcileArtifactRetentionStore) {
+      return;
+    }
+    // Keep upgrade reconciliation ordered with card mutations before GC can observe claims.
+    await this.enqueueMutation(this.reconcileArtifactRetentionStore);
+  }
+
   async prepareExecutionLaunch(
     id: string,
     input: {
@@ -637,8 +675,13 @@ export class WorkboardStore extends WorkboardNotificationStore {
     return buildWorkerContext(card, await this.list());
   }
 
-  static openSqlite() {
+  static openSqlite(
+    options: { worktrees?: Pick<PluginRuntime["worktrees"], "setRetentionClaim"> } = {},
+  ) {
     const stores = createWorkboardSqliteStores();
-    return new WorkboardStore(stores.cards, stores);
+    const cards = options.worktrees
+      ? withWorkboardArtifactRetention(stores.cards, options.worktrees)
+      : stores.cards;
+    return new WorkboardStore(cards, stores);
   }
 }

--- a/src/agents/worktrees/registry-retention.ts
+++ b/src/agents/worktrees/registry-retention.ts
@@ -1,0 +1,135 @@
+import type { DatabaseSync } from "node:sqlite";
+import { executeSqliteQuerySync, getNodeSqliteKysely } from "../../infra/kysely-sync.js";
+import type { DB as OpenClawStateKyselyDatabase } from "../../state/openclaw-state-db.generated.js";
+import {
+  openOpenClawStateDatabase,
+  runOpenClawStateWriteTransaction,
+} from "../../state/openclaw-state-db.js";
+import { ensureWorktreeRetentionClaimsSchema } from "./retention-schema.js";
+import { WORKTREE_REMOVING_LEASE_KEY, worktreeRunLeaseScope } from "./run-lease-owner.js";
+
+type WorktreeRetentionDatabase = Pick<
+  OpenClawStateKyselyDatabase,
+  "worktrees" | "state_leases" | "worktree_retention_claims" | "worktree_provisioned_file_chunks"
+>;
+
+function dbFor(env: NodeJS.ProcessEnv): DatabaseSync {
+  return openOpenClawStateDatabase({ env }).db;
+}
+
+function kyselyFor(db: DatabaseSync) {
+  return getNodeSqliteKysely<WorktreeRetentionDatabase>(db);
+}
+
+function deleteWorktreeLeaseAndRetentionRows(db: DatabaseSync, worktreeId: string): void {
+  const k = kyselyFor(db);
+  executeSqliteQuerySync(
+    db,
+    k.deleteFrom("state_leases").where("scope", "=", worktreeRunLeaseScope(worktreeId)),
+  );
+  executeSqliteQuerySync(
+    db,
+    k.deleteFrom("worktree_retention_claims").where("worktree_id", "=", worktreeId),
+  );
+}
+
+export function deleteRegistryWorktree(env: NodeJS.ProcessEnv, id: string): void {
+  ensureWorktreeRetentionClaimsSchema(env);
+  const db = dbFor(env);
+  const k = kyselyFor(db);
+  runOpenClawStateWriteTransaction(() => {
+    executeSqliteQuerySync(
+      db,
+      k.deleteFrom("worktree_provisioned_file_chunks").where("worktree_id", "=", id),
+    );
+    deleteWorktreeLeaseAndRetentionRows(db, id);
+    executeSqliteQuerySync(db, k.deleteFrom("worktrees").where("id", "=", id));
+  });
+}
+
+export function findWorktreeRetentionClaimId(
+  db: DatabaseSync,
+  worktreeId: string,
+): string | undefined {
+  return executeSqliteQuerySync(
+    db,
+    kyselyFor(db)
+      .selectFrom("worktree_retention_claims")
+      .select("claim_id")
+      .where("worktree_id", "=", worktreeId)
+      .limit(1),
+  ).rows[0]?.claim_id;
+}
+
+export function setWorktreeRetentionClaimRow(
+  env: NodeJS.ProcessEnv,
+  params: {
+    worktreeId: string;
+    claimId: string;
+    claimOwner: string;
+    active: boolean;
+    now: number;
+  },
+): boolean {
+  ensureWorktreeRetentionClaimsSchema(env);
+  return runOpenClawStateWriteTransaction(
+    (database) => {
+      const db = database.db;
+      const k = kyselyFor(db);
+      if (!params.active) {
+        executeSqliteQuerySync(
+          db,
+          k
+            .deleteFrom("worktree_retention_claims")
+            .where("worktree_id", "=", params.worktreeId)
+            .where("claim_id", "=", params.claimId),
+        );
+        return true;
+      }
+      const record = executeSqliteQuerySync(
+        db,
+        k.selectFrom("worktrees").select(["removed_at"]).where("id", "=", params.worktreeId),
+      ).rows[0];
+      if (!record || record.removed_at !== null) {
+        return false;
+      }
+      const removing = executeSqliteQuerySync(
+        db,
+        k
+          .selectFrom("state_leases")
+          .select("owner")
+          .where("scope", "=", worktreeRunLeaseScope(params.worktreeId))
+          .where("lease_key", "=", WORKTREE_REMOVING_LEASE_KEY)
+          .limit(1),
+      ).rows[0];
+      if (removing) {
+        throw new Error("worktree removal is already in progress");
+      }
+      executeSqliteQuerySync(
+        db,
+        k
+          .insertInto("worktree_retention_claims")
+          .values({
+            worktree_id: params.worktreeId,
+            claim_id: params.claimId,
+            claim_owner: params.claimOwner,
+            created_at: params.now,
+            updated_at: params.now,
+          })
+          .onConflict((conflict) =>
+            conflict.columns(["worktree_id", "claim_id"]).doUpdateSet({
+              claim_owner: params.claimOwner,
+              updated_at: params.now,
+            }),
+          ),
+      );
+      return true;
+    },
+    { env },
+  );
+}
+
+export function hasWorktreeRetentionClaimRow(env: NodeJS.ProcessEnv, worktreeId: string): boolean {
+  ensureWorktreeRetentionClaimsSchema(env);
+  return findWorktreeRetentionClaimId(dbFor(env), worktreeId) !== undefined;
+}

--- a/src/agents/worktrees/registry-retention.ts
+++ b/src/agents/worktrees/registry-retention.ts
@@ -7,6 +7,7 @@ import {
 } from "../../state/openclaw-state-db.js";
 import { ensureWorktreeRetentionClaimsSchema } from "./retention-schema.js";
 import { WORKTREE_REMOVING_LEASE_KEY, worktreeRunLeaseScope } from "./run-lease-owner.js";
+import type { ManagedWorktreeOwnerKind } from "./types.js";
 
 type WorktreeRetentionDatabase = Pick<
   OpenClawStateKyselyDatabase,
@@ -27,6 +28,8 @@ function deleteWorktreeLeaseAndRetentionRows(db: DatabaseSync, worktreeId: strin
     db,
     k.deleteFrom("state_leases").where("scope", "=", worktreeRunLeaseScope(worktreeId)),
   );
+  // Terminal claims can disappear only with their immutable registry identity.
+  // Removing or restoring a checkout alone must not revive an old generation.
   executeSqliteQuerySync(
     db,
     k.deleteFrom("worktree_retention_claims").where("worktree_id", "=", worktreeId),
@@ -37,14 +40,17 @@ export function deleteRegistryWorktree(env: NodeJS.ProcessEnv, id: string): void
   ensureWorktreeRetentionClaimsSchema(env);
   const db = dbFor(env);
   const k = kyselyFor(db);
-  runOpenClawStateWriteTransaction(() => {
-    executeSqliteQuerySync(
-      db,
-      k.deleteFrom("worktree_provisioned_file_chunks").where("worktree_id", "=", id),
-    );
-    deleteWorktreeLeaseAndRetentionRows(db, id);
-    executeSqliteQuerySync(db, k.deleteFrom("worktrees").where("id", "=", id));
-  });
+  runOpenClawStateWriteTransaction(
+    () => {
+      executeSqliteQuerySync(
+        db,
+        k.deleteFrom("worktree_provisioned_file_chunks").where("worktree_id", "=", id),
+      );
+      deleteWorktreeLeaseAndRetentionRows(db, id);
+      executeSqliteQuerySync(db, k.deleteFrom("worktrees").where("id", "=", id));
+    },
+    { env },
+  );
 }
 
 export function findWorktreeRetentionClaimId(
@@ -57,6 +63,7 @@ export function findWorktreeRetentionClaimId(
       .selectFrom("worktree_retention_claims")
       .select("claim_id")
       .where("worktree_id", "=", worktreeId)
+      .where("released_at", "is", null)
       .limit(1),
   ).rows[0]?.claim_id;
 }
@@ -66,7 +73,8 @@ export function setWorktreeRetentionClaimRow(
   params: {
     worktreeId: string;
     claimId: string;
-    claimOwner: string;
+    ownerKind: ManagedWorktreeOwnerKind;
+    ownerId: string;
     active: boolean;
     now: number;
   },
@@ -76,35 +84,50 @@ export function setWorktreeRetentionClaimRow(
     (database) => {
       const db = database.db;
       const k = kyselyFor(db);
-      if (!params.active) {
-        executeSqliteQuerySync(
-          db,
-          k
-            .deleteFrom("worktree_retention_claims")
-            .where("worktree_id", "=", params.worktreeId)
-            .where("claim_id", "=", params.claimId),
-        );
-        return true;
-      }
       const record = executeSqliteQuerySync(
         db,
-        k.selectFrom("worktrees").select(["removed_at"]).where("id", "=", params.worktreeId),
+        k
+          .selectFrom("worktrees")
+          .select(["removed_at", "owner_kind", "owner_id"])
+          .where("id", "=", params.worktreeId),
       ).rows[0];
-      if (!record || record.removed_at !== null) {
+      if (!record) {
+        return !params.active;
+      }
+      if (record.owner_kind !== params.ownerKind || record.owner_id !== params.ownerId) {
         return false;
       }
-      const removing = executeSqliteQuerySync(
+      const claim = executeSqliteQuerySync(
         db,
         k
-          .selectFrom("state_leases")
-          .select("owner")
-          .where("scope", "=", worktreeRunLeaseScope(params.worktreeId))
-          .where("lease_key", "=", WORKTREE_REMOVING_LEASE_KEY)
-          .limit(1),
+          .selectFrom("worktree_retention_claims")
+          .select("released_at")
+          .where("worktree_id", "=", params.worktreeId)
+          .where("claim_id", "=", params.claimId),
       ).rows[0];
-      if (removing) {
-        throw new Error("worktree removal is already in progress");
+      if (claim?.released_at != null) {
+        return !params.active;
       }
+      if (params.active) {
+        if (record.removed_at !== null) {
+          return false;
+        }
+        const removing = executeSqliteQuerySync(
+          db,
+          k
+            .selectFrom("state_leases")
+            .select("owner")
+            .where("scope", "=", worktreeRunLeaseScope(params.worktreeId))
+            .where("lease_key", "=", WORKTREE_REMOVING_LEASE_KEY)
+            .limit(1),
+        ).rows[0];
+        if (removing) {
+          throw new Error("worktree removal is already in progress");
+        }
+      }
+      // Release is terminal even when it arrives before acquisition. The caller's
+      // durable cancellation must fence an already-dispatched, delayed acquire.
+      const releasedAt = params.active ? null : params.now;
       executeSqliteQuerySync(
         db,
         k
@@ -112,14 +135,15 @@ export function setWorktreeRetentionClaimRow(
           .values({
             worktree_id: params.worktreeId,
             claim_id: params.claimId,
-            claim_owner: params.claimOwner,
+            claim_owner: `${params.ownerKind}:${params.ownerId}`,
             created_at: params.now,
             updated_at: params.now,
+            released_at: releasedAt,
           })
           .onConflict((conflict) =>
             conflict.columns(["worktree_id", "claim_id"]).doUpdateSet({
-              claim_owner: params.claimOwner,
               updated_at: params.now,
+              released_at: releasedAt,
             }),
           ),
       );

--- a/src/agents/worktrees/registry-retention.ts
+++ b/src/agents/worktrees/registry-retention.ts
@@ -88,7 +88,7 @@ export function setWorktreeRetentionClaimRow(
         db,
         k
           .selectFrom("worktrees")
-          .select(["removed_at", "owner_kind", "owner_id"])
+          .select(["removed_at", "snapshot_ref", "owner_kind", "owner_id"])
           .where("id", "=", params.worktreeId),
       ).rows[0];
       if (!record) {
@@ -109,7 +109,9 @@ export function setWorktreeRetentionClaimRow(
         return !params.active;
       }
       if (params.active) {
-        if (record.removed_at !== null) {
+        // Enrollment may precede restoration, but cannot manufacture a recoverable
+        // identity for a checkout that disappeared without a recorded snapshot.
+        if (record.removed_at !== null && !record.snapshot_ref) {
           return false;
         }
         const removing = executeSqliteQuerySync(

--- a/src/agents/worktrees/registry.ts
+++ b/src/agents/worktrees/registry.ts
@@ -12,9 +12,12 @@ import {
   openOpenClawStateDatabase,
   runOpenClawStateWriteTransaction,
 } from "../../state/openclaw-state-db.js";
+import { findWorktreeRetentionClaimId } from "./registry-retention.js";
+import { ensureWorktreeRetentionClaimsSchema } from "./retention-schema.js";
 import {
   collectLiveRunLeases,
   WORKTREE_REMOVING_LEASE_KEY,
+  worktreeRunLeaseScope,
   type RunLeaseOwnerChecks,
 } from "./run-lease-owner.js";
 import type {
@@ -23,6 +26,12 @@ import type {
   ManagedWorktreeRunEndCleanup,
   ProvisionedFileState,
 } from "./types.js";
+
+export {
+  deleteRegistryWorktree,
+  hasWorktreeRetentionClaimRow,
+  setWorktreeRetentionClaimRow,
+} from "./registry-retention.js";
 
 type WorktreesTable = OpenClawStateKyselyDatabase["worktrees"];
 type WorktreeRow = Selectable<WorktreesTable>;
@@ -375,6 +384,21 @@ export function findLiveRegistryWorktreeByPath(
   return row ? rowToRecord(row) : undefined;
 }
 
+export function findRegistryWorktreeByPath(
+  env: NodeJS.ProcessEnv,
+  worktreePath: string,
+): ManagedWorktreeRecord | undefined {
+  const db = dbFor(env);
+  const query = kyselyFor(db)
+    .selectFrom("worktrees")
+    .selectAll()
+    .where("path", "=", worktreePath)
+    .orderBy("created_at", "desc")
+    .limit(1);
+  const row = executeSqliteQuerySync(db, query).rows[0];
+  return row ? rowToRecord(row) : undefined;
+}
+
 export function findLiveRegistryWorktreeByOwner(
   env: NodeJS.ProcessEnv,
   ownerKind: ManagedWorktreeOwnerKind,
@@ -459,21 +483,6 @@ export function updateRegistryWorktree(
   });
 }
 
-export function deleteRegistryWorktree(env: NodeJS.ProcessEnv, id: string): void {
-  const db = dbFor(env);
-  runOpenClawStateWriteTransaction(() => {
-    executeSqliteQuerySync(
-      db,
-      kyselyProvisionedFor(db)
-        .deleteFrom("worktree_provisioned_file_chunks")
-        .where("worktree_id", "=", id),
-    );
-    executeSqliteQuerySync(db, kyselyFor(db).deleteFrom("worktrees").where("id", "=", id));
-  });
-}
-
-const WORKTREE_RUN_LEASE_SCOPE_PREFIX = "worktree-run:";
-
 export class WorktreeRemovalContentionError extends Error {
   constructor(
     readonly kind: "busy" | "finalized",
@@ -482,10 +491,6 @@ export class WorktreeRemovalContentionError extends Error {
     super(message);
     this.name = "WorktreeRemovalContentionError";
   }
-}
-
-function worktreeRunLeaseScope(worktreeId: string): string {
-  return `${WORKTREE_RUN_LEASE_SCOPE_PREFIX}${worktreeId}`;
 }
 
 export function admitWorktreeRunLeaseRow(
@@ -561,8 +566,12 @@ export function claimWorktreeRemovalRow(
     startTime: number | null;
     now: number;
     checks?: RunLeaseOwnerChecks;
+    respectRetentionClaims?: boolean;
   },
 ): void {
+  if (params.respectRetentionClaims) {
+    ensureWorktreeRetentionClaimsSchema(env);
+  }
   runOpenClawStateWriteTransaction(
     (database) => {
       const db = database.db;
@@ -580,6 +589,15 @@ export function claimWorktreeRemovalRow(
           "finalized",
           `managed worktree was removed: ${record?.path ?? params.worktreeId}`,
         );
+      }
+      if (params.respectRetentionClaims) {
+        const retentionClaimId = findWorktreeRetentionClaimId(db, params.worktreeId);
+        if (retentionClaimId !== undefined) {
+          throw new WorktreeRemovalContentionError(
+            "busy",
+            `worktree is retained by durable claim ${retentionClaimId}`,
+          );
+        }
       }
       const { livePids, removingToken } = collectLiveRunLeases(db, k, scope, params.checks ?? {});
       if (livePids.length > 0) {

--- a/src/agents/worktrees/retention-schema.ts
+++ b/src/agents/worktrees/retention-schema.ts
@@ -12,6 +12,7 @@ CREATE TABLE IF NOT EXISTS worktree_retention_claims (
   claim_owner TEXT NOT NULL,
   created_at INTEGER NOT NULL,
   updated_at INTEGER NOT NULL,
+  released_at INTEGER,
   PRIMARY KEY (worktree_id, claim_id)
 ) STRICT;
 `;

--- a/src/agents/worktrees/retention-schema.ts
+++ b/src/agents/worktrees/retention-schema.ts
@@ -1,0 +1,33 @@
+import type { DatabaseSync } from "node:sqlite";
+import {
+  openOpenClawStateDatabase,
+  runOpenClawStateWriteTransaction,
+} from "../../state/openclaw-state-db.js";
+
+const ensuredDatabases = new WeakSet<DatabaseSync>();
+const WORKTREE_RETENTION_CLAIMS_SCHEMA_SQL = `
+CREATE TABLE IF NOT EXISTS worktree_retention_claims (
+  worktree_id TEXT NOT NULL,
+  claim_id TEXT NOT NULL,
+  claim_owner TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  PRIMARY KEY (worktree_id, claim_id)
+) STRICT;
+`;
+
+export function ensureWorktreeRetentionClaimsSchema(env: NodeJS.ProcessEnv): void {
+  const database = openOpenClawStateDatabase({ env });
+  if (ensuredDatabases.has(database.db)) {
+    return;
+  }
+  runOpenClawStateWriteTransaction(
+    ({ db }) => {
+      // sqlite-allow-raw -- feature-local additive schema DDL; claim rows use Kysely below.
+      db.exec(WORKTREE_RETENTION_CLAIMS_SCHEMA_SQL);
+    },
+    { env },
+    { operationLabel: "worktrees.retention-claims.schema.ensure" },
+  );
+  ensuredDatabases.add(database.db);
+}

--- a/src/agents/worktrees/run-lease-owner.ts
+++ b/src/agents/worktrees/run-lease-owner.ts
@@ -5,7 +5,12 @@ import { isLockOwnerDefinitelyStale } from "../../infra/stale-lock-file.js";
 import type { DB } from "../../state/openclaw-state-db.generated.js";
 
 type WorktreeLeaseDatabase = Pick<DB, "worktrees" | "state_leases">;
+const WORKTREE_RUN_LEASE_SCOPE_PREFIX = "worktree-run:";
 export const WORKTREE_REMOVING_LEASE_KEY = "__removing__";
+
+export function worktreeRunLeaseScope(worktreeId: string): string {
+  return `${WORKTREE_RUN_LEASE_SCOPE_PREFIX}${worktreeId}`;
+}
 
 export type RunLeaseOwnerChecks = {
   isPidDefinitelyDead?: (pid: number) => boolean;

--- a/src/agents/worktrees/run-lease.ts
+++ b/src/agents/worktrees/run-lease.ts
@@ -305,7 +305,7 @@ export async function acquireWorktreeRunLease(
 
 export function claimWorktreeRemoval(
   env: NodeJS.ProcessEnv,
-  params: { worktreeId: string; token: string },
+  params: { worktreeId: string; token: string; respectRetentionClaims?: boolean },
 ): void {
   const pid = process.pid;
   claimWorktreeRemovalRow(env, {

--- a/src/agents/worktrees/service.retention.test.ts
+++ b/src/agents/worktrees/service.retention.test.ts
@@ -1,0 +1,126 @@
+import { execFile } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { requireNodeSqlite } from "../../infra/node-sqlite.js";
+import { OPENCLAW_STATE_SCHEMA_VERSION } from "../../state/openclaw-state-db-contract.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../../state/openclaw-state-db.js";
+import { IDLE_GC_MS, ManagedWorktreeService } from "./service.js";
+
+const execFileAsync = promisify(execFile);
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+async function git(cwd: string, ...args: string[]): Promise<void> {
+  await execFileAsync("git", ["-C", cwd, ...args]);
+}
+
+describe("managed worktree retention claims", () => {
+  let root: string;
+  let repo: string;
+  let env: NodeJS.ProcessEnv;
+  let now: number;
+  let service: ManagedWorktreeService;
+
+  beforeEach(async () => {
+    root = tempDirs.make("worktree-retention-", await fs.realpath(os.tmpdir()));
+    repo = path.join(root, "repo");
+    await fs.mkdir(repo);
+    await git(repo, "init", "-b", "main");
+    await git(repo, "config", "user.name", "OpenClaw Test");
+    await git(repo, "config", "user.email", "openclaw-test@example.invalid");
+    await fs.writeFile(path.join(repo, "README.md"), "base\n");
+    await git(repo, "add", "README.md");
+    await git(repo, "commit", "-m", "initial");
+    repo = await fs.realpath(repo);
+    env = { ...process.env, OPENCLAW_STATE_DIR: path.join(root, "state") };
+    now = 1_700_000_000_000;
+    service = new ManagedWorktreeService({ env, now: () => now });
+  });
+
+  afterEach(async () => {
+    closeOpenClawStateDatabaseForTest();
+  });
+
+  it("persists across run-end, idle, count, and size cleanup", async () => {
+    const created = await service.create({
+      repoRoot: repo,
+      name: "retained-artifact",
+      ownerKind: "workboard",
+      ownerId: "card-retained",
+    });
+    expect(
+      service.setRetentionClaimByPath(
+        created.path,
+        { ownerKind: "workboard", ownerId: "card-retained" },
+        { claimId: "artifact", active: true },
+      ),
+    ).toBe(true);
+
+    const restarted = new ManagedWorktreeService({ env, now: () => now });
+    expect(await restarted.removeIfLossless(created.id)).toBe(false);
+    now += IDLE_GC_MS + 1;
+    expect((await restarted.gc()).removed).toEqual([]);
+    expect((await restarted.gc({ limits: { maxCount: 0 } })).removed).toEqual([]);
+
+    await fs.writeFile(path.join(created.path, "artifact.bin"), Buffer.alloc(10_000));
+    expect((await restarted.gc({ limits: { maxTotalSizeBytes: 1 } })).removed).toEqual([]);
+    await expect(fs.stat(created.path)).resolves.toBeDefined();
+
+    expect(
+      restarted.setRetentionClaimByPath(
+        created.path,
+        { ownerKind: "workboard", ownerId: "card-retained" },
+        { claimId: "artifact", active: false },
+      ),
+    ).toBe(true);
+    expect((await restarted.gc({ limits: { maxCount: 0 } })).removed).toEqual([created.id]);
+    await expect(fs.stat(created.path)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("lazily adds retention claims to a pre-existing current-schema database", async () => {
+    const created = await service.create({
+      repoRoot: repo,
+      name: "legacy-retained-artifact",
+      ownerKind: "workboard",
+      ownerId: "card-legacy-retained",
+    });
+    const databasePath = openOpenClawStateDatabase({ env }).path;
+    closeOpenClawStateDatabaseForTest();
+
+    const { DatabaseSync } = requireNodeSqlite();
+    const legacy = new DatabaseSync(databasePath);
+    expect(legacy.prepare("PRAGMA user_version").get()).toEqual({
+      user_version: OPENCLAW_STATE_SCHEMA_VERSION,
+    });
+    legacy.exec("DROP TABLE worktree_retention_claims;");
+    legacy.close();
+
+    const reopened = openOpenClawStateDatabase({ env });
+    expect(
+      reopened.db
+        .prepare("SELECT name FROM sqlite_schema WHERE type = 'table' AND name = ?")
+        .get("worktree_retention_claims"),
+    ).toBeUndefined();
+
+    const restarted = new ManagedWorktreeService({ env, now: () => now });
+    expect(
+      restarted.setRetentionClaimByPath(
+        created.path,
+        { ownerKind: "workboard", ownerId: "card-legacy-retained" },
+        { claimId: "artifact", active: true },
+      ),
+    ).toBe(true);
+    expect(
+      reopened.db
+        .prepare("SELECT name FROM sqlite_schema WHERE type = 'table' AND name = ?")
+        .get("worktree_retention_claims"),
+    ).toEqual({ name: "worktree_retention_claims" });
+    expect(await restarted.removeIfLossless(created.id)).toBe(false);
+  });
+});

--- a/src/agents/worktrees/service.retention.test.ts
+++ b/src/agents/worktrees/service.retention.test.ts
@@ -1,9 +1,10 @@
 import { execFile } from "node:child_process";
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { requireNodeSqlite } from "../../infra/node-sqlite.js";
 import { OPENCLAW_STATE_SCHEMA_VERSION } from "../../state/openclaw-state-db-contract.js";
@@ -11,7 +12,8 @@ import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
 } from "../../state/openclaw-state-db.js";
-import { IDLE_GC_MS, ManagedWorktreeService } from "./service.js";
+import { abortWorktreeRemoval, claimWorktreeRemoval } from "./run-lease.js";
+import { IDLE_GC_MS, ManagedWorktreeService, SNAPSHOT_RETENTION_MS } from "./service.js";
 
 const execFileAsync = promisify(execFile);
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -29,6 +31,11 @@ describe("managed worktree retention claims", () => {
 
   beforeEach(async () => {
     root = tempDirs.make("worktree-retention-", await fs.realpath(os.tmpdir()));
+    // Disk admission is covered separately; these tiny fixtures exercise retention owners.
+    const disk = fsSync.statfsSync(root);
+    disk.bavail = 100_000_000;
+    disk.bfree = 100_000_000;
+    vi.spyOn(fsSync, "statfsSync").mockReturnValue(disk);
     repo = path.join(root, "repo");
     await fs.mkdir(repo);
     await git(repo, "init", "-b", "main");
@@ -37,6 +44,10 @@ describe("managed worktree retention claims", () => {
     await fs.writeFile(path.join(repo, "README.md"), "base\n");
     await git(repo, "add", "README.md");
     await git(repo, "commit", "-m", "initial");
+    const remote = path.join(root, "remote.git");
+    await execFileAsync("git", ["clone", "--bare", repo, remote]);
+    await git(repo, "remote", "add", "origin", remote);
+    await git(repo, "push", "-u", "origin", "main");
     repo = await fs.realpath(repo);
     env = { ...process.env, OPENCLAW_STATE_DIR: path.join(root, "state") };
     now = 1_700_000_000_000;
@@ -44,6 +55,7 @@ describe("managed worktree retention claims", () => {
   });
 
   afterEach(async () => {
+    vi.restoreAllMocks();
     closeOpenClawStateDatabaseForTest();
   });
 
@@ -55,8 +67,8 @@ describe("managed worktree retention claims", () => {
       ownerId: "card-retained",
     });
     expect(
-      service.setRetentionClaimByPath(
-        created.path,
+      service.setRetentionClaim(
+        created.id,
         { ownerKind: "workboard", ownerId: "card-retained" },
         { claimId: "artifact", active: true },
       ),
@@ -73,8 +85,8 @@ describe("managed worktree retention claims", () => {
     await expect(fs.stat(created.path)).resolves.toBeDefined();
 
     expect(
-      restarted.setRetentionClaimByPath(
-        created.path,
+      restarted.setRetentionClaim(
+        created.id,
         { ownerKind: "workboard", ownerId: "card-retained" },
         { claimId: "artifact", active: false },
       ),
@@ -110,8 +122,8 @@ describe("managed worktree retention claims", () => {
 
     const restarted = new ManagedWorktreeService({ env, now: () => now });
     expect(
-      restarted.setRetentionClaimByPath(
-        created.path,
+      restarted.setRetentionClaim(
+        created.id,
         { ownerKind: "workboard", ownerId: "card-legacy-retained" },
         { claimId: "artifact", active: true },
       ),
@@ -122,5 +134,127 @@ describe("managed worktree retention claims", () => {
         .get("worktree_retention_claims"),
     ).toEqual({ name: "worktree_retention_claims" });
     expect(await restarted.removeIfLossless(created.id)).toBe(false);
+  });
+
+  it.each([false, true])(
+    "keeps cancellation terminal across restart when acquired first is %s",
+    async (acquiredFirst) => {
+      const owner = { ownerKind: "workboard", ownerId: "card-cancelled" } as const;
+      const created = await service.create({ repoRoot: repo, name: "cancelled", ...owner });
+      if (acquiredFirst) {
+        expect(service.setRetentionClaim(created.id, owner, { claimId: "old", active: true })).toBe(
+          true,
+        );
+      }
+      expect(service.setRetentionClaim(created.id, owner, { claimId: "old", active: false })).toBe(
+        true,
+      );
+      closeOpenClawStateDatabaseForTest();
+      const restarted = new ManagedWorktreeService({ env, now: () => now });
+      expect(restarted.setRetentionClaim(created.id, owner, { claimId: "old", active: true })).toBe(
+        false,
+      );
+      expect(restarted.setRetentionClaim(created.id, owner, { claimId: "new", active: true })).toBe(
+        true,
+      );
+      expect(
+        restarted.setRetentionClaim(created.id, owner, { claimId: "old", active: false }),
+      ).toBe(true);
+      expect((await restarted.gc({ limits: { maxCount: 0 } })).removed).toEqual([]);
+      expect(
+        restarted.setRetentionClaim(created.id, owner, { claimId: "new", active: false }),
+      ).toBe(true);
+      expect((await restarted.gc({ limits: { maxCount: 0 } })).removed).toEqual([created.id]);
+    },
+  );
+
+  it("resolves only the exact owner and keeps other owners from changing claims", async () => {
+    const owner = { ownerKind: "workboard", ownerId: "card-owned" } as const;
+    const created = await service.create({ repoRoot: repo, name: "owned", ...owner });
+    expect(service.resolveRetentionTargetByPath(created.path, owner)).toBe(created.id);
+    for (const other of [
+      { ownerKind: "workboard", ownerId: "another-card" },
+      { ownerKind: "session", ownerId: owner.ownerId },
+    ] as const) {
+      expect(service.resolveRetentionTargetByPath(created.path, other)).toBeUndefined();
+      for (const active of [true, false]) {
+        expect(service.setRetentionClaim(created.id, other, { claimId: "owned", active })).toBe(
+          false,
+        );
+      }
+    }
+    expect(service.setRetentionClaim(created.id, owner, { claimId: "owned", active: true })).toBe(
+      true,
+    );
+    expect(await service.removeIfLossless(created.id)).toBe(false);
+  });
+
+  it("keeps released generations through restore and prunes them only with registry identity", async () => {
+    const owner = { ownerKind: "workboard", ownerId: "card-restored" } as const;
+    const created = await service.create({ repoRoot: repo, name: "restored", ...owner });
+    expect(service.setRetentionClaim(created.id, owner, { claimId: "old", active: true })).toBe(
+      true,
+    );
+    expect(
+      (await service.remove({ id: created.id, reason: "test-explicit-removal" })).removed,
+    ).toBe(true);
+    expect(service.resolveRetentionTargetByPath(created.path, owner)).toBeUndefined();
+    expect(service.setRetentionClaim(created.id, owner, { claimId: "old", active: false })).toBe(
+      true,
+    );
+    await service.restore({ id: created.id });
+    expect(service.setRetentionClaim(created.id, owner, { claimId: "old", active: true })).toBe(
+      false,
+    );
+    expect(await service.removeIfLossless(created.id)).toBe(true);
+    now += SNAPSHOT_RETENTION_MS + 1;
+    const database = openOpenClawStateDatabase({ env }).db;
+    database.exec(`
+      CREATE TRIGGER retain_registry_identity BEFORE DELETE ON worktrees
+      BEGIN SELECT RAISE(ABORT, 'injected registry prune failure'); END;
+    `);
+    expect((await service.gc()).snapshotsPruned).toBe(0);
+    expect(
+      database
+        .prepare("SELECT claim_id FROM worktree_retention_claims WHERE worktree_id = ?")
+        .all(created.id),
+    ).toEqual([{ claim_id: "old" }]);
+    database.exec("DROP TRIGGER retain_registry_identity");
+    expect((await service.gc()).snapshotsPruned).toBe(1);
+    expect(
+      database
+        .prepare("SELECT claim_id FROM worktree_retention_claims WHERE worktree_id = ?")
+        .all(created.id),
+    ).toEqual([]);
+    const replacement = await service.create({ repoRoot: repo, name: "restored", ...owner });
+    expect(replacement.id).not.toBe(created.id);
+    expect(replacement.path).toBe(created.path);
+    expect(service.setRetentionClaim(created.id, owner, { claimId: "old", active: false })).toBe(
+      true,
+    );
+    expect(service.setRetentionClaim(created.id, owner, { claimId: "old", active: true })).toBe(
+      false,
+    );
+    expect(await service.removeIfLossless(replacement.id)).toBe(true);
+  });
+
+  it("rejects acquisition during removal but can terminally cancel that generation", async () => {
+    const owner = { ownerKind: "workboard", ownerId: "card-removing" } as const;
+    const created = await service.create({ repoRoot: repo, name: "removing", ...owner });
+    claimWorktreeRemoval(env, { worktreeId: created.id, token: "remover" });
+    try {
+      expect(() =>
+        service.setRetentionClaim(created.id, owner, { claimId: "delayed", active: true }),
+      ).toThrow("worktree removal is already in progress");
+      expect(
+        service.setRetentionClaim(created.id, owner, { claimId: "delayed", active: false }),
+      ).toBe(true);
+    } finally {
+      abortWorktreeRemoval(env, created.id, "remover");
+    }
+    expect(service.setRetentionClaim(created.id, owner, { claimId: "delayed", active: true })).toBe(
+      false,
+    );
+    expect(await service.removeIfLossless(created.id)).toBe(true);
   });
 });

--- a/src/agents/worktrees/service.retention.test.ts
+++ b/src/agents/worktrees/service.retention.test.ts
@@ -168,25 +168,45 @@ describe("managed worktree retention claims", () => {
     },
   );
 
-  it("resolves only the exact owner and keeps other owners from changing claims", async () => {
-    const owner = { ownerKind: "workboard", ownerId: "card-owned" } as const;
-    const created = await service.create({ repoRoot: repo, name: "owned", ...owner });
-    expect(service.resolveRetentionTargetByPath(created.path, owner)).toBe(created.id);
-    for (const other of [
-      { ownerKind: "workboard", ownerId: "another-card" },
-      { ownerKind: "session", ownerId: owner.ownerId },
-    ] as const) {
-      expect(service.resolveRetentionTargetByPath(created.path, other)).toBeUndefined();
-      for (const active of [true, false]) {
-        expect(service.setRetentionClaim(created.id, other, { claimId: "owned", active })).toBe(
-          false,
-        );
+  it.each([false, true])(
+    "resolves only the exact owner and keeps other owners from changing claims (removed: %s)",
+    async (removed) => {
+      const owner = { ownerKind: "workboard", ownerId: "card-owned" } as const;
+      const created = await service.create({ repoRoot: repo, name: "owned", ...owner });
+      if (removed) {
+        await service.remove({ id: created.id, reason: "test-explicit-removal" });
       }
-    }
-    expect(service.setRetentionClaim(created.id, owner, { claimId: "owned", active: true })).toBe(
-      true,
+      expect(service.resolveRetentionTargetByPath(created.path, owner)).toBe(created.id);
+      for (const other of [
+        { ownerKind: "workboard", ownerId: "another-card" },
+        { ownerKind: "session", ownerId: owner.ownerId },
+      ] as const) {
+        expect(service.resolveRetentionTargetByPath(created.path, other)).toBeUndefined();
+        for (const active of [true, false]) {
+          expect(service.setRetentionClaim(created.id, other, { claimId: "owned", active })).toBe(
+            false,
+          );
+        }
+      }
+      expect(service.setRetentionClaim(created.id, owner, { claimId: "owned", active: true })).toBe(
+        true,
+      );
+      if (removed) {
+        await service.restore({ id: created.id });
+      }
+      expect(await service.removeIfLossless(created.id)).toBe(false);
+    },
+  );
+
+  it("does not enroll a checkout lost without a snapshot", async () => {
+    const owner = { ownerKind: "workboard", ownerId: "card-lost" } as const;
+    const created = await service.create({ repoRoot: repo, name: "lost", ...owner });
+    await fs.rm(created.path, { recursive: true, force: true });
+    await service.gc();
+    expect(service.resolveRetentionTargetByPath(created.path, owner)).toBeUndefined();
+    expect(service.setRetentionClaim(created.id, owner, { claimId: "new", active: true })).toBe(
+      false,
     );
-    expect(await service.removeIfLossless(created.id)).toBe(false);
   });
 
   it("keeps released generations through restore and prunes them only with registry identity", async () => {
@@ -198,7 +218,13 @@ describe("managed worktree retention claims", () => {
     expect(
       (await service.remove({ id: created.id, reason: "test-explicit-removal" })).removed,
     ).toBe(true);
-    expect(service.resolveRetentionTargetByPath(created.path, owner)).toBeUndefined();
+    expect(service.resolveRetentionTargetByPath(created.path, owner)).toBe(created.id);
+    expect(service.setRetentionClaim(created.id, owner, { claimId: "new", active: true })).toBe(
+      true,
+    );
+    expect(service.setRetentionClaim(created.id, owner, { claimId: "new", active: false })).toBe(
+      true,
+    );
     expect(service.setRetentionClaim(created.id, owner, { claimId: "old", active: false })).toBe(
       true,
     );
@@ -216,9 +242,11 @@ describe("managed worktree retention claims", () => {
     expect((await service.gc()).snapshotsPruned).toBe(0);
     expect(
       database
-        .prepare("SELECT claim_id FROM worktree_retention_claims WHERE worktree_id = ?")
+        .prepare(
+          "SELECT claim_id FROM worktree_retention_claims WHERE worktree_id = ? ORDER BY claim_id",
+        )
         .all(created.id),
-    ).toEqual([{ claim_id: "old" }]);
+    ).toEqual([{ claim_id: "new" }, { claim_id: "old" }]);
     database.exec("DROP TRIGGER retain_registry_identity");
     expect((await service.gc()).snapshotsPruned).toBe(1);
     expect(

--- a/src/agents/worktrees/service.ts
+++ b/src/agents/worktrees/service.ts
@@ -51,7 +51,6 @@ import {
   deleteRegistryWorktree,
   findLiveRegistryWorktreeByOwner,
   findLiveRegistryWorktreeByPath,
-  findRegistryWorktreeByPath,
   getRegistryWorktree,
   getRegistryWorktreeProvisionedPaths,
   getRegistryWorktreeProvisionedState,
@@ -1550,8 +1549,16 @@ export class ManagedWorktreeService {
     }
   }
 
-  setRetentionClaimByPath(
+  resolveRetentionTargetByPath(
     worktreePath: string,
+    owner: Pick<CreateManagedWorktreeParams, "ownerKind" | "ownerId">,
+  ): string | undefined {
+    const record = findLiveRegistryWorktreeByPath(this.env, worktreePath);
+    return record?.ownerId && worktreeOwnerMatches(record, owner) ? record.id : undefined;
+  }
+
+  setRetentionClaim(
+    worktreeId: string,
     owner: Pick<CreateManagedWorktreeParams, "ownerKind" | "ownerId">,
     params: { claimId: string; active: boolean },
   ): boolean {
@@ -1559,16 +1566,14 @@ export class ManagedWorktreeService {
     if (!claimId) {
       throw new Error("worktree retention claim id is required");
     }
-    const record = params.active
-      ? findLiveRegistryWorktreeByPath(this.env, worktreePath)
-      : findRegistryWorktreeByPath(this.env, worktreePath);
-    if (!record || !worktreeOwnerMatches(record, owner) || !record.ownerId) {
+    if (!owner.ownerId) {
       return false;
     }
     return setWorktreeRetentionClaimRow(this.env, {
-      worktreeId: record.id,
+      worktreeId,
       claimId,
-      claimOwner: `${record.ownerKind}:${record.ownerId}`,
+      ownerKind: owner.ownerKind ?? "manual",
+      ownerId: owner.ownerId,
       active: params.active,
       now: this.now(),
     });

--- a/src/agents/worktrees/service.ts
+++ b/src/agents/worktrees/service.ts
@@ -51,11 +51,14 @@ import {
   deleteRegistryWorktree,
   findLiveRegistryWorktreeByOwner,
   findLiveRegistryWorktreeByPath,
+  findRegistryWorktreeByPath,
   getRegistryWorktree,
   getRegistryWorktreeProvisionedPaths,
   getRegistryWorktreeProvisionedState,
+  hasWorktreeRetentionClaimRow,
   insertRegistryWorktree,
   listRegistryWorktrees,
+  setWorktreeRetentionClaimRow,
   updateRegistryWorktree,
   WorktreeRemovalContentionError,
 } from "./registry.js";
@@ -165,6 +168,7 @@ type RemoveWorktreeParams = WorktreeMutationGuard & {
   reason: string;
   allowSnapshotLoss?: boolean;
   claimToken?: string;
+  respectRetentionClaims?: boolean;
   runEndCleanup?: ManagedWorktreeRunEndCleanup;
 };
 const WORKTREE_CLEANUP_TARGET = 100;
@@ -1224,7 +1228,11 @@ export class ManagedWorktreeService {
     // opaque token makes the claim exclusive against competing removers; a caller
     // that already claimed (removeIfLossless) passes its token to keep one claim.
     const claimToken = params.claimToken ?? randomUUID();
-    claimWorktreeRemoval(this.env, { worktreeId: record.id, token: claimToken });
+    claimWorktreeRemoval(this.env, {
+      worktreeId: record.id,
+      token: claimToken,
+      respectRetentionClaims: params.respectRetentionClaims,
+    });
     try {
       record = await this.rebindLiveRepository(record, params);
       const state = await lockState(record);
@@ -1450,7 +1458,11 @@ export class ManagedWorktreeService {
     // Run-end cleanup must leave a durable outcome even when safety retains the checkout.
     // QA and operators observe this product-boundary fact through worktrees.list.
     try {
-      claimWorktreeRemoval(this.env, { worktreeId: id, token: claimToken });
+      claimWorktreeRemoval(this.env, {
+        worktreeId: id,
+        token: claimToken,
+        respectRetentionClaims: true,
+      });
     } catch (error) {
       if (error instanceof WorktreeRemovalContentionError) {
         if (error.kind === "finalized") {
@@ -1509,6 +1521,7 @@ export class ManagedWorktreeService {
         id,
         reason: "run-end",
         claimToken,
+        respectRetentionClaims: true,
         runEndCleanup: { outcome: "removed-lossless", at: this.now() },
       });
     } catch (error) {
@@ -1537,6 +1550,30 @@ export class ManagedWorktreeService {
     }
   }
 
+  setRetentionClaimByPath(
+    worktreePath: string,
+    owner: Pick<CreateManagedWorktreeParams, "ownerKind" | "ownerId">,
+    params: { claimId: string; active: boolean },
+  ): boolean {
+    const claimId = params.claimId.trim();
+    if (!claimId) {
+      throw new Error("worktree retention claim id is required");
+    }
+    const record = params.active
+      ? findLiveRegistryWorktreeByPath(this.env, worktreePath)
+      : findRegistryWorktreeByPath(this.env, worktreePath);
+    if (!record || !worktreeOwnerMatches(record, owner) || !record.ownerId) {
+      return false;
+    }
+    return setWorktreeRetentionClaimRow(this.env, {
+      worktreeId: record.id,
+      claimId,
+      claimOwner: `${record.ownerKind}:${record.ownerId}`,
+      active: params.active,
+      now: this.now(),
+    });
+  }
+
   async gc(params: ManagedWorktreeGcParams = {}): Promise<ManagedWorktreeGcResult> {
     const now = this.now();
     let removed: string[] = [];
@@ -1563,6 +1600,7 @@ export class ManagedWorktreeService {
           await this.remove({
             id: record.id,
             reason: retiredOwner ? "owner-gc" : "idle-gc",
+            respectRetentionClaims: true,
             commitGuard: () => this.assertOwnerAllowsCleanup(record, params, retiredOwner),
           });
           removed.push(record.id);
@@ -1603,6 +1641,9 @@ export class ManagedWorktreeService {
       record.ownerId !== undefined &&
       shouldProtectOwner?.(record.ownerKind, record.ownerId) === true
     ) {
+      return true;
+    }
+    if (hasWorktreeRetentionClaimRow(this.env, record.id)) {
       return true;
     }
     if (hasLiveWorktreeRunLease(this.env, record.id)) {
@@ -1703,6 +1744,7 @@ export class ManagedWorktreeService {
         await this.remove({
           id: record.id,
           reason: "limit-gc",
+          respectRetentionClaims: true,
           commitGuard: () => this.assertOwnerAllowsCleanup(record, params),
         });
       } catch (error) {

--- a/src/agents/worktrees/service.ts
+++ b/src/agents/worktrees/service.ts
@@ -51,6 +51,7 @@ import {
   deleteRegistryWorktree,
   findLiveRegistryWorktreeByOwner,
   findLiveRegistryWorktreeByPath,
+  findRegistryWorktreeByPath,
   getRegistryWorktree,
   getRegistryWorktreeProvisionedPaths,
   getRegistryWorktreeProvisionedState,
@@ -1553,8 +1554,15 @@ export class ManagedWorktreeService {
     worktreePath: string,
     owner: Pick<CreateManagedWorktreeParams, "ownerKind" | "ownerId">,
   ): string | undefined {
-    const record = findLiveRegistryWorktreeByPath(this.env, worktreePath);
-    return record?.ownerId && worktreeOwnerMatches(record, owner) ? record.id : undefined;
+    const record = findRegistryWorktreeByPath(this.env, worktreePath);
+    // A persisted reference can predate enrollment while its checkout is removed.
+    // Protect that snapshot-backed identity before restore makes it GC-eligible.
+    // Restore remains responsible for verifying the snapshot's actual recoverability.
+    return record?.ownerId &&
+      worktreeOwnerMatches(record, owner) &&
+      (record.removedAt === undefined || Boolean(record.snapshotRef))
+      ? record.id
+      : undefined;
   }
 
   setRetentionClaim(

--- a/src/plugin-sdk/plugin-test-runtime.ts
+++ b/src/plugin-sdk/plugin-test-runtime.ts
@@ -152,6 +152,7 @@ export {
   type CapturedPluginRegistration,
 } from "../plugins/captured-registration.js";
 export { createRuntimeTaskFlow } from "../plugins/runtime/runtime-taskflow.js";
+export { IDLE_GC_MS, ManagedWorktreeService } from "../agents/worktrees/service.js";
 export {
   createPluginRuntimeMediaMock,
   createPluginRuntimeMock,

--- a/src/plugin-sdk/test-helpers/plugin-runtime-mock.ts
+++ b/src/plugin-sdk/test-helpers/plugin-runtime-mock.ts
@@ -1052,6 +1052,7 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
       hasSelfContainedCheckoutMetadata: vi.fn(),
       create: vi.fn(),
       release: vi.fn(),
+      resolveRetentionTarget: vi.fn(),
       setRetentionClaim: vi.fn(),
       removeIfLossless: vi.fn(),
     },

--- a/src/plugin-sdk/test-helpers/plugin-runtime-mock.ts
+++ b/src/plugin-sdk/test-helpers/plugin-runtime-mock.ts
@@ -1052,6 +1052,7 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
       hasSelfContainedCheckoutMetadata: vi.fn(),
       create: vi.fn(),
       release: vi.fn(),
+      setRetentionClaim: vi.fn(),
       removeIfLossless: vi.fn(),
     },
     llm: {

--- a/src/plugins/runtime/index.test.ts
+++ b/src/plugins/runtime/index.test.ts
@@ -435,6 +435,7 @@ describe("plugin runtime command execution", () => {
           "hasSelfContainedCheckoutMetadata",
           "create",
           "release",
+          "resolveRetentionTarget",
           "setRetentionClaim",
           "removeIfLossless",
         ]);

--- a/src/plugins/runtime/index.test.ts
+++ b/src/plugins/runtime/index.test.ts
@@ -435,6 +435,7 @@ describe("plugin runtime command execution", () => {
           "hasSelfContainedCheckoutMetadata",
           "create",
           "release",
+          "setRetentionClaim",
           "removeIfLossless",
         ]);
       },

--- a/src/plugins/runtime/index.ts
+++ b/src/plugins/runtime/index.ts
@@ -182,10 +182,17 @@ function createRuntimeWorktrees(): PluginRuntime["worktrees"] {
       const { managedWorktrees } = await loadService();
       await managedWorktrees.releaseByPath(params.path);
     },
+    async resolveRetentionTarget(params) {
+      const { managedWorktrees } = await loadService();
+      return managedWorktrees.resolveRetentionTargetByPath(params.path, {
+        ownerKind: params.ownerKind,
+        ownerId: params.ownerId,
+      });
+    },
     async setRetentionClaim(params) {
       const { managedWorktrees } = await loadService();
-      return managedWorktrees.setRetentionClaimByPath(
-        params.path,
+      return managedWorktrees.setRetentionClaim(
+        params.worktreeId,
         { ownerKind: params.ownerKind, ownerId: params.ownerId },
         { claimId: params.claimId, active: params.active },
       );

--- a/src/plugins/runtime/index.ts
+++ b/src/plugins/runtime/index.ts
@@ -182,6 +182,14 @@ function createRuntimeWorktrees(): PluginRuntime["worktrees"] {
       const { managedWorktrees } = await loadService();
       await managedWorktrees.releaseByPath(params.path);
     },
+    async setRetentionClaim(params) {
+      const { managedWorktrees } = await loadService();
+      return managedWorktrees.setRetentionClaimByPath(
+        params.path,
+        { ownerKind: params.ownerKind, ownerId: params.ownerId },
+        { claimId: params.claimId, active: params.active },
+      );
+    },
     async removeIfLossless(params) {
       const { managedWorktrees } = await loadService();
       return managedWorktrees.removeIfLosslessByPath(params.path, {

--- a/src/plugins/runtime/types.ts
+++ b/src/plugins/runtime/types.ts
@@ -203,6 +203,13 @@ export type PluginRuntime = PluginRuntimeCore & {
       ownerId: string;
     }) => Promise<PluginManagedWorktree>;
     release: (params: { path: string }) => Promise<void>;
+    setRetentionClaim: (params: {
+      path: string;
+      ownerKind: "workboard";
+      ownerId: string;
+      claimId: string;
+      active: boolean;
+    }) => Promise<boolean>;
     removeIfLossless: (params: {
       path: string;
       ownerKind: "workboard";

--- a/src/plugins/runtime/types.ts
+++ b/src/plugins/runtime/types.ts
@@ -203,8 +203,13 @@ export type PluginRuntime = PluginRuntimeCore & {
       ownerId: string;
     }) => Promise<PluginManagedWorktree>;
     release: (params: { path: string }) => Promise<void>;
-    setRetentionClaim: (params: {
+    resolveRetentionTarget: (params: {
       path: string;
+      ownerKind: "workboard";
+      ownerId: string;
+    }) => Promise<string | undefined>;
+    setRetentionClaim: (params: {
+      worktreeId: string;
       ownerKind: "workboard";
       ownerId: string;
       claimId: string;

--- a/src/state/openclaw-state-db-contract.ts
+++ b/src/state/openclaw-state-db-contract.ts
@@ -79,6 +79,7 @@ export const LAZY_ADDITIVE_STATE_TABLES = [
   "skill_workshop_proposals",
   "worker_environment_ssh_fallback_ports",
   "worker_session_placement_moves",
+  "worktree_retention_claims",
 ] as const;
 export const LAZY_ADDITIVE_STATE_INDEXES = [
   ...FIRST_USE_STATE_INDEXES,

--- a/src/state/openclaw-state-db.generated.d.ts
+++ b/src/state/openclaw-state-db.generated.d.ts
@@ -1670,6 +1670,14 @@ export interface WorktreeProvisionedFileChunks {
   worktree_id: string;
 }
 
+export interface WorktreeRetentionClaims {
+  claim_id: string;
+  claim_owner: string;
+  created_at: number;
+  updated_at: number;
+  worktree_id: string;
+}
+
 export interface Worktrees {
   base_ref: string;
   branch: string;
@@ -1812,5 +1820,6 @@ export interface DB {
   workspace_path_aliases: WorkspacePathAliases;
   workspace_setup_state: WorkspaceSetupState;
   worktree_provisioned_file_chunks: WorktreeProvisionedFileChunks;
+  worktree_retention_claims: WorktreeRetentionClaims;
   worktrees: Worktrees;
 }

--- a/src/state/openclaw-state-db.generated.d.ts
+++ b/src/state/openclaw-state-db.generated.d.ts
@@ -1674,6 +1674,7 @@ export interface WorktreeRetentionClaims {
   claim_id: string;
   claim_owner: string;
   created_at: number;
+  released_at: number | null;
   updated_at: number;
   worktree_id: string;
 }

--- a/src/state/openclaw-state-schema.sql
+++ b/src/state/openclaw-state-schema.sql
@@ -1840,6 +1840,15 @@ CREATE TABLE IF NOT EXISTS worktree_provisioned_file_chunks (
   PRIMARY KEY (worktree_id, path, chunk_index)
 ) STRICT;
 
+CREATE TABLE IF NOT EXISTS worktree_retention_claims (
+  worktree_id TEXT NOT NULL,
+  claim_id TEXT NOT NULL,
+  claim_owner TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  PRIMARY KEY (worktree_id, claim_id)
+) STRICT;
+
 CREATE TABLE IF NOT EXISTS projects (
   id TEXT NOT NULL PRIMARY KEY,
   display_name TEXT NOT NULL,

--- a/src/state/openclaw-state-schema.sql
+++ b/src/state/openclaw-state-schema.sql
@@ -1846,6 +1846,7 @@ CREATE TABLE IF NOT EXISTS worktree_retention_claims (
   claim_owner TEXT NOT NULL,
   created_at INTEGER NOT NULL,
   updated_at INTEGER NOT NULL,
+  released_at INTEGER,
   PRIMARY KEY (worktree_id, claim_id)
 ) STRICT;
 


### PR DESCRIPTION
Related: #111496

## What Problem This Solves

Fixes an issue where users completing Workboard tasks could lose locally referenced generated files when automatic cleanup removed their Git-clean managed worktree. The card keeps its artifact path, but the bytes disappear. Protecting only run-end cleanup merely defers that loss to idle, count, or size GC.

## Why This Change Was Made

Workboard owns artifact interpretation and its durable generation journal; core owns generic, exact-owner claims against immutable worktree IDs and enforces those claims at automatic-removal admission. This follows the [requested ownership boundary](https://github.com/openclaw/openclaw/pull/111497#issuecomment-5143059431), without a Workboard-specific core scan or process-local lock.

Preparation is durable before acquisition. A card publishes its new references only after protection is acquired; the card, active generation, and obsolete-generation release obligations commit together. Cancellation/release is terminal, and failed releases remain durably retryable. An exact owner-matched removed identity with an existing snapshot can enroll before restoration, so restore does not create an unprotected window. A startup reconciliation failure warns without disabling change events or the existing real maintenance timer.

The latest commit also fixes a boundary exposed by native POSIX proof: `kind: worktree` represents both a source-checkout request and a materialized managed workspace. Only the latter carries `sourcePath`. Retention now uses that existing discriminator, preserving exact-owner/identity checks while allowing cleanup to return the card to its source checkout. Same-path edits preserve protection.

## User Impact

- Enrolled local references survive automatic run-end, idle, count, and size cleanup, including process restart.
- Removing, externalizing, archiving, or deleting references leaves durable release obligations so ordinary collection can resume.
- URL-only and canonically outside-worktree references do not pin unrelated checkouts. Native inbound aliases still protect the actual referenced worktree.
- A claim is not a backup: explicit operator removal, snapshot contents, and removed-snapshot expiry are unchanged. Enrollment cannot recover already-lost bytes or turn ignored output into snapshot-backed content.

### Compatibility and scope

The two tables are lazy/same-version additive for stable pre-feature schemas. Older binaries do not enforce claims: readable storage does **not** make downgrade artifact-safe. Earlier unmerged preview table shapes are not automatically migrated; preserve artifacts and use a targeted migration or disposable test state, never delete a shared state database as a workaround.

The persistent SDK, snapshot-backed removed-identity enrollment, and upgrade/downgrade boundaries still require maintainer acceptance. The [specific decision request](https://github.com/openclaw/openclaw/pull/111497#issuecomment-5600556086) is open; neither tests nor this contributor's implementation choice constitute approval.

One artifact-reference lifecycle PR: **30 files, +2157/-87** against frozen base `20e0ed5`. The latest follow-up changes only two existing Workboard files (+65/-2), mostly regressions, with one production state discriminator. It adds no API, table, dependency, callback, configuration, or new subsystem. Generic enforcement and its first Workboard consumer remain together; the proof harness lives on a separate validation-only branch, outside this PR diff.

## Evidence

Candidate: **`849b9156c0d8ca5a9fe7d6252edff7a6b68edb16`**. Frozen pre-retention baseline: `20e0ed521c00fd38b1d4d003636fa4ddd3bf2066`.

The [public proof bundle](https://gist.github.com/ooiuuii/9e28d79c9b962ca5017a6e82f8644492) preserves the original baseline RED and historical receipts, with separate current-head Windows and POSIX/upgrade projections. Recorders, commands, immutable harness source, raw-receipt hashes, source identities, worker PIDs, checks, and timing are linked there. Only redacted synthetic evidence is published, never configuration, credentials, personal paths, transcripts, or application databases.

### Current-head real behavior

- **Windows:** all four fresh runs on clean committed `849b9156` pass: lifecycle **5/5**, legacy first-enrollment/restore **5/5**, startup-release **1/1**, and supplemental events **3/3**. Eight distinct workers exit successfully, with unchanged clean before/after source identities. Actual maintenance retries complete after **62,737 / 62,763 ms**, each with two attempts and one successful release; subsequent real GC removes the retired checkout.
- **Native POSIX containment:** the secretless [Ubuntu run 34347410012](https://github.com/ooiuuii/openclaw/actions/runs/34347410012) passes all three fresh, two-process lanes: idle **6/6**, count **6/6**, size **6/6**. Native inbound symlinks protect the actual artifact; URL-only, outside-path, and outbound-symlink controls retain their exact references/outside bytes while the unrelated checkout is actually removed. Each lane then externalizes the retained reference and requires real removal with that same lane's GC parameters. Count/size clocks are not aged, so idle GC cannot stand in for them.
- **Existing-database upgrade:** the same run creates a real database/card through baseline `20e0ed5`, then opens it through `849b9156` in another process. All **4/4** checks pass: complete card preserved, both retention tables added, core/Workboard `user_version` unchanged at **16/0**, then real run-end protection, count GC protection, and externalization/removal. This proves the documented stable-baseline upgrade, not preview-table migration or downgrade protection.
- The Linux job independently reproduces and strictly verifies baseline artifact/checkout loss with the card/reference still present. All five Linux receipts have successful separate workers and unchanged clean source identities; the downloaded redacted artifact was checked against the pinned head/base. Recorder/workflow source is immutable at [proof commit f036c9d](https://github.com/ooiuuii/openclaw/tree/f036c9daaa723d584e4e2b7a2caecacc80a357b6); it is outside this product PR.

These are production source-owner/lifecycle runs using real Git, SQLite, files, separate processes, and unmocked disk capacity in isolated synthetic state. No installed Gateway, channel, provider, UI, or production configuration is started. Event coverage observes the real service's output sink, not network/UI delivery. Idle eligibility advances the exported service clock; startup retry uses real wall time. The release outage is deliberately injected. Externalization uses `https://example.invalid/report.txt` and proves reference retirement, not remote upload.

### Focused checks and CI

- Both new source-request/cleanup regressions failed with the unavailable-source-repository error before the fix. The final current-head delta passes **25 tests across three files**, type-aware focused lint, formatting, and `git diff --check`.
- The Windows outbound-junction regression requires real registry removal, `.git` disappearance, source-checkout fallback, unchanged references, and intact outside bytes. Git for Windows can leave an ignored junction directory after deregistration; a pure Git probe reproduced that without this PR. That independent existing cleanup behavior is excluded, not counted as complete Windows directory removal. The POSIX standalone proof retains its strict whole-directory disappearance assertion.
- The earlier broader suite on `78a1e91` had 95 passes and three unchanged Windows baseline failures (CRLF, executable-bit fixture, path separators). Its [full upstream CI](https://github.com/openclaw/openclaw/actions/runs/34338980894), including typecheck and required CI gate, passed. This is explicitly historical evidence, not a current-head CI pass.
- Current-head primary [upstream run 34347235499](https://github.com/openclaw/openclaw/actions/runs/34347235499) failed at GitHub startup **before creating any test job**. Its annotation reports an unexpected GitHub error. Author retry was denied with “Must have admin rights to Repository”; a maintainer must retry it. Separate dependency and security guards passed. No workflow was weakened or empty commit added to manufacture green.

### Review closeout

The whole preceding candidate was reviewed against `20e0ed5`; the final two-file follow-up was then reviewed using the repository's structured Codex helper: `--mode local --engine codex --max-priority P2`, frozen lifecycle context, 5,440-byte delta. Final source verification completed; result **exit 0 / scoped-clean**, no P0–P2 findings. Focused tests passed, and the reviewed change was committed as `849b9156`. The Windows Git residual-directory issue is a separate follow-up; the persistence contract is a maintainer decision, not an invitation to expand this PR.

AI-assisted: yes. Maintainer edits remain enabled.
