### PR TITLE
fix: reject malformed UTF-8 in proxy gateway error response bodies

### DIFF
--- a/src/agents/runtime/proxy.ts
+++ b/src/agents/runtime/proxy.ts
@@ -198,7 +198,7 @@ async function readProxyErrorData(
     onIdleTimeout: ({ chunkTimeoutMs }) =>
       new Error(`Proxy error body stalled: no data received for ${chunkTimeoutMs}ms`),
   });
-  return JSON.parse(new TextDecoder().decode(bytes)) as { error?: string };
+  return JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(bytes)) as { error?: string };
 }
 
 async function readProxySseChunk(


### PR DESCRIPTION
## Summary

Reject malformed UTF-8 bytes in proxy gateway error response bodies with TextDecoder("utf-8", { fatal: true }) so invalid bytes throw immediately instead of silently becoming U+FFFD.

## What Problem This Solves

readProxyErrorData in src/agents/runtime/proxy.ts:201 downloads proxy error JSON responses and decodes them with a forgiving TextDecoder (default fatal: false), so invalid bytes are silently replaced with U+FFFD. The corrupted error message then passes JSON.parse and is used as the gateway error string.

## Root Cause

- Per the WHATWG Encoding standard, TextDecoder() defaults to fatal: false, which substitutes U+FFFD for malformed sequences instead of throwing.
- Invariant violated: HTTP response bytes from the proxy gateway are always valid UTF-8.

## Why This Fix

Add { fatal: true } to the TextDecoder so malformed UTF-8 bytes throw a TypeError before JSON.parse. The caller already has a try/catch that swallows non-body-overflow errors and falls back to the HTTP status message.

## User Impact

- Before: corrupted proxy error responses are silently accepted with U+FFFD substitution.
- After: corrupted bodies are rejected at decode time; the existing catch handler falls back to the HTTP status-based error message.

## Evidence

Proof serves a proxy error JSON response with a raw 0xFF byte injected inside the error string value. Reads it with the exact pattern used by the codebase.

### Before (on main)


### After (with fix)


## Tests and Validation

- npx vitest run src/agents/runtime/proxy.test.ts — 28 passed, 0 failed
- oxfmt --check clean on the changed file
