### PR TITLE
fix(ui): keep steered composer messages visible until the transcript owns them

### DIFF
--- a/ui/src/pages/chat/chat-gateway.ts
+++ b/ui/src/pages/chat/chat-gateway.ts
@@ -14,6 +14,7 @@ import {
   type ChatState,
 } from "./chat-history.ts";
 import { clearPendingQueueItemsForRun } from "./chat-queue.ts";
+import { preserveSteeredQueueItemsForRun } from "./queued-user-turn.ts";
 import { reconcileChatRunLifecycle } from "./run-lifecycle.ts";
 import { appendChatMessageToCache } from "./session-message-cache.ts";
 import {
@@ -394,6 +395,14 @@ export function handleChatGatewayEvent(state: ChatState, payload?: ChatEventPayl
     return null;
   }
   const activeRunIdBeforeEvent = state.chatRunId;
+  if (
+    isTerminalChatState(payload?.state) &&
+    !isEventForDifferentActiveRun(payload, activeRunIdBeforeEvent)
+  ) {
+    // A steered chip can be the only local copy while transcript persistence lags.
+    // Materialize it before the terminal assistant so user/assistant order stays stable.
+    preserveSteeredQueueItemsForRun(state, payload?.runId);
+  }
   const result = handleChatEvent(state, payload);
   if (
     isTerminalChatState(result) &&

--- a/ui/src/pages/chat/chat-send.test.ts
+++ b/ui/src/pages/chat/chat-send.test.ts
@@ -3411,6 +3411,38 @@ describe("handleSendChat", () => {
     );
   });
 
+  it("keeps a steered message visible when only the session row reports an active run", async () => {
+    let wireRunId: unknown;
+    const request = vi.fn(async (method: string, params?: unknown) => {
+      if (method === "chat.send") {
+        wireRunId = requireRecord(params, "steered chat send payload").idempotencyKey;
+        return { status: "started", runId: "steer-run" };
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const host = makeHost({
+      client: { request } as unknown as ChatHost["client"],
+      chatMessage: "tighten the live plan",
+      chatRunId: null,
+      sessionKey: "agent:main:main",
+      sessionsResult: createSessionsResult([
+        row("agent:main:main", { hasActiveRun: true, status: "running" }),
+      ]),
+      settings: { chatFollowUpMode: "steer" },
+    });
+
+    await handleSendChat(host);
+    await waitForFast(() => expect(host.chatQueue[0]?.kind).toBe("steered"));
+
+    expect(host.chatQueue).toHaveLength(1);
+    expect(host.chatQueue[0]).toMatchObject({
+      kind: "steered",
+      pendingRunId: "steer-run",
+      sendRunId: wireRunId,
+      text: "tighten the live plan",
+    });
+  });
+
   it("keeps busy sends queued in steer mode while disconnected", async () => {
     const host = makeHost({
       client: null,
@@ -7101,6 +7133,7 @@ describe("handleSendChat", () => {
     expect(host.chatQueue[0]?.text).toBe("tighten the plan");
     expect(host.chatQueue[0]?.kind).toBe("steered");
     expect(host.chatQueue[0]?.pendingRunId).toBe("run-1");
+    expect(host.chatQueue[0]?.sendRunId).toBe(idempotencyKey);
   });
 
   it("steers a queued message when only the session row reports an active run", async () => {
@@ -7123,17 +7156,69 @@ describe("handleSendChat", () => {
 
     await steerQueuedChatMessage(host, original.id);
 
-    expect(request).toHaveBeenCalledWith(
+    const payload = findRequestPayload(
+      request as unknown as MockCallSource,
       "chat.send",
-      expect.objectContaining({
-        sessionKey: "agent:main:main",
-        message: "tighten the plan",
-        deliver: false,
-      }),
+      "session-row steer payload",
     );
+    expect(payload).toMatchObject({
+      sessionKey: "agent:main:main",
+      message: "tighten the plan",
+      deliver: false,
+      queueMode: "steer",
+    });
     expect(host.chatRunId).toBeNull();
-    expect(host.chatQueue).toEqual([]);
+    expect(host.chatQueue).toEqual([
+      expect.objectContaining({
+        kind: "steered",
+        pendingRunId: "steer-run",
+        sendRunId: payload.idempotencyKey,
+        text: original.text,
+      }),
+    ]);
     expect(listStoredChatOutboxes(host)).toEqual([]);
+  });
+
+  it("materializes an immediately completed steer before retiring its queue row", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === "chat.send") {
+        return { status: "ok", runId: "completed-steer-run" };
+      }
+      if (method === "chat.history") {
+        return idleChatHistory("agent:main:main");
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const original = {
+      id: "completed-steer",
+      text: "record this completed steer",
+      createdAt: 1,
+      sendRunId: "completed-steer-run",
+      sendState: "waiting-idle" as const,
+      sessionKey: "agent:main:main",
+    };
+    const host = makeHost({
+      client: { request } as unknown as ChatHost["client"],
+      chatQueue: [original],
+      chatRunId: "active-run",
+      sessionKey: original.sessionKey,
+    });
+    expect(admitQueuedMessageForSession(host, host.sessionKey, original)).toBe(true);
+
+    await steerQueuedChatMessage(host, original.id);
+
+    expect(host.chatQueue).toEqual([]);
+    expect(host.chatMessages).toEqual([
+      expect.objectContaining({
+        role: "user",
+        __openclaw: { idempotencyKey: "completed-steer-run:user" },
+      }),
+    ]);
+    expect(JSON.stringify(host.chatMessages[0])).toContain(original.text);
+    expect(request).toHaveBeenCalledWith(
+      "chat.history",
+      expect.objectContaining({ sessionKey: original.sessionKey }),
+    );
   });
 
   it("does not steer a queued message without a durable claim", async () => {
@@ -7184,13 +7269,14 @@ describe("handleSendChat", () => {
 
     expect(listStoredChatOutboxes(host)).toEqual([]);
     expect(host.chatQueue).toEqual([
-      {
+      expect.objectContaining({
         id: original.id,
         text: original.text,
         createdAt: original.createdAt,
         kind: "steered",
         pendingRunId: "active-run",
-      },
+        sendRunId: original.sendRunId,
+      }),
     ]);
 
     clearPendingQueueItemsForRun(host, "active-run");
@@ -7201,7 +7287,7 @@ describe("handleSendChat", () => {
     expect(request.mock.calls.filter(([method]) => method === "chat.send")).toHaveLength(1);
   });
 
-  it("does not restore a steer indicator after its run ends before the acknowledgement", async () => {
+  it("restores a steer indicator when its only pending copy disappears before the acknowledgement", async () => {
     let resolveRequest: (value: { status: "started"; runId: string }) => void = () => {};
     const request = vi.fn(async (method: string) => {
       if (method === "chat.send") {
@@ -7237,7 +7323,176 @@ describe("handleSendChat", () => {
     await steering;
 
     expect(listStoredChatOutboxes(host)).toEqual([]);
+    // The captured run died mid-request, so the restored chip binds to the
+    // steer's own gateway lifecycle instead of the dead run id.
+    expect(host.chatQueue).toEqual([
+      expect.objectContaining({
+        id: original.id,
+        kind: "steered",
+        pendingRunId: "steer-run",
+        sendRunId: original.sendRunId,
+        text: original.text,
+      }),
+    ]);
+  });
+
+  it("does not materialize an unacknowledged steer when its run terminates mid-request", async () => {
+    let resolveSteer: (value: { status: "error"; runId: string }) => void = () => {};
+    const request = vi.fn(async (method: string) => {
+      if (method === "chat.send") {
+        return await new Promise<{ status: "error"; runId: string }>((resolve) => {
+          resolveSteer = resolve;
+        });
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const original = {
+      id: "phantom-guard-steer",
+      text: "must not become a phantom turn",
+      createdAt: 1,
+      sendAttempts: 0,
+      sendRunId: "queued-run",
+      sendState: "waiting-idle" as const,
+      sessionKey: "agent:main:main",
+      agentId: "main",
+    };
+    const host = makeHost({
+      client: { request } as unknown as ChatHost["client"],
+      chatRunId: "active-run",
+      chatQueue: [original],
+      sessionKey: original.sessionKey,
+    });
+    expect(admitQueuedMessageForSession(host, host.sessionKey, original)).toBe(true);
+
+    const steering = steerQueuedChatMessage(host, original.id);
+    await waitForFast(() => expect(request).toHaveBeenCalledOnce());
+    handlePageGatewayEvent(
+      host as unknown as ChatPageHost,
+      {
+        event: "chat",
+        payload: {
+          state: "final",
+          runId: "active-run",
+          sessionKey: "agent:main:main",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "finished before the steer landed" }],
+            timestamp: 2,
+          },
+        },
+      } as Parameters<typeof handlePageGatewayEvent>[1],
+    );
+    const userTurns = () =>
+      host.chatMessages.filter((message) => (message as { role?: string }).role === "user");
+    expect(userTurns()).toEqual([]);
+
+    resolveSteer({ status: "error", runId: "steer-error" });
+    await steering;
+
+    expect(userTurns()).toEqual([]);
+    const restored = [
+      ...host.chatQueue,
+      ...listStoredChatOutboxes(host).flatMap((outbox) => outbox.queue),
+    ].find((item) => item.id === original.id);
+    expect(restored?.text).toBe(original.text);
+  });
+
+  it("materializes a steered user turn before a terminal event clears its chip", () => {
+    const host = makeHost({
+      chatRunId: "active-run",
+      chatQueue: [
+        {
+          id: "terminal-steer",
+          text: "keep this visible",
+          createdAt: 1,
+          kind: "steered",
+          pendingRunId: "active-run",
+          sendRunId: "steer-send-run",
+          sessionKey: "agent:main:main",
+        },
+      ],
+      sessionKey: "agent:main:main",
+    });
+
+    handlePageGatewayEvent(
+      host as unknown as ChatPageHost,
+      {
+        event: "chat",
+        payload: {
+          state: "final",
+          runId: "active-run",
+          sessionKey: "agent:main:main",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "done" }],
+            timestamp: 2,
+          },
+        },
+      } as Parameters<typeof handlePageGatewayEvent>[1],
+    );
+
     expect(host.chatQueue).toEqual([]);
+    expect(host.chatMessages).toHaveLength(2);
+    expect(host.chatMessages[0]).toMatchObject({
+      role: "user",
+      __openclaw: { idempotencyKey: "steer-send-run:user" },
+    });
+    expect(JSON.stringify(host.chatMessages[0])).toContain("keep this visible");
+  });
+
+  it("materializes both the run's queued turn and its steered follow-up at the terminal event", () => {
+    const original = {
+      id: "original-turn",
+      text: "original queued turn",
+      createdAt: 1,
+      sendRunId: "active-run",
+      sendState: "sending" as const,
+      sessionKey: "agent:main:main",
+    };
+    const host = makeHost({
+      chatRunId: "active-run",
+      chatQueue: [
+        original,
+        {
+          id: "steer-follow-up",
+          text: "steered follow-up",
+          createdAt: 2,
+          kind: "steered",
+          pendingRunId: "active-run",
+          sendRunId: "steer-send-run",
+          sessionKey: "agent:main:main",
+        },
+      ],
+      sessionKey: "agent:main:main",
+    });
+    expect(admitQueuedMessageForSession(host, host.sessionKey, original)).toBe(true);
+
+    handlePageGatewayEvent(
+      host as unknown as ChatPageHost,
+      {
+        event: "chat",
+        payload: {
+          state: "final",
+          runId: "active-run",
+          sessionKey: "agent:main:main",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "done" }],
+            timestamp: 3,
+          },
+        },
+      } as Parameters<typeof handlePageGatewayEvent>[1],
+    );
+
+    expect(listStoredChatOutboxes(host)).toEqual([]);
+    expect(host.chatQueue).toEqual([]);
+    const idempotencyKeys = host.chatMessages.map((message) => {
+      const marker = (message as { __openclaw?: { idempotencyKey?: string } }).__openclaw;
+      return marker?.idempotencyKey;
+    });
+    expect(idempotencyKeys.slice(0, 2)).toEqual(["active-run:user", "steer-send-run:user"]);
+    expect(JSON.stringify(host.chatMessages[0])).toContain("original queued turn");
+    expect(JSON.stringify(host.chatMessages[1])).toContain("steered follow-up");
   });
 
   it("resumes a restored steer after its active run ended before a terminal error", async () => {

--- a/ui/src/pages/chat/chat-send.test.ts
+++ b/ui/src/pages/chat/chat-send.test.ts
@@ -7487,7 +7487,7 @@ describe("handleSendChat", () => {
     expect(listStoredChatOutboxes(host)).toEqual([]);
     expect(host.chatQueue).toEqual([]);
     const idempotencyKeys = host.chatMessages.map((message) => {
-      const marker = (message as { __openclaw?: { idempotencyKey?: string } }).__openclaw;
+      const marker = (message as { __openclaw?: { idempotencyKey?: string } })["__openclaw"];
       return marker?.idempotencyKey;
     });
     expect(idempotencyKeys.slice(0, 2)).toEqual(["active-run:user", "steer-send-run:user"]);

--- a/ui/src/pages/chat/chat-send.test.ts
+++ b/ui/src/pages/chat/chat-send.test.ts
@@ -7440,6 +7440,58 @@ describe("handleSendChat", () => {
     expect(JSON.stringify(host.chatMessages[0])).toContain("keep this visible");
   });
 
+  it("still materializes the user turn when an assistant entry carries the steer's run key", () => {
+    const assistantWithRunKey = {
+      role: "assistant",
+      content: [{ type: "text", text: "assistant reply for the same run" }],
+      timestamp: 1,
+      __openclaw: { idempotencyKey: "steer-send-run" },
+    };
+    const host = makeHost({
+      chatRunId: "active-run",
+      chatMessages: [assistantWithRunKey],
+      chatQueue: [
+        {
+          id: "assistant-key-steer",
+          text: "user turn must still appear",
+          createdAt: 2,
+          kind: "steered",
+          pendingRunId: "active-run",
+          sendRunId: "steer-send-run",
+          sessionKey: "agent:main:main",
+        },
+      ],
+      sessionKey: "agent:main:main",
+    });
+
+    handlePageGatewayEvent(
+      host as unknown as ChatPageHost,
+      {
+        event: "chat",
+        payload: {
+          state: "final",
+          runId: "active-run",
+          sessionKey: "agent:main:main",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "done" }],
+            timestamp: 3,
+          },
+        },
+      } as Parameters<typeof handlePageGatewayEvent>[1],
+    );
+
+    expect(host.chatQueue).toEqual([]);
+    const userTurn = host.chatMessages.find(
+      (message) => (message as { role?: string }).role === "user",
+    );
+    expect(userTurn).toMatchObject({
+      role: "user",
+      __openclaw: { idempotencyKey: "steer-send-run:user" },
+    });
+    expect(JSON.stringify(userTurn)).toContain("user turn must still appear");
+  });
+
   it("materializes an attachment-only steered chip from store-backed payload bytes", () => {
     const file = new File(["fake-png"], "shot.png", { type: "image/png" });
     const dataUrl = "data:image/png;base64,ZmFrZS1wbmc=";

--- a/ui/src/pages/chat/chat-send.test.ts
+++ b/ui/src/pages/chat/chat-send.test.ts
@@ -7440,6 +7440,66 @@ describe("handleSendChat", () => {
     expect(JSON.stringify(host.chatMessages[0])).toContain("keep this visible");
   });
 
+  it("materializes an attachment-only steered chip from store-backed payload bytes", () => {
+    const file = new File(["fake-png"], "shot.png", { type: "image/png" });
+    const dataUrl = "data:image/png;base64,ZmFrZS1wbmc=";
+    registerChatAttachmentPayload({
+      attachment: {
+        id: "steer-att",
+        mimeType: "image/png",
+        fileName: "shot.png",
+        sizeBytes: file.size,
+      },
+      dataUrl,
+      file,
+    });
+    const host = makeHost({
+      chatRunId: "active-run",
+      chatQueue: [
+        {
+          id: "attachment-only-steer",
+          text: "",
+          createdAt: 1,
+          kind: "steered",
+          pendingRunId: "active-run",
+          sendRunId: "steer-att-run",
+          sessionKey: "agent:main:main",
+          // Queue rows carry attachment metadata only; bytes live in the store.
+          attachments: [
+            { id: "steer-att", mimeType: "image/png", fileName: "shot.png", sizeBytes: file.size },
+          ],
+        },
+      ],
+      sessionKey: "agent:main:main",
+    });
+
+    handlePageGatewayEvent(
+      host as unknown as ChatPageHost,
+      {
+        event: "chat",
+        payload: {
+          state: "final",
+          runId: "active-run",
+          sessionKey: "agent:main:main",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "done" }],
+            timestamp: 2,
+          },
+        },
+      } as Parameters<typeof handlePageGatewayEvent>[1],
+    );
+
+    expect(host.chatQueue).toEqual([]);
+    expect(host.chatMessages[0]).toMatchObject({
+      role: "user",
+      __openclaw: { idempotencyKey: "steer-att-run:user" },
+    });
+    // Inline data-URL images render as a labeled placeholder block; the point
+    // is the turn materializes with content instead of vanishing.
+    expect(JSON.stringify(host.chatMessages[0])).toContain("Attached image: shot.png");
+  });
+
   it("materializes both the run's queued turn and its steered follow-up at the terminal event", () => {
     const original = {
       id: "original-turn",

--- a/ui/src/pages/chat/chat-send.ts
+++ b/ui/src/pages/chat/chat-send.ts
@@ -97,6 +97,7 @@ import {
   type ChatInputHistoryState,
 } from "./input-history.ts";
 import { controlUiNowMs, roundedControlUiDurationMs } from "./performance.ts";
+import { chatMessagesContainQueuedUserTurn, preserveQueuedUserTurn } from "./queued-user-turn.ts";
 import type { RenderLifecycle } from "./render-lifecycle.ts";
 import {
   handleAbortChat,
@@ -1367,6 +1368,7 @@ async function sendQueuedChatMessageWithQueueMode(
   const claimed = updateQueuedMessage(host, id, (entry) => ({
     ...entry,
     sendError: unconfirmedError,
+    sendRunId: entry.sendRunId ?? generateUUID(),
     sendState: "unconfirmed",
   }));
   if (!claimed) {
@@ -1379,9 +1381,14 @@ async function sendQueuedChatMessageWithQueueMode(
     createdAt: item.createdAt,
     ...(isSteer ? { kind: "steered" as const } : {}),
     ...(item.attachments?.length ? { attachments: item.attachments } : {}),
-    ...(isSteer && activeRunId
-      ? { pendingRunId: activeRunId }
-      : { sendState: isSteer ? ("steering" as const) : ("sending" as const) }),
+    ...(claimed.sendRunId ? { sendRunId: claimed.sendRunId } : {}),
+    ...(claimed.sessionKey ? { sessionKey: claimed.sessionKey } : {}),
+    ...(claimed.agentId ? { agentId: claimed.agentId } : {}),
+    ...(isSteer && activeRunId ? { pendingRunId: activeRunId } : {}),
+    // In-flight marker: terminal-event preservation must skip a steer the
+    // Gateway has not acknowledged yet, or a rejected send leaves a phantom
+    // user turn that a later retry duplicates.
+    sendState: isSteer ? ("steering" as const) : ("sending" as const),
   };
   const hasTransientProjection = setTransientQueuedMessageProjection(
     host,
@@ -1410,12 +1417,9 @@ async function sendQueuedChatMessageWithQueueMode(
     {
       canApplyError: () => visibleSessionMatches(host, itemSessionKey, item.agentId),
       ...(queueMode ? { queueMode } : {}),
+      runId: claimed.sendRunId,
     },
   );
-  const pendingStillVisible =
-    isSteer && activeRunId
-      ? host.chatQueue.some((entry) => entry.id === id && entry.pendingRunId === activeRunId)
-      : false;
   if (isSteer && activeRunId) {
     replacePendingQueuedMessageProjection(
       host,
@@ -1465,16 +1469,27 @@ async function sendQueuedChatMessageWithQueueMode(
     }
     return;
   }
-  if (
-    isSteer &&
-    ack.status !== "ok" &&
-    pendingStillVisible &&
-    host.chatRunId === activeRunId &&
-    itemStillVisible
-  ) {
-    host.chatQueue = [...host.chatQueue, pendingIndicator].toSorted(
-      (left, right) => left.createdAt - right.createdAt,
-    );
+  const userTurnAlreadyVisible = chatMessagesContainQueuedUserTurn(host.chatMessages, claimed);
+  if (isSteer && ack.status === "ok") {
+    preserveQueuedUserTurn(host, claimed);
+    if (itemStillVisible) {
+      void loadChatHistory(host as unknown as ChatState);
+    }
+  }
+  if (isSteer && ack.status !== "ok" && itemStillVisible && !userTurnAlreadyVisible) {
+    // Key the chip to the run that will emit its terminal cleanup: the active
+    // run when it still owns the tab, else the steer's own gateway lifecycle
+    // (session-row-only runs, or the captured run ended mid-request).
+    const chipRunId = activeRunId && host.chatRunId === activeRunId ? activeRunId : ack.runId;
+    const steeredIndicator: ChatQueueItem = {
+      ...pendingIndicator,
+      pendingRunId: chipRunId,
+    };
+    delete steeredIndicator.sendState;
+    host.chatQueue = [
+      ...host.chatQueue.filter((entry) => entry.id !== id),
+      steeredIndicator,
+    ].toSorted((left, right) => left.createdAt - right.createdAt);
   } else {
     releaseChatAttachmentPayloads(attachments);
   }

--- a/ui/src/pages/chat/chat-state.ts
+++ b/ui/src/pages/chat/chat-state.ts
@@ -26,11 +26,7 @@ import { retirePendingChatSideQuestion, type ChatSideResult } from "../../lib/ch
 import type { EmbedSandboxMode } from "../../lib/chat/tool-display.ts";
 import { isGatewayMethodAdvertised } from "../../lib/gateway-methods.ts";
 import { loadModelAuthStatus } from "../../lib/model-auth.ts";
-import {
-  scopedAgentParamsForSession,
-  visibleSessionMatches,
-  type SessionCapability,
-} from "../../lib/sessions/index.ts";
+import { scopedAgentParamsForSession, type SessionCapability } from "../../lib/sessions/index.ts";
 import {
   readSessionChangedEvent,
   type SessionChangedResult,
@@ -124,6 +120,7 @@ import {
   type ChatInputHistoryKeyResult,
 } from "./input-history.ts";
 import { applyModelCatalogResult, loadModels } from "./models.ts";
+import { preserveQueuedUserTurn, preserveSteeredQueueItemsForRun } from "./queued-user-turn.ts";
 import type { AfterCommitEffect, RenderLifecycle } from "./render-lifecycle.ts";
 import {
   handleAbortChat,
@@ -140,9 +137,7 @@ import {
   scheduleCommittedChatScroll,
 } from "./scroll.ts";
 import {
-  appendChatMessageToCache,
   cacheChatSessionSnapshot,
-  readChatMessagesFromCache,
   readChatSessionSnapshot,
   type ChatMessageCache,
   type ChatSessionSnapshot,
@@ -160,7 +155,6 @@ import {
   type PlanStatus,
   type ToolStreamEntry,
 } from "./tool-stream.ts";
-import { buildUserChatMessageContentBlocks } from "./user-message-content.ts";
 
 type ChatPageElement = {
   querySelector: (selectors: string) => Element | null;
@@ -1067,6 +1061,7 @@ function finishSessionMessageRunReconcile(
   if (!cleared) {
     return false;
   }
+  preserveSteeredQueueItemsForRun(state, runId ?? undefined);
   clearPendingQueueItemsForRun(state, runId ?? undefined);
   void loadChatHistory(state)
     .finally(() => {
@@ -1467,7 +1462,7 @@ export function handlePageGatewayEvent(state: ChatPageHost, event: GatewayEventF
     if (delivered) {
       // The queued projection is the only local copy until history catches up.
       // Materialize it before the terminal assistant to preserve transcript order.
-      preserveDeliveredQueuedUserTurn(state, delivered);
+      preserveQueuedUserTurn(state, delivered);
     }
     const result = handleChatGatewayEvent(state as unknown as ChatState, payload);
     if (shouldCelebrateFirstReply && result === "final") {
@@ -1537,6 +1532,12 @@ function rememberDeliveredQueuedUserTurn(
     turns = new Map();
     deliveredQueueTurnsByClient.set(owner, turns);
   }
+  const pending = state.chatQueue.find(
+    // sendState marks an in-flight steer whose chat.send is unacknowledged;
+    // materializing it would leave a phantom turn if the Gateway rejects it.
+    (item) =>
+      item.kind === "steered" && item.pendingRunId === runId && item.sendRunId && !item.sendState,
+  );
   const stored = readDeliveredQueuedChatSendForRun(state, runId)?.item;
   if (stored) {
     turns.delete(runId);
@@ -1549,64 +1550,11 @@ function rememberDeliveredQueuedUserTurn(
       turns.delete(oldestRunId);
     }
   }
-  return stored ?? turns.get(runId) ?? null;
-}
-
-function durableDeliveredAttachments(
-  attachments: readonly ChatAttachment[] | undefined,
-): ChatAttachment[] | undefined {
-  return attachments?.flatMap((attachment) => {
-    if (!attachment.dataUrl) {
-      return [];
-    }
-    // Terminal retirement releases the queue-owned live blob. Pin synthetic
-    // transcript content to durable bytes before that ownership ends.
-    return [{ ...attachment, previewUrl: attachment.dataUrl }];
-  });
-}
-
-function preserveDeliveredQueuedUserTurn(state: ChatPageHost, item: ChatQueueItem): void {
-  const runId = item.sendRunId;
-  const sessionKey = item.sessionKey ?? state.sessionKey;
-  if (!runId) {
-    return;
-  }
-  const idempotencyKey = `${runId}:user`;
-  const containsUserTurn = (messages: unknown[]) =>
-    messages.some((message) => {
-      if (!message || typeof message !== "object" || Array.isArray(message)) {
-        return false;
-      }
-      const marker = (message as { __openclaw?: unknown })["__openclaw"];
-      return (
-        Boolean(marker && typeof marker === "object" && !Array.isArray(marker)) &&
-        (marker as { idempotencyKey?: unknown }).idempotencyKey === idempotencyKey
-      );
-    });
-  const content = buildUserChatMessageContentBlocks(
-    item.text,
-    durableDeliveredAttachments(item.attachments),
-  );
-  if (!content.length) {
-    return;
-  }
-  const userMessage = {
-    role: "user",
-    content,
-    timestamp: item.createdAt,
-    __openclaw: { idempotencyKey },
-  };
-  if (visibleSessionMatches(state, sessionKey, item.agentId)) {
-    if (!containsUserTurn(state.chatMessages)) {
-      state.chatMessages = [...state.chatMessages, userMessage];
-    }
-    return;
-  }
-  const target = { sessionKey, agentId: item.agentId };
-  const cached = readChatMessagesFromCache(state.chatMessagesBySession, state, target);
-  if (!containsUserTurn(cached)) {
-    appendChatMessageToCache(state.chatMessagesBySession, state, target, userMessage);
-  }
+  // Original-turn copies first: a run can own both its queued turn (stored, or
+  // its remembered fallback in `turns`) and a steered follow-up chip; the chip
+  // is preserved separately by preserveSteeredQueueItemsForRun and must not
+  // mask the original copy here.
+  return stored ?? turns.get(runId) ?? pending ?? null;
 }
 
 type ChatPageUpdateMode = "immediate" | "animation-frame";

--- a/ui/src/pages/chat/history-merge.test.ts
+++ b/ui/src/pages/chat/history-merge.test.ts
@@ -53,4 +53,22 @@ describe("preserveOptimisticTailMessages", () => {
       ),
     ).toEqual([persistedUser, historyAssistant]);
   });
+
+  it("keeps an idempotency-marked queued turn while history is stale", () => {
+    const persistedUser = {
+      role: "user",
+      content: [{ type: "text", text: "first" }],
+      __openclaw: { seq: 1 },
+    };
+    const materializedQueuedUser = {
+      role: "user",
+      content: [{ type: "text", text: "steered follow-up" }],
+      timestamp: 10,
+      __openclaw: { idempotencyKey: "steer-run:user" },
+    };
+
+    expect(
+      preserveOptimisticTailMessages([persistedUser], [persistedUser, materializedQueuedUser]),
+    ).toEqual([persistedUser, materializedQueuedUser]);
+  });
 });

--- a/ui/src/pages/chat/history-merge.ts
+++ b/ui/src/pages/chat/history-merge.ts
@@ -2,12 +2,16 @@ import { extractText } from "../../lib/chat/message-extract.ts";
 import { normalizeLowercaseStringOrEmpty } from "../../lib/string-coerce.ts";
 
 function hasTranscriptMeta(message: unknown): boolean {
-  return Boolean(
-    message &&
-    typeof message === "object" &&
-    (message as { __openclaw?: unknown })["__openclaw"] &&
-    typeof (message as { __openclaw?: unknown })["__openclaw"] === "object",
-  );
+  if (!message || typeof message !== "object") {
+    return false;
+  }
+  const metadata = (message as { __openclaw?: unknown })["__openclaw"];
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+    return false;
+  }
+  // An idempotency marker alone identifies a locally materialized queued turn;
+  // authoritative transcript metadata adds identity, sequence, or kind fields.
+  return Object.keys(metadata).some((key) => key !== "idempotencyKey");
 }
 
 export function readTranscriptSequence(message: unknown): number | null {

--- a/ui/src/pages/chat/queued-user-turn.ts
+++ b/ui/src/pages/chat/queued-user-turn.ts
@@ -1,5 +1,6 @@
 import type { ChatAttachment, ChatQueueItem } from "../../lib/chat/chat-types.ts";
 import { visibleSessionMatches, type SessionScopeHost } from "../../lib/sessions/index.ts";
+import { getChatAttachmentDataUrl } from "./attachment-payload-store.ts";
 import {
   appendChatMessageToCache,
   readChatMessagesFromCache,
@@ -42,12 +43,16 @@ function durableDeliveredAttachments(
   attachments: readonly ChatAttachment[] | undefined,
 ): ChatAttachment[] | undefined {
   return attachments?.flatMap((attachment) => {
-    if (!attachment.dataUrl) {
+    // Composer uploads keep their bytes in the payload store; queue rows carry
+    // metadata only. Resolve through the store or attachment-only turns
+    // materialize empty and vanish at chip retirement.
+    const dataUrl = getChatAttachmentDataUrl(attachment);
+    if (!dataUrl) {
       return [];
     }
     // Terminal retirement releases the queue-owned live blob. Pin synthetic
     // transcript content to durable bytes before that ownership ends.
-    return [{ ...attachment, previewUrl: attachment.dataUrl }];
+    return [{ ...attachment, dataUrl, previewUrl: dataUrl }];
   });
 }
 

--- a/ui/src/pages/chat/queued-user-turn.ts
+++ b/ui/src/pages/chat/queued-user-turn.ts
@@ -30,6 +30,11 @@ export function chatMessagesContainQueuedUserTurn(
     if (!message || typeof message !== "object" || Array.isArray(message)) {
       return false;
     }
+    // Only a user-role entry proves the queued turn is visible; an assistant
+    // entry can carry the same run's idempotency key and must not satisfy this.
+    if ((message as { role?: unknown }).role !== "user") {
+      return false;
+    }
     const marker = (message as { __openclaw?: unknown })["__openclaw"];
     const idempotencyKey =
       marker && typeof marker === "object" && !Array.isArray(marker)

--- a/ui/src/pages/chat/queued-user-turn.ts
+++ b/ui/src/pages/chat/queued-user-turn.ts
@@ -1,0 +1,104 @@
+import type { ChatAttachment, ChatQueueItem } from "../../lib/chat/chat-types.ts";
+import { visibleSessionMatches, type SessionScopeHost } from "../../lib/sessions/index.ts";
+import {
+  appendChatMessageToCache,
+  readChatMessagesFromCache,
+  type ChatMessageCache,
+} from "./session-message-cache.ts";
+import { buildUserChatMessageContentBlocks } from "./user-message-content.ts";
+
+type QueuedUserTurnHost = SessionScopeHost & {
+  sessionKey: string;
+  chatMessages: unknown[];
+  chatMessagesBySession?: ChatMessageCache;
+};
+
+function queuedUserTurnIdempotencyKeys(item: ChatQueueItem): string[] {
+  return item.sendRunId ? [item.sendRunId, `${item.sendRunId}:user`] : [];
+}
+
+export function chatMessagesContainQueuedUserTurn(
+  messages: readonly unknown[],
+  item: ChatQueueItem,
+): boolean {
+  const idempotencyKeys = queuedUserTurnIdempotencyKeys(item);
+  if (idempotencyKeys.length === 0) {
+    return false;
+  }
+  return messages.some((message) => {
+    if (!message || typeof message !== "object" || Array.isArray(message)) {
+      return false;
+    }
+    const marker = (message as { __openclaw?: unknown })["__openclaw"];
+    const idempotencyKey =
+      marker && typeof marker === "object" && !Array.isArray(marker)
+        ? (marker as { idempotencyKey?: unknown }).idempotencyKey
+        : undefined;
+    return typeof idempotencyKey === "string" && idempotencyKeys.includes(idempotencyKey);
+  });
+}
+
+function durableDeliveredAttachments(
+  attachments: readonly ChatAttachment[] | undefined,
+): ChatAttachment[] | undefined {
+  return attachments?.flatMap((attachment) => {
+    if (!attachment.dataUrl) {
+      return [];
+    }
+    // Terminal retirement releases the queue-owned live blob. Pin synthetic
+    // transcript content to durable bytes before that ownership ends.
+    return [{ ...attachment, previewUrl: attachment.dataUrl }];
+  });
+}
+
+export function preserveQueuedUserTurn(state: QueuedUserTurnHost, item: ChatQueueItem): void {
+  const runId = item.sendRunId;
+  const sessionKey = item.sessionKey ?? state.sessionKey;
+  if (!runId) {
+    return;
+  }
+  const content = buildUserChatMessageContentBlocks(
+    item.text,
+    durableDeliveredAttachments(item.attachments),
+  );
+  if (!content.length) {
+    return;
+  }
+  const userMessage = {
+    role: "user",
+    content,
+    timestamp: item.createdAt,
+    __openclaw: { idempotencyKey: `${runId}:user` },
+  };
+  if (visibleSessionMatches(state, sessionKey, item.agentId)) {
+    if (!chatMessagesContainQueuedUserTurn(state.chatMessages, item)) {
+      state.chatMessages = [...state.chatMessages, userMessage];
+    }
+    return;
+  }
+  if (!state.chatMessagesBySession) {
+    return;
+  }
+  const target = { sessionKey, agentId: item.agentId };
+  const cached = readChatMessagesFromCache(state.chatMessagesBySession, state, target);
+  if (!chatMessagesContainQueuedUserTurn(cached, item)) {
+    appendChatMessageToCache(state.chatMessagesBySession, state, target, userMessage);
+  }
+}
+
+export function preserveSteeredQueueItemsForRun(
+  state: QueuedUserTurnHost & { chatQueue: ChatQueueItem[] },
+  runId: string | undefined,
+): void {
+  if (!runId) {
+    return;
+  }
+  for (const item of state.chatQueue) {
+    // sendState marks an in-flight steer whose chat.send has not been
+    // acknowledged; materializing it here would leave a phantom user turn if
+    // the Gateway rejects the send.
+    if (item.kind === "steered" && item.pendingRunId === runId && !item.sendState) {
+      preserveQueuedUserTurn(state, item);
+    }
+  }
+}


### PR DESCRIPTION
## What Problem This Solves

Typing a message in the Control UI composer while the agent is working briefly shows the "steering" state, then the message vanishes from the UI entirely — it reappears only after a much later full history reload. Reported live on team chat (dashboard session on a Hetzner gateway box); the gateway side is fine (the steered turn eventually lands in the transcript), so the user's text has no visible copy for the whole gap.

## Why This Change Was Made

The steer path (`sendQueuedChatMessageWithQueueMode`) removes the durable queue row the moment `chat.send` is acked, and only restored the visible "steered" chip when the tab-local `chatRunId` was adopted before the steer *and* unchanged after the round-trip. That never holds for runs started by automations, other clients, or tabs opened mid-run (`hasAbortableSessionRun` is true from the session row while `chatRunId` is null), so the chip was deterministically dropped. Three compounding defects:

- the steer send generated a throwaway wire `runId` instead of reusing the row's `sendRunId`, so the existing delivered-turn/history-proof machinery could never correlate steered rows;
- the chip was cleared at run end even when the steered turn had not reached the transcript yet;
- `preserveDeliveredQueuedUserTurn` only materialized stored outbox rows, which the steer path had already deleted.

The fix enforces one invariant: from submit until the transcript contains the steered text, some visible copy always exists (queue row → steering state → steered chip → materialized user turn). Steer sends now reuse the row's `sendRunId` as the wire idempotency key; the chip is restored after every accepted ack (keyed to the active run, or to the steer's own gateway lifecycle when the tab never adopted a run id); terminal events materialize acknowledged chips into the transcript before clearing them; stale history reloads keep idempotency-marked local turns; and in-flight (unacknowledged) steers are never materialized so a rejected send cannot leave a phantom turn that a retry would duplicate.

## User Impact

Steered messages stay visible as a "Steered" chip from the moment the gateway accepts them until the transcript contains the turn — no more vanishing composer input while the agent is busy. Known bounded tradeoff: in the previously-broken scenario the chip can briefly coexist with the history copy of the same turn until the steer's own terminal event retires it; strictly better than a gap.

## Evidence

- New regressions in `ui/src/pages/chat/chat-send.test.ts`: session-row-only steer keeps the chip after the ack (previously failed), wire idempotencyKey === row `sendRunId`, chip restored when its pending copy disappears pre-ack (flipped from asserting the vanish), terminal event materializes both the run's original queued turn and its steered follow-up in order, and an unacknowledged steer whose run terminates mid-request is never materialized (phantom guard).
- `ui/src/pages/chat/history-merge.test.ts`: idempotency-marked local turns survive stale history reloads.
- Focused proof: `node scripts/run-vitest.mjs ui/src/pages/chat/chat-send.test.ts ui/src/pages/chat/chat-view.test.ts ui/src/pages/chat/chat-thread.test.ts ui/src/pages/chat/history-merge.test.ts` → 4 files, 520 tests passed.
- Structured review (Codex `gpt-5.6-sol`, 4 rounds): two accepted findings fixed with regression tests (steered chip masking the run's original queued turn; phantom turn from materializing unacknowledged steers). Remaining round-4 reports verified not reachable: terminal-failure acks return via the restore path before the chip re-add, and the late-`ok` ordering blip self-heals via the immediate authoritative history reload its own branch triggers.


### Live proof & review follow-through

- Mantis Control UI web chat proof (candidate `d4aafd48970`, scenario `web-ui-chat-proof`): **pass** — screenshot, recording, and raw QA artifacts in https://github.com/openclaw/openclaw/pull/111540#issuecomment-5017550018 (run https://github.com/openclaw/openclaw/actions/runs/29705394688).
- ClawSweeper rank-up moves applied: preserved-turn detection now matches user-role entries only, with an assistant-carries-run-key regression test (`d4aafd48970`); live UI proof attached via the prescribed Mantis capture above.
- Codex connector inline finding applied: steered attachment payloads resolve through the payload store so attachment-only steers materialize (`35555ae3718`).
