### PR TITLE
fix(ui): keep completed work expanded outside dashboard sessions

### DIFF
--- a/ui/src/pages/chat/chat-thread.test.ts
+++ b/ui/src/pages/chat/chat-thread.test.ts
@@ -88,6 +88,7 @@ function messageRecord(group: MessageGroup, index = 0): Record<string, unknown> 
 describe("collapseCompletedTurnWork", () => {
   const collapsedItems = (props: Partial<CachedChatItemsProps>, runWorking = false) =>
     collapseCompletedTurnWork(coalesceStreamRuns(buildCachedChatItems(createProps(props))), {
+      sessionKey: "agent:main:dashboard:test-session",
       runWorking,
     });
 
@@ -122,6 +123,31 @@ describe("collapseCompletedTurnWork", () => {
     expect(work.durationMs).toBe(9_000);
     expect(work.hasError).toBe(false);
     expect(requireGroup(items[2]).role).toBe("assistant");
+  });
+
+  it.each([
+    "agent:main:main",
+    "agent:main:telegram:direct:42",
+    "agent:main::dashboard:malformed",
+    "agent:main:dashboard:session:extra",
+  ])("keeps completed work expanded for non-dashboard session %s", (sessionKey) => {
+    const items = coalesceStreamRuns(
+      buildCachedChatItems(
+        createProps({
+          sessionKey,
+          messages: [
+            { role: "user", content: "do it", timestamp: 1_000 },
+            { role: "assistant", content: "Checking…", timestamp: 2_000 },
+            toolResult("call-1", 3_000),
+            { role: "assistant", content: "All done.", timestamp: 10_000 },
+          ],
+        }),
+      ),
+    );
+
+    const rendered = collapseCompletedTurnWork(items, { sessionKey, runWorking: false });
+
+    expect(rendered.map((item) => item.kind)).toEqual(["group", "group", "group", "group"]);
   });
 
   it("keeps the trailing turn expanded while the run works", () => {
@@ -251,7 +277,11 @@ describe("collapseCompletedTurnWork", () => {
           }),
         ),
       ),
-      { runWorking: false, searchActive: true },
+      {
+        sessionKey: "agent:main:dashboard:test-session",
+        runWorking: false,
+        searchActive: true,
+      },
     );
 
     expect(items.some((item) => item.kind === "work-group")).toBe(false);

--- a/ui/src/pages/chat/chat-thread.ts
+++ b/ui/src/pages/chat/chat-thread.ts
@@ -1905,11 +1905,20 @@ function workGroupHasError(groups: MessageGroup[]): boolean {
  */
 export function collapseCompletedTurnWork(
   items: TurnRenderItem[],
-  opts: { runWorking: boolean; searchActive?: boolean },
+  opts: { sessionKey: string; runWorking: boolean; searchActive?: boolean },
 ): Array<TurnRenderItem | WorkGroupRenderItem> {
-  // Chat search filters the thread to matching messages; folding a match into
-  // a collapsed rollup would hide the very row the query found.
-  if (opts.searchActive) {
+  const [scope, agentId, kind, sessionId, ...extraParts] = normalizeLowercaseStringOrEmpty(
+    opts.sessionKey,
+  ).split(":");
+  const isDashboardSession =
+    scope === "agent" &&
+    Boolean(agentId) &&
+    kind === "dashboard" &&
+    Boolean(sessionId) &&
+    extraParts.length === 0;
+  // Channel sessions can also be opened in the Control UI, but their full
+  // transcript remains the canonical presentation on message surfaces.
+  if (!isDashboardSession || opts.searchActive) {
     return items;
   }
   const turns: TurnRenderItem[][] = [];

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -1233,6 +1233,7 @@ function renderChatThreadContents(
     return nothing;
   });
   const collapsedItems = collapseCompletedTurnWork(coalesceStreamRuns(chatItems), {
+    sessionKey: props.sessionKey,
     runWorking: Boolean(props.runWorking),
     searchActive: state.searchOpen && Boolean(state.searchQuery.trim()),
   });


### PR DESCRIPTION
Follow-up to https://github.com/openclaw/openclaw/pull/105012; preserves the visibility invariant from https://github.com/openclaw/openclaw/pull/106791; related but distinct from https://github.com/openclaw/openclaw/pull/111540.

## What Problem This Solves

Fixes an issue where users opening channel-backed or main sessions in the Control UI lose intermediate assistant and tool answers behind a dashboard-style “Worked for” rollup, even though those message-channel transcripts must remain complete and steering can produce multiple meaningful outputs.

## Why This Change Was Made

Collapse only exact canonical dashboard-created keys, `agent:<agentId>:dashboard:<sessionId>`, and keep main, channel, malformed, and extended keys expanded. There is no prompt, protocol, or persistence change. This change was developed with AI assistance and maintainer review.

## User Impact

Dashboard sessions retain their final-output-first rollup; all other sessions retain every answer and tool row.

## Evidence

- Commit/rebase proof: local `HEAD` and `origin/steipete/jovial-meitner-cb4027` both resolve to `af22da8ba9c8b526b68ced195852c6e5602330db`.
- `node scripts/run-vitest.mjs ui/src/pages/chat/chat-thread.test.ts` — 124/124 passed.
- Full path-scoped `scripts/check-changed.mjs` passed formatting, i18n, core-test and UI typechecks, plus lint and guards.
- `git diff --check` passed.
- Fresh autoreview completed cleanly.

### Live Control UI proof

Direct Crabbox Hetzner run portal: https://crabbox.openclaw.ai/portal/runs/run_948f52881e36

Exact head: `af22da8ba9c8b526b68ced195852c6e5602330db`.

The same synthetic five-message completed transcript was injected through the existing Control UI mock Gateway and rendered in real windowed Chromium.

![Dashboard session renders the rollup without intermediate rows](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/e65511c45cc8408d7ccef6584ea9b54f0db898be/pr-111640-worked-for-session-scope/dashboard-rollup.png)

Observation: canonical `agent:main:dashboard:pr-111640` shows `Worked for 5s`; intermediate `I will inspect the sample.` and `Read sample.txt` rows are absent.

![Main session retains intermediate assistant and tool rows](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/e65511c45cc8408d7ccef6584ea9b54f0db898be/pr-111640-worked-for-session-scope/main-expanded.png)

Observation: `agent:main:main` shows the same intermediate assistant/tool rows and no `Worked for` rollup.

[Evidence manifest](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/e65511c45cc8408d7ccef6584ea9b54f0db898be/pr-111640-worked-for-session-scope/mantis-evidence.json).

Both 1234x640 element-only screenshots were visually inspected and contain only synthetic generic content; no secrets or private session data.
