### PR TITLE
fix(json-parse): exclude code-context tails from Windows-path heuristic (#93139)

### DIFF
--- a/packages/ai/src/utils/json-parse.ts
+++ b/packages/ai/src/utils/json-parse.ts
@@ -110,7 +110,28 @@ export function parseJsonWithRepair(json: string): unknown {
 
 function looksLikeWindowsPathPrefix(prefix: string): boolean {
   const tail = prefix.slice(-160);
-  return /(?:^|[^A-Za-z0-9])[A-Za-z]:(?:[\\/][^"\\/:*?<>|\r\n]*)*$/.test(tail);
+  const m = tail.match(/(^|[^A-Za-z0-9])([A-Za-z]):(?:[\\/][^"\\/:*?<>|\r\n]*)*$/);
+  if (!m) {
+    return false;
+  }
+
+  const separator = m[1] ?? "";
+  const driveCandidate = m[2] ?? "";
+  const matchIndex = m.index ?? 0;
+  const keywordSubject = tail.slice(0, matchIndex);
+  // Lowercase candidates after code keywords favor code; conventional uppercase
+  // drive letters favor paths.
+  if (
+    /^[a-z]$/.test(driveCandidate) &&
+    /\s/.test(separator) &&
+    /(?:^|[^A-Za-z0-9]|\\[nrt])(?:as|if|in|for|def|not|try|else|elif|while|class|with|return|except|finally|match|case)\s*$/.test(
+      keywordSubject,
+    )
+  ) {
+    return false;
+  }
+
+  return true;
 }
 
 function asStreamingJsonRecord(value: unknown): Record<string, unknown> {

--- a/src/llm/utils/json-parse.test.ts
+++ b/src/llm/utils/json-parse.test.ts
@@ -44,3 +44,54 @@ describe("json-parse repairJson invalid \\u escapes", () => {
     },
   );
 });
+
+describe("json-parse repairJson Windows-path false positives (issue #93139)", () => {
+  it.each([
+    ["if x", '{"command": "if x:\\n    pass"}', "if x:\n    pass"],
+    [
+      "as f",
+      '{"command": "with open(path) as f:\\n    read(f)"}',
+      "with open(path) as f:\n    read(f)",
+    ],
+    ["in d", '{"command": "if x in d:\\n    pass"}', "if x in d:\n    pass"],
+    ["match x", '{"command": "match x:\\n    pass"}', "match x:\n    pass"],
+    ["case x", '{"command": "case x:\\n    pass"}', "case x:\n    pass"],
+  ])("preserves real newlines after code keyword candidates: %s", (_name, input, expected) => {
+    expect(parseJsonWithRepair(input)).toEqual({ command: expected });
+    expect(parseStreamingJson(input)).toEqual({ command: expected });
+  });
+
+  it("preserves the reported if r code candidate", () => {
+    const input = '{"command": "r = re.match(p, s)\\nif r:\\n    print(r)"}';
+    const expected = { command: "r = re.match(p, s)\nif r:\n    print(r)" };
+    expect(parseJsonWithRepair(input)).toEqual(expected);
+    expect(parseStreamingJson(input)).toEqual(expected);
+  });
+
+  it("preserves uppercase batch paths after guarded keywords", () => {
+    const input = '{"command":"if C:\\new==C:\\temp echo same"}';
+    const expected = { command: "if C:\\new==C:\\temp echo same" };
+    expect(parseJsonWithRepair(input)).toEqual(expected);
+    expect(parseStreamingJson(input)).toEqual(expected);
+  });
+
+  it.each([
+    ["comma", '{"value":"if,C:\\new"}', "if,C:\\new"],
+    ["parentheses", '{"value":"(C:\\new)"}', "(C:\\new)"],
+    ["braces", '{"value":"{C:\\new}"}', "{C:\\new}"],
+  ])("preserves punctuation-wrapped Windows paths: %s", (_name, input, expected) => {
+    expect(parseJsonWithRepair(input)).toEqual({ value: expected });
+    expect(parseStreamingJson(input)).toEqual({ value: expected });
+  });
+
+  it("preserves a malformed Windows path after code-like command text", () => {
+    const input = '{"cmd": "python -c \'x\'; C:\\new\\file.txt"}';
+    expect(repairJson(input)).not.toBe(input);
+    expect(parseJsonWithRepair(input)).toEqual({
+      cmd: "python -c 'x'; C:\\new\\file.txt",
+    });
+    expect(parseStreamingJson(input)).toEqual({
+      cmd: "python -c 'x'; C:\\new\\file.txt",
+    });
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes silent newline corruption when users write multi-line Python or shell code through agent tools and a block header ends in a lowercase one-letter identifier, such as `as f:`, `if r:`, `in d:`, `match x:`, or `case x:`.

`repairJson()` could mistake that final `<letter>:` for a Windows drive prefix. It then doubled the following `\n` escape, so `JSON.parse` produced a literal backslash plus `n` instead of a newline. Once triggered, later newlines in the same string could also be corrupted.

Related: #93139 and #95982 (same root cause, but targeting source paths that moved on current `main`).

Closes #93139

## Why This Change Was Made

The existing Windows-path heuristic matches tails ending in `<non-alphanumeric><letter>:` so it can recover malformed JSON containing paths such as `C:\new\file`. That shape is inherently ambiguous with code such as `if x:\n`.

The final rule keeps the repair localized to the shared parser and uses a bounded convention-based tie-break:

1. Match only the candidate drive-path suffix.
2. End the keyword subject before the candidate separator.
3. Treat a whitespace-separated **lowercase** candidate after a block-opening keyword as code.
4. Preserve conventional uppercase drive letters and punctuation-delimited paths as Windows paths.

The keyword boundary recognizes prior JSON control escapes in their literal tracked form (`\\n`, `\\r`, and `\\t`), because `stringValuePrefix` stores those two-character escape spellings rather than decoded whitespace.

This deliberately favors the reported lowercase code variables (`x`, `r`, `d`, `f`) while preserving conventional uppercase paths such as `if C:\new==C:\temp`. The malformed input is otherwise ambiguous: uppercase code variables remain path-biased, while lowercase drive paths immediately following a guarded keyword remain code-biased.

The guard is suffix-scoped, so punctuation or code-like text earlier in the same value does not disable repair for a later genuine path.

## User Impact

- Multi-line code containing the reported one-letter block headers now retains real newlines through tool-call JSON repair.
- Existing malformed Windows-path recovery remains intact for uppercase drives, punctuation-wrapped paths, and paths following code-like command text.
- No public API, configuration, dependency, or export changes.

## Evidence

### Byte-level proof before the fix

The corrupted file contained `5c 6e` (backslash plus `n`) where `0a` (newline) was expected:

```text
# Line 35 of test_write.py, at the "as f:" boundary
Bytes: 61 73 20 66 3a 5c 6e 20 20 20 20 20 20 20 20 20 20 20 20 64 61 74 61
ASCII: as f:\n            data
#            ^^ ^^ literal 0x5c 0x6e instead of 0x0a
```

### Real OpenClaw verifier — before fix

OpenClaw v2026.7.1 stable, Claude Opus 4.6 through Anthropic Vertex:

```text
Run 1 — Version 2026.7.1-2 (stable), NO FIX

🐛 BUG DETECTED: test_write.py
  Real newlines: 61, Literal \n: 6
  Suspicious lines:
      Line 8: with open(f"/tmp/{item['name']}.log", 'w') as f:\n                f.write(...)
      Line 35: with open(self.config['db_path']) as f:\n            data = json.load(f)\n        if key in data:

🐛 BUG DETECTED: test_write2.py
  Real newlines: 24, Literal \n: 2

RESULT: 🐛 Bug reproduced — literal \n found in tool output
```

Two unpatched runs reproduced the same structural corruption.

### Real OpenClaw verifier — after applying the parser guard

```text
Run 3 — Version 2026.7.1, parser guard deployed

✅ Clean: test_write.py
  Real newlines: 66, Structural bugs: 0, Total literal \n: 1
  (the remaining literal \n was inside a string literal and expected)

✅ Clean: test_write2.py
  Real newlines: 26, Structural bugs: 0, Total literal \n: 0

RESULT: ✅ No bug detected in this run
```

Two patched runs completed with zero structural newline corruption. This live proof exercised the reported lowercase `as f:`/`if` class. The final candidate-boundary and compatibility narrowing is covered by the exact-head parser tests below.

### Final-head focused tests

Final head: `74a47a126f3`

```text
$ node scripts/run-vitest.mjs src/llm/utils/json-parse.test.ts

 Test Files  1 passed (1)
      Tests  25 passed (25)
   Duration  406ms

[test] passed 1 Vitest shard in 4.88s
```

The 25 tests include 14 pre-existing parser cases plus 11 focused regressions covering both `parseJsonWithRepair` and `parseStreamingJson`:

- direct lowercase code candidates: `if x:`, `as f:`, `in d:`, `match x:`, `case x:`
- the reported `if r:` sequence after a prior newline
- uppercase batch paths after a guarded keyword: `if C:\new==C:\temp`
- punctuation-wrapped malformed paths: `if,C:\new`, `(C:\new)`, `{C:\new}`
- a malformed `C:\new\file.txt` path after code-like command text
- the existing `C:\bin`, `C:\temp`, `C:\new`, `D:\reports`, and `C:\users` compatibility fixtures

### Formatting and diff checks

```text
$ ./node_modules/.bin/oxfmt --check packages/ai/src/utils/json-parse.ts src/llm/utils/json-parse.test.ts
All matched files use the correct format.

$ git diff --check upstream/main...HEAD
git diff --check: PASS
```

Exact-head hosted CI is being refreshed by this history-cleanup push. On the previous head, 1,503/1,504 tests passed; only the unrelated `src/system-agent/tui-backend.test.ts` timed out, so `openclaw/ci-gate` failed transitively.

## Scope

- `packages/ai/src/utils/json-parse.ts`
- `src/llm/utils/json-parse.test.ts`
- No changelog change, per contributor policy.
- Allow edits by maintainers remains enabled.
- AI-assisted: yes; the implementation and regressions were manually reviewed and validated as described above.

