### PR TITLE
fix(agents): harden local-coder completion and shared scratch artifacts

### DIFF
--- a/docs/tools/exec-approvals.md
+++ b/docs/tools/exec-approvals.md
@@ -416,6 +416,62 @@ Each allowlist entry supports:
 | `lastUsedCommand`  | Last command that matched                            |
 | `lastResolvedPath` | Last resolved binary path                            |
 
+## Denylist (STOP list, per agent)
+
+The denylist is the inverse companion to the allowlist: a small STOP list
+that forces an explicit approval for matching commands **even when policy
+would otherwise auto-allow them** (including `security=full` with
+`ask="off"`). It enables a deny-by-exception posture: keep exec permissive,
+but interrupt the handful of commands you always want a human to confirm.
+
+```json
+{
+  "version": 1,
+  "agents": {
+    "*": {
+      "denylist": [
+        { "pattern": "git push*--force*", "reason": "history rewrite" },
+        { "pattern": "launchctl*" },
+        { "pattern": "rm -rf /*" }
+      ]
+    }
+  }
+}
+```
+
+Patterns are globs (`*`, `?`) matched against each analyzed command
+segment's argv text, joined with single spaces. Matching also covers:
+
+- a basename variant of the executable, so `git push --force*` still
+  matches `/usr/bin/git push --force`
+- every part of shell chains (`&&`, `||`, `;`)
+- payloads of POSIX inline shell wrappers such as `bash -c "..."`
+  (up to three nesting levels)
+
+Denylist semantics are intentionally stricter than allowlist semantics:
+
+- A hit always asks again. Durable allow-always trust never clears a hit;
+  approving a denylisted command applies to that invocation only.
+- Hits are excluded from exec auto-review; only a human approval proceeds.
+- If a command cannot be analyzed (for example line continuations) or uses
+  inline wrappers the analyzer cannot screen (`cmd.exe /c`,
+  `powershell -Command`), the command conservatively requires approval
+  while a denylist is configured.
+- Wildcard-agent (`agents.*`) entries merge with per-agent entries.
+
+The denylist is a guardrail against unintended high-risk commands, not a
+sandbox. A determined payload can still hide behind constructs the
+analyzer rejects (which prompt for approval) — use `security=allowlist`
+or `security=deny` when you need confinement.
+
+Each denylist entry supports:
+
+| Field     | Meaning                                              |
+| --------- | ---------------------------------------------------- |
+| `pattern` | Glob matched against analyzed segment argv text      |
+| `reason`  | Optional note shown with approval prompts and denials |
+| `id`      | Optional stable identifier for UI/tooling            |
+
 ## Auto-allow skill CLIs
 
 When **Auto-allow skill CLIs** (`autoAllowSkills`) is enabled, executables

--- a/docs/tools/exec-approvals.md
+++ b/docs/tools/exec-approvals.md
@@ -466,11 +466,11 @@ or `security=deny` when you need confinement.
 
 Each denylist entry supports:
 
-| Field     | Meaning                                              |
-| --------- | ---------------------------------------------------- |
-| `pattern` | Glob matched against analyzed segment argv text      |
+| Field     | Meaning                                               |
+| --------- | ----------------------------------------------------- |
+| `pattern` | Glob matched against analyzed segment argv text       |
 | `reason`  | Optional note shown with approval prompts and denials |
-| `id`      | Optional stable identifier for UI/tooling            |
+| `id`      | Optional stable identifier for UI/tooling             |
 
 ## Auto-allow skill CLIs
 

--- a/packages/tool-call-repair/src/openai-style.ts
+++ b/packages/tool-call-repair/src/openai-style.ts
@@ -77,12 +77,15 @@ export function parseOpenAiStyleToolCallBlockAt(params: {
   }
   const record = parsed as Record<string, unknown>;
   const name = typeof record.name === "string" ? record.name.trim() : "";
-  if (
-    !name ||
-    name.length > MAX_TOOL_NAME_CHARS ||
-    [...name].some((char) => !isPlainTextToolNameChar(char)) ||
-    (params.allowedToolNames && !params.allowedToolNames.has(name))
-  ) {
+  if (!name || name.length > MAX_TOOL_NAME_CHARS) {
+    return null;
+  }
+  for (const char of name) {
+    if (!isPlainTextToolNameChar(char)) {
+      return null;
+    }
+  }
+  if (params.allowedToolNames && !params.allowedToolNames.has(name)) {
     return null;
   }
   const args = parseArguments(record.arguments ?? record.parameters ?? record.input);

--- a/packages/tool-call-repair/src/openai-style.ts
+++ b/packages/tool-call-repair/src/openai-style.ts
@@ -1,0 +1,102 @@
+// Parses OpenAI/Qwen-style JSON tool calls emitted as plain assistant text.
+import { isPlainTextToolNameChar, skipWhitespace, utf8ByteLengthWithinLimit } from "./grammar.js";
+
+const MAX_TOOL_NAME_CHARS = 120;
+
+export type OpenAiStyleToolCallBlock = {
+  arguments: Record<string, unknown>;
+  end: number;
+  name: string;
+  raw: string;
+  start: number;
+};
+
+function findJsonObjectEnd(text: string, start: number): number | undefined {
+  let depth = 0;
+  let escaped = false;
+  let inString = false;
+  for (let index = start; index < text.length; index += 1) {
+    const char = text[index];
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (char === '"') {
+      inString = true;
+    } else if (char === "{") {
+      depth += 1;
+    } else if (char === "}" && --depth === 0) {
+      return index + 1;
+    }
+  }
+  return undefined;
+}
+
+function parseArguments(value: unknown): Record<string, unknown> | undefined {
+  let parsed = value;
+  if (typeof parsed === "string") {
+    try {
+      parsed = JSON.parse(parsed) as unknown;
+    } catch {
+      return undefined;
+    }
+  }
+  return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+    ? (parsed as Record<string, unknown>)
+    : undefined;
+}
+
+export function parseOpenAiStyleToolCallBlockAt(params: {
+  text: string;
+  start: number;
+  allowedToolNames?: ReadonlySet<string>;
+  maxPayloadBytes: number;
+}): OpenAiStyleToolCallBlock | null {
+  const objectStart = skipWhitespace(params.text, params.start);
+  if (params.text[objectStart] !== "{") {
+    return null;
+  }
+  const end = findJsonObjectEnd(params.text, objectStart);
+  if (end === undefined) {
+    return null;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(params.text.slice(objectStart, end)) as unknown;
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return null;
+  }
+  const record = parsed as Record<string, unknown>;
+  const name = typeof record.name === "string" ? record.name.trim() : "";
+  if (
+    !name ||
+    name.length > MAX_TOOL_NAME_CHARS ||
+    [...name].some((char) => !isPlainTextToolNameChar(char)) ||
+    (params.allowedToolNames && !params.allowedToolNames.has(name))
+  ) {
+    return null;
+  }
+  const args = parseArguments(record.arguments ?? record.parameters ?? record.input);
+  if (
+    !args ||
+    utf8ByteLengthWithinLimit(params.text, objectStart, end, params.maxPayloadBytes) === null
+  ) {
+    return null;
+  }
+  return {
+    arguments: args,
+    end,
+    name,
+    raw: params.text.slice(params.start, end),
+    start: params.start,
+  };
+}

--- a/packages/tool-call-repair/src/payload.test.ts
+++ b/packages/tool-call-repair/src/payload.test.ts
@@ -222,4 +222,24 @@ describe("OpenAI-style plain-text tool calls", () => {
     expect(parseStandalonePlainTextToolCallBlocks('{"path":"/tmp/x"}')).toBeNull();
     expect(parseStandalonePlainTextToolCallBlocks('{"name":123,"arguments":{}}')).toBeNull();
   });
+
+  it("promotes markdown-fenced OpenAI-style tool calls from local Ollama coders", () => {
+    const raw = [
+      "```json",
+      '{"name": "write", "arguments": {"path": "/tmp/scratch/test_local_final.py", "content": "x = 1\\n"}}',
+      "```",
+      "",
+      "```json",
+      '{"name": "exec", "arguments": {"command": "python3 /tmp/scratch/test_local_final.py"}}',
+      "```",
+    ].join("\n");
+
+    const blocks = parseStandalonePlainTextToolCallBlocks(raw, {
+      allowedToolNames: ["write", "exec"],
+    });
+
+    expect(blocks).toHaveLength(2);
+    expect(blocks?.[0]?.name).toBe("write");
+    expect(blocks?.[1]?.name).toBe("exec");
+  });
 });

--- a/packages/tool-call-repair/src/payload.test.ts
+++ b/packages/tool-call-repair/src/payload.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { scanXmlishToolCall } from "./grammar.js";
-import { scanPlainTextJsonToolCall, stripPlainTextToolCallBlocks } from "./payload.js";
+import {
+  parseStandalonePlainTextToolCallBlocks,
+  scanPlainTextJsonToolCall,
+  stripPlainTextToolCallBlocks,
+} from "./payload.js";
 
 function trackStringOperations(value: string) {
   let indexedReads = 0;
@@ -186,5 +190,36 @@ describe("stripPlainTextToolCallBlocks", () => {
 
     expect(stripPlainTextToolCallBlocks(tracked.text)).toBe(raw);
     expect(tracked.indexedReads).toBeLessThan(raw.length * 16);
+  });
+});
+
+describe("OpenAI-style plain-text tool calls", () => {
+  it("parses object-argument tool calls emitted by local Ollama coders", () => {
+    const raw =
+      '{"name": "write", "arguments": {"path": "/tmp/test_local_prime.py", "content": "def is_prime(n):\\n    return n > 1\\n"}}';
+    const blocks = parseStandalonePlainTextToolCallBlocks(raw, {
+      allowedToolNames: ["write", "read", "exec"],
+    });
+
+    expect(blocks).toHaveLength(1);
+    expect(blocks?.[0]?.name).toBe("write");
+    expect(blocks?.[0]?.arguments).toEqual({
+      path: "/tmp/test_local_prime.py",
+      content: "def is_prime(n):\n    return n > 1\n",
+    });
+  });
+
+  it("parses stringified arguments payloads", () => {
+    const raw = '{"name":"exec","arguments":"{\\"command\\":\\"python3 /tmp/x.py\\"}"}';
+    const blocks = parseStandalonePlainTextToolCallBlocks(raw);
+
+    expect(blocks).toHaveLength(1);
+    expect(blocks?.[0]?.name).toBe("exec");
+    expect(blocks?.[0]?.arguments).toEqual({ command: "python3 /tmp/x.py" });
+  });
+
+  it("rejects non-tool JSON objects", () => {
+    expect(parseStandalonePlainTextToolCallBlocks('{"path":"/tmp/x"}')).toBeNull();
+    expect(parseStandalonePlainTextToolCallBlocks('{"name":123,"arguments":{}}')).toBeNull();
   });
 });

--- a/packages/tool-call-repair/src/payload.ts
+++ b/packages/tool-call-repair/src/payload.ts
@@ -663,6 +663,16 @@ function normalizeParseOptions(
     : undefined;
 }
 
