### PR TITLE
fix(agents): use || for empty provider/model fallback in transcript persistence

### DIFF
--- a/src/agents/command/attempt-execution.provider-model.test.ts
+++ b/src/agents/command/attempt-execution.provider-model.test.ts
@@ -1,0 +1,68 @@
+// Regression test for Bug #5: provider/model fallback in persistCliTurnTranscript
+import { describe, it, expect, vi } from "vitest";
+
+const captured: Array<{ provider?: string; model?: string; api?: string }> = [];
+
+vi.mock("../../config/sessions/session-accessor.js", () => ({
+  persistSessionTranscriptTurn: vi.fn(async (_sessionInfo: unknown, options: { messages?: Array<{ message?: { provider?: string; model?: string; api?: string; role?: string } }> }) => {
+    for (const m of options.messages ?? []) {
+      if (m.message?.role === "assistant") {
+        captured.push({
+          provider: m.message.provider,
+          model: m.message.model,
+          api: m.message.api,
+        });
+      }
+    }
+    return { kind: "persisted" as const, sessionFile: "/tmp/mock-session.json", appended: true, rejectedReason: undefined, sessionEntry: undefined };
+  }),
+  loadSessionEntry: vi.fn(async () => undefined),
+  patchSessionEntry: vi.fn(async () => undefined),
+  listSessionEntries: vi.fn(async () => []),
+}));
+
+vi.mock("../../config/sessions/transcript.js", () => ({
+  readTailAssistantTextFromSessionTranscript: vi.fn(async () => null),
+}));
+
+vi.mock("../../infra/node-sqlite.js", () => ({
+  requireNodeSqlite: () => {
+    throw new Error("SQLite mocked out");
+  },
+}));
+
+const { persistCliTurnTranscript } = await import("./attempt-execution.js");
+
+describe("Bug #5 - persistCliTurnTranscript provider/model fallback", () => {
+  it("uses cli and default when provider and model are empty/whitespace", async () => {
+    captured.length = 0;
+    await persistCliTurnTranscript({
+      body: "test",
+      result: { meta: { agentMeta: { provider: "   ", model: "" }, finalAssistantVisibleText: "reply" } } as never,
+      sessionId: "s1",
+      sessionKey: "agent:main:s1",
+      sessionEntry: undefined,
+      sessionAgentId: "main",
+      sessionCwd: "/tmp",
+      config: {} as never,
+    });
+    expect(captured[0]?.provider).toBe("cli");
+    expect(captured[0]?.model).toBe("default");
+  });
+
+  it("uses actual provider and model when non-empty", async () => {
+    captured.length = 0;
+    await persistCliTurnTranscript({
+      body: "test",
+      result: { meta: { agentMeta: { provider: "anthropic", model: "claude-3" }, finalAssistantVisibleText: "reply" } } as never,
+      sessionId: "s1",
+      sessionKey: "agent:main:s1",
+      sessionEntry: undefined,
+      sessionAgentId: "main",
+      sessionCwd: "/tmp",
+      config: {} as never,
+    });
+    expect(captured[0]?.provider).toBe("anthropic");
+    expect(captured[0]?.model).toBe("claude-3");
+  });
+});

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -417,8 +417,8 @@ export async function persistCliTurnTranscript(params: {
   skipUserTurn?: boolean;
 }): Promise<PersistTextTurnTranscriptResult> {
   const replyText = resolveCliTranscriptReplyText(params.result);
-  const provider = params.result.meta.agentMeta?.provider?.trim() ?? "cli";
-  const model = params.result.meta.agentMeta?.model?.trim() ?? "default";
+  const provider = params.result.meta.agentMeta?.provider?.trim() || "cli";
+  const model = params.result.meta.agentMeta?.model?.trim() || "default";
   const gapFill = params.embeddedAssistantGapFill ?? false;
   const skipUserTurn = gapFill || params.skipUserTurn === true;
 


### PR DESCRIPTION
## What Problem This Solves

`persistCliTurnTranscript` in `src/agents/command/attempt-execution.ts:420-421` used `??` for provider and model fallbacks. When values were empty/whitespace, `??` did NOT fall through to `"cli"/"default"` defaults.

## Why This Change Was Made

Changes `??` to `||` so empty/whitespace strings fall through to defaults.

## Real behavior proof

- **Behavior addressed:** Empty/whitespace provider/model retained instead of falling back to defaults
- **Real environment tested:** Linux x86_64, Node 24, commit `f3e4dec55` on branch `fix/transcript-provider-model-fallback` (rebased on upstream/main `a8dd80afc`)
- **Exact steps or command run after this patch:** `node --import tsx` reading the actual source file and extracting/executing the exact provider/model fallback logic
- **Evidence after fix:** Terminal capture of `node` runtime verification (copied live output):

  ```text
  Source verified: provider line uses ||: true model line uses ||: true

  Empty provider+model: provider="cli" model="default" [PASS]
  Valid provider+model: provider="anthropic" model="claude-3" [PASS]
  Undefined provider+model: provider="cli" model="default" [PASS]
  ```

- **Observed result after fix:** Empty/whitespace provider falls back to `"cli"`, model to `"default"`. Valid values preserved.
- **What was not tested:** Full transcript file persistence (regression tests mock persistSessionTranscriptTurn; CI covers full IO)

## Tests and validation
```text
$ node_modules/.bin/vitest run --reporter=verbose --config test/vitest/vitest.agents.config.ts src/agents/command/attempt-execution.provider-model.test.ts
✓ uses cli and default when provider and model are empty/whitespace
✓ uses actual provider and model when non-empty
Test Files  1 passed  Tests  2 passed
```

New regression test file calls the real `persistCliTurnTranscript` and captures assistant metadata via mocked `persistSessionTranscriptTurn`.

## Risk checklist

- User-visible behavior: No
- Config/env/migration behavior: No
- Security/auth/secrets/network/tool execution: No
- Plugins/providers/channels/SDK: No
- Highest-risk area: Transcript metadata fallback for empty string edge case
- Mitigation: `||` semantics are the intended behavior; real source verified; regression tests pass

Closes: N/A (no existing issue)