### PR TITLE
fix(scripts): bound check-file-utils git ls-files lookup

### DIFF
--- a/scripts/check-file-utils.ts
+++ b/scripts/check-file-utils.ts
@@ -14,6 +14,8 @@ export const REPO_SCAN_SKIPPED_DIR_NAMES: ReadonlySet<string> = new Set([
   "node_modules",
   "vendor",
 ]);
+// Bound the Git lookup before falling back to direct filesystem traversal.
+const GIT_LS_FILES_TIMEOUT_MS = 30_000;
 
 export function isCodeFile(filePath: string): boolean {
   if (filePath.endsWith(".d.ts")) {
@@ -89,6 +91,8 @@ export function listRepoFilesSync(
     return execFileSync("git", ["-C", repoRoot, "ls-files", "--", ...roots], {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],
+      timeout: GIT_LS_FILES_TIMEOUT_MS,
+      killSignal: "SIGKILL",
     })
       .split(/\r?\n/u)
       .filter(Boolean)

--- a/test/scripts/check-file-utils.test.ts
+++ b/test/scripts/check-file-utils.test.ts
@@ -1,14 +1,22 @@
 // Check File Utils tests cover check file utils script behavior.
 import fs from "node:fs";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   collectFilesSync,
   isCodeFile,
+  listRepoFilesSync,
   relativeToCwd,
   toPosixPath,
 } from "../../scripts/check-file-utils.js";
 import { createScriptTestHarness } from "./test-helpers.js";
+
+const execFileSyncMock = vi.hoisted(() => vi.fn(() => ""));
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const original = (await importOriginal()) as typeof import("node:child_process");
+  return { ...original, execFileSync: execFileSyncMock };
+});
 
 const { createTempDir } = createScriptTestHarness();
 
@@ -62,5 +70,47 @@ describe("scripts/check-file-utils relativeToCwd", () => {
     expect(relativeToCwd(path.join(process.cwd(), "scripts", "check-file-utils.ts"))).toBe(
       "scripts/check-file-utils.ts",
     );
+  });
+});
+
+describe("scripts/check-file-utils listRepoFilesSync", () => {
+  afterEach(() => {
+    execFileSyncMock.mockReset();
+  });
+
+  it("bounds git ls-files with a timeout and kill signal", () => {
+    execFileSyncMock.mockReturnValue("src/keep.ts\nsrc/skip.d.ts\n");
+
+    expect(
+      listRepoFilesSync("/fake/repo", {
+        includeFile: (filePath) => isCodeFile(filePath),
+      }),
+    ).toEqual(["src/keep.ts"]);
+    expect(execFileSyncMock).toHaveBeenCalledWith(
+      "git",
+      expect.arrayContaining(["-C", "/fake/repo", "ls-files", "--"]),
+      expect.objectContaining({
+        timeout: 30_000,
+        killSignal: "SIGKILL",
+      }),
+    );
+  });
+
+  it("falls back to filesystem traversal when git ls-files times out", () => {
+    const error: NodeJS.ErrnoException & { signal?: string } = new Error("Command timed out");
+    error.code = "ETIMEDOUT";
+    error.signal = "SIGKILL";
+    execFileSyncMock.mockImplementation(() => {
+      throw error;
+    });
+    const rootDir = createTempDir("openclaw-check-file-utils-fallback-");
+    fs.mkdirSync(path.join(rootDir, "src"), { recursive: true });
+    fs.writeFileSync(path.join(rootDir, "src", "keep.ts"), "");
+
+    expect(
+      listRepoFilesSync(rootDir, {
+        includeFile: (filePath) => filePath.endsWith(".ts"),
+      }),
+    ).toEqual(["src/keep.ts"]);
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where repository inventory scripts could wait indefinitely when their synchronous `git ls-files` lookup stalls.

## Why This Change Was Made

The shared file-inventory helper now gives the Git lookup a 30-second deadline and forcefully terminates a wedged child. Its existing filesystem traversal remains the canonical fallback, so callers continue instead of hanging.

The deadline bounds only the Git phase. A slow fallback traversal remains possible, and a timed-out Git lookup can include untracked files through the existing fallback behavior.

## User Impact

Maintainer inventory and validation scripts recover from a stuck Git child instead of blocking forever. Normal Git results and file ordering are unchanged.

## Evidence

- Real owner-path timeout proof: a fake `git` process was killed and `listRepoFilesSync` returned the fallback file after `30.009s`.
- Normal Git parity: the helper matched raw `git ls-files` output for all 878 tracked script code files.
- Owner-neighborhood smoke:
  - test environment mutation report scanned 10,787 files.
  - test skip inventory scanned 10,787 files.
  - type suppression inventory scanned 24,702 files.
- Focused tests: 19 passed across the shared helper and all three inventory callers.
- Blacksmith Testbox changed gate: `tbx_01kz3wb13nvczd43qpvhdz2vyj`.
- Testbox Actions run: https://github.com/openclaw/openclaw/actions/runs/30817256527
- Scoped format and lint checks passed; `git diff --check` passed.
- Autoreview: clean, no P0/P1 findings; patch confidence `0.97`.

Contributor credit is preserved in the rewritten commit.
