### PR TITLE
fix(release): accept package tarballs with large entry lists

### DIFF
--- a/scripts/check-openclaw-package-tarball.mjs
+++ b/scripts/check-openclaw-package-tarball.mjs
@@ -258,6 +258,8 @@ function collectRequiredBundledWorkspaceDependencyErrors(
 }
 
 const phaseTimingsEnabled = process.env.OPENCLAW_PACKAGE_TARBALL_CHECK_TIMINGS !== "0";
+// Self-contained artifacts can exceed Node's 1 MiB spawnSync output default.
+const TAR_LIST_MAX_BUFFER_BYTES = 64 * 1024 * 1024;
 function runPhase(label, action) {
   const startedAt = performance.now();
   try {
@@ -273,11 +275,12 @@ function runPhase(label, action) {
 const list = runPhase("tar list", () =>
   spawnSync("tar", ["-tf", tarball], {
     encoding: "utf8",
+    maxBuffer: TAR_LIST_MAX_BUFFER_BYTES,
     stdio: ["ignore", "pipe", "pipe"],
   }),
 );
 if (list.status !== 0) {
-  fail(`tar -tf failed for ${tarball}: ${list.stderr || list.status}`);
+  fail(`tar -tf failed for ${tarball}: ${list.stderr || list.error?.message || list.status}`);
 }
 
 const extractDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-package-tarball-"));

--- a/test/scripts/check-openclaw-package-tarball.test.ts
+++ b/test/scripts/check-openclaw-package-tarball.test.ts
@@ -17,6 +17,7 @@ import { PACKAGE_INSTALL_GUARD_RELATIVE_PATH } from "../../scripts/lib/package-d
 import { WORKSPACE_TEMPLATE_PACK_PATHS } from "../../scripts/lib/workspace-bootstrap-smoke.mjs";
 
 const CHECK_SCRIPT = "scripts/check-openclaw-package-tarball.mjs";
+const NODE_DEFAULT_SPAWN_MAX_BUFFER_BYTES = 1024 * 1024;
 const FLAT_PLUGIN_SDK_DECLARATION = "dist/plugin-sdk/provider-entry.d.ts";
 const DEEP_PLUGIN_SDK_DECLARATION = "dist/plugin-sdk/src/plugin-sdk/provider-entry.d.ts";
 const AI_RUNTIME_PACKAGE_JSON = JSON.stringify({
@@ -138,6 +139,36 @@ describe("check-openclaw-package-tarball", () => {
     expect(extra.status).not.toBe(0);
     expect(extra.stderr).toContain("Unexpected OpenClaw package tarball check argument: extra");
     expect(extra.stderr).not.toContain("OpenClaw package tarball does not exist");
+  });
+
+  it("accepts tarballs whose entry list exceeds Node's default spawn buffer", () => {
+    const longNameSuffix = "x".repeat(80);
+    const largeEntryList = Object.fromEntries(
+      Array.from({ length: 8_000 }, (_, index) => [
+        `dist/control-ui/assets/large-entry-list/asset-${String(index).padStart(5, "0")}-${longNameSuffix}.txt`,
+        "",
+      ]),
+    );
+
+    withTarball(
+      ["dist/index.js"],
+      { "dist/index.js": "export {};\n", ...largeEntryList },
+      (tarball) => {
+        const listing = spawnSync("tar", ["-tf", tarball], {
+          encoding: "utf8",
+          maxBuffer: NODE_DEFAULT_SPAWN_MAX_BUFFER_BYTES * 2,
+        });
+        expect(listing.status, listing.stderr).toBe(0);
+        expect(Buffer.byteLength(listing.stdout)).toBeGreaterThan(
+          NODE_DEFAULT_SPAWN_MAX_BUFFER_BYTES,
+        );
+
+        const result = spawnSync("node", [CHECK_SCRIPT, tarball], { encoding: "utf8" });
+
+        expect(result.status, result.stderr).toBe(0);
+        expect(result.stdout).toContain("OpenClaw package tarball integrity passed.");
+      },
+    );
   });
 
   it.runIf(process.platform !== "win32")(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where release and package-acceptance checks rejected otherwise valid self-contained OpenClaw tarballs when their archive entry listing exceeded Node's default child-process capture buffer.

## Why This Change Was Made

The checker now gives only `tar -tf` a bounded 64 MiB capture buffer, matching the existing npm release-check capture limit, while keeping the current synchronous inventory-validation path. Spawn failures also retain the child error message when no exit status or stderr is available; package contents and plugin bundling are unchanged.

## User Impact

Release operators can validate larger self-contained deployment artifacts without the checker terminating at Node's 1 MiB default output limit. Malformed archives and nonzero tar exits continue to fail with actionable diagnostics.

## Evidence

- Before the patch, a valid fixture whose `tar -tf` output measured 1,160,784 bytes failed with status 1 and `tar -tf failed ...: null`.
- After the patch, the same fixture passed with `OpenClaw package tarball integrity passed.`
- Blacksmith Testbox run [29719088844](https://github.com/openclaw/openclaw/actions/runs/29719088844): all 35 focused checker tests passed, including the large-list regression and existing extraction-failure cleanup case; oxfmt passed on both touched files; oxlint reported 0 warnings and 0 errors.
- `git diff --check upstream/main...HEAD` and `node --check scripts/check-openclaw-package-tarball.mjs` passed after the final rebase.
- Autoreview: `$autoreview --mode branch --base upstream/main` returned no accepted/actionable findings on the final diff.

## Real behavior proof

Behavior addressed: Valid package tarballs no longer fail validation solely because their entry listing exceeds Node's default 1 MiB `spawnSync` capture limit.

Real environment tested: Local macOS tar/Node execution and delegated Blacksmith Linux Node 24 Testbox.

Exact steps or command run after this patch: Generated a valid OpenClaw fixture with 8,000 additional archive entries, measured `tar -tf` output, ran `node scripts/check-openclaw-package-tarball.mjs <fixture.tgz>`, then ran `pnpm test test/scripts/check-openclaw-package-tarball.test.ts -- --reporter=verbose` on Testbox.

Evidence after fix: The real listing was 1,160,784 bytes; the checker exited 0, and all 35 focused tests passed on Testbox run 29719088844.

Observed result after fix: The large valid tarball passed; malformed tarballs and the existing fake nonzero extraction path still failed with their tar diagnostics, and failed extraction cleanup remained green.

What was not tested: The full release-validation or Package Acceptance workflow was not dispatched because this change is isolated to the checker process buffer and its direct test project.
