### PR TITLE
fix(openai): keep embedding batch waits within timeout

### DIFF
--- a/extensions/openai/embedding-batch.test.ts
+++ b/extensions/openai/embedding-batch.test.ts
@@ -1,6 +1,6 @@
 // Openai tests cover embedding batch plugin behavior.
 import { createServer } from "node:http";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { runOpenAiEmbeddingBatches } from "./embedding-batch.js";
 
 const jsonlEncoder = new TextEncoder();
@@ -82,7 +82,100 @@ async function closeServer(server: ReturnType<typeof createServer>): Promise<voi
   });
 }
 
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
 describe("OpenAI embedding batch output", () => {
+  it.each([
+    {
+      name: "pending status",
+      pollIntervalMs: 2_000,
+      expectedWaits: [500],
+      retryFirstStatus: false,
+    },
+    {
+      name: "retry backoff",
+      pollIntervalMs: 500,
+      expectedWaits: [500, 500],
+      retryFirstStatus: true,
+    },
+  ])("clamps $name waits to the remaining batch timeout", async (scenario) => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    let statusCalls = 0;
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = fetchInputUrl(input);
+      if (url.endsWith("/files") && init?.method === "POST") {
+        return jsonResponse({ id: "file-0" });
+      }
+      if (url.endsWith("/batches") && init?.method === "POST") {
+        return jsonResponse({ id: "batch-0", status: "in_progress" });
+      }
+      if (url.endsWith("/batches/batch-0")) {
+        statusCalls += 1;
+        if (scenario.retryFirstStatus && statusCalls === 1) {
+          return jsonResponse({ error: { message: "retry status" } }, 503);
+        }
+        return jsonResponse({ id: "batch-0", status: "completed", output_file_id: "output-0" });
+      }
+      if (url.endsWith("/files/output-0/content")) {
+        return new Response(
+          JSON.stringify({
+            custom_id: "0",
+            response: { status_code: 200, body: { data: [{ embedding: [1] }] } },
+          }),
+        );
+      }
+      return new Response("unexpected request", { status: 500 });
+    });
+
+    const result = runOpenAiEmbeddingBatches({
+      openAi: {
+        baseUrl: "https://openai-compatible.example/v1",
+        headers: { Authorization: "Bearer test" },
+        model: "text-embedding-3-small",
+        fetchImpl,
+      },
+      agentId: "main",
+      requests: [
+        {
+          custom_id: "0",
+          method: "POST",
+          url: "/v1/embeddings",
+          body: { model: "text-embedding-3-small", input: "payload" },
+        },
+      ],
+      wait: true,
+      concurrency: 1,
+      pollIntervalMs: scenario.pollIntervalMs,
+      timeoutMs: 1_000,
+      debug: (message) => {
+        if (!scenario.retryFirstStatus && message.includes("batch-0 in_progress")) {
+          vi.setSystemTime(500);
+        }
+      },
+    });
+    const rejection = expect(result).rejects.toThrow("openai batch batch-0 timed out after 1000ms");
+
+    for (const [index, waitMs] of scenario.expectedWaits.entries()) {
+      for (
+        let attempt = 0;
+        attempt < 100 && setTimeoutSpy.mock.calls.length < index + 1;
+        attempt++
+      ) {
+        await Promise.resolve();
+      }
+      expect(setTimeoutSpy).toHaveBeenCalledTimes(index + 1);
+      expect(setTimeoutSpy.mock.calls[index]?.[1]).toBe(waitMs);
+      await vi.advanceTimersByTimeAsync(waitMs);
+    }
+    await rejection;
+    expect(statusCalls).toBe(scenario.retryFirstStatus ? 1 : 0);
+  });
+
   it("reads a completed error file before downloading successful output", async () => {
     let outputFetched = false;
     const fetchImpl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {

--- a/extensions/openai/embedding-batch.test.ts
+++ b/extensions/openai/embedding-batch.test.ts
@@ -105,6 +105,12 @@ describe("OpenAI embedding batch output", () => {
     vi.useFakeTimers();
     vi.setSystemTime(0);
     const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    // Provider error-body reads own independent 10s chunk timers; only poll
+    // delays belong to the embedding batch's 1s operation deadline.
+    const pollTimeoutCalls = () =>
+      setTimeoutSpy.mock.calls.filter(([, timeout]) =>
+        scenario.expectedWaits.includes(Number(timeout)),
+      );
     let statusCalls = 0;
     const fetchImpl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = fetchInputUrl(input);
@@ -158,18 +164,17 @@ describe("OpenAI embedding batch output", () => {
         }
       },
     });
-    const rejection = expect(result).rejects.toThrow("openai batch batch-0 timed out after 1000ms");
+    const rejection = expect(result).rejects.toMatchObject({
+      message: "openai batch batch-0 timed out after 1000ms",
+      ...(scenario.retryFirstStatus ? { cause: { status: 503 } } : {}),
+    });
 
     for (const [index, waitMs] of scenario.expectedWaits.entries()) {
-      for (
-        let attempt = 0;
-        attempt < 100 && setTimeoutSpy.mock.calls.length < index + 1;
-        attempt++
-      ) {
+      for (let attempt = 0; attempt < 100 && pollTimeoutCalls().length < index + 1; attempt++) {
         await Promise.resolve();
       }
-      expect(setTimeoutSpy).toHaveBeenCalledTimes(index + 1);
-      expect(setTimeoutSpy.mock.calls[index]?.[1]).toBe(waitMs);
+      expect(pollTimeoutCalls()).toHaveLength(index + 1);
+      expect(pollTimeoutCalls()[index]?.[1]).toBe(waitMs);
       await vi.advanceTimersByTimeAsync(waitMs);
     }
     await rejection;

--- a/extensions/openai/embedding-batch.ts
+++ b/extensions/openai/embedding-batch.ts
@@ -24,8 +24,11 @@ import {
 } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
 import {
   assertOkOrThrowProviderError,
+  createProviderOperationDeadline,
   readProviderJsonResponse,
   readProviderTextResponse,
+  resolveProviderOperationTimeoutMs,
+  waitProviderOperationPollInterval,
 } from "openclaw/plugin-sdk/provider-http";
 import { normalizeStringEntries } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { OpenAiEmbeddingClient } from "./embedding-provider.js";
@@ -90,11 +93,13 @@ async function submitOpenAiBatch(params: {
 async function fetchOpenAiBatchStatus(params: {
   openAi: OpenAiEmbeddingClient;
   batchId: string;
+  signal?: AbortSignal;
 }): Promise<OpenAiBatchStatus> {
   return await fetchOpenAiBatchResource({
     openAi: params.openAi,
     path: `/batches/${params.batchId}`,
     label: "openai.batch-status",
+    signal: params.signal,
     parse: async (res) => readProviderJsonResponse<OpenAiBatchStatus>(res, "openai.batch-status"),
   });
 }
@@ -134,6 +139,7 @@ async function fetchOpenAiBatchResource<T>(params: {
   openAi: OpenAiEmbeddingClient;
   path: string;
   label: string;
+  signal?: AbortSignal;
   parse: (res: Response) => Promise<T>;
 }): Promise<T> {
   const baseUrl = normalizeBatchBaseUrl(params.openAi);
@@ -141,6 +147,7 @@ async function fetchOpenAiBatchResource<T>(params: {
     url: `${baseUrl}${params.path}`,
     ssrfPolicy: params.openAi.ssrfPolicy,
     fetchImpl: params.openAi.fetchImpl,
+    signal: params.signal,
     init: {
       headers: buildBatchHeaders(params.openAi, { json: true }),
     },
@@ -256,34 +263,52 @@ async function waitForOpenAiBatch(params: {
   debug?: (message: string, data?: Record<string, unknown>) => void;
   initial?: OpenAiBatchStatus;
 }): Promise<BatchCompletionResult> {
-  const start = Date.now();
+  const deadline = createProviderOperationDeadline({
+    label: `openai batch ${params.batchId}`,
+    timeoutMs: params.timeoutMs,
+  });
   const pollBackoff = createOpenAiBatchPollBackoff(params);
   let current: OpenAiBatchStatus | undefined = params.initial;
   while (true) {
     let status: OpenAiBatchStatus;
+    let statusSignal: AbortSignal | undefined;
     try {
-      status =
-        current ??
-        (await fetchOpenAiBatchStatus({
+      if (current) {
+        status = current;
+      } else {
+        statusSignal = AbortSignal.timeout(
+          resolveProviderOperationTimeoutMs({
+            deadline,
+            defaultTimeoutMs: params.timeoutMs,
+          }),
+        );
+        status = await fetchOpenAiBatchStatus({
           openAi: params.openAi,
           batchId: params.batchId,
-        }));
-    } catch (error) {
-      if (!params.wait || !isRetryableOpenAiBatchPollError(error)) {
-        throw error;
+          signal: statusSignal,
+        });
       }
-      if (Date.now() - start > params.timeoutMs) {
+    } catch (error) {
+      if (statusSignal?.aborted) {
         throw new Error(`openai batch ${params.batchId} timed out after ${params.timeoutMs}ms`, {
           cause: error,
         });
       }
+      if (!params.wait || !isRetryableOpenAiBatchPollError(error)) {
+        throw error;
+      }
       const delayMs = pollBackoff.nextDelayMs();
       params.debug?.(
-        `openai batch ${params.batchId} status check failed: ${formatOpenAiBatchDiagnostic(error)}; waiting ${delayMs}ms`,
+        `openai batch ${params.batchId} status check failed: ${formatOpenAiBatchDiagnostic(error)}; waiting up to ${delayMs}ms`,
       );
-      await new Promise((resolve) => {
-        setTimeout(resolve, delayMs);
-      });
+      try {
+        await waitProviderOperationPollInterval({ deadline, pollIntervalMs: delayMs });
+        resolveProviderOperationTimeoutMs({ deadline, defaultTimeoutMs: params.timeoutMs });
+      } catch {
+        throw new Error(`openai batch ${params.batchId} timed out after ${params.timeoutMs}ms`, {
+          cause: error,
+        });
+      }
       current = undefined;
       continue;
     }
@@ -316,18 +341,14 @@ async function waitForOpenAiBatch(params: {
     if (!params.wait) {
       throw new Error(`openai batch ${params.batchId} still ${state}; wait disabled`);
     }
-    if (Date.now() - start > params.timeoutMs) {
-      throw new Error(`openai batch ${params.batchId} timed out after ${params.timeoutMs}ms`);
-    }
     const delayMs = pollBackoff.nextDelayMs();
     params.debug?.(
       `openai batch ${params.batchId} ${state}${formatOpenAiBatchProgress(
         status,
-      )}; waiting ${delayMs}ms`,
+      )}; waiting up to ${delayMs}ms`,
     );
-    await new Promise((resolve) => {
-      setTimeout(resolve, delayMs);
-    });
+    await waitProviderOperationPollInterval({ deadline, pollIntervalMs: delayMs });
+    resolveProviderOperationTimeoutMs({ deadline, defaultTimeoutMs: params.timeoutMs });
     current = undefined;
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users waiting for OpenAI embedding batches could exceed the configured total timeout in either the normal pending-status path or the retryable status-error backoff path.

## Why This Change Was Made

Both waiter branches now share one provider operation deadline across backoff sleeps and status-request aborts while preserving the retry error as the timeout cause. Risk note: retry timing is user-visible for transient provider failures, so both pending and retry branches are covered through expiration.

## User Impact

OpenAI remote embedding batch waits now stop within the configured total budget, including after transient status errors.

## Evidence

I drove the real exported `runOpenAiEmbeddingBatches()` and real provider deadline/backoff code. A temporary loader replaced only upload/HTTP transport seams; the timer and status loop remained production code. The same harness against the pre-fix source showed the pending wait at 1000 ms and retry waits at `[500,1000]`; the fixed source clamps both remaining waits to 500 ms:

```text
$ node --import /tmp/openai-proof-register.mjs --import tsx --no-warnings /tmp/openai-timeout-proof.mts
before: {"pending":{"waits":[1000]},"retry":{"waits":[500,1000]}}
after:  {"pending":{"waits":[500]},"retry":{"waits":[500,500]}}
```

The regression cases keep each operation pending through expiration, verify no extra status request is sent, and retain the original retry failure as the timeout cause.

```text
$ node scripts/run-vitest.mjs extensions/openai/embedding-batch.test.ts
Test Files  1 passed (1)
Tests  11 passed (11)

$ CI=1 OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 pnpm check:changed --base upstream/main -- extensions/openai/embedding-batch.ts extensions/openai/embedding-batch.test.ts
exit 0
```

Live OpenAI credentials were not available; the proof exercises the deadline and retry behavior before provider-specific output processing.

AI-assisted: Codex helped implement and review the change; the behavior proof and validation above were run manually.

### Maintainer real-transport verification (rebased head `df7d68ae08f1183ba3d2f724e348bcb36b0fadae`)

Ran the unchanged production OpenAI embedding owner plus actual shared SSRF-guarded HTTP transport against a real localhost provider. Every request used an isolated synthetic bearer credential; multipart uploads, batch creation, status replies, real HTTP 503 errors, output downloads, abort signals, TCP socket cleanup, wall-clock timers, and retry loops were real—not mocked.

```text
scenario                         configured   untouched current main    exact rebased PR head
stalled status HTTP/TCP          120 ms       368 ms; socket unbounded  127 ms; socket aborted/closed; cause=TimeoutError
pending status poll              100 ms       203 ms; 2 status GETs     103 ms; 1 status GET; no post-deadline request
actual HTTP 503 retry/backoff    100 ms       146 ms; 2 status GETs     103 ms; 1 status GET; cause=ProviderHttpError(status=503)
healthy upload/create/output     100 ms       embedding=[1,2,3]         embedding=[1,2,3]
```

Focused changed-surface proof: `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/private/tmp/openclaw-vitest-s02-111675-openai-repaired node scripts/run-vitest.mjs extensions/openai/embedding-batch.test.ts` — **11 passed**. Fresh Codex Sol xhigh structured review: clean (0.98). Exact-head hosted run IDs: **CI 30720195761**; **Workflow Sanity 30720195766**.

Contributor commit `0ef01bcfc43cbbcff09a4853d8f86527ca6e48da` preserves @ZengWen-DT's original name, email, July 20 author date and unchanged production patch. Separately attributed maintainer test-only commit `df7d68ae08f1183ba3d2f724e348bcb36b0fadae` accounts for newer `main`'s independent provider error-body timers, keeps exact pending/retry poll assertions, and adds explicit retained HTTP 503 cause coverage.

There is **no persisted data model, SQLite schema, migration, embedding metadata, or embedding output change**; this patch changes only in-memory provider request/poll timeout enforcement, despite generic filename-based embedding/storage heuristics.

Official provider Batch API/status contract: https://developers.openai.com/api/reference/resources/batches . Detailed maintainer evidence: https://github.com/openclaw/openclaw/pull/111675#issuecomment-5153633303 .
