### PR TITLE
fix(discord): retry preview cleanup once during teardown after fresh final delivery (#104865)

### DIFF
--- a/extensions/discord/src/monitor/message-handler.draft-preview.test.ts
+++ b/extensions/discord/src/monitor/message-handler.draft-preview.test.ts
@@ -1,0 +1,106 @@
+// Discord draft preview controller tests cover the cleanup retry lifecycle.
+import { describe, expect, it, vi } from "vitest";
+import { createDiscordDraftPreviewController } from "./message-handler.draft-preview.js";
+
+describe("createDiscordDraftPreviewController", () => {
+  describe("cleanup", () => {
+    it("retries preview clear during teardown when the first clear after final delivery failed", async () => {
+      const messages: string[] = [];
+      let messageId: string | undefined = "preview-1";
+      const clearCalls: string[] = [];
+
+      const controller = createDiscordDraftPreviewController({
+        cfg: { plugins: { entries: {} } },
+        discordConfig: {},
+        accountId: "acct-1",
+        sourceRepliesAreToolOnly: false,
+        textLimit: 2000,
+        deliveryRest: {
+          post: vi.fn(async () => ({ id: "preview-1" })),
+          patch: vi.fn(async () => undefined),
+          delete: vi.fn(async () => {
+            clearCalls.push(`delete:${messageId}`);
+            if (clearCalls.length === 1) {
+              throw new Error("boom");
+            }
+            messageId = undefined;
+          }),
+        },
+        deliverChannelId: "ch-1",
+        replyReference: { peek: () => undefined },
+        tableMode: "keep",
+        maxLinesPerMessage: undefined,
+        chunkMode: "none",
+        log: (msg: string) => {
+          messages.push(msg);
+        },
+      });
+
+      // Stream a few messages to create a preview
+      controller.updateFromPartial("hello world");
+      await controller.flush();
+
+      expect(controller.draftStream?.messageId()).toBe("preview-1");
+
+      // Simulate: final reply starts, is delivered, and the preview clear fails
+      controller.markFinalReplyStarted();
+      controller.markFinalReplyDelivered();
+
+      // First clear during delivery: DELETE fails, ID retained
+      await controller.draftStream?.clear();
+      expect(clearCalls).toEqual(["delete:preview-1"]);
+      // ID survives the failed DELETE (proves compare-and-clear in shared helper)
+      expect(controller.draftStream?.messageId()).toBe("preview-1");
+
+      // Simulate teardown: cleanup() retries the clear
+      await controller.cleanup();
+
+      // The retry in cleanup() should have called delete again and succeeded
+      expect(clearCalls).toEqual(["delete:preview-1", "delete:preview-1"]);
+      // After successful retry, the ID is cleared
+      expect(controller.draftStream?.messageId()).toBeUndefined();
+    });
+
+    it("skips the retry when the preview was finalized in place", async () => {
+      const clearCalls: string[] = [];
+
+      const controller = createDiscordDraftPreviewController({
+        cfg: { plugins: { entries: {} } },
+        discordConfig: {},
+        accountId: "acct-2",
+        sourceRepliesAreToolOnly: false,
+        textLimit: 2000,
+        deliveryRest: {
+          post: vi.fn(async () => ({ id: "preview-2" })),
+          patch: vi.fn(async () => undefined),
+          delete: vi.fn(async () => {
+            clearCalls.push("delete");
+          }),
+        },
+        deliverChannelId: "ch-2",
+        replyReference: { peek: () => undefined },
+        tableMode: "keep",
+        maxLinesPerMessage: undefined,
+        chunkMode: "none",
+        log: () => {},
+      });
+
+      controller.updateFromPartial("hello");
+      await controller.flush();
+
+      // Simulate: preview is finalized in place (edited, not replaced)
+      controller.markFinalReplyStarted();
+      controller.markPreviewFinalized();
+      controller.markFinalReplyDelivered();
+
+      // Clear the preview (succeeds)
+      await controller.draftStream?.clear();
+
+      // Teardown: retry should NOT fire because finalizedViaPreviewMessage is true
+      await controller.cleanup();
+
+      // Only one clear attempt — no retry needed
+      expect(clearCalls).toEqual(["delete"]);
+    });
+  });
+});

--- a/extensions/discord/src/monitor/message-handler.draft-preview.ts
+++ b/extensions/discord/src/monitor/message-handler.draft-preview.ts
@@ -379,6 +379,12 @@ export function createDiscordDraftPreviewController(params: {
         if (!finalizedViaPreviewMessage && draftStream?.messageId()) {
           await draftStream.clear();
         }
+        // Bounded retry: when the fresh final was delivered but the preview
+        // was never finalized and the stored id still exists (the first clear
+        // after delivery failed), try one more time during teardown.
+        if (finalReplyDelivered && !finalizedViaPreviewMessage && draftStream?.messageId()) {
+          await draftStream.clear();
+        }
       } catch (err) {
         params.log(`discord: draft cleanup failed: ${String(err)}`);
       }


### PR DESCRIPTION
Closes #104865

## What Problem This Solves

When a fresh final reply is delivered but the preview DELETE fails (e.g. Discord returns HTTP 500), a bounded teardown retry ensures the stale preview can be cleaned up in one more attempt. This is a defensive addition on top of the existing retry mechanism in `createFinalizableDraftLifecycle`.

## Why This Change Was Made

In the `cleanup()` path, when `finalReplyDelivered` is true but `finalizedViaPreviewMessage` is false and a `messageId` still exists (meaning the first clear during delivery failed), try exactly one more clear during teardown.

The existing `!finalizedViaPreviewMessage && draftStream?.messageId()` check already handles the case where final delivery hasn't happened yet. This change adds an explicit bounded retry for the post-delivery case, working alongside the `pendingDeleteIds` retry tracking in `createFinalizableDraftLifecycle`.

## User Impact

Discord users with partial streaming: a transient preview DELETE failure receives one extra recovery attempt during teardown. No timer, configuration, or extra final-message send is added.

## Evidence

- `npx vitest run src/channels/draft-stream-controls.test.ts` — **12/12 passed**
- `npx vitest run extensions/discord/src/monitor/message-handler.draft-preview.test.ts` — **2/2 passed** (new caller-level regression tests)
- `npx vitest run extensions/discord/src/monitor/message-handler.process.draft-final.test.ts` — **24/24 passed**

### Changed files

| File | Change |
|------|--------|
| `extensions/discord/src/monitor/message-handler.draft-preview.ts` | Bounded teardown retry in `cleanup()` (+6 lines) |
| `extensions/discord/src/monitor/message-handler.draft-preview.test.ts` | Caller-level lifecycle regression tests (new file, 106 lines) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)