### PR TITLE
fix(logging): keep environment lookup snippets readable

### DIFF
--- a/src/infra/exec-approval-command-display.test.ts
+++ b/src/infra/exec-approval-command-display.test.ts
@@ -115,6 +115,16 @@ describe("sanitizeExecApprovalDisplayText", () => {
     expect(result).toContain("https://api.example.com");
   });
 
+  it("preserves a same-key programmatic env lookup when a separate secret triggers bypass", () => {
+    const lookup = "OPENAI_API_KEY=process.env.OPENAI_API_KEY";
+    const cmd = `${lookup} echo sk-abc123\u200B456789012345678`;
+    const result = sanitizeExecApprovalDisplayText(cmd);
+
+    expect(result).toContain(lookup);
+    expect(result).not.toContain("sk-abc123");
+    expect(result).not.toContain("456789012345678");
+  });
+
   it("masks newly added vendor token prefixes through the default redaction path", () => {
     const token = "glpat-abcdefghijklmnopqrstuv";
     const result = sanitizeExecApprovalDisplayText(`deploy --with ${token}`);

--- a/src/logging/redact.test.ts
+++ b/src/logging/redact.test.ts
@@ -137,6 +137,95 @@ describe("redactSensitiveText", () => {
     expect(output).toBe(input);
   });
 
+  it("preserves programmatic env lookups in assignments", () => {
+    const key = "OPENAI_API_KEY";
+    const assignment = (value: string) => `${key}=${value}`;
+    const input = [
+      assignment(`process.env.${key}`),
+      assignment(`process.env["${key}"]`),
+      assignment(`Deno.env.get("${key}")`),
+      assignment(`os.getenv("${key}")`),
+      assignment(`os.environ["${key}"]`),
+      assignment(`os.environ.get("${key}")`),
+      assignment(`$ENV{${key}}`),
+      `${assignment(`process.env.${key}`)};`,
+    ].join("\n");
+    expect(redactSensitiveText(input, { mode: "tools" })).toBe(input);
+  });
+
+  it("does not preserve env lookups with value continuations", () => {
+    const key = "OPENAI_API_KEY";
+    const input = `${key}=os.getenv("${key}", "fallback-value")`;
+    const output = redactSensitiveText(input, { mode: "tools" });
+    expect(output).not.toBe(input);
+    expect(output).not.toContain("os.getenv(");
+  });
+
+  it("does not preserve content appended to an env lookup in the same match", () => {
+    const key = "OPENAI_API_KEY";
+    const appended = "literal-value";
+    const input = `${key}=process.env.${key};${appended}`;
+    const output = redactSensitiveText(input, { mode: "tools" });
+    expect(output).not.toBe(input);
+    expect(output).not.toContain(appended);
+  });
+
+  it("does not preserve programmatic lookups of a different env key", () => {
+    const key = "OPENAI_API_KEY";
+    const otherKey = "PUBLIC_VALUE";
+    const assignment = (value: string) => `${key}=${value}`;
+    const lookups = [
+      `process.env.${otherKey}`,
+      `process.env["${otherKey}"]`,
+      `Deno.env.get("${otherKey}")`,
+      `os.getenv("${otherKey}")`,
+      `os.environ["${otherKey}"]`,
+      `os.environ.get("${otherKey}")`,
+      `$ENV{${otherKey}}`,
+    ];
+    const outputLines = redactSensitiveText(lookups.map(assignment).join("\n"), {
+      mode: "tools",
+    }).split("\n");
+    expect(outputLines).toHaveLength(lookups.length);
+    for (const [index, lookup] of lookups.entries()) {
+      expect(outputLines[index]).not.toBe(assignment(lookup));
+    }
+  });
+
+  it("does not preserve a longer dotted env key with the assigned key as its prefix", () => {
+    const key = "OPENAI_API_KEY";
+    const input = `${key}=process.env.${key}_SUFFIX`;
+    expect(redactSensitiveText(input, { mode: "tools" })).not.toBe(input);
+  });
+
+  it("does not preserve a match based on an assignment nested in its value", () => {
+    const key = "OPENAI_API_KEY";
+    const literal = "literal-value";
+    const input = `${key}=${literal};${key}=process.env.${key}`;
+    const output = redactSensitiveText(input, { mode: "tools" });
+    expect(output).not.toBe(input);
+    expect(output).not.toContain(literal);
+  });
+
+  it("does not preserve lookups with mismatched quote delimiters", () => {
+    const key = "OPENAI_API_KEY";
+    const assignment = (value: string) => `${key}=${value}`;
+    const lookups = [
+      `process.env["${key}']`,
+      `Deno.env.get("${key}')`,
+      `os.getenv("${key}')`,
+      `os.environ["${key}']`,
+      `os.environ.get("${key}')`,
+    ];
+    const outputLines = redactSensitiveText(lookups.map(assignment).join("\n"), {
+      mode: "tools",
+    }).split("\n");
+    expect(outputLines).toHaveLength(lookups.length);
+    for (const [index, lookup] of lookups.entries()) {
+      expect(outputLines[index]).not.toBe(assignment(lookup));
+    }
+  });
+
   it("masks shell env references that do not match the assignment key", () => {
     const output = redactSensitiveText("DISCORD_BOT_TOKEN=$SUPERSECRET123", { mode: "tools" });
     expect(output).toBe("DISCORD_BOT_TOKEN=***");

--- a/src/logging/redact.ts
+++ b/src/logging/redact.ts
@@ -70,6 +70,30 @@ const URL_QUERY_PAIR_RE = new RegExp(
 const SECRET_VALUE_TRAILING_DELIMITER_RE = /(["'`,;)}\]]+)$/u;
 const SECRET_VALUE_SUFFIX_RE = /^["'`,;)}\]]*$/u;
 const SECRET_VALUE_QUOTE_CHARS = new Set(['"', "'", "`"]);
+const PROGRAMMATIC_ENV_LOOKUP_PATTERNS = [
+  { pattern: /^process\.env\.([A-Za-z_][A-Za-z0-9_]*)(?![A-Za-z0-9_])/u, keyGroup: 1 },
+  {
+    pattern: /^process\.env\[\s*(["'])([A-Za-z_][A-Za-z0-9_]*)\1\s*\]/u,
+    keyGroup: 2,
+  },
+  {
+    pattern: /^Deno\.env\.get\(\s*(["'])([A-Za-z_][A-Za-z0-9_]*)\1\s*\)/u,
+    keyGroup: 2,
+  },
+  {
+    pattern: /^os\.getenv\(\s*(["'])([A-Za-z_][A-Za-z0-9_]*)\1\s*\)/u,
+    keyGroup: 2,
+  },
+  {
+    pattern: /^os\.environ\[\s*(["'])([A-Za-z_][A-Za-z0-9_]*)\1\s*\]/u,
+    keyGroup: 2,
+  },
+  {
+    pattern: /^os\.environ\.get\(\s*(["'])([A-Za-z_][A-Za-z0-9_]*)\1\s*\)/u,
+    keyGroup: 2,
+  },
+  { pattern: /^\$ENV\{([A-Za-z_][A-Za-z0-9_]*)\}/u, keyGroup: 1 },
+] as const;
 const FORM_BODY_LINE_BREAK_SPLIT_RE = /(\r\n|\r|\n)/u;
 const FORM_BODY_LINE_BREAK_SEGMENT_RE = /^(?:\r\n|\r|\n)$/u;
 const STRUCTURED_SECRET_FIELD_RE = new RegExp(
@@ -578,6 +602,32 @@ function shouldPreserveShellReferenceMatch(match: string, token: string): boolea
   return key ? isShellReferenceToKey(key, token) : false;
 }
 
+function shouldPreserveProgrammaticEnvLookupMatch(
+  match: string,
+  input: string | undefined,
+  matchOffset: number | undefined,
+): boolean {
+  if (!input || matchOffset == null || matchOffset < 0) {
+    return false;
+  }
+  const assignmentPrefix = match.match(/^(?:[\s,;])?([A-Za-z_][A-Za-z0-9_-]*)\b\s*[=:]\s*/u);
+  if (!assignmentPrefix) {
+    return false;
+  }
+  const rhsStart = matchOffset + assignmentPrefix[0].length;
+  const rhs = input.slice(rhsStart);
+  const lookup = PROGRAMMATIC_ENV_LOOKUP_PATTERNS.map(({ pattern, keyGroup }) => {
+    const matched = rhs.match(pattern);
+    return matched ? { text: matched[0], key: matched[keyGroup] } : undefined;
+  }).find(Boolean);
+  if (!lookup || lookup.key !== assignmentPrefix[1]) {
+    return false;
+  }
+  const lookupEnd = rhsStart + lookup.text.length;
+  const matchEnd = matchOffset + match.length;
+  return matchEnd <= lookupEnd || /^[;,)}\]]*$/u.test(input.slice(lookupEnd, matchEnd));
+}
+
 function isEmptyShellParameterExpansionTail(token: string): boolean {
   return /^[-=?+]\}$/.test(token);
 }
@@ -685,7 +735,9 @@ function redactMatch(
   // assignment key are not masked.
   if (
     isShellReferencePattern &&
-    (shouldPreserveShellReferenceMatch(match, token) || isEmptyShellParameterExpansionTail(token))
+    (shouldPreserveShellReferenceMatch(match, token) ||
+      shouldPreserveProgrammaticEnvLookupMatch(match, context?.input, context?.offset) ||
+      isEmptyShellParameterExpansionTail(token))
   ) {
     return match;
   }

--- a/src/logging/redact.ts
+++ b/src/logging/redact.ts
@@ -632,6 +632,20 @@ function isEmptyShellParameterExpansionTail(token: string): boolean {
   return /^[-=?+]\}$/.test(token);
 }
 
+function shouldPreserveShellReferencePatternMatch(
+  match: string,
+  token: string,
+  pattern: RegExp,
+  context?: { input?: string; offset?: number },
+): boolean {
+  return (
+    shellReferencePreservingPatterns.has(pattern) &&
+    (shouldPreserveShellReferenceMatch(match, token) ||
+      shouldPreserveProgrammaticEnvLookupMatch(match, context?.input, context?.offset) ||
+      isEmptyShellParameterExpansionTail(token))
+  );
+}
+
 function hasBackreferenceToGroup(pattern: RegExp, groupNumber: number): boolean {
   return new RegExp(String.raw`\\${groupNumber}(?!\d)`).test(pattern.source);
 }
@@ -729,22 +743,16 @@ function redactMatch(
   if (splitSecretValueForMask(formAwareValue.secret).maskable === "***") {
     return match;
   }
-  const isShellReferencePattern = shellReferencePreservingPatterns.has(pattern);
   // Preserve shell variable references (e.g. `MY_TOKEN=$MY_TOKEN`) for assignment patterns
   // registered as shell-reference-preserving, so non-secret expansions that merely echo the
   // assignment key are not masked.
-  if (
-    isShellReferencePattern &&
-    (shouldPreserveShellReferenceMatch(match, token) ||
-      shouldPreserveProgrammaticEnvLookupMatch(match, context?.input, context?.offset) ||
-      isEmptyShellParameterExpansionTail(token))
-  ) {
+  if (shouldPreserveShellReferencePatternMatch(match, token, pattern, context)) {
     return match;
   }
   // Assignment values can legitimately include trailing shell/structural characters
   // (e.g. `${VAR:-default}`); mask the captured token whole so those characters count toward the
   // retained hint instead of being exposed by delimiter-aware masking.
-  const masked = isShellReferencePattern
+  const masked = shellReferencePreservingPatterns.has(pattern)
     ? maskToken(token)
     : `${maskSecretValue(formAwareValue.secret, { hinted: true })}${formAwareValue.suffix}`;
   if (token === match) {
@@ -832,6 +840,14 @@ function markPatternMatchRedaction(
     fullMatch,
     match.slice(1).map((value) => (typeof value === "string" ? value : "")),
   );
+  if (
+    shouldPreserveShellReferencePatternMatch(fullMatch, selected.value, pattern, {
+      input,
+      offset: match.index,
+    })
+  ) {
+    return;
+  }
   const tokenStart =
     selected.value === fullMatch
       ? 0


### PR DESCRIPTION
Closes #111785

## What Problem This Solves

Fixes an issue where developers inspecting logs or support output would see valid source snippets corrupted when a secret-named variable was assigned from the same environment variable, for example `MY_API_KEY=process.env.MY_API_KEY`.

## Why This Change Was Made

The redactor now preserves a small allowlist of complete programmatic environment lookup expressions only when the referenced environment key exactly matches the assigned key. It continues to redact different-key lookups, malformed expressions, fallback arguments, appended values, and nested assignments.

## User Impact

Source and configuration snippets that contain environment lookups remain readable and syntactically intact, while literal credentials and ambiguous values keep the existing redaction behavior.

## Evidence

Before on `upstream/main` (`7fe1d70a50`):

```text
input:  MY_API_KEY=process.env.MY_API_KEY
output: MY_API_KEY=proces…_KEY

input:  MY_API_KEY=os.getenv("MY_API_KEY")
output: MY_API_KEY=***"MY_API_KEY")
```

After:

```text
input:  MY_API_KEY=process.env.MY_API_KEY
output: MY_API_KEY=process.env.MY_API_KEY

input:  MY_API_KEY=os.getenv("MY_API_KEY")
output: MY_API_KEY=os.getenv("MY_API_KEY")
```

Validation:

- `vitest run src/logging/redact.test.ts`: 150/150 passed
- `oxlint --type-aware src/logging/redact.ts src/logging/redact.test.ts`: passed
- `oxfmt src/logging/redact.ts src/logging/redact.test.ts`: clean
- `git diff --check upstream/main...HEAD`: clean
- Full branch autoreview against latest `upstream/main`: clean, patch correct (0.88)

Security-focused regressions cover same-key lookups, different keys, longer key prefixes, malformed quote pairs, fallback arguments, appended content, nested assignments, and custom redaction-pattern behavior.
