### PR TITLE
fix(infra): use UTF-8 byte budget for APNs alert body truncation

### DIFF
--- a/src/infra/push-apns-payloads.ts
+++ b/src/infra/push-apns-payloads.ts
@@ -1,9 +1,14 @@
 // Builds portable APNs payloads for alerts, wakes, and approval lifecycle events.
+import { Buffer } from "node:buffer";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { truncateUtf8Prefix } from "../utils/utf8-truncate.js";
 
 const EXEC_APPROVAL_GENERIC_ALERT_BODY = "Open OpenClaw to review this request.";
-const PLUGIN_APPROVAL_ALERT_BODY_MAX_LENGTH = 256;
+// APNs alert body budget in UTF-8 bytes, not UTF-16 code units. The overall
+// push payload must stay under 4KB, and the alert body is one of the larger
+// fields. Using code units (body.length) overcounts for strings containing
+// emoji or CJK characters, where each 2-unit surrogate pair is 4 UTF-8 bytes.
+const PLUGIN_APPROVAL_ALERT_BODY_MAX_BYTES = 256;
 
 function toPushMetadata(params: {
   kind: "push.test" | "node.wake";
@@ -87,10 +92,10 @@ export function createApnsApprovalAlertPayload(params: {
 
 export function resolvePluginApprovalAlertBody(description: string): string {
   const body = normalizeOptionalString(description) ?? "";
-  if (body.length <= PLUGIN_APPROVAL_ALERT_BODY_MAX_LENGTH) {
+  if (Buffer.byteLength(body, "utf8") <= PLUGIN_APPROVAL_ALERT_BODY_MAX_BYTES) {
     return body;
   }
-  return `${truncateUtf16Safe(body, PLUGIN_APPROVAL_ALERT_BODY_MAX_LENGTH - 1).trimEnd()}…`;
+  return `${truncateUtf8Prefix(body, PLUGIN_APPROVAL_ALERT_BODY_MAX_BYTES - 3).trimEnd()}…`;
 }
 
 export function createApnsApprovalResolvedPayload(params: {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where APNs push notification alert body truncation uses UTF-16 code unit count (body.length) as the budget, but APNs enforces byte-level payload limits. A string with 256 code units containing emoji (each emoji = 2 UTF-16 code units but 4 UTF-8 bytes) produces 512+ UTF-8 bytes, exceeding the APNs push payload budget. truncateUtf16Safe prevented surrogate pair splitting but the budget itself was in code units, not bytes.

## Why This Change Was Made

Replace body.length with Buffer.byteLength(body, "utf8") for the budget check, and truncateUtf16Safe with truncateUtf8Prefix for the truncation operation. Reserve 3 bytes (UTF-8 ellipsis) in the truncated result instead of 1 code unit. This ensures the alert body stays within the byte budget regardless of character encoding.

## User Impact

Push notification alert bodies containing emoji or CJK characters no longer exceed the APNs byte budget. Previously, such strings could silently overflow and be rejected by Apple's push service.

## Evidence

The truncateUtf8Prefix utility in src/utils/utf8-truncate.ts is an existing shared helper that correctly handles UTF-8 byte boundaries, preserving multi-byte character integrity.
