### PR TITLE
fix(openai): fail fast on invalid TLS certificates

### DIFF
--- a/extensions/openai/openai-chatgpt-oauth-preflight.runtime.ts
+++ b/extensions/openai/openai-chatgpt-oauth-preflight.runtime.ts
@@ -1,22 +1,8 @@
 import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
+import { inspectTlsCertificateError } from "openclaw/plugin-sdk/provider-http";
 
 const OPENAI_AUTH_PROBE_URL =
   "https://auth.openai.com/oauth/authorize?response_type=code&client_id=openclaw-preflight&redirect_uri=http%3A%2F%2Flocalhost%3A1455%2Fauth%2Fcallback&scope=openid+profile+email";
-const TLS_CERT_ERROR_CODES = new Set([
-  "UNABLE_TO_GET_ISSUER_CERT_LOCALLY",
-  "UNABLE_TO_VERIFY_LEAF_SIGNATURE",
-  "CERT_HAS_EXPIRED",
-  "DEPTH_ZERO_SELF_SIGNED_CERT",
-  "SELF_SIGNED_CERT_IN_CHAIN",
-  "ERR_TLS_CERT_ALTNAME_INVALID",
-]);
-const TLS_CERT_ERROR_PATTERNS = [
-  /unable to get local issuer certificate/i,
-  /unable to verify the first certificate/i,
-  /self[- ]signed certificate/i,
-  /certificate has expired/i,
-];
-
 type PreflightFailureKind = "tls-cert" | "network";
 export type OpenAIOAuthTlsPreflightResult =
   | { ok: true }
@@ -36,6 +22,14 @@ function extractFailure(error: unknown): {
   message: string;
   kind: PreflightFailureKind;
 } {
+  const tlsFailure = inspectTlsCertificateError(error);
+  if (tlsFailure) {
+    return {
+      code: tlsFailure.code,
+      message: tlsFailure.message,
+      kind: "tls-cert",
+    };
+  }
   const root = getErrorRecord(error);
   const rootCause = getErrorRecord(root?.cause);
   const code = typeof rootCause?.code === "string" ? rootCause.code : undefined;
@@ -45,13 +39,10 @@ function extractFailure(error: unknown): {
       : typeof root?.message === "string"
         ? root.message
         : String(error);
-  const isTlsCertError =
-    (code ? TLS_CERT_ERROR_CODES.has(code) : false) ||
-    TLS_CERT_ERROR_PATTERNS.some((pattern) => pattern.test(message));
   return {
     code,
     message,
-    kind: isTlsCertError ? "tls-cert" : "network",
+    kind: "network",
   };
 }
 

--- a/extensions/openai/openai-chatgpt-oauth.runtime.test.ts
+++ b/extensions/openai/openai-chatgpt-oauth.runtime.test.ts
@@ -37,4 +37,27 @@ describe("OpenAI Codex OAuth runtime", () => {
 
     expect(cancel).toHaveBeenCalledOnce();
   });
+
+  it("uses the shared classifier for hostname mismatch failures", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new TypeError("fetch failed", {
+        cause: {
+          code: "ERR_TLS_CERT_ALTNAME_INVALID",
+          message: "Hostname/IP does not match certificate's altnames",
+        },
+      });
+    });
+
+    await expect(
+      runOpenAIOAuthTlsPreflight({
+        timeoutMs: 20,
+        fetchImpl,
+      }),
+    ).resolves.toEqual({
+      ok: false,
+      kind: "tls-cert",
+      code: "ERR_TLS_CERT_ALTNAME_INVALID",
+      message: "Hostname/IP does not match certificate's altnames",
+    });
+  });
 });

--- a/packages/ai/src/internal/shared.ts
+++ b/packages/ai/src/internal/shared.ts
@@ -4,3 +4,4 @@ export * from "../providers/transform-messages.js";
 export * from "../utils/prompt-cache-stability.js";
 export * from "../utils/sanitize-unicode.js";
 export * from "../utils/system-prompt-cache-boundary.js";
+export * from "../utils/tls-certificate-errors.js";

