### PR TITLE
fix(media-core): recognize audio/aac as an audio hint for ambiguous ISOBMFF bytes

### DIFF
--- a/packages/media-core/src/mime.test.ts
+++ b/packages/media-core/src/mime.test.ts
@@ -259,10 +259,16 @@ describe("mime detection", () => {
       expected: "video/mp4",
     },
     {
-      name: "audio/aac elementary-stream metadata",
+      name: "audio/aac header with isom-brand bytes",
       filePath: "voice.aac",
       headerMime: "audio/aac",
-      expected: "video/mp4",
+      expected: "audio/aac",
+    },
+    {
+      name: "aac extension with isom-brand bytes and no header",
+      filePath: "voice.aac",
+      headerMime: undefined,
+      expected: "audio/aac",
     },
   ] as const)("resolves ambiguous isom-brand bytes from $name", async (testCase) => {
     await expectDetectedMime({

--- a/packages/media-core/src/mime.ts
+++ b/packages/media-core/src/mime.ts
@@ -91,6 +91,7 @@ const AMBIGUOUS_VIDEO_MIME_BY_AUDIO_MIME: Readonly<Record<string, string>> = {
   "audio/mp4": "video/mp4",
   "audio/x-m4a": "video/mp4",
   "audio/m4a": "video/mp4",
+  "audio/aac": "video/mp4",
   "audio/webm": "video/webm",
 };
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where AAC audio files in ISOBMFF (MP4) containers were mis-classified as `video/mp4` instead of `audio/aac`. This affects any consumer that routes media based on `kindFromMime()` — including voice-note transcription, audio capability detection, and channel media attachment processing.

The root cause is that the `AMBIGUOUS_VIDEO_MIME_BY_AUDIO_MIME` disambiguation map in `detectMime()` already had entries for `audio/mp4`, `audio/x-m4a`, and `audio/m4a` (all ISOBMFF-containerized audio types that `file-type` defaults to `video/mp4`), but was missing the canonical IANA type `audio/aac`. When a server serves an AAC-in-MP4 file with `Content-Type: audio/aac` (or when only the `.aac` file extension provides the hint), the map lookup fails and the ambiguous `video/mp4` result is returned as-is.

This is especially relevant for Android-produced voice notes and FFmpeg-transcoded m4a files, where `audio/aac` is a common content-type or file-extension-derived MIME hint.

## Why This Change Was Made

One-line addition of `"audio/aac": "video/mp4"` to the `AMBIGUOUS_VIDEO_MIME_BY_AUDIO_MIME` map. This follows the exact same pattern as the three existing ISOBMFF audio entries (`audio/mp4`, `audio/x-m4a`, `audio/m4a`). No other code paths change — the map is consumed only by `detectMime()` in the same file, which already checks both `mimeHints` (from header/content-type) and `extMime` (from file extension) against this map.

## User Impact

- Voice notes and AAC audio files served from CDNs or messaging platforms with `audio/aac` content-type are now correctly classified as audio, preserving transcription and audio-capability routing.
- `.aac` files whose ISOBMFF bytes are sniffed as `video/mp4` by `file-type` are now correctly disambiguated as audio when no explicit content-type header is present.

## Evidence

### Test proof

The existing test `"audio/aac elementary-stream metadata"` at [mime.test.ts:262](packages/media-core/src/mime.test.ts#L262) previously **expected** the bug: it asserted `video/mp4` for an `audio/aac` header with ISOBMFF bytes. This test was documenting the missing map entry as if it were correct behavior.

After the fix:
- The renamed test `"audio/aac header with isom-brand bytes"` now correctly expects `audio/aac`
- A new test `"aac extension with isom-brand bytes and no header"` verifies that the extension-only path also resolves to `audio/aac`
- Both tests **fail on unfixed main** (old expected: `video/mp4`; actual on patched: `audio/aac`)
- All 190 media-core tests pass on the patched branch

### Sibling-surface audit

- The `AMBIGUOUS_VIDEO_MIME_BY_AUDIO_MIME` map is consumed exclusively by `detectMime()` in `packages/media-core/src/mime.ts:251-252`. No other file references it.
- The three existing ISOBMFF entries (`audio/mp4`, `audio/x-m4a`, `audio/m4a`) already cover the common m4a variants. The `audio/aac` entry is the only missing canonical type for the same container family.
- Callers of `detectMime()` / `kindFromMime()` in extension code (telegram delivery, send, etc.) benefit from the corrected classification without any changes — the MIME type returned by `detectMime()` is their sole source of truth.
- The fix has no effect on non-ISOBMFF audio (e.g., raw AAC ADTS streams, Ogg, MP3, WAV, FLAC) — those are never sniffed as `video/mp4` by `file-type`, so they never reach the ambiguity map.

### Format & lint

- `pnpm exec oxfmt --check` passes on both changed files