### PR TITLE
fix(telegram): honor linkPreview:false on draft-stream send/edit (#111525)

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch-draft.ts
+++ b/extensions/telegram/src/bot-message-dispatch-draft.ts
@@ -127,6 +127,7 @@ export function createTelegramDraftController(params: {
           replyToMessageId: params.draftReplyToMessageId,
           replyToMode: params.replyToMode,
           richMessages: params.telegramCfg.richMessages,
+          linkPreview: params.telegramCfg.linkPreview,
           minInitialChars: params.streamMode === "progress" ? 0 : DRAFT_MIN_INITIAL_CHARS,
           renderText: renderStreamText,
           onRetainedPage: (page) => {

--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -101,11 +101,7 @@ function expectPreviewEdit(
   text: string,
   params?: Record<string, unknown>,
 ) {
-  if (params) {
-    expect(api.editMessageText).toHaveBeenCalledWith(123, 17, text, params);
-    return;
-  }
-  expect(api.editMessageText).toHaveBeenCalledWith(123, 17, text);
+  expect(api.editMessageText).toHaveBeenCalledWith(123, 17, text, params);
 }
 
 function createForceNewMessageHarness(params: { throttleMs?: number } = {}) {
@@ -277,7 +273,7 @@ describe("createTelegramDraftStream", () => {
 
     expect(messageId).toBe(17);
     // The window message is EDITED into the bar, never deleted (no focus-jump).
-    expect(api.editMessageText).toHaveBeenCalledWith(123, 17, "🛠️ 1 tool call · ⏱️ 1s");
+    expect(api.editMessageText).toHaveBeenCalledWith(123, 17, "🛠️ 1 tool call · ⏱️ 1s", undefined);
     expect(api.deleteMessage).not.toHaveBeenCalled();
   });
 
@@ -854,7 +850,7 @@ describe("createTelegramDraftStream", () => {
     await stream.flush();
 
     expect(api.editMessageText).toHaveBeenCalledTimes(2);
-    expect(api.editMessageText).toHaveBeenLastCalledWith(123, 17, "Hello more");
+    expect(api.editMessageText).toHaveBeenLastCalledWith(123, 17, "Hello more", undefined);
     expect(warn).not.toHaveBeenCalled();
   });
 
@@ -877,7 +873,7 @@ describe("createTelegramDraftStream", () => {
     await stream.flush();
 
     expect(api.editMessageText).toHaveBeenCalledTimes(2);
-    expect(api.editMessageText).toHaveBeenLastCalledWith(123, 17, "Hello again");
+    expect(api.editMessageText).toHaveBeenLastCalledWith(123, 17, "Hello again", undefined);
     expect(stream.lastDeliveredText?.()).toBe("Hello again");
   });
 
@@ -905,7 +901,7 @@ describe("createTelegramDraftStream", () => {
       await stream.flush();
 
       expect(api.editMessageText).toHaveBeenCalledTimes(2);
-      expect(api.editMessageText).toHaveBeenLastCalledWith(123, 17, "Hello more");
+      expect(api.editMessageText).toHaveBeenLastCalledWith(123, 17, "Hello more", undefined);
     } finally {
       vi.useRealTimers();
     }
@@ -938,7 +934,7 @@ describe("createTelegramDraftStream", () => {
       await stopPromise;
 
       expect(api.editMessageText).toHaveBeenCalledTimes(2);
-      expect(api.editMessageText).toHaveBeenLastCalledWith(123, 17, "Hello final");
+      expect(api.editMessageText).toHaveBeenLastCalledWith(123, 17, "Hello final", undefined);
     } finally {
       vi.useRealTimers();
     }
@@ -1084,7 +1080,7 @@ describe("createTelegramDraftStream", () => {
     expect(api.editMessageText).toHaveBeenNthCalledWith(1, 123, 17, "<b>Done &lt;&amp;&gt;</b>", {
       parse_mode: "HTML",
     });
-    expect(api.editMessageText).toHaveBeenNthCalledWith(2, 123, 17, "Done <&>");
+    expect(api.editMessageText).toHaveBeenNthCalledWith(2, 123, 17, "Done <&>", undefined);
     expect(stream.currentMessageSnapshot?.()).toEqual({
       text: "Done <&>",
       sourceText: "Done &lt;&amp;&gt;",
@@ -1791,6 +1787,175 @@ describe("createTelegramDraftStream", () => {
     expect(requireSendMessageCallText(api, 0).length).toBeLessThanOrEqual(100);
     expect(api.editMessageText).not.toHaveBeenCalled();
     expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("sends link_preview_options when linkPreview is false", async () => {
+    const api = createMockDraftApi();
+    const stream = createDraftStream(api, { linkPreview: false });
+
+    stream.update("Hello https://example.com");
+    await stream.flush();
+
+    expectPreviewSend(api, "Hello https://example.com", {
+      link_preview_options: { is_disabled: true },
+    });
+  });
+
+  it("edits with link_preview_options when linkPreview is false", async () => {
+    const api = createMockDraftApi();
+    const stream = createDraftStream(api, { linkPreview: false });
+
+    stream.update("First https://example.com");
+    await stream.flush();
+    stream.update("Second https://example.org");
+    await stream.flush();
+
+    expectPreviewEdit(api, "Second https://example.org", {
+      link_preview_options: { is_disabled: true },
+    });
+  });
+
+  it("omits link_preview_options from sendMessage when linkPreview is not set", async () => {
+    const api = createMockDraftApi();
+    const stream = createDraftStream(api);
+
+    stream.update("Hello https://example.com");
+    await stream.flush();
+
+    const call = api.sendMessage.mock.calls[0]!;
+    expect(call[2]).not.toHaveProperty("link_preview_options");
+  });
+
+  it("omits link_preview_options from sendMessage when linkPreview is true", async () => {
+    const api = createMockDraftApi();
+    const stream = createDraftStream(api, { linkPreview: true });
+
+    stream.update("Hello https://example.com");
+    await stream.flush();
+
+    const call = api.sendMessage.mock.calls[0]!;
+    expect(call[2]).not.toHaveProperty("link_preview_options");
+  });
+
+  it("includes link_preview_options in HTML send and edit params when linkPreview is false", async () => {
+    const api = createMockDraftApi();
+    const stream = createDraftStream(api, {
+      linkPreview: false,
+      renderText: (text) => ({ text: `<b>${text}</b>`, parseMode: "HTML" }),
+    });
+
+    stream.update("Hello https://example.com");
+    await stream.flush();
+
+    expect(api.sendMessage).toHaveBeenCalledWith(123, "<b>Hello https://example.com</b>", {
+      parse_mode: "HTML",
+      link_preview_options: { is_disabled: true },
+    });
+
+    stream.update("Again https://example.org");
+    await stream.flush();
+
+    expect(api.editMessageText).toHaveBeenCalledWith(123, 17, "<b>Again https://example.org</b>", {
+      parse_mode: "HTML",
+      link_preview_options: { is_disabled: true },
+    });
+  });
+
+  it("includes link_preview_options in rich send params when linkPreview is false", async () => {
+    const api = createMockDraftApi();
+    const stream = createDraftStream(api, { richMessages: true, linkPreview: false });
+
+    stream.update("## Hello https://example.com");
+    await stream.flush();
+
+    expect(api.sendMessage).not.toHaveBeenCalled();
+    const call = api.raw.sendRichMessage.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(call?.link_preview_options).toEqual({ is_disabled: true });
+  });
+
+  it("includes link_preview_options in HTML plain fallback send when linkPreview is false", async () => {
+    const api = createMockDraftApi();
+    api.sendMessage
+      .mockRejectedValueOnce(new Error("can't parse entities: unsupported tag"))
+      .mockResolvedValueOnce({ message_id: 17 });
+    const stream = createDraftStream(api, {
+      linkPreview: false,
+      renderText: (text) => ({ text: `<b>${text}</b>`, parseMode: "HTML" }),
+    });
+
+    stream.update("Hello https://example.com");
+    await stream.flush();
+
+    expect(api.sendMessage).toHaveBeenNthCalledWith(1, 123, "<b>Hello https://example.com</b>", {
+      parse_mode: "HTML",
+      link_preview_options: { is_disabled: true },
+    });
+    expect(api.sendMessage).toHaveBeenNthCalledWith(2, 123, "Hello https://example.com", {
+      link_preview_options: { is_disabled: true },
+    });
+  });
+
+  it("includes link_preview_options in HTML plain fallback edit when linkPreview is false", async () => {
+    const api = createMockDraftApi();
+    const stream = createDraftStream(api, {
+      linkPreview: false,
+      renderText: (text) => ({ text: `<b>${text}</b>`, parseMode: "HTML" }),
+    });
+
+    stream.update("First https://example.com");
+    await stream.flush();
+
+    api.editMessageText
+      .mockRejectedValueOnce(new Error("can't parse entities: unsupported tag"))
+      .mockResolvedValueOnce(true);
+    stream.update("Again https://example.org");
+    await stream.flush();
+
+    expect(api.editMessageText).toHaveBeenNthCalledWith(
+      1,
+      123,
+      17,
+      "<b>Again https://example.org</b>",
+      { parse_mode: "HTML", link_preview_options: { is_disabled: true } },
+    );
+    expect(api.editMessageText).toHaveBeenNthCalledWith(2, 123, 17, "Again https://example.org", {
+      link_preview_options: { is_disabled: true },
+    });
+  });
+
+  it("includes link_preview_options in rich plain fallback send when linkPreview is false", async () => {
+    const api = createMockDraftApi();
+    api.raw.sendRichMessage.mockRejectedValueOnce(
+      new Error("400: Bad Request: RICH_MESSAGE_URL_INVALID"),
+    );
+    const stream = createDraftStream(api, { richMessages: true, linkPreview: false });
+
+    stream.update("## Hello https://example.com");
+    await stream.flush();
+
+    expect(api.raw.sendRichMessage).toHaveBeenCalledTimes(1);
+    expect(api.sendMessage).toHaveBeenCalledWith(123, expect.any(String), {
+      link_preview_options: { is_disabled: true },
+    });
+  });
+
+  it("includes link_preview_options in rich plain fallback edit when linkPreview is false", async () => {
+    const api = createMockDraftApi();
+    api.raw.editMessageText.mockRejectedValueOnce(
+      new Error("400: Bad Request: RICH_MESSAGE_URL_INVALID"),
+    );
+    const stream = createDraftStream(api, { richMessages: true, linkPreview: false });
+
+    stream.update("## First https://example.com");
+    await stream.flush();
+
+    stream.update("## Again https://example.org");
+    await stream.flush();
+
+    expect(api.raw.editMessageText).toHaveBeenCalledTimes(1);
+    expect(api.editMessageText).toHaveBeenCalledWith(123, 17, expect.any(String), {
+      link_preview_options: { is_disabled: true },
+    });
   });
 });
 

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -233,6 +233,7 @@ export function createTelegramDraftStream(params: {
   replyToMessageId?: number;
   replyToMode?: ReplyToMode;
   richMessages?: boolean;
+  linkPreview?: boolean;
   throttleMs?: number;
   /** Minimum chars before sending first message (debounce for push notifications) */
   minInitialChars?: number;
@@ -375,6 +376,10 @@ export function createTelegramDraftStream(params: {
     page: PlannedTelegramDraftPage,
     sendGeneration: number,
   ): Promise<boolean> => {
+    const linkPreviewOptions =
+      params.linkPreview === false
+        ? { link_preview_options: { is_disabled: true } as const }
+        : undefined;
     const targetMessageId = streamMessageId;
     if (typeof targetMessageId === "number") {
       streamVisibleSinceMs ??= Date.now();
@@ -401,23 +406,34 @@ export function createTelegramDraftStream(params: {
           if (!fallbackPlan) {
             throw err;
           }
-          await params.api.editMessageText(chatId, targetMessageId, fallbackPlan.plainText);
+          await params.api.editMessageText(
+            chatId,
+            targetMessageId,
+            fallbackPlan.plainText,
+            linkPreviewOptions,
+          );
           acceptedSnapshot = fallbackSnapshot(fallbackPlan.plainText);
         }
       } else if (page.sourceTextMode === "html") {
         try {
           await params.api.editMessageText(chatId, targetMessageId, page.sourceText, {
             parse_mode: "HTML" as const,
+            ...linkPreviewOptions,
           });
         } catch (err) {
           if (!isTelegramHtmlParseError(err)) {
             throw err;
           }
-          await params.api.editMessageText(chatId, targetMessageId, page.text);
+          await params.api.editMessageText(chatId, targetMessageId, page.text, linkPreviewOptions);
           acceptedSnapshot = fallbackSnapshot(page.text);
         }
       } else {
-        await params.api.editMessageText(chatId, targetMessageId, page.sourceText);
+        await params.api.editMessageText(
+          chatId,
+          targetMessageId,
+          page.sourceText,
+          linkPreviewOptions,
+        );
       }
       if (sendGeneration === generation && streamMessageId === targetMessageId) {
         streamMessageSnapshot = acceptedSnapshot;
@@ -426,9 +442,12 @@ export function createTelegramDraftStream(params: {
     }
     messageSendAttempted = true;
     const sendMessageParams = reserveReplyTargetForSend(sendGeneration);
+    const finalSendMessageParams = linkPreviewOptions
+      ? { ...sendMessageParams, ...linkPreviewOptions }
+      : sendMessageParams;
     let sent: Awaited<ReturnType<typeof sendPlannedMessage>>;
     try {
-      sent = await sendPlannedMessage(page, sendMessageParams);
+      sent = await sendPlannedMessage(page, finalSendMessageParams);
     } catch (err) {
       const definitelyRejected = isSafeToRetrySendError(err) || isTelegramClientRejection(err);
       if (sendGeneration === generation && definitelyRejected) {


### PR DESCRIPTION

Closes #111525

## What Problem This Solves

Fixes an issue where users who configure `channels.telegram.linkPreview: false` would still see Telegram link preview cards on streamed (draft) replies, even though non-streamed replies correctly suppressed them. The preview persisted because the streaming path never passed `link_preview_options` to Telegram's API.

## Why This Change Was Made

The draft-stream funnel (`createTelegramDraftStream`) was created before the `linkPreview` config option existed and was never retrofitted. All other Telegram send/edit paths (durable send, durable edit, rich message send, native command delivery) already honor the flag via `link_preview_options: { is_disabled: true }` on plain/HTML calls or `skip_entity_detection` on rich messages.

The fix threads the existing `telegramCfg.linkPreview` boolean into `createTelegramDraftStream` and applies `link_preview_options` to every internal `sendMessage` and `editMessageText` call when the flag is `false`, covering all branches: initial send, incremental edits, rich-message fallback, HTML parse-error fallback, and finalization. Rich messages were already correct via the renderer's `skipEntityDetection` and require no change.

Non-goals: no config surface changes, no new API, no behavioral change when `linkPreview` is unset or `true`.

## User Impact

Users with `channels.telegram.linkPreview: false` can now rely on link previews being suppressed on all Telegram replies, regardless of whether draft streaming is enabled. This closes the last remaining gap in the `linkPreview` coverage across the Telegram send funnel.

## Evidence

- **94/94** draft-stream unit tests pass (84 existing + 10 new `linkPreview` coverage tests)
- **10/10** draft-finalization tests pass
- **19/19** delivery-basics tests pass
- **25/25** progress-rendering tests pass
- **74/74** bot delivery tests pass (including existing `link_preview_options` assertions)

### Test coverage matrix (all on `linkPreview: false`)

| Code path | API call pattern | Covered |
|---|---|---|
| Plain text send | `api.sendMessage(chatId, text, finalSendMessageParams)` | ✅ |
| Plain text edit | `api.editMessageText(chatId, msgId, text, linkPreviewOptions)` | ✅ |
| HTML send | `{ parse_mode: "HTML", ...finalSendMessageParams }` | ✅ |
| HTML edit | `{ parse_mode: "HTML", ...linkPreviewOptions }` | ✅ |
| Rich send | `raw.sendRichMessage({..., ...finalSendMessageParams})` | ✅ |
| HTML→plain fallback send | `api.sendMessage(chatId, text, finalSendMessageParams)` | ✅ |
| HTML→plain fallback edit | `api.editMessageText(chatId, msgId, text, linkPreviewOptions)` | ✅ |
| Rich→plain fallback send | `api.sendMessage(chatId, text, finalSendMessageParams)` | ✅ |
| Rich→plain fallback edit | `api.editMessageText(chatId, msgId, text, linkPreviewOptions)` | ✅ |

All 9 `linkPreviewOptions` distribution patterns (positional 4th arg, spread into params, send-params merge) are tested across both primary and error-recovery fallback paths.

- All changes are additive: when `linkPreview` is `undefined` or `true`, the generated Telegram API calls are byte-identical to before (the 4th argument to `editMessageText` is `undefined`, which grammY treats identically to omission)
- Historical precedent: this is the same class and pattern as the earlier `fix(telegram): honor linkPreview on fallback (#1730)`, which addressed the same gap in the durable-send fallback path

---

This PR is AI-assisted. Analysis, implementation, and testing were performed using opencode with review by the author. The author confirms understanding of the code and its behavior.