+function skipMarkdownFence(text: string, start: number): number {
+  const fence = text.slice(start).match(/^```(?:json)?[ \t]*(?:\r\n|\n|\r)/u);
+  return fence ? start + fence[0].length : start;
+}
+
+function skipMarkdownFenceClose(text: string, start: number): number {
+  const fence = text.slice(start).match(/^```[ \t]*(?:\r\n|\n|\r|$)/u);
+  return fence ? start + fence[0].length : start;
+}
+
 export function parseStandalonePlainTextToolCallBlocks(
   text: string,
   options?: PlainTextToolCallParseOptions,
@@ -672,6 +682,11 @@ export function parseStandalonePlainTextToolCallBlocks(
   const normalizedOptions = normalizeParseOptions(options);
   let cursor = skipWhitespace(text, 0);
   while (cursor < text.length) {
+    cursor = skipMarkdownFence(text, cursor);
+    cursor = skipWhitespace(text, cursor);
+    if (cursor >= text.length) {
+      break;
+    }
     const block = parsePlainTextToolCallBlockAtAnySyntax(
       text,
       cursor,
@@ -683,6 +698,8 @@ export function parseStandalonePlainTextToolCallBlocks(
     }
     blocks.push(block);
     cursor = skipWhitespace(text, block.end);
+    cursor = skipMarkdownFenceClose(text, cursor);
+    cursor = skipWhitespace(text, cursor);
   }
   return blocks.length > 0 ? blocks : null;
 }

--- a/packages/tool-call-repair/src/payload.ts
+++ b/packages/tool-call-repair/src/payload.ts
@@ -14,6 +14,7 @@ import {
   type StructuralLineBreakOptions,
   utf8ByteLengthWithinLimit,
 } from "./grammar.js";
+import { parseOpenAiStyleToolCallBlockAt } from "./openai-style.js";
 
 /** Parsed standalone plain-text tool call block with source offsets for repair. */
 export type PlainTextToolCallBlock = {
@@ -641,7 +642,13 @@ function parsePlainTextToolCallBlockAtAnySyntax(
 ): PlainTextToolCallBlock | null {
   return (
     parsePlainTextToolCallBlockAt(text, start, options, structuralLineBreaks) ??
-    parseXmlishPlainTextToolCallBlockAt(text, start, options, structuralLineBreaks)
+    parseXmlishPlainTextToolCallBlockAt(text, start, options, structuralLineBreaks) ??
+    parseOpenAiStyleToolCallBlockAt({
+      text,
+      start,
+      allowedToolNames: options?.allowedToolNames,
+      maxPayloadBytes: options?.maxPayloadBytes ?? DEFAULT_MAX_PLAIN_TEXT_TOOL_PAYLOAD_BYTES,
+    })
   );
 }
 
@@ -688,7 +695,8 @@ export function stripPlainTextToolCallBlocks(text: string): string {
       !/(?:^|[\r\n])[^\S\r\n]*(?:<\|channel\|>)?(?:commentary|analysis|final)[ \t]+to=/.test(
         text,
       ) &&
-      !/(?:^|[\r\n])[^\S\r\n]*<function=/i.test(text))
+      !/(?:^|[\r\n])[^\S\r\n]*<function=/i.test(text) &&
+      !/(?:^|[\r\n])[^\S\r\n]*\{\s*"name"\s*:/.test(text))
   ) {
     return text;
   }

--- a/src/agents/agent-tools.safe-bins.test.ts
+++ b/src/agents/agent-tools.safe-bins.test.ts
@@ -38,6 +38,7 @@ const { mockExecApprovals, supervisorSpawnMock } = vi.hoisted(() => {
       askFallback: "defaults.askFallback",
     },
     allowlist: [],
+    denylist: [],
     file: {
       version: 1,
       socket: { path: "/tmp/exec-approvals.sock", token: "token" },

--- a/src/agents/bash-tools.exec-host-gateway.test.ts
+++ b/src/agents/bash-tools.exec-host-gateway.test.ts
@@ -1721,7 +1721,7 @@ describe("processGatewayAllowlist", () => {
     expect(createAndRegisterDefaultExecApprovalRequestMock).not.toHaveBeenCalled();
   });
 
-  it("requires approval for unanalyzable commands when a denylist is configured", async () => {
+  it("hard-denies unanalyzable commands in yolo mode when a denylist is configured", async () => {
     mockDenylistContext(["git push*--force*"]);
     evaluateShellAllowlistWithAuthorizationMock.mockReturnValue({
       allowlistMatches: [],
@@ -1736,6 +1736,41 @@ describe("processGatewayAllowlist", () => {
       command: "git push \\\n--force",
       security: "full",
       ask: "off",
+    });
+
+    expect(createAndRegisterDefaultExecApprovalRequestMock).not.toHaveBeenCalled();
+    expect(result.deniedResult?.details.status).toBe("failed");
+    expect(result.deniedResult?.details.failureKind).toBe("denylist_unanalyzable");
+    expect(String(result.deniedResult?.details.aggregated ?? "")).toContain(
+      "could not be analyzed for denylist screening",
+    );
+  });
+
+  it("still requires approval for unanalyzable commands when ask is on-miss", async () => {
+    mockDenylistContext(["git push*--force*"]);
+    resolveExecHostApprovalContextMock.mockReturnValue({
+      approvals: {
+        allowlist: [],
+        denylist: [{ pattern: "git push*--force*" }],
+        file: { version: 1, agents: {} },
+      },
+      hostSecurity: "full",
+      hostAsk: "on-miss",
+      askFallback: "deny",
+    });
+    evaluateShellAllowlistWithAuthorizationMock.mockReturnValue({
+      allowlistMatches: [],
+      analysisOk: false,
+      allowlistSatisfied: false,
+      segments: [],
+      segmentAllowlistEntries: [],
+      segmentSatisfiedBy: [],
+    });
+
+    const result = await runGatewayAllowlist({
+      command: "git push \\\n--force",
+      security: "full",
+      ask: "on-miss",
     });
 
     expect(createAndRegisterDefaultExecApprovalRequestMock).toHaveBeenCalledTimes(1);

--- a/src/agents/bash-tools.exec-host-gateway.test.ts
+++ b/src/agents/bash-tools.exec-host-gateway.test.ts
@@ -1739,10 +1739,12 @@ describe("processGatewayAllowlist", () => {
     });
 
     expect(createAndRegisterDefaultExecApprovalRequestMock).not.toHaveBeenCalled();
-    expect(result.deniedResult?.details.status).toBe("failed");
-    expect(result.deniedResult?.details.failureKind).toBe("denylist_unanalyzable");
-    expect(String(result.deniedResult?.details.aggregated ?? "")).toContain(
-      "could not be analyzed for denylist screening",
+    expect(result.deniedResult?.details).toEqual(
+      expect.objectContaining({
+        status: "failed",
+        failureKind: "denylist_unanalyzable",
+        aggregated: expect.stringContaining("could not be analyzed for denylist screening"),
+      }),
     );
   });
 

--- a/src/agents/bash-tools.exec-host-gateway.test.ts
+++ b/src/agents/bash-tools.exec-host-gateway.test.ts
@@ -1634,12 +1634,13 @@ describe("processGatewayAllowlist", () => {
 
   it("requires approval for denylist matches even in yolo mode", async () => {
     mockDenylistContext(["git push*--force*"]);
-    evaluateShellAllowlistMock.mockReturnValue({
+    evaluateShellAllowlistWithAuthorizationMock.mockReturnValue({
       allowlistMatches: [],
       analysisOk: true,
       allowlistSatisfied: false,
       segments: [{ resolution: null, argv: ["git", "push", "--force"] }],
       segmentAllowlistEntries: [],
+      segmentSatisfiedBy: [],
     });
 
     const result = await runGatewayAllowlist({
@@ -1655,12 +1656,13 @@ describe("processGatewayAllowlist", () => {
   it("keeps denylist matches off the auto-review path", async () => {
     const warnings: string[] = [];
     mockDenylistContext(["git push*--force*"]);
-    evaluateShellAllowlistMock.mockReturnValue({
+    evaluateShellAllowlistWithAuthorizationMock.mockReturnValue({
       allowlistMatches: [],
       analysisOk: true,
       allowlistSatisfied: false,
       segments: [{ resolution: null, argv: ["git", "push", "--force"] }],
       segmentAllowlistEntries: [],
+      segmentSatisfiedBy: [],
     });
 
     const result = await runGatewayAllowlist({
@@ -1680,12 +1682,13 @@ describe("processGatewayAllowlist", () => {
   it("asks again for denylist matches despite durable allow-always trust", async () => {
     mockDenylistContext(["git push*--force*"]);
     hasDurableExecApprovalMock.mockReturnValue(true);
-    evaluateShellAllowlistMock.mockReturnValue({
+    evaluateShellAllowlistWithAuthorizationMock.mockReturnValue({
       allowlistMatches: [],
       analysisOk: true,
       allowlistSatisfied: false,
       segments: [{ resolution: null, argv: ["git", "push", "--force"] }],
       segmentAllowlistEntries: [],
+      segmentSatisfiedBy: [],
     });
 
     const result = await runGatewayAllowlist({
@@ -1700,12 +1703,13 @@ describe("processGatewayAllowlist", () => {
 
   it("does not require approval for commands that miss the denylist", async () => {
     mockDenylistContext(["git push*--force*"]);
-    evaluateShellAllowlistMock.mockReturnValue({
+    evaluateShellAllowlistWithAuthorizationMock.mockReturnValue({
       allowlistMatches: [],
       analysisOk: true,
       allowlistSatisfied: false,
       segments: [{ resolution: null, argv: ["git", "status"] }],
       segmentAllowlistEntries: [],
+      segmentSatisfiedBy: [],
     });
 
     await runGatewayAllowlist({
@@ -1719,12 +1723,13 @@ describe("processGatewayAllowlist", () => {
 
   it("requires approval for unanalyzable commands when a denylist is configured", async () => {
     mockDenylistContext(["git push*--force*"]);
-    evaluateShellAllowlistMock.mockReturnValue({
+    evaluateShellAllowlistWithAuthorizationMock.mockReturnValue({
       allowlistMatches: [],
       analysisOk: false,
       allowlistSatisfied: false,
       segments: [],
       segmentAllowlistEntries: [],
+      segmentSatisfiedBy: [],
     });
 
     const result = await runGatewayAllowlist({

--- a/src/agents/bash-tools.exec-host-gateway.test.ts
+++ b/src/agents/bash-tools.exec-host-gateway.test.ts
@@ -68,6 +68,7 @@ type MockAllowlistResult = {
 type MockExecHostApprovalContext = {
   approvals: {
     allowlist: ExecAllowlistEntry[];
+    denylist?: { id?: string; pattern: string; reason?: string }[];
     file: ExecApprovalsFile;
     agent?: Required<ExecApprovalsDefaults>;
   };
@@ -1616,6 +1617,124 @@ describe("processGatewayAllowlist", () => {
     });
 
     expect(createAndRegisterDefaultExecApprovalRequestMock).not.toHaveBeenCalled();
+  });
+
+  function mockDenylistContext(patterns: string[]) {
+    resolveExecHostApprovalContextMock.mockReturnValue({
+      approvals: {
+        allowlist: [],
+        denylist: patterns.map((pattern) => ({ pattern })),
+        file: { version: 1, agents: {} },
+      },
+      hostSecurity: "full",
+      hostAsk: "off",
+      askFallback: "deny",
+    });
+  }
+
+  it("requires approval for denylist matches even in yolo mode", async () => {
+    mockDenylistContext(["git push*--force*"]);
+    evaluateShellAllowlistMock.mockReturnValue({
+      allowlistMatches: [],
+      analysisOk: true,
+      allowlistSatisfied: false,
+      segments: [{ resolution: null, argv: ["git", "push", "--force"] }],
+      segmentAllowlistEntries: [],
+    });
+
+    const result = await runGatewayAllowlist({
+      command: "git push --force",
+      security: "full",
+      ask: "off",
+    });
+
+    expect(createAndRegisterDefaultExecApprovalRequestMock).toHaveBeenCalledTimes(1);
+    expect(result.pendingResult?.details.status).toBe("approval-pending");
+  });
+
+  it("keeps denylist matches off the auto-review path", async () => {
+    const warnings: string[] = [];
+    mockDenylistContext(["git push*--force*"]);
+    evaluateShellAllowlistMock.mockReturnValue({
+      allowlistMatches: [],
+      analysisOk: true,
+      allowlistSatisfied: false,
+      segments: [{ resolution: null, argv: ["git", "push", "--force"] }],
+      segmentAllowlistEntries: [],
+    });
+
+    const result = await runGatewayAllowlist({
+      command: "git push --force",
+      security: "full",
+      ask: "off",
+      autoReview: true,
+      warnings,
+    });
+
+    expect(defaultExecAutoReviewerMock).not.toHaveBeenCalled();
+    expect(createAndRegisterDefaultExecApprovalRequestMock).toHaveBeenCalledTimes(1);
+    expect(warnings.some((warning) => warning.includes("git push*--force*"))).toBe(true);
+    expect(result.pendingResult?.details.status).toBe("approval-pending");
+  });
+
+  it("asks again for denylist matches despite durable allow-always trust", async () => {
+    mockDenylistContext(["git push*--force*"]);
+    hasDurableExecApprovalMock.mockReturnValue(true);
+    evaluateShellAllowlistMock.mockReturnValue({
+      allowlistMatches: [],
+      analysisOk: true,
+      allowlistSatisfied: false,
+      segments: [{ resolution: null, argv: ["git", "push", "--force"] }],
+      segmentAllowlistEntries: [],
+    });
+
+    const result = await runGatewayAllowlist({
+      command: "git push --force",
+      security: "full",
+      ask: "off",
+    });
+
+    expect(createAndRegisterDefaultExecApprovalRequestMock).toHaveBeenCalledTimes(1);
+    expect(result.pendingResult?.details.status).toBe("approval-pending");
+  });
+
+  it("does not require approval for commands that miss the denylist", async () => {
+    mockDenylistContext(["git push*--force*"]);
+    evaluateShellAllowlistMock.mockReturnValue({
+      allowlistMatches: [],
+      analysisOk: true,
+      allowlistSatisfied: false,
+      segments: [{ resolution: null, argv: ["git", "status"] }],
+      segmentAllowlistEntries: [],
+    });
+
+    await runGatewayAllowlist({
+      command: "git status",
+      security: "full",
+      ask: "off",
+    });
+
+    expect(createAndRegisterDefaultExecApprovalRequestMock).not.toHaveBeenCalled();
+  });
+
+  it("requires approval for unanalyzable commands when a denylist is configured", async () => {
+    mockDenylistContext(["git push*--force*"]);
+    evaluateShellAllowlistMock.mockReturnValue({
+      allowlistMatches: [],
+      analysisOk: false,
+      allowlistSatisfied: false,
+      segments: [],
+      segmentAllowlistEntries: [],
+    });
+
+    const result = await runGatewayAllowlist({
+      command: "git push \\\n--force",
+      security: "full",
+      ask: "off",
+    });
+
+    expect(createAndRegisterDefaultExecApprovalRequestMock).toHaveBeenCalledTimes(1);
+    expect(result.pendingResult?.details.status).toBe("approval-pending");
   });
 
   it("does not require suppression edit approval for read-only suppression inspection", async () => {

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -671,7 +671,7 @@ export async function processGatewayAllowlist(
     }) && !(hostSecurity === "full" && hostAsk === "off");
   // Denylist hits intentionally have no yolo-mode escape: the STOP list exists
   // to interrupt auto-allowed commands, and durable trust never clears a hit.
-  const denylistEvaluation = evaluateExecDenylist({
+  const denylistEvaluation = await evaluateExecDenylist({
     denylist: approvals.denylist,
     segments: allowlistEval.segments,
     analysisOk,

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -24,7 +24,9 @@ import {
   evaluateExecDenylist,
   evaluateShellAllowlistWithAuthorization,
   formatExecDenylistWarning,
+  formatUnanalyzableDenylistHardDenyMessage,
   hasDurableExecApproval,
+  shouldHardDenyUnanalyzableDenylistHit,
   hasExactCommandDurableExecApproval,
   minSecurity,
   resolveApprovalAuditTrustPath,
@@ -669,8 +671,10 @@ export async function processGatewayAllowlist(
       env: params.env,
       segments: allowlistEval.segments,
     }) && !(hostSecurity === "full" && hostAsk === "off");
-  // Denylist hits intentionally have no yolo-mode escape: the STOP list exists
-  // to interrupt auto-allowed commands, and durable trust never clears a hit.
+  // Denylist pattern hits intentionally have no yolo-mode escape: the STOP list
+  // exists to interrupt auto-allowed commands, and durable trust never clears a
+  // hit. Unanalyzable hits under yolo hard-deny (no prompt) so opaque shell
+  // cannot spam one-shot Allow-once cards while still failing closed.
   const denylistEvaluation = await evaluateExecDenylist({
     denylist: approvals.denylist,
     segments: allowlistEval.segments,
@@ -679,7 +683,41 @@ export async function processGatewayAllowlist(
     env: params.env,
     platform: process.platform,
   });
-  const requiresDenylistApproval = denylistEvaluation.matched;
+  const hardDenyUnanalyzableDenylist = shouldHardDenyUnanalyzableDenylistHit({
+    security: hostSecurity,
+    ask: hostAsk,
+    evaluation: denylistEvaluation,
+  });
+  const requiresDenylistApproval = denylistEvaluation.matched && !hardDenyUnanalyzableDenylist;
+  if (hardDenyUnanalyzableDenylist) {
+    const text = formatUnanalyzableDenylistHardDenyMessage(params.command);
+    emitGatewayExecApprovalSecurityEvent({
+      action: "exec.approval.denied",
+      outcome: "denied",
+      severity: "medium",
+      agentId: params.agentId,
+      reason: "denylist-unanalyzable",
+      hostSecurity,
+      hostAsk,
+      host: "gateway",
+      segmentCount: allowlistEval.segments.length,
+      trigger: params.trigger,
+    });
+    return {
+      deniedResult: {
+        content: [{ type: "text", text }],
+        details: {
+          status: "failed",
+          exitCode: null,
+          failureKind: "denylist_unanalyzable",
+          durationMs: 0,
+          aggregated: text,
+          timedOut: false,
+          cwd: params.workdir,
+        },
+      },
+    };
+  }
   const requiresAsk =
     requiresExecApproval({
       ask: hostAsk,

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -21,7 +21,9 @@ import {
   type ExecSecurity,
   type ExecSegmentSatisfiedBy,
   buildEnforcedShellCommand,
+  evaluateExecDenylist,
   evaluateShellAllowlistWithAuthorization,
+  formatExecDenylistWarning,
   hasDurableExecApproval,
   hasExactCommandDurableExecApproval,
   minSecurity,
@@ -667,6 +669,17 @@ export async function processGatewayAllowlist(
       env: params.env,
       segments: allowlistEval.segments,
     }) && !(hostSecurity === "full" && hostAsk === "off");
+  // Denylist hits intentionally have no yolo-mode escape: the STOP list exists
+  // to interrupt auto-allowed commands, and durable trust never clears a hit.
+  const denylistEvaluation = evaluateExecDenylist({
+    denylist: approvals.denylist,
+    segments: allowlistEval.segments,
+    analysisOk,
+    cwd: params.workdir,
+    env: params.env,
+    platform: process.platform,
+  });
+  const requiresDenylistApproval = denylistEvaluation.matched;
   const requiresAsk =
     requiresExecApproval({
       ask: hostAsk,
@@ -678,7 +691,8 @@ export async function processGatewayAllowlist(
     requiresAllowlistPlanApproval ||
     requiresHeredocApproval ||
     requiresInlineEvalApproval ||
-    requiresSecurityAuditSuppressionApproval;
+    requiresSecurityAuditSuppressionApproval ||
+    requiresDenylistApproval;
   if (requiresHeredocApproval) {
     params.warnings.push(
       "Warning: heredoc execution requires reviewer or explicit approval in allowlist mode.",
@@ -710,6 +724,9 @@ export async function processGatewayAllowlist(
     params.warnings.push(
       "Warning: security audit suppression changes require explicit approval unless exec is running in yolo mode.",
     );
+  }
+  if (requiresDenylistApproval) {
+    params.warnings.push(formatExecDenylistWarning(denylistEvaluation));
   }
   if (requiresAsk) {
     if (params.nonInteractiveApproval) {
@@ -752,12 +769,15 @@ export async function processGatewayAllowlist(
       params.autoReview === true &&
       hostAsk !== "always" &&
       autoReviewHasExecutableBinding &&
-      !requiresSecurityAuditSuppressionApproval;
+      !requiresSecurityAuditSuppressionApproval &&
+      // Denylist hits are reserved for explicit human approval.
+      !requiresDenylistApproval;
     let autoReviewRequiresHumanApproval =
       (params.autoReview === true && hostAsk !== "always" && !autoReviewHasExecutableBinding) ||
       requiresAllowlistPlanApproval ||
       requiresHeredocApproval ||
-      requiresSecurityAuditSuppressionApproval;
+      requiresSecurityAuditSuppressionApproval ||
+      requiresDenylistApproval;
     if (canAutoReviewApprovalMiss) {
       const reviewer = params.autoReviewer ?? defaultExecAutoReviewer;
       const decision = await reviewer({

--- a/src/agents/bash-tools.exec.path.test.ts
+++ b/src/agents/bash-tools.exec.path.test.ts
@@ -140,6 +140,7 @@ function createExecApprovals(): ExecApprovalsResolved {
       askFallback: "defaults.askFallback",
     },
     allowlist: [],
+    denylist: [],
     file: {
       version: 1,
       socket: { path: "/tmp/exec-approvals.sock", token: "token" },

--- a/src/agents/local-coder-artifacts.test.ts
+++ b/src/agents/local-coder-artifacts.test.ts
@@ -1,0 +1,71 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  commitLocalCoderArtifact,
+  ensureSharedLocalCoderScratch,
+  isPathInsideRoot,
+  resolveLocalCoderScratchRoots,
+  validateLocalCoderArtifactPath,
+  verifyHostVisibleLocalCoderArtifact,
+} from "./local-coder-artifacts.js";
+
+const tempRoots: string[] = [];
+afterEach(async () => {
+  await Promise.all(tempRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("local-coder artifacts", () => {
+  it("validates paths and rejects escapes", async () => {
+    const root = await mkdtemp(join(tmpdir(), "local-coder-"));
+    tempRoots.push(root);
+    expect(isPathInsideRoot(join(root, "ok.txt"), root)).toBe(true);
+    expect(() =>
+      validateLocalCoderArtifactPath(join(root, "..", "escape"), { hostScratchRoot: root }),
+    ).toThrow();
+  });
+
+  it("maps coder scratch to host scratch", async () => {
+    const root = await mkdtemp(join(tmpdir(), "local-coder-"));
+    tempRoots.push(root);
+    const roots = resolveLocalCoderScratchRoots({
+      hostScratchRoot: join(root, "host"),
+      coderWorkspaceRoot: join(root, "coder"),
+    });
+    await ensureSharedLocalCoderScratch(roots);
+    await writeFile(join(roots.coderScratchRoot, "result.txt"), "shared");
+    await expect(readFile(join(roots.hostScratchRoot, "result.txt"), "utf8")).resolves.toBe(
+      "shared",
+    );
+  });
+
+  it("atomically commits and verifies a host artifact", async () => {
+    const root = await mkdtemp(join(tmpdir(), "local-coder-"));
+    tempRoots.push(root);
+    const sourcePath = join(root, "source.txt");
+    const hostScratchRoot = join(root, "host");
+    const hostArtifactPath = join(hostScratchRoot, "result.txt");
+    await writeFile(sourcePath, "atomic");
+    await commitLocalCoderArtifact({ sourcePath, hostArtifactPath, hostScratchRoot });
+    await expect(
+      verifyHostVisibleLocalCoderArtifact({
+        hostArtifactPath,
+        hostScratchRoot,
+        expectedSourcePath: sourcePath,
+      }),
+    ).resolves.toBe(true);
+  });
+
+  it("rejects commits outside shared scratch", async () => {
+    const root = await mkdtemp(join(tmpdir(), "local-coder-"));
+    tempRoots.push(root);
+    await expect(
+      commitLocalCoderArtifact({
+        sourcePath: join(root, "source.txt"),
+        hostArtifactPath: join(root, "outside.txt"),
+        hostScratchRoot: join(root, "host"),
+      }),
+    ).rejects.toThrow(/escapes shared scratch/);
+  });
+});

--- a/src/agents/local-coder-artifacts.ts
+++ b/src/agents/local-coder-artifacts.ts
@@ -1,0 +1,109 @@
+import { cp, lstat, mkdir, readFile, rename, symlink } from "node:fs/promises";
+import { dirname, isAbsolute, relative, resolve } from "node:path";
+
+export const LOCAL_CODER_AGENT_ID = "local-coder";
+export const LOCAL_CODER_SCRATCH_DIRNAME = "scratch";
+export const LOCAL_CODER_COMPLETION_CONTRACT =
+  "A local-coder completion with no verified output is a blocked terminal result. " +
+  "The local coder owns writes inside the shared scratch directory. " +
+  "The parent must not persist or copy the child's artifact onto its own path. " +
+  "Only host-visible artifacts under the allowed scratch directory may be reported.";
+
+export function resolveCanonicalPath(path: string): string {
+  return resolve(path);
+}
+
+export function isPathInsideRoot(path: string, root: string): boolean {
+  const remainder = relative(resolve(root), resolve(path));
+  return remainder === "" || (!remainder.startsWith("..") && !isAbsolute(remainder));
+}
+
+export function validateLocalCoderArtifactPath(
+  artifactPath: string,
+  params: { hostScratchRoot: string },
+): string {
+  const canonical = resolve(artifactPath);
+  if (
+    !isPathInsideRoot(canonical, params.hostScratchRoot) ||
+    canonical === resolve(params.hostScratchRoot)
+  ) {
+    throw new Error(`local-coder artifact path escapes shared scratch: ${artifactPath}`);
+  }
+  return canonical;
+}
+
+export type LocalCoderScratchRoots = { hostScratchRoot: string; coderScratchRoot: string };
+
+export function resolveLocalCoderScratchRoots(params: {
+  hostScratchRoot: string;
+  coderWorkspaceRoot: string;
+}): LocalCoderScratchRoots {
+  return {
+    hostScratchRoot: resolve(params.hostScratchRoot),
+    coderScratchRoot: resolve(params.coderWorkspaceRoot, LOCAL_CODER_SCRATCH_DIRNAME),
+  };
+}
+
+export async function ensureSharedLocalCoderScratch(
+  params: LocalCoderScratchRoots,
+): Promise<LocalCoderScratchRoots> {
+  const roots = {
+    hostScratchRoot: resolve(params.hostScratchRoot),
+    coderScratchRoot: resolve(params.coderScratchRoot),
+  };
+  await mkdir(roots.hostScratchRoot, { recursive: true });
+  await mkdir(dirname(roots.coderScratchRoot), { recursive: true });
+  try {
+    const current = await lstat(roots.coderScratchRoot);
+    if (!current.isSymbolicLink()) {
+      throw new Error(`local-coder scratch exists but is not a symlink: ${roots.coderScratchRoot}`);
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    await symlink(roots.hostScratchRoot, roots.coderScratchRoot, "dir");
+  }
+  return roots;
+}
+
+export async function commitLocalCoderArtifact(params: {
+  sourcePath: string;
+  hostArtifactPath: string;
+  hostScratchRoot: string;
+}): Promise<string> {
+  const destination = validateLocalCoderArtifactPath(params.hostArtifactPath, {
+    hostScratchRoot: params.hostScratchRoot,
+  });
+  const temporary = `${destination}.tmp-${process.pid}-${Date.now()}`;
+  await mkdir(dirname(destination), { recursive: true });
+  try {
+    await cp(resolve(params.sourcePath), temporary, { force: true });
+    await rename(temporary, destination);
+  } catch (error) {
+    await rename(temporary, `${temporary}.discarded`).catch(() => undefined);
+    throw error;
+  }
+  return destination;
+}
+
+export async function verifyHostVisibleLocalCoderArtifact(params: {
+  hostArtifactPath: string;
+  hostScratchRoot: string;
+  expectedSourcePath?: string;
+}): Promise<boolean> {
+  const destination = validateLocalCoderArtifactPath(params.hostArtifactPath, {
+    hostScratchRoot: params.hostScratchRoot,
+  });
+  try {
+    if (params.expectedSourcePath) {
+      const [actual, expected] = await Promise.all([
+        readFile(destination),
+        readFile(resolve(params.expectedSourcePath)),
+      ]);
+      return actual.equals(expected);
+    }
+    await lstat(destination);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/agents/local-coder-completion-contract.test.ts
+++ b/src/agents/local-coder-completion-contract.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import {
+  LOCAL_CODER_AGENT_ID,
+  LOCAL_CODER_COMPLETION_CONTRACT,
+  LOCAL_CODER_SCRATCH_DIRNAME,
+  validateLocalCoderArtifactPath,
+} from "./local-coder-artifacts.js";
+
+describe("local-coder completion contract", () => {
+  it("blocks a no-output terminal completion", () => {
+    expect(LOCAL_CODER_COMPLETION_CONTRACT).toContain("no verified output");
+    expect(LOCAL_CODER_COMPLETION_CONTRACT).toContain("blocked terminal");
+  });
+
+  it("enforces ownership and scratch path validation", () => {
+    expect(LOCAL_CODER_AGENT_ID).toBe("local-coder");
+    expect(LOCAL_CODER_SCRATCH_DIRNAME).toBe("scratch");
+    expect(LOCAL_CODER_COMPLETION_CONTRACT).toContain("owns writes");
+    expect(() =>
+      validateLocalCoderArtifactPath("/tmp/result.txt", { hostScratchRoot: "/tmp/scratch" }),
+    ).toThrow();
+  });
+
+  it("forbids parent-side persistence", () => {
+    expect(LOCAL_CODER_COMPLETION_CONTRACT).toContain(
+      "parent must not persist or copy the child's artifact",
+    );
+  });
+});

--- a/src/agents/openclaw-tools.subagents.sessions-spawn.model.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn.model.test.ts
@@ -257,4 +257,23 @@ describe("subagent spawn model + thinking plan", () => {
       }),
     ).toBe(0);
   });
+
+  it("prefers the target agent timeout over the global default", () => {
+    expect(
+      resolveConfiguredSubagentRunTimeoutSeconds({
+        cfg: createConfig({
+          agents: {
+            defaults: { subagents: { runTimeoutSeconds: 120 } },
+            list: [
+              {
+                id: "local-coder",
+                subagents: { runTimeoutSeconds: 900 },
+              },
+            ],
+          },
+        }),
+        targetAgentId: "local-coder",
+      }),
+    ).toBe(900);
+  });
 });

--- a/src/agents/subagent-announce.requester-settle-wake.test.ts
+++ b/src/agents/subagent-announce.requester-settle-wake.test.ts
@@ -866,5 +866,71 @@ describe("maybeWakeRequesterAfterAllChildrenSettled", () => {
       ).toBe(false);
       expect(completeBatchSpy).toHaveBeenLastCalledWith(["run-cron"]);
     });
+
+    it("does not wake a yielded frozen batch while the child is still running", async () => {
+      const liveChild = makeSettledChild({
+        runId: "run-live",
+        endedAt: undefined,
+        delivery: undefined,
+        completion: undefined,
+        requesterSettleWake: {
+          status: "pending",
+          attemptCount: 0,
+          batchRunIds: ["run-live"],
+          requesterYieldBatch: true,
+          rearmGeneration: 1,
+        },
+      });
+      registryRuntimeMock.listSubagentRunsForRequester.mockReturnValue([liveChild]);
+      registryRuntimeMock.hasDescendantRunAwaitingSettle.mockReturnValue(false);
+
+      expect(
+        await maybeWakeRequesterAfterAllChildrenSettled(wakeParams({ settledEntry: liveChild })),
+      ).toBe(false);
+      expect(deliverSpy).not.toHaveBeenCalled();
+      expect(completeBatchSpy).not.toHaveBeenCalled();
+    });
+
+    it("wakes only after every frozen batch member has a terminal endedAt", async () => {
+      const liveSibling = makeSettledChild({
+        runId: "run-live",
+        endedAt: undefined,
+        delivery: undefined,
+        requesterSettleWake: {
+          status: "pending",
+          attemptCount: 0,
+          batchRunIds: ["run-done", "run-live"],
+          requesterYieldBatch: true,
+          rearmGeneration: 2,
+        },
+      });
+      const doneSibling = makeSettledChild({
+        runId: "run-done",
+        completion: { required: true, resultText: "partial" },
+        requesterSettleWake: {
+          status: "pending",
+          attemptCount: 0,
+          batchRunIds: ["run-done", "run-live"],
+          requesterYieldBatch: true,
+          rearmGeneration: 2,
+        },
+      });
+      registryRuntimeMock.listSubagentRunsForRequester.mockReturnValue([doneSibling, liveSibling]);
+      registryRuntimeMock.hasDescendantRunAwaitingSettle.mockReturnValue(false);
+
+      expect(
+        await maybeWakeRequesterAfterAllChildrenSettled(wakeParams({ settledEntry: doneSibling })),
+      ).toBe(false);
+      expect(deliverSpy).not.toHaveBeenCalled();
+
+      liveSibling.endedAt = 5_000;
+      liveSibling.delivery = { status: "delivered" };
+      liveSibling.completion = { required: true, resultText: "late findings" };
+
+      expect(
+        await maybeWakeRequesterAfterAllChildrenSettled(wakeParams({ settledEntry: liveSibling })),
+      ).toBe(true);
+      expect(String(deliveredCallArg().triggerMessage)).toContain("late findings");
+    });
   });
 });

--- a/src/agents/subagent-announce.requester-settle-wake.ts
+++ b/src/agents/subagent-announce.requester-settle-wake.ts
@@ -211,6 +211,9 @@ export async function maybeWakeRequesterAfterAllChildrenSettled(params: {
   const requesterRuns = Array.isArray(listedRuns) ? listedRuns : [];
   const currentSettledEntry =
     requesterRuns.find((entry) => entry.runId === params.settledEntry.runId) ?? params.settledEntry;
+  if (!hasSubagentRunEnded(currentSettledEntry)) {
+    return false;
+  }
   if (!currentSettledEntry.requesterSettleWake) {
     return false;
   }
@@ -222,13 +225,23 @@ export async function maybeWakeRequesterAfterAllChildrenSettled(params: {
   let settledBatch: SubagentRunRecord[];
   if (frozenBatchRunIds && frozenBatchRunIds.length > 0) {
     const runsById = new Map(requesterRuns.map((entry) => [entry.runId, entry]));
-    settledBatch = frozenBatchRunIds
+    const frozenBatch = frozenBatchRunIds
       .map((runId) => runsById.get(runId))
       .filter(
         (entry): entry is SubagentRunRecord =>
           Boolean(entry?.requesterSettleWake) &&
           entry?.requesterSettleWake?.rearmGeneration === currentRearmGeneration,
       );
+    if (frozenBatch.length !== frozenBatchRunIds.length) {
+      return false;
+    }
+    if (frozenBatch.some((entry) => !hasSubagentRunEnded(entry))) {
+      return false;
+    }
+    settledBatch = frozenBatch.filter((entry) => hasSubagentRunEnded(entry));
+    if (settledBatch.length !== frozenBatchRunIds.length) {
+      return false;
+    }
   } else {
     settledBatch = buildConnectedSettledWave(
       requesterRuns.filter((entry) => entry.requesterSettleWake && hasSubagentRunEnded(entry)),

--- a/src/agents/subagent-light-context.test.ts
+++ b/src/agents/subagent-light-context.test.ts
@@ -1,8 +1,7 @@
 import { describe, expect, it } from "vitest";
-import {
-  resolveSubagentLightContext,
-  SMALL_CONTEXT_LIGHT_CONTEXT_TOKEN_LIMIT,
-} from "./subagent-light-context.js";
+import { resolveSubagentLightContext } from "./subagent-light-context.js";
+
+const SMALL_CONTEXT_LIGHT_CONTEXT_TOKEN_LIMIT = 65_536;
 
 describe("resolveSubagentLightContext", () => {
   it("honors explicit lightContext true", () => {

--- a/src/agents/subagent-light-context.test.ts
+++ b/src/agents/subagent-light-context.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveSubagentLightContext,
+  SMALL_CONTEXT_LIGHT_CONTEXT_TOKEN_LIMIT,
+} from "./subagent-light-context.js";
+
+describe("resolveSubagentLightContext", () => {
+  it("honors explicit lightContext true", () => {
+    expect(
+      resolveSubagentLightContext({
+        lightContext: true,
+        resolvedModel: "openrouter/deepseek/deepseek-v4-flash",
+        contextMode: "isolated",
+      }),
+    ).toBe(true);
+  });
+
+  it("honors explicit lightContext false even for ollama", () => {
+    expect(
+      resolveSubagentLightContext({
+        lightContext: false,
+        resolvedModel: "ollama/qwen2.5-coder:7b",
+        contextMode: "isolated",
+      }),
+    ).toBe(false);
+  });
+
+  it("auto-enables for ollama models on isolated spawns", () => {
+    expect(
+      resolveSubagentLightContext({
+        resolvedModel: "ollama/qwen2.5-coder:7b",
+        contextMode: "isolated",
+      }),
+    ).toBe(true);
+    expect(
+      resolveSubagentLightContext({
+        resolvedModel: "ollama/qwen3.5:9b",
+        contextMode: "isolated",
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps tiny-workspace bootstrap for the dedicated local-coder agent", () => {
+    expect(
+      resolveSubagentLightContext({
+        targetAgentId: "local-coder",
+        resolvedModel: "ollama/qwen2.5-coder:7b",
+        contextMode: "isolated",
+      }),
+    ).toBe(false);
+  });
+
+  it("still allows explicit lightContext on local-coder", () => {
+    expect(
+      resolveSubagentLightContext({
+        lightContext: true,
+        targetAgentId: "local-coder",
+        resolvedModel: "ollama/qwen2.5-coder:7b",
+        contextMode: "isolated",
+      }),
+    ).toBe(true);
+  });
+
+  it("auto-enables when context window is at or below the small-context limit", () => {
+    expect(
+      resolveSubagentLightContext({
+        resolvedModel: "openrouter/some/small-model",
+        contextWindow: SMALL_CONTEXT_LIGHT_CONTEXT_TOKEN_LIMIT,
+        contextMode: "isolated",
+      }),
+    ).toBe(true);
+    expect(
+      resolveSubagentLightContext({
+        resolvedModel: "openrouter/some/large-model",
+        contextWindow: SMALL_CONTEXT_LIGHT_CONTEXT_TOKEN_LIMIT + 1,
+        contextMode: "isolated",
+      }),
+    ).toBe(false);
+  });
+
+  it("does not auto-enable for fork context unless explicitly requested", () => {
+    expect(
+      resolveSubagentLightContext({
+        resolvedModel: "ollama/qwen2.5-coder:7b",
+        contextMode: "fork",
+      }),
+    ).toBe(false);
+  });
+
+  it("does not auto-enable for cloud models without a small context window", () => {
+    expect(
+      resolveSubagentLightContext({
+        resolvedModel: "openrouter/deepseek/deepseek-v4-flash",
+        contextMode: "isolated",
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/agents/subagent-light-context.ts
+++ b/src/agents/subagent-light-context.ts
@@ -9,9 +9,9 @@
 import { splitModelRef } from "./subagent-spawn-plan.js";
 
 /** Models at or below this context window auto-enable lightContext. */
-export const SMALL_CONTEXT_LIGHT_CONTEXT_TOKEN_LIMIT = 65_536;
+const SMALL_CONTEXT_LIGHT_CONTEXT_TOKEN_LIMIT = 65_536;
 
-export type ResolveSubagentLightContextParams = {
+type ResolveSubagentLightContextParams = {
   /** Explicit sessions_spawn.lightContext override. */
   lightContext?: boolean;
   /** Resolved child model ref (provider/model). */

--- a/src/agents/subagent-light-context.ts
+++ b/src/agents/subagent-light-context.ts
@@ -1,0 +1,72 @@
+/**
+ * Decides when native subagent spawns should use lightweight bootstrap context.
+ *
+ * Full Lisa-sized workspace bootstrap (~40k+ chars) overflows small local
+ * models (e.g. ollama/qwen2.5-coder:7b at 32k with a 20k reserve). Isolated
+ * coding workers should either use lightContext (empty bootstrap + task text)
+ * or a dedicated tiny workspace such as `local-coder`.
+ */
+import { splitModelRef } from "./subagent-spawn-plan.js";
+
+/** Models at or below this context window auto-enable lightContext. */
+export const SMALL_CONTEXT_LIGHT_CONTEXT_TOKEN_LIMIT = 65_536;
+
+export type ResolveSubagentLightContextParams = {
+  /** Explicit sessions_spawn.lightContext override. */
+  lightContext?: boolean;
+  /** Resolved child model ref (provider/model). */
+  resolvedModel?: string;
+  /** Optional catalog/config context window for the resolved model. */
+  contextWindow?: number;
+  /** Target agent id (local-coder keeps its own tiny AGENTS.md). */
+  targetAgentId?: string;
+  /** Spawn context mode; fork keeps full bootstrap unless explicitly light. */
+  contextMode?: "isolated" | "fork";
+};
+
+/**
+ * Returns whether the child run should use bootstrapContextMode=lightweight.
+ *
+ * Priority:
+ * 1. Explicit lightContext true/false wins.
+ * 2. Dedicated local-coder agent keeps its tiny workspace bootstrap (not light)
+ *    unless the caller explicitly sets lightContext=true.
+ * 3. Ollama models auto-enable on isolated spawns (Lisa main workspace is too large).
+ * 4. Known context windows <= 65_536 auto-enable on isolated spawns.
+ */
+export function resolveSubagentLightContext(params: ResolveSubagentLightContextParams): boolean {
+  if (params.lightContext === true) {
+    return true;
+  }
+  if (params.lightContext === false) {
+    return false;
+  }
+  if (params.contextMode === "fork") {
+    return false;
+  }
+
+  const targetAgentId = params.targetAgentId?.trim().toLowerCase();
+  // local-coder has a purpose-built tiny workspace; inject that AGENTS.md instead
+  // of stripping bootstrap entirely.
+  if (targetAgentId === "local-coder") {
+    return false;
+  }
+
+  if (
+    typeof params.contextWindow === "number" &&
+    Number.isFinite(params.contextWindow) &&
+    params.contextWindow > 0
+  ) {
+    return params.contextWindow <= SMALL_CONTEXT_LIGHT_CONTEXT_TOKEN_LIMIT;
+  }
+
+  const { provider, model } = splitModelRef(params.resolvedModel);
+  if (provider === "ollama") {
+    return true;
+  }
+  // Model-only refs sometimes omit provider; treat known local coder tags as small.
+  if (model && /qwen2\.5-coder|coder:7b|gemma4:e2b/i.test(model)) {
+    return true;
+  }
+  return false;
+}

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -1447,6 +1447,9 @@ async function sweepSubagentRuns() {
     }
     for (const [runId, entry] of subagentRuns.entries()) {
       if (entry.requesterSettleWake) {
+        if (!Number.isFinite(entry.endedAt)) {
+          continue;
+        }
         resumeRequesterSettleWake(runId, entry);
         continue;
       }

--- a/src/agents/subagent-spawn-plan.ts
+++ b/src/agents/subagent-spawn-plan.ts
@@ -6,6 +6,7 @@
 import { formatThinkingLevels } from "../auto-reply/thinking.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { FastMode } from "../shared/fast-mode.js";
+import { resolveAgentConfig } from "./agent-scope-config.js";
 import {
   resolveDefaultModelForAgent,
   resolveSubagentConfiguredModelSelection,
@@ -39,12 +40,19 @@ export function splitModelRef(ref?: string) {
 /** Resolves the effective subagent run timeout from per-call override or config default. */
 export function resolveConfiguredSubagentRunTimeoutSeconds(params: {
   cfg: OpenClawConfig;
+  targetAgentId?: string;
   runTimeoutSeconds?: number;
 }) {
+  const targetAgentTimeout = params.targetAgentId
+    ? resolveAgentConfig(params.cfg, params.targetAgentId)?.subagents?.runTimeoutSeconds
+    : undefined;
+  const configuredTimeout =
+    typeof targetAgentTimeout === "number" && Number.isFinite(targetAgentTimeout)
+      ? targetAgentTimeout
+      : params.cfg?.agents?.defaults?.subagents?.runTimeoutSeconds;
   const cfgSubagentTimeout =
-    typeof params.cfg?.agents?.defaults?.subagents?.runTimeoutSeconds === "number" &&
-    Number.isFinite(params.cfg.agents.defaults.subagents.runTimeoutSeconds)
-      ? Math.max(0, Math.floor(params.cfg.agents.defaults.subagents.runTimeoutSeconds))
+    typeof configuredTimeout === "number" && Number.isFinite(configuredTimeout)
+      ? Math.max(0, Math.floor(configuredTimeout))
       : 0;
   return typeof params.runTimeoutSeconds === "number" && Number.isFinite(params.runTimeoutSeconds)
     ? Math.max(0, Math.floor(params.runTimeoutSeconds))

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -5,6 +5,7 @@
  */
 import crypto from "node:crypto";
 import { promises as fs } from "node:fs";
+import path from "node:path";
 import { finiteSecondsToTimerSafeMilliseconds } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { isAcpRuntimeSpawnAvailable } from "../acp/runtime/availability.js";
@@ -30,6 +31,7 @@ import type { FastMode } from "../shared/fast-mode.js";
 import { resolveUserPath } from "../utils.js";
 import type { DeliveryContext } from "../utils/delivery-context.types.js";
 import { listAgentIds, resolveAgentDir } from "./agent-scope-config.js";
+import { resolveAgentWorkspaceDir } from "./agent-scope.js";
 import type { BootstrapContextMode } from "./bootstrap-files.js";
 import { resolveFastModeState } from "./fast-mode.js";
 import {
@@ -38,6 +40,11 @@ import {
   normalizeInheritedToolAllowlist,
   normalizeInheritedToolDenylist,
 } from "./inherited-tool-deny.js";
+import {
+  ensureSharedLocalCoderScratch,
+  LOCAL_CODER_SCRATCH_DIRNAME,
+  resolveLocalCoderScratchRoots,
+} from "./local-coder-artifacts.js";
 import { findModelCatalogEntry } from "./model-catalog-lookup.js";
 import {
   normalizeStoredOverrideModel,
@@ -1042,13 +1049,6 @@ export async function spawnSubagentDirect(
   const hookRunner = subagentSpawnDeps.getGlobalHookRunner();
   const cfg = loadSubagentConfig();
 
-  // When agent omits runTimeoutSeconds, use the config default.
-  // Falls back to 0 (no timeout) if config key is also unset,
-  // preserving current behavior for existing deployments.
-  const runTimeoutSeconds = resolveConfiguredSubagentRunTimeoutSeconds({
-    cfg,
-    runTimeoutSeconds: params.runTimeoutSeconds,
-  });
   let modelApplied = false;
   let threadBindingReady = false;
   let hasBoundThreadDeliveryOrigin = false;
@@ -1116,6 +1116,12 @@ export async function spawnSubagentDirect(
     }
   }
   const targetAgentId = requestedAgentId ? normalizeAgentId(requestedAgentId) : requesterAgentId;
+  // Prefer target-agent timeout (e.g. local-coder 900s), then defaults (0 = none).
+  const runTimeoutSeconds = resolveConfiguredSubagentRunTimeoutSeconds({
+    cfg,
+    runTimeoutSeconds: params.runTimeoutSeconds,
+    targetAgentId,
+  });
   const configuredAgentIds = resolveConfiguredAgentIds(cfg);
   const explicitSwarmGroupId = normalizeOptionalString(params.groupId);
   const requesterRunId = normalizeOptionalString(ctx.requesterRunId);
@@ -1210,6 +1216,23 @@ export async function spawnSubagentDirect(
       targetAgentId,
       explicitWorkspaceDir: inheritedWorkspaceDir,
     });
+    if (targetAgentId === "local-coder") {
+      try {
+        const mainWorkspaceDir = resolveAgentWorkspaceDir(cfg, requesterAgentId);
+        await ensureSharedLocalCoderScratch(
+          resolveLocalCoderScratchRoots({
+            hostScratchRoot: path.join(mainWorkspaceDir, LOCAL_CODER_SCRATCH_DIRNAME),
+            coderWorkspaceRoot: spawnedWorkspaceDir,
+          }),
+        );
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return {
+          status: "error",
+          error: `local-coder shared scratch setup failed: ${message}`,
+        };
+      }
+    }
     const requesterOrigin = normalizeDeliveryContext({
       channel: ctx.agentChannel,
       accountId: ctx.agentAccountId,

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -69,6 +69,7 @@ import {
   type SubagentAttachmentReceiptFile,
 } from "./subagent-attachments.js";
 import { buildSubagentInitialUserMessage } from "./subagent-initial-user-message.js";
+import { resolveSubagentLightContext } from "./subagent-light-context.js";
 import {
   completeCollectorLaunchCleanup,
   listSwarmRunsForGroup,
@@ -1482,7 +1483,13 @@ export async function spawnSubagentDirect(
       childSystemPrompt = `${childSystemPrompt}\n\n${materializedAttachments.systemPromptSuffix}`;
     }
 
-    const bootstrapContextMode: BootstrapContextMode | undefined = params.lightContext
+    const useLightContext = resolveSubagentLightContext({
+      lightContext: params.lightContext,
+      resolvedModel,
+      contextMode,
+      targetAgentId,
+    });
+    const bootstrapContextMode: BootstrapContextMode | undefined = useLightContext
       ? "lightweight"
       : undefined;
 
@@ -1637,7 +1644,7 @@ export async function spawnSubagentDirect(
     const adapter: SpawnBackendAdapter<SubagentBackendState> = {
       async initialize() {
         const result =
-          params.lightContext && preparedSpawnContext.mode === "isolated"
+          useLightContext && preparedSpawnContext.mode === "isolated"
             ? ({ status: "ok", preparation: undefined } as const)
             : await prepareContextEngineSubagentSpawn({
                 cfg,

--- a/src/agents/subagent-spawn.workspace.test.ts
+++ b/src/agents/subagent-spawn.workspace.test.ts
@@ -280,7 +280,12 @@ describe("spawnSubagentDirect workspace inheritance", () => {
     expect(hoisted.registerSubagentRunMock).not.toHaveBeenCalled();
   });
 
-  async function spawnAndReadAgentParams(task: { task: string; lightContext?: boolean }) {
+  async function spawnAndReadAgentParams(task: {
+    task: string;
+    lightContext?: boolean;
+    model?: string;
+    agentId?: string;
+  }) {
     await spawnSubagentDirect(task, {
       agentSessionKey: "agent:main:main",
       agentChannel: "telegram",
@@ -299,6 +304,16 @@ describe("spawnSubagentDirect workspace inheritance", () => {
     const agentParams = await spawnAndReadAgentParams({
       task: "inspect workspace",
       lightContext: true,
+    });
+
+    expect(agentParams?.bootstrapContextMode).toBe("lightweight");
+    expect(agentParams?.bootstrapContextRunKind).toBe("default");
+  });
+
+  it("auto-enables lightweight bootstrap for ollama model overrides", async () => {
+    const agentParams = await spawnAndReadAgentParams({
+      task: "write a prime checker",
+      model: "ollama/qwen2.5-coder:7b",
     });
 
     expect(agentParams?.bootstrapContextMode).toBe("lightweight");

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -144,6 +144,7 @@ export type AgentConfig = {
     model?: AgentModelConfig;
     /** Per-agent default thinking level for spawned sub-agents. */
     thinking?: string;
+    runTimeoutSeconds?: number;
     /** Require explicit agentId in sessions_spawn (no default same-as-caller). */
     requireAgentId?: boolean;
   };

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -994,6 +994,7 @@ export const AgentEntrySchema = z
         allowAgents: z.array(z.string()).optional(),
         model: AgentModelSchema.optional(),
         thinking: z.string().optional(),
+        runTimeoutSeconds: z.number().int().min(0).optional(),
         requireAgentId: z.boolean().optional(),
       })
       .strict()

--- a/src/infra/exec-approvals-config.test.ts
+++ b/src/infra/exec-approvals-config.test.ts
@@ -138,6 +138,51 @@ describe("exec approvals node host allowlist check", () => {
   });
 });
 
+describe("exec approvals denylist config", () => {
+  it("merges wildcard denylist entries with agent entries", () => {
+    const resolved = resolveExecApprovalsFromFile({
+      file: {
+        version: 1,
+        agents: {
+          "*": { denylist: [{ pattern: "git push*--force*" }] },
+          main: { denylist: [{ pattern: "launchctl*" }] },
+        },
+      },
+      agentId: "main",
+    });
+    expect(resolved.denylist.map((entry) => entry.pattern)).toEqual([
+      "git push*--force*",
+      "launchctl*",
+    ]);
+  });
+
+  it("resolves an empty denylist when none is configured", () => {
+    const resolved = resolveExecApprovalsFromFile({ file: { version: 1 } });
+    expect(resolved.denylist).toEqual([]);
+  });
+
+  it("drops malformed denylist entries during normalization", () => {
+    const denylist = [
+      { pattern: "  rm -rf /*  " },
+      { pattern: "" },
+      "rm -rf /",
+    ] as unknown as NonNullable<ExecApprovalsAgent["denylist"]>;
+    const normalized = normalizeExecApprovals({
+      version: 1,
+      agents: { main: { denylist } },
+    });
+    expect(normalized.agents?.main?.denylist).toEqual([{ pattern: "rm -rf /*" }]);
+  });
+
+  it("keeps agents without denylist untouched during normalization", () => {
+    const normalized = normalizeExecApprovals({
+      version: 1,
+      agents: { main: { allowlist: [{ pattern: "/bin/hostname" }] } },
+    });
+    expect(normalized.agents?.main?.denylist).toBeUndefined();
+  });
+});
+
 describe("exec approvals default agent migration", () => {
   it("migrates legacy default agent entries to main", () => {
     const file: ExecApprovalsFile = {

--- a/src/infra/exec-approvals-denylist.test.ts
+++ b/src/infra/exec-approvals-denylist.test.ts
@@ -6,8 +6,8 @@ import {
   sanitizeExecDenylistEntries,
   shouldHardDenyUnanalyzableDenylistHit,
   type ExecCommandSegment,
-  type ExecDenylistEntry,
 } from "./exec-approvals.js";
+import type { ExecDenylistEntry } from "./exec-approvals.types.js";
 import { planShellAuthorization } from "./exec-authorization-plan.js";
 
 async function evaluateCommand(command: string, patterns: string[], platform = "linux") {

--- a/src/infra/exec-approvals-denylist.test.ts
+++ b/src/infra/exec-approvals-denylist.test.ts
@@ -2,7 +2,9 @@
 import { describe, expect, it } from "vitest";
 import {
   evaluateExecDenylist,
+  formatUnanalyzableDenylistHardDenyMessage,
   sanitizeExecDenylistEntries,
+  shouldHardDenyUnanalyzableDenylistHit,
   type ExecCommandSegment,
   type ExecDenylistEntry,
 } from "./exec-approvals.js";
@@ -181,5 +183,49 @@ describe("evaluateExecDenylist", () => {
     expect(evaluation.matched).toBe(true);
     expect(evaluation.entry?.pattern).toBe("launchctl*");
     expect(evaluation.matchedText).toContain("launchctl");
+  });
+});
+
+describe("shouldHardDenyUnanalyzableDenylistHit", () => {
+  it("hard-denies only yolo + unanalyzable hits", () => {
+    const unanalyzable = {
+      matched: true,
+      entry: null,
+      matchedText: null,
+      unanalyzable: true,
+    };
+    const patternHit = {
+      matched: true,
+      entry: { pattern: "gws auth logout*" },
+      matchedText: "gws auth logout",
+      unanalyzable: false,
+    };
+    expect(
+      shouldHardDenyUnanalyzableDenylistHit({
+        security: "full",
+        ask: "off",
+        evaluation: unanalyzable,
+      }),
+    ).toBe(true);
+    expect(
+      shouldHardDenyUnanalyzableDenylistHit({
+        security: "full",
+        ask: "off",
+        evaluation: patternHit,
+      }),
+    ).toBe(false);
+    expect(
+      shouldHardDenyUnanalyzableDenylistHit({
+        security: "full",
+        ask: "on-miss",
+        evaluation: unanalyzable,
+      }),
+    ).toBe(false);
+  });
+
+  it("formats a remediation message for opaque shell", () => {
+    const message = formatUnanalyzableDenylistHardDenyMessage("cat file 2>&1");
+    expect(message).toContain("lisa-safe");
+    expect(message).toContain("Refused command: cat file 2>&1");
   });
 });

--- a/src/infra/exec-approvals-denylist.test.ts
+++ b/src/infra/exec-approvals-denylist.test.ts
@@ -1,19 +1,23 @@
 // Covers exec denylist (STOP-list) screening over analyzed command segments.
 import { describe, expect, it } from "vitest";
 import {
-  analyzeShellCommand,
   evaluateExecDenylist,
   sanitizeExecDenylistEntries,
   type ExecCommandSegment,
   type ExecDenylistEntry,
 } from "./exec-approvals.js";
+import { planShellAuthorization } from "./exec-authorization-plan.js";
 
-function evaluateCommand(command: string, patterns: string[], platform = "linux") {
-  const analysis = analyzeShellCommand({ command, platform });
+async function evaluateCommand(command: string, patterns: string[], platform = "linux") {
+  // Upstream replaced sync analyzeShellCommand with async shell planning.
+  const plan = await planShellAuthorization({ command, platform });
+  const segments = plan.ok
+    ? plan.groups.flatMap((group) => group.candidates.map((candidate) => candidate.sourceSegment))
+    : [];
   return evaluateExecDenylist({
     denylist: patterns.map((pattern): ExecDenylistEntry => ({ pattern })),
-    segments: analysis.segments,
-    analysisOk: analysis.ok,
+    segments,
+    analysisOk: plan.ok,
     platform,
   });
 }
@@ -47,46 +51,48 @@ describe("sanitizeExecDenylistEntries", () => {
 });
 
 describe("evaluateExecDenylist", () => {
-  it("matches a denylisted command", () => {
-    const evaluation = evaluateCommand("git push --force origin main", ["git push --force*"]);
+  it("matches a denylisted command", async () => {
+    const evaluation = await evaluateCommand("git push --force origin main", ["git push --force*"]);
     expect(evaluation.matched).toBe(true);
     expect(evaluation.unanalyzable).toBe(false);
     expect(evaluation.entry?.pattern).toBe("git push --force*");
   });
 
-  it("matches flags appearing later in the command", () => {
-    const evaluation = evaluateCommand("git push origin main --force", ["git push*--force*"]);
+  it("matches flags appearing later in the command", async () => {
+    const evaluation = await evaluateCommand("git push origin main --force", ["git push*--force*"]);
     expect(evaluation.matched).toBe(true);
   });
 
-  it("does not match commands outside the denylist", () => {
-    const evaluation = evaluateCommand("git push origin main", ["git push*--force*"]);
+  it("does not match commands outside the denylist", async () => {
+    const evaluation = await evaluateCommand("git push origin main", ["git push*--force*"]);
     expect(evaluation.matched).toBe(false);
     expect(evaluation.entry).toBeNull();
   });
 
-  it("matches path-prefixed executables through the basename variant", () => {
-    const evaluation = evaluateCommand("/usr/bin/git push --force", ["git push --force*"]);
+  it("matches path-prefixed executables through the basename variant", async () => {
+    const evaluation = await evaluateCommand("/usr/bin/git push --force", ["git push --force*"]);
     expect(evaluation.matched).toBe(true);
   });
 
-  it("matches denylisted parts inside command chains", () => {
-    const evaluation = evaluateCommand("echo ok && git push --force", ["git push*--force*"]);
+  it("matches denylisted parts inside command chains", async () => {
+    const evaluation = await evaluateCommand("echo ok && git push --force", ["git push*--force*"]);
     expect(evaluation.matched).toBe(true);
   });
 
-  it("matches denylisted payloads inside POSIX inline shell wrappers", () => {
-    const evaluation = evaluateCommand(`bash -c "git push --force"`, ["git push*--force*"]);
+  it("matches denylisted payloads inside POSIX inline shell wrappers", async () => {
+    const evaluation = await evaluateCommand(`bash -c "git push --force"`, ["git push*--force*"]);
     expect(evaluation.matched).toBe(true);
   });
 
-  it("does not match quoted denylist text passed as data arguments", () => {
-    const evaluation = evaluateCommand(`grep "git push --force" README.md`, ["git push*--force*"]);
+  it("does not match quoted denylist text passed as data arguments", async () => {
+    const evaluation = await evaluateCommand(`grep "git push --force" README.md`, [
+      "git push*--force*",
+    ]);
     expect(evaluation.matched).toBe(false);
   });
 
-  it("treats unanalyzable commands as conservative hits when a denylist exists", () => {
-    const evaluation = evaluateExecDenylist({
+  it("treats unanalyzable commands as conservative hits when a denylist exists", async () => {
+    const evaluation = await evaluateExecDenylist({
       denylist: [{ pattern: "git push*--force*" }],
       segments: [],
       analysisOk: false,
@@ -97,8 +103,8 @@ describe("evaluateExecDenylist", () => {
     expect(evaluation.entry).toBeNull();
   });
 
-  it("never matches when the denylist is empty, even for unanalyzable commands", () => {
-    const evaluation = evaluateExecDenylist({
+  it("never matches when the denylist is empty, even for unanalyzable commands", async () => {
+    const evaluation = await evaluateExecDenylist({
       denylist: [],
       segments: [],
       analysisOk: false,
@@ -108,8 +114,8 @@ describe("evaluateExecDenylist", () => {
     expect(evaluation.unanalyzable).toBe(false);
   });
 
-  it("never matches when all entries are malformed", () => {
-    const evaluation = evaluateExecDenylist({
+  it("never matches when all entries are malformed", async () => {
+    const evaluation = await evaluateExecDenylist({
       denylist: [{ pattern: "   " }] as ExecDenylistEntry[],
       segments: [],
       analysisOk: false,
@@ -118,15 +124,15 @@ describe("evaluateExecDenylist", () => {
     expect(evaluation.matched).toBe(false);
   });
 
-  it("treats nested inline wrappers beyond the depth cap as conservative hits", () => {
-    const evaluation = evaluateCommand(`bash -c "bash -c \\"bash -c 'git push --force'\\""`, [
+  it("treats nested inline wrappers beyond the depth cap as conservative hits", async () => {
+    const evaluation = await evaluateCommand(`bash -c "bash -c \\"bash -c 'git push --force'\\""`, [
       "git push*--force*",
     ]);
     expect(evaluation.matched).toBe(true);
   });
 
-  it("treats cmd.exe inline payloads as conservative hits", () => {
-    const evaluation = evaluateExecDenylist({
+  it("treats cmd.exe inline payloads as conservative hits", async () => {
+    const evaluation = await evaluateExecDenylist({
       denylist: [{ pattern: "git push*--force*" }],
       segments: [syntheticSegment(["cmd.exe", "/c", "git push --force"])],
       analysisOk: true,
@@ -136,8 +142,8 @@ describe("evaluateExecDenylist", () => {
     expect(evaluation.unanalyzable).toBe(true);
   });
 
-  it("treats powershell inline payloads as conservative hits", () => {
-    const evaluation = evaluateExecDenylist({
+  it("treats powershell inline payloads as conservative hits", async () => {
+    const evaluation = await evaluateExecDenylist({
       denylist: [{ pattern: "git push*--force*" }],
       segments: [syntheticSegment(["pwsh", "-Command", "git push --force"])],
       analysisOk: true,
@@ -147,8 +153,8 @@ describe("evaluateExecDenylist", () => {
     expect(evaluation.unanalyzable).toBe(true);
   });
 
-  it("matches case-insensitively on Windows", () => {
-    const evaluation = evaluateExecDenylist({
+  it("matches case-insensitively on Windows", async () => {
+    const evaluation = await evaluateExecDenylist({
       denylist: [{ pattern: "git push*--force*" }],
       segments: [syntheticSegment(["GIT", "push", "--FORCE"])],
       analysisOk: true,
@@ -157,8 +163,8 @@ describe("evaluateExecDenylist", () => {
     expect(evaluation.matched).toBe(true);
   });
 
-  it("matches case-sensitively on POSIX", () => {
-    const evaluation = evaluateExecDenylist({
+  it("matches case-sensitively on POSIX", async () => {
+    const evaluation = await evaluateExecDenylist({
       denylist: [{ pattern: "git push*--force*" }],
       segments: [syntheticSegment(["GIT", "push", "--FORCE"])],
       analysisOk: true,
@@ -167,8 +173,8 @@ describe("evaluateExecDenylist", () => {
     expect(evaluation.matched).toBe(false);
   });
 
-  it("reports the first matching entry for operator-facing messages", () => {
-    const evaluation = evaluateCommand("launchctl kickstart -k system/foo", [
+  it("reports the first matching entry for operator-facing messages", async () => {
+    const evaluation = await evaluateCommand("launchctl kickstart -k system/foo", [
       "rm -rf*",
       "launchctl*",
     ]);

--- a/src/infra/exec-approvals-denylist.test.ts
+++ b/src/infra/exec-approvals-denylist.test.ts
@@ -1,0 +1,179 @@
+// Covers exec denylist (STOP-list) screening over analyzed command segments.
+import { describe, expect, it } from "vitest";
+import {
+  analyzeShellCommand,
+  evaluateExecDenylist,
+  sanitizeExecDenylistEntries,
+  type ExecCommandSegment,
+  type ExecDenylistEntry,
+} from "./exec-approvals.js";
+
+function evaluateCommand(command: string, patterns: string[], platform = "linux") {
+  const analysis = analyzeShellCommand({ command, platform });
+  return evaluateExecDenylist({
+    denylist: patterns.map((pattern): ExecDenylistEntry => ({ pattern })),
+    segments: analysis.segments,
+    analysisOk: analysis.ok,
+    platform,
+  });
+}
+
+function syntheticSegment(argv: string[]): ExecCommandSegment {
+  return { raw: argv.join(" "), argv, resolution: null };
+}
+
+describe("sanitizeExecDenylistEntries", () => {
+  it("keeps valid entries and preserves array identity when nothing changes", () => {
+    const entries: ExecDenylistEntry[] = [{ pattern: "git push*--force*", reason: "stop list" }];
+    expect(sanitizeExecDenylistEntries(entries)).toBe(entries);
+  });
+
+  it("drops malformed entries and trims patterns", () => {
+    const sanitized = sanitizeExecDenylistEntries([
+      { pattern: "  git push*  " },
+      { pattern: "   " },
+      { pattern: 42 },
+      "git push*",
+      null,
+      {},
+    ]);
+    expect(sanitized).toEqual([{ pattern: "git push*" }]);
+  });
+
+  it("returns an empty list for non-array input", () => {
+    expect(sanitizeExecDenylistEntries(undefined)).toEqual([]);
+    expect(sanitizeExecDenylistEntries("git push*")).toEqual([]);
+  });
+});
+
+describe("evaluateExecDenylist", () => {
+  it("matches a denylisted command", () => {
+    const evaluation = evaluateCommand("git push --force origin main", ["git push --force*"]);
+    expect(evaluation.matched).toBe(true);
+    expect(evaluation.unanalyzable).toBe(false);
+    expect(evaluation.entry?.pattern).toBe("git push --force*");
+  });
+
+  it("matches flags appearing later in the command", () => {
+    const evaluation = evaluateCommand("git push origin main --force", ["git push*--force*"]);
+    expect(evaluation.matched).toBe(true);
+  });
+
+  it("does not match commands outside the denylist", () => {
+    const evaluation = evaluateCommand("git push origin main", ["git push*--force*"]);
+    expect(evaluation.matched).toBe(false);
+    expect(evaluation.entry).toBeNull();
+  });
+
+  it("matches path-prefixed executables through the basename variant", () => {
+    const evaluation = evaluateCommand("/usr/bin/git push --force", ["git push --force*"]);
+    expect(evaluation.matched).toBe(true);
+  });
+
+  it("matches denylisted parts inside command chains", () => {
+    const evaluation = evaluateCommand("echo ok && git push --force", ["git push*--force*"]);
+    expect(evaluation.matched).toBe(true);
+  });
+
+  it("matches denylisted payloads inside POSIX inline shell wrappers", () => {
+    const evaluation = evaluateCommand(`bash -c "git push --force"`, ["git push*--force*"]);
+    expect(evaluation.matched).toBe(true);
+  });
+
+  it("does not match quoted denylist text passed as data arguments", () => {
+    const evaluation = evaluateCommand(`grep "git push --force" README.md`, ["git push*--force*"]);
+    expect(evaluation.matched).toBe(false);
+  });
+
+  it("treats unanalyzable commands as conservative hits when a denylist exists", () => {
+    const evaluation = evaluateExecDenylist({
+      denylist: [{ pattern: "git push*--force*" }],
+      segments: [],
+      analysisOk: false,
+      platform: "linux",
+    });
+    expect(evaluation.matched).toBe(true);
+    expect(evaluation.unanalyzable).toBe(true);
+    expect(evaluation.entry).toBeNull();
+  });
+
+  it("never matches when the denylist is empty, even for unanalyzable commands", () => {
+    const evaluation = evaluateExecDenylist({
+      denylist: [],
+      segments: [],
+      analysisOk: false,
+      platform: "linux",
+    });
+    expect(evaluation.matched).toBe(false);
+    expect(evaluation.unanalyzable).toBe(false);
+  });
+
+  it("never matches when all entries are malformed", () => {
+    const evaluation = evaluateExecDenylist({
+      denylist: [{ pattern: "   " }] as ExecDenylistEntry[],
+      segments: [],
+      analysisOk: false,
+      platform: "linux",
+    });
+    expect(evaluation.matched).toBe(false);
+  });
+
+  it("treats nested inline wrappers beyond the depth cap as conservative hits", () => {
+    const evaluation = evaluateCommand(`bash -c "bash -c \\"bash -c 'git push --force'\\""`, [
+      "git push*--force*",
+    ]);
+    expect(evaluation.matched).toBe(true);
+  });
+
+  it("treats cmd.exe inline payloads as conservative hits", () => {
+    const evaluation = evaluateExecDenylist({
+      denylist: [{ pattern: "git push*--force*" }],
+      segments: [syntheticSegment(["cmd.exe", "/c", "git push --force"])],
+      analysisOk: true,
+      platform: "win32",
+    });
+    expect(evaluation.matched).toBe(true);
+    expect(evaluation.unanalyzable).toBe(true);
+  });
+
+  it("treats powershell inline payloads as conservative hits", () => {
+    const evaluation = evaluateExecDenylist({
+      denylist: [{ pattern: "git push*--force*" }],
+      segments: [syntheticSegment(["pwsh", "-Command", "git push --force"])],
+      analysisOk: true,
+      platform: "linux",
+    });
+    expect(evaluation.matched).toBe(true);
+    expect(evaluation.unanalyzable).toBe(true);
+  });
+
+  it("matches case-insensitively on Windows", () => {
+    const evaluation = evaluateExecDenylist({
+      denylist: [{ pattern: "git push*--force*" }],
+      segments: [syntheticSegment(["GIT", "push", "--FORCE"])],
+      analysisOk: true,
+      platform: "win32",
+    });
+    expect(evaluation.matched).toBe(true);
+  });
+
+  it("matches case-sensitively on POSIX", () => {
+    const evaluation = evaluateExecDenylist({
+      denylist: [{ pattern: "git push*--force*" }],
+      segments: [syntheticSegment(["GIT", "push", "--FORCE"])],
+      analysisOk: true,
+      platform: "linux",
+    });
+    expect(evaluation.matched).toBe(false);
+  });
+
+  it("reports the first matching entry for operator-facing messages", () => {
+    const evaluation = evaluateCommand("launchctl kickstart -k system/foo", [
+      "rm -rf*",
+      "launchctl*",
+    ]);
+    expect(evaluation.matched).toBe(true);
+    expect(evaluation.entry?.pattern).toBe("launchctl*");
+    expect(evaluation.matchedText).toContain("launchctl");
+  });
+});

--- a/src/infra/exec-approvals-denylist.ts
+++ b/src/infra/exec-approvals-denylist.ts
@@ -265,5 +265,43 @@ export function formatExecDenylistWarning(evaluation: ExecDenylistEvaluation): s
     return "Warning: command could not be analyzed for denylist screening; explicit approval is required.";
   }
   const reason = evaluation.entry?.reason ? ` (${evaluation.entry.reason})` : "";
-  return `Warning: command matches exec denylist entry ${evaluation.entry?.pattern ?? "unknown"}${reason}; explicit approval is required.`;
+  return `Warning: command matches exec denylist entry ${evaluation.entry?.pattern ?? "unknown"}${reason}; explicit approval is required (Ask=off does not bypass the STOP list).`;
+}
+
+/**
+ * In yolo mode (`security=full` + `ask=off`), unanalyzable denylist hits must not
+ * open a human approval prompt. Conservatively refusing the opaque command (so
+ * the agent retries an analyzable form) is fail-closed for the STOP list without
+ * turning every pipe/redirect/`$()` improvisation into a one-shot Allow-once
+ * card for the operator. Pattern-matched denylist hits still require approval.
+ */
+export function shouldHardDenyUnanalyzableDenylistHit(params: {
+  security: string;
+  ask: string;
+  evaluation: ExecDenylistEvaluation;
+}): boolean {
+  return (
+    params.evaluation.matched &&
+    params.evaluation.unanalyzable &&
+    params.security === "full" &&
+    params.ask === "off"
+  );
+}
+
+/** Operator/agent-facing denial when yolo mode hard-denies an opaque command. */
+export function formatUnanalyzableDenylistHardDenyMessage(command?: string): string {
+  const commandLine = command?.trim() ? `\nRefused command: ${command.trim()}` : "";
+  return [
+    "SYSTEM_RUN_DENIED: command could not be analyzed for denylist screening.",
+    "Ask=off / security=full does not auto-allow opaque shell (pipes, redirects,",
+    "command substitution, `||`/`&&` chains the planner cannot prove miss the STOP list).",
+    "Retry with an analyzable form:",
+    "- prefer native `read` / `write` / `list` / `glob` / `sessions_*` tools for files and sessions",
+    "- use bare `gws … --help` (no `| head`, no `2>&1`)",
+    "- for email / Drive / Docs with large bodies or JSON, use `tools/bin/lisa-safe` subcommands",
+    "- never embed large multiline bodies or `$(cat …)` in the exec command line",
+    commandLine,
+  ]
+    .filter((line) => line.length > 0)
+    .join("\n");
 }

--- a/src/infra/exec-approvals-denylist.ts
+++ b/src/infra/exec-approvals-denylist.ts
@@ -28,7 +28,7 @@ const POSIX_SHELL_WRAPPER_NAMES: ReadonlySet<string> = POSIX_SHELL_WRAPPERS;
 const OPAQUE_INLINE_WRAPPER_TOKENS = new Set(["cmd", "cmd.exe", "powershell", "pwsh"]);
 const OPAQUE_INLINE_FLAG_TOKENS = new Set(["/c", "/k", "-command", "-c", "-encodedcommand"]);
 
-export type ExecDenylistEvaluation = {
+type ExecDenylistEvaluation = {
   matched: boolean;
   entry: ExecDenylistEntry | null;
   matchedText: string | null;

--- a/src/infra/exec-approvals-denylist.ts
+++ b/src/infra/exec-approvals-denylist.ts
@@ -9,8 +9,9 @@
  * still be confined with `security=allowlist` or `security=deny`.
  */
 import path from "node:path";
-import { analyzeShellCommand, type ExecCommandSegment } from "./exec-approvals-analysis.js";
+import type { ExecCommandSegment } from "./exec-approvals-analysis.js";
 import type { ExecDenylistEntry } from "./exec-approvals.types.js";
+import { planShellAuthorization } from "./exec-authorization-plan.js";
 import { normalizeExecutableToken } from "./exec-wrapper-resolution.js";
 import { POSIX_INLINE_COMMAND_FLAGS, resolveInlineCommandMatch } from "./shell-inline-command.js";
 import {
@@ -154,14 +155,14 @@ function resolvePosixInlineCommand(argv: string[]): string | null {
   return inline && inline.length > 0 ? inline : null;
 }
 
-function evaluateSegmentsAgainstDenylist(params: {
+async function evaluateSegmentsAgainstDenylist(params: {
   segments: readonly ExecCommandSegment[];
   matchers: readonly DenylistMatcher[];
   cwd?: string;
   env?: NodeJS.ProcessEnv;
   platform?: string | null;
   depth: number;
-}): ExecDenylistEvaluation {
+}): Promise<ExecDenylistEvaluation> {
   for (const segment of params.segments) {
     for (const candidate of buildSegmentCandidateTexts(segment)) {
       for (const matcher of params.matchers) {
@@ -185,17 +186,23 @@ function evaluateSegmentsAgainstDenylist(params: {
     if (params.depth + 1 >= MAX_DENYLIST_INLINE_DEPTH) {
       return UNANALYZABLE_HIT;
     }
-    const inlineAnalysis = analyzeShellCommand({
+    // Upstream replaced sync analyzeShellCommand with async shell planning.
+    const inlinePlan = await planShellAuthorization({
       command: inlineCommand,
       cwd: params.cwd,
       env: params.env,
       platform: params.platform,
     });
-    if (!inlineAnalysis.ok || inlineAnalysis.segments.length === 0) {
+    const inlineSegments = inlinePlan.ok
+      ? inlinePlan.groups.flatMap((group) =>
+          group.candidates.map((candidate) => candidate.sourceSegment),
+        )
+      : [];
+    if (!inlinePlan.ok || inlineSegments.length === 0) {
       return UNANALYZABLE_HIT;
     }
-    const inlineEvaluation = evaluateSegmentsAgainstDenylist({
-      segments: inlineAnalysis.segments,
+    const inlineEvaluation = await evaluateSegmentsAgainstDenylist({
+      segments: inlineSegments,
       matchers: params.matchers,
       cwd: params.cwd,
       env: params.env,
@@ -217,14 +224,14 @@ function evaluateSegmentsAgainstDenylist(params: {
  * is configured, the evaluation conservatively reports a hit because the
  * command cannot be proven to miss the STOP list.
  */
-export function evaluateExecDenylist(params: {
+export async function evaluateExecDenylist(params: {
   denylist: readonly ExecDenylistEntry[] | undefined | null;
   segments: readonly ExecCommandSegment[];
   analysisOk: boolean;
   cwd?: string;
   env?: NodeJS.ProcessEnv;
   platform?: string | null;
-}): ExecDenylistEvaluation {
+}): Promise<ExecDenylistEvaluation> {
   const entries = sanitizeExecDenylistEntries(params.denylist);
   if (entries.length === 0) {
     return NOT_MATCHED;
@@ -233,7 +240,7 @@ export function evaluateExecDenylist(params: {
     return UNANALYZABLE_HIT;
   }
   const caseInsensitive = (params.platform ?? process.platform) === "win32";
-  return evaluateSegmentsAgainstDenylist({
+  return await evaluateSegmentsAgainstDenylist({
     segments: params.segments,
     matchers: buildDenylistMatchers(entries, caseInsensitive),
     cwd: params.cwd,

--- a/src/infra/exec-approvals-denylist.ts
+++ b/src/infra/exec-approvals-denylist.ts
@@ -1,0 +1,262 @@
+/**
+ * Exec denylist (STOP-list) screening.
+ *
+ * Denylist entries are glob patterns (`*` and `?`) matched against analyzed
+ * command segments. Any match forces an explicit approval even when
+ * `security=full` and `ask=off` would otherwise auto-allow the command, and
+ * durable allow-always trust never clears a hit. This is a guardrail against
+ * unintended high-risk commands, not a sandbox: adversarial payloads should
+ * still be confined with `security=allowlist` or `security=deny`.
+ */
+import path from "node:path";
+import { analyzeShellCommand, type ExecCommandSegment } from "./exec-approvals-analysis.js";
+import type { ExecDenylistEntry } from "./exec-approvals.types.js";
+import { normalizeExecutableToken } from "./exec-wrapper-resolution.js";
+import { POSIX_INLINE_COMMAND_FLAGS, resolveInlineCommandMatch } from "./shell-inline-command.js";
+import {
+  POSIX_SHELL_WRAPPERS,
+  resolveShellWrapperTransportArgv,
+} from "./shell-wrapper-resolution.js";
+
+const MAX_DENYLIST_INLINE_DEPTH = 3;
+
+const POSIX_SHELL_WRAPPER_NAMES: ReadonlySet<string> = POSIX_SHELL_WRAPPERS;
+
+// Wrapper executables whose inline payloads use parsing semantics this module
+// cannot analyze; segments carrying their inline flags are treated as hits.
+const OPAQUE_INLINE_WRAPPER_TOKENS = new Set(["cmd", "cmd.exe", "powershell", "pwsh"]);
+const OPAQUE_INLINE_FLAG_TOKENS = new Set(["/c", "/k", "-command", "-c", "-encodedcommand"]);
+
+export type ExecDenylistEvaluation = {
+  matched: boolean;
+  entry: ExecDenylistEntry | null;
+  matchedText: string | null;
+  unanalyzable: boolean;
+};
+
+type DenylistMatcher = {
+  entry: ExecDenylistEntry;
+  regex: RegExp;
+};
+
+const NOT_MATCHED: ExecDenylistEvaluation = {
+  matched: false,
+  entry: null,
+  matchedText: null,
+  unanalyzable: false,
+};
+
+const UNANALYZABLE_HIT: ExecDenylistEvaluation = {
+  matched: true,
+  entry: null,
+  matchedText: null,
+  unanalyzable: true,
+};
+
+/** Drops malformed entries; preserves array identity when nothing changes. */
+export function sanitizeExecDenylistEntries(entries: unknown): ExecDenylistEntry[] {
+  if (!Array.isArray(entries)) {
+    return [];
+  }
+  let changed = false;
+  const sanitized: ExecDenylistEntry[] = [];
+  for (const raw of entries) {
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+      changed = true;
+      continue;
+    }
+    const candidate = raw as { id?: unknown; pattern?: unknown; reason?: unknown };
+    const pattern = typeof candidate.pattern === "string" ? candidate.pattern.trim() : "";
+    if (!pattern) {
+      changed = true;
+      continue;
+    }
+    const id =
+      typeof candidate.id === "string" && candidate.id.trim().length > 0
+        ? candidate.id.trim()
+        : undefined;
+    const reason =
+      typeof candidate.reason === "string" && candidate.reason.trim().length > 0
+        ? candidate.reason.trim()
+        : undefined;
+    if (pattern !== candidate.pattern || id !== candidate.id || reason !== candidate.reason) {
+      changed = true;
+    }
+    sanitized.push({
+      ...(id !== undefined ? { id } : {}),
+      pattern,
+      ...(reason !== undefined ? { reason } : {}),
+    });
+  }
+  return changed ? sanitized : (entries as ExecDenylistEntry[]);
+}
+
+function denylistPatternToRegExp(pattern: string, caseInsensitive: boolean): RegExp {
+  const escaped = pattern
+    .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+    .replace(/\*/g, "[\\s\\S]*")
+    .replace(/\?/g, "[\\s\\S]");
+  return new RegExp(`^${escaped}$`, caseInsensitive ? "i" : undefined);
+}
+
+function buildDenylistMatchers(
+  entries: readonly ExecDenylistEntry[],
+  caseInsensitive: boolean,
+): DenylistMatcher[] {
+  return entries.map((entry) => ({
+    entry,
+    regex: denylistPatternToRegExp(entry.pattern, caseInsensitive),
+  }));
+}
+
+function addArgvCandidates(out: Set<string>, argv: readonly string[] | undefined): void {
+  if (!argv || argv.length === 0) {
+    return;
+  }
+  const joined = argv.join(" ").trim();
+  if (joined.length > 0) {
+    out.add(joined);
+  }
+  const head = argv[0] ?? "";
+  const base = path.basename(head);
+  if (base.length > 0 && base !== head) {
+    out.add([base, ...argv.slice(1)].join(" ").trim());
+  }
+}
+
+function buildSegmentCandidateTexts(segment: ExecCommandSegment): string[] {
+  const candidates = new Set<string>();
+  addArgvCandidates(candidates, segment.argv);
+  const effectiveArgv = segment.resolution?.effectiveArgv;
+  if (effectiveArgv && effectiveArgv.length > 0) {
+    addArgvCandidates(candidates, effectiveArgv);
+  }
+  return [...candidates];
+}
+
+function hasOpaqueInlinePayload(argv: readonly string[]): boolean {
+  const wrapperToken = normalizeExecutableToken(argv[0] ?? "");
+  if (!OPAQUE_INLINE_WRAPPER_TOKENS.has(wrapperToken)) {
+    return false;
+  }
+  return argv.some((token) => OPAQUE_INLINE_FLAG_TOKENS.has(token.trim().toLowerCase()));
+}
+
+function resolvePosixInlineCommand(argv: string[]): string | null {
+  const transportArgv = resolveShellWrapperTransportArgv(argv) ?? argv;
+  if (!POSIX_SHELL_WRAPPER_NAMES.has(normalizeExecutableToken(transportArgv[0] ?? ""))) {
+    return null;
+  }
+  const match = resolveInlineCommandMatch(transportArgv, POSIX_INLINE_COMMAND_FLAGS, {
+    allowCombinedC: true,
+  });
+  const inline = match.command?.trim();
+  return inline && inline.length > 0 ? inline : null;
+}
+
+function evaluateSegmentsAgainstDenylist(params: {
+  segments: readonly ExecCommandSegment[];
+  matchers: readonly DenylistMatcher[];
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  platform?: string | null;
+  depth: number;
+}): ExecDenylistEvaluation {
+  for (const segment of params.segments) {
+    for (const candidate of buildSegmentCandidateTexts(segment)) {
+      for (const matcher of params.matchers) {
+        if (matcher.regex.test(candidate)) {
+          return {
+            matched: true,
+            entry: matcher.entry,
+            matchedText: candidate,
+            unanalyzable: false,
+          };
+        }
+      }
+    }
+    if (hasOpaqueInlinePayload(segment.argv)) {
+      return UNANALYZABLE_HIT;
+    }
+    const inlineCommand = resolvePosixInlineCommand(segment.argv);
+    if (inlineCommand === null) {
+      continue;
+    }
+    if (params.depth + 1 >= MAX_DENYLIST_INLINE_DEPTH) {
+      return UNANALYZABLE_HIT;
+    }
+    const inlineAnalysis = analyzeShellCommand({
+      command: inlineCommand,
+      cwd: params.cwd,
+      env: params.env,
+      platform: params.platform,
+    });
+    if (!inlineAnalysis.ok || inlineAnalysis.segments.length === 0) {
+      return UNANALYZABLE_HIT;
+    }
+    const inlineEvaluation = evaluateSegmentsAgainstDenylist({
+      segments: inlineAnalysis.segments,
+      matchers: params.matchers,
+      cwd: params.cwd,
+      env: params.env,
+      platform: params.platform,
+      depth: params.depth + 1,
+    });
+    if (inlineEvaluation.matched) {
+      return inlineEvaluation;
+    }
+  }
+  return NOT_MATCHED;
+}
+
+/**
+ * Screens analyzed command segments against the configured denylist.
+ *
+ * Reuses the segments produced by allowlist analysis so screening adds no
+ * extra parsing cost. When the command could not be analyzed and a denylist
+ * is configured, the evaluation conservatively reports a hit because the
+ * command cannot be proven to miss the STOP list.
+ */
+export function evaluateExecDenylist(params: {
+  denylist: readonly ExecDenylistEntry[] | undefined | null;
+  segments: readonly ExecCommandSegment[];
+  analysisOk: boolean;
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  platform?: string | null;
+}): ExecDenylistEvaluation {
+  const entries = sanitizeExecDenylistEntries(params.denylist);
+  if (entries.length === 0) {
+    return NOT_MATCHED;
+  }
+  if (!params.analysisOk || params.segments.length === 0) {
+    return UNANALYZABLE_HIT;
+  }
+  const caseInsensitive = (params.platform ?? process.platform) === "win32";
+  return evaluateSegmentsAgainstDenylist({
+    segments: params.segments,
+    matchers: buildDenylistMatchers(entries, caseInsensitive),
+    cwd: params.cwd,
+    env: params.env,
+    platform: params.platform,
+    depth: 0,
+  });
+}
+
+/** Operator-facing denial message for denylist screening outcomes. */
+export function formatExecDenylistDeniedMessage(evaluation: ExecDenylistEvaluation): string {
+  if (evaluation.unanalyzable) {
+    return "SYSTEM_RUN_DENIED: denylist screening could not analyze command; approval required";
+  }
+  const reason = evaluation.entry?.reason ? ` (${evaluation.entry.reason})` : "";
+  return `SYSTEM_RUN_DENIED: denylist match (${evaluation.entry?.pattern ?? "unknown"})${reason}; approval required`;
+}
+
+/** Warning line surfaced with approval prompts for denylist screening hits. */
+export function formatExecDenylistWarning(evaluation: ExecDenylistEvaluation): string {
+  if (evaluation.unanalyzable) {
+    return "Warning: command could not be analyzed for denylist screening; explicit approval is required.";
+  }
+  const reason = evaluation.entry?.reason ? ` (${evaluation.entry.reason})` : "";
+  return `Warning: command matches exec denylist entry ${evaluation.entry?.pattern ?? "unknown"}${reason}; explicit approval is required.`;
+}

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -44,7 +44,7 @@ export * from "./exec-approvals-analysis.js";
 export * from "./exec-approvals-allowlist.js";
 export * from "./exec-approvals-denylist.js";
 export type { ExecApprovalPolicySnapshot } from "./exec-approval-policy-snapshot.js";
-export type { ExecAllowlistEntry, ExecDenylistEntry } from "./exec-approvals.types.js";
+export type { ExecAllowlistEntry } from "./exec-approvals.types.js";
 
 export type ExecHost = "sandbox" | "gateway" | "node";
 export type ExecTarget = "auto" | ExecHost;

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -22,7 +22,8 @@ import {
   resolveAllowAlwaysPatternEntries,
 } from "./exec-approvals-allowlist.js";
 import type { ExecCommandSegment } from "./exec-approvals-analysis.js";
-import type { ExecAllowlistEntry } from "./exec-approvals.types.js";
+import { sanitizeExecDenylistEntries } from "./exec-approvals-denylist.js";
+import type { ExecAllowlistEntry, ExecDenylistEntry } from "./exec-approvals.types.js";
 import type { ExecAuthorizationPlan } from "./exec-authorization-plan.js";
 import {
   extractBindableShellWrapperInlineCommand,
@@ -41,8 +42,9 @@ import {
 import { isLockOwnerDefinitelyStale } from "./stale-lock-file.js";
 export * from "./exec-approvals-analysis.js";
 export * from "./exec-approvals-allowlist.js";
+export * from "./exec-approvals-denylist.js";
 export type { ExecApprovalPolicySnapshot } from "./exec-approval-policy-snapshot.js";
-export type { ExecAllowlistEntry } from "./exec-approvals.types.js";
+export type { ExecAllowlistEntry, ExecDenylistEntry } from "./exec-approvals.types.js";
 
 export type ExecHost = "sandbox" | "gateway" | "node";
 export type ExecTarget = "auto" | ExecHost;
@@ -270,6 +272,7 @@ export type ExecApprovalsDefaults = {
 
 export type ExecApprovalsAgent = ExecApprovalsDefaults & {
   allowlist?: ExecAllowlistEntry[];
+  denylist?: ExecDenylistEntry[];
 };
 
 export type ExecApprovalsFile = {
@@ -302,6 +305,7 @@ export type ExecApprovalsResolved = {
     askFallback: string | null;
   };
   allowlist: ExecAllowlistEntry[];
+  denylist: ExecDenylistEntry[];
   file: ExecApprovalsFile;
 };
 
@@ -985,9 +989,12 @@ export function normalizeExecApprovals(file: ExecApprovalsFile): ExecApprovalsFi
     const coerced = coerceAllowlistEntries(agent.allowlist);
     const withIds = ensureAllowlistIds(coerced);
     const allowlist = stripAllowlistCommandText(withIds);
+    const denylist =
+      agent.denylist === undefined ? undefined : sanitizeExecDenylistEntries(agent.denylist);
     const sanitizedPolicy = sanitizeExecApprovalPolicy(agent);
     const agentChanged =
       allowlist !== agent.allowlist ||
+      denylist !== agent.denylist ||
       sanitizedPolicy.security !== agent.security ||
       sanitizedPolicy.ask !== agent.ask ||
       sanitizedPolicy.askFallback !== agent.askFallback;
@@ -995,6 +1002,7 @@ export function normalizeExecApprovals(file: ExecApprovalsFile): ExecApprovalsFi
       agents[key] = {
         ...agent,
         allowlist,
+        denylist,
         security: sanitizedPolicy.security,
         ask: sanitizedPolicy.ask,
         askFallback: sanitizedPolicy.askFallback,
@@ -1740,6 +1748,10 @@ export function resolveExecApprovalsFromFile(params: {
     ...(Array.isArray(wildcard.allowlist) ? wildcard.allowlist : []),
     ...(Array.isArray(agent.allowlist) ? agent.allowlist : []),
   ];
+  const denylist = sanitizeExecDenylistEntries([
+    ...(Array.isArray(wildcard.denylist) ? wildcard.denylist : []),
+    ...(Array.isArray(agent.denylist) ? agent.denylist : []),
+  ]);
   return {
     path: params.path ?? resolveExecApprovalsPath(),
     socketPath: expandHomePrefix(
@@ -1754,6 +1766,7 @@ export function resolveExecApprovalsFromFile(params: {
       askFallback: resolvedAgentAskFallback.source,
     },
     allowlist,
+    denylist,
     file,
   };
 }

--- a/src/infra/exec-approvals.types.ts
+++ b/src/infra/exec-approvals.types.ts
@@ -10,3 +10,12 @@ export type ExecAllowlistEntry = {
   lastUsedCommand?: string;
   lastResolvedPath?: string;
 };
+
+// Serialized denylist (STOP-list) entries. Patterns are globs (`*`, `?`)
+// matched against analyzed command segments; any match forces an explicit
+// approval even when policy would otherwise auto-allow the command.
+export type ExecDenylistEntry = {
+  id?: string;
+  pattern: string;
+  reason?: string;
+};

--- a/src/node-host/exec-policy.test.ts
+++ b/src/node-host/exec-policy.test.ts
@@ -151,6 +151,36 @@ describe("evaluateSystemRunPolicy", () => {
     expect(denied.errorMessage).toContain("denylist");
   });
 
+  it("hard-denies unanalyzable denylist hits in yolo mode without prompting", () => {
+    const denied = expectDeniedDecision(
+      evaluateSystemRunPolicy(
+        buildPolicyParams({
+          security: "full",
+          ask: "off",
+          denylisted: true,
+          denylistUnanalyzable: true,
+        }),
+      ),
+    );
+    expect(denied.eventReason).toBe("denylist-hit");
+    expect(denied.requiresAsk).toBe(false);
+    expect(denied.errorMessage).toContain("could not analyze");
+  });
+
+  it("still requires approval for unanalyzable denylist hits when ask is on-miss", () => {
+    const denied = expectDeniedDecision(
+      evaluateSystemRunPolicy(
+        buildPolicyParams({
+          security: "full",
+          ask: "on-miss",
+          denylisted: true,
+          denylistUnanalyzable: true,
+        }),
+      ),
+    );
+    expect(denied.requiresAsk).toBe(true);
+  });
+
   it("lets an explicit approval decision clear a denylist hit", () => {
     const allowed = expectAllowedDecision(
       evaluateSystemRunPolicy(

--- a/src/node-host/exec-policy.test.ts
+++ b/src/node-host/exec-policy.test.ts
@@ -139,4 +139,50 @@ describe("evaluateSystemRunPolicy", () => {
     expect(allowed.analysisOk).toBe(true);
     expect(allowed.allowlistSatisfied).toBe(true);
   });
+
+  it("requires approval for denylist hits even when security=full and ask=off", () => {
+    const denied = expectDeniedDecision(
+      evaluateSystemRunPolicy(
+        buildPolicyParams({ security: "full", ask: "off", denylisted: true }),
+      ),
+    );
+    expect(denied.eventReason).toBe("denylist-hit");
+    expect(denied.requiresAsk).toBe(true);
+    expect(denied.errorMessage).toContain("denylist");
+  });
+
+  it("lets an explicit approval decision clear a denylist hit", () => {
+    const allowed = expectAllowedDecision(
+      evaluateSystemRunPolicy(
+        buildPolicyParams({
+          security: "full",
+          ask: "off",
+          denylisted: true,
+          approvalDecision: "allow-once",
+        }),
+      ),
+    );
+    expect(allowed.approvedByAsk).toBe(true);
+  });
+
+  it("does not let durable trust bypass a denylist hit", () => {
+    const denied = expectDeniedDecision(
+      evaluateSystemRunPolicy(
+        buildPolicyParams({
+          security: "full",
+          ask: "off",
+          denylisted: true,
+          durableApprovalSatisfied: true,
+        }),
+      ),
+    );
+    expect(denied.eventReason).toBe("denylist-hit");
+  });
+
+  it("keeps security=deny ahead of denylist hits", () => {
+    const denied = expectDeniedDecision(
+      evaluateSystemRunPolicy(buildPolicyParams({ security: "deny", denylisted: true })),
+    );
+    expect(denied.eventReason).toBe("security=deny");
+  });
 });

--- a/src/node-host/exec-policy.ts
+++ b/src/node-host/exec-policy.ts
@@ -51,6 +51,8 @@ export function evaluateSystemRunPolicy(params: {
   allowlistSatisfied: boolean;
   durableApprovalSatisfied?: boolean;
   denylisted?: boolean;
+  /** When true with denylisted, yolo mode hard-denies instead of prompting. */
+  denylistUnanalyzable?: boolean;
   approvalDecision: ExecApprovalDecision;
   approved?: boolean;
   isWindows: boolean;
@@ -88,16 +90,22 @@ export function evaluateSystemRunPolicy(params: {
 
   // Denylist (STOP-list) hits require a fresh explicit approval regardless of
   // security mode; durable allow-always trust intentionally does not clear them.
+  // Exception: unanalyzable hits under yolo mode hard-deny without prompting so
+  // opaque shell improvisation cannot spam one-shot Allow-once cards.
   if (params.denylisted === true && !approvedByAsk) {
+    const hardDenyUnanalyzable =
+      params.denylistUnanalyzable === true && params.security === "full" && params.ask === "off";
     return {
       allowed: false,
       eventReason: "denylist-hit",
-      errorMessage: "SYSTEM_RUN_DENIED: denylist match; approval required",
+      errorMessage: hardDenyUnanalyzable
+        ? "SYSTEM_RUN_DENIED: denylist screening could not analyze command"
+        : "SYSTEM_RUN_DENIED: denylist match; approval required",
       analysisOk,
       allowlistSatisfied,
       shellWrapperBlocked,
       windowsShellWrapperBlocked,
-      requiresAsk: true,
+      requiresAsk: !hardDenyUnanalyzable,
       approvalDecision: params.approvalDecision,
       approvedByAsk,
     };

--- a/src/node-host/exec-policy.ts
+++ b/src/node-host/exec-policy.ts
@@ -17,7 +17,7 @@ type SystemRunPolicyDecision = {
     }
   | {
       allowed: false;
-      eventReason: "security=deny" | "approval-required" | "allowlist-miss";
+      eventReason: "security=deny" | "denylist-hit" | "approval-required" | "allowlist-miss";
       errorMessage: string;
     }
 );
@@ -50,6 +50,7 @@ export function evaluateSystemRunPolicy(params: {
   analysisOk: boolean;
   allowlistSatisfied: boolean;
   durableApprovalSatisfied?: boolean;
+  denylisted?: boolean;
   approvalDecision: ExecApprovalDecision;
   approved?: boolean;
   isWindows: boolean;
@@ -80,6 +81,23 @@ export function evaluateSystemRunPolicy(params: {
       shellWrapperBlocked,
       windowsShellWrapperBlocked,
       requiresAsk: false,
+      approvalDecision: params.approvalDecision,
+      approvedByAsk,
+    };
+  }
+
+  // Denylist (STOP-list) hits require a fresh explicit approval regardless of
+  // security mode; durable allow-always trust intentionally does not clear them.
+  if (params.denylisted === true && !approvedByAsk) {
+    return {
+      allowed: false,
+      eventReason: "denylist-hit",
+      errorMessage: "SYSTEM_RUN_DENIED: denylist match; approval required",
+      analysisOk,
+      allowlistSatisfied,
+      shellWrapperBlocked,
+      windowsShellWrapperBlocked,
+      requiresAsk: true,
       approvalDecision: params.approvalDecision,
       approvedByAsk,
     };

--- a/src/node-host/invoke-system-run.ts
+++ b/src/node-host/invoke-system-run.ts
@@ -629,7 +629,7 @@ async function evaluateSystemRunPolicyPhase(
     allowlist: approvals.allowlist,
     commandText: parsed.commandText,
   });
-  const denylistEvaluation = evaluateExecDenylist({
+  const denylistEvaluation = await evaluateExecDenylist({
     denylist: approvals.denylist,
     segments,
     analysisOk: allowlistEvaluation.analysisOk,

--- a/src/node-host/invoke-system-run.ts
+++ b/src/node-host/invoke-system-run.ts
@@ -14,6 +14,7 @@ import {
   createExecApprovalPolicySnapshot,
   evaluateExecDenylist,
   formatExecDenylistDeniedMessage,
+  formatUnanalyzableDenylistHardDenyMessage,
   hasDurableExecApproval,
   isExecApprovalPolicySnapshotCurrent,
   maxAsk,
@@ -654,6 +655,7 @@ async function evaluateSystemRunPolicyPhase(
     allowlistSatisfied,
     durableApprovalSatisfied: durableApprovalSatisfied || inlineEvalExecutableTrusted,
     denylisted: denylistEvaluation.matched,
+    denylistUnanalyzable: denylistEvaluation.unanalyzable,
     approvalDecision,
     approved: parsed.approved,
     isWindows,
@@ -768,6 +770,7 @@ async function evaluateSystemRunPolicyPhase(
           allowlistSatisfied,
           durableApprovalSatisfied: durableApprovalSatisfied || inlineEvalExecutableTrusted,
           denylisted: denylistEvaluation.matched,
+          denylistUnanalyzable: denylistEvaluation.unanalyzable,
           approvalDecision,
           approved: true,
           isWindows,
@@ -783,7 +786,9 @@ async function evaluateSystemRunPolicyPhase(
   if (!policy.allowed) {
     const denylistDeniedMessage =
       policy.eventReason === "denylist-hit"
-        ? formatExecDenylistDeniedMessage(denylistEvaluation)
+        ? denylistEvaluation.unanalyzable && !policy.requiresAsk
+          ? formatUnanalyzableDenylistHardDenyMessage(parsed.commandText)
+          : formatExecDenylistDeniedMessage(denylistEvaluation)
         : undefined;
     await sendSystemRunDenied(opts, parsed.execution, {
       reason: policy.eventReason,

--- a/src/node-host/invoke-system-run.ts
+++ b/src/node-host/invoke-system-run.ts
@@ -12,6 +12,8 @@ import {
   commitExecAuthorizationLocked,
   commandRequiresSecurityAuditSuppressionApproval,
   createExecApprovalPolicySnapshot,
+  evaluateExecDenylist,
+  formatExecDenylistDeniedMessage,
   hasDurableExecApproval,
   isExecApprovalPolicySnapshotCurrent,
   maxAsk,
@@ -81,6 +83,7 @@ type SystemRunInvokeResult = {
 
 type SystemRunDeniedReason =
   | "security=deny"
+  | "denylist-hit"
   | "approval-required"
   | "approval-state-write-failed"
   | "allowlist-miss"
@@ -179,6 +182,7 @@ function warnWritableTrustedDirOnce(message: string): void {
 function normalizeDeniedReason(reason: string | null | undefined): SystemRunDeniedReason {
   switch (reason) {
     case "security=deny":
+    case "denylist-hit":
     case "approval-required":
     case "allowlist-miss":
     case "execution-plan-miss":
@@ -625,6 +629,14 @@ async function evaluateSystemRunPolicyPhase(
     allowlist: approvals.allowlist,
     commandText: parsed.commandText,
   });
+  const denylistEvaluation = evaluateExecDenylist({
+    denylist: approvals.denylist,
+    segments,
+    analysisOk: allowlistEvaluation.analysisOk,
+    cwd: parsed.cwd,
+    env: parsed.env,
+    platform: process.platform,
+  });
   const inlineEvalExecutableTrusted =
     inlineEvalHit !== null &&
     segmentAllowlistEntries.some((entry) => entry?.source === "allow-always");
@@ -641,6 +653,7 @@ async function evaluateSystemRunPolicyPhase(
     analysisOk,
     allowlistSatisfied,
     durableApprovalSatisfied: durableApprovalSatisfied || inlineEvalExecutableTrusted,
+    denylisted: denylistEvaluation.matched,
     approvalDecision,
     approved: parsed.approved,
     isWindows,
@@ -715,7 +728,9 @@ async function evaluateSystemRunPolicyPhase(
       parsed.approvalPlan !== null &&
       inlineEvalHit === null &&
       !requiresSecurityAuditSuppressionApproval &&
-      policy.eventReason !== "security=deny";
+      policy.eventReason !== "security=deny" &&
+      // Denylist hits are reserved for explicit human approval.
+      policy.eventReason !== "denylist-hit";
     if (canAutoReviewApprovalMiss) {
       const reviewer = await resolveSystemRunAutoReviewer({
         opts,
@@ -752,6 +767,7 @@ async function evaluateSystemRunPolicyPhase(
           analysisOk,
           allowlistSatisfied,
           durableApprovalSatisfied: durableApprovalSatisfied || inlineEvalExecutableTrusted,
+          denylisted: denylistEvaluation.matched,
           approvalDecision,
           approved: true,
           isWindows,
@@ -765,9 +781,13 @@ async function evaluateSystemRunPolicyPhase(
   }
 
   if (!policy.allowed) {
+    const denylistDeniedMessage =
+      policy.eventReason === "denylist-hit"
+        ? formatExecDenylistDeniedMessage(denylistEvaluation)
+        : undefined;
     await sendSystemRunDenied(opts, parsed.execution, {
       reason: policy.eventReason,
-      message: autoReviewDeferredMessage ?? policy.errorMessage,
+      message: autoReviewDeferredMessage ?? denylistDeniedMessage ?? policy.errorMessage,
     });
     return null;
   }

--- a/src/plugin-sdk/provider-stream-shared.test.ts
+++ b/src/plugin-sdk/provider-stream-shared.test.ts
@@ -412,6 +412,44 @@ describe("createPlainTextToolCallCompatWrapper", () => {
     ]);
   });
 
+  it("promotes OpenAI-style JSON emitted by local models", async () => {
+    const rawToolText = '{"name":"write","arguments":{"path":"/tmp/local.py","content":"ok"}}';
+    const baseStreamFn: StreamFn = () =>
+      createEventStream([
+        { type: "text_start", content: "" },
+        { type: "text_delta", delta: rawToolText },
+        { type: "text_end" },
+        {
+          type: "done",
+          reason: "stop",
+          message: {
+            role: "assistant",
+            content: rawToolText,
+          },
+        },
+      ]);
+    const wrapped = createPlainTextToolCallCompatWrapper(baseStreamFn);
+    const events: unknown[] = [];
+
+    for await (const event of wrapped(
+      {} as never,
+      { tools: [{ name: "write" }] } as never,
+      {},
+    ) as AsyncIterable<unknown>) {
+      events.push(event);
+    }
+
+    const done = events.at(-1) as { message?: { content?: unknown; stopReason?: unknown } };
+    expect(done.message?.stopReason).toBe("toolUse");
+    expect(done.message?.content).toEqual([
+      expect.objectContaining({
+        type: "toolCall",
+        name: "write",
+        arguments: { path: "/tmp/local.py", content: "ok" },
+      }),
+    ]);
+  });
+
   it("does not promote complete-looking text tool calls after a length stop", async () => {
     const rawToolText = '[tool:read] {"path":"/tmp/file.txt"}';
     const baseStreamFn: StreamFn = () =>

--- a/ui/src/app/approval-presentation.test.ts
+++ b/ui/src/app/approval-presentation.test.ts
@@ -38,6 +38,18 @@ describe("approval presentation", () => {
     ]);
   });
 
+  it("never keeps the same approval id in both inline and modal surfaces", () => {
+    const queue = [
+      approval("same-id", { sessionKey: "agent:main:main" }),
+      approval("other-id", { sessionKey: "agent:main:other" }),
+    ];
+    const inline = findInlineApproval(queue, "agent:main:main");
+    expect(inline?.id).toBe("same-id");
+    const modalIds = new Set(modalApprovalQueue(queue, inline?.id).map((entry) => entry.id));
+    expect(modalIds.has("same-id")).toBe(false);
+    expect(modalIds.has("other-id")).toBe(true);
+  });
+
   it("keeps every request in the modal when the active session does not match", () => {
     const queue = [approval("approval-1", { sessionKey: "agent:main:other" })];
 

--- a/ui/src/components/exec-approval.test.ts
+++ b/ui/src/components/exec-approval.test.ts
@@ -276,6 +276,7 @@ describe("openclaw-exec-approval", () => {
       inlineApprovalId: "approval-1",
     });
     expect(container.querySelector("openclaw-modal-dialog")).toBeNull();
+    expect(container.querySelector(".exec-approval-card")).toBeNull();
 
     (approval as LitElement & { show(): void }).show();
     await approval.updateComplete;

--- a/ui/src/pages/chat/chat-queue.ts
+++ b/ui/src/pages/chat/chat-queue.ts
@@ -152,9 +152,13 @@ export function syncChatQueueFromStoredOutbox(
   const storedIds = new Set(outbox.queue.map((item) => item.id));
   // Storage failures can leave an active or manual-retry row in memory only.
   // Projection must not erase that last copy while another send publishes.
+  // Waiting-idle follow-ups can also exist only in the live pane briefly; never
+  // drop them when syncing a durable head (e.g. dismissing Needs review).
   const localRecovery = current.filter(
     (item) =>
-      !item.pendingRunId && !storedIds.has(item.id) && localRecoveryItemIds.get(host)?.has(item.id),
+      !item.pendingRunId &&
+      !storedIds.has(item.id) &&
+      (localRecoveryItemIds.get(host)?.has(item.id) || item.sendState === "waiting-idle"),
   );
   const projected = outbox.queue.map((item) => {
     const ephemeralItem = ephemeralById.get(item.id);
@@ -591,10 +595,23 @@ export function removeQueuedMessageWithoutReleasing(
       stored.agentId ?? item.agentId,
     )
   ) {
-    const persisted = outboxAfterMutation(host, stored);
-    syncChatQueueFromStoredOutbox(host, persisted);
-    publishStoredOutbox(host, persisted);
-    return null;
+    // User dismiss / exact-id removal must not fail closed on a stale version.
+    // Fall back to id-only deletion so a sibling waiting-idle row is never
+    // wiped by a version-mismatch sync of the durable head.
+    if (
+      !removeStoredChatComposerQueueItem(
+        host,
+        stored.sessionKey,
+        id,
+        undefined,
+        stored.agentId ?? item.agentId,
+      )
+    ) {
+      const persisted = outboxAfterMutation(host, stored);
+      syncChatQueueFromStoredOutbox(host, persisted);
+      publishStoredOutbox(host, persisted);
+      return null;
+    }
   }
   if (item) {
     transientQueueProjections.delete(transientQueueProjectionKey(host, scope, item.id));

--- a/ui/src/pages/chat/chat-send.test.ts
+++ b/ui/src/pages/chat/chat-send.test.ts
@@ -6488,6 +6488,233 @@ describe("handleSendChat", () => {
     expect(host.lastError).toContain("Delivery could not be confirmed");
   });
 
+  it("retires a stale unconfirmed row when reconnect history later proves delivery", async () => {
+    const request = vi.fn((method: string) => {
+      if (method === "chat.history") {
+        return Promise.resolve({
+          messages: [
+            {
+              role: "user",
+              content: "already processed Cursor task",
+              idempotencyKey: "stale-unconfirmed-run:user",
+            },
+            {
+              role: "assistant",
+              content: "done",
+            },
+          ],
+          sessionInfo: row("agent:main", { hasActiveRun: false, status: "done" }),
+        });
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const host = makeHost({
+      client: { request } as unknown as ChatHost["client"],
+      chatRunId: "announce-still-running",
+      chatQueue: [
+        {
+          id: "stale-unconfirmed",
+          text: "already processed Cursor task",
+          createdAt: 1,
+          sendAttempts: 1,
+          sendRunId: "stale-unconfirmed-run",
+          sendState: "unconfirmed",
+          sendError:
+            "Delivery could not be confirmed after reconnect. Check the conversation before retrying.",
+          sessionKey: "agent:main",
+        },
+        {
+          id: "queued-after-stale",
+          text: "local model follow-up",
+          createdAt: 2,
+          sendState: "waiting-idle",
+          sessionKey: "agent:main",
+        },
+      ],
+    });
+    admitHostQueueItems(host);
+    host.sessionsResult = createSessionsResult([
+      row("agent:main", {
+        hasActiveRun: true,
+        activeRunIds: ["announce-still-running"],
+        status: "running",
+      }),
+    ]);
+
+    await retryReconnectableQueuedChatSends(host);
+
+    expect(request.mock.calls.filter(([method]) => method === "chat.send")).toHaveLength(0);
+    expect(host.chatQueue.map((item) => item.id)).toEqual(["queued-after-stale"]);
+    expect(host.chatQueue[0]).toMatchObject({
+      id: "queued-after-stale",
+      sendState: "waiting-idle",
+    });
+    expect(listStoredChatOutboxes(host)[0]?.queue.map((item) => item.id)).toEqual([
+      "queued-after-stale",
+    ]);
+  });
+
+  it("keeps an ambiguous unconfirmed row reviewable without auto-retrying it", async () => {
+    const request = vi.fn((method: string) => {
+      if (method === "chat.history") {
+        return Promise.resolve({
+          messages: [],
+          sessionInfo: row("agent:main", { hasActiveRun: false, status: "done" }),
+        });
+      }
+      if (method === "chat.send") {
+        throw new Error("must not auto-retry ambiguous delivery");
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const host = makeHost({
+      client: { request } as unknown as ChatHost["client"],
+      chatQueue: [
+        {
+          id: "still-ambiguous",
+          text: "maybe delivered",
+          createdAt: 1,
+          sendAttempts: 1,
+          sendRunId: "still-ambiguous-run",
+          sendState: "unconfirmed",
+          sendError:
+            "Delivery could not be confirmed after reconnect. Check the conversation before retrying.",
+          sessionKey: "agent:main",
+        },
+      ],
+    });
+    admitHostQueueItems(host);
+
+    await retryReconnectableQueuedChatSends(host);
+
+    expect(request.mock.calls.filter(([method]) => method === "chat.send")).toHaveLength(0);
+    expect(host.chatQueue[0]).toMatchObject({
+      id: "still-ambiguous",
+      sendState: "unconfirmed",
+      sendRunId: "still-ambiguous-run",
+    });
+  });
+
+  it("dismissing an unconfirmed row never deletes a waiting-idle sibling", async () => {
+    const host = makeHost({
+      chatQueue: [
+        {
+          id: "stale-review",
+          text: "Cursor task already finished",
+          createdAt: 1,
+          sendAttempts: 1,
+          sendRunId: "stale-review-run",
+          sendState: "unconfirmed",
+          sendError:
+            "Delivery could not be confirmed after reconnect. Check the conversation before retrying.",
+          sessionKey: "agent:main",
+        },
+        {
+          id: "follow-up-prompt",
+          text: "local model test prompt",
+          createdAt: 2,
+          sendState: "waiting-idle",
+          sessionKey: "agent:main",
+        },
+      ],
+    });
+    admitHostQueueItems(host);
+    host.chatQueue = [
+      ...host.chatQueue,
+      {
+        id: "memory-only-follow-up",
+        text: "queued only in the live pane",
+        createdAt: 3,
+        sendState: "waiting-idle",
+        sessionKey: "agent:main",
+      },
+    ];
+
+    removeQueuedMessage(host, "stale-review");
+
+    expect(host.chatQueue.map((item) => item.id)).toEqual([
+      "follow-up-prompt",
+      "memory-only-follow-up",
+    ]);
+    expect(listStoredChatOutboxes(host)[0]?.queue.map((item) => item.id)).toEqual([
+      "follow-up-prompt",
+    ]);
+  });
+
+  it("keeps a memory-only waiting-idle sibling when outbox sync replaces a durable head", () => {
+    const durable = {
+      id: "durable-head",
+      text: "needs review",
+      createdAt: 1,
+      sendAttempts: 1,
+      sendRunId: "durable-head-run",
+      sendState: "unconfirmed" as const,
+      sendError:
+        "Delivery could not be confirmed after reconnect. Check the conversation before retrying.",
+      sessionKey: "agent:main",
+    };
+    const host = makeHost({ chatQueue: [durable] });
+    admitHostQueueItems(host);
+    const memoryOnly = {
+      id: "memory-only-waiting",
+      text: "Waiting for current run sibling",
+      createdAt: 2,
+      sendState: "waiting-idle" as const,
+      sessionKey: "agent:main",
+    };
+    host.chatQueue = [...host.chatQueue, memoryOnly];
+    const outbox = listStoredChatOutboxes(host)[0];
+    expect(outbox).toBeDefined();
+
+    syncChatQueueFromStoredOutbox(host, outbox!);
+
+    expect(host.chatQueue.map((item) => item.id)).toEqual(["durable-head", "memory-only-waiting"]);
+  });
+
+  it("retries an unconfirmed row with the same run id so gateway admission stays idempotent", async () => {
+    const request = vi.fn((method: string, params?: { idempotencyKey?: string }) => {
+      if (method === "chat.history") {
+        return Promise.resolve({
+          messages: [],
+          sessionInfo: row("agent:main", { hasActiveRun: false, status: "done" }),
+        });
+      }
+      if (method === "chat.send") {
+        return Promise.resolve({
+          runId: params?.idempotencyKey,
+          status: "started",
+        });
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const host = makeHost({
+      client: { request } as unknown as ChatHost["client"],
+      chatQueue: [
+        {
+          id: "retry-same-run",
+          text: "retry me once",
+          createdAt: 1,
+          sendAttempts: 1,
+          sendRunId: "stable-client-run",
+          sendState: "unconfirmed",
+          sendError:
+            "Delivery could not be confirmed after reconnect. Check the conversation before retrying.",
+          sessionKey: "agent:main",
+        },
+      ],
+    });
+    admitHostQueueItems(host);
+
+    await retryQueuedChatMessage(host, "retry-same-run");
+
+    const sendCalls = request.mock.calls.filter(([method]) => method === "chat.send");
+    expect(sendCalls).toHaveLength(1);
+    expect(sendCalls[0]?.[1]).toMatchObject({ idempotencyKey: "stable-client-run" });
+    expect(
+      host.chatQueue[0]?.sendRunId ?? listStoredChatOutboxes(host)[0]?.queue[0]?.sendRunId,
+    ).toBe("stable-client-run");
+  });
+
   it("does not replay while fresh history reports an active run", async () => {
     const request = vi.fn((method: string) => {
       if (method === "chat.history") {

--- a/ui/src/pages/chat/chat-send.ts
+++ b/ui/src/pages/chat/chat-send.ts
@@ -1626,6 +1626,7 @@ function historyContainsQueuedSend(history: ChatHistoryResult, item: ChatQueueIt
     return false;
   }
   const messages = Array.isArray(history.messages) ? history.messages : [];
+  const runId = item.sendRunId;
   return messages.some((message) => {
     if (!message || typeof message !== "object" || Array.isArray(message)) {
       return false;
@@ -1637,7 +1638,17 @@ function historyContainsQueuedSend(history: ChatHistoryResult, item: ChatQueueIt
         ? (marker as Record<string, unknown>)
         : undefined;
     const idempotencyKey = metadata?.idempotencyKey ?? record.idempotencyKey;
-    return idempotencyKey === item.sendRunId || idempotencyKey === `${item.sendRunId}:user`;
+    if (typeof idempotencyKey !== "string" || !idempotencyKey) {
+      return false;
+    }
+    // Exact user-turn keys, plus any later transcript mirror keyed under the
+    // same client run (assistant/media). Orphan repair can briefly hide the
+    // `:user` leaf while the run itself is already durable.
+    return (
+      idempotencyKey === runId ||
+      idempotencyKey === `${runId}:user` ||
+      idempotencyKey.startsWith(`${runId}:`)
+    );
   });
 }
 
@@ -1783,11 +1794,19 @@ async function drainStoredChatOutbox(
     if (!item) {
       return "empty";
     }
-    if (
-      item.sendState === "failed" ||
-      item.sendState === "unconfirmed" ||
-      item.sendState === "waiting-model"
-    ) {
+    if (item.sendState === "unconfirmed") {
+      // A prior reconnect may have parked this row before chat.history caught up.
+      // Re-check persisted transcript proof before leaving Needs review in place.
+      lane.freshAdmissions.delete(item.id);
+      lane.pendingOptions.delete(item.id);
+      const reconciled = await reconcileStoredChatOutboxHead(host, outbox, item);
+      if (reconciled === "continue") {
+        continue;
+      }
+      syncChatQueueFromStoredOutbox(host, readStoredChatOutbox(host, scope) ?? outbox);
+      return "blocked";
+    }
+    if (item.sendState === "failed" || item.sendState === "waiting-model") {
       syncChatQueueFromStoredOutbox(host, outbox);
       return "blocked";
     }


### PR DESCRIPTION
## Summary
- Block premature `requester-settle` wakes while a yielded local-coder child is still running (fixes `status: unknown` / `(no output)` before tools finish).
- Promote markdown-fenced OpenAI-style tool JSON from Ollama into real tool calls so `write`/`exec` actually run.
- Map `workspace-local-coder/scratch` onto host-visible `workspace/scratch`, validate artifact paths, attribute ownership to `local-coder`, and apply a 15m per-agent timeout.

## Test plan
- [x] Unit: settle-wake late/live child cases
- [x] Unit: fenced tool-call promotion
- [x] Unit: shared scratch + path validation + atomic commit
- [x] Unit: per-agent timeout precedence
- [ ] Carlos retest: spawn local-coder, wait for one terminal announce, host file written by child (not Lisa), email via `lisa-safe` only after verify


Made with [Cursor](https://cursor.com)