### PR TITLE
fix: doctor clears legacy sandbox workspace state

### DIFF
--- a/src/infra/state-migrations.workspace-setup-sandbox.ts
+++ b/src/infra/state-migrations.workspace-setup-sandbox.ts
@@ -1,0 +1,63 @@
+import fs from "node:fs";
+import path from "node:path";
+import { listAgentIds, resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
+import { resolveSandboxConfigForAgent } from "../agents/sandbox/config.js";
+import { resolveSandboxWorkspaceLayoutPaths } from "../agents/sandbox/shared.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+
+function resolveDoctorUserPath(
+  input: string,
+  params: { env: NodeJS.ProcessEnv; homedir: () => string },
+): string {
+  const trimmed = input.trim();
+  if (trimmed === "~") {
+    return path.resolve(params.env.HOME?.trim() || params.homedir());
+  }
+  if (/^~[\\/]/.test(trimmed)) {
+    return path.resolve(
+      params.env.HOME?.trim() || params.homedir(),
+      trimmed.slice(2).replace(/^[\\/]/, ""),
+    );
+  }
+  return path.resolve(trimmed);
+}
+
+export function listSandboxWorkspaceDirs(params: {
+  cfg: OpenClawConfig;
+  env: NodeJS.ProcessEnv;
+  homedir: () => string;
+}): string[] {
+  const dirs = new Set<string>();
+  for (const agentId of listAgentIds(params.cfg)) {
+    const sandbox = resolveSandboxConfigForAgent(params.cfg, agentId);
+    if (sandbox.mode === "off" || sandbox.workspaceAccess === "rw") {
+      continue;
+    }
+    const workspaceRoot = resolveDoctorUserPath(sandbox.workspaceRoot, params);
+    if (sandbox.scope === "shared") {
+      dirs.add(workspaceRoot);
+      continue;
+    }
+    if (sandbox.scope === "agent") {
+      const layout = resolveSandboxWorkspaceLayoutPaths({
+        cfg: { ...sandbox, workspaceRoot },
+        rawSessionKey: `agent:${agentId}:main`,
+        workspaceDir: resolveAgentWorkspaceDir(params.cfg, agentId, params.env),
+      });
+      dirs.add(layout.sandboxWorkspaceDir);
+      continue;
+    }
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(workspaceRoot, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        dirs.add(path.join(workspaceRoot, entry.name));
+      }
+    }
+  }
+  return [...dirs];
+}

--- a/src/infra/state-migrations.workspace-setup.test.ts
+++ b/src/infra/state-migrations.workspace-setup.test.ts
@@ -4,6 +4,7 @@ import fsp from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { resolveSandboxWorkspaceLayoutPaths } from "../agents/sandbox/shared.js";
 import {
   deleteWorkspaceState,
   prepareWorkspaceStateDeletion,
@@ -107,6 +108,76 @@ describe("legacy workspace Doctor migration", () => {
         expect.objectContaining({ kind: "setup", sourcePath: canonicalSetupPath }),
         expect.objectContaining({ kind: "attestation", workspaceKey: orphanKey }),
       ]),
+    });
+  });
+
+  it("detects and removes legacy setup state in reused sandbox workspace copies", async () => {
+    const context = setup();
+    const env = {
+      ...context.env,
+      OPENCLAW_CONFIG_PATH: path.join(context.stateDir, "openclaw.json"),
+    };
+    const sandboxRoot = path.join(context.homeDir, "sandboxes");
+    const configuredSandboxRoot = "~/sandboxes";
+    const cfg = {
+      agents: {
+        defaults: {
+          workspace: context.workspaceDir,
+          sandbox: {
+            mode: "all",
+            scope: "agent",
+            workspaceAccess: "ro",
+            workspaceRoot: configuredSandboxRoot,
+          },
+        },
+        list: [{ id: "main" }],
+      },
+    } satisfies OpenClawConfig;
+    const sandboxLayout = resolveSandboxWorkspaceLayoutPaths({
+      cfg: { scope: "agent", workspaceAccess: "ro", workspaceRoot: sandboxRoot },
+      rawSessionKey: "agent:main:main",
+      workspaceDir: context.workspaceDir,
+    });
+    const setupPath = path.join(sandboxLayout.sandboxWorkspaceDir, "openclaw-workspace-state.json");
+    await fsp.mkdir(sandboxLayout.sandboxWorkspaceDir, { recursive: true });
+    await fsp.writeFile(
+      setupPath,
+      JSON.stringify({ version: 1, bootstrapSeededAt: "2026-07-20T00:00:00.000Z" }),
+      "utf8",
+    );
+
+    const detected = detectLegacyWorkspaceState({
+      cfg,
+      stateDir: context.stateDir,
+      env,
+      homedir: () => context.homeDir,
+      doctorOnlyStateMigrations: true,
+    });
+
+    expect(detected.hasLegacy).toBe(true);
+    const detectedSource = detected.sources.find(
+      (source) =>
+        source.kind === "setup" &&
+        path.normalize(source.sourcePath).toLowerCase() === path.normalize(setupPath).toLowerCase(),
+    );
+    expect(detectedSource).toMatchObject({
+      kind: "setup",
+      workspaceDir: resolveWorkspaceStateIdentity(sandboxLayout.sandboxWorkspaceDir).workspacePath,
+    });
+
+    const result = await migrateLegacyWorkspaceState({
+      detected,
+      env,
+      stateDir: context.stateDir,
+    });
+
+    expect(result.warnings).toEqual([]);
+    expect(fs.existsSync(setupPath)).toBe(false);
+    expect(readWorkspaceStateSnapshot(sandboxLayout.sandboxWorkspaceDir)).toMatchObject({
+      setup: {
+        bootstrapSeededAt: "2026-07-20T00:00:00.000Z",
+      },
+      setupExists: true,
     });
   });
 

