### PR TITLE
fix(xai): reject invalid realtime tool arguments

### DIFF
--- a/extensions/xai/realtime-voice-protocol.ts
+++ b/extensions/xai/realtime-voice-protocol.ts
@@ -224,11 +224,21 @@ export abstract class XaiRealtimeVoiceProtocol {
     try {
       args = JSON.parse(fields.rawArgs || "{}");
     } catch {
-      this.recordRejectedToolCallArguments(itemId, "malformed-json");
+      this.rejectToolCallArguments({
+        itemId,
+        callId,
+        dedupeKey,
+        reason: "malformed-json",
+      });
       return;
     }
     if (!isRecord(args)) {
-      this.recordRejectedToolCallArguments(itemId, "non-object-json");
+      this.rejectToolCallArguments({
+        itemId,
+        callId,
+        dedupeKey,
+        reason: "non-object-json",
+      });
       return;
     }
     this.deliveredToolCallKeys.add(dedupeKey);
@@ -236,13 +246,22 @@ export abstract class XaiRealtimeVoiceProtocol {
     this.config.onToolCall({ itemId, callId, name, args });
   }
 
-  private recordRejectedToolCallArguments(itemId: string, reason: string): void {
+  private rejectToolCallArguments(params: {
+    itemId: string;
+    callId: string;
+    dedupeKey: string;
+    reason: string;
+  }): void {
+    // xAI pauses until every function call receives an output. Treat rejection as
+    // terminal and dedupe it before sending so replay cannot complete the call twice.
+    this.deliveredToolCallKeys.add(params.dedupeKey);
     this.config.onEvent?.({
       direction: "server",
       type: "tool_call.arguments.rejected",
-      detail: `reason=${reason}`,
-      itemId,
+      detail: `reason=${params.reason}`,
+      itemId: params.itemId,
     });
+    this.submitToolResultNow(params.callId, { error: "Invalid tool arguments." });
   }
 
   private flushPendingResponseCreateAfterToolResults(): void {

--- a/extensions/xai/realtime-voice-protocol.ts
+++ b/extensions/xai/realtime-voice-protocol.ts
@@ -5,6 +5,7 @@ import type {
   RealtimeVoiceToolResultOptions,
 } from "openclaw/plugin-sdk/realtime-voice";
 import { REALTIME_VOICE_AUDIO_FORMAT_G711_ULAW_8KHZ } from "openclaw/plugin-sdk/realtime-voice";
+import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   XAI_REALTIME_DEFAULT_PREFIX_PADDING_MS,
   XAI_REALTIME_DEFAULT_SILENCE_DURATION_MS,
@@ -219,18 +220,29 @@ export abstract class XaiRealtimeVoiceProtocol {
     if (this.deliveredToolCallKeys.has(dedupeKey)) {
       return;
     }
-    this.deliveredToolCallKeys.add(dedupeKey);
-    this.pendingToolCallIds.add(callId);
     let args: unknown;
     try {
       args = JSON.parse(fields.rawArgs || "{}");
     } catch {
+      this.recordRejectedToolCallArguments(itemId, "malformed-json");
       return;
     }
-    if (typeof args !== "object" || args === null || Array.isArray(args)) {
-      args = {};
+    if (!isRecord(args)) {
+      this.recordRejectedToolCallArguments(itemId, "non-object-json");
+      return;
     }
+    this.deliveredToolCallKeys.add(dedupeKey);
+    this.pendingToolCallIds.add(callId);
     this.config.onToolCall({ itemId, callId, name, args });
+  }
+
+  private recordRejectedToolCallArguments(itemId: string, reason: string): void {
+    this.config.onEvent?.({
+      direction: "server",
+      type: "tool_call.arguments.rejected",
+      detail: `reason=${reason}`,
+      itemId,
+    });
   }
 
   private flushPendingResponseCreateAfterToolResults(): void {

--- a/extensions/xai/realtime-voice-protocol.ts
+++ b/extensions/xai/realtime-voice-protocol.ts
@@ -221,10 +221,15 @@ export abstract class XaiRealtimeVoiceProtocol {
     }
     this.deliveredToolCallKeys.add(dedupeKey);
     this.pendingToolCallIds.add(callId);
-    let args: unknown = {};
+    let args: unknown;
     try {
       args = JSON.parse(fields.rawArgs || "{}");
-    } catch {}
+    } catch {
+      return;
+    }
+    if (typeof args !== "object" || args === null || Array.isArray(args)) {
+      args = {};
+    }
     this.config.onToolCall({ itemId, callId, name, args });
   }
 

--- a/extensions/xai/realtime-voice-provider.test.ts
+++ b/extensions/xai/realtime-voice-provider.test.ts
@@ -93,6 +93,9 @@ type FakeWebSocketInstance = InstanceType<typeof FakeWebSocket>;
 type SentRealtimeEvent = {
   type: string;
   audio?: string;
+  item?: {
+    type?: string;
+  };
   session?: {
     voice?: string;
     model?: string;

--- a/extensions/xai/realtime-voice-provider.test.ts
+++ b/extensions/xai/realtime-voice-provider.test.ts
@@ -1204,18 +1204,12 @@ describe("buildXaiRealtimeVoiceProvider", () => {
       const { connecting, socket } = await openRealtimeBridge(bridge);
       await connecting;
 
-      for (const [index, rawArgs] of [
-        "{",
-        "null",
-        "[]",
-        JSON.stringify("text"),
-        "1",
-        "true",
-      ].entries()) {
-        const itemId = `item_invalid_${index}`;
-        const callId = `call_invalid_${index}`;
-        const event =
-          ingress === "completed arguments"
+      socket.emit("message", Buffer.from(JSON.stringify({ type: "response.created" })));
+      const invalidEvents = ["{", "null", "[]", JSON.stringify("text"), "1", "true"].map(
+        (rawArgs, index) => {
+          const itemId = `item_invalid_${index}`;
+          const callId = `call_invalid_${index}`;
+          return ingress === "completed arguments"
             ? {
                 type: "response.function_call_arguments.done",
                 item_id: itemId,
@@ -1233,8 +1227,12 @@ describe("buildXaiRealtimeVoiceProvider", () => {
                   arguments: rawArgs,
                 },
               };
+        },
+      );
+      for (const event of invalidEvents) {
         socket.emit("message", Buffer.from(JSON.stringify(event)));
       }
+      socket.emit("message", Buffer.from(JSON.stringify(invalidEvents[0])));
 
       expect(onToolCall).not.toHaveBeenCalled();
       expect(
@@ -1255,7 +1253,31 @@ describe("buildXaiRealtimeVoiceProvider", () => {
           itemId: `item_invalid_${index + 1}`,
         })),
       ]);
+      expect(
+        parseSent(socket).filter(
+          (event) =>
+            event.type === "conversation.item.create" &&
+            event.item?.type === "function_call_output",
+        ),
+      ).toEqual(
+        Array.from({ length: 6 }, (_, index) => ({
+          type: "conversation.item.create",
+          item: {
+            type: "function_call_output",
+            call_id: `call_invalid_${index}`,
+            output: JSON.stringify({ error: "Invalid tool arguments." }),
+          },
+        })),
+      );
+      expect(parseSent(socket).filter((event) => event.type === "response.create")).toEqual([]);
 
+      socket.emit("message", Buffer.from(JSON.stringify({ type: "response.done" })));
+      expect(parseSent(socket).filter((event) => event.type === "response.create")).toEqual([
+        { type: "response.create" },
+      ]);
+
+      socket.emit("message", Buffer.from(JSON.stringify({ type: "response.created" })));
+      socket.emit("message", Buffer.from(JSON.stringify({ type: "response.done" })));
       bridge.sendUserMessage?.("Continue after rejected tool arguments.");
       expect(parseSent(socket).slice(-2)).toEqual([
         {
@@ -1272,7 +1294,7 @@ describe("buildXaiRealtimeVoiceProvider", () => {
     },
   );
 
-  it("allows corrected completed arguments after rejecting the same tool call identity", async () => {
+  it("treats rejected tool call arguments as terminal for the same identity", async () => {
     const onToolCall = vi.fn();
     const bridge = buildXaiRealtimeVoiceProvider().createBridge({
       providerConfig: { apiKey: "xai-test" }, // pragma: allowlist secret
@@ -1289,8 +1311,8 @@ describe("buildXaiRealtimeVoiceProvider", () => {
         Buffer.from(
           JSON.stringify({
             type: "response.function_call_arguments.done",
-            item_id: "item_corrected",
-            call_id: "call_corrected",
+            item_id: "item_rejected",
+            call_id: "call_rejected",
             name: "lookup_weather",
             arguments: rawArgs,
           }),
@@ -1298,13 +1320,22 @@ describe("buildXaiRealtimeVoiceProvider", () => {
       );
     }
 
-    expect(onToolCall).toHaveBeenCalledTimes(1);
-    expect(onToolCall).toHaveBeenCalledWith({
-      itemId: "item_corrected",
-      callId: "call_corrected",
-      name: "lookup_weather",
-      args: { city: "Paris" },
-    });
+    expect(onToolCall).not.toHaveBeenCalled();
+    expect(
+      parseSent(socket).filter(
+        (event) =>
+          event.type === "conversation.item.create" && event.item?.type === "function_call_output",
+      ),
+    ).toEqual([
+      {
+        type: "conversation.item.create",
+        item: {
+          type: "function_call_output",
+          call_id: "call_rejected",
+          output: JSON.stringify({ error: "Invalid tool arguments." }),
+        },
+      },
+    ]);
     bridge.close();
   });
 

--- a/extensions/xai/realtime-voice-provider.test.ts
+++ b/extensions/xai/realtime-voice-provider.test.ts
@@ -1186,6 +1186,128 @@ describe("buildXaiRealtimeVoiceProvider", () => {
     },
   );
 
+  it.each(["completed arguments", "resumed item replay"] as const)(
+    "rejects malformed and non-object tool arguments from %s without retaining pending state",
+    async (ingress) => {
+      const onEvent = vi.fn();
+      const onToolCall = vi.fn();
+      const bridge = buildXaiRealtimeVoiceProvider().createBridge({
+        providerConfig: {
+          apiKey: "xai-test", // pragma: allowlist secret
+          sessionResumption: ingress === "resumed item replay",
+        },
+        onAudio: vi.fn(),
+        onClearAudio: vi.fn(),
+        onEvent,
+        onToolCall,
+      });
+      const { connecting, socket } = await openRealtimeBridge(bridge);
+      await connecting;
+
+      for (const [index, rawArgs] of [
+        "{",
+        "null",
+        "[]",
+        JSON.stringify("text"),
+        "1",
+        "true",
+      ].entries()) {
+        const itemId = `item_invalid_${index}`;
+        const callId = `call_invalid_${index}`;
+        const event =
+          ingress === "completed arguments"
+            ? {
+                type: "response.function_call_arguments.done",
+                item_id: itemId,
+                call_id: callId,
+                name: "lookup_weather",
+                arguments: rawArgs,
+              }
+            : {
+                type: "conversation.item.created",
+                item: {
+                  id: itemId,
+                  type: "function_call",
+                  call_id: callId,
+                  name: "lookup_weather",
+                  arguments: rawArgs,
+                },
+              };
+        socket.emit("message", Buffer.from(JSON.stringify(event)));
+      }
+
+      expect(onToolCall).not.toHaveBeenCalled();
+      expect(
+        onEvent.mock.calls
+          .map(([event]) => event)
+          .filter((event) => event.type === "tool_call.arguments.rejected"),
+      ).toEqual([
+        {
+          direction: "server",
+          type: "tool_call.arguments.rejected",
+          detail: "reason=malformed-json",
+          itemId: "item_invalid_0",
+        },
+        ...Array.from({ length: 5 }, (_, index) => ({
+          direction: "server",
+          type: "tool_call.arguments.rejected",
+          detail: "reason=non-object-json",
+          itemId: `item_invalid_${index + 1}`,
+        })),
+      ]);
+
+      bridge.sendUserMessage?.("Continue after rejected tool arguments.");
+      expect(parseSent(socket).slice(-2)).toEqual([
+        {
+          type: "conversation.item.create",
+          item: {
+            type: "message",
+            role: "user",
+            content: [{ type: "input_text", text: "Continue after rejected tool arguments." }],
+          },
+        },
+        { type: "response.create" },
+      ]);
+      bridge.close();
+    },
+  );
+
+  it("allows corrected completed arguments after rejecting the same tool call identity", async () => {
+    const onToolCall = vi.fn();
+    const bridge = buildXaiRealtimeVoiceProvider().createBridge({
+      providerConfig: { apiKey: "xai-test" }, // pragma: allowlist secret
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+      onToolCall,
+    });
+    const { connecting, socket } = await openRealtimeBridge(bridge);
+    await connecting;
+
+    for (const rawArgs of ['{"city":', JSON.stringify({ city: "Paris" })]) {
+      socket.emit(
+        "message",
+        Buffer.from(
+          JSON.stringify({
+            type: "response.function_call_arguments.done",
+            item_id: "item_corrected",
+            call_id: "call_corrected",
+            name: "lookup_weather",
+            arguments: rawArgs,
+          }),
+        ),
+      );
+    }
+
+    expect(onToolCall).toHaveBeenCalledTimes(1);
+    expect(onToolCall).toHaveBeenCalledWith({
+      itemId: "item_corrected",
+      callId: "call_corrected",
+      name: "lookup_weather",
+      args: { city: "Paris" },
+    });
+    bridge.close();
+  });
+
   it("waits for all parallel tool results before sending response.create", async () => {
     vi.stubEnv("XAI_API_KEY", "xai-env"); // pragma: allowlist secret
     const provider = buildXaiRealtimeVoiceProvider();

--- a/extensions/xai/xai.live.test.ts
+++ b/extensions/xai/xai.live.test.ts
@@ -714,6 +714,68 @@ describeLive("xai plugin live", () => {
     }
   }, 240_000);
 
+  it("runs realtime voice tool calls with valid object arguments and continuation", async () => {
+    const realtimeProvider = registerXaiRealtimeVoiceProvider();
+    const marker = "OPENCLAW_XAI_TOOL_ARGS_OK";
+    const finalAssistantTranscripts: string[] = [];
+    const toolCalls: Array<{ callId: string; name: string; args: unknown }> = [];
+    const errors: Error[] = [];
+    const bridge: RealtimeVoiceBridge = realtimeProvider.createBridge({
+      cfg: createLiveConfig(),
+      providerConfig: {
+        apiKey: XAI_API_KEY,
+        baseUrl: "https://api.x.ai/v1",
+        model: "grok-voice-latest",
+        voice: "eve",
+      },
+      audioFormat: REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ,
+      instructions:
+        "When asked, call openclaw_live_probe with the exact token. After the tool result, say its marker exactly.",
+      tools: [
+        {
+          type: "function",
+          name: "openclaw_live_probe",
+          description: "Return the live validation marker.",
+          parameters: {
+            type: "object",
+            properties: { token: { type: "string" } },
+            required: ["token"],
+          },
+        },
+      ],
+      onAudio: () => {},
+      onClearAudio: () => {},
+      onMark: (markName) => bridge.acknowledgeMark(markName),
+      onTranscript: (role, text, isFinal) => {
+        if (role === "assistant" && isFinal) {
+          finalAssistantTranscripts.push(text);
+        }
+      },
+      onToolCall: (event) => toolCalls.push(event),
+      onError: (error) => errors.push(error),
+    });
+
+    try {
+      await bridge.connect();
+      bridge.sendUserMessage?.("Call openclaw_live_probe now with token bluebird.");
+      await waitForXaiLive("valid object tool arguments", () => toolCalls.length > 0);
+      expect(toolCalls[0]).toEqual({
+        callId: expect.any(String),
+        itemId: expect.any(String),
+        name: "openclaw_live_probe",
+        args: { token: "bluebird" },
+      });
+
+      await bridge.submitToolResult(toolCalls[0]?.callId ?? "", { marker });
+      await waitForXaiLive("tool result continuation", () =>
+        finalAssistantTranscripts.some((text) => text.includes(marker)),
+      );
+      expect(errors).toStrictEqual([]);
+    } finally {
+      bridge.close();
+    }
+  }, 120_000);
+
   it("generates and edits images through the registered image provider", async () => {
     await runXaiLiveCase("image", async () => {
       const { imageProviders } = await registerXaiPlugin();


### PR DESCRIPTION
## What Problem This Solves

xAI realtime voice could dispatch a tool call with `{}` when its argument JSON was malformed. It also accepted valid JSON values that were not objects, and marked rejected calls as delivered and pending before validation.

## Why This Change Was Made

- Parse and validate tool arguments before mutating delivery or pending-call state.
- Reject malformed JSON and non-object JSON without invoking the tool.
- Emit a sanitized `tool_call.arguments.rejected` lifecycle fact with the rejection class.
- Preserve the existing `{}` behavior for explicitly empty or missing argument payloads.

The fix stays inside the xAI realtime protocol owner. It does not add configuration, provider, or environment-variable surface.

## User Impact

Malformed or structurally invalid xAI tool arguments no longer execute a tool with invented empty arguments or leave a phantom pending call. Rejection is the terminal outcome for that call identifier, so duplicate or corrected late events cannot dispatch it after xAI has received the rejection output. The active response and later user turns can still continue.

## Evidence

- `node scripts/run-vitest.mjs extensions/xai/realtime-voice-lifecycle.test.ts extensions/xai/realtime-voice-provider.test.ts`
  - 61 tests passed.
- Focused regression coverage includes malformed JSON, `null`, arrays, strings, numbers, booleans, replayed ingress, active-response continuation, duplicate/corrected same-ID terminal precedence, and explicitly empty arguments.
- Inspectable exact-head invalid-path terminal proof:

```text
$ node scripts/run-vitest.mjs extensions/xai/realtime-voice-provider.test.ts -- --reporter=verbose -t 'rejects malformed and non-object tool arguments|treats rejected tool call arguments as terminal'
✓ rejects malformed and non-object tool arguments from completed arguments without retaining pending state
✓ rejects malformed and non-object tool arguments from resumed item replay without retaining pending state
✓ treats rejected tool call arguments as terminal for the same identity
Test Files  1 passed (1)
Tests       3 passed | 53 skipped (56)
```

- `git diff --check`
- P1 structured autoreview on exact head `eb45b87699eec8f2dc3cb1ed4665a8b491fb026f`: clean.
- Exact-head CI passed after retrying the lint job.
  - The first `check-lint` attempt was canceled by the runner after `oxlint` received exit 143; no lint finding was emitted.
  - The retry completed successfully: https://github.com/openclaw/openclaw/actions/runs/30702166433/job/91376253135
- Focused xAI live provider workflow before the terminal-output follow-up: passed.
  - https://github.com/openclaw/openclaw/actions/runs/30701084575/job/91372351724
- Focused xAI live provider rerun on exact head `eb45b87699eec8f2dc3cb1ed4665a8b491fb026f`: passed.
  - https://github.com/openclaw/openclaw/actions/runs/30702171059/job/91375213824

The real provider cannot be instructed deterministically to emit malformed function-call JSON. The focused protocol regression therefore owns invalid-argument rejection and active-response continuation proof; the live lane proves that the same exact head still completes a real valid-object xAI tool call and subsequent response.

Related: #116201
