### PR TITLE
fix(release): bound beta verifier command execution

### DIFF
--- a/scripts/lib/release-beta-verifier.ts
+++ b/scripts/lib/release-beta-verifier.ts
@@ -91,6 +91,10 @@ const TRUSTED_TOOLING_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), ".
 // verifier on the same release train instead of forcing a republish/correction.
 const NPM_VIEW_ATTEMPTS = 30;
 const NPM_VIEW_RETRY_MAX_DELAY_MS = 10_000;
+// Bounds every subprocess spawned by the verifier (npm view, gh api, git
+// rev-parse, postpublish verifier) so a stalled registry, API, or local
+// process cannot hang the release verification indefinitely.
+const RELEASE_COMMAND_TIMEOUT_MS = 120_000;
 
 function compareCodeUnits(left: string, right: string): number {
   return left < right ? -1 : left > right ? 1 : 0;
@@ -146,12 +150,16 @@ function runCommand(command: string, args: string[], options: { cwd?: string } =
     cwd: options.cwd,
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"],
+    timeout: RELEASE_COMMAND_TIMEOUT_MS,
+    killSignal: "SIGKILL",
   }).trim();
 }
 
 function runCommandInherited(command: string, args: string[]): void {
   execFileSync(command, args, {
     stdio: "inherit",
+    timeout: RELEASE_COMMAND_TIMEOUT_MS,
+    killSignal: "SIGKILL",
   });
 }
 

--- a/scripts/lib/release-beta-verifier.ts
+++ b/scripts/lib/release-beta-verifier.ts
@@ -93,6 +93,8 @@ const TRUSTED_TOOLING_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), ".
 // verifier on the same release train instead of forcing a republish/correction.
 const NPM_VIEW_ATTEMPTS = 30;
 const NPM_VIEW_RETRY_MAX_DELAY_MS = 10_000;
+const RELEASE_COMMAND_TIMEOUT_MS = 120_000;
+const RELEASE_COMMAND_MAX_BUFFER_BYTES = 4 * 1024 * 1024;
 
 function compareCodeUnits(left: string, right: string): number {
   return left < right ? -1 : left > right ? 1 : 0;
@@ -135,18 +137,31 @@ function readTrustedClawHubToolchainIdentity(): {
   };
 }
 
