### PR TITLE
fix(doctor): include sandbox workspace copies in legacy workspace state repair (fixes #111661)

### DIFF
--- a/src/agents/workspace-dirs.ts
+++ b/src/agents/workspace-dirs.ts
@@ -4,8 +4,16 @@
  * File sync and cleanup paths use this to enumerate configured agent workspaces
  * plus the default agent workspace without duplicating agent-scope logic.
  */
+import fs from "node:fs";
+import path from "node:path";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "./agent-scope.js";
+import { resolveUserPath } from "../utils.js";
+import {
+  resolveAgentConfig,
+  resolveAgentWorkspaceDir,
+  resolveDefaultAgentId,
+} from "./agent-scope.js";
+import { resolveSandboxConfigForAgent } from "./sandbox/config.js";
 
 /** Lists unique workspace directories for configured agents and the default agent. */
 export function listAgentWorkspaceDirs(cfg: OpenClawConfig): string[] {
@@ -19,5 +27,67 @@ export function listAgentWorkspaceDirs(cfg: OpenClawConfig): string[] {
     }
   }
   dirs.add(resolveAgentWorkspaceDir(cfg, resolveDefaultAgentId(cfg)));
+  return [...dirs];
+}
+
+/**
+ * Lists sandbox workspace copies that can hold retired workspace state.
+ *
+ * Sandboxed agents with non-`rw` access run against a copy under the sandbox
+ * workspace root instead of the configured workspace, so the configured-dir
+ * scan never sees legacy files there while the runtime gate still blocks on
+ * them. Doctor must enumerate these copies to offer the advertised repair.
+ */
+export function listSandboxWorkspaceCopyDirs(params: {
+  cfg: OpenClawConfig;
+  stateDir: string;
+  env?: NodeJS.ProcessEnv;
+  homedir?: () => string;
+}): string[] {
+  const agentIds = new Set<string>();
+  const list = params.cfg.agents?.list;
+  if (Array.isArray(list)) {
+    for (const entry of list) {
+      if (entry && typeof entry === "object" && typeof entry.id === "string") {
+        agentIds.add(entry.id);
+      }
+    }
+  }
+  agentIds.add(resolveDefaultAgentId(params.cfg));
+  const dirs = new Set<string>();
+  for (const agentId of agentIds) {
+    // A broken sandbox section must not take down the whole Doctor scan; other
+    // sources still need detection and repair.
+    try {
+      const sandbox = resolveSandboxConfigForAgent(params.cfg, agentId);
+      if (sandbox.mode === "off" || sandbox.workspaceAccess === "rw") {
+        continue;
+      }
+      // resolveSandboxConfigForAgent falls back to the process state dir; bind an
+      // unset root to the state dir Doctor is actually repairing.
+      const configuredRoot =
+        resolveAgentConfig(params.cfg, agentId)?.sandbox?.workspaceRoot ??
+        params.cfg.agents?.defaults?.sandbox?.workspaceRoot;
+      const root = configuredRoot
+        ? resolveUserPath(configuredRoot, params.env, params.homedir)
+        : path.join(params.stateDir, "sandboxes");
+      if (sandbox.scope === "shared") {
+        dirs.add(root);
+      }
+      let entries: fs.Dirent[];
+      try {
+        entries = fs.readdirSync(root, { withFileTypes: true });
+      } catch {
+        continue;
+      }
+      for (const entry of entries) {
+        if (entry.isDirectory()) {
+          dirs.add(path.join(root, entry.name));
+        }
+      }
+    } catch {
+      continue;
+    }
+  }
   return [...dirs];
 }

