### PR TITLE
fix(qa): restore private self-check after inbound refactor

### DIFF
--- a/extensions/qa-lab/src/harness-runtime.integration.test.ts
+++ b/extensions/qa-lab/src/harness-runtime.integration.test.ts
@@ -1,0 +1,78 @@
+// Qa Lab integration tests cover the real QA Channel runtime contract.
+import { qaChannelPlugin, setQaChannelRuntime } from "@openclaw/qa-channel/api.js";
+import { describe, expect, it, vi } from "vitest";
+import { startQaBusServer } from "./bus-server.js";
+import { createQaBusState } from "./bus-state.js";
+import { createQaRunnerRuntime } from "./harness-runtime.js";
+import { createQaChannelGatewayConfig } from "./qa-channel-transport.js";
+
+describe("QA runner runtime integration", () => {
+  it("dispatches a QA Channel inbound turn through the embedded runner", async () => {
+    const state = createQaBusState();
+    const bus = await startQaBusServer({ state });
+    const runtime = createQaRunnerRuntime();
+    setQaChannelRuntime(runtime);
+    const config = createQaChannelGatewayConfig({ baseUrl: bus.baseUrl });
+    const account = qaChannelPlugin.config.resolveAccount(config, "default");
+    const abort = new AbortController();
+    const startAccount = qaChannelPlugin.gateway?.startAccount;
+    if (!startAccount) {
+      throw new Error("QA Channel gateway is unavailable");
+    }
+    const gatewayTask = startAccount({
+      accountId: account.accountId,
+      account,
+      cfg: config,
+      runtime: {
+        log: () => undefined,
+        error: () => undefined,
+        exit: () => undefined,
+      },
+      abortSignal: abort.signal,
+      log: {
+        info: () => undefined,
+        warn: () => undefined,
+        error: () => undefined,
+        debug: () => undefined,
+      },
+      getStatus: () => ({
+        accountId: account.accountId,
+        configured: true,
+        enabled: true,
+        running: true,
+      }),
+      setStatus: () => undefined,
+    });
+
+    try {
+      state.addInboundMessage({
+        accountId: "default",
+        conversation: { kind: "direct", id: "alice" },
+        senderId: "alice",
+        senderName: "Alice",
+        text: "ping",
+      });
+
+      await Promise.race([
+        vi.waitFor(
+          () => {
+            expect(state.getSnapshot().messages).toContainEqual(
+              expect.objectContaining({ direction: "outbound", text: "qa-echo: ping" }),
+            );
+          },
+          { interval: 25, timeout: 2_000 },
+        ),
+        gatewayTask.then(() => {
+          throw new Error("QA Channel gateway stopped before delivering the turn");
+        }),
+      ]);
+    } finally {
+      abort.abort();
+      try {
+        await gatewayTask;
+      } finally {
+        await bus.stop();
+      }
+    }
+  });
+});

