### PR TITLE
fix(discord): reject malformed PluralKit message envelopes

### DIFF
--- a/extensions/discord/src/pluralkit.test.ts
+++ b/extensions/discord/src/pluralkit.test.ts
@@ -94,6 +94,23 @@ describe("fetchPluralKitMessageInfo", () => {
     expect(receivedHeaders?.Authorization).toBe("pk_test");
   });
 
+  it.each([
+    ["null", "null"],
+    ["array", "[]"],
+  ])(
+    "rejects a %s PluralKit message envelope with a stable provider error",
+    async (_kind, body) => {
+      const fetcher = vi.fn(async () => buildResponse({ status: 200, body }));
+      await expect(
+        fetchPluralKitMessageInfo({
+          messageId: "123",
+          config: { enabled: true },
+          fetcher: fetcher as unknown as typeof fetch,
+        }),
+      ).rejects.toThrow("PluralKit message: malformed JSON response");
+    },
+  );
+
   it("aborts PluralKit response body reads that exceed the lookup timeout", async () => {
     vi.useFakeTimers();
     try {

--- a/extensions/discord/src/pluralkit.ts
+++ b/extensions/discord/src/pluralkit.ts
@@ -2,7 +2,7 @@
 import { buildTimeoutAbortSignal } from "openclaw/plugin-sdk/extension-shared";
 import { resolveFetch } from "openclaw/plugin-sdk/fetch-runtime";
 import {
-  readProviderJsonResponse,
+  readProviderJsonObjectResponse,
   readResponseTextLimited,
 } from "openclaw/plugin-sdk/provider-http";
 
@@ -75,7 +75,7 @@ export async function fetchPluralKitMessageInfo(params: {
       const detail = text.trim() ? `: ${text.trim()}` : "";
       throw new Error(`PluralKit API failed (${res.status})${detail}`);
     }
-    return await readProviderJsonResponse<PluralKitMessageInfo>(res, "PluralKit message");
+    return (await readProviderJsonObjectResponse(res, "PluralKit message")) as PluralKitMessageInfo;
   } finally {
     // Keep the deadline active through bounded error and JSON body reads; header-only
     // coverage would leave a stalled response stream holding the inbound preflight.


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `fetchPluralKitMessageInfo` could receive a successful HTTP 200 response from the third-party PluralKit API with a `null` or array JSON body, then silently return a wrong result instead of a stable provider error. A `null` body was cast straight to `PluralKitMessageInfo | null` and returned as `null`, which callers interpret as "not found / PluralKit not configured" - so a malformed response made a legitimate proxied message get skipped. An array body (`[]`) was likewise cast to `PluralKitMessageInfo`, leaving `.id` and the member/system fields undefined for downstream code to operate on.

The PluralKit reader now uses `readProviderJsonObjectResponse`, which enforces the top-level object envelope the PluralKit message contract requires. The existing 10s lookup timeout, bounded error-body read, 404 short-circuit, token handling, and deadline cleanup remain unchanged.

## Why This Change Was Made

`readProviderJsonResponse<T>` parses the body as `JSON.parse(...) as T` without verifying the top-level shape, so a `null` or array body is cast straight to the caller's expected type. `readProviderJsonObjectResponse` layers `asObject(payload)` on top and throws the caller's `<label>: malformed JSON response` boundary error when the envelope is not an object. This mirrors the approach already adopted for Firecrawl search/scrape, media-understanding audio, and the google-meet calendar reader.

## User Impact

Malformed PluralKit responses fail with the existing provider-owned `malformed JSON response` boundary instead of silently returning `null` (mistaken for "not found") or an object with undefined fields. Valid PluralKit responses continue through the same message lookup path unchanged.

## Evidence

- Base: `main` at `250e636ffd0132fe8cee6054fd5a90a5cd748d9e`.
- Head: `0d6d0a5a68d025297455254f7158dd2f8a53b105`.
- Focused tests: `node scripts/run-vitest.mjs extensions/discord/src/pluralkit.test.ts --run` -> 1 file, 8/8 tests passed. Added 2 cases (`null` and `[]` bodies) asserting `fetchPluralKitMessageInfo` rejects with `PluralKit message: malformed JSON response`.
- Static hygiene: targeted `oxlint` clean; `oxfmt --check` clean; `tsgo` reports no errors in `extensions/discord/src/pluralkit.ts` or its test (a pre-existing, unrelated `anthropic-vertex/stream-runtime.ts` error exists on `main` and is not touched by this PR).
