### PR TITLE
fix(acpx): repair missing native adapter packages during install

### DIFF
--- a/extensions/acpx/package.json
+++ b/extensions/acpx/package.json
@@ -24,7 +24,23 @@
     "install": {
       "npmSpec": "@openclaw/acpx",
       "defaultChoice": "npm",
-      "minHostVersion": ">=2026.4.25"
+      "minHostVersion": ">=2026.4.25",
+      "requiredPlatformPackages": [
+        "@anthropic-ai/claude-agent-sdk-linux-x64",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64",
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64",
+        "@anthropic-ai/claude-agent-sdk-win32-x64",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64",
+        "@openai/codex-linux-x64",
+        "@openai/codex-linux-arm64",
+        "@openai/codex-darwin-x64",
+        "@openai/codex-darwin-arm64",
+        "@openai/codex-win32-x64",
+        "@openai/codex-win32-arm64"
+      ]
     },
     "compat": {
       "pluginApi": ">=2026.7.2"

--- a/extensions/acpx/src/manifest.test.ts
+++ b/extensions/acpx/src/manifest.test.ts
@@ -5,6 +5,11 @@ import { describe, expect, it } from "vitest";
 type AcpxPackageManifest = {
   dependencies?: Record<string, string>;
   devDependencies?: Record<string, string>;
+  openclaw?: {
+    install?: {
+      requiredPlatformPackages?: string[];
+    };
+  };
 };
 
 const packageJson = JSON.parse(
@@ -19,5 +24,24 @@ describe("acpx package manifest", () => {
     expect(packageJson.dependencies?.["@zed-industries/codex-acp"]).toBeUndefined();
     expect(packageJson.dependencies?.["@agentclientprotocol/claude-agent-acp"]).toBe("0.55.0");
     expect(packageJson.devDependencies?.["@agentclientprotocol/claude-agent-acp"]).toBeUndefined();
+  });
+
+  it("declares the transitive native platform packages required by ACP adapters", () => {
+    expect(packageJson.openclaw?.install?.requiredPlatformPackages).toEqual([
+      "@anthropic-ai/claude-agent-sdk-linux-x64",
+      "@anthropic-ai/claude-agent-sdk-linux-arm64",
+      "@anthropic-ai/claude-agent-sdk-linux-x64-musl",
+      "@anthropic-ai/claude-agent-sdk-linux-arm64-musl",
+      "@anthropic-ai/claude-agent-sdk-darwin-x64",
+      "@anthropic-ai/claude-agent-sdk-darwin-arm64",
+      "@anthropic-ai/claude-agent-sdk-win32-x64",
+      "@anthropic-ai/claude-agent-sdk-win32-arm64",
+      "@openai/codex-linux-x64",
+      "@openai/codex-linux-arm64",
+      "@openai/codex-darwin-x64",
+      "@openai/codex-darwin-arm64",
+      "@openai/codex-win32-x64",
+      "@openai/codex-win32-arm64",
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

- Declare every Claude Agent SDK and Codex native platform alias used transitively by ACPX.
- Add a focused manifest regression that locks the complete alias set.
- Keep the generic managed npm installer unchanged.

## What Problem This Solves

Fixes an issue where a managed ACPX install could report success after npm omitted the current host's native Claude or Codex package, leaving the affected ACP adapter to fail only when it starts.

## Why This Change Was Made

ACPX now opts into the existing `openclaw.install.requiredPlatformPackages` contract. That contract already matches optional lockfile entries to the current OS, CPU, and libc, retries an omitted package once with a fresh npm cache, and rolls back if it remains missing. Keeping the package list in ACPX metadata preserves the plugin ownership boundary and avoids ACPX-specific installer logic.

## User Impact

Managed ACPX installs and updates now verify the host-native packages needed by both bundled ACP adapters before the install is accepted.

## Evidence

- A pre-fix manifest regression failed because ACPX had no `requiredPlatformPackages` declaration; it passes with all eight Claude Agent SDK aliases and six Codex aliases.
- Packing and installing the ACPX tarball into an empty macOS arm64 npm project preserved all 14 declarations and materialized both current-host packages: `@anthropic-ai/claude-agent-sdk-darwin-arm64` and `@openai/codex-darwin-arm64`.
- The final patch ID remained unchanged across the required canonical-main rebases.

## Verification

- `node scripts/run-vitest.mjs extensions/acpx/src/manifest.test.ts`
- `node scripts/run-vitest.mjs extensions/acpx/src/manifest.test.ts src/plugins/install.npm-spec.test.ts -t 'transitive native platform packages|current-platform packages'`
- `node scripts/generate-npm-shrinkwrap.mjs --package-dir extensions/acpx --check`
- Packed `extensions/acpx` with `npm pack`, installed the tarball into an empty npm project, and asserted the 14 declared aliases plus both macOS arm64 package directories and lock constraints.
- Blacksmith Testbox `tbx_01kxz0jwxyab3y7j1tes7tbqj0`: `env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 corepack pnpm check:changed` ([run](https://github.com/openclaw/openclaw/actions/runs/29719643595))
- `$autoreview --mode branch --base upstream/main`: clean, no accepted/actionable findings (Codex, confidence 0.99).

## Real behavior proof

Behavior addressed: Managed ACPX installs can no longer be accepted when npm omits the current host's declared native Claude or Codex adapter package.

Real environment tested: macOS arm64, Node 24.16.0, npm 11.13.0; Linux Node 24 type/lint/guard proof on Blacksmith Testbox.

Exact steps or command run after this patch: Packed `extensions/acpx`, installed the tarball into an empty npm project, checked the installed ACPX manifest, current-platform package directories, and package-lock OS/CPU constraints; then ran the focused Vitest and Testbox commands listed above.

Evidence after fix: The installed tarball declared 14 required aliases; npm materialized the Darwin arm64 Claude and Codex packages; focused tests and the Testbox changed gate passed.

Observed result after fix: ACPX package metadata now activates the existing managed-install repair and rollback contract for both transitive native runtimes.

What was not tested: No live Claude or Codex agent turn was run because this change only opts package metadata into an already-tested installer contract and does not change adapter runtime behavior.
