### PR TITLE
fix(discord): accept raw mentions when hydration fails

### DIFF
--- a/extensions/discord/src/monitor/message-handler.hydration.test.ts
+++ b/extensions/discord/src/monitor/message-handler.hydration.test.ts
@@ -96,7 +96,7 @@ describe("hydrateDiscordMessageIfNeeded", () => {
     ]);
     const message = new Message<true>(client, { id: "m1", channelId: "c1" }) as unknown as Message;
 
-    const hydrated = await hydrateDiscordMessageIfNeeded({
+    const { message: hydrated } = await hydrateDiscordMessageIfNeeded({
       client: { rest },
       message,
       messageChannelId: "c1",
@@ -109,6 +109,28 @@ describe("hydrateDiscordMessageIfNeeded", () => {
     expect(hydrated.mentionedUsers[0]?.globalName).toBe("Bob Builder");
     expect(hydrated.mentionedRoles).toEqual(["role1"]);
     expect(hydrated.referencedMessage?.content).toBe("earlier");
+  });
+
+  it("reports current-message hydration failures as unavailable", async () => {
+    const client = createInternalTestClient();
+    const rest = createFakeRestClient();
+    rest.get = vi.fn(async () => {
+      throw new Error("Discord REST unavailable");
+    });
+    const message = new Message(
+      client,
+      createMessagePayload({
+        content: "hello <@123>",
+      }),
+    );
+
+    const outcome = await hydrateDiscordMessageIfNeeded({
+      client: { rest },
+      message,
+      messageChannelId: "c1",
+    });
+
+    expect(outcome).toEqual({ kind: "unavailable", message });
   });
 
   it("uses referenced messages supplied by current-message hydration", async () => {
@@ -135,7 +157,7 @@ describe("hydrateDiscordMessageIfNeeded", () => {
       }),
     );
 
-    const hydrated = await hydrateDiscordMessageIfNeeded({
+    const { message: hydrated } = await hydrateDiscordMessageIfNeeded({
       client: { rest },
       message,
       messageChannelId: "c1",
@@ -152,7 +174,7 @@ describe("hydrateDiscordMessageIfNeeded", () => {
     ]);
     const message = new Message(client, createDefaultReplyPayload());
 
-    const hydrated = await hydrateDiscordMessageIfNeeded({
+    const { message: hydrated } = await hydrateDiscordMessageIfNeeded({
       client: { rest },
       message,
       messageChannelId: "c1",
@@ -194,7 +216,7 @@ describe("hydrateDiscordMessageIfNeeded", () => {
     ]);
     const message = new Message(client, reply);
 
-    const hydrated = await hydrateDiscordMessageIfNeeded({
+    const { message: hydrated } = await hydrateDiscordMessageIfNeeded({
       client: { rest },
       message,
       messageChannelId: "c1",
@@ -213,7 +235,7 @@ describe("hydrateDiscordMessageIfNeeded", () => {
     rest.get = get;
     const message = new Message(client, createDefaultReplyPayload());
 
-    const hydrated = await hydrateDiscordMessageIfNeeded({
+    const { message: hydrated } = await hydrateDiscordMessageIfNeeded({
       client: { rest },
       message,
       messageChannelId: "c1",

--- a/extensions/discord/src/monitor/message-handler.hydration.ts
+++ b/extensions/discord/src/monitor/message-handler.hydration.ts
@@ -201,14 +201,11 @@ async function hydrateDiscordReplyReference(params: {
   }
   const referencedChannelId = reference.channel_id ?? params.messageChannelId;
   try {
-    const referenced = (await getChannelMessage(
+    const referenced = await getChannelMessage(
       params.client.rest,
       referencedChannelId,
       referencedMessageId,
-    )) as APIMessage | null | undefined;
-    if (!referenced) {
-      return params.message;
-    }
+    );
     // Discord may omit referenced_message from both Gateway and REST reply payloads.
     // Attach the canonical referenced fetch so downstream reply context stays bounded.
     return mergeFetchedDiscordMessage(params.message, {
@@ -223,35 +220,38 @@ async function hydrateDiscordReplyReference(params: {
   }
 }
 
+type DiscordMessageHydrationOutcome =
+  | { kind: "authoritative"; message: Message }
+  | { kind: "unavailable"; message: Message };
+
 export async function hydrateDiscordMessageIfNeeded(params: {
   client: { rest: Parameters<typeof getChannelMessage>[0] };
   message: Message;
   messageChannelId: string;
   channelInfo?: DiscordChannelInfo | null;
-  onMessageHydrationFailure?: () => void;
-}): Promise<Message> {
+}): Promise<DiscordMessageHydrationOutcome> {
   void params.channelInfo;
   let hydrated = params.message;
   if (shouldHydrateDiscordMessagePayload({ message: params.message })) {
     try {
-      const fetched = (await getChannelMessage(
+      const fetched = await getChannelMessage(
         params.client.rest,
         params.messageChannelId,
         params.message.id,
-      )) as APIMessage | null | undefined;
-      if (fetched) {
-        logVerbose(`discord: hydrated inbound payload via REST for ${params.message.id}`);
-        hydrated = mergeFetchedDiscordMessage(params.message, fetched);
-      }
+      );
+      logVerbose(`discord: hydrated inbound payload via REST for ${params.message.id}`);
+      hydrated = mergeFetchedDiscordMessage(params.message, fetched);
     } catch (err) {
       logVerbose(`discord: failed to hydrate message ${params.message.id}: ${String(err)}`);
-      params.onMessageHydrationFailure?.();
-      return params.message;
+      return { kind: "unavailable", message: params.message };
     }
   }
-  return hydrateDiscordReplyReference({
-    client: params.client,
-    message: hydrated,
-    messageChannelId: params.messageChannelId,
-  });
+  return {
+    kind: "authoritative",
+    message: await hydrateDiscordReplyReference({
+      client: params.client,
+      message: hydrated,
+      messageChannelId: params.messageChannelId,
+    }),
+  };
 }

--- a/extensions/discord/src/monitor/message-handler.hydration.ts
+++ b/extensions/discord/src/monitor/message-handler.hydration.ts
@@ -228,6 +228,7 @@ export async function hydrateDiscordMessageIfNeeded(params: {
   message: Message;
   messageChannelId: string;
   channelInfo?: DiscordChannelInfo | null;
+  onMessageHydrationFailure?: () => void;
 }): Promise<Message> {
   void params.channelInfo;
   let hydrated = params.message;
@@ -244,6 +245,7 @@ export async function hydrateDiscordMessageIfNeeded(params: {
       }
     } catch (err) {
       logVerbose(`discord: failed to hydrate message ${params.message.id}: ${String(err)}`);
+      params.onMessageHydrationFailure?.();
       return params.message;
     }
   }

--- a/extensions/discord/src/monitor/message-handler.preflight-helpers.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight-helpers.ts
@@ -122,6 +122,13 @@ export function resolveDiscordMentionState(params: {
   };
 }
 
+export function hasRawDiscordUserMention(text: string, userId?: string): boolean {
+  if (!userId) {
+    return false;
+  }
+  return text.includes(`<@${userId}>`) || text.includes(`<@!${userId}>`);
+}
+
 export function resolvePreflightMentionRequirement(params: {
   shouldRequireMention: boolean;
   bypassMentionRequirement: boolean;

--- a/extensions/discord/src/monitor/message-handler.preflight-helpers.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight-helpers.ts
@@ -4,6 +4,7 @@ import {
   matchesMentionWithExplicit,
 } from "openclaw/plugin-sdk/channel-inbound";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { findCodeRegions, isInsideCode } from "openclaw/plugin-sdk/text-chunking";
 import { ChannelType, type Message } from "../internal/discord.js";
 import type { DiscordMessagePreflightParams } from "./message-handler.preflight.types.js";
 import type { DiscordChannelInfo } from "./message-utils.js";
@@ -126,7 +127,21 @@ export function hasRawDiscordUserMention(text: string, userId?: string): boolean
   if (!userId) {
     return false;
   }
-  return text.includes(`<@${userId}>`) || text.includes(`<@!${userId}>`);
+  const codeRegions = findCodeRegions(text);
+  for (const mention of [`<@${userId}>`, `<@!${userId}>`]) {
+    let index = text.indexOf(mention);
+    while (index >= 0) {
+      let precedingBackslashes = 0;
+      for (let offset = index - 1; offset >= 0 && text[offset] === "\\"; offset -= 1) {
+        precedingBackslashes += 1;
+      }
+      if (precedingBackslashes % 2 === 0 && !isInsideCode(index, codeRegions)) {
+        return true;
+      }
+      index = text.indexOf(mention, index + mention.length);
+    }
+  }
+  return false;
 }
 
 export function resolvePreflightMentionRequirement(params: {

--- a/extensions/discord/src/monitor/message-handler.preflight.test.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.test.ts
@@ -1299,7 +1299,7 @@ describe("preflightDiscordMessage", () => {
     const message = createDiscordMessage({
       id: "m-bot-mentions-authoritative",
       channelId,
-      content: `example: \`<@${botId}>\``,
+      content: `hi <@${botId}>`,
       author: {
         id: "relay-bot-1",
         bot: true,
@@ -1345,6 +1345,9 @@ describe("preflightDiscordMessage", () => {
       content: (botId: string) => `example:\n\`\`\`text\n<@${botId}>\n\`\`\``,
     },
     { name: "escaped syntax", content: (botId: string) => `example: \\<@${botId}>` },
+    { name: "another user", content: () => "hi <@987654321098765432>" },
+    { name: "role mention", content: (botId: string) => `hi <@&${botId}>` },
+    { name: "longer user id", content: (botId: string) => `hi <@${botId}9>` },
   ])("does not trust $name when REST hydration fails", async ({ content }) => {
     const channelId = "channel-bot-mentions-untrusted";
     const guildId = "guild-bot-mentions-untrusted";

--- a/extensions/discord/src/monitor/message-handler.preflight.test.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.test.ts
@@ -1292,6 +1292,52 @@ describe("preflightDiscordMessage", () => {
     },
   );
 
+  it("does not trust raw mention syntax when REST hydration succeeds without a mention", async () => {
+    const channelId = "channel-bot-mentions-authoritative";
+    const guildId = "guild-bot-mentions-authoritative";
+    const botId = "123456789012345678";
+    const message = createDiscordMessage({
+      id: "m-bot-mentions-authoritative",
+      channelId,
+      content: `example: \`<@${botId}>\``,
+      author: {
+        id: "relay-bot-1",
+        bot: true,
+        username: "Relay",
+      },
+      mentionedUsers: [],
+    });
+    const client = createGuildTextClient(channelId);
+    client.rest = {
+      get: vi.fn(async () => ({
+        id: message.id,
+        content: message.content,
+        mentions: [],
+        mention_roles: [],
+        mention_everyone: false,
+      })),
+    } as unknown as DiscordClient["rest"];
+
+    const result = await preflightDiscordMessage({
+      ...createPreflightArgs({
+        cfg: DEFAULT_PREFLIGHT_CFG,
+        discordConfig: {
+          allowBots: "mentions",
+        } as DiscordConfig,
+        data: createGuildEvent({
+          channelId,
+          guildId,
+          author: message.author,
+          message,
+        }),
+        client,
+      }),
+      botUserId: botId,
+    });
+
+    expect(result).toBeNull();
+  });
+
   it("still drops bot control commands without a real mention when allowBots=mentions", async () => {
     const channelId = "channel-bot-command-no-mention";
     const guildId = "guild-bot-command-no-mention";

--- a/extensions/discord/src/monitor/message-handler.preflight.test.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.test.ts
@@ -1338,6 +1338,55 @@ describe("preflightDiscordMessage", () => {
     expect(result).toBeNull();
   });
 
+  it.each([
+    { name: "inline code", content: (botId: string) => `example: \`<@${botId}>\`` },
+    {
+      name: "fenced code",
+      content: (botId: string) => `example:\n\`\`\`text\n<@${botId}>\n\`\`\``,
+    },
+    { name: "escaped syntax", content: (botId: string) => `example: \\<@${botId}>` },
+  ])("does not trust $name when REST hydration fails", async ({ content }) => {
+    const channelId = "channel-bot-mentions-untrusted";
+    const guildId = "guild-bot-mentions-untrusted";
+    const botId = "123456789012345678";
+    const message = createDiscordMessage({
+      id: "m-bot-mentions-untrusted",
+      channelId,
+      content: content(botId),
+      author: {
+        id: "relay-bot-1",
+        bot: true,
+        username: "Relay",
+      },
+      mentionedUsers: [],
+    });
+    const client = createGuildTextClient(channelId);
+    client.rest = {
+      get: vi.fn(async () => {
+        throw new Error("Discord REST unavailable");
+      }),
+    } as unknown as DiscordClient["rest"];
+
+    const result = await preflightDiscordMessage({
+      ...createPreflightArgs({
+        cfg: DEFAULT_PREFLIGHT_CFG,
+        discordConfig: {
+          allowBots: "mentions",
+        } as DiscordConfig,
+        data: createGuildEvent({
+          channelId,
+          guildId,
+          author: message.author,
+          message,
+        }),
+        client,
+      }),
+      botUserId: botId,
+    });
+
+    expect(result).toBeNull();
+  });
+
   it("still drops bot control commands without a real mention when allowBots=mentions", async () => {
     const channelId = "channel-bot-command-no-mention";
     const guildId = "guild-bot-command-no-mention";

--- a/extensions/discord/src/monitor/message-handler.preflight.test.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.test.ts
@@ -1247,6 +1247,51 @@ describe("preflightDiscordMessage", () => {
     expect(expectPreflightResult(result).message.id).toBe("m-bot-mentions-hydrated");
   });
 
+  it.each(["<@123456789012345678>", "<@!123456789012345678>"])(
+    "accepts raw bot mention %s when REST hydration fails",
+    async (rawMention) => {
+      const channelId = "channel-bot-mentions-raw";
+      const guildId = "guild-bot-mentions-raw";
+      const botId = "123456789012345678";
+      const message = createDiscordMessage({
+        id: "m-bot-mentions-raw",
+        channelId,
+        content: `hi ${rawMention}`,
+        author: {
+          id: "relay-bot-1",
+          bot: true,
+          username: "Relay",
+        },
+        mentionedUsers: [],
+      });
+      const client = createGuildTextClient(channelId);
+      client.rest = {
+        get: vi.fn(async () => {
+          throw new Error("Discord REST unavailable");
+        }),
+      } as unknown as DiscordClient["rest"];
+
+      const result = await preflightDiscordMessage({
+        ...createPreflightArgs({
+          cfg: DEFAULT_PREFLIGHT_CFG,
+          discordConfig: {
+            allowBots: "mentions",
+          } as DiscordConfig,
+          data: createGuildEvent({
+            channelId,
+            guildId,
+            author: message.author,
+            message,
+          }),
+          client,
+        }),
+        botUserId: botId,
+      });
+
+      expect(expectPreflightResult(result).message.id).toBe("m-bot-mentions-raw");
+    },
+  );
+
   it("still drops bot control commands without a real mention when allowBots=mentions", async () => {
     const channelId = "channel-bot-command-no-mention";
     const guildId = "guild-bot-command-no-mention";

--- a/extensions/discord/src/monitor/message-handler.preflight.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.ts
@@ -250,15 +250,12 @@ export async function preflightDiscordMessage(
     return null;
   }
 
-  let messageHydrationFailed = false;
-  message = await hydrateDiscordMessageIfNeeded({
+  const hydration = await hydrateDiscordMessageIfNeeded({
     client: params.client,
     message,
     messageChannelId,
-    onMessageHydrationFailure: () => {
-      messageHydrationFailed = true;
-    },
   });
+  message = hydration.message;
   if (isPreflightAborted(params.abortSignal)) {
     return null;
   }
@@ -466,7 +463,7 @@ export async function preflightDiscordMessage(
   const explicitlyMentioned = Boolean(
     botId &&
     (message.mentionedUsers?.some((user: User) => user.id === botId) ||
-      (messageHydrationFailed && hasRawDiscordUserMention(baseText, botId))),
+      (hydration.kind === "unavailable" && hasRawDiscordUserMention(baseText, botId))),
   );
   const hasAnyMention =
     !isDirectMessage &&

--- a/extensions/discord/src/monitor/message-handler.preflight.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.ts
@@ -250,10 +250,14 @@ export async function preflightDiscordMessage(
     return null;
   }
 
+  let messageHydrationFailed = false;
   message = await hydrateDiscordMessageIfNeeded({
     client: params.client,
     message,
     messageChannelId,
+    onMessageHydrationFailure: () => {
+      messageHydrationFailed = true;
+    },
   });
   if (isPreflightAborted(params.abortSignal)) {
     return null;
@@ -462,7 +466,7 @@ export async function preflightDiscordMessage(
   const explicitlyMentioned = Boolean(
     botId &&
     (message.mentionedUsers?.some((user: User) => user.id === botId) ||
-      hasRawDiscordUserMention(baseText, botId)),
+      (messageHydrationFailed && hasRawDiscordUserMention(baseText, botId))),
   );
   const hasAnyMention =
     !isDirectMessage &&

--- a/extensions/discord/src/monitor/message-handler.preflight.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.ts
@@ -38,6 +38,7 @@ import { resolveDiscordPreflightChannelAccess } from "./message-handler.prefligh
 import { resolveDiscordPreflightChannelContext } from "./message-handler.preflight-channel-context.js";
 import { buildDiscordMessagePreflightContext } from "./message-handler.preflight-context.js";
 import {
+  hasRawDiscordUserMention,
   isBoundThreadBotSystemMessage,
   isDiscordThreadChannelMessage,
   resolveDiscordMentionState,
@@ -459,7 +460,9 @@ export async function preflightDiscordMessage(
     providerPolicy: params.discordConfig?.mentionPatterns,
   });
   const explicitlyMentioned = Boolean(
-    botId && message.mentionedUsers?.some((user: User) => user.id === botId),
+    botId &&
+    (message.mentionedUsers?.some((user: User) => user.id === botId) ||
+      hasRawDiscordUserMention(baseText, botId)),
   );
   const hasAnyMention =
     !isDirectMessage &&


### PR DESCRIPTION
Fixes #111858

## What Problem This Solves

Discord guild messages containing a direct `<@BOT_ID>` or `<@!BOT_ID>` mention can be silently dropped when mention metadata is absent and the fallback REST hydration request fails.

## Why This Change Was Made

Discord preflight continues to treat successfully hydrated mention metadata as authoritative. Only when REST hydration fails does it inspect the raw message for the exact current bot ID.

The fallback is deliberately narrower than a string search:

- it accepts only exact native `<@BOT_ID>` and `<@!BOT_ID>` forms;
- it rejects mention-like text inside inline or fenced code;
- it rejects syntax escaped with an odd number of backslashes;
- it does not broaden configured text mention patterns.

## User Impact

Transient Discord REST failures no longer turn a real mention-required ping into permanent message loss, while examples such as `` `<@BOT_ID>` `` cannot trigger the bot during the outage.

## Evidence

Validated on rebased head `14c8de67c92bf1c4e66d4cab7a810470f05d7abe`.

- Full Discord preflight integration suite: 1 file, 56 tests passed.
- Positive hydration-failure coverage for both `<@BOT_ID>` and `<@!BOT_ID>`.
- Negative hydration-failure coverage for inline code, fenced code, and escaped syntax.
- Successful-hydration coverage confirms authoritative empty metadata still rejects raw mention-like text.
- `oxlint` passed on all four touched files.
- `oxfmt --check` passed on all four touched files.
- `git diff --check` passed.
- Local whole-branch autoreview: no accepted/actionable findings; `overall: patch is correct (0.90)`.

### Review feedback addressed

The previous review identified a false-positive path where code-span or escaped mention syntax could satisfy the fallback. Head `14c8de67c...` now uses the existing plugin SDK code-region scanner and explicit escape handling, with full preflight regression coverage.

### Proof limitation

The validation above exercises the production Discord preflight with REST hydration forced to fail, but it is repository-controlled integration evidence rather than a live external Discord outage capture. No live-runtime claim is made here.
