### PR TITLE
fix(onboard): reject invalid setup options before writes

### DIFF
--- a/docs/cli/setup.md
+++ b/docs/cli/setup.md
@@ -47,7 +47,8 @@ auth (`--auth-choice`, `--token`, provider key flags), Gateway
 Tailscale (`--tailscale`), reset (`--reset`, `--reset-scope`), flow
 (`--flow quickstart|advanced|manual|import`), and skip flags
 (`--skip-channels`, `--skip-skills`, `--skip-bootstrap`, `--skip-search`,
-`--skip-health`, `--skip-ui`, `--skip-hooks`). See [Onboard](/cli/onboard) and
+`--skip-health`, `--skip-ui`, `--skip-hooks`). Pass `--tui` to use the same
+terminal hatch as `openclaw onboard --tui`. See [Onboard](/cli/onboard) and
 [CLI automation](/start/wizard-cli-automation) for the full flag reference and
 non-interactive examples. `openclaw onboard --modern` remains a compatibility
 entry for the same inference-gated OpenClaw assistant.
@@ -65,6 +66,7 @@ entry for the same inference-gated OpenClaw assistant.
 | `--workspace <dir>`        | Workspace proposal in guided mode; persisted directly by baseline, classic, and noninteractive setup. |
 | `--baseline`               | Create baseline config/workspace/session folders without onboarding.                                  |
 | `--wizard`                 | Force interactive onboarding.                                                                         |
+| `--tui`                    | Use the terminal hatch instead of the browser handoff.                                                |
 | `--non-interactive`        | Run onboarding without prompts.                                                                       |
 | `--accept-risk`            | Acknowledge full-system agent access risk; required with `--non-interactive`.                         |
 | `--mode <mode>`            | Onboarding mode: `local` or `remote`.                                                                 |
@@ -90,7 +92,9 @@ storage mode.
 
 `openclaw setup --baseline` preserves the older baseline-only behavior: it
 creates the config, workspace, and session directories, then exits without
-running onboarding.
+running onboarding. It accepts `--workspace` and harmless output controls, but
+rejects explicit onboarding, Gateway, auth, reset, or daemon options instead of
+silently ignoring them.
 
 ## Examples
 

--- a/src/cli/program/register.onboard.test.ts
+++ b/src/cli/program/register.onboard.test.ts
@@ -147,19 +147,23 @@ describe("registerOnboardCommand", () => {
     expect(setupWizardOptions(2).installDaemon).toBe(false);
   });
 
