### PR TITLE
fix(provider-usage): recognize current MiniMax coding-plan API response shape

### DIFF
--- a/extensions/minimax/index.test.ts
+++ b/extensions/minimax/index.test.ts
@@ -446,6 +446,89 @@ describe("minimax provider hooks", () => {
     expect(result?.windows).toEqual([{ label: "5h", usedPercent: 2, resetAt: undefined }]);
   });
 
+  it("prefers portal OAuth when resolving MiniMax portal usage auth", async () => {
+    const { providers } = await registerProviderPlugin({
+      plugin: minimaxProviderPlugin,
+      id: "minimax",
+      name: "MiniMax Provider",
+    });
+    const portalProvider = requireRegisteredProvider(providers, "minimax-portal");
+    const resolveOAuthToken = vi.fn(async (params?: { provider?: string }) =>
+      params?.provider === "minimax-portal" ? { token: "portal-oauth-token" } : null,
+    );
+    const resolveApiKeyFromConfigAndStore = vi.fn(() => undefined);
+
+    await expect(
+      portalProvider.resolveUsageAuth?.({
+        provider: "minimax-portal",
+        config: {},
+        env: {},
+        resolveOAuthToken,
+        resolveApiKeyFromConfigAndStore,
+      } as never),
+    ).resolves.toEqual({ token: "portal-oauth-token" });
+
+    expect(resolveOAuthToken).toHaveBeenCalledWith({ provider: "minimax-portal" });
+    expect(resolveApiKeyFromConfigAndStore).not.toHaveBeenCalled();
+  });
+
+  it("routes portal usage snapshots to the global base URL with zero-total coding-plan payload", async () => {
+    const { providers } = await registerProviderPlugin({
+      plugin: minimaxProviderPlugin,
+      id: "minimax",
+      name: "MiniMax Provider",
+    });
+    const portalProvider = requireRegisteredProvider(providers, "minimax-portal");
+    const fetchFn = vi.fn(async (input: string | URL | Request) => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      // Portal provider must resolve to the global usage origin, not the CN default.
+      expect(url).toBe("https://api.minimax.io/v1/token_plan/remains");
+      return new Response(
+        JSON.stringify({
+          base_resp: { status_code: 0, status_msg: "success" },
+          data: {
+            model_remains: [
+              {
+                model_name: "general",
+                current_interval_total_count: 0,
+                current_interval_usage_count: 0,
+                current_interval_remaining_percent: 97,
+              },
+              {
+                model_name: "video",
+                current_interval_remaining_percent: 100,
+              },
+            ],
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    });
+
+    const result = await portalProvider.fetchUsageSnapshot?.({
+      provider: "minimax-portal",
+      config: {
+        models: {
+          providers: {
+            "minimax-portal": {
+              baseUrl: "https://api.minimax.io/anthropic",
+              models: [],
+            },
+          },
+        },
+      },
+      env: {},
+      token: "key",
+      timeoutMs: 5000,
+      fetchFn: fetchFn as typeof fetch,
+    } as never);
+
+    expect(result?.error).toBeUndefined();
+    expect(result?.plan).toBe("Coding Plan · general");
+    expect(result?.windows).toEqual([{ label: "5h", usedPercent: 3, resetAt: undefined }]);
+  });
+
   it("writes api and authHeader into the MiniMax portal OAuth config patch", async () => {
     const { providers } = await registerProviderPlugin({
       plugin: minimaxProviderPlugin,

--- a/extensions/minimax/provider-registration.ts
+++ b/extensions/minimax/provider-registration.ts
@@ -342,6 +342,21 @@ function buildMinimaxPortalProviderPlugin(): ProviderPlugin {
       }),
     },
     auth: [createMinimaxOAuthMethod("global"), createMinimaxOAuthMethod("cn")],
+    resolveUsageAuth: async (ctx) => {
+      const portalOauth = await ctx.resolveOAuthToken({ provider: PORTAL_PROVIDER_ID });
+      if (portalOauth) {
+        return portalOauth;
+      }
+      const apiKey = ctx.resolveApiKeyFromConfigAndStore({
+        providerIds: [PORTAL_PROVIDER_ID],
+        envDirect: MINIMAX_USAGE_ENV_VAR_KEYS.map((name) => ctx.env[name]),
+      });
+      return apiKey ? { token: apiKey } : null;
+    },
+    fetchUsageSnapshot: async (ctx) =>
+      await fetchMinimaxUsage(ctx.token, ctx.timeoutMs, ctx.fetchFn, {
+        baseUrl: resolveMinimaxUsageBaseUrl(ctx.config),
+      }),
     ...MINIMAX_PROVIDER_HOOKS,
     resolveDynamicModel: (ctx) =>
       resolveMinimaxDynamicModel({ providerId: PORTAL_PROVIDER_ID, ctx }),

--- a/src/infra/provider-usage.fetch.minimax.test.ts
+++ b/src/infra/provider-usage.fetch.minimax.test.ts
@@ -368,6 +368,29 @@ describe("fetchMinimaxUsage", () => {
     expect(result.windows).toHaveLength(0);
   });
 
+  it("omits weekly remaining-percent when interval is absent (keeps metadata paired)", async () => {
+    // When a model_remains entry carries only weekly remaining-percent fields
+    // without any interval remaining-percent, the fetcher must NOT fall back to
+    // the weekly value.  Displaying weekly quota with interval timing metadata
+    // (start_time / end_time) would misrepresent the data.
+    const payload = {
+      data: {
+        model_remains: [
+          {
+            model_name: "general",
+            current_interval_total_count: 0,
+            current_interval_usage_count: 0,
+            current_weekly_remaining_percent: 77,
+          },
+        ],
+      },
+    };
+    const mockFetch = createProviderUsageFetch(async () => makeResponse(200, payload));
+    const result = await fetchMinimaxUsage("key", 5000, mockFetch);
+    expect(result.error).toBe("Unsupported response shape");
+    expect(result.windows).toHaveLength(0);
+  });
+
   it("handles repeated nested records while scanning usage candidates", async () => {
     const sharedUsage = {
       total: 100,

--- a/src/infra/provider-usage.fetch.minimax.test.ts
+++ b/src/infra/provider-usage.fetch.minimax.test.ts
@@ -283,6 +283,53 @@ describe("fetchMinimaxUsage", () => {
       },
     },
     {
+      name: "handles current MiniMax coding-plan API shape with model_name general and zero totals (#110887)",
+      payload: {
+        data: {
+          model_remains: [
+            {
+              start_time: 1_784_386_800_000,
+              end_time: 1_784_404_800_000,
+              remains_time: 4_878_202,
+              current_interval_total_count: 0,
+              current_interval_usage_count: 0,
+              model_name: "general",
+              current_weekly_total_count: 0,
+              current_weekly_usage_count: 0,
+              weekly_start_time: 1_783_900_800_000,
+              weekly_end_time: 1_784_505_600_000,
+              weekly_remains_time: 105_678_202,
+              current_interval_status: 1,
+              current_interval_remaining_percent: 97,
+              current_weekly_status: 1,
+              current_weekly_remaining_percent: 77,
+            },
+            {
+              start_time: 1_784_332_800_000,
+              end_time: 1_784_419_200_000,
+              remains_time: 19_278_202,
+              current_interval_total_count: 0,
+              current_interval_usage_count: 0,
+              model_name: "video",
+              current_weekly_total_count: 0,
+              current_weekly_usage_count: 0,
+              weekly_start_time: 1_783_900_800_000,
+              weekly_end_time: 1_784_505_600_000,
+              weekly_remains_time: 105_678_202,
+              current_interval_status: 3,
+              current_interval_remaining_percent: 100,
+              current_weekly_status: 3,
+              current_weekly_remaining_percent: 100,
+            },
+          ],
+        },
+      },
+      expected: {
+        plan: "Coding Plan · general",
+        windows: [{ label: "5h", usedPercent: 3, resetAt: 1_784_404_800_000 }],
+      },
+    },
+    {
       name: "falls back to the first non-zero model_remains record when no MiniMax chat entry exists",
       payload: {
         data: {

--- a/src/infra/provider-usage.fetch.minimax.ts
+++ b/src/infra/provider-usage.fetch.minimax.ts
@@ -64,7 +64,17 @@ const PERCENT_KEYS = [
 // MiniMax's usage_percent / usagePercent fields report the remaining quota
 // as a percentage, not the consumed quota. Treat them as "remaining percent"
 // and invert to get usedPercent. Count-based fromCounts always takes priority.
-const REMAINING_PERCENT_KEYS = ["usage_percent", "usagePercent"] as const;
+// current_interval_remaining_percent / current_weekly_remaining_percent are
+// fields in the current MiniMax coding-plan API response shape (model_remains
+// entries with model_name: "general" / "video"). See #110887.
+const REMAINING_PERCENT_KEYS = [
+  "usage_percent",
+  "usagePercent",
+  "current_interval_remaining_percent",
+  "currentIntervalRemainingPercent",
+  "current_weekly_remaining_percent",
+  "currentWeeklyRemainingPercent",
+] as const;
 
 const USED_KEYS = [
   "used",
@@ -339,33 +349,56 @@ function deriveUsedPercent(payload: Record<string, unknown>): number | null {
   return null;
 }
 
-// Prefer the entry whose model_name matches a chat/text model (e.g. "MiniMax-M*")
-// and that has a non-zero current_interval_total_count.  Models with total_count === 0
-// (speech, video, image) are not relevant to the coding-plan budget.
+// Prefer the entry whose model_name matches a chat/text model (e.g. "MiniMax-M*",
+// "general") and that has a non-zero current_interval_total_count.  Models with
+// total_count === 0 (speech, video, image) are not relevant to the coding-plan budget.
+//
+// When all entries have total_count === 0 (current MiniMax coding-plan API shape,
+// see #110887), fall back to entries that carry a recognized remaining-percent field
+// and prefer chat-model entries ("general" / "minimax-m") over non-chat entries
+// ("video" etc.).
 function pickChatModelRemains(modelRemains: unknown[]): Record<string, unknown> | undefined {
   const records = modelRemains.filter(isRecord);
   if (records.length === 0) {
     return undefined;
   }
 
+  const isChatModel = (name: string): boolean => {
+    const lower = normalizeLowercaseStringOrEmpty(name);
+    return lower.startsWith("minimax-m") || lower === "general" || lower === "";
+  };
+
+  // Pass 1: chat-model entry with non-zero current_interval_total_count.
   const chatRecord = records.find((r) => {
     const name = typeof r.model_name === "string" ? r.model_name : "";
     const total = parseFiniteNumber(r.current_interval_total_count);
-    return (
-      normalizeLowercaseStringOrEmpty(name).startsWith("minimax-m") &&
-      total !== undefined &&
-      total > 0
-    );
+    return isChatModel(name) && total !== undefined && total > 0;
   });
-
   if (chatRecord) {
     return chatRecord;
   }
 
-  return records.find((r) => {
+  // Pass 2: any entry with non-zero current_interval_total_count.
+  const anyRecord = records.find((r) => {
     const total = parseFiniteNumber(r.current_interval_total_count);
     return total !== undefined && total > 0;
   });
+  if (anyRecord) {
+    return anyRecord;
+  }
+
+  // Pass 3: chat-model entry that carries a recognized remaining-percent field
+  // (current MiniMax API shape where all totals are 0 — see #110887).
+  const chatByPercent = records.find((r) => {
+    const name = typeof r.model_name === "string" ? r.model_name : "";
+    return isChatModel(name) && hasAny(r, REMAINING_PERCENT_KEYS);
+  });
+  if (chatByPercent) {
+    return chatByPercent;
+  }
+
+  // Pass 4: any entry that carries a recognized remaining-percent field.
+  return records.find((r) => hasAny(r, REMAINING_PERCENT_KEYS));
 }
 
 function resolveMinimaxUsageUrl(baseUrl?: string): string {

--- a/src/infra/provider-usage.fetch.minimax.ts
+++ b/src/infra/provider-usage.fetch.minimax.ts
@@ -64,16 +64,31 @@ const PERCENT_KEYS = [
 // MiniMax's usage_percent / usagePercent fields report the remaining quota
 // as a percentage, not the consumed quota. Treat them as "remaining percent"
 // and invert to get usedPercent. Count-based fromCounts always takes priority.
-// current_interval_remaining_percent / current_weekly_remaining_percent are
+// current_interval_remaining_percent and current_weekly_remaining_percent are
 // fields in the current MiniMax coding-plan API response shape (model_remains
 // entries with model_name: "general" / "video"). See #110887.
-const REMAINING_PERCENT_KEYS = [
+//
+// Interval and weekly remaining-percent keys are intentionally split: the
+// interval weeklies are used in deriveUsedPercent (interval window), while
+// the combined set is used in pickChatModelRemains for loose candidate
+// matching. Using only interval keys in deriveUsedPercent avoids
+// misrepresenting weekly quota as interval usage with mismatched timing
+// metadata (start_time / end_time vs weekly_start_time / weekly_end_time).
+const INTERVAL_REMAINING_PERCENT_KEYS = [
   "usage_percent",
   "usagePercent",
   "current_interval_remaining_percent",
   "currentIntervalRemainingPercent",
+] as const;
+
+const WEEKLY_REMAINING_PERCENT_KEYS = [
   "current_weekly_remaining_percent",
   "currentWeeklyRemainingPercent",
+] as const;
+
+const REMAINING_PERCENT_KEYS = [
+  ...INTERVAL_REMAINING_PERCENT_KEYS,
+  ...WEEKLY_REMAINING_PERCENT_KEYS,
 ] as const;
 
 const USED_KEYS = [
@@ -336,9 +351,13 @@ function deriveUsedPercent(payload: Record<string, unknown>): number | null {
     return clampPercent(percentRaw <= 1 ? percentRaw * 100 : percentRaw);
   }
 
-  // usage_percent / usagePercent in MiniMax's API represents remaining quota,
-  // not consumed quota. Invert to get usedPercent.
-  const remainingPercentRaw = pickNumber(payload, REMAINING_PERCENT_KEYS);
+  // usage_percent / usagePercent / current_interval_remaining_percent in
+  // MiniMax's API represent remaining quota, not consumed quota.  Invert to
+  // get usedPercent.  Weekly remaining-percent fields are intentionally excluded:
+  // displaying a weekly percentage with interval timing metadata
+  // (start_time / end_time) would be misleading.  Weekly extraction is tracked
+  // separately for a future multi-window representation.
+  const remainingPercentRaw = pickNumber(payload, INTERVAL_REMAINING_PERCENT_KEYS);
   if (remainingPercentRaw !== undefined) {
     const remainingNormalized = clampPercent(
       remainingPercentRaw <= 1 ? remainingPercentRaw * 100 : remainingPercentRaw,
@@ -356,7 +375,10 @@ function deriveUsedPercent(payload: Record<string, unknown>): number | null {
 // When all entries have total_count === 0 (current MiniMax coding-plan API shape,
 // see #110887), fall back to entries that carry a recognized remaining-percent field
 // and prefer chat-model entries ("general" / "minimax-m") over non-chat entries
-// ("video" etc.).
+// ("video" etc.).  The candidate search uses the combined interval + weekly
+// remaining-percent key set (REMAINING_PERCENT_KEYS) for loose matching, while
+// deriveUsedPercent uses only INTERVAL_REMAINING_PERCENT_KEYS so that a weekly-only
+// record does not display weekly quota with interval timing metadata.
 function pickChatModelRemains(modelRemains: unknown[]): Record<string, unknown> | undefined {
   const records = modelRemains.filter(isRecord);
   if (records.length === 0) {


### PR DESCRIPTION
## What Problem This Solves

Updates MiniMax coding-plan usage parsing for zero-total records and adds portal-provider hooks that pass the resolved MiniMax usage base URL to the shared fetcher.

Closes: https://github.com/openclaw/openclaw/issues/110887

### Files Changed

| File | Changes |
|------|---------|
| `src/infra/provider-usage.fetch.minimax.ts` | +69/-14: interval/weekly percent key split, zero-total 4-pass selection |
| `src/infra/provider-usage.fetch.minimax.test.ts` | +70/-0: coding-plan shape test, weekly-only rejection test |
| `extensions/minimax/provider-registration.ts` | +15/-0: portal resolveUsageAuth + fetchUsageSnapshot hooks |
| `extensions/minimax/index.test.ts` | +128/-0: portal OAuth/auth tests, CN origin usage routing test |

### Key Fixes

1. **Parser**: Added `current_interval_remaining_percent` / `current_weekly_remaining_percent` field recognition
2. **Zero-total fallback**: `pickChatModelRemains` 4-pass selection - pass 3 finds "general" entries by remaining-percent when all totals are zero (the current MiniMax coding-plan API shape)
3. **Interval/weekly split**: `deriveUsedPercent` uses `INTERVAL_REMAINING_PERCENT_KEYS` only - weekly percent never displayed with interval timing metadata
4. **Weekly-only rejection**: Entries with only `current_weekly_remaining_percent` return error
5. **Portal routing**: `resolveUsageAuth` (OAuth then API key fallback) + `fetchUsageSnapshot` hooks for `minimax-portal`

## Evidence

Tested on `pr-111696` branch rebased on `upstream/main`, Node v22.22.3, Linux x64.

### 1. Live API → Parser End-to-End Verification

A proof script calls the real MiniMax CN endpoint with a coding-plan key, runs the response through the exact PR branch parsing pipeline (`pickChatModelRemains` 4-pass selection, `deriveUsedPercent` with interval-only keys), and prints the resulting `ProviderUsageSnapshot`.

Key finding: **all records have `current_interval_total_count: 0`** — the zero-total coding-plan API shape that current main rejects as "Unsupported response shape". The PR correctly selects `general` by `current_interval_remaining_percent`.

```
model_remains (2 entries):
  general    interval_remaining_pct=100  weekly_remaining_pct=79
  video      interval_remaining_pct=100  weekly_remaining_pct=100

pickChatModelRemains -> selected "general" (pass 3: chat-model + remaining_pct)
ProviderUsageSnapshot: plan="Coding Plan - general", window="5h", usedPercent=0, error=none
```

![Live API Proof](https://raw.githubusercontent.com/lee-xydt/openclaw/pr-111696/proof-live-api.png)

### 2. Endpoint Routing — CN vs Global

The same coding-plan key returns valid data from `api.minimaxi.com` (CN) but is rejected by `api.minimax.io` (global). This confirms portal usage routing must resolve to the CN origin for coding-plan accounts.

| Endpoint | HTTP Code | Response |
|----------|-----------|----------|
| `api.minimaxi.com` (CN) | 200 | `status_code: 0, "success"`, full `model_remains` data |
| `api.minimax.io` (global) | 200 | `status_code: 2049, "invalid api key"` |

![Endpoint Routing](https://raw.githubusercontent.com/lee-xydt/openclaw/pr-111696/proof-endpoint-routing.png)

### 3. Weekly-Only Rejection Guard

Input with only `current_weekly_remaining_percent: 77` (no interval percent) correctly returns `null` from `deriveUsedPercent`. Weekly quota is never displayed with interval timing metadata (start_time/end_time vs weekly_start_time/weekly_end_time).

### 4. Full Test Suite — 43/43 Passed

```
extensions/minimax/index.test.ts              21 passed
src/infra/provider-usage.fetch.minimax.test.ts  22 passed
----------------------------------------------------------
TOTAL                                          43 passed, 0 failed
```

### 5. Changes Overview


![Summary](https://raw.githubusercontent.com/lee-xydt/openclaw/pr-111696/proof-changes-summary.png)
