### PR TITLE
test(ios): refresh chat, voice, and sidebar UI coverage

### DIFF
--- a/apps/ios/UITests/OpenClawSnapshotUITests.swift
+++ b/apps/ios/UITests/OpenClawSnapshotUITests.swift
@@ -204,7 +204,7 @@ final class OpenClawSnapshotUITests: XCTestCase {
         XCTAssertTrue(self.app?.buttons["While Using"].isSelected == true)
     }
 
-    func testSettingsBackReturnsToOriginatingSidebarDestination() throws {
+    func testGatewaySettingsOpenedFromChatUsesRootSidebarNavigation() throws {
         try XCTSkipIf(UIDevice.current.userInterfaceIdiom != .phone, "Phone sidebar navigation only")
 
         self.launchApp(for: ScreenshotTarget(
@@ -216,12 +216,18 @@ final class OpenClawSnapshotUITests: XCTestCase {
         let gatewayNavigationBar = try XCTUnwrap(self.app?.navigationBars["Gateway"])
         XCTAssertTrue(gatewayNavigationBar.waitForExistence(timeout: 5))
         XCTAssertTrue(self.app?.buttons["RootTabs.Sidebar.Show"].exists == true)
-        self.attachScreenshot(named: "chat-gateway-origin-stack")
+        XCTAssertFalse(gatewayNavigationBar.buttons["BackButton"].exists)
+        self.attachScreenshot(named: "chat-gateway-root")
 
-        gatewayNavigationBar.buttons["BackButton"].tap()
-        XCTAssertTrue(self.app?.otherElements["chat-agent-identity"].waitForExistence(timeout: 5) == true)
+        let showSidebar = try XCTUnwrap(self.app?.buttons["RootTabs.Sidebar.Show"])
+        showSidebar.tap()
+        let settings = try XCTUnwrap(self.app?.buttons["Settings"])
+        XCTAssertTrue(settings.waitForExistence(timeout: 5))
+        settings.tap()
+
+        XCTAssertTrue(self.app?.navigationBars["Settings"].waitForExistence(timeout: 5) == true)
         XCTAssertTrue(self.app?.buttons["RootTabs.Sidebar.Show"].exists == true)
-        self.attachScreenshot(named: "chat-after-settings-back")
+        self.attachScreenshot(named: "gateway-to-settings-via-sidebar")
     }
 
     func testVoiceWakeResumesAfterTalkModeToggle() throws {
@@ -241,25 +247,25 @@ final class OpenClawSnapshotUITests: XCTestCase {
         XCTAssertTrue(voiceSettings.waitForExistence(timeout: 8))
         voiceSettings.tap()
 
-        let voiceWake = try XCTUnwrap(self.app?.switches["Voice Wake"])
-        let talkMode = try XCTUnwrap(self.app?.switches["Talk Mode"])
+        let voiceWake = try XCTUnwrap(self.app?.buttons["Voice Wake"])
+        let talkMode = try XCTUnwrap(self.app?.buttons["Talk Mode"])
         XCTAssertTrue(voiceWake.waitForExistence(timeout: 5))
         XCTAssertTrue(talkMode.exists)
 
-        if talkMode.value as? String == "1" {
+        if talkMode.value as? String == "On" {
             talkMode.tap()
         }
-        if voiceWake.value as? String == "1" {
+        if voiceWake.value as? String == "On" {
             voiceWake.tap()
         }
 
         voiceWake.tap()
-        XCTAssertEqual(voiceWake.value as? String, "1")
+        self.waitForValue("On", of: voiceWake)
         talkMode.tap()
-        XCTAssertEqual(talkMode.value as? String, "1")
+        self.waitForValue("On", of: talkMode)
         talkMode.tap()
-        XCTAssertEqual(talkMode.value as? String, "0")
-        XCTAssertEqual(voiceWake.value as? String, "1")
+        self.waitForValue("Off", of: talkMode)
+        XCTAssertEqual(voiceWake.value as? String, "On")
         XCTAssertEqual(self.app?.state, .runningForeground)
         self.attachScreenshot(named: "voice-wake-after-talk-resume")
 
@@ -267,24 +273,28 @@ final class OpenClawSnapshotUITests: XCTestCase {
         voiceNavigationBar.buttons["BackButton"].tap()
         let diagnostics = try XCTUnwrap(
             self.app?.buttons.containing(.staticText, identifier: "Diagnostics").firstMatch)
+        let settingsList = try XCTUnwrap(self.app?.collectionViews.firstMatch)
+        for _ in 0..<4 {
+            if diagnostics.waitForExistence(timeout: 1) { break }
+            settingsList.swipeUp()
+        }
         XCTAssertTrue(diagnostics.waitForExistence(timeout: 5))
         diagnostics.tap()
         let voiceWakeStatus = try XCTUnwrap(
-            self.app?.descendants(matching: .any)["diagnostics-voice-wake-status"])
+            self.app?.staticTexts["Voice Wake isn’t supported on Simulator"])
         XCTAssertTrue(voiceWakeStatus.waitForExistence(timeout: 5))
-        let resumed = expectation(
-            for: NSPredicate(
-                format: "value == %@",
-                "Voice Wake isn’t supported on Simulator"),
-            evaluatedWith: voiceWakeStatus)
-        wait(for: [resumed], timeout: 5)
 
         let diagnosticsNavigationBar = try XCTUnwrap(self.app?.navigationBars["Diagnostics"])
         diagnosticsNavigationBar.buttons["BackButton"].tap()
+        for _ in 0..<4 {
+            if voiceSettings.waitForExistence(timeout: 1) { break }
+            settingsList.swipeDown()
+        }
+        XCTAssertTrue(voiceSettings.waitForExistence(timeout: 5))
         voiceSettings.tap()
         XCTAssertTrue(voiceWake.waitForExistence(timeout: 5))
         voiceWake.tap()
-        XCTAssertEqual(voiceWake.value as? String, "0")
+        self.waitForValue("Off", of: voiceWake)
     }
 
     func testChatComposerStartsCompactAndGrowsWithDraft() throws {
@@ -564,30 +574,26 @@ final class OpenClawSnapshotUITests: XCTestCase {
         try XCTSkipIf(UIDevice.current.userInterfaceIdiom != .phone, "Phone sidebar proof only")
         self.launchApp(for: ScreenshotTarget(
             initialTab: "control",
-            initialDestination: "activity",
+            initialDestination: "overview",
             name: "control-chat-return"))
 
-        let recentActivity = try XCTUnwrap(self.app?.staticTexts["Recent activity"])
-        XCTAssertTrue(recentActivity.waitForExistence(timeout: 8))
-        self.attachScreenshot(named: "control-activity-before-chat")
+        let agentSession = try XCTUnwrap(self.app?.staticTexts["Agent session"])
+        XCTAssertTrue(agentSession.waitForExistence(timeout: 8))
+        self.attachScreenshot(named: "control-overview-before-chat")
 
         try self.startNewChatFromSidebar()
         XCTAssertTrue(self.app?.otherElements["chat-composer-surface"].waitForExistence(timeout: 8) == true)
-        self.attachScreenshot(named: "chat-return-to-activity")
+        self.attachScreenshot(named: "chat-return-to-overview")
 
-        try self.selectSidebarDestination("Activity")
-        XCTAssertTrue(recentActivity.waitForExistence(timeout: 8))
-        self.attachScreenshot(named: "control-activity-after-chat")
-
-        try self.startNewChatFromSidebar()
         try self.selectSidebarDestination("Overview")
-        XCTAssertTrue(self.app?.staticTexts["Agent session"].waitForExistence(timeout: 8) == true)
-        self.attachScreenshot(named: "control-tab-returns-to-root")
-
-        let agentSession = try XCTUnwrap(
-            self.app?.buttons.containing(.staticText, identifier: "Molty").firstMatch)
         XCTAssertTrue(agentSession.waitForExistence(timeout: 8))
-        agentSession.tap()
+        self.attachScreenshot(named: "control-overview-after-chat")
+
+        let agentSessionRow = try XCTUnwrap(self.app?.buttons.matching(NSPredicate(
+            format: "label BEGINSWITH[c] %@",
+            "Molty, chat")).firstMatch)
+        XCTAssertTrue(agentSessionRow.waitForExistence(timeout: 8))
+        agentSessionRow.tap()
 
         XCTAssertTrue(self.app?.otherElements["chat-composer-surface"].waitForExistence(timeout: 8) == true)
         self.attachScreenshot(named: "chat-session-return-to-overview")
@@ -827,6 +833,13 @@ final class OpenClawSnapshotUITests: XCTestCase {
         XCTAssertEqual(XCTWaiter.wait(for: [expectation], timeout: 3), .completed)
     }
 
+    private func waitForHittable(_ isHittable: Bool, of element: XCUIElement) {
+        let expectation = XCTNSPredicateExpectation(
+            predicate: NSPredicate(format: "hittable == %@", NSNumber(value: isHittable)),
+            object: element)
+        XCTAssertEqual(XCTWaiter.wait(for: [expectation], timeout: 5), .completed)
+    }
+
     private func selectSidebarDestination(
         _ title: String,
         file: StaticString = #filePath,
@@ -834,18 +847,23 @@ final class OpenClawSnapshotUITests: XCTestCase {
     {
         let app = try XCTUnwrap(self.app, file: file, line: line)
         let hideSidebar = app.buttons["RootTabs.Sidebar.Hide"]
-        if !hideSidebar.exists {
+        if !hideSidebar.isHittable {
             let showSidebar = app.buttons["RootTabs.Sidebar.Show"]
             XCTAssertTrue(showSidebar.waitForExistence(timeout: 5), file: file, line: line)
+            XCTAssertTrue(showSidebar.isHittable, file: file, line: line)
             showSidebar.tap()
-            XCTAssertTrue(hideSidebar.waitForExistence(timeout: 5), file: file, line: line)
+            self.waitForHittable(true, of: hideSidebar)
         }
 
-        let destination = app.buttons[title]
+        let destination = app.buttons.matching(NSPredicate(
+            format: "label == %@ OR label BEGINSWITH %@",
+            title,
+            "\(title),")).firstMatch
         XCTAssertTrue(destination.waitForExistence(timeout: 5), file: file, line: line)
+        XCTAssertTrue(destination.isHittable, file: file, line: line)
         destination.tap()
 
-        XCTAssertTrue(hideSidebar.waitForNonExistence(timeout: 5), file: file, line: line)
+        self.waitForHittable(false, of: hideSidebar)
         XCTAssertTrue(app.buttons["RootTabs.Sidebar.Show"].waitForExistence(timeout: 5), file: file, line: line)
     }
 
@@ -855,19 +873,21 @@ final class OpenClawSnapshotUITests: XCTestCase {
     {
         let app = try XCTUnwrap(self.app, file: file, line: line)
         let hideSidebar = app.buttons["RootTabs.Sidebar.Hide"]
-        if !hideSidebar.exists {
+        if !hideSidebar.isHittable {
             let showSidebar = app.buttons["RootTabs.Sidebar.Show"]
             XCTAssertTrue(showSidebar.waitForExistence(timeout: 5), file: file, line: line)
+            XCTAssertTrue(showSidebar.isHittable, file: file, line: line)
             showSidebar.tap()
-            XCTAssertTrue(hideSidebar.waitForExistence(timeout: 5), file: file, line: line)
+            self.waitForHittable(true, of: hideSidebar)
         }
 
         let newChat = app.buttons["New Chat"]
         XCTAssertTrue(newChat.waitForExistence(timeout: 5), file: file, line: line)
         XCTAssertTrue(newChat.isEnabled, file: file, line: line)
+        XCTAssertTrue(newChat.isHittable, file: file, line: line)
         newChat.tap()
 
-        XCTAssertTrue(hideSidebar.waitForNonExistence(timeout: 5), file: file, line: line)
+        self.waitForHittable(false, of: hideSidebar)
         XCTAssertTrue(app.buttons["RootTabs.Sidebar.Show"].waitForExistence(timeout: 5), file: file, line: line)
     }
 
@@ -967,10 +987,13 @@ final class OpenClawSnapshotUITests: XCTestCase {
         XCTAssertTrue(actions.waitForExistence(timeout: 8), file: file, line: line)
         actions.tap()
 
-        let gatewaySettings = try XCTUnwrap(
-            self.app?.buttons["chat-gateway-settings"],
-            file: file,
-            line: line)
+        let app = try XCTUnwrap(self.app, file: file, line: line)
+        let gatewaySettings = app.buttons["chat-gateway-settings"]
+        let actionsMenu = app.collectionViews.firstMatch
+        for _ in 0..<3 {
+            if gatewaySettings.waitForExistence(timeout: 1) { break }
+            actionsMenu.swipeUp()
+        }
         XCTAssertTrue(gatewaySettings.waitForExistence(timeout: 3), file: file, line: line)
         gatewaySettings.tap()
     }


### PR DESCRIPTION
## What Problem This Solves

The iOS UI suite still used selectors and navigation expectations from before the unified chat/voice work in #107879 and the overlay sidebar work in #111339. Hidden drawer controls could remain in the accessibility tree, Gateway was still treated as a pushed screen, Voice controls were queried as switches, and the chat/session route exercised a stale Activity flow.

This PR is test coverage and test-harness cleanup only. It changes no production source and does not include the sidebar interaction fixes tracked in #111643.

Closes #111684.

## Why This Change Was Made

- Use hittability, rather than accessibility-tree existence, to determine whether the overlay sidebar is actually open.
- Match sidebar rows by their destination prefix so status text such as `Overview, Attention` remains testable.
- Validate Gateway and Settings as root sidebar destinations.
- Query Voice Wake and Talk Mode through their current button-style `On` / `Off` accessibility contract.
- Exercise the current Overview session flow after starting and reopening chat.
- Add bounded scrolling when Gateway settings is below the visible chat-actions menu.

This is AI-assisted work. The final test-only diff was manually reviewed, run against unmodified `main` app code, and passed structured autoreview with no actionable findings.

## User Impact

There is no production behavior change. The UI suite now follows the shipped accessibility and navigation contracts, reducing false failures and giving future chat, voice, Gateway, Settings, and sidebar changes reliable regression coverage.

## Evidence

### Scope proof

- **1 changed file:** `apps/ios/UITests/OpenClawSnapshotUITests.swift`
- **0 production files changed**
- **71 additions / 48 deletions**
- Final head: `3d3612521e71b18cfec9f1ef3c56491c7b5dfe77`

### Simulator proof

Validated on `OpenClaw iPhone Preview` (iPhone 17 Pro, iOS 26.2) with Xcode 27 beta:

- **4/4 affected UI tests passed**, 0 failures, in 83.156 seconds.
- `testSidebarOverviewNavigation`
- `testGatewaySettingsOpenedFromChatUsesRootSidebarNavigation`
- `testVoiceWakeResumesAfterTalkModeToggle`
- `testChatAndOverviewNavigateThroughSidebar`
- The pre-cleanup run reproduced two false failures where hidden drawer elements existed but were not hittable; the hittability-based helper cleanup resolved both without app-source changes.
- `git diff --check` passed.
- Structured autoreview: **no accepted/actionable findings**, `patch is correct` (0.84 confidence).
- A final non-iOS `main` rebase preserved the stable patch ID byte-for-byte.

Focused command:

```sh
xcodebuild -project apps/ios/OpenClaw.xcodeproj -scheme OpenClawUITests -configuration Debug \
  -destination 'platform=iOS Simulator,id=9FAC1566-D7F6-46E3-BC28-DC622866AB6B' test \
  -only-testing:OpenClawUITests/OpenClawSnapshotUITests/testSidebarOverviewNavigation \
  -only-testing:OpenClawUITests/OpenClawSnapshotUITests/testGatewaySettingsOpenedFromChatUsesRootSidebarNavigation \
  -only-testing:OpenClawUITests/OpenClawSnapshotUITests/testVoiceWakeResumesAfterTalkModeToggle \
  -only-testing:OpenClawUITests/OpenClawSnapshotUITests/testChatAndOverviewNavigateThroughSidebar
```

### Visual proof

<table>
<tr>
<td><strong>Gateway as a root destination</strong></td>
<td><strong>Settings through the sidebar</strong></td>
<td><strong>Voice state after Talk Mode round-trip</strong></td>
</tr>
<tr>
<td><img width="300" alt="Gateway shown as a root destination" src="https://github.com/user-attachments/assets/7338002c-65f4-4717-8b01-ac5c1ef0fb0a" /></td>
<td><img width="300" alt="Settings reached through the sidebar" src="https://github.com/user-attachments/assets/effd535d-fe61-4084-b55f-f1a09248b536" /></td>
<td><img width="300" alt="Voice Wake restored after toggling Talk Mode" src="https://github.com/user-attachments/assets/e23f76c5-3e59-4acf-82ed-1c38c6afc280" /></td>
</tr>
</table>
