### PR TITLE
docs: add Agent37 managed hosting install guide

### DIFF
--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -4,6 +4,18 @@
     "target": "OpenClaw"
   },
   {
+    "source": "Hostinger",
+    "target": "Hostinger"
+  },
+  {
+    "source": "Channels",
+    "target": "频道"
+  },
+  {
+    "source": "Agent37",
+    "target": "Agent37"
+  },
+  {
     "source": "macOS platform notes",
     "target": "macOS 平台说明"
   },

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1105,6 +1105,7 @@
               {
                 "group": "Hosting",
                 "pages": [
+                  "install/agent37",
                   "install/azure",
                   "install/digitalocean",
                   "install/docker-vm-runtime",

--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -4331,6 +4331,18 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: Start here
   - H2: Learn more
 
+## install/agent37.md
+
+- Route: /install/agent37
+- Headings:
+  - H2: Prerequisites
+  - H2: Deploy
+  - H2: Manage the instance
+  - H2: Verify your setup
+  - H2: Troubleshooting
+  - H2: Next steps
+  - H2: Related
+
 ## install/ansible.md
 
 - Route: /install/ansible

--- a/docs/install/agent37.md
+++ b/docs/install/agent37.md
@@ -1,0 +1,79 @@
+---
+summary: "Host OpenClaw on Agent37 managed hosting"
+read_when:
+  - Setting up OpenClaw on Agent37
+  - Looking for managed OpenClaw hosting with a browser dashboard
+  - You want a hosted Gateway without administering a VPS
+title: "Agent37"
+---
+
+Run a persistent OpenClaw Gateway on [Agent37](https://www.agent37.com/) managed
+hosting. Agent37 provisions and operates the instance for you: each instance runs in
+an isolated container with a browser dashboard, so there is no server setup or VPS
+administration.
+
+## Prerequisites
+
+- Agent37 account ([signup](https://www.agent37.com/))
+- A model API key (bring your own key from Anthropic, OpenAI, or another provider;
+  some plans bundle models)
+- About 5 minutes
+
+## Deploy
+
+<Steps>
+  <Step title="Choose a plan">
+    From [agent37.com](https://www.agent37.com/), pick a managed hosting plan and
+    complete checkout. See the Agent37 site for current plans.
+  </Step>
+
+  <Step title="Launch the agent">
+    In the [Agent37 dashboard](https://www.agent37.com/dashboard), click
+    **Launch Agent**. Provisioning takes about a minute; the instance appears in
+    your dashboard when it is ready.
+  </Step>
+
+  <Step title="Add your model key">
+    Provide your model API key during setup (or use bundled models if your plan
+    includes them). Keys are used by your instance directly against the model
+    provider.
+  </Step>
+</Steps>
+
+## Manage the instance
+
+From the instance view in the dashboard:
+
+- **Web Chat** -- open the hosted chat UI and talk to your agent.
+- **Terminal** -- full TTY shell access to the instance: inspect logs, run
+  `openclaw` CLI commands, or make manual changes.
+- **Files** -- visual file browser for the instance workspace.
+- Scheduled jobs and a live Linux desktop are also available from the dashboard.
+
+Runtime updates and security patches are applied by Agent37 automatically.
+
+## Verify your setup
+
+Open **Web Chat** and send "Hi". OpenClaw replies and walks you through initial
+preferences. From there, connect channels and configure the Gateway the same way
+as any other OpenClaw install; see [Getting Started](/start/getting-started).
+
+## Troubleshooting
+
+**Instance stuck provisioning** -- provisioning normally completes in about a
+minute; if it takes much longer, refresh the dashboard, then contact Agent37
+support from the dashboard.
+
+**Agent not replying in Web Chat** -- open **Terminal** and check the Gateway
+logs, and confirm your model API key is valid for the configured provider.
+
+## Next steps
+
+- [Channels](/channels) -- connect Telegram, WhatsApp, Discord, and more
+- [Gateway configuration](/gateway/configuration) -- all config options
+
+## Related
+
+- [Install overview](/install)
+- [VPS hosting](/vps)
+- [Hostinger](/install/hostinger)

--- a/docs/vps.md
+++ b/docs/vps.md
@@ -15,6 +15,7 @@ tuning that applies everywhere.
 ## Pick a provider
 
 <CardGroup cols={2}>
+  <Card title="Agent37" href="/install/agent37">Managed instance, browser dashboard</Card>
   <Card title="Azure" href="/install/azure">Linux VM</Card>
   <Card title="DigitalOcean" href="/install/digitalocean">Simple paid VPS</Card>
   <Card title="exe.dev" href="/install/exe-dev">VM with HTTPS proxy</Card>


### PR DESCRIPTION
Resubmission of #43500, rewritten against current main to address every criterion from the triage closure and review comments there.

## What Problem This Solves

The Install > Hosting section documents managed and one-click hosted paths (Hostinger, Railway, Render, Northflank, exe.dev) but has no page for Agent37, a managed OpenClaw host that operates the Gateway in an isolated container with a browser dashboard (Web Chat, TTY terminal, file browser, scheduled jobs). Users searching the docs for how to run OpenClaw on Agent37 find nothing, so setup questions land on Agent37 support instead of a docs page that follows the same conventions as the other hosted guides. This adds that page using the exact pattern of the merged Hostinger guide (docs/install/hostinger.md, #65904).

Disclosure: I am the founder of Agent37. I have kept the page factual and free of pricing or marketing figures per the Greptile review on #43500.

## Evidence

Rendered with `mint dev` on this branch:

![Install page rendered](https://raw.githubusercontent.com/vishnukool/openclaw/a68045a7cfb8081e6d18d6c16bb27f62d4aee426/agent37-doc-rendered.png)

![VPS provider picker with Agent37 card](https://raw.githubusercontent.com/vishnukool/openclaw/a68045a7cfb8081e6d18d6c16bb27f62d4aee426/vps-picker-rendered.png)

Checks run locally on this branch, all passing: `node scripts/generate-docs-map.mjs --check`, `node scripts/check-docs-i18n-glossary.mjs --base main --head HEAD`, oxfmt with the repo config, and docs.json parses as valid JSON. The described dashboard flow (Launch Agent, Web Chat, Terminal) matches the live product at agent37.com today; I verified each step against the current dashboard before writing it.

## What changed vs #43500

- Rebased onto current main; single commit, docs only.
- vps.md now edits the CardGroup provider picker (the old branch patched the removed bullet list).
- Frontmatter now includes `summary` and `read_when` matching railway.mdx and hostinger.md.
- Removed all pricing and integration-count figures flagged by Greptile.
- Added Troubleshooting, Next steps, and Related sections to match the Hostinger guide structure.
- Regenerated docs_map.md and added the required zh-CN glossary entries so docs CI passes.
- Dropped the redirects and platforms/index.md edits from the old PR; Hostinger has neither, so this now mirrors that merged precedent exactly (guide + nav entry + picker card).

https://claude.ai/code/session_018sVSGwjB4hqi1BstoWkyQq