### PR TITLE
feat(gateway): allow explicit operator.admin in device auto-approval with critical audit finding

### DIFF
--- a/docs/gateway/trusted-proxy-auth.md
+++ b/docs/gateway/trusted-proxy-auth.md
@@ -124,7 +124,7 @@ Internal Gateway clients that do not travel through the reverse proxy should use
   Automatically approve new Control UI and WebChat device identities after trusted-proxy authentication.
 </ParamField>
 <ParamField path="gateway.auth.trustedProxy.deviceAutoApprove.scopes" type="string[]" default='["operator.read", "operator.write", "operator.approvals"]'>
-  Maximum scopes granted to an auto-approved browser device. `operator.admin` is not allowed.
+  Maximum scopes granted to an auto-approved browser device. Explicitly listing `operator.admin` lets every proxy-authenticated user request an automatic full-admin device grant, makes scope-less requests receive full admin automatically, and triggers the CRITICAL `gateway.trusted_proxy_device_auto_approve_admin` security audit finding plus a Gateway startup warning.
 </ParamField>
 
 <Warning>
@@ -158,10 +158,10 @@ The default is `enabled: false`. When enabled, all of these rules apply:
 1. The WebSocket must have authenticated through the `trusted-proxy` method with a non-empty user identity that passed `allowUsers` when an allowlist is configured. Token, password, Tailscale, and unauthenticated connections never use this policy.
 2. Only a new Control UI or WebChat browser device can be approved automatically. Any request for an existing device, including a scope upgrade, remains pending for manual approval with `openclaw devices approve <requestId>`.
 3. The device is approved with role `operator`. If the connect request includes scopes, the grant is the exact intersection of the requested scopes and `deviceAutoApprove.scopes`. If the request omits scopes, the configured list is granted; when that list is omitted, it defaults to `operator.read`, `operator.write`, and `operator.approvals`. The resulting grant is then additionally capped by the connection's [`x-openclaw-scopes`](#control-ui-pairing-behavior) proxy header when present, so a proxy that narrows a user's scopes also limits the **persistent** device grant, not just the session — a present-but-empty header yields no scopes. This cap applies even when the client omits its own scope list.
-4. `operator.admin` cannot appear in `deviceAutoApprove.scopes`; configuration validation rejects it. Grant admin access manually with `openclaw devices approve` or `openclaw devices rotate`.
+4. `operator.admin` is allowed only through explicit listing in `deviceAutoApprove.scopes`. When listed, every proxy-authenticated user can request and automatically receive full admin on a new browser device; requests without scopes receive full admin automatically. `openclaw security audit` reports the CRITICAL `gateway.trusted_proxy_device_auto_approve_admin` finding, and the Gateway logs a warning once at startup. Prefer manual admin approval with `openclaw devices approve` or `openclaw devices rotate` until per-identity roles are available.
 
 <Warning>
-Enabling this option delegates new browser device enrollment entirely to the reverse-proxy identity. A compromised proxy account can enroll a persistent device with every configured scope. Keep the Gateway reachable only through the proxy, require strong proxy authentication, overwrite identity headers, and use a narrow `allowUsers` list.
+Enabling this option delegates new browser device enrollment entirely to the reverse-proxy identity. A compromised proxy account can enroll a persistent device with every configured scope. Listing `operator.admin` makes that device a full administrator without manual approval. Keep the Gateway reachable only through the proxy, require strong proxy authentication, overwrite identity headers, and use a narrow `allowUsers` list.
 </Warning>
 
 ## Control UI pairing behavior

