### PR TITLE
docs(plugin-sdk): catalog remaining private-local subpaths from #111451

### DIFF
--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -304,6 +304,13 @@ usage endpoint failed or returned no usable usage data.
     | `plugin-sdk/string-coerce-runtime` | Narrow primitive record/string coercion and normalization helpers without markdown/logging imports |
     | `plugin-sdk/html-entity-runtime` | Private-local after July 2026; Single-pass semicolon-terminated HTML5 entity decoding without broad text utilities |
     | `plugin-sdk/text-utility-runtime` | Private-local after July 2026; Low-level text and path helpers, including five-entity HTML escaping |
+    | `plugin-sdk/agent-core` | Private-local after July 2026; Agent core runtime adapter, `Agent` class, agent loop, context compaction helpers, and agent/tool/message types |
+    | `plugin-sdk/agent-sessions` | Private-local after July 2026; Agent session entry types, persistence/migration helpers, extension runtime, and session manager |
+    | `plugin-sdk/document-extractor` | Private-local after July 2026; Document extractor plugin types for extraction requests, results, and extracted images |
+    | `plugin-sdk/llm` | Private-local after July 2026; LLM streaming, model utilities, validation, and message/tool/usage types |
+    | `plugin-sdk/time-runtime` | Private-local after July 2026; Timezone resolution and UTC/zoned timestamp formatting helpers |
+    | `plugin-sdk/types` | Private-local after July 2026; Plugin hook contract types for before-tool-call and tool-result-persist events |
+    | `plugin-sdk/windows-spawn` | Private-local after July 2026; Windows command spawn resolution, PATH/PATHEXT lookup, and cmd/bat wrapper entrypoint detection |
     | `plugin-sdk/widget-html` | Complete-document detection, size validation, and tool input errors for self-contained HTML widgets |
     | `plugin-sdk/host-runtime` | Private-local after July 2026; Hostname and SCP host normalization helpers |
     | `plugin-sdk/retry-runtime` | Private-local after July 2026; Retry config and retry runner helpers |


### PR DESCRIPTION
## What Problem This Solves

#111451 demoted several `plugin-sdk/*` subpaths to private-local-only after July 2026, but the docs sync in `docs/plugins/sdk-subpaths.md` was only applied to `text-utility-runtime`. The remaining demoted subpaths were still undocumented, leaving plugin authors to reasonably assume they are public SDK seams — the same ambiguous-state class reported in #111660 for `simple-completion-runtime`.

## Why This Change Was Made

Complete the docs half of the 4-file alignment for these demotes. Add `Private-local after July 2026; ...` rows for 7 subpaths, mirroring the prefix and placement #111451 applied to `text-utility-runtime`, in the same "Runtime and storage subpaths" Accordion.

**`tool-results` is excluded.** Per maintainer decision on this PR, `plugin-sdk/tool-results` remains a supported typed public SDK entrypoint — the public SDK docs already advertise it and external plugins consume it as a package subpath. #116345 restores its declaration packaging and adds a contract guard so documented public entrypoints cannot silently ship JavaScript without typings again. A `private-local` row for it would be incorrect.

Subpaths added (7):

- `agent-core` — Agent core runtime adapter, `Agent` class, agent loop, context compaction helpers, and agent/tool/message types
- `agent-sessions` — Agent session entry types, persistence/migration helpers, extension runtime, and session manager
- `document-extractor` — Document extractor plugin types for extraction requests, results, and extracted images
- `llm` — LLM streaming, model utilities, validation, and message/tool/usage types
- `time-runtime` — Timezone resolution and UTC/zoned timestamp formatting helpers
- `types` — Plugin hook contract types for before-tool-call and tool-result-persist events
- `windows-spawn` — Windows command spawn resolution, PATH/PATHEXT lookup, and cmd/bat wrapper entrypoint detection

## User Impact

Plugin authors reading the SDK subpaths reference no longer reasonably assume these 7 subpaths are public SDK seams. `tool-results` continues to be documented as a supported public entrypoint.

## Evidence

- Docs-only change: `docs/plugins/sdk-subpaths.md` (+7 lines).
- `git diff --check` clean.
- Row format mirrors the existing `text-utility-runtime` entry from #111451.
- `tool-results` exclusion follows maintainer decision in #111718; public entrypoint status tracked by #116345.

Related to #111451
