### PR TITLE
fix(mattermost): parse mixed-case JSON content types

### DIFF
--- a/extensions/mattermost/src/mattermost/client.test.ts
+++ b/extensions/mattermost/src/mattermost/client.test.ts
@@ -195,6 +195,15 @@ describe("readMattermostError", () => {
     expect(jsonSpy).not.toHaveBeenCalled();
     expect(textSpy).not.toHaveBeenCalled();
   });
+
+  it("parses JSON error messages with mixed-case content types", async () => {
+    const response = new Response(JSON.stringify({ message: "invalid token" }), {
+      status: 401,
+      headers: { "content-type": "Application/JSON; Charset=UTF-8" },
+    });
+
+    await expect(readMattermostError(response)).resolves.toBe("invalid token");
+  });
 });
 
 // ── createMattermostClient ───────────────────────────────────────────
@@ -213,6 +222,15 @@ describe("createMattermostClient", () => {
 
     expect(arrayBuffer).not.toHaveBeenCalled();
     expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it("parses successful JSON responses with mixed-case content types", async () => {
+    const { client } = createTestClient({
+      body: { id: "u1" },
+      contentType: "Application/JSON; Charset=UTF-8",
+    });
+
+    await expect(client.request("/users/me")).resolves.toEqual({ id: "u1" });
   });
 
   it("reads guarded null-body Mattermost errors without response.json/text", async () => {

--- a/extensions/mattermost/src/mattermost/client.ts
+++ b/extensions/mattermost/src/mattermost/client.ts
@@ -121,7 +121,7 @@ async function readMattermostSuccessText(res: Response, path: string): Promise<s
 }
 
 export async function readMattermostError(res: Response): Promise<string> {
-  const contentType = res.headers.get("content-type") ?? "";
+  const contentType = normalizeLowercaseStringOrEmpty(res.headers.get("content-type"));
   const text = await readResponseTextLimited(res, MATTERMOST_ERROR_BODY_LIMIT_BYTES);
   if (contentType.includes("application/json")) {
     try {
@@ -278,7 +278,7 @@ export function createMattermostClient(params: {
       return undefined as T;
     }
 
-    const contentType = res.headers.get("content-type") ?? "";
+    const contentType = normalizeLowercaseStringOrEmpty(res.headers.get("content-type"));
     if (contentType.includes("application/json")) {
       return await readProviderJsonResponse<T>(res, `Mattermost API ${path}`);
     }


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where Mattermost channel startup, probes, and API-backed actions could receive a JSON string instead of the expected object when a self-hosted server returned a valid mixed-case media type such as `Application/JSON`. Callers that expected fields such as the current bot user ID could then behave as though the response were missing data.

## Why This Change Was Made

The Mattermost REST client now normalizes response media types before deciding whether both success and error bodies are JSON. This keeps the change inside the Mattermost-owned HTTP boundary and preserves the existing response limits, SSRF guard, timeout handling, and non-JSON fallback.

## User Impact

Mattermost deployments that vary the casing of JSON `Content-Type` values now work like deployments that return lowercase `application/json`. Successful responses are parsed into their expected objects, and JSON error messages retain their useful server-provided detail.

## Evidence

- Before the fix, a real loopback HTTP server returning `Application/JSON; Charset=UTF-8` from `/api/v4/users/me` produced `resultType: "string"` and no parsed user ID.
- After the fix, the same production Mattermost client and SSRF-guarded loopback path produced:

  ```json
  {"requestPaths":["/api/v4/users/me"],"resultType":"object","parsedUser":{"id":"bot-user","username":"bot"}}
  ```

- Focused Mattermost client suite: 1 file passed, 33 tests passed.
- Formatter check: both changed files use the expected format.
