### PR TITLE
fix(gateway): make agent deletion transactional

### DIFF
--- a/src/agents/agent-create.test.ts
+++ b/src/agents/agent-create.test.ts
@@ -13,6 +13,8 @@ const mocks = vi.hoisted(() => ({
   rootRead: vi.fn(),
   rootWrite: vi.fn(),
   mkdir: vi.fn(),
+  readAgentDeletionJournal: vi.fn(() => undefined as Record<string, unknown> | undefined),
+  claimCompletedAgentDeletion: vi.fn(() => true),
 }));
 
 vi.mock("node:fs/promises", () => ({ default: { mkdir: mocks.mkdir } }));
@@ -35,6 +37,14 @@ vi.mock("./agent-scope.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("./agent-scope.js")>()),
   resolveAgentWorkspaceDir: mocks.resolveAgentWorkspaceDir,
   resolveAgentDir: mocks.resolveAgentDir,
+}));
+
+vi.mock("./agent-lifecycle-registry.js", () => ({
+  claimCompletedAgentDeletion: mocks.claimCompletedAgentDeletion,
+}));
+
+vi.mock("../state/agent-deletion-journal.js", () => ({
+  readAgentDeletionJournal: mocks.readAgentDeletionJournal,
 }));
 
 vi.mock("./workspace.js", async (importOriginal) => {
@@ -64,6 +74,8 @@ describe("createAgent", () => {
     vi.clearAllMocks();
     mocks.config = {};
     mocks.persisted = {};
+    mocks.readAgentDeletionJournal.mockReturnValue(undefined);
+    mocks.claimCompletedAgentDeletion.mockReturnValue(true);
     mocks.resolveAgentWorkspaceDir.mockReturnValue("/tmp/default-researcher");
     mocks.resolveAgentDir.mockReturnValue("/tmp/agent-researcher");
     mocks.ensureAgentWorkspace.mockImplementation(async ({ dir }: { dir: string }) => ({
@@ -74,9 +86,9 @@ describe("createAgent", () => {
     mocks.rootWrite.mockResolvedValue(undefined);
     mocks.mkdir.mockResolvedValue(undefined);
     mocks.parseBindingSpecs.mockReturnValue({ bindings: [], errors: [] });
-    mocks.withConfigMutationExclusive.mockImplementation(async (fn: () => Promise<unknown>) => {
-      return await fn();
-    });
+    mocks.withConfigMutationExclusive.mockImplementation(
+      async (fn: (config: Record<string, unknown>) => Promise<unknown>) => await fn(mocks.config),
+    );
     mocks.transformConfigFileWithRetry.mockImplementation(
       async ({
         transform,
@@ -207,6 +219,62 @@ describe("createAgent", () => {
     });
     expect(mocks.transformConfigFileWithRetry).toHaveBeenCalledOnce();
     expect(mocks.persisted).not.toHaveProperty("agents");
+  });
+
+  it("does not recreate an id with pending deletion cleanup", async () => {
+    mocks.readAgentDeletionJournal.mockReturnValue({
+      operationId: "delete-1",
+      cleanupCompleted: false,
+    });
+
+    await expect(createAgent({ name: "researcher" })).resolves.toMatchObject({
+      status: "error",
+      reason: "deletion-pending",
+    });
+    expect(mocks.transformConfigFileWithRetry).not.toHaveBeenCalled();
+  });
+
+  it("claims a completed deletion tombstone after recreating the id", async () => {
+    mocks.readAgentDeletionJournal.mockReturnValue({
+      operationId: "delete-1",
+      cleanupCompleted: true,
+    });
+
+    await expect(createAgent({ name: "researcher" })).resolves.toMatchObject({
+      status: "created",
+      agentId: "researcher",
+    });
+    expect(mocks.claimCompletedAgentDeletion).toHaveBeenCalledWith("researcher", "delete-1");
+  });
+
+  it("claims a recovered completed tombstone only once for an existing roster entry", async () => {
+    mocks.config = { agents: { list: [{ id: "researcher" }] } };
+    mocks.readAgentDeletionJournal.mockReturnValue({
+      operationId: "delete-1",
+      cleanupCompleted: true,
+    });
+
+    await expect(createAgent({ name: "researcher" })).resolves.toMatchObject({
+      status: "error",
+      reason: "already-exists",
+    });
+    expect(mocks.claimCompletedAgentDeletion).toHaveBeenCalledTimes(1);
+  });
+
+  it("retains a completed tombstone when creation returns an error result", async () => {
+    mocks.readAgentDeletionJournal.mockReturnValue({
+      operationId: "delete-1",
+      cleanupCompleted: true,
+    });
+    mocks.transformConfigFileWithRetry.mockResolvedValueOnce({
+      result: { status: "error", reason: "invalid-bindings", message: "invalid" },
+      nextConfig: {},
+    });
+
+    await expect(createAgent({ name: "researcher" })).resolves.toMatchObject({
+      status: "error",
+    });
+    expect(mocks.claimCompletedAgentDeletion).not.toHaveBeenCalled();
   });
 
   it("rejects a concurrent duplicate from the mutation snapshot", async () => {

--- a/src/agents/agent-create.ts
+++ b/src/agents/agent-create.ts
@@ -10,8 +10,10 @@ import { transformConfigFileWithRetry, withConfigMutationExclusive } from "../co
 import { resolveSessionTranscriptsDirForAgent } from "../config/sessions/paths.js";
 import { FsSafeError, root } from "../infra/fs-safe.js";
 import { DEFAULT_AGENT_ID, normalizeAgentId } from "../routing/session-key.js";
+import { readAgentDeletionJournal } from "../state/agent-deletion-journal.js";
 import { isReservedSystemAgentId } from "../system-agent/agent-id.js";
 import { resolveUserPath } from "../utils.js";
+import { claimCompletedAgentDeletion } from "./agent-lifecycle-registry.js";
 import { resolveAgentDir, resolveAgentWorkspaceDir } from "./agent-scope.js";
 import {
   createAgentIdentityConfig,
@@ -37,6 +39,7 @@ type CreateAgentResult =
         | "invalid-name"
         | "reserved-id"
         | "already-exists"
+        | "deletion-pending"
         | "invalid-bindings"
         | "unsafe-identity-file";
       agentId?: string;
@@ -114,7 +117,25 @@ export async function createAgent(params: CreateAgentParams): Promise<CreateAgen
   const transformConfig = params.transformConfig ?? transformConfigFileWithRetry;
 
   try {
-    return await withConfigMutationExclusive(async () => {
+    return await withConfigMutationExclusive(async (lockedConfig) => {
+      const deletion = readAgentDeletionJournal(agentId);
+      if (deletion && !deletion.cleanupCompleted) {
+        return createError(
+          "deletion-pending",
+          `agent "${agentId}" deletion cleanup is still pending`,
+          agentId,
+        );
+      }
+      let tombstoneClaimed = false;
+      if (
+        deletion?.cleanupCompleted &&
+        findAgentEntryIndex(listAgentEntries(lockedConfig), agentId) >= 0
+      ) {
+        if (!claimCompletedAgentDeletion(agentId, deletion.operationId)) {
+          throw new Error(`agent "${agentId}" deletion tombstone changed during creation`);
+        }
+        tombstoneClaimed = true;
+      }
       const committed = await transformConfig<CreateAgentResult>({
         afterWrite: { mode: "auto" },
         maxAttempts: 1,
@@ -182,6 +203,14 @@ export async function createAgent(params: CreateAgentParams): Promise<CreateAgen
           };
         },
       });
+      if (
+        deletion?.cleanupCompleted &&
+        !tombstoneClaimed &&
+        committed.result?.status === "created" &&
+        !claimCompletedAgentDeletion(agentId, deletion.operationId)
+      ) {
+        throw new Error(`agent "${agentId}" deletion tombstone changed during creation`);
+      }
       return committed.result!;
     });
   } catch (error) {

--- a/src/agents/agent-dir-registry.test.ts
+++ b/src/agents/agent-dir-registry.test.ts
@@ -1,20 +1,87 @@
+import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
+  isPathOwnedByAnotherRegisteredAgent,
   registerResolvedAgentDir,
   resolveRegisteredAgentIdForDir,
   unregisterResolvedAgentDir,
 } from "./agent-dir-registry.js";
 
 describe("agent directory registry", () => {
-  it("does not let stale cleanup remove a directory's current owner", () => {
+  it("unregisters only the requested owner", () => {
     const agentDir = path.join("/tmp", `openclaw-agent-dir-registry-${process.pid}`);
     registerResolvedAgentDir({ agentId: "first", agentDir });
     registerResolvedAgentDir({ agentId: "second", agentDir });
 
-    expect(unregisterResolvedAgentDir({ agentId: "first", agentDir })).toBe(false);
+    expect(resolveRegisteredAgentIdForDir(agentDir)).toBeUndefined();
+    expect(unregisterResolvedAgentDir({ agentId: "first", agentDir })).toBe(true);
     expect(resolveRegisteredAgentIdForDir(agentDir)).toBe("second");
     expect(unregisterResolvedAgentDir({ agentId: "second", agentDir })).toBe(true);
     expect(resolveRegisteredAgentIdForDir(agentDir)).toBeUndefined();
+  });
+
+  it("detects registered ownership on either side of a cleanup boundary", () => {
+    const root = path.join("/tmp", `openclaw-agent-dir-overlap-${process.pid}`);
+    const agentDir = path.join(root, "agent");
+    registerResolvedAgentDir({ agentId: "current", agentDir });
+
+    expect(
+      isPathOwnedByAnotherRegisteredAgent({
+        agentId: "deleted",
+        pathname: root,
+      }),
+    ).toBe(true);
+    expect(
+      isPathOwnedByAnotherRegisteredAgent({
+        agentId: "deleted",
+        pathname: path.join(agentDir, "openclaw-agent.sqlite"),
+      }),
+    ).toBe(true);
+    expect(
+      isPathOwnedByAnotherRegisteredAgent({
+        agentId: "current",
+        pathname: root,
+      }),
+    ).toBe(false);
+
+    unregisterResolvedAgentDir({ agentId: "current", agentDir });
+  });
+
+  it("keeps ownership stable through a symlinked parent after the agent dir is removed", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-agent-dir-registry-"));
+    const realRoot = path.join(root, "real");
+    const linkedRoot = path.join(root, "linked");
+    const realAgentDir = path.join(realRoot, "agent");
+    const linkedAgentDir = path.join(linkedRoot, "agent");
+    fs.mkdirSync(realAgentDir, { recursive: true });
+    fs.symlinkSync(realRoot, linkedRoot, process.platform === "win32" ? "junction" : "dir");
+
+    try {
+      registerResolvedAgentDir({ agentId: "current", agentDir: realAgentDir });
+      expect(resolveRegisteredAgentIdForDir(linkedAgentDir)).toBe("current");
+      registerResolvedAgentDir({ agentId: "deleted", agentDir: linkedAgentDir });
+      expect(resolveRegisteredAgentIdForDir(realAgentDir)).toBeUndefined();
+      expect(
+        isPathOwnedByAnotherRegisteredAgent({
+          agentId: "deleted",
+          pathname: linkedAgentDir,
+        }),
+      ).toBe(true);
+      expect(unregisterResolvedAgentDir({ agentId: "deleted", agentDir: linkedAgentDir })).toBe(
+        true,
+      );
+      expect(resolveRegisteredAgentIdForDir(realAgentDir)).toBe("current");
+
+      fs.rmSync(realAgentDir, { recursive: true });
+      expect(unregisterResolvedAgentDir({ agentId: "current", agentDir: linkedAgentDir })).toBe(
+        true,
+      );
+      expect(resolveRegisteredAgentIdForDir(realAgentDir)).toBeUndefined();
+    } finally {
+      unregisterResolvedAgentDir({ agentId: "current", agentDir: linkedAgentDir });
+      fs.rmSync(root, { recursive: true, force: true });
+    }
   });
 });

--- a/src/agents/agent-dir-registry.test.ts
+++ b/src/agents/agent-dir-registry.test.ts
@@ -1,0 +1,20 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  registerResolvedAgentDir,
+  resolveRegisteredAgentIdForDir,
+  unregisterResolvedAgentDir,
+} from "./agent-dir-registry.js";
+
+describe("agent directory registry", () => {
+  it("does not let stale cleanup remove a directory's current owner", () => {
+    const agentDir = path.join("/tmp", `openclaw-agent-dir-registry-${process.pid}`);
+    registerResolvedAgentDir({ agentId: "first", agentDir });
+    registerResolvedAgentDir({ agentId: "second", agentDir });
+
+    expect(unregisterResolvedAgentDir({ agentId: "first", agentDir })).toBe(false);
+    expect(resolveRegisteredAgentIdForDir(agentDir)).toBe("second");
+    expect(unregisterResolvedAgentDir({ agentId: "second", agentDir })).toBe(true);
+    expect(resolveRegisteredAgentIdForDir(agentDir)).toBeUndefined();
+  });
+});

--- a/src/agents/agent-dir-registry.ts
+++ b/src/agents/agent-dir-registry.ts
@@ -1,14 +1,33 @@
 /** Process-local reverse registry from prepared agent directories to agent ids. */
+import fs from "node:fs";
 import path from "node:path";
+import { isPathInside } from "../infra/path-guards.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import { resolveUserPath } from "../utils.js";
 
 // Process-local registry mapping resolved agent directories back to agent ids.
 // It lets later runtime paths recover scope from an already-prepared agent dir.
-const agentIdByDir = new Map<string, string>();
+const agentIdsByDir = new Map<string, Set<string>>();
 
-function normalizeAgentDirKey(agentDir: string, env: NodeJS.ProcessEnv = process.env): string {
-  return path.resolve(resolveUserPath(agentDir, env));
+export function normalizeAgentDirRegistryPath(
+  agentDir: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const resolved = path.resolve(resolveUserPath(agentDir, env));
+  const missingSegments: string[] = [];
+  let cursor = resolved;
+  while (true) {
+    try {
+      return path.join(fs.realpathSync.native(cursor), ...missingSegments.toReversed());
+    } catch {
+      const parent = path.dirname(cursor);
+      if (parent === cursor) {
+        return resolved;
+      }
+      missingSegments.push(path.basename(cursor));
+      cursor = parent;
+    }
+  }
 }
 
 /** Register a resolved agent directory for later reverse lookup. */
@@ -17,10 +36,10 @@ export function registerResolvedAgentDir(params: {
   agentDir: string;
   env?: NodeJS.ProcessEnv;
 }): void {
-  agentIdByDir.set(
-    normalizeAgentDirKey(params.agentDir, params.env),
-    normalizeAgentId(params.agentId),
-  );
+  const key = normalizeAgentDirRegistryPath(params.agentDir, params.env);
+  const agentIds = agentIdsByDir.get(key) ?? new Set<string>();
+  agentIds.add(normalizeAgentId(params.agentId));
+  agentIdsByDir.set(key, agentIds);
 }
 
 /** Remove a reverse lookup only while it still belongs to the expected agent. */
@@ -29,11 +48,15 @@ export function unregisterResolvedAgentDir(params: {
   agentDir: string;
   env?: NodeJS.ProcessEnv;
 }): boolean {
-  const key = normalizeAgentDirKey(params.agentDir, params.env);
-  if (agentIdByDir.get(key) !== normalizeAgentId(params.agentId)) {
+  const key = normalizeAgentDirRegistryPath(params.agentDir, params.env);
+  const agentIds = agentIdsByDir.get(key);
+  if (!agentIds?.delete(normalizeAgentId(params.agentId))) {
     return false;
   }
-  return agentIdByDir.delete(key);
+  if (agentIds.size === 0) {
+    agentIdsByDir.delete(key);
+  }
+  return true;
 }
 
 /** Resolve the agent id previously registered for an agent directory. */
@@ -41,5 +64,27 @@ export function resolveRegisteredAgentIdForDir(
   agentDir: string,
   env?: NodeJS.ProcessEnv,
 ): string | undefined {
-  return agentIdByDir.get(normalizeAgentDirKey(agentDir, env));
+  const agentIds = agentIdsByDir.get(normalizeAgentDirRegistryPath(agentDir, env));
+  return agentIds?.size === 1 ? agentIds.values().next().value : undefined;
+}
+
+/** Whether a path overlaps a directory currently owned by another agent. */
+export function isPathOwnedByAnotherRegisteredAgent(params: {
+  agentId: string;
+  pathname: string;
+  env?: NodeJS.ProcessEnv;
+}): boolean {
+  const pathname = normalizeAgentDirRegistryPath(params.pathname, params.env);
+  const agentId = normalizeAgentId(params.agentId);
+  for (const [registeredDir, ownerIds] of agentIdsByDir) {
+    if (
+      [...ownerIds].some((ownerId) => ownerId !== agentId) &&
+      (registeredDir === pathname ||
+        isPathInside(registeredDir, pathname) ||
+        isPathInside(pathname, registeredDir))
+    ) {
+      return true;
+    }
+  }
+  return false;
 }

--- a/src/agents/agent-dir-registry.ts
+++ b/src/agents/agent-dir-registry.ts
@@ -23,6 +23,19 @@ export function registerResolvedAgentDir(params: {
   );
 }
 
+/** Remove a reverse lookup only while it still belongs to the expected agent. */
+export function unregisterResolvedAgentDir(params: {
+  agentId: string;
+  agentDir: string;
+  env?: NodeJS.ProcessEnv;
+}): boolean {
+  const key = normalizeAgentDirKey(params.agentDir, params.env);
+  if (agentIdByDir.get(key) !== normalizeAgentId(params.agentId)) {
+    return false;
+  }
+  return agentIdByDir.delete(key);
+}
+
 /** Resolve the agent id previously registered for an agent directory. */
 export function resolveRegisteredAgentIdForDir(
   agentDir: string,

--- a/src/agents/agent-lifecycle-registry.test.ts
+++ b/src/agents/agent-lifecycle-registry.test.ts
@@ -1,0 +1,120 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  claimCompletedAgentDeletionJournal,
+  readAgentDeletionJournal,
+} from "../state/agent-deletion-journal.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import {
+  beginAgentDeletion,
+  claimCompletedAgentDeletion,
+  isAgentDeletionBlocked,
+} from "./agent-lifecycle-registry.js";
+
+const tempDirs: string[] = [];
+
+function createOptions() {
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-agent-delete-"));
+  tempDirs.push(stateDir);
+  return { env: { ...process.env, OPENCLAW_STATE_DIR: stateDir } };
+}
+
+function createEntry(agentId: string) {
+  return {
+    agentId,
+    agentDir: `/agents/${agentId}`,
+    workspaceDir: `/workspaces/${agentId}`,
+    sessionsDir: `/sessions/${agentId}`,
+  };
+}
+
+afterEach(() => {
+  closeOpenClawStateDatabaseForTest();
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("agent lifecycle registry", () => {
+  it("keeps a committed deletion fenced until recreation claims cleanup", () => {
+    const options = createOptions();
+    const deletion = beginAgentDeletion(createEntry("Recreated-Agent"), options);
+
+    expect(isAgentDeletionBlocked("recreated-agent", options)).toBe(true);
+    deletion.commit();
+    expect(readAgentDeletionJournal("RECREATED-AGENT", options)).toMatchObject({
+      agentId: "recreated-agent",
+      agentDir: "/agents/Recreated-Agent",
+    });
+    expect(isAgentDeletionBlocked("RECREATED-AGENT", options)).toBe(true);
+
+    deletion.finish();
+    expect(readAgentDeletionJournal("recreated-agent", options)).toMatchObject({
+      cleanupCompleted: true,
+    });
+    expect(isAgentDeletionBlocked("recreated-agent", options)).toBe(true);
+
+    expect(
+      claimCompletedAgentDeletion("recreated-agent", deletion.entry.operationId, options),
+    ).toBe(true);
+    expect(readAgentDeletionJournal("recreated-agent", options)).toBeUndefined();
+    expect(isAgentDeletionBlocked("recreated-agent", options)).toBe(false);
+  });
+
+  it("releases the durable fence when deletion rolls back before roster commit", () => {
+    const options = createOptions();
+    const deletion = beginAgentDeletion(createEntry("rollback-agent"), options);
+    deletion.rollback();
+
+    expect(readAgentDeletionJournal("rollback-agent", options)).toBeUndefined();
+    expect(isAgentDeletionBlocked("rollback-agent", options)).toBe(false);
+  });
+
+  it("does not let a stale operation clear a journal claimed by recovery", () => {
+    const options = createOptions();
+    const first = beginAgentDeletion(createEntry("claimed-agent"), options);
+    const recovery = beginAgentDeletion(createEntry("claimed-agent"), options);
+
+    first.finish();
+    expect(readAgentDeletionJournal("claimed-agent", options)?.operationId).toBe(
+      recovery.entry.operationId,
+    );
+    expect(isAgentDeletionBlocked("claimed-agent", options)).toBe(true);
+
+    recovery.finish();
+    expect(isAgentDeletionBlocked("claimed-agent", options)).toBe(true);
+    expect(claimCompletedAgentDeletion("claimed-agent", recovery.entry.operationId, options)).toBe(
+      true,
+    );
+    expect(isAgentDeletionBlocked("claimed-agent", options)).toBe(false);
+  });
+
+  it("lets recovery roll back after a stale operation also tries to roll back", () => {
+    const options = createOptions();
+    const first = beginAgentDeletion(createEntry("rollback-claimed-agent"), options);
+    const recovery = beginAgentDeletion(createEntry("rollback-claimed-agent"), options);
+
+    first.rollback();
+    expect(isAgentDeletionBlocked("rollback-claimed-agent", options)).toBe(true);
+    recovery.rollback();
+    expect(isAgentDeletionBlocked("rollback-claimed-agent", options)).toBe(false);
+  });
+
+  it("clears stale process state after another process claims the tombstone", () => {
+    const options = createOptions();
+    const deletion = beginAgentDeletion(createEntry("cross-process-agent"), options);
+    deletion.commit();
+    deletion.finish();
+
+    expect(
+      claimCompletedAgentDeletionJournal(
+        "cross-process-agent",
+        deletion.entry.operationId,
+        options,
+      ),
+    ).toBe(true);
+    expect(isAgentDeletionBlocked("cross-process-agent", options)).toBe(false);
+  });
+});

--- a/src/agents/agent-lifecycle-registry.test.ts
+++ b/src/agents/agent-lifecycle-registry.test.ts
@@ -80,13 +80,25 @@ describe("agent lifecycle registry", () => {
     const cleanupPaths = [
       {
         path: "/real/workspace",
+        canonicalPath: "/real/workspace",
+        parentPath: "/real",
         kind: "target" as const,
         sourcePaths: ["/linked/workspace"],
+        dev: 1,
+        ino: 1,
+        coversDescendants: true,
+        done: false,
       },
       {
         path: "/linked/workspace",
+        canonicalPath: "/linked/workspace",
+        parentPath: "/linked",
         kind: "symlink" as const,
         sourcePaths: ["/linked/workspace"],
+        dev: 1,
+        ino: 2,
+        coversDescendants: false,
+        done: false,
       },
     ];
     first.fenceCleanupPaths(cleanupPaths);

--- a/src/agents/agent-lifecycle-registry.test.ts
+++ b/src/agents/agent-lifecycle-registry.test.ts
@@ -16,7 +16,9 @@ import {
 const tempDirs: string[] = [];
 
 function createOptions() {
-  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-agent-delete-"));
+  const stateDir = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-agent-delete-")),
+  );
   tempDirs.push(stateDir);
   return { env: { ...process.env, OPENCLAW_STATE_DIR: stateDir } };
 }
@@ -70,6 +72,32 @@ describe("agent lifecycle registry", () => {
 
     expect(readAgentDeletionJournal("rollback-agent", options)).toBeUndefined();
     expect(isAgentDeletionBlocked("rollback-agent", options)).toBe(false);
+  });
+
+  it("retains pre-resolved cleanup targets when recovery claims the journal", () => {
+    const options = createOptions();
+    const first = beginAgentDeletion(createEntry("cleanup-recovery-agent"), options);
+    const cleanupPaths = [
+      {
+        path: "/real/workspace",
+        kind: "target" as const,
+        sourcePaths: ["/linked/workspace"],
+      },
+      {
+        path: "/linked/workspace",
+        kind: "symlink" as const,
+        sourcePaths: ["/linked/workspace"],
+      },
+    ];
+    first.fenceCleanupPaths(cleanupPaths);
+
+    const recovery = beginAgentDeletion(createEntry("cleanup-recovery-agent"), options);
+
+    expect(recovery.entry.cleanupPaths).toEqual(cleanupPaths);
+    expect(readAgentDeletionJournal("cleanup-recovery-agent", options)?.cleanupPaths).toEqual(
+      cleanupPaths,
+    );
+    recovery.rollback();
   });
 
   it("does not let a stale operation clear a journal claimed by recovery", () => {

--- a/src/agents/agent-lifecycle-registry.ts
+++ b/src/agents/agent-lifecycle-registry.ts
@@ -9,6 +9,8 @@ import {
   readAgentDeletionJournal,
   removeAgentDeletionJournal,
   updateAgentDeletionJournalDatabasePaths,
+  updateAgentDeletionJournalCleanupPaths,
+  type AgentDeletionJournalCleanupPath,
   type AgentDeletionJournalEntry,
 } from "../state/agent-deletion-journal.js";
 import type { OpenClawStateDatabaseOptions } from "../state/openclaw-state-db-contract.js";
@@ -36,13 +38,23 @@ function lifecycleKey(agentId: string, options: OpenClawStateDatabaseOptions): s
 export function beginAgentDeletion(
   entry: Omit<
     AgentDeletionJournalEntry,
-    "createdAt" | "operationId" | "cleanupCompleted" | "databasePaths" | "deleteFiles"
-  > & { databasePaths?: string[]; deleteFiles?: boolean },
+    | "createdAt"
+    | "operationId"
+    | "cleanupCompleted"
+    | "databasePaths"
+    | "cleanupPaths"
+    | "deleteFiles"
+  > & {
+    databasePaths?: string[];
+    cleanupPaths?: AgentDeletionJournalCleanupPath[];
+    deleteFiles?: boolean;
+  },
   options: OpenClawStateDatabaseOptions = {},
 ): {
   entry: AgentDeletionJournalEntry;
   commit: () => void;
   fenceDatabasePaths: (paths: readonly string[]) => void;
+  fenceCleanupPaths: (paths: readonly AgentDeletionJournalCleanupPath[]) => void;
   finish: () => void;
   rollback: () => void;
 } {
@@ -62,6 +74,12 @@ export function beginAgentDeletion(
         throw new Error(`Failed to fence database cleanup paths for agent ${id}.`);
       }
       journal.databasePaths = [...new Set(paths.map((entryPath) => path.resolve(entryPath)))];
+    },
+    fenceCleanupPaths: (paths) => {
+      if (!updateAgentDeletionJournalCleanupPaths(id, operationId, paths, options)) {
+        throw new Error(`Failed to fence cleanup paths for agent ${id}.`);
+      }
+      journal.cleanupPaths = [...paths];
     },
     finish: () => {
       if (completeAgentDeletionJournal(id, operationId, options)) {

--- a/src/agents/agent-lifecycle-registry.ts
+++ b/src/agents/agent-lifecycle-registry.ts
@@ -8,6 +8,7 @@ import {
   completeAgentDeletionJournal,
   readAgentDeletionJournal,
   removeAgentDeletionJournal,
+  updateAgentDeletionJournalDatabasePaths,
   type AgentDeletionJournalEntry,
 } from "../state/agent-deletion-journal.js";
 import type { OpenClawStateDatabaseOptions } from "../state/openclaw-state-db-contract.js";
@@ -35,12 +36,13 @@ function lifecycleKey(agentId: string, options: OpenClawStateDatabaseOptions): s
 export function beginAgentDeletion(
   entry: Omit<
     AgentDeletionJournalEntry,
-    "createdAt" | "operationId" | "cleanupCompleted" | "deleteFiles"
-  > & { deleteFiles?: boolean },
+    "createdAt" | "operationId" | "cleanupCompleted" | "databasePaths" | "deleteFiles"
+  > & { databasePaths?: string[]; deleteFiles?: boolean },
   options: OpenClawStateDatabaseOptions = {},
 ): {
   entry: AgentDeletionJournalEntry;
   commit: () => void;
+  fenceDatabasePaths: (paths: readonly string[]) => void;
   finish: () => void;
   rollback: () => void;
 } {
@@ -55,6 +57,12 @@ export function beginAgentDeletion(
   return {
     entry: journal,
     commit: () => agentLifecycle.set(key, "deleted"),
+    fenceDatabasePaths: (paths) => {
+      if (!updateAgentDeletionJournalDatabasePaths(id, operationId, paths, options)) {
+        throw new Error(`Failed to fence database cleanup paths for agent ${id}.`);
+      }
+      journal.databasePaths = [...new Set(paths.map((entryPath) => path.resolve(entryPath)))];
+    },
     finish: () => {
       if (completeAgentDeletionJournal(id, operationId, options)) {
         agentLifecycle.set(key, "deleted");

--- a/src/agents/agent-lifecycle-registry.ts
+++ b/src/agents/agent-lifecycle-registry.ts
@@ -1,0 +1,97 @@
+import crypto from "node:crypto";
+import path from "node:path";
+import { normalizeAgentId } from "../routing/session-key.js";
+import { resolveGlobalMap } from "../shared/global-singleton.js";
+import {
+  beginAgentDeletionJournal,
+  claimCompletedAgentDeletionJournal,
+  completeAgentDeletionJournal,
+  readAgentDeletionJournal,
+  removeAgentDeletionJournal,
+  type AgentDeletionJournalEntry,
+} from "../state/agent-deletion-journal.js";
+import type { OpenClawStateDatabaseOptions } from "../state/openclaw-state-db-contract.js";
+import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
+
+const AGENT_LIFECYCLE_KEY = Symbol.for("openclaw.agentLifecycle");
+const agentLifecycle = resolveGlobalMap<string, "deleting" | "deleted">(AGENT_LIFECYCLE_KEY);
+
+export class AgentDeletionAuthorityRollbackError extends AggregateError {}
+
+export class AgentDeletionCommitUncertainError extends Error {
+  constructor(cause: unknown) {
+    super(cause instanceof Error ? cause.message : String(cause), { cause });
+  }
+}
+
+function lifecycleKey(agentId: string, options: OpenClawStateDatabaseOptions): string {
+  const databasePath = path.resolve(
+    options.path ?? resolveOpenClawStateSqlitePath(options.env ?? process.env),
+  );
+  return `${databasePath}\0${agentId}`;
+}
+
+/** Fence authority producers while an agent deletion is pending or committed. */
+export function beginAgentDeletion(
+  entry: Omit<
+    AgentDeletionJournalEntry,
+    "createdAt" | "operationId" | "cleanupCompleted" | "deleteFiles"
+  > & { deleteFiles?: boolean },
+  options: OpenClawStateDatabaseOptions = {},
+): {
+  entry: AgentDeletionJournalEntry;
+  commit: () => void;
+  finish: () => void;
+  rollback: () => void;
+} {
+  const id = normalizeAgentId(entry.agentId);
+  const key = lifecycleKey(id, options);
+  const operationId = crypto.randomUUID();
+  const journal = beginAgentDeletionJournal(
+    { ...entry, agentId: id, operationId, deleteFiles: entry.deleteFiles !== false },
+    options,
+  );
+  agentLifecycle.set(key, "deleting");
+  return {
+    entry: journal,
+    commit: () => agentLifecycle.set(key, "deleted"),
+    finish: () => {
+      if (completeAgentDeletionJournal(id, operationId, options)) {
+        agentLifecycle.set(key, "deleted");
+      }
+    },
+    rollback: () => {
+      if (removeAgentDeletionJournal(id, operationId, options)) {
+        agentLifecycle.delete(key);
+      }
+    },
+  };
+}
+
+/** Atomically claim a completed deletion tombstone for a newly created identity. */
+export function claimCompletedAgentDeletion(
+  agentId: string,
+  operationId: string,
+  options: OpenClawStateDatabaseOptions = {},
+): boolean {
+  const id = normalizeAgentId(agentId);
+  const removed = claimCompletedAgentDeletionJournal(id, operationId, options);
+  if (removed) {
+    agentLifecycle.delete(lifecycleKey(id, options));
+  }
+  return removed;
+}
+
+/** Return whether this process must refuse new authority for an agent id. */
+export function isAgentDeletionBlocked(
+  agentId: string,
+  options: OpenClawStateDatabaseOptions = {},
+): boolean {
+  const id = normalizeAgentId(agentId);
+  const key = lifecycleKey(id, options);
+  const journal = readAgentDeletionJournal(id, options);
+  if (!journal) {
+    agentLifecycle.delete(key);
+  }
+  return Boolean(journal);
+}

--- a/src/config/mutate.ts
+++ b/src/config/mutate.ts
@@ -318,8 +318,13 @@ async function withConfigMutationSnapshotLock<T>(
  * Run a multi-phase operation under the canonical cross-process write lock.
  * Nested mutation helpers are reentrant through activeConfigMutationLocks.
  */
-export async function withConfigMutationExclusive<T>(fn: () => Promise<T>): Promise<T> {
-  return await withConfigMutationSnapshotLock({}, async () => await fn());
+export async function withConfigMutationExclusive<T>(
+  fn: (config: OpenClawConfig) => Promise<T>,
+): Promise<T> {
+  return await withConfigMutationSnapshotLock(
+    {},
+    async (prepared) => await fn(prepared.snapshot.sourceConfig),
+  );
 }
 
 function getChangedTopLevelKeys(base: unknown, next: unknown): string[] {

--- a/src/cron/service.ts
+++ b/src/cron/service.ts
@@ -120,6 +120,10 @@ export class CronService implements CronServiceContract {
     return await ops.remove(this.state, id);
   }
 
+  async removeAgentJobsTransactional<T>(agentId: string, commit: () => Promise<T>): Promise<T> {
+    return await ops.removeAgentJobsTransactional(this.state, agentId, commit);
+  }
+
   async run(
     id: string,
     mode?: "due" | "force",
@@ -152,7 +156,7 @@ export class CronService implements CronServiceContract {
   }
 
   getDefaultAgentId(): string | undefined {
-    return this.state.deps.defaultAgentId;
+    return this.state.deps.resolveDefaultAgentId?.() ?? this.state.deps.defaultAgentId;
   }
 
   wake(opts: { mode: CronWakeMode; text: string; sessionKey?: string; agentId?: string }) {

--- a/src/cron/service.ts
+++ b/src/cron/service.ts
@@ -156,7 +156,7 @@ export class CronService implements CronServiceContract {
   }
 
   getDefaultAgentId(): string | undefined {
-    return this.state.deps.resolveDefaultAgentId?.() ?? this.state.deps.defaultAgentId;
+    return this.state.deps.defaultAgentId;
   }
 
   wake(opts: { mode: CronWakeMode; text: string; sessionKey?: string; agentId?: string }) {

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -4,6 +4,10 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
+import {
+  AgentDeletionAuthorityRollbackError,
+  AgentDeletionCommitUncertainError,
+} from "../../agents/agent-lifecycle-registry.js";
 import { enqueueCommandInLane, type CommandLaneTaskMarker } from "../../process/command-queue.js";
 import { runWithGatewayIndependentRootWorkContinuation } from "../../process/gateway-work-admission.js";
 import { CommandLane } from "../../process/lanes.js";
@@ -387,12 +391,19 @@ function resolveJobLastRunStatus(job: CronJob): CronJobsLastRunStatusFilter {
   return job.state.lastRunStatus ?? job.state.lastStatus ?? "unknown";
 }
 
-function resolveEffectiveJobAgentId(job: CronJob, defaultAgentId: string | undefined) {
+function resolveEffectiveJobAgentId(
+  job: { agentId?: string | null },
+  defaultAgentId: string | undefined,
+) {
   return (
     normalizeOptionalAgentId(job.agentId) ??
     normalizeOptionalAgentId(defaultAgentId) ??
     DEFAULT_AGENT_ID
   );
+}
+
+function resolveCurrentDefaultAgentId(state: CronServiceState): string | undefined {
+  return state.deps.resolveDefaultAgentId?.() ?? state.deps.defaultAgentId;
 }
 
 /** Lists a filtered, sorted, bounded page of cron jobs for CLI/RPC callers. */
@@ -568,6 +579,10 @@ export async function add(state: CronServiceState, input: CronJobCreate, opts?: 
   return await locked(state, async () => {
     warnIfDisabled(state, "add");
     await ensureLoaded(state, { skipRecompute: true });
+    const agentId = resolveEffectiveJobAgentId(input, resolveCurrentDefaultAgentId(state));
+    if (state.deps.isAgentAvailable?.(agentId) === false) {
+      throw new Error(`cron job agent is unavailable: ${agentId}`);
+    }
     const normalizedId = normalizeOptionalString(input.id);
     if (input.id !== undefined && !normalizedId) {
       throw new Error("cron job id must not be blank");
@@ -678,6 +693,12 @@ async function updateLoadedJob(params: {
     scheduleValidationNowMs: now,
     cronConfig: state.deps.cronConfig,
   });
+  if (patch.agentId !== undefined) {
+    const agentId = resolveEffectiveJobAgentId(nextJob, resolveCurrentDefaultAgentId(state));
+    if (state.deps.isAgentAvailable?.(agentId) === false) {
+      throw new Error(`cron job agent is unavailable: ${agentId}`);
+    }
+  }
   finalizeUpdatedJob({
     job,
     nextJob,
@@ -736,6 +757,67 @@ export async function remove(state: CronServiceState, id: string) {
       emit(state, { jobId: id, action: "removed", job: removedJob });
     }
     return { ok: true, removed } as const;
+  });
+}
+
+/** Remove one agent's jobs while holding the cron lock across an external roster commit. */
+export async function removeAgentJobsTransactional<T>(
+  state: CronServiceState,
+  agentId: string,
+  commit: () => Promise<T>,
+): Promise<T> {
+  return await locked(state, async () => {
+    warnIfDisabled(state, "remove agent jobs");
+    await ensureLoaded(state, { skipRecompute: true });
+    const id = normalizeOptionalAgentId(agentId);
+    if (!id || !state.store) {
+      return await commit();
+    }
+    const defaultAgentId = resolveCurrentDefaultAgentId(state);
+    const removedJobs = state.store.jobs.filter(
+      (job) => resolveEffectiveJobAgentId(job, defaultAgentId) === id,
+    );
+    if (removedJobs.length === 0) {
+      return await commit();
+    }
+    const snapshot = snapshotStoreForRollback(state);
+    state.store.jobs = state.store.jobs.filter(
+      (job) => resolveEffectiveJobAgentId(job, defaultAgentId) !== id,
+    );
+    recomputeNextRunsForMaintenance(state);
+    await persistOrRestore(state, snapshot);
+    let result: T;
+    try {
+      result = await commit();
+    } catch (error) {
+      if (error instanceof AgentDeletionCommitUncertainError) {
+        armTimer(state);
+        for (const job of removedJobs) {
+          emit(state, { jobId: job.id, action: "removed", job });
+        }
+        throw error;
+      }
+      state.store = snapshot.store;
+      state.durableNextRunAtMsByJobId = snapshot.durableNextRunAtMsByJobId;
+      try {
+        if (!(await persist(state))) {
+          throw new Error("cron: rollback store write did not complete", { cause: error });
+        }
+        armTimer(state);
+      } catch (rollbackError) {
+        throw new AgentDeletionAuthorityRollbackError(
+          [error, rollbackError],
+          `cron: failed to roll back agent job deletion for ${id}`,
+          { cause: error },
+        );
+      }
+      throw error;
+    }
+    armTimer(state);
+    for (const job of removedJobs) {
+      emit(state, { jobId: job.id, action: "removed", job });
+    }
+    return result;
   });
 }
 

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -80,6 +80,10 @@ export type CronServiceDeps = {
   }) => Promise<CronTriggerEvaluationResult>;
   /** Default agent id for jobs without an agent id. */
   defaultAgentId?: string;
+  /** Resolve the current default when runtime config can change after startup. */
+  resolveDefaultAgentId?: () => string;
+  /** Revalidate agent ownership inside the cron mutation lock. */
+  isAgentAvailable?: (agentId: string) => boolean;
   /** Resolve session store path for a given agent id. */
   resolveSessionStorePath?: (agentId?: string) => string;
   /** Path to the session store (sessions.json) for reaper use. */

--- a/src/gateway/local-request-context.test.ts
+++ b/src/gateway/local-request-context.test.ts
@@ -1,11 +1,15 @@
 /**
  * Local gateway request-context tests.
  */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import * as preparedModelCatalog from "../agents/prepared-model-catalog.js";
 import type { CliDeps } from "../cli/deps.types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { getPluginRuntimeGatewayRequestScope } from "../plugins/runtime/gateway-request-scope.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { withLocalGatewayRequestScope } from "./local-request-context.js";
 import { dispatchGatewayMethodInProcessRaw } from "./server-plugins.js";
 
@@ -58,5 +62,32 @@ describe("local gateway request context", () => {
 
     expect(loadSnapshot).toHaveBeenCalledWith({ config: cfg, readOnly: true });
     loadSnapshot.mockRestore();
+  });
+
+  it("commits agent deletion through the canonical cron store", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-local-cron-delete-"));
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+    const cfg = {
+      cron: { store: path.join(stateDir, "cron", "jobs.json") },
+      agents: { list: [{ id: "main", default: true }, { id: "worker" }] },
+    } as OpenClawConfig;
+    try {
+      await withLocalGatewayRequestScope(
+        { deps: {} as CliDeps, getRuntimeConfig: () => cfg },
+        async () => {
+          const context = getPluginRuntimeGatewayRequestScope()?.context;
+          if (!context) {
+            throw new Error("expected local gateway request context");
+          }
+          await expect(
+            context.cron.removeAgentJobsTransactional("worker", async () => "committed"),
+          ).resolves.toBe("committed");
+        },
+      );
+    } finally {
+      closeOpenClawStateDatabaseForTest();
+      vi.unstubAllEnvs();
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/gateway/local-request-context.ts
+++ b/src/gateway/local-request-context.ts
@@ -1,3 +1,5 @@
+import { isAgentDeletionBlocked } from "../agents/agent-lifecycle-registry.js";
+import { listAgentIds, resolveDefaultAgentId } from "../agents/agent-scope.js";
 // Local embedded Gateway request context.
 // Lets local agent paths reuse Gateway server methods without starting a server.
 import {
@@ -6,11 +8,14 @@ import {
 } from "../agents/prepared-model-catalog.js";
 import type { CliDeps } from "../cli/deps.types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { CronService } from "../cron/service.js";
+import { resolveCronJobsStorePath } from "../cron/store.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
   getPluginRuntimeGatewayRequestScope,
   withPluginRuntimeGatewayRequestScope,
 } from "../plugins/runtime/gateway-request-scope.js";
+import { normalizeAgentId } from "../routing/session-key.js";
 import { NodeRegistry } from "./node-registry.js";
 import type { ChannelRuntimeSnapshot } from "./server-channel-runtime.types.js";
 import { createChatRunEntry, type ChatRunEntry } from "./server-chat-state.js";
@@ -43,6 +48,7 @@ const unavailableCron: GatewayCronServiceContract = {
   update: async () => cronUnavailable(),
   updateWithPrecondition: async () => cronUnavailable(),
   remove: async () => cronUnavailable(),
+  removeAgentJobsTransactional: async () => cronUnavailable(),
   run: async () => cronUnavailable(),
   enqueueRun: async () => cronUnavailable(),
   getJob: () => undefined,
@@ -56,6 +62,35 @@ function createLocalGatewayRequestContext(
   params: LocalGatewayRequestContextParams,
 ): GatewayRequestContext {
   const logGateway = createSubsystemLogger("gateway/local");
+  const cron: GatewayCronServiceContract = {
+    ...unavailableCron,
+    removeAgentJobsTransactional: async (agentId, commit) => {
+      const cfg = params.getRuntimeConfig();
+      const service = new CronService({
+        storePath: resolveCronJobsStorePath(cfg.cron?.store),
+        cronEnabled: cfg.cron?.enabled !== false,
+        cronConfig: cfg.cron,
+        log: logGateway,
+        defaultAgentId: resolveDefaultAgentId(cfg),
+        resolveDefaultAgentId: () => resolveDefaultAgentId(params.getRuntimeConfig()),
+        isAgentAvailable: (id) =>
+          !isAgentDeletionBlocked(id) &&
+          listAgentIds(params.getRuntimeConfig()).some(
+            (configuredId) => normalizeAgentId(configuredId) === id,
+          ),
+        enqueueSystemEvent: () => false,
+        requestHeartbeat: () => {},
+        runIsolatedAgentJob: async () => {
+          throw new Error("Cron execution is unavailable in local embedded agent gateway context.");
+        },
+      });
+      try {
+        return await service.removeAgentJobsTransactional(agentId, commit);
+      } finally {
+        service.stop();
+      }
+    },
+  };
   const sessionEvents = new Set<string>();
   const chatRuns = new Map<string, ChatRunEntry>();
   const chatRunBuffers: GatewayRequestContext["chatRunBuffers"] = new Map();
@@ -81,7 +116,7 @@ function createLocalGatewayRequestContext(
   };
   return {
     deps: params.deps,
-    cron: unavailableCron,
+    cron,
     cronStorePath: "",
     getRuntimeConfig: params.getRuntimeConfig,
     notifyPluginMetadataChanged: () => {},

--- a/src/gateway/local-request-context.ts
+++ b/src/gateway/local-request-context.ts
@@ -10,6 +10,7 @@ import type { CliDeps } from "../cli/deps.types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { CronService } from "../cron/service.js";
 import { resolveCronJobsStorePath } from "../cron/store.js";
+import { getChildLogger } from "../logging/logger.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
   getPluginRuntimeGatewayRequestScope,
@@ -66,11 +67,12 @@ function createLocalGatewayRequestContext(
     ...unavailableCron,
     removeAgentJobsTransactional: async (agentId, commit) => {
       const cfg = params.getRuntimeConfig();
+      const storePath = resolveCronJobsStorePath(cfg.cron?.store);
       const service = new CronService({
-        storePath: resolveCronJobsStorePath(cfg.cron?.store),
+        storePath,
         cronEnabled: cfg.cron?.enabled !== false,
         cronConfig: cfg.cron,
-        log: logGateway,
+        log: getChildLogger({ module: "cron", storePath }),
         defaultAgentId: resolveDefaultAgentId(cfg),
         resolveDefaultAgentId: () => resolveDefaultAgentId(params.getRuntimeConfig()),
         isAgentAvailable: (id) =>

--- a/src/gateway/server-cron-contract.ts
+++ b/src/gateway/server-cron-contract.ts
@@ -3,6 +3,8 @@
 import type { CronServiceContract } from "../cron/service-contract.js";
 
 export type GatewayCronServiceContract = CronServiceContract & {
+  /** Serialize agent-job removal with the roster commit and restore on failure. */
+  removeAgentJobsTransactional<T>(agentId: string, commit: () => Promise<T>): Promise<T>;
   /** Temporarily disarm ticks without running startup recovery on resume. */
   pauseScheduling(): void;
   resumeScheduling(): void;

--- a/src/gateway/server-cron-lazy.test.ts
+++ b/src/gateway/server-cron-lazy.test.ts
@@ -319,6 +319,7 @@ function createCronService(): GatewayCronServiceContract {
     update: vi.fn(async () => ({ ok: true }) as never),
     updateWithPrecondition: vi.fn(async () => ({ ok: true }) as never),
     remove: vi.fn(async () => ({ ok: true }) as never),
+    removeAgentJobsTransactional: vi.fn(async (_agentId, commit) => await commit()),
     run: vi.fn(async () => ({ ok: true, ran: false, reason: "invalid-spec" }) as never),
     enqueueRun: vi.fn(async () => ({ ok: true, ran: false, reason: "invalid-spec" }) as never),
     getJob: vi.fn(() => undefined),

--- a/src/gateway/server-cron-lazy.ts
+++ b/src/gateway/server-cron-lazy.ts
@@ -244,6 +244,9 @@ export function createLazyGatewayCronState(params: LazyGatewayCronParams): Gatew
     async remove(id) {
       return await (await load()).state.cron.remove(id);
     },
+    async removeAgentJobsTransactional(agentId, commit) {
+      return await (await load()).state.cron.removeAgentJobsTransactional(agentId, commit);
+    },
     async run(id, mode, opts) {
       return await (await load()).state.cron.run(id, mode, opts);
     },

--- a/src/gateway/server-cron.test.ts
+++ b/src/gateway/server-cron.test.ts
@@ -96,7 +96,7 @@ const {
   createCronScriptRuntimeMock: vi.fn(),
   cronTriggerEvaluatorMock: vi.fn(),
   cronScriptExecutorMock: vi.fn(),
-  isAgentDeletionBlockedMock: vi.fn(() => false),
+  isAgentDeletionBlockedMock: vi.fn((_agentId: string) => false),
 }));
 
 function enqueueSystemEvent(text: string, opts?: unknown) {

--- a/src/gateway/server-cron.test.ts
+++ b/src/gateway/server-cron.test.ts
@@ -240,11 +240,6 @@ function requireRecord(value: unknown, label: string): Record<string, unknown> {
   return value as Record<string, unknown>;
 }
 
-function requireArray(value: unknown, label: string): Array<unknown> {
-  expect(Array.isArray(value), label).toBe(true);
-  return value as Array<unknown>;
-}
-
 function callArg(
   mock: { mock: { calls: Array<Array<unknown>> } },
   callIndex: number,

--- a/src/gateway/server-cron.test.ts
+++ b/src/gateway/server-cron.test.ts
@@ -3,6 +3,7 @@
 import os from "node:os";
 import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AgentDeletionCommitUncertainError } from "../agents/agent-lifecycle-registry.js";
 import type { CliDeps } from "../cli/deps.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { SsrFBlockedError } from "../infra/net/ssrf.js";
@@ -35,6 +36,7 @@ const {
   createCronScriptRuntimeMock,
   cronTriggerEvaluatorMock,
   cronScriptExecutorMock,
+  isAgentDeletionBlockedMock,
 } = vi.hoisted(() => ({
   enqueueSystemEventMock: vi.fn(),
   consumeSelectedSystemEventEntriesMock: vi.fn((_sessionKey, entries) => entries ?? []),
@@ -94,6 +96,7 @@ const {
   createCronScriptRuntimeMock: vi.fn(),
   cronTriggerEvaluatorMock: vi.fn(),
   cronScriptExecutorMock: vi.fn(),
+  isAgentDeletionBlockedMock: vi.fn(() => false),
 }));
 
 function enqueueSystemEvent(text: string, opts?: unknown) {
@@ -199,6 +202,12 @@ vi.mock("../agents/embedded-agent.js", () => ({
 
 vi.mock("../agents/agent-bundle-mcp-tools.js", () => ({
   retireSessionMcpRuntime: retireSessionMcpRuntimeMock,
+}));
+
+vi.mock("../agents/agent-lifecycle-registry.js", () => ({
+  AgentDeletionAuthorityRollbackError: class extends AggregateError {},
+  AgentDeletionCommitUncertainError: class extends Error {},
+  isAgentDeletionBlocked: isAgentDeletionBlockedMock,
 }));
 
 vi.mock("../process/supervisor/index.js", () => ({
@@ -323,6 +332,7 @@ describe("buildGatewayCronService", () => {
     cronTriggerEvaluatorMock.mockReset();
     cronTriggerEvaluatorMock.mockResolvedValue({ kind: "evaluated", fire: false });
     cronScriptExecutorMock.mockReset();
+    isAgentDeletionBlockedMock.mockReset().mockReturnValue(false);
     cronScriptExecutorMock.mockResolvedValue({ kind: "completed", stateChanged: false });
     createCronScriptRuntimeMock.mockReset();
     createCronScriptRuntimeMock.mockReturnValue({
@@ -626,6 +636,7 @@ describe("buildGatewayCronService", () => {
 
   it("cron_changed hook event includes agentId from the job", async () => {
     const cfg = createCronConfig("server-cron-hook-agentId");
+    cfg.agents = { list: [{ id: "main", default: true }, { id: "yinze" }] };
     loadConfigMock.mockReturnValue(cfg);
 
     const state = buildGatewayCronService({
@@ -1762,7 +1773,7 @@ describe("buildGatewayCronService", () => {
     }
   });
 
-  it("falls back to the configured default agent main session for unknown agent-prefixed keys", () => {
+  it("rejects unknown agent-prefixed keys instead of rebinding them to the default agent", () => {
     const cfg = {
       session: { mainKey: "main" },
       cron: {
@@ -1799,24 +1810,21 @@ describe("buildGatewayCronService", () => {
         }
       ).state?.deps;
 
-      cronDeps?.enqueueSystemEvent?.("hello", {
-        sessionKey: "agent:ghost:discord:channel:ops",
-      });
-      cronDeps?.requestHeartbeat?.({
-        source: "cron",
-        intent: "event",
-        reason: "cron:test",
-        sessionKey: "agent:ghost:discord:channel:ops",
-      });
-
-      const enqueueCall = lastMockCall(enqueueSystemEventMock, "enqueue system event");
-      const wakeCall = lastMockCall(requestHeartbeatMock, "request heartbeat");
-      expect((enqueueCall?.[1] as { sessionKey?: string } | undefined)?.sessionKey).toBe(
-        "agent:primary:main",
-      );
-      const wakeRequest = wakeCall?.[0] as { agentId?: string; sessionKey?: string } | undefined;
-      expect(wakeRequest?.agentId).toBe("primary");
-      expect(wakeRequest?.sessionKey).toBe("agent:primary:main");
+      expect(() =>
+        cronDeps?.enqueueSystemEvent?.("hello", {
+          sessionKey: "agent:ghost:discord:channel:ops",
+        }),
+      ).toThrow("cron job agent is unavailable: ghost");
+      expect(() =>
+        cronDeps?.requestHeartbeat?.({
+          source: "cron",
+          intent: "event",
+          reason: "cron:test",
+          sessionKey: "agent:ghost:discord:channel:ops",
+        }),
+      ).toThrow("cron job agent is unavailable: ghost");
+      expect(enqueueSystemEventMock).not.toHaveBeenCalled();
+      expect(requestHeartbeatMock).not.toHaveBeenCalled();
     } finally {
       state.cron.stop();
     }
@@ -2041,7 +2049,7 @@ describe("buildGatewayCronService", () => {
     }
   });
 
-  it("preserves explicit isolated agent workspace when runtime reload config is stale", async () => {
+  it("does not resurrect a startup agent missing from the runtime roster", async () => {
     const tmpDir = path.join(os.tmpdir(), `server-cron-agent-workspace-${Date.now()}`);
     const startupCfg = {
       session: {
@@ -2074,7 +2082,7 @@ describe("buildGatewayCronService", () => {
         list: [{ id: "main", default: true }],
       },
     } as OpenClawConfig;
-    loadConfigMock.mockReturnValue(reloadedCfg);
+    loadConfigMock.mockReturnValue(startupCfg);
 
     const state = buildGatewayCronService({
       cfg: startupCfg,
@@ -2092,23 +2100,248 @@ describe("buildGatewayCronService", () => {
         payload: { kind: "agentTurn", message: "read SOW.md" },
       });
 
-      await state.cron.run(job.id, "force");
-
-      const options = expectIsolatedRunFields({ agentId: "yinze" });
-      const cfg = requireRecord(options.cfg, "isolated run config");
-      const agents = requireRecord(cfg.agents, "isolated run agents");
-      const list = requireArray(agents.list, "isolated run agent list");
-      const yinze = requireRecord(
-        list.find((agent) => requireRecord(agent, "agent entry").id === "yinze"),
-        "yinze agent entry",
-      );
-      expect(yinze.workspace).toBe(path.join(tmpDir, "workspace-yinze"));
+      loadConfigMock.mockReturnValue(reloadedCfg);
+      await expect(state.cron.run(job.id, "force")).resolves.toEqual({ ok: true, ran: true });
+      expect(runCronIsolatedAgentTurnMock).not.toHaveBeenCalled();
+      expect(await state.cron.readJob(job.id)).toMatchObject({
+        state: {
+          lastRunStatus: "error",
+          lastError: expect.stringContaining("cron job agent is unavailable: yinze"),
+        },
+      });
     } finally {
       state.cron.stop();
     }
   });
 
-  it("preserves agent heartbeat overrides when runtime reload config is stale", async () => {
+  it("removes only one agent's cron jobs and restores them if roster commit fails", async () => {
+    const tmpDir = path.join(os.tmpdir(), `server-cron-agent-delete-${Date.now()}`);
+    const cfg = {
+      cron: { store: path.join(tmpDir, "cron.json") },
+      agents: {
+        defaults: { workspace: path.join(tmpDir, "workspace") },
+        list: [{ id: "main", default: true }, { id: "yinze" }, { id: "other" }],
+      },
+    } as OpenClawConfig;
+    loadConfigMock.mockReturnValue(cfg);
+    const state = buildGatewayCronService({ cfg, deps: {} as CliDeps, broadcast: () => {} });
+    const addJob = async (agentId: string, name: string) =>
+      await state.cron.add({
+        name,
+        enabled: true,
+        schedule: { kind: "at", at: new Date(Date.now() + 3_600_000).toISOString() },
+        sessionTarget: "isolated",
+        wakeMode: "next-heartbeat",
+        agentId,
+        payload: { kind: "agentTurn", message: name },
+      });
+    try {
+      await addJob("yinze", "deleted-one");
+      await addJob("yinze", "deleted-two");
+      await addJob("other", "kept");
+
+      await expect(
+        state.cron.removeAgentJobsTransactional("yinze", async () => {
+          throw new Error("config commit failed");
+        }),
+      ).rejects.toThrow("config commit failed");
+      expect((await state.cron.list({ includeDisabled: true })).map((job) => job.name)).toEqual(
+        expect.arrayContaining(["deleted-one", "deleted-two", "kept"]),
+      );
+
+      await state.cron.removeAgentJobsTransactional("yinze", async () => "committed");
+      expect((await state.cron.list({ includeDisabled: true })).map((job) => job.name)).toEqual([
+        "kept",
+      ]);
+    } finally {
+      state.cron.stop();
+    }
+  });
+
+  it("keeps removed jobs deleted when the roster commit outcome is uncertain", async () => {
+    const tmpDir = path.join(os.tmpdir(), `server-cron-agent-uncertain-${Date.now()}`);
+    const cfg = {
+      cron: { store: path.join(tmpDir, "cron.json") },
+      agents: { list: [{ id: "main", default: true }, { id: "yinze" }, { id: "other" }] },
+    } as OpenClawConfig;
+    loadConfigMock.mockReturnValue(cfg);
+    const state = buildGatewayCronService({ cfg, deps: {} as CliDeps, broadcast: () => {} });
+    try {
+      for (const [agentId, name] of [
+        ["yinze", "deleted"],
+        ["other", "kept"],
+      ] as const) {
+        await state.cron.add({
+          name,
+          enabled: true,
+          schedule: { kind: "at", at: new Date(Date.now() + 3_600_000).toISOString() },
+          sessionTarget: "isolated",
+          wakeMode: "next-heartbeat",
+          agentId,
+          payload: { kind: "agentTurn", message: name },
+        });
+      }
+
+      await expect(
+        state.cron.removeAgentJobsTransactional("yinze", async () => {
+          throw new AgentDeletionCommitUncertainError(new Error("config outcome unknown"));
+        }),
+      ).rejects.toThrow("config outcome unknown");
+      expect((await state.cron.list({ includeDisabled: true })).map((job) => job.name)).toEqual([
+        "kept",
+      ]);
+    } finally {
+      state.cron.stop();
+    }
+  });
+
+  it("keeps agent-less jobs owned by the current runtime default", async () => {
+    const tmpDir = path.join(os.tmpdir(), `server-cron-default-change-${Date.now()}`);
+    const startupCfg = {
+      cron: { store: path.join(tmpDir, "cron.json") },
+      agents: { list: [{ id: "main" }, { id: "yinze", default: true }, { id: "other" }] },
+    } as OpenClawConfig;
+    const runtimeCfg = {
+      ...startupCfg,
+      agents: { list: [{ id: "main" }, { id: "yinze" }, { id: "other", default: true }] },
+    } as OpenClawConfig;
+    loadConfigMock.mockReturnValue(startupCfg);
+    const state = buildGatewayCronService({
+      cfg: startupCfg,
+      deps: {} as CliDeps,
+      broadcast: () => {},
+    });
+    try {
+      await state.cron.add({
+        name: "follows-runtime-default",
+        enabled: true,
+        schedule: { kind: "at", at: new Date(Date.now() + 3_600_000).toISOString() },
+        sessionTarget: "isolated",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "agentTurn", message: "keep" },
+      });
+      loadConfigMock.mockReturnValue(runtimeCfg);
+
+      await state.cron.removeAgentJobsTransactional("yinze", async () => {});
+      await expect(
+        state.cron.add({
+          name: "new-runtime-default",
+          enabled: true,
+          schedule: { kind: "at", at: new Date(Date.now() + 3_600_000).toISOString() },
+          sessionTarget: "isolated",
+          wakeMode: "next-heartbeat",
+          payload: { kind: "agentTurn", message: "keep too" },
+        }),
+      ).resolves.toBeDefined();
+      expect((await state.cron.list({ includeDisabled: true })).map((job) => job.name)).toEqual([
+        "follows-runtime-default",
+        "new-runtime-default",
+      ]);
+    } finally {
+      state.cron.stop();
+    }
+  });
+
+  it("does not execute jobs for a journal-fenced agent still present in the roster", async () => {
+    const tmpDir = path.join(os.tmpdir(), `server-cron-agent-fenced-${Date.now()}`);
+    const cfg = {
+      cron: { store: path.join(tmpDir, "cron.json") },
+      agents: { list: [{ id: "main", default: true }, { id: "yinze" }] },
+    } as OpenClawConfig;
+    loadConfigMock.mockReturnValue(cfg);
+    const state = buildGatewayCronService({ cfg, deps: {} as CliDeps, broadcast: () => {} });
+    try {
+      const job = await state.cron.add({
+        name: "fenced-job",
+        enabled: true,
+        schedule: { kind: "at", at: new Date(1).toISOString() },
+        sessionTarget: "isolated",
+        wakeMode: "next-heartbeat",
+        agentId: "yinze",
+        payload: { kind: "agentTurn", message: "must not run" },
+      });
+      isAgentDeletionBlockedMock.mockImplementation((agentId: string) => agentId === "yinze");
+
+      await expect(state.cron.run(job.id, "force")).resolves.toEqual({ ok: true, ran: true });
+      expect(runCronIsolatedAgentTurnMock).not.toHaveBeenCalled();
+      expect(await state.cron.readJob(job.id)).toMatchObject({
+        state: {
+          lastRunStatus: "error",
+          lastError: expect.stringContaining("cron job agent is unavailable: yinze"),
+        },
+      });
+    } finally {
+      state.cron.stop();
+    }
+  });
+
+  it("rejects an agent job queued while that agent is removed from the roster", async () => {
+    const tmpDir = path.join(os.tmpdir(), `server-cron-agent-delete-race-${Date.now()}`);
+    const cfg = {
+      cron: { store: path.join(tmpDir, "cron.json") },
+      agents: {
+        defaults: { workspace: path.join(tmpDir, "workspace") },
+        list: [{ id: "main", default: true }, { id: "yinze" }],
+      },
+    } as OpenClawConfig;
+    const deletedCfg = {
+      ...cfg,
+      agents: { ...cfg.agents, list: [{ id: "main", default: true }] },
+    } as OpenClawConfig;
+    loadConfigMock.mockReturnValue(cfg);
+    const state = buildGatewayCronService({ cfg, deps: {} as CliDeps, broadcast: () => {} });
+    const commitStarted = createDeferred();
+    const releaseCommit = createDeferred();
+    try {
+      await state.cron.add({
+        name: "old-job",
+        enabled: true,
+        schedule: { kind: "at", at: new Date(Date.now() + 3_600_000).toISOString() },
+        sessionTarget: "isolated",
+        wakeMode: "next-heartbeat",
+        agentId: "yinze",
+        payload: { kind: "agentTurn", message: "old" },
+      });
+      const retained = await state.cron.add({
+        name: "retained-job",
+        enabled: true,
+        schedule: { kind: "at", at: new Date(Date.now() + 3_600_000).toISOString() },
+        sessionTarget: "isolated",
+        wakeMode: "next-heartbeat",
+        agentId: "main",
+        payload: { kind: "agentTurn", message: "retained" },
+      });
+      const removal = state.cron.removeAgentJobsTransactional("yinze", async () => {
+        commitStarted.resolve();
+        await releaseCommit.promise;
+      });
+      await commitStarted.promise;
+      loadConfigMock.mockReturnValue(deletedCfg);
+      const lateAdd = state.cron.add({
+        name: "late-job",
+        enabled: true,
+        schedule: { kind: "at", at: new Date(Date.now() + 3_600_000).toISOString() },
+        sessionTarget: "isolated",
+        wakeMode: "next-heartbeat",
+        agentId: "yinze",
+        payload: { kind: "agentTurn", message: "late" },
+      });
+      const lateUpdate = state.cron.update(retained.id, { agentId: "yinze" });
+      releaseCommit.resolve();
+
+      await removal;
+      await expect(lateAdd).rejects.toThrow("cron job agent is unavailable: yinze");
+      await expect(lateUpdate).rejects.toThrow("cron job agent is unavailable: yinze");
+      expect((await state.cron.list({ includeDisabled: true })).map((job) => job.name)).toEqual([
+        "retained-job",
+      ]);
+    } finally {
+      releaseCommit.resolve();
+      state.cron.stop();
+    }
+  });
+
+  it("does not reuse startup heartbeat policy for an agent missing from the runtime roster", async () => {
     const tmpDir = path.join(os.tmpdir(), `server-cron-agent-heartbeat-${Date.now()}`);
     const startupCfg = {
       session: {
@@ -2177,34 +2410,14 @@ describe("buildGatewayCronService", () => {
           };
         }
       ).state?.deps;
-      await cronDeps?.runHeartbeatOnce?.({
-        agentId: "yinze",
-        sessionKey: "agent:yinze:main",
-        heartbeat: {},
-      });
-
-      const options = requireRecord(
-        callArg(runHeartbeatOnceMock, 0, 0, "heartbeat options"),
-        "heartbeat options",
-      );
-      expect(options.agentId).toBe("yinze");
-      const cfg = requireRecord(options.cfg, "heartbeat config");
-      const agents = requireRecord(cfg.agents, "heartbeat agents");
-      const list = requireArray(agents.list, "heartbeat agent list");
-      const yinze = requireRecord(
-        list.find((agent) => requireRecord(agent, "agent entry").id === "yinze"),
-        "yinze agent entry",
-      );
-      const agentHeartbeat = requireRecord(yinze.heartbeat, "agent heartbeat");
-      expect(agentHeartbeat.target).toBe("last");
-      expect(agentHeartbeat.deliveryFormat).toBe("markdown");
-      const heartbeat = requireRecord(options.heartbeat, "heartbeat override");
-      expect(heartbeat).toEqual({
-        target: "last",
-        deliveryFormat: "markdown",
-        to: undefined,
-        accountId: undefined,
-      });
+      await expect(
+        cronDeps?.runHeartbeatOnce?.({
+          agentId: "yinze",
+          sessionKey: "agent:yinze:main",
+          heartbeat: {},
+        }),
+      ).rejects.toThrow("cron job agent is unavailable: yinze");
+      expect(runHeartbeatOnceMock).not.toHaveBeenCalled();
     } finally {
       state.cron.stop();
     }

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -1,7 +1,8 @@
 // Gateway cron runtime service runs scheduled agent turns, heartbeat wakeups,
 // plugin hooks, notifications, and cron lifecycle cleanup.
 import { retireSessionMcpRuntime } from "../agents/agent-bundle-mcp-tools.js";
-import { resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { isAgentDeletionBlocked } from "../agents/agent-lifecycle-registry.js";
+import { listAgentIds, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { abortAndDrainEmbeddedAgentRun } from "../agents/embedded-agent.js";
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import { cleanupBrowserSessionsForLifecycleEnd } from "../browser-lifecycle-cleanup.js";
@@ -220,41 +221,23 @@ export function buildGatewayCronService(params: {
   const hasConfiguredAgent = (cfg: OpenClawConfig, agentId: string) =>
     Boolean(findAgentEntry(cfg, agentId));
 
-  const mergeRuntimeAgentConfig = (runtimeConfig: OpenClawConfig, requestedAgentId: string) => {
-    if (hasConfiguredAgent(runtimeConfig, requestedAgentId)) {
-      return runtimeConfig;
-    }
-    const fallbackAgentEntry = findAgentEntry(params.cfg, requestedAgentId);
-    if (!fallbackAgentEntry) {
-      return runtimeConfig;
-    }
-    const startupAgents = params.cfg.agents;
-    const runtimeAgents = runtimeConfig.agents;
-    return {
-      ...runtimeConfig,
-      agents: {
-        ...startupAgents,
-        ...runtimeAgents,
-        defaults: {
-          ...startupAgents?.defaults,
-          ...runtimeAgents?.defaults,
-        },
-        list: [...(runtimeAgents?.list ?? []), fallbackAgentEntry],
-      },
-    };
-  };
-
   const resolveCronAgent = (requested?: string | null) => {
     const runtimeConfig = getRuntimeConfig();
     const normalized =
       typeof requested === "string" && requested.trim() ? normalizeAgentId(requested) : undefined;
-    const effectiveConfig =
-      normalized !== undefined ? mergeRuntimeAgentConfig(runtimeConfig, normalized) : runtimeConfig;
-    const agentId =
-      normalized !== undefined && hasConfiguredAgent(effectiveConfig, normalized)
-        ? normalized
-        : resolveDefaultAgentId(effectiveConfig);
-    return { agentId, cfg: effectiveConfig };
+    const defaultAgentId = resolveDefaultAgentId(runtimeConfig);
+    if (
+      normalized !== undefined &&
+      normalized !== defaultAgentId &&
+      !hasConfiguredAgent(runtimeConfig, normalized)
+    ) {
+      throw new Error(`cron job agent is unavailable: ${normalized}`);
+    }
+    const agentId = normalized ?? defaultAgentId;
+    if (isAgentDeletionBlocked(agentId)) {
+      throw new Error(`cron job agent is unavailable: ${agentId}`);
+    }
+    return { agentId, cfg: runtimeConfig };
   };
 
   const resolveCronSessionKey = (paramsValue: {
@@ -471,6 +454,10 @@ export function buildGatewayCronService(params: {
         }
       : {}),
     defaultAgentId,
+    resolveDefaultAgentId: () => resolveDefaultAgentId(getRuntimeConfig()),
+    isAgentAvailable: (agentId) =>
+      !isAgentDeletionBlocked(agentId) &&
+      listAgentIds(getRuntimeConfig()).some((id) => normalizeAgentId(id) === agentId),
     resolveSessionStorePath,
     sessionStorePath,
     enqueueSystemEvent: (text, opts) => {

--- a/src/gateway/server-methods/agents-mutate.test.ts
+++ b/src/gateway/server-methods/agents-mutate.test.ts
@@ -280,6 +280,7 @@ vi.mock("../../infra/fs-safe.js", async () => {
   return {
     ...actual,
     root: vi.fn(async (rootDir: string) => ({
+      rootReal: rootDir,
       open: async (relativePath: string, options?: Record<string, unknown>) =>
         await mocks.rootOpen({ rootDir, relativePath, ...options }),
       stat: async (relativePath: string) => await mocks.rootStat({ rootDir, relativePath }),
@@ -383,12 +384,18 @@ beforeEach(() => {
     realPath: "/workspace/test-agent/AGENTS.md",
     stat: { size: 0, mtimeMs: 0 },
   });
-  mocks.rootStat.mockResolvedValue({
-    isFile: true,
-    isSymbolicLink: false,
-    mtimeMs: 0,
-    nlink: 1,
-    size: 0,
+  mocks.rootStat.mockImplementation(async (params?: unknown) => {
+    const { rootDir, relativePath } = params as { rootDir: string; relativePath: string };
+    const stat = await mocks.fsLstat(path.join(rootDir, relativePath));
+    return {
+      dev: stat?.dev,
+      ino: stat?.ino,
+      isFile: stat?.isFile?.() ?? true,
+      isSymbolicLink: stat?.isSymbolicLink?.() ?? false,
+      mtimeMs: stat?.mtimeMs ?? 0,
+      nlink: stat?.nlink ?? 1,
+      size: stat?.size ?? 0,
+    };
   });
   mocks.rootWrite.mockResolvedValue(undefined);
 });
@@ -401,6 +408,7 @@ function makeRootForTest(overrides?: {
 }) {
   return async (rootDir: string) =>
     ({
+      rootReal: rootDir,
       open: async (relativePath: string, options?: Record<string, unknown>) =>
         await (overrides?.open ?? mocks.rootOpen)({ rootDir, relativePath, ...options }),
       stat: async (relativePath: string) =>
@@ -1753,7 +1761,10 @@ describe("agents.delete", () => {
   });
 
   it("resolves a symlinked workspace and removes descendants before its target and link", async () => {
-    const workspaceLink = "/tmp-root/workspace-link";
+    const workspaceParent = "/tmp-root";
+    const workspaceParentTarget = "/real-tmp/source-parent";
+    const workspaceLink = `${workspaceParent}/workspace-link`;
+    const canonicalWorkspaceLink = `${workspaceParentTarget}/workspace-link`;
     const workspaceTarget = "/real-tmp/workspace";
     const agentDir = `${workspaceLink}/agent`;
     const sessionsDir = `${workspaceLink}/transcripts`;
@@ -1774,13 +1785,16 @@ describe("agents.delete", () => {
     mocks.normalizeAgentDirRegistryPath.mockImplementation((pathname: string) =>
       pathname.replace(workspaceLink, workspaceTarget),
     );
-    mocks.fsRealpath.mockImplementation(async (pathname: string) =>
-      pathname.replace(workspaceLink, workspaceTarget),
-    );
+    mocks.fsRealpath.mockImplementation(async (pathname: string) => {
+      if (pathname === workspaceParent) {
+        return workspaceParentTarget;
+      }
+      return pathname.replace(workspaceLink, workspaceTarget);
+    });
     mocks.fsLstat.mockImplementation(
       async (pathname: unknown) =>
         ({
-          isSymbolicLink: () => pathname === workspaceLink,
+          isSymbolicLink: () => pathname === workspaceLink || pathname === canonicalWorkspaceLink,
         }) as unknown as import("node:fs").Stats,
     );
 
@@ -1792,9 +1806,10 @@ describe("agents.delete", () => {
     const targetIndex = trashedPaths.indexOf(workspaceTarget);
     expect(trashedPaths.indexOf(`${workspaceTarget}/agent`)).toBeLessThan(targetIndex);
     expect(trashedPaths.indexOf(`${workspaceTarget}/transcripts`)).toBeLessThan(targetIndex);
-    expect(targetIndex).toBeLessThan(trashedPaths.indexOf(workspaceLink));
+    expect(targetIndex).toBeLessThan(trashedPaths.indexOf(canonicalWorkspaceLink));
     expect(mocks.movePathToTrash).toHaveBeenCalledWith(workspaceTarget);
-    expect(mocks.movePathToTrash).toHaveBeenCalledWith(workspaceLink);
+    expect(mocks.movePathToTrash).toHaveBeenCalledWith(canonicalWorkspaceLink);
+    expect(mocks.movePathToTrash).not.toHaveBeenCalledWith(workspaceLink);
     expect(mocks.beginAgentDeletionFinish).toHaveBeenCalledOnce();
   });
 
@@ -1893,6 +1908,71 @@ describe("agents.delete", () => {
     expect(mocks.movePathToTrash).toHaveBeenCalledWith(originalTarget);
     expect(mocks.movePathToTrash).toHaveBeenCalledWith(workspaceLink);
     expect(mocks.beginAgentDeletionFinish).toHaveBeenCalledOnce();
+  });
+
+  it("does not follow a retargeted canonical ancestor during recovery", async () => {
+    const canonicalRoot = "/canonical/deleted";
+    const unrelatedRoot = "/unrelated/current";
+    const workspaceDir = "/linked/workspace";
+    const journal = {
+      agentId: "test-agent",
+      operationId: "delete-1",
+      agentDir: `${workspaceDir}/agent`,
+      workspaceDir,
+      sessionsDir: `${workspaceDir}/transcripts`,
+      cleanupPaths: [
+        {
+          path: `${canonicalRoot}/workspace/agent`,
+          parentPath: `${canonicalRoot}/workspace`,
+          kind: "target" as const,
+          sourcePaths: [`${workspaceDir}/agent`],
+        },
+        {
+          path: `${canonicalRoot}/workspace/transcripts`,
+          parentPath: `${canonicalRoot}/workspace`,
+          kind: "target" as const,
+          sourcePaths: [`${workspaceDir}/transcripts`],
+        },
+        {
+          path: `${canonicalRoot}/workspace`,
+          parentPath: canonicalRoot,
+          kind: "target" as const,
+          sourcePaths: [workspaceDir],
+        },
+      ],
+      createdAt: 1,
+      cleanupCompleted: false,
+      deleteFiles: true,
+    };
+    mocks.findAgentEntryIndex.mockReturnValue(-1);
+    mocks.readAgentDeletionJournal.mockReturnValue(journal);
+    mocks.resolveRegisteredAgentIdForDir.mockImplementation((pathname?: string) =>
+      pathname === journal.agentDir ? "test-agent" : undefined,
+    );
+    agentsTesting.setDepsForTests({
+      root: (async (rootDir: string) => ({
+        rootReal: rootDir.startsWith(canonicalRoot)
+          ? rootDir.replace(canonicalRoot, unrelatedRoot)
+          : rootDir,
+        stat: async (relativePath: string) => await mocks.rootStat({ rootDir, relativePath }),
+      })) as never,
+    });
+
+    const { respond, promise } = makeCall("agents.delete", { agentId: "test-agent" });
+    await promise;
+
+    const result = expectRespondOk(respond, {});
+    expect(result.failed).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ reason: "cleanup path parent changed before deletion" }),
+      ]),
+    );
+    expect(
+      mocks.movePathToTrash.mock.calls.some(([pathname]) =>
+        String(pathname).startsWith(unrelatedRoot),
+      ),
+    ).toBe(false);
+    expect(mocks.beginAgentDeletionFinish).not.toHaveBeenCalled();
   });
 
   it("reclaims durable journal ownership after a process restart", async () => {

--- a/src/gateway/server-methods/agents-mutate.test.ts
+++ b/src/gateway/server-methods/agents-mutate.test.ts
@@ -45,7 +45,6 @@ const mocks = vi.hoisted(() => ({
   ),
   closeOpenClawAgentDatabaseByPath: vi.fn((_pathname?: string) => true),
   listOpenClawRegisteredAgentDatabases: vi.fn(() => [] as Array<Record<string, unknown>>),
-  beginOpenClawAgentDatabaseRegistrationFence: vi.fn(() => vi.fn()),
   unregisterOpenClawAgentDatabase: vi.fn(),
   assertNoOpenClawAgentDatabaseLeases: vi.fn(),
   registerResolvedAgentDir: vi.fn(),
@@ -196,8 +195,11 @@ vi.mock("../../agents/agent-lifecycle-registry.js", () => ({
     }
   },
   beginAgentDeletion: (entry: Record<string, unknown>) => ({
-    entry,
+    entry: Object.assign(entry, { databasePaths: entry.databasePaths ?? [] }),
     commit: mocks.beginAgentDeletionCommit,
+    fenceDatabasePaths: (paths: string[]) => {
+      entry.databasePaths = [...new Set(paths)];
+    },
     finish: mocks.beginAgentDeletionFinish,
     rollback: mocks.beginAgentDeletionRollback,
   }),
@@ -220,7 +222,6 @@ vi.mock("../../state/agent-deletion-journal.js", () => ({
 }));
 
 vi.mock("../../state/openclaw-agent-db-registry.js", () => ({
-  beginOpenClawAgentDatabaseRegistrationFence: mocks.beginOpenClawAgentDatabaseRegistrationFence,
   unregisterOpenClawAgentDatabase: mocks.unregisterOpenClawAgentDatabase,
 }));
 
@@ -341,7 +342,6 @@ beforeEach(() => {
     );
   mocks.closeOpenClawAgentDatabaseByPath.mockReset().mockReturnValue(true);
   mocks.listOpenClawRegisteredAgentDatabases.mockReset().mockReturnValue([]);
-  mocks.beginOpenClawAgentDatabaseRegistrationFence.mockReset().mockReturnValue(vi.fn());
   mocks.unregisterOpenClawAgentDatabase.mockReset();
   mocks.registerResolvedAgentDir.mockReset();
   mocks.resolveRegisteredAgentIdForDir
@@ -1462,6 +1462,184 @@ describe("agents.delete", () => {
     expect(mocks.beginAgentDeletionFinish).toHaveBeenCalledOnce();
   });
 
+  it("converges after partial cleanup and makes the agent id recreatable", async () => {
+    const journal = {
+      agentId: "test-agent",
+      operationId: "delete-1",
+      agentDir: "/agents/test-agent",
+      workspaceDir: "/workspace/test-agent",
+      sessionsDir: "/transcripts/test-agent",
+      createdAt: 1,
+      cleanupCompleted: false,
+      deleteFiles: true,
+    };
+    const trashed = new Set<string>();
+    let workspaceAttempts = 0;
+    mocks.fsLstat.mockImplementation(async (pathname: unknown) => {
+      if (trashed.has(String(pathname))) {
+        throw createEnoentError();
+      }
+      return null as unknown as import("node:fs").Stats;
+    });
+    mocks.movePathToTrash.mockImplementation(async (pathname?: string) => {
+      if (pathname === journal.workspaceDir && workspaceAttempts++ === 0) {
+        throw new Error("workspace trash failed");
+      }
+      trashed.add(pathname ?? "");
+      return "/trashed";
+    });
+    mocks.beginAgentDeletionFinish.mockImplementation(() => {
+      journal.cleanupCompleted = true;
+    });
+
+    const firstDelete = makeCall("agents.delete", { agentId: "test-agent" });
+    await firstDelete.promise;
+
+    expectRespondOk(firstDelete.respond, {
+      failed: [{ path: journal.workspaceDir, reason: "workspace trash failed" }],
+    });
+    expect(mocks.beginAgentDeletionFinish).not.toHaveBeenCalled();
+    mocks.findAgentEntryIndex.mockReturnValue(-1);
+    mocks.readAgentDeletionJournal.mockReturnValue(journal);
+    const blockedCreate = makeCall("agents.create", { name: "Test Agent" });
+    await blockedCreate.promise;
+    expectRespondErrorContaining(blockedCreate.respond, "still pending");
+
+    const recovery = makeCall("agents.delete", { agentId: "test-agent" });
+    await recovery.promise;
+
+    expectRespondOk(recovery.respond, { failed: [] });
+    expect(mocks.beginAgentDeletionFinish).toHaveBeenCalledOnce();
+    expect(journal.cleanupCompleted).toBe(true);
+    const recreated = makeCall("agents.create", { name: "Test Agent" });
+    await recreated.promise;
+    expectRespondOk(recreated.respond, { ok: true, agentId: "test-agent" });
+  });
+
+  it("treats a source that disappears during Trash as successful cleanup", async () => {
+    let workspaceLstatCalls = 0;
+    mocks.fsLstat.mockImplementation(async (pathname: unknown) => {
+      if (pathname === "/workspace/test-agent" && workspaceLstatCalls++ > 1) {
+        throw createEnoentError();
+      }
+      return null as unknown as import("node:fs").Stats;
+    });
+    mocks.movePathToTrash.mockImplementation(async (pathname?: string) => {
+      if (pathname === "/workspace/test-agent") {
+        throw createEnoentError();
+      }
+      return "/trashed";
+    });
+
+    const { respond, promise } = makeCall("agents.delete", { agentId: "test-agent" });
+    await promise;
+
+    expectRespondOk(respond, {
+      removed: [
+        { path: "/workspace/test-agent", method: "missing" },
+        { path: "/agents/test-agent", method: "trash" },
+        { path: "/transcripts/test-agent", method: "trash" },
+      ],
+      failed: [],
+    });
+    expect(mocks.beginAgentDeletionFinish).toHaveBeenCalledOnce();
+  });
+
+  it("canonicalizes overlapping journal paths and cleans only the outermost path", async () => {
+    mocks.findAgentEntryIndex.mockReturnValue(-1);
+    mocks.readAgentDeletionJournal.mockReturnValue({
+      agentId: "test-agent",
+      operationId: "delete-1",
+      agentDir: "/journal/agent",
+      workspaceDir: "/journal",
+      sessionsDir: "/journal/agent/sessions",
+      createdAt: 1,
+      cleanupCompleted: false,
+      deleteFiles: true,
+    });
+
+    const { respond, promise } = makeCall("agents.delete", { agentId: "test-agent" });
+    await promise;
+
+    expectRespondOk(respond, {
+      removed: [{ path: "/journal", method: "trash" }],
+      failed: [],
+    });
+    expect(mocks.movePathToTrash).toHaveBeenCalledOnce();
+    expect(mocks.movePathToTrash).toHaveBeenCalledWith("/journal");
+    expect(mocks.deleteWorkspaceState).toHaveBeenCalledWith({ workspaceDir: "/journal" });
+    expect(mocks.beginAgentDeletionFinish).toHaveBeenCalledOnce();
+  });
+
+  it("skips an overlapping workspace that covers an agent directory claimed by a survivor", async () => {
+    mocks.findAgentEntryIndex.mockReturnValue(-1);
+    mocks.readAgentDeletionJournal.mockReturnValue({
+      agentId: "test-agent",
+      operationId: "delete-1",
+      agentDir: "/journal/agent",
+      workspaceDir: "/journal",
+      sessionsDir: "/deleted/sessions",
+      createdAt: 1,
+      cleanupCompleted: false,
+      deleteFiles: true,
+    });
+    mocks.resolveRegisteredAgentIdForDir.mockImplementation((pathname?: string) =>
+      pathname === "/journal/agent" ? "other-agent" : undefined,
+    );
+
+    const { respond, promise } = makeCall("agents.delete", { agentId: "test-agent" });
+    await promise;
+
+    expectRespondOk(respond, { failed: [] });
+    expect(mocks.movePathToTrash).not.toHaveBeenCalledWith("/journal");
+    expect(mocks.movePathToTrash).not.toHaveBeenCalledWith("/journal/agent");
+    expect(mocks.movePathToTrash).toHaveBeenCalledWith("/deleted/sessions");
+    expect(mocks.beginAgentDeletionFinish).toHaveBeenCalledOnce();
+  });
+
+  it("does not collapse a symlink trash target with its canonical descendant", async () => {
+    mocks.findAgentEntryIndex.mockReturnValue(-1);
+    mocks.readAgentDeletionJournal.mockReturnValue({
+      agentId: "test-agent",
+      operationId: "delete-1",
+      agentDir: "/canonical/agent",
+      workspaceDir: "/journal/link",
+      sessionsDir: "/journal/sessions",
+      createdAt: 1,
+      cleanupCompleted: false,
+      deleteFiles: true,
+    });
+    mocks.resolveRegisteredAgentIdForDir.mockImplementation((pathname?: string) =>
+      pathname === "/canonical/agent" ? "test-agent" : undefined,
+    );
+    mocks.normalizeAgentDirRegistryPath.mockImplementation((pathname: string) =>
+      pathname === "/journal/link" ? "/canonical" : pathname,
+    );
+    mocks.fsLstat.mockImplementation(
+      async (pathname: unknown) =>
+        ({
+          isSymbolicLink: () => pathname === "/journal/link",
+        }) as unknown as import("node:fs").Stats,
+    );
+    mocks.movePathToTrash.mockImplementation(async (pathname?: string) => {
+      if (pathname === "/canonical/agent") {
+        throw new Error("agent trash failed");
+      }
+      return "/trashed";
+    });
+
+    const { respond, promise } = makeCall("agents.delete", { agentId: "test-agent" });
+    await promise;
+
+    expectRespondOk(respond, {
+      failed: [{ path: "/canonical/agent", reason: "agent trash failed" }],
+    });
+    expect(mocks.movePathToTrash).toHaveBeenCalledWith("/journal/link");
+    expect(mocks.movePathToTrash).toHaveBeenCalledWith("/canonical/agent");
+    expect(mocks.unregisterResolvedAgentDir).not.toHaveBeenCalled();
+    expect(mocks.beginAgentDeletionFinish).not.toHaveBeenCalled();
+  });
+
   it("reclaims durable journal ownership after a process restart", async () => {
     const directoryOwners = new Map<string, string>();
     mocks.findAgentEntryIndex.mockReturnValue(-1);
@@ -2064,7 +2242,12 @@ describe("agents.delete", () => {
   });
 
   it("reports an absent source without invoking the trash backend", async () => {
-    mocks.fsLstat.mockRejectedValueOnce(createEnoentError());
+    mocks.fsLstat.mockImplementation(async (pathname: unknown) => {
+      if (pathname === "/workspace/test-agent") {
+        throw createEnoentError();
+      }
+      return null as unknown as import("node:fs").Stats;
+    });
 
     const { respond, promise } = makeCall("agents.delete", {
       agentId: "test-agent",
@@ -2084,9 +2267,13 @@ describe("agents.delete", () => {
   });
 
   it("retains workspace state when workspace presence cannot be checked", async () => {
-    mocks.fsLstat.mockRejectedValueOnce(
-      Object.assign(new Error("permission denied"), { code: "EACCES" }),
-    );
+    const permissionError = Object.assign(new Error("permission denied"), { code: "EACCES" });
+    mocks.fsLstat.mockImplementation(async (pathname: unknown) => {
+      if (pathname === "/workspace/test-agent") {
+        throw permissionError;
+      }
+      return null as unknown as import("node:fs").Stats;
+    });
 
     const { respond, promise } = makeCall("agents.delete", {
       agentId: "test-agent",

--- a/src/gateway/server-methods/agents-mutate.test.ts
+++ b/src/gateway/server-methods/agents-mutate.test.ts
@@ -195,10 +195,16 @@ vi.mock("../../agents/agent-lifecycle-registry.js", () => ({
     }
   },
   beginAgentDeletion: (entry: Record<string, unknown>) => ({
-    entry: Object.assign(entry, { databasePaths: entry.databasePaths ?? [] }),
+    entry: Object.assign(entry, {
+      databasePaths: entry.databasePaths ?? [],
+      cleanupPaths: entry.cleanupPaths ?? [],
+    }),
     commit: mocks.beginAgentDeletionCommit,
     fenceDatabasePaths: (paths: string[]) => {
       entry.databasePaths = [...new Set(paths)];
+    },
+    fenceCleanupPaths: (paths: unknown[]) => {
+      entry.cleanupPaths = [...paths];
     },
     finish: mocks.beginAgentDeletionFinish,
     rollback: mocks.beginAgentDeletionRollback,
@@ -1234,7 +1240,10 @@ describe("agents.update", () => {
 describe("agents.delete", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.fsLstat.mockResolvedValue(null as unknown as import("node:fs").Stats);
+    mocks.fsLstat.mockResolvedValue({
+      isSymbolicLink: () => false,
+    } as unknown as import("node:fs").Stats);
+    mocks.fsRealpath.mockImplementation(async (pathname: string) => pathname);
     mocks.loadConfigReturn = {};
     mocks.findAgentEntryIndex.mockReturnValue(0);
     mocks.pruneAgentConfig.mockReturnValue({ config: {}, removedBindings: 2 });
@@ -1516,6 +1525,59 @@ describe("agents.delete", () => {
     expectRespondOk(recreated.respond, { ok: true, agentId: "test-agent" });
   });
 
+  it("extends a recovery cleanup snapshot with newly discovered database files", async () => {
+    const relocatedDatabase = "/relocated/recovered.sqlite";
+    const journal = {
+      agentId: "test-agent",
+      operationId: "delete-1",
+      agentDir: "/journal/agent",
+      workspaceDir: "/journal/workspace",
+      sessionsDir: "/journal/sessions",
+      databasePaths: [],
+      cleanupPaths: [
+        {
+          path: "/journal/agent",
+          kind: "target" as const,
+          sourcePaths: ["/journal/agent"],
+        },
+        {
+          path: "/journal/workspace",
+          kind: "target" as const,
+          sourcePaths: ["/journal/workspace"],
+        },
+        {
+          path: "/journal/sessions",
+          kind: "target" as const,
+          sourcePaths: ["/journal/sessions"],
+        },
+      ],
+      createdAt: 1,
+      cleanupCompleted: false,
+      deleteFiles: true,
+    };
+    mocks.findAgentEntryIndex.mockReturnValue(-1);
+    mocks.readAgentDeletionJournal.mockReturnValue(journal);
+    mocks.listOpenClawRegisteredAgentDatabases.mockReturnValue([
+      { agentId: "test-agent", path: relocatedDatabase },
+    ]);
+
+    const { respond, promise } = makeCall("agents.delete", { agentId: "test-agent" });
+    await promise;
+
+    expectRespondOk(respond, { failed: [] });
+    for (const databasePath of [
+      relocatedDatabase,
+      `${relocatedDatabase}-wal`,
+      `${relocatedDatabase}-shm`,
+    ]) {
+      expect(journal.cleanupPaths.some((entry) => entry.sourcePaths.includes(databasePath))).toBe(
+        true,
+      );
+      expect(mocks.movePathToTrash).toHaveBeenCalledWith(databasePath);
+    }
+    expect(mocks.beginAgentDeletionFinish).toHaveBeenCalledOnce();
+  });
+
   it("treats a source that disappears during Trash as successful cleanup", async () => {
     let workspaceLstatCalls = 0;
     mocks.fsLstat.mockImplementation(async (pathname: unknown) => {
@@ -1534,18 +1596,14 @@ describe("agents.delete", () => {
     const { respond, promise } = makeCall("agents.delete", { agentId: "test-agent" });
     await promise;
 
-    expectRespondOk(respond, {
-      removed: [
-        { path: "/workspace/test-agent", method: "missing" },
-        { path: "/agents/test-agent", method: "trash" },
-        { path: "/transcripts/test-agent", method: "trash" },
-      ],
-      failed: [],
-    });
+    const result = expectRespondOk(respond, { failed: [] });
+    expect(result.removed).toEqual(
+      expect.arrayContaining([{ path: "/workspace/test-agent", method: "missing" }]),
+    );
     expect(mocks.beginAgentDeletionFinish).toHaveBeenCalledOnce();
   });
 
-  it("canonicalizes overlapping journal paths and cleans only the outermost path", async () => {
+  it("canonicalizes overlapping journal paths and cleans descendants first", async () => {
     mocks.findAgentEntryIndex.mockReturnValue(-1);
     mocks.readAgentDeletionJournal.mockReturnValue({
       agentId: "test-agent",
@@ -1561,12 +1619,13 @@ describe("agents.delete", () => {
     const { respond, promise } = makeCall("agents.delete", { agentId: "test-agent" });
     await promise;
 
-    expectRespondOk(respond, {
-      removed: [{ path: "/journal", method: "trash" }],
-      failed: [],
-    });
-    expect(mocks.movePathToTrash).toHaveBeenCalledOnce();
-    expect(mocks.movePathToTrash).toHaveBeenCalledWith("/journal");
+    expectRespondOk(respond, { failed: [] });
+    const trashedPaths = mocks.movePathToTrash.mock.calls.map(([pathname]) => pathname);
+    expect(trashedPaths).toHaveLength(new Set(trashedPaths).size);
+    expect(trashedPaths.indexOf("/journal/agent/sessions")).toBeLessThan(
+      trashedPaths.indexOf("/journal/agent"),
+    );
+    expect(trashedPaths.indexOf("/journal/agent")).toBeLessThan(trashedPaths.indexOf("/journal"));
     expect(mocks.deleteWorkspaceState).toHaveBeenCalledWith({ workspaceDir: "/journal" });
     expect(mocks.beginAgentDeletionFinish).toHaveBeenCalledOnce();
   });
@@ -1597,32 +1656,37 @@ describe("agents.delete", () => {
     expect(mocks.beginAgentDeletionFinish).toHaveBeenCalledOnce();
   });
 
-  it("does not collapse a symlink trash target with its canonical descendant", async () => {
+  it("does not move a symlink ancestor when its canonical descendant fails", async () => {
+    const agentLink = "/deep/journal/link";
+    const agentTarget = "/target";
     mocks.findAgentEntryIndex.mockReturnValue(-1);
     mocks.readAgentDeletionJournal.mockReturnValue({
       agentId: "test-agent",
       operationId: "delete-1",
-      agentDir: "/canonical/agent",
-      workspaceDir: "/journal/link",
-      sessionsDir: "/journal/sessions",
+      agentDir: agentLink,
+      workspaceDir: "/deep",
+      sessionsDir: "/deep/sessions",
       createdAt: 1,
       cleanupCompleted: false,
       deleteFiles: true,
     });
     mocks.resolveRegisteredAgentIdForDir.mockImplementation((pathname?: string) =>
-      pathname === "/canonical/agent" ? "test-agent" : undefined,
+      pathname === agentLink ? "test-agent" : undefined,
     );
     mocks.normalizeAgentDirRegistryPath.mockImplementation((pathname: string) =>
-      pathname === "/journal/link" ? "/canonical" : pathname,
+      pathname.replace(agentLink, agentTarget),
+    );
+    mocks.fsRealpath.mockImplementation(async (pathname: string) =>
+      pathname.replace(agentLink, agentTarget),
     );
     mocks.fsLstat.mockImplementation(
       async (pathname: unknown) =>
         ({
-          isSymbolicLink: () => pathname === "/journal/link",
+          isSymbolicLink: () => pathname === agentLink,
         }) as unknown as import("node:fs").Stats,
     );
     mocks.movePathToTrash.mockImplementation(async (pathname?: string) => {
-      if (pathname === "/canonical/agent") {
+      if (pathname === agentTarget) {
         throw new Error("agent trash failed");
       }
       return "/trashed";
@@ -1632,12 +1696,203 @@ describe("agents.delete", () => {
     await promise;
 
     expectRespondOk(respond, {
-      failed: [{ path: "/canonical/agent", reason: "agent trash failed" }],
+      failed: [{ path: agentTarget, reason: "agent trash failed" }],
     });
-    expect(mocks.movePathToTrash).toHaveBeenCalledWith("/journal/link");
-    expect(mocks.movePathToTrash).toHaveBeenCalledWith("/canonical/agent");
+    expect(mocks.movePathToTrash).not.toHaveBeenCalledWith(agentLink);
+    expect(mocks.movePathToTrash).not.toHaveBeenCalledWith("/deep");
+    expect(mocks.movePathToTrash).toHaveBeenCalledWith(agentTarget);
     expect(mocks.unregisterResolvedAgentDir).not.toHaveBeenCalled();
     expect(mocks.beginAgentDeletionFinish).not.toHaveBeenCalled();
+  });
+
+  it("does not trash a replacement at a journaled symlink path", async () => {
+    const workspaceLink = "/journal/workspace-link";
+    mocks.findAgentEntryIndex.mockReturnValue(-1);
+    mocks.readAgentDeletionJournal.mockReturnValue({
+      agentId: "test-agent",
+      operationId: "delete-1",
+      agentDir: "/journal/agent",
+      workspaceDir: workspaceLink,
+      sessionsDir: "/journal/sessions",
+      cleanupPaths: [
+        {
+          path: "/canonical/workspace",
+          kind: "target",
+          sourcePaths: [workspaceLink],
+        },
+        { path: workspaceLink, kind: "symlink", sourcePaths: [workspaceLink] },
+        {
+          path: "/journal/agent",
+          kind: "target",
+          sourcePaths: ["/journal/agent"],
+        },
+        {
+          path: "/journal/sessions",
+          kind: "target",
+          sourcePaths: ["/journal/sessions"],
+        },
+      ],
+      createdAt: 1,
+      cleanupCompleted: false,
+      deleteFiles: true,
+    });
+
+    const { respond, promise } = makeCall("agents.delete", { agentId: "test-agent" });
+    await promise;
+
+    expectRespondOk(respond, {
+      failed: [
+        {
+          path: workspaceLink,
+          reason: "cleanup path changed from symlink before deletion",
+        },
+      ],
+    });
+    expect(mocks.movePathToTrash).not.toHaveBeenCalledWith(workspaceLink);
+    expect(mocks.beginAgentDeletionFinish).not.toHaveBeenCalled();
+  });
+
+  it("resolves a symlinked workspace and removes descendants before its target and link", async () => {
+    const workspaceLink = "/tmp-root/workspace-link";
+    const workspaceTarget = "/real-tmp/workspace";
+    const agentDir = `${workspaceLink}/agent`;
+    const sessionsDir = `${workspaceLink}/transcripts`;
+    mocks.findAgentEntryIndex.mockReturnValue(-1);
+    mocks.readAgentDeletionJournal.mockReturnValue({
+      agentId: "test-agent",
+      operationId: "delete-1",
+      agentDir,
+      workspaceDir: workspaceLink,
+      sessionsDir,
+      createdAt: 1,
+      cleanupCompleted: false,
+      deleteFiles: true,
+    });
+    mocks.resolveRegisteredAgentIdForDir.mockImplementation((pathname?: string) =>
+      pathname === agentDir ? "test-agent" : undefined,
+    );
+    mocks.normalizeAgentDirRegistryPath.mockImplementation((pathname: string) =>
+      pathname.replace(workspaceLink, workspaceTarget),
+    );
+    mocks.fsRealpath.mockImplementation(async (pathname: string) =>
+      pathname.replace(workspaceLink, workspaceTarget),
+    );
+    mocks.fsLstat.mockImplementation(
+      async (pathname: unknown) =>
+        ({
+          isSymbolicLink: () => pathname === workspaceLink,
+        }) as unknown as import("node:fs").Stats,
+    );
+
+    const { respond, promise } = makeCall("agents.delete", { agentId: "test-agent" });
+    await promise;
+
+    expectRespondOk(respond, { failed: [] });
+    const trashedPaths = mocks.movePathToTrash.mock.calls.map(([pathname]) => String(pathname));
+    const targetIndex = trashedPaths.indexOf(workspaceTarget);
+    expect(trashedPaths.indexOf(`${workspaceTarget}/agent`)).toBeLessThan(targetIndex);
+    expect(trashedPaths.indexOf(`${workspaceTarget}/transcripts`)).toBeLessThan(targetIndex);
+    expect(targetIndex).toBeLessThan(trashedPaths.indexOf(workspaceLink));
+    expect(mocks.movePathToTrash).toHaveBeenCalledWith(workspaceTarget);
+    expect(mocks.movePathToTrash).toHaveBeenCalledWith(workspaceLink);
+    expect(mocks.beginAgentDeletionFinish).toHaveBeenCalledOnce();
+  });
+
+  it("does not commit deletion when a journaled path cannot be resolved", async () => {
+    const resolutionError = Object.assign(new Error("workspace target is inaccessible"), {
+      code: "EACCES",
+    });
+    mocks.fsRealpath.mockImplementation(async (pathname: string) => {
+      if (pathname === "/workspace/test-agent") {
+        throw resolutionError;
+      }
+      return pathname;
+    });
+
+    const { respond, promise } = makeCall("agents.delete", { agentId: "test-agent" });
+    await expect(promise).rejects.toBe(resolutionError);
+
+    expect(respond).not.toHaveBeenCalled();
+    expect(mocks.writeConfigFile).not.toHaveBeenCalled();
+    expect(mocks.movePathToTrash).not.toHaveBeenCalled();
+    expect(mocks.beginAgentDeletionRollback).toHaveBeenCalledOnce();
+    expect(mocks.beginAgentDeletionFinish).not.toHaveBeenCalled();
+  });
+
+  it("recovers against the persisted target when a workspace symlink is retargeted", async () => {
+    const workspaceLink = "/tmp-root/workspace-link";
+    const originalTarget = "/real-tmp/original-workspace";
+    const retargetedWorkspace = "/real-tmp/replacement-workspace";
+    const missingTranscriptTarget = `${originalTarget}/transcripts`;
+    const journal = {
+      agentId: "test-agent",
+      operationId: "delete-1",
+      agentDir: `${workspaceLink}/agent`,
+      workspaceDir: workspaceLink,
+      sessionsDir: `${workspaceLink}/transcripts`,
+      createdAt: 1,
+      cleanupCompleted: false,
+      deleteFiles: true,
+    };
+    const trashed = new Set<string>();
+    let workspaceAttempts = 0;
+    mocks.findAgentEntryIndex.mockReturnValue(-1);
+    mocks.readAgentDeletionJournal.mockReturnValue(journal);
+    mocks.resolveRegisteredAgentIdForDir.mockImplementation((pathname?: string) =>
+      pathname === journal.agentDir ? "test-agent" : undefined,
+    );
+    mocks.normalizeAgentDirRegistryPath.mockImplementation((pathname: string) =>
+      pathname.replace(workspaceLink, originalTarget),
+    );
+    mocks.fsRealpath.mockImplementation(async (pathname: string) => {
+      if (pathname === journal.sessionsDir) {
+        throw createEnoentError();
+      }
+      return pathname.replace(workspaceLink, originalTarget);
+    });
+    mocks.fsLstat.mockImplementation(async (pathname: unknown) => {
+      if (
+        pathname === journal.sessionsDir ||
+        pathname === missingTranscriptTarget ||
+        trashed.has(String(pathname))
+      ) {
+        throw createEnoentError();
+      }
+      return {
+        isSymbolicLink: () => pathname === workspaceLink,
+      } as unknown as import("node:fs").Stats;
+    });
+    mocks.movePathToTrash.mockImplementation(async (pathname?: string) => {
+      if (pathname === originalTarget && workspaceAttempts++ === 0) {
+        throw new Error("workspace trash failed");
+      }
+      trashed.add(pathname ?? "");
+      return "/trashed";
+    });
+
+    const firstDelete = makeCall("agents.delete", { agentId: "test-agent" });
+    await firstDelete.promise;
+
+    expectRespondOk(firstDelete.respond, {
+      failed: [{ path: originalTarget, reason: "workspace trash failed" }],
+    });
+    expect(mocks.beginAgentDeletionFinish).not.toHaveBeenCalled();
+    expect(journal).toHaveProperty("cleanupPaths");
+
+    mocks.fsRealpath.mockClear();
+    mocks.fsRealpath.mockImplementation(async (pathname: string) =>
+      pathname.replace(workspaceLink, retargetedWorkspace),
+    );
+    const recovery = makeCall("agents.delete", { agentId: "test-agent" });
+    await recovery.promise;
+
+    expectRespondOk(recovery.respond, { failed: [] });
+    expect(mocks.fsRealpath).not.toHaveBeenCalled();
+    expect(mocks.movePathToTrash).not.toHaveBeenCalledWith(retargetedWorkspace);
+    expect(mocks.movePathToTrash).not.toHaveBeenCalledWith(`${retargetedWorkspace}/transcripts`);
+    expect(mocks.movePathToTrash).toHaveBeenCalledWith(originalTarget);
+    expect(mocks.movePathToTrash).toHaveBeenCalledWith(workspaceLink);
+    expect(mocks.beginAgentDeletionFinish).toHaveBeenCalledOnce();
   });
 
   it("reclaims durable journal ownership after a process restart", async () => {
@@ -1771,7 +2026,7 @@ describe("agents.delete", () => {
       claimed ? [{ agentId: "other-agent", path: "/journal/agent/survivor.sqlite" }] : [],
     );
     mocks.movePathToTrash.mockImplementation(async (pathname?: string) => {
-      if (pathname === "/journal/workspace") {
+      if (pathname === "/journal/agent/openclaw-agent.sqlite") {
         claimed = true;
       }
       return "/trashed";
@@ -1781,6 +2036,7 @@ describe("agents.delete", () => {
     await promise;
 
     expectRespondOk(respond, { ok: true });
+    expect(mocks.movePathToTrash).toHaveBeenCalledWith("/journal/agent/openclaw-agent.sqlite");
     expect(mocks.movePathToTrash).toHaveBeenCalledWith("/journal/workspace");
     expect(mocks.movePathToTrash).not.toHaveBeenCalledWith("/journal/agent");
     expect(mocks.movePathToTrash).not.toHaveBeenCalledWith("/journal/agent/survivor.sqlite");
@@ -2050,7 +2306,12 @@ describe("agents.delete", () => {
   });
 
   it("releases cleaned directory ownership while a sibling Trash cleanup remains fenced", async () => {
-    mocks.movePathToTrash.mockRejectedValueOnce(new Error("trash unavailable"));
+    mocks.movePathToTrash.mockImplementation(async (pathname?: string) => {
+      if (pathname === "/workspace/test-agent") {
+        throw new Error("trash unavailable");
+      }
+      return "/trashed";
+    });
 
     const { respond, promise } = makeCall("agents.delete", { agentId: "test-agent" });
     await promise;
@@ -2147,20 +2408,18 @@ describe("agents.delete", () => {
     });
     await promise;
 
-    expect(respond).toHaveBeenCalledWith(
-      true,
-      {
-        ok: true,
-        agentId: "test-agent",
-        removedBindings: 2,
-        removed: [
-          { path: "/workspace/test-agent", method: "trash" },
-          { path: "/agents/test-agent", method: "trash" },
-          { path: "/transcripts/test-agent", method: "trash" },
-        ],
-        failed: [],
-      },
-      undefined,
+    const result = expectRespondOk(respond, {
+      ok: true,
+      agentId: "test-agent",
+      removedBindings: 2,
+      failed: [],
+    });
+    expect(result.removed).toEqual(
+      expect.arrayContaining([
+        { path: "/workspace/test-agent", method: "trash" },
+        { path: "/agents/test-agent", method: "trash" },
+        { path: "/transcripts/test-agent", method: "trash" },
+      ]),
     );
     expect(mocks.writeConfigFile).toHaveBeenCalled();
     expect(mocks.movePathToTrash).toHaveBeenCalled();
@@ -2212,8 +2471,8 @@ describe("agents.delete", () => {
 
   it("reports trash failures without deleting the retained directory", async () => {
     const actualFs = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
-    const workspaceDir = await actualFs.mkdtemp(
-      path.join(os.tmpdir(), "openclaw-agent-delete-trash-failure-"),
+    const workspaceDir = await actualFs.realpath(
+      await actualFs.mkdtemp(path.join(os.tmpdir(), "openclaw-agent-delete-trash-failure-")),
     );
     mocks.resolveAgentWorkspaceDir.mockReturnValue(workspaceDir);
     mocks.movePathToTrash.mockRejectedValueOnce(
@@ -2227,10 +2486,6 @@ describe("agents.delete", () => {
       await promise;
 
       expectRespondOk(respond, {
-        removed: [
-          { path: "/agents/test-agent", method: "trash" },
-          { path: "/transcripts/test-agent", method: "trash" },
-        ],
         failed: [{ path: workspaceDir, reason: "trash destination missing" }],
       });
       await expect(actualFs.stat(workspaceDir)).resolves.toBeDefined();
@@ -2254,19 +2509,15 @@ describe("agents.delete", () => {
     });
     await promise;
 
-    expectRespondOk(respond, {
-      removed: [
-        { path: "/workspace/test-agent", method: "missing" },
-        { path: "/agents/test-agent", method: "trash" },
-        { path: "/transcripts/test-agent", method: "trash" },
-      ],
-      failed: [],
-    });
+    const result = expectRespondOk(respond, { failed: [] });
+    expect(result.removed).toEqual(
+      expect.arrayContaining([{ path: "/workspace/test-agent", method: "missing" }]),
+    );
     expect(mocks.movePathToTrash).not.toHaveBeenCalledWith("/workspace/test-agent");
     expect(mocks.deleteWorkspaceState).toHaveBeenCalled();
   });
 
-  it("retains workspace state when workspace presence cannot be checked", async () => {
+  it("does not commit deletion when workspace presence cannot be checked", async () => {
     const permissionError = Object.assign(new Error("permission denied"), { code: "EACCES" });
     mocks.fsLstat.mockImplementation(async (pathname: unknown) => {
       if (pathname === "/workspace/test-agent") {
@@ -2278,12 +2529,13 @@ describe("agents.delete", () => {
     const { respond, promise } = makeCall("agents.delete", {
       agentId: "test-agent",
     });
-    await promise;
+    await expect(promise).rejects.toBe(permissionError);
 
-    expectRespondOk(respond, {
-      failed: [{ path: "/workspace/test-agent", reason: "permission denied" }],
-    });
+    expect(respond).not.toHaveBeenCalled();
+    expect(mocks.writeConfigFile).not.toHaveBeenCalled();
+    expect(mocks.movePathToTrash).not.toHaveBeenCalled();
     expect(mocks.deleteWorkspaceState).not.toHaveBeenCalled();
+    expect(mocks.beginAgentDeletionRollback).toHaveBeenCalledOnce();
   });
 
   it("skips file deletion when deleteFiles is false", async () => {

--- a/src/gateway/server-methods/agents-mutate.test.ts
+++ b/src/gateway/server-methods/agents-mutate.test.ts
@@ -45,9 +45,16 @@ const mocks = vi.hoisted(() => ({
   ),
   closeOpenClawAgentDatabaseByPath: vi.fn((_pathname?: string) => true),
   listOpenClawRegisteredAgentDatabases: vi.fn(() => [] as Array<Record<string, unknown>>),
+  beginOpenClawAgentDatabaseRegistrationFence: vi.fn(() => vi.fn()),
   unregisterOpenClawAgentDatabase: vi.fn(),
   assertNoOpenClawAgentDatabaseLeases: vi.fn(),
-  unregisterResolvedAgentDir: vi.fn(),
+  registerResolvedAgentDir: vi.fn(),
+  resolveRegisteredAgentIdForDir: vi.fn((_pathname?: string) => undefined as string | undefined),
+  isPathOwnedByAnotherRegisteredAgent: vi.fn(
+    (_params?: { agentId: string; pathname: string }) => false,
+  ),
+  normalizeAgentDirRegistryPath: vi.fn((pathname: string) => path.resolve(pathname)),
+  unregisterResolvedAgentDir: vi.fn(() => true),
   cronRemoveAgentJobsTransactional: vi.fn(
     async (_agentId: string, commit: () => Promise<unknown>) => await commit(),
   ),
@@ -174,6 +181,10 @@ vi.mock("../../agents/agent-scope.js", () => ({
 }));
 
 vi.mock("../../agents/agent-dir-registry.js", () => ({
+  isPathOwnedByAnotherRegisteredAgent: mocks.isPathOwnedByAnotherRegisteredAgent,
+  normalizeAgentDirRegistryPath: mocks.normalizeAgentDirRegistryPath,
+  registerResolvedAgentDir: mocks.registerResolvedAgentDir,
+  resolveRegisteredAgentIdForDir: mocks.resolveRegisteredAgentIdForDir,
   unregisterResolvedAgentDir: mocks.unregisterResolvedAgentDir,
 }));
 
@@ -209,6 +220,7 @@ vi.mock("../../state/agent-deletion-journal.js", () => ({
 }));
 
 vi.mock("../../state/openclaw-agent-db-registry.js", () => ({
+  beginOpenClawAgentDatabaseRegistrationFence: mocks.beginOpenClawAgentDatabaseRegistrationFence,
   unregisterOpenClawAgentDatabase: mocks.unregisterOpenClawAgentDatabase,
 }));
 
@@ -329,8 +341,17 @@ beforeEach(() => {
     );
   mocks.closeOpenClawAgentDatabaseByPath.mockReset().mockReturnValue(true);
   mocks.listOpenClawRegisteredAgentDatabases.mockReset().mockReturnValue([]);
+  mocks.beginOpenClawAgentDatabaseRegistrationFence.mockReset().mockReturnValue(vi.fn());
   mocks.unregisterOpenClawAgentDatabase.mockReset();
-  mocks.unregisterResolvedAgentDir.mockReset();
+  mocks.registerResolvedAgentDir.mockReset();
+  mocks.resolveRegisteredAgentIdForDir
+    .mockReset()
+    .mockImplementation((pathname?: string) =>
+      pathname === "/agents/test-agent" || pathname === "/journal/agent" ? "test-agent" : undefined,
+    );
+  mocks.isPathOwnedByAnotherRegisteredAgent.mockReset().mockReturnValue(false);
+  mocks.normalizeAgentDirRegistryPath.mockReset().mockImplementation((pathname) => pathname);
+  mocks.unregisterResolvedAgentDir.mockReset().mockReturnValue(true);
   mocks.cronRemoveAgentJobsTransactional
     .mockReset()
     .mockImplementation(async (_agentId: string, commit: () => Promise<unknown>) => await commit());
@@ -1217,6 +1238,7 @@ describe("agents.delete", () => {
     mocks.loadConfigReturn = {};
     mocks.findAgentEntryIndex.mockReturnValue(0);
     mocks.pruneAgentConfig.mockReturnValue({ config: {}, removedBindings: 2 });
+    mocks.movePathToTrash.mockReset().mockResolvedValue("/trashed");
   });
 
   it("removes only the deleted agent's authority before committing its roster removal", async () => {
@@ -1261,6 +1283,7 @@ describe("agents.delete", () => {
     });
     mocks.unregisterResolvedAgentDir.mockImplementationOnce(() => {
       events.push("directory");
+      return true;
     });
     mocks.closeOpenClawAgentDatabaseByPath.mockImplementation(() => {
       events.push("database");
@@ -1411,7 +1434,7 @@ describe("agents.delete", () => {
     expect(mocks.unregisterOpenClawAgentDatabase).not.toHaveBeenCalled();
   });
 
-  it("resumes a journaled deletion after the roster entry is already absent", async () => {
+  it("resumes a journaled deletion while its directory is still owned by the deleted agent", async () => {
     mocks.findAgentEntryIndex.mockReturnValue(-1);
     mocks.readAgentDeletionJournal.mockReturnValue({
       agentId: "test-agent",
@@ -1429,9 +1452,376 @@ describe("agents.delete", () => {
     expect(mocks.closeOpenClawAgentDatabaseByPath).toHaveBeenCalledWith(
       "/journal/agent/openclaw-agent.sqlite",
     );
+    expect(mocks.unregisterResolvedAgentDir).toHaveBeenCalledWith({
+      agentId: "test-agent",
+      agentDir: "/journal/agent",
+    });
     expect(mocks.movePathToTrash).toHaveBeenCalledWith("/journal/workspace");
     expect(mocks.movePathToTrash).toHaveBeenCalledWith("/journal/agent");
     expect(mocks.movePathToTrash).toHaveBeenCalledWith("/journal/sessions");
+    expect(mocks.beginAgentDeletionFinish).toHaveBeenCalledOnce();
+  });
+
+  it("reclaims durable journal ownership after a process restart", async () => {
+    const directoryOwners = new Map<string, string>();
+    mocks.findAgentEntryIndex.mockReturnValue(-1);
+    mocks.readAgentDeletionJournal.mockReturnValue({
+      agentId: "test-agent",
+      operationId: "delete-1",
+      agentDir: "/journal/agent",
+      workspaceDir: "/journal/workspace",
+      sessionsDir: "/journal/sessions",
+      createdAt: 1,
+      cleanupCompleted: false,
+      deleteFiles: true,
+    });
+    mocks.resolveRegisteredAgentIdForDir.mockImplementation((pathname?: string) =>
+      directoryOwners.get(pathname ?? ""),
+    );
+    mocks.registerResolvedAgentDir.mockImplementation(
+      ({ agentId, agentDir }: { agentId: string; agentDir: string }) => {
+        directoryOwners.set(agentDir, agentId);
+      },
+    );
+    mocks.unregisterResolvedAgentDir.mockImplementation(
+      ({ agentId, agentDir }: { agentId: string; agentDir: string }) => {
+        if (directoryOwners.get(agentDir) !== agentId) {
+          return false;
+        }
+        return directoryOwners.delete(agentDir);
+      },
+    );
+
+    const { respond, promise } = makeCall("agents.delete", { agentId: "test-agent" });
+    await promise;
+
+    expectRespondOk(respond, { ok: true });
+    expect(mocks.registerResolvedAgentDir).toHaveBeenCalledWith({
+      agentId: "test-agent",
+      agentDir: "/journal/agent",
+    });
+    expect(mocks.closeOpenClawAgentDatabaseByPath).toHaveBeenCalledWith(
+      "/journal/agent/openclaw-agent.sqlite",
+    );
+    expect(mocks.movePathToTrash).toHaveBeenCalledWith("/journal/agent");
+    expect(directoryOwners.has("/journal/agent")).toBe(false);
+    expect(mocks.beginAgentDeletionFinish).toHaveBeenCalledOnce();
+  });
+
+  it("settles recovery without touching a journaled directory claimed by another agent", async () => {
+    const directoryOwners = new Map([["/journal/agent", "other-agent"]]);
+    const databaseRows = [
+      { agentId: "test-agent", path: "/journal/agent/openclaw-agent.sqlite" },
+      { agentId: "other-agent", path: "/journal/agent/openclaw-agent.sqlite" },
+    ];
+    mocks.findAgentEntryIndex.mockReturnValue(-1);
+    mocks.readAgentDeletionJournal.mockReturnValue({
+      agentId: "test-agent",
+      operationId: "delete-1",
+      agentDir: "/journal/agent",
+      workspaceDir: "/journal/workspace",
+      sessionsDir: "/journal/sessions",
+      createdAt: 1,
+      cleanupCompleted: false,
+      deleteFiles: true,
+    });
+    mocks.resolveRegisteredAgentIdForDir.mockImplementation((pathname?: string) =>
+      directoryOwners.get(pathname ?? ""),
+    );
+    mocks.isPathOwnedByAnotherRegisteredAgent.mockImplementation(
+      ({ agentId, pathname }: { agentId: string; pathname: string }) =>
+        (pathname === "/journal/agent" || pathname.startsWith("/journal/agent/")) &&
+        directoryOwners.get("/journal/agent") !== agentId,
+    );
+    mocks.unregisterResolvedAgentDir.mockImplementation(
+      ({ agentId, agentDir }: { agentId: string; agentDir: string }) => {
+        if (directoryOwners.get(agentDir) !== agentId) {
+          return false;
+        }
+        return directoryOwners.delete(agentDir);
+      },
+    );
+    mocks.listOpenClawRegisteredAgentDatabases.mockImplementation(() => databaseRows);
+    mocks.unregisterOpenClawAgentDatabase.mockImplementation(
+      ({ agentId, path }: { agentId: string; path: string }) => {
+        const index = databaseRows.findIndex(
+          (entry) => entry.agentId === agentId && entry.path === path,
+        );
+        if (index >= 0) {
+          databaseRows.splice(index, 1);
+        }
+      },
+    );
+
+    const { respond, promise } = makeCall("agents.delete", { agentId: "test-agent" });
+    await promise;
+
+    expectRespondOk(respond, { ok: true });
+    expect(mocks.listOpenClawRegisteredAgentDatabases).toHaveBeenCalled();
+    expect(mocks.closeOpenClawAgentDatabaseByPath).not.toHaveBeenCalled();
+    expect(mocks.assertNoOpenClawAgentDatabaseLeases).toHaveBeenCalledWith("test-agent");
+    expect(mocks.movePathToTrash).not.toHaveBeenCalledWith("/journal/agent");
+    expect(mocks.unregisterOpenClawAgentDatabase).toHaveBeenCalledWith({
+      agentId: "test-agent",
+      path: "/journal/agent/openclaw-agent.sqlite",
+    });
+    expect(databaseRows).toEqual([
+      { agentId: "other-agent", path: "/journal/agent/openclaw-agent.sqlite" },
+    ]);
+    expect(mocks.unregisterResolvedAgentDir).toHaveBeenCalledWith({
+      agentId: "test-agent",
+      agentDir: "/journal/agent",
+    });
+    expect(directoryOwners.get("/journal/agent")).toBe("other-agent");
+    expect(mocks.beginAgentDeletionFinish).toHaveBeenCalledOnce();
+  });
+
+  it("revalidates database ownership after earlier filesystem cleanup", async () => {
+    let claimed = false;
+    mocks.findAgentEntryIndex.mockReturnValue(-1);
+    mocks.readAgentDeletionJournal.mockReturnValue({
+      agentId: "test-agent",
+      operationId: "delete-1",
+      agentDir: "/journal/agent",
+      workspaceDir: "/journal/workspace",
+      sessionsDir: "/journal/sessions",
+      createdAt: 1,
+      cleanupCompleted: false,
+      deleteFiles: true,
+    });
+    mocks.listOpenClawRegisteredAgentDatabases.mockImplementation(() =>
+      claimed ? [{ agentId: "other-agent", path: "/journal/agent/survivor.sqlite" }] : [],
+    );
+    mocks.movePathToTrash.mockImplementation(async (pathname?: string) => {
+      if (pathname === "/journal/workspace") {
+        claimed = true;
+      }
+      return "/trashed";
+    });
+
+    const { respond, promise } = makeCall("agents.delete", { agentId: "test-agent" });
+    await promise;
+
+    expectRespondOk(respond, { ok: true });
+    expect(mocks.movePathToTrash).toHaveBeenCalledWith("/journal/workspace");
+    expect(mocks.movePathToTrash).not.toHaveBeenCalledWith("/journal/agent");
+    expect(mocks.movePathToTrash).not.toHaveBeenCalledWith("/journal/agent/survivor.sqlite");
+    expect(mocks.beginAgentDeletionFinish).toHaveBeenCalledOnce();
+  });
+
+  it("cleans a relocated deleted-agent database while preserving a claimed agent directory", async () => {
+    mocks.findAgentEntryIndex.mockReturnValue(-1);
+    mocks.readAgentDeletionJournal.mockReturnValue({
+      agentId: "test-agent",
+      operationId: "delete-1",
+      agentDir: "/journal/agent",
+      workspaceDir: "/journal/workspace",
+      sessionsDir: "/journal/sessions",
+      createdAt: 1,
+      cleanupCompleted: false,
+      deleteFiles: true,
+    });
+    mocks.resolveRegisteredAgentIdForDir.mockImplementation((pathname?: string) =>
+      pathname === "/journal/agent" ? "other-agent" : undefined,
+    );
+    mocks.isPathOwnedByAnotherRegisteredAgent.mockImplementation(
+      ({ pathname }: { agentId: string; pathname: string }) =>
+        pathname === "/journal/agent" || pathname.startsWith("/journal/agent/"),
+    );
+    mocks.listOpenClawRegisteredAgentDatabases.mockReturnValue([
+      { agentId: "other-agent", path: "/journal/agent/openclaw-agent.sqlite" },
+      { agentId: "test-agent", path: "/relocated/deleted.sqlite" },
+    ]);
+
+    const { respond, promise } = makeCall("agents.delete", { agentId: "test-agent" });
+    await promise;
+
+    expectRespondOk(respond, { ok: true });
+    expect(mocks.closeOpenClawAgentDatabaseByPath).toHaveBeenCalledTimes(1);
+    expect(mocks.closeOpenClawAgentDatabaseByPath).toHaveBeenCalledWith(
+      "/relocated/deleted.sqlite",
+    );
+    expect(mocks.unregisterOpenClawAgentDatabase).toHaveBeenCalledWith({
+      agentId: "test-agent",
+      path: "/relocated/deleted.sqlite",
+    });
+    expect(mocks.movePathToTrash).not.toHaveBeenCalledWith("/journal/agent");
+    expect(mocks.beginAgentDeletionFinish).toHaveBeenCalledOnce();
+  });
+
+  it("protects every journaled path claimed as a surviving agent workspace", async () => {
+    mocks.loadConfigReturn = {
+      agents: { list: [{ id: "other-agent", workspace: "/journal" }] },
+    };
+    mocks.findAgentEntryIndex.mockReturnValue(-1);
+    mocks.readAgentDeletionJournal.mockReturnValue({
+      agentId: "test-agent",
+      operationId: "delete-1",
+      agentDir: "/journal/agent",
+      workspaceDir: "/journal/workspace",
+      sessionsDir: "/journal/sessions",
+      createdAt: 1,
+      cleanupCompleted: false,
+      deleteFiles: true,
+    });
+
+    const { respond, promise } = makeCall("agents.delete", { agentId: "test-agent" });
+    await promise;
+
+    expectRespondOk(respond, { ok: true, removed: [], failed: [] });
+    expect(mocks.closeOpenClawAgentDatabaseByPath).not.toHaveBeenCalled();
+    expect(mocks.movePathToTrash).not.toHaveBeenCalled();
+    expect(mocks.beginAgentDeletionFinish).toHaveBeenCalledOnce();
+  });
+
+  it("preserves a relocated database path registered to another agent", async () => {
+    const databaseRows = [
+      { agentId: "test-agent", path: "/linked/shared/agent.sqlite" },
+      { agentId: "other-agent", path: "/real/shared/agent.sqlite" },
+    ];
+    mocks.normalizeAgentDirRegistryPath.mockImplementation((pathname: string) =>
+      pathname.startsWith("/linked/shared/")
+        ? pathname.replace("/linked/shared/", "/real/shared/")
+        : path.resolve(pathname),
+    );
+    mocks.listOpenClawRegisteredAgentDatabases.mockImplementation(() => databaseRows);
+    mocks.unregisterOpenClawAgentDatabase.mockImplementation(
+      ({ agentId, path }: { agentId: string; path: string }) => {
+        const index = databaseRows.findIndex(
+          (entry) => entry.agentId === agentId && entry.path === path,
+        );
+        if (index >= 0) {
+          databaseRows.splice(index, 1);
+        }
+      },
+    );
+
+    const { respond, promise } = makeCall("agents.delete", { agentId: "test-agent" });
+    await promise;
+
+    expectRespondOk(respond, { ok: true });
+    expect(mocks.closeOpenClawAgentDatabaseByPath).toHaveBeenCalledTimes(1);
+    expect(mocks.closeOpenClawAgentDatabaseByPath).toHaveBeenCalledWith(
+      "/agents/test-agent/openclaw-agent.sqlite",
+    );
+    expect(mocks.closeOpenClawAgentDatabaseByPath).not.toHaveBeenCalledWith(
+      "/linked/shared/agent.sqlite",
+    );
+    expect(mocks.movePathToTrash).not.toHaveBeenCalledWith("/linked/shared/agent.sqlite");
+    expect(databaseRows).toEqual([{ agentId: "other-agent", path: "/real/shared/agent.sqlite" }]);
+    expect(mocks.beginAgentDeletionFinish).toHaveBeenCalledOnce();
+  });
+
+  it("preserves a parent directory containing another agent's relocated database", async () => {
+    mocks.listOpenClawRegisteredAgentDatabases.mockReturnValue([
+      { agentId: "other-agent", path: "/agents/test-agent/survivor.sqlite" },
+    ]);
+
+    const { respond, promise } = makeCall("agents.delete", { agentId: "test-agent" });
+    await promise;
+
+    expectRespondOk(respond, { ok: true });
+    expect(mocks.closeOpenClawAgentDatabaseByPath).toHaveBeenCalledWith(
+      "/agents/test-agent/openclaw-agent.sqlite",
+    );
+    expect(mocks.movePathToTrash).not.toHaveBeenCalledWith("/agents/test-agent");
+    expect(mocks.movePathToTrash).toHaveBeenCalledWith("/agents/test-agent/openclaw-agent.sqlite");
+    expect(mocks.beginAgentDeletionFinish).toHaveBeenCalledOnce();
+  });
+
+  it("does not close a database whose companion file is registered to another agent", async () => {
+    mocks.listOpenClawRegisteredAgentDatabases.mockReturnValue([
+      { agentId: "test-agent", path: "/shared/deleted.sqlite" },
+      { agentId: "other-agent", path: "/shared/deleted.sqlite-wal" },
+    ]);
+
+    const { respond, promise } = makeCall("agents.delete", { agentId: "test-agent" });
+    await promise;
+
+    expectRespondOk(respond, { ok: true });
+    expect(mocks.closeOpenClawAgentDatabaseByPath).not.toHaveBeenCalledWith(
+      "/shared/deleted.sqlite",
+    );
+    expect(mocks.movePathToTrash).not.toHaveBeenCalledWith("/shared/deleted.sqlite-wal");
+    expect(mocks.beginAgentDeletionFinish).toHaveBeenCalledOnce();
+  });
+
+  it("drops stale deleted ownership when overlap intentionally skips directory cleanup", async () => {
+    const directoryOwners = new Map([
+      ["/journal/agent", "test-agent"],
+      ["/journal/agent/current", "other-agent"],
+    ]);
+    mocks.findAgentEntryIndex.mockReturnValue(-1);
+    mocks.readAgentDeletionJournal.mockReturnValue({
+      agentId: "test-agent",
+      operationId: "delete-1",
+      agentDir: "/journal/agent",
+      workspaceDir: "/journal/workspace",
+      sessionsDir: "/journal/sessions",
+      createdAt: 1,
+      cleanupCompleted: false,
+      deleteFiles: true,
+    });
+    mocks.resolveRegisteredAgentIdForDir.mockImplementation((pathname?: string) =>
+      directoryOwners.get(pathname ?? ""),
+    );
+    mocks.isPathOwnedByAnotherRegisteredAgent.mockImplementation(
+      ({ agentId, pathname }: { agentId: string; pathname: string }) =>
+        pathname === "/journal/agent" && directoryOwners.get("/journal/agent/current") !== agentId,
+    );
+    mocks.unregisterResolvedAgentDir.mockImplementation(
+      ({ agentId, agentDir }: { agentId: string; agentDir: string }) => {
+        if (directoryOwners.get(agentDir) !== agentId) {
+          return false;
+        }
+        return directoryOwners.delete(agentDir);
+      },
+    );
+
+    const { respond, promise } = makeCall("agents.delete", { agentId: "test-agent" });
+    await promise;
+
+    expectRespondOk(respond, { ok: true });
+    expect(mocks.movePathToTrash).not.toHaveBeenCalledWith("/journal/agent");
+    expect(mocks.closeOpenClawAgentDatabaseByPath).toHaveBeenCalledWith(
+      "/journal/agent/openclaw-agent.sqlite",
+    );
+    expect(mocks.unregisterOpenClawAgentDatabase).toHaveBeenCalledWith({
+      agentId: "test-agent",
+      path: "/journal/agent/openclaw-agent.sqlite",
+    });
+    expect(directoryOwners.has("/journal/agent")).toBe(false);
+    expect(directoryOwners.get("/journal/agent/current")).toBe("other-agent");
+    expect(mocks.beginAgentDeletionFinish).toHaveBeenCalledOnce();
+  });
+
+  it("unregisters the captured canonical directory after trashing a symlink path", async () => {
+    mocks.findAgentEntryIndex.mockReturnValue(-1);
+    mocks.readAgentDeletionJournal.mockReturnValue({
+      agentId: "test-agent",
+      operationId: "delete-1",
+      agentDir: "/journal/linked-agent",
+      workspaceDir: "/journal/workspace",
+      sessionsDir: "/journal/sessions",
+      createdAt: 1,
+      cleanupCompleted: false,
+      deleteFiles: true,
+    });
+    mocks.resolveRegisteredAgentIdForDir.mockImplementation((pathname?: string) =>
+      pathname === "/journal/linked-agent" ? "test-agent" : undefined,
+    );
+    mocks.normalizeAgentDirRegistryPath.mockImplementation((pathname: string) =>
+      pathname === "/journal/linked-agent" ? "/canonical/agent" : pathname,
+    );
+
+    const { respond, promise } = makeCall("agents.delete", { agentId: "test-agent" });
+    await promise;
+
+    expectRespondOk(respond, { ok: true });
+    expect(mocks.unregisterResolvedAgentDir).toHaveBeenCalledWith({
+      agentId: "test-agent",
+      agentDir: "/canonical/agent",
+    });
     expect(mocks.beginAgentDeletionFinish).toHaveBeenCalledOnce();
   });
 
@@ -1481,7 +1871,7 @@ describe("agents.delete", () => {
     expect(mocks.unregisterOpenClawAgentDatabase).not.toHaveBeenCalled();
   });
 
-  it("keeps the deletion journal fenced when Trash cleanup fails", async () => {
+  it("releases cleaned directory ownership while a sibling Trash cleanup remains fenced", async () => {
     mocks.movePathToTrash.mockRejectedValueOnce(new Error("trash unavailable"));
 
     const { respond, promise } = makeCall("agents.delete", { agentId: "test-agent" });
@@ -1490,6 +1880,26 @@ describe("agents.delete", () => {
     expectRespondOk(respond, { ok: true });
     expect(mocks.beginAgentDeletionCommit).toHaveBeenCalledOnce();
     expect(mocks.beginAgentDeletionFinish).not.toHaveBeenCalled();
+    expect(mocks.unregisterResolvedAgentDir).toHaveBeenCalledWith({
+      agentId: "test-agent",
+      agentDir: "/agents/test-agent",
+    });
+  });
+
+  it("keeps directory ownership registered when that Trash cleanup fails", async () => {
+    mocks.movePathToTrash.mockImplementation(async (pathname?: string) => {
+      if (pathname === "/agents/test-agent") {
+        throw new Error("trash unavailable");
+      }
+      return "/trashed";
+    });
+
+    const { respond, promise } = makeCall("agents.delete", { agentId: "test-agent" });
+    await promise;
+
+    expectRespondOk(respond, { ok: true });
+    expect(mocks.beginAgentDeletionFinish).not.toHaveBeenCalled();
+    expect(mocks.unregisterResolvedAgentDir).not.toHaveBeenCalled();
   });
 
   it("unregisters a closed database row after committing deletion", async () => {

--- a/src/gateway/server-methods/agents-mutate.test.ts
+++ b/src/gateway/server-methods/agents-mutate.test.ts
@@ -1508,6 +1508,7 @@ describe("agents.delete", () => {
     mocks.beginAgentDeletionFinish.mockImplementation(() => {
       journal.cleanupCompleted = true;
     });
+    mocks.readAgentDeletionJournal.mockReturnValue(journal);
 
     const firstDelete = makeCall("agents.delete", { agentId: "test-agent" });
     await firstDelete.promise;
@@ -1516,6 +1517,16 @@ describe("agents.delete", () => {
       failed: [{ path: journal.workspaceDir, reason: "workspace trash failed" }],
     });
     expect(mocks.beginAgentDeletionFinish).not.toHaveBeenCalled();
+    const completedAgentDir = (
+      journal as typeof journal & {
+        cleanupPaths: Array<{ path: string; done: boolean }>;
+      }
+    ).cleanupPaths.find((entry) => entry.path === journal.agentDir);
+    expect(completedAgentDir?.done).toBe(true);
+    const agentDirMoveCount = mocks.movePathToTrash.mock.calls.filter(
+      ([pathname]) => pathname === journal.agentDir,
+    ).length;
+    trashed.delete(journal.agentDir);
     mocks.findAgentEntryIndex.mockReturnValue(-1);
     mocks.readAgentDeletionJournal.mockReturnValue(journal);
     const blockedCreate = makeCall("agents.create", { name: "Test Agent" });
@@ -1526,11 +1537,159 @@ describe("agents.delete", () => {
     await recovery.promise;
 
     expectRespondOk(recovery.respond, { failed: [] });
+    expect(
+      mocks.movePathToTrash.mock.calls.filter(([pathname]) => pathname === journal.agentDir),
+    ).toHaveLength(agentDirMoveCount);
+    expect(trashed.has(journal.agentDir)).toBe(false);
     expect(mocks.beginAgentDeletionFinish).toHaveBeenCalledOnce();
     expect(journal.cleanupCompleted).toBe(true);
     const recreated = makeCall("agents.create", { name: "Test Agent" });
     await recreated.promise;
     expectRespondOk(recreated.respond, { ok: true, agentId: "test-agent" });
+  });
+
+  it("preserves a replacement whose identity differs from the journal", async () => {
+    const workspaceDir = "/journal/workspace";
+    const workspaceAlias = "/journal/workspace-alias";
+    const journal = {
+      agentId: "test-agent",
+      operationId: "delete-1",
+      agentDir: "/journal/agent",
+      workspaceDir,
+      sessionsDir: "/journal/sessions",
+      databasePaths: [workspaceAlias],
+      cleanupPaths: [
+        {
+          path: "/journal/agent",
+          canonicalPath: "/journal/agent",
+          parentPath: "/journal",
+          kind: "target" as const,
+          sourcePaths: ["/journal/agent"],
+          dev: 1,
+          ino: 10,
+          coversDescendants: true,
+          done: true,
+        },
+        {
+          path: workspaceDir,
+          canonicalPath: workspaceDir,
+          parentPath: "/journal",
+          kind: "target" as const,
+          sourcePaths: [workspaceDir],
+          dev: null,
+          ino: null,
+          coversDescendants: true,
+          done: false,
+        },
+        {
+          path: "/journal/sessions",
+          canonicalPath: "/journal/sessions",
+          parentPath: "/journal",
+          kind: "target" as const,
+          sourcePaths: ["/journal/sessions"],
+          dev: 1,
+          ino: 30,
+          coversDescendants: true,
+          done: true,
+        },
+      ],
+      createdAt: 1,
+      cleanupCompleted: false,
+      deleteFiles: true,
+    };
+    mocks.findAgentEntryIndex.mockReturnValue(-1);
+    mocks.readAgentDeletionJournal.mockReturnValue(journal);
+    mocks.fsRealpath.mockImplementation(async (pathname: string) =>
+      pathname === workspaceAlias ? workspaceDir : pathname,
+    );
+    mocks.fsLstat.mockImplementation(
+      async (pathname: unknown) =>
+        ({
+          dev: 2,
+          ino: pathname === workspaceDir ? 200 : 100,
+          isFile: () => false,
+          isSymbolicLink: () => false,
+          nlink: 1,
+        }) as unknown as import("node:fs").Stats,
+    );
+
+    const { respond, promise } = makeCall("agents.delete", { agentId: "test-agent" });
+    await promise;
+
+    expectRespondOk(respond, { failed: [] });
+    expect(mocks.movePathToTrash).not.toHaveBeenCalledWith(workspaceDir);
+    const replacementRecord = journal.cleanupPaths.find((entry) => entry.path === workspaceDir);
+    expect(replacementRecord).toMatchObject({
+      done: true,
+      note: "cleanup path appeared after deletion preparation",
+    });
+    expect(mocks.beginAgentDeletionFinish).toHaveBeenCalledOnce();
+  });
+
+  it("protects a pending ancestor when a done descendant is recreated", async () => {
+    const workspaceDir = "/journal/workspace";
+    const completedChild = `${workspaceDir}/cleaned`;
+    const journal = {
+      agentId: "test-agent",
+      operationId: "delete-1",
+      agentDir: "/journal/agent",
+      workspaceDir,
+      sessionsDir: "/journal/sessions",
+      databasePaths: [],
+      cleanupPaths: [
+        {
+          path: completedChild,
+          canonicalPath: completedChild,
+          parentPath: workspaceDir,
+          kind: "target" as const,
+          sourcePaths: [workspaceDir],
+          dev: 1,
+          ino: 10,
+          coversDescendants: true,
+          done: true,
+        },
+        {
+          path: workspaceDir,
+          canonicalPath: workspaceDir,
+          parentPath: "/journal",
+          kind: "target" as const,
+          sourcePaths: [workspaceDir],
+          dev: 1,
+          ino: 20,
+          coversDescendants: true,
+          done: false,
+        },
+      ],
+      createdAt: 1,
+      cleanupCompleted: false,
+      deleteFiles: true,
+    };
+    mocks.findAgentEntryIndex.mockReturnValue(-1);
+    mocks.readAgentDeletionJournal.mockReturnValue(journal);
+    mocks.fsLstat.mockImplementation(async (pathname: unknown) => {
+      if (pathname !== completedChild && pathname !== workspaceDir) {
+        throw createEnoentError();
+      }
+      return {
+        dev: pathname === completedChild ? 2 : 1,
+        ino: pathname === completedChild ? 100 : 20,
+        isFile: () => false,
+        isSymbolicLink: () => false,
+        nlink: 1,
+      } as unknown as import("node:fs").Stats;
+    });
+
+    const { respond, promise } = makeCall("agents.delete", { agentId: "test-agent" });
+    await promise;
+
+    expectRespondOk(respond, { failed: [] });
+    expect(mocks.movePathToTrash).not.toHaveBeenCalledWith(completedChild);
+    expect(mocks.movePathToTrash).not.toHaveBeenCalledWith(workspaceDir);
+    expect(journal.cleanupPaths.find((entry) => entry.path === workspaceDir)).toMatchObject({
+      done: true,
+      note: "completed cleanup path is occupied; replacement preserved",
+    });
+    expect(mocks.beginAgentDeletionFinish).toHaveBeenCalledOnce();
   });
 
   it("extends a recovery cleanup snapshot with newly discovered database files", async () => {
@@ -1545,18 +1704,36 @@ describe("agents.delete", () => {
       cleanupPaths: [
         {
           path: "/journal/agent",
+          canonicalPath: "/journal/agent",
+          parentPath: "/journal",
           kind: "target" as const,
           sourcePaths: ["/journal/agent"],
+          dev: null,
+          ino: null,
+          coversDescendants: true,
+          done: false,
         },
         {
           path: "/journal/workspace",
+          canonicalPath: "/journal/workspace",
+          parentPath: "/journal",
           kind: "target" as const,
           sourcePaths: ["/journal/workspace"],
+          dev: null,
+          ino: null,
+          coversDescendants: true,
+          done: false,
         },
         {
           path: "/journal/sessions",
+          canonicalPath: "/journal/sessions",
+          parentPath: "/journal",
           kind: "target" as const,
           sourcePaths: ["/journal/sessions"],
+          dev: null,
+          ino: null,
+          coversDescendants: true,
+          done: false,
         },
       ],
       createdAt: 1,
@@ -1725,19 +1902,47 @@ describe("agents.delete", () => {
       cleanupPaths: [
         {
           path: "/canonical/workspace",
+          canonicalPath: "/canonical/workspace",
+          parentPath: "/canonical",
           kind: "target",
           sourcePaths: [workspaceLink],
+          dev: null,
+          ino: null,
+          coversDescendants: true,
+          done: false,
         },
-        { path: workspaceLink, kind: "symlink", sourcePaths: [workspaceLink] },
+        {
+          path: workspaceLink,
+          canonicalPath: workspaceLink,
+          parentPath: "/journal",
+          kind: "symlink",
+          sourcePaths: [workspaceLink],
+          dev: null,
+          ino: null,
+          coversDescendants: false,
+          done: false,
+        },
         {
           path: "/journal/agent",
+          canonicalPath: "/journal/agent",
+          parentPath: "/journal",
           kind: "target",
           sourcePaths: ["/journal/agent"],
+          dev: null,
+          ino: null,
+          coversDescendants: true,
+          done: false,
         },
         {
           path: "/journal/sessions",
+          canonicalPath: "/journal/sessions",
+          parentPath: "/journal",
           kind: "target",
           sourcePaths: ["/journal/sessions"],
+          dev: null,
+          ino: null,
+          coversDescendants: true,
+          done: false,
         },
       ],
       createdAt: 1,
@@ -1748,16 +1953,19 @@ describe("agents.delete", () => {
     const { respond, promise } = makeCall("agents.delete", { agentId: "test-agent" });
     await promise;
 
-    expectRespondOk(respond, {
-      failed: [
-        {
-          path: workspaceLink,
-          reason: "cleanup path changed from symlink before deletion",
-        },
-      ],
-    });
+    expectRespondOk(respond, { failed: [] });
     expect(mocks.movePathToTrash).not.toHaveBeenCalledWith(workspaceLink);
-    expect(mocks.beginAgentDeletionFinish).not.toHaveBeenCalled();
+    const replacementRecord = expectDefined(
+      mocks.readAgentDeletionJournal.mock.results[0]?.value?.cleanupPaths?.find(
+        (entry: { path?: string }) => entry.path === workspaceLink,
+      ),
+      "replacement cleanup record",
+    );
+    expect(replacementRecord).toMatchObject({
+      done: true,
+      note: "cleanup path changed from symlink before deletion",
+    });
+    expect(mocks.beginAgentDeletionFinish).toHaveBeenCalledOnce();
   });
 
   it("resolves a symlinked workspace and removes descendants before its target and link", async () => {
@@ -1923,21 +2131,36 @@ describe("agents.delete", () => {
       cleanupPaths: [
         {
           path: `${canonicalRoot}/workspace/agent`,
+          canonicalPath: `${canonicalRoot}/workspace/agent`,
           parentPath: `${canonicalRoot}/workspace`,
           kind: "target" as const,
           sourcePaths: [`${workspaceDir}/agent`],
+          dev: null,
+          ino: null,
+          coversDescendants: true,
+          done: false,
         },
         {
           path: `${canonicalRoot}/workspace/transcripts`,
+          canonicalPath: `${canonicalRoot}/workspace/transcripts`,
           parentPath: `${canonicalRoot}/workspace`,
           kind: "target" as const,
           sourcePaths: [`${workspaceDir}/transcripts`],
+          dev: null,
+          ino: null,
+          coversDescendants: true,
+          done: false,
         },
         {
           path: `${canonicalRoot}/workspace`,
+          canonicalPath: `${canonicalRoot}/workspace`,
           parentPath: canonicalRoot,
           kind: "target" as const,
           sourcePaths: [workspaceDir],
+          dev: null,
+          ino: null,
+          coversDescendants: true,
+          done: false,
         },
       ],
       createdAt: 1,

--- a/src/gateway/server-methods/agents-mutate.test.ts
+++ b/src/gateway/server-methods/agents-mutate.test.ts
@@ -102,7 +102,9 @@ vi.mock("../../config/config.js", async () => {
     writeConfigFile: mocks.writeConfigFile,
     replaceConfigFile: async (params: { nextConfig: unknown }) =>
       await mocks.writeConfigFile(params.nextConfig),
-    readConfigFileSnapshotForWrite: async () => ({ sourceConfig: mocks.loadConfigReturn }),
+    readConfigFileSnapshotForWrite: async () => ({
+      snapshot: { sourceConfig: mocks.loadConfigReturn },
+    }),
     mutateConfigFileWithRetry: async (params: {
       mutate: (draft: Record<string, unknown>, context: unknown) => unknown;
     }) => {

--- a/src/gateway/server-methods/agents-mutate.test.ts
+++ b/src/gateway/server-methods/agents-mutate.test.ts
@@ -1367,8 +1367,11 @@ describe("agents.delete", () => {
       configuredCheck += 1;
       return configuredCheck < 4 ? 0 : -1;
     });
-    mocks.writeConfigFile.mockImplementationOnce(async (nextConfig: Record<string, unknown>) => {
-      mocks.loadConfigReturn = nextConfig;
+    mocks.writeConfigFile.mockImplementationOnce(async (nextConfig?: unknown) => {
+      if (!nextConfig || typeof nextConfig !== "object") {
+        throw new Error("expected config object");
+      }
+      mocks.loadConfigReturn = nextConfig as Record<string, unknown>;
       throw new Error("post-write refresh failed");
     });
 

--- a/src/gateway/server-methods/agents-mutate.test.ts
+++ b/src/gateway/server-methods/agents-mutate.test.ts
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it, vi, beforeEach } from "vitest";
+import { AgentDeletionAuthorityRollbackError } from "../../agents/agent-lifecycle-registry.js";
 import { FsSafeError } from "../../infra/fs-safe.js";
 /* ------------------------------------------------------------------ */
 /* Mocks                                                              */
@@ -17,6 +18,7 @@ const mocks = vi.hoisted(() => ({
   applyAgentConfig: vi.fn((_cfg: unknown, _opts: unknown) => ({})),
   pruneAgentConfig: vi.fn(() => ({ config: {}, removedBindings: 0 })),
   writeConfigFile: vi.fn(async (_nextConfig?: unknown) => {}),
+  omitConfigMutationResult: false,
   ensureAgentWorkspace: vi.fn(
     async (params?: { dir?: string }): Promise<{ dir: string; identityPathCreated: boolean }> => ({
       dir: params?.dir
@@ -30,6 +32,25 @@ const mocks = vi.hoisted(() => ({
   isWorkspaceSetupCompleted: vi.fn(async () => false),
   deleteWorkspaceState: vi.fn(),
   prepareWorkspaceStateDeletion: vi.fn((workspaceDir: string) => ({ workspaceDir })),
+  withAgentExecApprovalsRemoved: vi.fn(
+    async (_agentId: string, commit: () => Promise<unknown>) => await commit(),
+  ),
+  beginAgentDeletionCommit: vi.fn(),
+  beginAgentDeletionRollback: vi.fn(),
+  beginAgentDeletionFinish: vi.fn(),
+  claimCompletedAgentDeletion: vi.fn(() => true),
+  readAgentDeletionJournal: vi.fn(() => undefined as Record<string, unknown> | undefined),
+  resolveOpenClawAgentSqlitePath: vi.fn(
+    (params?: { path?: string }) => params?.path ?? "/agents/test-agent/openclaw-agent.sqlite",
+  ),
+  closeOpenClawAgentDatabaseByPath: vi.fn((_pathname?: string) => true),
+  listOpenClawRegisteredAgentDatabases: vi.fn(() => [] as Array<Record<string, unknown>>),
+  unregisterOpenClawAgentDatabase: vi.fn(),
+  assertNoOpenClawAgentDatabaseLeases: vi.fn(),
+  unregisterResolvedAgentDir: vi.fn(),
+  cronRemoveAgentJobsTransactional: vi.fn(
+    async (_agentId: string, commit: () => Promise<unknown>) => await commit(),
+  ),
   resolveAgentDir: vi.fn((_cfg?: unknown, _agentId?: string) => "/agents/test-agent"),
   resolveAgentWorkspaceDir: vi.fn((_cfg?: unknown, _agentId?: string) => "/workspace/test-agent"),
   resolveSessionTranscriptsDirForAgent: vi.fn((_agentId?: string) => "/transcripts/test-agent"),
@@ -39,7 +60,7 @@ const mocks = vi.hoisted(() => ({
     scope: "global",
     agents: [],
   })),
-  movePathToTrash: vi.fn(async () => "/trashed"),
+  movePathToTrash: vi.fn(async (_pathname?: string) => "/trashed"),
   fsAccess: vi.fn(async () => {}),
   fsMkdir: vi.fn(async () => undefined),
   fsAppendFile: vi.fn(async () => {}),
@@ -81,6 +102,7 @@ vi.mock("../../config/config.js", async () => {
     writeConfigFile: mocks.writeConfigFile,
     replaceConfigFile: async (params: { nextConfig: unknown }) =>
       await mocks.writeConfigFile(params.nextConfig),
+    readConfigFileSnapshotForWrite: async () => ({ sourceConfig: mocks.loadConfigReturn }),
     mutateConfigFileWithRetry: async (params: {
       mutate: (draft: Record<string, unknown>, context: unknown) => unknown;
     }) => {
@@ -97,7 +119,7 @@ vi.mock("../../config/config.js", async () => {
         persistedHash: "persisted-hash",
         snapshot: { path: "/tmp/openclaw/config.json" },
         nextConfig: draft,
-        result,
+        result: mocks.omitConfigMutationResult ? undefined : result,
         attempts: 1,
         afterWrite: { mode: "auto" },
         followUp: { action: "none" },
@@ -128,7 +150,8 @@ vi.mock("../../config/config.js", async () => {
         followUp: { action: "none" },
       };
     },
-    withConfigMutationExclusive: async (fn: () => Promise<unknown>) => await fn(),
+    withConfigMutationExclusive: async (fn: (config: unknown) => Promise<unknown>) =>
+      await fn(mocks.loadConfigReturn),
   };
 });
 
@@ -146,6 +169,49 @@ vi.mock("../../agents/agent-scope.js", () => ({
   resolveAgentConfig: (cfg: unknown, agentId: string) =>
     getAgentList(cfg).find((entry) => entry.id === agentId),
   resolveAgentWorkspaceDir: mocks.resolveAgentWorkspaceDir,
+}));
+
+vi.mock("../../agents/agent-dir-registry.js", () => ({
+  unregisterResolvedAgentDir: mocks.unregisterResolvedAgentDir,
+}));
+
+vi.mock("../../agents/agent-lifecycle-registry.js", () => ({
+  AgentDeletionAuthorityRollbackError: class extends AggregateError {},
+  AgentDeletionCommitUncertainError: class extends Error {
+    constructor(cause: unknown) {
+      super(cause instanceof Error ? cause.message : String(cause));
+    }
+  },
+  beginAgentDeletion: (entry: Record<string, unknown>) => ({
+    entry,
+    commit: mocks.beginAgentDeletionCommit,
+    finish: mocks.beginAgentDeletionFinish,
+    rollback: mocks.beginAgentDeletionRollback,
+  }),
+  claimCompletedAgentDeletion: mocks.claimCompletedAgentDeletion,
+  isAgentDeletionBlocked: () => false,
+}));
+
+vi.mock("../../infra/exec-approvals.js", () => ({
+  withAgentExecApprovalsRemoved: mocks.withAgentExecApprovalsRemoved,
+}));
+
+vi.mock("../../state/openclaw-agent-db.js", () => ({
+  closeOpenClawAgentDatabaseByPath: mocks.closeOpenClawAgentDatabaseByPath,
+  listOpenClawRegisteredAgentDatabases: mocks.listOpenClawRegisteredAgentDatabases,
+  resolveOpenClawAgentSqlitePath: mocks.resolveOpenClawAgentSqlitePath,
+}));
+
+vi.mock("../../state/agent-deletion-journal.js", () => ({
+  readAgentDeletionJournal: mocks.readAgentDeletionJournal,
+}));
+
+vi.mock("../../state/openclaw-agent-db-registry.js", () => ({
+  unregisterOpenClawAgentDatabase: mocks.unregisterOpenClawAgentDatabase,
+}));
+
+vi.mock("../../state/openclaw-agent-db-lease.js", () => ({
+  assertNoOpenClawAgentDatabaseLeases: mocks.assertNoOpenClawAgentDatabaseLeases,
 }));
 
 vi.mock("../../agents/workspace.js", async () => {
@@ -246,6 +312,26 @@ const { testing: agentsTesting, agentsHandlers } = await import("./agents.js");
 
 beforeEach(() => {
   agentsTesting.resetDepsForTests();
+  mocks.omitConfigMutationResult = false;
+  mocks.withAgentExecApprovalsRemoved
+    .mockReset()
+    .mockImplementation(async (_agentId: string, commit: () => Promise<unknown>) => await commit());
+  mocks.beginAgentDeletionCommit.mockReset();
+  mocks.beginAgentDeletionRollback.mockReset();
+  mocks.beginAgentDeletionFinish.mockReset();
+  mocks.readAgentDeletionJournal.mockReset().mockReturnValue(undefined);
+  mocks.resolveOpenClawAgentSqlitePath
+    .mockReset()
+    .mockImplementation(
+      (params?: { path?: string }) => params?.path ?? "/agents/test-agent/openclaw-agent.sqlite",
+    );
+  mocks.closeOpenClawAgentDatabaseByPath.mockReset().mockReturnValue(true);
+  mocks.listOpenClawRegisteredAgentDatabases.mockReset().mockReturnValue([]);
+  mocks.unregisterOpenClawAgentDatabase.mockReset();
+  mocks.unregisterResolvedAgentDir.mockReset();
+  mocks.cronRemoveAgentJobsTransactional
+    .mockReset()
+    .mockImplementation(async (_agentId: string, commit: () => Promise<unknown>) => await commit());
   mocks.listAgentEntries.mockImplementation((cfg: unknown) => getAgentList(cfg));
   mocks.findAgentEntryIndex.mockImplementation((list: unknown, agentId?: string) =>
     (Array.isArray(list) ? (list as MockAgentEntry[]) : []).findIndex(
@@ -312,7 +398,10 @@ function makeCall(method: keyof typeof agentsHandlers, params: Record<string, un
   const promise = handler({
     params,
     respond,
-    context: { getRuntimeConfig: () => mocks.loadConfigReturn } as never,
+    context: {
+      getRuntimeConfig: () => mocks.loadConfigReturn,
+      cron: { removeAgentJobsTransactional: mocks.cronRemoveAgentJobsTransactional },
+    } as never,
     req: { type: "req" as const, id: "1", method },
     client: null,
     isWebchatConnect: () => false,
@@ -1128,6 +1217,337 @@ describe("agents.delete", () => {
     mocks.pruneAgentConfig.mockReturnValue({ config: {}, removedBindings: 2 });
   });
 
+  it("removes only the deleted agent's authority before committing its roster removal", async () => {
+    const cronJobs = [
+      { id: "deleted-job", agentId: "test-agent" },
+      { id: "other-job", agentId: "other-agent" },
+    ];
+    const approvals = new Set(["test-agent", "other-agent"]);
+    const events: string[] = [];
+    mocks.cronRemoveAgentJobsTransactional.mockImplementation(
+      async (agentId: string, commit: () => Promise<unknown>) => {
+        const snapshot = structuredClone(cronJobs);
+        cronJobs.splice(0, cronJobs.length, ...cronJobs.filter((job) => job.agentId !== agentId));
+        events.push("cron");
+        try {
+          return await commit();
+        } catch (error) {
+          cronJobs.splice(0, cronJobs.length, ...snapshot);
+          throw error;
+        }
+      },
+    );
+    mocks.withAgentExecApprovalsRemoved.mockImplementation(
+      async (agentId: string, commit: () => Promise<unknown>) => {
+        const existed = approvals.delete(agentId);
+        events.push("approvals");
+        try {
+          return await commit();
+        } catch (error) {
+          if (existed) {
+            approvals.add(agentId);
+          }
+          throw error;
+        }
+      },
+    );
+    mocks.writeConfigFile.mockImplementationOnce(async () => {
+      events.push("config");
+    });
+    mocks.beginAgentDeletionCommit.mockImplementationOnce(() => {
+      events.push("lifecycle");
+    });
+    mocks.unregisterResolvedAgentDir.mockImplementationOnce(() => {
+      events.push("directory");
+    });
+    mocks.closeOpenClawAgentDatabaseByPath.mockImplementation(() => {
+      events.push("database");
+      return true;
+    });
+
+    const { respond, promise } = makeCall("agents.delete", { agentId: "test-agent" });
+    await promise;
+
+    expectRespondOk(respond, { ok: true });
+    expect(cronJobs).toEqual([{ id: "other-job", agentId: "other-agent" }]);
+    expect(approvals).toEqual(new Set(["other-agent"]));
+    expect(mocks.cronRemoveAgentJobsTransactional).toHaveBeenCalledWith(
+      "test-agent",
+      expect.any(Function),
+    );
+    expect(mocks.withAgentExecApprovalsRemoved).toHaveBeenCalledWith(
+      "test-agent",
+      expect.any(Function),
+    );
+    expect(mocks.closeOpenClawAgentDatabaseByPath).toHaveBeenCalledWith(
+      "/agents/test-agent/openclaw-agent.sqlite",
+    );
+    expect(mocks.unregisterOpenClawAgentDatabase).toHaveBeenCalledWith({
+      agentId: "test-agent",
+      path: "/agents/test-agent/openclaw-agent.sqlite",
+    });
+    expect(mocks.unregisterResolvedAgentDir).toHaveBeenCalledWith({
+      agentId: "test-agent",
+      agentDir: "/agents/test-agent",
+    });
+    expect(events).toEqual(["database", "cron", "approvals", "config", "lifecycle", "directory"]);
+    expect(mocks.beginAgentDeletionFinish).toHaveBeenCalledOnce();
+  });
+
+  it("rolls cron back and keeps the roster when authority cleanup fails", async () => {
+    const cronJobs = [
+      { id: "deleted-job", agentId: "test-agent" },
+      { id: "other-job", agentId: "other-agent" },
+    ];
+    mocks.cronRemoveAgentJobsTransactional.mockImplementation(
+      async (agentId: string, commit: () => Promise<unknown>) => {
+        const snapshot = structuredClone(cronJobs);
+        cronJobs.splice(0, cronJobs.length, ...cronJobs.filter((job) => job.agentId !== agentId));
+        try {
+          return await commit();
+        } catch (error) {
+          cronJobs.splice(0, cronJobs.length, ...snapshot);
+          throw error;
+        }
+      },
+    );
+    mocks.withAgentExecApprovalsRemoved.mockRejectedValueOnce(new Error("approvals busy"));
+
+    const { promise } = makeCall("agents.delete", { agentId: "test-agent" });
+
+    await expect(promise).rejects.toThrow("approvals busy");
+    expect(cronJobs).toEqual([
+      { id: "deleted-job", agentId: "test-agent" },
+      { id: "other-job", agentId: "other-agent" },
+    ]);
+    expect(mocks.beginAgentDeletionRollback).toHaveBeenCalledOnce();
+    expect(mocks.writeConfigFile).not.toHaveBeenCalled();
+    expect(mocks.closeOpenClawAgentDatabaseByPath).toHaveBeenCalledOnce();
+    expect(mocks.movePathToTrash).not.toHaveBeenCalled();
+  });
+
+  it("keeps a recovered deletion journal fenced when retry cleanup fails", async () => {
+    mocks.readAgentDeletionJournal.mockReturnValue({
+      agentId: "test-agent",
+      agentDir: "/journal/agent",
+      workspaceDir: "/journal/workspace",
+      sessionsDir: "/journal/sessions",
+      createdAt: 1,
+    });
+    mocks.withAgentExecApprovalsRemoved.mockRejectedValueOnce(new Error("approvals busy"));
+
+    const { promise } = makeCall("agents.delete", { agentId: "test-agent" });
+
+    await expect(promise).rejects.toThrow("approvals busy");
+    expect(mocks.beginAgentDeletionRollback).not.toHaveBeenCalled();
+    expect(mocks.beginAgentDeletionFinish).not.toHaveBeenCalled();
+    expect(mocks.writeConfigFile).not.toHaveBeenCalled();
+  });
+
+  it("keeps a new deletion fenced when authority rollback fails", async () => {
+    mocks.withAgentExecApprovalsRemoved.mockRejectedValueOnce(
+      new AgentDeletionAuthorityRollbackError(
+        [new Error("config failed"), new Error("approval restore failed")],
+        "approval rollback failed",
+      ),
+    );
+
+    const { promise } = makeCall("agents.delete", { agentId: "test-agent" });
+
+    await expect(promise).rejects.toThrow("approval rollback failed");
+    expect(mocks.beginAgentDeletionRollback).not.toHaveBeenCalled();
+    expect(mocks.writeConfigFile).not.toHaveBeenCalled();
+  });
+
+  it("keeps deletion fenced when config persistence succeeds before reporting failure", async () => {
+    let configuredCheck = 0;
+    mocks.findAgentEntryIndex.mockImplementation(() => {
+      configuredCheck += 1;
+      return configuredCheck < 4 ? 0 : -1;
+    });
+    mocks.writeConfigFile.mockImplementationOnce(async (nextConfig: Record<string, unknown>) => {
+      mocks.loadConfigReturn = nextConfig;
+      throw new Error("post-write refresh failed");
+    });
+
+    const { promise } = makeCall("agents.delete", { agentId: "test-agent" });
+
+    await expect(promise).rejects.toThrow("post-write refresh failed");
+    expect(mocks.beginAgentDeletionRollback).not.toHaveBeenCalled();
+    expect(mocks.closeOpenClawAgentDatabaseByPath).toHaveBeenCalled();
+    expect(mocks.movePathToTrash).not.toHaveBeenCalled();
+  });
+
+  it("does not perform destructive cleanup without a config deletion result", async () => {
+    mocks.omitConfigMutationResult = true;
+
+    const { promise } = makeCall("agents.delete", { agentId: "test-agent" });
+
+    await expect(promise).rejects.toThrow("config mutation did not return its target");
+    expect(mocks.closeOpenClawAgentDatabaseByPath).toHaveBeenCalledOnce();
+    expect(mocks.movePathToTrash).not.toHaveBeenCalled();
+    expect(mocks.unregisterOpenClawAgentDatabase).not.toHaveBeenCalled();
+    expect(mocks.beginAgentDeletionRollback).toHaveBeenCalledOnce();
+  });
+
+  it("keeps authority removed when the committed config omits its mutation result", async () => {
+    mocks.omitConfigMutationResult = true;
+    let configuredCheck = 0;
+    mocks.findAgentEntryIndex.mockImplementation(() => {
+      configuredCheck += 1;
+      return configuredCheck < 4 ? 0 : -1;
+    });
+
+    const { promise } = makeCall("agents.delete", { agentId: "test-agent" });
+
+    await expect(promise).rejects.toThrow("config mutation did not return its target");
+    expect(mocks.beginAgentDeletionRollback).not.toHaveBeenCalled();
+    expect(mocks.movePathToTrash).not.toHaveBeenCalled();
+    expect(mocks.unregisterOpenClawAgentDatabase).not.toHaveBeenCalled();
+  });
+
+  it("resumes a journaled deletion after the roster entry is already absent", async () => {
+    mocks.findAgentEntryIndex.mockReturnValue(-1);
+    mocks.readAgentDeletionJournal.mockReturnValue({
+      agentId: "test-agent",
+      agentDir: "/journal/agent",
+      workspaceDir: "/journal/workspace",
+      sessionsDir: "/journal/sessions",
+      createdAt: 1,
+    });
+
+    const { respond, promise } = makeCall("agents.delete", { agentId: "test-agent" });
+    await promise;
+
+    expectRespondOk(respond, { ok: true });
+    expect(mocks.writeConfigFile).not.toHaveBeenCalled();
+    expect(mocks.closeOpenClawAgentDatabaseByPath).toHaveBeenCalledWith(
+      "/journal/agent/openclaw-agent.sqlite",
+    );
+    expect(mocks.movePathToTrash).toHaveBeenCalledWith("/journal/workspace");
+    expect(mocks.movePathToTrash).toHaveBeenCalledWith("/journal/agent");
+    expect(mocks.movePathToTrash).toHaveBeenCalledWith("/journal/sessions");
+    expect(mocks.beginAgentDeletionFinish).toHaveBeenCalledOnce();
+  });
+
+  it("preserves the original keep-files intent while recovering deletion", async () => {
+    mocks.findAgentEntryIndex.mockReturnValue(-1);
+    mocks.readAgentDeletionJournal.mockReturnValue({
+      agentId: "test-agent",
+      operationId: "delete-1",
+      agentDir: "/journal/agent",
+      workspaceDir: "/journal/workspace",
+      sessionsDir: "/journal/sessions",
+      createdAt: 1,
+      cleanupCompleted: false,
+      deleteFiles: false,
+    });
+
+    const { respond, promise } = makeCall("agents.delete", { agentId: "test-agent" });
+    await promise;
+
+    expectRespondOk(respond, { ok: true, removed: [], failed: [] });
+    expect(mocks.movePathToTrash).not.toHaveBeenCalled();
+    expect(mocks.unregisterOpenClawAgentDatabase).not.toHaveBeenCalled();
+    expect(mocks.beginAgentDeletionFinish).toHaveBeenCalledOnce();
+  });
+
+  it("uses the new request intent when deleting a recreated roster entry", async () => {
+    mocks.readAgentDeletionJournal.mockReturnValue({
+      agentId: "test-agent",
+      operationId: "old-delete",
+      agentDir: "/old/agent",
+      workspaceDir: "/old/workspace",
+      sessionsDir: "/old/sessions",
+      createdAt: 1,
+      cleanupCompleted: true,
+      deleteFiles: true,
+    });
+
+    const { respond, promise } = makeCall("agents.delete", {
+      agentId: "test-agent",
+      deleteFiles: false,
+    });
+    await promise;
+
+    expectRespondOk(respond, { ok: true, removed: [], failed: [] });
+    expect(mocks.claimCompletedAgentDeletion).toHaveBeenCalledWith("test-agent", "old-delete");
+    expect(mocks.movePathToTrash).not.toHaveBeenCalled();
+    expect(mocks.unregisterOpenClawAgentDatabase).not.toHaveBeenCalled();
+  });
+
+  it("keeps the deletion journal fenced when Trash cleanup fails", async () => {
+    mocks.movePathToTrash.mockRejectedValueOnce(new Error("trash unavailable"));
+
+    const { respond, promise } = makeCall("agents.delete", { agentId: "test-agent" });
+    await promise;
+
+    expectRespondOk(respond, { ok: true });
+    expect(mocks.beginAgentDeletionCommit).toHaveBeenCalledOnce();
+    expect(mocks.beginAgentDeletionFinish).not.toHaveBeenCalled();
+  });
+
+  it("unregisters a closed database row after committing deletion", async () => {
+    mocks.closeOpenClawAgentDatabaseByPath.mockReturnValueOnce(false);
+
+    const { promise } = makeCall("agents.delete", { agentId: "test-agent" });
+    await promise;
+
+    expect(mocks.unregisterOpenClawAgentDatabase).toHaveBeenCalledWith({
+      agentId: "test-agent",
+      path: "/agents/test-agent/openclaw-agent.sqlite",
+    });
+    expect(mocks.writeConfigFile.mock.invocationCallOrder[0]).toBeLessThan(
+      expectDefined(
+        mocks.unregisterOpenClawAgentDatabase.mock.invocationCallOrder[0],
+        "database unregister call order",
+      ),
+    );
+  });
+
+  it("closes and archives every registered database path owned by the deleted agent", async () => {
+    mocks.listOpenClawRegisteredAgentDatabases.mockReturnValue([
+      { agentId: "test-agent", path: "/relocated/test-agent.sqlite" },
+      { agentId: "other-agent", path: "/relocated/other-agent.sqlite" },
+    ]);
+
+    const { promise } = makeCall("agents.delete", { agentId: "test-agent" });
+    await promise;
+
+    expect(mocks.closeOpenClawAgentDatabaseByPath).toHaveBeenCalledWith(
+      "/agents/test-agent/openclaw-agent.sqlite",
+    );
+    expect(mocks.closeOpenClawAgentDatabaseByPath).toHaveBeenCalledWith(
+      "/relocated/test-agent.sqlite",
+    );
+    expect(mocks.closeOpenClawAgentDatabaseByPath).not.toHaveBeenCalledWith(
+      "/relocated/other-agent.sqlite",
+    );
+    expect(mocks.movePathToTrash).toHaveBeenCalledWith("/relocated/test-agent.sqlite");
+    expect(mocks.unregisterOpenClawAgentDatabase).toHaveBeenCalledWith({
+      agentId: "test-agent",
+      path: "/relocated/test-agent.sqlite",
+    });
+  });
+
+  it("retains relocated database ownership when its Trash archival fails", async () => {
+    mocks.listOpenClawRegisteredAgentDatabases.mockReturnValue([
+      { agentId: "test-agent", path: "/relocated/test-agent.sqlite" },
+    ]);
+    mocks.movePathToTrash.mockImplementation(async (pathname?: string) => {
+      if (pathname === "/relocated/test-agent.sqlite") {
+        throw new Error("relocated trash failed");
+      }
+      return "/trashed";
+    });
+
+    const { promise } = makeCall("agents.delete", { agentId: "test-agent" });
+    await promise;
+
+    expect(mocks.unregisterOpenClawAgentDatabase).not.toHaveBeenCalled();
+    expect(mocks.beginAgentDeletionFinish).not.toHaveBeenCalled();
+  });
+
   it("deletes an existing agent and trashes files by default", async () => {
     const { respond, promise } = makeCall("agents.delete", {
       agentId: "test-agent",
@@ -1202,7 +1622,7 @@ describe("agents.delete", () => {
     const workspaceDir = await actualFs.mkdtemp(
       path.join(os.tmpdir(), "openclaw-agent-delete-trash-failure-"),
     );
-    mocks.resolveAgentWorkspaceDir.mockReturnValueOnce(workspaceDir);
+    mocks.resolveAgentWorkspaceDir.mockReturnValue(workspaceDir);
     mocks.movePathToTrash.mockRejectedValueOnce(
       Object.assign(new Error("trash destination missing"), { code: "ENOENT" }),
     );
@@ -1279,6 +1699,7 @@ describe("agents.delete", () => {
     expect(mocks.fsLstat).not.toHaveBeenCalled();
     expect(mocks.movePathToTrash).not.toHaveBeenCalled();
     expect(mocks.deleteWorkspaceState).not.toHaveBeenCalled();
+    expect(mocks.unregisterOpenClawAgentDatabase).not.toHaveBeenCalled();
   });
 
   it("rejects deleting the main agent", async () => {

--- a/src/gateway/server-methods/agents-mutate.test.ts
+++ b/src/gateway/server-methods/agents-mutate.test.ts
@@ -50,10 +50,10 @@ const mocks = vi.hoisted(() => ({
   registerResolvedAgentDir: vi.fn(),
   resolveRegisteredAgentIdForDir: vi.fn((_pathname?: string) => undefined as string | undefined),
   isPathOwnedByAnotherRegisteredAgent: vi.fn(
-    (_params?: { agentId: string; pathname: string }) => false,
+    (_params: { agentId: string; pathname: string }) => false,
   ),
   normalizeAgentDirRegistryPath: vi.fn((pathname: string) => path.resolve(pathname)),
-  unregisterResolvedAgentDir: vi.fn(() => true),
+  unregisterResolvedAgentDir: vi.fn((_params: { agentId: string; agentDir: string }) => true),
   cronRemoveAgentJobsTransactional: vi.fn(
     async (_agentId: string, commit: () => Promise<unknown>) => await commit(),
   ),
@@ -2279,9 +2279,9 @@ describe("agents.delete", () => {
     );
     mocks.listOpenClawRegisteredAgentDatabases.mockImplementation(() => databaseRows);
     mocks.unregisterOpenClawAgentDatabase.mockImplementation(
-      ({ agentId, path }: { agentId: string; path: string }) => {
+      ({ agentId, path: databasePath }: { agentId: string; path: string }) => {
         const index = databaseRows.findIndex(
-          (entry) => entry.agentId === agentId && entry.path === path,
+          (entry) => entry.agentId === agentId && entry.path === databasePath,
         );
         if (index >= 0) {
           databaseRows.splice(index, 1);
@@ -2423,9 +2423,9 @@ describe("agents.delete", () => {
     );
     mocks.listOpenClawRegisteredAgentDatabases.mockImplementation(() => databaseRows);
     mocks.unregisterOpenClawAgentDatabase.mockImplementation(
-      ({ agentId, path }: { agentId: string; path: string }) => {
+      ({ agentId, path: databasePath }: { agentId: string; path: string }) => {
         const index = databaseRows.findIndex(
-          (entry) => entry.agentId === agentId && entry.path === path,
+          (entry) => entry.agentId === agentId && entry.path === databasePath,
         );
         if (index >= 0) {
           databaseRows.splice(index, 1);
@@ -2778,9 +2778,12 @@ describe("agents.delete", () => {
       await actualFs.mkdtemp(path.join(os.tmpdir(), "openclaw-agent-delete-trash-failure-")),
     );
     mocks.resolveAgentWorkspaceDir.mockReturnValue(workspaceDir);
-    mocks.movePathToTrash.mockRejectedValueOnce(
-      Object.assign(new Error("trash destination missing"), { code: "ENOENT" }),
-    );
+    mocks.movePathToTrash.mockImplementation(async (pathname?: string) => {
+      if (pathname === workspaceDir) {
+        throw Object.assign(new Error("trash destination missing"), { code: "ENOENT" });
+      }
+      return "/trashed";
+    });
 
     try {
       const { respond, promise } = makeCall("agents.delete", {

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -17,7 +17,13 @@ import {
 } from "../../../packages/gateway-protocol/src/index.js";
 import { createAgent } from "../../agents/agent-create.js";
 import { findOverlappingWorkspaceAgentIds } from "../../agents/agent-delete-safety.js";
-import { unregisterResolvedAgentDir } from "../../agents/agent-dir-registry.js";
+import {
+  isPathOwnedByAnotherRegisteredAgent,
+  normalizeAgentDirRegistryPath,
+  registerResolvedAgentDir,
+  resolveRegisteredAgentIdForDir,
+  unregisterResolvedAgentDir,
+} from "../../agents/agent-dir-registry.js";
 import {
   AgentDeletionAuthorityRollbackError,
   AgentDeletionCommitUncertainError,
@@ -67,12 +73,16 @@ import type { IdentityConfig } from "../../config/types.base.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { withAgentExecApprovalsRemoved } from "../../infra/exec-approvals.js";
 import { root, FsSafeError, type ReadResult } from "../../infra/fs-safe.js";
+import { isPathInside } from "../../infra/path-guards.js";
 import { resolveSqliteDatabaseFilePaths } from "../../infra/sqlite-files.js";
 import { movePathToTrash } from "../../plugin-sdk/browser-maintenance.js";
 import { DEFAULT_AGENT_ID, normalizeAgentId } from "../../routing/session-key.js";
 import { readAgentDeletionJournal } from "../../state/agent-deletion-journal.js";
 import { assertNoOpenClawAgentDatabaseLeases } from "../../state/openclaw-agent-db-lease.js";
-import { unregisterOpenClawAgentDatabase } from "../../state/openclaw-agent-db-registry.js";
+import {
+  beginOpenClawAgentDatabaseRegistrationFence,
+  unregisterOpenClawAgentDatabase,
+} from "../../state/openclaw-agent-db-registry.js";
 import {
   closeOpenClawAgentDatabaseByPath,
   listOpenClawRegisteredAgentDatabases,
@@ -360,36 +370,106 @@ async function removeAgentPath(pathname: string): Promise<AgentDeletePathOutcome
 
 type AgentDeleteDatabasePlan = {
   paths: string[];
-  relocatedFilePaths: string[];
+  registrationPaths: string[];
+  fileGroups: string[][];
+  relocatedFileGroups: string[][];
 };
 
-function prepareAgentDeleteDatabases(agentId: string, agentDir: string): AgentDeleteDatabasePlan {
-  const databasePaths = new Set([
+function resolveSurvivingDatabaseFilePaths(
+  registeredDatabases: ReturnType<typeof listOpenClawRegisteredAgentDatabases>,
+  agentId: string,
+): string[] {
+  return [
+    ...new Set(
+      registeredDatabases
+        .filter((entry) => normalizeAgentId(entry.agentId) !== agentId)
+        .flatMap((entry) => resolveSqliteDatabaseFilePaths(entry.path))
+        .map((pathname) => normalizeAgentDirRegistryPath(pathname)),
+    ),
+  ];
+}
+
+function isPathOwnedBySurvivingAgent(
+  cfg: OpenClawConfig,
+  agentId: string,
+  pathname: string,
+  survivingDatabaseFilePaths: readonly string[] = [],
+): boolean {
+  const canonicalPath = normalizeAgentDirRegistryPath(pathname);
+  return (
+    isPathOwnedByAnotherRegisteredAgent({ agentId, pathname }) ||
+    findOverlappingWorkspaceAgentIds(cfg, agentId, pathname).length > 0 ||
+    survivingDatabaseFilePaths.some(
+      (databasePath) =>
+        databasePath === canonicalPath ||
+        isPathInside(databasePath, canonicalPath) ||
+        isPathInside(canonicalPath, databasePath),
+    )
+  );
+}
+
+function prepareAgentDeleteDatabases(
+  cfg: OpenClawConfig,
+  agentId: string,
+  agentDir: string,
+): AgentDeleteDatabasePlan {
+  const registeredDatabases = listOpenClawRegisteredAgentDatabases();
+  const survivingDatabaseFilePaths = resolveSurvivingDatabaseFilePaths(
+    registeredDatabases,
+    agentId,
+  );
+  const registeredDatabasePaths = new Set([
     resolveOpenClawAgentSqlitePath({
       agentId,
       path: path.join(agentDir, "openclaw-agent.sqlite"),
     }),
-    ...listOpenClawRegisteredAgentDatabases()
+    ...registeredDatabases
       .filter((entry) => normalizeAgentId(entry.agentId) === agentId)
       .map((entry) => entry.path),
   ]);
+  const databasePaths = [...registeredDatabasePaths].filter((pathname) =>
+    resolveSqliteDatabaseFilePaths(pathname).every(
+      (filePath) =>
+        !isPathOwnedBySurvivingAgent(cfg, agentId, filePath, survivingDatabaseFilePaths),
+    ),
+  );
   for (const databasePath of databasePaths) {
     closeOpenClawAgentDatabaseByPath(databasePath);
   }
   assertNoOpenClawAgentDatabaseLeases(agentId);
-  const relocatedFilePaths = [...databasePaths]
-    .filter((databasePath) => {
-      const relative = path.relative(agentDir, databasePath);
-      return relative.startsWith("..") || path.isAbsolute(relative);
-    })
-    .flatMap(resolveSqliteDatabaseFilePaths);
-  return { paths: [...databasePaths], relocatedFilePaths: [...new Set(relocatedFilePaths)] };
+  const fileGroups = databasePaths.map(resolveSqliteDatabaseFilePaths);
+  const relocatedFileGroups = fileGroups.filter((fileGroup) => {
+    const relative = path.relative(agentDir, fileGroup[0] ?? agentDir);
+    return relative.startsWith("..") || path.isAbsolute(relative);
+  });
+  return {
+    paths: databasePaths,
+    registrationPaths: [...registeredDatabasePaths],
+    fileGroups,
+    relocatedFileGroups,
+  };
 }
 
 function unregisterAgentDeleteDatabases(agentId: string, databasePaths: string[]): void {
   for (const databasePath of databasePaths) {
     unregisterOpenClawAgentDatabase({ agentId, path: databasePath });
   }
+}
+
+function prepareJournaledAgentDirOwnership(
+  cfg: OpenClawConfig,
+  agentId: string,
+  agentDir: string,
+): void {
+  for (const configuredAgentId of listAgentIds(cfg)) {
+    resolveAgentDir(cfg, configuredAgentId);
+  }
+  const registeredOwner = resolveRegisteredAgentIdForDir(agentDir);
+  if (registeredOwner !== undefined) {
+    return;
+  }
+  // The durable journal retains ownership across restarts after the roster entry is gone.
+  registerResolvedAgentDir({ agentId, agentDir });
 }
 
 function respondWorkspaceFileUnsafe(respond: RespondFn, name: string): void {
@@ -698,7 +778,8 @@ export const agentsHandlers: GatewayRequestHandlers = {
         let committed: Awaited<ReturnType<typeof deleteAgentConfigEntry>> | undefined;
         let databasePlan: AgentDeleteDatabasePlan | undefined;
         try {
-          databasePlan = prepareAgentDeleteDatabases(agentId, journal.agentDir);
+          prepareJournaledAgentDirOwnership(lockedConfig, agentId, journal.agentDir);
+          databasePlan = prepareAgentDeleteDatabases(lockedConfig, agentId, journal.agentDir);
           await context.cron.removeAgentJobsTransactional(
             agentId,
             async () =>
@@ -764,63 +845,123 @@ export const agentsHandlers: GatewayRequestHandlers = {
         };
         const nextConfig = committed?.nextConfig ?? lockedConfig;
 
-        // The durable journal is created before authority changes and cleared only after
-        // roster commit plus destructive cleanup, so crashes and same-id recreation fail closed.
-        unregisterResolvedAgentDir({ agentId, agentDir: deleteResult.agentDir });
-        await purgeAgentSessionStoreEntries(lockedConfig, agentId);
+        // A journaled path is trash-eligible only while registry ownership still points at the
+        // deleted agent; recovery must not consume a path claimed by a surviving agent.
+        const agentDirRegistryPath = normalizeAgentDirRegistryPath(deleteResult.agentDir);
+        const releaseDatabaseFence = deleteFiles
+          ? beginOpenClawAgentDatabaseRegistrationFence([
+              deleteResult.agentDir,
+              deleteResult.workspaceDir,
+              deleteResult.sessionsDir,
+              ...(databasePlan?.fileGroups.flat() ?? []),
+            ])
+          : () => {};
+        try {
+          await purgeAgentSessionStoreEntries(lockedConfig, agentId);
 
-        const removed: AgentDeleteRemovedPath[] = [];
-        const failed: AgentDeleteFailedPath[] = [];
-        const recordOutcome = (outcome: AgentDeletePathOutcome) => {
-          if ("removed" in outcome) {
-            removed.push(outcome.removed);
-          } else {
-            failed.push(outcome.failed);
-          }
-        };
+          const removed: AgentDeleteRemovedPath[] = [];
+          const failed: AgentDeleteFailedPath[] = [];
+          const recordOutcome = (outcome: AgentDeletePathOutcome) => {
+            if ("removed" in outcome) {
+              removed.push(outcome.removed);
+            } else {
+              failed.push(outcome.failed);
+            }
+          };
 
-        if (deleteFiles) {
-          const workspaceSharedWith = findOverlappingWorkspaceAgentIds(
-            nextConfig,
-            agentId,
-            deleteResult.workspaceDir,
-          );
-          if (workspaceSharedWith.length === 0) {
-            const legacyPlan = prepareLegacyWorkspaceStateReset(deleteResult.workspaceDir);
-            const statePlan = prepareWorkspaceStateDeletion(deleteResult.workspaceDir);
-            const workspaceOutcome = await removeAgentPath(deleteResult.workspaceDir);
-            recordOutcome(workspaceOutcome);
-            if ("removed" in workspaceOutcome) {
-              try {
-                await removeLegacyWorkspaceStateForReset(legacyPlan);
-                deleteWorkspaceState(statePlan);
-              } catch {
-                // Best-effort cleanup. A later explicit reset can remove stale rows.
+          if (deleteFiles) {
+            let survivingDatabaseFilePaths = resolveSurvivingDatabaseFilePaths(
+              listOpenClawRegisteredAgentDatabases(),
+              agentId,
+            );
+            if (
+              !isPathOwnedBySurvivingAgent(
+                nextConfig,
+                agentId,
+                deleteResult.workspaceDir,
+                survivingDatabaseFilePaths,
+              )
+            ) {
+              const legacyPlan = prepareLegacyWorkspaceStateReset(deleteResult.workspaceDir);
+              const statePlan = prepareWorkspaceStateDeletion(deleteResult.workspaceDir);
+              const workspaceOutcome = await removeAgentPath(deleteResult.workspaceDir);
+              recordOutcome(workspaceOutcome);
+              if ("removed" in workspaceOutcome) {
+                try {
+                  await removeLegacyWorkspaceStateForReset(legacyPlan);
+                  deleteWorkspaceState(statePlan);
+                } catch {
+                  // Best-effort cleanup. A later explicit reset can remove stale rows.
+                }
               }
             }
-          }
-          const stateOutcomes = await Promise.all(
-            [
-              deleteResult.agentDir,
+            survivingDatabaseFilePaths = resolveSurvivingDatabaseFilePaths(
+              listOpenClawRegisteredAgentDatabases(),
+              agentId,
+            );
+            // The config mutation lock blocks new roster claims across this final recheck and Trash.
+            const agentDirTrashEligible =
+              resolveRegisteredAgentIdForDir(deleteResult.agentDir) === agentId &&
+              !isPathOwnedBySurvivingAgent(
+                nextConfig,
+                agentId,
+                deleteResult.agentDir,
+                survivingDatabaseFilePaths,
+              );
+            const sessionsDirTrashEligible = !isPathOwnedBySurvivingAgent(
+              nextConfig,
+              agentId,
               deleteResult.sessionsDir,
-              ...(databasePlan?.relocatedFilePaths ?? []),
-            ].map(removeAgentPath),
-          );
-          stateOutcomes.forEach(recordOutcome);
-        }
-        if (failed.length === 0) {
-          if (deleteFiles) {
-            unregisterAgentDeleteDatabases(agentId, databasePlan?.paths ?? []);
+              survivingDatabaseFilePaths,
+            );
+            const databaseFilePaths = (
+              agentDirTrashEligible
+                ? (databasePlan?.relocatedFileGroups ?? [])
+                : (databasePlan?.fileGroups ?? [])
+            )
+              .filter((fileGroup) =>
+                fileGroup.every(
+                  (pathname) =>
+                    !isPathOwnedBySurvivingAgent(
+                      nextConfig,
+                      agentId,
+                      pathname,
+                      survivingDatabaseFilePaths,
+                    ),
+                ),
+              )
+              .flat();
+            const statePaths = [
+              ...new Set([
+                ...(agentDirTrashEligible ? [deleteResult.agentDir] : []),
+                ...(sessionsDirTrashEligible ? [deleteResult.sessionsDir] : []),
+                ...databaseFilePaths,
+              ]),
+            ];
+            const stateOutcomes = await Promise.all(statePaths.map(removeAgentPath));
+            stateOutcomes.forEach(recordOutcome);
+            const agentDirOutcome = stateOutcomes[statePaths.indexOf(deleteResult.agentDir)];
+            if (agentDirOutcome && "removed" in agentDirOutcome) {
+              unregisterResolvedAgentDir({ agentId, agentDir: agentDirRegistryPath });
+            }
           }
-          deletion.finish();
+          if (failed.length === 0) {
+            unregisterResolvedAgentDir({ agentId, agentDir: agentDirRegistryPath });
+            if (deleteFiles) {
+              unregisterAgentDeleteDatabases(agentId, databasePlan?.registrationPaths ?? []);
+            }
+            deletion.finish();
+          }
+          return {
+            ok: true,
+            agentId,
+            removedBindings: deleteResult.removedBindings,
+            removed,
+            failed,
+          };
+        } finally {
+          releaseDatabaseFence();
         }
-        return {
-          ok: true,
-          agentId,
-          removedBindings: deleteResult.removedBindings,
-          removed,
-          failed,
-        };
       });
       respond(true, result, undefined);
     } catch (error) {

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -17,7 +17,18 @@ import {
 } from "../../../packages/gateway-protocol/src/index.js";
 import { createAgent } from "../../agents/agent-create.js";
 import { findOverlappingWorkspaceAgentIds } from "../../agents/agent-delete-safety.js";
-import { listAgentIds, resolveAgentWorkspaceDir } from "../../agents/agent-scope.js";
+import { unregisterResolvedAgentDir } from "../../agents/agent-dir-registry.js";
+import {
+  AgentDeletionAuthorityRollbackError,
+  AgentDeletionCommitUncertainError,
+  beginAgentDeletion,
+  claimCompletedAgentDeletion,
+} from "../../agents/agent-lifecycle-registry.js";
+import {
+  listAgentIds,
+  resolveAgentDir,
+  resolveAgentWorkspaceDir,
+} from "../../agents/agent-scope.js";
 import {
   createAgentIdentityConfig,
   mergeIdentityMarkdownContent,
@@ -46,12 +57,27 @@ import {
   isWorkspaceSetupCompleted,
 } from "../../agents/workspace.js";
 import { applyAgentConfig } from "../../commands/agents.config.js";
+import {
+  readConfigFileSnapshotForWrite,
+  withConfigMutationExclusive,
+} from "../../config/config.js";
 import { purgeAgentSessionStoreEntries } from "../../config/sessions.js";
+import { resolveSessionTranscriptsDirForAgent } from "../../config/sessions/paths.js";
 import type { IdentityConfig } from "../../config/types.base.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { withAgentExecApprovalsRemoved } from "../../infra/exec-approvals.js";
 import { root, FsSafeError, type ReadResult } from "../../infra/fs-safe.js";
+import { resolveSqliteDatabaseFilePaths } from "../../infra/sqlite-files.js";
 import { movePathToTrash } from "../../plugin-sdk/browser-maintenance.js";
 import { DEFAULT_AGENT_ID, normalizeAgentId } from "../../routing/session-key.js";
+import { readAgentDeletionJournal } from "../../state/agent-deletion-journal.js";
+import { assertNoOpenClawAgentDatabaseLeases } from "../../state/openclaw-agent-db-lease.js";
+import { unregisterOpenClawAgentDatabase } from "../../state/openclaw-agent-db-registry.js";
+import {
+  closeOpenClawAgentDatabaseByPath,
+  listOpenClawRegisteredAgentDatabases,
+  resolveOpenClawAgentSqlitePath,
+} from "../../state/openclaw-agent-db.js";
 import { resolveUserPath } from "../../utils.js";
 import { listAgentsForGateway } from "../session-utils.js";
 import {
@@ -332,6 +358,40 @@ async function removeAgentPath(pathname: string): Promise<AgentDeletePathOutcome
   }
 }
 
+type AgentDeleteDatabasePlan = {
+  paths: string[];
+  relocatedFilePaths: string[];
+};
+
+function prepareAgentDeleteDatabases(agentId: string, agentDir: string): AgentDeleteDatabasePlan {
+  const databasePaths = new Set([
+    resolveOpenClawAgentSqlitePath({
+      agentId,
+      path: path.join(agentDir, "openclaw-agent.sqlite"),
+    }),
+    ...listOpenClawRegisteredAgentDatabases()
+      .filter((entry) => normalizeAgentId(entry.agentId) === agentId)
+      .map((entry) => entry.path),
+  ]);
+  for (const databasePath of databasePaths) {
+    closeOpenClawAgentDatabaseByPath(databasePath);
+  }
+  assertNoOpenClawAgentDatabaseLeases(agentId);
+  const relocatedFilePaths = [...databasePaths]
+    .filter((databasePath) => {
+      const relative = path.relative(agentDir, databasePath);
+      return relative.startsWith("..") || path.isAbsolute(relative);
+    })
+    .flatMap(resolveSqliteDatabaseFilePaths);
+  return { paths: [...databasePaths], relocatedFilePaths: [...new Set(relocatedFilePaths)] };
+}
+
+function unregisterAgentDeleteDatabases(agentId: string, databasePaths: string[]): void {
+  for (const databasePath of databasePaths) {
+    unregisterOpenClawAgentDatabase({ agentId, path: databasePath });
+  }
+}
+
 function respondWorkspaceFileUnsafe(respond: RespondFn, name: string): void {
   respond(
     false,
@@ -597,15 +657,172 @@ export const agentsHandlers: GatewayRequestHandlers = {
       );
       return;
     }
-    if (!isConfiguredAgent(cfg, agentId)) {
+    const existingJournal = readAgentDeletionJournal(agentId);
+    if (
+      !isConfiguredAgent(cfg, agentId) &&
+      (!existingJournal || existingJournal.cleanupCompleted)
+    ) {
       respondAgentNotFound(respond, agentId);
       return;
     }
 
-    const deleteFiles = typeof params.deleteFiles === "boolean" ? params.deleteFiles : true;
-    let committed: Awaited<ReturnType<typeof deleteAgentConfigEntry>>;
+    const requestedDeleteFiles =
+      typeof params.deleteFiles === "boolean" ? params.deleteFiles : true;
     try {
-      committed = await deleteAgentConfigEntry({ agentId });
+      const result = await withConfigMutationExclusive(async (lockedConfig) => {
+        let lockedJournal = readAgentDeletionJournal(agentId);
+        const configured = isConfiguredAgent(lockedConfig, agentId);
+        if (!configured && (!lockedJournal || lockedJournal.cleanupCompleted)) {
+          throw new AgentConfigPreconditionError(`agent "${agentId}" not found`);
+        }
+        if (configured && lockedJournal?.cleanupCompleted) {
+          const claimed = claimCompletedAgentDeletion(agentId, lockedJournal.operationId);
+          const remainingJournal = readAgentDeletionJournal(agentId);
+          if (!claimed && remainingJournal) {
+            throw new Error(`agent "${agentId}" deletion tombstone changed before fresh deletion`);
+          }
+          lockedJournal = undefined;
+        }
+        const deleteFiles = lockedJournal?.deleteFiles ?? requestedDeleteFiles;
+        const deletion = beginAgentDeletion(
+          lockedJournal ?? {
+            agentId,
+            agentDir: resolveAgentDir(lockedConfig, agentId),
+            workspaceDir: resolveAgentWorkspaceDir(lockedConfig, agentId),
+            sessionsDir: resolveSessionTranscriptsDirForAgent(agentId),
+            deleteFiles,
+          },
+        );
+        const journal = deletion.entry;
+        let rosterCommitted = !configured;
+        let committed: Awaited<ReturnType<typeof deleteAgentConfigEntry>> | undefined;
+        let databasePlan: AgentDeleteDatabasePlan | undefined;
+        try {
+          databasePlan = prepareAgentDeleteDatabases(agentId, journal.agentDir);
+          await context.cron.removeAgentJobsTransactional(
+            agentId,
+            async () =>
+              await withAgentExecApprovalsRemoved(agentId, async () => {
+                if (!rosterCommitted) {
+                  try {
+                    committed = await deleteAgentConfigEntry({ agentId });
+                  } catch (error) {
+                    try {
+                      const persisted = await readConfigFileSnapshotForWrite();
+                      if (!isConfiguredAgent(persisted.sourceConfig, agentId)) {
+                        rosterCommitted = true;
+                        throw new AgentDeletionCommitUncertainError(error);
+                      }
+                    } catch (readError) {
+                      if (readError instanceof AgentDeletionCommitUncertainError) {
+                        throw readError;
+                      }
+                      throw new AgentDeletionCommitUncertainError(error);
+                    }
+                    throw error;
+                  }
+                  if (!committed.result) {
+                    rosterCommitted = !isConfiguredAgent(committed.nextConfig, agentId);
+                    const missingResultError = new Error(
+                      "agent delete config mutation did not return its target",
+                    );
+                    if (rosterCommitted) {
+                      throw new AgentDeletionCommitUncertainError(missingResultError);
+                    }
+                    throw missingResultError;
+                  }
+                  rosterCommitted = true;
+                }
+              }),
+          );
+          deletion.commit();
+        } catch (error) {
+          let canReleaseFence =
+            !rosterCommitted &&
+            !lockedJournal &&
+            !(error instanceof AgentDeletionAuthorityRollbackError) &&
+            !(error instanceof AgentDeletionCommitUncertainError);
+          if (canReleaseFence) {
+            try {
+              const persisted = await readConfigFileSnapshotForWrite();
+              canReleaseFence = isConfiguredAgent(persisted.sourceConfig, agentId);
+            } catch {
+              canReleaseFence = false;
+            }
+          }
+          if (canReleaseFence) {
+            deletion.rollback();
+          }
+          throw error;
+        }
+
+        const deleteResult = committed?.result ?? {
+          agentDir: journal.agentDir,
+          workspaceDir: journal.workspaceDir,
+          sessionsDir: journal.sessionsDir,
+          removedBindings: 0,
+        };
+        const nextConfig = committed?.nextConfig ?? lockedConfig;
+
+        // The durable journal is created before authority changes and cleared only after
+        // roster commit plus destructive cleanup, so crashes and same-id recreation fail closed.
+        unregisterResolvedAgentDir({ agentId, agentDir: deleteResult.agentDir });
+        await purgeAgentSessionStoreEntries(lockedConfig, agentId);
+
+        const removed: AgentDeleteRemovedPath[] = [];
+        const failed: AgentDeleteFailedPath[] = [];
+        const recordOutcome = (outcome: AgentDeletePathOutcome) => {
+          if ("removed" in outcome) {
+            removed.push(outcome.removed);
+          } else {
+            failed.push(outcome.failed);
+          }
+        };
+
+        if (deleteFiles) {
+          const workspaceSharedWith = findOverlappingWorkspaceAgentIds(
+            nextConfig,
+            agentId,
+            deleteResult.workspaceDir,
+          );
+          if (workspaceSharedWith.length === 0) {
+            const legacyPlan = prepareLegacyWorkspaceStateReset(deleteResult.workspaceDir);
+            const statePlan = prepareWorkspaceStateDeletion(deleteResult.workspaceDir);
+            const workspaceOutcome = await removeAgentPath(deleteResult.workspaceDir);
+            recordOutcome(workspaceOutcome);
+            if ("removed" in workspaceOutcome) {
+              try {
+                await removeLegacyWorkspaceStateForReset(legacyPlan);
+                deleteWorkspaceState(statePlan);
+              } catch {
+                // Best-effort cleanup. A later explicit reset can remove stale rows.
+              }
+            }
+          }
+          const stateOutcomes = await Promise.all(
+            [
+              deleteResult.agentDir,
+              deleteResult.sessionsDir,
+              ...(databasePlan?.relocatedFilePaths ?? []),
+            ].map(removeAgentPath),
+          );
+          stateOutcomes.forEach(recordOutcome);
+        }
+        if (failed.length === 0) {
+          if (deleteFiles) {
+            unregisterAgentDeleteDatabases(agentId, databasePlan?.paths ?? []);
+          }
+          deletion.finish();
+        }
+        return {
+          ok: true,
+          agentId,
+          removedBindings: deleteResult.removedBindings,
+          removed,
+          failed,
+        };
+      });
+      respond(true, result, undefined);
     } catch (error) {
       if (error instanceof AgentConfigPreconditionError) {
         respondAgentNotFound(respond, agentId);
@@ -613,57 +830,6 @@ export const agentsHandlers: GatewayRequestHandlers = {
       }
       throw error;
     }
-    const deleteResult = committed.result;
-    if (!deleteResult) {
-      respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, "agent delete did not commit"));
-      return;
-    }
-
-    // Purge session store entries so orphaned sessions cannot be targeted (#65524).
-    await purgeAgentSessionStoreEntries(cfg, agentId);
-
-    const removed: AgentDeleteRemovedPath[] = [];
-    const failed: AgentDeleteFailedPath[] = [];
-    const recordOutcome = (outcome: AgentDeletePathOutcome) => {
-      if ("removed" in outcome) {
-        removed.push(outcome.removed);
-      } else {
-        failed.push(outcome.failed);
-      }
-    };
-
-    if (deleteFiles) {
-      const workspaceSharedWith = findOverlappingWorkspaceAgentIds(
-        committed.nextConfig,
-        agentId,
-        deleteResult.workspaceDir,
-      );
-      const deleteWorkspace = workspaceSharedWith.length === 0;
-      if (deleteWorkspace) {
-        const legacyPlan = prepareLegacyWorkspaceStateReset(deleteResult.workspaceDir);
-        const statePlan = prepareWorkspaceStateDeletion(deleteResult.workspaceDir);
-        const workspaceOutcome = await removeAgentPath(deleteResult.workspaceDir);
-        recordOutcome(workspaceOutcome);
-        if ("removed" in workspaceOutcome) {
-          try {
-            await removeLegacyWorkspaceStateForReset(legacyPlan);
-            deleteWorkspaceState(statePlan);
-          } catch {
-            // Best-effort cleanup. A later explicit reset can remove stale rows.
-          }
-        }
-      }
-      const stateOutcomes = await Promise.all(
-        [deleteResult.agentDir, deleteResult.sessionsDir].map(removeAgentPath),
-      );
-      stateOutcomes.forEach(recordOutcome);
-    }
-
-    respond(
-      true,
-      { ok: true, agentId, removedBindings: deleteResult.removedBindings, removed, failed },
-      undefined,
-    );
   },
   "agents.files.list": async ({ params, respond, context }) => {
     if (!validateAgentsFilesListParams(params)) {

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -79,10 +79,7 @@ import { movePathToTrash } from "../../plugin-sdk/browser-maintenance.js";
 import { DEFAULT_AGENT_ID, normalizeAgentId } from "../../routing/session-key.js";
 import { readAgentDeletionJournal } from "../../state/agent-deletion-journal.js";
 import { assertNoOpenClawAgentDatabaseLeases } from "../../state/openclaw-agent-db-lease.js";
-import {
-  beginOpenClawAgentDatabaseRegistrationFence,
-  unregisterOpenClawAgentDatabase,
-} from "../../state/openclaw-agent-db-registry.js";
+import { unregisterOpenClawAgentDatabase } from "../../state/openclaw-agent-db-registry.js";
 import {
   closeOpenClawAgentDatabaseByPath,
   listOpenClawRegisteredAgentDatabases,
@@ -364,8 +361,76 @@ async function removeAgentPath(pathname: string): Promise<AgentDeletePathOutcome
     await movePathToTrash(pathname);
     return { removed: { path: pathname, method: "trash" } };
   } catch (error) {
-    return cleanupFailure(pathname, error);
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      return cleanupFailure(pathname, error);
+    }
+    try {
+      await fs.lstat(pathname);
+      return cleanupFailure(pathname, error);
+    } catch (statError) {
+      return (statError as NodeJS.ErrnoException).code === "ENOENT"
+        ? { removed: { path: pathname, method: "missing" } }
+        : cleanupFailure(pathname, statError);
+    }
   }
+}
+
+type AgentDeleteCleanupPath = {
+  path: string;
+  canonicalPath: string;
+  trashPath: string;
+  trashCoversDescendants: boolean;
+};
+
+async function prepareAgentDeleteCleanupPaths(
+  paths: readonly string[],
+): Promise<AgentDeleteCleanupPath[]> {
+  const uniquePaths = new Map<string, AgentDeleteCleanupPath>();
+  for (const pathname of paths) {
+    const trashPath = path.resolve(pathname);
+    if (uniquePaths.has(trashPath)) {
+      continue;
+    }
+    const canonicalPath = normalizeAgentDirRegistryPath(pathname);
+    let trashCoversDescendants = false;
+    try {
+      const stat = await fs.lstat(pathname);
+      trashCoversDescendants = stat?.isSymbolicLink?.() !== true;
+    } catch {
+      // Missing or unreadable parents cannot prove that trashing them covers a child path.
+    }
+    uniquePaths.set(trashPath, {
+      path: pathname,
+      canonicalPath,
+      trashPath,
+      trashCoversDescendants,
+    });
+  }
+  const candidates = [...uniquePaths.values()];
+  return candidates.filter(
+    (candidate) =>
+      !candidates.some(
+        (parent) =>
+          parent !== candidate &&
+          parent.trashCoversDescendants &&
+          isPathInside(parent.trashPath, candidate.trashPath) &&
+          isPathInside(parent.canonicalPath, candidate.canonicalPath),
+      ),
+  );
+}
+
+function cleanupPathCovers(
+  cleanupPath: AgentDeleteCleanupPath,
+  targetPath: string,
+  canonicalTargetPath: string,
+): boolean {
+  const trashTargetPath = path.resolve(targetPath);
+  return (
+    cleanupPath.trashPath === trashTargetPath ||
+    (cleanupPath.trashCoversDescendants &&
+      isPathInside(cleanupPath.trashPath, trashTargetPath) &&
+      isPathInside(cleanupPath.canonicalPath, canonicalTargetPath))
+  );
 }
 
 type AgentDeleteDatabasePlan = {
@@ -780,6 +845,10 @@ export const agentsHandlers: GatewayRequestHandlers = {
         try {
           prepareJournaledAgentDirOwnership(lockedConfig, agentId, journal.agentDir);
           databasePlan = prepareAgentDeleteDatabases(lockedConfig, agentId, journal.agentDir);
+          deletion.fenceDatabasePaths([
+            ...journal.databasePaths,
+            ...databasePlan.fileGroups.flat(),
+          ]);
           await context.cron.removeAgentJobsTransactional(
             agentId,
             async () =>
@@ -848,120 +917,147 @@ export const agentsHandlers: GatewayRequestHandlers = {
         // A journaled path is trash-eligible only while registry ownership still points at the
         // deleted agent; recovery must not consume a path claimed by a surviving agent.
         const agentDirRegistryPath = normalizeAgentDirRegistryPath(deleteResult.agentDir);
-        const releaseDatabaseFence = deleteFiles
-          ? beginOpenClawAgentDatabaseRegistrationFence([
-              deleteResult.agentDir,
-              deleteResult.workspaceDir,
-              deleteResult.sessionsDir,
-              ...(databasePlan?.fileGroups.flat() ?? []),
-            ])
-          : () => {};
-        try {
-          await purgeAgentSessionStoreEntries(lockedConfig, agentId);
+        await purgeAgentSessionStoreEntries(lockedConfig, agentId);
 
-          const removed: AgentDeleteRemovedPath[] = [];
-          const failed: AgentDeleteFailedPath[] = [];
-          const recordOutcome = (outcome: AgentDeletePathOutcome) => {
+        const removed: AgentDeleteRemovedPath[] = [];
+        const failed: AgentDeleteFailedPath[] = [];
+
+        if (deleteFiles) {
+          const survivingDatabaseFilePaths = resolveSurvivingDatabaseFilePaths(
+            listOpenClawRegisteredAgentDatabases(),
+            agentId,
+          );
+          const workspaceTrashEligible = !isPathOwnedBySurvivingAgent(
+            nextConfig,
+            agentId,
+            deleteResult.workspaceDir,
+            survivingDatabaseFilePaths,
+          );
+          // The config mutation lock and durable journal fence block new roster and database
+          // claims across this final ownership recheck and the filesystem cleanup below.
+          const agentDirTrashEligible =
+            resolveRegisteredAgentIdForDir(deleteResult.agentDir) === agentId &&
+            !isPathOwnedBySurvivingAgent(
+              nextConfig,
+              agentId,
+              deleteResult.agentDir,
+              survivingDatabaseFilePaths,
+            );
+          const sessionsDirTrashEligible = !isPathOwnedBySurvivingAgent(
+            nextConfig,
+            agentId,
+            deleteResult.sessionsDir,
+            survivingDatabaseFilePaths,
+          );
+          const databaseFilePaths = [
+            ...(agentDirTrashEligible
+              ? (databasePlan?.relocatedFileGroups ?? [])
+              : (databasePlan?.fileGroups ?? [])
+            ).flat(),
+            ...journal.databasePaths,
+          ].filter(
+            (pathname) =>
+              !isPathOwnedBySurvivingAgent(
+                nextConfig,
+                agentId,
+                pathname,
+                survivingDatabaseFilePaths,
+              ),
+          );
+          const cleanupPaths = (
+            await prepareAgentDeleteCleanupPaths([
+              ...(workspaceTrashEligible ? [deleteResult.workspaceDir] : []),
+              ...(agentDirTrashEligible ? [deleteResult.agentDir] : []),
+              ...(sessionsDirTrashEligible ? [deleteResult.sessionsDir] : []),
+              ...databaseFilePaths,
+            ])
+          ).filter(
+            (cleanupPath) =>
+              agentDirTrashEligible ||
+              !cleanupPathCovers(cleanupPath, deleteResult.agentDir, agentDirRegistryPath),
+          );
+          const workspaceCanonicalPath = normalizeAgentDirRegistryPath(deleteResult.workspaceDir);
+          const workspaceCleanupPath = cleanupPaths.find((cleanupPath) =>
+            cleanupPathCovers(cleanupPath, deleteResult.workspaceDir, workspaceCanonicalPath),
+          );
+          const legacyPlan = workspaceCleanupPath
+            ? prepareLegacyWorkspaceStateReset(deleteResult.workspaceDir)
+            : undefined;
+          const statePlan = workspaceCleanupPath
+            ? prepareWorkspaceStateDeletion(deleteResult.workspaceDir)
+            : undefined;
+          const workspaceOutcome = workspaceCleanupPath
+            ? {
+                cleanupPath: workspaceCleanupPath,
+                outcome: await removeAgentPath(workspaceCleanupPath.path),
+              }
+            : undefined;
+          const refreshedDatabaseFilePaths = resolveSurvivingDatabaseFilePaths(
+            listOpenClawRegisteredAgentDatabases(),
+            agentId,
+          );
+          const remainingCleanupPaths = cleanupPaths.filter(
+            (cleanupPath) =>
+              cleanupPath !== workspaceCleanupPath &&
+              !isPathOwnedBySurvivingAgent(
+                nextConfig,
+                agentId,
+                cleanupPath.path,
+                refreshedDatabaseFilePaths,
+              ) &&
+              (!cleanupPathCovers(cleanupPath, deleteResult.agentDir, agentDirRegistryPath) ||
+                resolveRegisteredAgentIdForDir(deleteResult.agentDir) === agentId),
+          );
+          const outcomes = [
+            ...(workspaceOutcome ? [workspaceOutcome] : []),
+            ...(await Promise.all(
+              remainingCleanupPaths.map(async (cleanupPath) => ({
+                cleanupPath,
+                outcome: await removeAgentPath(cleanupPath.path),
+              })),
+            )),
+          ];
+          for (const { outcome } of outcomes) {
             if ("removed" in outcome) {
               removed.push(outcome.removed);
             } else {
               failed.push(outcome.failed);
             }
-          };
-
-          if (deleteFiles) {
-            let survivingDatabaseFilePaths = resolveSurvivingDatabaseFilePaths(
-              listOpenClawRegisteredAgentDatabases(),
-              agentId,
-            );
-            if (
-              !isPathOwnedBySurvivingAgent(
-                nextConfig,
-                agentId,
-                deleteResult.workspaceDir,
-                survivingDatabaseFilePaths,
-              )
-            ) {
-              const legacyPlan = prepareLegacyWorkspaceStateReset(deleteResult.workspaceDir);
-              const statePlan = prepareWorkspaceStateDeletion(deleteResult.workspaceDir);
-              const workspaceOutcome = await removeAgentPath(deleteResult.workspaceDir);
-              recordOutcome(workspaceOutcome);
-              if ("removed" in workspaceOutcome) {
-                try {
-                  await removeLegacyWorkspaceStateForReset(legacyPlan);
-                  deleteWorkspaceState(statePlan);
-                } catch {
-                  // Best-effort cleanup. A later explicit reset can remove stale rows.
-                }
-              }
-            }
-            survivingDatabaseFilePaths = resolveSurvivingDatabaseFilePaths(
-              listOpenClawRegisteredAgentDatabases(),
-              agentId,
-            );
-            // The config mutation lock blocks new roster claims across this final recheck and Trash.
-            const agentDirTrashEligible =
-              resolveRegisteredAgentIdForDir(deleteResult.agentDir) === agentId &&
-              !isPathOwnedBySurvivingAgent(
-                nextConfig,
-                agentId,
-                deleteResult.agentDir,
-                survivingDatabaseFilePaths,
-              );
-            const sessionsDirTrashEligible = !isPathOwnedBySurvivingAgent(
-              nextConfig,
-              agentId,
-              deleteResult.sessionsDir,
-              survivingDatabaseFilePaths,
-            );
-            const databaseFilePaths = (
-              agentDirTrashEligible
-                ? (databasePlan?.relocatedFileGroups ?? [])
-                : (databasePlan?.fileGroups ?? [])
-            )
-              .filter((fileGroup) =>
-                fileGroup.every(
-                  (pathname) =>
-                    !isPathOwnedBySurvivingAgent(
-                      nextConfig,
-                      agentId,
-                      pathname,
-                      survivingDatabaseFilePaths,
-                    ),
-                ),
-              )
-              .flat();
-            const statePaths = [
-              ...new Set([
-                ...(agentDirTrashEligible ? [deleteResult.agentDir] : []),
-                ...(sessionsDirTrashEligible ? [deleteResult.sessionsDir] : []),
-                ...databaseFilePaths,
-              ]),
-            ];
-            const stateOutcomes = await Promise.all(statePaths.map(removeAgentPath));
-            stateOutcomes.forEach(recordOutcome);
-            const agentDirOutcome = stateOutcomes[statePaths.indexOf(deleteResult.agentDir)];
-            if (agentDirOutcome && "removed" in agentDirOutcome) {
-              unregisterResolvedAgentDir({ agentId, agentDir: agentDirRegistryPath });
+          }
+          if (
+            workspaceOutcome &&
+            "removed" in workspaceOutcome.outcome &&
+            legacyPlan &&
+            statePlan
+          ) {
+            try {
+              await removeLegacyWorkspaceStateForReset(legacyPlan);
+              deleteWorkspaceState(statePlan);
+            } catch {
+              // Best-effort cleanup. A later explicit reset can remove stale rows.
             }
           }
-          if (failed.length === 0) {
+          const agentDirOutcome = outcomes.find(({ cleanupPath }) =>
+            cleanupPathCovers(cleanupPath, deleteResult.agentDir, agentDirRegistryPath),
+          )?.outcome;
+          if (agentDirOutcome && "removed" in agentDirOutcome) {
             unregisterResolvedAgentDir({ agentId, agentDir: agentDirRegistryPath });
-            if (deleteFiles) {
-              unregisterAgentDeleteDatabases(agentId, databasePlan?.registrationPaths ?? []);
-            }
-            deletion.finish();
           }
-          return {
-            ok: true,
-            agentId,
-            removedBindings: deleteResult.removedBindings,
-            removed,
-            failed,
-          };
-        } finally {
-          releaseDatabaseFence();
         }
+        if (failed.length === 0) {
+          unregisterResolvedAgentDir({ agentId, agentDir: agentDirRegistryPath });
+          if (deleteFiles) {
+            unregisterAgentDeleteDatabases(agentId, databasePlan?.registrationPaths ?? []);
+          }
+          deletion.finish();
+        }
+        return {
+          ok: true,
+          agentId,
+          removedBindings: deleteResult.removedBindings,
+          removed,
+          failed,
+        };
       });
       respond(true, result, undefined);
     } catch (error) {

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -77,7 +77,10 @@ import { isPathInside } from "../../infra/path-guards.js";
 import { resolveSqliteDatabaseFilePaths } from "../../infra/sqlite-files.js";
 import { movePathToTrash } from "../../plugin-sdk/browser-maintenance.js";
 import { DEFAULT_AGENT_ID, normalizeAgentId } from "../../routing/session-key.js";
-import { readAgentDeletionJournal } from "../../state/agent-deletion-journal.js";
+import {
+  readAgentDeletionJournal,
+  type AgentDeletionJournalCleanupPath,
+} from "../../state/agent-deletion-journal.js";
 import { assertNoOpenClawAgentDatabaseLeases } from "../../state/openclaw-agent-db-lease.js";
 import { unregisterOpenClawAgentDatabase } from "../../state/openclaw-agent-db-registry.js";
 import {
@@ -349,13 +352,24 @@ function cleanupFailure(pathname: string, error: unknown): AgentDeletePathOutcom
   return { failed: { path: pathname, reason: reason || "unknown error" } };
 }
 
-async function removeAgentPath(pathname: string): Promise<AgentDeletePathOutcome> {
+async function removeAgentPath(
+  pathname: string,
+  expectedKind: AgentDeletionJournalCleanupPath["kind"],
+): Promise<AgentDeletePathOutcome> {
+  let targetStat: Awaited<ReturnType<typeof fs.lstat>>;
   try {
-    await fs.lstat(pathname);
+    targetStat = await fs.lstat(pathname);
   } catch (error) {
     return (error as NodeJS.ErrnoException).code === "ENOENT"
       ? { removed: { path: pathname, method: "missing" } }
       : cleanupFailure(pathname, error);
+  }
+  const isSymlink = targetStat?.isSymbolicLink?.() === true;
+  if (isSymlink !== (expectedKind === "symlink")) {
+    return cleanupFailure(
+      pathname,
+      new Error(`cleanup path changed from ${expectedKind} before deletion`),
+    );
   }
   try {
     await movePathToTrash(pathname);
@@ -380,43 +394,198 @@ type AgentDeleteCleanupPath = {
   canonicalPath: string;
   trashPath: string;
   trashCoversDescendants: boolean;
+  kind: "target" | "symlink";
+  preparationError?: unknown;
+  sourcePaths: string[];
 };
+
+async function resolveAgentDeleteCleanupTarget(pathname: string): Promise<string> {
+  let candidate = path.resolve(pathname);
+  const missingSuffix: string[] = [];
+  while (true) {
+    try {
+      return path.resolve(await fs.realpath(candidate), ...missingSuffix);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw error;
+      }
+      let candidateStat: Awaited<ReturnType<typeof fs.lstat>> | undefined;
+      try {
+        candidateStat = await fs.lstat(candidate);
+      } catch (statError) {
+        if ((statError as NodeJS.ErrnoException).code !== "ENOENT") {
+          throw statError;
+        }
+      }
+      if (candidateStat?.isSymbolicLink()) {
+        const linkTarget = await fs.readlink(candidate);
+        const resolvedLinkTarget = await resolveAgentDeleteCleanupTarget(
+          path.isAbsolute(linkTarget)
+            ? linkTarget
+            : path.resolve(path.dirname(candidate), linkTarget),
+        );
+        return path.resolve(resolvedLinkTarget, ...missingSuffix);
+      }
+      const parent = path.dirname(candidate);
+      if (parent === candidate) {
+        throw error;
+      }
+      missingSuffix.unshift(path.basename(candidate));
+      candidate = parent;
+    }
+  }
+}
 
 async function prepareAgentDeleteCleanupPaths(
   paths: readonly string[],
+  persistedPaths: readonly AgentDeletionJournalCleanupPath[] = [],
 ): Promise<AgentDeleteCleanupPath[]> {
   const uniquePaths = new Map<string, AgentDeleteCleanupPath>();
-  for (const pathname of paths) {
-    const trashPath = path.resolve(pathname);
-    if (uniquePaths.has(trashPath)) {
-      continue;
+  const addPath = (candidate: AgentDeleteCleanupPath) => {
+    const existing = uniquePaths.get(candidate.trashPath);
+    if (!existing) {
+      uniquePaths.set(candidate.trashPath, candidate);
+      return;
     }
-    const canonicalPath = normalizeAgentDirRegistryPath(pathname);
-    let trashCoversDescendants = false;
-    try {
-      const stat = await fs.lstat(pathname);
-      trashCoversDescendants = stat?.isSymbolicLink?.() !== true;
-    } catch {
-      // Missing or unreadable parents cannot prove that trashing them covers a child path.
+    existing.sourcePaths = [...new Set([...existing.sourcePaths, ...candidate.sourcePaths])];
+    existing.preparationError ??= candidate.preparationError;
+    if (candidate.kind === "target") {
+      existing.kind = "target";
+      existing.canonicalPath = candidate.canonicalPath;
+      existing.trashCoversDescendants ||= candidate.trashCoversDescendants;
     }
-    uniquePaths.set(trashPath, {
-      path: pathname,
-      canonicalPath,
-      trashPath,
-      trashCoversDescendants,
-    });
+  };
+  if (persistedPaths.length > 0) {
+    for (const persistedPath of persistedPaths) {
+      const trashPath = path.resolve(persistedPath.path);
+      let targetStat: Awaited<ReturnType<typeof fs.lstat>> | undefined;
+      let preparationError: unknown;
+      try {
+        targetStat = await fs.lstat(trashPath);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+          preparationError = error;
+        }
+      }
+      if (targetStat && targetStat.isSymbolicLink() !== (persistedPath.kind === "symlink")) {
+        preparationError = new Error(
+          `cleanup path changed from ${persistedPath.kind} before deletion`,
+        );
+      }
+      addPath({
+        path: trashPath,
+        canonicalPath: normalizeAgentDirRegistryPath(trashPath),
+        trashPath,
+        trashCoversDescendants:
+          persistedPath.kind === "target" && targetStat
+            ? targetStat.isSymbolicLink() !== true
+            : false,
+        kind: persistedPath.kind,
+        preparationError,
+        sourcePaths: persistedPath.sourcePaths.map((sourcePath) => path.resolve(sourcePath)),
+      });
+    }
   }
-  const candidates = [...uniquePaths.values()];
-  return candidates.filter(
-    (candidate) =>
-      !candidates.some(
-        (parent) =>
-          parent !== candidate &&
-          parent.trashCoversDescendants &&
-          isPathInside(parent.trashPath, candidate.trashPath) &&
-          isPathInside(parent.canonicalPath, candidate.canonicalPath),
+  for (const pathname of paths) {
+    const sourcePath = path.resolve(pathname);
+    let resolvedPath = sourcePath;
+    let preparationError: unknown;
+    try {
+      resolvedPath = await resolveAgentDeleteCleanupTarget(pathname);
+    } catch (error) {
+      preparationError = error;
+    }
+    let sourceStat: Awaited<ReturnType<typeof fs.lstat>> | undefined;
+    try {
+      sourceStat = await fs.lstat(pathname);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        preparationError ??= error;
+      }
+    }
+    let targetStat = sourceStat;
+    if (resolvedPath !== sourcePath) {
+      try {
+        targetStat = await fs.lstat(resolvedPath);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+          preparationError ??= error;
+        }
+        targetStat = undefined;
+      }
+    }
+    const canonicalPath = normalizeAgentDirRegistryPath(resolvedPath);
+    let trashCoversDescendants = false;
+    if (targetStat) {
+      trashCoversDescendants = targetStat.isSymbolicLink() !== true;
+    }
+    addPath({
+      path: resolvedPath,
+      canonicalPath,
+      trashPath: resolvedPath,
+      trashCoversDescendants,
+      kind: "target",
+      preparationError,
+      sourcePaths: [sourcePath],
+    });
+    if (sourceStat?.isSymbolicLink() && sourcePath !== resolvedPath) {
+      addPath({
+        path: sourcePath,
+        canonicalPath,
+        trashPath: sourcePath,
+        trashCoversDescendants: false,
+        kind: "symlink",
+        sourcePaths: [sourcePath],
+      });
+    }
+  }
+  const depth = (pathname: string) =>
+    path.relative(path.parse(pathname).root, pathname).split(path.sep).filter(Boolean).length;
+  const cleanupDepth = (cleanupPath: AgentDeleteCleanupPath) =>
+    Math.max(
+      depth(cleanupPath.canonicalPath),
+      depth(cleanupPath.trashPath),
+      ...cleanupPath.sourcePaths.map(depth),
+    );
+  const compareFallback = (left: AgentDeleteCleanupPath, right: AgentDeleteCleanupPath) => {
+    if (left.kind !== right.kind) {
+      return left.kind === "target" ? -1 : 1;
+    }
+    const depthDifference = cleanupDepth(right) - cleanupDepth(left);
+    if (depthDifference !== 0) {
+      return depthDifference;
+    }
+    const trashDepth = depth(right.trashPath) - depth(left.trashPath);
+    return trashDepth || left.trashPath.localeCompare(right.trashPath);
+  };
+  const mustPrecede = (left: AgentDeleteCleanupPath, right: AgentDeleteCleanupPath) => {
+    if (left.kind !== right.kind) {
+      return left.kind === "target";
+    }
+    if (isPathInside(right.trashPath, left.trashPath)) {
+      return true;
+    }
+    if (isPathInside(left.trashPath, right.trashPath)) {
+      return false;
+    }
+    const rightRoots = [right.trashPath, ...right.sourcePaths];
+    return left.sourcePaths.some((leftSource) =>
+      rightRoots.some((rightRoot) => isPathInside(rightRoot, leftSource)),
+    );
+  };
+  const remaining = [...uniquePaths.values()].sort(compareFallback);
+  const ordered: AgentDeleteCleanupPath[] = [];
+  // Snapshot real targets and clean every physical or lexical descendant first; moving an
+  // ancestor symlink would otherwise hide surviving child data and let recovery finalize.
+  while (remaining.length > 0) {
+    const nextIndex = remaining.findIndex((candidate, candidateIndex) =>
+      remaining.every(
+        (other, otherIndex) => otherIndex === candidateIndex || !mustPrecede(other, candidate),
       ),
-  );
+    );
+    ordered.push(...remaining.splice(nextIndex < 0 ? 0 : nextIndex, 1));
+  }
+  return ordered;
 }
 
 function cleanupPathCovers(
@@ -426,9 +595,10 @@ function cleanupPathCovers(
 ): boolean {
   const trashTargetPath = path.resolve(targetPath);
   return (
+    cleanupPath.sourcePaths.includes(trashTargetPath) ||
     cleanupPath.trashPath === trashTargetPath ||
     (cleanupPath.trashCoversDescendants &&
-      isPathInside(cleanupPath.trashPath, trashTargetPath) &&
+      (cleanupPath.kind === "target" || isPathInside(cleanupPath.trashPath, trashTargetPath)) &&
       isPathInside(cleanupPath.canonicalPath, canonicalTargetPath))
   );
 }
@@ -849,6 +1019,45 @@ export const agentsHandlers: GatewayRequestHandlers = {
             ...journal.databasePaths,
             ...databasePlan.fileGroups.flat(),
           ]);
+          if (deleteFiles) {
+            const fencedSourcePaths = new Set(
+              journal.cleanupPaths.flatMap((cleanupPath) =>
+                cleanupPath.sourcePaths.map((sourcePath) => path.resolve(sourcePath)),
+              ),
+            );
+            const unfencedSourcePaths = [
+              journal.workspaceDir,
+              journal.agentDir,
+              journal.sessionsDir,
+              ...journal.databasePaths,
+            ].filter((sourcePath) => !fencedSourcePaths.has(path.resolve(sourcePath)));
+            if (unfencedSourcePaths.length > 0) {
+              const unfencedSourcePathSet = new Set(
+                unfencedSourcePaths.map((sourcePath) => path.resolve(sourcePath)),
+              );
+              const cleanupPlan = await prepareAgentDeleteCleanupPaths(
+                unfencedSourcePaths,
+                journal.cleanupPaths,
+              );
+              const unresolvedPath = cleanupPlan.find(
+                (cleanupPath) =>
+                  cleanupPath.preparationError !== undefined &&
+                  cleanupPath.sourcePaths.some((sourcePath) =>
+                    unfencedSourcePathSet.has(path.resolve(sourcePath)),
+                  ),
+              );
+              if (unresolvedPath) {
+                throw unresolvedPath.preparationError;
+              }
+              deletion.fenceCleanupPaths(
+                cleanupPlan.map(({ path: cleanupPath, kind, sourcePaths }) => ({
+                  path: cleanupPath,
+                  kind,
+                  sourcePaths,
+                })),
+              );
+            }
+          }
           await context.cron.removeAgentJobsTransactional(
             agentId,
             async () =>
@@ -964,59 +1173,88 @@ export const agentsHandlers: GatewayRequestHandlers = {
                 survivingDatabaseFilePaths,
               ),
           );
-          const cleanupPaths = (
-            await prepareAgentDeleteCleanupPaths([
+          const eligibleSourcePaths = new Set(
+            [
               ...(workspaceTrashEligible ? [deleteResult.workspaceDir] : []),
               ...(agentDirTrashEligible ? [deleteResult.agentDir] : []),
               ...(sessionsDirTrashEligible ? [deleteResult.sessionsDir] : []),
               ...databaseFilePaths,
-            ])
+            ].map((sourcePath) => path.resolve(sourcePath)),
+          );
+          const cleanupPaths = (
+            await prepareAgentDeleteCleanupPaths([], journal.cleanupPaths)
           ).filter(
             (cleanupPath) =>
-              agentDirTrashEligible ||
-              !cleanupPathCovers(cleanupPath, deleteResult.agentDir, agentDirRegistryPath),
+              cleanupPath.sourcePaths.some((sourcePath) => eligibleSourcePaths.has(sourcePath)) &&
+              (agentDirTrashEligible ||
+                !cleanupPathCovers(cleanupPath, deleteResult.agentDir, agentDirRegistryPath)),
           );
           const workspaceCanonicalPath = normalizeAgentDirRegistryPath(deleteResult.workspaceDir);
-          const workspaceCleanupPath = cleanupPaths.find((cleanupPath) =>
+          const workspaceCleanupPaths = cleanupPaths.filter((cleanupPath) =>
             cleanupPathCovers(cleanupPath, deleteResult.workspaceDir, workspaceCanonicalPath),
           );
-          const legacyPlan = workspaceCleanupPath
-            ? prepareLegacyWorkspaceStateReset(deleteResult.workspaceDir)
-            : undefined;
-          const statePlan = workspaceCleanupPath
-            ? prepareWorkspaceStateDeletion(deleteResult.workspaceDir)
-            : undefined;
-          const workspaceOutcome = workspaceCleanupPath
-            ? {
-                cleanupPath: workspaceCleanupPath,
-                outcome: await removeAgentPath(workspaceCleanupPath.path),
-              }
-            : undefined;
-          const refreshedDatabaseFilePaths = resolveSurvivingDatabaseFilePaths(
-            listOpenClawRegisteredAgentDatabases(),
-            agentId,
-          );
-          const remainingCleanupPaths = cleanupPaths.filter(
-            (cleanupPath) =>
-              cleanupPath !== workspaceCleanupPath &&
-              !isPathOwnedBySurvivingAgent(
+          const legacyPlan =
+            workspaceCleanupPaths.length > 0
+              ? prepareLegacyWorkspaceStateReset(deleteResult.workspaceDir)
+              : undefined;
+          const statePlan =
+            workspaceCleanupPaths.length > 0
+              ? prepareWorkspaceStateDeletion(deleteResult.workspaceDir)
+              : undefined;
+          const outcomes: Array<{
+            cleanupPath: AgentDeleteCleanupPath;
+            outcome: AgentDeletePathOutcome;
+          }> = [];
+          const protectedCleanupPaths: Array<{
+            cleanupPath: AgentDeleteCleanupPath;
+            protectAliases: boolean;
+          }> = [];
+          for (const cleanupPath of cleanupPaths) {
+            const refreshedDatabaseFilePaths = resolveSurvivingDatabaseFilePaths(
+              listOpenClawRegisteredAgentDatabases(),
+              agentId,
+            );
+            const blockingProtection = protectedCleanupPaths.find(
+              ({ cleanupPath: protectedPath, protectAliases }) =>
+                ((cleanupPath.kind !== "symlink" || protectAliases) &&
+                  (protectedPath.canonicalPath === cleanupPath.canonicalPath ||
+                    isPathInside(cleanupPath.canonicalPath, protectedPath.canonicalPath))) ||
+                [
+                  protectedPath.trashPath,
+                  ...(protectAliases ? protectedPath.sourcePaths : []),
+                ].some(
+                  (protectedSourcePath) =>
+                    protectedSourcePath === cleanupPath.trashPath ||
+                    isPathInside(cleanupPath.trashPath, protectedSourcePath),
+                ),
+            );
+            const ownedBySurvivor =
+              isPathOwnedBySurvivingAgent(
                 nextConfig,
                 agentId,
                 cleanupPath.path,
                 refreshedDatabaseFilePaths,
-              ) &&
-              (!cleanupPathCovers(cleanupPath, deleteResult.agentDir, agentDirRegistryPath) ||
-                resolveRegisteredAgentIdForDir(deleteResult.agentDir) === agentId),
-          );
-          const outcomes = [
-            ...(workspaceOutcome ? [workspaceOutcome] : []),
-            ...(await Promise.all(
-              remainingCleanupPaths.map(async (cleanupPath) => ({
+              ) ||
+              (cleanupPathCovers(cleanupPath, deleteResult.agentDir, agentDirRegistryPath) &&
+                resolveRegisteredAgentIdForDir(deleteResult.agentDir) !== agentId);
+            if (blockingProtection || ownedBySurvivor) {
+              protectedCleanupPaths.push({
                 cleanupPath,
-                outcome: await removeAgentPath(cleanupPath.path),
-              })),
-            )),
-          ];
+                protectAliases: blockingProtection?.protectAliases ?? false,
+              });
+              continue;
+            }
+            const outcome = cleanupPath.preparationError
+              ? cleanupFailure(cleanupPath.path, cleanupPath.preparationError)
+              : await removeAgentPath(cleanupPath.path, cleanupPath.kind);
+            outcomes.push({
+              cleanupPath,
+              outcome,
+            });
+            if ("failed" in outcome) {
+              protectedCleanupPaths.push({ cleanupPath, protectAliases: true });
+            }
+          }
           for (const { outcome } of outcomes) {
             if ("removed" in outcome) {
               removed.push(outcome.removed);
@@ -1024,9 +1262,12 @@ export const agentsHandlers: GatewayRequestHandlers = {
               failed.push(outcome.failed);
             }
           }
+          const workspaceOutcomes = workspaceCleanupPaths.map((cleanupPath) =>
+            outcomes.find((candidate) => candidate.cleanupPath === cleanupPath),
+          );
           if (
-            workspaceOutcome &&
-            "removed" in workspaceOutcome.outcome &&
+            workspaceOutcomes.length > 0 &&
+            workspaceOutcomes.every((candidate) => candidate && "removed" in candidate.outcome) &&
             legacyPlan &&
             statePlan
           ) {
@@ -1037,10 +1278,13 @@ export const agentsHandlers: GatewayRequestHandlers = {
               // Best-effort cleanup. A later explicit reset can remove stale rows.
             }
           }
-          const agentDirOutcome = outcomes.find(({ cleanupPath }) =>
+          const agentDirOutcomes = outcomes.filter(({ cleanupPath }) =>
             cleanupPathCovers(cleanupPath, deleteResult.agentDir, agentDirRegistryPath),
-          )?.outcome;
-          if (agentDirOutcome && "removed" in agentDirOutcome) {
+          );
+          if (
+            agentDirOutcomes.length > 0 &&
+            agentDirOutcomes.every(({ outcome }) => "removed" in outcome)
+          ) {
             unregisterResolvedAgentDir({ agentId, agentDir: agentDirRegistryPath });
           }
         }

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -352,37 +352,76 @@ function cleanupFailure(pathname: string, error: unknown): AgentDeletePathOutcom
   return { failed: { path: pathname, reason: reason || "unknown error" } };
 }
 
+function cleanupPathIdentity(stat: { dev?: number; ino?: number } | undefined) {
+  return typeof stat?.dev === "number" && typeof stat.ino === "number"
+    ? { dev: stat.dev, ino: stat.ino }
+    : undefined;
+}
+
+async function statAgentCleanupPath(cleanupPath: AgentDeleteCleanupPath) {
+  const parentPath = cleanupPath.parentPath;
+  const parentRoot = await agentsHandlerDeps.root(parentPath, {
+    hardlinks: "reject",
+    symlinks: "reject",
+  });
+  if (path.resolve(parentRoot.rootReal) !== parentPath) {
+    throw new FsSafeError("path-mismatch", "cleanup path parent changed before deletion");
+  }
+  const stat = await parentRoot.stat(path.basename(cleanupPath.trashPath));
+  const isSymlink = stat.isSymbolicLink === true;
+  if (isSymlink !== (cleanupPath.kind === "symlink")) {
+    throw new FsSafeError(
+      "path-mismatch",
+      `cleanup path changed from ${cleanupPath.kind} before deletion`,
+    );
+  }
+  if (stat.isFile && stat.nlink > 1) {
+    throw new FsSafeError("hardlink", "hardlinked cleanup path not allowed");
+  }
+  const identity = cleanupPathIdentity(stat);
+  if (
+    cleanupPath.preparedIdentity &&
+    identity &&
+    (identity.dev !== cleanupPath.preparedIdentity.dev ||
+      identity.ino !== cleanupPath.preparedIdentity.ino)
+  ) {
+    throw new FsSafeError("path-mismatch", "cleanup path identity changed before deletion");
+  }
+}
+
+function isMissingCleanupPathError(error: unknown): boolean {
+  return (
+    (error instanceof FsSafeError && error.code === "not-found") ||
+    (error as NodeJS.ErrnoException).code === "ENOENT"
+  );
+}
+
 async function removeAgentPath(
-  pathname: string,
-  expectedKind: AgentDeletionJournalCleanupPath["kind"],
+  cleanupPath: AgentDeleteCleanupPath,
 ): Promise<AgentDeletePathOutcome> {
-  let targetStat: Awaited<ReturnType<typeof fs.lstat>>;
+  const pathname = cleanupPath.path;
+  const trashPath = cleanupPath.trashPath;
   try {
-    targetStat = await fs.lstat(pathname);
+    await statAgentCleanupPath(cleanupPath);
   } catch (error) {
-    return (error as NodeJS.ErrnoException).code === "ENOENT"
+    return isMissingCleanupPathError(error)
       ? { removed: { path: pathname, method: "missing" } }
       : cleanupFailure(pathname, error);
   }
-  const isSymlink = targetStat?.isSymbolicLink?.() === true;
-  if (isSymlink !== (expectedKind === "symlink")) {
-    return cleanupFailure(
-      pathname,
-      new Error(`cleanup path changed from ${expectedKind} before deletion`),
-    );
-  }
   try {
-    await movePathToTrash(pathname);
+    // fs-safe pins traversal and identity for validation; Trash has no fd-relative move API, so
+    // replacement after this check and before its rename is the accepted residual race bound.
+    await movePathToTrash(trashPath);
     return { removed: { path: pathname, method: "trash" } };
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
       return cleanupFailure(pathname, error);
     }
     try {
-      await fs.lstat(pathname);
+      await statAgentCleanupPath(cleanupPath);
       return cleanupFailure(pathname, error);
     } catch (statError) {
-      return (statError as NodeJS.ErrnoException).code === "ENOENT"
+      return isMissingCleanupPathError(statError)
         ? { removed: { path: pathname, method: "missing" } }
         : cleanupFailure(pathname, statError);
     }
@@ -391,10 +430,12 @@ async function removeAgentPath(
 
 type AgentDeleteCleanupPath = {
   path: string;
+  parentPath: string;
   canonicalPath: string;
   trashPath: string;
   trashCoversDescendants: boolean;
   kind: "target" | "symlink";
+  preparedIdentity?: { dev: number; ino: number };
   preparationError?: unknown;
   sourcePaths: string[];
 };
@@ -448,16 +489,23 @@ async function prepareAgentDeleteCleanupPaths(
       return;
     }
     existing.sourcePaths = [...new Set([...existing.sourcePaths, ...candidate.sourcePaths])];
+    existing.preparedIdentity ??= candidate.preparedIdentity;
     existing.preparationError ??= candidate.preparationError;
     if (candidate.kind === "target") {
       existing.kind = "target";
       existing.canonicalPath = candidate.canonicalPath;
+      existing.parentPath = candidate.parentPath;
       existing.trashCoversDescendants ||= candidate.trashCoversDescendants;
     }
   };
   if (persistedPaths.length > 0) {
     for (const persistedPath of persistedPaths) {
-      const trashPath = path.resolve(persistedPath.path);
+      const journalPath = path.resolve(persistedPath.path);
+      const parentPath = path.resolve(persistedPath.parentPath ?? path.dirname(journalPath));
+      const trashPath =
+        persistedPath.kind === "symlink"
+          ? path.join(parentPath, path.basename(journalPath))
+          : journalPath;
       let targetStat: Awaited<ReturnType<typeof fs.lstat>> | undefined;
       let preparationError: unknown;
       try {
@@ -473,7 +521,8 @@ async function prepareAgentDeleteCleanupPaths(
         );
       }
       addPath({
-        path: trashPath,
+        path: journalPath,
+        parentPath,
         canonicalPath: normalizeAgentDirRegistryPath(trashPath),
         trashPath,
         trashCoversDescendants:
@@ -481,6 +530,7 @@ async function prepareAgentDeleteCleanupPaths(
             ? targetStat.isSymbolicLink() !== true
             : false,
         kind: persistedPath.kind,
+        preparedIdentity: cleanupPathIdentity(targetStat),
         preparationError,
         sourcePaths: persistedPath.sourcePaths.map((sourcePath) => path.resolve(sourcePath)),
       });
@@ -488,10 +538,12 @@ async function prepareAgentDeleteCleanupPaths(
   }
   for (const pathname of paths) {
     const sourcePath = path.resolve(pathname);
+    let sourceParentPath = path.dirname(sourcePath);
     let resolvedPath = sourcePath;
     let preparationError: unknown;
     try {
       resolvedPath = await resolveAgentDeleteCleanupTarget(pathname);
+      sourceParentPath = await resolveAgentDeleteCleanupTarget(path.dirname(sourcePath));
     } catch (error) {
       preparationError = error;
     }
@@ -521,20 +573,24 @@ async function prepareAgentDeleteCleanupPaths(
     }
     addPath({
       path: resolvedPath,
+      parentPath: path.dirname(resolvedPath),
       canonicalPath,
       trashPath: resolvedPath,
       trashCoversDescendants,
       kind: "target",
+      preparedIdentity: cleanupPathIdentity(targetStat),
       preparationError,
       sourcePaths: [sourcePath],
     });
     if (sourceStat?.isSymbolicLink() && sourcePath !== resolvedPath) {
       addPath({
         path: sourcePath,
+        parentPath: sourceParentPath,
         canonicalPath,
-        trashPath: sourcePath,
+        trashPath: path.join(sourceParentPath, path.basename(sourcePath)),
         trashCoversDescendants: false,
         kind: "symlink",
+        preparedIdentity: cleanupPathIdentity(sourceStat),
         sourcePaths: [sourcePath],
       });
     }
@@ -1050,8 +1106,9 @@ export const agentsHandlers: GatewayRequestHandlers = {
                 throw unresolvedPath.preparationError;
               }
               deletion.fenceCleanupPaths(
-                cleanupPlan.map(({ path: cleanupPath, kind, sourcePaths }) => ({
+                cleanupPlan.map(({ path: cleanupPath, parentPath, kind, sourcePaths }) => ({
                   path: cleanupPath,
+                  parentPath,
                   kind,
                   sourcePaths,
                 })),
@@ -1246,7 +1303,7 @@ export const agentsHandlers: GatewayRequestHandlers = {
             }
             const outcome = cleanupPath.preparationError
               ? cleanupFailure(cleanupPath.path, cleanupPath.preparationError)
-              : await removeAgentPath(cleanupPath.path, cleanupPath.kind);
+              : await removeAgentPath(cleanupPath);
             outcomes.push({
               cleanupPath,
               outcome,

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -709,7 +709,7 @@ export const agentsHandlers: GatewayRequestHandlers = {
                   } catch (error) {
                     try {
                       const persisted = await readConfigFileSnapshotForWrite();
-                      if (!isConfiguredAgent(persisted.sourceConfig, agentId)) {
+                      if (!isConfiguredAgent(persisted.snapshot.sourceConfig, agentId)) {
                         rosterCommitted = true;
                         throw new AgentDeletionCommitUncertainError(error);
                       }
@@ -745,7 +745,7 @@ export const agentsHandlers: GatewayRequestHandlers = {
           if (canReleaseFence) {
             try {
               const persisted = await readConfigFileSnapshotForWrite();
-              canReleaseFence = isConfiguredAgent(persisted.sourceConfig, agentId);
+              canReleaseFence = isConfiguredAgent(persisted.snapshot.sourceConfig, agentId);
             } catch {
               canReleaseFence = false;
             }

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -345,7 +345,10 @@ type AgentDeleteFailedPath = {
 
 type AgentDeletePathOutcome =
   | { removed: AgentDeleteRemovedPath }
+  | { skipped: AgentDeleteFailedPath }
   | { failed: AgentDeleteFailedPath };
+
+class AgentCleanupIdentityMismatchError extends Error {}
 
 function cleanupFailure(pathname: string, error: unknown): AgentDeletePathOutcome {
   const reason = error instanceof Error && error.message ? error.message : String(error);
@@ -355,7 +358,7 @@ function cleanupFailure(pathname: string, error: unknown): AgentDeletePathOutcom
 function cleanupPathIdentity(stat: { dev?: number; ino?: number } | undefined) {
   return typeof stat?.dev === "number" && typeof stat.ino === "number"
     ? { dev: stat.dev, ino: stat.ino }
-    : undefined;
+    : null;
 }
 
 async function statAgentCleanupPath(cleanupPath: AgentDeleteCleanupPath) {
@@ -370,22 +373,26 @@ async function statAgentCleanupPath(cleanupPath: AgentDeleteCleanupPath) {
   const stat = await parentRoot.stat(path.basename(cleanupPath.trashPath));
   const isSymlink = stat.isSymbolicLink === true;
   if (isSymlink !== (cleanupPath.kind === "symlink")) {
-    throw new FsSafeError(
-      "path-mismatch",
+    throw new AgentCleanupIdentityMismatchError(
       `cleanup path changed from ${cleanupPath.kind} before deletion`,
     );
   }
   if (stat.isFile && stat.nlink > 1) {
-    throw new FsSafeError("hardlink", "hardlinked cleanup path not allowed");
+    throw new AgentCleanupIdentityMismatchError("hardlinked cleanup replacement preserved");
   }
   const identity = cleanupPathIdentity(stat);
-  if (
-    cleanupPath.preparedIdentity &&
-    identity &&
-    (identity.dev !== cleanupPath.preparedIdentity.dev ||
-      identity.ino !== cleanupPath.preparedIdentity.ino)
+  if (cleanupPath.preparedIdentity === null) {
+    if (identity !== null) {
+      throw new AgentCleanupIdentityMismatchError(
+        "cleanup path appeared after deletion preparation",
+      );
+    }
+  } else if (
+    identity === null ||
+    identity.dev !== cleanupPath.preparedIdentity.dev ||
+    identity.ino !== cleanupPath.preparedIdentity.ino
   ) {
-    throw new FsSafeError("path-mismatch", "cleanup path identity changed before deletion");
+    throw new AgentCleanupIdentityMismatchError("cleanup path identity changed before deletion");
   }
 }
 
@@ -404,6 +411,9 @@ async function removeAgentPath(
   try {
     await statAgentCleanupPath(cleanupPath);
   } catch (error) {
+    if (error instanceof AgentCleanupIdentityMismatchError) {
+      return { skipped: { path: pathname, reason: error.message } };
+    }
     return isMissingCleanupPathError(error)
       ? { removed: { path: pathname, method: "missing" } }
       : cleanupFailure(pathname, error);
@@ -435,7 +445,9 @@ type AgentDeleteCleanupPath = {
   trashPath: string;
   trashCoversDescendants: boolean;
   kind: "target" | "symlink";
-  preparedIdentity?: { dev: number; ino: number };
+  preparedIdentity: { dev: number; ino: number } | null;
+  done: boolean;
+  note?: string;
   preparationError?: unknown;
   sourcePaths: string[];
 };
@@ -489,7 +501,8 @@ async function prepareAgentDeleteCleanupPaths(
       return;
     }
     existing.sourcePaths = [...new Set([...existing.sourcePaths, ...candidate.sourcePaths])];
-    existing.preparedIdentity ??= candidate.preparedIdentity;
+    existing.done ||= candidate.done;
+    existing.note ??= candidate.note;
     existing.preparationError ??= candidate.preparationError;
     if (candidate.kind === "target") {
       existing.kind = "target";
@@ -501,37 +514,20 @@ async function prepareAgentDeleteCleanupPaths(
   if (persistedPaths.length > 0) {
     for (const persistedPath of persistedPaths) {
       const journalPath = path.resolve(persistedPath.path);
-      const parentPath = path.resolve(persistedPath.parentPath ?? path.dirname(journalPath));
-      const trashPath =
-        persistedPath.kind === "symlink"
-          ? path.join(parentPath, path.basename(journalPath))
-          : journalPath;
-      let targetStat: Awaited<ReturnType<typeof fs.lstat>> | undefined;
-      let preparationError: unknown;
-      try {
-        targetStat = await fs.lstat(trashPath);
-      } catch (error) {
-        if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
-          preparationError = error;
-        }
-      }
-      if (targetStat && targetStat.isSymbolicLink() !== (persistedPath.kind === "symlink")) {
-        preparationError = new Error(
-          `cleanup path changed from ${persistedPath.kind} before deletion`,
-        );
-      }
+      const trashPath = path.resolve(persistedPath.canonicalPath);
       addPath({
         path: journalPath,
-        parentPath,
+        parentPath: path.resolve(persistedPath.parentPath),
         canonicalPath: normalizeAgentDirRegistryPath(trashPath),
         trashPath,
-        trashCoversDescendants:
-          persistedPath.kind === "target" && targetStat
-            ? targetStat.isSymbolicLink() !== true
-            : false,
+        trashCoversDescendants: persistedPath.coversDescendants,
         kind: persistedPath.kind,
-        preparedIdentity: cleanupPathIdentity(targetStat),
-        preparationError,
+        preparedIdentity:
+          persistedPath.dev === null || persistedPath.ino === null
+            ? null
+            : { dev: persistedPath.dev, ino: persistedPath.ino },
+        done: persistedPath.done,
+        note: persistedPath.note,
         sourcePaths: persistedPath.sourcePaths.map((sourcePath) => path.resolve(sourcePath)),
       });
     }
@@ -579,6 +575,7 @@ async function prepareAgentDeleteCleanupPaths(
       trashCoversDescendants,
       kind: "target",
       preparedIdentity: cleanupPathIdentity(targetStat),
+      done: false,
       preparationError,
       sourcePaths: [sourcePath],
     });
@@ -591,6 +588,7 @@ async function prepareAgentDeleteCleanupPaths(
         trashCoversDescendants: false,
         kind: "symlink",
         preparedIdentity: cleanupPathIdentity(sourceStat),
+        done: false,
         sourcePaths: [sourcePath],
       });
     }
@@ -1106,12 +1104,30 @@ export const agentsHandlers: GatewayRequestHandlers = {
                 throw unresolvedPath.preparationError;
               }
               deletion.fenceCleanupPaths(
-                cleanupPlan.map(({ path: cleanupPath, parentPath, kind, sourcePaths }) => ({
-                  path: cleanupPath,
-                  parentPath,
-                  kind,
-                  sourcePaths,
-                })),
+                cleanupPlan.map(
+                  ({
+                    path: cleanupPath,
+                    trashPath,
+                    parentPath,
+                    kind,
+                    preparedIdentity,
+                    trashCoversDescendants,
+                    done,
+                    note,
+                    sourcePaths,
+                  }) => ({
+                    path: cleanupPath,
+                    canonicalPath: trashPath,
+                    parentPath,
+                    kind,
+                    sourcePaths,
+                    dev: preparedIdentity?.dev ?? null,
+                    ino: preparedIdentity?.ino ?? null,
+                    coversDescendants: trashCoversDescendants,
+                    done,
+                    ...(note ? { note } : {}),
+                  }),
+                ),
               );
             }
           }
@@ -1262,11 +1278,54 @@ export const agentsHandlers: GatewayRequestHandlers = {
             cleanupPath: AgentDeleteCleanupPath;
             outcome: AgentDeletePathOutcome;
           }> = [];
+          const completedCleanupPaths = new Set(
+            cleanupPaths.filter((cleanupPath) => cleanupPath.done),
+          );
+          const markCleanupPathDone = (cleanupPath: AgentDeleteCleanupPath, note?: string) => {
+            const canonicalPath = path.resolve(cleanupPath.trashPath);
+            deletion.fenceCleanupPaths(
+              journal.cleanupPaths.map((entry) =>
+                path.resolve(entry.canonicalPath) === canonicalPath &&
+                entry.kind === cleanupPath.kind
+                  ? { ...entry, done: true, ...(note ? { note } : {}) }
+                  : entry,
+              ),
+            );
+            cleanupPath.done = true;
+            cleanupPath.note = note;
+            completedCleanupPaths.add(cleanupPath);
+          };
           const protectedCleanupPaths: Array<{
             cleanupPath: AgentDeleteCleanupPath;
             protectAliases: boolean;
+            terminal: boolean;
+            note?: string;
           }> = [];
           for (const cleanupPath of cleanupPaths) {
+            if (cleanupPath.done) {
+              let replacementPresent = true;
+              let note =
+                cleanupPath.note ?? "completed cleanup path is occupied; replacement preserved";
+              try {
+                await statAgentCleanupPath(cleanupPath);
+              } catch (error) {
+                if (isMissingCleanupPathError(error)) {
+                  replacementPresent = false;
+                } else if (!(error instanceof AgentCleanupIdentityMismatchError)) {
+                  note = "completed cleanup path could not be verified; replacement preserved";
+                }
+              }
+              if (replacementPresent) {
+                markCleanupPathDone(cleanupPath, note);
+                protectedCleanupPaths.push({
+                  cleanupPath,
+                  protectAliases: true,
+                  terminal: true,
+                  note,
+                });
+              }
+              continue;
+            }
             const refreshedDatabaseFilePaths = resolveSurvivingDatabaseFilePaths(
               listOpenClawRegisteredAgentDatabases(),
               agentId,
@@ -1295,9 +1354,18 @@ export const agentsHandlers: GatewayRequestHandlers = {
               (cleanupPathCovers(cleanupPath, deleteResult.agentDir, agentDirRegistryPath) &&
                 resolveRegisteredAgentIdForDir(deleteResult.agentDir) !== agentId);
             if (blockingProtection || ownedBySurvivor) {
+              const terminal = ownedBySurvivor || blockingProtection?.terminal === true;
+              const note = ownedBySurvivor
+                ? "replacement owned by a surviving agent"
+                : blockingProtection?.note;
+              if (terminal) {
+                markCleanupPathDone(cleanupPath, note ?? "protected replacement preserved");
+              }
               protectedCleanupPaths.push({
                 cleanupPath,
                 protectAliases: blockingProtection?.protectAliases ?? false,
+                terminal,
+                note,
               });
               continue;
             }
@@ -1308,23 +1376,34 @@ export const agentsHandlers: GatewayRequestHandlers = {
               cleanupPath,
               outcome,
             });
-            if ("failed" in outcome) {
-              protectedCleanupPaths.push({ cleanupPath, protectAliases: true });
+            if ("removed" in outcome) {
+              markCleanupPathDone(cleanupPath);
+            } else if ("skipped" in outcome) {
+              markCleanupPathDone(cleanupPath, outcome.skipped.reason);
+              protectedCleanupPaths.push({
+                cleanupPath,
+                protectAliases: true,
+                terminal: true,
+                note: outcome.skipped.reason,
+              });
+            } else {
+              protectedCleanupPaths.push({
+                cleanupPath,
+                protectAliases: true,
+                terminal: false,
+              });
             }
           }
           for (const { outcome } of outcomes) {
             if ("removed" in outcome) {
               removed.push(outcome.removed);
-            } else {
+            } else if ("failed" in outcome) {
               failed.push(outcome.failed);
             }
           }
-          const workspaceOutcomes = workspaceCleanupPaths.map((cleanupPath) =>
-            outcomes.find((candidate) => candidate.cleanupPath === cleanupPath),
-          );
           if (
-            workspaceOutcomes.length > 0 &&
-            workspaceOutcomes.every((candidate) => candidate && "removed" in candidate.outcome) &&
+            workspaceCleanupPaths.length > 0 &&
+            workspaceCleanupPaths.every((cleanupPath) => completedCleanupPaths.has(cleanupPath)) &&
             legacyPlan &&
             statePlan
           ) {
@@ -1335,12 +1414,12 @@ export const agentsHandlers: GatewayRequestHandlers = {
               // Best-effort cleanup. A later explicit reset can remove stale rows.
             }
           }
-          const agentDirOutcomes = outcomes.filter(({ cleanupPath }) =>
+          const agentDirCleanupPaths = cleanupPaths.filter((cleanupPath) =>
             cleanupPathCovers(cleanupPath, deleteResult.agentDir, agentDirRegistryPath),
           );
           if (
-            agentDirOutcomes.length > 0 &&
-            agentDirOutcomes.every(({ outcome }) => "removed" in outcome)
+            agentDirCleanupPaths.length > 0 &&
+            agentDirCleanupPaths.every((cleanupPath) => completedCleanupPaths.has(cleanupPath))
           ) {
             unregisterResolvedAgentDir({ agentId, agentDir: agentDirRegistryPath });
           }

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -355,10 +355,19 @@ function cleanupFailure(pathname: string, error: unknown): AgentDeletePathOutcom
   return { failed: { path: pathname, reason: reason || "unknown error" } };
 }
 
-function cleanupPathIdentity(stat: { dev?: number; ino?: number } | undefined) {
-  return typeof stat?.dev === "number" && typeof stat.ino === "number"
-    ? { dev: stat.dev, ino: stat.ino }
-    : null;
+function cleanupPathIdentity(stat: { dev?: number | bigint; ino?: number | bigint } | undefined) {
+  if (
+    (typeof stat?.dev !== "number" && typeof stat?.dev !== "bigint") ||
+    (typeof stat.ino !== "number" && typeof stat.ino !== "bigint")
+  ) {
+    return null;
+  }
+  const dev = Number(stat.dev);
+  const ino = Number(stat.ino);
+  if (!Number.isSafeInteger(dev) || !Number.isSafeInteger(ino)) {
+    throw new Error("cleanup path identity exceeds the safe integer range");
+  }
+  return { dev, ino };
 }
 
 async function statAgentCleanupPath(cleanupPath: AgentDeleteCleanupPath) {
@@ -371,7 +380,7 @@ async function statAgentCleanupPath(cleanupPath: AgentDeleteCleanupPath) {
     throw new FsSafeError("path-mismatch", "cleanup path parent changed before deletion");
   }
   const stat = await parentRoot.stat(path.basename(cleanupPath.trashPath));
-  const isSymlink = stat.isSymbolicLink === true;
+  const isSymlink = stat.isSymbolicLink;
   if (isSymlink !== (cleanupPath.kind === "symlink")) {
     throw new AgentCleanupIdentityMismatchError(
       `cleanup path changed from ${cleanupPath.kind} before deletion`,
@@ -565,7 +574,7 @@ async function prepareAgentDeleteCleanupPaths(
     const canonicalPath = normalizeAgentDirRegistryPath(resolvedPath);
     let trashCoversDescendants = false;
     if (targetStat) {
-      trashCoversDescendants = targetStat.isSymbolicLink() !== true;
+      trashCoversDescendants = !targetStat.isSymbolicLink();
     }
     addPath({
       path: resolvedPath,
@@ -627,7 +636,7 @@ async function prepareAgentDeleteCleanupPaths(
       rightRoots.some((rightRoot) => isPathInside(rightRoot, leftSource)),
     );
   };
-  const remaining = [...uniquePaths.values()].sort(compareFallback);
+  const remaining = [...uniquePaths.values()].toSorted(compareFallback);
   const ordered: AgentDeleteCleanupPath[] = [];
   // Snapshot real targets and clean every physical or lexical descendant first; moving an
   // ancestor symlink would otherwise hide surviving child data and let recovery finalize.
@@ -637,7 +646,7 @@ async function prepareAgentDeleteCleanupPaths(
         (other, otherIndex) => otherIndex === candidateIndex || !mustPrecede(other, candidate),
       ),
     );
-    ordered.push(...remaining.splice(nextIndex < 0 ? 0 : nextIndex, 1));
+    ordered.push(...remaining.splice(Math.max(0, nextIndex), 1));
   }
   return ordered;
 }
@@ -1115,18 +1124,23 @@ export const agentsHandlers: GatewayRequestHandlers = {
                     done,
                     note,
                     sourcePaths,
-                  }) => ({
-                    path: cleanupPath,
-                    canonicalPath: trashPath,
-                    parentPath,
-                    kind,
-                    sourcePaths,
-                    dev: preparedIdentity?.dev ?? null,
-                    ino: preparedIdentity?.ino ?? null,
-                    coversDescendants: trashCoversDescendants,
-                    done,
-                    ...(note ? { note } : {}),
-                  }),
+                  }) => {
+                    const journalPath: AgentDeletionJournalCleanupPath = {
+                      path: cleanupPath,
+                      canonicalPath: trashPath,
+                      parentPath,
+                      kind,
+                      sourcePaths,
+                      dev: preparedIdentity?.dev ?? null,
+                      ino: preparedIdentity?.ino ?? null,
+                      coversDescendants: trashCoversDescendants,
+                      done,
+                    };
+                    if (note) {
+                      journalPath.note = note;
+                    }
+                    return journalPath;
+                  },
                 ),
               );
             }
@@ -1284,12 +1298,19 @@ export const agentsHandlers: GatewayRequestHandlers = {
           const markCleanupPathDone = (cleanupPath: AgentDeleteCleanupPath, note?: string) => {
             const canonicalPath = path.resolve(cleanupPath.trashPath);
             deletion.fenceCleanupPaths(
-              journal.cleanupPaths.map((entry) =>
-                path.resolve(entry.canonicalPath) === canonicalPath &&
-                entry.kind === cleanupPath.kind
-                  ? { ...entry, done: true, ...(note ? { note } : {}) }
-                  : entry,
-              ),
+              journal.cleanupPaths.map((entry) => {
+                if (
+                  path.resolve(entry.canonicalPath) !== canonicalPath ||
+                  entry.kind !== cleanupPath.kind
+                ) {
+                  return entry;
+                }
+                const updated = Object.assign({}, entry, { done: true });
+                if (note) {
+                  updated.note = note;
+                }
+                return updated;
+              }),
             );
             cleanupPath.done = true;
             cleanupPath.note = note;

--- a/src/gateway/server.cron.test.ts
+++ b/src/gateway/server.cron.test.ts
@@ -1296,6 +1296,9 @@ describe("gateway server cron", () => {
       tempPrefix: "openclaw-gw-cron-log-",
       cronEnabled: true,
     });
+    await writeCronConfig({
+      agents: { list: [{ id: "main", default: true }, { id: "writer" }] },
+    });
     const events = createCronEventCollector();
     const cronState = await createDirectCronState({ broadcast: events["broadcast"] });
 

--- a/src/infra/exec-approvals-store.test.ts
+++ b/src/infra/exec-approvals-store.test.ts
@@ -4,6 +4,12 @@ import { once } from "node:events";
 import fs from "node:fs";
 import path from "node:path";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  AgentDeletionCommitUncertainError,
+  beginAgentDeletion,
+  claimCompletedAgentDeletion,
+} from "../agents/agent-lifecycle-registry.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { captureEnv, deleteTestEnvValue, setTestEnvValue } from "../test-utils/env.js";
 import { makeTempDir } from "./exec-approvals-test-helpers.js";
 
@@ -27,6 +33,7 @@ let normalizeExecApprovals: ExecApprovalsModule["normalizeExecApprovals"];
 let persistAllowAlwaysDecisionSync: ExecApprovalsModule["persistAllowAlwaysDecision"];
 let persistAllowAlwaysPatterns: ExecApprovalsModule["persistAllowAlwaysPatterns"];
 let readExecApprovalsSnapshot: ExecApprovalsModule["readExecApprovalsSnapshot"];
+let withAgentExecApprovalsRemoved: ExecApprovalsModule["withAgentExecApprovalsRemoved"];
 let recordAllowlistMatchesUseSync: ExecApprovalsModule["recordAllowlistMatchesUse"];
 let requestExecApprovalViaSocket: ExecApprovalsModule["requestExecApprovalViaSocket"];
 let restoreExecApprovalsSnapshotLocked: ExecApprovalsModule["restoreExecApprovalsSnapshotLocked"];
@@ -54,6 +61,7 @@ beforeAll(async () => {
   persistAllowAlwaysDecisionSync = module.persistAllowAlwaysDecision;
   persistAllowAlwaysPatterns = module.persistAllowAlwaysPatterns;
   readExecApprovalsSnapshot = module.readExecApprovalsSnapshot;
+  withAgentExecApprovalsRemoved = module.withAgentExecApprovalsRemoved;
   recordAllowlistMatchesUseSync = module.recordAllowlistMatchesUse;
   requestExecApprovalViaSocket = module.requestExecApprovalViaSocket;
   restoreExecApprovalsSnapshotLocked = module.restoreExecApprovalsSnapshotLocked;
@@ -74,6 +82,7 @@ beforeEach(() => {
 afterEach(() => {
   vi.restoreAllMocks();
   testEnvSnapshot.restore();
+  closeOpenClawStateDatabaseForTest();
   for (const dir of tempDirs.splice(0)) {
     fs.rmSync(dir, { recursive: true, force: true });
   }
@@ -486,6 +495,208 @@ describe("exec approvals store helpers", () => {
       }),
     ).resolves.toBeNull();
     expect(fs.readFileSync(approvalsPath, "utf8")).toBe("");
+  });
+
+  it("removes only the deleted agent policy so recreating the id inherits nothing", async () => {
+    const dir = createHomeDir();
+    saveExecApprovals({
+      version: 1,
+      defaults: { security: "deny", ask: "off" },
+      agents: {
+        "deleted-agent": {
+          security: "allowlist",
+          allowlist: [{ pattern: "/usr/bin/old-tool" }],
+        },
+        "other-agent": {
+          security: "allowlist",
+          allowlist: [{ pattern: "/usr/bin/keep-tool" }],
+        },
+      },
+    });
+
+    await expect(
+      withAgentExecApprovalsRemoved("Deleted-Agent", async () => "committed"),
+    ).resolves.toBe("committed");
+
+    const persisted = readApprovalsFile(dir);
+    expect(persisted.agents?.["deleted-agent"]).toBeUndefined();
+    expect(persisted.agents?.["other-agent"]?.allowlist).toEqual([
+      expect.objectContaining({ pattern: "/usr/bin/keep-tool" }),
+    ]);
+    const recreatedPolicy = resolveExecApprovalsSync("deleted-agent");
+    expect(recreatedPolicy.agent.security).toBe("deny");
+    expect(recreatedPolicy.allowlist).toEqual([]);
+  });
+
+  it("does not create an approvals file when the deleted agent has no policy", async () => {
+    const dir = createHomeDir();
+
+    await expect(
+      withAgentExecApprovalsRemoved("missing-agent", async () => "committed"),
+    ).resolves.toBe("committed");
+
+    expect(fs.existsSync(approvalsFilePath(dir))).toBe(false);
+  });
+
+  it("restores the deleted policy when the roster commit fails", async () => {
+    const dir = createHomeDir();
+    saveExecApprovals({
+      version: 1,
+      agents: {
+        "deleted-agent": {
+          security: "allowlist",
+          allowlist: [{ pattern: "/usr/bin/old-tool" }],
+        },
+        "other-agent": {
+          security: "allowlist",
+          allowlist: [{ pattern: "/usr/bin/keep-tool" }],
+        },
+      },
+    });
+
+    await expect(
+      withAgentExecApprovalsRemoved("deleted-agent", async () => {
+        expect(readApprovalsFile(dir).agents?.["deleted-agent"]).toBeUndefined();
+        throw new Error("config commit failed");
+      }),
+    ).rejects.toThrow("config commit failed");
+
+    const restored = readApprovalsFile(dir);
+    expect(restored.agents?.["deleted-agent"]?.allowlist).toEqual([
+      expect.objectContaining({ pattern: "/usr/bin/old-tool" }),
+    ]);
+    expect(restored.agents?.["other-agent"]?.allowlist).toEqual([
+      expect.objectContaining({ pattern: "/usr/bin/keep-tool" }),
+    ]);
+  });
+
+  it("rejects a late policy write until the deleted id is recreated", async () => {
+    createHomeDir();
+    const deletion = beginAgentDeletion({
+      agentId: "deleted-agent",
+      agentDir: "/agents/deleted-agent",
+      workspaceDir: "/workspaces/deleted-agent",
+      sessionsDir: "/sessions/deleted-agent",
+    });
+    try {
+      await withAgentExecApprovalsRemoved("deleted-agent", async () => {
+        deletion.commit();
+      });
+
+      await expect(
+        updateExecApprovals({
+          update: (file) => ({
+            ...file,
+            agents: {
+              ...file.agents,
+              "deleted-agent": { security: "allowlist" },
+            },
+          }),
+        }),
+      ).rejects.toThrow("agent deleted-agent is deleted");
+
+      deletion.finish();
+      await expect(
+        updateExecApprovals({
+          update: (file) => ({
+            ...file,
+            agents: {
+              ...file.agents,
+              "deleted-agent": { security: "allowlist" },
+            },
+          }),
+        }),
+      ).rejects.toThrow("agent deleted-agent is deleted");
+      expect(claimCompletedAgentDeletion("deleted-agent", deletion.entry.operationId)).toBe(true);
+      await expect(
+        updateExecApprovals({
+          update: (file) => ({
+            ...file,
+            agents: {
+              ...file.agents,
+              "deleted-agent": { security: "allowlist" },
+            },
+          }),
+        }),
+      ).resolves.not.toBeNull();
+    } finally {
+      deletion.finish();
+    }
+  });
+
+  it("rejects generic removal of a fenced agent policy", async () => {
+    const dir = createHomeDir();
+    saveExecApprovals({
+      version: 1,
+      agents: { "deleted-agent": { security: "deny" } },
+    });
+    const deletion = beginAgentDeletion({
+      agentId: "deleted-agent",
+      agentDir: "/agents/deleted-agent",
+      workspaceDir: "/workspaces/deleted-agent",
+      sessionsDir: "/sessions/deleted-agent",
+    });
+    try {
+      await expect(
+        updateExecApprovals({
+          update: (file) => ({ ...file, agents: {} }),
+        }),
+      ).rejects.toThrow("agent deleted-agent is deleted");
+      expect(readApprovalsFile(dir).agents?.["deleted-agent"]?.security).toBe("deny");
+    } finally {
+      deletion.rollback();
+    }
+  });
+
+  it("rejects an in-place update to a fenced agent policy", async () => {
+    const dir = createHomeDir();
+    saveExecApprovals({
+      version: 1,
+      agents: { "deleted-agent": { security: "deny" } },
+    });
+    const deletion = beginAgentDeletion({
+      agentId: "deleted-agent",
+      agentDir: "/agents/deleted-agent",
+      workspaceDir: "/workspaces/deleted-agent",
+      sessionsDir: "/sessions/deleted-agent",
+    });
+    try {
+      await expect(
+        updateExecApprovals({
+          update: (file) => {
+            file.agents = { "deleted-agent": { security: "full" } };
+            return file;
+          },
+        }),
+      ).rejects.toThrow("agent deleted-agent is deleted");
+      expect(readApprovalsFile(dir).agents?.["deleted-agent"]?.security).toBe("deny");
+    } finally {
+      deletion.rollback();
+    }
+  });
+
+  it("does not restore removed policy when roster commit outcome is uncertain", async () => {
+    const dir = createHomeDir();
+    saveExecApprovals({
+      version: 1,
+      agents: { "deleted-agent": { security: "allowlist" } },
+    });
+    const deletion = beginAgentDeletion({
+      agentId: "deleted-agent",
+      agentDir: "/agents/deleted-agent",
+      workspaceDir: "/workspaces/deleted-agent",
+      sessionsDir: "/sessions/deleted-agent",
+    });
+    try {
+      await expect(
+        withAgentExecApprovalsRemoved("deleted-agent", async () => {
+          throw new AgentDeletionCommitUncertainError(new Error("config outcome unknown"));
+        }),
+      ).rejects.toThrow("config outcome unknown");
+      expect(readApprovalsFile(dir).agents?.["deleted-agent"]).toBeUndefined();
+    } finally {
+      deletion.rollback();
+    }
   });
 
   it("restores a matching real-store snapshot", async () => {

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -2,13 +2,19 @@
 import { randomBytes } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import { isDeepStrictEqual } from "node:util";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
   readStringValue,
 } from "@openclaw/normalization-core/string-coerce";
-import { DEFAULT_AGENT_ID } from "../routing/session-key.js";
+import {
+  AgentDeletionAuthorityRollbackError,
+  AgentDeletionCommitUncertainError,
+  isAgentDeletionBlocked,
+} from "../agents/agent-lifecycle-registry.js";
+import { DEFAULT_AGENT_ID, normalizeAgentId } from "../routing/session-key.js";
 import { resolveGlobalMap } from "../shared/global-singleton.js";
 import { getFileLockProcessStartTime } from "../shared/pid-alive.js";
 import type { CommandExplanationSummary } from "./command-analysis/explain.js";
@@ -1252,16 +1258,49 @@ type ExecApprovalsUpdate = {
   update: (file: ExecApprovalsFile) => ExecApprovalsFile | null;
 };
 
-function updateExecApprovalsUnlocked(params: ExecApprovalsUpdate): ExecApprovalsSnapshot | null {
+type InternalExecApprovalsUpdate = ExecApprovalsUpdate & {
+  allowDeletedAgentRemoval?: string;
+};
+
+function assertNoDeletedAgentApprovalChanged(
+  current: ExecApprovalsFile,
+  next: ExecApprovalsFile,
+  allowDeletedAgentRemoval?: string,
+): void {
+  const agentIds = new Set([
+    ...Object.keys(current.agents ?? {}),
+    ...Object.keys(next.agents ?? {}),
+  ]);
+  for (const agentId of agentIds) {
+    const currentPolicy = current.agents?.[agentId];
+    const nextPolicy = next.agents?.[agentId];
+    const allowedRemoval =
+      agentId === allowDeletedAgentRemoval &&
+      currentPolicy !== undefined &&
+      nextPolicy === undefined;
+    if (
+      isAgentDeletionBlocked(agentId) &&
+      !allowedRemoval &&
+      !isDeepStrictEqual(currentPolicy, nextPolicy)
+    ) {
+      throw new Error(`Exec approvals are unavailable while agent ${agentId} is deleted.`);
+    }
+  }
+}
+
+function updateExecApprovalsUnlocked(
+  params: InternalExecApprovalsUpdate,
+): ExecApprovalsSnapshot | null {
   // Both sync and async entry points hold the sidecar lock across this full CAS transaction.
   const current = readExecApprovalsSnapshotUnlocked();
   if (params.baseHash !== undefined && current.hash !== params.baseHash) {
     return null;
   }
-  const next = params.update(current.file);
+  const next = params.update(structuredClone(current.file));
   if (next === null) {
     return current;
   }
+  assertNoDeletedAgentApprovalChanged(current.file, next, params.allowDeletedAgentRemoval);
   if (
     current.exists &&
     current.hash === hashExecApprovalsFile(next) &&
@@ -1322,6 +1361,46 @@ export async function updateExecApprovals(
   params: ExecApprovalsUpdate,
 ): Promise<ExecApprovalsSnapshot | null> {
   return await withExecApprovalsLock(async () => updateExecApprovalsUnlocked(params));
+}
+
+/** Hold the approvals lock across an agent deletion and restore policy if commit fails. */
+export async function withAgentExecApprovalsRemoved<T>(
+  agentId: string,
+  commit: () => Promise<T>,
+): Promise<T> {
+  const key = normalizeAgentId(agentId);
+  return await withExecApprovalsLock(async () => {
+    const snapshot = readExecApprovalsSnapshotUnlocked();
+    try {
+      if (Object.hasOwn(snapshot.file.agents ?? {}, key)) {
+        const agents = { ...snapshot.file.agents };
+        delete agents[key];
+        const updated = updateExecApprovalsUnlocked({
+          baseHash: snapshot.hash,
+          allowDeletedAgentRemoval: key,
+          update: (file) => ({ ...file, agents }),
+        });
+        if (!updated) {
+          throw new Error("Exec approvals changed while deleting agent; retry deletion.");
+        }
+      }
+      return await commit();
+    } catch (error) {
+      if (error instanceof AgentDeletionCommitUncertainError) {
+        throw error;
+      }
+      try {
+        restoreExecApprovalsSnapshotUnlocked(snapshot);
+      } catch (rollbackError) {
+        throw new AgentDeletionAuthorityRollbackError(
+          [error, rollbackError],
+          `Failed to roll back exec approvals deletion for agent ${key}.`,
+          { cause: error },
+        );
+      }
+      throw error;
+    }
+  });
 }
 
 function hardenUnchangedExecApprovals(filePath: string): boolean {

--- a/src/state/agent-deletion-journal.ts
+++ b/src/state/agent-deletion-journal.ts
@@ -128,6 +128,10 @@ export function prepareAgentDeletionPathFence(
   return {
     claimAgentId: normalizeAgentId(claim.agentId),
     ...(claim.fenceAgentId ? { fenceAgentId: normalizeAgentId(claim.fenceAgentId) } : {}),
+    // targetPaths is a pre-open realpath snapshot. A co-equal same-user
+    // process could retarget a symlink between snapshot and open; that actor
+    // already owns every file here, so the fence defends cooperative
+    // interleavings only — adversarial local races are out of threat model.
     targetPaths: resolveSqliteDatabaseFilePaths(claim.path).map((filePath) =>
       normalizeAgentDirRegistryPath(filePath, env),
     ),

--- a/src/state/agent-deletion-journal.ts
+++ b/src/state/agent-deletion-journal.ts
@@ -38,33 +38,6 @@ export function ensureAgentDeletionJournalSchema(database: DatabaseSync): void {
       delete_files INTEGER NOT NULL DEFAULT 1
     ) STRICT
   `);
-  const hasOperationId = database
-    .prepare("PRAGMA table_info(agent_deletion_journal)")
-    .all()
-    .some((column) => (column as { name?: unknown }).name === "operation_id");
-  if (!hasOperationId) {
-    database.exec(
-      "ALTER TABLE agent_deletion_journal ADD COLUMN operation_id TEXT NOT NULL DEFAULT ''",
-    );
-  }
-  const hasCleanupCompleted = database
-    .prepare("PRAGMA table_info(agent_deletion_journal)")
-    .all()
-    .some((column) => (column as { name?: unknown }).name === "cleanup_completed");
-  if (!hasCleanupCompleted) {
-    database.exec(
-      "ALTER TABLE agent_deletion_journal ADD COLUMN cleanup_completed INTEGER NOT NULL DEFAULT 0",
-    );
-  }
-  const hasDeleteFiles = database
-    .prepare("PRAGMA table_info(agent_deletion_journal)")
-    .all()
-    .some((column) => (column as { name?: unknown }).name === "delete_files");
-  if (!hasDeleteFiles) {
-    database.exec(
-      "ALTER TABLE agent_deletion_journal ADD COLUMN delete_files INTEGER NOT NULL DEFAULT 1",
-    );
-  }
 }
 
 function fromRow(row: {

--- a/src/state/agent-deletion-journal.ts
+++ b/src/state/agent-deletion-journal.ts
@@ -1,0 +1,240 @@
+import { existsSync } from "node:fs";
+import path from "node:path";
+import type { DatabaseSync } from "node:sqlite";
+import {
+  executeSqliteQuerySync,
+  executeSqliteQueryTakeFirstSync,
+  getNodeSqliteKysely,
+} from "../infra/kysely-sync.js";
+import { normalizeAgentId } from "../routing/session-key.js";
+import type { OpenClawStateDatabaseOptions } from "./openclaw-state-db-contract.js";
+import type { DB as OpenClawStateKyselyDatabase } from "./openclaw-state-db.generated.js";
+import { runOpenClawStateWriteTransaction } from "./openclaw-state-db.js";
+import { resolveOpenClawStateSqlitePath } from "./openclaw-state-db.paths.js";
+
+type AgentDeletionDatabase = Pick<OpenClawStateKyselyDatabase, "agent_deletion_journal">;
+
+export type AgentDeletionJournalEntry = {
+  agentId: string;
+  operationId: string;
+  agentDir: string;
+  workspaceDir: string;
+  sessionsDir: string;
+  createdAt: number;
+  cleanupCompleted: boolean;
+  deleteFiles: boolean;
+};
+
+export function ensureAgentDeletionJournalSchema(database: DatabaseSync): void {
+  database.exec(`
+    CREATE TABLE IF NOT EXISTS agent_deletion_journal (
+      agent_id TEXT PRIMARY KEY,
+      operation_id TEXT NOT NULL DEFAULT '',
+      agent_dir TEXT NOT NULL,
+      workspace_dir TEXT NOT NULL,
+      sessions_dir TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      cleanup_completed INTEGER NOT NULL DEFAULT 0,
+      delete_files INTEGER NOT NULL DEFAULT 1
+    ) STRICT
+  `);
+  const hasOperationId = database
+    .prepare("PRAGMA table_info(agent_deletion_journal)")
+    .all()
+    .some((column) => (column as { name?: unknown }).name === "operation_id");
+  if (!hasOperationId) {
+    database.exec(
+      "ALTER TABLE agent_deletion_journal ADD COLUMN operation_id TEXT NOT NULL DEFAULT ''",
+    );
+  }
+  const hasCleanupCompleted = database
+    .prepare("PRAGMA table_info(agent_deletion_journal)")
+    .all()
+    .some((column) => (column as { name?: unknown }).name === "cleanup_completed");
+  if (!hasCleanupCompleted) {
+    database.exec(
+      "ALTER TABLE agent_deletion_journal ADD COLUMN cleanup_completed INTEGER NOT NULL DEFAULT 0",
+    );
+  }
+  const hasDeleteFiles = database
+    .prepare("PRAGMA table_info(agent_deletion_journal)")
+    .all()
+    .some((column) => (column as { name?: unknown }).name === "delete_files");
+  if (!hasDeleteFiles) {
+    database.exec(
+      "ALTER TABLE agent_deletion_journal ADD COLUMN delete_files INTEGER NOT NULL DEFAULT 1",
+    );
+  }
+}
+
+function fromRow(row: {
+  agent_id: string;
+  operation_id: string;
+  agent_dir: string;
+  workspace_dir: string;
+  sessions_dir: string;
+  created_at: number;
+  cleanup_completed: number;
+  delete_files: number;
+}): AgentDeletionJournalEntry {
+  return {
+    agentId: row.agent_id,
+    operationId: row.operation_id,
+    agentDir: row.agent_dir,
+    workspaceDir: row.workspace_dir,
+    sessionsDir: row.sessions_dir,
+    createdAt: row.created_at,
+    cleanupCompleted: row.cleanup_completed === 1,
+    deleteFiles: row.delete_files === 1,
+  };
+}
+
+export function readAgentDeletionJournal(
+  agentId: string,
+  options: OpenClawStateDatabaseOptions = {},
+): AgentDeletionJournalEntry | undefined {
+  const id = normalizeAgentId(agentId);
+  const databasePath = path.resolve(
+    options.path ?? resolveOpenClawStateSqlitePath(options.env ?? process.env),
+  );
+  if (!existsSync(databasePath)) {
+    return undefined;
+  }
+  let entry: AgentDeletionJournalEntry | undefined;
+  runOpenClawStateWriteTransaction((database) => {
+    ensureAgentDeletionJournalSchema(database.db);
+    const db = getNodeSqliteKysely<AgentDeletionDatabase>(database.db);
+    const row = executeSqliteQueryTakeFirstSync(
+      database.db,
+      db.selectFrom("agent_deletion_journal").selectAll().where("agent_id", "=", id),
+    );
+    entry = row ? fromRow(row) : undefined;
+  }, options);
+  return entry;
+}
+
+export function beginAgentDeletionJournal(
+  entry: Omit<AgentDeletionJournalEntry, "createdAt" | "cleanupCompleted">,
+  options: OpenClawStateDatabaseOptions = {},
+): AgentDeletionJournalEntry {
+  const normalized = { ...entry, agentId: normalizeAgentId(entry.agentId) };
+  let persisted: AgentDeletionJournalEntry | undefined;
+  runOpenClawStateWriteTransaction((database) => {
+    ensureAgentDeletionJournalSchema(database.db);
+    const db = getNodeSqliteKysely<AgentDeletionDatabase>(database.db);
+    const existing = executeSqliteQueryTakeFirstSync(
+      database.db,
+      db
+        .selectFrom("agent_deletion_journal")
+        .selectAll()
+        .where("agent_id", "=", normalized.agentId),
+    );
+    if (existing) {
+      executeSqliteQuerySync(
+        database.db,
+        db
+          .updateTable("agent_deletion_journal")
+          .set({
+            operation_id: normalized.operationId,
+            cleanup_completed: 0,
+            delete_files: normalized.deleteFiles ? 1 : 0,
+          })
+          .where("agent_id", "=", normalized.agentId),
+      );
+      persisted = {
+        ...fromRow(existing),
+        operationId: normalized.operationId,
+        cleanupCompleted: false,
+        deleteFiles: normalized.deleteFiles,
+      };
+      return;
+    }
+    const createdAt = Date.now();
+    executeSqliteQuerySync(
+      database.db,
+      db.insertInto("agent_deletion_journal").values({
+        agent_id: normalized.agentId,
+        operation_id: normalized.operationId,
+        agent_dir: normalized.agentDir,
+        workspace_dir: normalized.workspaceDir,
+        sessions_dir: normalized.sessionsDir,
+        created_at: createdAt,
+        cleanup_completed: 0,
+        delete_files: normalized.deleteFiles ? 1 : 0,
+      }),
+    );
+    persisted = { ...normalized, createdAt, cleanupCompleted: false };
+  }, options);
+  if (!persisted) {
+    throw new Error(`Failed to record deletion journal for agent ${normalized.agentId}.`);
+  }
+  return persisted;
+}
+
+export function completeAgentDeletionJournal(
+  agentId: string,
+  operationId: string,
+  options: OpenClawStateDatabaseOptions = {},
+): boolean {
+  const id = normalizeAgentId(agentId);
+  let completed = false;
+  runOpenClawStateWriteTransaction((database) => {
+    ensureAgentDeletionJournalSchema(database.db);
+    const db = getNodeSqliteKysely<AgentDeletionDatabase>(database.db);
+    const result = executeSqliteQuerySync(
+      database.db,
+      db
+        .updateTable("agent_deletion_journal")
+        .set({ cleanup_completed: 1 })
+        .where("agent_id", "=", id)
+        .where("operation_id", "=", operationId),
+    );
+    completed = Number(result.numAffectedRows ?? 0) > 0;
+  }, options);
+  return completed;
+}
+
+export function removeAgentDeletionJournal(
+  agentId: string,
+  operationId: string,
+  options: OpenClawStateDatabaseOptions = {},
+): boolean {
+  const id = normalizeAgentId(agentId);
+  let removed = false;
+  runOpenClawStateWriteTransaction((database) => {
+    ensureAgentDeletionJournalSchema(database.db);
+    const db = getNodeSqliteKysely<AgentDeletionDatabase>(database.db);
+    const result = executeSqliteQuerySync(
+      database.db,
+      db
+        .deleteFrom("agent_deletion_journal")
+        .where("agent_id", "=", id)
+        .where("operation_id", "=", operationId),
+    );
+    removed = Number(result.numAffectedRows ?? 0) > 0;
+  }, options);
+  return removed;
+}
+
+export function claimCompletedAgentDeletionJournal(
+  agentId: string,
+  operationId: string,
+  options: OpenClawStateDatabaseOptions = {},
+): boolean {
+  const id = normalizeAgentId(agentId);
+  let removed = false;
+  runOpenClawStateWriteTransaction((database) => {
+    ensureAgentDeletionJournalSchema(database.db);
+    const db = getNodeSqliteKysely<AgentDeletionDatabase>(database.db);
+    const result = executeSqliteQuerySync(
+      database.db,
+      db
+        .deleteFrom("agent_deletion_journal")
+        .where("agent_id", "=", id)
+        .where("operation_id", "=", operationId)
+        .where("cleanup_completed", "=", 1),
+    );
+    removed = Number(result.numAffectedRows ?? 0) > 0;
+  }, options);
+  return removed;
+}

--- a/src/state/agent-deletion-journal.ts
+++ b/src/state/agent-deletion-journal.ts
@@ -32,7 +32,14 @@ type AgentDeletionPathFenceSnapshot = {
     cleanupCompleted: boolean;
     canonicalPaths: string[];
     databasePaths: Array<{ path: string; canonicalPath: string }>;
+    cleanupPaths: Array<AgentDeletionJournalCleanupPath & { canonicalPath: string }>;
   }>;
+};
+
+export type AgentDeletionJournalCleanupPath = {
+  path: string;
+  kind: "target" | "symlink";
+  sourcePaths: string[];
 };
 
 export type AgentDeletionJournalEntry = {
@@ -42,6 +49,7 @@ export type AgentDeletionJournalEntry = {
   workspaceDir: string;
   sessionsDir: string;
   databasePaths: string[];
+  cleanupPaths: AgentDeletionJournalCleanupPath[];
   createdAt: number;
   cleanupCompleted: boolean;
   deleteFiles: boolean;
@@ -56,6 +64,7 @@ export function ensureAgentDeletionJournalSchema(database: DatabaseSync): void {
       workspace_dir TEXT NOT NULL,
       sessions_dir TEXT NOT NULL,
       database_paths_json TEXT NOT NULL DEFAULT '[]',
+      cleanup_paths_json TEXT NOT NULL DEFAULT '[]',
       created_at INTEGER NOT NULL,
       cleanup_completed INTEGER NOT NULL DEFAULT 0,
       delete_files INTEGER NOT NULL DEFAULT 1
@@ -74,6 +83,7 @@ export function prepareAgentDeletionPathFence(
     workspace_dir: string;
     sessions_dir: string;
     database_paths_json: string;
+    cleanup_paths_json: string;
     cleanup_completed: number;
   }> = [];
   runOpenClawStateWriteTransaction((database) => {
@@ -90,6 +100,7 @@ export function prepareAgentDeletionPathFence(
           "workspace_dir",
           "sessions_dir",
           "database_paths_json",
+          "cleanup_paths_json",
           "cleanup_completed",
         ]),
     ).rows;
@@ -114,6 +125,10 @@ export function prepareAgentDeletionPathFence(
         path: databasePath,
         canonicalPath: normalizeAgentDirRegistryPath(databasePath, env),
       })),
+      cleanupPaths: parseCleanupPaths(row.cleanup_paths_json).map((cleanupPath) => ({
+        ...cleanupPath,
+        canonicalPath: normalizeAgentDirRegistryPath(cleanupPath.path, env),
+      })),
     })),
   };
 }
@@ -136,6 +151,7 @@ export function assertAgentDeletionPathFence(
         "workspace_dir",
         "sessions_dir",
         "database_paths_json",
+        "cleanup_paths_json",
         "cleanup_completed",
       ]),
   ).rows;
@@ -148,6 +164,11 @@ export function assertAgentDeletionPathFence(
         entry.workspaceDir,
         entry.sessionsDir,
         JSON.stringify(entry.databasePaths.map((candidate) => candidate.path)),
+        JSON.stringify(
+          entry.cleanupPaths.map(({ canonicalPath: _canonicalPath, ...candidate }) => ({
+            ...candidate,
+          })),
+        ),
         entry.cleanupCompleted ? 1 : 0,
       ].join("\0"),
     )
@@ -161,6 +182,7 @@ export function assertAgentDeletionPathFence(
         row.workspace_dir,
         row.sessions_dir,
         row.database_paths_json,
+        row.cleanup_paths_json,
         row.cleanup_completed,
       ].join("\0"),
     )
@@ -182,7 +204,12 @@ export function assertAgentDeletionPathFence(
         candidate.workspaceDir === row.workspace_dir &&
         candidate.sessionsDir === row.sessions_dir &&
         JSON.stringify(candidate.databasePaths.map((databasePath) => databasePath.path)) ===
-          row.database_paths_json,
+          row.database_paths_json &&
+        JSON.stringify(
+          candidate.cleanupPaths.map(({ canonicalPath: _canonicalPath, ...cleanupPath }) => ({
+            ...cleanupPath,
+          })),
+        ) === row.cleanup_paths_json,
     );
     if (!entry) {
       throw new Error("Agent deletion journal changed while preparing a database claim.");
@@ -198,6 +225,7 @@ export function assertAgentDeletionPathFence(
         path: [entry.agentDir, entry.workspaceDir, entry.sessionsDir][index],
       })),
       ...entry.databasePaths,
+      ...entry.cleanupPaths,
     ];
     for (const fence of fences) {
       const blockedPath = snapshot.targetPaths.find(
@@ -220,6 +248,7 @@ function fromRow(row: {
   workspace_dir: string;
   sessions_dir: string;
   database_paths_json: string;
+  cleanup_paths_json: string;
   created_at: number;
   cleanup_completed: number;
   delete_files: number;
@@ -231,6 +260,7 @@ function fromRow(row: {
     workspaceDir: row.workspace_dir,
     sessionsDir: row.sessions_dir,
     databasePaths: parseDatabasePaths(row.database_paths_json),
+    cleanupPaths: parseCleanupPaths(row.cleanup_paths_json),
     createdAt: row.created_at,
     cleanupCompleted: row.cleanup_completed === 1,
     deleteFiles: row.delete_files === 1,
@@ -244,6 +274,28 @@ function parseDatabasePaths(value: string): string[] {
     !parsed.every((entry): entry is string => typeof entry === "string")
   ) {
     throw new Error("Invalid agent deletion database path journal.");
+  }
+  return parsed;
+}
+
+function parseCleanupPaths(value: string): AgentDeletionJournalCleanupPath[] {
+  const parsed: unknown = JSON.parse(value);
+  if (
+    !Array.isArray(parsed) ||
+    !parsed.every(
+      (entry): entry is AgentDeletionJournalCleanupPath =>
+        typeof entry === "object" &&
+        entry !== null &&
+        typeof (entry as { path?: unknown }).path === "string" &&
+        ((entry as { kind?: unknown }).kind === "target" ||
+          (entry as { kind?: unknown }).kind === "symlink") &&
+        Array.isArray((entry as { sourcePaths?: unknown }).sourcePaths) &&
+        (entry as { sourcePaths: unknown[] }).sourcePaths.every(
+          (sourcePath) => typeof sourcePath === "string",
+        ),
+    )
+  ) {
+    throw new Error("Invalid agent deletion cleanup path journal.");
   }
   return parsed;
 }
@@ -273,8 +325,12 @@ export function readAgentDeletionJournal(
 }
 
 export function beginAgentDeletionJournal(
-  entry: Omit<AgentDeletionJournalEntry, "createdAt" | "cleanupCompleted" | "databasePaths"> & {
+  entry: Omit<
+    AgentDeletionJournalEntry,
+    "createdAt" | "cleanupCompleted" | "databasePaths" | "cleanupPaths"
+  > & {
     databasePaths?: string[];
+    cleanupPaths?: AgentDeletionJournalCleanupPath[];
   },
   options: OpenClawStateDatabaseOptions = {},
 ): AgentDeletionJournalEntry {
@@ -284,6 +340,7 @@ export function beginAgentDeletionJournal(
     databasePaths: [
       ...new Set((entry.databasePaths ?? []).map((entryPath) => path.resolve(entryPath))),
     ],
+    cleanupPaths: entry.cleanupPaths ?? [],
   };
   let persisted: AgentDeletionJournalEntry | undefined;
   runOpenClawStateWriteTransaction((database) => {
@@ -309,6 +366,7 @@ export function beginAgentDeletionJournal(
         ].map((entryPath) => path.resolve(entryPath)),
       ),
     ];
+    const cleanupPaths = existing ? fromRow(existing).cleanupPaths : normalized.cleanupPaths;
     if (existing) {
       executeSqliteQuerySync(
         database.db,
@@ -317,6 +375,7 @@ export function beginAgentDeletionJournal(
           .set({
             operation_id: normalized.operationId,
             database_paths_json: JSON.stringify(databasePaths),
+            cleanup_paths_json: JSON.stringify(cleanupPaths),
             cleanup_completed: 0,
             delete_files: normalized.deleteFiles ? 1 : 0,
           })
@@ -326,6 +385,7 @@ export function beginAgentDeletionJournal(
         ...fromRow(existing),
         operationId: normalized.operationId,
         databasePaths,
+        cleanupPaths,
         cleanupCompleted: false,
         deleteFiles: normalized.deleteFiles,
       };
@@ -341,17 +401,43 @@ export function beginAgentDeletionJournal(
         workspace_dir: normalized.workspaceDir,
         sessions_dir: normalized.sessionsDir,
         database_paths_json: JSON.stringify(databasePaths),
+        cleanup_paths_json: JSON.stringify(cleanupPaths),
         created_at: createdAt,
         cleanup_completed: 0,
         delete_files: normalized.deleteFiles ? 1 : 0,
       }),
     );
-    persisted = { ...normalized, databasePaths, createdAt, cleanupCompleted: false };
+    persisted = { ...normalized, databasePaths, cleanupPaths, createdAt, cleanupCompleted: false };
   }, options);
   if (!persisted) {
     throw new Error(`Failed to record deletion journal for agent ${normalized.agentId}.`);
   }
   return persisted;
+}
+
+export function updateAgentDeletionJournalCleanupPaths(
+  agentId: string,
+  operationId: string,
+  cleanupPaths: readonly AgentDeletionJournalCleanupPath[],
+  options: OpenClawStateDatabaseOptions = {},
+): boolean {
+  const id = normalizeAgentId(agentId);
+  let updated = false;
+  runOpenClawStateWriteTransaction((database) => {
+    ensureAgentDeletionJournalSchema(database.db);
+    const db = getNodeSqliteKysely<AgentDeletionDatabase>(database.db);
+    const result = executeSqliteQuerySync(
+      database.db,
+      db
+        .updateTable("agent_deletion_journal")
+        .set({ cleanup_paths_json: JSON.stringify(cleanupPaths) })
+        .where("agent_id", "=", id)
+        .where("operation_id", "=", operationId)
+        .where("cleanup_completed", "=", 0),
+    );
+    updated = Number(result.numAffectedRows ?? 0) > 0;
+  }, options);
+  return updated;
 }
 
 export function updateAgentDeletionJournalDatabasePaths(

--- a/src/state/agent-deletion-journal.ts
+++ b/src/state/agent-deletion-journal.ts
@@ -1,18 +1,39 @@
 import { existsSync } from "node:fs";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
+import { normalizeAgentDirRegistryPath } from "../agents/agent-dir-registry.js";
 import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
 } from "../infra/kysely-sync.js";
+import { isPathInside } from "../infra/path-guards.js";
+import { resolveSqliteDatabaseFilePaths } from "../infra/sqlite-files.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import type { OpenClawStateDatabaseOptions } from "./openclaw-state-db-contract.js";
 import type { DB as OpenClawStateKyselyDatabase } from "./openclaw-state-db.generated.js";
 import { runOpenClawStateWriteTransaction } from "./openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "./openclaw-state-db.paths.js";
 
-type AgentDeletionDatabase = Pick<OpenClawStateKyselyDatabase, "agent_deletion_journal">;
+type AgentDeletionDatabase = Pick<
+  OpenClawStateKyselyDatabase,
+  "agent_databases" | "agent_deletion_journal"
+>;
+
+type AgentDeletionPathFenceSnapshot = {
+  claimAgentId: string;
+  targetPaths: string[];
+  entries: Array<{
+    agentId: string;
+    operationId: string;
+    agentDir: string;
+    workspaceDir: string;
+    sessionsDir: string;
+    cleanupCompleted: boolean;
+    canonicalPaths: string[];
+    databasePaths: Array<{ path: string; canonicalPath: string }>;
+  }>;
+};
 
 export type AgentDeletionJournalEntry = {
   agentId: string;
@@ -20,6 +41,7 @@ export type AgentDeletionJournalEntry = {
   agentDir: string;
   workspaceDir: string;
   sessionsDir: string;
+  databasePaths: string[];
   createdAt: number;
   cleanupCompleted: boolean;
   deleteFiles: boolean;
@@ -33,11 +55,162 @@ export function ensureAgentDeletionJournalSchema(database: DatabaseSync): void {
       agent_dir TEXT NOT NULL,
       workspace_dir TEXT NOT NULL,
       sessions_dir TEXT NOT NULL,
+      database_paths_json TEXT NOT NULL DEFAULT '[]',
       created_at INTEGER NOT NULL,
       cleanup_completed INTEGER NOT NULL DEFAULT 0,
       delete_files INTEGER NOT NULL DEFAULT 1
     ) STRICT
   `);
+}
+
+export function prepareAgentDeletionPathFence(
+  claim: { agentId: string; path: string },
+  options: OpenClawStateDatabaseOptions = {},
+): AgentDeletionPathFenceSnapshot {
+  let rows: Array<{
+    agent_id: string;
+    operation_id: string;
+    agent_dir: string;
+    workspace_dir: string;
+    sessions_dir: string;
+    database_paths_json: string;
+    cleanup_completed: number;
+  }> = [];
+  runOpenClawStateWriteTransaction((database) => {
+    ensureAgentDeletionJournalSchema(database.db);
+    const db = getNodeSqliteKysely<AgentDeletionDatabase>(database.db);
+    rows = executeSqliteQuerySync(
+      database.db,
+      db
+        .selectFrom("agent_deletion_journal")
+        .select([
+          "agent_id",
+          "operation_id",
+          "agent_dir",
+          "workspace_dir",
+          "sessions_dir",
+          "database_paths_json",
+          "cleanup_completed",
+        ]),
+    ).rows;
+  }, options);
+  const env = options.env ?? process.env;
+  return {
+    claimAgentId: normalizeAgentId(claim.agentId),
+    targetPaths: resolveSqliteDatabaseFilePaths(claim.path).map((filePath) =>
+      normalizeAgentDirRegistryPath(filePath, env),
+    ),
+    entries: rows.map((row) => ({
+      agentId: row.agent_id,
+      operationId: row.operation_id,
+      agentDir: row.agent_dir,
+      workspaceDir: row.workspace_dir,
+      sessionsDir: row.sessions_dir,
+      cleanupCompleted: row.cleanup_completed === 1,
+      canonicalPaths: [row.agent_dir, row.workspace_dir, row.sessions_dir].map((entryPath) =>
+        normalizeAgentDirRegistryPath(entryPath, env),
+      ),
+      databasePaths: parseDatabasePaths(row.database_paths_json).map((databasePath) => ({
+        path: databasePath,
+        canonicalPath: normalizeAgentDirRegistryPath(databasePath, env),
+      })),
+    })),
+  };
+}
+
+/** Refuse database claims beneath paths still owned by an unfinished deletion. */
+export function assertAgentDeletionPathFence(
+  database: DatabaseSync,
+  snapshot: AgentDeletionPathFenceSnapshot,
+): void {
+  ensureAgentDeletionJournalSchema(database);
+  const db = getNodeSqliteKysely<AgentDeletionDatabase>(database);
+  const journalRows = executeSqliteQuerySync(
+    database,
+    db
+      .selectFrom("agent_deletion_journal")
+      .select([
+        "agent_id",
+        "operation_id",
+        "agent_dir",
+        "workspace_dir",
+        "sessions_dir",
+        "database_paths_json",
+        "cleanup_completed",
+      ]),
+  ).rows;
+  const snapshotJournal = snapshot.entries
+    .map((entry) =>
+      [
+        entry.agentId,
+        entry.operationId,
+        entry.agentDir,
+        entry.workspaceDir,
+        entry.sessionsDir,
+        JSON.stringify(entry.databasePaths.map((candidate) => candidate.path)),
+        entry.cleanupCompleted ? 1 : 0,
+      ].join("\0"),
+    )
+    .sort();
+  const currentJournal = journalRows
+    .map((row) =>
+      [
+        row.agent_id,
+        row.operation_id,
+        row.agent_dir,
+        row.workspace_dir,
+        row.sessions_dir,
+        row.database_paths_json,
+        row.cleanup_completed,
+      ].join("\0"),
+    )
+    .sort();
+  if (snapshotJournal.join("\n") !== currentJournal.join("\n")) {
+    throw new Error("Agent deletion journal changed while preparing a database claim.");
+  }
+  for (const row of journalRows) {
+    if (row.cleanup_completed === 1) {
+      continue;
+    }
+    // Filesystem canonicalization stays outside the SQLite write transaction; the exact journal
+    // row is revalidated here so a concurrent deletion can only make the claim fail closed.
+    const entry = snapshot.entries.find(
+      (candidate) =>
+        candidate.agentId === row.agent_id &&
+        candidate.operationId === row.operation_id &&
+        candidate.agentDir === row.agent_dir &&
+        candidate.workspaceDir === row.workspace_dir &&
+        candidate.sessionsDir === row.sessions_dir &&
+        JSON.stringify(candidate.databasePaths.map((databasePath) => databasePath.path)) ===
+          row.database_paths_json,
+    );
+    if (!entry) {
+      throw new Error("Agent deletion journal changed while preparing a database claim.");
+    }
+    if (snapshot.claimAgentId === row.agent_id) {
+      throw new Error(
+        `OpenClaw agent database is unavailable while agent ${row.agent_id} is deleted.`,
+      );
+    }
+    const fences = [
+      ...entry.canonicalPaths.map((canonicalPath, index) => ({
+        canonicalPath,
+        path: [entry.agentDir, entry.workspaceDir, entry.sessionsDir][index],
+      })),
+      ...entry.databasePaths,
+    ];
+    for (const fence of fences) {
+      const blockedPath = snapshot.targetPaths.find(
+        (targetPath) =>
+          targetPath === fence.canonicalPath || isPathInside(fence.canonicalPath, targetPath),
+      );
+      if (blockedPath) {
+        throw new Error(
+          `OpenClaw agent database ${blockedPath} is unavailable while agent ${row.agent_id} deletion owns ${fence.path}.`,
+        );
+      }
+    }
+  }
 }
 
 function fromRow(row: {
@@ -46,6 +219,7 @@ function fromRow(row: {
   agent_dir: string;
   workspace_dir: string;
   sessions_dir: string;
+  database_paths_json: string;
   created_at: number;
   cleanup_completed: number;
   delete_files: number;
@@ -56,10 +230,22 @@ function fromRow(row: {
     agentDir: row.agent_dir,
     workspaceDir: row.workspace_dir,
     sessionsDir: row.sessions_dir,
+    databasePaths: parseDatabasePaths(row.database_paths_json),
     createdAt: row.created_at,
     cleanupCompleted: row.cleanup_completed === 1,
     deleteFiles: row.delete_files === 1,
   };
+}
+
+function parseDatabasePaths(value: string): string[] {
+  const parsed: unknown = JSON.parse(value);
+  if (
+    !Array.isArray(parsed) ||
+    !parsed.every((entry): entry is string => typeof entry === "string")
+  ) {
+    throw new Error("Invalid agent deletion database path journal.");
+  }
+  return parsed;
 }
 
 export function readAgentDeletionJournal(
@@ -87,10 +273,18 @@ export function readAgentDeletionJournal(
 }
 
 export function beginAgentDeletionJournal(
-  entry: Omit<AgentDeletionJournalEntry, "createdAt" | "cleanupCompleted">,
+  entry: Omit<AgentDeletionJournalEntry, "createdAt" | "cleanupCompleted" | "databasePaths"> & {
+    databasePaths?: string[];
+  },
   options: OpenClawStateDatabaseOptions = {},
 ): AgentDeletionJournalEntry {
-  const normalized = { ...entry, agentId: normalizeAgentId(entry.agentId) };
+  const normalized = {
+    ...entry,
+    agentId: normalizeAgentId(entry.agentId),
+    databasePaths: [
+      ...new Set((entry.databasePaths ?? []).map((entryPath) => path.resolve(entryPath))),
+    ],
+  };
   let persisted: AgentDeletionJournalEntry | undefined;
   runOpenClawStateWriteTransaction((database) => {
     ensureAgentDeletionJournalSchema(database.db);
@@ -102,6 +296,19 @@ export function beginAgentDeletionJournal(
         .selectAll()
         .where("agent_id", "=", normalized.agentId),
     );
+    const registeredDatabasePaths = executeSqliteQuerySync(
+      database.db,
+      db.selectFrom("agent_databases").select("path").where("agent_id", "=", normalized.agentId),
+    ).rows.flatMap((row) => resolveSqliteDatabaseFilePaths(row.path));
+    const databasePaths = [
+      ...new Set(
+        [
+          ...(existing ? fromRow(existing).databasePaths : []),
+          ...normalized.databasePaths,
+          ...registeredDatabasePaths,
+        ].map((entryPath) => path.resolve(entryPath)),
+      ),
+    ];
     if (existing) {
       executeSqliteQuerySync(
         database.db,
@@ -109,6 +316,7 @@ export function beginAgentDeletionJournal(
           .updateTable("agent_deletion_journal")
           .set({
             operation_id: normalized.operationId,
+            database_paths_json: JSON.stringify(databasePaths),
             cleanup_completed: 0,
             delete_files: normalized.deleteFiles ? 1 : 0,
           })
@@ -117,6 +325,7 @@ export function beginAgentDeletionJournal(
       persisted = {
         ...fromRow(existing),
         operationId: normalized.operationId,
+        databasePaths,
         cleanupCompleted: false,
         deleteFiles: normalized.deleteFiles,
       };
@@ -131,17 +340,44 @@ export function beginAgentDeletionJournal(
         agent_dir: normalized.agentDir,
         workspace_dir: normalized.workspaceDir,
         sessions_dir: normalized.sessionsDir,
+        database_paths_json: JSON.stringify(databasePaths),
         created_at: createdAt,
         cleanup_completed: 0,
         delete_files: normalized.deleteFiles ? 1 : 0,
       }),
     );
-    persisted = { ...normalized, createdAt, cleanupCompleted: false };
+    persisted = { ...normalized, databasePaths, createdAt, cleanupCompleted: false };
   }, options);
   if (!persisted) {
     throw new Error(`Failed to record deletion journal for agent ${normalized.agentId}.`);
   }
   return persisted;
+}
+
+export function updateAgentDeletionJournalDatabasePaths(
+  agentId: string,
+  operationId: string,
+  databasePaths: readonly string[],
+  options: OpenClawStateDatabaseOptions = {},
+): boolean {
+  const id = normalizeAgentId(agentId);
+  const normalizedPaths = [...new Set(databasePaths.map((entryPath) => path.resolve(entryPath)))];
+  let updated = false;
+  runOpenClawStateWriteTransaction((database) => {
+    ensureAgentDeletionJournalSchema(database.db);
+    const db = getNodeSqliteKysely<AgentDeletionDatabase>(database.db);
+    const result = executeSqliteQuerySync(
+      database.db,
+      db
+        .updateTable("agent_deletion_journal")
+        .set({ database_paths_json: JSON.stringify(normalizedPaths) })
+        .where("agent_id", "=", id)
+        .where("operation_id", "=", operationId)
+        .where("cleanup_completed", "=", 0),
+    );
+    updated = Number(result.numAffectedRows ?? 0) > 0;
+  }, options);
+  return updated;
 }
 
 export function completeAgentDeletionJournal(

--- a/src/state/agent-deletion-journal.ts
+++ b/src/state/agent-deletion-journal.ts
@@ -33,16 +33,33 @@ type AgentDeletionPathFenceSnapshot = {
     cleanupCompleted: boolean;
     canonicalPaths: string[];
     databasePaths: Array<{ path: string; canonicalPath: string }>;
-    cleanupPaths: Array<AgentDeletionJournalCleanupPath & { canonicalPath: string }>;
+    cleanupPaths: Array<AgentDeletionJournalCleanupPath & { fencePath: string }>;
   }>;
 };
 
 export type AgentDeletionJournalCleanupPath = {
   path: string;
-  parentPath?: string;
+  canonicalPath: string;
+  parentPath: string;
   kind: "target" | "symlink";
   sourcePaths: string[];
+  dev: number | null;
+  ino: number | null;
+  coversDescendants: boolean;
+  done: boolean;
+  note?: string;
 };
+
+export function assertAgentDeletionIdentityClaimAllowed(
+  claimAgentId: string,
+  deletedAgentId: string | undefined,
+): void {
+  if (deletedAgentId && normalizeAgentId(claimAgentId) === normalizeAgentId(deletedAgentId)) {
+    throw new Error(
+      `OpenClaw agent database is unavailable while agent ${normalizeAgentId(deletedAgentId)} is deleted.`,
+    );
+  }
+}
 
 export type AgentDeletionJournalEntry = {
   agentId: string;
@@ -130,7 +147,7 @@ export function prepareAgentDeletionPathFence(
       })),
       cleanupPaths: parseCleanupPaths(row.cleanup_paths_json).map((cleanupPath) => ({
         ...cleanupPath,
-        canonicalPath: normalizeAgentDirRegistryPath(cleanupPath.path, env),
+        fencePath: normalizeAgentDirRegistryPath(cleanupPath.canonicalPath, env),
       })),
     })),
   };
@@ -168,7 +185,7 @@ export function assertAgentDeletionPathFence(
         entry.sessionsDir,
         JSON.stringify(entry.databasePaths.map((candidate) => candidate.path)),
         JSON.stringify(
-          entry.cleanupPaths.map(({ canonicalPath: _canonicalPath, ...candidate }) => ({
+          entry.cleanupPaths.map(({ fencePath: _fencePath, ...candidate }) => ({
             ...candidate,
           })),
         ),
@@ -194,10 +211,11 @@ export function assertAgentDeletionPathFence(
     throw new Error("Agent deletion journal changed while preparing a database claim.");
   }
   for (const row of journalRows) {
-    if (row.cleanup_completed === 1) {
+    if (snapshot.fenceAgentId && snapshot.fenceAgentId !== row.agent_id) {
       continue;
     }
-    if (snapshot.fenceAgentId && snapshot.fenceAgentId !== row.agent_id) {
+    assertAgentDeletionIdentityClaimAllowed(snapshot.claimAgentId, row.agent_id);
+    if (row.cleanup_completed === 1) {
       continue;
     }
     // Filesystem canonicalization stays outside the SQLite write transaction; the exact journal
@@ -212,7 +230,7 @@ export function assertAgentDeletionPathFence(
         JSON.stringify(candidate.databasePaths.map((databasePath) => databasePath.path)) ===
           row.database_paths_json &&
         JSON.stringify(
-          candidate.cleanupPaths.map(({ canonicalPath: _canonicalPath, ...cleanupPath }) => ({
+          candidate.cleanupPaths.map(({ fencePath: _fencePath, ...cleanupPath }) => ({
             ...cleanupPath,
           })),
         ) === row.cleanup_paths_json,
@@ -220,18 +238,16 @@ export function assertAgentDeletionPathFence(
     if (!entry) {
       throw new Error("Agent deletion journal changed while preparing a database claim.");
     }
-    if (snapshot.claimAgentId === row.agent_id) {
-      throw new Error(
-        `OpenClaw agent database is unavailable while agent ${row.agent_id} is deleted.`,
-      );
-    }
     const fences = [
       ...entry.canonicalPaths.map((canonicalPath, index) => ({
         canonicalPath,
         path: [entry.agentDir, entry.workspaceDir, entry.sessionsDir][index],
       })),
       ...entry.databasePaths,
-      ...entry.cleanupPaths,
+      ...entry.cleanupPaths.map((cleanupPath) => ({
+        path: cleanupPath.path,
+        canonicalPath: cleanupPath.fencePath,
+      })),
     ];
     for (const fence of fences) {
       const blockedPath = snapshot.targetPaths.find(
@@ -293,10 +309,18 @@ function parseCleanupPaths(value: string): AgentDeletionJournalCleanupPath[] {
         typeof entry === "object" &&
         entry !== null &&
         typeof (entry as { path?: unknown }).path === "string" &&
-        ((entry as { parentPath?: unknown }).parentPath === undefined ||
-          typeof (entry as { parentPath?: unknown }).parentPath === "string") &&
+        typeof (entry as { canonicalPath?: unknown }).canonicalPath === "string" &&
+        typeof (entry as { parentPath?: unknown }).parentPath === "string" &&
         ((entry as { kind?: unknown }).kind === "target" ||
           (entry as { kind?: unknown }).kind === "symlink") &&
+        ((entry as { dev?: unknown }).dev === null ||
+          typeof (entry as { dev?: unknown }).dev === "number") &&
+        ((entry as { ino?: unknown }).ino === null ||
+          typeof (entry as { ino?: unknown }).ino === "number") &&
+        typeof (entry as { coversDescendants?: unknown }).coversDescendants === "boolean" &&
+        typeof (entry as { done?: unknown }).done === "boolean" &&
+        ((entry as { note?: unknown }).note === undefined ||
+          typeof (entry as { note?: unknown }).note === "string") &&
         Array.isArray((entry as { sourcePaths?: unknown }).sourcePaths) &&
         (entry as { sourcePaths: unknown[] }).sourcePaths.every(
           (sourcePath) => typeof sourcePath === "string",

--- a/src/state/agent-deletion-journal.ts
+++ b/src/state/agent-deletion-journal.ts
@@ -22,6 +22,7 @@ type AgentDeletionDatabase = Pick<
 
 type AgentDeletionPathFenceSnapshot = {
   claimAgentId: string;
+  fenceAgentId?: string;
   targetPaths: string[];
   entries: Array<{
     agentId: string;
@@ -38,6 +39,7 @@ type AgentDeletionPathFenceSnapshot = {
 
 export type AgentDeletionJournalCleanupPath = {
   path: string;
+  parentPath?: string;
   kind: "target" | "symlink";
   sourcePaths: string[];
 };
@@ -73,7 +75,7 @@ export function ensureAgentDeletionJournalSchema(database: DatabaseSync): void {
 }
 
 export function prepareAgentDeletionPathFence(
-  claim: { agentId: string; path: string },
+  claim: { agentId: string; path: string; fenceAgentId?: string },
   options: OpenClawStateDatabaseOptions = {},
 ): AgentDeletionPathFenceSnapshot {
   let rows: Array<{
@@ -108,6 +110,7 @@ export function prepareAgentDeletionPathFence(
   const env = options.env ?? process.env;
   return {
     claimAgentId: normalizeAgentId(claim.agentId),
+    ...(claim.fenceAgentId ? { fenceAgentId: normalizeAgentId(claim.fenceAgentId) } : {}),
     targetPaths: resolveSqliteDatabaseFilePaths(claim.path).map((filePath) =>
       normalizeAgentDirRegistryPath(filePath, env),
     ),
@@ -192,6 +195,9 @@ export function assertAgentDeletionPathFence(
   }
   for (const row of journalRows) {
     if (row.cleanup_completed === 1) {
+      continue;
+    }
+    if (snapshot.fenceAgentId && snapshot.fenceAgentId !== row.agent_id) {
       continue;
     }
     // Filesystem canonicalization stays outside the SQLite write transaction; the exact journal
@@ -287,6 +293,8 @@ function parseCleanupPaths(value: string): AgentDeletionJournalCleanupPath[] {
         typeof entry === "object" &&
         entry !== null &&
         typeof (entry as { path?: unknown }).path === "string" &&
+        ((entry as { parentPath?: unknown }).parentPath === undefined ||
+          typeof (entry as { parentPath?: unknown }).parentPath === "string") &&
         ((entry as { kind?: unknown }).kind === "target" ||
           (entry as { kind?: unknown }).kind === "symlink") &&
         Array.isArray((entry as { sourcePaths?: unknown }).sourcePaths) &&

--- a/src/state/agent-deletion-journal.ts
+++ b/src/state/agent-deletion-journal.ts
@@ -1,6 +1,5 @@
 import { existsSync } from "node:fs";
 import path from "node:path";
-import type { DatabaseSync } from "node:sqlite";
 import { normalizeAgentDirRegistryPath } from "../agents/agent-dir-registry.js";
 import {
   executeSqliteQuerySync,
@@ -10,7 +9,11 @@ import {
 import { isPathInside } from "../infra/path-guards.js";
 import { resolveSqliteDatabaseFilePaths } from "../infra/sqlite-files.js";
 import { normalizeAgentId } from "../routing/session-key.js";
-import type { OpenClawStateDatabaseOptions } from "./openclaw-state-db-contract.js";
+import type {
+  OpenClawStateDatabase,
+  OpenClawStateDatabaseOptions,
+} from "./openclaw-state-db-contract.js";
+import { ensureAgentDeletionJournalSchema } from "./openclaw-state-db-schema-additive.js";
 import type { DB as OpenClawStateKyselyDatabase } from "./openclaw-state-db.generated.js";
 import { runOpenClawStateWriteTransaction } from "./openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "./openclaw-state-db.paths.js";
@@ -74,23 +77,6 @@ export type AgentDeletionJournalEntry = {
   deleteFiles: boolean;
 };
 
-export function ensureAgentDeletionJournalSchema(database: DatabaseSync): void {
-  database.exec(`
-    CREATE TABLE IF NOT EXISTS agent_deletion_journal (
-      agent_id TEXT PRIMARY KEY,
-      operation_id TEXT NOT NULL DEFAULT '',
-      agent_dir TEXT NOT NULL,
-      workspace_dir TEXT NOT NULL,
-      sessions_dir TEXT NOT NULL,
-      database_paths_json TEXT NOT NULL DEFAULT '[]',
-      cleanup_paths_json TEXT NOT NULL DEFAULT '[]',
-      created_at INTEGER NOT NULL,
-      cleanup_completed INTEGER NOT NULL DEFAULT 0,
-      delete_files INTEGER NOT NULL DEFAULT 1
-    ) STRICT
-  `);
-}
-
 export function prepareAgentDeletionPathFence(
   claim: { agentId: string; path: string; fenceAgentId?: string },
   options: OpenClawStateDatabaseOptions = {},
@@ -149,17 +135,18 @@ export function prepareAgentDeletionPathFence(
         path: databasePath,
         canonicalPath: normalizeAgentDirRegistryPath(databasePath, env),
       })),
-      cleanupPaths: parseCleanupPaths(row.cleanup_paths_json).map((cleanupPath) => ({
-        ...cleanupPath,
-        fencePath: normalizeAgentDirRegistryPath(cleanupPath.canonicalPath, env),
-      })),
+      cleanupPaths: parseCleanupPaths(row.cleanup_paths_json).map((cleanupPath) =>
+        Object.assign({}, cleanupPath, {
+          fencePath: normalizeAgentDirRegistryPath(cleanupPath.canonicalPath, env),
+        }),
+      ),
     })),
   };
 }
 
 /** Refuse database claims beneath paths still owned by an unfinished deletion. */
 export function assertAgentDeletionPathFence(
-  database: DatabaseSync,
+  database: OpenClawStateDatabase["db"],
   snapshot: AgentDeletionPathFenceSnapshot,
 ): void {
   ensureAgentDeletionJournalSchema(database);
@@ -196,7 +183,7 @@ export function assertAgentDeletionPathFence(
         entry.cleanupCompleted ? 1 : 0,
       ].join("\0"),
     )
-    .sort();
+    .toSorted();
   const currentJournal = journalRows
     .map((row) =>
       [
@@ -210,7 +197,7 @@ export function assertAgentDeletionPathFence(
         row.cleanup_completed,
       ].join("\0"),
     )
-    .sort();
+    .toSorted();
   if (snapshotJournal.join("\n") !== currentJournal.join("\n")) {
     throw new Error("Agent deletion journal changed while preparing a database claim.");
   }

--- a/src/state/openclaw-agent-db-lease.ts
+++ b/src/state/openclaw-agent-db-lease.ts
@@ -7,7 +7,11 @@ import {
 } from "../infra/kysely-sync.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import { getFileLockProcessStartTime, isPidDefinitelyDead } from "../shared/pid-alive.js";
-import { ensureAgentDeletionJournalSchema } from "./agent-deletion-journal.js";
+import {
+  assertAgentDeletionPathFence,
+  ensureAgentDeletionJournalSchema,
+  prepareAgentDeletionPathFence,
+} from "./agent-deletion-journal.js";
 import type { OpenClawStateDatabaseOptions } from "./openclaw-state-db-contract.js";
 import type { DB as OpenClawStateKyselyDatabase } from "./openclaw-state-db.generated.js";
 import { runOpenClawStateWriteTransaction } from "./openclaw-state-db.js";
@@ -37,6 +41,10 @@ export function claimOpenClawAgentDatabaseLease(params: {
   env?: NodeJS.ProcessEnv;
 }): string {
   const agentId = normalizeAgentId(params.agentId);
+  const deletionFence = prepareAgentDeletionPathFence(
+    { agentId, path: params.path },
+    { env: params.env },
+  );
   const leaseId = crypto.randomUUID();
   const ownerStartTime = getFileLockProcessStartTime(process.pid);
   runOpenClawStateWriteTransaction(
@@ -52,6 +60,7 @@ export function claimOpenClawAgentDatabaseLease(params: {
           `OpenClaw agent database is unavailable while agent ${agentId} is deleted.`,
         );
       }
+      assertAgentDeletionPathFence(database.db, deletionFence);
       executeSqliteQuerySync(
         database.db,
         db.insertInto("agent_database_leases").values({

--- a/src/state/openclaw-agent-db-lease.ts
+++ b/src/state/openclaw-agent-db-lease.ts
@@ -1,0 +1,134 @@
+import crypto from "node:crypto";
+import type { DatabaseSync } from "node:sqlite";
+import {
+  executeSqliteQuerySync,
+  executeSqliteQueryTakeFirstSync,
+  getNodeSqliteKysely,
+} from "../infra/kysely-sync.js";
+import { normalizeAgentId } from "../routing/session-key.js";
+import { getFileLockProcessStartTime, isPidDefinitelyDead } from "../shared/pid-alive.js";
+import { ensureAgentDeletionJournalSchema } from "./agent-deletion-journal.js";
+import type { OpenClawStateDatabaseOptions } from "./openclaw-state-db-contract.js";
+import type { DB as OpenClawStateKyselyDatabase } from "./openclaw-state-db.generated.js";
+import { runOpenClawStateWriteTransaction } from "./openclaw-state-db.js";
+
+type AgentDatabaseLeaseDatabase = Pick<
+  OpenClawStateKyselyDatabase,
+  "agent_database_leases" | "agent_deletion_journal"
+>;
+
+function ensureAgentDatabaseLeaseSchema(database: DatabaseSync): void {
+  ensureAgentDeletionJournalSchema(database);
+  database.exec(`
+    CREATE TABLE IF NOT EXISTS agent_database_leases (
+      lease_id TEXT PRIMARY KEY,
+      agent_id TEXT NOT NULL,
+      path TEXT NOT NULL,
+      owner_pid INTEGER NOT NULL,
+      owner_start_time INTEGER,
+      opened_at INTEGER NOT NULL
+    ) STRICT
+  `);
+}
+
+export function claimOpenClawAgentDatabaseLease(params: {
+  agentId: string;
+  path: string;
+  env?: NodeJS.ProcessEnv;
+}): string {
+  const agentId = normalizeAgentId(params.agentId);
+  const leaseId = crypto.randomUUID();
+  const ownerStartTime = getFileLockProcessStartTime(process.pid);
+  runOpenClawStateWriteTransaction(
+    (database) => {
+      ensureAgentDatabaseLeaseSchema(database.db);
+      const db = getNodeSqliteKysely<AgentDatabaseLeaseDatabase>(database.db);
+      const deletion = executeSqliteQueryTakeFirstSync(
+        database.db,
+        db.selectFrom("agent_deletion_journal").select("agent_id").where("agent_id", "=", agentId),
+      );
+      if (deletion) {
+        throw new Error(
+          `OpenClaw agent database is unavailable while agent ${agentId} is deleted.`,
+        );
+      }
+      executeSqliteQuerySync(
+        database.db,
+        db.insertInto("agent_database_leases").values({
+          lease_id: leaseId,
+          agent_id: agentId,
+          path: params.path,
+          owner_pid: process.pid,
+          owner_start_time: ownerStartTime,
+          opened_at: Date.now(),
+        }),
+      );
+    },
+    { env: params.env },
+  );
+  return leaseId;
+}
+
+export function releaseOpenClawAgentDatabaseLease(
+  leaseId: string,
+  options: OpenClawStateDatabaseOptions = {},
+): void {
+  runOpenClawStateWriteTransaction((database) => {
+    ensureAgentDatabaseLeaseSchema(database.db);
+    const db = getNodeSqliteKysely<AgentDatabaseLeaseDatabase>(database.db);
+    executeSqliteQuerySync(
+      database.db,
+      db.deleteFrom("agent_database_leases").where("lease_id", "=", leaseId),
+    );
+  }, options);
+}
+
+export function assertNoOpenClawAgentDatabaseLeases(
+  agentIdRaw: string,
+  options: OpenClawStateDatabaseOptions = {},
+): void {
+  const agentId = normalizeAgentId(agentIdRaw);
+  let rows: Array<{
+    lease_id: string;
+    owner_pid: number;
+    owner_start_time: number | null;
+  }> = [];
+  runOpenClawStateWriteTransaction((database) => {
+    ensureAgentDatabaseLeaseSchema(database.db);
+    const db = getNodeSqliteKysely<AgentDatabaseLeaseDatabase>(database.db);
+    rows = executeSqliteQuerySync(
+      database.db,
+      db
+        .selectFrom("agent_database_leases")
+        .select(["lease_id", "owner_pid", "owner_start_time"])
+        .where("agent_id", "=", agentId),
+    ).rows;
+  }, options);
+
+  const staleLeaseIds = rows
+    .filter((row) => {
+      if (isPidDefinitelyDead(row.owner_pid)) {
+        return true;
+      }
+      const currentStartTime = getFileLockProcessStartTime(row.owner_pid);
+      return (
+        row.owner_start_time !== null &&
+        currentStartTime !== null &&
+        row.owner_start_time !== currentStartTime
+      );
+    })
+    .map((row) => row.lease_id);
+  if (staleLeaseIds.length > 0) {
+    runOpenClawStateWriteTransaction((database) => {
+      ensureAgentDatabaseLeaseSchema(database.db);
+      const db = getNodeSqliteKysely<AgentDatabaseLeaseDatabase>(database.db);
+      executeSqliteQuerySync(
+        database.db,
+        db.deleteFrom("agent_database_leases").where("lease_id", "in", staleLeaseIds),
+      );
+    }, options);
+  }
+  if (rows.length > staleLeaseIds.length) {
+    throw new Error(`Agent ${agentId} database is still open in another process.`);
+  }
+}

--- a/src/state/openclaw-agent-db-lease.ts
+++ b/src/state/openclaw-agent-db-lease.ts
@@ -8,6 +8,7 @@ import {
 import { normalizeAgentId } from "../routing/session-key.js";
 import { getFileLockProcessStartTime, isPidDefinitelyDead } from "../shared/pid-alive.js";
 import {
+  assertAgentDeletionIdentityClaimAllowed,
   assertAgentDeletionPathFence,
   ensureAgentDeletionJournalSchema,
   prepareAgentDeletionPathFence,
@@ -55,11 +56,7 @@ export function claimOpenClawAgentDatabaseLease(params: {
         database.db,
         db.selectFrom("agent_deletion_journal").select("agent_id").where("agent_id", "=", agentId),
       );
-      if (deletion) {
-        throw new Error(
-          `OpenClaw agent database is unavailable while agent ${agentId} is deleted.`,
-        );
-      }
+      assertAgentDeletionIdentityClaimAllowed(agentId, deletion?.agent_id);
       assertAgentDeletionPathFence(database.db, deletionFence);
       executeSqliteQuerySync(
         database.db,

--- a/src/state/openclaw-agent-db-lease.ts
+++ b/src/state/openclaw-agent-db-lease.ts
@@ -98,9 +98,11 @@ export function assertNoOpenClawAgentDatabaseLeases(
 ): void {
   const agentId = normalizeAgentId(agentIdRaw);
   let rows: Array<{
+    agent_id: string;
     lease_id: string;
     owner_pid: number;
     owner_start_time: number | null;
+    path: string;
   }> = [];
   runOpenClawStateWriteTransaction((database) => {
     ensureAgentDatabaseLeaseSchema(database.db);
@@ -109,8 +111,7 @@ export function assertNoOpenClawAgentDatabaseLeases(
       database.db,
       db
         .selectFrom("agent_database_leases")
-        .select(["lease_id", "owner_pid", "owner_start_time"])
-        .where("agent_id", "=", agentId),
+        .select(["agent_id", "lease_id", "owner_pid", "owner_start_time", "path"]),
     ).rows;
   }, options);
 
@@ -137,7 +138,33 @@ export function assertNoOpenClawAgentDatabaseLeases(
       );
     }, options);
   }
-  if (rows.length > staleLeaseIds.length) {
-    throw new Error(`Agent ${agentId} database is still open in another process.`);
+  const staleLeaseIdSet = new Set(staleLeaseIds);
+  for (const row of rows) {
+    if (staleLeaseIdSet.has(row.lease_id)) {
+      continue;
+    }
+    const deletionFence = prepareAgentDeletionPathFence(
+      { agentId: row.agent_id, path: row.path, fenceAgentId: agentId },
+      options,
+    );
+    let leaseStillExists = false;
+    runOpenClawStateWriteTransaction((database) => {
+      ensureAgentDatabaseLeaseSchema(database.db);
+      const db = getNodeSqliteKysely<AgentDatabaseLeaseDatabase>(database.db);
+      leaseStillExists =
+        executeSqliteQueryTakeFirstSync(
+          database.db,
+          db
+            .selectFrom("agent_database_leases")
+            .select("lease_id")
+            .where("lease_id", "=", row.lease_id),
+        ) !== undefined;
+      if (leaseStillExists && row.agent_id !== agentId) {
+        assertAgentDeletionPathFence(database.db, deletionFence);
+      }
+    }, options);
+    if (leaseStillExists && row.agent_id === agentId) {
+      throw new Error(`Agent ${agentId} database is still open in another process.`);
+    }
   }
 }

--- a/src/state/openclaw-agent-db-lease.ts
+++ b/src/state/openclaw-agent-db-lease.ts
@@ -1,5 +1,4 @@
 import crypto from "node:crypto";
-import type { DatabaseSync } from "node:sqlite";
 import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
@@ -10,10 +9,10 @@ import { getFileLockProcessStartTime, isPidDefinitelyDead } from "../shared/pid-
 import {
   assertAgentDeletionIdentityClaimAllowed,
   assertAgentDeletionPathFence,
-  ensureAgentDeletionJournalSchema,
   prepareAgentDeletionPathFence,
 } from "./agent-deletion-journal.js";
 import type { OpenClawStateDatabaseOptions } from "./openclaw-state-db-contract.js";
+import { ensureAgentDatabaseLeaseSchema } from "./openclaw-state-db-schema-additive.js";
 import type { DB as OpenClawStateKyselyDatabase } from "./openclaw-state-db.generated.js";
 import { runOpenClawStateWriteTransaction } from "./openclaw-state-db.js";
 
@@ -21,20 +20,6 @@ type AgentDatabaseLeaseDatabase = Pick<
   OpenClawStateKyselyDatabase,
   "agent_database_leases" | "agent_deletion_journal"
 >;
-
-function ensureAgentDatabaseLeaseSchema(database: DatabaseSync): void {
-  ensureAgentDeletionJournalSchema(database);
-  database.exec(`
-    CREATE TABLE IF NOT EXISTS agent_database_leases (
-      lease_id TEXT PRIMARY KEY,
-      agent_id TEXT NOT NULL,
-      path TEXT NOT NULL,
-      owner_pid INTEGER NOT NULL,
-      owner_start_time INTEGER,
-      opened_at INTEGER NOT NULL
-    ) STRICT
-  `);
-}
 
 export function claimOpenClawAgentDatabaseLease(params: {
   agentId: string;

--- a/src/state/openclaw-agent-db-registry.ts
+++ b/src/state/openclaw-agent-db-registry.ts
@@ -1,11 +1,13 @@
 import { existsSync, lstatSync, statSync } from "node:fs";
 import path from "node:path";
+import { normalizeAgentDirRegistryPath } from "../agents/agent-dir-registry.js";
 import {
   clearNodeSqliteKyselyCacheForDatabase,
   executeSqliteQuerySync,
   getNodeSqliteKysely,
 } from "../infra/kysely-sync.js";
 import { requireNodeSqlite } from "../infra/node-sqlite.js";
+import { isPathInside } from "../infra/path-guards.js";
 import { resolveSqliteDatabaseFilePaths } from "../infra/sqlite-files.js";
 import { readSqliteUserVersion } from "../infra/sqlite-user-version.js";
 import { normalizeAgentId } from "../routing/session-key.js";
@@ -25,11 +27,51 @@ import { resolveOpenClawStateSqlitePath } from "./openclaw-state-db.paths.js";
 
 type OpenClawAgentRegistryDatabase = Pick<OpenClawStateKyselyDatabase, "agent_databases">;
 
+const registrationFenceCounts = new Map<string, number>();
+
+function pathsOverlap(left: string, right: string): boolean {
+  return left === right || isPathInside(left, right) || isPathInside(right, left);
+}
+
+function isOpenClawAgentDatabaseRegistrationFenced(pathname: string): boolean {
+  return resolveSqliteDatabaseFilePaths(pathname)
+    .map((filePath) => normalizeAgentDirRegistryPath(filePath))
+    .some((filePath) =>
+      [...registrationFenceCounts.keys()].some((fence) => pathsOverlap(filePath, fence)),
+    );
+}
+
+/** Fence process-local database claims while agent paths are moved to Trash. */
+export function beginOpenClawAgentDatabaseRegistrationFence(paths: readonly string[]): () => void {
+  const fences = [...new Set(paths.map((pathname) => normalizeAgentDirRegistryPath(pathname)))];
+  for (const fence of fences) {
+    registrationFenceCounts.set(fence, (registrationFenceCounts.get(fence) ?? 0) + 1);
+  }
+  let released = false;
+  return () => {
+    if (released) {
+      return;
+    }
+    released = true;
+    for (const fence of fences) {
+      const count = registrationFenceCounts.get(fence) ?? 0;
+      if (count <= 1) {
+        registrationFenceCounts.delete(fence);
+      } else {
+        registrationFenceCounts.set(fence, count - 1);
+      }
+    }
+  };
+}
+
 export function registerOpenClawAgentDatabase(params: {
   agentId: string;
   path: string;
   env?: NodeJS.ProcessEnv;
 }): void {
+  if (isOpenClawAgentDatabaseRegistrationFenced(params.path)) {
+    throw new Error(`OpenClaw agent database ${params.path} is being deleted.`);
+  }
   let sizeBytes: number | null = null;
   try {
     sizeBytes = statSync(params.path).size;

--- a/src/state/openclaw-agent-db-registry.ts
+++ b/src/state/openclaw-agent-db-registry.ts
@@ -1,16 +1,18 @@
 import { existsSync, lstatSync, statSync } from "node:fs";
 import path from "node:path";
-import { normalizeAgentDirRegistryPath } from "../agents/agent-dir-registry.js";
 import {
   clearNodeSqliteKyselyCacheForDatabase,
   executeSqliteQuerySync,
   getNodeSqliteKysely,
 } from "../infra/kysely-sync.js";
 import { requireNodeSqlite } from "../infra/node-sqlite.js";
-import { isPathInside } from "../infra/path-guards.js";
 import { resolveSqliteDatabaseFilePaths } from "../infra/sqlite-files.js";
 import { readSqliteUserVersion } from "../infra/sqlite-user-version.js";
 import { normalizeAgentId } from "../routing/session-key.js";
+import {
+  assertAgentDeletionPathFence,
+  prepareAgentDeletionPathFence,
+} from "./agent-deletion-journal.js";
 import {
   OPENCLAW_AGENT_SCHEMA_VERSION,
   type OpenClawRegisteredAgentDatabase,
@@ -27,51 +29,15 @@ import { resolveOpenClawStateSqlitePath } from "./openclaw-state-db.paths.js";
 
 type OpenClawAgentRegistryDatabase = Pick<OpenClawStateKyselyDatabase, "agent_databases">;
 
-const registrationFenceCounts = new Map<string, number>();
-
-function pathsOverlap(left: string, right: string): boolean {
-  return left === right || isPathInside(left, right) || isPathInside(right, left);
-}
-
-function isOpenClawAgentDatabaseRegistrationFenced(pathname: string): boolean {
-  return resolveSqliteDatabaseFilePaths(pathname)
-    .map((filePath) => normalizeAgentDirRegistryPath(filePath))
-    .some((filePath) =>
-      [...registrationFenceCounts.keys()].some((fence) => pathsOverlap(filePath, fence)),
-    );
-}
-
-/** Fence process-local database claims while agent paths are moved to Trash. */
-export function beginOpenClawAgentDatabaseRegistrationFence(paths: readonly string[]): () => void {
-  const fences = [...new Set(paths.map((pathname) => normalizeAgentDirRegistryPath(pathname)))];
-  for (const fence of fences) {
-    registrationFenceCounts.set(fence, (registrationFenceCounts.get(fence) ?? 0) + 1);
-  }
-  let released = false;
-  return () => {
-    if (released) {
-      return;
-    }
-    released = true;
-    for (const fence of fences) {
-      const count = registrationFenceCounts.get(fence) ?? 0;
-      if (count <= 1) {
-        registrationFenceCounts.delete(fence);
-      } else {
-        registrationFenceCounts.set(fence, count - 1);
-      }
-    }
-  };
-}
-
 export function registerOpenClawAgentDatabase(params: {
   agentId: string;
   path: string;
   env?: NodeJS.ProcessEnv;
 }): void {
-  if (isOpenClawAgentDatabaseRegistrationFenced(params.path)) {
-    throw new Error(`OpenClaw agent database ${params.path} is being deleted.`);
-  }
+  const deletionFence = prepareAgentDeletionPathFence(
+    { agentId: params.agentId, path: params.path },
+    { env: params.env },
+  );
   let sizeBytes: number | null = null;
   try {
     sizeBytes = statSync(params.path).size;
@@ -81,6 +47,7 @@ export function registerOpenClawAgentDatabase(params: {
   const lastSeenAt = Date.now();
   runOpenClawStateWriteTransaction(
     (database) => {
+      assertAgentDeletionPathFence(database.db, deletionFence);
       const db = getNodeSqliteKysely<OpenClawAgentRegistryDatabase>(database.db);
       executeSqliteQuerySync(
         database.db,

--- a/src/state/openclaw-agent-db.test.ts
+++ b/src/state/openclaw-agent-db.test.ts
@@ -19,13 +19,16 @@ import { listOpenFileDescriptorsForPath } from "../infra/open-file-descriptors.t
 import { readSqliteNumberPragma } from "../infra/sqlite-pragma.test-support.js";
 import { VERSION } from "../version.js";
 import {
+  assertAgentDeletionPathFence,
+  prepareAgentDeletionPathFence,
+} from "./agent-deletion-journal.js";
+import {
   assertNoOpenClawAgentDatabaseLeases,
   claimOpenClawAgentDatabaseLease,
   releaseOpenClawAgentDatabaseLease,
 } from "./openclaw-agent-db-lease.js";
 import { withOpenClawAgentDatabaseReadOnly } from "./openclaw-agent-db-readonly.js";
 import {
-  beginOpenClawAgentDatabaseRegistrationFence,
   registerOpenClawAgentDatabase,
   unregisterOpenClawAgentDatabase,
 } from "./openclaw-agent-db-registry.js";
@@ -48,6 +51,7 @@ import {
   closeOpenClawStateDatabaseForTest,
   OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,
   openOpenClawStateDatabase,
+  runOpenClawStateWriteTransaction,
 } from "./openclaw-state-db.js";
 import {
   collectSqliteSchemaShape,
@@ -416,25 +420,88 @@ afterEach(() => {
 });
 
 describe("openclaw agent database", () => {
-  it("fences database registration while a parent path is being deleted", () => {
+  it("fences registration and lease claims beneath another agent's pending deletion", () => {
     const stateDir = createTempStateDir();
     const env = { OPENCLAW_STATE_DIR: stateDir };
     const agentDir = path.join(stateDir, "agents", "deleted", "agent");
-    const databasePath = path.join(agentDir, "openclaw-agent.sqlite");
-    const release = beginOpenClawAgentDatabaseRegistrationFence([agentDir]);
+    const linkedAgentDir = path.join(stateDir, "linked-deleted-agent");
+    fs.mkdirSync(agentDir, { recursive: true });
+    fs.symlinkSync(agentDir, linkedAgentDir, "dir");
+    const databasePath = path.join(agentDir, "nested", "survivor.sqlite");
+    const relocatedDatabasePath = path.join(stateDir, "relocated", "deleted.sqlite");
+    const sidecarClaimPath = path.join(stateDir, "sidecar", "shared.sqlite");
+    const registeredSidecarPath = `${sidecarClaimPath}-wal`;
+    registerOpenClawAgentDatabase({
+      agentId: "deleted",
+      path: relocatedDatabasePath,
+      env,
+    });
+    registerOpenClawAgentDatabase({ agentId: "deleted", path: registeredSidecarPath, env });
+    const deletion = beginAgentDeletion(
+      {
+        agentId: "deleted",
+        agentDir: linkedAgentDir,
+        workspaceDir: path.join(stateDir, "workspace-deleted"),
+        sessionsDir: path.join(stateDir, "sessions-deleted"),
+      },
+      { env },
+    );
+
+    unregisterOpenClawAgentDatabase({ agentId: "deleted", path: relocatedDatabasePath, env });
+    unregisterOpenClawAgentDatabase({ agentId: "deleted", path: registeredSidecarPath, env });
 
     try {
-      expect(() =>
-        registerOpenClawAgentDatabase({ agentId: "survivor", path: databasePath, env }),
-      ).toThrow("is being deleted");
+      for (const fencedPath of [databasePath, relocatedDatabasePath, sidecarClaimPath]) {
+        expect(() =>
+          registerOpenClawAgentDatabase({ agentId: "survivor", path: fencedPath, env }),
+        ).toThrow("deletion owns");
+        expect(() =>
+          claimOpenClawAgentDatabaseLease({ agentId: "survivor", path: fencedPath, env }),
+        ).toThrow("deletion owns");
+      }
     } finally {
-      release();
+      deletion.rollback();
     }
 
     expect(() =>
       registerOpenClawAgentDatabase({ agentId: "survivor", path: databasePath, env }),
     ).not.toThrow();
+    const leaseId = claimOpenClawAgentDatabaseLease({
+      agentId: "survivor",
+      path: databasePath,
+      env,
+    });
+    releaseOpenClawAgentDatabaseLease(leaseId, { env });
     unregisterOpenClawAgentDatabase({ agentId: "survivor", path: databasePath, env });
+  });
+
+  it("rejects a database claim prepared before deletion cleanup completes", () => {
+    const stateDir = createTempStateDir();
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const agentDir = path.join(stateDir, "agents", "deleted", "agent");
+    const databasePath = path.join(agentDir, "survivor.sqlite");
+    const deletion = beginAgentDeletion(
+      {
+        agentId: "deleted",
+        agentDir,
+        workspaceDir: path.join(stateDir, "workspace-deleted"),
+        sessionsDir: path.join(stateDir, "sessions-deleted"),
+      },
+      { env },
+    );
+    const fence = prepareAgentDeletionPathFence(
+      { agentId: "survivor", path: databasePath },
+      { env },
+    );
+
+    deletion.finish();
+
+    expect(() =>
+      runOpenClawStateWriteTransaction(
+        (database) => assertAgentDeletionPathFence(database.db, fence),
+        { env },
+      ),
+    ).toThrow("deletion journal changed");
   });
 
   it("resolves under the per-agent state directory", () => {

--- a/src/state/openclaw-agent-db.test.ts
+++ b/src/state/openclaw-agent-db.test.ts
@@ -24,6 +24,11 @@ import {
   releaseOpenClawAgentDatabaseLease,
 } from "./openclaw-agent-db-lease.js";
 import { withOpenClawAgentDatabaseReadOnly } from "./openclaw-agent-db-readonly.js";
+import {
+  beginOpenClawAgentDatabaseRegistrationFence,
+  registerOpenClawAgentDatabase,
+  unregisterOpenClawAgentDatabase,
+} from "./openclaw-agent-db-registry.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "./openclaw-agent-db.generated.js";
 import {
   assertOpenClawAgentDatabaseForMaintenance,
@@ -411,6 +416,27 @@ afterEach(() => {
 });
 
 describe("openclaw agent database", () => {
+  it("fences database registration while a parent path is being deleted", () => {
+    const stateDir = createTempStateDir();
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const agentDir = path.join(stateDir, "agents", "deleted", "agent");
+    const databasePath = path.join(agentDir, "openclaw-agent.sqlite");
+    const release = beginOpenClawAgentDatabaseRegistrationFence([agentDir]);
+
+    try {
+      expect(() =>
+        registerOpenClawAgentDatabase({ agentId: "survivor", path: databasePath, env }),
+      ).toThrow("is being deleted");
+    } finally {
+      release();
+    }
+
+    expect(() =>
+      registerOpenClawAgentDatabase({ agentId: "survivor", path: databasePath, env }),
+    ).not.toThrow();
+    unregisterOpenClawAgentDatabase({ agentId: "survivor", path: databasePath, env });
+  });
+
   it("resolves under the per-agent state directory", () => {
     const stateDir = createTempStateDir();
 

--- a/src/state/openclaw-agent-db.test.ts
+++ b/src/state/openclaw-agent-db.test.ts
@@ -508,6 +508,32 @@ describe("openclaw agent database", () => {
     unregisterOpenClawAgentDatabase({ agentId: "survivor", path: databasePath, env });
   });
 
+  it("blocks deletion on a foreign lease beneath its workspace until release", () => {
+    const stateDir = createTempStateDir();
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const workspaceDir = path.join(stateDir, "workspace-deleted");
+    const foreignDatabasePath = path.join(workspaceDir, "nested", "survivor.sqlite");
+    const leaseId = claimOpenClawAgentDatabaseLease({
+      agentId: "survivor",
+      path: foreignDatabasePath,
+      env,
+    });
+    const deletion = beginAgentDeletion(
+      {
+        agentId: "deleted",
+        agentDir: path.join(stateDir, "agents", "deleted", "agent"),
+        workspaceDir,
+        sessionsDir: path.join(stateDir, "sessions-deleted"),
+      },
+      { env },
+    );
+
+    expect(() => assertNoOpenClawAgentDatabaseLeases("deleted", { env })).toThrow("deletion owns");
+    releaseOpenClawAgentDatabaseLease(leaseId, { env });
+    expect(() => assertNoOpenClawAgentDatabaseLeases("deleted", { env })).not.toThrow();
+    deletion.rollback();
+  });
+
   it("rejects a database claim prepared before deletion cleanup completes", () => {
     const stateDir = createTempStateDir();
     const env = { OPENCLAW_STATE_DIR: stateDir };

--- a/src/state/openclaw-agent-db.test.ts
+++ b/src/state/openclaw-agent-db.test.ts
@@ -53,6 +53,7 @@ import {
   openOpenClawStateDatabase,
   runOpenClawStateWriteTransaction,
 } from "./openclaw-state-db.js";
+import { resolveOpenClawStateSqlitePath } from "./openclaw-state-db.paths.js";
 import {
   collectSqliteSchemaShape,
   createSqliteSchemaShapeFromSql,
@@ -420,6 +421,38 @@ afterEach(() => {
 });
 
 describe("openclaw agent database", () => {
+  it("uses the canonical state schema for deletion journal reads and updates", () => {
+    const stateDir = createTempStateDir();
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const stateDatabasePath = resolveOpenClawStateSqlitePath(env);
+    fs.mkdirSync(path.dirname(stateDatabasePath), { recursive: true });
+    const { DatabaseSync } = requireNodeSqlite();
+    const stateDatabase = new DatabaseSync(stateDatabasePath);
+    stateDatabase.exec(
+      fs.readFileSync(new URL("./openclaw-state-schema.sql", import.meta.url), "utf8"),
+    );
+    stateDatabase.close();
+
+    const entry = {
+      agentId: "deleted",
+      agentDir: path.join(stateDir, "agents", "deleted", "agent"),
+      workspaceDir: path.join(stateDir, "workspace-deleted"),
+      sessionsDir: path.join(stateDir, "sessions-deleted"),
+    };
+    const deletion = beginAgentDeletion(entry, { env });
+    const databasePaths = [path.join(entry.agentDir, "openclaw-agent.sqlite")];
+    const cleanupPaths = [
+      { path: entry.agentDir, kind: "target" as const, sourcePaths: [entry.agentDir] },
+    ];
+    deletion.fenceDatabasePaths(databasePaths);
+    deletion.fenceCleanupPaths(cleanupPaths);
+
+    const recovery = beginAgentDeletion(entry, { env });
+    expect(recovery.entry.databasePaths).toEqual(databasePaths);
+    expect(recovery.entry.cleanupPaths).toEqual(cleanupPaths);
+    recovery.rollback();
+  });
+
   it("fences registration and lease claims beneath another agent's pending deletion", () => {
     const stateDir = createTempStateDir();
     const env = { OPENCLAW_STATE_DIR: stateDir };
@@ -1134,6 +1167,31 @@ describe("openclaw agent database", () => {
       }),
     ).toThrow("file is not a database");
     expect(listOpenFileDescriptorsForPath(databasePath)).toEqual([]);
+  });
+
+  it("retains a failed-open handle and lease when initialization cleanup also fails", () => {
+    const stateDir = createTempStateDir();
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const database = openOpenClawAgentDatabase({ agentId: "worker-1", env });
+    expect(closeOpenClawAgentDatabaseByPath(database.path)).toBe(true);
+    const { DatabaseSync } = requireNodeSqlite();
+    const close = vi.spyOn(DatabaseSync.prototype, "close").mockImplementationOnce(() => {
+      throw new Error("initialization close failed");
+    });
+
+    expect(() =>
+      openOpenClawAgentDatabase({ agentId: "worker-2", env, path: database.path }),
+    ).toThrow("initialization close failed");
+    close.mockRestore();
+    expect(() => assertNoOpenClawAgentDatabaseLeases("worker-2", { env })).toThrow(
+      "database is still open",
+    );
+    expect(() =>
+      openOpenClawAgentDatabase({ agentId: "worker-2", env, path: database.path }),
+    ).toThrow("initialization close failed");
+
+    expect(disposeOpenClawAgentDatabaseByPath(database.path, { env })).toBe(true);
+    expect(() => assertNoOpenClawAgentDatabaseLeases("worker-2", { env })).not.toThrow();
   });
 
   it("keeps multiple registered paths for the same agent", () => {

--- a/src/state/openclaw-agent-db.test.ts
+++ b/src/state/openclaw-agent-db.test.ts
@@ -442,7 +442,17 @@ describe("openclaw agent database", () => {
     const deletion = beginAgentDeletion(entry, { env });
     const databasePaths = [path.join(entry.agentDir, "openclaw-agent.sqlite")];
     const cleanupPaths = [
-      { path: entry.agentDir, kind: "target" as const, sourcePaths: [entry.agentDir] },
+      {
+        path: entry.agentDir,
+        canonicalPath: entry.agentDir,
+        parentPath: path.dirname(entry.agentDir),
+        kind: "target" as const,
+        sourcePaths: [entry.agentDir],
+        dev: null,
+        ino: null,
+        coversDescendants: true,
+        done: false,
+      },
     ];
     deletion.fenceDatabasePaths(databasePaths);
     deletion.fenceCleanupPaths(cleanupPaths);
@@ -1553,6 +1563,37 @@ describe("openclaw agent database", () => {
     } finally {
       deletion.finish();
     }
+  });
+
+  it("keeps the deleted id fenced until its completed tombstone is claimed", () => {
+    const stateDir = createTempStateDir();
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const agentDir = path.join(stateDir, "agents", "worker-1", "agent");
+    const databasePath = path.join(agentDir, "openclaw-agent.sqlite");
+    const deletion = beginAgentDeletion(
+      {
+        agentId: "worker-1",
+        agentDir,
+        workspaceDir: path.join(stateDir, "workspace-worker-1"),
+        sessionsDir: path.join(stateDir, "sessions-worker-1"),
+      },
+      { env },
+    );
+    deletion.finish();
+
+    expect(() =>
+      registerOpenClawAgentDatabase({ agentId: "worker-1", path: databasePath, env }),
+    ).toThrow("agent worker-1 is deleted");
+    expect(() =>
+      registerOpenClawAgentDatabase({ agentId: "worker-2", path: databasePath, env }),
+    ).not.toThrow();
+    unregisterOpenClawAgentDatabase({ agentId: "worker-2", path: databasePath, env });
+
+    expect(claimCompletedAgentDeletion("worker-1", deletion.entry.operationId, { env })).toBe(true);
+    expect(() =>
+      registerOpenClawAgentDatabase({ agentId: "worker-1", path: databasePath, env }),
+    ).not.toThrow();
+    unregisterOpenClawAgentDatabase({ agentId: "worker-1", path: databasePath, env });
   });
 
   it("serializes database leases with the durable deletion fence", () => {

--- a/src/state/openclaw-agent-db.test.ts
+++ b/src/state/openclaw-agent-db.test.ts
@@ -6,6 +6,10 @@ import path from "node:path";
 import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
 import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
 import {
+  beginAgentDeletion,
+  claimCompletedAgentDeletion,
+} from "../agents/agent-lifecycle-registry.js";
+import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
@@ -14,6 +18,11 @@ import { requireNodeSqlite } from "../infra/node-sqlite.js";
 import { listOpenFileDescriptorsForPath } from "../infra/open-file-descriptors.test-support.js";
 import { readSqliteNumberPragma } from "../infra/sqlite-pragma.test-support.js";
 import { VERSION } from "../version.js";
+import {
+  assertNoOpenClawAgentDatabaseLeases,
+  claimOpenClawAgentDatabaseLease,
+  releaseOpenClawAgentDatabaseLease,
+} from "./openclaw-agent-db-lease.js";
 import { withOpenClawAgentDatabaseReadOnly } from "./openclaw-agent-db-readonly.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "./openclaw-agent-db.generated.js";
 import {
@@ -961,7 +970,7 @@ describe("openclaw agent database", () => {
     ]);
   });
 
-  it("rolls back a failed version 1 migration without claiming version 2", () => {
+  it("rolls back a failed version 1 migration without retaining ownership", () => {
     const stateDir = createTempStateDir();
     const env = { OPENCLAW_STATE_DIR: stateDir };
     const databasePath = path.join(
@@ -975,8 +984,12 @@ describe("openclaw agent database", () => {
 
     expect(() => openOpenClawAgentDatabase({ agentId: "worker-1", env })).toThrow();
 
-    const stateDatabasePath = path.join(stateDir, "state", "openclaw.sqlite");
-    expect(fs.existsSync(stateDatabasePath)).toBe(false);
+    expect(listOpenClawRegisteredAgentDatabases({ env })).toEqual([]);
+    expect(
+      openOpenClawStateDatabase({ env })
+        .db.prepare("SELECT COUNT(*) AS count FROM agent_database_leases")
+        .get(),
+    ).toEqual({ count: 0 });
     const { DatabaseSync } = requireNodeSqlite();
     const db = new DatabaseSync(databasePath);
     try {
@@ -1278,6 +1291,25 @@ describe("openclaw agent database", () => {
     expect(second.db.isOpen).toBe(true);
   });
 
+  it("retains its durable lease when closing the handle fails", () => {
+    const stateDir = createTempStateDir();
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const database = openOpenClawAgentDatabase({ agentId: "worker-1", env });
+    const close = vi.spyOn(database.walMaintenance, "close").mockImplementationOnce(() => {
+      throw new Error("wal close failed");
+    });
+
+    expect(() => closeOpenClawAgentDatabaseByPath(database.path)).toThrow("wal close failed");
+    expect(database.db.isOpen).toBe(true);
+    expect(() => assertNoOpenClawAgentDatabaseLeases("worker-1", { env })).toThrow(
+      "database is still open",
+    );
+
+    close.mockRestore();
+    expect(closeOpenClawAgentDatabaseByPath(database.path)).toBe(true);
+    expect(() => assertNoOpenClawAgentDatabaseLeases("worker-1", { env })).not.toThrow();
+  });
+
   it("disposes only its exact cached owner and unregisters that registry row", () => {
     const stateDir = createTempStateDir();
     const env = { OPENCLAW_STATE_DIR: stateDir };
@@ -1302,6 +1334,81 @@ describe("openclaw agent database", () => {
       expect.objectContaining({ agentId: "worker-1", path: reopened.path }),
       expect.objectContaining({ agentId: "worker-2", path: second.path }),
     ]);
+  });
+
+  it("reopens a recreated agent id on a fresh database after archival", () => {
+    const stateDir = createTempStateDir();
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const original = openOpenClawAgentDatabase({ agentId: "worker-1", env });
+    const originalInode = fs.statSync(original.path).ino;
+    const archivedDir = path.join(stateDir, "trash", "worker-1-agent");
+    const deletion = beginAgentDeletion(
+      {
+        agentId: "worker-1",
+        agentDir: path.dirname(original.path),
+        workspaceDir: path.join(stateDir, "workspace-worker-1"),
+        sessionsDir: path.join(stateDir, "sessions-worker-1"),
+      },
+      { env },
+    );
+    try {
+      expect(disposeOpenClawAgentDatabaseByPath(original.path, { env })).toBe(true);
+      deletion.commit();
+      expect(original.db.isOpen).toBe(false);
+      expect(listOpenClawRegisteredAgentDatabases({ env })).toEqual([]);
+      fs.mkdirSync(path.dirname(archivedDir), { recursive: true });
+      fs.renameSync(path.dirname(original.path), archivedDir);
+      expect(() => openOpenClawAgentDatabase({ agentId: "worker-1", env })).toThrow(
+        "agent worker-1 is deleted",
+      );
+
+      deletion.finish();
+      expect(claimCompletedAgentDeletion("worker-1", deletion.entry.operationId, { env })).toBe(
+        true,
+      );
+      const recreated = openOpenClawAgentDatabase({ agentId: "worker-1", env });
+      expect(recreated.db.isOpen).toBe(true);
+      expect(fs.statSync(recreated.path).ino).not.toBe(originalInode);
+      expect(fs.existsSync(path.join(archivedDir, "openclaw-agent.sqlite"))).toBe(true);
+      expect(listOpenClawRegisteredAgentDatabases({ env })).toEqual([
+        expect.objectContaining({ agentId: "worker-1", path: recreated.path }),
+      ]);
+    } finally {
+      deletion.finish();
+    }
+  });
+
+  it("serializes database leases with the durable deletion fence", () => {
+    const stateDir = createTempStateDir();
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const databasePath = path.join(stateDir, "agents", "worker-1", "openclaw-agent.sqlite");
+    const leaseId = claimOpenClawAgentDatabaseLease({
+      agentId: "worker-1",
+      path: databasePath,
+      env,
+    });
+    const deletion = beginAgentDeletion(
+      {
+        agentId: "worker-1",
+        agentDir: path.dirname(databasePath),
+        workspaceDir: path.join(stateDir, "workspace-worker-1"),
+        sessionsDir: path.join(stateDir, "sessions-worker-1"),
+      },
+      { env },
+    );
+    try {
+      expect(() => assertNoOpenClawAgentDatabaseLeases("worker-1", { env })).toThrow(
+        "database is still open",
+      );
+      expect(() =>
+        claimOpenClawAgentDatabaseLease({ agentId: "worker-1", path: databasePath, env }),
+      ).toThrow("agent worker-1 is deleted");
+      releaseOpenClawAgentDatabaseLease(leaseId, { env });
+      expect(() => assertNoOpenClawAgentDatabaseLeases("worker-1", { env })).not.toThrow();
+    } finally {
+      releaseOpenClawAgentDatabaseLease(leaseId, { env });
+      deletion.rollback();
+    }
   });
 
   it("serializes concurrent ownership claims for one unowned database", async () => {

--- a/src/state/openclaw-agent-db.ts
+++ b/src/state/openclaw-agent-db.ts
@@ -21,6 +21,10 @@ import type {
   OpenClawAgentDatabaseOptions,
   OpenClawAgentDatabaseOwnerInspection,
 } from "./openclaw-agent-db-contract.js";
+import {
+  claimOpenClawAgentDatabaseLease,
+  releaseOpenClawAgentDatabaseLease,
+} from "./openclaw-agent-db-lease.js";
 import { ensureOpenClawAgentDatabasePermissions } from "./openclaw-agent-db-permissions.js";
 import {
   registerOpenClawAgentDatabase,
@@ -75,6 +79,10 @@ const OPENCLAW_AGENT_DB_SLOW_OPEN_MS = 1_000;
 export const OPENCLAW_AGENT_DB_OPEN_HANDLE_CAP = 64;
 const agentDbLog = createSubsystemLogger("state/agent-db");
 const cachedDatabases = new Map<string, OpenClawAgentDatabase>();
+const cachedDatabaseLeases = new Map<
+  string,
+  { leaseId: string; env: NodeJS.ProcessEnv | undefined }
+>();
 // External schema changes under a live process are unsupported: doctor migrations
 // require restart, so successful owner/schema validation is process-stable.
 const validatedAgentDatabasePaths = new Map<string, string>();
@@ -191,79 +199,93 @@ export function openOpenClawAgentDatabase(
   }
   if (cached) {
     // A closed handle can leave Kysely and WAL helpers cached; clear both before reopening.
-    cached.walMaintenance.close();
-    clearNodeSqliteKyselyCacheForDatabase(cached.db);
+    closeCachedOpenClawAgentDatabase(cached);
     cachedDatabases.delete(pathname);
   }
-  const openStartedAt = Date.now();
-  ensureOpenClawAgentDatabasePermissions(pathname, databaseOptions);
-  // Free a slot before constructing the new handle: under real descriptor
-  // pressure the 65th open would otherwise fail before eviction could run.
-  evictLruAgentDatabaseHandles();
-  const sqlite = requireNodeSqlite();
-  const db = new sqlite.DatabaseSync(pathname);
-  // Eviction churn must avoid schema/registry busy waits on the event loop while
-  // reconcile workers hold write transactions on these same agent databases.
-  const isValidatedReopen = validatedAgentDatabasePaths.get(pathname) === agentId;
-  const walMaintenance = (() => {
-    let maintenance: OpenClawAgentDatabase["walMaintenance"] | undefined;
-    try {
-      db.exec(`PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS};`);
-      if (!isValidatedReopen) {
-        assertSupportedAgentSchemaVersion(db, pathname);
-        assertExistingAgentSchemaOwner(readExistingAgentSchemaMeta(db), agentId, pathname);
-      }
-      // Integrity is not process-stable: the file can be damaged while evicted.
-      // This guard is read-only (no busy waits), so every physical open pays it.
-      assertAgentDatabaseIntegrityBeforeMutation(db, pathname);
-      configureSqlitePreSchemaPragmas(db, {
-        busyTimeoutMs: OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,
-      });
-      maintenance = configureSqliteConnectionPragmas(db, {
-        busyTimeoutMs: OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,
-        databaseLabel: `openclaw-agent:${agentId}`,
-        databasePath: pathname,
-        foreignKeys: true,
-        synchronous: "NORMAL",
-      });
-      if (!isValidatedReopen) {
-        ensureOpenClawAgentSchema(db, agentId, pathname);
-      }
-      return maintenance;
-    } catch (err) {
-      maintenance?.close();
-      db.close();
-      if (
-        err instanceof Error &&
-        (err.name === "SqliteSchemaVersionError" || isTerminalSqliteIntegrityError(err))
-      ) {
-        recordOpenClawAgentDatabaseOpenFailure(pathname, err);
-      }
-      throw err;
-    }
-  })();
-  ensureOpenClawAgentDatabasePermissions(pathname, databaseOptions);
-  const database = { agentId, db, path: pathname, walMaintenance };
-  if (!isValidatedReopen) {
-    try {
-      registerOpenClawAgentDatabase({ agentId, path: pathname, env: options.env });
-    } catch (error) {
-      closeCachedOpenClawAgentDatabase(database);
-      throw error;
-    }
-    validatedAgentDatabasePaths.set(pathname, agentId);
-  }
-  cachedDatabases.set(pathname, database);
-  terminalOpenLatch.clear(pathname);
-  // Safety net for processes that end without an orderly close: agent DBs have
-  // no shutdown owner like the ACP/gateway state DB closes. Closing unregisters.
-  unregisterExitClose ??= registerSqliteCacheExitClose(closeOpenClawAgentDatabases);
-  logSlowAgentDatabaseOpen({
+  const leaseId = claimOpenClawAgentDatabaseLease({
     agentId,
-    elapsedMs: Date.now() - openStartedAt,
     path: pathname,
+    ...(options.env ? { env: options.env } : {}),
   });
-  return database;
+  const openStartedAt = Date.now();
+  let openedDb: DatabaseSync | undefined;
+  let openedDatabase: OpenClawAgentDatabase | undefined;
+  try {
+    ensureOpenClawAgentDatabasePermissions(pathname, databaseOptions);
+    // Free a slot before constructing the new handle: under real descriptor
+    // pressure the 65th open would otherwise fail before eviction could run.
+    evictLruAgentDatabaseHandles();
+    const sqlite = requireNodeSqlite();
+    const db = new sqlite.DatabaseSync(pathname);
+    openedDb = db;
+    // Eviction churn must avoid schema/registry busy waits on the event loop while
+    // reconcile workers hold write transactions on these same agent databases.
+    const isValidatedReopen = validatedAgentDatabasePaths.get(pathname) === agentId;
+    const walMaintenance = (() => {
+      let maintenance: OpenClawAgentDatabase["walMaintenance"] | undefined;
+      try {
+        db.exec(`PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS};`);
+        if (!isValidatedReopen) {
+          assertSupportedAgentSchemaVersion(db, pathname);
+          assertExistingAgentSchemaOwner(readExistingAgentSchemaMeta(db), agentId, pathname);
+        }
+        // Integrity is not process-stable: the file can be damaged while evicted.
+        // This guard is read-only (no busy waits), so every physical open pays it.
+        assertAgentDatabaseIntegrityBeforeMutation(db, pathname);
+        configureSqlitePreSchemaPragmas(db, {
+          busyTimeoutMs: OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,
+        });
+        maintenance = configureSqliteConnectionPragmas(db, {
+          busyTimeoutMs: OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,
+          databaseLabel: `openclaw-agent:${agentId}`,
+          databasePath: pathname,
+          foreignKeys: true,
+          synchronous: "NORMAL",
+        });
+        if (!isValidatedReopen) {
+          ensureOpenClawAgentSchema(db, agentId, pathname);
+        }
+        return maintenance;
+      } catch (err) {
+        maintenance?.close();
+        db.close();
+        if (
+          err instanceof Error &&
+          (err.name === "SqliteSchemaVersionError" || isTerminalSqliteIntegrityError(err))
+        ) {
+          recordOpenClawAgentDatabaseOpenFailure(pathname, err);
+        }
+        throw err;
+      }
+    })();
+    ensureOpenClawAgentDatabasePermissions(pathname, databaseOptions);
+    const database = { agentId, db, path: pathname, walMaintenance };
+    openedDatabase = database;
+    if (!isValidatedReopen) {
+      registerOpenClawAgentDatabase({ agentId, path: pathname, env: options.env });
+      validatedAgentDatabasePaths.set(pathname, agentId);
+    }
+    terminalOpenLatch.clear(pathname);
+    // Safety net for processes that end without an orderly close: agent DBs have
+    // no shutdown owner like the ACP/gateway state DB closes. Closing unregisters.
+    unregisterExitClose ??= registerSqliteCacheExitClose(closeOpenClawAgentDatabases);
+    logSlowAgentDatabaseOpen({
+      agentId,
+      elapsedMs: Date.now() - openStartedAt,
+      path: pathname,
+    });
+    cachedDatabaseLeases.set(pathname, { leaseId, env: options.env });
+    cachedDatabases.set(pathname, database);
+    return database;
+  } catch (error) {
+    if (openedDatabase) {
+      closeCachedOpenClawAgentDatabase(openedDatabase);
+    }
+    if (!openedDb?.isOpen) {
+      releaseOpenClawAgentDatabaseLease(leaseId, { env: options.env });
+    }
+    throw error;
+  }
 }
 
 /** Run a synchronous immediate transaction against an agent database. */
@@ -347,6 +369,11 @@ function closeCachedOpenClawAgentDatabase(
   clearNodeSqliteKyselyCacheForDatabase(database.db);
   if (database.db.isOpen) {
     database.db.close();
+  }
+  const lease = cachedDatabaseLeases.get(database.path);
+  if (lease) {
+    releaseOpenClawAgentDatabaseLease(lease.leaseId, { env: lease.env });
+    cachedDatabaseLeases.delete(database.path);
   }
 }
 

--- a/src/state/openclaw-agent-db.ts
+++ b/src/state/openclaw-agent-db.ts
@@ -13,6 +13,7 @@ import {
   configureSqliteConnectionPragmas,
   configureSqlitePreSchemaPragmas,
   registerSqliteCacheExitClose,
+  type SqliteWalMaintenance,
 } from "../infra/sqlite-wal.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { normalizeAgentId } from "../routing/session-key.js";
@@ -79,6 +80,7 @@ const OPENCLAW_AGENT_DB_SLOW_OPEN_MS = 1_000;
 export const OPENCLAW_AGENT_DB_OPEN_HANDLE_CAP = 64;
 const agentDbLog = createSubsystemLogger("state/agent-db");
 const cachedDatabases = new Map<string, OpenClawAgentDatabase>();
+const cachedDatabaseOpenFailures = new Map<string, unknown>();
 const cachedDatabaseLeases = new Map<
   string,
   { leaseId: string; env: NodeJS.ProcessEnv | undefined }
@@ -160,10 +162,12 @@ export function openOpenClawAgentDatabase(
   const agentId = normalizeAgentId(options.agentId);
   const databaseOptions = { ...options, agentId };
   const pathname = resolveOpenClawAgentSqlitePath(databaseOptions);
-  // A live cached handle is authoritative: the recorder closes handles when it
-  // latches, so a cache hit implies the path is not quarantined in this process.
+  // A live successful cache entry is authoritative; failed entries remain only for disposal.
   const cached = cachedDatabases.get(pathname);
   if (cached?.db.isOpen) {
+    if (cachedDatabaseOpenFailures.has(pathname)) {
+      throw cachedDatabaseOpenFailures.get(pathname);
+    }
     if (cached.agentId !== agentId) {
       throw new Error(
         `OpenClaw agent database ${pathname} is already open for agent ${cached.agentId}; requested agent ${agentId}.`,
@@ -201,6 +205,7 @@ export function openOpenClawAgentDatabase(
     // A closed handle can leave Kysely and WAL helpers cached; clear both before reopening.
     closeCachedOpenClawAgentDatabase(cached);
     cachedDatabases.delete(pathname);
+    cachedDatabaseOpenFailures.delete(pathname);
   }
   const leaseId = claimOpenClawAgentDatabaseLease({
     agentId,
@@ -210,6 +215,7 @@ export function openOpenClawAgentDatabase(
   const openStartedAt = Date.now();
   let openedDb: DatabaseSync | undefined;
   let openedDatabase: OpenClawAgentDatabase | undefined;
+  let openedWalMaintenance: SqliteWalMaintenance | undefined;
   try {
     ensureOpenClawAgentDatabasePermissions(pathname, databaseOptions);
     // Free a slot before constructing the new handle: under real descriptor
@@ -242,6 +248,7 @@ export function openOpenClawAgentDatabase(
           foreignKeys: true,
           synchronous: "NORMAL",
         });
+        openedWalMaintenance = maintenance;
         if (!isValidatedReopen) {
           ensureOpenClawAgentSchema(db, agentId, pathname);
         }
@@ -278,13 +285,36 @@ export function openOpenClawAgentDatabase(
     cachedDatabases.set(pathname, database);
     return database;
   } catch (error) {
+    let closeError: unknown;
     if (openedDatabase) {
-      closeCachedOpenClawAgentDatabase(openedDatabase);
+      try {
+        closeCachedOpenClawAgentDatabase(openedDatabase);
+      } catch (caught) {
+        closeError = caught;
+      }
     }
-    if (!openedDb?.isOpen) {
+    if (openedDb?.isOpen) {
+      validatedAgentDatabasePaths.delete(pathname);
+      const retainedDatabase =
+        openedDatabase ??
+        ({
+          agentId,
+          db: openedDb,
+          path: pathname,
+          walMaintenance: openedWalMaintenance ?? {
+            checkpoint: () => false,
+            close: () => false,
+          },
+        } satisfies OpenClawAgentDatabase);
+      // Failed opens remain disposal-owned but cannot become successful cache hits.
+      cachedDatabases.set(pathname, retainedDatabase);
+      cachedDatabaseLeases.set(pathname, { leaseId, env: options.env });
+      cachedDatabaseOpenFailures.set(pathname, closeError ?? error);
+      unregisterExitClose ??= registerSqliteCacheExitClose(closeOpenClawAgentDatabases);
+    } else {
       releaseOpenClawAgentDatabaseLease(leaseId, { env: options.env });
     }
-    throw error;
+    throw closeError ?? error;
   }
 }
 
@@ -393,6 +423,7 @@ function evictLruAgentDatabaseHandles(): void {
       // unregisters them, while eviction closes this process-local handle.
       closeCachedOpenClawAgentDatabase(database, { eviction: true });
       cachedDatabases.delete(pathname);
+      cachedDatabaseOpenFailures.delete(pathname);
       agentDbLog.debug("evicted OpenClaw agent database handle", {
         agentId: database.agentId,
         openHandles: cachedDatabases.size,
@@ -434,6 +465,7 @@ export function closeOpenClawAgentDatabaseByPath(pathname: string): boolean {
   }
   closeCachedOpenClawAgentDatabase(database);
   cachedDatabases.delete(resolvedPath);
+  cachedDatabaseOpenFailures.delete(resolvedPath);
   if (cachedDatabases.size === 0) {
     unregisterExitClose?.();
     unregisterExitClose = null;
@@ -477,6 +509,7 @@ export function closeOpenClawAgentDatabases(): void {
     closeCachedOpenClawAgentDatabase(database);
   }
   cachedDatabases.clear();
+  cachedDatabaseOpenFailures.clear();
 }
 
 /** Close cached agent handles and clear terminal failure latches for test isolation. */

--- a/src/state/openclaw-state-db-schema-additive.ts
+++ b/src/state/openclaw-state-db-schema-additive.ts
@@ -13,6 +13,37 @@ import {
 } from "./openclaw-state-db-legacy-backfills.js";
 import { ensureColumn } from "./openclaw-state-db-schema-helpers.js";
 
+export function ensureAgentDeletionJournalSchema(database: DatabaseSync): void {
+  database.exec(`
+    CREATE TABLE IF NOT EXISTS agent_deletion_journal (
+      agent_id TEXT PRIMARY KEY,
+      operation_id TEXT NOT NULL DEFAULT '',
+      agent_dir TEXT NOT NULL,
+      workspace_dir TEXT NOT NULL,
+      sessions_dir TEXT NOT NULL,
+      database_paths_json TEXT NOT NULL DEFAULT '[]',
+      cleanup_paths_json TEXT NOT NULL DEFAULT '[]',
+      created_at INTEGER NOT NULL,
+      cleanup_completed INTEGER NOT NULL DEFAULT 0,
+      delete_files INTEGER NOT NULL DEFAULT 1
+    ) STRICT
+  `);
+}
+
+export function ensureAgentDatabaseLeaseSchema(database: DatabaseSync): void {
+  ensureAgentDeletionJournalSchema(database);
+  database.exec(`
+    CREATE TABLE IF NOT EXISTS agent_database_leases (
+      lease_id TEXT PRIMARY KEY,
+      agent_id TEXT NOT NULL,
+      path TEXT NOT NULL,
+      owner_pid INTEGER NOT NULL,
+      owner_start_time INTEGER,
+      opened_at INTEGER NOT NULL
+    ) STRICT
+  `);
+}
+
 function resolveLegacyManagedImageRoot(recordJson: unknown): string | null {
   if (typeof recordJson !== "string") {
     return null;

--- a/src/state/openclaw-state-db.generated.d.ts
+++ b/src/state/openclaw-state-db.generated.d.ts
@@ -68,6 +68,7 @@ export interface AgentDeletionJournal {
   agent_dir: string;
   agent_id: string;
   cleanup_completed: Generated<number>;
+  cleanup_paths_json: Generated<string>;
   created_at: number;
   database_paths_json: Generated<string>;
   delete_files: Generated<number>;

--- a/src/state/openclaw-state-db.generated.d.ts
+++ b/src/state/openclaw-state-db.generated.d.ts
@@ -47,12 +47,32 @@ export interface AcpSessions {
   updated_at: number;
 }
 
+export interface AgentDatabaseLeases {
+  agent_id: string;
+  lease_id: string;
+  opened_at: number;
+  owner_pid: number;
+  owner_start_time: number | null;
+  path: string;
+}
+
 export interface AgentDatabases {
   agent_id: string;
   last_seen_at: number;
   path: string;
   schema_version: number;
   size_bytes: number | null;
+}
+
+export interface AgentDeletionJournal {
+  agent_dir: string;
+  agent_id: string;
+  cleanup_completed: Generated<number>;
+  created_at: number;
+  delete_files: Generated<number>;
+  operation_id: Generated<string>;
+  sessions_dir: string;
+  workspace_dir: string;
 }
 
 export interface AgentModelCatalogs {
@@ -1316,7 +1336,9 @@ export interface DB {
   acp_replay_events: AcpReplayEvents;
   acp_replay_sessions: AcpReplaySessions;
   acp_sessions: AcpSessions;
+  agent_database_leases: AgentDatabaseLeases;
   agent_databases: AgentDatabases;
+  agent_deletion_journal: AgentDeletionJournal;
   agent_model_catalogs: AgentModelCatalogs;
   android_notification_recent_packages: AndroidNotificationRecentPackages;
   apns_registration_tombstones: ApnsRegistrationTombstones;

--- a/src/state/openclaw-state-db.generated.d.ts
+++ b/src/state/openclaw-state-db.generated.d.ts
@@ -69,6 +69,7 @@ export interface AgentDeletionJournal {
   agent_id: string;
   cleanup_completed: Generated<number>;
   created_at: number;
+  database_paths_json: Generated<string>;
   delete_files: Generated<number>;
   operation_id: Generated<string>;
   sessions_dir: string;

--- a/src/state/openclaw-state-schema.generated.ts
+++ b/src/state/openclaw-state-schema.generated.ts
@@ -967,6 +967,7 @@ CREATE TABLE IF NOT EXISTS agent_deletion_journal (
   agent_dir TEXT NOT NULL,
   workspace_dir TEXT NOT NULL,
   sessions_dir TEXT NOT NULL,
+  database_paths_json TEXT NOT NULL DEFAULT '[]',
   created_at INTEGER NOT NULL,
   cleanup_completed INTEGER NOT NULL DEFAULT 0,
   delete_files INTEGER NOT NULL DEFAULT 1

--- a/src/state/openclaw-state-schema.generated.ts
+++ b/src/state/openclaw-state-schema.generated.ts
@@ -968,6 +968,7 @@ CREATE TABLE IF NOT EXISTS agent_deletion_journal (
   workspace_dir TEXT NOT NULL,
   sessions_dir TEXT NOT NULL,
   database_paths_json TEXT NOT NULL DEFAULT '[]',
+  cleanup_paths_json TEXT NOT NULL DEFAULT '[]',
   created_at INTEGER NOT NULL,
   cleanup_completed INTEGER NOT NULL DEFAULT 0,
   delete_files INTEGER NOT NULL DEFAULT 1

--- a/src/state/openclaw-state-schema.generated.ts
+++ b/src/state/openclaw-state-schema.generated.ts
@@ -961,6 +961,26 @@ CREATE TABLE IF NOT EXISTS agent_databases (
   PRIMARY KEY (agent_id, path)
 ) STRICT;
 
+CREATE TABLE IF NOT EXISTS agent_deletion_journal (
+  agent_id TEXT PRIMARY KEY,
+  operation_id TEXT NOT NULL DEFAULT '',
+  agent_dir TEXT NOT NULL,
+  workspace_dir TEXT NOT NULL,
+  sessions_dir TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  cleanup_completed INTEGER NOT NULL DEFAULT 0,
+  delete_files INTEGER NOT NULL DEFAULT 1
+) STRICT;
+
+CREATE TABLE IF NOT EXISTS agent_database_leases (
+  lease_id TEXT PRIMARY KEY,
+  agent_id TEXT NOT NULL,
+  path TEXT NOT NULL,
+  owner_pid INTEGER NOT NULL,
+  owner_start_time INTEGER,
+  opened_at INTEGER NOT NULL
+) STRICT;
+
 CREATE TABLE IF NOT EXISTS plugin_state_entries (
   plugin_id TEXT NOT NULL,
   namespace TEXT NOT NULL,

--- a/src/state/openclaw-state-schema.sql
+++ b/src/state/openclaw-state-schema.sql
@@ -962,6 +962,8 @@ CREATE TABLE IF NOT EXISTS agent_deletion_journal (
   agent_dir TEXT NOT NULL,
   workspace_dir TEXT NOT NULL,
   sessions_dir TEXT NOT NULL,
+  database_paths_json TEXT NOT NULL DEFAULT '[]',
+  cleanup_paths_json TEXT NOT NULL DEFAULT '[]',
   created_at INTEGER NOT NULL,
   cleanup_completed INTEGER NOT NULL DEFAULT 0,
   delete_files INTEGER NOT NULL DEFAULT 1

--- a/src/state/openclaw-state-schema.sql
+++ b/src/state/openclaw-state-schema.sql
@@ -956,6 +956,26 @@ CREATE TABLE IF NOT EXISTS agent_databases (
   PRIMARY KEY (agent_id, path)
 ) STRICT;
 
+CREATE TABLE IF NOT EXISTS agent_deletion_journal (
+  agent_id TEXT PRIMARY KEY,
+  operation_id TEXT NOT NULL DEFAULT '',
+  agent_dir TEXT NOT NULL,
+  workspace_dir TEXT NOT NULL,
+  sessions_dir TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  cleanup_completed INTEGER NOT NULL DEFAULT 0,
+  delete_files INTEGER NOT NULL DEFAULT 1
+) STRICT;
+
+CREATE TABLE IF NOT EXISTS agent_database_leases (
+  lease_id TEXT PRIMARY KEY,
+  agent_id TEXT NOT NULL,
+  path TEXT NOT NULL,
+  owner_pid INTEGER NOT NULL,
+  owner_start_time INTEGER,
+  opened_at INTEGER NOT NULL
+) STRICT;
+
 CREATE TABLE IF NOT EXISTS plugin_state_entries (
   plugin_id TEXT NOT NULL,
   namespace TEXT NOT NULL,


### PR DESCRIPTION
## What Problem This Solves
Deleting an agent cleaned config, bindings, and sessions but left everything else behind (single-agent-era assumptions; audit P1 cluster): its cron jobs kept running and startup reconciliation could resurrect them from retained startup config; an open agent SQLite handle and its registry row survived; the agent's exec-approval allowlist in exec-approvals.json survived id reuse — a recreated agent silently inherited its predecessor's command authority; and stale directory-ownership registrations could attribute later auth/DB work to a removed id.

## Why This Change Was Made
Deletion is now a fenced transaction ordered so authorization and scheduled work cannot outlive the roster entry: a durable deletion journal (additive `agent_deletion_journal` + `agent_database_leases` state tables, no schema-version bump) fences recreation and database claims path-aware and cross-process; cron jobs are removed transactionally and startup reconciliation no longer re-adds roster-absent agents; the agent DB is closed, leases (including path-overlapping foreign-agent leases) drained, and the registry row removed only after successful Trash archival; the exec-approvals entry is removed base-hash-safe; cleanup is idempotent and symlink-safe (fs-safe no-follow primitives, pre-resolved depth-sorted targets, per-path identity+completion persisted in the journal so recovery skips done paths and never adopts replacement objects); recreation of the same id atomically claims the completed tombstone.

## User Impact
Deleting an agent now fully retires it: no ghost cron runs, no inherited exec allowlists on id reuse, no stale DB handles blocking or corrupting later work. Interrupted deletions converge on retry instead of wedging the id.

## Evidence
- 361 tests green across the ten-file focused suite: delete/recreate clean-slate, cron non-resurrection, approvals-entry removal + rollback, lease draining incl. foreign-path overlap, symlinked-workspace cleanup, recovery convergence with replacement-object protection, fence ordering.
- Remote check-changed (typecheck/lint/format/schema guards incl. schema-version + database-first) green on Blacksmith Testbox.
- Structured autoreview: seven rounds; all cooperative-interleaving findings fixed; one adversarial local-symlink finding consciously rejected with an inline trust-boundary comment.
