### PR TITLE
fix(ui): oversized chat history messages show a clear notice

### DIFF
--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -3898,6 +3898,7 @@ export const en: TranslationMap = {
       forkUnavailable: "Fork is unavailable while the agent is working",
       unknownDate: "Unknown date",
       voiceNote: "Voice note",
+      tooLargeToDisplay: "This message is too large to display here.",
     },
     modelControls: {
       default: "Default",

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -529,6 +529,24 @@ describe("grouped chat rendering", () => {
     expect(userBubble.querySelector(".chat-bubble-actions")).toBeNull();
   });
 
+  it("renders oversized history placeholders as a user-facing notice", () => {
+    const container = document.createElement("div");
+    renderGroupedMessage(
+      container,
+      {
+        role: "user",
+        content: [{ type: "text", text: "[chat.history omitted: message too large]" }],
+        __openclaw: { id: "oversized-user", seq: 1, truncated: true, reason: "oversized" },
+      },
+      "user",
+    );
+
+    const notice = expectElement(container, ".chat-history-omitted", HTMLElement);
+    expect(notice.textContent?.trim()).toBe("This message is too large to display here.");
+    expect(container.textContent).not.toContain("[chat.history omitted: message too large]");
+    expect(notice.classList.contains("chat-text")).toBe(true);
+  });
+
   it("does not replay an arrival animation when a message row mounts", () => {
     const container = document.createElement("div");
     renderAssistantMessage(container, {
@@ -3622,6 +3640,41 @@ describe("grouped chat rendering", () => {
       sessionKey: "global",
       agentId: "work",
       messageId: "msg-truncated-1",
+      kind: "assistant_message",
+    });
+  });
+
+  it("keeps oversized assistant history expandable without exposing the internal placeholder", () => {
+    const container = document.createElement("div");
+    const onOpenSidebar = vi.fn();
+    renderAssistantMessage(
+      container,
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "[chat.history omitted: message too large]" }],
+        __openclaw: {
+          id: "msg-oversized-assistant",
+          seq: 1,
+          truncated: true,
+          reason: "oversized",
+        },
+      },
+      {
+        sessionKey: "global",
+        agentId: "work",
+        onOpenSidebar,
+      },
+    );
+
+    expect(container.textContent).not.toContain("[chat.history omitted: message too large]");
+    container.querySelector<HTMLButtonElement>(".chat-expand-btn")?.click();
+
+    const sidebar = requireFirstMockArg(onOpenSidebar, "sidebar open");
+    expect(sidebar.content).toBe("This message is too large to display here.");
+    expect(sidebar.fullMessageRequest).toEqual({
+      sessionKey: "global",
+      agentId: "work",
+      messageId: "msg-oversized-assistant",
       kind: "assistant_message",
     });
   });

--- a/ui/src/pages/chat/components/chat-message.ts
+++ b/ui/src/pages/chat/components/chat-message.ts
@@ -2247,6 +2247,21 @@ function resolveNormalizedMessageMarkdown(normalizedMessage: NormalizedMessage):
     .trim();
 }
 
