### PR TITLE
fix(msteams): prevent toPluginJsonValue from crashing on unserializable values

### DIFF
--- a/extensions/msteams/src/sqlite-state.test.ts
+++ b/extensions/msteams/src/sqlite-state.test.ts
@@ -3,8 +3,48 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { setMSTeamsRuntime } from "./runtime.js";
-import { withMSTeamsSqliteMutationLock } from "./sqlite-state.js";
+import { toPluginJsonValue, withMSTeamsSqliteMutationLock } from "./sqlite-state.js";
 import { msteamsRuntimeStub } from "./test-support/runtime.js";
+
+describe("toPluginJsonValue", () => {
+  it("serializes nested BigInt values as strings", () => {
+    expect(toPluginJsonValue({ id: 9007199254740993n, nested: { seq: 42n } })).toEqual({
+      id: "9007199254740993",
+      nested: { seq: "42" },
+    });
+  });
+
+  it("replaces circular references in place while preserving serializable siblings", () => {
+    const record: Record<string, unknown> = {
+      id: "poll-1",
+      question: "ship it?",
+      options: ["yes", "no"],
+      updatedAtMs: 1750000000000,
+    };
+    record.self = record;
+
+    expect(toPluginJsonValue(record)).toEqual({
+      id: "poll-1",
+      question: "ship it?",
+      options: ["yes", "no"],
+      updatedAtMs: 1750000000000,
+      self: "[Circular]",
+    });
+  });
+
+  it("preserves repeated non-circular references", () => {
+    const shared = { tag: "shared" };
+    expect(toPluginJsonValue({ first: shared, second: shared })).toEqual({
+      first: { tag: "shared" },
+      second: { tag: "shared" },
+    });
+  });
+
+  it("round-trips plain JSON values unchanged", () => {
+    const value = { id: "c-1", unread: 3, pinned: true, last: null, tags: ["a", "b"] };
+    expect(toPluginJsonValue(value)).toEqual(value);
+  });
+});
 
 describe("MSTeams SQLite mutation lock", () => {
   let stateDir = "";

--- a/extensions/msteams/src/sqlite-state.ts
+++ b/extensions/msteams/src/sqlite-state.ts
@@ -43,7 +43,25 @@ export function resolveMSTeamsSqliteStateEnv(
 }
 
 export function toPluginJsonValue<T>(value: T): T {
-  const serialized = JSON.stringify(value);
+  // JSON-safe clone for the keyed plugin-state store: BigInts serialize as
+  // strings, and circular references are replaced in place so every
+  // serializable sibling field survives the round trip.
+  const ancestors: unknown[] = [];
+  const serialized = JSON.stringify(value, function (this: unknown, _key, val) {
+    if (typeof val === "bigint") {
+      return String(val);
+    }
+    if (val !== null && typeof val === "object") {
+      while (ancestors.length > 0 && ancestors[ancestors.length - 1] !== this) {
+        ancestors.pop();
+      }
+      if (ancestors.includes(val)) {
+        return "[Circular]";
+      }
+      ancestors.push(val);
+    }
+    return val;
+  });
   return JSON.parse(serialized) as T;
 }
 


### PR DESCRIPTION
## Summary

`fix(msteams): make plugin JSON state conversion cycle-safe and BigInt-safe so unserializable values no longer crash state writes or silently discard record fields`

## What Problem This Solves

`toPluginJsonValue` (`extensions/msteams/src/sqlite-state.ts`) clones plugin state records — poll records, conversation metadata, upload state — through a bare `JSON.stringify` + `JSON.parse` round trip immediately before they are written to the plugin-scoped SQLite keyed store. Two ordinary value shapes crash it:

- a nested **BigInt** (e.g. a large message or event id): `TypeError: Do not know how to serialize a BigInt`;
- a **circular reference** anywhere in the record: `TypeError: Converting circular structure to JSON`.

The `TypeError` propagates unhandled to the caller, so the state write never happens and the channel workflow (polls, uploads, conversations) loses the record entirely.

**代码证据**: in `extensions/msteams/src/sqlite-state.ts:45-48` (main), the helper is two unguarded lines — no replacer, no cycle handling, no fallback.

## Root Cause

- Bug introduced by commit `a2b2c4a76c79` (2026-05-30, `refactor(msteams): persist conversation and poll stores in sqlite`), which created the helper in the unguarded form. Verified via the GitHub API: the previous commit touching the file has no `toPluginJsonValue`.
- Violated invariant: the keyed plugin-state store accepts only plain JSON-compatible values, so every value the helper produces must be plain JSON — but the helper assumed its input already was. BigInts and cycles are both valid JavaScript that appears in real records.
- Trigger condition: persisting any record that carries a BigInt field or a back-reference (parent/self links are common in poll/upload metadata).

## Why This Fix

- Option A (chosen): a single replacer that (1) serializes BigInts as strings and (2) detects cycles with an ancestor stack and replaces them in place with `"[Circular]"`. The round trip always succeeds and always yields plain JSON; **every serializable sibling field survives**; repeated (non-circular) references still serialize normally.
- Option B (the previous head of this PR): replacer for BigInt plus a `catch` returning `{}`. Rejected per review: for a circular record it persisted an empty object, discarding valid siblings such as the poll id, question, options, and timestamps while bypassing the store's plain-JSON contract — silent state loss instead of a crash.
- Option C: throw on cycles/BigInts and make each caller pre-sanitize — rejected: spreads the policy across every call site; the helper exists precisely to be the single JSON-safety choke point before persistence.
- No `catch` remains: with both real-world crash causes handled structurally, the only remaining `stringify` failures are pathological throwing getters/toJSON, which should fail loudly rather than persist a misleading empty record.

## User Impact

- Affected operations: MSTeams poll, conversation, and upload state writes whose records contain BigInt fields or circular references.
- Before: the write crashes with an unhandled `TypeError`; the record is lost.
- After: the write succeeds; BigInts persist as strings, circular links persist as `"[Circular]"`, and all sibling fields (poll id, question, options, timestamps) are intact when the record is read back.
- Behavior change: records that previously crashed now persist in a plain-JSON form; records that were already JSON-safe round-trip byte-identically.

## Real Behavior Proof

Setup: the **real** `toPluginJsonValue` executed via `node --import tsx` against a BigInt record and a circular poll-shaped record. No mocks anywhere.

### Before (on main)

```bash
$ node --import tsx proof-msteams-json.mjs   # main version
[proof] bigint record: CRASH TypeError: Do not know how to serialize a BigInt
[proof] circular poll record: CRASH TypeError: Converting circular structure to JSON
    --> starting at object with constructor 'Object'
    --- property 'self' closes the circle
[proof] RESULT: FAIL - unserializable values crash the state write
exit=1
```

### After (with fix)

```bash
$ node --import tsx proof-msteams-json.mjs   # with fix
[proof] bigint record: returned {"messageId":"9007199254740993","text":"hello"}
[proof] circular poll record: returned {"id":"poll-1","question":"ship it?","options":["yes","no"],"updatedAtMs":1750000000000,"self":"[Circular]"}
[proof] RESULT: PASS - BigInt serialized as string; circular poll keeps all siblings ["id","options","question","self","updatedAtMs"] with self="[Circular]"
exit=0
```

## Tests and Validation

- `node node_modules/vitest/vitest.mjs run extensions/msteams/src/sqlite-state.test.ts` — 5 passed (4 new: BigInt-as-string, cycle replacement with sibling preservation, repeated non-circular references, plain round-trip)
- Red-green check: with the source change stashed, the BigInt and circular tests fail with the exact `TypeError`s shown above; with the fix, all pass.
- Manual verification is the proof above (same script on main vs fixed code).

_Note: this head replaces the earlier `{}`-fallback approach after review feedback (P1: preserve serializable siblings when a cycle is encountered)._
