### PR TITLE
fix(session-write-lock): continue watchdog loop past per-lock release errors

### DIFF
--- a/src/agents/session-write-lock.test.ts
+++ b/src/agents/session-write-lock.test.ts
@@ -681,12 +681,10 @@ describe("acquireSessionWriteLock", () => {
     }
   });
 
-  it("releases all stale locks even when a force-release throws", async () => {
+  it("releases the second stale lock when the first force-release throws", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-lock-"));
     const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
     try {
-      // Acquire two independent locks with short max-hold windows so
-      // both are stale when the watchdog runs.
       const sessionFileA = path.join(root, "session-a.jsonl");
       const sessionFileB = path.join(root, "session-b.jsonl");
       const lockPathA = `${sessionFileA}.lock`;
@@ -703,14 +701,35 @@ describe("acquireSessionWriteLock", () => {
         maxHoldMs: 1,
       });
 
+      // Replace the first lock file with a directory so
+      // readSidecarLockSnapshot fails with EISDIR (not ENOENT),
+      // causing forceRelease to throw. This is the only reliable
+      // way to trigger a non-ENOENT filesystem error — JSON parse
+      // failures are caught and ENOENT returns null.
+      await fs.rm(lockPathA, { force: true });
+      await fs.mkdir(lockPathA);
+
       const released = await testing.runLockWatchdogCheck(Date.now() + 1000);
-      // Both locks must be released — a single forceRelease error
-      // is isolated to its own iteration and must not abort the loop.
-      expect(released).toBe(2);
-      await expectPathMissing(lockPathA);
+      // The first lock's forceRelease threw (EISDIR), the loop
+      // continued, and the second lock was successfully released.
+      // On unfixed main this test fails: the loop aborts and
+      // released is 0 (the error propagates, skipping lock B).
+      expect(released).toBe(1);
       await expectPathMissing(lockPathB);
+
+      const errorLine = stderrSpy.mock.calls
+        .map((call) => String(call[0]))
+        .find((line) => line.includes("[session-write-lock] failed to release lock"));
+      expect(errorLine).toBeDefined();
+      expect(errorLine).toContain("EISDIR");
     } finally {
       stderrSpy.mockRestore();
+      // The directory at lockPathA must be cleaned up before rm(root).
+      try {
+        await fs.rm(lockPathA, { recursive: true, force: true });
+      } catch {
+        /* best effort */
+      }
       await fs.rm(root, { recursive: true, force: true });
     }
   });

--- a/src/agents/session-write-lock.test.ts
+++ b/src/agents/session-write-lock.test.ts
@@ -681,6 +681,40 @@ describe("acquireSessionWriteLock", () => {
     }
   });
 
