### PR TITLE
fix(ai): flatten Gemini allOf tool schemas

### DIFF
--- a/packages/ai/src/providers/clean-for-gemini.test.ts
+++ b/packages/ai/src/providers/clean-for-gemini.test.ts
@@ -298,4 +298,93 @@ describe("cleanSchemaForGemini", () => {
 
     expect(cleaned.enum).toBeUndefined();
   });
+
+  it("flattens a nested single-branch allOf literal", () => {
+    const cleaned = cleanSchemaForGemini({
+      type: "object",
+      properties: {
+        settings: {
+          description: "Selected settings mode",
+          allOf: [{ const: "x", type: "string" }],
+        },
+      },
+    }) as { properties?: { settings?: Record<string, unknown> } };
+
+    expect(cleaned.properties?.settings).toEqual({
+      description: "Selected settings mode",
+      enum: ["x"],
+      type: "string",
+    });
+    expect(JSON.stringify(cleaned)).not.toContain("allOf");
+  });
+
+  it("flattens a nested single-branch allOf enum", () => {
+    const cleaned = cleanSchemaForGemini({
+      type: "object",
+      properties: {
+        settings: {
+          description: "Selected settings mode",
+          allOf: [{ enum: ["x"], type: "string" }],
+        },
+      },
+    }) as { properties?: { settings?: Record<string, unknown> } };
+
+    expect(cleaned.properties?.settings).toEqual({
+      description: "Selected settings mode",
+      enum: ["x"],
+      type: "string",
+    });
+    expect(JSON.stringify(cleaned)).not.toContain("allOf");
+  });
+
+  it("merges multiple compatible object intersections", () => {
+    const cleaned = cleanSchemaForGemini({
+      description: "Combined settings",
+      allOf: [
+        {
+          type: "object",
+          properties: { name: { type: "string" } },
+          required: ["name"],
+        },
+        {
+          type: "object",
+          properties: { enabled: { type: "boolean" } },
+          required: ["enabled", "notDeclared"],
+        },
+        {
+          type: "object",
+          properties: { mode: { type: "string", enum: ["safe", "fast"] } },
+          required: ["mode"],
+        },
+      ],
+    });
+
+    expect(cleaned).toEqual({
+      description: "Combined settings",
+      type: "object",
+      properties: {
+        name: { type: "string" },
+        enabled: { type: "boolean" },
+        mode: { type: "string", enum: ["safe", "fast"] },
+      },
+      required: ["name", "enabled", "mode"],
+    });
+    expect(JSON.stringify(cleaned)).not.toContain("allOf");
+  });
+
+  it("widens conflicting intersections without retaining allOf", () => {
+    const cleaned = cleanSchemaForGemini({
+      description: "Conflicting mode",
+      allOf: [
+        { type: "string", enum: ["x"] },
+        { type: "string", enum: ["y"] },
+      ],
+    });
+
+    expect(cleaned).toEqual({
+      type: "string",
+      description: "Conflicting mode",
+    });
+    expect(JSON.stringify(cleaned)).not.toContain("allOf");
+  });
 });

--- a/packages/ai/src/providers/clean-for-gemini.ts
+++ b/packages/ai/src/providers/clean-for-gemini.ts
@@ -31,8 +31,10 @@ export const GEMINI_UNSUPPORTED_SCHEMA_KEYWORDS = new Set([
   "maxProperties",
 
   // JSON Schema composition keywords not supported by OpenAPI 3.0 subset.
-  // `const` is handled separately (converted to enum) in the cleaning loop,
-  // but `not` has no safe equivalent and must be stripped.
+  // `const` is handled separately (converted to enum) in the cleaning loop;
+  // `allOf` is flattened separately, while `not` has no safe equivalent and
+  // must be stripped.
+  "allOf",
   "not",
 ]);
 
@@ -272,6 +274,232 @@ function sanitizeRequiredFields(schema: Record<string, unknown>): Record<string,
   return schema;
 }
 
