### PR TITLE
fix(feishu): treat block-level silent skip (NO_REPLY) same as final skip

### DIFF
--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -2090,6 +2090,23 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     });
   });
 
+  it("does not send no-visible-reply fallback when NO_REPLY arrives as a block reply (kind: block, reason: silent)", async () => {
+    const runtime = createRuntimeLogger();
+    const { result, options } = createDispatcherHarness({ runtime, sessionKey: "main" });
+
+    // NO_REPLY emitted via emitSplitResultAsBlockReply produces kind: "block",
+    // not kind: "final". The onSkip handler must still track the silent skip
+    // so the fallback message is not sent.
+    options.onSkip?.({ text: "NO_REPLY" }, { kind: "block", reason: "silent" });
+    await expect(result.ensureNoVisibleReplyFallback("empty-complete")).resolves.toBe(false);
+
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+    expect(result.getVisibleReplyState()).toEqual({
+      visibleReplySent: false,
+      skippedFinalReason: "silent",
+    });
+  });
+
   it("sends no-visible-reply fallback when a final fails after an earlier silent skip", async () => {
     useNonStreamingAutoAccount();
     const runtime = createRuntimeLogger();

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -670,7 +670,11 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       conversationType: chatId.startsWith("oc_") ? "group" : "direct",
     },
     onSkip: (_payload, info) => {
-      if (info.kind === "final") {
+      // A block-level silent skip (e.g. NO_REPLY emitted as a block via
+      // emitSplitResultAsBlockReply) is terminal: the model returned a clean
+      // stop with no visible content. Track it the same as a final skip so
+      // the no-visible-reply fallback is not sent for intentional silence.
+      if (info.kind === "final" || (info.kind === "block" && info.reason === "silent")) {
         skippedFinalReason = info.reason;
       }
     },


### PR DESCRIPTION
## Problem

In a Feishu DM, when the model returns `NO_REPLY` with `stopReason: "stop"`, the user sees the fallback message:

> ⚠️ This reply completed without visible content. The turn may have been interrupted; please retry or ask me to recover from recent context.

This happens because NO_REPLY arrives as `kind: "block"` (via `emitSplitResultAsBlockReply`), but the Feishu dispatcher's `onSkip` handler only tracks `kind: "final"` skips. Block-level silent skips are silently dropped, so `skippedFinalReason` stays `null`, and `ensureNoVisibleReplyFallback` sends the fallback text.

## Fix

In `reply-dispatcher.ts`, propagate block-level silent skips (`kind: "block", reason: "silent"`) the same as final skips. The skip is terminal once `normalizeReplyPayload` detects it — the model returned a clean stop with no visible content.

```ts
onSkip: (_payload, info) => {
  if (info.kind === "final" || (info.kind === "block" && info.reason === "silent")) {
    skippedFinalReason = info.reason;
  }
},
```

## Test Coverage

Added test: NO_REPLY as `kind: "block"` does not trigger the no-visible-reply fallback.

Fixes #109912
