### PR TITLE
fix(browser): time out Google Docs page exports

### DIFF
--- a/extensions/browser/chrome-extension/modules/page-share-core.js
+++ b/extensions/browser/chrome-extension/modules/page-share-core.js
@@ -3,6 +3,8 @@ const PAGE_SHARE_MAX_CONTENT_CHARS = 120_000;
 const PAGE_SHARE_MAX_NOTE_CHARS = 2_000;
 const PAGE_SHARE_MAX_TITLE_CHARS = 500;
 const PAGE_SHARE_MAX_URL_CHARS = 2_000;
+// Export precedes relay delivery, so its deadline owns capture settlement.
+const GOOGLE_DOC_EXPORT_TIMEOUT_MS = 30_000;
 
 function googleDocIdFromUrl(url) {
   let parsed;
@@ -80,7 +82,7 @@ export async function capturePageShare(tab) {
     const [injection] = await chrome.scripting.executeScript({
       target: { tabId },
       func: fetchGoogleDocExportInTab,
-      args: [docId],
+      args: [docId, GOOGLE_DOC_EXPORT_TIMEOUT_MS],
     });
     const result = injection?.result;
     if (!result || result.error) {
@@ -226,11 +228,11 @@ function capturePageContent() {
 }
 
 /** Self-contained so the request runs in the tab with the user's Google cookies. */
-async function fetchGoogleDocExportInTab(docId) {
+async function fetchGoogleDocExportInTab(docId, timeoutMs) {
   try {
     const response = await fetch(
       `https://docs.google.com/document/d/${encodeURIComponent(docId)}/export?format=txt`,
-      { credentials: "include" },
+      { credentials: "include", signal: AbortSignal.timeout(timeoutMs) },
     );
     if (!response.ok) {
       return { error: `Google Docs export failed (${response.status}).` };

--- a/extensions/browser/chrome-extension/modules/page-share-core.test.ts
+++ b/extensions/browser/chrome-extension/modules/page-share-core.test.ts
@@ -32,8 +32,63 @@ describe("page share core", () => {
     });
     expect(executeScript.mock.calls[1]?.[0]).toMatchObject({
       target: { tabId: 17 },
-      args: ["document-id_123"],
+      args: ["document-id_123", 30_000],
     });
+  });
+
+  it.each([
+    ["response headers", false],
+    ["response body", true],
+  ] as const)("aborts a Google Docs export stalled during %s", async (_phase, headersReceived) => {
+    type ExecuteScriptDetails = {
+      args?: unknown[];
+      func: (...args: unknown[]) => unknown;
+    };
+    const executeScript = vi.fn(async (details: ExecuteScriptDetails) => {
+      if (!details.args) {
+        return [{ result: "" }];
+      }
+      const result = await details.func(details.args[0], 1);
+      return [{ result }];
+    });
+    const fetchImpl = vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
+      const signal = init?.signal;
+      if (!(signal instanceof AbortSignal)) {
+        throw new Error("Expected export timeout signal");
+      }
+      if (!headersReceived) {
+        return new Promise<Response>((_resolve, reject) => {
+          signal.addEventListener("abort", () => reject(new Error(String(signal.reason))), {
+            once: true,
+          });
+        });
+      }
+      return Promise.resolve(
+        new Response(
+          new ReadableStream({
+            start(controller) {
+              signal.addEventListener("abort", () => controller.error(signal.reason), {
+                once: true,
+              });
+            },
+          }),
+        ),
+      );
+    });
+    vi.stubGlobal("chrome", { scripting: { executeScript } });
+    vi.stubGlobal("fetch", fetchImpl);
+
+    await expect(
+      capturePageShare({
+        id: 17,
+        url: "https://docs.google.com/document/d/document-id_123/edit",
+        title: "Document",
+      }),
+    ).rejects.toThrow(/timeout|abort/i);
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://docs.google.com/document/d/document-id_123/export?format=txt",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
   });
 
   it("keeps text at the boundary and marks truncation beyond it", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users sending a Google Docs tab from the Chrome extension can leave the send workflow pending indefinitely when the authenticated Docs text-export request stalls.

## Why This Change Was Made

The export runs inside the tab to use the user's Google session. It now receives a conservative 30-second `AbortSignal.timeout` deadline, covering both response headers and body reads while preserving credentials and existing successful-response handling. The relay's existing 10-second acknowledgement timeout remains unchanged.

The deadline belongs at the export owner: capture happens before relay delivery, so the relay timeout cannot settle an export that never completes. A whole-capture timeout would also penalize unrelated page capture paths.

## User Impact

A stalled Google Docs export now fails through the existing error path within 30 seconds; the popup re-enables its send control and keyboard/context-menu shares settle through their existing rejection handling. Healthy exports are unchanged.

## Evidence

- Exact-head unit coverage exercises both a response-header stall and a 200 response whose `ReadableStream` body stalls, using one table-driven harness.
- Trusted-copy `oxfmt` with trusted main config — exact formatter output applied and re-check returned `FORMAT_OK`.
- `git diff --check HEAD^...HEAD` — passed at `a667d800e9e569612a6f69a3e8fab3943b77b50f`.
- Pre-publication autoreview against the pinned publication parent — clean, no accepted/actionable P0/P1 findings (0.96 correctness).
- Chrome extension manifest requires Chrome 125; MDN browser-compat-data records full `AbortSignal.timeout` support from Chrome 124.
- Live anonymous request to the Google Docs export endpoint returned HTTP 401 in 694 ms, confirming endpoint settlement without reading credentials.
- Exact-head secretless fork CI is green: 73 successful checks, including oxlint and repository-wide `oxfmt --check`; 36 checks were intentionally skipped, with none pending or failed. The exact-head ClawSweeper retry remains automatically scheduled after GitHub throttling. A sanitized AWS focused run was attempted first but the trusted Crabbox installation lacked broker/instance-role credentials before any checkout or code execution; no untrusted source ran locally or on Testbox.
- AI-assisted implementation (Codex).

## Real Extension-Flow Proof (Supplemental)

A fresh isolated Chrome 149.0.7827.196 run used an exact detached checkout at head `3364f3d7f0b334668a96f1fd64f33c937f259289`, loaded the unpacked MV3 extension, paired it to a local WebSocket relay, and drove the popup's real "Send page to OpenClaw" control against a public Google Docs document. Before launch, the harness required `git rev-parse HEAD` to equal that full SHA and recorded it as `proofHead`. The redacted timeline was:

- healthy export request at 6,942 ms -> relay `pageShare` at 6,947 ms with 57 content characters -> popup `Sent ✓` at 7,023 ms
- stalled export request at 7,031 ms -> popup `signal timed out` after 30,010 ms with the configured 30,000 ms deadline

The run kept its Chrome profile, runtime socket, and harness on the data disk and cleaned them afterward. Local, uncommitted artifacts: `codex-tmp/chrome-google-doc-proof/artifacts/timeline.log`, `healthy-sent.png`, and `stalled-error.png`.

Caveat: this is supplemental real-extension-flow evidence only. The document was public, the isolated harness temporarily added `https://docs.google.com/*` host permission so a regular popup tab could exercise scripting, and no existing Chrome profile or cookies were read. It is therefore not authenticated private-document proof; exact-head header/body regression coverage and CI are authoritative.

### Current-head continuity

- Current PR head: `a667d800e9e569612a6f69a3e8fab3943b77b50f`; rebase parent: `5a913fa453c2078a586b23f7d3fa6577f9d8a741`.
- The executable production change remains the one exercised by the prior Chrome proof. This refresh rebased it onto current main, added an invariant comment, and consolidated duplicated regression tests without changing runtime behavior.
- Production delta: +5/-3. Test delta: +56/-1.
