### PR TITLE
fix(gateway): bound MCP App standalone page fetches with deadlines

### DIFF
--- a/src/gateway/mcp-app-standalone.test.ts
+++ b/src/gateway/mcp-app-standalone.test.ts
@@ -1,6 +1,6 @@
 import type { IncomingMessage } from "node:http";
 import { Readable } from "node:stream";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { makeMockHttpResponse } from "./test-http-response.js";
 
 const mocks = vi.hoisted(() => ({
@@ -366,5 +366,63 @@ describe("MCP App standalone host", () => {
         })
       ).res.statusCode,
     ).toBe(400);
+  });
+});
+
+describe("standalone page fetch deadlines", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function stubBrowserGlobals() {
+    let failedWith: string | null = null;
+    const element = () => ({
+      className: "",
+      textContent: "",
+      referrerPolicy: "",
+      src: "",
+      title: "",
+      style: {} as Record<string, string>,
+      setAttribute: () => undefined,
+      remove: () => undefined,
+    });
+    vi.stubGlobal("document", {
+      createElement: () => element(),
+      getElementById: () => ({
+        replaceChildren(...children: Array<{ textContent?: string }>) {
+          failedWith = children[0]?.textContent ?? null;
+        },
+      }),
+    });
+    vi.stubGlobal("location", { hash: "#ticket", origin: "http://127.0.0.1:18789" });
+    vi.stubGlobal("addEventListener", () => undefined);
+    vi.stubGlobal("matchMedia", () => ({ matches: false }));
+    vi.stubGlobal("innerWidth", 1280);
+    vi.stubGlobal("navigator", { language: "en" });
+    return { failedWith: () => failedWith };
+  }
+
+  it("passes a deadline signal to the bootstrap fetch and surfaces its failure", async () => {
+    const seenSignals: unknown[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string, init?: RequestInit) => {
+        seenSignals.push(init?.signal);
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        throw new Error("The operation was aborted due to timeout");
+      }),
+    );
+    const page = stubBrowserGlobals();
+
+    mcpAppStandaloneTesting.runStandaloneMcpAppHost({
+      protocolVersion: "test",
+      viewPath: "http://127.0.0.1:18789/view",
+    });
+
+    await vi.waitFor(() => {
+      expect(page.failedWith()).toBe("The operation was aborted due to timeout");
+    });
+    expect(seenSignals).toHaveLength(1);
+    expect(seenSignals[0]).toBeInstanceOf(AbortSignal);
   });
 });

