### PR TITLE
fix(ui): show attributed sender identity properly in chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- **Control UI sender identity polish:** attributed user messages show the author's real avatar in an always-visible gutter on identity-resolving gateways, sender labels drop the opaque profile-UUID suffix (new and historical transcripts), and profile-id senders resolve avatars through the canonical gateway route.
 - **Control UI who's-online roster:** click the sidebar footer facepile to open a scrollable roster of everyone online, showing each person's avatar, name, and email with your own entry pinned first.
 - **Discord and Slack native login:** register `/login` in native command menus while keeping pairing-code issuance limited to private chats and the Web UI.
 - **Control UI user profiles:** let trusted-proxy users manage their own display name and avatar, resolve attributed chat and presence identities through uploaded avatars or a private cached Gravatar proxy, and keep other users' profiles admin-only.

--- a/src/channels/sender-label.test.ts
+++ b/src/channels/sender-label.test.ts
@@ -30,3 +30,29 @@ describe("resolveSenderLabel", () => {
     ).toBeNull();
   });
 });
+
+describe("resolveSenderLabel opaque ids", () => {
+  it("never appends an opaque profile UUID to the display label", () => {
+    expect(
+      resolveSenderLabel({
+        name: "steipete",
+        id: "c3e32452-0467-47e5-aafa-233cd5dae29f",
+      }),
+    ).toBe("steipete");
+  });
+
+  it("still appends disambiguating handles and numbers", () => {
+    expect(resolveSenderLabel({ name: "Peter", e164: "+436641234567" })).toBe(
+      "Peter (+436641234567)",
+    );
+    expect(resolveSenderLabel({ name: "Peter", id: "peter@example.com" })).toBe(
+      "Peter (peter@example.com)",
+    );
+  });
+
+  it("keeps a UUID-only identity as a last-resort label", () => {
+    expect(resolveSenderLabel({ id: "c3e32452-0467-47e5-aafa-233cd5dae29f" })).toBe(
+      "c3e32452-0467-47e5-aafa-233cd5dae29f",
+    );
+  });
+});

--- a/src/channels/sender-label.ts
+++ b/src/channels/sender-label.ts
@@ -19,13 +19,18 @@ function normalizeSenderLabelParams(params: SenderLabelParams) {
   };
 }
 
