### PR TITLE
fix(ui): keep stray file drops from leaving Control UI

### DIFF
--- a/ui/src/app/app-host.test.ts
+++ b/ui/src/app/app-host.test.ts
@@ -165,6 +165,13 @@ type ShellChromeEventState = {
   disconnectedCallback: () => void;
 };
 
+function createDragEvent(type: "dragover" | "drop", types: string[]) {
+  const event = new Event(type, { bubbles: true, cancelable: true }) as DragEvent;
+  const dataTransfer = { dropEffect: "copy", types };
+  Object.defineProperty(event, "dataTransfer", { value: dataTransfer });
+  return { dataTransfer, event };
+}
+
 type ShellSettingsSearchLoadState = {
   runtime: {
     context: ApplicationContext;
@@ -459,6 +466,41 @@ describe("OpenClaw shell keyboard shortcuts", () => {
     );
     shell.disconnectedCallback();
     addEventListener.mockRestore();
+  });
+
+  it("prevents unhandled window file drops without overriding accepted targets", () => {
+    const shell = document.createElement("openclaw-app-shell") as unknown as ShellChromeEventState;
+    const nativeFileInput = document.createElement("input");
+    nativeFileInput.type = "file";
+    document.body.append(nativeFileInput);
+    shell.connectedCallback();
+
+    try {
+      for (const type of ["dragover", "drop"] as const) {
+        const unhandled = createDragEvent(type, ["Files"]);
+        window.dispatchEvent(unhandled.event);
+        expect(unhandled.event.defaultPrevented).toBe(true);
+        expect(unhandled.dataTransfer.dropEffect).toBe("none");
+
+        const accepted = createDragEvent(type, ["Files"]);
+        accepted.event.preventDefault();
+        window.dispatchEvent(accepted.event);
+        expect(accepted.dataTransfer.dropEffect).toBe("copy");
+
+        const nativeAccepted = createDragEvent(type, ["Files"]);
+        nativeFileInput.dispatchEvent(nativeAccepted.event);
+        expect(nativeAccepted.event.defaultPrevented).toBe(false);
+        expect(nativeAccepted.dataTransfer.dropEffect).toBe("copy");
+
+        const nonFile = createDragEvent(type, ["text/plain"]);
+        window.dispatchEvent(nonFile.event);
+        expect(nonFile.event.defaultPrevented).toBe(false);
+        expect(nonFile.dataTransfer.dropEffect).toBe("copy");
+      }
+    } finally {
+      shell.disconnectedCallback();
+      nativeFileInput.remove();
+    }
   });
 
   it("handles merged header drawer and palette requests", () => {

--- a/ui/src/app/app-host.test.ts
+++ b/ui/src/app/app-host.test.ts
@@ -470,9 +470,10 @@ describe("OpenClaw shell keyboard shortcuts", () => {
 
   it("prevents unhandled window file drops without overriding accepted targets", () => {
     const shell = document.createElement("openclaw-app-shell") as unknown as ShellChromeEventState;
+    const acceptedDropTarget = document.createElement("div");
     const nativeFileInput = document.createElement("input");
     nativeFileInput.type = "file";
-    document.body.append(nativeFileInput);
+    document.body.append(acceptedDropTarget, nativeFileInput);
     shell.connectedCallback();
 
     try {
@@ -483,8 +484,11 @@ describe("OpenClaw shell keyboard shortcuts", () => {
         expect(unhandled.dataTransfer.dropEffect).toBe("none");
 
         const accepted = createDragEvent(type, ["Files"]);
-        accepted.event.preventDefault();
-        window.dispatchEvent(accepted.event);
+        acceptedDropTarget.addEventListener(type, (event) => event.preventDefault(), {
+          once: true,
+        });
+        acceptedDropTarget.dispatchEvent(accepted.event);
+        expect(accepted.event.defaultPrevented).toBe(true);
         expect(accepted.dataTransfer.dropEffect).toBe("copy");
 
         const nativeAccepted = createDragEvent(type, ["Files"]);
@@ -499,6 +503,7 @@ describe("OpenClaw shell keyboard shortcuts", () => {
       }
     } finally {
       shell.disconnectedCallback();
+      acceptedDropTarget.remove();
       nativeFileInput.remove();
     }
   });

--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -620,6 +620,8 @@ class OpenClawShell extends OpenClawLightDomElement {
     window.addEventListener(SHELL_NAV_DRAWER_TOGGLE_EVENT, this.handleShellNavDrawerToggle);
     document.addEventListener("keydown", this.handleDocumentKeydown);
     window.addEventListener("resize", this.handleWindowResize);
+    window.addEventListener("dragover", this.handleUnhandledFileDrag);
+    window.addEventListener("drop", this.handleUnhandledFileDrag);
     window.addEventListener(NATIVE_HISTORY_STATE_EVENT, this.handleNativeHistoryState);
     // Shipped Mac app builds without web chrome still drive these events; the
     // app's ⌘N menu item reuses native-new-session, while its ⌘K menu item
@@ -650,6 +652,8 @@ class OpenClawShell extends OpenClawLightDomElement {
     window.removeEventListener(SHELL_NAV_DRAWER_TOGGLE_EVENT, this.handleShellNavDrawerToggle);
     document.removeEventListener("keydown", this.handleDocumentKeydown);
     window.removeEventListener("resize", this.handleWindowResize);
+    window.removeEventListener("dragover", this.handleUnhandledFileDrag);
+    window.removeEventListener("drop", this.handleUnhandledFileDrag);
     window.removeEventListener(NATIVE_HISTORY_STATE_EVENT, this.handleNativeHistoryState);
     window.removeEventListener("openclaw:native-toggle-sidebar", this.handleNativeToggleSidebar);
     window.removeEventListener("openclaw:native-open-search", this.handleNativeOpenSearch);
@@ -970,6 +974,28 @@ class OpenClawShell extends OpenClawLightDomElement {
         });
       }
     });
+  };
+
+  private readonly handleUnhandledFileDrag = (event: DragEvent) => {
+    // Page drop targets prevent the event first; this fallback only rejects stray files
+    // so the browser cannot navigate away and discard the current app state.
+    const nativeFileInput = event
+      .composedPath()
+      .some(
+        (target) =>
+          target instanceof HTMLInputElement && target.type === "file" && !target.disabled,
+      );
+    if (
+      event.defaultPrevented ||
+      nativeFileInput ||
+      !Array.from(event.dataTransfer?.types ?? []).includes("Files")
+    ) {
+      return;
+    }
+    event.preventDefault();
+    if (event.dataTransfer) {
+      event.dataTransfer.dropEffect = "none";
+    }
   };
 
   private dismissSidebarTransientMenus(): boolean {

--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -977,8 +977,8 @@ class OpenClawShell extends OpenClawLightDomElement {
   };
 
   private readonly handleUnhandledFileDrag = (event: DragEvent) => {
-    // Page drop targets prevent the event first; this fallback only rejects stray files
-    // so the browser cannot navigate away and discard the current app state.
+    // Bubble phase is intentional: explicit drop targets get first refusal by
+    // preventing the event, while only unaccepted file drags reach this fallback.
     const nativeFileInput = event
       .composedPath()
       .some(

--- a/ui/src/e2e/file-drop-guard.e2e.test.ts
+++ b/ui/src/e2e/file-drop-guard.e2e.test.ts
@@ -1,0 +1,153 @@
+// Control UI tests cover browser-level file-drop routing against a mocked Gateway.
+import { chromium, type Browser } from "playwright";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  canRunPlaywrightChromium,
+  installMockGateway,
+  resolvePlaywrightChromiumExecutablePath,
+  startControlUiE2eServer,
+  type ControlUiE2eServer,
+} from "../test-helpers/control-ui-e2e.ts";
+
+const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
+const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
+const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
+const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+
+let browser: Browser;
+let server: ControlUiE2eServer;
+
+describeControlUiE2e("Control UI file-drop guard", () => {
+  beforeAll(async () => {
+    if (!chromiumAvailable) {
+      throw new Error(`Playwright Chromium is not installed at ${chromiumExecutablePath}`);
+    }
+    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
+    try {
+      server = await startControlUiE2eServer();
+    } catch (error) {
+      await browser.close();
+      throw error;
+    }
+  });
+
+  afterAll(async () => {
+    await browser?.close();
+    await server?.close();
+  });
+
+  it("rejects a stray file drop while preserving attachment inputs", async () => {
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    await installMockGateway(page);
+
+    try {
+      await page.goto(`${server.baseUrl}chat`);
+      const composer = page.locator(".agent-chat__composer-combobox textarea");
+      await composer.waitFor({ state: "visible", timeout: 10_000 });
+      await composer.fill("draft survives stray drop");
+
+      const stray = await page.locator("openclaw-app-shell").evaluate((element) => {
+        const transfer = new DataTransfer();
+        transfer.items.add(new File(["stray"], "stray-proof.txt", { type: "text/plain" }));
+        const beforeUrl = location.href;
+        const beforeDraft = document.querySelector<HTMLTextAreaElement>(
+          ".agent-chat__composer-combobox textarea",
+        )?.value;
+        const dragOver = new DragEvent("dragover", {
+          bubbles: true,
+          cancelable: true,
+          dataTransfer: transfer,
+        });
+        const drop = new DragEvent("drop", {
+          bubbles: true,
+          cancelable: true,
+          dataTransfer: transfer,
+        });
+        element.dispatchEvent(dragOver);
+        element.dispatchEvent(drop);
+        return {
+          draftUnchanged:
+            document.querySelector<HTMLTextAreaElement>(".agent-chat__composer-combobox textarea")
+              ?.value === beforeDraft,
+          dragOverPrevented: dragOver.defaultPrevented,
+          dropEffect: transfer.dropEffect,
+          dropPrevented: drop.defaultPrevented,
+          urlUnchanged: location.href === beforeUrl,
+        };
+      });
+
+      expect(stray).toEqual({
+        draftUnchanged: true,
+        dragOverPrevented: true,
+        dropEffect: "none",
+        dropPrevented: true,
+        urlUnchanged: true,
+      });
+
+      const accepted = await page.locator("section.card.chat").evaluate((element) => {
+        const transfer = new DataTransfer();
+        transfer.items.add(
+          new File(["accepted drop"], "accepted-drop.txt", { type: "text/plain" }),
+        );
+        const dragOver = new DragEvent("dragover", {
+          bubbles: true,
+          cancelable: true,
+          dataTransfer: transfer,
+        });
+        const drop = new DragEvent("drop", {
+          bubbles: true,
+          cancelable: true,
+          dataTransfer: transfer,
+        });
+        element.dispatchEvent(dragOver);
+        element.dispatchEvent(drop);
+        return {
+          dragOverPrevented: dragOver.defaultPrevented,
+          dropPrevented: drop.defaultPrevented,
+        };
+      });
+
+      expect(accepted).toEqual({
+        dragOverPrevented: true,
+        dropPrevented: true,
+      });
+      await page
+        .locator(".chat-attachment-file__name", { hasText: "accepted-drop.txt" })
+        .first()
+        .waitFor({ timeout: 10_000 });
+      await expect
+        .poll(() =>
+          page.locator(".chat-attachment-file__name", { hasText: "stray-proof.txt" }).count(),
+        )
+        .toBe(0);
+
+      const nativeInput = page.locator(".agent-chat__file-input");
+      expect(await nativeInput.isEnabled()).toBe(true);
+      await nativeInput.setInputFiles({
+        name: "native-input.txt",
+        mimeType: "text/plain",
+        buffer: Buffer.from("native input"),
+      });
+      await page
+        .locator(".chat-attachment-file__name", { hasText: "native-input.txt" })
+        .first()
+        .waitFor({ timeout: 10_000 });
+
+      console.info(
+        `[file-drop-proof] ${JSON.stringify({
+          accepted,
+          nativeInputAccepted: true,
+          path: new URL(page.url()).pathname,
+          stray,
+        })}`,
+      );
+    } finally {
+      await context.close();
+    }
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users dropping a file outside an attachment drop target in the Control UI would navigate the browser to that file, discarding the current app state and unsent drafts.

## Why This Change Was Made

The app shell now rejects only file drags that reach the window without being accepted by an inner handler. Accepted page drop targets and enabled native file inputs keep their existing behavior, while stray drops use a `none` drop effect and cannot navigate away.

This change was AI-assisted and reviewed with the repository autoreview workflow.

## User Impact

Accidental file drops outside chat attachment targets are now harmless. Users keep their current route, session state, and drafts instead of unexpectedly leaving the Control UI.

## Evidence

- Baseline regression probe on Blacksmith Testbox: the focused test failed with `defaultPrevented === false` when the production guard was temporarily removed.
- Focused test on Blacksmith Testbox: `pnpm test ui/src/app/app-host.test.ts` — 32/32 passed.
- Real Chromium E2E on Blacksmith Testbox: `ui/src/e2e/file-drop-guard.e2e.test.ts` — 1/1 passed. The run exercised the actual `/chat` shell, chat attachment target, and enabled native file input.
- Redacted browser-runtime output: `[file-drop-proof] {"accepted":{"dragOverPrevented":true,"dropPrevented":true},"nativeInputAccepted":true,"path":"/chat","stray":{"draftUnchanged":true,"dragOverPrevented":true,"dropEffect":"none","dropPrevented":true,"urlUnchanged":true}}`
- The E2E also asserts that `stray-proof.txt` never appears while `accepted-drop.txt` and `native-input.txt` both render in the attachment preview.
- Browser proof run: https://github.com/openclaw/openclaw/actions/runs/29704163016
- Formatting: `pnpm format:check ui/src/app/app-host.ts ui/src/app/app-host.test.ts ui/src/e2e/file-drop-guard.e2e.test.ts` — passed.
- Autoreview: `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output` — clean after the browser proof, patch correct with 0.95 confidence.
- Visual evidence: not applicable; this changes browser default-event handling without changing layout or styling. The linked Chromium run provides the behavior evidence.
