### PR TITLE
fix(providers): usage returns empty data when a provider response is malformed

### DIFF
--- a/extensions/clawrouter/usage.test.ts
+++ b/extensions/clawrouter/usage.test.ts
@@ -283,7 +283,7 @@ describe("ClawRouter usage", () => {
           }),
         ),
       }),
-    ).rejects.toThrow("ClawRouter usage response exceeds");
+    ).rejects.toThrow("ClawRouter usage: JSON response exceeds");
   });
 
   it("fetches usage through the production SSRF-guarded transport", async () => {

--- a/extensions/clawrouter/usage.test.ts
+++ b/extensions/clawrouter/usage.test.ts
@@ -218,7 +218,7 @@ describe("ClawRouter usage", () => {
         timeoutMs: 5000,
         fetchGuard: mockFetchGuard(new Response(body)),
       }),
-    ).rejects.toThrow(TypeError);
+    ).rejects.toThrow("ClawRouter usage: malformed JSON response");
   });
 
   it("cancels non-OK usage response body before throwing", async () => {

--- a/extensions/clawrouter/usage.ts
+++ b/extensions/clawrouter/usage.ts
@@ -1,6 +1,6 @@
 import { withTrustedEnvProxyGuardedFetchMode } from "openclaw/plugin-sdk/fetch-runtime";
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import type { ProviderUsageSnapshot } from "openclaw/plugin-sdk/provider-usage";
-import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import {
   fetchWithSsrFGuard,
   ssrfPolicyFromHttpBaseUrlAllowedHostname,
@@ -76,15 +76,12 @@ async function readClawRouterUsagePayload(
   response: Response,
   timeoutMs: number,
 ): Promise<ClawRouterUsagePayload> {
-  const buffer = await readResponseWithLimit(response, CLAWROUTER_USAGE_RESPONSE_MAX_BYTES, {
+  return await readProviderJsonResponse(response, "ClawRouter usage", {
+    maxBytes: CLAWROUTER_USAGE_RESPONSE_MAX_BYTES,
     chunkTimeoutMs: timeoutMs,
-    onOverflow: ({ maxBytes }) => new Error(`ClawRouter usage response exceeds ${maxBytes} bytes`),
     onIdleTimeout: ({ chunkTimeoutMs }) =>
       new Error(`ClawRouter usage response stalled: no data received for ${chunkTimeoutMs}ms`),
   });
-  return JSON.parse(
-    new TextDecoder("utf-8", { fatal: true }).decode(buffer),
-  ) as ClawRouterUsagePayload;
 }
 
 export async function fetchClawRouterUsage(params: {

--- a/extensions/openrouter/usage.test.ts
+++ b/extensions/openrouter/usage.test.ts
@@ -218,6 +218,23 @@ describe("OpenRouter usage", () => {
     ]);
   });
 
+  it("rejects malformed UTF-8 in successful usage responses", async () => {
+    const malformed = new Uint8Array([
+      ...new TextEncoder().encode('{"data":{"usage":"2'),
+      0xff,
+      ...new TextEncoder().encode('"}}'),
+    ]);
+    const snapshot = await fetchOpenRouterUsage({
+      token: "router-key",
+      timeoutMs: 5000,
+      fetchFn: vi.fn(async () => new Response(malformed)) as unknown as typeof fetch,
+    });
+
+    expect(snapshot.error).toBe("Malformed usage response");
+    expect(snapshot.windows).toEqual([]);
+    expect(snapshot.billing).toBeUndefined();
+  });
+
   it("returns a bounded HTTP error when neither endpoint is available", async () => {
     const snapshot = await fetchOpenRouterUsage({
       token: "router-key",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where provider usage could appear successful but empty when a provider returned malformed UTF-8 inside an otherwise JSON-shaped response.

## Why This Change Was Made

The ClawRouter usage reader now uses the shared bounded provider JSON boundary, which decodes UTF-8 fatally and normalizes malformed JSON errors. OpenRouter keeps the same strict boundary and gains regression coverage for malformed UTF-8 responses. Existing byte limits and response-idle deadlines remain in place.

## User Impact

Malformed provider usage responses are reported as unavailable/malformed instead of being decoded permissively and presented as an apparently valid empty usage report.

## Evidence

- Full affected usage test files passed: 39 tests across Anthropic, ClawRouter, OpenAI, OpenRouter, and Venice.
- Formatting passed for all affected usage source and test files.
- Oxlint passed for the changed ClawRouter and OpenRouter source/test files.
- Strong live proof over real loopback TCP with a child HTTP server: OpenRouter credits/key requests containing invalid UTF-8 returned the stable `Malformed usage response` snapshot, and ClawRouter returned `ClawRouter usage: malformed JSON response`. Authorization headers were observed on every request.
