### PR TITLE
fix(ui): request re-render after input history navigation

### DIFF
--- a/ui/src/pages/chat/chat-state.ts
+++ b/ui/src/pages/chat/chat-state.ts
@@ -1685,6 +1685,7 @@ export class ChatStateController<TState extends ChatPageHost> implements Reactiv
       const result = navigateInputHistory(input);
       if (result.handled) {
         this.composerPersistence.schedule();
+        this.renderLifecycle.invalidate();
       }
       return result;
     };


### PR DESCRIPTION
## Problem

Pressing ↑/↓ to recall previous chat input in the Control UI composer updates the internal draft state correctly, but the textarea is never re-rendered. The recalled value stays invisible until some other interaction forces a render.

The `handleChatInputHistoryKey` wrapper persists the draft change but was the only sibling handler that did **not** call `renderLifecycle.invalidate()` — every other key handler already does.

## Fix

Add `this.renderLifecycle.invalidate()` after `this.composerPersistence.schedule()` when `result.handled` is true.

One line. Same pattern used by every other handler in the same wrapper block.

## Reproduction

1. Type and send a few messages in Control UI chat
2. Click into the empty composer and press ↑
3. Before: textarea stays empty (state changed, no re-render)
4. After: textarea shows the previous input; further ↑/↓ cycles through history

Fixes #109031
