### PR TITLE
feat(ui): nudge stale tabs to refresh after gateway upgrade

### DIFF
--- a/scripts/control-ui-mock-dev.ts
+++ b/scripts/control-ui-mock-dev.ts
@@ -26,6 +26,7 @@ type CliOptions = {
   fixture?: "board";
   host: string;
   port: number;
+  staleBundle: boolean;
 };
 
 type SessionListOptions = {
@@ -74,7 +75,12 @@ function mockFileHash(value: string): string {
 }
 
 function parseArgs(args: string[]): CliOptions {
-  const options: CliOptions = { allowedHosts: [], host: "127.0.0.1", port: 5187 };
+  const options: CliOptions = {
+    allowedHosts: [],
+    host: "127.0.0.1",
+    port: 5187,
+    staleBundle: false,
+  };
   for (let i = 0; i < args.length; i += 1) {
     const arg = expectDefined(args[i], `control UI mock argument at index ${i}`);
     if (arg === "--allowed-host") {
@@ -99,6 +105,8 @@ function parseArgs(args: string[]): CliOptions {
       options.port = parsePort(args[++i], options.port);
     } else if (arg.startsWith("--port=")) {
       options.port = parsePort(arg.slice("--port=".length), options.port);
+    } else if (arg === "--stale-bundle") {
+      options.staleBundle = true;
     }
   }
   return options;
@@ -1625,7 +1633,10 @@ async function waitForShutdown(): Promise<void> {
 }
 
 const options = parseArgs(process.argv.slice(2));
-const scenario = await createChatPickerScenario();
+const scenario = {
+  ...(await createChatPickerScenario()),
+  serverVersion: options.staleBundle ? "2026.7.11" : "2026.7.10",
+};
 const server = await createServer({
   base: "/",
   cacheDir: path.join(repoRoot, ".artifacts", "control-ui-mock-vite"),

--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -106,10 +106,10 @@ import {
   prepareStaleBundleAutoReload,
   prepareStaleBundleManualReload,
   readGatewayVersionFromSnapshot,
-  resolveStaleBundleGatewayVersion,
   resolveStaleBundleReloadPair,
   StaleBundleReloadController,
   type StaleBundleReloadTarget,
+  type StaleBundleVersionPair,
 } from "./stale-bundle.ts";
 
 type ShellRouteState = {
@@ -1248,18 +1248,22 @@ class OpenClawShell extends OpenClawLightDomElement {
   }
 
   private synchronizeGateway(snapshot: ApplicationContext["gateway"]["snapshot"]) {
-    const gatewayVersion = readGatewayVersionFromSnapshot(snapshot.hello?.snapshot);
-    this.staleBundleReload.update(
-      snapshot.connected
-        ? resolveStaleBundleReloadPair({
-            gatewayUrl: this.context?.gateway.connection.gatewayUrl ?? "",
-            gatewayVersion,
-          })
-        : null,
-    );
+    this.staleBundleReload.update(this.resolveActionableStaleBundlePair(snapshot));
     this.updateGatewaySessionKey(snapshot);
     this.ensureAgentsList(snapshot);
     this.ensureRuntimeConfig(snapshot);
+  }
+
+  private resolveActionableStaleBundlePair(
+    snapshot: ApplicationContext["gateway"]["snapshot"],
+  ): StaleBundleVersionPair | null {
+    if (!snapshot.connected) {
+      return null;
+    }
+    return resolveStaleBundleReloadPair({
+      gatewayUrl: this.context?.gateway.connection.gatewayUrl ?? "",
+      gatewayVersion: readGatewayVersionFromSnapshot(snapshot.hello?.snapshot),
+    });
   }
 
   private prepareForStaleBundleReload(): boolean {
@@ -1412,9 +1416,8 @@ class OpenClawShell extends OpenClawLightDomElement {
       return nothing;
     }
     const gatewaySnapshot = context.gateway.snapshot;
-    const staleBundleGatewayVersion = resolveStaleBundleGatewayVersion(
-      readGatewayVersionFromSnapshot(gatewaySnapshot.hello?.snapshot),
-    );
+    const staleBundleGatewayVersion =
+      this.resolveActionableStaleBundlePair(gatewaySnapshot)?.gatewayVersion ?? null;
     const navigationSnapshot = context.navigation.snapshot;
     const overlaySnapshot = context.overlays.snapshot;
     const terminalAvailable = isTerminalAvailable(

--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -103,9 +103,13 @@ import {
   setSettingsChangeListener,
 } from "./settings.ts";
 import {
+  prepareStaleBundleAutoReload,
+  prepareStaleBundleManualReload,
   readGatewayVersionFromSnapshot,
   resolveStaleBundleGatewayVersion,
+  resolveStaleBundleReloadPair,
   StaleBundleReloadController,
+  type StaleBundleReloadTarget,
 } from "./stale-bundle.ts";
 
 type ShellRouteState = {
@@ -117,9 +121,7 @@ type ShellRouteState = {
 type AppSidebarElement = HTMLElement & {
   dismissTransientMenus: () => boolean;
 };
-type ReloadableChatPaneElement = HTMLElement & {
-  prepareForStaleBundleReload?: () => boolean;
-};
+type ReloadableChatPaneElement = HTMLElement & Partial<StaleBundleReloadTarget>;
 
 // Stable references so the sidebar's enabledRouteIds property does not churn
 // on every shell render.
@@ -1246,9 +1248,13 @@ class OpenClawShell extends OpenClawLightDomElement {
   }
 
   private synchronizeGateway(snapshot: ApplicationContext["gateway"]["snapshot"]) {
+    const gatewayVersion = readGatewayVersionFromSnapshot(snapshot.hello?.snapshot);
     this.staleBundleReload.update(
       snapshot.connected
-        ? resolveStaleBundleGatewayVersion(readGatewayVersionFromSnapshot(snapshot.hello?.snapshot))
+        ? resolveStaleBundleReloadPair({
+            gatewayUrl: this.context?.gateway.connection.gatewayUrl ?? "",
+            gatewayVersion,
+          })
         : null,
     );
     this.updateGatewaySessionKey(snapshot);
@@ -1257,10 +1263,24 @@ class OpenClawShell extends OpenClawLightDomElement {
   }
 
   private prepareForStaleBundleReload(): boolean {
-    return [...this.querySelectorAll<ReloadableChatPaneElement>("openclaw-chat-pane")].every(
-      (pane) => pane.prepareForStaleBundleReload?.() ?? true,
+    return prepareStaleBundleAutoReload(this.staleBundleReloadTargets());
+  }
+
+  private staleBundleReloadTargets(): StaleBundleReloadTarget[] {
+    return [...this.querySelectorAll<ReloadableChatPaneElement>("openclaw-chat-pane")].filter(
+      (pane): pane is ReloadableChatPaneElement & StaleBundleReloadTarget =>
+        typeof pane.prepareForStaleBundleReload === "function",
     );
   }
+
+  private readonly refreshStaleBundle = () => {
+    const prepared = prepareStaleBundleManualReload(this.staleBundleReloadTargets(), () =>
+      window.confirm(t("chat.sidebar.discardAttachmentsForRefresh")),
+    );
+    if (prepared) {
+      window.location.reload();
+    }
+  };
 
   private ensureRuntimeConfig(
     snapshot: {
@@ -1560,6 +1580,7 @@ class OpenClawShell extends OpenClawLightDomElement {
                 gatewaySnapshot.hello?.server?.version ??
                 null}
                 .staleBundleGatewayVersion=${staleBundleGatewayVersion}
+                .onRefreshStaleBundle=${this.refreshStaleBundle}
                 .devGitBranch=${context.config.current.devGitBranch}
                 .updateAvailable=${navigationSurfaceHidden ? null : overlaySnapshot.updateAvailable}
                 .updateRunning=${overlaySnapshot.updateRunning}

--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -103,12 +103,11 @@ import {
   setSettingsChangeListener,
 } from "./settings.ts";
 import {
-  prepareStaleBundleAutoReload,
-  prepareStaleBundleManualReload,
+  prepareComposerForIdleReload,
   readGatewayVersionFromSnapshot,
+  reloadWithComposerGuard,
   resolveStaleBundleReloadPair,
   StaleBundleReloadController,
-  type StaleBundleReloadTarget,
   type StaleBundleVersionPair,
 } from "./stale-bundle.ts";
 
@@ -121,12 +120,14 @@ type ShellRouteState = {
 type AppSidebarElement = HTMLElement & {
   dismissTransientMenus: () => boolean;
 };
-type ReloadableChatPaneElement = HTMLElement & Partial<StaleBundleReloadTarget>;
 
 // Stable references so the sidebar's enabledRouteIds property does not churn
 // on every shell render.
 const ROUTE_IDS_WITHOUT_WORKBOARD = APP_ROUTE_IDS.filter((routeId) => routeId !== "workboard");
 const AGENT_ROSTER_REFRESH_DEBOUNCE_MS = 100;
+const reloadControlUiWithComposerGuard = () => {
+  reloadWithComposerGuard();
+};
 
 function diffAgentRoster(
   previous: readonly GatewayAgentRow[],
@@ -514,7 +515,7 @@ class OpenClawShell extends OpenClawLightDomElement {
   >();
   private readonly subscriptions = new SubscriptionsController(this);
   private readonly staleBundleReload = new StaleBundleReloadController({
-    prepareReload: () => this.prepareForStaleBundleReload(),
+    prepareReload: prepareComposerForIdleReload,
   });
 
   private get context(): ApplicationContext<RouteId> | undefined {
@@ -1266,26 +1267,6 @@ class OpenClawShell extends OpenClawLightDomElement {
     });
   }
 
-  private prepareForStaleBundleReload(): boolean {
-    return prepareStaleBundleAutoReload(this.staleBundleReloadTargets());
-  }
-
-  private staleBundleReloadTargets(): StaleBundleReloadTarget[] {
-    return [...this.querySelectorAll<ReloadableChatPaneElement>("openclaw-chat-pane")].filter(
-      (pane): pane is ReloadableChatPaneElement & StaleBundleReloadTarget =>
-        typeof pane.prepareForStaleBundleReload === "function",
-    );
-  }
-
-  private readonly refreshStaleBundle = () => {
-    const prepared = prepareStaleBundleManualReload(this.staleBundleReloadTargets(), () =>
-      window.confirm(t("chat.sidebar.discardAttachmentsForRefresh")),
-    );
-    if (prepared) {
-      window.location.reload();
-    }
-  };
-
   private ensureRuntimeConfig(
     snapshot: {
       client: GatewayBrowserClient | null;
@@ -1583,7 +1564,7 @@ class OpenClawShell extends OpenClawLightDomElement {
                 gatewaySnapshot.hello?.server?.version ??
                 null}
                 .staleBundleGatewayVersion=${staleBundleGatewayVersion}
-                .onRefreshStaleBundle=${this.refreshStaleBundle}
+                .onRefreshStaleBundle=${reloadControlUiWithComposerGuard}
                 .devGitBranch=${context.config.current.devGitBranch}
                 .updateAvailable=${navigationSurfaceHidden ? null : overlaySnapshot.updateAvailable}
                 .updateRunning=${overlaySnapshot.updateRunning}

--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -102,6 +102,11 @@ import {
   normalizeCatalogOpenTarget,
   setSettingsChangeListener,
 } from "./settings.ts";
+import {
+  readGatewayVersionFromSnapshot,
+  resolveStaleBundleGatewayVersion,
+  StaleBundleReloadController,
+} from "./stale-bundle.ts";
 
 type ShellRouteState = {
   routeId?: RouteId;
@@ -111,6 +116,9 @@ type ShellRouteState = {
 };
 type AppSidebarElement = HTMLElement & {
   dismissTransientMenus: () => boolean;
+};
+type ReloadableChatPaneElement = HTMLElement & {
+  prepareForStaleBundleReload?: () => boolean;
 };
 
 // Stable references so the sidebar's enabledRouteIds property does not churn
@@ -503,6 +511,9 @@ class OpenClawShell extends OpenClawLightDomElement {
     ReturnType<typeof globalThis.setTimeout>
   >();
   private readonly subscriptions = new SubscriptionsController(this);
+  private readonly staleBundleReload = new StaleBundleReloadController({
+    prepareReload: () => this.prepareForStaleBundleReload(),
+  });
 
   private get context(): ApplicationContext<RouteId> | undefined {
     return this.runtime?.context;
@@ -662,6 +673,7 @@ class OpenClawShell extends OpenClawLightDomElement {
     window.removeEventListener(TERMINAL_PANEL_TOGGLE_EVENT, this.handleDeferredTerminalToggle);
     window.removeEventListener(BROWSER_PANEL_TOGGLE_EVENT, this.handleDeferredBrowserToggle);
     setSettingsChangeListener(null);
+    this.staleBundleReload.stop();
     this.resetShellEpochState();
     super.disconnectedCallback();
   }
@@ -1234,9 +1246,20 @@ class OpenClawShell extends OpenClawLightDomElement {
   }
 
   private synchronizeGateway(snapshot: ApplicationContext["gateway"]["snapshot"]) {
+    this.staleBundleReload.update(
+      snapshot.connected
+        ? resolveStaleBundleGatewayVersion(readGatewayVersionFromSnapshot(snapshot.hello?.snapshot))
+        : null,
+    );
     this.updateGatewaySessionKey(snapshot);
     this.ensureAgentsList(snapshot);
     this.ensureRuntimeConfig(snapshot);
+  }
+
+  private prepareForStaleBundleReload(): boolean {
+    return [...this.querySelectorAll<ReloadableChatPaneElement>("openclaw-chat-pane")].every(
+      (pane) => pane.prepareForStaleBundleReload?.() ?? true,
+    );
   }
 
   private ensureRuntimeConfig(
@@ -1369,6 +1392,9 @@ class OpenClawShell extends OpenClawLightDomElement {
       return nothing;
     }
     const gatewaySnapshot = context.gateway.snapshot;
+    const staleBundleGatewayVersion = resolveStaleBundleGatewayVersion(
+      readGatewayVersionFromSnapshot(gatewaySnapshot.hello?.snapshot),
+    );
     const navigationSnapshot = context.navigation.snapshot;
     const overlaySnapshot = context.overlays.snapshot;
     const terminalAvailable = isTerminalAvailable(
@@ -1533,6 +1559,7 @@ class OpenClawShell extends OpenClawLightDomElement {
                 .gatewayVersion=${context.config.current.serverVersion ??
                 gatewaySnapshot.hello?.server?.version ??
                 null}
+                .staleBundleGatewayVersion=${staleBundleGatewayVersion}
                 .devGitBranch=${context.config.current.devGitBranch}
                 .updateAvailable=${navigationSurfaceHidden ? null : overlaySnapshot.updateAvailable}
                 .updateRunning=${overlaySnapshot.updateRunning}

--- a/ui/src/app/stale-bundle.test.ts
+++ b/ui/src/app/stale-bundle.test.ts
@@ -1,12 +1,23 @@
 /* @vitest-environment jsdom */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createStorageMock } from "../test-helpers/storage.ts";
 import {
+  gatewayUrlMatchesDocumentOrigin,
+  prepareStaleBundleManualReload,
   readGatewayVersionFromSnapshot,
   resolveStaleBundleGatewayVersion,
+  resolveStaleBundleReloadPair,
+  STALE_BUNDLE_AUTO_RELOAD_STORAGE_KEY,
   STALE_BUNDLE_IDLE_RELOAD_MS,
   StaleBundleReloadController,
+  type StaleBundleVersionPair,
 } from "./stale-bundle.ts";
+
+const VERSION_PAIR: StaleBundleVersionPair = {
+  bundleVersion: "2026.7.10",
+  gatewayVersion: "2026.7.11",
+};
 
 function setDocumentActivityState(visibility: DocumentVisibilityState, focused: boolean) {
   Object.defineProperty(document, "visibilityState", { configurable: true, value: visibility });
@@ -35,6 +46,85 @@ describe("stale bundle detection", () => {
     expect(resolveStaleBundleGatewayVersion("", "2026.7.10")).toBeNull();
     expect(resolveStaleBundleGatewayVersion("2026.7.11", null)).toBeNull();
   });
+
+  it("maps WebSocket protocols before comparing the active gateway with the document origin", () => {
+    expect(
+      gatewayUrlMatchesDocumentOrigin(
+        "wss://team.openclaw.ai/gateway",
+        "https://team.openclaw.ai/chat",
+      ),
+    ).toBe(true);
+    expect(
+      gatewayUrlMatchesDocumentOrigin("ws://127.0.0.1:18789", "http://127.0.0.1:18789/chat"),
+    ).toBe(true);
+    expect(
+      gatewayUrlMatchesDocumentOrigin(
+        "wss://gateway.example.test",
+        "https://team.openclaw.ai/chat",
+      ),
+    ).toBe(false);
+    expect(gatewayUrlMatchesDocumentOrigin("", "https://team.openclaw.ai/chat")).toBe(false);
+    expect(
+      gatewayUrlMatchesDocumentOrigin(
+        "https://team.openclaw.ai/gateway",
+        "https://team.openclaw.ai/chat",
+      ),
+    ).toBe(false);
+  });
+
+  it("only produces an auto-reload pair for a same-origin mismatch", () => {
+    expect(
+      resolveStaleBundleReloadPair({
+        bundleVersion: VERSION_PAIR.bundleVersion,
+        gatewayUrl: "wss://team.openclaw.ai/gateway",
+        gatewayVersion: VERSION_PAIR.gatewayVersion,
+        documentHref: "https://team.openclaw.ai/chat",
+      }),
+    ).toEqual(VERSION_PAIR);
+    expect(
+      resolveStaleBundleReloadPair({
+        bundleVersion: VERSION_PAIR.bundleVersion,
+        gatewayUrl: "wss://gateway.example.test",
+        gatewayVersion: VERSION_PAIR.gatewayVersion,
+        documentHref: "https://team.openclaw.ai/chat",
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("manual stale-bundle reload preparation", () => {
+  it("flushes every composer and continues when all state is restorable", () => {
+    const prepare = vi.fn(() => "ready" as const);
+    const confirmDiscard = vi.fn(() => true);
+
+    expect(
+      prepareStaleBundleManualReload([{ prepareForStaleBundleReload: prepare }], confirmDiscard),
+    ).toBe(true);
+    expect(prepare).toHaveBeenCalledOnce();
+    expect(confirmDiscard).not.toHaveBeenCalled();
+  });
+
+  it("requires consent before discarding staged attachments", () => {
+    const prepare = vi.fn(() => "attachments" as const);
+    const confirmDiscard = vi.fn(() => false);
+
+    expect(
+      prepareStaleBundleManualReload([{ prepareForStaleBundleReload: prepare }], confirmDiscard),
+    ).toBe(false);
+    expect(prepare).toHaveBeenCalledOnce();
+    expect(confirmDiscard).toHaveBeenCalledOnce();
+  });
+
+  it("does not offer attachment discard when draft persistence is blocked", () => {
+    const confirmDiscard = vi.fn(() => true);
+    expect(
+      prepareStaleBundleManualReload(
+        [{ prepareForStaleBundleReload: () => "blocked" }],
+        confirmDiscard,
+      ),
+    ).toBe(false);
+    expect(confirmDiscard).not.toHaveBeenCalled();
+  });
 });
 
 describe("StaleBundleReloadController", () => {
@@ -53,17 +143,20 @@ describe("StaleBundleReloadController", () => {
     vi.useRealTimers();
   });
 
-  function createController(prepareReload = vi.fn(() => true)) {
+  function createController(
+    prepareReload = vi.fn(() => true),
+    storage: Storage | null = createStorageMock(),
+  ) {
     const reload = vi.fn();
-    const controller = new StaleBundleReloadController({ prepareReload, reload });
+    const controller = new StaleBundleReloadController({ prepareReload, reload, storage });
     controllers.push(controller);
-    return { controller, prepareReload, reload };
+    return { controller, prepareReload, reload, storage };
   }
 
   it("reloads an idle background tab after preparing its composer draft", async () => {
     setDocumentActivityState("hidden", false);
     const { controller, prepareReload, reload } = createController();
-    controller.update("2026.7.11");
+    controller.update(VERSION_PAIR);
 
     await vi.advanceTimersByTimeAsync(STALE_BUNDLE_IDLE_RELOAD_MS);
 
@@ -71,10 +164,27 @@ describe("StaleBundleReloadController", () => {
     expect(reload).toHaveBeenCalledOnce();
   });
 
+  it("never arms auto-reload for a cross-origin gateway mismatch", async () => {
+    setDocumentActivityState("hidden", false);
+    const { controller, prepareReload, reload } = createController();
+    const crossOriginPair = resolveStaleBundleReloadPair({
+      bundleVersion: VERSION_PAIR.bundleVersion,
+      documentHref: "https://team.openclaw.ai/chat",
+      gatewayUrl: "wss://gateway.example.test",
+      gatewayVersion: VERSION_PAIR.gatewayVersion,
+    });
+
+    controller.update(crossOriginPair);
+    await vi.advanceTimersByTimeAsync(STALE_BUNDLE_IDLE_RELOAD_MS * 2);
+
+    expect(prepareReload).not.toHaveBeenCalled();
+    expect(reload).not.toHaveBeenCalled();
+  });
+
   it("never reloads a visible focused tab", async () => {
     setDocumentActivityState("visible", true);
     const { controller, prepareReload, reload } = createController();
-    controller.update("2026.7.11");
+    controller.update(VERSION_PAIR);
 
     await vi.advanceTimersByTimeAsync(STALE_BUNDLE_IDLE_RELOAD_MS * 2);
 
@@ -85,7 +195,7 @@ describe("StaleBundleReloadController", () => {
   it("resets the idle window on user activity", async () => {
     setDocumentActivityState("hidden", false);
     const { controller, reload } = createController();
-    controller.update("2026.7.11");
+    controller.update(VERSION_PAIR);
     await vi.advanceTimersByTimeAsync(STALE_BUNDLE_IDLE_RELOAD_MS - 1_000);
 
     window.dispatchEvent(new KeyboardEvent("keydown", { key: "a" }));
@@ -99,7 +209,7 @@ describe("StaleBundleReloadController", () => {
   it("does not reload when composer state cannot be persisted safely", async () => {
     setDocumentActivityState("hidden", false);
     const { controller, prepareReload, reload } = createController(vi.fn(() => false));
-    controller.update("2026.7.11");
+    controller.update(VERSION_PAIR);
 
     await vi.advanceTimersByTimeAsync(STALE_BUNDLE_IDLE_RELOAD_MS);
 
@@ -110,12 +220,85 @@ describe("StaleBundleReloadController", () => {
   it("tears down the idle timer when the mismatch disconnects", async () => {
     setDocumentActivityState("hidden", false);
     const { controller, prepareReload, reload } = createController();
-    controller.update("2026.7.11");
+    controller.update(VERSION_PAIR);
     controller.update(null);
 
     await vi.advanceTimersByTimeAsync(STALE_BUNDLE_IDLE_RELOAD_MS);
 
     expect(prepareReload).not.toHaveBeenCalled();
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it("records every reloaded version pair and does not re-loop through A-B-A", async () => {
+    setDocumentActivityState("hidden", false);
+    const storage = createStorageMock();
+    const first = createController(
+      vi.fn(() => true),
+      storage,
+    );
+    first.controller.update(VERSION_PAIR);
+
+    await vi.advanceTimersByTimeAsync(STALE_BUNDLE_IDLE_RELOAD_MS);
+
+    expect(first.reload).toHaveBeenCalledOnce();
+    expect(storage.getItem(STALE_BUNDLE_AUTO_RELOAD_STORAGE_KEY)).toBe(
+      JSON.stringify([JSON.stringify([VERSION_PAIR.bundleVersion, VERSION_PAIR.gatewayVersion])]),
+    );
+
+    const secondPair = { ...VERSION_PAIR, gatewayVersion: "2026.7.12" };
+    const interveningReload = createController(
+      vi.fn(() => true),
+      storage,
+    );
+    interveningReload.controller.update(secondPair);
+    await vi.advanceTimersByTimeAsync(STALE_BUNDLE_IDLE_RELOAD_MS);
+    expect(interveningReload.reload).toHaveBeenCalledOnce();
+
+    const repeatedFirstPair = createController(
+      vi.fn(() => true),
+      storage,
+    );
+    repeatedFirstPair.controller.update(VERSION_PAIR);
+    await vi.advanceTimersByTimeAsync(STALE_BUNDLE_IDLE_RELOAD_MS * 2);
+
+    expect(repeatedFirstPair.prepareReload).not.toHaveBeenCalled();
+    expect(repeatedFirstPair.reload).not.toHaveBeenCalled();
+  });
+
+  it("suppresses a delayed reload when another controller records the pair first", async () => {
+    setDocumentActivityState("hidden", false);
+    const storage = createStorageMock();
+    const first = createController(
+      vi.fn(() => true),
+      storage,
+    );
+    const second = createController(
+      vi.fn(() => true),
+      storage,
+    );
+    first.controller.update(VERSION_PAIR);
+    second.controller.update(VERSION_PAIR);
+
+    await vi.advanceTimersByTimeAsync(STALE_BUNDLE_IDLE_RELOAD_MS);
+
+    expect(first.reload).toHaveBeenCalledOnce();
+    expect(second.reload).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when the reload guard cannot be stored", async () => {
+    setDocumentActivityState("hidden", false);
+    const storage = createStorageMock();
+    storage.setItem = () => {
+      throw new Error("storage disabled");
+    };
+    const { controller, reload } = createController(
+      vi.fn(() => true),
+      storage,
+    );
+    controller.update(VERSION_PAIR);
+
+    await vi.advanceTimersByTimeAsync(STALE_BUNDLE_IDLE_RELOAD_MS);
+
     expect(reload).not.toHaveBeenCalled();
   });
 });

--- a/ui/src/app/stale-bundle.test.ts
+++ b/ui/src/app/stale-bundle.test.ts
@@ -7,13 +7,14 @@ import {
   prepareComposerForIdleReload,
   readGatewayVersionFromSnapshot,
   reloadWithComposerGuard,
-  resolveStaleBundleGatewayVersion,
   resolveStaleBundleReloadPair,
-  STALE_BUNDLE_AUTO_RELOAD_STORAGE_KEY,
-  STALE_BUNDLE_IDLE_RELOAD_MS,
   StaleBundleReloadController,
   type StaleBundleVersionPair,
 } from "./stale-bundle.ts";
+
+const TEST_IDLE_MS = 10_000;
+// Mirrors the module-local key so storage behavior stays observable without a test-only export.
+const AUTO_RELOAD_STORAGE_KEY = "openclaw:control-ui:stale-bundle-auto-reloaded:v1";
 
 const VERSION_PAIR: StaleBundleVersionPair = {
   bundleVersion: "2026.7.10",
@@ -50,11 +51,35 @@ describe("stale bundle detection", () => {
     ).toBeNull();
   });
 
-  it("returns the normalized gateway version only when it differs from the bundle", () => {
-    expect(resolveStaleBundleGatewayVersion(" 2026.7.11 ", "2026.7.10")).toBe("2026.7.11");
-    expect(resolveStaleBundleGatewayVersion("2026.7.10", " 2026.7.10 ")).toBeNull();
-    expect(resolveStaleBundleGatewayVersion("", "2026.7.10")).toBeNull();
-    expect(resolveStaleBundleGatewayVersion("2026.7.11", null)).toBeNull();
+  it("normalizes versions and returns only actionable mismatches", () => {
+    const input = {
+      documentHref: "https://team.openclaw.ai/chat",
+      gatewayUrl: "wss://team.openclaw.ai/gateway",
+    };
+    expect(
+      resolveStaleBundleReloadPair({
+        ...input,
+        bundleVersion: " 2026.7.10 ",
+        gatewayVersion: " 2026.7.11 ",
+      }),
+    ).toEqual(VERSION_PAIR);
+    expect(
+      resolveStaleBundleReloadPair({
+        ...input,
+        bundleVersion: " 2026.7.10 ",
+        gatewayVersion: "2026.7.10",
+      }),
+    ).toBeNull();
+    expect(
+      resolveStaleBundleReloadPair({ ...input, bundleVersion: "2026.7.10", gatewayVersion: "" }),
+    ).toBeNull();
+    expect(
+      resolveStaleBundleReloadPair({
+        ...input,
+        bundleVersion: null,
+        gatewayVersion: "2026.7.11",
+      }),
+    ).toBeNull();
   });
 
   it("maps WebSocket protocols before comparing the active gateway with the document origin", () => {
@@ -187,7 +212,12 @@ describe("StaleBundleReloadController", () => {
     storage: Storage | null = createStorageMock(),
   ) {
     const reload = vi.fn();
-    const controller = new StaleBundleReloadController({ prepareReload, reload, storage });
+    const controller = new StaleBundleReloadController({
+      idleMs: TEST_IDLE_MS,
+      prepareReload,
+      reload,
+      storage,
+    });
     controllers.push(controller);
     return { controller, prepareReload, reload, storage };
   }
@@ -197,7 +227,7 @@ describe("StaleBundleReloadController", () => {
     const { controller, prepareReload, reload } = createController();
     controller.update(VERSION_PAIR);
 
-    await vi.advanceTimersByTimeAsync(STALE_BUNDLE_IDLE_RELOAD_MS);
+    await vi.advanceTimersByTimeAsync(TEST_IDLE_MS);
 
     expect(prepareReload).toHaveBeenCalledOnce();
     expect(reload).toHaveBeenCalledOnce();
@@ -214,7 +244,7 @@ describe("StaleBundleReloadController", () => {
     });
 
     controller.update(crossOriginPair);
-    await vi.advanceTimersByTimeAsync(STALE_BUNDLE_IDLE_RELOAD_MS * 2);
+    await vi.advanceTimersByTimeAsync(TEST_IDLE_MS * 2);
 
     expect(prepareReload).not.toHaveBeenCalled();
     expect(reload).not.toHaveBeenCalled();
@@ -225,7 +255,7 @@ describe("StaleBundleReloadController", () => {
     const { controller, prepareReload, reload } = createController();
     controller.update(VERSION_PAIR);
 
-    await vi.advanceTimersByTimeAsync(STALE_BUNDLE_IDLE_RELOAD_MS * 2);
+    await vi.advanceTimersByTimeAsync(TEST_IDLE_MS * 2);
 
     expect(prepareReload).not.toHaveBeenCalled();
     expect(reload).not.toHaveBeenCalled();
@@ -235,13 +265,13 @@ describe("StaleBundleReloadController", () => {
     setDocumentActivityState("hidden", false);
     const { controller, reload } = createController();
     controller.update(VERSION_PAIR);
-    await vi.advanceTimersByTimeAsync(STALE_BUNDLE_IDLE_RELOAD_MS - 1_000);
+    await vi.advanceTimersByTimeAsync(TEST_IDLE_MS - 1_000);
 
     window.dispatchEvent(new KeyboardEvent("keydown", { key: "a" }));
     await vi.advanceTimersByTimeAsync(1_000);
     expect(reload).not.toHaveBeenCalled();
 
-    await vi.advanceTimersByTimeAsync(STALE_BUNDLE_IDLE_RELOAD_MS - 1_000);
+    await vi.advanceTimersByTimeAsync(TEST_IDLE_MS - 1_000);
     expect(reload).toHaveBeenCalledOnce();
   });
 
@@ -250,7 +280,7 @@ describe("StaleBundleReloadController", () => {
     const { controller, prepareReload, reload } = createController(vi.fn(() => false));
     controller.update(VERSION_PAIR);
 
-    await vi.advanceTimersByTimeAsync(STALE_BUNDLE_IDLE_RELOAD_MS);
+    await vi.advanceTimersByTimeAsync(TEST_IDLE_MS);
 
     expect(prepareReload).toHaveBeenCalledOnce();
     expect(reload).not.toHaveBeenCalled();
@@ -262,7 +292,7 @@ describe("StaleBundleReloadController", () => {
     controller.update(VERSION_PAIR);
     controller.update(null);
 
-    await vi.advanceTimersByTimeAsync(STALE_BUNDLE_IDLE_RELOAD_MS);
+    await vi.advanceTimersByTimeAsync(TEST_IDLE_MS);
 
     expect(prepareReload).not.toHaveBeenCalled();
     expect(reload).not.toHaveBeenCalled();
@@ -277,10 +307,10 @@ describe("StaleBundleReloadController", () => {
     );
     first.controller.update(VERSION_PAIR);
 
-    await vi.advanceTimersByTimeAsync(STALE_BUNDLE_IDLE_RELOAD_MS);
+    await vi.advanceTimersByTimeAsync(TEST_IDLE_MS);
 
     expect(first.reload).toHaveBeenCalledOnce();
-    expect(storage.getItem(STALE_BUNDLE_AUTO_RELOAD_STORAGE_KEY)).toBe(
+    expect(storage.getItem(AUTO_RELOAD_STORAGE_KEY)).toBe(
       JSON.stringify([JSON.stringify([VERSION_PAIR.bundleVersion, VERSION_PAIR.gatewayVersion])]),
     );
 
@@ -290,7 +320,7 @@ describe("StaleBundleReloadController", () => {
       storage,
     );
     interveningReload.controller.update(secondPair);
-    await vi.advanceTimersByTimeAsync(STALE_BUNDLE_IDLE_RELOAD_MS);
+    await vi.advanceTimersByTimeAsync(TEST_IDLE_MS);
     expect(interveningReload.reload).toHaveBeenCalledOnce();
 
     const repeatedFirstPair = createController(
@@ -298,7 +328,7 @@ describe("StaleBundleReloadController", () => {
       storage,
     );
     repeatedFirstPair.controller.update(VERSION_PAIR);
-    await vi.advanceTimersByTimeAsync(STALE_BUNDLE_IDLE_RELOAD_MS * 2);
+    await vi.advanceTimersByTimeAsync(TEST_IDLE_MS * 2);
 
     expect(repeatedFirstPair.prepareReload).not.toHaveBeenCalled();
     expect(repeatedFirstPair.reload).not.toHaveBeenCalled();
@@ -318,7 +348,7 @@ describe("StaleBundleReloadController", () => {
     first.controller.update(VERSION_PAIR);
     second.controller.update(VERSION_PAIR);
 
-    await vi.advanceTimersByTimeAsync(STALE_BUNDLE_IDLE_RELOAD_MS);
+    await vi.advanceTimersByTimeAsync(TEST_IDLE_MS);
 
     expect(first.reload).toHaveBeenCalledOnce();
     expect(second.reload).not.toHaveBeenCalled();
@@ -336,7 +366,7 @@ describe("StaleBundleReloadController", () => {
     );
     controller.update(VERSION_PAIR);
 
-    await vi.advanceTimersByTimeAsync(STALE_BUNDLE_IDLE_RELOAD_MS);
+    await vi.advanceTimersByTimeAsync(TEST_IDLE_MS);
 
     expect(reload).not.toHaveBeenCalled();
   });

--- a/ui/src/app/stale-bundle.test.ts
+++ b/ui/src/app/stale-bundle.test.ts
@@ -4,8 +4,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createStorageMock } from "../test-helpers/storage.ts";
 import {
   gatewayUrlMatchesDocumentOrigin,
-  prepareStaleBundleManualReload,
+  prepareComposerForIdleReload,
   readGatewayVersionFromSnapshot,
+  reloadWithComposerGuard,
   resolveStaleBundleGatewayVersion,
   resolveStaleBundleReloadPair,
   STALE_BUNDLE_AUTO_RELOAD_STORAGE_KEY,
@@ -22,6 +23,15 @@ const VERSION_PAIR: StaleBundleVersionPair = {
 function setDocumentActivityState(visibility: DocumentVisibilityState, focused: boolean) {
   Object.defineProperty(document, "visibilityState", { configurable: true, value: visibility });
   vi.spyOn(document, "hasFocus").mockReturnValue(focused);
+}
+
+function reloadRoot(...preparations: Array<() => "attachments" | "blocked" | "ready">) {
+  const targets = preparations.map((prepareForStaleBundleReload) => ({
+    prepareForStaleBundleReload,
+  }));
+  return {
+    querySelectorAll: () => targets,
+  } as unknown as ParentNode;
 }
 
 describe("stale bundle detection", () => {
@@ -96,34 +106,63 @@ describe("manual stale-bundle reload preparation", () => {
   it("flushes every composer and continues when all state is restorable", () => {
     const prepare = vi.fn(() => "ready" as const);
     const confirmDiscard = vi.fn(() => true);
+    const reload = vi.fn();
 
     expect(
-      prepareStaleBundleManualReload([{ prepareForStaleBundleReload: prepare }], confirmDiscard),
+      reloadWithComposerGuard({
+        root: reloadRoot(prepare),
+        confirmDiscardAttachments: confirmDiscard,
+        reload,
+      }),
     ).toBe(true);
     expect(prepare).toHaveBeenCalledOnce();
     expect(confirmDiscard).not.toHaveBeenCalled();
+    expect(reload).toHaveBeenCalledOnce();
   });
 
   it("requires consent before discarding staged attachments", () => {
     const prepare = vi.fn(() => "attachments" as const);
     const confirmDiscard = vi.fn(() => false);
+    const reload = vi.fn();
 
     expect(
-      prepareStaleBundleManualReload([{ prepareForStaleBundleReload: prepare }], confirmDiscard),
+      reloadWithComposerGuard({
+        root: reloadRoot(prepare),
+        confirmDiscardAttachments: confirmDiscard,
+        reload,
+      }),
     ).toBe(false);
     expect(prepare).toHaveBeenCalledOnce();
     expect(confirmDiscard).toHaveBeenCalledOnce();
+    expect(reload).not.toHaveBeenCalled();
   });
 
   it("does not offer attachment discard when draft persistence is blocked", () => {
     const confirmDiscard = vi.fn(() => true);
+    const reload = vi.fn();
     expect(
-      prepareStaleBundleManualReload(
-        [{ prepareForStaleBundleReload: () => "blocked" }],
-        confirmDiscard,
-      ),
+      reloadWithComposerGuard({
+        root: reloadRoot(() => "blocked"),
+        confirmDiscardAttachments: confirmDiscard,
+        reload,
+      }),
     ).toBe(false);
     expect(confirmDiscard).not.toHaveBeenCalled();
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it("reloads safely when no composer is mounted", () => {
+    const reload = vi.fn();
+    expect(reloadWithComposerGuard({ root: reloadRoot(), reload })).toBe(true);
+    expect(reload).toHaveBeenCalledOnce();
+  });
+});
+
+describe("idle stale-bundle reload preparation", () => {
+  it("uses the shared probe but blocks instead of prompting for attachments", () => {
+    const prepare = vi.fn(() => "attachments" as const);
+    expect(prepareComposerForIdleReload(reloadRoot(prepare))).toBe(false);
+    expect(prepare).toHaveBeenCalledOnce();
   });
 });
 

--- a/ui/src/app/stale-bundle.test.ts
+++ b/ui/src/app/stale-bundle.test.ts
@@ -1,0 +1,121 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  readGatewayVersionFromSnapshot,
+  resolveStaleBundleGatewayVersion,
+  STALE_BUNDLE_IDLE_RELOAD_MS,
+  StaleBundleReloadController,
+} from "./stale-bundle.ts";
+
+function setDocumentActivityState(visibility: DocumentVisibilityState, focused: boolean) {
+  Object.defineProperty(document, "visibilityState", { configurable: true, value: visibility });
+  vi.spyOn(document, "hasFocus").mockReturnValue(focused);
+}
+
+describe("stale bundle detection", () => {
+  it("reads the gateway self version from the hello snapshot", () => {
+    expect(
+      readGatewayVersionFromSnapshot({
+        presence: [
+          { mode: "node", version: "2026.7.9" },
+          { mode: "gateway", reason: "proxy", version: "2026.7.99" },
+          { mode: " Gateway ", reason: "self", version: " 2026.7.11 " },
+        ],
+      }),
+    ).toBe("2026.7.11");
+    expect(
+      readGatewayVersionFromSnapshot({ presence: [{ mode: "node", version: "x" }] }),
+    ).toBeNull();
+  });
+
+  it("returns the normalized gateway version only when it differs from the bundle", () => {
+    expect(resolveStaleBundleGatewayVersion(" 2026.7.11 ", "2026.7.10")).toBe("2026.7.11");
+    expect(resolveStaleBundleGatewayVersion("2026.7.10", " 2026.7.10 ")).toBeNull();
+    expect(resolveStaleBundleGatewayVersion("", "2026.7.10")).toBeNull();
+    expect(resolveStaleBundleGatewayVersion("2026.7.11", null)).toBeNull();
+  });
+});
+
+describe("StaleBundleReloadController", () => {
+  const controllers: StaleBundleReloadController[] = [];
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+  });
+
+  afterEach(() => {
+    for (const controller of controllers.splice(0)) {
+      controller.stop();
+    }
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  function createController(prepareReload = vi.fn(() => true)) {
+    const reload = vi.fn();
+    const controller = new StaleBundleReloadController({ prepareReload, reload });
+    controllers.push(controller);
+    return { controller, prepareReload, reload };
+  }
+
+  it("reloads an idle background tab after preparing its composer draft", async () => {
+    setDocumentActivityState("hidden", false);
+    const { controller, prepareReload, reload } = createController();
+    controller.update("2026.7.11");
+
+    await vi.advanceTimersByTimeAsync(STALE_BUNDLE_IDLE_RELOAD_MS);
+
+    expect(prepareReload).toHaveBeenCalledOnce();
+    expect(reload).toHaveBeenCalledOnce();
+  });
+
+  it("never reloads a visible focused tab", async () => {
+    setDocumentActivityState("visible", true);
+    const { controller, prepareReload, reload } = createController();
+    controller.update("2026.7.11");
+
+    await vi.advanceTimersByTimeAsync(STALE_BUNDLE_IDLE_RELOAD_MS * 2);
+
+    expect(prepareReload).not.toHaveBeenCalled();
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it("resets the idle window on user activity", async () => {
+    setDocumentActivityState("hidden", false);
+    const { controller, reload } = createController();
+    controller.update("2026.7.11");
+    await vi.advanceTimersByTimeAsync(STALE_BUNDLE_IDLE_RELOAD_MS - 1_000);
+
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "a" }));
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(reload).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(STALE_BUNDLE_IDLE_RELOAD_MS - 1_000);
+    expect(reload).toHaveBeenCalledOnce();
+  });
+
+  it("does not reload when composer state cannot be persisted safely", async () => {
+    setDocumentActivityState("hidden", false);
+    const { controller, prepareReload, reload } = createController(vi.fn(() => false));
+    controller.update("2026.7.11");
+
+    await vi.advanceTimersByTimeAsync(STALE_BUNDLE_IDLE_RELOAD_MS);
+
+    expect(prepareReload).toHaveBeenCalledOnce();
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it("tears down the idle timer when the mismatch disconnects", async () => {
+    setDocumentActivityState("hidden", false);
+    const { controller, prepareReload, reload } = createController();
+    controller.update("2026.7.11");
+    controller.update(null);
+
+    await vi.advanceTimersByTimeAsync(STALE_BUNDLE_IDLE_RELOAD_MS);
+
+    expect(prepareReload).not.toHaveBeenCalled();
+    expect(reload).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/app/stale-bundle.ts
+++ b/ui/src/app/stale-bundle.ts
@@ -1,4 +1,5 @@
 import { CONTROL_UI_BUILD_INFO } from "../build-info.ts";
+import { t } from "../i18n/index.ts";
 
 export const STALE_BUNDLE_IDLE_RELOAD_MS = 5 * 60 * 1_000;
 export const STALE_BUNDLE_AUTO_RELOAD_STORAGE_KEY =
@@ -15,6 +16,12 @@ export type StaleBundleReloadPreparation = "attachments" | "blocked" | "ready";
 
 export type StaleBundleReloadTarget = {
   prepareForStaleBundleReload: () => StaleBundleReloadPreparation;
+};
+
+type ComposerReloadGuardOptions = {
+  confirmDiscardAttachments?: () => boolean;
+  reload?: () => void;
+  root?: ParentNode;
 };
 
 export function gatewayUrlMatchesDocumentOrigin(
@@ -48,19 +55,45 @@ export function resolveStaleBundleReloadPair(params: {
   return { bundleVersion, gatewayVersion };
 }
 
-export function prepareStaleBundleAutoReload(targets: readonly StaleBundleReloadTarget[]): boolean {
-  return targets.every((target) => target.prepareForStaleBundleReload() === "ready");
+function composerReloadTargets(root: ParentNode): StaleBundleReloadTarget[] {
+  return [...root.querySelectorAll<HTMLElement>("openclaw-chat-pane")].filter(
+    (element): element is HTMLElement & StaleBundleReloadTarget =>
+      "prepareForStaleBundleReload" in element &&
+      typeof element.prepareForStaleBundleReload === "function",
+  );
 }
 
-export function prepareStaleBundleManualReload(
-  targets: readonly StaleBundleReloadTarget[],
-  confirmDiscardAttachments: () => boolean,
-): boolean {
-  const results = new Set(targets.map((target) => target.prepareForStaleBundleReload()));
+function collectComposerReloadPreparation(root: ParentNode): Set<StaleBundleReloadPreparation> {
+  return new Set(composerReloadTargets(root).map((target) => target.prepareForStaleBundleReload()));
+}
+
+function reloadDocument(): void {
+  // Full-page reload stays private to the guarded manual path and the idle
+  // controller, which runs the same composer probe without prompting.
+  globalThis.location.reload();
+}
+
+export function prepareComposerForIdleReload(root: ParentNode = document): boolean {
+  const results = collectComposerReloadPreparation(root);
+  return !results.has("blocked") && !results.has("attachments");
+}
+
+export function reloadWithComposerGuard(options: ComposerReloadGuardOptions = {}): boolean {
+  const results = collectComposerReloadPreparation(options.root ?? document);
   if (results.has("blocked")) {
     return false;
   }
-  return !results.has("attachments") || confirmDiscardAttachments();
+  if (
+    results.has("attachments") &&
+    !(
+      options.confirmDiscardAttachments ??
+      (() => globalThis.confirm(t("chat.sidebar.discardAttachmentsForRefresh")))
+    )()
+  ) {
+    return false;
+  }
+  (options.reload ?? reloadDocument)();
+  return true;
 }
 
 export function readGatewayVersionFromSnapshot(snapshot: unknown): string | null {
@@ -137,7 +170,9 @@ export class StaleBundleReloadController {
     this.idleMs = options.idleMs ?? STALE_BUNDLE_IDLE_RELOAD_MS;
     this.now = options.now ?? Date.now;
     this.prepareReload = options.prepareReload;
-    this.reload = options.reload ?? (() => globalThis.location.reload());
+    // Unattended reload calls this only after prepareReload has accepted the
+    // shared composer probe and the version-pair loop guard is durable.
+    this.reload = options.reload ?? reloadDocument;
     this.storage = options.storage === undefined ? safeSessionStorage() : options.storage;
   }
 

--- a/ui/src/app/stale-bundle.ts
+++ b/ui/src/app/stale-bundle.ts
@@ -1,0 +1,149 @@
+import { CONTROL_UI_BUILD_INFO } from "../build-info.ts";
+
+export const STALE_BUNDLE_IDLE_RELOAD_MS = 5 * 60 * 1_000;
+
+const ACTIVITY_THROTTLE_MS = 1_000;
+
+export function readGatewayVersionFromSnapshot(snapshot: unknown): string | null {
+  if (!snapshot || typeof snapshot !== "object") {
+    return null;
+  }
+  const presence = (snapshot as { presence?: unknown }).presence;
+  if (!Array.isArray(presence)) {
+    return null;
+  }
+  const gateway = presence.find(
+    (entry) =>
+      entry !== null &&
+      typeof entry === "object" &&
+      typeof (entry as { mode?: unknown }).mode === "string" &&
+      (entry as { mode: string }).mode.trim().toLowerCase() === "gateway" &&
+      (entry as { reason?: unknown }).reason === "self" &&
+      typeof (entry as { version?: unknown }).version === "string" &&
+      Boolean((entry as { version: string }).version.trim()),
+  );
+  const version = (gateway as { version?: unknown } | undefined)?.version;
+  return typeof version === "string" && version.trim() ? version.trim() : null;
+}
+
+export function resolveStaleBundleGatewayVersion(
+  gatewayVersion: string | null | undefined,
+  bundleVersion: string | null | undefined = CONTROL_UI_BUILD_INFO.version,
+): string | null {
+  // The connected Gateway snapshot is canonical for this tab. Any release
+  // inequality, including an older Gateway, means the loaded bundle is stale.
+  const normalizedGatewayVersion = gatewayVersion?.trim() ?? "";
+  const normalizedBundleVersion = bundleVersion?.trim() ?? "";
+  if (
+    !normalizedGatewayVersion ||
+    !normalizedBundleVersion ||
+    normalizedGatewayVersion === normalizedBundleVersion
+  ) {
+    return null;
+  }
+  return normalizedGatewayVersion;
+}
+
+type StaleBundleReloadControllerOptions = {
+  idleMs?: number;
+  now?: () => number;
+  prepareReload: () => boolean;
+  reload?: () => void;
+};
+
+export class StaleBundleReloadController {
+  private readonly idleMs: number;
+  private readonly now: () => number;
+  private readonly prepareReload: () => boolean;
+  private readonly reload: () => void;
+  private staleGatewayVersion: string | null = null;
+  private lastActivityAt = 0;
+  private timer: ReturnType<typeof globalThis.setTimeout> | null = null;
+
+  constructor(options: StaleBundleReloadControllerOptions) {
+    this.idleMs = options.idleMs ?? STALE_BUNDLE_IDLE_RELOAD_MS;
+    this.now = options.now ?? Date.now;
+    this.prepareReload = options.prepareReload;
+    this.reload = options.reload ?? (() => globalThis.location.reload());
+  }
+
+  update(staleGatewayVersion: string | null): void {
+    if (staleGatewayVersion === this.staleGatewayVersion) {
+      return;
+    }
+    this.stop();
+    this.staleGatewayVersion = staleGatewayVersion;
+    if (!staleGatewayVersion) {
+      return;
+    }
+    this.lastActivityAt = this.now();
+    window.addEventListener("pointerdown", this.handleActivity, { passive: true });
+    window.addEventListener("pointermove", this.handlePointerMove, { passive: true });
+    window.addEventListener("keydown", this.handleActivity, { passive: true });
+    window.addEventListener("focus", this.handleActivity, { passive: true });
+    window.addEventListener("blur", this.handleActivity, { passive: true });
+    document.addEventListener("visibilitychange", this.handleActivity, { passive: true });
+    this.schedule(this.idleMs);
+  }
+
+  stop(): void {
+    this.clearTimer();
+    window.removeEventListener("pointerdown", this.handleActivity);
+    window.removeEventListener("pointermove", this.handlePointerMove);
+    window.removeEventListener("keydown", this.handleActivity);
+    window.removeEventListener("focus", this.handleActivity);
+    window.removeEventListener("blur", this.handleActivity);
+    document.removeEventListener("visibilitychange", this.handleActivity);
+    this.staleGatewayVersion = null;
+  }
+
+  private readonly handleActivity = () => {
+    if (!this.staleGatewayVersion) {
+      return;
+    }
+    this.lastActivityAt = this.now();
+    this.schedule(this.idleMs);
+  };
+
+  private readonly handlePointerMove = () => {
+    if (this.now() - this.lastActivityAt >= ACTIVITY_THROTTLE_MS) {
+      this.handleActivity();
+    }
+  };
+
+  private schedule(delay: number): void {
+    this.clearTimer();
+    this.timer = globalThis.setTimeout(this.handleIdleTimer, delay);
+  }
+
+  private clearTimer(): void {
+    if (this.timer === null) {
+      return;
+    }
+    globalThis.clearTimeout(this.timer);
+    this.timer = null;
+  }
+
+  private readonly handleIdleTimer = () => {
+    this.timer = null;
+    if (!this.staleGatewayVersion) {
+      return;
+    }
+    const remaining = this.idleMs - (this.now() - this.lastActivityAt);
+    if (remaining > 0) {
+      this.schedule(remaining);
+      return;
+    }
+    // A dismissed Tier-1 card does not disable this lossless idle refresh.
+    // Foreground work always wins; blur/visibility activity starts a fresh idle window.
+    if (document.visibilityState === "visible" && document.hasFocus()) {
+      return;
+    }
+    if (!this.prepareReload()) {
+      this.lastActivityAt = this.now();
+      this.schedule(this.idleMs);
+      return;
+    }
+    this.reload();
+  };
+}

--- a/ui/src/app/stale-bundle.ts
+++ b/ui/src/app/stale-bundle.ts
@@ -1,9 +1,8 @@
 import { CONTROL_UI_BUILD_INFO } from "../build-info.ts";
 import { t } from "../i18n/index.ts";
 
-export const STALE_BUNDLE_IDLE_RELOAD_MS = 5 * 60 * 1_000;
-export const STALE_BUNDLE_AUTO_RELOAD_STORAGE_KEY =
-  "openclaw:control-ui:stale-bundle-auto-reloaded:v1";
+const STALE_BUNDLE_IDLE_RELOAD_MS = 5 * 60 * 1_000;
+const STALE_BUNDLE_AUTO_RELOAD_STORAGE_KEY = "openclaw:control-ui:stale-bundle-auto-reloaded:v1";
 
 const ACTIVITY_THROTTLE_MS = 1_000;
 
@@ -14,7 +13,7 @@ export type StaleBundleVersionPair = Readonly<{
 
 export type StaleBundleReloadPreparation = "attachments" | "blocked" | "ready";
 
-export type StaleBundleReloadTarget = {
+type StaleBundleReloadTarget = {
   prepareForStaleBundleReload: () => StaleBundleReloadPreparation;
 };
 
@@ -118,7 +117,7 @@ export function readGatewayVersionFromSnapshot(snapshot: unknown): string | null
   return typeof version === "string" && version.trim() ? version.trim() : null;
 }
 
-export function resolveStaleBundleGatewayVersion(
+function resolveStaleBundleGatewayVersion(
   gatewayVersion: string | null | undefined,
   bundleVersion: string | null | undefined = CONTROL_UI_BUILD_INFO.version,
 ): string | null {

--- a/ui/src/app/stale-bundle.ts
+++ b/ui/src/app/stale-bundle.ts
@@ -1,8 +1,67 @@
 import { CONTROL_UI_BUILD_INFO } from "../build-info.ts";
 
 export const STALE_BUNDLE_IDLE_RELOAD_MS = 5 * 60 * 1_000;
+export const STALE_BUNDLE_AUTO_RELOAD_STORAGE_KEY =
+  "openclaw:control-ui:stale-bundle-auto-reloaded:v1";
 
 const ACTIVITY_THROTTLE_MS = 1_000;
+
+export type StaleBundleVersionPair = Readonly<{
+  bundleVersion: string;
+  gatewayVersion: string;
+}>;
+
+export type StaleBundleReloadPreparation = "attachments" | "blocked" | "ready";
+
+export type StaleBundleReloadTarget = {
+  prepareForStaleBundleReload: () => StaleBundleReloadPreparation;
+};
+
+export function gatewayUrlMatchesDocumentOrigin(
+  gatewayUrl: string,
+  documentHref: string = globalThis.location.href,
+): boolean {
+  try {
+    const documentUrl = new URL(documentHref);
+    const gateway = new URL(gatewayUrl, documentUrl);
+    if (gateway.protocol !== "ws:" && gateway.protocol !== "wss:") {
+      return false;
+    }
+    gateway.protocol = gateway.protocol === "ws:" ? "http:" : "https:";
+    return documentUrl.origin !== "null" && gateway.origin === documentUrl.origin;
+  } catch {
+    return false;
+  }
+}
+
+export function resolveStaleBundleReloadPair(params: {
+  bundleVersion?: string | null;
+  documentHref?: string;
+  gatewayUrl: string;
+  gatewayVersion?: string | null;
+}): StaleBundleVersionPair | null {
+  const bundleVersion = (params.bundleVersion ?? CONTROL_UI_BUILD_INFO.version)?.trim() ?? "";
+  const gatewayVersion = resolveStaleBundleGatewayVersion(params.gatewayVersion, bundleVersion);
+  if (!gatewayVersion || !gatewayUrlMatchesDocumentOrigin(params.gatewayUrl, params.documentHref)) {
+    return null;
+  }
+  return { bundleVersion, gatewayVersion };
+}
+
+export function prepareStaleBundleAutoReload(targets: readonly StaleBundleReloadTarget[]): boolean {
+  return targets.every((target) => target.prepareForStaleBundleReload() === "ready");
+}
+
+export function prepareStaleBundleManualReload(
+  targets: readonly StaleBundleReloadTarget[],
+  confirmDiscardAttachments: () => boolean,
+): boolean {
+  const results = new Set(targets.map((target) => target.prepareForStaleBundleReload()));
+  if (results.has("blocked")) {
+    return false;
+  }
+  return !results.has("attachments") || confirmDiscardAttachments();
+}
 
 export function readGatewayVersionFromSnapshot(snapshot: unknown): string | null {
   if (!snapshot || typeof snapshot !== "object") {
@@ -49,14 +108,28 @@ type StaleBundleReloadControllerOptions = {
   now?: () => number;
   prepareReload: () => boolean;
   reload?: () => void;
+  storage?: Storage | null;
 };
+
+function safeSessionStorage(): Storage | null {
+  try {
+    return globalThis.sessionStorage;
+  } catch {
+    return null;
+  }
+}
+
+function versionPairKey(pair: StaleBundleVersionPair): string {
+  return JSON.stringify([pair.bundleVersion, pair.gatewayVersion]);
+}
 
 export class StaleBundleReloadController {
   private readonly idleMs: number;
   private readonly now: () => number;
   private readonly prepareReload: () => boolean;
   private readonly reload: () => void;
-  private staleGatewayVersion: string | null = null;
+  private readonly storage: Storage | null;
+  private stalePairKey: string | null = null;
   private lastActivityAt = 0;
   private timer: ReturnType<typeof globalThis.setTimeout> | null = null;
 
@@ -65,17 +138,19 @@ export class StaleBundleReloadController {
     this.now = options.now ?? Date.now;
     this.prepareReload = options.prepareReload;
     this.reload = options.reload ?? (() => globalThis.location.reload());
+    this.storage = options.storage === undefined ? safeSessionStorage() : options.storage;
   }
 
-  update(staleGatewayVersion: string | null): void {
-    if (staleGatewayVersion === this.staleGatewayVersion) {
+  update(stalePair: StaleBundleVersionPair | null): void {
+    const nextPairKey = stalePair ? versionPairKey(stalePair) : null;
+    if (nextPairKey === this.stalePairKey) {
       return;
     }
     this.stop();
-    this.staleGatewayVersion = staleGatewayVersion;
-    if (!staleGatewayVersion) {
+    if (!nextPairKey || this.readReloadedPairs().has(nextPairKey)) {
       return;
     }
+    this.stalePairKey = nextPairKey;
     this.lastActivityAt = this.now();
     window.addEventListener("pointerdown", this.handleActivity, { passive: true });
     window.addEventListener("pointermove", this.handlePointerMove, { passive: true });
@@ -94,11 +169,11 @@ export class StaleBundleReloadController {
     window.removeEventListener("focus", this.handleActivity);
     window.removeEventListener("blur", this.handleActivity);
     document.removeEventListener("visibilitychange", this.handleActivity);
-    this.staleGatewayVersion = null;
+    this.stalePairKey = null;
   }
 
   private readonly handleActivity = () => {
-    if (!this.staleGatewayVersion) {
+    if (!this.stalePairKey) {
       return;
     }
     this.lastActivityAt = this.now();
@@ -126,7 +201,7 @@ export class StaleBundleReloadController {
 
   private readonly handleIdleTimer = () => {
     this.timer = null;
-    if (!this.staleGatewayVersion) {
+    if (!this.stalePairKey) {
       return;
     }
     const remaining = this.idleMs - (this.now() - this.lastActivityAt);
@@ -144,6 +219,43 @@ export class StaleBundleReloadController {
       this.schedule(this.idleMs);
       return;
     }
+    if (!this.recordReloadedPair()) {
+      return;
+    }
     this.reload();
   };
+
+  private readReloadedPairs(): Set<string> {
+    try {
+      const raw = this.storage?.getItem(STALE_BUNDLE_AUTO_RELOAD_STORAGE_KEY);
+      const parsed = raw ? (JSON.parse(raw) as unknown) : [];
+      return new Set(
+        Array.isArray(parsed)
+          ? parsed.filter((entry): entry is string => typeof entry === "string")
+          : [],
+      );
+    } catch {
+      return new Set();
+    }
+  }
+
+  private recordReloadedPair(): boolean {
+    if (!this.storage || !this.stalePairKey) {
+      return false;
+    }
+    try {
+      const reloadedPairs = this.readReloadedPairs();
+      if (reloadedPairs.has(this.stalePairKey)) {
+        return false;
+      }
+      reloadedPairs.add(this.stalePairKey);
+      this.storage.setItem(
+        STALE_BUNDLE_AUTO_RELOAD_STORAGE_KEY,
+        JSON.stringify([...reloadedPairs]),
+      );
+      return true;
+    } catch {
+      return false;
+    }
+  }
 }

--- a/ui/src/components/app-sidebar-base.ts
+++ b/ui/src/components/app-sidebar-base.ts
@@ -33,6 +33,7 @@ export abstract class AppSidebarBase extends OpenClawLightDomContentsElement {
   @property({ attribute: false }) lobsterPetSounds = false;
   @property({ attribute: false }) gatewayVersion: string | null = null;
   @property({ attribute: false }) staleBundleGatewayVersion: string | null = null;
+  @property({ attribute: false }) onRefreshStaleBundle: () => void = () => undefined;
   @property({ attribute: false }) devGitBranch: string | null = null;
   @property({ attribute: false }) updateAvailable: UpdateAvailable | null = null;
   @property({ attribute: false }) updateRunning = false;

--- a/ui/src/components/app-sidebar-base.ts
+++ b/ui/src/components/app-sidebar-base.ts
@@ -32,6 +32,7 @@ export abstract class AppSidebarBase extends OpenClawLightDomContentsElement {
   @property({ attribute: false }) lobsterPetVisits = true;
   @property({ attribute: false }) lobsterPetSounds = false;
   @property({ attribute: false }) gatewayVersion: string | null = null;
+  @property({ attribute: false }) staleBundleGatewayVersion: string | null = null;
   @property({ attribute: false }) devGitBranch: string | null = null;
   @property({ attribute: false }) updateAvailable: UpdateAvailable | null = null;
   @property({ attribute: false }) updateRunning = false;

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -18,6 +18,7 @@ import "./session-menu.ts";
 import "./sidebar-agent-card.ts";
 import "./sidebar-attention.ts";
 import "./sidebar-build-chip.ts";
+import "./sidebar-stale-bundle-card.ts";
 import "./sidebar-update-card.ts";
 import "./theme-mode-toggle.ts";
 import "./tooltip.ts";
@@ -305,6 +306,9 @@ class AppSidebar extends AppSidebarSessionListElement {
       : null;
     const selfLabel = selfUser?.name ?? selfUser?.email ?? selfUser?.id;
     return html`
+      <openclaw-sidebar-stale-bundle-card
+        .gatewayVersion=${this.staleBundleGatewayVersion}
+      ></openclaw-sidebar-stale-bundle-card>
       <div class="sidebar-footer-bar">
         <span class="sidebar-brand__logo-slot sidebar-footer-bar__logo">
           <img

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -308,6 +308,7 @@ class AppSidebar extends AppSidebarSessionListElement {
     return html`
       <openclaw-sidebar-stale-bundle-card
         .gatewayVersion=${this.staleBundleGatewayVersion}
+        .onRefresh=${this.onRefreshStaleBundle}
       ></openclaw-sidebar-stale-bundle-card>
       <div class="sidebar-footer-bar">
         <span class="sidebar-brand__logo-slot sidebar-footer-bar__logo">

--- a/ui/src/components/login-gate.test.ts
+++ b/ui/src/components/login-gate.test.ts
@@ -1,6 +1,6 @@
 /* @vitest-environment jsdom */
 
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { ConnectErrorDetailCodes } from "../../../packages/gateway-protocol/src/connect-error-details.js";
 import "./login-gate.ts";
 
@@ -12,16 +12,17 @@ type LoginGateElement = HTMLElement & {
 afterEach(() => document.body.replaceChildren());
 
 describe("LoginGate protocol mismatch", () => {
-  it("renders a blocking refresh screen instead of reconnect controls", async () => {
-    const gate = document.createElement("openclaw-login-gate") as LoginGateElement;
-    gate.props = {
+  function props(overrides: Record<string, unknown> = {}) {
+    const documentUrl = new URL(window.location.href);
+    documentUrl.protocol = documentUrl.protocol === "https:" ? "wss:" : "ws:";
+    return {
       basePath: "",
       connected: false,
       lastError: "protocol mismatch",
       lastErrorCode: ConnectErrorDetailCodes.PROTOCOL_MISMATCH,
       hasToken: false,
       hasPassword: false,
-      gatewayUrl: "ws://127.0.0.1:18789",
+      gatewayUrl: documentUrl.href,
       token: "",
       password: "",
       showGatewayToken: false,
@@ -32,13 +33,39 @@ describe("LoginGate protocol mismatch", () => {
       onToggleGatewayToken: () => undefined,
       onToggleGatewayPassword: () => undefined,
       onConnect: () => undefined,
+      ...overrides,
     };
+  }
+
+  async function mount(overrides: Record<string, unknown> = {}) {
+    const gate = document.createElement("openclaw-login-gate") as LoginGateElement;
+    gate.props = props(overrides);
     document.body.append(gate);
     await gate.updateComplete;
+    return gate;
+  }
+
+  it("keeps reconnect controls beside the primary same-origin refresh recovery", async () => {
+    const onConnect = vi.fn();
+    const gate = await mount({ onConnect });
 
     const screen = gate.querySelector('[data-kind="protocol-mismatch"]');
-    expect(screen?.textContent).toContain("This app is out of date — refresh to continue");
+    expect(screen?.textContent).toContain("This app is out of date");
+    expect(screen?.textContent).toContain("Refresh to load the Control UI served by this Gateway");
     expect(screen?.querySelector(".login-gate__protocol-refresh")).not.toBeNull();
-    expect(screen?.querySelector(".login-gate__form")).toBeNull();
+    expect(screen?.querySelector(".login-gate__form")).not.toBeNull();
+    screen?.querySelector<HTMLButtonElement>(".login-gate__form .login-gate__connect")?.click();
+    expect(onConnect).toHaveBeenCalledOnce();
+  });
+
+  it("emphasizes choosing a compatible gateway for a cross-origin mismatch", async () => {
+    const gate = await mount({ gatewayUrl: "wss://gateway.example.test" });
+    const screen = gate.querySelector('[data-kind="protocol-mismatch"]');
+
+    expect(screen?.textContent).toContain("This UI came from a different origin");
+    expect(screen?.textContent).toContain("Choose a compatible Gateway URL below");
+    expect(
+      screen?.querySelector<HTMLInputElement>('.login-gate__form input[inputmode="url"]'),
+    ).toHaveProperty("value", "wss://gateway.example.test");
   });
 });

--- a/ui/src/components/login-gate.test.ts
+++ b/ui/src/components/login-gate.test.ts
@@ -2,6 +2,7 @@
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ConnectErrorDetailCodes } from "../../../packages/gateway-protocol/src/connect-error-details.js";
+import { reloadWithComposerGuard } from "../app/stale-bundle.ts";
 import "./login-gate.ts";
 
 type LoginGateElement = HTMLElement & {
@@ -32,6 +33,7 @@ describe("LoginGate protocol mismatch", () => {
       onPasswordChange: () => undefined,
       onToggleGatewayToken: () => undefined,
       onToggleGatewayPassword: () => undefined,
+      onRefresh: () => undefined,
       onConnect: () => undefined,
       ...overrides,
     };
@@ -47,15 +49,43 @@ describe("LoginGate protocol mismatch", () => {
 
   it("keeps reconnect controls beside the primary same-origin refresh recovery", async () => {
     const onConnect = vi.fn();
-    const gate = await mount({ onConnect });
+    const onRefresh = vi.fn();
+    const gate = await mount({ onConnect, onRefresh });
 
     const screen = gate.querySelector('[data-kind="protocol-mismatch"]');
     expect(screen?.textContent).toContain("This app is out of date");
     expect(screen?.textContent).toContain("Refresh to load the Control UI served by this Gateway");
     expect(screen?.querySelector(".login-gate__protocol-refresh")).not.toBeNull();
     expect(screen?.querySelector(".login-gate__form")).not.toBeNull();
+    screen?.querySelector<HTMLButtonElement>(".login-gate__protocol-refresh")?.click();
     screen?.querySelector<HTMLButtonElement>(".login-gate__form .login-gate__connect")?.click();
+    expect(onRefresh).toHaveBeenCalledOnce();
     expect(onConnect).toHaveBeenCalledOnce();
+  });
+
+  it("flushes the composer and requires consent before protocol refresh discards attachments", async () => {
+    const prepareForStaleBundleReload = vi.fn(() => "attachments" as const);
+    const root = {
+      querySelectorAll: () => [{ prepareForStaleBundleReload }],
+    } as unknown as ParentNode;
+    const confirmDiscardAttachments = vi.fn(() => false);
+    const reload = vi.fn();
+    const gate = await mount({
+      onRefresh: () => {
+        reloadWithComposerGuard({ root, confirmDiscardAttachments, reload });
+      },
+    });
+    const refresh = gate.querySelector<HTMLButtonElement>(".login-gate__protocol-refresh");
+
+    refresh?.click();
+    expect(prepareForStaleBundleReload).toHaveBeenCalledOnce();
+    expect(confirmDiscardAttachments).toHaveBeenCalledOnce();
+    expect(reload).not.toHaveBeenCalled();
+
+    confirmDiscardAttachments.mockReturnValue(true);
+    refresh?.click();
+    expect(prepareForStaleBundleReload).toHaveBeenCalledTimes(2);
+    expect(reload).toHaveBeenCalledOnce();
   });
 
   it("emphasizes choosing a compatible gateway for a cross-origin mismatch", async () => {

--- a/ui/src/components/login-gate.test.ts
+++ b/ui/src/components/login-gate.test.ts
@@ -1,0 +1,44 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, describe, expect, it } from "vitest";
+import { ConnectErrorDetailCodes } from "../../../packages/gateway-protocol/src/connect-error-details.js";
+import "./login-gate.ts";
+
+type LoginGateElement = HTMLElement & {
+  props: Record<string, unknown>;
+  updateComplete: Promise<unknown>;
+};
+
+afterEach(() => document.body.replaceChildren());
+
+describe("LoginGate protocol mismatch", () => {
+  it("renders a blocking refresh screen instead of reconnect controls", async () => {
+    const gate = document.createElement("openclaw-login-gate") as LoginGateElement;
+    gate.props = {
+      basePath: "",
+      connected: false,
+      lastError: "protocol mismatch",
+      lastErrorCode: ConnectErrorDetailCodes.PROTOCOL_MISMATCH,
+      hasToken: false,
+      hasPassword: false,
+      gatewayUrl: "ws://127.0.0.1:18789",
+      token: "",
+      password: "",
+      showGatewayToken: false,
+      showGatewayPassword: false,
+      onGatewayUrlChange: () => undefined,
+      onTokenChange: () => undefined,
+      onPasswordChange: () => undefined,
+      onToggleGatewayToken: () => undefined,
+      onToggleGatewayPassword: () => undefined,
+      onConnect: () => undefined,
+    };
+    document.body.append(gate);
+    await gate.updateComplete;
+
+    const screen = gate.querySelector('[data-kind="protocol-mismatch"]');
+    expect(screen?.textContent).toContain("This app is out of date — refresh to continue");
+    expect(screen?.querySelector(".login-gate__protocol-refresh")).not.toBeNull();
+    expect(screen?.querySelector(".login-gate__form")).toBeNull();
+  });
+});

--- a/ui/src/components/login-gate.ts
+++ b/ui/src/components/login-gate.ts
@@ -295,6 +295,31 @@ function renderLoginFailure(feedback: LoginFailureFeedback) {
 function renderLoginGate(props: LoginGateProps) {
   const basePath = normalizeBasePath(props.basePath);
   const faviconSrc = controlUiPublicAssetPath("favicon.svg", basePath);
+  // This typed terminal decision cannot recover by retrying the same bundle;
+  // unlike ordinary connection failures, it intentionally offers refresh only.
+  if (props.lastErrorCode === ConnectErrorDetailCodes.PROTOCOL_MISMATCH) {
+    return html`
+      <div class="login-gate">
+        <div
+          class="login-gate__card login-gate__card--protocol-mismatch"
+          role="alert"
+          data-kind="protocol-mismatch"
+        >
+          <div class="login-gate__header">
+            <img class="login-gate__logo" src=${faviconSrc} alt="OpenClaw" />
+            <div class="login-gate__title">${t("login.failure.protocol.outOfDate")}</div>
+          </div>
+          <button
+            class="btn primary login-gate__connect login-gate__protocol-refresh"
+            type="button"
+            @click=${() => globalThis.location.reload()}
+          >
+            ${t("common.refresh")}
+          </button>
+        </div>
+      </div>
+    `;
+  }
   const failure = resolveLoginFailureFeedback({
     connected: props.connected,
     lastError: props.lastError,

--- a/ui/src/components/login-gate.ts
+++ b/ui/src/components/login-gate.ts
@@ -4,7 +4,7 @@ import { property } from "lit/decorators.js";
 import { ConnectErrorDetailCodes } from "../../../packages/gateway-protocol/src/connect-error-details.js";
 import { normalizeBasePath } from "../app-route-paths.ts";
 import { controlUiPublicAssetPath } from "../app/public-assets.ts";
-import { gatewayUrlMatchesDocumentOrigin } from "../app/stale-bundle.ts";
+import { gatewayUrlMatchesDocumentOrigin, reloadWithComposerGuard } from "../app/stale-bundle.ts";
 import { t } from "../i18n/index.ts";
 import {
   resolveAuthHintKind,
@@ -54,6 +54,7 @@ type LoginGateProps = {
   onPasswordChange: (value: string) => void;
   onToggleGatewayToken: () => void;
   onToggleGatewayPassword: () => void;
+  onRefresh?: () => void;
   onConnect: () => void;
 };
 
@@ -319,7 +320,7 @@ function renderLoginGate(props: LoginGateProps) {
           <button
             class="btn primary login-gate__connect login-gate__protocol-refresh"
             type="button"
-            @click=${() => globalThis.location.reload()}
+            @click=${() => (props.onRefresh ?? reloadWithComposerGuard)()}
           >
             ${t("common.refresh")}
           </button>

--- a/ui/src/components/login-gate.ts
+++ b/ui/src/components/login-gate.ts
@@ -4,6 +4,7 @@ import { property } from "lit/decorators.js";
 import { ConnectErrorDetailCodes } from "../../../packages/gateway-protocol/src/connect-error-details.js";
 import { normalizeBasePath } from "../app-route-paths.ts";
 import { controlUiPublicAssetPath } from "../app/public-assets.ts";
+import { gatewayUrlMatchesDocumentOrigin } from "../app/stale-bundle.ts";
 import { t } from "../i18n/index.ts";
 import {
   resolveAuthHintKind,
@@ -295,9 +296,8 @@ function renderLoginFailure(feedback: LoginFailureFeedback) {
 function renderLoginGate(props: LoginGateProps) {
   const basePath = normalizeBasePath(props.basePath);
   const faviconSrc = controlUiPublicAssetPath("favicon.svg", basePath);
-  // This typed terminal decision cannot recover by retrying the same bundle;
-  // unlike ordinary connection failures, it intentionally offers refresh only.
   if (props.lastErrorCode === ConnectErrorDetailCodes.PROTOCOL_MISMATCH) {
+    const sameOrigin = gatewayUrlMatchesDocumentOrigin(props.gatewayUrl);
     return html`
       <div class="login-gate">
         <div
@@ -308,6 +308,13 @@ function renderLoginGate(props: LoginGateProps) {
           <div class="login-gate__header">
             <img class="login-gate__logo" src=${faviconSrc} alt="OpenClaw" />
             <div class="login-gate__title">${t("login.failure.protocol.outOfDate")}</div>
+            <div class="login-gate__sub">
+              ${t(
+                sameOrigin
+                  ? "login.failure.protocol.sameOriginRecovery"
+                  : "login.failure.protocol.crossOriginRecovery",
+              )}
+            </div>
           </div>
           <button
             class="btn primary login-gate__connect login-gate__protocol-refresh"
@@ -316,6 +323,32 @@ function renderLoginGate(props: LoginGateProps) {
           >
             ${t("common.refresh")}
           </button>
+          <div class="login-gate__form">
+            <label class="field">
+              <span>${t("connection.access.wsUrl")}</span>
+              <input
+                inputmode="url"
+                autocapitalize="none"
+                autocorrect="off"
+                autocomplete="off"
+                spellcheck="false"
+                enterkeyhint="go"
+                .value=${props.gatewayUrl}
+                @input=${(event: Event) => {
+                  props.onGatewayUrlChange((event.target as HTMLInputElement).value);
+                }}
+                @keydown=${(event: KeyboardEvent) => {
+                  if (event.key === "Enter") {
+                    props.onConnect();
+                  }
+                }}
+                placeholder="ws://127.0.0.1:18789"
+              />
+            </label>
+            <button class="btn login-gate__connect" type="button" @click=${props.onConnect}>
+              ${t("common.connect")}
+            </button>
+          </div>
         </div>
       </div>
     `;

--- a/ui/src/components/sidebar-stale-bundle-card.test.ts
+++ b/ui/src/components/sidebar-stale-bundle-card.test.ts
@@ -1,6 +1,7 @@
 /* @vitest-environment jsdom */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveStaleBundleReloadPair } from "../app/stale-bundle.ts";
 import { createStorageMock } from "../test-helpers/storage.ts";
 import { STALE_BUNDLE_DISMISS_KEY } from "./sidebar-stale-bundle-card.ts";
 
@@ -43,6 +44,27 @@ describe("SidebarStaleBundleCard", () => {
   it("renders nothing without a mismatch version", async () => {
     const element = await mount(null);
     expect(element.querySelector(".sidebar-stale-bundle")).toBeNull();
+  });
+
+  it("shows only same-origin actionable mismatches", async () => {
+    const input = {
+      bundleVersion: "2026.7.10",
+      gatewayVersion: "2026.7.11",
+      documentHref: "https://team.openclaw.ai/chat",
+    };
+    const sameOrigin = resolveStaleBundleReloadPair({
+      ...input,
+      gatewayUrl: "wss://team.openclaw.ai/gateway",
+    });
+    const crossOrigin = resolveStaleBundleReloadPair({
+      ...input,
+      gatewayUrl: "wss://gateway.example.test",
+    });
+
+    const sameOriginCard = await mount(sameOrigin?.gatewayVersion ?? null);
+    const crossOriginCard = await mount(crossOrigin?.gatewayVersion ?? null);
+    expect(sameOriginCard.querySelector(".sidebar-stale-bundle")).not.toBeNull();
+    expect(crossOriginCard.querySelector(".sidebar-stale-bundle")).toBeNull();
   });
 
   it("forwards the Refresh action", async () => {

--- a/ui/src/components/sidebar-stale-bundle-card.test.ts
+++ b/ui/src/components/sidebar-stale-bundle-card.test.ts
@@ -3,7 +3,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveStaleBundleReloadPair } from "../app/stale-bundle.ts";
 import { createStorageMock } from "../test-helpers/storage.ts";
-import { STALE_BUNDLE_DISMISS_KEY } from "./sidebar-stale-bundle-card.ts";
+import "./sidebar-stale-bundle-card.ts";
+
+// Mirrors the module-local key so persistence is tested without exporting internals.
+const DISMISS_STORAGE_KEY = "openclaw:control-ui:stale-bundle-dismissed:v1";
 
 type SidebarStaleBundleCardElement = HTMLElement & {
   gatewayVersion: string | null;
@@ -82,7 +85,7 @@ describe("SidebarStaleBundleCard", () => {
     element.querySelector<HTMLButtonElement>(".sidebar-stale-bundle__dismiss")?.click();
     await element.updateComplete;
 
-    expect(JSON.parse(localStorage.getItem(STALE_BUNDLE_DISMISS_KEY) ?? "null")).toMatchObject({
+    expect(JSON.parse(localStorage.getItem(DISMISS_STORAGE_KEY) ?? "null")).toMatchObject({
       gatewayVersion: "2026.7.11",
     });
     expect(element.querySelector(".sidebar-stale-bundle")).toBeNull();

--- a/ui/src/components/sidebar-stale-bundle-card.test.ts
+++ b/ui/src/components/sidebar-stale-bundle-card.test.ts
@@ -1,0 +1,73 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createStorageMock } from "../test-helpers/storage.ts";
+import { STALE_BUNDLE_DISMISS_KEY } from "./sidebar-stale-bundle-card.ts";
+
+type SidebarStaleBundleCardElement = HTMLElement & {
+  gatewayVersion: string | null;
+  onRefresh: () => void;
+  updateComplete: Promise<unknown>;
+};
+
+async function mount(gatewayVersion: string | null) {
+  const element = document.createElement(
+    "openclaw-sidebar-stale-bundle-card",
+  ) as SidebarStaleBundleCardElement;
+  element.gatewayVersion = gatewayVersion;
+  document.body.append(element);
+  await element.updateComplete;
+  return element;
+}
+
+describe("SidebarStaleBundleCard", () => {
+  beforeEach(() => {
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      value: createStorageMock(),
+    });
+  });
+
+  afterEach(() => {
+    document.body.replaceChildren();
+    vi.restoreAllMocks();
+  });
+
+  it("shows the refresh nudge for a mismatched gateway version", async () => {
+    const element = await mount("2026.7.11");
+    expect(element.querySelector(".sidebar-stale-bundle")?.textContent).toContain(
+      "Server updated — refresh for the latest features.",
+    );
+  });
+
+  it("renders nothing without a mismatch version", async () => {
+    const element = await mount(null);
+    expect(element.querySelector(".sidebar-stale-bundle")).toBeNull();
+  });
+
+  it("forwards the Refresh action", async () => {
+    const element = await mount("2026.7.11");
+    const onRefresh = vi.fn();
+    element.onRefresh = onRefresh;
+    await element.updateComplete;
+
+    element.querySelector<HTMLButtonElement>(".sidebar-stale-bundle__refresh")?.click();
+    expect(onRefresh).toHaveBeenCalledOnce();
+  });
+
+  it("persists dismissal per gateway version and re-nudges after another upgrade", async () => {
+    const element = await mount("2026.7.11");
+    element.querySelector<HTMLButtonElement>(".sidebar-stale-bundle__dismiss")?.click();
+    await element.updateComplete;
+
+    expect(JSON.parse(localStorage.getItem(STALE_BUNDLE_DISMISS_KEY) ?? "null")).toMatchObject({
+      gatewayVersion: "2026.7.11",
+    });
+    expect(element.querySelector(".sidebar-stale-bundle")).toBeNull();
+
+    const dismissedReplacement = await mount("2026.7.11");
+    expect(dismissedReplacement.querySelector(".sidebar-stale-bundle")).toBeNull();
+    const newerReplacement = await mount("2026.7.12");
+    expect(newerReplacement.querySelector(".sidebar-stale-bundle")).not.toBeNull();
+  });
+});

--- a/ui/src/components/sidebar-stale-bundle-card.ts
+++ b/ui/src/components/sidebar-stale-bundle-card.ts
@@ -5,7 +5,7 @@ import { OpenClawLightDomContentsElement } from "../lit/openclaw-element.ts";
 import { getSafeLocalStorage } from "../local-storage.ts";
 import { icons } from "./icons.ts";
 
-export const STALE_BUNDLE_DISMISS_KEY = "openclaw:control-ui:stale-bundle-dismissed:v1";
+const STALE_BUNDLE_DISMISS_KEY = "openclaw:control-ui:stale-bundle-dismissed:v1";
 
 type DismissedStaleBundle = {
   gatewayVersion: string;

--- a/ui/src/components/sidebar-stale-bundle-card.ts
+++ b/ui/src/components/sidebar-stale-bundle-card.ts
@@ -38,9 +38,7 @@ function dismiss(gatewayVersion: string): void {
 
 class SidebarStaleBundleCard extends OpenClawLightDomContentsElement {
   @property({ attribute: false }) gatewayVersion: string | null = null;
-  // Explicit user action reloads immediately; only the unattended Tier-2 path
-  // requires lossless composer preparation before it may reload.
-  @property({ attribute: false }) onRefresh: () => void = () => globalThis.location.reload();
+  @property({ attribute: false }) onRefresh: () => void = () => undefined;
   @state() private dismissedGatewayVersion: string | null = null;
 
   override render() {

--- a/ui/src/components/sidebar-stale-bundle-card.ts
+++ b/ui/src/components/sidebar-stale-bundle-card.ts
@@ -1,0 +1,79 @@
+import { html, nothing } from "lit";
+import { property, state } from "lit/decorators.js";
+import { t } from "../i18n/index.ts";
+import { OpenClawLightDomContentsElement } from "../lit/openclaw-element.ts";
+import { getSafeLocalStorage } from "../local-storage.ts";
+import { icons } from "./icons.ts";
+
+export const STALE_BUNDLE_DISMISS_KEY = "openclaw:control-ui:stale-bundle-dismissed:v1";
+
+type DismissedStaleBundle = {
+  gatewayVersion: string;
+  dismissedAtMs: number;
+};
+
+function isDismissed(gatewayVersion: string): boolean {
+  try {
+    const raw = getSafeLocalStorage()?.getItem(STALE_BUNDLE_DISMISS_KEY);
+    if (!raw) {
+      return false;
+    }
+    const dismissed = JSON.parse(raw) as Partial<DismissedStaleBundle>;
+    return dismissed.gatewayVersion === gatewayVersion;
+  } catch {
+    return false;
+  }
+}
+
+function dismiss(gatewayVersion: string): void {
+  try {
+    getSafeLocalStorage()?.setItem(
+      STALE_BUNDLE_DISMISS_KEY,
+      JSON.stringify({ gatewayVersion, dismissedAtMs: Date.now() } satisfies DismissedStaleBundle),
+    );
+  } catch {
+    // Dismissal persistence is best effort; this card still hides for the current mount.
+  }
+}
+
+class SidebarStaleBundleCard extends OpenClawLightDomContentsElement {
+  @property({ attribute: false }) gatewayVersion: string | null = null;
+  // Explicit user action reloads immediately; only the unattended Tier-2 path
+  // requires lossless composer preparation before it may reload.
+  @property({ attribute: false }) onRefresh: () => void = () => globalThis.location.reload();
+  @state() private dismissedGatewayVersion: string | null = null;
+
+  override render() {
+    const gatewayVersion = this.gatewayVersion;
+    if (
+      !gatewayVersion ||
+      this.dismissedGatewayVersion === gatewayVersion ||
+      isDismissed(gatewayVersion)
+    ) {
+      return nothing;
+    }
+    return html`
+      <div class="sidebar-stale-bundle" role="status" aria-live="polite">
+        <span class="sidebar-stale-bundle__text">${t("chat.sidebar.staleBundle")}</span>
+        <button class="sidebar-stale-bundle__refresh" type="button" @click=${this.onRefresh}>
+          ${t("common.refresh")}
+        </button>
+        <button
+          class="sidebar-stale-bundle__dismiss"
+          type="button"
+          aria-label=${t("common.dismiss")}
+          @click=${() => {
+            this.dismissedGatewayVersion = gatewayVersion;
+            dismiss(gatewayVersion);
+          }}
+        >
+          ${icons.x}
+        </button>
+      </div>
+    `;
+  }
+}
+
+if (!customElements.get("openclaw-sidebar-stale-bundle-card")) {
+  customElements.define("openclaw-sidebar-stale-bundle-card", SidebarStaleBundleCard);
+}

--- a/ui/src/e2e/login-gate.e2e.test.ts
+++ b/ui/src/e2e/login-gate.e2e.test.ts
@@ -50,6 +50,7 @@ async function mountLoginGate(page: Page): Promise<void> {
       onPasswordChange: () => {},
       onToggleGatewayToken: () => {},
       onToggleGatewayPassword: () => {},
+      onRefresh: () => {},
       onConnect: () => {
         const current = Number.parseInt(document.body.dataset.connectCount ?? "0", 10);
         document.body.dataset.connectCount = String(current + 1);

--- a/ui/src/e2e/login-gate.e2e.test.ts
+++ b/ui/src/e2e/login-gate.e2e.test.ts
@@ -95,11 +95,10 @@ describeControlUiE2e("Control UI responsive login gate E2E", () => {
         details: { code: ConnectErrorDetailCodes.PROTOCOL_MISMATCH },
       });
 
-      const failure = page.locator(".login-gate__failure-summary");
+      const failure = page.locator('[data-kind="protocol-mismatch"]');
       await failure.waitFor({ timeout: 10_000 });
-      expect((await failure.textContent())?.toLowerCase()).toContain(
-        "supported connection protocol",
-      );
+      expect((await failure.textContent())?.toLowerCase()).toContain("refresh to continue");
+      expect(await failure.locator(".login-gate__form").count()).toBe(0);
       await page.clock.runFor(1_600);
       expect(await gateway.getRequests("connect")).toHaveLength(1);
     } finally {

--- a/ui/src/e2e/login-gate.e2e.test.ts
+++ b/ui/src/e2e/login-gate.e2e.test.ts
@@ -97,8 +97,8 @@ describeControlUiE2e("Control UI responsive login gate E2E", () => {
 
       const failure = page.locator('[data-kind="protocol-mismatch"]');
       await failure.waitFor({ timeout: 10_000 });
-      expect((await failure.textContent())?.toLowerCase()).toContain("refresh to continue");
-      expect(await failure.locator(".login-gate__form").count()).toBe(0);
+      expect((await failure.textContent())?.toLowerCase()).toContain("this app is out of date");
+      expect(await failure.locator(".login-gate__form").count()).toBe(1);
       await page.clock.runFor(1_600);
       expect(await gateway.getRequests("connect")).toHaveLength(1);
     } finally {

--- a/ui/src/i18n/.i18n/raw-copy-baseline.json
+++ b/ui/src/i18n/.i18n/raw-copy-baseline.json
@@ -86,7 +86,7 @@
       "text": "OPENCLAW_GATEWAY_TOKEN ("
     },
     {
-      "count": 1,
+      "count": 2,
       "kind": "html-attribute",
       "name": "placeholder",
       "path": "ui/src/components/login-gate.ts",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -3590,6 +3590,7 @@ export const en: TranslationMap = {
       },
       protocol: {
         title: "Protocol mismatch",
+        outOfDate: "This app is out of date — refresh to continue",
         summary:
           "The served Control UI and the running Gateway do not agree on the supported connection protocol.",
         stepDashboard:
@@ -3793,6 +3794,7 @@ export const en: TranslationMap = {
       updateAvailable: "Update available",
       updateMacAndGateway: "Update Mac app + Gateway",
       updateGateway: "Update Gateway",
+      staleBundle: "Server updated — refresh for the latest features.",
       allSessions: "All threads",
       threads: "Threads",
       groups: "Groups",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -3590,7 +3590,11 @@ export const en: TranslationMap = {
       },
       protocol: {
         title: "Protocol mismatch",
-        outOfDate: "This app is out of date — refresh to continue",
+        outOfDate: "This app is out of date",
+        sameOriginRecovery:
+          "Refresh to load the Control UI served by this Gateway, or connect to a different compatible Gateway below.",
+        crossOriginRecovery:
+          "This UI came from a different origin. Choose a compatible Gateway URL below, or refresh if this host was updated.",
         summary:
           "The served Control UI and the running Gateway do not agree on the supported connection protocol.",
         stepDashboard:
@@ -3795,6 +3799,8 @@ export const en: TranslationMap = {
       updateMacAndGateway: "Update Mac app + Gateway",
       updateGateway: "Update Gateway",
       staleBundle: "Server updated — refresh for the latest features.",
+      discardAttachmentsForRefresh:
+        "Refreshing will discard staged attachments that have not been sent. Refresh anyway?",
       allSessions: "All threads",
       threads: "Threads",
       groups: "Groups",

--- a/ui/src/pages/chat/chat-pane.test-support.ts
+++ b/ui/src/pages/chat/chat-pane.test-support.ts
@@ -9,19 +9,24 @@ import type {
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { GatewaySessionRow } from "../../api/types.ts";
 import type { ApplicationContext } from "../../app/context.ts";
+import type { StaleBundleReloadPreparation } from "../../app/stale-bundle.ts";
 import type { CatalogSessionKey } from "../../lib/sessions/catalog-key.ts";
-import type { SessionCapability } from "../../lib/sessions/index.ts";
 import "./chat-pane.ts";
+import type { SessionCapability } from "../../lib/sessions/index.ts";
 import type { ChatPageHost } from "./chat-state.ts";
 import { createBackgroundTasksProps } from "./components/chat-background-tasks.ts";
 import { createSessionWorkspaceProps } from "./components/chat-session-workspace.ts";
+import type { ChatComposerPersistResult } from "./composer-persistence.ts";
 import type { ChatMessageCache } from "./session-message-cache.ts";
 
 export type TestChatPane = HTMLElement & {
   catalogMessages: unknown[];
   active: boolean;
   chatMessagesBySession?: ChatMessageCache;
-  chatState: { attach: (state: ChatPageHost) => void };
+  chatState: {
+    attach: (state: ChatPageHost) => void;
+    persistComposerForReload: () => ChatComposerPersistResult;
+  };
   context: ApplicationContext;
   state: ChatPageHost;
   connectedClient: GatewayBrowserClient | null;
@@ -38,6 +43,7 @@ export type TestChatPane = HTMLElement & {
   onPaneSessionChange?: (paneId: string, sessionKey: string) => void;
   sessionKey: string;
   paneTitle: string;
+  prepareForStaleBundleReload: () => StaleBundleReloadPreparation;
   catalogSession: SessionCatalogSession | null;
   catalogItemMessage: (item: SessionCatalogTranscriptItem) => Record<string, unknown> | null;
   handleTranscriptScroll: (event: Event) => void;

--- a/ui/src/pages/chat/chat-pane.test.ts
+++ b/ui/src/pages/chat/chat-pane.test.ts
@@ -61,6 +61,37 @@ function dispatchSidebarShortcut(pane: TestChatPane, shiftKey = true) {
   return event;
 }
 
+describe("chat pane stale-bundle reload preparation", () => {
+  it("flushes text drafts and reports staged attachments separately", () => {
+    const { pane, state } = createTestChatPane({
+      client: {} as GatewayBrowserClient,
+      sessions: {} as SessionCapability,
+    });
+    const persist = vi
+      .spyOn(pane.chatState, "persistComposerForReload")
+      .mockReturnValue({ status: "persisted" });
+    state.chatAttachments = [];
+
+    expect(pane.prepareForStaleBundleReload()).toBe("ready");
+    expect(persist).toHaveBeenCalledOnce();
+
+    state.chatAttachments = [{} as ChatPageHost["chatAttachments"][number]];
+    expect(pane.prepareForStaleBundleReload()).toBe("attachments");
+  });
+
+  it("blocks reload when draft persistence does not commit", () => {
+    const { pane } = createTestChatPane({
+      client: {} as GatewayBrowserClient,
+      sessions: {} as SessionCapability,
+    });
+    vi.spyOn(pane.chatState, "persistComposerForReload").mockReturnValue({
+      status: "conflict",
+    });
+
+    expect(pane.prepareForStaleBundleReload()).toBe("blocked");
+  });
+});
+
 function createInitializationContext(): ApplicationContext {
   return {
     basePath: "",

--- a/ui/src/pages/chat/chat-pane.ts
+++ b/ui/src/pages/chat/chat-pane.ts
@@ -46,6 +46,7 @@ import {
   type QuestionPrompt,
 } from "../../app/question-prompt.ts";
 import { loadSettings, patchSettings } from "../../app/settings.ts";
+import type { StaleBundleReloadPreparation } from "../../app/stale-bundle.ts";
 import {
   BROWSER_ANNOTATION_EVENT,
   type BrowserAnnotationDraft,
@@ -2276,17 +2277,17 @@ class ChatPane extends OpenClawLightDomElement {
     super.disconnectedCallback();
   }
 
-  prepareForStaleBundleReload(): boolean {
+  prepareForStaleBundleReload(): StaleBundleReloadPreparation {
     const state = this.state;
     if (!state) {
-      return true;
+      return "ready";
     }
-    // Text drafts have a crash-safe localStorage restore path. Attachments do not,
-    // so an idle refresh must wait until staged files are sent or removed.
-    if (state.chatAttachments.length > 0) {
-      return false;
+    if (this.chatState.persistComposerForReload().status !== "persisted") {
+      return "blocked";
     }
-    return this.chatState.persistComposerForReload().status === "persisted";
+    // Text drafts are now durable. Attachments have no restore path, so the
+    // caller must either wait (idle reload) or obtain explicit discard consent.
+    return state.chatAttachments.length > 0 ? "attachments" : "ready";
   }
 
   private applySessionsState(stateValue: ApplicationContext["sessions"]["state"]) {

--- a/ui/src/pages/chat/chat-pane.ts
+++ b/ui/src/pages/chat/chat-pane.ts
@@ -2276,6 +2276,19 @@ class ChatPane extends OpenClawLightDomElement {
     super.disconnectedCallback();
   }
 
+  prepareForStaleBundleReload(): boolean {
+    const state = this.state;
+    if (!state) {
+      return true;
+    }
+    // Text drafts have a crash-safe localStorage restore path. Attachments do not,
+    // so an idle refresh must wait until staged files are sent or removed.
+    if (state.chatAttachments.length > 0) {
+      return false;
+    }
+    return this.chatState.persistComposerForReload().status === "persisted";
+  }
+
   private applySessionsState(stateValue: ApplicationContext["sessions"]["state"]) {
     const state = this.state;
     if (!state) {

--- a/ui/src/pages/chat/chat-state.ts
+++ b/ui/src/pages/chat/chat-state.ts
@@ -1886,6 +1886,10 @@ export class ChatStateController<TState extends ChatPageHost> implements Reactiv
     return this.composerPersistence.persistForRouteSwitchResult();
   }
 
+  persistComposerForReload(): ChatComposerPersistResult {
+    return this.composerPersistence.persistForRouteSwitchResult();
+  }
+
   composerScopeForRouteSwitch(): StoredChatOutboxScope | null {
     return this.composerPersistence.scopeForRouteSwitch();
   }

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -124,6 +124,10 @@
   font-weight: 600;
 }
 
+.login-gate__protocol-refresh {
+  margin-bottom: 12px;
+}
+
 .login-gate__failure {
   margin-top: 14px;
 }

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -3049,6 +3049,68 @@ wa-dropdown.sidebar-session-sort-menu::part(menu) {
   padding: 6px 12px;
 }
 
+.sidebar-stale-bundle {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 6px;
+  margin: 0 8px 4px;
+  padding: 5px 7px 5px 9px;
+  border: 1px solid color-mix(in srgb, var(--accent) 18%, var(--border));
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--accent-subtle) 38%, var(--bg-elevated));
+  color: var(--text);
+  font-size: 11px;
+  line-height: 1.25;
+}
+
+.sidebar-stale-bundle__text {
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.sidebar-stale-bundle__refresh,
+.sidebar-stale-bundle__dismiss {
+  flex: none;
+  border: 0;
+  background: transparent;
+  color: var(--accent);
+  cursor: pointer;
+}
+
+.sidebar-stale-bundle__refresh {
+  padding: 2px 3px;
+  font: inherit;
+  font-weight: 650;
+}
+
+.sidebar-stale-bundle__dismiss {
+  display: inline-flex;
+  width: 22px;
+  height: 22px;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border-radius: var(--radius-sm);
+  color: var(--muted);
+}
+
+.sidebar-stale-bundle__refresh:hover,
+.sidebar-stale-bundle__refresh:focus-visible,
+.sidebar-stale-bundle__dismiss:hover,
+.sidebar-stale-bundle__dismiss:focus-visible {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+
+.sidebar-stale-bundle__dismiss svg {
+  width: 14px;
+  height: 14px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.8px;
+}
+
 .sidebar-footer-bar__logo {
   width: 18px;
   height: 18px;

--- a/ui/src/test-helpers/app-sidebar-cases/basics.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/basics.ts
@@ -45,11 +45,17 @@ describe("AppSidebar update card wiring", () => {
   it("renders a stale-bundle nudge immediately above the slim footer bar", async () => {
     const gateway = createGateway({} as GatewayBrowserClient);
     const { sidebar } = await mountSidebar(gateway, createSessions("main", ["agent:main:main"]));
+    const onRefresh = vi.fn();
     sidebar.staleBundleGatewayVersion = "2026.7.11";
+    sidebar.onRefreshStaleBundle = onRefresh;
     await sidebar.updateComplete;
 
     const footerBar = sidebar.querySelector(".sidebar-footer-bar");
     expect(footerBar?.previousElementSibling?.localName).toBe("openclaw-sidebar-stale-bundle-card");
+    footerBar?.previousElementSibling
+      ?.querySelector<HTMLButtonElement>(".sidebar-stale-bundle__refresh")
+      ?.click();
+    expect(onRefresh).toHaveBeenCalledOnce();
   });
 });
 

--- a/ui/src/test-helpers/app-sidebar-cases/basics.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/basics.ts
@@ -41,6 +41,16 @@ describe("AppSidebar update card wiring", () => {
     card?.querySelector<HTMLButtonElement>(".sidebar-update-card__action")?.click();
     expect(onUpdate).toHaveBeenCalledOnce();
   });
+
+  it("renders a stale-bundle nudge immediately above the slim footer bar", async () => {
+    const gateway = createGateway({} as GatewayBrowserClient);
+    const { sidebar } = await mountSidebar(gateway, createSessions("main", ["agent:main:main"]));
+    sidebar.staleBundleGatewayVersion = "2026.7.11";
+    await sidebar.updateComplete;
+
+    const footerBar = sidebar.querySelector(".sidebar-footer-bar");
+    expect(footerBar?.previousElementSibling?.localName).toBe("openclaw-sidebar-stale-bundle-card");
+  });
 });
 
 describe("AppSidebar viewer presence", () => {

--- a/ui/src/test-helpers/app-sidebar.ts
+++ b/ui/src/test-helpers/app-sidebar.ts
@@ -29,6 +29,7 @@ export type SidebarLifecycleState = HTMLElement & {
   activeRouteId?: string;
   connected: boolean;
   staleBundleGatewayVersion: string | null;
+  onRefreshStaleBundle: () => void;
   terminalAvailable: boolean;
   catalogOpenTarget: "viewer" | "terminal";
   canPairDevice: boolean;

--- a/ui/src/test-helpers/app-sidebar.ts
+++ b/ui/src/test-helpers/app-sidebar.ts
@@ -28,6 +28,7 @@ type SessionState = SessionCapability["state"];
 export type SidebarLifecycleState = HTMLElement & {
   activeRouteId?: string;
   connected: boolean;
+  staleBundleGatewayVersion: string | null;
   terminalAvailable: boolean;
   catalogOpenTarget: "viewer" | "terminal";
   canPairDevice: boolean;

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -855,20 +855,7 @@ function installControlUiMockGateway(input: {
           protocol: protocolVersion,
           server: { connId: "control-ui-e2e", version: scenario.serverVersion },
           snapshot: {
-<<<<<<< HEAD
             ...presenceSnapshot(params),
-||||||| parent of 46d3ae04955 (feat(ui): nudge stale tabs to refresh after gateway upgrade)
-=======
-            presence: [
-              {
-                instanceId: "mock-gateway",
-                mode: "gateway",
-                reason: "self",
-                ts: Date.now(),
-                version: scenario.serverVersion,
-              },
-            ],
->>>>>>> 46d3ae04955 (feat(ui): nudge stale tabs to refresh after gateway upgrade)
             sessionDefaults: {
               defaultAgentId: scenario.defaultAgentId,
               mainKey: "main",

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -93,6 +93,7 @@ export type ControlUiMockGatewayScenario = {
     available?: boolean;
   }>;
   sessionKey?: string;
+  serverVersion?: string;
   /** Initial gateway-owned custom group catalog (sessions.groups.*), in order. */
   sessionGroups?: string[];
   terminalEnabled?: boolean;
@@ -285,6 +286,7 @@ function normalizeScenario(
     sessionInfo: scenario.sessionInfo ?? null,
     sessionArchiveFiltering: scenario.sessionArchiveFiltering ?? false,
     sessionKey,
+    serverVersion: scenario.serverVersion?.trim() || "e2e",
     sessionGroups: scenario.sessionGroups ?? [],
     terminalEnabled: scenario.terminalEnabled ?? false,
     workspaceGit: scenario.workspaceGit ?? false,
@@ -302,7 +304,7 @@ export function createControlUiMockBootstrapConfig(scenario: ControlUiMockGatewa
     devGitBranch: normalizedScenario.devGitBranch || undefined,
     embedSandbox: "scripts",
     localMediaPreviewRoots: [],
-    serverVersion: "e2e",
+    serverVersion: normalizedScenario.serverVersion,
     terminalEnabled: normalizedScenario.terminalEnabled,
   };
 }
@@ -598,28 +600,33 @@ function installControlUiMockGateway(input: {
   /** Presence slice of the connect snapshot. The self-flagged entry adopts the
    * connecting client's instanceId so presence surfaces resolve "you". */
   function presenceSnapshot(connectParams: unknown): { presence?: unknown[] } {
-    if (scenario.presenceUsers.length === 0) {
-      return {};
-    }
     const client = isRecord(connectParams) ? connectParams.client : undefined;
     const selfInstanceId =
       isRecord(client) && typeof client.instanceId === "string"
         ? client.instanceId
         : "e2e-self-instance";
-    return {
-      presence: scenario.presenceUsers.map((user, index) => ({
-        instanceId: user.self ? selfInstanceId : `e2e-presence-${index}`,
-        mode: "webchat",
-        reason: "connect",
-        user: {
-          id: user.id,
-          name: user.name ?? null,
-          email: user.email ?? null,
-          avatarUrl: user.avatarUrl ?? null,
-        },
-        watchedSessions: user.watchedSessions ?? [],
-      })),
+    // The gateway self entry carries the server version the stale-bundle detector
+    // compares against the loaded bundle; keep it alongside any human presence users.
+    const gatewaySelf = {
+      instanceId: "mock-gateway",
+      mode: "gateway",
+      reason: "self",
+      ts: Date.now(),
+      version: scenario.serverVersion,
     };
+    const users = scenario.presenceUsers.map((user, index) => ({
+      instanceId: user.self ? selfInstanceId : `e2e-presence-${index}`,
+      mode: "webchat",
+      reason: "connect",
+      user: {
+        id: user.id,
+        name: user.name ?? null,
+        email: user.email ?? null,
+        avatarUrl: user.avatarUrl ?? null,
+      },
+      watchedSessions: user.watchedSessions ?? [],
+    }));
+    return { presence: [gatewaySelf, ...users] };
   }
 
   function recordSessionPatch(params: unknown): void {
@@ -846,9 +853,22 @@ function installControlUiMockGateway(input: {
           },
           controlUiTabs: scenario.controlUiTabs,
           protocol: protocolVersion,
-          server: { connId: "control-ui-e2e", version: "e2e" },
+          server: { connId: "control-ui-e2e", version: scenario.serverVersion },
           snapshot: {
+<<<<<<< HEAD
             ...presenceSnapshot(params),
+||||||| parent of 46d3ae04955 (feat(ui): nudge stale tabs to refresh after gateway upgrade)
+=======
+            presence: [
+              {
+                instanceId: "mock-gateway",
+                mode: "gateway",
+                reason: "self",
+                ts: Date.now(),
+                version: scenario.serverVersion,
+              },
+            ],
+>>>>>>> 46d3ae04955 (feat(ui): nudge stale tabs to refresh after gateway upgrade)
             sessionDefaults: {
               defaultAgentId: scenario.defaultAgentId,
               mainKey: "main",


### PR DESCRIPTION
## What Problem This Solves

A gateway in-place upgrade replaces `ui/dist`, but a browser tab loaded before the upgrade keeps running its OLD bundle. On auto-reconnect that tab re-advertises the old bundle's client capability list, so newer capability-gated agent tools (e.g. `show_widget`, gated by `inline-widgets`) silently vanish from runs driven by that tab — the user reads it as "the tool is disabled," not "I need to refresh." Observed live on team.openclaw.ai: an agent lost `show_widget` because the operator's tab predated the morning's deploy. The existing `stale-chunk-reload.ts` only recovers reactively when a lazy chunk 404s on navigation; the capability-degradation case never 404s, so nothing fired.

## Why This Change Was Made

A three-tier staleness response, keyed on comparing the connected gateway's version (from the presence self entry in every snapshot) against this tab's `CONTROL_UI_BUILD_INFO.version`. No new protocol fields, no config.

- **Tier 1 — passive banner (active user).** A slim, neutral card in the sidebar footer (next to the identity chip / version / settings — bottom-left), "Server updated — refresh for the latest features." with a Refresh action. Dismissible; dismissal is keyed on the gateway version so a later upgrade re-nudges. Never red, never blocking.
- **Tier 2 — idle auto-reload (lossless).** After 5 minutes of no pointer/key/focus/visibility activity, the tab reloads itself — but only when it is not visible+focused, and only after synchronously persisting any composer text draft through the existing composer storage. Attachments (no crash-safe restore) block the auto-reload; a dismissed Tier-1 banner does not (it's lossless). Foreground activity always resets the idle window.
- **Tier 3 — protocol-reject screen.** The already-terminal `PROTOCOL_MISMATCH` path now renders an explicit "refresh to continue" blocking screen instead of a silently dead/retrying connection. Ordinary reconnects are unchanged.

Complementary to `stale-chunk-reload.ts` (which handles the 404-on-navigation case) — this covers the capability-degradation case it never reached.

## User Impact

Users on a tab that outlived a server upgrade get a clear, dismissible nudge; idle tabs quietly self-heal without losing composer text; and truly incompatible clients get an actionable screen instead of a dead app. Fresh tabs see nothing new.

## Evidence

Before (fresh tab, versions match — no banner) / after (stale bundle — banner in footer):

| Fresh (no banner) | Stale (banner) |
|---|---|
| ![fresh](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/540adf5289ab/ui-refresh-nudge/fresh-nobanner-footer.png) | ![stale](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/540adf5289ab/ui-refresh-nudge/stale-banner-footer.png) |

Full sidebar with the banner:

![stale sidebar](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/540adf5289ab/ui-refresh-nudge/stale-banner.png)

- Focused suites (`node scripts/run-vitest.mjs`): `stale-bundle.test.ts`, `sidebar-stale-bundle-card.test.ts`, `login-gate.test.ts` — green (mismatch→banner, match→none, dismissal persists per gateway version and re-nudges on a new one, idle reload fires only when composer empty + tab idle, active/visible never reloads, protocol-mismatch→blocking screen). 209 focused UI tests green on Testbox.
- Screenshots captured from `pnpm dev:ui:mock -- --stale-bundle` (bundle 2026.7.10 vs gateway snapshot 2026.7.11).
- Structured autoreview (codex/gpt-5.6-sol, xhigh): converged over four rounds — self-presence signal, **same-origin gating** (a refresh only helps when this tab's bundle is served by the connected gateway; cross-origin UI↔gateway setups get no nudge and no auto-reload loop), and **unified composer-state preservation**: every user-triggered reload (sidebar Refresh, protocol-mismatch Refresh) and the idle path route through one `reloadWithComposerGuard` helper — text drafts persist, staged attachments require consent (manual) or block the reload (idle), single `location.reload()` in the feature. Final pass clean ("patch is correct").
