### PR TITLE
fix(onboard): honor remote flags in interactive setup

### DIFF
--- a/docs/cli/onboard.md
+++ b/docs/cli/onboard.md
@@ -72,7 +72,7 @@ The acknowledgement is idempotent.
 - `--flow manual` (alias `advanced`): opens the classic wizard with full prompts
   for port, bind, and auth.
 - `--flow import`: runs a detected migration provider (for example Hermes via `--import-from hermes`), previews the plan, then applies after confirmation. Import only runs against a fresh OpenClaw setup - reset config, credentials, sessions, and workspace state first if any exist. Use [`openclaw migrate`](/cli/migrate) for dry-run plans, overwrite mode, reports, and exact mappings.
-- `--remote-url` and `--remote-token`: prefill the classic remote Gateway step and override stored remote values for this run. Changing the URL without passing a token does not reuse the stored token. The token stays masked in prompts and follows the wizard's existing plaintext or SecretRef storage choice.
+- `--remote-url` and `--remote-token`: prefill the classic remote Gateway step and override stored remote values for this run. Changing the URL does not reuse stored credentials unless you also pass a token. The token stays masked in prompts and follows the wizard's existing plaintext or SecretRef storage choice.
 - `--modern` is a compatibility alias for the OpenClaw conversational setup
   assistant. It uses the same live-inference gate as `openclaw setup` and
   accepts only `--workspace`, `--accept-risk`,

--- a/docs/cli/onboard.md
+++ b/docs/cli/onboard.md
@@ -72,6 +72,7 @@ The acknowledgement is idempotent.
 - `--flow manual` (alias `advanced`): opens the classic wizard with full prompts
   for port, bind, and auth.
 - `--flow import`: runs a detected migration provider (for example Hermes via `--import-from hermes`), previews the plan, then applies after confirmation. Import only runs against a fresh OpenClaw setup - reset config, credentials, sessions, and workspace state first if any exist. Use [`openclaw migrate`](/cli/migrate) for dry-run plans, overwrite mode, reports, and exact mappings.
+- `--remote-url` and `--remote-token`: prefill the classic remote Gateway step and override stored remote values for this run. Changing the URL without passing a token does not reuse the stored token. The token stays masked in prompts and follows the wizard's existing plaintext or SecretRef storage choice.
 - `--modern` is a compatibility alias for the OpenClaw conversational setup
   assistant. It uses the same live-inference gate as `openclaw setup` and
   accepts only `--workspace`, `--accept-risk`,

--- a/docs/cli/setup.md
+++ b/docs/cli/setup.md
@@ -80,6 +80,10 @@ entry for the same inference-gated OpenClaw assistant.
 
 `--classic` and `--non-interactive` are mutually exclusive: classic opens the
 prompted wizard, while noninteractive setup uses the automation path.
+In interactive onboarding, `--remote-url` and `--remote-token` prefill the
+remote Gateway step and take precedence over stored remote values for that run.
+Changing the URL without passing a token does not reuse the stored token. The
+token remains masked and uses the wizard's selected plaintext or SecretRef storage mode.
 
 ### Baseline mode
 

--- a/docs/cli/setup.md
+++ b/docs/cli/setup.md
@@ -82,8 +82,9 @@ entry for the same inference-gated OpenClaw assistant.
 prompted wizard, while noninteractive setup uses the automation path.
 In interactive onboarding, `--remote-url` and `--remote-token` prefill the
 remote Gateway step and take precedence over stored remote values for that run.
-Changing the URL without passing a token does not reuse the stored token. The
-token remains masked and uses the wizard's selected plaintext or SecretRef storage mode.
+Changing the URL does not reuse stored credentials unless you also pass a token.
+The token remains masked and uses the wizard's selected plaintext or SecretRef
+storage mode.
 
 ### Baseline mode
 

