### PR TITLE
fix: doctor --fix recovers legacy workspace-state in sandbox copies

### DIFF
--- a/src/infra/state-migrations.workspace-setup-sandbox-dirs.ts
+++ b/src/infra/state-migrations.workspace-setup-sandbox-dirs.ts
@@ -1,0 +1,64 @@
+// Doctor discovery of sandbox workspace copies for legacy workspace-state repair.
+import fs from "node:fs";
+import path from "node:path";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveUserPath } from "./home-dir.js";
+
+/**
+ * Non-rw sandbox turns use copies under workspaceRoot (default `<stateDir>/sandboxes`),
+ * not the configured agent workspace. Runtime asserts against those copies, so Doctor
+ * must discover the same roots or the advertised `doctor --fix` recovery path fails.
+ */
+export function listSandboxWorkspaceCopyDirs(params: {
+  cfg: OpenClawConfig;
+  stateDir: string;
+  env: NodeJS.ProcessEnv;
+  homedir: () => string;
+}): string[] {
+  const roots = new Set<string>();
+  roots.add(path.resolve(params.stateDir, "sandboxes"));
+
+  const addConfiguredRoot = (value: unknown) => {
+    if (typeof value !== "string") {
+      return;
+    }
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return;
+    }
+    roots.add(resolveUserPath(trimmed, params.env, params.homedir));
+  };
+
+  addConfiguredRoot(params.cfg.agents?.defaults?.sandbox?.workspaceRoot);
+  const list = params.cfg.agents?.list;
+  if (Array.isArray(list)) {
+    for (const entry of list) {
+      if (entry && typeof entry === "object") {
+        addConfiguredRoot(entry.sandbox?.workspaceRoot);
+      }
+    }
+  }
+
+  const dirs = new Set<string>();
+  for (const sandboxRoot of roots) {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(sandboxRoot, { withFileTypes: true });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        continue;
+      }
+      // Unreadable sandbox root: skip; configured workspaces remain covered.
+      continue;
+    }
+    // Shared-scope sandbox uses the root itself as the workspace dir.
+    dirs.add(sandboxRoot);
+    for (const entry of entries) {
+      if (!entry.isDirectory()) {
+        continue;
+      }
+      dirs.add(path.join(sandboxRoot, entry.name));
+    }
+  }
+  return [...dirs];
+}

--- a/src/infra/state-migrations.workspace-setup.test.ts
+++ b/src/infra/state-migrations.workspace-setup.test.ts
@@ -961,4 +961,83 @@ describe("legacy workspace Doctor migration", () => {
         .get(identity.workspaceKey),
     ).toEqual({ attested_at_ms: originalMtime.getTime() });
   });
