### PR TITLE
fix: install exact app recommendations and retry failures

### DIFF
--- a/docs/cli/onboard.md
+++ b/docs/cli/onboard.md
@@ -46,6 +46,7 @@ openclaw onboard --import-from hermes --import-source ~/.hermes
 openclaw onboard --skip-bootstrap
 openclaw onboard recommendations --json
 openclaw onboard recommendations acknowledge
+openclaw onboard recommendations acknowledge --retry "<failed-id>"
 openclaw onboard recommendations refresh
 openclaw onboard --mode remote --remote-url wss://gateway-host:18789
 ```
@@ -63,7 +64,10 @@ onboarding run rescans installed apps and creates a new offer.
 Fresh workspaces defer the recommendation choice to the bootstrap conversation.
 After that conversation handles the user's choices,
 `openclaw onboard recommendations acknowledge` marks the stored offer answered.
-The acknowledgement is idempotent.
+The acknowledgement is idempotent. If a chosen install fails, pass each failed
+opaque ID with `--retry <id...>`; successful and declined matches are consumed,
+while failed matches remain pending for a later onboarding run. Unknown IDs
+fail without changing the stored offer.
 
 - `--classic`: opens the full step-by-step wizard. It cannot be combined with
   `--non-interactive`; omit `--classic` for automated setup.

--- a/docs/cli/onboard.md
+++ b/docs/cli/onboard.md
@@ -67,7 +67,13 @@ After that conversation handles the user's choices,
 The acknowledgement is idempotent. If a chosen install fails, pass each failed
 opaque ID with `--retry <id...>`; successful and declined matches are consumed,
 while failed matches remain pending for a later onboarding run. Unknown IDs
-fail without changing the stored offer.
+fail without changing the stored offer. After an interrupted ClawHub skill
+install, an existing target counts as successful only when
+`openclaw skills verify "@owner/slug"` succeeds for the same
+publisher-qualified recommendation ID and its JSON output reports
+`openclaw.resolution.source: "installed"`. Registry verification alone is not
+proof of a local install. Otherwise keep that ID pending with `--retry` and do
+not overwrite the existing skill.
 
 - `--classic`: opens the full step-by-step wizard. It cannot be combined with
   `--non-interactive`; omit `--classic` for automated setup.

--- a/docs/reference/templates/BOOTSTRAP.md
+++ b/docs/reference/templates/BOOTSTRAP.md
@@ -77,7 +77,19 @@ openclaw onboard recommendations acknowledge --retry "<failed-id>" ["<failed-id>
 ```
 
 Use the exact opaque IDs returned by the read command. Never acknowledge a
-failed install without `--retry`.
+failed install without `--retry`. One interrupted skill install can report that
+its target already exists on the next attempt. In that case, verify the exact
+publisher-qualified ID before treating it as successful:
+
+```bash
+openclaw skills verify "@owner/slug"
+```
+
+Only count it as installed when verification succeeds for that same ID and its
+JSON output has `openclaw.resolution.source` set to `installed`. A registry
+verification is not proof of a local install. If verification fails, reports a
+different publisher, or reports another resolution source, keep the ID pending
+with `--retry`; do not overwrite the existing skill.
 
 When the three beats are complete, delete this file. Then say one line:
 

--- a/docs/reference/templates/BOOTSTRAP.md
+++ b/docs/reference/templates/BOOTSTRAP.md
@@ -62,12 +62,22 @@ convenience?"**
   `openclaw skills install <id>`.
 - If there are no stored matches, skip this beat without commentary.
 
-After the user answers and any chosen installs finish, record completion so the
-offer never appears again:
+After the user answers and every chosen install succeeds, record completion so
+the offer never appears again:
 
 ```bash
 openclaw onboard recommendations acknowledge
 ```
+
+If an install fails, consume the successful and declined recommendations but
+leave every failed ID pending for a later onboarding run:
+
+```bash
+openclaw onboard recommendations acknowledge --retry "<failed-id>" ["<failed-id>"...]
+```
+
+Use the exact opaque IDs returned by the read command. Never acknowledge a
+failed install without `--retry`.
 
 When the three beats are complete, delete this file. Then say one line:
 

