### PR TITLE
fix(xai): reject invalid UTF-8 OAuth responses

### DIFF
--- a/extensions/xai/xai-oauth.test.ts
+++ b/extensions/xai/xai-oauth.test.ts
@@ -24,6 +24,19 @@ function jsonResponse(value: unknown, init?: ResponseInit): Response {
   });
 }
 
+function invalidUtf8JsonResponse(prefix: string, suffix: string): Response {
+  const prefixBytes = new TextEncoder().encode(prefix);
+  const suffixBytes = new TextEncoder().encode(suffix);
+  const body = new Uint8Array(prefixBytes.length + 1 + suffixBytes.length);
+  body.set(prefixBytes);
+  body[prefixBytes.length] = 0xff;
+  body.set(suffixBytes, prefixBytes.length + 1);
+  return new Response(body, {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
 function createJwt(payload: Record<string, unknown>): string {
   const header = Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" })).toString("base64url");
   const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
@@ -502,6 +515,59 @@ describe("xAI OAuth", () => {
     });
     expect(progress.update).toHaveBeenCalledWith("Waiting for xAI device authorization...");
     expect(progress.stop).toHaveBeenCalledWith("xAI OAuth complete");
+  });
+
+  it("rejects invalid UTF-8 in xAI device-code token responses", async () => {
+    const progress = {
+      update: vi.fn(),
+      stop: vi.fn(),
+    };
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        jsonResponse({
+          authorization_endpoint: "https://auth.x.ai/oauth2/authorize",
+          device_authorization_endpoint: "https://auth.x.ai/oauth2/device/code",
+          token_endpoint: "https://auth.x.ai/oauth2/token",
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          device_code: "device-code-1",
+          user_code: "ABCD-1234",
+          verification_uri: "https://accounts.x.ai/oauth2/device",
+          expires_in: 900,
+          interval: 5,
+        }),
+      )
+      .mockResolvedValueOnce(
+        invalidUtf8JsonResponse(
+          '{"access_token":"test-access-token-',
+          '","refresh_token":"test-refresh-token","expires_in":120}',
+        ),
+      );
+    vi.stubGlobal("fetch", fetchImpl);
+    const ctx: ProviderAuthContext = {
+      config: {},
+      isRemote: true,
+      openUrl: vi.fn(async () => {}),
+      prompter: createTestWizardPrompter({
+        progress: vi.fn(() => progress),
+        deviceCode: vi.fn(async () => {}),
+      }),
+      runtime: createRuntimeEnv(),
+      oauth: {
+        createVpsAwareHandlers: () => {
+          throw new Error("unexpected VPS OAuth handler request");
+        },
+      },
+    };
+
+    await expect(createXaiOAuthAuthMethod().run(ctx)).rejects.toThrow(
+      "xAI OAuth token response is missing access_token",
+    );
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+    expect(progress.stop).toHaveBeenCalledWith("xAI OAuth failed");
   });
 
   it("falls back for unsafe xAI device-code lifetime fields", async () => {

--- a/extensions/xai/xai-oauth.ts
+++ b/extensions/xai/xai-oauth.ts
@@ -459,7 +459,7 @@ async function pollXaiDeviceCodeToken(
         onOverflow: ({ maxBytes }) =>
           new Error(`xAI device code response exceeds ${maxBytes} bytes`),
       });
-      body = JSON.parse(new TextDecoder().decode(buffer));
+      body = JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(buffer));
     } catch {
       body = null;
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes xAI device-code login saving corrupted OAuth credentials when the token endpoint returns malformed UTF-8 inside otherwise valid JSON.

## User Impact

Invalid token responses fail during sign-in instead of saving credentials that later fail API requests. Valid Unicode credentials continue to work; no configuration changes are required.

## Why This Change Was Made

Decode the bounded device-token response strictly before parsing JSON, while retaining the guarded transport, response release, cancellation, and polling behavior. Discovery and refresh decoding are unchanged. This changes input validation only: the stored credential schema and existing profiles are unchanged, so no data migration is needed.

## Evidence

- 112 current-source OAuth, registration, entry-point, and real-persistence tests pass; scoped production/test type checks, formatting, and diff checks pass.
- Malformed-byte regressions fail against the original decoder; valid split-multibyte controls pass.
- Both registered auth choices pass loopback HTTP-to-real-isolated-storage checks: malformed responses write nothing and preserve an unrelated credential; valid multilingual tokens persist.
- Independent review found no actionable P0–P2 issues. [Exact-head hosted lint and CI passed](https://github.com/openclaw/openclaw/actions/runs/35409239376). Fresh ClawSweeper review also found no actionable issues.
- Live xAI sign-in was not run. No production credential store was used.

Original fix and reproduction by @ZengWen-DT; updated to preserve the current guarded transport and broaden regression coverage.