--- a/src/config/schema.help.core.ts
+++ b/src/config/schema.help.core.ts
@@ -155,7 +155,7 @@ export const CORE_FIELD_HELP: Record<string, string> = {
   "gateway.auth.trustedProxy.deviceAutoApprove.enabled":
     "Automatically approves new browser device identities after the reverse proxy authenticates an allowed user. Default: false. Enable only when the proxy identity boundary is strong enough to replace manual device pairing.",
   "gateway.auth.trustedProxy.deviceAutoApprove.scopes":
-    "Maximum scopes granted to auto-approved browser devices. Requested scopes are capped to this list; requests without scopes receive this list. operator.admin is rejected and must be approved manually.",
+    "Maximum scopes granted to auto-approved browser devices. Requested scopes are capped to this list; requests without scopes receive this list. Explicitly listing operator.admin lets every proxy-authenticated user auto-approve full admin and makes scope-less requests receive full admin automatically; it also triggers a critical security audit finding and Gateway startup warning.",
   "gateway.trustedProxies":
     "CIDR/IP allowlist of upstream proxies permitted to provide forwarded client identity headers. Keep this list narrow so untrusted hops cannot impersonate users.",
   "gateway.allowRealIpFallback":

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -206,8 +206,10 @@ export type GatewayTrustedProxyConfig = {
     /** Enable automatic approval for new browser devices. @default false */
     enabled?: boolean;
     /**
-     * Maximum operator scopes granted by automatic approval. operator.admin
-     * is intentionally forbidden. @default operator.read, operator.write,
+     * Maximum operator scopes granted by automatic approval. Listing
+     * operator.admin explicitly lets every proxy-authenticated user request
+     * automatic full-admin device grants. Requests without scopes receive the
+     * configured maximum. @default operator.read, operator.write,
      * operator.approvals
      */
     scopes?: string[];

--- a/src/config/zod-schema.gateway-auth.test.ts
+++ b/src/config/zod-schema.gateway-auth.test.ts
@@ -21,32 +21,25 @@ describe("gateway trusted-proxy device auto-approval config", () => {
     expect(result.success).toBe(true);
   });
 
-  test.each(["operator.admin", " operator.admin "])("rejects %j", (adminScope) => {
-    const result = OpenClawSchema.safeParse({
-      gateway: {
-        auth: {
-          mode: "trusted-proxy",
-          trustedProxy: {
-            userHeader: "x-forwarded-user",
-            deviceAutoApprove: {
-              enabled: true,
-              scopes: ["operator.read", adminScope],
+  test.each(["operator.admin", " operator.admin "])(
+    "accepts %j as an explicit admin opt-in",
+    (adminScope) => {
+      const result = OpenClawSchema.safeParse({
+        gateway: {
+          auth: {
+            mode: "trusted-proxy",
+            trustedProxy: {
+              userHeader: "x-forwarded-user",
+              deviceAutoApprove: {
+                enabled: true,
+                scopes: ["operator.read", adminScope],
+              },
             },
           },
         },
-      },
-    });
+      });
 
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(result.error.issues).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            path: ["gateway", "auth", "trustedProxy", "deviceAutoApprove", "scopes"],
-            message: expect.stringContaining("operator.admin is not allowed"),
-          }),
-        ]),
-      );
-    }
-  });
+      expect(result.success).toBe(true);
+    },
+  );
 });

--- a/src/config/zod-schema.gateway.ts
+++ b/src/config/zod-schema.gateway.ts
@@ -86,13 +86,7 @@ export const GatewayConfigSchema = z
             deviceAutoApprove: z
               .strictObject({
                 enabled: z.boolean().optional(),
-                scopes: z
-                  .array(z.string().min(1))
-                  .refine((scopes) => !scopes.some((scope) => scope.trim() === "operator.admin"), {
-                    message:
-                      "operator.admin is not allowed in trusted-proxy device auto-approval scopes; approve admin access manually",
-                  })
-                  .optional(),
+                scopes: z.array(z.string().min(1)).optional(),
               })
               .optional(),
           })

--- a/src/gateway/server.auth.trusted-proxy-device-autoapprove.test.ts
+++ b/src/gateway/server.auth.trusted-proxy-device-autoapprove.test.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { WebSocket } from "ws";
 import { PROTOCOL_VERSION } from "../../packages/gateway-protocol/src/index.js";
 import { writeConfigFile } from "../config/config.js";
@@ -11,6 +11,8 @@ import {
   signDevicePayload,
 } from "../infra/device-identity.js";
 import { getPairedDevice, listDevicePairing } from "../infra/device-pairing.js";
