### PR TITLE
fix: reject malformed UTF-8 in Discord API response bodies

### DIFF
--- a/extensions/discord/src/api.ts
+++ b/extensions/discord/src/api.ts
@@ -219,7 +219,7 @@ export async function requestDiscord<T>(
               ),
           },
         );
-        const text = new TextDecoder().decode(responseBody);
+        const text = new TextDecoder("utf-8", { fatal: true }).decode(responseBody);
         if (!text.trim()) {
           return undefined as T;
         }


### PR DESCRIPTION
## Summary

Reject malformed UTF-8 bytes in Discord API response bodies with TextDecoder("utf-8", { fatal: true }) so invalid bytes throw immediately instead of silently becoming U+FFFD.

## What Problem This Solves

fetchDiscord in extensions/discord/src/api.ts:222 downloads Discord API JSON responses and decodes them with a forgiving TextDecoder (default fatal: false), so invalid bytes are silently replaced with U+FFFD. The corrupted text then passes JSON.parse with mangled field values.

## Root Cause

- Per the WHATWG Encoding standard, TextDecoder() defaults to fatal: false, which substitutes U+FFFD for malformed sequences instead of throwing.
- Invariant violated: "HTTP response bytes from Discord API are always valid UTF-8."

## Why This Fix

Add { fatal: true } to the TextDecoder so malformed UTF-8 bytes throw a TypeError before JSON.parse. The existing catch block catches JSON.parse errors and throws DiscordApiError("malformed JSON") - and the TypeError from TextDecoder will propagate to the caller's error handling, which is already robust.

## User Impact

- Before: corrupted Discord API responses are silently accepted with U+FFFD substitution.
- After: corrupted responses are rejected at decode time, surfacing the encoding error.

## Evidence

Proof serves a Discord API JSON response with a raw 0xFF byte injected inside a string value. Reads it with the exact pattern used by the codebase.

### Before (on main)
```
[1] DISCORD API (before) - accepted, username: "test<0xFF>user"
    FAIL: invalid UTF-8 byte silently became U+FFFD
Results: 0 passed, 1 failed
```

### After (with fix)
```
[2] DISCORD API (after) - rejected: The encoded data was not valid for encoding utf-8
    PASS: corrupted Discord API response rejected before JSON.parse
Results: 1 passed, 0 failed
```

## Tests and Validation

- npx vitest run extensions/discord/src/api.test.ts -- 18 passed, 0 failed
- oxfmt --check clean on the changed file
