### PR TITLE
refactor(channels): consolidate message-action read gate

### DIFF
--- a/src/channels/plugins/message-action-dispatch.ts
+++ b/src/channels/plugins/message-action-dispatch.ts
@@ -14,40 +14,143 @@ import type {
   ChannelPlugin,
 } from "./types.js";
 
-const READ_DEPENDENT_ACTIONS = new Set<ChannelMessageActionName>([
-  "poll-vote",
-  "react",
-  "reactions",
-  "read",
-  "edit",
-  "unsend",
-  "delete",
-  "pin",
-  "unpin",
-  "list-pins",
-  "permissions",
-  "thread-list",
-  "search",
-  "sticker-search",
-  "member-info",
-  "role-info",
-  "emoji-list",
-  "channel-info",
-  "channel-list",
-  "voice-status",
-  "event-list",
-  "download-file",
-]);
-
 // These bundled adapters have host-reviewed provider-side current/configured
 // gates. Other bundled adapters retain the exact-current compatibility limit.
-const BUNDLED_CHANNELS_WITH_PROVIDER_READ_GATES = new Set([
+const BUNDLED_CHANNELS_WITH_PROVIDER_READ_GATES: ReadonlySet<string> = new Set([
   "discord",
   "feishu",
   "matrix",
   "msteams",
   "slack",
 ]);
+
+declare const serverOwnedConversationReadOrigin: unique symbol;
+
+type ServerOwnedConversationReadOrigin = ReturnType<
+  typeof normalizeConversationReadInvocationOrigin
+> & {
+  readonly [serverOwnedConversationReadOrigin]: true;
+};
+
+type ChannelMessageActionDispatchContext = Omit<ChannelMessageActionContext, "action"> & {
+  action: unknown;
+};
+
+type ChannelMessageActionReadPolicy =
+  | { readonly kind: "none" }
+  | {
+      readonly kind: "conversation-read";
+      readonly targetlessCache: "deny" | "bundled-current-context";
+    };
+
+const NO_CONVERSATION_READ = { kind: "none" } as const;
+const CONVERSATION_READ = {
+  kind: "conversation-read",
+  targetlessCache: "deny",
+} as const;
+const BUNDLED_CURRENT_CONTEXT_CACHE_READ = {
+  kind: "conversation-read",
+  targetlessCache: "bundled-current-context",
+} as const;
+
+// Exhaustive by design: every new core action must declare its read authority
+// before the dispatcher will compile.
+const CHANNEL_MESSAGE_ACTION_READ_POLICIES = {
+  send: NO_CONVERSATION_READ,
+  broadcast: NO_CONVERSATION_READ,
+  poll: NO_CONVERSATION_READ,
+  "poll-vote": CONVERSATION_READ,
+  react: CONVERSATION_READ,
+  reactions: CONVERSATION_READ,
+  read: CONVERSATION_READ,
+  edit: CONVERSATION_READ,
+  unsend: CONVERSATION_READ,
+  reply: NO_CONVERSATION_READ,
+  sendWithEffect: NO_CONVERSATION_READ,
+  renameGroup: NO_CONVERSATION_READ,
+  setGroupIcon: NO_CONVERSATION_READ,
+  addParticipant: NO_CONVERSATION_READ,
+  removeParticipant: NO_CONVERSATION_READ,
+  leaveGroup: NO_CONVERSATION_READ,
+  sendAttachment: NO_CONVERSATION_READ,
+  delete: CONVERSATION_READ,
+  pin: CONVERSATION_READ,
+  unpin: CONVERSATION_READ,
+  "list-pins": CONVERSATION_READ,
+  permissions: CONVERSATION_READ,
+  "thread-create": NO_CONVERSATION_READ,
+  "thread-list": CONVERSATION_READ,
+  "thread-reply": NO_CONVERSATION_READ,
+  search: CONVERSATION_READ,
+  sticker: NO_CONVERSATION_READ,
+  "sticker-search": BUNDLED_CURRENT_CONTEXT_CACHE_READ,
+  "member-info": CONVERSATION_READ,
+  "role-info": CONVERSATION_READ,
+  "emoji-list": CONVERSATION_READ,
+  "emoji-upload": NO_CONVERSATION_READ,
+  "sticker-upload": NO_CONVERSATION_READ,
+  "role-add": NO_CONVERSATION_READ,
+  "role-remove": NO_CONVERSATION_READ,
+  "channel-info": CONVERSATION_READ,
+  "channel-list": CONVERSATION_READ,
+  "channel-create": NO_CONVERSATION_READ,
+  "channel-edit": NO_CONVERSATION_READ,
+  "channel-delete": NO_CONVERSATION_READ,
+  "channel-move": NO_CONVERSATION_READ,
+  "category-create": NO_CONVERSATION_READ,
+  "category-edit": NO_CONVERSATION_READ,
+  "category-delete": NO_CONVERSATION_READ,
+  "topic-create": NO_CONVERSATION_READ,
+  "topic-edit": NO_CONVERSATION_READ,
+  "voice-status": CONVERSATION_READ,
+  "event-list": CONVERSATION_READ,
+  "event-create": NO_CONVERSATION_READ,
+  timeout: NO_CONVERSATION_READ,
+  kick: NO_CONVERSATION_READ,
+  ban: NO_CONVERSATION_READ,
+  "set-profile": NO_CONVERSATION_READ,
+  "set-presence": NO_CONVERSATION_READ,
+  "download-file": CONVERSATION_READ,
+  "upload-file": NO_CONVERSATION_READ,
+} as const satisfies Record<ChannelMessageActionName, ChannelMessageActionReadPolicy>;
+
+function resolveChannelMessageActionReadPolicy(
+  action: unknown,
+): ChannelMessageActionReadPolicy | undefined {
+  if (typeof action !== "string" || !Object.hasOwn(CHANNEL_MESSAGE_ACTION_READ_POLICIES, action)) {
+    return undefined;
+  }
+  return CHANNEL_MESSAGE_ACTION_READ_POLICIES[action as ChannelMessageActionName];
+}
+
+function resolveServerOwnedConversationReadOrigin(
+  value: unknown,
+): ServerOwnedConversationReadOrigin {
+  return normalizeConversationReadInvocationOrigin(value) as ServerOwnedConversationReadOrigin;
+}
+
+type MessageActionReadEnforcement =
+  | { kind: "provider-owned" }
+  | {
+      kind: "host-exact-current";
+      pluginTrust: "bundled" | "external";
+    };
+
+function resolveMessageActionReadEnforcement(params: {
+  channel: string;
+  pluginOrigin: string | undefined;
+}): MessageActionReadEnforcement {
+  if (
+    params.pluginOrigin === "bundled" &&
+    BUNDLED_CHANNELS_WITH_PROVIDER_READ_GATES.has(params.channel)
+  ) {
+    return { kind: "provider-owned" };
+  }
+  return {
+    kind: "host-exact-current",
+    pluginTrust: params.pluginOrigin === "bundled" ? "bundled" : "external",
+  };
+}
 
 type HostConversationTargetKind =
   | "user"
@@ -230,7 +333,7 @@ function hasTargetInput(value: unknown): boolean {
 function isExactCurrentConversation(params: {
   ctx: ChannelMessageActionContext;
   plugin: ChannelPlugin;
-  pluginOrigin: string | undefined;
+  pluginTrust: "bundled" | "external";
 }): boolean {
   if (
     !hasMatchingCurrentProviderContext(params.ctx) ||
@@ -239,10 +342,10 @@ function isExactCurrentConversation(params: {
     return false;
   }
   const normalizeTarget =
-    params.pluginOrigin === "bundled" ? params.plugin.messaging?.normalizeTarget : undefined;
+    params.pluginTrust === "bundled" ? params.plugin.messaging?.normalizeTarget : undefined;
   const providerPrefixes = params.plugin.messaging?.targetPrefixes;
   const aliasSpec =
-    params.pluginOrigin === "bundled"
+    params.pluginTrust === "bundled"
       ? params.plugin.actions?.messageActionTargetAliases?.[params.ctx.action]
       : undefined;
   const deliveryTargetAliases = new Set(aliasSpec?.deliveryTargetAliases ?? []);
@@ -272,7 +375,7 @@ function isExactCurrentConversation(params: {
   }
   let hasDeliveryAliasInput = false;
   let normalizedAliasTarget: HostConversationTarget | undefined;
-  if (params.pluginOrigin === "bundled") {
+  if (params.pluginTrust === "bundled") {
     hasDeliveryAliasInput = (aliasSpec?.deliveryTargetAliases ?? []).some((alias) =>
       hasTargetInput(params.ctx.params[alias]),
     );
@@ -337,7 +440,7 @@ function isExactCurrentConversation(params: {
     return true;
   }
   if (
-    params.pluginOrigin !== "bundled" ||
+    params.pluginTrust !== "bundled" ||
     !hasDeliveryAliasInput ||
     !params.ctx.toolContext ||
     !aliasSpec?.matchesCurrentConversation ||
@@ -352,63 +455,53 @@ function isExactCurrentConversation(params: {
   });
 }
 
-function assertConversationReadAllowed(params: {
-  ctx: ChannelMessageActionContext;
-  plugin: ChannelPlugin;
-  pluginOrigin: string | undefined;
-}): void {
-  const usesBundledProviderReadGate =
-    params.pluginOrigin === "bundled" &&
-    BUNDLED_CHANNELS_WITH_PROVIDER_READ_GATES.has(params.ctx.channel);
-  if (
-    normalizeConversationReadInvocationOrigin(params.ctx.conversationReadOrigin) ===
-      "direct-operator" ||
-    usesBundledProviderReadGate ||
-    !READ_DEPENDENT_ACTIONS.has(params.ctx.action)
-  ) {
-    return;
-  }
-  const isBundledCurrentContextCacheRead =
-    params.pluginOrigin === "bundled" &&
-    params.ctx.action === "sticker-search" &&
-    hasMatchingCurrentProviderContext(params.ctx) &&
-    hasMatchingCurrentAccountContext(params.ctx) &&
-    hasCurrentConversationTarget(params.ctx);
-  if (
-    isBundledCurrentContextCacheRead ||
-    isExactCurrentConversation({
-      ctx: params.ctx,
-      plugin: params.plugin,
-      pluginOrigin: params.pluginOrigin,
-    })
-  ) {
-    return;
-  }
-  throw new Error(
-    `Delegated ${params.ctx.channel}:${params.ctx.action} requires the exact current conversation and account for this plugin.`,
-  );
-}
-
-function canonicalizeExternalExactCurrentTarget(params: {
-  ctx: ChannelMessageActionContext;
-  pluginOrigin: string | undefined;
-}): void {
-  if (
-    params.pluginOrigin === "bundled" ||
-    normalizeConversationReadInvocationOrigin(params.ctx.conversationReadOrigin) ===
-      "direct-operator" ||
-    !READ_DEPENDENT_ACTIONS.has(params.ctx.action)
-  ) {
-    return;
-  }
-  const target = params.ctx.params.target;
-  const resolvedTarget = [params.ctx.params.to, params.ctx.params.channelId].find(
+function canonicalizeExternalExactCurrentTarget(ctx: ChannelMessageActionContext): void {
+  const target = ctx.params.target;
+  const resolvedTarget = [ctx.params.to, ctx.params.channelId].find(
     (value): value is string => typeof value === "string" && Boolean(value.trim()),
   );
   if (typeof target === "string" && target.trim() && resolvedTarget) {
     // Authorization used the raw spelling. Plugin execution receives the
     // resolved destination so it cannot reinterpret an accepted kind alias.
-    params.ctx.params.target = resolvedTarget;
+    ctx.params.target = resolvedTarget;
+  }
+}
+
+/** The sole host chokepoint before any read-capable plugin callback runs. */
+function enforceMessageActionConversationReadGate(params: {
+  ctx: ChannelMessageActionContext;
+  plugin: ChannelPlugin;
+  origin: ServerOwnedConversationReadOrigin;
+  actionPolicy: ChannelMessageActionReadPolicy;
+  enforcement: MessageActionReadEnforcement;
+}): void {
+  if (params.actionPolicy.kind === "none" || params.origin === "direct-operator") {
+    return;
+  }
+  if (params.enforcement.kind === "provider-owned") {
+    return;
+  }
+
+  const isBundledCurrentContextCacheRead =
+    params.enforcement.pluginTrust === "bundled" &&
+    params.actionPolicy.targetlessCache === "bundled-current-context" &&
+    hasMatchingCurrentProviderContext(params.ctx) &&
+    hasMatchingCurrentAccountContext(params.ctx) &&
+    hasCurrentConversationTarget(params.ctx);
+  const exactCurrentConversation =
+    isBundledCurrentContextCacheRead ||
+    isExactCurrentConversation({
+      ctx: params.ctx,
+      plugin: params.plugin,
+      pluginTrust: params.enforcement.pluginTrust,
+    });
+  if (!exactCurrentConversation) {
+    throw new Error(
+      `Delegated ${params.ctx.channel}:${params.ctx.action} requires the exact current conversation and account for this plugin.`,
+    );
+  }
+  if (params.enforcement.pluginTrust === "external") {
+    canonicalizeExternalExactCurrentTarget(params.ctx);
   }
 }
 
@@ -428,8 +521,14 @@ function requiresTrustedRequesterSender(
  * Runs a channel message action if the target plugin supports it.
  */
 export async function dispatchChannelMessageAction(
-  ctx: ChannelMessageActionContext,
+  ctx: ChannelMessageActionDispatchContext,
 ): Promise<AgentToolResult<unknown> | null> {
+  const actionPolicy = resolveChannelMessageActionReadPolicy(ctx.action);
+  if (!actionPolicy) {
+    return null;
+  }
+  // The policy lookup is the runtime proof that this is a core-owned action.
+  const action = ctx.action as ChannelMessageActionName;
   const registration = resolveChannelPluginRegistration(ctx.channel);
   if (!registration) {
     return null;
@@ -439,28 +538,37 @@ export async function dispatchChannelMessageAction(
   if (!actions?.handleAction) {
     return null;
   }
-  // Loader provenance is host-owned. External and legacy registrations must
-  // prove the exact current conversation before any plugin callback can run.
-  assertConversationReadAllowed({
-    ctx,
+  const origin = resolveServerOwnedConversationReadOrigin(ctx.conversationReadOrigin);
+  const actionContext: ChannelMessageActionContext = {
+    ...ctx,
+    action,
+    // Plugins receive only the closed server-normalized classification.
+    conversationReadOrigin: origin,
+  };
+  enforceMessageActionConversationReadGate({
+    ctx: actionContext,
     plugin,
-    pluginOrigin: registration.origin,
-  });
-  canonicalizeExternalExactCurrentTarget({
-    ctx,
-    pluginOrigin: registration.origin,
+    origin,
+    actionPolicy,
+    enforcement: resolveMessageActionReadEnforcement({
+      channel: actionContext.channel,
+      pluginOrigin: registration.origin,
+    }),
   });
   // Some plugin actions depend on the sender identity to enforce channel-local
   // trust. Reject tool-driven calls before invoking the action without it.
-  if (requiresTrustedRequesterSender(ctx, plugin) && !ctx.requesterSenderId?.trim()) {
+  if (
+    requiresTrustedRequesterSender(actionContext, plugin) &&
+    !actionContext.requesterSenderId?.trim()
+  ) {
     throw new Error(
-      `Trusted sender identity is required for ${ctx.channel}:${ctx.action} in tool-driven contexts.`,
+      `Trusted sender identity is required for ${actionContext.channel}:${actionContext.action} in tool-driven contexts.`,
     );
   }
   // `handleAction` may be broad; `supportsAction` lets plugins cheaply decline
   // action names before the dispatcher enters channel-specific behavior.
-  if (actions.supportsAction && !actions.supportsAction({ action: ctx.action })) {
+  if (actions.supportsAction && !actions.supportsAction({ action: actionContext.action })) {
     return null;
   }
-  return await actions.handleAction(ctx);
+  return await actions.handleAction(actionContext);
 }

--- a/src/channels/plugins/message-actions.security.test.ts
+++ b/src/channels/plugins/message-actions.security.test.ts
@@ -167,6 +167,58 @@ describe("dispatchChannelMessageAction conversation-read provenance", () => {
     expect(handleAction).toHaveBeenCalledOnce();
   });
 
+  it.each([
+    { name: "missing", conversationReadOrigin: undefined },
+    { name: "unknown", conversationReadOrigin: "forged-direct-operator" as never },
+  ])(
+    "fails closed on $name origin despite model-argument and channelData spoofing",
+    async (testCase) => {
+      setReadPlugin();
+
+      await expect(
+        dispatchChannelMessageAction({
+          channel: "discord",
+          action: "read",
+          cfg: {} as OpenClawConfig,
+          params: {
+            channelId: "other",
+            conversationReadOrigin: "direct-operator",
+            pluginOrigin: "bundled",
+            channelData: {
+              conversationReadOrigin: "direct-operator",
+              pluginOrigin: "bundled",
+            },
+          },
+          accountId: "default",
+          requesterAccountId: "default",
+          conversationReadOrigin: testCase.conversationReadOrigin,
+          toolContext: {
+            currentChannelProvider: "discord",
+            currentChannelId: "current",
+          },
+        }),
+      ).rejects.toThrow("requires the exact current conversation and account");
+      expect(handleAction).not.toHaveBeenCalled();
+    },
+  );
+
+  it("rejects a non-core runtime action before any plugin callback", async () => {
+    setReadPlugin();
+
+    const result = await dispatchChannelMessageAction({
+      channel: "discord",
+      action: "forged-read" as never,
+      cfg: {} as OpenClawConfig,
+      params: { channelId: "other" },
+      conversationReadOrigin: "direct-operator",
+    });
+
+    expect(result).toBeNull();
+    expect(handleAction).not.toHaveBeenCalled();
+    expect(supportsAction).not.toHaveBeenCalled();
+    expect(requiresTrustedRequesterSender).not.toHaveBeenCalled();
+  });
+
   it("matches a sanitized channelId to a typed current-channel target", async () => {
     setReadPlugin();
 
@@ -288,6 +340,47 @@ describe("dispatchChannelMessageAction conversation-read provenance", () => {
         toolContext: {
           currentChannelProvider: "discord",
           currentMessagingTarget: "user:123",
+        },
+      }),
+    ).rejects.toThrow("requires the exact current conversation and account");
+    expect(handleAction).not.toHaveBeenCalled();
+  });
+
+  it("keeps external conversation ids case-sensitive after prefix normalization", async () => {
+    setReadPlugin();
+
+    await expect(
+      dispatchChannelMessageAction({
+        channel: "discord",
+        action: "read",
+        cfg: {} as OpenClawConfig,
+        params: { channelId: "CHANNEL:CURRENT" },
+        accountId: "default",
+        requesterAccountId: "default",
+        conversationReadOrigin: "delegated",
+        toolContext: {
+          currentChannelProvider: "discord",
+          currentChannelId: "channel:current",
+        },
+      }),
+    ).rejects.toThrow("requires the exact current conversation and account");
+    expect(handleAction).not.toHaveBeenCalled();
+  });
+
+  it("does not promote an omitted target account across a non-default requester account", async () => {
+    setReadPlugin();
+
+    await expect(
+      dispatchChannelMessageAction({
+        channel: "discord",
+        action: "read",
+        cfg: {} as OpenClawConfig,
+        params: { channelId: "current" },
+        requesterAccountId: "work",
+        conversationReadOrigin: "delegated",
+        toolContext: {
+          currentChannelProvider: "discord",
+          currentChannelId: "current",
         },
       }),
     ).rejects.toThrow("requires the exact current conversation and account");


### PR DESCRIPTION
## What Problem This Solves

Message-action conversation reads had authorization decisions split across a read-action set, provider-origin conditionals, exact-current checks, and a separate post-authorization canonicalization branch. That made it harder to prove that every read-capable dispatch path enforced the same fail-closed provenance rules.

## Why This Change Was Made

This consolidates host enforcement in `enforceMessageActionConversationReadGate` (`src/channels/plugins/message-action-dispatch.ts:470`). The gate receives a private branded origin minted only inside the core dispatcher, an exhaustive discriminated policy for every canonical action, and a closed provider-owned vs host-exact-current enforcement shape. Unknown runtime actions are rejected before any plugin callback.

The security invariants remain unchanged: direct-operator origin is recognized only by the strict server normalizer; audited bundled providers retain their provider-owned gates; every other delegated read must prove the exact current provider, conversation, and account; missing or unknown origin remains delegated; external adapters cannot supply normalizers, aliases, origin, or policy that widen authority.

## User Impact

No intended user-visible behavior change. This makes the existing message-action read boundary structurally harder to bypass and makes future action additions fail compilation until their read policy is explicitly classified.

## Evidence

### Chokepoint and dispatch coverage

- Chokepoint: `src/channels/plugins/message-action-dispatch.ts:470`.
- Private server-owned brand and constructor: `src/channels/plugins/message-action-dispatch.ts:27` and `src/channels/plugins/message-action-dispatch.ts:126`.
- Exhaustive action policy: `src/channels/plugins/message-action-dispatch.ts:39` and `src/channels/plugins/message-action-dispatch.ts:58`.
- All three production callers converge on the dispatcher (none needed call-site changes):
  - `src/gateway/server-methods/send.ts:578`
  - `src/infra/outbound/outbound-send-service.ts:233`
  - `src/infra/outbound/message-action-runner.ts:1787`
- Repository search finds one core plugin callback invocation, after the gate: `src/channels/plugins/message-action-dispatch.ts:573`.

### Adversarial security pass

| Attack class | Proof | Result |
| --- | --- | --- |
| Origin spoofing through tool/model params or `channelData` | New missing/unknown-origin table injects forged `conversationReadOrigin` and `pluginOrigin` at both parameter levels (`src/channels/plugins/message-actions.security.test.ts:170`). | Rejected before plugin code; only the dispatcher-owned normalized origin reaches the branded gate. |
| Cross-conversation reads through case tricks or ID aliases | New case-sensitive ID regression (`src/channels/plugins/message-actions.security.test.ts:349`) plus existing typed/untyped, conflicting-kind, provider-prefix, and alias-equivalence cases. | Crafted aliases, case changes, and semantic-kind collisions remain fail-closed. |
| Cross-account reads through omission/default promotion | New omitted-account/non-default-requester regression (`src/channels/plugins/message-actions.security.test.ts:370`) plus existing wrong, missing, and invalid account table cases (`src/channels/plugins/message-actions.security.test.ts:245`). | Omission cannot promote a request to the default account; exact normalized account equality is still required. |
| Bundled vs non-bundled misclassification | Existing bundled-provider delegation, unaudited-bundled exact-current, external-normalizer, stray-policy, and unknown-provenance cases (`src/channels/plugins/message-actions.security.test.ts:498`, `:512`, `:566`, `:1216`, `:1240`). | Only host-owned registration origin plus the audited bundled-provider set selects provider-owned enforcement. |
| Bypass through a dispatch path that skips the chokepoint | Static call-site search above plus focused gateway-send, outbound-send, and runner-dispatch suites; only one core `actions.handleAction` invocation exists. | Every production message-action path reaches the dispatcher, and every canonical read policy reaches the gate before plugin callbacks. |
| Non-core action name smuggling | New forged runtime-action regression (`src/channels/plugins/message-actions.security.test.ts:205`). | Rejected before support, trust, or action callbacks. |

### Validation

- `node scripts/run-vitest.mjs src/channels/plugins/message-actions.security.test.ts src/infra/outbound/message-action-runner.plugin-dispatch.test.ts src/infra/outbound/outbound-send-service.test.ts src/gateway/server-methods/send.test.ts` — 219 tests passed across 3 shards (61 channel security, 80 infra, 78 gateway).
- `pnpm deadcode:exports && pnpm deadcode:unused-files` — passed on Blacksmith Testbox `tbx_01kxy1eamz25fbpaq2raha4rpm` ([run](https://github.com/openclaw/openclaw/actions/runs/29702804103)); production/full-tree/script scans reported 0 entries.
- `pnpm check:changed` — passed all selected core, core-test, extension, and extension-test typecheck/lint/boundary/SDK contract gates during the workstream.
- `oxfmt` on both touched files — clean.
- `git diff --check` — clean.
- `AGENTS_HOME="$HOME/.claude" ~/.claude/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean, no accepted/actionable findings.
- `git diff --numstat`: production `+205/-97` (net `+108`), security tests `+93/-0` (net `+93`), total net `+201`. The production growth is intentional: the old partial read-action set is replaced by an exhaustive 56-action policy record plus private branded/discriminated enforcement types, so a new action cannot silently default to ungated behavior.
