### PR TITLE
chore(pr): warn when ci-dispatch targets a remote head behind local work

### DIFF
--- a/scripts/pr-lib/ci-dispatch.mjs
+++ b/scripts/pr-lib/ci-dispatch.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import { spawnSync } from "node:child_process";
 import { isDirectRunUrl } from "../lib/direct-run.mjs";
 import { execPlainGh } from "../lib/plain-gh.mjs";
 
@@ -126,6 +127,27 @@ async function dispatchCiForPr(
   return undefined;
 }
 
+// Dispatch always targets the REMOTE head; unpushed local work silently gets
+// no CI. Warn (never block) when a same-named local branch points elsewhere,
+// so an operator who meant to test local changes pushes first. Best-effort:
+// any git failure (no repo, no branch) skips the check.
+function warnOnLocalHeadDrift(record) {
+  const probe = spawnSync(
+    "git",
+    ["rev-parse", "--verify", "--quiet", `refs/heads/${record.headRefName}`],
+    { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
+  );
+  if (probe.status !== 0) {
+    return;
+  }
+  const localOid = probe.stdout.trim();
+  if (SHA_PATTERN.test(localOid) && localOid !== record.headRefOid) {
+    console.error(
+      `warning: local branch ${record.headRefName} is at ${localOid}, but CI is being dispatched for the remote head ${record.headRefOid}; push first if you meant to test local changes.`,
+    );
+  }
+}
+
 async function main(argv = process.argv.slice(2)) {
   if (argv.length !== 4 || !["true", "false"].includes(argv[3])) {
     console.error("Usage: ci-dispatch.mjs <PR> <headRefName> <headRefOid> <isCrossRepository>");
@@ -138,6 +160,8 @@ async function main(argv = process.argv.slice(2)) {
     headRefOid: argv[2],
     isCrossRepository: argv[3] === "true",
   };
+  requirePrRecord(record);
+  warnOnLocalHeadDrift(record);
   const run = await dispatchCiForPr(record);
   if (run) {
     console.log(

--- a/test/scripts/pr-ci-dispatch.test.ts
+++ b/test/scripts/pr-ci-dispatch.test.ts
@@ -53,6 +53,7 @@ function runDispatch(
   options: {
     mode?: "observed-head-change" | "pending-head-change";
     immediateTimers?: boolean;
+    cwd?: string;
   } = {},
 ) {
   let nodeOptions = process.env.NODE_OPTIONS ?? "";
@@ -65,6 +66,7 @@ function runDispatch(
     process.execPath,
     [dispatchScript, "12345", "contributor/fix-hosted-gates", sha, "false"],
     {
+      cwd: options.cwd,
       encoding: "utf8",
       env: {
         ...process.env,
@@ -82,6 +84,33 @@ function runDispatch(
 }
 
 describePosix("scripts/pr ci-dispatch", () => {
+  it("warns when a same-named local branch points away from the dispatched remote head", () => {
+    const repo = tempDirs.make("openclaw-pr-ci-dispatch-repo-");
+    const git = (...args: string[]) =>
+      spawnSync("git", args, { cwd: repo, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+    git("init", "-q", "-b", "main");
+    git("-c", "user.email=t@t", "-c", "user.name=t", "commit", "--allow-empty", "-q", "-m", "x");
+    git("branch", "contributor/fix-hosted-gates");
+
+    const fakeGh = createFakeGh();
+    const result = runDispatch(fakeGh, { cwd: repo });
+
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+    expect(result.stderr).toContain("warning: local branch contributor/fix-hosted-gates is at");
+    expect(result.stderr).toContain(`remote head ${sha}`);
+  });
+
+  it("stays silent when no same-named local branch exists", () => {
+    const repo = tempDirs.make("openclaw-pr-ci-dispatch-repo-");
+    spawnSync("git", ["init", "-q", "-b", "main"], { cwd: repo, encoding: "utf8" });
+
+    const fakeGh = createFakeGh();
+    const result = runDispatch(fakeGh, { cwd: repo });
+
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+    expect(result.stderr).not.toContain("warning: local branch");
+  });
+
   it("dispatches the exact CI workflow for the remote PR head", () => {
     const fakeGh = createFakeGh();
     const result = runDispatch(fakeGh);


### PR DESCRIPTION
## What Problem This Solves

`scripts/pr ci-dispatch` deliberately dispatches CI for the PR's *remote* head. When an operator has local commits that failed to push (observed once during the dev-wrapper landing: a rejected force-push followed by a dispatch), the command silently starts CI for stale code — one cancelled run and a re-dispatch later, the mistake is obvious only in hindsight.

## Why This Change Was Made

Before dispatching, `ci-dispatch` now probes `refs/heads/<headRefName>` in the invoking checkout (best-effort, shell-free `git rev-parse`; any git failure skips the check). If a same-named local branch points at a different commit than the remote head being dispatched, it prints a stderr warning naming both SHAs and suggesting a push first. Never blocks — dispatching the remote head remains correct behavior; the warning only surfaces the divergence at decision time. Follow-up noted in #111656's review artifacts.

## User Impact

Maintainer tooling: the dispatch-stale-head footgun announces itself.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/pr-ci-dispatch.test.ts` — 7 passing, including two new hermetic subprocess cases: fixture repo with a drifted same-named branch → warning with both SHAs on stderr, exit 0; fixture repo without the branch → silent.
- Existing dispatch/fork/head-race tests unchanged and green; `git diff --check` clean.
- Autoreview (Codex `gpt-5.6-sol`): clean, patch correct 0.94 (notes shell-free argument passing and safe failure handling).

Release-note context: none needed (maintainer tooling).
