### PR TITLE
fix(infra): use || for empty Claude session key fallback

### DIFF
--- a/src/infra/provider-usage.fetch.claude.test.ts
+++ b/src/infra/provider-usage.fetch.claude.test.ts
@@ -375,4 +375,68 @@ describe("fetchClaudeUsage", () => {
       expectMissingScopeError(result);
     },
   );
+
+  it("falls back to CLAUDE_WEB_SESSION_KEY when CLAUDE_AI_SESSION_KEY is blank/whitespace", async () => {
+    // Blank/whitespace AI session key must fall through to the WEB session key.
+    vi.stubEnv("CLAUDE_AI_SESSION_KEY", "   ");
+    vi.stubEnv("CLAUDE_WEB_SESSION_KEY", "sk-ant-web-fallback");
+
+    const mockFetch = createProviderUsageFetch(async (url, init) => {
+      if (url.includes("/api/oauth/usage")) {
+        return makeMissingScopeResponse();
+      }
+
+      const headers = (init?.headers as Record<string, string> | undefined) ?? {};
+      // The WEB session key should be used, not the blank AI key.
+      expect(headers.Cookie).toBe("sessionKey=sk-ant-web-fallback");
+
+      if (url.endsWith("/api/organizations")) {
+        return makeResponse(200, [{ uuid: "org-blank" }]);
+      }
+
+      if (url.endsWith("/api/organizations/org-blank/usage")) {
+        return makeResponse(200, {
+          five_hour: { utilization: 42 },
+        });
+      }
+
+      return makeResponse(404, "not found");
+    });
+
+    const result = await fetchClaudeUsage("token", 5000, mockFetch);
+
+    expect(result.error).toBeUndefined();
+    expect(result.windows).toEqual([{ label: "5h", usedPercent: 42, resetAt: undefined }]);
+  });
+
+  it("falls back to CLAUDE_WEB_SESSION_KEY when CLAUDE_AI_SESSION_KEY is empty string", async () => {
+    vi.stubEnv("CLAUDE_AI_SESSION_KEY", "");
+    vi.stubEnv("CLAUDE_WEB_SESSION_KEY", "sk-ant-web-empty");
+
+    const mockFetch = createProviderUsageFetch(async (url, init) => {
+      if (url.includes("/api/oauth/usage")) {
+        return makeMissingScopeResponse();
+      }
+
+      const headers = (init?.headers as Record<string, string> | undefined) ?? {};
+      expect(headers.Cookie).toBe("sessionKey=sk-ant-web-empty");
+
+      if (url.endsWith("/api/organizations")) {
+        return makeResponse(200, [{ uuid: "org-empty" }]);
+      }
+
+      if (url.endsWith("/api/organizations/org-empty/usage")) {
+        return makeResponse(200, {
+          five_hour: { utilization: 99 },
+        });
+      }
+
+      return makeResponse(404, "not found");
+    });
+
+    const result = await fetchClaudeUsage("token", 5000, mockFetch);
+
+    expect(result.error).toBeUndefined();
+    expect(result.windows).toEqual([{ label: "5h", usedPercent: 99, resetAt: undefined }]);
+  });
 });

--- a/src/infra/provider-usage.fetch.claude.ts
+++ b/src/infra/provider-usage.fetch.claude.ts
@@ -101,7 +101,7 @@ function buildClaudeUsageWindows(
 
 function resolveClaudeWebSessionKey(): string | undefined {
   const direct =
-    process.env.CLAUDE_AI_SESSION_KEY?.trim() ?? process.env.CLAUDE_WEB_SESSION_KEY?.trim();
+    process.env.CLAUDE_AI_SESSION_KEY?.trim() || process.env.CLAUDE_WEB_SESSION_KEY?.trim();
   if (direct?.startsWith("sk-ant-")) {
     return direct;
   }


### PR DESCRIPTION
## What Problem This Solves

`resolveClaudeWebSessionKey` in `src/infra/provider-usage.fetch.claude.ts:104` used `??` (nullish coalescing) to fall back from `CLAUDE_AI_SESSION_KEY` to `CLAUDE_WEB_SESSION_KEY`. When the AI key was empty/whitespace, `??` did NOT fall through.

## Why This Change Was Made

Changes `??` to `||` so empty/whitespace strings fall through to the next fallback.

## Real behavior proof

- **Behavior addressed:** Empty/whitespace CLAUDE_AI_SESSION_KEY prevented fallback to CLAUDE_WEB_SESSION_KEY
- **Real environment tested:** Linux x86_64, Node 24, commit `d382e2f4b` on branch `fix/claude-session-key-fallback`
- **Exact steps or command run after this patch:** `node --import tsx` setting real `process.env.CLAUDE_AI_SESSION_KEY` and `process.env.CLAUDE_WEB_SESSION_KEY` then reading them back through the exact `||` logic from the source file
- **Evidence after fix:** Terminal capture of `node` runtime verification (copied live output):

  ```text
  Source line 104: process.env.CLAUDE_AI_SESSION_KEY?.trim() || process.env.CLAUDE_WEB_SESSION_KEY?.trim();
  Uses || (fixed): true [PASS]
  
  With whitespace AI key: "   "
    || result: "sk-ant-real-web-verified" [PASS]
  
  Without AI key:
    || result: "sk-ant-real-web-verified" [PASS]
  
  With valid AI key: "sk-ant-ai-primary-xyz"
    || result: "sk-ant-ai-primary-xyz" [PASS]
  ```

- **Observed result after fix:** Empty/whitespace CLAUDE_AI_SESSION_KEY correctly falls back to CLAUDE_WEB_SESSION_KEY. Valid non-empty AI key takes precedence.
- **What was not tested:** Live HTTP call to claude.ai (requires real credentials; mocked fetch in regression test covers the session key selection path)

## Tests and validation
```text
$ node_modules/.bin/vitest run --reporter=verbose --config test/vitest/vitest.infra.config.ts src/infra/provider-usage.fetch.claude.test.ts -t "falls back to CLAUDE_WEB_SESSION_KEY"
✓ falls back to CLAUDE_WEB_SESSION_KEY when CLAUDE_AI_SESSION_KEY is blank/whitespace
✓ falls back to CLAUDE_WEB_SESSION_KEY when CLAUDE_AI_SESSION_KEY is empty string
Test Files  1 passed  Tests  2 passed
```

Two regression tests through the real `fetchClaudeUsage → resolveClaudeWebSessionKey` path.

## Risk checklist

- User-visible behavior: No — empty/whitespace session keys were invalid
- Config/env/migration behavior: Yes — affects env var fallback; only fixes empty string handling
- Security/auth/secrets/network/tool execution: Yes — affects Claude web session key resolution
- Highest-risk area: Session key env var fallback for empty string edge case
- Mitigation: `||` semantics are the intended behavior; full test suite passes

Closes: N/A (no existing issue)