### PR TITLE
fix(sms): ignore blank public webhook URL env override

### DIFF
--- a/extensions/sms/src/accounts.test.ts
+++ b/extensions/sms/src/accounts.test.ts
@@ -205,6 +205,37 @@ describe("SMS account config", () => {
     });
   });
 
+  it("ignores a blank SMS_PUBLIC_WEBHOOK_URL env override", () => {
+    process.env.TWILIO_ACCOUNT_SID = "AC-env";
+    process.env.TWILIO_AUTH_TOKEN = "env-token";
+    process.env.TWILIO_SMS_FROM = "+15550001111";
+    process.env.SMS_PUBLIC_WEBHOOK_URL = " ";
+
+    expect(resolveSmsAccount({})).toMatchObject({
+      accountId: "default",
+      publicWebhookUrl: "",
+    });
+  });
+
+  it("prefers a config publicWebhookUrl over a blank SMS_PUBLIC_WEBHOOK_URL env override", () => {
+    process.env.SMS_PUBLIC_WEBHOOK_URL = "\t";
+
+    expect(
+      resolveSmsAccount({
+        channels: {
+          sms: {
+            accountSid: "AC123",
+            authToken: "token",
+            fromNumber: "+15550001111",
+            publicWebhookUrl: "https://example.com/webhooks/sms",
+          },
+        },
+      }),
+    ).toMatchObject({
+      publicWebhookUrl: "https://example.com/webhooks/sms",
+    });
+  });
+
   it("coerces numeric allowFrom entries accepted by the config schema", () => {
     const parsed = parseSmsConfig({
       accountSid: "AC123",

--- a/extensions/sms/src/accounts.ts
+++ b/extensions/sms/src/accounts.ts
@@ -14,7 +14,10 @@ import {
   hasConfiguredSecretInput,
   normalizeResolvedSecretInputString,
 } from "openclaw/plugin-sdk/secret-input";
-import { normalizeStringEntries } from "openclaw/plugin-sdk/string-coerce-runtime";
+import {
+  normalizeOptionalString,
+  normalizeStringEntries,
+} from "openclaw/plugin-sdk/string-coerce-runtime";
 import { normalizeSmsAllowFrom, normalizeSmsPhoneNumber } from "./phone.js";
 import type { ResolvedSmsAccount, SmsChannelConfig } from "./types.js";
 
@@ -119,7 +122,9 @@ export function resolveSmsAccount(
     ? process.env.TWILIO_MESSAGING_SERVICE_SID
     : undefined;
   const envWebhookPath = useEnvFallbacks ? process.env.SMS_WEBHOOK_PATH : undefined;
-  const envPublicWebhookUrl = useEnvFallbacks ? process.env.SMS_PUBLIC_WEBHOOK_URL : undefined;
+  const envPublicWebhookUrl = useEnvFallbacks
+    ? normalizeOptionalString(process.env.SMS_PUBLIC_WEBHOOK_URL)
+    : undefined;
   const envAllowFrom = useEnvFallbacks ? process.env.SMS_ALLOWED_USERS : undefined;
   const envTextChunkLimit = useEnvFallbacks ? process.env.SMS_TEXT_CHUNK_LIMIT : undefined;
   const envDisableSignatureValidation = useEnvFallbacks


### PR DESCRIPTION
## Summary
- **Problem:** Blank SMS_PUBLIC_WEBHOOK_URL bypasses ?? fallback, silently disabling Twilio signature verification.
- **Fix:** Wrap env read with normalizeOptionalString() so blank values trigger ?? fallback.

## Linked context
N/A (no existing issue)

## Real behavior proof
- **Behavior or issue addressed:** Blank SMS_PUBLIC_WEBHOOK_URL bypasses ?? fallback, silently disabling Twilio signature verification.
- **Real environment tested:** Linux, Node 24
- **Evidence after fix:** Terminal capture of node runtime verification confirming correct behavior.
- **What was not tested:** Cross-platform.

## Tests and validation
```
14 tests pass
```

## Risk checklist
| Risk | Assessment |
|------|-----------|
| Backward compatible | Yes |
| Security improvement | Yes |
| Requires config migration | No |
| Documentation needed | No |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
