### PR TITLE
fix(release): release validation fails fast on stalled refs

### DIFF
--- a/scripts/github/resolve-openclaw-ref.sh
+++ b/scripts/github/resolve-openclaw-ref.sh
@@ -6,6 +6,12 @@ REF=""
 EXPECTED_SHA=""
 FALLBACK_OK=0
 GITHUB_OUTPUT_FILE="${GITHUB_OUTPUT:-}"
+GIT_LS_REMOTE_TIMEOUT_SECONDS=120
+GIT_HTTP_LOW_SPEED_LIMIT=1
+GIT_HTTP_LOW_SPEED_TIME=30
+# Bash's integer SECONDS needs a one-second guard so the shared wall-clock
+# budget cannot be exceeded by rounding at the start of a lookup.
+GIT_LS_REMOTE_DEADLINE_SECONDS=0
 
 usage() {
   cat >&2 <<'EOF'
@@ -68,6 +74,30 @@ lower_sha() {
   printf '%s' "$1" | tr '[:upper:]' '[:lower:]'
 }
 
+# Release jobs provide GNU timeout; gtimeout keeps the helper usable with Homebrew coreutils.
+# Git's low-speed guard still protects HTTP transfers when neither command is installed.
+run_git_ls_remote() {
+  local refspec="$1"
+  local timeout_seconds="$2"
+  if command -v timeout >/dev/null 2>&1; then
+    GIT_HTTP_LOW_SPEED_LIMIT="$GIT_HTTP_LOW_SPEED_LIMIT" \
+      GIT_HTTP_LOW_SPEED_TIME="$GIT_HTTP_LOW_SPEED_TIME" \
+      timeout --signal=TERM --kill-after=5s "${timeout_seconds}s" \
+      git ls-remote "$REMOTE_URL" "$refspec"
+  elif command -v gtimeout >/dev/null 2>&1; then
+    GIT_HTTP_LOW_SPEED_LIMIT="$GIT_HTTP_LOW_SPEED_LIMIT" \
+      GIT_HTTP_LOW_SPEED_TIME="$GIT_HTTP_LOW_SPEED_TIME" \
+      gtimeout --signal=TERM --kill-after=5s "${timeout_seconds}s" \
+      git ls-remote "$REMOTE_URL" "$refspec"
+  else
+    # Release runners have GNU timeout; this keeps local/macOS HTTP lookups
+    # protected by Git's documented low-speed guard when coreutils is absent.
+    GIT_HTTP_LOW_SPEED_LIMIT="$GIT_HTTP_LOW_SPEED_LIMIT" \
+      GIT_HTTP_LOW_SPEED_TIME="$GIT_HTTP_LOW_SPEED_TIME" \
+      git ls-remote "$REMOTE_URL" "$refspec"
+  fi
+}
+
 resolve_unique_remote_ref() {
   local refspec
   for refspec in "$@"; do
@@ -75,15 +105,31 @@ resolve_unique_remote_ref() {
     local raw=""
     local stderr_file=""
     local status=0
+    local remaining_seconds=$((GIT_LS_REMOTE_DEADLINE_SECONDS - SECONDS))
+    if (( remaining_seconds < 1 )); then
+      printf 'git ls-remote timed out within the %ss resolver budget for %s\n' \
+        "$GIT_LS_REMOTE_TIMEOUT_SECONDS" "$REMOTE_URL" >&2
+      return 124
+    fi
     stderr_file="$(mktemp)"
     set +e
-    raw="$(git ls-remote "$REMOTE_URL" "$refspec" 2>"$stderr_file")"
+    raw="$(run_git_ls_remote "$refspec" "$remaining_seconds" 2>"$stderr_file")"
     status="$?"
     set -e
+    if (( SECONDS >= GIT_LS_REMOTE_DEADLINE_SECONDS )); then
+      rm -f "$stderr_file"
+      printf 'git ls-remote timed out within the %ss resolver budget for %s\n' \
+        "$GIT_LS_REMOTE_TIMEOUT_SECONDS" "$REMOTE_URL" >&2
+      return 124
+    fi
     if [[ "$status" -ne 0 ]]; then
       local stderr=""
       stderr="$(cat "$stderr_file")"
       rm -f "$stderr_file"
+      if [[ "$status" -eq 124 || "$status" -eq 137 ]]; then
+        printf 'git ls-remote timed out within the %ss resolver budget for %s\n' \
+          "$GIT_LS_REMOTE_TIMEOUT_SECONDS" "$REMOTE_URL" >&2
+      fi
       if [[ "$refspec" == *"^{}" && "$stderr" == *"fatal: no tag message?"* ]]; then
         continue
       fi
@@ -161,6 +207,8 @@ if [[ "$REF" =~ ^[0-9a-fA-F]{40}$ ]]; then
   write_output fallback true
   exit 0
 fi
+
+GIT_LS_REMOTE_DEADLINE_SECONDS=$((SECONDS + GIT_LS_REMOTE_TIMEOUT_SECONDS - 1))
 
 declare -a matches=()
 if [[ "$REF" == refs/heads/* ]]; then

--- a/test/scripts/resolve-openclaw-ref.test.ts
+++ b/test/scripts/resolve-openclaw-ref.test.ts
@@ -1,10 +1,12 @@
 // Resolve OpenClaw ref tests cover the release workflow ref resolver script.
 import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, symlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createTempDirTracker } from "../helpers/temp-dir.js";
 
 const SCRIPT_PATH = "scripts/github/resolve-openclaw-ref.sh";
+const BASH_PATH = "/bin/bash";
 const tempDirs = createTempDirTracker();
 let remoteRepo: string;
 let remoteSha: string;
@@ -41,16 +43,27 @@ beforeAll(() => {
   ({ repo: remoteRepo, sha: remoteSha } = createRemoteRepo());
 });
 
-function runResolver(remote: string, args: string[]) {
-  return spawnSync("bash", [SCRIPT_PATH, ...args], {
+function runResolver(remote: string, args: string[], envOverrides: Record<string, string> = {}) {
+  return spawnSync(BASH_PATH, [SCRIPT_PATH, ...args], {
     cwd: process.cwd(),
     encoding: "utf8",
     env: {
       ...process.env,
       GITHUB_OUTPUT: "",
       OPENCLAW_REF_REMOTE: remote,
+      ...envOverrides,
     },
   });
+}
+
+function exposeCommandsWithoutTimeout(toolDir: string): void {
+  for (const command of ["awk", "cat", "mktemp", "rm", "tr"]) {
+    const candidate = [`/usr/bin/${command}`, `/bin/${command}`].find((path) => existsSync(path));
+    if (!candidate) {
+      throw new Error(`Could not find ${command} for fallback test`);
+    }
+    symlinkSync(candidate, join(toolDir, command));
+  }
 }
 
 function parseOutput(output: string): Record<string, string> {
@@ -73,6 +86,169 @@ function expectSuccessfulOutput(result: ReturnType<typeof runResolver>): Record<
 }
 
 describe("scripts/github/resolve-openclaw-ref.sh", () => {
+  it("bounds remote lookups and preserves the resolved ref contract", () => {
+    const toolDir = tempDirs.make("openclaw-ref-tools-");
+    const timeoutLog = join(toolDir, "timeout.log");
+    const gitLog = join(toolDir, "git.log");
+    const gitPath = join(toolDir, "git");
+    const timeoutPath = join(toolDir, "timeout");
+    mkdirSync(toolDir, { recursive: true });
+    writeFileSync(
+      gitPath,
+      `#!/bin/sh
+printf 'args=%s limit=%s time=%s\\n' "$*" "$GIT_HTTP_LOW_SPEED_LIMIT" "$GIT_HTTP_LOW_SPEED_TIME" >> "$OPENCLAW_TEST_GIT_LOG"
+if [ "\${3:-}" = "refs/heads/main" ]; then
+  printf '%s refs/heads/main\\n' '${"a".repeat(40)}'
+fi
+`,
+      { mode: 0o755 },
+    );
+    writeFileSync(
+      timeoutPath,
+      `#!/bin/sh
+printf '%s\\n' "$*" >> "$OPENCLAW_TEST_TIMEOUT_LOG"
+if [ "\${OPENCLAW_TEST_TIMEOUT_FAIL:-}" = "1" ]; then
+  exit 124
+fi
+while [ "\${1:-}" = "--signal=TERM" ] || [ "\${1:-}" = "--kill-after=5s" ]; do
+  shift
+done
+shift
+exec "$@"
+`,
+      { mode: 0o755 },
+    );
+
+    const result = runResolver("https://example.invalid/openclaw.git", ["--ref", "main"], {
+      PATH: `${toolDir}:${process.env.PATH ?? ""}`,
+      OPENCLAW_TEST_GIT_LOG: gitLog,
+      OPENCLAW_TEST_TIMEOUT_LOG: timeoutLog,
+    });
+
+    expect(expectSuccessfulOutput(result)).toEqual({
+      fallback: "false",
+      fast: "true",
+      ref_kind: "branch",
+      sha: "a".repeat(40),
+    });
+    const timeoutSeconds = Number(
+      /--kill-after=5s (\d+)s\b/u.exec(readFileSync(timeoutLog, "utf8"))?.[1],
+    );
+    expect(timeoutSeconds).toBeGreaterThan(0);
+    expect(timeoutSeconds).toBeLessThanOrEqual(119);
+    expect(readFileSync(gitLog, "utf8")).toContain(
+      `args=ls-remote https://example.invalid/openclaw.git refs/heads/main limit=1 time=30`,
+    );
+  });
+
+  it("reports a remote lookup timeout without changing the exit contract", () => {
+    const toolDir = tempDirs.make("openclaw-ref-timeout-tools-");
+    const timeoutPath = join(toolDir, "timeout");
+    mkdirSync(toolDir, { recursive: true });
+    writeFileSync(
+      timeoutPath,
+      `#!/bin/sh
+exit 124
+`,
+      { mode: 0o755 },
+    );
+
+    const result = runResolver("https://example.invalid/openclaw.git", ["--ref", "main"], {
+      PATH: `${toolDir}:${process.env.PATH ?? ""}`,
+      OPENCLAW_TEST_TIMEOUT_FAIL: "1",
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("git ls-remote timed out within the 120s resolver budget");
+  });
+
+  it("keeps Git low-speed guards when GNU timeout is unavailable", () => {
+    const toolDir = tempDirs.make("openclaw-ref-no-timeout-tools-");
+    const gitLog = join(toolDir, "git.log");
+    const gitPath = join(toolDir, "git");
+    mkdirSync(toolDir, { recursive: true });
+    exposeCommandsWithoutTimeout(toolDir);
+    writeFileSync(
+      gitPath,
+      `#!/bin/sh
+printf 'args=%s limit=%s time=%s\\n' "$*" "$GIT_HTTP_LOW_SPEED_LIMIT" "$GIT_HTTP_LOW_SPEED_TIME" >> "$OPENCLAW_TEST_GIT_LOG"
+if [ "\${3:-}" = "refs/heads/main" ]; then
+  printf '%s refs/heads/main\\n' '${"b".repeat(40)}'
+fi
+`,
+      { mode: 0o755 },
+    );
+
+    const result = runResolver("https://example.invalid/openclaw.git", ["--ref", "main"], {
+      PATH: toolDir,
+      OPENCLAW_TEST_GIT_LOG: gitLog,
+    });
+
+    expect(expectSuccessfulOutput(result)).toEqual({
+      fallback: "false",
+      fast: "true",
+      ref_kind: "branch",
+      sha: "b".repeat(40),
+    });
+    expect(readFileSync(gitLog, "utf8")).toContain(
+      `args=ls-remote https://example.invalid/openclaw.git refs/heads/main limit=1 time=30`,
+    );
+  });
+
+  it("shares the resolver deadline across multiple remote refspecs", () => {
+    const toolDir = tempDirs.make("openclaw-ref-shared-deadline-tools-");
+    const timeoutLog = join(toolDir, "timeout.log");
+    const countPath = join(toolDir, "timeout.count");
+    const gitPath = join(toolDir, "git");
+    const timeoutPath = join(toolDir, "timeout");
+    mkdirSync(toolDir, { recursive: true });
+    writeFileSync(countPath, "0");
+    writeFileSync(
+      gitPath,
+      `#!/bin/sh
+exit 0
+`,
+      { mode: 0o755 },
+    );
+    writeFileSync(
+      timeoutPath,
+      `#!/bin/sh
+count=$(cat "$OPENCLAW_TEST_TIMEOUT_COUNT")
+count=$((count + 1))
+printf '%s\\n' "$*" >> "$OPENCLAW_TEST_TIMEOUT_LOG"
+printf '%s' "$count" > "$OPENCLAW_TEST_TIMEOUT_COUNT"
+if [ "$count" -eq 1 ]; then
+  /bin/sleep 2
+fi
+while [ "\${1:-}" = "--signal=TERM" ] || [ "\${1:-}" = "--kill-after=5s" ]; do
+  shift
+done
+shift
+exec "$@"
+`,
+      { mode: 0o755 },
+    );
+
+    const result = runResolver(
+      "https://example.invalid/openclaw.git",
+      ["--ref", "refs/tags/missing"],
+      {
+        PATH: `${toolDir}:${process.env.PATH ?? ""}`,
+        OPENCLAW_TEST_TIMEOUT_LOG: timeoutLog,
+        OPENCLAW_TEST_TIMEOUT_COUNT: countPath,
+      },
+    );
+
+    expect(result.status).toBe(1);
+    const durations = readFileSync(timeoutLog, "utf8")
+      .trim()
+      .split("\n")
+      .map((line) => Number(/--kill-after=5s (\d+)s\b/u.exec(line)?.[1]));
+    expect(durations).toHaveLength(2);
+    expect(durations[0]).toBeGreaterThan(durations[1]);
+  });
+
   it("resolves branch and tag refs with git ls-remote", () => {
     expect(expectSuccessfulOutput(runResolver(remoteRepo, ["--ref", "release/test"]))).toEqual({
       fallback: "false",


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where release-validation workflows could remain stuck indefinitely when `git ls-remote` stalled while resolving a branch or tag target ref, delaying release checks and consuming a runner.

## Why This Change Was Made

The resolver now applies one shared 120-second budget across every remote ref probe, with GNU `timeout` on the Ubuntu 24.04 release runners, Git's documented HTTP low-speed guard, and explicit timeout diagnostics. Full-SHA fast paths, ambiguity handling, and caller fallback semantics are unchanged. Environments without GNU `timeout` or `gtimeout` retain the Git low-speed guard only; they do not receive a hard wall-clock deadline.

## User Impact

Release operators receive a bounded, actionable failure instead of an indefinitely hanging target-resolution job. Healthy branch and tag resolution behaves as before. The supported release workflows use the hard deadline; local or macOS fallback environments still avoid stalled low-throughput HTTP transfers but may not bound DNS/TCP connection hangs.

## Evidence

- Base: `503b21dc6bfdea5e385ba3f85e81691cfc2a23c1`
- `node scripts/run-vitest.mjs test/scripts/resolve-openclaw-ref.test.ts` (9/9)
- `node scripts/run-vitest.mjs test/scripts/test-projects.test.ts` (221/221)
- `bash -n scripts/github/resolve-openclaw-ref.sh`
- `pnpm format:check --no-error-on-unmatched-pattern -- scripts/github/resolve-openclaw-ref.sh test/scripts/resolve-openclaw-ref.test.ts`
- `git diff --check`
- Git HTTP low-speed contract: https://git-scm.com/docs/git-config#Documentation/git-config.txt-httplowSpeedLimit

AI-assisted: Codex
