### PR TITLE
fix(test): keep CI=1 test suites within the worker budget

### DIFF
--- a/scripts/lib/vitest-local-scheduling.mjs
+++ b/scripts/lib/vitest-local-scheduling.mjs
@@ -4,6 +4,7 @@
 import os from "node:os";
 
 const MAX_LOCAL_FULL_SUITE_PARALLELISM = 10;
+const TRUTHY_ENV_VALUES = new Set(["1", "true", "yes", "on"]);
 
 const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
 
@@ -27,9 +28,13 @@ function isSystemThrottleDisabled(env) {
   return normalized === "1" || normalized === "true";
 }
 
+function isTruthyEnvValue(value) {
+  return TRUTHY_ENV_VALUES.has(value?.trim().toLowerCase() ?? "");
+}
+
 /** @internal Shared repository-script contract. */
 export function isCiLikeEnv(env = process.env) {
-  return env.CI === "true" || env.GITHUB_ACTIONS === "true";
+  return isTruthyEnvValue(env.CI) || isTruthyEnvValue(env.GITHUB_ACTIONS);
 }
 
 /** @internal Shared repository-script contract. */

--- a/scripts/test-projects.test-support.mjs
+++ b/scripts/test-projects.test-support.mjs
@@ -4551,13 +4551,11 @@ function shouldUseLocalFullSuiteParallelByDefault(env = process.env) {
   if (hasConservativeVitestWorkerBudget(env)) {
     return false;
   }
-  return (
-    env.OPENCLAW_TEST_PROJECTS_SERIAL !== "1" && env.CI !== "true" && env.GITHUB_ACTIONS !== "true"
-  );
+  return env.OPENCLAW_TEST_PROJECTS_SERIAL !== "1" && !isCiLikeEnv(env);
 }
 
 function shouldExpandLocalFullSuiteShardsByDefault(env = process.env) {
-  return env.CI !== "true" && env.GITHUB_ACTIONS !== "true";
+  return !isCiLikeEnv(env);
 }
 
 function parsePositiveInt(value, label) {

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -4276,20 +4276,41 @@ describe("scripts/test-projects full-suite sharding", () => {
     ).toBe(6);
   });
 
-  it("keeps CI full-suite runs serial even on roomy hosts", () => {
-    expect(
-      resolveParallelFullSuiteConcurrency(
-        61,
-        {
-          CI: "true",
-        },
-        {
-          cpuCount: 14,
-          loadAverage1m: 0,
-          totalMemoryBytes: 48 * 1024 ** 3,
-        },
-      ),
-    ).toBe(1);
+  it.each(["1", "true", "yes", "on"])(
+    "keeps CI=%s full-suite runs serial even on roomy hosts",
+    (ciValue) => {
+      expect(
+        resolveParallelFullSuiteConcurrency(
+          61,
+          {
+            CI: ciValue,
+            OPENCLAW_VITEST_MAX_WORKERS: "3",
+          },
+          {
+            cpuCount: 14,
+            loadAverage1m: 0,
+            totalMemoryBytes: 48 * 1024 ** 3,
+          },
+        ),
+      ).toBe(1);
+    },
+  );
+
+  it("keeps CI=1 full-suite runs on aggregate shard configs", () => {
+    vi.stubEnv("CI", "1");
+    vi.stubEnv("GITHUB_ACTIONS", "");
+    vi.stubEnv("OPENCLAW_TEST_PROJECTS_LEAF_SHARDS", "");
+    vi.stubEnv("OPENCLAW_TEST_PROJECTS_PARALLEL", "");
+    try {
+      const configs = buildFullSuiteVitestRunPlans([], process.cwd()).map((plan) => plan.config);
+
+      expect(configs).toContain("test/vitest/vitest.full-agentic.config.ts");
+      expect(configs).toContain("test/vitest/vitest.full-extensions.config.ts");
+      expect(configs).not.toContain("test/vitest/vitest.gateway-server.config.ts");
+      expect(configs).not.toContain("test/vitest/vitest.extension-telegram.config.ts");
+    } finally {
+      vi.unstubAllEnvs();
+    }
   });
 
   it("keeps explicit parallel overrides ahead of the host-aware profile", () => {
@@ -5111,6 +5132,7 @@ describe("scripts/test-projects Vitest stall watchdog", () => {
   it("allows changed checks to disable automatic silent-run retries", () => {
     expect(shouldRetryVitestNoOutputTimeout({})).toBe(true);
     expect(shouldRetryVitestNoOutputTimeout({ CI: "true" })).toBe(false);
+    expect(shouldRetryVitestNoOutputTimeout({ CI: "1" })).toBe(false);
   });
 
   it("raises short shard no-output timeouts for the retry attempt", () => {

--- a/test/scripts/vitest-local-scheduling.test.ts
+++ b/test/scripts/vitest-local-scheduling.test.ts
@@ -18,15 +18,20 @@ describe("vitest local full-suite profile", () => {
     });
   });
 
-  it("keeps local-check disablement for CI Vitest runs", () => {
+  it.each([
+    ["CI", "1"],
+    ["CI", "true"],
+    ["GITHUB_ACTIONS", "yes"],
+    ["GITHUB_ACTIONS", "on"],
+  ] as const)("keeps local-check disablement for %s=%s Vitest runs", (name, value) => {
     expect(
       resolveLocalVitestEnv({
-        CI: "true",
+        [name]: value,
         OPENCLAW_LOCAL_CHECK: "0",
         PATH: "/usr/bin",
       }),
     ).toEqual({
-      CI: "true",
+      [name]: value,
       OPENCLAW_LOCAL_CHECK: "0",
       PATH: "/usr/bin",
     });


### PR DESCRIPTION
Related: #107031

## What Problem This Solves

Fixes an issue where repository test runs using the documented `CI=1` form were treated as local runs. Full extension runs could therefore expand to 34 leaf shards and run three shards concurrently, while each shard also received a three-worker Vitest budget.

## Why This Change Was Made

CI detection now accepts the same common truthy values used by the repository's other environment flags. Full-suite parallelism, aggregate-shard planning, worker selection, and stall-retry policy all use that shared predicate, preserving the existing invariant that CI owns one global worker budget.

## User Impact

Maintainers and CI jobs using `CI=1` no longer multiply shard concurrency by per-shard Vitest concurrency. There is no product or runtime behavior change.

## Evidence

- Before: a Blacksmith Testbox run with `CI=1` and `OPENCLAW_VITEST_MAX_WORKERS=3` logged 34 Vitest shards at parallelism 3, peaked at 7,642,856 KB RSS, and took 8m46s. [Baseline run](https://github.com/openclaw/openclaw/actions/runs/29700370177)
- After: the same scheduling inputs resolve to concurrency 1 and aggregate full-suite configs; regression coverage includes `CI=1`, `true`, `yes`, and `on`.
- `node scripts/run-vitest.mjs test/scripts/vitest-local-scheduling.test.ts test/scripts/test-projects.test.ts` — 229 tests passed on the rebased head.
- Targeted `check:changed` passed on Blacksmith Testbox, including formatting, root-test typecheck, script lint, declaration contracts, and dependency/patch guards. [Changed gate](https://github.com/openclaw/openclaw/actions/runs/29700746114)
- Autoreview: clean, no accepted/actionable findings.

AI-assisted; I reviewed the scheduler, runner, tests, and relevant git history and understand the change.
