### PR TITLE
fix(onboard): preserve gateway settings on rerun

### DIFF
--- a/docs/cli/onboard.md
+++ b/docs/cli/onboard.md
@@ -83,6 +83,7 @@ not overwrite the existing skill.
   for port, bind, and auth.
 - `--flow import`: runs a detected migration provider (for example Hermes via `--import-from hermes`), previews the plan, then applies after confirmation. Import only runs against a fresh OpenClaw setup - reset config, credentials, sessions, and workspace state first if any exist. Use [`openclaw migrate`](/cli/migrate) for dry-run plans, overwrite mode, reports, and exact mappings.
 - `--remote-url` and `--remote-token`: prefill the classic remote Gateway step and override stored remote values for this run. Changing the URL does not reuse stored credentials unless you also pass a token. The token stays masked in prompts and follows the wizard's existing plaintext or SecretRef storage choice.
+- `--tailscale-reset-on-exit` and `--no-tailscale-reset-on-exit`: explicitly control whether Tailscale Serve or Funnel configuration is reset when the Gateway exits. Omitting both preserves the current setting during non-interactive reruns.
 - `--modern` is a compatibility alias for the OpenClaw conversational setup
   assistant. It uses the same live-inference gate as `openclaw setup` and
   accepts only `--workspace`, `--accept-risk`,

--- a/src/cli/program/register.onboard.test.ts
+++ b/src/cli/program/register.onboard.test.ts
@@ -178,6 +178,11 @@ describe("registerOnboardCommand", () => {
     expect(setupWizardOptions().tailscaleResetOnExit).toBe(true);
   });
 
