### PR TITLE
fix(memory): prevent active session ingestion starvation

### DIFF
--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -159,6 +159,7 @@ async function seedDreamingSessionTranscript(params: {
   }>;
   sessionId: string;
   sessionKey?: string;
+  updatedAt?: number;
 }): Promise<void> {
   const agentId = params.agentId ?? "main";
   const sessionsDir = resolveSessionTranscriptsDirForAgent(agentId);
@@ -171,7 +172,7 @@ async function seedDreamingSessionTranscript(params: {
     .filter((timestamp) => Number.isFinite(timestamp));
   // Accessor writes run normal maintenance; keep fixture entries fresh while
   // retaining per-message timestamps as the dreaming corpus clock.
-  const updatedAt = Math.max(Date.now(), ...timestamps);
+  const updatedAt = params.updatedAt ?? Math.max(Date.now(), ...timestamps);
   await fs.mkdir(sessionsDir, { recursive: true });
   const sessionFile = formatSqliteSessionFileMarker({
     agentId,
@@ -2216,6 +2217,118 @@ describe("memory-core dreaming phases", () => {
     expect(persistedLines).toHaveLength(160);
     expect(corpus).toContain("bulk-line-0");
     expect(corpus).toContain("bulk-line-159");
+  });
+
+  it("prioritizes current sessions and preserves capped-out checkpoints", async () => {
+    const workspaceDir = await createDreamingWorkspace();
+    setDreamingTestEnv(path.join(workspaceDir, ".state"));
+    const oldUpdatedAt = Date.now();
+    const directSessionId = "00000000-0000-4000-8000-000000000001";
+    const directSessionKey = "agent:main:discord:channel:1506288692048953495";
+    const directSessionsDir = resolveSessionTranscriptsDirForAgent("main");
+    const directStorePath = path.join(directSessionsDir, "sessions.json");
+    await seedDreamingSessionTranscript({
+      sessionId: directSessionId,
+      sessionKey: directSessionKey,
+      updatedAt: oldUpdatedAt - 1,
+      messages: [
+        {
+          role: "user",
+          timestamp: "2026-04-05T17:30:00.000Z",
+          content: [{ type: "text", text: "Previously seen checkpoint survives a capped sweep." }],
+        },
+      ],
+    });
+
+    const { beforeAgentReply } = createHarness(LIGHT_DREAMING_TEST_CONFIG, workspaceDir);
+    await withDreamingTestClock(async () => {
+      await triggerLightDreaming(beforeAgentReply, workspaceDir, 4);
+    });
+    const initialState = await dreamingTestState.readSessionIngestionState(workspaceDir);
+    const preservedKey = Object.keys(initialState.files).find((key) =>
+      key.includes(directSessionId),
+    );
+    expect(preservedKey).toBeDefined();
+
+    await seedDreamingSessionTranscript({
+      sessionId: directSessionId,
+      sessionKey: directSessionKey,
+      updatedAt: oldUpdatedAt - 1,
+      messages: [
+        {
+          role: "assistant",
+          timestamp: "2026-04-06T01:02:00.000Z",
+          content: [
+            { type: "text", text: "Capped direct-session message drains on the next sweep." },
+          ],
+        },
+      ],
+    });
+
+    for (let sessionIndex = 0; sessionIndex < 24; sessionIndex += 1) {
+      await seedDreamingSessionTranscript({
+        sessionId: `aaa-old-${sessionIndex.toString().padStart(2, "0")}`,
+        updatedAt: oldUpdatedAt + sessionIndex,
+        messages: Array.from({ length: 12 }, (_, messageIndex) => ({
+          role: messageIndex % 2 === 0 ? ("user" as const) : ("assistant" as const),
+          timestamp: "2026-04-05T18:00:00.000Z",
+          content: [{ type: "text", text: `old-${sessionIndex}-line-${messageIndex}` }],
+        })),
+      });
+    }
+    await seedDreamingSessionTranscript({
+      sessionId: "zzz-current-direct",
+      updatedAt: oldUpdatedAt + 60_000,
+      messages: [
+        {
+          role: "assistant",
+          timestamp: "2026-04-05T18:30:00.000Z",
+          content: [{ type: "text", text: "Current direct-session shipment must not starve." }],
+        },
+      ],
+    });
+
+    await withDreamingTestClock(async () => {
+      await triggerLightDreaming(beforeAgentReply, workspaceDir, 5);
+    });
+
+    const corpus = await fs.readFile(
+      path.join(workspaceDir, "memory", ".dreams", "session-corpus", "2026-04-05.txt"),
+      "utf-8",
+    );
+    expect(corpus).toContain("Current direct-session shipment must not starve.");
+
+    const cappedState = await dreamingTestState.readSessionIngestionState(workspaceDir);
+    expect(cappedState.files[preservedKey!]).toEqual(initialState.files[preservedKey!]);
+    expect(corpus).not.toContain("Capped direct-session message drains on the next sweep.");
+
+    await upsertSessionEntry({
+      agentId: "main",
+      sessionKey: directSessionKey,
+      storePath: directStorePath,
+      entry: {
+        sessionFile: formatSqliteSessionFileMarker({
+          agentId: "main",
+          sessionId: directSessionId,
+          storePath: directStorePath,
+        }),
+        sessionId: directSessionId,
+        updatedAt: oldUpdatedAt + 120_000,
+      },
+    });
+
+    await withDreamingTestClock(async () => {
+      await triggerLightDreaming(beforeAgentReply, workspaceDir, 910);
+    });
+    const drainedCorpus = await fs.readFile(
+      path.join(workspaceDir, "memory", ".dreams", "session-corpus", "2026-04-06.txt"),
+      "utf-8",
+    );
+    expect(drainedCorpus).toContain("Capped direct-session message drains on the next sweep.");
+    const drainedState = await dreamingTestState.readSessionIngestionState(workspaceDir);
+    expect(drainedState.files[preservedKey!]?.lastContentLine).toBeGreaterThan(
+      cappedState.files[preservedKey!]?.lastContentLine ?? 0,
+    );
   });
 
   it("ingests appended SQLite session transcript rows after prior checkpoint", async () => {

--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -184,6 +184,7 @@ async function seedDreamingSessionTranscript(params: {
   sessionKey?: string;
   spawnedBy?: string;
   hookExternalContentSource?: "gmail" | "webhook";
+  updatedAt?: number;
 }): Promise<void> {
   const agentId = params.agentId ?? "main";
   const sessionsDir = resolveSessionTranscriptsDirForAgent(agentId);
@@ -196,7 +197,7 @@ async function seedDreamingSessionTranscript(params: {
     .filter((timestamp) => Number.isFinite(timestamp));
   // Accessor writes run normal maintenance; keep fixture entries fresh while
   // retaining per-message timestamps as the dreaming corpus clock.
-  const updatedAt = Math.max(Date.now(), ...timestamps);
+  const updatedAt = params.updatedAt ?? Math.max(Date.now(), ...timestamps);
   await fs.mkdir(sessionsDir, { recursive: true });
   await upsertSessionEntry({
     agentId,
@@ -2146,6 +2147,55 @@ describe("memory-core dreaming phases", () => {
       expect(after.files[knownStateKey]).toStrictEqual(knownCheckpoint);
     } finally {
       restoreDreamingTestEnv();
+    }
+  });
+
+  it("visits the most recently active sessions first when the sweep cap binds", async () => {
+    // A busy agent can hold more transcripts than one sweep can visit. Ordering
+    // by path alone starves whichever session sorts late, however active it is.
+    const workspaceDir = await createDreamingWorkspace();
+    setDreamingTestEnv(path.join(workspaceDir, ".state"));
+    const baseUpdatedAt = Date.parse("2026-04-05T18:00:00.000Z");
+    const staleSessionIds = Array.from(
+      { length: 24 },
+      (_, index) => `aa-stale-${index.toString().padStart(2, "0")}`,
+    );
+    for (const [index, sessionId] of staleSessionIds.entries()) {
+      await seedDreamingSessionTranscript({
+        sessionId,
+        updatedAt: baseUpdatedAt + index,
+        messages: Array.from({ length: 12 }, (_, messageIndex) => ({
+          role: "user" as const,
+          timestamp: "2026-04-05T18:00:00.000Z",
+          content: `Stale filler ${messageIndex} for ${sessionId}`,
+        })),
+      });
+    }
+    // Sorts last by path, but is the only recently active session.
+    await seedDreamingSessionTranscript({
+      sessionId: "zz-current",
+      updatedAt: baseUpdatedAt + 600_000,
+      messages: [
+        {
+          role: "user",
+          timestamp: "2026-04-05T18:05:00.000Z",
+          content: "Current session shipment must not starve behind the cap.",
+        },
+      ],
+    });
+
+    const { beforeAgentReply } = createHarness(LIGHT_DREAMING_TEST_CONFIG, workspaceDir);
+    try {
+      await withDreamingTestClock(async () => {
+        await triggerLightDreaming(beforeAgentReply, workspaceDir, 5);
+      });
+      const corpus = await fs.readFile(
+        path.join(workspaceDir, "memory", ".dreams", "session-corpus", "2026-04-05.txt"),
+        "utf-8",
+      );
+      expect(corpus).toContain("Current session shipment must not starve behind the cap.");
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
     }
   });
 

--- a/extensions/memory-core/src/dreaming-phases.ts
+++ b/extensions/memory-core/src/dreaming-phases.ts
@@ -847,12 +847,22 @@ async function collectSessionIngestionBatches(params: {
     }
   }
 
+  // A busy agent can have more transcript files than the sweep-wide cap can
+  // visit. Prefer the most recently active sessions so current conversations
+  // are not starved behind an old lexicographic prefix.
   const sortedFiles = sessionFiles.toSorted((a, b) => {
+    const recencyDelta = (b.updatedAtMs ?? 0) - (a.updatedAtMs ?? 0);
+    if (recencyDelta !== 0) {
+      return recencyDelta;
+    }
     if (a.agentId !== b.agentId) {
       return a.agentId.localeCompare(b.agentId);
     }
     return a.sessionPath.localeCompare(b.sessionPath);
   });
+  const discoveredStateKeys = new Set(
+    sortedFiles.map((file) => buildSessionStateKey(file.agentId, file.sessionPath)),
+  );
 
   const totalCap = SESSION_INGESTION_MAX_MESSAGES_PER_SWEEP;
   let remaining = totalCap;
@@ -1059,6 +1069,15 @@ async function collectSessionIngestionBatches(params: {
       previous.lastContentLine !== cursor
     ) {
       changed = true;
+    }
+  }
+
+  // Reaching the sweep cap means "not visited yet", not "file disappeared".
+  // Preserve checkpoints for discovered-but-unvisited transcripts so the next
+  // sweep resumes safely instead of forgetting their cursors and dedupe state.
+  for (const [key, state] of Object.entries(params.state.files)) {
+    if (discoveredStateKeys.has(key) && !Object.hasOwn(nextFiles, key)) {
+      nextFiles[key] = state;
     }
   }
 

--- a/extensions/memory-core/src/dreaming-phases.ts
+++ b/extensions/memory-core/src/dreaming-phases.ts
@@ -627,6 +627,10 @@ async function collectSessionIngestionBatches(params: {
   const nextFiles = { ...params.state.files };
   const nextSeenMessages: Record<string, string[]> = { ...params.state.seenMessages };
   const sources: SessionIngestionSource[] = [];
+  // Recency per discovered source, keyed by state key. Kept beside the source
+  // list rather than on SessionIngestionSource so the shared type stays a
+  // description of the transcript, not of one sweep's ordering.
+  const sourceRecencyMs = new Map<string, number>();
   for (const agentId of agentIds) {
     const knownStateKeys = new Set<string>();
     const forgottenSessionIds = new Set(
@@ -667,6 +671,7 @@ async function collectSessionIngestionBatches(params: {
         continue;
       }
       sources.push(source);
+      sourceRecencyMs.set(source.stateKey, entry.updatedAtMs ?? 0);
     }
     // Complete corpus enumeration proves which owned checkpoints are stale;
     // foreign backfill checkpoints belong to a separate lifecycle.
@@ -676,7 +681,16 @@ async function collectSessionIngestionBatches(params: {
       }
     }
   }
+  // A busy agent can have more transcript files than the sweep-wide cap can
+  // visit. Prefer the most recently active sessions so current conversations are
+  // not starved behind an old lexicographic prefix. Agent and path remain the
+  // tie-break, so ordering stays deterministic when recency is equal or absent.
   const sortedSources = sources.toSorted((a, b) => {
+    const recencyDelta =
+      (sourceRecencyMs.get(b.stateKey) ?? 0) - (sourceRecencyMs.get(a.stateKey) ?? 0);
+    if (recencyDelta !== 0) {
+      return recencyDelta;
+    }
     if (a.agentId !== b.agentId) {
       return a.agentId.localeCompare(b.agentId);
     }


### PR DESCRIPTION
## What Problem This Solves

Session-transcript ingestion is capped at 240 messages per sweep. Under sustained activity, lexical file ordering can repeatedly consume that budget before a recently active direct session is reached. The prior state rebuild also omitted checkpoints for discovered transcripts that the capped sweep did not visit, causing unnecessary rereads and weakening continuity.

## Changes

- Prioritize discovered transcript sessions by current session-store activity before applying the sweep-wide cap.
- Preserve prior checkpoints for discovered-but-unvisited transcripts.
- Add an adversarial regression with more than one sweep of transcripts, a real Discord direct-session key, and an appended message on an earlier checkpoint. The test proves the active direct session is ingested, the capped-out checkpoint stays unconsumed during that sweep, and the appended message drains on the next sweep.

## Evidence

Rebased without conflicts onto upstream `main` at `752f059753e89806ce3bbe3b9e6136484e5a3f93` and validated at exact head `3116795698bd048a588bb6e929ff357b9326dfe3`:

- `pnpm exec vitest run extensions/memory-core/src/dreaming-phases.test.ts` — 48/48 passed.
- `pnpm exec vitest list extensions/memory-core/src/dreaming-phases.test.ts` — 48 tests collected, including `prioritizes current sessions and preserves capped-out checkpoints`.
- `pnpm exec oxfmt --check extensions/memory-core/src/dreaming-phases.ts extensions/memory-core/src/dreaming-phases.test.ts` — passed.
- `pnpm exec oxlint extensions/memory-core/src/dreaming-phases.ts extensions/memory-core/src/dreaming-phases.test.ts` — passed.
- `git diff --check upstream/main...HEAD` — passed.
- [Exact-head Real behavior proof run 29804428893](https://github.com/openclaw/openclaw/actions/runs/29804428893) — passed.

Immediately before push, upstream had advanced to `56bc39e689b4d9d374d5742e67c823b8d277831d` by two commits affecting agent session reset and AI context accounting only. Neither commit touched memory-core ingestion, session storage, plugin state, or this PR's two-file surface, so the exact-head proof remained applicable.

### Redacted after-fix runtime proof

This is a standalone run from the exact checkout, outside Vitest. It uses OpenClaw's real SQLite plugin-state store, real SQLite session store, and the production `runDreamingSweepPhases` path in an isolated temporary state directory. The probe seeds only synthetic redacted messages; it does not read or mutate production state.

```json
{
  "schema": "openclaw.memory-session-ingestion-runtime-proof.v1",
  "exactHead": "3116795698bd048a588bb6e929ff357b9326dfe3",
  "backend": {
    "pluginState": "sqlite-runtime-store",
    "sessionTranscript": "sqlite-session-store",
    "environment": "isolated-redacted-runtime"
  },
  "scenario": {
    "discoveredSessions": 26,
    "seededBacklogMessages": 288,
    "sweepMessageCap": 240
  },
  "assertions": {
    "activeDirectSessionIngestedBeforeBacklog": true,
    "discoveredButUnvisitedCheckpointPreserved": true,
    "deferredMessageAbsentDuringCappedSweep": true,
    "deferredMessageDrainedNextSweep": true,
    "preservedCursorAdvancedAfterDrain": true
  }
}
```

The change does not broaden workspace or agent selection; it only reorders already-authorized discovered transcripts and preserves their existing ingestion state.
