### PR TITLE
fix(mxc): bound sandbox policy file reads to prevent OOM

### DIFF
--- a/extensions/mxc/README.md
+++ b/extensions/mxc/README.md
@@ -170,6 +170,17 @@ baseline:
 - A configured policy file that does not exist on the host is an error
   (`Configured sandbox policy file <path> does not exist. Remove it from
 mxcPolicyPaths or create the file.`), not a silent skip.
+- A configured policy file larger than 1 MiB is rejected when the sandbox
+  backend activates (`Configured sandbox policy file <path> exceeds the
+maximum policy file size of 1048576 bytes (1 MiB). Reduce the file to 1 MiB
+or less or remove it from mxcPolicyPaths.`), so policy reads never buffer
+  unbounded operator-supplied content. Policy files above the ceiling must be
+  reduced to 1 MiB or less or removed before upgrading to this MXC version;
+  there is no silent fallback to the built-in baseline.
+- `openclaw doctor` performs a read-only preflight for configured policy files
+  above the ceiling and reports them before an upgrade. Doctor does not remove,
+  rewrite, or silently drop the configured policy; reduce the file to 1 MiB or
+  less or remove its path, then run Doctor again.
 - A policy file that is malformed JSON or includes an unsupported field fails
   with an error naming the policy file path and the invalid field.
 - Every `filesystem.additionalReadonlyPaths` and

--- a/extensions/mxc/doctor-contract-api.ts
+++ b/extensions/mxc/doctor-contract-api.ts
@@ -1,0 +1,39 @@
+// MXC doctor contract warns about policy files that will fail the bounded loader after upgrade.
+import { statSync } from "node:fs";
+import { MAX_SANDBOX_POLICY_FILE_BYTES } from "./src/sandbox-policy-loader.js";
+
+type LegacyConfigRule = {
+  path: string[];
+  message: string;
+  match: (value: unknown, root: Record<string, unknown>) => boolean;
+};
+
+const MXC_POLICY_PATHS = ["plugins", "entries", "mxc", "config", "mxcPolicyPaths"];
+const MXC_POLICY_SIZE_MESSAGE =
+  `Configured MXC policy files include a file larger than ${MAX_SANDBOX_POLICY_FILE_BYTES} bytes (1 MiB). ` +
+  "Reduce each file to 1 MiB or less or remove it from plugins.entries.mxc.config.mxcPolicyPaths before upgrading; do not rely on a silent fallback.";
+
+function hasOversizedPolicyFile(value: unknown): boolean {
+  if (!Array.isArray(value)) {
+    return false;
+  }
+  return value.some((entry) => {
+    if (typeof entry !== "string" || !entry.trim()) {
+      return false;
+    }
+    try {
+      const stats = statSync(entry.trim());
+      return stats.isFile() && stats.size > MAX_SANDBOX_POLICY_FILE_BYTES;
+    } catch {
+      return false;
+    }
+  });
+}
+
+export const legacyConfigRules: LegacyConfigRule[] = [
+  {
+    path: MXC_POLICY_PATHS,
+    message: MXC_POLICY_SIZE_MESSAGE,
+    match: hasOversizedPolicyFile,
+  },
+];

