### PR TITLE
fix(nostr): normal shutdown no longer reports relay errors

### DIFF
--- a/extensions/nostr/src/nostr-relay-subscription.test.ts
+++ b/extensions/nostr/src/nostr-relay-subscription.test.ts
@@ -6,25 +6,36 @@ type RelayHandlers = Parameters<SimplePool["subscribeMany"]>[2];
 
 function createHarness() {
   const handlers: RelayHandlers[] = [];
+  const abortController = new AbortController();
   const subscribeMany = vi.fn(
     (_relays: string[], _filter: unknown, nextHandlers: RelayHandlers) => {
       handlers.push(nextHandlers);
-      return { close: vi.fn() };
+      nextHandlers.abort?.addEventListener(
+        "abort",
+        () => nextHandlers.onclose?.([String(nextHandlers.abort?.reason ?? "aborted")]),
+        { once: true },
+      );
+      return {
+        close: vi.fn(async (reason?: string) => {
+          nextHandlers.onclose?.([reason ?? "closed by caller"]);
+        }),
+      };
     },
   );
   const onBackfillComplete = vi.fn<(relays: string[]) => void>();
+  const onClose = vi.fn<(relay: string, reasons: string[]) => void>();
   const group = createNostrRelaySubscriptionGroup({
     pool: { subscribeMany } as unknown as SimplePool,
     relays: ["wss://one.example", "wss://two.example"],
     filter: { kinds: [4] },
-    abort: new AbortController().signal,
+    abort: abortController.signal,
     onEvent: (_event: Event) => {},
     onBackfillComplete,
-    onClose: () => {},
+    onClose,
     eoseConfirmDeadlineMs: 10,
   });
   group.start();
-  return { group, handlers, onBackfillComplete, subscribeMany };
+  return { abortController, group, handlers, onBackfillComplete, onClose, subscribeMany };
 }
 
 describe("Nostr relay subscriptions", () => {
@@ -64,6 +75,24 @@ describe("Nostr relay subscriptions", () => {
     await Promise.resolve();
 
     expect(onBackfillComplete).not.toHaveBeenCalled();
+    await group.close("test complete");
+  });
+
+  it("does not report locally requested closes as relay failures", async () => {
+    const { abortController, group, onClose } = createHarness();
+
+    abortController.abort("closed by caller");
+    await group.close("closed by caller");
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("still reports closes initiated by the relay", async () => {
+    const { group, handlers, onClose } = createHarness();
+
+    handlers[0]?.onclose?.(["relay unavailable"]);
+
+    expect(onClose).toHaveBeenCalledWith("wss://one.example", ["relay unavailable"]);
     await group.close("test complete");
   });
 });

--- a/extensions/nostr/src/nostr-relay-subscription.ts
+++ b/extensions/nostr/src/nostr-relay-subscription.ts
@@ -18,6 +18,7 @@ export function createNostrRelaySubscriptionGroup(options: {
   const relays = [...new Set(options.relays)];
   const subscriptions: Array<ReturnType<SimplePool["subscribeMany"]>> = [];
   const deadlineTimers = new Set<ReturnType<typeof setTimeout>>();
+  let locallyClosing = false;
   const backfillStatus = new Map<string, BackfillStatus>(
     relays.map((relay): [string, BackfillStatus] => [relay, "pending"]),
   );
@@ -74,7 +75,9 @@ export function createNostrRelaySubscriptionGroup(options: {
               clearTimeout(deadlineTimer);
               deadlineTimers.delete(deadlineTimer);
               settleBackfill(relay, "incomplete");
-              options.onClose(relay, reasons);
+              if (!locallyClosing && !options.abort.aborted) {
+                options.onClose(relay, reasons);
+              }
             },
             // Own earlier deadline marks synthetic library EOSE as incomplete.
             maxWait: confirmDeadlineMs + LIBRARY_EOSE_TIMEOUT_MARGIN_MS,
@@ -84,6 +87,8 @@ export function createNostrRelaySubscriptionGroup(options: {
       }
     },
     close: async (reason: string): Promise<void> => {
+      // nostr-tools reports caller-requested closes through the same callback as relay failures.
+      locallyClosing = true;
       clearDeadlines();
       await Promise.all(subscriptions.map(async (subscription) => subscription.close(reason)));
     },


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators stopping a Nostr-enabled gateway normally would see
`Nostr error (subscription): Subscription closed: closed by caller`, making a clean shutdown look
like a relay or channel failure.

## Why This Change Was Made

The per-relay subscription group now distinguishes locally requested shutdown from relay-initiated
closure before forwarding close callbacks to the gateway error path. Real relay connection and
closure failures remain reportable; configuration, protocol, message delivery, reconnect behavior,
and public APIs are unchanged.

## User Impact

Normal Nostr gateway shutdowns no longer emit a false subscription error. Operators still receive
errors for genuine relay failures.

## Evidence

The regression test, public-relay before/after run, and unreachable-relay control below cover both
the corrected shutdown path and the failure-reporting behavior that must remain unchanged.

## Real behavior proof

- **Behavior addressed:** A normal SIGINT shutdown of a Nostr-enabled OpenClaw gateway was reported as a subscription error even though the provider stopped cleanly.
- **Real environment tested:** Linux x86_64, Node 24, isolated OpenClaw state/config, a randomly generated temporary Nostr key, and public third-party relay `wss://relay.nostr.net`. All runs used OpenClaw directly; no CoClaw/Coclaw path was used.
- **Exact steps or command run after this patch:** Started the real gateway with `openclaw gateway run --verbose`, waited for the Nostr provider to connect to `wss://relay.nostr.net` and receive EOSE, then sent SIGINT. A control run added unreachable `wss://relay.invalid` beside the healthy public relay.
- **Evidence after fix:** Selected live terminal output from the public-relay run:

    2026-07-20T23:43:20.060+08:00 [nostr] [default] Nostr provider started with 1 configured relay(s)
    2026-07-20T23:43:21.288+08:00 [nostr] [default] Connected to relay: wss://relay.nostr.net/
    2026-07-20T23:43:21.606+08:00 [nostr] [default] EOSE received from relays: wss://relay.nostr.net
    2026-07-20T23:43:58.182+08:00 [gateway] signal SIGINT received
    2026-07-20T23:43:58.187+08:00 [gateway] received SIGINT; shutting down
    2026-07-20T23:44:06.358+08:00 [nostr] [default] Nostr provider stopped

  Before the patch, the same production path ended with:

    2026-07-20T23:06:20.851+08:00 [nostr] [default] Nostr error (subscription): Subscription closed: closed by caller
    2026-07-20T23:06:20.855+08:00 [nostr] [default] Nostr provider stopped

  The control run preserved genuine failure reporting:

    2026-07-20T23:46:18.463+08:00 [nostr] [default] Nostr error (subscription): Subscription closed: connection failed
    2026-07-20T23:46:19.854+08:00 [nostr] [default] Connected to relay: wss://relay.nostr.net/
    2026-07-20T23:47:05.620+08:00 [nostr] [default] Nostr provider stopped

- **Observed result after fix:** The healthy public relay connected and completed backfill, SIGINT stopped the provider without a caller-close error, and an actually unreachable relay still produced its existing connection-failure error.
- **What was not tested:** Other Nostr relays and non-Linux operating systems were not exercised. No inbound or outbound DM was sent because this change is limited to subscription shutdown reporting.

## Tests and validation

- Regression test was added first and failed on the abort-first production shutdown sequence.
- `pnpm exec vitest run extensions/nostr/src/nostr-relay-subscription.test.ts` — 5 tests passed.
- Nostr extension suite — 19 files, 241 tests passed.
- `pnpm tsgo:extensions` — passed.
- `pnpm tsgo:extensions:test` — passed.
- Full build — passed.
- Touched-file formatting and lint, plus `git diff --check` — passed.

## Risk checklist

- User-visible behavior: Yes — removes a false error during normal Nostr shutdown.
- Config/env/migration behavior: No.
- Security/auth/secrets/network/tool execution: No behavior change; proof used only a temporary test key.
- Plugins/providers/channels/SDK: Nostr channel only.
- Highest-risk area: Suppressing a real relay close alongside local shutdown.
- Mitigation: The guard is limited to local close/abort state, with a regression test and live control proving genuine connection failure reporting remains intact.

Closes: N/A (no existing issue)

Allow edits from maintainers: Enabled.
