### PR TITLE
fix: prevent fresh-state gateway startup timeouts

### DIFF
--- a/src/agents/prepared-model-runtime.lifecycle.test.ts
+++ b/src/agents/prepared-model-runtime.lifecycle.test.ts
@@ -107,7 +107,8 @@ describe("prepared model runtime snapshots", () => {
     getTesting().resetPreparedModelRuntimeSnapshotsForTest();
     mocks.discoverAuthStorage.mockClear();
     mocks.discoverModels.mockClear();
-    mocks.ensureOpenClawModelsJson.mockClear();
+    mocks.ensureOpenClawModelsJson.mockReset();
+    mocks.ensureOpenClawModelsJson.mockResolvedValue({ agentDir: "/tmp/agent", wrote: false });
     mocks.buildPreparedModelCatalogSnapshot.mockClear();
     mocks.ensureRuntimePluginsLoaded.mockClear();
     mocks.loadStaticCatalog.mockClear();
@@ -698,6 +699,22 @@ describe("prepared model runtime snapshots", () => {
         }),
       ).rejects.toBe(refreshError);
     }
+  });
+
+  it("does not replay an auth mutation that occurs before the first owner is registered", async () => {
+    getTesting().setModelRuntimeBuildTimeoutMsForTest(100);
+    mocks.configuredAgentIds = ["default"];
+    mocks.ensureRuntimePluginsLoaded.mockImplementationOnce(() => {
+      mocks.mutationListener?.({ affectsInheritedStores: true });
+    });
+    mocks.ensureOpenClawModelsJson
+      .mockResolvedValueOnce({ agentDir: "/tmp/unused-agent", wrote: false })
+      .mockImplementationOnce(async () => await new Promise<never>(() => {}));
+
+    await expect(
+      refreshPreparedModelRuntimeSnapshots({}, { gatewayLifecycle: true }),
+    ).resolves.toBeUndefined();
+    expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledOnce();
   });
 
   it("awaits auth invalidation queued during lifecycle publication", async () => {

--- a/src/agents/prepared-model-runtime.ts
+++ b/src/agents/prepared-model-runtime.ts
@@ -698,6 +698,7 @@ function invalidateForAuthMutation(event: AuthMutationEvent): void {
     agentDir: normalizeOptionalDir(event.agentDir),
   };
   const staleError = new Error("prepared model runtime owner is stale after auth mutation");
+  let invalidatedOwner = false;
   for (const owner of owners.values()) {
     if (
       !normalizedEvent.affectsInheritedStores &&
@@ -706,9 +707,15 @@ function invalidateForAuthMutation(event: AuthMutationEvent): void {
     ) {
       continue;
     }
+    invalidatedOwner = true;
     owner.generation += 1;
     owner.needsRefresh = true;
     owner.refreshError = staleError;
+  }
+  if (!invalidatedOwner) {
+    // A first owner reads the already-published auth snapshot while it builds. Replaying an earlier
+    // mutation would immediately stale that initial generation even though no prior owner existed.
+    return;
   }
   pendingAuthMutations.push(normalizedEvent);
   void enqueuePreparedModelRuntimePublication(drainPendingAuthMutations).catch((error: unknown) => {


### PR DESCRIPTION
Closes #111627

## What Problem This Solves

Fixes an issue where any cold-start gateway boot on a fresh state directory could time out during prepared model runtime publication. The symptom surfaced through `openclaw doctor --fix`, where the command announced legacy config migrations but exited before persisting them, but the impact was broader than doctor: a first-run Gateway could fail before reaching readiness.

## Why This Change Was Made

Commit 06f5f73e473 (#111173, "own model discovery by runtime lifecycle") caused an auth mutation that fired before the first prepared-runtime owner registered to enqueue a superseding publication. That replay staled the first owner's initial generation before it could complete, producing `prepared model runtime owner is stale after auth mutation` followed by `prepared model runtime publication timed out`.

The fix skips mutation replay only when no existing owner was invalidated. Existing-owner invalidation and refresh behavior remains unchanged. An independent maintainer bisect pinned the regression to 06f5f73e473: its parent e24420bc1c0 reaches `[gateway] ready`, while 06f5f73e473 does not.

AI-assisted implementation; the maintainer reviewed the behavior and root-cause boundary before submission.

## User Impact

First-run gateways on fresh state directories now reach readiness, and `openclaw doctor --fix` can complete and persist config migrations instead of timing out after announcing them.

## Evidence

- Regression and sibling lifecycle suites: 2 files, 64 tests passed on Blacksmith Testbox run https://github.com/openclaw/openclaw/actions/runs/29722098817.
- Negative control: temporarily removing the production guard makes `does not replay an auth mutation that occurs before the first owner is registered` fail with `prepared model runtime publication timed out`; restoring it passes.
- Doctor persistence proof on a fresh state directory:
  - before mtime: `1784529155`; content: `{"tui":{"footer":{"showRemoteHost":true}}}`
  - after mtime: `1784529177`; retired `tui` key absent; `Doctor complete`; no publication timeout.
- Fresh-state Gateway proof on Blacksmith Testbox run https://github.com/openclaw/openclaw/actions/runs/29721771703: `2026-07-20T06:31:41.487+00:00 [gateway] ready`, with no `startup_failed` stability bundle.
- `pnpm deadcode:exports`: production, full-tree, and script scans passed with zero unused exports.
- `pnpm format` on both touched files and `git diff --check`: passed.
- A live LLM turn is intentionally not included because the current box has transient degraded model-provider egress; the network-free Gateway readiness and doctor persistence repros are authoritative for this startup regression.