-function runCommand(command: string, args: string[], options: { cwd?: string } = {}): string {
+export function runReleaseVerifierCommand(
+  command: string,
+  args: string[],
+  options: { cwd?: string; maxBufferBytes?: number; timeoutMs?: number } = {},
+): string {
   return execFileSync(command, args, {
     cwd: options.cwd,
     encoding: "utf8",
+    killSignal: "SIGKILL",
+    maxBuffer: options.maxBufferBytes ?? RELEASE_COMMAND_MAX_BUFFER_BYTES,
     stdio: ["ignore", "pipe", "pipe"],
+    timeout: options.timeoutMs ?? RELEASE_COMMAND_TIMEOUT_MS,
   }).trim();
 }
 
-function runCommandInherited(command: string, args: string[]): void {
-  execFileSync(command, args, {
-    stdio: "inherit",
-  });
+function isNpmPropagationError(error: unknown): boolean {
+  if (!isJsonRecord(error)) {
+    return false;
+  }
+  const details = [error.code, error.message, error.stderr]
+    .map((value) =>
+      Buffer.isBuffer(value) ? value.toString("utf8") : typeof value === "string" ? value : "",
+    )
+    .join("\n");
+  return /\b(?:E404|ETARGET)\b|No match found for version/u.test(details);
 }
 
 export async function runNpmViewWithRetry(
@@ -164,13 +179,16 @@ export async function runNpmViewWithRetry(
       new Promise((resolveDelay) => {
         setTimeout(resolveDelay, delayMs);
       }));
-  const run = options.run ?? ((npmArgs: string[]) => runCommand("npm", npmArgs));
+  const run = options.run ?? ((npmArgs: string[]) => runReleaseVerifierCommand("npm", npmArgs));
   let lastError: unknown;
 
   for (let attempt = 1; attempt <= attempts; attempt += 1) {
     try {
       return run([...args, "--prefer-online"]);
     } catch (error) {
+      if (!isNpmPropagationError(error)) {
+        throw error;
+      }
       lastError = error;
     }
     if (attempt < attempts) {
@@ -564,7 +582,7 @@ async function verifyClawHubPackage(params: {
 }
 
 function verifyGitHubRelease(params: ReleaseVerifyBetaArgs): string {
-  const raw = runCommand("gh", [
+  const raw = runReleaseVerifierCommand("gh", [
     "release",
     "view",
     params.tag,
@@ -597,7 +615,7 @@ function verifyWorkflowRun(params: {
   allowedHeadBranches?: string[];
   rerunFailed: boolean;
 }): WorkflowRunSummary {
-  const raw = runCommand("gh", [
+  const raw = runReleaseVerifierCommand("gh", [
     "run",
     "view",
     params.id,
@@ -641,7 +659,7 @@ function verifyWorkflowRun(params: {
     );
   });
   if (failedJobs.length > 0 && params.rerunFailed) {
-    runCommandInherited("gh", ["run", "rerun", params.id, "--repo", params.repo, "--failed"]);
+    runReleaseVerifierCommand("gh", ["run", "rerun", params.id, "--repo", params.repo, "--failed"]);
     throw new Error(
       `${params.label}: reran ${failedJobs.length} failed job(s); rerun verifier after it finishes.`,
     );
@@ -1082,12 +1100,14 @@ export function validateClawHubBootstrapEvidence(params: {
 }
 
 function readGitHubApiJson(repo: string, endpoint: string, label: string): unknown {
-  return parseJson(runCommand("gh", ["api", `repos/${repo}/${endpoint}`]), label);
+  return parseJson(runReleaseVerifierCommand("gh", ["api", `repos/${repo}/${endpoint}`]), label);
 }
 
 function readGitHubToken(): string {
   return requireString(
-    process.env.GH_TOKEN ?? process.env.GITHUB_TOKEN ?? runCommand("gh", ["auth", "token"]),
+    process.env.GH_TOKEN ??
+      process.env.GITHUB_TOKEN ??
+      runReleaseVerifierCommand("gh", ["auth", "token"]),
     "GitHub token",
   );
 }
@@ -1276,7 +1296,9 @@ export async function verifyBetaRelease(
     throw new Error(`package.json version is ${rootVersion}; expected ${args.version}.`);
   }
   if (args.releaseSha !== undefined) {
-    const checkedOutSha = runCommand("git", ["rev-parse", "HEAD"], { cwd: rootDir });
+    const checkedOutSha = runReleaseVerifierCommand("git", ["rev-parse", "HEAD"], {
+      cwd: rootDir,
+    });
     if (checkedOutSha !== args.releaseSha) {
       throw new Error(`release checkout SHA is ${checkedOutSha}; expected ${args.releaseSha}.`);
     }
@@ -1298,7 +1320,9 @@ export async function verifyBetaRelease(
       rootDir,
       args.postpublishVerifier,
     );
-    runCommandInherited("node", ["--import", "tsx", postpublishVerifier, args.version]);
+    execFileSync("node", ["--import", "tsx", postpublishVerifier, args.version], {
+      stdio: "inherit",
+    });
     lines.push("openclaw postpublish verifier OK");
   }
 

--- a/test/scripts/release-beta-verifier.test.ts
+++ b/test/scripts/release-beta-verifier.test.ts
@@ -625,8 +625,7 @@ describe("runNpmViewWithRetry", () => {
   it("bounds npm view command execution with a timeout and kill signal", async () => {
     execFileSyncMock.mockReturnValue('"2026.5.10-beta.3"');
     await runNpmViewWithRetry(
-      ["view", "openclaw@2026.5.10-beta.3", "version", "--json"],
-      {
+      ["view", "openclaw@2026.5.10-beta.3", "version", "--json"], {
         attempts: 1,
         delay: async () => {},
       },

--- a/test/scripts/release-beta-verifier.test.ts
+++ b/test/scripts/release-beta-verifier.test.ts
@@ -16,6 +16,13 @@ import {
   validateClawHubBootstrapEvidence,
 } from "../../scripts/lib/release-beta-verifier.ts";
 
+const execFileSyncMock = vi.hoisted(() => vi.fn(() => "{}"));
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const original = await importOriginal();
+  return { ...original, execFileSync: execFileSyncMock };
+});
+
 function sha256(bytes: Uint8Array): string {
   return createHash("sha256").update(bytes).digest("hex");
 }
@@ -610,6 +617,36 @@ describe("parseNpmViewFields", () => {
 });
 
 describe("runNpmViewWithRetry", () => {
+  afterEach(() => {
+    execFileSyncMock.mockReset();
+    execFileSyncMock.mockReturnValue("{}");
+  });
+
+  it("bounds npm view command execution with a timeout and kill signal", async () => {
+    execFileSyncMock.mockReturnValue('"2026.5.10-beta.3"');
+    await runNpmViewWithRetry(
+      ["view", "openclaw@2026.5.10-beta.3", "version", "--json"],
+      {
+        attempts: 1,
+        delay: async () => {},
+      },
+    );
+    expect(execFileSyncMock).toHaveBeenCalledWith(
+      "npm",
+      expect.arrayContaining([
+        "view",
+        "openclaw@2026.5.10-beta.3",
+        "version",
+        "--json",
+        "--prefer-online",
+      ]),
+      expect.objectContaining({
+        timeout: 120_000,
+        killSignal: "SIGKILL",
+      }),
+    );
+  });
+
   it("retries transient registry failures with online metadata reads", async () => {
     const calls: string[][] = [];
     const delays: number[] = [];

--- a/test/scripts/release-beta-verifier.test.ts
+++ b/test/scripts/release-beta-verifier.test.ts
@@ -19,7 +19,7 @@ import {
 const execFileSyncMock = vi.hoisted(() => vi.fn(() => "{}"));
 
 vi.mock("node:child_process", async (importOriginal) => {
-  const original = await importOriginal();
+  const original = (await importOriginal()) as typeof import("node:child_process");
   return { ...original, execFileSync: execFileSyncMock };
 });
 

--- a/test/scripts/release-beta-verifier.test.ts
+++ b/test/scripts/release-beta-verifier.test.ts
@@ -624,12 +624,10 @@ describe("runNpmViewWithRetry", () => {
 
   it("bounds npm view command execution with a timeout and kill signal", async () => {
     execFileSyncMock.mockReturnValue('"2026.5.10-beta.3"');
-    await runNpmViewWithRetry(
-      ["view", "openclaw@2026.5.10-beta.3", "version", "--json"], {
-        attempts: 1,
-        delay: async () => {},
-      },
-    );
+    await runNpmViewWithRetry(["view", "openclaw@2026.5.10-beta.3", "version", "--json"], {
+      attempts: 1,
+      delay: async () => {},
+    });
     expect(execFileSyncMock).toHaveBeenCalledWith(
       "npm",
       expect.arrayContaining([

--- a/test/scripts/release-beta-verifier.test.ts
+++ b/test/scripts/release-beta-verifier.test.ts
@@ -13,8 +13,25 @@ import {
   readBoundedJsonResponse,
   resolveOpenClawNpmPostpublishVerifier,
   runNpmViewWithRetry,
+  runReleaseVerifierCommand,
   validateClawHubBootstrapEvidence,
 } from "../../scripts/lib/release-beta-verifier.ts";
+type CommandError = Error & {
+  code?: string;
+  signal?: NodeJS.Signals;
+  status?: number;
+  stderr?: string;
+  stdout?: string;
+};
+
+function captureCommandError(run: () => unknown): CommandError {
+  try {
+    run();
+  } catch (error) {
+    return error as CommandError;
+  }
+  throw new Error("expected command to fail");
+}
 
 function sha256(bytes: Uint8Array): string {
   return createHash("sha256").update(bytes).digest("hex");
@@ -623,7 +640,9 @@ describe("runNpmViewWithRetry", () => {
         run: (args) => {
           calls.push(args);
           if (calls.length < 3) {
-            throw new Error("npm registry has not propagated the release yet");
+            throw Object.assign(new Error("npm registry has not propagated the release yet"), {
+              code: "E404",
+            });
           }
           return '"2026.5.10-beta.3"';
         },
@@ -633,6 +652,71 @@ describe("runNpmViewWithRetry", () => {
     expect(calls).toHaveLength(3);
     expect(calls.every((args) => args.at(-1) === "--prefer-online")).toBe(true);
     expect(delays).toEqual([1000, 2000]);
+  });
+
+  it("fails a timed-out npm read after one attempt and reaps the child", async () => {
+    const delay = vi.fn(async () => {});
+    let calls = 0;
+    let timeoutError: CommandError | undefined;
+    const result = runNpmViewWithRetry(["view", "openclaw", "version"], {
+      attempts: 3,
+      delay,
+      run: () => {
+        calls += 1;
+        try {
+          return runReleaseVerifierCommand(
+            process.execPath,
+            ["-e", "process.stdout.write(String(process.pid)); setInterval(() => {}, 1000)"],
+            { timeoutMs: 5_000 },
+          );
+        } catch (error) {
+          timeoutError = error as CommandError;
+          throw error;
+        }
+      },
+    });
+    await expect(result).rejects.toMatchObject({ code: "ETIMEDOUT", signal: "SIGKILL" });
+    expect(calls).toBe(1);
+    expect(delay).not.toHaveBeenCalled();
+    const observedTimeoutError = expectDefined(timeoutError, "timeout command error");
+    const childPid = Number(observedTimeoutError.stdout?.trim());
+    expect(Number.isInteger(childPid) && childPid > 0).toBe(true);
+    expect(() => process.kill(childPid, 0)).toThrow();
+  });
+});
+
+describe("runReleaseVerifierCommand", () => {
+  it("trims successful captured output", () => {
+    expect(
+      runReleaseVerifierCommand(process.execPath, [
+        "-e",
+        'process.stdout.write("  release ready  \\n")',
+      ]),
+    ).toBe("release ready");
+  });
+
+  it("preserves stdout and stderr when a command exits nonzero", () => {
+    const error = captureCommandError(() =>
+      runReleaseVerifierCommand(process.execPath, [
+        "-e",
+        'process.stdout.write("partial output"); process.stderr.write("failure detail"); process.exit(7)',
+      ]),
+    );
+    expect(error).toMatchObject({ status: 7 });
+    expect(error.stdout).toContain("partial output");
+    expect(error.stderr).toContain("failure detail");
+  });
+
+  it("fails when captured output exceeds the command buffer", () => {
+    const error = captureCommandError(() =>
+      runReleaseVerifierCommand(
+        process.execPath,
+        ["-e", 'process.stdout.write("x".repeat(4096))'],
+        { maxBufferBytes: 64 },
+      ),
+    );
+    expect(error.code).toBe("ENOBUFS");
+    expect(error.stdout).toContain("x");
   });
 });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where beta release verification could hang indefinitely when an npm metadata read, GitHub CLI request, rerun command, or Git command stalled.

## Why This Change Was Made

The verifier now uses one captured command runner with a 120-second default timeout, `SIGKILL`, and a 4 MiB output bound for npm, GitHub, and Git operations. npm metadata retries remain limited to publication-propagation failures (`E404` and `ETARGET`); timeouts and other command failures return immediately with their captured stdout and stderr.

The postpublish verifier intentionally has no new parent deadline. Its owner-level request, install, and verification limits remain authoritative.

## User Impact

Release operators now receive a bounded command failure instead of an indefinitely stuck beta verification, without terminating valid long-running postpublish verification.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/release-beta-verifier.test.ts test/scripts/npm-verify-exec.test.ts test/openclaw-npm-postpublish-verify.test.ts`: 81 tests passed.
- Real subprocess proof covers timeout, `SIGKILL`, one attempt despite a retry budget, child reaping, successful output trimming, nonzero stdout/stderr preservation, and buffer overflow.
- Live runner probes succeeded against the npm registry (`openclaw` version metadata) and GitHub API (`openclaw/openclaw` repository identity).
- Focused formatting, script erasability, dependency guards, duplicate coverage, and targeted oxlint passed.
- Exact amended-head P1 autoreview: no accepted or actionable findings; patch judged correct with 0.94 confidence.
- `check-changed` reached script typecheck, then stopped on an unrelated stale shared dependency install missing the existing `pako` declaration. Exact-head clean-install CI/Testbox is the authority for that lane.

After-fix terminal proof through the real npm retry and command-runner path:

```text
$ node --import tsx --input-type=module <<'EOF'
import { runNpmViewWithRetry, runReleaseVerifierCommand } from "./scripts/lib/release-beta-verifier.ts";
let attempts = 0;
const startedAt = Date.now();
try {
  await runNpmViewWithRetry(["view", "openclaw", "version"], {
    attempts: 3,
    delay: async () => { throw new Error("unexpected retry"); },
    run: () => {
      attempts += 1;
      return runReleaseVerifierCommand(
        process.execPath,
        ["-e", "process.stdout.write('child-ready'); setInterval(() => {}, 1000)"],
        { timeoutMs: 1_000 },
      );
    },
  });
} catch (error) {
  console.log(JSON.stringify({
    code: error.code,
    signal: error.signal,
    attempts,
    stdout: error.stdout?.trim(),
    elapsedMs: Date.now() - startedAt,
  }));
}
EOF
{"code":"ETIMEDOUT","signal":"SIGKILL","attempts":1,"stdout":"child-ready","elapsedMs":1005}
```

The postpublish path remains a direct inherited-stdio call with no parent timeout:

```ts
execFileSync("node", ["--import", "tsx", postpublishVerifier, args.version], {
  stdio: "inherit",
});
```

Production LOC: +37/-13 (net +24) | Tests: +85/-1

Contributor authorship remains @coaiMax.

Punchcard-Session: silver-meadow-cedar-x6
