### PR TITLE
fix(doctor): repair active profile state reliably

### DIFF
--- a/src/commands/doctor-config-preflight.test.ts
+++ b/src/commands/doctor-config-preflight.test.ts
@@ -2,8 +2,9 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { applyCliProfileEnv } from "../cli/profile.js";
 import { promoteConfigSnapshotToLastKnownGood, readConfigFileSnapshot } from "../config/config.js";
-import { withTempHome, writeOpenClawConfig } from "../config/test-helpers.js";
+import { withEnvOverride, withTempHome, writeOpenClawConfig } from "../config/test-helpers.js";
 import { executeSqliteQueryTakeFirstSync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import {
@@ -29,6 +30,13 @@ function readConfigHealthRow(env: NodeJS.ProcessEnv, configPath: string) {
   );
 }
 
+async function writeLegacyConfig(home: string): Promise<string> {
+  const legacyPath = path.join(home, ".clawdbot", "clawdbot.json");
+  await fs.mkdir(path.dirname(legacyPath), { recursive: true });
+  await fs.writeFile(legacyPath, '{"gateway":{"mode":"local"}}\n', "utf-8");
+  return legacyPath;
+}
+
 describe("runDoctorConfigPreflight", () => {
   afterEach(() => {
     closeOpenClawStateDatabaseForTest();
@@ -46,6 +54,84 @@ describe("runDoctorConfigPreflight", () => {
       });
 
       expect(readConfigHealthRow({ ...process.env, HOME: home }, configPath)).toBeUndefined();
+    });
+  });
+
+  it("migrates legacy config into the active state directory", async () => {
+    await withTempHome(async (home) => {
+      await writeLegacyConfig(home);
+      const stateDir = await fs.realpath(await fs.mkdtemp(path.join(home, "custom-state-")));
+      const configPath = path.join(stateDir, "openclaw.json");
+      const defaultConfigPath = path.join(home, ".openclaw", "openclaw.json");
+
+      await withEnvOverride(
+        {
+          OPENCLAW_CONFIG_PATH: undefined,
+          OPENCLAW_PROFILE: undefined,
+          OPENCLAW_STATE_DIR: stateDir,
+        },
+        async () => {
+          const preflight = await runDoctorConfigPreflight({
+            migrateState: false,
+            invalidConfigNote: false,
+          });
+
+          expect(preflight.snapshot.path).toBe(configPath);
+          await expect(fs.readFile(configPath, "utf-8")).resolves.toContain('"mode":"local"');
+          await expect(fs.access(defaultConfigPath)).rejects.toMatchObject({ code: "ENOENT" });
+        },
+      );
+    });
+  });
+
+  it("migrates legacy config into an explicit config path", async () => {
+    await withTempHome(async (home) => {
+      await writeLegacyConfig(home);
+      const configRoot = await fs.realpath(await fs.mkdtemp(path.join(home, "custom-config-")));
+      const configPath = path.join(configRoot, "nested", "custom-openclaw.json");
+
+      await withEnvOverride(
+        {
+          OPENCLAW_CONFIG_PATH: configPath,
+          OPENCLAW_PROFILE: undefined,
+          OPENCLAW_STATE_DIR: undefined,
+        },
+        async () => {
+          const preflight = await runDoctorConfigPreflight({
+            migrateState: false,
+            invalidConfigNote: false,
+          });
+
+          expect(preflight.snapshot.path).toBe(configPath);
+          await expect(fs.readFile(configPath, "utf-8")).resolves.toContain('"mode":"local"');
+        },
+      );
+    });
+  });
+
+  it("migrates legacy config into the selected profile", async () => {
+    await withTempHome(async (home) => {
+      await writeLegacyConfig(home);
+      const profileStateDir = path.join(home, ".openclaw-work");
+      const configPath = path.join(profileStateDir, "openclaw.json");
+
+      await withEnvOverride(
+        {
+          OPENCLAW_CONFIG_PATH: undefined,
+          OPENCLAW_PROFILE: undefined,
+          OPENCLAW_STATE_DIR: undefined,
+        },
+        async () => {
+          applyCliProfileEnv({ profile: "work", homedir: () => home });
+          const preflight = await runDoctorConfigPreflight({
+            migrateState: false,
+            invalidConfigNote: false,
+          });
+
+          expect(preflight.snapshot.path).toBe(configPath);
+          await expect(fs.readFile(configPath, "utf-8")).resolves.toContain('"mode":"local"');
+        },
+      );
     });
   });
 

--- a/src/commands/doctor-config-preflight.ts
+++ b/src/commands/doctor-config-preflight.ts
@@ -12,6 +12,7 @@ import {
   recoverConfigFromLastKnownGood,
 } from "../config/io.js";
 import { formatConfigIssueLines } from "../config/issue-format.js";
+import { resolveCanonicalConfigPath } from "../config/paths.js";
 import type { ConfigFileSnapshot, LegacyConfigIssue } from "../config/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isTruthyEnvValue } from "../infra/env.js";
@@ -80,8 +81,8 @@ async function maybeMigrateLegacyConfig(): Promise<string[]> {
     return changes;
   }
 
-  const targetDir = path.join(home, ".openclaw");
-  const targetPath = path.join(targetDir, "openclaw.json");
+  const targetPath = resolveCanonicalConfigPath();
+  const targetDir = path.dirname(targetPath);
   try {
     await fs.access(targetPath);
     return changes;

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -155,7 +155,7 @@ export let STATE_DIR = resolveStateDir();
  * Can be overridden via OPENCLAW_CONFIG_PATH.
  * Default: ~/.openclaw/openclaw.json (or $OPENCLAW_STATE_DIR/openclaw.json)
  */
-function resolveCanonicalConfigPath(
+export function resolveCanonicalConfigPath(
   env: NodeJS.ProcessEnv = process.env,
   stateDir: string = resolveStateDir(env, envHomedir(env)),
 ): string {

--- a/src/infra/state-migrations.doctor.ts
+++ b/src/infra/state-migrations.doctor.ts
@@ -170,13 +170,13 @@ function describeStateSchemaMigration(migration: OpenClawStateDatabaseSchemaMigr
   return migration.kind satisfies never;
 }
 
-let autoMigrateChecked = false;
+const autoMigrateChecked = new Set<string>();
 
 const PLUGIN_DOCTOR_MIGRATION_LOCK_TIMEOUT_MS = 250;
 const PLUGIN_DOCTOR_MIGRATION_LOCK_POLL_INTERVAL_MS = 25;
 
 export function resetAutoMigrateLegacyStateForTest(): void {
-  autoMigrateChecked = false;
+  autoMigrateChecked.clear();
   resetAutoMigrateLegacyTaskStateSidecarsForTest();
   resetLegacySessionSurfacesForTest();
 }
@@ -1205,18 +1205,23 @@ export async function autoMigrateLegacyState(params: {
   warnings: string[];
   notices?: string[];
 }> {
-  if (autoMigrateChecked) {
+  const env = params.env ?? process.env;
+  const homedir = params.homedir ?? os.homedir;
+  const migrationMode = params.doctorOnlyStateMigrations === true ? "doctor-repair" : "automatic";
+  const initialStateDir = resolveStateDir(env, homedir);
+  const checkKey = `${path.resolve(initialStateDir)}\0${migrationMode}`;
+  if (autoMigrateChecked.has(checkKey)) {
     return { migrated: false, skipped: true, changes: [], warnings: [] };
   }
-  autoMigrateChecked = true;
+  autoMigrateChecked.add(checkKey);
 
-  const env = params.env ?? process.env;
   const stateDirResult = await autoMigrateLegacyStateDir({
     env,
-    homedir: params.homedir,
+    homedir,
     log: params.log,
   });
-  const stateDir = resolveStateDir(env, params.homedir ?? os.homedir);
+  const stateDir = resolveStateDir(env, homedir);
+  autoMigrateChecked.add(`${path.resolve(stateDir)}\0${migrationMode}`);
   const stateSchema = repairOpenClawStateDatabaseSchema({
     env: { ...env, OPENCLAW_STATE_DIR: stateDir },
   });

--- a/src/infra/state-migrations.test.ts
+++ b/src/infra/state-migrations.test.ts
@@ -596,6 +596,74 @@ describe("state migrations", () => {
     expect(migrateLegacyState).toHaveBeenCalledOnce();
   });
 
+  it("runs doctor-only repairs after the automatic migration check", async () => {
+    const root = await createTempDir();
+    const stateDir = path.join(root, ".openclaw");
+    const env = createEnv(stateDir);
+    const cfg = createConfig();
+    const detectLegacyState = vi.fn(() => ({ preview: ["doctor-only repair"] }));
+    const migrateLegacyState = vi.fn(() => ({
+      changes: ["doctor-only repair migrated"],
+      warnings: [],
+    }));
+    pluginDoctorStateMigrationEntries.entries = [
+      {
+        pluginId: "memory-core",
+        migration: {
+          id: "memory-core-doctor-only-latch-test",
+          label: "Memory Core doctor-only latch test",
+          doctorOnly: true,
+          detectLegacyState,
+          migrateLegacyState,
+        },
+      },
+    ];
+
+    const automatic = await autoMigrateLegacyState({ cfg, env, homedir: () => root });
+    expect(automatic.changes).not.toContain("doctor-only repair migrated");
+    expect(detectLegacyState).not.toHaveBeenCalled();
+
+    const repaired = await autoMigrateLegacyState({
+      cfg,
+      env,
+      homedir: () => root,
+      doctorOnlyStateMigrations: true,
+    });
+    expect(repaired.changes).toContain("doctor-only repair migrated");
+    expect(detectLegacyState).toHaveBeenCalledTimes(2);
+    expect(migrateLegacyState).toHaveBeenCalledOnce();
+  });
+
+  it("checks automatic migrations independently for each state directory", async () => {
+    const root = await createTempDir();
+    const stateDirs = [path.join(root, "state-a"), path.join(root, "state-b")];
+    const detectedStateDirs: string[] = [];
+    pluginDoctorStateMigrationEntries.entries = [
+      {
+        pluginId: "memory-core",
+        migration: {
+          id: "memory-core-state-dir-latch-test",
+          label: "Memory Core state-dir latch test",
+          detectLegacyState: ({ stateDir }) => {
+            detectedStateDirs.push(stateDir);
+            return null;
+          },
+          migrateLegacyState: () => ({ changes: [], warnings: [] }),
+        },
+      },
+    ];
+
+    for (const stateDir of stateDirs) {
+      await autoMigrateLegacyState({
+        cfg: createConfig(),
+        env: createEnv(stateDir),
+        homedir: () => root,
+      });
+    }
+
+    expect(new Set(detectedStateDirs)).toStrictEqual(new Set(stateDirs));
+  });
+
   it("detects legacy sessions, agent files, channel auth, and pairing state", () => {
     expect(detectionCase.targetAgentId).toBe("worker-1");
     expect(detectionCase.targetMainKey).toBe("desk");


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users running doctor with a custom state directory, explicit config path, or named profile could have legacy config migrated into the default location instead of the active one. It also fixes doctor-only state repairs being skipped after the process had already performed its automatic migration check.

## Why This Change Was Made

Doctor now uses the CLI's canonical config-path resolver for the migration target. The state-migration deduplication guard is scoped by resolved state directory and migration authority, so automatic checks remain deduplicated while explicit doctor repairs can still run.

No SQLite schema version, gateway protocol version, or public config surface changes are included.

## User Impact

`openclaw doctor` now migrates legacy configuration into the state/config location the user actually selected, including `OPENCLAW_STATE_DIR`, `OPENCLAW_CONFIG_PATH`, and `--profile`. Repair-only migrations also remain available after an automatic startup migration check in the same process.

## Evidence

- Regression proof: `src/commands/doctor-config-preflight.test.ts` (10 tests passed), covering custom state directory, explicit config path, and named profile targets.
- Regression proof: `src/config/paths.test.ts` (25 tests passed).
- Regression proof: `src/infra/state-migrations.test.ts` (55 tests passed), covering doctor-only repair after automatic checking and independent state roots.
- Remote Node 24 typecheck: `pnpm tsgo` passed on Blacksmith Testbox ([run 29705553955](https://github.com/openclaw/openclaw/actions/runs/29705553955)).
- Targeted formatting, lint, and `git diff --check` passed.
- Fresh autoreview reported no accepted/actionable findings after the final rebase.

AI-assisted: yes. The implementation and regression tests were reviewed and verified against the current source paths and migration contracts.