+import { resetLogger, setLoggerOverride } from "../logging.js";
+import { loggingState } from "../logging/state.js";
 import { buildDeviceAuthPayloadV3 } from "./device-auth.js";
 import { CONTROL_UI_CLIENT, NODE_CLIENT } from "./server.auth.test-helpers.js";
 import {
@@ -174,6 +176,64 @@ async function connectBrowserWithoutScopes(params: {
 }
 
 describe("trusted-proxy browser device auto-approval", () => {
+  test("auto-approves operator.admin and warns once at startup", async () => {
+    await writeGatewayAuthConfig({
+      mode: "trusted-proxy",
+      deviceAutoApprove: { enabled: true, scopes: ["operator.admin"] },
+    });
+    const identityPath = deviceIdentityPath("trusted-proxy-admin");
+    const identity = loadOrCreateDeviceIdentity({ path: identityPath });
+    const warnings: string[] = [];
+    loggingState.rawConsole = {
+      log: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn((message: string) => warnings.push(message)),
+      error: vi.fn(),
+    };
+    setLoggerOverride({ level: "silent", consoleLevel: "warn" });
+
+    try {
+      await withGatewayServer(async ({ port }) => {
+        const res = await connectBrowser({
+          port,
+          identityPath,
+          scopes: ["operator.admin"],
+        });
+        expect(res.ok).toBe(true);
+      });
+      await withGatewayServer(async () => {}, {
+        serverOptions: { auth: { mode: "token", token: "secret" } },
+      });
+    } finally {
+      loggingState.rawConsole = null;
+      resetLogger();
+    }
+
+    expect(
+      warnings.filter((message) =>
+        message.includes(
+          "SECURITY WARNING: gateway.auth.trustedProxy.deviceAutoApprove.scopes includes operator.admin; every proxy-authenticated user can auto-approve a new browser device with full admin, and requests without scopes receive full admin automatically. Remove operator.admin to require manual approval until per-identity roles are available.",
+        ),
+      ),
+    ).toHaveLength(1);
+    const paired = await getPairedDevice(identity.deviceId);
+    expect(paired?.approvedScopes).toEqual(["operator.admin"]);
+    expect(paired?.tokens?.operator?.scopes).toEqual([
+      "operator.admin",
+      "operator.read",
+      "operator.write",
+    ]);
+    expect(paired?.approvedVia).toBe("trusted-proxy");
+
+    expect(
+      warnings.filter((message) =>
+        message.includes(
+          "SECURITY WARNING: gateway.auth.trustedProxy.deviceAutoApprove.scopes includes operator.admin",
+        ),
+      ),
+    ).toHaveLength(1);
+  });
+
   test("auto-approves a new browser device with the default scopes", async () => {
     await writeGatewayAuthConfig({
       mode: "trusted-proxy",

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -726,6 +726,18 @@ export async function startGatewayServer(
   if (authBootstrap.generatedToken) {
     log.warn(formatRuntimeGatewayAuthTokenWarning());
   }
+  // prepareGatewayStartupConfig has already applied startupAuthOverride to cfgAtStart,
+  // so this warning follows the effective auth mode rather than dormant file config.
+  const trustedProxyDeviceAutoApprove = cfgAtStart.gateway?.auth?.trustedProxy?.deviceAutoApprove;
+  if (
+    cfgAtStart.gateway?.auth?.mode === "trusted-proxy" &&
+    trustedProxyDeviceAutoApprove?.enabled === true &&
+    trustedProxyDeviceAutoApprove.scopes?.some((scope) => scope.trim() === ADMIN_SCOPE)
+  ) {
+    log.warn(
+      "SECURITY WARNING: gateway.auth.trustedProxy.deviceAutoApprove.scopes includes operator.admin; every proxy-authenticated user can auto-approve a new browser device with full admin, and requests without scopes receive full admin automatically. Remove operator.admin to require manual approval until per-identity roles are available.",
+    );
+  }
   const resolvedStartupAuthOverride = startupAuthOverride
     ? (Object.fromEntries(
         (

--- a/src/security/audit-gateway-config.ts
+++ b/src/security/audit-gateway-config.ts
@@ -384,6 +384,22 @@ export function collectGatewayConfigFindings(
         remediation:
           "Enable this only when the proxy is the exclusive Gateway ingress, strongly authenticates users, overwrites identity headers, and restricts access with allowUsers.",
       });
+
+      if (
+        trustedProxyConfig.deviceAutoApprove.scopes?.some(
+          (scope) => scope.trim() === "operator.admin",
+        )
+      ) {
+        findings.push({
+          checkId: "gateway.trusted_proxy_device_auto_approve_admin",
+          severity: "critical",
+          title: "Trusted-proxy device auto-approval allows full admin",
+          detail:
+            "gateway.auth.trustedProxy.deviceAutoApprove.scopes includes operator.admin, so every proxy-authenticated user can auto-approve a new browser device with full admin; requests without scopes receive full admin automatically.",
+          remediation:
+            "Remove operator.admin and approve admin access manually, or use per-identity roles when they become available.",
+        });
+      }
     }
 
     const allowUsers = trustedProxyConfig?.allowUsers ?? [];

--- a/src/security/audit-gateway-exposure.test.ts
+++ b/src/security/audit-gateway-exposure.test.ts
@@ -475,6 +475,25 @@ describe("security audit gateway exposure findings", () => {
         expectedCheckId: "gateway.trusted_proxy_device_auto_approve",
         expectedSeverity: "warn",
       },
+      {
+        name: "browser device auto-approval grants admin",
+        cfg: {
+          gateway: {
+            bind: "lan",
+            trustedProxies: ["10.0.0.1"],
+            auth: {
+              mode: "trusted-proxy",
+              trustedProxy: {
+                userHeader: "x-forwarded-user",
+                allowUsers: ["nick@example.com"],
+                deviceAutoApprove: { enabled: true, scopes: ["operator.admin"] },
+              },
+            },
+          },
+        },
+        expectedCheckId: "gateway.trusted_proxy_device_auto_approve_admin",
+        expectedSeverity: "critical",
+      },
     ];
 
     for (const testCase of cases) {
@@ -489,5 +508,59 @@ describe("security audit gateway exposure findings", () => {
         expect(checkIds).not.toContain("gateway.auth_no_rate_limit");
       }
     }
+  });
+
+  it("explains the trusted-proxy admin auto-approval impact and alternatives", () => {
+    const cfg = {
+      gateway: {
+        bind: "lan",
+        trustedProxies: ["10.0.0.1"],
+        auth: {
+          mode: "trusted-proxy",
+          trustedProxy: {
+            userHeader: "x-forwarded-user",
+            allowUsers: ["nick@example.com"],
+            deviceAutoApprove: { enabled: true, scopes: [" operator.admin "] },
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    expect(
+      requireFinding(
+        collectGatewayConfigFindings(cfg, cfg, {}),
+        "gateway.trusted_proxy_device_auto_approve_admin",
+        "trusted-proxy admin device auto-approval",
+      ),
+    ).toEqual({
+      checkId: "gateway.trusted_proxy_device_auto_approve_admin",
+      severity: "critical",
+      title: "Trusted-proxy device auto-approval allows full admin",
+      detail:
+        "gateway.auth.trustedProxy.deviceAutoApprove.scopes includes operator.admin, so every proxy-authenticated user can auto-approve a new browser device with full admin; requests without scopes receive full admin automatically.",
+      remediation:
+        "Remove operator.admin and approve admin access manually, or use per-identity roles when they become available.",
+    });
+  });
+
+  it("does not report dormant trusted-proxy admin auto-approval config", () => {
+    const cfg = {
+      gateway: {
+        auth: {
+          mode: "token",
+          token: "test",
+          trustedProxy: {
+            userHeader: "x-forwarded-user",
+            deviceAutoApprove: { enabled: true, scopes: ["operator.admin"] },
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    expect(
+      collectGatewayConfigFindings(cfg, cfg, {}).some(
+        (finding) => finding.checkId === "gateway.trusted_proxy_device_auto_approve_admin",
+      ),
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
## What Problem This Solves

`gateway.auth.trustedProxy.deviceAutoApprove` hard-rejects `operator.admin` in its scope set, forcing operators of fully-trusted shared gateways (everyone-is-admin teams) into per-device manual approval loops or out-of-band approval scripts. The operator of the openclaw team gateway explicitly decided every maintainer gets full capabilities until per-identity roles ship — the config should be able to express that decision loudly rather than forbid it absolutely.

## Why This Change Was Made

**Shipped contract change**: `gateway.auth.trustedProxy.deviceAutoApprove.scopes` now accepts an explicitly listed `operator.admin`. When active, proxy-authenticated users automatically obtain full-admin device grants.

The guard becomes loud instead of absolute — explicitly writing `"operator.admin"` in config is the opt-in (no new flag; the string is the intent). Compensating controls, both mandatory and tested:

- `openclaw security audit` emits a CRITICAL finding (`gateway.trusted_proxy_device_auto_approve_admin`), gated on trusted-proxy mode being active, naming the exposure and the remediation (remove admin / manual approval / per-identity roles when available).
- The Gateway logs one startup SECURITY WARNING when the configuration is active.

Defaults are byte-identical: admin absent from scopes behaves exactly as today. The approval path was traced end-to-end to confirm no second admin filter exists (connect-device-pairing.ts scope capping at lines 59/296/344; device-pairing.ts caller-scope authorization) — an integration test proves an admin token persists when requested and configured.

Per-identity roles (the granular successor) remain the planned extension of this same config surface, per #111133's deferred item.

## User Impact

Trusted shared-gateway teams can opt into hands-free full-capability onboarding; everyone else is unaffected. Anyone enabling it sees a critical audit finding and a startup warning.

## Evidence

- Focused suites: config zod-schema gateway, security audit (18/18), gateway startup warning (10/10), device auto-approve integration incl. all six original deny-path tests — 31 tests in the primary run, all green.
- `docs/gateway/trusted-proxy-auth.md` updated (admin grants, scope intersection, audit + warning, alternatives).
- Structured autoreview (codex/gpt-5.6-sol, xhigh): clean — "retains disabled-by-default behavior with matching schema coverage, runtime warnings, security-audit findings, documentation, and integration tests" (0.93).
