### PR TITLE
fix(process): resolve Windows commands when env aliases are blank

### DIFF
--- a/src/infra/executable-path.ts
+++ b/src/infra/executable-path.ts
@@ -8,22 +8,37 @@ function isDriveLessWindowsRootedPath(value: string): boolean {
   return process.platform === "win32" && /^:[\\/]/.test(value);
 }
 
-function resolveEnvironmentValue(
+export function resolveWindowsEnvironmentValue(
   env: NodeJS.ProcessEnv | undefined,
   name: string,
 ): string | undefined {
   if (!env) {
     return undefined;
   }
-  const exactValue = env[name] ?? (name === "PATH" ? env.Path : undefined);
-  if (exactValue !== undefined) {
-    return exactValue;
+  const titleCaseName = `${name.slice(0, 1)}${name.slice(1).toLowerCase()}`;
+  const matches: Array<[string, string]> = [];
+  for (const [key, value] of Object.entries(env)) {
+    if (key.toUpperCase() === name && value !== undefined) {
+      matches.push([key, value]);
+    }
   }
-  if (process.platform !== "win32") {
-    return undefined;
+  const priority = (key: string) => (key === name ? 0 : key === titleCaseName ? 1 : 2);
+  matches.sort(([leftKey], [rightKey]) => priority(leftKey) - priority(rightKey));
+
+  // Plain ProcessEnv-shaped objects can contain duplicate Windows aliases.
+  // Prefer the first usable value, but keep an all-blank set authoritative so
+  // an intentionally empty child search path never falls back to the host.
+  return matches.find(([, value]) => value.trim().length > 0)?.[1] ?? matches[0]?.[1];
+}
+
+function resolveEnvironmentValue(
+  env: NodeJS.ProcessEnv | undefined,
+  name: string,
+): string | undefined {
+  if (process.platform === "win32") {
+    return resolveWindowsEnvironmentValue(env, name);
   }
-  const normalizedName = name.toLowerCase();
-  return Object.entries(env).find(([key]) => key.toLowerCase() === normalizedName)?.[1];
+  return env?.[name] ?? (name === "PATH" ? env?.Path : undefined);
 }
 
 export function resolveExecutablePathCandidate(

--- a/src/plugin-sdk/windows-spawn.test.ts
+++ b/src/plugin-sdk/windows-spawn.test.ts
@@ -5,7 +5,11 @@ import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { createPluginSdkTestHarness } from "./test-helpers.js";
-import { materializeWindowsSpawnProgram, resolveWindowsSpawnProgram } from "./windows-spawn.js";
+import {
+  materializeWindowsSpawnProgram,
+  resolveWindowsExecutablePath,
+  resolveWindowsSpawnProgram,
+} from "./windows-spawn.js";
 
 const { createTempDir } = createPluginSdkTestHarness({
   cleanup: {
@@ -15,6 +19,55 @@ const { createTempDir } = createPluginSdkTestHarness({
 });
 
 describe("resolveWindowsSpawnProgram", () => {
+  it("uses a nonblank arbitrary-case PATH alias", async () => {
+    const dir = await createTempDir("openclaw-windows-spawn-test-");
+    const shimPath = path.join(dir, "tool.CMD");
+    await writeFile(shimPath, "@ECHO off\r\n", "utf8");
+
+    expect(
+      resolveWindowsExecutablePath("tool", {
+        PATH: "",
+        pAtH: dir,
+        PATHEXT: ".CMD",
+      }),
+    ).toBe(shimPath);
+  });
+
+  it("uses a nonblank arbitrary-case PATHEXT alias", async () => {
+    const dir = await createTempDir("openclaw-windows-spawn-test-");
+    const shimPath = path.join(dir, "tool.CMD");
+    await writeFile(shimPath, "@ECHO off\r\n", "utf8");
+
+    expect(
+      resolveWindowsExecutablePath("tool", {
+        PATH: dir,
+        PATHEXT: "",
+        pAtHeXt: ".CMD",
+      }),
+    ).toBe(shimPath);
+  });
+
+  it("preserves canonical alias precedence across duplicate casings", async () => {
+    const canonicalDir = await createTempDir("openclaw-windows-spawn-canonical-");
+    const aliasDir = await createTempDir("openclaw-windows-spawn-alias-");
+    const canonicalShimPath = path.join(canonicalDir, "tool.CMD");
+    await writeFile(canonicalShimPath, "@ECHO off\r\n", "utf8");
+    await writeFile(path.join(aliasDir, "tool.EXE"), "", "utf8");
+
+    expect(
+      resolveWindowsExecutablePath("tool", {
+        Path: aliasDir,
+        PATH: canonicalDir,
+        Pathext: ".EXE",
+        PATHEXT: ".CMD",
+      }),
+    ).toBe(canonicalShimPath);
+  });
+
+  it("preserves an explicitly empty Windows search path", () => {
+    expect(resolveWindowsExecutablePath("node", { PATH: "", PATHEXT: ".EXE" })).toBe("node");
+  });
+
   it("rejects node command strings that include inline entrypoint arguments on Windows", () => {
     expect(() =>
       resolveWindowsSpawnProgram({

--- a/src/plugin-sdk/windows-spawn.ts
+++ b/src/plugin-sdk/windows-spawn.ts
@@ -93,6 +93,44 @@ function isFilePath(candidate: string): boolean {
   }
 }
 
+function readCaseInsensitiveEnvironmentValue(
+  env: NodeJS.ProcessEnv,
+  uppercaseKey: string,
+): { found: boolean; value?: string } {
+  const titleCaseKey = `${uppercaseKey.slice(0, 1)}${uppercaseKey.slice(1).toLowerCase()}`;
+  const matchingEntries: Array<[string, string]> = [];
+  for (const [candidateKey, value] of Object.entries(env)) {
+    if (candidateKey.toUpperCase() === uppercaseKey && value !== undefined) {
+      matchingEntries.push([candidateKey, value]);
+    }
+  }
+  const priority = (candidateKey: string) =>
+    candidateKey === uppercaseKey ? 0 : candidateKey === titleCaseKey ? 1 : 2;
+  matchingEntries.sort(([leftKey], [rightKey]) => {
+    return priority(leftKey) - priority(rightKey);
+  });
+
+  let firstDefined: string | undefined;
+  for (const [, value] of matchingEntries) {
+    firstDefined ??= value;
+    if (value.trim().length > 0) {
+      return { found: true, value };
+    }
+  }
+  return firstDefined === undefined ? { found: false } : { found: true, value: firstDefined };
+}
+
+function resolveEnvironmentValue(
+  env: NodeJS.ProcessEnv,
+  fallbackEnv: NodeJS.ProcessEnv,
+  key: string,
+): string | undefined {
+  const configured = readCaseInsensitiveEnvironmentValue(env, key);
+  return configured.found
+    ? configured.value
+    : readCaseInsensitiveEnvironmentValue(fallbackEnv, key).value;
+}
+
 function readCommandToken(command: string): { token: string; rest: string } | null {
   const trimmed = command.trim();
   if (!trimmed) {
@@ -143,15 +181,13 @@ export function resolveWindowsExecutablePath(command: string, env: NodeJS.Proces
     return command;
   }
 
-  const pathValue = env.PATH ?? env.Path ?? process.env.PATH ?? process.env.Path ?? "";
+  // Windows env keys are case-insensitive, but ProcessEnv objects can contain
+  // multiple casings. Prefer a usable sibling without discarding an explicitly
+  // empty search path when every matching entry is blank.
+  const pathValue = resolveEnvironmentValue(env, process.env, "PATH") ?? "";
   const pathEntries = normalizeStringEntries(pathValue.split(";"));
   const hasExtension = path.extname(command).length > 0;
-  const pathExtRaw =
-    env.PATHEXT ??
-    env.Pathext ??
-    process.env.PATHEXT ??
-    process.env.Pathext ??
-    ".EXE;.CMD;.BAT;.COM";
+  const pathExtRaw = resolveEnvironmentValue(env, process.env, "PATHEXT") ?? ".EXE;.CMD;.BAT;.COM";
   const pathExt = hasExtension
     ? [""]
     : normalizeStringEntries(pathExtRaw.split(";")).map((ext) =>

--- a/src/process/windows-command.test.ts
+++ b/src/process/windows-command.test.ts
@@ -138,6 +138,27 @@ describe("Windows command helpers", () => {
     });
   });
 
+  it("uses nonblank PATH and PATHEXT aliases after blank canonical entries", async () => {
+    await withTempDir("openclaw-windows-command-env-alias-", async (binDir) => {
+      const executable = path.join(binDir, "tool.exe");
+      await writeFile(executable, "");
+
+      await withMockedWindowsPlatform(async () => {
+        expect(
+          resolveSafeChildProcessInvocation({
+            argv: ["tool"],
+            env: {
+              PATH: "",
+              pAtH: binDir,
+              PATHEXT: "",
+              pAtHeXt: ".EXE",
+            },
+          }).command,
+        ).toBe(executable);
+      });
+    });
+  });
+
   it("accepts PATH executables with explicit extensions independently of PATHEXT", async () => {
     await withTempDir("openclaw-windows-command-path-extension-", async (binDir) => {
       const executable = path.join(binDir, "tool.exe");

--- a/src/process/windows-command.ts
+++ b/src/process/windows-command.ts
@@ -9,6 +9,7 @@ import {
   isRegularFile,
   resolveExecutableFromPathEnv,
   resolveExecutablePathCandidate,
+  resolveWindowsEnvironmentValue,
 } from "../infra/executable-path.js";
 import { getWindowsCmdExePath } from "../infra/windows-install-roots.js";
 
@@ -42,11 +43,6 @@ function createWindowsCommandNotFoundError(command: string): NodeJS.ErrnoExcepti
   error.path = command;
   error.syscall = `spawn ${command}`;
   return error;
-}
-
-function resolveWindowsEnvironmentValue(env: NodeJS.ProcessEnv, name: string): string | undefined {
-  const normalizedName = name.toLowerCase();
-  return Object.entries(env).find(([key]) => key.toLowerCase() === normalizedName)?.[1];
 }
 
 function resolveWindowsCommandFromCwdOrPath(params: {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Windows process and agent launch paths could fail to resolve an executable when an injected environment contained a blank `PATH` or `PATHEXT` entry alongside a usable differently-cased alias.

## Why This Change Was Made

Windows environment keys are case-insensitive, including arbitrary mixed-case spellings. Resolution now scans all own entries whose keys case-fold to `PATH` or `PATHEXT`, chooses the first nonblank value, and preserves the existing deterministic preference for `PATH`/`PATHEXT`, then `Path`/`Pathext`, before other spellings. If all matching entries are blank, the explicit empty search configuration remains authoritative instead of falling back to the host process.

This PR is AI-assisted. I reviewed the full resolver, its callers, sibling Windows command and executable-path implementations, adjacent tests, and the official Node.js `process.env` Windows contract.

## User Impact

Windows commands and shims remain discoverable for every environment-key casing, including injected plain objects with mixed-case aliases, without overriding callers that intentionally provide an empty search path.

## Evidence

Original base: `46ceb21b895d58ca6268dee84de2fc5e7c12dd5b`

Exact head: `a14aa44fc01b4e023914d1f449a35f2948c2bb1f`

Original regression proof:

```text
node scripts/run-vitest.mjs src/plugin-sdk/windows-spawn.test.ts
Expected: C:\...\tool.CMD
Received: "tool"
```

Review regression proof against the previous PR head with `pAtH` and `pAtHeXt`:

```text
Test Files  1 failed (1)
Tests       1 failed | 7 passed (8)
Expected: C:\...\tool.CMD
Received: "tool"
```

Focused tests after the fix, covering arbitrary-case `PATH`, arbitrary-case `PATHEXT`, canonical duplicate precedence, and explicit-empty behavior:

```text
node scripts/run-vitest.mjs src/plugin-sdk/windows-spawn.test.ts
Test Files  1 passed (1)
Tests       10 passed (10)
```

Sibling Windows command baseline before adding the new regression:

```text
node scripts/run-vitest.mjs src/process/windows-command.test.ts
Test Files  1 passed (1)
Tests       11 passed (11)
```

Real Windows production-path probe using arbitrary mixed-case aliases:

```text
{"platform":"win32","resolved":"tool.CMD","matches":true}
cleanup=removed
```

Official runtime contract: Node.js documents that environment variables are case-insensitive on Windows: https://nodejs.org/api/process.html#processenv

Current-head clean-install CI proof:

- Windows Node tests: passed (`checks-windows-node-test`).
- Core executable-path regression shard: passed (`checks-node-compact-small-11`), including the new `resolveSafeChildProcessInvocation` mixed-case `PATH`/`PATHEXT` regression and the existing non-Windows `Path` contract.
- Production and test type checks: passed (`check-prod-types`, `check-test-types`).
- Plugin SDK API baseline and package contract: passed.
- Lint: passed.

The overall CI gate is currently red only because `test/scripts/pr-wrappers.test.ts` fails in `checks-node-compact-small-1`; that file and its wrapper behavior are outside this PR's five-file diff. The same isolated failure reproduced on two successive PR heads, while the current `main` CI run is green. The contributor account cannot rerun upstream jobs.

Formatting and whitespace validation:

```text
G:\AI??\openclaw\node_modules\.bin\oxfmt.CMD --check src/plugin-sdk/windows-spawn.ts src/plugin-sdk/windows-spawn.test.ts
All matched files use the correct format.

git diff --check
(no output)
```

The first revised CI head exposed `TS18048` in the new entry collector. The implementation now collects narrowed `[string, string]` tuples explicitly. A fresh local core tsgo run reports no error in `windows-spawn.ts`; it stops later on two unrelated missing exports from the linked worktree's stale shared `@openclaw/fs-safe/advanced` dependency. GitHub CI on this exact head is the authoritative clean-install typecheck.

The linked-worktree changed-check classifier attempted to delegate its broader lane but could not start because pnpm tried to reconcile the linked `node_modules` and stopped with `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY`. No dependency installation or purge was performed.
