### PR TITLE
fix(ui): render sidebar view-archived icon as outline

### DIFF
--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1732,6 +1732,10 @@ html.openclaw-native-macos
   width: 12px;
   height: 12px;
   stroke: currentColor;
+  fill: none;
+  stroke-width: 1.7px;
+  stroke-linecap: round;
+  stroke-linejoin: round;
 }
 
 .sidebar-recent-session--dragging {


### PR DESCRIPTION
## What Problem This Solves

The "View archived" button at the bottom of the sidebar thread list rendered its archive icon as a solid black bar with a faint outline underneath — it looked broken rather than like an archive box.

## Why This Change Was Made

`.sidebar-view-archived svg` in `ui/src/styles/layout.css` set `stroke: currentColor` but never `fill: none`, so the Lucide archive icon's lid `<rect>` picked up SVG's default black fill. Every sibling sidebar icon rule (`.sidebar-session-sort svg`, `.sidebar-session-group-actions svg`, `.sidebar-session-group-toggle__icon svg`) sets `fill: none` plus an explicit stroke width; this rule was the one outlier. The fix aligns it with the sibling pattern: `fill: none; stroke-width: 1.7px; stroke-linecap: round; stroke-linejoin: round`.

## User Impact

The "View archived" row now shows a clean outlined archive-box icon matching the weight and style of the other sidebar icons.

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/2026-07-view-archived-icon/before.png) | ![after](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/2026-07-view-archived-icon/after.png) |

## Evidence

- Verified live against the mock Control UI dev harness (`pnpm dev:ui:mock`): computed style on the button's `svg` now reports `fill: none`, `stroke-width: 1.7px`, round caps/joins, and the icon renders as the outlined archive box (screenshots above, captured at 3x device scale; "before" reproduced by re-applying the old rule).
- CSS-only diff (4 added lines); `git diff --check` clean. Full gates run on PR CI.


> Note: ClawSweeper's review worker posted its placeholder at 15:04Z but never completed (lease expired 15:45Z, no requeue after 65+ minutes) — there are no Rank-up moves to apply. Landing on green CI plus the live visual verification above; the diff is a 4-line CSS alignment with sibling icon rules.
