### PR TITLE
fix(compaction): recover after tool-only post-compaction suffixes

### DIFF
--- a/src/agents/compaction-real-conversation.ts
+++ b/src/agents/compaction-real-conversation.ts
@@ -49,7 +49,8 @@ export function hasMeaningfulConversationContent(message: AgentMessage): boolean
     const output = typeof bash.output === "string" ? bash.output : "";
     return hasMeaningfulText(`${command}\n${output}`);
   }
-  if ((message as { role?: unknown }).role === "branchSummary") {
+  const role = (message as { role?: unknown }).role;
+  if (role === "branchSummary" || role === "compactionSummary") {
     const summary = (message as { summary?: unknown }).summary;
     return typeof summary === "string" && hasMeaningfulText(summary);
   }
@@ -96,7 +97,8 @@ function isToolResultConversationAnchor(message: AgentMessage): boolean {
     (role === "user" ||
       role === "custom" ||
       role === "bashExecution" ||
-      role === "branchSummary") &&
+      role === "branchSummary" ||
+      role === "compactionSummary") &&
     hasMeaningfulConversationContent(message)
   );
 }
@@ -112,7 +114,8 @@ export function isRealConversationMessage(
     message.role === "assistant" ||
     message.role === "custom" ||
     message.role === "bashExecution" ||
-    message.role === "branchSummary"
+    message.role === "branchSummary" ||
+    message.role === "compactionSummary"
   ) {
     return hasMeaningfulConversationContent(message);
   }

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -2199,6 +2199,47 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
     expect(compactTesting.containsRealConversationMessages(messages)).toBe(false);
   });
 
+  it("keeps a post-compaction summary as real conversation before a tool-only suffix", () => {
+    const messages = [
+      {
+        role: "compactionSummary",
+        summary: "The user asked for a long-running repository audit.",
+        timestamp: 1,
+      },
+      ...Array.from({ length: 12 }, (_, index) => ({
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: `call-${index}`,
+            name: "exec",
+            arguments: {},
+          },
+        ],
+        timestamp: index + 2,
+      })),
+      ...Array.from({ length: 27 }, (_, index) => ({
+        role: "toolResult",
+        toolCallId: `call-${index}`,
+        toolName: "exec",
+        content: [{ type: "text", text: `result-${index}` }],
+        isError: false,
+        timestamp: index + 14,
+      })),
+    ] as AgentMessage[];
+
+    expect(messages).toHaveLength(40);
+    expect(compactTesting.containsRealConversationMessages(messages)).toBe(true);
+  });
+
+  it("does not treat an empty compaction summary as real conversation", () => {
+    expect(
+      compactTesting.containsRealConversationMessages([
+        { role: "compactionSummary", summary: "   ", timestamp: 1 } as AgentMessage,
+      ]),
+    ).toBe(false);
+  });
+
   it("does not treat assistant-only tool-call blocks as meaningful conversation", () => {
     expect(
       compactTesting.hasMeaningfulConversationContent({


### PR DESCRIPTION
Related: https://github.com/karmaterminal/openclaw/issues/1187
Related: https://github.com/openclaw/openclaw/issues/78562

## What Problem This Solves

Fixes an issue where a session that has already compacted can fail overflow recovery after the same turn appends only tool calls and tool results. The valid compaction summary is currently ignored by the real-conversation guard, so the next compaction reports that there are no real conversation messages and the session can require a reset or new session.

## Why This Change Was Made

Treat a non-empty `compactionSummary` as the same kind of conversation anchor as an existing `branchSummary`. Empty summaries remain ineligible, and tool-call-only assistant blocks or orphan tool results do not become conversation anchors.

## User Impact

Long tool-heavy turns can compact again from their preserved summary instead of falling into a no-progress overflow/reset path.

## Evidence

AI-assisted; I reviewed the resulting code and understand the classifier change.

Red on untouched upstream `27f05c8993fb18ad6d65a5912d50966594d9662c`:
- Exact 40-message shape: one non-empty `compactionSummary`, 12 tool-call-only assistant messages, 27 tool results, no user message.
- Test-only regression on untouched production source:

```text
FAIL  keeps a post-compaction summary as real conversation before a tool-only suffix
AssertionError: expected false to be true
Test Files  2 failed (2)
Tests       2 failed | 218 passed (220)
```

Green after the fix, initially rebased onto upstream `a20e08a56e69a8b3e4702da9984c8bf5255e5927`:

```text
Test Files  8 passed (8)
Tests       656 passed (656)
```

Rebased again onto current upstream `200653bd60c840566f0c134c98d8684c02c6a0e6` and pushed as exact head `3c40b70ee7c7a2151c7365b0471cacc34ae1da35`:

```text
pnpm exec vitest run src/agents/embedded-agent-runner/compact.hooks.test.ts test/scripts/plugin-lifecycle-measure.test.ts
Test Files  3 passed (3)
Tests       234 passed (234)
```

- Adjacent set covered compact hooks, compaction safeguard, both overflow-compaction suites, and tool-result truncation.
- `pnpm check:changed`: passed core/coreTests typecheck, lint, format, import-cycle, schema, and repository guards on the prior exact head.
- `git diff --check`: passed.
- A blank `compactionSummary` has a dedicated negative regression test.
- Previous hosted CI's unrelated `plugin-lifecycle-measure.test.ts` temp-file race was locally rerun on the rebased head: 12/12 passed as part of the command above.
- New hosted CI is pending on the rebased head.

Safety boundary: no live deployment, gateway/config mutation, continuation branch, proof row, or presentation state was used. This is an inspectable isolated production-module RED→GREEN receipt; maintainers may explicitly accept test-only evidence or request a separate non-deployed harness.


<!-- frond-scribe-real-behavior-proof-v1 -->
## Real behavior proof corpus

A live before/after corpus is published on `karmaterminal-openclaw-docs:main`:

- Entry: [PR-111616/PROOFS/INDEX.json](https://github.com/karmaterminal/karmaterminal-openclaw-docs/blob/main/PR-111616/PROOFS/INDEX.json)
- Exact-runtime README: [c354b220.../README.md](https://github.com/karmaterminal/karmaterminal-openclaw-docs/blob/main/PR-111616/PROOFS/c354b220ba63bf1d56286da383cd8ce3b9eaa71a/README.md)
- Published commit: [`abe1f9f0`](https://github.com/karmaterminal/karmaterminal-openclaw-docs/commit/abe1f9f0749d849b01da4e5d354c205ecffac946)

How to parse: `INDEX.json` selects the exact deployed SHA; follow `manifest_path` for the verdict row and artifact pointers, then `readme_path` for the neutral before/after table and honest limits. `SHA256SUMS` makes the exact-SHA corpus byte-verifiable.

Testbed disclosure: fixed continuation assembly `ceaf8cba72c48914acd1baf8b6796b5f35fc5f1e` plus PRs #111616, #111617, and #112013 at combined runtime `c354b220ba63bf1d56286da383cd8ce3b9eaa71a`. This PR source head, applied commit, and stable patch ID are bound in `RESOLVED-SHA.md`; protected #85651 presentation bytes were not changed.

Observed distinction: for the same 41-message role shape, assembly classified the transcript `false` and skipped compaction; the candidate classified it `true`, the production gateway compaction path reduced 41 messages to 3, and the next turn completed under the same session ID. The corpus explicitly discloses that compaction was manually invoked against an overflow-shaped transcript; it does not claim a naturally generated provider overflow.
