### PR TITLE
fix(agents): preserve hatch for fresh named workspaces

### DIFF
--- a/src/agents/agent-create.integration.test.ts
+++ b/src/agents/agent-create.integration.test.ts
@@ -1,0 +1,40 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { expect, it } from "vitest";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { createOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { createAgent } from "./agent-create.js";
+import {
+  DEFAULT_IDENTITY_FILENAME,
+  ensureAgentWorkspace,
+  isWorkspaceBootstrapPending,
+} from "./workspace.js";
+
+it("keeps a fresh named workspace pending through the first run setup", async () => {
+  const state = await createOpenClawTestState({
+    layout: "state-only",
+    scenario: "minimal",
+    label: "named-agent-hatch",
+  });
+  const workspace = state.path("named-workspace");
+
+  try {
+    const created = await createAgent({ name: "Researcher", workspace });
+
+    expect(created).toMatchObject({ status: "created", bootstrapPending: true });
+    expect(await isWorkspaceBootstrapPending(workspace)).toBe(true);
+
+    const firstRunWorkspace = await ensureAgentWorkspace({
+      dir: workspace,
+      ensureBootstrapFiles: true,
+    });
+    expect(firstRunWorkspace.bootstrapPending).toBe(true);
+    expect(await isWorkspaceBootstrapPending(workspace)).toBe(true);
+    expect(
+      await fs.readFile(path.join(workspace, DEFAULT_IDENTITY_FILENAME), "utf8"),
+    ).not.toContain("Researcher");
+  } finally {
+    closeOpenClawStateDatabaseForTest();
+    await state.cleanup();
+  }
+});

--- a/src/agents/agent-create.test.ts
+++ b/src/agents/agent-create.test.ts
@@ -180,7 +180,25 @@ describe("createAgent", () => {
     expect(mocks.ensureAgentWorkspace).toHaveBeenCalledOnce();
   });
 
+  it("keeps the template identity while bootstrap is pending", async () => {
+    await createAgent({ name: "researcher" });
+
+    expect(mocks.rootRead).not.toHaveBeenCalled();
+    expect(mocks.rootWrite).not.toHaveBeenCalled();
+    expect(mocks.persisted).toMatchObject({
+      agents: {
+        list: expect.arrayContaining([
+          expect.objectContaining({ identity: { name: "researcher" } }),
+        ]),
+      },
+    });
+  });
+
   it("does not publish config when identity setup is unsafe", async () => {
+    mocks.ensureAgentWorkspace.mockImplementation(async ({ dir }: { dir: string }) => ({
+      dir,
+      bootstrapPending: false,
+    }));
     mocks.rootRead.mockRejectedValue(new FsSafeError("invalid-path", "unsafe identity path"));
 
     await expect(createAgent({ name: "researcher" })).resolves.toMatchObject({

--- a/src/agents/agent-create.ts
+++ b/src/agents/agent-create.ts
@@ -161,7 +161,11 @@ export async function createAgent(params: CreateAgentParams): Promise<CreateAgen
             });
           }
           await fs.mkdir(resolveSessionTranscriptsDirForAgent(agentId), { recursive: true });
-          await writeIdentityFile({ workspaceDir: workspace.dir, identity });
+          // A creation-time name is config, not proof that the fresh workspace hatched.
+          // Keep IDENTITY.md templated until BOOTSTRAP completes its first-turn ceremony.
+          if (!workspace.bootstrapPending) {
+            await writeIdentityFile({ workspaceDir: workspace.dir, identity });
+          }
 
           return {
             nextConfig,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users creating a named agent through the canonical creation flow, including Custodian, could have the fresh workspace treated as already hatched before its first turn. Creation wrote the configured name into `IDENTITY.md`; the next workspace ensure interpreted that profile divergence as legacy setup-completion evidence and removed `BOOTSTRAP.md`.

## Why This Change Was Made

The agent identity remains canonical in `agents.list[].identity`, but creation now leaves the workspace identity template untouched while bootstrap is pending. Established workspaces still receive identity-file updates, and the existing legacy-workspace recovery heuristic remains unchanged.

## User Impact

Fresh named agents now enter the expected first-turn hatch instead of silently skipping it. CLI, Gateway, and Custodian creation share the same corrected path.

## Evidence

- Before fix: the integration regression created a named agent, called the first-run workspace ensure, and observed `bootstrapPending: false` instead of `true`.
- Live CLI proof used an isolated state directory and the compiled production workspace ensure:

```text
$ openclaw agents add Researcher --non-interactive --workspace <tmp>/workspace --json
{"agentId":"researcher","name":"Researcher","workspace":"<tmp>/workspace"}

$ ensureAgentWorkspace({ dir: "<tmp>/workspace", ensureBootstrapFiles: true })
{"bootstrapPending":true,"identityPathCreated":false}
BOOTSTRAP_PRESENT_AFTER_ENSURE=yes
CONFIGURED_NAME_IN_IDENTITY_AFTER_ENSURE=no
```

- Focused local proof: `node scripts/run-vitest.mjs src/agents/agent-create.test.ts src/agents/agent-create.integration.test.ts` (11 tests passed).
- Blacksmith Testbox: core `pnpm tsgo`, targeted type-aware lint, and both focused test files passed in [run 29705532441](https://github.com/openclaw/openclaw/actions/runs/29705532441).
- Exact-head CI: [run 29705711089](https://github.com/openclaw/openclaw/actions/runs/29705711089) passed for `7956825e01720dd74fdb7b658b3945dc4f815a94`.
- Refreshed against current `main` at `6c25f5ae3354784ce4db703854c484a4feefc878`; intervening changes do not touch agent creation or workspace bootstrap, and fresh autoreview is clean with no accepted/actionable findings.

AI-assisted implementation; the patch and its behavior were reviewed and verified before submission.
