### PR TITLE
fix(ui): preserve native context menu for chat links

### DIFF
--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -5414,6 +5414,27 @@ describe("right-click Reply", () => {
     expect(target.text).toBe("x".repeat(499));
   });
 
+  it("keeps the native context menu for links inside a replyable bubble", () => {
+    const container = renderChatView({ onSetReply: vi.fn() });
+    const group = document.createElement("div");
+    group.className = "chat-group";
+    const bubble = document.createElement("div");
+    bubble.className = "chat-bubble";
+    bubble.dataset.messageText = "hello world";
+    const link = document.createElement("a");
+    link.href = "https://example.com";
+    link.textContent = "Example";
+    bubble.appendChild(link);
+    group.appendChild(bubble);
+    container.querySelector(".chat-thread-inner")!.appendChild(group);
+
+    const evt = new MouseEvent("contextmenu", { bubbles: true, cancelable: true });
+    link.dispatchEvent(evt);
+
+    expect(evt.defaultPrevented).toBe(false);
+    expect(document.querySelector(".chat-reply-context-menu")).toBeNull();
+  });
+
   it("keeps the native context menu when Reply is unavailable", () => {
     const container = renderChatView();
     const section = container.querySelector<HTMLElement>(".card.chat");

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -793,6 +793,9 @@ function handleChatThreadSelectionPointerUp(event: PointerEvent, props: ChatThre
 }
 
 function handleChatContextMenu(event: MouseEvent, props: ChatThreadProps) {
+  if (event.composedPath().some((target) => target instanceof HTMLAnchorElement)) {
+    return;
+  }
   const bubble = (event.target as HTMLElement).closest(".chat-bubble");
   if (!bubble) {
     return;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users who right-clicked a link inside a Control UI chat message saw OpenClaw's message actions menu instead of the browser's native link context menu.

## Why This Change Was Made

The chat thread now leaves context-menu events originating from anchors to the browser or native host. Message actions remain unchanged for ordinary non-link content.

## User Impact

Users can use standard browser link actions such as opening a link in a new tab, copying its address, or otherwise interacting with the real link. Right-clicking elsewhere on a message still offers Reply, Rewind, and Fork when available.

## Evidence

- `node scripts/run-vitest.mjs ui/src/pages/chat/chat-view.test.ts --configLoader runner` — 179 tests passed after rebasing onto current `main`.
- Targeted oxlint and oxfmt checks — passed.
- `git diff --check` — passed.
- Codex autoreview — clean, no accepted/actionable findings; patch judged correct with 0.97 confidence.
- Exact-head hosted CI run [29713133976](https://github.com/openclaw/openclaw/actions/runs/29713133976) — green, including `checks-ui`, lint, production/test types, and `openclaw/ci-gate`.

Live Chrome automation was unavailable because the session sandbox denied the browser bridge's Unix socket. The regression test exercises the real delegated DOM event handler and proves the link event remains unprevented and the custom message menu is absent; existing tests prove non-link message content still opens the custom actions.

### Maintainer proof decision

ClawSweeper requested a native browser-menu capture. For this narrow event-ownership change, focused DOM coverage is accepted as sufficient: operating-system context menus are not exposed to DevTools, the browser bridge was unavailable in this session, and the regression directly verifies the browser-critical contract (`defaultPrevented === false`) plus absence of OpenClaw's competing menu. This records the proof gap explicitly rather than silently merging past it.

AI-assisted change; the implementation and evidence were reviewed before submission.
