### PR TITLE
docs(agents): expand scoped-guide paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ Skills own workflows; root owns hard policy and routing.
 
 - Core TS: `src/`, `ui/`, `packages/`; plugins: `extensions/`; SDK: `src/plugin-sdk/*`; channels: `src/channels/*`; loader: `src/plugins/*`; protocol: `packages/gateway-protocol/*`; docs/apps: `docs/`, `apps/`.
 - Installers: sibling `../openclaw.ai`.
-- Scoped guides: `extensions/`, `src/{plugin-sdk,channels,plugins,gateway,agents}/`, `packages/`, `test/helpers*/`, `docs/`, `ui/`, `scripts/`.
+- Scoped guides: `extensions/` (plus per-plugin), `src/{plugin-sdk,channels,plugins,gateway,agents,tui}/`, `test/`, `test/helpers/`, `docs/`, `ui/`, `scripts/`, `apps/{android,ios}/`.
 
 ## Docs
 


### PR DESCRIPTION
Expands the scoped agent-guide paths in the docs. Rescued from a dev box where it was stranded (no write credential); rebased onto current main.