### PR TITLE
fix(bedrock): route Mantle OpenAI Responses models

### DIFF
--- a/extensions/amazon-bedrock-mantle/discovery.test.ts
+++ b/extensions/amazon-bedrock-mantle/discovery.test.ts
@@ -504,7 +504,15 @@ describe("bedrock mantle discovery", () => {
   it("resolves implicit provider when bearer token is set", async () => {
     const mockFetch = vi.fn().mockResolvedValue(
       modelDiscoveryResponse({
-        data: [{ id: "anthropic.claude-sonnet-4-6", object: "model" }],
+        data: [
+          { id: "anthropic.claude-sonnet-4-6", object: "model" },
+          { id: "openai.gpt-5.4", object: "model" },
+          { id: "openai.gpt-5.5", object: "model" },
+          { id: "openai.gpt-5.6-sol", object: "model" },
+          { id: "openai.gpt-5.6-terra", object: "model" },
+          { id: "openai.gpt-5.6-luna", object: "model" },
+          { id: "openai.gpt-oss-120b", object: "model" },
+        ],
       }),
     );
 
@@ -520,7 +528,7 @@ describe("bedrock mantle discovery", () => {
     expect(provider?.api).toBe("openai-completions");
     expect(provider?.auth).toBe("api-key");
     expect(provider?.apiKey).toBe("env:AWS_BEARER_TOKEN_BEDROCK");
-    expect(provider?.models).toHaveLength(6);
+    expect(provider?.models).toHaveLength(12);
     const opus5 = provider?.models?.find((model) => model.id === "anthropic.claude-opus-5");
     expect(opus5).toMatchObject({
       api: "anthropic-messages",
@@ -567,6 +575,32 @@ describe("bedrock mantle discovery", () => {
       contextWindow: 1_000_000,
       maxTokens: 128_000,
     });
+    for (const id of [
+      "openai.gpt-5.4",
+      "openai.gpt-5.5",
+      "openai.gpt-5.6-sol",
+      "openai.gpt-5.6-terra",
+      "openai.gpt-5.6-luna",
+    ]) {
+      expect(provider?.models?.find((model) => model.id === id)).toMatchObject({
+        api: "openai-responses",
+        baseUrl: "https://bedrock-mantle.us-east-1.api.aws/openai/v1",
+        input: ["text", "image"],
+        contextWindow: 272_000,
+      });
+    }
+    expect(provider?.models?.find((model) => model.id === "openai.gpt-oss-120b")).toEqual(
+      expect.objectContaining({
+        input: ["text"],
+        contextWindow: 32_000,
+      }),
+    );
+    expect(provider?.models?.find((model) => model.id === "openai.gpt-oss-120b")).not.toHaveProperty(
+      "api",
+    );
+    expect(provider?.models?.find((model) => model.id === "openai.gpt-oss-120b")).not.toHaveProperty(
+      "baseUrl",
+    );
   });
 
   it("rolls Claude Sonnet 5 to standard pricing on September 1, 2026", async () => {

--- a/extensions/amazon-bedrock-mantle/discovery.ts
+++ b/extensions/amazon-bedrock-mantle/discovery.ts
@@ -257,6 +257,14 @@ const REASONING_PATTERNS = [
   "gpt-oss-safeguard-120b",
 ];
 
+const MANTLE_OPENAI_RESPONSES_MODEL_IDS = new Set([
+  "openai.gpt-5.4",
+  "openai.gpt-5.5",
+  "openai.gpt-5.6-sol",
+  "openai.gpt-5.6-terra",
+  "openai.gpt-5.6-luna",
+]);
+
 function inferReasoningSupport(modelId: string): boolean {
   const lower = normalizeLowercaseStringOrEmpty(modelId);
   return REASONING_PATTERNS.some((p) => lower.includes(p));
@@ -509,10 +517,23 @@ export async function resolveImplicitMantleProvider(params: {
       maxTokens: 128_000,
     },
   ];
+  // These OpenAI models use Mantle's special `/openai/v1/responses` path.
+  // Keep the list exact so other discovered OpenAI models retain the provider default.
+  const modelsWithResponsesOverrides: ModelDefinitionConfig[] = models.map((model) =>
+    MANTLE_OPENAI_RESPONSES_MODEL_IDS.has(model.id)
+      ? {
+          ...model,
+          api: "openai-responses" as const,
+          baseUrl: `${mantleEndpoint(region)}/openai/v1`,
+          input: ["text", "image"],
+          contextWindow: 272_000,
+        }
+      : model,
+  );
   // Replace generic discovery rows so first-match lookup sees exact Claude metadata.
   const exactClaudeModelIds = new Set(claudeModels.map((model) => model.id));
   const allModels = [
-    ...models.filter((model) => !exactClaudeModelIds.has(model.id)),
+    ...modelsWithResponsesOverrides.filter((model) => !exactClaudeModelIds.has(model.id)),
     ...claudeModels,
   ];
 


### PR DESCRIPTION
Closes #108216

## What Problem This Solves

Fixes an issue where users selecting Bedrock Mantle GPT-5.4, GPT-5.5, or GPT-5.6 models would send requests to the generic OpenAI-compatible endpoint instead of Mantle's required Responses endpoint.

## Why This Change Was Made

The Bedrock Mantle plugin now gives the documented GPT-5.4/5.5/5.6 model IDs explicit `openai-responses` routing and the `/openai/v1` base path. Other discovered OpenAI models retain the plugin's existing default route.

AWS documents this Responses-only compatibility and endpoint shape in:

- https://docs.aws.amazon.com/bedrock/latest/userguide/models-api-compatibility.html
- https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-54.html
- https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-55.html
- https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-openai-gpt-56-sol.html
- https://aws.amazon.com/blogs/machine-learning/get-started-with-openai-gpt-5-6-sol-terra-and-luna-on-amazon-bedrock/

## User Impact

Users can configure the supported Bedrock Mantle GPT-5.4/5.5/5.6 models without the endpoint mismatch that previously prevented the intended request flow.

## Evidence

- Added focused discovery assertions for all five documented IDs and a generic OpenAI control model.
- Rebased onto current `main`; the PR is mergeable without conflicts.
- `git diff --check` passed.
- Required branch autoreview passed with no accepted or actionable findings.
- All GitHub Actions checks that ran on head `9619ede5027680bb79679a321f61edd41beb4bf1` passed; unrelated path-filtered jobs skipped normally.
- ClawSweeper re-reviewed that exact head, reported no actionable findings, and rated patch quality 4/6.
- A credentialed live Mantle request has not been run from this environment because no AWS credentials are available; this remains explicit follow-up proof rather than a claimed result.
