### PR TITLE
fix(push): bound APNs key file read with size limit

### DIFF
--- a/src/infra/push-apns.auth.test.ts
+++ b/src/infra/push-apns.auth.test.ts
@@ -89,6 +89,26 @@ describe("push APNs auth and helper coverage", () => {
     }
   });
 
+  it.skipIf(process.platform === "win32")("keeps symlinked APNs key paths working", async () => {
+    const dir = await makeTempDir();
+    const targetPath = path.join(dir, "apns-key-target.p8");
+    const keyPath = path.join(dir, "apns-key-link.p8");
+    await fs.writeFile(
+      targetPath,
+      "-----BEGIN PRIVATE KEY-----\nline-g\nline-h\n-----END PRIVATE KEY-----\n",
+      "utf8",
+    );
+    await fs.symlink(targetPath, keyPath);
+
+    const resolved = await resolveApnsAuthConfigFromEnv({
+      OPENCLAW_APNS_TEAM_ID: "TEAM123",
+      OPENCLAW_APNS_KEY_ID: "KEY123",
+      OPENCLAW_APNS_PRIVATE_KEY_PATH: keyPath,
+    } as NodeJS.ProcessEnv);
+
+    expect(resolved.ok).toBe(true);
+  });
+
   it("rejects oversized key files from OPENCLAW_APNS_PRIVATE_KEY_PATH", async () => {
     const dir = await makeTempDir();
     const keyPath = path.join(dir, "apns-key-oversized.p8");

--- a/src/infra/push-apns.auth.test.ts
+++ b/src/infra/push-apns.auth.test.ts
@@ -89,6 +89,26 @@ describe("push APNs auth and helper coverage", () => {
     }
   });
 
+  it("rejects oversized key files from OPENCLAW_APNS_PRIVATE_KEY_PATH", async () => {
+    const dir = await makeTempDir();
+    const keyPath = path.join(dir, "apns-key-oversized.p8");
+    const oversized = Buffer.alloc(32 * 1024, 0x61).toString("utf8");
+    await fs.writeFile(keyPath, oversized, "utf8");
+
+    const resolved = await resolveApnsAuthConfigFromEnv({
+      OPENCLAW_APNS_TEAM_ID: "TEAM123",
+      OPENCLAW_APNS_KEY_ID: "KEY123",
+      OPENCLAW_APNS_PRIVATE_KEY_PATH: keyPath,
+    } as NodeJS.ProcessEnv);
+
+    expect(resolved.ok).toBe(false);
+    if (!resolved.ok) {
+      expect(resolved.error).toContain(
+        `failed reading OPENCLAW_APNS_PRIVATE_KEY_PATH (${keyPath})`,
+      );
+    }
+  });
+
   it("reports missing auth fields and path read failures", async () => {
     const dir = await makeTempDir();
     const missingPath = path.join(dir, "missing-key.p8");

--- a/src/infra/push-apns.ts
+++ b/src/infra/push-apns.ts
@@ -1,8 +1,10 @@
 // Manages APNs registration state and direct/relay push sending.
 import { createHash, createPrivateKey, sign as signJwt } from "node:crypto";
+import { open } from "node:fs/promises";
 import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { readFileDescriptorBounded } from "./boundary-file-read.js";
 import type { DeviceIdentity } from "./device-identity.js";
 import { formatErrorMessage, toErrorObject } from "./errors.js";
 import {
@@ -37,7 +39,6 @@ import {
   resolveApnsRelayConfigFromEnv,
   sendApnsRelayPush,
 } from "./push-apns.relay.js";
-import { readRegularFile } from "./regular-file.js";
 
 export {
   clearApnsRegistrationIfCurrent,
@@ -97,7 +98,7 @@ type ApnsRequestSender = (params: ApnsRequestParams) => Promise<ApnsRequestRespo
 const APNS_JWT_TTL_MS = 50 * 60 * 1000;
 const DEFAULT_APNS_TIMEOUT_MS = 10_000;
 
-/** APNs private key files are small (RSA 2048 ~1.7KB, Ed25519 ~200 bytes). */
+// APNs private keys are small; keep headroom without allowing unbounded reads.
 const MAX_APNS_KEY_FILE_BYTES = 16 * 1024;
 
 let cachedJwt: { cacheKey: string; token: string; expiresAtMs: number } | null = null;
@@ -230,11 +231,15 @@ export async function resolveApnsAuthConfigFromEnv(
     };
   }
   try {
-    const keyFile = await readRegularFile({
-      filePath: keyPath,
-      maxBytes: MAX_APNS_KEY_FILE_BYTES,
-    });
-    const privateKey = normalizePrivateKey(keyFile.buffer.toString("utf8"));
+    const keyFile = await open(keyPath, "r");
+    let privateKey: string;
+    try {
+      privateKey = normalizePrivateKey(
+        (await readFileDescriptorBounded(keyFile.fd, MAX_APNS_KEY_FILE_BYTES)).toString("utf8"),
+      );
+    } finally {
+      await keyFile.close();
+    }
     return {
       ok: true,
       value: {

--- a/src/infra/push-apns.ts
+++ b/src/infra/push-apns.ts
@@ -1,6 +1,5 @@
 // Manages APNs registration state and direct/relay push sending.
 import { createHash, createPrivateKey, sign as signJwt } from "node:crypto";
-import fs from "node:fs/promises";
 import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
@@ -38,6 +37,7 @@ import {
   resolveApnsRelayConfigFromEnv,
   sendApnsRelayPush,
 } from "./push-apns.relay.js";
+import { readRegularFile } from "./regular-file.js";
 
 export {
   clearApnsRegistrationIfCurrent,
@@ -96,6 +96,9 @@ type ApnsRequestSender = (params: ApnsRequestParams) => Promise<ApnsRequestRespo
 
 const APNS_JWT_TTL_MS = 50 * 60 * 1000;
 const DEFAULT_APNS_TIMEOUT_MS = 10_000;
+
+/** APNs private key files are small (RSA 2048 ~1.7KB, Ed25519 ~200 bytes). */
+const MAX_APNS_KEY_FILE_BYTES = 16 * 1024;
 
 let cachedJwt: { cacheKey: string; token: string; expiresAtMs: number } | null = null;
 
@@ -227,7 +230,11 @@ export async function resolveApnsAuthConfigFromEnv(
     };
   }
   try {
-    const privateKey = normalizePrivateKey(await fs.readFile(keyPath, "utf8"));
+    const keyFile = await readRegularFile({
+      filePath: keyPath,
+      maxBytes: MAX_APNS_KEY_FILE_BYTES,
+    });
+    const privateKey = normalizePrivateKey(keyFile.buffer.toString("utf8"));
     return {
       ok: true,
       value: {


### PR DESCRIPTION
## Summary
- **Problem:** `OPENCLAW_APNS_PRIVATE_KEY_PATH` was read without a byte limit.
- **Root cause:** APNs auth used `fs.readFile`, which buffers the entire configured path.
- **Fix:** Open the key once and read its descriptor through the shared bounded reader with a 16 KiB cap.
- **Impact:** Oversized paths fail closed while normal and symlinked APNs key files remain supported.

## Linked context
N/A (no existing issue)

## Real behavior proof
- **Behavior or issue addressed:** Bound APNs key reads without breaking symlink-based secret mounts.
- **Real environment tested:** Linux, Node 24.13.1, exact head `5f803076d1234f215524ca6f8adff67a7b183ccb`.
- **Exact steps or command run:** `node --import tsx --input-type=module -e '<resolve a symlinked key and a 32 KiB key>'`
- **Evidence after fix:** Terminal capture of `node` source-runtime verification:
```text
symlink_ok=true
oversized_ok=false
oversized_error=true
exact_head=5f803076d1234f215524ca6f8adff67a7b183ccb
```
- **Observed result after fix:** The symlinked key resolves successfully and the oversized key is rejected with the bounded-read error.
- **What was not tested:** A live APNs request and Windows symlink behavior; auth parsing and descriptor cleanup are covered by the focused suite.

## Tests and validation
```text
$ node scripts/run-vitest.mjs src/infra/push-apns.auth.test.ts
Test Files  1 passed (1)
Tests       8 passed (8)
[test] passed 1 Vitest shard in 9.67s

$ git diff --check
# no output
```

## Risk checklist
| Risk | Assessment |
|------|-----------|
| Backward compatible | Yes; symlinked key files remain supported |
| Performance impact | Bounded incremental read |
| Security improvement | Yes; caps key-file memory use |
| Requires config migration | No |
| Affects external API | No |
| Tested on all platforms | No; Linux focused proof |
| Documentation needed | No |

AI-assisted: yes. Fresh autoreview was attempted; the local Codex CLI exited before producing findings because its isolated CODEX_HOME rejected PATH helper creation. No autoreview-clean claim is made.