+
+  it("detects and migrates legacy setup markers in sandbox workspace copies", async () => {
+    const context = setup();
+    const sandboxCopy = path.join(context.stateDir, "sandboxes", "agent-main-deadbeef");
+    await fsp.mkdir(sandboxCopy, { recursive: true });
+    const completedAt = "2026-07-16T12:00:00.000Z";
+    const setupPath = path.join(sandboxCopy, "openclaw-workspace-state.json");
+    await fsp.writeFile(
+      setupPath,
+      JSON.stringify({ version: 1, setupCompletedAt: completedAt }),
+      "utf8",
+    );
+    const identity = resolveWorkspaceStateIdentity(sandboxCopy);
+    const canonicalSetupPath = path.join(identity.workspacePath, "openclaw-workspace-state.json");
+
+    // Configured agent workspace has no legacy marker; only the sandbox copy does.
+    expect(detect(context)).toMatchObject({
+      hasLegacy: true,
+      sources: expect.arrayContaining([
+        expect.objectContaining({
+          kind: "setup",
+          sourcePath: canonicalSetupPath,
+          workspaceKey: identity.workspaceKey,
+          workspaceDir: identity.workspacePath,
+        }),
+      ]),
+    });
+
+    const result = await migrate(context);
+
+    expect(result.warnings).toEqual([]);
+    expect(result.changes.length).toBeGreaterThan(0);
+    expect(fs.existsSync(setupPath)).toBe(false);
+    expect(
+      openOpenClawStateDatabase({ env: context.env })
+        .db.prepare(
+          "SELECT workspace_path, setup_completed_at FROM workspace_setup_state WHERE workspace_key = ?",
+        )
+        .get(identity.workspaceKey),
+    ).toEqual({
+      workspace_path: identity.workspacePath,
+      setup_completed_at: completedAt,
+    });
+  });
+
+  it("detects legacy setup markers under a custom sandbox workspaceRoot", async () => {
+    const context = setup();
+    const customRoot = path.join(context.homeDir, "custom-sandboxes");
+    const sandboxCopy = path.join(customRoot, "agent-sandbox-copy");
+    await fsp.mkdir(sandboxCopy, { recursive: true });
+    const setupPath = path.join(sandboxCopy, "openclaw-workspace-state.json");
+    await fsp.writeFile(setupPath, JSON.stringify({ version: 1 }), "utf8");
+    const customContext = {
+      ...context,
+      cfg: {
+        agents: {
+          defaults: {
+            workspace: context.workspaceDir,
+            sandbox: { workspaceRoot: customRoot },
+          },
+        },
+      } satisfies OpenClawConfig,
+    };
+    const identity = resolveWorkspaceStateIdentity(sandboxCopy);
+
+    expect(detect(customContext)).toMatchObject({
+      hasLegacy: true,
+      sources: expect.arrayContaining([
+        expect.objectContaining({
+          kind: "setup",
+          workspaceKey: identity.workspaceKey,
+          workspaceDir: identity.workspacePath,
+        }),
+      ]),
+    });
+
+    expect((await migrate(customContext)).warnings).toEqual([]);
+    expect(fs.existsSync(setupPath)).toBe(false);
+  });
 });

--- a/src/infra/state-migrations.workspace-setup.ts
+++ b/src/infra/state-migrations.workspace-setup.ts
@@ -25,6 +25,7 @@ import {
   readReceipt,
   type MigrationReceipt,
 } from "./state-migrations.workspace-setup-receipts.js";