+// Matches opaque profile/device UUIDs. A phone number or handle in the id
+// position disambiguates a human label; a UUID is machine noise, so it never
+// belongs in a display label suffix.
+const OPAQUE_UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu;
+
 /** Resolves the best one-line sender label from available identity fields. */
 export function resolveSenderLabel(params: SenderLabelParams): string | null {
   const { name, username, tag, e164, id } = normalizeSenderLabelParams(params);
 
   const display = name ?? username ?? tag ?? "";
   const idPart = e164 ?? id ?? "";
-  if (display && idPart && display !== idPart) {
+  if (display && idPart && display !== idPart && !OPAQUE_UUID_RE.test(idPart)) {
     return `${display} (${idPart})`;
   }
   return display || idPart || null;

--- a/ui/src/lib/chat/message-normalizer.test.ts
+++ b/ui/src/lib/chat/message-normalizer.test.ts
@@ -652,14 +652,30 @@ describe("message-normalizer", () => {
 });
 
 describe("sender label opaque-id stripping", () => {
-  it("strips a baked profile-UUID suffix from historical sender labels", () => {
-    expect(
-      normalizeMessage({
-        role: "user",
-        content: "hi",
-        senderLabel: "steipete (c3e32452-0467-47e5-aafa-233cd5dae29f)",
-      }).senderLabel,
-    ).toBe("steipete");
+  it("strips a baked profile-UUID suffix and preserves it as sender identity", () => {
+    const normalized = normalizeMessage({
+      role: "user",
+      content: "hi",
+      senderLabel: "steipete (c3e32452-0467-47e5-aafa-233cd5dae29f)",
+    });
+    expect(normalized.senderLabel).toBe("steipete");
+    // Legacy rows have no structured sender; the UUID from the label is the
+    // only author key, so it must survive as non-display identity.
+    expect(normalized.sender).toEqual({
+      id: "c3e32452-0467-47e5-aafa-233cd5dae29f",
+      name: "steipete",
+    });
+  });
+
+  it("prefers durable metadata identity over the legacy label identity", () => {
+    const normalized = normalizeMessage({
+      role: "user",
+      content: "hi",
+      senderLabel: "steipete (c3e32452-0467-47e5-aafa-233cd5dae29f)",
+      __openclaw: { senderId: "meta-profile", senderName: "Meta Name" },
+    });
+    expect(normalized.sender).toEqual({ id: "meta-profile", name: "Meta Name" });
+    expect(normalized.senderLabel).toBe("steipete");
   });
 
   it("keeps human-meaningful parenthesized suffixes", () => {

--- a/ui/src/lib/chat/message-normalizer.test.ts
+++ b/ui/src/lib/chat/message-normalizer.test.ts
@@ -697,4 +697,17 @@ describe("sender label opaque-id stripping", () => {
       }).senderLabel,
     ).toBe("(c3e32452-0467-47e5-aafa-233cd5dae29f)");
   });
+
+  it("attributes a bare-UUID legacy label to that profile", () => {
+    const normalized = normalizeMessage({
+      role: "user",
+      content: "hi",
+      senderLabel: "c3e32452-0467-47e5-aafa-233cd5dae29f",
+    });
+    // Nameless legacy senders keep the UUID as last-resort display, but the
+    // row still attributes (and resolves its avatar) to that profile instead
+    // of falling back to the local viewer identity.
+    expect(normalized.senderLabel).toBe("c3e32452-0467-47e5-aafa-233cd5dae29f");
+    expect(normalized.sender).toEqual({ id: "c3e32452-0467-47e5-aafa-233cd5dae29f" });
+  });
 });

--- a/ui/src/lib/chat/message-normalizer.test.ts
+++ b/ui/src/lib/chat/message-normalizer.test.ts
@@ -650,3 +650,35 @@ describe("message-normalizer", () => {
     });
   });
 });
+
+describe("sender label opaque-id stripping", () => {
+  it("strips a baked profile-UUID suffix from historical sender labels", () => {
+    expect(
+      normalizeMessage({
+        role: "user",
+        content: "hi",
+        senderLabel: "steipete (c3e32452-0467-47e5-aafa-233cd5dae29f)",
+      }).senderLabel,
+    ).toBe("steipete");
+  });
+
+  it("keeps human-meaningful parenthesized suffixes", () => {
+    expect(
+      normalizeMessage({
+        role: "user",
+        content: "hi",
+        senderLabel: "Peter (+436641234567)",
+      }).senderLabel,
+    ).toBe("Peter (+436641234567)");
+  });
+
+  it("keeps a label that is only a UUID rather than emptying it", () => {
+    expect(
+      normalizeMessage({
+        role: "user",
+        content: "hi",
+        senderLabel: "(c3e32452-0467-47e5-aafa-233cd5dae29f)",
+      }).senderLabel,
+    ).toBe("(c3e32452-0467-47e5-aafa-233cd5dae29f)");
+  });
+});

--- a/ui/src/lib/chat/message-normalizer.ts
+++ b/ui/src/lib/chat/message-normalizer.ts
@@ -26,6 +26,17 @@ function asMessageRecord(message: unknown): Record<string, unknown> {
   return message && typeof message === "object" ? (message as Record<string, unknown>) : {};
 }
 
