### PR TITLE
chore: sync yuanbao plugin catalog to 2.17.0

### DIFF
--- a/scripts/lib/official-external-channel-catalog.json
+++ b/scripts/lib/official-external-channel-catalog.json
@@ -76,9 +76,9 @@
           }
         },
         "install": {
-          "npmSpec": "openclaw-plugin-yuanbao@2.15.0",
+          "npmSpec": "openclaw-plugin-yuanbao@2.17.0",
           "defaultChoice": "npm",
-          "expectedIntegrity": "sha512-3GD+mf3EjTSUTOAREjTHAyp/deXdpgqB+q+xE0b19Qtat4ADhUV1mHDwFkVCRqTCBY5ATFKtKcipoDejqFj/+w=="
+          "expectedIntegrity": "sha512-3MLXEQSH2997TJFrcUAO5DAadvWB300RGXg14i0yfX36m1QuR9QPV41ko3icSCe4r/vcOUq1g5Rvriyt+UE3SQ=="
         }
       }
     },

--- a/src/channels/plugins/catalog.test.ts
+++ b/src/channels/plugins/catalog.test.ts
@@ -33,7 +33,7 @@ describe("channel plugin catalog", () => {
     expect(yuanbao?.id).toBe("yuanbao");
     expect(yuanbao?.pluginId).toBe("openclaw-plugin-yuanbao");
     expect(yuanbao?.trustedSourceLinkedOfficialInstall).toBe(true);
-    expect(yuanbao?.install?.npmSpec).toBe("openclaw-plugin-yuanbao@2.15.0");
+    expect(yuanbao?.install?.npmSpec).toBe("openclaw-plugin-yuanbao@2.17.0");
   });
 
   it("excludes only the rejected origin/plugin pair when resolving fallback copies", () => {

--- a/src/channels/plugins/contracts/channel-catalog.contract.test.ts
+++ b/src/channels/plugins/contracts/channel-catalog.contract.test.ts
@@ -46,7 +46,7 @@ describeChannelCatalogEntryContract({
 
 describeChannelCatalogEntryContract({
   channelId: "yuanbao",
-  npmSpec: "openclaw-plugin-yuanbao@2.15.0",
+  npmSpec: "openclaw-plugin-yuanbao@2.17.0",
   alias: "yb",
 });
 

--- a/src/config/config.plugin-validation.test.ts
+++ b/src/config/config.plugin-validation.test.ts
@@ -1268,7 +1268,7 @@ describe("config plugin validation", () => {
 
     expect(res.ok).toBe(true);
     const message =
-      "plugin not installed: yuanbao — install the official external plugin with: openclaw plugins install openclaw-plugin-yuanbao@2.15.0";
+      "plugin not installed: yuanbao — install the official external plugin with: openclaw plugins install openclaw-plugin-yuanbao@2.17.0";
     expectPathMessage(res.warnings, "plugins.entries.yuanbao", message);
     expect((res.warnings ?? []).filter((warning) => warning.message === message)).toHaveLength(1);
   });

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -1223,7 +1223,7 @@ describe("official external plugin catalog", () => {
     );
     expect(resolveOfficialExternalPluginId(yuanbaoByChannel)).toBe("openclaw-plugin-yuanbao");
     expect(resolveOfficialExternalPluginInstall(yuanbaoByChannel)?.npmSpec).toBe(
-      "openclaw-plugin-yuanbao@2.15.0",
+      "openclaw-plugin-yuanbao@2.17.0",
     );
   });
 

--- a/test/official-channel-catalog.test.ts
+++ b/test/official-channel-catalog.test.ts
@@ -171,10 +171,10 @@ describe("buildOfficialChannelCatalog", () => {
         aliases: ["yuanbao", "yb", "tencent-yuanbao", "元宝"],
       },
       install: {
-        npmSpec: "openclaw-plugin-yuanbao@2.15.0",
+        npmSpec: "openclaw-plugin-yuanbao@2.17.0",
         defaultChoice: "npm",
         expectedIntegrity:
-          "sha512-3GD+mf3EjTSUTOAREjTHAyp/deXdpgqB+q+xE0b19Qtat4ADhUV1mHDwFkVCRqTCBY5ATFKtKcipoDejqFj/+w==",
+          "sha512-3MLXEQSH2997TJFrcUAO5DAadvWB300RGXg14i0yfX36m1QuR9QPV41ko3icSCe4r/vcOUq1g5Rvriyt+UE3SQ==",
       },
     });
     expect(


### PR DESCRIPTION
Automated catalog sync after openclaw-plugin-yuanbao@2.17.0 published to npm.

- Updated npmSpec version (2.15.0 → 2.17.0)
- Updated expectedIntegrity

This PR was generated by running scripts/sync-catalog.mjs locally (outside CI) to verify the extracted script works end-to-end.