### PR TITLE
fix(zalo): prevent Bot API requests from hanging

### DIFF
--- a/extensions/zalo/src/api.test.ts
+++ b/extensions/zalo/src/api.test.ts
@@ -15,11 +15,14 @@ import {
   callZaloApi,
   deleteWebhook,
   getMe,
+  getUpdates,
   getWebhookInfo,
   sendChatAction,
+  sendMessage,
   sendPhoto,
   type ZaloFetch,
 } from "./api.js";
+import { ZALO_DEFAULT_REQUEST_TIMEOUT_MS, ZALO_SEND_PHOTO_REQUEST_TIMEOUT_MS } from "./timeouts.js";
 
 const ZALO_JSON_CAP_BYTES = 16 * 1024 * 1024;
 
@@ -41,6 +44,28 @@ function oversizedZaloJsonResponse(onCancel: () => void): Response {
     },
   });
   return response;
+}
+
+function signalAbortedZaloJsonResponse(signal: AbortSignal, onAbort: () => void): Response {
+  return new Response(
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        const abortBody = () => {
+          onAbort();
+          controller.error(new Error("zalo body aborted"));
+        };
+        if (signal.aborted) {
+          abortBody();
+          return;
+        }
+        signal.addEventListener("abort", abortBody, { once: true });
+      },
+      async pull() {
+        await new Promise<void>(() => {});
+      },
+    }),
+    { headers: { "content-type": "application/json" }, status: 200 },
+  );
 }
 
 function createOkFetcher() {
@@ -216,6 +241,44 @@ describe("Zalo API request methods", () => {
     }
   });
 
