### PR TITLE
fix(gateway): bound TLS cert/key file reads with size limit

### DIFF
--- a/src/infra/tls/gateway.test.ts
+++ b/src/infra/tls/gateway.test.ts
@@ -1,7 +1,7 @@
 // Covers gateway TLS loading, fingerprint reporting, generated certificate
 // paths, and error handling for missing or invalid material.
 import { X509Certificate } from "node:crypto";
-import { writeFile } from "node:fs/promises";
+import { symlink, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { createTrackedTempDirs } from "../../test-utils/tracked-temp-dirs.js";
@@ -108,6 +108,29 @@ describe("loadGatewayTlsRuntime", () => {
     expect(result.tlsOptions?.ca).toBe(CERT_PEM);
     expect(result.tlsOptions?.minVersion).toBe("TLSv1.3");
     expect(result.error).toBeUndefined();
+  });
+
+  it.skipIf(process.platform === "win32")("loads symlinked certificate files", async () => {
+    const dir = await createTempDir();
+    const certTarget = path.join(dir, "gateway-cert-target.pem");
+    const keyTarget = path.join(dir, "gateway-key-target.pem");
+    const certPath = path.join(dir, "gateway-cert.pem");
+    const keyPath = path.join(dir, "gateway-key.pem");
+    await writeFile(certTarget, CERT_PEM, "utf8");
+    await writeFile(keyTarget, KEY_PEM, "utf8");
+    await symlink(certTarget, certPath);
+    await symlink(keyTarget, keyPath);
+
+    const result = await loadGatewayTlsRuntime({
+      enabled: true,
+      certPath,
+      keyPath,
+      autoGenerate: false,
+    });
+
+    expect(result.enabled).toBe(true);
+    expect(result.tlsOptions?.cert).toBe(CERT_PEM);
+    expect(result.tlsOptions?.key).toBe(KEY_PEM);
   });
 
   it("fails closed when cert/key are missing and auto generation is disabled", async () => {

--- a/src/infra/tls/gateway.test.ts
+++ b/src/infra/tls/gateway.test.ts
@@ -192,4 +192,48 @@ describe("loadGatewayTlsRuntime", () => {
     expect(result.certPath).not.toContain("gateway-cert.pem");
     expect(result.keyPath).not.toContain("gateway-key.pem");
   });
+
+  it("reports load failure when cert file exceeds the size limit", async () => {
+    const dir = await createTempDir();
+    const certPath = path.join(dir, "gateway-cert.pem");
+    const keyPath = path.join(dir, "gateway-key.pem");
+    // Create a cert file larger than MAX_TLS_CERT_FILE_BYTES (64 KB).
+    await writeFile(certPath, Buffer.alloc(128 * 1024, "#"), "utf8");
+    await writeFile(keyPath, KEY_PEM, "utf8");
+
+    const result = await loadGatewayTlsRuntime({
+      enabled: true,
+      certPath,
+      keyPath,
+      autoGenerate: false,
+    });
+
+    expect(result.enabled).toBe(false);
+    expect(result.required).toBe(true);
+    expect(result.certPath).toBe(certPath);
+    expect(result.keyPath).toBe(keyPath);
+    expect(result.error).toContain("gateway tls: failed to load cert");
+  });
+
+  it("reports load failure when key file exceeds the size limit", async () => {
+    const dir = await createTempDir();
+    const certPath = path.join(dir, "gateway-cert.pem");
+    const keyPath = path.join(dir, "gateway-key.pem");
+    await writeFile(certPath, CERT_PEM, "utf8");
+    // Create a key file larger than MAX_TLS_CERT_FILE_BYTES (64 KB).
+    await writeFile(keyPath, Buffer.alloc(128 * 1024, "#"), "utf8");
+
+    const result = await loadGatewayTlsRuntime({
+      enabled: true,
+      certPath,
+      keyPath,
+      autoGenerate: false,
+    });
+
+    expect(result.enabled).toBe(false);
+    expect(result.required).toBe(true);
+    expect(result.certPath).toBe(certPath);
+    expect(result.keyPath).toBe(keyPath);
+    expect(result.error).toContain("gateway tls: failed to load cert");
+  });
 });

--- a/src/infra/tls/gateway.ts
+++ b/src/infra/tls/gateway.ts
@@ -7,15 +7,22 @@ import tls from "node:tls";
 import type { GatewayTlsConfig } from "../../config/types.gateway.js";
 import { runExec } from "../../process/exec.js";
 import { CONFIG_DIR, ensureDir, resolveUserPath, shortenHomeInString } from "../../utils.js";
+import { readFileDescriptorBounded } from "../boundary-file-read.js";
 import { pathExists } from "../fs-safe.js";
-import { readRegularFile } from "../regular-file.js";
 import { resolveSystemBin } from "../resolve-system-bin.js";
 import { normalizeFingerprint } from "./fingerprint.js";
 
-/** Max byte size for TLS certificate, key, and CA files. Real cert/key files
- *  are typically under 8 KB; 64 KB is generous enough for large chain files
- *  while still protecting against misconfigured paths pointing at huge files. */
+// Keep enough room for certificate chains while bounding misconfigured paths.
 const MAX_TLS_CERT_FILE_BYTES = 64 * 1024;
+
+async function readTlsFile(filePath: string): Promise<string> {
+  const file = await fs.open(filePath, "r");
+  try {
+    return (await readFileDescriptorBounded(file.fd, MAX_TLS_CERT_FILE_BYTES)).toString("utf8");
+  } finally {
+    await file.close();
+  }
+}
 
 // Gateway TLS runtime carries loaded cert material plus the normalized SHA-256
 // fingerprint advertised to clients.
@@ -131,17 +138,9 @@ export async function loadGatewayTlsRuntime(
   }
 
   try {
-    const cert = (
-      await readRegularFile({ filePath: certPath, maxBytes: MAX_TLS_CERT_FILE_BYTES })
-    ).buffer.toString("utf8");
-    const key = (
-      await readRegularFile({ filePath: keyPath, maxBytes: MAX_TLS_CERT_FILE_BYTES })
-    ).buffer.toString("utf8");
-    const ca = caPath
-      ? (
-          await readRegularFile({ filePath: caPath, maxBytes: MAX_TLS_CERT_FILE_BYTES })
-        ).buffer.toString("utf8")
-      : undefined;
+    const cert = await readTlsFile(certPath);
+    const key = await readTlsFile(keyPath);
+    const ca = caPath ? await readTlsFile(caPath) : undefined;
     const x509 = new X509Certificate(cert);
     const fingerprintSha256 = normalizeFingerprint(x509.fingerprint256 ?? "");
 

--- a/src/infra/tls/gateway.ts
+++ b/src/infra/tls/gateway.ts
@@ -8,8 +8,14 @@ import type { GatewayTlsConfig } from "../../config/types.gateway.js";
 import { runExec } from "../../process/exec.js";
 import { CONFIG_DIR, ensureDir, resolveUserPath, shortenHomeInString } from "../../utils.js";
 import { pathExists } from "../fs-safe.js";
+import { readRegularFile } from "../regular-file.js";
 import { resolveSystemBin } from "../resolve-system-bin.js";
 import { normalizeFingerprint } from "./fingerprint.js";
+
+/** Max byte size for TLS certificate, key, and CA files. Real cert/key files
+ *  are typically under 8 KB; 64 KB is generous enough for large chain files
+ *  while still protecting against misconfigured paths pointing at huge files. */
+const MAX_TLS_CERT_FILE_BYTES = 64 * 1024;
 
 // Gateway TLS runtime carries loaded cert material plus the normalized SHA-256
 // fingerprint advertised to clients.
@@ -125,9 +131,17 @@ export async function loadGatewayTlsRuntime(
   }
 
   try {
-    const cert = await fs.readFile(certPath, "utf8");
-    const key = await fs.readFile(keyPath, "utf8");
-    const ca = caPath ? await fs.readFile(caPath, "utf8") : undefined;
+    const cert = (
+      await readRegularFile({ filePath: certPath, maxBytes: MAX_TLS_CERT_FILE_BYTES })
+    ).buffer.toString("utf8");
+    const key = (
+      await readRegularFile({ filePath: keyPath, maxBytes: MAX_TLS_CERT_FILE_BYTES })
+    ).buffer.toString("utf8");
+    const ca = caPath
+      ? (
+          await readRegularFile({ filePath: caPath, maxBytes: MAX_TLS_CERT_FILE_BYTES })
+        ).buffer.toString("utf8")
+      : undefined;
     const x509 = new X509Certificate(cert);
     const fingerprintSha256 = normalizeFingerprint(x509.fingerprint256 ?? "");
 


### PR DESCRIPTION
## Summary
- **Problem:** Gateway TLS certificate, key, and CA paths were read without a byte limit.
- **Root cause:** `loadGatewayTlsRuntime` used `fs.readFile`, buffering each configured file in full.
- **Fix:** Read each opened descriptor through the shared bounded reader with a 64 KiB cap.
- **Impact:** Oversized TLS material fails closed while symlinked certificate deployments continue to work.

## Linked context
N/A (no existing issue)

## Real behavior proof
- **Behavior or issue addressed:** Bound TLS material reads without regressing symlinked certificates/keys.
- **Real environment tested:** Linux, Node 24.13.1, OpenSSL-generated fixture, exact head `a31e36e3c67b37d557a00d57ec570e0b8a894268`.
- **Exact steps or command run:** `node --import tsx --input-type=module -e '<generate a certificate, load symlink paths, then load a 128 KiB cert>'`
- **Evidence after fix:** Terminal capture of `node` source-runtime verification:
```text
symlink_ok=true
oversized_ok=false
oversized_error=true
exact_head=a31e36e3c67b37d557a00d57ec570e0b8a894268
```
- **Observed result after fix:** Valid symlinked TLS material enables the runtime; oversized material disables it with the expected load error.
- **What was not tested:** Windows symlink behavior and a live network TLS handshake; certificate parsing, limits, and cleanup are covered by the focused suite.

## Tests and validation
```text
$ node scripts/run-vitest.mjs src/infra/tls/gateway.test.ts
Test Files  1 passed (1)
Tests       10 passed (10)
[test] passed 1 Vitest shard in 7.63s

$ git diff --check
# no output
```

## Risk checklist
| Risk | Assessment |
|------|-----------|
| Backward compatible | Yes; symlinked TLS files remain supported |
| Performance impact | Bounded incremental read |
| Security improvement | Yes; caps TLS-file memory use |
| Requires config migration | No |
| Affects external API | No |
| Tested on all platforms | No; Linux focused proof |
| Documentation needed | No |

AI-assisted: yes. Fresh autoreview was attempted; the local Codex CLI exited before producing findings because its isolated CODEX_HOME rejected PATH helper creation. No autoreview-clean claim is made.
