### PR TITLE
fix(agents): recover structured context overflow

### DIFF
--- a/packages/ai/src/providers/openai-chatgpt-responses.test.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.test.ts
@@ -457,6 +457,39 @@ describe("streamOpenAICodexResponses transport", () => {
     expect(result.errorMessage).toContain("Request timed out after 5ms");
   });
 
+  it("preserves structured response failure codes on assistant errors", async () => {
+    const errorMessage = "Your input exceeds the context window of this model";
+    const event = {
+      type: "response.failed",
+      response: {
+        error: { code: "context_length_exceeded", message: errorMessage },
+      },
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(`data: ${JSON.stringify(event)}\n\n`, {
+            status: 200,
+            headers: { "content-type": "text/event-stream" },
+          }),
+      ),
+    );
+
+    const stream = streamOpenAICodexResponses(model, context, {
+      apiKey: createJwt({
+        "https://api.openai.com/auth": { chatgpt_account_id: "acct-1" },
+      }),
+      transport: "sse",
+    });
+
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("error");
+    expect(result.errorCode).toBe("context_length_exceeded");
+    expect(result.errorMessage).toBe(errorMessage);
+  });
+
   it("does not replay Responses item ids for store-disabled ChatGPT requests", async () => {
     let capturedPayload:
       | {

--- a/packages/ai/src/providers/openai-chatgpt-responses.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.ts
@@ -493,6 +493,9 @@ export const streamOpenAICodexResponses: StreamFunction<
         delete (block as { partialJson?: string }).partialJson;
       }
       output.stopReason = options?.signal?.aborted ? "aborted" : "error";
+      if (normalizedError instanceof CodexApiError && normalizedError.code) {
+        output.errorCode = normalizedError.code;
+      }
       output.errorMessage =
         normalizedError instanceof Error ? normalizedError.message : String(normalizedError);
       stream.push({ type: "error", reason: output.stopReason, error: output });

--- a/packages/ai/src/utils/overflow.ts
+++ b/packages/ai/src/utils/overflow.ts
@@ -172,3 +172,14 @@ export function isContextOverflow(message: AssistantMessage, contextWindow?: num
 
   return false;
 }
+
+/** Match a provider error string against the shared context-overflow vocabulary. */
+export function isContextOverflowErrorMessage(errorMessage?: string): boolean {
+  if (!errorMessage) {
+    return false;
+  }
+  if (NON_OVERFLOW_PATTERNS.some((pattern) => pattern.test(errorMessage))) {
+    return false;
+  }
+  return OVERFLOW_PATTERNS.some((pattern) => pattern.test(errorMessage));
+}

--- a/src/agents/embedded-agent-helpers.ts
+++ b/src/agents/embedded-agent-helpers.ts
@@ -27,6 +27,7 @@ export {
   isBillingErrorMessage,
   isCloudCodeAssistFormatError,
   isCompactionFailureError,
+  isContextOverflowAssistantError,
   isContextOverflowError,
   isLikelyContextOverflowError,
   isFailoverAssistantError,

--- a/src/agents/embedded-agent-helpers/errors.test.ts
+++ b/src/agents/embedded-agent-helpers/errors.test.ts
@@ -6,8 +6,10 @@ import { MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE } from "../../shared/assista
 import { makeAssistantMessageFixture } from "../test-helpers/assistant-message-fixtures.js";
 import {
   classifyFailoverReason,
+  classifyFailoverSignal,
   extractFailoverSignalDetails,
   formatAssistantErrorText,
+  isContextOverflowAssistantError,
   isLikelyContextOverflowError,
 } from "./errors.js";
 
@@ -139,5 +141,25 @@ describe("isLikelyContextOverflowError", () => {
         "Codex ran out of room in the model's context window. Start a new thread or clear earlier history before retrying.",
       ),
     ).toBe(true);
+  });
+
+  it("uses the shared OpenAI overflow wording", () => {
+    expect(
+      isLikelyContextOverflowError("Your input exceeds the context window of this model"),
+    ).toBe(true);
+  });
+
+  it("classifies context_length_exceeded from the structured code", () => {
+    const msg = makeAssistantMessageFixture({
+      errorCode: "context_length_exceeded",
+      errorMessage: "Request failed",
+    });
+
+    expect(classifyFailoverSignal({ code: msg.errorCode, message: msg.errorMessage })).toEqual({
+      kind: "reason",
+      reason: "context_overflow",
+    });
+    expect(isContextOverflowAssistantError(msg)).toBe(true);
+    expect(formatAssistantErrorText(msg)).toContain("Context overflow");
   });
 });

--- a/src/agents/embedded-agent-helpers/errors.ts
+++ b/src/agents/embedded-agent-helpers/errors.ts
@@ -1,4 +1,7 @@
-import { isConfiguredContextSizeOverflowError } from "@openclaw/ai/internal/runtime";
+import {
+  isConfiguredContextSizeOverflowError,
+  isContextOverflowErrorMessage,
+} from "@openclaw/ai/internal/runtime";
 /**
  * Classifies provider/runtime failures and formats assistant-facing error text.
  */
