### PR TITLE
fix(acp): /acp close leaves acpx session resumable, next message resumes the closed session

### DIFF
--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -1893,10 +1893,18 @@ describe("AcpxRuntime fresh reset wrapper", () => {
       sessionKey: "agent:codex:acp:binding:test",
     });
 
+    expect(baseStore["save"]).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        acpxRecordId: "stale",
+        closed: true,
+        acpx: expect.objectContaining({ reset_on_next_ensure: true }),
+      }),
+    );
     expect(await wrappedStore.load("agent:codex:acp:binding:test")).toBeUndefined();
-    expect(baseStore["load"]).toHaveBeenCalledTimes(1);
+    expect(baseStore["load"]).toHaveBeenCalledTimes(2);
     expect(await wrappedStore.load("agent:codex:acp:binding:test")).toBeUndefined();
-    expect(baseStore["load"]).toHaveBeenCalledTimes(1);
+    expect(baseStore["load"]).toHaveBeenCalledTimes(2);
 
     await wrappedStore.save({
       acpxRecordId: "fresh-record",
@@ -1906,7 +1914,32 @@ describe("AcpxRuntime fresh reset wrapper", () => {
     expect(await wrappedStore.load("agent:codex:acp:binding:test")).toEqual({
       acpxRecordId: "stale",
     });
-    expect(baseStore["load"]).toHaveBeenCalledTimes(2);
+    expect(baseStore["load"]).toHaveBeenCalledTimes(3);
+  });
+
+  it("keeps a discarded persistent record non-resumable after a runtime restart", async () => {
+    const records = new Map<string, Record<string, unknown>>();
+    records.set("agent:main:main", {
+      acpxRecordId: "agent:main:main",
+      acpSessionId: "sess-old",
+      acpx: {},
+    });
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async (sessionId: string) => records.get(sessionId) as never),
+      save: vi.fn(async (record: Record<string, unknown>) => {
+        records.set(String(record.acpxRecordId), record);
+      }),
+    };
+
+    const first = makeRuntime(baseStore);
+    await first.runtime.prepareFreshSession({ sessionKey: "agent:main:main" });
+
+    const second = makeRuntime(baseStore);
+    expect(await second.wrappedStore.load("agent:main:main")).toMatchObject({
+      acpSessionId: "sess-old",
+      closed: true,
+      acpx: { reset_on_next_ensure: true },
+    });
   });
 
   it("marks the session fresh after discardPersistentState close", async () => {

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -73,6 +73,7 @@ const ACPX_OPENCLAW_TOOLS_MCP_SERVER_NAME = "openclaw-tools";
 const OPENCLAW_TOOLS_MCP_AGENT_SESSION_KEY_ENV = "OPENCLAW_TOOLS_MCP_AGENT_SESSION_KEY";
 type ResetAwareSessionStore = AcpSessionStore & {
   markFresh: (sessionKey: string) => void;
+  discardPersistedRecord: (sessionKey: string) => Promise<void>;
 };
 
 type OpenClawLeaseSessionMetadata = {
@@ -372,6 +373,23 @@ function createResetAwareSessionStore(
       if (normalized) {
         freshSessionKeys.add(normalized);
       }
+    },
+    async discardPersistedRecord(sessionKey: string): Promise<void> {
+      const normalized = sessionKey.trim();
+      if (!normalized) {
+        return;
+      }
+      freshSessionKeys.add(normalized);
+      const record = await baseStore.load(normalized);
+      if (!record || readRecordResetOnNextEnsure(record)) {
+        return;
+      }
+      await baseStore.save({
+        ...record,
+        closed: true,
+        closedAt: new Date().toISOString(),
+        acpx: { ...record.acpx, reset_on_next_ensure: true },
+      });
     },
   };
 }
@@ -1835,7 +1853,7 @@ export class AcpxRuntime implements AcpRuntime {
     // Fresh reset has no ACP handle to close the delegate's upstream client.
     // Keep the scoped delegate reachable so the next ensure can replace it;
     // close() owns cache release when the session lifecycle ends.
-    this.sessionStore.markFresh(input.sessionKey);
+    await this.sessionStore.discardPersistedRecord(input.sessionKey);
   }
 
   async close(input: Parameters<AcpRuntime["close"]>[0]): Promise<void> {

--- a/src/auto-reply/reply/commands-acp.test.ts
+++ b/src/auto-reply/reply/commands-acp.test.ts
@@ -1845,6 +1845,7 @@ describe("/acp command", () => {
       sessionKey: defaultAcpSessionKey,
       reason: "manual-close",
       allowBackendUnavailable: true,
+      discardPersistentState: true,
       clearMeta: true,
     });
     expectMockCallFields(hoisted.sessionBindingUnbindMock, {

--- a/src/auto-reply/reply/commands-acp/lifecycle.ts
+++ b/src/auto-reply/reply/commands-acp/lifecycle.ts
@@ -484,6 +484,7 @@ export async function handleAcpCloseAction(
           sessionKey,
           reason: "manual-close",
           allowBackendUnavailable: true,
+          discardPersistentState: true,
           clearMeta: true,
         });
         runtimeNotice = closed.runtimeNotice ? ` (${closed.runtimeNotice})` : "";


### PR DESCRIPTION
Fixes #107487

## What Problem This Solves

`/acp close` on a persistent acpx-backed ACP session does not end the session. The SQLite `acp_sessions` row is cleared, but the acpx `FileSessionStore` record under `state/sessions/<url-encoded-sessionKey>.json` stays resumable, so the next message for that session key silently reattaches to the closed session with `session/resume` instead of opening a fresh one with `session/new`. The closed session identity also survives a gateway restart. This is the three-layer state split reported in #107487.

## Why This Change Was Made

Two defects combine to produce the report:

1. `handleAcpCloseAction` in `src/auto-reply/reply/commands-acp/lifecycle.ts` called `closeSession` with `clearMeta: true` but never `discardPersistentState: true`. Upstream acpx then runs its non-discard close, which saves the record with `closed: true` and no `reset_on_next_ensure` flag, and upstream `ensureSession` deliberately revives such records (`existing.closed = false`) and resumes them. The session-reset service (`/new`, session delete) already passes `discardPersistentState: true`; the `/acp close` command was the outlier. The fix adds the flag.
2. Even with `discardPersistentState`, when the agent does not support `session/close`, upstream acpx throws `ACP_BACKEND_UNSUPPORTED_CONTROL` from `closeBackendSession` before it sets the reset flag on the record, and the manager recovery path falls back to `prepareFreshSession`, which only added the session key to an in-process `Set` (`markFresh`). That mask dies with the gateway process, so a restart resurrected the resumable record. The fix makes the reset-aware store in `extensions/acpx/src/runtime.ts` persist upstream acpx's own closed-record contract (`closed: true` plus `acpx.reset_on_next_ensure: true`) onto the base store record during `prepareFreshSession`, in addition to the in-process mask.

Both halves were re-verified against the acpx version main currently locks, `acpx@0.13.0` (`extensions/acpx/package.json`). In the installed 0.13 runtime, `shouldReuseExistingRecord` starts with `if (record.acpx?.reset_on_next_ensure === true) return false;`, and `ensureSession` only revives a record (`existing.closed = false`) when that gate passes, so the persisted marker is exactly what makes 0.13 open a new session. The same 0.13 `close()` sets `reset_on_next_ensure` only inside the `options.discardPersistentState` branch, and only after `closeBackendSession`, which is why an agent without `session/close` never reaches it. The wrapper gate `canReuseStablePersistentSession` rejects the same flag, and the next `ensureSession` writes a brand-new record, so the flag is self-clearing. No new state files and no parallel invalidation path: the fix reuses the exact record contract the upstream close path persists on success.

Sibling `closeSession` callers were checked: the session-reset service and task-registry maintenance already pass `discardPersistentState: true` and now also become restart-durable through the `prepareFreshSession` change; the config-binding-reconfigure close (`persistent-bindings.lifecycle.ts`) intentionally omits the discard because it immediately re-initializes the same key; the spawn-failure cleanup closes a throwaway UUID key that is never re-ensured. The `prepareFreshSession` durability also covers the `SESSION_RESUME_REQUIRED` retry path, where the backend has already declared the old session unresumable.

## User Impact

`/acp close` now fully ends a persistent acpx session: the next message for that session key creates a fresh ACP session with `session/new`, with no manual deletion of `state/sessions/*.json` and no gateway restart required. The discard also survives a gateway restart, and it works for harnesses that do not support `session/close` (the close reply then carries the existing "Agent does not support session/close" notice while local state is still discarded).

## Evidence

Live before and after on identical inputs, driving the real ACP control plane and the real acpx 0.13 runtime against a real external ACP agent process. See the proof block below for the captured runtime output, and the regression and gate runs under it.

## Real behavior proof
Behavior addressed: `/acp close` on a persistent acpx session left the acpx store record resumable, so the next message for that session key reattached to the closed session with `session/resume` instead of opening a fresh one with `session/new`.
Real environment tested: real `AcpSessionManager` (`initializeSession`, `runTurn`, `closeSession`), real `/acp close` handler `handleAcpCloseAction`, real acpx extension runtime `AcpxRuntime` constructed the same way `extensions/acpx/src/service.ts` constructs it, over the real `acpx` 0.13.0 package that current main locks, real `createFileSessionStore` JSON record on disk, real SQLite ACP session metadata and session entry, and a real external ACP agent process spoken to over stdio; run on pristine main 46e6f93a86ae21b66a09f01910cb7c6b544af982 and on PR head 8a0f2f19f3c421fedd32c26b7d410e9fdb9c419c with identical inputs.
Exact steps or command run after this patch: drive `initializeSession` plus `runTurn` for `agent:fakeacp:acp:proof-session`, then `handleAcpCloseAction`, then re-ensure the same session key and prompt again, once inside one process and once across three separate OS processes sharing the same acpx session-store directory; the external agent advertises `sessionCapabilities.resume: true` and `sessionCapabilities.close: false` like the reporter's harness, and appends every JSON-RPC method it receives to a log file.
Evidence after fix:
```
# BEFORE (pristine main 46e6f93a86ae21b66a09f01910cb7c6b544af982, acpx 0.13.0)
# scenario 1, same process
close reply: Closed ACP session agent:fakeacp:acp:proof-session. Removed 0 bindings.
store record after close:        {"acp_session_id":"fake-session-001","closed":true,"acpx":{}}
store record after next message: {"acp_session_id":"fake-session-001","closed":false,"acpx":{}}
# scenario 1, agent method log
{"pid":69375,"method":"initialize"}
{"pid":69375,"method":"session/new","sessionId":"fake-session-001"}
{"pid":69375,"method":"session/prompt","sessionId":"fake-session-001"}
{"pid":69407,"method":"initialize"}
{"pid":69407,"method":"session/resume","sessionId":"fake-session-001"}   <- closed session revived
{"pid":69407,"method":"session/prompt","sessionId":"fake-session-001"}
# scenario 2, three separate OS processes over one acpx session store
store record after first turn: {"acp_session_id":"fake-session-001","closed":false,"acpx":{}}
close reply: Closed ACP session agent:fakeacp:acp:proof-session. Removed 0 bindings.
store record after close:        {"acp_session_id":"fake-session-001","closed":true,"acpx":{}}
store record after next message: {"acp_session_id":"fake-session-001","closed":false,"acpx":{}}
# scenario 2, agent method log
{"pid":69474,"method":"initialize"}
{"pid":69474,"method":"session/new","sessionId":"fake-session-001"}
{"pid":69474,"method":"session/prompt","sessionId":"fake-session-001"}
{"pid":69802,"method":"initialize"}
{"pid":69802,"method":"session/resume","sessionId":"fake-session-001"}   <- resumed after restart
{"pid":69802,"method":"session/prompt","sessionId":"fake-session-001"}

# AFTER (this patch, identical inputs, head 8a0f2f19f3c421fedd32c26b7d410e9fdb9c419c, acpx 0.13.0)
# scenario 1, same process
close reply: Closed ACP session agent:fakeacp:acp:proof-session (Agent does not support session/close for agent:fakeacp:acp:proof-session.). Removed 0 bindings.
store record after close:        {"acp_session_id":"fake-session-001","closed":true,"acpx":{"reset_on_next_ensure":true}}
store record after next message: {"acp_session_id":"fake-session-002","closed":false,"acpx":{}}
# scenario 1, agent method log
{"pid":70332,"method":"initialize"}
{"pid":70332,"method":"session/new","sessionId":"fake-session-001"}
{"pid":70332,"method":"session/prompt","sessionId":"fake-session-001"}
{"pid":70345,"method":"initialize"}
{"pid":70345,"method":"session/new","sessionId":"fake-session-002"}      <- fresh session, new id
{"pid":70345,"method":"session/prompt","sessionId":"fake-session-002"}
# scenario 2, three separate OS processes over one acpx session store
store record after first turn: {"acp_session_id":"fake-session-001","closed":false,"acpx":{}}
close reply: Closed ACP session agent:fakeacp:acp:proof-session (Agent does not support session/close for agent:fakeacp:acp:proof-session.). Removed 0 bindings.
store record after close:        {"acp_session_id":"fake-session-001","closed":true,"acpx":{"reset_on_next_ensure":true}}
store record after next message: {"acp_session_id":"fake-session-002","closed":false,"acpx":{}}
# scenario 2, agent method log
{"pid":70558,"method":"initialize"}
{"pid":70558,"method":"session/new","sessionId":"fake-session-001"}
{"pid":70558,"method":"session/prompt","sessionId":"fake-session-001"}
{"pid":70781,"method":"initialize"}
{"pid":71272,"method":"initialize"}
{"pid":71272,"method":"session/new","sessionId":"fake-session-002"}      <- fresh session after restart
{"pid":71272,"method":"session/prompt","sessionId":"fake-session-002"}
```
Observed result after fix: on pristine main the agent receives `session/resume` for the just-closed session id, both in the same process and after a restart, and the stored record flips back to `closed: false` under the same `acp_session_id`; with this patch the close writes `reset_on_next_ensure: true` onto the record and the next message opens a brand-new session id with `session/new` in both scenarios. In the restart scenario the extra bare `initialize` at pid 70781 is the close attempt itself: acpx starts the agent, sees `sessionCapabilities.close: false`, raises `ACP_BACKEND_UNSUPPORTED_CONTROL`, and the recovery path persists the reset marker instead.
What was not tested: no live vendor harness (Claude or Codex) end to end over a real chat channel; the external ACP agent in the proof is a scripted process that advertises resume support and, like the reporter's harness, does not support `session/close`. No live chat channel was used, so the close handler received a minimal command envelope. Full `pnpm build` was not run (no packaging or module-boundary changes).

### Regression and gate runs

On the rebased head, `node scripts/run-vitest.mjs extensions/acpx/src/runtime.test.ts src/auto-reply/reply/commands-acp.test.ts` passes. The touched regression assertions fail on pristine main and pass with the patch: the `/acp close` exact-argument case in `commands-acp.test.ts`, and in `extensions/acpx/src/runtime.test.ts` the persisted-reset assertions in "keeps stale persistent loads hidden until a fresh record is saved" plus "keeps a discarded persistent record non-resumable after a runtime restart".
