### PR TITLE
fix(ui): keep Windows catalog sessions in one project group

### DIFF
--- a/ui/src/components/app-sidebar-session-catalog-render.ts
+++ b/ui/src/components/app-sidebar-session-catalog-render.ts
@@ -60,6 +60,11 @@ type SessionCatalogGroupsParams = {
   ownerId?: string | null;
   renderLiveRow: (row: GatewaySessionRow, display: CatalogBackingSessionDisplay) => unknown;
   onToggleSection: (sectionId: string) => void;
+  onMigrateCollapsedProjectSection: (
+    sectionPrefix: string,
+    sectionId: string,
+    projectIdentity: string,
+  ) => boolean;
   draggingSectionId: string | null;
   sectionDropTarget: { sectionId: string; position: "before" | "after" } | null;
   onSectionDragOver: (event: DragEvent, sectionId: string) => void;
@@ -472,14 +477,25 @@ function renderCatalogHostGroup(
                 (group) => group.key,
                 (group) => {
                   const sectionId = `catalog-${group.kind}:${catalog.id}:${host.hostId}:${group.key}`;
+                  const sectionPrefix = `catalog-project:${catalog.id}:${host.hostId}:`;
+                  const migrated =
+                    group.kind === "project"
+                      ? params.onMigrateCollapsedProjectSection(
+                          sectionPrefix,
+                          sectionId,
+                          group.key.slice("project:".length),
+                        )
+                      : false;
                   const legacySectionId = group.legacySectionKey
                     ? `catalog-project:${catalog.id}:${host.hostId}:${group.legacySectionKey}`
                     : null;
                   const collapsedSectionId = params.collapsedSections.has(sectionId)
                     ? sectionId
-                    : legacySectionId && params.collapsedSections.has(legacySectionId)
-                      ? legacySectionId
-                      : null;
+                    : migrated
+                      ? sectionId
+                      : legacySectionId && params.collapsedSections.has(legacySectionId)
+                        ? legacySectionId
+                        : null;
                   const collapsed = collapsedSectionId !== null;
                   return html`
                     <div class="sidebar-session-catalog-project" role="listitem">

--- a/ui/src/components/app-sidebar-session-list-render.ts
+++ b/ui/src/components/app-sidebar-session-list-render.ts
@@ -11,7 +11,10 @@ import {
   presenceViewerLabel,
   projectPresenceViewers,
 } from "../lib/presence-users.ts";
-import type { CatalogProjectGrouping } from "../lib/sessions/catalog-project-grouping.ts";
+import {
+  migrateCollapsedCatalogProjectSection,
+  type CatalogProjectGrouping,
+} from "../lib/sessions/catalog-project-grouping.ts";
 import { openCatalogSessionInTerminal } from "../lib/sessions/catalog-terminal.ts";
 import type { SidebarSessionSection } from "../lib/sessions/grouping.ts";
 import type { SessionCatalogGroupsRenderer } from "./app-sidebar-session-catalog-render.ts";
@@ -473,6 +476,19 @@ function renderSessionCatalog(params: {
           display,
         }),
       onToggleSection: (sectionId) => host.toggleSection(sectionId),
+      onMigrateCollapsedProjectSection: (prefix, id, projectIdentity) => {
+        const sections = migrateCollapsedCatalogProjectSection(
+          host.collapsedSessionSections,
+          prefix,
+          id,
+          projectIdentity,
+        );
+        if (!sections) {
+          return false;
+        }
+        host.sessionOrganizer.saveCollapsedSessionSections(sections);
+        return true;
+      },
       draggingSectionId: host.sessionOrganizer.draggingSidebarSection,
       sectionDropTarget: host.sessionOrganizer.sidebarSectionDropTarget,
       onSectionDragOver: (event, sectionId) => host.sectionDragOver(event, sectionId),

--- a/ui/src/components/app-sidebar-session-row-render.ts
+++ b/ui/src/components/app-sidebar-session-row-render.ts
@@ -77,6 +77,7 @@ export interface SessionListHost {
     SessionOrganizerController,
     | "draggingSidebarSection"
     | "draggingSessionKey"
+    | "saveCollapsedSessionSections"
     | "sessionDropTarget"
     | "sidebarSectionDropTarget"
     | "sessionListRemovalDrop"

--- a/ui/src/components/app-sidebar-session-types.test.ts
+++ b/ui/src/components/app-sidebar-session-types.test.ts
@@ -9,6 +9,7 @@ import {
   loadStoredSidebarSessionOwnerFilter,
   loadStoredSidebarSessionsShowPreview,
   setStoredSessionCatalogHidden,
+  storeCollapsedSessionSections,
   storeSidebarSessionSortMode,
   storeSidebarSessionStatusFilter,
   storeSidebarSessionOwnerFilter,
@@ -157,6 +158,47 @@ describe("sidebar session sort preference", () => {
 describe("collapsed sidebar sections preference", () => {
   it("defaults Coding to compact while Online remains expanded", () => {
     expect([...loadStoredCollapsedSessionSections()]).toEqual(["work"]);
+  });
+
+  it.each([
+    [String.raw`C:\Work\Repo\.CLAUDE\WORKTREES\task\src`, String.raw`C:\Work\Repo`],
+    [String.raw`\\host\share\Repo\.CLAUDE\WORKTREES\task`, String.raw`\\host\share\Repo`],
+    [String.raw`\Work\Repo\.CLAUDE\WORKTREES\task`, String.raw`\Work\Repo`],
+  ])(
+    "migrates regular project collapse keys and preserves later expansion: %s",
+    (oldPath, path) => {
+      const storageKey = "openclaw:sidebar:sessions:collapsed-sections";
+      const unchanged = [
+        "work",
+        "category:project:example",
+        "catalog-project:codex:gateway:local:project:C:\\Work\\Repo",
+        "project:/work/Repo/.CLAUDE/WORKTREES/task",
+      ];
+      localStorage.setItem(storageKey, JSON.stringify([`project:${oldPath}`, ...unchanged]));
+
+      const collapsed = loadStoredCollapsedSessionSections();
+      expect([...collapsed]).toEqual([`project:${path}`, ...unchanged]);
+      expect(JSON.parse(localStorage.getItem(storageKey) ?? "[]")).toEqual([...collapsed]);
+      expect(loadStoredCollapsedSessionSections()).toEqual(collapsed);
+
+      // A later user expansion must not be undone by an old alias on reload.
+      storeCollapsedSessionSections(new Set(unchanged));
+      expect([...loadStoredCollapsedSessionSections()]).toEqual(unchanged);
+    },
+  );
+
+  it("keeps migrated collapse preferences when storage rejects writes", () => {
+    localStorage.setItem(
+      "openclaw:sidebar:sessions:collapsed-sections",
+      JSON.stringify([String.raw`project:C:\Work\Repo\.CLAUDE\WORKTREES\task`, "groups"]),
+    );
+    localStorage.setItem = () => {
+      throw new Error("storage is read-only");
+    };
+    expect([...loadStoredCollapsedSessionSections()]).toEqual([
+      String.raw`project:C:\Work\Repo`,
+      "groups",
+    ]);
   });
 });
 

--- a/ui/src/components/app-sidebar-session-types.ts
+++ b/ui/src/components/app-sidebar-session-types.ts
@@ -16,6 +16,7 @@ import type { ApplicationContext } from "../app/context.ts";
 import type { BoardFace } from "../lib/board/settings.ts";
 import type { SessionWorkContext } from "../lib/session-display.ts";
 import {
+  foldWorktreeCheckoutPath,
   normalizeCatalogProjectGrouping,
   type CatalogProjectGrouping,
 } from "../lib/sessions/catalog-project-grouping.ts";
@@ -349,11 +350,33 @@ export function loadStoredCollapsedSessionSections(): ReadonlySet<string> {
       return new Set(["work"]);
     }
     const parsed: unknown = JSON.parse(raw);
-    return new Set(
+    const sections = new Set(
       Array.isArray(parsed)
         ? parsed.flatMap((value) => (typeof value === "string" && value ? [value] : []))
         : [],
     );
+    let changed = false;
+    const migrated = new Set(
+      [...sections].map((id) => {
+        if (!id.startsWith("project:")) {
+          return id;
+        }
+        // Regular sidebar keys use the folded display path, not the catalog
+        // identity. Migrate before rendering so expansion cannot revive an alias.
+        const path = foldWorktreeCheckoutPath(id.slice("project:".length));
+        const nextId = path ? `project:${path}` : id;
+        changed ||= nextId !== id;
+        return nextId;
+      }),
+    );
+    if (changed) {
+      try {
+        storeCollapsedSessionSections(migrated);
+      } catch {
+        // Preserve the migrated in-memory choice when storage is read-only.
+      }
+    }
+    return migrated;
   } catch {
     return new Set(["work"]);
   }

--- a/ui/src/e2e/codex-sessions-windows-collapse.e2e.test.ts
+++ b/ui/src/e2e/codex-sessions-windows-collapse.e2e.test.ts
@@ -14,7 +14,7 @@ const catalogGroupingStorageKey = "openclaw:sidebar:sessions:catalog-grouping";
 const collapsedSessionSectionsStorageKey = "openclaw:sidebar:sessions:collapsed-sections";
 
 suite.define(() => {
-  it("migrates a collapsed Windows project key and keeps it collapsed after reload", async () => {
+  it("migrates catalog and regular Windows project keys through reload and expansion", async () => {
     await suite.withPage(
       {
         colorScheme: "dark",
@@ -33,22 +33,45 @@ suite.define(() => {
         const legacySectionId = String.raw`catalog-project:codex:gateway:local:project:C:\WORK\OPENCLAW\.CLAUDE\WORKTREES\fix-older`;
         const canonicalSectionId =
           "catalog-project:codex:gateway:local:project:windows:drive:c:/work/openclaw";
+        const regularPath = String.raw`C:\Work\OpenClaw\.CLAUDE\WORKTREES\task`;
+        const regularId = String.raw`project:C:\Work\OpenClaw`;
         await page.addInitScript(
-          ({ groupingKey, legacyId, sectionsKey }) => {
+          ({ groupingKey, legacyId, sectionsKey, regularPath: savedRegularPath }) => {
             localStorage.setItem(groupingKey, "project");
+            localStorage.setItem("openclaw:sidebar:sessions:grouping", "project");
             if (localStorage.getItem(sectionsKey) === null) {
-              localStorage.setItem(sectionsKey, JSON.stringify([legacyId]));
+              localStorage.setItem(
+                sectionsKey,
+                JSON.stringify([legacyId, `project:${savedRegularPath}`]),
+              );
             }
           },
           {
             groupingKey: catalogGroupingStorageKey,
             legacyId: legacySectionId,
             sectionsKey: collapsedSessionSectionsStorageKey,
+            regularPath,
           },
         );
         await installMockGateway(page, {
           featureMethods: ["chat.metadata", "chat.startup", "sessions.catalog.list"],
           methodResponses: {
+            "sessions.list": {
+              count: 1,
+              defaults: { contextTokens: null, model: "fixture-model", modelProvider: "fixture" },
+              path: "",
+              ts: Date.now(),
+              sessions: [
+                {
+                  key: "agent:main:windows-upgrade",
+                  kind: "direct",
+                  label: "Regular Windows workspace",
+                  status: "idle",
+                  updatedAt: Date.now(),
+                  spawnedWorkspaceDir: regularPath,
+                },
+              ],
+            },
             "sessions.catalog.list": {
               catalogs: [
                 {
@@ -90,6 +113,9 @@ suite.define(() => {
         });
 
         await page.goto(`${suite.server.baseUrl}chat`);
+        const regularSection = page.locator(`[data-session-section=${JSON.stringify(regularId)}]`);
+        const regularToggle = regularSection.locator(".sidebar-session-group-toggle");
+        await expect.poll(() => regularToggle.getAttribute("aria-expanded")).toBe("false");
         const section = page.locator('[data-session-section="catalog:codex"]');
         const project = section.locator(
           '[data-session-catalog-project="project:windows:drive:c:/work/openclaw"]',
@@ -103,7 +129,7 @@ suite.define(() => {
             (key) => JSON.parse(localStorage.getItem(key) ?? "[]"),
             collapsedSessionSectionsStorageKey,
           ),
-        ).toEqual([canonicalSectionId]);
+        ).toEqual([regularId, canonicalSectionId]);
         if (captureUiProofEnabled) {
           await section.screenshot({
             animations: "disabled",
@@ -112,6 +138,7 @@ suite.define(() => {
         }
 
         await page.reload();
+        await expect.poll(() => regularToggle.getAttribute("aria-expanded")).toBe("false");
         await project.waitFor({ state: "visible" });
         await expect.poll(() => project.getAttribute("aria-expanded")).toBe("false");
         expect(
@@ -119,7 +146,7 @@ suite.define(() => {
             (key) => JSON.parse(localStorage.getItem(key) ?? "[]"),
             collapsedSessionSectionsStorageKey,
           ),
-        ).toEqual([canonicalSectionId]);
+        ).toEqual([regularId, canonicalSectionId]);
         if (captureUiProofEnabled) {
           await section.screenshot({
             animations: "disabled",
@@ -131,6 +158,8 @@ suite.define(() => {
         }
 
         await project.click();
+        await regularToggle.click();
+        await regularSection.getByText("Regular Windows workspace", { exact: true }).waitFor();
         await expect.poll(() => project.getAttribute("aria-expanded")).toBe("true");
         expect(await section.getByText("Direct Windows checkout", { exact: true }).count()).toBe(1);
         expect(await section.getByText("Windows worktree checkout", { exact: true }).count()).toBe(
@@ -142,6 +171,15 @@ suite.define(() => {
             path: path.join(suite.artifactDir, "03-windows-project-expanded.png"),
           });
         }
+        await page.reload();
+        await expect.poll(() => regularToggle.getAttribute("aria-expanded")).toBe("true");
+        await expect.poll(() => project.getAttribute("aria-expanded")).toBe("true");
+        expect(
+          await page.evaluate(
+            (key) => JSON.parse(localStorage.getItem(key) ?? "[]"),
+            collapsedSessionSectionsStorageKey,
+          ),
+        ).toEqual([]);
       },
     );
   });

--- a/ui/src/e2e/codex-sessions-windows-collapse.e2e.test.ts
+++ b/ui/src/e2e/codex-sessions-windows-collapse.e2e.test.ts
@@ -30,7 +30,7 @@ suite.define(() => {
           : {}),
       },
       async ({ page }) => {
-        const legacySectionId = String.raw`catalog-project:codex:gateway:local:C:\WORK\OPENCLAW\.CLAUDE\WORKTREES\fix-older`;
+        const legacySectionId = String.raw`catalog-project:codex:gateway:local:project:C:\WORK\OPENCLAW\.CLAUDE\WORKTREES\fix-older`;
         const canonicalSectionId =
           "catalog-project:codex:gateway:local:project:windows:drive:c:/work/openclaw";
         await page.addInitScript(

--- a/ui/src/e2e/codex-sessions-windows-collapse.e2e.test.ts
+++ b/ui/src/e2e/codex-sessions-windows-collapse.e2e.test.ts
@@ -1,0 +1,148 @@
+import path from "node:path";
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({
+  name: "Codex Windows catalog collapse migration",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) => `Playwright Chromium is unavailable at ${executablePath}`,
+});
+
+const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
+const catalogGroupingStorageKey = "openclaw:sidebar:sessions:catalog-grouping";
+const collapsedSessionSectionsStorageKey = "openclaw:sidebar:sessions:collapsed-sections";
+
+suite.define(() => {
+  it("migrates a collapsed Windows project key and keeps it collapsed after reload", async () => {
+    await suite.withPage(
+      {
+        colorScheme: "dark",
+        deviceScaleFactor: 2,
+        viewport: { height: 900, width: 1280 },
+        ...(captureUiProofEnabled
+          ? {
+              recordVideo: {
+                dir: path.join(suite.artifactDir, "windows-collapse-migration-video"),
+                size: { height: 900, width: 1280 },
+              },
+            }
+          : {}),
+      },
+      async ({ page }) => {
+        const legacySectionId = String.raw`catalog-project:codex:gateway:local:C:\WORK\OPENCLAW\.CLAUDE\WORKTREES\fix-older`;
+        const canonicalSectionId =
+          "catalog-project:codex:gateway:local:project:windows:drive:c:/work/openclaw";
+        await page.addInitScript(
+          ({ groupingKey, legacyId, sectionsKey }) => {
+            localStorage.setItem(groupingKey, "project");
+            if (localStorage.getItem(sectionsKey) === null) {
+              localStorage.setItem(sectionsKey, JSON.stringify([legacyId]));
+            }
+          },
+          {
+            groupingKey: catalogGroupingStorageKey,
+            legacyId: legacySectionId,
+            sectionsKey: collapsedSessionSectionsStorageKey,
+          },
+        );
+        await installMockGateway(page, {
+          featureMethods: ["chat.metadata", "chat.startup", "sessions.catalog.list"],
+          methodResponses: {
+            "sessions.catalog.list": {
+              catalogs: [
+                {
+                  id: "codex",
+                  label: "Codex",
+                  capabilities: { continueSession: true, archive: true },
+                  hosts: [
+                    {
+                      hostId: "gateway:local",
+                      label: "Local Codex",
+                      kind: "gateway",
+                      connected: true,
+                      sessions: [
+                        {
+                          threadId: "thread-direct",
+                          name: "Direct Windows checkout",
+                          cwd: "C:\\Work\\OpenClaw",
+                          status: "idle",
+                          archived: false,
+                          canContinue: true,
+                          canArchive: true,
+                        },
+                        {
+                          threadId: "thread-worktree",
+                          name: "Windows worktree checkout",
+                          cwd: "c:/work/openclaw/.CLAUDE/WORKTREES/fix-new/ui/src",
+                          status: "idle",
+                          archived: false,
+                          canContinue: true,
+                          canArchive: true,
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        });
+
+        await page.goto(`${suite.server.baseUrl}chat`);
+        const section = page.locator('[data-session-section="catalog:codex"]');
+        const project = section.locator(
+          '[data-session-catalog-project="project:windows:drive:c:/work/openclaw"]',
+        );
+        await project.waitFor({ state: "visible" });
+        await expect.poll(() => project.getAttribute("aria-expanded")).toBe("false");
+        expect(await section.locator("[data-session-catalog-project]").count()).toBe(1);
+        expect(await section.getByText("Direct Windows checkout", { exact: true }).count()).toBe(0);
+        expect(
+          await page.evaluate(
+            (key) => JSON.parse(localStorage.getItem(key) ?? "[]"),
+            collapsedSessionSectionsStorageKey,
+          ),
+        ).toEqual([canonicalSectionId]);
+        if (captureUiProofEnabled) {
+          await section.screenshot({
+            animations: "disabled",
+            path: path.join(suite.artifactDir, "01-windows-project-collapsed-after-migration.png"),
+          });
+        }
+
+        await page.reload();
+        await project.waitFor({ state: "visible" });
+        await expect.poll(() => project.getAttribute("aria-expanded")).toBe("false");
+        expect(
+          await page.evaluate(
+            (key) => JSON.parse(localStorage.getItem(key) ?? "[]"),
+            collapsedSessionSectionsStorageKey,
+          ),
+        ).toEqual([canonicalSectionId]);
+        if (captureUiProofEnabled) {
+          await section.screenshot({
+            animations: "disabled",
+            path: path.join(
+              suite.artifactDir,
+              "02-windows-project-still-collapsed-after-reload.png",
+            ),
+          });
+        }
+
+        await project.click();
+        await expect.poll(() => project.getAttribute("aria-expanded")).toBe("true");
+        expect(await section.getByText("Direct Windows checkout", { exact: true }).count()).toBe(1);
+        expect(await section.getByText("Windows worktree checkout", { exact: true }).count()).toBe(
+          1,
+        );
+        if (captureUiProofEnabled) {
+          await section.screenshot({
+            animations: "disabled",
+            path: path.join(suite.artifactDir, "03-windows-project-expanded.png"),
+          });
+        }
+      },
+    );
+  });
+});

--- a/ui/src/lib/sessions/catalog-project-grouping.test.ts
+++ b/ui/src/lib/sessions/catalog-project-grouping.test.ts
@@ -123,6 +123,52 @@ describe("groupCatalogSessionsByProject", () => {
       title: expectedPath,
     });
   });
+
+  it("groups equivalent Windows cwd spellings under the first display path", () => {
+    const result = groupCatalogSessionsByProject([
+      session("first", "C:\\Work\\Notes"),
+      session("second", "c:/work/notes/"),
+      session("third", "C:/WORK/NOTES"),
+    ]);
+
+    expect(result.groups).toHaveLength(1);
+    expect(result.groups[0]).toMatchObject({
+      key: "C:\\Work\\Notes",
+      label: "Notes",
+      title: "C:\\Work\\Notes",
+    });
+    expect(result.groups[0]?.sessions.map((item) => item.threadId)).toEqual([
+      "first",
+      "second",
+      "third",
+    ]);
+  });
+
+  it("folds case-varied Windows worktree paths into their origin project", () => {
+    const result = groupCatalogSessionsByProject([
+      session("direct", "C:\\Work\\OpenClaw"),
+      session("worktree", "c:/work/openclaw/.CLAUDE/WORKTREES/fix-1/ui/src"),
+    ]);
+
+    expect(result.groups).toHaveLength(1);
+    expect(result.groups[0]?.sessions.map((item) => item.threadId)).toEqual(["direct", "worktree"]);
+  });
+
+  it("keeps POSIX cwd matching case-sensitive", () => {
+    const result = groupCatalogSessionsByProject([
+      session("upper", "/Work/Notes"),
+      session("lower", "/work/notes"),
+      session("double-upper", "//mnt/Repo"),
+      session("double-lower", "//mnt/repo"),
+    ]);
+
+    expect(result.groups.map((group) => group.key)).toEqual([
+      "/Work/Notes",
+      "/work/notes",
+      "//mnt/Repo",
+      "//mnt/repo",
+    ]);
+  });
 });
 
 describe("groupCatalogSessionsByPerson", () => {

--- a/ui/src/lib/sessions/catalog-project-grouping.test.ts
+++ b/ui/src/lib/sessions/catalog-project-grouping.test.ts
@@ -110,6 +110,23 @@ describe("groupCatalogSessionsByProject", () => {
     expect(result.ungrouped.map((item) => item.threadId)).toEqual(["missing", "blank"]);
   });
 
+  it("leaves Windows filesystem roots and root worktrees ungrouped", () => {
+    const result = groupCatalogSessionsByProject([
+      session("drive-root", "C:\\"),
+      session("drive-root-worktree", "c:\\.CLAUDE\\WORKTREES\\fix-1\\src"),
+      session("current-drive-root", "\\"),
+      session("current-drive-root-worktree", "\\.claude\\worktrees\\fix-2\\src"),
+    ]);
+
+    expect(result.groups).toHaveLength(0);
+    expect(result.ungrouped.map((item) => item.threadId)).toEqual([
+      "drive-root",
+      "drive-root-worktree",
+      "current-drive-root",
+      "current-drive-root-worktree",
+    ]);
+  });
+
   it.each([
     [" /Users/dev/openclaw/// ", "/Users/dev/openclaw", "openclaw"],
     ["C:\\Users\\dev\\openclaw\\", "C:\\Users\\dev\\openclaw", "openclaw"],
@@ -142,6 +159,34 @@ describe("groupCatalogSessionsByProject", () => {
       "second",
       "third",
     ]);
+  });
+
+  it("preserves Windows root kinds while grouping equivalent UNC paths", () => {
+    const result = groupCatalogSessionsByProject([
+      session("unc-first", "\\\\Server\\Share\\Project"),
+      session("unc-second", "\\\\server\\share\\project"),
+      session("current-drive-rooted", "\\Server\\Share\\Project"),
+    ]);
+
+    expect(result.groups).toHaveLength(2);
+    expect(result.groups[0]?.sessions.map((item) => item.threadId)).toEqual([
+      "unc-first",
+      "unc-second",
+    ]);
+    expect(result.groups[1]?.sessions.map((item) => item.threadId)).toEqual([
+      "current-drive-rooted",
+    ]);
+  });
+
+  it("keeps an UNC share root groupable as a project root", () => {
+    const result = groupCatalogSessionsByProject([
+      session("first", "\\\\Server\\Share\\"),
+      session("second", "\\\\server\\share"),
+    ]);
+
+    expect(result.groups).toHaveLength(1);
+    expect(result.groups[0]?.sessions.map((item) => item.threadId)).toEqual(["first", "second"]);
+    expect(result.ungrouped).toHaveLength(0);
   });
 
   it("folds case-varied Windows worktree paths into their origin project", () => {

--- a/ui/src/lib/sessions/catalog-project-grouping.test.ts
+++ b/ui/src/lib/sessions/catalog-project-grouping.test.ts
@@ -86,17 +86,25 @@ describe("groupCatalogSessionsByProject", () => {
   });
 
   it.each([
-    ["/Users/dev/openclaw/.claude/worktrees/fix-1", "/Users/dev/openclaw"],
-    ["/Users/dev/openclaw/.claude/worktrees/fix-1/ui/src", "/Users/dev/openclaw"],
-    ["C:\\Users\\dev\\openclaw\\.claude\\worktrees\\fix-1", "C:\\Users\\dev\\openclaw"],
-  ])("folds worktree cwd %s into %s", (worktreeCwd, expectedProject) => {
+    ["/Users/dev/openclaw/.claude/worktrees/fix-1", "/Users/dev/openclaw", "project:/Users/dev/openclaw"],
+    [
+      "/Users/dev/openclaw/.claude/worktrees/fix-1/ui/src",
+      "/Users/dev/openclaw",
+      "project:/Users/dev/openclaw",
+    ],
+    [
+      "C:\\Users\\dev\\openclaw\\.claude\\worktrees\\fix-1",
+      "C:\\Users\\dev\\openclaw",
+      "project:windows:drive:c:/users/dev/openclaw",
+    ],
+  ])("folds worktree cwd %s into %s", (worktreeCwd, expectedProject, expectedKey) => {
     const result = groupCatalogSessionsByProject([
       session("direct", expectedProject),
       session("worktree", worktreeCwd),
     ]);
 
     expect(result.groups).toHaveLength(1);
-    expect(result.groups[0]?.key).toBe(`project:${expectedProject}`);
+    expect(result.groups[0]?.key).toBe(expectedKey);
     expect(result.groups[0]?.sessions.map((item) => item.threadId)).toEqual(["direct", "worktree"]);
   });
 
@@ -128,18 +136,26 @@ describe("groupCatalogSessionsByProject", () => {
   });
 
   it.each([
-    [" /Users/dev/openclaw/// ", "/Users/dev/openclaw", "openclaw"],
-    ["C:\\Users\\dev\\openclaw\\", "C:\\Users\\dev\\openclaw", "openclaw"],
-  ])("normalizes %s to project %s with label %s", (cwd, expectedPath, expectedLabel) => {
+    [" /Users/dev/openclaw/// ", "/Users/dev/openclaw", "openclaw", "project:/Users/dev/openclaw"],
+    [
+      "C:\\Users\\dev\\openclaw\\",
+      "C:\\Users\\dev\\openclaw",
+      "openclaw",
+      "project:windows:drive:c:/users/dev/openclaw",
+    ],
+  ])(
+    "normalizes %s to project %s with label %s",
+    (cwd, expectedPath, expectedLabel, expectedKey) => {
     const result = groupCatalogSessionsByProject([session("one", cwd)]);
 
     expect(result.groups[0]).toMatchObject({
-      key: `project:${expectedPath}`,
+      key: expectedKey,
       legacySectionKey: expectedPath,
       label: expectedLabel,
       title: expectedPath,
-    });
-  });
+      });
+    },
+  );
 
   it("groups equivalent Windows cwd spellings under the first display path", () => {
     const result = groupCatalogSessionsByProject([
@@ -150,7 +166,7 @@ describe("groupCatalogSessionsByProject", () => {
 
     expect(result.groups).toHaveLength(1);
     expect(result.groups[0]).toMatchObject({
-      key: "C:\\Work\\Notes",
+      key: "project:windows:drive:c:/work/notes",
       label: "Notes",
       title: "C:\\Work\\Notes",
     });
@@ -159,6 +175,26 @@ describe("groupCatalogSessionsByProject", () => {
       "second",
       "third",
     ]);
+  });
+
+  it("keeps the normalized Windows group key stable when recency order reverses", () => {
+    const firstOrder = groupCatalogSessionsByProject([
+      session("newer", "C:\\Work\\Notes"),
+      session("older", "c:/work/notes/"),
+    ]);
+    const reversedOrder = groupCatalogSessionsByProject([
+      session("older", "c:/work/notes/"),
+      session("newer", "C:\\Work\\Notes"),
+    ]);
+
+    expect(firstOrder.groups[0]).toMatchObject({
+      key: "project:windows:drive:c:/work/notes",
+      title: "C:\\Work\\Notes",
+    });
+    expect(reversedOrder.groups[0]).toMatchObject({
+      key: "project:windows:drive:c:/work/notes",
+      title: "c:/work/notes",
+    });
   });
 
   it("preserves Windows root kinds while grouping equivalent UNC paths", () => {

--- a/ui/src/lib/sessions/catalog-project-grouping.test.ts
+++ b/ui/src/lib/sessions/catalog-project-grouping.test.ts
@@ -3,6 +3,7 @@ import type { SessionCatalogSession } from "../../../../packages/gateway-protoco
 import {
   groupCatalogSessionsByPerson,
   groupCatalogSessionsByProject,
+  migrateCollapsedCatalogProjectSection,
   normalizeCatalogProjectGrouping,
 } from "./catalog-project-grouping.ts";
 
@@ -86,7 +87,11 @@ describe("groupCatalogSessionsByProject", () => {
   });
 
   it.each([
-    ["/Users/dev/openclaw/.claude/worktrees/fix-1", "/Users/dev/openclaw", "project:/Users/dev/openclaw"],
+    [
+      "/Users/dev/openclaw/.claude/worktrees/fix-1",
+      "/Users/dev/openclaw",
+      "project:/Users/dev/openclaw",
+    ],
     [
       "/Users/dev/openclaw/.claude/worktrees/fix-1/ui/src",
       "/Users/dev/openclaw",
@@ -146,13 +151,13 @@ describe("groupCatalogSessionsByProject", () => {
   ])(
     "normalizes %s to project %s with label %s",
     (cwd, expectedPath, expectedLabel, expectedKey) => {
-    const result = groupCatalogSessionsByProject([session("one", cwd)]);
+      const result = groupCatalogSessionsByProject([session("one", cwd)]);
 
-    expect(result.groups[0]).toMatchObject({
-      key: expectedKey,
-      legacySectionKey: expectedPath,
-      label: expectedLabel,
-      title: expectedPath,
+      expect(result.groups[0]).toMatchObject({
+        key: expectedKey,
+        legacySectionKey: expectedPath,
+        label: expectedLabel,
+        title: expectedPath,
       });
     },
   );
@@ -244,11 +249,35 @@ describe("groupCatalogSessionsByProject", () => {
     ]);
 
     expect(result.groups.map((group) => group.key)).toEqual([
-      "/Work/Notes",
-      "/work/notes",
-      "//mnt/Repo",
-      "//mnt/repo",
+      "project:/Work/Notes",
+      "project:/work/notes",
+      "project://mnt/Repo",
+      "project://mnt/repo",
     ]);
+  });
+});
+
+describe("catalog project collapse migration", () => {
+  it("replaces an equivalent Windows worktree key and preserves unrelated sections", () => {
+    const prefix = "catalog-project:codex:gateway:local:";
+    const canonical = `${prefix}project:windows:drive:c:/work/openclaw`;
+    const unrelated = "catalog:claude";
+    const migrated = migrateCollapsedCatalogProjectSection(
+      new Set([`${prefix}${String.raw`C:\Work\OpenClaw\.CLAUDE\WORKTREES\fix-1`}`, unrelated]),
+      prefix,
+      canonical,
+      "windows:drive:c:/work/openclaw",
+    );
+
+    expect(migrated).toEqual(new Set([unrelated, canonical]));
+    expect(
+      migrateCollapsedCatalogProjectSection(
+        migrated ?? new Set(),
+        prefix,
+        canonical,
+        "windows:drive:c:/work/openclaw",
+      ),
+    ).toBeNull();
   });
 });
 

--- a/ui/src/lib/sessions/catalog-project-grouping.test.ts
+++ b/ui/src/lib/sessions/catalog-project-grouping.test.ts
@@ -258,12 +258,13 @@ describe("groupCatalogSessionsByProject", () => {
 });
 
 describe("catalog project collapse migration", () => {
-  it("replaces an equivalent Windows worktree key and preserves unrelated sections", () => {
+  it("replaces raw and project-prefixed Windows worktree keys", () => {
     const prefix = "catalog-project:codex:gateway:local:";
     const canonical = `${prefix}project:windows:drive:c:/work/openclaw`;
+    const rawWorktree = String.raw`C:\Work\OpenClaw\.CLAUDE\WORKTREES\fix-1`;
     const unrelated = "catalog:claude";
     const migrated = migrateCollapsedCatalogProjectSection(
-      new Set([`${prefix}${String.raw`C:\Work\OpenClaw\.CLAUDE\WORKTREES\fix-1`}`, unrelated]),
+      new Set([`${prefix}${rawWorktree}`, `${prefix}project:${rawWorktree}`, unrelated]),
       prefix,
       canonical,
       "windows:drive:c:/work/openclaw",

--- a/ui/src/lib/sessions/catalog-project-grouping.ts
+++ b/ui/src/lib/sessions/catalog-project-grouping.ts
@@ -95,12 +95,14 @@ export function migrateCollapsedCatalogProjectSection(
   projectIdentity: string,
 ): ReadonlySet<string> | null {
   const migrated = new Set(
-    [...sections].filter(
-      (candidate) =>
-        candidate === id ||
-        !candidate.startsWith(prefix) ||
-        catalogProjectPathIdentity(candidate.slice(prefix.length)) !== projectIdentity,
-    ),
+    [...sections].filter((candidate) => {
+      if (candidate === id || !candidate.startsWith(prefix)) {
+        return true;
+      }
+      const suffix = candidate.slice(prefix.length);
+      const legacyPath = suffix.startsWith("project:") ? suffix.slice("project:".length) : suffix;
+      return catalogProjectPathIdentity(legacyPath) !== projectIdentity;
+    }),
   );
   if (migrated.size === sections.size) {
     return null;

--- a/ui/src/lib/sessions/catalog-project-grouping.ts
+++ b/ui/src/lib/sessions/catalog-project-grouping.ts
@@ -133,7 +133,7 @@ export function groupCatalogSessionsByProject(sessions: readonly SessionCatalogS
     if (!group) {
       group = {
         kind: "project",
-        key: `project:${projectPath}`,
+        key: `project:${pathIdentity}`,
         legacySectionKey: projectPath,
         label: checkoutDisplayName(projectPath),
         title: projectPath,

--- a/ui/src/lib/sessions/catalog-project-grouping.ts
+++ b/ui/src/lib/sessions/catalog-project-grouping.ts
@@ -32,7 +32,10 @@ export function foldWorktreeCheckoutPath(path: string): string | null {
   if (!trimmed) {
     return null;
   }
-  const match = trimmed.match(/^(.*?)[\\/]\.claude[\\/]worktrees[\\/][^\\/]/);
+  const pattern = isWindowsPath(trimmed)
+    ? /^(.*?)[\\/]\.claude[\\/]worktrees[\\/][^\\/]/i
+    : /^(.*?)[\\/]\.claude[\\/]worktrees[\\/][^\\/]/;
+  const match = trimmed.match(pattern);
   return match ? match[1] || null : trimmed;
 }
 
@@ -51,6 +54,21 @@ type CatalogProjectGroup = {
   title: string;
   sessions: SessionCatalogSession[];
 };
+
+function isWindowsPath(value: string): boolean {
+  return /^[A-Za-z]:[\\/]/.test(value) || value.startsWith("\\");
+}
+
+function catalogProjectPathIdentity(value: string): string {
+  if (!isWindowsPath(value)) {
+    return value;
+  }
+  return `windows:${value
+    .split(/[\\/]+/)
+    .filter(Boolean)
+    .map((segment) => segment.toLowerCase())
+    .join("/")}`;
+}
 
 export function groupCatalogSessionsByProject(sessions: readonly SessionCatalogSession[]): {
   groups: CatalogProjectGroup[];
@@ -93,7 +111,8 @@ export function groupCatalogSessionsByProject(sessions: readonly SessionCatalogS
       ungrouped.push(session);
       continue;
     }
-    let group = projectGroupsByPath.get(projectPath);
+    const pathIdentity = catalogProjectPathIdentity(projectPath);
+    let group = projectGroupsByPath.get(pathIdentity);
     if (!group) {
       group = {
         kind: "project",
@@ -103,7 +122,7 @@ export function groupCatalogSessionsByProject(sessions: readonly SessionCatalogS
         title: projectPath,
         sessions: [],
       };
-      projectGroupsByPath.set(projectPath, group);
+      projectGroupsByPath.set(pathIdentity, group);
       projectGroups.push(group);
     }
     group.sessions.push(session);

--- a/ui/src/lib/sessions/catalog-project-grouping.ts
+++ b/ui/src/lib/sessions/catalog-project-grouping.ts
@@ -75,7 +75,8 @@ function isWindowsPath(value: string): boolean {
   return windowsPathRootKind(value) !== undefined;
 }
 
-function catalogProjectPathIdentity(value: string): string {
+export function catalogProjectPathIdentity(p: string): string {
+  const value = isWindowsPath(p) ? (p.split(/[\\/]\.claude[\\/]worktrees[\\/]/i)[0] ?? p) : p;
   const rootKind = windowsPathRootKind(value);
   if (!rootKind) {
     return value;
@@ -85,6 +86,27 @@ function catalogProjectPathIdentity(value: string): string {
     .filter(Boolean)
     .map((segment) => segment.toLowerCase())
     .join("/")}`;
+}
+
+export function migrateCollapsedCatalogProjectSection(
+  sections: ReadonlySet<string>,
+  prefix: string,
+  id: string,
+  projectIdentity: string,
+): ReadonlySet<string> | null {
+  const migrated = new Set(
+    [...sections].filter(
+      (candidate) =>
+        candidate === id ||
+        !candidate.startsWith(prefix) ||
+        catalogProjectPathIdentity(candidate.slice(prefix.length)) !== projectIdentity,
+    ),
+  );
+  if (migrated.size === sections.size) {
+    return null;
+  }
+  migrated.add(id);
+  return migrated;
 }
 
 export function groupCatalogSessionsByProject(sessions: readonly SessionCatalogSession[]): {

--- a/ui/src/lib/sessions/catalog-project-grouping.ts
+++ b/ui/src/lib/sessions/catalog-project-grouping.ts
@@ -29,14 +29,15 @@ export function sessionActorGroupId(owner: SessionCreatedActor | undefined): str
 // paths or worktrees with no origin repo.
 export function foldWorktreeCheckoutPath(path: string): string | null {
   const trimmed = path.replace(/[\\/]+$/, "");
-  if (!trimmed) {
+  if (!trimmed || /^[A-Za-z]:$/.test(trimmed)) {
     return null;
   }
   const pattern = isWindowsPath(trimmed)
     ? /^(.*?)[\\/]\.claude[\\/]worktrees[\\/][^\\/]/i
     : /^(.*?)[\\/]\.claude[\\/]worktrees[\\/][^\\/]/;
   const match = trimmed.match(pattern);
-  return match ? match[1] || null : trimmed;
+  const folded = match ? match[1] || null : trimmed;
+  return folded && !/^[A-Za-z]:$/.test(folded) ? folded : null;
 }
 
 /** Basename shown for a checkout path in project sections. */
@@ -55,15 +56,31 @@ type CatalogProjectGroup = {
   sessions: SessionCatalogSession[];
 };
 
+type WindowsPathRootKind = "drive" | "unc" | "rooted";
+
+function windowsPathRootKind(value: string): WindowsPathRootKind | undefined {
+  if (/^[A-Za-z]:[\\/]/.test(value)) {
+    return "drive";
+  }
+  if (value.startsWith("\\\\")) {
+    return "unc";
+  }
+  if (value.startsWith("\\")) {
+    return "rooted";
+  }
+  return undefined;
+}
+
 function isWindowsPath(value: string): boolean {
-  return /^[A-Za-z]:[\\/]/.test(value) || value.startsWith("\\");
+  return windowsPathRootKind(value) !== undefined;
 }
 
 function catalogProjectPathIdentity(value: string): string {
-  if (!isWindowsPath(value)) {
+  const rootKind = windowsPathRootKind(value);
+  if (!rootKind) {
     return value;
   }
-  return `windows:${value
+  return `windows:${rootKind}:${value
     .split(/[\\/]+/)
     .filter(Boolean)
     .map((segment) => segment.toLowerCase())

--- a/ui/src/lib/sessions/catalog-project-grouping.ts
+++ b/ui/src/lib/sessions/catalog-project-grouping.ts
@@ -75,7 +75,7 @@ function isWindowsPath(value: string): boolean {
   return windowsPathRootKind(value) !== undefined;
 }
 
-export function catalogProjectPathIdentity(p: string): string {
+function catalogProjectPathIdentity(p: string): string {
   const value = isWindowsPath(p) ? (p.split(/[\\/]\.claude[\\/]worktrees[\\/]/i)[0] ?? p) : p;
   const rootKind = windowsPathRootKind(value);
   if (!rootKind) {


### PR DESCRIPTION
Closes #111595

## What Problem This Solves

Native Codex or Claude sessions from one Windows project could appear in separate sidebar groups when catalog `cwd` values differed only by drive-letter/path casing, slash style, a trailing separator, or a `.claude/worktrees/...` suffix. Existing collapsed-section preferences could also stop applying after those paths were canonicalized.

## Why This Change Was Made

- Preserve the current catalog grouping architecture (`kind`, namespaced `key`, legacy section key, pagination, and Lit keyed rendering).
- Build comparison-only Windows project identities that include the root kind and normalize drive paths without changing POSIX case sensitivity.
- Fold Windows worktree paths into their project root while retaining first-seen spelling for display.
- Migrate both the older raw-path and current-main `project:<raw path>` collapse keys to the canonical project key and persist that migration.
- Preserve ordinary-sidebar `project:<display path>` collapse preferences at their existing load/store owner when the shared worktree folder changes the displayed project root. Catalog identities remain separately namespaced.

## User Impact

Sessions from equivalent Windows project paths stay together, and previously collapsed project sections keep their preference across the identity migration and page reload.

## Scope

The change is limited to catalog project grouping, ordinary and catalog sidebar collapse-state migration, and focused regressions. It does not change gateway protocols, session storage, or provider behavior.

```text
8 files changed, 525 insertions, 24 deletions
398 added lines are tests/browser proof
127 added lines are production code
```

## Evidence

### Current-head regular-sidebar real Gateway proof — 2026-09-09 03:02 UTC

**PASS at `aef5b4d5b21fb7893df45c0f93c3ed9f0449377b`: actual `sessions.create` / `sessions.list`, four captured Windows browser states, recorder exit 0.** This demonstrates the ordinary-sidebar upgrade and subsequent-expansion flow requested in [the latest reviewed-head assessment](https://github.com/openclaw/openclaw/pull/111596#issuecomment-5018198129).

The candidate is rebased onto the fixed main `9465116fd3bda32bef0c3c06f32d40eb2c704e1a`. Range-diff retains all seven commits: six are exactly equivalent and one differs only in current-main import context (`presenceViewerLabel`). There is no new behavior change in this refresh; the scope remains **8 files, +525/-24**.

**Real environment and source identity:** Windows, Node 24.19.0, pnpm 12.3.4 with the frozen lockfile, Chromium headless shell 151.0.7922.34. The production UI and built isolated Gateway were both built from this exact clean candidate, with the fixed build timestamp `2026-09-09T02:53:49.000Z`. No old-version Gateway/new-UI pairing was used.

**Operations actually performed:**

1. Start the exact-head built Gateway with task-owned state and the exact-head production UI. Wait for `/readyz` to report `ready:true, failing:[]`.
2. Call real `sessions.create` twice, with a project directory and its existing `.CLAUDE\\WORKTREES\\proof-task` subdirectory as the two `cwd` values. Both return `ok:true`; real `sessions.list` returns those two durable ordinary-session rows.
3. Seed only the historical browser preference `project:<proof-root>\\WindowsRepo\\.CLAUDE\\WORKTREES\\proof-task` before the first app initialization, with project grouping selected.
4. Load the regular sidebar, reload, explicitly expand the project, then reload again. Read the browser's persisted collapse keys at each state. The app's real preference owner performs all subsequent storage writes.

| Actual regular-sidebar state | Rendered project | Expanded | Persisted collapse keys |
| --- | --- | --- | --- |
| Initial render after migration | One WindowsRepo group, 2 sessions | false | Only `project:<proof-root>\\WindowsRepo`; old alias removed |
| Full reload | Same group, 2 sessions | false | Same canonical display-path key |
| User expands | Both created session rows visible in the group | true | Empty set |
| Full reload after expansion | Both rows still visible in the same group | true | Empty set; old alias does not return |

Copied result summary (only the task path prefix is redacted):

```text
head=aef5b4d5b21fb7893df45c0f93c3ed9f0449377b
sessions.create project directory: ok=true
sessions.create .CLAUDE/WORKTREES/proof-task directory: ok=true
sessions.list: count=2, totalCount=2
01-migrated-collapsed: expanded=false; canonical key only
02-after-reload-still-collapsed: expanded=false; canonical key only
03-user-expanded: expanded=true; keys=[]
04-expanded-after-reload: expanded=true; keys=[]
receipt.ok=true; cleanupErrors=[]
```

**Artifact integrity:** 206 captured served JS/CSS response bodies match the same-head production bundle, with zero mismatches; 22 additional responses had no readable body and are not counted as hash matches. The Gateway entry SHA-256 is `455dad7ce402d45537f2c606d7560408bd1d864986fa3bdb68268fdf9ae56e9d`; the main UI bundle SHA-256 is `a57a1944783909c1273dc722118545fb5b2b162ca817efd0979c7203c018b73c`. The attached receipt records the build metadata, source blobs, RPC results, persisted keys and four states.

- [111596-regular-sidebar-proof.txt — redacted receipt and build identity](https://github.com/user-attachments/files/31986930/111596-regular-sidebar-proof.txt)

Actual Windows browser recording: complete 5.48-second capture, untrimmed; no simulated UI or reconstructed frames.

https://github.com/user-attachments/assets/cf2866c6-b273-4628-86e2-4bdecd8980d1

<details>
<summary>Four actual regular-sidebar screenshots: migrated, reloaded, expanded, expanded after reload</summary>

1. Initial migrated collapsed group:

![Regular sidebar: migrated and collapsed](https://github.com/user-attachments/assets/7eef22ee-2693-41fc-aa32-99b555a5a0c0)

2. Still collapsed after full reload:

![Regular sidebar: still collapsed after reload](https://github.com/user-attachments/assets/65477fd1-77c3-40aa-a925-8e8b1de6cdbb)

3. User expanded, both real Gateway session rows visible:

![Regular sidebar: user expanded](https://github.com/user-attachments/assets/bf9cd30d-3f63-49f1-aa04-a51beafc6add)

4. Still expanded after full reload:

![Regular sidebar: still expanded after reload](https://github.com/user-attachments/assets/c2666e90-d48c-45d0-b3b9-244c956cbca9)

</details>

**Proof boundary:** the Gateway, WebSocket RPC, durable ordinary sessions, production UI and browser-local preference writes are real. The directories and initial legacy localStorage value are synthetic test inputs. In particular, the existing `.CLAUDE/WORKTREES` directory is not a Git-created worktree. This run does not prove native Codex/Claude catalog discovery, node binding, a model turn, or an old-version-to-new-version runtime upgrade. It seeds an old saved preference and verifies the new version's real migration/reload/expansion behavior. Historical RED is covered separately by the prior regression run, not claimed from these screenshots. No Gateway/socket response or UI render is mocked in this live run; no personal sessions, credentials or daily Gateway are used. The isolated browser and task-owned Gateway process tree were stopped afterward.

This completed same-head run supersedes the previously documented incomplete ordinary-sidebar attempt, in which `sessions.create` did not return before cancellation. That earlier attempt remains a failure, not additional passing evidence. The accepted catalog-only proof below remains historical and tied to `faef4a49268e3cc28381bd564c2ac527ff43626f`.

### Current-head focused validation — separate from live proof

All commands below completed successfully on `aef5b4d5b21fb7893df45c0f93c3ed9f0449377b`; tracked source and lockfiles remained unchanged.

```text
node scripts/run-vitest.mjs ui/src/components/app-sidebar-session-types.test.ts ui/src/lib/sessions/grouping.test.ts ui/src/lib/sessions/catalog-project-grouping.test.ts
  3 files / 83 tests passed; exit 0

node scripts/run-vitest.mjs ui/src/e2e/codex-sessions-windows-collapse.e2e.test.ts
  1 file / 1 test passed; exit 0
  Mocked-Gateway browser regression, not real/native catalog discovery.

node --import ./scripts/tsx.mjs ui/src/test-helpers/control-ui-e2e.ts --production-build <proof-output>/ui-candidate
  production UI build passed; 3417 modules; exit 0

OPENCLAW_BUILD_ALL_NO_PNPM=1 node --import ./scripts/tsx.mjs scripts/build-all.mts sourcePerformance
  backend runtime build passed; exit 0

node scripts/run-node-package-bin.mts oxfmt --check <the eight PR files>
node scripts/run-node-package-bin.mts oxlint --type-aware --tsconfig config/tsconfig/oxlint.core.json <the eight PR files>
git diff --check 9465116fd3bda32bef0c3c06f32d40eb2c704e1a HEAD
  passed
```

The mocked browser regression separately covers catalog and ordinary collapse migration/reload/expansion; the 83 unit tests cover the existing preference reader, regular grouping and catalog grouping. These are not substitutes for the actual-Gateway ordinary-sidebar proof above.

The ordinary-sidebar correction remains at the existing preference reader: it persists the folded display-path key rather than the catalog comparison identity, and explicit expansion cannot revive the legacy alias. The prior implementation's four newly added preference regressions were observed failing before the source correction and passing afterward. Its previous scoped review reported no accepted/actionable findings; that historical review is not relabeled as a fresh review of this integration-only rebase. No fresh autoreview result or all-green remote CI result is claimed here.

### Historical catalog-only Windows UI / Gateway proof — 2026-09-07 18:55 UTC

**PASS: six checks, four captured browser states; recorder exit 0** at `faef4a49268e3cc28381bd564c2ac527ff43626f`. This is a fresh production UI build on Windows (Node 22.22.3, Chromium 151.0.7922.34), served by an actual isolated source Gateway. The checkout remained clean.

Unlike the earlier mocked-Gateway browser regression, this run uses the real plugin registry, `sessions.catalog.list` WebSocket RPC, production UI grouping, and existing organizer-owned localStorage writes. A small test-only catalog plugin reads three harmless existing Windows directories; it does not replace Gateway responses or UI rendering. **Native Codex/Claude discovery is not claimed:** these are explicitly labeled test-catalog rows, and the worktree-shaped directories are not Git-created worktrees.

The browser starts with the old `catalog-project:windows-proof:gateway:local:project:<uppercase Windows path>\\.CLAUDE\\WORKTREES\\fix-older` collapse key. The exact observed keys and RPC rows are in the attached receipt.

| Actual browser state | Project groups | Expanded | Persisted collapse key |
| --- | --- | --- | --- |
| Initial render after migration | 1 | false | Canonical Windows project key only; legacy key removed |
| Full reload | 1 | false | Same canonical key, also observed before app initialization |
| Expand the project | 1, containing all 3 path variants | true | Empty set |
| Collapse again, then full reload | 1 | false | Canonical key retained |

The direct and case/slash-variant paths resolve to the same real Windows file identity. The third directory uses a worktree-style suffix and is grouped with that project. The actual Gateway returned `ready:true, failing:[]` before the browser ran; all three rows were observed in received RPC frames. **47 captured served JS/CSS bodies were independently hash-matched to the freshly built bundle, with zero mismatches**, tying the screenshots to this exact head.

- [Inspectable receipt: exact keys, four states, RPC projection, build/source hashes, cleanup](https://github.com/user-attachments/files/31925168/111596-public-proof.txt)
- [Recorder and catalog fixture](https://github.com/user-attachments/files/31925170/111596-recorder-and-fixture.txt) — portable path declarations are explicitly marked; behavior/assertions are unchanged. Build the exact head with the receipt's canonical `control-ui-e2e.ts --production-build` command, populate the fixture files, then run the recorder using existing Playwright/dependencies.
- The browser/context and task-owned Gateway were stopped afterward. No personal profile, private sessions, credentials, model turn, or production source change was involved.

The raw 31-second browser recording includes real loading/reloads; the expanded three-row state is visible near **00:28**, followed by re-collapse/reload. It is a format conversion of the actual captured WebM, with no cuts, overlays, reconstructed frames, or simulated UI:

https://github.com/user-attachments/assets/63a35042-3a53-4a4c-90d6-36464dbbb040

<details>
<summary>Four actual Windows screenshots: migrated, reloaded, expanded, re-collapsed</summary>

1. Initial migrated collapsed group:

![Initial migrated collapsed group](https://github.com/user-attachments/assets/a914b9ff-542b-4b27-9cde-1cba1a278d9f)

2. Still collapsed after full reload:

![Still collapsed after reload](https://github.com/user-attachments/assets/e5934c1e-b7fa-4b1a-8e39-0e8a734de51c)

3. One expanded project containing all three path variants:

![One project, three path variants](https://github.com/user-attachments/assets/e5bf14de-e486-4188-8b4d-345790cfad09)

4. Re-collapsed and reloaded:

![Re-collapsed after second reload](https://github.com/user-attachments/assets/393c5146-6595-4bb3-927f-d1b40b33424a)

</details>

Earlier diagnostic attempts were not counted as a pass: one timed out during cold Gateway readiness, and another recorder's asset-response observer rejected during a redirect after three captures. The observer was made rejection-safe and the final run above completed all assertions. No product behavior or assertion was weakened. This evidence does not assert all remote CI is green.

### Historical exact-head regression checks — faef4a49268e

Validated on exact head `faef4a49268e3cc28381bd564c2ac527ff43626f`, rebased onto `ebdfd202ebe42a3bd5a8803f5ef3f2a889567355`.

```text
focused unit suite
  ui/src/lib/sessions/catalog-project-grouping.test.ts
  28 passed

focused bundled-browser regression
  ui/src/e2e/codex-sessions-windows-collapse.e2e.test.ts
  1 passed

pnpm ui:build
  passed (3234 modules; sidecar and performance checks passed)

type-aware lint on all six changed files
  passed

format check on all six changed files
  passed

production Knip unused-export scan
  passed after keeping the internal path-identity helper private

git diff --check
  clean
```

The earlier browser regression exercises the rendered sidebar with a mocked Gateway and checks all of the following in one flow:

1. a current-main `project:<raw path>` case/slash/worktree collapse key migrates to the canonical Windows project identity (with unit coverage for the older raw-path key too);
2. direct and worktree sessions render in one project group;
3. the group is collapsed on initial render;
4. the canonical key is persisted to local storage;
5. the group remains collapsed after a full page reload;
6. expanding the group reveals both session rows.

That earlier mocked-Gateway run produced locally retained screenshots and a recording. The newly attached real-Gateway run above supersedes the prior missing-artifact evidence gap. The focused correction is three files, +12/-9, with only +8/-6 in production migration logic; it does not change grouping, rendering, storage, gateway, or provider ownership.