+function schemaValuesEqual(left: unknown, right: unknown): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function intersectEnums(left: unknown[], right: unknown[]): unknown[] {
+  return left.filter((leftValue) =>
+    right.some((rightValue) => schemaValuesEqual(leftValue, rightValue)),
+  );
+}
+
+/** Merge schemas only when their intersection can be represented without `allOf`. */
+function tryMergeCompatibleAllOfSchemas(
+  schemas: Record<string, unknown>[],
+): Record<string, unknown> | undefined {
+  const merged: Record<string, unknown> = {};
+  const required = new Set<string>();
+
+  for (const schema of schemas) {
+    for (const [key, value] of Object.entries(schema)) {
+      if (key === "allOf") {
+        continue;
+      }
+      if (SCHEMA_META_KEYS.includes(key as (typeof SCHEMA_META_KEYS)[number])) {
+        if (!(key in merged)) {
+          merged[key] = value;
+        }
+        continue;
+      }
+      if (key === "required" && Array.isArray(value)) {
+        for (const entry of value) {
+          if (typeof entry === "string") {
+            required.add(entry);
+          }
+        }
+        continue;
+      }
+      if (key === "properties" && value && typeof value === "object" && !Array.isArray(value)) {
+        const properties = (merged.properties ?? {}) as Record<string, unknown>;
+        for (const [propertyName, propertySchema] of Object.entries(
+          value as Record<string, unknown>,
+        )) {
+          const existing = properties[propertyName];
+          if (existing === undefined) {
+            properties[propertyName] = propertySchema;
+            continue;
+          }
+          if (
+            !existing ||
+            typeof existing !== "object" ||
+            Array.isArray(existing) ||
+            !propertySchema ||
+            typeof propertySchema !== "object" ||
+            Array.isArray(propertySchema)
+          ) {
+            if (!schemaValuesEqual(existing, propertySchema)) {
+              return undefined;
+            }
+            continue;
+          }
+          const propertyIntersection = tryMergeCompatibleAllOfSchemas([
+            existing as Record<string, unknown>,
+            propertySchema as Record<string, unknown>,
+          ]);
+          if (!propertyIntersection) {
+            return undefined;
+          }
+          properties[propertyName] = propertyIntersection;
+        }
+        merged.properties = properties;
+        continue;
+      }
+      if (key === "enum" && Array.isArray(value)) {
+        if (!Array.isArray(merged.enum)) {
+          merged.enum = value;
+          continue;
+        }
+        const intersection = intersectEnums(merged.enum, value);
+        if (intersection.length === 0) {
+          return undefined;
+        }
+        merged.enum = intersection;
+        continue;
+      }
+      if (!(key in merged)) {
+        merged[key] = value;
+        continue;
+      }
+      if (!schemaValuesEqual(merged[key], value)) {
+        return undefined;
+      }
+    }
+  }
+
+  if (required.size > 0) {
+    merged.required = [...required];
+  }
+  return sanitizeRequiredFields(merged);
+}
+
+function copyPreferredSchemaMeta(
+  schemas: Record<string, unknown>[],
+  to: Record<string, unknown>,
+): void {
+  for (const schema of schemas) {
+    for (const key of SCHEMA_META_KEYS) {
+      if (!(key in to) && key in schema && schema[key] !== undefined) {
+        to[key] = schema[key];
+      }
+    }
+  }
+}
+
+/**
+ * Last-resort representation for conflicting intersections. It deliberately
+ * widens conflicting constraints, but retains object fields and explicitly
+ * declared required names so the callable shape remains useful.
+ */
+function flattenAllOfFallback(schemas: Record<string, unknown>[]): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  const explicitTypes = schemas
+    .map((schema) => schema.type)
+    .filter((type): type is string => typeof type === "string");
+  const commonType = explicitTypes.every((type) => type === explicitTypes[0])
+    ? explicitTypes[0]
+    : undefined;
+  const objectLike = schemas.every(
+    (schema) =>
+      schema.type === undefined ||
+      schema.type === "object" ||
+      (schema.properties &&
+        typeof schema.properties === "object" &&
+        !Array.isArray(schema.properties)),
+  );
+
+  if (objectLike && schemas.some((schema) => schema.type === "object" || schema.properties)) {
+    result.type = "object";
+    const properties: Record<string, unknown> = {};
+    const required = new Set<string>();
+    for (const schema of schemas) {
+      if (
+        schema.properties &&
+        typeof schema.properties === "object" &&
+        !Array.isArray(schema.properties)
+      ) {
+        for (const [name, propertySchema] of Object.entries(
+          schema.properties as Record<string, unknown>,
+        )) {
+          const existing = properties[name];
+          if (existing === undefined) {
+            properties[name] = propertySchema;
+            continue;
+          }
+          if (
+            existing &&
+            typeof existing === "object" &&
+            !Array.isArray(existing) &&
+            propertySchema &&
+            typeof propertySchema === "object" &&
+            !Array.isArray(propertySchema)
+          ) {
+            properties[name] =
+              tryMergeCompatibleAllOfSchemas([
+                existing as Record<string, unknown>,
+                propertySchema as Record<string, unknown>,
+              ]) ??
+              flattenAllOfFallback([
+                existing as Record<string, unknown>,
+                propertySchema as Record<string, unknown>,
+              ]);
+          }
+        }
+      }
+    }
+    for (const schema of schemas) {
+      if (!Array.isArray(schema.required)) {
+        continue;
+      }
+      for (const name of schema.required) {
+        if (typeof name === "string" && Object.hasOwn(properties, name)) {
+          required.add(name);
+        }
+      }
+    }
+    result.properties = properties;
+    if (required.size > 0) {
+      result.required = [...required];
+    }
+  } else if (commonType) {
+    result.type = commonType;
+  }
+
+  copyPreferredSchemaMeta(schemas, result);
+  return sanitizeRequiredFields(result);
+}
+
+function flattenAllOf(
+  outer: Record<string, unknown>,
+  variants: unknown[],
+): Record<string, unknown> {
+  const schemas = [outer, ...variants].filter(
+    (variant): variant is Record<string, unknown> =>
+      Boolean(variant) && typeof variant === "object" && !Array.isArray(variant),
+  );
+  return tryMergeCompatibleAllOfSchemas(schemas) ?? flattenAllOfFallback(schemas);
+}
+
+function removeSurvivingAllOf(schema: unknown): unknown {
+  if (!schema || typeof schema !== "object") {
+    return schema;
+  }
+  if (Array.isArray(schema)) {
+    return schema.map(removeSurvivingAllOf);
+  }
+
+  const record = schema as Record<string, unknown>;
+  const outer = Object.fromEntries(
+    Object.entries(record)
+      .filter(([key]) => key !== "allOf")
+      .map(([key, value]) => [key, removeSurvivingAllOf(value)]),
+  );
+  if (!Array.isArray(record.allOf)) {
+    return outer;
+  }
+  return flattenAllOf(outer, record.allOf.map(removeSurvivingAllOf));
+}
+
 function cleanSchemaForGeminiWithDefs(
   schema: unknown,
   defs: SchemaDefs | undefined,
@@ -317,6 +545,7 @@ function cleanSchemaForGeminiWithDefs(
 
   const hasAnyOf = "anyOf" in obj && Array.isArray(obj.anyOf);
   const hasOneOf = "oneOf" in obj && Array.isArray(obj.oneOf);
+  const hasAllOf = "allOf" in obj && Array.isArray(obj.allOf);
   let cleanedAnyOf = hasAnyOf
     ? (obj.anyOf as unknown[]).map((variant) =>
         cleanSchemaForGeminiWithDefs(variant, nextDefs, refStack),
@@ -324,6 +553,11 @@ function cleanSchemaForGeminiWithDefs(
     : undefined;
   let cleanedOneOf = hasOneOf
     ? (obj.oneOf as unknown[]).map((variant) =>
+        cleanSchemaForGeminiWithDefs(variant, nextDefs, refStack),
+      )
+    : undefined;
+  const cleanedAllOf = hasAllOf
+    ? (obj.allOf as unknown[]).map((variant) =>
         cleanSchemaForGeminiWithDefs(variant, nextDefs, refStack),
       )
     : undefined;
@@ -347,6 +581,11 @@ function cleanSchemaForGeminiWithDefs(
   const cleaned: Record<string, unknown> = {};
 
   for (const [key, value] of Object.entries(obj)) {
+    // allOf is flattened after its siblings are cleaned. Malformed allOf values
+    // are omitted as unsupported rather than passed through to Gemini.
+    if (key === "allOf") {
+      continue;
+    }
     if (GEMINI_UNSUPPORTED_SCHEMA_KEYWORDS.has(key)) {
       continue;
     }
@@ -417,13 +656,13 @@ function cleanSchemaForGeminiWithDefs(
       cleaned[key] =
         cleanedOneOf ??
         value.map((variant) => cleanSchemaForGeminiWithDefs(variant, nextDefs, refStack));
-    } else if (key === "allOf" && Array.isArray(value)) {
-      cleaned[key] = value.map((variant) =>
-        cleanSchemaForGeminiWithDefs(variant, nextDefs, refStack),
-      );
     } else {
       cleaned[key] = value;
     }
+  }
+
+  if (cleanedAllOf) {
+    return flattenAllOf(cleaned, cleanedAllOf);
   }
 
   // Cloud Code Assist API rejects anyOf/oneOf in nested schemas even after
@@ -492,5 +731,6 @@ export function cleanSchemaForGemini(schema: unknown): TSchema {
   }
 
   const defs = extendSchemaDefs(undefined, schema as Record<string, unknown>);
-  return cleanSchemaForGeminiWithDefs(schema, defs, undefined) as TSchema;
+  const cleaned = cleanSchemaForGeminiWithDefs(schema, defs, undefined);
+  return removeSurvivingAllOf(cleaned) as TSchema;
 }


### PR DESCRIPTION
## Summary

- flatten Gemini-incompatible `allOf` schemas before tool submission
- preserve compatible object intersections and literal/enum constraints
- widen only conflicting intersections that cannot be represented in Gemini's supported schema subset

## Motivation

Gemini rejects tool schemas containing `allOf`, including nested single-branch schemas emitted by common schema generators. The existing cleaner removed several unsupported JSON Schema keywords but left `allOf` in place, so otherwise valid tools could fail before execution.

## Verification

- focused Gemini schema regression suite
- formatter check for changed files
- guarded `gatewayWatch` production build

The regression coverage includes nested literal and enum branches, compatible multi-object intersections, conflicting intersections, and confirms that no `allOf` remains in the cleaned schema.
