### PR TITLE
fix(ui): hydrate security verdicts on first skills page load

### DIFF
--- a/ui/src/lib/skills/index.ts
+++ b/ui/src/lib/skills/index.ts
@@ -181,7 +181,7 @@ function isValidClawHubLink(
   return Boolean(link && link.status === "linked" && link.valid);
 }
 
-function reportHasLinkedClawHubSkills(report: SkillStatusReport): boolean {
+export function reportHasLinkedClawHubSkills(report: SkillStatusReport): boolean {
   return report.skills.some((skill) => isValidClawHubLink(skill.clawhub));
 }
 
@@ -463,7 +463,7 @@ export async function loadSkillCard(state: SkillsState, skillKey: string) {
   }
 }
 
-async function loadClawHubSecurityVerdicts(state: SkillsState, report: SkillStatusReport) {
+export async function loadClawHubSecurityVerdicts(state: SkillsState, report: SkillStatusReport) {
   const client = state.client;
   const agentScope = captureSkillsAgentScope(state);
   if (!client || !state.connected || !reportHasLinkedClawHubSkills(report)) {

--- a/ui/src/pages/skills/skills-page.ts
+++ b/ui/src/pages/skills/skills-page.ts
@@ -16,10 +16,12 @@ import {
   installFromClawHub,
   installSkill,
   loadClawHubDetail,
+  loadClawHubSecurityVerdicts,
   loadSkillCard,
   loadSkills,
   refreshSkills,
   reconcileSkillsAgentId,
+  reportHasLinkedClawHubSkills,
   saveSkillApiKey,
   searchClawHub,
   setClawHubSearchQuery,
@@ -242,6 +244,17 @@ class SkillsPage extends OpenClawLightDomElement {
       this.routeDataEnabled &&
       (this.routeData?.agentsList || this.routeData?.report || this.routeData?.error)
     ) {
+      // Route data provides the skills report, but security verdicts are not
+      // included in the route payload. Hydrate verdicts when linked ClawHub
+      // skills exist in the report and no verdict fetch is in progress.
+      if (
+        this.skillsReport &&
+        !this.clawhubVerdictsLoading &&
+        Object.keys(this.clawhubVerdicts).length === 0 &&
+        reportHasLinkedClawHubSkills(this.skillsReport)
+      ) {
+        void loadClawHubSecurityVerdicts(this, this.skillsReport);
+      }
       return;
     }
     if (!this.agentsList && !this.agentsLoading) {

--- a/ui/src/pages/skills/view.ts
+++ b/ui/src/pages/skills/view.ts
@@ -159,9 +159,12 @@ function verdictForSkill(skill: SkillStatusEntry, verdicts: SkillsProps["clawhub
   );
 }
 
-function verdictLabel(verdict: ClawHubSkillSecurityVerdict | null | undefined): string {
+function verdictLabel(
+  verdict: ClawHubSkillSecurityVerdict | null | undefined,
+  verdictsLoading = false,
+): string {
   if (!verdict) {
-    return t("skillsPage.verdict.unavailable");
+    return verdictsLoading ? t("skillsPage.verdict.pending") : t("skillsPage.verdict.unavailable");
   }
   const status = verdict.securityStatus?.trim() || null;
   if (verdict.ok && verdict.decision === "pass") {
@@ -179,9 +182,12 @@ function verdictLabel(verdict: ClawHubSkillSecurityVerdict | null | undefined): 
   return t("skillsPage.verdict.unavailable");
 }
 
-function verdictChipClass(verdict: ClawHubSkillSecurityVerdict | null | undefined): string {
+function verdictChipClass(
+  verdict: ClawHubSkillSecurityVerdict | null | undefined,
+  loading = false,
+): string {
   if (!verdict) {
-    return "chip-warn";
+    return loading ? "chip" : "chip-warn";
   }
   if (verdict.ok && verdict.decision === "pass") {
     return "chip-ok";
@@ -192,9 +198,10 @@ function verdictChipClass(verdict: ClawHubSkillSecurityVerdict | null | undefine
 
 function verdictStatusKind(
   verdict: ClawHubSkillSecurityVerdict | null | undefined,
+  loading = false,
 ): "ok" | "warn" | "muted" {
   if (!verdict) {
-    return "warn";
+    return loading ? "muted" : "warn";
   }
   if (verdict.ok && verdict.decision === "pass") {
     return "ok";
@@ -565,7 +572,10 @@ function renderSkill(skill: SkillStatusEntry, props: SkillsProps) {
       <div class="settings-row__control">
         ${skillAvailabilityStatus(skill)}
         ${skill.clawhub?.status === "linked"
-          ? renderSettingsStatus({ kind: verdictStatusKind(verdict), label: verdictLabel(verdict) })
+          ? renderSettingsStatus({
+              kind: verdictStatusKind(verdict, props.clawhubVerdictsLoading),
+              label: verdictLabel(verdict, props.clawhubVerdictsLoading),
+            })
           : skill.clawhub?.status === "invalid"
             ? renderSettingsStatus({ kind: "warn", label: t("skillsPage.invalidLink") })
             : nothing}
@@ -780,7 +790,9 @@ function renderInstalledClawHubOverview(
       style="display: grid; gap: 8px; border-color: var(--border); background: var(--panel-2);"
     >
       <div style="display: flex; align-items: center; gap: 8px; flex-wrap: wrap;">
-        <span class="chip ${verdictChipClass(verdict)}">${verdictLabel(verdict)}</span>
+        <span class="chip ${verdictChipClass(verdict, props.clawhubVerdictsLoading)}"
+          >${verdictLabel(verdict, props.clawhubVerdictsLoading)}</span
+        >
         <span class="muted" style="font-size: 12px;">${link.slug}@${link.installedVersion}</span>
         ${props.clawhubVerdictsLoading
           ? html`<span class="muted">${t("skillsPage.refreshing")}</span>`


### PR DESCRIPTION
## Problem
When the Control UI skills page loads with route data, ClawHub security verdicts are never fetched because `ensureInitialData()` short-circuits early after finding agentsList/report in route data. Verdict labels stay stuck as "Unavailable" until manual refresh.

## Fix
Three targeted changes:

1. **`ui/src/lib/skills/index.ts`** — Export `loadClawHubSecurityVerdicts` and `reportHasLinkedClawHubSkills` so the page can call them directly.

2. **`ui/src/pages/skills/skills-page.ts`** — In `ensureInitialData()`, after the route-data early return, hydrate verdicts when the report has linked ClawHub skills, verdicts are empty, and no fetch is in progress.

3. **`ui/src/pages/skills/view.ts`** — Update `verdictLabel()`, `verdictChipClass()`, and `verdictStatusKind()` to accept an optional `loading` parameter. When verdicts are null but loading is true, show "Pending" (muted style) instead of "Unavailable" (warn), avoiding a flash of misleading state before the fetch completes.

## Testing
- Open Control UI → Skills page
- Verify verdicts populate on first load (no manual refresh needed)
- Disconnect/reconnect: verdicts should show "Pending" while loading, then resolve to actual status
- No change to verdict display when already loaded

Fixes #108647