### PR TITLE
fix(novita): model listing stalls when filtering Novita

### DIFF
--- a/extensions/novita/index.test.ts
+++ b/extensions/novita/index.test.ts
@@ -19,8 +19,7 @@ function requireCatalogProvider(
 
 describe("novita provider plugin", () => {
   it("declares its manifest model catalog as static", () => {
-    const discovery = "discovery" in manifest.modelCatalog ? manifest.modelCatalog.discovery : {};
-    expect(discovery.novita).toBe("static");
+    expect(manifest.modelCatalog.discovery.novita).toBe("static");
   });
 
   it("registers NovitaAI as an OpenAI-compatible provider", async () => {

--- a/extensions/novita/index.test.ts
+++ b/extensions/novita/index.test.ts
@@ -2,6 +2,7 @@
 import { registerSingleProviderPlugin } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { describe, expect, it } from "vitest";
 import plugin from "./index.js";
+import manifest from "./openclaw.plugin.json" with { type: "json" };
 
 function requireCatalogProvider(
   result:
@@ -17,6 +18,11 @@ function requireCatalogProvider(
 }
 
 describe("novita provider plugin", () => {
+  it("declares its manifest model catalog as static", () => {
+    const discovery = "discovery" in manifest.modelCatalog ? manifest.modelCatalog.discovery : {};
+    expect(discovery.novita).toBe("static");
+  });
+
   it("registers NovitaAI as an OpenAI-compatible provider", async () => {
     const provider = await registerSingleProviderPlugin(plugin);
 

--- a/extensions/novita/openclaw.plugin.json
+++ b/extensions/novita/openclaw.plugin.json
@@ -158,6 +158,9 @@
           }
         ]
       }
+    },
+    "discovery": {
+      "novita": "static"
     }
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users filtering the model catalog to Novita would see `openclaw models list --all --provider novita --json` stall instead of returning the bundled Novita models.

## Why This Change Was Made

Declare Novita's manifest-owned model catalog as static so provider-filtered listing uses the lightweight manifest path. A focused regression test protects that ownership declaration. This does not change Novita authentication, requests, model metadata, defaults, or provider routing.

## User Impact

Novita users can list the provider's six bundled models without the command falling into full runtime catalog preparation and timing out.

## Evidence

- Before on current main: `pnpm openclaw models list --all --provider novita --json` produced no model output before a 30-second deadline (exit 124). The same OpenClaw source entry under a 20-second deadline also timed out with peak RSS 606,668 KB.
- After: the same `pnpm openclaw` command exited 0 in 14.19 seconds and returned all 6 bundled Novita models; peak RSS was 369,432 KB.
- Live third-party control: `https://api.novita.ai/openai/v1/models` reported all 6 returned model IDs present with status `1`. Only a random temporary test credential was used.
- TDD: focused regression was red on main (`expected "static", received undefined`) and green after the manifest fix (2/2 passed).
- `pnpm test:extension novita` — 2/2 passed.
- `pnpm tsgo:extensions:test` — passed after the first CI head exposed and the follow-up commit removed a test-only TypeScript narrowing error.
- Local changed lane selected `extensions` and `extensionTests`; conflict-marker and max-lines checks passed. The repository's Blacksmith delegation could not start because the local Crabbox/Blacksmith binary was unavailable, so hosted execution was not claimed.
- Targeted oxfmt and `git diff --check` passed.
- `codex review --base origin/main` returned no actionable findings.
