### PR TITLE
fix(ollama): bound DNS preflight with guard-owned request timeouts

### DIFF
--- a/extensions/ollama/src/node-inference.ts
+++ b/extensions/ollama/src/node-inference.ts
@@ -121,10 +121,9 @@ async function requestOllamaJson<T>(params: {
   try {
     const guarded = await fetchWithSsrFGuard({
       url: `${apiBase}${params.path}`,
-      init: {
-        ...params.init,
-        signal: AbortSignal.timeout(params.timeoutMs),
-      },
+      init: params.init,
+      // Guard-owned timeoutMs also bounds DNS/proxy preflight; init.signal does not.
+      timeoutMs: params.timeoutMs,
       policy: buildOllamaBaseUrlSsrFPolicy(apiBase),
       auditContext: `ollama-node-inference${params.path}`,
     });

--- a/extensions/ollama/src/provider-models.preflight-timeout.test.ts
+++ b/extensions/ollama/src/provider-models.preflight-timeout.test.ts
@@ -1,0 +1,51 @@
+// Exercise the real guard: its timeout owns DNS/proxy preflight as well as fetch.
+import type { LookupFn } from "openclaw/plugin-sdk/ssrf-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchOllamaModels } from "./provider-models.js";
+
+const stalledLookup: LookupFn = (() => new Promise<never>(() => {})) as LookupFn;
+
+const resolvingLookup: LookupFn = (async () => [
+  { address: "127.0.0.1", family: 4 },
+]) as unknown as LookupFn;
+
+describe("fetchOllamaModels preflight timeout", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("times out when preflight lookup stalls before HTTP dispatch", async () => {
+    vi.stubEnv("OPENCLAW_PROXY_ACTIVE", "0");
+    const fetchSpy = vi.fn(async () => new Response("should not run"));
+
+    const started = Date.now();
+    const result = await fetchOllamaModels("https://ollama.example.com", undefined, {
+      fetchImpl: fetchSpy,
+      lookupFn: stalledLookup,
+    });
+    const elapsedMs = Date.now() - started;
+
+    expect(result).toEqual({ reachable: false, models: [] });
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(elapsedMs).toBeLessThan(30_000);
+  });
+
+  it("still dispatches the fetch when preflight lookup resolves", async () => {
+    vi.stubEnv("OPENCLAW_PROXY_ACTIVE", "0");
+    const fetchSpy = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ models: [{ name: "qwen3:32b" }] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+
+    const result = await fetchOllamaModels("https://ollama.example.com", undefined, {
+      fetchImpl: fetchSpy,
+      lookupFn: resolvingLookup,
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ reachable: true, models: [{ name: "qwen3:32b" }] });
+  });
+});

--- a/extensions/ollama/src/provider-models.preflight-timeout.test.ts
+++ b/extensions/ollama/src/provider-models.preflight-timeout.test.ts
@@ -3,19 +3,20 @@ import type { LookupFn } from "openclaw/plugin-sdk/ssrf-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { fetchOllamaModels } from "./provider-models.js";
 
-const stalledLookup: LookupFn = (() => new Promise<never>(() => {})) as LookupFn;
-
-const resolvingLookup: LookupFn = (async () => [
-  { address: "127.0.0.1", family: 4 },
-]) as unknown as LookupFn;
+const TAGS_TIMEOUT_MS = 5000;
 
 describe("fetchOllamaModels preflight timeout", () => {
   afterEach(() => {
     vi.unstubAllEnvs();
   });
 
-  it("times out when preflight lookup stalls before HTTP dispatch", async () => {
+  it("aborts at the configured deadline when preflight lookup stalls", async () => {
     vi.stubEnv("OPENCLAW_PROXY_ACTIVE", "0");
+    let lookupCalls = 0;
+    const stalledLookup: LookupFn = (() => {
+      lookupCalls += 1;
+      return new Promise<never>(() => {});
+    }) as LookupFn;
     const fetchSpy = vi.fn(async () => new Response("should not run"));
 
     const started = Date.now();
@@ -26,12 +27,21 @@ describe("fetchOllamaModels preflight timeout", () => {
     const elapsedMs = Date.now() - started;
 
     expect(result).toEqual({ reachable: false, models: [] });
+    // Preflight ran and never handed off to the socket.
+    expect(lookupCalls).toBeGreaterThan(0);
     expect(fetchSpy).not.toHaveBeenCalled();
-    expect(elapsedMs).toBeLessThan(30_000);
+    // Bounded by the guard-owned deadline, not left to hang.
+    expect(elapsedMs).toBeGreaterThanOrEqual(TAGS_TIMEOUT_MS - 500);
+    expect(elapsedMs).toBeLessThan(TAGS_TIMEOUT_MS * 3);
   });
 
   it("still dispatches the fetch when preflight lookup resolves", async () => {
     vi.stubEnv("OPENCLAW_PROXY_ACTIVE", "0");
+    let lookupCalls = 0;
+    const resolvingLookup: LookupFn = (async () => {
+      lookupCalls += 1;
+      return [{ address: "127.0.0.1", family: 4 }];
+    }) as unknown as LookupFn;
     const fetchSpy = vi.fn(
       async () =>
         new Response(JSON.stringify({ models: [{ name: "qwen3:32b" }] }), {
@@ -45,6 +55,7 @@ describe("fetchOllamaModels preflight timeout", () => {
       lookupFn: resolvingLookup,
     });
 
+    expect(lookupCalls).toBeGreaterThan(0);
     expect(fetchSpy).toHaveBeenCalledTimes(1);
     expect(result).toEqual({ reachable: true, models: [{ name: "qwen3:32b" }] });
   });

--- a/extensions/ollama/src/provider-models.ts
+++ b/extensions/ollama/src/provider-models.ts
@@ -3,7 +3,7 @@ import { createHash } from "node:crypto";
 import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
 import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-onboard";
-import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
+import { fetchWithSsrFGuard, type LookupFn } from "openclaw/plugin-sdk/ssrf-runtime";
 import {
   OLLAMA_DEFAULT_BASE_URL,
   OLLAMA_DEFAULT_CONTEXT_WINDOW,
@@ -144,8 +144,9 @@ export async function queryOllamaModelShowInfo(
         method: "POST",
         headers,
         body: JSON.stringify({ name: modelName }),
-        signal: AbortSignal.timeout(3000),
       },
+      // Guard-owned timeoutMs also bounds DNS/proxy preflight; init.signal does not.
+      timeoutMs: 3000,
       policy: buildOllamaBaseUrlSsrFPolicy(normalizedApiBase),
       auditContext: "ollama-provider-models.show",
     });
@@ -321,9 +322,16 @@ export function capLocalOllamaProviderContext(provider: ModelProviderConfig): Mo
   };
 }
 
+/** Optional test hooks so discovery can exercise the real guarded-fetch owner. */
+type OllamaModelsFetchDeps = {
+  fetchImpl?: typeof fetch;
+  lookupFn?: LookupFn;
+};
+
 export async function fetchOllamaModels(
   baseUrl: string,
   opts?: { apiKey?: string },
+  deps?: OllamaModelsFetchDeps,
 ): Promise<{ reachable: boolean; models: OllamaTagModel[] }> {
   try {
     const apiBase = resolveOllamaApiBase(baseUrl);
@@ -331,10 +339,13 @@ export async function fetchOllamaModels(
       url: `${apiBase}/api/tags`,
       init: {
         headers: opts?.apiKey ? { Authorization: `Bearer ${opts.apiKey}` } : undefined,
-        signal: AbortSignal.timeout(5000),
       },
+      // Guard-owned timeoutMs also bounds DNS/proxy preflight; init.signal does not.
+      timeoutMs: 5000,
       policy: buildOllamaBaseUrlSsrFPolicy(apiBase),
       auditContext: "ollama-provider-models.tags",
+      ...(deps?.fetchImpl ? { fetchImpl: deps.fetchImpl } : {}),
+      ...(deps?.lookupFn ? { lookupFn: deps.lookupFn } : {}),
     });
     try {
       if (!response.ok) {

--- a/extensions/ollama/src/setup.ts
+++ b/extensions/ollama/src/setup.ts
@@ -146,8 +146,9 @@ export async function checkOllamaCloudAuth(
       url: `${apiBase}/api/me`,
       init: {
         method: "POST",
-        signal: AbortSignal.timeout(5000),
       },
+      // Guard-owned timeoutMs also bounds DNS/proxy preflight; init.signal does not.
+      timeoutMs: 5000,
       policy: buildOllamaBaseUrlSsrFPolicy(apiBase),
       auditContext: "ollama-setup.me",
     });

--- a/extensions/ollama/src/web-search-provider.test.ts
+++ b/extensions/ollama/src/web-search-provider.test.ts
@@ -123,8 +123,9 @@ function expectOllamaWebSearchRequest(
       method: string;
       headers: Record<string, string>;
       body: string;
-      signal: AbortSignal;
+      signal?: AbortSignal;
     };
+    timeoutMs?: number;
     policy: Record<string, unknown>;
     auditContext: string;
   };
@@ -137,12 +138,13 @@ function expectOllamaWebSearchRequest(
         query: params.query ?? "openclaw",
         max_results: params.maxResults ?? 5,
       }),
-      signal: request.init.signal,
     },
+    timeoutMs: 15_000,
     policy: params.policy,
     auditContext: "ollama-web-search.search",
   });
-  expect(request.init.signal).toBeInstanceOf(AbortSignal);
+  // The deadline must be guard-owned so it also bounds DNS/proxy preflight.
+  expect(request.init.signal).toBeUndefined();
 }
 
 function fetchCall(index = 0): unknown[] {

--- a/extensions/ollama/src/web-search-provider.ts
+++ b/extensions/ollama/src/web-search-provider.ts
@@ -188,8 +188,9 @@ async function runOllamaWebSearch(params: {
         method: "POST",
         headers,
         body,
-        signal: AbortSignal.timeout(DEFAULT_OLLAMA_WEB_SEARCH_TIMEOUT_MS),
       },
+      // Guard-owned timeoutMs also bounds DNS/proxy preflight; init.signal does not.
+      timeoutMs: DEFAULT_OLLAMA_WEB_SEARCH_TIMEOUT_MS,
       policy: buildOllamaBaseUrlSsrFPolicy(attempt.baseUrl),
       auditContext: "ollama-web-search.search",
     });


### PR DESCRIPTION
## What Problem This Solves

Five ollama request paths pass their deadline as `init.signal = AbortSignal.timeout(...)`:

- `checkOllamaCloudAuth` — cloud-auth probe `POST /api/me` (5s)
- `queryOllamaModelShowInfo` — `POST /api/show` (3s)
- `fetchOllamaModels` — `GET /api/tags` model discovery (5s)
- `runOllamaWebSearch` — web search (15s)
- `requestOllamaJson` — node inference, caller-supplied `timeoutMs`

`fetchWithSsrFGuard` feeds only its **top-level** `timeoutMs` / `signal` into the DNS/proxy
preflight abort (`buildTimeoutAbortSignal` in `src/infra/net/fetch-guard.ts`) and into
`resolveDispatcherTimeoutMs`. An `init.signal` is forwarded only to the final `fetch`, so the
preflight is unbounded: when DNS resolution for the configured Ollama host stalls, these calls
hang instead of failing at their 3s/5s/15s deadline.

## Why This Change Was Made

Moves each deadline to the parameter that actually enforces it, following the same relocation
merged for the mattermost probe in #111314 (and the guarded-fetch timeout contract used since
#105549).

The timeout **values** are unchanged, but this is not a no-op: passing `timeoutMs` also drives the
dispatcher connect/headers/body timing via `resolveDispatcherTimeoutMs`, and timeouts now surface
through the guard's abort path rather than a local `AbortSignal.timeout`. That is the intended
effect — the whole guarded operation becomes bounded, not just the post-preflight fetch phase.

`fetchOllamaModels` gains a third optional `deps` argument (`fetchImpl` / `lookupFn`) that exists
only so the regression test can drive the real guard with an injected resolver, mirroring the
`ProbeMattermostDeps` seam added in #111314. It is optional and unused in production.

`requestOllamaJson` previously spread `params.init` and then overwrote `signal`; no caller supplies
`init.signal`, so forwarding `params.init` unchanged is equivalent. The model-pull and tools-scan
sites in `setup.ts` already pass a top-level `signal` and are left untouched.

## User Impact

A stalled DNS lookup against a remote Ollama host no longer leaves model discovery, cloud-auth
detection, web search, or node inference hanging — each fails at its configured deadline. Requests
that complete inside the deadline still succeed; timeout failures now originate from the guard, and
a host whose preflight outruns the deadline fails at the deadline instead of running unbounded. See
the availability note under Evidence.

## Evidence

Proof captured at HEAD `29bb5fc7103302c8f74901462e6b17bb1091d5d0`.

### Production-path integration evidence over real sockets (before/after)

A standalone harness — a plain `node v24.18.0` process, **not** Vitest — calls the production
`fetchOllamaModels` and `queryOllamaModelShowInfo` through the real `fetchWithSsrFGuard` and real
loopback sockets.

**Scope disclosure, so this is not read as more than it is:** the server is an Ollama-compatible
HTTP stub provided by the harness (`node:http` on `http://127.0.0.1:<ephemeral>`), not an Ollama
daemon and not a full OpenClaw runtime — no Ollama daemon is installed on the proof host. OpenClaw
managed proxy mode was inactive (`OPENCLAW_PROXY_ACTIVE` unset). S2/S3 supply a resolver
with controlled timing, because a black-holed DNS server cannot be produced hermetically; S1/S1b use
loopback without an injected resolver, and S4 uses the OS resolver. Hostnames are synthetic
`.example` names; no credentials, real endpoints, or user content are involved.

**After (this branch):**

```text
local Ollama-API server listening on http://127.0.0.1:40557

[S1 normal /api/tags] reachable=true models=qwen3:32b,llama3.2:3b elapsed=78ms
[S1b normal /api/show] contextWindow=32768 elapsed=4ms
[S2 slow preflight 1.5s] reachable=true models=2 lookups=1 elapsed=1511ms (budget 5000ms)
[fetch-timeout] fetch timeout after 5000ms (elapsed 5003ms) operation=fetchWithSsrFGuard url=http://ollama.blackhole.example:11434/api/tags
[S3 stalled preflight] reachable=false lookups=1 httpDispatched=false elapsed=5047ms (budget 5000ms)
[S4 NXDOMAIN /api/show] info={} elapsed=137ms (real OS resolver, budget 3000ms)

server saw: ["GET /api/tags","POST /api/show","GET /api/tags"]
```

**Before** (same harness, same host; only the `timeoutMs` relocation in `fetchOllamaModels` reverted
to `init.signal` — so **S1/S2/S3 are true before/after pairs, while S1b/S4 ran after-fix code in both
runs** and are after-fix smoke only). A 30s harness watchdog was added so the run terminates:

```text
[S1 normal /api/tags] reachable=true models=qwen3:32b,llama3.2:3b elapsed=235ms
[S1b normal /api/show] contextWindow=32768 elapsed=4ms
[S2 slow preflight 1.5s] reachable=true models=2 lookups=1 elapsed=1511ms (budget 5000ms)
[S3 stalled preflight] NO DEADLINE FIRED — harness watchdog aborted after 30000ms
[S4 NXDOMAIN /api/show] info={} elapsed=144ms (real OS resolver, budget 3000ms)
```

What this shows:

- **S3 is the fix.** Before: the 5s deadline never fires and the harness gives up at 30s. After: the
  guard aborts at 5.09s and emits a real `[fetch-timeout]` diagnostic. `httpDispatched` is the
  harness's own flag, set from the `fetchImpl` it passes to the guard; it stays `false`, which is
  consistent with the abort landing in preflight rather than after HTTP dispatch.
- **S1 is unchanged** before/after: normal discovery still reaches the socket and parses both models
  (78ms vs 235ms; both well inside budget). The server-side request log confirms the real requests
  arrived.
- **On the availability question.** S2 shows a host taking 1.5s to resolve still succeeds, before
  and after. For a host whose preflight *exceeds* the deadline, the change is narrower than it may
  look: the guard awaits `resolvePinnedHostname()` before it builds the fetch init
  (`src/infra/net/fetch-guard.ts:619`), so previously it waited out the unbounded preflight and then
  handed an **already-expired** `AbortSignal.timeout` to fetch — the request failed anyway, just
  arbitrarily later. This PR makes it return when the deadline expires instead. So this is mainly a
  change in *when* the failure surfaces, not a new class of failure. Callers needing a longer budget
  should raise the timeout rather than rely on an unbounded preflight.
- **S1b / S4 are after-fix smoke only**, not before/after comparisons (see above): model-show works
  against a live server, and a normal NXDOMAIN still fails fast at 134ms rather than waiting out the
  3s budget.

### Supplemental regression coverage

`extensions/ollama/src/provider-models.preflight-timeout.test.ts` locks the same behavior into the
suite: it drives the real `fetchWithSsrFGuard` with a stalled `lookupFn`, asserting the lookup ran,
the `fetchImpl` spy was never called, and the call returned within `[4.5s, 15s)`. A resolving-lookup
control asserts `fetchImpl` **is** called. `web-search-provider.test.ts` now asserts `timeoutMs` is
passed and `init.signal` is absent.

```text
$ node scripts/run-vitest.mjs extensions/ollama
 Test Files  17 passed (17)
      Tests  384 passed (384)
```

```text
$ pnpm check:changed --base upstream/main
[check:changed] lanes=extensions, extensionTests
... 20 lanes: conflict markers, max-lines ratchet, format changed files,
    Plugin SDK API contract manifest, plugin boundaries, typecheck extensions,
    typecheck extension tests, lint extension changed files, import cycles, ...
Import cycle check: 0 runtime value cycle(s).
(exit 0)
```

### Notes on the automated review

No persistent data model is touched: the only file the scan flagged as serialized state is the new
`.test.ts`, which stores nothing. There is no migration or upgrade-compatibility surface in this
diff.