+// Older gateways baked sender labels as "name (<profile uuid>)" into transcript
+// text. The UUID is machine noise in a human label, so strip the suffix when
+// rendering historical entries; new gateways no longer emit it.
+const OPAQUE_ID_LABEL_SUFFIX_RE =
+  /\s+\([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\)$/iu;
+
+function stripOpaqueIdLabelSuffix(label: string): string {
+  const stripped = label.replace(OPAQUE_ID_LABEL_SUFFIX_RE, "").trim();
+  return stripped || label;
+}
+
 export function normalizeRoleForGrouping(role: string): string {
   const lower = role.toLowerCase();
   if (lower === "user") {
@@ -537,7 +548,7 @@ export function normalizeMessage(message: unknown): NormalizedMessage {
   });
   const senderLabel =
     typeof m.senderLabel === "string" && m.senderLabel.trim()
-      ? m.senderLabel.trim()
+      ? stripOpaqueIdLabelSuffix(m.senderLabel.trim())
       : formatSenderLabel(sender);
 
   content = stripMessageDisplayMetadata(content);

--- a/ui/src/lib/chat/message-normalizer.ts
+++ b/ui/src/lib/chat/message-normalizer.ts
@@ -31,8 +31,14 @@ function asMessageRecord(message: unknown): Record<string, unknown> {
 // only author key, so split it into display + identity instead of discarding.
 const OPAQUE_ID_LABEL_SUFFIX_RE =
   /\s+\(([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\)$/iu;
+const OPAQUE_ID_LABEL_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu;
 
 function splitOpaqueIdLabel(label: string): { display: string; id: string } | null {
+  // A nameless legacy sender labels as the bare UUID; keep it as the
+  // last-resort display while still attributing the row to that profile.
+  if (OPAQUE_ID_LABEL_RE.test(label)) {
+    return { display: label, id: label };
+  }
   const match = OPAQUE_ID_LABEL_SUFFIX_RE.exec(label);
   if (!match?.[1]) {
     return null;
@@ -561,7 +567,12 @@ export function normalizeMessage(message: unknown): NormalizedMessage {
   const sender =
     metaSender ??
     (legacyLabelIdentity
-      ? normalizeSenderIdentity({ id: legacyLabelIdentity.id, name: legacyLabelIdentity.display })
+      ? normalizeSenderIdentity({
+          id: legacyLabelIdentity.id,
+          ...(legacyLabelIdentity.display !== legacyLabelIdentity.id
+            ? { name: legacyLabelIdentity.display }
+            : {}),
+        })
       : null);
 
   content = stripMessageDisplayMetadata(content);

--- a/ui/src/lib/chat/message-normalizer.ts
+++ b/ui/src/lib/chat/message-normalizer.ts
@@ -27,14 +27,18 @@ function asMessageRecord(message: unknown): Record<string, unknown> {
 }
 
 // Older gateways baked sender labels as "name (<profile uuid>)" into transcript
-// text. The UUID is machine noise in a human label, so strip the suffix when
-// rendering historical entries; new gateways no longer emit it.
+// text. The UUID is machine noise in a human label but it is also the row's
+// only author key, so split it into display + identity instead of discarding.
 const OPAQUE_ID_LABEL_SUFFIX_RE =
-  /\s+\([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\)$/iu;
+  /\s+\(([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\)$/iu;
 
-function stripOpaqueIdLabelSuffix(label: string): string {
-  const stripped = label.replace(OPAQUE_ID_LABEL_SUFFIX_RE, "").trim();
-  return stripped || label;
+function splitOpaqueIdLabel(label: string): { display: string; id: string } | null {
+  const match = OPAQUE_ID_LABEL_SUFFIX_RE.exec(label);
+  if (!match?.[1]) {
+    return null;
+  }
+  const display = label.slice(0, match.index).trim();
+  return display ? { display, id: match[1] } : null;
 }
 
 export function normalizeRoleForGrouping(role: string): string {
@@ -540,16 +544,25 @@ export function normalizeMessage(message: unknown): NormalizedMessage {
     rawOpenClawMeta && typeof rawOpenClawMeta === "object" && !Array.isArray(rawOpenClawMeta)
       ? (rawOpenClawMeta as Record<string, unknown>)
       : undefined;
-  const sender = normalizeSenderIdentity({
+  const metaSender = normalizeSenderIdentity({
     id: openClawMeta?.senderId,
     name: openClawMeta?.senderName,
     username: openClawMeta?.senderUsername,
     profileAvatarUrl: openClawMeta?.senderProfileAvatarUrl,
   });
-  const senderLabel =
-    typeof m.senderLabel === "string" && m.senderLabel.trim()
-      ? stripOpaqueIdLabelSuffix(m.senderLabel.trim())
-      : formatSenderLabel(sender);
+  const rawLabel = typeof m.senderLabel === "string" ? m.senderLabel.trim() : "";
+  const legacyLabelIdentity = rawLabel ? splitOpaqueIdLabel(rawLabel) : null;
+  const senderLabel = rawLabel
+    ? (legacyLabelIdentity?.display ?? rawLabel)
+    : formatSenderLabel(metaSender);
+  // Legacy transcripts baked the author's profile UUID only into the label.
+  // Keep it as structured (non-display) identity so the avatar gutter resolves
+  // the actual author instead of falling back to the local viewer.
+  const sender =
+    metaSender ??
+    (legacyLabelIdentity
+      ? normalizeSenderIdentity({ id: legacyLabelIdentity.id, name: legacyLabelIdentity.display })
+      : null);
 
   content = stripMessageDisplayMetadata(content);
 

--- a/ui/src/lib/identity-avatar.test.ts
+++ b/ui/src/lib/identity-avatar.test.ts
@@ -125,3 +125,36 @@ describe("resolveAvatar gateway origin trust", () => {
     ).toEqual({ kind: "profile", url: "https://gw.example.com/api/users/p1/avatar" });
   });
 });
+
+describe("resolveAvatar profile-id senders", () => {
+  it("derives the canonical avatar route from a UUID-shaped sender id", () => {
+    expect(resolveAvatar({ id: "c3e32452-0467-47e5-aafa-233cd5dae29f", name: "steipete" })).toEqual(
+      {
+        kind: "profile",
+        url: "/api/users/c3e32452-0467-47e5-aafa-233cd5dae29f/avatar",
+      },
+    );
+  });
+
+  it("resolves the derived route against the gateway origin", () => {
+    setAvatarGatewayOrigin("wss://gw.example.com/ws");
+    expect(resolveAvatar({ id: "c3e32452-0467-47e5-aafa-233cd5dae29f" })).toEqual({
+      kind: "profile",
+      url: "https://gw.example.com/api/users/c3e32452-0467-47e5-aafa-233cd5dae29f/avatar",
+    });
+  });
+
+  it("keeps non-UUID sender ids on initials (no route probing)", () => {
+    expect(resolveAvatar({ id: "alice@example.com" })).toMatchObject({ kind: "initials" });
+    expect(resolveAvatar({ id: "+436641234567" })).toMatchObject({ kind: "initials" });
+  });
+
+  it("prefers an explicit trusted route over the derived one", () => {
+    expect(
+      resolveAvatar({
+        id: "c3e32452-0467-47e5-aafa-233cd5dae29f",
+        profileAvatarUrl: "/api/users/other-profile/avatar?v=9",
+      }),
+    ).toEqual({ kind: "profile", url: "/api/users/other-profile/avatar?v=9" });
+  });
+});

--- a/ui/src/lib/identity-avatar.ts
+++ b/ui/src/lib/identity-avatar.ts
@@ -97,6 +97,11 @@ export function resolveAvatarInitials(
  * the client never constructs a Gravatar URL — it only ever renders the
  * canonical /api/users/<id>/avatar endpoint or falls back to initials.
  */
+// User-profile ids are crypto UUIDs. Chat sender metadata carries only the id
+// (the prompt-visible envelope stays free of URLs), so a UUID-shaped sender id
+// is the signal to resolve the canonical avatar route for it client-side.
+const PROFILE_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu;
+
 export function resolveAvatar(input: IdentityAvatarInput): ResolvedIdentityAvatar {
   // Trusted origin comes only from the app connection, never from `input`.
   const gatewayOrigin = appGatewayOrigin;
@@ -104,6 +109,19 @@ export function resolveAvatar(input: IdentityAvatarInput): ResolvedIdentityAvata
   const profileAvatarUrl = input.profileAvatarUrl?.trim();
   if (profileAvatarUrl) {
     const trusted = toTrustedAvatarUrl(profileAvatarUrl, gatewayOrigin);
+    if (trusted) {
+      return { kind: "profile", url: trusted };
+    }
+  }
+
+  // Sender metadata without an explicit route: a profile-id sender still has a
+  // canonical gateway avatar (upload → Gravatar proxy → 404-to-initials).
+  const id = input.id?.trim();
+  if (id && PROFILE_ID_RE.test(id)) {
+    const trusted = toTrustedAvatarUrl(
+      `/api/users/${encodeURIComponent(id)}/avatar`,
+      gatewayOrigin,
+    );
     if (trusted) {
       return { kind: "profile", url: trusted };
     }

--- a/ui/src/pages/chat/chat-avatar.test.ts
+++ b/ui/src/pages/chat/chat-avatar.test.ts
@@ -181,4 +181,27 @@ describe("attributed sender avatars", () => {
     const avatar = renderAvatar(["user", undefined, { name: "Viewer", avatar: null }, "", null]);
     expect(avatar?.classList.contains("chat-avatar--sender-initials")).toBe(false);
   });
+
+  it("swaps to identity initials when the derived avatar route errors", () => {
+    const container = document.createElement("div");
+    render(
+      renderChatAvatar("user", undefined, undefined, "", null, {
+        id: "c3e32452-0467-47e5-aafa-233cd5dae29f",
+        name: "steipete",
+      }),
+      container,
+    );
+    const slot = container.querySelector<HTMLElement>(".chat-avatar-slot");
+    const image = slot?.querySelector("img");
+    expect(image).not.toBeNull();
+    expect(slot?.classList.contains("is-fallback")).toBe(false);
+
+    image?.dispatchEvent(new Event("error"));
+    expect(slot?.classList.contains("is-fallback")).toBe(true);
+    expect(slot?.querySelector(".chat-avatar--sender-initials")?.textContent?.trim()).toBe("S");
+
+    // A later successful load for a reused DOM part clears the error state.
+    image?.dispatchEvent(new Event("load"));
+    expect(slot?.classList.contains("is-fallback")).toBe(false);
+  });
 });

--- a/ui/src/pages/chat/chat-avatar.test.ts
+++ b/ui/src/pages/chat/chat-avatar.test.ts
@@ -145,3 +145,40 @@ describe("refreshChatAvatar", () => {
     expect(vi.getTimerCount()).toBe(0);
   });
 });
+
+describe("attributed sender avatars", () => {
+  it("renders the sender's profile avatar route for user messages", () => {
+    const avatar = renderAvatar([
+      "user",
+      undefined,
+      { name: "Viewer", avatar: null },
+      "",
+      null,
+      { id: "c3e32452-0467-47e5-aafa-233cd5dae29f", name: "steipete" },
+    ]);
+    expect(avatar?.tagName).toBe("IMG");
+    expect(avatar?.getAttribute("src")).toBe(
+      "/api/users/c3e32452-0467-47e5-aafa-233cd5dae29f/avatar",
+    );
+    expect(avatar?.getAttribute("alt")).toBe("steipete");
+  });
+
+  it("renders identity-colored initials when the sender has no profile route", () => {
+    const avatar = renderAvatar([
+      "user",
+      undefined,
+      { name: "Viewer", avatar: null },
+      "",
+      null,
+      { id: "alice@example.com", name: "Alice Lovelace" },
+    ]);
+    expect(avatar?.tagName).toBe("DIV");
+    expect(avatar?.classList.contains("chat-avatar--sender-initials")).toBe(true);
+    expect(avatar?.textContent?.trim()).toBe("AL");
+  });
+
+  it("keeps the local viewer identity when no sender is attributed", () => {
+    const avatar = renderAvatar(["user", undefined, { name: "Viewer", avatar: null }, "", null]);
+    expect(avatar?.classList.contains("chat-avatar--sender-initials")).toBe(false);
+  });
+});

--- a/ui/src/pages/chat/chat-avatar.ts
+++ b/ui/src/pages/chat/chat-avatar.ts
@@ -15,6 +15,9 @@ import {
   resolveAssistantTextAvatar,
 } from "../../lib/avatar.ts";
 import { normalizeRoleForGrouping } from "../../lib/chat/message-normalizer.ts";
+import type { SenderIdentity } from "../../lib/chat/sender-label.ts";
+import { formatSenderLabel } from "../../lib/chat/sender-label.ts";
+import { resolveAvatar, resolveAvatarInitials } from "../../lib/identity-avatar.ts";
 import {
   DEFAULT_AGENT_ID,
   isUiGlobalSessionKey,
@@ -28,8 +31,26 @@ export function renderChatAvatar(
   user?: { name?: string | null; avatar?: string | null },
   basePath?: string,
   authToken?: string | null,
+  sender?: SenderIdentity | null,
 ) {
   const normalized = normalizeRoleForGrouping(role);
+  // Attributed multi-user messages show the author's own avatar (profile
+  // upload → gateway Gravatar proxy → initials), not the local viewer's.
+  if (normalized === "user" && sender) {
+    const label = formatSenderLabel(sender) ?? "";
+    const resolved = resolveAvatar(sender);
+    if (resolved.kind !== "initials") {
+      return html`<img class="chat-avatar user" src="${resolved.url}" alt="${label}" />`;
+    }
+    const initials = resolveAvatarInitials(sender);
+    return html`<div
+      class="chat-avatar user chat-avatar--sender-initials"
+      style=${`background: hsl(${initials.colorSeed % 360} 48% 42%)`}
+      aria-label="${label}"
+    >
+      ${initials.initials}
+    </div>`;
+  }
   const assistantName = assistant?.name?.trim() || "Assistant";
   const assistantAvatar = assistant?.avatar?.trim() || "";
   const assistantAvatarText = resolveAssistantTextAvatar(assistantAvatar);

--- a/ui/src/pages/chat/chat-avatar.ts
+++ b/ui/src/pages/chat/chat-avatar.ts
@@ -38,18 +38,39 @@ export function renderChatAvatar(
   // upload → gateway Gravatar proxy → initials), not the local viewer's.
   if (normalized === "user" && sender) {
     const label = formatSenderLabel(sender) ?? "";
-    const resolved = resolveAvatar(sender);
-    if (resolved.kind !== "initials") {
-      return html`<img class="chat-avatar user" src="${resolved.url}" alt="${label}" />`;
-    }
     const initials = resolveAvatarInitials(sender);
-    return html`<div
+    const initialsAvatar = html`<div
       class="chat-avatar user chat-avatar--sender-initials"
       style=${`background: hsl(${initials.colorSeed % 360} 48% 42%)`}
       aria-label="${label}"
     >
       ${initials.initials}
     </div>`;
+    const resolved = resolveAvatar(sender);
+    if (resolved.kind === "initials") {
+      return initialsAvatar;
+    }
+    // The derived route may 404 (no upload, no Gravatar); swap to initials
+    // instead of a broken image. Lit reuses DOM parts, so a load must clear a
+    // prior sender's error state.
+    return html`<span class="chat-avatar-slot">
+      <img
+        class="chat-avatar user"
+        src="${resolved.url}"
+        alt="${label}"
+        @error=${(event: Event) => {
+          (event.currentTarget as HTMLElement)
+            .closest(".chat-avatar-slot")
+            ?.classList.add("is-fallback");
+        }}
+        @load=${(event: Event) => {
+          (event.currentTarget as HTMLElement)
+            .closest(".chat-avatar-slot")
+            ?.classList.remove("is-fallback");
+        }}
+      />
+      ${initialsAvatar}
+    </span>`;
   }
   const assistantName = assistant?.name?.trim() || "Assistant";
   const assistantAvatar = assistant?.avatar?.trim() || "";

--- a/ui/src/pages/chat/chat-pane.ts
+++ b/ui/src/pages/chat/chat-pane.ts
@@ -3309,6 +3309,7 @@ class ChatPane extends OpenClawLightDomElement {
       assistantAvatar: state.assistantAvatar,
       userName: state.userName,
       userAvatar: state.userAvatar,
+      attributedIdentity: Boolean(this.context.gateway.snapshot.selfUser),
       localMediaPreviewRoots: state.localMediaPreviewRoots,
       embedSandboxMode: state.embedSandboxMode,
       allowExternalEmbedUrls: state.allowExternalEmbedUrls,

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -911,6 +911,22 @@ describe("direct thread avatar mode", () => {
     ).toBe(true);
   });
 
+  it("keeps avatars in direct sessions when the gateway attributes identities", () => {
+    const attributed = renderChatView({
+      sessionKey: "kind-direct",
+      sessions: sessionsListWithKind("kind-direct", "direct"),
+      messages: labeledHistory,
+      attributedIdentity: true,
+    });
+    // Multi-user gateways share even 1:1-shaped sessions, so the author
+    // marker is signal, not decoration.
+    expect(
+      requireElement(attributed, ".chat-thread", "chat thread").classList.contains(
+        "chat-thread--direct",
+      ),
+    ).toBe(false);
+  });
+
   it("falls back to session-key shape when session metadata is missing", () => {
     // Labeled DM rows must not flip the mode: sanitization labels 1:1 DMs too.
     const direct = renderChatView({

--- a/ui/src/pages/chat/chat-view.ts
+++ b/ui/src/pages/chat/chat-view.ts
@@ -154,6 +154,7 @@ export type ChatProps = {
   assistantAvatar: string | null;
   userName?: string | null;
   userAvatar?: string | null;
+  attributedIdentity?: boolean;
   localMediaPreviewRoots?: string[];
   assistantAttachmentAuthToken?: string | null;
   autoExpandToolCalls?: boolean;
@@ -346,6 +347,7 @@ export function renderChat(props: ChatProps) {
       assistantAvatarUrl: props.assistantAvatarUrl,
       userName: props.userName,
       userAvatar: props.userAvatar,
+      attributedIdentity: props.attributedIdentity,
       basePath: props.basePath,
       fullMessageAgentId: props.fullMessageAgentId,
       localMediaPreviewRoots: props.localMediaPreviewRoots,

--- a/ui/src/pages/chat/components/chat-message.ts
+++ b/ui/src/pages/chat/components/chat-message.ts
@@ -903,6 +903,7 @@ export function renderMessageGroup(group: MessageGroup, opts: RenderMessageGroup
           },
           opts.basePath,
           opts.assistantAttachmentAuthToken,
+          group.sender,
         )}
         <div class="chat-group-messages">
           <div class="chat-activity-group ${activityExpanded ? "is-open" : ""}">
@@ -981,6 +982,7 @@ export function renderMessageGroup(group: MessageGroup, opts: RenderMessageGroup
         },
         opts.basePath,
         opts.assistantAttachmentAuthToken,
+        group.sender,
       )}
       <div class="chat-group-messages">
         ${group.messages.map((item, index) => {

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -128,6 +128,8 @@ type ChatThreadProps = {
   assistantAvatarUrl?: string | null;
   userName?: string | null;
   userAvatar?: string | null;
+  /** Gateway resolves authenticated user identities (multi-user attribution). */
+  attributedIdentity?: boolean;
   basePath?: string;
   fullMessageAgentId?: string;
   localMediaPreviewRoots?: string[];
@@ -1120,9 +1122,12 @@ function renderChatThreadContents(
         : classifySessionKind(props.sessionKey);
   // Only agent-solo kinds qualify: "global" aggregates every inbound context
   // under session.scope="global" (including group/channel senders), so it
-  // keeps avatars like "group" and "unknown" do.
+  // keeps avatars like "group" and "unknown" do. An identity-resolving gateway
+  // (multi-user trusted proxy) also keeps them: several people share these
+  // sessions, so the author marker is signal, not decoration.
   const isDirectThread =
-    sessionKind === "direct" || sessionKind === "cron" || sessionKind === "spawn-child";
+    (sessionKind === "direct" || sessionKind === "cron" || sessionKind === "spawn-child") &&
+    !props.attributedIdentity;
   const showLoadingSkeleton = props.loading && chatItems.length === 0;
   const threadContextWindow =
     activeSession?.contextTokens ?? props.sessions?.defaults?.contextTokens ?? null;

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -320,6 +320,17 @@
   border-color: color-mix(in srgb, var(--accent) 20%, transparent);
 }
 
+/* Attributed sender initials carry their stable identity color inline. */
+.chat-avatar.chat-avatar--sender-initials {
+  color: white;
+  font-size: 12px;
+  letter-spacing: -0.02em;
+}
+
+img.chat-avatar.user {
+  object-fit: cover;
+}
+
 .chat-avatar.assistant {
   background: var(--secondary);
   color: var(--muted);

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -331,6 +331,24 @@ img.chat-avatar.user {
   object-fit: cover;
 }
 
+/* Sender avatars pair the route image with an initials fallback; the slot
+   swaps them when the canonical route has no avatar (404). */
+.chat-avatar-slot {
+  display: contents;
+}
+
+.chat-avatar-slot > .chat-avatar--sender-initials {
+  display: none;
+}
+
+.chat-avatar-slot.is-fallback > img.chat-avatar {
+  display: none;
+}
+
+.chat-avatar-slot.is-fallback > .chat-avatar--sender-initials {
+  display: grid;
+}
+
 .chat-avatar.assistant {
   background: var(--secondary);
   color: var(--muted);


### PR DESCRIPTION
## What

Fixes three sender-attribution defects visible on multi-user gateways (reported from team.openclaw.ai):

1. **UUID in the sender label** — messages rendered as `steipete (c3e32452-0467-…)`. `resolveSenderLabel` appended the id part even when it is an opaque profile UUID. The suffix is now suppressed at the source, and the UI normalizer strips already-baked suffixes so historical transcripts read clean too. Human-meaningful suffixes (phone numbers, emails) still render.
2. **Initials instead of the author's avatar** — chat sender metadata carries only the profile id (the prompt-visible envelope stays URL-free), so the client never found an avatar even when the profile has an upload or a Gravatar. `resolveAvatar` now derives the canonical `/api/users/<id>/avatar` route from UUID-shaped sender ids (gateway serves upload → Gravatar proxy → 404-to-initials). Non-UUID ids stay on initials, so channel senders never probe the route.
3. **Identity only visible on hover** — 1:1-shaped sessions drop the avatar gutter by design, but on an identity-resolving gateway (trusted-proxy multi-user) several people share those sessions, so the author marker is signal. A new `attributedIdentity` prop (from `gateway.snapshot.selfUser`) keeps the always-visible gutter, and the gutter now renders the message author's avatar (identity-colored initials fallback) instead of the local viewer's.

Single-user gateways are unchanged: no `selfUser` → direct threads keep dropping the gutter, labels never had UUIDs, and non-UUID sender ids don't touch the avatar route.

## Tests

- `src/channels/sender-label.test.ts`: UUID suffix suppressed, phone/email suffixes kept, UUID-only identity still labels.
- `ui/.../message-normalizer.test.ts`: baked `name (uuid)` stripped, human suffixes kept, UUID-only label not emptied.
- `ui/.../identity-avatar.test.ts`: UUID sender id → canonical route (origin-resolved), non-UUID ids stay initials, explicit route wins.
- `ui/.../chat-avatar.test.ts`: sender renders profile-route img / identity-colored initials; no sender keeps local viewer identity.
- `ui/.../chat-view.test.ts`: `attributedIdentity` keeps avatars in direct-kind sessions.

Full UI suite green (4811 passed), affected core suites green, tsgo ui+core clean.
