### PR TITLE
feat(ui): accept drag-and-drop attachments in the new-session composer

### DIFF
--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -3492,7 +3492,9 @@ describe("chat attachment picker", () => {
     });
     const droppedFile = new File(["%PDF-1.4\n"], "brief.pdf", { type: "application/pdf" });
     const dropEvent = new Event("drop", { bubbles: true, cancelable: true });
-    Object.defineProperty(dropEvent, "dataTransfer", { value: { files: [droppedFile] } });
+    Object.defineProperty(dropEvent, "dataTransfer", {
+      value: { files: [droppedFile], types: ["Files"] },
+    });
 
     try {
       textarea.dispatchEvent(pasteEvent);

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -3328,6 +3328,24 @@ describe("chat attachment picker", () => {
     expect(chat.hasAttribute("data-attachment-drop-active")).toBe(false);
   });
 
+  it("cancels non-file drops outside the composer textarea but keeps them native inside it", () => {
+    const container = renderChatView();
+    const chat = requireElement(container, "section.card.chat", "chat drop target");
+    const textarea = requireElement(
+      container,
+      ".agent-chat__composer-combobox > textarea",
+      "composer textarea",
+    );
+
+    const outsideDrop = createDragEvent("drop", ["text/uri-list"]);
+    chat.dispatchEvent(outsideDrop);
+    expect(outsideDrop.defaultPrevented).toBe(true);
+
+    const textareaDrop = createDragEvent("drop", ["text/uri-list"]);
+    textarea.dispatchEvent(textareaDrop);
+    expect(textareaDrop.defaultPrevented).toBe(false);
+  });
+
   it("turns large pasted plain text into a compact attachment", async () => {
     const onAttachmentsChange = vi.fn();
     const container = renderChatView({

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -3344,6 +3344,13 @@ describe("chat attachment picker", () => {
     const textareaDrop = createDragEvent("drop", ["text/uri-list"]);
     textarea.dispatchEvent(textareaDrop);
     expect(textareaDrop.defaultPrevented).toBe(false);
+
+    const range = document.createElement("input");
+    range.type = "range";
+    chat.append(range);
+    const rangeDrop = createDragEvent("drop", ["text/uri-list"]);
+    range.dispatchEvent(rangeDrop);
+    expect(rangeDrop.defaultPrevented).toBe(true);
   });
 
   it("turns large pasted plain text into a compact attachment", async () => {

--- a/ui/src/pages/chat/chat-view.ts
+++ b/ui/src/pages/chat/chat-view.ts
@@ -26,7 +26,11 @@ import type { ChatSideResult, ChatSideResultPending } from "../../lib/chat/side-
 import type { EmbedSandboxMode } from "../../lib/chat/tool-display.ts";
 import type { ProviderUsageDisplayProps } from "../../lib/provider-quota-summary.ts";
 import type { UiSessionDefaultsHost } from "../../lib/sessions/session-key.ts";
-import { handleChatAttachmentDrop, isFileDrag } from "./components/chat-attachments.ts";
+import {
+  handleChatAttachmentDrop,
+  isEditableDropTarget,
+  isFileDrag,
+} from "./components/chat-attachments.ts";
 import {
   renderBackgroundTasksRail,
   type BackgroundTasksProps,
@@ -474,10 +478,13 @@ export function renderChat(props: ChatProps) {
           : {},
       )}
       @drop=${(event: DragEvent) => {
-        // Only cancel file drags: text/URL drops must keep the composer
-        // textarea's native drop behavior. Session drags are handled by the
-        // parent chat page and are unaffected either way.
+        // Text/URL drops stay native only inside editable controls; anywhere
+        // else they are cancelled so a dropped link cannot navigate the app
+        // away. Session drags are handled by the parent chat page either way.
         if (!isFileDrag(event.dataTransfer)) {
+          if (!isEditableDropTarget(event)) {
+            event.preventDefault();
+          }
           return;
         }
         event.preventDefault();
@@ -490,6 +497,12 @@ export function renderChat(props: ChatProps) {
       @dragleave=${(event: DragEvent) => setAttachmentDropActive(event, false)}
       @dragover=${(event: DragEvent) => {
         if (!isFileDrag(event.dataTransfer)) {
+          if (!isEditableDropTarget(event)) {
+            event.preventDefault();
+            if (event.dataTransfer) {
+              event.dataTransfer.dropEffect = "none";
+            }
+          }
           return;
         }
         event.preventDefault();

--- a/ui/src/pages/chat/chat-view.ts
+++ b/ui/src/pages/chat/chat-view.ts
@@ -26,7 +26,7 @@ import type { ChatSideResult, ChatSideResultPending } from "../../lib/chat/side-
 import type { EmbedSandboxMode } from "../../lib/chat/tool-display.ts";
 import type { ProviderUsageDisplayProps } from "../../lib/provider-quota-summary.ts";
 import type { UiSessionDefaultsHost } from "../../lib/sessions/session-key.ts";
-import { handleChatAttachmentDrop } from "./components/chat-attachments.ts";
+import { handleChatAttachmentDrop, isFileDrag } from "./components/chat-attachments.ts";
 import {
   renderBackgroundTasksRail,
   type BackgroundTasksProps,
@@ -66,10 +66,6 @@ import type { RealtimeTalkStatus } from "./realtime-talk.ts";
 import type { ChatRunUiStatus } from "./run-lifecycle.ts";
 import type { CompactionStatus, FallbackStatus, PlanStatus } from "./tool-stream.ts";
 import "../../components/resizable-divider.ts";
-
-function isFileDrag(dataTransfer: DataTransfer | null): boolean {
-  return Array.from(dataTransfer?.types ?? []).includes("Files");
-}
 
 export type ChatProps = {
   transcript: ChatTranscriptController;
@@ -478,6 +474,12 @@ export function renderChat(props: ChatProps) {
           : {},
       )}
       @drop=${(event: DragEvent) => {
+        // Only cancel file drags: text/URL drops must keep the composer
+        // textarea's native drop behavior. Session drags are handled by the
+        // parent chat page and are unaffected either way.
+        if (!isFileDrag(event.dataTransfer)) {
+          return;
+        }
         event.preventDefault();
         clearAttachmentDropActive(event);
         if (canCompose) {
@@ -487,9 +489,12 @@ export function renderChat(props: ChatProps) {
       @dragenter=${(event: DragEvent) => setAttachmentDropActive(event, true)}
       @dragleave=${(event: DragEvent) => setAttachmentDropActive(event, false)}
       @dragover=${(event: DragEvent) => {
+        if (!isFileDrag(event.dataTransfer)) {
+          return;
+        }
         event.preventDefault();
-        if (canCompose && event.dataTransfer && isFileDrag(event.dataTransfer)) {
-          event.dataTransfer.dropEffect = "copy";
+        if (event.dataTransfer) {
+          event.dataTransfer.dropEffect = canCompose ? "copy" : "none";
         }
       }}
       @keydown=${(event: KeyboardEvent) => {

--- a/ui/src/pages/chat/components/chat-attachments.ts
+++ b/ui/src/pages/chat/components/chat-attachments.ts
@@ -40,16 +40,30 @@ export function isFileDrag(dataTransfer: DataTransfer | null): boolean {
   return Array.from(dataTransfer?.types ?? []).includes("Files");
 }
 
+const TEXT_ENTRY_INPUT_TYPES = new Set([
+  "email",
+  "number",
+  "password",
+  "search",
+  "tel",
+  "text",
+  "url",
+]);
+
 // Native text/URL drop insertion is only meaningful on controls that can
-// actually accept it; anywhere else (including disabled/readonly inputs) an
-// uncancelled URL drop navigates the app away and discards unsent drafts.
+// actually accept it; anywhere else (disabled/readonly inputs, non-text
+// controls like checkbox/range) an uncancelled URL drop navigates the app
+// away and discards unsent drafts.
 export function isEditableDropTarget(event: DragEvent): boolean {
   const target = event.target;
   if (!(target instanceof Element)) {
     return false;
   }
   const editable = target.closest("textarea, input, [contenteditable]");
-  if (editable instanceof HTMLTextAreaElement || editable instanceof HTMLInputElement) {
+  if (editable instanceof HTMLInputElement) {
+    return TEXT_ENTRY_INPUT_TYPES.has(editable.type) && !editable.disabled && !editable.readOnly;
+  }
+  if (editable instanceof HTMLTextAreaElement) {
     return !editable.disabled && !editable.readOnly;
   }
   return editable instanceof HTMLElement && editable.isContentEditable;

--- a/ui/src/pages/chat/components/chat-attachments.ts
+++ b/ui/src/pages/chat/components/chat-attachments.ts
@@ -36,6 +36,10 @@ type ChatAttachmentControlsProps = {
   readSignal?: AbortSignal;
 };
 
+export function isFileDrag(dataTransfer: DataTransfer | null): boolean {
+  return Array.from(dataTransfer?.types ?? []).includes("Files");
+}
+
 function currentAttachments(props: ChatAttachmentControlsProps): ChatAttachment[] {
   return props.getAttachments?.() ?? props.attachments ?? [];
 }

--- a/ui/src/pages/chat/components/chat-attachments.ts
+++ b/ui/src/pages/chat/components/chat-attachments.ts
@@ -40,14 +40,19 @@ export function isFileDrag(dataTransfer: DataTransfer | null): boolean {
   return Array.from(dataTransfer?.types ?? []).includes("Files");
 }
 
-// Native text/URL drop insertion is only meaningful on editable controls;
-// anywhere else an uncancelled URL drop navigates the app away and discards
-// unsent drafts.
+// Native text/URL drop insertion is only meaningful on controls that can
+// actually accept it; anywhere else (including disabled/readonly inputs) an
+// uncancelled URL drop navigates the app away and discards unsent drafts.
 export function isEditableDropTarget(event: DragEvent): boolean {
-  return (
-    event.target instanceof Element &&
-    event.target.closest("textarea, input, [contenteditable]") !== null
-  );
+  const target = event.target;
+  if (!(target instanceof Element)) {
+    return false;
+  }
+  const editable = target.closest("textarea, input, [contenteditable]");
+  if (editable instanceof HTMLTextAreaElement || editable instanceof HTMLInputElement) {
+    return !editable.disabled && !editable.readOnly;
+  }
+  return editable instanceof HTMLElement && editable.isContentEditable;
 }
 
 function currentAttachments(props: ChatAttachmentControlsProps): ChatAttachment[] {

--- a/ui/src/pages/chat/components/chat-attachments.ts
+++ b/ui/src/pages/chat/components/chat-attachments.ts
@@ -40,6 +40,16 @@ export function isFileDrag(dataTransfer: DataTransfer | null): boolean {
   return Array.from(dataTransfer?.types ?? []).includes("Files");
 }
 
+// Native text/URL drop insertion is only meaningful on editable controls;
+// anywhere else an uncancelled URL drop navigates the app away and discards
+// unsent drafts.
+export function isEditableDropTarget(event: DragEvent): boolean {
+  return (
+    event.target instanceof Element &&
+    event.target.closest("textarea, input, [contenteditable]") !== null
+  );
+}
+
 function currentAttachments(props: ChatAttachmentControlsProps): ChatAttachment[] {
   return props.getAttachments?.() ?? props.attachments ?? [];
 }

--- a/ui/src/pages/new-session/composer.test.ts
+++ b/ui/src/pages/new-session/composer.test.ts
@@ -111,6 +111,13 @@ describe("new-session composer attachment drops", () => {
     composer.dispatchEvent(shellDrop);
     expect(shellDrop.defaultPrevented).toBe(true);
     expect(replace).not.toHaveBeenCalled();
+
+    const checkbox = document.createElement("input");
+    checkbox.type = "checkbox";
+    composer.append(checkbox);
+    const checkboxDrop = createDragEvent("drop", [], ["text/uri-list"]);
+    checkbox.dispatchEvent(checkboxDrop);
+    expect(checkboxDrop.defaultPrevented).toBe(true);
   });
 
   it.each([

--- a/ui/src/pages/new-session/composer.test.ts
+++ b/ui/src/pages/new-session/composer.test.ts
@@ -1,0 +1,125 @@
+/* @vitest-environment jsdom */
+
+import { render } from "lit";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { waitForFast } from "../../test-helpers/wait-for.ts";
+import { NewSessionAttachmentDraft } from "./attachment-draft.ts";
+import { renderNewSessionDraftComposer } from "./composer.ts";
+import { NewSessionModelControl } from "./model-control.ts";
+
+const attachmentDrafts: NewSessionAttachmentDraft[] = [];
+
+function renderComposer(overrides: { submitting?: boolean; messageLocked?: boolean } = {}) {
+  const container = document.createElement("div");
+  const attachmentDraft = new NewSessionAttachmentDraft(() => undefined);
+  attachmentDrafts.push(attachmentDraft);
+  render(
+    renderNewSessionDraftComposer({
+      agentId: "main",
+      attachmentDraft,
+      canSubmit: true,
+      context: undefined,
+      isCatalogTarget: true,
+      message: "",
+      modelControl: new NewSessionModelControl(() => undefined),
+      requiresModifier: false,
+      submitting: overrides.submitting ?? false,
+      messageLocked: overrides.messageLocked,
+      onInput: () => undefined,
+      onSubmit: () => undefined,
+    }),
+    container,
+  );
+  const composer = container.querySelector<HTMLElement>(".new-session-page__composer");
+  if (!composer) {
+    throw new Error("Expected new-session composer");
+  }
+  return { attachmentDraft, composer };
+}
+
+function createDragEvent(type: string, files: File[] = [], types = ["Files"]): Event {
+  const event = new Event(type, { bubbles: true, cancelable: true });
+  Object.defineProperty(event, "dataTransfer", {
+    value: { files, types },
+  });
+  return event;
+}
+
+afterEach(() => {
+  for (const attachmentDraft of attachmentDrafts) {
+    attachmentDraft.reset({ release: true });
+  }
+  attachmentDrafts.length = 0;
+  vi.restoreAllMocks();
+});
+
+describe("new-session composer attachment drops", () => {
+  it("adds a dropped file through the shared attachment handling", async () => {
+    const { attachmentDraft, composer } = renderComposer();
+    const replace = vi.spyOn(attachmentDraft, "replace");
+    const file = new File(["image"], "pic.png", { type: "image/png" });
+
+    composer.dispatchEvent(createDragEvent("drop", [file]));
+
+    await waitForFast(() => expect(replace).toHaveBeenCalledOnce());
+    expect(replace).toHaveBeenCalledWith([
+      expect.objectContaining({
+        fileName: "pic.png",
+        mimeType: "image/png",
+        sizeBytes: file.size,
+      }),
+    ]);
+    expect(attachmentDraft.attachments).toHaveLength(1);
+    expect(attachmentDraft.attachments[0]).toMatchObject({
+      fileName: "pic.png",
+      mimeType: "image/png",
+      sizeBytes: file.size,
+    });
+  });
+
+  it("keeps the drop affordance balanced across nested drag targets", () => {
+    const { composer } = renderComposer();
+
+    composer.dispatchEvent(createDragEvent("dragenter"));
+    expect(composer.hasAttribute("data-attachment-drop-active")).toBe(true);
+
+    composer.dispatchEvent(createDragEvent("dragenter"));
+    composer.dispatchEvent(createDragEvent("dragleave"));
+    expect(composer.hasAttribute("data-attachment-drop-active")).toBe(true);
+
+    composer.dispatchEvent(createDragEvent("dragleave"));
+    expect(composer.hasAttribute("data-attachment-drop-active")).toBe(false);
+  });
+
+  it("leaves non-file drags to the textarea's native drop behavior", () => {
+    const { attachmentDraft, composer } = renderComposer();
+    const replace = vi.spyOn(attachmentDraft, "replace");
+
+    const dragenter = createDragEvent("dragenter", [], ["text/plain"]);
+    composer.dispatchEvent(dragenter);
+    expect(composer.hasAttribute("data-attachment-drop-active")).toBe(false);
+
+    const drop = createDragEvent("drop", [], ["text/plain"]);
+    composer.dispatchEvent(drop);
+    expect(drop.defaultPrevented).toBe(false);
+    expect(replace).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { submitting: true, messageLocked: false },
+    { submitting: false, messageLocked: true },
+  ])("ignores drops while the composer is disabled", (disabled) => {
+    const { attachmentDraft, composer } = renderComposer(disabled);
+    const replace = vi.spyOn(attachmentDraft, "replace");
+    const readAsDataUrl = vi.spyOn(FileReader.prototype, "readAsDataURL");
+    const file = new File(["image"], "pic.png", { type: "image/png" });
+
+    composer.dispatchEvent(createDragEvent("dragenter"));
+    composer.dispatchEvent(createDragEvent("drop", [file]));
+
+    expect(composer.hasAttribute("data-attachment-drop-active")).toBe(false);
+    expect(readAsDataUrl).not.toHaveBeenCalled();
+    expect(replace).not.toHaveBeenCalled();
+    expect(attachmentDraft.attachments).toEqual([]);
+  });
+});

--- a/ui/src/pages/new-session/composer.test.ts
+++ b/ui/src/pages/new-session/composer.test.ts
@@ -91,17 +91,25 @@ describe("new-session composer attachment drops", () => {
     expect(composer.hasAttribute("data-attachment-drop-active")).toBe(false);
   });
 
-  it("leaves non-file drags to the textarea's native drop behavior", () => {
+  it("keeps non-file drops native inside the textarea and cancels them elsewhere", () => {
     const { attachmentDraft, composer } = renderComposer();
     const replace = vi.spyOn(attachmentDraft, "replace");
+    const textarea = composer.querySelector<HTMLTextAreaElement>("textarea");
+    if (!textarea) {
+      throw new Error("Expected composer textarea");
+    }
 
     const dragenter = createDragEvent("dragenter", [], ["text/plain"]);
     composer.dispatchEvent(dragenter);
     expect(composer.hasAttribute("data-attachment-drop-active")).toBe(false);
 
-    const drop = createDragEvent("drop", [], ["text/plain"]);
-    composer.dispatchEvent(drop);
-    expect(drop.defaultPrevented).toBe(false);
+    const textareaDrop = createDragEvent("drop", [], ["text/plain"]);
+    textarea.dispatchEvent(textareaDrop);
+    expect(textareaDrop.defaultPrevented).toBe(false);
+
+    const shellDrop = createDragEvent("drop", [], ["text/uri-list"]);
+    composer.dispatchEvent(shellDrop);
+    expect(shellDrop.defaultPrevented).toBe(true);
     expect(replace).not.toHaveBeenCalled();
   });
 

--- a/ui/src/pages/new-session/composer.test.ts
+++ b/ui/src/pages/new-session/composer.test.ts
@@ -129,5 +129,14 @@ describe("new-session composer attachment drops", () => {
     expect(readAsDataUrl).not.toHaveBeenCalled();
     expect(replace).not.toHaveBeenCalled();
     expect(attachmentDraft.attachments).toEqual([]);
+
+    const textarea = composer.querySelector<HTMLTextAreaElement>("textarea");
+    if (!textarea) {
+      throw new Error("Expected composer textarea");
+    }
+    expect(textarea.disabled).toBe(true);
+    const disabledTextareaDrop = createDragEvent("drop", [], ["text/uri-list"]);
+    textarea.dispatchEvent(disabledTextareaDrop);
+    expect(disabledTextareaDrop.defaultPrevented).toBe(true);
   });
 });

--- a/ui/src/pages/new-session/composer.ts
+++ b/ui/src/pages/new-session/composer.ts
@@ -6,6 +6,7 @@ import type { ChatAttachment } from "../../lib/chat/chat-types.ts";
 import {
   handleChatAttachmentDrop,
   handleChatAttachmentPaste,
+  isEditableDropTarget,
   isFileDrag,
   renderAttachmentPreview,
   renderChatAttachmentInputs,
@@ -91,10 +92,13 @@ function renderNewSessionComposer(options: NewSessionComposerOptions) {
     <div
       class="agent-chat__composer-shell new-session-page__composer"
       @drop=${(event: DragEvent) => {
-        // Only cancel file drags: text/URL drops must keep the textarea's
-        // native drop behavior. File drops are cancelled even while disabled
-        // so the browser never navigates to the dropped file.
+        // Text/URL drops stay native only inside the textarea; elsewhere they
+        // are cancelled so a dropped link cannot navigate the app away. File
+        // drops are cancelled even while disabled for the same reason.
         if (!isFileDrag(event.dataTransfer)) {
+          if (!isEditableDropTarget(event)) {
+            event.preventDefault();
+          }
           return;
         }
         event.preventDefault();
@@ -107,6 +111,12 @@ function renderNewSessionComposer(options: NewSessionComposerOptions) {
       @dragleave=${(event: DragEvent) => setAttachmentDropActive(event, false)}
       @dragover=${(event: DragEvent) => {
         if (!isFileDrag(event.dataTransfer)) {
+          if (!isEditableDropTarget(event)) {
+            event.preventDefault();
+            if (event.dataTransfer) {
+              event.dataTransfer.dropEffect = "none";
+            }
+          }
           return;
         }
         event.preventDefault();

--- a/ui/src/pages/new-session/composer.ts
+++ b/ui/src/pages/new-session/composer.ts
@@ -4,7 +4,9 @@ import "../../components/tooltip.ts";
 import { t } from "../../i18n/index.ts";
 import type { ChatAttachment } from "../../lib/chat/chat-types.ts";
 import {
+  handleChatAttachmentDrop,
   handleChatAttachmentPaste,
+  isFileDrag,
   renderAttachmentPreview,
   renderChatAttachmentInputs,
   renderChatAttachmentMenu,
@@ -59,8 +61,60 @@ function renderNewSessionComposer(options: NewSessionComposerOptions) {
     onPendingReadsChange: options.onPendingReadsChange,
     readSignal: options.readSignal,
   };
+  const enabled = !options.submitting && !options.messageLocked;
+  // Nested dragenter/dragleave events must stay balanced so crossing composer
+  // children does not flicker the file drop affordance.
+  let attachmentDragDepth = 0;
+  const setAttachmentDropActive = (event: DragEvent, active: boolean) => {
+    const target = event.currentTarget;
+    if (!(target instanceof HTMLElement)) {
+      return;
+    }
+    if (active) {
+      if (!enabled || !isFileDrag(event.dataTransfer)) {
+        return;
+      }
+      attachmentDragDepth += 1;
+    } else {
+      attachmentDragDepth = Math.max(0, attachmentDragDepth - 1);
+    }
+    target.toggleAttribute("data-attachment-drop-active", attachmentDragDepth > 0);
+  };
+  const clearAttachmentDropActive = (event: DragEvent) => {
+    attachmentDragDepth = 0;
+    const target = event.currentTarget;
+    if (target instanceof HTMLElement) {
+      target.removeAttribute("data-attachment-drop-active");
+    }
+  };
   return html`
-    <div class="agent-chat__composer-shell new-session-page__composer">
+    <div
+      class="agent-chat__composer-shell new-session-page__composer"
+      @drop=${(event: DragEvent) => {
+        // Only cancel file drags: text/URL drops must keep the textarea's
+        // native drop behavior. File drops are cancelled even while disabled
+        // so the browser never navigates to the dropped file.
+        if (!isFileDrag(event.dataTransfer)) {
+          return;
+        }
+        event.preventDefault();
+        clearAttachmentDropActive(event);
+        if (enabled) {
+          handleChatAttachmentDrop(event, attachmentProps);
+        }
+      }}
+      @dragenter=${(event: DragEvent) => setAttachmentDropActive(event, true)}
+      @dragleave=${(event: DragEvent) => setAttachmentDropActive(event, false)}
+      @dragover=${(event: DragEvent) => {
+        if (!isFileDrag(event.dataTransfer)) {
+          return;
+        }
+        event.preventDefault();
+        if (event.dataTransfer) {
+          event.dataTransfer.dropEffect = enabled ? "copy" : "none";
+        }
+      }}
+    >
       <div class="agent-chat__input">
         ${renderChatAttachmentInputs(attachmentProps)} ${renderAttachmentPreview(attachmentProps)}
         <div class="agent-chat__composer-input-row">

--- a/ui/src/styles/new-session.css
+++ b/ui/src/styles/new-session.css
@@ -245,7 +245,40 @@ wa-popover.new-session-page__select--folder::part(body) {
 
 /* The chip row already spaces itself; keep the composer snug beneath it. */
 .new-session-page__composer.agent-chat__composer-shell {
+  position: relative;
   margin-top: 0;
+  border-radius: var(--radius-md);
+}
+
+.new-session-page__composer::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  pointer-events: none;
+  border-radius: inherit;
+  background: var(--accent);
+  opacity: 0;
+  transition: opacity 140ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+.new-session-page__composer[data-attachment-drop-active]::after {
+  opacity: 0.1;
+}
+
+.new-session-page__composer > * {
+  transition: opacity 140ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+.new-session-page__composer[data-attachment-drop-active] > * {
+  opacity: 0.5;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .new-session-page__composer::after,
+  .new-session-page__composer > * {
+    transition-duration: 0ms;
+  }
 }
 
 .new-session-page__target-icon {


### PR DESCRIPTION
## What Problem This Solves

Dragging an image (or any file) onto the new-thread composer in the Control UI did nothing: the composer wired paste and the "+" attachment menu, but never registered drag-and-drop handlers, so the shared drop pipeline (`handleChatAttachmentDrop`) was only reachable from the regular chat pane.

## Why This Change Was Made

Users expect the new-session ("What should this thread work on?") composer to accept dropped files the same way the chat composer does. The fix reuses the existing shared attachment ingestion path rather than adding a parallel one:

- `ui/src/pages/new-session/composer.ts`: drag/drop wiring on the composer shell with the same balanced dragenter/dragleave depth affordance the chat pane uses (`data-attachment-drop-active`).
- `ui/src/pages/chat/components/chat-attachments.ts`: `isFileDrag` moved here as the single shared helper, plus `isEditableDropTarget` (checks real editability: disabled/readonly inputs and non-editable elements don't count).
- Drop policy in both composers, per review feedback: **file drags** are always cancelled and ingested (even while disabled, so the browser never navigates to a dropped file); **non-file drops (text/URL)** stay native only when the target is an actually-editable control, and are cancelled everywhere else so a dropped link cannot navigate the app away and discard drafts.
- `ui/src/styles/new-session.css`: drop overlay affordance matching the chat pane's visual language, with reduced-motion handling.

## User Impact

Dropping images/files onto the new-thread composer now attaches them, with the same highlight affordance as the chat pane. Dragging text into either composer's textarea inserts it natively instead of being swallowed (a pre-existing chat-pane quirk), while URL drops anywhere else in the chat pane or composer chrome remain cancelled — no navigation, no lost drafts.

## Evidence

**Unit/regression tests** (focused remote run on Blacksmith Testbox `tbx_01kxy6v0jydbrc781y1d4g5y9t`, `pnpm test ui/src/pages/new-session/composer.test.ts ui/src/pages/chat/chat-view.test.ts`: 2 files, 183 tests, all passed at head `d80401f`):
- file drop attaches via shared handling; nested drag affordance stays balanced; disabled composer ignores drops and cancels URL drops on its disabled textarea; non-file drops stay native inside the textarea and are cancelled outside it (both composers).

**Live browser proof** (real Control UI served by `pnpm dev:ui:mock`, real Chromium via Playwright on the same Testbox; fixture data only; `results.json` assertions ran in the live app):
1. File dragenter shows the drop affordance; drop attaches the file (thumbnail + remove chip visible): ![1a](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/pr-111530/1a-file-dragover-overlay.jpg) ![1b](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/pr-111530/1b-file-dropped-attached.jpg) ![2](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/pr-111530/2-url-drop-into-textarea-native.jpg) (red square = attached test image)
2. URL drop into the textarea: `defaultPrevented === false` → native insertion allowed.
3. URL drop on composer chrome (send-button row): `defaultPrevented === true` → navigation blocked: ![3](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/pr-111530/3-url-drop-composer-chrome-cancelled.jpg)
4. URL drop on the regular chat transcript: `defaultPrevented === true` → navigation blocked, transcript/draft intact: ![4](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/pr-111530/4-url-drop-chat-transcript-cancelled.jpg)

Proof-method note: synthesized drag events cannot trigger browser-native navigation in headless Chromium (verified with a control: a CDP URL drop on an unguarded `data:` page did not navigate either), so the live run asserts the `defaultPrevented` contract per target in the real running app — the exact signal browsers act on when deciding to navigate or insert. The attach path (proof 1) is fully exercised end-to-end including FileReader ingestion and preview rendering.

**Gates**: PR CI green on head `d80401f68a3` (run 29705573034); autoreview (Codex `gpt-5.6-sol`, xhigh) clean on the final branch diff; `git diff --check` clean.
