### PR TITLE
fix(config): reject gateway.port values above TCP port range (1–65535)

### DIFF
--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -481,4 +481,34 @@ describe("config schema regressions", () => {
 
     expect(res.ok).toBe(false);
   });
+
+  it("rejects gateway.port above 65535", () => {
+    const res = validateConfigObject({
+      gateway: {
+        port: 70000,
+      },
+    });
+
+    expect(res.ok).toBe(false);
+  });
+
+  it("accepts gateway.port 443", () => {
+    const res = validateConfigObject({
+      gateway: {
+        port: 443,
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
+  it("rejects gateway.port 0", () => {
+    const res = validateConfigObject({
+      gateway: {
+        port: 0,
+      },
+    });
+
+    expect(res.ok).toBe(false);
+  });
 });

--- a/src/config/zod-schema.gateway.ts
+++ b/src/config/zod-schema.gateway.ts
@@ -13,7 +13,7 @@ import { sensitive } from "./zod-schema.sensitive.js";
 
 export const GatewayConfigSchema = z
   .strictObject({
-    port: z.number().int().positive().optional(),
+    port: z.number().int().min(1).max(65535).optional(),
     mode: z.union([z.literal("local"), z.literal("remote")]).optional(),
     bind: z
       .union([

--- a/src/config/zod-schema.hooks.ts
+++ b/src/config/zod-schema.hooks.ts
@@ -125,7 +125,7 @@ export const HooksGmailSchema = z
     serve: z
       .object({
         bind: z.string().optional(),
-        port: z.number().int().positive().optional(),
+        port: z.number().int().min(1).max(65535).optional(),
         path: z.string().optional(),
       })
       .strict()

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -1310,7 +1310,7 @@ export const MSTeamsConfigSchema = z
     managedIdentityClientId: z.string().optional(),
     webhook: z
       .object({
-        port: z.number().int().positive().optional(),
+        port: z.number().int().min(1).max(65535).optional(),
         path: z.string().optional(),
       })
       .strict()


### PR DESCRIPTION
## Problem

Setting `gateway.port` to a value above 65535 (e.g. 70000) passes config validation but fails at runtime with a cryptic `EADDRINUSE` or `EINVAL` binding error. TCP ports are 16-bit unsigned integers with a valid range of 0–65535, and 0 is reserved.

The schema used `z.number().int().positive()` which accepts any positive integer — no upper bound check.

## Fix

Replace `z.number().int().positive()` with `z.number().int().min(1).max(65535)` for all port config fields:
- `gateway.port`
- `hooks.serve.port`
- Slack webhook `port`

This produces a clear validation error at config load time instead of a runtime binding failure.

## Test Coverage

- `gateway.port: 70000` → rejected ❌
- `gateway.port: 443` → accepted ✅
- `gateway.port: 0` → rejected ❌

Fixes #109293