+function resolveTranscriptMetadata(message: unknown): Record<string, unknown> | null {
+  if (!message || typeof message !== "object" || Array.isArray(message)) {
+    return null;
+  }
+  const metadata = (message as Record<string, unknown>)["__openclaw"];
+  return metadata && typeof metadata === "object" && !Array.isArray(metadata)
+    ? (metadata as Record<string, unknown>)
+    : null;
+}
+
+function isOversizedHistoryPlaceholder(message: unknown): boolean {
+  const metadata = resolveTranscriptMetadata(message);
+  return metadata?.truncated === true && metadata.reason === "oversized";
+}
+
 function resolveMessageActionDetails(
   message: unknown,
   onOpenSidebar?: (content: SidebarContent) => void,
@@ -2256,16 +2271,13 @@ function resolveMessageActionDetails(
   if (normalizeRoleForGrouping(normalizedMessage.role) !== "assistant") {
     return null;
   }
-  const markdown = stripThinkingTags(resolveNormalizedMessageMarkdown(normalizedMessage)).trim();
+  const markdown = isOversizedHistoryPlaceholder(message)
+    ? t("chat.messages.tooLargeToDisplay")
+    : stripThinkingTags(resolveNormalizedMessageMarkdown(normalizedMessage)).trim();
   if (!markdown) {
     return null;
   }
-  const transcriptMeta =
-    record["__openclaw"] &&
-    typeof record["__openclaw"] === "object" &&
-    !Array.isArray(record["__openclaw"])
-      ? (record["__openclaw"] as Record<string, unknown>)
-      : null;
+  const transcriptMeta = resolveTranscriptMetadata(message);
   const messageId =
     typeof transcriptMeta?.id === "string"
       ? transcriptMeta.id
@@ -2357,7 +2369,11 @@ function renderGroupedMessage(
   const pairingQrExpiryNotices = extractPairingQrExpiryNotices(message);
   const hasPairingQrExpiryNotices = pairingQrExpiryNotices.length > 0;
 
-  const extractedText = resolveNormalizedMessageMarkdown(normalizedMessage);
+  const oversizedHistoryNotice = isOversizedHistoryPlaceholder(message)
+    ? t("chat.messages.tooLargeToDisplay")
+    : null;
+  const extractedText =
+    oversizedHistoryNotice ?? resolveNormalizedMessageMarkdown(normalizedMessage);
   const assistantAttachments = normalizedMessage.content.filter(
     (item): item is AttachmentItem => item.type === "attachment",
   );
@@ -2575,7 +2591,12 @@ function renderGroupedMessage(
                             <pre class="chat-json-content"><code>${jsonResult.pretty}</code></pre>
                           </details>`
                         : markdown
-                          ? renderMarkdownText(markdown, opts.isStreaming, markdownRenderOptions)
+                          ? renderMarkdownText(
+                              markdown,
+                              opts.isStreaming,
+                              markdownRenderOptions,
+                              Boolean(oversizedHistoryNotice),
+                            )
                           : nothing}
                       ${hasToolCards
                         ? singleToolCard && !markdown && !hasImages
@@ -2634,7 +2655,12 @@ function renderGroupedMessage(
                   <pre class="chat-json-content"><code>${jsonResult.pretty}</code></pre>
                 </details>`
               : markdown
-                ? renderMarkdownText(markdown, opts.isStreaming, markdownRenderOptions)
+                ? renderMarkdownText(
+                    markdown,
+                    opts.isStreaming,
+                    markdownRenderOptions,
+                    Boolean(oversizedHistoryNotice),
+                  )
                 : nothing}
             ${hasToolCards
               ? renderInlineToolCards(toolCards, {
@@ -2668,16 +2694,18 @@ function renderMarkdownText(
   markdown: string,
   isStreaming: boolean,
   markdownRenderOptions?: MarkdownRenderOptions,
+  isHistoryOmitted = false,
 ) {
+  const className = isHistoryOmitted ? "chat-text chat-history-omitted" : "chat-text";
   if (isStreaming) {
     return html`
-      <div class="chat-text" dir="${detectTextDirection(markdown)}">
+      <div class=${className} dir="${detectTextDirection(markdown)}">
         ${unsafeHTML(toStreamingMarkdownHtml(markdown, markdownRenderOptions))}
       </div>
     `;
   }
   return html`
-    <div class="chat-text" dir="${detectTextDirection(markdown)}">
+    <div class=${className} dir="${detectTextDirection(markdown)}">
       ${unsafeHTML(toSanitizedMarkdownHtml(markdown, markdownRenderOptions))}
     </div>
   `;

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -399,6 +399,11 @@ img.chat-avatar {
   box-shadow: none;
 }
 
+.chat-history-omitted {
+  color: var(--muted);
+  font-style: italic;
+}
+
 /* Assistant replies render as a flat text stream: only user messages keep the
    bubble card. Border collapses to 0 so the streaming border pulse and hover
    outline become no-ops without extra rules. */


### PR DESCRIPTION
Closes #111854

## What Problem This Solves

Fixes an issue where users viewing oversized transcript rows in the Control UI would see the internal `[chat.history omitted: message too large]` marker as normal chat content.

## Why This Change Was Made

The Control UI now uses the existing structured transcript metadata (`truncated: true`, `reason: "oversized"`) to render a localized, muted notice instead of exposing the gateway's internal placeholder. The gateway protocol and history-budget behavior are unchanged, and truncated assistant rows keep their existing full-message expansion request.

## User Impact

Oversized history rows now say "This message is too large to display here." rather than showing an implementation detail. When an omitted assistant message has a transcript ID, users can still open the full message through the existing detail-panel flow.

## Evidence

- Before: `[chat.history omitted: message too large]`
- After: `This message is too large to display here.`
- Focused component suite: `108 passed` in `ui/src/pages/chat/components/chat-message.test.ts`
- Production UI types: `node scripts/run-tsgo.mjs -p tsconfig.ui.json ...`
- UI test types: `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.ui.json ...`
- Targeted Oxlint: passed for all changed TypeScript files
- Control UI i18n verification: passed
- Oxfmt check: passed for all four changed files
- Production bundle: `vite build` passed with 2,461 modules transformed
