### PR TITLE
fix(configure): ignore blank gateway token env overrides

### DIFF
--- a/src/commands/configure.wizard.test.ts
+++ b/src/commands/configure.wizard.test.ts
@@ -1,6 +1,7 @@
 // Configure wizard tests cover guided setup routing across gateway, auth, channels, skills, and search.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
+import { withEnvAsync } from "../test-utils/env.js";
 
 const mocks = vi.hoisted(() => {
   const writeConfigFile = vi.fn();
@@ -397,26 +398,22 @@ describe("runConfigureWizard", () => {
     setupBaseWizardState({
       gateway: {
         mode: "local",
-        auth: { token: "configured-token", password: "configured-password" },
+        auth: { token: "t", password: "p" },
       },
     });
-    const prevToken = process.env.OPENCLAW_GATEWAY_TOKEN;
-    const prevPassword = process.env.OPENCLAW_GATEWAY_PASSWORD;
-    try {
-      process.env.OPENCLAW_GATEWAY_TOKEN = "";
-      process.env.OPENCLAW_GATEWAY_PASSWORD = "   ";
-      await runConfigureWizard({ command: "configure", sections: ["gateway"] }, createRuntime());
+    await withEnvAsync(
+      { OPENCLAW_GATEWAY_TOKEN: "", OPENCLAW_GATEWAY_PASSWORD: "   " },
+      async () => {
+        await runConfigureWizard({ command: "configure", sections: ["gateway"] }, createRuntime());
 
-      const probeRequests = mocks.probeGatewayReachable.mock.calls.map(([request]) =>
-        requireRecord(request, "probe request"),
-      );
-      const localProbe = probeRequests.find((request) => request.url === "ws://127.0.0.1:18789");
-      expect(localProbe?.token).toBe("configured-token");
-      expect(localProbe?.password).toBe("configured-password");
-    } finally {
-      process.env.OPENCLAW_GATEWAY_TOKEN = prevToken;
-      process.env.OPENCLAW_GATEWAY_PASSWORD = prevPassword;
-    }
+        const probeRequests = mocks.probeGatewayReachable.mock.calls.map(([request]) =>
+          requireRecord(request, "probe request"),
+        );
+        const localProbe = probeRequests.find((request) => request.url === "ws://127.0.0.1:18789");
+        expect(localProbe?.token).toBe("t");
+        expect(localProbe?.password).toBe("p");
+      },
+    );
   });
 
   it("advertises LAN Control UI links while probing the local gateway", async () => {

--- a/src/commands/configure.wizard.test.ts
+++ b/src/commands/configure.wizard.test.ts
@@ -393,6 +393,32 @@ describe("runConfigureWizard", () => {
     expect(remoteProbe?.timeoutMs).toBe(300);
   });
 
+  it("ignores blank gateway token env vars and falls back to configured values", async () => {
+    setupBaseWizardState({
+      gateway: {
+        mode: "local",
+        auth: { token: "configured-token", password: "configured-password" },
+      },
+    });
+    const prevToken = process.env.OPENCLAW_GATEWAY_TOKEN;
+    const prevPassword = process.env.OPENCLAW_GATEWAY_PASSWORD;
+    try {
+      process.env.OPENCLAW_GATEWAY_TOKEN = "";
+      process.env.OPENCLAW_GATEWAY_PASSWORD = "   ";
+      await runConfigureWizard({ command: "configure", sections: ["gateway"] }, createRuntime());
+
+      const probeRequests = mocks.probeGatewayReachable.mock.calls.map(([request]) =>
+        requireRecord(request, "probe request"),
+      );
+      const localProbe = probeRequests.find((request) => request.url === "ws://127.0.0.1:18789");
+      expect(localProbe?.token).toBe("configured-token");
+      expect(localProbe?.password).toBe("configured-password");
+    } finally {
+      process.env.OPENCLAW_GATEWAY_TOKEN = prevToken;
+      process.env.OPENCLAW_GATEWAY_PASSWORD = prevPassword;
+    }
+  });
+
   it("advertises LAN Control UI links while probing the local gateway", async () => {
     setupBaseWizardState({
       gateway: {

--- a/src/commands/configure.wizard.ts
+++ b/src/commands/configure.wizard.ts
@@ -123,8 +123,9 @@ async function runGatewayHealthCheck(params: {
     value: params.cfg.gateway?.auth?.password,
     path: "gateway.auth.password",
   });
-  const token = process.env.OPENCLAW_GATEWAY_TOKEN ?? configuredToken;
-  const password = process.env.OPENCLAW_GATEWAY_PASSWORD ?? configuredPassword;
+  const token = normalizeOptionalString(process.env.OPENCLAW_GATEWAY_TOKEN) ?? configuredToken;
+  const password =
+    normalizeOptionalString(process.env.OPENCLAW_GATEWAY_PASSWORD) ?? configuredPassword;
 
   await waitForGatewayReachable({
     url: wsUrl,
@@ -439,8 +440,10 @@ export async function runConfigureWizard(
         ]);
         return probeGatewayReachable({
           url: localUrl,
-          token: process.env.OPENCLAW_GATEWAY_TOKEN ?? baseLocalProbeToken,
-          password: process.env.OPENCLAW_GATEWAY_PASSWORD ?? baseLocalProbePassword,
+          token: normalizeOptionalString(process.env.OPENCLAW_GATEWAY_TOKEN) ?? baseLocalProbeToken,
+          password:
+            normalizeOptionalString(process.env.OPENCLAW_GATEWAY_PASSWORD) ??
+            baseLocalProbePassword,
           timeoutMs: GATEWAY_HINT_PROBE_TIMEOUT_MS,
         });
       })();
@@ -826,21 +829,21 @@ export async function runConfigureWizard(
       tlsEnabled: nextConfig.gateway?.tls?.enabled === true,
     });
     const newPassword =
-      process.env.OPENCLAW_GATEWAY_PASSWORD ??
+      normalizeOptionalString(process.env.OPENCLAW_GATEWAY_PASSWORD) ??
       (await resolveGatewaySecretInputForWizard({
         cfg: nextConfig,
         value: nextConfig.gateway?.auth?.password,
         path: "gateway.auth.password",
       }));
     const oldPassword =
-      process.env.OPENCLAW_GATEWAY_PASSWORD ??
+      normalizeOptionalString(process.env.OPENCLAW_GATEWAY_PASSWORD) ??
       (await resolveGatewaySecretInputForWizard({
         cfg: baseConfig,
         value: baseConfig.gateway?.auth?.password,
         path: "gateway.auth.password",
       }));
     const token =
-      process.env.OPENCLAW_GATEWAY_TOKEN ??
+      normalizeOptionalString(process.env.OPENCLAW_GATEWAY_TOKEN) ??
       (await resolveGatewaySecretInputForWizard({
         cfg: nextConfig,
         value: nextConfig.gateway?.auth?.token,


### PR DESCRIPTION
## Summary
- **Problem:** Empty or whitespace-only `OPENCLAW_GATEWAY_TOKEN` and `OPENCLAW_GATEWAY_PASSWORD` values were treated as configured credentials by the configure wizard.
- **Root cause:** Nullish coalescing does not treat blank strings as absent.
- **Fix:** Normalize optional environment values at every wizard gateway probe/health/save boundary while preserving configured fallback credentials.
- **Impact:** Configure uses the configured token/password when env overrides are blank, without changing nonblank env precedence.

## Linked context
N/A (no existing issue)

## Real behavior proof
- **Behavior or issue addressed:** Blank gateway credential environment overrides must fall back to configured credentials.
- **Real environment tested:** Linux, Node 24.13.1, exact head `d1b069ce45da40dd9022880af0a4ca879706ee56`.
- **Exact steps or command run:** `node --import tsx --input-type=module -e '<run the credential-precedence probe against the exact-head source helper>'`
- **Evidence after fix:** Terminal capture of `node` source-runtime credential-precedence verification (redacted values):
```text
blank: token=configured-fallback password=configured-password
nonblank: token=env-override password=env-password
exact_head=d1b069ce45da40dd9022880af0a4ca879706ee56
```
- **Observed result after fix:** Blank and whitespace-only environment values resolve to the configured credentials, while nonblank environment values still take precedence.
- **What was not tested:** Windows/macOS configure flows and an interactive live Gateway; the change is confined to credential selection and the focused wizard suite passed.

## Tests and validation
```text
$ node scripts/run-vitest.mjs src/commands/configure.wizard.test.ts
Test Files  1 passed (1)
Tests       18 passed (18)
[test] passed 1 Vitest shard in 13.58s

$ git diff --check
# no output
```

## Risk checklist
| Risk | Assessment |
|------|-----------|
| Backward compatible | Yes; nonblank env values still win |
| Performance impact | Negligible |
| Security improvement | Yes; avoids blank credential selection |
| Requires config migration | No |
| Affects external API | No |
| Tested on all platforms | No; Linux focused proof |
| Documentation needed | No |

AI-assisted: yes. Fresh autoreview was attempted; the local Codex CLI exited before producing findings because its isolated CODEX_HOME rejected PATH helper creation. No autoreview-clean claim is made.