--- a/extensions/mxc/openclaw.plugin.json
+++ b/extensions/mxc/openclaw.plugin.json
@@ -1,6 +1,9 @@
 {
   "id": "mxc",
-  "categories": ["security"],
+  "categories": ["security", "runtime"],
+  "doctorContract": {
+    "configRepair": true
+  },
   "name": "MXC Sandbox Execution",
   "description": "OS-level sandboxed tool execution via MXC: runs commands in a Windows ProcessContainer with configured MXC policy files.",
   "activation": {

--- a/extensions/mxc/src/sandbox-policy-loader.ts
+++ b/extensions/mxc/src/sandbox-policy-loader.ts
@@ -1,6 +1,7 @@
-import { readFileSync, statSync } from "node:fs";
+import { realpathSync, statSync } from "node:fs";
 import { win32 } from "node:path";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { FsSafeError, readRegularFileSync } from "openclaw/plugin-sdk/security-runtime";
 import { z } from "zod";
 import {
   DEFAULT_SANDBOX_BASELINE,
@@ -91,10 +92,24 @@ export function loadSandboxBaselinePolicy(
   };
 }
 
+/**
+ * Cap sandbox policy file reads at 1 MiB. Operator-authored policy files
+ * are configuration artifacts far below this ceiling; rejecting oversized
+ * files before {@link JSON.parse} prevents unbounded memory use.
+ *
+ * Resolve configured symlinks first to preserve existing policyPaths behavior;
+ * {@link readRegularFileSync} still rejects a non-regular final target.
+ */
+export const MAX_SANDBOX_POLICY_FILE_BYTES = 1024 * 1024;
+
 function readSandboxPolicyFile(policyPath: string): SandboxPolicyLayer {
   let parsed: unknown;
   try {
-    parsed = JSON.parse(readFileSync(policyPath, "utf-8"));
+    const { buffer } = readRegularFileSync({
+      filePath: realpathSync(policyPath),
+      maxBytes: MAX_SANDBOX_POLICY_FILE_BYTES,
+    });
+    parsed = JSON.parse(buffer.toString("utf-8"));
   } catch (err) {
     throw policyFileError(policyPath, err);
   }
@@ -307,12 +322,24 @@ function policyFileError(policyPath: string, err: unknown): Error {
       { cause: err },
     );
   }
-  return new Error(
-    `Failed to load sandbox policy file at ${policyPath}: ${formatErrorMessage(err)}`,
-    {
+  if (err instanceof FsSafeError && err.code === "too-large") {
+    return new Error(
+      `Configured sandbox policy file ${policyPath} exceeds the maximum policy file size of ${MAX_SANDBOX_POLICY_FILE_BYTES} bytes (${MAX_SANDBOX_POLICY_FILE_BYTES / (1024 * 1024)} MiB). Reduce the file to 1 MiB or less or remove it from mxcPolicyPaths.`,
+      { cause: err },
+    );
+  }
+  // readRegularFileSync already includes an actionable message with the file
+  // path for oversized and non-regular-file rejections. Preserve that message
+  // as-is and avoid prepending the path a second time.
+  const causeMsg = formatErrorMessage(err);
+  if (causeMsg.includes(policyPath)) {
+    return new Error(`Failed to load sandbox policy file: ${causeMsg}`, {
       cause: err instanceof Error ? err : undefined,
-    },
-  );
+    });
+  }
+  return new Error(`Failed to load sandbox policy file at ${policyPath}: ${causeMsg}`, {
+    cause: err instanceof Error ? err : undefined,
+  });
 }
 
 function formatSandboxPolicyIssue(sourceLabel: string, issue: z.ZodIssue | undefined): string {

--- a/extensions/mxc/test/doctor-contract-api.test.ts
+++ b/extensions/mxc/test/doctor-contract-api.test.ts
@@ -1,0 +1,36 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { legacyConfigRules } from "../doctor-contract-api.js";
+import { MAX_SANDBOX_POLICY_FILE_BYTES } from "../src/sandbox-policy-loader.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+describe("mxc doctor contract", () => {
+  it("warns before upgrade for oversized policy files without mutating config", () => {
+    const dir = mkdtempSync(join(tmpdir(), "openclaw-mxc-doctor-"));
+    tempDirs.push(dir);
+    const smallPath = join(dir, "small.json");
+    const oversizedPath = join(dir, "oversized.json");
+    writeFileSync(smallPath, "{}", "utf8");
+    writeFileSync(oversizedPath, Buffer.alloc(MAX_SANDBOX_POLICY_FILE_BYTES + 1, 0x20));
+
+    const rule = legacyConfigRules[0];
+    expect(rule).toBeDefined();
+    const policyPaths = [smallPath, oversizedPath];
+
+    expect(rule?.match?.(policyPaths, {})).toBe(true);
+    expect(policyPaths).toEqual([smallPath, oversizedPath]);
+    expect(rule?.match?.([smallPath], {})).toBe(false);
+    expect(rule?.match?.([join(dir, "missing.json")], {})).toBe(false);
+    expect(rule?.message).toContain("before upgrading");
+    expect(rule?.message).toContain("1 MiB or less");
+  });
+});

--- a/extensions/mxc/test/sandbox-policy-loader.test.ts
+++ b/extensions/mxc/test/sandbox-policy-loader.test.ts
@@ -1,8 +1,11 @@
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, test } from "vitest";
-import { loadSandboxBaselinePolicy } from "../src/sandbox-policy-loader.js";
+import {
+  loadSandboxBaselinePolicy,
+  MAX_SANDBOX_POLICY_FILE_BYTES,
+} from "../src/sandbox-policy-loader.js";
 
 const describeOnWindows = describe.runIf(process.platform === "win32");
 
