### PR TITLE
fix(compaction): skip preflight compaction when backend owns native compaction

### DIFF
--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -8,6 +8,7 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { resolveBootstrapWarningSignaturesSeen } from "../../agents/bootstrap-budget.js";
+import { resolveCliBackendConfig } from "../../agents/cli-backends.js";
 import { estimateMessagesTokens } from "../../agents/compaction.js";
 import { classifyCompactionReason } from "../../agents/embedded-agent-runner/compact-reasons.js";
 import { runEmbeddedAgentEntry } from "../../agents/embedded-agent-runner/run-entry.js";
@@ -777,6 +778,18 @@ export async function runPreflightCompactionIfNeeded(params: {
   if (params.isHeartbeat || isCli) {
     return entry ?? params.sessionEntry;
   }
+
+  // Defense in depth: if the resolved backend owns native compaction, do not
+  // run OpenClaw's own preflight compaction. This catches sessions that reach
+  // a CLI backend via provider/model routing but where isCliProvider() returns
+  // false because the provider string differs from the backend key.
+  const resolvedBackend = resolveCliBackendConfig(params.followupRun.run.provider, params.cfg);
+  if (resolvedBackend?.ownsNativeCompaction) {
+    logVerbose(
+      `preflightCompaction skipped: sessionKey=${params.sessionKey} provider=${params.followupRun.run.provider} reason=owns_native_compaction`,
+    );
+    return entry ?? params.sessionEntry;
+  }
   if (
     followupUsesCodexRuntime({
       cfg: params.cfg,
@@ -1124,7 +1137,13 @@ export async function runMemoryFlushIfNeeded(params: {
     followupRun: params.followupRun,
     sessionEntry: entry,
   });
-  const canAttemptFlush = memoryFlushWritable && !params.isHeartbeat && !isCli;
+  // Defense in depth: also skip memory flush for backends that own native compaction.
+  const flushBackendOwnsCompaction =
+    !isCli &&
+    resolveCliBackendConfig(params.followupRun.run.provider, params.cfg)?.ownsNativeCompaction ===
+      true;
+  const canAttemptFlush =
+    memoryFlushWritable && !params.isHeartbeat && !isCli && !flushBackendOwnsCompaction;
   const contextWindowTokens = resolveMemoryFlushContextWindowTokens({
     cfg: params.cfg,
     provider: resolveFollowupContextConfigProvider({


### PR DESCRIPTION
## Problem

On the claude-cli backend, OpenClaw's own transcript-byte compaction fires against sessions whose real conversation lives inside the Claude Code subprocess. Because OpenClaw's in-memory `session.messages` for these sessions are near-empty, the summarizer produces an empty summary ("(No conversation provided to summarize)"), and with `truncateAfterCompaction` enabled, the session is truncated/rotated — destroying continuity mid-conversation.

This happens even though the installed version ships two guards:
1. **Guard A (isCli early-return):** `if (params.isHeartbeat || isCli) return entry;` — but `isCli` evaluates false for sessions that reach claude-cli via provider/model routing rather than an explicit `claude-cli` provider string.
2. **Guard B (ownsNativeCompaction):** `cli-compaction.ts` defers when `ownsNativeCompaction` is true — but this guard is only in the CLI compaction path, not in the preflight byte-guard path.

## Fix

Add a defense-in-depth check to both the preflight compaction path and the memory flush path in `agent-runner-memory.ts`:

After the `isCli` early-return, resolve the CLI backend config for the provider and check `ownsNativeCompaction`. If true, skip compaction/flush — mirroring the guard already present in `cli-compaction.ts`.

This ensures that regardless of how `isCliProvider()` evaluates, backends that own their own compaction are never subject to OpenClaw's byte-guard compaction.

## Test Plan

1. Configure a claude-cli backend with `ownsNativeCompaction: true`
2. Route a session to it via provider/model resolution (not direct `claude-cli` provider)
3. Set `truncateAfterCompaction: true` and `maxActiveTranscriptBytes: "512kb"`
4. Drive a long session until transcript exceeds 512kb
5. **Before:** OpenClaw fires `transcript_bytes` compaction, empty summary, session truncated
6. **After:** Preflight compaction skips with `reason=owns_native_compaction`

Fixes #108984
