### PR TITLE
fix(gateway): reload when included config changes

### DIFF
--- a/src/config/includes.ts
+++ b/src/config/includes.ts
@@ -75,6 +75,8 @@ export type IncludeResolver = {
   readFile: (path: string) => string;
   readFileWithGuards?: (params: IncludeFileReadParams) => string;
   parseJson: (raw: string) => unknown;
+  /** Reports lexically contained paths before canonical/open checks for watcher repair flows. */
+  onLexicalPath?: (resolvedPath: string) => void;
 };
 
 type IncludeFileReadParams = {
@@ -278,6 +280,7 @@ class IncludeProcessor {
         includePath,
       );
     }
+    this.resolver.onLexicalPath?.(normalized);
 
     // SECURITY: Resolve symlinks and re-validate to prevent symlink bypass.
     // The realpath may legitimately land in a different allowed root than the

--- a/src/config/io.read-helpers.ts
+++ b/src/config/io.read-helpers.ts
@@ -232,8 +232,12 @@ export function resolveConfigIncludesForRead(
   deps: NormalizedConfigIoDeps,
   includeFileHashesForWrite?: Record<string, string>,
   includeFileTargetsForWrite?: Record<string, string>,
+  includeFilePathsForWatch?: Set<string>,
 ): unknown {
   const allowedRoots = resolveIncludeRoots(deps.env, deps.homedir);
+  const recordIncludeWatchPath = (resolvedPath: string) => {
+    includeFilePathsForWatch?.add(path.normalize(resolvedPath));
+  };
   const recordIncludeTarget = (resolvedPath: string, canonicalPath?: string) => {
     if (!includeFileTargetsForWrite) {
       return;
@@ -253,6 +257,7 @@ export function resolveConfigIncludesForRead(
     configPath,
     {
       readFile: (candidate) => deps.fs.readFileSync(candidate, "utf-8"),
+      onLexicalPath: recordIncludeWatchPath,
       readFileWithGuards: ({ includePath, resolvedPath, rootRealDir }) => {
         try {
           const raw = readConfigIncludeFileWithGuards({
@@ -260,7 +265,10 @@ export function resolveConfigIncludesForRead(
             resolvedPath,
             rootRealDir,
             ioFs: deps.fs,
-            onResolvedPath: (canonicalPath) => recordIncludeTarget(resolvedPath, canonicalPath),
+            onResolvedPath: (canonicalPath) => {
+              recordIncludeWatchPath(canonicalPath);
+              recordIncludeTarget(resolvedPath, canonicalPath);
+            },
           });
           if (includeFileHashesForWrite) {
             includeFileHashesForWrite[path.normalize(resolvedPath)] = hashConfigIncludeRaw(raw);

--- a/src/config/io.snapshot-shared.ts
+++ b/src/config/io.snapshot-shared.ts
@@ -5,6 +5,7 @@ import type { ConfigFileSnapshot, LegacyConfigIssue, OpenClawConfig } from "./ty
 
 export function createConfigFileSnapshot(params: {
   path: string;
+  includedPaths?: readonly string[];
   exists: boolean;
   raw: string | null;
   parsed: unknown;
@@ -21,6 +22,7 @@ export function createConfigFileSnapshot(params: {
   const runtimeConfig = asRuntimeConfig(params.runtimeConfig);
   return {
     path: params.path,
+    includedPaths: [...(params.includedPaths ?? [])],
     exists: params.exists,
     raw: params.raw,
     parsed: params.parsed,

--- a/src/config/io.snapshot.ts
+++ b/src/config/io.snapshot.ts
@@ -41,15 +41,8 @@ type InternalReadOptions = {
   ) => boolean | Promise<boolean>;
 };
 
-function listResolvedIncludePaths(includeFileTargetsForWrite: Record<string, string>): string[] {
-  return [
-    ...new Set(
-      Object.entries(includeFileTargetsForWrite).flatMap(([lexicalPath, canonicalPath]) => [
-        lexicalPath,
-        canonicalPath,
-      ]),
-    ),
-  ].toSorted();
+function listResolvedIncludePaths(includeFilePathsForWatch: ReadonlySet<string>): string[] {
+  return [...includeFilePathsForWatch].toSorted();
 }
 
 export async function readConfigFileSnapshotInternal(
@@ -86,6 +79,7 @@ export async function readConfigFileSnapshotInternal(
   let fallbackEnvSnapshotForRestore: Record<string, string | undefined> | undefined;
   const includeFileHashesForWrite: Record<string, string> = {};
   const includeFileTargetsForWrite: Record<string, string> = {};
+  const includeFilePathsForWatch = new Set<string>();
 
   try {
     const raw = await deps.measure("config.snapshot.read.file", () =>
@@ -101,7 +95,7 @@ export async function readConfigFileSnapshotInternal(
       return await finalizeReadConfigSnapshotInternalResult(deps, {
         snapshot: createConfigFileSnapshot({
           path: configPath,
-          includedPaths: listResolvedIncludePaths(includeFileTargetsForWrite),
+          includedPaths: listResolvedIncludePaths(includeFilePathsForWatch),
           exists: true,
           raw,
           parsed: {},
@@ -128,6 +122,7 @@ export async function readConfigFileSnapshotInternal(
           deps,
           includeFileHashesForWrite,
           includeFileTargetsForWrite,
+          includeFilePathsForWatch,
         ),
       );
     } catch (error) {
@@ -138,7 +133,7 @@ export async function readConfigFileSnapshotInternal(
       return await finalizeReadConfigSnapshotInternalResult(deps, {
         snapshot: createConfigFileSnapshot({
           path: configPath,
-          includedPaths: listResolvedIncludePaths(includeFileTargetsForWrite),
+          includedPaths: listResolvedIncludePaths(includeFilePathsForWatch),
           exists: true,
           raw,
           parsed: effectiveParsed,
@@ -195,7 +190,7 @@ export async function readConfigFileSnapshotInternal(
       return await finalizeReadConfigSnapshotInternalResult(deps, {
         snapshot: createConfigFileSnapshot({
           path: configPath,
-          includedPaths: listResolvedIncludePaths(includeFileTargetsForWrite),
+          includedPaths: listResolvedIncludePaths(includeFilePathsForWatch),
           exists: true,
           raw: snapshotRaw,
           parsed: snapshotParsed,
@@ -270,7 +265,7 @@ export async function readConfigFileSnapshotInternal(
         {
           snapshot: createConfigFileSnapshot({
             path: configPath,
-            includedPaths: listResolvedIncludePaths(includeFileTargetsForWrite),
+            includedPaths: listResolvedIncludePaths(includeFilePathsForWatch),
             exists: true,
             raw: snapshotRaw,
             parsed: snapshotParsed,
@@ -311,7 +306,7 @@ export async function readConfigFileSnapshotInternal(
     return await finalizeReadConfigSnapshotInternalResult(deps, {
       snapshot: createConfigFileSnapshot({
         path: configPath,
-        includedPaths: listResolvedIncludePaths(includeFileTargetsForWrite),
+        includedPaths: listResolvedIncludePaths(includeFilePathsForWatch),
         exists: true,
         raw: fallbackRaw,
         parsed: fallbackParsed,

--- a/src/config/io.snapshot.ts
+++ b/src/config/io.snapshot.ts
@@ -41,6 +41,17 @@ type InternalReadOptions = {
   ) => boolean | Promise<boolean>;
 };
 
+function listResolvedIncludePaths(includeFileTargetsForWrite: Record<string, string>): string[] {
+  return [
+    ...new Set(
+      Object.entries(includeFileTargetsForWrite).flatMap(([lexicalPath, canonicalPath]) => [
+        lexicalPath,
+        canonicalPath,
+      ]),
+    ),
+  ].toSorted();
+}
+
 export async function readConfigFileSnapshotInternal(
   context: ConfigIoContext,
   options: InternalReadOptions = {},
@@ -90,6 +101,7 @@ export async function readConfigFileSnapshotInternal(
       return await finalizeReadConfigSnapshotInternalResult(deps, {
         snapshot: createConfigFileSnapshot({
           path: configPath,
+          includedPaths: listResolvedIncludePaths(includeFileTargetsForWrite),
           exists: true,
           raw,
           parsed: {},
@@ -126,6 +138,7 @@ export async function readConfigFileSnapshotInternal(
       return await finalizeReadConfigSnapshotInternalResult(deps, {
         snapshot: createConfigFileSnapshot({
           path: configPath,
+          includedPaths: listResolvedIncludePaths(includeFileTargetsForWrite),
           exists: true,
           raw,
           parsed: effectiveParsed,
@@ -182,6 +195,7 @@ export async function readConfigFileSnapshotInternal(
       return await finalizeReadConfigSnapshotInternalResult(deps, {
         snapshot: createConfigFileSnapshot({
           path: configPath,
+          includedPaths: listResolvedIncludePaths(includeFileTargetsForWrite),
           exists: true,
           raw: snapshotRaw,
           parsed: snapshotParsed,
@@ -256,6 +270,7 @@ export async function readConfigFileSnapshotInternal(
         {
           snapshot: createConfigFileSnapshot({
             path: configPath,
+            includedPaths: listResolvedIncludePaths(includeFileTargetsForWrite),
             exists: true,
             raw: snapshotRaw,
             parsed: snapshotParsed,
@@ -296,6 +311,7 @@ export async function readConfigFileSnapshotInternal(
     return await finalizeReadConfigSnapshotInternalResult(deps, {
       snapshot: createConfigFileSnapshot({
         path: configPath,
+        includedPaths: listResolvedIncludePaths(includeFileTargetsForWrite),
         exists: true,
         raw: fallbackRaw,
         parsed: fallbackParsed,

--- a/src/config/types.openclaw.ts
+++ b/src/config/types.openclaw.ts
@@ -310,6 +310,8 @@ export type LegacyConfigIssue = {
 export type ConfigFileSnapshot = {
   /** Config file path that was read. */
   path: string;
+  /** Lexical and canonical file paths reached while resolving $include directives. */
+  includedPaths?: string[];
   /** Whether the config file exists on disk. */
   exists: boolean;
   /** Raw file contents before parsing; null when missing. */

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -1,5 +1,8 @@
 // Gateway config reload tests cover changed-path detection, reload planning,
 // plugin registry refresh, skill snapshot invalidation, and watcher behavior.
+import { mkdtemp, realpath, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import nodePath from "node:path";
 import chokidar from "chokidar";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ChannelPlugin } from "../channels/plugins/types.js";
@@ -10,6 +13,7 @@ import type {
   ConfigWriteNotification,
   OpenClawConfig,
 } from "../config/config.js";
+import { createConfigIO } from "../config/io.js";
 import { hashRuntimeConfigValue } from "../config/runtime-snapshot.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
 import {
@@ -574,7 +578,7 @@ type WatcherEvent = "add" | "change" | "unlink" | "error" | "ready";
 
 function createWatcherMock(effectiveUsePolling?: boolean) {
   const handlers = new Map<WatcherEvent, WatcherHandler[]>();
-  return {
+  const watcher = {
     effectiveUsePolling,
     options: { usePolling: false },
     on(event: WatcherEvent, handler: WatcherHandler) {
@@ -590,6 +594,7 @@ function createWatcherMock(effectiveUsePolling?: boolean) {
     },
     close: vi.fn(async () => {}),
   };
+  return watcher;
 }
 
 function makeSnapshot(partial: Partial<ConfigFileSnapshot> = {}): ConfigFileSnapshot {
@@ -600,6 +605,7 @@ function makeSnapshot(partial: Partial<ConfigFileSnapshot> = {}): ConfigFileSnap
   const runtimeConfig = partial.runtimeConfig ?? partial.config ?? {};
   return {
     path: "/tmp/openclaw.json",
+    includedPaths: [],
     exists: true,
     raw: "{}",
     parsed: {},
@@ -656,6 +662,7 @@ function createReloaderHarness(
     initialCompareConfig?: OpenClawConfig;
     initialSnapshotRawHash?: string | null;
     initialAuthoredConfig?: unknown;
+    initialIncludedPaths?: readonly string[];
     initialSnapshotValid?: boolean;
     initialSnapshotIssues?: ConfigFileSnapshot["issues"];
     prepareConfigCandidate?: (params: {
@@ -770,6 +777,7 @@ function createReloaderHarness(
         ? "initial-raw-hash"
         : options.initialSnapshotRawHash,
     initialAuthoredConfig: options.initialAuthoredConfig ?? initialConfig,
+    initialIncludedPaths: options.initialIncludedPaths,
     initialSnapshotValid: options.initialSnapshotValid ?? true,
     initialSnapshotIssues: options.initialSnapshotIssues ?? [],
     ...(options.prepareConfigCandidate
@@ -836,6 +844,81 @@ function getOnlyHotReloadCall(harness: ReloaderHarness): [GatewayReloadPlan, Ope
   return [call[0], call[1]];
 }
 
+describe("startGatewayConfigReloader include files", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("reloads when an included config file changes", async () => {
+    const rootDir = await realpath(
+      await mkdtemp(nodePath.join(tmpdir(), "openclaw-config-reload-")),
+    );
+    const configPath = nodePath.join(rootDir, "openclaw.json5");
+    const includePath = nodePath.join(rootDir, "hooks.json5");
+    const includeLinkPath = nodePath.join(rootDir, "hooks-link.json5");
+    const nestedIncludePath = nodePath.join(rootDir, "hooks-enabled.json5");
+    await writeFile(
+      configPath,
+      `${JSON.stringify({ gateway: { reload: { mode: "hot" } }, hooks: { $include: "./hooks-link.json5" } }, null, 2)}\n`,
+    );
+    await writeFile(
+      includePath,
+      `${JSON.stringify({ $include: "./hooks-enabled.json5" }, null, 2)}\n`,
+    );
+    await writeFile(nestedIncludePath, `${JSON.stringify({ enabled: true }, null, 2)}\n`);
+    await symlink(includePath, includeLinkPath);
+    const configIo = createConfigIO({
+      configPath,
+      env: {},
+      homedir: () => rootDir,
+      observe: false,
+      pluginValidation: "skip",
+      logger: { error: vi.fn(), warn: vi.fn() },
+    });
+    const initialSnapshot = await configIo.readConfigFileSnapshot();
+    const onHotReload = vi.fn(async () => {});
+    let signalWatcherReady!: () => void;
+    const watcherReady = new Promise<void>((resolve) => {
+      signalWatcherReady = resolve;
+    });
+    const reloader = startGatewayConfigReloader({
+      initialConfig: initialSnapshot.config,
+      initialCompareConfig: initialSnapshot.sourceConfig,
+      initialSnapshotRawHash: initialSnapshot.hash ?? null,
+      initialAuthoredConfig: initialSnapshot.parsed,
+      initialIncludedPaths: initialSnapshot.includedPaths,
+      initialSnapshotValid: initialSnapshot.valid,
+      initialSnapshotIssues: initialSnapshot.issues,
+      testDebounceMs: 0,
+      onWatcherReady: signalWatcherReady,
+      readSnapshot: async () => await configIo.readConfigFileSnapshot(),
+      initialPluginInstallRecords: {},
+      readPluginInstallRecords: async () => ({}),
+      onNoopConfigCommit: async () => {},
+      onHotReload,
+      onRestart: vi.fn(),
+      log: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+      watchPath: configPath,
+    });
+
+    try {
+      expect(initialSnapshot.includedPaths).toEqual(
+        [
+          includeLinkPath,
+          await realpath(includePath),
+          await realpath(nestedIncludePath),
+        ].toSorted(),
+      );
+      await watcherReady;
+      await writeFile(nestedIncludePath, `${JSON.stringify({ enabled: false }, null, 2)}\n`);
+      await vi.waitFor(() => expect(onHotReload).toHaveBeenCalledOnce(), { timeout: 5000 });
+    } finally {
+      await reloader.stop();
+      await rm(rootDir, { force: true, recursive: true });
+    }
+  });
+});
+
 function getOnlyPromoteSnapshotCall(promoteSnapshot: {
   mock: { calls: Array<readonly [ConfigFileSnapshot, string]> };
 }): readonly [ConfigFileSnapshot, string] {
@@ -857,6 +940,93 @@ describe("startGatewayConfigReloader", () => {
     resetGatewayWorkAdmission();
     vi.useRealTimers();
     vi.restoreAllMocks();
+  });
+
+  it("watches resolved includes and reconciles them after an accepted reload", async () => {
+    const initialConfig: OpenClawConfig = {
+      gateway: { reload: {}, port: 18789 },
+    };
+    const nextConfig: OpenClawConfig = {
+      gateway: { reload: {}, port: 18790 },
+    };
+    const initialIncludePath = "/tmp/initial.json5";
+    const retainedIncludePath = "/tmp/retained.json5";
+    const addedIncludePath = "/tmp/added.json5";
+    const harness = createReloaderHarness(
+      vi.fn(async () =>
+        makeSnapshot({
+          config: nextConfig,
+          parsed: nextConfig,
+          hash: "next-raw-hash",
+          includedPaths: [retainedIncludePath, addedIncludePath],
+        }),
+      ),
+      {
+        initialConfig,
+        initialIncludedPaths: [initialIncludePath, retainedIncludePath],
+      },
+    );
+
+    expect(chokidar.watch).toHaveBeenCalledWith(
+      ["/tmp/openclaw.json", initialIncludePath, retainedIncludePath],
+      expect.objectContaining({ ignoreInitial: true }),
+    );
+
+    harness.watcher.emit("change");
+    await vi.runAllTimersAsync();
+
+    // Candidate discovery adds the new include before acceptance; acceptance
+    // then retires the old include in a second readiness-reconciled watcher.
+    expect(harness.watcher.close).toHaveBeenCalledTimes(2);
+    expect(chokidar.watch).toHaveBeenLastCalledWith(
+      ["/tmp/openclaw.json", retainedIncludePath, addedIncludePath],
+      expect.objectContaining({ ignoreInitial: true }),
+    );
+    await harness.reloader.stop();
+  });
+
+  it("retains accepted include watches while replacing a rejected candidate set", async () => {
+    const acceptedIncludePath = "/tmp/accepted.json5";
+    const firstCandidatePath = "/tmp/first-invalid.json5";
+    const secondCandidatePath = "/tmp/second-invalid.json5";
+    const readSnapshot = vi
+      .fn<() => Promise<ConfigFileSnapshot>>()
+      .mockResolvedValueOnce(
+        makeSnapshot({
+          valid: false,
+          hash: "first-invalid-hash",
+          includedPaths: [firstCandidatePath],
+          issues: [{ path: "hooks.enabled", message: "Expected boolean" }],
+        }),
+      )
+      .mockResolvedValueOnce(
+        makeSnapshot({
+          valid: false,
+          hash: "second-invalid-hash",
+          includedPaths: [secondCandidatePath],
+          issues: [{ path: "hooks.enabled", message: "Expected boolean" }],
+        }),
+      );
+    const harness = createReloaderHarness(readSnapshot, {
+      initialIncludedPaths: [acceptedIncludePath],
+    });
+
+    harness.watcher.emit("change");
+    await vi.runAllTimersAsync();
+    expect(harness.watcher.close).toHaveBeenCalledOnce();
+    expect(chokidar.watch).toHaveBeenLastCalledWith(
+      ["/tmp/openclaw.json", acceptedIncludePath, firstCandidatePath],
+      expect.objectContaining({ ignoreInitial: true }),
+    );
+
+    harness.watcher.emit("change");
+    await vi.runAllTimersAsync();
+    expect(harness.watcher.close).toHaveBeenCalledTimes(2);
+    expect(chokidar.watch).toHaveBeenLastCalledWith(
+      ["/tmp/openclaw.json", acceptedIncludePath, secondCandidatePath],
+      expect.objectContaining({ ignoreInitial: true }),
+    );
+    await harness.reloader.stop();
   });
 
   it("journals valid external watcher edits and advances the snapshot slot", async () => {

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -917,6 +917,38 @@ describe("startGatewayConfigReloader include files", () => {
       await rm(rootDir, { force: true, recursive: true });
     }
   });
+
+  it("keeps a lexically safe rejected include path watchable", async () => {
+    const rootDir = await realpath(
+      await mkdtemp(nodePath.join(tmpdir(), "openclaw-config-reload-")),
+    );
+    const outsideDir = await realpath(
+      await mkdtemp(nodePath.join(tmpdir(), "openclaw-config-outside-")),
+    );
+    const configPath = nodePath.join(rootDir, "openclaw.json5");
+    const includeLinkPath = nodePath.join(rootDir, "hooks-link.json5");
+    const outsideIncludePath = nodePath.join(outsideDir, "hooks.json5");
+    await writeFile(configPath, `${JSON.stringify({ $include: "./hooks-link.json5" })}\n`);
+    await writeFile(outsideIncludePath, `${JSON.stringify({ hooks: { enabled: true } })}\n`);
+    await symlink(outsideIncludePath, includeLinkPath);
+    const configIo = createConfigIO({
+      configPath,
+      env: {},
+      homedir: () => rootDir,
+      observe: false,
+      pluginValidation: "skip",
+      logger: { error: vi.fn(), warn: vi.fn() },
+    });
+
+    try {
+      const snapshot = await configIo.readConfigFileSnapshot();
+      expect(snapshot.valid).toBe(false);
+      expect(snapshot.includedPaths).toEqual([includeLinkPath]);
+    } finally {
+      await rm(rootDir, { force: true, recursive: true });
+      await rm(outsideDir, { force: true, recursive: true });
+    }
+  });
 });
 
 function getOnlyPromoteSnapshotCall(promoteSnapshot: {

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -573,8 +573,9 @@ describe("buildGatewayReloadPlan", () => {
   });
 });
 
-type WatcherHandler = () => void;
+type WatcherHandler = (value?: unknown) => void;
 type WatcherEvent = "add" | "change" | "unlink" | "error" | "ready";
+const WATCHER_PATH_EVENTS = new Set<WatcherEvent>(["add", "change", "unlink"]);
 
 function createWatcherMock(effectiveUsePolling?: boolean) {
   const handlers = new Map<WatcherEvent, WatcherHandler[]>();
@@ -587,9 +588,11 @@ function createWatcherMock(effectiveUsePolling?: boolean) {
       handlers.set(event, existing);
       return this;
     },
-    emit(event: WatcherEvent) {
+    emit(event: WatcherEvent, value?: unknown) {
+      const eventValue =
+        value ?? (WATCHER_PATH_EVENTS.has(event) ? "/tmp/openclaw.json" : undefined);
       for (const handler of handlers.get(event) ?? []) {
-        handler();
+        handler(eventValue);
       }
     },
     close: vi.fn(async () => {}),
@@ -1058,6 +1061,35 @@ describe("startGatewayConfigReloader", () => {
       ["/tmp/openclaw.json", acceptedIncludePath, secondCandidatePath],
       expect.objectContaining({ ignoreInitial: true }),
     );
+    await harness.reloader.stop();
+  });
+
+  it("does not recurse into or reload for children of a rejected include directory", async () => {
+    const rejectedIncludeDir = "/tmp/rejected-include";
+    const readSnapshot = vi.fn(async () =>
+      makeSnapshot({
+        valid: false,
+        hash: "invalid-directory-hash",
+        includedPaths: [rejectedIncludeDir],
+        issues: [{ path: "", message: "Include path is not a regular file" }],
+      }),
+    );
+    const harness = createReloaderHarness(readSnapshot, {
+      initialIncludedPaths: [rejectedIncludeDir],
+    });
+
+    expect(chokidar.watch).toHaveBeenCalledWith(
+      ["/tmp/openclaw.json", rejectedIncludeDir],
+      expect.objectContaining({ depth: 0 }),
+    );
+
+    harness.watcher.emit("change", nodePath.join(rejectedIncludeDir, "session.json"));
+    await vi.runAllTimersAsync();
+    expect(readSnapshot).not.toHaveBeenCalled();
+
+    harness.watcher.emit("change", rejectedIncludeDir);
+    await vi.runAllTimersAsync();
+    expect(readSnapshot).toHaveBeenCalledOnce();
     await harness.reloader.stop();
   });
 

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -162,10 +162,13 @@ export function startGatewayConfigReloader(opts: {
   initialCompareConfig?: OpenClawConfig;
   initialSnapshotRawHash: string | null;
   initialAuthoredConfig: unknown;
+  initialIncludedPaths?: readonly string[];
   initialSnapshotValid: boolean;
   initialSnapshotIssues: ConfigFileSnapshot["issues"];
   /** Keeps watcher-heavy tests immediate without reopening config-level debounce tuning. */
   testDebounceMs?: number;
+  /** Per-instance test hook for synchronizing filesystem edits with watcher startup. */
+  onWatcherReady?: () => void;
   prepareConfigCandidate?: (params: {
     runtimeConfig: OpenClawConfig;
     sourceConfig: OpenClawConfig;
@@ -809,6 +812,9 @@ export function startGatewayConfigReloader(opts: {
         updateAcceptedSnapshot(snapshot.hash, snapshot.parsed);
       }
     });
+    if (snapshot?.valid) {
+      await acceptWatchedPaths(snapshot.includedPaths ?? []);
+    }
   };
 
   const promoteAcceptedInProcessWrite = async (persistedHash: string) => {
@@ -818,6 +824,7 @@ export function startGatewayConfigReloader(opts: {
         return;
       }
       updateAcceptedSnapshot(snapshot.hash, snapshot.parsed);
+      await acceptWatchedPaths(snapshot.includedPaths ?? []);
       await promoteAcceptedSnapshot(snapshot, "in-process-write");
     } catch (err) {
       opts.log.warn(`config reload in-process last-known-good promotion failed: ${String(err)}`);
@@ -888,6 +895,7 @@ export function startGatewayConfigReloader(opts: {
         await appliedRevision.flush(currentConfig);
         return;
       }
+      await observeCandidateWatchedPaths(snapshot.includedPaths ?? []);
       const observedRawHash = snapshot.hash ?? null;
       const previousObservedRawHash = lastObservedRawHash;
       const newObservedRawHash = observedRawHash !== previousObservedRawHash;
@@ -938,6 +946,7 @@ export function startGatewayConfigReloader(opts: {
           }
           throw err;
         }
+        await acceptWatchedPaths(snapshot.includedPaths ?? []);
         return;
       }
       if (watcherIntentCandidate === intentCandidate) {
@@ -983,6 +992,7 @@ export function startGatewayConfigReloader(opts: {
                 updateAcceptedSnapshot(snapshot.hash, snapshot.parsed);
               }
             });
+            await acceptWatchedPaths(snapshot.includedPaths ?? []);
             return;
           }
           await acceptCurrentRuntimeEcho(transactionEpoch, snapshot);
@@ -1047,6 +1057,7 @@ export function startGatewayConfigReloader(opts: {
         );
         await promoteAcceptedSnapshot(snapshot, "valid-config");
       });
+      await acceptWatchedPaths(snapshot.includedPaths ?? []);
     } catch (err) {
       if (isGatewayConfigReloadSupersededError(err)) {
         opts.log.info(`config reload superseded: ${String(err)}`);
@@ -1121,6 +1132,9 @@ export function startGatewayConfigReloader(opts: {
     }) ?? (() => {});
 
   let watcher: ReturnType<typeof chokidar.watch> | null = null;
+  const acceptedIncludedPaths = new Set(opts.initialIncludedPaths ?? []);
+  let candidateIncludedPaths = new Set<string>();
+  const watchedPaths = new Set([opts.watchPath, ...acceptedIncludedPaths]);
   let watcherRecreateRetries = 0;
   let watcherRecreateTimer: ReturnType<typeof setTimeout> | null = null;
   let hotReloadStatus: GatewayHotReloadStatus = "active";
@@ -1132,7 +1146,7 @@ export function startGatewayConfigReloader(opts: {
       return;
     }
     const usePolling = resolveChokidarUsePolling(degradedToPolling);
-    const next = chokidar.watch(opts.watchPath, {
+    const next = chokidar.watch([...watchedPaths], {
       ignoreInitial: true,
       awaitWriteFinish: { stabilityThreshold: 200, pollInterval: 50 },
       usePolling,
@@ -1149,15 +1163,16 @@ export function startGatewayConfigReloader(opts: {
     next.on("error", (err) => {
       handleWatcherError(next, err);
     });
-    if (reconcileAfterReady) {
-      next.on("ready", () => {
+    next.on("ready", () => {
+      opts.onWatcherReady?.();
+      if (reconcileAfterReady) {
         // Replacement watchers suppress their initial add event. Reconcile only after the
         // scan completes, and ignore a watcher that failed again before reaching ready.
         if (!stopped && watcher === next) {
           scheduleExternalRefresh();
         }
-      });
-    }
+      }
+    });
     watcher = next;
     watcherUsesPolling = next.options.usePolling;
     hotReloadStatus = "active";
@@ -1207,6 +1222,50 @@ export function startGatewayConfigReloader(opts: {
       watcherRecreateTimer = null;
       createWatcher(true);
     }, backoff);
+  };
+
+  const reconcileWatchedPaths = async (includedPaths: readonly string[]) => {
+    const nextPaths = new Set([opts.watchPath, ...includedPaths]);
+    const additions = [...nextPaths].filter((candidate) => !watchedPaths.has(candidate));
+    const removals = [...watchedPaths].filter((candidate) => !nextPaths.has(candidate));
+    if (additions.length === 0 && removals.length === 0) {
+      return;
+    }
+
+    watchedPaths.clear();
+    for (const candidate of nextPaths) {
+      watchedPaths.add(candidate);
+    }
+    const activeWatcher = watcher;
+    if (!activeWatcher) {
+      return;
+    }
+    try {
+      await activeWatcher.close();
+    } catch (err) {
+      handleWatcherError(activeWatcher, err);
+      return;
+    }
+    if (stopped || watcher !== activeWatcher) {
+      return;
+    }
+    watcher = null;
+    watcherUsesPolling = false;
+    createWatcher(true);
+  };
+
+  const observeCandidateWatchedPaths = async (includedPaths: readonly string[]) => {
+    candidateIncludedPaths = new Set(includedPaths);
+    await reconcileWatchedPaths([...acceptedIncludedPaths, ...candidateIncludedPaths]);
+  };
+
+  const acceptWatchedPaths = async (includedPaths: readonly string[]) => {
+    acceptedIncludedPaths.clear();
+    for (const candidate of includedPaths) {
+      acceptedIncludedPaths.add(candidate);
+    }
+    candidateIncludedPaths.clear();
+    await reconcileWatchedPaths([...acceptedIncludedPaths]);
   };
 
   createWatcher();

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -1,4 +1,5 @@
 import { homedir } from "node:os";
+import nodePath from "node:path";
 // Gateway config hot-reload watcher.
 // Diffs config/plugin install snapshots and dispatches hot reload or restart plans.
 import chokidar from "chokidar";
@@ -1147,13 +1148,17 @@ export function startGatewayConfigReloader(opts: {
     }
     const usePolling = resolveChokidarUsePolling(degradedToPolling);
     const next = chokidar.watch([...watchedPaths], {
+      depth: 0,
       ignoreInitial: true,
       awaitWriteFinish: { stabilityThreshold: 200, pollInterval: 50 },
       usePolling,
     });
     // A file event proves this watcher recovered. Reset only here so plugin
     // metadata refreshes and consecutive watcher errors cannot refill the budget.
-    const scheduleFromWatcherEvent = () => {
+    const scheduleFromWatcherEvent = (eventPath: string) => {
+      if (!watchedPaths.has(nodePath.normalize(eventPath))) {
+        return;
+      }
       watcherRecreateRetries = 0;
       scheduleExternalRefresh();
     };

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -407,6 +407,7 @@ type ManagedGatewayConfigReloaderParams = Omit<
   initialCompareConfig?: OpenClawConfig;
   initialSnapshotRawHash: string | null;
   initialAuthoredConfig: unknown;
+  initialIncludedPaths?: readonly string[];
   initialSnapshotValid: boolean;
   initialSnapshotIssues: ConfigFileSnapshot["issues"];
   initialInternalWriteHash: string | null;
@@ -1928,6 +1929,7 @@ export function startManagedGatewayConfigReloader(
     initialCompareConfig: params.initialCompareConfig,
     initialSnapshotRawHash: params.initialSnapshotRawHash,
     initialAuthoredConfig: params.initialAuthoredConfig,
+    initialIncludedPaths: params.initialIncludedPaths ?? [],
     initialSnapshotValid: params.initialSnapshotValid,
     initialSnapshotIssues: params.initialSnapshotIssues,
     // Single notification point for every persisted config change — gateway

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -2296,6 +2296,7 @@ export async function startGatewayServer(
         ? (startupLastGoodSnapshot.hash ?? null)
         : null,
       initialAuthoredConfig: startupLastGoodSnapshot.parsed,
+      initialIncludedPaths: startupLastGoodSnapshot.includedPaths ?? [],
       initialSnapshotValid: startupLastGoodSnapshot.valid,
       initialSnapshotIssues: startupLastGoodSnapshot.issues,
       initialInternalWriteHash: startupInternalWriteHash,

--- a/src/gateway/test-helpers.config-snapshots.ts
+++ b/src/gateway/test-helpers.config-snapshots.ts
@@ -24,6 +24,7 @@ export function buildTestConfigSnapshot(params: {
 }): ConfigFileSnapshot {
   return {
     path: params.path,
+    includedPaths: [],
     exists: params.exists,
     raw: params.raw,
     parsed: params.parsed,


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where gateway operators using `$include` would not get a hot reload when an included config file changed. The gateway only watched the main config file, so included-file edits were silently ignored until another main-file edit or a restart.

## Why This Change Was Made

Resolved include dependencies now travel with each config snapshot into the existing gateway watcher. Lexically contained paths are captured before canonical/open checks so rejected symlinks, directories, and permission failures remain repairable without weakening include guards. The watcher is depth-bounded and filters events to exact configured paths, so rejected directories cannot recursively watch state trees or trigger unrelated reloads. It is rebuilt when the accepted or latest candidate include set changes: newly referenced files are added, removed references are dropped after a successful reload, and the replacement watcher's ready event feeds the existing debounced reload path.

## User Impact

Editing direct or nested included config files now triggers the same gateway hot-reload behavior as editing the main config. Symlinked includes are tracked through both their configured and canonical paths, and changing the include graph does not leak stale watchers.

## Evidence

- `node scripts/run-vitest.mjs config-reload` — 163 tests passed, including a real filesystem watcher regression, rejected-path discovery, bounded directory watching, exact event filtering, and include-set reconciliation coverage.
- `node scripts/run-vitest.mjs src/config/includes.test.ts` — 63 tests passed.
- `pnpm tsgo`
- `pnpm format src/config/io.snapshot-shared.ts src/config/io.snapshot.ts src/config/types.openclaw.ts src/gateway/config-reload.test.ts src/gateway/config-reload.ts src/gateway/server-reload-handlers.ts src/gateway/server.impl.ts src/gateway/test-helpers.config-snapshots.ts`
- `node scripts/run-oxlint.mjs src/config/io.snapshot-shared.ts src/config/io.snapshot.ts src/config/types.openclaw.ts src/gateway/config-reload.test.ts src/gateway/config-reload.ts src/gateway/server-reload-handlers.ts src/gateway/server.impl.ts src/gateway/test-helpers.config-snapshots.ts`
- `git diff --check origin/main...HEAD`
- Fresh branch autoreview against `origin/main`: clean, with no accepted or actionable findings.

AI-assisted; I reviewed the implementation and understand the watcher lifecycle and reconciliation behavior.
