### PR TITLE
fix(ui): restyle chat pane error banner as a compact centered alert

### DIFF
--- a/ui/src/pages/chat/chat-view.ts
+++ b/ui/src/pages/chat/chat-view.ts
@@ -534,13 +534,14 @@ export function renderChat(props: ChatProps) {
     >
       ${props.error
         ? html`
-            <div class="callout danger callout--dismissible" role="alert">
-              <span class="callout__content">${props.error}</span>
+            <div class="chat-error" role="alert">
+              <span class="chat-error__dot" aria-hidden="true"></span>
+              <span class="chat-error__content">${props.error}</span>
               ${props.onDismissError
                 ? html`
                     <openclaw-tooltip .content=${t("chat.actions.dismissError")}>
                       <button
-                        class="callout__dismiss"
+                        class="chat-error__dismiss"
                         type="button"
                         @click=${props.onDismissError}
                         aria-label=${t("chat.actions.dismissError")}

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -28,6 +28,99 @@ openclaw-chat-page {
   box-shadow: none !important;
 }
 
+/* Chat pane error alert. The pane strips its own padding, so the alert
+   carries its own inset as a centered card instead of stretching into a
+   full-bleed bar; visual language mirrors the connection pill (status dot
+   on an elevated surface) with a danger accent. */
+.chat-error {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  align-self: center;
+  max-width: min(36rem, calc(100% - 32px));
+  margin: 12px 16px 4px;
+  padding: 10px 14px;
+  border: 1px solid color-mix(in srgb, var(--danger) 32%, var(--border));
+  border-radius: var(--radius-lg);
+  background: color-mix(in srgb, var(--danger) 9%, var(--bg-elevated));
+  box-shadow: var(--shadow-lg);
+  color: var(--text-strong);
+  font-size: 13px;
+  line-height: 1.5;
+  animation: chat-error-enter 0.25s var(--ease-out);
+}
+
+@keyframes chat-error-enter {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .chat-error {
+    animation: none;
+  }
+}
+
+.chat-error__dot {
+  flex-shrink: 0;
+  width: 7px;
+  height: 7px;
+  /* Optically centers the dot on the first text line when the message wraps. */
+  margin-top: 6px;
+  border-radius: var(--radius-full);
+  background: var(--danger);
+  box-shadow: 0 0 8px color-mix(in srgb, var(--danger) 55%, transparent);
+}
+
+.chat-error__content {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.chat-error__dismiss {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: 26px;
+  height: 26px;
+  /* Pulls the hit target into the card's padding so the text stays the
+     tallest run and the card keeps its compact height. */
+  margin: -4px -6px -4px 2px;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--muted);
+  transition: background var(--duration-fast) var(--ease-out);
+}
+
+.chat-error__dismiss:hover {
+  background: color-mix(in srgb, currentColor 12%, transparent);
+  color: var(--text-strong);
+}
+
+.chat-error__dismiss:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.chat-error__dismiss svg {
+  display: block;
+  width: 15px;
+  height: 15px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.8;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
 .chat::after {
   content: "";
   position: absolute;


### PR DESCRIPTION
## What Problem This Solves

The chat pane error banner (e.g. "The Gateway asked us to retry this message shortly." during a gateway restart) rendered as a full-bleed red slab: the `.chat` container strips its own padding (`padding: 0 !important`), so the generic `.callout.danger` stretched edge-to-edge with no margin, flush under the header, while the connection pill floating right above it is a polished rounded overlay. The clash made every transient chat error look broken.

## Why This Change Was Made

The chat error now has dedicated markup and styles (`.chat-error*` in the chat layout stylesheet) instead of borrowing the generic callout: a compact centered card, bounded at `min(36rem, 100% - 32px)`, with the connection pill's visual language — danger status dot, elevated tinted surface, soft border/shadow, enter animation with a reduced-motion opt-out. The dot pins to the first text line and long messages wrap inside the card (`overflow-wrap: anywhere`). The generic `.callout` styles are untouched, so the other callout consumers (sidebar session errors, panel refresh, settings pages) are unaffected.

## User Impact

Chat errors — gateway retry hints, send failures, draft-storage warnings — now appear as a quiet dismissible alert consistent with the rest of the chat chrome instead of a screen-wide red bar. Works in dark and light themes.

## Evidence

Captured on the mock-gateway dev harness (`pnpm dev:ui:mock`), Chromium 1440×900 @2x.

Before (dark):
![before dark](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/chat-error-redesign/chat-error-before-dark.png)

After (dark):
![after dark](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/chat-error-redesign/chat-error-after-dark.png)

Before (light):
![before light](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/chat-error-redesign/chat-error-before-light.png)

After (light):
![after light](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/chat-error-redesign/chat-error-after-light.png)

- Long multi-line error verified to wrap cleanly inside the bounded card (dot stays on the first line, dismiss stays top-right).
- `node scripts/check-changed.mjs` green (delegated Testbox run: https://github.com/openclaw/openclaw/actions/runs/29718831345).
- Structured autoreview (Codex, gpt-5.6-sol): clean, no accepted/actionable findings.
- No test updates needed: no test or e2e selector targets the chat pane's old `.callout` markup (the only `.callout.danger` e2e assertion is the worktrees settings page, untouched).