@@ -222,5 +225,57 @@ describeOnWindows("loadSandboxBaselinePolicy validation", () => {
         item.detail,
       );
     }
+  });
+});
+
+describe("sandbox policy bounded reads", () => {
+  test("small valid policy file loads successfully", () => {
+    const dir = makeTestDir();
+    const policyPath = join(dir, "normal-policy.json");
+    writePolicy(policyPath, {
+      filesystem: { additionalReadonlyPaths: [] },
+      process: { timeoutSeconds: 60 },
+    });
+
+    const policy = loadSandboxBaselinePolicy({ policyPaths: [policyPath] });
+
+    expect(policy.process.timeoutSeconds).toBe(60);
+  });
+
+  test("loads a configured policy through a symlink", () => {
+    const dir = makeTestDir();
+    const targetPath = join(dir, "target-policy.json");
+    const policyPath = join(dir, "linked-policy.json");
+    writePolicy(targetPath, { process: { timeoutSeconds: 45 } });
+    symlinkSync(targetPath, policyPath, "file");
+
+    const policy = loadSandboxBaselinePolicy({ policyPaths: [policyPath] });
+
+    expect(policy.process.timeoutSeconds).toBe(45);
+  });
+
+  test("accepts a policy file at the inclusive size limit", () => {
+    const dir = makeTestDir();
+    const policyPath = join(dir, "boundary-policy.json");
+    const policyJson = JSON.stringify({ process: { timeoutSeconds: 45 } });
+    writeFileSync(
+      policyPath,
+      policyJson + " ".repeat(MAX_SANDBOX_POLICY_FILE_BYTES - Buffer.byteLength(policyJson)),
+      "utf-8",
+    );
+
+    const policy = loadSandboxBaselinePolicy({ policyPaths: [policyPath] });
+
+    expect(policy.process.timeoutSeconds).toBe(45);
+  });
+
+  test("oversized policy file is rejected with the documented size limit", () => {
+    const dir = makeTestDir();
+    const policyPath = join(dir, "huge-policy.json");
+    writeFileSync(policyPath, "x".repeat(MAX_SANDBOX_POLICY_FILE_BYTES + 1), "utf-8");
+
+    expect(() => loadSandboxBaselinePolicy({ policyPaths: [policyPath] })).toThrow(
+      `Configured sandbox policy file ${policyPath} exceeds the maximum policy file size of ${MAX_SANDBOX_POLICY_FILE_BYTES} bytes (${MAX_SANDBOX_POLICY_FILE_BYTES / (1024 * 1024)} MiB). Reduce the file to 1 MiB or less or remove it from mxcPolicyPaths.`,
+    );
   });
 });


### PR DESCRIPTION
## Conflict Repair (2026-09-11)

The latest head `552d0aa15c881cbc2f4b3bb34f477ec7421b149b` is rebased onto current `origin/main` `68b7893b3ca977a238af165717f7bc2a40e1a8f0`. The only conflict was the additive MXC plugin manifest change; the resolution preserves main's security category and the PR's runtime category and read-only Doctor contract. The conflict-resolution focused tests passed, and no review request was issued.

## What Problem This Solves

`readSandboxPolicyFile` in the MXC extension used unbounded `readFileSync` to load user-supplied sandbox policy JSON files, allowing a very large policy file to exhaust memory during policy loading.

## Why This Change Was Made

The policy file read now resolves configured symlinks before using `readRegularFileSync` from `openclaw/plugin-sdk/security-runtime`, capped at 1 MiB. This preserves the existing `policyPaths` behavior while rejecting oversized files before JSON parsing and requiring the final target to remain a regular file.

## User Impact

Operators configuring custom MXC sandbox policies are protected against accidental OOM from oversized files without breaking existing symlink-based policy paths.

## Supported policy-file contract

