### PR TITLE
fix(voyage): keep embedding batch waits within timeout

### DIFF
--- a/extensions/voyage/embedding-batch.test.ts
+++ b/extensions/voyage/embedding-batch.test.ts
@@ -1,5 +1,5 @@
 // Voyage batch tests cover bounded status/error response reads.
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { runVoyageEmbeddingBatches } from "./embedding-batch.js";
 import type { VoyageEmbeddingClient } from "./embedding-provider.js";
 import { voyageEmbeddingBatchTesting as testing } from "./test-support.js";
@@ -76,6 +76,64 @@ function streamingResponse(params: { chunkCount: number; chunkSize: number; stat
 }
 
 describe("voyage batch bounded reads", () => {
+  it("clamps polling to the remaining batch timeout", async () => {
+    const sleeps: number[] = [];
+
+    await expect(
+      runVoyageEmbeddingBatches({
+        client: buildClient(),
+        agentId: "main",
+        requests: [{ custom_id: "req-0", body: { input: "hello" } }],
+        wait: true,
+        pollIntervalMs: 2_000,
+        timeoutMs: 1_000,
+        concurrency: 1,
+        deps: {
+          now: (() => {
+            const times = [0, 500];
+            return () => times.shift() ?? 500;
+          })(),
+          sleep: async (ms) => {
+            sleeps.push(ms);
+            throw new Error("stop after first wait");
+          },
+          uploadBatchJsonlFile: async () => "input-0",
+          postJsonWithRetry: async () => ({ id: "batch-0", status: "in_progress" }),
+        },
+      }),
+    ).rejects.toThrow("stop after first wait");
+
+    expect(sleeps).toEqual([500]);
+  });
+
+  it("does not poll status after the batch timeout expires", async () => {
+    let now = 0;
+    const statusFetch = vi.fn();
+
+    await expect(
+      runVoyageEmbeddingBatches({
+        client: buildClient(),
+        agentId: "main",
+        requests: [{ custom_id: "req-0", body: { input: "hello" } }],
+        wait: true,
+        pollIntervalMs: 1_000,
+        timeoutMs: 1_000,
+        concurrency: 1,
+        deps: {
+          now: () => now,
+          sleep: async (ms) => {
+            now += ms;
+          },
+          uploadBatchJsonlFile: async () => "input-0",
+          postJsonWithRetry: async () => ({ id: "batch-0", status: "in_progress" }),
+          withRemoteHttpResponse: statusFetch as never,
+        },
+      }),
+    ).rejects.toThrow("voyage batch batch-0 timed out after 1000ms");
+
+    expect(statusFetch).not.toHaveBeenCalled();
+  });
+
   it("uses a 16 MiB cap for successful status/error-file responses", () => {
     expect(VOYAGE_BATCH_RESPONSE_MAX_BYTES).toBe(16 * 1024 * 1024);
   });

--- a/extensions/voyage/embedding-batch.ts
+++ b/extensions/voyage/embedding-batch.ts
@@ -77,12 +77,14 @@ function resolveVoyageBatchDeps(overrides: Partial<VoyageBatchDeps> | undefined)
 function buildVoyageBatchRequest<T>(params: {
   client: VoyageEmbeddingClient;
   path: string;
+  signal?: AbortSignal;
   onResponse: (res: Response) => Promise<T>;
 }) {
   const baseUrl = normalizeBatchBaseUrl(params.client);
   return {
     url: `${baseUrl}/${params.path}`,
     ssrfPolicy: params.client.ssrfPolicy,
+    signal: params.signal,
     init: {
       headers: buildBatchHeaders(params.client, { json: true }),
     },
@@ -130,12 +132,14 @@ async function fetchVoyageBatchStatus(params: {
   batchId: string;
   deps: VoyageBatchDeps;
   maxResponseBytes?: number;
+  signal?: AbortSignal;
 }): Promise<VoyageBatchStatus> {
   const maxBytes = params.maxResponseBytes ?? VOYAGE_BATCH_RESPONSE_MAX_BYTES;
   return await params.deps.withRemoteHttpResponse(
     buildVoyageBatchRequest({
       client: params.client,
       path: `batches/${params.batchId}`,
+      signal: params.signal,
       onResponse: async (res) => {
         await assertOkOrThrowProviderError(res, "voyage.batch-status");
         return await readProviderJsonResponse<VoyageBatchStatus>(res, "voyage-batch-status", {
@@ -191,15 +195,34 @@ async function waitForVoyageBatch(params: {
   deps: VoyageBatchDeps;
 }): Promise<BatchCompletionResult> {
   const start = params.deps.now();
+  const deadline = start + params.timeoutMs;
   let current: VoyageBatchStatus | undefined = params.initial;
   while (true) {
-    const status =
-      current ??
-      (await fetchVoyageBatchStatus({
-        client: params.client,
-        batchId: params.batchId,
-        deps: params.deps,
-      }));
+    let status: VoyageBatchStatus;
+    if (current) {
+      status = current;
+    } else {
+      const remainingRequestMs = deadline - params.deps.now();
+      if (remainingRequestMs <= 0) {
+        throw new Error(`voyage batch ${params.batchId} timed out after ${params.timeoutMs}ms`);
+      }
+      const signal = AbortSignal.timeout(Math.max(1, remainingRequestMs));
+      try {
+        status = await fetchVoyageBatchStatus({
+          client: params.client,
+          batchId: params.batchId,
+          deps: params.deps,
+          signal,
+        });
+      } catch (error) {
+        if (signal.aborted) {
+          throw new Error(`voyage batch ${params.batchId} timed out after ${params.timeoutMs}ms`, {
+            cause: error,
+          });
+        }
+        throw error;
+      }
+    }
     const state = status.status ?? "unknown";
     await throwIfBatchCompletionError({
       provider: "voyage",
@@ -231,11 +254,13 @@ async function waitForVoyageBatch(params: {
     if (!params.wait) {
       throw new Error(`voyage batch ${params.batchId} still ${state}; wait disabled`);
     }
-    if (params.deps.now() - start > params.timeoutMs) {
+    const remainingMs = deadline - params.deps.now();
+    if (remainingMs <= 0) {
       throw new Error(`voyage batch ${params.batchId} timed out after ${params.timeoutMs}ms`);
     }
-    params.debug?.(`voyage batch ${params.batchId} ${state}; waiting ${params.pollIntervalMs}ms`);
-    await params.deps.sleep(params.pollIntervalMs);
+    const waitMs = Math.min(params.pollIntervalMs, remainingMs);
+    params.debug?.(`voyage batch ${params.batchId} ${state}; waiting ${waitMs}ms`);
+    await params.deps.sleep(waitMs);
     current = undefined;
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users waiting for Voyage embedding batches could exceed the configured total timeout when the next poll delay or status request was longer than the remaining budget.

## Why This Change Was Made

The Voyage waiter now carries one deadline through poll sleeps and status requests, using its existing injected clock/sleep seam and an abort signal for the request. Risk note: an incorrect boundary could stop a still-valid batch early, so the tests cover both the remaining-time clamp and the exact deadline before another status request.

## User Impact

Voyage remote embedding batches now stop within their configured wait budget instead of overshooting by another polling or request interval.

## Evidence

I drove the real exported `runVoyageEmbeddingBatches()` from the branch. The only replacements were its existing upload/status transport and clock/sleep dependency seams. The same harness against the pre-fix source registered a 1000 ms sleep with only 500 ms remaining; the fixed source registers 500 ms:

```text
$ node --import tsx --no-warnings /tmp/voyage-timeout-proof.mts
before: {"error":"proof stop after first poll wait","sleeps":[1000]}
after:  {"error":"proof stop after first poll wait","sleeps":[500]}
```

The regression test also advances through the final bounded sleep and verifies that no status request is sent after the deadline.

```text
$ node scripts/run-vitest.mjs extensions/voyage/embedding-batch.test.ts
Test Files  1 passed (1)
Tests  12 passed (12)

$ CI=1 OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 pnpm check:changed --base upstream/main -- extensions/voyage/embedding-batch.ts extensions/voyage/embedding-batch.test.ts
exit 0
```

AI-assisted: Codex helped implement and review the change; the behavior proof and validation above were run manually.

### Maintainer real-transport verification (rebased head `847bc74a7ceb256bd83e3c73518c1e39b494b0b4`)

Ran the actual Voyage embedding owner and shared SSRF-guarded HTTP implementation against a real authenticated localhost provider: multipart file upload → batch creation → pending status HTTP socket → deadline abort; no transport, clock, sleep, or HTTP response was mocked. Every request carried an isolated synthetic bearer credential.

```text
configured batch timeout: 120 ms
current main: total 524 ms; status request signal=false; socket remained open until provider replied
exact PR head: total 196 ms including real upload/create; status request signal=true; stalled TCP request aborted and socket closed; cause=TimeoutError
successful batch: multipart upload + create + status + output download -> embedding [1,2,3]
wait=false: existing actionable error preserved; zero status requests
```

Focused provider and shared-boundary proof: `node scripts/run-vitest.mjs extensions/voyage/embedding-batch.test.ts packages/memory-host-sdk/src/host/batch-runner.test.ts packages/memory-host-sdk/src/host/remote-http.test.ts` — **21 tests passed**. Fresh Codex Sol xhigh structured review: clean (0.98). Exact-head hosted **CI 30719607364: success**; **Workflow Sanity 30719607356: success**.

Official provider contract: https://docs.voyageai.com/docs/batch-inference . Detailed reproducible maintainer evidence: https://github.com/openclaw/openclaw/pull/111673#issuecomment-5153630993 . Original contributor author/email/July 20 author date and original patch identity are preserved.