+  it("keeps the default request deadline active while reading a hanging send response body", async () => {
+    vi.useFakeTimers();
+    try {
+      let bodyAborted = false;
+      const fetcher = vi.fn<ZaloFetch>(async (_input, init) => {
+        const signal = init?.signal;
+        if (!(signal instanceof AbortSignal)) {
+          throw new Error("expected Zalo request abort signal");
+        }
+        return signalAbortedZaloJsonResponse(signal, () => {
+          bodyAborted = true;
+        });
+      });
+
+      const promise = sendMessage(
+        "test-token",
+        {
+          chat_id: "chat-123",
+          text: "hello",
+        },
+        fetcher,
+      );
+      const rejected = expect(promise).rejects.toThrow("zalo body aborted");
+
+      await vi.advanceTimersByTimeAsync(ZALO_DEFAULT_REQUEST_TIMEOUT_MS);
+
+      await rejected;
+      const [, init] = requireFirstFetchCall(fetcher, "Zalo send request");
+      if (!init?.signal) {
+        throw new Error("expected Zalo send request abort signal");
+      }
+      expect(init.signal.aborted).toBe(true);
+      expect(bodyAborted).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("caps oversized sendChatAction timeouts before scheduling the timer", async () => {
     const setTimeoutMock = vi
       .spyOn(globalThis, "setTimeout")
@@ -245,22 +308,100 @@ describe("Zalo API request methods", () => {
     }
   });
 
+  it("keeps getUpdates on the long-poll request timeout", async () => {
+    const setTimeoutMock = vi
+      .spyOn(globalThis, "setTimeout")
+      .mockReturnValue(1 as unknown as ReturnType<typeof setTimeout>);
+    const clearTimeoutMock = vi
+      .spyOn(globalThis, "clearTimeout")
+      .mockImplementation(() => undefined);
+    try {
+      const fetcher = createOkFetcher();
+
+      await getUpdates("test-token", { timeout: 45 }, fetcher);
+
+      expect(setTimeoutMock).toHaveBeenCalledWith(expect.any(Function), 50_000);
+      const [, init] = requireFirstFetchCall(fetcher, "Zalo getUpdates request");
+      expect(init?.body).toBe(JSON.stringify({ timeout: "45" }));
+    } finally {
+      setTimeoutMock.mockRestore();
+      clearTimeoutMock.mockRestore();
+    }
+  });
+
   it("validates outbound photo URLs against the SSRF guard before posting", async () => {
+    const setTimeoutMock = vi
+      .spyOn(globalThis, "setTimeout")
+      .mockReturnValue(1 as unknown as ReturnType<typeof setTimeout>);
+    const clearTimeoutMock = vi
+      .spyOn(globalThis, "clearTimeout")
+      .mockImplementation(() => undefined);
     const fetcher = createOkFetcher();
+    try {
+      await sendPhoto(
+        "test-token",
+        {
+          chat_id: "chat-123",
+          photo: "https://example.com/image.png",
+        },
+        fetcher,
+      );
 
-    await sendPhoto(
-      "test-token",
-      {
-        chat_id: "chat-123",
-        photo: "https://example.com/image.png",
-      },
-      fetcher,
-    );
+      expect(resolvePinnedHostnameWithPolicyMock).toHaveBeenCalledWith("example.com", {
+        policy: {},
+      });
+      expect(setTimeoutMock).toHaveBeenCalledWith(
+        expect.any(Function),
+        ZALO_SEND_PHOTO_REQUEST_TIMEOUT_MS,
+      );
+      expect(fetcher).toHaveBeenCalledTimes(1);
+      const [, init] = requireFirstFetchCall(fetcher, "Zalo photo request");
+      expect(init?.body).toBe(
+        JSON.stringify({
+          chat_id: "chat-123",
+          photo: "https://example.com/image.png",
+        }),
+      );
+    } finally {
+      setTimeoutMock.mockRestore();
+      clearTimeoutMock.mockRestore();
+    }
+  });
 
-    expect(resolvePinnedHostnameWithPolicyMock).toHaveBeenCalledWith("example.com", {
-      policy: {},
-    });
-    expect(fetcher).toHaveBeenCalledTimes(1);
+  it("keeps URL-only photo sends past the default and bounds the media window", async () => {
+    vi.useFakeTimers();
+    try {
+      let requestSignal: AbortSignal | undefined;
+      const fetcher = vi.fn<ZaloFetch>(
+        (_input, init) =>
+          new Promise<Response>((_resolve, reject) => {
+            requestSignal = init?.signal ?? undefined;
+            requestSignal?.addEventListener("abort", () => reject(new Error("photo aborted")), {
+              once: true,
+            });
+          }),
+      );
+
+      const promise = sendPhoto(
+        "test-token",
+        {
+          chat_id: "chat-123",
+          photo: "https://example.com/image.png",
+        },
+        fetcher,
+      );
+      await vi.advanceTimersByTimeAsync(ZALO_DEFAULT_REQUEST_TIMEOUT_MS);
+      expect(requestSignal?.aborted).toBe(false);
+
+      const rejected = expect(promise).rejects.toThrow("photo aborted");
+      await vi.advanceTimersByTimeAsync(
+        ZALO_SEND_PHOTO_REQUEST_TIMEOUT_MS - ZALO_DEFAULT_REQUEST_TIMEOUT_MS,
+      );
+      await rejected;
+      expect(requestSignal?.aborted).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("blocks private-network photo URLs before they reach the Zalo API", async () => {

--- a/extensions/zalo/src/api.ts
+++ b/extensions/zalo/src/api.ts
@@ -6,6 +6,7 @@
 import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
 import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import { resolvePinnedHostnameWithPolicy, type SsrFPolicy } from "openclaw/plugin-sdk/ssrf-runtime";
+import { ZALO_DEFAULT_REQUEST_TIMEOUT_MS, ZALO_SEND_PHOTO_REQUEST_TIMEOUT_MS } from "./timeouts.js";
 
 const ZALO_API_BASE = "https://bot-api.zaloplatforms.com";
 const ZALO_API_URL_ENV = "ZALO_API_URL";
@@ -137,12 +138,11 @@ export async function callZaloApi<T = unknown>(
 ): Promise<ZaloApiResponse<T>> {
   const url = `${resolveZaloApiUrl(options?.apiUrl)}/bot${token}/${method}`;
   const controller = new AbortController();
-  const requestTimeoutMs =
-    options?.timeoutMs === undefined ? undefined : resolveTimerTimeoutMs(options.timeoutMs, 1);
-  const timeoutId =
-    requestTimeoutMs === undefined
-      ? undefined
-      : setTimeout(() => controller.abort(), requestTimeoutMs);
+  const requestTimeoutMs = resolveTimerTimeoutMs(
+    options?.timeoutMs,
+    ZALO_DEFAULT_REQUEST_TIMEOUT_MS,
+  );
+  const timeoutId = setTimeout(() => controller.abort(), requestTimeoutMs);
   const fetcher = options?.fetch ?? fetch;
 
   try {
@@ -167,9 +167,7 @@ export async function callZaloApi<T = unknown>(
 
     return data;
   } finally {
-    if (timeoutId) {
-      clearTimeout(timeoutId);
-    }
+    clearTimeout(timeoutId);
   }
 }
 
@@ -223,7 +221,12 @@ export async function sendPhoto(
     "sendPhoto",
     token,
     { ...params, photo: parsedPhotoUrl.href },
-    { fetch: fetcher },
+    {
+      // Zalo receives a URL-only JSON body and may resolve that URL before replying.
+      // Wait through the hosted-media lifetime plus normal response-processing grace.
+      timeoutMs: ZALO_SEND_PHOTO_REQUEST_TIMEOUT_MS,
+      fetch: fetcher,
+    },
   );
 }
 

--- a/extensions/zalo/src/outbound-media.ts
+++ b/extensions/zalo/src/outbound-media.ts
@@ -13,8 +13,8 @@ import {
 import { safeEqualSecret } from "openclaw/plugin-sdk/security-runtime";
 import { resolveWebhookPath } from "openclaw/plugin-sdk/webhook-ingress";
 import { getZaloRuntime } from "./runtime.js";
+import { ZALO_OUTBOUND_MEDIA_TTL_MS } from "./timeouts.js";
 
-const ZALO_OUTBOUND_MEDIA_TTL_MS = 2 * 60_000;
 const ZALO_OUTBOUND_MEDIA_SEGMENT = "media";
 const ZALO_OUTBOUND_MEDIA_PREFIX = `/${ZALO_OUTBOUND_MEDIA_SEGMENT}/`;
 const ZALO_OUTBOUND_MEDIA_ID_RE = /^[a-f0-9]{24}$/;

--- a/extensions/zalo/src/timeouts.ts
+++ b/extensions/zalo/src/timeouts.ts
@@ -1,0 +1,7 @@
+export const ZALO_DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+export const ZALO_OUTBOUND_MEDIA_TTL_MS = 2 * 60_000;
+
+// Zalo resolves photo URLs server-side. Wait through the hosted URL lifetime,
+// then retain one ordinary request budget for provider response processing.
+export const ZALO_SEND_PHOTO_REQUEST_TIMEOUT_MS =
+  ZALO_OUTBOUND_MEDIA_TTL_MS + ZALO_DEFAULT_REQUEST_TIMEOUT_MS;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Zalo channel sends and webhook/lifecycle API calls could wait indefinitely when the Bot API stopped returning, leaving outbound delivery or startup/shutdown work stuck.

## Why This Change Was Made

Adds operation-aware deadlines at the shared Zalo Bot API boundary:

- ordinary API requests use a 30-second deadline;
- `getUpdates` keeps the requested long-poll timeout plus five seconds of transport grace;
- `sendPhoto` uses 150 seconds because Zalo receives a URL and may resolve it before replying. This combines OpenClaw's existing 120-second hosted-media URL lifetime with one ordinary 30-second response-processing budget.

The 150-second value is an OpenClaw compatibility budget, not a Zalo response SLA; Zalo's official `sendPhoto` contract publishes a URL string request but no response timing guarantee. One abort signal remains active through response-body reads.

## User Impact

Stalled Zalo Bot API requests now fail within a bounded window so channel delivery and lifecycle work can continue instead of hanging. Slow URL-based photo resolution is not cut off by the ordinary 30-second deadline, while it is still bounded at 150 seconds.

## Evidence

- `node scripts/run-vitest.mjs extensions/zalo/src/api.test.ts` - 20/20 passed. Coverage includes a stalled response-body abort, long-poll grace, URL-only photo JSON, survival past 30 seconds, and abort at 150 seconds.
- `node scripts/run-vitest.mjs extensions/zalo/src/send.test.ts` - 5/5 passed.
- `node scripts/run-vitest.mjs extensions/zalo/src/monitor.lifecycle.test.ts` - 5/5 passed.
- `./node_modules/.bin/oxfmt --check extensions/zalo/src/api.ts extensions/zalo/src/api.test.ts extensions/zalo/src/outbound-media.ts extensions/zalo/src/timeouts.ts` - passed.
- `git diff --check` - passed.
- Official API references: [getUpdates](https://docs.zaloplatforms.com/docs/BOT/apis/getUpdates), [sendMessage](https://docs.zaloplatforms.com/docs/BOT/apis/sendMessage), and [sendPhoto](https://docs.zaloplatforms.com/docs/BOT/apis/sendPhoto). The official `sendPhoto` example posts `photo` as a URL string in JSON rather than uploading media bytes.

Controlled local runtime proof at exact PR head `4c5ffd4b010d9e5678ad4b84d1559295341424a6` used native `fetch` against an ephemeral localhost HTTP server that accepted each JSON request, returned HTTP 200 JSON headers, and deliberately stalled every response body. It exercised the production `callZaloApi`, `getUpdates`, `sendPhoto`, and `readProviderJsonResponse` boundaries without a mock fetch or Zalo credentials. All three requests ran concurrently.

```bash
OPENCLAW_VITEST_INCLUDE_FILE=codex-tmp/zalo-timeout-proof/include.json \
  node scripts/run-vitest.mjs --config test/vitest/vitest.extension-zalo.config.ts \
  ../codex-tmp/zalo-timeout-proof/zalo-timeout-proof.test.ts --reporter verbose --silent false
```

```text
sendPhoto after ordinary deadline: settled=false
default: elapsedMs=30002 error=AbortError:This operation was aborted
getUpdates(timeout=1): elapsedMs=6010 error=AbortError:This operation was aborted
sendPhoto: elapsedMs=150011 error=AbortError:This operation was aborted

Test Files  1 passed (1)
Tests       1 passed (1)
```

The local `outbound-media.test.ts` attempt was blocked by this checkout's Node 22.22.0 / SQLite 3.50.4 WAL safety gate, which requires Node 22.22.3+; the failure occurs while opening the state database and is unrelated to this diff.

AI-assisted: Codex. The complete API/caller/media-hosting surface and current official Zalo Bot API contract were reviewed. An independent adversarial review found no P0-P2 issue. The optional Codex autoreview helper was attempted but could not authenticate (HTTP 401).
