### PR TITLE
fix(gateway): return 400 for invalid attachment id and malformed url encoding instead of 404

### DIFF
--- a/src/gateway/managed-image-attachments.ts
+++ b/src/gateway/managed-image-attachments.ts
@@ -1071,14 +1071,14 @@ export async function handleManagedOutgoingImageHttpRequest(
     return false;
   }
   if (!MANAGED_OUTGOING_ATTACHMENT_ID_RE.test(attachmentId)) {
-    sendStatus(res, 404, "not found");
+    sendStatus(res, 400, "invalid attachment id");
     return true;
   }
   let sessionKey: string;
   try {
     sessionKey = decodeURIComponent(encodedSessionKey);
   } catch {
-    sendStatus(res, 404, "not found");
+    sendStatus(res, 400, "malformed url encoding");
     return true;
   }
   const record = readManagedImageRecord(attachmentId, opts.stateDir);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where invalid attachment IDs that don't match the UUID format pattern and malformed percent-encoding in the URL both returned HTTP 404 "not found". These are client input errors (the ID is syntactically invalid, or the URL encoding is malformed), not missing resources. A client receiving 404 may retry the same malformed URL indefinitely.

## Why This Change Was Made

Return 400 Bad Request with descriptive error messages ("invalid attachment id" and "malformed url encoding") for these two validation failures, while keeping 404 for the actual "resource not found" case where the attachment record doesn't exist or doesn't match the session key. This follows HTTP semantics: 400 signals the request itself is invalid, 404 signals the referenced resource does not exist.

## User Impact

Clients now receive clear 400 responses for malformed requests, enabling them to identify and fix the issue rather than endlessly retrying the same invalid URL.

## Evidence

The remaining 404 case at line 1085 (record not found or session key mismatch) is correctly a "not found" condition and is unchanged.
