### PR TITLE
fix(agents): let swarm collector fan-outs honor group caps

### DIFF
--- a/docs/tools/swarm.md
+++ b/docs/tools/swarm.md
@@ -251,9 +251,16 @@ not validate, the collector completion keeps the child's raw text, leaves
 `structured` unset, and includes `schemaError`. The low-level `agents_wait`
 result exposes those fields for explicit recovery logic.
 
-Swarm enforces all three group caps before starting more work. Children above
-`maxConcurrent` queue FIFO. A spawn that exceeds `maxChildrenPerGroup` or
-`maxTotalPerGroup` is rejected with the relevant config key in the error.
+Every child has one admission owner. Announce and interactive children use
+`agents.defaults.subagents.maxChildrenPerAgent` (default `5`) and do not count
+collector children. Collector children use only `maxChildrenPerGroup` and
+`maxTotalPerGroup`; they do not consume the per-session child budget. The spawn
+depth guard still applies to both modes.
+
+After admission, children above `maxConcurrent` queue FIFO within their swarm
+group, nested inside the global sub-agent lane. These concurrency layers queue
+work rather than rejecting it. A collector spawn that exceeds either group cap
+is rejected with the relevant config key in the error.
 
 ## Observe a Swarm
 

--- a/src/agents/child-admission.ts
+++ b/src/agents/child-admission.ts
@@ -1,0 +1,48 @@
+export type ChildAdmissionCap =
+  | "subagents.maxSpawnDepth"
+  | "subagents.maxChildrenPerAgent"
+  | "tools.swarm.maxChildrenPerGroup"
+  | "tools.swarm.maxTotalPerGroup";
+
+type ChildAdmissionResult =
+  | { ok: true }
+  | { ok: false; governingCap: ChildAdmissionCap; error: string };
+
+type ChildAdmissionParams = {
+  callerDepth: number;
+  maxSpawnDepth: number;
+  activeChildren: number;
+  maxActiveChildren: number;
+} & ({ collect: false } | { collect: true; totalChildren: number; maxTotalChildren: number });
+
+const rejectChildAdmission = (
+  governingCap: ChildAdmissionCap,
+  error: string,
+): ChildAdmissionResult => ({ ok: false, governingCap, error });
+
+export function resolveChildAdmission(params: ChildAdmissionParams): ChildAdmissionResult {
+  if (params.callerDepth >= params.maxSpawnDepth) {
+    return rejectChildAdmission(
+      "subagents.maxSpawnDepth",
+      `sessions_spawn is not allowed at this depth (current depth: ${params.callerDepth}, max: ${params.maxSpawnDepth}; agents.defaults.subagents.maxSpawnDepth).`,
+    );
+  }
+  if (params.collect && params.totalChildren >= params.maxTotalChildren) {
+    return rejectChildAdmission(
+      "tools.swarm.maxTotalPerGroup",
+      `sessions_spawn reached tools.swarm.maxTotalPerGroup (${params.totalChildren}/${params.maxTotalChildren}).`,
+    );
+  }
+  if (params.activeChildren < params.maxActiveChildren) {
+    return { ok: true };
+  }
+  return params.collect
+    ? rejectChildAdmission(
+        "tools.swarm.maxChildrenPerGroup",
+        `sessions_spawn reached tools.swarm.maxChildrenPerGroup (${params.activeChildren}/${params.maxActiveChildren}).`,
+      )
+    : rejectChildAdmission(
+        "subagents.maxChildrenPerAgent",
+        `sessions_spawn has reached max active children for this session (${params.activeChildren}/${params.maxActiveChildren}; agents.defaults.subagents.maxChildrenPerAgent).`,
+      );
+}

