### PR TITLE
fix(exa): search results can show corrupted text from malformed UTF-8

### DIFF
--- a/extensions/exa/src/exa-web-search-provider.runtime.ts
+++ b/extensions/exa/src/exa-web-search-provider.runtime.ts
@@ -1,6 +1,9 @@
 // Exa provider module implements model/runtime integration.
 import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
-import { readResponseTextLimited } from "openclaw/plugin-sdk/provider-http";
+import {
+  readProviderJsonResponse,
+  readResponseTextLimited,
+} from "openclaw/plugin-sdk/provider-http";
 import {
   buildSearchCacheKey,
   DEFAULT_SEARCH_COUNT,
@@ -20,7 +23,6 @@ import {
   wrapWebContent,
   writeCachedSearchPayload,
 } from "openclaw/plugin-sdk/provider-web-search";
-import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
@@ -31,10 +33,6 @@ const EXA_SEARCH_TYPES = ["auto", "neural", "fast", "deep", "deep-reasoning", "i
 const EXA_FRESHNESS_VALUES = ["day", "week", "month", "year"] as const;
 const EXA_MAX_SEARCH_COUNT = 100;
 const EXA_ERROR_BODY_LIMIT_BYTES = 8 * 1024;
-// Exa search responses are untrusted external bodies. Cap the success JSON the
-// same way other bundled providers do (16 MiB) so a misbehaving or hostile
-// endpoint cannot stream an unbounded body into memory before we parse it.
-const EXA_SEARCH_JSON_MAX_BYTES = 16 * 1024 * 1024;
 
 type ExaConfig = {
   apiKey?: string;
@@ -79,16 +77,7 @@ async function readExaSearchResults(
   response: Response,
   opts?: { maxBytes?: number },
 ): Promise<ExaSearchResult[]> {
-  const maxBytes = opts?.maxBytes ?? EXA_SEARCH_JSON_MAX_BYTES;
-  const bytes = await readResponseWithLimit(response, maxBytes, {
-    onOverflow: ({ maxBytes: maxBytesLocal }) =>
-      new Error(`Exa API response exceeds ${maxBytesLocal} bytes`),
-  });
-  try {
-    return normalizeExaResults(JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(bytes)));
-  } catch (cause) {
-    throw new Error("Exa API returned malformed JSON", { cause });
-  }
+  return normalizeExaResults(await readProviderJsonResponse(response, "Exa API", opts));
 }
 
 async function readExaErrorDetail(response: Response): Promise<string> {

--- a/extensions/exa/src/exa-web-search-provider.runtime.ts
+++ b/extensions/exa/src/exa-web-search-provider.runtime.ts
@@ -85,7 +85,7 @@ async function readExaSearchResults(
       new Error(`Exa API response exceeds ${maxBytesLocal} bytes`),
   });
   try {
-    return normalizeExaResults(JSON.parse(new TextDecoder().decode(bytes)));
+    return normalizeExaResults(JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(bytes)));
   } catch (cause) {
     throw new Error("Exa API returned malformed JSON", { cause });
   }

--- a/extensions/exa/src/exa-web-search-provider.test.ts
+++ b/extensions/exa/src/exa-web-search-provider.test.ts
@@ -318,6 +318,17 @@ describe("exa web search provider", () => {
     );
   });
 
