### PR TITLE
fix(discord): raise checkbox maxValues ceiling from 10 to 25 to match Discord API limit

### DIFF
--- a/extensions/discord/src/components.parse.ts
+++ b/extensions/discord/src/components.parse.ts
@@ -264,7 +264,7 @@ function parseModalField(raw: unknown, label: string, index: number): DiscordMod
     throw new Error(`${label}.minValues/maxValues are not supported for radio fields`);
   }
   const required = typeof obj.required === "boolean" ? obj.required : undefined;
-  const maxValues = type === "checkbox" ? 10 : 25;
+  const maxValues = 25;
   return {
     type,
     name: normalizeModalFieldName(readOptionalString(obj.name), index),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Discord checkbox (multi-select) fields are capped at maxValues=10, but Discord's String Select Menu component API allows max_values up to 25 for all select types. Both "checkbox" and "select" map to the same Discord select component, yet checkbox was artificially limited to 10 while select was allowed 25. Valid Discord components with 11-25 selectable checkbox options were incorrectly rejected.

## Why This Change Was Made

Remove the conditional branch that assigned different maxValues ceilings per type. Both checkbox and select use the same Discord String Select Menu API with max_values up to 25, so a single constant of 25 is correct for all types. Radio fields are already separately validated to reject minValues/maxValues entirely.

## User Impact

Discord modal fields of type "checkbox" can now correctly specify maxValues up to 25, matching the Discord API limit. Previously, valid configurations with 11+ selectable options were rejected.

## Evidence

Discord API documentation for String Select Menu components confirms max_values can be set up to 25 (matching the max_options limit of 25). Radio fields continue to reject minValues/maxValues at line 263-264.
