### PR TITLE
fix(doctor): check every configured agent for workspace suggestions

### DIFF
--- a/src/flows/doctor-core-checks.ts
+++ b/src/flows/doctor-core-checks.ts
@@ -43,6 +43,7 @@ import { resolveSkillWorkshopConfig } from "../skills/workshop/config.js";
 import { detectSkillWorkshopToolPolicyDiagnostic } from "../skills/workshop/tool-policy-diagnostic.js";
 import { hasActiveGatewayExecCredential } from "./doctor-gateway-exec-credential.js";
 import { removedWorkspacesStateCheck } from "./doctor-removed-workspaces-state-check.js";
+import { resolveDoctorWorkspaceSuggestionScopes } from "./doctor-workspace-suggestion-scopes.js";
 import type { SplitHealthCheckInput } from "./health-check-runner-types.js";
 import type {
   HealthCheck,
@@ -639,6 +640,7 @@ function noteTextToFinding(params: {
   checkId: string;
   severity: HealthFinding["severity"];
   text: string;
+  target?: string;
 }): HealthFinding {
   const lines = params.text.split("\n");
   const first = normalizeDoctorNoteLine(lines[0] ?? params.text);
@@ -647,6 +649,7 @@ function noteTextToFinding(params: {
     checkId: params.checkId,
     severity: params.severity,
     message: first,
+    ...(params.target ? { target: params.target } : {}),
     ...(rest ? { fixHint: rest } : {}),
   };
 }
@@ -1240,15 +1243,22 @@ function createWorkspaceSuggestionsCheck(
     defaultEnabled: false,
     source: "doctor",
     async detect(ctx) {
-      const workspaceDir = resolveAgentWorkspaceDir(ctx.cfg, resolveDefaultAgentId(ctx.cfg));
-      const notes = await deps.collectWorkspaceSuggestionNotes(workspaceDir);
-      return notes.map((text) =>
-        noteTextToFinding({
-          checkId: "core/doctor/workspace-suggestions",
-          severity: "info",
-          text,
+      const scopes = resolveDoctorWorkspaceSuggestionScopes(ctx.cfg);
+      const findings = await Promise.all(
+        scopes.map(async ({ agentId, workspaceDir, labelAgent }) => {
+          const prefix = labelAgent ? `Agent "${agentId}": ` : "";
+          const notes = await deps.collectWorkspaceSuggestionNotes(workspaceDir);
+          return notes.map((text) =>
+            noteTextToFinding({
+              checkId: "core/doctor/workspace-suggestions",
+              severity: "info",
+              text: `${prefix}${text}`,
+              ...(labelAgent ? { target: agentId } : {}),
+            }),
+          );
         }),
       );
+      return findings.flat();
     },
   };
 }

--- a/src/flows/doctor-health-contribution-runners.workspace.ts
+++ b/src/flows/doctor-health-contribution-runners.workspace.ts
@@ -1,6 +1,7 @@
 import type { DoctorOptions } from "../commands/doctor-prompter.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { DoctorHealthFlowContext } from "./doctor-health-contribution-types.js";
+import { resolveDoctorWorkspaceSuggestionScopes } from "./doctor-workspace-suggestion-scopes.js";
 import type { HealthCheckContext, HealthFinding } from "./health-checks.js";
 
 type PluginVersionDriftReport =
@@ -230,15 +231,20 @@ export async function runWorkspaceSuggestionsHealth(ctx: DoctorHealthFlowContext
   if (ctx.options.workspaceSuggestions === false) {
     return;
   }
-  const { resolveAgentWorkspaceDir, resolveDefaultAgentId } =
-    await import("../agents/agent-scope.js");
-  const { noteWorkspaceBackupTip } = await loadDoctorStateIntegrityModule();
+  const { collectWorkspaceBackupTip } = await loadDoctorStateIntegrityModule();
   const { MEMORY_SYSTEM_PROMPT, shouldSuggestMemorySystem } =
     await import("../commands/doctor-workspace.js");
   const { note } = await import("../../packages/terminal-core/src/note.js");
-  const workspaceDir = resolveAgentWorkspaceDir(ctx.cfg, resolveDefaultAgentId(ctx.cfg));
-  noteWorkspaceBackupTip(workspaceDir);
-  if (await shouldSuggestMemorySystem(workspaceDir)) {
-    note(MEMORY_SYSTEM_PROMPT, "Workspace");
+  for (const { agentId, workspaceDir, labelAgent } of resolveDoctorWorkspaceSuggestionScopes(
+    ctx.cfg,
+  )) {
+    const prefix = labelAgent ? `Agent "${agentId}": ` : "";
+    const backupTip = collectWorkspaceBackupTip(workspaceDir);
+    if (backupTip) {
+      note(`${prefix}${backupTip}`, "Workspace");
+    }
+    if (await shouldSuggestMemorySystem(workspaceDir)) {
+      note(`${prefix}${MEMORY_SYSTEM_PROMPT}`, "Workspace");
+    }
   }
 }

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -92,8 +92,11 @@ const mocks = vi.hoisted(() => ({
   maybeRepairLegacyPluginManifestContracts: vi.fn().mockResolvedValue(undefined),
   detectLegacyClawdBrowserProfileResidue: vi.fn(),
   maybeArchiveLegacyClawdBrowserProfileResidue: vi.fn(),
-  resolveAgentWorkspaceDir: vi.fn(() => "/tmp/openclaw-workspace"),
-  resolveDefaultAgentId: vi.fn(() => "default"),
+  listAgentIds: vi.fn<(_cfg: OpenClawConfig) => string[]>(() => ["default"]),
+  resolveAgentWorkspaceDir: vi.fn<(_cfg: OpenClawConfig, agentId: string) => string>(
+    () => "/tmp/openclaw-workspace",
+  ),
+  resolveDefaultAgentId: vi.fn<(_cfg: OpenClawConfig) => string>(() => "default"),
   resolveAgentContextLimits: vi.fn(
     (cfg: { agents?: { defaults?: { contextLimits?: unknown } } }) =>
       cfg.agents?.defaults?.contextLimits ?? {},
@@ -117,8 +120,8 @@ const mocks = vi.hoisted(() => ({
   gatherDaemonStatus: vi.fn(),
   noteWorkspaceStatus: vi.fn(),
   collectWorkspaceStatusHealthFindings: vi.fn().mockResolvedValue([]),
-  collectWorkspaceBackupTip: vi.fn((): string | undefined => undefined),
-  shouldSuggestMemorySystem: vi.fn(async () => false),
+  collectWorkspaceBackupTip: vi.fn<(workspaceDir: string) => string | undefined>(() => undefined),
+  shouldSuggestMemorySystem: vi.fn<(workspaceDir: string) => Promise<boolean>>(async () => false),
   collectDiskSpaceHealthFindings: vi.fn((): readonly HealthFinding[] => []),
   collectHeartbeatCadenceMigrationFindings: vi.fn(async () => [] as unknown[]),
   maybeMigrateHeartbeatCadenceToCron: vi.fn().mockResolvedValue({ changes: [], warnings: [] }),
@@ -362,6 +365,7 @@ vi.mock("../commands/doctor-browser.js", () => ({
 }));
 
 vi.mock("../agents/agent-scope.js", () => ({
+  listAgentIds: mocks.listAgentIds,
   resolveAgentWorkspaceDir: mocks.resolveAgentWorkspaceDir,
   resolveDefaultAgentId: mocks.resolveDefaultAgentId,
   resolveAgentContextLimits: mocks.resolveAgentContextLimits,
@@ -673,6 +677,8 @@ describe("doctor health contributions", () => {
     });
     mocks.resolveAgentWorkspaceDir.mockReset();
     mocks.resolveAgentWorkspaceDir.mockReturnValue("/tmp/openclaw-workspace");
+    mocks.listAgentIds.mockReset();
+    mocks.listAgentIds.mockReturnValue(["default"]);
     mocks.resolveDefaultAgentId.mockReset();
     mocks.resolveDefaultAgentId.mockReturnValue("default");
     mocks.resolveAgentContextLimits.mockReset();
@@ -2266,6 +2272,69 @@ describe("doctor health contributions", () => {
       ],
     });
     expect(mocks.collectWorkspaceBackupTip).toHaveBeenCalledWith("/tmp/openclaw-workspace");
+  });
+
+  it("labels normal workspace suggestions for secondary agents", async () => {
+    const contribution = requireDoctorContribution("doctor:workspace-suggestions");
+    const cfg = {} as OpenClawConfig;
+    const ctx = {
+      cfg,
+      cfgForPersistence: cfg,
+      configResult: { cfg },
+      configPath: "/tmp/fake-openclaw.json",
+      sourceConfigValid: true,
+      prompter: buildDoctorPrompter(false),
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+      options: {},
+      env: {},
+    } as DoctorContributionRunContext;
+    mocks.listAgentIds.mockReturnValue(["default", "secondary"]);
+    mocks.resolveAgentWorkspaceDir.mockImplementation((_cfg, agentId) => `/tmp/${agentId}`);
+    mocks.collectWorkspaceBackupTip.mockImplementation((workspaceDir) =>
+      workspaceDir === "/tmp/secondary" ? "- Back up this workspace." : undefined,
+    );
+    mocks.shouldSuggestMemorySystem.mockImplementation(
+      async (workspaceDir) => workspaceDir === "/tmp/secondary",
+    );
+
+    await contribution.run(ctx);
+
+    expect(mocks.note).toHaveBeenCalledWith(
+      'Agent "secondary": - Back up this workspace.',
+      "Workspace",
+    );
+    expect(mocks.note).toHaveBeenCalledWith(
+      'Agent "secondary": Enable memory system for better recall.',
+      "Workspace",
+    );
+    expect(mocks.note).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps single-agent workspace suggestion wording unchanged", async () => {
+    const contribution = requireDoctorContribution("doctor:workspace-suggestions");
+    const cfg = {} as OpenClawConfig;
+    const ctx = {
+      cfg,
+      cfgForPersistence: cfg,
+      configResult: { cfg },
+      configPath: "/tmp/fake-openclaw.json",
+      sourceConfigValid: true,
+      prompter: buildDoctorPrompter(false),
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+      options: {},
+      env: {},
+    } as DoctorContributionRunContext;
+    mocks.collectWorkspaceBackupTip.mockReturnValue("- Back up this workspace.");
+    mocks.shouldSuggestMemorySystem.mockResolvedValue(true);
+
+    await contribution.run(ctx);
+
+    expect(mocks.note).toHaveBeenNthCalledWith(1, "- Back up this workspace.", "Workspace");
+    expect(mocks.note).toHaveBeenNthCalledWith(
+      2,
+      "Enable memory system for better recall.",
+      "Workspace",
+    );
   });
 
   it("keeps disk space opt-in for default lint selection", async () => {

--- a/src/flows/doctor-workspace-suggestion-scopes.ts
+++ b/src/flows/doctor-workspace-suggestion-scopes.ts
@@ -1,0 +1,26 @@
+import {
+  listAgentIds,
+  resolveAgentWorkspaceDir,
+  resolveDefaultAgentId,
+} from "../agents/agent-scope.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+
+type DoctorWorkspaceSuggestionScope = {
+  agentId: string;
+  workspaceDir: string;
+  labelAgent: boolean;
+};
+
+/** Resolves every configured agent workspace while preserving invalid empty-roster failures. */
+export function resolveDoctorWorkspaceSuggestionScopes(
+  cfg: OpenClawConfig,
+): DoctorWorkspaceSuggestionScope[] {
+  const listedAgentIds = listAgentIds(cfg);
+  const agentIds = listedAgentIds.length > 0 ? listedAgentIds : [resolveDefaultAgentId(cfg)];
+  const labelAgent = agentIds.length > 1;
+  return agentIds.map((agentId) => ({
+    agentId,
+    workspaceDir: resolveAgentWorkspaceDir(cfg, agentId),
+    labelAgent,
+  }));
+}

--- a/src/flows/doctor-workspace-suggestions.test.ts
+++ b/src/flows/doctor-workspace-suggestions.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+import type { SkillStatusEntry } from "../skills/discovery/status.js";
+import { createCoreHealthChecks, type CoreHealthCheckDeps } from "./doctor-core-checks.js";
+import type { HealthCheck } from "./health-checks.js";
+
+const runtime = { log() {}, error() {}, exit() {} };
+
+function createDeps(
+  collectWorkspaceSuggestionNotes: CoreHealthCheckDeps["collectWorkspaceSuggestionNotes"],
+): CoreHealthCheckDeps {
+  return {
+    async detectUnavailableSkills(): Promise<readonly SkillStatusEntry[]> {
+      return [];
+    },
+    async collectSecurityWarnings() {
+      return [];
+    },
+    collectWorkspaceSuggestionNotes,
+    async collectRuntimeToolSchemaFindings() {
+      return [];
+    },
+    async collectProviderCatalogProjectionFindings() {
+      return [];
+    },
+    async collectLocalAudioAccelerationFindings() {
+      return [];
+    },
+    async collectGatewayHealthFindings() {
+      return [];
+    },
+    async collectGatewayDaemonFindings() {
+      return [];
+    },
+    async listGatewayCronJobs() {
+      return [];
+    },
+  };
+}
+
+function createWorkspaceSuggestionsCheck(
+  collectWorkspaceSuggestionNotes: CoreHealthCheckDeps["collectWorkspaceSuggestionNotes"],
+): HealthCheck {
+  const check = createCoreHealthChecks(createDeps(collectWorkspaceSuggestionNotes)).find(
+    (candidate) => candidate.id === "core/doctor/workspace-suggestions",
+  );
+  if (!check || !("detect" in check)) {
+    throw new Error("workspace suggestions check not found");
+  }
+  return check;
+}
+
+describe("core/doctor/workspace-suggestions", () => {
+  it("labels secondary-agent findings with structured targets", async () => {
+    const check = createWorkspaceSuggestionsCheck(async (workspaceDir) =>
+      workspaceDir === "/tmp/secondary"
+        ? ["- Back up this workspace.", "Memory system not found in workspace."]
+        : [],
+    );
+
+    const findings = await check.detect({
+      mode: "lint",
+      runtime,
+      cfg: {
+        agents: {
+          entries: {
+            main: { default: true, workspace: "/tmp/main" },
+            secondary: { workspace: "/tmp/secondary" },
+          },
+        },
+      },
+    });
+
+    expect(findings).toEqual([
+      expect.objectContaining({
+        message: 'Agent "secondary": - Back up this workspace.',
+        target: "secondary",
+      }),
+      expect.objectContaining({
+        message: 'Agent "secondary": Memory system not found in workspace.',
+        target: "secondary",
+      }),
+    ]);
+  });
+
+  it("keeps shared workspace suggestions agent-scoped", async () => {
+    const check = createWorkspaceSuggestionsCheck(async () => [
+      "Memory system not found in workspace.",
+    ]);
+
+    const findings = await check.detect({
+      mode: "lint",
+      runtime,
+      cfg: {
+        agents: {
+          entries: {
+            main: { default: true, workspace: "/tmp/shared" },
+            secondary: { workspace: "/tmp/shared" },
+          },
+        },
+      },
+    });
+
+    expect(findings).toEqual([
+      expect.objectContaining({
+        message: 'Agent "main": Memory system not found in workspace.',
+        target: "main",
+      }),
+      expect.objectContaining({
+        message: 'Agent "secondary": Memory system not found in workspace.',
+        target: "secondary",
+      }),
+    ]);
+  });
+
+  it("preserves the explicit empty-roster failure", async () => {
+    const check = createWorkspaceSuggestionsCheck(async () => []);
+
+    await expect(
+      check.detect({
+        mode: "lint",
+        runtime,
+        cfg: { agents: { entries: {} } },
+      }),
+    ).rejects.toThrow("No agents configured");
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `openclaw doctor` inspected only the default agent's workspace for backup and memory-system suggestions. In a multi-agent setup, a secondary workspace could be missing both and still produce no visible outcome.

This completes the per-agent Doctor audit started by https://github.com/openclaw/openclaw/pull/111758 for the remaining workspace-suggestions paths.

## Why This Change Was Made

The normal Doctor runner and the structured `core/doctor/workspace-suggestions` check now share one agent-workspace scope resolver. Each configured agent is checked, multi-agent results carry the agent id, and single-agent wording remains unchanged.

The rewrite targets the current owner at `src/flows/doctor-health-contribution-runners.workspace.ts`, preserves the existing explicit-empty-roster failure, and keeps shared workspaces agent-scoped.

## User Impact

Operators now see missing backup or memory guidance for every configured agent workspace. A healthy default workspace no longer hides a broken secondary workspace.

Single-agent installations receive the same messages as before.

## Evidence

### Real CLI before/after

Blacksmith Testbox `tbx_01kz3szh8fc1w20bkgzhsqqrpy` rebuilt and ran the public CLI separately on frozen main `8895b0c28858caf9c45f4924bc27db281f672522` and repaired head `5b46ffbdc2c1503655a5bfa5a9ae6f44a3063534`.

Run: https://github.com/openclaw/openclaw/actions/runs/30814249336

Fixture: healthy default workspace with `MEMORY.md`; secondary workspace without memory guidance.

```json
{
  "frozenBase": "8895b0c28858caf9c45f4924bc27db281f672522",
  "baseMultiFindings": [],
  "headMultiFindings": [
    {
      "checkId": "core/doctor/workspace-suggestions",
      "severity": "info",
      "message": "Agent \"secondary\": Memory system not found in workspace.",
      "target": "secondary"
    }
  ],
  "singleAgentWordingParity": true,
  "normalDoctorSecondaryLabelObserved": true
}
```

The same run also verified ordinary `openclaw doctor --non-interactive` output contains the labeled secondary-agent suggestion only after the repair.

### Automated validation

- `node scripts/run-vitest.mjs src/flows/doctor-workspace-suggestions.test.ts src/flows/doctor-health-contributions.test.ts src/flows/doctor-core-checks.test.ts`: 133 tests passed.
- Full changed-surface gate passed on Blacksmith Testbox `tbx_01kz3s9h6mc7yxcfwhc4696xtv`: typecheck core, typecheck core tests, targeted lint, formatting, dead-export scans, API/boundary guards, database-first guard, runtime sidecar guard, and import-cycle checks.
- Changed gate run: https://github.com/openclaw/openclaw/actions/runs/30813421481
- `git diff --check`: clean.
- Autoreview at P1: no accepted or actionable findings; patch correctness confidence 0.91.
