### PR TITLE
fix(google): surface public client PKCE mode when OAuth client secret is missing

### DIFF
--- a/extensions/google/oauth.credentials.ts
+++ b/extensions/google/oauth.credentials.ts
@@ -350,6 +350,10 @@ function findGeminiCliCredentialsInTree(
   return null;
 }
 
+export function isPublicClientOAuthConfig(): boolean {
+  return Boolean(resolveEnv(CLIENT_ID_KEYS)) && !resolveEnv(CLIENT_SECRET_KEYS);
+}
+
 export function resolveOAuthClientConfig(): { clientId: string; clientSecret?: string } {
   const envClientId = resolveEnv(CLIENT_ID_KEYS);
   const envClientSecret = resolveEnv(CLIENT_SECRET_KEYS);

--- a/extensions/google/oauth.shared.ts
+++ b/extensions/google/oauth.shared.ts
@@ -4,6 +4,7 @@ export const CLIENT_SECRET_KEYS = [
   "OPENCLAW_GEMINI_OAUTH_CLIENT_SECRET",
   "GEMINI_CLI_OAUTH_CLIENT_SECRET",
 ];
+export const MISSING_CLIENT_SECRET_GUIDANCE = `If your Google OAuth client is a confidential web or desktop client, set ${CLIENT_SECRET_KEYS.join(" or ")} and sign in again.`;
 export const REDIRECT_URI = "http://localhost:8085/oauth2callback";
 export const AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth";
 export const TOKEN_URL = "https://oauth2.googleapis.com/token";

--- a/extensions/google/oauth.test.ts
+++ b/extensions/google/oauth.test.ts
@@ -995,6 +995,101 @@ describe("loginGeminiCliOAuth", () => {
     ).rejects.toThrow("OAuth state mismatch - please try again");
   });
 