--- a/src/gateway/mcp-app-standalone.ts
+++ b/src/gateway/mcp-app-standalone.ts
@@ -37,6 +37,7 @@ const ticketBindings = new Map<string, StandaloneTicketBinding>();
 
 export const mcpAppStandaloneTesting = {
   clearTickets: () => ticketBindings.clear(),
+  runStandaloneMcpAppHost,
 };
 
 function pruneTicketBindings(nowMs: number): void {
@@ -258,6 +259,10 @@ function runStandaloneMcpAppHost(config: { protocolVersion: string; viewPath: st
 
   const host = browser.document.getElementById("host");
   const ticket = browser.location.hash.startsWith("#") ? browser.location.hash.slice(1) : "";
+  // Never wait forever on a stalled gateway: bound the bootstrap metadata fetch
+  // and proxied operations (kept under the standalone ticket TTL).
+  const BOOTSTRAP_TIMEOUT_MS = 15_000;
+  const OPERATION_TIMEOUT_MS = 115_000;
   let frame: StandaloneFrame | undefined;
   let payload: ViewPayload | undefined;
   let initializeAccepted = false;
@@ -327,6 +332,7 @@ function runStandaloneMcpAppHost(config: { protocolVersion: string; viewPath: st
       body: JSON.stringify({ method, params }),
       cache: "no-store",
       credentials: "omit",
+      signal: AbortSignal.timeout(OPERATION_TIMEOUT_MS),
     });
     const body = (await response.json().catch(() => undefined)) as
       | { ok?: boolean; result?: unknown; error?: string }
@@ -489,6 +495,7 @@ function runStandaloneMcpAppHost(config: { protocolVersion: string; viewPath: st
     headers: { Authorization: `MCP-App ${ticket}` },
     cache: "no-store",
     credentials: "omit",
+    signal: AbortSignal.timeout(BOOTSTRAP_TIMEOUT_MS),
   })
     .then(async (response) => {
       if (!response.ok) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an indefinite hang where the MCP App standalone page (served by the gateway for `ui://` standalone views) would wait forever when the gateway accepts its bootstrap metadata fetch — or a proxied operation POST — but stalls the response: no deadline existed on either `fetch`, so the page showed a permanent spinner with no error and no recovery, even though the standalone ticket itself expires after 2 minutes.

## Why This Change Was Made

Both fetch sites inside the page host script (`src/gateway/mcp-app-standalone.ts`, `runStandaloneMcpAppHost`) now carry `AbortSignal.timeout(...)`: 15s for the bootstrap metadata fetch (a tiny same-origin GET) and 115s for proxied operations, deliberately kept under the 2-minute standalone ticket TTL so a stalled gateway fails the operation before the ticket dies. The constants live inside the host function because the script is serialized into the served HTML via `runStandaloneMcpAppHost.toString()`. On timeout the existing `.catch` renders the error through the page's `fail()` path instead of spinning forever. Out of scope: the sandbox iframe channel and ticket lifecycle.

## User Impact

Users opening a standalone MCP App view against a stalled or wedged gateway now get a visible error within seconds-to-two-minutes instead of an infinite spinner, and proxied tool operations fail with an error rather than hanging the page indefinitely.

## Evidence

Real probe evaluating the production `runStandaloneMcpAppHost` source (the exact bytes the gateway serializes into the page) with stubbed browser globals and a real local TCP server that accepts the bootstrap fetch and never responds:

```console
$ node --import tsx probe.mjs        # before fix (upstream/main)
stalled gateway stub listening on 127.0.0.1:45803
after 20051ms: page still waiting, no error surfaced (HANG)
VERDICT: bootstrap fetch has no deadline — page waits forever

$ node --import tsx probe.mjs        # after fix (this branch)
stalled gateway stub listening on 127.0.0.1:39085
after 15051ms: page surfaced error: The operation was aborted due to timeout
VERDICT: bootstrap fetch is bounded (fixed)
```

Focused suite: `src/gateway/mcp-app-standalone.test.ts` all pass, including a new regression test asserting the bootstrap fetch receives an `AbortSignal` deadline and that its failure is surfaced through the page error path; oxlint/oxfmt clean.

## Real behavior proof

- Behavior or issue addressed: the MCP App standalone page had no deadline on its bootstrap metadata fetch or its proxied operation POSTs, so a stalled gateway left the page spinning forever with no error.
- Real environment tested: Linux x86_64, Node 24.15.0, OpenClaw `main` (7fe1d70a50), production `runStandaloneMcpAppHost` from `src/gateway/mcp-app-standalone.ts` evaluated verbatim against a real stalled local TCP server.
- Exact steps or command run after this patch: started a local TCP server that accepts connections and never completes the response, ran `node --import tsx probe.mjs` which evaluates the real production page-host function with stubbed browser globals pointed at that server, and timed how long until the page surfaced an error.
- Evidence after fix:

```console
$ node --import tsx probe.mjs
stalled gateway stub listening on 127.0.0.1:39085
after 15051ms: page surfaced error: The operation was aborted due to timeout
VERDICT: bootstrap fetch is bounded (fixed)
```

- Observed result after fix: the page surfaces "The operation was aborted due to timeout" at ~15s (the bootstrap deadline) instead of waiting past 20s with no error as before the patch.
- What was not tested: a real browser session and the 115s operation-POST deadline end to end (the regression test locks the deadline wiring; the live probe covers the bootstrap path).

## Regression test plan

- Target test file: `src/gateway/mcp-app-standalone.test.ts`
- Scenario locked in: the bootstrap fetch must receive an `AbortSignal` and its timeout failure must reach the page's `fail()` rendering path (the host function is exposed via the existing `mcpAppStandaloneTesting` barrel for this).

## Risk checklist

- User-visible behavior changed? Yes — standalone MCP App pages now fail visibly on stalled gateways instead of spinning forever.
- Config/env/migration changed? No.
- Security/auth/secrets/network/tool-exec changed? No new network surface; existing fetches gain deadlines.
