### PR TITLE
fix(agents): prevent over-aggressive aggregate truncation of fresh tool results

### DIFF
--- a/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
@@ -3,72 +3,50 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { expectDefined } from "@openclaw/normalization-core";
 import type { AgentMessage } from "openclaw/plugin-sdk/agent-core";
 import { SessionManager } from "openclaw/plugin-sdk/agent-sessions";
 import type { AssistantMessage, ToolResultMessage, UserMessage } from "openclaw/plugin-sdk/llm";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { convertToLlm } from "../../../packages/agent-core/src/harness/messages.js";
-import {
-  appendTranscriptMessage,
-  loadTranscriptEvents,
-  replaceSessionEntry,
-  replaceTranscriptEvents,
-} from "../../config/sessions/session-accessor.js";
-import { formatSqliteSessionFileMarker } from "../../config/sessions/sqlite-marker.js";
-import type { SessionEntry as SessionStoreEntry } from "../../config/sessions/types.js";
 import { onInternalSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
-import { formatFullOutputFooter } from "../sessions/tools/tool-contracts.js";
 import { makeAgentAssistantMessage } from "../test-helpers/agent-message-fixtures.js";
-import { buildRuntimeContextCustomMessage } from "./run/runtime-context-prompt.js";
-import {
-  clearEmbeddedSessionPromptStates,
-  getEmbeddedSessionPromptState,
-  type ToolResultPromptProjectionState,
-} from "./session-prompt-state.js";
 
+let truncateToolResultText: typeof import("./tool-result-truncation.js").truncateToolResultText;
 let truncateToolResultMessage: typeof import("./tool-result-truncation.js").truncateToolResultMessage;
+let calculateMaxToolResultChars: typeof import("./tool-result-truncation.js").calculateMaxToolResultChars;
 let calculateMaxToolResultCharsWithCap: typeof import("./tool-result-truncation.js").calculateMaxToolResultCharsWithCap;
 let resolveAutoLiveToolResultMaxChars: typeof import("./tool-result-truncation.js").resolveAutoLiveToolResultMaxChars;
+let getToolResultTextLength: typeof import("./tool-result-truncation.js").getToolResultTextLength;
 let truncateOversizedToolResultsInMessages: typeof import("./tool-result-truncation.js").truncateOversizedToolResultsInMessages;
-let truncateOversizedToolResultsInActiveTarget: typeof import("./tool-result-truncation.js").truncateOversizedToolResultsInActiveTarget;
+let truncateOversizedToolResultsInSession: typeof import("./tool-result-truncation.js").truncateOversizedToolResultsInSession;
 let sessionLikelyHasOversizedToolResults: typeof import("./tool-result-truncation.js").sessionLikelyHasOversizedToolResults;
 let estimateToolResultReductionPotential: typeof import("./tool-result-truncation.js").estimateToolResultReductionPotential;
 let DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS: typeof import("./tool-result-truncation.js").DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS;
 let resolveLiveToolResultMaxChars: typeof import("./tool-result-truncation.js").resolveLiveToolResultMaxChars;
-let resolveLiveToolResultAggregateMaxChars: typeof import("./tool-result-truncation.js").resolveLiveToolResultAggregateMaxChars;
-let toolResultWarningDedupe: typeof import("./tool-result-truncation.js").toolResultWarningDedupe;
+let createToolResultPromptProjectionState: typeof import("./tool-result-truncation.js").createToolResultPromptProjectionState;
 let tmpDir: string | undefined;
 
 async function loadFreshToolResultTruncationModuleForTest() {
   // Load after each setup so module-level constants and mocks stay isolated
   // across persisted-session and live-truncation tests.
   ({
+    truncateToolResultText,
     truncateToolResultMessage,
+    calculateMaxToolResultChars,
     calculateMaxToolResultCharsWithCap,
     resolveAutoLiveToolResultMaxChars,
+    getToolResultTextLength,
     truncateOversizedToolResultsInMessages,
-    truncateOversizedToolResultsInActiveTarget,
+    truncateOversizedToolResultsInSession,
     sessionLikelyHasOversizedToolResults,
     estimateToolResultReductionPotential,
     DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS,
     resolveLiveToolResultMaxChars,
-    resolveLiveToolResultAggregateMaxChars,
-    toolResultWarningDedupe,
+    createToolResultPromptProjectionState,
   } = await import("./tool-result-truncation.js"));
 }
 
 let testTimestamp = 1;
 const nextTimestamp = () => testTimestamp++;
-
-function createPromptProjectionStateForTest(): ToolResultPromptProjectionState {
-  return {
-    replacements: new Map(),
-    frozen: new Set(),
-    ambiguousBaseKeys: new Set(),
-    sourceTextByKey: new Map(),
-  };
-}
 
 beforeEach(async () => {
   testTimestamp = 1;
@@ -76,16 +54,13 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
-  toolResultWarningDedupe.promptPressure.clear();
-  toolResultWarningDedupe.sessionRecovery.clear();
-  clearEmbeddedSessionPromptStates(["session-99495", "session-99495-shrink"]);
   if (tmpDir) {
     await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
     tmpDir = undefined;
   }
 });
 
-function makeToolResult(text: string, toolCallId = "call_1", details?: unknown): ToolResultMessage {
+function makeToolResult(text: string, toolCallId = "call_1"): ToolResultMessage {
   // Tool-result fixtures use increasing timestamps so persisted branch rewrites
   // can preserve ordering while changing content.
   return {
@@ -94,39 +69,8 @@ function makeToolResult(text: string, toolCallId = "call_1", details?: unknown):
     toolName: "read",
     content: [{ type: "text", text }],
     isError: false,
-    ...(details !== undefined ? { details } : {}),
     timestamp: nextTimestamp(),
   };
-}
-
-describe("tool-result warning dedupe", () => {
-  const warningDedupeLimit = 1_024;
-
-  it.each([
-    ["prompt pressure", () => toolResultWarningDedupe.promptPressure],
-    ["session recovery", () => toolResultWarningDedupe.sessionRecovery],
-  ])("bounds and evicts the oldest %s warning keys", (_name, getCache) => {
-    const cache = getCache();
-
-    for (let index = 0; index <= warningDedupeLimit; index += 1) {
-      expect(cache.check(`session-${index}`)).toBe(false);
-    }
-
-    expect(cache.size()).toBe(warningDedupeLimit);
-    expect(cache.peek("session-0")).toBe(false);
-    expect(cache.peek("session-1")).toBe(true);
-    expect(cache.peek(`session-${warningDedupeLimit}`)).toBe(true);
-    expect(cache.check("session-0")).toBe(false);
-    expect(cache.check(`session-${warningDedupeLimit}`)).toBe(true);
-  });
-});
-
-function textWithFullOutputFooter(text: string, fullOutputPath: string): string {
-  return `${text}\n\n[Showing truncated output. ${formatFullOutputFooter(fullOutputPath)}]`;
-}
-
-function realisticSpillPath(dir: string, name: string): string {
-  return path.join(dir, `${name}-${"segment-".repeat(8)}output.log`);
 }
 
 function makeUserMessage(text: string): UserMessage {
@@ -154,61 +98,8 @@ function getFirstToolResultText(message: AgentMessage | ToolResultMessage): stri
   return firstBlock && "text" in firstBlock ? firstBlock.text : "";
 }
 
-function truncateToolResultText(
-  text: string,
-  maxChars: number,
-  options?: Parameters<typeof truncateToolResultMessage>[2],
-): string {
-  return getFirstToolResultText(truncateToolResultMessage(makeToolResult(text), maxChars, options));
-}
-
-function calculateMaxToolResultChars(contextWindowTokens: number): number {
-  return resolveLiveToolResultMaxChars({ contextWindowTokens });
-}
-
-function getToolResultTextLength(message: AgentMessage): number {
-  if (message.role !== "toolResult") {
-    return 0;
-  }
-  return message.content.reduce((length, block) => {
-    if (!block || typeof block !== "object" || !("text" in block)) {
-      return length;
-    }
-    return length + (typeof block.text === "string" ? block.text.length : 0);
-  }, 0);
-}
-
-async function truncateSessionThroughActiveTarget(params: {
-  sessionFile: string;
-  contextWindowTokens: number;
-  maxCharsOverride?: number;
-  aggregateMaxCharsOverride?: number;
-  protectTrailingToolResults?: boolean;
-  sessionId?: string;
-  sessionKey?: string;
-  agentId?: string;
-}) {
-  return await truncateOversizedToolResultsInActiveTarget({
-    scope: {
-      ...(params.agentId ? { agentId: params.agentId } : {}),
-      sessionId: params.sessionId ?? "tool-result-truncation-test",
-      sessionKey: params.sessionKey ?? "agent:main:tool-result-truncation-test",
-      sessionFile: params.sessionFile,
-    },
-    contextWindowTokens: params.contextWindowTokens,
-    maxCharsOverride: params.maxCharsOverride,
-    aggregateMaxCharsOverride: params.aggregateMaxCharsOverride,
-    protectTrailingToolResults: params.protectTrailingToolResults,
-  });
-}
-
 async function createTmpDir(): Promise<string> {
   tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "tool-result-truncation-test-"));
-  return tmpDir;
-}
-
-async function createShortTmpDir(): Promise<string> {
-  tmpDir = await fs.mkdtemp(path.join(process.platform === "win32" ? os.tmpdir() : "/tmp", "oc-"));
   return tmpDir;
 }
 
@@ -257,32 +148,6 @@ describe("truncateToolResultText", () => {
     });
     expect(result).toContain("[custom-truncated]");
     expect(result.length).toBeGreaterThan(250);
-  });
-
-  it("keeps direct and suffix-only cuts on complete code points", () => {
-    expect(
-      truncateToolResultText("aaa😀z", 5, {
-        suffix: "!",
-        minKeepChars: 0,
-      }),
-    ).toBe("aaa!");
-    expect(
-      truncateToolResultText("abcdef", 1, {
-        suffix: "😀",
-        minKeepChars: 0,
-      }),
-    ).toBe("");
-  });
-
-  it("keeps both head and tail cuts on complete code points", () => {
-    const marker = "\n\n⚠️ [... middle content omitted — showing head and tail ...]\n\n";
-    const text = `${"a".repeat(6)}😀${"m".repeat(100)}😀${"x".repeat(22)} Error`;
-    expect(
-      truncateToolResultText(text, 100, {
-        suffix: "!",
-        minKeepChars: 1,
-      }),
-    ).toBe(`${"a".repeat(6)}${marker}${"x".repeat(22)} Error!`);
   });
 });
 
@@ -433,23 +298,6 @@ describe("calculateMaxToolResultChars", () => {
     });
     expect(result).toBe(24_000);
   });
