### PR TITLE
fix(ui): prevent chat jump when the working claw appears

### DIFF
--- a/ui/src/e2e/chat-flow.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.e2e.test.ts
@@ -2229,7 +2229,7 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
     },
   );
 
-  it("replaces the pending reading indicator with the streamed response", async () => {
+  it("keeps the pending working row stable through acknowledgement and streaming", async () => {
     const context = await newBrowserContext({
       locale: "en-US",
       serviceWorkers: "block",
@@ -2256,13 +2256,97 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
       const runId = requireString(params.idempotencyKey, "chat send idempotency key");
 
       await page.locator(".chat-thread").getByText(prompt).waitFor({ timeout: 10_000 });
-      await page.locator(".chat-reading-indicator").waitFor({ timeout: 10_000 });
+      const indicator = page.locator(".chat-reading-indicator");
+      await indicator.waitFor({ timeout: 10_000 });
       expect(await page.locator(".chat-queue").count()).toBe(0);
+      await page.locator(".chat-working-indicator").evaluate(async (element) => {
+        await Promise.all(element.getAnimations().map((animation) => animation.finished));
+      });
+      const pendingRow = await indicator
+        .locator(
+          "xpath=ancestor::*[contains(concat(' ', normalize-space(@class), ' '), ' chat-virtual-row ')][1]",
+        )
+        .elementHandle();
+      if (!pendingRow) {
+        throw new Error("expected pending working indicator virtual row");
+      }
+      const pendingLayout = await pendingRow.evaluate((row) => {
+        const rect = row.getBoundingClientRect();
+        Reflect.set(window, "__openclawPendingWorkingRow", row);
+        return {
+          height: rect.height,
+          key: row.getAttribute("data-virtual-row-key"),
+          top: rect.top,
+        };
+      });
+      expect(pendingLayout.key).not.toBeNull();
+      await page.evaluate(() => {
+        const samples: Array<{
+          height: number | null;
+          key: string | null;
+          sameRow: boolean;
+          top: number | null;
+        }> = [];
+        Reflect.set(window, "__openclawWorkingRowSamples", samples);
+        let remaining = 20;
+        const sample = () => {
+          const originalRow = Reflect.get(window, "__openclawPendingWorkingRow");
+          const currentRow = document
+            .querySelector(".chat-reading-indicator")
+            ?.closest<HTMLElement>(".chat-virtual-row");
+          const rect = currentRow?.getBoundingClientRect();
+          samples.push({
+            height: rect?.height ?? null,
+            key: currentRow?.getAttribute("data-virtual-row-key") ?? null,
+            sameRow: currentRow === originalRow,
+            top: rect?.top ?? null,
+          });
+          remaining -= 1;
+          if (remaining > 0) {
+            requestAnimationFrame(sample);
+          }
+        };
+        sample();
+      });
 
       await gateway.resolveDeferred("chat.send", { runId, status: "started" });
 
       await page.locator(".chat-thread").getByText(prompt).waitFor({ timeout: 10_000 });
-      await page.locator(".chat-reading-indicator").waitFor({ timeout: 10_000 });
+      await indicator.waitFor({ timeout: 10_000 });
+      const samples = await page.evaluate(
+        () =>
+          new Promise<
+            Array<{
+              height: number | null;
+              key: string | null;
+              sameRow: boolean;
+              top: number | null;
+            }>
+          >((resolve) => {
+            const read = () => {
+              const current = Reflect.get(window, "__openclawWorkingRowSamples");
+              if (Array.isArray(current) && current.length >= 20) {
+                resolve(current);
+                return;
+              }
+              requestAnimationFrame(read);
+            };
+            read();
+          }),
+      );
+      const layouts = samples.filter(
+        (sample): sample is { height: number; key: string; sameRow: true; top: number } =>
+          sample.sameRow &&
+          typeof sample.height === "number" &&
+          typeof sample.key === "string" &&
+          typeof sample.top === "number",
+      );
+      expect(layouts).toHaveLength(20);
+      expect(new Set(layouts.map((sample) => sample.key))).toEqual(new Set([pendingLayout.key]));
+      const tops = layouts.map((sample) => sample.top);
+      const heights = layouts.map((sample) => sample.height);
+      expect(Math.max(...tops) - Math.min(...tops)).toBeLessThan(1);
+      expect(Math.max(...heights) - Math.min(...heights)).toBeLessThan(1);
 
       const response = "The streamed response is now visible.";
       await gateway.emitGatewayEvent("chat", {
@@ -2279,6 +2363,19 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
 
       await page.getByText(response).waitFor({ timeout: 10_000 });
       await page.locator(".chat-reading-indicator").waitFor({ state: "detached", timeout: 10_000 });
+      const streamingLayout = await pendingRow.evaluate(
+        (row, visibleResponse) => ({
+          connected: row.isConnected,
+          hasResponse: row.textContent?.includes(visibleResponse) === true,
+          key: row.getAttribute("data-virtual-row-key"),
+        }),
+        response,
+      );
+      expect(streamingLayout).toEqual({
+        connected: true,
+        hasResponse: true,
+        key: pendingLayout.key,
+      });
     } finally {
       await closeBrowserContext(context);
     }

--- a/ui/src/e2e/chat-flow.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.e2e.test.ts
@@ -2366,7 +2366,7 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
       const streamingLayout = await pendingRow.evaluate(
         (row, visibleResponse) => ({
           connected: row.isConnected,
-          hasResponse: row.textContent?.includes(visibleResponse) === true,
+          hasResponse: row.textContent?.includes(visibleResponse) ?? false,
           key: row.getAttribute("data-virtual-row-key"),
         }),
         response,

--- a/ui/src/pages/chat/chat-progress.ts
+++ b/ui/src/pages/chat/chat-progress.ts
@@ -2,7 +2,17 @@ import { t } from "../../i18n/index.ts";
 import type { ChatItem, ChatQueueItem } from "../../lib/chat/chat-types.ts";
 import { formatCompactTokenCount } from "../../lib/format.ts";
 
-const workingStartBySession = new Map<string, { runId: string | null; startedAt: number }>();
+type WorkingProgress = {
+  key: string;
+  startedAt: number;
+};
+
+type WorkingProgressCache = WorkingProgress & {
+  runId: string | null;
+};
+
+const workingProgressBySession = new Map<string, WorkingProgressCache>();
+let anonymousWorkingProgressId = 0;
 
 export function buildCompactionDividerItem(
   marker: Record<string, unknown>,
@@ -50,14 +60,14 @@ export function shouldRenderQueuedSendInThread(item: ChatQueueItem): boolean {
   );
 }
 
-export function resolveWorkingStartedAt(
+export function resolveWorkingProgress(
   sessionKey: string,
   runId: string | null,
   streamStartedAt: number | null,
   queue: ChatQueueItem[],
   streamSegments: Array<{ ts: number }>,
   toolMessages: unknown[],
-): number {
+): WorkingProgress {
   const queuedRunId =
     queue.find((item) => item.sendState === "sending" && shouldRenderQueuedSendInThread(item))
       ?.sendRunId ?? queue.find(shouldRenderQueuedSendInThread)?.sendRunId;
@@ -67,13 +77,11 @@ export function resolveWorkingStartedAt(
       (candidate): candidate is string => typeof candidate === "string" && candidate.length > 0,
     );
   const explicitRunId = queuedRunId ?? runId ?? toolRunId;
-  const cached = workingStartBySession.get(sessionKey);
-  const cachedStartedAt =
-    cached && (!explicitRunId || !cached.runId || cached.runId === explicitRunId)
-      ? cached.startedAt
-      : null;
+  const cached = workingProgressBySession.get(sessionKey);
+  const compatibleCached =
+    cached && (!explicitRunId || !cached.runId || cached.runId === explicitRunId) ? cached : null;
   const candidates = [
-    cachedStartedAt,
+    compatibleCached?.startedAt,
     streamStartedAt,
     ...queue
       .filter(shouldRenderQueuedSendInThread)
@@ -88,17 +96,25 @@ export function resolveWorkingStartedAt(
     }),
   ].filter((value): value is number => typeof value === "number" && Number.isFinite(value));
   const startedAt = candidates.length > 0 ? Math.min(...candidates) : Date.now();
-  workingStartBySession.set(sessionKey, {
-    runId: explicitRunId ?? cached?.runId ?? null,
+  const key =
+    compatibleCached?.key ??
+    `stream-working:${JSON.stringify([
+      sessionKey,
+      explicitRunId ?? `anonymous-${++anonymousWorkingProgressId}`,
+    ])}`;
+  workingProgressBySession.set(sessionKey, {
+    key,
+    runId: explicitRunId ?? compatibleCached?.runId ?? null,
     startedAt,
   });
-  return startedAt;
+  return { key, startedAt };
 }
 
-export function clearWorkingStartedAt(sessionKey: string): void {
-  workingStartBySession.delete(sessionKey);
+export function clearWorkingProgress(sessionKey: string): void {
+  workingProgressBySession.delete(sessionKey);
 }
 
-export function resetWorkingStartedAt(): void {
-  workingStartBySession.clear();
+export function resetWorkingProgress(): void {
+  workingProgressBySession.clear();
+  anonymousWorkingProgressId = 0;
 }

--- a/ui/src/pages/chat/chat-thread.test.ts
+++ b/ui/src/pages/chat/chat-thread.test.ts
@@ -2811,7 +2811,7 @@ describe("thread item cache", () => {
 
     expect(second).not.toBe(first);
     expect(secondStream.key).not.toBe(firstStream.key);
-    expect(secondStream.startedAt).toBe(20);
+    expect(secondStream).toMatchObject({ kind: "stream", startedAt: 20 });
   });
 
   it("updates the live stream without rescanning retained history", () => {

--- a/ui/src/pages/chat/chat-thread.test.ts
+++ b/ui/src/pages/chat/chat-thread.test.ts
@@ -554,8 +554,10 @@ describe("buildCachedChatItems row identity", () => {
 });
 
 describe("buildCachedChatItems working spark", () => {
+  const readingIndicator = (props: Partial<CachedChatItemsProps>) =>
+    buildCachedChatItems(createProps(props)).find((item) => item.kind === "reading-indicator");
   const hasReadingIndicator = (props: Partial<CachedChatItemsProps>) =>
-    buildCachedChatItems(createProps(props)).some((item) => item.kind === "reading-indicator");
+    readingIndicator(props) !== undefined;
   const liveTool = (resultReceived: boolean) => ({
     role: "assistant",
     runId: "engine-run-1",
@@ -648,6 +650,104 @@ describe("buildCachedChatItems working spark", () => {
     ).find((item) => item.kind === "reading-indicator");
 
     expect(indicator).toMatchObject({ kind: "reading-indicator", startedAt: 1_000 });
+  });
+
+  it("keeps one working row from optimistic send through acknowledgement", () => {
+    resetChatThreadState();
+    const sessionKey = "agent:main:working-row";
+    const pendingItems = buildCachedChatItems(
+      createProps({
+        sessionKey,
+        queue: [
+          {
+            id: "queued-send-1",
+            text: "keep the row stable",
+            createdAt: 1_000,
+            sendRunId: "run-1",
+            sendState: "sending",
+            sendSubmittedAtMs: 10,
+          },
+        ],
+        runWorking: true,
+      }),
+    );
+    const pendingIndicator = expectDefined(
+      pendingItems.find((item) => item.kind === "reading-indicator"),
+      "pending working indicator",
+    );
+    const pendingRun = expectDefined(
+      coalesceStreamRuns(pendingItems).find((item) => item.kind === "stream-run"),
+      "pending stream run",
+    );
+
+    const acknowledgedItems = buildCachedChatItems(
+      createProps({
+        sessionKey,
+        runId: "run-1",
+        runWorking: true,
+        stream: "",
+        streamStartedAt: 2_000,
+      }),
+    );
+    const acknowledgedIndicator = expectDefined(
+      acknowledgedItems.find((item) => item.kind === "reading-indicator"),
+      "acknowledged working indicator",
+    );
+    const acknowledgedRun = expectDefined(
+      coalesceStreamRuns(acknowledgedItems).find((item) => item.kind === "stream-run"),
+      "acknowledged stream run",
+    );
+
+    expect(acknowledgedIndicator).toMatchObject({
+      key: pendingIndicator.key,
+      startedAt: pendingIndicator.startedAt,
+    });
+    expect(acknowledgedRun.key).toBe(pendingRun.key);
+
+    const streamingItems = buildCachedChatItems(
+      createProps({
+        sessionKey,
+        runId: "run-1",
+        runWorking: true,
+        stream: "The reply has started.",
+        streamStartedAt: 2_000,
+      }),
+    );
+    const visibleStream = expectDefined(
+      streamingItems.find((item) => item.kind === "stream" && item.isStreaming),
+      "visible live stream",
+    );
+    const streamingRun = expectDefined(
+      coalesceStreamRuns(streamingItems).find((item) => item.kind === "stream-run"),
+      "streaming run",
+    );
+
+    expect(visibleStream.key).toBe(pendingIndicator.key);
+    expect(streamingRun.key).toBe(pendingRun.key);
+
+    const nextRunIndicator = expectDefined(
+      readingIndicator({
+        sessionKey,
+        runId: "run-2",
+        runWorking: true,
+        stream: "",
+        streamStartedAt: 3_000,
+      }),
+      "next run working indicator",
+    );
+    const otherSessionIndicator = expectDefined(
+      readingIndicator({
+        sessionKey: "agent:other:working-row",
+        runId: "run-1",
+        runWorking: true,
+        stream: "",
+        streamStartedAt: 2_000,
+      }),
+      "other session working indicator",
+    );
+
+    expect(nextRunIndicator.key).not.toBe(pendingIndicator.key);
+    expect(otherSessionIndicator.key).not.toBe(pendingIndicator.key);
   });
 
   it("keeps client and engine run identities separate", () => {
@@ -1616,10 +1716,9 @@ describe("buildCachedChatItems", () => {
       }),
     );
 
-    expect(items).toEqual([
+    expect(items).toMatchObject([
       {
         kind: "stream",
-        key: "stream:main:1",
         text: "Visible reply",
         startedAt: 1,
         isStreaming: true,
@@ -2682,6 +2781,37 @@ describe("thread item cache", () => {
         messages: [{ role: "assistant", content: "changed" }],
       }),
     ).not.toBe(first);
+  });
+
+  it("rebuilds the live row when active stream identity changes", () => {
+    resetChatThreadState();
+    const first = buildCachedChatItems(
+      createProps({
+        runId: "run-1",
+        stream: "first reply",
+        streamStartedAt: 10,
+      }),
+    );
+    const firstStream = expectDefined(
+      first.find((item) => item.kind === "stream" && item.isStreaming),
+      "first live stream",
+    );
+
+    const second = buildCachedChatItems(
+      createProps({
+        runId: "run-2",
+        stream: "second reply",
+        streamStartedAt: 20,
+      }),
+    );
+    const secondStream = expectDefined(
+      second.find((item) => item.kind === "stream" && item.isStreaming),
+      "second live stream",
+    );
+
+    expect(second).not.toBe(first);
+    expect(secondStream.key).not.toBe(firstStream.key);
+    expect(secondStream.startedAt).toBe(20);
   });
 
   it("updates the live stream without rescanning retained history", () => {

--- a/ui/src/pages/chat/chat-thread.ts
+++ b/ui/src/pages/chat/chat-thread.ts
@@ -40,9 +40,9 @@ import { areUiSessionKeysEquivalent } from "../../lib/sessions/session-key.ts";
 import { normalizeLowercaseStringOrEmpty } from "../../lib/string-coerce.ts";
 import {
   buildCompactionDividerItem,
-  clearWorkingStartedAt,
-  resetWorkingStartedAt,
-  resolveWorkingStartedAt,
+  clearWorkingProgress,
+  resetWorkingProgress,
+  resolveWorkingProgress,
   shouldRenderQueuedSendInThread,
 } from "./chat-progress.ts";
 import { getOrCreateSessionCacheValue } from "./session-cache.ts";
@@ -79,6 +79,7 @@ type BuildChatItemsProps = {
 type CachedChatItems = {
   input: BuildChatItemsProps | null;
   items: ReturnType<typeof buildChatItems>;
+  liveStreamIdentity: string | null;
   liveStreamIndex: number;
   liveStreamPrefix: string | null;
 };
@@ -106,7 +107,7 @@ export function resetChatThreadState(paneId?: string): void {
     return;
   }
   chatItemsByPane.clear();
-  resetWorkingStartedAt();
+  resetWorkingProgress();
   expandedToolCardsBySession.clear();
   initializedToolCardsBySession.clear();
   lastAutoExpandPrefBySession.clear();
@@ -1471,38 +1472,49 @@ function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | MessageGro
         (item) => item.sendState === "sending" && shouldRenderQueuedSendInThread(item),
       ));
   if (props.runWorking !== true && props.stream === null && !hasPendingResponse) {
-    clearWorkingStartedAt(props.sessionKey);
+    clearWorkingProgress(props.sessionKey);
   }
   if (hasPendingResponse) {
-    items.push({
-      kind: "reading-indicator",
-      key: `stream:${props.sessionKey}:pending`,
-      startedAt: resolveWorkingStartedAt(
+    const progress = resolveWorkingProgress(
+      props.sessionKey,
+      props.runId ?? null,
+      props.streamStartedAt,
+      queuedSends,
+      segments,
+      tools,
+    );
+    items.push({ kind: "reading-indicator", ...progress });
+  } else if (props.stream !== null) {
+    const text = sanitizeStreamText(props.stream);
+    const visibleText = trimAccumulatedStreamPrefix(text, previousAccumulatedStreamText);
+    if (visibleText.length > 0) {
+      if (!stripHeartbeatTokenForDisplay(visibleText).shouldSkip) {
+        const progress = resolveWorkingProgress(
+          props.sessionKey,
+          props.runId ?? null,
+          props.streamStartedAt,
+          queuedSends,
+          segments,
+          tools,
+        );
+        items.push({
+          kind: "stream",
+          key: progress.key,
+          text: visibleText,
+          startedAt: timestampAfterVisibleItems(items, props.streamStartedAt ?? Date.now()),
+          isStreaming: true,
+        });
+      }
+    } else if (props.stream.trim().length === 0) {
+      const progress = resolveWorkingProgress(
         props.sessionKey,
         props.runId ?? null,
         props.streamStartedAt,
         queuedSends,
         segments,
         tools,
-      ),
-    });
-  } else if (props.stream !== null) {
-    const key = `stream:${props.sessionKey}:${props.streamStartedAt ?? "live"}`;
-    const text = sanitizeStreamText(props.stream);
-    const visibleText = trimAccumulatedStreamPrefix(text, previousAccumulatedStreamText);
-    const startedAt = timestampAfterVisibleItems(items, props.streamStartedAt ?? Date.now());
-    if (visibleText.length > 0) {
-      if (!stripHeartbeatTokenForDisplay(visibleText).shouldSkip) {
-        items.push({
-          kind: "stream",
-          key,
-          text: visibleText,
-          startedAt,
-          isStreaming: true,
-        });
-      }
-    } else if (props.stream.trim().length === 0) {
-      items.push({ kind: "reading-indicator", key, startedAt });
+      );
+      items.push({ kind: "reading-indicator", ...progress });
     }
   }
   if (props.runActive === true && props.planStatus && props.planStatus.steps.length > 0) {
@@ -1734,18 +1746,24 @@ function accumulatedIndexedStreamText(segments: readonly ChatStreamSegment[]): s
   return accumulated;
 }
 
+function liveStreamIdentity(input: BuildChatItemsProps): string {
+  return JSON.stringify([input.sessionKey, input.runId ?? null, input.streamStartedAt]);
+}
+
 function updateCachedLiveStream(
   items: ReturnType<typeof buildChatItems>,
   index: number,
+  identity: string | null,
   accumulatedPrefix: string | null,
   input: BuildChatItemsProps,
 ): boolean {
   const item = items[index];
-  if (item?.kind !== "stream" || !item.isStreaming) {
-    return false;
-  }
-  const expectedKey = `stream:${input.sessionKey}:${input.streamStartedAt ?? "live"}`;
-  if (item.key !== expectedKey || input.stream === null) {
+  if (
+    item?.kind !== "stream" ||
+    !item.isStreaming ||
+    identity !== liveStreamIdentity(input) ||
+    input.stream === null
+  ) {
     return false;
   }
   const text = trimAccumulatedStreamPrefix(sanitizeStreamText(input.stream), accumulatedPrefix);
@@ -1771,6 +1789,7 @@ export function buildCachedChatItems(
   const cached = getOrCreateSessionCacheValue(paneCache, input.sessionKey, () => ({
     input: null,
     items: [],
+    liveStreamIdentity: null,
     liveStreamIndex: -1,
     liveStreamPrefix: null,
   }));
@@ -1783,7 +1802,13 @@ export function buildCachedChatItems(
   if (
     cached.input &&
     sameChatItemsInputExceptStream(cached.input, input) &&
-    updateCachedLiveStream(cached.items, cached.liveStreamIndex, cached.liveStreamPrefix, input)
+    updateCachedLiveStream(
+      cached.items,
+      cached.liveStreamIndex,
+      cached.liveStreamIdentity,
+      cached.liveStreamPrefix,
+      input,
+    )
   ) {
     cached.input = input;
     return cached.items;
@@ -1792,6 +1817,7 @@ export function buildCachedChatItems(
   cached.input = input;
   cached.items = items;
   cached.liveStreamIndex = findLiveStreamIndex(items);
+  cached.liveStreamIdentity = cached.liveStreamIndex === -1 ? null : liveStreamIdentity(input);
   cached.liveStreamPrefix = accumulatedIndexedStreamText(input.streamSegments);
   return items;
 }

--- a/ui/src/styles/chat/tool-cards.css
+++ b/ui/src/styles/chat/tool-cards.css
@@ -1102,11 +1102,11 @@
    reply will materialize while the agent works with nothing visibly
    streaming. Bubble chrome and sizing come from
    .chat-bubble.chat-reading-indicator (components.css). Filled silhouette;
-   18px because the claw is denser than a star glyph. No opacity fade: the
-   claw stays solid and the motion carries the "working" signal. One cycle =
-   jab, jab, cross; the jaw snaps shut on every impact and a pow star pops on
-   the cross. --claw-cycle drives all three animations so stance variants
-   only retune the tempo. */
+   18px because the claw is denser than a star glyph. The row settles into
+   stance once, then the solid claw carries the ongoing working signal. One
+   cycle = jab, jab, cross; the jaw snaps shut on every impact and a pow star
+   pops on the cross. --claw-cycle drives all three animations so stance
+   variants only retune the tempo. */
 .chat-reading-indicator {
   --claw-cycle: 2.4s;
 
@@ -1121,6 +1121,7 @@
   align-items: center;
   gap: 22px;
   min-height: 28px;
+  animation: chatWorkingIndicatorEnter 200ms cubic-bezier(0.22, 1, 0.36, 1) both;
 }
 
 .chat-working-indicator__status {
@@ -1169,6 +1170,23 @@
   opacity: 0;
   animation: chatWorkingClawPow var(--claw-cycle) ease-out infinite;
   pointer-events: none;
+}
+
+@keyframes chatWorkingIndicatorEnter {
+  0% {
+    opacity: 0;
+    transform: translateY(4px) scale(0.96);
+  }
+
+  72% {
+    opacity: 1;
+    transform: translateY(-1px) scale(1.01);
+  }
+
+  100% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
 }
 
 /* Jab 1 at 12-16%, jab 2 at 26-30%, big wind-up, cross at 46-52%. */
@@ -1294,6 +1312,10 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .chat-working-indicator {
+    animation: none;
+  }
+
   .chat-reading-indicator svg,
   .chat-reading-indicator svg .claw-icon__jaw {
     animation: none;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users sending a message in the Control UI would see the transcript jump as the working claw appeared and the Gateway acknowledged the run. The visually identical working state changed virtual-row identity between phases, so the end-anchored virtualizer briefly fell back to its generic row estimate before measuring the replacement.

## Why This Change Was Made

The working phase now owns one stable, session-scoped identity from optimistic send through acknowledgement and the first visible streamed text. This keeps the measured virtual row mounted instead of replacing it at each phase boundary. The claw also gets a short layout-neutral fade/rise/scale entrance, disabled for reduced motion, while existing punch animation and stream-cache behavior remain intact.

This PR is AI-assisted. The implementation and review findings were inspected and validated before submission.

## User Impact

Sending a chat message now feels continuous: the working claw settles into place without a second vertical correction, does not remount when the send is acknowledged, and transitions into streamed text in the same transcript row.

## Evidence

- Mantis real-browser proof passed on exact head `a4a1b10bdaf8b9d9c3cbbbfa4b459b4c291729d1`: [workflow run](https://github.com/openclaw/openclaw/actions/runs/29717311022), [screenshot](https://artifacts.openclaw.ai/mantis/web-ui-chat-proof/pr-111642/run-29717311022-1/web-ui-chat.png), [full recording](https://artifacts.openclaw.ai/mantis/web-ui-chat-proof/pr-111642/run-29717311022-1/web-ui-chat.webm), and [raw QA files](https://artifacts.openclaw.ai/mantis/web-ui-chat-proof/pr-111642/run-29717311022-1/index.json).
- Exact-head CI passed: [run 29716946443](https://github.com/openclaw/openclaw/actions/runs/29716946443).
- `node scripts/run-vitest.mjs run --root ui --config vitest.config.ts src/pages/chat/chat-thread.test.ts src/pages/chat/components/chat-message.test.ts` — 228 tests passed after rebasing onto current `main`.
- Added a mocked-Gateway browser regression that defers `chat.send`, samples 20 frames across acknowledgement, verifies stable row identity and geometry, and confirms the same row transitions to streamed text.
- `git diff --check` and targeted oxfmt/oxlint passed.
- Fresh branch autoreview against `origin/main`: clean, no accepted/actionable findings.
- Local browser execution was blocked before app launch by macOS sandbox permissions, so the repository Mantis harness supplied the redacted after-fix browser artifact above.