Policy files are operator-controlled configuration artifacts, and the 1 MiB read ceiling is now an explicit, documented part of the supported `mxcPolicyPaths` surface ([README](extensions/mxc/README.md#sandbox-policy-files)):

- A configured policy file larger than 1 MiB fails closed at sandbox-backend activation with an actionable error naming the file and the limit (`Configured sandbox policy file <path> exceeds the maximum policy file size of 1048576 bytes (1 MiB). Reduce the file to 1 MiB or less or remove it from mxcPolicyPaths.`).
- Existing policy files above the ceiling must be reduced to 1 MiB or less or removed before upgrading to this MXC version; there is no silent fallback to the built-in baseline.
- Symlinked policy paths keep working; the bounded read resolves the symlink first and still requires a regular final target.
- `openclaw doctor` now has a read-only plugin contract that reports existing configured policy files above the ceiling before upgrade. It does not rewrite, remove, or silently drop `mxcPolicyPaths`; operators remediate the file and rerun Doctor.

## Evidence

### Real behavior proof (production module, public API)

```text
$ pnpm exec tsx proof-live.ts
boundaryBytes=1048576
symlinkTimeoutSeconds=60
oversizedRejected=true
oversizedMessage=Error: Configured sandbox policy file <tmpdir>/oversized.json exceeds the maximum policy file size of 1048576 bytes (1 MiB). Reduce the file to 1 MiB or less or remove it from mxcPolicyPaths.
missingRejected=true
```

Run on the exact head (`552d0aa15c881cbc2f4b3bb34f477ec7421b149b`) on macOS with real filesystem I/O. The temporary proof script exercises `loadSandboxBaselinePolicy` (the changed module's public API). A symlink to a valid policy padded to exactly the 1 MiB compatibility boundary loads successfully; a 1 MiB + 1 byte file is rejected before parsing with the documented contract message; and the existing missing-file behavior remains intact. The script was removed after the run and is embedded below for reproducibility.

The bounded read relies on `@openclaw/fs-safe` (0.5.6) `readRegularFileSync`, whose internal implementation was inspected in the installed package: it stats the file first and rejects non-regular and oversized targets before reading, then reads through a chunked bounded reader that never allocates more than `maxBytes + 1`, so a file growing after the stat cannot force an unbounded buffer.

### Tests

```
$ node scripts/run-vitest.mjs extensions/mxc/test/sandbox-policy-loader.test.ts extensions/mxc/test/doctor-contract-api.test.ts

 Test Files  2 passed (2)
      Tests  5 passed | 8 skipped (13)
   Duration  1.29s
```

4 cross-platform bounded-read tests pass (normal policy, symlinked policy, exact 1 MiB boundary acceptance, and > 1 MiB rejection), plus the read-only Doctor warning contract. 8 additional Windows-only tests are skipped on macOS and remain covered on their target platform.

<details>
<summary>proof test source</summary>

```ts
import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
import { tmpdir } from "node:os";
import { join } from "node:path";
import { loadSandboxBaselinePolicy } from "./extensions/mxc/src/sandbox-policy-loader.js";

const limit = 1024 * 1024;
const dir = mkdtempSync(join(tmpdir(), "openclaw-mxc-proof-"));

try {
  const boundaryPath = join(dir, "boundary.json");
  const symlinkPath = join(dir, "linked.json");
  const oversizedPath = join(dir, "oversized.json");
  const missingPath = join(dir, "missing.json");
  const policyJson = JSON.stringify({ process: { timeoutSeconds: 60 } });

  writeFileSync(boundaryPath, policyJson + " ".repeat(limit - Buffer.byteLength(policyJson)));
  symlinkSync(boundaryPath, symlinkPath, "file");
  const policy = loadSandboxBaselinePolicy({ policyPaths: [symlinkPath] });
  console.log(`boundaryBytes=${limit}`);
  console.log(`symlinkTimeoutSeconds=${policy.process.timeoutSeconds}`);

  writeFileSync(oversizedPath, "x".repeat(limit + 1));
  try {
    loadSandboxBaselinePolicy({ policyPaths: [oversizedPath] });
  } catch (error) {
    const message = String(error);
    console.log(`oversizedRejected=${message.includes("exceeds the maximum policy file size of 1048576 bytes")}`);
    console.log(`oversizedMessage=${message.replace(tmpdir(), "<tmpdir>")}`);
  }

  try {
    loadSandboxBaselinePolicy({ policyPaths: [missingPath] });
  } catch (error) {
    console.log(`missingRejected=${String(error).includes("does not exist")}`);
  }
} finally {
  rmSync(dir, { force: true, recursive: true });
}
```
</details>

AI-assisted: built with Codex
