### PR TITLE
fix(google-meet): reject malformed calendar events.list envelopes

### DIFF
--- a/extensions/google-meet/src/calendar.test.ts
+++ b/extensions/google-meet/src/calendar.test.ts
@@ -66,6 +66,25 @@ describe("Google Calendar requests", () => {
     expect(signal?.aborted).toBe(true);
     await rejection;
   });
+
+  it.each([
+    ["null", "null"],
+    ["array", "[]"],
+  ])("rejects a %s events.list envelope with a stable provider error", async (_kind, body) => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(body, {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+      ),
+    );
+    await expect(listGoogleMeetCalendarEvents({ accessToken: "test-token" })).rejects.toThrow(
+      "Google Calendar events.list: malformed JSON response",
+    );
+  });
 });
 
 describe("Google Meet calendar URL extraction", () => {

--- a/extensions/google-meet/src/calendar.ts
+++ b/extensions/google-meet/src/calendar.ts
@@ -1,4 +1,4 @@
-import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
+import { readProviderJsonObjectResponse } from "openclaw/plugin-sdk/provider-http";
 // Google Meet plugin module implements calendar behavior.
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { googleApiError } from "./google-api-errors.js";
@@ -237,10 +237,7 @@ async function fetchGoogleCalendarEvents(params: {
         scopes: [GOOGLE_CALENDAR_EVENTS_SCOPE],
       });
     }
-    const payload = await readProviderJsonResponse<{ items?: unknown }>(
-      response,
-      "Google Calendar events.list",
-    );
+    const payload = await readProviderJsonObjectResponse(response, "Google Calendar events.list");
     if (payload.items !== undefined && !Array.isArray(payload.items)) {
       throw new Error("Google Calendar events.list response had non-array items");
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `listGoogleMeetCalendarEvents` could receive a successful HTTP 200 response from the Google Calendar events.list endpoint with a `null` or array JSON body, then either crash with a raw `TypeError` (`null` body -> `null.items`) or silently return an empty event list (array body -> `[].items` is `undefined`, which passes the existing non-array `items` guard and yields `events: []`). Both cases misrepresent a malformed upstream response as a working result instead of a stable provider error.

The calendar reader now uses `readProviderJsonObjectResponse`, which enforces the top-level object envelope that the Google Calendar API contract requires. The existing bounded body reader, 30s request timeout, SSRF host allow-list, non-array `items` guard, and valid payload handling remain unchanged.

## Why This Change Was Made

`readProviderJsonResponse<T>` parses the body as `JSON.parse(...) as T` without verifying the top-level shape, so a `null` or array body is cast straight to the caller's expected type. `readProviderJsonObjectResponse` layers `asObject(payload)` on top and throws the caller's `<label>: malformed JSON response` boundary error when the envelope is not an object. This mirrors the approach already adopted for Firecrawl search/scrape and media-understanding audio readers.

## User Impact

Malformed upstream Calendar responses fail with the existing provider-owned `malformed JSON response` boundary instead of a raw `TypeError` or an empty event list. Valid Calendar responses continue through the same events.list path unchanged.

## Evidence

- Base: `main` at `250e636ffd0132fe8cee6054fd5a90a5cd748d9e`.
- Head: `8cd85882056ed4da613559eed21796a64f136962`.
- Focused tests: `node scripts/run-vitest.mjs extensions/google-meet/src/calendar.test.ts --run` -> 1 file, 6/6 tests passed. Added 2 cases (`null` and `[]` bodies) asserting `listGoogleMeetCalendarEvents` rejects with `Google Calendar events.list: malformed JSON response`.
- Static hygiene: targeted `oxlint` clean; `tsgo` reports no errors in `extensions/google-meet/src/calendar.ts` or its test (a pre-existing, unrelated `anthropic-vertex/stream-runtime.ts` error exists on `main` and is not touched by this PR).