--- a/packages/ai/src/providers/openai-chatgpt-responses.retry.test.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.retry.test.ts
@@ -15,6 +15,37 @@ function createTestJwt(payload: Record<string, unknown>): string {
 }
 
 describe("streamOpenAICodexResponses retry classification", () => {
+  const deterministicTlsCertificateCodes = [
+    "CERT_HAS_EXPIRED",
+    "CERT_REJECTED",
+    "CERT_REVOKED",
+    "CERT_SIGNATURE_FAILURE",
+    "CERT_UNTRUSTED",
+    "CERT_CHAIN_TOO_LONG",
+    "CERT_NOT_YET_VALID",
+    "CRL_HAS_EXPIRED",
+    "CRL_NOT_YET_VALID",
+    "CRL_SIGNATURE_FAILURE",
+    "DEPTH_ZERO_SELF_SIGNED_CERT",
+    "ERROR_IN_CERT_NOT_AFTER_FIELD",
+    "ERROR_IN_CERT_NOT_BEFORE_FIELD",
+    "ERROR_IN_CRL_LAST_UPDATE_FIELD",
+    "ERROR_IN_CRL_NEXT_UPDATE_FIELD",
+    "ERR_TLS_CERT_ALTNAME_INVALID",
+    "HOSTNAME_MISMATCH",
+    "INVALID_CA",
+    "INVALID_PURPOSE",
+    "PATH_LENGTH_EXCEEDED",
+    "SELF_SIGNED_CERT_IN_CHAIN",
+    "UNABLE_TO_DECODE_ISSUER_PUBLIC_KEY",
+    "UNABLE_TO_DECRYPT_CERT_SIGNATURE",
+    "UNABLE_TO_DECRYPT_CRL_SIGNATURE",
+    "UNABLE_TO_GET_CRL",
+    "UNABLE_TO_GET_ISSUER_CERT",
+    "UNABLE_TO_GET_ISSUER_CERT_LOCALLY",
+    "UNABLE_TO_VERIFY_LEAF_SIGNATURE",
+  ];
+
   afterEach(() => {
     closeOpenAICodexWebSocketSessions();
     vi.restoreAllMocks();
@@ -81,6 +112,100 @@ describe("streamOpenAICodexResponses retry classification", () => {
           status: 401,
         }),
       );
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(globalThis, "setTimeout").mockImplementation((callback: TimerHandler) => {
+      if (typeof callback === "function") {
+        callback();
+      }
+      return 0 as unknown as ReturnType<typeof setTimeout>;
+    });
+
+    const result = await streamOpenAICodexResponses(model, context, {
+      apiKey: jwt,
+      transport: "sse",
+    }).result();
+
+    expect(result.stopReason).toBe("error");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    Object.assign(new Error("unable to verify the first certificate"), {
+      code: "UNABLE_TO_VERIFY_LEAF_SIGNATURE",
+    }),
+    new Error("fetch failed", {
+      cause: Object.assign(new Error("certificate has expired"), {
+        code: "CERT_HAS_EXPIRED",
+      }),
+    }),
+    Object.assign(new Error("TLS validation failed"), {
+      code: "CERT_NOT_YET_VALID",
+    }),
+    new Error("fetch failed", {
+      cause: Object.assign(new Error("TLS validation failed"), {
+        code: "CERT_NOT_YET_VALID",
+      }),
+    }),
+    new Error("certificate is not yet valid"),
+  ])("does not retry deterministic TLS certificate failures", async (error) => {
+    const fetchMock = vi.fn<typeof fetch>().mockRejectedValue(error);
+    vi.stubGlobal("fetch", fetchMock);
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+
+    const result = await streamOpenAICodexResponses(model, context, {
+      apiKey: jwt,
+      transport: "sse",
+    }).result();
+
+    expect(result.stopReason).toBe("error");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(setTimeoutSpy).not.toHaveBeenCalled();
+  });
+
+  it.each(deterministicTlsCertificateCodes)(
+    "does not retry Node/OpenSSL certificate code %s from a non-Error rejection",
+    async (code) => {
+      const fetchMock = vi.fn<typeof fetch>().mockRejectedValue({
+        code,
+        message: "TLS certificate validation failed",
+      });
+      vi.stubGlobal("fetch", fetchMock);
+      const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+
+      const result = await streamOpenAICodexResponses(model, context, {
+        apiKey: jwt,
+        transport: "sse",
+      }).result();
+
+      expect(result.stopReason).toBe("error");
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(setTimeoutSpy).not.toHaveBeenCalled();
+    },
+  );
+
+  it("does not retry a non-Error rejection with a wrapped certificate code", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockRejectedValue({
+      cause: { code: "INVALID_CA" },
+      message: "fetch failed",
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+
+    const result = await streamOpenAICodexResponses(model, context, {
+      apiKey: jwt,
+      transport: "sse",
+    }).result();
+
+    expect(result.stopReason).toBe("error");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(setTimeoutSpy).not.toHaveBeenCalled();
+  });
+
+  it("keeps retrying transient network failures", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockRejectedValueOnce(Object.assign(new Error("socket hang up"), { code: "ECONNRESET" }))
+      .mockRejectedValueOnce(new Error("usage limit: stop after retry"));
     vi.stubGlobal("fetch", fetchMock);
     vi.spyOn(globalThis, "setTimeout").mockImplementation((callback: TimerHandler) => {
       if (typeof callback === "function") {

--- a/packages/ai/src/providers/openai-chatgpt-responses.retry.test.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.retry.test.ts
@@ -15,37 +15,6 @@ function createTestJwt(payload: Record<string, unknown>): string {
 }
 
 describe("streamOpenAICodexResponses retry classification", () => {
-  const deterministicTlsCertificateCodes = [
-    "CERT_HAS_EXPIRED",
-    "CERT_REJECTED",
-    "CERT_REVOKED",
-    "CERT_SIGNATURE_FAILURE",
-    "CERT_UNTRUSTED",
-    "CERT_CHAIN_TOO_LONG",
-    "CERT_NOT_YET_VALID",
-    "CRL_HAS_EXPIRED",
-    "CRL_NOT_YET_VALID",
-    "CRL_SIGNATURE_FAILURE",
-    "DEPTH_ZERO_SELF_SIGNED_CERT",
-    "ERROR_IN_CERT_NOT_AFTER_FIELD",
-    "ERROR_IN_CERT_NOT_BEFORE_FIELD",
-    "ERROR_IN_CRL_LAST_UPDATE_FIELD",
-    "ERROR_IN_CRL_NEXT_UPDATE_FIELD",
-    "ERR_TLS_CERT_ALTNAME_INVALID",
-    "HOSTNAME_MISMATCH",
-    "INVALID_CA",
-    "INVALID_PURPOSE",
-    "PATH_LENGTH_EXCEEDED",
-    "SELF_SIGNED_CERT_IN_CHAIN",
-    "UNABLE_TO_DECODE_ISSUER_PUBLIC_KEY",
-    "UNABLE_TO_DECRYPT_CERT_SIGNATURE",
-    "UNABLE_TO_DECRYPT_CRL_SIGNATURE",
-    "UNABLE_TO_GET_CRL",
-    "UNABLE_TO_GET_ISSUER_CERT",
-    "UNABLE_TO_GET_ISSUER_CERT_LOCALLY",
-    "UNABLE_TO_VERIFY_LEAF_SIGNATURE",
-  ];
-
   afterEach(() => {
     closeOpenAICodexWebSocketSessions();
     vi.restoreAllMocks();
@@ -147,6 +116,9 @@ describe("streamOpenAICodexResponses retry classification", () => {
       }),
     }),
     new Error("certificate is not yet valid"),
+    Object.assign(new Error("TLS validation failed"), {
+      code: "ERR_TLS_CERT_ALTNAME_INVALID",
+    }),
   ])("does not retry deterministic TLS certificate failures", async (error) => {
     const fetchMock = vi.fn<typeof fetch>().mockRejectedValue(error);
     vi.stubGlobal("fetch", fetchMock);
@@ -161,27 +133,6 @@ describe("streamOpenAICodexResponses retry classification", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(setTimeoutSpy).not.toHaveBeenCalled();
   });
-
-  it.each(deterministicTlsCertificateCodes)(
-    "does not retry Node/OpenSSL certificate code %s from a non-Error rejection",
-    async (code) => {
-      const fetchMock = vi.fn<typeof fetch>().mockRejectedValue({
-        code,
-        message: "TLS certificate validation failed",
-      });
-      vi.stubGlobal("fetch", fetchMock);
-      const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
-
-      const result = await streamOpenAICodexResponses(model, context, {
-        apiKey: jwt,
-        transport: "sse",
-      }).result();
-
-      expect(result.stopReason).toBe("error");
-      expect(fetchMock).toHaveBeenCalledTimes(1);
-      expect(setTimeoutSpy).not.toHaveBeenCalled();
-    },
-  );
 
   it("does not retry a non-Error rejection with a wrapped certificate code", async () => {
     const fetchMock = vi.fn<typeof fetch>().mockRejectedValue({

--- a/packages/ai/src/providers/openai-chatgpt-responses.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.ts
@@ -60,6 +60,7 @@ import {
 } from "../utils/stream-first-event-timeout.js";
 import { createSseByteGuard } from "../utils/streaming-byte-guard.js";
 import { stripSystemPromptCacheBoundary } from "../utils/system-prompt-cache-boundary.js";
+import { inspectTlsCertificateError } from "../utils/tls-certificate-errors.js";
 import { clampOpenAIPromptCacheKey } from "./openai-prompt-cache.js";
 import { supportsOpenAITemperature } from "./openai-reasoning-effort.js";
 import {
@@ -134,66 +135,6 @@ interface RequestBody {
 // ============================================================================
 // Retry Helpers
 // ============================================================================
-
-const TLS_CERTIFICATE_ERROR_CODES = new Set([
-  "CERT_HAS_EXPIRED",
-  "CERT_REJECTED",
-  "CERT_REVOKED",
-  "CERT_SIGNATURE_FAILURE",
-  "CERT_UNTRUSTED",
-  "CERT_CHAIN_TOO_LONG",
-  "CERT_NOT_YET_VALID",
-  "CRL_HAS_EXPIRED",
-  "CRL_NOT_YET_VALID",
-  "CRL_SIGNATURE_FAILURE",
-  "DEPTH_ZERO_SELF_SIGNED_CERT",
-  "ERROR_IN_CERT_NOT_AFTER_FIELD",
-  "ERROR_IN_CERT_NOT_BEFORE_FIELD",
-  "ERROR_IN_CRL_LAST_UPDATE_FIELD",
-  "ERROR_IN_CRL_NEXT_UPDATE_FIELD",
-  "ERR_TLS_CERT_ALTNAME_INVALID",
-  "HOSTNAME_MISMATCH",
-  "INVALID_CA",
-  "INVALID_PURPOSE",
-  "PATH_LENGTH_EXCEEDED",
-  "SELF_SIGNED_CERT_IN_CHAIN",
-  "UNABLE_TO_DECODE_ISSUER_PUBLIC_KEY",
-  "UNABLE_TO_DECRYPT_CERT_SIGNATURE",
-  "UNABLE_TO_DECRYPT_CRL_SIGNATURE",
-  "UNABLE_TO_GET_CRL",
-  "UNABLE_TO_GET_ISSUER_CERT",
-  "UNABLE_TO_GET_ISSUER_CERT_LOCALLY",
-  "UNABLE_TO_VERIFY_LEAF_SIGNATURE",
-]);
-
-const TLS_CERTIFICATE_ERROR_PATTERNS = [
-  /certificate has expired/i,
-  /certificate is not yet valid/i,
-  /self[- ]signed certificate/i,
-  /unable to get local issuer certificate/i,
-  /unable to verify the first certificate/i,
-];
-
-function isTlsCertificateError(error: unknown, seen = new Set<object>()): boolean {
-  if (
-    error instanceof Error &&
-    TLS_CERTIFICATE_ERROR_PATTERNS.some((re) => re.test(error.message))
-  ) {
-    return true;
-  }
-  if (!error || typeof error !== "object" || seen.has(error)) {
-    return false;
-  }
-  seen.add(error);
-  const candidate = error as { cause?: unknown; code?: unknown };
-  if (
-    typeof candidate.code === "string" &&
-    TLS_CERTIFICATE_ERROR_CODES.has(candidate.code.trim().toUpperCase())
-  ) {
-    return true;
-  }
-  return isTlsCertificateError(candidate.cause, seen);
-}
 
 function isRetryableError(status: number, errorText: string): boolean {
   if (status === 429 || status === 500 || status === 502 || status === 503 || status === 504) {
@@ -498,7 +439,7 @@ export const streamOpenAICodexResponses: StreamFunction<
               throw new Error(`Request timed out after ${requestTimeoutMs}ms`, { cause: error });
             }
           }
-          const tlsCertificateError = isTlsCertificateError(error);
+          const tlsCertificateError = inspectTlsCertificateError(error);
           lastError = toLintErrorObject(error, String(error));
           // Deterministic certificate failures cannot recover through backoff.
           if (

--- a/packages/ai/src/providers/openai-chatgpt-responses.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.ts
@@ -135,6 +135,66 @@ interface RequestBody {
 // Retry Helpers
 // ============================================================================
 
+const TLS_CERTIFICATE_ERROR_CODES = new Set([
+  "CERT_HAS_EXPIRED",
+  "CERT_REJECTED",
+  "CERT_REVOKED",
+  "CERT_SIGNATURE_FAILURE",
+  "CERT_UNTRUSTED",
+  "CERT_CHAIN_TOO_LONG",
+  "CERT_NOT_YET_VALID",
+  "CRL_HAS_EXPIRED",
+  "CRL_NOT_YET_VALID",
+  "CRL_SIGNATURE_FAILURE",
+  "DEPTH_ZERO_SELF_SIGNED_CERT",
+  "ERROR_IN_CERT_NOT_AFTER_FIELD",
+  "ERROR_IN_CERT_NOT_BEFORE_FIELD",
+  "ERROR_IN_CRL_LAST_UPDATE_FIELD",
+  "ERROR_IN_CRL_NEXT_UPDATE_FIELD",
+  "ERR_TLS_CERT_ALTNAME_INVALID",
+  "HOSTNAME_MISMATCH",
+  "INVALID_CA",
+  "INVALID_PURPOSE",
+  "PATH_LENGTH_EXCEEDED",
+  "SELF_SIGNED_CERT_IN_CHAIN",
+  "UNABLE_TO_DECODE_ISSUER_PUBLIC_KEY",
+  "UNABLE_TO_DECRYPT_CERT_SIGNATURE",
+  "UNABLE_TO_DECRYPT_CRL_SIGNATURE",
+  "UNABLE_TO_GET_CRL",
+  "UNABLE_TO_GET_ISSUER_CERT",
+  "UNABLE_TO_GET_ISSUER_CERT_LOCALLY",
+  "UNABLE_TO_VERIFY_LEAF_SIGNATURE",
+]);
+
+const TLS_CERTIFICATE_ERROR_PATTERNS = [
+  /certificate has expired/i,
+  /certificate is not yet valid/i,
+  /self[- ]signed certificate/i,
+  /unable to get local issuer certificate/i,
+  /unable to verify the first certificate/i,
+];
+
+function isTlsCertificateError(error: unknown, seen = new Set<object>()): boolean {
+  if (
+    error instanceof Error &&
+    TLS_CERTIFICATE_ERROR_PATTERNS.some((re) => re.test(error.message))
+  ) {
+    return true;
+  }
+  if (!error || typeof error !== "object" || seen.has(error)) {
+    return false;
+  }
+  seen.add(error);
+  const candidate = error as { cause?: unknown; code?: unknown };
+  if (
+    typeof candidate.code === "string" &&
+    TLS_CERTIFICATE_ERROR_CODES.has(candidate.code.trim().toUpperCase())
+  ) {
+    return true;
+  }
+  return isTlsCertificateError(candidate.cause, seen);
+}
+
 function isRetryableError(status: number, errorText: string): boolean {
   if (status === 429 || status === 500 || status === 502 || status === 503 || status === 504) {
     return true;
@@ -438,9 +498,14 @@ export const streamOpenAICodexResponses: StreamFunction<
               throw new Error(`Request timed out after ${requestTimeoutMs}ms`, { cause: error });
             }
           }
-          lastError = error instanceof Error ? error : new Error(String(error));
-          // Network errors are retryable
-          if (attempt < maxRetries && !lastError.message.includes("usage limit")) {
+          const tlsCertificateError = isTlsCertificateError(error);
+          lastError = toLintErrorObject(error, String(error));
+          // Deterministic certificate failures cannot recover through backoff.
+          if (
+            attempt < maxRetries &&
+            !lastError.message.includes("usage limit") &&
+            !tlsCertificateError
+          ) {
             const delayMs = BASE_DELAY_MS * 2 ** attempt;
             await sleepWithAbort(delayMs, activeSignal);
             continue;

--- a/packages/ai/src/utils/tls-certificate-errors.test.ts
+++ b/packages/ai/src/utils/tls-certificate-errors.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import { inspectTlsCertificateError } from "./tls-certificate-errors.js";
+
+const CERTIFICATE_INVALID_CODES = [
+  "CERT_CHAIN_TOO_LONG",
+  "CERT_HAS_EXPIRED",
+  "CERT_NOT_YET_VALID",
+  "CERT_REJECTED",
+  "CERT_REVOKED",
+  "CERT_SIGNATURE_FAILURE",
+  "CERT_UNTRUSTED",
+  "CRL_HAS_EXPIRED",
+  "CRL_NOT_YET_VALID",
+  "CRL_SIGNATURE_FAILURE",
+  "DEPTH_ZERO_SELF_SIGNED_CERT",
+  "ERROR_IN_CERT_NOT_AFTER_FIELD",
+  "ERROR_IN_CERT_NOT_BEFORE_FIELD",
+  "ERROR_IN_CRL_LAST_UPDATE_FIELD",
+  "ERROR_IN_CRL_NEXT_UPDATE_FIELD",
+  "INVALID_CA",
+  "INVALID_PURPOSE",
+  "PATH_LENGTH_EXCEEDED",
+  "SELF_SIGNED_CERT_IN_CHAIN",
+  "UNABLE_TO_DECODE_ISSUER_PUBLIC_KEY",
+  "UNABLE_TO_DECRYPT_CERT_SIGNATURE",
+  "UNABLE_TO_DECRYPT_CRL_SIGNATURE",
+  "UNABLE_TO_GET_CRL",
+  "UNABLE_TO_GET_ISSUER_CERT",
+  "UNABLE_TO_GET_ISSUER_CERT_LOCALLY",
+  "UNABLE_TO_VERIFY_LEAF_SIGNATURE",
+];
+
+describe("inspectTlsCertificateError", () => {
+  it.each(CERTIFICATE_INVALID_CODES)("classifies Node/OpenSSL certificate code %s", (code) => {
+    expect(inspectTlsCertificateError({ code, message: "TLS validation failed" })).toEqual({
+      kind: "certificate_invalid",
+      code,
+      message: "TLS validation failed",
+    });
+  });
+
+  it.each(["ERR_TLS_CERT_ALTNAME_INVALID", "HOSTNAME_MISMATCH"])(
+    "classifies hostname mismatch code %s",
+    (code) => {
+      expect(inspectTlsCertificateError({ code, message: "TLS validation failed" })).toEqual({
+        kind: "hostname_mismatch",
+        code,
+        message: "TLS validation failed",
+      });
+    },
+  );
+
+  it("walks nested causes and preserves the matching details", () => {
+    const cause = Object.assign(new Error("certificate has expired"), {
+      code: "CERT_HAS_EXPIRED",
+    });
+    expect(inspectTlsCertificateError(new TypeError("fetch failed", { cause }))).toEqual({
+      kind: "certificate_invalid",
+      code: "CERT_HAS_EXPIRED",
+      message: "certificate has expired",
+    });
+  });
+
+  it("walks AggregateError members", () => {
+    const certificateError = Object.assign(new Error("certificate revoked"), {
+      code: "CERT_REVOKED",
+    });
+    const error = new AggregateError(
+      [new Error("connection failed"), certificateError],
+      "request failed",
+    );
+
+    expect(inspectTlsCertificateError(error)).toEqual({
+      kind: "certificate_invalid",
+      code: "CERT_REVOKED",
+      message: "certificate revoked",
+    });
+  });
+
+  it("handles cycles without recursing forever", () => {
+    const error: { cause?: unknown; message: string } = { message: "fetch failed" };
+    error.cause = error;
+    expect(inspectTlsCertificateError(error)).toBeNull();
+  });
+
+  it.each([
+    ["certificate is not yet valid", "certificate_invalid"],
+    ["self-signed certificate in certificate chain", "certificate_invalid"],
+    [
+      "Hostname/IP does not match certificate's altnames: Host: api.example.com",
+      "hostname_mismatch",
+    ],
+  ] as const)("classifies message-only failure %s", (message, kind) => {
+    expect(inspectTlsCertificateError(message)).toEqual({ kind, message });
+  });
+
+  it.each([
+    Object.assign(new Error("socket hang up"), { code: "ECONNRESET" }),
+    new Error("Client network socket disconnected before secure TLS connection was established"),
+    { code: "OUT_OF_MEM", message: "out of memory" },
+  ])("does not classify transient or non-certificate failure", (error) => {
+    expect(inspectTlsCertificateError(error)).toBeNull();
+  });
+});

--- a/packages/ai/src/utils/tls-certificate-errors.ts
+++ b/packages/ai/src/utils/tls-certificate-errors.ts
@@ -1,0 +1,128 @@
+export type TlsCertificateErrorKind = "certificate_invalid" | "hostname_mismatch";
+
+export type TlsCertificateErrorDetails = {
+  kind: TlsCertificateErrorKind;
+  code?: string;
+  message: string;
+};
+
+const HOSTNAME_MISMATCH_CODES = new Set(["ERR_TLS_CERT_ALTNAME_INVALID", "HOSTNAME_MISMATCH"]);
+
+const CERTIFICATE_INVALID_CODES = new Set([
+  "CERT_CHAIN_TOO_LONG",
+  "CERT_HAS_EXPIRED",
+  "CERT_NOT_YET_VALID",
+  "CERT_REJECTED",
+  "CERT_REVOKED",
+  "CERT_SIGNATURE_FAILURE",
+  "CERT_UNTRUSTED",
+  "CRL_HAS_EXPIRED",
+  "CRL_NOT_YET_VALID",
+  "CRL_SIGNATURE_FAILURE",
+  "DEPTH_ZERO_SELF_SIGNED_CERT",
+  "ERROR_IN_CERT_NOT_AFTER_FIELD",
+  "ERROR_IN_CERT_NOT_BEFORE_FIELD",
+  "ERROR_IN_CRL_LAST_UPDATE_FIELD",
+  "ERROR_IN_CRL_NEXT_UPDATE_FIELD",
+  "INVALID_CA",
+  "INVALID_PURPOSE",
+  "PATH_LENGTH_EXCEEDED",
+  "SELF_SIGNED_CERT_IN_CHAIN",
+  "UNABLE_TO_DECODE_ISSUER_PUBLIC_KEY",
+  "UNABLE_TO_DECRYPT_CERT_SIGNATURE",
+  "UNABLE_TO_DECRYPT_CRL_SIGNATURE",
+  "UNABLE_TO_GET_CRL",
+  "UNABLE_TO_GET_ISSUER_CERT",
+  "UNABLE_TO_GET_ISSUER_CERT_LOCALLY",
+  "UNABLE_TO_VERIFY_LEAF_SIGNATURE",
+]);
+
+const HOSTNAME_MISMATCH_PATTERNS = [
+  /hostname\/ip does not match certificate(?:'s)? altnames/i,
+  /hostname mismatch/i,
+  /host: .+ is not in the cert(?:ificate)?(?:'s)? altnames/i,
+];
+
+const CERTIFICATE_INVALID_PATTERNS = [
+  /certificate has expired/i,
+  /certificate is not yet valid/i,
+  /self[- ]signed certificate/i,
+  /unable to get local issuer certificate/i,
+  /unable to verify the first certificate/i,
+];
+
+const MAX_TLS_ERROR_DEPTH = 8;
+
+function classifyCode(code: string): TlsCertificateErrorKind | null {
+  if (HOSTNAME_MISMATCH_CODES.has(code)) {
+    return "hostname_mismatch";
+  }
+  return CERTIFICATE_INVALID_CODES.has(code) ? "certificate_invalid" : null;
+}
+
+function classifyMessage(message: string): TlsCertificateErrorKind | null {
+  if (HOSTNAME_MISMATCH_PATTERNS.some((pattern) => pattern.test(message))) {
+    return "hostname_mismatch";
+  }
+  return CERTIFICATE_INVALID_PATTERNS.some((pattern) => pattern.test(message))
+    ? "certificate_invalid"
+    : null;
+}
+
+function inspectTlsCertificateErrorInternal(
+  error: unknown,
+  seen: Set<object>,
+  depth: number,
+): TlsCertificateErrorDetails | null {
+  if (depth > MAX_TLS_ERROR_DEPTH) {
+    return null;
+  }
+  if (typeof error === "string") {
+    const kind = classifyMessage(error);
+    return kind ? { kind, message: error } : null;
+  }
+  if (!error || typeof error !== "object" || seen.has(error)) {
+    return null;
+  }
+  seen.add(error);
+
+  const candidate = error as {
+    cause?: unknown;
+    code?: unknown;
+    error?: unknown;
+    errors?: unknown;
+    message?: unknown;
+  };
+  const code = typeof candidate.code === "string" ? candidate.code.trim().toUpperCase() : undefined;
+  const message =
+    typeof candidate.message === "string" && candidate.message.trim()
+      ? candidate.message
+      : undefined;
+  const codeKind = code ? classifyCode(code) : null;
+  if (code && codeKind) {
+    return {
+      kind: codeKind,
+      code,
+      message: message ?? code,
+    };
+  }
+
+  const nestedErrors = Array.isArray(candidate.errors) ? candidate.errors : [];
+  for (const nested of [candidate.cause, candidate.error, ...nestedErrors]) {
+    if (nested === undefined || nested === error) {
+      continue;
+    }
+    const details = inspectTlsCertificateErrorInternal(nested, seen, depth + 1);
+    if (details) {
+      return details;
+    }
+  }
+
+  const messageKind = message ? classifyMessage(message) : null;
+  return messageKind && message ? { kind: messageKind, message } : null;
+}
+
+/** Classify deterministic Node/OpenSSL certificate validation failures. */
+export function inspectTlsCertificateError(error: unknown): TlsCertificateErrorDetails | null {
+  return inspectTlsCertificateErrorInternal(error, new Set<object>(), 0);
+}

--- a/src/agents/auth-profiles/failure-copy.ts
+++ b/src/agents/auth-profiles/failure-copy.ts
@@ -81,6 +81,7 @@ function shouldIncludeRecoveryHint(reason: FailoverReason): boolean {
     case "rate_limit":
     case "overloaded":
     case "timeout":
+    case "tls_certificate":
     case "server_error":
     case "model_not_found":
     case "format":

--- a/src/agents/embedded-agent-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/embedded-agent-helpers.formatassistanterrortext.test.ts
@@ -551,6 +551,16 @@ describe("formatAssistantErrorText", () => {
     );
   });
 
+  it("returns a certificate-specific message for TLS validation failures", () => {
+    const msg = makeAssistantError(
+      "Hostname/IP does not match certificate's altnames: Host: api.example.com",
+    );
+    expect(formatAssistantErrorText(msg)).toBe(
+      "LLM request failed: TLS certificate validation rejected the provider endpoint. " +
+        "Check the endpoint hostname, proxy, and local certificate trust.",
+    );
+  });
+
   it("keeps non-transport config errors that mention proxy settings actionable", () => {
     const msg = makeAssistantError(
       'Model-provider request.proxy/request.tls is not yet supported for api "ollama"',

--- a/src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts
@@ -1655,6 +1655,25 @@ describe("classifyProviderRuntimeFailureKind", () => {
     ).toBe("dns");
     expect(classifyProviderRuntimeFailureKind("socket hang up")).toBe("timeout");
     expect(
+      classifyProviderRuntimeFailureKind({
+        code: "CERT_HAS_EXPIRED",
+        message: "certificate has expired",
+      }),
+    ).toBe("tls_certificate");
+    expect(
+      classifyProviderRuntimeFailureKind({
+        code: "CERT_REVOKED",
+        message: "TLS validation failed",
+      }),
+    ).toBe("tls_certificate");
+    expect(
+      classifyProviderRuntimeFailureKind({
+        status: 400,
+        code: "CERT_HAS_EXPIRED",
+        message: "certificate field rejected",
+      }),
+    ).toBe("unclassified");
+    expect(
       classifyProviderRuntimeFailureKind("INVALID_REQUEST_ERROR: string should match pattern"),
     ).toBe("schema");
     expect(classifyProviderRuntimeFailureKind("exec denied (allowlist-miss):")).toBe(

--- a/src/agents/embedded-agent-helpers/errors.ts
+++ b/src/agents/embedded-agent-helpers/errors.ts
@@ -1,4 +1,5 @@
 import { isConfiguredContextSizeOverflowError } from "@openclaw/ai/internal/runtime";
+import { inspectTlsCertificateError } from "@openclaw/ai/internal/shared";
 /**
  * Classifies provider/runtime failures and formats assistant-facing error text.
  */
@@ -390,6 +391,7 @@ export type ProviderRuntimeFailureKind =
   | "rate_limit"
   | "dns"
   | "timeout"
+  | "tls_certificate"
   | "model_not_found"
   | "schema"
   | "sandbox_blocked"
@@ -1182,6 +1184,10 @@ function mergeMessageAndDetailClassification(
 
 export function classifyFailoverSignal(signal: FailoverSignal): FailoverClassification | null {
   const inferredStatus = inferSignalStatus(signal);
+  const tlsCertificateError = inspectTlsCertificateError(signal);
+  if (tlsCertificateError && inferredStatus === undefined) {
+    return toReasonClassification("tls_certificate");
+  }
   const explicitStatus =
     typeof signal.status === "number" && Number.isFinite(signal.status) ? signal.status : undefined;
   if (
@@ -1296,6 +1302,12 @@ export function classifyProviderRuntimeFailureKind(
     status,
     message: message || undefined,
   });
+  if (
+    failoverClassification?.kind === "reason" &&
+    failoverClassification.reason === "tls_certificate"
+  ) {
+    return "tls_certificate";
+  }
   if (failoverClassification?.kind === "reason" && failoverClassification.reason === "rate_limit") {
     return "rate_limit";
   }
@@ -1486,6 +1498,13 @@ export function formatAssistantErrorText(
 
   if (providerRuntimeFailureKind === "proxy") {
     return "LLM request failed: proxy or tunnel configuration blocked the provider request.";
+  }
+
+  if (providerRuntimeFailureKind === "tls_certificate") {
+    return (
+      "LLM request failed: TLS certificate validation rejected the provider endpoint. " +
+      "Check the endpoint hostname, proxy, and local certificate trust."
+    );
   }
 
   if (providerRuntimeFailureKind === "model_not_found") {

--- a/src/agents/embedded-agent-helpers/types.ts
+++ b/src/agents/embedded-agent-helpers/types.ts
@@ -11,6 +11,7 @@ export type FailoverReason =
   | "billing"
   | "server_error"
   | "timeout"
+  | "tls_certificate"
   | "context_overflow"
   | "model_not_found"
   | "session_expired"

--- a/src/agents/embedded-agent-runner/run/auth-profile-failure-policy.test.ts
+++ b/src/agents/embedded-agent-runner/run/auth-profile-failure-policy.test.ts
@@ -95,6 +95,11 @@ describe("resolveAuthProfileFailureReason", () => {
         failoverReason: "server_error",
       }),
     ).toBeNull();
+    expect(
+      resolveAuthProfileFailureReason({
+        failoverReason: "tls_certificate",
+      }),
+    ).toBeNull();
   });
 
   it("does not persist empty responses as auth-profile health", () => {

--- a/src/agents/embedded-agent-runner/run/auth-profile-failure-policy.ts
+++ b/src/agents/embedded-agent-runner/run/auth-profile-failure-policy.ts
@@ -33,6 +33,7 @@ export function resolveAuthProfileFailureReason(params: {
       (params.failoverReason === "overloaded" ||
         (params.failoverReason === "rate_limit" && params.transientRateLimit === true))) ||
     params.failoverReason === "server_error" ||
+    params.failoverReason === "tls_certificate" ||
     params.failoverReason === "empty_response" ||
     params.failoverReason === "context_overflow" ||
     params.failoverReason === "format"

--- a/src/agents/embedded-agent-runner/run/failover-policy.test.ts
+++ b/src/agents/embedded-agent-runner/run/failover-policy.test.ts
@@ -95,6 +95,23 @@ describe("resolveRunFailoverDecision", () => {
     });
   });
 
+  it("sends prompt TLS certificate failures directly to model fallback", () => {
+    expect(
+      resolveRunFailoverDecision({
+        stage: "prompt",
+        aborted: false,
+        externalAbort: false,
+        fallbackConfigured: true,
+        failoverFailure: true,
+        failoverReason: "tls_certificate",
+        profileRotated: false,
+      }),
+    ).toEqual({
+      action: "fallback_model",
+      reason: "tls_certificate",
+    });
+  });
+
   it("surfaces max-turn prompt failures without profile rotation or model fallback", () => {
     expect(
       resolveRunFailoverDecision({
@@ -272,6 +289,28 @@ describe("resolveRunFailoverDecision", () => {
     ).toEqual({
       action: "fallback_model",
       reason: "rate_limit",
+    });
+  });
+
+  it("sends assistant TLS certificate failures directly to model fallback", () => {
+    expect(
+      resolveRunFailoverDecision({
+        stage: "assistant",
+        aborted: false,
+        externalAbort: false,
+        fallbackConfigured: true,
+        failoverFailure: true,
+        failoverReason: "tls_certificate",
+        timedOut: false,
+        idleTimedOut: false,
+        timedOutDuringCompaction: false,
+        timedOutDuringToolExecution: false,
+        timedOutByRunBudget: false,
+        profileRotated: false,
+      }),
+    ).toEqual({
+      action: "fallback_model",
+      reason: "tls_certificate",
     });
   });
 

--- a/src/agents/embedded-agent-runner/run/failover-policy.ts
+++ b/src/agents/embedded-agent-runner/run/failover-policy.ts
@@ -101,6 +101,7 @@ function shouldRotatePrompt(params: PromptDecisionParams): boolean {
   return (
     params.failoverFailure &&
     params.failoverReason !== "timeout" &&
+    params.failoverReason !== "tls_certificate" &&
     !isTerminalFormatFailure(params)
   );
 }
@@ -241,6 +242,17 @@ export function resolveRunFailoverDecision(params: RunFailoverDecisionParams): R
       action: "surface_error",
       reason: params.failoverReason,
     };
+  }
+  if (params.failoverFailure && params.failoverReason === "tls_certificate") {
+    return params.fallbackConfigured
+      ? {
+          action: "fallback_model",
+          reason: "tls_certificate",
+        }
+      : {
+          action: "surface_error",
+          reason: "tls_certificate",
+        };
   }
   const assistantShouldRotate = shouldRotateAssistant(params);
   if (!params.profileRotated && assistantShouldRotate) {

--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -235,6 +235,33 @@ describe("failover-error", () => {
     expect(resolveFailoverReasonFromError({ status: 529 })).toBe("overloaded");
   });
 
+  it("classifies certificate failures separately from timeouts", () => {
+    expect(
+      resolveFailoverReasonFromError({
+        code: "ERR_TLS_CERT_ALTNAME_INVALID",
+        message: "Hostname/IP does not match certificate's altnames",
+      }),
+    ).toBe("tls_certificate");
+    expect(
+      resolveFailoverReasonFromError(
+        new TypeError("fetch failed", {
+          cause: {
+            code: "CERT_HAS_EXPIRED",
+            message: "certificate has expired",
+          },
+        }),
+      ),
+    ).toBe("tls_certificate");
+    expect(
+      resolveFailoverReasonFromError({
+        status: 400,
+        code: "CERT_HAS_EXPIRED",
+        message: "certificate field rejected",
+      }),
+    ).toBe("format");
+    expect(resolveFailoverStatus("tls_certificate")).toBe(502);
+  });
+
   it("stops on cyclic cause chains", () => {
     const first: { cause?: unknown } = {};
     const second: { cause?: unknown } = { cause: first };

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -191,6 +191,8 @@ export function resolveFailoverStatus(reason: FailoverReason): number | undefine
       return 403;
     case "timeout":
       return 408;
+    case "tls_certificate":
+      return 502;
     case "context_overflow":
       return 413;
     case "format":

--- a/src/agents/failover-policy.ts
+++ b/src/agents/failover-policy.ts
@@ -43,6 +43,7 @@ export function shouldPreserveTransientCooldownProbeSlot(
     reason === "format" ||
     reason === "auth" ||
     reason === "auth_permanent" ||
-    reason === "session_expired"
+    reason === "session_expired" ||
+    reason === "tls_certificate"
   );
 }

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -664,6 +664,90 @@ describe("runWithModelFallback", () => {
     );
   });
 
+  it("skips same-provider candidates after a TLS certificate failure", async () => {
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new FailoverError("Hostname/IP does not match certificate's altnames", {
+          provider: "openai",
+          model: "gpt-5.5",
+          reason: "tls_certificate",
+          code: "ERR_TLS_CERT_ALTNAME_INVALID",
+        }),
+      )
+      .mockResolvedValueOnce("anthropic success");
+
+    const result = await runWithModelFallback({
+      cfg: makeDiagnosticFallbackConfig(["openai/gpt-5.5-mini", "anthropic/claude-opus-4-6"]),
+      provider: "openai",
+      model: "gpt-5.5",
+      run,
+    });
+
+    expect(result.result).toBe("anthropic success");
+    expect(run.mock.calls).toEqual([
+      ["openai", "gpt-5.5", { isFinalFallbackAttempt: false }],
+      ["anthropic", "claude-opus-4-6", { isFinalFallbackAttempt: true }],
+    ]);
+    expect(result.attempts).toHaveLength(1);
+    expect(result.attempts[0]?.reason).toBe("tls_certificate");
+  });
+
+  it("keeps TLS-failed providers excluded across interleaved fallbacks", async () => {
+    const diagnostics = captureModelFailoverDiagnostics();
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new FailoverError("Hostname/IP does not match certificate's altnames", {
+          provider: "openai",
+          model: "gpt-5.5",
+          reason: "tls_certificate",
+          code: "ERR_TLS_CERT_ALTNAME_INVALID",
+        }),
+      )
+      .mockRejectedValueOnce(
+        new FailoverError("overloaded", {
+          provider: "anthropic",
+          model: "claude-opus-4-6",
+          reason: "overloaded",
+        }),
+      )
+      .mockResolvedValueOnce("must not run");
+    let thrown: unknown;
+
+    try {
+      await runWithModelFallback({
+        cfg: makeDiagnosticFallbackConfig(["anthropic/claude-opus-4-6", "openai/gpt-5.5-mini"]),
+        provider: "openai",
+        model: "gpt-5.5",
+        sessionId: "session:tls-provider-exclusion",
+        sessionKey: "agent:test:tls-provider-exclusion",
+        lane: "main",
+        run,
+      });
+    } catch (error) {
+      thrown = error;
+    } finally {
+      diagnostics.stop();
+    }
+
+    expect(isFallbackSummaryError(thrown)).toBe(true);
+    expect(run.mock.calls).toEqual([
+      ["openai", "gpt-5.5", { isFinalFallbackAttempt: false }],
+      ["anthropic", "claude-opus-4-6", { isFinalFallbackAttempt: true }],
+    ]);
+    expect(diagnostics.events).toHaveLength(1);
+    expect(diagnostics.events).toMatchObject([
+      {
+        fromProvider: "openai",
+        fromModel: "gpt-5.5",
+        toProvider: "anthropic",
+        toModel: "claude-opus-4-6",
+        reason: "tls_certificate",
+      },
+    ]);
+  });
+
   it("does not replay CLI max-turn failures on configured fallback models", async () => {
     const failure = new FailoverError(
       "Claude CLI stopped after reaching the maximum number of turns (limit: 1). Tool actions may already have run; verify their effects before retrying.",

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -556,6 +556,20 @@ function sameModelCandidate(a: ModelCandidate, b: ModelCandidate): boolean {
   return a.provider === b.provider && a.model === b.model;
 }
 
+function resolveNextFallbackCandidateIndex(params: {
+  candidates: ModelCandidate[];
+  currentIndex: number;
+  excludedProviders: ReadonlySet<string>;
+}): number {
+  for (let index = params.currentIndex + 1; index < params.candidates.length; index += 1) {
+    const candidate = params.candidates[index];
+    if (candidate && !params.excludedProviders.has(candidate.provider)) {
+      return index;
+    }
+  }
+  return params.candidates.length;
+}
+
 function isCliAgentRuntime(runtime: string | undefined, cfg: OpenClawConfig | undefined): boolean {
   const normalized = normalizeOptionalString(runtime);
   if (!normalized) {
@@ -1457,6 +1471,7 @@ async function runWithModelFallbackInternal<T>(
   let latestClassifiedResult: ModelFallbackClassifiedResult<T> | undefined;
   let exhaustionResult: ModelFallbackExhaustionResult<T> | undefined;
   const cooldownProbeUsedProviders = new Set<string>();
+  const tlsFailedProviders = new Set<string>();
   const resolveTerminalSuspensionLane = () =>
     deferredSuspension.pending ? deferredSuspension.pending.laneId : params.lane;
   const observeDecision = async (decision: ModelFallbackDecisionParams) => {
@@ -1506,6 +1521,16 @@ async function runWithModelFallbackInternal<T>(
     if (!candidate) {
       throw new Error(`Missing model fallback candidate at index ${i}`);
     }
+    if (tlsFailedProviders.has(candidate.provider)) {
+      continue;
+    }
+    const nextCandidateIndex = resolveNextFallbackCandidateIndex({
+      candidates,
+      currentIndex: i,
+      excludedProviders: tlsFailedProviders,
+    });
+    const nextCandidate = candidates[nextCandidateIndex];
+    const hasRemainingCandidate = nextCandidate !== undefined;
     const candidateHarnessAuth = await resolveModelFallbackCandidateHarnessAuthPrecheck({
       cfg: params.cfg,
       agentId: params.agentId,
@@ -1561,7 +1586,7 @@ async function runWithModelFallbackInternal<T>(
           total: candidates.length,
           reason: skipReason as FailoverReason,
           error,
-          nextCandidate: candidates[i + 1],
+          nextCandidate,
           isPrimary,
           requestedModelMatched: requestedModel,
           fallbackConfigured: hasFallbackCandidates,
@@ -1622,7 +1647,7 @@ async function runWithModelFallbackInternal<T>(
           // Only lock the lane when no remaining candidates can serve as
           // fallbacks. Per-provider cooldown state already prevents
           // re-attempting the failed provider on subsequent turns.
-          const hasRemainingCandidates = i + 1 < candidates.length;
+          const hasRemainingCandidates = hasRemainingCandidate;
           if (params.sessionId) {
             emitFailoverEvent({
               sessionId: params.sessionId,
@@ -1659,7 +1684,7 @@ async function runWithModelFallbackInternal<T>(
             total: candidates.length,
             reason: decision.reason,
             error,
-            nextCandidate: candidates[i + 1],
+            nextCandidate,
             isPrimary,
             requestedModelMatched: requestedModel,
             fallbackConfigured: hasFallbackCandidates,
@@ -1688,7 +1713,7 @@ async function runWithModelFallbackInternal<T>(
             total: candidates.length,
             reason: decision.reason,
             error: decision.error,
-            nextCandidate: candidates[i + 1],
+            nextCandidate,
             isPrimary,
             requestedModelMatched: requestedModel,
             fallbackConfigured: hasFallbackCandidates,
@@ -1726,7 +1751,7 @@ async function runWithModelFallbackInternal<T>(
               total: candidates.length,
               reason: decision.reason,
               error,
-              nextCandidate: candidates[i + 1],
+              nextCandidate,
               isPrimary,
               requestedModelMatched: requestedModel,
               fallbackConfigured: hasFallbackCandidates,
@@ -1751,7 +1776,7 @@ async function runWithModelFallbackInternal<T>(
           attempt: i + 1,
           total: candidates.length,
           reason: decision.reason,
-          nextCandidate: candidates[i + 1],
+          nextCandidate,
           isPrimary,
           requestedModelMatched: requestedModel,
           fallbackConfigured: hasFallbackCandidates,
@@ -1767,12 +1792,12 @@ async function runWithModelFallbackInternal<T>(
       attempts,
       options: {
         ...runOptions,
-        isFinalFallbackAttempt: i + 1 === candidates.length,
+        isFinalFallbackAttempt: !hasRemainingCandidate,
       },
       // Only the outer fallback loop knows another candidate remains. Carry
       // that fact through this attempt so the embedded runner does not freeze
       // the shared lane before the next candidate can run.
-      deferSessionSuspension: i + 1 < candidates.length,
+      deferSessionSuspension: hasRemainingCandidate,
       onDeferredSessionSuspension: (suspension) => {
         deferredSuspension.pending = suspension;
       },
@@ -1921,7 +1946,7 @@ async function runWithModelFallbackInternal<T>(
           requestedModel: params.model,
           attempt: i + 1,
           total: candidates.length,
-          nextCandidate: candidates[i + 1],
+          nextCandidate,
           isPrimary,
           requestedModelMatched: requestedModel,
           fallbackConfigured: hasFallbackCandidates,
@@ -1933,7 +1958,7 @@ async function runWithModelFallbackInternal<T>(
       // there are remaining candidates.  Only abort/context-overflow errors
       // (handled above) are truly non-retryable.
       const isKnownFailover = isFailoverError(normalized);
-      if (!isKnownFailover && i === candidates.length - 1) {
+      if (!isKnownFailover && !hasRemainingCandidate) {
         throw err;
       }
 
@@ -1954,6 +1979,14 @@ async function runWithModelFallbackInternal<T>(
         });
       }
 
+      if (isKnownFailover && normalized.reason === "tls_certificate") {
+        tlsFailedProviders.add(candidate.provider);
+      }
+      const failedNextCandidateIndex = resolveNextFallbackCandidateIndex({
+        candidates,
+        currentIndex: i,
+        excludedProviders: tlsFailedProviders,
+      });
       lastError = isKnownFailover ? normalized : err;
       await observeFailedCandidate({
         attempts,
@@ -1966,7 +1999,7 @@ async function runWithModelFallbackInternal<T>(
         requestedModel: params.model,
         attempt: i + 1,
         total: candidates.length,
-        nextCandidate: candidates[i + 1],
+        nextCandidate: candidates[failedNextCandidateIndex],
         isPrimary,
         requestedModelMatched: requestedModel,
         fallbackConfigured: hasFallbackCandidates,
@@ -1978,6 +2011,9 @@ async function runWithModelFallbackInternal<T>(
         attempt: i + 1,
         total: candidates.length,
       });
+      if (failedNextCandidateIndex > i + 1) {
+        i = failedNextCandidateIndex - 1;
+      }
     }
   }
 

--- a/src/agents/runtime-plan/types.ts
+++ b/src/agents/runtime-plan/types.ts
@@ -41,6 +41,7 @@ type AgentRuntimeFailoverReason =
   | "billing"
   | "server_error"
   | "timeout"
+  | "tls_certificate"
   | "context_overflow"
   | "model_not_found"
   | "session_expired"

--- a/src/commands/oauth-tls-preflight.test.ts
+++ b/src/commands/oauth-tls-preflight.test.ts
@@ -54,6 +54,28 @@ describe("runOpenAIOAuthTlsPreflight", () => {
     }
     expect(result.kind).toBe("tls-cert");
     expect(result.code).toBe("UNABLE_TO_GET_ISSUER_CERT_LOCALLY");
+    expect(result.message).toBe("unable to get local issuer certificate");
+  });
+
+  it("classifies a deeply wrapped hostname mismatch", async () => {
+    const tlsFetchImpl = vi.fn(async () => {
+      throw new TypeError("fetch failed", {
+        cause: {
+          cause: {
+            code: "ERR_TLS_CERT_ALTNAME_INVALID",
+            message: "Hostname/IP does not match certificate's altnames",
+          },
+        },
+      });
+    }) as unknown as typeof fetch;
+    await expect(
+      runOpenAIOAuthTlsPreflight({ fetchImpl: tlsFetchImpl, timeoutMs: 20 }),
+    ).resolves.toEqual({
+      ok: false,
+      kind: "tls-cert",
+      code: "ERR_TLS_CERT_ALTNAME_INVALID",
+      message: "Hostname/IP does not match certificate's altnames",
+    });
   });
 
   it("keeps generic TLS transport failures in network classification", async () => {

--- a/src/gateway/openai-compat-errors.ts
+++ b/src/gateway/openai-compat-errors.ts
@@ -23,6 +23,7 @@ const ERROR_TYPE_BY_REASON: Partial<Record<FailoverReason, string>> = {
   rate_limit: "rate_limit_error",
   server_error: "api_error",
   session_expired: "invalid_request_error",
+  tls_certificate: "api_error",
   timeout: "api_error",
 };
 

--- a/src/plugin-sdk/provider-http.ts
+++ b/src/plugin-sdk/provider-http.ts
@@ -2,6 +2,11 @@
 // capability SDKs do not depend on each other.
 
 export {
+  inspectTlsCertificateError,
+  type TlsCertificateErrorDetails,
+  type TlsCertificateErrorKind,
+} from "@openclaw/ai/internal/shared";
+export {
   assertOkOrThrowHttpError,
   assertOkOrThrowProviderError,
   assertProviderBinaryResponseContent,

--- a/src/plugins/provider-openai-chatgpt-oauth-tls.ts
+++ b/src/plugins/provider-openai-chatgpt-oauth-tls.ts
@@ -1,26 +1,11 @@
 /** TLS helpers for ChatGPT OAuth provider discovery in plugin runtime code. */
 import path from "node:path";
+import { inspectTlsCertificateError } from "@openclaw/ai/internal/shared";
 import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
 import { asNullableObjectRecord } from "@openclaw/normalization-core/record-coerce";
 import { note } from "../../packages/terminal-core/src/note.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-
-const TLS_CERT_ERROR_CODES = new Set([
-  "UNABLE_TO_GET_ISSUER_CERT_LOCALLY",
-  "UNABLE_TO_VERIFY_LEAF_SIGNATURE",
-  "CERT_HAS_EXPIRED",
-  "DEPTH_ZERO_SELF_SIGNED_CERT",
-  "SELF_SIGNED_CERT_IN_CHAIN",
-  "ERR_TLS_CERT_ALTNAME_INVALID",
-]);
-
-const TLS_CERT_ERROR_PATTERNS = [
-  /unable to get local issuer certificate/i,
-  /unable to verify the first certificate/i,
-  /self[- ]signed certificate/i,
-  /certificate has expired/i,
-];
 
 const OPENAI_AUTH_PROBE_URL =
   "https://auth.openai.com/oauth/authorize?response_type=code&client_id=openclaw-preflight&redirect_uri=http%3A%2F%2Flocalhost%3A1455%2Fauth%2Fcallback&scope=openid+profile+email";
@@ -42,6 +27,14 @@ function extractFailure(error: unknown): {
   message: string;
   kind: PreflightFailureKind;
 } {
+  const tlsFailure = inspectTlsCertificateError(error);
+  if (tlsFailure) {
+    return {
+      code: tlsFailure.code,
+      message: tlsFailure.message,
+      kind: "tls-cert",
+    };
+  }
   const root = asNullableObjectRecord(error);
   const rootCause = asNullableObjectRecord(root?.cause);
   const code = typeof rootCause?.code === "string" ? rootCause.code : undefined;
@@ -51,13 +44,10 @@ function extractFailure(error: unknown): {
       : typeof root?.message === "string"
         ? root.message
         : String(error);
-  const isTlsCertError =
-    (code ? TLS_CERT_ERROR_CODES.has(code) : false) ||
-    TLS_CERT_ERROR_PATTERNS.some((pattern) => pattern.test(message));
   return {
     code,
     message,
-    kind: isTlsCertError ? "tls-cert" : "network",
+    kind: "network",
   };
 }
 


### PR DESCRIPTION
Closes #111817

## What Problem This Solves

Fixes an issue where users of the OpenAI ChatGPT Responses SSE transport would wait through the full retry budget when a request failed certificate validation. Certificate validity, trust-chain, policy, hostname, and signature failures cannot recover through backoff.

## Why This Change Was Made

The network retry classifier now recognizes the deterministic certificate and CRL verification codes documented by Node/OpenSSL, including direct errors, wrapped `cause` chains, and non-`Error` rejection objects. Classification happens before rejection normalization so `code` metadata is not lost. Transient network failures such as `ECONNRESET` continue to retry as before.

## User Impact

Users receive the actionable TLS failure immediately instead of after repeated doomed connections and exponential backoff. Normal transient-network resilience is unchanged.

## Evidence

### Real after-fix TLS behavior

Environment: Windows 11, Node `v22.22.3`, exact PR head `eb504e33e566eb1c2f7303eec3539d0cfe1e01f9`, system-default TLS verification.

I generated a local HTTPS certificate whose `notBefore` is one day in the future. The proof first used native Node `fetch` to record the actual verification code, waited for that socket to settle, reset all server counters, and then invoked the production `streamOpenAICodexResponses` SSE path with `maxRetries: 3`.

```text
NOT_BEFORE=2026-07-22T09:12:13+00:00
NOT_AFTER=2026-07-23T09:12:13+00:00
PR_HEAD=eb504e33e566eb1c2f7303eec3539d0cfe1e01f9
NODE_VERSION=v22.22.3
TLS_TRUST=system-default (certificate notBefore is one day in the future)
NATIVE_TLS_ERROR_CODE=CERT_NOT_YET_VALID
NATIVE_TLS_ERROR_MESSAGE=certificate is not yet valid
CONFIGURED_MAX_RETRIES=3
STOP_REASON=error
ERROR_MESSAGE=fetch failed
TCP_CONNECTIONS=1
TLS_CLIENT_ERRORS=1
HTTP_REQUESTS=0
ELAPSED_MS=8
TLS_CERTIFICATE_FAIL_FAST=PASS
```

The production invocation made exactly one TLS connection, never reached HTTP, and returned before the first 1-second retry backoff.

### Focused regression suite

```text
node node_modules/vitest/vitest.mjs run packages/ai/src/providers/openai-chatgpt-responses.retry.test.ts --config vitest.config.ts

Test Files  1 passed (1)
Tests       42 passed (42)
```

Coverage includes all 28 deterministic Node/OpenSSL certificate and CRL verification codes handled by the classifier, direct and wrapped errors, non-`Error` rejection objects, message-only fallback, and a transient `ECONNRESET` case that still retries.

Additional validation:

```text
node_modules/.bin/oxfmt.CMD --check packages/ai/src/providers/openai-chatgpt-responses.ts packages/ai/src/providers/openai-chatgpt-responses.retry.test.ts
All matched files use the correct format.

git diff --check
# clean

python .agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main
trufflehog: clean
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.96)
```

No public OpenAI endpoint or production credential was used: certificate verification fails before any HTTP request, and the local HTTPS endpoint provides the relevant real transport boundary.

<!-- pr-111818-current-head-proof -->

## Maintainer boundary decision

Approved: `inspectTlsCertificateError` remains available from `openclaw/plugin-sdk/provider-http` as the shared provider-facing certificate-classification contract. It is a pure detection helper; same-endpoint retry and cross-provider fallback policy remain internal to their owning runtime layers.

## Current-head Cloudflare runtime proof

Environment: Cloudflare Crabbox, Node `v24.15.0`, exact PR head `2a9e4dd5976baac5fde65837d5ef3dde3d3ea5e9`. No external endpoint or production credential was used. The local CA was trusted, while the server certificate SAN intentionally mismatched `127.0.0.1`.

The harness exercised the production OpenAI ChatGPT Responses retry loop and production model-fallback router with the native TLS failure:

```text
PR_HEAD=2a9e4dd5976baac5fde65837d5ef3dde3d3ea5e9
NODE_VERSION=v24.15.0
TLS_TRUST=local CA trusted; certificate SAN intentionally mismatches 127.0.0.1
NATIVE_TLS_ERROR_CODE=ERR_TLS_CERT_ALTNAME_INVALID
NATIVE_TLS_ERROR_KIND=hostname_mismatch
CONFIGURED_MAX_RETRIES=3
RETRY_STOP_REASON=error
RETRY_ERROR_MESSAGE=fetch failed
RETRY_TCP_CONNECTIONS=1
RETRY_HTTP_REQUESTS=0
RETRY_ELAPSED_MS=10
FALLBACK_CALLS=openai/gpt-5.5 -> anthropic/claude-opus-4-6
FALLBACK_REASON=tls_certificate
FALLBACK_RESULT=anthropic success
FALLBACK_SELECTED=anthropic/claude-opus-4-6
FALLBACK_TCP_CONNECTIONS=1
FALLBACK_HTTP_REQUESTS=0
SAME_ENDPOINT_TLS_RETRY=PASS
SAME_PROVIDER_MODEL_SKIP=PASS
CROSS_PROVIDER_FALLBACK=PASS
```

This demonstrates that a deterministic certificate failure does not retry the same endpoint, does not probe another model on the failed provider, and remains eligible for an explicitly configured fallback on a different provider.