### PR TITLE
fix(config): add compaction.enabled to schema so users can disable auto-compaction

### DIFF
--- a/src/config/config.compaction-settings.test.ts
+++ b/src/config/config.compaction-settings.test.ts
@@ -60,6 +60,23 @@ describe("config compaction settings", () => {
     expect(compaction?.mode).toBe("safeguard");
   });
 
+  it("accepts compaction.enabled to disable auto-compaction", () => {
+    const compaction = materializeCompactionConfig({
+      enabled: false,
+    });
+
+    expect(compaction?.enabled).toBe(false);
+    expect(compaction?.mode).toBe("safeguard");
+  });
+
+  it("accepts compaction.enabled: true explicitly", () => {
+    const compaction = materializeCompactionConfig({
+      enabled: true,
+    });
+
+    expect(compaction?.enabled).toBe(true);
+  });
+
   it("preserves recent turn safeguard values during materialization", () => {
     const compaction = materializeCompactionConfig({
       mode: "safeguard",

--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -209,6 +209,20 @@ describe("config schema regressions", () => {
     expect(res.ok).toBe(true);
   });
 
+  it("accepts agents.defaults.compaction.enabled", () => {
+    const res = validateConfigObject({
+      agents: {
+        defaults: {
+          compaction: {
+            enabled: false,
+          },
+        },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
   it("accepts Matrix queue byChannel overrides", () => {
     const res = validateConfigObject({
       messages: {

--- a/src/config/schema.help.agents.ts
+++ b/src/config/schema.help.agents.ts
@@ -122,6 +122,8 @@ export const AGENT_FIELD_HELP: Record<string, string> = {
   "agents.defaults.cliBackends": "Optional CLI backends for text-only fallback (claude-cli, etc.).",
   "agents.defaults.compaction":
     "Compaction behavior for when context nears token limits, including strategy and pre-compaction memory flush behavior. Use this when long-running sessions need stable continuity under tight context windows.",
+  "agents.defaults.compaction.enabled":
+    "Enable or disable auto-compaction. Default: true (compaction runs when context nears token limits). Set to false to disable compaction entirely; sessions will still respect context limits but won't summarize, so they may hit hard truncation instead.",
   "agents.defaults.compaction.mode":
     'Compaction strategy mode: "default" uses baseline behavior, while "safeguard" applies stricter guardrails to preserve recent context. Keep "default" unless you observe aggressive history loss near limit boundaries.',
   "agents.defaults.compaction.provider":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -680,6 +680,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "agents.defaults.humanDelay.maxMs": "Human Delay Max (ms)",
   "agents.defaults.cliBackends": "CLI Backends",
   "agents.defaults.compaction": "Compaction",
+  "agents.defaults.compaction.enabled": "Compaction Enabled",
   "agents.defaults.compaction.mode": "Compaction Mode",
   "agents.defaults.compaction.provider": "Compaction Provider",
   "agents.defaults.compaction.thinkingLevel": "Compaction Thinking Level",

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -488,6 +488,8 @@ export type AgentCompactionMidTurnPrecheckConfig = {
 };
 
 export type AgentCompactionConfig = {
+  /** Enable or disable auto-compaction. Default: true. Set to false to disable compaction entirely. */
+  enabled?: boolean;
   /** Compaction summarization mode. */
   mode?: AgentCompactionMode;
   /** Override the session thinking level for embedded OpenClaw compaction summaries. */

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -159,6 +159,7 @@ export const AgentDefaultsSchema = z
       .optional(),
     compaction: z
       .object({
+        enabled: z.boolean().optional(),
         mode: z.union([z.literal("default"), z.literal("safeguard")]).optional(),
         provider: z.string().optional(),
         thinkingLevel: AgentThinkingLevelSchema.optional(),


### PR DESCRIPTION
## Problem

Setting `compaction.enabled: false` in `openclaw.json` causes the entire config to be rejected as invalid:

```
Invalid config at ~/.openclaw/openclaw.json:
- agents.defaults.compaction: Invalid input
```

The session runtime already reads `compaction.enabled` via `getCompactionEnabled()` (defaulting to `true`) and writes it via `setCompactionEnabled()`, but the Zod config schema never included the `enabled` field. This makes it **impossible to disable auto-compaction through configuration**, even though the code is written to support it.

Users experiencing premature compaction (#86684, #108215, #110055) have no workaround except manually calling `setCompactionEnabled(false)` at runtime, which doesn't persist.

## Fix

Add `enabled` (boolean, optional) to the compaction Zod schema and TypeScript type, with corresponding schema label and help text.

The runtime already handles `enabled` correctly:
- `getCompactionEnabled()` returns `this.settings.compaction?.enabled ?? true`
- `setCompactionEnabled()` writes `this.globalSettings.compaction.enabled`
- No behavior change when `enabled` is unset (defaults to `true`)

## Test Coverage

- Added regression test: `compaction.enabled: false` passes schema validation
- Added unit tests: `enabled: false`, `enabled: true`, and unset all pass through materialization

Fixes #110065