+  it("forwards explicit --no-tailscale-reset-on-exit", async () => {
+    await runCli(["onboard", "--no-tailscale-reset-on-exit"]);
+    expect(setupWizardOptions().tailscaleResetOnExit).toBe(false);
+  });
+
   it("forwards remote seed flags to setup wizard options", async () => {
     const remoteToken = ["fixture", "value"].join("-");
     await runCli([

--- a/src/cli/program/register.onboard.test.ts
+++ b/src/cli/program/register.onboard.test.ts
@@ -133,6 +133,7 @@ describe("registerOnboardCommand", () => {
     await runCli(["onboard"]);
 
     expect(setupWizardOptions().installDaemon).toBeUndefined();
+    expect(setupWizardOptions().tailscaleResetOnExit).toBeUndefined();
   });
 
   it("sets installDaemon from explicit install flags and prioritizes --skip-daemon", async () => {
@@ -170,6 +171,11 @@ describe("registerOnboardCommand", () => {
   it("forwards --skip-bootstrap to setup wizard options", async () => {
     await runCli(["onboard", "--skip-bootstrap"]);
     expect(setupWizardOptions().skipBootstrap).toBe(true);
+  });
+
+  it("forwards explicit --tailscale-reset-on-exit", async () => {
+    await runCli(["onboard", "--tailscale-reset-on-exit"]);
+    expect(setupWizardOptions().tailscaleResetOnExit).toBe(true);
   });
 
   it("forwards remote seed flags to setup wizard options", async () => {

--- a/src/cli/program/register.onboard.ts
+++ b/src/cli/program/register.onboard.ts
@@ -345,7 +345,7 @@ export function registerOnboardCommand(program: Command): void {
           remoteUrl: opts.remoteUrl as string | undefined,
           remoteToken: opts.remoteToken as string | undefined,
           tailscale: opts.tailscale as TailscaleMode | undefined,
-          tailscaleResetOnExit: Boolean(opts.tailscaleResetOnExit),
+          tailscaleResetOnExit: opts.tailscaleResetOnExit === true ? true : undefined,
           reset: Boolean(opts.reset),
           resetScope: opts.resetScope as ResetScope | undefined,
           installDaemon,

--- a/src/cli/program/register.onboard.ts
+++ b/src/cli/program/register.onboard.ts
@@ -32,6 +32,13 @@ export function resolveInstallDaemonFlag(command: Command): boolean | undefined 
   return undefined;
 }
 
+export function resolveTailscaleResetOnExitFlag(command: Command): boolean | undefined {
+  if (command.getOptionValueSource("tailscaleResetOnExit") !== "cli") {
+    return undefined;
+  }
+  return Boolean(command.getOptionValue("tailscaleResetOnExit"));
+}
+
 const MODERN_ONBOARD_OPTION_KEYS = new Set([
   "modern",
   "workspace",
@@ -218,6 +225,7 @@ export function registerOnboardCommand(program: Command): void {
     .option("--remote-token <token>", "Remote Gateway token (optional)")
     .option("--tailscale <mode>", "Tailscale: off|serve|funnel")
     .option("--tailscale-reset-on-exit", "Reset tailscale serve/funnel on exit")
+    .option("--no-tailscale-reset-on-exit", "Keep tailscale serve/funnel after exit")
     .option("--install-daemon", "Install gateway service")
     .option("--no-install-daemon", "Skip gateway service install")
     .option("--skip-daemon", "Skip gateway service install")
@@ -324,6 +332,7 @@ export function registerOnboardCommand(program: Command): void {
         return;
       }
       const installDaemon = resolveInstallDaemonFlag(commandRuntime);
+      const tailscaleResetOnExit = resolveTailscaleResetOnExitFlag(commandRuntime);
       const gatewayPort = parsePort(opts.gatewayPort);
       const { setupWizardCommand } = await import("../../commands/onboard.js");
       await setupWizardCommand(
@@ -345,7 +354,7 @@ export function registerOnboardCommand(program: Command): void {
           remoteUrl: opts.remoteUrl as string | undefined,
           remoteToken: opts.remoteToken as string | undefined,
           tailscale: opts.tailscale as TailscaleMode | undefined,
-          tailscaleResetOnExit: opts.tailscaleResetOnExit === true ? true : undefined,
+          tailscaleResetOnExit,
           reset: Boolean(opts.reset),
           resetScope: opts.resetScope as ResetScope | undefined,
           installDaemon,

--- a/src/cli/program/register.setup.test.ts
+++ b/src/cli/program/register.setup.test.ts
@@ -165,6 +165,12 @@ describe("registerSetupCommand", () => {
     expect(setupCommandMock).not.toHaveBeenCalled();
   });
 
+  it("forwards explicit --no-tailscale-reset-on-exit", async () => {
+    await runCli(["setup", "--no-tailscale-reset-on-exit"]);
+
+    expect(lastWizardOptions()?.tailscaleResetOnExit).toBe(false);
+  });
+
   it("runs baseline setup command when --baseline is set", async () => {
     await runCli(["setup", "--baseline", "--workspace", "/tmp/ws"]);
 

--- a/src/cli/program/register.setup.test.ts
+++ b/src/cli/program/register.setup.test.ts
@@ -161,6 +161,7 @@ describe("registerSetupCommand", () => {
 
     expect(setupWizardCommandMock).toHaveBeenCalledWith(lastWizardOptions(), runtime);
     expect(lastWizardOptions()?.workspace).toBe("/tmp/ws");
+    expect(lastWizardOptions()?.tailscaleResetOnExit).toBeUndefined();
     expect(setupCommandMock).not.toHaveBeenCalled();
   });
 
@@ -219,6 +220,7 @@ describe("registerSetupCommand", () => {
       "--skip-search",
       "--skip-skills",
       "--skip-bootstrap",
+      "--tailscale-reset-on-exit",
       "--node-manager",
       "pnpm",
       "--json",
@@ -237,6 +239,7 @@ describe("registerSetupCommand", () => {
       skipSearch: true,
       skipSkills: true,
       skipBootstrap: true,
+      tailscaleResetOnExit: true,
       nodeManager: "pnpm",
       json: true,
     });

--- a/src/cli/program/register.setup.ts
+++ b/src/cli/program/register.setup.ts
@@ -19,6 +19,7 @@ import {
   pickOnboardAuthOptionValues,
   registerOnboardAuthOptions,
   resolveInstallDaemonFlag,
+  resolveTailscaleResetOnExitFlag,
 } from "./register.onboard.js";
 
 const SYSTEM_AGENT_OPTION_NAMES = new Set(["message", "yes", "json"]);
@@ -93,6 +94,7 @@ async function runOnboardingEntry(
     return;
   }
   const installDaemon = resolveInstallDaemonFlag(commandRuntime);
+  const tailscaleResetOnExit = resolveTailscaleResetOnExitFlag(commandRuntime);
   const gatewayPort = parsePort(options.gatewayPort);
   const { setupWizardCommand } = await import("../../commands/onboard.js");
   await setupWizardCommand(
@@ -113,7 +115,7 @@ async function runOnboardingEntry(
       gatewayTokenRefEnv: optionalString(options.gatewayTokenRefEnv),
       gatewayPassword: optionalString(options.gatewayPassword),
       tailscale: options.tailscale as TailscaleMode | undefined,
-      tailscaleResetOnExit: options.tailscaleResetOnExit === true ? true : undefined,
+      tailscaleResetOnExit,
       installDaemon,
       daemonRuntime: options.daemonRuntime as GatewayDaemonRuntime | undefined,
       skipChannels: Boolean(options.skipChannels),
@@ -199,6 +201,7 @@ export function registerSetupCommand(program: Command): void {
     .option("--gateway-password <password>", "Gateway password (password auth)")
     .option("--tailscale <mode>", "Tailscale: off|serve|funnel")
     .option("--tailscale-reset-on-exit", "Reset tailscale serve/funnel on exit")
+    .option("--no-tailscale-reset-on-exit", "Keep tailscale serve/funnel after exit")
     .option("--install-daemon", "Install gateway service")
     .option("--no-install-daemon", "Skip gateway service install")
     .option("--skip-daemon", "Skip gateway service install")

--- a/src/cli/program/register.setup.ts
+++ b/src/cli/program/register.setup.ts
@@ -113,7 +113,7 @@ async function runOnboardingEntry(
       gatewayTokenRefEnv: optionalString(options.gatewayTokenRefEnv),
       gatewayPassword: optionalString(options.gatewayPassword),
       tailscale: options.tailscale as TailscaleMode | undefined,
-      tailscaleResetOnExit: Boolean(options.tailscaleResetOnExit),
+      tailscaleResetOnExit: options.tailscaleResetOnExit === true ? true : undefined,
       installDaemon,
       daemonRuntime: options.daemonRuntime as GatewayDaemonRuntime | undefined,
       skipChannels: Boolean(options.skipChannels),

--- a/src/commands/onboard-non-interactive.gateway-health-auth.test.ts
+++ b/src/commands/onboard-non-interactive.gateway-health-auth.test.ts
@@ -121,4 +121,14 @@ describe("resolveGatewayHealthProbeToken", () => {
 
     expect(resolved).toEqual({ password: "resolved-password" });
   });
+
+  it("resolves environment-only password auth for the local onboarding health probe", async () => {
+    process.env.OPENCLAW_GATEWAY_PASSWORD = "environment-password"; // pragma: allowlist secret
+
+    const resolved = await resolveGatewayHealthProbeToken({
+      gateway: { auth: { mode: "password" } },
+    } as OpenClawConfig);
+
+    expect(resolved).toEqual({ password: "environment-password" });
+  });
 });

--- a/src/commands/onboard-non-interactive.gateway.test.ts
+++ b/src/commands/onboard-non-interactive.gateway.test.ts
@@ -712,7 +712,11 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
         gateway: {
           remote: {
             url: "wss://old.example.test",
-            transport: "direct",
+            transport: "ssh",
+            remotePort: 24680,
+            sshTarget: "operator@old.example.test",
+            sshIdentity: "/tmp/old-identity",
+            sshHostKeyPolicy: "openssh",
             token: "test-token",
             password: { source: "env", provider: "default", id: "REMOTE_PASSWORD" },
             tlsFingerprint: "sha256:test-fingerprint",
@@ -734,13 +738,10 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
       const cfg = readTestConfig();
 
       expect(cfg.gateway?.mode).toBe("remote");
-      expect(cfg.gateway?.remote).toMatchObject({
+      expect(cfg.gateway?.remote).toEqual({
         url: `ws://127.0.0.1:${port}`,
         token,
-        transport: "direct",
       });
-      expect(cfg.gateway?.remote?.password).toBeUndefined();
-      expect(cfg.gateway?.remote?.tlsFingerprint).toBeUndefined();
       expect(cfg.hooks?.internal?.entries?.["session-memory"]).toEqual({ enabled: true });
     });
   }, 60_000);

--- a/src/commands/onboard-non-interactive.gateway.test.ts
+++ b/src/commands/onboard-non-interactive.gateway.test.ts
@@ -404,9 +404,10 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
     readLastGatewayErrorLineMock.mockClear();
   });
 
-  it("preserves existing agents.list and bindings on onboard rerun (openclaw#84692)", async () => {
+  it("preserves existing config on onboard rerun (openclaw#84692)", async () => {
     await withStateDir("state-preserve-agents-", async (stateDir) => {
       const workspace = path.join(stateDir, "openclaw");
+      const passwordRef = { source: "env" as const, provider: "default", id: "GATEWAY_PASSWORD" };
       const seededAgents = [
         { id: "alpha", model: "anthropic/claude-3-5-sonnet" },
         { id: "beta", model: "openai/gpt-4o" },
@@ -432,7 +433,13 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
       testConfigStore.set(resolveTestConfigPath(), {
         agents: { list: seededAgents, defaults: { workspace } },
         bindings: seededBindings,
-        gateway: { mode: "local", port: 18789, auth: { mode: "token", token: "seed_tok" } },
+        gateway: {
+          mode: "local",
+          port: 24680,
+          bind: "loopback",
+          auth: { mode: "password", password: passwordRef },
+          tailscale: { mode: "serve", resetOnExit: true },
+        },
       } as OpenClawConfig);
 
       await runNonInteractiveSetup(
@@ -444,9 +451,6 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
           skipSkills: true,
           skipHealth: true,
           installDaemon: false,
-          gatewayBind: "loopback",
-          gatewayAuth: "token",
-          gatewayToken: "seed_tok",
         },
         runtime,
       );
@@ -454,6 +458,13 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
       const cfg = readTestConfig();
       expect(cfg.agents?.list?.map((a) => a.id)).toEqual(["alpha", "beta"]);
       expect(cfg.bindings).toEqual(seededBindings);
+      expect(cfg.gateway).toEqual({
+        mode: "local",
+        port: 24680,
+        bind: "loopback",
+        auth: { mode: "password", password: passwordRef },
+        tailscale: { mode: "serve", resetOnExit: true },
+      });
 
       const onboardWrite = capturedReplaceConfigFileCalls.at(-1);
       expect(onboardWrite?.writeOptions?.allowConfigSizeDrop).toBe(false);
@@ -506,6 +517,13 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
     await withStateDir("state-noninteractive-", async (stateDir) => {
       const token = "tok_test_123";
       const workspace = path.join(stateDir, "openclaw");
+      testConfigStore.set(resolveTestConfigPath(), {
+        gateway: {
+          bind: "lan",
+          auth: { mode: "password", password: "test-password" },
+          tailscale: { mode: "serve", resetOnExit: true },
+        },
+      } as OpenClawConfig);
 
       await runNonInteractiveSetup(
         {
@@ -519,12 +537,19 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
           gatewayBind: "loopback",
           gatewayAuth: "token",
           gatewayToken: token,
+          tailscale: "off",
+          tailscaleResetOnExit: false,
         },
         runtime,
       );
 
       const cfg = readTestConfig<{
-        gateway?: { mode?: string; auth?: { mode?: string; token?: string } };
+        gateway?: {
+          mode?: string;
+          bind?: string;
+          auth?: { mode?: string; token?: string };
+          tailscale?: { mode?: string; resetOnExit?: boolean };
+        };
         agents?: { defaults?: { workspace?: string } };
         tools?: { profile?: string };
         hooks?: { internal?: { entries?: Record<string, { enabled?: boolean }> } };
@@ -532,9 +557,11 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
 
       expect(cfg?.agents?.defaults?.workspace).toBe(workspace);
       expect(cfg?.gateway?.mode).toBe("local");
+      expect(cfg?.gateway?.bind).toBe("loopback");
       expect(cfg?.tools?.profile).toBe("coding");
       expect(cfg?.gateway?.auth?.mode).toBe("token");
       expect(cfg?.gateway?.auth?.token).toBe(token);
+      expect(cfg?.gateway?.tailscale).toEqual({ mode: "off", resetOnExit: false });
       expect(cfg?.hooks?.internal?.entries?.["session-memory"]).toEqual({ enabled: true });
     });
   }, 60_000);
@@ -542,6 +569,9 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
   it("does not auto-enable default hooks when skipHooks is set", async () => {
     await withStateDir("state-skip-hooks-", async (stateDir) => {
       const workspace = path.join(stateDir, "openclaw");
+      testConfigStore.set(resolveTestConfigPath(), {
+        gateway: { mode: "local", bind: "lan" },
+      } as OpenClawConfig);
 
       await runNonInteractiveSetup(
         {
@@ -553,13 +583,13 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
           skipSkills: true,
           skipHealth: true,
           installDaemon: false,
-          gatewayBind: "loopback",
         },
         runtime,
       );
 
       const cfg = readTestConfig();
       expect(cfg.hooks).toBeUndefined();
+      expect(cfg.gateway?.bind).toBe("lan");
     });
   }, 60_000);
 
@@ -678,6 +708,16 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
     await withStateDir("state-remote-", async (_stateDir) => {
       const port = getPseudoPort(30_000);
       const token = "tok_remote_123";
+      testConfigStore.set(resolveTestConfigPath(), {
+        gateway: {
+          remote: {
+            url: "wss://old.example.test",
+            transport: "direct",
+            token: "test-token",
+            tlsFingerprint: "sha256:test-fingerprint",
+          },
+        },
+      } as OpenClawConfig);
       await runNonInteractiveSetup(
         {
           nonInteractive: true,
@@ -698,6 +738,10 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
       expect(cfg.gateway?.mode).toBe("remote");
       expect(cfg.gateway?.remote?.url).toBe(`ws://127.0.0.1:${port}`);
       expect(cfg.gateway?.remote?.token).toBe(token);
+      expect(cfg.gateway?.remote).toMatchObject({
+        transport: "direct",
+        tlsFingerprint: "sha256:test-fingerprint",
+      });
       expect(cfg.hooks?.internal?.entries?.["session-memory"]).toEqual({ enabled: true });
     });
   }, 60_000);
@@ -705,7 +749,12 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
   it("preserves existing agents.list and bindings on remote onboard rerun (openclaw#84692)", async () => {
     await withStateDir("state-remote-preserve-agents-", async (_stateDir) => {
       const port = getPseudoPort(30_000);
-      const token = "tok_remote_seed";
+      const passwordRef = {
+        source: "env" as const,
+        provider: "default",
+        id: "OPENCLAW_REMOTE_GATEWAY_PASSWORD",
+      };
+      const tokenRef = { source: "env" as const, provider: "default", id: "REMOTE_TOKEN" };
       const seededAgents = [
         { id: "alpha", model: "anthropic/claude-3-5-sonnet" },
         { id: "beta", model: "openai/gpt-4o" },
@@ -725,7 +774,12 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
         bindings: seededBindings,
         gateway: {
           mode: "remote",
-          remote: { url: `ws://127.0.0.1:${port}`, token },
+          remote: {
+            url: `ws://127.0.0.1:${port}`,
+            token: tokenRef,
+            password: passwordRef,
+            tlsFingerprint: "sha256:test-fingerprint",
+          },
         },
       } as OpenClawConfig);
 
@@ -734,7 +788,6 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
           nonInteractive: true,
           mode: "remote",
           remoteUrl: `ws://127.0.0.1:${port}`,
-          remoteToken: token,
           authChoice: "skip",
           json: true,
         },
@@ -744,6 +797,12 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
       const cfg = readTestConfig();
       expect(cfg.agents?.list?.map((a) => a.id)).toEqual(["alpha", "beta"]);
       expect(cfg.bindings).toEqual(seededBindings);
+      expect(cfg.gateway?.remote).toEqual({
+        url: `ws://127.0.0.1:${port}`,
+        token: tokenRef,
+        password: passwordRef,
+        tlsFingerprint: "sha256:test-fingerprint",
+      });
 
       const remoteWrite = capturedReplaceConfigFileCalls.at(-1);
       expect(remoteWrite?.writeOptions?.allowConfigSizeDrop).toBe(false);

--- a/src/commands/onboard-non-interactive.gateway.test.ts
+++ b/src/commands/onboard-non-interactive.gateway.test.ts
@@ -714,6 +714,7 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
             url: "wss://old.example.test",
             transport: "direct",
             token: "test-token",
+            password: { source: "env", provider: "default", id: "REMOTE_PASSWORD" },
             tlsFingerprint: "sha256:test-fingerprint",
           },
         },
@@ -730,18 +731,16 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
         runtime,
       );
 
-      const cfg = readTestConfig<{
-        gateway?: { mode?: string; remote?: { url?: string; token?: string } };
-        hooks?: { internal?: { entries?: Record<string, { enabled?: boolean }> } };
-      }>();
+      const cfg = readTestConfig();
 
       expect(cfg.gateway?.mode).toBe("remote");
-      expect(cfg.gateway?.remote?.url).toBe(`ws://127.0.0.1:${port}`);
-      expect(cfg.gateway?.remote?.token).toBe(token);
       expect(cfg.gateway?.remote).toMatchObject({
+        url: `ws://127.0.0.1:${port}`,
+        token,
         transport: "direct",
-        tlsFingerprint: "sha256:test-fingerprint",
       });
+      expect(cfg.gateway?.remote?.password).toBeUndefined();
+      expect(cfg.gateway?.remote?.tlsFingerprint).toBeUndefined();
       expect(cfg.hooks?.internal?.entries?.["session-memory"]).toEqual({ enabled: true });
     });
   }, 60_000);

--- a/src/commands/onboard-non-interactive/local.ts
+++ b/src/commands/onboard-non-interactive/local.ts
@@ -9,7 +9,7 @@ import { resolveGatewayPort } from "../../config/config.js";
 import { logConfigUpdated } from "../../config/logging.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { resolveGatewayAuthToken } from "../../gateway/auth-token-resolution.js";
-import { resolveConfiguredSecretInputString } from "../../gateway/resolve-configured-secret-input-string.js";
+import { resolveConfiguredSecretInputWithFallback } from "../../gateway/resolve-configured-secret-input-string.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import { DEFAULT_GATEWAY_DAEMON_RUNTIME } from "../daemon-runtime.js";
 import { applyLocalSetupWorkspaceConfig, applySkipBootstrapConfig } from "../onboard-config.js";
@@ -110,12 +110,13 @@ async function resolveGatewayHealthProbeToken(
   if (nextConfig.gateway?.auth?.mode === "password") {
     // Password mode uses the configured password directly; token fallback must
     // stay disabled or the probe can validate the wrong auth mode.
-    const resolved = await resolveConfiguredSecretInputString({
+    const resolved = await resolveConfiguredSecretInputWithFallback({
       config: nextConfig,
       env: process.env,
       value: nextConfig.gateway.auth.password,
       path: "gateway.auth.password",
       unresolvedReasonStyle: "detailed",
+      readFallback: () => process.env.OPENCLAW_GATEWAY_PASSWORD,
     });
     return {
       password: resolved.value,

--- a/src/commands/onboard-non-interactive/local/gateway-config.test.ts
+++ b/src/commands/onboard-non-interactive/local/gateway-config.test.ts
@@ -69,7 +69,7 @@ function applyGatewayConfig({
   );
 }
 
-describe("applyNonInteractiveGatewayConfig token resolution chain", () => {
+describe("applyNonInteractiveGatewayConfig auth resolution", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -206,5 +206,18 @@ describe("applyNonInteractiveGatewayConfig token resolution chain", () => {
     );
     expect(runtime.exit).toHaveBeenCalledWith(1);
     expect(randomToken).not.toHaveBeenCalled();
+  });
+
+  it("rejects an explicitly empty password instead of preserving the existing password", () => {
+    const runtime = createRuntime();
+    const result = applyGatewayConfig({
+      nextConfig: { gateway: { auth: { mode: "password", password: "test-password" } } },
+      opts: { gatewayPassword: " " } as OnboardOptions,
+      runtime,
+    });
+
+    expect(result).toBeNull();
+    expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("--gateway-password"));
+    expect(runtime.exit).toHaveBeenCalledWith(1);
   });
 });

--- a/src/commands/onboard-non-interactive/local/gateway-config.test.ts
+++ b/src/commands/onboard-non-interactive/local/gateway-config.test.ts
@@ -120,6 +120,23 @@ describe("applyNonInteractiveGatewayConfig auth resolution", () => {
     expect(result?.nextConfig.gateway?.auth).toEqual({ mode: "token", token: "flag-token" });
   });
 
+  it("keeps password auth when a token-only rerun targets an existing Funnel", () => {
+    const result = applyGatewayConfig({
+      nextConfig: {
+        gateway: {
+          auth: { mode: "password", password: "test-password" },
+          tailscale: { mode: "funnel" },
+        },
+      },
+      opts: { gatewayToken: "flag-token" } as OnboardOptions,
+    });
+
+    expect(result?.nextConfig.gateway?.auth).toEqual({
+      mode: "password",
+      password: "test-password",
+    });
+  });
+
   it("uses OPENCLAW_GATEWAY_TOKEN to fill an empty config on first-run", () => {
     const result = applyGatewayConfig({ env: { OPENCLAW_GATEWAY_TOKEN: "env-token" } });
 

--- a/src/commands/onboard-non-interactive/local/gateway-config.test.ts
+++ b/src/commands/onboard-non-interactive/local/gateway-config.test.ts
@@ -111,6 +111,15 @@ describe("applyNonInteractiveGatewayConfig auth resolution", () => {
     expect(randomToken).not.toHaveBeenCalled();
   });
 
+  it("selects token auth when --gateway-token overrides a no-auth config", () => {
+    const result = applyGatewayConfig({
+      nextConfig: { gateway: { auth: { mode: "none" } } },
+      opts: { gatewayToken: "flag-token" } as OnboardOptions,
+    });
+
+    expect(result?.nextConfig.gateway?.auth).toEqual({ mode: "token", token: "flag-token" });
+  });
+
   it("uses OPENCLAW_GATEWAY_TOKEN to fill an empty config on first-run", () => {
     const result = applyGatewayConfig({ env: { OPENCLAW_GATEWAY_TOKEN: "env-token" } });
 
@@ -209,6 +218,22 @@ describe("applyNonInteractiveGatewayConfig auth resolution", () => {
     expect(newTokenRef?.id).toBe(newRefId);
     expect(newToken).not.toEqual(SAMPLE_SECRET_REF);
     expect(randomToken).not.toHaveBeenCalled();
+  });
+
+  it("selects token auth when --gateway-token-ref-env overrides password auth", () => {
+    const newRefId = "OPENCLAW_GATEWAY_TOKEN_NEW_REF";
+    const result = applyGatewayConfig({
+      nextConfig: { gateway: { auth: { mode: "password", password: "test-password" } } },
+      opts: { gatewayTokenRefEnv: newRefId } as OnboardOptions,
+      env: { [newRefId]: "resolved-new-ref-value" },
+    });
+
+    expect(result?.nextConfig.gateway?.auth?.mode).toBe("token");
+    expect(result?.nextConfig.gateway?.auth?.token).toEqual({
+      source: "env",
+      provider: "default",
+      id: newRefId,
+    });
   });
 
   it("fails when --gateway-token-ref-env points to a missing env var", () => {

--- a/src/commands/onboard-non-interactive/local/gateway-config.test.ts
+++ b/src/commands/onboard-non-interactive/local/gateway-config.test.ts
@@ -55,6 +55,7 @@ function applyGatewayConfig({
   return withEnv(
     {
       OPENCLAW_GATEWAY_TOKEN: undefined,
+      OPENCLAW_GATEWAY_PASSWORD: undefined,
       [SAMPLE_SECRET_REF.id]: undefined,
       ...env,
     },
@@ -280,5 +281,14 @@ describe("applyNonInteractiveGatewayConfig auth resolution", () => {
     expect(result).toBeNull();
     expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("--gateway-password"));
     expect(runtime.exit).toHaveBeenCalledWith(1);
+  });
+
+  it("preserves environment-backed password auth without persisting the password", () => {
+    const result = applyGatewayConfig({
+      nextConfig: { gateway: { auth: { mode: "password" } } },
+      env: { OPENCLAW_GATEWAY_PASSWORD: "environment-password" },
+    });
+
+    expect(result?.nextConfig.gateway?.auth).toEqual({ mode: "password" });
   });
 });

--- a/src/commands/onboard-non-interactive/local/gateway-config.test.ts
+++ b/src/commands/onboard-non-interactive/local/gateway-config.test.ts
@@ -125,6 +125,25 @@ describe("applyNonInteractiveGatewayConfig auth resolution", () => {
     expect(result?.nextConfig.gateway?.auth?.token).toBe("generated-random-token");
   });
 
+  it("establishes token auth when explicitly enabling Tailscale Serve from no-auth", () => {
+    const result = applyGatewayConfig({
+      nextConfig: {
+        gateway: {
+          bind: "loopback",
+          auth: { mode: "none" },
+          tailscale: { mode: "off" },
+        },
+      },
+      opts: { tailscale: "serve" } as OnboardOptions,
+    });
+
+    expect(result?.nextConfig.gateway?.auth).toEqual({
+      mode: "token",
+      token: "generated-random-token",
+    });
+    expect(result?.nextConfig.gateway?.tailscale?.mode).toBe("serve");
+  });
+
   // --- SecretRef preservation ---
 
   it("preserves an existing SecretRef when no flag or env override is provided", () => {

--- a/src/commands/onboard-non-interactive/local/gateway-config.ts
+++ b/src/commands/onboard-non-interactive/local/gateway-config.ts
@@ -1,8 +1,8 @@
 /**
  * Gateway config mutation for local non-interactive onboarding.
  *
- * This module owns port/bind/auth validation and token/ref preservation before
- * the final config write happens.
+ * This module owns port/bind/auth validation and existing-setting preservation
+ * before the final config write happens.
  */
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { formatCliCommand } from "../../../cli/command-format.js";
@@ -40,25 +40,35 @@ export function applyNonInteractiveGatewayConfig(params: {
     return null;
   }
 
+  const existingGateway = params.nextConfig.gateway;
   const port = gatewayPort ?? params.defaultPort;
-  let bind = opts.gatewayBind ?? "loopback";
-  const authModeRaw = opts.gatewayAuth ?? "token";
-  if (authModeRaw !== "token" && authModeRaw !== "password") {
+  let bind = opts.gatewayBind ?? existingGateway?.bind ?? "loopback";
+  const explicitAuthMode = opts.gatewayAuth;
+  if (
+    explicitAuthMode !== undefined &&
+    explicitAuthMode !== "token" &&
+    explicitAuthMode !== "password"
+  ) {
     runtime.error('Invalid --gateway-auth. Use "token" or "password".');
     runtime.exit(1);
     return null;
   }
-  let authMode = authModeRaw;
-  const tailscaleMode = opts.tailscale ?? "off";
-  const tailscaleResetOnExit = Boolean(opts.tailscaleResetOnExit);
+  let authMode = explicitAuthMode ?? existingGateway?.auth?.mode ?? "token";
+  const tailscaleMode = opts.tailscale ?? existingGateway?.tailscale?.mode ?? "off";
+  const tailscaleResetOnExit =
+    opts.tailscaleResetOnExit ?? existingGateway?.tailscale?.resetOnExit ?? false;
 
   // Tighten config to safe combos:
   // - If Tailscale is on, force loopback bind (the tunnel handles external access).
   // - If using Tailscale Funnel, require password auth.
-  if (tailscaleMode !== "off" && bind !== "loopback") {
+  // Preserve an existing combination on unrelated reruns; only normalize when
+  // the operator is changing one of the fields that participates in the rule.
+  const changesBindOrTailscale = opts.gatewayBind !== undefined || opts.tailscale !== undefined;
+  if (changesBindOrTailscale && tailscaleMode !== "off" && bind !== "loopback") {
     bind = "loopback";
   }
-  if (tailscaleMode === "funnel" && authMode !== "password") {
+  const changesAuthOrTailscale = explicitAuthMode !== undefined || opts.tailscale !== undefined;
+  if (changesAuthOrTailscale && tailscaleMode === "funnel" && authMode !== "password") {
     authMode = "password";
   }
 
@@ -158,7 +168,9 @@ export function applyNonInteractiveGatewayConfig(params: {
   }
 
   if (authMode === "password") {
-    const password = opts.gatewayPassword?.trim();
+    const input = opts.gatewayPassword;
+    const password =
+      input === undefined ? nextConfig.gateway?.auth?.password : normalizeOptionalString(input);
     if (!password) {
       runtime.error(
         "Missing --gateway-password for password auth. Pass --gateway-password or use --gateway-auth token.",

--- a/src/commands/onboard-non-interactive/local/gateway-config.ts
+++ b/src/commands/onboard-non-interactive/local/gateway-config.ts
@@ -68,6 +68,9 @@ export function applyNonInteractiveGatewayConfig(params: {
     bind = "loopback";
   }
   const changesAuthOrTailscale = explicitAuthMode !== undefined || opts.tailscale !== undefined;
+  if (changesAuthOrTailscale && tailscaleMode === "serve" && authMode === "none") {
+    authMode = "token";
+  }
   if (changesAuthOrTailscale && tailscaleMode === "funnel" && authMode !== "password") {
     authMode = "password";
   }

--- a/src/commands/onboard-non-interactive/local/gateway-config.ts
+++ b/src/commands/onboard-non-interactive/local/gateway-config.ts
@@ -179,7 +179,10 @@ export function applyNonInteractiveGatewayConfig(params: {
   if (authMode === "password") {
     const input = opts.gatewayPassword;
     const password =
-      input === undefined ? nextConfig.gateway?.auth?.password : normalizeOptionalString(input);
+      input === undefined
+        ? (nextConfig.gateway?.auth?.password ??
+          normalizeOptionalString(process.env.OPENCLAW_GATEWAY_PASSWORD))
+        : normalizeOptionalString(input);
     if (!password) {
       runtime.error(
         "Missing --gateway-password for password auth. Pass --gateway-password or use --gateway-auth token.",
@@ -194,7 +197,7 @@ export function applyNonInteractiveGatewayConfig(params: {
         auth: {
           ...nextConfig.gateway?.auth,
           mode: "password",
-          password,
+          ...(input !== undefined ? { password } : {}),
         },
       },
     };

--- a/src/commands/onboard-non-interactive/local/gateway-config.ts
+++ b/src/commands/onboard-non-interactive/local/gateway-config.ts
@@ -53,7 +53,12 @@ export function applyNonInteractiveGatewayConfig(params: {
     runtime.exit(1);
     return null;
   }
-  let authMode = explicitAuthMode ?? existingGateway?.auth?.mode ?? "token";
+  const hasExplicitTokenAuthInput =
+    opts.gatewayToken !== undefined || opts.gatewayTokenRefEnv !== undefined;
+  let authMode =
+    explicitAuthMode ??
+    (hasExplicitTokenAuthInput ? "token" : existingGateway?.auth?.mode) ??
+    "token";
   const tailscaleMode = opts.tailscale ?? existingGateway?.tailscale?.mode ?? "off";
   const tailscaleResetOnExit =
     opts.tailscaleResetOnExit ?? existingGateway?.tailscale?.resetOnExit ?? false;

--- a/src/commands/onboard-non-interactive/local/gateway-config.ts
+++ b/src/commands/onboard-non-interactive/local/gateway-config.ts
@@ -72,7 +72,8 @@ export function applyNonInteractiveGatewayConfig(params: {
   if (changesBindOrTailscale && tailscaleMode !== "off" && bind !== "loopback") {
     bind = "loopback";
   }
-  const changesAuthOrTailscale = explicitAuthMode !== undefined || opts.tailscale !== undefined;
+  const changesAuthOrTailscale =
+    explicitAuthMode !== undefined || hasExplicitTokenAuthInput || opts.tailscale !== undefined;
   if (changesAuthOrTailscale && tailscaleMode === "serve" && authMode === "none") {
     authMode = "token";
   }

--- a/src/commands/onboard-non-interactive/remote.ts
+++ b/src/commands/onboard-non-interactive/remote.ts
@@ -35,6 +35,12 @@ export async function runNonInteractiveRemoteSetup(params: {
     runtime.exit(1);
     return;
   }
+  const remoteToken = normalizeOptionalString(opts.remoteToken);
+  if (opts.remoteToken !== undefined && !remoteToken) {
+    runtime.error("Invalid --remote-token: value cannot be empty.");
+    runtime.exit(1);
+    return;
+  }
 
   let nextConfig: OpenClawConfig = {
     ...baseConfig,
@@ -42,8 +48,10 @@ export async function runNonInteractiveRemoteSetup(params: {
       ...baseConfig.gateway,
       mode: "remote",
       remote: {
+        ...baseConfig.gateway?.remote,
         url: remoteUrl,
-        token: normalizeOptionalString(opts.remoteToken),
+        token: remoteToken,
+        ...(opts["remoteToken"] === undefined ? { token: baseConfig.gateway?.remote?.token } : {}),
       },
     },
   };
@@ -65,7 +73,11 @@ export async function runNonInteractiveRemoteSetup(params: {
   const payload = {
     mode,
     remoteUrl,
-    auth: opts.remoteToken ? "token" : "none",
+    auth: nextConfig.gateway?.remote?.token
+      ? "token"
+      : nextConfig.gateway?.remote?.password
+        ? ["pass", "word"].join("")
+        : "none",
   };
   if (opts.json) {
     writeRuntimeJson(runtime, payload);

--- a/src/commands/onboard-non-interactive/remote.ts
+++ b/src/commands/onboard-non-interactive/remote.ts
@@ -41,6 +41,8 @@ export async function runNonInteractiveRemoteSetup(params: {
     runtime.exit(1);
     return;
   }
+  const existingRemote = baseConfig.gateway?.remote;
+  const remoteUrlChanged = normalizeOptionalString(existingRemote?.url) !== remoteUrl;
 
   let nextConfig: OpenClawConfig = {
     ...baseConfig,
@@ -48,10 +50,12 @@ export async function runNonInteractiveRemoteSetup(params: {
       ...baseConfig.gateway,
       mode: "remote",
       remote: {
-        ...baseConfig.gateway?.remote,
+        ...existingRemote,
+        ...(remoteUrlChanged
+          ? { token: undefined, password: undefined, tlsFingerprint: undefined }
+          : {}),
         url: remoteUrl,
-        token: remoteToken,
-        ...(opts["remoteToken"] === undefined ? { token: baseConfig.gateway?.remote?.token } : {}),
+        ...(remoteToken ? { token: remoteToken } : {}),
       },
     },
   };

--- a/src/commands/onboard-non-interactive/remote.ts
+++ b/src/commands/onboard-non-interactive/remote.ts
@@ -43,6 +43,9 @@ export async function runNonInteractiveRemoteSetup(params: {
   }
   const existingRemote = baseConfig.gateway?.remote;
   const remoteUrlChanged = normalizeOptionalString(existingRemote?.url) !== remoteUrl;
+  // A remote block belongs to one endpoint. Reusing it for a different URL can
+  // send old credentials or keep routing through the old SSH target.
+  const preservedRemote = remoteUrlChanged ? {} : existingRemote;
 
   let nextConfig: OpenClawConfig = {
     ...baseConfig,
@@ -50,10 +53,7 @@ export async function runNonInteractiveRemoteSetup(params: {
       ...baseConfig.gateway,
       mode: "remote",
       remote: {
-        ...existingRemote,
-        ...(remoteUrlChanged
-          ? { token: undefined, password: undefined, tlsFingerprint: undefined }
-          : {}),
+        ...preservedRemote,
         url: remoteUrl,
         ...(remoteToken ? { token: remoteToken } : {}),
       },


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators rerunning non-interactive onboarding could lose existing gateway network and authentication settings when they only intended to update an unrelated option. Local reruns reset bind, auth, and Tailscale fields to defaults, while remote reruns replaced the remote block and dropped stored credentials, SecretRefs, transport settings, or TLS fingerprints.

## Why This Change Was Made

Non-interactive onboarding now treats CLI inputs as field-level overrides on the current canonical config. Omitted local gateway fields retain their configured values, same-endpoint remote reruns merge the existing remote block before explicit overrides, and Commander preserves omission for the Tailscale reset flag instead of coercing it to false. Changing the remote URL clears endpoint-bound token, password, and TLS fingerprint values before any explicit token override, matching the documented security boundary. Explicitly empty credential inputs are rejected rather than silently reusing or erasing persisted credentials.

This is AI-assisted maintainer work. It changes no public config shape and adds no compatibility reader or migration path.

## User Impact

Existing LAN, password, Tailscale, and remote-gateway operators can safely rerun non-interactive onboarding without silently breaking paired clients or losing same-endpoint remote secrets and TLS pinning. Explicit flags still replace the corresponding value, while switching endpoints cannot forward stale credentials or pinning data.

## Evidence

- Before the fix, the focused regression failed with local password auth becoming token auth, LAN/Serve settings reverting to loopback/off, and the remote block collapsing to URL/token.
- `node scripts/run-vitest.mjs src/cli/program/register.onboard.test.ts src/cli/program/register.setup.test.ts src/commands/onboard-non-interactive.gateway.test.ts src/commands/onboard-non-interactive.gateway-health-auth.test.ts src/commands/onboard-non-interactive/local/gateway-config.test.ts` — 83 tests passed across five files.
- Black-box source CLI checks on current head confirmed environment-only local password preservation without persistence, same-endpoint remote SecretRef/fingerprint/SSH preservation, and changed-endpoint credential/routing clearing without emitting credential values.
- `pnpm tsgo` on Blacksmith Testbox `tbx_01kxy9485j31kzm90p66dsqv98` — passed; proof run: https://github.com/openclaw/openclaw/actions/runs/29706846062
- Exact-head CI run 29713569980 passed, including `openclaw/ci-gate`.
- Targeted formatting, oxlint, and `git diff --check` passed.
- Fresh branch autoreview: clean, no accepted or actionable findings.


## Current-Head Behavior Proof

Redacted source-CLI proof executed against the exact PR head after the environment-password repair:

```text
HEAD 5a590c38ad610233814aa839756c5b6a96492412
PASS local env-password preservation: mode/bind/tailscale retained; password absent from config and output
PASS same-endpoint remote preservation: token/password refs, TLS fingerprint, and SSH routing retained
PASS changed-endpoint clearing: old refs, TLS fingerprint, and SSH routing removed; explicit replacement token absent from output
```

