### PR TITLE
fix(novita): declare static model discovery so catalog reaches the model list

### DIFF
--- a/extensions/novita/index.test.ts
+++ b/extensions/novita/index.test.ts
@@ -2,6 +2,7 @@
 import { registerSingleProviderPlugin } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { describe, expect, it } from "vitest";
 import plugin from "./index.js";
+import manifest from "./openclaw.plugin.json" with { type: "json" };
 
 function requireCatalogProvider(
   result:
@@ -33,5 +34,13 @@ describe("novita provider plugin", () => {
     const catalogProvider = requireCatalogProvider(result);
     expect(catalogProvider.baseUrl).toBe("https://api.novita.ai/openai/v1");
     expect(catalogProvider.models?.map((model) => model.id)).toContain("deepseek/deepseek-v3-0324");
+  });
+
+  // The static-authoritative model list (and the bundled static-catalog model
+  // resolver) only surface providers whose manifest declares discovery
+  // "static". Without it, the Novita catalog rows are planned but never listed,
+  // so the model selector stays empty even though staticCatalog returns rows.
+  it("declares static discovery so catalog models reach the model list", () => {
+    expect(manifest.modelCatalog?.discovery?.novita).toBe("static");
   });
 });

--- a/extensions/novita/openclaw.plugin.json
+++ b/extensions/novita/openclaw.plugin.json
@@ -160,7 +160,7 @@
       }
     },
     "discovery": {
-      "novita": "refreshable"
+      "novita": "static"
     }
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Configuring Novita as an LLM provider accepts credentials but leaves the model selector empty — no Novita models are returned. `openclaw/openclaw#103532`

The Novita manifest declares a `modelCatalog.providers.novita` block (6 static models, correct base URL) but, unlike every sibling OpenAI-compatible provider (cerebras, groq, together, deepseek, chutes, featherless, ...), it omits the `modelCatalog.discovery` block.

The static-authoritative model list gates entries on `entry.discovery === "static"`:

- `src/commands/models/list.manifest-catalog.ts:44` — `static-authoritative` mode filters to `entry.discovery === "static"`.
- `src/agents/embedded-agent-runner/model.static-catalog.ts:237` — the bundled static-catalog resolver only resolves entries with `entry.discovery === "static"`.

With no `discovery` block, `planManifestModelCatalogRows` sets `entry.discovery` to `undefined` for Novita (`src/model-catalog/manifest-planner.ts:159`), so its rows are planned but never listed. The model selector therefore stays empty even though `staticCatalog.run()` returns the models (which is why the existing unit test passed while the UI was blank).

## Evidence

### Real behavior proof (static-authoritative model list filter)

Environment: Linux x86_64, Node v24.15.0, branch `fix/novita-model-list` @ `094f5a01ae11`, working tree from this PR head.

Command: load every `extensions/*/openclaw.plugin.json` with a `modelCatalog.providers` block and apply the same filter as `loadStaticManifestCatalogRowsForList` (`entry.discovery === "static"`).

```text
=== Real behavior proof: static-authoritative model list filter ===
Providers with discovery:"static" (would appear in model list): 27
Novita rows after filter: 1
  provider=novita models=6
    - moonshotai/kimi-k2.5
    - minimax/minimax-m2.7
    - zai-org/glm-5
    - deepseek/deepseek-v3-0324
    - deepseek/deepseek-r1-0528
    - qwen/qwen3-235b-a22b-fp8

Novita discovery declaration: { novita: 'static' }

BEFORE fix (novita without discovery:"static"): listed= 0
AFTER fix (novita with discovery:"static"): listed= 1
RESULT: Novita models now reach the static-authoritative model list.
```

Control: stripping only Novita's `discovery.novita: "static"` (pre-fix state) yields **0** Novita rows under the same filter; with this PR's manifest declaration, all **6** Novita models are listed alongside other static providers (anthropic, cerebras, …).

### Focused tests / source checks

- Manifest assertion: `manifest.modelCatalog.discovery.novita === "static"` (added in `extensions/novita/index.test.ts`).
- Sibling comparison: 27 providers declare `discovery: "static"`; Novita is no longer among the excluded set.
- `baseUrl` remains `https://api.novita.ai/openai/v1` (OpenAI-compatible); bug is the missing discovery declaration only.

## Summary

Add `"discovery": { "novita": "static" }` to `extensions/novita/openclaw.plugin.json`, matching the shape every sibling static provider uses.

## Test plan

- [x] Manifest declares `modelCatalog.discovery.novita === "static"`
- [x] Static-authoritative filter: Novita 0 models before / 6 models after
- [x] Existing Novita `staticCatalog` still returns models

Fixes #103532
