### PR TITLE
fix(agents): tools-disabled finalizer after blank post-tool stop

### DIFF
--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -25,10 +25,12 @@ import {
 import {
   buildAttemptReplayMetadata,
   DEFAULT_EMPTY_RESPONSE_RETRY_LIMIT,
+  DEFAULT_POST_TOOL_EMPTY_FINALIZER_LIMIT,
   DEFAULT_REASONING_ONLY_RETRY_LIMIT,
   resolveEmptyResponseRetryInstruction,
   isIncompleteTerminalAssistantTurn,
   resolveIncompleteTurnPayloadText as resolveIncompleteTurnPayloadTextCore,
+  resolvePostToolEmptyFinalizerInstruction,
   resolveReasoningOnlyRetryInstruction,
   resolveReplayInvalidFlag,
   resolveRunLivenessState,
@@ -46,6 +48,10 @@ const EMPTY_RESPONSE_RETRY_INSTRUCTION =
   "The previous attempt did not produce a user-visible answer. Continue from the current state and produce the visible answer now. Do not restart from scratch.";
 const TOOL_USE_TERMINAL_CONTINUATION_INSTRUCTION =
   "The previous assistant turn completed its tool calls but did not produce a user-visible answer. Continue from the current transcript and produce the final user-visible answer now. Do not repeat completed tool calls or restart from scratch.";
+const POST_TOOL_EMPTY_FINALIZER_INSTRUCTION =
+  "Do not call tools. Based only on the tool results already in the transcript, produce a short, truthful final reply for the user. Do not claim any unverified action as done, and do not restart the task.";
+const POST_TOOL_EMPTY_DEGRADED_MESSAGE =
+  "⚠️ Tool work completed, but no summary could be generated. Please check the produced artifacts before retrying.";
 
 let runEmbeddedAgent: typeof import("./run.js").runEmbeddedAgent;
 
@@ -87,6 +93,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     prompt?: string;
     suppressNextUserMessagePersistence?: boolean;
     skipPreparedUserTurnMessage?: boolean;
+    disableTools?: boolean;
   } {
     // Continuation prompt assertions read the exact prompt passed to the runner
     // attempt rather than derived result metadata.
@@ -98,6 +105,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       prompt?: string;
       suppressNextUserMessagePersistence?: boolean;
       skipPreparedUserTurnMessage?: boolean;
+      disableTools?: boolean;
     };
   }
 
@@ -663,7 +671,9 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     });
 
     expect(result.payloads?.[0]?.isError).toBe(true);
-    expect(result.payloads?.[0]?.text).toContain("couldn't generate a response");
+    expect(result.payloads?.[0]?.text).toContain(
+      "Tool work completed, but no summary could be generated",
+    );
     expect(result.meta.error?.fallbackSafe).toBe(false);
   });
 
@@ -712,7 +722,9 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     });
 
     expect(result.payloads?.[0]?.isError).toBe(true);
-    expect(result.payloads?.[0]?.text).toContain("couldn't generate a response");
+    expect(result.payloads?.[0]?.text).toContain(
+      "Tool work completed, but no summary could be generated",
+    );
     expect(result.meta.error?.fallbackSafe).toBe(false);
   });
 
@@ -1171,7 +1183,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
     expect(result.payloads?.[0]?.isError).toBe(true);
     expect(result.payloads?.[0]?.text).toContain(
-      "some tool actions may have already been executed",
+      "Tool work completed, but no summary could be generated",
     );
     expectWarnMessageWith("toolUseContinuations=1/1");
   });
@@ -2296,7 +2308,9 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       attempt: interruptedToolOnlyAttempt,
     });
 
-    expect(incompleteTurnText).toContain("couldn't generate a response");
+    // Blank visible text after side-effecting tools uses the artifact-oriented
+    // degraded card rather than the generic total-failure wording. (#111764)
+    expect(incompleteTurnText).toBe(POST_TOOL_EMPTY_DEGRADED_MESSAGE);
 
     const explicitCancellationText = resolveIncompleteTurnPayloadText({
       payloadCount: interruptedToolOnlyAttempt.assistantTexts.length,
@@ -2316,7 +2330,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       attempt: interruptedToolOnlyAttempt,
     });
 