+  it("releases all stale locks even when a force-release throws", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-lock-"));
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    try {
+      // Acquire two independent locks with short max-hold windows so
+      // both are stale when the watchdog runs.
+      const sessionFileA = path.join(root, "session-a.jsonl");
+      const sessionFileB = path.join(root, "session-b.jsonl");
+      const lockPathA = `${sessionFileA}.lock`;
+      const lockPathB = `${sessionFileB}.lock`;
+
+      await acquireSessionWriteLock({
+        sessionFile: sessionFileA,
+        timeoutMs: 500,
+        maxHoldMs: 1,
+      });
+      await acquireSessionWriteLock({
+        sessionFile: sessionFileB,
+        timeoutMs: 500,
+        maxHoldMs: 1,
+      });
+
+      const released = await testing.runLockWatchdogCheck(Date.now() + 1000);
+      // Both locks must be released — a single forceRelease error
+      // is isolated to its own iteration and must not abort the loop.
+      expect(released).toBe(2);
+      await expectPathMissing(lockPathA);
+      await expectPathMissing(lockPathB);
+    } finally {
+      stderrSpy.mockRestore();
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("removes lock files during process-exit cleanup", async () => {
     await withTempSessionLockFile(async ({ sessionFile, lockPath }) => {
       const lock = await acquireSessionWriteLock({ sessionFile, timeoutMs: 500 });

--- a/src/agents/session-write-lock.ts
+++ b/src/agents/session-write-lock.ts
@@ -289,9 +289,15 @@ async function runLockWatchdogCheck(nowMs = Date.now()): Promise<number> {
       `[session-write-lock] releasing lock held for ${heldForMs}ms (max=${maxHoldMs}ms): ${held.lockPath}\n`,
     );
 
-    const didRelease = await held.forceRelease();
-    if (didRelease) {
-      released += 1;
+    try {
+      const didRelease = await held.forceRelease();
+      if (didRelease) {
+        released += 1;
+      }
+    } catch (err) {
+      process.stderr.write(
+        `[session-write-lock] failed to release lock ${held.lockPath}: ${String(err)}\n`,
+      );
     }
   }
   return released;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the session write-lock watchdog aborts its cleanup loop when a single lock's `forceRelease()` throws a filesystem error (e.g. EACCES, EPERM, EISDIR, or a transient I/O fault). On unfixed main, the `await held.forceRelease()` call inside `runLockWatchdogCheck` has no per-iteration error isolation — any exception propagates out of the function, is swallowed by the `.catch(() => {})` in the `setInterval` callback, and **all subsequent stale locks in the same watchdog cycle are left unreleased**.

The watchdog is the only automatic recovery path for session write-locks held past `maxHoldMs`. Stale locks accumulate and block every concurrent session writer with `SessionWriteLockTimeoutError`, preventing agent turns from starting or continuing. Under filesystem instability (disk pressure, NFS mount issues, permission drift), a single failing release can cascade into indefinite lock starvation across all concurrent sessions.

## Why This Change Was Made

The fix wraps each `await held.forceRelease()` iteration in its own try/catch block. A failed release is reported to stderr (matching the existing watchdog diagnostic convention) and the loop continues to the next held lock. No other code paths or behavioral contracts change — the watchdog still returns the count of successfully released locks, and `setInterval`/cleanup logic is unchanged.

This follows the principle of best-effort cleanup: one stuck or broken lock must never prevent cleanup of unrelated locks.

## User Impact

- Multi-session and concurrent agent deployments are protected from cascading lock starvation caused by a single filesystem error during watchdog cleanup.
- Operators gain observability: the watchdog now emits `[session-write-lock] failed to release lock <path>: <error>` to stderr when a per-lock release fails.

## Evidence

### Regression test with injected failure

The test "releases the second stale lock when the first force-release throws" in `session-write-lock.test.ts`:

1. Acquires two independent session write-locks with `maxHoldMs: 1` (both immediately stale)
2. Replaces the first lock's file with a directory — this causes `readSidecarLockSnapshot` to fail with EISDIR (not ENOENT) when `forceRelease` tries to clean up, which is the only non-ENOENT path that triggers a throw from the `@openclaw/fs-safe` internals
3. Runs `runLockWatchdogCheck` at a far-future timestamp
4. Asserts `released === 1` — lock A's release threw (caught + logged), lock B was still released
5. Asserts lock B's file is gone (successfully cleaned up)
6. Asserts the EISDIR error was reported to stderr

**On unfixed main**: the EISDIR error propagates out of the loop, `released === 0`, and lock B is never touched. **This test fails on main.**

### Test results

```
 ✓ |agents| src/agents/session-write-lock.test.ts (52 tests)
   ✓ releases the second stale lock when the first force-release throws
   ✓ watchdog releases stale in-process locks
   ... (50 more passing; 2 pre-existing Windows-only EPERM failures in events.test.ts)
```

### Sibling-surface audit

- `runLockWatchdogCheck` is the only watchdog loop that iterates held entries and calls `forceRelease()`. It is exclusively consumed by `startWatchdogTimer()`.
- `releaseAllLocksSync` uses `SESSION_LOCKS.reset()` (synchronous) — not affected.
- `cleanStaleLockFiles` operates on filesystem-level stale lock scanning, not in-process held entries — not affected.
- The underlying `@openclaw/fs-safe` `releaseHeldLock` wraps internal cleanup in try/catch but re-throws cleanup failures; our fix adds the missing isolation at the watchdog call site.

### Format

`pnpm exec oxfmt --check` passes on both changed files.