--- a/src/cli/program/register.onboard.test.ts
+++ b/src/cli/program/register.onboard.test.ts
@@ -98,7 +98,27 @@ describe("registerOnboardCommand", () => {
   it("routes the recommendations acknowledgement subcommand", async () => {
     await runCli(["onboard", "recommendations", "acknowledge"]);
 
-    expect(mocks.acknowledgeOnboardRecommendationsCommand).toHaveBeenCalledWith(runtime);
+    expect(mocks.acknowledgeOnboardRecommendationsCommand).toHaveBeenCalledWith(
+      { retry: undefined },
+      runtime,
+    );
+    expect(setupWizardCommandMock).not.toHaveBeenCalled();
+  });
+
+  it("routes failed recommendation ids through acknowledgement", async () => {
+    await runCli([
+      "onboard",
+      "recommendations",
+      "acknowledge",
+      "--retry",
+      "chat-plugin",
+      "@demo-owner/notes",
+    ]);
+
+    expect(mocks.acknowledgeOnboardRecommendationsCommand).toHaveBeenCalledWith(
+      { retry: ["chat-plugin", "@demo-owner/notes"] },
+      runtime,
+    );
     expect(setupWizardCommandMock).not.toHaveBeenCalled();
   });
 

--- a/src/cli/program/register.onboard.ts
+++ b/src/cli/program/register.onboard.ts
@@ -257,12 +257,13 @@ export function registerOnboardCommand(program: Command): void {
   recommendations
     .command("acknowledge")
     .description("Mark the stored onboarding recommendation offer as answered")
-    .action(async () => {
+    .option("--retry <id...>", "Leave failed recommendation IDs pending for a later run")
+    .action(async (opts: { retry?: string[] }) => {
       const { defaultRuntime } = await import("../../runtime.js");
       await runCommandWithRuntime(defaultRuntime, async () => {
         const { acknowledgeOnboardRecommendationsCommand } =
           await import("../../commands/onboard-recommendations.js");
-        acknowledgeOnboardRecommendationsCommand(defaultRuntime);
+        acknowledgeOnboardRecommendationsCommand({ retry: opts.retry }, defaultRuntime);
       });
     });
 

--- a/src/commands/onboard-guided.custodian.test.ts
+++ b/src/commands/onboard-guided.custodian.test.ts
@@ -135,7 +135,9 @@ function setupDeps(params: {
       })),
     persistRiskAcknowledgement: params.persistRiskAcknowledgement ?? vi.fn(async () => undefined),
     runSetupMemoryImportStep: params.runSetupMemoryImportStep ?? vi.fn(async () => undefined),
-    runAppRecommendations: params.runAppRecommendations ?? vi.fn(async ({ config }) => config),
+    runAppRecommendations:
+      params.runAppRecommendations ??
+      vi.fn(async ({ config }) => ({ config, commitResult: vi.fn() })),
     runSystemAgentChat,
     ...(params.handoffMode ? { handoffMode: params.handoffMode } : {}),
   } satisfies GuidedOnboardingDeps;

--- a/src/commands/onboard-guided.test.ts
+++ b/src/commands/onboard-guided.test.ts
@@ -110,6 +110,10 @@ function setupApplyResult() {
   };
 }
 
+function recommendationOutcome(config: OpenClawConfig) {
+  return { config, commitResult: vi.fn() };
+}
+
 function setupDeps(params: {
   prompter: WizardPrompter;
   detect?: GuidedOnboardingDeps["detect"];
@@ -149,7 +153,8 @@ function setupDeps(params: {
       })),
     persistRiskAcknowledgement: params.persistRiskAcknowledgement ?? vi.fn(async () => undefined),
     runSetupMemoryImportStep: params.runSetupMemoryImportStep ?? vi.fn(async () => undefined),
-    runAppRecommendations: params.runAppRecommendations ?? vi.fn(async ({ config }) => config),
+    runAppRecommendations:
+      params.runAppRecommendations ?? vi.fn(async ({ config }) => recommendationOutcome(config)),
     runBrowserHandoff:
       params.runBrowserHandoff ??
       (vi.fn(async () => ({
@@ -232,7 +237,7 @@ describe("runGuidedOnboarding", () => {
     });
     const applySetup = vi.fn(async () => setupApplyResult());
     const runAppRecommendations = vi.fn<NonNullable<GuidedOnboardingDeps["runAppRecommendations"]>>(
-      async ({ config }) => config,
+      async ({ config }) => recommendationOutcome(config),
     );
     const deps = setupDeps({ prompter, applySetup, runAppRecommendations });
     const runtime = makeRuntime();
@@ -275,7 +280,7 @@ describe("runGuidedOnboarding", () => {
     const prompter = createWizardPrompter();
     const applySetup = vi.fn(async () => setupApplyResult());
     const runAppRecommendations = vi.fn<NonNullable<GuidedOnboardingDeps["runAppRecommendations"]>>(
-      async ({ config }) => config,
+      async ({ config }) => recommendationOutcome(config),
     );
     const probeBrowserHandoffGateway = vi.fn(async () => ({ ok: true }));
     const runBrowserHandoff = vi.fn(async () => ({ handedOff: true as const }));

--- a/src/commands/onboard-guided.ts
+++ b/src/commands/onboard-guided.ts
@@ -449,13 +449,14 @@ async function runGuidedOnboardingFlow(
     const runAppRecommendations =
       deps.runAppRecommendations ??
       (await import("../wizard/setup.app-recommendations.js")).setupAppRecommendations;
-    const recommendedConfig = await runAppRecommendations({
+    const recommendationOutcome = await runAppRecommendations({
       config: persistedConfig,
       prompter,
       runtime,
       workspaceDir: workspace,
       modelRouteVerified: true,
     });
+    const recommendedConfig = recommendationOutcome.config;
     if (recommendedConfig !== persistedConfig) {
       const latestSnapshot = await readConfigFileSnapshot();
       if (!latestSnapshot.valid) {
@@ -476,6 +477,7 @@ async function runGuidedOnboardingFlow(
       });
       persistedConfig = mergedConfig;
     }
+    recommendationOutcome.commitResult();
   }
   const hatchWorkspace = alreadyConfigured
     ? resolveUserPath(

--- a/src/commands/onboard-recommendations.test.ts
+++ b/src/commands/onboard-recommendations.test.ts
@@ -150,7 +150,16 @@ describe("onboard recommendations command", () => {
       updatePending,
     });
 
-    expect(updatePending).toHaveBeenCalledWith({ matches: [matches[1]] });
+    expect(updatePending).toHaveBeenCalledWith({
+      matches: [matches[1]],
+      expected: {
+        inventoryHash: "hash",
+        offeredAt: 1,
+        acceptedAt: null,
+        updatedAt: 1,
+        matches,
+      },
+    });
     expect(runtime.log).toHaveBeenCalledWith(
       "Onboarding recommendations updated; 1 left pending for retry.",
     );
@@ -177,6 +186,74 @@ describe("onboard recommendations command", () => {
     expect(runtime.exit).toHaveBeenCalledWith(1);
     expect(acknowledge).not.toHaveBeenCalled();
     expect(updatePending).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when the pending offer changes before retry persistence", () => {
+    const runtime = makeRuntime();
+    const updatePending = vi.fn(() => null);
+    const match = {
+      appLabel: "Notes",
+      candidateId: "@demo-owner/notes",
+      tier: "optional" as const,
+      reason: "Connects notes",
+      candidate: {
+        id: "@demo-owner/notes",
+        displayName: "Notes skill",
+        summary: "Notes",
+        source: "clawhub-skill" as const,
+      },
+    };
+
+    acknowledgeOnboardRecommendationsCommand({ retry: [match.candidateId] }, runtime, {
+      read: () => ({
+        inventoryHash: "hash",
+        offeredAt: 1,
+        acceptedAt: null,
+        updatedAt: 1,
+        matches: [match],
+      }),
+      updatePending,
+    });
+
+    expect(runtime.error).toHaveBeenCalledWith(
+      "Stored recommendations changed; read them again before recording retries.",
+    );
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(runtime.log).not.toHaveBeenCalled();
+  });
+
+  it("clears pending bootstrap offers with legacy bare ClawHub ids", () => {
+    const runtime = makeRuntime();
+    const clearPending = vi.fn(() => true);
+
+    onboardRecommendationsCommand({ json: true }, runtime, {
+      read: () => ({
+        inventoryHash: "hash",
+        offeredAt: 1,
+        acceptedAt: null,
+        updatedAt: 1,
+        matches: [
+          {
+            appLabel: "Notes",
+            candidateId: "notes",
+            tier: "optional",
+            reason: "Connects notes",
+            candidate: {
+              id: "notes",
+              displayName: "Notes skill",
+              summary: "Notes",
+              source: "clawhub-skill",
+            },
+          },
+        ],
+      }),
+      clearPending,
+    });
+
+    expect(clearPending).toHaveBeenCalledWith({
+      expected: expect.objectContaining({ inventoryHash: "hash", updatedAt: 1 }),
+    });
+    expect(runtime.log).toHaveBeenCalledWith("[]");
   });
 
   it("clears a stored offer for the next onboarding scan", () => {

--- a/src/commands/onboard-recommendations.test.ts
+++ b/src/commands/onboard-recommendations.test.ts
@@ -97,10 +97,86 @@ describe("onboard recommendations command", () => {
       matches: [],
     }));
 
-    acknowledgeOnboardRecommendationsCommand(runtime, { acknowledge });
+    acknowledgeOnboardRecommendationsCommand({}, runtime, { acknowledge });
 
     expect(acknowledge).toHaveBeenCalledOnce();
     expect(runtime.log).toHaveBeenCalledWith("Onboarding recommendations acknowledged.");
+  });
+
+  it("leaves failed bootstrap installs pending and consumes the other matches", () => {
+    const runtime = makeRuntime();
+    const updatePending = vi.fn(() => ({
+      inventoryHash: "hash",
+      offeredAt: 1,
+      acceptedAt: null,
+      updatedAt: 2,
+      matches: [],
+    }));
+    const matches = [
+      {
+        appLabel: "Chat",
+        candidateId: "chat-plugin",
+        tier: "recommended" as const,
+        reason: "Connects conversations",
+        candidate: {
+          id: "chat-plugin",
+          displayName: "Chat plugin",
+          summary: "Chat",
+          source: "official-channel" as const,
+        },
+      },
+      {
+        appLabel: "Notes",
+        candidateId: "@demo-owner/notes",
+        tier: "optional" as const,
+        reason: "Connects notes",
+        candidate: {
+          id: "@demo-owner/notes",
+          displayName: "Notes skill",
+          summary: "Notes",
+          source: "clawhub-skill" as const,
+        },
+      },
+    ];
+
+    acknowledgeOnboardRecommendationsCommand({ retry: ["@demo-owner/notes"] }, runtime, {
+      read: () => ({
+        inventoryHash: "hash",
+        offeredAt: 1,
+        acceptedAt: null,
+        updatedAt: 1,
+        matches,
+      }),
+      updatePending,
+    });
+
+    expect(updatePending).toHaveBeenCalledWith({ matches: [matches[1]] });
+    expect(runtime.log).toHaveBeenCalledWith(
+      "Onboarding recommendations updated; 1 left pending for retry.",
+    );
+  });
+
+  it("rejects unknown bootstrap retry ids without consuming the offer", () => {
+    const runtime = makeRuntime();
+    const acknowledge = vi.fn();
+    const updatePending = vi.fn();
+
+    acknowledgeOnboardRecommendationsCommand({ retry: ["missing-skill"] }, runtime, {
+      read: () => ({
+        inventoryHash: "hash",
+        offeredAt: 1,
+        acceptedAt: null,
+        updatedAt: 1,
+        matches: [],
+      }),
+      acknowledge,
+      updatePending,
+    });
+
+    expect(runtime.error).toHaveBeenCalledWith("Unknown pending recommendation id: missing-skill");
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(acknowledge).not.toHaveBeenCalled();
+    expect(updatePending).not.toHaveBeenCalled();
   });
 
   it("clears a stored offer for the next onboarding scan", () => {

--- a/src/commands/onboard-recommendations.ts
+++ b/src/commands/onboard-recommendations.ts
@@ -3,13 +3,19 @@ import {
   acknowledgeOnboardingRecommendations,
   clearOnboardingRecommendations,
   readOnboardingRecommendations,
+  updatePendingOnboardingRecommendations,
   type OnboardingRecommendationsRecord,
 } from "../state/onboarding-recommendations.js";
 
 type OnboardRecommendationsDeps = {
   read?: () => OnboardingRecommendationsRecord | null;
   acknowledge?: () => OnboardingRecommendationsRecord | null;
+  updatePending?: typeof updatePendingOnboardingRecommendations;
   clear?: () => boolean;
+};
+
+type AcknowledgeOnboardRecommendationsOptions = {
+  retry?: readonly string[];
 };
 
 const SAFE_INSTALL_ID_RE = /^(?:@[a-z0-9][a-z0-9._-]*\/)?[a-z0-9][a-z0-9._-]*$/iu;
@@ -70,9 +76,34 @@ export function onboardRecommendationsCommand(
 }
 
 export function acknowledgeOnboardRecommendationsCommand(
+  opts: AcknowledgeOnboardRecommendationsOptions,
   runtime: RuntimeEnv,
   deps: OnboardRecommendationsDeps = {},
 ): void {
+  const retryIds = [...new Set(opts.retry ?? [])];
+  if (retryIds.length > 0) {
+    const record = (deps.read ?? readOnboardingRecommendations)();
+    const pending = bootstrapRecommendations(record);
+    const pendingIds = new Set(pending.map((match) => match.id));
+    const unknownIds = retryIds.filter((id) => !pendingIds.has(id));
+    if (unknownIds.length > 0) {
+      runtime.error(`Unknown pending recommendation id: ${unknownIds.join(", ")}`);
+      runtime.exit(1);
+      return;
+    }
+    const retryIdSet = new Set(retryIds);
+    const retryMatches =
+      record?.matches.filter((match) => retryIdSet.has(match.candidate.id)) ?? [];
+    const updated = (deps.updatePending ?? updatePendingOnboardingRecommendations)({
+      matches: retryMatches,
+    });
+    runtime.log(
+      updated?.acceptedAt == null
+        ? `Onboarding recommendations updated; ${retryIds.length} left pending for retry.`
+        : "Onboarding recommendations already acknowledged.",
+    );
+    return;
+  }
   const record = (deps.acknowledge ?? acknowledgeOnboardingRecommendations)();
   runtime.log(record ? "Onboarding recommendations acknowledged." : "No stored recommendations.");
 }

--- a/src/commands/onboard-recommendations.ts
+++ b/src/commands/onboard-recommendations.ts
@@ -2,6 +2,7 @@ import type { RuntimeEnv } from "../runtime.js";
 import {
   acknowledgeOnboardingRecommendations,
   clearOnboardingRecommendations,
+  clearPendingOnboardingRecommendations,
   readOnboardingRecommendations,
   updatePendingOnboardingRecommendations,
   type OnboardingRecommendationsRecord,
@@ -11,6 +12,7 @@ type OnboardRecommendationsDeps = {
   read?: () => OnboardingRecommendationsRecord | null;
   acknowledge?: () => OnboardingRecommendationsRecord | null;
   updatePending?: typeof updatePendingOnboardingRecommendations;
+  clearPending?: typeof clearPendingOnboardingRecommendations;
   clear?: () => boolean;
 };
 
@@ -26,6 +28,14 @@ type BootstrapRecommendation = {
   tier: "recommended" | "optional";
 };
 
+function isLegacyBareClawHubId(match: OnboardingRecommendationsRecord["matches"][number]): boolean {
+  return (
+    match.candidate.source === "clawhub-skill" &&
+    SAFE_INSTALL_ID_RE.test(match.candidate.id) &&
+    !match.candidate.id.startsWith("@")
+  );
+}
+
 function bootstrapRecommendations(
   record: OnboardingRecommendationsRecord | null,
 ): BootstrapRecommendation[] {
@@ -35,7 +45,10 @@ function bootstrapRecommendations(
   const byInstall = new Map<string, BootstrapRecommendation>();
   for (const match of record?.matches ?? []) {
     const id = match.candidate.id;
-    if (!SAFE_INSTALL_ID_RE.test(id)) {
+    if (
+      !SAFE_INSTALL_ID_RE.test(id) ||
+      (match.candidate.source === "clawhub-skill" && !id.startsWith("@"))
+    ) {
       continue;
     }
     const source = match.candidate.source === "clawhub-skill" ? "clawhub-skill" : "official-plugin";
@@ -53,7 +66,19 @@ export function onboardRecommendationsCommand(
   runtime: RuntimeEnv,
   deps: OnboardRecommendationsDeps = {},
 ): void {
-  const record = (deps.read ?? readOnboardingRecommendations)();
+  const stored = (deps.read ?? readOnboardingRecommendations)();
+  const hasLegacyClawHubId = stored?.matches.some(isLegacyBareClawHubId);
+  if (hasLegacyClawHubId && stored && stored.acceptedAt == null) {
+    const cleared = (deps.clearPending ?? clearPendingOnboardingRecommendations)({
+      expected: stored,
+    });
+    if (!cleared) {
+      runtime.error("Stored recommendations changed; read them again.");
+      runtime.exit(1);
+      return;
+    }
+  }
+  const record = hasLegacyClawHubId ? null : stored;
   // The bootstrap consumes only safe opaque install ids. Marketplace prose,
   // model reasons, and local app labels are untrusted prompt input.
   const matches = bootstrapRecommendations(record);
@@ -83,6 +108,11 @@ export function acknowledgeOnboardRecommendationsCommand(
   const retryIds = [...new Set(opts.retry ?? [])];
   if (retryIds.length > 0) {
     const record = (deps.read ?? readOnboardingRecommendations)();
+    if (!record || record.acceptedAt != null) {
+      runtime.error("No pending onboarding recommendations to retry.");
+      runtime.exit(1);
+      return;
+    }
     const pending = bootstrapRecommendations(record);
     const pendingIds = new Set(pending.map((match) => match.id));
     const unknownIds = retryIds.filter((id) => !pendingIds.has(id));
@@ -96,12 +126,14 @@ export function acknowledgeOnboardRecommendationsCommand(
       record?.matches.filter((match) => retryIdSet.has(match.candidate.id)) ?? [];
     const updated = (deps.updatePending ?? updatePendingOnboardingRecommendations)({
       matches: retryMatches,
+      expected: record,
     });
-    runtime.log(
-      updated?.acceptedAt == null
-        ? `Onboarding recommendations updated; ${retryIds.length} left pending for retry.`
-        : "Onboarding recommendations already acknowledged.",
-    );
+    if (!updated) {
+      runtime.error("Stored recommendations changed; read them again before recording retries.");
+      runtime.exit(1);
+      return;
+    }
+    runtime.log(`Onboarding recommendations updated; ${retryIds.length} left pending for retry.`);
     return;
   }
   const record = (deps.acknowledge ?? acknowledgeOnboardingRecommendations)();

--- a/src/infra/clawhub.ts
+++ b/src/infra/clawhub.ts
@@ -270,6 +270,7 @@ export type ClawHubPackageSearchResult = {
 export type ClawHubSkillSearchResult = {
   score: number;
   slug: string;
+  // Search may return the same slug for multiple publishers; exact install refs need this handle.
   ownerHandle?: string | null;
   displayName: string;
   summary?: string;

--- a/src/state/onboarding-recommendations.test.ts
+++ b/src/state/onboarding-recommendations.test.ts
@@ -3,8 +3,10 @@ import { afterEach, describe, expect, it } from "vitest";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import {
   acknowledgeOnboardingRecommendations,
+  clearPendingOnboardingRecommendations,
   clearOnboardingRecommendations,
   readOnboardingRecommendations,
+  updatePendingOnboardingRecommendations,
   writeOnboardingRecommendationsOffer,
   type OnboardingRecommendationMatch,
 } from "./onboarding-recommendations.js";
@@ -84,6 +86,60 @@ describe("onboarding recommendations store", () => {
       expect(acknowledged).toEqual({ ...record, acceptedAt: 3_456, updatedAt: 3_456 });
       expect(readOnboardingRecommendations({ env: state.env })).toEqual(acknowledged);
     });
+  });
+
+  it("updates pending matches without changing the inventory identity", async () => {
+    await withOpenClawTestState({ label: "onboarding-recommendations-retry" }, async (state) => {
+      const database = { env: state.env };
+      const record = writeOnboardingRecommendationsOffer({
+        inventory: [{ label: "Chat" }, { label: "Notes" }],
+        matches,
+        answered: false,
+        nowMs: 2_000,
+        database,
+      });
+      const retryMatch = { ...matches[0]!, reason: "Retry this install" };
+
+      const updated = updatePendingOnboardingRecommendations({
+        matches: [retryMatch],
+        nowMs: 3_000,
+        database,
+      });
+
+      expect(updated).toEqual({
+        ...record,
+        matches: [retryMatch],
+        updatedAt: 3_000,
+      });
+      expect(updated?.inventoryHash).toBe(record.inventoryHash);
+    });
+  });
+
+  it("clears only pending offers", async () => {
+    await withOpenClawTestState(
+      { label: "onboarding-recommendations-pending-clear" },
+      async (state) => {
+        const database = { env: state.env };
+        writeOnboardingRecommendationsOffer({
+          inventory: [{ label: "Chat" }],
+          matches,
+          answered: false,
+          database,
+        });
+
+        expect(clearPendingOnboardingRecommendations(database)).toBe(true);
+        expect(readOnboardingRecommendations(database)).toBeNull();
+
+        writeOnboardingRecommendationsOffer({
+          inventory: [{ label: "Chat" }],
+          matches,
+          answered: true,
+          database,
+        });
+        expect(clearPendingOnboardingRecommendations(database)).toBe(false);
+        expect(readOnboardingRecommendations(database)?.acceptedAt).toBeTypeOf("number");
+      },
+    );
   });
 
   it("deletes the stored offer so recommendations can be scanned again", async () => {

--- a/src/state/onboarding-recommendations.test.ts
+++ b/src/state/onboarding-recommendations.test.ts
@@ -102,6 +102,7 @@ describe("onboarding recommendations store", () => {
 
       const updated = updatePendingOnboardingRecommendations({
         matches: [retryMatch],
+        expected: record,
         nowMs: 3_000,
         database,
       });
@@ -115,28 +116,65 @@ describe("onboarding recommendations store", () => {
     });
   });
 
+  it("does not overwrite a concurrently replaced pending offer", async () => {
+    await withOpenClawTestState({ label: "onboarding-recommendations-stale" }, async (state) => {
+      const database = { env: state.env };
+      const original = writeOnboardingRecommendationsOffer({
+        inventory: [{ label: "Chat" }],
+        matches,
+        answered: false,
+        nowMs: 2_000,
+        database,
+      });
+      const replacement = writeOnboardingRecommendationsOffer({
+        inventory: [{ label: "Notes" }],
+        matches: [],
+        answered: false,
+        nowMs: 2_500,
+        database,
+      });
+
+      expect(
+        updatePendingOnboardingRecommendations({
+          matches,
+          expected: original,
+          nowMs: 3_000,
+          database,
+        }),
+      ).toBeNull();
+      expect(
+        acknowledgeOnboardingRecommendations({
+          expected: original,
+          nowMs: 3_000,
+          database,
+        }),
+      ).toBeNull();
+      expect(readOnboardingRecommendations(database)).toEqual(replacement);
+    });
+  });
+
   it("clears only pending offers", async () => {
     await withOpenClawTestState(
       { label: "onboarding-recommendations-pending-clear" },
       async (state) => {
         const database = { env: state.env };
-        writeOnboardingRecommendationsOffer({
+        const pending = writeOnboardingRecommendationsOffer({
           inventory: [{ label: "Chat" }],
           matches,
           answered: false,
           database,
         });
 
-        expect(clearPendingOnboardingRecommendations(database)).toBe(true);
+        expect(clearPendingOnboardingRecommendations({ expected: pending, database })).toBe(true);
         expect(readOnboardingRecommendations(database)).toBeNull();
 
-        writeOnboardingRecommendationsOffer({
+        const accepted = writeOnboardingRecommendationsOffer({
           inventory: [{ label: "Chat" }],
           matches,
           answered: true,
           database,
         });
-        expect(clearPendingOnboardingRecommendations(database)).toBe(false);
+        expect(clearPendingOnboardingRecommendations({ expected: accepted, database })).toBe(false);
         expect(readOnboardingRecommendations(database)?.acceptedAt).toBeTypeOf("number");
       },
     );

--- a/src/state/onboarding-recommendations.ts
+++ b/src/state/onboarding-recommendations.ts
@@ -190,6 +190,7 @@ export function acknowledgeOnboardingRecommendations(
   params: {
     nowMs?: number;
     database?: OpenClawStateDatabaseOptions;
+    expected?: OnboardingRecommendationsRecord;
   } = {},
 ): OnboardingRecommendationsRecord | null {
   const nowMs = params.nowMs ?? Date.now();
@@ -212,14 +213,33 @@ export function acknowledgeOnboardingRecommendations(
       if (!existing) {
         return null;
       }
+      if (
+        params.expected &&
+        (existing.inventory_hash !== params.expected.inventoryHash ||
+          existing.matches_json !== JSON.stringify(params.expected.matches) ||
+          existing.offered_at_ms !== params.expected.offeredAt ||
+          existing.accepted_at_ms !== params.expected.acceptedAt ||
+          existing.updated_at_ms !== params.expected.updatedAt)
+      ) {
+        return null;
+      }
       if (typeof existing.accepted_at_ms !== "number") {
-        executeSqliteQuerySync(
-          database.db,
-          db
-            .updateTable("onboarding_recommendations")
-            .set({ accepted_at_ms: nowMs, updated_at_ms: nowMs })
-            .where("config_key", "=", ONBOARDING_RECOMMENDATIONS_KEY),
-        );
+        let update = db
+          .updateTable("onboarding_recommendations")
+          .set({ accepted_at_ms: nowMs, updated_at_ms: nowMs })
+          .where("config_key", "=", ONBOARDING_RECOMMENDATIONS_KEY);
+        if (params.expected) {
+          update = update
+            .where("inventory_hash", "=", params.expected.inventoryHash)
+            .where("matches_json", "=", JSON.stringify(params.expected.matches))
+            .where("offered_at_ms", "=", params.expected.offeredAt)
+            .where("accepted_at_ms", "is", params.expected.acceptedAt)
+            .where("updated_at_ms", "=", params.expected.updatedAt);
+        }
+        const result = executeSqliteQuerySync(database.db, update);
+        if ((result.numAffectedRows ?? 0n) === 0n) {
+          return null;
+        }
       }
       const acceptedAt = existing.accepted_at_ms ?? nowMs;
       return {
@@ -237,6 +257,7 @@ export function acknowledgeOnboardingRecommendations(
 
 export function updatePendingOnboardingRecommendations(params: {
   matches: readonly OnboardingRecommendationMatch[];
+  expected: OnboardingRecommendationsRecord;
   nowMs?: number;
   database?: OpenClawStateDatabaseOptions;
 }): OnboardingRecommendationsRecord | null {
@@ -258,27 +279,32 @@ export function updatePendingOnboardingRecommendations(params: {
           ])
           .where("config_key", "=", ONBOARDING_RECOMMENDATIONS_KEY),
       );
-      if (!existing || typeof existing.accepted_at_ms === "number") {
-        return existing
-          ? {
-              inventoryHash: existing.inventory_hash,
-              matches: OnboardingRecommendationMatchesSchema.parse(
-                JSON.parse(existing.matches_json),
-              ),
-              offeredAt: existing.offered_at_ms,
-              acceptedAt: existing.accepted_at_ms,
-              updatedAt: existing.updated_at_ms,
-            }
-          : null;
+      if (
+        !existing ||
+        typeof existing.accepted_at_ms === "number" ||
+        existing.inventory_hash !== params.expected.inventoryHash ||
+        existing.matches_json !== JSON.stringify(params.expected.matches) ||
+        existing.offered_at_ms !== params.expected.offeredAt ||
+        existing.accepted_at_ms !== params.expected.acceptedAt ||
+        existing.updated_at_ms !== params.expected.updatedAt
+      ) {
+        return null;
       }
-      executeSqliteQuerySync(
+      const result = executeSqliteQuerySync(
         database.db,
         db
           .updateTable("onboarding_recommendations")
           .set({ matches_json: JSON.stringify(matches), updated_at_ms: nowMs })
           .where("config_key", "=", ONBOARDING_RECOMMENDATIONS_KEY)
-          .where("accepted_at_ms", "is", null),
+          .where("accepted_at_ms", "is", null)
+          .where("inventory_hash", "=", params.expected.inventoryHash)
+          .where("matches_json", "=", JSON.stringify(params.expected.matches))
+          .where("offered_at_ms", "=", params.expected.offeredAt)
+          .where("updated_at_ms", "=", params.expected.updatedAt),
       );
+      if ((result.numAffectedRows ?? 0n) === 0n) {
+        return null;
+      }
       return {
         inventoryHash: existing.inventory_hash,
         matches,
@@ -292,9 +318,10 @@ export function updatePendingOnboardingRecommendations(params: {
   );
 }
 
-export function clearPendingOnboardingRecommendations(
-  databaseOptions: OpenClawStateDatabaseOptions = {},
-): boolean {
+export function clearPendingOnboardingRecommendations(params: {
+  expected: OnboardingRecommendationsRecord;
+  database?: OpenClawStateDatabaseOptions;
+}): boolean {
   return runOpenClawStateWriteTransaction(
     (database) => {
       const db = getNodeSqliteKysely<OnboardingRecommendationsDatabase>(database.db);
@@ -303,11 +330,15 @@ export function clearPendingOnboardingRecommendations(
         db
           .deleteFrom("onboarding_recommendations")
           .where("config_key", "=", ONBOARDING_RECOMMENDATIONS_KEY)
-          .where("accepted_at_ms", "is", null),
+          .where("accepted_at_ms", "is", null)
+          .where("inventory_hash", "=", params.expected.inventoryHash)
+          .where("matches_json", "=", JSON.stringify(params.expected.matches))
+          .where("offered_at_ms", "=", params.expected.offeredAt)
+          .where("updated_at_ms", "=", params.expected.updatedAt),
       );
       return (result.numAffectedRows ?? 0n) > 0n;
     },
-    databaseOptions,
+    params.database,
     { operationLabel: "onboarding.recommendations.clear-pending" },
   );
 }

--- a/src/state/onboarding-recommendations.ts
+++ b/src/state/onboarding-recommendations.ts
@@ -235,6 +235,83 @@ export function acknowledgeOnboardingRecommendations(
   );
 }
 
+export function updatePendingOnboardingRecommendations(params: {
+  matches: readonly OnboardingRecommendationMatch[];
+  nowMs?: number;
+  database?: OpenClawStateDatabaseOptions;
+}): OnboardingRecommendationsRecord | null {
+  const nowMs = params.nowMs ?? Date.now();
+  const matches = OnboardingRecommendationMatchesSchema.parse(params.matches);
+  return runOpenClawStateWriteTransaction(
+    (database) => {
+      const db = getNodeSqliteKysely<OnboardingRecommendationsDatabase>(database.db);
+      const existing = executeSqliteQueryTakeFirstSync(
+        database.db,
+        db
+          .selectFrom("onboarding_recommendations")
+          .select([
+            "inventory_hash",
+            "matches_json",
+            "offered_at_ms",
+            "accepted_at_ms",
+            "updated_at_ms",
+          ])
+          .where("config_key", "=", ONBOARDING_RECOMMENDATIONS_KEY),
+      );
+      if (!existing || typeof existing.accepted_at_ms === "number") {
+        return existing
+          ? {
+              inventoryHash: existing.inventory_hash,
+              matches: OnboardingRecommendationMatchesSchema.parse(
+                JSON.parse(existing.matches_json),
+              ),
+              offeredAt: existing.offered_at_ms,
+              acceptedAt: existing.accepted_at_ms,
+              updatedAt: existing.updated_at_ms,
+            }
+          : null;
+      }
+      executeSqliteQuerySync(
+        database.db,
+        db
+          .updateTable("onboarding_recommendations")
+          .set({ matches_json: JSON.stringify(matches), updated_at_ms: nowMs })
+          .where("config_key", "=", ONBOARDING_RECOMMENDATIONS_KEY)
+          .where("accepted_at_ms", "is", null),
+      );
+      return {
+        inventoryHash: existing.inventory_hash,
+        matches,
+        offeredAt: existing.offered_at_ms,
+        acceptedAt: null,
+        updatedAt: nowMs,
+      };
+    },
+    params.database,
+    { operationLabel: "onboarding.recommendations.update-pending" },
+  );
+}
+
+export function clearPendingOnboardingRecommendations(
+  databaseOptions: OpenClawStateDatabaseOptions = {},
+): boolean {
+  return runOpenClawStateWriteTransaction(
+    (database) => {
+      const db = getNodeSqliteKysely<OnboardingRecommendationsDatabase>(database.db);
+      const result = executeSqliteQuerySync(
+        database.db,
+        db
+          .deleteFrom("onboarding_recommendations")
+          .where("config_key", "=", ONBOARDING_RECOMMENDATIONS_KEY)
+          .where("accepted_at_ms", "is", null),
+      );
+      return (result.numAffectedRows ?? 0n) > 0n;
+    },
+    databaseOptions,
+    { operationLabel: "onboarding.recommendations.clear-pending" },
+  );
+}
+
 export function clearOnboardingRecommendations(
   databaseOptions: OpenClawStateDatabaseOptions = {},
 ): boolean {

--- a/src/system-agent/setup-app-recommendations.test.ts
+++ b/src/system-agent/setup-app-recommendations.test.ts
@@ -33,6 +33,47 @@ function officialEntry(params: {
 }
 
 describe("setup app recommendation candidates", () => {
+  it("preserves the ClawHub publisher in candidate ids", async () => {
+    const result = await getSetupAppRecommendations({
+      inventorySource: async () => [{ label: "Notes" }],
+      runtime: defaultRuntime,
+      deps: {
+        listPlugins: () => [],
+        listChannels: () => [],
+        listProviders: () => [],
+        searchSkills: async () => [
+          {
+            score: 1,
+            slug: "notes-tools",
+            ownerHandle: "demo-owner",
+            displayName: "Notes Tools",
+          },
+          {
+            score: 0.9,
+            slug: "notes-tools",
+            ownerHandle: "other-owner",
+            displayName: "Other Notes Tools",
+          },
+          {
+            score: 0.8,
+            slug: "legacy-notes-tools",
+            displayName: "Ownerless Notes Tools",
+          },
+        ],
+        complete: completeMatching([{ appLabel: "Notes", candidateId: "@demo-owner/notes-tools" }]),
+      },
+    });
+
+    expect(result.status).toBe("ok");
+    if (result.status === "ok") {
+      expect(result.groups[0]?.candidates.map((candidate) => candidate.id)).toEqual([
+        "@demo-owner/notes-tools",
+        "@other-owner/notes-tools",
+      ]);
+      expect(result.matches[0]?.candidate.id).toBe("@demo-owner/notes-tools");
+    }
+  });
+
   it("gathers, dedupes, and sorts official and ClawHub candidates", async () => {
     const channel = officialEntry({
       id: "chat",
@@ -46,8 +87,19 @@ describe("setup app recommendation candidates", () => {
       description: "Notes integration",
     });
     const searchSkills = vi.fn(async () => [
-      { score: 2, slug: "notes", displayName: "Duplicate notes" },
-      { score: 1, slug: "notes-tools", displayName: "Notes Tools", summary: "Work with notes" },
+      {
+        score: 2,
+        slug: "notes-tools",
+        ownerHandle: "demo-owner",
+        displayName: "Duplicate notes",
+      },
+      {
+        score: 1,
+        slug: "notes-tools",
+        ownerHandle: "demo-owner",
+        displayName: "Notes Tools",
+        summary: "Work with notes",
+      },
     ]);
 
     const result = await getSetupAppRecommendations({
@@ -68,7 +120,7 @@ describe("setup app recommendation candidates", () => {
       const notes = result.groups.find((group) => group.app.label === "Notes");
       expect(notes?.candidates.map((candidate) => [candidate.source, candidate.id])).toEqual([
         ["official-plugin", "notes"],
-        ["clawhub-skill", "notes-tools"],
+        ["clawhub-skill", "@demo-owner/notes-tools"],
       ]);
     }
     expect(searchSkills).toHaveBeenCalledTimes(2);
@@ -79,7 +131,7 @@ describe("setup app recommendation candidates", () => {
       if (query === "Broken") {
         throw new Error("offline");
       }
-      return [{ score: 1, slug: "working", displayName: "Working" }];
+      return [{ score: 1, slug: "working", ownerHandle: "demo-owner", displayName: "Working" }];
     });
     const result = await getSetupAppRecommendations({
       inventorySource: async () => [{ label: "Broken" }, { label: "Working" }],
@@ -89,7 +141,7 @@ describe("setup app recommendation candidates", () => {
         listChannels: () => [],
         listProviders: () => [],
         searchSkills,
-        complete: completeMatching([{ appLabel: "Working", candidateId: "working" }]),
+        complete: completeMatching([{ appLabel: "Working", candidateId: "@demo-owner/working" }]),
       },
     });
     expect(result.status).toBe("ok");
@@ -138,7 +190,13 @@ describe("setup app recommendation matcher", () => {
     listChannels: () => [],
     listProviders: () => [],
     searchSkills: async () => [
-      { score: 1, slug: "notes-tools", displayName: "Notes Tools", summary: "Work with notes" },
+      {
+        score: 1,
+        slug: "notes-tools",
+        ownerHandle: "demo-owner",
+        displayName: "Notes Tools",
+        summary: "Work with notes",
+      },
     ],
   };
 
@@ -154,7 +212,7 @@ describe("setup app recommendation matcher", () => {
             matches: [
               {
                 appLabel: "Notes",
-                candidateId: "notes-tools",
+                candidateId: "@demo-owner/notes-tools",
                 tier: "recommended",
                 reason: "Connects directly to your notes",
               },
@@ -165,7 +223,10 @@ describe("setup app recommendation matcher", () => {
     });
     expect(result.status).toBe("ok");
     if (result.status === "ok") {
-      expect(result.matches[0]).toMatchObject({ candidateId: "notes-tools", tier: "recommended" });
+      expect(result.matches[0]).toMatchObject({
+        candidateId: "@demo-owner/notes-tools",
+        tier: "recommended",
+      });
     }
   });
 
@@ -185,7 +246,7 @@ describe("setup app recommendation matcher", () => {
               matches: [
                 {
                   appLabel: "Notes",
-                  candidateId: "notes-tools",
+                  candidateId: "@demo-owner/notes-tools",
                   tier: "optional",
                   reason,
                   confidence: "high",
@@ -199,7 +260,7 @@ describe("setup app recommendation matcher", () => {
     });
     expect(result.status).toBe("ok");
     if (result.status === "ok") {
-      expect(result.matches[0]?.candidateId).toBe("notes-tools");
+      expect(result.matches[0]?.candidateId).toBe("@demo-owner/notes-tools");
       expect(result.matches[0]?.reason).toBe(`${"a".repeat(118)}…`);
       expect(result.matches[0]?.reason.length).toBeLessThanOrEqual(120);
     }

--- a/src/system-agent/setup-app-recommendations.ts
+++ b/src/system-agent/setup-app-recommendations.ts
@@ -1,3 +1,4 @@
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import pLimit from "p-limit";
 import { z } from "zod";
@@ -255,14 +256,19 @@ async function gatherSetupAppCandidates(params: {
             limit: CLAWHUB_SEARCH_LIMIT,
             timeoutMs: CLAWHUB_SEARCH_TIMEOUT_MS,
           });
-          return results.slice(0, CLAWHUB_SEARCH_LIMIT).map(
-            (result): SetupAppCandidate => ({
-              id: result.slug,
-              displayName: result.displayName,
-              summary: result.summary?.trim() || "ClawHub skill",
-              source: "clawhub-skill",
-            }),
-          );
+          return results.slice(0, CLAWHUB_SEARCH_LIMIT).flatMap((result): SetupAppCandidate[] => {
+            const ownerHandle = normalizeOptionalString(result.ownerHandle);
+            return ownerHandle
+              ? [
+                  {
+                    id: `@${ownerHandle}/${result.slug}`,
+                    displayName: result.displayName,
+                    summary: result.summary?.trim() || "ClawHub skill",
+                    source: "clawhub-skill",
+                  },
+                ]
+              : [];
+          });
         } catch {
           return [];
         }

--- a/src/wizard/setup.app-recommendations.test.ts
+++ b/src/wizard/setup.app-recommendations.test.ts
@@ -52,11 +52,11 @@ function recommendationResult(): Extract<SetupAppRecommendationsResult, { status
     },
     {
       appLabel: "Chat",
-      candidateId: "chat-skill",
+      candidateId: "@demo-owner/chat-skill",
       tier: "optional" as const,
       reason: "Adds useful actions",
       candidate: {
-        id: "chat-skill",
+        id: "@demo-owner/chat-skill",
         displayName: "Chat skill",
         summary: "Chat skill",
         source: "clawhub-skill" as const,
@@ -199,6 +199,42 @@ describe("setupAppRecommendations", () => {
     expect(ensurePlugin).toHaveBeenCalledOnce();
   });
 
+  it("rescans a pending offer with a bare ClawHub id", async () => {
+    const pendingMatches = recommendationResult().matches;
+    pendingMatches[1] = {
+      ...pendingMatches[1]!,
+      candidateId: "chat-skill",
+      candidate: { ...pendingMatches[1]!.candidate, id: "chat-skill" },
+    };
+    const recommend = vi.fn(async () => recommendationResult());
+    const clearPendingStored = vi.fn(() => true);
+
+    await setupAppRecommendations({
+      config: {},
+      prompter: createPrompter(),
+      runtime,
+      workspaceDir: "/tmp/workspace",
+      modelRouteVerified: true,
+      platform: "darwin",
+      deps: {
+        recommend,
+        readStored: () => ({
+          inventoryHash: "hash",
+          matches: pendingMatches,
+          offeredAt: 1,
+          acceptedAt: null,
+          updatedAt: 1,
+        }),
+        writeOffer: vi.fn(),
+        clearPendingStored,
+        deferOfferToBootstrap: () => false,
+      },
+    });
+
+    expect(clearPendingStored).toHaveBeenCalledOnce();
+    expect(recommend).toHaveBeenCalledOnce();
+  });
+
   it("leaves a pending stored offer to the bootstrap without rescanning", async () => {
     const recommend = vi.fn(async () => recommendationResult());
     const writeOffer = vi.fn();
@@ -255,6 +291,7 @@ describe("setupAppRecommendations", () => {
   it("preselects recommended matches and installs selected plugin and skill", async () => {
     const config: OpenClawConfig = {};
     const prompter = createPrompter(["recommendation:0", "recommendation:1"]);
+    const store = storeDeps();
     const ensurePlugin = vi.fn(async () => ({
       cfg: { ...config, plugins: { entries: { "chat-plugin": { enabled: true } } } },
       installed: true,
@@ -276,7 +313,7 @@ describe("setupAppRecommendations", () => {
       modelRouteVerified: true,
       platform: "darwin",
       deps: {
-        ...storeDeps(),
+        ...store,
         recommend: async () => recommendationResult(),
         ensurePlugin,
         installSkill,
@@ -293,7 +330,96 @@ describe("setupAppRecommendations", () => {
     );
     expect(ensurePlugin).toHaveBeenCalledOnce();
     expect(installSkill).toHaveBeenCalledOnce();
+    expect(installSkill).toHaveBeenCalledWith(
+      expect.objectContaining({ slug: "@demo-owner/chat-skill" }),
+    );
+    expect(store.writeOffer).toHaveBeenCalledWith(expect.objectContaining({ answered: true }));
+    expect(installSkill.mock.invocationCallOrder[0]).toBeLessThan(
+      store.writeOffer.mock.invocationCallOrder[0]!,
+    );
     expect(result.plugins?.entries?.["chat-plugin"]?.enabled).toBe(true);
+  });
+
+  it("reoffers a failed install and consumes it after a successful retry", async () => {
+    const storeState: { current: OnboardingRecommendationsRecord | null } = { current: null };
+    let now = 0;
+    const writeOffer = vi.fn(
+      (
+        params: Parameters<
+          typeof import("../state/onboarding-recommendations.js").writeOnboardingRecommendationsOffer
+        >[0],
+      ) => {
+        now += 1;
+        storeState.current = {
+          inventoryHash: "hash",
+          matches: [...params.matches],
+          offeredAt: now,
+          acceptedAt: params.answered ? now : null,
+          updatedAt: now,
+        };
+        return storeState.current;
+      },
+    );
+    const acknowledgeStored = vi.fn(() => {
+      if (!storeState.current) {
+        return null;
+      }
+      now += 1;
+      storeState.current = { ...storeState.current, acceptedAt: now, updatedAt: now };
+      return storeState.current;
+    });
+    const recommend = vi.fn(async () => recommendationResult());
+    const installSkill = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: false as const, error: "offline" })
+      .mockResolvedValueOnce({
+        ok: true as const,
+        slug: "chat-skill",
+        version: "1.0.0",
+        targetDir: "/tmp/workspace/skills/chat-skill",
+      });
+    const prompter = createPrompter();
+    vi.mocked(prompter.multiselect)
+      .mockResolvedValueOnce(["recommendation:1"])
+      .mockResolvedValueOnce(["recommendation:0"]);
+    const deps = {
+      recommend,
+      installSkill,
+      readStored: () => storeState.current,
+      writeOffer,
+      acknowledgeStored,
+      deferOfferToBootstrap: () => false,
+    };
+
+    await setupAppRecommendations({
+      config: {},
+      prompter,
+      runtime,
+      workspaceDir: "/tmp/workspace",
+      modelRouteVerified: true,
+      platform: "darwin",
+      deps,
+    });
+
+    expect(storeState.current).toMatchObject({
+      acceptedAt: null,
+      matches: [expect.objectContaining({ candidateId: "@demo-owner/chat-skill" })],
+    });
+
+    await setupAppRecommendations({
+      config: {},
+      prompter,
+      runtime,
+      workspaceDir: "/tmp/workspace",
+      modelRouteVerified: true,
+      platform: "darwin",
+      deps,
+    });
+
+    expect(recommend).toHaveBeenCalledOnce();
+    expect(installSkill).toHaveBeenCalledTimes(2);
+    expect(acknowledgeStored).toHaveBeenCalledOnce();
+    expect(storeState.current?.acceptedAt).toBeTypeOf("number");
   });
 
   it("installs nothing when the explicit skip entry is selected", async () => {

--- a/src/wizard/setup.app-recommendations.test.ts
+++ b/src/wizard/setup.app-recommendations.test.ts
@@ -425,9 +425,24 @@ describe("setupAppRecommendations", () => {
     expect(store.writeOffer.mock.invocationCallOrder[0]).toBeLessThan(
       ensurePlugin.mock.invocationCallOrder[0]!,
     );
+    expect(store.updatePendingStored).toHaveBeenCalledWith({
+      matches: [recommendationResult().matches[0]],
+      expected: expect.objectContaining({
+        matches: recommendationResult().matches,
+        updatedAt: 1,
+      }),
+    });
+    expect(installSkill.mock.invocationCallOrder[0]).toBeLessThan(
+      store.updatePendingStored.mock.invocationCallOrder[0]!,
+    );
+    expect(store.acknowledgeStored).not.toHaveBeenCalled();
     outcome.commitResult();
     expect(store.acknowledgeStored).toHaveBeenCalledWith({
-      expected: expect.objectContaining({ inventoryHash: "hash", updatedAt: 1 }),
+      expected: expect.objectContaining({
+        inventoryHash: "hash",
+        matches: [recommendationResult().matches[0]],
+        updatedAt: 2,
+      }),
     });
     expect(store.writeOffer).toHaveBeenCalledOnce();
     expect(outcome.config.plugins?.entries?.["chat-plugin"]?.enabled).toBe(true);
@@ -549,6 +564,40 @@ describe("setupAppRecommendations", () => {
     expect(installSkill).toHaveBeenCalledTimes(2);
     expect(acknowledgeStored).toHaveBeenCalledOnce();
     expect(storeState.current?.acceptedAt).toBeTypeOf("number");
+  });
+
+  it("consumes an exact installed skill left pending by an interrupted run", async () => {
+    const skill = recommendationResult().matches[1]!;
+    const stored: OnboardingRecommendationsRecord = {
+      inventoryHash: "hash",
+      matches: [skill],
+      offeredAt: 1,
+      acceptedAt: null,
+      updatedAt: 1,
+    };
+    const store = storeDeps(stored);
+    const installSkill = vi.fn();
+
+    const outcome = await setupAppRecommendationsWithOutcome({
+      config: {},
+      prompter: createPrompter(["recommendation:0"]),
+      runtime,
+      workspaceDir: "/tmp/workspace",
+      modelRouteVerified: true,
+      platform: "darwin",
+      deps: {
+        ...store,
+        installSkill,
+        isSkillInstalled: vi.fn(async ({ skillRef }) => skillRef === skill.candidate.id),
+      },
+    });
+
+    expect(installSkill).not.toHaveBeenCalled();
+    expect(store.acknowledgeStored).toHaveBeenCalledWith({
+      expected: expect.objectContaining({ matches: [skill], updatedAt: 1 }),
+    });
+    outcome.commitResult();
+    expect(store.acknowledgeStored).toHaveBeenCalledOnce();
   });
 
   it("installs nothing when the explicit skip entry is selected", async () => {

--- a/src/wizard/setup.app-recommendations.test.ts
+++ b/src/wizard/setup.app-recommendations.test.ts
@@ -38,10 +38,68 @@ const runtime: RuntimeEnv = {
   exit: vi.fn(),
 };
 
-function storeDeps() {
+function storeDeps(initial: OnboardingRecommendationsRecord | null = null) {
+  let current = initial;
+  let now = 0;
+  const writeOffer = vi.fn(
+    (
+      params: Parameters<
+        typeof import("../state/onboarding-recommendations.js").writeOnboardingRecommendationsOffer
+      >[0],
+    ) => {
+      now += 1;
+      current = {
+        inventoryHash: "hash",
+        matches: [...params.matches],
+        offeredAt: now,
+        acceptedAt: params.answered ? now : null,
+        updatedAt: now,
+      };
+      return current;
+    },
+  );
+  const acknowledgeStored = vi.fn(
+    (
+      params: Parameters<
+        typeof import("../state/onboarding-recommendations.js").acknowledgeOnboardingRecommendations
+      >[0] = {},
+    ) => {
+      if (
+        !current ||
+        (params.expected &&
+          (params.expected.inventoryHash !== current.inventoryHash ||
+            params.expected.updatedAt !== current.updatedAt))
+      ) {
+        return null;
+      }
+      now += 1;
+      current = { ...current, acceptedAt: now, updatedAt: now };
+      return current;
+    },
+  );
+  const updatePendingStored = vi.fn(
+    (
+      params: Parameters<
+        typeof import("../state/onboarding-recommendations.js").updatePendingOnboardingRecommendations
+      >[0],
+    ) => {
+      if (
+        !current ||
+        params.expected.inventoryHash !== current.inventoryHash ||
+        params.expected.updatedAt !== current.updatedAt
+      ) {
+        return null;
+      }
+      now += 1;
+      current = { ...current, matches: [...params.matches], updatedAt: now };
+      return current;
+    },
+  );
   return {
-    readStored: vi.fn((): OnboardingRecommendationsRecord | null => null),
-    writeOffer: vi.fn(),
+    readStored: vi.fn((): OnboardingRecommendationsRecord | null => current),
+    writeOffer,
+    acknowledgeStored,
+    updatePendingStored,
     deferOfferToBootstrap: vi.fn(() => false),
   };
 }
@@ -100,7 +158,9 @@ describe("setupAppRecommendations", () => {
   it("short-circuits before scanning when the offer was already answered", async () => {
     const recommend = vi.fn(async () => recommendationResult());
     const writeOffer = vi.fn();
+    const clearPendingStored = vi.fn();
     const prompter = createPrompter();
+    const legacyMatch = recommendationResult().matches[1]!;
 
     await setupAppRecommendations({
       config: {},
@@ -112,9 +172,16 @@ describe("setupAppRecommendations", () => {
       deps: {
         recommend,
         writeOffer,
+        clearPendingStored,
         readStored: () => ({
           inventoryHash: "hash",
-          matches: [],
+          matches: [
+            {
+              ...legacyMatch,
+              candidateId: "chat-skill",
+              candidate: { ...legacyMatch.candidate, id: "chat-skill" },
+            },
+          ],
           offeredAt: 1,
           acceptedAt: 2,
           updatedAt: 2,
@@ -125,6 +192,7 @@ describe("setupAppRecommendations", () => {
     expect(recommend).not.toHaveBeenCalled();
     expect(prompter.progress).not.toHaveBeenCalled();
     expect(writeOffer).not.toHaveBeenCalled();
+    expect(clearPendingStored).not.toHaveBeenCalled();
   });
 
   it("scans again after the refresh command clears an answered offer", async () => {
@@ -163,9 +231,6 @@ describe("setupAppRecommendations", () => {
 
   it("reuses a pending stored offer without rescanning and acknowledges the answer", async () => {
     const recommend = vi.fn(async () => recommendationResult());
-    const writeOffer = vi.fn();
-    const acknowledgeStored = vi.fn();
-    const updatePendingStored = vi.fn();
     const prompter = createPrompter(["recommendation:0"]);
     const pending: OnboardingRecommendationsRecord = {
       inventoryHash: "hash",
@@ -174,6 +239,7 @@ describe("setupAppRecommendations", () => {
       acceptedAt: null,
       updatedAt: 1,
     };
+    const store = storeDeps(pending);
     const ensurePlugin = vi.fn(async ({ cfg }: { cfg: OpenClawConfig }) => ({
       cfg,
       installed: true as const,
@@ -188,12 +254,8 @@ describe("setupAppRecommendations", () => {
       modelRouteVerified: true,
       platform: "darwin",
       deps: {
+        ...store,
         recommend,
-        writeOffer,
-        acknowledgeStored,
-        updatePendingStored,
-        readStored: () => pending,
-        deferOfferToBootstrap: () => false,
         ensurePlugin: ensurePlugin as never,
         resolveOfficialEntry: () => ({
           pluginId: "chat-plugin",
@@ -207,12 +269,15 @@ describe("setupAppRecommendations", () => {
     expect(recommend).not.toHaveBeenCalled();
     expect(prompter.progress).not.toHaveBeenCalled();
     expect(prompter.multiselect).toHaveBeenCalledOnce();
-    expect(acknowledgeStored).toHaveBeenCalledOnce();
-    expect(updatePendingStored).toHaveBeenCalledWith({ matches: [pending.matches[0]] });
-    expect(updatePendingStored.mock.invocationCallOrder[0]).toBeLessThan(
+    expect(store.acknowledgeStored).toHaveBeenCalledOnce();
+    expect(store.updatePendingStored).toHaveBeenCalledWith({
+      matches: [pending.matches[0]],
+      expected: pending,
+    });
+    expect(store.updatePendingStored.mock.invocationCallOrder[0]).toBeLessThan(
       ensurePlugin.mock.invocationCallOrder[0]!,
     );
-    expect(writeOffer).not.toHaveBeenCalled();
+    expect(store.writeOffer).not.toHaveBeenCalled();
     expect(ensurePlugin).toHaveBeenCalledOnce();
   });
 
@@ -248,7 +313,9 @@ describe("setupAppRecommendations", () => {
       },
     });
 
-    expect(clearPendingStored).toHaveBeenCalledOnce();
+    expect(clearPendingStored).toHaveBeenCalledWith({
+      expected: expect.objectContaining({ inventoryHash: "hash", updatedAt: 1 }),
+    });
     expect(recommend).toHaveBeenCalledOnce();
   });
 
@@ -359,7 +426,10 @@ describe("setupAppRecommendations", () => {
       ensurePlugin.mock.invocationCallOrder[0]!,
     );
     outcome.commitResult();
-    expect(store.writeOffer).toHaveBeenLastCalledWith(expect.objectContaining({ answered: true }));
+    expect(store.acknowledgeStored).toHaveBeenCalledWith({
+      expected: expect.objectContaining({ inventoryHash: "hash", updatedAt: 1 }),
+    });
+    expect(store.writeOffer).toHaveBeenCalledOnce();
     expect(outcome.config.plugins?.entries?.["chat-plugin"]?.enabled).toBe(true);
   });
 
@@ -383,17 +453,38 @@ describe("setupAppRecommendations", () => {
         return storeState.current;
       },
     );
-    const acknowledgeStored = vi.fn(() => {
-      if (!storeState.current) {
-        return null;
-      }
-      now += 1;
-      storeState.current = { ...storeState.current, acceptedAt: now, updatedAt: now };
-      return storeState.current;
-    });
+    const acknowledgeStored = vi.fn(
+      (
+        params: Parameters<
+          typeof import("../state/onboarding-recommendations.js").acknowledgeOnboardingRecommendations
+        >[0] = {},
+      ) => {
+        if (
+          !storeState.current ||
+          (params.expected &&
+            (params.expected.inventoryHash !== storeState.current.inventoryHash ||
+              params.expected.updatedAt !== storeState.current.updatedAt))
+        ) {
+          return null;
+        }
+        now += 1;
+        storeState.current = { ...storeState.current, acceptedAt: now, updatedAt: now };
+        return storeState.current;
+      },
+    );
     const updatePendingStored = vi.fn(
-      ({ matches }: { matches: readonly OnboardingRecommendationMatch[] }) => {
-        if (!storeState.current) {
+      ({
+        matches,
+        expected,
+      }: {
+        matches: readonly OnboardingRecommendationMatch[];
+        expected: OnboardingRecommendationsRecord;
+      }) => {
+        if (
+          !storeState.current ||
+          expected.inventoryHash !== storeState.current.inventoryHash ||
+          expected.updatedAt !== storeState.current.updatedAt
+        ) {
           return null;
         }
         now += 1;

--- a/src/wizard/setup.app-recommendations.test.ts
+++ b/src/wizard/setup.app-recommendations.test.ts
@@ -2,10 +2,21 @@ import { describe, expect, it, vi } from "vitest";
 import { refreshOnboardRecommendationsCommand } from "../commands/onboard-recommendations.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { RuntimeEnv } from "../runtime.js";
-import type { OnboardingRecommendationsRecord } from "../state/onboarding-recommendations.js";
+import type {
+  OnboardingRecommendationMatch,
+  OnboardingRecommendationsRecord,
+} from "../state/onboarding-recommendations.js";
 import type { SetupAppRecommendationsResult } from "../system-agent/setup-app-recommendations.js";
 import type { WizardPrompter } from "./prompts.js";
-import { setupAppRecommendations } from "./setup.app-recommendations.js";
+import { setupAppRecommendations as setupAppRecommendationsWithOutcome } from "./setup.app-recommendations.js";
+
+async function setupAppRecommendations(
+  params: Parameters<typeof setupAppRecommendationsWithOutcome>[0],
+): Promise<OpenClawConfig> {
+  const outcome = await setupAppRecommendationsWithOutcome(params);
+  outcome.commitResult();
+  return outcome.config;
+}
 
 function createPrompter(selected: string[] = []): WizardPrompter {
   return {
@@ -154,6 +165,7 @@ describe("setupAppRecommendations", () => {
     const recommend = vi.fn(async () => recommendationResult());
     const writeOffer = vi.fn();
     const acknowledgeStored = vi.fn();
+    const updatePendingStored = vi.fn();
     const prompter = createPrompter(["recommendation:0"]);
     const pending: OnboardingRecommendationsRecord = {
       inventoryHash: "hash",
@@ -179,6 +191,7 @@ describe("setupAppRecommendations", () => {
         recommend,
         writeOffer,
         acknowledgeStored,
+        updatePendingStored,
         readStored: () => pending,
         deferOfferToBootstrap: () => false,
         ensurePlugin: ensurePlugin as never,
@@ -195,6 +208,10 @@ describe("setupAppRecommendations", () => {
     expect(prompter.progress).not.toHaveBeenCalled();
     expect(prompter.multiselect).toHaveBeenCalledOnce();
     expect(acknowledgeStored).toHaveBeenCalledOnce();
+    expect(updatePendingStored).toHaveBeenCalledWith({ matches: [pending.matches[0]] });
+    expect(updatePendingStored.mock.invocationCallOrder[0]).toBeLessThan(
+      ensurePlugin.mock.invocationCallOrder[0]!,
+    );
     expect(writeOffer).not.toHaveBeenCalled();
     expect(ensurePlugin).toHaveBeenCalledOnce();
   });
@@ -305,7 +322,7 @@ describe("setupAppRecommendations", () => {
       targetDir: "/tmp/workspace/skills/chat-skill",
     }));
 
-    const result = await setupAppRecommendations({
+    const outcome = await setupAppRecommendationsWithOutcome({
       config,
       prompter,
       runtime,
@@ -333,11 +350,17 @@ describe("setupAppRecommendations", () => {
     expect(installSkill).toHaveBeenCalledWith(
       expect.objectContaining({ slug: "@demo-owner/chat-skill" }),
     );
-    expect(store.writeOffer).toHaveBeenCalledWith(expect.objectContaining({ answered: true }));
-    expect(installSkill.mock.invocationCallOrder[0]).toBeLessThan(
-      store.writeOffer.mock.invocationCallOrder[0]!,
+    expect(store.writeOffer).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ answered: false, matches: recommendationResult().matches }),
     );
-    expect(result.plugins?.entries?.["chat-plugin"]?.enabled).toBe(true);
+    expect(store.writeOffer).toHaveBeenCalledOnce();
+    expect(store.writeOffer.mock.invocationCallOrder[0]).toBeLessThan(
+      ensurePlugin.mock.invocationCallOrder[0]!,
+    );
+    outcome.commitResult();
+    expect(store.writeOffer).toHaveBeenLastCalledWith(expect.objectContaining({ answered: true }));
+    expect(outcome.config.plugins?.entries?.["chat-plugin"]?.enabled).toBe(true);
   });
 
   it("reoffers a failed install and consumes it after a successful retry", async () => {
@@ -368,6 +391,20 @@ describe("setupAppRecommendations", () => {
       storeState.current = { ...storeState.current, acceptedAt: now, updatedAt: now };
       return storeState.current;
     });
+    const updatePendingStored = vi.fn(
+      ({ matches }: { matches: readonly OnboardingRecommendationMatch[] }) => {
+        if (!storeState.current) {
+          return null;
+        }
+        now += 1;
+        storeState.current = {
+          ...storeState.current,
+          matches: [...matches],
+          updatedAt: now,
+        };
+        return storeState.current;
+      },
+    );
     const recommend = vi.fn(async () => recommendationResult());
     const installSkill = vi
       .fn()
@@ -388,6 +425,7 @@ describe("setupAppRecommendations", () => {
       readStored: () => storeState.current,
       writeOffer,
       acknowledgeStored,
+      updatePendingStored,
       deferOfferToBootstrap: () => false,
     };
 

--- a/src/wizard/setup.app-recommendations.ts
+++ b/src/wizard/setup.app-recommendations.ts
@@ -18,7 +18,9 @@ import type { RuntimeEnv } from "../runtime.js";
 import { installSkillFromClawHub } from "../skills/lifecycle/clawhub.js";
 import {
   acknowledgeOnboardingRecommendations,
+  clearPendingOnboardingRecommendations,
   readOnboardingRecommendations,
+  updatePendingOnboardingRecommendations,
   writeOnboardingRecommendationsOffer,
   type OnboardingRecommendationsRecord,
 } from "../state/onboarding-recommendations.js";
@@ -40,6 +42,8 @@ type SetupAppRecommendationDeps = {
   readStored?: () => OnboardingRecommendationsRecord | null;
   writeOffer?: typeof writeOnboardingRecommendationsOffer;
   acknowledgeStored?: typeof acknowledgeOnboardingRecommendations;
+  updatePendingStored?: typeof updatePendingOnboardingRecommendations;
+  clearPendingStored?: typeof clearPendingOnboardingRecommendations;
   deferOfferToBootstrap?: () => boolean;
 };
 
@@ -101,12 +105,25 @@ export async function setupAppRecommendations(params: {
     return params.config;
   }
   const readStored = params.deps?.readStored ?? readOnboardingRecommendations;
-  const stored = readStored();
-  if (typeof stored?.acceptedAt === "number") {
+  const storedRecord = readStored();
+  if (typeof storedRecord?.acceptedAt === "number") {
     return params.config;
   }
+  const clearPendingStored =
+    params.deps?.clearPendingStored ?? clearPendingOnboardingRecommendations;
+  // Pending recommendations are rebuildable cache. Rescan legacy bare
+  // ClawHub ids instead of installing without a publisher identity.
+  const hasLegacyClawHubId = storedRecord?.matches.some(
+    (match) => match.candidate.source === "clawhub-skill" && !match.candidate.id.startsWith("@"),
+  );
+  if (hasLegacyClawHubId) {
+    clearPendingStored();
+  }
+  const stored = hasLegacyClawHubId ? null : storedRecord;
   const writeOffer = params.deps?.writeOffer ?? writeOnboardingRecommendationsOffer;
   const acknowledgeStored = params.deps?.acknowledgeStored ?? acknowledgeOnboardingRecommendations;
+  const updatePendingStored =
+    params.deps?.updatePendingStored ?? updatePendingOnboardingRecommendations;
   const deferOfferToBootstrap =
     params.deps?.deferOfferToBootstrap ??
     (() => existsSync(path.join(params.workspaceDir, DEFAULT_BOOTSTRAP_FILENAME)));
@@ -116,14 +133,20 @@ export async function setupAppRecommendations(params: {
   // bootstrap still owns the ask, or the wizard presents the stored matches.
   let matches: SetupAppRecommendationMatch[];
   let appLabels: string[];
-  let recordAnswer: () => void;
+  let recordResult: (retryMatches: SetupAppRecommendationMatch[]) => void;
   if (stored) {
     if (deferOfferToBootstrap()) {
       return params.config;
     }
     matches = stored.matches;
     appLabels = [...new Set(stored.matches.map((match) => match.appLabel))];
-    recordAnswer = () => void acknowledgeStored();
+    recordResult = (retryMatches) => {
+      if (retryMatches.length === 0) {
+        void acknowledgeStored();
+        return;
+      }
+      void updatePendingStored({ matches: retryMatches });
+    };
   } else {
     const progress = params.prompter.progress(t("wizard.appRecommendations.scanning"));
     let result: SetupAppRecommendationsResult;
@@ -153,8 +176,12 @@ export async function setupAppRecommendations(params: {
     const scanned = result;
     matches = scanned.matches;
     appLabels = scanned.apps.map((app) => app.label);
-    recordAnswer = () =>
-      void writeOffer({ inventory: scanned.apps, matches: scanned.matches, answered: true });
+    recordResult = (retryMatches) =>
+      void writeOffer({
+        inventory: scanned.apps,
+        matches: retryMatches.length > 0 ? retryMatches : scanned.matches,
+        answered: retryMatches.length === 0,
+      });
   }
 
   await params.prompter.note(
@@ -194,14 +221,13 @@ export async function setupAppRecommendations(params: {
         : [],
     ),
   });
-  // Returning from the prompt means the user answered even when every option
-  // was deselected. Cancellation throws before this point.
-  recordAnswer();
   if (selected.includes(SKIP_VALUE)) {
+    recordResult([]);
     return params.config;
   }
 
   let next = params.config;
+  const retryMatches: SetupAppRecommendationMatch[] = [];
   const ensurePlugin = params.deps?.ensurePlugin ?? ensureOnboardingPluginInstalled;
   const installSkill = params.deps?.installSkill ?? installSkillFromClawHub;
   for (const match of uniqueSelectedMatches(matches, selected)) {
@@ -242,6 +268,7 @@ export async function setupAppRecommendations(params: {
         throw new Error(installed.error ?? installed.status);
       }
     } catch (error) {
+      retryMatches.push(match);
       params.runtime.error(
         t("wizard.appRecommendations.installFailed", {
           name: match.candidate.displayName,
@@ -250,5 +277,8 @@ export async function setupAppRecommendations(params: {
       );
     }
   }
+  // Unselected recommendations were explicitly declined. Keep only failed
+  // selected installs pending so later onboarding can retry them.
+  recordResult(retryMatches);
   return next;
 }

--- a/src/wizard/setup.app-recommendations.ts
+++ b/src/wizard/setup.app-recommendations.ts
@@ -6,6 +6,7 @@ import {
   type OnboardingPluginInstallEntry,
 } from "../commands/onboarding-plugin-install.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { fetchClawHubSkillVerification } from "../infra/clawhub.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { scanInstalledApps } from "../infra/installed-apps.js";
 import {
@@ -15,7 +16,10 @@ import {
   resolveOfficialExternalPluginLabel,
 } from "../plugins/official-external-plugin-catalog.js";
 import type { RuntimeEnv } from "../runtime.js";
-import { installSkillFromClawHub } from "../skills/lifecycle/clawhub.js";
+import {
+  installSkillFromClawHub,
+  resolveClawHubSkillVerificationTarget,
+} from "../skills/lifecycle/clawhub.js";
 import {
   acknowledgeOnboardingRecommendations,
   clearPendingOnboardingRecommendations,
@@ -38,6 +42,7 @@ type SetupAppRecommendationDeps = {
   recommend?: () => Promise<SetupAppRecommendationsResult>;
   ensurePlugin?: typeof ensureOnboardingPluginInstalled;
   installSkill?: typeof installSkillFromClawHub;
+  isSkillInstalled?: (params: { workspaceDir: string; skillRef: string }) => Promise<boolean>;
   resolveOfficialEntry?: (pluginId: string) => OnboardingPluginInstallEntry | undefined;
   readStored?: () => OnboardingRecommendationsRecord | null;
   writeOffer?: typeof writeOnboardingRecommendationsOffer;
@@ -46,6 +51,26 @@ type SetupAppRecommendationDeps = {
   clearPendingStored?: typeof clearPendingOnboardingRecommendations;
   deferOfferToBootstrap?: () => boolean;
 };
+
+async function isClawHubSkillInstalled(params: {
+  workspaceDir: string;
+  skillRef: string;
+}): Promise<boolean> {
+  const target = await resolveClawHubSkillVerificationTarget({
+    workspaceDir: params.workspaceDir,
+    slug: params.skillRef,
+  });
+  if (!target.ok || target.resolution.source !== "installed") {
+    return false;
+  }
+  const verification = await fetchClawHubSkillVerification({
+    slug: target.slug,
+    ...(target.ownerHandle ? { ownerHandle: target.ownerHandle } : {}),
+    version: target.version,
+    baseUrl: target.baseUrl,
+  });
+  return verification.ok && verification.decision === "pass";
+}
 
 export type SetupAppRecommendationsOutcome = {
   config: OpenClawConfig;
@@ -260,27 +285,36 @@ export async function setupAppRecommendations(params: {
   // Persist the selected set before external installs. Unselected matches are
   // explicit declines; selected matches stay retryable until each install succeeds.
   recordResult(selectedMatches);
+  let pendingMatches = selectedMatches;
   const retryMatches: SetupAppRecommendationMatch[] = [];
   const ensurePlugin = params.deps?.ensurePlugin ?? ensureOnboardingPluginInstalled;
   const installSkill = params.deps?.installSkill ?? installSkillFromClawHub;
+  const isSkillInstalled = params.deps?.isSkillInstalled ?? isClawHubSkillInstalled;
   for (const match of selectedMatches) {
+    let installed = false;
     try {
       if (match.candidate.source === "clawhub-skill") {
-        const installed = await installSkill({
+        const alreadyInstalled = await isSkillInstalled({
           workspaceDir: params.workspaceDir,
-          slug: match.candidate.id,
-          config: next,
-          onClawHubRisk: async () =>
-            await params.prompter.confirm({
-              message: t("wizard.appRecommendations.skillTrust", {
-                name: match.candidate.displayName,
-              }),
-              initialValue: false,
-            }),
-          logger: { warn: (message) => params.runtime.error(message) },
+          skillRef: match.candidate.id,
         });
-        if (!installed.ok) {
-          throw new Error(installed.error);
+        if (!alreadyInstalled) {
+          const result = await installSkill({
+            workspaceDir: params.workspaceDir,
+            slug: match.candidate.id,
+            config: next,
+            onClawHubRisk: async () =>
+              await params.prompter.confirm({
+                message: t("wizard.appRecommendations.skillTrust", {
+                  name: match.candidate.displayName,
+                }),
+                initialValue: false,
+              }),
+            logger: { warn: (message) => params.runtime.error(message) },
+          });
+          if (!result.ok) {
+            throw new Error(result.error);
+          }
         }
       } else {
         const entry = (params.deps?.resolveOfficialEntry ?? resolveOfficialEntry)(
@@ -289,7 +323,7 @@ export async function setupAppRecommendations(params: {
         if (!entry) {
           throw new Error(t("wizard.appRecommendations.catalogEntryMissing"));
         }
-        const installed = await ensurePlugin({
+        const pluginResult = await ensurePlugin({
           cfg: next,
           entry,
           prompter: params.prompter,
@@ -297,11 +331,12 @@ export async function setupAppRecommendations(params: {
           workspaceDir: params.workspaceDir,
           promptInstall: false,
         });
-        next = installed.cfg;
-        if (!installed.installed) {
-          throw new Error(installed.error ?? installed.status);
+        next = pluginResult.cfg;
+        if (!pluginResult.installed) {
+          throw new Error(pluginResult.error ?? pluginResult.status);
         }
       }
+      installed = true;
     } catch (error) {
       retryMatches.push(match);
       params.runtime.error(
@@ -311,8 +346,20 @@ export async function setupAppRecommendations(params: {
         }),
       );
     }
+    if (installed && match.candidate.source === "clawhub-skill") {
+      // Skill installation is already durable on disk. Checkpoint it now so a
+      // later crash cannot turn an existing target into a permanent retry.
+      pendingMatches = pendingMatches.filter((candidate) => candidate !== match);
+      recordResult(pendingMatches);
+    }
   }
   // Official plugin config is durable only after the caller writes `next`.
   // Commit recommendation outcomes at that owner boundary, never inside the install catch.
-  return { config: next, commitResult: () => recordResult(retryMatches) };
+  const hasDeferredOfficialResult = selectedMatches.some(
+    (match) => match.candidate.source !== "clawhub-skill",
+  );
+  return {
+    config: next,
+    commitResult: hasDeferredOfficialResult ? () => recordResult(retryMatches) : () => undefined,
+  };
 }

--- a/src/wizard/setup.app-recommendations.ts
+++ b/src/wizard/setup.app-recommendations.ts
@@ -125,8 +125,10 @@ export async function setupAppRecommendations(params: {
   const hasLegacyClawHubId = storedRecord?.matches.some(
     (match) => match.candidate.source === "clawhub-skill" && !match.candidate.id.startsWith("@"),
   );
-  if (hasLegacyClawHubId) {
-    clearPendingStored();
+  if (hasLegacyClawHubId && storedRecord) {
+    if (!clearPendingStored({ expected: storedRecord })) {
+      return unchangedOutcome(params.config);
+    }
   }
   const stored = hasLegacyClawHubId ? null : storedRecord;
   const writeOffer = params.deps?.writeOffer ?? writeOnboardingRecommendationsOffer;
@@ -142,20 +144,29 @@ export async function setupAppRecommendations(params: {
   // bootstrap still owns the ask, or the wizard presents the stored matches.
   let matches: SetupAppRecommendationMatch[];
   let appLabels: string[];
+  let pendingRecord = stored;
   let recordResult: (retryMatches: SetupAppRecommendationMatch[]) => void;
+  const commitStoredResult = (retryMatches: SetupAppRecommendationMatch[]) => {
+    if (!pendingRecord) {
+      throw new Error("Stored onboarding recommendations changed while setup was running.");
+    }
+    const expected = pendingRecord;
+    const updated =
+      retryMatches.length === 0
+        ? acknowledgeStored({ expected })
+        : updatePendingStored({ matches: retryMatches, expected });
+    if (!updated) {
+      throw new Error("Stored onboarding recommendations changed while setup was running.");
+    }
+    pendingRecord = updated;
+  };
   if (stored) {
     if (deferOfferToBootstrap()) {
       return unchangedOutcome(params.config);
     }
     matches = stored.matches;
     appLabels = [...new Set(stored.matches.map((match) => match.appLabel))];
-    recordResult = (retryMatches) => {
-      if (retryMatches.length === 0) {
-        void acknowledgeStored();
-        return;
-      }
-      void updatePendingStored({ matches: retryMatches });
-    };
+    recordResult = commitStoredResult;
   } else {
     const progress = params.prompter.progress(t("wizard.appRecommendations.scanning"));
     let result: SetupAppRecommendationsResult;
@@ -185,12 +196,17 @@ export async function setupAppRecommendations(params: {
     const scanned = result;
     matches = scanned.matches;
     appLabels = scanned.apps.map((app) => app.label);
-    recordResult = (retryMatches) =>
-      void writeOffer({
-        inventory: scanned.apps,
-        matches: retryMatches.length > 0 ? retryMatches : scanned.matches,
-        answered: retryMatches.length === 0,
-      });
+    recordResult = (retryMatches) => {
+      if (!pendingRecord) {
+        pendingRecord = writeOffer({
+          inventory: scanned.apps,
+          matches: retryMatches.length > 0 ? retryMatches : scanned.matches,
+          answered: retryMatches.length === 0,
+        });
+        return;
+      }
+      commitStoredResult(retryMatches);
+    };
   }
 
   await params.prompter.note(

--- a/src/wizard/setup.app-recommendations.ts
+++ b/src/wizard/setup.app-recommendations.ts
@@ -47,6 +47,15 @@ type SetupAppRecommendationDeps = {
   deferOfferToBootstrap?: () => boolean;
 };
 
+export type SetupAppRecommendationsOutcome = {
+  config: OpenClawConfig;
+  commitResult: () => void;
+};
+
+function unchangedOutcome(config: OpenClawConfig): SetupAppRecommendationsOutcome {
+  return { config, commitResult: () => undefined };
+}
+
 function resolveOfficialEntry(pluginId: string): OnboardingPluginInstallEntry | undefined {
   const catalogEntry = listOfficialExternalPluginCatalogEntries().find(
     (entry) => resolveOfficialExternalPluginId(entry) === pluginId,
@@ -91,7 +100,7 @@ export async function setupAppRecommendations(params: {
   modelRouteVerified: boolean;
   platform?: NodeJS.Platform;
   deps?: SetupAppRecommendationDeps;
-}): Promise<OpenClawConfig> {
+}): Promise<SetupAppRecommendationsOutcome> {
   const platform = params.platform ?? process.platform;
   // Product decision: default-on "magical" scan with a kill switch, not
   // consent-first. App labels/bundle ids go to the user's configured model and
@@ -102,12 +111,12 @@ export async function setupAppRecommendations(params: {
     platform !== "darwin" ||
     !params.modelRouteVerified
   ) {
-    return params.config;
+    return unchangedOutcome(params.config);
   }
   const readStored = params.deps?.readStored ?? readOnboardingRecommendations;
   const storedRecord = readStored();
   if (typeof storedRecord?.acceptedAt === "number") {
-    return params.config;
+    return unchangedOutcome(params.config);
   }
   const clearPendingStored =
     params.deps?.clearPendingStored ?? clearPendingOnboardingRecommendations;
@@ -136,7 +145,7 @@ export async function setupAppRecommendations(params: {
   let recordResult: (retryMatches: SetupAppRecommendationMatch[]) => void;
   if (stored) {
     if (deferOfferToBootstrap()) {
-      return params.config;
+      return unchangedOutcome(params.config);
     }
     matches = stored.matches;
     appLabels = [...new Set(stored.matches.map((match) => match.appLabel))];
@@ -162,16 +171,16 @@ export async function setupAppRecommendations(params: {
       params.runtime.log(
         t("wizard.appRecommendations.skipped", { reason: formatErrorMessage(error) }),
       );
-      return params.config;
+      return unchangedOutcome(params.config);
     }
     progress.stop();
     if (result.status !== "ok") {
       params.runtime.log(t("wizard.appRecommendations.noneFound"));
-      return params.config;
+      return unchangedOutcome(params.config);
     }
     if (deferOfferToBootstrap()) {
       writeOffer({ inventory: result.apps, matches: result.matches, answered: false });
-      return params.config;
+      return unchangedOutcome(params.config);
     }
     const scanned = result;
     matches = scanned.matches;
@@ -223,14 +232,22 @@ export async function setupAppRecommendations(params: {
   });
   if (selected.includes(SKIP_VALUE)) {
     recordResult([]);
-    return params.config;
+    return unchangedOutcome(params.config);
   }
 
   let next = params.config;
+  const selectedMatches = uniqueSelectedMatches(matches, selected);
+  if (selectedMatches.length === 0) {
+    recordResult([]);
+    return unchangedOutcome(params.config);
+  }
+  // Persist the selected set before external installs. Unselected matches are
+  // explicit declines; selected matches stay retryable until each install succeeds.
+  recordResult(selectedMatches);
   const retryMatches: SetupAppRecommendationMatch[] = [];
   const ensurePlugin = params.deps?.ensurePlugin ?? ensureOnboardingPluginInstalled;
   const installSkill = params.deps?.installSkill ?? installSkillFromClawHub;
-  for (const match of uniqueSelectedMatches(matches, selected)) {
+  for (const match of selectedMatches) {
     try {
       if (match.candidate.source === "clawhub-skill") {
         const installed = await installSkill({
@@ -249,23 +266,25 @@ export async function setupAppRecommendations(params: {
         if (!installed.ok) {
           throw new Error(installed.error);
         }
-        continue;
-      }
-      const entry = (params.deps?.resolveOfficialEntry ?? resolveOfficialEntry)(match.candidate.id);
-      if (!entry) {
-        throw new Error(t("wizard.appRecommendations.catalogEntryMissing"));
-      }
-      const installed = await ensurePlugin({
-        cfg: next,
-        entry,
-        prompter: params.prompter,
-        runtime: params.runtime,
-        workspaceDir: params.workspaceDir,
-        promptInstall: false,
-      });
-      next = installed.cfg;
-      if (!installed.installed) {
-        throw new Error(installed.error ?? installed.status);
+      } else {
+        const entry = (params.deps?.resolveOfficialEntry ?? resolveOfficialEntry)(
+          match.candidate.id,
+        );
+        if (!entry) {
+          throw new Error(t("wizard.appRecommendations.catalogEntryMissing"));
+        }
+        const installed = await ensurePlugin({
+          cfg: next,
+          entry,
+          prompter: params.prompter,
+          runtime: params.runtime,
+          workspaceDir: params.workspaceDir,
+          promptInstall: false,
+        });
+        next = installed.cfg;
+        if (!installed.installed) {
+          throw new Error(installed.error ?? installed.status);
+        }
       }
     } catch (error) {
       retryMatches.push(match);
@@ -277,8 +296,7 @@ export async function setupAppRecommendations(params: {
       );
     }
   }
-  // Unselected recommendations were explicitly declined. Keep only failed
-  // selected installs pending so later onboarding can retry them.
-  recordResult(retryMatches);
-  return next;
+  // Official plugin config is durable only after the caller writes `next`.
+  // Commit recommendation outcomes at that owner boundary, never inside the install catch.
+  return { config: next, commitResult: () => recordResult(retryMatches) };
 }

--- a/src/wizard/setup.ts
+++ b/src/wizard/setup.ts
@@ -628,6 +628,7 @@ async function runSetupWizardOnce(
     });
   }
 
+  let commitAppRecommendationResult: (() => void) | undefined;
   if (flow !== "quickstart") {
     const { setupOfficialPluginInstalls } = await import("./setup.official-plugins.js");
     nextConfig = await setupOfficialPluginInstalls({
@@ -637,13 +638,15 @@ async function runSetupWizardOnce(
       workspaceDir,
     });
     const { setupAppRecommendations } = await import("./setup.app-recommendations.js");
-    nextConfig = await setupAppRecommendations({
+    const recommendationOutcome = await setupAppRecommendations({
       config: nextConfig,
       prompter,
       runtime,
       workspaceDir,
       modelRouteVerified: liveModelVerified,
     });
+    nextConfig = recommendationOutcome.config;
+    commitAppRecommendationResult = recommendationOutcome.commitResult;
     const { setupPluginConfig } = await import("./setup.plugin-config.js");
     nextConfig = await setupPluginConfig({
       config: nextConfig,
@@ -661,6 +664,7 @@ async function runSetupWizardOnce(
   nextConfig = await writeSetupConfigFile(nextConfig, {
     allowConfigSizeDrop: false,
   });
+  commitAppRecommendationResult?.();
 
   const { finalizeSetupWizard } = await import("./setup.finalize.js");
   const finalizeResult = await finalizeSetupWizard({


### PR DESCRIPTION
## What Problem This Solves

Fixes two issues where macOS onboarding app recommendations could install the wrong ClawHub skill when multiple publishers used the same slug, and where a transient installation failure permanently suppressed the recommendation instead of offering a retry.

## Why This Change Was Made

ClawHub recommendations now carry the canonical `@owner/slug` identity from search through installation and skip ownerless results. Pending beta-era records with ambiguous bare skill IDs are atomically discarded and rescanned; accepted records remain accepted.

Recommendation outcomes now follow their durability boundary. Explicit declines are consumed immediately, successful ClawHub skill installs are checkpointed after exact publisher verification, and official plugin results are committed only after their config is written. Failures remain pending through compare-and-swap state transitions. Fresh-workspace bootstrap uses the same retry-aware contract through `openclaw onboard recommendations acknowledge --retry`.

The system-agent flow owns discovery only; the wizard and bootstrap CLI own installation outcomes. This changes persisted transition semantics but not the SQLite schema, so there is no protocol or schema-version bump.

## User Impact

Users now install the exact recommended ClawHub publisher. Network errors, resolution errors, cancelled trust prompts, and interrupted bootstrap installs no longer make a failed recommendation disappear permanently. Successfully installed or explicitly declined recommendations remain consumed.

AI-assisted; the resulting code, ownership boundaries, and state transitions were reviewed and verified.

## Evidence

- Live ClawHub search for `weather` returned three `weather` results with distinct publishers (`steipete`, `legionspace-hackathon`, and `lfengwa2`), reproducing the ambiguity that requires `@owner/slug`.
- Real CLI proof on an isolated state database at head `7fb9df2eaaaf052c7d6fe79b8cd9a8f94e7514f5`:

```text
$ openclaw onboard recommendations --json
[
  { "id": "chat-plugin", "source": "official-plugin", "tier": "recommended" },
  { "id": "@demo-owner/chat-skill", "source": "clawhub-skill", "tier": "optional" }
]

$ openclaw onboard recommendations acknowledge --retry '@demo-owner/chat-skill'
Onboarding recommendations updated; 1 left pending for retry.

$ openclaw onboard recommendations --json
[
  { "id": "@demo-owner/chat-skill", "source": "clawhub-skill", "tier": "optional" }
]

$ openclaw onboard recommendations acknowledge
Onboarding recommendations acknowledged.

$ openclaw onboard recommendations --json
[]
```

- Focused regression graph: 135 tests passed across discovery, wizard, state, bootstrap CLI, guided onboarding, registration, and setup callers.
- Final requested filters: `node scripts/run-vitest.mjs setup-app-recommendations` (8 passed) and `node scripts/run-vitest.mjs setup.app-recommendations` (14 passed).
- `pnpm tsgo` and `pnpm tsgo:core:test` passed.
- `pnpm docs:check-mdx` passed (745 files); `pnpm docs:check-links` passed (6,142 links, 0 broken).
- Targeted `pnpm format`, `node scripts/run-oxlint.mjs`, and `git diff --check` passed.
- Fresh `autoreview --mode branch --base origin/main` is clean with no accepted/actionable findings.
