### PR TITLE
fix(ui): redesign the who's-online roster menu

### DIFF
--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1982,19 +1982,45 @@ html.openclaw-native-macos
   background: color-mix(in srgb, var(--fg) 8%, transparent);
 }
 
-/* Long rosters scroll inside the popup instead of growing past the viewport. */
+/* Long rosters scroll inside the popup instead of growing past the viewport.
+   Chrome matches the sidebar's other fixed menus (customize/session menus). */
 .presence-roster-menu::part(menu) {
-  max-height: min(320px, 60vh);
+  min-width: 232px;
+  max-width: 288px;
+  max-height: min(340px, 60vh);
   overflow-y: auto;
+  padding: 6px;
+  border: 1px solid color-mix(in srgb, var(--border-strong) 78%, transparent);
+  border-radius: var(--radius-lg);
+  background: var(--bg-elevated);
+  box-shadow: var(--shadow-lg);
 }
 
 .presence-roster-menu__title {
-  padding: 4px 10px 2px;
+  padding: 6px 8px 4px;
   color: var(--muted);
   font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0.02em;
+  font-weight: 650;
+  letter-spacing: 0.05em;
   text-transform: uppercase;
+}
+
+/* Rows are informational people entries, not checkbox menu items: drop Web
+   Awesome's checkmark gutter and item metrics so title, avatars, and text
+   share one left edge with the rest of the app's menus. */
+.presence-roster-menu__item {
+  padding: 5px 8px;
+  border-radius: var(--radius-md);
+}
+
+.presence-roster-menu__item:hover,
+.presence-roster-menu__item:focus-visible {
+  outline: none;
+  background: color-mix(in srgb, var(--bg-hover) 84%, transparent);
+}
+
+.presence-roster-menu__item::part(checkmark) {
+  display: none;
 }
 
 .presence-roster-menu__item::part(label) {
@@ -2002,13 +2028,38 @@ html.openclaw-native-macos
   align-items: center;
 }
 
+/* Roster avatars grow to two-line row scale. The circle clips via the child
+   image/initials instead of the wrapper so the online badge can overflow. */
 .presence-roster-menu__item .viewer-avatar {
-  border-color: transparent;
+  width: 26px;
+  height: 26px;
+  overflow: visible;
+  border: none;
+  font-size: 10px;
+}
+
+.presence-roster-menu__item .viewer-avatar > img,
+.presence-roster-menu__item .viewer-avatar > span {
+  border-radius: var(--radius-full);
+}
+
+/* Everyone listed is online; the dot restates the header at a glance. */
+.presence-roster-menu__item .viewer-avatar::after {
+  content: "";
+  position: absolute;
+  right: -1px;
+  bottom: -1px;
+  width: 8px;
+  height: 8px;
+  border: 2px solid var(--bg-elevated);
+  border-radius: var(--radius-full);
+  background: var(--ok);
 }
 
 .presence-roster-menu__text {
   display: flex;
   flex-direction: column;
+  gap: 1px;
   min-width: 0;
   line-height: 1.3;
 }
@@ -2017,11 +2068,14 @@ html.openclaw-native-macos
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  color: var(--text);
   font-size: 13px;
+  font-weight: 500;
 }
 
 .presence-roster-menu__you {
   color: var(--muted);
+  font-weight: 400;
 }
 
 .presence-roster-menu__email {


### PR DESCRIPTION
## What Problem This Solves

The footer "who's online" roster menu (team picker) in the Control UI looked unpolished: it relied on Web Awesome's default dropdown chrome instead of the app's menu styling, so its padding, corner radius, and background didn't match the sibling sidebar menus. The title didn't share a left edge with the rows (Web Awesome reserves a checkmark gutter for informational people rows), the 20px footer-size avatars were undersized for two-line name+email rows, and the name/email hierarchy was flat.

## Why This Change Was Made

CSS-only redesign of `.presence-roster-menu` in `ui/src/styles/layout.css`, aligning it with the sidebar's other fixed menus (customize/session menus):

- Menu chrome matches app menus: 6px padding, `--radius-lg`, `--bg-elevated`, `--border-strong` hairline, `--shadow-lg`, 232–288px width.
- The Web Awesome checkmark gutter is hidden (`::part(checkmark)`) and item metrics are overridden so the title, avatars, and text share one left edge.
- Roster avatars grow to 26px (two-line row scale) and carry an online status dot; the circle clips via the child image/initials so the badge can overflow the wrapper.
- Names get `--text` at weight 500 over the muted email subtitle; hover/focus rows use the app's standard `--bg-hover` mix with `--radius-md`.

## User Impact

The online-roster popover from the sidebar footer facepile now reads like a native part of the app: consistent chrome, aligned columns, clearer name/email hierarchy, and an at-a-glance online indicator per person. No behavior change.

## Evidence

Before / after (dark), after (light) — captured via the mock-gateway dev harness with an injected 3-user presence payload:

| Before | After | After (light) |
| --- | --- | --- |
| ![before](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/presence-roster-redesign/roster-before.png) | ![after](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/presence-roster-redesign/roster-after.png) | ![after light](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/presence-roster-redesign/roster-after-light.png) |

- `node scripts/run-vitest.mjs ui/src/components/viewer-facepile.test.ts` — 6/6 passed.
- `oxfmt --check ui/src/styles/layout.css` — clean; `git diff --check` clean.
- Codex autoreview (`gpt-5.6-sol`, branch vs origin/main) — clean, no findings.
