### PR TITLE
fix: reject malformed UTF-8 in live provider model catalog responses

### DIFF
--- a/src/plugin-sdk/provider-catalog-live-runtime.ts
+++ b/src/plugin-sdk/provider-catalog-live-runtime.ts
@@ -157,7 +157,7 @@ async function readLiveModelCatalogJson(response: Response, timeoutMs: number): 
     onIdleTimeout: ({ chunkTimeoutMs }) =>
       new Error(`Live model catalog response stalled: no data received for ${chunkTimeoutMs}ms`),
   });
-  return JSON.parse(new TextDecoder().decode(buffer));
+  return JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(buffer));
 }
 
 function readLiveModelCatalogString(value: unknown): string | undefined {


### PR DESCRIPTION
**What Problem This Solves**

`readLiveModelCatalogJson` in `src/plugin-sdk/provider-catalog-live-runtime.ts` downloaded provider model catalog JSON responses from the network and decoded them with a forgiving `TextDecoder` (fatal: false), so invalid UTF-8 bytes were silently replaced with U+FFFD before JSON.parse.

**Why This Fix**

This is the same class of issue as the ClawHub fix: a network-origin JSON response should reject invalid UTF-8 at the decoder level, not silently substitute U+FFFD into the parsed payload.

Add `{ fatal: true }` to the TextDecoder so malformed UTF-8 bytes throw immediately, preventing corrupted values from passing JSON.parse and entering the model catalog.

**User Impact**

Before: corrupted live provider model catalog responses could silently produce a model with display name "Pl�" instead of "Plan" (etc.). After: the response is rejected at decode time, causing the catalog fetch to fail and fall back to the static catalog cache — safe to retry.

**Evidence**

- `npx vitest run src/plugin-sdk/provider-catalog-live-runtime.test.ts` — 19 passed, 0 failed
- `oxfmt --check` clean on the changed file