### PR TITLE
fix(dashboard): inset board widgets from pane edges

### DIFF
--- a/ui/src/styles/chat/board.css
+++ b/ui/src/styles/chat/board.css
@@ -80,6 +80,7 @@
   flex: 1 1 0;
   min-width: 0;
   min-height: 0;
+  padding: 12px 16px 16px;
 }
 
 .board-session-surface__chat {


### PR DESCRIPTION
## What Problem This Solves

The session dashboard (board face) renders its widget grid flush against the pane edges: the first widget card touches the sidebar boundary on the left, the pane header on top, and the chat-dock divider on the right. Widgets look squeezed, and card borders/shadows sit directly on the surrounding chrome.

## Why This Change Was Made

`.board-view` has no padding of its own, and the session-surface mount (`.board-session-surface__board > openclaw-board-view`) filled the pane edge-to-edge. Adding the inset at the surface mount keeps the board component itself layout-neutral (the standalone board fixture supplies its own shell padding) while giving the product surface breathing room. `12px 16px 16px` matches the grid's 12px gap rhythm and applies to every dock orientation (left/right/bottom/hidden) plus the mobile column layout, which all share this mount.

## User Impact

Dashboard widgets no longer sit flush against the sidebar, header, and chat dock; cards get a consistent inset in every dock layout.

## Evidence

Autoreview (Codex `gpt-5.6-sol`): clean, no findings. `oxfmt --check` and `git diff --check` clean; CSS-only diff, no behavior lanes touched.

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/2026-07-dashboard-widget-padding/before.png) | ![after](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/2026-07-dashboard-widget-padding/after.png) |

Captured against the mock-gateway dev harness with a temporary `board.get` fixture (two granted HTML widgets, right chat dock); fixture was not committed.
