### PR TITLE
docs(plugin-sdk): catalog the private completion helper

### DIFF
--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -304,6 +304,7 @@ usage endpoint failed or returned no usable usage data.
     | `plugin-sdk/string-coerce-runtime` | Narrow primitive record/string coercion and normalization helpers without markdown/logging imports |
     | `plugin-sdk/html-entity-runtime` | Private-local after July 2026; Single-pass semicolon-terminated HTML5 entity decoding without broad text utilities |
     | `plugin-sdk/text-utility-runtime` | Private-local after July 2026; Low-level text and path helpers, including five-entity HTML escaping |
+    | `plugin-sdk/simple-completion-runtime` | Private-local after July 2026; Prepared simple-completion model helpers and assistant text extraction for lightweight agent tasks |
     | `plugin-sdk/widget-html` | Complete-document detection, size validation, and tool input errors for self-contained HTML widgets |
     | `plugin-sdk/host-runtime` | Private-local after July 2026; Hostname and SCP host normalization helpers |
     | `plugin-sdk/retry-runtime` | Private-local after July 2026; Retry config and retry runner helpers |


### PR DESCRIPTION
## What Problem This Solves

The Plugin SDK catalog omits `plugin-sdk/simple-completion-runtime`, although the existing registry classifies it as private-local. Plugin authors cannot find its classification alongside the related helpers.

## Why This Change Was Made

Add the missing row to the existing runtime and storage table. Its description covers prepared completion model helpers and assistant text extraction. The conflict resolution preserves the neighboring row's current UTF-8 wording and every other catalog entry.

## User Impact

Readers can see that this helper is private-local after July 2026. Its JavaScript runtime export remains available, its public TypeScript declaration remains excluded, and `api.runtime.llm.complete` remains the supported public completion route. No runtime, package export, registry or build behavior changes.

## Evidence

- Source review confirms the existing classification, JavaScript-only export, declaration exclusion, helper purpose and public completion route.
- The official source-sync and documentation renderer produced complete baseline and candidate catalog previews. Browser captures show the missing row before and the private-local row after, with the current neighboring description preserved.
- Changed-docs guards, formatting, Markdown/MDX, glossary, 13,317 regular internal links and the native commit hook passed.
- Fresh source-blind browser acceptance opened all seven catalog groups and inspected all eight tables. It confirmed the new row, preserved all 304 existing rows, and followed the relevant documentation links in both previews. This proves the generated preview, not a deployed-site or plugin runtime change.

Related: #111660. That issue's runtime-export defect was already fixed and remains closed; this PR only clarifies the catalog.

AI-assisted.
