### PR TITLE
fix(install): keep source postinstall out of operator state

### DIFF
--- a/scripts/postinstall-bundled-plugins.mjs
+++ b/scripts/postinstall-bundled-plugins.mjs
@@ -823,10 +823,17 @@ export async function runPluginRegistryPostinstallMigration(params = {}) {
   const log = params.log ?? console;
   const packageRoot = params.packageRoot ?? DEFAULT_PACKAGE_ROOT;
   const env = params.env ?? process.env;
+  const pathExists = params.existsSync ?? existsSync;
+
+  // Registry migration belongs to installed-package upgrades. Source checkouts
+  // can contain stale dist from a different build and must not touch operator state.
+  if (isSourceCheckoutRoot({ packageRoot, existsSync: pathExists })) {
+    return { status: "skipped", reason: "source-checkout" };
+  }
 
   try {
     const migrationModule = await importInstalledDistModule(
-      params,
+      { ...params, existsSync: pathExists },
       "dist/commands/doctor/shared/plugin-registry-migration.js",
     );
     if (!migrationModule) {

--- a/test/scripts/postinstall-bundled-plugins.test.ts
+++ b/test/scripts/postinstall-bundled-plugins.test.ts
@@ -482,6 +482,37 @@ describe("bundled plugin postinstall", () => {
     );
   });
 
+  it("does not migrate operator plugin state from a source checkout", async () => {
+    const packageRoot = "/source";
+    const existingPaths = new Set([
+      path.join(packageRoot, ".git"),
+      path.join(packageRoot, "src"),
+      path.join(packageRoot, "extensions"),
+      path.join(
+        packageRoot,
+        "dist",
+        "commands",
+        "doctor",
+        "shared",
+        "plugin-registry-migration.js",
+      ),
+    ]);
+    const importModule = vi.fn();
+
+    await expect(
+      runPluginRegistryPostinstallMigration({
+        packageRoot,
+        existsSync: vi.fn((filePath: string) => existingPaths.has(filePath)),
+        importModule,
+        log: { log: vi.fn(), warn: vi.fn() },
+      }),
+    ).resolves.toEqual({
+      status: "skipped",
+      reason: "source-checkout",
+    });
+    expect(importModule).not.toHaveBeenCalled();
+  });
+
   it("keeps plugin registry postinstall migration non-fatal when dist entries are unavailable", async () => {
     const warn = vi.fn();
 


### PR DESCRIPTION
Closes #111513

## What Problem This Solves

Fixes an issue where developers running dependency installation in a source checkout could have postinstall inspect and attempt to migrate the unrelated operator plugin registry when built `dist` output was present.

## Why This Change Was Made

Plugin-registry migration is an installed-package upgrade concern. The migration entry point now recognizes a source checkout before importing any built config or registry module, preserving the existing source-maintenance path while preventing stale `dist` from crossing into operator state.

## User Impact

Source development and dependency installation no longer read or attempt to migrate the operator state database. Installed npm/package upgrades retain their existing plugin-registry migration behavior.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/postinstall-bundled-plugins.test.ts`: 37/37 passed.
- `node scripts/check-changed.mjs -- scripts/postinstall-bundled-plugins.mjs test/scripts/postinstall-bundled-plugins.test.ts`: passed on Blacksmith Testbox, including test-root types, tooling lint, formatting, dependency/package guards, script contracts, and boundaries.
- Source-blind command proof with `OPENCLAW_STATE_DIR=/dev/null`: postinstall exited 0 with no config/database/registry warning while still pruning a controlled compile-cache fixture.
- Autoreview: clean, no accepted/actionable findings.

AI-assisted: implementation and tests were produced with Codex and independently checked by the repository autoreview workflow.