+  it("notes public client PKCE mode when no client secret is configured", async () => {
+    delete process.env.OPENCLAW_GEMINI_OAUTH_CLIENT_SECRET;
+    const { requests } = installGeminiOAuthFetchMock(({ url }) => {
+      if (url === LOAD_PROD) {
+        return responseJson({
+          currentTier: { id: "standard-tier" },
+          cloudaicompanionProject: { id: "prod-project" },
+        });
+      }
+      return undefined;
+    });
+
+    const { loginGeminiCliOAuth } = await import("./oauth.js");
+    const { notes } = await runRemoteLoginWithCapturedAuthUrl(loginGeminiCliOAuth);
+
+    expect(notes).toContainEqual(
+      expect.stringContaining("continues as a public client using PKCE only"),
+    );
+    expect(notes).toContainEqual(expect.stringContaining("OPENCLAW_GEMINI_OAUTH_CLIENT_SECRET"));
+
+    const tokenRequest = requireRecordedRequest(
+      requests.find((request) => request.url === TOKEN_URL),
+      "token",
+    );
+    expect(getFormField(tokenRequest.init?.body, "client_secret")).toBeNull();
+  });
+
+  it("does not note public client mode when a client secret is configured", async () => {
+    const { requests } = installGeminiOAuthFetchMock(({ url }) => {
+      if (url === LOAD_PROD) {
+        return responseJson({
+          currentTier: { id: "standard-tier" },
+          cloudaicompanionProject: { id: "prod-project" },
+        });
+      }
+      return undefined;
+    });
+
+    const { loginGeminiCliOAuth } = await import("./oauth.js");
+    const { notes } = await runRemoteLoginWithCapturedAuthUrl(loginGeminiCliOAuth);
+
+    expect(notes).not.toContainEqual(expect.stringContaining("public client"));
+
+    const tokenRequest = requireRecordedRequest(
+      requests.find((request) => request.url === TOKEN_URL),
+      "token",
+    );
+    expect(getFormField(tokenRequest.init?.body, "client_secret")).toBe(
+      "GOCSPX-test-client-secret",
+    );
+  });
+
+  it("appends missing client secret guidance when token exchange fails without a secret", async () => {
+    delete process.env.OPENCLAW_GEMINI_OAUTH_CLIENT_SECRET;
+    installGeminiOAuthFetchMock(() => undefined, {
+      tokenResponse: () =>
+        responseJson(
+          { error: "invalid_request", error_description: "client_secret is missing." },
+          400,
+        ),
+    });
+
+    const { exchangeCodeForTokens } = await import("./oauth.token.js");
+    const failure = exchangeCodeForTokens("oauth-code", "pkce-verifier");
+    await expect(failure).rejects.toThrow("client_secret is missing.");
+    await expect(failure).rejects.toThrow("No client_secret was sent because none is configured.");
+    await expect(failure).rejects.toThrow("OPENCLAW_GEMINI_OAUTH_CLIENT_SECRET");
+  });
+
+  it("keeps the raw token error for unrelated failures when no client secret is configured", async () => {
+    delete process.env.OPENCLAW_GEMINI_OAUTH_CLIENT_SECRET;
+    installGeminiOAuthFetchMock(() => undefined, {
+      tokenResponse: () =>
+        responseJson({ error: "invalid_grant", error_description: "Bad Request" }, 400),
+    });
+
+    const { exchangeCodeForTokens } = await import("./oauth.token.js");
+    const failure = exchangeCodeForTokens("oauth-code", "pkce-verifier");
+    await expect(failure).rejects.toThrow("invalid_grant");
+    await expect(failure).rejects.not.toThrow("No client_secret was sent");
+    await expect(failure).rejects.not.toThrow("OPENCLAW_GEMINI_OAUTH_CLIENT_SECRET");
+  });
+
+  it("keeps the raw token error when a client secret was sent", async () => {
+    installGeminiOAuthFetchMock(() => undefined, {
+      tokenResponse: () =>
+        responseJson({ error: "invalid_grant", error_description: "Bad Request" }, 400),
+    });
+
+    const { exchangeCodeForTokens } = await import("./oauth.token.js");
+    const failure = exchangeCodeForTokens("oauth-code", "pkce-verifier");
+    await expect(failure).rejects.toThrow("invalid_grant");
+    await expect(failure).rejects.not.toThrow("No client_secret was sent");
+  });
+
   it("rejects first login when project discovery fails and no stored identity exists", async () => {
     const { requests } = installGeminiOAuthFetchMock(({ url }) => {
       if ([LOAD_PROD, LOAD_DAILY, LOAD_AUTOPUSH].includes(url)) {

--- a/extensions/google/oauth.token.ts
+++ b/extensions/google/oauth.token.ts
@@ -11,10 +11,16 @@ import { resolveOAuthClientConfig } from "./oauth.credentials.js";
 import { fetchWithTimeout } from "./oauth.http.js";
 import { resolveGoogleOAuthIdentity, resolveGooglePersonalOAuthIdentity } from "./oauth.project.js";
 import { isGeminiCliPersonalOAuth } from "./oauth.settings.js";
-import { REDIRECT_URI, TOKEN_URL, type GeminiCliOAuthCredentials } from "./oauth.shared.js";
+import {
+  MISSING_CLIENT_SECRET_GUIDANCE,
+  REDIRECT_URI,
+  TOKEN_URL,
+  type GeminiCliOAuthCredentials,
+} from "./oauth.shared.js";
 
 const TOKEN_EXPIRY_BUFFER_MS = 5 * 60 * 1000;
 const GOOGLE_OAUTH_TOKEN_ERROR_BODY_LIMIT_BYTES = 8 * 1024;
+const MISSING_CLIENT_SECRET_ERROR_PATTERN = /client[_ ]?secret/i;
 
 async function requestTokenGrant(
   body: URLSearchParams,
@@ -40,7 +46,11 @@ async function requestTokenGrant(
       response,
       GOOGLE_OAUTH_TOKEN_ERROR_BODY_LIMIT_BYTES,
     );
-    throw new Error(`Token exchange failed: ${errorText}`);
+    const hint =
+      !body.has("client_secret") && MISSING_CLIENT_SECRET_ERROR_PATTERN.test(errorText)
+        ? ` No client_secret was sent because none is configured. ${MISSING_CLIENT_SECRET_GUIDANCE}`
+        : "";
+    throw new Error(`Token exchange failed: ${errorText}${hint}`);
   }
 
   return readProviderJsonResponse<{

--- a/extensions/google/oauth.ts
+++ b/extensions/google/oauth.ts
@@ -1,5 +1,6 @@
 // Google plugin module implements oauth behavior.
 import type { OAuthCredential } from "openclaw/plugin-sdk/provider-auth";
+import { isPublicClientOAuthConfig } from "./oauth.credentials.js";
 import {
   buildAuthUrl,
   generateOAuthState,
@@ -8,7 +9,11 @@ import {
   shouldUseManualOAuthFlow,
   waitForLocalCallback,
 } from "./oauth.flow.js";
-import type { GeminiCliOAuthContext, GeminiCliOAuthCredentials } from "./oauth.shared.js";
+import {
+  MISSING_CLIENT_SECRET_GUIDANCE,
+  type GeminiCliOAuthContext,
+  type GeminiCliOAuthCredentials,
+} from "./oauth.shared.js";
 import { exchangeCodeForTokens, refreshTokensForGeminiCli } from "./oauth.token.js";
 
 export async function loginGeminiCliOAuth(
@@ -29,6 +34,13 @@ export async function loginGeminiCliOAuth(
         ].join("\n"),
     "Gemini CLI OAuth",
   );
+
+  if (isPublicClientOAuthConfig()) {
+    await ctx.note(
+      `No OAuth client secret is configured, so sign-in continues as a public client using PKCE only. ${MISSING_CLIENT_SECRET_GUIDANCE}`,
+      "Gemini CLI OAuth",
+    );
+  }
 
   const { verifier, challenge } = generatePkce();
   const state = generateOAuthState();


### PR DESCRIPTION
Related: #54299

## What Problem This Solves

Fixes an issue where users who configure Gemini CLI OAuth with only a client id (GEMINI_CLI_OAUTH_CLIENT_ID or OPENCLAW_GEMINI_OAUTH_CLIENT_ID) would silently proceed through the whole browser sign-in and then fail at the very end with an opaque Google error when their OAuth client is confidential. The token exchange conditionally omits client_secret when none is configured, so the flow never tells the user it downgraded to public client PKCE mode, and the terminal failure ("client_secret is missing.") gives no hint which setting is absent. This is the remaining live half of issue #54299; the occupied callback port half was already fixed on main for both the google and google-meet plugins (manual paste fallback, PR #96492).

## Why This Change Was Made

Maintainer direction on #54299 flagged fail-closed as a product decision (client-id-only PKCE setups are legitimately supported), and the ClawSweeper review of that issue recommended keeping optional client_secret support while making the mode explicit and warning when a confidential client setup appears incomplete. This change implements exactly that boundary: login now posts a notice when it proceeds without a client secret, and a failed token grant that sent no client_secret appends guidance naming the client secret env keys. No contract changes: client-id-only logins still proceed, extracted Gemini CLI credentials (which always include a secret) are unaffected, and no new config surface is added.

Two revisions since the first push, both from the ClawSweeper review round:

- The token-grant hint is now gated on the provider actually naming the secret in its rejection, not on request shape alone. Previously `!body.has("client_secret")` was the whole condition, so a public-client login failing on an expired or already-used authorization code would get confidential-client setup advice stapled onto an `invalid_grant` that was the real actionable failure. The hint now additionally requires the response body to mention `client_secret`; every other grant failure relays Google's original error untouched.
- The login-time notice no longer calls `resolveOAuthClientConfig()`. That helper throws "Gemini CLI not found..." when neither an env client id nor an installed Gemini CLI is present, so calling it at the top of login moved that failure ahead of the auth URL being printed and changed the observable failure ordering of the flow. It is replaced by a non-throwing `isPublicClientOAuthConfig()` predicate, which is also the semantically precise condition: credentials extracted from an installed Gemini CLI always carry a secret, so env-client-id-without-env-secret is exactly the public-client case.

## User Impact

Users signing in with a client-id-only OAuth configuration now see up front that the flow is using public client PKCE mode and which env var to set if their client is confidential. When the token exchange is rejected because the secret was never sent, the error now says so and names OPENCLAW_GEMINI_OAUTH_CLIENT_SECRET / GEMINI_CLI_OAUTH_CLIENT_SECRET instead of only relaying Google's terse response. Correctly configured setups (secret present, or credentials extracted from an installed Gemini CLI) see no change, and grant failures unrelated to the client secret keep their original error text.

## Evidence

Rebased onto current main and re-proven live. The real `loginGeminiCliOAuth` production flow was driven end to end against the real Google token endpoint, with nothing stubbed anywhere in the path, on pristine main and on this branch head with identical inputs. Full field block below.

## Real behavior proof
Behavior addressed: A client-id-only Gemini CLI OAuth setup silently downgrades to public client PKCE mode and then dies at the token exchange with Google's bare "client_secret is missing." response, never naming the env var the user has to set.
Real environment tested: the real exported `loginGeminiCliOAuth` production flow from `extensions/google/oauth.ts`, driven with the same context shape `gemini-cli-provider.ts` builds for it (remote/manual paste branch), real `generatePkce` and `generateOAuthState`, real `buildAuthUrl`, real `parseCallbackInput`, and a real HTTPS POST to `https://oauth2.googleapis.com/token`. Nothing was stubbed: `globalThis.fetch` untouched, no interception of the network. Run on pristine main@1a5d71ee6bb7c98b673de5ff9e45008cf42391c2 with only the changed production files reverted, and on PR head 8998929da1ec57170372dd13aeed435b7410bd36, both with `GEMINI_CLI_OAUTH_CLIENT_ID` set to the Gemini CLI client id and both client secret env keys unset.
Exact steps or command run after this patch: `env -u OPENCLAW_GEMINI_OAUTH_CLIENT_SECRET -u GEMINI_CLI_OAUTH_CLIENT_SECRET GEMINI_CLI_OAUTH_CLIENT_ID=681255809395-oo8ft2oprdrnp9e3aqf6av3hmdib135j.apps.googleusercontent.com node --import tsx proof-harness.ts out.txt`, where the harness only supplies the terminal callbacks (note, log, prompt, progress) and pastes back the redirect URL carrying the state the flow itself generated.
Evidence after fix:
```
# BEFORE (pristine main 1a5d71ee6bb7c98b673de5ff9e45008cf42391c2)
[note Gemini CLI OAuth] You are running in a remote/VPS environment. / A URL will be shown for you to open in your LOCAL browser. / After signing in, copy the redirect URL and paste it back here.
[progress] OAuth URL ready
[log]  / Open this URL in your LOCAL browser: /  / <auth-url> /
[openUrl] <auth-url>
[note Gemini CLI OAuth] Open this URL in your LOCAL browser: /  / <auth-url>
[progress] Waiting for you to paste the callback URL...
[progress] Exchanging authorization code for tokens...
[result] login failed: Token exchange failed: { /   "error": "invalid_request", /   "error_description": "client_secret is missing." / }

# AFTER (this patch, identical inputs, head 8998929da1ec57170372dd13aeed435b7410bd36)
[note Gemini CLI OAuth] You are running in a remote/VPS environment. / A URL will be shown for you to open in your LOCAL browser. / After signing in, copy the redirect URL and paste it back here.
[note Gemini CLI OAuth] No OAuth client secret is configured, so sign-in continues as a public client using PKCE only. If your Google OAuth client is a confidential web or desktop client, set OPENCLAW_GEMINI_OAUTH_CLIENT_SECRET or GEMINI_CLI_OAUTH_CLIENT_SECRET and sign in again.
[progress] OAuth URL ready
[log]  / Open this URL in your LOCAL browser: /  / <auth-url> /
[openUrl] <auth-url>
[note Gemini CLI OAuth] Open this URL in your LOCAL browser: /  / <auth-url>
[progress] Waiting for you to paste the callback URL...
[progress] Exchanging authorization code for tokens...
[result] login failed: Token exchange failed: { /   "error": "invalid_request", /   "error_description": "client_secret is missing." / } No client_secret was sent because none is configured. If your Google OAuth client is a confidential web or desktop client, set OPENCLAW_GEMINI_OAUTH_CLIENT_SECRET or GEMINI_CLI_OAUTH_CLIENT_SECRET and sign in again.
```
Observed result after fix: On byte-identical inputs against the live Google endpoint, exactly two user-visible strings change. The flow now announces public client PKCE mode before the sign-in URL is shown instead of leaving the user to discover it from the failure, and Google's rejection now carries a sentence naming the two env keys that would have supplied the secret. Everything else in the sequence, including the auth URL, the callback parse, the state check and Google's own error body, is identical between the two runs.
What was not tested: No successful token grant was exercised in either direction, because a real success needs a genuine authorization code from an interactive Google sign-in; the run reaches the live endpoint and stops at Google's rejection. Extraction of credentials from a locally installed Gemini CLI was not exercised. Windows and WSL2 were not covered, and only the remote/manual paste branch of the flow was driven; the localhost callback branch shares the same notice and token code path but was not run live.

### Additional live run: secret configured, guidance correctly withheld

Same harness, same live endpoint, patched tree, with `OPENCLAW_GEMINI_OAUTH_CLIENT_SECRET` set. Google returns a rejection whose text does mention the client secret, and the guidance is still correctly withheld because the request did carry one, which is the request-shape half of the gate doing its job:

```
[note Gemini CLI OAuth] You are running in a remote/VPS environment. / A URL will be shown for you to open in your LOCAL browser. / After signing in, copy the redirect URL and paste it back here.
[progress] OAuth URL ready
[log]  / Open this URL in your LOCAL browser: /  / <auth-url> /
[openUrl] <auth-url>
[note Gemini CLI OAuth] Open this URL in your LOCAL browser: /  / <auth-url>
[progress] Waiting for you to paste the callback URL...
[progress] Exchanging authorization code for tokens...
[result] login failed: Token exchange failed: { /   "error": "invalid_client", /   "error_description": "The provided client secret is invalid." / }
```

No public client notice, and no appended guidance, on a rejection that names the client secret.

### Local validation on the rebased head

- `node scripts/run-vitest.mjs run extensions/google/oauth.test.ts extensions/google/oauth-token-shared.test.ts extensions/google/oauth.local-login.test.ts extensions/google/oauth.http.test.ts`: 4 files passed, 50 passed.
- The rebase onto `origin/main` 1a5d71ee6b was conflict free. The only main-side movement in the touched files was `extensions/google/oauth.credentials.ts` adopting `readSecretFileSync`, which lands in the import block and does not overlap this diff.