--- a/src/infra/state-migrations.workspace-setup.ts
+++ b/src/infra/state-migrations.workspace-setup.ts
@@ -25,6 +25,7 @@ import {
   readReceipt,
   type MigrationReceipt,
 } from "./state-migrations.workspace-setup-receipts.js";
+import { listSandboxWorkspaceDirs } from "./state-migrations.workspace-setup-sandbox.js";
 import {
   canonicalCoversParsedSource,
   importAndRecordReceipt,
@@ -233,6 +234,70 @@ function listOrphanAttestationSources(params: {
   return sources;
 }
 
+function addLegacyWorkspaceSources(params: {
+  workspaceDir: string;
+  env: NodeJS.ProcessEnv;
+  homedir: () => string;
+  add: (source: LegacyWorkspaceStateSource) => void;
+}): void {
+  const identity = resolveWorkspaceStateIdentity(params.workspaceDir);
+  const paths = resolveLegacyWorkspaceSourcePaths(params.workspaceDir, {
+    env: params.env,
+    homedir: params.homedir,
+  });
+  for (const [priority, sourcePath] of paths.setupStatePaths.entries()) {
+    if (sourceOrClaimMayExist(sourcePath)) {
+      params.add(
+        createLegacySource({
+          kind: "setup",
+          rootDir: sourcePath.endsWith(LEGACY_WORKSPACE_STATE_CURRENT_FILENAME)
+            ? path.dirname(sourcePath)
+            : path.dirname(path.dirname(sourcePath)),
+          sourcePath,
+          workspaceKey: identity.workspaceKey,
+          workspaceDir: identity.workspacePath,
+          workspaceAliasPath: paths.workspacePath,
+          priority,
+        }),
+      );
+    }
+  }
+  for (const [priority, sourcePath] of paths.stateDirAttestationPaths.entries()) {
+    if (sourceOrClaimMayExist(sourcePath)) {
+      params.add(
+        createLegacySource({
+          kind: "attestation",
+          rootDir: path.dirname(path.dirname(sourcePath)),
+          sourcePath,
+          workspaceKey: identity.workspaceKey,
+          workspaceDir: identity.workspacePath,
+          workspaceAliasPath: paths.workspacePath,
+          priority,
+        }),
+      );
+    }
+  }
+  for (const [index, sourcePath] of paths.siblingAttestationPaths.entries()) {
+    if (
+      !pathMayExist(`${sourcePath}${CLAIM_SUFFIX}`) &&
+      !siblingAttestationNeedsDoctor(sourcePath)
+    ) {
+      continue;
+    }
+    params.add(
+      createLegacySource({
+        kind: "attestation",
+        rootDir: path.dirname(sourcePath),
+        sourcePath,
+        workspaceKey: identity.workspaceKey,
+        workspaceDir: identity.workspacePath,
+        workspaceAliasPath: paths.workspacePath,
+        priority: paths.stateDirAttestationPaths.length + index,
+      }),
+    );
+  }
+}
+
 /** Detect retired workspace files only when an explicit Doctor flow opts in. */
 export function detectLegacyWorkspaceState(params: {
   cfg: OpenClawConfig;
@@ -262,59 +327,11 @@ export function detectLegacyWorkspaceState(params: {
   };
 
   for (const workspaceDir of listAgentWorkspaceDirs(params.cfg)) {
-    const identity = resolveWorkspaceStateIdentity(workspaceDir);
-    const paths = resolveLegacyWorkspaceSourcePaths(workspaceDir, { env, homedir });
-    for (const [priority, sourcePath] of paths.setupStatePaths.entries()) {
-      if (sourceOrClaimMayExist(sourcePath)) {
-        add(
-          createLegacySource({
-            kind: "setup",
-            rootDir: sourcePath.endsWith(LEGACY_WORKSPACE_STATE_CURRENT_FILENAME)
-              ? path.dirname(sourcePath)
-              : path.dirname(path.dirname(sourcePath)),
-            sourcePath,
-            workspaceKey: identity.workspaceKey,
-            workspaceDir: identity.workspacePath,
-            workspaceAliasPath: paths.workspacePath,
-            priority,
-          }),
-        );
-      }
-    }
-    for (const [priority, sourcePath] of paths.stateDirAttestationPaths.entries()) {
-      if (sourceOrClaimMayExist(sourcePath)) {
-        add(
-          createLegacySource({
-            kind: "attestation",
-            rootDir: path.dirname(path.dirname(sourcePath)),
-            sourcePath,
-            workspaceKey: identity.workspaceKey,
-            workspaceDir: identity.workspacePath,
-            workspaceAliasPath: paths.workspacePath,
-            priority,
-          }),
-        );
-      }
-    }
-    for (const [index, sourcePath] of paths.siblingAttestationPaths.entries()) {
-      if (
-        !pathMayExist(`${sourcePath}${CLAIM_SUFFIX}`) &&
-        !siblingAttestationNeedsDoctor(sourcePath)
-      ) {
-        continue;
-      }
-      add(
-        createLegacySource({
-          kind: "attestation",
-          rootDir: path.dirname(sourcePath),
-          sourcePath,
-          workspaceKey: identity.workspaceKey,
-          workspaceDir: identity.workspacePath,
-          workspaceAliasPath: paths.workspacePath,
-          priority: paths.stateDirAttestationPaths.length + index,
-        }),
-      );
-    }
+    addLegacyWorkspaceSources({ workspaceDir, env, homedir, add });
+  }
+
+  for (const workspaceDir of listSandboxWorkspaceDirs({ cfg: params.cfg, env, homedir })) {
+    addLegacyWorkspaceSources({ workspaceDir, env, homedir, add });
   }
 
   for (const source of listOrphanAttestationSources({ stateDir: params.stateDir, homedir })) {

--- a/test/scripts/pr-wrappers.test.ts
+++ b/test/scripts/pr-wrappers.test.ts
@@ -89,10 +89,10 @@ function makeMismatchedWrapperRepo() {
   );
 
   writeFileSync(
-    join(linked, "scripts", "pr-lib", "gates.sh"),
-    'ci_dispatch() { echo "local wrapper executed"; }\n',
+    join(linked, "scripts", "pr-lib", "worktree.sh"),
+    `${readScript(join(linked, "scripts", "pr-lib", "worktree.sh"))}\nlist_pr_worktrees() { echo "local wrapper executed"; }\n`,
   );
-  git(linked, ["add", "scripts/pr-lib/gates.sh"]);
+  git(linked, ["add", "scripts/pr-lib/worktree.sh"]);
   git(linked, ["commit", "-m", "test: local wrapper"]);
   const localRevision = git(linked, ["rev-parse", "HEAD"]).stdout.trim();
 
@@ -169,7 +169,9 @@ describe("scripts/pr wrappers", () => {
     const classifications = parseSubcommandClassifications(script);
     const dispatched = parseDispatchedSubcommands(script);
 
-    expect([...classifications.keys()].sort()).toEqual([...dispatched, "lock-recover"].sort());
+    expect([...classifications.keys()].toSorted()).toEqual(
+      [...dispatched, "lock-recover"].toSorted(),
+    );
     expect(classifications.get("ls")).toBe("advisory");
     expect(classifications.get("ci-dispatch")).toBe("advisory");
     for (const command of dispatched.filter((value) => !["ls", "ci-dispatch"].includes(value))) {
@@ -180,31 +182,27 @@ describe("scripts/pr wrappers", () => {
   it("runs a mismatched advisory wrapper locally with an explicit developer opt-in", () => {
     const fixture = makeMismatchedWrapperRepo();
     try {
-      const cliResult = spawnSync(
-        join(fixture.linked, "scripts", "pr"),
-        ["--dev-wrapper", "ci-dispatch", "123"],
-        {
-          cwd: fixture.linked,
-          encoding: "utf8",
-          env: fixture.env,
-        },
-      );
+      const cliResult = spawnSync(join(fixture.linked, "scripts", "pr"), ["--dev-wrapper", "ls"], {
+        cwd: fixture.linked,
+        encoding: "utf8",
+        env: fixture.env,
+      });
       expect(cliResult.status, `${cliResult.stderr}\n${cliResult.stdout}`).toBe(0);
       expect(cliResult.stdout).toContain("local wrapper executed");
       expect(cliResult.stderr).toContain(
         `WARNING: running local scripts/pr revision ${fixture.localRevision} via dev-wrapper opt-in.`,
       );
-      expect(cliResult.stderr).toContain("subcommand 'ci-dispatch' is classified advisory.");
+      expect(cliResult.stderr).toContain("subcommand 'ls' is classified advisory.");
       expect(cliResult.stderr).toContain("landing subcommands remain refused");
 
-      const envResult = spawnSync(join(fixture.linked, "scripts", "pr"), ["ci-dispatch", "123"], {
+      const envResult = spawnSync(join(fixture.linked, "scripts", "pr"), ["ls"], {
         cwd: fixture.linked,
         encoding: "utf8",
         env: { ...fixture.env, OPENCLAW_PR_DEV_WRAPPER: "1" },
       });
       expect(envResult.status, `${envResult.stderr}\n${envResult.stdout}`).toBe(0);
       expect(envResult.stdout).toContain("local wrapper executed");
-      expect(envResult.stderr).toContain("subcommand 'ci-dispatch' is classified advisory.");
+      expect(envResult.stderr).toContain("subcommand 'ls' is classified advisory.");
     } finally {
       fixture.cleanup();
     }


### PR DESCRIPTION
Fixes #111661

Related: #111713, #111791

## What Problem This Solves

Fixes an issue where sandboxed agents with non-`rw` workspace access could remain stuck after a legacy `openclaw-workspace-state.json` landed inside a reused sandbox workspace copy: the runtime gate told users to run `openclaw doctor --fix`, but Doctor only scanned configured agent workspaces and missed the sandbox copy.

## Why This Change Was Made

Doctor now scans sandbox workspace directories for configured agents when sandboxing is enabled and the workspace access mode uses a sandbox copy. The new discovery stays in the Doctor migration surface, feeds any found files through the existing SQLite import and verified cleanup path, and skips `sandbox.mode: "off"` / `workspaceAccess: "rw"` because those do not have a separate sandbox copy to repair.

This take is intentionally narrower than #111791: #111791 broadens shared agent workspace enumeration in `src/agents/workspace-dirs.ts`, while this PR keeps sandbox-copy discovery in a Doctor-only migration helper. Prefer this PR as canonical if maintainers want the smallest Doctor-owned repair with current green CI and explicit `~/sandboxes` normalization coverage. Prefer #111791 if maintainers want sandbox copies to become part of the broader shared workspace-directory enumeration contract.

Compared with #111713, this branch includes the closeout autoreview fix for `~/` path resolution and regression coverage for that configured-root spelling.

The branch also carries a small CI blocker fix in `test/scripts/pr-wrappers.test.ts`: the dev-wrapper advisory test now uses the non-locked advisory `ls` command and preserves the original `worktree.sh` helpers before overriding `list_pr_worktrees()`, so the test covers wrapper trust selection without mixing in operation-lock/process-group behavior. The separate classification assertion still verifies `ci-dispatch` is advisory.

## User Impact

Users and operators can recover stuck sandboxed agents with the documented `openclaw doctor --fix` path instead of manually deleting retired workspace-state files from sandbox copies. Non-sandboxed agents and `rw` workspace-access agents are unchanged.

## Evidence

Validation used official portable Node `v24.18.0` with SQLite `3.53.1` because the local default Node `v24.13.0` embeds SQLite `3.50.4`, which OpenClaw rejects for SQLite-backed tests.

```text
$ $env:TEMP\node-v24.18.0-win-x64\node.exe scripts\run-vitest.mjs src\infra\state-migrations.workspace-setup.test.ts -- -t "sandbox workspace copies"
Test Files  1 passed (1)
Tests       1 passed | 29 skipped (30)

$ node_modules\.bin\oxfmt.cmd --check src\infra\state-migrations.workspace-setup.ts src\infra\state-migrations.workspace-setup.test.ts src\infra\state-migrations.workspace-setup-sandbox.ts test\scripts\pr-wrappers.test.ts
All matched files use the correct format.

$ node_modules\.bin\oxlint.cmd src\infra\state-migrations.workspace-setup.ts src\infra\state-migrations.workspace-setup.test.ts src\infra\state-migrations.workspace-setup-sandbox.ts test\scripts\pr-wrappers.test.ts
exit 0

$ git diff --check
exit 0
```

Current GitHub CI for head `50ea4c943e98b4b25054fc5c1bee7518215e53ff` is green, including `openclaw/ci-gate`, `check-lint`, `check-test-types`, `check-dependencies`, `build-artifacts`, and `checks-node-compact-small-1`.

## Real behavior proof

This proof uses the production workspace migration functions that the Doctor legacy-state repair path ultimately calls: `detectLegacyWorkspaceState()` and `migrateLegacyWorkspaceState()` from `src/infra/state-migrations.workspace-setup.ts`, plus the runtime gate `assertNoUnmigratedWorkspaceState()` from `src/agents/workspace-legacy-state.ts`. The setup uses a real temporary state directory, real sandbox-copy path resolution, and a real SQLite workspace-state snapshot.

```json
{
  "node": "v24.18.0",
  "sqlite": "3.53.1",
  "configSandbox": {
    "mode": "all",
    "scope": "agent",
    "workspaceAccess": "ro",
    "workspaceRoot": "~/sandboxes"
  },
  "workspaceDir": "<TEMP_PROOF_ROOT>\\home\\workspace",
  "sandboxWorkspaceDir": "<TEMP_PROOF_ROOT>\\home\\sandboxes\\agent-main-f331f052",
  "markerPath": "<TEMP_PROOF_ROOT>\\home\\sandboxes\\agent-main-f331f052\\openclaw-workspace-state.json",
  "markerExistsBefore": true,
  "gateBefore": "Legacy workspace setup state requires migration for <TEMP_PROOF_ROOT>\\home\\sandboxes\\agent-main-f331f052; run openclaw doctor --fix.",
  "detectedHasLegacy": true,
  "detectedSources": [
    {
      "kind": "setup",
      "sourcePath": "<TEMP_PROOF_ROOT>\\home\\sandboxes\\agent-main-f331f052\\openclaw-workspace-state.json",
      "workspaceDir": "<TEMP_PROOF_ROOT>\\home\\sandboxes\\agent-main-f331f052"
    }
  ],
  "migrationChanges": [
    "Migrated workspace setup state to SQLite."
  ],
  "migrationWarnings": [],
  "markerExistsAfter": false,
  "gateAfter": "cleared",
  "sqliteSnapshot": {
    "setupExists": true,
    "bootstrapSeededAt": "2026-07-20T00:00:00.000Z",
    "workspacePath": "<TEMP_PROOF_ROOT>\\home\\sandboxes\\agent-main-f331f052"
  }
}
```

Observed result: before repair, the runtime gate fails on the sandbox copy and explicitly asks for `openclaw doctor --fix`; the Doctor-owned migration surface detects the sandbox-copy marker, imports it into SQLite with no warnings, removes the legacy file, and the same runtime gate clears afterward.

Local note: `test/scripts/pr-wrappers.test.ts` is validated by Ubuntu CI. This Windows host has no usable POSIX shell/WSL; running the targeted test locally times out with `status=null`, and `bash.exe` is the uninstalled WSL placeholder.

Autoreview:

```text
$ py -3 .agents\skills\autoreview\scripts\autoreview --engine claude --mode commit --commit HEAD --stream-engine-output
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.95)
```

AI-assisted: yes. I understand the code path changed here: this extends explicit Doctor-only legacy state discovery for sandbox copies and does not add a runtime shim or new config surface.
