### PR TITLE
fix: keep streaming OpenAI-compatible requests admitted

### DIFF
--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -15,6 +15,10 @@ import { HISTORY_CONTEXT_MARKER } from "../auto-reply/reply/history.js";
 import { CURRENT_MESSAGE_MARKER } from "../auto-reply/reply/mentions.js";
 import { resetConfigRuntimeState } from "../config/config.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
+import {
+  GatewayDrainingError,
+  isGatewaySubordinateWorkAdmissionClosed,
+} from "../process/gateway-work-admission.js";
 import { buildAssistantDeltaResult } from "./test-helpers.agent-results.js";
 import {
   agentCommand,
@@ -2330,6 +2334,32 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
       );
     },
   );
+
+  it("keeps streaming agent work admitted after the HTTP handler returns", async () => {
+    const port = enabledPort;
+    agentCommand.mockClear();
+    agentCommand.mockImplementationOnce((async () => {
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      if (isGatewaySubordinateWorkAdmissionClosed()) {
+        throw new GatewayDrainingError();
+      }
+      return { payloads: [{ text: "hello" }] };
+    }) as never);
+
+    const res = await postChatCompletions(port, {
+      stream: true,
+      model: "openclaw",
+      messages: [{ role: "user", content: "hi" }],
+    });
+
+    expect(res.status).toBe(200);
+    const data = parseSseDataLines(await res.text());
+    expect(data.at(-1)).toBe("[DONE]");
+    expect(data.join("\n")).toContain("hello");
+    expect(data.join("\n")).not.toContain("Error: internal error");
+  });
 
   it("buffers replaceable assistant events for streaming chat completions", async () => {
     const port = enabledPort;

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -33,6 +33,7 @@ import {
   type InputImageLimits,
   type InputImageSource,
 } from "../media/input-files.js";
+import { runWithGatewayIndependentRootWorkContinuation } from "../process/gateway-work-admission.js";
 import { defaultRuntime } from "../runtime.js";
 import {
   isReplaceableAssistantStreamEvent,
@@ -1282,7 +1283,7 @@ export async function handleOpenAiHttpRequest(
   wroteRole = true;
   writeAssistantRoleChunk(res, { runId, model });
 
-  void (async () => {
+  void runWithGatewayIndependentRootWorkContinuation(async () => {
     try {
       const result = await agentCommandFromIngress(commandInput, defaultRuntime, deps);
       resultResolved = true;
@@ -1424,7 +1425,7 @@ export async function handleOpenAiHttpRequest(
         });
       }
     }
-  })();
+  });
 
   return true;
 }

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -10,6 +10,10 @@ import { HISTORY_CONTEXT_MARKER } from "../auto-reply/reply/history.js";
 import { CURRENT_MESSAGE_MARKER } from "../auto-reply/reply/mentions.js";
 import { resetConfigRuntimeState } from "../config/config.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
+import {
+  GatewayDrainingError,
+  isGatewaySubordinateWorkAdmissionClosed,
+} from "../process/gateway-work-admission.js";
 import { IMAGE_ONLY_USER_MESSAGE } from "./agent-prompt.js";
 import { buildAssistantDeltaResult } from "./test-helpers.agent-results.js";
 import {
@@ -1093,6 +1097,32 @@ describe("OpenResponses HTTP API (e2e)", () => {
     } finally {
       await server.close({ reason: "openresponses token auth owner test done" });
     }
+  });
+
+  it("keeps streaming agent work admitted after the HTTP handler returns", async () => {
+    const port = enabledPort;
+    agentCommand.mockClear();
+    agentCommand.mockImplementationOnce((async () => {
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      if (isGatewaySubordinateWorkAdmissionClosed()) {
+        throw new GatewayDrainingError();
+      }
+      return { payloads: [{ text: "hello" }] };
+    }) as never);
+
+    const res = await postResponses(port, {
+      stream: true,
+      model: "openclaw",
+      input: "hi",
+    });
+
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).toContain("response.completed");
+    expect(text).toContain("hello");
+    expect(text).not.toContain("response.failed");
   });
 
   it("preserves assistant text alongside non-stream function_call output", async () => {

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -32,6 +32,7 @@ import {
   type InputImageLimits,
   type InputImageSource,
 } from "../media/input-files.js";
+import { runWithGatewayIndependentRootWorkContinuation } from "../process/gateway-work-admission.js";
 import { defaultRuntime } from "../runtime.js";
 import {
   isReplaceableAssistantStreamEvent,
@@ -1108,7 +1109,7 @@ export async function handleOpenResponsesHttpRequest(
     unsubscribe();
   });
 
-  void (async () => {
+  void runWithGatewayIndependentRootWorkContinuation(async () => {
     try {
       const result = await runResponsesAgentCommand({
         message: prompt.message,
@@ -1363,7 +1364,7 @@ export async function handleOpenResponsesHttpRequest(
         });
       }
     }
-  })();
+  });
 
   return true;
 }


### PR DESCRIPTION
Closes #111752

## What Problem This Solves

Fixes an issue where users of the OpenAI-compatible streaming HTTP APIs would receive an internal-error stream because the detached agent run inherited a root-work admission that was released when the HTTP handler returned.

## Why This Change Was Made

The streaming lifecycles for both `/v1/chat/completions` and the sibling `/v1/responses` endpoint now run through the existing independent-root continuation primitive. This reserves tracked work before the handler returns while preserving restart and suspension admission behavior.

## User Impact

Streaming Chat Completions and Responses requests can continue their agent run after the HTTP handler begins the SSE response instead of failing with `GatewayDrainingError`.

## Evidence

Environment: macOS arm64, Node v25.9.0, pnpm 11.2.2, current `main` after rebase.

- Added real local Gateway HTTP regressions for both streaming endpoints. Before the production change, both tests failed: Chat Completions emitted `Error: internal error`; Responses emitted `response.failed`.
- `pnpm test src/gateway/openai-http.test.ts src/gateway/openresponses-http.test.ts --run` — 2 files, 54 tests passed after the fix and again after rebasing onto current `main`.
- `pnpm exec oxfmt --check ...` and targeted `oxlint --deny-warnings ...` — passed for all four changed files.
- `pnpm build` — passed.
- Full `pnpm check` was not claimed: 15 emitted repository guards passed, but the all-package npm shrinkwrap guard produced no completion after 415 seconds and was interrupted.

## AI Assistance

AI-assisted. I reviewed the relevant HTTP admission boundary, detached streaming paths, independent-root primitive, sibling Responses implementation, and focused Gateway tests, and I understand the submitted change.