### PR TITLE
fix(codex): bound app-server websocket upgrade with handshake timeout

### DIFF
--- a/extensions/codex/src/app-server/transport-websocket.test.ts
+++ b/extensions/codex/src/app-server/transport-websocket.test.ts
@@ -3,11 +3,23 @@ import { mkdtemp, rm } from "node:fs/promises";
 import http from "node:http";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { WebSocketServer, type RawData } from "ws";
 import { CodexAppServerClient } from "./client.js";
 import { createWebSocketTransport } from "./transport-websocket.js";
 
+const wsClientOptionsSeen = vi.hoisted(() => [] as Array<Record<string, unknown>>);
+
+vi.mock("ws", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("ws")>();
+  class RecordingWebSocket extends actual.WebSocket {
+    constructor(address: string | URL, options?: Record<string, unknown>) {
+      wsClientOptionsSeen.push(options ?? {});
+      super(address, options as ConstructorParameters<typeof actual.WebSocket>[1]);
+    }
+  }
+  return { ...actual, default: RecordingWebSocket };
+});
 describe("Codex app-server websocket transport", () => {
   const clients: CodexAppServerClient[] = [];
   const transports: Array<ReturnType<typeof createWebSocketTransport>> = [];
@@ -41,6 +53,14 @@ describe("Codex app-server websocket transport", () => {
       ),
     );
     await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { force: true, recursive: true })));
+  });
+
+  it("bounds the upgrade wait with a handshake timeout", () => {
+    const transport = createWebSocketTransport({ url: "ws://127.0.0.1:1/" });
+    // Swallow the expected connection-refused error so the wiring assertion is
+    // the only signal; the socket closes itself without an open connection.
+    transport.once?.("error", () => undefined);
+    expect(wsClientOptionsSeen.at(-1)).toMatchObject({ handshakeTimeout: 30_000 });
   });
 
   it("can speak JSON-RPC over websocket transport", async () => {

--- a/extensions/codex/src/app-server/transport-websocket.ts
+++ b/extensions/codex/src/app-server/transport-websocket.ts
@@ -11,6 +11,11 @@ import WebSocket, { type RawData } from "ws";
 import { resolveCodexAppServerUserHomeDir, type CodexAppServerStartOptions } from "./config.js";
 import type { CodexAppServerTransport } from "./transport.js";
 
+// `ws` otherwise waits indefinitely for the HTTP upgrade. Keep the 30s channel
+// precedent (qqbot, Discord, Slack, Signal) so a half-open upgrade fails
+// instead of pinning buffered frames until process exit.
+const CODEX_APP_SERVER_WS_HANDSHAKE_TIMEOUT_MS = 30_000;
+
 /** Opens a WebSocket app-server transport and maps newline-delimited frames to stdout/stdin. */
 export function createWebSocketTransport(
   options: CodexAppServerStartOptions,
@@ -31,6 +36,7 @@ export function createWebSocketTransport(
     headers,
     // Codex app-server closes Unix upgrade handshakes that offer compression.
     perMessageDeflate: false,
+    handshakeTimeout: CODEX_APP_SERVER_WS_HANDSHAKE_TIMEOUT_MS,
   };
   const unixSocketPath = resolveCodexAppServerUnixSocketPath(options);
   const socket = unixSocketPath


### PR DESCRIPTION
## What Problem This Solves

Fixes an indefinite hang where the Codex app-server WebSocket transport (`extensions/codex/src/app-server/transport-websocket.ts`) would wait forever when a remote endpoint accepts the TCP connection but never completes the WebSocket upgrade: `ws` applies no handshake deadline by default, so no `open`/`error`/`close` ever fires and outbound JSON-RPC frames pile up in `pendingFrames` until process exit.

## Why This Change Was Made

Adds `handshakeTimeout: 30_000` to the transport's `ws` client options — the same 30s precedent already used by every other WebSocket client in the repo (`extensions/qqbot/src/engine/gateway/ws-client.ts`, Discord, Slack, Signal) — so a half-open upgrade fails with `Opening handshake has timed out` and the transport surfaces `error`/`exit` through its normal event path instead of waiting forever. The timeout only abandons a stalled upgrade attempt; no frames are exchanged before the upgrade completes, so the Codex app-server protocol is unaffected (server side just authorizes and upgrades: `codex-rs/app-server-transport/src/transport/websocket.rs`). Out of scope: request-level deadlines after the upgrade, which the shared-client acquire path already bounds.

## User Impact

Operators running the Codex harness against a remote or wedged app-server endpoint now get a bounded 30s handshake failure with a clear error instead of a permanently stuck connection that never reports.

## Evidence

Real probe against the production `createWebSocketTransport` with a raw local TCP server that accepts the connection and never answers the HTTP upgrade:

```console
$ node --import tsx probe.mjs        # before fix (upstream/main)
silent TCP stub listening on 127.0.0.1:40199
after 40085ms: transport still waiting (killed=false)
VERDICT: half-open upgrade waits forever (bug)

$ node --import tsx probe.mjs        # after fix (this branch)
silent TCP stub listening on 127.0.0.1:46711
after 30068ms: transport closed (error: Opening handshake has timed out)
VERDICT: half-open upgrade is bounded (fixed)
```

Focused suite: `extensions/codex/src/app-server/transport-websocket.test.ts` 5/5 pass, including a new regression test asserting the `ws` client is constructed with `handshakeTimeout: 30_000`; oxlint/oxfmt clean.

## Real behavior proof

- Behavior or issue addressed: the Codex app-server WebSocket transport had no handshake deadline, so an endpoint that accepts TCP but never completes the upgrade left the transport waiting forever with buffered frames.
- Real environment tested: Linux x86_64, Node 24.15.0, OpenClaw `main` (7fe1d70a50), production `createWebSocketTransport` from `extensions/codex/src/app-server/transport-websocket.ts` against a real silent local TCP server.
- Exact steps or command run after this patch: started a raw `node:net` server that accepts and stays silent, created the real transport via `node --import tsx probe.mjs` pointed at it, and timed how long until the transport surfaced error/exit (listening on its documented `once` event API).
- Evidence after fix:

```console
$ node --import tsx probe.mjs
silent TCP stub listening on 127.0.0.1:46711
after 30068ms: transport closed (error: Opening handshake has timed out)
VERDICT: half-open upgrade is bounded (fixed)
```

- Observed result after fix: the transport fails the half-open upgrade at ~30s with "Opening handshake has timed out" delivered through its normal `error` event, instead of waiting past 40s with no signal as before the patch.
- What was not tested: a live remote Codex app-server; post-upgrade request deadlines (already bounded by the shared-client acquire path).

## Regression test plan

- Target test file: `extensions/codex/src/app-server/transport-websocket.test.ts`
- Scenario locked in: the `ws` client must be constructed with `handshakeTimeout: 30_000` (recorded via a constructor-wrapping mock of `ws`).

## Risk checklist

- User-visible behavior changed? Yes — stalled app-server upgrades now fail after 30s with a clear error instead of hanging forever.
- Config/env/migration changed? No.
- Security/auth/secrets/network/tool-exec changed? No new network surface; the existing upgrade wait gains a deadline.
