### PR TITLE
fix(gateway): prevent cross-client system-agent session takeover

### DIFF
--- a/src/gateway/server-methods/shared-types.ts
+++ b/src/gateway/server-methods/shared-types.ts
@@ -135,7 +135,7 @@ type GatewaySystemAgentSession = {
   welcome: string;
   welcomeQuestion?: SystemAgentChatQuestion;
   lastUsedAt: number;
-  delegationKey?: string;
+  ownerKey: string;
   pendingApproval?: { id: string; proposalHash: string };
 };
 

--- a/src/gateway/server-methods/system-agent-session-ownership.test.ts
+++ b/src/gateway/server-methods/system-agent-session-ownership.test.ts
@@ -4,7 +4,7 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resetCommandQueueStateForTest } from "../../process/command-queue.test-support.js";
 import { systemAgentHandlers, type SystemAgentChatSession } from "./system-agent.js";
-import type { GatewayClient, GatewayRequestContext } from "./types.js";
+import type { GatewayClient, GatewayRequestContext, RespondFn } from "./types.js";
 
 const setupInferenceMocks = vi.hoisted(() => ({ verifySetupInference: vi.fn() }));
 const delegatedInferenceMocks = vi.hoisted(() => ({
@@ -104,6 +104,7 @@ async function callChat(
   client: GatewayClient | null = defaultClient,
 ): Promise<RespondCall> {
   const calls: RespondCall[] = [];
+  const respond: RespondFn = (ok, payload, error) => calls.push({ ok, payload, error });
   await expectDefined(
     systemAgentHandlers["openclaw.chat"],
     'systemAgentHandlers["openclaw.chat"] test invariant',
@@ -111,7 +112,7 @@ async function callChat(
     params,
     client,
     context,
-    respond: (ok, payload, error) => calls.push({ ok, payload, error }),
+    respond,
   } as never);
   return expectDefined(calls[0], "system-agent response");
 }

--- a/src/gateway/server-methods/system-agent-session-ownership.test.ts
+++ b/src/gateway/server-methods/system-agent-session-ownership.test.ts
@@ -1,0 +1,355 @@
+// System-agent session tests cover caller ownership and response projection.
+
+import { expectDefined } from "@openclaw/normalization-core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resetCommandQueueStateForTest } from "../../process/command-queue.test-support.js";
+import { systemAgentHandlers, type SystemAgentChatSession } from "./system-agent.js";
+import type { GatewayClient, GatewayRequestContext } from "./types.js";
+
+const setupInferenceMocks = vi.hoisted(() => ({ verifySetupInference: vi.fn() }));
+const delegatedInferenceMocks = vi.hoisted(() => ({
+  verifySystemAgentInferenceWithFallback: vi.fn(),
+}));
+
+vi.mock("../../system-agent/setup-inference.js", () => ({
+  verifySetupInference: setupInferenceMocks.verifySetupInference,
+}));
+vi.mock("../../system-agent/inference-fallback.js", () => ({
+  verifySystemAgentInferenceWithFallback:
+    delegatedInferenceMocks.verifySystemAgentInferenceWithFallback,
+}));
+vi.mock("../../system-agent/transcript-store.js", () => ({
+  appendTranscriptReset: vi.fn(),
+  appendTranscriptTurn: vi.fn(),
+  readTranscriptTail: vi.fn(() => []),
+}));
+
+type FakeEngine = {
+  handle: ReturnType<typeof vi.fn>;
+  seedHistory: ReturnType<typeof vi.fn>;
+  historyLength: ReturnType<typeof vi.fn>;
+  historySince: ReturnType<typeof vi.fn>;
+  getPendingOperatorProposal: ReturnType<typeof vi.fn>;
+  resolveOperatorApproval: ReturnType<typeof vi.fn>;
+  dispose: ReturnType<typeof vi.fn>;
+  loadOverview: ReturnType<typeof vi.fn>;
+  noteAssistantMessage: ReturnType<typeof vi.fn>;
+};
+
+function makeEngine(): FakeEngine {
+  return {
+    handle: vi.fn(async () => ({ text: "did the thing", action: "none" })),
+    seedHistory: vi.fn(),
+    historyLength: vi.fn(() => 0),
+    historySince: vi.fn(() => []),
+    getPendingOperatorProposal: vi.fn(() => null),
+    resolveOperatorApproval: vi.fn(async () => null),
+    dispose: vi.fn(async () => undefined),
+    loadOverview: vi.fn(async () => ({})),
+    noteAssistantMessage: vi.fn(),
+  };
+}
+
+const createdEngines = vi.hoisted(() => [] as FakeEngine[]);
+
+vi.mock("../../system-agent/chat-engine.js", () => ({
+  SystemAgentChatEngine: function FakeSystemAgentChatEngine(this: FakeEngine) {
+    const engine = makeEngine();
+    createdEngines.push(engine);
+    Object.assign(this, engine);
+  },
+}));
+vi.mock("../../system-agent/overview.js", () => ({
+  formatSystemAgentStartupMessage: vi.fn(() => "welcome text"),
+}));
+
+type RespondCall = { ok: boolean; payload?: unknown; error?: unknown };
+
+function makeClient(params: {
+  connId: string;
+  deviceId?: string;
+  authenticatedUserId?: string;
+}): GatewayClient {
+  return {
+    connId: params.connId,
+    connect: {
+      client: { id: "openclaw-control-ui", mode: "webchat" },
+      ...(params.deviceId ? { device: { id: params.deviceId } } : {}),
+    },
+    ...(params.authenticatedUserId ? { authenticatedUserId: params.authenticatedUserId } : {}),
+  } as GatewayClient;
+}
+
+const defaultClient = makeClient({ connId: "conn-test", deviceId: "device-test" });
+
+function makeContext(sessions: Map<string, SystemAgentChatSession>): GatewayRequestContext {
+  return { systemAgentSessions: sessions } as unknown as GatewayRequestContext;
+}
+
+function seededSession(params?: {
+  engine?: FakeEngine;
+  ownerKey?: string;
+}): SystemAgentChatSession {
+  return {
+    engine: params?.engine ?? makeEngine(),
+    welcome: "welcome text",
+    lastUsedAt: 1,
+    ownerKey: params?.ownerKey ?? "device:device-test",
+  } as unknown as SystemAgentChatSession;
+}
+
+async function callChat(
+  context: GatewayRequestContext,
+  params: Record<string, unknown>,
+  client: GatewayClient | null = defaultClient,
+): Promise<RespondCall> {
+  const calls: RespondCall[] = [];
+  await expectDefined(
+    systemAgentHandlers["openclaw.chat"],
+    'systemAgentHandlers["openclaw.chat"] test invariant',
+  )({
+    params,
+    client,
+    context,
+    respond: (ok, payload, error) => calls.push({ ok, payload, error }),
+  } as never);
+  return expectDefined(calls[0], "system-agent response");
+}
+
+beforeEach(() => {
+  createdEngines.length = 0;
+  setupInferenceMocks.verifySetupInference.mockResolvedValue({ ok: true, binding: {} });
+  delegatedInferenceMocks.verifySystemAgentInferenceWithFallback.mockResolvedValue({
+    ok: true,
+    binding: {},
+  });
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  resetCommandQueueStateForTest();
+});
+
+describe("openclaw.chat session ownership", () => {
+  it("binds a new non-delegated session and rejects another principal", async () => {
+    const sessions = new Map<string, SystemAgentChatSession>();
+    const context = makeContext(sessions);
+    const owner = makeClient({
+      connId: "conn-owner",
+      deviceId: "device-owner",
+      authenticatedUserId: "owner@example.com",
+    });
+    const attacker = makeClient({
+      connId: "conn-attacker",
+      deviceId: "device-attacker",
+      authenticatedUserId: "attacker@example.com",
+    });
+
+    expect(await callChat(context, { sessionId: "owned-session" }, owner)).toMatchObject({
+      ok: true,
+    });
+    expect(sessions.get("owned-session")?.ownerKey).toBe("user:owner@example.com");
+    const handle = expectDefined(createdEngines[0], "created system-agent engine").handle;
+
+    const turn = await callChat(
+      context,
+      { sessionId: "owned-session", message: "show status" },
+      attacker,
+    );
+    const approval = await callChat(
+      context,
+      { sessionId: "owned-session", message: "yes" },
+      attacker,
+    );
+    const reset = await callChat(context, { sessionId: "owned-session", reset: true }, attacker);
+
+    expect(turn).toMatchObject({
+      ok: false,
+      payload: undefined,
+      error: { code: "INVALID_REQUEST" },
+    });
+    expect(approval).toMatchObject({
+      ok: false,
+      payload: undefined,
+      error: { code: "INVALID_REQUEST" },
+    });
+    expect(reset).toMatchObject({
+      ok: false,
+      payload: undefined,
+      error: { code: "INVALID_REQUEST" },
+    });
+    expect(handle).not.toHaveBeenCalled();
+    expect(
+      expectDefined(createdEngines[0], "created system-agent engine").dispose,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("lets the same authenticated principal resume after reconnecting", async () => {
+    const sessions = new Map<string, SystemAgentChatSession>();
+    const context = makeContext(sessions);
+    await callChat(
+      context,
+      { sessionId: "reconnect" },
+      makeClient({
+        connId: "conn-old",
+        deviceId: "device-old",
+        authenticatedUserId: "owner@example.com",
+      }),
+    );
+    const handle = expectDefined(createdEngines[0], "created system-agent engine").handle;
+
+    const resumed = await callChat(
+      context,
+      { sessionId: "reconnect", message: "continue" },
+      makeClient({
+        connId: "conn-new",
+        deviceId: "device-new",
+        authenticatedUserId: "owner@example.com",
+      }),
+    );
+
+    expect(resumed.ok).toBe(true);
+    expect(handle).toHaveBeenCalledWith("continue");
+  });
+
+  it("lets the same paired device resume after reconnecting", async () => {
+    const sessions = new Map<string, SystemAgentChatSession>();
+    const context = makeContext(sessions);
+    await callChat(
+      context,
+      { sessionId: "device-reconnect" },
+      makeClient({ connId: "conn-old", deviceId: "device-owner" }),
+    );
+    const handle = expectDefined(createdEngines[0], "created system-agent engine").handle;
+
+    const resumed = await callChat(
+      context,
+      { sessionId: "device-reconnect", message: "continue" },
+      makeClient({ connId: "conn-new", deviceId: "device-owner" }),
+    );
+
+    expect(resumed.ok).toBe(true);
+    expect(handle).toHaveBeenCalledWith("continue");
+  });
+
+  it("rejects non-delegated chat without a server-authenticated identity", async () => {
+    const call = await callChat(makeContext(new Map()), { sessionId: "anonymous" }, null);
+
+    expect(call).toMatchObject({ ok: false, error: { code: "INVALID_REQUEST" } });
+  });
+
+  it("keeps explicit delegation authoritative across connection identities", async () => {
+    const sessions = new Map<string, SystemAgentChatSession>();
+    const context = makeContext(sessions);
+    const delegation = { agentId: "main", sessionKey: "agent:main:main" };
+    await callChat(
+      context,
+      { sessionId: "delegated", delegation },
+      makeClient({ connId: "conn-owner", deviceId: "device-owner" }),
+    );
+    const handle = expectDefined(createdEngines[0], "created delegated engine").handle;
+
+    const resumed = await callChat(
+      context,
+      { sessionId: "delegated", message: "continue", delegation },
+      makeClient({
+        connId: "conn-other",
+        deviceId: "device-other",
+        authenticatedUserId: "other@example.com",
+      }),
+    );
+
+    expect(resumed.ok).toBe(true);
+    expect(handle).toHaveBeenCalledWith("continue");
+  });
+
+  it("rejects delegated reuse of a non-delegated session", async () => {
+    const engine = makeEngine();
+    const sessions = new Map<string, SystemAgentChatSession>([
+      ["shared", seededSession({ engine })],
+    ]);
+
+    const delegated = await callChat(makeContext(sessions), {
+      sessionId: "shared",
+      message: "yes",
+      delegation: { agentId: "main", sessionKey: "agent:main:main" },
+    });
+
+    expect(delegated).toMatchObject({ ok: false, error: { code: "INVALID_REQUEST" } });
+    expect(engine.handle).not.toHaveBeenCalled();
+  });
+});
+
+describe("openclaw.chat session responses", () => {
+  it("returns the stored welcome when no message is sent", async () => {
+    const sessions = new Map<string, SystemAgentChatSession>([["s1", seededSession()]]);
+    const call = await callChat(makeContext(sessions), { sessionId: "s1" });
+
+    expect(call).toMatchObject({
+      ok: true,
+      payload: { sessionId: "s1", reply: "welcome text", action: "none" },
+    });
+  });
+
+  it("routes messages through the session engine", async () => {
+    const engine = makeEngine();
+    const sessions = new Map<string, SystemAgentChatSession>([["s1", seededSession({ engine })]]);
+
+    const call = await callChat(makeContext(sessions), { sessionId: "s1", message: "status" });
+
+    expect(engine.handle).toHaveBeenCalledWith("status");
+    expect(call.payload).toMatchObject({ reply: "did the thing", action: "none" });
+  });
+
+  it("forwards sensitive-input metadata", async () => {
+    const engine = makeEngine();
+    engine.handle.mockResolvedValue({
+      text: "Enter the bot token",
+      action: "none",
+      sensitive: true,
+    });
+    const sessions = new Map<string, SystemAgentChatSession>([["s1", seededSession({ engine })]]);
+
+    const call = await callChat(makeContext(sessions), { sessionId: "s1", message: "yes" });
+
+    expect(call.payload).toMatchObject({ sensitive: true });
+  });
+
+  it("maps the TUI handoff to an open-agent action", async () => {
+    const engine = makeEngine();
+    engine.handle.mockResolvedValue({
+      text: "",
+      action: "open-tui",
+      handoff: { kind: "open-tui" },
+    });
+    const sessions = new Map<string, SystemAgentChatSession>([["s1", seededSession({ engine })]]);
+
+    const call = await callChat(makeContext(sessions), {
+      sessionId: "s1",
+      message: "talk to agent",
+    });
+
+    expect(call.payload).toMatchObject({ action: "open-agent" });
+    expect(call.payload).not.toHaveProperty("agentDraft");
+    expect((call.payload as { reply: string }).reply).toContain("continue with your agent");
+  });
+
+  it("forwards the hatch draft intent with an agent handoff", async () => {
+    const engine = makeEngine();
+    engine.handle.mockResolvedValue({
+      text: "Your agent is hatching.",
+      action: "open-tui",
+      agentDraft: "hatch",
+      handoff: { kind: "open-tui", agentId: "researcher" },
+    });
+    const sessions = new Map<string, SystemAgentChatSession>([["s1", seededSession({ engine })]]);
+
+    const call = await callChat(makeContext(sessions), { sessionId: "s1", message: "yes" });
+
+    expect(call.payload).toMatchObject({
+      action: "open-agent",
+      agentDraft: "hatch",
+      agentId: "researcher",
+    });
+  });
+});

--- a/src/gateway/server-methods/system-agent.test.ts
+++ b/src/gateway/server-methods/system-agent.test.ts
@@ -23,7 +23,7 @@ import {
   runExclusiveSystemAgentSetupActivation,
   type SystemAgentChatSession,
 } from "./system-agent.js";
-import type { GatewayRequestContext } from "./types.js";
+import type { GatewayClient, GatewayRequestContext } from "./types.js";
 
 const setupInferenceMocks = vi.hoisted(() => ({
   activateSetupInference: vi.fn(),
@@ -86,6 +86,11 @@ function makeRespond() {
 function makeContext(sessions: Map<string, SystemAgentChatSession>): GatewayRequestContext {
   return { systemAgentSessions: sessions } as unknown as GatewayRequestContext;
 }
+
+const defaultClient = {
+  connId: "conn-test",
+  connect: { device: { id: "device-test" } },
+} as GatewayClient;
 
 const verifiedConfig: OpenClawConfig = {
   agents: { defaults: { model: "openai/gpt-5.5@openai:verified" } },
@@ -157,6 +162,7 @@ function seededSession(overrides?: Partial<SystemAgentChatSession>): SystemAgent
     engine: makeVerifiedEngine(),
     welcome: "welcome text",
     lastUsedAt: 1,
+    ownerKey: "device:device-test",
     ...overrides,
   };
 }
@@ -203,6 +209,7 @@ afterEach(() => {
 async function callChat(
   context: GatewayRequestContext,
   params: Record<string, unknown>,
+  client: GatewayClient | null = defaultClient,
 ): Promise<RespondCall> {
   const { calls, respond } = makeRespond();
   await expectDefined(
@@ -212,6 +219,7 @@ async function callChat(
     params,
     respond,
     context,
+    client,
   } as never);
   const call = calls[0];
   if (!call) {
@@ -604,26 +612,6 @@ describe("openclaw.chat", () => {
     expect(call.ok).toBe(false);
   });
 
-  it("returns the stored welcome when no message is sent", async () => {
-    const sessions = new Map<string, SystemAgentChatSession>([["s1", seededSession()]]);
-    const call = await callChat(makeContext(sessions), { sessionId: "s1" });
-    expect(call.ok).toBe(true);
-    expect(call.payload).toMatchObject({ sessionId: "s1", reply: "welcome text", action: "none" });
-  });
-
-  it("routes messages through the session engine", async () => {
-    const engine = makeVerifiedEngine();
-    const handle = vi
-      .spyOn(engine, "handle")
-      .mockResolvedValue({ text: "did the thing", action: "none" });
-    const sessions = new Map<string, SystemAgentChatSession>([["s1", seededSession({ engine })]]);
-
-    const call = await callChat(makeContext(sessions), { sessionId: "s1", message: "status" });
-
-    expect(handle).toHaveBeenCalledWith("status");
-    expect(call.payload).toMatchObject({ reply: "did the thing", action: "none" });
-  });
-
   it("persists completed turns from the engine's sanitized history", async () => {
     const engine = new SystemAgentChatEngine({
       verifiedInference: requireVerifiedInferenceFixture(),
@@ -744,7 +732,7 @@ describe("openclaw.chat", () => {
         "delegate-1",
         seededSession({
           engine,
-          delegationKey: JSON.stringify(["main", "agent:main:main"]),
+          ownerKey: JSON.stringify(["main", "agent:main:main"]),
         }),
       ],
     ]);
@@ -796,23 +784,6 @@ describe("openclaw.chat", () => {
     await vi.waitFor(() => {
       expect(resolveOperatorApproval).toHaveBeenCalledWith("allow-once", proposalHash);
     });
-  });
-
-  it("rejects delegated reuse of another caller's session", async () => {
-    const engine = makeVerifiedEngine();
-    const handle = vi.spyOn(engine, "handle");
-    const sessions = new Map<string, SystemAgentChatSession>([
-      ["shared", seededSession({ engine })],
-    ]);
-
-    const delegated = await callChat(makeContext(sessions), {
-      sessionId: "shared",
-      message: "yes",
-      delegation: { agentId: "main", sessionKey: "agent:main:main" },
-    });
-
-    expect(delegated).toMatchObject({ ok: false, error: { code: "INVALID_REQUEST" } });
-    expect(handle).not.toHaveBeenCalled();
   });
 
   it("drops a failed session and requires fresh inference on retry", async () => {
@@ -884,6 +855,7 @@ describe("openclaw.chat", () => {
       'systemAgentHandlers["openclaw.chat"] test invariant',
     )({
       params: { sessionId: "s1", message: "yes" },
+      client: defaultClient,
       context: makeContext(sessions),
       respond: () => {
         activeAtResponse.push(getCommandLaneSnapshot(CommandLane.SystemAgent).activeCount);
@@ -894,6 +866,7 @@ describe("openclaw.chat", () => {
       'systemAgentHandlers["openclaw.chat"] test invariant',
     )({
       params: { sessionId: "s2", message: "yes" },
+      client: defaultClient,
       context: makeContext(sessions),
       respond: () => {
         activeAtResponse.push(getCommandLaneSnapshot(CommandLane.SystemAgent).activeCount);
@@ -950,61 +923,6 @@ describe("openclaw.chat", () => {
     expect(sessions.has("new-2")).toBe(true);
   });
 
-  it("forwards sensitive-input metadata to clients", async () => {
-    const engine = makeVerifiedEngine();
-    vi.spyOn(engine, "handle").mockResolvedValue({
-      text: "Enter the bot token",
-      action: "none",
-      sensitive: true,
-    });
-    const sessions = new Map<string, SystemAgentChatSession>([["s1", seededSession({ engine })]]);
-
-    const call = await callChat(makeContext(sessions), { sessionId: "s1", message: "yes" });
-
-    expect(call.payload).toMatchObject({ sensitive: true });
-  });
-
-  it("maps the TUI handoff to an open-agent action for clients", async () => {
-    const engine = makeVerifiedEngine();
-    vi.spyOn(engine, "handle").mockResolvedValue({
-      text: "",
-      action: "open-tui",
-      handoff: { kind: "open-tui" },
-    });
-    const sessions = new Map<string, SystemAgentChatSession>([["s1", seededSession({ engine })]]);
-
-    const call = await callChat(makeContext(sessions), {
-      sessionId: "s1",
-      message: "talk to agent",
-    });
-
-    expect(call.payload).toMatchObject({ action: "open-agent" });
-    expect(call.payload).not.toHaveProperty("agentDraft");
-    expect((call.payload as { reply: string }).reply).toContain("continue with your agent");
-  });
-
-  it("forwards the hatch draft intent with an agent handoff", async () => {
-    const engine = makeVerifiedEngine();
-    vi.spyOn(engine, "handle").mockResolvedValue({
-      text: "Your agent is hatching.",
-      action: "open-tui",
-      agentDraft: "hatch",
-      handoff: { kind: "open-tui", agentId: "researcher" },
-    });
-    const sessions = new Map<string, SystemAgentChatSession>([["s1", seededSession({ engine })]]);
-
-    const call = await callChat(makeContext(sessions), {
-      sessionId: "s1",
-      message: "yes",
-    });
-
-    expect(call.payload).toMatchObject({
-      action: "open-agent",
-      agentDraft: "hatch",
-      agentId: "researcher",
-    });
-  });
-
   it("resets a session on request", async () => {
     stubEngineOverview();
     transcriptStoreMocks.readTranscriptTail.mockReturnValue([]);
@@ -1023,6 +941,7 @@ describe("openclaw.chat", () => {
       'systemAgentHandlers["openclaw.chat"] test invariant',
     )({
       params: { sessionId: "s1", reset: true },
+      client: defaultClient,
       respond,
       context,
     } as never);

--- a/src/gateway/server-methods/system-agent.ts
+++ b/src/gateway/server-methods/system-agent.ts
@@ -39,7 +39,7 @@ import {
   handlePendingApprovalRequest,
   listVisiblePendingApprovalRequests,
 } from "./approval-shared.js";
-import type { GatewayRequestContext, GatewayRequestHandlers } from "./types.js";
+import type { GatewayClient, GatewayRequestContext, GatewayRequestHandlers } from "./types.js";
 import { assertValidParams } from "./validation.js";
 
 /**
@@ -88,6 +88,30 @@ async function runSystemAgentGatewayTask<T>(task: () => Promise<T>): Promise<T> 
     // setup writes atomic with respect to other OpenClaw gateway requests.
     systemAgentGatewayExecutionQueue.enqueue(SYSTEM_AGENT_GATEWAY_EXECUTION_KEY, task),
   );
+}
+
+function resolveSystemAgentSessionOwnerKey(params: {
+  delegation?: { agentId?: string; sessionKey?: string };
+  client: GatewayClient | null;
+}): string | undefined {
+  const delegationKey = resolveSystemAgentDelegationKey(params.delegation);
+  if (delegationKey !== undefined) {
+    // Delegation is the host-only, cross-connection owner asserted by the regular-agent
+    // tool path. Keep its agent/session tuple authoritative across gateway reconnects.
+    return delegationKey;
+  }
+  // Authenticated users survive reconnects and may span paired devices. Otherwise
+  // bind to the verified device, with the server-issued connection as a last resort.
+  const userId = params.client?.authenticatedUserId?.trim();
+  if (userId) {
+    return `user:${userId}`;
+  }
+  const deviceId = params.client?.connect.device?.id.trim();
+  if (deviceId) {
+    return `device:${deviceId}`;
+  }
+  const connId = params.client?.connId?.trim();
+  return connId ? `connection:${connId}` : undefined;
 }
 
 let systemAgentSetupActivationInProgress = false;
@@ -452,7 +476,7 @@ export const systemAgentHandlers: GatewayRequestHandlers = {
       );
     }
   },
-  "openclaw.chat": async ({ params, respond, context }) => {
+  "openclaw.chat": async ({ params, respond, client, context }) => {
     if (!assertValidParams(params, validateSystemAgentChatParams, "openclaw.chat", respond)) {
       return;
     }
@@ -463,9 +487,20 @@ export const systemAgentHandlers: GatewayRequestHandlers = {
       // it, concurrent first messages can create competing engines and lose
       // conversation state when the later initializer replaces the first.
       await getSystemAgentSessionQueue(sessions).enqueue(sessionId, async () => {
-        const delegationKey = resolveSystemAgentDelegationKey(params.delegation);
+        const ownerKey = resolveSystemAgentSessionOwnerKey({
+          delegation: params.delegation,
+          client,
+        });
+        if (!ownerKey) {
+          respond(
+            false,
+            undefined,
+            errorShape(ErrorCodes.INVALID_REQUEST, "OpenClaw caller identity unavailable."),
+          );
+          return;
+        }
         const boundSession = sessions.get(sessionId);
-        if (boundSession && boundSession.delegationKey !== delegationKey) {
+        if (boundSession && boundSession.ownerKey !== ownerKey) {
           respond(
             false,
             undefined,
@@ -557,7 +592,7 @@ export const systemAgentHandlers: GatewayRequestHandlers = {
             welcome,
             ...(welcomeQuestion ? { welcomeQuestion } : {}),
             lastUsedAt: Date.now(),
-            delegationKey,
+            ownerKey,
           };
           sessions.set(sessionId, session);
           if (params.message === undefined || !params.message.trim()) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a second authenticated client on a shared gateway could submit turns, approve a pending proposal, or reset another client's non-delegated system-agent chat when it knew or guessed that chat's session ID. Non-delegated sessions previously collapsed onto the same empty ownership key, so the existing session-binding check did not distinguish callers.

Threat model: two authenticated gateway clients, one known or guessable system-agent session ID, and no explicit host delegation. The second client must not learn session data or drive the first client's setup/configuration conversation.

## Why This Change Was Made

Every system-agent session now has a required owner key. Explicit host-only delegation keeps its existing agent/session tuple so intentional cross-connection delegation continues to work; ordinary calls use the authenticated user identity, then the cryptographically verified paired-device identity, and finally the server-issued connection ID. Ownership is checked before any session message, approval response, or reset is processed, and mismatches return the existing redacted invalid-request response.

This is an additive gateway-internal ownership check. It does not change or version the gateway protocol, configuration, or persistent state.

## User Impact

Control UI, CLI, and native clients can continue their own system-agent chats across legitimate reconnects, while another authenticated gateway client can no longer take over those sessions by replaying a session ID. Existing explicit regular-agent delegation behavior is unchanged.

## Evidence

- Regression reproduced before the fix: a different authenticated principal using the same session ID received a successful response and reached the original engine.
- Focused ownership suite: 11/11 passed, covering cross-principal turn, proposal-decision, and reset rejection; redacted payloads; same-user reconnect; same-device reconnect; identityless fail-closed behavior; and unchanged explicit delegation.
- Existing system-agent suite: 23/23 passed after the test-module split.
- Remote Node 24 core typecheck: pnpm tsgo passed on Blacksmith Testbox (Actions run 29706113527).
- Remote test typecheck: pnpm check:test-types passed on Blacksmith Testbox (Actions run 29706769628).
- Targeted oxfmt, oxlint, and git diff --check passed.
- Fresh autoreview on the rebased branch reported no accepted/actionable findings.
- Exact-head CI passed on commit 1449bf2183ea0ba8ac59708d95dc9c981ce56efa (Actions run 29706935942). The first CI run caught implicit-any parameters in the new test helper and an unrelated TUI restart flake; the helper was typed in a follow-up commit, and both lanes passed on the corrected head.

AI-assisted: yes. The behavior, trust boundary, regression proof, and reconnect semantics were reviewed directly.
