### PR TITLE
fix(ui): give markdown list items more breathing room

### DIFF
--- a/ui/src/e2e/route-css.e2e.test.ts
+++ b/ui/src/e2e/route-css.e2e.test.ts
@@ -73,18 +73,27 @@ describeControlUiE2e("Control UI route CSS mocked Gateway E2E", () => {
       const cronStyles = await page.evaluate(() => {
         const probe = document.createElement("div");
         probe.innerHTML = `
-          <div class="chat-text"><ul><li>Item</li></ul><pre><code>code</code></pre></div>
+          <div class="chat-text"><ul><li>First</li><li>Second</li></ul><pre><code>code</code></pre></div>
           <a class="session-link">session</a>
         `;
         document.body.append(probe);
         const list = probe.querySelector("ul");
+        const secondListItem = probe.querySelector("li + li");
         const pre = probe.querySelector("pre");
         const link = probe.querySelector(".session-link");
-        if (!(list instanceof HTMLElement) || !(pre instanceof HTMLElement) || !link) {
+        if (
+          !(list instanceof HTMLElement) ||
+          !(secondListItem instanceof HTMLElement) ||
+          !(pre instanceof HTMLElement) ||
+          !link
+        ) {
           throw new Error("Cron style probe did not render");
         }
+        const listItemStyle = getComputedStyle(secondListItem);
         const result = {
           listPadding: Number.parseFloat(getComputedStyle(list).paddingLeft),
+          listItemGap: Number.parseFloat(listItemStyle.marginTop),
+          listItemFontSize: Number.parseFloat(listItemStyle.fontSize),
           preBorderStyle: getComputedStyle(pre).borderTopStyle,
           preOverflow: getComputedStyle(pre).overflowX,
           sessionFontWeight: getComputedStyle(link).fontWeight,
@@ -94,6 +103,7 @@ describeControlUiE2e("Control UI route CSS mocked Gateway E2E", () => {
         return result;
       });
       expect(cronStyles.listPadding).toBeGreaterThan(0);
+      expect(cronStyles.listItemGap / cronStyles.listItemFontSize).toBeCloseTo(0.4, 2);
       expect(cronStyles.preBorderStyle).toBe("solid");
       expect(cronStyles.preOverflow).toBe("auto");
       expect(cronStyles.sessionFontWeight).toBe("500");

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -60,7 +60,7 @@
 }
 
 .chat-text :where(li + li) {
-  margin-top: 0.25em;
+  margin-top: 0.4em;
 }
 
 /* Hide default marker only for unordered task lists; ordered lists keep numbers */


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users reading Markdown lists in Control UI chat would see adjacent bullet points packed too tightly, making dense answers harder to scan.

## Why This Change Was Made

Increases the chat-only adjacent list-item gap from `0.25em` to `0.4em`. The relative unit preserves text-size scaling, and the existing browser CSS probe now verifies the computed ratio so the spacing does not silently regress.

## User Impact

Markdown bullet and numbered lists in chat have clearer vertical rhythm without changing sidebar previews, file previews, typography, or wrapping behavior.

## Evidence

| Before (`0.25em`) | After (`0.4em`) |
| --- | --- |
| ![Before: tightly spaced Markdown list items](https://github.com/steipete/openclaw-pr-assets/releases/download/pr-111693/before.png) | ![After: roomier Markdown list items](https://github.com/steipete/openclaw-pr-assets/releases/download/pr-111693/after.png) |

- [Full-page before](https://github.com/steipete/openclaw-pr-assets/releases/download/pr-111693/before-full.png) / [full-page after](https://github.com/steipete/openclaw-pr-assets/releases/download/pr-111693/after-full.png) / [proof asset release](https://github.com/steipete/openclaw-pr-assets/releases/tag/pr-111693)
- Blacksmith Testbox `tbx_01kxyy2xactg6ymv5vz6b0gwqf`: `pnpm test ui/src/e2e/route-css.e2e.test.ts` — 1 test passed.
- Same Testbox: `pnpm format:check ui/src/styles/chat/text.css ui/src/e2e/route-css.e2e.test.ts` — passed.
- Same Testbox: `pnpm check:changed` — passed (`coreTests`, `ui`).
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/29717991774
- Claude Fable autoreview (`--mode uncommitted`, max thinking) — clean, no accepted/actionable findings.

AI-assisted implementation; the diff and rendered behavior were reviewed and verified.
