### PR TITLE
fix(onboard): keep invalid wizard retries unpersisted

### DIFF
--- a/src/commands/auth-choice.apply.plugin-provider.test.ts
+++ b/src/commands/auth-choice.apply.plugin-provider.test.ts
@@ -256,7 +256,16 @@ describe("applyAuthChoiceLoadedPluginProvider", () => {
     ]);
     expect(upsertAuthProfile).not.toHaveBeenCalled();
 
-    await prepared?.persistAuthProfiles();
+    await prepared?.persistAuthProfiles([
+      {
+        profileId: LOCAL_PROFILE_ID,
+        credential: {
+          type: "api_key",
+          provider: LOCAL_PROVIDER_ID,
+          key: "refreshed-local-provider-key",
+        },
+      },
+    ]);
     await prepared?.persistAuthProfiles();
 
     expect(upsertAuthProfile).toHaveBeenCalledOnce();
@@ -265,7 +274,7 @@ describe("applyAuthChoiceLoadedPluginProvider", () => {
       credential: {
         type: "api_key",
         provider: LOCAL_PROVIDER_ID,
-        key: LOCAL_API_KEY,
+        key: "refreshed-local-provider-key",
       },
       agentDir: "/tmp/agent",
     });

--- a/src/commands/auth-choice.apply.plugin-provider.test.ts
+++ b/src/commands/auth-choice.apply.plugin-provider.test.ts
@@ -3,6 +3,7 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   applyAuthChoiceLoadedPluginProvider,
+  prepareAuthChoiceLoadedPluginProvider,
   runProviderPluginAuthMethod,
 } from "../plugins/provider-auth-choice.js";
 import type { ProviderPlugin } from "../plugins/types.js";
@@ -231,6 +232,43 @@ describe("applyAuthChoiceLoadedPluginProvider", () => {
       pluginId: entry?.pluginId ?? "missing-plugin",
       status: "skipped",
     }));
+  });
+
+  it("stages provider profiles until the caller commits them", async () => {
+    const provider = buildProvider();
+    resolvePluginProviders.mockReturnValue([provider]);
+    resolveProviderPluginChoice.mockReturnValue({
+      provider,
+      method: expectDefined(provider.auth[0], "provider.auth[0] test invariant"),
+    });
+
+    const prepared = await prepareAuthChoiceLoadedPluginProvider(buildParams());
+
+    expect(prepared?.authProfiles).toEqual([
+      {
+        profileId: LOCAL_PROFILE_ID,
+        credential: {
+          type: "api_key",
+          provider: LOCAL_PROVIDER_ID,
+          key: LOCAL_API_KEY,
+        },
+      },
+    ]);
+    expect(upsertAuthProfile).not.toHaveBeenCalled();
+
+    await prepared?.persistAuthProfiles();
+    await prepared?.persistAuthProfiles();
+
+    expect(upsertAuthProfile).toHaveBeenCalledOnce();
+    expect(upsertAuthProfile).toHaveBeenCalledWith({
+      profileId: LOCAL_PROFILE_ID,
+      credential: {
+        type: "api_key",
+        provider: LOCAL_PROVIDER_ID,
+        key: LOCAL_API_KEY,
+      },
+      agentDir: "/tmp/agent",
+    });
   });
 
   it("returns an agent model override when default model application is deferred", async () => {

--- a/src/commands/auth-choice.apply.plugin-provider.test.ts
+++ b/src/commands/auth-choice.apply.plugin-provider.test.ts
@@ -262,7 +262,7 @@ describe("applyAuthChoiceLoadedPluginProvider", () => {
         credential: {
           type: "api_key",
           provider: LOCAL_PROVIDER_ID,
-          key: "refreshed-local-provider-key",
+          key: "test-refreshed-provider-key",
         },
       },
     ]);
@@ -274,7 +274,7 @@ describe("applyAuthChoiceLoadedPluginProvider", () => {
       credential: {
         type: "api_key",
         provider: LOCAL_PROVIDER_ID,
-        key: "refreshed-local-provider-key",
+        key: "test-refreshed-provider-key",
       },
       agentDir: "/tmp/agent",
     });

--- a/src/commands/auth-choice.apply.plugin-provider.test.ts
+++ b/src/commands/auth-choice.apply.plugin-provider.test.ts
@@ -262,7 +262,7 @@ describe("applyAuthChoiceLoadedPluginProvider", () => {
         credential: {
           type: "api_key",
           provider: LOCAL_PROVIDER_ID,
-          key: "test-refreshed-provider-key",
+          key: "test-key",
         },
       },
     ]);
@@ -274,7 +274,7 @@ describe("applyAuthChoiceLoadedPluginProvider", () => {
       credential: {
         type: "api_key",
         provider: LOCAL_PROVIDER_ID,
-        key: "test-refreshed-provider-key",
+        key: "test-key",
       },
       agentDir: "/tmp/agent",
     });

--- a/src/commands/auth-choice.apply.ts
+++ b/src/commands/auth-choice.apply.ts
@@ -1,7 +1,11 @@
 // Applies an onboarding auth choice through provider setup flows and legacy normalization.
 import { formatCliCommand } from "../cli/command-format.js";
