### PR TITLE
fix(agents): update implicit default agent identity

### DIFF
--- a/src/gateway/server-methods/agents-config-mutations.ts
+++ b/src/gateway/server-methods/agents-config-mutations.ts
@@ -1,6 +1,10 @@
 // Agent config mutation helpers wrap retrying config writes for create/update/
 // delete flows and surface typed precondition failures to gateway handlers.
-import { resolveAgentDir, resolveAgentWorkspaceDir } from "../../agents/agent-scope.js";
+import {
+  resolveAgentDir,
+  resolveAgentWorkspaceDir,
+  resolveDefaultAgentId,
+} from "../../agents/agent-scope.js";
 import {
   applyAgentConfig,
   findAgentEntryIndex,
@@ -27,6 +31,15 @@ export function isConfiguredAgent(cfg: OpenClawConfig, agentId: string): boolean
   return findAgentEntryIndex(listAgentEntries(cfg), agentId) >= 0;
 }
 
+/** Allows updates to concrete agents and to the implicit default when no list exists yet. */
+export function isUpdatableAgent(cfg: OpenClawConfig, agentId: string): boolean {
+  const agents = listAgentEntries(cfg);
+  return (
+    findAgentEntryIndex(agents, agentId) >= 0 ||
+    (agents.length === 0 && agentId === resolveDefaultAgentId(cfg))
+  );
+}
+
 /** Updates an existing agent entry while preserving omitted fields. */
 export async function updateAgentConfigEntry(params: {
   agentId: string;
@@ -38,7 +51,7 @@ export async function updateAgentConfigEntry(params: {
   await mutateConfigFileWithRetry({
     afterWrite: { mode: "auto" },
     mutate: (draft) => {
-      if (!isConfiguredAgent(draft, params.agentId)) {
+      if (!isUpdatableAgent(draft, params.agentId)) {
         throw new AgentConfigPreconditionError(`agent "${params.agentId}" not found`);
       }
       const latestNextConfig = applyAgentConfig(draft, {

--- a/src/gateway/server-methods/agents-mutate.test.ts
+++ b/src/gateway/server-methods/agents-mutate.test.ts
@@ -145,6 +145,7 @@ vi.mock("../../agents/agent-scope.js", () => ({
   resolveAgentDir: mocks.resolveAgentDir,
   resolveAgentConfig: (cfg: unknown, agentId: string) =>
     getAgentList(cfg).find((entry) => entry.id === agentId),
+  resolveDefaultAgentId: (cfg: unknown) => getAgentList(cfg)[0]?.id ?? "main",
   resolveAgentWorkspaceDir: mocks.resolveAgentWorkspaceDir,
 }));
 
@@ -759,6 +760,32 @@ describe("agents.update", () => {
 
     expect(respond).toHaveBeenCalledWith(true, { ok: true, agentId: "test-agent" }, undefined);
     expect(mocks.writeConfigFile).toHaveBeenCalled();
+  });
+
+  it("materializes the implicit default agent when updating its identity", async () => {
+    mocks.loadConfigReturn = {
+      agents: {
+        defaults: { workspace: "/workspace/main" },
+      },
+    };
+
+    const { respond, promise } = makeCall("agents.update", {
+      agentId: "main",
+      name: "Main Agent",
+      emoji: "🐾",
+    });
+    await promise;
+
+    expectRespondOk(respond, { ok: true, agentId: "main" });
+    const persisted = expectRecordFields(mockCallArg(mocks.writeConfigFile), {});
+    const agents = expectRecordFields(persisted.agents, {});
+    expect(agents.list).toEqual([
+      {
+        id: "main",
+        name: "Main Agent",
+        identity: { name: "Main Agent", emoji: "🐾" },
+      },
+    ]);
   });
 
   it("rejects updating a nonexistent agent", async () => {

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -58,6 +58,7 @@ import {
   AgentConfigPreconditionError,
   deleteAgentConfigEntry,
   isConfiguredAgent,
+  isUpdatableAgent,
   updateAgentConfigEntry,
 } from "./agents-config-mutations.js";
 import { loadOptionalServerMethodModelCatalog } from "./optional-model-catalog.js";
@@ -495,7 +496,7 @@ export const agentsHandlers: GatewayRequestHandlers = {
 
     const cfg = context.getRuntimeConfig();
     const agentId = normalizeAgentId(params.agentId);
-    if (!isConfiguredAgent(cfg, agentId)) {
+    if (!isUpdatableAgent(cfg, agentId)) {
       respondAgentNotFound(respond, agentId);
       return;
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes #106894.

When `agents.list` is absent, the Gateway roster still exposes the implicit default `main` agent. The Agents identity editor accepts identity changes for that row, but `agents.update` previously required a concrete list entry and failed with `agent "main" not found`. The preview was then lost on reload because no identity was persisted.

The linked issue now includes a concrete reproduction on `2026.7.2-beta.3` using a valid 663 KB PNG, plus the observed Gateway error and persisted-config result.

## Why This Change Was Made

- allow `agents.update` to target the implicit default agent only when no agent list exists yet
- materialize that implicit agent through the existing `applyAgentConfig` path
- keep the concrete-entry requirement for unknown agents and for delete operations

The CLI identity command already materializes the implicit default agent. This applies the same narrow rule to the Gateway update path without weakening arbitrary-agent or delete preconditions.

## User Impact

Users can save the display name, emoji, and avatar identity fields for the implicit default agent from Settings → Agents → main → Overview. The save creates the concrete `agents.list` entry needed to persist those fields instead of returning `agent "main" not found`.

## Evidence

Automated regression proof:

- added a focused Gateway mutation test starting from `agents.defaults` with no `agents.list`
- invoked `agents.update` for `main`
- verified that the persisted config materializes `agents.list[0]` with the requested identity
- existing unknown-agent and concurrent-delete rejection coverage remains in place

Validation run before push:

- `node node_modules/vitest/vitest.mjs run src/gateway/server-methods/agents-mutate.test.ts --pool=forks --maxWorkers=1 --reporter=dot` (52 passed)
- `pnpm exec oxlint src/gateway/server-methods/agents-config-mutations.ts src/gateway/server-methods/agents.ts src/gateway/server-methods/agents-mutate.test.ts`
- `pnpm exec oxfmt --check src/gateway/server-methods/agents-config-mutations.ts src/gateway/server-methods/agents.ts src/gateway/server-methods/agents-mutate.test.ts`
- `git diff --check`
- repository CI gate passed on commit `7431b2fb223fb392be3a44b1320421489c6429a8`

Live behavior evidence is not claimed here. The concrete before-fix live reproduction is in #106894; this PR provides source-level and automated after-fix regression proof.

## AI Assistance

This PR was AI-assisted. I reviewed the resulting change and validation scope before submission.
