### PR TITLE
fix(browser): control results can contain corrupted text from malformed UTF-8

### DIFF
--- a/extensions/browser/src/browser/client-fetch.error-body-boundary.test.ts
+++ b/extensions/browser/src/browser/client-fetch.error-body-boundary.test.ts
@@ -40,8 +40,10 @@ describe("fetchHttpJson error body boundary", () => {
   let resolveSmallConnectionClosed: () => void;
   let successStreamClosed: Promise<void>;
   let resolveSuccessStreamClosed: () => void;
-  let malformedConnectionClosed: Promise<void>;
-  let resolveMalformedConnectionClosed: () => void;
+  let malformedSuccessConnectionClosed: Promise<void>;
+  let resolveMalformedSuccessConnectionClosed: () => void;
+  let malformedErrorConnectionClosed: Promise<void>;
+  let resolveMalformedErrorConnectionClosed: () => void;
   let streamCompleted: boolean;
   let successStreamCompleted: boolean;
 
@@ -66,8 +68,11 @@ describe("fetchHttpJson error body boundary", () => {
     successStreamClosed = new Promise<void>((resolve) => {
       resolveSuccessStreamClosed = resolve;
     });
-    malformedConnectionClosed = new Promise<void>((resolve) => {
-      resolveMalformedConnectionClosed = resolve;
+    malformedSuccessConnectionClosed = new Promise<void>((resolve) => {
+      resolveMalformedSuccessConnectionClosed = resolve;
+    });
+    malformedErrorConnectionClosed = new Promise<void>((resolve) => {
+      resolveMalformedErrorConnectionClosed = resolve;
     });
     streamCompleted = false;
     successStreamCompleted = false;
@@ -78,10 +83,22 @@ describe("fetchHttpJson error body boundary", () => {
         return;
       }
       if (req.url === "/success-malformed-utf8") {
-        req.socket.once("close", () => resolveMalformedConnectionClosed());
+        req.socket.once("close", () => resolveMalformedSuccessConnectionClosed());
         res.writeHead(200, { "Content-Type": "application/json" });
         res.end(
           Buffer.concat([Buffer.from('{"payload":"'), Buffer.from([0xff]), Buffer.from('"}')]),
+        );
+        return;
+      }
+      if (req.url === "/error-malformed-utf8") {
+        req.socket.once("close", () => resolveMalformedErrorConnectionClosed());
+        res.writeHead(500, { "Content-Type": "application/json" });
+        res.end(
+          Buffer.concat([
+            Buffer.from('{"error":"control '),
+            Buffer.from([0xff]),
+            Buffer.from('"}'),
+          ]),
         );
         return;
       }
@@ -221,7 +238,20 @@ describe("fetchHttpJson error body boundary", () => {
       message: "Browser control response was not valid UTF-8 (HTTP 200)",
       status: 200,
     });
-    await expect(malformedConnectionClosed).resolves.toBeUndefined();
+    await expect(malformedSuccessConnectionClosed).resolves.toBeUndefined();
+  });
+
+  it("rejects malformed UTF-8 error JSON and releases the guarded fetch", async () => {
+    const error = await fetchBrowserJson(`${baseUrl}/error-malformed-utf8`).catch(
+      (err: unknown) => err,
+    );
+
+    expect(error).toMatchObject({
+      name: "BrowserServiceError",
+      message: "Browser control response was not valid UTF-8 (HTTP 500)",
+      status: 500,
+    });
+    await expect(malformedErrorConnectionClosed).resolves.toBeUndefined();
   });
 
   it("preserves a complete diagnostic body within the limit", async () => {

--- a/extensions/browser/src/browser/client-fetch.error-body-boundary.test.ts
+++ b/extensions/browser/src/browser/client-fetch.error-body-boundary.test.ts
@@ -40,6 +40,8 @@ describe("fetchHttpJson error body boundary", () => {
   let resolveSmallConnectionClosed: () => void;
   let successStreamClosed: Promise<void>;
   let resolveSuccessStreamClosed: () => void;
+  let malformedConnectionClosed: Promise<void>;
+  let resolveMalformedConnectionClosed: () => void;
   let streamCompleted: boolean;
   let successStreamCompleted: boolean;
 
@@ -64,12 +66,23 @@ describe("fetchHttpJson error body boundary", () => {
     successStreamClosed = new Promise<void>((resolve) => {
       resolveSuccessStreamClosed = resolve;
     });
+    malformedConnectionClosed = new Promise<void>((resolve) => {
+      resolveMalformedConnectionClosed = resolve;
+    });
     streamCompleted = false;
     successStreamCompleted = false;
     server = http.createServer((req, res) => {
       if (req.url === "/success-small") {
         res.writeHead(200, { "Content-Type": "application/json" });
         res.end('{"payload":"control"}');
+        return;
+      }
+      if (req.url === "/success-malformed-utf8") {
+        req.socket.once("close", () => resolveMalformedConnectionClosed());
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(
+          Buffer.concat([Buffer.from('{"payload":"'), Buffer.from([0xff]), Buffer.from('"}')]),
+        );
         return;
       }
       if (req.url === "/success-large") {
@@ -196,6 +209,19 @@ describe("fetchHttpJson error body boundary", () => {
     await expect(fetchBrowserJson(`${baseUrl}/success-small`)).resolves.toEqual({
       payload: "control",
     });
+  });
+
+  it("rejects malformed UTF-8 JSON and releases the guarded fetch", async () => {
+    const error = await fetchBrowserJson(`${baseUrl}/success-malformed-utf8`).catch(
+      (err: unknown) => err,
+    );
+
+    expect(error).toMatchObject({
+      name: "BrowserServiceError",
+      message: "Browser control response was not valid UTF-8 (HTTP 200)",
+      status: 200,
+    });
+    await expect(malformedConnectionClosed).resolves.toBeUndefined();
   });
 
   it("preserves a complete diagnostic body within the limit", async () => {

--- a/extensions/browser/src/browser/client-fetch.error-body-boundary.test.ts
+++ b/extensions/browser/src/browser/client-fetch.error-body-boundary.test.ts
@@ -25,6 +25,7 @@ const STREAM_BODY_BYTES = 1024 * 1024;
 const SUCCESS_STREAM_CHUNK = Buffer.alloc(64 * 1024, "x");
 const SUCCESS_STREAM_BODY_BYTES = 33 * 1024 * 1024;
 const BROWSER_SUCCESS_BODY_LIMIT_BYTES = 32 * 1024 * 1024;
+const MALFORMED_UTF8_STATUSES = [200, 401, 408, 500, 504] as const;
 
 function scheduleStreamChunk(writeNext: () => void): void {
   // Separate event-loop turns preserve streaming and backpressure without a wall-clock sleep.
@@ -40,10 +41,8 @@ describe("fetchHttpJson error body boundary", () => {
   let resolveSmallConnectionClosed: () => void;
   let successStreamClosed: Promise<void>;
   let resolveSuccessStreamClosed: () => void;
-  let malformedSuccessConnectionClosed: Promise<void>;
-  let resolveMalformedSuccessConnectionClosed: () => void;
-  let malformedErrorConnectionClosed: Promise<void>;
-  let resolveMalformedErrorConnectionClosed: () => void;
+  let malformedConnectionClosed: Map<number, Promise<void>>;
+  let resolveMalformedConnectionClosed: Map<number, () => void>;
   let streamCompleted: boolean;
   let successStreamCompleted: boolean;
 
@@ -68,12 +67,16 @@ describe("fetchHttpJson error body boundary", () => {
     successStreamClosed = new Promise<void>((resolve) => {
       resolveSuccessStreamClosed = resolve;
     });
-    malformedSuccessConnectionClosed = new Promise<void>((resolve) => {
-      resolveMalformedSuccessConnectionClosed = resolve;
-    });
-    malformedErrorConnectionClosed = new Promise<void>((resolve) => {
-      resolveMalformedErrorConnectionClosed = resolve;
-    });
+    malformedConnectionClosed = new Map();
+    resolveMalformedConnectionClosed = new Map();
+    for (const status of MALFORMED_UTF8_STATUSES) {
+      malformedConnectionClosed.set(
+        status,
+        new Promise<void>((resolve) => {
+          resolveMalformedConnectionClosed.set(status, resolve);
+        }),
+      );
+    }
     streamCompleted = false;
     successStreamCompleted = false;
     server = http.createServer((req, res) => {
@@ -82,17 +85,10 @@ describe("fetchHttpJson error body boundary", () => {
         res.end('{"payload":"control 🦞"}');
         return;
       }
-      if (req.url === "/success-malformed-utf8") {
-        req.socket.once("close", () => resolveMalformedSuccessConnectionClosed());
-        res.writeHead(200, { "Content-Type": "application/json" });
-        res.end(
-          Buffer.concat([Buffer.from('{"payload":"'), Buffer.from([0xff]), Buffer.from('"}')]),
-        );
-        return;
-      }
-      if (req.url === "/error-malformed-utf8") {
-        req.socket.once("close", () => resolveMalformedErrorConnectionClosed());
-        res.writeHead(500, { "Content-Type": "application/json" });
+      const malformedStatus = Number(req.url?.match(/^\/malformed-utf8\/(\d+)$/)?.[1]);
+      if (MALFORMED_UTF8_STATUSES.some((status) => status === malformedStatus)) {
+        req.socket.once("close", () => resolveMalformedConnectionClosed.get(malformedStatus)?.());
+        res.writeHead(malformedStatus, { "Content-Type": "application/json" });
         res.end(
           Buffer.concat([
             Buffer.from('{"error":"control '),
@@ -228,18 +224,27 @@ describe("fetchHttpJson error body boundary", () => {
     });
   });
 
-  it("rejects malformed UTF-8 success and error responses and releases each fetch", async () => {
-    for (const [path, status, connectionClosed] of [
-      ["/success-malformed-utf8", 200, malformedSuccessConnectionClosed],
-      ["/error-malformed-utf8", 500, malformedErrorConnectionClosed],
-    ] as const) {
-      const error = await fetchBrowserJson(`${baseUrl}${path}`).catch((err: unknown) => err);
+  it("rejects malformed UTF-8 responses, preserves retry policy, and releases each fetch", async () => {
+    for (const status of MALFORMED_UTF8_STATUSES) {
+      const error = await fetchBrowserJson(`${baseUrl}/malformed-utf8/${status}`).catch(
+        (err: unknown) => err,
+      );
 
       expect(error).toMatchObject({
         name: "BrowserServiceError",
-        message: `Browser control response was not valid UTF-8 (HTTP ${status})`,
         status,
       });
+      const message = error instanceof Error ? error.message : "";
+      expect(message).toContain(`Browser control response was not valid UTF-8 (HTTP ${status})`);
+      if (status === 401) {
+        expect(message).toContain("Do NOT retry the browser tool");
+      } else if (status === 408 || status === 504) {
+        expect(message).toContain("Retry the browser tool once");
+      } else {
+        expect(message).not.toContain("Retry the browser tool");
+      }
+      const connectionClosed = malformedConnectionClosed.get(status);
+      expect(connectionClosed).toBeDefined();
       await expect(connectionClosed).resolves.toBeUndefined();
     }
   });

--- a/extensions/browser/src/browser/client-fetch.error-body-boundary.test.ts
+++ b/extensions/browser/src/browser/client-fetch.error-body-boundary.test.ts
@@ -79,7 +79,7 @@ describe("fetchHttpJson error body boundary", () => {
     server = http.createServer((req, res) => {
       if (req.url === "/success-small") {
         res.writeHead(200, { "Content-Type": "application/json" });
-        res.end('{"payload":"control"}');
+        res.end('{"payload":"control 🦞"}');
         return;
       }
       if (req.url === "/success-malformed-utf8") {
@@ -224,34 +224,24 @@ describe("fetchHttpJson error body boundary", () => {
 
   it("preserves a normal successful JSON response", async () => {
     await expect(fetchBrowserJson(`${baseUrl}/success-small`)).resolves.toEqual({
-      payload: "control",
+      payload: "control 🦞",
     });
   });
 
-  it("rejects malformed UTF-8 JSON and releases the guarded fetch", async () => {
-    const error = await fetchBrowserJson(`${baseUrl}/success-malformed-utf8`).catch(
-      (err: unknown) => err,
-    );
+  it("rejects malformed UTF-8 success and error responses and releases each fetch", async () => {
+    for (const [path, status, connectionClosed] of [
+      ["/success-malformed-utf8", 200, malformedSuccessConnectionClosed],
+      ["/error-malformed-utf8", 500, malformedErrorConnectionClosed],
+    ] as const) {
+      const error = await fetchBrowserJson(`${baseUrl}${path}`).catch((err: unknown) => err);
 
-    expect(error).toMatchObject({
-      name: "BrowserServiceError",
-      message: "Browser control response was not valid UTF-8 (HTTP 200)",
-      status: 200,
-    });
-    await expect(malformedSuccessConnectionClosed).resolves.toBeUndefined();
-  });
-
-  it("rejects malformed UTF-8 error JSON and releases the guarded fetch", async () => {
-    const error = await fetchBrowserJson(`${baseUrl}/error-malformed-utf8`).catch(
-      (err: unknown) => err,
-    );
-
-    expect(error).toMatchObject({
-      name: "BrowserServiceError",
-      message: "Browser control response was not valid UTF-8 (HTTP 500)",
-      status: 500,
-    });
-    await expect(malformedErrorConnectionClosed).resolves.toBeUndefined();
+      expect(error).toMatchObject({
+        name: "BrowserServiceError",
+        message: `Browser control response was not valid UTF-8 (HTTP ${status})`,
+        status,
+      });
+      await expect(connectionClosed).resolves.toBeUndefined();
+    }
   });
 
   it("preserves a complete diagnostic body within the limit", async () => {

--- a/extensions/browser/src/browser/client-fetch.ts
+++ b/extensions/browser/src/browser/client-fetch.ts
@@ -155,9 +155,9 @@ function decodeBrowserControlResponseUtf8(body: Uint8Array, status: number): str
   try {
     return new TextDecoder("utf-8", { fatal: true }).decode(body);
   } catch {
-    throw new BrowserServiceError(
-      `Browser control response was not valid UTF-8 (HTTP ${status})`,
+    throw browserServiceErrorFromPayload(
       undefined,
+      `Browser control response was not valid UTF-8 (HTTP ${status})`,
       status,
     );
   }

--- a/extensions/browser/src/browser/client-fetch.ts
+++ b/extensions/browser/src/browser/client-fetch.ts
@@ -151,6 +151,18 @@ const BROWSER_ERROR_BODY_LIMIT_BYTES = 16 * 1024;
 // `response/body` supports 5M characters; 32 MiB covers worst-case JSON escaping while staying bounded.
 const BROWSER_SUCCESS_BODY_LIMIT_BYTES = 32 * 1024 * 1024;
 
+function decodeBrowserControlResponseUtf8(body: Uint8Array, status: number): string {
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(body);
+  } catch {
+    throw new BrowserServiceError(
+      `Browser control response was not valid UTF-8 (HTTP ${status})`,
+      undefined,
+      status,
+    );
+  }
+}
+
 function isRateLimitStatus(status: number): boolean {
   return status === 429;
 }
@@ -378,7 +390,7 @@ async function fetchHttpJson<T>(
       const body = await readResponseWithLimit(res, BROWSER_ERROR_BODY_LIMIT_BYTES).catch(
         () => undefined,
       );
-      const text = body ? new TextDecoder().decode(body) : "";
+      const text = body ? decodeBrowserControlResponseUtf8(body, res.status) : "";
       let parsed: unknown;
       if (text) {
         try {
@@ -393,7 +405,7 @@ async function fetchHttpJson<T>(
       onOverflow: ({ maxBytes }) =>
         new BrowserServiceError(`Browser control response exceeded ${maxBytes} bytes`),
     });
-    return JSON.parse(new TextDecoder().decode(body)) as T;
+    return JSON.parse(decodeBrowserControlResponseUtf8(body, res.status)) as T;
   } finally {
     clearTimeout(t);
     await release?.();


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Allow edits from maintainers is enabled so maintainers can update the branch if needed.

</details>

## What Problem This Solves

Fixes an issue where users of an absolute browser-control or sandbox endpoint could receive apparently successful browser tool data containing the Unicode replacement character when the endpoint returned malformed UTF-8 bytes.

## Why This Change Was Made

The browser plugin now decodes bounded HTTP response bytes with strict UTF-8 validation at the existing `fetchBrowserJson` transport boundary for both successful and error responses. Invalid byte sequences become a `BrowserServiceError` with the HTTP status preserved; the in-process dispatcher path remains unchanged, and the existing guarded-fetch cleanup path still owns connection release.

## User Impact

Malformed browser-control responses now fail clearly instead of silently corrupting returned text. The guarded connection is released when decoding fails, so the invalid response does not leave its per-request dispatcher open.

## Evidence

- Before the fix, malformed success and error JSON bodies decoded `0xff` as U+FFFD instead of rejecting the invalid response; a successful body could therefore return `{ payload: "�" }` as apparently valid tool data.
- `node scripts/run-vitest.mjs extensions/browser/src/browser/client-fetch.error-body-boundary.test.ts` — 7/7 tests passed after the fix. The regression cases send malformed bytes over real loopback HTTP for both HTTP 200 and HTTP 500, assert the status-preserving `BrowserServiceError`, and observe the server-side socket closing after guarded-fetch release.
- The standalone terminal proof below runs outside Vitest and calls the production `fetchBrowserJson` export against a real `node:http` loopback server. Its temporary harness injects raw `0xff` into HTTP 200 and HTTP 500 JSON bodies, asserts the exact status-preserving `BrowserServiceError`, and waits for the server-observed socket close before reporting success. An isolated empty config/state path keeps local operator configuration out of the transcript.
- No separate GUI browser proof was run: a healthy browser-control server does not emit malformed UTF-8, so reproducing this condition in a live browser environment would still require the same byte-level fault injection at this canonical HTTP decoding boundary.
- Changed-surface validation passed formatting, extension production/test typechecks, dependency and plugin-boundary guards, Plugin SDK API manifest checks, and targeted extension lint. The lint retry used a work-disk `TMPDIR` because the host `/tmp` filesystem was full; the original failure was `ENOSPC`, not a code finding.
- `git diff --check` passed.
- Autoreview: a fresh `gpt-5.6-sol`/`xhigh` review of the exact rebased head reported `patch is correct`, confidence 0.98, with no actionable findings.

### Standalone transport proof

Run from exact rebased PR head `45cdc361cb331107608e6607274a6da5d52a5f14`; the temporary proof harness was not committed.

```text
$ PROOF_HEAD="$(git rev-parse HEAD)" OPENCLAW_CONFIG_PATH="$PWD/.artifacts/tmp-browser-utf8-rebase/openclaw.json" OPENCLAW_STATE_DIR="$PWD/.artifacts/tmp-browser-utf8-rebase/state" TMPDIR="$PWD/.artifacts/tmp-browser-utf8-rebase" node --import tsx .artifacts/browser-control-malformed-utf8-proof.ts
head=45cdc361cb331107608e6607274a6da5d52a5f14
transport=real-loopback-http
caller=production-fetchBrowserJson
malformed-byte=0xff
case=http-200 name=BrowserServiceError status=200 message="Browser control response was not valid UTF-8 (HTTP 200)" socketClosed=true
case=http-500 name=BrowserServiceError status=500 message="Browser control response was not valid UTF-8 (HTTP 500)" socketClosed=true
result=PASS
```

AI-assisted: yes. I reviewed the implementation, regression test, and cleanup behavior.
