### PR TITLE
fix(agents): bound models.json catalog file read with size limit

### DIFF
--- a/src/agents/sessions/model-registry.test.ts
+++ b/src/agents/sessions/model-registry.test.ts
@@ -1,6 +1,6 @@
 // Model registry tests cover models.json auth modes and plugin-owned model
 // catalog shards.
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { getApiProvider } from "@openclaw/ai/internal/runtime";
@@ -671,6 +671,17 @@ describe("ModelRegistry models.json auth", () => {
 
     expect(registry.getError()).toBeDefined();
     expect(registry.getError()).toContain("exceeds");
+    expect(registry.getAvailable()).toHaveLength(0);
+  });
+
+  it.skipIf(process.platform === "win32")("keeps symlinked models.json catalogs working", () => {
+    const target = writeModelsJson({ providers: {} });
+    const file = join(dirname(target), "models-link.json");
+    symlinkSync(target, file);
+
+    const registry = ModelRegistry.create(AuthStorage.inMemory(), file);
+
+    expect(registry.getError()).toBeUndefined();
     expect(registry.getAvailable()).toHaveLength(0);
   });
 });

--- a/src/agents/sessions/model-registry.test.ts
+++ b/src/agents/sessions/model-registry.test.ts
@@ -656,6 +656,23 @@ describe("ModelRegistry models.json auth", () => {
     expect(registry.getError()).toBeUndefined();
     expect(registry.find("zai", "glm-5.1")).toBeUndefined();
   });
+
+  it("rejects oversized models.json catalogs with a size-bound error", () => {
+    const dir = mkdtempSync(join(tmpdir(), "openclaw-model-registry-"));
+    tempDirs.push(dir);
+    const file = join(dir, "models.json");
+    // Write a file larger than the 1 MB limit with a valid JSON prefix so the
+    // size check fires before parsing.
+    const header = JSON.stringify({ providers: {} });
+    const padding = Buffer.alloc(1024 * 1024 + 1 - header.length, " ");
+    writeFileSync(file, header + padding.toString());
+
+    const registry = ModelRegistry.create(AuthStorage.inMemory(), file);
+
+    expect(registry.getError()).toBeDefined();
+    expect(registry.getError()).toContain("exceeds");
+    expect(registry.getAvailable()).toHaveLength(0);
+  });
 });
 
 describe("ModelRegistry OAuth provider ownership", () => {

--- a/src/agents/sessions/model-registry.ts
+++ b/src/agents/sessions/model-registry.ts
@@ -2,11 +2,12 @@
  * Model registry - manages configured/provider-owned models and API key resolution.
  */
 
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { type Static, Type } from "typebox";
 import { Compile } from "typebox/compile";
 import type { TLocalizedValidationError } from "typebox/error";
+import { readRegularFileSync } from "../../infra/regular-file.js";
 import type {
   AnthropicMessagesCompat,
   Api,
@@ -316,6 +317,8 @@ function mergeCompat(
 /** Clear the config value command cache. Exported for testing. */
 export const clearApiKeyCache = clearConfigValueCache;
 
+const MAX_MODELS_CATALOG_BYTES = 1024 * 1024;
+
 /**
  * Model registry - loads and manages models, resolves API keys via AuthStorage.
  */
@@ -487,7 +490,10 @@ export class ModelRegistry {
     }
 
     try {
-      const content = readFileSync(modelsJsonPath, "utf-8");
+      const content = readRegularFileSync({
+        filePath: modelsJsonPath,
+        maxBytes: MAX_MODELS_CATALOG_BYTES,
+      }).buffer.toString("utf-8");
       const parsed = JSON.parse(stripJsonComments(content)) as unknown;
       if (options.requireGeneratedCatalog === true && !isGeneratedPluginModelCatalog(parsed)) {
         return emptyCustomModelsResult();

--- a/src/agents/sessions/model-registry.ts
+++ b/src/agents/sessions/model-registry.ts
@@ -2,12 +2,12 @@
  * Model registry - manages configured/provider-owned models and API key resolution.
  */
 
-import { existsSync } from "node:fs";
+import { closeSync, existsSync, openSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { type Static, Type } from "typebox";
 import { Compile } from "typebox/compile";
 import type { TLocalizedValidationError } from "typebox/error";
-import { readRegularFileSync } from "../../infra/regular-file.js";
+import { readFileDescriptorBoundedSync } from "../../infra/boundary-file-read.js";
 import type {
   AnthropicMessagesCompat,
   Api,
@@ -490,10 +490,13 @@ export class ModelRegistry {
     }
 
     try {
-      const content = readRegularFileSync({
-        filePath: modelsJsonPath,
-        maxBytes: MAX_MODELS_CATALOG_BYTES,
-      }).buffer.toString("utf-8");
+      const fd = openSync(modelsJsonPath, "r");
+      let content: string;
+      try {
+        content = readFileDescriptorBoundedSync(fd, MAX_MODELS_CATALOG_BYTES).toString("utf-8");
+      } finally {
+        closeSync(fd);
+      }
       const parsed = JSON.parse(stripJsonComments(content)) as unknown;
       if (options.requireGeneratedCatalog === true && !isGeneratedPluginModelCatalog(parsed)) {
         return emptyCustomModelsResult();


### PR DESCRIPTION
## Summary
- **Problem:** `models.json` is user-influenced input read with an unbounded `readFileSync`.
- **Root cause:** Catalog loading had no maximum byte budget.
- **Fix:** Read the catalog through the shared bounded descriptor reader with a 1 MiB cap, preserving symlinked catalog paths.
- **Impact:** Oversized catalogs fail closed before JSON parsing while normal and symlinked catalogs keep working.

## Linked context
N/A (no existing issue)

## Real behavior proof
- **Behavior or issue addressed:** Bound custom model catalog reads without changing valid catalog path behavior.
- **Real environment tested:** Linux, Node 24.13.1, exact head `c5f24edfdf55d325e6eaf7972d573e191ee24e87`.
- **Exact steps or command run:** `node --import tsx --input-type=module -e '<create symlinked and oversized models.json files and instantiate ModelRegistry>'`
- **Evidence after fix:** Terminal capture of `node` source-runtime verification:
```text
symlink_error=none
oversized_error=true
available=0
exact_head=c5f24edfdf55d325e6eaf7972d573e191ee24e87
```
- **Observed result after fix:** Symlinked catalogs load normally; a catalog over 1 MiB is rejected and exposes no available models.
- **What was not tested:** Windows symlink behavior and a published package install; the focused registry suite passed on Linux.

## Tests and validation
```text
$ node scripts/run-vitest.mjs src/agents/sessions/model-registry.test.ts
Test Files  1 passed (1)
Tests       21 passed (21)
[test] passed 1 Vitest shard in 17.79s

$ git diff --check
# no output
```

## Risk checklist
| Risk | Assessment |
|------|-----------|
| Backward compatible | Yes; symlinked catalogs remain supported |
| Performance impact | Bounded incremental read |
| Security improvement | Yes; limits catalog memory use |
| Requires config migration | No |
| Affects external API | No |
| Tested on all platforms | No; Linux focused proof |
| Documentation needed | No |

AI-assisted: yes. Fresh autoreview was attempted; the local Codex CLI exited before producing findings because its isolated CODEX_HOME rejected PATH helper creation. No autoreview-clean claim is made.
