### PR TITLE
fix(infra): reject on timeout in provider-usage withTimeout instead of resolving to fallback

### DIFF
--- a/src/infra/provider-usage.load.ts
+++ b/src/infra/provider-usage.load.ts
@@ -153,13 +153,6 @@ export async function loadProviderUsageSummary(
         fetchFn,
       }),
       timeoutMs + 1000,
-      {
-        provider: auth.provider,
-        displayName:
-          displayNames.get(auth.provider) ?? resolveProviderUsageDisplayName(auth.provider),
-        windows: [],
-        error: "Timeout",
-      },
     ).catch((error: unknown) => {
       const message = error instanceof Error ? error.message : String(error);
       return failureSnapshot(message.trim() || "Fetch failed");

--- a/src/infra/provider-usage.shared.test.ts
+++ b/src/infra/provider-usage.shared.test.ts
@@ -1,7 +1,12 @@
 // Covers shared provider usage helpers.
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { MAX_TIMER_TIMEOUT_MS } from "../shared/number-coercion.js";
-import { clampPercent, resolveUsageProviderId, withTimeout } from "./provider-usage.shared.js";
+import {
+  UsageTimeoutError,
+  clampPercent,
+  resolveUsageProviderId,
+  withTimeout,
+} from "./provider-usage.shared.js";
 
 describe("provider-usage.shared", () => {
   afterEach(() => {
@@ -57,38 +62,38 @@ describe("provider-usage.shared", () => {
     },
   ])("$name", async ({ promise, expected, error }) => {
     if (error) {
-      await expect(withTimeout(promise(), 100, "fallback")).rejects.toThrow(error);
+      await expect(withTimeout(promise(), 100)).rejects.toThrow(error);
       return;
     }
-    await expect(withTimeout(promise(), 100, "fallback")).resolves.toBe(expected);
+    await expect(withTimeout(promise(), 100)).resolves.toBe(expected);
   });
 
-  it("returns fallback when timeout wins", async () => {
+  it("rejects with UsageTimeoutError when timeout wins", async () => {
     vi.useFakeTimers();
     const late = new Promise<string>((resolve) => {
       setTimeout(() => resolve("late"), 50);
     });
-    const result = withTimeout(late, 1, "fallback");
+    const result = withTimeout(late, 1);
     await vi.advanceTimersByTimeAsync(1);
-    await expect(result).resolves.toBe("fallback");
+    await expect(result).rejects.toThrow(UsageTimeoutError);
   });
 
   it("clamps oversized timeout delays before scheduling", async () => {
     vi.useFakeTimers();
     const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
 
-    const result = withTimeout(new Promise<string>(() => {}), Number.MAX_SAFE_INTEGER, "fallback");
+    const result = withTimeout(new Promise<string>(() => {}), Number.MAX_SAFE_INTEGER);
 
     expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
 
     await vi.advanceTimersByTimeAsync(MAX_TIMER_TIMEOUT_MS);
-    await expect(result).resolves.toBe("fallback");
+    await expect(result).rejects.toThrow(UsageTimeoutError);
   });
 
   it("clears the timeout after successful work", async () => {
     const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
 
-    await expect(withTimeout(Promise.resolve("ok"), 100, "fallback")).resolves.toBe("ok");
+    await expect(withTimeout(Promise.resolve("ok"), 100)).resolves.toBe("ok");
 
     expect(clearTimeoutSpy).toHaveBeenCalledTimes(1);
   });

--- a/src/infra/provider-usage.shared.ts
+++ b/src/infra/provider-usage.shared.ts
@@ -81,15 +81,22 @@ export const ignoredErrors = new Set([
 export const clampPercent = (value: number) =>
   Math.max(0, Math.min(100, Number.isFinite(value) ? value : 0));
 
-/** Resolves a promise with a fallback when usage collection exceeds the timeout. */
-export const withTimeout = async <T>(work: Promise<T>, ms: number, fallback: T): Promise<T> => {
+export class UsageTimeoutError extends Error {
+  constructor() {
+    super("Usage collection timed out");
+    this.name = "UsageTimeoutError";
+  }
+}
+
+/** Rejects on timeout so callers can distinguish timed-out data from real results. */
+export const withTimeout = async <T>(work: Promise<T>, ms: number): Promise<T> => {
   let timeout: NodeJS.Timeout | undefined;
   const timeoutMs = resolveTimerTimeoutMs(ms, 1);
   try {
     return await Promise.race([
       work,
-      new Promise<T>((resolve) => {
-        timeout = setTimeout(() => resolve(fallback), timeoutMs);
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(() => reject(new UsageTimeoutError()), timeoutMs);
       }),
     ]);
   } finally {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where provider-usage `withTimeout` resolved to a fallback value (e.g. `{input: 0, output: 0}`) on timeout, making it impossible for callers to distinguish real zero-usage data from timed-out collection that fell back to zeroes. This silently corrupted billing/observability data since the fallback looked identical to legitimate zero-usage results.

## Why This Change Was Made

Replace the fallback parameter with a named `UsageTimeoutError` rejection. The only caller (provider-usage.load.ts) already had a `.catch()` handler that converts rejections into failure snapshots, so the functional result is preserved — the difference is that timeout failures are now explicit rather than disguised as valid data. The `withTimeout` signature changed from `(work, ms, fallback)` to `(work, ms)` and returns `Promise<T>` instead of `Promise<T>`.

## User Impact

Provider usage collection timeouts are now visible as explicit errors in observability/billing data rather than silently appearing as zero-usage. Operators can distinguish "this provider reported zero usage" from "this provider's usage endpoint timed out".

## Evidence

The existing `.catch()` handler in provider-usage.load.ts already converts any rejection into a failure snapshot with the error message, so the end-user data shape is preserved. Tests updated to expect `UsageTimeoutError` rejection on timeout.
