### PR TITLE
fix: match current tool error format in trace line sanitizer

### DIFF
--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -900,6 +900,10 @@ describe("sanitizeAssistantVisibleText", () => {
       "⚠️ 🛠️ `run openclaw definitely-not-a-real-subcommand (agent)` failed",
       "⚠️ 🛠️ gh search issues --repo openclaw/openclaw --state open --no-search-pages.jsonl /tmp/openclaw_open_unlabeled_current.json (agent) failed",
       "⚠️ 🛠️ gh search issues --repo openclaw/openclaw --state open (agent) failed: command timed out",
+      "⚠️ 🛠️ Exec failed: `python3 /path/to/daily-cost-audit.py` (exit 1)",
+      "⚠️ 🛠️ Bash failed: `git status` (workspace) (exit 1)",
+      "⚠️ 🛠️ Exec failed (exit 1)",
+      "⚠️ 🛠️ Bash failed",
       "🛠️ run git status",
       "Visible outro.",
     ].join("\n");
@@ -907,10 +911,20 @@ describe("sanitizeAssistantVisibleText", () => {
     expect(sanitizeAssistantVisibleText(input)).toBe("Visible intro.\nVisible outro.");
   });
 
+  it("preserves assistant warnings that are not internal trace formats", () => {
+    const input = [
+      "⚠️ 🛠️ The deployment failed",
+      "⚠️ 🛠️ Exec failed to start, so I used the fallback",
+    ].join("\n");
+
+    expect(sanitizeAssistantVisibleText(input)).toBe(input);
+  });
+
   it("preserves internal tool trace examples inside fenced code", () => {
     const input = [
       "Example:",
       "```",
+      "⚠️ 🛠️ Exec failed: `python3 /path/to/daily-cost-audit.py` (exit 1)",
       "⚠️ 🛠️ `run openclaw definitely-not-a-real-subcommand (agent)` failed",
       "```",
     ].join("\n");

--- a/src/shared/text/assistant-visible-text.ts
+++ b/src/shared/text/assistant-visible-text.ts
@@ -18,8 +18,10 @@ const INTERNAL_TRACE_LINE_QUICK_RE =
   /(?:📊|🛠️|📖|📝|🔍|🔎|⚙️|tool[-_ ]?call|tool[-_ ]?result|function[-_ ]?call)/i;
 const INTERNAL_TRACE_LINE_RE =
   /^(?:>\s*)?(?:⚠️\s*)?(?:📊|🛠️|📖|📝|🔍|🔎|⚙️)\s*(?:Session Status|Exec|Read|Edit|Write|Patch|Search|Open|Click|Find|Screenshot|Update Plan|Tool Call|Tool Result|Function Call|Shell|Command)\s*:/i;
+// The current producer reserves "⚠️ 🛠️ Exec|Bash failed[:...]" for exec warnings, so
+// echoed copies must be removed. The second branch preserves the historical "(agent) failed" shape.
 const INTERNAL_COMPACT_FAILURE_TRACE_LINE_RE =
-  /^(?:>\s*)?⚠️\s*🛠️\s+\S[\s\S]*\s+\(agent\)`{0,2}\s+failed(?:\s*:.*)?\s*$/i;
+  /^(?:>\s*)?⚠️\s*🛠️\s+(?:(?:Exec|Bash)\s+failed(?:(?:\s+\(exit\s+-?\d+\))|(?:\s*:[^\r\n]*))?|\S[^\r\n]*\s+\(agent\)`{0,2}\s+failed(?:\s*:[^\r\n]*)?)\s*$/i;
 const INTERNAL_COMPACT_COMMAND_TRACE_LINE_RE =
   /^(?:>\s*)?🛠️\s*(?:(?:(?:elevated|pty)\b\s*(?:·|,)\s*)+)?(?:`{1,2}\s*\S|(?:run|check|fetch|pull|push|view|show|list|switch|create|merge|rebase|stage|restore|reset|stash|search|find|print|copy|move|remove|install|start|cd|git|pnpm|npm|yarn|bun|node|python|python3|bash|sh)\b)/i;
 const INTERNAL_CHANNEL_TRACE_LINE_RE =


### PR DESCRIPTION
## What Problem This Solves

`stripAssistantInternalTraceLines` failed to strip the current tool error format from assistant-visible text.

The compact failure matcher only recognized the historical form where `failed` appears after an `(agent)` context:

```text
⚠️ 🛠️ `run openclaw definitely-not-a-real-subcommand (agent)` failed
```

The current `formatToolErrorWarningText` emitter puts `failed` immediately after the exec-like tool label:

```text
⚠️ 🛠️ Exec failed: `python3 /path/to/daily-cost-audit.py` (exit 1)
⚠️ 🛠️ Bash failed: `git status` (workspace) (exit 1)
```

Those current-format lines could slip through the sanitizer when echoed by the model and appear in user-facing output. Fixes #111832.

## Why This Change Was Made

Keep one canonical shared sanitizer matcher with two explicit producer-contract branches:

- current `Exec failed` / `Bash failed` warnings;
- historical `(agent) ... failed` traces.

The maintainer rewrite deliberately avoids a broad `failed` match, which could silently remove legitimate assistant warnings such as `⚠️ 🛠️ Exec failed to start, so I used the fallback`. The shared sanitizer remains the correct ownership boundary; no channel-specific filter or delivery-policy change is added.

ClawSweeper's completed rank-up moves were applied: the branch was refreshed onto current `main`, and the unrelated Control UI gzip-budget change was removed from this fix.

## User Impact

Models can no longer echo these reserved internal exec/bash failure traces into assistant-visible channel output. Adjacent visible text, ordinary warning prose, historical trace handling, and fenced-code examples remain intact.

## Evidence

- Exact landing head: `940fab76178023f48ac3ccbe631b69618e12a69e`.
- `node scripts/run-vitest.mjs src/shared/text/assistant-visible-text.test.ts`: 113 passed.
- `git diff --check origin/main...HEAD`: clean.
- Fresh Codex autoreview on `origin/main...HEAD`: no accepted/actionable findings; patch-correct confidence 0.96.
- Exact-head CI completed successfully: https://github.com/openclaw/openclaw/actions/runs/29957747950.
- Final diff: two files, 17 additions, 1 deletion; no Control UI, dependency, config, protocol, public API, or persistence changes.

Redacted behavior transcript:

```text
SANITIZED_OUTPUT_START
Visible intro.
Visible outro.
SANITIZED_OUTPUT_END
PRESERVED_OUTPUT=⚠️ 🛠️ Exec failed to start, so I used the fallback
```

The removed middle line was the current emitter shape `⚠️ 🛠️ Exec failed: <redacted command> (exit 1)`.

Contributor credit is preserved in the landing commit with `Co-authored-by: xbrxr03 <abrarhabib03@gmail.com>`.
