### PR TITLE
fix(ui): give roster rows their avatar-text gap and add presence mock fixtures

### DIFF
--- a/scripts/control-ui-mock-dev.ts
+++ b/scripts/control-ui-mock-dev.ts
@@ -1128,6 +1128,13 @@ async function createChatPickerScenario(): Promise<ControlUiMockGatewayScenario>
       "sessions.files.set",
     ],
     historyMessages: buildScrollableChatHistory(baseTime),
+    // Lights up the footer facepile and who's-online roster; the email-only
+    // entry keeps the roster's no-display-name row exercised.
+    presenceUsers: [
+      { self: true, id: "presence-riley", name: "Riley", email: "riley@example.com" },
+      { id: "presence-colin", name: "Colin", email: "colin@example.com" },
+      { id: "presence-patricia", email: "patricia.erichsen@example.com" },
+    ],
     methodResponses: {
       ...buildBackgroundTasksMock(baseTime),
       // config.set/config.apply are served statefully by the mock gateway

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -2009,7 +2009,7 @@ html.openclaw-native-macos
    Awesome's checkmark gutter and item metrics so title, avatars, and text
    share one left edge with the rest of the app's menus. */
 .presence-roster-menu__item {
-  padding: 5px 8px;
+  padding: 6px 8px;
   border-radius: var(--radius-md);
 }
 
@@ -2029,10 +2029,14 @@ html.openclaw-native-macos
 }
 
 /* Roster avatars grow to two-line row scale. The circle clips via the child
-   image/initials instead of the wrapper so the online badge can overflow. */
+   image/initials instead of the wrapper so the online badge can overflow.
+   The avatar-to-text gap lives here: Web Awesome's icon-slot margin targets
+   the slotted openclaw-viewer-avatar host, which is display:contents and
+   therefore generates no box for the margin to apply to. */
 .presence-roster-menu__item .viewer-avatar {
   width: 26px;
   height: 26px;
+  margin-inline-end: 10px;
   overflow: visible;
   border: none;
   font-size: 10px;

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -595,6 +595,33 @@ function installControlUiMockGateway(input: {
     return { found: true, value: matchingCase.response };
   }
 
+  /** Presence slice of the connect snapshot. The self-flagged entry adopts the
+   * connecting client's instanceId so presence surfaces resolve "you". */
+  function presenceSnapshot(connectParams: unknown): { presence?: unknown[] } {
+    if (scenario.presenceUsers.length === 0) {
+      return {};
+    }
+    const client = isRecord(connectParams) ? connectParams.client : undefined;
+    const selfInstanceId =
+      isRecord(client) && typeof client.instanceId === "string"
+        ? client.instanceId
+        : "e2e-self-instance";
+    return {
+      presence: scenario.presenceUsers.map((user, index) => ({
+        instanceId: user.self ? selfInstanceId : `e2e-presence-${index}`,
+        mode: "webchat",
+        reason: "connect",
+        user: {
+          id: user.id,
+          name: user.name ?? null,
+          email: user.email ?? null,
+          avatarUrl: user.avatarUrl ?? null,
+        },
+        watchedSessions: user.watchedSessions ?? [],
+      })),
+    };
+  }
+
   function recordSessionPatch(params: unknown): void {
     if (!isRecord(params) || typeof params.key !== "string") {
       return;
@@ -799,24 +826,7 @@ function installControlUiMockGateway(input: {
         : configured.value;
     }
     switch (method) {
-      case "connect": {
-        const connectClient = isRecord(params) ? params.client : undefined;
-        const clientInstanceId =
-          isRecord(connectClient) && typeof connectClient.instanceId === "string"
-            ? connectClient.instanceId
-            : "e2e-self-instance";
-        const presence = scenario.presenceUsers.map((user, index) => ({
-          instanceId: user.self ? clientInstanceId : `e2e-presence-${index}`,
-          mode: "webchat",
-          reason: "connect",
-          user: {
-            id: user.id,
-            name: user.name ?? null,
-            email: user.email ?? null,
-            avatarUrl: user.avatarUrl ?? null,
-          },
-          watchedSessions: user.watchedSessions ?? [],
-        }));
+      case "connect":
         return {
           auth: {
             deviceToken: scenario.deviceToken,
@@ -838,7 +848,7 @@ function installControlUiMockGateway(input: {
           protocol: protocolVersion,
           server: { connId: "control-ui-e2e", version: "e2e" },
           snapshot: {
-            ...(presence.length > 0 ? { presence } : {}),
+            ...presenceSnapshot(params),
             sessionDefaults: {
               defaultAgentId: scenario.defaultAgentId,
               mainKey: "main",
@@ -848,7 +858,6 @@ function installControlUiMockGateway(input: {
           },
           type: "hello-ok",
         };
-      }
       case "agent.identity.get":
         return {
           agentId: scenario.assistantAgentId,

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -66,6 +66,17 @@ export type ControlUiMockGatewayScenario = {
   methodResponses?: Record<string, unknown>;
   /** Replayed in-flight run snapshot served by chat.history and chat.startup. */
   inFlightRun?: { runId: string; text?: string; plan?: unknown } | null;
+  /** Online users included in the connect snapshot's presence list. The entry
+   * flagged `self` adopts the connecting client's instanceId so presence
+   * surfaces (footer facepile, who's-online roster) resolve "you". */
+  presenceUsers?: Array<{
+    self?: boolean;
+    id: string;
+    name?: string;
+    email?: string;
+    avatarUrl?: string;
+    watchedSessions?: string[];
+  }>;
   /** Subscription-scoped Gateway events replayed on a fixed browser-side cycle. */
   repeatingSessionEvents?: {
     events: Array<{ event: "agent" | "session.tool"; payload: unknown }>;
@@ -268,6 +279,7 @@ function normalizeScenario(
     historyMessages: scenario.historyMessages ?? [],
     methodResponses: scenario.methodResponses ?? {},
     inFlightRun: scenario.inFlightRun ?? null,
+    presenceUsers: scenario.presenceUsers ?? [],
     models: scenario.models ?? [{ id: "gpt-5.5", name: "gpt-5.5", provider: "openai" }],
     repeatingSessionEvents: scenario.repeatingSessionEvents ?? { events: [] },
     sessionInfo: scenario.sessionInfo ?? null,
@@ -787,7 +799,24 @@ function installControlUiMockGateway(input: {
         : configured.value;
     }
     switch (method) {
-      case "connect":
+      case "connect": {
+        const connectClient = isRecord(params) ? params.client : undefined;
+        const clientInstanceId =
+          isRecord(connectClient) && typeof connectClient.instanceId === "string"
+            ? connectClient.instanceId
+            : "e2e-self-instance";
+        const presence = scenario.presenceUsers.map((user, index) => ({
+          instanceId: user.self ? clientInstanceId : `e2e-presence-${index}`,
+          mode: "webchat",
+          reason: "connect",
+          user: {
+            id: user.id,
+            name: user.name ?? null,
+            email: user.email ?? null,
+            avatarUrl: user.avatarUrl ?? null,
+          },
+          watchedSessions: user.watchedSessions ?? [],
+        }));
         return {
           auth: {
             deviceToken: scenario.deviceToken,
@@ -809,6 +838,7 @@ function installControlUiMockGateway(input: {
           protocol: protocolVersion,
           server: { connId: "control-ui-e2e", version: "e2e" },
           snapshot: {
+            ...(presence.length > 0 ? { presence } : {}),
             sessionDefaults: {
               defaultAgentId: scenario.defaultAgentId,
               mainKey: "main",
@@ -818,6 +848,7 @@ function installControlUiMockGateway(input: {
           },
           type: "hello-ok",
         };
+      }
       case "agent.identity.get":
         return {
           agentId: scenario.assistantAgentId,


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #111668: the redesigned who's-online roster rendered with no gap between the avatar and the name/email text, so rows read as cramped and unfinished. Root cause: Web Awesome's dropdown-item spaces its icon slot via `#icon ::slotted(*) { margin-inline-end: 0.75em }`, but the slotted `openclaw-viewer-avatar` host is `display: contents` — it generates no box, so the margin silently never applies.

Separately, the mock harness could not exercise any presence surface: its `system-presence` fixtures carry no user identities, so the footer facepile and roster only rendered against a real gateway (the #111668 screenshots needed manual property injection).

## Why This Change Was Made

- `ui/src/styles/layout.css`: the roster row now owns its avatar-to-text gap (`margin-inline-end: 10px` on the light-DOM `.viewer-avatar`, where a real box exists), with a comment explaining why the slot margin can't do it; row padding bumped 5px → 6px vertical.
- `ui/src/test-helpers/control-ui-e2e.ts`: new optional scenario field `presenceUsers` — the shared mock gateway now emits a `presence` list in the connect snapshot, with the `self`-flagged entry adopting the connecting client's `instanceId` so "you" resolves. Empty by default; existing scenarios and tests are unaffected.
- `scripts/control-ui-mock-dev.ts`: the dev harness ships three presence users (self + named + email-only), lighting up the footer identity, facepile, and roster from fixtures alone — no injection needed to develop or verify presence UI.

## User Impact

Roster rows get proper breathing room between avatar and text in both themes. No runtime behavior change outside CSS; the rest is test/dev tooling.

## Evidence

Fixture-driven captures (no property injection) from `scripts/control-ui-mock-dev.ts`:

| Dark | Light |
| --- | --- |
| ![dark](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/presence-roster-redesign/roster-v2-dark.png) | ![light](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/presence-roster-redesign/roster-v2-light.png) |

- `node scripts/run-vitest.mjs ui/src/test-helpers/control-ui-e2e.mock-gateway.test.ts ui/src/test-helpers/control-ui-e2e.test.ts ui/src/components/viewer-facepile.test.ts` — 14/14 passed.
- `oxfmt --check` clean on all three files; `git diff --check` clean.
- Codex autoreview (`gpt-5.6-sol`, branch vs origin/main) — clean, no findings.
- Live-verified: mock dev server renders footer facepile + roster from the new fixtures (screenshots above).
