### PR TITLE
fix(ui): close stale realtime Talk relays

### DIFF
--- a/ui/src/pages/chat/realtime-talk.test.ts
+++ b/ui/src/pages/chat/realtime-talk.test.ts
@@ -209,6 +209,64 @@ describe("RealtimeTalkSession", () => {
     expect(webRtcInstances).toHaveLength(0);
   });
 
+  it("closes a stale Gateway relay after Talk restarts", async () => {
+    const resolveCreates: Array<(value: unknown) => void> = [];
+    const request = vi.fn((method: string) => {
+      if (method === "talk.client.create") {
+        return Promise.reject(new Error("gateway relay is server-owned"));
+      }
+      if (method === "talk.session.create") {
+        return new Promise<unknown>((resolve) => {
+          resolveCreates.push(resolve);
+        });
+      }
+      if (method === "talk.session.close") {
+        return Promise.resolve({ ok: true });
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const session = new RealtimeTalkSession(
+      { request } as never,
+      "main",
+      {},
+      { transport: "gateway-relay" },
+    );
+
+    const firstStart = session.start();
+    await vi.waitFor(() => expect(resolveCreates).toHaveLength(1));
+    session.stop();
+    const secondStart = session.start();
+    await vi.waitFor(() => expect(resolveCreates).toHaveLength(2));
+    resolveCreates[1]!({
+      provider: "example",
+      transport: "gateway-relay",
+      relaySessionId: "relay-current",
+      audio: {
+        inputEncoding: "pcm16",
+        inputSampleRateHz: 24_000,
+        outputEncoding: "pcm16",
+        outputSampleRateHz: 24_000,
+      },
+    });
+    await secondStart;
+    resolveCreates[0]!({
+      provider: "example",
+      transport: "gateway-relay",
+      relaySessionId: "relay-stale",
+      audio: {
+        inputEncoding: "pcm16",
+        inputSampleRateHz: 24_000,
+        outputEncoding: "pcm16",
+        outputSampleRateHz: 24_000,
+      },
+    });
+    await firstStart;
+
+    expect(request).toHaveBeenCalledWith("talk.session.close", { sessionId: "relay-stale" });
+    expect(relayInstances).toHaveLength(1);
+    expect(relayStart).toHaveBeenCalledTimes(1);
+  });
+
   it("falls back to talk.session.create when gateway-relay is rejected by talk.client.create", async () => {
     const request = vi
       .fn()

--- a/ui/src/pages/chat/realtime-talk.ts
+++ b/ui/src/pages/chat/realtime-talk.ts
@@ -137,6 +137,7 @@ function compactLaunchParams(
 export class RealtimeTalkSession {
   private transport: RealtimeTalkTransport | null = null;
   private closed = false;
+  private lifecycleGeneration = 0;
   private videoEnabled = false;
   private videoOperation = 0;
   private voiceSessionId: string | undefined;
@@ -155,10 +156,11 @@ export class RealtimeTalkSession {
   ) {}
 
   async start(): Promise<void> {
+    const generation = ++this.lifecycleGeneration;
     this.closed = false;
     this.callbacks.onStatus?.("connecting");
     const providerVideoCapable = await this.resolveVideoCapability();
-    if (this.closed) {
+    if (this.closed || generation !== this.lifecycleGeneration) {
       return;
     }
     // Declaring voice-transcript arms the server-side spoken-confirmation gate;
@@ -182,10 +184,14 @@ export class RealtimeTalkSession {
     if (!voiceSessionId) {
       throw new Error("Realtime Talk session did not return a voice session id");
     }
+    if (this.closed || generation !== this.lifecycleGeneration) {
+      this.closeStaleGatewayRelay(session);
+      return;
+    }
     this.voiceSessionId = voiceSessionId;
     this.acceptingTranscripts = true;
     this.serverOwnedVoiceSession = transport === "gateway-relay";
-    if (this.closed) {
+    if (this.closed || generation !== this.lifecycleGeneration) {
       const detached = this.detachVoiceSession();
       if (detached) {
         this.closeLogicalVoiceSession(detached);
@@ -300,6 +306,7 @@ export class RealtimeTalkSession {
   }
 
   stop(): void {
+    this.lifecycleGeneration += 1;
     this.closed = true;
     this.videoOperation += 1;
     this.videoEnabled = false;
@@ -311,6 +318,19 @@ export class RealtimeTalkSession {
     if (detached) {
       this.closeLogicalVoiceSession(detached);
     }
+  }
+
+  private closeStaleGatewayRelay(session: RealtimeTalkSessionResult): void {
+    if (resolveTransport(session) !== "gateway-relay") {
+      return;
+    }
+    // Gateway relays allocate server state before their create response returns.
+    // A retired start owns the matching close even though no transport was installed.
+    void this.client
+      .request("talk.session.close", {
+        sessionId: (session as RealtimeTalkGatewayRelaySessionResult).relaySessionId,
+      })
+      .catch(() => undefined);
   }
 
   private clientOwnedTranscriptCallbacks(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Control UI users who stop or restart Talk while a Gateway relay is still being created may leave the stale relay open after its delayed create response arrives.

## Why This Change Was Made

The Talk session now invalidates an earlier start when its lifecycle has been stopped or replaced. If that retired start created a Gateway relay, it explicitly closes that relay even though no transport was installed for the stale result.

## User Impact

Stopping or restarting Talk during connection setup no longer leaves an orphaned realtime relay behind. The current Talk session continues normally.

## Evidence

- `node scripts/run-vitest.mjs ui/src/pages/chat/realtime-talk.test.ts` (27 passing tests)
- `oxfmt` on the changed files
- `git diff --check`