-    expect(internalAbortText).toContain("couldn't generate a response");
+    expect(internalAbortText).toBe(POST_TOOL_EMPTY_DEGRADED_MESSAGE);
   });
 
   it("allows a same-prompt retry only for replay-safe missing assistant turns", () => {
@@ -3846,8 +3860,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       }),
     });
 
-    expect(incompleteTurnText).toContain("couldn't generate a response");
-    expect(incompleteTurnText).toContain("verify before retrying");
+    expect(incompleteTurnText).toBe(POST_TOOL_EMPTY_DEGRADED_MESSAGE);
   });
 
   it("retries generic empty Bedrock Converse turns without visible text", () => {
@@ -4334,6 +4347,209 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     });
 
     expect(retryInstruction).toBeNull();
+  });
+
+  it("offers a tools-disabled finalizer for blank stop after settled side-effecting tools (#111764)", () => {
+    const attempt = makeAttemptResult({
+      assistantTexts: [],
+      toolMetas: [{ toolName: "write", meta: "path=doc.md", replaySafe: false }],
+      itemLifecycle: { startedCount: 2, completedCount: 2, activeCount: 0 },
+      lastAssistant: {
+        role: "assistant",
+        stopReason: "stop",
+        provider: "deepseek",
+        model: "deepseek-v4-pro",
+        content: [{ type: "thinking", thinking: " " }],
+      } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      currentAttemptAssistant: {
+        role: "assistant",
+        stopReason: "stop",
+        provider: "deepseek",
+        model: "deepseek-v4-pro",
+        content: [{ type: "thinking", thinking: " " }],
+      } as unknown as EmbeddedRunAttemptResult["currentAttemptAssistant"],
+    });
+
+    expect(
+      resolveEmptyResponseRetryInstruction({
+        provider: "deepseek",
+        modelId: "deepseek-v4-pro",
+        modelApi: "openai-completions",
+        payloadCount: 0,
+        aborted: false,
+        timedOut: false,
+        attempt,
+      }),
+    ).toBeNull();
+
+    expect(
+      resolvePostToolEmptyFinalizerInstruction({
+        provider: "deepseek",
+        modelId: "deepseek-v4-pro",
+        modelApi: "openai-completions",
+        payloadCount: 0,
+        aborted: false,
+        timedOut: false,
+        attempt,
+      }),
+    ).toBe(POST_TOOL_EMPTY_FINALIZER_INSTRUCTION);
+
+    expect(
+      resolveIncompleteTurnPayloadText({
+        payloadCount: 0,
+        aborted: false,
+        timedOut: false,
+        attempt,
+      }),
+    ).toBe(POST_TOOL_EMPTY_DEGRADED_MESSAGE);
+  });
+
+  it("does not arm post-tool finalizer when the empty-response path can still retry", () => {
+    const attempt = makeAttemptResult({
+      assistantTexts: [],
+      toolMetas: [{ toolName: "read", meta: "path=a.txt", replaySafe: true }],
+      lastAssistant: {
+        role: "assistant",
+        stopReason: "stop",
+        provider: "openai",
+        model: "gpt-5.5",
+        content: [{ type: "text", text: "" }],
+      } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+    });
+
+    expect(
+      resolveEmptyResponseRetryInstruction({
+        provider: "openai",
+        modelId: "gpt-5.5",
+        modelApi: "openai-completions",
+        payloadCount: 0,
+        aborted: false,
+        timedOut: false,
+        attempt,
+      }),
+    ).toBe(EMPTY_RESPONSE_RETRY_INSTRUCTION);
+
+    expect(
+      resolvePostToolEmptyFinalizerInstruction({
+        provider: "openai",
+        modelId: "gpt-5.5",
+        modelApi: "openai-completions",
+        payloadCount: 0,
+        aborted: false,
+        timedOut: false,
+        attempt,
+      }),
+    ).toBeNull();
+  });
+
+  it("does not arm post-tool finalizer for toolUse terminals (owned by tool-use continuation)", () => {
+    expect(
+      resolvePostToolEmptyFinalizerInstruction({
+        provider: "openai",
+        modelId: "gpt-5.5",
+        modelApi: "openai-completions",
+        payloadCount: 0,
+        aborted: false,
+        timedOut: false,
+        attempt: makeAttemptResult({
+          assistantTexts: [],
+          toolMetas: [{ toolName: "write", meta: "path=note.txt", replaySafe: false }],
+          lastAssistant: {
+            role: "assistant",
+            stopReason: "toolUse",
+            provider: "openai",
+            model: "gpt-5.5",
+            content: [{ type: "toolCall", id: "tool_1", name: "write", arguments: {} }],
+          } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
+      }),
+    ).toBeNull();
+  });
+
+  it("runs one tools-disabled finalizer after blank stop with settled side-effect tools (#111764)", async () => {
+    expect(DEFAULT_POST_TOOL_EMPTY_FINALIZER_LIMIT).toBe(1);
+    mockedClassifyFailoverReason.mockReturnValue(null);
+    mockedRunEmbeddedAttempt.mockImplementationOnce(async (attemptParams) => {
+      markUserMessagePersisted(attemptParams);
+      return makeAttemptResult({
+        assistantTexts: [],
+        toolMetas: [{ toolName: "write", meta: "path=doc.md", replaySafe: false }],
+        itemLifecycle: { startedCount: 1, completedCount: 1, activeCount: 0 },
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "stop",
+          provider: "openai",
+          model: "gpt-5.5",
+          content: [{ type: "thinking", thinking: " " }],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        currentAttemptAssistant: {
+          role: "assistant",
+          stopReason: "stop",
+          provider: "openai",
+          model: "gpt-5.5",
+          content: [{ type: "thinking", thinking: " " }],
+        } as unknown as EmbeddedRunAttemptResult["currentAttemptAssistant"],
+      });
+    });
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({ assistantTexts: ["Doc updates finished successfully."] }),
+    );
+    mockedBuildEmbeddedRunPayloads
+      .mockReturnValueOnce([])
+      .mockReturnValueOnce([{ text: "Doc updates finished successfully." }]);
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "openai",
+      model: "gpt-5.5",
+      runId: "run-post-tool-empty-finalizer",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expect(result.payloads?.[0]?.text).toBe("Doc updates finished successfully.");
+    const secondCall = runAttemptCall(1);
+    expect(secondCall.prompt).toBe(POST_TOOL_EMPTY_FINALIZER_INSTRUCTION);
+    expect(secondCall.disableTools).toBe(true);
+    expectWarnMessageWith("post-tool empty final completion detected");
+    expectWarnMessageWith("with tools disabled");
+  });
+
+  it("surfaces artifact-oriented degraded text when post-tool finalizer stays blank (#111764)", async () => {
+    mockedClassifyFailoverReason.mockReturnValue(null);
+    mockedRunEmbeddedAttempt.mockResolvedValue(
+      makeAttemptResult({
+        assistantTexts: [],
+        toolMetas: [{ toolName: "write", meta: "path=doc.md", replaySafe: false }],
+        itemLifecycle: { startedCount: 1, completedCount: 1, activeCount: 0 },
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "stop",
+          provider: "openai",
+          model: "gpt-5.5",
+          content: [{ type: "thinking", thinking: " " }],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        currentAttemptAssistant: {
+          role: "assistant",
+          stopReason: "stop",
+          provider: "openai",
+          model: "gpt-5.5",
+          content: [{ type: "thinking", thinking: " " }],
+        } as unknown as EmbeddedRunAttemptResult["currentAttemptAssistant"],
+      }),
+    );
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "openai",
+      model: "gpt-5.5",
+      runId: "run-post-tool-empty-finalizer-exhausted",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expect(result.payloads?.[0]?.isError).toBe(true);
+    expect(result.payloads?.[0]?.text).toBe(POST_TOOL_EMPTY_DEGRADED_MESSAGE);
+    expect(runAttemptCall(1).disableTools).toBe(true);
+    expectWarnMessageWith("postToolFinalizers=1/1");
   });
 
   it("marks compaction-timeout retries as paused and replay-invalid", () => {

--- a/src/agents/embedded-agent-runner/run/attempt-dispatch-preparation.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-dispatch-preparation.ts
@@ -163,8 +163,18 @@ export async function prepareAndDispatchEmbeddedRunAttempt(input: {
     emitStartupStageSummary(EMBEDDED_RUN_ATTEMPT_DISPATCH_STAGE.dispatch);
     startupStagesEmitted = true;
   }
+  // Consume one-shot tools-disabled arm from the post-tool empty finalizer.
+  // Cleared here so only that next attempt is tool-free. (#111764)
+  const disableToolsForNextAttempt = terminalRetryState.disableToolsForNextAttempt === true;
+  if (disableToolsForNextAttempt) {
+    terminalRetryState.disableToolsForNextAttempt = false;
+  }
+  const attemptParams =
+    disableToolsForNextAttempt && params.disableTools !== true
+      ? { ...params, disableTools: true }
+      : params;
   const dispatchedAttempt = await dispatchEmbeddedRunAttempt({
-    params,
+    params: attemptParams,
     runtime: {
       sessionId: sessionPromptState.sessionId,
       sessionFile: sessionPromptState.sessionFile,

--- a/src/agents/embedded-agent-runner/run/incomplete-turn.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn.ts
@@ -133,12 +133,20 @@ const RETRY_GUARD_MODEL_APIS = new Set([
 // surfacing the existing incomplete-turn error path.
 export const DEFAULT_REASONING_ONLY_RETRY_LIMIT = 2;
 export const DEFAULT_EMPTY_RESPONSE_RETRY_LIMIT = 1;
+/** One tools-disabled summary after successful tool work ends with a blank visible completion. */
+export const DEFAULT_POST_TOOL_EMPTY_FINALIZER_LIMIT = 1;
 const REASONING_ONLY_RETRY_INSTRUCTION =
   "The previous assistant turn recorded reasoning but did not produce a user-visible answer. Continue from that partial turn and produce the visible answer now. Do not restate the reasoning or restart from scratch.";
 const EMPTY_RESPONSE_RETRY_INSTRUCTION =
   "The previous attempt did not produce a user-visible answer. Continue from the current state and produce the visible answer now. Do not restart from scratch.";
 const TOOL_USE_TERMINAL_CONTINUATION_INSTRUCTION =
   "The previous assistant turn completed its tool calls but did not produce a user-visible answer. Continue from the current transcript and produce the final user-visible answer now. Do not repeat completed tool calls or restart from scratch.";
+// Tools stay unavailable on this retry: the prior attempt already performed
+// mutating work, so replaying tool calls would risk duplicate side effects.
+const POST_TOOL_EMPTY_FINALIZER_INSTRUCTION =
+  "Do not call tools. Based only on the tool results already in the transcript, produce a short, truthful final reply for the user. Do not claim any unverified action as done, and do not restart the task.";
+const POST_TOOL_EMPTY_DEGRADED_MESSAGE =
+  "⚠️ Tool work completed, but no summary could be generated. Please check the produced artifacts before retrying.";
 
 /**
  * Marks whether retrying the attempt can safely replay the prompt. Concrete
@@ -294,6 +302,18 @@ export function resolveIncompleteTurnPayloadText(params: {
     stopReason !== "error"
   ) {
     return null;
+  }
+
+  // Settled successful tool work with a blank final completion is partial
+  // success, not a full agent failure. Prefer a truthful degraded summary over
+  // the generic "couldn't generate a response" card. Only apply when there is
+  // still no visible assistant text — partial toolUse narration keeps the
+  // generic incomplete-turn wording. (#111764)
+  if (
+    joinAssistantTexts(params.attempt.assistantTexts).length === 0 &&
+    hasSettledSuccessfulToolWorkForEmptyFinalizer(params.attempt)
+  ) {
+    return POST_TOOL_EMPTY_DEGRADED_MESSAGE;
   }
 
   return resolveAttemptReplayMetadata(params.attempt).hadPotentialSideEffects
@@ -855,6 +875,120 @@ export function resolveEmptyResponseRetryInstruction(params: {
   }
 
   return null;
+}
+
+/**
+ * After successful tool work, a normal stop with no user-visible text cannot
+ * use the replay-safe empty-response retry (side effects force a skip). This
+ * separate one-shot lane continues with tools disabled so the model can only
+ * summarize already-committed results. (#111764)
+ */
+export function resolvePostToolEmptyFinalizerInstruction(params: {
+  provider?: string;
+  modelId?: string;
+  modelApi?: string;
+  executionContract?: string;
+  payloadCount: number;
+  aborted: boolean;
+  timedOut: boolean;
+  attempt: IncompleteTurnAttempt;
+}): string | null {
+  if (
+    params.payloadCount !== 0 ||
+    params.aborted ||
+    params.timedOut ||
+    params.attempt.clientToolCalls ||
+    params.attempt.yieldDetected ||
+    params.attempt.didSendDeterministicApprovalPrompt ||
+    params.attempt.lastToolError
+  ) {
+    return null;
+  }
+
+  if (joinAssistantTexts(params.attempt.assistantTexts).length > 0) {
+    return null;
+  }
+
+  if (hasOnlySilentAssistantReply(params.attempt.assistantTexts)) {
+    return null;
+  }
+
+  if (hasCommittedMessagingToolDeliveryEvidence(params.attempt)) {
+    return null;
+  }
+
+  if (hasAcceptedSessionSpawn(params.attempt.acceptedSessionSpawns)) {
+    return null;
+  }
+
+  if (hasAsyncStartedToolActivity(params.attempt.toolMetas)) {
+    return null;
+  }
+
+  if (!hasSettledSuccessfulToolWorkForEmptyFinalizer(params.attempt)) {
+    return null;
+  }
+
+  const assistant = params.attempt.currentAttemptAssistant ?? params.attempt.lastAssistant;
+  const stopReason = assistant?.stopReason;
+  // toolUse has its own settled-tool continuation lane; this finalizer is for a
+  // post-tool stop/end_turn that still produced no visible answer.
+  if (stopReason === "toolUse" || stopReason === "error") {
+    return null;
+  }
+  if (
+    stopReason !== "stop" &&
+    stopReason !== "end_turn" &&
+    // Some providers omit stopReason while still emitting a blank final turn.
+    stopReason != null
+  ) {
+    return null;
+  }
+
+  const blankFinal =
+    isEmptyResponseAssistantTurn({
+      payloadCount: params.payloadCount,
+      attempt: params.attempt,
+    }) ||
+    isReasoningOnlyAssistantTurn(assistant) ||
+    isUnsignedThinkingOnlyAssistantTurn(assistant) ||
+    Boolean(assistant && hasOnlyAssistantReasoningContent(assistant));
+  if (!blankFinal) {
+    return null;
+  }
+
+  if (
+    !shouldApplyNonVisibleTurnRetryGuard({
+      provider: params.provider,
+      modelId: params.modelId,
+      modelApi: params.modelApi,
+      executionContract: params.executionContract,
+    }) &&
+    !isZeroUsageEmptyStopAssistantTurn(assistant ?? null)
+  ) {
+    return null;
+  }
+
+  return POST_TOOL_EMPTY_FINALIZER_INSTRUCTION;
+}
+
+/**
+ * Tool work finished with no active lifecycle items and no hard tool error.
+ * Used both for the tools-disabled finalizer and the degraded summary card.
+ */
+function hasSettledSuccessfulToolWorkForEmptyFinalizer(attempt: IncompleteTurnAttempt): boolean {
+  if ((attempt.toolMetas?.length ?? 0) === 0) {
+    return false;
+  }
+  if ((attempt.itemLifecycle?.activeCount ?? 0) > 0) {
+    return false;
+  }
+  if (attempt.lastToolError) {
+    return false;
+  }
+  // Prefer explicit side-effect evidence so replay-safe empty retries stay on
+  // the existing empty-response path when they can still fire.
+  return resolveAttemptReplayMetadata(attempt).hadPotentialSideEffects === true;
 }
 
 function shouldApplyNonVisibleTurnRetryGuard(params: {

--- a/src/agents/embedded-agent-runner/run/terminal-resolution.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-resolution.ts
@@ -19,10 +19,12 @@ import {
 } from "./auth-profile-success.js";
 import type { EmbeddedRunContextRecoveryState } from "./context-recovery-state.js";
 import {
+  DEFAULT_POST_TOOL_EMPTY_FINALIZER_LIMIT,
   hasAttemptTerminalState,
   resolveAttemptReplayMetadata,
   resolveEmptyResponseRetryInstruction,
   resolveIncompleteTurnPayloadText,
+  resolvePostToolEmptyFinalizerInstruction,
   resolveReasoningOnlyRetryInstruction,
   resolveRunLivenessState,
   resolveSilentToolResultReplyPayload,
@@ -39,6 +41,7 @@ import type { EmbeddedRunAttemptResult } from "./types.js";
 
 const MAX_MISSING_ASSISTANT_RETRIES = 1;
 const MAX_TOOL_USE_TERMINAL_CONTINUATIONS = 1;
+const MAX_POST_TOOL_EMPTY_FINALIZER_ATTEMPTS = DEFAULT_POST_TOOL_EMPTY_FINALIZER_LIMIT;
 const COMPACTION_CONTINUATION_RETRY_INSTRUCTION =
   "The previous attempt compacted the conversation context before producing a final user-visible answer. Continue from the compacted transcript and produce the final answer now. Do not restart from scratch, do not repeat completed work, and do not rerun tools unless the transcript clearly lacks required evidence.";
 const BEFORE_AGENT_FINALIZE_RETRY_PROMPT_PREFIX =
@@ -234,6 +237,35 @@ export async function resolveEmbeddedRunTerminal(input: {
     );
     return { action: "retry" };
   }
+  // Side-effecting empty stops cannot use the replay-safe empty-response retry.
+  // Run one tools-disabled finalizer so successful tool work can still get a
+  // short summary instead of the generic failure card. (#111764)
+  const nextPostToolEmptyFinalizerInstruction = emptyAssistantReplyIsSilent
+    ? null
+    : resolvePostToolEmptyFinalizerInstruction({
+        provider: input.activeErrorContext.provider,
+        modelId: input.activeErrorContext.model,
+        modelApi: input.modelApi,
+        executionContract: input.executionContract,
+        payloadCount,
+        aborted: input.terminalAborted,
+        timedOut: input.terminalTimedOut,
+        attempt,
+      });
+  if (
+    nextPostToolEmptyFinalizerInstruction &&
+    retryState.postToolEmptyFinalizerAttempts < MAX_POST_TOOL_EMPTY_FINALIZER_ATTEMPTS
+  ) {
+    retryState.postToolEmptyFinalizerAttempts += 1;
+    retryState.disableToolsForNextAttempt = true;
+    input.activateInternalPrompt(nextPostToolEmptyFinalizerInstruction, false);
+    log.warn(
+      `post-tool empty final completion detected: runId=${runParams.runId} sessionId=${runParams.sessionId} ` +
+        `provider=${input.activeErrorContext.provider}/${input.activeErrorContext.model} — finalizing ${retryState.postToolEmptyFinalizerAttempts}/${MAX_POST_TOOL_EMPTY_FINALIZER_ATTEMPTS} ` +
+        `with tools disabled`,
+    );
+    return { action: "retry" };
+  }
   const incompleteTurnText = emptyAssistantReplyIsSilent
     ? null
     : resolveIncompleteTurnPayloadText({
@@ -315,7 +347,8 @@ export async function resolveEmbeddedRunTerminal(input: {
         `compactions=${input.attemptCompactionCount} reasoningRetries=${retryState.reasoningOnlyAttempts}/${input.maxReasoningOnlyRetryAttempts} ` +
         `emptyRetries=${retryState.emptyResponseAttempts}/${input.maxEmptyResponseRetryAttempts} ` +
         `missingAssistantRetries=${retryState.missingAssistantAttempts}/${MAX_MISSING_ASSISTANT_RETRIES} ` +
-        `toolUseContinuations=${retryState.toolUseContinuationAttempts}/${MAX_TOOL_USE_TERMINAL_CONTINUATIONS} — ` +
+        `toolUseContinuations=${retryState.toolUseContinuationAttempts}/${MAX_TOOL_USE_TERMINAL_CONTINUATIONS} ` +
+        `postToolFinalizers=${retryState.postToolEmptyFinalizerAttempts}/${MAX_POST_TOOL_EMPTY_FINALIZER_ATTEMPTS} — ` +
         (terminalToolPresentation
           ? "surfacing tool-authored terminal presentation"
           : "surfacing error to user"),

--- a/src/agents/embedded-agent-runner/run/terminal-retry-state.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-retry-state.ts
@@ -5,6 +5,13 @@ export type EmbeddedRunTerminalRetryState = {
   emptyResponseAttempts: number;
   missingAssistantAttempts: number;
   toolUseContinuationAttempts: number;
+  postToolEmptyFinalizerAttempts: number;
+  /**
+   * When true, the next prepared attempt must run with tools disabled. Armed by
+   * the post-tool empty finalizer so a summary retry cannot re-fire side effects.
+   * Cleared once consumed by attempt dispatch.
+   */
+  disableToolsForNextAttempt: boolean;
   compactionContinuationAttempts: number;
   compactionContinuationInstruction: string | null;
   beforeFinalizeRevisionAttempts: number;
@@ -16,6 +23,8 @@ export function createEmbeddedRunTerminalRetryState(): EmbeddedRunTerminalRetryS
     emptyResponseAttempts: 0,
     missingAssistantAttempts: 0,
     toolUseContinuationAttempts: 0,
+    postToolEmptyFinalizerAttempts: 0,
+    disableToolsForNextAttempt: false,
     compactionContinuationAttempts: 0,
     compactionContinuationInstruction: null,
     beforeFinalizeRevisionAttempts: 0,


### PR DESCRIPTION
Closes #111764

## What Problem This Solves

Fixes an issue where users running long multi-tool turns would see a generic "Agent couldn't generate a response" failure card when the provider returned only a whitespace-only thinking block (or otherwise blank visible text) after successful tool work. The work itself had already completed, so the generic failure card made successful runs look like total failures and prompted unnecessary full retries.

## Why This Change Was Made

Current main already has a one-shot empty-response retry, but it deliberately skips after potential tool side effects so mutating tools are not replayed. That skip is correct for replay safety, yet it left successful post-tool blank stops with only the generic failure card.

This change adds a separate, one-shot **tools-disabled finalizer** lane for that case: normal stop/end_turn, blank visible output, settled successful side-effecting tool work, and no current-request messaging delivery. The finalizer continues once with tools unavailable so the model can only summarize already-committed results. If that summary is still blank, the user gets a truthful degraded message ("tool work completed, but no summary could be generated") instead of the generic total-failure card.

Quality notes:
- **Compatibility:** no config/API/env changes; additive runner recovery only.
- **Performance:** at most one extra tools-disabled attempt after the failing blank completion.
- **Usability:** partial-success wording instead of false total failure after successful tools.
- **Security:** tools stay disabled on the finalizer so side effects cannot be re-fired.

## User Impact

After successful multi-tool work, a blank final completion no longer looks like a full agent crash. OpenClaw attempts one tools-disabled summary; if that also fails, the channel shows that tool work completed and artifacts should be checked rather than implying nothing happened.

## Evidence

Verification host: local macOS (Crabbox bypass)

Focused tests:

```text
node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
# 144 passed
```

Including new/updated cases for #111764:
- tools-disabled finalizer instruction after blank stop with settled side-effect tools
- finalizer not armed when the existing empty-response path can still retry
- finalizer not armed for toolUse terminals (owned by tool-use continuation)
- one tools-disabled finalizer run produces a visible summary
- exhausted finalizer surfaces artifact-oriented degraded text
- related incomplete-turn assertions updated for the degraded wording

Also: `oxfmt --check` on touched files; `git diff --check`.

## Real behavior proof

- Behavior addressed: blank/whitespace-only final completion after successful tool work no longer surfaces only as a generic non-deliverable failure; one tools-disabled finalizer runs, then a truthful degraded card if needed
- Environment: local macOS, openclaw checkout at `fix/111764-post-tool-empty-finalizer`, focused Vitest harness for embedded-agent-runner incomplete-turn recovery
- Current-main contrast: on main, `resolveEmptyResponseRetryInstruction` returns null after `hadPotentialSideEffects`, so `emptyRetries=0/1` and the user sees "Agent couldn't generate a response... tool actions may have already been executed" for blank stop after write/side-effect tools
- Exact steps or command run after this patch:
  1. `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run.incomplete-turn.test.ts -t "post-tool|tools-disabled finalizer|blank stop after settled|toolUse terminals"`
  2. Full file: `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run.incomplete-turn.test.ts`
- Evidence after fix: new integration case `runs one tools-disabled finalizer after blank stop with settled side-effect tools` asserts second attempt prompt is the no-tools finalizer instruction, `disableTools === true`, and visible summary payload is returned; exhausted case asserts `Tool work completed, but no summary could be generated`
- Control check: existing empty-response retry still fires when tools are replay-safe; toolUse terminals still use tool-use continuation and do not arm the post-tool finalizer; generic no-side-effect incomplete turns keep the prior wording
- Observed result after fix: blank post-tool stop → one tools-disabled finalizer → summary or degraded artifact-oriented card; no generic total-failure-only path for this settled-tool case
- What was not tested: live DeepSeek/Feishu multi-minute doc turn (intermittent provider empty completion); ClawSweeper accepted source-repro / focused Vitest as the landable proof path

---

This PR was authored with AI assistance (Grok).
