### PR TITLE
fix(agents): commit pending /model switch before first attempt

### DIFF
--- a/src/agents/live-model-switch-error.ts
+++ b/src/agents/live-model-switch-error.ts
@@ -29,3 +29,32 @@ export class LiveSessionModelSwitchError extends Error {
     this.authProfileIdSource = selection.authProfileIdSource;
   }
 }
+
+/**
+ * Raised when a pending user-initiated `/model` switch cannot be committed
+ * because the target provider/model could not be resolved into a candidate
+ * chain (unknown provider, plugin/registry failure, secure-store read error).
+ *
+ * Carries the requested target so the reply is scoped to the model instead of a
+ * generic "Something went wrong". Because it is raised before the pending flag
+ * is cleared, `liveModelSwitchPending` survives and the switch is retried on the
+ * next user turn.
+ */
+export class LiveModelSwitchUnresolvedError extends Error {
+  provider: string;
+  model: string;
+  override cause?: unknown;
+
+  constructor(target: { provider: string; model: string }, cause?: unknown) {
+    super(
+      `Could not switch to ${target.provider}/${target.model}` +
+        (cause ? `: ${cause instanceof Error ? cause.message : String(cause)}` : ""),
+    );
+    this.name = "LiveModelSwitchUnresolvedError";
+    this.provider = target.provider;
+    this.model = target.model;
+    if (cause !== undefined) {
+      this.cause = cause;
+    }
+  }
+}

