### PR TITLE
fix(agents): allow configless gateway rebind to activate standalone owner

### DIFF
--- a/src/agents/prepared-model-runtime.lifecycle.test.ts
+++ b/src/agents/prepared-model-runtime.lifecycle.test.ts
@@ -315,6 +315,7 @@ describe("prepared model runtime snapshots", () => {
     const config = {};
     await refreshPreparedModelRuntimeSnapshots(config, { gatewayLifecycle: true });
     const input = {
+      agentId: "openclaw",
       config,
       agentDir: "/tmp/unused-agent",
       inheritedAuthDir: "/tmp/unused-agent",
@@ -330,6 +331,7 @@ describe("prepared model runtime snapshots", () => {
     const config = {};
     await refreshPreparedModelRuntimeSnapshots(config, { gatewayLifecycle: true });
     const input = {
+      agentId: "openclaw",
       config,
       agentDir: "/tmp/unused-agent",
       inheritedAuthDir: "/tmp/unused-agent",
@@ -338,6 +340,22 @@ describe("prepared model runtime snapshots", () => {
     const lease = await acquireAgentRunPreparedModelRuntime(input);
     expect(lease.snapshot.agentDir).toBe("/tmp/unused-agent");
     lease.release();
+  });
+
+  it("rejects an ordinary unconfigured agent on an active gateway", async () => {
+    mocks.configuredAgentIds = ["default"];
+    const config = {};
+    await refreshPreparedModelRuntimeSnapshots(config, { gatewayLifecycle: true });
+
+    await expect(
+      acquireAgentRunPreparedModelRuntime({
+        agentId: "missing",
+        config,
+        agentDir: "/tmp/configured-missing",
+        inheritedAuthDir: "/tmp/unused-agent",
+        workspaceDir: "/tmp/workspace-missing",
+      }),
+    ).rejects.toThrow("prepared model runtime owner was not committed");
   });
 
   it("rebases a stale dynamic owner onto the committed configured generation", async () => {

--- a/src/agents/prepared-model-runtime.lifecycle.test.ts
+++ b/src/agents/prepared-model-runtime.lifecycle.test.ts
@@ -325,6 +325,21 @@ describe("prepared model runtime snapshots", () => {
     lease.release();
   });
 
+  it("activates a standalone lease for a configless runtime while another agent is configured", async () => {
+    mocks.configuredAgentIds = ["other"];
+    const config = {};
+    await refreshPreparedModelRuntimeSnapshots(config, { gatewayLifecycle: true });
+    const input = {
+      config,
+      agentDir: "/tmp/unused-agent",
+      inheritedAuthDir: "/tmp/unused-agent",
+      workspaceDir: "/tmp/configless-mixed-workspace",
+    };
+    const lease = await acquireAgentRunPreparedModelRuntime(input);
+    expect(lease.snapshot.agentDir).toBe("/tmp/unused-agent");
+    lease.release();
+  });
+
   it("rebases a stale dynamic owner onto the committed configured generation", async () => {
     mocks.configuredAgentIds = ["default"];
     const initialConfig = {};

--- a/src/agents/prepared-model-runtime.lifecycle.test.ts
+++ b/src/agents/prepared-model-runtime.lifecycle.test.ts
@@ -310,6 +310,21 @@ describe("prepared model runtime snapshots", () => {
     firstLease.release();
   });
 
+  it("activates a standalone lease on a configless gateway with no configured owners", async () => {
+    mocks.configuredAgentIds = [];
+    const config = {};
+    await refreshPreparedModelRuntimeSnapshots(config, { gatewayLifecycle: true });
+    const input = {
+      config,
+      agentDir: "/tmp/unused-agent",
+      inheritedAuthDir: "/tmp/unused-agent",
+      workspaceDir: "/tmp/configless-workspace",
+    };
+    const lease = await acquireAgentRunPreparedModelRuntime(input);
+    expect(lease.snapshot.agentDir).toBe("/tmp/unused-agent");
+    lease.release();
+  });
+
   it("rebases a stale dynamic owner onto the committed configured generation", async () => {
     mocks.configuredAgentIds = ["default"];
     const initialConfig = {};

--- a/src/agents/prepared-model-runtime.owner.ts
+++ b/src/agents/prepared-model-runtime.owner.ts
@@ -82,33 +82,47 @@ export class PreparedModelRuntimeOwnerNotPublishedError extends Error {}
 
 export class PreparedModelRuntimePublicationSupersededError extends PreparedModelRuntimeOwnerNotPublishedError {}
 
+function findConfiguredOwnerCandidates(
+  owners: Map<string, PreparedModelRuntimeOwner>,
+  rawInput: PreparedModelRuntimeInput,
+): PreparedModelRuntimeOwner[] {
+  const input = normalizePreparedModelRuntimeInput(rawInput);
+  const configured = [...owners.values()].filter((owner) => owner.provenance === "configured");
+  const identityCandidates =
+    input.agentId === undefined
+      ? []
+      : configured.filter((owner) => owner.input.agentId === input.agentId);
+  const exactCandidates = identityCandidates.filter(
+    (owner) => owner.input.agentDir === input.agentDir,
+  );
+  const directoryCandidates = configured.filter((owner) => owner.input.agentDir === input.agentDir);
+  // Unbound inputs and reserved setup identities derive ownership from the configured directory.
+  // Ordinary agent runs stay bound to their explicit identity, even when handed a stale directory.
+  const canRebindByDirectory =
+    input.agentId === undefined || isReservedSystemAgentId(input.agentId);
+  return exactCandidates.length > 0
+    ? exactCandidates
+    : canRebindByDirectory && directoryCandidates.length > 0
+      ? directoryCandidates
+      : identityCandidates;
+}
+
+/** Whether a configured owner matches the requesting runtime's identity/directory. */
+export function hasConfiguredOwnerMatching(
+  owners: Map<string, PreparedModelRuntimeOwner>,
+  rawInput: PreparedModelRuntimeInput,
+): boolean {
+  return findConfiguredOwnerCandidates(owners, rawInput).length > 0;
+}
+
 export function rebindInputToCommittedConfiguredOwner(
   owners: Map<string, PreparedModelRuntimeOwner>,
   rawInput: PreparedModelRuntimeInput,
 ): PreparedModelRuntimeInput {
   const input = normalizePreparedModelRuntimeInput(rawInput);
-  const committed = [...owners.values()].filter(
-    (owner) =>
-      owner.provenance === "configured" && owner.snapshot && !owner.needsRefresh && !owner.pending,
+  const candidates = findConfiguredOwnerCandidates(owners, rawInput).filter(
+    (owner) => owner.snapshot && !owner.needsRefresh && !owner.pending,
   );
-  const identityCandidates =
-    input.agentId === undefined
-      ? []
-      : committed.filter((owner) => owner.input.agentId === input.agentId);
-  const exactCandidates = identityCandidates.filter(
-    (owner) => owner.input.agentDir === input.agentDir,
-  );
-  const directoryCandidates = committed.filter((owner) => owner.input.agentDir === input.agentDir);
-  // Unbound inputs and reserved setup identities derive ownership from the configured directory.
-  // Ordinary agent runs stay bound to their explicit identity, even when handed a stale directory.
-  const canRebindByDirectory =
-    input.agentId === undefined || isReservedSystemAgentId(input.agentId);
-  const candidates =
-    exactCandidates.length > 0
-      ? exactCandidates
-      : canRebindByDirectory && directoryCandidates.length > 0
-        ? directoryCandidates
-        : identityCandidates;
   if (candidates.length !== 1) {
     throw new PreparedModelRuntimeOwnerNotPublishedError(
       `prepared model runtime owner was not committed after replacement for ${input.agentDir}`,

--- a/src/agents/prepared-model-runtime.ts
+++ b/src/agents/prepared-model-runtime.ts
@@ -7,6 +7,7 @@ import {
   PreparedModelRuntimePublicationSupersededError,
   createPreparedModelRuntimeReplacement,
   effectiveEnvironmentFingerprint,
+  hasConfiguredOwnerMatching,
   hasSameLifecycleInput,
   listConfiguredOwnerInputs,
   normalizeOptionalDir,
@@ -289,15 +290,13 @@ async function acquirePreparedModelRuntimeLease(
         if (!(error instanceof PreparedModelRuntimeOwnerNotPublishedError)) {
           throw error;
         }
-        const hasAnyConfiguredOwner = [...owners.values()].some(
-          (candidate) => candidate.provenance === "configured",
-        );
-        if (hasAnyConfiguredOwner) {
+        if (hasConfiguredOwnerMatching(owners, input)) {
           throw error;
         }
-        // A configless gateway has no committed configured owner yet (e.g.
-        // first-run Model Setup activation). The raw input continues to a
-        // standalone lease publication below without a configured rebind.
+        // The requesting runtime has no committed configured owner to rebind to
+        // (e.g. first-run Model Setup on a configless gateway). The raw input
+        // continues to a standalone lease publication below without a configured
+        // rebind.
       }
     }
     try {

--- a/src/agents/prepared-model-runtime.ts
+++ b/src/agents/prepared-model-runtime.ts
@@ -1,6 +1,7 @@
 /** Lifecycle-owned auth/model discovery snapshots for agent runs. */
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { isReservedSystemAgentId } from "../system-agent/agent-id.js";
 import { registerRuntimeAuthProfileStoreMutationListener } from "./auth-profiles/runtime-snapshots.js";
 import {
   PreparedModelRuntimeOwnerNotPublishedError,
@@ -290,13 +291,13 @@ async function acquirePreparedModelRuntimeLease(
         if (!(error instanceof PreparedModelRuntimeOwnerNotPublishedError)) {
           throw error;
         }
-        if (hasConfiguredOwnerMatching(owners, input)) {
+        const canActivateConfiglessSetup =
+          input.agentId !== undefined && isReservedSystemAgentId(input.agentId);
+        if (hasConfiguredOwnerMatching(owners, input) || !canActivateConfiglessSetup) {
           throw error;
         }
-        // The requesting runtime has no committed configured owner to rebind to
-        // (e.g. first-run Model Setup on a configless gateway). The raw input
-        // continues to a standalone lease publication below without a configured
-        // rebind.
+        // First-run Model Setup uses the reserved system-agent identity before a configless gateway
+        // has an owner to rebind. Keep ordinary agent runs fail-closed at this ownership boundary.
       }
     }
     try {

--- a/src/agents/prepared-model-runtime.ts
+++ b/src/agents/prepared-model-runtime.ts
@@ -290,7 +290,7 @@ async function acquirePreparedModelRuntimeLease(
           throw error;
         }
         const hasAnyConfiguredOwner = [...owners.values()].some(
-          (owner) => owner.provenance === "configured",
+          (candidate) => candidate.provenance === "configured",
         );
         if (hasAnyConfiguredOwner) {
           throw error;

--- a/src/agents/prepared-model-runtime.ts
+++ b/src/agents/prepared-model-runtime.ts
@@ -277,13 +277,28 @@ async function acquirePreparedModelRuntimeLease(
       // Dynamic workspaces still inherit the committed agent/config generation. Only their
       // explicitly pinned workspace may differ from the configured owner. A stale leased owner
       // can share this key, so rebase its input before publishing a replacement generation.
-      input = rebindInputToCommittedConfiguredOwner(owners, input);
-      key = ownerKey(input);
-      existing = owners.get(key);
-      staleDynamicOwner =
-        existing?.needsRefresh &&
-        !existing.pending &&
-        (existing.provenance === "run" || existing.provenance === "ephemeral");
+      try {
+        input = rebindInputToCommittedConfiguredOwner(owners, input);
+        key = ownerKey(input);
+        existing = owners.get(key);
+        staleDynamicOwner =
+          existing?.needsRefresh &&
+          !existing.pending &&
+          (existing.provenance === "run" || existing.provenance === "ephemeral");
+      } catch (error) {
+        if (!(error instanceof PreparedModelRuntimeOwnerNotPublishedError)) {
+          throw error;
+        }
+        const hasAnyConfiguredOwner = [...owners.values()].some(
+          (owner) => owner.provenance === "configured",
+        );
+        if (hasAnyConfiguredOwner) {
+          throw error;
+        }
+        // A configless gateway has no committed configured owner yet (e.g.
+        // first-run Model Setup activation). The raw input continues to a
+        // standalone lease publication below without a configured rebind.
+      }
     }
     try {
       if (staleDynamicOwner) {


### PR DESCRIPTION
Fixes #111520

## What Problem This Solves

Fixes an issue where operator admins on a configless gateway (no explicit model in `openclaw.json`, model resolved from a provider env key like `OPENAI_API_KEY`) are permanently stuck on the Control UI Model Setup page. Clicking "Test & use" fails with:

```
Connection failed: prepared model runtime owner was not committed after replacement
```

Because activation never commits, `openclaw.setup.detect` keeps returning `setupComplete: false`, so every admin device is bounced to `/settings/model-setup?firstRun=1` from the default chat landing. On a multi-user trusted-proxy gateway this locks all admins out of the chat UI.

The only workaround is host-side CLI (`openclaw models set openai/gpt-5.6-sol` + gateway restart), which regular Control UI users cannot perform.

## Why This Change Was Made

`acquirePreparedModelRuntimeLease` unconditionally calls `rebindInputToCommittedConfiguredOwner` when the gateway lifecycle is active and the requesting path has `provenance: "run"`. On a configless gateway, no `provenance: "configured"` owner exists, so rebind throws `PreparedModelRuntimeOwnerNotPublishedError` with no fallback.

The sibling path `loadPreparedModelRuntimeSnapshot` already handles this by catching the same error and falling through to `activateStandalonePreparedModelRuntime`. This change adds a parallel guard in `acquirePreparedModelRuntimeLease`: catch the error, verify the requesting runtime has no matching configured owner (to preserve the error for stale-owner refresh), then let the raw input proceed to standalone lease publication.

The fallback predicate was refined from "any configured owner exists in the process" to "a configured owner matches this runtime's identity/directory", so a mixed gateway (one configured agent + one configless runtime) no longer incorrectly blocks the configless runtime.

## User Impact

Operator admins on configless gateways can now complete Model Setup "Test & use" directly through the Control UI without host-side CLI intervention. The setup flow detects the provider-derived model, live-tests it, persists the config, and marks setup complete — all from the browser.

## Evidence

### Before fix

Gateway with empty `openclaw.json`, `OPENAI_API_KEY` set via env. Model Setup "Test & use" → error:

```
Connection failed: prepared model runtime owner was not committed after replacement for /home/openclaw/.openclaw/agents/main/agent
```

`setup.detect` continues reporting `setupComplete: false`, redirect loop persists.

### After fix — real gateway proof

Started a clean-state gateway with no `openclaw.json` and a fake `OPENAI_API_KEY`:

```bash
OPENCLAW_STATE_DIR=/tmp/openclaw-proof-111841 \
OPENAI_API_KEY=sk-proof-fake-key-111841 \
node openclaw.mjs gateway run --port 18790 --auth token --token proof-token-111841 --allow-unconfigured
```

Gateway resolved the default model from the env key and became ready:

```
[gateway] agent model: openai/gpt-5.6-sol (thinking=medium, fast=off)
[gateway] ready
```

`openclaw.setup.detect` found the OpenAI API-key candidate:

```bash
node openclaw.mjs gateway call --url ws://127.0.0.1:18790 --token proof-token-111841 --json \
  openclaw.setup.detect --params '{}'
```

```json
{
  "candidates": [
    { "kind": "openai-api-key", "modelRef": "openai/gpt-5.6", "credentials": true }
  ],
  "setupComplete": false
}
```

`openclaw.setup.activate` (Model Setup "Test & use") proceeded past prepared-runtime activation and reached the provider call instead of failing with the lifecycle error:

```bash
node openclaw.mjs gateway call --url ws://127.0.0.1:18790 --token proof-token-111841 --json --timeout 60000 \
  openclaw.setup.activate --params '{"kind":"openai-api-key"}'
```

```json
{
  "ok": false,
  "status": "auth",
  "error": "403 Country, region, or territory not supported"
}
```

The request did **not** fail with `prepared model runtime owner was not committed after replacement`; it failed only at the provider auth step, which is expected with a fake/redacted key and confirms the configless runtime activated successfully.

### Unit tests

```
✓ src/agents/prepared-model-runtime.test.ts — 26 passed
✓ src/agents/prepared-model-runtime.lifecycle.test.ts — 40 passed (66 total)
```

Includes a new regression test: a configless runtime activates standalone while another agent is configured.
