### PR TITLE
fix(plugins): marketplace feed loads when HTTP proxy is required

### DIFF
--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -2,9 +2,11 @@ import crypto from "node:crypto";
 import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { EnvHttpProxyAgent } from "undici";
 import { describe, expect, it, vi } from "vitest";
 import officialExternalPluginCatalog from "../../scripts/lib/official-external-plugin-catalog.json" with { type: "json" };
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { withEnvAsync } from "../test-utils/env.js";
 import { createSqliteHostedOfficialExternalPluginCatalogSnapshotStore } from "./official-external-plugin-catalog-snapshot-store.js";
 import {
   type HostedOfficialExternalPluginCatalogSnapshot,
@@ -411,26 +413,39 @@ describe("official external plugin catalog", () => {
       const headers = new Headers(init?.headers);
       expect(headers.get("accept")).toBe("application/vnd.dsse+json");
       expect(headers.has("if-modified-since")).toBe(false);
+      expect((init as RequestInit & { dispatcher?: unknown }).dispatcher).toBeInstanceOf(
+        EnvHttpProxyAgent,
+      );
       return dsseResponse(signed.body, { status: 200 });
     });
 
-    const result = await loadHostedCatalog({
-      catalogConfig: {
-        feeds: {
-          "clawhub-public": {
-            url: "https://clawhub.ai/v1/feeds/plugins",
-            feedId: "clawhub-official",
-            verification: {
-              mode: "signed",
-              keys: [{ keyId: "acme-root", publicKey: signed.publicKeyPem }],
+    const result = await withEnvAsync(
+      {
+        HTTPS_PROXY: "http://127.0.0.1:7890",
+        https_proxy: undefined,
+        NO_PROXY: "",
+        no_proxy: undefined,
+        OPENCLAW_PROXY_ACTIVE: undefined,
+      },
+      async () =>
+        await loadHostedCatalog({
+          catalogConfig: {
+            feeds: {
+              "clawhub-public": {
+                url: "https://clawhub.ai/v1/feeds/plugins",
+                feedId: "clawhub-official",
+                verification: {
+                  mode: "signed",
+                  keys: [{ keyId: "acme-root", publicKey: signed.publicKeyPem }],
+                },
+              },
             },
           },
-        },
-      },
-      ifModifiedSince: "Mon, 22 Jun 2026 00:00:00 GMT",
-      fetchImpl,
-      snapshotStore: null,
-    });
+          ifModifiedSince: "Mon, 22 Jun 2026 00:00:00 GMT",
+          fetchImpl,
+          snapshotStore: null,
+        }),
+    );
 
     expect(fetchImpl).toHaveBeenCalledOnce();
     expectHosted(result);

--- a/src/plugins/official-external-plugin-catalog.ts
+++ b/src/plugins/official-external-plugin-catalog.ts
@@ -1120,17 +1120,20 @@ async function loadHostedOfficialExternalPluginCatalogEntries(params?: {
   let response: Response | undefined;
   let release: (() => Promise<void>) | undefined;
   try {
-    const { fetchWithSsrFGuard } = await import("../infra/net/fetch-guard.js");
-    const guarded = await fetchWithSsrFGuard({
-      url: url.href,
-      fetchImpl: params?.fetchImpl,
-      init: { method: "GET", headers },
-      requireHttps: true,
-      maxRedirects: 2,
-      timeoutMs: params?.timeoutMs ?? DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_TIMEOUT_MS,
-      policy: { hostnameAllowlist: source.hostnameAllowlist },
-      auditContext: "official-external-plugin-catalog-feed",
-    });
+    const { fetchWithSsrFGuard, withTrustedEnvProxyGuardedFetchMode } =
+      await import("../infra/net/fetch-guard.js");
+    const guarded = await fetchWithSsrFGuard(
+      withTrustedEnvProxyGuardedFetchMode({
+        url: url.href,
+        fetchImpl: params?.fetchImpl,
+        init: { method: "GET", headers },
+        requireHttps: true,
+        maxRedirects: 2,
+        timeoutMs: params?.timeoutMs ?? DEFAULT_HOSTED_OFFICIAL_EXTERNAL_PLUGIN_CATALOG_TIMEOUT_MS,
+        policy: { hostnameAllowlist: source.hostnameAllowlist },
+        auditContext: "official-external-plugin-catalog-feed",
+      }),
+    );
     response = guarded.response;
     release = guarded.release;
     const base = metadataBase(response);


### PR DESCRIPTION
## What Problem This Solves

Proxy-only operators silently received the bundled marketplace fallback because
the official hosted plugin catalog used strict guarded fetch. Strict mode kept
destination DNS and egress local instead of selecting the operator's trusted
`HTTPS_PROXY`.

## Root Cause And Owner

The official external plugin catalog owns this request. Its existing HTTPS,
hostname allowlist, two-redirect limit, timeout, audit context, redirect
revalidation, signed-feed verification, snapshots, and bundled fallback were
already correct. The missing piece was selecting the existing trusted
environment-proxy guarded-fetch mode at that owner boundary.

The canonical fix wraps the existing catalog fetch with
`withTrustedEnvProxyGuardedFetchMode`. It adds no proxy policy, config, fallback,
dependency, or security exception.

## Production And Test Delta

- Production: `+14/-11`, net `+3`.
- Tests: `+30/-15`, net `+15`.
- The obsolete standalone proxy test was deleted during the current-main
  rewrite. The existing signed-feed integration test now asserts that the
  injected dispatcher is Undici's `EnvHttpProxyAgent` while the result remains
  hosted and signed.

## Verification

- Current-main regression: the dispatcher assertion failed before the production
  wrapper while signed parsing continued through the existing integration path.
- Catalog suite: 80/80 passed.
- Fetch-guard SSRF suite: 106/106 passed.
- Targeted oxfmt and `git diff --check`: passed.
- Isolated real CONNECT proxy proof:
  - strict mode: local DNS failed with `ENOTFOUND`, no CONNECT occurred, and the
    loader returned `bundled-fallback`;
  - trusted mode: one CONNECT to the catalog destination returned HTTP 200, and
    the loader returned `source: hosted` with `trust.mode: signed` and
    `signedBy: proxy-proof-root`.
- Hosted changed-check: Testbox `tbx_01kzqvz2a4hgzvvn85dwjshqy1` passed in
  7m43s. Actions run:
  https://github.com/openclaw/openclaw/actions/runs/31469585379
- Exact-feature Clawpatch review `20260811T073708-c086c4`: 0 findings.

## Dependency Contract

Direct inspection of pinned Undici 8.9.0 confirmed that
`EnvHttpProxyAgent` snapshots proxy environment variables at construction,
selects the HTTPS proxy for HTTPS destinations, and honors `NO_PROXY`.
OpenClaw's existing trusted wrapper preserves the catalog allowlist before proxy
selection and revalidates each redirect.

## Attribution

Original fix by @mushuiyu886. The current-main rewrite preserves their commit
authorship.

Punchcard-Session: quiet-brook-meadow-8n
Punchcard-PR-Attestation: att_01KZQWE4FW4MAW8YGYVVQ4WP1W
