### PR TITLE
fix(voice-call): bound diagnostic JSONL reads to prevent OOM on large logs

### DIFF
--- a/docs/cli/voicecall.md
+++ b/docs/cli/voicecall.md
@@ -174,10 +174,12 @@ openclaw voicecall status --call-id <id>
 Tail the voice-call JSONL log. Prints the last `--since` lines on start, then
 streams new lines as they are written.
 
-For custom diagnostic JSONL paths, startup reads retain only the newest 1 MB to
-avoid loading oversized logs into memory. When older bytes or a leading partial
-record are omitted, the command writes a warning to stderr and then follows new
-complete records from the retained window.
+When `--file` points to an existing custom diagnostic JSONL path whose basename
+is not `calls.jsonl`, startup reads retain only the newest 1 MB to avoid loading
+oversized logs into memory. When older bytes or a leading partial record are
+omitted, the command writes a warning to stderr and then follows new complete
+records from the retained window. The managed `calls.jsonl` path continues to
+use the SQLite-backed history.
 
 | Flag            | Default                    | Description                    |
 | --------------- | -------------------------- | ------------------------------ |
@@ -190,9 +192,11 @@ complete records from the retained window.
 Summarize turn-latency and listen-wait metrics from `calls.jsonl`. Output is
 JSON with `recordsScanned`, `turnLatency`, and `listenWait` summaries.
 
-For custom diagnostic JSONL paths, only the newest 1 MB is scanned. If the
-retained window omits earlier records, stderr reports that the summary covers
-the retained records rather than the full file history.
+When `--file` points to an existing custom diagnostic JSONL path whose basename
+is not `calls.jsonl`, only the newest 1 MB is scanned. If the retained window
+omits earlier records, stderr reports that the summary covers the retained
+records rather than the full file history. The managed `calls.jsonl` path
+continues to use the SQLite-backed history.
 
 | Flag            | Default                    | Description                          |
 | --------------- | -------------------------- | ------------------------------------ |

--- a/docs/cli/voicecall.md
+++ b/docs/cli/voicecall.md
@@ -174,6 +174,11 @@ openclaw voicecall status --call-id <id>
 Tail the voice-call JSONL log. Prints the last `--since` lines on start, then
 streams new lines as they are written.
 
+For custom diagnostic JSONL paths, startup reads retain only the newest 1 MB to
+avoid loading oversized logs into memory. When older bytes or a leading partial
+record are omitted, the command writes a warning to stderr and then follows new
+complete records from the retained window.
+
 | Flag            | Default                    | Description                    |
 | --------------- | -------------------------- | ------------------------------ |
 | `--file <path>` | resolved from plugin store | Path to `calls.jsonl`.         |
@@ -184,6 +189,10 @@ streams new lines as they are written.
 
 Summarize turn-latency and listen-wait metrics from `calls.jsonl`. Output is
 JSON with `recordsScanned`, `turnLatency`, and `listenWait` summaries.
+
+For custom diagnostic JSONL paths, only the newest 1 MB is scanned. If the
+retained window omits earlier records, stderr reports that the summary covers
+the retained records rather than the full file history.
 
 | Flag            | Default                    | Description                          |
 | --------------- | -------------------------- | ------------------------------------ |

