### PR TITLE
fix(cron): ignore inherited normalization fields

### DIFF
--- a/src/cron/normalize-payload.ts
+++ b/src/cron/normalize-payload.ts
@@ -9,6 +9,7 @@ import {
   TrimmedNonEmptyStringFieldSchema,
   parseOptionalField,
 } from "./delivery-field-schemas.js";
+import { snapshotOwnCronRecord } from "./own-record.js";
 
 type UnknownRecord = Record<string, unknown>;
 
@@ -66,7 +67,7 @@ function hasAgentTurnOnlyPayloadHint(payload: UnknownRecord): boolean {
 }
 
 export function normalizeCronPayload(payload: UnknownRecord): UnknownRecord {
-  const next: UnknownRecord = { ...payload };
+  const next = snapshotOwnCronRecord(payload);
   const kindRaw = normalizeLowercaseStringOrEmpty(next.kind);
   if (kindRaw === "agentturn") {
     next.kind = "agentTurn";
@@ -260,5 +261,5 @@ export function normalizeCronPayload(payload: UnknownRecord): UnknownRecord {
     delete next.noOutputTimeoutSeconds;
     delete next.outputMaxBytes;
   }
-  return next;
+  return { ...next };
 }

--- a/src/cron/normalize.test.ts
+++ b/src/cron/normalize.test.ts
@@ -98,6 +98,27 @@ function expectAnnounceDeliveryTarget(
   expect(delivery.to).toBe(params.to);
 }
 describe("normalizeCronJobCreate", () => {
+  it.each(["create", "patch"] as const)(
+    "does not promote prototype-only schedule fields during %s normalization",
+    (mode) => {
+      const schedule = Object.assign(Object.create({ expr: "*/17 * * * *" }) as UnknownRecord, {
+        kind: "cron",
+      });
+      const normalized =
+        mode === "create" ? createMain({ schedule }) : normalizePatch({ schedule });
+
+      expect(Object.hasOwn(schedule, "expr")).toBe(false);
+      expect(Object.hasOwn(child(normalized, "schedule"), "expr")).toBe(false);
+    },
+  );
+  it("does not promote prototype-only payload fields", () => {
+    const payload = Object.assign(
+      Object.create({ model: "openai/gpt-5" }) as UnknownRecord,
+      AGENT_TURN,
+    );
+
+    expect(child(createAgent({ payload }), "payload")).not.toHaveProperty("model");
+  });
   it("trims cron timezones and drops blank values", () => {
     const trimmed = mainSchedule({ ...CRON_SCHEDULE, tz: "  Europe/Vienna  " });
     const blank = mainSchedule({ ...CRON_SCHEDULE, tz: "   " });

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -62,12 +62,12 @@ function coerceSchedule(schedule: UnknownRecord) {
 
   if (exprRaw) {
     next.expr = exprRaw;
-  } else if ("expr" in next) {
+  } else if (Object.hasOwn(next, "expr")) {
     delete next.expr;
   }
   if (timezone) {
     next.tz = timezone;
-  } else if ("tz" in next) {
+  } else if (Object.hasOwn(next, "tz")) {
     delete next.tz;
   }
 
@@ -79,18 +79,18 @@ function coerceSchedule(schedule: UnknownRecord) {
   }
   if (commandRaw) {
     next.command = commandRaw;
-  } else if ("command" in next) {
+  } else if (Object.hasOwn(next, "command")) {
     delete next.command;
   }
   if (cwdRaw) {
     next.cwd = cwdRaw;
-  } else if ("cwd" in next) {
+  } else if (Object.hasOwn(next, "cwd")) {
     delete next.cwd;
   }
   const staggerMs = normalizeCronStaggerMs(schedule.staggerMs);
   if (staggerMs !== undefined) {
     next.staggerMs = staggerMs;
-  } else if ("staggerMs" in next) {
+  } else if (Object.hasOwn(next, "staggerMs")) {
     delete next.staggerMs;
   }
 
@@ -144,38 +144,38 @@ function coerceDelivery(delivery: UnknownRecord) {
   const parsed = parseDeliveryInput(delivery);
   if (parsed.mode !== undefined) {
     next.mode = parsed.mode;
-  } else if ("mode" in next) {
+  } else if (Object.hasOwn(next, "mode")) {
     delete next.mode;
   }
-  if ("channel" in delivery && delivery.channel === null) {
+  if (Object.hasOwn(delivery, "channel") && delivery.channel === null) {
     next.channel = null;
   } else if (parsed.channel !== undefined) {
     next.channel = parsed.channel;
-  } else if ("channel" in next) {
+  } else if (Object.hasOwn(next, "channel")) {
     delete next.channel;
   }
-  if ("to" in delivery && delivery.to === null) {
+  if (Object.hasOwn(delivery, "to") && delivery.to === null) {
     next.to = null;
   } else if (parsed.to !== undefined) {
     next.to = parsed.to;
-  } else if ("to" in next) {
+  } else if (Object.hasOwn(next, "to")) {
     delete next.to;
   }
-  if ("threadId" in delivery && delivery.threadId === null) {
+  if (Object.hasOwn(delivery, "threadId") && delivery.threadId === null) {
     next.threadId = null;
   } else if (parsed.threadId !== undefined) {
     next.threadId = parsed.threadId;
-  } else if ("threadId" in next) {
+  } else if (Object.hasOwn(next, "threadId")) {
     delete next.threadId;
   }
-  if ("accountId" in delivery && delivery.accountId === null) {
+  if (Object.hasOwn(delivery, "accountId") && delivery.accountId === null) {
     next.accountId = null;
   } else if (parsed.accountId !== undefined) {
     next.accountId = parsed.accountId;
-  } else if ("accountId" in next) {
+  } else if (Object.hasOwn(next, "accountId")) {
     delete next.accountId;
   }
-  if ("failureDestination" in next) {
+  if (Object.hasOwn(next, "failureDestination")) {
     // Null is an explicit clear signal in patches; invalid objects are dropped.
     if (next.failureDestination === null) {
       next.failureDestination = null;
@@ -185,7 +185,7 @@ function coerceDelivery(delivery: UnknownRecord) {
       delete next.failureDestination;
     }
   }
-  if ("completionDestination" in next) {
+  if (Object.hasOwn(next, "completionDestination")) {
     // Completion destinations are currently webhook-only, so other shapes are
     // discarded before they can persist as ambiguous config.
     if (next.completionDestination === null) {
@@ -218,7 +218,7 @@ function coerceCompletionDestination(value: UnknownRecord) {
 
 function coerceFailureDestination(value: UnknownRecord) {
   const next: UnknownRecord = { ...value };
-  if ("channel" in next) {
+  if (Object.hasOwn(next, "channel")) {
     if (next.channel === null) {
       next.channel = null;
     } else if (next.channel === undefined) {
@@ -232,7 +232,7 @@ function coerceFailureDestination(value: UnknownRecord) {
       }
     }
   }
-  if ("to" in next) {
+  if (Object.hasOwn(next, "to")) {
     if (next.to === null) {
       next.to = null;
     } else if (next.to === undefined) {
@@ -246,7 +246,7 @@ function coerceFailureDestination(value: UnknownRecord) {
       }
     }
   }
-  if ("accountId" in next) {
+  if (Object.hasOwn(next, "accountId")) {
     if (next.accountId === null) {
       next.accountId = null;
     } else if (next.accountId === undefined) {
@@ -260,7 +260,7 @@ function coerceFailureDestination(value: UnknownRecord) {
       }
     }
   }
-  if ("mode" in next) {
+  if (Object.hasOwn(next, "mode")) {
     if (next.mode === null) {
       next.mode = null;
     } else if (next.mode === undefined) {
@@ -317,7 +317,7 @@ export function normalizeCronJobInput(
   const next: UnknownRecord = { ...base };
 
   for (const field of ["declarationKey", "displayName"] as const) {
-    if (field in base && typeof base[field] === "string") {
+    if (Object.hasOwn(base, field) && typeof base[field] === "string") {
       const trimmed = base[field].trim();
       if (trimmed) {
         next[field] = trimmed;
@@ -340,7 +340,7 @@ export function normalizeCronJobInput(
     }
   }
 
-  if ("agentId" in base) {
+  if (Object.hasOwn(base, "agentId")) {
     const agentId = base.agentId;
     if (agentId === null) {
       next.agentId = null;
@@ -354,7 +354,7 @@ export function normalizeCronJobInput(
     }
   }
 
-  if ("sessionKey" in base) {
+  if (Object.hasOwn(base, "sessionKey")) {
     const sessionKey = base.sessionKey;
     if (sessionKey === null) {
       next.sessionKey = null;
@@ -368,14 +368,14 @@ export function normalizeCronJobInput(
     }
   }
 
-  if ("enabled" in base) {
+  if (Object.hasOwn(base, "enabled")) {
     const enabled = parseBoolean(base.enabled);
     if (enabled !== undefined) {
       next.enabled = enabled;
     }
   }
 
-  if ("sessionTarget" in base) {
+  if (Object.hasOwn(base, "sessionTarget")) {
     const normalized = normalizeSessionTarget(base.sessionTarget);
     if (normalized) {
       next.sessionTarget = normalized;
@@ -384,7 +384,7 @@ export function normalizeCronJobInput(
     }
   }
 
-  if ("wakeMode" in base) {
+  if (Object.hasOwn(base, "wakeMode")) {
     const normalized = normalizeWakeMode(base.wakeMode);
     if (normalized) {
       next.wakeMode = normalized;
@@ -401,7 +401,7 @@ export function normalizeCronJobInput(
     next.payload = normalizeCronPayload(base.payload);
   }
 
-  if ("trigger" in base) {
+  if (Object.hasOwn(base, "trigger")) {
     if (base.trigger === null) {
       next.trigger = null;
     } else if (isRecord(base.trigger)) {
@@ -477,14 +477,18 @@ export function normalizeCronJobInput(
       delete next.sessionTarget;
     }
     if (
-      "schedule" in next &&
+      Object.hasOwn(next, "schedule") &&
       isRecord(next.schedule) &&
       next.schedule.kind === "at" &&
-      !("deleteAfterRun" in next)
+      !Object.hasOwn(next, "deleteAfterRun")
     ) {
       next.deleteAfterRun = true;
     }
-    if ("schedule" in next && isRecord(next.schedule) && next.schedule.kind === "cron") {
+    if (
+      Object.hasOwn(next, "schedule") &&
+      isRecord(next.schedule) &&
+      next.schedule.kind === "cron"
+    ) {
       const schedule = next.schedule as UnknownRecord;
       const explicit = normalizeCronStaggerMs(schedule.staggerMs);
       if (explicit !== undefined) {
@@ -502,7 +506,7 @@ export function normalizeCronJobInput(
     const sessionTarget = typeof next.sessionTarget === "string" ? next.sessionTarget : "";
     // Omitted output targets were canonicalized to "isolated" above. Resolved
     // "current" and custom session ids share those announce semantics.
-    const hasDelivery = "delivery" in next && next.delivery !== undefined;
+    const hasDelivery = Object.hasOwn(next, "delivery") && next.delivery !== undefined;
     if (!hasDelivery && shouldDefaultCronDeliveryToAnnounce({ payloadKind, sessionTarget })) {
       next.delivery = { mode: "announce" };
     }

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -1,6 +1,7 @@
 /** Normalizes cron create/patch payloads before validation and persistence. */
 import { parseBoolean } from "@openclaw/normalization-core/boolean-coercion";
 import { timestampMsToIsoString } from "@openclaw/normalization-core/number-coercion";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalLowercaseString,
@@ -8,10 +9,10 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import { normalizeOptionalAccountId } from "../routing/account-id.js";
 import { sanitizeAgentId } from "../routing/session-key.js";
-import { isRecord } from "../utils.js";
 import { shouldDefaultCronDeliveryToAnnounce } from "./delivery-defaults.js";
 import { parseDeliveryInput } from "./delivery-field-schemas.js";
 import { normalizeCronCommandArgv, normalizeCronPayload } from "./normalize-payload.js";
+import { snapshotOwnCronRecord } from "./own-record.js";
 import { parseAbsoluteTimeMs } from "./parse.js";
 import { normalizeCronRuntimeAuthority } from "./runtime-authority.js";
 import { coerceFiniteScheduleNumber } from "./schedule-number.js";
@@ -43,8 +44,8 @@ const DEFAULT_OPTIONS: NormalizeOptions = {
 };
 
 function coerceSchedule(schedule: UnknownRecord) {
-  const next: UnknownRecord = { ...schedule };
-  const rawKind = normalizeLowercaseStringOrEmpty(schedule.kind);
+  const next = snapshotOwnCronRecord(schedule);
+  const rawKind = normalizeLowercaseStringOrEmpty(next.kind);
   const kind =
     rawKind === "at" ||
     rawKind === "every" ||
@@ -53,16 +54,16 @@ function coerceSchedule(schedule: UnknownRecord) {
     rawKind === "stream"
       ? rawKind
       : undefined;
-  const exprRaw = normalizeOptionalString(schedule.expr) ?? "";
-  const timezone = normalizeOptionalString(schedule.tz);
-  const commandRaw = normalizeOptionalString(schedule.command) ?? "";
-  const streamCommand = normalizeCronCommandArgv(schedule.command);
-  const cwdRaw = normalizeOptionalString(schedule.cwd) ?? "";
-  const streamMode = normalizeOptionalLowercaseString(schedule.mode);
-  const streamMatch = typeof schedule.match === "string" ? schedule.match : undefined;
-  const everyMs = coerceFiniteScheduleNumber(schedule.everyMs);
-  const anchorMs = coerceFiniteScheduleNumber(schedule.anchorMs);
-  const atString = normalizeOptionalString(schedule.at) ?? "";
+  const exprRaw = normalizeOptionalString(next.expr) ?? "";
+  const timezone = normalizeOptionalString(next.tz);
+  const commandRaw = normalizeOptionalString(next.command) ?? "";
+  const streamCommand = normalizeCronCommandArgv(next.command);
+  const cwdRaw = normalizeOptionalString(next.cwd) ?? "";
+  const streamMode = normalizeOptionalLowercaseString(next.mode);
+  const streamMatch = typeof next.match === "string" ? next.match : undefined;
+  const everyMs = coerceFiniteScheduleNumber(next.everyMs);
+  const anchorMs = coerceFiniteScheduleNumber(next.anchorMs);
+  const atString = normalizeOptionalString(next.at) ?? "";
   const parsedAtMs = atString ? parseAbsoluteTimeMs(atString) : null;
 
   if (kind) {
@@ -118,7 +119,7 @@ function coerceSchedule(schedule: UnknownRecord) {
     }
     normalizeCronStreamBatching(next);
   }
-  const staggerMs = normalizeCronStaggerMs(schedule.staggerMs);
+  const staggerMs = normalizeCronStaggerMs(next.staggerMs);
   if (staggerMs !== undefined) {
     next.staggerMs = staggerMs;
   } else if ("staggerMs" in next) {
@@ -175,12 +176,13 @@ function coerceSchedule(schedule: UnknownRecord) {
     delete next.maxBatchBytes;
   }
 
-  return next;
+  return { ...next };
 }
 
 function coerceTrigger(trigger: UnknownRecord): UnknownRecord {
-  const script = typeof trigger.script === "string" ? trigger.script.trim() : "";
-  const once = parseBoolean(trigger.once);
+  const input = snapshotOwnCronRecord(trigger);
+  const script = typeof input.script === "string" ? input.script.trim() : "";
+  const once = parseBoolean(input.once);
   return {
     script,
     ...(once !== undefined ? { once } : {}),
@@ -188,35 +190,35 @@ function coerceTrigger(trigger: UnknownRecord): UnknownRecord {
 }
 
 function coerceDelivery(delivery: UnknownRecord) {
-  const next: UnknownRecord = { ...delivery };
-  const parsed = parseDeliveryInput(delivery);
+  const next = snapshotOwnCronRecord(delivery);
+  const parsed = parseDeliveryInput(next);
   if (parsed.mode !== undefined) {
     next.mode = parsed.mode;
   } else if ("mode" in next) {
     delete next.mode;
   }
-  if ("channel" in delivery && delivery.channel === null) {
+  if ("channel" in next && next.channel === null) {
     next.channel = null;
   } else if (parsed.channel !== undefined) {
     next.channel = parsed.channel;
   } else if ("channel" in next) {
     delete next.channel;
   }
-  if ("to" in delivery && delivery.to === null) {
+  if ("to" in next && next.to === null) {
     next.to = null;
   } else if (parsed.to !== undefined) {
     next.to = parsed.to;
   } else if ("to" in next) {
     delete next.to;
   }
-  if ("threadId" in delivery && delivery.threadId === null) {
+  if ("threadId" in next && next.threadId === null) {
     next.threadId = null;
   } else if (parsed.threadId !== undefined) {
     next.threadId = parsed.threadId;
   } else if ("threadId" in next) {
     delete next.threadId;
   }
-  if ("accountId" in delivery && delivery.accountId === null) {
+  if ("accountId" in next && next.accountId === null) {
     next.accountId = null;
   } else if (parsed.accountId !== undefined) {
     next.accountId = parsed.accountId;
@@ -249,12 +251,13 @@ function coerceDelivery(delivery: UnknownRecord) {
       }
     }
   }
-  return next;
+  return { ...next };
 }
 
 function coerceCompletionDestination(value: UnknownRecord) {
-  const mode = normalizeOptionalLowercaseString(value.mode);
-  const to = normalizeOptionalString(value.to);
+  const input = snapshotOwnCronRecord(value);
+  const mode = normalizeOptionalLowercaseString(input.mode);
+  const to = normalizeOptionalString(input.to);
   if (mode !== "webhook") {
     return null;
   }
@@ -265,7 +268,7 @@ function coerceCompletionDestination(value: UnknownRecord) {
 }
 
 function coerceFailureDestination(value: UnknownRecord) {
-  const next: UnknownRecord = { ...value };
+  const next = snapshotOwnCronRecord(value);
   if ("channel" in next) {
     if (next.channel === null) {
       next.channel = null;
@@ -322,7 +325,7 @@ function coerceFailureDestination(value: UnknownRecord) {
       }
     }
   }
-  return next;
+  return { ...next };
 }
 
 function normalizeSessionTarget(raw: unknown) {
@@ -361,8 +364,8 @@ export function normalizeCronJobInput(
   if (!isRecord(raw)) {
     return null;
   }
-  const base = raw;
-  const next: UnknownRecord = { ...base };
+  const base = snapshotOwnCronRecord(raw);
+  const next = snapshotOwnCronRecord(base);
 
   for (const field of ["declarationKey", "displayName"] as const) {
     if (field in base && typeof base[field] === "string") {
@@ -376,10 +379,11 @@ export function normalizeCronJobInput(
   }
 
   if (isRecord(base.owner)) {
-    const agentId = normalizeOptionalString(base.owner.agentId);
-    const sessionKey = normalizeOptionalString(base.owner.sessionKey);
+    const owner = snapshotOwnCronRecord(base.owner);
+    const agentId = normalizeOptionalString(owner.agentId);
+    const sessionKey = normalizeOptionalString(owner.sessionKey);
     const accountId = normalizeOptionalAccountId(
-      typeof base.owner.accountId === "string" ? base.owner.accountId : undefined,
+      typeof owner.accountId === "string" ? owner.accountId : undefined,
     );
     if (agentId || sessionKey || accountId) {
       next.owner = {
@@ -402,7 +406,9 @@ export function normalizeCronJobInput(
   }
 
   if ("toolsAllowProvenance" in base) {
-    const provenance = base.toolsAllowProvenance;
+    const provenance = isRecord(base.toolsAllowProvenance)
+      ? snapshotOwnCronRecord(base.toolsAllowProvenance)
+      : undefined;
     if (
       isRecord(provenance) &&
       provenance.version === 1 &&
@@ -623,7 +629,7 @@ export function normalizeCronJobInput(
     }
   }
 
-  return next;
+  return { ...next };
 }
 
 /** Normalizes a raw cron create request and applies create-time defaults. */

--- a/src/cron/own-record.ts
+++ b/src/cron/own-record.ts
@@ -1,0 +1,8 @@
+/**
+ * Copies authored fields into a record with no inherited properties.
+ * Direct normalization would otherwise persist prototype-only input.
+ */
+export function snapshotOwnCronRecord(record: Record<string, unknown>): Record<string, unknown> {
+  const snapshot: Record<string, unknown> = Object.create(null);
+  return Object.assign(snapshot, record);
+}

--- a/src/cron/runtime-authority.test.ts
+++ b/src/cron/runtime-authority.test.ts
@@ -63,6 +63,16 @@ describe("normalizeCronRuntimeAuthority", () => {
     expect(({} as { polluted?: boolean }).polluted).toBeUndefined();
   });
 
+  it("does not treat an inherited envelope version as authored", () => {
+    const input = Object.assign(Object.create({ version: 1 }) as Record<string, unknown>, {
+      runtimeId: "codex",
+      namespace: "codex.apps",
+      payload: {},
+    });
+
+    expect(normalizeCronRuntimeAuthority(input)).toBeUndefined();
+  });
+
   it("rejects the complete envelope above 64 KiB", () => {
     expect(
       normalizeCronRuntimeAuthority(authority({ data: "x".repeat(64 * 1024) })),

--- a/src/cron/runtime-authority.ts
+++ b/src/cron/runtime-authority.ts
@@ -1,5 +1,6 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import { isRecord } from "../utils.js";
+import { snapshotOwnCronRecord } from "./own-record.js";
 
 const CRON_RUNTIME_AUTHORITY_MAX_BYTES = 64 * 1024;
 const CRON_RUNTIME_AUTHORITY_MAX_ID_LENGTH = 128;
@@ -101,19 +102,20 @@ function deepFreezeJson(value: JsonValue): JsonValue {
 
 /** Validates the private persisted transport without learning runtime-owned payload semantics. */
 export function normalizeCronRuntimeAuthority(value: unknown): CronRuntimeAuthority | undefined {
+  const input = isRecord(value) ? snapshotOwnCronRecord(value) : undefined;
   if (
-    !isRecord(value) ||
-    value.version !== 1 ||
-    Object.keys(value).some((key) => !CRON_RUNTIME_AUTHORITY_KEYS.has(key)) ||
-    !Object.hasOwn(value, "runtimeId") ||
-    !Object.hasOwn(value, "namespace") ||
-    !Object.hasOwn(value, "payload")
+    !input ||
+    input.version !== 1 ||
+    Object.keys(input).some((key) => !CRON_RUNTIME_AUTHORITY_KEYS.has(key)) ||
+    !("runtimeId" in input) ||
+    !("namespace" in input) ||
+    !("payload" in input)
   ) {
     return undefined;
   }
-  const runtimeId = normalizeAuthorityId(value.runtimeId);
-  const namespace = normalizeAuthorityId(value.namespace);
-  const payload = cloneJsonObject(value.payload);
+  const runtimeId = normalizeAuthorityId(input.runtimeId);
+  const namespace = normalizeAuthorityId(input.namespace);
+  const payload = cloneJsonObject(input.payload);
   if (!runtimeId || !namespace || !payload) {
     return undefined;
   }

--- a/src/cron/scheduled-tool-policy.test.ts
+++ b/src/cron/scheduled-tool-policy.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
   createAccountCronScheduledToolPolicy,
+  normalizeCronScheduledToolCallerOrigin,
   normalizeCronScheduledToolPolicy,
+  normalizeCronToolsAllowExecTarget,
+  normalizeCronToolsAllowExecTargetRequirement,
   resolveCronScheduledToolPolicy,
 } from "./scheduled-tool-policy.js";
 
@@ -15,6 +18,27 @@ describe("cron scheduled tool policy", () => {
     expect(
       normalizeCronScheduledToolPolicy({ version: 1, mode: "trusted", ownerAccountId: "work" }),
     ).toBeUndefined();
+  });
+
+  it("does not treat inherited authority fields as authored", () => {
+    expect(normalizeCronScheduledToolCallerOrigin(Object.create({ kind: "local" }))).toEqual({
+      kind: "unknown",
+    });
+    expect(
+      normalizeCronScheduledToolPolicy(Object.create({ version: 1, mode: "trusted" })),
+    ).toBeUndefined();
+    expect(
+      normalizeCronToolsAllowExecTarget(Object.create({ version: 1, host: "gateway" })),
+    ).toBeUndefined();
+    expect(
+      normalizeCronToolsAllowExecTargetRequirement(
+        Object.create({
+          version: 1,
+          target: { version: 1, host: "gateway" },
+          grantIndex: 0,
+        }),
+      ),
+    ).toEqual({ version: 1, recoveryRequired: true });
   });
 
   it("requires account provenance to match the persisted owner", () => {

--- a/src/cron/scheduled-tool-policy.ts
+++ b/src/cron/scheduled-tool-policy.ts
@@ -1,6 +1,7 @@
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { normalizeOptionalAccountId } from "../routing/account-id.js";
+import { snapshotOwnCronRecord } from "./own-record.js";
 
 /** Closed, server-authored origin of an account-scoped scheduled tool cap. */
 export type CronScheduledToolCallerOrigin =
@@ -12,18 +13,19 @@ export type CronScheduledToolCallerOrigin =
 export function normalizeCronScheduledToolCallerOrigin(
   value: unknown,
 ): CronScheduledToolCallerOrigin {
-  if (!isRecord(value) || typeof value.kind !== "string") {
+  const input = isRecord(value) ? snapshotOwnCronRecord(value) : undefined;
+  if (!input || typeof input.kind !== "string") {
     return { kind: "unknown" };
   }
-  const keys = Object.keys(value);
-  if (value.kind === "local" && keys.every((key) => key === "kind")) {
+  const keys = Object.keys(input);
+  if (input.kind === "local" && keys.every((key) => key === "kind")) {
     return { kind: "local" };
   }
-  if (value.kind === "unknown" && keys.every((key) => key === "kind")) {
+  if (input.kind === "unknown" && keys.every((key) => key === "kind")) {
     return { kind: "unknown" };
   }
   const channel = normalizeOptionalString(
-    value.kind === "external" && typeof value.channel === "string" ? value.channel : undefined,
+    input.kind === "external" && typeof input.channel === "string" ? input.channel : undefined,
   )?.toLowerCase();
   return channel && keys.every((key) => key === "kind" || key === "channel")
     ? { kind: "external", channel }
@@ -61,11 +63,12 @@ export type CronToolsAllowExecTargetRequirement =
 export function normalizeCronToolsAllowExecTarget(
   value: unknown,
 ): CronToolsAllowExecTarget | undefined {
-  return isRecord(value) && value.version === 1 && value.host === "gateway"
+  const input = isRecord(value) ? snapshotOwnCronRecord(value) : undefined;
+  return input?.version === 1 && input.host === "gateway"
     ? {
         version: 1,
         host: "gateway",
-        ...(value.ask === "always" ? { ask: "always" } : {}),
+        ...(input.ask === "always" ? { ask: "always" } : {}),
       }
     : undefined;
 }
@@ -77,15 +80,13 @@ export function normalizeCronToolsAllowExecTargetRequirement(
   if (value === undefined) {
     return undefined;
   }
-  if (!isRecord(value) || value.version !== 1) {
+  const input = isRecord(value) ? snapshotOwnCronRecord(value) : undefined;
+  if (!input || input.version !== 1 || input.recoveryRequired === true) {
     return { version: 1, recoveryRequired: true };
   }
-  if (value.recoveryRequired === true) {
-    return { version: 1, recoveryRequired: true };
-  }
-  const rawTarget = value.target;
+  const rawTarget = isRecord(input.target) ? snapshotOwnCronRecord(input.target) : undefined;
   const target =
-    isRecord(rawTarget) &&
+    rawTarget &&
     rawTarget.version === 1 &&
     rawTarget.host === "gateway" &&
     (rawTarget.ask === undefined || rawTarget.ask === "always")
@@ -95,7 +96,7 @@ export function normalizeCronToolsAllowExecTargetRequirement(
           ...(rawTarget.ask === "always" ? { ask: "always" as const } : {}),
         }
       : undefined;
-  const grantIndex = value.grantIndex;
+  const grantIndex = input.grantIndex;
   return target && typeof grantIndex === "number" && Number.isInteger(grantIndex) && grantIndex >= 0
     ? { version: 1, target, grantIndex }
     : { version: 1, recoveryRequired: true };
@@ -209,25 +210,26 @@ export function createAccountCronScheduledToolPolicy(params: {
 export function normalizeCronScheduledToolPolicy(
   value: unknown,
 ): CronScheduledToolPolicy | undefined {
-  if (!isRecord(value) || value.version !== 1) {
+  const input = isRecord(value) ? snapshotOwnCronRecord(value) : undefined;
+  if (!input || input.version !== 1) {
     return undefined;
   }
-  if (value.mode === "trusted") {
-    return Object.keys(value).every((key) => key === "version" || key === "mode")
+  if (input.mode === "trusted") {
+    return Object.keys(input).every((key) => key === "version" || key === "mode")
       ? createTrustedCronScheduledToolPolicy()
       : undefined;
   }
-  if (value.mode !== "account") {
+  if (input.mode !== "account") {
     return undefined;
   }
   const policy = createAccountCronScheduledToolPolicy({
-    ownerSessionKey: typeof value.ownerSessionKey === "string" ? value.ownerSessionKey : "",
-    ownerAccountId: typeof value.ownerAccountId === "string" ? value.ownerAccountId : "",
+    ownerSessionKey: typeof input.ownerSessionKey === "string" ? input.ownerSessionKey : "",
+    ownerAccountId: typeof input.ownerAccountId === "string" ? input.ownerAccountId : "",
   });
   if (!policy) {
     return undefined;
   }
-  return Object.keys(value).every(
+  return Object.keys(input).every(
     (key) =>
       key === "version" || key === "mode" || key === "ownerSessionKey" || key === "ownerAccountId",
   )


### PR DESCRIPTION
## Problem

Cron normalization could turn an inherited configuration field into authored, serialized data. A schedule with an `expr` only on its prototype gained an own `expr` field after normalization.

## Root cause

The normalizer copied own schedule fields, then read values from the original prototype-bearing object. The earlier patch changed later membership checks, but the inherited value had already been assigned to the result.

## Fix

- Snapshot each cron input record into a null-prototype own-field record before reading it.
- Apply the same boundary to payload and scheduled-authority normalization.
- Return ordinary records that contain only the normalized own fields.
- Keep the current `at`, `every`, `cron`, `on-exit`, and `stream` paths unchanged.

## Proof

Current main `5a1e1316e0a1a56362d6bf4124c983228fbfb1a4`:

```json
{"label":"prototype-only","inputOwnExpr":false,"outputOwnExpr":true,"stored":"{\"kind\":\"cron\",\"expr\":\"0 0 * * *\"}"}
{"label":"clean","inputOwnExpr":false,"outputOwnExpr":false,"stored":"{\"kind\":\"cron\"}"}
```

This head `13368705ea3e23683a84bd4935e8013ff08a9c1a`:

```json
{"label":"prototype-only","inputOwnExpr":false,"outputOwnExpr":false,"stored":"{\"kind\":\"cron\"}"}
{"label":"clean","inputOwnExpr":false,"outputOwnExpr":false,"stored":"{\"kind\":\"cron\"}"}
```

Focused validation passed 299 tests across the cron normalizer, authority, persistence codec, and Gateway method boundary. Formatting, lint, repository ratchets, import cycles, and storage guards also passed. Hosted CI owns type checking and builds.

Exact-head CI passed in [run 33294847016](https://github.com/openclaw/openclaw/actions/runs/33294847016).

Production code grows by 19 lines. The shared snapshot boundary replaces an incomplete 31-site membership rewrite and covers the current normalization and authority fields.