-import { applyAuthChoiceLoadedPluginProvider } from "../plugins/provider-auth-choice.js";
-import type { ApplyAuthChoiceParams, ApplyAuthChoiceResult } from "./auth-choice.apply.types.js";
+import { prepareAuthChoiceLoadedPluginProvider } from "../plugins/provider-auth-choice.js";
+import type {
+  ApplyAuthChoiceParams,
+  ApplyAuthChoiceResult,
+  PreparedAuthChoiceResult,
+} from "./auth-choice.apply.types.js";
 import type { AuthChoice } from "./onboard-types.js";
 
 async function normalizeLegacyChoice(
@@ -71,10 +75,10 @@ async function formatDeprecatedProviderChoiceError(
   return `Auth choice ${JSON.stringify(authChoice)} is no longer supported. Use ${JSON.stringify(externalDeprecatedChoice.choiceId)} instead, or run ${formatCliCommand("openclaw onboard")} to choose interactively.`;
 }
 
-/** Apply a selected auth choice, returning the mutated config or retry/model override signals. */
-export async function applyAuthChoice(
+/** Prepare a selected auth choice without writing its returned provider profiles. */
+export async function prepareAuthChoice(
   params: ApplyAuthChoiceParams,
-): Promise<ApplyAuthChoiceResult> {
+): Promise<PreparedAuthChoiceResult> {
   const normalizedAuthChoice =
     (await normalizeLegacyChoice(params.authChoice, {
       config: params.config,
@@ -88,7 +92,7 @@ export async function applyAuthChoice(
     normalizedProviderAuthChoice === params.authChoice
       ? params
       : { ...params, authChoice: normalizedProviderAuthChoice };
-  const result = await applyAuthChoiceLoadedPluginProvider(normalizedParams);
+  const result = await prepareAuthChoiceLoadedPluginProvider(normalizedParams);
   if (result) {
     return result;
   }
@@ -119,5 +123,22 @@ export async function applyAuthChoice(
     );
   }
 
-  return { config: normalizedParams.config };
+  return {
+    config: normalizedParams.config,
+    authProfiles: [],
+    persistAuthProfiles: async () => {},
+  };
+}
+
+/** Apply a selected auth choice, returning the mutated config or retry/model override signals. */
+export async function applyAuthChoice(
+  params: ApplyAuthChoiceParams,
+): Promise<ApplyAuthChoiceResult> {
+  const prepared = await prepareAuthChoice(params);
+  await prepared.persistAuthProfiles();
+  return {
+    config: prepared.config,
+    ...(prepared.agentModelOverride ? { agentModelOverride: prepared.agentModelOverride } : {}),
+    ...(prepared.retrySelection ? { retrySelection: true } : {}),
+  };
 }

--- a/src/commands/auth-choice.apply.types.ts
+++ b/src/commands/auth-choice.apply.types.ts
@@ -1,5 +1,6 @@
 // Shared types for applying auth-choice selections during onboarding and agent setup.
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { ProviderAuthResult } from "../plugins/types.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
 import type { AuthChoice, OnboardOptions } from "./onboard-types.js";
@@ -21,4 +22,9 @@ export type ApplyAuthChoiceResult = {
   config: OpenClawConfig;
   agentModelOverride?: string;
   retrySelection?: boolean;
+};
+
+export type PreparedAuthChoiceResult = ApplyAuthChoiceResult & {
+  authProfiles: ProviderAuthResult["profiles"];
+  persistAuthProfiles: () => Promise<void>;
 };

--- a/src/commands/auth-choice.apply.types.ts
+++ b/src/commands/auth-choice.apply.types.ts
@@ -26,5 +26,5 @@ export type ApplyAuthChoiceResult = {
 
 export type PreparedAuthChoiceResult = ApplyAuthChoiceResult & {
   authProfiles: ProviderAuthResult["profiles"];
-  persistAuthProfiles: () => Promise<void>;
+  persistAuthProfiles: (profiles?: ProviderAuthResult["profiles"]) => Promise<void>;
 };

--- a/src/commands/auth-choice.ts
+++ b/src/commands/auth-choice.ts
@@ -1,5 +1,5 @@
 // Public auth-choice barrel used by onboarding and agent setup commands.
-export { applyAuthChoice } from "./auth-choice.apply.js";
+export { applyAuthChoice, prepareAuthChoice } from "./auth-choice.apply.js";
 export {
   resolveDefaultModelCatalogFacts,
   resolveDefaultModelAuthStatus,

--- a/src/plugins/provider-auth-choice.ts
+++ b/src/plugins/provider-auth-choice.ts
@@ -58,7 +58,7 @@ type ApplyProviderAuthChoiceResult = {
 
 type PreparedApplyProviderAuthChoiceResult = ApplyProviderAuthChoiceResult & {
   authProfiles: ProviderAuthResult["profiles"];
-  persistAuthProfiles: () => Promise<void>;
+  persistAuthProfiles: (profiles?: ProviderAuthResult["profiles"]) => Promise<void>;
 };
 
 function preparedWithoutAuthProfiles(
@@ -387,7 +387,7 @@ export async function prepareProviderPluginAuthMethod(
   config: OpenClawConfig;
   defaultModel?: string;
   authProfiles: ProviderAuthResult["profiles"];
-  persistAuthProfiles: () => Promise<void>;
+  persistAuthProfiles: (profiles?: ProviderAuthResult["profiles"]) => Promise<void>;
 }> {
   const agentId = params.agentId ?? resolveDefaultAgentId(params.config);
   const agentDir = params.agentDir ?? resolveAgentDir(params.config, agentId);
@@ -423,12 +423,12 @@ export async function prepareProviderPluginAuthMethod(
     : undefined;
 
   let profilesPersisted = false;
-  const persistAuthProfiles = async () => {
+  const persistAuthProfiles = async (profiles = result.profiles) => {
     if (profilesPersisted) {
       return;
     }
     await params.beforePersistentEffect?.();
-    for (const profile of result.profiles) {
+    for (const profile of profiles) {
       const { profileId, credential } = profile;
       await upsertAuthProfileWithLockOrThrow({
         profileId,

--- a/src/plugins/provider-auth-choice.ts
+++ b/src/plugins/provider-auth-choice.ts
@@ -56,6 +56,21 @@ type ApplyProviderAuthChoiceResult = {
   retrySelection?: boolean;
 };
 
+type PreparedApplyProviderAuthChoiceResult = ApplyProviderAuthChoiceResult & {
+  authProfiles: ProviderAuthResult["profiles"];
+  persistAuthProfiles: () => Promise<void>;
+};
+
+function preparedWithoutAuthProfiles(
+  result: ApplyProviderAuthChoiceResult,
+): PreparedApplyProviderAuthChoiceResult {
+  return {
+    ...result,
+    authProfiles: [],
+    persistAuthProfiles: async () => {},
+  };
+}
+
 function formatModelRefForDisplay(modelRef: string, provider: ProviderPlugin): string {
   if (!provider.preserveLiteralProviderPrefix) {
     return modelRef;
@@ -300,7 +315,7 @@ export function applyProviderPluginAuthMethodResultConfig(params: {
   return nextConfig;
 }
 
-export async function runProviderPluginAuthMethod(params: {
+export async function prepareProviderPluginAuthMethod(params: {
   config: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
   runtime: RuntimeEnv;
@@ -316,7 +331,12 @@ export async function runProviderPluginAuthMethod(params: {
   secretInputMode?: ProviderAuthOptionBag["secretInputMode"];
   allowSecretRefPrompt?: boolean;
   opts?: Partial<ProviderAuthOptionBag>;
-}): Promise<{ config: OpenClawConfig; defaultModel?: string }> {
+}): Promise<{
+  config: OpenClawConfig;
+  defaultModel?: string;
+  authProfiles: ProviderAuthResult["profiles"];
+  persistAuthProfiles: () => Promise<void>;
+}> {
   const agentId = params.agentId ?? resolveDefaultAgentId(params.config);
   const agentDir = params.agentDir ?? resolveAgentDir(params.config, agentId);
   const workspaceDir =
@@ -342,15 +362,6 @@ export async function runProviderPluginAuthMethod(params: {
     await params.prompter.note(result.notes.join("\n"), "Provider notes");
   }
 
-  await params.beforePersistentEffect?.();
-  for (const profile of result.profiles) {
-    await upsertAuthProfileWithLockOrThrow({
-      profileId: profile.profileId,
-      credential: profile.credential,
-      agentDir,
-    });
-  }
-
   const nextConfig = applyProviderPluginAuthMethodResultConfig({
     config: params.config,
     result,
@@ -360,15 +371,44 @@ export async function runProviderPluginAuthMethod(params: {
     ? normalizeAgentModelRefForConfig(result.defaultModel)
     : undefined;
 
+  let profilesPersisted = false;
+  const persistAuthProfiles = async () => {
+    if (profilesPersisted) {
+      return;
+    }
+    await params.beforePersistentEffect?.();
+    for (const profile of result.profiles) {
+      await upsertAuthProfileWithLockOrThrow({
+        profileId: profile.profileId,
+        credential: profile.credential,
+        agentDir,
+      });
+    }
+    profilesPersisted = true;
+  };
+
   return {
     config: nextConfig,
     ...(defaultModel ? { defaultModel } : {}),
+    authProfiles: result.profiles,
+    persistAuthProfiles,
   };
 }
 
-export async function applyAuthChoiceLoadedPluginProvider(
+export async function runProviderPluginAuthMethod(
+  params: Parameters<typeof prepareProviderPluginAuthMethod>[0],
+): Promise<{ config: OpenClawConfig; defaultModel?: string }> {
+  const prepared = await prepareProviderPluginAuthMethod(params);
+  await prepared.persistAuthProfiles();
+  return {
+    config: prepared.config,
+    ...(prepared.defaultModel ? { defaultModel: prepared.defaultModel } : {}),
+  };
+}
+
+export async function prepareAuthChoiceLoadedPluginProvider(
   params: ApplyProviderAuthChoiceParams,
-): Promise<ApplyProviderAuthChoiceResult | null> {
+): Promise<PreparedApplyProviderAuthChoiceResult | null> {
   const agentId = params.agentId ?? resolveDefaultAgentId(params.config);
   const workspaceDir =
     params.workspaceDir ??
@@ -407,7 +447,7 @@ export async function applyAuthChoiceLoadedPluginProvider(
         `${safeLabel} plugin is disabled (${enableResult.reason ?? "blocked"}).`,
         safeLabel,
       );
-      return { config: nextConfig };
+      return preparedWithoutAuthProfiles({ config: nextConfig });
     }
     enabledConfig = enableResult.config;
   }
@@ -466,7 +506,7 @@ export async function applyAuthChoiceLoadedPluginProvider(
       workspaceDir,
     });
     if (!installResult.installed) {
-      return { config: installResult.cfg, retrySelection: true };
+      return preparedWithoutAuthProfiles({ config: installResult.cfg, retrySelection: true });
     }
     nextConfig = installResult.cfg;
     providers = resolveScopedRuntimeProviders(nextConfig);
@@ -476,14 +516,16 @@ export async function applyAuthChoiceLoadedPluginProvider(
     });
   }
   if (!resolved) {
-    return nextConfig === params.config ? null : { config: nextConfig, retrySelection: true };
+    return nextConfig === params.config
+      ? null
+      : preparedWithoutAuthProfiles({ config: nextConfig, retrySelection: true });
   }
   if (nextConfig === params.config && enabledConfig !== params.config) {
     nextConfig = enabledConfig;
   }
 
   const configBeforeProviderAuth = nextConfig;
-  const applied = await runProviderPluginAuthMethod({
+  const applied = await prepareProviderPluginAuthMethod({
     config: nextConfig,
     env: params.env,
     runtime: params.runtime,
@@ -527,13 +569,37 @@ export async function applyAuthChoiceLoadedPluginProvider(
           });
         },
       });
-      return { config: nextConfig };
+      return {
+        config: nextConfig,
+        authProfiles: applied.authProfiles,
+        persistAuthProfiles: applied.persistAuthProfiles,
+      };
     }
     nextConfig = restoreConfiguredPrimaryModel(nextConfig, params.config);
     agentModelOverride = selectedModel;
   }
 
-  return { config: nextConfig, agentModelOverride };
+  return {
+    config: nextConfig,
+    agentModelOverride,
+    authProfiles: applied.authProfiles,
+    persistAuthProfiles: applied.persistAuthProfiles,
+  };
+}
+
+export async function applyAuthChoiceLoadedPluginProvider(
+  params: ApplyProviderAuthChoiceParams,
+): Promise<ApplyProviderAuthChoiceResult | null> {
+  const prepared = await prepareAuthChoiceLoadedPluginProvider(params);
+  if (!prepared) {
+    return null;
+  }
+  await prepared.persistAuthProfiles();
+  return {
+    config: prepared.config,
+    ...(prepared.agentModelOverride ? { agentModelOverride: prepared.agentModelOverride } : {}),
+    ...(prepared.retrySelection ? { retrySelection: true } : {}),
+  };
 }
 async function upsertAuthProfileWithLockOrThrow(params: UpsertAuthProfileParams): Promise<void> {
   const updated = await upsertAuthProfileWithLock(params);

--- a/src/plugins/provider-auth-choice.ts
+++ b/src/plugins/provider-auth-choice.ts
@@ -315,7 +315,7 @@ export function applyProviderPluginAuthMethodResultConfig(params: {
   return nextConfig;
 }
 
-export async function prepareProviderPluginAuthMethod(params: {
+export async function runProviderPluginAuthMethod(params: {
   config: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
   runtime: RuntimeEnv;
@@ -331,7 +331,59 @@ export async function prepareProviderPluginAuthMethod(params: {
   secretInputMode?: ProviderAuthOptionBag["secretInputMode"];
   allowSecretRefPrompt?: boolean;
   opts?: Partial<ProviderAuthOptionBag>;
-}): Promise<{
+}): Promise<{ config: OpenClawConfig; defaultModel?: string }> {
+  const agentId = params.agentId ?? resolveDefaultAgentId(params.config);
+  const agentDir = params.agentDir ?? resolveAgentDir(params.config, agentId);
+  const workspaceDir =
+    params.workspaceDir ??
+    resolveAgentWorkspaceDir(params.config, agentId) ??
+    resolveDefaultAgentWorkspaceDir();
+  const result = await runProviderPluginAuthMethodUnpersisted({
+    config: params.config,
+    env: params.env,
+    runtime: params.runtime,
+    prompter: params.prompter,
+    method: params.method,
+    agentDir,
+    workspaceDir,
+    ...(params.signal ? { signal: params.signal } : {}),
+    ...(params.isRemote !== undefined ? { isRemote: params.isRemote } : {}),
+    secretInputMode: params.secretInputMode,
+    allowSecretRefPrompt: params.allowSecretRefPrompt,
+    opts: params.opts,
+  });
+
+  if (params.emitNotes !== false && result.notes && result.notes.length > 0) {
+    await params.prompter.note(result.notes.join("\n"), "Provider notes");
+  }
+
+  await params.beforePersistentEffect?.();
+  for (const profile of result.profiles) {
+    await upsertAuthProfileWithLockOrThrow({
+      profileId: profile.profileId,
+      credential: profile.credential,
+      agentDir,
+    });
+  }
+
+  const nextConfig = applyProviderPluginAuthMethodResultConfig({
+    config: params.config,
+    result,
+  });
+
+  const defaultModel = result.defaultModel
+    ? normalizeAgentModelRefForConfig(result.defaultModel)
+    : undefined;
+
+  return {
+    config: nextConfig,
+    ...(defaultModel ? { defaultModel } : {}),
+  };
+}
+
+export async function prepareProviderPluginAuthMethod(
+  params: Parameters<typeof runProviderPluginAuthMethod>[0],
+): Promise<{
   config: OpenClawConfig;
   defaultModel?: string;
   authProfiles: ProviderAuthResult["profiles"];
@@ -366,7 +418,6 @@ export async function prepareProviderPluginAuthMethod(params: {
     config: params.config,
     result,
   });
-
   const defaultModel = result.defaultModel
     ? normalizeAgentModelRefForConfig(result.defaultModel)
     : undefined;
@@ -393,17 +444,6 @@ export async function prepareProviderPluginAuthMethod(params: {
     ...(defaultModel ? { defaultModel } : {}),
     authProfiles: result.profiles,
     persistAuthProfiles,
-  };
-}
-
-export async function runProviderPluginAuthMethod(
-  params: Parameters<typeof prepareProviderPluginAuthMethod>[0],
-): Promise<{ config: OpenClawConfig; defaultModel?: string }> {
-  const prepared = await prepareProviderPluginAuthMethod(params);
-  await prepared.persistAuthProfiles();
-  return {
-    config: prepared.config,
-    ...(prepared.defaultModel ? { defaultModel: prepared.defaultModel } : {}),
   };
 }
 

--- a/src/plugins/provider-auth-choice.ts
+++ b/src/plugins/provider-auth-choice.ts
@@ -381,7 +381,7 @@ export async function runProviderPluginAuthMethod(params: {
   };
 }
 
-export async function prepareProviderPluginAuthMethod(
+async function prepareProviderPluginAuthMethod(
   params: Parameters<typeof runProviderPluginAuthMethod>[0],
 ): Promise<{
   config: OpenClawConfig;

--- a/src/plugins/provider-auth-choice.ts
+++ b/src/plugins/provider-auth-choice.ts
@@ -378,9 +378,10 @@ export async function prepareProviderPluginAuthMethod(params: {
     }
     await params.beforePersistentEffect?.();
     for (const profile of result.profiles) {
+      const { profileId, credential } = profile;
       await upsertAuthProfileWithLockOrThrow({
-        profileId: profile.profileId,
-        credential: profile.credential,
+        profileId,
+        credential,
         agentDir,
       });
     }

--- a/src/system-agent/setup-inference.test.ts
+++ b/src/system-agent/setup-inference.test.ts
@@ -5395,8 +5395,8 @@ describe("verifySetupInference", () => {
         });
         await updateAuthProfileStoreWithLock({
           agentDir: params.agentDir!,
-          updater: (store) => {
-            store.profiles[profileId] = {
+          updater: ({ profiles }) => {
+            profiles[profileId] = {
               type: "oauth",
               provider: "openai",
               access: "sample",

--- a/src/system-agent/setup-inference.test.ts
+++ b/src/system-agent/setup-inference.test.ts
@@ -5478,6 +5478,71 @@ describe("verifySetupInference", () => {
     }
   });
 
+  it("returns a refreshed staged profile when the live inference test fails", async () => {
+    const profileId = "openai:default";
+    const runEmbeddedAgent = vi.fn(async (params: { agentDir?: string }) => {
+      expect(params.agentDir).toBeDefined();
+      await updateAuthProfileStoreWithLock({
+        agentDir: params.agentDir!,
+        updater: ({ profiles }) => {
+          profiles[profileId] = {
+            type: "oauth",
+            provider: "openai",
+            access: "sample",
+            refresh: "sample",
+            expires: Date.now() + 7_200_000,
+          };
+          return true;
+        },
+      });
+      throw new Error("request timed out");
+    });
+
+    const result = await verifySetupInferenceConfig({
+      config: {
+        auth: {
+          profiles: { [profileId]: { provider: "openai", mode: "oauth" } },
+          order: { openai: [profileId] },
+        },
+        agents: { defaults: { model: `openai/gpt-5.5@${profileId}` } },
+      },
+      authProfiles: [
+        {
+          profileId,
+          credential: {
+            type: "oauth",
+            provider: "openai",
+            access: "fake",
+            refresh: "fake",
+            expires: Date.now() + 3_600_000,
+          },
+        },
+      ],
+      runtime,
+      deps: {
+        runEmbeddedAgent: runEmbeddedAgent as never,
+        createTempDir: makeTempDir,
+      },
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      status: "timeout",
+      authProfiles: [
+        {
+          profileId,
+          credential: {
+            type: "oauth",
+            provider: "openai",
+            access: "sample",
+            refresh: "sample",
+            expires: expect.any(Number),
+          },
+        },
+      ],
+    });
+  });
+
   it("rejects a staged credential that differs from the configured profile pin", async () => {
     const runEmbeddedAgent = vi.fn();
     const result = await verifySetupInferenceConfig({

--- a/src/system-agent/setup-inference.test.ts
+++ b/src/system-agent/setup-inference.test.ts
@@ -5373,8 +5373,8 @@ describe("verifySetupInference", () => {
       credential: {
         type: "oauth",
         provider: "openai",
-        access: "test-original-access-token",
-        refresh: "test-original-refresh-token",
+        access: "dummy",
+        refresh: "dummy",
         expires: Date.now() + 3_600_000,
       },
       agentDir,
@@ -5389,8 +5389,8 @@ describe("verifySetupInference", () => {
         expect(readAuthProfileStoreForTest(params.agentDir!).profiles[profileId]).toEqual({
           type: "oauth",
           provider: "openai",
-          access: "test-staged-access-token",
-          refresh: "test-staged-refresh-token",
+          access: "fake",
+          refresh: "fake",
           expires: expect.any(Number),
         });
         await updateAuthProfileStoreWithLock({
@@ -5399,8 +5399,8 @@ describe("verifySetupInference", () => {
             store.profiles[profileId] = {
               type: "oauth",
               provider: "openai",
-              access: "test-refreshed-access-token",
-              refresh: "test-refreshed-refresh-token",
+              access: "sample",
+              refresh: "sample",
               expires: Date.now() + 7_200_000,
             };
             return true;
@@ -5437,8 +5437,8 @@ describe("verifySetupInference", () => {
             credential: {
               type: "oauth",
               provider: "openai",
-              access: "test-staged-access-token",
-              refresh: "test-staged-refresh-token",
+              access: "fake",
+              refresh: "fake",
               expires: Date.now() + 3_600_000,
             },
           },
@@ -5459,8 +5459,8 @@ describe("verifySetupInference", () => {
             credential: {
               type: "oauth",
               provider: "openai",
-              access: "test-refreshed-access-token",
-              refresh: "test-refreshed-refresh-token",
+              access: "sample",
+              refresh: "sample",
               expires: expect.any(Number),
             },
           },
@@ -5469,8 +5469,8 @@ describe("verifySetupInference", () => {
       expect(readAuthProfileStoreForTest(agentDir).profiles[profileId]).toEqual({
         type: "oauth",
         provider: "openai",
-        access: "test-original-access-token",
-        refresh: "test-original-refresh-token",
+        access: "dummy",
+        refresh: "dummy",
         expires: expect.any(Number),
       });
     } finally {

--- a/src/system-agent/setup-inference.test.ts
+++ b/src/system-agent/setup-inference.test.ts
@@ -5364,16 +5364,18 @@ describe("verifySetupInference", () => {
     expect(runEmbeddedAgent).toHaveBeenCalledOnce();
   });
 
-  it("probes a staged profile in isolation without changing the configured agent store", async () => {
+  it("returns a refreshed staged profile without changing the configured agent store", async () => {
     const stateDir = await makeTempDir();
     const agentDir = path.join(stateDir, "configured-agent");
     const profileId = "openai:default";
     await upsertAuthProfileWithLock({
       profileId,
       credential: {
-        type: "api_key",
+        type: "oauth",
         provider: "openai",
-        key: "test-original-key",
+        access: "test-original-access",
+        refresh: "test-original-refresh",
+        expires: Date.now() + 3_600_000,
       },
       agentDir,
     });
@@ -5385,9 +5387,24 @@ describe("verifySetupInference", () => {
         expect(params.agentDir).toBeDefined();
         expect(params.agentDir).not.toBe(agentDir);
         expect(readAuthProfileStoreForTest(params.agentDir!).profiles[profileId]).toEqual({
-          type: "api_key",
+          type: "oauth",
           provider: "openai",
-          key: "test-staged-key",
+          access: "test-staged-access",
+          refresh: "test-staged-refresh",
+          expires: expect.any(Number),
+        });
+        await updateAuthProfileStoreWithLock({
+          agentDir: params.agentDir!,
+          updater: (store) => {
+            store.profiles[profileId] = {
+              type: "oauth",
+              provider: "openai",
+              access: "test-refreshed-access",
+              refresh: "test-refreshed-refresh",
+              expires: Date.now() + 7_200_000,
+            };
+            return true;
+          },
         });
         return successfulRun("openai", "gpt-5.5", {
           authProfileId: profileId,
@@ -5400,7 +5417,7 @@ describe("verifySetupInference", () => {
       const result = await verifySetupInferenceConfig({
         config: {
           auth: {
-            profiles: { [profileId]: { provider: "openai", mode: "api_key" } },
+            profiles: { [profileId]: { provider: "openai", mode: "oauth" } },
             order: { openai: [profileId] },
           },
           agents: {
@@ -5418,9 +5435,11 @@ describe("verifySetupInference", () => {
           {
             profileId,
             credential: {
-              type: "api_key",
+              type: "oauth",
               provider: "openai",
-              key: "test-staged-key",
+              access: "test-staged-access",
+              refresh: "test-staged-refresh",
+              expires: Date.now() + 3_600_000,
             },
           },
         ],
@@ -5431,11 +5450,28 @@ describe("verifySetupInference", () => {
         },
       });
 
-      expect(result).toMatchObject({ ok: true, modelRef: "openai/gpt-5.5" });
+      expect(result).toMatchObject({
+        ok: true,
+        modelRef: "openai/gpt-5.5",
+        authProfiles: [
+          {
+            profileId,
+            credential: {
+              type: "oauth",
+              provider: "openai",
+              access: "test-refreshed-access",
+              refresh: "test-refreshed-refresh",
+              expires: expect.any(Number),
+            },
+          },
+        ],
+      });
       expect(readAuthProfileStoreForTest(agentDir).profiles[profileId]).toEqual({
-        type: "api_key",
+        type: "oauth",
         provider: "openai",
-        key: "test-original-key",
+        access: "test-original-access",
+        refresh: "test-original-refresh",
+        expires: expect.any(Number),
       });
     } finally {
       await removeOAuthTestTempRoot(stateDir);

--- a/src/system-agent/setup-inference.test.ts
+++ b/src/system-agent/setup-inference.test.ts
@@ -5373,8 +5373,8 @@ describe("verifySetupInference", () => {
       credential: {
         type: "oauth",
         provider: "openai",
-        access: "test-original-access",
-        refresh: "test-original-refresh",
+        access: "test-original-access-token",
+        refresh: "test-original-refresh-token",
         expires: Date.now() + 3_600_000,
       },
       agentDir,
@@ -5389,8 +5389,8 @@ describe("verifySetupInference", () => {
         expect(readAuthProfileStoreForTest(params.agentDir!).profiles[profileId]).toEqual({
           type: "oauth",
           provider: "openai",
-          access: "test-staged-access",
-          refresh: "test-staged-refresh",
+          access: "test-staged-access-token",
+          refresh: "test-staged-refresh-token",
           expires: expect.any(Number),
         });
         await updateAuthProfileStoreWithLock({
@@ -5399,8 +5399,8 @@ describe("verifySetupInference", () => {
             store.profiles[profileId] = {
               type: "oauth",
               provider: "openai",
-              access: "test-refreshed-access",
-              refresh: "test-refreshed-refresh",
+              access: "test-refreshed-access-token",
+              refresh: "test-refreshed-refresh-token",
               expires: Date.now() + 7_200_000,
             };
             return true;
@@ -5437,8 +5437,8 @@ describe("verifySetupInference", () => {
             credential: {
               type: "oauth",
               provider: "openai",
-              access: "test-staged-access",
-              refresh: "test-staged-refresh",
+              access: "test-staged-access-token",
+              refresh: "test-staged-refresh-token",
               expires: Date.now() + 3_600_000,
             },
           },
@@ -5459,8 +5459,8 @@ describe("verifySetupInference", () => {
             credential: {
               type: "oauth",
               provider: "openai",
-              access: "test-refreshed-access",
-              refresh: "test-refreshed-refresh",
+              access: "test-refreshed-access-token",
+              refresh: "test-refreshed-refresh-token",
               expires: expect.any(Number),
             },
           },
@@ -5469,8 +5469,8 @@ describe("verifySetupInference", () => {
       expect(readAuthProfileStoreForTest(agentDir).profiles[profileId]).toEqual({
         type: "oauth",
         provider: "openai",
-        access: "test-original-access",
-        refresh: "test-original-refresh",
+        access: "test-original-access-token",
+        refresh: "test-original-refresh-token",
         expires: expect.any(Number),
       });
     } finally {

--- a/src/system-agent/setup-inference.test.ts
+++ b/src/system-agent/setup-inference.test.ts
@@ -5442,6 +5442,51 @@ describe("verifySetupInference", () => {
     }
   });
 
+  it("rejects a staged credential that differs from the configured profile pin", async () => {
+    const runEmbeddedAgent = vi.fn();
+    const result = await verifySetupInferenceConfig({
+      config: {
+        auth: {
+          profiles: { "openai:old": { provider: "openai", mode: "api_key" } },
+          order: { openai: ["openai:old"] },
+        },
+        agents: { defaults: { model: "openai/gpt-5.5@openai:old" } },
+      },
+      authProfiles: [
+        {
+          profileId: "openai:new",
+          credential: {
+            type: "api_key",
+            provider: "openai",
+            key: "test-new-key",
+          },
+        },
+      ],
+      runtime,
+      deps: {
+        loadAuthProfileStoreForRuntime: vi.fn(() => ({
+          version: 1,
+          profiles: {
+            "openai:old": {
+              type: "api_key",
+              provider: "openai",
+              key: "test-old-key",
+            },
+          },
+        })) as never,
+        runEmbeddedAgent: runEmbeddedAgent as never,
+        createTempDir: makeTempDir,
+      },
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      status: "auth",
+      error: "The staged credential does not match the configured auth profile.",
+    });
+    expect(runEmbeddedAgent).not.toHaveBeenCalled();
+  });
+
   it("rejects a configured route that changes during its live check", async () => {
     const initialConfig = {
       agents: { defaults: { model: { primary: "openai/gpt-5.5" } } },

--- a/src/system-agent/setup-inference.test.ts
+++ b/src/system-agent/setup-inference.test.ts
@@ -5368,17 +5368,15 @@ describe("verifySetupInference", () => {
     const stateDir = await makeTempDir();
     const agentDir = path.join(stateDir, "configured-agent");
     const profileId = "openai:default";
-    const originalCredential = {
-      type: "api_key" as const,
-      provider: "openai",
-      key: "test-original-key",
-    };
-    const stagedCredential = {
-      type: "api_key" as const,
-      provider: "openai",
-      key: "test-staged-key",
-    };
-    await upsertAuthProfileWithLock({ profileId, credential: originalCredential, agentDir });
+    await upsertAuthProfileWithLock({
+      profileId,
+      credential: {
+        type: "api_key",
+        provider: "openai",
+        key: "test-original-key",
+      },
+      agentDir,
+    });
     const runEmbeddedAgent = vi.fn(
       async (params: {
         agentDir?: string;
@@ -5386,9 +5384,11 @@ describe("verifySetupInference", () => {
       }) => {
         expect(params.agentDir).toBeDefined();
         expect(params.agentDir).not.toBe(agentDir);
-        expect(readAuthProfileStoreForTest(params.agentDir!).profiles[profileId]).toEqual(
-          stagedCredential,
-        );
+        expect(readAuthProfileStoreForTest(params.agentDir!).profiles[profileId]).toEqual({
+          type: "api_key",
+          provider: "openai",
+          key: "test-staged-key",
+        });
         return successfulRun("openai", "gpt-5.5", {
           authProfileId: profileId,
           onSuccessfulAuthBinding: params.onSuccessfulAuthBinding,
@@ -5414,7 +5414,16 @@ describe("verifySetupInference", () => {
             ],
           },
         },
-        authProfiles: [{ profileId, credential: stagedCredential }],
+        authProfiles: [
+          {
+            profileId,
+            credential: {
+              type: "api_key",
+              provider: "openai",
+              key: "test-staged-key",
+            },
+          },
+        ],
         runtime,
         deps: {
           runEmbeddedAgent: runEmbeddedAgent as never,
@@ -5423,7 +5432,11 @@ describe("verifySetupInference", () => {
       });
 
       expect(result).toMatchObject({ ok: true, modelRef: "openai/gpt-5.5" });
-      expect(readAuthProfileStoreForTest(agentDir).profiles[profileId]).toEqual(originalCredential);
+      expect(readAuthProfileStoreForTest(agentDir).profiles[profileId]).toEqual({
+        type: "api_key",
+        provider: "openai",
+        key: "test-original-key",
+      });
     } finally {
       await removeOAuthTestTempRoot(stateDir);
     }

--- a/src/system-agent/setup-inference.test.ts
+++ b/src/system-agent/setup-inference.test.ts
@@ -5364,6 +5364,71 @@ describe("verifySetupInference", () => {
     expect(runEmbeddedAgent).toHaveBeenCalledOnce();
   });
 
+  it("probes a staged profile in isolation without changing the configured agent store", async () => {
+    const stateDir = await makeTempDir();
+    const agentDir = path.join(stateDir, "configured-agent");
+    const profileId = "openai:default";
+    const originalCredential = {
+      type: "api_key" as const,
+      provider: "openai",
+      key: "test-original-key",
+    };
+    const stagedCredential = {
+      type: "api_key" as const,
+      provider: "openai",
+      key: "test-staged-key",
+    };
+    await upsertAuthProfileWithLock({ profileId, credential: originalCredential, agentDir });
+    const runEmbeddedAgent = vi.fn(
+      async (params: {
+        agentDir?: string;
+        onSuccessfulAuthBinding?: (binding: AgentExecutionAuthBinding) => void;
+      }) => {
+        expect(params.agentDir).toBeDefined();
+        expect(params.agentDir).not.toBe(agentDir);
+        expect(readAuthProfileStoreForTest(params.agentDir!).profiles[profileId]).toEqual(
+          stagedCredential,
+        );
+        return successfulRun("openai", "gpt-5.5", {
+          authProfileId: profileId,
+          onSuccessfulAuthBinding: params.onSuccessfulAuthBinding,
+        });
+      },
+    );
+
+    try {
+      const result = await verifySetupInferenceConfig({
+        config: {
+          auth: {
+            profiles: { [profileId]: { provider: "openai", mode: "api_key" } },
+            order: { openai: [profileId] },
+          },
+          agents: {
+            list: [
+              {
+                id: "main",
+                default: true,
+                agentDir,
+                model: { primary: `openai/gpt-5.5@${profileId}` },
+              },
+            ],
+          },
+        },
+        authProfiles: [{ profileId, credential: stagedCredential }],
+        runtime,
+        deps: {
+          runEmbeddedAgent: runEmbeddedAgent as never,
+          createTempDir: makeTempDir,
+        },
+      });
+
+      expect(result).toMatchObject({ ok: true, modelRef: "openai/gpt-5.5" });
+      expect(readAuthProfileStoreForTest(agentDir).profiles[profileId]).toEqual(originalCredential);
+    } finally {
+      await removeOAuthTestTempRoot(stateDir);
+    }
+  });
+
   it("rejects a configured route that changes during its live check", async () => {
     const initialConfig = {
       agents: { defaults: { model: { primary: "openai/gpt-5.5" } } },

--- a/src/system-agent/setup-inference.ts
+++ b/src/system-agent/setup-inference.ts
@@ -194,7 +194,12 @@ class SetupInferenceActivationUnavailableError extends Error {
 }
 
 export type VerifySetupInferenceResult =
-  | { ok: true; modelRef: string; latencyMs: number }
+  | {
+      ok: true;
+      modelRef: string;
+      latencyMs: number;
+      authProfiles?: ProviderAuthResult["profiles"];
+    }
   | { ok: false; status: SetupInferenceFailureStatus; error: string };
 
 export type CompleteSetupInferenceResult =
@@ -2748,7 +2753,37 @@ export async function verifySetupInferenceConfig(params: {
           };
         }
       }
-      return { ok: true, latencyMs: test.latencyMs, modelRef: plan.modelRef };
+      let authProfiles: ProviderAuthResult["profiles"] | undefined;
+      if (params.authProfiles && params.authProfiles.length > 0) {
+        try {
+          const loadStore = deps.loadAuthProfileStoreForRuntime ?? loadAuthProfileStoreForRuntime;
+          const store = loadStore(plan.agentDir, {
+            readOnly: true,
+            allowKeychainPrompt: false,
+            config: plan.config,
+            externalCliProviderIds: [plan.provider],
+          });
+          authProfiles = params.authProfiles.map((profile) => {
+            const credential = store.profiles[profile.profileId];
+            if (!credential) {
+              throw new Error("staged profile missing after verification");
+            }
+            return { profileId: profile.profileId, credential };
+          });
+        } catch {
+          return {
+            ok: false,
+            status: "unknown",
+            error: "Could not retain the verified credential after its live inference test.",
+          };
+        }
+      }
+      return {
+        ok: true,
+        latencyMs: test.latencyMs,
+        modelRef: plan.modelRef,
+        ...(authProfiles ? { authProfiles } : {}),
+      };
     }
     return {
       ...test,

--- a/src/system-agent/setup-inference.ts
+++ b/src/system-agent/setup-inference.ts
@@ -2757,14 +2757,14 @@ export async function verifySetupInferenceConfig(params: {
       if (params.authProfiles && params.authProfiles.length > 0) {
         try {
           const loadStore = deps.loadAuthProfileStoreForRuntime ?? loadAuthProfileStoreForRuntime;
-          const store = loadStore(plan.agentDir, {
+          const { profiles } = loadStore(plan.agentDir, {
             readOnly: true,
             allowKeychainPrompt: false,
             config: plan.config,
             externalCliProviderIds: [plan.provider],
           });
           authProfiles = params.authProfiles.map((profile) => {
-            const credential = store.profiles[profile.profileId];
+            const credential = profiles[profile.profileId];
             if (!credential) {
               throw new Error("staged profile missing after verification");
             }

--- a/src/system-agent/setup-inference.ts
+++ b/src/system-agent/setup-inference.ts
@@ -200,7 +200,12 @@ export type VerifySetupInferenceResult =
       latencyMs: number;
       authProfiles?: ProviderAuthResult["profiles"];
     }
-  | { ok: false; status: SetupInferenceFailureStatus; error: string };
+  | {
+      ok: false;
+      status: SetupInferenceFailureStatus;
+      error: string;
+      authProfiles?: ProviderAuthResult["profiles"];
+    };
 
 export type CompleteSetupInferenceResult =
   | { ok: true; modelRef: string; latencyMs: number; text: string }
@@ -2656,6 +2661,39 @@ export async function verifySetupInferenceConfig(params: {
         authProfileId: selectedProfile.profileId,
       };
     }
+    const readStagedAuthProfiles = (): ProviderAuthResult["profiles"] | undefined => {
+      if (!params.authProfiles || params.authProfiles.length === 0) {
+        return undefined;
+      }
+      const loadStore = deps.loadAuthProfileStoreForRuntime ?? loadAuthProfileStoreForRuntime;
+      const { profiles } = loadStore(plan.agentDir, {
+        readOnly: true,
+        allowKeychainPrompt: false,
+        config: plan.config,
+        externalCliProviderIds: [plan.provider],
+      });
+      return params.authProfiles.map((profile) => {
+        const credential = profiles[profile.profileId];
+        if (!credential) {
+          throw new Error("staged profile missing after verification");
+        }
+        return { profileId: profile.profileId, credential };
+      });
+    };
+    const retainStagedAuthProfiles = () => {
+      try {
+        return { ok: true as const, authProfiles: readStagedAuthProfiles() };
+      } catch {
+        return {
+          ok: false as const,
+          result: {
+            ok: false as const,
+            status: "unknown" as const,
+            error: "Could not retain the credential after its live inference test.",
+          },
+        };
+      }
+    };
     const requiresExecutionOwner =
       params.requireExecutionOwner === true || params.onVerifiedExecution !== undefined;
     let configuredRoute:
@@ -2696,6 +2734,11 @@ export async function verifySetupInferenceConfig(params: {
       authProfileStateMode: "read-only",
       requireExecutionOwner: requiresExecutionOwner,
     });
+    let retained = retainStagedAuthProfiles();
+    if (!retained.ok) {
+      return retained.result;
+    }
+    let authProfiles = retained.authProfiles;
     if (test.ok) {
       const verifiedProfileId = test.auth.authProfileId;
       if (plan.authProfileId && verifiedProfileId !== plan.authProfileId) {
@@ -2703,6 +2746,7 @@ export async function verifySetupInferenceConfig(params: {
           ok: false,
           status: "auth",
           error: `The inference run used profile "${verifiedProfileId ?? "unknown"}" instead of the configured profile "${plan.authProfileId}".`,
+          ...(authProfiles ? { authProfiles } : {}),
         };
       }
       if (params.onVerifiedExecution && !plan.authProfileId && verifiedProfileId) {
@@ -2716,10 +2760,16 @@ export async function verifySetupInferenceConfig(params: {
           authProfileStateMode: "read-only",
           requireExecutionOwner: true,
         });
+        retained = retainStagedAuthProfiles();
+        if (!retained.ok) {
+          return retained.result;
+        }
+        authProfiles = retained.authProfiles;
         if (!test.ok) {
           return {
             ...test,
             error: await redactSetupInferenceError(test.error),
+            ...(authProfiles ? { authProfiles } : {}),
           };
         }
         if (test.auth.authProfileId !== verifiedProfileId) {
@@ -2727,6 +2777,7 @@ export async function verifySetupInferenceConfig(params: {
             ok: false,
             status: "auth",
             error: "The selected inference credential changed during its locked verification.",
+            ...(authProfiles ? { authProfiles } : {}),
           };
         }
       }
@@ -2750,31 +2801,7 @@ export async function verifySetupInferenceConfig(params: {
             status: "auth",
             error:
               "The verified inference owner changed before validation completed. Retry the inference check.",
-          };
-        }
-      }
-      let authProfiles: ProviderAuthResult["profiles"] | undefined;
-      if (params.authProfiles && params.authProfiles.length > 0) {
-        try {
-          const loadStore = deps.loadAuthProfileStoreForRuntime ?? loadAuthProfileStoreForRuntime;
-          const { profiles } = loadStore(plan.agentDir, {
-            readOnly: true,
-            allowKeychainPrompt: false,
-            config: plan.config,
-            externalCliProviderIds: [plan.provider],
-          });
-          authProfiles = params.authProfiles.map((profile) => {
-            const credential = profiles[profile.profileId];
-            if (!credential) {
-              throw new Error("staged profile missing after verification");
-            }
-            return { profileId: profile.profileId, credential };
-          });
-        } catch {
-          return {
-            ok: false,
-            status: "unknown",
-            error: "Could not retain the verified credential after its live inference test.",
+            ...(authProfiles ? { authProfiles } : {}),
           };
         }
       }
@@ -2788,6 +2815,7 @@ export async function verifySetupInferenceConfig(params: {
     return {
       ...test,
       error: await redactSetupInferenceError(test.error),
+      ...(authProfiles ? { authProfiles } : {}),
     };
   } finally {
     await cleanupSetupInferenceTempDir({ tempDir, deps, runtime: params.runtime });

--- a/src/system-agent/setup-inference.ts
+++ b/src/system-agent/setup-inference.ts
@@ -2568,6 +2568,8 @@ export async function resolvePersistentApplyInference(params: {
 /** Live-test a staged default-agent route before any caller persists it. */
 export async function verifySetupInferenceConfig(params: {
   config: OpenClawConfig;
+  /** Candidate profiles staged in the isolated probe store, never the real agent store. */
+  authProfiles?: ProviderAuthResult["profiles"];
   agentId?: string;
   runtime: RuntimeEnv;
   timeoutMs?: number;
@@ -2597,7 +2599,7 @@ export async function verifySetupInferenceConfig(params: {
     deps.createTempDir ?? (() => fs.mkdtemp(path.join(os.tmpdir(), "openclaw-setup-inference-")))
   )();
   try {
-    const plan = await buildTestPlan({
+    const builtPlan = await buildTestPlan({
       kind: "existing-model",
       cfg,
       sourceCfg: cfg,
@@ -2608,8 +2610,43 @@ export async function verifySetupInferenceConfig(params: {
       routeAgentId,
       deps,
     });
-    if ("error" in plan) {
-      return { ok: false, status: "unavailable", error: plan.error };
+    if ("error" in builtPlan) {
+      return { ok: false, status: "unavailable", error: builtPlan.error };
+    }
+    let plan: SetupInferenceTestPlan = builtPlan;
+    if (params.authProfiles && params.authProfiles.length > 0) {
+      const selectedProfile =
+        params.authProfiles.find((profile) => profile.profileId === plan.authProfileId) ??
+        params.authProfiles.find(
+          (profile) =>
+            normalizeProviderId(profile.credential.provider) === normalizeProviderId(plan.provider),
+        );
+      if (!selectedProfile) {
+        return {
+          ok: false,
+          status: "auth",
+          error: "The staged credential does not belong to the configured inference provider.",
+        };
+      }
+      const stagedAgentDir = path.join(tempDir, "agent");
+      const staged = await persistManualAuthProfiles({
+        profiles: params.authProfiles,
+        agentDir: stagedAgentDir,
+        deps,
+      });
+      if (staged.status !== "persisted") {
+        return {
+          ok: false,
+          status: "unknown",
+          error:
+            "Could not stage the credential for its live inference test; try again in a moment.",
+        };
+      }
+      plan = {
+        ...plan,
+        agentDir: stagedAgentDir,
+        authProfileId: selectedProfile.profileId,
+      };
     }
     const requiresExecutionOwner =
       params.requireExecutionOwner === true || params.onVerifiedExecution !== undefined;

--- a/src/system-agent/setup-inference.ts
+++ b/src/system-agent/setup-inference.ts
@@ -2615,17 +2615,20 @@ export async function verifySetupInferenceConfig(params: {
     }
     let plan: SetupInferenceTestPlan = builtPlan;
     if (params.authProfiles && params.authProfiles.length > 0) {
-      const selectedProfile =
-        params.authProfiles.find((profile) => profile.profileId === plan.authProfileId) ??
-        params.authProfiles.find(
-          (profile) =>
-            normalizeProviderId(profile.credential.provider) === normalizeProviderId(plan.provider),
-        );
+      const selectedProfile = plan.authProfileId
+        ? params.authProfiles.find((profile) => profile.profileId === plan.authProfileId)
+        : params.authProfiles.find(
+            (profile) =>
+              normalizeProviderId(profile.credential.provider) ===
+              normalizeProviderId(plan.provider),
+          );
       if (!selectedProfile) {
         return {
           ok: false,
           status: "auth",
-          error: "The staged credential does not belong to the configured inference provider.",
+          error: plan.authProfileId
+            ? "The staged credential does not match the configured auth profile."
+            : "The staged credential does not belong to the configured inference provider.",
         };
       }
       const stagedAgentDir = path.join(tempDir, "agent");

--- a/src/wizard/setup.model-auth.test.ts
+++ b/src/wizard/setup.model-auth.test.ts
@@ -13,6 +13,7 @@ const promptAuthChoiceGrouped = vi.hoisted(() => vi.fn());
 
 vi.mock("../commands/auth-choice.js", () => ({
   applyAuthChoice,
+  prepareAuthChoice: applyAuthChoice,
   warnIfModelConfigLooksOff,
   resolvePreferredProviderForAuthChoice,
 }));
@@ -71,7 +72,11 @@ describe("runSetupModelAuthStep provider failures", () => {
       workspaceDir: "/tmp/workspace",
     });
 
-    expect(result).toEqual({});
+    expect(result).toEqual({
+      config: {},
+      authProfiles: [],
+      persistAuthProfiles: expect.any(Function),
+    });
     expect(promptAuthChoiceGrouped).toHaveBeenCalledTimes(2);
     expect(prompter.note).toHaveBeenCalledWith(
       expect.stringContaining("Claude CLI is not authenticated on this host."),

--- a/src/wizard/setup.model-auth.ts
+++ b/src/wizard/setup.model-auth.ts
@@ -123,18 +123,19 @@ async function resolveAuthChoiceModelSelectionPolicy(params: {
  */
 export async function runSetupModelAuthStep(params: {
   config: OpenClawConfig;
-  stagedAuth?: Pick<SetupModelAuthCandidate, "authProfiles" | "persistAuthProfiles">;
+  stagedCandidate?: SetupModelAuthCandidate;
   opts: OnboardOptions;
   prompter: WizardPrompter;
   runtime: RuntimeEnv;
   workspaceDir: string;
 }): Promise<SetupModelAuthCandidate> {
   const { opts, prompter, runtime, workspaceDir } = params;
-  let nextConfig = params.config;
+  let nextConfig = params.stagedCandidate?.config ?? params.config;
+  let replacementBaseConfig = params.config;
   let authProfiles: PreparedAuthChoiceResult["authProfiles"] =
-    params.stagedAuth?.authProfiles ?? [];
+    params.stagedCandidate?.authProfiles ?? [];
   let persistAuthProfiles: PreparedAuthChoiceResult["persistAuthProfiles"] =
-    params.stagedAuth?.persistAuthProfiles ?? (async () => {});
+    params.stagedCandidate?.persistAuthProfiles ?? (async () => {});
   const authChoiceFromPrompt = opts.authChoice === undefined;
   let authChoice: AuthChoice | KeepCurrentAuthChoice | undefined = opts.authChoice;
   let authStore:
@@ -171,6 +172,11 @@ export async function runSetupModelAuthStep(params: {
       break;
     }
 
+    // A new auth choice replaces the rejected candidate instead of layering onto it.
+    nextConfig = replacementBaseConfig;
+    authProfiles = [];
+    persistAuthProfiles = async () => {};
+
     if (authChoice === "custom-api-key") {
       const { promptCustomApiConfig } = await import("../commands/onboard-custom.js");
       const customResult = await promptCustomApiConfig({
@@ -180,8 +186,6 @@ export async function runSetupModelAuthStep(params: {
         secretInputMode: opts.secretInputMode,
       });
       nextConfig = customResult.config;
-      authProfiles = [];
-      persistAuthProfiles = async () => {};
       prompter.disableBackNavigation?.();
       break;
     }
@@ -250,6 +254,7 @@ export async function runSetupModelAuthStep(params: {
     persistAuthProfiles = authResult.persistAuthProfiles;
     if (authResult.retrySelection) {
       if (authChoiceFromPrompt) {
+        replacementBaseConfig = authResult.config;
         continue;
       }
       break;

--- a/src/wizard/setup.model-auth.ts
+++ b/src/wizard/setup.model-auth.ts
@@ -10,6 +10,15 @@ import { WizardCancelledError, type WizardPrompter } from "./prompts.js";
 
 type KeepCurrentAuthChoice =
   typeof import("../commands/auth-choice-prompt.js").KEEP_CURRENT_AUTH_CHOICE;
+type PreparedAuthChoiceResult = Awaited<
+  ReturnType<typeof import("../commands/auth-choice.js").prepareAuthChoice>
+>;
+
+export type SetupModelAuthCandidate = {
+  config: OpenClawConfig;
+  authProfiles: PreparedAuthChoiceResult["authProfiles"];
+  persistAuthProfiles: PreparedAuthChoiceResult["persistAuthProfiles"];
+};
 
 const loadAuthChoiceModule = createLazyRuntimeModule(() => import("../commands/auth-choice.js"));
 
@@ -118,9 +127,11 @@ export async function runSetupModelAuthStep(params: {
   prompter: WizardPrompter;
   runtime: RuntimeEnv;
   workspaceDir: string;
-}): Promise<OpenClawConfig> {
+}): Promise<SetupModelAuthCandidate> {
   const { opts, prompter, runtime, workspaceDir } = params;
   let nextConfig = params.config;
+  let authProfiles: PreparedAuthChoiceResult["authProfiles"] = [];
+  let persistAuthProfiles: PreparedAuthChoiceResult["persistAuthProfiles"] = async () => {};
   const authChoiceFromPrompt = opts.authChoice === undefined;
   let authChoice: AuthChoice | KeepCurrentAuthChoice | undefined = opts.authChoice;
   let authStore:
@@ -198,13 +209,13 @@ export async function runSetupModelAuthStep(params: {
     }
 
     const [
-      { applyAuthChoice, resolvePreferredProviderForAuthChoice, warnIfModelConfigLooksOff },
+      { prepareAuthChoice, resolvePreferredProviderForAuthChoice, warnIfModelConfigLooksOff },
       { applyPrimaryModel, promptDefaultModel },
     ] = await Promise.all([loadAuthChoiceModule(), loadModelPickerModule()]);
     prompter.disableBackNavigation?.();
-    let authResult: Awaited<ReturnType<typeof applyAuthChoice>>;
+    let authResult: PreparedAuthChoiceResult;
     try {
-      authResult = await applyAuthChoice({
+      authResult = await prepareAuthChoice({
         authChoice,
         config: nextConfig,
         prompter,
@@ -230,6 +241,8 @@ export async function runSetupModelAuthStep(params: {
       continue;
     }
     nextConfig = authResult.config;
+    authProfiles = authResult.authProfiles;
+    persistAuthProfiles = authResult.persistAuthProfiles;
     if (authResult.retrySelection) {
       if (authChoiceFromPrompt) {
         continue;
@@ -271,5 +284,5 @@ export async function runSetupModelAuthStep(params: {
     await warnIfModelConfigLooksOff(nextConfig, prompter, { validateCatalog: false });
     break;
   }
-  return nextConfig;
+  return { config: nextConfig, authProfiles, persistAuthProfiles };
 }

--- a/src/wizard/setup.model-auth.ts
+++ b/src/wizard/setup.model-auth.ts
@@ -123,6 +123,7 @@ async function resolveAuthChoiceModelSelectionPolicy(params: {
  */
 export async function runSetupModelAuthStep(params: {
   config: OpenClawConfig;
+  stagedAuth?: Pick<SetupModelAuthCandidate, "authProfiles" | "persistAuthProfiles">;
   opts: OnboardOptions;
   prompter: WizardPrompter;
   runtime: RuntimeEnv;
@@ -130,8 +131,10 @@ export async function runSetupModelAuthStep(params: {
 }): Promise<SetupModelAuthCandidate> {
   const { opts, prompter, runtime, workspaceDir } = params;
   let nextConfig = params.config;
-  let authProfiles: PreparedAuthChoiceResult["authProfiles"] = [];
-  let persistAuthProfiles: PreparedAuthChoiceResult["persistAuthProfiles"] = async () => {};
+  let authProfiles: PreparedAuthChoiceResult["authProfiles"] =
+    params.stagedAuth?.authProfiles ?? [];
+  let persistAuthProfiles: PreparedAuthChoiceResult["persistAuthProfiles"] =
+    params.stagedAuth?.persistAuthProfiles ?? (async () => {});
   const authChoiceFromPrompt = opts.authChoice === undefined;
   let authChoice: AuthChoice | KeepCurrentAuthChoice | undefined = opts.authChoice;
   let authStore:
@@ -177,6 +180,8 @@ export async function runSetupModelAuthStep(params: {
         secretInputMode: opts.secretInputMode,
       });
       nextConfig = customResult.config;
+      authProfiles = [];
+      persistAuthProfiles = async () => {};
       prompter.disableBackNavigation?.();
       break;
     }

--- a/src/wizard/setup.test.ts
+++ b/src/wizard/setup.test.ts
@@ -2268,5 +2268,65 @@ describe("runSetupWizard", () => {
       await removeOAuthTestTempRoot(stateDir);
     }
   });
+
+  it("retains a staged retry credential when a later Fix keeps the current auth", async () => {
+    const stateDir = await makeCaseDir("kept-auth-profile-retry-");
+    const agentDir = path.join(stateDir, "agent");
+    prepareMockAuthProfilesIn(agentDir);
+    applyAuthChoice
+      .mockResolvedValueOnce({
+        config: modelConfigWithApiKey("test-original-key"),
+      })
+      .mockResolvedValueOnce({
+        config: modelConfigWithApiKey("test-staged-key"),
+      });
+    promptAuthChoiceGrouped
+      .mockResolvedValueOnce("demo-provider")
+      .mockResolvedValueOnce(keepCurrentAuthChoice);
+    verifySetupInferenceConfig
+      .mockResolvedValueOnce({ ok: false, status: "auth", error: "login expired" })
+      .mockResolvedValueOnce({ ok: false, status: "network", error: "request timed out" })
+      .mockResolvedValueOnce({
+        ok: true,
+        modelRef: "openai/gpt-5.5",
+        latencyMs: 300,
+      });
+    const select = vi.fn(async () => "fix") as unknown as WizardPrompter["select"];
+    const prompter = buildWizardPrompter({ confirm: vi.fn(async () => true), select });
+
+    try {
+      await runSetupWizard(
+        {
+          acceptRisk: true,
+          flow: "quickstart",
+          authChoice: "demo-provider",
+          installDaemon: false,
+          skipChannels: true,
+          skipSkills: true,
+          skipSearch: true,
+          skipHealth: true,
+          skipUi: true,
+        },
+        createRuntime(),
+        prompter,
+      );
+
+      expect(applyAuthChoice).toHaveBeenCalledTimes(2);
+      expect(promptAuthChoiceGrouped).toHaveBeenCalledTimes(2);
+      expect(verifySetupInferenceConfig).toHaveBeenCalledTimes(3);
+      const finalVerification = getMockCallArg(
+        verifySetupInferenceConfig,
+        2,
+        0,
+        "final verification",
+      ) as Parameters<VerifySetupInferenceConfig>[0];
+      expect(finalVerification.authProfiles).toEqual([stagedOpenAiProfile("test-staged-key")]);
+      expect(readAuthProfileStoreForTest(agentDir).profiles["openai:default"]).toEqual(
+        stagedOpenAiProfile("test-staged-key").credential,
+      );
+    } finally {
+      await removeOAuthTestTempRoot(stateDir);
+    }
+  });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/wizard/setup.test.ts
+++ b/src/wizard/setup.test.ts
@@ -2297,7 +2297,7 @@ describe("runSetupWizard", () => {
       .mockResolvedValueOnce({ ok: false, status: "auth", error: "login expired" })
       .mockResolvedValueOnce({
         ok: false,
-        status: "network",
+        status: "timeout",
         error: "request timed out",
         authProfiles: [stagedOpenAiProfile("test-refreshed-key")],
       })

--- a/src/wizard/setup.test.ts
+++ b/src/wizard/setup.test.ts
@@ -5,6 +5,11 @@ import path from "node:path";
 import type { ProviderPlugin } from "openclaw/plugin-sdk/provider-model-shared";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { createWizardPrompter as buildWizardPrompter } from "../../test/helpers/wizard-prompter.js";
+import {
+  readAuthProfileStoreForTest,
+  removeOAuthTestTempRoot,
+} from "../agents/auth-profiles/oauth-test-utils.js";
+import { upsertAuthProfileWithLock } from "../agents/auth-profiles/profiles.js";
 import { DEFAULT_BOOTSTRAP_FILENAME } from "../agents/workspace.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginCompatibilityNotice } from "../plugins/status.js";
@@ -22,6 +27,7 @@ type ResolveManifestProviderAuthChoice =
   typeof import("../plugins/provider-auth-choices.js").resolveManifestProviderAuthChoice;
 type PromptDefaultModel = typeof import("../commands/model-picker.js").promptDefaultModel;
 type ApplyAuthChoice = typeof import("../commands/auth-choice.js").applyAuthChoice;
+type PrepareAuthChoice = typeof import("../commands/auth-choice.js").prepareAuthChoice;
 type VerifySetupInferenceConfig =
   typeof import("../system-agent/setup-inference.js").verifySetupInferenceConfig;
 
@@ -30,6 +36,13 @@ const keepCurrentAuthChoice = vi.hoisted(() => "__keep-current" as const);
 const promptAuthChoiceGrouped = vi.hoisted(() => vi.fn(async () => "skip"));
 const applyAuthChoice = vi.hoisted(() =>
   vi.fn<ApplyAuthChoice>(async (args) => ({ config: args.config })),
+);
+const prepareAuthChoice = vi.hoisted(() =>
+  vi.fn<PrepareAuthChoice>(async (args) => ({
+    ...(await applyAuthChoice(args)),
+    authProfiles: [],
+    persistAuthProfiles: async () => {},
+  })),
 );
 const resolvePreferredProviderForAuthChoice = vi.hoisted(() => vi.fn(async () => "demo-provider"));
 const resolveManifestProviderAuthChoice = vi.hoisted(() =>
@@ -193,6 +206,10 @@ function getWizardNoteCalls(note: WizardPrompter["note"]) {
 function modelConfigWithApiKey(apiKey: string): OpenClawConfig {
   return {
     agents: { defaults: { model: { primary: "openai/gpt-5.5" } } },
+    auth: {
+      profiles: { "openai:default": { provider: "openai", mode: "api_key" } },
+      order: { openai: ["openai:default"] },
+    },
     models: {
       providers: {
         openai: {
@@ -203,6 +220,38 @@ function modelConfigWithApiKey(apiKey: string): OpenClawConfig {
       },
     },
   };
+}
+
+function stagedOpenAiProfile(apiKey: string) {
+  return {
+    profileId: "openai:default",
+    credential: { type: "api_key" as const, provider: "openai", key: apiKey },
+  };
+}
+
+function prepareMockAuthProfilesIn(agentDir: string): void {
+  prepareAuthChoice.mockImplementation(async (args) => {
+    const result = await applyAuthChoice(args);
+    const apiKey = result.config.models?.providers?.openai?.apiKey;
+    if (typeof apiKey !== "string") {
+      return {
+        ...result,
+        authProfiles: [],
+        persistAuthProfiles: async () => {},
+      };
+    }
+    const profile = stagedOpenAiProfile(apiKey);
+    return {
+      ...result,
+      authProfiles: [profile],
+      persistAuthProfiles: async () => {
+        const updated = await upsertAuthProfileWithLock({ ...profile, agentDir });
+        if (!updated) {
+          throw new Error("test auth profile write failed");
+        }
+      },
+    };
+  });
 }
 
 function persistedWizardConfigs(): OpenClawConfig[] {
@@ -283,6 +332,7 @@ vi.mock("../commands/auth-choice-prompt.js", () => ({
 
 vi.mock("../commands/auth-choice.js", () => ({
   applyAuthChoice,
+  prepareAuthChoice,
   resolvePreferredProviderForAuthChoice,
   warnIfModelConfigLooksOff,
 }));
@@ -449,6 +499,12 @@ describe("runSetupWizard", () => {
     promptAuthChoiceGrouped.mockResolvedValue("skip");
     applyAuthChoice.mockReset();
     applyAuthChoice.mockImplementation(async (args) => ({ config: args.config }));
+    prepareAuthChoice.mockReset();
+    prepareAuthChoice.mockImplementation(async (args) => ({
+      ...(await applyAuthChoice(args)),
+      authProfiles: [],
+      persistAuthProfiles: async () => {},
+    }));
     setupChannels.mockReset();
     setupChannels.mockImplementation(async (cfg) => cfg);
     setupSkills.mockReset();
@@ -2068,6 +2124,9 @@ describe("runSetupWizard", () => {
   });
 
   it("keeps failed model/auth fixes in the verification loop without persisting them", async () => {
+    const stateDir = await makeCaseDir("failed-auth-profile-retry-");
+    const agentDir = path.join(stateDir, "agent");
+    prepareMockAuthProfilesIn(agentDir);
     applyAuthChoice
       .mockResolvedValueOnce({
         config: modelConfigWithApiKey("test-original-key"),
@@ -2090,52 +2149,65 @@ describe("runSetupWizard", () => {
       .mockResolvedValueOnce("continue") as unknown as WizardPrompter["select"];
     const prompter = buildWizardPrompter({ confirm: vi.fn(async () => true), select });
 
-    await runSetupWizard(
-      {
-        acceptRisk: true,
-        flow: "quickstart",
-        authChoice: "demo-provider",
-        installDaemon: false,
-        skipChannels: true,
-        skipSkills: true,
-        skipSearch: true,
-        skipHealth: true,
-        skipUi: true,
-      },
-      createRuntime(),
-      prompter,
-    );
+    try {
+      await runSetupWizard(
+        {
+          acceptRisk: true,
+          flow: "quickstart",
+          authChoice: "demo-provider",
+          installDaemon: false,
+          skipChannels: true,
+          skipSkills: true,
+          skipSearch: true,
+          skipHealth: true,
+          skipUi: true,
+        },
+        createRuntime(),
+        prompter,
+      );
 
-    expect(applyAuthChoice).toHaveBeenCalledTimes(3);
-    expect(promptAuthChoiceGrouped).toHaveBeenCalledTimes(2);
-    expect(verifySetupInferenceConfig).toHaveBeenCalledTimes(3);
-    const thirdVerification = getMockCallArg(
-      verifySetupInferenceConfig,
-      2,
-      0,
-      "third verification",
-    ) as Parameters<VerifySetupInferenceConfig>[0];
-    expect(thirdVerification.config.models?.providers?.openai?.apiKey).toBe(
-      "test-retry-still-invalid-key",
-    );
-    const secondRetry = getMockCallArg(
-      applyAuthChoice,
-      2,
-      0,
-      "second retry auth choice",
-    ) as Parameters<ApplyAuthChoice>[0];
-    expect(secondRetry.config.models?.providers?.openai?.apiKey).toBe("test-retry-invalid-key");
-    expect(select).toHaveBeenCalledTimes(3);
-    expect(
-      persistedWizardConfigs().some(
-        (config) =>
-          config.models?.providers?.openai?.apiKey === "test-retry-invalid-key" ||
-          config.models?.providers?.openai?.apiKey === "test-retry-still-invalid-key",
-      ),
-    ).toBe(false);
+      expect(applyAuthChoice).toHaveBeenCalledTimes(3);
+      expect(promptAuthChoiceGrouped).toHaveBeenCalledTimes(2);
+      expect(verifySetupInferenceConfig).toHaveBeenCalledTimes(3);
+      const thirdVerification = getMockCallArg(
+        verifySetupInferenceConfig,
+        2,
+        0,
+        "third verification",
+      ) as Parameters<VerifySetupInferenceConfig>[0];
+      expect(thirdVerification.config.models?.providers?.openai?.apiKey).toBe(
+        "test-retry-still-invalid-key",
+      );
+      const secondRetry = getMockCallArg(
+        applyAuthChoice,
+        2,
+        0,
+        "second retry auth choice",
+      ) as Parameters<ApplyAuthChoice>[0];
+      expect(secondRetry.config.models?.providers?.openai?.apiKey).toBe("test-retry-invalid-key");
+      expect(select).toHaveBeenCalledTimes(3);
+      expect(thirdVerification.authProfiles).toEqual([
+        stagedOpenAiProfile("test-retry-still-invalid-key"),
+      ]);
+      expect(
+        persistedWizardConfigs().some(
+          (config) =>
+            config.models?.providers?.openai?.apiKey === "test-retry-invalid-key" ||
+            config.models?.providers?.openai?.apiKey === "test-retry-still-invalid-key",
+        ),
+      ).toBe(false);
+      expect(readAuthProfileStoreForTest(agentDir).profiles["openai:default"]).toEqual(
+        stagedOpenAiProfile("test-original-key").credential,
+      );
+    } finally {
+      await removeOAuthTestTempRoot(stateDir);
+    }
   });
 
   it("persists a model/auth fix after its live verification succeeds", async () => {
+    const stateDir = await makeCaseDir("successful-auth-profile-retry-");
+    const agentDir = path.join(stateDir, "agent");
+    prepareMockAuthProfilesIn(agentDir);
     applyAuthChoice
       .mockResolvedValueOnce({
         config: modelConfigWithApiKey("test-original-key"),
@@ -2154,37 +2226,47 @@ describe("runSetupWizard", () => {
     const select = vi.fn(async () => "fix") as unknown as WizardPrompter["select"];
     const prompter = buildWizardPrompter({ confirm: vi.fn(async () => true), select });
 
-    await runSetupWizard(
-      {
-        acceptRisk: true,
-        flow: "quickstart",
-        authChoice: "demo-provider",
-        installDaemon: false,
-        skipChannels: true,
-        skipSkills: true,
-        skipSearch: true,
-        skipHealth: true,
-        skipUi: true,
-      },
-      createRuntime(),
-      prompter,
-    );
+    try {
+      await runSetupWizard(
+        {
+          acceptRisk: true,
+          flow: "quickstart",
+          authChoice: "demo-provider",
+          installDaemon: false,
+          skipChannels: true,
+          skipSkills: true,
+          skipSearch: true,
+          skipHealth: true,
+          skipUi: true,
+        },
+        createRuntime(),
+        prompter,
+      );
 
-    expect(applyAuthChoice).toHaveBeenCalledTimes(2);
-    expect(promptAuthChoiceGrouped).toHaveBeenCalledOnce();
-    expect(verifySetupInferenceConfig).toHaveBeenCalledTimes(2);
-    const retryVerification = getMockCallArg(
-      verifySetupInferenceConfig,
-      1,
-      0,
-      "retry verification",
-    ) as Parameters<VerifySetupInferenceConfig>[0];
-    expect(retryVerification.config.models?.providers?.openai?.apiKey).toBe("test-retry-valid-key");
-    expect(
-      persistedWizardConfigs().some(
-        (config) => config.models?.providers?.openai?.apiKey === "test-retry-valid-key",
-      ),
-    ).toBe(true);
+      expect(applyAuthChoice).toHaveBeenCalledTimes(2);
+      expect(promptAuthChoiceGrouped).toHaveBeenCalledOnce();
+      expect(verifySetupInferenceConfig).toHaveBeenCalledTimes(2);
+      const retryVerification = getMockCallArg(
+        verifySetupInferenceConfig,
+        1,
+        0,
+        "retry verification",
+      ) as Parameters<VerifySetupInferenceConfig>[0];
+      expect(retryVerification.config.models?.providers?.openai?.apiKey).toBe(
+        "test-retry-valid-key",
+      );
+      expect(retryVerification.authProfiles).toEqual([stagedOpenAiProfile("test-retry-valid-key")]);
+      expect(
+        persistedWizardConfigs().some(
+          (config) => config.models?.providers?.openai?.apiKey === "test-retry-valid-key",
+        ),
+      ).toBe(true);
+      expect(readAuthProfileStoreForTest(agentDir).profiles["openai:default"]).toEqual(
+        stagedOpenAiProfile("test-retry-valid-key").credential,
+      );
+    } finally {
+      await removeOAuthTestTempRoot(stateDir);
+    }
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/wizard/setup.test.ts
+++ b/src/wizard/setup.test.ts
@@ -13,6 +13,7 @@ import { upsertAuthProfileWithLock } from "../agents/auth-profiles/profiles.js";
 import { DEFAULT_BOOTSTRAP_FILENAME } from "../agents/workspace.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginCompatibilityNotice } from "../plugins/status.js";
+import type { ProviderAuthResult } from "../plugins/types.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { WizardPrompter, WizardSelectParams } from "./prompts.js";
 import { runSetupWizard } from "./setup.js";
@@ -229,7 +230,10 @@ function stagedOpenAiProfile(apiKey: string) {
   };
 }
 
-function prepareMockAuthProfilesIn(agentDir: string): void {
+function prepareMockAuthProfilesIn(
+  agentDir: string,
+): Array<ProviderAuthResult["profiles"] | undefined> {
+  const persistCalls: Array<ProviderAuthResult["profiles"] | undefined> = [];
   prepareAuthChoice.mockImplementation(async (args) => {
     const result = await applyAuthChoice(args);
     const apiKey = result.config.models?.providers?.openai?.apiKey;
@@ -244,14 +248,18 @@ function prepareMockAuthProfilesIn(agentDir: string): void {
     return {
       ...result,
       authProfiles: [profile],
-      persistAuthProfiles: async () => {
-        const updated = await upsertAuthProfileWithLock({ ...profile, agentDir });
-        if (!updated) {
-          throw new Error("test auth profile write failed");
+      persistAuthProfiles: async (profiles) => {
+        persistCalls.push(profiles);
+        for (const candidate of profiles ?? [profile]) {
+          const updated = await upsertAuthProfileWithLock({ ...candidate, agentDir });
+          if (!updated) {
+            throw new Error("test auth profile write failed");
+          }
         }
       },
     };
   });
+  return persistCalls;
 }
 
 function persistedWizardConfigs(): OpenClawConfig[] {
@@ -2207,7 +2215,7 @@ describe("runSetupWizard", () => {
   it("persists a model/auth fix after its live verification succeeds", async () => {
     const stateDir = await makeCaseDir("successful-auth-profile-retry-");
     const agentDir = path.join(stateDir, "agent");
-    prepareMockAuthProfilesIn(agentDir);
+    const persistCalls = prepareMockAuthProfilesIn(agentDir);
     applyAuthChoice
       .mockResolvedValueOnce({
         config: modelConfigWithApiKey("test-original-key"),
@@ -2222,6 +2230,7 @@ describe("runSetupWizard", () => {
         ok: true,
         modelRef: "openai/gpt-5.5",
         latencyMs: 300,
+        authProfiles: [stagedOpenAiProfile("test-retry-valid-key")],
       });
     const select = vi.fn(async () => "fix") as unknown as WizardPrompter["select"];
     const prompter = buildWizardPrompter({ confirm: vi.fn(async () => true), select });
@@ -2264,6 +2273,7 @@ describe("runSetupWizard", () => {
       expect(readAuthProfileStoreForTest(agentDir).profiles["openai:default"]).toEqual(
         stagedOpenAiProfile("test-retry-valid-key").credential,
       );
+      expect(persistCalls).toEqual([undefined, [stagedOpenAiProfile("test-retry-valid-key")]]);
     } finally {
       await removeOAuthTestTempRoot(stateDir);
     }

--- a/src/wizard/setup.test.ts
+++ b/src/wizard/setup.test.ts
@@ -2184,7 +2184,7 @@ describe("runSetupWizard", () => {
         0,
         "second retry auth choice",
       ) as Parameters<ApplyAuthChoice>[0];
-      expect(secondRetry.config.models?.providers?.openai?.apiKey).toBe("test-retry-invalid-key");
+      expect(secondRetry.config.models?.providers?.openai?.apiKey).toBe("test-original-key");
       expect(select).toHaveBeenCalledTimes(3);
       expect(thirdVerification.authProfiles).toEqual([
         stagedOpenAiProfile("test-retry-still-invalid-key"),

--- a/src/wizard/setup.test.ts
+++ b/src/wizard/setup.test.ts
@@ -6,6 +6,7 @@ import type { ProviderPlugin } from "openclaw/plugin-sdk/provider-model-shared";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { createWizardPrompter as buildWizardPrompter } from "../../test/helpers/wizard-prompter.js";
 import { DEFAULT_BOOTSTRAP_FILENAME } from "../agents/workspace.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginCompatibilityNotice } from "../plugins/status.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { WizardPrompter, WizardSelectParams } from "./prompts.js";
@@ -21,6 +22,8 @@ type ResolveManifestProviderAuthChoice =
   typeof import("../plugins/provider-auth-choices.js").resolveManifestProviderAuthChoice;
 type PromptDefaultModel = typeof import("../commands/model-picker.js").promptDefaultModel;
 type ApplyAuthChoice = typeof import("../commands/auth-choice.js").applyAuthChoice;
+type VerifySetupInferenceConfig =
+  typeof import("../system-agent/setup-inference.js").verifySetupInferenceConfig;
 
 const ensureAuthProfileStore = vi.hoisted(() => vi.fn(() => ({ profiles: {} })));
 const keepCurrentAuthChoice = vi.hoisted(() => "__keep-current" as const);
@@ -111,10 +114,12 @@ const detectSetupMigrationSources = vi.hoisted(() => vi.fn(async () => []));
 const listSetupMigrationOptions = vi.hoisted(() => vi.fn(async () => []));
 const runSetupMigrationImport = vi.hoisted(() => vi.fn(async () => {}));
 const runSetupMemoryImportStep = vi.hoisted(() => vi.fn(async () => {}));
-const verifySetupInference = vi.hoisted(() =>
-  vi.fn<() => Promise<import("../system-agent/setup-inference.js").VerifySetupInferenceResult>>(
-    async () => ({ ok: true, modelRef: "openai/gpt-5.5", latencyMs: 250 }),
-  ),
+const verifySetupInferenceConfig = vi.hoisted(() =>
+  vi.fn<VerifySetupInferenceConfig>(async () => ({
+    ok: true,
+    modelRef: "openai/gpt-5.5",
+    latencyMs: 250,
+  })),
 );
 
 const setupChannels = vi.hoisted(() =>
@@ -183,6 +188,27 @@ const formatPluginCompatibilityNotice = vi.hoisted(() =>
 
 function getWizardNoteCalls(note: WizardPrompter["note"]) {
   return (note as unknown as { mock: { calls: unknown[][] } }).mock.calls;
+}
+
+function modelConfigWithApiKey(apiKey: string): OpenClawConfig {
+  return {
+    agents: { defaults: { model: { primary: "openai/gpt-5.5" } } },
+    models: {
+      providers: {
+        openai: {
+          apiKey,
+          baseUrl: "https://api.openai.com/v1",
+          models: [],
+        },
+      },
+    },
+  };
+}
+
+function persistedWizardConfigs(): OpenClawConfig[] {
+  return (replaceConfigFile.mock.calls as unknown[][]).map(
+    ([params]) => (params as { nextConfig: OpenClawConfig }).nextConfig,
+  );
 }
 
 function requireRecord(value: unknown, label: string): Record<string, unknown> {
@@ -303,7 +329,7 @@ vi.mock("./setup.memory-import.js", () => ({
 }));
 
 vi.mock("../system-agent/setup-inference.js", () => ({
-  verifySetupInference,
+  verifySetupInferenceConfig,
 }));
 
 vi.mock("../config/config.js", () => ({
@@ -474,8 +500,8 @@ describe("runSetupWizard", () => {
     warnIfModelConfigLooksOff.mockResolvedValue(undefined);
     buildPluginCompatibilitySnapshotNotices.mockReset();
     buildPluginCompatibilitySnapshotNotices.mockReturnValue([]);
-    verifySetupInference.mockReset();
-    verifySetupInference.mockResolvedValue({
+    verifySetupInferenceConfig.mockReset();
+    verifySetupInferenceConfig.mockResolvedValue({
       ok: true,
       modelRef: "openai/gpt-5.5",
       latencyMs: 250,
@@ -2002,14 +2028,14 @@ describe("runSetupWizard", () => {
     expect(confirm).toHaveBeenCalledWith(
       expect.objectContaining({ message: "Test AI access now with a live completion?" }),
     );
-    expect(verifySetupInference).toHaveBeenCalledOnce();
+    expect(verifySetupInferenceConfig).toHaveBeenCalledOnce();
   });
 
   it("continues classic setup when live AI verification fails", async () => {
     applyAuthChoice.mockResolvedValueOnce({
       config: { agents: { defaults: { model: { primary: "openai/gpt-5.5" } } } },
     });
-    verifySetupInference.mockResolvedValueOnce({
+    verifySetupInferenceConfig.mockResolvedValueOnce({
       ok: false,
       status: "auth",
       error: "login expired",
@@ -2038,17 +2064,93 @@ describe("runSetupWizard", () => {
     expect(select).toHaveBeenCalledWith(
       expect.objectContaining({ message: "How would you like to continue?" }),
     );
-    expect(verifySetupInference).toHaveBeenCalledOnce();
+    expect(verifySetupInferenceConfig).toHaveBeenCalledOnce();
   });
 
-  it("re-enters model/auth setup once and re-verifies after a failed AI check", async () => {
-    applyAuthChoice.mockResolvedValue({
-      config: { agents: { defaults: { model: { primary: "openai/gpt-5.5" } } } },
-    });
+  it("keeps failed model/auth fixes in the verification loop without persisting them", async () => {
+    applyAuthChoice
+      .mockResolvedValueOnce({
+        config: modelConfigWithApiKey("test-original-key"),
+      })
+      .mockResolvedValueOnce({
+        config: modelConfigWithApiKey("test-retry-invalid-key"),
+      })
+      .mockResolvedValueOnce({
+        config: modelConfigWithApiKey("test-retry-still-invalid-key"),
+      });
     promptAuthChoiceGrouped.mockResolvedValue("demo-provider");
-    verifySetupInference
+    verifySetupInferenceConfig
       .mockResolvedValueOnce({ ok: false, status: "auth", error: "login expired" })
-      .mockResolvedValueOnce({ ok: true, modelRef: "openai/gpt-5.5", latencyMs: 300 });
+      .mockResolvedValueOnce({ ok: false, status: "auth", error: "key rejected" })
+      .mockResolvedValueOnce({ ok: false, status: "auth", error: "key still rejected" });
+    const select = vi
+      .fn()
+      .mockResolvedValueOnce("fix")
+      .mockResolvedValueOnce("fix")
+      .mockResolvedValueOnce("continue") as unknown as WizardPrompter["select"];
+    const prompter = buildWizardPrompter({ confirm: vi.fn(async () => true), select });
+
+    await runSetupWizard(
+      {
+        acceptRisk: true,
+        flow: "quickstart",
+        authChoice: "demo-provider",
+        installDaemon: false,
+        skipChannels: true,
+        skipSkills: true,
+        skipSearch: true,
+        skipHealth: true,
+        skipUi: true,
+      },
+      createRuntime(),
+      prompter,
+    );
+
+    expect(applyAuthChoice).toHaveBeenCalledTimes(3);
+    expect(promptAuthChoiceGrouped).toHaveBeenCalledTimes(2);
+    expect(verifySetupInferenceConfig).toHaveBeenCalledTimes(3);
+    const thirdVerification = getMockCallArg(
+      verifySetupInferenceConfig,
+      2,
+      0,
+      "third verification",
+    ) as Parameters<VerifySetupInferenceConfig>[0];
+    expect(thirdVerification.config.models?.providers?.openai?.apiKey).toBe(
+      "test-retry-still-invalid-key",
+    );
+    const secondRetry = getMockCallArg(
+      applyAuthChoice,
+      2,
+      0,
+      "second retry auth choice",
+    ) as Parameters<ApplyAuthChoice>[0];
+    expect(secondRetry.config.models?.providers?.openai?.apiKey).toBe("test-retry-invalid-key");
+    expect(select).toHaveBeenCalledTimes(3);
+    expect(
+      persistedWizardConfigs().some(
+        (config) =>
+          config.models?.providers?.openai?.apiKey === "test-retry-invalid-key" ||
+          config.models?.providers?.openai?.apiKey === "test-retry-still-invalid-key",
+      ),
+    ).toBe(false);
+  });
+
+  it("persists a model/auth fix after its live verification succeeds", async () => {
+    applyAuthChoice
+      .mockResolvedValueOnce({
+        config: modelConfigWithApiKey("test-original-key"),
+      })
+      .mockResolvedValueOnce({
+        config: modelConfigWithApiKey("test-retry-valid-key"),
+      });
+    promptAuthChoiceGrouped.mockResolvedValue("demo-provider");
+    verifySetupInferenceConfig
+      .mockResolvedValueOnce({ ok: false, status: "auth", error: "login expired" })
+      .mockResolvedValueOnce({
+        ok: true,
+        modelRef: "openai/gpt-5.5",
+        latencyMs: 300,
+      });
     const select = vi.fn(async () => "fix") as unknown as WizardPrompter["select"];
     const prompter = buildWizardPrompter({ confirm: vi.fn(async () => true), select });
 
@@ -2070,7 +2172,19 @@ describe("runSetupWizard", () => {
 
     expect(applyAuthChoice).toHaveBeenCalledTimes(2);
     expect(promptAuthChoiceGrouped).toHaveBeenCalledOnce();
-    expect(verifySetupInference).toHaveBeenCalledTimes(2);
+    expect(verifySetupInferenceConfig).toHaveBeenCalledTimes(2);
+    const retryVerification = getMockCallArg(
+      verifySetupInferenceConfig,
+      1,
+      0,
+      "retry verification",
+    ) as Parameters<VerifySetupInferenceConfig>[0];
+    expect(retryVerification.config.models?.providers?.openai?.apiKey).toBe("test-retry-valid-key");
+    expect(
+      persistedWizardConfigs().some(
+        (config) => config.models?.providers?.openai?.apiKey === "test-retry-valid-key",
+      ),
+    ).toBe(true);
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/wizard/setup.test.ts
+++ b/src/wizard/setup.test.ts
@@ -2295,7 +2295,12 @@ describe("runSetupWizard", () => {
       .mockResolvedValueOnce(keepCurrentAuthChoice);
     verifySetupInferenceConfig
       .mockResolvedValueOnce({ ok: false, status: "auth", error: "login expired" })
-      .mockResolvedValueOnce({ ok: false, status: "network", error: "request timed out" })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: "network",
+        error: "request timed out",
+        authProfiles: [stagedOpenAiProfile("test-refreshed-key")],
+      })
       .mockResolvedValueOnce({
         ok: true,
         modelRef: "openai/gpt-5.5",
@@ -2330,7 +2335,7 @@ describe("runSetupWizard", () => {
         0,
         "final verification",
       ) as Parameters<VerifySetupInferenceConfig>[0];
-      expect(finalVerification.authProfiles).toEqual([stagedOpenAiProfile("test-staged-key")]);
+      expect(finalVerification.authProfiles).toEqual([stagedOpenAiProfile("test-refreshed-key")]);
       expect(readAuthProfileStoreForTest(agentDir).profiles["openai:default"]).toEqual(
         stagedOpenAiProfile("test-staged-key").credential,
       );

--- a/src/wizard/setup.ts
+++ b/src/wizard/setup.ts
@@ -62,11 +62,11 @@ async function offerLiveModelVerification(params: {
     return { config: params.config, verified: false };
   }
 
-  const { verifySetupInference } = await import("../system-agent/setup-inference.js");
-  const verify = async () => {
+  const { verifySetupInferenceConfig } = await import("../system-agent/setup-inference.js");
+  const verify = async (config: OpenClawConfig) => {
     const progress = params.prompter.progress(t("wizard.setup.testAiProgress"));
     const result = await withConsoleSubsystemsSuppressed(() =>
-      verifySetupInference({ runtime: params.runtime }),
+      verifySetupInferenceConfig({ config, runtime: params.runtime }),
     );
     progress.stop();
     if (result.ok) {
@@ -83,31 +83,37 @@ async function offerLiveModelVerification(params: {
     return result;
   };
 
-  const firstResult = await verify();
-  if (firstResult.ok) {
-    return { config: params.config, verified: true };
-  }
-  const action = await params.prompter.select({
-    message: t("wizard.setup.testAiFailureChoice"),
-    options: [
-      { value: "fix", label: t("wizard.setup.testAiFix") },
-      { value: "continue", label: t("wizard.setup.testAiContinue") },
-    ],
-  });
-  if (action === "continue") {
-    return { config: params.config, verified: false };
-  }
+  let candidateConfig = params.config;
+  let shouldPersistCandidate = false;
+  while (true) {
+    const result = await verify(candidateConfig);
+    if (result.ok) {
+      const config = shouldPersistCandidate
+        ? await params.writeConfig(candidateConfig)
+        : params.config;
+      return { config, verified: true };
+    }
+    const action = await params.prompter.select({
+      message: t("wizard.setup.testAiFailureChoice"),
+      options: [
+        { value: "fix", label: t("wizard.setup.testAiFix") },
+        { value: "continue", label: t("wizard.setup.testAiContinue") },
+      ],
+    });
+    if (action === "continue") {
+      return { config: params.config, verified: false };
+    }
 
-  const fixedConfig = await runSetupModelAuthStep({
-    config: params.config,
-    opts: { ...params.opts, authChoice: undefined },
-    prompter: params.prompter,
-    runtime: params.runtime,
-    workspaceDir: params.workspaceDir,
-  });
-  const persistedConfig = await params.writeConfig(fixedConfig);
-  const retryResult = await verify();
-  return { config: persistedConfig, verified: retryResult.ok };
+    // Attempts N>1 must pass the same gate as attempt 1 so failed retry config never persists.
+    candidateConfig = await runSetupModelAuthStep({
+      config: candidateConfig,
+      opts: { ...params.opts, authChoice: undefined },
+      prompter: params.prompter,
+      runtime: params.runtime,
+      workspaceDir: params.workspaceDir,
+    });
+    shouldPersistCandidate = true;
+  }
 }
 
 function isSetupImportFlowChoice(flow: SetupFlowChoice): boolean {

--- a/src/wizard/setup.ts
+++ b/src/wizard/setup.ts
@@ -114,9 +114,10 @@ async function offerLiveModelVerification(params: {
       return { config: params.config, verified: false };
     }
 
-    // Attempts N>1 must pass the same gate as attempt 1 so failed retry config never persists.
+    // Attempts N>1 share the same gate and staged credentials until the user replaces them.
     candidate = await runSetupModelAuthStep({
       config: candidate.config,
+      stagedAuth: candidate,
       opts: { ...params.opts, authChoice: undefined },
       prompter: params.prompter,
       runtime: params.runtime,

--- a/src/wizard/setup.ts
+++ b/src/wizard/setup.ts
@@ -116,8 +116,8 @@ async function offerLiveModelVerification(params: {
 
     // Attempts N>1 share the same gate and staged credentials until the user replaces them.
     candidate = await runSetupModelAuthStep({
-      config: candidate.config,
-      stagedAuth: candidate,
+      config: params.config,
+      stagedCandidate: candidate,
       opts: { ...params.opts, authChoice: undefined },
       prompter: params.prompter,
       runtime: params.runtime,

--- a/src/wizard/setup.ts
+++ b/src/wizard/setup.ts
@@ -103,6 +103,9 @@ async function offerLiveModelVerification(params: {
       const config = await params.writeConfig(candidate.config);
       return { config, verified: true };
     }
+    if (result.authProfiles) {
+      candidate.authProfiles = result.authProfiles;
+    }
     const action = await params.prompter.select({
       message: t("wizard.setup.testAiFailureChoice"),
       options: [

--- a/src/wizard/setup.ts
+++ b/src/wizard/setup.ts
@@ -23,7 +23,7 @@ import {
   listSetupMigrationOptions,
   runSetupMigrationImport,
 } from "./setup.migration-import.js";
-import { runSetupModelAuthStep } from "./setup.model-auth.js";
+import { runSetupModelAuthStep, type SetupModelAuthCandidate } from "./setup.model-auth.js";
 import { resolveSetupSecretInputString } from "./setup.secret-input.js";
 import {
   readSetupConfigFileSnapshot,
@@ -63,10 +63,14 @@ async function offerLiveModelVerification(params: {
   }
 
   const { verifySetupInferenceConfig } = await import("../system-agent/setup-inference.js");
-  const verify = async (config: OpenClawConfig) => {
+  const verify = async (candidate: SetupModelAuthCandidate) => {
     const progress = params.prompter.progress(t("wizard.setup.testAiProgress"));
     const result = await withConsoleSubsystemsSuppressed(() =>
-      verifySetupInferenceConfig({ config, runtime: params.runtime }),
+      verifySetupInferenceConfig({
+        config: candidate.config,
+        runtime: params.runtime,
+        authProfiles: candidate.authProfiles,
+      }),
     );
     progress.stop();
     if (result.ok) {
@@ -83,14 +87,20 @@ async function offerLiveModelVerification(params: {
     return result;
   };
 
-  let candidateConfig = params.config;
+  let candidate: SetupModelAuthCandidate = {
+    config: params.config,
+    authProfiles: [],
+    persistAuthProfiles: async () => {},
+  };
   let shouldPersistCandidate = false;
   while (true) {
-    const result = await verify(candidateConfig);
+    const result = await verify(candidate);
     if (result.ok) {
-      const config = shouldPersistCandidate
-        ? await params.writeConfig(candidateConfig)
-        : params.config;
+      if (!shouldPersistCandidate) {
+        return { config: params.config, verified: true };
+      }
+      await candidate.persistAuthProfiles();
+      const config = await params.writeConfig(candidate.config);
       return { config, verified: true };
     }
     const action = await params.prompter.select({
@@ -105,8 +115,8 @@ async function offerLiveModelVerification(params: {
     }
 
     // Attempts N>1 must pass the same gate as attempt 1 so failed retry config never persists.
-    candidateConfig = await runSetupModelAuthStep({
-      config: candidateConfig,
+    candidate = await runSetupModelAuthStep({
+      config: candidate.config,
       opts: { ...params.opts, authChoice: undefined },
       prompter: params.prompter,
       runtime: params.runtime,
@@ -555,13 +565,15 @@ async function runSetupWizardOnce(
   }
 
   if (!keepExistingModelConfig) {
-    nextConfig = await runSetupModelAuthStep({
+    const modelAuth = await runSetupModelAuthStep({
       config: nextConfig,
       opts,
       prompter,
       runtime,
       workspaceDir,
     });
+    await modelAuth.persistAuthProfiles();
+    nextConfig = modelAuth.config;
   }
 
   const { configureGatewayForSetup } = await import("./setup.gateway-config.js");

--- a/src/wizard/setup.ts
+++ b/src/wizard/setup.ts
@@ -99,7 +99,7 @@ async function offerLiveModelVerification(params: {
       if (!shouldPersistCandidate) {
         return { config: params.config, verified: true };
       }
-      await candidate.persistAuthProfiles();
+      await candidate.persistAuthProfiles(result.authProfiles);
       const config = await params.writeConfig(candidate.config);
       return { config, verified: true };
     }


### PR DESCRIPTION
## What Problem This Solves

Classic interactive setup treated the first failed model/auth validation differently from later Fix attempts. A second failing key could be written and setup could continue as though validation had succeeded. Provider auth profiles were also written before the live check, so deferring only the config write was not enough.

## Why This Change Was Made

The wizard now keeps each repair as one staged candidate containing both config and provider auth profiles. Every attempt passes through the same live-verification gate; only a successful result commits the verified profiles and config. Continue retains the last accepted setup, a new auth choice starts from that accepted setup instead of layering onto a rejected repair, and Keep preserves the current staged candidate.

Verification uses an isolated temporary agent auth store, locks the probe to the profile selected by the candidate config, and returns any OAuth refresh made during the live run so the deferred commit writes the credential that actually passed. Existing non-retry auth-choice callers retain their immediate-persist behavior.

AI-assisted implementation. Review findings about eager profile writes, cross-attempt state, exact profile pins, and refreshed OAuth credentials were applied before the final clean autoreview.

## User Impact

Repeated invalid retries no longer leave a broken key or rejected config behind. A valid retry persists normally, Continue keeps the previously working setup, and refreshable credentials remain usable after a successful verification.

## Evidence

- `node scripts/run-vitest.mjs src/wizard/setup.test.ts` — 38 passed, including invalid → Fix → invalid, invalid → Fix → valid, and later Keep-current retry coverage against a real SQLite auth store.
- `node scripts/run-vitest.mjs src/wizard/setup.model-auth.test.ts` — 3 passed.
- `node scripts/run-vitest.mjs src/commands/auth-choice.apply.plugin-provider.test.ts` — 12 passed.
- `node scripts/run-vitest.mjs src/plugins/provider-auth-choice.test.ts` — 1 passed.
- `node scripts/run-vitest.mjs src/commands/auth-choice.test.ts` — 11 passed.
- `node scripts/run-vitest.mjs src/system-agent/setup-inference.test.ts -t "staged profile|staged credential"` — 2 passed; proves isolated OAuth refresh capture and exact profile-pin rejection.
- `pnpm tsgo` — passed.
- `pnpm tsgo:core:test` — passed.
- Targeted `node scripts/run-oxlint.mjs` across all changed files — passed.
- `git diff --check` — passed.
- Fresh branch autoreview against `origin/main` — clean, no accepted/actionable findings.
- ClawSweeper's requested real-provider wizard transcript was not added because no disposable live credential pair was available. This maintainer landing accepts that proof gap; the exact rejected and successful config/auth-store transitions are covered against real temporary SQLite stores.
