### PR TITLE
fix(telegram): honor linkPreview:false on draft-stream replies

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch-draft.ts
+++ b/extensions/telegram/src/bot-message-dispatch-draft.ts
@@ -127,6 +127,9 @@ export function createTelegramDraftController(params: {
           replyToMessageId: params.draftReplyToMessageId,
           replyToMode: params.replyToMode,
           richMessages: params.telegramCfg.richMessages,
+          // Stream path must honor the same config as durable send; otherwise
+          // in-place finals keep URL unfurls when linkPreview is false.
+          linkPreview: params.telegramCfg.linkPreview,
           minInitialChars: params.streamMode === "progress" ? 0 : DRAFT_MIN_INITIAL_CHARS,
           renderText: renderStreamText,
           onRetainedPage: (page) => {

--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -1912,5 +1912,71 @@ describe("draft stream initial message debounce", () => {
       expectPreviewSend(api, "Hi");
     });
   });
+
+  describe("linkPreview: false", () => {
+    const disabledPreview = {
+      link_preview_options: { is_disabled: true },
+    };
+
+    it("disables link previews on initial send and every subsequent edit", async () => {
+      const api = createMockDraftApi();
+      const stream = createDraftStream(api, { linkPreview: false, throttleMs: 250 });
+
+      stream.update("See https://example.com/a");
+      await stream.flush();
+      expectPreviewSend(api, "See https://example.com/a", disabledPreview);
+
+      stream.update("See https://example.com/a and https://example.com/b");
+      await stream.flush();
+      expectPreviewEdit(
+        api,
+        "See https://example.com/a and https://example.com/b",
+        disabledPreview,
+      );
+    });
+
+    it("merges disabled preview into HTML send and edit params", async () => {
+      const api = createMockDraftApi();
+      const stream = createDraftStream(api, {
+        linkPreview: false,
+        throttleMs: 250,
+        renderText: (text) => ({
+          text,
+          parseMode: "HTML",
+          markdownSource: { text },
+        }),
+      });
+
+      stream.update("See https://example.com/html");
+      await stream.flush();
+
+      await vi.waitFor(() => expect(api.sendMessage).toHaveBeenCalledTimes(1));
+      const sendParams = api.sendMessage.mock.calls[0]?.[2] as Record<string, unknown>;
+      expect(sendParams).toMatchObject({
+        parse_mode: "HTML",
+        ...disabledPreview,
+      });
+
+      stream.update("See https://example.com/html-edit");
+      await stream.flush();
+      await vi.waitFor(() => expect(api.editMessageText).toHaveBeenCalled());
+      const editParams = api.editMessageText.mock.calls[0]?.[3] as Record<string, unknown>;
+      expect(editParams).toMatchObject({
+        parse_mode: "HTML",
+        ...disabledPreview,
+      });
+    });
+
+    it("does not attach link_preview_options when linkPreview is true", async () => {
+      const api = createMockDraftApi();
+      const stream = createDraftStream(api, { linkPreview: true, throttleMs: 250 });
+
+      stream.update("See https://example.com/enabled");
+      await stream.flush();
+      expectPreviewSend(api, "See https://example.com/enabled");
+      const sendParams = api.sendMessage.mock.calls[0]?.[2] as Record<string, unknown> | undefined;
+      expect(sendParams ?? {}).not.toHaveProperty("link_preview_options");
+    });
+  });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -233,6 +233,13 @@ export function createTelegramDraftStream(params: {
   replyToMessageId?: number;
   replyToMode?: ReplyToMode;
   richMessages?: boolean;
+  /**
+   * Mirrors `channels.telegram.linkPreview` (default enabled). When false, every
+   * draft send/edit must pass `link_preview_options.is_disabled` — omitting it on
+   * edit re-enables the unfurl server-side, which is why streamed finals kept cards
+   * even though durable send already honored the flag.
+   */
+  linkPreview?: boolean;
   throttleMs?: number;
   /** Minimum chars before sending first message (debounce for push notifications) */
   minInitialChars?: number;
@@ -249,6 +256,13 @@ export function createTelegramDraftStream(params: {
   const throttleMs = Math.max(250, params.throttleMs ?? DEFAULT_THROTTLE_MS);
   const minInitialChars = params.minInitialChars;
   const chatId = params.chatId;
+  // Same contract as durable send: only attach disable options when false.
+  const linkPreviewParams =
+    params.linkPreview === false
+      ? { link_preview_options: { is_disabled: true as const } }
+      : undefined;
+  const withLinkPreview = <T extends Record<string, unknown>>(base: T) =>
+    linkPreviewParams ? { ...base, ...linkPreviewParams } : base;
   const threadParams = buildTelegramThreadParams(params.thread);
   const replyToMessageId = normalizeTelegramReplyToMessageId(params.replyToMessageId);
   const initialSendMessageParams =
@@ -316,6 +330,9 @@ export function createTelegramDraftStream(params: {
     page: PlannedTelegramDraftPage,
     sendMessageParams: ReturnType<typeof reserveReplyTargetForSend>,
   ) => {
+    // Thread/reply bag plus optional preview-disable; rich raw API has no
+    // link_preview_options field (skip_entity_detection owns that path).
+    const plainSendParams = withLinkPreview({ ...sendMessageParams });
     if (page.richMessage) {
       warnTelegramRichBlocksDegradations({
         context: "stream preview",
@@ -342,23 +359,27 @@ export function createTelegramDraftStream(params: {
           throw err;
         }
         return {
-          message: await params.api.sendMessage(chatId, fallbackPlan.plainText, sendMessageParams),
+          message: await params.api.sendMessage(chatId, fallbackPlan.plainText, plainSendParams),
           snapshot: fallbackSnapshot(fallbackPlan.plainText),
         };
       }
     }
     if (page.sourceTextMode !== "html") {
       return {
-        message: await params.api.sendMessage(chatId, page.text, sendMessageParams),
+        message: await params.api.sendMessage(chatId, page.text, plainSendParams),
         snapshot: page,
       };
     }
     try {
       return {
-        message: await params.api.sendMessage(chatId, page.sourceText, {
-          parse_mode: "HTML" as const,
-          ...sendMessageParams,
-        }),
+        message: await params.api.sendMessage(
+          chatId,
+          page.sourceText,
+          withLinkPreview({
+            parse_mode: "HTML" as const,
+            ...sendMessageParams,
+          }),
+        ),
         snapshot: page,
       };
     } catch (err) {
@@ -366,7 +387,7 @@ export function createTelegramDraftStream(params: {
         throw err;
       }
       return {
-        message: await params.api.sendMessage(chatId, page.text, sendMessageParams),
+        message: await params.api.sendMessage(chatId, page.text, plainSendParams),
         snapshot: fallbackSnapshot(page.text),
       };
     }
@@ -401,21 +422,47 @@ export function createTelegramDraftStream(params: {
           if (!fallbackPlan) {
             throw err;
           }
-          await params.api.editMessageText(chatId, targetMessageId, fallbackPlan.plainText);
+          // Plain fallback re-enters the ordinary edit path: re-apply disable.
+          if (linkPreviewParams) {
+            await params.api.editMessageText(
+              chatId,
+              targetMessageId,
+              fallbackPlan.plainText,
+              linkPreviewParams,
+            );
+          } else {
+            await params.api.editMessageText(chatId, targetMessageId, fallbackPlan.plainText);
+          }
           acceptedSnapshot = fallbackSnapshot(fallbackPlan.plainText);
         }
       } else if (page.sourceTextMode === "html") {
         try {
-          await params.api.editMessageText(chatId, targetMessageId, page.sourceText, {
-            parse_mode: "HTML" as const,
-          });
+          await params.api.editMessageText(
+            chatId,
+            targetMessageId,
+            page.sourceText,
+            withLinkPreview({
+              parse_mode: "HTML" as const,
+            }),
+          );
         } catch (err) {
           if (!isTelegramHtmlParseError(err)) {
             throw err;
           }
-          await params.api.editMessageText(chatId, targetMessageId, page.text);
+          if (linkPreviewParams) {
+            await params.api.editMessageText(chatId, targetMessageId, page.text, linkPreviewParams);
+          } else {
+            await params.api.editMessageText(chatId, targetMessageId, page.text);
+          }
           acceptedSnapshot = fallbackSnapshot(page.text);
         }
+      } else if (linkPreviewParams) {
+        await params.api.editMessageText(
+          chatId,
+          targetMessageId,
+          page.sourceText,
+          linkPreviewParams,
+        );
       } else {
         await params.api.editMessageText(chatId, targetMessageId, page.sourceText);
       }


### PR DESCRIPTION
Closes #111525

## What Problem This Solves

Fixes an issue where Telegram users with `channels.telegram.linkPreview: false` still saw link-preview cards on bot replies delivered via draft streaming. Non-streamed sends already suppressed previews; only the in-place stream path left unfurls visible.

## Why This Change Was Made

Thread the existing `linkPreview` config into `createTelegramDraftStream` and attach `link_preview_options: { is_disabled: true }` on every ordinary/HTML/plain draft `sendMessage` and `editMessageText` when previews are disabled. Omitting the field on edit re-enables the unfurl server-side, which is why finals that never needed a last edit kept the card. No new config keys; same policy and option shape as the durable send funnel. Rich streaming continues to use `skip_entity_detection` for entity auto-detection (rich Bot API has no `link_preview_options` field).

Compatibility: reuses `channels.telegram.linkPreview` only. Performance: one boolean resolve per stream, no extra I/O. Usability: stream path matches durable send for the same operator flag. Security: no secrets; only Telegram Bot API preview-disable options.

## User Impact

With `linkPreview: false`, draft-streamed Telegram replies no longer show link-preview cards on the initial stream message or subsequent in-place edits, matching non-streamed bot messages.

## Evidence

Verification host: local macOS (Crabbox bypass).

Focused suite (primary surface):

```text
node scripts/run-vitest.mjs extensions/telegram/src/draft-stream.test.ts
# Test Files  1 passed (1)
# Tests  87 passed (87)
```

New cases under `linkPreview: false` assert `link_preview_options: { is_disabled: true }` on initial send and every subsequent edit (plain + HTML), and that enabled/default paths still omit the field.

Static on touched files:

```text
git diff --check  # clean
oxfmt --check extensions/telegram/src/draft-stream.ts \
  extensions/telegram/src/draft-stream.test.ts \
  extensions/telegram/src/bot-message-dispatch-draft.ts  # ok
oxlint (same three files)  # 0 warnings, 0 errors
```

`pnpm check:changed` was started but exceeded a ~1h local phase budget while still running unrelated package lanes after extensions typecheck/lint of the touched files had already progressed; closeout used path-scoped static + the full focused suite above.

## Real behavior proof

- Behavior addressed: draft-stream Telegram send/edit must honor `channels.telegram.linkPreview: false` by disabling URL unfurls on the in-place stream message.
- Environment: local macOS openclaw checkout at branch `fix/111525-telegram-draft-stream-link-preview`, Vitest via `node scripts/run-vitest.mjs`.
- Current-main contrast: on main, `createTelegramDraftStream` accepts no `linkPreview` and never sets `link_preview_options`; durable `send.ts` / `delivery.send.ts` already do when disabled. Focused tests on this branch fail the new assertions if the option is omitted.
- Exact steps or command run after this patch:
  1. `node scripts/run-vitest.mjs extensions/telegram/src/draft-stream.test.ts -t "linkPreview"`
  2. `node scripts/run-vitest.mjs extensions/telegram/src/draft-stream.test.ts`
- Evidence after fix: three new tests pass — initial send and edits carry `{ link_preview_options: { is_disabled: true } }` when `linkPreview: false`; HTML send/edit merge `parse_mode` with the same option; `linkPreview: true` still omits the field. Full file: 87/87 green.
- Control check: only the draft-stream transport parameter bags are asserted; durable send tests remain the contract for non-stream paths; sibling cases in the same file still pass.
- Observed result after fix: stream factory and `createDraftLane` propagate `telegramCfg.linkPreview`; disabled previews attach on every plain/HTML send and edit branch used for in-place streaming.
- What was not tested: live Telegram client unfurl rendering (no live Telegram tenant in this proof run). Source-level parameter-bag coverage matches the ClawSweeper source-repro path; rich raw API has no `link_preview_options` field (entity skip remains the rich-path contract).

## AI disclosure

This PR was authored with AI assistance (Grok).