--- a/src/infra/state-migrations.workspace-setup.test.ts
+++ b/src/infra/state-migrations.workspace-setup.test.ts
@@ -4,6 +4,8 @@ import fsp from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { assertNoUnmigratedWorkspaceState } from "../agents/workspace-legacy-state.js";
+import { resetLegacyWorkspaceStateCheckForTest } from "../agents/workspace-legacy-state.test-support.js";
 import {
   deleteWorkspaceState,
   prepareWorkspaceStateDeletion,
@@ -28,6 +30,7 @@ describe("legacy workspace Doctor migration", () => {
   const tempDirs = useAutoCleanupTempDirTracker((cleanup) => {
     afterEach(() => {
       closeOpenClawStateDatabaseForTest();
+      resetLegacyWorkspaceStateCheckForTest();
       envSnapshot?.restore();
       envSnapshot = undefined;
       cleanup();
@@ -108,6 +111,108 @@ describe("legacy workspace Doctor migration", () => {
         expect.objectContaining({ kind: "attestation", workspaceKey: orphanKey }),
       ]),
     });
+  });
+
+  it("detects and migrates legacy state in sandbox workspace copies", async () => {
+    const context = setup();
+    const sandboxContext = {
+      ...context,
+      cfg: {
+        agents: {
+          defaults: {
+            workspace: context.workspaceDir,
+            sandbox: { mode: "all", workspaceAccess: "ro" },
+          },
+        },
+      } satisfies OpenClawConfig,
+    };
+    const sandboxCopyDir = path.join(context.stateDir, "sandboxes", "agent-main-deadbeef");
+    await fsp.mkdir(sandboxCopyDir, { recursive: true });
+    const completedAt = "2026-07-15T10:01:00.000Z";
+    const setupPath = path.join(sandboxCopyDir, "openclaw-workspace-state.json");
+    await fsp.writeFile(setupPath, JSON.stringify({ setupCompletedAt: completedAt }), "utf8");
+
+    // The runtime gate blocks the sandboxed turn on the copy, but Doctor must
+    // be able to find and clear it (previously detection missed these dirs).
+    expect(() => assertNoUnmigratedWorkspaceState({ workspaceDir: sandboxCopyDir })).toThrow(
+      /Legacy workspace setup state requires migration/,
+    );
+    const detected = detect(sandboxContext);
+    expect(detected.hasLegacy).toBe(true);
+    expect(detected.sources).toEqual([
+      expect.objectContaining({
+        kind: "setup",
+        sourcePath: path.join(
+          resolveWorkspaceStateIdentity(sandboxCopyDir).workspacePath,
+          "openclaw-workspace-state.json",
+        ),
+      }),
+    ]);
+
+    const result = await migrate(sandboxContext);
+
+    expect(result.warnings).toEqual([]);
+    expect(fs.existsSync(setupPath)).toBe(false);
+    expect(() => assertNoUnmigratedWorkspaceState({ workspaceDir: sandboxCopyDir })).not.toThrow();
+    const identity = resolveWorkspaceStateIdentity(sandboxCopyDir);
+    expect(
+      openOpenClawStateDatabase({ env: context.env })
+        .db.prepare("SELECT setup_completed_at FROM workspace_setup_state WHERE workspace_key = ?")
+        .get(identity.workspaceKey),
+    ).toEqual({ setup_completed_at: completedAt });
+  });
+
+  it.each([
+    { name: "sandbox mode is off", sandbox: { mode: "off", workspaceAccess: "ro" } },
+    { name: "workspace access is rw", sandbox: { mode: "all", workspaceAccess: "rw" } },
+  ] as const)("ignores sandbox copies when $name", async ({ sandbox }) => {
+    const context = setup();
+    const sandboxContext = {
+      ...context,
+      cfg: {
+        agents: {
+          defaults: { workspace: context.workspaceDir, sandbox },
+        },
+      } satisfies OpenClawConfig,
+    };
+    const sandboxCopyDir = path.join(context.stateDir, "sandboxes", "agent-main-deadbeef");
+    await fsp.mkdir(sandboxCopyDir, { recursive: true });
+    await fsp.writeFile(
+      path.join(sandboxCopyDir, "openclaw-workspace-state.json"),
+      JSON.stringify({ setupCompletedAt: "2026-07-15T10:01:00.000Z" }),
+      "utf8",
+    );
+
+    expect(detect(sandboxContext).hasLegacy).toBe(false);
+  });
+
+  it("detects legacy state in a custom sandbox workspace root", async () => {
+    const context = setup();
+    const customRoot = path.join(context.homeDir, "custom-sandboxes");
+    const sandboxCopyDir = path.join(customRoot, "agent-main-deadbeef");
+    await fsp.mkdir(sandboxCopyDir, { recursive: true });
+    await fsp.writeFile(
+      path.join(sandboxCopyDir, "openclaw-workspace-state.json"),
+      JSON.stringify({ setupCompletedAt: "2026-07-15T10:01:00.000Z" }),
+      "utf8",
+    );
+    const sandboxContext = {
+      ...context,
+      cfg: {
+        agents: {
+          defaults: {
+            workspace: context.workspaceDir,
+            sandbox: { mode: "all", workspaceAccess: "ro", workspaceRoot: customRoot },
+          },
+        },
+      } satisfies OpenClawConfig,
+    };
+
+    const detected = detect(sandboxContext);
+
+    expect(detected.sources).toEqual([
+      expect.objectContaining({ kind: "setup", sourcePath: expect.stringContaining(customRoot) }),
+    ]);
   });
 
   it("imports setup and attestation state, records receipts, and removes files", async () => {

--- a/src/infra/state-migrations.workspace-setup.ts
+++ b/src/infra/state-migrations.workspace-setup.ts
@@ -5,7 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { TextDecoder } from "node:util";
 import { root, type Root } from "@openclaw/fs-safe";
-import { listAgentWorkspaceDirs } from "../agents/workspace-dirs.js";
+import { listAgentWorkspaceDirs, listSandboxWorkspaceCopyDirs } from "../agents/workspace-dirs.js";
 import {
   LEGACY_WORKSPACE_ATTESTATION_DIRNAME,
   LEGACY_WORKSPACE_ATTESTATION_HEADER,
@@ -261,7 +261,7 @@ export function detectLegacyWorkspaceState(params: {
     }
   };
 
-  for (const workspaceDir of listAgentWorkspaceDirs(params.cfg)) {
+  const addWorkspaceSources = (workspaceDir: string) => {
     const identity = resolveWorkspaceStateIdentity(workspaceDir);
     const paths = resolveLegacyWorkspaceSourcePaths(workspaceDir, { env, homedir });
     for (const [priority, sourcePath] of paths.setupStatePaths.entries()) {
@@ -315,6 +315,18 @@ export function detectLegacyWorkspaceState(params: {
         }),
       );
     }
+  };
+
+  for (const workspaceDir of listAgentWorkspaceDirs(params.cfg)) {
+    addWorkspaceSources(workspaceDir);
+  }
+  for (const workspaceDir of listSandboxWorkspaceCopyDirs({
+    cfg: params.cfg,
+    stateDir: params.stateDir,
+    env,
+    homedir,
+  })) {
+    addWorkspaceSources(workspaceDir);
   }
 
   for (const source of listOrphanAttestationSources({ stateDir: params.stateDir, homedir })) {


### PR DESCRIPTION
Closes #111661

Note: #111713 addresses the same issue. This take differs in that it enumerates copies only for agents with sandbox mode enabled and non-`rw` workspace access (direction (b) in the issue), covers `shared`-scope roots and custom `workspaceRoot`, and adds regression tests asserting the runtime gate actually clears after repair, with before/after probe proof below.

## What Problem This Solves

Fixes an issue where users with a sandboxed agent (`sandbox.mode` enabled, workspace access not `rw`) would see every agent turn hard-fail with `Legacy workspace setup state requires migration for <sandbox-copy>; run openclaw doctor --fix` when a legacy `openclaw-workspace-state.json` was left behind in the reused per-agent sandbox workspace copy — while `openclaw doctor --fix` reported nothing to migrate, so the advertised recovery path could never clear the error.

## Why This Change Was Made

`detectLegacyWorkspaceState()` only enumerated `listAgentWorkspaceDirs(cfg)` (configured agent workspaces), but the runtime gate `assertNoUnmigratedWorkspaceState()` runs against the effective workspace, which for non-`rw` sandboxed agents is the sandbox copy under the sandbox workspace root (`<stateDir>/sandboxes/<slug>` by default). Doctor now also enumerates those copies — via a new `listSandboxWorkspaceCopyDirs()` helper next to `listAgentWorkspaceDirs()` — for agents with sandbox mode enabled and non-`rw` workspace access, including custom `workspaceRoot` setups and `shared` scope roots, and feeds them through the same detection and SQLite migration path. A broken sandbox config section or an unreadable root is skipped without failing the rest of the scan. Out of scope: how sandbox copies are seeded or pruned; this change is detection/repair only.

## User Impact

Operators hitting the legacy-state turn failure now have a working recovery: `openclaw doctor --fix` finds the retired file inside sandbox workspace copies, imports it into SQLite, removes it, and the agent turns again — instead of requiring the undocumented manual workaround of deleting the file by hand. No behavior change for agents without sandboxing or with `rw` workspace access.

## Evidence

Real probe against the production detection/migration/gate functions, on a real pre-migration state dir (sandbox copy under `<stateDir>/sandboxes/agent-main-deadbeef/` with a legacy `openclaw-workspace-state.json`, config `sandbox.mode: "all"`, `workspaceAccess: "ro"`):

```console
$ node --import tsx probe.mjs        # before fix (upstream/main)
1) runtime gate on sandbox copy THROWS: Legacy workspace setup state requires migration for /tmp/openclaw-111661-d3xkKW/.openclaw/sandboxes/agent-main-deadbeef; run openclaw doctor --fix.
2) doctor detect hasLegacy: false
3-5) skipped: doctor found nothing to migrate (bug: recovery path dead)

$ node --import tsx probe.mjs        # after fix (this branch)
1) runtime gate on sandbox copy THROWS: Legacy workspace setup state requires migration for /tmp/openclaw-111661-NJyr5z/.openclaw/sandboxes/agent-main-deadbeef; run openclaw doctor --fix.
2) doctor detect hasLegacy: true
   detected source: setup /tmp/openclaw-111661-NJyr5z/.openclaw/sandboxes/agent-main-deadbeef/openclaw-workspace-state.json
3) migrate changes: ["Migrated workspace setup state to SQLite."]
3) migrate warnings: []
4) legacy file exists after migrate: false
5) runtime gate on sandbox copy after doctor: CLEAR
```

Focused suite: `src/infra/state-migrations.workspace-setup.test.ts` 33/33 pass (2 of the 3 new tests fail on `main` without this change); sibling suites `workspace-legacy-state`, `state-migrations`, `workspace` 67/67 pass; oxlint/oxfmt clean.

## Real behavior proof

- Behavior or issue addressed: every turn of a sandboxed agent (non-`rw` workspace access) hard-fails when its reused sandbox workspace copy contains a legacy `openclaw-workspace-state.json`, and `openclaw doctor --fix` cannot repair it because detection never scans sandbox copies.
- Real environment tested: Linux x86_64, Node 24.15.0, OpenClaw `main` (9056c43368), production `detectLegacyWorkspaceState` / `migrateLegacyWorkspaceState` from `src/infra/state-migrations.workspace-setup.ts` and `assertNoUnmigratedWorkspaceState` from `src/agents/workspace-legacy-state.ts`.
- Exact steps or command run after this patch: created a real state dir whose `sandboxes/<slug>/` copy contained a legacy `openclaw-workspace-state.json` (layout matches `resolveSandboxWorkspaceLayoutPaths`), with config `sandbox.mode: "all"`, `workspaceAccess: "ro"`, then ran `node --import tsx probe.mjs` calling the real production functions before and after the patch.
- Evidence after fix:

```console
$ node --import tsx probe.mjs
1) runtime gate on sandbox copy THROWS: Legacy workspace setup state requires migration for /tmp/openclaw-111661-NJyr5z/.openclaw/sandboxes/agent-main-deadbeef; run openclaw doctor --fix.
2) doctor detect hasLegacy: true
   detected source: setup /tmp/openclaw-111661-NJyr5z/.openclaw/sandboxes/agent-main-deadbeef/openclaw-workspace-state.json
3) migrate changes: ["Migrated workspace setup state to SQLite."]
3) migrate warnings: []
4) legacy file exists after migrate: false
5) runtime gate on sandbox copy after doctor: CLEAR
```

- Observed result after fix: doctor detects the retired setup file inside the sandbox copy, migrates it into SQLite with no warnings, removes the file, and the runtime gate that hard-failed every turn clears. Before the patch the same probe printed `hasLegacy: false` and the recovery path was dead.
- What was not tested: end-to-end `openclaw doctor --fix` CLI run against a live gateway with a real Docker sandbox container; the sandbox copy layout was created directly per the production path derivation.

## Regression test plan

- Target test file: `src/infra/state-migrations.workspace-setup.test.ts`
- Scenario locked in: a legacy `openclaw-workspace-state.json` inside a sandbox copy is detected and migrated (default `<stateDir>/sandboxes` root and custom `workspaceRoot`), after which `assertNoUnmigratedWorkspaceState` no longer throws for that copy; copies are ignored when sandbox mode is `off` or workspace access is `rw`.

## Risk checklist

- User-visible behavior changed? Yes — `openclaw doctor --fix` now also repairs retired workspace state inside sandbox workspace copies of sandbox-enabled agents.
- Config/env/migration changed? No new config keys; doctor detection surface widened to sandbox copies.
- Security/auth/secrets/network/tool-exec changed? No.