@@ -125,6 +128,7 @@ export function isContextOverflowError(errorMessage?: string): boolean {
   const hasContextWindowOutOfRoom =
     hasContextWindow && (lower.includes("ran out of room") || lower.includes("ran out of space"));
   return (
+    isContextOverflowErrorMessage(errorMessage) ||
     lower.includes("request_too_large") ||
     isConfiguredContextSizeOverflowError(errorMessage) ||
     (lower.includes("invalid_argument") && lower.includes("maximum number of tokens")) ||
@@ -877,6 +881,8 @@ function classifyFailoverReasonFromCode(raw: string | undefined): FailoverReason
     return null;
   }
   switch (normalized) {
+    case "CONTEXT_LENGTH_EXCEEDED":
+      return "context_overflow";
     case "RESOURCE_EXHAUSTED":
     case "RATE_LIMIT":
     case "RATE_LIMITED":
@@ -1478,7 +1484,7 @@ export function formatAssistantErrorText(
     return MODEL_NOT_FOUND_USER_TEXT;
   }
 
-  if (isContextOverflowError(raw)) {
+  if (isContextOverflowAssistantError(msg) || isContextOverflowError(raw)) {
     return (
       "Context overflow: prompt too large for the model. " +
       "Try /reset (or /new) to start a fresh session, or use a larger-context model."
@@ -1809,5 +1815,9 @@ export function isFailoverErrorMessage(raw: string, opts?: { provider?: string }
 
 export function isFailoverAssistantError(msg: AssistantMessage | undefined): boolean {
   return classifyAssistantFailoverReason(msg) !== null;
+}
+
+export function isContextOverflowAssistantError(msg: AssistantMessage | undefined): boolean {
+  return classifyAssistantFailoverReason(msg) === "context_overflow";
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/agents/embedded-agent-runner/run.overflow-compaction.harness.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.harness.ts
@@ -224,7 +224,11 @@ type MockCoerceToFailoverError = (
 ) => unknown;
 type MockDescribeFailoverError = (err: unknown) => MockFailoverErrorDescription;
 type MockResolveFailoverStatus = (reason: string) => number | undefined;
-type MockAssistantErrorProbe = (assistant?: { errorMessage?: string }) => boolean;
+type MockAssistantErrorProbe = (assistant?: {
+  stopReason?: string;
+  errorCode?: string;
+  errorMessage?: string;
+}) => boolean;
 export class MockedFailoverError extends Error {
   constructor(message: string) {
     super(message);
@@ -273,6 +277,10 @@ export const mockedFormatAssistantErrorText = vi.fn(() => "");
 const mockedIsAuthAssistantError = vi.fn(() => false);
 const mockedIsBillingAssistantError = vi.fn(() => false);
 export const mockedIsCompactionFailureError = vi.fn(() => false);
+export const mockedIsContextOverflowAssistantError = vi.fn<MockAssistantErrorProbe>(
+  (assistant) =>
+    assistant?.stopReason === "error" && assistant.errorCode === "context_length_exceeded",
+);
 export const mockedIsFailoverAssistantError = vi.fn<MockAssistantErrorProbe>(() => false);
 const mockedIsFailoverErrorMessage = vi.fn(() => false);
 const mockedIsGenericUnknownStreamErrorMessage = vi.fn((raw: string) =>
@@ -498,6 +506,11 @@ export function resetRunOverflowCompactionHarnessMocks(): void {
   });
   mockedIsCompactionFailureError.mockReset();
   mockedIsCompactionFailureError.mockReturnValue(false);
+  mockedIsContextOverflowAssistantError.mockReset();
+  mockedIsContextOverflowAssistantError.mockImplementation(
+    (assistant) =>
+      assistant?.stopReason === "error" && assistant.errorCode === "context_length_exceeded",
+  );
   mockedIsFailoverAssistantError.mockReset();
   mockedIsFailoverAssistantError.mockReturnValue(false);
   mockedIsFailoverErrorMessage.mockReset();
@@ -816,6 +829,7 @@ export async function loadRunOverflowCompactionHarness(): Promise<{
     isAuthAssistantError: mockedIsAuthAssistantError,
     isBillingAssistantError: mockedIsBillingAssistantError,
     isCompactionFailureError: mockedIsCompactionFailureError,
+    isContextOverflowAssistantError: mockedIsContextOverflowAssistantError,
     isLikelyContextOverflowError: mockedIsLikelyContextOverflowError,
     isFailoverAssistantError: mockedIsFailoverAssistantError,
     isFailoverErrorMessage: mockedIsFailoverErrorMessage,

--- a/src/agents/embedded-agent-runner/run.overflow-compaction.test.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.test.ts
@@ -47,6 +47,7 @@ import {
   mockedExtractObservedOverflowTokenCount,
   mockedGlobalHookRunner,
   mockedGetApiKeyForModel,
+  mockedIsContextOverflowAssistantError,
   mockedIsProfileInCooldown,
   mockedIsLikelyContextOverflowError,
   mockedMarkAuthProfileSuccess,
@@ -3615,6 +3616,49 @@ describe("runEmbeddedAgent overflow compaction trigger routing", () => {
       currentTokenCount: 200001,
     });
     expect(result.meta.error).toBeUndefined();
+  });
+
+  it("compacts and retries a structured ChatGPT context overflow", async () => {
+    const assistantError = {
+      role: "assistant",
+      content: [],
+      api: "openai-chatgpt-responses",
+      provider: "openai",
+      model: "gpt-5.6-sol",
+      stopReason: "error",
+      errorCode: "context_length_exceeded",
+      errorMessage: "Request failed",
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      timestamp: 1,
+    } as const;
+    mockedRunEmbeddedAttempt
+      .mockResolvedValueOnce(
+        makeAttemptResult({
+          currentAttemptAssistant: assistantError,
+          assistantTexts: [],
+        }),
+      )
+      .mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
+    mockedCompactDirect.mockResolvedValueOnce(
+      makeCompactionSuccess({ summary: "Compacted session", tokensAfter: 50 }),
+    );
+
+    const result = await runEmbeddedAgent(overflowBaseRunParams);
+
+    expect(mockedIsContextOverflowAssistantError).toHaveBeenCalledWith(assistantError);
+    expect(mockedCompactDirect).toHaveBeenCalledTimes(1);
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expect(result.meta.error).toBeUndefined();
+    expect(result.payloads).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ text: "LLM request failed." })]),
+    );
   });
 
   it("surfaces a visible blocked payload for Codex promptError overflow without assistant text", async () => {

--- a/src/agents/embedded-agent-runner/run/attempt-recovery.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-recovery.ts
@@ -190,6 +190,7 @@ export async function recoverEmbeddedRunAttempt(input: {
     aborted,
     signalOwnedInterruption,
     promptError,
+    attemptAssistant,
     assistantErrorText,
     attemptCompactionCount,
     prepareCurrentTranscriptRetry: sessionPromptState.continueFromCurrentTranscript,

--- a/src/agents/embedded-agent-runner/run/overflow-context-recovery.ts
+++ b/src/agents/embedded-agent-runner/run/overflow-context-recovery.ts
@@ -7,6 +7,7 @@ import { listActiveProcessSessionReferences } from "../../bash-process-reference
 import {
   extractObservedOverflowTokenCount,
   isCompactionFailureError,
+  isContextOverflowAssistantError,
   isLikelyContextOverflowError,
 } from "../../embedded-agent-helpers.js";
 import { buildEmbeddedCompactionRuntimeContext } from "../compaction-runtime-context.js";
@@ -61,6 +62,7 @@ export async function recoverEmbeddedRunOverflow(input: {
   aborted: boolean;
   signalOwnedInterruption: boolean;
   promptError: unknown;
+  attemptAssistant?: EmbeddedRunAttemptResult["currentAttemptAssistant"];
   assistantErrorText?: string;
   attempt: EmbeddedRunAttemptResult;
   attemptCompactionCount: number;
@@ -107,6 +109,12 @@ export async function recoverEmbeddedRunOverflow(input: {
             // A non-overflow prompt failure must not inherit a stale assistant
             // error from the previous transcript leaf.
             return null;
+          }
+          if (input.attemptAssistant && isContextOverflowAssistantError(input.attemptAssistant)) {
+            return {
+              text: input.attemptAssistant.errorMessage?.trim() || "Context overflow",
+              source: "assistantError" as const,
+            };
           }
           if (input.assistantErrorText && isLikelyContextOverflowError(input.assistantErrorText)) {
             return { text: input.assistantErrorText, source: "assistantError" as const };


### PR DESCRIPTION
## Summary

- preserve structured ChatGPT response failure codes on assistant errors
- classify `context_length_exceeded` as context overflow
- route structured overflow errors through the existing bounded compaction-and-retry path

## Motivation

The ChatGPT Responses transport receives a structured `context_length_exceeded` code, but the adapter previously discarded it when producing the assistant error. When the accompanying message was generic, the embedded runner could not recognise the overflow and skipped its existing compaction recovery.

This keeps the provider code on the assistant message and lets the current modular runner recover it without changing the normal retry limit or compaction ownership rules.

## Verification

- focused transport, error-classification and overflow-recovery regression suites
- formatter and diff checks for changed files
- guarded `gatewayWatch` production build

The regression verifies that a structured ChatGPT overflow triggers one compaction, retries the model attempt, and does not surface a generic failure payload.
