### PR TITLE
fix(telegram): suppress link previews in draft stream when linkPreview is false

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch-draft.ts
+++ b/extensions/telegram/src/bot-message-dispatch-draft.ts
@@ -127,6 +127,7 @@ export function createTelegramDraftController(params: {
           replyToMessageId: params.draftReplyToMessageId,
           replyToMode: params.replyToMode,
           richMessages: params.telegramCfg.richMessages,
+          linkPreview: params.telegramCfg.linkPreview,
           minInitialChars: params.streamMode === "progress" ? 0 : DRAFT_MIN_INITIAL_CHARS,
           renderText: renderStreamText,
           onRetainedPage: (page) => {

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -233,6 +233,8 @@ export function createTelegramDraftStream(params: {
   replyToMessageId?: number;
   replyToMode?: ReplyToMode;
   richMessages?: boolean;
+  /** When false, suppresses link previews on all streamed messages. */
+  linkPreview?: boolean;
   throttleMs?: number;
   /** Minimum chars before sending first message (debounce for push notifications) */
   minInitialChars?: number;
@@ -251,6 +253,9 @@ export function createTelegramDraftStream(params: {
   const chatId = params.chatId;
   const threadParams = buildTelegramThreadParams(params.thread);
   const replyToMessageId = normalizeTelegramReplyToMessageId(params.replyToMessageId);
+  // When link previews are disabled, every send/edit must carry the flag;
+  // Telegram re-enables previews on edits that omit link_preview_options.
+  const linkPreviewOptions = params.linkPreview === false ? { is_disabled: true } : undefined;
   const initialSendMessageParams =
     replyToMessageId != null
       ? {
@@ -259,8 +264,12 @@ export function createTelegramDraftStream(params: {
             message_id: replyToMessageId,
             allow_sending_without_reply: true,
           },
+          ...(linkPreviewOptions ? { link_preview_options: linkPreviewOptions } : {}),
         }
-      : (threadParams ?? {});
+      : {
+          ...(threadParams ?? {}),
+          ...(linkPreviewOptions ? { link_preview_options: linkPreviewOptions } : {}),
+        };
   const consumesReplyTarget =
     replyToMessageId != null &&
     params.replyToMode !== undefined &&
@@ -390,6 +399,7 @@ export function createTelegramDraftStream(params: {
             chat_id: chatId,
             message_id: targetMessageId,
             rich_message: page.richMessage,
+            ...(linkPreviewOptions ? { link_preview_options: linkPreviewOptions } : {}),
           });
         } catch (err) {
           const fallbackPlan = buildTelegramPlainFallbackPlan({
@@ -401,23 +411,30 @@ export function createTelegramDraftStream(params: {
           if (!fallbackPlan) {
             throw err;
           }
-          await params.api.editMessageText(chatId, targetMessageId, fallbackPlan.plainText);
+          await params.api.editMessageText(chatId, targetMessageId, fallbackPlan.plainText, {
+            ...(linkPreviewOptions ? { link_preview_options: linkPreviewOptions } : {}),
+          });
           acceptedSnapshot = fallbackSnapshot(fallbackPlan.plainText);
         }
       } else if (page.sourceTextMode === "html") {
         try {
           await params.api.editMessageText(chatId, targetMessageId, page.sourceText, {
             parse_mode: "HTML" as const,
+            ...(linkPreviewOptions ? { link_preview_options: linkPreviewOptions } : {}),
           });
         } catch (err) {
           if (!isTelegramHtmlParseError(err)) {
             throw err;
           }
-          await params.api.editMessageText(chatId, targetMessageId, page.text);
+          await params.api.editMessageText(chatId, targetMessageId, page.text, {
+            ...(linkPreviewOptions ? { link_preview_options: linkPreviewOptions } : {}),
+          });
           acceptedSnapshot = fallbackSnapshot(page.text);
         }
       } else {
-        await params.api.editMessageText(chatId, targetMessageId, page.sourceText);
+        await params.api.editMessageText(chatId, targetMessageId, page.sourceText, {
+          ...(linkPreviewOptions ? { link_preview_options: linkPreviewOptions } : {}),
+        });
       }
       if (sendGeneration === generation && streamMessageId === targetMessageId) {
         streamMessageSnapshot = acceptedSnapshot;

--- a/extensions/telegram/src/rich-message.ts
+++ b/extensions/telegram/src/rich-message.ts
@@ -69,11 +69,12 @@ type TelegramSendRichMessageParams = {
   suggested_post_parameters?: unknown;
   reply_parameters?: ReplyParameters;
   reply_markup?: TelegramRichMessageReplyMarkup;
+  link_preview_options?: { is_disabled: boolean };
 };
 
 export type TelegramRichMessageContextParams = Pick<
   TelegramSendRichMessageParams,
-  "disable_notification" | "message_thread_id" | "reply_parameters"
+  "disable_notification" | "message_thread_id" | "reply_parameters" | "link_preview_options"
 >;
 
 export type TelegramEditRichMessageTextParams = {
@@ -83,6 +84,7 @@ export type TelegramEditRichMessageTextParams = {
   inline_message_id?: string;
   rich_message: TelegramInputRichMessage;
   reply_markup?: InlineKeyboardMarkup;
+  link_preview_options?: { is_disabled: boolean };
 };
 
 type TelegramRichRawApi = {
@@ -133,6 +135,9 @@ export function toTelegramRichMessageContextParams(
   }
   if (params?.disable_notification === true) {
     richParams.disable_notification = true;
+  }
+  if (params?.link_preview_options) {
+    richParams.link_preview_options = params.link_preview_options;
   }
   if (isReplyParameters(params?.reply_parameters)) {
     richParams.reply_parameters = params.reply_parameters;


### PR DESCRIPTION
## Problem

When `channels.telegram.linkPreview: false` is set, replies delivered via the draft streaming path still unfurl the first URL. Non-streamed sends (e.g. `message` tool / CLI send path) correctly suppress previews. The issue is that `createTelegramDraftStream` never sets `link_preview_options` on any of its `sendMessage` or `editMessageText` calls.

Telegram **re-enables previews on edits that omit `link_preview_options`**, so even if the initial `sendMessage` somehow suppressed them, every subsequent `editMessageText` during the stream would bring them back.

The finalization path (`editStreamMessage` in `delivery.replies.ts`) does correctly pass `linkPreview`, but when the streamed draft text already equals the final text, finalization skips the edit — so the preview persists.

## Fix

1. **Add `linkPreview` param to `createTelegramDraftStream`** — accepts the Telegram config's `linkPreview` setting
2. **Compute `linkPreviewOptions` once** (`{ is_disabled: true }` when `linkPreview === false`) and thread it into every send/edit call:
   - `sendMessage` (initial message creation) via `initialSendMessageParams`
   - `editMessageText` (stream preview edits) — all 5 call sites
   - `editMessageText` via rich message API
3. **Thread `linkPreview` from `telegramCfg`** in `bot-message-dispatch-draft.ts`
4. **Add `link_preview_options` to rich message types** — `TelegramSendRichMessageParams`, `TelegramEditRichMessageTextParams`, `TelegramRichMessageContextParams`
5. **Thread through `toTelegramRichMessageContextParams`**

This ensures link preview suppression is consistent across all streaming paths, matching the behavior of the non-streamed send path.

Fixes #111525