### PR TITLE
fix(plugins): load configured standalone files without manifests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Standalone plugin files:** let manifestless files explicitly listed in `plugins.load.paths` pass config validation and load independently when several files share a directory.
 - **Control UI terminal error messages:** preserve message-only assistant output beginning with `Error:` or a warning marker instead of treating text prefixes as synthetic failures. Thanks @shakkernerd.
 - **Channel outbound echo suppression:** drop recently emitted platform message and source identities at shared inbound admission and migrate Discord thread unbinds off channel-local expiry state, preventing delayed webhook copies from re-entering agents.
 - **Reef startup reconciliation:** contain retryable relay failures during startup without supervisor restart loops, while preserving definitive-error and cancellation handling. Thanks @Yigtwxx.

--- a/src/plugins/loader-cli-registry.ts
+++ b/src/plugins/loader-cli-registry.ts
@@ -72,7 +72,7 @@ export async function loadOpenClawPluginCliRegistry(
     }),
     activateGlobalSideEffects: false,
   });
-  const { manifestRegistry, orderedCandidates, manifestByRoot } = resolvePluginLoadDiscovery({
+  const { manifestRegistry, orderedCandidates, manifestBySource } = resolvePluginLoadDiscovery({
     options,
     context,
     diagnostics: registry.diagnostics,
@@ -93,7 +93,7 @@ export async function loadOpenClawPluginCliRegistry(
   });
 
   for (const candidate of orderedCandidates) {
-    const manifestRecord = manifestByRoot.get(candidate.rootDir);
+    const manifestRecord = manifestBySource.get(candidate.source);
     if (!manifestRecord) {
       continue;
     }

--- a/src/plugins/loader-discovery.ts
+++ b/src/plugins/loader-discovery.ts
@@ -25,7 +25,7 @@ type ResolvedPluginLoadDiscovery = {
   discovery: PluginDiscoveryResult;
   manifestRegistry: PluginManifestRegistry;
   orderedCandidates: PluginCandidate[];
-  manifestByRoot: Map<string, PluginManifestRecord>;
+  manifestBySource: Map<string, PluginManifestRecord>;
   provenance: ReturnType<typeof buildProvenanceIndex>;
 };
 
@@ -89,19 +89,19 @@ export function resolvePluginLoadDiscovery(params: {
     env: context.env,
     installRecords: context.installRecords,
   });
-  const manifestByRoot = new Map(
-    manifestRegistry.plugins.map((record) => [record.rootDir, record]),
+  const manifestBySource = new Map(
+    manifestRegistry.plugins.map((record) => [record.source, record]),
   );
   const orderedCandidates = [...discovery.candidates].toSorted((left, right) =>
     compareDuplicateCandidateOrder({
       left,
       right,
-      manifestByRoot,
+      manifestBySource,
       provenance,
       env: context.env,
     }),
   );
-  return { discovery, manifestRegistry, orderedCandidates, manifestByRoot, provenance };
+  return { discovery, manifestRegistry, orderedCandidates, manifestBySource, provenance };
 }
 
 function nonEmptyInstallRecords(

--- a/src/plugins/loader-provenance.ts
+++ b/src/plugins/loader-provenance.ts
@@ -142,11 +142,11 @@ function matchesExplicitInstallRule(params: {
 
 function resolveCandidateDuplicateRank(params: {
   candidate: PluginCandidate;
-  manifestByRoot: Map<string, PluginManifestRecord>;
+  manifestBySource: Map<string, PluginManifestRecord>;
   provenance: PluginProvenanceIndex;
   env: NodeJS.ProcessEnv;
 }): number {
-  const manifestRecord = params.manifestByRoot.get(params.candidate.rootDir);
+  const manifestRecord = params.manifestBySource.get(params.candidate.source);
   const pluginId = manifestRecord?.id;
   const isExplicitInstall =
     params.candidate.origin === "global" &&
@@ -187,25 +187,25 @@ function resolveCandidateDuplicateRank(params: {
 export function compareDuplicateCandidateOrder(params: {
   left: PluginCandidate;
   right: PluginCandidate;
-  manifestByRoot: Map<string, PluginManifestRecord>;
+  manifestBySource: Map<string, PluginManifestRecord>;
   provenance: PluginProvenanceIndex;
   env: NodeJS.ProcessEnv;
 }): number {
-  const leftPluginId = params.manifestByRoot.get(params.left.rootDir)?.id;
-  const rightPluginId = params.manifestByRoot.get(params.right.rootDir)?.id;
+  const leftPluginId = params.manifestBySource.get(params.left.source)?.id;
+  const rightPluginId = params.manifestBySource.get(params.right.source)?.id;
   if (!leftPluginId || leftPluginId !== rightPluginId) {
     return 0;
   }
   return (
     resolveCandidateDuplicateRank({
       candidate: params.left,
-      manifestByRoot: params.manifestByRoot,
+      manifestBySource: params.manifestBySource,
       provenance: params.provenance,
       env: params.env,
     }) -
     resolveCandidateDuplicateRank({
       candidate: params.right,
-      manifestByRoot: params.manifestByRoot,
+      manifestBySource: params.manifestBySource,
       provenance: params.provenance,
       env: params.env,
     })

--- a/src/plugins/loader-runtime-load.ts
+++ b/src/plugins/loader-runtime-load.ts
@@ -118,7 +118,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       activateGlobalSideEffects: context.shouldActivate,
     });
     const { registry } = registryBuilder;
-    const { manifestRegistry, orderedCandidates, manifestByRoot, provenance } =
+    const { manifestRegistry, orderedCandidates, manifestBySource, provenance } =
       resolvePluginLoadDiscovery({
         options,
         context,
@@ -145,7 +145,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     });
     const pluginLoadStartMs = performance.now();
     for (const candidate of orderedCandidates) {
-      const manifestRecord = manifestByRoot.get(candidate.rootDir);
+      const manifestRecord = manifestBySource.get(candidate.source);
       if (!manifestRecord) {
         continue;
       }

--- a/src/plugins/loader.base.test-utils.ts
+++ b/src/plugins/loader.base.test-utils.ts
@@ -629,6 +629,32 @@ describe("loadOpenClawPlugins", () => {
     ]);
   });
 
+  it("loads multiple manifestless standalone files from one configured directory", () => {
+    useNoBundledPlugins();
+    const pluginDir = makeTempDir();
+    const alpha = path.join(pluginDir, "alpha.cjs");
+    const beta = path.join(pluginDir, "beta.cjs");
+    fs.writeFileSync(alpha, `module.exports = { id: "alpha", register() {} };`, "utf-8");
+    fs.writeFileSync(beta, `module.exports = { id: "beta", register() {} };`, "utf-8");
+
+    const registry = loadOpenClawPlugins({
+      cache: false,
+      config: {
+        plugins: {
+          load: { paths: [alpha, beta] },
+          allow: ["alpha", "beta"],
+        },
+      },
+    });
+
+    expect(
+      registry.plugins
+        .filter((entry) => entry.status === "loaded")
+        .map((entry) => entry.id)
+        .toSorted(),
+    ).toEqual(["alpha", "beta"]);
+  });
+
   it.each([
     {
       name: "loads bundled telegram plugin when enabled",

--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -517,6 +517,68 @@ describe("loadPluginManifestRegistry", () => {
     expect(manifestChangeCase.secondName).toBe("After");
   });
 
+  it("synthesizes an empty manifest for explicitly configured standalone files", () => {
+    const dir = makeTempDir();
+    const source = path.join(dir, "maintenance-access.ts");
+    writeTextFile(dir, "maintenance-access.ts", "export default { register() {} };");
+
+    const registry = loadPluginManifestRegistry({
+      config: { plugins: { load: { paths: [source] } } },
+      candidates: [
+        createPluginCandidate({
+          idHint: "maintenance-access",
+          rootDir: dir,
+          sourceName: "maintenance-access.ts",
+          origin: "config",
+        }),
+      ],
+    });
+
+    expect(registry.diagnostics).toStrictEqual([]);
+    expect(registry.plugins).toEqual([
+      expect.objectContaining({
+        id: "maintenance-access",
+        source,
+        manifestPath: source,
+        configSchema: { type: "object", additionalProperties: false },
+      }),
+    ]);
+  });
+
+  it("keeps core-reserved ids unavailable to configured standalone files", () => {
+    const dir = makeTempDir();
+    const source = path.join(dir, "node-mcp.ts");
+    writeTextFile(dir, "node-mcp.ts", "export default { register() {} };");
+
+    const registry = loadPluginManifestRegistry({
+      config: { plugins: { load: { paths: [source] } } },
+      candidates: [
+        createPluginCandidate({
+          idHint: "node-mcp",
+          rootDir: dir,
+          sourceName: "node-mcp.ts",
+          origin: "config",
+        }),
+      ],
+    });
+
+    expect(registry.plugins).toStrictEqual([]);
+    expectRegistryDiagnosticContains(registry, 'plugin manifest id "node-mcp" is reserved');
+  });
+
+  it("still requires manifests for explicitly configured directories", () => {
+    const dir = makeTempDir();
+    writeTextFile(dir, "index.ts", "export default { register() {} };");
+
+    const registry = loadPluginManifestRegistry({
+      config: { plugins: { load: { paths: [dir] } } },
+      env: hermeticEnv(),
+    });
+
+    expect(registry.plugins.filter((plugin) => plugin.origin === "config")).toStrictEqual([]);
+    expectRegistryDiagnosticContains(registry, "plugin manifest not found");
+  });
+
   it("preserves optional manifest icon URLs on registry records", () => {
     const dir = makeTempDir();
     writeManifest(dir, {

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -31,7 +31,9 @@ import type {
   PluginFormat,
 } from "./manifest-types.js";
 import {
+  isCoreReservedPluginId,
   loadPluginManifest,
+  PLUGIN_MANIFEST_FILENAME,
   type OpenClawPackageManifest,
   type PluginManifestActivation,
   type PluginManifestCatalog,
@@ -1008,6 +1010,12 @@ export function loadPluginManifestRegistry(
   const seenIds = new Map<string, SeenIdEntry>();
   const realpathCache = new Map<string, string>();
   const currentHostVersion = resolveCompatibilityHostVersion(env);
+  const explicitConfiguredFileSources = new Set(
+    normalized.loadPaths
+      .map((loadPath) => resolveUserPath(loadPath, env))
+      .filter((loadPath) => safeStatSync(loadPath)?.isFile() === true)
+      .map((loadPath) => path.resolve(loadPath)),
+  );
 
   for (const candidate of candidates) {
     const rejectHardlinks = shouldRejectHardlinkedPluginFiles({
@@ -1017,6 +1025,19 @@ export function loadPluginManifestRegistry(
       realpathCache,
     });
     const isBundleRecord = (candidate.format ?? "openclaw") === "bundle";
+    const isManifestlessConfiguredFile =
+      candidate.origin === "config" &&
+      explicitConfiguredFileSources.has(path.resolve(candidate.source)) &&
+      !fs.existsSync(path.join(candidate.rootDir, PLUGIN_MANIFEST_FILENAME));
+    if (isManifestlessConfiguredFile && isCoreReservedPluginId(candidate.idHint)) {
+      diagnostics.push({
+        level: "error",
+        pluginId: candidate.idHint,
+        source: candidate.source,
+        message: `plugin manifest id "${candidate.idHint}" is reserved by OpenClaw core`,
+      });
+      continue;
+    }
     const manifestRes:
       | ReturnType<typeof loadPluginManifest>
       | ReturnType<typeof loadBundleManifest>
@@ -1033,7 +1054,16 @@ export function loadPluginManifestRegistry(
               bundleFormat: candidate.bundleFormat,
               rejectHardlinks,
             })
-          : loadPluginManifest(candidate.rootDir, rejectHardlinks);
+          : isManifestlessConfiguredFile
+            ? {
+                ok: true,
+                manifest: {
+                  id: candidate.idHint,
+                  configSchema: { type: "object", additionalProperties: false },
+                },
+                manifestPath: candidate.source,
+              }
+            : loadPluginManifest(candidate.rootDir, rejectHardlinks);
     if (!manifestRes.ok) {
       diagnostics.push({
         level: "error",

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -36,6 +36,10 @@ const MAX_SECRET_PROVIDER_EXEC_PASS_ENV = 128;
 const SECRET_PROVIDER_NODE_COMMAND_PLACEHOLDER = "${node}";
 const CORE_RESERVED_PLUGIN_IDS = new Set(["node-mcp"]);
 
+export function isCoreReservedPluginId(id: string): boolean {
+  return CORE_RESERVED_PLUGIN_IDS.has(normalizePluginPolicyId(id));
+}
+
 type PluginManifestLoadCacheEntry = {
   result: PluginManifestLoadResult;
   size: number;
@@ -1811,7 +1815,7 @@ export function loadPluginManifest(
   if (!id) {
     return cacheResult({ ok: false, error: "plugin manifest requires id", manifestPath });
   }
-  if (CORE_RESERVED_PLUGIN_IDS.has(normalizePluginPolicyId(id))) {
+  if (isCoreReservedPluginId(id)) {
     return cacheResult({
       ok: false,
       error: `plugin manifest id "${id}" is reserved by OpenClaw core`,


### PR DESCRIPTION
Related: #111190

## What Problem This Solves

Fixes an issue where users adding a single TypeScript or JavaScript plugin file to `plugins.load.paths` would get a `plugin manifest not found` validation error when the file had no adjacent `openclaw.plugin.json`.

## Why This Change Was Made

Explicitly configured files now receive a strict empty synthetic manifest, while configured directories and packages still require their normal manifest. Manifest lookup is keyed by source file so multiple standalone files in one directory remain independent. Core-reserved plugin ids remain rejected.

## User Impact

Operators can keep a small local authorization or automation hook in one file and load it directly. Existing directory/package validation stays unchanged.

## Evidence

- 278 focused plugin loader and manifest-registry tests passed.
- Built-CLI behavior proof loaded two manifestless sibling files independently and rejected an exported id mismatch at runtime inspection.
- `pnpm check:changed` passed on Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/29699997333
- Final autoreview reported no accepted or actionable findings.

AI-assisted: yes. I reviewed the implementation and validation evidence.
