### PR TITLE
fix(macos): show local ClickClack session discussions

### DIFF
--- a/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
@@ -903,15 +903,31 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
         return String(raw.dropFirst().dropLast())
     }
 
-    static func shouldAllowNavigation(to url: URL, dashboardURL: URL) -> Bool {
+    static func shouldAllowNavigation(to url: URL, dashboardURL: URL, isMainFrame: Bool) -> Bool {
         guard let scheme = url.scheme?.lowercased() else { return true }
         if scheme == "about" || scheme == "blob" || scheme == "data" {
             return true
         }
         guard scheme == "http" || scheme == "https" else { return false }
-        return url.scheme?.lowercased() == dashboardURL.scheme?.lowercased() &&
-            url.host?.lowercased() == dashboardURL.host?.lowercased() &&
-            url.port == dashboardURL.port
+        let dashboardScheme = dashboardURL.scheme?.lowercased()
+        let dashboardHost = dashboardURL.host?.lowercased()
+        let host = url.host?.lowercased()
+        if scheme == dashboardScheme && host == dashboardHost && url.port == dashboardURL.port {
+            return true
+        }
+        guard !isMainFrame,
+              scheme == dashboardScheme,
+              host == dashboardHost,
+              host == "127.0.0.1" || host == "localhost" || host == "::1" || host == "[::1]",
+              url.user == nil,
+              url.password == nil
+        else {
+            return false
+        }
+        let components = url.path.split(separator: "/", omittingEmptySubsequences: true)
+        return components.count == 4 &&
+            components[0] == "embed" &&
+            (components[1] == "channel" || components[1] == "thread")
     }
 
     static func shouldAllowBrowserNavigation(to url: URL, isMainFrame: Bool) -> Bool {
@@ -1118,7 +1134,11 @@ extension DashboardWindowController {
                 decisionHandler: decisionHandler)
             return
         }
-        if Self.shouldAllowNavigation(to: url, dashboardURL: self.currentURL) {
+        if Self.shouldAllowNavigation(
+            to: url,
+            dashboardURL: self.currentURL,
+            isMainFrame: navigationAction.targetFrame?.isMainFrame == true)
+        {
             decisionHandler(.allow)
             return
         }

--- a/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
@@ -903,7 +903,12 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
         return String(raw.dropFirst().dropLast())
     }
 
-    static func shouldAllowNavigation(to url: URL, dashboardURL: URL, isMainFrame: Bool) -> Bool {
+    static func shouldAllowNavigation(
+        to url: URL,
+        dashboardURL: URL,
+        isMainFrame: Bool,
+        isTrustedDashboardSource: Bool = false) -> Bool
+    {
         guard let scheme = url.scheme?.lowercased() else { return true }
         if scheme == "about" || scheme == "blob" || scheme == "data" {
             return true
@@ -915,13 +920,9 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
         if scheme == dashboardScheme, host == dashboardHost, url.port == dashboardURL.port {
             return true
         }
-        let loopbackHosts = ["127.0.0.1", "localhost", "::1", "[::1]"]
         guard !isMainFrame,
-              scheme == dashboardScheme,
-              let dashboardHost,
-              let host,
-              loopbackHosts.contains(dashboardHost),
-              loopbackHosts.contains(host),
+              isTrustedDashboardSource,
+              host?.isEmpty == false,
               url.user == nil,
               url.password == nil
         else {
@@ -1137,10 +1138,13 @@ extension DashboardWindowController {
                 decisionHandler: decisionHandler)
             return
         }
+        let sourceURL = navigationAction.request.mainDocumentURL ??
+            (navigationAction.sourceFrame.isMainFrame ? navigationAction.sourceFrame.request.url : nil)
         if Self.shouldAllowNavigation(
             to: url,
             dashboardURL: self.currentURL,
-            isMainFrame: navigationAction.targetFrame?.isMainFrame == true)
+            isMainFrame: navigationAction.targetFrame?.isMainFrame == true,
+            isTrustedDashboardSource: Self.isTrustedLinkSource(sourceURL, dashboardURL: self.currentURL))
         {
             decisionHandler(.allow)
             return

--- a/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
@@ -912,13 +912,16 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
         let dashboardScheme = dashboardURL.scheme?.lowercased()
         let dashboardHost = dashboardURL.host?.lowercased()
         let host = url.host?.lowercased()
-        if scheme == dashboardScheme && host == dashboardHost && url.port == dashboardURL.port {
+        if scheme == dashboardScheme, host == dashboardHost, url.port == dashboardURL.port {
             return true
         }
+        let loopbackHosts = ["127.0.0.1", "localhost", "::1", "[::1]"]
         guard !isMainFrame,
               scheme == dashboardScheme,
-              host == dashboardHost,
-              host == "127.0.0.1" || host == "localhost" || host == "::1" || host == "[::1]",
+              let dashboardHost,
+              let host,
+              loopbackHosts.contains(dashboardHost),
+              loopbackHosts.contains(host),
               url.user == nil,
               url.password == nil
         else {

--- a/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
@@ -1138,13 +1138,14 @@ extension DashboardWindowController {
                 decisionHandler: decisionHandler)
             return
         }
-        let sourceURL = navigationAction.request.mainDocumentURL ??
-            (navigationAction.sourceFrame.isMainFrame ? navigationAction.sourceFrame.request.url : nil)
         if Self.shouldAllowNavigation(
             to: url,
             dashboardURL: self.currentURL,
             isMainFrame: navigationAction.targetFrame?.isMainFrame == true,
-            isTrustedDashboardSource: Self.isTrustedLinkSource(sourceURL, dashboardURL: self.currentURL))
+            isTrustedDashboardSource: navigationAction.sourceFrame.isMainFrame &&
+                Self.isTrustedLinkSource(
+                    navigationAction.sourceFrame.request.url,
+                    dashboardURL: self.currentURL))
         {
             decisionHandler(.allow)
             return

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
@@ -208,6 +208,9 @@ struct DashboardWindowSmokeTests {
         let dashboard = try #require(URL(string: "http://127.0.0.1:18789/control/"))
         let channel = try #require(URL(string: "http://127.0.0.1:18890/embed/channel/T01/C01"))
         let thread = try #require(URL(string: "http://127.0.0.1:18890/embed/thread/T01/M01"))
+        let hostnameAlias = try #require(URL(string: "http://localhost:18890/embed/channel/T01/C01"))
+        let ipv6Alias = try #require(URL(string: "http://[::1]:18890/embed/thread/T01/M01"))
+        let credentialedFrame = try #require(URL(string: "http://user:pass@localhost:18890/embed/channel/T01/C01"))
         let unrelatedPath = try #require(URL(string: "http://127.0.0.1:18890/admin"))
         let externalFrame = try #require(URL(string: "https://clickclack.example/embed/channel/T01/C01"))
         let localFile = try #require(URL(string: "file:///tmp/discussion.html"))
@@ -216,8 +219,14 @@ struct DashboardWindowSmokeTests {
             to: channel, dashboardURL: dashboard, isMainFrame: false))
         #expect(DashboardWindowController.shouldAllowNavigation(
             to: thread, dashboardURL: dashboard, isMainFrame: false))
+        #expect(DashboardWindowController.shouldAllowNavigation(
+            to: hostnameAlias, dashboardURL: dashboard, isMainFrame: false))
+        #expect(DashboardWindowController.shouldAllowNavigation(
+            to: ipv6Alias, dashboardURL: dashboard, isMainFrame: false))
         #expect(!DashboardWindowController.shouldAllowNavigation(
             to: channel, dashboardURL: dashboard, isMainFrame: true))
