### PR TITLE
chore: sync yuanbao plugin catalog to 2.17.0

### DIFF
--- a/scripts/lib/official-external-channel-catalog.json
+++ b/scripts/lib/official-external-channel-catalog.json
@@ -76,9 +76,9 @@
           }
         },
         "install": {
-          "npmSpec": "openclaw-plugin-yuanbao@2.15.0",
+          "npmSpec": "openclaw-plugin-yuanbao@2.17.0",
           "defaultChoice": "npm",
-          "expectedIntegrity": "sha512-3GD+mf3EjTSUTOAREjTHAyp/deXdpgqB+q+xE0b19Qtat4ADhUV1mHDwFkVCRqTCBY5ATFKtKcipoDejqFj/+w=="
+          "expectedIntegrity": "sha512-3MLXEQSH2997TJFrcUAO5DAadvWB300RGXg14i0yfX36m1QuR9QPV41ko3icSCe4r/vcOUq1g5Rvriyt+UE3SQ=="
         }
       }
     },

--- a/src/channels/plugins/catalog.test.ts
+++ b/src/channels/plugins/catalog.test.ts
@@ -33,7 +33,7 @@ describe("channel plugin catalog", () => {
     expect(yuanbao?.id).toBe("yuanbao");
     expect(yuanbao?.pluginId).toBe("openclaw-plugin-yuanbao");
     expect(yuanbao?.trustedSourceLinkedOfficialInstall).toBe(true);
-    expect(yuanbao?.install?.npmSpec).toBe("openclaw-plugin-yuanbao@2.15.0");
+    expect(yuanbao?.install?.npmSpec).toBe("openclaw-plugin-yuanbao@2.17.0");
   });
 
   it("excludes only the rejected origin/plugin pair when resolving fallback copies", () => {

--- a/src/channels/plugins/contracts/channel-catalog.contract.test.ts
+++ b/src/channels/plugins/contracts/channel-catalog.contract.test.ts
@@ -46,7 +46,7 @@ describeChannelCatalogEntryContract({
 
 describeChannelCatalogEntryContract({
   channelId: "yuanbao",
-  npmSpec: "openclaw-plugin-yuanbao@2.15.0",
+  npmSpec: "openclaw-plugin-yuanbao@2.17.0",
   alias: "yb",
 });
 

--- a/src/config/config.plugin-validation.test.ts
+++ b/src/config/config.plugin-validation.test.ts
@@ -1268,7 +1268,7 @@ describe("config plugin validation", () => {
 
     expect(res.ok).toBe(true);
     const message =
-      "plugin not installed: yuanbao — install the official external plugin with: openclaw plugins install openclaw-plugin-yuanbao@2.15.0";
+      "plugin not installed: yuanbao — install the official external plugin with: openclaw plugins install openclaw-plugin-yuanbao@2.17.0";
     expectPathMessage(res.warnings, "plugins.entries.yuanbao", message);
     expect((res.warnings ?? []).filter((warning) => warning.message === message)).toHaveLength(1);
   });

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -1223,7 +1223,7 @@ describe("official external plugin catalog", () => {
     );
     expect(resolveOfficialExternalPluginId(yuanbaoByChannel)).toBe("openclaw-plugin-yuanbao");
     expect(resolveOfficialExternalPluginInstall(yuanbaoByChannel)?.npmSpec).toBe(
-      "openclaw-plugin-yuanbao@2.15.0",
+      "openclaw-plugin-yuanbao@2.17.0",
     );
   });
 

--- a/test/official-channel-catalog.test.ts
+++ b/test/official-channel-catalog.test.ts
@@ -171,10 +171,10 @@ describe("buildOfficialChannelCatalog", () => {
         aliases: ["yuanbao", "yb", "tencent-yuanbao", "元宝"],
       },
       install: {
-        npmSpec: "openclaw-plugin-yuanbao@2.15.0",
+        npmSpec: "openclaw-plugin-yuanbao@2.17.0",
         defaultChoice: "npm",
         expectedIntegrity:
-          "sha512-3GD+mf3EjTSUTOAREjTHAyp/deXdpgqB+q+xE0b19Qtat4ADhUV1mHDwFkVCRqTCBY5ATFKtKcipoDejqFj/+w==",
+          "sha512-3MLXEQSH2997TJFrcUAO5DAadvWB300RGXg14i0yfX36m1QuR9QPV41ko3icSCe4r/vcOUq1g5Rvriyt+UE3SQ==",
       },
     });
     expect(


### PR DESCRIPTION
## Summary

Sync the Yuanbao official external channel catalog pin to `openclaw-plugin-yuanbao@2.17.0`, with the matching `expectedIntegrity` updated to the 2.17.0 npm registry value.

- Keep the catalog the single source of truth for trusted official Yuanbao install/update resolution; this is a routine upstream package-pin sync, not a behavior/code change.
- Update the five catalog tests that hard-code the pinned spec/integrity so they assert the new 2.17.0 values.
- Intentionally out of scope: no workflow, lockfile, secret-handling, or runtime code changes.
- Success: a real OpenClaw install path resolves Yuanbao to `openclaw-plugin-yuanbao@2.17.0` and the catalog integrity check passes.
- Reviewers should focus on the single changed install pin (`scripts/lib/official-external-channel-catalog.json`) and confirm the integrity matches the npm registry value for 2.17.0.

## Linked context

Routine upstream package-pin sync for the Tencent Yuanbao channel plugin. No issue/maintainer request is linked; this tracks the published `openclaw-plugin-yuanbao@2.17.0` release on npm.

## What Problem This Solves

The official catalog pinned Yuanbao to a prior version; npm now publishes 2.17.0, so trusted official install/update should resolve to 2.17.0. Without this sync, a fresh install through the official catalog would either pin to an outdated version or fail the `expectedIntegrity` drift check when the registry serves 2.17.0.

## Evidence

Real environment tested: GitHub Actions runner (ubuntu-latest), Node 22, OpenClaw built from this PR head.

Exact steps run by the workflow after this patch:
- `npm view openclaw-plugin-yuanbao@2.17.0 dist.integrity` → resolved the integrity used in the catalog pin.
- The five catalog tests that assert the pinned spec/integrity were updated to 2.17.0 and will be exercised by upstream CI.

Observed result after fix: the catalog `expectedIntegrity` for Yuanbao now equals the npm registry integrity for 2.17.0, so the trusted official install path will resolve 2.17.0 without an integrity-drift abort.

What was not tested: live end-to-end Yuanbao channel messaging (out of scope for a catalog pin); only install/resolution behavior is validated by the catalog tests.

## Tests and validation

Commands run: `npm view openclaw-plugin-yuanbao@2.17.0 dist.integrity` (integrity captured by the workflow's "Wait for npm registry and get integrity" step). The five updated catalog tests assert the new 2.17.0 spec/integrity. Nothing failed before in a behavioral sense; this is a forward version sync, and the tests were updated to track the new pin.

## Risk checklist

- Did user-visible behavior change? No (install resolves to a newer published version).
- Did config, environment, or migration behavior change? No.
- Did security, auth, secrets, network, or tool execution behavior change? No.
- Highest-risk area: the trusted official install pin can affect fresh installs and trusted-source update/sync.
- How is that risk mitigated: `expectedIntegrity` was updated to the npm registry integrity for 2.17.0, captured directly from `npm view` in CI.

## Current review state

Automated catalog sync PR generated by the `Sync OpenClaw Catalog` workflow. No human review action expected beyond confirming the integrity matches the npm registry value for 2.17.0.