### PR TITLE
fix(telegram): linkPreview:false is ignored by the draft-streaming path

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch-draft.ts
+++ b/extensions/telegram/src/bot-message-dispatch-draft.ts
@@ -127,6 +127,7 @@ export function createTelegramDraftController(params: {
           replyToMessageId: params.draftReplyToMessageId,
           replyToMode: params.replyToMode,
           richMessages: params.telegramCfg.richMessages,
+          linkPreview: params.telegramCfg.linkPreview,
           minInitialChars: params.streamMode === "progress" ? 0 : DRAFT_MIN_INITIAL_CHARS,
           renderText: renderStreamText,
           onRetainedPage: (page) => {

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -233,6 +233,7 @@ export function createTelegramDraftStream(params: {
   replyToMessageId?: number;
   replyToMode?: ReplyToMode;
   richMessages?: boolean;
+  linkPreview?: boolean;
   throttleMs?: number;
   /** Minimum chars before sending first message (debounce for push notifications) */
   minInitialChars?: number;
@@ -244,6 +245,7 @@ export function createTelegramDraftStream(params: {
   warn?: (message: string) => void;
 }): TelegramDraftStream {
   const richMessages = params.richMessages === true;
+  const disableLinkPreview = params.linkPreview === false;
   const transportLimit = richMessages ? TELEGRAM_RICH_TEXT_LIMIT : TELEGRAM_TEXT_CHUNK_LIMIT;
   const maxChars = Math.min(params.maxChars ?? transportLimit, transportLimit);
   const throttleMs = Math.max(250, params.throttleMs ?? DEFAULT_THROTTLE_MS);
@@ -327,6 +329,7 @@ export function createTelegramDraftStream(params: {
           message: await getTelegramRichRawApi(params.api).sendRichMessage({
             chat_id: chatId,
             rich_message: page.richMessage,
+            ...(disableLinkPreview ? { link_preview_options: { is_disabled: true } } : {}),
             ...sendMessageParams,
           }),
           snapshot: page,
@@ -342,14 +345,20 @@ export function createTelegramDraftStream(params: {
           throw err;
         }
         return {
-          message: await params.api.sendMessage(chatId, fallbackPlan.plainText, sendMessageParams),
+          message: await params.api.sendMessage(chatId, fallbackPlan.plainText, {
+            ...(disableLinkPreview ? { link_preview_options: { is_disabled: true } } : {}),
+            ...sendMessageParams,
+          }),
           snapshot: fallbackSnapshot(fallbackPlan.plainText),
         };
       }
     }
     if (page.sourceTextMode !== "html") {
       return {
-        message: await params.api.sendMessage(chatId, page.text, sendMessageParams),
+        message: await params.api.sendMessage(chatId, page.text, {
+          ...(disableLinkPreview ? { link_preview_options: { is_disabled: true } } : {}),
+          ...sendMessageParams,
+        }),
         snapshot: page,
       };
     }
@@ -357,6 +366,7 @@ export function createTelegramDraftStream(params: {
       return {
         message: await params.api.sendMessage(chatId, page.sourceText, {
           parse_mode: "HTML" as const,
+          ...(disableLinkPreview ? { link_preview_options: { is_disabled: true } } : {}),
           ...sendMessageParams,
         }),
         snapshot: page,
@@ -366,7 +376,10 @@ export function createTelegramDraftStream(params: {
         throw err;
       }
       return {
-        message: await params.api.sendMessage(chatId, page.text, sendMessageParams),
+        message: await params.api.sendMessage(chatId, page.text, {
+          ...(disableLinkPreview ? { link_preview_options: { is_disabled: true } } : {}),
+          ...sendMessageParams,
+        }),
         snapshot: fallbackSnapshot(page.text),
       };
     }
@@ -390,6 +403,7 @@ export function createTelegramDraftStream(params: {
             chat_id: chatId,
             message_id: targetMessageId,
             rich_message: page.richMessage,
+            ...(disableLinkPreview ? { link_preview_options: { is_disabled: true } } : {}),
           });
         } catch (err) {
           const fallbackPlan = buildTelegramPlainFallbackPlan({
@@ -401,23 +415,39 @@ export function createTelegramDraftStream(params: {
           if (!fallbackPlan) {
             throw err;
           }
-          await params.api.editMessageText(chatId, targetMessageId, fallbackPlan.plainText);
+          await params.api.editMessageText(
+            chatId,
+            targetMessageId,
+            fallbackPlan.plainText,
+            ...(disableLinkPreview ? [{ link_preview_options: { is_disabled: true } }] : []),
+          );
           acceptedSnapshot = fallbackSnapshot(fallbackPlan.plainText);
         }
       } else if (page.sourceTextMode === "html") {
         try {
           await params.api.editMessageText(chatId, targetMessageId, page.sourceText, {
             parse_mode: "HTML" as const,
+            ...(disableLinkPreview ? { link_preview_options: { is_disabled: true } } : {}),
           });
         } catch (err) {
           if (!isTelegramHtmlParseError(err)) {
             throw err;
           }
-          await params.api.editMessageText(chatId, targetMessageId, page.text);
+          await params.api.editMessageText(
+            chatId,
+            targetMessageId,
+            page.text,
+            ...(disableLinkPreview ? [{ link_preview_options: { is_disabled: true } }] : []),
+          );
           acceptedSnapshot = fallbackSnapshot(page.text);
         }
       } else {
-        await params.api.editMessageText(chatId, targetMessageId, page.sourceText);
+        await params.api.editMessageText(
+          chatId,
+          targetMessageId,
+          page.sourceText,
+          ...(disableLinkPreview ? [{ link_preview_options: { is_disabled: true } }] : []),
+        );
       }
       if (sendGeneration === generation && streamMessageId === targetMessageId) {
         streamMessageSnapshot = acceptedSnapshot;


### PR DESCRIPTION
Closes #111525

## What Problem This Solves

Fixes an issue where Telegram's `linkPreview: false` channel config was silently ignored by the draft-streaming path. Non-streamed sends correctly attached `link_preview_options: { is_disabled: true }`, but the streaming preview (`createTelegramDraftStream`) never sent it — not on the initial `sendMessage`, and not on any subsequent `editMessageText`. In the common case where the streamed draft text exactly matches the final text, the edit-at-finalization step is skipped, so the preview survives permanently.

## Why This Change Was Made

`createTelegramDraftStream` now accepts a `linkPreview` option and applies `link_preview_options: { is_disabled: true }` to every Telegram API call — `sendMessage`, `sendRichMessage`, and all `editMessageText` variants (plain, HTML, rich message) — when `linkPreview === false`. The flag is threaded from the existing `telegramCfg.linkPreview` in `createDraftLane`. When `linkPreview` is not explicitly `false`, no extra parameter is added to any API call, preserving the existing default behavior and avoiding call-arity changes.

## User Impact

Telegram users with `linkPreview: false` in their config no longer see unfurled link cards on streamed draft/preview replies. Non-streamed sends, ingress spool delivery, and the edit-at-finalization path continue to honor the flag as before.

## Evidence

### Regression coverage

- `extensions/telegram/src/draft-stream.test.ts`: 84 tests pass with the fix (no regressions). The existing tests assert exact API call parameters; the fix only adds `link_preview_options` when `linkPreview === false`, so default behavior produces byte-identical API calls.

### Sibling-surface context

The non-stream send path (`send-*.js`) already builds `linkPreviewOptions` from `account.config.linkPreview` and attaches `link_preview_options: { is_disabled: true }`. The ingress spool also wires `linkPreview` into `deliveryBaseOptions` and `editStreamMessage`. This change brings `createTelegramDraftStream` into alignment with those paths.

### Validation

- `node scripts/run-vitest.mjs extensions/telegram/src/draft-stream.test.ts` — 84 passed.
- Scoped `oxfmt`, `oxlint`, and `git diff --check` pass on the two changed files.

AI-assisted.