+        #expect(!DashboardWindowController.shouldAllowNavigation(
+            to: credentialedFrame, dashboardURL: dashboard, isMainFrame: false))
         #expect(!DashboardWindowController.shouldAllowNavigation(
             to: unrelatedPath, dashboardURL: dashboard, isMainFrame: false))
         #expect(!DashboardWindowController.shouldAllowNavigation(

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
@@ -188,17 +188,42 @@ struct DashboardWindowSmokeTests {
         let staleEndpoint = try #require(URL(string: "http://127.0.0.1:18790/control/chat"))
         #expect(try DashboardWindowController.shouldAllowNavigation(
             to: #require(URL(string: "http://127.0.0.1:18789/control/chat")),
-            dashboardURL: dashboard))
+            dashboardURL: dashboard,
+            isMainFrame: true))
         #expect(try !DashboardWindowController.shouldAllowNavigation(
             to: #require(URL(string: "https://docs.openclaw.ai/")),
-            dashboardURL: dashboard))
+            dashboardURL: dashboard,
+            isMainFrame: true))
         #expect(!DashboardWindowController.shouldAllowNavigation(
             to: staleEndpoint,
-            dashboardURL: dashboard))
+            dashboardURL: dashboard,
+            isMainFrame: true))
         #expect(!DashboardWindowController.shouldOpenExternalDashboardNavigation(
             staleEndpoint,
             navigationType: .backForward,
             buttonNumber: 1))