-  it("parses numeric gateway port and drops invalid values", async () => {
+  it("parses a valid numeric gateway port", async () => {
     await runCli(["onboard", "--gateway-port", "18789"]);
-    expect(setupWizardOptions(0).gatewayPort).toBe(18789);
-
-    await runCli(["onboard", "--gateway-port", "nope"]);
-    expect(setupWizardOptions(1).gatewayPort).toBeUndefined();
-
-    await runCli(["onboard", "--gateway-port", "18789x"]);
-    expect(setupWizardOptions(2).gatewayPort).toBeUndefined();
-
-    await runCli(["onboard", "--gateway-port", "99999"]);
-    expect(setupWizardOptions(3).gatewayPort).toBeUndefined();
+    expect(setupWizardOptions().gatewayPort).toBe(18789);
   });
+
+  it.each(["not-a-port", "70000"])(
+    "rejects invalid --gateway-port %s before onboarding dispatch",
+    async (gatewayPort) => {
+      await runCli(["onboard", "--gateway-port", gatewayPort]);
+
+      expect(runtime.error).toHaveBeenCalledWith(
+        "Error: --gateway-port must be an integer between 1 and 65535.",
+      );
+      expect(runtime.exit).toHaveBeenCalledWith(1);
+      expect(setupWizardCommandMock).not.toHaveBeenCalled();
+    },
+  );
 
   it("forwards --reset-scope to setup wizard options", async () => {
     await runCli(["onboard", "--reset", "--reset-scope", "full"]);

--- a/src/cli/program/register.onboard.ts
+++ b/src/cli/program/register.onboard.ts
@@ -18,7 +18,7 @@ import type {
 import { resolveProviderOnboardAuthFlags } from "../../plugins/provider-auth-choices.js";
 import { runCommandWithRuntime } from "../cli-utils.js";
 import { formatCliCommand } from "../command-format.js";
-import { parsePort } from "../shared/parse-port.js";
+import { parseGatewayPortOption } from "../gateway-port-option.js";
 
 export function resolveInstallDaemonFlag(command: Command): boolean | undefined {
   // Commander doesn't support option conflicts natively; keep original behavior.
@@ -333,7 +333,7 @@ export function registerOnboardCommand(program: Command): void {
       }
       const installDaemon = resolveInstallDaemonFlag(commandRuntime);
       const tailscaleResetOnExit = resolveTailscaleResetOnExitFlag(commandRuntime);
-      const gatewayPort = parsePort(opts.gatewayPort);
+      const gatewayPort = parseGatewayPortOption(opts.gatewayPort, "--gateway-port");
       const { setupWizardCommand } = await import("../../commands/onboard.js");
       await setupWizardCommand(
         {
@@ -345,7 +345,7 @@ export function registerOnboardCommand(program: Command): void {
           flow: opts.flow as "quickstart" | "advanced" | "manual" | "import" | undefined,
           mode: opts.mode as "local" | "remote" | undefined,
           ...pickOnboardAuthOptionValues(opts as Record<string, unknown>),
-          gatewayPort: gatewayPort ?? undefined,
+          gatewayPort,
           gatewayBind: opts.gatewayBind as GatewayBind | undefined,
           gatewayAuth: opts.gatewayAuth as GatewayAuthChoice | undefined,
           gatewayToken: opts.gatewayToken as string | undefined,

--- a/src/cli/program/register.setup.test.ts
+++ b/src/cli/program/register.setup.test.ts
@@ -172,10 +172,25 @@ describe("registerSetupCommand", () => {
   });
 
   it("runs baseline setup command when --baseline is set", async () => {
-    await runCli(["setup", "--baseline", "--workspace", "/tmp/ws"]);
+    await runCli(["setup", "--baseline", "--workspace", "/tmp/ws", "--json"]);
 
     expect(setupCommandMock).toHaveBeenCalledWith(lastSetupOptions(), runtime);
     expect(lastSetupOptions()?.workspace).toBe("/tmp/ws");
+    expect(setupWizardCommandMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["onboarding mode", ["--mode", "remote"]],
+    ["remote Gateway", ["--remote-url", "wss://example.invalid"]],
+    ["reset", ["--reset"]],
+    ["daemon", ["--daemon-runtime", "node"]],
+    ["auth", ["--auth-choice", "skip"]],
+  ])("rejects explicit %s options with --baseline", async (_label, args) => {
+    await runCli(["setup", "--baseline", ...args]);
+
+    expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining(args[0]!));
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(setupCommandMock).not.toHaveBeenCalled();
     expect(setupWizardCommandMock).not.toHaveBeenCalled();
   });
 
@@ -198,6 +213,27 @@ describe("registerSetupCommand", () => {
     expect(lastWizardOptions()?.remoteToken).toBe(remoteToken);
     expect(setupCommandMock).not.toHaveBeenCalled();
   });
+
+  it("forwards --tui through the canonical onboarding path", async () => {
+    await runCli(["setup", "--tui"]);
+
+    expect(lastWizardOptions()?.tui).toBe(true);
+    expect(setupCommandMock).not.toHaveBeenCalled();
+  });
+
+  it.each(["not-a-port", "70000"])(
+    "rejects invalid --gateway-port %s before onboarding dispatch",
+    async (gatewayPort) => {
+      await runCli(["setup", "--gateway-port", gatewayPort]);
+
+      expect(runtime.error).toHaveBeenCalledWith(
+        "Error: --gateway-port must be an integer between 1 and 65535.",
+      );
+      expect(runtime.exit).toHaveBeenCalledWith(1);
+      expect(setupWizardCommandMock).not.toHaveBeenCalled();
+      expect(setupCommandMock).not.toHaveBeenCalled();
+    },
+  );
 
   it("runs setup wizard command when wizard-only flags are passed explicitly", async () => {
     await runCli(["setup", "--mode", "remote", "--non-interactive", "--accept-risk"]);

--- a/src/cli/program/register.setup.ts
+++ b/src/cli/program/register.setup.ts
@@ -14,7 +14,7 @@ import type { RuntimeEnv } from "../../runtime.js";
 import { runCommandWithRuntime } from "../cli-utils.js";
 import { hasExplicitOptions } from "../command-options.js";
 import { isUnconfiguredConfigSource } from "../fresh-install-config.js";
-import { parsePort } from "../shared/parse-port.js";
+import { parseGatewayPortOption } from "../gateway-port-option.js";
 import {
   pickOnboardAuthOptionValues,
   registerOnboardAuthOptions,
@@ -23,6 +23,7 @@ import {
 } from "./register.onboard.js";
 
 const SYSTEM_AGENT_OPTION_NAMES = new Set(["message", "yes", "json"]);
+const BASELINE_OPTION_NAMES = new Set(["baseline", "workspace", "json"]);
 
 const optionalString = (value: unknown): string | undefined =>
   typeof value === "string" ? value : undefined;
@@ -53,6 +54,24 @@ function hasExplicitOnboardingOption(command: Command): boolean {
     const name = option.attributeName();
     return !SYSTEM_AGENT_OPTION_NAMES.has(name) && command.getOptionValueSource(name) === "cli";
   });
+}
+
+function listUnsupportedBaselineOptions(command: Command): string[] {
+  const optionsByName = new Map<string, (typeof command.options)[number]>();
+  for (const option of command.options) {
+    const name = option.attributeName();
+    if (BASELINE_OPTION_NAMES.has(name) || command.getOptionValueSource(name) !== "cli") {
+      continue;
+    }
+    const existing = optionsByName.get(name);
+    const valueIsNegated = command.getOptionValue(name) === false;
+    if (!existing || option.negate === valueIsNegated) {
+      optionsByName.set(name, option);
+    }
+  }
+  return [...optionsByName.values()]
+    .map((option) => option.long ?? option.short ?? option.flags)
+    .toSorted();
 }
 
 async function isConfiguredInstance(): Promise<boolean> {
@@ -89,13 +108,19 @@ async function runOnboardingEntry(
   runtime: RuntimeEnv,
 ): Promise<void> {
   if (options.baseline) {
+    const unsupportedOptions = listUnsupportedBaselineOptions(commandRuntime);
+    if (unsupportedOptions.length > 0) {
+      runtime.error(`--baseline cannot be combined with: ${unsupportedOptions.join(", ")}.`);
+      runtime.exit(1);
+      return;
+    }
     const { setupCommand } = await import("../../commands/setup.js");
     await setupCommand({ workspace: optionalString(options.workspace) }, runtime);
     return;
   }
   const installDaemon = resolveInstallDaemonFlag(commandRuntime);
   const tailscaleResetOnExit = resolveTailscaleResetOnExitFlag(commandRuntime);
-  const gatewayPort = parsePort(options.gatewayPort);
+  const gatewayPort = parseGatewayPortOption(options.gatewayPort, "--gateway-port");
   const { setupWizardCommand } = await import("../../commands/onboard.js");
   await setupWizardCommand(
     {
@@ -103,12 +128,13 @@ async function runOnboardingEntry(
       nonInteractive: Boolean(options.nonInteractive),
       acceptRisk: Boolean(options.acceptRisk),
       classic: Boolean(options.classic),
+      tui: Boolean(options.tui),
       flow: options.flow as "quickstart" | "advanced" | "manual" | "import" | undefined,
       mode: options.mode as "local" | "remote" | undefined,
       ...pickOnboardAuthOptionValues(options),
       reset: Boolean(options.reset),
       resetScope: options.resetScope as ResetScope | undefined,
-      gatewayPort: gatewayPort ?? undefined,
+      gatewayPort,
       gatewayBind: options.gatewayBind as GatewayBind | undefined,
       gatewayAuth: options.gatewayAuth as GatewayAuthChoice | undefined,
       gatewayToken: optionalString(options.gatewayToken),
@@ -179,6 +205,7 @@ export function registerSetupCommand(program: Command): void {
     .option("--reset-scope <scope>", "Reset scope: config|config+creds+sessions|full")
     .option("--non-interactive", "Run onboarding without prompts", false)
     .option("--classic", "Use the classic multi-step setup wizard", false)
+    .option("--tui", "Use the terminal hatch instead of the browser handoff", false)
     .option(
       "--accept-risk",
       "Acknowledge that agents are powerful and full system access is risky (required for --non-interactive)",

--- a/src/commands/onboard-skills.ts
+++ b/src/commands/onboard-skills.ts
@@ -21,7 +21,7 @@ import {
 import { t } from "../wizard/i18n/index.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
 import { detectBinary } from "./onboard-helpers.js";
-import type { NodeManagerChoice } from "./onboard-types.js";
+import { isNodeManagerChoice, type NodeManagerChoice } from "./onboard-types.js";
 
 const HOMEBREW_PROMPT_PLATFORMS = new Set(["darwin", "linux"]);
 const SKIPPED_INSTALL_NAME_LIMIT = 8;
@@ -121,10 +121,6 @@ function isTrustedAutoInstallableSkill(skill: { bundled: boolean; source: string
   // Onboarding can auto-run bundled recipes without another prompt. Workspace
   // skill metadata is mutable project input, so those installs stay explicit.
   return skill.bundled && skill.source === "openclaw-bundled";
-}
-
-function isNodeManagerChoice(value: unknown): value is NodeManagerChoice {
-  return value === "npm" || value === "pnpm" || value === "bun";
 }
 
 function resolveDefaultNodeManager(

--- a/src/commands/onboard-types.ts
+++ b/src/commands/onboard-types.ts
@@ -25,9 +25,20 @@ export type GatewayAuthChoice = "token" | "password";
 export type ResetScope = "config" | "config+creds+sessions" | "full";
 export type GatewayBind = "loopback" | "lan" | "auto" | "custom" | "tailnet";
 export type TailscaleMode = "off" | "serve" | "funnel";
-export type NodeManagerChoice = "npm" | "pnpm" | "bun";
+const NODE_MANAGER_CHOICES = ["npm", "pnpm", "bun"] as const;
+export type NodeManagerChoice = (typeof NODE_MANAGER_CHOICES)[number];
+const ONBOARD_FLOWS = ["quickstart", "advanced", "manual", "import"] as const;
+export type OnboardFlow = (typeof ONBOARD_FLOWS)[number];
 export type ChannelChoice = ChannelId;
 export type { SecretInputMode } from "../plugins/provider-auth-types.js";
+
+export function isNodeManagerChoice(value: unknown): value is NodeManagerChoice {
+  return NODE_MANAGER_CHOICES.some((choice) => choice === value);
+}
+
+export function isOnboardFlow(value: unknown): value is OnboardFlow {
+  return ONBOARD_FLOWS.some((flow) => flow === value);
+}
 
 type OnboardDynamicProviderOptions = {
   /**
@@ -41,7 +52,7 @@ type OnboardDynamicProviderOptions = {
 export type OnboardOptions = OnboardDynamicProviderOptions & {
   mode?: OnboardMode;
   /** "manual" is an alias for "advanced". */
-  flow?: "quickstart" | "advanced" | "manual" | "import";
+  flow?: OnboardFlow;
   /** Force the classic multi-step interactive wizard instead of guided setup. */
   classic?: boolean;
   /** Force the terminal hatch instead of the guided browser handoff. */

--- a/src/commands/onboard-types.ts
+++ b/src/commands/onboard-types.ts
@@ -28,7 +28,7 @@ export type TailscaleMode = "off" | "serve" | "funnel";
 const NODE_MANAGER_CHOICES = ["npm", "pnpm", "bun"] as const;
 export type NodeManagerChoice = (typeof NODE_MANAGER_CHOICES)[number];
 const ONBOARD_FLOWS = ["quickstart", "advanced", "manual", "import"] as const;
-export type OnboardFlow = (typeof ONBOARD_FLOWS)[number];
+type OnboardFlow = (typeof ONBOARD_FLOWS)[number];
 export type ChannelChoice = ChannelId;
 export type { SecretInputMode } from "../plugins/provider-auth-types.js";
 

--- a/src/commands/onboard.test.ts
+++ b/src/commands/onboard.test.ts
@@ -395,6 +395,49 @@ describe("setupWizardCommand", () => {
     expect(mocks.runNonInteractiveSetup).not.toHaveBeenCalled();
   });
 
+  it.each([
+    {
+      label: "unsupported flow",
+      options: { flow: "bogus" as never },
+      expectedError: "Invalid --flow",
+    },
+    {
+      label: "malformed remote URL",
+      options: { mode: "remote" as const, remoteUrl: "garbage" },
+      expectedError: "URL must start with ws:// or wss://",
+    },
+    {
+      label: "non-WebSocket remote URL",
+      options: { mode: "remote" as const, remoteUrl: "https://example.invalid" },
+      expectedError: "URL must start with ws:// or wss://",
+    },
+    {
+      label: "unsupported daemon runtime while daemon install is skipped",
+      options: { daemonRuntime: "bogus" as never, installDaemon: false },
+      expectedError: "Invalid --daemon-runtime",
+    },
+    {
+      label: "unsupported node manager",
+      options: { nodeManager: "bogus" as never },
+      expectedError: "Invalid --node-manager",
+    },
+  ])(
+    "rejects $label before non-interactive setup without reset",
+    async ({ options, expectedError }) => {
+      const runtime = makeRuntime();
+
+      await setupWizardCommand({ nonInteractive: true, acceptRisk: true, ...options }, runtime);
+
+      expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining(expectedError));
+      expect(runtime.exit).toHaveBeenCalledWith(1);
+      expect(mocks.readConfigFileSnapshot).not.toHaveBeenCalled();
+      expect(mocks.handleReset).not.toHaveBeenCalled();
+      expect(mocks.runNonInteractiveSetup).not.toHaveBeenCalled();
+      expect(mocks.runInteractiveSetup).not.toHaveBeenCalled();
+      expect(mocks.runGuidedOnboarding).not.toHaveBeenCalled();
+    },
+  );
+
   it("validates dependent gateway options before reset", async () => {
     const runtime = makeRuntime();
 

--- a/src/commands/onboard.ts
+++ b/src/commands/onboard.ts
@@ -28,6 +28,7 @@ import {
   resolveDeprecatedAuthChoiceReplacement,
 } from "./auth-choice-legacy.js";
 import { formatAuthChoiceChoicesForCli } from "./auth-choice-options.js";
+import { isGatewayDaemonRuntime } from "./daemon-runtime.js";
 import {
   applyCustomApiConfig,
   CustomApiError,
@@ -42,7 +43,12 @@ import { resolveNonInteractiveApiKey as resolveNonInteractiveCredential } from "
 import { inferAuthChoiceFromFlags } from "./onboard-non-interactive/local/auth-choice-inference.js";
 import { applyNonInteractiveGatewayConfig } from "./onboard-non-interactive/local/gateway-config.js";
 import { validateGatewayWebSocketUrl } from "./onboard-remote.js";
-import type { OnboardOptions, ResetScope } from "./onboard-types.js";
+import {
+  isNodeManagerChoice,
+  isOnboardFlow,
+  type OnboardOptions,
+  type ResetScope,
+} from "./onboard-types.js";
 
 const VALID_RESET_SCOPES = new Set<ResetScope>(["config", "config+creds+sessions", "full"]);
 const BUILT_IN_AUTH_CHOICES = ["setup-token", "token", "apiKey", "custom-api-key", "skip"];
@@ -53,7 +59,7 @@ function rejectOption(runtime: RuntimeEnv, message: string): false {
   return false;
 }
 
-function validateResetPreflightOptions(opts: OnboardOptions, runtime: RuntimeEnv): boolean {
+function validatePreflightOptions(opts: OnboardOptions, runtime: RuntimeEnv): boolean {
   if (opts.mode !== undefined && opts.mode !== "local" && opts.mode !== "remote") {
     return rejectOption(
       runtime,
@@ -61,12 +67,9 @@ function validateResetPreflightOptions(opts: OnboardOptions, runtime: RuntimeEnv
     );
   }
   const choiceValidations: Array<readonly [string, string | undefined, readonly string[]]> = [
-    ["--flow", opts.flow, ["quickstart", "advanced", "import"]],
     ["--gateway-bind", opts.gatewayBind, ["loopback", "tailnet", "lan", "auto", "custom"]],
     ["--gateway-auth", opts.gatewayAuth, ["token", "password"]],
     ["--tailscale", opts.tailscale, ["off", "serve", "funnel"]],
-    ["--node-manager", opts.nodeManager, ["npm", "pnpm", "bun"]],
-    ["--daemon-runtime", opts.daemonRuntime, ["node"]],
     [
       "--custom-compatibility",
       opts.customCompatibility,
@@ -80,6 +83,18 @@ function validateResetPreflightOptions(opts: OnboardOptions, runtime: RuntimeEnv
         `Invalid ${flag} ${JSON.stringify(value)}. Use ${allowed.map((choice) => JSON.stringify(choice)).join(", ")}.`,
       );
     }
+  }
+  if (opts.flow !== undefined && !isOnboardFlow(opts.flow)) {
+    return rejectOption(
+      runtime,
+      'Invalid --flow. Use "quickstart", "advanced", "manual", or "import".',
+    );
+  }
+  if (opts.daemonRuntime !== undefined && !isGatewayDaemonRuntime(opts.daemonRuntime)) {
+    return rejectOption(runtime, 'Invalid --daemon-runtime. Use "node".');
+  }
+  if (opts.nodeManager !== undefined && !isNodeManagerChoice(opts.nodeManager)) {
+    return rejectOption(runtime, 'Invalid --node-manager. Use "npm", "pnpm", or "bun".');
   }
   if (
     opts.gatewayPort !== undefined &&
@@ -426,6 +441,9 @@ export async function setupWizardCommand(
     normalizedAuthChoice === opts.authChoice && flow === opts.flow
       ? opts
       : { ...opts, authChoice: normalizedAuthChoice, flow };
+  if (!validatePreflightOptions(normalizedOpts, runtime)) {
+    return;
+  }
   if (normalizedOpts.classic && normalizedOpts.nonInteractive) {
     runtime.error(
       "--classic cannot be combined with --non-interactive. Remove --non-interactive to open the classic wizard, or remove --classic for automated setup.",
@@ -485,9 +503,6 @@ export async function setupWizardCommand(
       : runGuidedOnboarding;
 
   if (normalizedOpts.reset) {
-    if (!validateResetPreflightOptions(normalizedOpts, runtime)) {
-      return;
-    }
     const snapshot = await readConfigFileSnapshot();
     const baseConfig = snapshot.sourceConfig ?? (snapshot.valid ? snapshot.config : {});
     const resetScope: ResetScope = normalizedOpts.resetScope ?? "config+creds+sessions";


### PR DESCRIPTION
## What Problem This Solves

Fixes a group of onboarding CLI cases where explicitly invalid or unsupported setup options could be silently ignored, converted to defaults, or persisted before validation. In particular, malformed Gateway ports, unknown flows, invalid remote URLs, unsupported daemon runtimes/node managers, and incompatible `setup --baseline` options could all produce a successful-looking setup. `openclaw setup --tui` was also missing despite setup documenting onboarding flag parity.

## Why This Change Was Made

Validation now happens at the canonical pre-dispatch boundary before config, credentials, or workspace state can be mutated. Gateway ports use the existing strict port parser, remote mode reuses the canonical WebSocket URL validator, baseline checks only explicitly supplied Commander options, and setup forwards `--tui` through the same onboarding path rather than adding a second implementation.

This PR is AI-assisted. I reviewed the complete diff, reran the original black-box reproductions, and verified the resulting behavior and tests.

## User Impact

Invalid setup commands now fail clearly with a nonzero exit status and leave state untouched instead of silently choosing defaults or writing unusable config. Baseline automation reports conflicting options rather than ignoring them, and setup users can select the documented terminal hatch with `--tui`.

## Evidence

Before this change on `bc76bb893379c21fd86134e5ca5521833a69daa7`:

- `--gateway-port not-a-port` and `70000` exited 0 and persisted port 18789.
- `--flow bogus`, `--daemon-runtime bogus`, and `--node-manager bogus` exited 0 and wrote config.
- Remote onboarding persisted both `garbage` and `https://example.invalid` as Gateway URLs.
- `setup --baseline --mode remote --remote-url ... --reset` exited 0 and silently wrote local baseline config.
- `setup --tui` exited 1 as an unrecognized option.

After this change:

- The same invalid-value matrix exits 1 before creating config for every affected case.
- Valid non-interactive JSON onboarding still exits 0 and emits one parseable JSON document.
- `openclaw setup --help` includes `--tui`.

Focused proof on the final rebased commit:

```text
fnm exec --using 24.15.0 -- node scripts/run-vitest.mjs \
  src/cli/program/register.onboard.test.ts \
  src/cli/program/register.setup.test.ts \
  src/commands/onboard.test.ts

96 tests passed across 2 Vitest shards.
```

Additional proof:

- Source-mode black-box CLI matrix for malformed ports, invalid flow, invalid remote URLs, baseline conflicts, daemon runtime, node manager, and valid JSON output.
- `pnpm docs:list` completed successfully.
- Fresh autoreview: clean, no accepted/actionable findings.
- Blacksmith Testbox `tbx_01kxz0324eh68pd5t1d6jh518q`: `pnpm check:changed && pnpm build` passed.
- Testbox workflow: https://github.com/openclaw/openclaw/actions/runs/29719317115
- `git diff --check origin/main..HEAD` passed after rebase.
