### PR TITLE
fix: channel setup succeeds when audit storage fails

### DIFF
--- a/src/system-agent/chat-engine.test.ts
+++ b/src/system-agent/chat-engine.test.ts
@@ -725,6 +725,25 @@ describe("SystemAgentChatEngine", () => {
     expect(wizardRuns).toEqual(["telegram", "token:123:abc", "mode:open"]);
   });
 
+  it("reports hosted channel setup success when audit persistence fails", async () => {
+    const appendAuditEntry = vi.fn(async () => {
+      throw new Error("audit store is read-only");
+    });
+    const engine = new SystemAgentChatEngine({
+      runAgentTurn: async () => null,
+      planWithAssistant: async () => null,
+      deps: { loadOverview: fakeOverviewLoader() },
+      runChannelSetupWizard: async () => {},
+      appendAuditEntry,
+    });
+
+    const reply = await engine.handle("connect telegram");
+
+    expect(reply.text).toContain("Done — telegram is configured.");
+    expect(reply.text).not.toContain("audit store is read-only");
+    expect(appendAuditEntry).toHaveBeenCalledOnce();
+  });
+
   it("recommends the confirm option matching the initial value", async () => {
     let enabled: boolean | undefined;
     const engine = new SystemAgentChatEngine({

--- a/src/system-agent/chat-engine.ts
+++ b/src/system-agent/chat-engine.ts
@@ -1,6 +1,8 @@
 // OpenClaw chat engine: transport-agnostic conversation over typed operations.
 import type { SystemAgentChatQuestion } from "../../packages/gateway-protocol/src/index.js";
 import { isSensitiveConfigPath } from "../config/sensitive-paths.js";
+import { formatErrorMessage } from "../infra/errors.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { WizardSession, type WizardStep } from "../wizard/session.js";
 import {
@@ -63,6 +65,8 @@ export type SystemAgentChatEngineOptions = {
   classifyApproval?: SystemAgentApprovalClassifier;
   /** Test seam for the audited host operation executor. */
   executeOperation?: typeof executeSystemAgentOperation;
+  /** Test seam for best-effort audit persistence. */
+  appendAuditEntry?: typeof import("./audit.js").appendSystemAgentAuditEntry;
   /** Where side effects run; the gateway surface never manages its own daemon. */
   surface?: "cli" | "gateway";
   /** Test seam for the channel-setup wizard hosted by the chat bridge. */
@@ -106,6 +110,8 @@ type ActiveWizardBridge = {
 type CaptureRuntime = RuntimeEnv & {
   read: () => string;
 };
+
+const log = createSubsystemLogger("system-agent/chat-engine");
 
 function createHostedWizardRuntime(runtime: RuntimeEnv): RuntimeEnv {
   return {
@@ -1161,12 +1167,19 @@ export class SystemAgentChatEngine {
       this.wizardBridge = null;
       const label = bridge.label;
       if (result.status === "done") {
-        const { appendSystemAgentAuditEntry } = await import("./audit.js");
-        await appendSystemAgentAuditEntry({
-          operation: "channels.setup",
-          summary: `Configured channel ${label} via chat setup`,
-          details: { channel: label },
-        });
+        try {
+          const appendAuditEntry =
+            this.opts.appendAuditEntry ?? (await import("./audit.js")).appendSystemAgentAuditEntry;
+          await appendAuditEntry({
+            operation: "channels.setup",
+            summary: `Configured channel ${label} via chat setup`,
+            details: { channel: label },
+          });
+        } catch (error) {
+          // Channel setup already committed. Audit failure must not turn its
+          // truthful success result into a user-facing setup failure.
+          log.warn(`channel setup completed without audit entry: ${formatErrorMessage(error)}`);
+        }
         const verify = await this.verifyConfigAfterWrite();
         return [
           `Done — ${label} is configured.`,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a hosted channel setup that had already configured the channel successfully could be reported as failed when the system-agent audit store was unwritable.

## Why This Change Was Made

Treats the post-commit channel audit append as best effort: failures are logged through the system-agent subsystem logger, while post-write verification and the truthful success response continue. The other completed-operation audit paths already follow this non-fatal contract and are unchanged.

This PR is AI-assisted, and the implementation and proof were reviewed before submission.

## User Impact

Users now see that their channel is configured even if disk, permission, or SQLite failures prevent OpenClaw from recording the audit entry. The audit failure remains visible in logs for operators.

## Evidence

- Current-main verification: `origin/main` at `5a6a19c13393529647895793861de2298d5573ad` still awaits `appendSystemAgentAuditEntry` without a guard after the hosted wizard returns `done` (`src/system-agent/chat-engine.ts:1164-1165`).
- Refreshed exact-head runtime fault injection: after a clean rebase through `163a6c6e169e5d00aa23212a9f51aad75a115ed8`, head `6e40c6458685f8740c8a24ab22b7b86d1559e59f` ran an isolated hosted wizard that committed `channels.telegram.enabled=true`, then called the real SQLite audit append with its state path deliberately replaced by a regular file. The process exited 0 and printed:

  ```text
  [system-agent/chat-engine] channel setup completed without audit entry: ENOTDIR: not a directory, mkdir '<isolated-state-path>/state'
  CONFIG_COMMITTED=true
  USER_REPLY=Done — telegram is configured.
  AUDIT_STORE_FAILURE=see subsystem warning above
  ```

- Maintainer owner-boundary/history review: `pumpWizardBridge()` is the caller and the already-completed wizard mutation is the authoritative boundary. `applyPersistentOperation()` (`src/system-agent/operations-execution-helpers.ts:271-286`) and gateway inference setup (`src/system-agent/setup-inference.ts:2316-2330`) already catch post-commit audit failures and preserve success; no other production system-agent append caller remains. Blame traces the hosted completion path to `07bf384a8b3f` and the current audit import/await to rename commit `a6a071648601`; neither established audit persistence as a pre-commit gate.
- Focused regression: `node scripts/run-vitest.mjs src/system-agent/chat-engine.test.ts` — 65 tests passed.
- Targeted lint: `node scripts/run-oxlint.mjs src/system-agent/chat-engine.ts src/system-agent/chat-engine.test.ts` — passed.
- Formatting: `pnpm format src/system-agent/chat-engine.ts src/system-agent/chat-engine.test.ts` — passed.
- Typecheck: `pnpm tsgo` on Blacksmith Testbox `tbx_01kxxsxg88m63zzp20p3jsvh18`, Actions run `29698638250` — exit 0.
- Patch integrity: `git diff --check` — passed.
- Autoreview: `/Users/steipete/.claude/skills/autoreview/scripts/autoreview --mode branch --base origin/main` on refreshed head `6e40c6458685f8740c8a24ab22b7b86d1559e59f` — clean, no accepted/actionable findings.