+    }
+
+    @Test func `dashboard permits only local ClickClack discussion subframes`() throws {
+        let dashboard = try #require(URL(string: "http://127.0.0.1:18789/control/"))
+        let channel = try #require(URL(string: "http://127.0.0.1:18890/embed/channel/T01/C01"))
+        let thread = try #require(URL(string: "http://127.0.0.1:18890/embed/thread/T01/M01"))
+        let unrelatedPath = try #require(URL(string: "http://127.0.0.1:18890/admin"))
+        let externalFrame = try #require(URL(string: "https://clickclack.example/embed/channel/T01/C01"))
+        let localFile = try #require(URL(string: "file:///tmp/discussion.html"))
+
+        #expect(DashboardWindowController.shouldAllowNavigation(
+            to: channel, dashboardURL: dashboard, isMainFrame: false))
+        #expect(DashboardWindowController.shouldAllowNavigation(
+            to: thread, dashboardURL: dashboard, isMainFrame: false))
+        #expect(!DashboardWindowController.shouldAllowNavigation(
+            to: channel, dashboardURL: dashboard, isMainFrame: true))
+        #expect(!DashboardWindowController.shouldAllowNavigation(
+            to: unrelatedPath, dashboardURL: dashboard, isMainFrame: false))
+        #expect(!DashboardWindowController.shouldAllowNavigation(
+            to: externalFrame, dashboardURL: dashboard, isMainFrame: false))
+        #expect(!DashboardWindowController.shouldAllowNavigation(
+            to: localFile, dashboardURL: dashboard, isMainFrame: false))
     }
 
     @Test func `dashboard navigation shortcuts target the focused browser`() throws {

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
@@ -204,7 +204,7 @@ struct DashboardWindowSmokeTests {
             buttonNumber: 1))
     }
 
-    @Test func `dashboard permits only local ClickClack discussion subframes`() throws {
+    @Test func `dashboard permits only trusted ClickClack discussion subframes`() throws {
         let dashboard = try #require(URL(string: "http://127.0.0.1:18789/control/"))
         let channel = try #require(URL(string: "http://127.0.0.1:18890/embed/channel/T01/C01"))
         let thread = try #require(URL(string: "http://127.0.0.1:18890/embed/thread/T01/M01"))
@@ -213,26 +213,31 @@ struct DashboardWindowSmokeTests {
         let credentialedFrame = try #require(URL(string: "http://user:pass@localhost:18890/embed/channel/T01/C01"))
         let unrelatedPath = try #require(URL(string: "http://127.0.0.1:18890/admin"))
         let externalFrame = try #require(URL(string: "https://clickclack.example/embed/channel/T01/C01"))
+        let externalHTTPFrame = try #require(URL(string: "http://clickclack.example/embed/thread/T01/M01"))
         let localFile = try #require(URL(string: "file:///tmp/discussion.html"))
 
         #expect(DashboardWindowController.shouldAllowNavigation(
-            to: channel, dashboardURL: dashboard, isMainFrame: false))
+            to: channel, dashboardURL: dashboard, isMainFrame: false, isTrustedDashboardSource: true))
         #expect(DashboardWindowController.shouldAllowNavigation(
