### PR TITLE
fix(openrouter): keep valid video models with malformed catalog rows

### DIFF
--- a/extensions/openrouter/video-generation-provider.test.ts
+++ b/extensions/openrouter/video-generation-provider.test.ts
@@ -355,6 +355,52 @@ describe("openrouter video generation provider", () => {
     });
   });
 
+  it("keeps valid rows when OpenRouter video catalog data is mixed with malformed entries", async () => {
+    fetchWithTimeoutGuardedMock.mockResolvedValueOnce(
+      releasedJson({
+        data: [null, "malformed-row", ["nested-array"], { id: "google/veo-3.1", name: "Veo 3.1" }],
+      }),
+    );
+
+    const rows = await listOpenRouterVideoModelCatalog({
+      config: {} as never,
+      env: {},
+      resolveProviderApiKey: () => ({
+        apiKey: "k",
+        discoveryApiKey: "d",
+      }),
+      resolveProviderAuth: () => ({
+        apiKey: "k",
+        discoveryApiKey: "d",
+        mode: "api_key" as const,
+        source: "env" as const,
+      }),
+    });
+
+    expect(rows?.map((row) => row.model)).toEqual(["google/veo-3.1"]);
+  });
+
+  it("returns an empty catalog for a malformed OpenRouter video catalog envelope", async () => {
+    fetchWithTimeoutGuardedMock.mockResolvedValueOnce(releasedJson(null));
+
+    const rows = await listOpenRouterVideoModelCatalog({
+      config: {} as never,
+      env: {},
+      resolveProviderApiKey: () => ({
+        apiKey: "k",
+        discoveryApiKey: "d",
+      }),
+      resolveProviderAuth: () => ({
+        apiKey: "k",
+        discoveryApiKey: "d",
+        mode: "api_key" as const,
+        source: "env" as const,
+      }),
+    });
+
+    expect(rows).toEqual([]);
+  });
+
   it("lets configured auth replace the OpenRouter catalog default", async () => {
     fetchWithTimeoutGuardedMock.mockResolvedValueOnce(releasedJson({ data: [] }));
 

--- a/extensions/openrouter/video-model-catalog.ts
+++ b/extensions/openrouter/video-model-catalog.ts
@@ -12,6 +12,7 @@ import {
   sanitizeConfiguredModelProviderRequest,
 } from "openclaw/plugin-sdk/provider-http";
 import {
+  isRecord,
   normalizeOptionalString,
   normalizeTrimmedStringList,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -40,10 +41,6 @@ type OpenRouterVideoModel = {
   supported_frame_images?: unknown;
   supported_resolutions?: unknown;
   supported_sizes?: unknown;
-};
-
-type OpenRouterVideoModelsResponse = {
-  data?: OpenRouterVideoModel[];
 };
 
 type OpenRouterVideoModelCatalogCapabilities = VideoGenerationProviderCapabilities & {
@@ -98,6 +95,10 @@ function normalizeStringRecord(value: unknown): Record<string, string> | undefin
     }
   }
   return Object.keys(record).length > 0 ? record : undefined;
+}
+
+function isOpenRouterVideoModel(value: unknown): value is OpenRouterVideoModel {
+  return isRecord(value);
 }
 
 function buildOpenRouterVideoModeCapabilities(params: {
@@ -190,11 +191,15 @@ function buildOpenRouterVideoModelCapabilities(
 }
 
 function projectOpenRouterVideoModelsToCatalogEntries(
-  payload: OpenRouterVideoModelsResponse,
+  payload: unknown,
 ): Array<UnifiedModelCatalogEntry<OpenRouterVideoModelCatalogCapabilities>> {
   const entries: Array<UnifiedModelCatalogEntry<OpenRouterVideoModelCatalogCapabilities>> = [];
   const seen = new Set<string>();
-  for (const model of payload.data ?? []) {
+  const models = isRecord(payload) && Array.isArray(payload.data) ? payload.data : [];
+  for (const model of models) {
+    if (!isOpenRouterVideoModel(model)) {
+      continue;
+    }
     const id = normalizeOptionalString(model.id);
     if (!id || seen.has(id)) {
       continue;
@@ -266,7 +271,7 @@ async function fetchOpenRouterVideoModels(params: {
   timeoutMs: number;
   allowPrivateNetwork: boolean;
   dispatcherPolicy: OpenRouterVideoDispatcherPolicy;
-}): Promise<OpenRouterVideoModelsResponse> {
+}): Promise<unknown> {
   return await getCachedLiveCatalogValue({
     keyParts: [
       "openrouter",
@@ -287,7 +292,7 @@ async function fetchOpenRouterVideoModels(params: {
       });
       try {
         await assertOkOrThrowHttpError(response, "OpenRouter video models request failed");
-        return await readProviderJsonResponse<OpenRouterVideoModelsResponse>(
+        return await readProviderJsonResponse<unknown>(
           response,
           "OpenRouter video models request failed",
         );


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where OpenRouter video model discovery would throw a raw `TypeError` and return no catalog when an otherwise successful response contained a `null` model row. A top-level `null` success body could fail the same way before projection.

## Why This Change Was Made

The OpenRouter video catalog response is now treated as untrusted JSON at the provider boundary. The parser requires a record with a `data` array, skips `null` and other non-record rows, and continues projecting valid records. The demonstrated crash trigger is `null`; primitive and array rows are also rejected explicitly as defensive boundary handling. Request policy, caching, deduplication, and capability mapping remain unchanged.

## User Impact

OpenRouter video model discovery and per-model capability lookup continue to return healthy models when a provider response contains an isolated `null` row. A malformed top-level success body now degrades to an empty catalog instead of surfacing a raw exception.

## Evidence

- Red before the fix: `node scripts/run-vitest.mjs extensions/openrouter/video-generation-provider.test.ts` failed the mixed-row regression with `TypeError: Cannot read properties of null (reading 'id')` (`21 tests | 1 failed`).
- Green after the fix: the same focused command passes `22/22` tests, including mixed malformed rows and a malformed top-level envelope.
- `node scripts/run-oxlint.mjs --openclaw-focused-config extensions/openrouter/video-model-catalog.ts extensions/openrouter/video-generation-provider.test.ts` passes.
- `node_modules/.bin/oxfmt --check extensions/openrouter/video-model-catalog.ts extensions/openrouter/video-generation-provider.test.ts` and `git diff --check` pass.
- A no-credential live probe of the documented [`GET /api/v1/videos/models`](https://openrouter.ai/docs/api/api-reference/video-generation/list-videos-models) endpoint returned HTTP 200 with 16 rows and 16 valid IDs. This confirms the normal response shape while the regression tests prove degraded mixed/malformed success bodies.

### Production-entry before/after proof

The same temporary, untracked proof harness directly invoked the exported `listOpenRouterVideoModelCatalog` production entry through its real guarded fetch path. A loopback HTTP server returned status 200 with this mixed body:

```json
{"data":[null,"bad",[],{"id":"proof/video","name":"Proof Video"}]}
```

Command used against each exact commit:

```text
OPENROUTER_CATALOG_PROOF_PHASE=<before|after> node scripts/run-vitest.mjs extensions/openrouter/video-catalog-production-proof.test.ts --reporter=verbose --silent=false
```

- Exact parent before fix: [`25d6f13a1ff864e241d28f4540494ecba43a6421`](https://github.com/openclaw/openclaw/commit/25d6f13a1ff864e241d28f4540494ecba43a6421)

```text
OPENROUTER_CATALOG_PROOF={"phase":"before","httpStatus":200,"error":"TypeError: Cannot read properties of null (reading 'id')"}
Test Files  1 passed (1)
Tests  1 passed (1)
```

- Exact current head after fix: [`ea93400df4a1afe165e1c84e82d0aa4f79cbfb3c`](https://github.com/openclaw/openclaw/commit/ea93400df4a1afe165e1c84e82d0aa4f79cbfb3c)

```text
OPENROUTER_CATALOG_PROOF={"phase":"after","httpStatus":200,"models":["proof/video"]}
Test Files  1 passed (1)
Tests  1 passed (1)
```

The harness was removed after both runs and did not alter the PR product diff.

### CI status

- `openclaw/ci-gate` and the executed repository checks are green on exact head `ea93400df4a1afe165e1c84e82d0aa4f79cbfb3c`.
- The sole red check is external tooling: [OpenGrep - PR Diff](https://github.com/openclaw/openclaw/actions/runs/29716236515/job/88269972538) failed in `Install opengrep` with `Error: Failed to fetch available versions from GitHub.` The verification, scan, and SARIF steps were skipped, so this is not an OpenGrep code finding.

AI-assisted.

### Current-head proof continuity (immutable source equivalence, 2026-07-27)

- Current PR head: `809508f779a23e0848aabd518d08fd323ee0ad71`.
- Previously proven production-entry head: `ea93400df4a1afe165e1c84e82d0aa4f79cbfb3c`.
- The current PR diff contains 2 changed files. Git object comparison reports identical blob IDs for both files at the proven and current heads (2/2 identical).
- Current-head repository checks are complete with zero failures and zero pending checks.
- The existing guarded-fetch production-entry proof therefore transfers without a changed product or test blob. This is immutable source-equivalence proof, not a claim of a new runtime execution. `PROOF_RESULT=PASS`.