### PR TITLE
fix: admit healthy sessions after restart recovery completes

### DIFF
--- a/src/agents/main-session-recovery-state.test.ts
+++ b/src/agents/main-session-recovery-state.test.ts
@@ -204,6 +204,53 @@ describe("main session recovery state", () => {
     expect(entry).toEqual(before);
   });
 
+  it("clears orphaned lifecycle fences before healthy foreground admission", () => {
+    const entry = interruptedEntry({
+      abortedLastRun: false,
+      mainRestartRecovery: undefined,
+      restartRecoveryRuns: [{ runId: "stale-run", lifecycleGeneration: "stale-generation" }],
+    });
+
+    expect(
+      transitionMainSessionRecovery(entry, {
+        kind: "claim_foreground",
+        cycleId: "unused",
+        lifecycleGeneration: "generation-1",
+        sessionId: "session-1",
+        sessionKey,
+        claimId: "foreground-1",
+      }),
+    ).toEqual({ kind: "applied" });
+    expect(entry).toMatchObject({
+      status: "running",
+      abortedLastRun: false,
+    });
+    expect(entry.restartRecoveryRuns).toBeUndefined();
+    expect(entry.mainRestartRecovery).toBeUndefined();
+  });
+
+  it("keeps lifecycle fences while a recovery delivery owner remains", () => {
+    const entry = interruptedEntry({
+      abortedLastRun: false,
+      mainRestartRecovery: undefined,
+      restartRecoveryDeliveryRunId: "active-recovery",
+      restartRecoveryRuns: [{ runId: "active-recovery", lifecycleGeneration: "generation-1" }],
+    });
+    const before = structuredClone(entry);
+
+    expect(
+      transitionMainSessionRecovery(entry, {
+        kind: "claim_foreground",
+        cycleId: "unused",
+        lifecycleGeneration: "generation-1",
+        sessionId: "session-1",
+        sessionKey,
+        claimId: "foreground-1",
+      }),
+    ).toEqual({ kind: "no_change" });
+    expect(entry).toEqual(before);
+  });
+
   it("retires a stale reservation before granting foreground ownership", () => {
     const entry = interruptedEntry({
       mainRestartRecovery: recoveryState({

--- a/src/agents/main-session-recovery-state.ts
+++ b/src/agents/main-session-recovery-state.ts
@@ -155,6 +155,19 @@ export function isMainRestartRecoveryCandidate(entry: SessionEntry, sessionKey: 
   );
 }
 
+// A healthy session can retain lifecycle fences after its final recovery owner
+// clears. With no active delivery or aggregate, those fences no longer own work.
+function hasOrphanedMainRestartRecoveryFences(entry: SessionEntry, sessionKey: string): boolean {
+  return (
+    entry.status === "running" &&
+    entry.abortedLastRun !== true &&
+    entry.restartRecoveryRuns !== undefined &&
+    entry.mainRestartRecovery === undefined &&
+    entry.restartRecoveryDeliveryRunId === undefined &&
+    isMainRestartRecoveryCandidate(entry, sessionKey)
+  );
+}
+
 function inspectMainSessionRecovery(params: {
   entry: SessionEntry;
   lifecycleGeneration: string;
@@ -444,6 +457,13 @@ export function transitionMainSessionRecovery(
       return { kind: "applied" };
     }
     case "claim_foreground": {
+      if (
+        entry.sessionId === command.sessionId &&
+        hasOrphanedMainRestartRecoveryFences(entry, command.sessionKey)
+      ) {
+        Object.assign(entry, buildMainSessionRecoveryClearPatch(entry));
+        return { kind: "applied" };
+      }
       if (
         entry.sessionId !== command.sessionId ||
         entry.status !== "running" ||

--- a/src/agents/main-session-recovery-store.test.ts
+++ b/src/agents/main-session-recovery-store.test.ts
@@ -366,6 +366,31 @@ describe("main session recovery store", () => {
     expect(accessorSpy.mock.calls[0]?.[0]).toMatchObject({ sessionKeys: [sessionKey] });
   });
 
+  it("atomically clears orphaned lifecycle fences from a healthy row", async () => {
+    await write(
+      interruptedEntry({
+        abortedLastRun: false,
+        mainRestartRecovery: undefined,
+        restartRecoveryRuns: [{ runId: "stale-run", lifecycleGeneration: "stale-generation" }],
+      }),
+    );
+
+    await expect(
+      claimMainSessionRecoveryOwner({
+        lifecycleGeneration,
+        sessionId: "session-1",
+        target: { sessionKey, storePath },
+      }),
+    ).resolves.toEqual({ kind: "not_required" });
+    expect(read()).toMatchObject({
+      sessionId: "session-1",
+      status: "running",
+      abortedLastRun: false,
+    });
+    expect(read().restartRecoveryRuns).toBeUndefined();
+    expect(read().mainRestartRecovery).toBeUndefined();
+  });
+
   it("binds a foreground claim to its lifecycle run", async () => {
     await write(interruptedEntry());
 

--- a/src/auto-reply/reply/reply-turn-admission.test.ts
+++ b/src/auto-reply/reply/reply-turn-admission.test.ts
@@ -425,6 +425,36 @@ describe("reply turn admission", () => {
     },
   );
 
+  it("admits a visible turn after clearing orphaned restart-recovery fences", async () => {
+    const sessionKey = "agent:main:telegram:topic:orphaned-recovery-fence";
+    const sessionId = "healthy-session";
+    const storePath = createSessionStore({
+      [sessionKey]: {
+        sessionId,
+        updatedAt: 100,
+        status: "running",
+        abortedLastRun: false,
+        restartRecoveryRuns: [{ runId: "stale-run", lifecycleGeneration: "stale-generation" }],
+      },
+    });
+
+    const admission = await admitReplyTurn({
+      sessionKey,
+      sessionId,
+      expectedSessionId: sessionId,
+      storePath,
+      kind: "visible",
+      resetTriggered: false,
+    });
+    expect(admission.status).toBe("owned");
+    const persisted = await readSessionEntry(storePath, sessionKey);
+    expect(persisted?.restartRecoveryRuns).toBeUndefined();
+    expect(persisted?.mainRestartRecovery).toBeUndefined();
+    if (admission.status === "owned") {
+      admission.operation.complete();
+    }
+  });
+
   it("drops a queued followup for an admitted recovery fence", async () => {
     const sessionKey = "agent:main:telegram:topic:admitted-recovery";
     const sessionId = "admitted-recovery-session";


### PR DESCRIPTION
Closes #111862

## What Problem This Solves

Fixes an issue where healthy sessions could permanently reject ordinary turns after restart recovery left stale lifecycle fences in persisted session state. Channel retries then failed immediately with `Session changed while starting work` even though the Gateway had no active run.

## Why This Change Was Made

The recovery state machine now atomically clears orphaned lifecycle fences when the same running session is healthy and has neither an active recovery aggregate nor a delivery owner. Interrupted, actively owned, tombstoned, replaced-session, subagent, cron, and ACP recovery states remain fenced.

## User Impact

Users can continue an otherwise healthy session after restart recovery completes instead of requiring `/new`, reset, or manual state repair.

## Evidence

- Before the fix, focused state, store, and visible-admission regressions reproduced the stale-fence rejection.
- After the fix:
  - `main-session-recovery-state.test.ts`: 30 passed
  - `main-session-recovery-store.test.ts`: 25 passed
  - `reply-turn-admission.test.ts`: 43 passed
  - targeted `oxlint` and `git diff --check`: passed
- Structured Codex autoreview: clean, no accepted/actionable findings, 0.9 confidence.
- Live Phaedrus proof on exact head `95d3b31`:
  - pre-deploy SQLite backup contained 2 same-session rows with the exact orphaned-fence shape
  - after restart recovery, one affected row naturally returned to that exact stale state
  - an ordinary Gateway turn on that session completed un-aborted in 8.5s and delivered its reply to Telegram
  - both original session identities ended with all recovery fences cleared; 0 exact orphan rows remained
  - 0 post-deploy `Session changed while starting work` errors
  - Gateway stayed active with 0 restarts; health reported no event-loop degradation, plugin errors, or Telegram errors
  - the unrelated Tailscale serve startup warning remained unchanged at one occurrence before and after deployment
- GitHub `openclaw/ci-gate`: passed on exact head `95d3b31`.

AI-assisted implementation and review using Codex; the maintainer inspected the source, tests, and live failure state.
