### PR TITLE
fix(minimax): recognize coding-plan response shape with remaining-percent fields

### DIFF
--- a/src/infra/provider-usage.fetch.minimax.test.ts
+++ b/src/infra/provider-usage.fetch.minimax.test.ts
@@ -321,6 +321,81 @@ describe("fetchMinimaxUsage", () => {
     expect(result.windows).toHaveLength(0);
   });
 
+  it.each([
+    {
+      name: "recognizes general model_name with current_interval_remaining_percent (coding-plan shape)",
+      payload: {
+        model_remains: [
+          {
+            start_time: 1_784_386_800_000,
+            end_time: 1_784_404_800_000,
+            remains_time: 4878202,
+            current_interval_total_count: 0,
+            current_interval_usage_count: 0,
+            model_name: "general",
+            current_weekly_total_count: 0,
+            current_weekly_usage_count: 0,
+            weekly_start_time: 1_783_900_800_000,
+            weekly_end_time: 1_784_505_600_000,
+            weekly_remains_time: 105678202,
+            current_interval_status: 1,
+            current_interval_remaining_percent: 97,
+            current_weekly_status: 1,
+            current_weekly_remaining_percent: 77,
+          },
+          {
+            start_time: 1_784_332_800_000,
+            end_time: 1_784_419_200_000,
+            remains_time: 19278202,
+            current_interval_total_count: 0,
+            current_interval_usage_count: 0,
+            model_name: "video",
+            current_weekly_total_count: 0,
+            current_weekly_usage_count: 0,
+            weekly_start_time: 1_783_900_800_000,
+            weekly_end_time: 1_784_505_600_000,
+            weekly_remains_time: 105678202,
+            current_interval_status: 3,
+            current_interval_remaining_percent: 100,
+            current_weekly_status: 3,
+            current_weekly_remaining_percent: 100,
+          },
+        ],
+        base_resp: { status_code: 0, status_msg: "success" },
+      },
+      expected: {
+        plan: "Coding Plan · general",
+        windows: [{ label: "5h", usedPercent: 3, resetAt: 1_784_404_800_000 }],
+      },
+    },
+    {
+      name: "uses current_weekly_remaining_percent when interval remaining percent is absent",
+      payload: {
+        model_remains: [
+          {
+            start_time: 1_784_386_800_000,
+            end_time: 1_784_404_800_000,
+            model_name: "general",
+            current_interval_total_count: 0,
+            current_interval_usage_count: 0,
+            current_interval_status: 1,
+            current_weekly_status: 1,
+            current_weekly_remaining_percent: 55,
+            weekly_start_time: 1_783_900_800_000,
+            weekly_end_time: 1_784_505_600_000,
+          },
+        ],
+        base_resp: { status_code: 0, status_msg: "success" },
+      },
+      expected: {
+        plan: "Coding Plan · general",
+        windows: [{ label: "5h", usedPercent: 45, resetAt: 1_784_404_800_000 }],
+      },
+    },
+  ])("$name", async ({ payload, expected }) => {
+    await expectMinimaxUsageResult({ payload, expected });
+  });
+
   it("handles repeated nested records while scanning usage candidates", async () => {
     const sharedUsage = {
       total: 100,

--- a/src/infra/provider-usage.fetch.minimax.ts
+++ b/src/infra/provider-usage.fetch.minimax.ts
@@ -48,6 +48,8 @@ const RESET_KEYS = [
   "endTime",
   "window_end",
   "windowEnd",
+  "weekly_end_time",
+  "weeklyEndTime",
 ] as const;
 
 const PERCENT_KEYS = [
@@ -64,7 +66,16 @@ const PERCENT_KEYS = [
 // MiniMax's usage_percent / usagePercent fields report the remaining quota
 // as a percentage, not the consumed quota. Treat them as "remaining percent"
 // and invert to get usedPercent. Count-based fromCounts always takes priority.
-const REMAINING_PERCENT_KEYS = ["usage_percent", "usagePercent"] as const;
+//
+// The coding-plan endpoint also reports per-interval and weekly remaining
+// percentages (current_interval_remaining_percent / current_weekly_remaining_percent)
+// which should be treated the same way.
+const REMAINING_PERCENT_KEYS = [
+  "usage_percent",
+  "usagePercent",
+  "current_interval_remaining_percent",
+  "current_weekly_remaining_percent",
+] as const;
 
 const USED_KEYS = [
   "used",
@@ -339,16 +350,20 @@ function deriveUsedPercent(payload: Record<string, unknown>): number | null {
   return null;
 }
 
-// Prefer the entry whose model_name matches a chat/text model (e.g. "MiniMax-M*")
-// and that has a non-zero current_interval_total_count.  Models with total_count === 0
-// (speech, video, image) are not relevant to the coding-plan budget.
+// Prefer the entry whose model_name matches a chat/text model (e.g. "MiniMax-M*"
+// or "general") and that has billing activity.  Models with total_count === 0
+// (speech, video, image) are not relevant to the coding-plan budget, but the
+// coding-plan endpoint now reports total_count as 0 even for the active chat plan
+// (quota is reported via remaining_percent fields instead).  Use
+// current_interval_status === 1 as the activity signal when total_count is 0.
 function pickChatModelRemains(modelRemains: unknown[]): Record<string, unknown> | undefined {
   const records = modelRemains.filter(isRecord);
   if (records.length === 0) {
     return undefined;
   }
 
-  const chatRecord = records.find((r) => {
+  // 1. Prefer MiniMax-M* chat models with total > 0 (legacy shape)
+  const legacyChatRecord = records.find((r) => {
     const name = typeof r.model_name === "string" ? r.model_name : "";
     const total = parseFiniteNumber(r.current_interval_total_count);
     return (
@@ -357,11 +372,21 @@ function pickChatModelRemains(modelRemains: unknown[]): Record<string, unknown> 
       total > 0
     );
   });
-
-  if (chatRecord) {
-    return chatRecord;
+  if (legacyChatRecord) {
+    return legacyChatRecord;
   }
 
+  // 2. "general" model with active billing window (current_shape)
+  const generalRecord = records.find((r) => {
+    const name = typeof r.model_name === "string" ? r.model_name : "";
+    const status = parseFiniteNumber(r.current_interval_status);
+    return normalizeLowercaseStringOrEmpty(name) === "general" && status === 1;
+  });
+  if (generalRecord) {
+    return generalRecord;
+  }
+
+  // 3. Any record with total > 0 (fallback)
   return records.find((r) => {
     const total = parseFiniteNumber(r.current_interval_total_count);
     return total !== undefined && total > 0;


### PR DESCRIPTION
## Problem

`openclaw status` shows **MiniMax: Unsupported response shape** even though the API call succeeds (HTTP 200, `base_resp.status_code === 0`) and returns valid billing data.

The MiniMax coding-plan endpoint now returns a different response shape:
- `model_name: "general"` instead of `"MiniMax-M*"` — `pickChatModelRemains` rejects it because it only matches `minimax-m` prefix
- `current_interval_total_count: 0` for all entries — the fallback requires `total > 0`, so even a relaxed model name check fails
- `current_interval_remaining_percent` / `current_weekly_remaining_percent` instead of `usage_percent` / `usagePercent` — `REMAINING_PERCENT_KEYS` doesn't include these new fields

The result: `deriveUsedPercent` returns `null`, and the fetcher surfaces "Unsupported response shape".

## Fix

1. **Add `current_interval_remaining_percent` and `current_weekly_remaining_percent` to `REMAINING_PERCENT_KEYS`** — these are remaining-percent fields that get inverted to `usedPercent` (e.g. 97% remaining → 3% used)
2. **Loosen `pickChatModelRemains`** — add a step that matches `model_name === "general"` with `current_interval_status === 1` (active billing window), falling back to the existing `total > 0` check
3. **Add `weekly_end_time` to `RESET_KEYS`** — so weekly window reset times are picked up for the reset-at timestamp

## Test Coverage

Two new test cases:
- Live coding-plan shape: `model_name: "general"` with `current_interval_remaining_percent: 97` → 3% used, 5h window, reset at `end_time`
- Weekly remaining percent: `current_weekly_remaining_percent: 55` → 45% used, when interval percent is absent

All 12 existing tests still pass.

Fixes #110887
