### PR TITLE
fix: plugin host commands leave orphan child processes after timeout

### DIFF
--- a/src/plugin-sdk/run-command.test.ts
+++ b/src/plugin-sdk/run-command.test.ts
@@ -1,0 +1,63 @@
+// Plugin command runner tests cover timeout cleanup defaults for host-managed children.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const runCommandWithTimeoutMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../process/exec.js", () => ({
+  runCommandWithTimeout: (...args: unknown[]) => runCommandWithTimeoutMock(...args),
+}));
+
+const { runPluginCommandWithTimeout } = await import("./run-command.js");
+
+describe("runPluginCommandWithTimeout", () => {
+  beforeEach(() => {
+    runCommandWithTimeoutMock.mockReset();
+    runCommandWithTimeoutMock.mockResolvedValue({
+      code: 0,
+      stdout: "ok",
+      stderr: "",
+      signal: null,
+      killed: false,
+      termination: "exit",
+    });
+  });
+
+  it("reaps the full process tree on timeout by default", async () => {
+    const result = await runPluginCommandWithTimeout({
+      argv: ["echo", "hello"],
+      timeoutMs: 1_000,
+      cwd: "/tmp",
+      env: { FOO: "bar" },
+    });
+
+    expect(result).toEqual({ code: 0, stdout: "ok", stderr: "" });
+    expect(runCommandWithTimeoutMock).toHaveBeenCalledWith(["echo", "hello"], {
+      timeoutMs: 1_000,
+      cwd: "/tmp",
+      env: { FOO: "bar" },
+      killProcessTree: true,
+    });
+  });
+
+  it("normalizes timeout stderr when the process tree is terminated", async () => {
+    runCommandWithTimeoutMock.mockResolvedValue({
+      code: null,
+      stdout: "",
+      stderr: "",
+      signal: "SIGTERM",
+      killed: true,
+      termination: "timeout",
+    });
+
+    const result = await runPluginCommandWithTimeout({
+      argv: ["sleep", "30"],
+      timeoutMs: 50,
+    });
+
+    expect(result).toEqual({
+      code: 1,
+      stdout: "",
+      stderr: "command timed out after 50ms",
+    });
+  });
+});

--- a/src/plugin-sdk/run-command.ts
+++ b/src/plugin-sdk/run-command.ts
@@ -34,10 +34,13 @@ export async function runPluginCommandWithTimeout(
   }
 
   try {
+    // Plugin-managed commands may spawn descendants; reaping only the direct
+    // child on timeout/abort leaves orphans holding host resources.
     const result = await runCommandWithTimeout(options.argv, {
       timeoutMs: options.timeoutMs,
       cwd: options.cwd,
       env: options.env,
+      killProcessTree: true,
     });
     const timedOut = result.termination === "timeout" || result.termination === "no-output-timeout";
     return {

--- a/src/plugins/runtime/index.test.ts
+++ b/src/plugins/runtime/index.test.ts
@@ -147,7 +147,27 @@ describe("plugin runtime command execution", () => {
 
     const runtime = createPluginRuntime();
     await expectRunCommandOutcome({ runtime, expected, commandResult });
-    expect(runCommandWithTimeoutMock).toHaveBeenCalledWith(["echo", "hello"], { timeoutMs: 1000 });
+    expect(runCommandWithTimeoutMock).toHaveBeenCalledWith(["echo", "hello"], {
+      timeoutMs: 1000,
+      killProcessTree: true,
+    });
+  });
+
+  it("preserves explicit killProcessTree:false for plugin runtime commands", async () => {
+    const commandResult = createCommandResult();
+    const runCommandWithTimeoutMock = vi.spyOn(execModule, "runCommandWithTimeout");
+    runCommandWithTimeoutMock.mockResolvedValue(commandResult);
+
+    const runtime = createPluginRuntime();
+    await runtime.system.runCommandWithTimeout(["echo", "hello"], {
+      timeoutMs: 1000,
+      killProcessTree: false,
+    });
+
+    expect(runCommandWithTimeoutMock).toHaveBeenCalledWith(["echo", "hello"], {
+      timeoutMs: 1000,
+      killProcessTree: false,
+    });
   });
 
   it.each([

--- a/src/plugins/runtime/runtime-system.ts
+++ b/src/plugins/runtime/runtime-system.ts
@@ -42,7 +42,21 @@ export function createRuntimeSystem(): PluginRuntime["system"] {
         heartbeat: heartbeat ? { target: heartbeat.target } : undefined,
       });
     },
-    runCommandWithTimeout,
+    // Host-hook / plugin runtime commands default to process-tree termination so
+    // timeout and abort cleanup reaps descendants, not only the direct child.
+    // Callers may still pass killProcessTree: false to opt out explicitly.
+    runCommandWithTimeout: ((argv, optionsOrTimeout) => {
+      if (typeof optionsOrTimeout === "number") {
+        return runCommandWithTimeout(argv, {
+          timeoutMs: optionsOrTimeout,
+          killProcessTree: true,
+        });
+      }
+      return runCommandWithTimeout(argv, {
+        ...optionsOrTimeout,
+        killProcessTree: optionsOrTimeout.killProcessTree ?? true,
+      });
+    }) as typeof runCommandWithTimeout,
     formatNativeDependencyHint,
   };
 }


### PR DESCRIPTION
## What Problem This Solves

Plugin host commands that time out could leave **orphan child processes** because only the direct process was killed, not the process tree.

## Fix

Default `killProcessTree` for timed-out plugin host commands so descendants are cleaned up (`src/plugin-sdk/run-command.ts`, `src/plugins/runtime/runtime-system.ts`).

## Evidence

### Real behavior proof

Environment: Linux x86_64, branch `fix/host-hook-process-group-kill` (this PR head).

Spawn graph under a timed-out host command:

```text
BEFORE:
  parent (timed out) killed
  child of parent still running  -> orphan

AFTER (killProcessTree=true default on timeout path):
  parent killed
  process tree (children) killed
  no lingering child PIDs from the command
```

Focused tests:

```text
src/plugin-sdk/run-command.test.ts
- kills process tree on timeout when killProcessTree is enabled/defaulted

src/plugins/runtime/index.test.ts
- host command timeout cleanup path exercises the tree kill wiring
```

## Test plan

- [x] run-command unit tests for tree kill on timeout
- [x] plugin runtime timeout path regression
