### PR TITLE
fix(board): prevent emoji corruption in event notices

### DIFF
--- a/src/boards/board-notices.ts
+++ b/src/boards/board-notices.ts
@@ -1,3 +1,4 @@
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { enqueueSystemEvent } from "../infra/system-events.js";
 
 const BOARD_EVENT_MAX_BYTES = 8 * 1024;
@@ -27,7 +28,9 @@ function formatNotice(widget: string, summary: string): string {
   const suffix = ` on widget ${widget}`;
   const available = BOARD_NOTICE_MAX_CHARS - prefix.length - suffix.length;
   const clipped =
-    summary.length <= available ? summary : `${summary.slice(0, Math.max(0, available - 1))}…`;
+    summary.length <= available
+      ? summary
+      : `${truncateUtf16Safe(summary, Math.max(0, available - 1))}…`;
   return `${prefix}${clipped}${suffix}`;
 }
 

--- a/src/gateway/server-methods/board.test.ts
+++ b/src/gateway/server-methods/board.test.ts
@@ -1029,6 +1029,29 @@ describe("board gateway methods", () => {
     expect(oversized.mock.calls[0]?.[0]).toBe(false);
   });
 
+  it("does not split surrogate pairs when truncating board.event notices", async () => {
+    const { invoke } = createHarness();
+    await invoke("board.widget.put", {
+      sessionKey: "session",
+      name: "counter",
+      content: { kind: "html", html: "ok" },
+    });
+    const prefix = "[dashboard] ";
+    const suffix = " on widget counter";
+    const clippedCodeUnits = 500 - prefix.length - suffix.length - 1;
+
+    await invoke("board.event", {
+      sessionKey: "session",
+      widget: "counter",
+      payload: `${"x".repeat(clippedCodeUnits - 2)}😀tail`,
+    });
+
+    const notice = peekSystemEvents("session")[0] ?? "";
+    expect(notice.length).toBeLessThanOrEqual(500);
+    expect(notice).not.toContain(String.fromCharCode(0xd83d));
+    expect(notice).toMatch(/… on widget counter$/u);
+  });
+
   it("keeps board state across the real sessions.reset handler", async () => {
     const sessionKey = "agent:main:board-reset-proof";
     const stateDir = tempDirs.make("openclaw-board-reset-");

--- a/src/gateway/server-methods/board.test.ts
+++ b/src/gateway/server-methods/board.test.ts
@@ -1008,50 +1008,33 @@ describe("board gateway methods", () => {
     expect(triggerCronJob).toHaveBeenCalledWith("job-1", expect.any(Object));
   });
 
-  it("caps board.event payloads at 8KB and notices at 500 characters", async () => {
+  it("caps board.event payloads and preserves Unicode at the notice boundary", async () => {
     const { invoke } = createHarness();
     await invoke("board.widget.put", {
       sessionKey: "session",
       name: "counter",
       content: { kind: "html", html: "ok" },
     });
+    const clippedCodeUnits = 500 - "[dashboard] ".length - " on widget counter".length - 1;
+    // JSON's opening quote places the emoji across the legacy slice boundary.
+    const payload = `${"x".repeat(clippedCodeUnits - 2)}😀tail`;
+    await invoke("board.event", { sessionKey: "session", widget: "counter", payload });
+    const unicodeNotice = peekSystemEvents("session")[0] ?? "";
+    expect(unicodeNotice.length).toBeLessThanOrEqual(500);
+    expect(unicodeNotice).not.toContain(String.fromCharCode(0xd83d));
+    expect(unicodeNotice).toMatch(/… on widget counter$/u);
     await invoke("board.event", {
       sessionKey: "session",
       widget: "counter",
       payload: "x".repeat(1_000),
     });
-    expect(peekSystemEvents("session")[0]).toHaveLength(500);
+    expect(peekSystemEvents("session")[1]).toHaveLength(500);
     const oversized = await invoke("board.event", {
       sessionKey: "session",
       widget: "counter",
       payload: "x".repeat(8_193),
     });
     expect(oversized.mock.calls[0]?.[0]).toBe(false);
-  });
-
-  it("does not split surrogate pairs when truncating board.event notices", async () => {
-    const { invoke } = createHarness();
-    await invoke("board.widget.put", {
-      sessionKey: "session",
-      name: "counter",
-      content: { kind: "html", html: "ok" },
-    });
-    const prefix = "[dashboard] ";
-    const suffix = " on widget counter";
-    const clippedCodeUnits = 500 - prefix.length - suffix.length - 1;
-
-    // JSON serialization adds a leading quote, placing the emoji's high surrogate
-    // at the old slice boundary when the payload contains clippedCodeUnits - 2 ASCII units.
-    await invoke("board.event", {
-      sessionKey: "session",
-      widget: "counter",
-      payload: `${"x".repeat(clippedCodeUnits - 2)}😀tail`,
-    });
-
-    const notice = peekSystemEvents("session")[0] ?? "";
-    expect(notice.length).toBeLessThanOrEqual(500);
-    expect(notice).not.toContain(String.fromCharCode(0xd83d));
-    expect(notice).toMatch(/… on widget counter$/u);
   });
 
   it("keeps board state across the real sessions.reset handler", async () => {

--- a/src/gateway/server-methods/board.test.ts
+++ b/src/gateway/server-methods/board.test.ts
@@ -1040,6 +1040,8 @@ describe("board gateway methods", () => {
     const suffix = " on widget counter";
     const clippedCodeUnits = 500 - prefix.length - suffix.length - 1;
 
+    // JSON serialization adds a leading quote, placing the emoji's high surrogate
+    // at the old slice boundary when the payload contains clippedCodeUnits - 2 ASCII units.
     await invoke("board.event", {
       sessionKey: "session",
       widget: "counter",

--- a/test/scripts/pr-wrappers.test.ts
+++ b/test/scripts/pr-wrappers.test.ts
@@ -39,8 +39,12 @@ function makeMismatchedWrapperRepo() {
   const originPath = join(root, "origin.git");
   mkdirSync(bin, { recursive: true });
   mkdirSync(home, { recursive: true });
-  writeFileSync(join(bin, "rg"), "#!/usr/bin/env sh\nexit 0\n");
-  chmodSync(join(bin, "rg"), 0o755);
+  // This fixture exercises wrapper trust routing, not the host command inventory.
+  for (const command of ["jq", "pnpm", "rg"]) {
+    const commandPath = join(bin, command);
+    writeFileSync(commandPath, "#!/bin/sh\nexit 0\n");
+    chmodSync(commandPath, 0o755);
+  }
 
   const fixtureEnv = {
     ...process.env,
@@ -186,6 +190,7 @@ describe("scripts/pr wrappers", () => {
     try {
       rmSync(join(fixture.bin, "rg"));
       for (const command of ["bash", "basename", "dirname", "git", "jq", "pnpm", "node"]) {
+        rmSync(join(fixture.bin, command), { force: true });
         symlinkSync(resolveCommand(command), join(fixture.bin, command));
       }
 


### PR DESCRIPTION
## What Problem This Solves

Long dashboard board.event payloads can split an emoji surrogate pair at the existing 500-character notice limit, publishing corrupted Unicode in the user-visible session event.

## Outcome

What problem does this PR solve?

Dashboard widget events with long Unicode payloads could show a replacement character when the 500-character notice limit landed inside an emoji. The `board.event` Gateway path could emit a lone UTF-16 surrogate into the session system event instead of a well-formed notice.

What is the intended outcome?

Root-cause fix. Board notice formatting must preserve the existing 500 UTF-16-code-unit envelope and widget suffix without cutting a surrogate pair.

What is intentionally out of scope?

The public `board.event` request/response protocol, widget persistence, payload-size cap, deduplication window, notice limit, and configuration are not changed. The related open PR scan and current PR discussion did not identify a separate canonical contract change to adopt; this remains an internal board-notice normalization fix.

## Why This Change Was Made

The canonical owner is `src/boards/board-notices.ts`, where the serialized payload becomes the queued human-readable notice. The old raw string slice could stop after an emoji's high surrogate. The fix uses the repository's shared surrogate-safe UTF-16 truncation capability at that owner boundary, before `enqueueSystemEvent` stores text for the session consumer.

The numeric subtraction is not a new product threshold: one UTF-16 code unit is reserved for the literal ellipsis already required by the notice format, while the existing 500-unit limit and full widget suffix remain unchanged. This fixes the normalization invariant rather than adding a downstream replacement-character cleanup.

The branch also keeps the existing `scripts/pr` wrapper fixture independent of the host's optional `rg`, `jq`, and `pnpm` inventory. That test-only change does not alter product or wrapper behavior.

## User Impact

Users can receive long dashboard widget event summaries without emoji or other supplementary Unicode characters being corrupted at the truncation boundary.

## Risk

What is the highest-risk area?

The merge risk is availability and message integrity at the Gateway-to-session system-event boundary: an incorrect truncation budget could exceed the existing notice cap, remove the widget suffix, or change queue behavior.

How is that risk mitigated?

The change is confined to the canonical notice formatter, preserves every existing limit and queue contract, adds a focused boundary regression, and is backed by a live production-Gateway WebSocket run that observed the actual queued event. No public contract, persistence, or configuration surface changes.

## Evidence

- Fresh complete-branch xhigh autoreview passed with 0.99 confidence.
- Verified current main publishes a 500-character notice containing a dangling high surrogate; repaired head publishes a valid 499-character notice with the same ellipsis and widget suffix.\n- Rebased-head Gateway board suite: 30/30 passed.\n- Rebased-head maintainer wrapper suite: 13/13 passed.

- Exact current-main port head: `0ad37857e3de548855c778b50e57b7c2d716b84b`.
- `src/gateway/server-methods/board.test.ts`: 28 tests passed, including the surrogate-boundary regression.
- `test/scripts/pr-wrappers.test.ts`: 12 tests passed. The local Git 2.27 runner used a bootstrap-only compatibility shim for newer `git init -b` and `rev-parse --path-format=absolute` syntax; all other Git commands passed through unchanged.
- `oxfmt --check` passed for all three changed files.
- `pnpm check:max-lines-ratchet --base f466c3de326e34f02caac610f601fffb8f413768` passed on the exact synthetic merge preview (1136 grandfathered suppressions).

## Real Behavior Proof

An isolated production Gateway was started from the exact current head with temporary state and a loopback token. A real `GatewayClient` WebSocket connection then:

1. created and listed a live session,
2. installed the `counter` widget through `board.widget.put`,
3. confirmed it through `board.get`,
4. sent a payload through `board.event` whose emoji high surrogate landed at the legacy truncation edge, and
5. inspected the system event queued by the same Gateway process.

```text
BOARD_EVENT_APPENDED=true
SYSTEM_EVENT_COUNT=1
NOTICE_UTF16_CODE_UNITS=499
NOTICE_MAX_UTF16_CODE_UNITS=500
NOTICE_HAS_ELLIPSIS=true
NOTICE_ENDS_WITH_EXPECTED_SUFFIX=true
NOTICE_LONE_SURROGATE_INDEXES=[]
```

This proof exercised production WebSocket authentication and routing, board handlers and store, JSON serialization, surrogate-safe truncation, and the real system-event queue. Only the loopback port, temporary configuration/state, authentication token, and final in-process queue observation were test-owned.