+import { listSandboxWorkspaceCopyDirs } from "./state-migrations.workspace-setup-sandbox-dirs.js";
 import {
   canonicalCoversParsedSource,
   importAndRecordReceipt,
@@ -261,7 +262,7 @@ export function detectLegacyWorkspaceState(params: {
     }
   };
 
-  for (const workspaceDir of listAgentWorkspaceDirs(params.cfg)) {
+  const addSourcesForWorkspaceDir = (workspaceDir: string) => {
     const identity = resolveWorkspaceStateIdentity(workspaceDir);
     const paths = resolveLegacyWorkspaceSourcePaths(workspaceDir, { env, homedir });
     for (const [priority, sourcePath] of paths.setupStatePaths.entries()) {
@@ -315,6 +316,19 @@ export function detectLegacyWorkspaceState(params: {
         }),
       );
     }
+  };
+
+  for (const workspaceDir of listAgentWorkspaceDirs(params.cfg)) {
+    addSourcesForWorkspaceDir(workspaceDir);
+  }
+  // Sandbox copies are effective workspaces for non-rw sandbox turns; scan them too.
+  for (const workspaceDir of listSandboxWorkspaceCopyDirs({
+    cfg: params.cfg,
+    stateDir: params.stateDir,
+    env,
+    homedir,
+  })) {
+    addSourcesForWorkspaceDir(workspaceDir);
   }
 
   for (const source of listOrphanAttestationSources({ stateDir: params.stateDir, homedir })) {


### PR DESCRIPTION
Closes #111661

## What Problem This Solves

Fixes an issue where operators running sandboxed agents (non-`rw` workspace access) could hard-fail every agent turn after an upgrade left a legacy `openclaw-workspace-state.json` inside a reused sandbox copy under `sandboxes/`, while `openclaw doctor --fix` reported nothing to migrate because it only scanned configured agent workspaces.

## Why This Change Was Made

Doctor’s legacy workspace-state detector now also enumerates sandbox workspace copies under the default `<stateDir>/sandboxes` root and any configured sandbox `workspaceRoot`. Detected markers still go through the existing SQLite verification-before-delete migration path—no runtime shim and no broad filesystem deletion. Compatibility is preserved for existing doctor/workspace recovery; only discovery roots expand. Performance cost is a single shallow directory listing per sandbox root during explicit doctor repair.

## User Impact

Operators with stuck sandboxed agents can recover with the advertised `openclaw doctor --fix` path instead of manually deleting legacy files from sandbox copies. Clean sandbox installs are unchanged when no legacy markers exist.

## Evidence

Verification host: local macOS (Crabbox bypass).

```text
$ node scripts/run-vitest.mjs src/infra/state-migrations.workspace-setup.test.ts
 ✓ |infra| src/infra/state-migrations.workspace-setup.test.ts (31 tests) 6545ms
 Test Files  1 passed (1)
      Tests  31 passed (31)

$ node scripts/run-vitest.mjs src/infra/state-migrations.workspace-setup.test.ts -t sandbox
 ✓ 2 passed | 29 skipped (sandbox copy + custom workspaceRoot cases)

$ git diff --check
(clean)

$ ./node_modules/.bin/oxfmt --check <touched files>
All matched files use the correct format.

$ ./node_modules/.bin/oxlint <touched files>
Found 0 warnings and 0 errors.
```

Closeout note: `pnpm check:changed` stalled after dependency reconciliation (~13m, idle CPU); substituted path-scoped oxfmt/oxlint + focused Vitest, which cover the touched doctor migration surface.

## Real behavior proof

- Behavior addressed: `openclaw doctor --fix` must discover and clear legacy `openclaw-workspace-state.json` markers in non-`rw` sandbox workspace copies so sandboxed turns can recover without manual file deletion.
- Environment: local macOS, OpenClaw checkout on branch `fix/111661-doctor-sandbox-workspace-state`, focused Vitest harness against doctor-owned migration APIs.
- Current-main contrast: with a legacy setup marker only under `<stateDir>/sandboxes/<copy>/openclaw-workspace-state.json` and none in the configured agent workspace, `detectLegacyWorkspaceState({ doctorOnlyStateMigrations: true })` returned `hasLegacy: false` / no setup source for that sandbox path (doctor recovery gap).
- Exact steps or command run after this patch:
  1. Create temp state with a sandbox copy containing `openclaw-workspace-state.json` and no marker in the configured workspace.
  2. Run `detectLegacyWorkspaceState` with `doctorOnlyStateMigrations: true`.
  3. Run `migrateLegacyWorkspaceState` on the detection result.
  4. Assert marker removed and SQLite `workspace_setup_state` recorded for the sandbox workspace key.
  5. Repeat with a custom `agents.defaults.sandbox.workspaceRoot`.
- Evidence after fix: focused tests `detects and migrates legacy setup markers in sandbox workspace copies` and `detects legacy setup markers under a custom sandbox workspaceRoot` both pass; migration removes the file and writes setup completion into SQLite.
- Control check: existing configured-workspace and orphan-attestation doctor cases in the same file still pass (31/31), so discovery expansion does not break prior doctor roots.
- Observed result after fix: doctor detection now reports the sandbox-copy setup source; migrate clears it via the existing verified import/delete path.
- What was not tested: full live Gateway agent turn through a real Docker sandbox; live multi-agent fleets with custom remote SSH sandbox roots.

## AI disclosure

This PR was authored with AI assistance (Grok).