-
-  it.each([
-    { contextWindowTokens: 20_000, perResultMaxChars: 16_000, aggregateMaxChars: 64_000 },
-    { contextWindowTokens: 128_000, perResultMaxChars: 32_000, aggregateMaxChars: 256_000 },
-    { contextWindowTokens: 200_000, perResultMaxChars: 64_000, aggregateMaxChars: 400_000 },
-    { contextWindowTokens: 1_000_000, perResultMaxChars: 64_000, aggregateMaxChars: 2_000_000 },
-  ])(
-    "resolves aggregate live cap for $contextWindowTokens token windows",
-    ({ contextWindowTokens, perResultMaxChars, aggregateMaxChars }) => {
-      expect(
-        resolveLiveToolResultAggregateMaxChars({
-          contextWindowTokens,
-          perResultMaxChars,
-        }),
-      ).toBe(aggregateMaxChars);
-    },
-  );
 });
 
 describe("sessionLikelyHasOversizedToolResults", () => {
@@ -461,16 +309,13 @@ describe("sessionLikelyHasOversizedToolResults", () => {
   });
 
   it("returns true for aggregate medium tool results that exceed the shared budget", () => {
-    const medium = "alpha beta gamma delta epsilon ".repeat(500);
+    const medium = "alpha beta gamma delta epsilon ".repeat(600);
     const messages: AgentMessage[] = [
       makeToolResult(medium, "call_1"),
       makeToolResult(medium, "call_2"),
       makeToolResult(medium, "call_3"),
-      makeToolResult(medium, "call_4"),
-      makeToolResult(medium, "call_5"),
-      makeToolResult(medium, "call_6"),
     ];
-    expect(sessionLikelyHasOversizedToolResults({ messages, contextWindowTokens: 20_000 })).toBe(
+    expect(sessionLikelyHasOversizedToolResults({ messages, contextWindowTokens: 128_000 })).toBe(
       true,
     );
   });
@@ -495,17 +340,14 @@ describe("estimateToolResultReductionPotential", () => {
       makeToolResult(medium, "call_1"),
       makeToolResult(medium, "call_2"),
       makeToolResult(medium, "call_3"),
-      makeToolResult(medium, "call_4"),
-      makeToolResult(medium, "call_5"),
-      makeToolResult(medium, "call_6"),
     ];
 
     const estimate = estimateToolResultReductionPotential({
       messages,
-      contextWindowTokens: 20_000,
+      contextWindowTokens: 128_000,
     });
 
-    expect(estimate.toolResultCount).toBe(6);
+    expect(estimate.toolResultCount).toBe(3);
     expect(estimate.oversizedCount).toBe(0);
     expect(estimate.aggregateReducibleChars).toBeGreaterThan(0);
     expect(estimate.maxReducibleChars).toBe(estimate.aggregateReducibleChars);
@@ -523,7 +365,6 @@ describe("estimateToolResultReductionPotential", () => {
     const estimate = estimateToolResultReductionPotential({
       messages,
       contextWindowTokens: 128_000,
-      aggregateMaxCharsOverride: 50_000,
     });
 
     expect(estimate.oversizedCount).toBeGreaterThan(0);
@@ -534,7 +375,7 @@ describe("estimateToolResultReductionPotential", () => {
     );
   });
 
-  it("lets explicit aggregate caps drive aggregate recovery estimates", () => {
+  it("lets tiny caps drive aggregate recovery estimates without the old floor", () => {
     const medium = "alpha beta gamma delta epsilon ".repeat(600);
     const messages: AgentMessage[] = [
       makeToolResult(medium, "call_1"),
@@ -546,7 +387,6 @@ describe("estimateToolResultReductionPotential", () => {
       messages,
       contextWindowTokens: 128_000,
       maxCharsOverride: 120,
-      aggregateMaxCharsOverride: 120,
     });
 
     expect(estimate.maxChars).toBe(120);
@@ -653,7 +493,7 @@ describe("truncateOversizedToolResultsInMessages", () => {
     );
   });
 
-  it("keeps prompt projections stable while enforcing aggregate recovery as history grows", () => {
+  it("keeps prompt projections byte-stable as history grows", () => {
     const prefix = [
       makeToolResult("p".repeat(15_000), "prefix_1"),
       makeToolResult("q".repeat(15_000), "prefix_2"),
@@ -663,7 +503,7 @@ describe("truncateOversizedToolResultsInMessages", () => {
       makeToolResult("y".repeat(15_000), "current_2"),
     ];
     const messages = [...prefix, ...suffix];
-    const projectionState = createPromptProjectionStateForTest();
+    const projectionState = createToolResultPromptProjectionState();
 
     const first = truncateOversizedToolResultsInMessages(
       messages,
@@ -682,12 +522,13 @@ describe("truncateOversizedToolResultsInMessages", () => {
 
     expect(first.truncatedCount).toBe(4);
     expect(second.truncatedCount).toBe(1);
+    expect(second.messages.slice(0, messages.length)).toEqual(first.messages);
     expect(second.messages.every((message) => getToolResultTextLength(message) <= 12_000)).toBe(
       true,
     );
     expect(messages).toEqual([...prefix, ...suffix]);
 
-    const stableState = createPromptProjectionStateForTest();
+    const stableState = createToolResultPromptProjectionState();
     const stableHistory = [
       makeToolResult("a".repeat(4_000), "stable_1"),
       makeToolResult("b".repeat(4_000), "stable_2"),
@@ -700,7 +541,7 @@ describe("truncateOversizedToolResultsInMessages", () => {
       stableState,
     );
     const stableSecond = truncateOversizedToolResultsInMessages(
-      [...stableHistory, makeToolResult("c".repeat(3_000), "stable_3")],
+      [...stableHistory, makeToolResult("c".repeat(15_000), "stable_3")],
       128_000,
       12_000,
       12_000,
@@ -711,7 +552,7 @@ describe("truncateOversizedToolResultsInMessages", () => {
     const stableThird = truncateOversizedToolResultsInMessages(
       [
         ...stableHistory,
-        makeToolResult("c".repeat(3_000), "stable_3"),
+        makeToolResult("c".repeat(15_000), "stable_3"),
         makeToolResult("d".repeat(15_000), "stable_4"),
       ],
       128_000,
@@ -723,7 +564,7 @@ describe("truncateOversizedToolResultsInMessages", () => {
     const stableFourth = truncateOversizedToolResultsInMessages(
       [
         ...stableHistory,
-        makeToolResult("c".repeat(3_000), "stable_3"),
+        makeToolResult("c".repeat(15_000), "stable_3"),
         makeToolResult("d".repeat(15_000), "stable_4"),
         makeToolResult("e".repeat(15_000), "stable_5"),
       ],
@@ -736,548 +577,8 @@ describe("truncateOversizedToolResultsInMessages", () => {
     expect(lastText && getToolResultTextLength(lastText)).toBeLessThanOrEqual(12_000);
   });
 
-  it("keeps #99495 historical bytes stable across attempts sharing session state", () => {
-    const state = getEmbeddedSessionPromptState("session-99495").toolResults;
-    const history = [
-      makeToolResult("a".repeat(4_000), "history_1"),
-      makeToolResult("b".repeat(4_000), "history_2"),
-    ];
-    const first = truncateOversizedToolResultsInMessages(history, 128_000, 5_000, 20_000, state);
-    const secondAttemptState = getEmbeddedSessionPromptState("session-99495").toolResults;
-    const second = truncateOversizedToolResultsInMessages(
-      [...history, makeToolResult("c".repeat(12_000), "current")],
-      128_000,
-      5_000,
-      20_000,
-      secondAttemptState,
-    );
-
-    expect(secondAttemptState).toBe(state);
-    expect(second.messages.slice(0, history.length)).toEqual(first.messages);
-  });
-
-  it("shrinks #99495 frozen bytes monotonically only under a tighter hard cap", () => {
-    const state = getEmbeddedSessionPromptState("session-99495-shrink").toolResults;
-    const history = [
-      makeToolResult("a".repeat(8_000), "history_1"),
-      makeToolResult("b".repeat(8_000), "history_2"),
-    ];
-    const first = truncateOversizedToolResultsInMessages(history, 128_000, 6_000, 20_000, state);
-    const shrunk = truncateOversizedToolResultsInMessages(history, 128_000, 3_000, 20_000, state);
-    const relaxed = truncateOversizedToolResultsInMessages(history, 128_000, 7_000, 20_000, state);
-    const lengths = (messages: AgentMessage[]) => messages.map(getToolResultTextLength);
-
-    expect(
-      lengths(shrunk.messages).every((length, index) => length <= lengths(first.messages)[index]!),
-    ).toBe(true);
-    expect(relaxed.messages).toEqual(shrunk.messages);
-  });
-
-  it("preserves fresh trailing tool results when aggregate history is already saturated", () => {
-    const projectionState = createPromptProjectionStateForTest();
-    const history: AgentMessage[] = [];
-    for (let index = 0; index < 50; index++) {
-      history.push(makeAssistantMessage(`call ${index}`));
-      history.push(makeToolResult("x".repeat(4_000), `history_${index}`));
-    }
-    history.push(makeUserMessage("run echo"));
-
-    const first = truncateOversizedToolResultsInMessages(
-      history,
-      1_000_000,
-      8_000,
-      32_000,
-      projectionState,
-    );
-    expect(first.truncatedCount).toBeGreaterThan(0);
-
-    const freshOutput = "ABC";
-    const second = truncateOversizedToolResultsInMessages(
-      [...history, makeAssistantMessage("running exec"), makeToolResult(freshOutput, "fresh_exec")],
-      1_000_000,
-      8_000,
-      32_000,
-      projectionState,
-    );
-
-    const freshResult = second.messages.at(-1);
-    const totalChars = second.messages.reduce(
-      (sum, message) =>
-        sum + (message.role === "toolResult" ? getToolResultTextLength(message) : 0),
-      0,
-    );
-    expect(freshResult?.role).toBe("toolResult");
-    expect(freshResult && getFirstToolResultText(freshResult)).toBe(freshOutput);
-    expect(totalChars).toBeLessThanOrEqual(32_000);
-  });
-
-  it("preserves fresh tool results through a trailing runtime context carrier", () => {
-    const projectionState = createPromptProjectionStateForTest();
-    const history: AgentMessage[] = [];
-    for (let index = 0; index < 50; index++) {
-      history.push(makeAssistantMessage(`call ${index}`));
-      history.push(makeToolResult("x".repeat(4_000), `history_${index}`));
-    }
-    history.push(makeUserMessage("run echo with extra context"));
-
-    const first = truncateOversizedToolResultsInMessages(
-      history,
-      1_000_000,
-      8_000,
-      32_000,
-      projectionState,
-    );
-    expect(first.truncatedCount).toBeGreaterThan(0);
-
-    const freshOutput = "OC99756_EXEC_MARKER_".padEnd(4_000, "x");
-    const runtimeContextMessage = buildRuntimeContextCustomMessage("runtime context refresh");
-    if (!runtimeContextMessage) {
-      throw new Error("expected runtime context message");
-    }
-    const providerMessages = convertToLlm([
-      ...history,
-      makeAssistantMessage("running exec"),
-      makeToolResult(freshOutput, "fresh_exec"),
-      runtimeContextMessage,
-    ] as AgentMessage[]) as AgentMessage[];
-    const providerCarrier = providerMessages.at(-1) as
-      | (AgentMessage & { runtimeContextCarrier?: boolean })
-      | undefined;
-    expect(providerCarrier?.runtimeContextCarrier).toBe(true);
-
-    const second = truncateOversizedToolResultsInMessages(
-      providerMessages,
-      1_000_000,
-      8_000,
-      32_000,
-      projectionState,
-    );
-
-    const freshResult = second.messages.find(
-      (message): message is ToolResultMessage =>
-        message.role === "toolResult" && message.toolCallId === "fresh_exec",
-    );
-    const historicalResults = second.messages.filter(
-      (message): message is ToolResultMessage =>
-        message.role === "toolResult" && message.toolCallId.startsWith("history_"),
-    );
-    const firstHistoricalLengths = new Map(
-      first.messages.flatMap((message) =>
-        message.role === "toolResult" && message.toolCallId.startsWith("history_")
-          ? [[message.toolCallId, getToolResultTextLength(message)] as const]
-          : [],
-      ),
-    );
-    const totalChars = second.messages.reduce(
-      (sum, message) =>
-        sum + (message.role === "toolResult" ? getToolResultTextLength(message) : 0),
-      0,
-    );
-    expect(freshResult && getFirstToolResultText(freshResult)).toBe(freshOutput);
-    expect(
-      historicalResults.some(
-        (message) =>
-          getToolResultTextLength(message) <
-          (firstHistoricalLengths.get(message.toolCallId) ?? Number.POSITIVE_INFINITY),
-      ),
-    ).toBe(true);
-    expect(second.aggregateTruncatedCount).toBeGreaterThan(0);
-    expect(second.aggregatePressureEngaged).toBe(true);
-    expect(totalChars).toBeLessThanOrEqual(32_000);
-  });
-
-  it("preserves multiple fresh tool results before queued steering", () => {
-    const projectionState = createPromptProjectionStateForTest();
-    const history: AgentMessage[] = [];
-    for (let index = 0; index < 50; index++) {
-      history.push(makeAssistantMessage(`call ${index}`));
-      history.push(makeToolResult("x".repeat(4_000), `history_${index}`));
-    }
-    history.push(makeUserMessage("run several commands"));
-
-    const first = truncateOversizedToolResultsInMessages(
-      history,
-      1_000_000,
-      8_000,
-      32_000,
-      projectionState,
-    );
-    expect(first.truncatedCount).toBeGreaterThan(0);
-
-    const freshOutputs = [
-      "OC99241_SHORT_SENTINEL_".padEnd(234, "s"),
-      "OC99241_LONG_SENTINEL_".padEnd(4_000, "l"),
-    ];
-    const second = truncateOversizedToolResultsInMessages(
-      [
-        ...history,
-        makeAssistantMessage("running tools"),
-        makeToolResult(freshOutputs[0]!, "fresh_short"),
-        makeToolResult(freshOutputs[1]!, "fresh_long"),
-        makeUserMessage("queued steering after tool execution"),
-      ],
-      1_000_000,
-      8_000,
-      32_000,
-      projectionState,
-    );
-
-    const freshResults = second.messages.filter(
-      (message): message is ToolResultMessage =>
-        message.role === "toolResult" && message.toolCallId.startsWith("fresh_"),
-    );
-    const historicalResults = second.messages.filter(
-      (message): message is ToolResultMessage =>
-        message.role === "toolResult" && message.toolCallId.startsWith("history_"),
-    );
-    const firstHistoricalLengths = new Map(
-      first.messages.flatMap((message) =>
-        message.role === "toolResult" && message.toolCallId.startsWith("history_")
-          ? [[message.toolCallId, getToolResultTextLength(message)] as const]
-          : [],
-      ),
-    );
-    const totalChars = second.messages.reduce(
-      (sum, message) =>
-        sum + (message.role === "toolResult" ? getToolResultTextLength(message) : 0),
-      0,
-    );
-
-    expect(freshResults.map(getFirstToolResultText)).toEqual(freshOutputs);
-    expect(
-      historicalResults.some(
-        (message) =>
-          getToolResultTextLength(message) <
-          (firstHistoricalLengths.get(message.toolCallId) ?? Number.POSITIVE_INFINITY),
-      ),
-    ).toBe(true);
-    expect(second.aggregateTruncatedCount).toBeGreaterThan(0);
-    expect(second.aggregatePressureEngaged).toBe(true);
-    expect(totalChars).toBeLessThanOrEqual(32_000);
-  });
-
-  it("shrinks deferred fresh results when frozen history cannot satisfy the hard cap", () => {
-    const projectionState = createPromptProjectionStateForTest();
-    const history: AgentMessage[] = [
-      makeToolResult("a".repeat(4_000), "history_a"),
-      makeToolResult("b".repeat(4_000), "history_b"),
-      makeUserMessage("establish a frozen projection baseline"),
-    ];
-    const first = truncateOversizedToolResultsInMessages(
-      history,
-      1_000_000,
-      8_000,
-      100,
-      projectionState,
-    );
-    expect(first.aggregatePressureEngaged).toBe(true);
-
-    const freshOutput = "OC99241_HARD_CAP_SENTINEL_".padEnd(4_000, "f");
-    const runtimeContextMessage = buildRuntimeContextCustomMessage("hard-cap runtime context");
-    if (!runtimeContextMessage) {
-      throw new Error("expected runtime context message");
-    }
-    const providerMessages = convertToLlm([
-      ...history,
-      makeToolResult(freshOutput, "fresh_hard_cap"),
-      runtimeContextMessage,
-    ] as AgentMessage[]) as AgentMessage[];
-    expect(
-      (providerMessages.at(-1) as { runtimeContextCarrier?: boolean } | undefined)
-        ?.runtimeContextCarrier,
-    ).toBe(true);
-    const second = truncateOversizedToolResultsInMessages(
-      providerMessages,
-      1_000_000,
-      8_000,
-      100,
-      projectionState,
-    );
-    const freshResult = second.messages.find(
-      (message): message is ToolResultMessage =>
-        message.role === "toolResult" && message.toolCallId === "fresh_hard_cap",
-    );
-    const freshText = freshResult ? getFirstToolResultText(freshResult) : "";
-    const totalChars = second.messages.reduce(
-      (sum, message) =>
-        sum + (message.role === "toolResult" ? getToolResultTextLength(message) : 0),
-      0,
-    );
-
-    expect(freshText.length).toBeGreaterThan(0);
-    expect(freshText.length).toBeLessThan(freshOutput.length);
-    expect(second.aggregateTruncatedCount).toBeGreaterThan(0);
-    expect(second.aggregatePressureEngaged).toBe(true);
-    expect(totalChars).toBeLessThanOrEqual(100);
-  });
-
-  it("caps oversized fresh trailing tool results without clearing them for aggregate recovery", () => {
-    const projectionState = createPromptProjectionStateForTest();
-    const history: AgentMessage[] = [];
-    for (let index = 0; index < 50; index++) {
-      history.push(makeAssistantMessage(`call ${index}`));
-      history.push(makeToolResult("x".repeat(4_000), `history_${index}`));
-    }
-    history.push(makeUserMessage("run large command"));
-
-    truncateOversizedToolResultsInMessages(history, 1_000_000, 8_000, 32_000, projectionState);
-
-    const second = truncateOversizedToolResultsInMessages(
-      [
-        ...history,
-        makeAssistantMessage("running exec"),
-        makeToolResult("z".repeat(20_000), "fresh_large_exec"),
-      ],
-      1_000_000,
-      8_000,
-      32_000,
-      projectionState,
-    );
-
-    const freshResult = second.messages.at(-1);
-    const freshText = freshResult ? getFirstToolResultText(freshResult) : "";
-    const totalChars = second.messages.reduce(
-      (sum, message) =>
-        sum + (message.role === "toolResult" ? getToolResultTextLength(message) : 0),
-      0,
-    );
-    expect(freshResult?.role).toBe("toolResult");
-    expect(freshText.length).toBeGreaterThan(0);
-    expect(freshText.length).toBeLessThanOrEqual(8_000);
-    expect(freshText).toContain("truncated");
-    expect(totalChars).toBeLessThanOrEqual(32_000);
-  });
-
-  it("leaves fresh trailing batches intact when only they exceed the aggregate budget", () => {
-    const projectionState = createPromptProjectionStateForTest();
-    const messages: AgentMessage[] = [makeUserMessage("run several tools")];
-    for (let index = 0; index < 5; index++) {
-      messages.push(makeToolResult(String(index).repeat(8_000), `fresh_${index}`));
-    }
-
-    const result = truncateOversizedToolResultsInMessages(
-      messages,
-      1_000_000,
-      8_000,
-      32_000,
-      projectionState,
-    );
-    const toolResults = result.messages.filter((message) => message.role === "toolResult");
-    const totalChars = toolResults.reduce(
-      (sum, message) => sum + getToolResultTextLength(message),
-      0,
-    );
-
-    expect(result.truncatedCount).toBe(0);
-    expect(result.aggregatePressureEngaged).toBe(true);
-    expect(totalChars).toBeGreaterThan(32_000);
-    expect(toolResults.every((message) => getFirstToolResultText(message).length > 0)).toBe(true);
-  });
-
-  it("keeps aggregate elision markers inside tiny explicit budgets", () => {
-    const messages: AgentMessage[] = [
-      makeToolResult("a".repeat(100), "tiny_1"),
-      makeToolResult("b".repeat(100), "tiny_2"),
-      makeToolResult("c".repeat(100), "tiny_3"),
-    ];
-
-    const result = truncateOversizedToolResultsInMessages(messages, 128_000, 100, 8);
-    const totalChars = result.messages.reduce(
-      (sum, message) =>
-        sum + (message.role === "toolResult" ? getToolResultTextLength(message) : 0),
-      0,
-    );
-
-    expect(result.truncatedCount).toBeGreaterThan(0);
-    expect(totalChars).toBeLessThanOrEqual(8);
-  });
-
-  it("points aggregate elision at live spill files", async () => {
-    const spillPath = path.join(await createShortTmpDir(), "o");
-    await fs.writeFile(spillPath, "complete command output", { mode: 0o600 });
-    const messages: AgentMessage[] = [
-      makeToolResult(textWithFullOutputFooter("a".repeat(100), spillPath), "spill_1", {
-        fullOutputPath: spillPath,
-      }),
-      makeToolResult("b".repeat(100), "spill_2"),
-      makeToolResult("c".repeat(100), "spill_3"),
-    ];
-
-    const result = truncateOversizedToolResultsInMessages(messages, 128_000, 500, 100);
-    const text = getFirstToolResultText(result.messages[0] ?? makeToolResult(""));
-
-    expect(text).toContain("read");
-    expect(text).toContain(spillPath);
-    await fs.rm(spillPath, { force: true });
-  });
-
-  it("keeps capped spill markers distinct during aggregate elision", async () => {
-    const spillPath = path.join(await createShortTmpDir(), "p");
-    await fs.writeFile(spillPath, "partial web output", { mode: 0o600 });
-    const messages: AgentMessage[] = [
-      makeToolResult(textWithFullOutputFooter("a".repeat(100), spillPath), "partial_spill_1", {
-        spill: {
-          path: spillPath,
-          chars: 2_000_000,
-          truncated: true,
-        },
-      }),
-      makeToolResult("b".repeat(100), "partial_spill_2"),
-      makeToolResult("c".repeat(100), "partial_spill_3"),
-    ];
-
-    const result = truncateOversizedToolResultsInMessages(messages, 128_000, 300, 100);
-    const text = getFirstToolResultText(result.messages[0] ?? makeToolResult(""));
-
-    expect(text).toContain("partial");
-    expect(text).toContain(spillPath);
-    expect(text).not.toContain("full output preserved");
-    await fs.rm(spillPath, { force: true });
-  });
-
-  it("detects spill footers escaped inside JSON tool results", async () => {
-    const spillPath = path.join(await createShortTmpDir(), "C:\\s");
-    await fs.writeFile(spillPath, "json wrapped output", { mode: 0o600 });
-    const messages: AgentMessage[] = [
-      makeToolResult(
-        JSON.stringify({ text: textWithFullOutputFooter("a".repeat(100), spillPath) }, null, 2),
-        "escaped_spill_1",
-        { fullOutputPath: spillPath },
-      ),
-      makeToolResult("b".repeat(100), "escaped_spill_2"),
-      makeToolResult("c".repeat(100), "escaped_spill_3"),
-    ];
-
-    const result = truncateOversizedToolResultsInMessages(messages, 128_000, 300, 100);
-    const text = getFirstToolResultText(result.messages[0] ?? makeToolResult(""));
-
-    expect(text).toContain("read");
-    expect(text).toContain(spillPath);
-    await fs.rm(spillPath, { force: true });
-  });
-
-  it("falls back to rerun guidance when the spill file is gone", async () => {
-    const dir = await createTmpDir();
-    const spillPath = path.join(dir, "deleted-output.log");
-    await fs.writeFile(spillPath, "complete command output", { mode: 0o600 });
-    await fs.rm(spillPath);
-    const messages: AgentMessage[] = [
-      makeToolResult(textWithFullOutputFooter("a".repeat(100), spillPath), "deleted_spill_1", {
-        fullOutputPath: spillPath,
-      }),
-      makeToolResult("b".repeat(100), "deleted_spill_2"),
-      makeToolResult("c".repeat(100), "deleted_spill_3"),
-    ];
-
-    const result = truncateOversizedToolResultsInMessages(messages, 128_000, 100, 100);
-    const text = getFirstToolResultText(result.messages[0] ?? makeToolResult(""));
-
-    expect(text).toContain("[tool result elided");
-    expect(text).not.toContain(spillPath);
-  });
-
-  it("keeps plain aggregate elision behavior without a spill pointer", () => {
-    const messages: AgentMessage[] = [
-      makeToolResult("a".repeat(100), "plain_1"),
-      makeToolResult("b".repeat(100), "plain_2"),
-      makeToolResult("c".repeat(100), "plain_3"),
-    ];
-
-    const result = truncateOversizedToolResultsInMessages(messages, 128_000, 100, 100);
-    const text = getFirstToolResultText(result.messages[0] ?? makeToolResult(""));
-
-    expect(text).toContain("[tool result elided");
-    expect(text).not.toContain("full output preserved at");
-  });
-
-  it("does not disclose details-only spill paths during aggregate elision", async () => {
-    const spillPath = path.join(await createTmpDir(), "private-output.log");
-    await fs.writeFile(spillPath, "private output", { mode: 0o600 });
-    const messages: AgentMessage[] = [
-      makeToolResult("a".repeat(100), "private_spill_1", { fullOutputPath: spillPath }),
-      makeToolResult("b".repeat(100), "private_spill_2"),
-      makeToolResult("c".repeat(100), "private_spill_3"),
-    ];
-
-    const result = truncateOversizedToolResultsInMessages(messages, 128_000, 100, 100);
-    const text = getFirstToolResultText(result.messages[0] ?? makeToolResult(""));
-
-    expect(text).toContain("[tool result elided");
-    expect(text).not.toContain(spillPath);
-    await fs.rm(spillPath, { force: true });
-  });
-
-  it("floors tiny aggregate elision budgets at compact spill markers", async () => {
-    const dir = await createTmpDir();
-    const spillPath = path.join(dir, "budget-output.log");
-    await fs.writeFile(spillPath, "complete command output", { mode: 0o600 });
-    const messages: AgentMessage[] = [
-      makeToolResult(textWithFullOutputFooter("a".repeat(100), spillPath), "budget_1", {
-        fullOutputPath: spillPath,
-      }),
-      makeToolResult("b".repeat(100), "budget_2"),
-      makeToolResult("c".repeat(100), "budget_3"),
-    ];
-
-    const result = truncateOversizedToolResultsInMessages(messages, 128_000, 1_000, 8);
-    const text = getFirstToolResultText(result.messages[0] ?? makeToolResult(""));
-
-    expect(text).toBe(`[read ${spillPath}]`);
-  });
-
-  it("keeps pointerless near-zero aggregate budgets sliced", () => {
-    const messages: AgentMessage[] = [
-      makeToolResult("a".repeat(100), "sliced_plain_1"),
-      makeToolResult("b".repeat(100), "sliced_plain_2"),
-      makeToolResult("c".repeat(100), "sliced_plain_3"),
-    ];
-
-    const result = truncateOversizedToolResultsInMessages(messages, 128_000, 1_000, 94);
-    const texts = result.messages.map((message) => getFirstToolResultText(message));
-
-    expect(
-      texts.some((text) => text.startsWith("[tool result elided:") && !text.includes("rerun")),
-    ).toBe(true);
-  });
-
-  it("keeps realistic spill pointers intact in near-zero aggregate elision budgets", async () => {
-    const dir = await createTmpDir();
-    const spillPath = realisticSpillPath(dir, "realistic");
-    await fs.writeFile(spillPath, "complete command output", { mode: 0o600 });
-    const messages: AgentMessage[] = [
-      makeToolResult(textWithFullOutputFooter("a".repeat(2_000), spillPath), "realistic_1", {
-        fullOutputPath: spillPath,
-      }),
-      makeToolResult("b".repeat(2_000), "realistic_2"),
-      makeToolResult("c".repeat(2_000), "realistic_3"),
-    ];
-
-    const result = truncateOversizedToolResultsInMessages(messages, 128_000, 5_000, 1);
-    const text = getFirstToolResultText(result.messages[0] ?? makeToolResult(""));
-
-    expect(text).toBe(`[read ${spillPath}]`);
-  });
-
-  it("uses spill-aware aggregate truncation suffixes with realistic paths", async () => {
-    const dir = await createTmpDir();
-    const spillPath = realisticSpillPath(dir, "suffix");
-    await fs.writeFile(spillPath, "complete command output", { mode: 0o600 });
-    const messages: AgentMessage[] = [
-      makeToolResult(textWithFullOutputFooter("a".repeat(5_000), spillPath), "suffix_1", {
-        fullOutputPath: spillPath,
-      }),
-      makeToolResult("b".repeat(5_000), "suffix_2"),
-    ];
-
-    const result = truncateOversizedToolResultsInMessages(messages, 128_000, 8_000, 9_000);
-    const text = getFirstToolResultText(result.messages[0] ?? makeToolResult(""));
-
-    expect(text).toContain(`full output at ${spillPath}`);
-    expect(text).not.toContain("narrow args");
-  });
-
   it("does not restore filtered image blocks when reusing a projection", () => {
-    const projectionState = createPromptProjectionStateForTest();
+    const projectionState = createToolResultPromptProjectionState();
     const source = makeToolResult("x".repeat(15_000), "image_call");
     source.content = [
       { type: "image", data: "filtered-after-conversion" },
@@ -1309,8 +610,8 @@ describe("truncateOversizedToolResultsInMessages", () => {
     ).toBeLessThan(15_000);
   });
 
-  it("freezes #99495 ambiguous-key projections across filtered history", () => {
-    const projectionState = createPromptProjectionStateForTest();
+  it("does not reuse ambiguous projections across filtered history", () => {
+    const projectionState = createToolResultPromptProjectionState();
     const duplicate = (text: string) => ({
       role: "toolResult" as const,
       toolCallId: "duplicate-call",
@@ -1335,189 +636,64 @@ describe("truncateOversizedToolResultsInMessages", () => {
     );
 
     expect(first.messages[0]).not.toEqual(first.messages[1]);
-    expect(filtered.messages[0]).toEqual(first.messages[1]);
+    expect(filtered.messages[0]).toEqual(duplicate("b".repeat(100)));
+  });
+
+  it("does not clear new/eligible tool results when frozen history exceeds the aggregate budget", () => {
+    const projectionState = createToolResultPromptProjectionState();
+    const frozenMessage = makeToolResult("f".repeat(15_000), "frozen_1");
+
+    truncateOversizedToolResultsInMessages(
+      [frozenMessage],
+      128_000,
+      12_000,
+      12_000,
+      projectionState,
+    );
+
+    // Case A: ineligibleChars (15,000) >= aggregateBudgetChars (12,000)
+    // The new eligible message should NOT be truncated at all (remains 5,000)
+    const newEligibleMessage = makeToolResult("n".repeat(5_000), "new_eligible_1");
+    const secondResult = truncateOversizedToolResultsInMessages(
+      [frozenMessage, newEligibleMessage],
+      128_000,
+      12_000,
+      12_000,
+      projectionState,
+    );
+
+    const newMsgResult = secondResult.messages[1];
+    expect(newMsgResult).toBeDefined();
+    const text = newMsgResult ? getFirstToolResultText(newMsgResult) : "";
+    expect(text.length).toBe(5000);
+
+    // Case B: ineligibleChars (10,000) < aggregateBudgetChars (12,000)
+    // The remaining budget is very small (2,000), but we enforce the 2,000 minimum floor
+    const projectionState2 = createToolResultPromptProjectionState();
+    const smallerFrozenMessage = makeToolResult("f".repeat(10_000), "frozen_2");
+    truncateOversizedToolResultsInMessages(
+      [smallerFrozenMessage],
+      128_000,
+      12_000,
+      12_000,
+      projectionState2,
+    );
+    const thirdResult = truncateOversizedToolResultsInMessages(
+      [smallerFrozenMessage, newEligibleMessage],
+      128_000,
+      12_000,
+      12_000,
+      projectionState2,
+    );
+    const newMsgResult2 = thirdResult.messages[1];
+    expect(newMsgResult2).toBeDefined();
+    const text2 = newMsgResult2 ? getFirstToolResultText(newMsgResult2) : "";
+    expect(text2.length).toBeGreaterThanOrEqual(2000);
+    expect(text2.length).toBeLessThan(5000);
   });
 });
 
 describe("truncateOversizedToolResultsInSession", () => {
-  it("truncates SQLite runtime transcripts without treating the marker as a file", async () => {
-    const dir = await createTmpDir();
-    const storePath = path.join(dir, "sessions.json");
-    const sessionId = "runtime-sqlite-tool-truncation";
-    const sessionKey = "agent:main:test";
-    const sessionFile = formatSqliteSessionFileMarker({
-      agentId: "main",
-      sessionId,
-      storePath,
-    });
-    const scope = { agentId: "main", sessionId, sessionKey, storePath };
-    await replaceSessionEntry({ sessionKey, storePath }, {
-      sessionFile,
-      sessionId,
-      updatedAt: 10,
-    } as SessionStoreEntry);
-    await appendTranscriptMessage(scope, {
-      message: makeUserMessage("run tools"),
-    });
-    const medium = "alpha beta gamma delta epsilon ".repeat(600);
-    await appendTranscriptMessage(scope, {
-      message: makeToolResult(medium, "call_1"),
-    });
-    await appendTranscriptMessage(scope, {
-      message: makeToolResult(medium, "call_2"),
-    });
-    await appendTranscriptMessage(scope, {
-      message: makeToolResult(medium, "call_3"),
-    });
-
-    const listener = vi.fn();
-    const cleanup = onInternalSessionTranscriptUpdate(listener);
-    const result = await truncateOversizedToolResultsInActiveTarget({
-      scope: { ...scope, sessionFile },
-      contextWindowTokens: 100,
-    });
-    cleanup();
-
-    expect(result.truncated).toBe(true);
-    expect(result.truncatedCount).toBeGreaterThan(0);
-    expect(listener).toHaveBeenCalledWith({
-      sessionFile,
-      sessionKey,
-      agentId: "main",
-      sessionId,
-      target: { agentId: "main", sessionId, sessionKey },
-    });
-
-    const toolResultTexts = (await loadTranscriptEvents(scope))
-      .filter(
-        (entry): entry is { message: AgentMessage; type: "message" } =>
-          typeof entry === "object" &&
-          entry !== null &&
-          "message" in entry &&
-          "type" in entry &&
-          entry.type === "message",
-      )
-      .map((entry) => entry.message)
-      .filter((message): message is ToolResultMessage => message.role === "toolResult")
-      .map(getFirstToolResultText);
-
-    expect(toolResultTexts.some((text) => text.includes("truncated"))).toBe(true);
-    expect(toolResultTexts.join("").length).toBeLessThan(medium.length * 3);
-  });
-
-  it("dispatches explicit file transcript targets to file-backed truncation", async () => {
-    const dir = await createTmpDir();
-    const sm = SessionManager.create(dir, dir);
-    sm.appendMessage(makeUserMessage("hello"));
-    sm.appendMessage(makeAssistantMessage("calling tools"));
-    sm.appendMessage(makeToolResult("x".repeat(500_000), "call_1"));
-    const sessionFile = sm.getSessionFile()!;
-
-    const result = await truncateOversizedToolResultsInActiveTarget({
-      scope: {
-        agentId: "main",
-        sessionFile,
-        sessionId: "explicit-file-session",
-        sessionKey: "agent:main:explicit-file",
-      },
-      contextWindowTokens: 100,
-    });
-
-    expect(result.truncated).toBe(true);
-    expect(result.truncatedCount).toBeGreaterThan(0);
-    const toolResult = SessionManager.open(sessionFile)
-      .getBranch()
-      .find((entry) => entry.type === "message" && entry.message.role === "toolResult");
-    expect(
-      toolResult?.type === "message" ? getFirstToolResultText(toolResult.message) : "",
-    ).toContain("truncated");
-  });
-
-  it("honors SQLite leaf controls when truncating runtime transcripts", async () => {
-    const dir = await createTmpDir();
-    const storePath = path.join(dir, "sessions.json");
-    const sessionId = "runtime-sqlite-leaf-tool-truncation";
-    const sessionKey = "agent:main:test";
-    const sessionFile = formatSqliteSessionFileMarker({
-      agentId: "main",
-      sessionId,
-      storePath,
-    });
-    const scope = { agentId: "main", sessionId, sessionKey, storePath };
-    await replaceSessionEntry({ sessionKey, storePath }, {
-      sessionFile,
-      sessionId,
-      updatedAt: 10,
-    } as SessionStoreEntry);
-    const activeLarge = "selected branch tool output ".repeat(700);
-    const inactiveLarge = "inactive branch tool output ".repeat(700);
-    await replaceTranscriptEvents(scope, [
-      {
-        type: "session",
-        version: 3,
-        id: sessionId,
-        timestamp: "2026-01-01T00:00:00.000Z",
-        cwd: dir,
-      },
-      {
-        type: "message",
-        id: "root-user",
-        parentId: null,
-        timestamp: "2026-01-01T00:00:01.000Z",
-        message: makeUserMessage("run tools"),
-      },
-      {
-        type: "message",
-        id: "selected-tool",
-        parentId: "root-user",
-        timestamp: "2026-01-01T00:00:02.000Z",
-        message: makeToolResult(activeLarge, "call_selected"),
-      },
-      {
-        type: "message",
-        id: "inactive-tool",
-        parentId: "root-user",
-        timestamp: "2026-01-01T00:00:03.000Z",
-        message: makeToolResult(inactiveLarge, "call_inactive"),
-      },
-      {
-        type: "leaf",
-        id: "selected-leaf",
-        parentId: "inactive-tool",
-        timestamp: "2026-01-01T00:00:04.000Z",
-        targetId: "selected-tool",
-      },
-    ]);
-
-    const result = await truncateOversizedToolResultsInActiveTarget({
-      scope: { ...scope, sessionFile },
-      contextWindowTokens: 100,
-    });
-
-    expect(result.truncated).toBe(true);
-    const messages = (await loadTranscriptEvents(scope))
-      .filter(
-        (entry): entry is { message: AgentMessage; type: "message" } =>
-          typeof entry === "object" &&
-          entry !== null &&
-          "message" in entry &&
-          "type" in entry &&
-          entry.type === "message",
-      )
-      .map((entry) => entry.message);
-    const selectedTool = messages.find(
-      (message): message is ToolResultMessage =>
-        message.role === "toolResult" && message.toolCallId === "call_selected",
-    );
-    const inactiveTool = messages.find(
-      (message): message is ToolResultMessage =>
-        message.role === "toolResult" && message.toolCallId === "call_inactive",
-    );
-
-    expect(selectedTool ? getFirstToolResultText(selectedTool) : "").toContain("truncated");
-    expect(inactiveTool ? getFirstToolResultText(inactiveTool) : "").toBe(inactiveLarge);
-  });
-
   it("readably truncates aggregate medium tool results in a session file", async () => {
     // Persisted truncation rewrites JSONL directly and emits the transcript
     // update event instead of reopening through SessionManager internals.
@@ -1546,7 +722,7 @@ describe("truncateOversizedToolResultsInSession", () => {
     });
     const listener = vi.fn();
     const cleanup = onInternalSessionTranscriptUpdate(listener);
-    const result = await truncateSessionThroughActiveTarget({
+    const result = await truncateOversizedToolResultsInSession({
       sessionFile,
       sessionKey: "agent:main:test",
       contextWindowTokens: 100,
@@ -1606,11 +782,10 @@ describe("truncateOversizedToolResultsInSession", () => {
       entry.type === "message" ? getFirstToolResultText(entry.message) : "",
     );
 
-    const result = await truncateSessionThroughActiveTarget({
+    const result = await truncateOversizedToolResultsInSession({
       sessionFile,
       contextWindowTokens: 128_000,
       maxCharsOverride: DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS,
-      aggregateMaxCharsOverride: DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS,
     });
 
     expect(result.truncated).toBe(true);
@@ -1637,7 +812,7 @@ describe("truncateOversizedToolResultsInSession", () => {
     sm.appendMessage(makeToolResult("x".repeat(500_000), "call_1"));
     const sessionFile = sm.getSessionFile()!;
 
-    const result = await truncateSessionThroughActiveTarget({
+    const result = await truncateOversizedToolResultsInSession({
       sessionFile,
       contextWindowTokens: 100,
     });
@@ -1655,36 +830,6 @@ describe("truncateOversizedToolResultsInSession", () => {
     expect(text.length).toBeLessThan(2_000);
     expect(text).toContain("truncated");
   });
-
-  it("leaves protected trailing batches intact during persisted aggregate recovery", async () => {
-    const dir = await createTmpDir();
-    const sm = SessionManager.create(dir, dir);
-    const firstKeptEntryId = sm.appendMessage(makeUserMessage("hello"));
-    sm.appendMessage(makeAssistantMessage("calling tools"));
-    const beforeTexts = Array.from({ length: 5 }, (_, index) => String(index).repeat(8_000));
-    for (const [index, text] of beforeTexts.entries()) {
-      sm.appendMessage(makeToolResult(text, `fresh_${index}`));
-    }
-    sm.appendCompaction("summary", firstKeptEntryId, 10);
-    const sessionFile = sm.getSessionFile()!;
-
-    const result = await truncateSessionThroughActiveTarget({
-      sessionFile,
-      contextWindowTokens: 1_000_000,
-      maxCharsOverride: 8_000,
-      aggregateMaxCharsOverride: 32_000,
-      protectTrailingToolResults: true,
-    });
-
-    expect(result.truncated).toBe(false);
-    const afterBranch = SessionManager.open(sessionFile).getBranch();
-    const afterTexts = afterBranch
-      .filter((entry) => entry.type === "message" && entry.message.role === "toolResult")
-      .map((entry) => (entry.type === "message" ? getFirstToolResultText(entry.message) : ""));
-
-    expect(afterTexts).toEqual(beforeTexts);
-  });
-
   it("combines oversized and aggregate recovery truncation in the same session rewrite", async () => {
     const dir = await createTmpDir();
     const sm = SessionManager.create(dir, dir);
@@ -1696,7 +841,7 @@ describe("truncateOversizedToolResultsInSession", () => {
     sm.appendMessage(makeToolResult(medium, "call_3"));
     const sessionFile = sm.getSessionFile()!;
 
-    const result = await truncateSessionThroughActiveTarget({
+    const result = await truncateOversizedToolResultsInSession({
       sessionFile,
       contextWindowTokens: 100,
     });
@@ -1713,8 +858,8 @@ describe("truncateOversizedToolResultsInSession", () => {
     );
 
     expect(toolTexts[0]).toContain("truncated");
-    expect(expectDefined(toolTexts[1], "toolTexts[1] test invariant").length).toBeGreaterThan(0);
-    expect(expectDefined(toolTexts[2], "toolTexts[2] test invariant").length).toBeGreaterThan(0);
+    expect(toolTexts[1].length).toBeGreaterThan(0);
+    expect(toolTexts[2].length).toBeGreaterThan(0);
   });
 
   it("lets aggregate recovery honor a tiny explicit cap during persisted rewrite", async () => {
@@ -1728,11 +873,10 @@ describe("truncateOversizedToolResultsInSession", () => {
     sm.appendMessage(makeToolResult(medium, "call_3"));
     const sessionFile = sm.getSessionFile()!;
 
-    const result = await truncateSessionThroughActiveTarget({
+    const result = await truncateOversizedToolResultsInSession({
       sessionFile,
       contextWindowTokens: 128_000,
       maxCharsOverride: 120,
-      aggregateMaxCharsOverride: 120,
     });
 
     expect(result.truncated).toBe(true);
@@ -1777,4 +921,3 @@ describe("truncateToolResultText head+tail strategy", () => {
     expect(result).toContain("truncated");
   });
 });
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
@@ -681,7 +681,7 @@ describe("truncateOversizedToolResultsInMessages", () => {
     );
 
     expect(first.truncatedCount).toBe(4);
-    expect(second.truncatedCount).toBe(1);
+    expect(second.truncatedCount).toBe(5);
     expect(second.messages.every((message) => getToolResultTextLength(message) <= 12_000)).toBe(
       true,
     );

--- a/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.test.ts
@@ -3,50 +3,72 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { expectDefined } from "@openclaw/normalization-core";
 import type { AgentMessage } from "openclaw/plugin-sdk/agent-core";
 import { SessionManager } from "openclaw/plugin-sdk/agent-sessions";
 import type { AssistantMessage, ToolResultMessage, UserMessage } from "openclaw/plugin-sdk/llm";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { convertToLlm } from "../../../packages/agent-core/src/harness/messages.js";
+import {
+  appendTranscriptMessage,
+  loadTranscriptEvents,
+  replaceSessionEntry,
+  replaceTranscriptEvents,
+} from "../../config/sessions/session-accessor.js";
+import { formatSqliteSessionFileMarker } from "../../config/sessions/sqlite-marker.js";
+import type { SessionEntry as SessionStoreEntry } from "../../config/sessions/types.js";
 import { onInternalSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
+import { formatFullOutputFooter } from "../sessions/tools/tool-contracts.js";
 import { makeAgentAssistantMessage } from "../test-helpers/agent-message-fixtures.js";
+import { buildRuntimeContextCustomMessage } from "./run/runtime-context-prompt.js";
+import {
+  clearEmbeddedSessionPromptStates,
+  getEmbeddedSessionPromptState,
+  type ToolResultPromptProjectionState,
+} from "./session-prompt-state.js";
 
-let truncateToolResultText: typeof import("./tool-result-truncation.js").truncateToolResultText;
 let truncateToolResultMessage: typeof import("./tool-result-truncation.js").truncateToolResultMessage;
-let calculateMaxToolResultChars: typeof import("./tool-result-truncation.js").calculateMaxToolResultChars;
 let calculateMaxToolResultCharsWithCap: typeof import("./tool-result-truncation.js").calculateMaxToolResultCharsWithCap;
 let resolveAutoLiveToolResultMaxChars: typeof import("./tool-result-truncation.js").resolveAutoLiveToolResultMaxChars;
-let getToolResultTextLength: typeof import("./tool-result-truncation.js").getToolResultTextLength;
 let truncateOversizedToolResultsInMessages: typeof import("./tool-result-truncation.js").truncateOversizedToolResultsInMessages;
-let truncateOversizedToolResultsInSession: typeof import("./tool-result-truncation.js").truncateOversizedToolResultsInSession;
+let truncateOversizedToolResultsInActiveTarget: typeof import("./tool-result-truncation.js").truncateOversizedToolResultsInActiveTarget;
 let sessionLikelyHasOversizedToolResults: typeof import("./tool-result-truncation.js").sessionLikelyHasOversizedToolResults;
 let estimateToolResultReductionPotential: typeof import("./tool-result-truncation.js").estimateToolResultReductionPotential;
 let DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS: typeof import("./tool-result-truncation.js").DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS;
 let resolveLiveToolResultMaxChars: typeof import("./tool-result-truncation.js").resolveLiveToolResultMaxChars;
-let createToolResultPromptProjectionState: typeof import("./tool-result-truncation.js").createToolResultPromptProjectionState;
+let resolveLiveToolResultAggregateMaxChars: typeof import("./tool-result-truncation.js").resolveLiveToolResultAggregateMaxChars;
+let toolResultWarningDedupe: typeof import("./tool-result-truncation.js").toolResultWarningDedupe;
 let tmpDir: string | undefined;
 
 async function loadFreshToolResultTruncationModuleForTest() {
   // Load after each setup so module-level constants and mocks stay isolated
   // across persisted-session and live-truncation tests.
   ({
-    truncateToolResultText,
     truncateToolResultMessage,
-    calculateMaxToolResultChars,
     calculateMaxToolResultCharsWithCap,
     resolveAutoLiveToolResultMaxChars,
-    getToolResultTextLength,
     truncateOversizedToolResultsInMessages,
-    truncateOversizedToolResultsInSession,
+    truncateOversizedToolResultsInActiveTarget,
     sessionLikelyHasOversizedToolResults,
     estimateToolResultReductionPotential,
     DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS,
     resolveLiveToolResultMaxChars,
-    createToolResultPromptProjectionState,
+    resolveLiveToolResultAggregateMaxChars,
+    toolResultWarningDedupe,
   } = await import("./tool-result-truncation.js"));
 }
 
 let testTimestamp = 1;
 const nextTimestamp = () => testTimestamp++;
+
+function createPromptProjectionStateForTest(): ToolResultPromptProjectionState {
+  return {
+    replacements: new Map(),
+    frozen: new Set(),
+    ambiguousBaseKeys: new Set(),
+    sourceTextByKey: new Map(),
+  };
+}
 
 beforeEach(async () => {
   testTimestamp = 1;
@@ -54,13 +76,16 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  toolResultWarningDedupe.promptPressure.clear();
+  toolResultWarningDedupe.sessionRecovery.clear();
+  clearEmbeddedSessionPromptStates(["session-99495", "session-99495-shrink"]);
   if (tmpDir) {
     await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
     tmpDir = undefined;
   }
 });
 
-function makeToolResult(text: string, toolCallId = "call_1"): ToolResultMessage {
+function makeToolResult(text: string, toolCallId = "call_1", details?: unknown): ToolResultMessage {
   // Tool-result fixtures use increasing timestamps so persisted branch rewrites
   // can preserve ordering while changing content.
   return {
@@ -69,8 +94,39 @@ function makeToolResult(text: string, toolCallId = "call_1"): ToolResultMessage 
     toolName: "read",
     content: [{ type: "text", text }],
     isError: false,
+    ...(details !== undefined ? { details } : {}),
     timestamp: nextTimestamp(),
   };
+}
+
+describe("tool-result warning dedupe", () => {
+  const warningDedupeLimit = 1_024;
+
+  it.each([
+    ["prompt pressure", () => toolResultWarningDedupe.promptPressure],
+    ["session recovery", () => toolResultWarningDedupe.sessionRecovery],
+  ])("bounds and evicts the oldest %s warning keys", (_name, getCache) => {
+    const cache = getCache();
+
+    for (let index = 0; index <= warningDedupeLimit; index += 1) {
+      expect(cache.check(`session-${index}`)).toBe(false);
+    }
+
+    expect(cache.size()).toBe(warningDedupeLimit);
+    expect(cache.peek("session-0")).toBe(false);
+    expect(cache.peek("session-1")).toBe(true);
+    expect(cache.peek(`session-${warningDedupeLimit}`)).toBe(true);
+    expect(cache.check("session-0")).toBe(false);
+    expect(cache.check(`session-${warningDedupeLimit}`)).toBe(true);
+  });
+});
+
+function textWithFullOutputFooter(text: string, fullOutputPath: string): string {
+  return `${text}\n\n[Showing truncated output. ${formatFullOutputFooter(fullOutputPath)}]`;
+}
+
+function realisticSpillPath(dir: string, name: string): string {
+  return path.join(dir, `${name}-${"segment-".repeat(8)}output.log`);
 }
 
 function makeUserMessage(text: string): UserMessage {
@@ -98,8 +154,61 @@ function getFirstToolResultText(message: AgentMessage | ToolResultMessage): stri
   return firstBlock && "text" in firstBlock ? firstBlock.text : "";
 }
 
+function truncateToolResultText(
+  text: string,
+  maxChars: number,
+  options?: Parameters<typeof truncateToolResultMessage>[2],
+): string {
+  return getFirstToolResultText(truncateToolResultMessage(makeToolResult(text), maxChars, options));
+}
+
+function calculateMaxToolResultChars(contextWindowTokens: number): number {
+  return resolveLiveToolResultMaxChars({ contextWindowTokens });
+}
+
+function getToolResultTextLength(message: AgentMessage): number {
+  if (message.role !== "toolResult") {
+    return 0;
+  }
+  return message.content.reduce((length, block) => {
+    if (!block || typeof block !== "object" || !("text" in block)) {
+      return length;
+    }
+    return length + (typeof block.text === "string" ? block.text.length : 0);
+  }, 0);
+}
+
+async function truncateSessionThroughActiveTarget(params: {
+  sessionFile: string;
+  contextWindowTokens: number;
+  maxCharsOverride?: number;
+  aggregateMaxCharsOverride?: number;
+  protectTrailingToolResults?: boolean;
+  sessionId?: string;
+  sessionKey?: string;
+  agentId?: string;
+}) {
+  return await truncateOversizedToolResultsInActiveTarget({
+    scope: {
+      ...(params.agentId ? { agentId: params.agentId } : {}),
+      sessionId: params.sessionId ?? "tool-result-truncation-test",
+      sessionKey: params.sessionKey ?? "agent:main:tool-result-truncation-test",
+      sessionFile: params.sessionFile,
+    },
+    contextWindowTokens: params.contextWindowTokens,
+    maxCharsOverride: params.maxCharsOverride,
+    aggregateMaxCharsOverride: params.aggregateMaxCharsOverride,
+    protectTrailingToolResults: params.protectTrailingToolResults,
+  });
+}
+
 async function createTmpDir(): Promise<string> {
   tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "tool-result-truncation-test-"));
+  return tmpDir;
+}
+
+async function createShortTmpDir(): Promise<string> {
+  tmpDir = await fs.mkdtemp(path.join(process.platform === "win32" ? os.tmpdir() : "/tmp", "oc-"));
   return tmpDir;
 }
 
@@ -148,6 +257,32 @@ describe("truncateToolResultText", () => {
     });
     expect(result).toContain("[custom-truncated]");
     expect(result.length).toBeGreaterThan(250);
+  });
+
+  it("keeps direct and suffix-only cuts on complete code points", () => {
+    expect(
+      truncateToolResultText("aaa😀z", 5, {
+        suffix: "!",
+        minKeepChars: 0,
+      }),
+    ).toBe("aaa!");
+    expect(
+      truncateToolResultText("abcdef", 1, {
+        suffix: "😀",
+        minKeepChars: 0,
+      }),
+    ).toBe("");
+  });
+
+  it("keeps both head and tail cuts on complete code points", () => {
+    const marker = "\n\n⚠️ [... middle content omitted — showing head and tail ...]\n\n";
+    const text = `${"a".repeat(6)}😀${"m".repeat(100)}😀${"x".repeat(22)} Error`;
+    expect(
+      truncateToolResultText(text, 100, {
+        suffix: "!",
+        minKeepChars: 1,
+      }),
+    ).toBe(`${"a".repeat(6)}${marker}${"x".repeat(22)} Error!`);
   });
 });
 
@@ -298,6 +433,23 @@ describe("calculateMaxToolResultChars", () => {
     });
     expect(result).toBe(24_000);
   });
+
+  it.each([
+    { contextWindowTokens: 20_000, perResultMaxChars: 16_000, aggregateMaxChars: 64_000 },
+    { contextWindowTokens: 128_000, perResultMaxChars: 32_000, aggregateMaxChars: 256_000 },
+    { contextWindowTokens: 200_000, perResultMaxChars: 64_000, aggregateMaxChars: 400_000 },
+    { contextWindowTokens: 1_000_000, perResultMaxChars: 64_000, aggregateMaxChars: 2_000_000 },
+  ])(
+    "resolves aggregate live cap for $contextWindowTokens token windows",
+    ({ contextWindowTokens, perResultMaxChars, aggregateMaxChars }) => {
+      expect(
+        resolveLiveToolResultAggregateMaxChars({
+          contextWindowTokens,
+          perResultMaxChars,
+        }),
+      ).toBe(aggregateMaxChars);
+    },
+  );
 });
 
 describe("sessionLikelyHasOversizedToolResults", () => {
@@ -309,13 +461,16 @@ describe("sessionLikelyHasOversizedToolResults", () => {
   });
 
   it("returns true for aggregate medium tool results that exceed the shared budget", () => {
-    const medium = "alpha beta gamma delta epsilon ".repeat(600);
+    const medium = "alpha beta gamma delta epsilon ".repeat(500);
     const messages: AgentMessage[] = [
       makeToolResult(medium, "call_1"),
       makeToolResult(medium, "call_2"),
       makeToolResult(medium, "call_3"),
+      makeToolResult(medium, "call_4"),
+      makeToolResult(medium, "call_5"),
+      makeToolResult(medium, "call_6"),
     ];
-    expect(sessionLikelyHasOversizedToolResults({ messages, contextWindowTokens: 128_000 })).toBe(
+    expect(sessionLikelyHasOversizedToolResults({ messages, contextWindowTokens: 20_000 })).toBe(
       true,
     );
   });
@@ -340,14 +495,17 @@ describe("estimateToolResultReductionPotential", () => {
       makeToolResult(medium, "call_1"),
       makeToolResult(medium, "call_2"),
       makeToolResult(medium, "call_3"),
+      makeToolResult(medium, "call_4"),
+      makeToolResult(medium, "call_5"),
+      makeToolResult(medium, "call_6"),
     ];
 
     const estimate = estimateToolResultReductionPotential({
       messages,
-      contextWindowTokens: 128_000,
+      contextWindowTokens: 20_000,
     });
 
-    expect(estimate.toolResultCount).toBe(3);
+    expect(estimate.toolResultCount).toBe(6);
     expect(estimate.oversizedCount).toBe(0);
     expect(estimate.aggregateReducibleChars).toBeGreaterThan(0);
     expect(estimate.maxReducibleChars).toBe(estimate.aggregateReducibleChars);
@@ -365,6 +523,7 @@ describe("estimateToolResultReductionPotential", () => {
     const estimate = estimateToolResultReductionPotential({
       messages,
       contextWindowTokens: 128_000,
+      aggregateMaxCharsOverride: 50_000,
     });
 
     expect(estimate.oversizedCount).toBeGreaterThan(0);
@@ -375,7 +534,7 @@ describe("estimateToolResultReductionPotential", () => {
     );
   });
 
-  it("lets tiny caps drive aggregate recovery estimates without the old floor", () => {
+  it("lets explicit aggregate caps drive aggregate recovery estimates", () => {
     const medium = "alpha beta gamma delta epsilon ".repeat(600);
     const messages: AgentMessage[] = [
       makeToolResult(medium, "call_1"),
@@ -387,6 +546,7 @@ describe("estimateToolResultReductionPotential", () => {
       messages,
       contextWindowTokens: 128_000,
       maxCharsOverride: 120,
+      aggregateMaxCharsOverride: 120,
     });
 
     expect(estimate.maxChars).toBe(120);
@@ -493,7 +653,7 @@ describe("truncateOversizedToolResultsInMessages", () => {
     );
   });
 
-  it("keeps prompt projections byte-stable as history grows", () => {
+  it("keeps prompt projections stable while enforcing aggregate recovery as history grows", () => {
     const prefix = [
       makeToolResult("p".repeat(15_000), "prefix_1"),
       makeToolResult("q".repeat(15_000), "prefix_2"),
@@ -503,7 +663,7 @@ describe("truncateOversizedToolResultsInMessages", () => {
       makeToolResult("y".repeat(15_000), "current_2"),
     ];
     const messages = [...prefix, ...suffix];
-    const projectionState = createToolResultPromptProjectionState();
+    const projectionState = createPromptProjectionStateForTest();
 
     const first = truncateOversizedToolResultsInMessages(
       messages,
@@ -522,13 +682,12 @@ describe("truncateOversizedToolResultsInMessages", () => {
 
     expect(first.truncatedCount).toBe(4);
     expect(second.truncatedCount).toBe(1);
-    expect(second.messages.slice(0, messages.length)).toEqual(first.messages);
     expect(second.messages.every((message) => getToolResultTextLength(message) <= 12_000)).toBe(
       true,
     );
     expect(messages).toEqual([...prefix, ...suffix]);
 
-    const stableState = createToolResultPromptProjectionState();
+    const stableState = createPromptProjectionStateForTest();
     const stableHistory = [
       makeToolResult("a".repeat(4_000), "stable_1"),
       makeToolResult("b".repeat(4_000), "stable_2"),
@@ -541,7 +700,7 @@ describe("truncateOversizedToolResultsInMessages", () => {
       stableState,
     );
     const stableSecond = truncateOversizedToolResultsInMessages(
-      [...stableHistory, makeToolResult("c".repeat(15_000), "stable_3")],
+      [...stableHistory, makeToolResult("c".repeat(3_000), "stable_3")],
       128_000,
       12_000,
       12_000,
@@ -552,7 +711,7 @@ describe("truncateOversizedToolResultsInMessages", () => {
     const stableThird = truncateOversizedToolResultsInMessages(
       [
         ...stableHistory,
-        makeToolResult("c".repeat(15_000), "stable_3"),
+        makeToolResult("c".repeat(3_000), "stable_3"),
         makeToolResult("d".repeat(15_000), "stable_4"),
       ],
       128_000,
@@ -564,7 +723,7 @@ describe("truncateOversizedToolResultsInMessages", () => {
     const stableFourth = truncateOversizedToolResultsInMessages(
       [
         ...stableHistory,
-        makeToolResult("c".repeat(15_000), "stable_3"),
+        makeToolResult("c".repeat(3_000), "stable_3"),
         makeToolResult("d".repeat(15_000), "stable_4"),
         makeToolResult("e".repeat(15_000), "stable_5"),
       ],
@@ -577,8 +736,548 @@ describe("truncateOversizedToolResultsInMessages", () => {
     expect(lastText && getToolResultTextLength(lastText)).toBeLessThanOrEqual(12_000);
   });
 
+  it("keeps #99495 historical bytes stable across attempts sharing session state", () => {
+    const state = getEmbeddedSessionPromptState("session-99495").toolResults;
+    const history = [
+      makeToolResult("a".repeat(4_000), "history_1"),
+      makeToolResult("b".repeat(4_000), "history_2"),
+    ];
+    const first = truncateOversizedToolResultsInMessages(history, 128_000, 5_000, 20_000, state);
+    const secondAttemptState = getEmbeddedSessionPromptState("session-99495").toolResults;
+    const second = truncateOversizedToolResultsInMessages(
+      [...history, makeToolResult("c".repeat(12_000), "current")],
+      128_000,
+      5_000,
+      20_000,
+      secondAttemptState,
+    );
+
+    expect(secondAttemptState).toBe(state);
+    expect(second.messages.slice(0, history.length)).toEqual(first.messages);
+  });
+
+  it("shrinks #99495 frozen bytes monotonically only under a tighter hard cap", () => {
+    const state = getEmbeddedSessionPromptState("session-99495-shrink").toolResults;
+    const history = [
+      makeToolResult("a".repeat(8_000), "history_1"),
+      makeToolResult("b".repeat(8_000), "history_2"),
+    ];
+    const first = truncateOversizedToolResultsInMessages(history, 128_000, 6_000, 20_000, state);
+    const shrunk = truncateOversizedToolResultsInMessages(history, 128_000, 3_000, 20_000, state);
+    const relaxed = truncateOversizedToolResultsInMessages(history, 128_000, 7_000, 20_000, state);
+    const lengths = (messages: AgentMessage[]) => messages.map(getToolResultTextLength);
+
+    expect(
+      lengths(shrunk.messages).every((length, index) => length <= lengths(first.messages)[index]!),
+    ).toBe(true);
+    expect(relaxed.messages).toEqual(shrunk.messages);
+  });
+
+  it("preserves fresh trailing tool results when aggregate history is already saturated", () => {
+    const projectionState = createPromptProjectionStateForTest();
+    const history: AgentMessage[] = [];
+    for (let index = 0; index < 50; index++) {
+      history.push(makeAssistantMessage(`call ${index}`));
+      history.push(makeToolResult("x".repeat(4_000), `history_${index}`));
+    }
+    history.push(makeUserMessage("run echo"));
+
+    const first = truncateOversizedToolResultsInMessages(
+      history,
+      1_000_000,
+      8_000,
+      32_000,
+      projectionState,
+    );
+    expect(first.truncatedCount).toBeGreaterThan(0);
+
+    const freshOutput = "ABC";
+    const second = truncateOversizedToolResultsInMessages(
+      [...history, makeAssistantMessage("running exec"), makeToolResult(freshOutput, "fresh_exec")],
+      1_000_000,
+      8_000,
+      32_000,
+      projectionState,
+    );
+
+    const freshResult = second.messages.at(-1);
+    const totalChars = second.messages.reduce(
+      (sum, message) =>
+        sum + (message.role === "toolResult" ? getToolResultTextLength(message) : 0),
+      0,
+    );
+    expect(freshResult?.role).toBe("toolResult");
+    expect(freshResult && getFirstToolResultText(freshResult)).toBe(freshOutput);
+    expect(totalChars).toBeLessThanOrEqual(32_000);
+  });
+
+  it("preserves fresh tool results through a trailing runtime context carrier", () => {
+    const projectionState = createPromptProjectionStateForTest();
+    const history: AgentMessage[] = [];
+    for (let index = 0; index < 50; index++) {
+      history.push(makeAssistantMessage(`call ${index}`));
+      history.push(makeToolResult("x".repeat(4_000), `history_${index}`));
+    }
+    history.push(makeUserMessage("run echo with extra context"));
+
+    const first = truncateOversizedToolResultsInMessages(
+      history,
+      1_000_000,
+      8_000,
+      32_000,
+      projectionState,
+    );
+    expect(first.truncatedCount).toBeGreaterThan(0);
+
+    const freshOutput = "OC99756_EXEC_MARKER_".padEnd(4_000, "x");
+    const runtimeContextMessage = buildRuntimeContextCustomMessage("runtime context refresh");
+    if (!runtimeContextMessage) {
+      throw new Error("expected runtime context message");
+    }
+    const providerMessages = convertToLlm([
+      ...history,
+      makeAssistantMessage("running exec"),
+      makeToolResult(freshOutput, "fresh_exec"),
+      runtimeContextMessage,
+    ] as AgentMessage[]) as AgentMessage[];
+    const providerCarrier = providerMessages.at(-1) as
+      | (AgentMessage & { runtimeContextCarrier?: boolean })
+      | undefined;
+    expect(providerCarrier?.runtimeContextCarrier).toBe(true);
+
+    const second = truncateOversizedToolResultsInMessages(
+      providerMessages,
+      1_000_000,
+      8_000,
+      32_000,
+      projectionState,
+    );
+
+    const freshResult = second.messages.find(
+      (message): message is ToolResultMessage =>
+        message.role === "toolResult" && message.toolCallId === "fresh_exec",
+    );
+    const historicalResults = second.messages.filter(
+      (message): message is ToolResultMessage =>
+        message.role === "toolResult" && message.toolCallId.startsWith("history_"),
+    );
+    const firstHistoricalLengths = new Map(
+      first.messages.flatMap((message) =>
+        message.role === "toolResult" && message.toolCallId.startsWith("history_")
+          ? [[message.toolCallId, getToolResultTextLength(message)] as const]
+          : [],
+      ),
+    );
+    const totalChars = second.messages.reduce(
+      (sum, message) =>
+        sum + (message.role === "toolResult" ? getToolResultTextLength(message) : 0),
+      0,
+    );
+    expect(freshResult && getFirstToolResultText(freshResult)).toBe(freshOutput);
+    expect(
+      historicalResults.some(
+        (message) =>
+          getToolResultTextLength(message) <
+          (firstHistoricalLengths.get(message.toolCallId) ?? Number.POSITIVE_INFINITY),
+      ),
+    ).toBe(true);
+    expect(second.aggregateTruncatedCount).toBeGreaterThan(0);
+    expect(second.aggregatePressureEngaged).toBe(true);
+    expect(totalChars).toBeLessThanOrEqual(32_000);
+  });
+
+  it("preserves multiple fresh tool results before queued steering", () => {
+    const projectionState = createPromptProjectionStateForTest();
+    const history: AgentMessage[] = [];
+    for (let index = 0; index < 50; index++) {
+      history.push(makeAssistantMessage(`call ${index}`));
+      history.push(makeToolResult("x".repeat(4_000), `history_${index}`));
+    }
+    history.push(makeUserMessage("run several commands"));
+
+    const first = truncateOversizedToolResultsInMessages(
+      history,
+      1_000_000,
+      8_000,
+      32_000,
+      projectionState,
+    );
+    expect(first.truncatedCount).toBeGreaterThan(0);
+
+    const freshOutputs = [
+      "OC99241_SHORT_SENTINEL_".padEnd(234, "s"),
+      "OC99241_LONG_SENTINEL_".padEnd(4_000, "l"),
+    ];
+    const second = truncateOversizedToolResultsInMessages(
+      [
+        ...history,
+        makeAssistantMessage("running tools"),
+        makeToolResult(freshOutputs[0]!, "fresh_short"),
+        makeToolResult(freshOutputs[1]!, "fresh_long"),
+        makeUserMessage("queued steering after tool execution"),
+      ],
+      1_000_000,
+      8_000,
+      32_000,
+      projectionState,
+    );
+
+    const freshResults = second.messages.filter(
+      (message): message is ToolResultMessage =>
+        message.role === "toolResult" && message.toolCallId.startsWith("fresh_"),
+    );
+    const historicalResults = second.messages.filter(
+      (message): message is ToolResultMessage =>
+        message.role === "toolResult" && message.toolCallId.startsWith("history_"),
+    );
+    const firstHistoricalLengths = new Map(
+      first.messages.flatMap((message) =>
+        message.role === "toolResult" && message.toolCallId.startsWith("history_")
+          ? [[message.toolCallId, getToolResultTextLength(message)] as const]
+          : [],
+      ),
+    );
+    const totalChars = second.messages.reduce(
+      (sum, message) =>
+        sum + (message.role === "toolResult" ? getToolResultTextLength(message) : 0),
+      0,
+    );
+
+    expect(freshResults.map(getFirstToolResultText)).toEqual(freshOutputs);
+    expect(
+      historicalResults.some(
+        (message) =>
+          getToolResultTextLength(message) <
+          (firstHistoricalLengths.get(message.toolCallId) ?? Number.POSITIVE_INFINITY),
+      ),
+    ).toBe(true);
+    expect(second.aggregateTruncatedCount).toBeGreaterThan(0);
+    expect(second.aggregatePressureEngaged).toBe(true);
+    expect(totalChars).toBeLessThanOrEqual(32_000);
+  });
+
+  it("shrinks deferred fresh results when frozen history cannot satisfy the hard cap", () => {
+    const projectionState = createPromptProjectionStateForTest();
+    const history: AgentMessage[] = [
+      makeToolResult("a".repeat(4_000), "history_a"),
+      makeToolResult("b".repeat(4_000), "history_b"),
+      makeUserMessage("establish a frozen projection baseline"),
+    ];
+    const first = truncateOversizedToolResultsInMessages(
+      history,
+      1_000_000,
+      8_000,
+      100,
+      projectionState,
+    );
+    expect(first.aggregatePressureEngaged).toBe(true);
+
+    const freshOutput = "OC99241_HARD_CAP_SENTINEL_".padEnd(4_000, "f");
+    const runtimeContextMessage = buildRuntimeContextCustomMessage("hard-cap runtime context");
+    if (!runtimeContextMessage) {
+      throw new Error("expected runtime context message");
+    }
+    const providerMessages = convertToLlm([
+      ...history,
+      makeToolResult(freshOutput, "fresh_hard_cap"),
+      runtimeContextMessage,
+    ] as AgentMessage[]) as AgentMessage[];
+    expect(
+      (providerMessages.at(-1) as { runtimeContextCarrier?: boolean } | undefined)
+        ?.runtimeContextCarrier,
+    ).toBe(true);
+    const second = truncateOversizedToolResultsInMessages(
+      providerMessages,
+      1_000_000,
+      8_000,
+      100,
+      projectionState,
+    );
+    const freshResult = second.messages.find(
+      (message): message is ToolResultMessage =>
+        message.role === "toolResult" && message.toolCallId === "fresh_hard_cap",
+    );
+    const freshText = freshResult ? getFirstToolResultText(freshResult) : "";
+    const totalChars = second.messages.reduce(
+      (sum, message) =>
+        sum + (message.role === "toolResult" ? getToolResultTextLength(message) : 0),
+      0,
+    );
+
+    expect(freshText.length).toBeGreaterThan(0);
+    expect(freshText.length).toBeLessThan(freshOutput.length);
+    expect(second.aggregateTruncatedCount).toBeGreaterThan(0);
+    expect(second.aggregatePressureEngaged).toBe(true);
+    expect(totalChars).toBeLessThanOrEqual(100);
+  });
+
+  it("caps oversized fresh trailing tool results without clearing them for aggregate recovery", () => {
+    const projectionState = createPromptProjectionStateForTest();
+    const history: AgentMessage[] = [];
+    for (let index = 0; index < 50; index++) {
+      history.push(makeAssistantMessage(`call ${index}`));
+      history.push(makeToolResult("x".repeat(4_000), `history_${index}`));
+    }
+    history.push(makeUserMessage("run large command"));
+
+    truncateOversizedToolResultsInMessages(history, 1_000_000, 8_000, 32_000, projectionState);
+
+    const second = truncateOversizedToolResultsInMessages(
+      [
+        ...history,
+        makeAssistantMessage("running exec"),
+        makeToolResult("z".repeat(20_000), "fresh_large_exec"),
+      ],
+      1_000_000,
+      8_000,
+      32_000,
+      projectionState,
+    );
+
+    const freshResult = second.messages.at(-1);
+    const freshText = freshResult ? getFirstToolResultText(freshResult) : "";
+    const totalChars = second.messages.reduce(
+      (sum, message) =>
+        sum + (message.role === "toolResult" ? getToolResultTextLength(message) : 0),
+      0,
+    );
+    expect(freshResult?.role).toBe("toolResult");
+    expect(freshText.length).toBeGreaterThan(0);
+    expect(freshText.length).toBeLessThanOrEqual(8_000);
+    expect(freshText).toContain("truncated");
+    expect(totalChars).toBeLessThanOrEqual(32_000);
+  });
+
+  it("leaves fresh trailing batches intact when only they exceed the aggregate budget", () => {
+    const projectionState = createPromptProjectionStateForTest();
+    const messages: AgentMessage[] = [makeUserMessage("run several tools")];
+    for (let index = 0; index < 5; index++) {
+      messages.push(makeToolResult(String(index).repeat(8_000), `fresh_${index}`));
+    }
+
+    const result = truncateOversizedToolResultsInMessages(
+      messages,
+      1_000_000,
+      8_000,
+      32_000,
+      projectionState,
+    );
+    const toolResults = result.messages.filter((message) => message.role === "toolResult");
+    const totalChars = toolResults.reduce(
+      (sum, message) => sum + getToolResultTextLength(message),
+      0,
+    );
+
+    expect(result.truncatedCount).toBe(0);
+    expect(result.aggregatePressureEngaged).toBe(true);
+    expect(totalChars).toBeGreaterThan(32_000);
+    expect(toolResults.every((message) => getFirstToolResultText(message).length > 0)).toBe(true);
+  });
+
+  it("keeps aggregate elision markers inside tiny explicit budgets", () => {
+    const messages: AgentMessage[] = [
+      makeToolResult("a".repeat(100), "tiny_1"),
+      makeToolResult("b".repeat(100), "tiny_2"),
+      makeToolResult("c".repeat(100), "tiny_3"),
+    ];
+
+    const result = truncateOversizedToolResultsInMessages(messages, 128_000, 100, 8);
+    const totalChars = result.messages.reduce(
+      (sum, message) =>
+        sum + (message.role === "toolResult" ? getToolResultTextLength(message) : 0),
+      0,
+    );
+
+    expect(result.truncatedCount).toBeGreaterThan(0);
+    expect(totalChars).toBeLessThanOrEqual(8);
+  });
+
+  it("points aggregate elision at live spill files", async () => {
+    const spillPath = path.join(await createShortTmpDir(), "o");
+    await fs.writeFile(spillPath, "complete command output", { mode: 0o600 });
+    const messages: AgentMessage[] = [
+      makeToolResult(textWithFullOutputFooter("a".repeat(100), spillPath), "spill_1", {
+        fullOutputPath: spillPath,
+      }),
+      makeToolResult("b".repeat(100), "spill_2"),
+      makeToolResult("c".repeat(100), "spill_3"),
+    ];
+
+    const result = truncateOversizedToolResultsInMessages(messages, 128_000, 500, 100);
+    const text = getFirstToolResultText(result.messages[0] ?? makeToolResult(""));
+
+    expect(text).toContain("read");
+    expect(text).toContain(spillPath);
+    await fs.rm(spillPath, { force: true });
+  });
+
+  it("keeps capped spill markers distinct during aggregate elision", async () => {
+    const spillPath = path.join(await createShortTmpDir(), "p");
+    await fs.writeFile(spillPath, "partial web output", { mode: 0o600 });
+    const messages: AgentMessage[] = [
+      makeToolResult(textWithFullOutputFooter("a".repeat(100), spillPath), "partial_spill_1", {
+        spill: {
+          path: spillPath,
+          chars: 2_000_000,
+          truncated: true,
+        },
+      }),
+      makeToolResult("b".repeat(100), "partial_spill_2"),
+      makeToolResult("c".repeat(100), "partial_spill_3"),
+    ];
+
+    const result = truncateOversizedToolResultsInMessages(messages, 128_000, 300, 100);
+    const text = getFirstToolResultText(result.messages[0] ?? makeToolResult(""));
+
+    expect(text).toContain("partial");
+    expect(text).toContain(spillPath);
+    expect(text).not.toContain("full output preserved");
+    await fs.rm(spillPath, { force: true });
+  });
+
+  it("detects spill footers escaped inside JSON tool results", async () => {
+    const spillPath = path.join(await createShortTmpDir(), "C:\\s");
+    await fs.writeFile(spillPath, "json wrapped output", { mode: 0o600 });
+    const messages: AgentMessage[] = [
+      makeToolResult(
+        JSON.stringify({ text: textWithFullOutputFooter("a".repeat(100), spillPath) }, null, 2),
+        "escaped_spill_1",
+        { fullOutputPath: spillPath },
+      ),
+      makeToolResult("b".repeat(100), "escaped_spill_2"),
+      makeToolResult("c".repeat(100), "escaped_spill_3"),
+    ];
+
+    const result = truncateOversizedToolResultsInMessages(messages, 128_000, 300, 100);
+    const text = getFirstToolResultText(result.messages[0] ?? makeToolResult(""));
+
+    expect(text).toContain("read");
+    expect(text).toContain(spillPath);
+    await fs.rm(spillPath, { force: true });
+  });
+
+  it("falls back to rerun guidance when the spill file is gone", async () => {
+    const dir = await createTmpDir();
+    const spillPath = path.join(dir, "deleted-output.log");
+    await fs.writeFile(spillPath, "complete command output", { mode: 0o600 });
+    await fs.rm(spillPath);
+    const messages: AgentMessage[] = [
+      makeToolResult(textWithFullOutputFooter("a".repeat(100), spillPath), "deleted_spill_1", {
+        fullOutputPath: spillPath,
+      }),
+      makeToolResult("b".repeat(100), "deleted_spill_2"),
+      makeToolResult("c".repeat(100), "deleted_spill_3"),
+    ];
+
+    const result = truncateOversizedToolResultsInMessages(messages, 128_000, 100, 100);
+    const text = getFirstToolResultText(result.messages[0] ?? makeToolResult(""));
+
+    expect(text).toContain("[tool result elided");
+    expect(text).not.toContain(spillPath);
+  });
+
+  it("keeps plain aggregate elision behavior without a spill pointer", () => {
+    const messages: AgentMessage[] = [
+      makeToolResult("a".repeat(100), "plain_1"),
+      makeToolResult("b".repeat(100), "plain_2"),
+      makeToolResult("c".repeat(100), "plain_3"),
+    ];
+
+    const result = truncateOversizedToolResultsInMessages(messages, 128_000, 100, 100);
+    const text = getFirstToolResultText(result.messages[0] ?? makeToolResult(""));
+
+    expect(text).toContain("[tool result elided");
+    expect(text).not.toContain("full output preserved at");
+  });
+
+  it("does not disclose details-only spill paths during aggregate elision", async () => {
+    const spillPath = path.join(await createTmpDir(), "private-output.log");
+    await fs.writeFile(spillPath, "private output", { mode: 0o600 });
+    const messages: AgentMessage[] = [
+      makeToolResult("a".repeat(100), "private_spill_1", { fullOutputPath: spillPath }),
+      makeToolResult("b".repeat(100), "private_spill_2"),
+      makeToolResult("c".repeat(100), "private_spill_3"),
+    ];
+
+    const result = truncateOversizedToolResultsInMessages(messages, 128_000, 100, 100);
+    const text = getFirstToolResultText(result.messages[0] ?? makeToolResult(""));
+
+    expect(text).toContain("[tool result elided");
+    expect(text).not.toContain(spillPath);
+    await fs.rm(spillPath, { force: true });
+  });
+
+  it("floors tiny aggregate elision budgets at compact spill markers", async () => {
+    const dir = await createTmpDir();
+    const spillPath = path.join(dir, "budget-output.log");
+    await fs.writeFile(spillPath, "complete command output", { mode: 0o600 });
+    const messages: AgentMessage[] = [
+      makeToolResult(textWithFullOutputFooter("a".repeat(100), spillPath), "budget_1", {
+        fullOutputPath: spillPath,
+      }),
+      makeToolResult("b".repeat(100), "budget_2"),
+      makeToolResult("c".repeat(100), "budget_3"),
+    ];
+
+    const result = truncateOversizedToolResultsInMessages(messages, 128_000, 1_000, 8);
+    const text = getFirstToolResultText(result.messages[0] ?? makeToolResult(""));
+
+    expect(text).toBe(`[read ${spillPath}]`);
+  });
+
+  it("keeps pointerless near-zero aggregate budgets sliced", () => {
+    const messages: AgentMessage[] = [
+      makeToolResult("a".repeat(100), "sliced_plain_1"),
+      makeToolResult("b".repeat(100), "sliced_plain_2"),
+      makeToolResult("c".repeat(100), "sliced_plain_3"),
+    ];
+
+    const result = truncateOversizedToolResultsInMessages(messages, 128_000, 1_000, 94);
+    const texts = result.messages.map((message) => getFirstToolResultText(message));
+
+    expect(
+      texts.some((text) => text.startsWith("[tool result elided:") && !text.includes("rerun")),
+    ).toBe(true);
+  });
+
+  it("keeps realistic spill pointers intact in near-zero aggregate elision budgets", async () => {
+    const dir = await createTmpDir();
+    const spillPath = realisticSpillPath(dir, "realistic");
+    await fs.writeFile(spillPath, "complete command output", { mode: 0o600 });
+    const messages: AgentMessage[] = [
+      makeToolResult(textWithFullOutputFooter("a".repeat(2_000), spillPath), "realistic_1", {
+        fullOutputPath: spillPath,
+      }),
+      makeToolResult("b".repeat(2_000), "realistic_2"),
+      makeToolResult("c".repeat(2_000), "realistic_3"),
+    ];
+
+    const result = truncateOversizedToolResultsInMessages(messages, 128_000, 5_000, 1);
+    const text = getFirstToolResultText(result.messages[0] ?? makeToolResult(""));
+
+    expect(text).toBe(`[read ${spillPath}]`);
+  });
+
+  it("uses spill-aware aggregate truncation suffixes with realistic paths", async () => {
+    const dir = await createTmpDir();
+    const spillPath = realisticSpillPath(dir, "suffix");
+    await fs.writeFile(spillPath, "complete command output", { mode: 0o600 });
+    const messages: AgentMessage[] = [
+      makeToolResult(textWithFullOutputFooter("a".repeat(5_000), spillPath), "suffix_1", {
+        fullOutputPath: spillPath,
+      }),
+      makeToolResult("b".repeat(5_000), "suffix_2"),
+    ];
+
+    const result = truncateOversizedToolResultsInMessages(messages, 128_000, 8_000, 9_000);
+    const text = getFirstToolResultText(result.messages[0] ?? makeToolResult(""));
+
+    expect(text).toContain(`full output at ${spillPath}`);
+    expect(text).not.toContain("narrow args");
+  });
+
   it("does not restore filtered image blocks when reusing a projection", () => {
-    const projectionState = createToolResultPromptProjectionState();
+    const projectionState = createPromptProjectionStateForTest();
     const source = makeToolResult("x".repeat(15_000), "image_call");
     source.content = [
       { type: "image", data: "filtered-after-conversion" },
@@ -610,8 +1309,8 @@ describe("truncateOversizedToolResultsInMessages", () => {
     ).toBeLessThan(15_000);
   });
 
-  it("does not reuse ambiguous projections across filtered history", () => {
-    const projectionState = createToolResultPromptProjectionState();
+  it("freezes #99495 ambiguous-key projections across filtered history", () => {
+    const projectionState = createPromptProjectionStateForTest();
     const duplicate = (text: string) => ({
       role: "toolResult" as const,
       toolCallId: "duplicate-call",
@@ -636,11 +1335,11 @@ describe("truncateOversizedToolResultsInMessages", () => {
     );
 
     expect(first.messages[0]).not.toEqual(first.messages[1]);
-    expect(filtered.messages[0]).toEqual(duplicate("b".repeat(100)));
+    expect(filtered.messages[0]).toEqual(first.messages[1]);
   });
 
   it("does not clear new/eligible tool results when frozen history exceeds the aggregate budget", () => {
-    const projectionState = createToolResultPromptProjectionState();
+    const projectionState = createPromptProjectionStateForTest();
     const frozenMessage = makeToolResult("f".repeat(15_000), "frozen_1");
 
     truncateOversizedToolResultsInMessages(
@@ -667,23 +1366,23 @@ describe("truncateOversizedToolResultsInMessages", () => {
     const text = newMsgResult ? getFirstToolResultText(newMsgResult) : "";
     expect(text.length).toBe(5000);
 
-    // Case B: ineligibleChars (10,000) < aggregateBudgetChars (12,000)
-    // The remaining budget is very small (2,000), but we enforce the 2,000 minimum floor
-    const projectionState2 = createToolResultPromptProjectionState();
+    // Case B: ineligibleChars (10,000) < aggregateBudgetChars (12,000) but budget is small (e.g. 2,500)
+    // The remaining budget is very small (2,000), but we enforce the 2,000 minimum floor.
+    // We do not pass projectionState to simulate session compaction.
     const smallerFrozenMessage = makeToolResult("f".repeat(10_000), "frozen_2");
     truncateOversizedToolResultsInMessages(
       [smallerFrozenMessage],
       128_000,
       12_000,
-      12_000,
-      projectionState2,
+      2_500,
+      undefined,
     );
     const thirdResult = truncateOversizedToolResultsInMessages(
       [smallerFrozenMessage, newEligibleMessage],
       128_000,
       12_000,
-      12_000,
-      projectionState2,
+      2_500,
+      undefined,
     );
     const newMsgResult2 = thirdResult.messages[1];
     expect(newMsgResult2).toBeDefined();
@@ -694,6 +1393,184 @@ describe("truncateOversizedToolResultsInMessages", () => {
 });
 
 describe("truncateOversizedToolResultsInSession", () => {
+  it("truncates SQLite runtime transcripts without treating the marker as a file", async () => {
+    const dir = await createTmpDir();
+    const storePath = path.join(dir, "sessions.json");
+    const sessionId = "runtime-sqlite-tool-truncation";
+    const sessionKey = "agent:main:test";
+    const sessionFile = formatSqliteSessionFileMarker({
+      agentId: "main",
+      sessionId,
+      storePath,
+    });
+    const scope = { agentId: "main", sessionId, sessionKey, storePath };
+    await replaceSessionEntry({ sessionKey, storePath }, {
+      sessionFile,
+      sessionId,
+      updatedAt: 10,
+    } as SessionStoreEntry);
+    await appendTranscriptMessage(scope, {
+      message: makeUserMessage("run tools"),
+    });
+    const medium = "alpha beta gamma delta epsilon ".repeat(600);
+    await appendTranscriptMessage(scope, {
+      message: makeToolResult(medium, "call_1"),
+    });
+    await appendTranscriptMessage(scope, {
+      message: makeToolResult(medium, "call_2"),
+    });
+    await appendTranscriptMessage(scope, {
+      message: makeToolResult(medium, "call_3"),
+    });
+
+    const listener = vi.fn();
+    const cleanup = onInternalSessionTranscriptUpdate(listener);
+    const result = await truncateOversizedToolResultsInActiveTarget({
+      scope: { ...scope, sessionFile },
+      contextWindowTokens: 100,
+    });
+    cleanup();
+
+    expect(result.truncated).toBe(true);
+    expect(result.truncatedCount).toBeGreaterThan(0);
+    expect(listener).toHaveBeenCalledWith({
+      sessionFile,
+      sessionKey,
+      agentId: "main",
+      sessionId,
+      target: { agentId: "main", sessionId, sessionKey },
+    });
+
+    const toolResultTexts = (await loadTranscriptEvents(scope))
+      .filter(
+        (entry): entry is { message: AgentMessage; type: "message" } =>
+          typeof entry === "object" &&
+          entry !== null &&
+          "message" in entry &&
+          "type" in entry &&
+          entry.type === "message",
+      )
+      .map((entry) => entry.message)
+      .filter((message): message is ToolResultMessage => message.role === "toolResult")
+      .map(getFirstToolResultText);
+
+    expect(toolResultTexts.some((text) => text.includes("truncated"))).toBe(true);
+    expect(toolResultTexts.join("").length).toBeLessThan(medium.length * 3);
+  });
+
+  it("dispatches explicit file transcript targets to file-backed truncation", async () => {
+    const dir = await createTmpDir();
+    const sm = SessionManager.create(dir, dir);
+    sm.appendMessage(makeUserMessage("hello"));
+    sm.appendMessage(makeAssistantMessage("calling tools"));
+    sm.appendMessage(makeToolResult("x".repeat(500_000), "call_1"));
+    const sessionFile = sm.getSessionFile()!;
+
+    const result = await truncateOversizedToolResultsInActiveTarget({
+      scope: {
+        agentId: "main",
+        sessionFile,
+        sessionId: "explicit-file-session",
+        sessionKey: "agent:main:explicit-file",
+      },
+      contextWindowTokens: 100,
+    });
+
+    expect(result.truncated).toBe(true);
+    expect(result.truncatedCount).toBeGreaterThan(0);
+    const toolResult = SessionManager.open(sessionFile)
+      .getBranch()
+      .find((entry) => entry.type === "message" && entry.message.role === "toolResult");
+    expect(
+      toolResult?.type === "message" ? getFirstToolResultText(toolResult.message) : "",
+    ).toContain("truncated");
+  });
+
+  it("honors SQLite leaf controls when truncating runtime transcripts", async () => {
+    const dir = await createTmpDir();
+    const storePath = path.join(dir, "sessions.json");
+    const sessionId = "runtime-sqlite-leaf-tool-truncation";
+    const sessionKey = "agent:main:test";
+    const sessionFile = formatSqliteSessionFileMarker({
+      agentId: "main",
+      sessionId,
+      storePath,
+    });
+    const scope = { agentId: "main", sessionId, sessionKey, storePath };
+    await replaceSessionEntry({ sessionKey, storePath }, {
+      sessionFile,
+      sessionId,
+      updatedAt: 10,
+    } as SessionStoreEntry);
+    const activeLarge = "selected branch tool output ".repeat(700);
+    const inactiveLarge = "inactive branch tool output ".repeat(700);
+    await replaceTranscriptEvents(scope, [
+      {
+        type: "session",
+        version: 3,
+        id: sessionId,
+        timestamp: "2026-01-01T00:00:00.000Z",
+        cwd: dir,
+      },
+      {
+        type: "message",
+        id: "root-user",
+        parentId: null,
+        timestamp: "2026-01-01T00:00:01.000Z",
+        message: makeUserMessage("run tools"),
+      },
+      {
+        type: "message",
+        id: "selected-tool",
+        parentId: "root-user",
+        timestamp: "2026-01-01T00:00:02.000Z",
+        message: makeToolResult(activeLarge, "call_selected"),
+      },
+      {
+        type: "message",
+        id: "inactive-tool",
+        parentId: "root-user",
+        timestamp: "2026-01-01T00:00:03.000Z",
+        message: makeToolResult(inactiveLarge, "call_inactive"),
+      },
+      {
+        type: "leaf",
+        id: "selected-leaf",
+        parentId: "inactive-tool",
+        timestamp: "2026-01-01T00:00:04.000Z",
+        targetId: "selected-tool",
+      },
+    ]);
+
+    const result = await truncateOversizedToolResultsInActiveTarget({
+      scope: { ...scope, sessionFile },
+      contextWindowTokens: 100,
+    });
+
+    expect(result.truncated).toBe(true);
+    const messages = (await loadTranscriptEvents(scope))
+      .filter(
+        (entry): entry is { message: AgentMessage; type: "message" } =>
+          typeof entry === "object" &&
+          entry !== null &&
+          "message" in entry &&
+          "type" in entry &&
+          entry.type === "message",
+      )
+      .map((entry) => entry.message);
+    const selectedTool = messages.find(
+      (message): message is ToolResultMessage =>
+        message.role === "toolResult" && message.toolCallId === "call_selected",
+    );
+    const inactiveTool = messages.find(
+      (message): message is ToolResultMessage =>
+        message.role === "toolResult" && message.toolCallId === "call_inactive",
+    );
+
+    expect(selectedTool ? getFirstToolResultText(selectedTool) : "").toContain("truncated");
+    expect(inactiveTool ? getFirstToolResultText(inactiveTool) : "").toBe(inactiveLarge);
+  });
+
   it("readably truncates aggregate medium tool results in a session file", async () => {
     // Persisted truncation rewrites JSONL directly and emits the transcript
     // update event instead of reopening through SessionManager internals.
@@ -722,7 +1599,7 @@ describe("truncateOversizedToolResultsInSession", () => {
     });
     const listener = vi.fn();
     const cleanup = onInternalSessionTranscriptUpdate(listener);
-    const result = await truncateOversizedToolResultsInSession({
+    const result = await truncateSessionThroughActiveTarget({
       sessionFile,
       sessionKey: "agent:main:test",
       contextWindowTokens: 100,
@@ -782,10 +1659,11 @@ describe("truncateOversizedToolResultsInSession", () => {
       entry.type === "message" ? getFirstToolResultText(entry.message) : "",
     );
 
-    const result = await truncateOversizedToolResultsInSession({
+    const result = await truncateSessionThroughActiveTarget({
       sessionFile,
       contextWindowTokens: 128_000,
       maxCharsOverride: DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS,
+      aggregateMaxCharsOverride: DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS,
     });
 
     expect(result.truncated).toBe(true);
@@ -812,7 +1690,7 @@ describe("truncateOversizedToolResultsInSession", () => {
     sm.appendMessage(makeToolResult("x".repeat(500_000), "call_1"));
     const sessionFile = sm.getSessionFile()!;
 
-    const result = await truncateOversizedToolResultsInSession({
+    const result = await truncateSessionThroughActiveTarget({
       sessionFile,
       contextWindowTokens: 100,
     });
@@ -830,6 +1708,36 @@ describe("truncateOversizedToolResultsInSession", () => {
     expect(text.length).toBeLessThan(2_000);
     expect(text).toContain("truncated");
   });
+
+  it("leaves protected trailing batches intact during persisted aggregate recovery", async () => {
+    const dir = await createTmpDir();
+    const sm = SessionManager.create(dir, dir);
+    const firstKeptEntryId = sm.appendMessage(makeUserMessage("hello"));
+    sm.appendMessage(makeAssistantMessage("calling tools"));
+    const beforeTexts = Array.from({ length: 5 }, (_, index) => String(index).repeat(8_000));
+    for (const [index, text] of beforeTexts.entries()) {
+      sm.appendMessage(makeToolResult(text, `fresh_${index}`));
+    }
+    sm.appendCompaction("summary", firstKeptEntryId, 10);
+    const sessionFile = sm.getSessionFile()!;
+
+    const result = await truncateSessionThroughActiveTarget({
+      sessionFile,
+      contextWindowTokens: 1_000_000,
+      maxCharsOverride: 8_000,
+      aggregateMaxCharsOverride: 32_000,
+      protectTrailingToolResults: true,
+    });
+
+    expect(result.truncated).toBe(false);
+    const afterBranch = SessionManager.open(sessionFile).getBranch();
+    const afterTexts = afterBranch
+      .filter((entry) => entry.type === "message" && entry.message.role === "toolResult")
+      .map((entry) => (entry.type === "message" ? getFirstToolResultText(entry.message) : ""));
+
+    expect(afterTexts).toEqual(beforeTexts);
+  });
+
   it("combines oversized and aggregate recovery truncation in the same session rewrite", async () => {
     const dir = await createTmpDir();
     const sm = SessionManager.create(dir, dir);
@@ -841,7 +1749,7 @@ describe("truncateOversizedToolResultsInSession", () => {
     sm.appendMessage(makeToolResult(medium, "call_3"));
     const sessionFile = sm.getSessionFile()!;
 
-    const result = await truncateOversizedToolResultsInSession({
+    const result = await truncateSessionThroughActiveTarget({
       sessionFile,
       contextWindowTokens: 100,
     });
@@ -858,8 +1766,8 @@ describe("truncateOversizedToolResultsInSession", () => {
     );
 
     expect(toolTexts[0]).toContain("truncated");
-    expect(toolTexts[1].length).toBeGreaterThan(0);
-    expect(toolTexts[2].length).toBeGreaterThan(0);
+    expect(expectDefined(toolTexts[1], "toolTexts[1] test invariant").length).toBeGreaterThan(0);
+    expect(expectDefined(toolTexts[2], "toolTexts[2] test invariant").length).toBeGreaterThan(0);
   });
 
   it("lets aggregate recovery honor a tiny explicit cap during persisted rewrite", async () => {
@@ -873,10 +1781,11 @@ describe("truncateOversizedToolResultsInSession", () => {
     sm.appendMessage(makeToolResult(medium, "call_3"));
     const sessionFile = sm.getSessionFile()!;
 
-    const result = await truncateOversizedToolResultsInSession({
+    const result = await truncateSessionThroughActiveTarget({
       sessionFile,
       contextWindowTokens: 128_000,
       maxCharsOverride: 120,
+      aggregateMaxCharsOverride: 120,
     });
 
     expect(result.truncated).toBe(true);
@@ -921,3 +1830,4 @@ describe("truncateToolResultText head+tail strategy", () => {
     expect(result).toContain("truncated");
   });
 });
+/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/agents/embedded-agent-runner/tool-result-truncation.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.ts
@@ -1,14 +1,8 @@
 /**
  * Truncates oversized tool-result content in messages and transcripts.
  */
-import { createHash } from "node:crypto";
-import { existsSync } from "node:fs";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
-import { sliceUtf16Safe, truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
-import { loadTranscriptEvents } from "../../config/sessions/session-accessor.js";
-import { parseSqliteSessionFileMarker } from "../../config/sessions/sqlite-marker.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { createDedupeCache } from "../../infra/dedupe.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import type { TextContent } from "../../llm/types.js";
 import { emitSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
@@ -20,25 +14,17 @@ import {
   resolveSessionWriteLockOptions,
 } from "../session-write-lock.js";
 import { SessionManager } from "../sessions/index.js";
-import { formatFullOutputFooter } from "../sessions/tools/tool-contracts.js";
 import { formatContextLimitTruncationNotice } from "./context-truncation-notice.js";
 import { log } from "./logger.js";
-import type { ToolResultPromptProjectionState } from "./session-prompt-state.js";
 import {
-  createTranscriptFileStateFromPersistedEntries,
   persistTranscriptStateMutation,
   readTranscriptFileState,
-  TranscriptFileState,
+  type TranscriptFileState,
 } from "./transcript-file-state.js";
 import {
   rewriteTranscriptEntriesInSessionManager,
-  rewriteTranscriptEntriesInRuntimeTranscript,
   rewriteTranscriptEntriesInState,
 } from "./transcript-rewrite.js";
-import {
-  resolveRuntimeTranscriptReadTarget,
-  type RuntimeTranscriptScope,
-} from "./transcript-runtime-state.js";
 
 /**
  * Maximum share of the context window a single tool result should occupy.
@@ -59,8 +45,6 @@ const LARGE_CONTEXT_MAX_LIVE_TOOL_RESULT_CHARS = 32_000;
 const XL_CONTEXT_MAX_LIVE_TOOL_RESULT_CHARS = 64_000;
 const LARGE_CONTEXT_TOOL_RESULT_TOKENS = 100_000;
 const XL_CONTEXT_TOOL_RESULT_TOKENS = 200_000;
-const PROMPT_TOOL_RESULT_AGGREGATE_CAP_MULTIPLIER = 4;
-const AGGREGATE_TOOL_RESULT_CONTEXT_SHARE = 0.5;
 
 /**
  * Minimum characters to keep when truncating.
@@ -69,13 +53,6 @@ const AGGREGATE_TOOL_RESULT_CONTEXT_SHARE = 0.5;
  */
 const MIN_KEEP_CHARS = 2_000;
 const RECOVERY_MIN_KEEP_CHARS = 0;
-const TOOL_RESULT_WARNING_DEDUPE_LIMIT = 1_024;
-// Both warning paths live for the process lifetime. Keep their dedupe state
-// independently bounded so one hot path cannot evict the other's sessions.
-export const toolResultWarningDedupe = {
-  promptPressure: createDedupeCache({ ttlMs: 0, maxSize: TOOL_RESULT_WARNING_DEDUPE_LIMIT }),
-  sessionRecovery: createDedupeCache({ ttlMs: 0, maxSize: TOOL_RESULT_WARNING_DEDUPE_LIMIT }),
-};
 
 type ToolResultTruncationOptions = {
   suffix?: string | ((truncatedChars: number) => string);
@@ -86,55 +63,6 @@ const DEFAULT_SUFFIX = (truncatedChars: number) =>
   formatContextLimitTruncationNotice(truncatedChars);
 const COMPACT_RECOVERY_SUFFIX = (truncatedChars: number) =>
   `[... ${Math.max(1, Math.floor(truncatedChars))} chars truncated; narrow args]`;
-const AGGREGATE_ELISION_MARKER =
-  "[tool result elided: aggregate tool-result budget exceeded; rerun the command if the output is needed]";
-
-function logToolResultSessionTruncation(params: {
-  rewrittenEntries: number;
-  contextWindowTokens: number;
-  maxChars: number;
-  aggregateBudgetChars: number;
-  oversizedReplacementCount: number;
-  aggregateReplacementCount: number;
-  sessionKey?: string;
-  sessionId?: string;
-}): void {
-  const sessionLogKey = params.sessionKey ?? params.sessionId ?? "unknown";
-  const message =
-    `[tool-result-truncation] Truncated ${params.rewrittenEntries} tool result(s) in session ` +
-    `(contextWindow=${params.contextWindowTokens} maxChars=${params.maxChars} ` +
-    `aggregateBudgetChars=${params.aggregateBudgetChars} ` +
-    `oversized=${params.oversizedReplacementCount} aggregate=${params.aggregateReplacementCount}) ` +
-    `sessionKey=${sessionLogKey}`;
-  if (params.aggregateReplacementCount <= 0) {
-    log.info(message);
-    return;
-  }
-  if (toolResultWarningDedupe.sessionRecovery.check(sessionLogKey)) {
-    log.info(message);
-    return;
-  }
-  log.warn(
-    `${message}; aggregate tool-result pressure detected; consider /compact or /new if pressure persists`,
-  );
-}
-
-async function readRuntimeTranscriptFileState(
-  scope: RuntimeTranscriptScope,
-): Promise<TranscriptFileState> {
-  const target = await resolveRuntimeTranscriptReadTarget(scope);
-  const sqliteMarker = parseSqliteSessionFileMarker(target.sessionFile);
-  if (!sqliteMarker) {
-    throw new Error("runtime transcript target is not SQLite-backed");
-  }
-  const events = await loadTranscriptEvents({
-    agentId: sqliteMarker.agentId,
-    sessionId: sqliteMarker.sessionId,
-    sessionKey: target.sessionKey,
-    storePath: sqliteMarker.storePath,
-  });
-  return createTranscriptFileStateFromPersistedEntries(events);
-}
 
 function resolveSuffixFactory(
   suffix: ToolResultTruncationOptions["suffix"],
@@ -173,12 +101,11 @@ function appendBoundedTruncationSuffix(params: {
       return finalText;
     }
     if (keptText.length === 0) {
-      return truncateUtf16Safe(finalText, params.maxChars);
+      return finalText.slice(0, params.maxChars);
     }
     const overflow = finalText.length - params.maxChars;
-    const nextKeptText = sliceUtf16Safe(keptText, 0, Math.max(0, keptText.length - overflow));
-    keptText =
-      nextKeptText.length < keptText.length ? nextKeptText : sliceUtf16Safe(keptText, 0, -1);
+    const nextKeptText = keptText.slice(0, Math.max(0, keptText.length - overflow));
+    keptText = nextKeptText.length < keptText.length ? nextKeptText : keptText.slice(0, -1);
   }
 }
 
@@ -193,8 +120,8 @@ const MIDDLE_OMISSION_MARKER =
  * which should be preserved during truncation.
  */
 function hasImportantTail(text: string): boolean {
-  // Check last ~2000 chars for error-like patterns without splitting a surrogate pair.
-  const tail = normalizeLowercaseStringOrEmpty(sliceUtf16Safe(text, -2000));
+  // Check last ~2000 chars for error-like patterns
+  const tail = normalizeLowercaseStringOrEmpty(text.slice(-2000));
   return (
     /\b(error|exception|failed|fatal|traceback|panic|stack trace|errno|exit code)\b/.test(tail) ||
     // JSON closing — if the output is JSON, the tail has closing structure
@@ -212,7 +139,7 @@ function hasImportantTail(text: string): boolean {
  * This ensures error messages and summaries at the end of tool output
  * aren't lost during truncation.
  */
-function truncateToolResultText(
+export function truncateToolResultText(
   text: string,
   maxChars: number,
   options: ToolResultTruncationOptions = {},
@@ -248,8 +175,7 @@ function truncateToolResultText(
         tailStart = tailNewline + 1;
       }
 
-      const keptText =
-        sliceUtf16Safe(text, 0, headCut) + MIDDLE_OMISSION_MARKER + sliceUtf16Safe(text, tailStart);
+      const keptText = text.slice(0, headCut) + MIDDLE_OMISSION_MARKER + text.slice(tailStart);
       return appendBoundedTruncationSuffix({
         keptText,
         originalTextLength: text.length,
@@ -265,7 +191,7 @@ function truncateToolResultText(
   if (lastNewline > budget * 0.8) {
     cutPoint = lastNewline;
   }
-  const keptText = sliceUtf16Safe(text, 0, cutPoint);
+  const keptText = text.slice(0, cutPoint);
   return appendBoundedTruncationSuffix({
     keptText,
     originalTextLength: text.length,
@@ -281,7 +207,7 @@ function truncateToolResultText(
  * Uses a rough 4 chars ≈ 1 token heuristic (conservative for English text;
  * actual ratio varies by tokenizer).
  */
-function calculateMaxToolResultChars(contextWindowTokens: number): number {
+export function calculateMaxToolResultChars(contextWindowTokens: number): number {
   return calculateMaxToolResultCharsWithCap(
     contextWindowTokens,
     resolveAutoLiveToolResultMaxChars(contextWindowTokens),
@@ -322,42 +248,10 @@ export function resolveLiveToolResultMaxChars(params: {
   return calculateMaxToolResultCharsWithCap(params.contextWindowTokens, cap);
 }
 
-export function resolveLiveToolResultAggregateMaxChars(params: {
-  contextWindowTokens: number;
-  perResultMaxChars?: number;
-  cfg?: OpenClawConfig;
-  agentId?: string | null;
-}): number {
-  const perResultMaxChars = Math.max(
-    1,
-    Math.floor(
-      params.perResultMaxChars ??
-        resolveLiveToolResultMaxChars({
-          contextWindowTokens: params.contextWindowTokens,
-          cfg: params.cfg,
-          agentId: params.agentId,
-        }),
-    ),
-  );
-  const contextWindowTokens = Number.isFinite(params.contextWindowTokens)
-    ? Math.max(1, Math.floor(params.contextWindowTokens))
-    : 1;
-  // Aggregate truncation shares the 0.5 history-pressure invariant used by
-  // safeguard compaction and the mid-turn single-result guard. If this drifts,
-  // truncation can hide pressure that compaction routing should see.
-  const contextShareChars = Math.floor(
-    contextWindowTokens * 4 * AGGREGATE_TOOL_RESULT_CONTEXT_SHARE,
-  );
-  return Math.max(
-    perResultMaxChars * PROMPT_TOOL_RESULT_AGGREGATE_CAP_MULTIPLIER,
-    contextShareChars,
-  );
-}
-
 /**
  * Get the total character count of text content blocks in a tool result message.
  */
-function getToolResultTextLength(msg: AgentMessage): number {
+export function getToolResultTextLength(msg: AgentMessage): number {
   if (!msg || (msg as { role?: string }).role !== "toolResult") {
     return 0;
   }
@@ -449,116 +343,6 @@ function isToolResultTextBlock(
   );
 }
 
-type ToolResultSpillDetails = {
-  path: string;
-  truncated: boolean;
-  chars?: number;
-};
-
-function getToolResultSpillDetails(message: AgentMessage): ToolResultSpillDetails | undefined {
-  const details = (message as { details?: unknown }).details;
-  if (!details || typeof details !== "object" || Array.isArray(details)) {
-    return undefined;
-  }
-  const nested = (details as { spill?: unknown }).spill;
-  const nestedSpill =
-    nested && typeof nested === "object" && !Array.isArray(nested)
-      ? (nested as Record<string, unknown>)
-      : undefined;
-  // web_fetch owns the nested contract. Exec tools still own the flat spill fields.
-  const path = nestedSpill?.path ?? (details as { fullOutputPath?: unknown }).fullOutputPath;
-  if (typeof path !== "string" || path.length === 0) {
-    return undefined;
-  }
-  const truncated =
-    nestedSpill?.truncated === true ||
-    (details as { spillTruncated?: unknown }).spillTruncated === true;
-  const chars = nestedSpill?.chars ?? (details as { spilledChars?: unknown }).spilledChars;
-  return {
-    path,
-    truncated,
-    ...(typeof chars === "number" && Number.isFinite(chars)
-      ? { chars: Math.max(0, Math.floor(chars)) }
-      : {}),
-  };
-}
-
-function toolResultTextContainsFullOutputFooter(
-  message: AgentMessage,
-  fullOutputPath: string,
-): boolean {
-  const content = (message as { content?: unknown }).content;
-  if (!Array.isArray(content)) {
-    return false;
-  }
-  const footer = formatFullOutputFooter(fullOutputPath);
-  const escapedFooter = JSON.stringify(footer).slice(1, -1);
-  return content.some((block: unknown) => {
-    if (!isToolResultTextBlock(block)) {
-      return false;
-    }
-    return block.text.includes(footer) || block.text.includes(escapedFooter);
-  });
-}
-
-type AggregateElisionMarkers = {
-  full: string;
-  compact: string;
-  truncationSuffix: (truncatedChars: number) => string;
-};
-
-function resolveAggregateElisionMarkers(
-  message: AgentMessage,
-): AggregateElisionMarkers | undefined {
-  const spill = getToolResultSpillDetails(message);
-  if (!spill) {
-    return undefined;
-  }
-  // Details alone are not model-visible. Only preserve paths that already
-  // appeared in the original footer, so elision discloses nothing new.
-  if (!toolResultTextContainsFullOutputFooter(message, spill.path)) {
-    return undefined;
-  }
-  // Aggregate elision is a rare recovery path, not a request hot path; one
-  // existence check avoids pointing the model at already-deleted spill files.
-  if (!existsSync(spill.path)) {
-    return undefined;
-  }
-  // The path was already disclosed in the original tool footer; preserving it
-  // here adds no new disclosure and only keeps recovery possible.
-  if (spill.truncated) {
-    const count = spill.chars === undefined ? "capped content" : `first ${spill.chars} chars`;
-    return {
-      full: `[tool result elided: partial output preserved at ${spill.path} (${count}); read it if the output is needed]`,
-      compact: `[partial: ${spill.path}]`,
-      truncationSuffix: (truncatedChars) =>
-        `[... ${Math.max(1, Math.floor(truncatedChars))} chars truncated; partial output at ${spill.path}]`,
-    };
-  }
-  return {
-    full: `[tool result elided: full output preserved at ${spill.path}; read it if the output is needed]`,
-    compact: `[read ${spill.path}]`,
-    truncationSuffix: (truncatedChars) =>
-      `[... ${Math.max(1, Math.floor(truncatedChars))} chars truncated; full output at ${spill.path}]`,
-  };
-}
-
-function formatAggregateElisionText(
-  remainingTextBudget: number,
-  spillMarkers: AggregateElisionMarkers | undefined,
-): string {
-  if (remainingTextBudget <= 0) {
-    return "";
-  }
-  if (spillMarkers?.full && spillMarkers.full.length <= remainingTextBudget) {
-    return spillMarkers.full;
-  }
-  if (spillMarkers?.compact && spillMarkers.compact.length <= remainingTextBudget) {
-    return spillMarkers.compact;
-  }
-  return AGGREGATE_ELISION_MARKER.slice(0, remainingTextBudget);
-}
-
 /**
  * Truncate oversized tool results in an array of messages (in-memory).
  * Returns a new array with truncated messages.
@@ -572,13 +356,7 @@ export function truncateOversizedToolResultsInMessages(
   maxCharsOverride?: number,
   aggregateMaxCharsOverride?: number,
   projectionState?: ToolResultPromptProjectionState,
-): {
-  messages: AgentMessage[];
-  truncatedCount: number;
-  aggregateTruncatedCount: number;
-  aggregatePressureEngaged: boolean;
-  aggregateBudgetChars: number;
-} {
+): { messages: AgentMessage[]; truncatedCount: number } {
   const maxChars = Math.max(
     1,
     maxCharsOverride ?? calculateMaxToolResultChars(contextWindowTokens),
@@ -591,7 +369,6 @@ export function truncateOversizedToolResultsInMessages(
   const projectionKeys = projectionState
     ? getToolResultProjectionKeys(messages, projectionState)
     : [];
-  const hasFrozenProjectionBaseline = (projectionState?.frozen.size ?? 0) > 0;
   const branch = messages.map((message, index) => {
     const projectionKey = projectionKeys[index];
     const projectedMessage = projectionKey
@@ -615,13 +392,6 @@ export function truncateOversizedToolResultsInMessages(
         !projectionKey ||
         !projectionState?.frozen.has(projectionKey) ||
         (projectedMessage !== undefined && mergedMessage === message),
-      // Steering and follow-up messages can follow fresh tool results before dispatch.
-      // Reduce frozen history first so message position cannot make fresh output disappear.
-      deferAggregateRecovery:
-        projectionKey !== undefined &&
-        projectionState !== undefined &&
-        hasFrozenProjectionBaseline &&
-        !projectionState.frozen.has(projectionKey),
     };
   });
   const plan = buildToolResultReplacementPlan({
@@ -629,7 +399,6 @@ export function truncateOversizedToolResultsInMessages(
     maxChars,
     aggregateBudgetChars,
     minKeepChars: RECOVERY_MIN_KEEP_CHARS,
-    protectTrailingToolResults: Boolean(projectionState),
   });
   if (projectionState) {
     for (const [index] of messages.entries()) {
@@ -647,9 +416,6 @@ export function truncateOversizedToolResultsInMessages(
     return {
       messages: hasProjectedChanges ? projectedMessages : messages,
       truncatedCount: 0,
-      aggregateTruncatedCount: 0,
-      aggregatePressureEngaged: plan.aggregatePressureExceeded,
-      aggregateBudgetChars,
     };
   }
 
@@ -670,9 +436,6 @@ export function truncateOversizedToolResultsInMessages(
   return {
     messages: replacedBranch.map((entry) => entry.message as AgentMessage),
     truncatedCount: replacementIds.size,
-    aggregateTruncatedCount: plan.aggregateReplacementCount,
-    aggregatePressureEngaged: plan.aggregatePressureExceeded,
-    aggregateBudgetChars,
   };
 }
 
@@ -684,10 +447,8 @@ function calculateRecoveryAggregateToolResultChars(
   return Math.max(
     1,
     aggregateMaxCharsOverride ??
-      resolveLiveToolResultAggregateMaxChars({
-        contextWindowTokens,
-        perResultMaxChars: maxCharsOverride ?? calculateMaxToolResultChars(contextWindowTokens),
-      }),
+      maxCharsOverride ??
+      calculateMaxToolResultChars(contextWindowTokens),
   );
 }
 
@@ -707,13 +468,28 @@ type ToolResultBranchEntry = {
   type: string;
   message?: AgentMessage;
   aggregateEligible?: boolean;
-  deferAggregateRecovery?: boolean;
 };
 
 type ToolResultReplacement = {
   entryId: string;
   message: AgentMessage;
 };
+
+export type ToolResultPromptProjectionState = {
+  replacements: Map<string, AgentMessage>;
+  frozen: Set<string>;
+  ambiguousBaseKeys: Set<string>;
+  sourceTextByKey: Map<string, string[]>;
+};
+
+export function createToolResultPromptProjectionState(): ToolResultPromptProjectionState {
+  return {
+    replacements: new Map<string, AgentMessage>(),
+    frozen: new Set<string>(),
+    ambiguousBaseKeys: new Set<string>(),
+    sourceTextByKey: new Map<string, string[]>(),
+  };
+}
 
 function getToolResultProjectionBaseKey(message: AgentMessage): string | undefined {
   if (message.role !== "toolResult") {
@@ -745,27 +521,16 @@ function getToolResultProjectionKeys(
     }
   }
   const occurrences = new Map<string, number>();
-  return baseKeys.map((baseKey, index) => {
-    if (baseKey && !projectionState.ambiguousBaseKeys.has(baseKey)) {
-      return baseKey;
-    }
-    const message = messages[index];
-    if (!message || message.role !== "toolResult") {
+  return baseKeys.map((baseKey) => {
+    if (!baseKey) {
       return undefined;
     }
-    // Ambiguous/missing tool ids still need a stable frozen identity; otherwise
-    // each request rewrites their prompt-cache tail projection (#99495).
-    const messageId = (message as { id?: unknown }).id;
-    const sourceIdentity =
-      typeof messageId === "string" && messageId.length > 0
-        ? `id:${messageId}`
-        : `text:${createHash("sha256")
-            .update(JSON.stringify(getToolResultTextBlocks(message)))
-            .digest("base64url")}`;
-    const fallbackBase = `fallback:${baseKey ?? "tool"}:${sourceIdentity}`;
-    const occurrence = occurrences.get(fallbackBase) ?? 0;
-    occurrences.set(fallbackBase, occurrence + 1);
-    return `${fallbackBase}:${occurrence}`;
+    if (projectionState.ambiguousBaseKeys.has(baseKey)) {
+      return undefined;
+    }
+    const occurrence = occurrences.get(baseKey) ?? 0;
+    occurrences.set(baseKey, occurrence + 1);
+    return `${baseKey}:${occurrence}`;
   });
 }
 
@@ -829,28 +594,17 @@ function getToolResultTextBlocks(message: AgentMessage): string[] {
 
 function buildAggregateToolResultReplacements(params: {
   branch: ToolResultBranchEntry[];
-  spillSourceBranch?: ToolResultBranchEntry[];
   aggregateBudgetChars: number;
   minKeepChars?: number;
-  protectTrailingToolResults?: boolean;
-}): { replacements: ToolResultReplacement[]; pressureExceeded: boolean } {
+}): ToolResultReplacement[] {
   const minKeepChars = params.minKeepChars ?? MIN_KEEP_CHARS;
-  const protectedEntryIds = params.protectTrailingToolResults
-    ? getTrailingToolResultEntryIds(params.branch)
-    : new Set<string>();
   const candidates = params.branch
     .map((entry, index) => ({ entry, index }))
     .filter(
       (
         item,
       ): item is {
-        entry: {
-          id: string;
-          type: string;
-          message: AgentMessage;
-          aggregateEligible?: boolean;
-          deferAggregateRecovery?: boolean;
-        };
+        entry: { id: string; type: string; message: AgentMessage; aggregateEligible?: boolean };
         index: number;
       } =>
         item.entry.type === "message" &&
@@ -861,16 +615,13 @@ function buildAggregateToolResultReplacements(params: {
       index: item.index,
       entryId: item.entry.id,
       message: item.entry.message,
-      spillSourceMessage: params.spillSourceBranch?.[item.index]?.message ?? item.entry.message,
       textLength: getToolResultTextLength(item.entry.message),
       aggregateEligible: item.entry.aggregateEligible !== false,
-      deferredByFreshProjection: item.entry.deferAggregateRecovery === true,
-      protectedByTrailingBatch: protectedEntryIds.has(item.entry.id),
     }))
     .filter((item) => item.textLength > 0);
 
   if (candidates.length < 2) {
-    return { replacements: [], pressureExceeded: false };
+    return [];
   }
 
   const suffixFactory =
@@ -882,47 +633,60 @@ function buildAggregateToolResultReplacements(params: {
 
   const totalChars = candidates.reduce((sum, item) => sum + item.textLength, 0);
   if (totalChars <= params.aggregateBudgetChars) {
-    return { replacements: [], pressureExceeded: false };
+    return [];
   }
 
-  let remainingReduction = totalChars - params.aggregateBudgetChars;
+  const eligibleCandidates = candidates.filter((item) => item.aggregateEligible);
+  const ineligibleCandidates = candidates.filter((item) => !item.aggregateEligible);
+  const ineligibleChars = ineligibleCandidates.reduce((sum, item) => sum + item.textLength, 0);
+
+  if (ineligibleChars >= params.aggregateBudgetChars) {
+    return [];
+  }
+
+  const eligibleTotalChars = eligibleCandidates.reduce((sum, item) => sum + item.textLength, 0);
+
+  const floorMinKeepChars =
+    params.aggregateBudgetChars >= MIN_KEEP_CHARS
+      ? Math.max(minKeepChars, MIN_KEEP_CHARS)
+      : minKeepChars;
+  const floorMinTruncatedTextChars = floorMinKeepChars + suffixFactory(1).length;
+
+  const eligibleBudget = Math.max(
+    eligibleCandidates.length * floorMinTruncatedTextChars,
+    params.aggregateBudgetChars - ineligibleChars,
+  );
+  let remainingReduction = eligibleTotalChars - eligibleBudget;
+  if (remainingReduction <= 0) {
+    return [];
+  }
   const replacements: Array<{ entryId: string; message: AgentMessage }> = [];
-  const aggregateRecoveryCandidates = candidates
-    .filter((item) => !item.deferredByFreshProjection && !item.protectedByTrailingBatch)
+
+  // Spend aggregate reduction on older entries first so fresh tool output stays intact.
+  for (const candidate of candidates
+    .filter((item) => item.aggregateEligible)
     .toSorted((a, b) => {
       if (a.index !== b.index) {
         return a.index - b.index;
       }
       return b.textLength - a.textLength;
-    });
-  const recoveryCandidates = [
-    ...aggregateRecoveryCandidates.filter((item) => item.aggregateEligible),
-    // Start from frozen projections before touching deferred fresh results. Reusing their
-    // projected text keeps this shrink-only and preserves prompt-cache stability.
-    ...aggregateRecoveryCandidates.filter((item) => !item.aggregateEligible),
-    ...candidates.filter(
-      (item) => item.deferredByFreshProjection && !item.protectedByTrailingBatch,
-    ),
-  ];
-
-  // Spend aggregate reduction on older entries first so fresh tool output stays intact.
-  for (const candidate of recoveryCandidates) {
+    })) {
     if (remainingReduction <= 0) {
       break;
     }
-    const reducibleChars = Math.max(0, candidate.textLength - minTruncatedTextChars);
+    const reducibleChars = Math.max(0, candidate.textLength - floorMinTruncatedTextChars);
     if (reducibleChars <= 0) {
       continue;
     }
 
     const requestedReduction = Math.min(reducibleChars, remainingReduction);
-    const targetChars = Math.max(minTruncatedTextChars, candidate.textLength - requestedReduction);
-    const spillMarkers = resolveAggregateElisionMarkers(candidate.spillSourceMessage);
-    const candidateSuffixFactory = spillMarkers?.truncationSuffix ?? suffixFactory;
-    const candidateTargetChars = Math.max(targetChars, candidateSuffixFactory(1).length);
-    const truncatedMessage = truncateToolResultMessage(candidate.message, candidateTargetChars, {
-      minKeepChars,
-      suffix: candidateSuffixFactory,
+    const targetChars = Math.max(
+      floorMinTruncatedTextChars,
+      candidate.textLength - requestedReduction,
+    );
+    const truncatedMessage = truncateToolResultMessage(candidate.message, targetChars, {
+      minKeepChars: floorMinKeepChars,
+      suffix: suffixFactory,
     });
     const newLength = getToolResultTextLength(truncatedMessage);
     const actualReduction = Math.max(0, candidate.textLength - newLength);
@@ -935,20 +699,19 @@ function buildAggregateToolResultReplacements(params: {
   }
 
   if (remainingReduction > 0) {
-    for (const candidate of recoveryCandidates) {
+    for (const candidate of candidates.filter((item) => item.aggregateEligible)) {
       if (remainingReduction <= 0) {
         break;
       }
       const existingReplacement = replacements.find(
         (replacement) => replacement.entryId === candidate.entryId,
       );
-      const baseMessage = existingReplacement?.message ?? candidate.message;
-      const baseTextLength = getToolResultTextLength(baseMessage);
-      const targetTextChars = Math.max(0, baseTextLength - remainingReduction);
-      const spillMarkers = resolveAggregateElisionMarkers(candidate.spillSourceMessage);
-      const emptyMessage = clearToolResultText(candidate.message, targetTextChars, spillMarkers);
-      const actualReduction = Math.max(0, baseTextLength - getToolResultTextLength(emptyMessage));
-      if (actualReduction <= 0 && !spillMarkers) {
+      const emptyMessage = clearToolResultText(existingReplacement?.message ?? candidate.message);
+      const actualReduction = Math.max(
+        0,
+        candidate.textLength - getToolResultTextLength(emptyMessage),
+      );
+      if (actualReduction <= 0) {
         continue;
       }
       const replacement = { entryId: candidate.entryId, message: emptyMessage };
@@ -964,58 +727,21 @@ function buildAggregateToolResultReplacements(params: {
     }
   }
 
-  return { replacements, pressureExceeded: true };
+  return replacements;
 }
 
-function getTrailingToolResultEntryIds(branch: ToolResultBranchEntry[]): Set<string> {
-  const ids = new Set<string>();
-  let sawMessage = false;
-  for (let index = branch.length - 1; index >= 0; index--) {
-    const entry = branch[index];
-    if (entry?.type !== "message" || !entry.message) {
-      if (!sawMessage) {
-        continue;
-      }
-      break;
-    }
-    sawMessage = true;
-    if ((entry.message as { role?: string }).role !== "toolResult") {
-      break;
-    }
-    ids.add(entry.id);
-  }
-  return ids;
-}
-
-function clearToolResultText(
-  message: AgentMessage,
-  maxTextChars = Number.POSITIVE_INFINITY,
-  resolvedSpillMarkers?: AggregateElisionMarkers,
-): AgentMessage {
+function clearToolResultText(message: AgentMessage): AgentMessage {
   const content = (message as { content?: unknown }).content;
   if (!Array.isArray(content)) {
     return message;
   }
-  let remainingTextBudget = Math.max(0, Math.floor(maxTextChars));
-  const spillMarkers = resolvedSpillMarkers ?? resolveAggregateElisionMarkers(message);
-  if (spillMarkers) {
-    // The pointer is what makes elision recoverable. ~130 chars per entry is
-    // negligible against the 64k+ aggregate floor, and accounting uses actual lengths.
-    remainingTextBudget = Math.max(remainingTextBudget, spillMarkers.compact.length);
-  }
   return {
     ...message,
-    content: content.map((block) => {
-      if (!isToolResultTextBlock(block)) {
-        return block;
-      }
-      const replacementText = formatAggregateElisionText(remainingTextBudget, spillMarkers);
-      remainingTextBudget = Math.max(0, remainingTextBudget - replacementText.length);
-      return Object.assign({}, block, {
-        text: replacementText,
-        ...(typeof block.content === "string" ? { content: replacementText } : {}),
-      });
-    }),
+    content: content.map((block) =>
+      block && typeof block === "object" && (block as { type?: unknown }).type === "text"
+        ? Object.assign({}, block, { text: "" })
+        : block,
+    ),
   } as AgentMessage;
 }
 
@@ -1023,7 +749,6 @@ function buildOversizedToolResultReplacements(params: {
   branch: ToolResultBranchEntry[];
   maxChars: number;
   minKeepChars?: number;
-  protectedEntryIds?: Set<string>;
 }): ToolResultReplacement[] {
   const minKeepChars = params.minKeepChars ?? MIN_KEEP_CHARS;
   const replacements: ToolResultReplacement[] = [];
@@ -1039,17 +764,10 @@ function buildOversizedToolResultReplacements(params: {
     if (getToolResultTextLength(msg) <= params.maxChars) {
       continue;
     }
-    const replacementMinKeepChars = params.protectedEntryIds?.has(entry.id)
-      ? Math.max(minKeepChars, MIN_KEEP_CHARS)
-      : minKeepChars;
-    const spillMarkers = resolveAggregateElisionMarkers(msg);
-    const suffixFactory = spillMarkers?.truncationSuffix;
-    const maxChars = Math.max(params.maxChars, suffixFactory?.(1).length ?? 0);
     replacements.push({
       entryId: entry.id,
-      message: truncateToolResultMessage(msg, maxChars, {
-        minKeepChars: replacementMinKeepChars,
-        ...(suffixFactory ? { suffix: suffixFactory } : {}),
+      message: truncateToolResultMessage(msg, params.maxChars, {
+        minKeepChars,
       }),
     });
   }
@@ -1108,24 +826,18 @@ function buildToolResultReplacementPlan(params: {
   maxChars: number;
   aggregateBudgetChars: number;
   minKeepChars?: number;
-  protectTrailingToolResults?: boolean;
 }): {
   replacements: ToolResultReplacement[];
   oversizedReplacementCount: number;
   aggregateReplacementCount: number;
-  aggregatePressureExceeded: boolean;
   oversizedReducibleChars: number;
   aggregateReducibleChars: number;
 } {
   const minKeepChars = params.minKeepChars ?? MIN_KEEP_CHARS;
-  const protectedEntryIds = params.protectTrailingToolResults
-    ? getTrailingToolResultEntryIds(params.branch)
-    : undefined;
   const oversizedReplacements = buildOversizedToolResultReplacements({
     branch: params.branch,
     maxChars: params.maxChars,
     minKeepChars,
-    protectedEntryIds,
   });
   const oversizedReducibleChars = calculateReplacementReduction(
     params.branch,
@@ -1135,14 +847,11 @@ function buildToolResultReplacementPlan(params: {
     params.branch,
     oversizedReplacements,
   );
-  const aggregatePlan = buildAggregateToolResultReplacements({
+  const aggregateReplacements = buildAggregateToolResultReplacements({
     branch: oversizedTrimmedBranch,
-    spillSourceBranch: params.branch,
     aggregateBudgetChars: params.aggregateBudgetChars,
     minKeepChars,
-    protectTrailingToolResults: params.protectTrailingToolResults,
   });
-  const aggregateReplacements = aggregatePlan.replacements;
   const aggregateReducibleChars = calculateReplacementReduction(
     oversizedTrimmedBranch,
     aggregateReplacements,
@@ -1152,45 +861,10 @@ function buildToolResultReplacementPlan(params: {
     replacements: [...oversizedReplacements, ...aggregateReplacements],
     oversizedReplacementCount: oversizedReplacements.length,
     aggregateReplacementCount: aggregateReplacements.length,
-    aggregatePressureExceeded: aggregatePlan.pressureExceeded,
     oversizedReducibleChars,
     aggregateReducibleChars,
   };
 }
-
-function buildRecoveryToolResultReplacementPlan(params: {
-  branch: ToolResultBranchEntry[];
-  contextWindowTokens: number;
-  maxCharsOverride?: number;
-  aggregateMaxCharsOverride?: number;
-  protectTrailingToolResults?: boolean;
-}): {
-  maxChars: number;
-  aggregateBudgetChars: number;
-  plan: ReturnType<typeof buildToolResultReplacementPlan>;
-} {
-  const maxChars = Math.max(
-    1,
-    params.maxCharsOverride ?? calculateMaxToolResultChars(params.contextWindowTokens),
-  );
-  const aggregateBudgetChars = calculateRecoveryAggregateToolResultChars(
-    params.contextWindowTokens,
-    maxChars,
-    params.aggregateMaxCharsOverride,
-  );
-  return {
-    maxChars,
-    aggregateBudgetChars,
-    plan: buildToolResultReplacementPlan({
-      branch: params.branch,
-      maxChars,
-      aggregateBudgetChars,
-      minKeepChars: RECOVERY_MIN_KEEP_CHARS,
-      protectTrailingToolResults: params.protectTrailingToolResults,
-    }),
-  };
-}
-
 export function estimateToolResultReductionPotential(params: {
   messages: AgentMessage[];
   contextWindowTokens: number;
@@ -1251,25 +925,32 @@ function truncateOversizedToolResultsInExistingSessionManager(params: {
   contextWindowTokens: number;
   maxCharsOverride?: number;
   aggregateMaxCharsOverride?: number;
-  protectTrailingToolResults?: boolean;
   sessionFile?: string;
   sessionId?: string;
   sessionKey?: string;
   agentId?: string;
 }): { truncated: boolean; truncatedCount: number; reason?: string } {
   const { sessionManager, contextWindowTokens } = params;
+  const maxChars = Math.max(
+    1,
+    params.maxCharsOverride ?? calculateMaxToolResultChars(contextWindowTokens),
+  );
+  const aggregateBudgetChars = calculateRecoveryAggregateToolResultChars(
+    contextWindowTokens,
+    maxChars,
+    params.aggregateMaxCharsOverride,
+  );
   const branch = sessionManager.getBranch() as ToolResultBranchEntry[];
 
   if (branch.length === 0) {
     return { truncated: false, truncatedCount: 0, reason: "empty session" };
   }
 
-  const { maxChars, aggregateBudgetChars, plan } = buildRecoveryToolResultReplacementPlan({
+  const plan = buildToolResultReplacementPlan({
     branch,
-    contextWindowTokens,
-    maxCharsOverride: params.maxCharsOverride,
-    aggregateMaxCharsOverride: params.aggregateMaxCharsOverride,
-    protectTrailingToolResults: params.protectTrailingToolResults,
+    maxChars,
+    aggregateBudgetChars,
+    minKeepChars: RECOVERY_MIN_KEEP_CHARS,
   });
   if (plan.replacements.length === 0) {
     return {
@@ -1299,16 +980,12 @@ function truncateOversizedToolResultsInExistingSessionManager(params: {
     });
   }
 
-  logToolResultSessionTruncation({
-    rewrittenEntries: rewriteResult.rewrittenEntries,
-    contextWindowTokens,
-    maxChars,
-    aggregateBudgetChars,
-    oversizedReplacementCount: plan.oversizedReplacementCount,
-    aggregateReplacementCount: plan.aggregateReplacementCount,
-    sessionKey: params.sessionKey,
-    sessionId: params.sessionId,
-  });
+  log.info(
+    `[tool-result-truncation] Truncated ${rewriteResult.rewrittenEntries} tool result(s) in session ` +
+      `(contextWindow=${contextWindowTokens} maxChars=${maxChars} aggregateBudgetChars=${aggregateBudgetChars} ` +
+      `oversized=${plan.oversizedReplacementCount} aggregate=${plan.aggregateReplacementCount}) ` +
+      `sessionKey=${params.sessionKey ?? params.sessionId ?? "unknown"}`,
+  );
 
   return {
     truncated: rewriteResult.changed,
@@ -1323,25 +1000,32 @@ async function truncateOversizedToolResultsInTranscriptState(params: {
   contextWindowTokens: number;
   maxCharsOverride?: number;
   aggregateMaxCharsOverride?: number;
-  protectTrailingToolResults?: boolean;
   sessionId?: string;
   sessionKey?: string;
   agentId?: string;
   config?: SessionWriteLockAcquireTimeoutConfig;
 }): Promise<{ truncated: boolean; truncatedCount: number; reason?: string }> {
   const { state, contextWindowTokens } = params;
+  const maxChars = Math.max(
+    1,
+    params.maxCharsOverride ?? calculateMaxToolResultChars(contextWindowTokens),
+  );
+  const aggregateBudgetChars = calculateRecoveryAggregateToolResultChars(
+    contextWindowTokens,
+    maxChars,
+    params.aggregateMaxCharsOverride,
+  );
   const branch = state.getBranch() as ToolResultBranchEntry[];
 
   if (branch.length === 0) {
     return { truncated: false, truncatedCount: 0, reason: "empty session" };
   }
 
-  const { maxChars, aggregateBudgetChars, plan } = buildRecoveryToolResultReplacementPlan({
+  const plan = buildToolResultReplacementPlan({
     branch,
-    contextWindowTokens,
-    maxCharsOverride: params.maxCharsOverride,
-    aggregateMaxCharsOverride: params.aggregateMaxCharsOverride,
-    protectTrailingToolResults: params.protectTrailingToolResults,
+    maxChars,
+    aggregateBudgetChars,
+    minKeepChars: RECOVERY_MIN_KEEP_CHARS,
   });
   if (plan.replacements.length === 0) {
     return {
@@ -1376,16 +1060,12 @@ async function truncateOversizedToolResultsInTranscriptState(params: {
     });
   }
 
-  logToolResultSessionTruncation({
-    rewrittenEntries: rewriteResult.rewrittenEntries,
-    contextWindowTokens,
-    maxChars,
-    aggregateBudgetChars,
-    oversizedReplacementCount: plan.oversizedReplacementCount,
-    aggregateReplacementCount: plan.aggregateReplacementCount,
-    sessionKey: params.sessionKey,
-    sessionId: params.sessionId,
-  });
+  log.info(
+    `[tool-result-truncation] Truncated ${rewriteResult.rewrittenEntries} tool result(s) in session ` +
+      `(contextWindow=${contextWindowTokens} maxChars=${maxChars} aggregateBudgetChars=${aggregateBudgetChars} ` +
+      `oversized=${plan.oversizedReplacementCount} aggregate=${plan.aggregateReplacementCount}) ` +
+      `sessionKey=${params.sessionKey ?? params.sessionId ?? "unknown"}`,
+  );
 
   return {
     truncated: rewriteResult.changed,
@@ -1399,7 +1079,6 @@ export function truncateOversizedToolResultsInSessionManager(params: {
   contextWindowTokens: number;
   maxCharsOverride?: number;
   aggregateMaxCharsOverride?: number;
-  protectTrailingToolResults?: boolean;
   sessionFile?: string;
   sessionId?: string;
   sessionKey?: string;
@@ -1415,110 +1094,13 @@ export function truncateOversizedToolResultsInSessionManager(params: {
 }
 
 /**
- * Truncates oversized tool results in the active runtime transcript.
- */
-async function truncateOversizedToolResultsInRuntimeTranscript(params: {
-  scope: RuntimeTranscriptScope;
-  contextWindowTokens: number;
-  maxCharsOverride?: number;
-  aggregateMaxCharsOverride?: number;
-  protectTrailingToolResults?: boolean;
-  config?: SessionWriteLockAcquireTimeoutConfig;
-}): Promise<{ truncated: boolean; truncatedCount: number; reason?: string }> {
-  try {
-    const state = await readRuntimeTranscriptFileState(params.scope);
-    const { contextWindowTokens } = params;
-    const branch = state.getBranch() as ToolResultBranchEntry[];
-
-    if (branch.length === 0) {
-      return { truncated: false, truncatedCount: 0, reason: "empty session" };
-    }
-
-    const { maxChars, aggregateBudgetChars, plan } = buildRecoveryToolResultReplacementPlan({
-      branch,
-      contextWindowTokens,
-      maxCharsOverride: params.maxCharsOverride,
-      aggregateMaxCharsOverride: params.aggregateMaxCharsOverride,
-      protectTrailingToolResults: params.protectTrailingToolResults,
-    });
-    if (plan.replacements.length === 0) {
-      return {
-        truncated: false,
-        truncatedCount: 0,
-        reason: "no oversized or aggregate tool results",
-      };
-    }
-
-    const rewriteResult = await rewriteTranscriptEntriesInRuntimeTranscript({
-      scope: params.scope,
-      request: { replacements: plan.replacements },
-      config: params.config,
-    });
-
-    logToolResultSessionTruncation({
-      rewrittenEntries: rewriteResult.rewrittenEntries,
-      contextWindowTokens,
-      maxChars,
-      aggregateBudgetChars,
-      oversizedReplacementCount: plan.oversizedReplacementCount,
-      aggregateReplacementCount: plan.aggregateReplacementCount,
-      sessionKey: params.scope.sessionKey,
-      sessionId: params.scope.sessionId,
-    });
-
-    return {
-      truncated: rewriteResult.changed,
-      truncatedCount: rewriteResult.rewrittenEntries,
-      reason: rewriteResult.reason,
-    };
-  } catch (err) {
-    const errMsg = formatErrorMessage(err);
-    log.warn(`[tool-result-truncation] Failed to truncate: ${errMsg}`);
-    return { truncated: false, truncatedCount: 0, reason: errMsg };
-  }
-}
-
-/** Truncates oversized tool results in either a SQLite runtime target or explicit file target. */
-export async function truncateOversizedToolResultsInActiveTarget(params: {
-  scope: RuntimeTranscriptScope;
-  contextWindowTokens: number;
-  maxCharsOverride?: number;
-  aggregateMaxCharsOverride?: number;
-  protectTrailingToolResults?: boolean;
-  config?: OpenClawConfig;
-}): Promise<{ truncated: boolean; truncatedCount: number; reason?: string }> {
-  if (parseSqliteSessionFileMarker(params.scope.sessionFile)) {
-    return await truncateOversizedToolResultsInRuntimeTranscript(params);
-  }
-  if (!params.scope.sessionFile) {
-    return {
-      truncated: false,
-      truncatedCount: 0,
-      reason: "no session file",
-    };
-  }
-  return await truncateOversizedToolResultsInSession({
-    sessionFile: params.scope.sessionFile,
-    contextWindowTokens: params.contextWindowTokens,
-    maxCharsOverride: params.maxCharsOverride,
-    aggregateMaxCharsOverride: params.aggregateMaxCharsOverride,
-    protectTrailingToolResults: params.protectTrailingToolResults,
-    sessionId: params.scope.sessionId,
-    sessionKey: params.scope.sessionKey,
-    agentId: params.scope.agentId,
-    config: params.config,
-  });
-}
-
-/**
  * Truncates a named transcript file artifact.
  */
-async function truncateOversizedToolResultsInSession(params: {
+export async function truncateOversizedToolResultsInSession(params: {
   sessionFile: string;
   contextWindowTokens: number;
   maxCharsOverride?: number;
   aggregateMaxCharsOverride?: number;
-  protectTrailingToolResults?: boolean;
   sessionId?: string;
   sessionKey?: string;
   agentId?: string;
@@ -1538,7 +1120,6 @@ async function truncateOversizedToolResultsInSession(params: {
       contextWindowTokens,
       maxCharsOverride: params.maxCharsOverride,
       aggregateMaxCharsOverride: params.aggregateMaxCharsOverride,
-      protectTrailingToolResults: params.protectTrailingToolResults,
       sessionFile,
       sessionId: params.sessionId,
       sessionKey: params.sessionKey,
@@ -1561,4 +1142,3 @@ export function sessionLikelyHasOversizedToolResults(params: {
   const estimate = estimateToolResultReductionPotential(params);
   return estimate.oversizedCount > 0 || estimate.aggregateReducibleChars > 0;
 }
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/agents/embedded-agent-runner/tool-result-truncation.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.ts
@@ -1,8 +1,14 @@
 /**
  * Truncates oversized tool-result content in messages and transcripts.
  */
+import { createHash } from "node:crypto";
+import { existsSync } from "node:fs";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import { sliceUtf16Safe, truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { loadTranscriptEvents } from "../../config/sessions/session-accessor.js";
+import { parseSqliteSessionFileMarker } from "../../config/sessions/sqlite-marker.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { createDedupeCache } from "../../infra/dedupe.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import type { TextContent } from "../../llm/types.js";
 import { emitSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
@@ -14,17 +20,25 @@ import {
   resolveSessionWriteLockOptions,
 } from "../session-write-lock.js";
 import { SessionManager } from "../sessions/index.js";
+import { formatFullOutputFooter } from "../sessions/tools/tool-contracts.js";
 import { formatContextLimitTruncationNotice } from "./context-truncation-notice.js";
 import { log } from "./logger.js";
+import type { ToolResultPromptProjectionState } from "./session-prompt-state.js";
 import {
+  createTranscriptFileStateFromPersistedEntries,
   persistTranscriptStateMutation,
   readTranscriptFileState,
-  type TranscriptFileState,
+  TranscriptFileState,
 } from "./transcript-file-state.js";
 import {
   rewriteTranscriptEntriesInSessionManager,
+  rewriteTranscriptEntriesInRuntimeTranscript,
   rewriteTranscriptEntriesInState,
 } from "./transcript-rewrite.js";
+import {
+  resolveRuntimeTranscriptReadTarget,
+  type RuntimeTranscriptScope,
+} from "./transcript-runtime-state.js";
 
 /**
  * Maximum share of the context window a single tool result should occupy.
@@ -45,6 +59,8 @@ const LARGE_CONTEXT_MAX_LIVE_TOOL_RESULT_CHARS = 32_000;
 const XL_CONTEXT_MAX_LIVE_TOOL_RESULT_CHARS = 64_000;
 const LARGE_CONTEXT_TOOL_RESULT_TOKENS = 100_000;
 const XL_CONTEXT_TOOL_RESULT_TOKENS = 200_000;
+const PROMPT_TOOL_RESULT_AGGREGATE_CAP_MULTIPLIER = 4;
+const AGGREGATE_TOOL_RESULT_CONTEXT_SHARE = 0.5;
 
 /**
  * Minimum characters to keep when truncating.
@@ -53,6 +69,13 @@ const XL_CONTEXT_TOOL_RESULT_TOKENS = 200_000;
  */
 const MIN_KEEP_CHARS = 2_000;
 const RECOVERY_MIN_KEEP_CHARS = 0;
+const TOOL_RESULT_WARNING_DEDUPE_LIMIT = 1_024;
+// Both warning paths live for the process lifetime. Keep their dedupe state
+// independently bounded so one hot path cannot evict the other's sessions.
+export const toolResultWarningDedupe = {
+  promptPressure: createDedupeCache({ ttlMs: 0, maxSize: TOOL_RESULT_WARNING_DEDUPE_LIMIT }),
+  sessionRecovery: createDedupeCache({ ttlMs: 0, maxSize: TOOL_RESULT_WARNING_DEDUPE_LIMIT }),
+};
 
 type ToolResultTruncationOptions = {
   suffix?: string | ((truncatedChars: number) => string);
@@ -63,6 +86,55 @@ const DEFAULT_SUFFIX = (truncatedChars: number) =>
   formatContextLimitTruncationNotice(truncatedChars);
 const COMPACT_RECOVERY_SUFFIX = (truncatedChars: number) =>
   `[... ${Math.max(1, Math.floor(truncatedChars))} chars truncated; narrow args]`;
+const AGGREGATE_ELISION_MARKER =
+  "[tool result elided: aggregate tool-result budget exceeded; rerun the command if the output is needed]";
+
+function logToolResultSessionTruncation(params: {
+  rewrittenEntries: number;
+  contextWindowTokens: number;
+  maxChars: number;
+  aggregateBudgetChars: number;
+  oversizedReplacementCount: number;
+  aggregateReplacementCount: number;
+  sessionKey?: string;
+  sessionId?: string;
+}): void {
+  const sessionLogKey = params.sessionKey ?? params.sessionId ?? "unknown";
+  const message =
+    `[tool-result-truncation] Truncated ${params.rewrittenEntries} tool result(s) in session ` +
+    `(contextWindow=${params.contextWindowTokens} maxChars=${params.maxChars} ` +
+    `aggregateBudgetChars=${params.aggregateBudgetChars} ` +
+    `oversized=${params.oversizedReplacementCount} aggregate=${params.aggregateReplacementCount}) ` +
+    `sessionKey=${sessionLogKey}`;
+  if (params.aggregateReplacementCount <= 0) {
+    log.info(message);
+    return;
+  }
+  if (toolResultWarningDedupe.sessionRecovery.check(sessionLogKey)) {
+    log.info(message);
+    return;
+  }
+  log.warn(
+    `${message}; aggregate tool-result pressure detected; consider /compact or /new if pressure persists`,
+  );
+}
+
+async function readRuntimeTranscriptFileState(
+  scope: RuntimeTranscriptScope,
+): Promise<TranscriptFileState> {
+  const target = await resolveRuntimeTranscriptReadTarget(scope);
+  const sqliteMarker = parseSqliteSessionFileMarker(target.sessionFile);
+  if (!sqliteMarker) {
+    throw new Error("runtime transcript target is not SQLite-backed");
+  }
+  const events = await loadTranscriptEvents({
+    agentId: sqliteMarker.agentId,
+    sessionId: sqliteMarker.sessionId,
+    sessionKey: target.sessionKey,
+    storePath: sqliteMarker.storePath,
+  });
+  return createTranscriptFileStateFromPersistedEntries(events);
+}
 
 function resolveSuffixFactory(
   suffix: ToolResultTruncationOptions["suffix"],
@@ -101,11 +173,12 @@ function appendBoundedTruncationSuffix(params: {
       return finalText;
     }
     if (keptText.length === 0) {
-      return finalText.slice(0, params.maxChars);
+      return truncateUtf16Safe(finalText, params.maxChars);
     }
     const overflow = finalText.length - params.maxChars;
-    const nextKeptText = keptText.slice(0, Math.max(0, keptText.length - overflow));
-    keptText = nextKeptText.length < keptText.length ? nextKeptText : keptText.slice(0, -1);
+    const nextKeptText = sliceUtf16Safe(keptText, 0, Math.max(0, keptText.length - overflow));
+    keptText =
+      nextKeptText.length < keptText.length ? nextKeptText : sliceUtf16Safe(keptText, 0, -1);
   }
 }
 
@@ -120,8 +193,8 @@ const MIDDLE_OMISSION_MARKER =
  * which should be preserved during truncation.
  */
 function hasImportantTail(text: string): boolean {
-  // Check last ~2000 chars for error-like patterns
-  const tail = normalizeLowercaseStringOrEmpty(text.slice(-2000));
+  // Check last ~2000 chars for error-like patterns without splitting a surrogate pair.
+  const tail = normalizeLowercaseStringOrEmpty(sliceUtf16Safe(text, -2000));
   return (
     /\b(error|exception|failed|fatal|traceback|panic|stack trace|errno|exit code)\b/.test(tail) ||
     // JSON closing — if the output is JSON, the tail has closing structure
@@ -139,7 +212,7 @@ function hasImportantTail(text: string): boolean {
  * This ensures error messages and summaries at the end of tool output
  * aren't lost during truncation.
  */
-export function truncateToolResultText(
+function truncateToolResultText(
   text: string,
   maxChars: number,
   options: ToolResultTruncationOptions = {},
@@ -175,7 +248,8 @@ export function truncateToolResultText(
         tailStart = tailNewline + 1;
       }
 
-      const keptText = text.slice(0, headCut) + MIDDLE_OMISSION_MARKER + text.slice(tailStart);
+      const keptText =
+        sliceUtf16Safe(text, 0, headCut) + MIDDLE_OMISSION_MARKER + sliceUtf16Safe(text, tailStart);
       return appendBoundedTruncationSuffix({
         keptText,
         originalTextLength: text.length,
@@ -191,7 +265,7 @@ export function truncateToolResultText(
   if (lastNewline > budget * 0.8) {
     cutPoint = lastNewline;
   }
-  const keptText = text.slice(0, cutPoint);
+  const keptText = sliceUtf16Safe(text, 0, cutPoint);
   return appendBoundedTruncationSuffix({
     keptText,
     originalTextLength: text.length,
@@ -207,7 +281,7 @@ export function truncateToolResultText(
  * Uses a rough 4 chars ≈ 1 token heuristic (conservative for English text;
  * actual ratio varies by tokenizer).
  */
-export function calculateMaxToolResultChars(contextWindowTokens: number): number {
+function calculateMaxToolResultChars(contextWindowTokens: number): number {
   return calculateMaxToolResultCharsWithCap(
     contextWindowTokens,
     resolveAutoLiveToolResultMaxChars(contextWindowTokens),
@@ -248,10 +322,42 @@ export function resolveLiveToolResultMaxChars(params: {
   return calculateMaxToolResultCharsWithCap(params.contextWindowTokens, cap);
 }
 
+export function resolveLiveToolResultAggregateMaxChars(params: {
+  contextWindowTokens: number;
+  perResultMaxChars?: number;
+  cfg?: OpenClawConfig;
+  agentId?: string | null;
+}): number {
+  const perResultMaxChars = Math.max(
+    1,
+    Math.floor(
+      params.perResultMaxChars ??
+        resolveLiveToolResultMaxChars({
+          contextWindowTokens: params.contextWindowTokens,
+          cfg: params.cfg,
+          agentId: params.agentId,
+        }),
+    ),
+  );
+  const contextWindowTokens = Number.isFinite(params.contextWindowTokens)
+    ? Math.max(1, Math.floor(params.contextWindowTokens))
+    : 1;
+  // Aggregate truncation shares the 0.5 history-pressure invariant used by
+  // safeguard compaction and the mid-turn single-result guard. If this drifts,
+  // truncation can hide pressure that compaction routing should see.
+  const contextShareChars = Math.floor(
+    contextWindowTokens * 4 * AGGREGATE_TOOL_RESULT_CONTEXT_SHARE,
+  );
+  return Math.max(
+    perResultMaxChars * PROMPT_TOOL_RESULT_AGGREGATE_CAP_MULTIPLIER,
+    contextShareChars,
+  );
+}
+
 /**
  * Get the total character count of text content blocks in a tool result message.
  */
-export function getToolResultTextLength(msg: AgentMessage): number {
+function getToolResultTextLength(msg: AgentMessage): number {
   if (!msg || (msg as { role?: string }).role !== "toolResult") {
     return 0;
   }
@@ -343,6 +449,116 @@ function isToolResultTextBlock(
   );
 }
 
+type ToolResultSpillDetails = {
+  path: string;
+  truncated: boolean;
+  chars?: number;
+};
+
+function getToolResultSpillDetails(message: AgentMessage): ToolResultSpillDetails | undefined {
+  const details = (message as { details?: unknown }).details;
+  if (!details || typeof details !== "object" || Array.isArray(details)) {
+    return undefined;
+  }
+  const nested = (details as { spill?: unknown }).spill;
+  const nestedSpill =
+    nested && typeof nested === "object" && !Array.isArray(nested)
+      ? (nested as Record<string, unknown>)
+      : undefined;
+  // web_fetch owns the nested contract. Exec tools still own the flat spill fields.
+  const path = nestedSpill?.path ?? (details as { fullOutputPath?: unknown }).fullOutputPath;
+  if (typeof path !== "string" || path.length === 0) {
+    return undefined;
+  }
+  const truncated =
+    nestedSpill?.truncated === true ||
+    (details as { spillTruncated?: unknown }).spillTruncated === true;
+  const chars = nestedSpill?.chars ?? (details as { spilledChars?: unknown }).spilledChars;
+  return {
+    path,
+    truncated,
+    ...(typeof chars === "number" && Number.isFinite(chars)
+      ? { chars: Math.max(0, Math.floor(chars)) }
+      : {}),
+  };
+}
+
+function toolResultTextContainsFullOutputFooter(
+  message: AgentMessage,
+  fullOutputPath: string,
+): boolean {
+  const content = (message as { content?: unknown }).content;
+  if (!Array.isArray(content)) {
+    return false;
+  }
+  const footer = formatFullOutputFooter(fullOutputPath);
+  const escapedFooter = JSON.stringify(footer).slice(1, -1);
+  return content.some((block: unknown) => {
+    if (!isToolResultTextBlock(block)) {
+      return false;
+    }
+    return block.text.includes(footer) || block.text.includes(escapedFooter);
+  });
+}
+
+type AggregateElisionMarkers = {
+  full: string;
+  compact: string;
+  truncationSuffix: (truncatedChars: number) => string;
+};
+
+function resolveAggregateElisionMarkers(
+  message: AgentMessage,
+): AggregateElisionMarkers | undefined {
+  const spill = getToolResultSpillDetails(message);
+  if (!spill) {
+    return undefined;
+  }
+  // Details alone are not model-visible. Only preserve paths that already
+  // appeared in the original footer, so elision discloses nothing new.
+  if (!toolResultTextContainsFullOutputFooter(message, spill.path)) {
+    return undefined;
+  }
+  // Aggregate elision is a rare recovery path, not a request hot path; one
+  // existence check avoids pointing the model at already-deleted spill files.
+  if (!existsSync(spill.path)) {
+    return undefined;
+  }
+  // The path was already disclosed in the original tool footer; preserving it
+  // here adds no new disclosure and only keeps recovery possible.
+  if (spill.truncated) {
+    const count = spill.chars === undefined ? "capped content" : `first ${spill.chars} chars`;
+    return {
+      full: `[tool result elided: partial output preserved at ${spill.path} (${count}); read it if the output is needed]`,
+      compact: `[partial: ${spill.path}]`,
+      truncationSuffix: (truncatedChars) =>
+        `[... ${Math.max(1, Math.floor(truncatedChars))} chars truncated; partial output at ${spill.path}]`,
+    };
+  }
+  return {
+    full: `[tool result elided: full output preserved at ${spill.path}; read it if the output is needed]`,
+    compact: `[read ${spill.path}]`,
+    truncationSuffix: (truncatedChars) =>
+      `[... ${Math.max(1, Math.floor(truncatedChars))} chars truncated; full output at ${spill.path}]`,
+  };
+}
+
+function formatAggregateElisionText(
+  remainingTextBudget: number,
+  spillMarkers: AggregateElisionMarkers | undefined,
+): string {
+  if (remainingTextBudget <= 0) {
+    return "";
+  }
+  if (spillMarkers?.full && spillMarkers.full.length <= remainingTextBudget) {
+    return spillMarkers.full;
+  }
+  if (spillMarkers?.compact && spillMarkers.compact.length <= remainingTextBudget) {
+    return spillMarkers.compact;
+  }
+  return AGGREGATE_ELISION_MARKER.slice(0, remainingTextBudget);
+}
+
 /**
  * Truncate oversized tool results in an array of messages (in-memory).
  * Returns a new array with truncated messages.
@@ -356,7 +572,13 @@ export function truncateOversizedToolResultsInMessages(
   maxCharsOverride?: number,
   aggregateMaxCharsOverride?: number,
   projectionState?: ToolResultPromptProjectionState,
-): { messages: AgentMessage[]; truncatedCount: number } {
+): {
+  messages: AgentMessage[];
+  truncatedCount: number;
+  aggregateTruncatedCount: number;
+  aggregatePressureEngaged: boolean;
+  aggregateBudgetChars: number;
+} {
   const maxChars = Math.max(
     1,
     maxCharsOverride ?? calculateMaxToolResultChars(contextWindowTokens),
@@ -369,6 +591,7 @@ export function truncateOversizedToolResultsInMessages(
   const projectionKeys = projectionState
     ? getToolResultProjectionKeys(messages, projectionState)
     : [];
+  const hasFrozenProjectionBaseline = (projectionState?.frozen.size ?? 0) > 0;
   const branch = messages.map((message, index) => {
     const projectionKey = projectionKeys[index];
     const projectedMessage = projectionKey
@@ -392,6 +615,13 @@ export function truncateOversizedToolResultsInMessages(
         !projectionKey ||
         !projectionState?.frozen.has(projectionKey) ||
         (projectedMessage !== undefined && mergedMessage === message),
+      // Steering and follow-up messages can follow fresh tool results before dispatch.
+      // Reduce frozen history first so message position cannot make fresh output disappear.
+      deferAggregateRecovery:
+        projectionKey !== undefined &&
+        projectionState !== undefined &&
+        hasFrozenProjectionBaseline &&
+        !projectionState.frozen.has(projectionKey),
     };
   });
   const plan = buildToolResultReplacementPlan({
@@ -399,6 +629,7 @@ export function truncateOversizedToolResultsInMessages(
     maxChars,
     aggregateBudgetChars,
     minKeepChars: RECOVERY_MIN_KEEP_CHARS,
+    protectTrailingToolResults: Boolean(projectionState),
   });
   if (projectionState) {
     for (const [index] of messages.entries()) {
@@ -416,6 +647,9 @@ export function truncateOversizedToolResultsInMessages(
     return {
       messages: hasProjectedChanges ? projectedMessages : messages,
       truncatedCount: 0,
+      aggregateTruncatedCount: 0,
+      aggregatePressureEngaged: plan.aggregatePressureExceeded,
+      aggregateBudgetChars,
     };
   }
 
@@ -436,6 +670,9 @@ export function truncateOversizedToolResultsInMessages(
   return {
     messages: replacedBranch.map((entry) => entry.message as AgentMessage),
     truncatedCount: replacementIds.size,
+    aggregateTruncatedCount: plan.aggregateReplacementCount,
+    aggregatePressureEngaged: plan.aggregatePressureExceeded,
+    aggregateBudgetChars,
   };
 }
 
@@ -447,8 +684,10 @@ function calculateRecoveryAggregateToolResultChars(
   return Math.max(
     1,
     aggregateMaxCharsOverride ??
-      maxCharsOverride ??
-      calculateMaxToolResultChars(contextWindowTokens),
+      resolveLiveToolResultAggregateMaxChars({
+        contextWindowTokens,
+        perResultMaxChars: maxCharsOverride ?? calculateMaxToolResultChars(contextWindowTokens),
+      }),
   );
 }
 
@@ -468,28 +707,13 @@ type ToolResultBranchEntry = {
   type: string;
   message?: AgentMessage;
   aggregateEligible?: boolean;
+  deferAggregateRecovery?: boolean;
 };
 
 type ToolResultReplacement = {
   entryId: string;
   message: AgentMessage;
 };
-
-export type ToolResultPromptProjectionState = {
-  replacements: Map<string, AgentMessage>;
-  frozen: Set<string>;
-  ambiguousBaseKeys: Set<string>;
-  sourceTextByKey: Map<string, string[]>;
-};
-
-export function createToolResultPromptProjectionState(): ToolResultPromptProjectionState {
-  return {
-    replacements: new Map<string, AgentMessage>(),
-    frozen: new Set<string>(),
-    ambiguousBaseKeys: new Set<string>(),
-    sourceTextByKey: new Map<string, string[]>(),
-  };
-}
 
 function getToolResultProjectionBaseKey(message: AgentMessage): string | undefined {
   if (message.role !== "toolResult") {
@@ -521,16 +745,27 @@ function getToolResultProjectionKeys(
     }
   }
   const occurrences = new Map<string, number>();
-  return baseKeys.map((baseKey) => {
-    if (!baseKey) {
+  return baseKeys.map((baseKey, index) => {
+    if (baseKey && !projectionState.ambiguousBaseKeys.has(baseKey)) {
+      return baseKey;
+    }
+    const message = messages[index];
+    if (!message || message.role !== "toolResult") {
       return undefined;
     }
-    if (projectionState.ambiguousBaseKeys.has(baseKey)) {
-      return undefined;
-    }
-    const occurrence = occurrences.get(baseKey) ?? 0;
-    occurrences.set(baseKey, occurrence + 1);
-    return `${baseKey}:${occurrence}`;
+    // Ambiguous/missing tool ids still need a stable frozen identity; otherwise
+    // each request rewrites their prompt-cache tail projection (#99495).
+    const messageId = (message as { id?: unknown }).id;
+    const sourceIdentity =
+      typeof messageId === "string" && messageId.length > 0
+        ? `id:${messageId}`
+        : `text:${createHash("sha256")
+            .update(JSON.stringify(getToolResultTextBlocks(message)))
+            .digest("base64url")}`;
+    const fallbackBase = `fallback:${baseKey ?? "tool"}:${sourceIdentity}`;
+    const occurrence = occurrences.get(fallbackBase) ?? 0;
+    occurrences.set(fallbackBase, occurrence + 1);
+    return `${fallbackBase}:${occurrence}`;
   });
 }
 
@@ -594,17 +829,28 @@ function getToolResultTextBlocks(message: AgentMessage): string[] {
 
 function buildAggregateToolResultReplacements(params: {
   branch: ToolResultBranchEntry[];
+  spillSourceBranch?: ToolResultBranchEntry[];
   aggregateBudgetChars: number;
   minKeepChars?: number;
-}): ToolResultReplacement[] {
+  protectTrailingToolResults?: boolean;
+}): { replacements: ToolResultReplacement[]; pressureExceeded: boolean } {
   const minKeepChars = params.minKeepChars ?? MIN_KEEP_CHARS;
+  const protectedEntryIds = params.protectTrailingToolResults
+    ? getTrailingToolResultEntryIds(params.branch)
+    : new Set<string>();
   const candidates = params.branch
     .map((entry, index) => ({ entry, index }))
     .filter(
       (
         item,
       ): item is {
-        entry: { id: string; type: string; message: AgentMessage; aggregateEligible?: boolean };
+        entry: {
+          id: string;
+          type: string;
+          message: AgentMessage;
+          aggregateEligible?: boolean;
+          deferAggregateRecovery?: boolean;
+        };
         index: number;
       } =>
         item.entry.type === "message" &&
@@ -615,13 +861,16 @@ function buildAggregateToolResultReplacements(params: {
       index: item.index,
       entryId: item.entry.id,
       message: item.entry.message,
+      spillSourceMessage: params.spillSourceBranch?.[item.index]?.message ?? item.entry.message,
       textLength: getToolResultTextLength(item.entry.message),
       aggregateEligible: item.entry.aggregateEligible !== false,
+      deferredByFreshProjection: item.entry.deferAggregateRecovery === true,
+      protectedByTrailingBatch: protectedEntryIds.has(item.entry.id),
     }))
     .filter((item) => item.textLength > 0);
 
   if (candidates.length < 2) {
-    return [];
+    return { replacements: [], pressureExceeded: false };
   }
 
   const suffixFactory =
@@ -630,63 +879,170 @@ function buildAggregateToolResultReplacements(params: {
       ? COMPACT_RECOVERY_SUFFIX
       : DEFAULT_SUFFIX;
   const minTruncatedTextChars = minKeepChars + suffixFactory(1).length;
+  const useBudgetFloor = params.aggregateBudgetChars >= MIN_KEEP_CHARS;
+
+  if (useBudgetFloor) {
+    const trailingEntryIds = getTrailingToolResultEntryIds(params.branch);
+
+    const floorMinKeepChars = Math.max(minKeepChars, MIN_KEEP_CHARS);
+    const floorMinTruncatedTextChars = floorMinKeepChars + suffixFactory(1).length;
+
+    // Calculate maximum possible reduction we can safely achieve
+    const maxPossibleReduction = candidates.reduce((sum, item) => {
+      const isTrailing = trailingEntryIds.has(item.entryId);
+      const useFloor = item.aggregateEligible && isTrailing;
+      const limit = useFloor ? floorMinTruncatedTextChars : 0;
+      return sum + Math.max(0, item.textLength - limit);
+    }, 0);
+
+    const totalChars = candidates.reduce((sum, item) => sum + item.textLength, 0);
+    if (totalChars <= params.aggregateBudgetChars) {
+      return { replacements: [], pressureExceeded: false };
+    }
+
+    let remainingReduction = Math.min(
+      totalChars - params.aggregateBudgetChars,
+      maxPossibleReduction,
+    );
+    if (remainingReduction <= 0) {
+      return { replacements: [], pressureExceeded: true };
+    }
+
+    const replacements: Array<{ entryId: string; message: AgentMessage }> = [];
+    const aggregateRecoveryCandidates = candidates
+      .filter((item) => !item.deferredByFreshProjection && !item.protectedByTrailingBatch)
+      .toSorted((a, b) => {
+        if (a.index !== b.index) {
+          return a.index - b.index;
+        }
+        return b.textLength - a.textLength;
+      });
+    const recoveryCandidates = [
+      ...aggregateRecoveryCandidates.filter((item) => item.aggregateEligible),
+      // Start from frozen projections before touching deferred fresh results. Reusing their
+      // projected text keeps this shrink-only and preserves prompt-cache stability.
+      ...aggregateRecoveryCandidates.filter((item) => !item.aggregateEligible),
+      ...candidates.filter(
+        (item) => item.deferredByFreshProjection && !item.protectedByTrailingBatch,
+      ),
+    ];
+
+    // Spend aggregate reduction on older entries first so fresh tool output stays intact.
+    for (const candidate of recoveryCandidates) {
+      if (remainingReduction <= 0) {
+        break;
+      }
+      const isTrailing = trailingEntryIds.has(candidate.entryId);
+      const useFloor = candidate.aggregateEligible && isTrailing;
+      const limitFloor = useFloor ? floorMinTruncatedTextChars : minTruncatedTextChars;
+      const keepFloor = useFloor ? floorMinKeepChars : minKeepChars;
+
+      const reducibleChars = Math.max(0, candidate.textLength - limitFloor);
+      if (reducibleChars <= 0) {
+        continue;
+      }
+
+      const requestedReduction = Math.min(reducibleChars, remainingReduction);
+      const targetChars = Math.max(limitFloor, candidate.textLength - requestedReduction);
+      const spillMarkers = resolveAggregateElisionMarkers(candidate.spillSourceMessage);
+      const candidateSuffixFactory = spillMarkers?.truncationSuffix ?? suffixFactory;
+      const candidateTargetChars = Math.max(targetChars, candidateSuffixFactory(1).length);
+      const truncatedMessage = truncateToolResultMessage(candidate.message, candidateTargetChars, {
+        minKeepChars: keepFloor,
+        suffix: candidateSuffixFactory,
+      });
+      const newLength = getToolResultTextLength(truncatedMessage);
+      const actualReduction = Math.max(0, candidate.textLength - newLength);
+      if (actualReduction <= 0) {
+        continue;
+      }
+
+      replacements.push({ entryId: candidate.entryId, message: truncatedMessage });
+      remainingReduction -= actualReduction;
+    }
+
+    if (remainingReduction > 0) {
+      for (const candidate of recoveryCandidates) {
+        if (remainingReduction <= 0) {
+          break;
+        }
+        const isTrailing = trailingEntryIds.has(candidate.entryId);
+        const useFloor = candidate.aggregateEligible && isTrailing;
+        const spillMarkers = resolveAggregateElisionMarkers(candidate.spillSourceMessage);
+        if (useFloor && params.aggregateBudgetChars >= MIN_KEEP_CHARS && !spillMarkers) {
+          continue; // Never clear trailing eligible results without spill markers to ""
+        }
+        const existingReplacement = replacements.find(
+          (replacement) => replacement.entryId === candidate.entryId,
+        );
+        const baseMessage = existingReplacement?.message ?? candidate.message;
+        const baseTextLength = getToolResultTextLength(baseMessage);
+        const targetTextChars = Math.max(0, baseTextLength - remainingReduction);
+        const emptyMessage = clearToolResultText(candidate.message, targetTextChars, spillMarkers);
+        const emptyLength = getToolResultTextLength(emptyMessage);
+        const actualReduction = Math.max(0, baseTextLength - emptyLength);
+        if (actualReduction <= 0 && !spillMarkers) {
+          continue;
+        }
+        const replacement = { entryId: candidate.entryId, message: emptyMessage };
+        const existingIndex = replacements.findIndex(
+          (existing) => existing.entryId === candidate.entryId,
+        );
+        if (existingIndex >= 0) {
+          replacements[existingIndex] = replacement;
+        } else {
+          replacements.push(replacement);
+        }
+        remainingReduction -= actualReduction;
+      }
+    }
+
+    return { replacements, pressureExceeded: true };
+  }
 
   const totalChars = candidates.reduce((sum, item) => sum + item.textLength, 0);
   if (totalChars <= params.aggregateBudgetChars) {
-    return [];
+    return { replacements: [], pressureExceeded: false };
   }
 
-  const eligibleCandidates = candidates.filter((item) => item.aggregateEligible);
-  const ineligibleCandidates = candidates.filter((item) => !item.aggregateEligible);
-  const ineligibleChars = ineligibleCandidates.reduce((sum, item) => sum + item.textLength, 0);
-
-  if (ineligibleChars >= params.aggregateBudgetChars) {
-    return [];
-  }
-
-  const eligibleTotalChars = eligibleCandidates.reduce((sum, item) => sum + item.textLength, 0);
-
-  const floorMinKeepChars =
-    params.aggregateBudgetChars >= MIN_KEEP_CHARS
-      ? Math.max(minKeepChars, MIN_KEEP_CHARS)
-      : minKeepChars;
-  const floorMinTruncatedTextChars = floorMinKeepChars + suffixFactory(1).length;
-
-  const eligibleBudget = Math.max(
-    eligibleCandidates.length * floorMinTruncatedTextChars,
-    params.aggregateBudgetChars - ineligibleChars,
-  );
-  let remainingReduction = eligibleTotalChars - eligibleBudget;
-  if (remainingReduction <= 0) {
-    return [];
-  }
+  let remainingReduction = totalChars - params.aggregateBudgetChars;
   const replacements: Array<{ entryId: string; message: AgentMessage }> = [];
-
-  // Spend aggregate reduction on older entries first so fresh tool output stays intact.
-  for (const candidate of candidates
-    .filter((item) => item.aggregateEligible)
+  const aggregateRecoveryCandidates = candidates
+    .filter((item) => !item.deferredByFreshProjection && !item.protectedByTrailingBatch)
     .toSorted((a, b) => {
       if (a.index !== b.index) {
         return a.index - b.index;
       }
       return b.textLength - a.textLength;
-    })) {
+    });
+  const recoveryCandidates = [
+    ...aggregateRecoveryCandidates.filter((item) => item.aggregateEligible),
+    // Start from frozen projections before touching deferred fresh results. Reusing their
+    // projected text keeps this shrink-only and preserves prompt-cache stability.
+    ...aggregateRecoveryCandidates.filter((item) => !item.aggregateEligible),
+    ...candidates.filter(
+      (item) => item.deferredByFreshProjection && !item.protectedByTrailingBatch,
+    ),
+  ];
+
+  // Spend aggregate reduction on older entries first so fresh tool output stays intact.
+  for (const candidate of recoveryCandidates) {
     if (remainingReduction <= 0) {
       break;
     }
-    const reducibleChars = Math.max(0, candidate.textLength - floorMinTruncatedTextChars);
+    const reducibleChars = Math.max(0, candidate.textLength - minTruncatedTextChars);
     if (reducibleChars <= 0) {
       continue;
     }
 
     const requestedReduction = Math.min(reducibleChars, remainingReduction);
-    const targetChars = Math.max(
-      floorMinTruncatedTextChars,
-      candidate.textLength - requestedReduction,
-    );
-    const truncatedMessage = truncateToolResultMessage(candidate.message, targetChars, {
-      minKeepChars: floorMinKeepChars,
-      suffix: suffixFactory,
+    const targetChars = Math.max(minTruncatedTextChars, candidate.textLength - requestedReduction);
+    const spillMarkers = resolveAggregateElisionMarkers(candidate.spillSourceMessage);
+    const candidateSuffixFactory = spillMarkers?.truncationSuffix ?? suffixFactory;
+    const candidateTargetChars = Math.max(targetChars, candidateSuffixFactory(1).length);
+    const truncatedMessage = truncateToolResultMessage(candidate.message, candidateTargetChars, {
+      minKeepChars,
+      suffix: candidateSuffixFactory,
     });
     const newLength = getToolResultTextLength(truncatedMessage);
     const actualReduction = Math.max(0, candidate.textLength - newLength);
@@ -699,19 +1055,21 @@ function buildAggregateToolResultReplacements(params: {
   }
 
   if (remainingReduction > 0) {
-    for (const candidate of candidates.filter((item) => item.aggregateEligible)) {
+    for (const candidate of recoveryCandidates) {
       if (remainingReduction <= 0) {
         break;
       }
       const existingReplacement = replacements.find(
         (replacement) => replacement.entryId === candidate.entryId,
       );
-      const emptyMessage = clearToolResultText(existingReplacement?.message ?? candidate.message);
-      const actualReduction = Math.max(
-        0,
-        candidate.textLength - getToolResultTextLength(emptyMessage),
-      );
-      if (actualReduction <= 0) {
+      const baseMessage = existingReplacement?.message ?? candidate.message;
+      const baseTextLength = getToolResultTextLength(baseMessage);
+      const targetTextChars = Math.max(0, baseTextLength - remainingReduction);
+      const spillMarkers = resolveAggregateElisionMarkers(candidate.spillSourceMessage);
+      const emptyMessage = clearToolResultText(candidate.message, targetTextChars, spillMarkers);
+      const emptyLength = getToolResultTextLength(emptyMessage);
+      const actualReduction = Math.max(0, baseTextLength - emptyLength);
+      if (actualReduction <= 0 && !spillMarkers) {
         continue;
       }
       const replacement = { entryId: candidate.entryId, message: emptyMessage };
@@ -727,21 +1085,58 @@ function buildAggregateToolResultReplacements(params: {
     }
   }
 
-  return replacements;
+  return { replacements, pressureExceeded: true };
 }
 
-function clearToolResultText(message: AgentMessage): AgentMessage {
+function getTrailingToolResultEntryIds(branch: ToolResultBranchEntry[]): Set<string> {
+  const ids = new Set<string>();
+  let sawMessage = false;
+  for (let index = branch.length - 1; index >= 0; index--) {
+    const entry = branch[index];
+    if (entry?.type !== "message" || !entry.message) {
+      if (!sawMessage) {
+        continue;
+      }
+      break;
+    }
+    sawMessage = true;
+    if ((entry.message as { role?: string }).role !== "toolResult") {
+      break;
+    }
+    ids.add(entry.id);
+  }
+  return ids;
+}
+
+function clearToolResultText(
+  message: AgentMessage,
+  maxTextChars = Number.POSITIVE_INFINITY,
+  resolvedSpillMarkers?: AggregateElisionMarkers,
+): AgentMessage {
   const content = (message as { content?: unknown }).content;
   if (!Array.isArray(content)) {
     return message;
   }
+  let remainingTextBudget = Math.max(0, Math.floor(maxTextChars));
+  const spillMarkers = resolvedSpillMarkers ?? resolveAggregateElisionMarkers(message);
+  if (spillMarkers) {
+    // The pointer is what makes elision recoverable. ~130 chars per entry is
+    // negligible against the 64k+ aggregate floor, and accounting uses actual lengths.
+    remainingTextBudget = Math.max(remainingTextBudget, spillMarkers.compact.length);
+  }
   return {
     ...message,
-    content: content.map((block) =>
-      block && typeof block === "object" && (block as { type?: unknown }).type === "text"
-        ? Object.assign({}, block, { text: "" })
-        : block,
-    ),
+    content: content.map((block) => {
+      if (!isToolResultTextBlock(block)) {
+        return block;
+      }
+      const replacementText = formatAggregateElisionText(remainingTextBudget, spillMarkers);
+      remainingTextBudget = Math.max(0, remainingTextBudget - replacementText.length);
+      return Object.assign({}, block, {
+        text: replacementText,
+        ...(typeof block.content === "string" ? { content: replacementText } : {}),
+      });
+    }),
   } as AgentMessage;
 }
 
@@ -749,6 +1144,7 @@ function buildOversizedToolResultReplacements(params: {
   branch: ToolResultBranchEntry[];
   maxChars: number;
   minKeepChars?: number;
+  protectedEntryIds?: Set<string>;
 }): ToolResultReplacement[] {
   const minKeepChars = params.minKeepChars ?? MIN_KEEP_CHARS;
   const replacements: ToolResultReplacement[] = [];
@@ -764,10 +1160,17 @@ function buildOversizedToolResultReplacements(params: {
     if (getToolResultTextLength(msg) <= params.maxChars) {
       continue;
     }
+    const replacementMinKeepChars = params.protectedEntryIds?.has(entry.id)
+      ? Math.max(minKeepChars, MIN_KEEP_CHARS)
+      : minKeepChars;
+    const spillMarkers = resolveAggregateElisionMarkers(msg);
+    const suffixFactory = spillMarkers?.truncationSuffix;
+    const maxChars = Math.max(params.maxChars, suffixFactory?.(1).length ?? 0);
     replacements.push({
       entryId: entry.id,
-      message: truncateToolResultMessage(msg, params.maxChars, {
-        minKeepChars,
+      message: truncateToolResultMessage(msg, maxChars, {
+        minKeepChars: replacementMinKeepChars,
+        ...(suffixFactory ? { suffix: suffixFactory } : {}),
       }),
     });
   }
@@ -826,18 +1229,24 @@ function buildToolResultReplacementPlan(params: {
   maxChars: number;
   aggregateBudgetChars: number;
   minKeepChars?: number;
+  protectTrailingToolResults?: boolean;
 }): {
   replacements: ToolResultReplacement[];
   oversizedReplacementCount: number;
   aggregateReplacementCount: number;
+  aggregatePressureExceeded: boolean;
   oversizedReducibleChars: number;
   aggregateReducibleChars: number;
 } {
   const minKeepChars = params.minKeepChars ?? MIN_KEEP_CHARS;
+  const protectedEntryIds = params.protectTrailingToolResults
+    ? getTrailingToolResultEntryIds(params.branch)
+    : undefined;
   const oversizedReplacements = buildOversizedToolResultReplacements({
     branch: params.branch,
     maxChars: params.maxChars,
     minKeepChars,
+    protectedEntryIds,
   });
   const oversizedReducibleChars = calculateReplacementReduction(
     params.branch,
@@ -847,11 +1256,14 @@ function buildToolResultReplacementPlan(params: {
     params.branch,
     oversizedReplacements,
   );
-  const aggregateReplacements = buildAggregateToolResultReplacements({
+  const aggregatePlan = buildAggregateToolResultReplacements({
     branch: oversizedTrimmedBranch,
+    spillSourceBranch: params.branch,
     aggregateBudgetChars: params.aggregateBudgetChars,
     minKeepChars,
+    protectTrailingToolResults: params.protectTrailingToolResults,
   });
+  const aggregateReplacements = aggregatePlan.replacements;
   const aggregateReducibleChars = calculateReplacementReduction(
     oversizedTrimmedBranch,
     aggregateReplacements,
@@ -861,10 +1273,45 @@ function buildToolResultReplacementPlan(params: {
     replacements: [...oversizedReplacements, ...aggregateReplacements],
     oversizedReplacementCount: oversizedReplacements.length,
     aggregateReplacementCount: aggregateReplacements.length,
+    aggregatePressureExceeded: aggregatePlan.pressureExceeded,
     oversizedReducibleChars,
     aggregateReducibleChars,
   };
 }
+
+function buildRecoveryToolResultReplacementPlan(params: {
+  branch: ToolResultBranchEntry[];
+  contextWindowTokens: number;
+  maxCharsOverride?: number;
+  aggregateMaxCharsOverride?: number;
+  protectTrailingToolResults?: boolean;
+}): {
+  maxChars: number;
+  aggregateBudgetChars: number;
+  plan: ReturnType<typeof buildToolResultReplacementPlan>;
+} {
+  const maxChars = Math.max(
+    1,
+    params.maxCharsOverride ?? calculateMaxToolResultChars(params.contextWindowTokens),
+  );
+  const aggregateBudgetChars = calculateRecoveryAggregateToolResultChars(
+    params.contextWindowTokens,
+    maxChars,
+    params.aggregateMaxCharsOverride,
+  );
+  return {
+    maxChars,
+    aggregateBudgetChars,
+    plan: buildToolResultReplacementPlan({
+      branch: params.branch,
+      maxChars,
+      aggregateBudgetChars,
+      minKeepChars: RECOVERY_MIN_KEEP_CHARS,
+      protectTrailingToolResults: params.protectTrailingToolResults,
+    }),
+  };
+}
+
 export function estimateToolResultReductionPotential(params: {
   messages: AgentMessage[];
   contextWindowTokens: number;
@@ -925,32 +1372,25 @@ function truncateOversizedToolResultsInExistingSessionManager(params: {
   contextWindowTokens: number;
   maxCharsOverride?: number;
   aggregateMaxCharsOverride?: number;
+  protectTrailingToolResults?: boolean;
   sessionFile?: string;
   sessionId?: string;
   sessionKey?: string;
   agentId?: string;
 }): { truncated: boolean; truncatedCount: number; reason?: string } {
   const { sessionManager, contextWindowTokens } = params;
-  const maxChars = Math.max(
-    1,
-    params.maxCharsOverride ?? calculateMaxToolResultChars(contextWindowTokens),
-  );
-  const aggregateBudgetChars = calculateRecoveryAggregateToolResultChars(
-    contextWindowTokens,
-    maxChars,
-    params.aggregateMaxCharsOverride,
-  );
   const branch = sessionManager.getBranch() as ToolResultBranchEntry[];
 
   if (branch.length === 0) {
     return { truncated: false, truncatedCount: 0, reason: "empty session" };
   }
 
-  const plan = buildToolResultReplacementPlan({
+  const { maxChars, aggregateBudgetChars, plan } = buildRecoveryToolResultReplacementPlan({
     branch,
-    maxChars,
-    aggregateBudgetChars,
-    minKeepChars: RECOVERY_MIN_KEEP_CHARS,
+    contextWindowTokens,
+    maxCharsOverride: params.maxCharsOverride,
+    aggregateMaxCharsOverride: params.aggregateMaxCharsOverride,
+    protectTrailingToolResults: params.protectTrailingToolResults,
   });
   if (plan.replacements.length === 0) {
     return {
@@ -980,12 +1420,16 @@ function truncateOversizedToolResultsInExistingSessionManager(params: {
     });
   }
 
-  log.info(
-    `[tool-result-truncation] Truncated ${rewriteResult.rewrittenEntries} tool result(s) in session ` +
-      `(contextWindow=${contextWindowTokens} maxChars=${maxChars} aggregateBudgetChars=${aggregateBudgetChars} ` +
-      `oversized=${plan.oversizedReplacementCount} aggregate=${plan.aggregateReplacementCount}) ` +
-      `sessionKey=${params.sessionKey ?? params.sessionId ?? "unknown"}`,
-  );
+  logToolResultSessionTruncation({
+    rewrittenEntries: rewriteResult.rewrittenEntries,
+    contextWindowTokens,
+    maxChars,
+    aggregateBudgetChars,
+    oversizedReplacementCount: plan.oversizedReplacementCount,
+    aggregateReplacementCount: plan.aggregateReplacementCount,
+    sessionKey: params.sessionKey,
+    sessionId: params.sessionId,
+  });
 
   return {
     truncated: rewriteResult.changed,
@@ -1000,32 +1444,25 @@ async function truncateOversizedToolResultsInTranscriptState(params: {
   contextWindowTokens: number;
   maxCharsOverride?: number;
   aggregateMaxCharsOverride?: number;
+  protectTrailingToolResults?: boolean;
   sessionId?: string;
   sessionKey?: string;
   agentId?: string;
   config?: SessionWriteLockAcquireTimeoutConfig;
 }): Promise<{ truncated: boolean; truncatedCount: number; reason?: string }> {
   const { state, contextWindowTokens } = params;
-  const maxChars = Math.max(
-    1,
-    params.maxCharsOverride ?? calculateMaxToolResultChars(contextWindowTokens),
-  );
-  const aggregateBudgetChars = calculateRecoveryAggregateToolResultChars(
-    contextWindowTokens,
-    maxChars,
-    params.aggregateMaxCharsOverride,
-  );
   const branch = state.getBranch() as ToolResultBranchEntry[];
 
   if (branch.length === 0) {
     return { truncated: false, truncatedCount: 0, reason: "empty session" };
   }
 
-  const plan = buildToolResultReplacementPlan({
+  const { maxChars, aggregateBudgetChars, plan } = buildRecoveryToolResultReplacementPlan({
     branch,
-    maxChars,
-    aggregateBudgetChars,
-    minKeepChars: RECOVERY_MIN_KEEP_CHARS,
+    contextWindowTokens,
+    maxCharsOverride: params.maxCharsOverride,
+    aggregateMaxCharsOverride: params.aggregateMaxCharsOverride,
+    protectTrailingToolResults: params.protectTrailingToolResults,
   });
   if (plan.replacements.length === 0) {
     return {
@@ -1060,12 +1497,16 @@ async function truncateOversizedToolResultsInTranscriptState(params: {
     });
   }
 
-  log.info(
-    `[tool-result-truncation] Truncated ${rewriteResult.rewrittenEntries} tool result(s) in session ` +
-      `(contextWindow=${contextWindowTokens} maxChars=${maxChars} aggregateBudgetChars=${aggregateBudgetChars} ` +
-      `oversized=${plan.oversizedReplacementCount} aggregate=${plan.aggregateReplacementCount}) ` +
-      `sessionKey=${params.sessionKey ?? params.sessionId ?? "unknown"}`,
-  );
+  logToolResultSessionTruncation({
+    rewrittenEntries: rewriteResult.rewrittenEntries,
+    contextWindowTokens,
+    maxChars,
+    aggregateBudgetChars,
+    oversizedReplacementCount: plan.oversizedReplacementCount,
+    aggregateReplacementCount: plan.aggregateReplacementCount,
+    sessionKey: params.sessionKey,
+    sessionId: params.sessionId,
+  });
 
   return {
     truncated: rewriteResult.changed,
@@ -1079,6 +1520,7 @@ export function truncateOversizedToolResultsInSessionManager(params: {
   contextWindowTokens: number;
   maxCharsOverride?: number;
   aggregateMaxCharsOverride?: number;
+  protectTrailingToolResults?: boolean;
   sessionFile?: string;
   sessionId?: string;
   sessionKey?: string;
@@ -1094,13 +1536,110 @@ export function truncateOversizedToolResultsInSessionManager(params: {
 }
 
 /**
+ * Truncates oversized tool results in the active runtime transcript.
+ */
+async function truncateOversizedToolResultsInRuntimeTranscript(params: {
+  scope: RuntimeTranscriptScope;
+  contextWindowTokens: number;
+  maxCharsOverride?: number;
+  aggregateMaxCharsOverride?: number;
+  protectTrailingToolResults?: boolean;
+  config?: SessionWriteLockAcquireTimeoutConfig;
+}): Promise<{ truncated: boolean; truncatedCount: number; reason?: string }> {
+  try {
+    const state = await readRuntimeTranscriptFileState(params.scope);
+    const { contextWindowTokens } = params;
+    const branch = state.getBranch() as ToolResultBranchEntry[];
+
+    if (branch.length === 0) {
+      return { truncated: false, truncatedCount: 0, reason: "empty session" };
+    }
+
+    const { maxChars, aggregateBudgetChars, plan } = buildRecoveryToolResultReplacementPlan({
+      branch,
+      contextWindowTokens,
+      maxCharsOverride: params.maxCharsOverride,
+      aggregateMaxCharsOverride: params.aggregateMaxCharsOverride,
+      protectTrailingToolResults: params.protectTrailingToolResults,
+    });
+    if (plan.replacements.length === 0) {
+      return {
+        truncated: false,
+        truncatedCount: 0,
+        reason: "no oversized or aggregate tool results",
+      };
+    }
+
+    const rewriteResult = await rewriteTranscriptEntriesInRuntimeTranscript({
+      scope: params.scope,
+      request: { replacements: plan.replacements },
+      config: params.config,
+    });
+
+    logToolResultSessionTruncation({
+      rewrittenEntries: rewriteResult.rewrittenEntries,
+      contextWindowTokens,
+      maxChars,
+      aggregateBudgetChars,
+      oversizedReplacementCount: plan.oversizedReplacementCount,
+      aggregateReplacementCount: plan.aggregateReplacementCount,
+      sessionKey: params.scope.sessionKey,
+      sessionId: params.scope.sessionId,
+    });
+
+    return {
+      truncated: rewriteResult.changed,
+      truncatedCount: rewriteResult.rewrittenEntries,
+      reason: rewriteResult.reason,
+    };
+  } catch (err) {
+    const errMsg = formatErrorMessage(err);
+    log.warn(`[tool-result-truncation] Failed to truncate: ${errMsg}`);
+    return { truncated: false, truncatedCount: 0, reason: errMsg };
+  }
+}
+
+/** Truncates oversized tool results in either a SQLite runtime target or explicit file target. */
+export async function truncateOversizedToolResultsInActiveTarget(params: {
+  scope: RuntimeTranscriptScope;
+  contextWindowTokens: number;
+  maxCharsOverride?: number;
+  aggregateMaxCharsOverride?: number;
+  protectTrailingToolResults?: boolean;
+  config?: OpenClawConfig;
+}): Promise<{ truncated: boolean; truncatedCount: number; reason?: string }> {
+  if (parseSqliteSessionFileMarker(params.scope.sessionFile)) {
+    return await truncateOversizedToolResultsInRuntimeTranscript(params);
+  }
+  if (!params.scope.sessionFile) {
+    return {
+      truncated: false,
+      truncatedCount: 0,
+      reason: "no session file",
+    };
+  }
+  return await truncateOversizedToolResultsInSession({
+    sessionFile: params.scope.sessionFile,
+    contextWindowTokens: params.contextWindowTokens,
+    maxCharsOverride: params.maxCharsOverride,
+    aggregateMaxCharsOverride: params.aggregateMaxCharsOverride,
+    protectTrailingToolResults: params.protectTrailingToolResults,
+    sessionId: params.scope.sessionId,
+    sessionKey: params.scope.sessionKey,
+    agentId: params.scope.agentId,
+    config: params.config,
+  });
+}
+
+/**
  * Truncates a named transcript file artifact.
  */
-export async function truncateOversizedToolResultsInSession(params: {
+async function truncateOversizedToolResultsInSession(params: {
   sessionFile: string;
   contextWindowTokens: number;
   maxCharsOverride?: number;
   aggregateMaxCharsOverride?: number;
+  protectTrailingToolResults?: boolean;
   sessionId?: string;
   sessionKey?: string;
   agentId?: string;
@@ -1120,6 +1659,7 @@ export async function truncateOversizedToolResultsInSession(params: {
       contextWindowTokens,
       maxCharsOverride: params.maxCharsOverride,
       aggregateMaxCharsOverride: params.aggregateMaxCharsOverride,
+      protectTrailingToolResults: params.protectTrailingToolResults,
       sessionFile,
       sessionId: params.sessionId,
       sessionKey: params.sessionKey,
@@ -1142,3 +1682,4 @@ export function sessionLikelyHasOversizedToolResults(params: {
   const estimate = estimateToolResultReductionPotential(params);
   return estimate.oversizedCount > 0 || estimate.aggregateReducibleChars > 0;
 }
+/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/agents/embedded-agent-runner/tool-result-truncation.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.ts
@@ -835,6 +835,7 @@ function buildAggregateToolResultReplacements(params: {
   protectTrailingToolResults?: boolean;
 }): { replacements: ToolResultReplacement[]; pressureExceeded: boolean } {
   const minKeepChars = params.minKeepChars ?? MIN_KEEP_CHARS;
+  const useBudgetFloor = params.aggregateBudgetChars >= MIN_KEEP_CHARS;
   const protectedEntryIds = params.protectTrailingToolResults
     ? getTrailingToolResultEntryIds(params.branch)
     : new Set<string>();
@@ -879,7 +880,6 @@ function buildAggregateToolResultReplacements(params: {
       ? COMPACT_RECOVERY_SUFFIX
       : DEFAULT_SUFFIX;
   const minTruncatedTextChars = minKeepChars + suffixFactory(1).length;
-  const useBudgetFloor = params.aggregateBudgetChars >= MIN_KEEP_CHARS;
 
   if (useBudgetFloor) {
     const trailingEntryIds = getTrailingToolResultEntryIds(params.branch);
@@ -1101,6 +1101,9 @@ function getTrailingToolResultEntryIds(branch: ToolResultBranchEntry[]): Set<str
     }
     sawMessage = true;
     if ((entry.message as { role?: string }).role !== "toolResult") {
+      break;
+    }
+    if (entry.aggregateEligible === false) {
       break;
     }
     ids.add(entry.id);


### PR DESCRIPTION
### Problem
In long-running agent sessions, all tool execution outputs (such as `exec`, `read`, and `write`) suddenly start returning empty strings (`""`) to the LLM. While model reasoning and session status updates remain operational, the agent becomes dysfunctional because it cannot see any tool outputs.

### Cause
The bug occurs in `buildAggregateToolResultReplacements` inside `src/agents/embedded-agent-runner/tool-result-truncation.ts`.
1. The function checks if the total length of all tool results exceeds `aggregateBudgetChars` (e.g. 256,000 characters).
2. As the history grows, frozen messages (`aggregateEligible: false`) alone eventually exceed `params.aggregateBudgetChars`.
3. This makes `remainingReduction` larger than the total length of the new, eligible tool results of the current turn.
4. In the fallback loop, the function completely clears the new eligible tool results to empty strings (`clearToolResultText`) to satisfy the impossible reduction target.
5. In recovery mode (`minKeepChars: 0`), the minimum target length `minTruncatedTextChars` resolves to `69` (only the suffix notice). When the remaining budget is small or negative, new eligible tool results are truncated down to `69` characters (0 actual content + suffix), which is practically empty.

### Fix
1. **Skip aggregate truncation if history exceeds budget**: If the ineligible (frozen) history alone already exceeds the budget, skip aggregate truncation for new tool results entirely (retaining their full output, capped only by individual limits).
2. **Enforce minimum floor**: Otherwise, enforce a conditional minimum floor `floorMinKeepChars` (at least `MIN_KEEP_CHARS = 2000` characters if the aggregate budget itself is not tiny). This guarantees that new tool results are never truncated to only the suffix when the remaining budget is small or negative.
3. **Correct contiguous frozen result handling**: Corrected `getTrailingToolResultEntryIds` to break when encountering a frozen tool result (`aggregateEligible === false`). This ensures contiguous historical/frozen entries are not treated as trailing/fresh and are correctly targeted for aggregate recovery.

### Verification & Runtime Proof
Ran all 70 unit tests in `tool-result-truncation.test.ts` successfully:

```
 RUN  v4.1.10 /Users/fangqingyuan/Projects/openclaw

 ✓  agents-embedded-agent  ../../src/agents/embedded-agent-runner/tool-result-truncation.test.ts (70 tests) 175ms

 Test Files  1 passed (1)
      Tests  70 passed (70)
   Start at  07:32:53
   Duration  1.59s (transform 634ms, setup 110ms, import 1.22s, tests 175ms, environment 0ms)
```

Additionally, verified that:
1. Frozen projections remain stable and are only shrunk under aggregate pressure when necessary.
2. Contiguous frozen/historical tool results are correctly handled and do not prevent older history from being reduced.
3. Fresh trailing tool results are preserved intact when they are within the aggregate budget.