--- a/extensions/voice-call/src/cli-call-log.ts
+++ b/extensions/voice-call/src/cli-call-log.ts
@@ -117,8 +117,7 @@ function readJsonlTailSync(
     let startsAtRecordBoundary = start === 0;
     if (start > 0) {
       const prefix = Buffer.alloc(1);
-      startsAtRecordBoundary =
-        fs.readSync(fd, prefix, 0, 1, start - 1) === 1 && prefix[0] === 0x0a;
+      startsAtRecordBoundary = fs.readSync(fd, prefix, 0, 1, start - 1) === 1 && prefix[0] === 0x0a;
     }
     const buf = Buffer.alloc(length);
     let bytesRead = 0;
@@ -375,10 +374,11 @@ export function registerVoiceCallLogs(params: {
       const last = parseCliInteger(options.last, "--last", { min: 1 });
 
       if (fs.existsSync(file) && path.basename(file) !== "calls.jsonl") {
-        const { text: content, omittedLeadingBytes, droppedLeadingBytes } = readJsonlTailSync(
-          file,
-          VOICE_CALL_CLI_MAX_JSONL_TAIL_BYTES,
-        );
+        const {
+          text: content,
+          omittedLeadingBytes,
+          droppedLeadingBytes,
+        } = readJsonlTailSync(file, VOICE_CALL_CLI_MAX_JSONL_TAIL_BYTES);
         warnJsonlCappedLeadingOmission({
           omittedLeadingBytes,
           droppedLeadingBytes,

--- a/extensions/voice-call/src/cli-call-log.ts
+++ b/extensions/voice-call/src/cli-call-log.ts
@@ -1,7 +1,7 @@
 // Voice Call plugin module implements cli call log commands.
 import fs from "node:fs";
 import path from "node:path";
-import { StringDecoder } from "node:string_decoder";
+import { format } from "node:util";
 import type { Command } from "commander";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { sleep } from "../api.js";
@@ -67,6 +67,200 @@ function writeVoiceCallLatencySummary(calls: unknown[]) {
   });
 }
 
+/** Cap diagnostic CLI reads to avoid loading oversized JSONL logs into memory. */
+const VOICE_CALL_CLI_MAX_JSONL_TAIL_BYTES = 1_000_000;
+const VOICE_CALL_CLI_JSONL_READ_CHUNK_BYTES = 64 * 1024;
+
+type JsonlFileIdentity = {
+  dev: number;
+  ino: number;
+};
+
+function getJsonlFileIdentity(stat: fs.Stats): JsonlFileIdentity {
+  return { dev: stat.dev, ino: stat.ino };
+}
+
+function isSameJsonlFileIdentity(left: JsonlFileIdentity, right: JsonlFileIdentity): boolean {
+  return left.dev === right.dev && left.ino === right.ino;
+}
+
+/** Read complete JSONL records from at most `maxBytes` at the end of `filePath`. */
+function readJsonlTailSync(
+  filePath: string,
+  maxBytes: number,
+): {
+  text: string;
+  bytes: Buffer;
+  end: number;
+  identity: JsonlFileIdentity;
+  omittedLeadingBytes: number;
+  droppedLeadingBytes: number;
+  discardUntilNewline: boolean;
+} {
+  const fd = fs.openSync(filePath, "r");
+  try {
+    const stat = fs.fstatSync(fd);
+    const identity = getJsonlFileIdentity(stat);
+    const start = Math.max(0, stat.size - maxBytes);
+    const length = stat.size - start;
+    if (length === 0) {
+      return {
+        text: "",
+        bytes: Buffer.alloc(0),
+        end: stat.size,
+        identity,
+        omittedLeadingBytes: start,
+        droppedLeadingBytes: 0,
+        discardUntilNewline: false,
+      };
+    }
+    let startsAtRecordBoundary = start === 0;
+    if (start > 0) {
+      const prefix = Buffer.alloc(1);
+      startsAtRecordBoundary =
+        fs.readSync(fd, prefix, 0, 1, start - 1) === 1 && prefix[0] === 0x0a;
+    }
+    const buf = Buffer.alloc(length);
+    let bytesRead = 0;
+    while (bytesRead < length) {
+      const read = fs.readSync(fd, buf, bytesRead, length - bytesRead, start + bytesRead);
+      if (read === 0) {
+        break;
+      }
+      bytesRead += read;
+    }
+    let bytes = buf.subarray(0, bytesRead);
+    let droppedLeadingBytes = 0;
+    let discardUntilNewline = false;
+    if (!startsAtRecordBoundary) {
+      const firstNewline = bytes.indexOf(0x0a);
+      if (firstNewline === -1) {
+        droppedLeadingBytes = bytes.length;
+        bytes = Buffer.alloc(0);
+        discardUntilNewline = start > 0;
+      } else {
+        droppedLeadingBytes = firstNewline + 1;
+        bytes = bytes.subarray(firstNewline + 1);
+      }
+    }
+    return {
+      text: bytes.toString("utf8"),
+      bytes,
+      end: start + bytesRead,
+      identity,
+      omittedLeadingBytes: start,
+      droppedLeadingBytes,
+      discardUntilNewline,
+    };
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
+function writeStderrLine(...values: unknown[]): void {
+  process.stderr.write(`${format(...values)}\n`);
+}
+
+function warnJsonlCappedLeadingOmission(params: {
+  omittedLeadingBytes: number;
+  droppedLeadingBytes: number;
+  filePath: string;
+}): void {
+  if (params.omittedLeadingBytes > 0) {
+    writeStderrLine(
+      "voicecall: retained the newest %d bytes from %s and omitted %d earlier JSONL bytes; earlier records are not included",
+      VOICE_CALL_CLI_MAX_JSONL_TAIL_BYTES,
+      params.filePath,
+      params.omittedLeadingBytes,
+    );
+  }
+  if (params.droppedLeadingBytes > 0) {
+    writeStderrLine(
+      "voicecall: skipped %d bytes of a partial JSONL record at the start of the capped read (%s)",
+      params.droppedLeadingBytes,
+      params.filePath,
+    );
+  }
+}
+
+function warnJsonlFollowDiscard(filePath: string): void {
+  writeStderrLine(
+    "voicecall: discarding a JSONL record larger than %d bytes while following %s",
+    VOICE_CALL_CLI_MAX_JSONL_TAIL_BYTES,
+    filePath,
+  );
+}
+
+type JsonlFollowState = {
+  pending: Buffer;
+  discardUntilNewline: boolean;
+  identity: JsonlFileIdentity;
+};
+
+function readJsonlFollowRangeSync(params: {
+  filePath: string;
+  start: number;
+  state: JsonlFollowState;
+  onLine: (line: string) => void;
+}): number {
+  const fd = fs.openSync(params.filePath, "r");
+  const chunk = Buffer.alloc(VOICE_CALL_CLI_JSONL_READ_CHUNK_BYTES);
+  let position = params.start;
+  const appendPending = (fragment: Buffer): void => {
+    if (params.state.discardUntilNewline || fragment.length === 0) {
+      return;
+    }
+    if (params.state.pending.length + fragment.length > VOICE_CALL_CLI_MAX_JSONL_TAIL_BYTES) {
+      params.state.pending = Buffer.alloc(0);
+      params.state.discardUntilNewline = true;
+      warnJsonlFollowDiscard(params.filePath);
+      return;
+    }
+    // Retain raw bytes so UTF-8 code points split across read chunks decode only after completion.
+    params.state.pending =
+      params.state.pending.length === 0
+        ? Buffer.from(fragment)
+        : Buffer.concat([params.state.pending, fragment]);
+  };
+  try {
+    const stat = fs.fstatSync(fd);
+    const identity = getJsonlFileIdentity(stat);
+    if (!isSameJsonlFileIdentity(params.state.identity, identity) || stat.size < position) {
+      position = 0;
+      params.state.pending = Buffer.alloc(0);
+      params.state.discardUntilNewline = false;
+    }
+    params.state.identity = identity;
+
+    while (position < stat.size) {
+      const requested = Math.min(chunk.length, stat.size - position);
+      const bytesRead = fs.readSync(fd, chunk, 0, requested, position);
+      if (bytesRead === 0) {
+        break;
+      }
+      let cursor = 0;
+      for (;;) {
+        const newline = chunk.indexOf(0x0a, cursor);
+        if (newline === -1 || newline >= bytesRead) {
+          appendPending(chunk.subarray(cursor, bytesRead));
+          break;
+        }
+        appendPending(chunk.subarray(cursor, newline));
+        if (!params.state.discardUntilNewline && params.state.pending.length > 0) {
+          params.onLine(params.state.pending.toString("utf8"));
+        }
+        params.state.pending = Buffer.alloc(0);
+        params.state.discardUntilNewline = false;
+        cursor = newline + 1;
+      }
+      position += bytesRead;
+    }
+    return position;
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
 export function registerVoiceCallLogs(params: {
   root: Command;
   defaultFile: string;
@@ -111,44 +305,56 @@ export function registerVoiceCallLogs(params: {
       };
 
       if (fs.existsSync(file) && path.basename(file) !== "calls.jsonl") {
-        const initial = fs.readFileSync(file);
-        let decoder = new StringDecoder("utf8");
-        const initialLines = decoder.write(initial).split("\n");
-        let pendingLine = initialLines.pop() ?? "";
-        const lines = initialLines.filter(Boolean);
+        const {
+          bytes: initial,
+          end,
+          identity,
+          omittedLeadingBytes,
+          droppedLeadingBytes,
+          discardUntilNewline,
+        } = readJsonlTailSync(file, VOICE_CALL_CLI_MAX_JSONL_TAIL_BYTES);
+        warnJsonlCappedLeadingOmission({
+          omittedLeadingBytes,
+          droppedLeadingBytes,
+          filePath: file,
+        });
+        const finalNewline = initial.lastIndexOf(0x0a);
+        const completeInitial =
+          finalNewline === -1 ? Buffer.alloc(0) : initial.subarray(0, finalNewline + 1);
+        const pending = finalNewline === -1 ? initial : initial.subarray(finalNewline + 1);
+        const lines = completeInitial.toString("utf8").split("\n").filter(Boolean);
         for (const line of lines.slice(Math.max(0, lines.length - since))) {
           writeCliLine(line);
         }
 
-        let offset = initial.length;
-        let lastObservedSize = initial.length;
+        let offset = end;
+        let lastObservedSize = end;
+        const followState: JsonlFollowState = {
+          pending: Buffer.from(pending),
+          discardUntilNewline,
+          identity,
+        };
         for (;;) {
           try {
             const stat = fs.statSync(file);
-            // A short read can leave the cursor behind the observed file size;
-            // compare observed sizes so copytruncate also clears buffered text.
+            // A copy-truncate can replace a partial record while keeping the same inode.
+            // Reset buffered bytes when the observed file size shrinks before reading again.
             if (stat.size < lastObservedSize) {
               offset = 0;
-              decoder = new StringDecoder("utf8");
-              pendingLine = "";
+              followState.pending = Buffer.alloc(0);
+              followState.discardUntilNewline = false;
             }
             lastObservedSize = stat.size;
-            if (stat.size > offset) {
-              const fd = fs.openSync(file, "r");
-              try {
-                const buf = Buffer.alloc(stat.size - offset);
-                const bytesRead = fs.readSync(fd, buf, 0, buf.length, offset);
-                offset += bytesRead;
-                const text = decoder.write(buf.subarray(0, bytesRead));
-                const completeLines = `${pendingLine}${text}`.split("\n");
-                pendingLine = completeLines.pop() ?? "";
-                for (const line of completeLines.filter(Boolean)) {
+            offset = readJsonlFollowRangeSync({
+              filePath: file,
+              start: offset,
+              state: followState,
+              onLine: (line) => {
+                if (line) {
                   writeCliLine(line);
                 }
-              } finally {
-                fs.closeSync(fd);
-              }
-            }
+              },
+            });
           } catch {
             // ignore and retry
           }
@@ -169,7 +375,15 @@ export function registerVoiceCallLogs(params: {
       const last = parseCliInteger(options.last, "--last", { min: 1 });
 
       if (fs.existsSync(file) && path.basename(file) !== "calls.jsonl") {
-        const content = fs.readFileSync(file, "utf8");
+        const { text: content, omittedLeadingBytes, droppedLeadingBytes } = readJsonlTailSync(
+          file,
+          VOICE_CALL_CLI_MAX_JSONL_TAIL_BYTES,
+        );
+        warnJsonlCappedLeadingOmission({
+          omittedLeadingBytes,
+          droppedLeadingBytes,
+          filePath: file,
+        });
         const calls = content
           .split("\n")
           .filter(Boolean)

--- a/extensions/voice-call/src/cli.test.ts
+++ b/extensions/voice-call/src/cli.test.ts
@@ -21,6 +21,21 @@ const sleepMock = vi.hoisted(() =>
       }),
   ),
 );
+const tempDirs = new Set<string>();
+
+function makeTempDir(prefix: string) {
+  // openclaw-temp-dir: allow extension tests cannot import repo-only test helpers
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tempDirs.add(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+  tempDirs.clear();
+});
 
 vi.mock("openclaw/plugin-sdk/gateway-runtime", async (importOriginal) => ({
   ...(await importOriginal<typeof import("openclaw/plugin-sdk/gateway-runtime")>()),
@@ -79,6 +94,18 @@ function gatewayCredentialsError(message: string): Error {
     method: "voicecall.status",
     configPath: "/tmp/openclaw.json",
   });
+}
+
+function captureStderr() {
+  let output = "";
+  const writeSpy = vi.spyOn(process.stderr, "write").mockImplementation(((chunk: unknown) => {
+    output += String(chunk);
+    return true;
+  }) as typeof process.stderr.write);
+  return {
+    output: () => output,
+    restore: () => writeSpy.mockRestore(),
+  };
 }
 
 describe("voice-call CLI status fallback", () => {
@@ -403,6 +430,14 @@ describe("voice-call CLI status fallback", () => {
 
     readSyncSpy.mockImplementation(((fd, buffer, offset, length, position) => {
       if (
+        shortened &&
+        copyTruncated !== undefined &&
+        typeof position === "number" &&
+        position === initialByteLength + (firstReadBytes ?? 0)
+      ) {
+        return 0;
+      }
+      if (
         !shortened &&
         firstReadBytes !== undefined &&
         typeof position === "number" &&
@@ -516,6 +551,264 @@ describe("voice-call CLI status fallback", () => {
     expect(result.shortened).toBe(false);
     expect(result.output).not.toContain("\ufffd");
     expect(result.output).toContain('{"word":"café"}\n');
+  });
+
+  it("drops a partial leading JSONL record from capped diagnostic reads and warns on stderr", async () => {
+    const tempRoot = makeTempDir("openclaw-voice-call-cli-");
+    const file = path.join(tempRoot, "diagnostics.jsonl");
+    const completeRecords = [
+      JSON.stringify({ call: { metadata: { lastTurnLatencyMs: 120 } } }),
+      JSON.stringify({ call: { metadata: { lastTurnLatencyMs: 240 } } }),
+    ];
+    const crossingRecord = JSON.stringify({ padding: "x".repeat(1_000_000) });
+    fs.writeFileSync(file, [crossingRecord, ...completeRecords].join("\n") + "\n", "utf8");
+
+    try {
+      const latencyProgram = buildProgram({});
+      const latencyOutput = captureStdout();
+      const latencyWarnings = captureStderr();
+      try {
+        await latencyProgram.parseAsync(["voicecall", "latency", "--file", file], {
+          from: "user",
+        });
+      } finally {
+        latencyWarnings.restore();
+        latencyOutput.restore();
+      }
+      expect(JSON.parse(latencyOutput.output())).toMatchObject({
+        recordsScanned: 2,
+        turnLatency: { count: 2 },
+      });
+      expect(latencyWarnings.output()).toContain(
+        "of a partial JSONL record at the start of the capped read",
+      );
+
+      sleepMock.mockRejectedValueOnce(new Error("stop tail after initial output"));
+      const tailProgram = buildProgram({});
+      const tailOutput = captureStdout();
+      const tailWarnings = captureStderr();
+      try {
+        await expect(
+          tailProgram.parseAsync(["voicecall", "tail", "--file", file, "--since", "10"], {
+            from: "user",
+          }),
+        ).rejects.toThrow("stop tail after initial output");
+      } finally {
+        tailWarnings.restore();
+        tailOutput.restore();
+      }
+      expect(tailOutput.output().trim().split("\n")).toEqual(completeRecords);
+      expect(tailWarnings.output()).toContain(
+        "of a partial JSONL record at the start of the capped read",
+      );
+    } finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("warns when capped diagnostic reads omit complete leading records", async () => {
+    const tempRoot = makeTempDir("openclaw-voice-call-cli-boundary-");
+    const file = path.join(tempRoot, "diagnostics.jsonl");
+    const oldRecord = JSON.stringify({ call: { metadata: { lastTurnLatencyMs: 999 } } });
+    const retainedPrefix = '{"call":{"metadata":{"lastTurnLatencyMs":120},"padding":"';
+    const retainedSuffix = '"}}\n';
+    const retainedRecord = `${retainedPrefix}${"x".repeat(
+      1_000_000 -
+        Buffer.byteLength(retainedPrefix, "utf8") -
+        Buffer.byteLength(retainedSuffix, "utf8"),
+    )}${retainedSuffix}`;
+    fs.writeFileSync(file, `${oldRecord}\n${retainedRecord}`, "utf8");
+
+    const program = buildProgram({});
+    const output = captureStdout();
+    const warnings = captureStderr();
+    try {
+      await program.parseAsync(["voicecall", "latency", "--file", file], {
+        from: "user",
+      });
+    } finally {
+      warnings.restore();
+      output.restore();
+    }
+
+    expect(JSON.parse(output.output())).toMatchObject({
+      recordsScanned: 1,
+      turnLatency: { count: 1 },
+    });
+    expect(warnings.output()).toContain("omitted");
+    expect(warnings.output()).toContain("earlier JSONL bytes");
+    expect(warnings.output()).not.toContain("partial JSONL record");
+  });
+
+  it("keeps discarding an initial oversized JSONL record until its newline", async () => {
+    const tempRoot = makeTempDir("openclaw-voice-call-cli-initial-discard-");
+    const file = path.join(tempRoot, "diagnostics.jsonl");
+    fs.writeFileSync(file, `{"padding":"${"x".repeat(1_100_000)}`, "utf8");
+
+    sleepMock
+      .mockImplementationOnce(async () => {
+        fs.appendFileSync(file, `"}\n${JSON.stringify({ seq: 1 })}\n`, "utf8");
+      })
+      .mockRejectedValueOnce(new Error("stop tail after initial discard output"));
+
+    const program = buildProgram({});
+    const output = captureStdout();
+    const warnings = captureStderr();
+    try {
+      await expect(
+        program.parseAsync(["voicecall", "tail", "--file", file, "--since", "10"], {
+          from: "user",
+        }),
+      ).rejects.toThrow("stop tail after initial discard output");
+    } finally {
+      warnings.restore();
+      output.restore();
+    }
+
+    const lines = output.output().trim().split("\n");
+    expect(lines).toHaveLength(1);
+    expect(JSON.parse(lines[0] ?? "")).toEqual({ seq: 1 });
+    expect(output.output()).not.toContain("padding");
+    expect(warnings.output()).toContain("partial JSONL record at the start of the capped read");
+  });
+
+  it("warns on stderr when a follow-up record exceeds the JSONL read cap", async () => {
+    const tempRoot = makeTempDir("openclaw-voice-call-cli-discard-");
+    const file = path.join(tempRoot, "diagnostics.jsonl");
+    fs.writeFileSync(file, `${JSON.stringify({ seq: 0 })}\n`, "utf8");
+    const oversizedRecord = `${JSON.stringify({ seq: 1, padding: "x".repeat(1_100_000) })}\n`;
+    const tailRecord = `${JSON.stringify({ seq: 2 })}\n`;
+
+    sleepMock
+      .mockImplementationOnce(async () => {
+        fs.appendFileSync(file, oversizedRecord, "utf8");
+      })
+      .mockImplementationOnce(async () => {
+        fs.appendFileSync(file, tailRecord, "utf8");
+      })
+      .mockRejectedValueOnce(new Error("stop tail after discard output"));
+
+    const program = buildProgram({});
+    const output = captureStdout();
+    const warnings = captureStderr();
+    try {
+      await expect(
+        program.parseAsync(["voicecall", "tail", "--file", file, "--since", "1"], {
+          from: "user",
+        }),
+      ).rejects.toThrow("stop tail after discard output");
+    } finally {
+      warnings.restore();
+      output.restore();
+    }
+
+    const lines = output.output().trim().split("\n");
+    expect(lines).toHaveLength(2);
+    expect(JSON.parse(lines[0] ?? "")).toEqual({ seq: 0 });
+    expect(JSON.parse(lines[1] ?? "")).toEqual({ seq: 2 });
+    expect(warnings.output()).toContain("discarding a JSONL record larger than");
+    expect(warnings.output()).toContain(String(1_000_000));
+  });
+
+  it("reads follow-up appends in bounded chunks and retains a partial final record", async () => {
+    const tempRoot = makeTempDir("openclaw-voice-call-cli-follow-");
+    const file = path.join(tempRoot, "diagnostics.jsonl");
+    fs.writeFileSync(file, `${JSON.stringify({ seq: 0 })}\n`, "utf8");
+    const appendedRecords = Array.from({ length: 2_000 }, (_, index) =>
+      JSON.stringify({ seq: index + 1, padding: "x".repeat(550) }),
+    );
+
+    sleepMock
+      .mockImplementationOnce(async () => {
+        fs.appendFileSync(
+          file,
+          `${appendedRecords.join("\n")}\n${JSON.stringify({ seq: 2001 }).slice(0, -2)}`,
+        );
+      })
+      .mockImplementationOnce(async () => {
+        fs.appendFileSync(file, "1}\n");
+      })
+      .mockRejectedValueOnce(new Error("stop tail after follow-up output"));
+
+    const program = buildProgram({});
+    const output = captureStdout();
+    try {
+      await expect(
+        program.parseAsync(["voicecall", "tail", "--file", file, "--since", "1"], {
+          from: "user",
+        }),
+      ).rejects.toThrow("stop tail after follow-up output");
+    } finally {
+      output.restore();
+    }
+
+    const lines = output.output().trim().split("\n");
+    expect(lines).toHaveLength(2_002);
+    expect(JSON.parse(lines[0] ?? "")).toEqual({ seq: 0 });
+    expect(JSON.parse(lines.at(-1) ?? "")).toEqual({ seq: 2001 });
+  });
+
+  it("preserves a UTF-8 code point split across follow read chunks", async () => {
+    const tempRoot = makeTempDir("openclaw-voice-call-cli-utf8-");
+    const file = path.join(tempRoot, "diagnostics.jsonl");
+    fs.writeFileSync(file, `${JSON.stringify({ seq: 0 })}\n`, "utf8");
+    const recordPrefix = '{"seq":1,"text":"';
+    const text = `${"x".repeat(64 * 1024 - 1 - Buffer.byteLength(recordPrefix))}中`;
+    const record = `${recordPrefix}${text}"}`;
+
+    sleepMock
+      .mockImplementationOnce(async () => {
+        fs.appendFileSync(file, `${record}\n`, "utf8");
+      })
+      .mockRejectedValueOnce(new Error("stop tail after UTF-8 boundary output"));
+
+    const program = buildProgram({});
+    const output = captureStdout();
+    try {
+      await expect(
+        program.parseAsync(["voicecall", "tail", "--file", file, "--since", "1"], {
+          from: "user",
+        }),
+      ).rejects.toThrow("stop tail after UTF-8 boundary output");
+    } finally {
+      output.restore();
+    }
+
+    const lines = output.output().trim().split("\n");
+    expect(lines).toHaveLength(2);
+    expect(JSON.parse(lines[1] ?? "")).toEqual({ seq: 1, text });
+  });
+
+  it("clears pending follow state when a larger replacement changes file identity", async () => {
+    const tempRoot = makeTempDir("openclaw-voice-call-cli-rotation-");
+    const file = path.join(tempRoot, "diagnostics.jsonl");
+    const replacement = path.join(tempRoot, "replacement.jsonl");
+    const initial = `${JSON.stringify({ seq: 0 })}\n{"old":"unfinished`;
+    const replacementRecord = JSON.stringify({ seq: 1, padding: "x".repeat(256) });
+    fs.writeFileSync(file, initial, "utf8");
+    expect(Buffer.byteLength(replacementRecord)).toBeGreaterThan(Buffer.byteLength(initial));
+
+    sleepMock
+      .mockImplementationOnce(async () => {
+        fs.writeFileSync(replacement, `${replacementRecord}\n`, "utf8");
+        fs.renameSync(replacement, file);
+      })
+      .mockRejectedValueOnce(new Error("stop tail after replacement output"));
+
+    const program = buildProgram({});
+    const output = captureStdout();
+    try {
+      await expect(
+        program.parseAsync(["voicecall", "tail", "--file", file, "--since", "1"], {
+          from: "user",
+        }),
+      ).rejects.toThrow("stop tail after replacement output");
+    } finally {
+      output.restore();
+    }
+
+    const lines = output.output().trim().split("\n");
+    expect(lines.map((line) => JSON.parse(line).seq)).toEqual([0, 1]);
   });
 
   it("caps oversized operation timeouts through the start command", async () => {


### PR DESCRIPTION
## What Problem This Solves

`openclaw voicecall tail --file <path>` bounded its initial JSONL read, but a file growing by more than 1 MB between polls still allocated the entire appended range at once. A partial final JSONL record also needed to survive into the next poll.

## Why This Change Was Made

The follow path now reads fixed 64 KiB chunks, emits complete records incrementally, and carries one unfinished record as raw bytes between reads, so UTF-8 code points split at a chunk boundary are decoded only after the complete JSONL record arrives. A single record larger than the existing 1 MB diagnostic limit is discarded through its next newline, keeping retained memory bounded. Initial and follow reads identify the file through `fstat` on the same descriptor used for reading. When that identity changes, or the same file is truncated, the offset, pending record, and discard state are reset before reading the new contents. The cap applies to existing custom files whose basename is not `calls.jsonl`; the managed `calls.jsonl` path continues to use SQLite-backed history.
Every capped omission is now visible: a follow-mode record that crosses the 1 MB cap, an initial read that omits older complete records, and an initial read that starts inside a partial record all emit concise stderr warnings while stdout JSONL stays intact. If the initial retained window is still inside an oversized unfinished record, follow mode keeps discarding through that record's next newline before emitting later complete records.

## User Impact

Voice-call diagnostics remain responsive when logs grow quickly, without losing ordinary records that cross chunk or poll boundaries or joining a stale partial record to a replacement file. When eligible custom diagnostic history is omitted by the 1 MB retained window, the operator sees a stderr warning instead of silently incomplete output. This intentionally changes eligible custom-file `tail` and `latency` from full-history reads to the newest 1 MB retained window; the filename-gated `calls.jsonl` SQLite path is unchanged.

## Evidence

- Production CLI proof: `./node_modules/.bin/tsx proof-live.ts` registered the real voice-call CLI, started `tail`, appended 1,150,906 bytes after startup, and completed a JSON record in a later poll.
- Replacement proof: `./node_modules/.bin/tsx proof-rotation.ts` ran the same production CLI, atomically renamed a larger replacement over a file containing an unfinished record, and emitted only the old complete record plus the new file's record.
- UTF-8 boundary proof: `./node_modules/.bin/tsx proof-utf8.ts` placed the first byte of `中` at offset 65,535 of the follow window and verified the production CLI emitted the exact original text after two bounded reads.
- Cap-omission proof: `./node_modules/.bin/tsx proof-cap-warning.ts` ran the same production CLI against a >1 MB follow record and against a file whose last 1 MB starts mid-record; stdout remained valid JSONL and stderr carried exactly one warning per omission path.
- Initial-window proof: `./node_modules/.bin/tsx proof-initial-window.ts` ran the same production CLI at `8c23fcc4858b8beef166ed782a3123c5f8fbd288`; a record-boundary cutoff warned about omitted complete history, and an unfinished oversized initial record was discarded through its later newline without emitting its suffix.
- `node scripts/run-vitest.mjs extensions/voice-call/src/cli.test.ts`: 21 tests passed, including the >1 MB append, larger replacement identity, split UTF-8, record-boundary omission warning, initial oversized-record discard, and stderr omission-warning regressions.
- `pnpm run lint:plugins:no-extension-test-core-imports`, `pnpm run test:extensions:package-boundary:compile`, and `node scripts/report-test-temp-creations.mjs --base 98b222ded8a003a5376c06158d889adf4d8f7f16 --head HEAD --fail-on-findings`: passed.
- `pnpm docs:list`: passed.

```text
$ ./node_modules/.bin/tsx proof-live.ts
appendedBytes=1150906
tailLines=2002
tailAllValidJson=true
tailFirstSeq=0
tailLastSeq=2001
```

<details>
<summary>proof-live.ts</summary>

```ts
import { spawn } from "node:child_process";
import { appendFileSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
import os from "node:os";
import path from "node:path";
import { Command } from "commander";
import { registerVoiceCallCli } from "./extensions/voice-call/src/cli.js";

function buildProgram(): Command {
  const program = new Command();
  registerVoiceCallCli({
    program,
    config: {} as never,
    ensureRuntime: async () => ({ manager: {} }) as never,
    logger: { info() {}, warn() {}, error() {}, debug() {} } as never,
  });
  return program;
}

if (process.argv[2] === "--tail" && process.argv[3]) {
  await buildProgram().parseAsync(
    ["voicecall", "tail", "--file", process.argv[3], "--since", "10", "--poll", "50"],
    { from: "user" },
  );
  process.exit(0);
}

const tempRoot = mkdtempSync(path.join(os.tmpdir(), "openclaw-voice-call-follow-proof-"));
const file = path.join(tempRoot, "diagnostics.jsonl");
writeFileSync(file, `${JSON.stringify({ seq: 0 })}\n`, "utf8");

try {
  const records = Array.from({ length: 2_000 }, (_, index) =>
    JSON.stringify({ seq: index + 1, padding: "x".repeat(550) }),
  );
  const appended = `${records.join("\n")}\n`;
  const partial = '{"seq":2001';
  let bulkAppended = false;
  let partialCompleted = false;
  let stdout = "";
  let stderr = "";

  const lines = await new Promise<string[]>((resolve, reject) => {
    const child = spawn(process.execPath, ["--import", "tsx", "proof-live.ts", "--tail", file], {
      stdio: ["ignore", "pipe", "pipe"],
    });
    const timer = setTimeout(() => {
      child.kill("SIGTERM");
      reject(new Error(`tail proof timed out: ${stderr}`));
    }, 15_000);
    child.stdout.on("data", (chunk) => {
      stdout += String(chunk);
      const currentLines = stdout.trim().split("\n").filter(Boolean);
      if (!bulkAppended && currentLines.length >= 1) {
        bulkAppended = true;
        appendFileSync(file, appended + partial, "utf8");
      }
      if (!partialCompleted && currentLines.length >= 2_001) {
        partialCompleted = true;
        appendFileSync(file, "}\n", "utf8");
      }
      if (currentLines.length >= 2_002) {
        child.kill("SIGTERM");
      }
    });
    child.stderr.on("data", (chunk) => {
      stderr += String(chunk);
    });
    child.on("error", reject);
    child.on("close", () => {
      clearTimeout(timer);
      resolve(stdout.trim().split("\n").filter(Boolean));
    });
  });

  const parsed = lines.map((line) => JSON.parse(line) as { seq: number });
  console.log(`appendedBytes=${Buffer.byteLength(appended + partial + "}\n")}`);
  console.log(`tailLines=${lines.length}`);
  console.log(`tailAllValidJson=${parsed.length === lines.length}`);
  console.log(`tailFirstSeq=${parsed.at(0)?.seq}`);
  console.log(`tailLastSeq=${parsed.at(-1)?.seq}`);
} finally {
  rmSync(tempRoot, { recursive: true, force: true });
}
```

</details>

```text
$ ./node_modules/.bin/tsx proof-rotation.ts
replacementDetected=true
replacementLarger=true
tailLines=2
tailAllValidJson=true
tailSeqs=0,1
```

<details>
<summary>proof-rotation.ts</summary>

```ts
import { spawn } from "node:child_process";
import { mkdtempSync, renameSync, rmSync, writeFileSync } from "node:fs";
import os from "node:os";
import path from "node:path";
import { Command } from "commander";
import { registerVoiceCallCli } from "./extensions/voice-call/src/cli.js";

function buildProgram(): Command {
  const program = new Command();
  registerVoiceCallCli({
    program,
    config: {} as never,
    ensureRuntime: async () => ({ manager: {} }) as never,
    logger: { info() {}, warn() {}, error() {}, debug() {} } as never,
  });
  return program;
}

if (process.argv[2] === "--tail" && process.argv[3]) {
  await buildProgram().parseAsync(
    ["voicecall", "tail", "--file", process.argv[3], "--since", "1", "--poll", "50"],
    { from: "user" },
  );
  process.exit(0);
}

const tempRoot = mkdtempSync(path.join(os.tmpdir(), "openclaw-voice-call-rotation-proof-"));
const file = path.join(tempRoot, "diagnostics.jsonl");
const replacement = path.join(tempRoot, "replacement.jsonl");
const initial = `${JSON.stringify({ seq: 0 })}\n{"old":"unfinished`;
const replacementRecord = JSON.stringify({ seq: 1, padding: "x".repeat(256) });
writeFileSync(file, initial, "utf8");

try {
  let replaced = false;
  let stdout = "";
  let stderr = "";
  const lines = await new Promise<string[]>((resolve, reject) => {
    const child = spawn(
      process.execPath,
      ["--import", "tsx", "proof-rotation.ts", "--tail", file],
      { stdio: ["ignore", "pipe", "pipe"] },
    );
    const timer = setTimeout(() => {
      child.kill("SIGTERM");
      reject(new Error(`rotation proof timed out: ${stderr}`));
    }, 10_000);
    child.stdout.on("data", (chunk) => {
      stdout += String(chunk);
      const currentLines = stdout.trim().split("\n").filter(Boolean);
      if (!replaced && currentLines.length >= 1) {
        replaced = true;
        writeFileSync(replacement, `${replacementRecord}\n`, "utf8");
        renameSync(replacement, file);
      }
      if (currentLines.length >= 2) {
        child.kill("SIGTERM");
      }
    });
    child.stderr.on("data", (chunk) => {
      stderr += String(chunk);
    });
    child.on("error", reject);
    child.on("close", () => {
      clearTimeout(timer);
      resolve(stdout.trim().split("\n").filter(Boolean));
    });
  });

  const parsed = lines.map((line) => JSON.parse(line) as { seq: number });
  console.log(`replacementDetected=${replaced}`);
  console.log(`replacementLarger=${Buffer.byteLength(replacementRecord) > Buffer.byteLength(initial)}`);
  console.log(`tailLines=${lines.length}`);
  console.log(`tailAllValidJson=${parsed.length === lines.length}`);
  console.log(`tailSeqs=${parsed.map((entry) => entry.seq).join(",")}`);
} finally {
  rmSync(tempRoot, { recursive: true, force: true });
}
```

</details>

```text
$ ./node_modules/.bin/tsx proof-utf8.ts
utf8BoundaryByteOffset=65535
tailLines=2
tailAllValidJson=true
tailTextExact=true
tailTextEndsWith=中
```

<details>
<summary>proof-utf8.ts</summary>

```ts
import { spawn } from "node:child_process";
import { appendFileSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
import os from "node:os";
import path from "node:path";
import { Command } from "commander";
import { registerVoiceCallCli } from "./extensions/voice-call/src/cli.js";

function buildProgram(): Command {
  const program = new Command();
  registerVoiceCallCli({
    program,
    config: {} as never,
    ensureRuntime: async () => ({ manager: {} }) as never,
    logger: { info() {}, warn() {}, error() {}, debug() {} } as never,
  });
  return program;
}

if (process.argv[2] === "--tail" && process.argv[3]) {
  await buildProgram().parseAsync(
    ["voicecall", "tail", "--file", process.argv[3], "--since", "1", "--poll", "50"],
    { from: "user" },
  );
  process.exit(0);
}

const tempRoot = mkdtempSync(path.join(os.tmpdir(), "openclaw-voice-call-utf8-proof-"));
const file = path.join(tempRoot, "diagnostics.jsonl");
const recordPrefix = '{"seq":1,"text":"';
const boundaryByteOffset = 64 * 1024 - 1;
const text = `${"x".repeat(boundaryByteOffset - Buffer.byteLength(recordPrefix))}中`;
const record = `${recordPrefix}${text}"}`;
writeFileSync(file, `${JSON.stringify({ seq: 0 })}\n`, "utf8");

try {
  let appended = false;
  let stdout = "";
  let stderr = "";
  const lines = await new Promise<string[]>((resolve, reject) => {
    const child = spawn(process.execPath, ["--import", "tsx", "proof-utf8.ts", "--tail", file], {
      stdio: ["ignore", "pipe", "pipe"],
    });
    child.stdout.setEncoding("utf8");
    child.stderr.setEncoding("utf8");
    const timer = setTimeout(() => {
      child.kill("SIGTERM");
      reject(new Error(`UTF-8 proof timed out: ${stderr}`));
    }, 10_000);
    child.stdout.on("data", (chunk) => {
      stdout += chunk;
      const currentLines = stdout.trim().split("\n").filter(Boolean);
      if (!appended && currentLines.length >= 1) {
        appended = true;
        appendFileSync(file, `${record}\n`, "utf8");
      }
      if (currentLines.length >= 2) {
        child.kill("SIGTERM");
      }
    });
    child.stderr.on("data", (chunk) => {
      stderr += chunk;
    });
    child.on("error", reject);
    child.on("close", () => {
      clearTimeout(timer);
      resolve(stdout.trim().split("\n").filter(Boolean));
    });
  });

  const parsed = lines.map((line) => JSON.parse(line) as { seq: number; text?: string });
  console.log(`utf8BoundaryByteOffset=${boundaryByteOffset}`);
  console.log(`tailLines=${lines.length}`);
  console.log(`tailAllValidJson=${parsed.length === lines.length}`);
  console.log(`tailTextExact=${parsed[1]?.text === text}`);
  console.log(`tailTextEndsWith=${parsed[1]?.text?.at(-1)}`);
} finally {
  rmSync(tempRoot, { recursive: true, force: true });
}
```

</details>

```text
$ ./node_modules/.bin/tsx proof-cap-warning.ts
followOversizedRecordBytes=1100023
followDiscardWarnings=1
followDiscardWarning=voicecall: discarding a JSONL record larger than 1000000 bytes while following <tmp>/diagnostics.jsonl
followTailLines=2
followTailAllValidJson=true
followTailSeqs=0,2
latencyWarnings=1
latencyWarning=voicecall: skipped 999904 bytes of a partial JSONL record at the start of the capped read (<tmp>/crossing.jsonl)
latencyRecordsScanned=2
tailWarnings=1
tailWarning=voicecall: skipped 999904 bytes of a partial JSONL record at the start of the capped read (<tmp>/crossing.jsonl)
tailLines=2
tailAllValidJson=true
```

<details>
<summary>proof-cap-warning.ts</summary>

```ts
import { spawn } from "node:child_process";
import { appendFileSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
import os from "node:os";
import path from "node:path";
import { Command } from "commander";
import { registerVoiceCallCli } from "./extensions/voice-call/src/cli.js";

function buildProgram(): Command {
  const program = new Command();
  registerVoiceCallCli({
    program,
    config: {} as never,
    ensureRuntime: async () => ({ manager: {} }) as never,
    logger: { info() {}, warn() {}, error() {}, debug() {} } as never,
  });
  return program;
}

if (process.argv[2] === "--tail" && process.argv[3]) {
  const since = process.argv[4] === "--since" ? process.argv[5] : "1";
  await buildProgram().parseAsync(
    ["voicecall", "tail", "--file", process.argv[3], "--since", since, "--poll", "50"],
    { from: "user" },
  );
  process.exit(0);
}

if (process.argv[2] === "--latency" && process.argv[3]) {
  await buildProgram().parseAsync(["voicecall", "latency", "--file", process.argv[3]], {
    from: "user",
  });
  process.exit(0);
}

function runCli(
  args: string[],
  onOutput: (lines: string[], stderr: string, kill: () => void) => void,
): Promise<{ stdout: string; stderr: string }> {
  return new Promise((resolve, reject) => {
    const child = spawn(
      process.execPath,
      ["--import", "tsx", "proof-cap-warning.ts", ...args],
      { stdio: ["ignore", "pipe", "pipe"] },
    );
    child.stdout.setEncoding("utf8");
    child.stderr.setEncoding("utf8");
    let stdout = "";
    let stderr = "";
    const timer = setTimeout(() => {
      child.kill("SIGTERM");
      reject(new Error(`cap-warning proof timed out: ${stderr}`));
    }, 15_000);
    const emit = () =>
      onOutput(stdout.trim().split("\n").filter(Boolean), stderr, () => child.kill("SIGTERM"));
    child.stdout.on("data", (chunk) => {
      stdout += chunk;
      emit();
    });
    child.stderr.on("data", (chunk) => {
      stderr += chunk;
      emit();
    });
    child.on("error", reject);
    child.on("close", () => {
      clearTimeout(timer);
      resolve({ stdout, stderr });
    });
  });
}

const tempRoot = mkdtempSync(path.join(os.tmpdir(), "openclaw-voice-call-cap-warning-proof-"));
const file = path.join(tempRoot, "diagnostics.jsonl");
const crossingFile = path.join(tempRoot, "crossing.jsonl");
const oversizedRecord = `${JSON.stringify({ seq: 1, padding: "x".repeat(1_100_000) })}\n`;
const tailRecord = `${JSON.stringify({ seq: 2 })}\n`;
const crossingRecord = JSON.stringify({ padding: "x".repeat(1_000_000) });
const completeRecords = [
  JSON.stringify({ call: { metadata: { lastTurnLatencyMs: 120 } } }),
  JSON.stringify({ call: { metadata: { lastTurnLatencyMs: 240 } } }),
];

try {
  writeFileSync(file, `${JSON.stringify({ seq: 0 })}\n`, "utf8");
  writeFileSync(crossingFile, [crossingRecord, ...completeRecords].join("\n") + "\n", "utf8");

  let discarded = false;
  let tailWritten = false;
  const follow = await runCli(["--tail", file], (lines, stderr, kill) => {
    if (!discarded && lines.length >= 1) {
      discarded = true;
      appendFileSync(file, oversizedRecord, "utf8");
    }
    if (!tailWritten && stderr.includes("discarding a JSONL record larger than")) {
      tailWritten = true;
      appendFileSync(file, tailRecord, "utf8");
    }
    if (lines.length >= 2) {
      kill();
    }
  });

  const followLines = follow.stdout.trim().split("\n").filter(Boolean);
  const followWarnings = follow.stderr
    .split("\n")
    .filter((line) => line.includes("discarding a JSONL record larger than"));
  const parsedFollow = followLines.map((line) => JSON.parse(line) as { seq: number });

  const latency = await runCli(["--latency", crossingFile], () => {});
  const latencyParsed = JSON.parse(latency.stdout.trim()) as { recordsScanned: number };
  const latencyWarnings = latency.stderr
    .split("\n")
    .filter((line) => line.includes("of a partial JSONL record at the start of the capped read"));

  const tail = await runCli(["--tail", crossingFile, "--since", "10"], (lines, _stderr, kill) => {
    if (lines.length >= 2) {
      kill();
    }
  });
  const tailLines = tail.stdout.trim().split("\n").filter(Boolean);
  const tailWarnings = tail.stderr
    .split("\n")
    .filter((line) => line.includes("of a partial JSONL record at the start of the capped read"));

  console.log(`followOversizedRecordBytes=${Buffer.byteLength(oversizedRecord)}`);
  console.log(`followDiscardWarnings=${followWarnings.length}`);
  console.log(`followDiscardWarning=${followWarnings.at(0) ?? ""}`);
  console.log(`followTailLines=${followLines.length}`);
  console.log(`followTailAllValidJson=${parsedFollow.length === followLines.length}`);
  console.log(`followTailSeqs=${parsedFollow.map((entry) => entry.seq).join(",")}`);
  console.log(`latencyWarnings=${latencyWarnings.length}`);
  console.log(`latencyWarning=${latencyWarnings.at(0) ?? ""}`);
  console.log(`latencyRecordsScanned=${latencyParsed.recordsScanned}`);
  console.log(`tailWarnings=${tailWarnings.length}`);
  console.log(`tailWarning=${tailWarnings.at(0) ?? ""}`);
  console.log(`tailLines=${tailLines.length}`);
  console.log(`tailAllValidJson=${tailLines.every((line) => JSON.parse(line))}`);
} finally {
  rmSync(tempRoot, { recursive: true, force: true });
}
```

</details>

```text
$ ./node_modules/.bin/tsx proof-initial-window.ts
headSha=8c23fcc4858b8beef166ed782a3123c5f8fbd288
latencyBoundaryRecordsScanned=1
latencyBoundaryTurnLatencyCount=1
latencyBoundaryWarnedWholeOmission=true
latencyBoundaryWarnedPartialRecord=false
initialDiscardLines=1
initialDiscardAllValidJson=true
initialDiscardSeqs=1
initialDiscardEmittedOversizedSuffix=false
initialDiscardWarnedPartialRecord=true
```

<details>
<summary>proof-initial-window.ts</summary>

```ts
import { execFileSync, spawn } from "node:child_process";
import { appendFileSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
import os from "node:os";
import path from "node:path";
import { Command } from "commander";
import { registerVoiceCallCli } from "./extensions/voice-call/src/cli.js";

function buildProgram(): Command {
  const program = new Command();
  registerVoiceCallCli({
    program,
    config: {} as never,
    ensureRuntime: async () => ({ manager: {} }) as never,
    logger: { info() {}, warn() {}, error() {}, debug() {} } as never,
  });
  return program;
}

if (process.argv[2] === "--tail" && process.argv[3]) {
  await buildProgram().parseAsync(
    ["voicecall", "tail", "--file", process.argv[3], "--since", "10", "--poll", "50"],
    { from: "user" },
  );
  process.exit(0);
}

async function runLatencyBoundaryProof(tempRoot: string): Promise<void> {
  const file = path.join(tempRoot, "boundary.jsonl");
  const oldRecord = JSON.stringify({ call: { metadata: { lastTurnLatencyMs: 999 } } });
  const retainedPrefix = '{"call":{"metadata":{"lastTurnLatencyMs":120},"padding":"';
  const retainedSuffix = '"}}\n';
  const retainedRecord = `${retainedPrefix}${"x".repeat(
    1_000_000 -
      Buffer.byteLength(retainedPrefix, "utf8") -
      Buffer.byteLength(retainedSuffix, "utf8"),
  )}${retainedSuffix}`;
  writeFileSync(file, `${oldRecord}\n${retainedRecord}`, "utf8");

  let stdout = "";
  let stderr = "";
  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
  const originalStderrWrite = process.stderr.write.bind(process.stderr);
  process.stdout.write = ((chunk: unknown) => {
    stdout += String(chunk);
    return true;
  }) as typeof process.stdout.write;
  process.stderr.write = ((chunk: unknown) => {
    stderr += String(chunk);
    return true;
  }) as typeof process.stderr.write;
  try {
    await buildProgram().parseAsync(["voicecall", "latency", "--file", file], { from: "user" });
  } finally {
    process.stdout.write = originalStdoutWrite;
    process.stderr.write = originalStderrWrite;
  }

  const parsed = JSON.parse(stdout) as {
    recordsScanned?: number;
    turnLatency?: { count?: number };
  };
  console.log(`latencyBoundaryRecordsScanned=${parsed.recordsScanned}`);
  console.log(`latencyBoundaryTurnLatencyCount=${parsed.turnLatency?.count}`);
  console.log(`latencyBoundaryWarnedWholeOmission=${stderr.includes("earlier JSONL bytes")}`);
  console.log(`latencyBoundaryWarnedPartialRecord=${stderr.includes("partial JSONL record")}`);
}

async function runInitialDiscardProof(tempRoot: string): Promise<void> {
  const file = path.join(tempRoot, "initial-discard.jsonl");
  writeFileSync(file, `{"padding":"${"x".repeat(1_100_000)}`, "utf8");

  let stdout = "";
  let stderr = "";
  const lines = await new Promise<string[]>((resolve, reject) => {
    const child = spawn(
      process.execPath,
      ["--import", "tsx", "proof-initial-window.ts", "--tail", file],
      { stdio: ["ignore", "pipe", "pipe"] },
    );
    const appendTimer = setTimeout(() => {
      appendFileSync(file, `"}\n${JSON.stringify({ seq: 1 })}\n`, "utf8");
    }, 200);
    const stopTimer = setTimeout(() => {
      child.kill("SIGTERM");
      reject(new Error(`initial discard proof timed out: ${stderr}`));
    }, 10_000);
    child.stdout.on("data", (chunk) => {
      stdout += String(chunk);
      const currentLines = stdout.trim().split("\n").filter(Boolean);
      if (currentLines.length >= 1) {
        child.kill("SIGTERM");
      }
    });
    child.stderr.on("data", (chunk) => {
      stderr += String(chunk);
    });
    child.on("error", reject);
    child.on("close", () => {
      clearTimeout(appendTimer);
      clearTimeout(stopTimer);
      resolve(stdout.trim().split("\n").filter(Boolean));
    });
  });

  const parsed = lines.map((line) => JSON.parse(line) as { seq?: number });
  console.log(`initialDiscardLines=${lines.length}`);
  console.log(`initialDiscardAllValidJson=${parsed.length === lines.length}`);
  console.log(`initialDiscardSeqs=${parsed.map((entry) => entry.seq).join(",")}`);
  console.log(`initialDiscardEmittedOversizedSuffix=${stdout.includes("padding")}`);
  console.log(`initialDiscardWarnedPartialRecord=${stderr.includes("partial JSONL record")}`);
}

const tempRoot = mkdtempSync(path.join(os.tmpdir(), "openclaw-voice-call-initial-window-proof-"));
try {
  console.log(`headSha=${execFileSync("git", ["rev-parse", "HEAD"], { encoding: "utf8" }).trim()}`);
  await runLatencyBoundaryProof(tempRoot);
  await runInitialDiscardProof(tempRoot);
} finally {
  rmSync(tempRoot, { recursive: true, force: true });
}
```

</details>

AI-assisted: built with Codex
