### PR TITLE
feat(plugin-runtime): support declarative tools and single-attempt completions

### DIFF
--- a/docs/plugins/sdk-runtime.md
+++ b/docs/plugins/sdk-runtime.md
@@ -227,8 +227,21 @@ two-party event loops that do not go through the shared inbound reply runner.
       messages: [{ role: "user", content: "Summarize this transcript." }],
       purpose: "my-plugin.summary",
       maxTokens: 512,
+      maxRetries: 0,
       temperature: 0.2,
       reasoning: "high",
+      tools: [
+        {
+          name: "lookup_record",
+          description: "Read one record by id.",
+          parameters: {
+            type: "object",
+            properties: { id: { type: "string" } },
+            required: ["id"],
+            additionalProperties: false,
+          },
+        },
+      ],
     });
     ```
 
@@ -276,6 +289,11 @@ two-party event loops that do not go through the shared inbound reply runner.
     `medium`, `high`, `xhigh`, `adaptive`, `max`, and `ultra`) for the selected
     provider and model before dispatching the completion. `adaptive` becomes
     `medium`; `max` and `ultra` become `max` when supported, otherwise `xhigh`.
+
+    Tool schemas are declarative: the helper returns structured calls in
+    `result.toolCalls` but never executes them. Set `maxRetries: 0` when the
+    caller must make exactly one provider/SDK attempt on transports that honor
+    this option; omitted values preserve the provider default.
 
     <Warning>
     Model overrides require operator opt-in via `plugins.entries.<id>.llm.allowModelOverride: true` in config. Use `plugins.entries.<id>.llm.allowedModels` to restrict trusted plugins to specific canonical `provider/model` targets. Cross-agent completions require `plugins.entries.<id>.llm.allowAgentIdOverride: true`.

--- a/extensions/clickclack/src/inbound.test.ts
+++ b/extensions/clickclack/src/inbound.test.ts
@@ -281,6 +281,7 @@ describe("handleClickClackInbound", () => {
     const runtime = createRuntime();
     vi.mocked(runtime.llm.complete).mockResolvedValue({
       text: "   ",
+      toolCalls: [],
       provider: "openai",
       model: "gpt-5.4-mini",
       agentId: "service-bot",

--- a/src/agents/simple-completion-runtime.ts
+++ b/src/agents/simple-completion-runtime.ts
@@ -69,6 +69,7 @@ type AllowedMissingApiKeyMode = ResolvedProviderAuth["mode"];
 
 type SimpleCompletionModelOptions = {
   maxTokens?: number;
+  maxRetries?: number;
   temperature?: number;
   reasoning?: ThinkLevel | SimpleCompletionThinkingLevel;
   signal?: AbortSignal;

--- a/src/plugins/runtime/runtime-llm.runtime.test.ts
+++ b/src/plugins/runtime/runtime-llm.runtime.test.ts
@@ -637,7 +637,7 @@ describe("runtime.llm.complete", () => {
     );
   });
 
-  it("passes declarative tools and zero retries to one provider attempt", async () => {
+  it("passes declarative tools and zero retries to the provider", async () => {
     hoisted.completeWithPreparedSimpleCompletionModel.mockResolvedValueOnce({
       content: [
         { type: "text", text: "Checking the snapshot." },

--- a/src/plugins/runtime/runtime-llm.runtime.test.ts
+++ b/src/plugins/runtime/runtime-llm.runtime.test.ts
@@ -595,6 +595,7 @@ describe("runtime.llm.complete", () => {
     });
     expectFields(requireRecord(result, "completion result"), {
       text: "done",
+      toolCalls: [],
       provider: "openai",
       model: "gpt-5.5",
     });
@@ -634,6 +635,74 @@ describe("runtime.llm.complete", () => {
     expect(requireRecord(completionArg.options, "completion options")).not.toHaveProperty(
       "reasoning",
     );
+  });
+
+  it("passes declarative tools and zero retries to one provider attempt", async () => {
+    hoisted.completeWithPreparedSimpleCompletionModel.mockResolvedValueOnce({
+      content: [
+        { type: "text", text: "Checking the snapshot." },
+        {
+          type: "toolCall",
+          id: "call_snapshot",
+          name: "lookup_record",
+          arguments: { id: "record-123" },
+        },
+      ],
+      usage: { input: 13, output: 5, total: 18 },
+    });
+    const llm = createRuntimeLlm({
+      getConfig: () => cfg,
+      authority: { allowComplete: true },
+    });
+    const tools = [
+      {
+        name: "lookup_record",
+        description: "Read one record by id.",
+        parameters: {
+          type: "object",
+          additionalProperties: false,
+          properties: { id: { type: "string" } },
+          required: ["id"],
+        },
+      },
+    ];
+
+    const result = await llm.complete({
+      messages: [{ role: "user", content: "Prepare the briefing." }],
+      maxRetries: 0,
+      tools,
+    });
+
+    const completionArg = expectSingleCallFirstArg(
+      hoisted.completeWithPreparedSimpleCompletionModel,
+      { cfg },
+    );
+    expect(requireRecord(completionArg.options, "completion options").maxRetries).toBe(0);
+    expect(requireRecord(completionArg.context, "completion context").tools).toEqual(tools);
+    expect(result.toolCalls).toEqual([
+      {
+        id: "call_snapshot",
+        name: "lookup_record",
+        arguments: { id: "record-123" },
+      },
+    ]);
+    expect(result.text).toBe("Checking the snapshot.");
+  });
+
+  it("rejects invalid retry counts before dispatch", async () => {
+    const llm = createRuntimeLlm({
+      getConfig: () => cfg,
+      authority: { allowComplete: true },
+    });
+
+    await expect(
+      llm.complete({
+        messages: [{ role: "user", content: "Ping" }],
+        maxRetries: -1,
+      }),
+    ).rejects.toThrow("maxRetries must be a non-negative integer");
+    expect(hoisted.prepareSimpleCompletionModelForAgent).not.toHaveBeenCalled();
+    expect(hoisted.completeWithPreparedSimpleCompletionModel).not.toHaveBeenCalled();
   });
 
   it("uses scoped plugin identity and ignores caller-shaped spoofing input", async () => {

--- a/src/plugins/runtime/runtime-llm.runtime.ts
+++ b/src/plugins/runtime/runtime-llm.runtime.ts
@@ -7,7 +7,7 @@ import { normalizeModelRef } from "../../agents/model-selection.js";
 import type { NormalizedUsage, UsageLike } from "../../agents/usage.js";
 import { normalizeUsage } from "../../agents/usage.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import type { Api, Message } from "../../llm/types.js";
+import type { Api, Message, Tool } from "../../llm/types.js";
 import { getChildLogger } from "../../logging.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
 import { estimateUsageCost, resolveModelCostConfig } from "../../utils/usage-format.js";
@@ -222,6 +222,27 @@ function finiteOption(value: number | undefined): number | undefined {
   return asFiniteNumber(value);
 }
 
+function nonNegativeIntegerOption(name: string, value: number | undefined): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new Error(`Plugin LLM completion ${name} must be a non-negative integer.`);
+  }
+  return value;
+}
+
+function buildTools(params: LlmCompleteParams): Tool[] | undefined {
+  if (!params.tools || params.tools.length === 0) {
+    return undefined;
+  }
+  return params.tools.map((tool) => ({
+    name: tool.name,
+    description: tool.description,
+    parameters: structuredClone(tool.parameters),
+  }));
+}
+
 function normalizeAllowedModelRef(raw: string): string | null {
   const trimmed = raw.trim();
   if (!trimmed) {
@@ -368,6 +389,7 @@ export function createRuntimeLlm(
         });
         throw new Error(`Plugin LLM completion denied: ${reason}`);
       }
+      const maxRetries = nonNegativeIntegerOption("maxRetries", params.maxRetries);
 
       const [
         {
@@ -437,6 +459,7 @@ export function createRuntimeLlm(
           model: prepared.model.id,
           api: prepared.model.api,
         }),
+        tools: buildTools(params),
       };
 
       const result = await completeWithPreparedSimpleCompletionModel({
@@ -446,6 +469,7 @@ export function createRuntimeLlm(
         context,
         options: {
           maxTokens: finiteOption(params.maxTokens),
+          maxRetries,
           temperature: finiteOption(params.temperature),
           ...(params.reasoning !== undefined ? { reasoning: params.reasoning } : {}),
           signal: params.signal,
@@ -456,6 +480,22 @@ export function createRuntimeLlm(
         .filter((c): c is { type: "text"; text: string } => c.type === "text")
         .map((c) => c.text)
         .join("");
+      const toolCalls = result.content
+        .filter(
+          (
+            c,
+          ): c is {
+            type: "toolCall";
+            id: string;
+            name: string;
+            arguments: Record<string, unknown>;
+          } => c.type === "toolCall",
+        )
+        .map((call) => ({
+          id: call.id,
+          name: call.name,
+          arguments: structuredClone(call.arguments),
+        }));
       const normalizedUsage = normalizeUsage(result.usage as UsageLike | undefined);
       const usage = buildUsage({
         rawUsage: result.usage,
@@ -477,6 +517,7 @@ export function createRuntimeLlm(
 
       return {
         text,
+        toolCalls,
         provider: prepared.selection.provider,
         model: prepared.selection.modelId,
         agentId,

--- a/src/plugins/runtime/types-core.ts
+++ b/src/plugins/runtime/types-core.ts
@@ -213,13 +213,13 @@ export type LlmCompleteUsage = {
   costUsd?: number;
 };
 
-export type LlmCompleteTool = {
+type LlmCompleteTool = {
   name: string;
   description: string;
   parameters: Record<string, unknown>;
 };
 
-export type LlmCompleteToolCall = {
+type LlmCompleteToolCall = {
   id: string;
   name: string;
   arguments: Record<string, unknown>;

--- a/src/plugins/runtime/types-core.ts
+++ b/src/plugins/runtime/types-core.ts
@@ -213,15 +213,31 @@ export type LlmCompleteUsage = {
   costUsd?: number;
 };
 
+export type LlmCompleteTool = {
+  name: string;
+  description: string;
+  parameters: Record<string, unknown>;
+};
+
+export type LlmCompleteToolCall = {
+  id: string;
+  name: string;
+  arguments: Record<string, unknown>;
+};
+
 export type LlmCompleteParams = {
   messages: LlmCompleteMessage[];
   /** Model ref (e.g. "anthropic/claude-sonnet-4-6"); defaults to the target agent's configured model. */
   model?: string;
   maxTokens?: number;
+  /** Provider/SDK retries after the initial attempt. Set to 0 for one-attempt calls. */
+  maxRetries?: number;
   temperature?: number;
   /** Requested reasoning effort; the host normalizes it for the selected model. */
   reasoning?: import("../../auto-reply/thinking.js").ThinkLevel;
   systemPrompt?: string;
+  /** Declarative tool schemas exposed to the model. The helper never executes them. */
+  tools?: LlmCompleteTool[];
   signal?: AbortSignal;
   /** Human-readable reason for audit/debug output. */
   purpose?: string;
@@ -231,6 +247,7 @@ export type LlmCompleteParams = {
 
 export type LlmCompleteResult = {
   text: string;
+  toolCalls: LlmCompleteToolCall[];
   provider: string;
   model: string;
   agentId: string;

--- a/src/plugins/runtime/types-core.ts
+++ b/src/plugins/runtime/types-core.ts
@@ -230,7 +230,7 @@ export type LlmCompleteParams = {
   /** Model ref (e.g. "anthropic/claude-sonnet-4-6"); defaults to the target agent's configured model. */
   model?: string;
   maxTokens?: number;
-  /** Provider/SDK retries after the initial attempt. Set to 0 for one-attempt calls. */
+  /** Provider/SDK retries after the initial attempt, when supported. Set to 0 to disable them. */
   maxRetries?: number;
   temperature?: number;
   /** Requested reasoning effort; the host normalizes it for the selected model. */


### PR DESCRIPTION
Related: #111889

## What Problem This Solves

Plugin authors can use `api.runtime.llm.complete`, but the helper cannot currently expose declarative tool schemas, return structured tool calls, or request zero SDK retries. Plugins that need a deterministic single-attempt decision must therefore bypass the supported runtime helper or weaken that execution contract.

## Why This Change Was Made

This extends the existing host-owned simple-completion path with optional `tools` and `maxRetries` inputs and a normalized `toolCalls` result. Tool schemas are passed to the model but never executed by the helper; omitted options preserve current provider defaults and behavior.

Invalid retry counts fail before model preparation or provider dispatch. The implementation retains the existing authority, model-selection, reasoning, authentication, usage-normalization, and audit paths.

## User Impact

Plugin developers can implement caller-controlled tool loops while keeping model preparation and credentials inside OpenClaw. Setting `maxRetries: 0` requests one provider/SDK attempt on transports that honor the option.

There is no change for existing callers that omit the new options.

## Evidence

- `node scripts/test-projects.mjs src/plugins/runtime/runtime-llm.runtime.test.ts`: 24/24 tests passed.
- `oxfmt --check` on all five changed files: passed.
- `oxlint` on the changed TypeScript files: passed.
- `pnpm plugin-sdk:api:check`: passed.
- `pnpm plugin-sdk:surface:check`: passed; no forbidden package-exported subpaths.
- `pnpm docs:check-mdx`: 748 files passed.
- `pnpm test:contracts:plugins`: 926/961 tests passed. The remaining 35 are blocked before their assertions by OpenClaw's SQLite safety guard because this host runs Node 22.22.2 / SQLite 3.51.2; the repository requires Node 22.22.3+, 24.15.0+, or 25.9.0+.
- `pnpm tsgo:all` passed on the original v2026.7.1 implementation. After rebasing onto current `main`, the all-workspace run was stopped after 12 minutes because the constrained host reached 83% process memory and a full disk; it emitted no type errors before interruption. Focused tests and SDK gates above were rerun after the rebase.
- No live OpenClaw instance, provider, model, or credential was invoked.

## AI Assistance

- [x] This change was prepared with Codex assistance.
- [x] I reviewed the resulting behavior and diff and understand the implementation.
- [x] The PR is opened as a draft so CI and maintainers can validate it on a supported Node runtime before review readiness.
