### PR TITLE
feat(ui): offer page refresh on protocol-mismatch failure

### DIFF
--- a/ui/src/components/login-gate.test.ts
+++ b/ui/src/components/login-gate.test.ts
@@ -1,0 +1,84 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ConnectErrorDetailCodes } from "../../../packages/gateway-protocol/src/connect-error-details.js";
+import "./login-gate.ts";
+
+type LoginGateElement = HTMLElement & {
+  props: Record<string, unknown>;
+  updateComplete: Promise<boolean>;
+};
+
+async function mountFailure(lastError: string, lastErrorCode: string | null) {
+  const element = document.createElement("openclaw-login-gate") as LoginGateElement;
+  element.props = {
+    basePath: "",
+    connected: false,
+    lastError,
+    lastErrorCode,
+    hasToken: false,
+    hasPassword: false,
+    gatewayUrl: "ws://127.0.0.1:18789",
+    token: "",
+    password: "",
+    showGatewayToken: false,
+    showGatewayPassword: false,
+    onGatewayUrlChange: vi.fn(),
+    onTokenChange: vi.fn(),
+    onPasswordChange: vi.fn(),
+    onToggleGatewayToken: vi.fn(),
+    onToggleGatewayPassword: vi.fn(),
+    onConnect: vi.fn(),
+  };
+  document.body.append(element);
+  await element.updateComplete;
+  return element;
+}
+
+afterEach(() => {
+  document.body.replaceChildren();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("login gate failure recovery", () => {
+  it("offers page refresh for a protocol mismatch and reloads when selected", async () => {
+    const element = await mountFailure(
+      "protocol mismatch",
+      ConnectErrorDetailCodes.PROTOCOL_MISMATCH,
+    );
+    const reload = vi.fn();
+    vi.stubGlobal("window", { location: { reload } });
+
+    const failure = element.querySelector<HTMLElement>(
+      '.login-gate__failure[data-kind="protocol-mismatch"]',
+    );
+    const refresh = failure?.querySelector<HTMLButtonElement>(".login-gate__failure-refresh");
+
+    expect(refresh?.textContent?.trim()).toBe("Refresh page");
+    expect(failure?.querySelector(".login-gate__failure-steps")).not.toBeNull();
+    expect(failure?.querySelector(".login-gate__failure-docs")).not.toBeNull();
+
+    refresh?.click();
+    expect(reload).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    [
+      "auth-required",
+      "unauthorized: gateway token required",
+      ConnectErrorDetailCodes.AUTH_REQUIRED,
+    ],
+    ["network", "WebSocket connection failed", null],
+    [
+      "insecure-context",
+      "device identity required",
+      ConnectErrorDetailCodes.CONTROL_UI_DEVICE_IDENTITY_REQUIRED,
+    ],
+  ])("does not offer page refresh for %s failures", async (kind, error, code) => {
+    const element = await mountFailure(error, code);
+
+    expect(element.querySelector(".login-gate__failure")?.getAttribute("data-kind")).toBe(kind);
+    expect(element.querySelector(".login-gate__failure-refresh")).toBeNull();
+  });
+});

--- a/ui/src/components/login-gate.ts
+++ b/ui/src/components/login-gate.ts
@@ -30,6 +30,7 @@ type LoginFailureFeedback = {
   kind: LoginFailureKind;
   title: string;
   summary: string;
+  refreshAction?: { label: string };
   steps: string[];
   docsHref: string;
   docsLabel: string;
@@ -96,12 +97,14 @@ function buildFeedback(params: {
   summaryKey: string;
   stepKeys: string[];
   stepParams?: Record<string, string>;
+  refreshAction?: { label: string };
 }): LoginFailureFeedback {
   const docsHref = params.docsHref ?? "https://docs.openclaw.ai/web/dashboard";
   return {
     kind: params.kind,
     title: t(params.titleKey, params.stepParams),
     summary: t(params.summaryKey, params.stepParams),
+    refreshAction: params.refreshAction,
     steps: params.stepKeys.map((key) => t(key, params.stepParams)),
     docsHref,
     docsLabel: resolveDocsLabel(docsHref),
@@ -209,6 +212,7 @@ function resolveLoginFailureFeedback(
         "https://docs.openclaw.ai/web/control-ui#debuggingtesting-dev-server--remote-gateway",
       titleKey: "login.failure.protocol.title",
       summaryKey: "login.failure.protocol.summary",
+      refreshAction: { label: t("login.failure.protocol.refresh") },
       stepKeys: [
         "login.failure.protocol.stepDashboard",
         "login.failure.protocol.stepDevUi",
@@ -264,6 +268,11 @@ function resolveLoginFailureFeedback(
   });
 }
 
+function refreshLoginGatePage() {
+  // The login gate blocks before the composer mounts, so there is no draft to preserve.
+  window.location.reload();
+}
+
 function renderLoginFailure(feedback: LoginFailureFeedback) {
   return html`
     <div
@@ -274,6 +283,17 @@ function renderLoginFailure(feedback: LoginFailureFeedback) {
     >
       <div class="login-gate__failure-title">${feedback.title}</div>
       <div class="login-gate__failure-summary">${feedback.summary}</div>
+      ${feedback.refreshAction
+        ? html`
+            <button
+              type="button"
+              class="btn primary login-gate__failure-refresh"
+              @click=${refreshLoginGatePage}
+            >
+              ${feedback.refreshAction.label}
+            </button>
+          `
+        : nothing}
       <ol class="login-gate__failure-steps">
         ${feedback.steps.map((step) => html`<li>${step}</li>`)}
       </ol>

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -3592,6 +3592,7 @@ export const en: TranslationMap = {
         title: "Protocol mismatch",
         summary:
           "The served Control UI and the running Gateway do not agree on the supported connection protocol.",
+        refresh: "Refresh page",
         stepDashboard:
           "Reopen the served dashboard with openclaw dashboard so the UI and Gateway come from the same install.",
         stepDevUi:


### PR DESCRIPTION
## What Problem This Solves

When the served Control UI and the running Gateway disagree on the connection protocol (terminal `PROTOCOL_MISMATCH`), the login gate already shows a failure card with troubleshooting steps and the gateway-URL/reconnect controls — but no one-click way to do the thing that most often fixes it. A stale served UI bundle is a common cause of protocol mismatch, and simply reloading the page fetches the compatible bundle; today the card only tells the user to check the dashboard and restart servers.

Follow-up to the stale-tab work: #111619 (already on `main`) handles the *non-terminal* stale-bundle case with the version-mismatch update banner. This PR fills the remaining gap on the *terminal* protocol-mismatch card only.

## Why This Change Was Made

Adds a primary **"Refresh page"** action to the protocol-mismatch failure card (that failure kind only), reusing the existing `btn primary` styling. It calls `window.location.reload()`. The existing troubleshooting steps, docs link, and gateway-URL + Connect controls are all preserved, so a mismatch caused by selecting a wrong/older gateway stays correctable by editing the URL and reconnecting — the refresh is offered as the likely fix, not the only path. No composer-preservation is needed (the login gate is a pre-connect blocking screen with no mounted composer; noted in a code comment).

No new module, config, or protocol; no stale-bundle/version logic (that's #111619's domain). ~20 production lines.

## User Impact

A user stuck on the protocol-mismatch screen after an upgrade can recover with one click instead of hunting through server-restart steps.

## Evidence

- `node scripts/run-vitest.mjs ui/src/components/login-gate.test.ts` — green: protocol-mismatch feedback exposes the refresh action and the button triggers `location.reload()`; auth-required / network / insecure-origin failures do NOT render it.
- `pnpm ui:i18n:verify` (keyless) green; one English source key added (`login.failure.protocol.refresh`), no generated baseline drift.
- Structured autoreview (codex/gpt-5.6-sol, xhigh): clean first pass, "patch is correct" (0.94).
- No mock-dev toggle exists to force a real installed-version protocol skew; the component test is the repeatable verification path.
