### PR TITLE
fix(synology-chat): ignore blank env overrides for incoming URL and NAS host

### DIFF
--- a/extensions/synology-chat/src/accounts.ts
+++ b/extensions/synology-chat/src/accounts.ts
@@ -12,7 +12,10 @@ import {
 } from "openclaw/plugin-sdk/account-resolution";
 import { resolveDangerousNameMatchingEnabled } from "openclaw/plugin-sdk/dangerous-name-runtime";
 import { parseStrictInteger } from "openclaw/plugin-sdk/number-runtime";
-import { normalizeStringEntries } from "openclaw/plugin-sdk/string-coerce-runtime";
+import {
+  normalizeOptionalString,
+  normalizeStringEntries,
+} from "openclaw/plugin-sdk/string-coerce-runtime";
 import type {
   SynologyChatChannelConfig,
   ResolvedSynologyChatAccount,
@@ -128,8 +131,8 @@ export function resolveAccount(
 
   // Env var fallbacks (primarily for the "default" account)
   const envToken = process.env.SYNOLOGY_CHAT_TOKEN ?? "";
-  const envIncomingUrl = process.env.SYNOLOGY_CHAT_INCOMING_URL ?? "";
-  const envNasHost = process.env.SYNOLOGY_NAS_HOST ?? "localhost";
+  const envIncomingUrl = normalizeOptionalString(process.env.SYNOLOGY_CHAT_INCOMING_URL) ?? "";
+  const envNasHost = normalizeOptionalString(process.env.SYNOLOGY_NAS_HOST) ?? "localhost";
   const envAllowedUserIds = process.env.SYNOLOGY_ALLOWED_USER_IDS ?? "";
   const envRateLimitValue = parseRateLimitPerMinute(process.env.SYNOLOGY_RATE_LIMIT);
   const envBotName = process.env.OPENCLAW_BOT_NAME ?? "OpenClaw";

--- a/extensions/synology-chat/src/core.test.ts
+++ b/extensions/synology-chat/src/core.test.ts
@@ -236,6 +236,18 @@ describe("synology-chat account resolution", () => {
     expect(account.botName).toBe("TestBot");
   });
 
+  it("ignores blank env vars and falls back to defaults", () => {
+    process.env.SYNOLOGY_CHAT_INCOMING_URL = "";
+    process.env.SYNOLOGY_NAS_HOST = "   ";
+
+    const cfg = { channels: { "synology-chat": {} } };
+    const account = resolveAccount(cfg);
+    // empty string env var → falls back to ""
+    expect(account.incomingUrl).toBe("");
+    // whitespace-only env var → falls back to "localhost"
+    expect(account.nasHost).toBe("localhost");
+  });
+
   it("lets config and account overrides win over env/base config", () => {
     process.env.SYNOLOGY_CHAT_TOKEN = "env-tok";
     const cfg = {

--- a/extensions/synology-chat/src/core.test.ts
+++ b/extensions/synology-chat/src/core.test.ts
@@ -237,14 +237,12 @@ describe("synology-chat account resolution", () => {
   });
 
   it("ignores blank env vars and falls back to defaults", () => {
-    process.env.SYNOLOGY_CHAT_INCOMING_URL = "";
+    process.env.SYNOLOGY_CHAT_INCOMING_URL = " \t ";
     process.env.SYNOLOGY_NAS_HOST = "   ";
 
     const cfg = { channels: { "synology-chat": {} } };
     const account = resolveAccount(cfg);
-    // empty string env var → falls back to ""
     expect(account.incomingUrl).toBe("");
-    // whitespace-only env var → falls back to "localhost"
     expect(account.nasHost).toBe("localhost");
   });
 


### PR DESCRIPTION
## Summary
- **Problem:** Whitespace-only `SYNOLOGY_CHAT_INCOMING_URL` and `SYNOLOGY_NAS_HOST` values were treated as real overrides; the NAS host could become an invalid blank hostname.
- **Root cause:** Raw environment strings were selected with `??`, which only rejects null/undefined.
- **Fix:** Normalize both optional strings before applying the existing empty-URL and `localhost` fallbacks.
- **Impact:** Blank overrides no longer break Synology Chat connection settings; nonblank values remain unchanged.

## Linked context
N/A (no existing issue)

## Real behavior proof
- **Behavior or issue addressed:** Whitespace-only Synology URL/host overrides must resolve to their defaults.
- **Real environment tested:** Linux, Node 24.13.1, exact head `66de6e769e925ccee13dec8e110ae8ba9a4d76c0`.
- **Exact steps or command run:** `node --import tsx --input-type=module -e '<set env values and call resolveAccount>'`
- **Evidence after fix:** Terminal capture of `node` source-runtime verification:
```text
incomingUrl=""
nasHost="localhost"
validIncomingUrl="https://chat.example.test/incoming"
validNasHost="nas.example.test"
exact_head=66de6e769e925ccee13dec8e110ae8ba9a4d76c0
```
- **Observed result after fix:** Blank values use the established defaults and valid URL/host values pass through.
- **What was not tested:** A live Synology NAS webhook and Windows/macOS; account resolution is pure and its focused plugin suite passed.

## Tests and validation
```text
$ node scripts/run-vitest.mjs extensions/synology-chat/src/core.test.ts
Test Files  1 passed (1)
Tests       26 passed (26)
[test] passed 1 Vitest shard in 18.92s

$ git diff --check
# no output
```

## Risk checklist
| Risk | Assessment |
|------|-----------|
| Backward compatible | Yes; only blank/whitespace overrides change |
| Performance impact | Negligible |
| Security improvement | No direct security impact |
| Requires config migration | No |
| Affects external API | No |
| Tested on all platforms | No; Linux focused proof |
| Documentation needed | No |

AI-assisted: yes. Fresh autoreview was attempted; the local Codex CLI exited before producing findings because its isolated CODEX_HOME rejected PATH helper creation. No autoreview-clean claim is made.
