### PR TITLE
test(ci): provide rg in PR wrapper fixture

### DIFF
--- a/test/scripts/pr-wrappers.test.ts
+++ b/test/scripts/pr-wrappers.test.ts
@@ -83,11 +83,12 @@ function makeMismatchedWrapperRepo() {
     git(canonical, ["rev-parse", "main"]).stdout.trim(),
   );
 
+  // Keep wrapper-selection coverage independent of ci-dispatch's POSIX lock path.
   writeFileSync(
-    join(linked, "scripts", "pr-lib", "gates.sh"),
-    'ci_dispatch() { echo "local wrapper executed"; }\n',
+    join(linked, "scripts", "pr-lib", "worktree.sh"),
+    `${readScript("scripts/pr-lib/worktree.sh")}\nlist_pr_worktrees() { echo "local wrapper executed"; }\n`,
   );
-  git(linked, ["add", "scripts/pr-lib/gates.sh"]);
+  git(linked, ["add", "scripts/pr-lib/worktree.sh"]);
   git(linked, ["commit", "-m", "test: local wrapper"]);
   const localRevision = git(linked, ["rev-parse", "HEAD"]).stdout.trim();
 
@@ -175,31 +176,27 @@ describe("scripts/pr wrappers", () => {
   it("runs a mismatched advisory wrapper locally with an explicit developer opt-in", () => {
     const fixture = makeMismatchedWrapperRepo();
     try {
-      const cliResult = spawnSync(
-        join(fixture.linked, "scripts", "pr"),
-        ["--dev-wrapper", "ci-dispatch", "123"],
-        {
-          cwd: fixture.linked,
-          encoding: "utf8",
-          env: fixture.env,
-        },
-      );
+      const cliResult = spawnSync(join(fixture.linked, "scripts", "pr"), ["--dev-wrapper", "ls"], {
+        cwd: fixture.linked,
+        encoding: "utf8",
+        env: fixture.env,
+      });
       expect(cliResult.status, cliResult.stderr).toBe(0);
       expect(cliResult.stdout).toContain("local wrapper executed");
       expect(cliResult.stderr).toContain(
         `WARNING: running local scripts/pr revision ${fixture.localRevision} via dev-wrapper opt-in.`,
       );
-      expect(cliResult.stderr).toContain("subcommand 'ci-dispatch' is classified advisory.");
+      expect(cliResult.stderr).toContain("subcommand 'ls' is classified advisory.");
       expect(cliResult.stderr).toContain("landing subcommands remain refused");
 
-      const envResult = spawnSync(join(fixture.linked, "scripts", "pr"), ["ci-dispatch", "123"], {
+      const envResult = spawnSync(join(fixture.linked, "scripts", "pr"), ["ls"], {
         cwd: fixture.linked,
         encoding: "utf8",
         env: { ...fixture.env, OPENCLAW_PR_DEV_WRAPPER: "1" },
       });
       expect(envResult.status, envResult.stderr).toBe(0);
       expect(envResult.stdout).toContain("local wrapper executed");
-      expect(envResult.stderr).toContain("subcommand 'ci-dispatch' is classified advisory.");
+      expect(envResult.stderr).toContain("subcommand 'ls' is classified advisory.");
     } finally {
       fixture.cleanup();
     }
@@ -208,7 +205,7 @@ describe("scripts/pr wrappers", () => {
   it("keeps the existing mismatch refusal for advisory commands without opt-in", () => {
     const fixture = makeMismatchedWrapperRepo();
     try {
-      const result = spawnSync(join(fixture.linked, "scripts", "pr"), ["ci-dispatch", "123"], {
+      const result = spawnSync(join(fixture.linked, "scripts", "pr"), ["ls"], {
         cwd: fixture.linked,
         encoding: "utf8",
         env: fixture.env,

--- a/test/scripts/pr-wrappers.test.ts
+++ b/test/scripts/pr-wrappers.test.ts
@@ -11,7 +11,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { delimiter, join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 function readScript(path: string): string {
@@ -28,17 +28,22 @@ const canonicalMismatchMessage = (repo: string) =>
 
 function makeMismatchedWrapperRepo() {
   const root = realpathSync(mkdtempSync(join(realpathSync(tmpdir()), "openclaw-pr-dev-wrapper-")));
+  const bin = join(root, "bin");
   const home = join(root, "home");
   const canonicalPath = join(root, "canonical");
   const linkedPath = join(root, "linked");
   const originPath = join(root, "origin.git");
+  mkdirSync(bin, { recursive: true });
   mkdirSync(home, { recursive: true });
+  writeFileSync(join(bin, "rg"), "#!/usr/bin/env sh\nexit 0\n");
+  chmodSync(join(bin, "rg"), 0o755);
 
   const fixtureEnv = {
     ...process.env,
     GIT_CONFIG_GLOBAL: "/dev/null",
     GIT_CONFIG_NOSYSTEM: "1",
     HOME: home,
+    PATH: `${bin}${delimiter}${process.env.PATH ?? ""}`,
     XDG_CONFIG_HOME: join(home, ".config"),
   };
   const git = (cwd: string, args: string[]) => {
@@ -83,12 +88,11 @@ function makeMismatchedWrapperRepo() {
     git(canonical, ["rev-parse", "main"]).stdout.trim(),
   );
 
-  // Keep wrapper-selection coverage independent of ci-dispatch's POSIX lock path.
   writeFileSync(
-    join(linked, "scripts", "pr-lib", "worktree.sh"),
-    `${readScript("scripts/pr-lib/worktree.sh")}\nlist_pr_worktrees() { echo "local wrapper executed"; }\n`,
+    join(linked, "scripts", "pr-lib", "gates.sh"),
+    'ci_dispatch() { echo "local wrapper executed"; }\n',
   );
-  git(linked, ["add", "scripts/pr-lib/worktree.sh"]);
+  git(linked, ["add", "scripts/pr-lib/gates.sh"]);
   git(linked, ["commit", "-m", "test: local wrapper"]);
   const localRevision = git(linked, ["rev-parse", "HEAD"]).stdout.trim();
 
@@ -176,27 +180,31 @@ describe("scripts/pr wrappers", () => {
   it("runs a mismatched advisory wrapper locally with an explicit developer opt-in", () => {
     const fixture = makeMismatchedWrapperRepo();
     try {
-      const cliResult = spawnSync(join(fixture.linked, "scripts", "pr"), ["--dev-wrapper", "ls"], {
-        cwd: fixture.linked,
-        encoding: "utf8",
-        env: fixture.env,
-      });
-      expect(cliResult.status, cliResult.stderr).toBe(0);
+      const cliResult = spawnSync(
+        join(fixture.linked, "scripts", "pr"),
+        ["--dev-wrapper", "ci-dispatch", "123"],
+        {
+          cwd: fixture.linked,
+          encoding: "utf8",
+          env: fixture.env,
+        },
+      );
+      expect(cliResult.status, `${cliResult.stderr}\n${cliResult.stdout}`).toBe(0);
       expect(cliResult.stdout).toContain("local wrapper executed");
       expect(cliResult.stderr).toContain(
         `WARNING: running local scripts/pr revision ${fixture.localRevision} via dev-wrapper opt-in.`,
       );
-      expect(cliResult.stderr).toContain("subcommand 'ls' is classified advisory.");
+      expect(cliResult.stderr).toContain("subcommand 'ci-dispatch' is classified advisory.");
       expect(cliResult.stderr).toContain("landing subcommands remain refused");
 
-      const envResult = spawnSync(join(fixture.linked, "scripts", "pr"), ["ls"], {
+      const envResult = spawnSync(join(fixture.linked, "scripts", "pr"), ["ci-dispatch", "123"], {
         cwd: fixture.linked,
         encoding: "utf8",
         env: { ...fixture.env, OPENCLAW_PR_DEV_WRAPPER: "1" },
       });
-      expect(envResult.status, envResult.stderr).toBe(0);
+      expect(envResult.status, `${envResult.stderr}\n${envResult.stdout}`).toBe(0);
       expect(envResult.stdout).toContain("local wrapper executed");
-      expect(envResult.stderr).toContain("subcommand 'ls' is classified advisory.");
+      expect(envResult.stderr).toContain("subcommand 'ci-dispatch' is classified advisory.");
     } finally {
       fixture.cleanup();
     }
@@ -205,7 +213,7 @@ describe("scripts/pr wrappers", () => {
   it("keeps the existing mismatch refusal for advisory commands without opt-in", () => {
     const fixture = makeMismatchedWrapperRepo();
     try {
-      const result = spawnSync(join(fixture.linked, "scripts", "pr"), ["ls"], {
+      const result = spawnSync(join(fixture.linked, "scripts", "pr"), ["ci-dispatch", "123"], {
         cwd: fixture.linked,
         encoding: "utf8",
         env: fixture.env,


### PR DESCRIPTION
Closes #111820

## What Problem This Solves

The mismatched advisory-wrapper test fails consistently on GitHub-hosted `ubuntu-24.04` runners used for external fork PRs, while it passes on the Blacksmith runners used by `main`.

## Root Cause

The fixture executes `scripts/pr`, whose prerequisite check requires `git`, `jq`, `rg`, `pnpm`, and `node`. The fixture inherits the host `PATH`, but GitHub's current Ubuntu 24.04 runner image does not install ripgrep. The wrapper therefore prints `Missing required command(s): rg` to stdout and exits before reaching the fixture's mocked `ci_dispatch`.

The prior assertion included only stderr in its failure message, which hid that prerequisite error and made the failure look related to the process-group path.

## Why This Change Was Made

This change adds an executable no-op `rg` shim to the temporary fixture and prepends the fixture's `bin` directory to `PATH`. The tested command never calls ripgrep; it only needs the prerequisite check to observe it.

The original `ci-dispatch` path remains covered. Both stdout and stderr are now included when a spawned wrapper unexpectedly fails, so future prerequisite failures identify themselves directly.

## User Impact

External contributors no longer receive this runner-image-specific CI failure. Production wrapper behavior is unchanged.

## Evidence

The wrapper assertion failed on four GitHub-hosted external-PR jobs:

- https://github.com/openclaw/openclaw/actions/runs/29737667998/job/88336906901
- https://github.com/openclaw/openclaw/actions/runs/29738476442/job/88339476511
- https://github.com/openclaw/openclaw/actions/runs/29741235294/job/88348327499
- https://github.com/openclaw/openclaw/actions/runs/29742176986/job/88351373790

The same test passed on Blacksmith `main` jobs:

- https://github.com/openclaw/openclaw/actions/runs/29738338465/job/88340583263
- https://github.com/openclaw/openclaw/actions/runs/29737189848/job/88335411116

GitHub's Ubuntu 24.04 image manifest lists the fixture's other prerequisites but not ripgrep:

- https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md

Hosted verification on the corrected head `c649a4f230`:

- Previously failing `checks-node-compact-small-1`: passed
  https://github.com/openclaw/openclaw/actions/runs/29743110813/job/88354433612
- Previously flaky `checks-node-compact-small-6`: passed
  https://github.com/openclaw/openclaw/actions/runs/29743110813/job/88354433697
- Required `openclaw/ci-gate`: passed
  https://github.com/openclaw/openclaw/actions/runs/29743110813/job/88355756860

Local validation:

- `.\\node_modules\\.bin\\oxfmt.CMD --check test/scripts/pr-wrappers.test.ts`
- `node scripts/run-oxlint.mjs --tsconfig test/tsconfig/tsconfig.test.root.json test/scripts/pr-wrappers.test.ts`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.root.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-root.tsbuildinfo`
- Platform-neutral wrapper assertions: 2 passed, 10 skipped by test-name selection
- `git diff --check`

The full POSIX wrapper test cannot run directly under Windows Node. This PR's GitHub-hosted Linux shard is the direct verification for the affected environment.