### PR TITLE
fix(openai): add handshakeTimeout to realtime voice WebSocket

### DIFF
--- a/extensions/openai/realtime-voice-provider.ts
+++ b/extensions/openai/realtime-voice-provider.ts
@@ -649,6 +649,7 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
         const ws = new WebSocket(connection.url, {
           headers: connection.headers,
           maxPayload: OPENAI_VOICE_WS_MAX_PAYLOAD_BYTES,
+          handshakeTimeout: 30_000,
           ...(proxyAgent ? { agent: proxyAgent } : {}),
         });
         this.ws = ws;


### PR DESCRIPTION
## Problem

The `openWebSocket` function in `extensions/openai/realtime-voice-provider.ts` creates a WebSocket connection to the OpenAI Realtime Voice API with `maxPayload` set but no `handshakeTimeout`. If the server accepts the TCP connection but never completes the WebSocket upgrade, the connection hangs indefinitely.

`rejectStartup` only fires on WS events — if the WS never opens, errors, or closes, the connection never times out.

## Fix

Add `handshakeTimeout: 30_000` (30 seconds) to the WebSocket constructor options. This matches the ws library's built-in handshake timeout and ensures connections that stall during the upgrade phase fail fast instead of hanging forever.

One line change. No behavior change for successful connections.

Fixes #109567