--- a/extensions/qa-lab/src/harness-runtime.ts
+++ b/extensions/qa-lab/src/harness-runtime.ts
@@ -15,6 +15,19 @@ type SessionRecord = {
 
 export function createQaRunnerRuntime(): PluginRuntime {
   const sessions = new Map<string, SessionRecord>();
+  const dispatchReplyWithBufferedBlockDispatcher: PluginRuntime["channel"]["reply"]["dispatchReplyWithBufferedBlockDispatcher"] =
+    async ({ ctx, dispatcherOptions }) => {
+      await dispatcherOptions.deliver(
+        {
+          text: `qa-echo: ${ctx.BodyForAgent ?? ctx.Body ?? ""}`,
+        },
+        { kind: "final" },
+      );
+      return {
+        queuedFinal: false,
+        counts: { tool: 0, block: 0, final: 1 },
+      };
+    };
   return {
     channel: {
       routing: {
@@ -73,39 +86,28 @@ export function createQaRunnerRuntime(): PluginRuntime {
         finalizeInboundContext(ctx: Record<string, unknown>) {
           return ctx as typeof ctx & { CommandAuthorized: boolean };
         },
-        async dispatchReplyWithBufferedBlockDispatcher({
-          ctx,
-          dispatcherOptions,
-        }: {
-          ctx: { BodyForAgent?: string; Body?: string };
-          dispatcherOptions: { deliver: (payload: { text: string }) => Promise<void> };
-        }) {
-          await dispatcherOptions.deliver({
-            text: `qa-echo: ${ctx.BodyForAgent ?? ctx.Body ?? ""}`,
-          });
-        },
+        dispatchReplyWithBufferedBlockDispatcher,
       },
       inbound: {
-        async dispatchReply(
-          params: Parameters<PluginRuntime["channel"]["inbound"]["dispatchReply"]>[0],
-        ) {
+        async dispatch(params: Parameters<PluginRuntime["channel"]["inbound"]["dispatch"]>[0]) {
           const sessionKey =
             typeof params.ctxPayload.SessionKey === "string"
               ? params.ctxPayload.SessionKey
-              : params.routeSessionKey;
-          await params.recordInboundSession({
-            storePath: params.storePath,
+              : params.route.sessionKey;
+          sessions.set(sessionKey, {
             sessionKey,
-            ctx: params.ctxPayload,
-            onRecordError: params.record?.onRecordError ?? (() => undefined),
+            body: params.ctxPayload.BodyForAgent ?? params.ctxPayload.Body ?? "",
           });
-          const dispatchResult = await params.dispatchReplyWithBufferedBlockDispatcher({
+          const delivery =
+            params.admission?.kind === "observeOnly"
+              ? async () => ({ visibleReplySent: false })
+              : params.delivery.deliver;
+          const dispatchResult = await dispatchReplyWithBufferedBlockDispatcher({
             ctx: params.ctxPayload,
             cfg: params.cfg,
             dispatcherOptions: {
-              ...params.dispatcherOptions,
               deliver: async (payload, info) => {
-                await params.delivery.deliver(payload, info);
+                await delivery(payload, info);
               },
               onError: params.delivery.onError,
             },
@@ -116,7 +118,7 @@ export function createQaRunnerRuntime(): PluginRuntime {
             admission: params.admission ?? { kind: "dispatch" },
             dispatched: true,
             ctxPayload: params.ctxPayload,
-            routeSessionKey: params.routeSessionKey,
+            routeSessionKey: params.route.sessionKey,
             dispatchResult,
           };
         },


### PR DESCRIPTION
Closes #111484

## What Problem This Solves

Fixes an issue where developers running the packaged private `openclaw qa run` self-check would hit an unhandled `runtime.channel.inbound.dispatch is not a function` rejection on the first synthetic inbound turn after the channel ingress refactor.

## Why This Change Was Made

QA Channel moved to the canonical channel-owned `inbound.dispatch` plan, but QA Lab's deterministic runner still implemented only the retired assembled-context `dispatchReply` seam. This updates the runner at its ownership boundary, removes the stale path, preserves deterministic session recording and observe-only delivery behavior, and returns a correctly typed final-dispatch result.

The regression test crosses the real plugin boundary: it starts the QA bus, installs the QA Lab runner through QA Channel's public API, launches the real QA Channel gateway account, injects an inbound user message, and requires the outbound deterministic echo. It does not substitute the general runtime mock that hid the drift.

## User Impact

Developers and CI can use the bundled private QA self-check again, so the normal user-path smoke gate reaches a live channel turn instead of crashing before dispatch.

## Evidence

- Before: the packaged command failed on every observed run with `TypeError: runtime.channel.inbound.dispatch is not a function`; the original Linux reproduction is in [Actions run 29694065624](https://github.com/openclaw/openclaw/actions/runs/29694065624).
- After: a private QA build completed, then `qa run` used isolated state and config directories, exited successfully, and wrote its QA self-check report without an unhandled rejection ([Blacksmith proof](https://github.com/openclaw/openclaw/actions/runs/29698359446)).
- Exact post-rebase focused proof: 17/17 QA Lab integration and server tests passed, including the new real QA Channel inbound roundtrip ([Blacksmith proof](https://github.com/openclaw/openclaw/actions/runs/29698804201)).
- `pnpm check:changed` passed the extension production/test typechecks, focused lint, formatting, plugin boundaries, Plugin SDK API baseline, database-first guard, and runtime import-cycle gate.
- `git diff --check` passed.
- Autoreview completed with no accepted or actionable findings. A claim that `inbound.dispatch` is absent was rejected against the current runtime type, implementation, QA Channel caller, successful extension typecheck, and live integration proof.

AI-assisted; the implementation and validation evidence were reviewed against the current source and the inbound-refactor history.
