### PR TITLE
fix(macos): refresh skills when control channel reconnects

### DIFF
--- a/apps/macos/Sources/OpenClaw/SkillsSettings.swift
+++ b/apps/macos/Sources/OpenClaw/SkillsSettings.swift
@@ -11,6 +11,7 @@ struct SkillsSettings: View {
     @State private var searchText = ""
     @State private var filter: SkillsFilter = .all
     @State private var didScheduleInitialRefresh = false
+    private let controlChannel = ControlChannel.shared
 
     init(state: AppState = AppStateStore.shared, model: SkillsSettingsModel = SkillsSettingsModel()) {
         self.state = state
@@ -44,6 +45,11 @@ struct SkillsSettings: View {
             self.didScheduleInitialRefresh = true
             await Task.yield()
             await self.model.refreshIfNeeded()
+        }
+        .onChange(of: self.controlChannel.state) { _, newState in
+            if case .connected = newState {
+                Task { await self.model.refresh(force: true) }
+            }
         }
         .sheet(item: self.$envEditor) { editor in
             EnvEditorView(editor: editor) { value in


### PR DESCRIPTION
## Problem
When the macOS app reconnects to the gateway, the Skills UI stays stuck showing "Unavailable" because the initial refresh only fires once on view load.

## Fix
Add an `.onChange(of: self.controlChannel.state)` modifier to `SkillsSettings` that triggers a forced `model.refresh(force: true)` when the connection state transitions to `.connected`. This ensures skill statuses and ClawHub verdicts update after a reconnect.

## Testing
- Disconnect and reconnect gateway while viewing Skills settings
- Verify skills refresh and verdicts populate after reconnect
- No change to initial load behavior (existing `refreshIfNeeded` path unchanged)

Fixes #107391