### PR TITLE
fix(discord): release pluralkit 404 response body before returning

### DIFF
--- a/extensions/discord/src/pluralkit.test.ts
+++ b/extensions/discord/src/pluralkit.test.ts
@@ -68,6 +68,18 @@ describe("fetchPluralKitMessageInfo", () => {
     expect(result).toBeNull();
   });
 
+  it("cancels the 404 response body before returning null", async () => {
+    const tracked = cancelTrackedResponse("not found", { status: 404 });
+    const fetcher = vi.fn(async () => tracked.response);
+    const result = await fetchPluralKitMessageInfo({
+      messageId: "missing",
+      config: { enabled: true },
+      fetcher: fetcher as unknown as typeof fetch,
+    });
+    expect(result).toBeNull();
+    expect(tracked.wasCanceled()).toBe(true);
+  });
+
   it("returns payload and sends token when configured", async () => {
     let receivedHeaders: Record<string, string> | undefined;
     const fetcher = vi.fn(async (_url: string, init?: RequestInit) => {

--- a/extensions/discord/src/pluralkit.ts
+++ b/extensions/discord/src/pluralkit.ts
@@ -65,6 +65,7 @@ export async function fetchPluralKitMessageInfo(params: {
       signal: timeout.signal,
     });
     if (res.status === 404) {
+      await res.body?.cancel().catch(() => undefined);
       return null;
     }
     if (!res.ok) {


### PR DESCRIPTION
## What Problem This Solves

Fixes a connection leak where a Discord guild with PluralKit enabled would leak the PluralKit API connection on every proxied-message lookup miss: `fetchPluralKitMessageInfo` returns `null` on HTTP 404 (the common case for non-proxied messages) without consuming or cancelling the response body, so the keep-alive socket stays pinned in the dispatcher pool until GC.

## Why This Change Was Made

The repo's contract for fetch paths that return without consuming the body is `await response.body?.cancel().catch(() => undefined)` first (as in `extensions/huggingface/models.ts` and `extensions/openrouter/usage.ts`). The 404 branch of `fetchPluralKitMessageInfo` (`extensions/discord/src/pluralkit.ts`) was the one return path in the function missing it; the error and success paths already read the body. Out of scope: other Discord fetch sites — `probe.ts` already cancels unread bodies in a `finally`.

## User Impact

Busy Discord gateways with PluralKit enabled no longer accumulate pinned keep-alive connections from routine 404 lookups. No behavior change besides releasing the unused response body.

## Evidence

Real probe against the production `fetchPluralKitMessageInfo` with a local keep-alive HTTP stub that answers `404` and holds the body open forever (slow-peer simulation), using the function's documented `fetcher` injection point. The probe counts client sockets still open after the call returns:

```console
$ node --import tsx probe.mjs        # before fix (upstream/main)
local pluralkit stub listening on 127.0.0.1:35101
call outcome: null
client sockets still open after return: 1
VERDICT: connection LEAKED — 404 response body never released

$ node --import tsx probe.mjs        # after fix (this branch)
local pluralkit stub listening on 127.0.0.1:41905
call outcome: null
client sockets still open after return: 0
VERDICT: connection released (fixed)
```

Focused suite: `extensions/discord/src/pluralkit.test.ts` 7/7 pass, including a new regression test asserting the 404 body stream is cancelled (fails without this change); oxlint/oxfmt clean.

## Real behavior proof

- Behavior or issue addressed: Discord PluralKit message lookups that return HTTP 404 (every non-proxied message when the integration is enabled) leaked the API connection because the 404 response body was never cancelled before returning `null`.
- Real environment tested: Linux x86_64, Node 24.15.0, OpenClaw `main` (7fe1d70a50), production `fetchPluralKitMessageInfo` from `extensions/discord/src/pluralkit.ts` against a real local `node:http` keep-alive server.
- Exact steps or command run after this patch: started a local HTTP stub that returns `404` for the PluralKit message endpoint and holds the body open, called the real `fetchPluralKitMessageInfo` via `node --import tsx probe.mjs` with its documented `fetcher` injection, then counted client sockets still open one second after the call returned.
- Evidence after fix:

```console
$ node --import tsx probe.mjs
local pluralkit stub listening on 127.0.0.1:41905
call outcome: null
client sockets still open after return: 0
VERDICT: connection released (fixed)
```

- Observed result after fix: the call returns `null` as before, but the client socket is released immediately (0 still open, vs 1 leaked before the patch). A regression test with a cancel-tracked `Response` stream confirms the same through the production function.
- What was not tested: the live PluralKit API; the probe and test exercise the exact fetch/return path with a real HTTP server and real `Response` streams.

## Regression test plan

- Target test file: `extensions/discord/src/pluralkit.test.ts`
- Scenario locked in: a 404 response whose body stream stays open until cancelled must be cancelled before `fetchPluralKitMessageInfo` returns `null`.

## Risk checklist

- User-visible behavior changed? No — same return values; only connection cleanup changes.
- Config/env/migration changed? No.
- Security/auth/secrets/network/tool-exec changed? No new network surface; failed responses are now released instead of pinned.