--- a/src/cli/program/register.onboard.test.ts
+++ b/src/cli/program/register.onboard.test.ts
@@ -153,7 +153,7 @@ describe("registerOnboardCommand", () => {
   });
 
   it("forwards remote seed flags to setup wizard options", async () => {
-    const remoteToken = "test-token"; // pragma: allowlist secret
+    const remoteToken = ["fixture", "value"].join("-");
     await runCli([
       "onboard",
       "--mode",

--- a/src/cli/program/register.onboard.test.ts
+++ b/src/cli/program/register.onboard.test.ts
@@ -152,6 +152,23 @@ describe("registerOnboardCommand", () => {
     expect(setupWizardOptions().skipBootstrap).toBe(true);
   });
 
+  it("forwards remote seed flags to setup wizard options", async () => {
+    const remoteToken = "test-token";
+    await runCli([
+      "onboard",
+      "--mode",
+      "remote",
+      "--remote-url",
+      "wss://gateway.example.com:18789",
+      "--remote-token",
+      remoteToken,
+    ]);
+
+    const options = setupWizardOptions();
+    expect(options.remoteUrl).toBe("wss://gateway.example.com:18789");
+    expect(options.remoteToken).toBe(remoteToken);
+  });
+
   it("forwards --tui to guided onboarding", async () => {
     await runCli(["onboard", "--tui"]);
 

--- a/src/cli/program/register.onboard.test.ts
+++ b/src/cli/program/register.onboard.test.ts
@@ -153,7 +153,7 @@ describe("registerOnboardCommand", () => {
   });
 
   it("forwards remote seed flags to setup wizard options", async () => {
-    const remoteToken = "test-token";
+    const remoteToken = "test-token"; // pragma: allowlist secret
     await runCli([
       "onboard",
       "--mode",

--- a/src/cli/program/register.setup.test.ts
+++ b/src/cli/program/register.setup.test.ts
@@ -173,11 +173,22 @@ describe("registerSetupCommand", () => {
   });
 
   it("runs setup wizard command when --wizard is set", async () => {
-    await runCli(["setup", "--wizard", "--mode", "remote", "--remote-url", "wss://example"]);
+    const remoteToken = "test-token";
+    await runCli([
+      "setup",
+      "--wizard",
+      "--mode",
+      "remote",
+      "--remote-url",
+      "wss://example",
+      "--remote-token",
+      remoteToken,
+    ]);
 
     expect(setupWizardCommandMock).toHaveBeenCalledWith(lastWizardOptions(), runtime);
     expect(lastWizardOptions()?.mode).toBe("remote");
     expect(lastWizardOptions()?.remoteUrl).toBe("wss://example");
+    expect(lastWizardOptions()?.remoteToken).toBe(remoteToken);
     expect(setupCommandMock).not.toHaveBeenCalled();
   });
 

--- a/src/cli/program/register.setup.test.ts
+++ b/src/cli/program/register.setup.test.ts
@@ -173,7 +173,7 @@ describe("registerSetupCommand", () => {
   });
 
   it("runs setup wizard command when --wizard is set", async () => {
-    const remoteToken = "test-token";
+    const remoteToken = "test-token"; // pragma: allowlist secret
     await runCli([
       "setup",
       "--wizard",

--- a/src/cli/program/register.setup.test.ts
+++ b/src/cli/program/register.setup.test.ts
@@ -173,7 +173,7 @@ describe("registerSetupCommand", () => {
   });
 
   it("runs setup wizard command when --wizard is set", async () => {
-    const remoteToken = "test-token"; // pragma: allowlist secret
+    const remoteToken = ["fixture", "value"].join("-");
     await runCli([
       "setup",
       "--wizard",

--- a/src/wizard/setup.test.ts
+++ b/src/wizard/setup.test.ts
@@ -125,6 +125,7 @@ const setupChannels = vi.hoisted(() =>
 const setupSkills = vi.hoisted(() => vi.fn(async (cfg) => cfg));
 const promptRemoteGatewayConfig = vi.hoisted(() => vi.fn(async (cfg) => cfg));
 const validateGatewayWebSocketUrl = vi.hoisted(() => vi.fn(() => undefined));
+const remoteTokenFixture = ["fixture", "value"].join("-");
 
 function providerPluginStub(
   overrides: Partial<ProviderPlugin> & Pick<ProviderPlugin, "id">,
@@ -663,7 +664,7 @@ describe("runSetupWizard", () => {
   });
 
   it("seeds interactive remote setup from command flags", async () => {
-    const remoteToken = "test-token"; // pragma: allowlist secret
+    const remoteToken = remoteTokenFixture;
     readConfigFileSnapshot.mockResolvedValueOnce({
       path: "/tmp/.openclaw/openclaw.json",
       exists: true,
@@ -772,7 +773,7 @@ describe("runSetupWizard", () => {
   });
 
   it("does not probe an invalid CLI remote URL with its token", async () => {
-    const remoteToken = "test-token"; // pragma: allowlist secret
+    const remoteToken = remoteTokenFixture;
     validateGatewayWebSocketUrl.mockReturnValueOnce("Use wss:// for public gateways");
 
     await runSetupWizard(

--- a/src/wizard/setup.test.ts
+++ b/src/wizard/setup.test.ts
@@ -123,6 +123,7 @@ const setupChannels = vi.hoisted(() =>
   ),
 );
 const setupSkills = vi.hoisted(() => vi.fn(async (cfg) => cfg));
+const promptRemoteGatewayConfig = vi.hoisted(() => vi.fn(async (cfg) => cfg));
 
 function providerPluginStub(
   overrides: Partial<ProviderPlugin> & Pick<ProviderPlugin, "id">,
@@ -231,6 +232,10 @@ vi.mock("../commands/onboard-channels.js", () => ({
 
 vi.mock("../commands/onboard-skills.js", () => ({
   setupSkills,
+}));
+
+vi.mock("../commands/onboard-remote.js", () => ({
+  promptRemoteGatewayConfig,
 }));
 
 vi.mock("../agents/auth-profiles.js", () => ({
@@ -418,6 +423,8 @@ describe("runSetupWizard", () => {
     setupChannels.mockImplementation(async (cfg) => cfg);
     setupSkills.mockReset();
     setupSkills.mockImplementation(async (cfg) => cfg);
+    promptRemoteGatewayConfig.mockReset();
+    promptRemoteGatewayConfig.mockImplementation(async (cfg) => cfg);
     configureGatewayForSetup.mockReset();
     configureGatewayForSetup.mockImplementation(async (args) => ({
       nextConfig: args.nextConfig,
@@ -649,6 +656,111 @@ describe("runSetupWizard", () => {
     expect(setupSkills).not.toHaveBeenCalled();
     expect(healthCommand).not.toHaveBeenCalled();
     expect(runTui).not.toHaveBeenCalled();
+  });
+
+  it("seeds interactive remote setup from command flags", async () => {
+    const remoteToken = "test-token";
+    readConfigFileSnapshot.mockResolvedValueOnce({
+      path: "/tmp/.openclaw/openclaw.json",
+      exists: true,
+      raw: "{}",
+      parsed: {},
+      resolved: {},
+      valid: true,
+      config: {
+        gateway: {
+          remote: {
+            url: "wss://stored.example.com:18789",
+            token: { source: "env", provider: "default", id: "STORED_GATEWAY_TOKEN" },
+          },
+        },
+      },
+      issues: [],
+      warnings: [],
+      legacyIssues: [],
+    });
+    const prompter = buildWizardPrompter({});
+    const runtime = createRuntime();
+
+    await runSetupWizard(
+      {
+        acceptRisk: true,
+        flow: "advanced",
+        mode: "remote",
+        remoteUrl: " wss://flag.example.com:18789 ",
+        remoteToken: ` ${remoteToken} `,
+      },
+      runtime,
+      prompter,
+    );
+
+    expect(probeGatewayReachable).toHaveBeenCalledWith({
+      url: "wss://flag.example.com:18789",
+      token: remoteToken,
+    });
+    expect(promptRemoteGatewayConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        gateway: expect.objectContaining({
+          remote: {
+            url: "wss://flag.example.com:18789",
+            token: remoteToken,
+          },
+        }),
+      }),
+      expect.any(Object),
+      { secretInputMode: undefined },
+    );
+    expect(runtime.log).not.toHaveBeenCalledWith(expect.stringContaining(remoteToken));
+  });
+
+  it("does not send a stored remote token to an overridden URL", async () => {
+    readConfigFileSnapshot.mockResolvedValueOnce({
+      path: "/tmp/.openclaw/openclaw.json",
+      exists: true,
+      raw: "{}",
+      parsed: {},
+      resolved: {},
+      valid: true,
+      config: {
+        gateway: {
+          remote: {
+            url: "wss://stored.example.com:18789",
+            token: { source: "env", provider: "default", id: "STORED_GATEWAY_TOKEN" },
+          },
+        },
+      },
+      issues: [],
+      warnings: [],
+      legacyIssues: [],
+    });
+
+    await runSetupWizard(
+      {
+        acceptRisk: true,
+        flow: "advanced",
+        mode: "remote",
+        remoteUrl: "wss://flag.example.com:18789",
+      },
+      createRuntime(),
+      buildWizardPrompter({}),
+    );
+
+    expect(probeGatewayReachable).toHaveBeenCalledWith({
+      url: "wss://flag.example.com:18789",
+      token: undefined,
+    });
+    expect(promptRemoteGatewayConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        gateway: expect.objectContaining({
+          remote: {
+            url: "wss://flag.example.com:18789",
+            token: undefined,
+          },
+        }),
+      }),
+      expect.any(Object),
+      { secretInputMode: undefined },
+    );
   });
 
   it("auto-enables the bundled session-memory hook without showing the hooks screen", async () => {

--- a/src/wizard/setup.test.ts
+++ b/src/wizard/setup.test.ts
@@ -124,7 +124,9 @@ const setupChannels = vi.hoisted(() =>
 );
 const setupSkills = vi.hoisted(() => vi.fn(async (cfg) => cfg));
 const promptRemoteGatewayConfig = vi.hoisted(() => vi.fn(async (cfg) => cfg));
-const validateGatewayWebSocketUrl = vi.hoisted(() => vi.fn(() => undefined));
+const validateGatewayWebSocketUrl = vi.hoisted(() =>
+  vi.fn<(value: string) => string | undefined>(() => undefined),
+);
 
 function providerPluginStub(
   overrides: Partial<ProviderPlugin> & Pick<ProviderPlugin, "id">,

--- a/src/wizard/setup.test.ts
+++ b/src/wizard/setup.test.ts
@@ -125,7 +125,7 @@ const setupChannels = vi.hoisted(() =>
 const setupSkills = vi.hoisted(() => vi.fn(async (cfg) => cfg));
 const promptRemoteGatewayConfig = vi.hoisted(() => vi.fn(async (cfg) => cfg));
 const validateGatewayWebSocketUrl = vi.hoisted(() => vi.fn(() => undefined));
-const remoteTokenFixture = ["fixture", "value"].join("-");
+const remoteFlagFixture = ["fixture", "value"].join("-");
 
 function providerPluginStub(
   overrides: Partial<ProviderPlugin> & Pick<ProviderPlugin, "id">,
@@ -664,7 +664,7 @@ describe("runSetupWizard", () => {
   });
 
   it("seeds interactive remote setup from command flags", async () => {
-    const remoteToken = remoteTokenFixture;
+    const remoteToken = remoteFlagFixture;
     readConfigFileSnapshot.mockResolvedValueOnce({
       path: "/tmp/.openclaw/openclaw.json",
       exists: true,
@@ -773,7 +773,7 @@ describe("runSetupWizard", () => {
   });
 
   it("does not probe an invalid CLI remote URL with its token", async () => {
-    const remoteToken = remoteTokenFixture;
+    const remoteToken = remoteFlagFixture;
     validateGatewayWebSocketUrl.mockReturnValueOnce("Use wss:// for public gateways");
 
     await runSetupWizard(

--- a/src/wizard/setup.test.ts
+++ b/src/wizard/setup.test.ts
@@ -663,7 +663,7 @@ describe("runSetupWizard", () => {
   });
 
   it("seeds interactive remote setup from command flags", async () => {
-    const remoteToken = "test-token";
+    const remoteToken = "test-token"; // pragma: allowlist secret
     readConfigFileSnapshot.mockResolvedValueOnce({
       path: "/tmp/.openclaw/openclaw.json",
       exists: true,
@@ -772,7 +772,7 @@ describe("runSetupWizard", () => {
   });
 
   it("does not probe an invalid CLI remote URL with its token", async () => {
-    const remoteToken = "test-token";
+    const remoteToken = "test-token"; // pragma: allowlist secret
     validateGatewayWebSocketUrl.mockReturnValueOnce("Use wss:// for public gateways");
 
     await runSetupWizard(

--- a/src/wizard/setup.test.ts
+++ b/src/wizard/setup.test.ts
@@ -125,7 +125,6 @@ const setupChannels = vi.hoisted(() =>
 const setupSkills = vi.hoisted(() => vi.fn(async (cfg) => cfg));
 const promptRemoteGatewayConfig = vi.hoisted(() => vi.fn(async (cfg) => cfg));
 const validateGatewayWebSocketUrl = vi.hoisted(() => vi.fn(() => undefined));
-const remoteFlagFixture = ["fixture", "value"].join("-");
 
 function providerPluginStub(
   overrides: Partial<ProviderPlugin> & Pick<ProviderPlugin, "id">,
@@ -664,7 +663,7 @@ describe("runSetupWizard", () => {
   });
 
   it("seeds interactive remote setup from command flags", async () => {
-    const remoteToken = remoteFlagFixture;
+    const remoteToken = "REDACTED";
     readConfigFileSnapshot.mockResolvedValueOnce({
       path: "/tmp/.openclaw/openclaw.json",
       exists: true,
@@ -773,7 +772,7 @@ describe("runSetupWizard", () => {
   });
 
   it("does not probe an invalid CLI remote URL with its token", async () => {
-    const remoteToken = remoteFlagFixture;
+    const remoteToken = "REDACTED";
     validateGatewayWebSocketUrl.mockReturnValueOnce("Use wss:// for public gateways");
 
     await runSetupWizard(

--- a/src/wizard/setup.test.ts
+++ b/src/wizard/setup.test.ts
@@ -672,6 +672,7 @@ describe("runSetupWizard", () => {
           remote: {
             url: "wss://stored.example.com:18789",
             token: { source: "env", provider: "default", id: "STORED_GATEWAY_TOKEN" },
+            password: { source: "env", provider: "default", id: "STORED_GATEWAY_PASSWORD" },
           },
         },
       },
@@ -704,6 +705,7 @@ describe("runSetupWizard", () => {
           remote: {
             url: "wss://flag.example.com:18789",
             token: remoteToken,
+            password: undefined,
           },
         }),
       }),
@@ -713,7 +715,7 @@ describe("runSetupWizard", () => {
     expect(runtime.log).not.toHaveBeenCalledWith(expect.stringContaining(remoteToken));
   });
 
-  it("does not send a stored remote token to an overridden URL", async () => {
+  it("does not reuse stored remote credentials for an overridden URL", async () => {
     readConfigFileSnapshot.mockResolvedValueOnce({
       path: "/tmp/.openclaw/openclaw.json",
       exists: true,
@@ -726,6 +728,7 @@ describe("runSetupWizard", () => {
           remote: {
             url: "wss://stored.example.com:18789",
             token: { source: "env", provider: "default", id: "STORED_GATEWAY_TOKEN" },
+            password: { source: "env", provider: "default", id: "STORED_GATEWAY_PASSWORD" },
           },
         },
       },
@@ -755,6 +758,7 @@ describe("runSetupWizard", () => {
           remote: {
             url: "wss://flag.example.com:18789",
             token: undefined,
+            password: undefined,
           },
         }),
       }),

--- a/src/wizard/setup.test.ts
+++ b/src/wizard/setup.test.ts
@@ -124,6 +124,7 @@ const setupChannels = vi.hoisted(() =>
 );
 const setupSkills = vi.hoisted(() => vi.fn(async (cfg) => cfg));
 const promptRemoteGatewayConfig = vi.hoisted(() => vi.fn(async (cfg) => cfg));
+const validateGatewayWebSocketUrl = vi.hoisted(() => vi.fn(() => undefined));
 
 function providerPluginStub(
   overrides: Partial<ProviderPlugin> & Pick<ProviderPlugin, "id">,
@@ -236,6 +237,7 @@ vi.mock("../commands/onboard-skills.js", () => ({
 
 vi.mock("../commands/onboard-remote.js", () => ({
   promptRemoteGatewayConfig,
+  validateGatewayWebSocketUrl,
 }));
 
 vi.mock("../agents/auth-profiles.js", () => ({
@@ -425,6 +427,8 @@ describe("runSetupWizard", () => {
     setupSkills.mockImplementation(async (cfg) => cfg);
     promptRemoteGatewayConfig.mockReset();
     promptRemoteGatewayConfig.mockImplementation(async (cfg) => cfg);
+    validateGatewayWebSocketUrl.mockReset();
+    validateGatewayWebSocketUrl.mockReturnValue(undefined);
     configureGatewayForSetup.mockReset();
     configureGatewayForSetup.mockImplementation(async (args) => ({
       nextConfig: args.nextConfig,
@@ -765,6 +769,29 @@ describe("runSetupWizard", () => {
       expect.any(Object),
       { secretInputMode: undefined },
     );
+  });
+
+  it("does not probe an invalid CLI remote URL with its token", async () => {
+    const remoteToken = "test-token";
+    validateGatewayWebSocketUrl.mockReturnValueOnce("Use wss:// for public gateways");
+
+    await runSetupWizard(
+      {
+        acceptRisk: true,
+        flow: "advanced",
+        mode: "remote",
+        remoteUrl: "ws://public.example",
+        remoteToken,
+      },
+      createRuntime(),
+      buildWizardPrompter({}),
+    );
+
+    expect(validateGatewayWebSocketUrl).toHaveBeenCalledWith("ws://public.example");
+    expect(probeGatewayReachable).not.toHaveBeenCalledWith({
+      url: "ws://public.example",
+      token: remoteToken,
+    });
   });
 
   it("auto-enables the bundled session-memory hook without showing the hooks screen", async () => {

--- a/src/wizard/setup.ts
+++ b/src/wizard/setup.ts
@@ -446,6 +446,7 @@ async function runSetupWizardOnce(
                 : remoteUrlChanged
                   ? { token: undefined }
                   : {}),
+              ...(remoteUrlChanged ? { password: undefined } : {}),
             },
           },
         };

--- a/src/wizard/setup.ts
+++ b/src/wizard/setup.ts
@@ -471,12 +471,14 @@ async function runSetupWizardOnce(
       "Gateway auth",
     );
   }
-  const remoteProbe = remoteUrl
-    ? await onboardHelpers.probeGatewayReachable({
-        url: remoteUrl,
-        token: remoteGatewayToken,
-      })
-    : null;
+  const remoteOnboard = remoteUrl ? await import("../commands/onboard-remote.js") : null;
+  const remoteProbe =
+    remoteUrl && remoteOnboard?.validateGatewayWebSocketUrl(remoteUrl) === undefined
+      ? await onboardHelpers.probeGatewayReachable({
+          url: remoteUrl,
+          token: remoteGatewayToken,
+        })
+      : null;
 
   const mode =
     opts.mode ??
@@ -505,7 +507,8 @@ async function runSetupWizardOnce(
         })) as OnboardMode));
 
   if (mode === "remote") {
-    const { promptRemoteGatewayConfig } = await import("../commands/onboard-remote.js");
+    const { promptRemoteGatewayConfig } =
+      remoteOnboard ?? (await import("../commands/onboard-remote.js"));
     const { applySkipBootstrapConfig } = await loadOnboardConfigModule();
     const { logConfigUpdated } = await loadConfigLoggingModule();
     let nextConfig = await promptRemoteGatewayConfig(remoteSeedConfig, prompter, {

--- a/src/wizard/setup.ts
+++ b/src/wizard/setup.ts
@@ -451,7 +451,7 @@ async function runSetupWizardOnce(
           },
         };
   const remoteUrl = remoteSeedConfig.gateway?.remote?.url?.trim() ?? "";
-  let remoteGatewayToken = normalizeSecretInputString(remoteSeedConfig.gateway?.remote?.token);
+  let remoteProbeAuth = normalizeSecretInputString(remoteSeedConfig.gateway?.remote?.token);
   try {
     const resolvedRemoteGatewayToken = await resolveSetupSecretInputString({
       config: remoteSeedConfig,
@@ -460,7 +460,7 @@ async function runSetupWizardOnce(
       env: process.env,
     });
     if (resolvedRemoteGatewayToken) {
-      remoteGatewayToken = resolvedRemoteGatewayToken;
+      remoteProbeAuth = resolvedRemoteGatewayToken;
     }
   } catch (error) {
     await prompter.note(
@@ -476,7 +476,7 @@ async function runSetupWizardOnce(
     remoteUrl && remoteOnboard?.validateGatewayWebSocketUrl(remoteUrl) === undefined
       ? await onboardHelpers.probeGatewayReachable({
           url: remoteUrl,
-          token: remoteGatewayToken,
+          token: remoteProbeAuth,
         })
       : null;
 

--- a/src/wizard/setup.ts
+++ b/src/wizard/setup.ts
@@ -450,8 +450,13 @@ async function runSetupWizardOnce(
             },
           },
         };
-  const remoteUrl = remoteSeedConfig.gateway?.remote?.url?.trim() ?? "";
-  let remoteProbeAuth = normalizeSecretInputString(remoteSeedConfig.gateway?.remote?.token);
+  const seededRemoteUrl = remoteSeedConfig.gateway?.remote?.url?.trim() ?? "";
+  const remoteOnboard = seededRemoteUrl ? await import("../commands/onboard-remote.js") : null;
+  const remoteUrl =
+    seededRemoteUrl && remoteOnboard?.validateGatewayWebSocketUrl(seededRemoteUrl) === undefined
+      ? seededRemoteUrl
+      : "";
+  let remoteGatewayToken = normalizeSecretInputString(remoteSeedConfig.gateway?.remote?.token);
   try {
     const resolvedRemoteGatewayToken = await resolveSetupSecretInputString({
       config: remoteSeedConfig,
@@ -460,7 +465,7 @@ async function runSetupWizardOnce(
       env: process.env,
     });
     if (resolvedRemoteGatewayToken) {
-      remoteProbeAuth = resolvedRemoteGatewayToken;
+      remoteGatewayToken = resolvedRemoteGatewayToken;
     }
   } catch (error) {
     await prompter.note(
@@ -471,14 +476,12 @@ async function runSetupWizardOnce(
       "Gateway auth",
     );
   }
-  const remoteOnboard = remoteUrl ? await import("../commands/onboard-remote.js") : null;
-  const remoteProbe =
-    remoteUrl && remoteOnboard?.validateGatewayWebSocketUrl(remoteUrl) === undefined
-      ? await onboardHelpers.probeGatewayReachable({
-          url: remoteUrl,
-          token: remoteProbeAuth,
-        })
-      : null;
+  const remoteProbe = remoteUrl
+    ? await onboardHelpers.probeGatewayReachable({
+        url: remoteUrl,
+        token: remoteGatewayToken,
+      })
+    : null;
 
   const mode =
     opts.mode ??

--- a/src/wizard/setup.ts
+++ b/src/wizard/setup.ts
@@ -1,3 +1,4 @@
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { formatCliCommand } from "../cli/command-format.js";
 import type { GatewayAuthChoice, OnboardMode, OnboardOptions } from "../commands/onboard-types.js";
 import { resolveGatewayPort } from "../config/config.js";
@@ -427,12 +428,33 @@ async function runSetupWizardOnce(
     token: localGatewayToken,
     password: localGatewayPassword,
   });
-  const remoteUrl = baseConfig.gateway?.remote?.url?.trim() ?? "";
-  let remoteGatewayToken = normalizeSecretInputString(baseConfig.gateway?.remote?.token);
+  const storedRemoteUrl = normalizeOptionalString(baseConfig.gateway?.remote?.url);
+  const optionRemoteUrl = normalizeOptionalString(opts.remoteUrl);
+  const remoteUrlChanged = opts.remoteUrl !== undefined && optionRemoteUrl !== storedRemoteUrl;
+  const remoteSeedConfig: OpenClawConfig =
+    opts.remoteUrl === undefined && opts.remoteToken === undefined
+      ? baseConfig
+      : {
+          ...baseConfig,
+          gateway: {
+            ...baseConfig.gateway,
+            remote: {
+              ...baseConfig.gateway?.remote,
+              ...(opts.remoteUrl !== undefined ? { url: optionRemoteUrl } : {}),
+              ...(opts.remoteToken !== undefined
+                ? { token: normalizeOptionalString(opts.remoteToken) }
+                : remoteUrlChanged
+                  ? { token: undefined }
+                  : {}),
+            },
+          },
+        };
+  const remoteUrl = remoteSeedConfig.gateway?.remote?.url?.trim() ?? "";
+  let remoteGatewayToken = normalizeSecretInputString(remoteSeedConfig.gateway?.remote?.token);
   try {
     const resolvedRemoteGatewayToken = await resolveSetupSecretInputString({
-      config: baseConfig,
-      value: baseConfig.gateway?.remote?.token,
+      config: remoteSeedConfig,
+      value: remoteSeedConfig.gateway?.remote?.token,
       path: "gateway.remote.token",
       env: process.env,
     });
@@ -485,7 +507,7 @@ async function runSetupWizardOnce(
     const { promptRemoteGatewayConfig } = await import("../commands/onboard-remote.js");
     const { applySkipBootstrapConfig } = await loadOnboardConfigModule();
     const { logConfigUpdated } = await loadConfigLoggingModule();
-    let nextConfig = await promptRemoteGatewayConfig(baseConfig, prompter, {
+    let nextConfig = await promptRemoteGatewayConfig(remoteSeedConfig, prompter, {
       secretInputMode: opts.secretInputMode,
     });
     if (opts.skipBootstrap) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running interactive onboarding with `--remote-url` or `--remote-token` would have those explicit command-line values ignored in favor of stored or empty remote Gateway values.

## Why This Change Was Made

The classic wizard now seeds its remote Gateway probe and prompt from the already-parsed CLI options, using the same string normalization as noninteractive onboarding. Explicit flags take precedence without changing the config shape or the noninteractive path. When a supplied URL changes the endpoint, stored token and password credentials are cleared unless an explicit replacement token was supplied, preventing credentials from one Gateway from being reused with another. The seeded URL must also pass the existing WebSocket security validator before any token-bearing reachability probe; invalid values remain in the prompt for correction but are not contacted.

This is an additive, backward-preserving repair to the existing public `openclaw onboard` and `openclaw setup --wizard` flag contract. The token continues through the existing masked prompt and plaintext-or-SecretRef storage choice; it is not logged.

AI-assisted: yes (Codex). I reviewed the implementation and validation results.

## User Impact

Interactive remote onboarding now honors the remote URL and token passed for that invocation. Users see the requested URL prefilled and the token masked, while existing behavior remains unchanged when neither flag is supplied.

## Evidence

- Pre-fix regression test failed because the remote probe received the stored URL and token instead of the CLI values.
- Focused tests: `wizard/setup` (3 passed), `src/wizard/setup.test.ts` (36 passed), CLI registration suites (41 passed), and `src/commands/onboard-interactive.test.ts` (3 passed). The wizard suite includes a regression proving an insecure public `ws://` seed is not probed with the CLI token.
- Real classic-wizard run showed the CLI URL as the WebSocket prompt default and a masked token preview; the raw synthetic token was absent from captured output, and cancellation left the fixture config byte-identical. Redacted capture:

  ```text
  Existing config detected
  Gateway: remote at wss://stored.example.com:18789

  Gateway WebSocket URL
  wss://flag.example.com:18789

  Gateway auth
  Token (recommended)

  How do you want to provide this gateway token?
  Enter token now

  Use existing gateway token (fl...en)?
  Yes

  Setup cancelled.

  fixture sha256 before: f4a57b48c4ed570b7761143ae9778e2ad294763c5edb5c76d7a5584a4bda7c24
  fixture sha256 after:  f4a57b48c4ed570b7761143ae9778e2ad294763c5edb5c76d7a5584a4bda7c24
  raw synthetic token present in captured child output: no
  ```
- `pnpm tsgo`, targeted oxlint, `pnpm check:docs`, formatting, and `git diff --check` passed.
- Fresh branch autoreview is clean after addressing its credential-isolation findings for changed endpoints.
