### PR TITLE
fix(qa-lab): close stalled upgrade sockets

### DIFF
--- a/extensions/qa-lab/src/lab-server-ui.test.ts
+++ b/extensions/qa-lab/src/lab-server-ui.test.ts
@@ -1,11 +1,15 @@
 // Qa Lab tests cover lab server ui plugin behavior.
+import { once } from "node:events";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import net, { type NetConnectOpts, type Server, type Socket } from "node:net";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import tls from "node:tls";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   detectContentType,
   missingUiHtml,
+  proxyUpgradeRequest,
   resolveUiAssetVersion,
   tryResolveUiAsset,
 } from "./lab-server-ui.js";
@@ -13,6 +17,7 @@ import {
 const cleanups: Array<() => Promise<void>> = [];
 
 afterEach(async () => {
+  vi.restoreAllMocks();
   while (cleanups.length > 0) {
     await cleanups.pop()?.();
   }
@@ -88,5 +93,325 @@ describe("qa-lab server ui helpers", () => {
     );
 
     expect(tryResolveUiAsset("/%E0%A4", uiDistDir, uiDistDir)).toBeNull();
+  });
+});
+
+const UPGRADE_RESPONSE = "HTTP/1.1 101 Switching Protocols\r\nConnection: Upgrade\r\n\r\n";
+const BAD_GATEWAY_RESPONSE = "HTTP/1.1 502 Bad Gateway\r\nConnection: close\r\n\r\n";
+const GATEWAY_TIMEOUT_RESPONSE = "HTTP/1.1 504 Gateway Timeout\r\nConnection: close\r\n\r\n";
+
+const TEST_TLS_OPTIONS = {
+  ciphers: "aNULL:@SECLEVEL=0",
+  minVersion: "TLSv1.2",
+  maxVersion: "TLSv1.2",
+} as const;
+
+function trackServer<T extends Server>(server: T): T {
+  const sockets = new Set<Socket>();
+  server.on("connection", (socket) => {
+    sockets.add(socket);
+    socket.once("close", () => sockets.delete(socket));
+  });
+  cleanups.push(async () => {
+    for (const socket of sockets) {
+      socket.destroy();
+    }
+    if (server.listening) {
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+    }
+  });
+  return server;
+}
+
+async function listenLoopback(server: Server, host = "127.0.0.1"): Promise<number> {
+  server.listen(0, host);
+  await once(server, "listening");
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("loopback server did not expose a TCP port");
+  }
+  return address.port;
+}
+
+async function openBrowserPair(): Promise<{ browser: Socket; proxySocket: Socket }> {
+  let resolveProxySocket!: (socket: Socket) => void;
+  const proxySocketPromise = new Promise<Socket>((resolve) => {
+    resolveProxySocket = resolve;
+  });
+  const server = trackServer(
+    net.createServer({ allowHalfOpen: true }, (socket) => resolveProxySocket(socket)),
+  );
+  const port = await listenLoopback(server);
+  const browser = net.connect({ host: "127.0.0.1", port });
+  await once(browser, "connect");
+  const proxySocket = await proxySocketPromise;
+  cleanups.push(async () => {
+    browser.destroy();
+    proxySocket.destroy();
+  });
+  return { browser, proxySocket };
+}
+
+function buildUpgradeRequest() {
+  return {
+    httpVersion: "1.1",
+    method: "GET",
+    rawHeaders: ["Host", "ignored.local", "Connection", "Upgrade", "Upgrade", "websocket"],
+    url: "/control-ui/socket?client=qa",
+  };
+}
+
+function runUpgradeProxy(params: { proxySocket: Socket; target: URL }) {
+  proxyUpgradeRequest({
+    req: buildUpgradeRequest() as never,
+    socket: params.proxySocket,
+    head: Buffer.alloc(0),
+    target: params.target,
+  });
+}
+
+async function readUntil(socket: Socket, marker: string, timeoutMs = 2_000): Promise<string> {
+  return await new Promise<string>((resolve, reject) => {
+    let body = "";
+    const timer = setTimeout(() => finish(new Error(`timed out waiting for ${marker}`)), timeoutMs);
+    const finish = (error?: Error) => {
+      clearTimeout(timer);
+      socket.off("data", onData);
+      socket.off("error", onError);
+      socket.off("close", onClose);
+      if (error) {
+        reject(error);
+      } else {
+        resolve(body);
+      }
+    };
+    const onData = (chunk: Buffer) => {
+      body += chunk.toString("utf8");
+      if (body.includes(marker)) {
+        finish();
+      }
+    };
+    const onError = (error: Error) => finish(error);
+    const onClose = () => finish(new Error(`socket closed before ${marker}`));
+    socket.on("data", onData);
+    socket.once("error", onError);
+    socket.once("close", onClose);
+  });
+}
+
+async function readToEnd(socket: Socket, timeoutMs = 2_000): Promise<string> {
+  return await new Promise<string>((resolve, reject) => {
+    let body = "";
+    const timer = setTimeout(
+      () => finish(new Error("timed out waiting for socket end")),
+      timeoutMs,
+    );
+    const finish = (error?: Error) => {
+      clearTimeout(timer);
+      socket.off("data", onData);
+      socket.off("end", onEnd);
+      socket.off("error", onError);
+      socket.off("close", onClose);
+      if (error) {
+        reject(error);
+      } else {
+        resolve(body);
+      }
+    };
+    const onData = (chunk: Buffer) => {
+      body += chunk.toString("utf8");
+    };
+    const onEnd = () => finish();
+    const onError = (error: Error) => finish(error);
+    const onClose = () => finish(new Error("socket closed before a clean end"));
+    socket.on("data", onData);
+    socket.once("end", onEnd);
+    socket.once("error", onError);
+    socket.once("close", onClose);
+  });
+}
+
+function collectUpgradeRequest(socket: Socket, resolve: (request: string) => void) {
+  let request = "";
+  socket.on("data", (chunk) => {
+    request += chunk.toString("utf8");
+    if (!request.includes("\r\n\r\n")) {
+      return;
+    }
+    resolve(request);
+    socket.write(UPGRADE_RESPONSE);
+  });
+}
+
+describe("proxyUpgradeRequest loopback transport", () => {
+  it("forwards HTTP upgrades after TCP connect and clears the opening timeout", async () => {
+    let resolveRequest!: (request: string) => void;
+    const requestPromise = new Promise<string>((resolve) => {
+      resolveRequest = resolve;
+    });
+    const upstreamServer = trackServer(
+      net.createServer((socket) => collectUpgradeRequest(socket, resolveRequest)),
+    );
+    const upstreamPort = await listenLoopback(upstreamServer);
+    const { browser, proxySocket } = await openBrowserPair();
+    const setTimeoutSpy = vi.spyOn(net.Socket.prototype, "setTimeout");
+    const removeListenerSpy = vi.spyOn(net.Socket.prototype, "removeListener");
+    const responsePromise = readUntil(browser, "\r\n\r\n");
+
+    runUpgradeProxy({
+      proxySocket,
+      target: new URL(`http://127.0.0.1:${upstreamPort}`),
+    });
+
+    await expect(requestPromise).resolves.toContain("GET /socket?client=qa HTTP/1.1");
+    await expect(responsePromise).resolves.toBe(UPGRADE_RESPONSE);
+    expect(setTimeoutSpy).toHaveBeenCalledWith(10_000);
+    expect(setTimeoutSpy).toHaveBeenCalledWith(0);
+    expect(removeListenerSpy.mock.calls.some(([event]) => event === "timeout")).toBe(true);
+  });
+
+  it("forwards HTTPS upgrades only after the TLS handshake and clears the opening timeout", async () => {
+    const connectTls = tls.connect;
+    vi.spyOn(tls, "connect").mockImplementation(((options: tls.ConnectionOptions) =>
+      connectTls({
+        ...options,
+        ...TEST_TLS_OPTIONS,
+        rejectUnauthorized: false,
+      })) as typeof tls.connect);
+
+    let resolveRequest!: (request: string) => void;
+    const requestPromise = new Promise<string>((resolve) => {
+      resolveRequest = resolve;
+    });
+    const upstreamServer = trackServer(
+      tls.createServer(TEST_TLS_OPTIONS, (socket) => collectUpgradeRequest(socket, resolveRequest)),
+    );
+    const upstreamPort = await listenLoopback(upstreamServer, "localhost");
+    const { browser, proxySocket } = await openBrowserPair();
+    const setTimeoutSpy = vi.spyOn(net.Socket.prototype, "setTimeout");
+    const removeListenerSpy = vi.spyOn(net.Socket.prototype, "removeListener");
+    const responsePromise = readUntil(browser, "\r\n\r\n");
+
+    runUpgradeProxy({
+      proxySocket,
+      target: new URL(`https://localhost:${upstreamPort}`),
+    });
+
+    await expect(requestPromise).resolves.toContain("GET /socket?client=qa HTTP/1.1");
+    await expect(responsePromise).resolves.toBe(UPGRADE_RESPONSE);
+    expect(setTimeoutSpy).toHaveBeenCalledWith(10_000);
+    expect(setTimeoutSpy).toHaveBeenCalledWith(0);
+    expect(removeListenerSpy.mock.calls.some(([event]) => event === "timeout")).toBe(true);
+  });
+
+  it("returns a flushed 504 and closes both sockets when TLS stays silent after TCP connect", async () => {
+    let resolveUpstream!: (socket: Socket) => void;
+    const upstreamPromise = new Promise<Socket>((resolve) => {
+      resolveUpstream = resolve;
+    });
+    const upstreamServer = trackServer(
+      net.createServer((socket) => {
+        socket.resume();
+        resolveUpstream(socket);
+      }),
+    );
+    const upstreamPort = await listenLoopback(upstreamServer, "localhost");
+    const { browser, proxySocket } = await openBrowserPair();
+    const setTimeoutSpy = vi.spyOn(net.Socket.prototype, "setTimeout");
+    const endSpy = vi.spyOn(proxySocket, "end");
+    const responsePromise = readToEnd(browser, 14_000);
+
+    runUpgradeProxy({
+      proxySocket,
+      target: new URL(`https://localhost:${upstreamPort}`),
+    });
+
+    const upstreamSocket = await upstreamPromise;
+    const upstreamClosed = once(upstreamSocket, "close");
+    await expect(responsePromise).resolves.toBe(GATEWAY_TIMEOUT_RESPONSE);
+    await upstreamClosed;
+    expect(setTimeoutSpy).toHaveBeenCalledWith(10_000);
+    expect(endSpy).toHaveBeenCalledWith(GATEWAY_TIMEOUT_RESPONSE, expect.any(Function));
+    expect(upstreamSocket.destroyed).toBe(true);
+    expect(proxySocket.destroyed).toBe(true);
+  }, 16_000);
+
+  it("closes a connecting upstream exactly once when the browser sends EOF", async () => {
+    const upstreamServer = trackServer(net.createServer());
+    const upstreamPort = await listenLoopback(upstreamServer);
+    const { browser, proxySocket } = await openBrowserPair();
+    const upstream = new net.Socket();
+    const destroySpy = vi.spyOn(upstream, "destroy");
+    let connectTimer: ReturnType<typeof setTimeout> | undefined;
+    vi.spyOn(net, "connect").mockImplementationOnce(((options: NetConnectOpts) => {
+      connectTimer = setTimeout(() => {
+        if (!upstream.destroyed) {
+          upstream.connect(options);
+        }
+      }, 50);
+      return upstream;
+    }) as typeof net.connect);
+    cleanups.push(async () => {
+      if (connectTimer) {
+        clearTimeout(connectTimer);
+      }
+      upstream.destroy();
+    });
+    const proxyEnded = once(proxySocket, "end");
+
+    runUpgradeProxy({
+      proxySocket,
+      target: new URL(`http://127.0.0.1:${upstreamPort}`),
+    });
+    browser.end();
+
+    await proxyEnded;
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+    expect(destroySpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns a flushed 502 when the upstream resets before its upgrade response", async () => {
+    const upstreamServer = trackServer(
+      net.createServer((socket) => {
+        socket.once("data", () => socket.resetAndDestroy());
+      }),
+    );
+    const upstreamPort = await listenLoopback(upstreamServer);
+    const { browser, proxySocket } = await openBrowserPair();
+    const endSpy = vi.spyOn(proxySocket, "end");
+    const responsePromise = readToEnd(browser);
+
+    runUpgradeProxy({
+      proxySocket,
+      target: new URL(`http://127.0.0.1:${upstreamPort}`),
+    });
+
+    await expect(responsePromise).resolves.toBe(BAD_GATEWAY_RESPONSE);
+    expect(endSpy).toHaveBeenCalledWith(BAD_GATEWAY_RESPONSE, expect.any(Function));
+    expect(proxySocket.destroyed).toBe(true);
+  });
+
+  it("returns a flushed 502 when the upstream connection is refused", async () => {
+    const refusedServer = net.createServer();
+    const refusedPort = await listenLoopback(refusedServer);
+    await new Promise<void>((resolve) => {
+      refusedServer.close(() => resolve());
+    });
+    const { browser, proxySocket } = await openBrowserPair();
+    const endSpy = vi.spyOn(proxySocket, "end");
+    const responsePromise = readToEnd(browser);
+
+    runUpgradeProxy({
+      proxySocket,
+      target: new URL(`http://127.0.0.1:${refusedPort}`),
+    });
+
+    await expect(responsePromise).resolves.toBe(BAD_GATEWAY_RESPONSE);
+    expect(endSpy).toHaveBeenCalledWith(BAD_GATEWAY_RESPONSE, expect.any(Function));
+    expect(proxySocket.destroyed).toBe(true);
   });
 });

--- a/extensions/qa-lab/src/lab-server-ui.ts
+++ b/extensions/qa-lab/src/lab-server-ui.ts
@@ -203,6 +203,10 @@ export async function proxyHttpRequest(params: {
   params.req.pipe(upstreamReq);
 }
 
+// Bound only the opening transport stage. Established WebSocket streams remain
+// unbounded after TCP connect for HTTP or the completed handshake for HTTPS.
+const PROXY_UPSTREAM_CONNECT_TIMEOUT_MS = 10_000;
+
 export function proxyUpgradeRequest(params: {
   req: IncomingMessage;
   socket: Duplex;
@@ -212,16 +216,19 @@ export function proxyUpgradeRequest(params: {
 }) {
   const requestUrl = new URL(params.req.url ?? "/", "http://127.0.0.1");
   const port = Number(params.target.port || (params.target.protocol === "https:" ? 443 : 80));
+  const usesTls = params.target.protocol === "https:";
   const upstream =
     params.target.protocol === "https:"
       ? tls.connect({
           host: params.target.hostname,
           port,
           servername: params.target.hostname,
+          timeout: PROXY_UPSTREAM_CONNECT_TIMEOUT_MS,
         })
       : net.connect({
           host: params.target.hostname,
           port,
+          timeout: PROXY_UPSTREAM_CONNECT_TIMEOUT_MS,
         });
 
   const headerLines: string[] = [];
@@ -238,7 +245,40 @@ export function proxyUpgradeRequest(params: {
     headerLines.push(`${name}: ${value}`);
   }
 
-  upstream.once("connect", () => {
+  let responseStarted = false;
+  let upstreamClosed = false;
+  const closeUpstream = () => {
+    if (!upstreamClosed) {
+      upstreamClosed = true;
+      upstream.destroy();
+    }
+  };
+  const closeBoth = () => {
+    closeUpstream();
+    params.socket.destroy();
+  };
+  const failOpening = (status: "502 Bad Gateway" | "504 Gateway Timeout") => {
+    if (responseStarted || upstreamClosed) {
+      return;
+    }
+    closeUpstream();
+    if (!params.socket.destroyed) {
+      params.socket.end(`HTTP/1.1 ${status}\r\nConnection: close\r\n\r\n`, () =>
+        params.socket.destroy(),
+      );
+    }
+  };
+  const onOpeningTimeout = () => {
+    failOpening("504 Gateway Timeout");
+  };
+
+  upstream.once("timeout", onOpeningTimeout);
+  upstream.once(usesTls ? "secureConnect" : "connect", () => {
+    if (upstreamClosed) {
+      return;
+    }
+    upstream.setTimeout(0);
+    upstream.removeListener("timeout", onOpeningTimeout);
     const requestText = [
       `${params.req.method ?? "GET"} ${rewriteControlUiProxyPath(requestUrl.pathname, requestUrl.search)} HTTP/${params.req.httpVersion}`,
       `Host: ${params.target.host}`,
@@ -255,21 +295,17 @@ export function proxyUpgradeRequest(params: {
     params.socket.pipe(upstream);
   });
 
-  const closeBoth = () => {
-    if (!params.socket.destroyed) {
-      params.socket.destroy();
-    }
-    if (!upstream.destroyed) {
-      upstream.destroy();
-    }
-  };
-
+  upstream.once("data", () => {
+    responseStarted = true;
+  });
   upstream.on("error", () => {
-    if (!params.socket.destroyed) {
-      params.socket.write("HTTP/1.1 502 Bad Gateway\r\nConnection: close\r\n\r\n");
+    if (!responseStarted) {
+      failOpening("502 Bad Gateway");
+      return;
     }
     closeBoth();
   });
+  params.socket.on("end", closeBoth);
   params.socket.on("error", closeBoth);
   params.socket.on("close", closeBoth);
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening the QA Lab Control UI could leave a WebSocket upgrade hanging indefinitely when the upstream TCP connection or TLS handshake stalled. Browser disconnects during opening could also leave the upstream socket alive, while pre-upgrade failures could drop the intended 502/504 response.

## Why This Change Was Made

`proxyUpgradeRequest` owns the opening transport lifecycle. The canonical flow now:

- treats HTTP `connect` and HTTPS `secureConnect` as transport readiness;
- keeps the 10-second inactivity timeout until that readiness event, then disables and removes it;
- closes the upstream exactly once when the client ends, errors, or closes;
- keeps pre-response upstream errors on the flushed 502 path;
- destroys the upstream before ending the client with a 502/504 response and destroys the client only from the `end` callback.

No policy, limit, config, dependency, docs, or changelog surface changed.

## User Impact

Control UI upgrade attempts now complete, fail visibly, or clean up. Silent TLS peers time out with 504, refused or reset upstreams return 502, and browser EOF does not leak the upstream connection.

## Evidence

- Exact head: `f122a272ed8dc7a1ed85af329ba5173e98435cc9`.
- Current-main red control at `2ae316e2f33d0a196192731e5fe1b66117d348b1`: 4 failed, 6 passed through the real `proxyUpgradeRequest` socket path.
- Fixed loopback suite: 11 passed, covering HTTP success, HTTPS `secureConnect`, TCP-connected silent TLS timeout with both sockets closed, browser EOF cleanup, refused upstream 502, reset-before-response 502, and flushed 504.
- Focused command: `node scripts/run-vitest.mjs extensions/qa-lab/src/lab-server-ui.test.ts --reporter=verbose`.
- Targeted `oxfmt` and `git diff --check`: clean.
- Structured autoreview: no findings, patch correct, confidence 0.99.
- Local exact-range ClawSweeper review (`4841e4e6b96275d5c298de4fb71c2a9754c457c4..f122a272ed8dc7a1ed85af329ba5173e98435cc9`): patch correct, no findings, confidence 0.93.
- Main CI contract repair #121942 is included in the base; its previously failing focused test passes 11/11 on this head.
- Production LOC: +48/-12. Test LOC: +326/-1. Production growth owns the explicit socket lifecycle and flushed failure contract.
- Node v26.5.0 source contract inspected directly:
  - `lib/net.js`: connection timeout is installed on the socket; timeout emits a notification and does not close it.
  - `lib/internal/tls/wrap.js`: the TLS callback runs on `secureConnect`, after handshake/authentication.
  - `lib/internal/streams/writable.js`: `end(data, callback)` waits for the write/finish path, while immediate destruction can discard buffered output.
- Regression provenance: the proxy path originated in #67430 by @gumadeiras.
- Contributor credit is preserved by `Co-authored-by: xydt-juyaohui <266015826+xydt-juyaohui@users.noreply.github.com>`.
- Exact-head CI: green (82 successful, 48 skipped, 1 neutral) in https://github.com/openclaw/openclaw/actions/runs/31475394947.
- Exact-head public ClawSweeper re-review: no findings, best-fix confirmed, proof sufficient, and no remaining rank-up action after CI completed; https://github.com/openclaw/clawsweeper/actions/runs/31475526084.
- Native `scripts/pr prepare-gates 111784`: passed in `hosted_exact_or_recent_parent` mode.
- Punchcard receipt: unavailable; the CLI returned `skipped` before mutation and emitted no session receipt.
