### PR TITLE
fix(config): bound config include file reads with size limit

### DIFF
--- a/src/config/includes.test.ts
+++ b/src/config/includes.test.ts
@@ -10,6 +10,7 @@ import {
   ConfigIncludeError,
   MAX_INCLUDE_DEPTH,
   type IncludeResolver,
+  readConfigIncludeFileWithGuards,
   resolveConfigIncludeWritePath,
   resolveConfigIncludes,
 } from "./includes.js";
@@ -67,6 +68,24 @@ function expectResolveIncludeError(
 }
 
 describe("resolveConfigIncludes", () => {
+  it("preserves reduced injected fs reads while enforcing the byte cap", () => {
+    const ioFs = {
+      readFileSync: () => "virtual include",
+      realpathSync: (value: string) => value,
+    } as unknown as typeof nodeFs;
+    const params = {
+      includePath: "./include.json",
+      resolvedPath: configPath("include.json"),
+      rootRealDir: CONFIG_DIR,
+      ioFs,
+    };
+
+    expect(readConfigIncludeFileWithGuards({ ...params, maxBytes: 15 })).toBe("virtual include");
+    expect(() => readConfigIncludeFileWithGuards({ ...params, maxBytes: 14 })).toThrow(
+      "Include file exceeds 14 bytes",
+    );
+  });
+
   it.each([
     { name: "string", value: "hello", expected: "hello" },
     { name: "number", value: 42, expected: 42 },

--- a/src/config/includes.ts
+++ b/src/config/includes.ts
@@ -17,6 +17,7 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { canUseRootFileOpen, openRootFileSync } from "../infra/boundary-file-read.js";
 import { resolvePathViaExistingAncestorSync } from "../infra/boundary-path.js";
 import { mergeDeep as mergeDeepValues } from "../infra/deep-merge.js";
+import { readRegularFileSync } from "../infra/regular-file.js";
 import { isPathInside } from "../security/scan-paths.js";
 import { isPlainObject } from "../utils.js";
 import { parseJsonWithJson5Fallback } from "../utils/parse-json-compat.js";
@@ -427,13 +428,19 @@ export function readConfigIncludeFileWithGuards(params: IncludeFileReadParams): 
   const ioFs = params.ioFs ?? fs;
   const maxBytes = params.maxBytes ?? MAX_INCLUDE_FILE_BYTES;
   if (!canUseRootFileOpen(ioFs)) {
-    const raw = ioFs.readFileSync(params.resolvedPath, "utf-8");
+    // Fallback for limited fs shims that lack openSync/realpathSync.
+    // Still enforces regular-file checks and the same maxBytes cap as the
+    // openRootFileSync path so unbounded reads are never reachable.
+    const result = readRegularFileSync({
+      filePath: params.resolvedPath,
+      maxBytes,
+    });
     try {
       params.onResolvedPath?.(path.normalize(ioFs.realpathSync(params.resolvedPath)));
     } catch {
       // The guarded read succeeded; target tracking is best-effort on reduced fs shims.
     }
-    return raw;
+    return result.buffer.toString("utf-8");
   }
 
   const opened = openRootFileSync({
@@ -473,7 +480,8 @@ export function readConfigIncludeFileWithGuards(params: IncludeFileReadParams): 
 // ============================================================================
 
 const defaultResolver: IncludeResolver = {
-  readFile: (p) => fs.readFileSync(p, "utf-8"),
+  readFile: (p) =>
+    readRegularFileSync({ filePath: p, maxBytes: MAX_INCLUDE_FILE_BYTES }).buffer.toString("utf-8"),
   readFileWithGuards: ({ includePath, resolvedPath, rootRealDir }) =>
     readConfigIncludeFileWithGuards({ includePath, resolvedPath, rootRealDir }),
   parseJson: parseJsonWithJson5Fallback,

--- a/src/config/includes.ts
+++ b/src/config/includes.ts
@@ -14,10 +14,13 @@ import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
-import { canUseRootFileOpen, openRootFileSync } from "../infra/boundary-file-read.js";
+import {
+  canUseRootFileOpen,
+  openRootFileSync,
+  readFileDescriptorBoundedSync,
+} from "../infra/boundary-file-read.js";
 import { resolvePathViaExistingAncestorSync } from "../infra/boundary-path.js";
 import { mergeDeep as mergeDeepValues } from "../infra/deep-merge.js";
-import { readRegularFileSync } from "../infra/regular-file.js";
 import { isPathInside } from "../security/scan-paths.js";
 import { isPlainObject } from "../utils.js";
 import { parseJsonWithJson5Fallback } from "../utils/parse-json-compat.js";
@@ -428,19 +431,21 @@ export function readConfigIncludeFileWithGuards(params: IncludeFileReadParams): 
   const ioFs = params.ioFs ?? fs;
   const maxBytes = params.maxBytes ?? MAX_INCLUDE_FILE_BYTES;
   if (!canUseRootFileOpen(ioFs)) {
-    // Fallback for limited fs shims that lack openSync/realpathSync.
-    // Still enforces regular-file checks and the same maxBytes cap as the
-    // openRootFileSync path so unbounded reads are never reachable.
-    const result = readRegularFileSync({
-      filePath: params.resolvedPath,
-      maxBytes,
-    });
+    // Reduced injected fs shims cannot provide pinned descriptor reads, but
+    // must still preserve their own read behavior and reject oversized data.
+    const raw = ioFs.readFileSync(params.resolvedPath, "utf-8");
+    if (Buffer.byteLength(raw, "utf-8") > maxBytes) {
+      throw new ConfigIncludeError(
+        `Include file exceeds ${maxBytes} bytes: ${params.includePath}`,
+        params.includePath,
+      );
+    }
     try {
       params.onResolvedPath?.(path.normalize(ioFs.realpathSync(params.resolvedPath)));
     } catch {
       // The guarded read succeeded; target tracking is best-effort on reduced fs shims.
     }
-    return result.buffer.toString("utf-8");
+    return raw;
   }
 
   const opened = openRootFileSync({
@@ -467,7 +472,16 @@ export function readConfigIncludeFileWithGuards(params: IncludeFileReadParams): 
   }
 
   try {
-    const raw = ioFs.readFileSync(opened.fd, "utf-8");
+    const raw =
+      ioFs === fs
+        ? readFileDescriptorBoundedSync(opened.fd, maxBytes).toString("utf-8")
+        : ioFs.readFileSync(opened.fd, "utf-8");
+    if (Buffer.byteLength(raw, "utf-8") > maxBytes) {
+      throw new ConfigIncludeError(
+        `Include file exceeds ${maxBytes} bytes: ${params.includePath}`,
+        params.includePath,
+      );
+    }
     params.onResolvedPath?.(path.normalize(opened.path));
     return raw;
   } finally {
@@ -480,8 +494,7 @@ export function readConfigIncludeFileWithGuards(params: IncludeFileReadParams): 
 // ============================================================================
 
 const defaultResolver: IncludeResolver = {
-  readFile: (p) =>
-    readRegularFileSync({ filePath: p, maxBytes: MAX_INCLUDE_FILE_BYTES }).buffer.toString("utf-8"),
+  readFile: (p) => fs.readFileSync(p, "utf-8"),
   readFileWithGuards: ({ includePath, resolvedPath, rootRealDir }) =>
     readConfigIncludeFileWithGuards({ includePath, resolvedPath, rootRealDir }),
   parseJson: parseJsonWithJson5Fallback,


### PR DESCRIPTION
## Summary
- **Problem:** Config include reads validated file size before opening but used an unbounded descriptor read, so file growth after validation could allocate beyond the 2 MiB limit.
- **Root cause:** The guarded open path ended with `readFileSync(fd)` instead of the shared bounded descriptor reader.
- **Fix:** Read production descriptors through `readFileDescriptorBoundedSync`; retain injected-fs semantics and enforce the same byte cap for reduced/full test shims.
- **Impact:** Include reads stay bounded without bypassing injected filesystem behavior.

## Linked context
N/A (no existing issue)

## Real behavior proof
- **Behavior or issue addressed:** Normal includes must load while files over 2 MiB fail closed.
- **Real environment tested:** Linux, Node 24.13.1, exact head `9e012a76fa1ca2f980f08919704eea83a15638de`.
- **Exact steps or command run:** `node --import tsx --input-type=module -e '<create normal/3 MiB files and call readConfigIncludeFileWithGuards>'`
- **Evidence after fix:** Terminal capture of `node` source-runtime verification:
```text
normal_bytes=2
oversized_rejected=true
exact_head=9e012a76fa1ca2f980f08919704eea83a15638de
```
- **Observed result after fix:** A normal include returns its exact bytes and a 3 MiB include is rejected before an unbounded descriptor allocation.
- **What was not tested:** Concurrent mutation timing on Windows/macOS; the bounded descriptor helper's dependency implementation and types were inspected directly.

## Tests and validation
```text
$ node scripts/run-vitest.mjs src/config/includes.test.ts
Test Files  1 passed (1)
Tests       64 passed (64)
[test] passed 1 Vitest shard in 6.90s

$ git diff --check
# no output
```

## Risk checklist
| Risk | Assessment |
|------|-----------|
| Backward compatible | Yes; injected fs reads are preserved |
| Performance impact | Bounded chunked read only |
| Security improvement | Yes; closes post-open growth allocation gap |
| Requires config migration | No |
| Affects external API | No |
| Tested on all platforms | No; Linux focused proof |
| Documentation needed | No |

AI-assisted: yes. Fresh autoreview was attempted; the local Codex CLI exited before producing findings because its isolated CODEX_HOME rejected PATH helper creation. No autoreview-clean claim is made.