--- a/src/agents/spawn-plan.admission.test.ts
+++ b/src/agents/spawn-plan.admission.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { resolveChildAdmission, type ChildAdmissionCap } from "./child-admission.js";
+
+type AdmissionParams = Parameters<typeof resolveChildAdmission>[0];
+type AnnounceAdmissionParams = Extract<AdmissionParams, { collect: false }>;
+type CollectorAdmissionParams = Extract<AdmissionParams, { collect: true }>;
+
+const announce = (
+  overrides: Partial<Omit<AnnounceAdmissionParams, "collect">> = {},
+): AnnounceAdmissionParams => ({
+  collect: false,
+  callerDepth: 0,
+  maxSpawnDepth: 2,
+  activeChildren: 0,
+  maxActiveChildren: 5,
+  ...overrides,
+});
+
+const collector = (
+  overrides: Partial<Omit<CollectorAdmissionParams, "collect">> = {},
+): CollectorAdmissionParams => ({
+  collect: true,
+  callerDepth: 0,
+  maxSpawnDepth: 2,
+  activeChildren: 0,
+  maxActiveChildren: 50,
+  totalChildren: 0,
+  maxTotalChildren: 200,
+  ...overrides,
+});
+
+const cases: Array<{
+  name: string;
+  params: AdmissionParams;
+  governingCap?: ChildAdmissionCap;
+}> = [
+  { name: "announce below depth", params: announce({ callerDepth: 1 }) },
+  {
+    name: "announce at depth",
+    params: announce({ callerDepth: 2 }),
+    governingCap: "subagents.maxSpawnDepth",
+  },
+  { name: "collector below depth", params: collector({ callerDepth: 1 }) },
+  {
+    name: "collector at depth",
+    params: collector({ callerDepth: 2 }),
+    governingCap: "subagents.maxSpawnDepth",
+  },
+  { name: "announce below session cap", params: announce({ activeChildren: 4 }) },
+  {
+    name: "announce at session cap",
+    params: announce({ activeChildren: 5 }),
+    governingCap: "subagents.maxChildrenPerAgent",
+  },
+  { name: "collector below live group cap", params: collector({ activeChildren: 49 }) },
+  {
+    name: "collector at live group cap",
+    params: collector({ activeChildren: 50 }),
+    governingCap: "tools.swarm.maxChildrenPerGroup",
+  },
+  { name: "collector below lifetime group cap", params: collector({ totalChildren: 199 }) },
+  {
+    name: "collector at lifetime group cap",
+    params: collector({ totalChildren: 200 }),
+    governingCap: "tools.swarm.maxTotalPerGroup",
+  },
+];
+
+describe("resolveChildAdmission", () => {
+  it.each(cases)("decides $name", ({ params, governingCap }) => {
+    const result = resolveChildAdmission(params);
+
+    if (!governingCap) {
+      expect(result).toEqual({ ok: true });
+      return;
+    }
+    expect(result).toMatchObject({ ok: false, governingCap });
+    if (!result.ok) {
+      expect(result.error).toContain(governingCap);
+    }
+  });
+});