-            to: thread, dashboardURL: dashboard, isMainFrame: false))
+            to: thread, dashboardURL: dashboard, isMainFrame: false, isTrustedDashboardSource: true))
         #expect(DashboardWindowController.shouldAllowNavigation(
-            to: hostnameAlias, dashboardURL: dashboard, isMainFrame: false))
+            to: hostnameAlias, dashboardURL: dashboard, isMainFrame: false, isTrustedDashboardSource: true))
         #expect(DashboardWindowController.shouldAllowNavigation(
-            to: ipv6Alias, dashboardURL: dashboard, isMainFrame: false))
+            to: ipv6Alias, dashboardURL: dashboard, isMainFrame: false, isTrustedDashboardSource: true))
+        #expect(DashboardWindowController.shouldAllowNavigation(
+            to: externalFrame, dashboardURL: dashboard, isMainFrame: false, isTrustedDashboardSource: true))
+        #expect(DashboardWindowController.shouldAllowNavigation(
+            to: externalHTTPFrame, dashboardURL: dashboard, isMainFrame: false, isTrustedDashboardSource: true))
         #expect(!DashboardWindowController.shouldAllowNavigation(
             to: channel, dashboardURL: dashboard, isMainFrame: true))
         #expect(!DashboardWindowController.shouldAllowNavigation(
-            to: credentialedFrame, dashboardURL: dashboard, isMainFrame: false))
+            to: credentialedFrame, dashboardURL: dashboard, isMainFrame: false, isTrustedDashboardSource: true))
         #expect(!DashboardWindowController.shouldAllowNavigation(
-            to: unrelatedPath, dashboardURL: dashboard, isMainFrame: false))
+            to: unrelatedPath, dashboardURL: dashboard, isMainFrame: false, isTrustedDashboardSource: true))
         #expect(!DashboardWindowController.shouldAllowNavigation(
-            to: externalFrame, dashboardURL: dashboard, isMainFrame: false))
+            to: externalFrame, dashboardURL: dashboard, isMainFrame: false, isTrustedDashboardSource: false))
         #expect(!DashboardWindowController.shouldAllowNavigation(
-            to: localFile, dashboardURL: dashboard, isMainFrame: false))
+            to: localFile, dashboardURL: dashboard, isMainFrame: false, isTrustedDashboardSource: true))
     }
 
     @Test func `dashboard navigation shortcuts target the focused browser`() throws {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening a ClickClack session discussion in the OpenClaw macOS dashboard saw an empty sidebar even though the same discussion loaded correctly in a browser.

## Why This Change Was Made

The dashboard’s WebKit navigation policy treated embedded discussion frames as top-level dashboard navigations and rejected the ClickClack service because it uses a different origin. The macOS dashboard now permits only credential-free HTTP(S) `/embed/channel/...` and `/embed/thread/...` subframes requested directly by the trusted dashboard main frame. This supports both loopback and public ClickClack deployments while keeping top-level navigation, unrelated paths, unsafe schemes, and follow-on requests from untrusted subframes blocked.

## User Impact

Local and publicly hosted ClickClack discussions can appear inside the macOS session sidebar without weakening the dashboard’s top-level navigation or native-authentication boundary.

## Evidence

- `swift test --package-path apps/macos --filter DashboardWindowSmokeTests` — **36 tests passed**.
- Focused SwiftFormat and production SwiftLint checks passed.
- Regression coverage accepts local and public channel/thread discussion frames—including loopback hostname aliases—and rejects untrusted, credentialed, top-level, unrelated, and file-based navigations.
- Non-persistent WebKit probes confirmed that the initial public ClickClack iframe is requested by the trusted dashboard main frame, while a nested iframe is correctly identified as an untrusted subframe.
- A live ClickClack discussion and model round-trip were verified in the browser-based dashboard before isolating the macOS-only WebKit navigation failure.
- Live before/after screenshots are omitted because the dashboard contains private session and workspace information.
- AI-assisted implementation; an independent automated review reported **no actionable findings**.
