### PR TITLE
fix: reject malformed UTF-8 in APNs relay response bodies

### DIFF
--- a/src/infra/push-apns.relay.test.ts
+++ b/src/infra/push-apns.relay.test.ts
@@ -456,5 +456,34 @@ describe("push-apns.relay", () => {
       expect(result.reason).toBe("RelayResponseTooLarge");
       expect(result.status).toBe(202);
     });
+
+    it("rejects relay body with malformed UTF-8 bytes instead of parsing corrupted metadata", async () => {
+      // Regression guard: with { fatal: true } on the TextDecoder, a relay body
+      // containing invalid UTF-8 sequences must be rejected at decode time and
+      // treated as absent (status-derived fallback). Corrupted field values must
+      // never reach the caller.
+      const encoder = new TextEncoder();
+      const prefix = encoder.encode('{"ok":true,"status":200,"apns-id":"test-');
+      const suffix = encoder.encode('1234"}');
+      const body = new Uint8Array(prefix.length + 1 + suffix.length);
+      body.set(prefix, 0);
+      body[prefix.length] = 0xff; // bare invalid byte inside the apns-id string
+      body.set(suffix, prefix.length + 1);
+
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValue(
+          new Response(body, { status: 202, headers: { "content-type": "application/json" } }),
+        );
+      vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+      await expect(sendApnsRelayPush(createRelayPushParams())).resolves.toEqual({
+        ok: true,
+        status: 202,
+        apnsId: undefined,
+        reason: undefined,
+        tokenSuffix: undefined,
+      });
+    });
   });
 });

--- a/src/infra/push-apns.relay.test.ts
+++ b/src/infra/push-apns.relay.test.ts
@@ -463,7 +463,7 @@ describe("push-apns.relay", () => {
       // treated as absent (status-derived fallback). Corrupted field values must
       // never reach the caller.
       const encoder = new TextEncoder();
-      const prefix = encoder.encode('{"ok":true,"status":200,"apns-id":"test-');
+      const prefix = encoder.encode('{"ok":true,"status":200,"apnsId":"test-');
       const suffix = encoder.encode('1234"}');
       const body = new Uint8Array(prefix.length + 1 + suffix.length);
       body.set(prefix, 0);

--- a/src/infra/push-apns.relay.ts
+++ b/src/infra/push-apns.relay.ts
@@ -309,7 +309,7 @@ async function sendApnsRelayRequest(params: {
     const buffer = await readResponseWithLimit(response, APNS_RELAY_MAX_RESPONSE_BYTES, {
       onOverflow: ({ size, maxBytes }) => new ApnsRelayResponseTooLargeError(size, maxBytes),
     });
-    json = JSON.parse(new TextDecoder("utf-8").decode(buffer)) as unknown;
+    json = JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(buffer)) as unknown;
   } catch (err) {
     if (err instanceof ApnsRelayResponseTooLargeError) {
       // Fail closed: an oversized relay body must never be reported as a delivered push.


### PR DESCRIPTION
## Summary

Reject malformed UTF-8 bytes in APNs relay HTTP response bodies with `TextDecoder("utf-8", { fatal: true })` so invalid bytes throw immediately instead of silently becoming U+FFFD in a payload that then passes `JSON.parse`.

## What Problem This Solves

APNs relay response body decoding in `src/infra/push-apns.relay.ts:312` downloads the relay response JSON and decodes it with `new TextDecoder("utf-8")` (default `fatal: false`), so invalid bytes are silently replaced with U+FFFD. The corrupted string then passes `JSON.parse` with mangled field values.

## Root Cause

- Per the WHATWG Encoding standard, `TextDecoder()` defaults to `fatal: false`, which substitutes U+FFFD for malformed sequences instead of throwing.
- Invariant violated: "HTTP response bytes from the APNs relay are always valid UTF-8" — not guaranteed for bytes served through a CDN edge or proxy.

## Why This Fix

Add `{ fatal: true }` to the TextDecoder so malformed UTF-8 bytes throw a `TypeError` before `JSON.parse`. The existing `catch` block already handles throw: the non-overflow catch branch treats the body as absent, which means the relay reports `ok`/`status` from the HTTP response alone — a safe degraded outcome.

## User Impact

- **Before**: corrupted APNs relay response bodies are silently accepted with U+FFFD substitution.
- **After**: corrupted bodies are rejected at decode time; the existing catch handler treats the body as absent — safe to retry.

## Evidence

Proof serves an APNs relay JSON response with a raw `0xFF` byte injected inside a string value. Reads it with the exact `readResponseWithLimit` + `TextDecoder.decode()` pattern used by the codebase.

### Before (on main)
```
$ node proof-utf8-fatal-apns-relay.mjs
[1] APNS RELAY — accepted, apns-id: "test-�1234"
    FAIL: invalid UTF-8 byte silently became U+FFFD

Results: 0 passed, 1 failed
FAIL: some paths did not reject
```

### After (with fix)
```
$ node proof-utf8-fatal-apns-relay.mjs
[2] APNS RELAY — rejected: The encoded data was not valid for encoding utf-8
    PASS: corrupted relay response rejected before parsing

Results: 1 passed, 0 failed
PASS: corrupted APNs relay response rejected with fatal decoder
```

## Tests and Validation

- `npx vitest run src/infra/push-apns.relay.test.ts` — **23 passed, 0 failed**
- `oxfmt --check` clean on the changed file
- Existing regression coverage unaffected; the behavior change is in the runtime `TextDecoder` built-in