--- a/src/agents/spawn-plan.ts
+++ b/src/agents/spawn-plan.ts
@@ -19,6 +19,7 @@ import {
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { getSessionBindingService } from "../infra/outbound/session-binding-service.js";
 import { resolveAgentConfig } from "./agent-scope.js";
+import { resolveChildAdmission, type ChildAdmissionCap } from "./child-admission.js";
 import { resolveSubagentCapabilities } from "./subagent-capabilities.js";
 import { getSubagentDepthFromSessionStore } from "./subagent-depth.js";
 import { countActiveRunsForSession } from "./subagent-registry.js";
@@ -280,6 +281,12 @@ export function prepareSpawnThreadBinding(params: {
 export function resolveSpawnAdmission(params: {
   cfg: OpenClawConfig;
   enabled?: boolean;
+  collector?: {
+    liveChildren: number;
+    totalChildren: number;
+    maxChildrenPerGroup: number;
+    maxTotalPerGroup: number;
+  };
   requesterSessionKey: string;
   requesterAgentId: string;
   targetAgentId: string;
@@ -289,7 +296,6 @@ export function resolveSpawnAdmission(params: {
 }):
   | {
       ok: true;
-      callerDepth?: number;
       maxSpawnDepth?: number;
       childSessionPatch?: {
         spawnDepth: number;
@@ -297,7 +303,7 @@ export function resolveSpawnAdmission(params: {
         subagentControlScope: "children" | "none";
       };
     }
-  | { ok: false; error: string } {
+  | { ok: false; governingCap?: ChildAdmissionCap; error: string } {
   if (params.enabled === false) {
     return { ok: true };
   }
@@ -306,22 +312,28 @@ export function resolveSpawnAdmission(params: {
   });
   const maxSpawnDepth =
     params.cfg.agents?.defaults?.subagents?.maxSpawnDepth ?? DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH;
-  if (callerDepth >= maxSpawnDepth) {
-    return {
-      ok: false,
-      error: `sessions_spawn is not allowed at this depth (current depth: ${callerDepth}, max: ${maxSpawnDepth})`,
-    };
-  }
-  const maxChildren =
-    params.cfg.agents?.defaults?.subagents?.maxChildrenPerAgent ??
-    DEFAULT_SUBAGENT_MAX_CHILDREN_PER_AGENT;
-  const activeChildren =
-    countActiveRunsForSession(params.requesterSessionKey) + (params.additionalActiveChildren ?? 0);
-  if (activeChildren >= maxChildren) {
-    return {
-      ok: false,
-      error: `sessions_spawn has reached max active children for this session (${activeChildren}/${maxChildren})`,
-    };
+  const collector = params.collector;
+  const childAdmission = resolveChildAdmission({
+    callerDepth,
+    maxSpawnDepth,
+    activeChildren:
+      collector?.liveChildren ??
+      countActiveRunsForSession(params.requesterSessionKey, { collect: false }) +
+        (params.additionalActiveChildren ?? 0),
+    maxActiveChildren:
+      collector?.maxChildrenPerGroup ??
+      params.cfg.agents?.defaults?.subagents?.maxChildrenPerAgent ??
+      DEFAULT_SUBAGENT_MAX_CHILDREN_PER_AGENT,
+    ...(collector
+      ? {
+          collect: true,
+          totalChildren: collector.totalChildren,
+          maxTotalChildren: collector.maxTotalPerGroup,
+        }
+      : { collect: false }),
+  });
+  if (!childAdmission.ok) {
+    return childAdmission;
   }
   const requesterSubagentConfig = resolveAgentConfig(
     params.cfg,
@@ -355,7 +367,6 @@ export function resolveSpawnAdmission(params: {
   });
   return {
     ok: true,
-    callerDepth,
     maxSpawnDepth,
     childSessionPatch: {
       spawnDepth: capabilities.depth,

--- a/src/agents/spawn-plan.ts
+++ b/src/agents/spawn-plan.ts
@@ -313,25 +313,29 @@ export function resolveSpawnAdmission(params: {
   const maxSpawnDepth =
     params.cfg.agents?.defaults?.subagents?.maxSpawnDepth ?? DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH;
   const collector = params.collector;
-  const childAdmission = resolveChildAdmission({
-    callerDepth,
-    maxSpawnDepth,
-    activeChildren:
-      collector?.liveChildren ??
-      countActiveRunsForSession(params.requesterSessionKey, { collect: false }) +
-        (params.additionalActiveChildren ?? 0),
-    maxActiveChildren:
-      collector?.maxChildrenPerGroup ??
-      params.cfg.agents?.defaults?.subagents?.maxChildrenPerAgent ??
-      DEFAULT_SUBAGENT_MAX_CHILDREN_PER_AGENT,
-    ...(collector
-      ? {
-          collect: true,
-          totalChildren: collector.totalChildren,
-          maxTotalChildren: collector.maxTotalPerGroup,
-        }
-      : { collect: false }),
-  });
+  // Build each mode's params in its own branch so collector counts can never
+  // pair with the announce cap (or vice versa) through fallback chaining.
+  const childAdmission = collector
+    ? resolveChildAdmission({
+        callerDepth,
+        maxSpawnDepth,
+        collect: true,
+        activeChildren: collector.liveChildren,
+        maxActiveChildren: collector.maxChildrenPerGroup,
+        totalChildren: collector.totalChildren,
+        maxTotalChildren: collector.maxTotalPerGroup,
+      })
+    : resolveChildAdmission({
+        callerDepth,
+        maxSpawnDepth,
+        collect: false,
+        activeChildren:
+          countActiveRunsForSession(params.requesterSessionKey, { collect: false }) +
+          (params.additionalActiveChildren ?? 0),
+        maxActiveChildren:
+          params.cfg.agents?.defaults?.subagents?.maxChildrenPerAgent ??
+          DEFAULT_SUBAGENT_MAX_CHILDREN_PER_AGENT,
+      });
   if (!childAdmission.ok) {
     return childAdmission;
   }

--- a/src/agents/subagent-registry-queries.test.ts
+++ b/src/agents/subagent-registry-queries.test.ts
@@ -135,6 +135,26 @@ describe("subagent registry query regressions", () => {
     expect(countActiveRunsForSessionFromRuns(runs, "agent:main:main")).toBe(0);
   });
 
+  it("filters collector children out of announce admission counts", () => {
+    const owner = "agent:main:main";
+    const runs = toRunMap(
+      Array.from({ length: 50 }, (_, index) =>
+        makeRun({
+          runId: `collector-${index}`,
+          childSessionKey: `agent:worker:subagent:collector-${index}`,
+          requesterSessionKey: owner,
+          collect: true,
+          swarmRequesterSessionKey: owner,
+          createdAt: Date.now(),
+          execution: { status: "running", startedAt: Date.now() },
+        }),
+      ),
+    );
+
+    expect(countActiveRunsForSessionFromRuns(runs, owner)).toBe(50);
+    expect(countActiveRunsForSessionFromRuns(runs, owner, { collect: false })).toBe(0);
+  });
+
   it("does not count stale unended descendants as pending work", () => {
     const now = Date.now();
     const parentSessionKey = "agent:main:subagent:parent-stale-desc";

--- a/src/agents/subagent-registry-queries.ts
+++ b/src/agents/subagent-registry-queries.ts
@@ -378,6 +378,7 @@ export function shouldIgnorePostCompletionAnnounceForSessionFromRuns(
 export function countActiveRunsForSessionFromRuns(
   runs: Map<string, SubagentRunRecord>,
   controllerSessionKey: string,
+  options?: { collect?: boolean },
 ): number {
   const key = controllerSessionKey.trim();
   if (!key) {
@@ -395,7 +396,12 @@ export function countActiveRunsForSessionFromRuns(
   };
 
   const latestByChildSessionKey = new Map<string, SubagentRunRecord>();
+  // Records already carry collect, and spawn admission is not request-hot, so a
+  // filtered snapshot is simpler than maintaining a second registry index.
   for (const entry of runs.values()) {
+    if (options?.collect !== undefined && (entry.collect === true) !== options.collect) {
+      continue;
+    }
     if (resolveConcurrencyOwnerSessionKey(entry) !== key) {
       continue;
     }

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -2549,10 +2549,14 @@ export function getSwarmRunByLaunchReplayKey(
   );
 }
 
-export function countActiveRunsForSession(requesterSessionKey: string): number {
+export function countActiveRunsForSession(
+  requesterSessionKey: string,
+  options?: { collect?: boolean },
+): number {
   return countActiveRunsForSessionFromRuns(
     subagentRegistryDeps.getSubagentRunsSnapshotForRead(subagentRuns),
     requesterSessionKey,
+    options,
   );
 }
 

--- a/src/agents/subagent-spawn.depth-limits.test.ts
+++ b/src/agents/subagent-spawn.depth-limits.test.ts
@@ -109,7 +109,22 @@ describe("subagent spawn depth + child limits", () => {
 
     expectForbidden(
       result,
-      "sessions_spawn is not allowed at this depth (current depth: 1, max: 1)",
+      "sessions_spawn is not allowed at this depth (current depth: 1, max: 1; agents.defaults.subagents.maxSpawnDepth).",
+    );
+  });
+
+  it("checks depth before collector group validation", async () => {
+    hoisted.configOverride = {
+      ...createDepthLimitConfig(),
+      tools: { swarm: { enabled: true } },
+    };
+    hoisted.depthBySession.set("agent:main:subagent:parent", 1);
+
+    const result = await spawnFrom("agent:main:subagent:parent", { collect: true });
+
+    expectForbidden(
+      result,
+      "sessions_spawn is not allowed at this depth (current depth: 1, max: 1; agents.defaults.subagents.maxSpawnDepth).",
     );
   });
 
@@ -167,7 +182,7 @@ describe("subagent spawn depth + child limits", () => {
 
     expectForbidden(
       result,
-      "sessions_spawn is not allowed at this depth (current depth: 2, max: 2)",
+      "sessions_spawn is not allowed at this depth (current depth: 2, max: 2; agents.defaults.subagents.maxSpawnDepth).",
     );
   });
 
@@ -183,7 +198,7 @@ describe("subagent spawn depth + child limits", () => {
 
     expectForbidden(
       result,
-      "sessions_spawn has reached max active children for this session (1/1)",
+      "sessions_spawn has reached max active children for this session (1/1; agents.defaults.subagents.maxChildrenPerAgent).",
     );
   });
 

--- a/src/agents/subagent-spawn.test.ts
+++ b/src/agents/subagent-spawn.test.ts
@@ -650,49 +650,59 @@ describe("spawnSubagentDirect seam flow", () => {
     expect(hoisted.registerSubagentRunMock).toHaveBeenCalledTimes(1);
   });
 
-  it("retains the requester-wide active-child ceiling for collector groups", async () => {
+  it("admits a sixth live collector under the swarm group cap", async () => {
     hoisted.configOverride = createConfigOverride({
-      tools: { swarm: true },
+      tools: { swarm: { enabled: true, maxChildrenPerGroup: 6 } },
       agents: {
         defaults: {
           workspace: os.tmpdir(),
-          subagents: { maxChildrenPerAgent: 1 },
+          subagents: { maxChildrenPerAgent: 5 },
         },
         list: [{ id: "main", workspace: "/tmp/workspace-main" }],
       },
     });
-    hoisted.countActiveRunsForSessionMock.mockReturnValue(1);
+    hoisted.countActiveRunsForSessionMock.mockReturnValue(5);
+    hoisted.listSwarmRunsForGroupMock.mockReturnValue(
+      Array.from({ length: 5 }, (_, index) => ({
+        runId: `collector-${index}`,
+        collect: true,
+        execution: { status: "running" },
+      })),
+    );
 
-    const rejected = await spawnSubagentDirect(
-      { task: "new group", collect: true, groupId: "fresh" },
+    const accepted = await spawnSubagentDirect(
+      { task: "sixth collector", collect: true, groupId: "fresh" },
       { agentSessionKey: "agent:main:main", requesterRunId: "parent-run" },
     );
 
-    expect(rejected.status).toBe("forbidden");
-    expect(rejected.error).toContain("max active children");
+    expect(accepted.status).toBe("accepted");
+    expect(hoisted.countActiveRunsForSessionMock).not.toHaveBeenCalled();
   });
 
-  it("rechecks the requester-wide cap before reserving a prepared collector", async () => {
+  it("admits an announce child when 50 collectors are active", async () => {
     hoisted.configOverride = createConfigOverride({
-      tools: { swarm: true },
       agents: {
         defaults: {
           workspace: os.tmpdir(),
-          subagents: { maxChildrenPerAgent: 1 },
+          subagents: { maxChildrenPerAgent: 5 },
         },
         list: [{ id: "main", workspace: "/tmp/workspace-main" }],
       },
     });
-    hoisted.countActiveRunsForSessionMock.mockReturnValueOnce(0).mockReturnValueOnce(1);
-
-    const rejected = await spawnSubagentDirect(
-      { task: "concurrent collector", collect: true, groupId: "fresh" },
-      { agentSessionKey: "agent:main:main", requesterRunId: "parent-run" },
+    hoisted.countActiveRunsForSessionMock.mockImplementation(
+      (_sessionKey: string, options?: { collect?: boolean }) =>
+        options?.collect === false ? 0 : 50,
     );
 
-    expect(rejected.status).toBe("forbidden");
-    expect(rejected.error).toContain("max active children");
-    expect(hoisted.registerSubagentRunMock).not.toHaveBeenCalled();
+    const accepted = await spawnSubagentDirect(
+      { task: "announce independently" },
+      { agentSessionKey: "agent:main:main" },
+    );
+
+    expect(accepted.status).toBe("accepted");
+    expect(hoisted.countActiveRunsForSessionMock).toHaveBeenCalledWith("agent:main:main", {
+      collect: false,
+    });
   });
 
   it("rejects invalid collector output schemas before creating a child session", async () => {

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -1116,57 +1116,56 @@ export async function spawnSubagentDirect(
   }
   const targetAgentId = requestedAgentId ? normalizeAgentId(requestedAgentId) : requesterAgentId;
   const configuredAgentIds = resolveConfiguredAgentIds(cfg);
-  const resolveAdmission = () =>
-    resolveSpawnAdmission({
+  const explicitSwarmGroupId = normalizeOptionalString(params.groupId);
+  const requesterRunId = normalizeOptionalString(ctx.requesterRunId);
+  const swarmGroupId = params.collect
+    ? (explicitSwarmGroupId ??
+      (requesterRunId ? `swarm:${requesterInternalKey}:${requesterRunId}` : undefined))
+    : undefined;
+  const swarmSchedulerGroupKey = swarmGroupId
+    ? JSON.stringify([requesterInternalKey, swarmGroupId])
+    : undefined;
+  const resolveAdmission = () => {
+    const collectorRuns = params.collect
+      ? swarmGroupId
+        ? listSwarmRunsForGroup(swarmGroupId, requesterInternalKey)
+        : []
+      : undefined;
+    return resolveSpawnAdmission({
       cfg,
+      collector: collectorRuns
+        ? {
+            liveChildren: collectorRuns.filter((entry) => !entry.collectorCompletion).length,
+            totalChildren: collectorRuns.length,
+            maxChildrenPerGroup: swarmConfig.maxChildrenPerGroup,
+            maxTotalPerGroup: swarmConfig.maxTotalPerGroup,
+          }
+        : undefined,
       requesterSessionKey: requesterInternalKey,
       requesterAgentId,
       targetAgentId,
       requestedAgentId,
       configuredAgentIds,
     });
+  };
   const admission = resolveAdmission();
   if (!admission.ok) {
     return {
       status: "forbidden",
-      error: usingDefaultAgentId
-        ? `tools.swarm.defaultAgentId is unavailable: ${admission.error}`
-        : admission.error,
+      error:
+        usingDefaultAgentId && !admission.governingCap?.startsWith("tools.swarm.")
+          ? `tools.swarm.defaultAgentId is unavailable: ${admission.error}`
+          : admission.error,
     };
   }
-  const childDepth = admission.childSessionPatch?.spawnDepth ?? 1;
-  const maxSpawnDepth = admission.maxSpawnDepth ?? childDepth;
-  const explicitSwarmGroupId = normalizeOptionalString(params.groupId);
-  const requesterRunId = normalizeOptionalString(ctx.requesterRunId);
-  if (params.collect && !explicitSwarmGroupId && !requesterRunId) {
+  if (params.collect && !swarmGroupId) {
     return {
       status: "error",
       error: "sessions_spawn collect=true requires a requesting run id when groupId is omitted.",
     };
   }
-  const swarmGroupId = params.collect
-    ? (explicitSwarmGroupId ?? `swarm:${requesterInternalKey}:${requesterRunId}`)
-    : undefined;
-  const swarmSchedulerGroupKey = swarmGroupId
-    ? JSON.stringify([requesterInternalKey, swarmGroupId])
-    : undefined;
-  const resolveSwarmCapError = () => {
-    if (!swarmGroupId) {
-      return undefined;
-    }
-    const groupRuns = listSwarmRunsForGroup(swarmGroupId, requesterInternalKey);
-    if (groupRuns.length >= swarmConfig.maxTotalPerGroup) {
-      return `sessions_spawn reached tools.swarm.maxTotalPerGroup (${groupRuns.length}/${swarmConfig.maxTotalPerGroup}).`;
-    }
-    const liveRuns = groupRuns.filter((entry) => !entry.collectorCompletion);
-    return liveRuns.length >= swarmConfig.maxChildrenPerGroup
-      ? `sessions_spawn reached tools.swarm.maxChildrenPerGroup (${liveRuns.length}/${swarmConfig.maxChildrenPerGroup}).`
-      : undefined;
-  };
-  const initialSwarmCapError = resolveSwarmCapError();
-  if (initialSwarmCapError) {
-    return { status: "forbidden", error: initialSwarmCapError };
-  }
+  const childDepth = admission.childSessionPatch?.spawnDepth ?? 1;
+  const maxSpawnDepth = admission.maxSpawnDepth ?? childDepth;
   const swarmLaunchReplayKey = normalizeOptionalString(params.swarmLaunchReplayKey);
   // Registry and Gateway identities are global, while host replay keys are requester-scoped.
   const childIdem = swarmLaunchReplayKey
@@ -1719,10 +1718,10 @@ export async function spawnSubagentDirect(
       buildRegistration: (_state, runId) => {
         if (params.collect) {
           const latestAdmission = resolveAdmission();
-          const latestCapError =
-            (latestAdmission.ok ? undefined : latestAdmission.error) ?? resolveSwarmCapError();
-          if (latestCapError) {
-            throw Object.assign(new Error(latestCapError), { spawnStatus: "forbidden" as const });
+          if (!latestAdmission.ok) {
+            throw Object.assign(new Error(latestAdmission.error), {
+              spawnStatus: "forbidden" as const,
+            });
           }
         }
         return {

--- a/src/agents/tools/sessions-spawn-visible.ts
+++ b/src/agents/tools/sessions-spawn-visible.ts
@@ -245,7 +245,10 @@ export async function maybeSpawnVisibleSession(params: {
   const reservation = reserveVisibleChildSlot({
     controllerSessionKey: requesterKey,
     maxChildren,
-    countActiveRuns: params.options?.countActiveRuns ?? countActiveRunsForSession,
+    countActiveRuns: (sessionKey) =>
+      (params.options?.countActiveRuns ?? countActiveRunsForSession)(sessionKey, {
+        collect: false,
+      }),
   });
   if (!reservation.ok) {
     return {


### PR DESCRIPTION
Closes #111401

## What Problem This Solves

Fixes an issue where Labs-gated Swarm fan-outs were rejected by the legacy five-child conversational cap before their configured Swarm group caps could admit them. The conflict was found live in the #110325 E2E, where the sixth collector was rejected despite Swarm advertising support for up to 50 children.

## Why This Change Was Made

Every child now has a single admission owner selected by completion mode. Announce children remain governed by `agents.defaults.subagents.maxChildrenPerAgent`, counting only non-collector children; collector children are governed solely by `tools.swarm` group caps. Depth remains universal. A closed admission decision module replaces scattered checks, and per-mode gather branches prevent cross-mode cap pairing.

## User Impact

Labs-gated Swarm fan-outs now honor their configured group caps. Announce behavior is unchanged, and rejection errors name the governing configuration key.

The caps section in `docs/tools/swarm.md` now documents the two admission owners and the universal depth guard.

## Evidence

- Table-driven 10-case admission matrix covering announce, collector, and depth outcomes.
- Regression proving a sixth collector is admitted.
- Regression proving an interactive spawn remains admitted with 50 existing collectors.
- Focused post-rebase proof: 90 tests passed across admission, spawn, depth-limit, registry-query, and Swarm integration suites.
- `pnpm ui:build` passed, including precompressed asset and Control UI performance checks.
- `pnpm format` completed with no diff; `git diff --check` clean.
- Production LOC note: +71 production lines are justified by the closed decision-point module replacing scattered checks.
