### PR TITLE
fix(codex): stop timed-out resume process trees on Windows

### DIFF
--- a/extensions/codex/src/node-cli-sessions.test.ts
+++ b/extensions/codex/src/node-cli-sessions.test.ts
@@ -5,18 +5,28 @@ import path from "node:path";
 import process from "node:process";
 import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const runCommandWithTimeoutMock = vi.hoisted(() => vi.fn());
+
+vi.mock("openclaw/plugin-sdk/process-runtime", () => ({
+  runCommandWithTimeout: runCommandWithTimeoutMock,
+}));
+
 import {
   createCodexCliSessionNodeHostCommands,
   listCodexCliSessionsOnNode,
+  resumeCodexCliSessionOnNode,
 } from "./node-cli-sessions.js";
 
 const CODEX_CLI_SESSIONS_LIST_COMMAND = "codex.cli.sessions.list";
+const CODEX_CLI_SESSION_RESUME_COMMAND = "codex.cli.session.resume";
 
 let tempDir: string;
 let previousCodexHome: string | undefined;
 
 describe("codex cli node sessions", () => {
   beforeEach(async () => {
+    runCommandWithTimeoutMock.mockReset();
     tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-cli-sessions-"));
     previousCodexHome = process.env.CODEX_HOME;
     process.env.CODEX_HOME = tempDir;
@@ -30,6 +40,134 @@ describe("codex cli node sessions", () => {
     }
     vi.restoreAllMocks();
     await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("routes CLI resume through the shared process-tree command runner", async () => {
+    const sessionId = "019e2007-1f7e-7eb1-a42b-8c01f4b9b5cd";
+    runCommandWithTimeoutMock.mockImplementationOnce(async (argv: string[]) => {
+      const outputFlagIndex = argv.indexOf("--output-last-message");
+      const outputPath = argv[outputFlagIndex + 1];
+      if (!outputPath) {
+        throw new Error("missing Codex output path");
+      }
+      await fs.writeFile(outputPath, " resumed reply \n");
+      return {
+        stdout: "",
+        stderr: "",
+        code: 0,
+        signal: null,
+        killed: false,
+        termination: "exit",
+      };
+    });
+
+    const command = createCodexCliSessionNodeHostCommands().find(
+      (entry) => entry.command === CODEX_CLI_SESSION_RESUME_COMMAND,
+    );
+    const raw = await command?.handle(
+      JSON.stringify({
+        sessionId,
+        prompt: "finish the task",
+        cwd: tempDir,
+        timeoutMs: 1_234,
+      }),
+    );
+
+    expect(JSON.parse(raw ?? "{}")).toEqual({ ok: true, sessionId, text: "resumed reply" });
+    expect(runCommandWithTimeoutMock).toHaveBeenCalledOnce();
+    const [argv, options] = runCommandWithTimeoutMock.mock.calls[0] ?? [];
+    expect(argv?.slice(-7)).toEqual([
+      "exec",
+      "resume",
+      "--skip-git-repo-check",
+      "--output-last-message",
+      expect.any(String),
+      sessionId,
+      "-",
+    ]);
+    expect(options).toMatchObject({
+      cwd: tempDir,
+      input: "finish the task",
+      killProcessTree: true,
+      timeoutMs: 1_234,
+    });
+    expect(options?.env).toBe(process.env);
+  });
+
+  it("preserves the owned timeout error from the shared command runner", async () => {
+    const sessionId = "019e2007-1f7e-7eb1-a42b-8c01f4b9b5ce";
+    runCommandWithTimeoutMock.mockResolvedValueOnce({
+      stdout: "",
+      stderr: "",
+      code: 124,
+      signal: null,
+      killed: true,
+      termination: "timeout",
+    });
+
+    const command = createCodexCliSessionNodeHostCommands().find(
+      (entry) => entry.command === CODEX_CLI_SESSION_RESUME_COMMAND,
+    );
+
+    await expect(
+      command?.handle(
+        JSON.stringify({
+          sessionId,
+          prompt: "finish the task",
+          cwd: tempDir,
+          timeoutMs: 1_234,
+        }),
+      ),
+    ).rejects.toThrow("codex exec resume timed out after 1234ms");
+  });
+
+  it("prefers Codex stderr for a nonzero shared-runner exit", async () => {
+    const sessionId = "019e2007-1f7e-7eb1-a42b-8c01f4b9b5cf";
+    runCommandWithTimeoutMock.mockResolvedValueOnce({
+      stdout: "fallback stdout",
+      stderr: "resume failed",
+      code: 7,
+      signal: null,
+      killed: false,
+      termination: "exit",
+    });
+
+    const command = createCodexCliSessionNodeHostCommands().find(
+      (entry) => entry.command === CODEX_CLI_SESSION_RESUME_COMMAND,
+    );
+
+    await expect(
+      command?.handle(
+        JSON.stringify({
+          sessionId,
+          prompt: "finish the task",
+          cwd: tempDir,
+          timeoutMs: 1_234,
+        }),
+      ),
+    ).rejects.toThrow("resume failed");
+  });
+
+  it("keeps enough outer invoke budget for shared Windows tree cleanup", async () => {
+    const invoke = vi.fn(async () => ({
+      payload: { ok: true, sessionId: "session-1", text: "done" },
+    }));
+    const runtime = { nodes: { invoke } } as unknown as PluginRuntime;
+
+    await resumeCodexCliSessionOnNode({
+      runtime,
+      nodeId: "node-1",
+      sessionId: "session-1",
+      prompt: "finish the task",
+      timeoutMs: 1_234,
+    });
+
+    expect(invoke).toHaveBeenCalledWith(
+      expect.objectContaining({
+        nodeId: "node-1",
+        timeoutMs: 11_234,
+      }),
+    );
   });
 
   it("lists recent sessions from Codex history and hydrates cwd from session files", async () => {

--- a/extensions/codex/src/node-cli-sessions.ts
+++ b/extensions/codex/src/node-cli-sessions.ts
@@ -1,5 +1,4 @@
 // Codex plugin module implements node cli sessions behavior.
-import { spawn } from "node:child_process";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -11,6 +10,7 @@ import type {
   OpenClawPluginNodeInvokePolicy,
 } from "openclaw/plugin-sdk/plugin-entry";
 import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
+import { runCommandWithTimeout } from "openclaw/plugin-sdk/process-runtime";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
@@ -27,6 +27,7 @@ export const CODEX_CLI_SESSION_RESUME_COMMAND = "codex.cli.session.resume";
 const DEFAULT_SESSION_LIMIT = 10;
 const MAX_SESSION_LIMIT = 50;
 const DEFAULT_RESUME_TIMEOUT_MS = 20 * 60_000;
+const RESUME_NODE_INVOKE_CLEANUP_GRACE_MS = 10_000;
 const SESSION_ID_PATTERN = /^[A-Za-z0-9._:-]{1,128}$/;
 const activeResumeSessions = new Set<string>();
 
@@ -164,7 +165,8 @@ export async function resumeCodexCliSessionOnNode(params: {
       cwd: params.cwd,
       timeoutMs: params.timeoutMs,
     },
-    timeoutMs: (params.timeoutMs ?? DEFAULT_RESUME_TIMEOUT_MS) + 5_000,
+    timeoutMs:
+      (params.timeoutMs ?? DEFAULT_RESUME_TIMEOUT_MS) + RESUME_NODE_INVOKE_CLEANUP_GRACE_MS,
     scopes: ["operator.write"],
   });
   const payload = unwrapNodeInvokePayload(raw);
@@ -273,48 +275,28 @@ async function runCodexExecResume(params: {
       params.sessionId,
       "-",
     ];
-    const invocation = resolveCodexCliResumeSpawnInvocation(args, {
+    const argv = resolveCodexCliResumeArgv(args, {
       platform: process.platform,
       env: process.env,
       execPath: process.execPath,
     });
-    const child = spawn(invocation.command, invocation.args, {
+    const result = await runCommandWithTimeout(argv, {
       cwd: params.cwd || process.cwd(),
-      stdio: ["pipe", "pipe", "pipe"],
       env: process.env,
-      shell: invocation.shell,
-      windowsHide: invocation.windowsHide,
+      input: params.prompt,
+      killProcessTree: true,
+      timeoutMs: params.timeoutMs,
     });
-    const stdout: Buffer[] = [];
-    const stderr: Buffer[] = [];
-    let timedOut = false;
-    let forceKillTimeout: NodeJS.Timeout | undefined;
-    const timeout = setTimeout(() => {
-      timedOut = true;
-      child.kill("SIGTERM");
-      forceKillTimeout = setTimeout(() => child.kill("SIGKILL"), 2_000);
-      forceKillTimeout.unref?.();
-    }, params.timeoutMs);
-    child.stdout.on("data", (chunk: Buffer) => stdout.push(chunk));
-    child.stderr.on("data", (chunk: Buffer) => stderr.push(chunk));
-    child.stdin.end(params.prompt);
-    const exitCode = await new Promise<number | null>((resolve, reject) => {
-      child.on("error", reject);
-      child.on("exit", (code) => resolve(code));
-    }).finally(() => {
-      clearTimeout(timeout);
-      if (forceKillTimeout) {
-        clearTimeout(forceKillTimeout);
-      }
-    });
-    if (timedOut) {
+    if (result.termination === "timeout" || result.termination === "no-output-timeout") {
       throw new Error(`codex exec resume timed out after ${String(params.timeoutMs)}ms`);
     }
-    if (exitCode !== 0) {
+    if (result.termination !== "exit" || result.code !== 0) {
       const message =
-        Buffer.concat(stderr).toString("utf8").trim() ||
-        Buffer.concat(stdout).toString("utf8").trim() ||
-        `codex exec resume exited with code ${String(exitCode)}`;
+        result.stderr.trim() ||
+        result.stdout.trim() ||
+        (result.signal
+          ? `codex exec resume terminated by ${result.signal}`
+          : `codex exec resume exited with code ${String(result.code)}`);
       throw new Error(message);
     }
     return await fs.readFile(outputPath, "utf8");
@@ -323,10 +305,10 @@ async function runCodexExecResume(params: {
   }
 }
 
-function resolveCodexCliResumeSpawnInvocation(
+function resolveCodexCliResumeArgv(
   args: string[],
   runtime: CodexCliResumeSpawnRuntime = DEFAULT_RESUME_SPAWN_RUNTIME,
-): { command: string; args: string[]; shell?: boolean; windowsHide?: boolean } {
+): string[] {
   const program = resolveWindowsSpawnProgram({
     command: "codex",
     platform: runtime.platform,
@@ -335,12 +317,7 @@ function resolveCodexCliResumeSpawnInvocation(
     packageName: "@openai/codex",
   });
   const resolved = materializeWindowsSpawnProgram(program, args);
-  return {
-    command: resolved.command,
-    args: resolved.argv,
-    shell: resolved.shell,
-    windowsHide: resolved.windowsHide,
-  };
+  return [resolved.command, ...resolved.argv];
 }
 
 async function readHistorySessions(


### PR DESCRIPTION
Closes #111900

## What Problem This Solves

Fixes an issue where a timed-out Codex CLI session resume on Windows could leave the native Codex process and tool descendants running after OpenClaw had returned a timeout.

## Why This Change Was Made

The Codex extension now sends its resolved shell-free CLI argv through the existing public process runtime with `killProcessTree: true`. Windows `taskkill /T` validation, graceful/forced escalation, settlement, and PID-reuse safety remain owned by core instead of being duplicated in the extension. The outer node invocation keeps a named 10-second cleanup allowance so the inner timeout can finish tree cleanup and return its owned error. No Plugin SDK surface was added.

## User Impact

Timed-out Codex resume work no longer continues in orphaned Windows descendants. Successful resumes, stdin prompts, working directories, and stderr-first failure messages keep their existing behavior.

## Evidence

Exact head: `946d4d0b1cd73d7aecc3e04e3fcb88e0e835f5fc`.

Rebase base: `cb50289e28369f61cab6572e3952879f8854b17c`. The patch remains two files, +157/-42. Its binary diff hash is still `d778c86fa5e322137dc6b773480f1f1377d8dd7e`; range-diff across the rebases showed the patch itself unchanged.

### Codex runtime contract

I inspected the required sibling Codex checkout directly rather than inferring the lifecycle from CLI behavior.

For `rust-v0.146.0` (commit `e363b08c9175ac1cbe5893615dd2cb9ddf95043b`):

- `codex-cli/bin/codex.js:195-225` spawns the native binary and forwards signals received by the JS launcher.
- `codex-rs/exec/src/lib.rs:800-831` starts the in-process app-server client and handles resume through `thread/resume`; resume does not add another external cleanup owner.
- `codex-rs/core/src/spawn.rs:82-125` uses Unix/Linux pre-exec parent-death/process-group behavior for shell tools.
- `codex-rs/utils/pty/src/process_group.rs:16,41-45,80-84,114-118,169-172,185-188` explicitly makes the corresponding non-Unix helpers no-ops.

Current main now pins `@openai/codex` `0.147.0`, so I also fetched and inspected `rust-v0.147.0` (commit `be6e8eac029b183056b7e4402879f15d2c85f61b`). The relevant contract is unchanged: the JS launcher remains at `codex-cli/bin/codex.js:195-225`, resume remains in-process at `codex-rs/exec/src/lib.rs:766-791`, and the Windows/non-Unix process-group helpers remain no-ops in `codex-rs/utils/pty/src/process_group.rs:114-118,245-249,257-261,281-285,297-301`. The 0.147 process-group additions are macOS-only fallbacks.

This leaves the OpenClaw launcher as the correct Windows tree owner, while core remains the correct owner of generic termination policy.

### Direct Windows `codex exec resume` proof

Using the installed `codex-cli 0.146.0-alpha.12`, I created an isolated real session and then exercised the new call shape directly through OpenClaw's public `runCommandWithTimeout`:

- actual command: `codex exec resume --skip-git-repo-check --output-last-message <path> <session-id> -`
- prompt supplied over stdin
- `killProcessTree: true`
- timeout: 30 seconds
- Codex visibly launched `node proof-root.mjs` in the foreground

The timeout settled as follows:

```json
{
  "termination": "timeout",
  "elapsedMs": 31147,
  "rootPid": 79280,
  "childPid": 87560,
  "grandchildPid": 85396,
  "aliveAfterSettle": {
    "79280": false,
    "87560": false,
    "85396": false
  }
}
```

This is a real `codex exec resume`, not a generic substitute process. All three recorded descendant PIDs were independently checked after the shared runner settled, and none remained alive.

### Tests and checks

The focused tests previously ran on the same `d778c86f...` patch hash and remain byte-for-byte applicable after rebase:

```text
node scripts/run-vitest.mjs extensions/codex/src/node-cli-sessions.test.ts
Test Files  1 passed (1)
Tests       13 passed (13)

node scripts/run-vitest.mjs src/process/exec.windows.test.ts
Test Files  1 passed (1)
Tests       22 passed (22)
```

The Codex tests cover shared-runner delegation, resolved argv, cwd, stdin, `killProcessTree`, timeout mapping, stderr-first nonzero exits, and the 10-second outer cleanup budget. The core tests cover graceful and forced Windows tree termination and settlement.

Exact-head checks:

```text
git diff --check origin/main...HEAD
(clean)

TruffleHog 3.95.9 on binary diff hash d778c86f...
verified_secrets: 0
unverified_secrets: 0

autoreview --mode branch --base origin/main
no accepted/actionable findings
patch is correct (0.98)
```

The current `check-test-types` failure is outside this PR: `src/sessions/user-turn-transcript.test.ts:548` references an undefined `createTempDir`. This PR does not touch that file, and the same undefined reference is present in base `cb50289e28369f61cab6572e3952879f8854b17c`.