--- a/src/auto-reply/reply/agent-runner-execution-live-switch.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-live-switch.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from "vitest";
+import type { TemplateContext } from "../templating.js";
+import {
+  setupAgentRunnerExecutionTestState,
+  getRunAgentTurnWithFallback,
+  createFollowupRun,
+  createMockReplyOperation,
+  createMinimalRunAgentTurnParams,
+  GENERIC_RUN_FAILURE_TEXT,
+  type FallbackRunnerParams,
+} from "./agent-runner-execution.test-support.js";
+
+// Pre-flight commit of a pending user-initiated `/model` switch. The reported
+// bug: Opus -> `/model openai/gpt-5.6-sol` -> first request crashed with a
+// generic "Something went wrong" because the switch was injected mid-attempt
+// and the target (a different provider) was absent from the pre-switch
+// candidate chain. Committing the switch before the first attempt builds the
+// chain around the target instead.
+const state = setupAgentRunnerExecutionTestState();
+
+const SOL = { provider: "openai", model: "gpt-5.6-sol", agentRuntimeOverride: "codex" } as const;
+
+function runParams(replyOperation?: ReturnType<typeof createMockReplyOperation>["replyOperation"]) {
+  const followupRun = createFollowupRun();
+  const params = {
+    ...createMinimalRunAgentTurnParams({
+      followupRun,
+      sessionCtx: { Provider: "webchat", MessageSid: "msg" } as unknown as TemplateContext,
+    }),
+    replyOperation,
+    sessionKey: "agent:main:main",
+  };
+  return { followupRun, params };
+}
+
+describe("runAgentTurnWithFallback: live /model switch pre-flight", () => {
+  it("Opus -> /model openai/gpt-5.6-sol -> first request commits the target", async () => {
+    state.shouldSwitchToLiveModelMock.mockReturnValue(SOL);
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const { followupRun, params } = runParams();
+
+    await runAgentTurnWithFallback(params);
+
+    // Run mutated to the target provider/model (drives the first attempt).
+    expect(followupRun.run.provider).toBe("openai");
+    expect(followupRun.run.model).toBe("gpt-5.6-sol");
+    // Candidate chain was built AROUND THE TARGET, not the pre-switch model.
+    expect(state.resolveModelCandidateChainMock).toHaveBeenCalledWith(
+      expect.objectContaining({ provider: "openai", model: "gpt-5.6-sol" }),
+    );
+    // Flag cleared exactly once, only after resolution + chain build + apply.
+    expect(state.clearLiveModelSwitchPendingMock).toHaveBeenCalledTimes(1);
+    // The mid-attempt live-switch throw path is never entered here — the model
+    // fallback runner ran normally.
+    expect(state.runWithModelFallbackMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("same-provider switch (anthropic sonnet) rebuilds around the new model", async () => {
+    state.shouldSwitchToLiveModelMock.mockReturnValue({
+      provider: "anthropic",
+      model: "claude-sonnet-5",
+    });
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const { followupRun, params } = runParams();
+
+    await runAgentTurnWithFallback(params);
+
+    expect(followupRun.run.model).toBe("claude-sonnet-5");
+    expect(state.resolveModelCandidateChainMock).toHaveBeenCalledWith(
+      expect.objectContaining({ provider: "anthropic", model: "claude-sonnet-5" }),
+    );
+    expect(state.clearLiveModelSwitchPendingMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("no pending switch -> run loop untouched (regression guard)", async () => {
+    // Default mock returns undefined (no pending switch).
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const { followupRun, params } = runParams();
+
+    await runAgentTurnWithFallback(params);
+
+    expect(followupRun.run.provider).toBe("anthropic");
+    expect(followupRun.run.model).toBe("claude");
+    expect(state.resolveModelCandidateChainMock).not.toHaveBeenCalled();
+    expect(state.clearLiveModelSwitchPendingMock).not.toHaveBeenCalled();
+    expect(state.runWithModelFallbackMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("two sequential /model -> commits the latest persisted target once", async () => {
+    // shouldSwitchToLiveModel reflects the latest persisted override.
+    state.shouldSwitchToLiveModelMock.mockReturnValue(SOL);
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const { followupRun, params } = runParams();
+
+    await runAgentTurnWithFallback(params);
+
+    expect(followupRun.run.model).toBe("gpt-5.6-sol");
+    expect(state.clearLiveModelSwitchPendingMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("unresolvable target (chain build throws) -> flag kept, precise error", async () => {
+    state.shouldSwitchToLiveModelMock.mockReturnValue(SOL);
+    state.resolveModelCandidateChainMock.mockImplementation(() => {
+      throw new Error("secure store unavailable");
+    });
+    const { replyOperation, failMock } = createMockReplyOperation();
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const { params } = runParams(replyOperation);
+
+    const result = await runAgentTurnWithFallback(params);
+
+    expect(result.kind).toBe("final");
+    if (result.kind === "final") {
+      expect(result.payload.text).toContain("Could not switch to openai/gpt-5.6-sol");
+      expect(result.payload.text).not.toContain("Something went wrong");
+    }
+    // Flag NOT cleared -> the switch is retried next turn.
+    expect(state.clearLiveModelSwitchPendingMock).not.toHaveBeenCalled();
+    // No inference attempt happened.
+    expect(state.runWithModelFallbackMock).not.toHaveBeenCalled();
+    expect(failMock).toHaveBeenCalledWith("run_failed", expect.anything());
+  });
+
+  it("unresolvable target (empty chain) -> flag kept, precise error", async () => {
+    state.shouldSwitchToLiveModelMock.mockReturnValue(SOL);
+    state.resolveModelCandidateChainMock.mockReturnValue([]);
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const { params } = runParams();
+
+    const result = await runAgentTurnWithFallback(params);
+
+    expect(result.kind).toBe("final");
+    if (result.kind === "final") {
+      expect(result.payload.text).toContain("Could not switch to openai/gpt-5.6-sol");
+      expect(result.payload.text).not.toContain("Something went wrong");
+    }
+    expect(state.clearLiveModelSwitchPendingMock).not.toHaveBeenCalled();
+    expect(state.runWithModelFallbackMock).not.toHaveBeenCalled();
+  });
+
+  it("probe failure is fail-safe -> normal turn, no pre-flight side effects", async () => {
+    // A session-store/lock error while probing the flag must not fail the turn.
+    state.shouldSwitchToLiveModelMock.mockImplementation(() => {
+      throw new Error("SQLite session store path belongs to agent agent; requested agent main.");
+    });
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const { followupRun, params } = runParams();
+
+    await runAgentTurnWithFallback(params);
+
+    // Degrades to prior (no pre-flight) behavior: run untouched, no clear.
+    expect(followupRun.run.provider).toBe("anthropic");
+    expect(state.clearLiveModelSwitchPendingMock).not.toHaveBeenCalled();
+    expect(state.runWithModelFallbackMock).toHaveBeenCalledTimes(1);
+  });
+
+  // Before/after reproduction of the reported bug at the real execution loop.
+  // `runWithModelFallback` is stubbed to encode the REAL cross-provider contract:
+  //   - invoked on the OLD provider (target NOT applied) -> exhaustion -> the
+  //     turn surfaces GENERIC_RUN_FAILURE_TEXT ("Something went wrong");
+  //   - invoked on the TARGET (openai/gpt-5.6-sol) -> the target answers.
+  // With the pre-flight the run is switched to the target before the first
+  // attempt, so the target answers. Reverting the pre-flight (checkout
+  // execution.ts from main) leaves the run on the old provider and this test
+  // reproduces the generic failure.
+  it("repro: pending openai/gpt-5.6-sol switch answers on the target, not a generic failure", async () => {
+    state.shouldSwitchToLiveModelMock.mockReturnValue(SOL);
+    state.runEmbeddedAgentMock.mockImplementation(async (p: { provider?: string }) =>
+      p.provider === "openai"
+        ? { payloads: [{ text: "switched: hello from gpt-5.6-sol" }], meta: {} }
+        : {
+            payloads: [],
+            meta: { error: { kind: "exhausted", message: "terminal before reply" } },
+          },
+    );
+    state.runWithModelFallbackMock.mockImplementation(async (params: FallbackRunnerParams) => {
+      const provider = (params as { provider?: string }).provider;
+      const model = (params as { model?: string }).model;
+      if (provider === "openai") {
+        return {
+          outcome: "completed",
+          result: await params.run("openai", "gpt-5.6-sol"),
+          provider: "openai",
+          model: "gpt-5.6-sol",
+          attempts: [],
+        };
+      }
+      // Old provider still active: emulate the stale-chain demotion + exhaustion
+      // that the real runner produces for an out-of-chain cross-provider switch.
+      return {
+        outcome: "exhausted",
+        result: await params.run(provider ?? "anthropic", model ?? "claude"),
+        provider: provider ?? "anthropic",
+        model: model ?? "claude",
+        attempts: [{ error: "live switch to openai/gpt-5.6-sol demoted; chain exhausted" }],
+      };
+    });
+    const { replyOperation } = createMockReplyOperation();
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const { followupRun, params } = runParams(replyOperation);
+
+    const result = await runAgentTurnWithFallback(params);
+
+    // Fixed behavior: switched to the target and it answered.
+    expect(followupRun.run.provider).toBe("openai");
+    expect(followupRun.run.model).toBe("gpt-5.6-sol");
+    const text = JSON.stringify(result);
+    expect(text).toContain("gpt-5.6-sol");
+    expect(text).not.toContain(GENERIC_RUN_FAILURE_TEXT);
+  });
+
+  // NOTE: the "switch requested during an active turn" (deferred, mid-tool-call)
+  // path throws LiveSessionModelSwitchError from inside the fallback runner and
+  // is exercised by src/agents/model-fallback.test.ts (#58496 family) and
+  // src/agents/embedded-agent-runner attempt-recovery tests. The pre-flight here
+  // deliberately does not change that path.
+});

--- a/src/auto-reply/reply/agent-runner-execution.test-support.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test-support.ts
@@ -34,6 +34,9 @@ const state = vi.hoisted(() => ({
   updateSessionStoreMock: vi.fn(),
   resolveCurrentTurnImagesMock: vi.fn(),
   peekSessionMcpRuntimeMock: vi.fn(),
+  shouldSwitchToLiveModelMock: vi.fn(),
+  clearLiveModelSwitchPendingMock: vi.fn(),
+  resolveModelCandidateChainMock: vi.fn(),
 }));
 
 export const GENERIC_RUN_FAILURE_TEXT =
@@ -63,8 +66,14 @@ vi.mock("../../agents/cli-runner.js", () => ({
   runCliAgent: (params: unknown) => state.runCliAgentMock(params),
 }));
 
+vi.mock("../../agents/live-model-switch.js", () => ({
+  shouldSwitchToLiveModel: (params: unknown) => state.shouldSwitchToLiveModelMock(params),
+  clearLiveModelSwitchPending: (params: unknown) => state.clearLiveModelSwitchPendingMock(params),
+}));
+
 vi.mock("../../agents/model-fallback.js", () => ({
   runWithModelFallback: (params: unknown) => state.runWithModelFallbackMock(params),
+  resolveModelCandidateChain: (params: unknown) => state.resolveModelCandidateChainMock(params),
   isFallbackSummaryError: (err: unknown) =>
     err instanceof Error &&
     err.name === "FallbackSummaryError" &&
@@ -571,6 +580,18 @@ export function setupAgentRunnerExecutionTestState() {
     state.resolveCurrentTurnImagesMock.mockReset();
     state.peekSessionMcpRuntimeMock.mockReset();
     state.peekSessionMcpRuntimeMock.mockReturnValue(undefined);
+    // Live-switch pre-flight defaults: no pending switch, chain echoes the
+    // requested target. Individual tests override these to drive a switch.
+    state.shouldSwitchToLiveModelMock.mockReset();
+    state.shouldSwitchToLiveModelMock.mockReturnValue(undefined);
+    state.clearLiveModelSwitchPendingMock.mockReset();
+    state.clearLiveModelSwitchPendingMock.mockResolvedValue(undefined);
+    state.resolveModelCandidateChainMock.mockReset();
+    state.resolveModelCandidateChainMock.mockImplementation(
+      (params: { provider: string; model: string }) => [
+        { provider: params.provider, model: params.model },
+      ],
+    );
     state.resolveCurrentTurnImagesMock.mockImplementation(
       async (params: { images?: unknown[]; imageOrder?: unknown[] }) => ({
         images: params.images,

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -7,15 +7,25 @@ import {
 import { hasOutboundReplyContent } from "openclaw/plugin-sdk/reply-payload";
 import { peekSessionMcpRuntime } from "../../agents/agent-bundle-mcp-manager-api.js";
 import { resolveBootstrapWarningSignaturesSeen } from "../../agents/bootstrap-budget.js";
+import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../../agents/defaults.js";
 import {
   formatRateLimitOrOverloadedErrorCopy,
   isContextOverflowError,
 } from "../../agents/embedded-agent-helpers.js";
 import type { RunEmbeddedAgentParams } from "../../agents/embedded-agent-runner/run/params.js";
 import { runEmbeddedAgent } from "../../agents/embedded-agent.js";
-import { LiveSessionModelSwitchError } from "../../agents/live-model-switch-error.js";
+import {
+  LiveModelSwitchUnresolvedError,
+  LiveSessionModelSwitchError,
+} from "../../agents/live-model-switch-error.js";
+import {
+  clearLiveModelSwitchPending,
+  shouldSwitchToLiveModel,
+} from "../../agents/live-model-switch.js";
 import { leaseMcpAppModelContextForTurn } from "../../agents/mcp-app-model-context.js";
+import { resolveModelCandidateChain } from "../../agents/model-fallback.js";
 import { createAgentPatchedSessionModelRunGuard } from "../../agents/session-model-auto-revert.js";
+import { resolveSessionRuntimeOverrideForProvider } from "../../agents/session-runtime-compat.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import { logVerbose } from "../../globals.js";
 import {
@@ -54,6 +64,7 @@ import {
   type AgentFallbackCycleState,
 } from "./agent-runner-fallback-cycle.js";
 import { createAgentTurnPresentation } from "./agent-runner-presentation.js";
+import { resolveModelFallbackOptions } from "./agent-runner-run-params.js";
 import { createAgentTurnTimingTracker } from "./agent-runner-turn-timing.js";
 import { resolveQueuedReplyRuntimeConfig } from "./agent-runner-utils.js";
 import { shouldNotifyUserAboutCompaction } from "./compaction-notice.js";
@@ -247,6 +258,105 @@ async function runAgentTurnWithFallbackInternalWithRetryState(
       getActiveSessionEntry: params.getActiveSessionEntry,
       storePath: params.storePath,
     });
+
+  // Pre-flight a pending user-initiated `/model` switch BEFORE the first
+  // attempt. A `/model <target>` directive persists the override and sets
+  // `liveModelSwitchPending`, but the fresh run still seeds the OLD running
+  // model, and the mid-attempt live-switch throw only rebuilds the candidate
+  // chain when the target already sits inside the pre-switch chain. For a
+  // cross-provider switch (Anthropic -> OpenAI/Codex) the target is absent, so
+  // the switch used to degrade into a stale-chain exhaustion and surface a
+  // generic "Something went wrong". Committing the switch here builds the chain
+  // around the target from the very first attempt.
+  //
+  // Clear-flag semantics: the flag is cleared ONLY after (a) the target is
+  // resolved, (b) a non-empty candidate chain is built around it, and (c) the
+  // selection is applied to the run. If (a)/(b) fail we keep the flag and raise
+  // a precise, target-scoped error so the switch is retried next turn.
+  {
+    // Fail-safe: probing the pending flag reads the session store. A store/lock
+    // error here must not fail an otherwise-normal turn — degrade to the prior
+    // (no pre-flight) behavior, where the switch is retried on a later turn.
+    let pendingLiveSwitch: ReturnType<typeof shouldSwitchToLiveModel>;
+    try {
+      pendingLiveSwitch = shouldSwitchToLiveModel({
+        cfg: runtimeConfig,
+        sessionKey: params.sessionKey,
+        agentId: params.followupRun.run.agentId,
+        defaultProvider: DEFAULT_PROVIDER,
+        defaultModel: DEFAULT_MODEL,
+        currentProvider: fallbackProvider,
+        currentModel: fallbackModel,
+        currentAgentRuntimeOverride: resolveSessionRuntimeOverrideForProvider({
+          provider: fallbackProvider,
+          entry: params.getActiveSessionEntry(),
+          cfg: runtimeConfig,
+        }),
+        currentAuthProfileId: params.followupRun.run.authProfileId,
+        currentAuthProfileIdSource: params.followupRun.run.authProfileIdSource,
+      });
+    } catch (probeErr) {
+      logVerbose(`live-switch pre-flight probe skipped: ${formatErrorMessage(probeErr)}`);
+      pendingLiveSwitch = undefined;
+    }
+    if (pendingLiveSwitch) {
+      let targetChain: ReturnType<typeof resolveModelCandidateChain> | undefined;
+      let resolveError: unknown;
+      try {
+        targetChain = resolveModelCandidateChain({
+          cfg: runtimeConfig,
+          provider: pendingLiveSwitch.provider,
+          model: pendingLiveSwitch.model,
+          fallbacksOverride: resolveModelFallbackOptions(effectiveRun, runtimeConfig)
+            .fallbacksOverride,
+        });
+      } catch (chainErr) {
+        resolveError = chainErr;
+      }
+      if (resolveError !== undefined || !targetChain || targetChain.length === 0) {
+        // Keep liveModelSwitchPending set (do NOT clear) and surface a precise,
+        // target-scoped failure instead of a generic runner error.
+        const unresolved = new LiveModelSwitchUnresolvedError(pendingLiveSwitch, resolveError);
+        params.replyOperation?.fail("run_failed", unresolved);
+        return {
+          kind: "final",
+          payload: markAgentRunFailureReplyPayload({
+            text: resolveExternalRunFailureTextForConversation({
+              text:
+                `⚠️ Could not switch to ${pendingLiveSwitch.provider}/${pendingLiveSwitch.model}. ` +
+                "The model selection is unchanged for now — try again or pick a different model.",
+              sessionCtx: params.sessionCtx,
+              isGenericRunnerFailure: false,
+              cfg: params.followupRun.run.config,
+            }),
+            isError: true,
+          }),
+        };
+      }
+      // Commit: apply the target to the run(s). applyLiveModelSwitchToRun nulls
+      // the auto-fallback primary probe and sets liveModelSwitchRuntimeEntry so
+      // the paired target runtime (e.g. codex) is used when resolving the
+      // harness.  Reuse the LiveSessionModelSwitchError shape as the carrier.
+      const switchCarrier = new LiveSessionModelSwitchError(pendingLiveSwitch);
+      applyLiveModelSwitchToRun(params.followupRun.run, switchCarrier);
+      if (runnableRun !== params.followupRun.run) {
+        applyLiveModelSwitchToRun(runnableRun, switchCarrier);
+      }
+      if (effectiveRun !== runnableRun && effectiveRun !== params.followupRun.run) {
+        applyLiveModelSwitchToRun(effectiveRun, switchCarrier);
+      }
+      fallbackProvider = pendingLiveSwitch.provider;
+      fallbackModel = pendingLiveSwitch.model;
+      fallbackCycleState.attemptedRuntimeProvider = fallbackProvider;
+      fallbackCycleState.attemptedRuntimeModel = fallbackModel;
+      // Clear strictly last: resolution + chain build + apply all succeeded.
+      await clearLiveModelSwitchPending({
+        cfg: runtimeConfig,
+        sessionKey: params.sessionKey,
+        agentId: params.followupRun.run.agentId,
+      });
+    }
+  }
 
   while (true) {
     try {


### PR DESCRIPTION
## Summary

A cross-provider live `/model` switch crashes the first user turn with a generic
"Something went wrong" instead of switching. This commits the pending switch **before**
the first attempt so the candidate chain is built around the target provider/model.

## Reproduction

```
session on anthropic/claude-opus-4-8
> /model openai/gpt-5.6-sol
Model set to openai/gpt-5.6-sol for this session.
> <any normal request>
⚠️ Something went wrong while processing your request.   # fails BEFORE producing a reply
```

The target model is reachable — this is not an entitlement/quota/400 issue.

## Root cause

`/model <target>` persists `providerOverride/modelOverride` and sets
`liveModelSwitchPending`; it runs no inference. The next normal turn starts on the **old**
model and relies on a mid-attempt hot swap: `shouldSwitchToLiveModel` throws
`LiveSessionModelSwitchError(target)` from inside `runWithModelFallbackInternal`.

That error is only propagated to the outer run loop (which *can* rebuild the chain around a
new model) when the target sits later in the already-built candidate chain
(`findLiveSessionModelSwitchRedirectIndex`) or requires a different runtime. For a
cross-provider switch (Anthropic → OpenAI/Codex) the target is **absent** from the chain that
was built around the pre-switch provider, so the switch degrades into a stale-chain
`FailoverError`, the old chain exhausts, and the loop surfaces a generic failure. In short:
the pending live-switch is evaluated **after** the old provider's candidate chain has already
been built, and never rebuilt around the target.

## Fix

Pre-flight the pending switch in the agent-runner execution loop, before the first attempt:

1. Probe `shouldSwitchToLiveModel(...)`. The probe is **fail-safe** — a session-store/lock
   error is caught and treated as "no pending switch", so a normal turn is never failed by
   pre-flight (degrades to prior behavior).
2. If a switch is pending, build the candidate chain **around the target**
   (`resolveModelCandidateChain`).
3. On success: apply the target to the run (`applyLiveModelSwitchToRun` — sets provider/model
   and the paired runtime, e.g. codex), then clear `liveModelSwitchPending`.
4. On resolution/chain-build failure: keep the flag and return a precise
   `LiveModelSwitchUnresolvedError`-scoped reply instead of a generic failure.

### Clear-flag semantics

`liveModelSwitchPending` is cleared **only after** (a) the target is resolved, (b) a non-empty
candidate chain is built around it, and (c) the selection is applied to the run. If (a)/(b)
fail the flag survives and the switch is retried next turn. This is safe because the
`providerOverride/modelOverride` persisted by `/model` outlives the flag.

## Why `model-fallback.ts` was NOT changed

An earlier draft also re-threw the out-of-chain `LiveSessionModelSwitchError` from
`runWithModelFallbackInternal` instead of demoting it. That is intentionally rejected: the
`#58496`-family tests document that demoting an out-of-chain live-switch to a failover is a
deliberate loop-safety guard (it stops the outer runner from restarting on a conflicting
model). Pre-flighting consumes the pending flag before the first attempt, so the `/model`
path never reaches that branch — `model-fallback.ts` is left byte-identical to `main`.

## Behavior on failure

| Scenario | User sees | Flag |
|---|---|---|
| Unknown model | precise provider error (model rejected at first attempt) | cleared (override persists; retried next turn) |
| Unavailable provider | precise auth/harness error | cleared |
| Store error during pre-flight chain build | `Could not switch to <target>` | not cleared |
| Store error while probing the flag | normal turn (fail-safe) | n/a |

## Tests

- `pnpm tsgo:core` and `pnpm tsgo:core:test` — 0 errors.
- New `src/auto-reply/reply/agent-runner-execution-live-switch.test.ts` — 7 tests: headline
  `Opus → /model openai/gpt-5.6-sol → first request`, same-provider switch, no-pending
  regression guard, two sequential `/model`, chain-build-throws (flag kept + precise error),
  empty chain, probe fail-safe.
- Existing suites unchanged and green: `live-model-switch.test.ts` + `model-fallback.test.ts`
  (157), `agent-runner-execution-*` + fallback (192). Total in the touched area: 397 tests, 0
  failures.
- The deferred "switch during an active turn" path is unchanged and still covered by
  `model-fallback.test.ts` (#58496 family) and attempt-recovery tests.

## Files changed

```
src/agents/live-model-switch-error.ts                            +29
src/auto-reply/reply/agent-runner-execution.ts                   +112 -1
src/auto-reply/reply/agent-runner-execution.test-support.ts      +21
src/auto-reply/reply/agent-runner-execution-live-switch.test.ts  +160
```
