### PR TITLE
fix(failover): classify provider finish_reason: error as server_error, not timeout

### DIFF
--- a/src/agents/embedded-agent-helpers/errors.ts
+++ b/src/agents/embedded-agent-helpers/errors.ts
@@ -1095,10 +1095,10 @@ function classifyFailoverClassificationFromMessage(
     return toReasonClassification("timeout");
   }
   if (isOpenRouterProviderReturnedError(raw, provider)) {
-    return toReasonClassification("timeout");
+    return toReasonClassification("server_error");
   }
   if (isServerErrorMessage(raw)) {
-    return toReasonClassification("timeout");
+    return toReasonClassification("server_error");
   }
   if (isJsonApiInternalServerError(raw)) {
     return toReasonClassification("timeout");

--- a/src/agents/embedded-agent-helpers/failover-matches.test.ts
+++ b/src/agents/embedded-agent-helpers/failover-matches.test.ts
@@ -232,3 +232,27 @@ describe("HTTP 429 overload wording (#98101)", () => {
     ).toBe("⚠️ rate limit: service overloaded, try again in 30 seconds");
   });
 });
+
+describe("finish_reason error classification (#109218)", () => {
+  it("classifies finish_reason: error as server_error, not timeout", () => {
+    expect(classifyFailoverReason("Provider finish_reason: error")).toBe("server_error");
+    expect(isServerErrorMessage("Provider finish_reason: error")).toBe(true);
+    expect(isTimeoutErrorMessage("Provider finish_reason: error")).toBe(false);
+  });
+
+  it("classifies finish_reason: malformed_response as server_error, not timeout", () => {
+    expect(classifyFailoverReason("finish_reason: malformed_response")).toBe("server_error");
+  });
+
+  it("classifies finish_reason: abort as server_error, not timeout", () => {
+    expect(classifyFailoverReason("stop reason: abort")).toBe("server_error");
+  });
+
+  it("classifies finish_reason: network_error as timeout (still a network error)", () => {
+    expect(classifyFailoverReason("finish_reason: network_error")).toBe("timeout");
+  });
+
+  it("classifies unhandled stop reason: error as server_error", () => {
+    expect(classifyFailoverReason("unhandled stop reason: error")).toBe("server_error");
+  });
+});

--- a/src/agents/embedded-agent-helpers/failover-matches.ts
+++ b/src/agents/embedded-agent-helpers/failover-matches.ts
@@ -128,6 +128,15 @@ const ERROR_PATTERNS = {
     "系统错误",
     "系统繁忙",
     "系统异常",
+    // Provider finish_reason values that signal an upstream provider error,
+    // not a timeout. OpenRouter and other routers return these when the
+    // upstream model fails quickly (seconds, not a hung request). Classifying
+    // them as "timeout" produces misleading 408/failoverReason="timeout"
+    // diagnostics that send operators hunting for nonexistent network issues.
+    /\bstop reason:\s*(?:abort|error|malformed_response)\b/i,
+    /\breason:\s*(?:abort|error|malformed_response)\b/i,
+    /\bunhandled stop reason:\s*(?:abort|error|malformed_response)\b/i,
+    /\bfinish_reason:\s*(?:abort|error|malformed_response)\b/i,
   ],
   timeout: [
     "timeout",
@@ -161,11 +170,10 @@ const ERROR_PATTERNS = {
     /\benotfound\b/i,
     /\beai_again\b/i,
     /without sending (?:any )?chunks?/i,
-    /\bstop reason:\s*(?:abort|error|malformed_response|network_error)\b/i,
-    /\breason:\s*(?:abort|error|malformed_response|network_error)\b/i,
-    /\bunhandled stop reason:\s*(?:abort|error|malformed_response|network_error)\b/i,
-    // `\breason:` does not match provider payloads like `finish_reason: network_error` (#61281).
-    /\bfinish_reason:\s*(?:abort|error|malformed_response|network_error)\b/i,
+    /\bstop reason:\s*network_error\b/i,
+    /\breason:\s*network_error\b/i,
+    /\bunhandled stop reason:\s*network_error\b/i,
+    /\bfinish_reason:\s*network_error\b/i,
     // AbortError messages from fetch/stream aborts (Ollama NDJSON stream
     // timeouts, signal aborts, etc.) — without these the flattened message
     // falls through to reason=unknown (#58315).


### PR DESCRIPTION
## Problem

When OpenRouter streams `finish_reason: error` (upstream provider error, **not** a hung request), OpenClaw's error classifier matches it in the **timeout** pattern group and produces misleading `failoverReason: "timeout"` with status 408. Operators then hunt for nonexistent network/config timeouts.

Example from the issue:
```
error: "LLM request timed out."
failoverReason: "timeout"
model: "google/gemini-2.5-flash-lite"
provider: "openrouter"
rawErrorPreview: "Provider finish_reason: error"
durationMs: 2988 … 19376   ← seconds, not a real hang
```

The request completed quickly — this is a **provider error**, not a timeout.

## Root Cause

`finish_reason` values (`abort`, `error`, `malformed_response`, `network_error`) were all lumped into the `timeout` pattern group. Only `network_error` represents an actual network/timeout failure. The other three are provider-side failures.

Additionally, `isOpenRouterProviderReturnedError()` and `isServerErrorMessage()` both returned `toReasonClassification("timeout")` — even though their pattern names and matches indicate server-side errors.

## Fix

**Pattern reclassification** (`failover-matches.ts`):
- Move `abort|error|malformed_response` patterns from `timeout` to `serverError`
- Keep `network_error` patterns in `timeout` (it IS a network error)

**Classification fix** (`errors.ts`):
- `isOpenRouterProviderReturnedError` → `"server_error"` (was: `"timeout"`)
- `isServerErrorMessage` → `"server_error"` (was: `"timeout"`)

## Impact

| Error pattern | Before | After |
|---|---|---|
| `finish_reason: error` | timeout (408) | server_error (500) |
| `finish_reason: malformed_response` | timeout (408) | server_error (500) |
| `finish_reason: abort` | timeout (408) | server_error (500) |
| `finish_reason: network_error` | timeout (408) | timeout (408) ✓ |
| OpenRouter "Provider returned error" | timeout (408) | server_error (500) |
| Fallback behavior | candidate_failed → next model | **unchanged** |

## Test Coverage

Added 5 test cases in `failover-matches.test.ts`:
- `finish_reason: error` → `server_error`, not `timeout`
- `finish_reason: malformed_response` → `server_error`
- `finish_reason: abort` → `server_error`
- `finish_reason: network_error` → `timeout` (unchanged)
- `unhandled stop reason: error` → `server_error`

Fixes #109218
