### PR TITLE
fix(tools): accept POSIX drive paths on Windows

### DIFF
--- a/src/agents/agent-tools.read.host-write-integrity.test.ts
+++ b/src/agents/agent-tools.read.host-write-integrity.test.ts
@@ -6,6 +6,14 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { createHostWorkspaceEditTool, createHostWorkspaceWriteTool } from "./agent-tools.read.js";
 import { createApplyPatchTool } from "./apply-patch.js";
 
+function toWindowsPosixDrivePath(nativePath: string, prefix: "" | "cygdrive/" | "mnt/"): string {
+  const drive = nativePath[0]?.toLowerCase();
+  if (!drive || nativePath[1] !== ":") {
+    throw new Error(`Expected a Windows drive path, got ${nativePath}`);
+  }
+  return `/${prefix}${drive}${nativePath.slice(2).replaceAll("\\", "/")}`;
+}
+
 describe("unrestricted host tool writes", () => {
   let tempDir = "";
 
@@ -23,6 +31,37 @@ describe("unrestricted host tool writes", () => {
     await fs.writeFile(filePath, content);
     return filePath;
   }
+
+  it.runIf(process.platform === "win32").each(["", "cygdrive/", "mnt/"] as const)(
+    "writes through the host tool using the %s form",
+    async (prefix) => {
+      await createFile("existing");
+      const nativePath = path.join(tempDir, "written.txt");
+      const tool = createHostWorkspaceWriteTool(tempDir);
+
+      await tool.execute("write-posix-drive", {
+        path: toWindowsPosixDrivePath(nativePath, prefix),
+        content: "written",
+      });
+
+      await expect(fs.readFile(nativePath, "utf8")).resolves.toBe("written");
+    },
+  );
+
+  it.runIf(process.platform === "win32").each(["", "cygdrive/", "mnt/"] as const)(
+    "edits through the host tool using the %s form",
+    async (prefix) => {
+      const nativePath = await createFile("before");
+      const tool = createHostWorkspaceEditTool(tempDir);
+
+      await tool.execute("edit-posix-drive", {
+        path: toWindowsPosixDrivePath(nativePath, prefix),
+        edits: [{ oldText: "before", newText: "after" }],
+      });
+
+      await expect(fs.readFile(nativePath, "utf8")).resolves.toBe("after");
+    },
+  );
 
   it.each(["write", "edit", "apply_patch"] as const)(
     "fences %s after asynchronous file preparation when permissions change",

--- a/src/agents/agent-tools.read.ts
+++ b/src/agents/agent-tools.read.ts
@@ -883,6 +883,8 @@ export function wrapToolWorkspaceRootGuardWithOptions(
     containerWorkdir?: string;
     pathParamKeys?: readonly string[];
     normalizeGuardedPathParams?: boolean;
+    /** Resolve host-owned aliases before containment so the checked path is the I/O path. */
+    resolveGuardedPath?: (filePath: string, cwd: string) => string | Promise<string>;
     resolutionCwd?: string;
     bridge?: SandboxFsBridge;
   },
@@ -899,11 +901,15 @@ export function wrapToolWorkspaceRootGuardWithOptions(
         if (typeof rawFilePath !== "string" || !rawFilePath.trim()) {
           continue;
         }
-        const filePath = await normalizeFileToolPathParam(
+        const resolutionCwd = options?.resolutionCwd ?? root;
+        const normalizedFilePath = await normalizeFileToolPathParam(
           rawFilePath,
-          options?.resolutionCwd ?? root,
+          resolutionCwd,
           options?.bridge,
         );
+        const filePath = options?.resolveGuardedPath
+          ? await options.resolveGuardedPath(normalizedFilePath, resolutionCwd)
+          : normalizedFilePath;
         if (!filePath.trim()) {
           throw malformedXmlArgValuePathError(key);
         }

--- a/src/agents/agent-tools.read.ts
+++ b/src/agents/agent-tools.read.ts
@@ -52,7 +52,11 @@ import {
   type ReadToolDetails,
   type ReadToolTruncationDetails,
 } from "./sessions/tools/index.js";
-import { expandOsHomePrefix, resolveToCwd } from "./sessions/tools/path-utils.js";
+import {
+  expandOsHomePrefix,
+  resolveLocalPathToCwd,
+  resolveToCwd,
+} from "./sessions/tools/path-utils.js";
 import {
   createBoundedReadTextPage,
   formatReadContinuationNotice,
@@ -1403,6 +1407,7 @@ function createHostWriteOperations(
     // When workspaceOnly is false, allow writes anywhere on the host
     return withMemoryWriteProvenance(
       {
+        resolvePath: resolveLocalPathToCwd,
         mkdir: async (dir: string) => {
           const resolved = resolveHostPath(dir);
           options?.abortSignal?.throwIfAborted();
@@ -1427,6 +1432,7 @@ function createHostWriteOperations(
   const getRoot = () => (rootPromise ??= fsRoot(root));
   return withMemoryWriteProvenance(
     {
+      resolvePath: resolveLocalPathToCwd,
       mkdir: async (dir: string) => {
         const relative = toRelativeWorkspacePath(root, dir, { allowRoot: true });
         const resolved = relative ? path.resolve(root, relative) : path.resolve(root);
@@ -1466,6 +1472,7 @@ function createHostEditOperations(
     // When workspaceOnly is false, allow edits anywhere on the host
     return withMemoryWriteProvenance(
       {
+        resolvePath: resolveLocalPathToCwd,
         readFile: async (absolutePath: string) => {
           return await fs.readFile(resolveHostPath(absolutePath));
         },
@@ -1488,6 +1495,7 @@ function createHostEditOperations(
   const getRoot = () => (rootPromise ??= fsRoot(root));
   return withMemoryWriteProvenance(
     {
+      resolvePath: resolveLocalPathToCwd,
       readFile: async (absolutePath: string) => {
         // Canonicalize symlink parents like the write path: fs-safe 0.5.2
         // rejects intermediate symlinks by default, but in-workspace symlink

--- a/src/agents/agent-tools.read.windows.test.ts
+++ b/src/agents/agent-tools.read.windows.test.ts
@@ -13,6 +13,14 @@ import { expectReadWriteEditTools, getTextContent } from "./test-helpers/agent-t
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
+function toWindowsPosixDrivePath(nativePath: string): string {
+  const drive = nativePath[0]?.toLowerCase();
+  if (!drive || nativePath[1] !== ":") {
+    throw new Error(`Expected a Windows drive path, got ${nativePath}`);
+  }
+  return `/${drive}${nativePath.slice(2).replaceAll("\\", "/")}`;
+}
+
 describe("registered core read on Windows", () => {
   it.runIf(process.platform === "win32")(
     "reads text produced by Windows PowerShell Out-File",
@@ -57,4 +65,52 @@ describe("registered core read on Windows", () => {
 
     expect(text).toContain("home read");
   });
+
+  it.runIf(process.platform === "win32")(
+    "normalizes drive aliases before workspace-only containment",
+    async () => {
+      const workspaceDir = tempDirs.make("openclaw-core-drive-workspace-");
+      const outsideDir = tempDirs.make("openclaw-core-drive-outside-");
+      const insidePath = path.join(workspaceDir, "inside.txt");
+      const outsidePath = path.join(outsideDir, "outside.txt");
+      await fs.writeFile(insidePath, "inside before", "utf8");
+      await fs.writeFile(outsidePath, "outside before", "utf8");
+
+      const { readTool, writeTool, editTool } = expectReadWriteEditTools(
+        createOpenClawCodingTools({
+          workspaceDir,
+          config: { tools: { fs: { workspaceOnly: true } } },
+        }),
+      );
+      const insideAlias = toWindowsPosixDrivePath(insidePath);
+      const outsideAlias = toWindowsPosixDrivePath(outsidePath);
+
+      expect(
+        getTextContent(await readTool.execute("drive-inside-read", { path: insideAlias })),
+      ).toBe("inside before");
+      await writeTool.execute("drive-inside-write", {
+        path: insideAlias,
+        content: "inside written",
+      });
+      await editTool.execute("drive-inside-edit", {
+        path: insideAlias,
+        edits: [{ oldText: "inside written", newText: "inside edited" }],
+      });
+      await expect(fs.readFile(insidePath, "utf8")).resolves.toBe("inside edited");
+
+      await expect(readTool.execute("drive-outside-read", { path: outsideAlias })).rejects.toThrow(
+        /escapes sandbox root/i,
+      );
+      await expect(
+        writeTool.execute("drive-outside-write", { path: outsideAlias, content: "changed" }),
+      ).rejects.toThrow(/escapes sandbox root/i);
+      await expect(
+        editTool.execute("drive-outside-edit", {
+          path: outsideAlias,
+          edits: [{ oldText: "outside before", newText: "changed" }],
+        }),
+      ).rejects.toThrow(/escapes sandbox root/i);
+      await expect(fs.readFile(outsidePath, "utf8")).resolves.toBe("outside before");
+    },
+  );
 });

--- a/src/agents/core-coding-tools.ts
+++ b/src/agents/core-coding-tools.ts
@@ -61,6 +61,7 @@ function guardHostWorkspaceTool(
 ): AnyAgentTool {
   return wrapToolWorkspaceRootGuardWithOptions(tool, options.containmentRoot, {
     resolutionCwd: options.codingRoot,
+    normalizeGuardedPathParams: true,
     resolveGuardedPath: normalizeLocalGuardPathAlias,
   });
 }
@@ -144,6 +145,7 @@ export function createCoreCodingTools(options: CoreCodingToolsOptions): AnyAgent
             : {
                 additionalRoots: skillReadRoots,
                 resolutionCwd: options.codingRoot,
+                normalizeGuardedPathParams: true,
                 resolveGuardedPath: normalizeLocalGuardPathAlias,
               },
         )

--- a/src/agents/core-coding-tools.ts
+++ b/src/agents/core-coding-tools.ts
@@ -24,9 +24,13 @@ import type { MemoryWriteProvenanceObserver } from "./memory-write-provenance.js
 import type { SandboxContext } from "./sandbox.js";
 import { buildSandboxFsMounts } from "./sandbox/fs-paths.js";
 import { resolveReadOnlyWorkspaceSkillMounts } from "./sandbox/workspace-mounts.js";
-import { resolveLocalPathToCwd } from "./sessions/tools/path-utils.js";
+import { normalizeWindowsPosixDrivePath } from "./sessions/tools/path-utils.js";
 import { createReadTool } from "./sessions/tools/read.js";
 import { resolveToolResultBudget } from "./tool-result-limits.js";
+
+function normalizeLocalGuardPathAlias(filePath: string): string {
+  return normalizeWindowsPosixDrivePath(filePath);
+}
 
 function sandboxReadMounts(
   sandbox: SandboxContext,
@@ -57,8 +61,7 @@ function guardHostWorkspaceTool(
 ): AnyAgentTool {
   return wrapToolWorkspaceRootGuardWithOptions(tool, options.containmentRoot, {
     resolutionCwd: options.codingRoot,
-    normalizeGuardedPathParams: true,
-    resolveGuardedPath: resolveLocalPathToCwd,
+    resolveGuardedPath: normalizeLocalGuardPathAlias,
   });
 }
 
@@ -141,8 +144,7 @@ export function createCoreCodingTools(options: CoreCodingToolsOptions): AnyAgent
             : {
                 additionalRoots: skillReadRoots,
                 resolutionCwd: options.codingRoot,
-                normalizeGuardedPathParams: true,
-                resolveGuardedPath: resolveLocalPathToCwd,
+                resolveGuardedPath: normalizeLocalGuardPathAlias,
               },
         )
       : read;

--- a/src/agents/core-coding-tools.ts
+++ b/src/agents/core-coding-tools.ts
@@ -24,6 +24,7 @@ import type { MemoryWriteProvenanceObserver } from "./memory-write-provenance.js
 import type { SandboxContext } from "./sandbox.js";
 import { buildSandboxFsMounts } from "./sandbox/fs-paths.js";
 import { resolveReadOnlyWorkspaceSkillMounts } from "./sandbox/workspace-mounts.js";
+import { resolveLocalPathToCwd } from "./sessions/tools/path-utils.js";
 import { createReadTool } from "./sessions/tools/read.js";
 import { resolveToolResultBudget } from "./tool-result-limits.js";
 
@@ -57,6 +58,7 @@ function guardHostWorkspaceTool(
   return wrapToolWorkspaceRootGuardWithOptions(tool, options.containmentRoot, {
     resolutionCwd: options.codingRoot,
     normalizeGuardedPathParams: true,
+    resolveGuardedPath: resolveLocalPathToCwd,
   });
 }
 
@@ -140,6 +142,7 @@ export function createCoreCodingTools(options: CoreCodingToolsOptions): AnyAgent
                 additionalRoots: skillReadRoots,
                 resolutionCwd: options.codingRoot,
                 normalizeGuardedPathParams: true,
+                resolveGuardedPath: resolveLocalPathToCwd,
               },
         )
       : read;

--- a/src/agents/sessions/tools/edit.test.ts
+++ b/src/agents/sessions/tools/edit.test.ts
@@ -447,6 +447,61 @@ describe("edit tool", () => {
     },
   );
 
+  it("uses the injected path resolver for both preview and execution", async () => {
+    let persisted = Buffer.from("before\n");
+    const resolvePath = vi.fn((filePath: string) => `remote:${filePath}`);
+    const access = vi.fn(async () => {});
+    const readFile = vi.fn(async () => persisted);
+    const writeFile = vi.fn(async (_absolutePath: string, content: string) => {
+      persisted = Buffer.from(content);
+    });
+    const operations: EditOperations = {
+      resolvePath,
+      access,
+      readFile,
+      statFile: async () => ({ type: "file", size: persisted.byteLength }),
+      writeFile,
+    };
+    const cwd = "/remote/workspace";
+    const tool = createEditToolDefinition(cwd, { operations });
+    const args = {
+      path: "/c/work/demo.txt",
+      edits: [{ oldText: "before", newText: "after" }],
+    };
+    const context = {
+      args,
+      argsComplete: true,
+      cwd,
+      executionStarted: false,
+      expanded: false,
+      invalidate: vi.fn(),
+      isError: false,
+      isPartial: false,
+      lastComponent: undefined,
+      showImages: false,
+      state: {},
+      toolCallId: "call-resolved-preview",
+    };
+
+    const component = tool.renderCall?.(args, testTheme, context);
+    await vi.waitFor(() => expect(context.invalidate).toHaveBeenCalled());
+    const preview = (component as { preview?: { error?: string; diff?: string } } | undefined)
+      ?.preview;
+    expect(preview?.error).toBeUndefined();
+    expect(preview?.diff).toContain("after");
+
+    await tool.execute("call-resolved-execution", args);
+
+    expect(resolvePath).toHaveBeenNthCalledWith(1, args.path, cwd);
+    expect(resolvePath).toHaveBeenNthCalledWith(2, args.path, cwd);
+    expect(access).toHaveBeenCalledTimes(2);
+    expect(access).toHaveBeenCalledWith(`remote:${args.path}`);
+    expect(
+      readFile.mock.calls.every(([absolutePath]) => absolutePath === `remote:${args.path}`),
+    ).toBe(true);
+    expect(writeFile).toHaveBeenCalledWith(`remote:${args.path}`, "after\n");
+  });
+
   it("renders fuzzy Unicode previews from the original source bytes", async () => {
     const readFile = vi.fn(async () =>
       Buffer.from(

--- a/src/agents/sessions/tools/edit.test.ts
+++ b/src/agents/sessions/tools/edit.test.ts
@@ -451,7 +451,7 @@ describe("edit tool", () => {
     let persisted = Buffer.from("before\n");
     const resolvePath = vi.fn((filePath: string) => `remote:${filePath}`);
     const access = vi.fn(async () => {});
-    const readFile = vi.fn(async () => persisted);
+    const readFile = vi.fn(async (_absolutePath: string) => persisted);
     const writeFile = vi.fn(async (_absolutePath: string, content: string) => {
       persisted = Buffer.from(content);
     });
@@ -490,7 +490,7 @@ describe("edit tool", () => {
     expect(preview?.error).toBeUndefined();
     expect(preview?.diff).toContain("after");
 
-    await tool.execute("call-resolved-execution", args);
+    await tool.execute("call-resolved-execution", args, undefined, undefined, {} as never);
 
     expect(resolvePath).toHaveBeenNthCalledWith(1, args.path, cwd);
     expect(resolvePath).toHaveBeenNthCalledWith(2, args.path, cwd);

--- a/src/agents/sessions/tools/edit.ts
+++ b/src/agents/sessions/tools/edit.ts
@@ -99,6 +99,8 @@ const EDIT_MISMATCH_HINT_LIMIT = 800;
  * Override these to delegate file editing to remote systems (for example SSH).
  */
 export interface EditOperations {
+  /** Resolve a user-supplied path in this backend's path space. */
+  resolvePath?: (filePath: string, cwd: string) => string;
   /** Resolve the physical identity used to order this backend's file operations. */
   resolveQueueKey?: (absolutePath: string, signal?: AbortSignal) => string | Promise<string>;
   /** Read file contents as a Buffer */
@@ -390,7 +392,9 @@ export function createEditToolDefinition(
   options?: EditToolOptions,
 ): ToolDefinition<typeof editSchema, EditToolDetails, EditRenderState> {
   const ops = options?.operations ?? defaultEditOperations;
-  const resolvePath = options?.operations ? resolveToCwd : resolveLocalPathToCwd;
+  const resolvePath =
+    options?.operations?.resolvePath ??
+    (options?.operations ? resolveToCwd : resolveLocalPathToCwd);
   return {
     name: "edit",
     label: "edit",

--- a/src/agents/sessions/tools/path-utils.test.ts
+++ b/src/agents/sessions/tools/path-utils.test.ts
@@ -4,9 +4,23 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../../test/helpers/temp-dir.js";
-import { getReadPathVariants, resolveLocalPathToCwd, resolveToCwd } from "./path-utils.js";
+import {
+  getReadPathVariants,
+  normalizeWindowsPosixDrivePath,
+  resolveLocalPathToCwd,
+  resolveToCwd,
+} from "./path-utils.js";
+import { createReadTool } from "./read.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+function toWindowsPosixDrivePath(nativePath: string, prefix: "" | "cygdrive/" | "mnt/"): string {
+  const drive = nativePath[0]?.toLowerCase();
+  if (!drive || nativePath[1] !== ":") {
+    throw new Error(`Expected a Windows drive path, got ${nativePath}`);
+  }
+  return `/${prefix}${drive}${nativePath.slice(2).replaceAll("\\", "/")}`;
+}
 
 describe("resolveToCwd", () => {
   const cwd = path.resolve("workspace");
@@ -67,4 +81,44 @@ describe("getReadPathVariants", () => {
     expect(variants.length).toBeGreaterThan(0);
     expect(new Set(variants.map((variant) => path.dirname(variant)))).toEqual(new Set([parent]));
   });
+});
+
+describe("normalizeWindowsPosixDrivePath", () => {
+  it.each([
+    ["/c/Users/Test/file.txt", "C:\\Users\\Test\\file.txt"],
+    ["/cygdrive/d/work/file.txt", "D:\\work\\file.txt"],
+    ["/mnt/e/work/file.txt", "E:\\work\\file.txt"],
+    ["/f", "F:\\"],
+  ])("maps %s to %s on native Windows", (input, expected) => {
+    expect(normalizeWindowsPosixDrivePath(input, "win32")).toBe(expected);
+  });
+
+  it.each(["/home/user/file.txt", "/tmp/file.txt", "/mnt/home/file.txt", "//server/share"])(
+    "leaves non-drive path %s unchanged",
+    (input) => {
+      expect(normalizeWindowsPosixDrivePath(input, "win32")).toBe(input);
+    },
+  );
+
+  it("leaves POSIX drive-like paths unchanged outside Windows", () => {
+    expect(normalizeWindowsPosixDrivePath("/c/work/file.txt", "linux")).toBe("/c/work/file.txt");
+  });
+});
+
+describe.runIf(process.platform === "win32")("local Windows POSIX drive paths", () => {
+  it.each(["", "cygdrive/", "mnt/"] as const)(
+    "reads an existing file through the %s form",
+    async (prefix) => {
+      const dir = tempDirs.make("openclaw-msys-read-");
+      const nativePath = path.join(dir, "fixture.txt");
+      await fs.writeFile(nativePath, "fixture", "utf8");
+      const tool = createReadTool(dir);
+
+      const result = await tool.execute("read-posix-drive", {
+        path: toWindowsPosixDrivePath(nativePath, prefix),
+      });
+
+      expect(result.content).toEqual([{ type: "text", text: "fixture" }]);
+    },
+  );
 });

--- a/src/agents/sessions/tools/path-utils.test.ts
+++ b/src/agents/sessions/tools/path-utils.test.ts
@@ -88,6 +88,9 @@ describe("normalizeWindowsPosixDrivePath", () => {
     ["/c/Users/Test/file.txt", "C:\\Users\\Test\\file.txt"],
     ["/cygdrive/d/work/file.txt", "D:\\work\\file.txt"],
     ["/mnt/e/work/file.txt", "E:\\work\\file.txt"],
+    ["@/c/Users/Test/file.txt", "C:\\Users\\Test\\file.txt"],
+    ["@/cygdrive/d/work/file.txt", "D:\\work\\file.txt"],
+    ["@/mnt/e/work/file.txt", "E:\\work\\file.txt"],
     ["/f", "F:\\"],
   ])("maps %s to %s on native Windows", (input, expected) => {
     expect(normalizeWindowsPosixDrivePath(input, "win32")).toBe(expected);
@@ -106,16 +109,23 @@ describe("normalizeWindowsPosixDrivePath", () => {
 });
 
 describe.runIf(process.platform === "win32")("local Windows POSIX drive paths", () => {
-  it.each(["", "cygdrive/", "mnt/"] as const)(
-    "reads an existing file through the %s form",
-    async (prefix) => {
+  it.each([
+    ["", ""],
+    ["", "@"],
+    ["cygdrive/", ""],
+    ["cygdrive/", "@"],
+    ["mnt/", ""],
+    ["mnt/", "@"],
+  ] as const)(
+    "reads an existing file through the %s form with %s shorthand",
+    async (prefix, at) => {
       const dir = tempDirs.make("openclaw-msys-read-");
       const nativePath = path.join(dir, "fixture.txt");
       await fs.writeFile(nativePath, "fixture", "utf8");
       const tool = createReadTool(dir);
 
       const result = await tool.execute("read-posix-drive", {
-        path: toWindowsPosixDrivePath(nativePath, prefix),
+        path: `${at}${toWindowsPosixDrivePath(nativePath, prefix)}`,
       });
 
       expect(result.content).toEqual([{ type: "text", text: "fixture" }]);

--- a/src/agents/sessions/tools/path-utils.ts
+++ b/src/agents/sessions/tools/path-utils.ts
@@ -10,7 +10,7 @@ import { preserveAtPrefixedRelativePath } from "../../path-policy.js";
 
 const UNICODE_SPACES = /[\u00A0\u2000-\u200A\u202F\u205F\u3000]/g;
 const NARROW_NO_BREAK_SPACE = "\u202F";
-const WINDOWS_POSIX_DRIVE_PATH_RE = /^\/(?:cygdrive\/|mnt\/)?([a-z])(?:\/(.*))?$/i;
+const WINDOWS_POSIX_DRIVE_PATH_RE = /^@?\/(?:cygdrive\/|mnt\/)?([a-z])(?:\/(.*))?$/i;
 function normalizeUnicodeSpaces(str: string): string {
   return str.replace(UNICODE_SPACES, " ");
 }

--- a/src/agents/sessions/tools/path-utils.ts
+++ b/src/agents/sessions/tools/path-utils.ts
@@ -10,6 +10,7 @@ import { preserveAtPrefixedRelativePath } from "../../path-policy.js";
 
 const UNICODE_SPACES = /[\u00A0\u2000-\u200A\u202F\u205F\u3000]/g;
 const NARROW_NO_BREAK_SPACE = "\u202F";
+const WINDOWS_POSIX_DRIVE_PATH_RE = /^\/(?:cygdrive\/|mnt\/)?([a-z])(?:\/(.*))?$/i;
 function normalizeUnicodeSpaces(str: string): string {
   return str.replace(UNICODE_SPACES, " ");
 }
@@ -56,9 +57,26 @@ export function resolveToCwd(filePath: string, cwd: string): string {
   return isAbsolute(expanded) ? expanded : resolvePath(cwd, expanded);
 }
 
+/** Translate common POSIX spellings of a Windows drive only for local Windows tools. */
+export function normalizeWindowsPosixDrivePath(
+  filePath: string,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  if (platform !== "win32") {
+    return filePath;
+  }
+  const match = WINDOWS_POSIX_DRIVE_PATH_RE.exec(filePath);
+  if (!match?.[1]) {
+    return filePath;
+  }
+  const root = `${match[1].toUpperCase()}:\\`;
+  return match[2] ? `${root}${match[2].replaceAll("/", "\\")}` : root;
+}
+
 /** Resolve local file paths using the filesystem that owns literal @ names. */
 export function resolveLocalPathToCwd(filePath: string, cwd: string): string {
-  return resolveToCwd(preserveAtPrefixedRelativePath(filePath, cwd), cwd);
+  const localPath = normalizeWindowsPosixDrivePath(filePath);
+  return resolveToCwd(preserveAtPrefixedRelativePath(localPath, cwd), cwd);
 }
 
 function collectReadPathVariants(filePath: string, includeNfd: boolean): string[] {

--- a/src/agents/sessions/tools/write.ts
+++ b/src/agents/sessions/tools/write.ts
@@ -77,6 +77,8 @@ const WriteToolOutputSchema = Type.Union([
  * Override these to delegate file writing to remote systems (for example SSH).
  */
 export interface WriteOperations {
+  /** Resolve a user-supplied path in this backend's path space. */
+  resolvePath?: (filePath: string, cwd: string) => string;
   /** Resolve the physical identity used to order this backend's file operations. */
   resolveQueueKey?: (absolutePath: string, signal?: AbortSignal) => string | Promise<string>;
   /** Write content to a file */
@@ -517,7 +519,9 @@ export function createWriteToolDefinition(
   options?: WriteToolOptions,
 ): ToolDefinition<typeof writeSchema, WriteToolDetails> {
   const ops = options?.operations ?? defaultWriteOperations;
-  const resolvePath = options?.operations ? resolveToCwd : resolveLocalPathToCwd;
+  const resolvePath =
+    options?.operations?.resolvePath ??
+    (options?.operations ? resolveToCwd : resolveLocalPathToCwd);
   return {
     name: "write",
     label: "write",


### PR DESCRIPTION
Closes #111620

## What Problem This Solves

Native Windows file tools treated POSIX-style drive paths emitted by Git Bash, Cygwin, and WSL as unrelated paths, so existing files could be reported as missing. Workspace-only mode also requires the path checked by containment to be the same path later opened by read, write, or edit.

## Summary

- Translate `/c/...`, `/cygdrive/c/...`, `/mnt/c/...`, and their established `@`-prefixed shorthand only in the local Windows path resolver.
- Resolve those host-owned aliases before registered workspace containment.
- Preserve raw ordinary relative, absolute, symlink, and `..` spellings through the security check.
- Forward the guard's canonical result to the local file tool only after containment succeeds.
- Give injected write/edit backends explicit ownership of their own path resolver, including edit preview.
- Leave sandbox/container paths and non-Windows local paths unchanged.

The current-main mutation queue, sandbox bridge, and memory-provenance implementations are not changed.

## Path Ownership

| Owner | Behavior |
|---|---|
| Native Windows local read/write/edit | Recognized POSIX drive spelling becomes `C:\\...` before optional workspace containment |
| Injected remote backend | Uses its supplied resolver; no forced Windows conversion |
| Sandbox/container backend | Keeps its existing POSIX path semantics |
| Non-Windows local tools | No conversion |

Ordinary `/home`, `/tmp`, `/mnt/home`, and UNC paths are not treated as Windows drive paths.

## Evidence

```text
Base:     0d2169fdabc48931e666ab227daca779fa9cba65
Head:     1a38c885d72a809448e4d59b72df7e35e0c3c433
Platform: process.platform=win32

Seven focused suites: 152 passed, 34 platform-specific skipped, 0 failed
Focused oxfmt: passed
Focused type-aware oxlint: passed
git diff --check: passed
```

The native Windows regression constructs the registered core read, write, and edit tools with `tools.fs.workspaceOnly=true`. An in-workspace drive alias succeeds through read, write, and edit; an alias targeting a real outside temporary file is rejected for all three tools, and the outside file remains unchanged. The same run covers all three `/c`, `/cygdrive/c`, and `/mnt/c` forms, their `@`-prefixed shorthand, workspace-root guard forwarding, host write/edit integrity, local path resolution, and injected edit preview/execution ownership.

Command:

```text
node C:\Users\Administrator\AppData\Local\node\corepack\v1\pnpm\12.1.0\bin\pnpm.mjs exec vitest run \
  src/agents/agent-tools.read.workspace-root-guard.test.ts \
  src/agents/agent-tools.read.windows.test.ts \
  src/agents/agent-tools.read.host-write-integrity.test.ts \
  src/agents/agent-tools.session-permissions.test.ts \
  src/agents/sessions/tools/path-utils.test.ts \
  src/agents/sessions/tools/edit.test.ts \
  src/agents/sessions/tools/write.test.ts
```

The Windows host skips the Linux-only real-symlink matrix. The fresh hosted Linux run is the final authority for that case. The exact fix retains the raw input for containment (so symlink-sensitive `..` cannot be erased before the check), then forwards `sandboxResult.resolved` after authorization so a trusted workspace alias reaches the underlying tool correctly.

## Scope

The PR is nine files, +268/-7. Production growth is limited to the local drive parser, backend resolver selection, and one optional pre-containment alias hook; +215 lines are focused test coverage. No sandbox, remote filesystem, process, queue, or provenance implementation is changed.
