### PR TITLE
fix(android): make welcome screen scrollable at large font sizes

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
@@ -1076,7 +1076,7 @@ private fun WelcomeScreen(
   modifier: Modifier = Modifier,
 ) {
   ClawScaffold(modifier = modifier, contentPadding = onboardingContentPadding()) {
-    Column(modifier = Modifier.fillMaxSize(), horizontalAlignment = Alignment.CenterHorizontally) {
+    Column(modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState()), horizontalAlignment = Alignment.CenterHorizontally) {
       OnboardingHeroTopSpacer(afterHeader = false)
       OnboardingIntroHero(
         title = nativeString("Welcome to OpenClaw"),


### PR DESCRIPTION
## Problem

On Android, using larger system font sizes causes the first-run welcome screen to overflow vertically. The **Continue** button is pushed below the bottom of the screen, and since the screen cannot scroll, the user cannot proceed with setup.

## Root Cause

`WelcomeScreen` uses `Column(modifier = Modifier.fillMaxSize())` without `.verticalScroll()`. Other onboarding steps (e.g. Gateway setup, Node Approval) already use `.verticalScroll(rememberScrollState())`.

## Fix

Add `.verticalScroll(rememberScrollState())` to the `WelcomeScreen` Column modifier, matching the pattern used by all other onboarding steps.

Both `verticalScroll` and `rememberScrollState` are already imported in the file.

## Testing

- Verify the welcome screen scrolls at default font size (should be no visible change since content fits)
- Verify the Continue button is reachable at Android "Large" and "Largest" font sizes
- Verify other onboarding steps are unaffected (they already had verticalScroll)

Fixes #111632