+  it("rejects malformed UTF-8 in Exa search results", async () => {
+    const bytes = new TextEncoder().encode(
+      JSON.stringify({ results: [{ url: "https://example.com", title: "bad X title" }] }),
+    );
+    bytes[bytes.indexOf("X".charCodeAt(0))] = 0xff;
+
+    await expect(testing.readExaSearchResults(new Response(bytes))).rejects.toThrow(
+      "Exa API returned malformed JSON",
+    );
+  });
+
   it("parses well-formed Exa search JSON under the byte cap", async () => {
     const response = new Response(
       JSON.stringify({ results: [{ url: "https://example.com", title: "Example" }] }),

--- a/extensions/exa/src/exa-web-search-provider.test.ts
+++ b/extensions/exa/src/exa-web-search-provider.test.ts
@@ -314,7 +314,7 @@ describe("exa web search provider", () => {
 
   it("reports malformed Exa API JSON with a stable provider error", async () => {
     await expect(testing.readExaSearchResults(new Response("{ nope"))).rejects.toThrow(
-      "Exa API returned malformed JSON",
+      "Exa API: malformed JSON response",
     );
   });
 
@@ -325,7 +325,7 @@ describe("exa web search provider", () => {
     bytes[bytes.indexOf("X".charCodeAt(0))] = 0xff;
 
     await expect(testing.readExaSearchResults(new Response(bytes))).rejects.toThrow(
-      "Exa API returned malformed JSON",
+      "Exa API: malformed JSON response",
     );
   });
 
@@ -345,7 +345,7 @@ describe("exa web search provider", () => {
 
     await expect(
       testing.readExaSearchResults(streamed.response, { maxBytes: 4096 }),
-    ).rejects.toThrow(/Exa API response exceeds 4096 bytes/);
+    ).rejects.toThrow(/Exa API: JSON response exceeds 4096 bytes/);
 
     expect(streamed.getReadCount()).toBeLessThan(64);
   });

--- a/extensions/exa/src/exa-web-search-provider.test.ts
+++ b/extensions/exa/src/exa-web-search-provider.test.ts
@@ -4,6 +4,18 @@ import { testing } from "../test-api.js";
 import { createExaWebSearchProvider as createContractExaWebSearchProvider } from "../web-search-contract-api.js";
 import { createExaWebSearchProvider } from "./exa-web-search-provider.js";
 
+const EXA_TEST_CONFIG = {
+  plugins: {
+    entries: {
+      exa: {
+        config: {
+          webSearch: { apiKey: "exa-test-key" },
+        },
+      },
+    },
+  },
+};
+
 function cancelTrackedResponse(
   text: string,
   init: ResponseInit,
@@ -229,9 +241,7 @@ describe("exa web search provider", () => {
   it("exposes newer documented Exa search types and count limits", () => {
     const provider = createExaWebSearchProvider();
     const tool = provider.createTool({
-      config: {
-        plugins: { entries: { exa: { config: { webSearch: { apiKey: "exa-secret" } } } } },
-      },
+      config: EXA_TEST_CONFIG,
       searchConfig: {},
     });
     if (!tool) {
@@ -265,9 +275,7 @@ describe("exa web search provider", () => {
   it("returns validation errors for conflicting time filters", async () => {
     const provider = createExaWebSearchProvider();
     const tool = provider.createTool({
-      config: {
-        plugins: { entries: { exa: { config: { webSearch: { apiKey: "exa-secret" } } } } },
-      },
+      config: EXA_TEST_CONFIG,
       searchConfig: {},
     });
     if (!tool) {
@@ -291,9 +299,7 @@ describe("exa web search provider", () => {
   it("returns validation errors for invalid date input", async () => {
     const provider = createExaWebSearchProvider();
     const tool = provider.createTool({
-      config: {
-        plugins: { entries: { exa: { config: { webSearch: { apiKey: "exa-secret" } } } } },
-      },
+      config: EXA_TEST_CONFIG,
       searchConfig: {},
     });
     if (!tool) {


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

<!--
Describe the concrete user, product, or operational problem.
For fixes, begin with:
"Fixes an issue where users <do X> would <experience Y> when <condition>."
or:
"Resolves a problem where..."

Name the affected UI surface or workflow. Do not describe the code-level cause here.
-->

Fixes an issue where Exa web search users could receive silently corrupted titles,
highlights, summaries, or extracted text when an upstream success response contained
malformed UTF-8. The previous decoder substituted invalid bytes, so altered content
could be presented to the model as genuine search output.

## Why This Change Was Made

<!--
In one or two sentences, explain the complete shipped solution, key design
decisions, and relevant boundaries or non-goals. Include implementation detail
only when it helps reviewers understand user-visible behavior or risk.
Avoid file-by-file narration.
-->

Exa success responses now use the canonical provider JSON reader, which owns the
bounded body read, fatal UTF-8 decoding, and JSON parsing contract. The current-main
port preserves Exa's plugin-owned API-key configuration and keeps error-body handling
separate from successful JSON decoding.

## User Impact

<!--
State what users, operators, or developers can now do or expect. Lead with the
concrete benefit and use user-facing language. If there is no user-visible
impact, say so plainly.
-->

Valid Exa results continue to work normally. Malformed upstream bytes now fail with a
stable `Exa API: malformed JSON response` error instead of surfacing replacement
characters as trustworthy search content.

## Evidence

<!--
Show the most useful proof that this change works. Screenshots, screencasts,
terminal output, focused tests, CI results, live observations, redacted logs,
and artifact links are all useful. Include before/after evidence for visual
changes when it clarifies the result.

Reviewers will inspect the code, tests, and CI. Use this section to make the
validation easy to understand, not to restate the diff.
-->

Near-real production-path E2E:

```text
control: production Exa tool returned provider=exa, count=1, title=Valid control title
malformed: production Exa tool rejected invalid UTF-8 with 'Exa API: malformed JSON response'
transport: guarded POST request reached a session-owned HTTP server; only remote routing was injected
```

This exercised production Exa tool creation and lazy runtime loading, request
construction, guarded fetch, the shared bounded JSON reader, fatal UTF-8 decoding,
and result normalization. Only the remote transport was redirected to a session-owned
HTTP server because the external Exa service cannot be instructed to emit malformed
bytes.

Regression validation:

```text
node scripts/run-vitest.mjs extensions/exa/src/exa-web-search-provider.test.ts src/agents/provider-http-errors.test.ts
2 Vitest shards passed; 36 tests passed.
```

Formatting validation:

```text
oxfmt --check extensions/exa/src/exa-web-search-provider.runtime.ts extensions/exa/src/exa-web-search-provider.test.ts
All matched files use the correct format.
```
