### PR TITLE
fix(ui): hide the custodian from the agent switcher

### DIFF
--- a/src/gateway/agent-list.test.ts
+++ b/src/gateway/agent-list.test.ts
@@ -1,11 +1,28 @@
 /**
  * Gateway agent-list RPC regression tests.
  */
+import fs from "node:fs/promises";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
+import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
 import { listGatewayAgentsBasic } from "./agent-list.js";
 
 describe("listGatewayAgentsBasic", () => {
+  it("omits reserved system-agent state directories from the discovered roster", async () => {
+    await withStateDirEnv("openclaw-agent-list-", async ({ stateDir }) => {
+      await Promise.all(
+        ["openclaw", "crestodian", "research"].map((id) =>
+          fs.mkdir(path.join(stateDir, "agents", id), { recursive: true }),
+        ),
+      );
+
+      const result = listGatewayAgentsBasic({});
+
+      expect(result.agents.map((agent) => agent.id)).toEqual(["main", "research"]);
+    });
+  });
+
   it("falls back to identity.name when the configured agent name is missing", () => {
     const cfg: OpenClawConfig = {
       session: { mainKey: "main" },

--- a/src/gateway/agent-list.ts
+++ b/src/gateway/agent-list.ts
@@ -8,6 +8,7 @@ import { resolveStateDir } from "../config/paths.js";
 import type { SessionScope } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizeAgentId, normalizeMainKey } from "../routing/session-key.js";
+import { isReservedSystemAgentId } from "../system-agent/agent-id.js";
 
 type GatewayAgentListRow = {
   id: string;
@@ -22,7 +23,7 @@ function listExistingAgentIdsFromDisk(): string[] {
     return entries
       .filter((entry) => entry.isDirectory())
       .map((entry) => normalizeAgentId(entry.name))
-      .filter(Boolean);
+      .filter((id) => id && !isReservedSystemAgentId(id));
   } catch {
     return [];
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users who opened the built-in OpenClaw setup agent would later see an extra `openclaw` entry in the normal Control UI agent switcher. The setup agent is a system custodian, not a selectable user agent.

## Why This Change Was Made

Disk-backed agent discovery now excludes the reserved system-agent identities `openclaw` and legacy `crestodian`. Explicitly configured entries remain visible for diagnosis, while ordinary discovered agents continue to appear normally.

This change was AI-assisted and reviewed with the repository's structured autoreview workflow.

## User Impact

The agent switcher now contains only normal user agents. Running or visiting the custodian no longer adds a misleading OpenClaw agent choice.

## Evidence

- `node scripts/run-vitest.mjs src/gateway/agent-list.test.ts` — 4 tests passed.
- Isolated operator-visible CLI proof with `main`, `research`, `openclaw`, and `crestodian` state directories returned only `main` and `research` in the agent roster.
- `node scripts/check-changed.mjs -- src/gateway/agent-list.ts src/gateway/agent-list.test.ts` — passed on Blacksmith Testbox run `29718250891`.
- `autoreview --mode commit --commit HEAD` — clean; no accepted or actionable findings.
