### PR TITLE
fix(dashboard): review follow-ups — provider lifecycle, scope-gated controls, pin robustness

### DIFF
--- a/src/agents/sandbox-host.ts
+++ b/src/agents/sandbox-host.ts
@@ -3,6 +3,7 @@ export type SandboxHostCsp = {
   resourceDomains?: string[];
   frameDomains?: string[];
   baseUriDomains?: string[];
+  blockDescendantFrames?: boolean;
 };
 
 export const SANDBOX_HOST_PATH = "/mcp-app-sandbox";
@@ -11,6 +12,66 @@ const SANDBOX_HOST_CSP_QUERY = "csp";
 const SANDBOX_HOST_CSP_MAX_JSON_BYTES = 5 * 1024;
 const SANDBOX_HOST_CSP_MAX_HEADER_BYTES = 6 * 1024;
 const SANDBOX_HOST_CSP_MAX_ENCODED_BYTES = Math.ceil(SANDBOX_HOST_CSP_MAX_JSON_BYTES / 3) * 4 + 4;
+
+// Best-effort mitigation of the documented WebRTC residual, not a security
+// boundary. Board widgets remove same-realm constructors and the common APIs
+// that create descendant browsing realms with pristine constructors.
+function buildSandboxDocumentGuardHtml(blockDescendantFrames: boolean): string {
+  if (!blockDescendantFrames) {
+    return "";
+  }
+  return `<script>(()=>{
+  const blocked=["iframe","frame","object","embed","portal","fencedframe","webview","browser"];
+  const apply=Reflect.apply;
+  const defineProperty=Object.defineProperty;
+  const getOwnPropertyDescriptor=Object.getOwnPropertyDescriptor;
+  const toString=String;
+  const toLowerCase=String.prototype.toLowerCase;
+  const lastIndexOf=String.prototype.lastIndexOf;
+  const slice=String.prototype.slice;
+  const includes=Array.prototype.includes;
+  const regexpTest=RegExp.prototype.test;
+  const descendantMarkup=/<\\s*(?:iframe|frame|object|embed|portal|fencedframe|webview|browser)\\b/iu;
+  const reject=()=>{throw new Error("sandbox descendant browsing contexts are disabled");};
+  const assertName=name=>{const value=apply(toLowerCase,toString(name),[]);const separator=apply(lastIndexOf,value,[":"]);const localName=separator<0?value:apply(slice,value,[separator+1]);if(apply(includes,blocked,[localName]))reject();};
+  const assertMarkup=value=>{if(apply(regexpTest,descendantMarkup,[toString(value)]))reject();};
+  const lock=(target,name,value)=>{try{defineProperty(target,name,{value,writable:false,configurable:false});}catch{}};
+  for(const name of ["RTCPeerConnection","webkitRTCPeerConnection","RTCIceGatherer","RTCIceTransport","RTCDtlsTransport","RTCSctpTransport","RTCDataChannel"])lock(globalThis,name,undefined);
+  const createElement=Document.prototype.createElement;
+  lock(Document.prototype,"createElement",function(name,...args){assertName(name);return Reflect.apply(createElement,this,[name,...args]);});
+  const createElementNS=Document.prototype.createElementNS;
+  lock(Document.prototype,"createElementNS",function(namespace,name,...args){assertName(name);return Reflect.apply(createElementNS,this,[namespace,name,...args]);});
+  const wrapSetter=(target,name)=>{const descriptor=getOwnPropertyDescriptor(target,name);if(!descriptor?.set)return;try{defineProperty(target,name,{get:descriptor.get,set(value){assertMarkup(value);return apply(descriptor.set,this,[value]);},enumerable:descriptor.enumerable,configurable:false});}catch{}};
+  wrapSetter(Element.prototype,"innerHTML");wrapSetter(Element.prototype,"outerHTML");
+  if(globalThis.ShadowRoot)wrapSetter(ShadowRoot.prototype,"innerHTML");
+  const wrapMethod=(target,name,indexes)=>{const original=target?.[name];if(typeof original!=="function")return;lock(target,name,function(...args){if(indexes){for(let index=0;index<indexes.length;index+=1)assertMarkup(args[indexes[index]]);}else{for(let index=0;index<args.length;index+=1)assertMarkup(args[index]);}return apply(original,this,args);});};
+  wrapMethod(Element.prototype,"insertAdjacentHTML",[1]);wrapMethod(Document.prototype,"write");wrapMethod(Document.prototype,"writeln");wrapMethod(Range.prototype,"createContextualFragment",[0]);wrapMethod(DOMParser.prototype,"parseFromString",[0]);
+  wrapMethod(Element.prototype,"setHTMLUnsafe",[0]);wrapMethod(Element.prototype,"setHTML",[0]);
+  if(globalThis.ShadowRoot){wrapMethod(ShadowRoot.prototype,"setHTMLUnsafe",[0]);wrapMethod(ShadowRoot.prototype,"setHTML",[0]);}
+  lock(globalThis,"open",undefined);
+})();</script>`;
+}
+
+const RESOLVE_LEADING_DOCTYPE_END_SOURCE = `(html) => {
+  let index = html.charCodeAt(0) === 0xfeff ? 1 : 0;
+  const whitespace = new Set([9, 10, 12, 13, 32]);
+  while (true) {
+    while (index < html.length && whitespace.has(html.charCodeAt(index))) index += 1;
+    if (html.slice(index, index + 4) !== "<!--") break;
+    const commentEnd = html.indexOf("-->", index + 4);
+    if (commentEnd < 0) return 0;
+    index = commentEnd + 3;
+  }
+  if (html.slice(index, index + 9).toLowerCase() !== "<!doctype") return 0;
+  let quote = "";
+  for (let cursor = index + 9; cursor < html.length; cursor += 1) {
+    const char = html[cursor];
+    if (quote) { if (char === quote) quote = ""; continue; }
+    if (char === '"' || char === "'") { quote = char; continue; }
+    if (char === ">") return cursor + 1;
+  }
+  return 0;
+}`;
 
 function asRecord(value: unknown): Record<string, unknown> | undefined {
   return value && typeof value === "object" && !Array.isArray(value)
@@ -81,6 +142,7 @@ export function normalizeSandboxHostCsp(value: unknown): SandboxHostCsp | undefi
     resourceDomains: normalizeDomains(record.resourceDomains),
     frameDomains: normalizeDomains(record.frameDomains),
     baseUriDomains: normalizeDomains(record.baseUriDomains),
+    blockDescendantFrames: record.blockDescendantFrames === true ? true : undefined,
   };
   if (!Object.values(csp).some(Boolean)) {
     return undefined;
@@ -147,7 +209,11 @@ export function decodeSandboxHostCsp(value: string | null): SandboxHostCsp | und
 }
 
 /** Trusted outer document. Untrusted content is written only into its inner iframe. */
-export function buildSandboxHostProxyHtml(): string {
+export function buildSandboxHostProxyHtml(csp?: SandboxHostCsp): string {
+  const blockDescendantFrames = csp?.blockDescendantFrames === true;
+  const serializedDocumentGuard = JSON.stringify(
+    buildSandboxDocumentGuardHtml(blockDescendantFrames),
+  ).replaceAll("<", "\\u003c");
   return `<!doctype html>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width,initial-scale=1" />
@@ -174,17 +240,37 @@ export function buildSandboxHostProxyHtml(): string {
   let inner = createInner();
   document.body.appendChild(inner);
   let widgetBridgePortOffered = false;
+  const blockDescendantFrames = ${blockDescendantFrames};
+  const descendantSelector = "iframe,frame,object,embed,portal,fencedframe,webview,browser";
+  const hasBlockedDescendant = root => {
+    if (root.querySelector(descendantSelector)) return true;
+    for (const template of root.querySelectorAll("template")) {
+      if (hasBlockedDescendant(template.content)) return true;
+    }
+    return false;
+  };
+  const documentGuard = ${serializedDocumentGuard};
+  const resolveLeadingDoctypeEnd = ${RESOLVE_LEADING_DOCTYPE_END_SOURCE};
+  const guardDocument = html => {
+    if (!blockDescendantFrames) return html;
+    if (hasBlockedDescendant(new DOMParser().parseFromString(html, "text/html"))) {
+      throw new Error("sandbox descendant browsing contexts are disabled");
+    }
+    const doctypeEnd = resolveLeadingDoctypeEnd(html);
+    return html.slice(0, doctypeEnd) + documentGuard + html.slice(doctypeEnd);
+  };
   window.addEventListener("message", (event) => {
     if (event.source === window.parent) {
       if (event.origin !== hostOrigin) return;
       if (event.data?.method === "ui/notifications/sandbox-resource-ready") {
         const params = event.data.params ?? {};
         if (typeof params.html === "string") {
+          const guardedHtml = guardDocument(params.html);
           // Replace the browsing context so a superseded document cannot race
           // the new wrapper's first private bridge-port offer.
           const nextInner = createInner();
           widgetBridgePortOffered = false;
-          nextInner.srcdoc = params.html;
+          nextInner.srcdoc = guardedHtml;
           inner.replaceWith(nextInner);
           inner = nextInner;
         }

--- a/src/canvas/widget-tool.test.ts
+++ b/src/canvas/widget-tool.test.ts
@@ -13,6 +13,7 @@ import { createShowWidgetTool } from "./widget-tool.js";
 import { buildWidgetDocument } from "./wrap.js";
 
 const WIDGET_CODE_MAX_CHARS = 262_144;
+const PINNED_WIDGET_MAX_UTF8_BYTES = 256 * 1024;
 const WIDGET_MAX_PER_SCOPE = 32;
 const tempDirs: string[] = [];
 
@@ -133,6 +134,54 @@ describe("show_widget", () => {
         pin: true,
       }),
     ).rejects.toThrow("pin requires an agent session");
+    await expect(access(resolveCanvasDocumentsDir(stateDir))).rejects.toThrow();
+  });
+
+  it("rejects multibyte pin input that exceeds the wrapped UTF-8 budget", async () => {
+    const stateDir = await createStateDir();
+    const callGateway = vi.fn();
+    const title = "Multibyte";
+    const wrapperBytes = Buffer.byteLength(buildWidgetDocument(title, ""), "utf8");
+    const widgetCode = "é".repeat(
+      Math.floor((PINNED_WIDGET_MAX_UTF8_BYTES - wrapperBytes) / 2) + 1,
+    );
+    expect(widgetCode.length).toBeLessThan(WIDGET_CODE_MAX_CHARS);
+    expect(Buffer.byteLength(buildWidgetDocument(title, widgetCode), "utf8")).toBeGreaterThan(
+      PINNED_WIDGET_MAX_UTF8_BYTES,
+    );
+    const tool = createShowWidgetTool({
+      stateDir,
+      sessionId: "wrapped-budget",
+      agentSessionKey: "agent:main:wrapped-budget",
+      callGateway,
+    });
+
+    await expect(
+      tool.execute("pin", { title, widget_code: widgetCode, pin: true }),
+    ).rejects.toThrow(
+      `pin exceeds effective dashboard budget (${PINNED_WIDGET_MAX_UTF8_BYTES} UTF-8 bytes after wrapping)`,
+    );
+    expect(callGateway).not.toHaveBeenCalled();
+    await expect(access(resolveCanvasDocumentsDir(stateDir))).rejects.toThrow();
+  });
+
+  it("does not create an inline Canvas document when dashboard pinning fails", async () => {
+    const stateDir = await createStateDir();
+    const callGateway = vi.fn(async () => {
+      throw new Error("board tab not found: missing");
+    });
+
+    await expect(
+      executeWidget({
+        stateDir,
+        agentSessionKey: "agent:main:failed-pin",
+        widgetCode: "<p>never materialized</p>",
+        pin: true,
+        tab: "missing",
+        callGateway,
+      }),
+    ).rejects.toThrow("board tab not found: missing");
+    expect(callGateway).toHaveBeenCalledOnce();
     await expect(access(resolveCanvasDocumentsDir(stateDir))).rejects.toThrow();
   });
 

--- a/src/canvas/widget-tool.ts
+++ b/src/canvas/widget-tool.ts
@@ -14,6 +14,7 @@ import { buildWidgetDocument } from "./wrap.js";
 
 const SHOW_WIDGET_REQUIRED_CLIENT_CAPS = ["inline-widgets"];
 const WIDGET_CODE_MAX_CHARS = 262_144;
+const PINNED_WIDGET_MAX_UTF8_BYTES = 256 * 1024;
 const WIDGET_MAX_PER_SCOPE = 32;
 
 const ShowWidgetToolSchema = Type.Object({
@@ -101,6 +102,14 @@ function resolveRetentionScope(options: ShowWidgetToolOptions): string {
   return createHash("sha256").update(scope).digest("hex");
 }
 
+function assertPinnedWidgetDocumentSize(html: string): void {
+  if (Buffer.byteLength(html, "utf8") > PINNED_WIDGET_MAX_UTF8_BYTES) {
+    throw new WidgetHtmlInputError(
+      `pin exceeds effective dashboard budget (${PINNED_WIDGET_MAX_UTF8_BYTES} UTF-8 bytes after wrapping)`,
+    );
+  }
+}
+
 /** Creates a self-contained widget hosted by OpenClaw core. */
 export function createShowWidgetTool(options: ShowWidgetToolOptions = {}): AnyAgentTool {
   const gatewayCall = options.callGateway ?? callInProcessGatewayTool;
@@ -138,21 +147,6 @@ export function createShowWidgetTool(options: ShowWidgetToolOptions = {}): AnyAg
       }
       const widgetCode = rawWidgetCode.trim();
       const wrappedDocument = buildWidgetDocument(title, widgetCode);
-      const document = await createCanvasDocument(
-        {
-          kind: "html_bundle",
-          title,
-          entrypoint: { type: "html", value: wrappedDocument },
-          surface: "assistant_message",
-          retentionScope: resolveRetentionScope(options),
-          // Direct navigation must not run widget script as the Control UI origin.
-          cspSandbox: "scripts",
-        },
-        {
-          stateDir: options.stateDir,
-          maxDocumentsPerScope: WIDGET_MAX_PER_SCOPE,
-        },
-      );
       let pinnedText = "";
       let pinnedWidgetName: string | undefined;
       if (pinSessionKey) {
@@ -163,6 +157,11 @@ export function createShowWidgetTool(options: ShowWidgetToolOptions = {}): AnyAg
         const size = readStringParam(params, "size");
         const after = readStringParam(params, "after");
         const pinnedTitle = boardWidgetTitle(title);
+        assertPinnedWidgetDocumentSize(
+          buildWidgetDocument(pinnedTitle ?? name, widgetCode, {
+            connectOrigins: capabilities?.netOrigins,
+          }),
+        );
         const snapshot = await gatewayCall<BoardSnapshot>("board.widget.put", {
           sessionKey,
           name,
@@ -186,6 +185,23 @@ export function createShowWidgetTool(options: ShowWidgetToolOptions = {}): AnyAg
           size ? ` (${size})` : ""
         }`;
       }
+      // Pin first: placement validation can fail, and a rejected board write
+      // must not materialize or prune the bounded inline-document store.
+      const document = await createCanvasDocument(
+        {
+          kind: "html_bundle",
+          title,
+          entrypoint: { type: "html", value: wrappedDocument },
+          surface: "assistant_message",
+          retentionScope: resolveRetentionScope(options),
+          // Direct navigation must not run widget script as the Control UI origin.
+          cspSandbox: "scripts",
+        },
+        {
+          stateDir: options.stateDir,
+          maxDocumentsPerScope: WIDGET_MAX_PER_SCOPE,
+        },
+      );
       return jsonResult({
         kind: "canvas",
         presentation: { target: "assistant_message", title, sandbox: "scripts" },

--- a/src/gateway/board-sandbox.test.ts
+++ b/src/gateway/board-sandbox.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildSandboxHostContentSecurityPolicy,
+  buildSandboxHostProxyHtml,
   decodeSandboxHostCsp,
 } from "../agents/sandbox-host.js";
 import type { BoardWidgetDocument } from "../boards/board-store.js";
@@ -26,8 +27,9 @@ function document(
 describe("board widget sandbox CSP", () => {
   it("emits no network authority while a declaration is pending", () => {
     const path = buildBoardWidgetSandboxPath(document("pending"));
+    const encoded = new URL(path, "https://sandbox.example").searchParams.get("csp");
 
-    expect(path).toBe("/mcp-app-sandbox");
+    expect(decodeSandboxHostCsp(encoded)).toEqual({ blockDescendantFrames: true });
     expect(buildSandboxHostContentSecurityPolicy()).toContain("connect-src 'none'");
     expect(buildSandboxHostContentSecurityPolicy()).toContain("webrtc 'block'");
     expect(buildBoardWidgetContentSecurityPolicy(document("pending"))).toContain(
@@ -53,6 +55,7 @@ describe("board widget sandbox CSP", () => {
         "https://status.example:8443",
         "https://[2001:db8::1]:9443",
       ],
+      blockDescendantFrames: true,
     });
     expect(buildSandboxHostContentSecurityPolicy(csp)).toContain(
       "connect-src https://api.open-meteo.com https://status.example:8443 https://[2001:db8::1]:9443",
@@ -62,5 +65,27 @@ describe("board widget sandbox CSP", () => {
     ).toContain(
       "connect-src https://api.open-meteo.com https://status.example:8443 https://[2001:db8::1]:9443",
     );
+  });
+
+  it("adds the best-effort descendant-frame guard only for board documents", () => {
+    const proxy = buildSandboxHostProxyHtml({ blockDescendantFrames: true });
+    const genericProxy = buildSandboxHostProxyHtml();
+
+    expect(proxy).toContain("const blockDescendantFrames = true");
+    expect(proxy).toContain("sandbox descendant browsing contexts are disabled");
+    expect(proxy).toContain('lock(Document.prototype,\\"createElement\\"');
+    expect(proxy).toContain('wrapSetter(Element.prototype,\\"innerHTML\\"');
+    expect(proxy).toContain('wrapMethod(Element.prototype,\\"setHTMLUnsafe\\"');
+    expect(proxy).toContain('lock(globalThis,\\"open\\",undefined)');
+    const guardedHtmlIndex = proxy.indexOf("const guardedHtml = guardDocument(params.html)");
+    expect(guardedHtmlIndex).toBeGreaterThan(-1);
+    expect(proxy.indexOf("widgetBridgePortOffered = false", guardedHtmlIndex)).toBeGreaterThan(
+      guardedHtmlIndex,
+    );
+    expect(proxy).toContain("const apply=Reflect.apply");
+    expect(proxy).toContain('if (html.slice(index, index + 4) !== "<!--") break');
+    expect(proxy).toContain('const commentEnd = html.indexOf("-->", index + 4)');
+    expect(genericProxy).toContain("const blockDescendantFrames = false");
+    expect(genericProxy).not.toContain('lock(Document.prototype,\\"createElement\\"');
   });
 });

--- a/src/gateway/board-sandbox.ts
+++ b/src/gateway/board-sandbox.ts
@@ -11,7 +11,12 @@ function grantedConnectOrigins(document: BoardWidgetDocument): string[] | undefi
 
 export function buildBoardWidgetSandboxPath(document: BoardWidgetDocument): string {
   const connectDomains = grantedConnectOrigins(document);
-  return buildSandboxHostPath(connectDomains ? { connectDomains } : undefined);
+  return buildSandboxHostPath({
+    // Best-effort hardening for the documented WebRTC residual; the DOM guard
+    // reduces fresh descendant realms but is not an authorization boundary.
+    blockDescendantFrames: true,
+    ...(connectDomains ? { connectDomains } : {}),
+  });
 }
 
 /** Defense in depth for direct/legacy widget document loads outside the proxy host. */

--- a/src/gateway/mcp-app-sandbox-http.test.ts
+++ b/src/gateway/mcp-app-sandbox-http.test.ts
@@ -45,7 +45,8 @@ describe("MCP App sandbox HTTP origin", () => {
     );
     expect(result.end).toHaveBeenCalledWith(expect.stringContaining("widgetBridgePortOffered"));
     const proxyHtml = String(result.end.mock.calls.at(-1)?.[0]);
-    expect(proxyHtml).toContain("nextInner.srcdoc = params.html");
+    expect(proxyHtml).toContain("const guardedHtml = guardDocument(params.html)");
+    expect(proxyHtml).toContain("nextInner.srcdoc = guardedHtml");
   });
 
   it("supports HEAD and rejects other paths, methods, and malformed policy", () => {

--- a/src/gateway/mcp-app-sandbox-http.ts
+++ b/src/gateway/mcp-app-sandbox-http.ts
@@ -49,7 +49,7 @@ function handleMcpAppSandboxHttpRequest(req: IncomingMessage, res: ServerRespons
   res.setHeader("Origin-Agent-Cluster", "?1");
   res.setHeader("Referrer-Policy", "no-referrer");
   res.setHeader("X-Content-Type-Options", "nosniff");
-  res.end(req.method === "HEAD" ? undefined : buildSandboxHostProxyHtml());
+  res.end(req.method === "HEAD" ? undefined : buildSandboxHostProxyHtml(csp));
 }
 
 /** Dedicated listener: this origin must never serve Control UI or authenticated Gateway data. */

--- a/src/gateway/server-methods/board.test.ts
+++ b/src/gateway/server-methods/board.test.ts
@@ -149,7 +149,7 @@ describe("board gateway methods", () => {
       viewTicket: expect.stringMatching(/^v1\./u),
       viewTicketTtlMs: 120_000,
       viewGeneration: expect.stringMatching(/^[a-f0-9]{32}$/u),
-      sandboxUrl: "/mcp-app-sandbox",
+      sandboxUrl: expect.stringMatching(/^\/mcp-app-sandbox\?csp=/u),
       sandboxPort: 18790,
     });
     expect(first.widgets.find((widget) => widget.name === "status")).toMatchObject({

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -100,11 +100,18 @@ class AppSidebar extends AppSidebarSessionListElement {
       undefined,
       () => {
         const snapshot = this.context?.gateway.snapshot;
+        const client = snapshot?.client;
+        const availabilityClient =
+          client &&
+          typeof client.request === "function" &&
+          typeof client.addEventListener === "function"
+            ? client
+            : null;
         return {
-          client: snapshot?.client ?? null,
+          client: availabilityClient,
           connected: snapshot?.connected ?? false,
           available: snapshot ? isGatewayMethodAdvertised(snapshot, "board.get") !== false : false,
-          key: `${this.context?.gateway.connection.gatewayUrl ?? ""}\u0000${
+          key: `${this.context?.gateway.connection?.gatewayUrl ?? ""}\u0000${
             snapshot?.hello?.server?.version ?? ""
           }`,
         };

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -13,6 +13,7 @@ import { readPresenceEntries, resolveCurrentSelfUser } from "../app/user-profile
 import { t } from "../i18n/index.ts";
 import { normalizeAgentLabel, resolveAgentTextAvatar } from "../lib/agents/display.ts";
 import { resolveAgentAvatarUrl } from "../lib/avatar.ts";
+import { BoardAvailabilityController } from "../lib/board/availability-controller.ts";
 import "./menu-surface.ts";
 import "./session-menu.ts";
 import "./sidebar-agent-card.ts";
@@ -21,8 +22,8 @@ import "./sidebar-build-chip.ts";
 import "./sidebar-update-card.ts";
 import "./theme-mode-toggle.ts";
 import "./tooltip.ts";
-import { BoardAvailabilityController } from "../lib/board/availability-controller.ts";
 import { sessionHasBoard } from "../lib/board/provider.ts";
+import { isGatewayMethodAdvertised } from "../lib/gateway-methods.ts";
 import { searchForSession } from "../lib/sessions/index.ts";
 import { areUiSessionKeysEquivalent, normalizeAgentId } from "../lib/sessions/session-key.ts";
 import { shouldHandleNavigationClick } from "./app-sidebar-nav-menus.ts";
@@ -85,15 +86,30 @@ class AppSidebar extends AppSidebarSessionListElement {
 
   constructor() {
     super();
-    void new BoardAvailabilityController(this, () => {
-      const mainKey = this.selectedAgentMainSessionKey(this.activeChipAgent().activeId);
-      return [
-        mainKey,
-        ...this.visibleSessionRowsInOrder()
-          .filter((session) => !session.isChild)
-          .map((session) => session.key),
-      ];
-    });
+    void new BoardAvailabilityController(
+      this,
+      () => {
+        const mainKey = this.selectedAgentMainSessionKey(this.activeChipAgent().activeId);
+        return [
+          mainKey,
+          ...this.visibleSessionRowsInOrder()
+            .filter((session) => !session.isChild)
+            .map((session) => session.key),
+        ];
+      },
+      undefined,
+      () => {
+        const snapshot = this.context?.gateway.snapshot;
+        return {
+          client: snapshot?.client ?? null,
+          connected: snapshot?.connected ?? false,
+          available: snapshot ? isGatewayMethodAdvertised(snapshot, "board.get") !== false : false,
+          key: `${this.context?.gateway.connection.gatewayUrl ?? ""}\u0000${
+            snapshot?.hello?.server?.version ?? ""
+          }`,
+        };
+      },
+    );
     // The footer pet announces logo stand-in phases through this bubbling event.
     this.addEventListener(LOBSTER_LOGO_VISIT_EVENT, this.handleLogoVisit as EventListener);
   }

--- a/ui/src/components/board/board-view.test-support.ts
+++ b/ui/src/components/board/board-view.test-support.ts
@@ -110,6 +110,8 @@ export async function mount(
     widgetFrameUrl?: (name: string, revision: number) => string;
     sessions?: readonly GatewaySessionRow[];
     context?: ApplicationContext<RouteId>;
+    canMutate?: boolean;
+    canGrant?: boolean;
   } = {},
 ): Promise<OpenClawBoardView> {
   const view = document.createElement("openclaw-board-view");
@@ -118,6 +120,8 @@ export async function mount(
   view.widgetFrameUrl = options.widgetFrameUrl ?? (() => "about:blank");
   view.callbacks = options.callbacks ?? callbacks();
   view.sessions = options.sessions ?? [];
+  view.canMutate = options.canMutate ?? true;
+  view.canGrant = options.canGrant ?? true;
   if (options.context) {
     const provider = createApplicationContextProvider(options.context);
     provider.append(view);

--- a/ui/src/components/board/board-view.test.ts
+++ b/ui/src/components/board/board-view.test.ts
@@ -573,6 +573,27 @@ describe("openclaw-board-view", () => {
     await vi.waitFor(() => expect(grant).toHaveBeenCalledWith("alpha", "rejected"));
   });
 
+  it.each([
+    { profile: "read-only", canMutate: false, canGrant: false, controls: false },
+    { profile: "writer with approvals", canMutate: true, canGrant: true, controls: true },
+  ])("gates dashboard controls for the $profile scope profile", async (profile) => {
+    const view = await mount({
+      snapshot: snapshot({ widgets: [boardWidget({ grantState: "pending" })] }),
+      canMutate: profile.canMutate,
+      canGrant: profile.canGrant,
+    });
+
+    expect(view.querySelector(".board-widget__drag-handle") !== null).toBe(profile.controls);
+    expect(view.querySelector(".board-widget__resize-handle") !== null).toBe(profile.controls);
+    expect(view.querySelector(".board-widget__menu") !== null).toBe(profile.controls);
+    expect(
+      view.querySelector<HTMLButtonElement>('[data-test-id="board-grant-allow"]')?.disabled,
+    ).toBe(!profile.canGrant);
+    expect(
+      view.querySelector<HTMLButtonElement>('[data-test-id="board-grant-reject"]')?.disabled,
+    ).toBe(!profile.canGrant);
+  });
+
   it("renders MCP App widgets through the bridge element while approval is pending", async () => {
     if (!customElements.get("mcp-app-view")) {
       customElements.define("mcp-app-view", class extends HTMLElement {});

--- a/ui/src/components/board/board-view.ts
+++ b/ui/src/components/board/board-view.ts
@@ -71,6 +71,8 @@ class OpenClawBoardView extends OpenClawLightDomElement {
   @property({ attribute: false }) widgetFrameUrl?: BoardWidgetFrameUrl;
   @property({ attribute: false }) callbacks?: BoardViewCallbacks;
   @property({ attribute: false }) sessions: readonly GatewaySessionRow[] = [];
+  @property({ type: Boolean }) canMutate = true;
+  @property({ type: Boolean }) canGrant = true;
 
   @state() private previewItems: BoardGridItem[] | null = null;
   @state() private gestureName = "";
@@ -224,7 +226,7 @@ class OpenClawBoardView extends OpenClawLightDomElement {
     widget: BoardViewWidget,
     event: PointerEvent,
   ): void {
-    if (event.button !== 0 || this.gesture || this.mutationPending) {
+    if (!this.canMutate || event.button !== 0 || this.gesture || this.mutationPending) {
       return;
     }
     const snapshot = this.snapshot;
@@ -582,6 +584,8 @@ class OpenClawBoardView extends OpenClawLightDomElement {
                 .positionInSet=${(logicalPosition.get(widget.name) ?? 0) + 1}
                 .setSize=${rects.length}
                 .busy=${this.mutationPending}
+                .canMutate=${this.canMutate}
+                .canGrant=${this.canGrant}
               ></openclaw-board-widget-cell>
             `;
           },

--- a/ui/src/components/board/board-widget-cell.ts
+++ b/ui/src/components/board/board-widget-cell.ts
@@ -65,6 +65,8 @@ class OpenClawBoardWidgetCell extends OpenClawLightDomElement {
   @property({ type: Number }) positionInSet = 1;
   @property({ type: Number }) setSize = 1;
   @property({ type: Boolean }) busy = false;
+  @property({ type: Boolean }) canMutate = true;
+  @property({ type: Boolean }) canGrant = true;
 
   @state() private actionError = "";
   @state() private actionPending = false;
@@ -143,6 +145,9 @@ class OpenClawBoardWidgetCell extends OpenClawLightDomElement {
     widget: BoardViewWidget,
     callbacks: BoardWidgetCellCallbacks,
   ): void {
+    if (!this.canMutate) {
+      return;
+    }
     const value = event.detail.item.value;
     if (value === "remove") {
       void this.runAction(() => callbacks.remove(widget));
@@ -170,7 +175,7 @@ class OpenClawBoardWidgetCell extends OpenClawLightDomElement {
       widget.grantState === "pending"
         ? renderBoardWidgetPending({
             widget,
-            disabled: this.busy || this.actionPending,
+            disabled: this.busy || this.actionPending || !this.canGrant,
             onGrant: (decision) =>
               void this.runAction(() => callbacks.grant(widget.name, decision)),
             ...(this.actionError
@@ -180,14 +185,14 @@ class OpenClawBoardWidgetCell extends OpenClawLightDomElement {
         : widget.grantState === "rejected"
           ? renderBoardWidgetRejected({
               widget,
-              disabled: this.busy || this.actionPending,
+              disabled: this.busy || this.actionPending || !this.canMutate,
               onRemove: () => void this.runAction(() => callbacks.remove(widget)),
             })
           : nothing;
     return renderBoardMcpAppContent({
       accessNotice,
       appView: this.appView.state,
-      busy: this.busy || this.actionPending,
+      busy: this.busy || this.actionPending || !this.canMutate,
       loading: this.appView.loading,
       nearVisible: this.appView.nearVisible,
       rectHeight: this.rect?.h ?? 4,
@@ -206,7 +211,7 @@ class OpenClawBoardWidgetCell extends OpenClawLightDomElement {
     if (widget.grantState === "pending") {
       return renderBoardWidgetPending({
         widget,
-        disabled: this.busy || this.actionPending,
+        disabled: this.busy || this.actionPending || !this.canGrant,
         onGrant: (decision) => void this.runAction(() => callbacks.grant(widget.name, decision)),
         ...(this.actionError
           ? { error: renderBoardWidgetActionError(this.actionError, true) }
@@ -216,7 +221,7 @@ class OpenClawBoardWidgetCell extends OpenClawLightDomElement {
     if (widget.grantState === "rejected") {
       return renderBoardWidgetRejected({
         widget,
-        disabled: this.busy || this.actionPending,
+        disabled: this.busy || this.actionPending || !this.canMutate,
         onRemove: () => void this.runAction(() => callbacks.remove(widget)),
       });
     }
@@ -235,7 +240,7 @@ class OpenClawBoardWidgetCell extends OpenClawLightDomElement {
     widget: BoardViewWidget,
     callbacks: BoardWidgetCellCallbacks,
   ): void {
-    if (event.target !== event.currentTarget || widget.readOnly) {
+    if (event.target !== event.currentTarget || widget.readOnly || !this.canMutate) {
       return;
     }
     const direction =
@@ -278,7 +283,7 @@ class OpenClawBoardWidgetCell extends OpenClawLightDomElement {
       bodyErrored = true;
     }
     const label = widget.title || widget.name;
-    const readOnly = widget.readOnly === true;
+    const readOnly = widget.readOnly === true || !this.canMutate;
     const bodyScrollable =
       bodyErrored ||
       this.actionError !== "" ||

--- a/ui/src/lib/board/availability-controller.test.ts
+++ b/ui/src/lib/board/availability-controller.test.ts
@@ -142,6 +142,55 @@ describe("BoardAvailabilityController", () => {
     controller.hostDisconnected();
   });
 
+  it("clears cached presence when a reconnect loses board support", async () => {
+    vi.stubGlobal("location", { search: "" });
+    const sessionKey = "agent:main:sidebar-capability-change";
+    const source = {
+      client: {
+        request: vi.fn(async () => ({
+          sessionKey,
+          revision: 1,
+          tabs: [{ tabId: "main", title: "Main", position: 0, chatDock: "right" as const }],
+          widgets: [],
+        })),
+        addEventListener: vi.fn(() => () => {}),
+      },
+      connected: true,
+      available: true,
+      key: "gateway-a",
+    };
+    const requestUpdate = vi.fn();
+    let controller: BoardAvailabilityController | undefined;
+    const host: ReactiveControllerHost = {
+      addController(next: ReactiveController) {
+        controller = next as BoardAvailabilityController;
+      },
+      removeController() {},
+      requestUpdate,
+      updateComplete: Promise.resolve(true),
+    };
+    controller = new BoardAvailabilityController(
+      host,
+      () => [sessionKey],
+      boardProviderForSession,
+      () => source as never,
+    );
+    controller.hostConnected();
+    await vi.waitFor(() => expect(sessionHasBoard(sessionKey)).toBe(true));
+    const updatesAfterLoad = requestUpdate.mock.calls.length;
+
+    source.connected = false;
+    controller.hostUpdate();
+    expect(sessionHasBoard(sessionKey)).toBe(true);
+
+    source.connected = true;
+    source.available = false;
+    controller.hostUpdate();
+    expect(sessionHasBoard(sessionKey)).toBe(false);
+    expect(requestUpdate).toHaveBeenCalledTimes(updatesAfterLoad + 1);
+    controller.hostDisconnected();
+  });
+
   it("retries a transient lookup failure with bounded backoff", async () => {
     vi.useFakeTimers();
     vi.stubGlobal("location", { search: "" });

--- a/ui/src/lib/board/availability-controller.test.ts
+++ b/ui/src/lib/board/availability-controller.test.ts
@@ -2,7 +2,7 @@
 import type { ReactiveController, ReactiveControllerHost } from "lit";
 import { describe, expect, it, vi } from "vitest";
 import { BoardAvailabilityController } from "./availability-controller.ts";
-import { boardProviderForSession } from "./provider.ts";
+import { boardProviderForSession, sessionHasBoard } from "./provider.ts";
 
 describe("BoardAvailabilityController", () => {
   it("invalidates its host when a visible session board snapshot changes", async () => {
@@ -29,5 +29,158 @@ describe("BoardAvailabilityController", () => {
 
     expect(requestUpdate).toHaveBeenCalledOnce();
     controller?.hostDisconnected();
+  });
+
+  it("loads and refreshes board presence for sessions without full providers", async () => {
+    vi.stubGlobal("location", { search: "" });
+    const sessionKey = "agent:main:sidebar-only";
+    let hasBoard = true;
+    let listener: ((event: { event: string; payload: unknown }) => void) | undefined;
+    const client = {
+      request: vi.fn(async () => ({
+        sessionKey,
+        revision: hasBoard ? 1 : 2,
+        tabs: hasBoard
+          ? [{ tabId: "main", title: "Main", position: 0, chatDock: "right" as const }]
+          : [],
+        widgets: [],
+      })),
+      addEventListener: vi.fn((next) => {
+        listener = next as typeof listener;
+        return () => {
+          listener = undefined;
+        };
+      }),
+    };
+    const requestUpdate = vi.fn();
+    let controller: BoardAvailabilityController | undefined;
+    const host: ReactiveControllerHost = {
+      addController(next: ReactiveController) {
+        controller = next as BoardAvailabilityController;
+      },
+      removeController() {},
+      requestUpdate,
+      updateComplete: Promise.resolve(true),
+    };
+    controller = new BoardAvailabilityController(
+      host,
+      () => [sessionKey],
+      boardProviderForSession,
+      () => ({ client: client as never, connected: true, available: true, key: "gateway-a" }),
+    );
+    controller.hostConnected();
+
+    await vi.waitFor(() => expect(sessionHasBoard(sessionKey)).toBe(true));
+    expect(client.request).toHaveBeenCalledWith("board.get", { sessionKey });
+
+    hasBoard = false;
+    listener?.({ event: "board.changed", payload: { sessionKey, revision: 2 } });
+    await vi.waitFor(() => expect(sessionHasBoard(sessionKey)).toBe(false));
+    expect(client.request).toHaveBeenCalledTimes(2);
+    expect(requestUpdate).toHaveBeenCalledTimes(2);
+
+    controller.hostDisconnected();
+    expect(listener).toBeUndefined();
+  });
+
+  it("ignores an older lookup after a session is hidden and shown again", async () => {
+    vi.stubGlobal("location", { search: "" });
+    const sessionKey = "agent:main:sidebar-race";
+    let visible = true;
+    const resolvers: Array<
+      (snapshot: {
+        sessionKey: string;
+        revision: number;
+        tabs: Array<{ tabId: string; title: string; position: number; chatDock: "right" }>;
+        widgets: [];
+      }) => void
+    > = [];
+    const client = {
+      request: vi.fn(
+        () =>
+          new Promise((resolve) => {
+            resolvers.push(resolve);
+          }),
+      ),
+      addEventListener: vi.fn(() => () => {}),
+    };
+    const requestUpdate = vi.fn();
+    let controller: BoardAvailabilityController | undefined;
+    const host: ReactiveControllerHost = {
+      addController(next: ReactiveController) {
+        controller = next as BoardAvailabilityController;
+      },
+      removeController() {},
+      requestUpdate,
+      updateComplete: Promise.resolve(true),
+    };
+    controller = new BoardAvailabilityController(
+      host,
+      () => (visible ? [sessionKey] : []),
+      boardProviderForSession,
+      () => ({ client: client as never, connected: true, available: true, key: "gateway-a" }),
+    );
+    controller.hostConnected();
+    await vi.waitFor(() => expect(resolvers).toHaveLength(1));
+
+    visible = false;
+    controller.hostUpdate();
+    visible = true;
+    controller.hostUpdate();
+    await vi.waitFor(() => expect(resolvers).toHaveLength(2));
+    resolvers[1]?.({ sessionKey, revision: 2, tabs: [], widgets: [] });
+    await vi.waitFor(() => expect(requestUpdate).toHaveBeenCalledOnce());
+
+    resolvers[0]?.({
+      sessionKey,
+      revision: 1,
+      tabs: [{ tabId: "main", title: "Main", position: 0, chatDock: "right" }],
+      widgets: [],
+    });
+    await Promise.resolve();
+    expect(sessionHasBoard(sessionKey)).toBe(false);
+    controller.hostDisconnected();
+  });
+
+  it("retries a transient lookup failure with bounded backoff", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("location", { search: "" });
+    const sessionKey = "agent:main:sidebar-retry";
+    const client = {
+      request: vi
+        .fn()
+        .mockRejectedValueOnce(new Error("gateway busy"))
+        .mockResolvedValue({
+          sessionKey,
+          revision: 1,
+          tabs: [{ tabId: "main", title: "Main", position: 0, chatDock: "right" }],
+          widgets: [],
+        }),
+      addEventListener: vi.fn(() => () => {}),
+    };
+    let controller: BoardAvailabilityController | undefined;
+    const host: ReactiveControllerHost = {
+      addController(next: ReactiveController) {
+        controller = next as BoardAvailabilityController;
+      },
+      removeController() {},
+      requestUpdate: vi.fn(),
+      updateComplete: Promise.resolve(true),
+    };
+    controller = new BoardAvailabilityController(
+      host,
+      () => [sessionKey],
+      boardProviderForSession,
+      () => ({ client: client as never, connected: true, available: true, key: "gateway-a" }),
+    );
+    controller.hostConnected();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(client.request).toHaveBeenCalledOnce();
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(client.request).toHaveBeenCalledTimes(2);
+    expect(sessionHasBoard(sessionKey)).toBe(true);
+    controller.hostDisconnected();
+    vi.useRealTimers();
   });
 });

--- a/ui/src/lib/board/availability-controller.ts
+++ b/ui/src/lib/board/availability-controller.ts
@@ -40,7 +40,7 @@ export class BoardAvailabilityController implements ReactiveController {
   private sourceKey = "";
   private sourceUnsubscribe: (() => void) | undefined;
   private sourceActive = false;
-  private sourceAvailable = false;
+  private available = false;
   private connected = false;
 
   constructor(
@@ -124,7 +124,7 @@ export class BoardAvailabilityController implements ReactiveController {
     if (
       this.sourceClient === source.client &&
       this.sourceActive === active &&
-      this.sourceAvailable === source.available &&
+      this.available === source.available &&
       this.sourceKey === source.key
     ) {
       return;
@@ -134,7 +134,7 @@ export class BoardAvailabilityController implements ReactiveController {
     this.disconnectSource();
     this.sourceClient = source.client;
     this.sourceActive = active;
-    this.sourceAvailable = source.available;
+    this.available = source.available;
     this.sourceKey = source.key;
     if (availabilitySourceChanged && clearSessionBoardAvailability()) {
       this.host.requestUpdate();
@@ -164,7 +164,7 @@ export class BoardAvailabilityController implements ReactiveController {
     this.sourceUnsubscribe = undefined;
     this.sourceClient = null;
     this.sourceActive = false;
-    this.sourceAvailable = false;
+    this.available = false;
     this.lookedUpSessions.clear();
     this.lookupGeneration.clear();
     for (const sessionKey of this.retryTimers.keys()) {

--- a/ui/src/lib/board/availability-controller.ts
+++ b/ui/src/lib/board/availability-controller.ts
@@ -40,6 +40,7 @@ export class BoardAvailabilityController implements ReactiveController {
   private sourceKey = "";
   private sourceUnsubscribe: (() => void) | undefined;
   private sourceActive = false;
+  private sourceAvailable = false;
   private connected = false;
 
   constructor(
@@ -123,6 +124,7 @@ export class BoardAvailabilityController implements ReactiveController {
     if (
       this.sourceClient === source.client &&
       this.sourceActive === active &&
+      this.sourceAvailable === source.available &&
       this.sourceKey === source.key
     ) {
       return;
@@ -132,6 +134,7 @@ export class BoardAvailabilityController implements ReactiveController {
     this.disconnectSource();
     this.sourceClient = source.client;
     this.sourceActive = active;
+    this.sourceAvailable = source.available;
     this.sourceKey = source.key;
     if (availabilitySourceChanged && clearSessionBoardAvailability()) {
       this.host.requestUpdate();
@@ -161,6 +164,7 @@ export class BoardAvailabilityController implements ReactiveController {
     this.sourceUnsubscribe = undefined;
     this.sourceClient = null;
     this.sourceActive = false;
+    this.sourceAvailable = false;
     this.lookedUpSessions.clear();
     this.lookupGeneration.clear();
     for (const sessionKey of this.retryTimers.keys()) {

--- a/ui/src/lib/board/availability-controller.ts
+++ b/ui/src/lib/board/availability-controller.ts
@@ -1,17 +1,52 @@
+import type { BoardChangedEvent, BoardSnapshot } from "@openclaw/gateway-protocol";
 import type { ReactiveController, ReactiveControllerHost } from "lit";
-import { boardProviderForSession, type BoardProvider } from "./provider.ts";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import {
+  boardExists,
+  boardProviderCacheKey,
+  boardProviderForSession,
+  clearSessionBoardAvailability,
+  recordSessionBoardAvailability,
+  type BoardProvider,
+} from "./provider.ts";
 
 type ProviderResolver = (sessionKey: string) => BoardProvider;
+type AvailabilityClient = Pick<GatewayBrowserClient, "request" | "addEventListener">;
+type AvailabilitySource = {
+  client: AvailabilityClient | null;
+  connected: boolean;
+  available: boolean;
+  key: string;
+};
+type SourceResolver = () => AvailabilitySource;
 
-/** Keeps board-presence consumers reactive without coupling them to board content. */
+const disconnectedSource: SourceResolver = () => ({
+  client: null,
+  connected: false,
+  available: false,
+  key: "",
+});
+
+/** Keeps board-presence consumers reactive without creating a provider per sidebar row. */
 export class BoardAvailabilityController implements ReactiveController {
   private readonly subscriptions = new Map<BoardProvider, () => void>();
+  private readonly lookupGeneration = new Map<string, number>();
+  private lookupSequence = 0;
+  private readonly lookedUpSessions = new Set<string>();
+  private readonly retryDelay = new Map<string, number>();
+  private readonly retryTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  private visibleSessionKeys = new Set<string>();
+  private sourceClient: AvailabilityClient | null = null;
+  private sourceKey = "";
+  private sourceUnsubscribe: (() => void) | undefined;
+  private sourceActive = false;
   private connected = false;
 
   constructor(
     private readonly host: ReactiveControllerHost,
     private readonly sessionKeys: () => readonly string[],
     private readonly resolveProvider: ProviderResolver = boardProviderForSession,
+    private readonly resolveSource: SourceResolver = disconnectedSource,
   ) {
     host.addController(this);
   }
@@ -31,25 +66,30 @@ export class BoardAvailabilityController implements ReactiveController {
       unsubscribe();
     }
     this.subscriptions.clear();
+    this.disconnectSource();
+    this.visibleSessionKeys.clear();
   }
 
   private synchronize(): void {
     if (!this.connected) {
       return;
     }
-    const current = new Set(
+    const keys = new Set(
       this.sessionKeys()
         .map((sessionKey) => sessionKey.trim())
         .filter(Boolean)
-        .map((sessionKey) => this.resolveProvider(sessionKey)),
+        .map(boardProviderCacheKey),
+    );
+    const currentProviders = new Set(
+      [...keys].map((sessionKey) => this.resolveProvider(sessionKey)),
     );
     for (const [provider, unsubscribe] of this.subscriptions) {
-      if (!current.has(provider)) {
+      if (!currentProviders.has(provider)) {
         unsubscribe();
         this.subscriptions.delete(provider);
       }
     }
-    for (const provider of current) {
+    for (const provider of currentProviders) {
       if (!this.subscriptions.has(provider)) {
         this.subscriptions.set(
           provider,
@@ -57,5 +97,134 @@ export class BoardAvailabilityController implements ReactiveController {
         );
       }
     }
+
+    for (const previous of this.visibleSessionKeys) {
+      if (!keys.has(previous)) {
+        this.lookedUpSessions.delete(previous);
+        this.lookupGeneration.delete(previous);
+        this.clearRetry(previous);
+      }
+    }
+    this.visibleSessionKeys = keys;
+    this.synchronizeSource();
+    if (this.sourceActive && this.sourceClient) {
+      for (const sessionKey of keys) {
+        if (!this.lookedUpSessions.has(sessionKey)) {
+          this.lookedUpSessions.add(sessionKey);
+          this.lookup(sessionKey, this.sourceClient);
+        }
+      }
+    }
+  }
+
+  private synchronizeSource(): void {
+    const source = this.resolveSource();
+    const active = source.connected && source.available && source.client !== null;
+    if (
+      this.sourceClient === source.client &&
+      this.sourceActive === active &&
+      this.sourceKey === source.key
+    ) {
+      return;
+    }
+    const availabilitySourceChanged =
+      this.sourceClient !== source.client || this.sourceKey !== source.key || !source.available;
+    this.disconnectSource();
+    this.sourceClient = source.client;
+    this.sourceActive = active;
+    this.sourceKey = source.key;
+    if (availabilitySourceChanged && clearSessionBoardAvailability()) {
+      this.host.requestUpdate();
+    }
+    if (!active || !source.client) {
+      return;
+    }
+    const client = source.client;
+    this.sourceUnsubscribe = client.addEventListener((event) => {
+      if (event.event !== "board.changed") {
+        return;
+      }
+      const payload = event.payload as Partial<BoardChangedEvent> | undefined;
+      const sessionKey =
+        typeof payload?.sessionKey === "string"
+          ? boardProviderCacheKey(payload.sessionKey)
+          : undefined;
+      if (sessionKey && this.visibleSessionKeys.has(sessionKey)) {
+        this.clearRetry(sessionKey);
+        this.lookup(sessionKey, client);
+      }
+    });
+  }
+
+  private disconnectSource(): void {
+    this.sourceUnsubscribe?.();
+    this.sourceUnsubscribe = undefined;
+    this.sourceClient = null;
+    this.sourceActive = false;
+    this.lookedUpSessions.clear();
+    this.lookupGeneration.clear();
+    for (const sessionKey of this.retryTimers.keys()) {
+      this.clearRetry(sessionKey);
+    }
+  }
+
+  private lookup(sessionKey: string, client: AvailabilityClient): void {
+    const generation = ++this.lookupSequence;
+    this.lookupGeneration.set(sessionKey, generation);
+    void client
+      .request<BoardSnapshot>("board.get", { sessionKey })
+      .then((snapshot) => {
+        if (
+          !this.connected ||
+          !this.sourceActive ||
+          this.sourceClient !== client ||
+          this.lookupGeneration.get(sessionKey) !== generation ||
+          !this.visibleSessionKeys.has(sessionKey)
+        ) {
+          return;
+        }
+        if (recordSessionBoardAvailability(sessionKey, boardExists(snapshot))) {
+          this.host.requestUpdate();
+        }
+        this.clearRetry(sessionKey);
+      })
+      .catch(() => {
+        if (
+          this.sourceClient === client &&
+          this.lookupGeneration.get(sessionKey) === generation &&
+          this.visibleSessionKeys.has(sessionKey)
+        ) {
+          this.scheduleRetry(sessionKey, client);
+        }
+      });
+  }
+
+  private scheduleRetry(sessionKey: string, client: AvailabilityClient): void {
+    if (this.retryTimers.has(sessionKey)) {
+      return;
+    }
+    const delay = this.retryDelay.get(sessionKey) ?? 1_000;
+    const timer = setTimeout(() => {
+      this.retryTimers.delete(sessionKey);
+      if (
+        this.connected &&
+        this.sourceActive &&
+        this.sourceClient === client &&
+        this.visibleSessionKeys.has(sessionKey)
+      ) {
+        this.lookup(sessionKey, client);
+      }
+    }, delay);
+    this.retryTimers.set(sessionKey, timer);
+    this.retryDelay.set(sessionKey, Math.min(delay * 2, 30_000));
+  }
+
+  private clearRetry(sessionKey: string): void {
+    const timer = this.retryTimers.get(sessionKey);
+    if (timer) {
+      clearTimeout(timer);
+      this.retryTimers.delete(sessionKey);
+    }
+    this.retryDelay.delete(sessionKey);
   }
 }

--- a/ui/src/lib/board/gateway-provider.test.ts
+++ b/ui/src/lib/board/gateway-provider.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { GatewayBoardProvider, type BoardCommandEvent, type BoardProvider } from "./provider.ts";
+import { GatewayBoardProvider, type BoardProvider } from "./provider.ts";
 
 afterEach(() => {
   vi.useRealTimers();

--- a/ui/src/lib/board/gateway-provider.test.ts
+++ b/ui/src/lib/board/gateway-provider.test.ts
@@ -1,0 +1,351 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { GatewayBoardProvider, type BoardCommandEvent, type BoardProvider } from "./provider.ts";
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe("gateway board provider lifecycle", () => {
+  it("discards mutation responses from a replaced gateway client", async () => {
+    let resolveMutation: ((snapshot: BoardProvider["snapshot$"]["value"]) => void) | undefined;
+    const oldClient = {
+      request: vi.fn(
+        () =>
+          new Promise<BoardProvider["snapshot$"]["value"]>((resolve) => {
+            resolveMutation = resolve;
+          }),
+      ) as never,
+      addEventListener: () => () => {},
+    };
+    const current = {
+      sessionKey: "agent:main:replacement",
+      revision: 3,
+      tabs: [],
+      widgets: [],
+    };
+    const newClient = {
+      request: vi.fn(async () => current) as never,
+      addEventListener: () => () => {},
+    };
+    const provider = new GatewayBoardProvider("agent:main:replacement", oldClient, false);
+    const mutation = provider.applyOps([]);
+
+    provider.attachClient(newClient, true);
+    await vi.waitFor(() => expect(provider.snapshot$.value).toEqual(current));
+    resolveMutation?.({ ...current, revision: 4 });
+    await mutation;
+
+    expect(provider.snapshot$.value).toEqual(current);
+  });
+
+  it("clears an old gateway snapshot before accepting a lower revision", async () => {
+    const oldSnapshot = {
+      sessionKey: "agent:main:gateway-swap",
+      revision: 5,
+      tabs: [{ tabId: "main", title: "Old", position: 0, chatDock: "right" as const }],
+      widgets: [],
+    };
+    const newSnapshot = {
+      sessionKey: "agent:main:gateway-swap",
+      revision: 1,
+      tabs: [{ tabId: "main", title: "New", position: 0, chatDock: "left" as const }],
+      widgets: [],
+    };
+    const oldClient = {
+      request: vi.fn(async () => oldSnapshot) as never,
+      addEventListener: () => () => {},
+    };
+    let resolveNewSnapshot: ((snapshot: BoardProvider["snapshot$"]["value"]) => void) | undefined;
+    const newClient = {
+      request: vi.fn(
+        () =>
+          new Promise<BoardProvider["snapshot$"]["value"]>((resolve) => {
+            resolveNewSnapshot = resolve;
+          }),
+      ) as never,
+      addEventListener: () => () => {},
+    };
+    const provider = new GatewayBoardProvider("agent:main:gateway-swap", oldClient);
+    await vi.waitFor(() => expect(provider.snapshot$.value).toEqual(oldSnapshot));
+
+    provider.attachClient(newClient, true);
+    expect(provider.snapshot$.value).toEqual({
+      sessionKey: "agent:main:gateway-swap",
+      revision: 0,
+      tabs: [],
+      widgets: [],
+    });
+    resolveNewSnapshot?.(newSnapshot);
+    await vi.waitFor(() => expect(provider.snapshot$.value).toEqual(newSnapshot));
+  });
+
+  it("retries a transient activation failure", async () => {
+    vi.useFakeTimers();
+    const snapshot = {
+      sessionKey: "agent:main:retry",
+      revision: 1,
+      tabs: [{ tabId: "main", title: "Main", position: 0, chatDock: "right" as const }],
+      widgets: [],
+    };
+    const request = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("temporarily unavailable"))
+      .mockResolvedValue(snapshot);
+    const provider = new GatewayBoardProvider("agent:main:retry", {
+      request: request as never,
+      addEventListener: () => () => {},
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(request).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(request).toHaveBeenCalledTimes(2);
+    expect(provider.snapshot$.value).toEqual(snapshot);
+  });
+
+  it("reactivates the same gateway client after reconnect", async () => {
+    const snapshot = {
+      sessionKey: "agent:main:reconnect",
+      revision: 1,
+      tabs: [],
+      widgets: [],
+    };
+    const request = vi.fn(async () => snapshot);
+    const client = {
+      request: request as never,
+      addEventListener: () => () => {},
+    };
+    const provider = new GatewayBoardProvider("agent:main:reconnect", client, false);
+
+    expect(request).not.toHaveBeenCalled();
+    provider.attachClient(client, true);
+    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+    expect(provider.snapshot$.value).toEqual(snapshot);
+  });
+
+  it("wakes a pending refresh backoff when the gateway reconnects", async () => {
+    vi.useFakeTimers();
+    const snapshot = {
+      sessionKey: "agent:main:reconnect-backoff",
+      revision: 1,
+      tabs: [],
+      widgets: [],
+    };
+    const request = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("temporarily unavailable"))
+      .mockResolvedValue(snapshot);
+    const client = {
+      request: request as never,
+      addEventListener: () => () => {},
+    };
+    const provider = new GatewayBoardProvider("agent:main:reconnect-backoff", client);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(request).toHaveBeenCalledOnce();
+
+    provider.attachClient(client, false);
+    provider.attachClient(client, true);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(request).toHaveBeenCalledTimes(2);
+    expect(provider.snapshot$.value).toEqual(snapshot);
+  });
+
+  it("retries a transient board.changed refresh failure", async () => {
+    vi.useFakeTimers();
+    let listener: ((event: { event: string; payload: unknown }) => void) | undefined;
+    const initial = {
+      sessionKey: "agent:main:event-retry",
+      revision: 1,
+      tabs: [{ tabId: "main", title: "Main", position: 0, chatDock: "right" as const }],
+      widgets: [],
+    };
+    const changed = { ...initial, revision: 2 };
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce(initial)
+      .mockRejectedValueOnce(new Error("temporarily unavailable"))
+      .mockResolvedValue(changed);
+    const provider = new GatewayBoardProvider("agent:main:event-retry", {
+      request: request as never,
+      addEventListener: (next) => {
+        listener = next as typeof listener;
+        return () => {};
+      },
+    });
+    await vi.advanceTimersByTimeAsync(0);
+
+    listener?.({
+      event: "board.changed",
+      payload: { sessionKey: "agent:main:event-retry", revision: 2 },
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(provider.snapshot$.value.revision).toBe(1);
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(request).toHaveBeenCalledTimes(3);
+    expect(provider.snapshot$.value.revision).toBe(2);
+  });
+
+  it("preserves minted view metadata across layout and grant mutation snapshots", async () => {
+    const widget = {
+      name: "alpha",
+      tabId: "main",
+      contentKind: "html" as const,
+      sizeW: 6,
+      sizeH: 4,
+      position: 0,
+      grantState: "pending" as const,
+      revision: 1,
+      frameUrl: "/ticketed-frame",
+      viewTicket: "view-ticket",
+      viewTicketTtlMs: 60_000,
+      viewGeneration: "a".repeat(32),
+      sandboxUrl: "https://sandbox.example/host",
+      sandboxPort: 18_790,
+      sandboxOrigin: "https://sandbox.example:18790",
+    };
+    const initial = {
+      sessionKey: "agent:main:mutation-view-contract",
+      revision: 1,
+      tabs: [{ tabId: "main", title: "Main", position: 0, chatDock: "right" as const }],
+      widgets: [widget],
+    };
+    const layoutMutation = {
+      ...initial,
+      revision: 2,
+      widgets: [{ ...widget, sizeW: 8, frameUrl: undefined, viewTicket: undefined }].map(
+        ({
+          frameUrl: _frameUrl,
+          viewTicket: _viewTicket,
+          viewTicketTtlMs: _viewTicketTtlMs,
+          viewGeneration: _viewGeneration,
+          sandboxUrl: _sandboxUrl,
+          sandboxPort: _sandboxPort,
+          sandboxOrigin: _sandboxOrigin,
+          ...plainWidget
+        }) => plainWidget,
+      ),
+    };
+    const grantMutation = {
+      ...layoutMutation,
+      revision: 3,
+      widgets: [{ ...layoutMutation.widgets[0]!, grantState: "granted" as const }],
+    };
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce(initial)
+      .mockResolvedValueOnce(layoutMutation)
+      .mockResolvedValueOnce(grantMutation);
+    const provider = new GatewayBoardProvider("agent:main:mutation-view-contract", {
+      request: request as never,
+      addEventListener: () => () => {},
+    });
+    await vi.waitFor(() => expect(provider.snapshot$.value).toEqual(initial));
+
+    await provider.applyOps([{ kind: "widget_resize", name: "alpha", sizeW: 8, sizeH: 4 }]);
+    await provider.grant("alpha", "granted");
+
+    expect(provider.snapshot$.value.widgets[0]).toEqual({
+      ...widget,
+      sizeW: 8,
+      grantState: "granted",
+    });
+  });
+
+  it("passes mutations through and surfaces board commands", async () => {
+    let listener: ((event: { event: string; payload: unknown }) => void) | undefined;
+    const empty = { sessionKey: "agent:main:live", revision: 0, tabs: [], widgets: [] };
+    const pinned = {
+      sessionKey: "agent:main:live",
+      revision: 1,
+      tabs: [{ tabId: "main", title: "Main", position: 0, chatDock: "right" as const }],
+      widgets: [
+        {
+          name: "canvas-cv-1",
+          tabId: "main",
+          contentKind: "html" as const,
+          sizeW: 6,
+          sizeH: 4,
+          position: 0,
+          grantState: "none" as const,
+          revision: 1,
+          instanceId: "canvas-instance",
+          frameUrl: "/frame",
+        },
+      ],
+    };
+    let getCount = 0;
+    const request = vi.fn(async (method: string) => {
+      if (method === "board.get") {
+        getCount += 1;
+        return getCount === 1 ? empty : pinned;
+      }
+      return pinned;
+    });
+    const provider = new GatewayBoardProvider("agent:main:live", {
+      request: request as never,
+      addEventListener: (next) => {
+        listener = next as typeof listener;
+        return () => {};
+      },
+    });
+    await vi.waitFor(() => expect(request).toHaveBeenCalledWith("board.get", expect.anything()));
+    const command = vi.fn();
+    provider.events.subscribe(command);
+
+    await provider.applyOps([{ kind: "tab_update", tabId: "main", chatDock: "left" }]);
+    await provider.grant("canvas-cv-1", "granted");
+    const longTitle = "Pinned ".repeat(20).trim();
+    await provider.pinWidget({ docId: "cv-1", title: longTitle });
+    await provider.pinMcpApp({
+      viewId: "mcp-app-source",
+      name: "mcp-app-opaque",
+      title: "App status",
+      tabId: "main",
+      size: "md",
+      after: "canvas-cv-1",
+    });
+    listener?.({
+      event: "board.command",
+      payload: {
+        sessionKey: "agent:main:live",
+        command: { kind: "focus_tab", tabId: "main" },
+      },
+    });
+
+    expect(request).toHaveBeenCalledWith("board.update", {
+      sessionKey: "agent:main:live",
+      ops: [{ kind: "tab_update", tabId: "main", chatDock: "left" }],
+    });
+    expect(request).toHaveBeenCalledWith("board.widget.grant", {
+      sessionKey: "agent:main:live",
+      name: "canvas-cv-1",
+      decision: "granted",
+      revision: 1,
+      instanceId: "canvas-instance",
+    });
+    expect(request).toHaveBeenCalledWith("board.widget.put", {
+      sessionKey: "agent:main:live",
+      name: "canvas-cv-1",
+      title: Array.from(longTitle).slice(0, 80).join(""),
+      content: { kind: "canvas-doc", docId: "cv-1" },
+    });
+    expect(request).toHaveBeenCalledWith("board.widget.put", {
+      sessionKey: "agent:main:live",
+      name: "mcp-app-opaque",
+      title: "App status",
+      content: { kind: "mcp-app", viewId: "mcp-app-source" },
+      placement: { tabId: "main", size: "md", after: "canvas-cv-1" },
+    });
+    expect(request.mock.calls.filter(([method]) => method === "board.get")).toHaveLength(1);
+    expect(provider.snapshot$.value).toEqual(pinned);
+    expect(command).toHaveBeenCalledWith({
+      sessionKey: "agent:main:live",
+      command: { kind: "focus_tab", tabId: "main" },
+    });
+  });
+});

--- a/ui/src/lib/board/gateway-provider.ts
+++ b/ui/src/lib/board/gateway-provider.ts
@@ -15,7 +15,7 @@ import {
   type BoardEventStream,
   type BoardSnapshotSignal,
 } from "./provider-signals.ts";
-import type { BoardProvider } from "./provider.ts";
+import type { BoardProvider } from "./provider-types.ts";
 import type { BoardWidgetAppViewState } from "./view-types.ts";
 import { canvasWidgetNameForDocument, mcpAppWidgetNameForViewId } from "./widget-names.ts";
 import {

--- a/ui/src/lib/board/gateway-provider.ts
+++ b/ui/src/lib/board/gateway-provider.ts
@@ -1,0 +1,477 @@
+import type {
+  BoardChangedEvent,
+  BoardCommandEvent,
+  BoardOp,
+  BoardSnapshot,
+  BoardWidget,
+  BoardWidgetAppViewResult,
+} from "@openclaw/gateway-protocol";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import { normalizeSessionKeyForUiComparison } from "../sessions/session-key.ts";
+import { BoardMcpAppViewCache } from "./mcp-app-view-cache.ts";
+import {
+  EventStream,
+  ValueSignal,
+  type BoardEventStream,
+  type BoardSnapshotSignal,
+} from "./provider-signals.ts";
+import type { BoardProvider } from "./provider.ts";
+import type { BoardWidgetAppViewState } from "./view-types.ts";
+import { canvasWidgetNameForDocument, mcpAppWidgetNameForViewId } from "./widget-names.ts";
+import {
+  copyBoardWidgetTicketReceipt,
+  recordBoardWidgetTicketReceipt,
+} from "./widget-ticket-lifetime.ts";
+
+type BoardGatewayClient = Pick<GatewayBrowserClient, "request" | "addEventListener">;
+type BoardPinPlacement = {
+  title?: string;
+  name?: string;
+  tabId?: string;
+  size?: "sm" | "md" | "lg" | "xl" | "full";
+  after?: string;
+};
+type BoardPinWidgetInput = BoardPinPlacement & { docId: string };
+type BoardPinMcpAppInput = BoardPinPlacement & { viewId: string };
+
+function emptySnapshot(sessionKey: string): BoardSnapshot {
+  return { sessionKey, revision: 0, tabs: [], widgets: [] };
+}
+
+function boardWidgetTitle(title: string | undefined): string | undefined {
+  const normalized = title?.trim() ?? "";
+  return normalized ? Array.from(normalized).slice(0, 80).join("") : undefined;
+}
+
+export class GatewayBoardProvider implements BoardProvider {
+  readonly snapshot$: BoardSnapshotSignal<BoardSnapshot>;
+  readonly events: BoardEventStream<BoardCommandEvent>;
+  private readonly snapshotSignal: ValueSignal<BoardSnapshot>;
+  private readonly eventStream = new EventStream<BoardCommandEvent>();
+  private client: BoardGatewayClient;
+  private clientGeneration = 0;
+  private unsubscribe: (() => void) | undefined;
+  private refreshLoop: Promise<void> | undefined;
+  private refreshRequested = false;
+  private readonly changedWidgets = new Set<string>();
+  private stateGeneration = 0;
+  private connected = false;
+  private wakeRetryDelay: (() => void) | undefined;
+  private readonly appViews = new BoardMcpAppViewCache();
+  private disposed = false;
+  private snapshotLoaded = false;
+
+  constructor(
+    readonly sessionKey: string,
+    client: BoardGatewayClient,
+    connected = true,
+    public canPinWidgets = true,
+    public canPinMcpApps = false,
+    public canMutate = true,
+    public canGrant = true,
+  ) {
+    this.snapshotSignal = new ValueSignal(emptySnapshot(sessionKey));
+    this.snapshot$ = this.snapshotSignal;
+    this.events = this.eventStream;
+    this.client = client;
+    this.connected = connected;
+    this.subscribe(client);
+    if (connected) {
+      void this.activate();
+    }
+  }
+
+  attachClient(
+    client: BoardGatewayClient,
+    connected = true,
+    canPinWidgets = true,
+    canPinMcpApps = false,
+    canMutate = true,
+    canGrant = true,
+  ): void {
+    if (this.disposed) {
+      return;
+    }
+    const connectionActivated = connected && !this.connected;
+    this.connected = connected;
+    this.canPinWidgets = canPinWidgets;
+    this.canPinMcpApps = canPinMcpApps;
+    this.canMutate = canMutate;
+    this.canGrant = canGrant;
+    if (client === this.client) {
+      if (connectionActivated) {
+        void this.activate();
+      }
+      return;
+    }
+    this.unsubscribe?.();
+    this.client = client;
+    this.clientGeneration += 1;
+    this.stateGeneration += 1;
+    this.changedWidgets.clear();
+    this.appViews.clear();
+    this.snapshotLoaded = false;
+    this.snapshotSignal.set(emptySnapshot(this.sessionKey));
+    this.subscribe(client);
+    if (connected) {
+      void this.activate();
+    }
+  }
+
+  activate(): Promise<void> {
+    return this.requestRefresh();
+  }
+
+  get hasLoadedSnapshot(): boolean {
+    return this.snapshotLoaded;
+  }
+
+  dispose(): void {
+    if (this.disposed) {
+      return;
+    }
+    this.disposed = true;
+    this.connected = false;
+    this.unsubscribe?.();
+    this.unsubscribe = undefined;
+    this.clientGeneration += 1;
+    this.stateGeneration += 1;
+    this.refreshRequested = false;
+    this.changedWidgets.clear();
+    this.appViews.clear();
+    this.wakeRetryDelay?.();
+  }
+
+  async applyOps(ops: BoardOp[]): Promise<void> {
+    await this.mutate("board.update", {
+      sessionKey: this.sessionKey,
+      ops,
+    });
+  }
+
+  async grant(name: string, decision: "granted" | "rejected"): Promise<void> {
+    const widget = this.snapshotSignal.value.widgets.find((candidate) => candidate.name === name);
+    if (!widget) {
+      void this.requestRefresh();
+      throw new Error(`Dashboard widget not found: ${name}`);
+    }
+    await this.mutate("board.widget.grant", {
+      sessionKey: this.sessionKey,
+      name,
+      decision,
+      revision: widget.revision,
+      ...(widget.instanceId ? { instanceId: widget.instanceId } : {}),
+    });
+  }
+
+  async pinWidget(input: BoardPinWidgetInput): Promise<void> {
+    const name = input.name ?? canvasWidgetNameForDocument(input.docId);
+    const title = boardWidgetTitle(input.title);
+    await this.mutate(
+      "board.widget.put",
+      {
+        sessionKey: this.sessionKey,
+        name,
+        ...(title ? { title } : {}),
+        content: { kind: "canvas-doc", docId: input.docId },
+        ...(input.tabId || input.size || input.after
+          ? {
+              placement: {
+                ...(input.tabId ? { tabId: input.tabId } : {}),
+                ...(input.size ? { size: input.size } : {}),
+                ...(input.after ? { after: input.after } : {}),
+              },
+            }
+          : {}),
+      },
+      name,
+    );
+  }
+
+  async pinMcpApp(input: BoardPinMcpAppInput): Promise<void> {
+    const name = input.name ?? mcpAppWidgetNameForViewId(input.viewId);
+    const title = boardWidgetTitle(input.title);
+    await this.mutate(
+      "board.widget.put",
+      {
+        sessionKey: this.sessionKey,
+        name,
+        ...(title ? { title } : {}),
+        content: { kind: "mcp-app", viewId: input.viewId },
+        ...(input.tabId || input.size || input.after
+          ? {
+              placement: {
+                ...(input.tabId ? { tabId: input.tabId } : {}),
+                ...(input.size ? { size: input.size } : {}),
+                ...(input.after ? { after: input.after } : {}),
+              },
+            }
+          : {}),
+      },
+      name,
+    );
+  }
+
+  widgetFrameUrl(name: string, revision: number): string {
+    return (
+      this.snapshotSignal.value.widgets.find(
+        (widget) => widget.name === name && widget.revision === revision,
+      )?.frameUrl ?? ""
+    );
+  }
+
+  refreshWidgetFrame(name: string): Promise<void> {
+    return this.requestRefresh(name);
+  }
+
+  async widgetAppView(name: string, revision: number): Promise<BoardWidgetAppViewState> {
+    return await this.resolveWidgetAppView(name, revision, false);
+  }
+
+  async refreshWidgetAppView(name: string, revision: number): Promise<BoardWidgetAppViewState> {
+    return await this.resolveWidgetAppView(name, revision, true);
+  }
+
+  private async resolveWidgetAppView(
+    name: string,
+    revision: number,
+    force: boolean,
+  ): Promise<BoardWidgetAppViewState> {
+    const widget = this.snapshotSignal.value.widgets.find(
+      (candidate) =>
+        candidate.name === name &&
+        candidate.revision === revision &&
+        candidate.contentKind === "mcp-app",
+    );
+    if (!widget) {
+      return { status: "stale", error: "Dashboard MCP App widget unavailable" };
+    }
+    const client = this.client;
+    return await this.appViews.resolve(
+      widget,
+      async () =>
+        await client.request<BoardWidgetAppViewResult>("board.widget.appView", {
+          sessionKey: this.sessionKey,
+          name,
+          revision,
+          ...(widget.instanceId ? { instanceId: widget.instanceId } : {}),
+        }),
+      force,
+    );
+  }
+
+  private subscribe(client: BoardGatewayClient): void {
+    this.unsubscribe = client.addEventListener((event) => {
+      if (this.disposed) {
+        return;
+      }
+      if (event.event === "board.changed") {
+        const payload = event.payload as Partial<BoardChangedEvent> | undefined;
+        if (payload && this.matchesSession(payload.sessionKey)) {
+          this.stateGeneration += 1;
+          void this.requestRefresh(payload.widget);
+        }
+        return;
+      }
+      if (event.event === "board.command") {
+        const payload = event.payload as Partial<BoardCommandEvent> | undefined;
+        if (payload?.command && this.matchesSession(payload.sessionKey)) {
+          this.eventStream.emit({ sessionKey: this.sessionKey, command: payload.command });
+        }
+      }
+    });
+  }
+
+  private matchesSession(sessionKey: string | undefined): boolean {
+    return (
+      typeof sessionKey === "string" &&
+      normalizeSessionKeyForUiComparison(sessionKey) ===
+        normalizeSessionKeyForUiComparison(this.sessionKey)
+    );
+  }
+
+  private requestRefresh(changedWidget?: string): Promise<void> {
+    if (this.disposed) {
+      return Promise.resolve();
+    }
+    this.refreshRequested = true;
+    if (changedWidget) {
+      this.changedWidgets.add(changedWidget);
+    }
+    this.wakeRetryDelay?.();
+    this.refreshLoop ??= this.runRefreshLoop().finally(() => {
+      this.refreshLoop = undefined;
+      if (this.refreshRequested) {
+        void this.requestRefresh();
+      }
+    });
+    return this.refreshLoop;
+  }
+
+  private async runRefreshLoop(): Promise<void> {
+    const retry = { delayMs: 1_000 };
+    while (this.refreshRequested) {
+      if (this.disposed) {
+        this.refreshRequested = false;
+        return;
+      }
+      this.refreshRequested = false;
+      const changedWidgets = new Set(this.changedWidgets);
+      this.changedWidgets.clear();
+      const client = this.client;
+      const stateGeneration = this.stateGeneration;
+      try {
+        const snapshot = await client.request<BoardSnapshot>("board.get", {
+          sessionKey: this.sessionKey,
+        });
+        if (this.disposed) {
+          return;
+        }
+        if (client !== this.client) {
+          this.refreshRequested = true;
+          continue;
+        }
+        if (stateGeneration !== this.stateGeneration) {
+          this.refreshRequested = true;
+          for (const name of changedWidgets) {
+            this.changedWidgets.add(name);
+          }
+          continue;
+        }
+        this.setSnapshot(snapshot, changedWidgets);
+        retry.delayMs = 1_000;
+      } catch {
+        if (this.disposed) {
+          return;
+        }
+        this.refreshRequested = true;
+        if (client !== this.client) {
+          continue;
+        }
+        for (const name of changedWidgets) {
+          this.changedWidgets.add(name);
+        }
+        const delayMs = retry.delayMs;
+        // Carry backoff across failed loop iterations; successful refreshes reset it above.
+        retry.delayMs = Math.min(delayMs * 2, 30_000);
+        await this.waitForRetry(delayMs);
+        continue;
+      }
+    }
+  }
+
+  private waitForRetry(delayMs: number): Promise<void> {
+    return new Promise((resolve) => {
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const finish = () => {
+        if (!timer) {
+          return;
+        }
+        clearTimeout(timer);
+        timer = undefined;
+        if (this.wakeRetryDelay === finish) {
+          this.wakeRetryDelay = undefined;
+        }
+        resolve();
+      };
+      timer = setTimeout(finish, delayMs);
+      this.wakeRetryDelay = finish;
+    });
+  }
+
+  private async mutate(
+    method: "board.update" | "board.widget.grant" | "board.widget.put",
+    params: Record<string, unknown>,
+    changedWidget?: string,
+  ): Promise<void> {
+    if (this.disposed) {
+      throw new Error("Session dashboard provider is no longer active");
+    }
+    const client = this.client;
+    const clientGeneration = this.clientGeneration;
+    const stateGeneration = ++this.stateGeneration;
+    try {
+      const snapshot = await client.request<BoardSnapshot>(method, params);
+      if (
+        !this.disposed &&
+        client === this.client &&
+        clientGeneration === this.clientGeneration &&
+        stateGeneration === this.stateGeneration
+      ) {
+        this.stateGeneration += 1;
+        this.setSnapshot(snapshot, changedWidget ? new Set([changedWidget]) : new Set(), true);
+      }
+    } catch (error) {
+      if (
+        !this.disposed &&
+        client === this.client &&
+        clientGeneration === this.clientGeneration &&
+        stateGeneration === this.stateGeneration
+      ) {
+        void this.requestRefresh();
+      }
+      throw error;
+    }
+  }
+
+  private setSnapshot(
+    snapshot: BoardSnapshot,
+    changedWidgets = new Set<string>(),
+    preserveMissingViewContracts = false,
+  ): void {
+    const receivedAtMs = Date.now();
+    const previousWidgets = new Map(
+      this.snapshotSignal.value.widgets.map((widget) => [widget.name, widget]),
+    );
+    const widgets = snapshot.widgets.map((widget) => {
+      const previous = previousWidgets.get(widget.name);
+      if (
+        preserveMissingViewContracts &&
+        previous &&
+        !changedWidgets.has(widget.name) &&
+        previous.revision === widget.revision &&
+        previous.instanceId === widget.instanceId &&
+        widget.viewGeneration === undefined
+      ) {
+        // Mutation snapshots contain board state but not the view contract minted
+        // by board.get. Keep that contract only while the document revision matches.
+        const preserved = preserveBoardWidgetViewContract(widget, previous);
+        copyBoardWidgetTicketReceipt(preserved, previous, receivedAtMs);
+        return preserved;
+      }
+      if (
+        previous &&
+        !changedWidgets.has(widget.name) &&
+        previous.revision === widget.revision &&
+        previous.instanceId === widget.instanceId &&
+        previous.viewGeneration === widget.viewGeneration &&
+        !widget.sandboxUrl &&
+        previous.frameUrl
+      ) {
+        const preserved = { ...widget, frameUrl: previous.frameUrl };
+        recordBoardWidgetTicketReceipt(preserved, receivedAtMs);
+        return preserved;
+      }
+      recordBoardWidgetTicketReceipt(widget, receivedAtMs);
+      return widget;
+    });
+    this.appViews.prune(widgets);
+    this.snapshotLoaded = true;
+    this.snapshotSignal.set({ ...snapshot, widgets });
+  }
+}
+
+function preserveBoardWidgetViewContract(widget: BoardWidget, previous: BoardWidget): BoardWidget {
+  return {
+    ...widget,
+    ...(previous.frameUrl !== undefined ? { frameUrl: previous.frameUrl } : {}),
+    ...(previous.viewTicket !== undefined ? { viewTicket: previous.viewTicket } : {}),
+    ...(previous.viewTicketTtlMs !== undefined
+      ? { viewTicketTtlMs: previous.viewTicketTtlMs }
+      : {}),
+    ...(previous.viewGeneration !== undefined ? { viewGeneration: previous.viewGeneration } : {}),
+    ...(previous.sandboxUrl !== undefined ? { sandboxUrl: previous.sandboxUrl } : {}),
+    ...(previous.sandboxPort !== undefined ? { sandboxPort: previous.sandboxPort } : {}),
+    ...(previous.sandboxOrigin !== undefined ? { sandboxOrigin: previous.sandboxOrigin } : {}),
+  };
+}

--- a/ui/src/lib/board/provider-types.ts
+++ b/ui/src/lib/board/provider-types.ts
@@ -1,0 +1,32 @@
+import type { BoardCommandEvent, BoardOp, BoardSnapshot } from "@openclaw/gateway-protocol";
+import type { BoardEventStream, BoardSnapshotSignal } from "./provider-signals.ts";
+import type { BoardWidgetAppViewState } from "./view-types.ts";
+
+type BoardPinPlacement = {
+  title?: string;
+  name?: string;
+  tabId?: string;
+  size?: "sm" | "md" | "lg" | "xl" | "full";
+  after?: string;
+};
+
+type BoardPinWidgetInput = BoardPinPlacement & { docId: string };
+type BoardPinMcpAppInput = BoardPinPlacement & { viewId: string };
+
+export type BoardProvider = {
+  readonly sessionKey: string;
+  readonly canMutate: boolean;
+  readonly canGrant: boolean;
+  readonly canPinWidgets: boolean;
+  readonly canPinMcpApps: boolean;
+  readonly snapshot$: BoardSnapshotSignal<BoardSnapshot>;
+  applyOps(ops: BoardOp[]): Promise<void>;
+  grant(name: string, decision: "granted" | "rejected"): Promise<void>;
+  pinWidget(input: BoardPinWidgetInput): Promise<void>;
+  pinMcpApp(input: BoardPinMcpAppInput): Promise<void>;
+  widgetFrameUrl(name: string, revision: number): string;
+  refreshWidgetFrame(name: string): Promise<void>;
+  widgetAppView(name: string, revision: number): Promise<BoardWidgetAppViewState>;
+  refreshWidgetAppView(name: string, revision: number): Promise<BoardWidgetAppViewState>;
+  readonly events: BoardEventStream<BoardCommandEvent>;
+};

--- a/ui/src/lib/board/provider.test.ts
+++ b/ui/src/lib/board/provider.test.ts
@@ -1,11 +1,14 @@
 // @vitest-environment node
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  acquireBoardProviderForSession,
   boardExists,
   boardProviderForSession,
   canvasWidgetNameForDocument,
   GatewayBoardProvider,
   mcpAppWidgetNameForViewId,
+  recordSessionBoardAvailability,
+  sessionHasBoard,
   type BoardCommandEvent,
   type BoardProvider,
 } from "./provider.ts";
@@ -103,6 +106,69 @@ describe("board providers", () => {
     expect(provider.canPinMcpApps).toBe(false);
     boardProviderForSession("agent:main:pin-capability", client as never, true, false, true, true);
     expect(provider.canPinMcpApps).toBe(true);
+  });
+
+  it("disposes a released gateway provider and creates a fresh provider on reacquire", async () => {
+    mockLocation.search = "";
+    type Event = { event: string; payload: unknown };
+    const listeners = new Set<(event: Event) => void>();
+    const snapshot = {
+      sessionKey: "agent:main:leased-provider",
+      revision: 1,
+      tabs: [{ tabId: "main", title: "Main", position: 0, chatDock: "right" as const }],
+      widgets: [],
+    };
+    const client = {
+      request: vi.fn(async () => snapshot) as never,
+      addEventListener: (listener: (event: Event) => void) => {
+        listeners.add(listener);
+        return () => listeners.delete(listener);
+      },
+    };
+    const first = acquireBoardProviderForSession(snapshot.sessionKey, client as never);
+    await vi.waitFor(() => expect(first.provider.snapshot$.value).toEqual(snapshot));
+    const command = vi.fn();
+    first.provider.events.subscribe(command);
+
+    for (const listener of listeners) {
+      listener({
+        event: "board.command",
+        payload: { sessionKey: snapshot.sessionKey, command: { kind: "focus_tab", tabId: "main" } },
+      });
+    }
+    expect(command).toHaveBeenCalledOnce();
+
+    first.release();
+    expect(listeners.size).toBe(0);
+    for (const listener of listeners) {
+      listener({
+        event: "board.command",
+        payload: { sessionKey: snapshot.sessionKey, command: { kind: "focus_tab", tabId: "main" } },
+      });
+    }
+    expect(command).toHaveBeenCalledOnce();
+
+    const second = acquireBoardProviderForSession(snapshot.sessionKey, client as never);
+    expect(second.provider).not.toBe(first.provider);
+    await vi.waitFor(() => expect(second.provider.snapshot$.value).toEqual(snapshot));
+    expect(listeners.size).toBe(1);
+    second.release();
+    expect(listeners.size).toBe(0);
+  });
+
+  it("preserves known availability when a provider is released before its first load", () => {
+    mockLocation.search = "";
+    const sessionKey = "agent:main:provisional-provider";
+    recordSessionBoardAvailability(sessionKey, true);
+    const lease = acquireBoardProviderForSession(sessionKey, {
+      request: vi.fn(() => new Promise(() => undefined)) as never,
+      addEventListener: () => () => {},
+    });
+
+    lease.release();
+
+    expect(boardExists(lease.provider.snapshot$.value)).toBe(false);
+    expect(sessionHasBoard(sessionKey)).toBe(true);
   });
 
   it("provides two mock tabs with mixed widget sizes", () => {
@@ -711,346 +777,5 @@ describe("board providers", () => {
 
     expect(getCount).toBe(3);
     expect(provider.widgetFrameUrl("alpha", 1)).toBe("/reminted-ticket");
-  });
-
-  it("discards mutation responses from a replaced gateway client", async () => {
-    let resolveMutation: ((snapshot: BoardProvider["snapshot$"]["value"]) => void) | undefined;
-    const oldClient = {
-      request: vi.fn(
-        () =>
-          new Promise<BoardProvider["snapshot$"]["value"]>((resolve) => {
-            resolveMutation = resolve;
-          }),
-      ) as never,
-      addEventListener: () => () => {},
-    };
-    const current = {
-      sessionKey: "agent:main:replacement",
-      revision: 3,
-      tabs: [],
-      widgets: [],
-    };
-    const newClient = {
-      request: vi.fn(async () => current) as never,
-      addEventListener: () => () => {},
-    };
-    const provider = new GatewayBoardProvider("agent:main:replacement", oldClient, false);
-    const mutation = provider.applyOps([]);
-
-    provider.attachClient(newClient, true);
-    await vi.waitFor(() => expect(provider.snapshot$.value).toEqual(current));
-    resolveMutation?.({ ...current, revision: 4 });
-    await mutation;
-
-    expect(provider.snapshot$.value).toEqual(current);
-  });
-
-  it("clears an old gateway snapshot before accepting a lower revision", async () => {
-    const oldSnapshot = {
-      sessionKey: "agent:main:gateway-swap",
-      revision: 5,
-      tabs: [{ tabId: "main", title: "Old", position: 0, chatDock: "right" as const }],
-      widgets: [],
-    };
-    const newSnapshot = {
-      sessionKey: "agent:main:gateway-swap",
-      revision: 1,
-      tabs: [{ tabId: "main", title: "New", position: 0, chatDock: "left" as const }],
-      widgets: [],
-    };
-    const oldClient = {
-      request: vi.fn(async () => oldSnapshot) as never,
-      addEventListener: () => () => {},
-    };
-    let resolveNewSnapshot: ((snapshot: BoardProvider["snapshot$"]["value"]) => void) | undefined;
-    const newClient = {
-      request: vi.fn(
-        () =>
-          new Promise<BoardProvider["snapshot$"]["value"]>((resolve) => {
-            resolveNewSnapshot = resolve;
-          }),
-      ) as never,
-      addEventListener: () => () => {},
-    };
-    const provider = new GatewayBoardProvider("agent:main:gateway-swap", oldClient);
-    await vi.waitFor(() => expect(provider.snapshot$.value).toEqual(oldSnapshot));
-
-    provider.attachClient(newClient, true);
-    expect(provider.snapshot$.value).toEqual({
-      sessionKey: "agent:main:gateway-swap",
-      revision: 0,
-      tabs: [],
-      widgets: [],
-    });
-    resolveNewSnapshot?.(newSnapshot);
-    await vi.waitFor(() => expect(provider.snapshot$.value).toEqual(newSnapshot));
-  });
-
-  it("retries a transient activation failure", async () => {
-    vi.useFakeTimers();
-    const snapshot = {
-      sessionKey: "agent:main:retry",
-      revision: 1,
-      tabs: [{ tabId: "main", title: "Main", position: 0, chatDock: "right" as const }],
-      widgets: [],
-    };
-    const request = vi
-      .fn()
-      .mockRejectedValueOnce(new Error("temporarily unavailable"))
-      .mockResolvedValue(snapshot);
-    const provider = new GatewayBoardProvider("agent:main:retry", {
-      request: request as never,
-      addEventListener: () => () => {},
-    });
-
-    await vi.advanceTimersByTimeAsync(0);
-    expect(request).toHaveBeenCalledTimes(1);
-    await vi.advanceTimersByTimeAsync(1_000);
-
-    expect(request).toHaveBeenCalledTimes(2);
-    expect(provider.snapshot$.value).toEqual(snapshot);
-  });
-
-  it("reactivates the same gateway client after reconnect", async () => {
-    const snapshot = {
-      sessionKey: "agent:main:reconnect",
-      revision: 1,
-      tabs: [],
-      widgets: [],
-    };
-    const request = vi.fn(async () => snapshot);
-    const client = {
-      request: request as never,
-      addEventListener: () => () => {},
-    };
-    const provider = new GatewayBoardProvider("agent:main:reconnect", client, false);
-
-    expect(request).not.toHaveBeenCalled();
-    provider.attachClient(client, true);
-    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
-    expect(provider.snapshot$.value).toEqual(snapshot);
-  });
-
-  it("wakes a pending refresh backoff when the gateway reconnects", async () => {
-    vi.useFakeTimers();
-    const snapshot = {
-      sessionKey: "agent:main:reconnect-backoff",
-      revision: 1,
-      tabs: [],
-      widgets: [],
-    };
-    const request = vi
-      .fn()
-      .mockRejectedValueOnce(new Error("temporarily unavailable"))
-      .mockResolvedValue(snapshot);
-    const client = {
-      request: request as never,
-      addEventListener: () => () => {},
-    };
-    const provider = new GatewayBoardProvider("agent:main:reconnect-backoff", client);
-    await vi.advanceTimersByTimeAsync(0);
-    expect(request).toHaveBeenCalledOnce();
-
-    provider.attachClient(client, false);
-    provider.attachClient(client, true);
-    await vi.advanceTimersByTimeAsync(0);
-
-    expect(request).toHaveBeenCalledTimes(2);
-    expect(provider.snapshot$.value).toEqual(snapshot);
-  });
-
-  it("retries a transient board.changed refresh failure", async () => {
-    vi.useFakeTimers();
-    let listener: ((event: { event: string; payload: unknown }) => void) | undefined;
-    const initial = {
-      sessionKey: "agent:main:event-retry",
-      revision: 1,
-      tabs: [{ tabId: "main", title: "Main", position: 0, chatDock: "right" as const }],
-      widgets: [],
-    };
-    const changed = { ...initial, revision: 2 };
-    const request = vi
-      .fn()
-      .mockResolvedValueOnce(initial)
-      .mockRejectedValueOnce(new Error("temporarily unavailable"))
-      .mockResolvedValue(changed);
-    const provider = new GatewayBoardProvider("agent:main:event-retry", {
-      request: request as never,
-      addEventListener: (next) => {
-        listener = next as typeof listener;
-        return () => {};
-      },
-    });
-    await vi.advanceTimersByTimeAsync(0);
-
-    listener?.({
-      event: "board.changed",
-      payload: { sessionKey: "agent:main:event-retry", revision: 2 },
-    });
-    await vi.advanceTimersByTimeAsync(0);
-    expect(provider.snapshot$.value.revision).toBe(1);
-    await vi.advanceTimersByTimeAsync(1_000);
-
-    expect(request).toHaveBeenCalledTimes(3);
-    expect(provider.snapshot$.value.revision).toBe(2);
-  });
-
-  it("preserves minted view metadata across layout and grant mutation snapshots", async () => {
-    const widget = {
-      name: "alpha",
-      tabId: "main",
-      contentKind: "html" as const,
-      sizeW: 6,
-      sizeH: 4,
-      position: 0,
-      grantState: "pending" as const,
-      revision: 1,
-      frameUrl: "/ticketed-frame",
-      viewTicket: "view-ticket",
-      viewTicketTtlMs: 60_000,
-      viewGeneration: "a".repeat(32),
-      sandboxUrl: "https://sandbox.example/host",
-      sandboxPort: 18_790,
-      sandboxOrigin: "https://sandbox.example:18790",
-    };
-    const initial = {
-      sessionKey: "agent:main:mutation-view-contract",
-      revision: 1,
-      tabs: [{ tabId: "main", title: "Main", position: 0, chatDock: "right" as const }],
-      widgets: [widget],
-    };
-    const layoutMutation = {
-      ...initial,
-      revision: 2,
-      widgets: [{ ...widget, sizeW: 8, frameUrl: undefined, viewTicket: undefined }].map(
-        ({
-          frameUrl: _frameUrl,
-          viewTicket: _viewTicket,
-          viewTicketTtlMs: _viewTicketTtlMs,
-          viewGeneration: _viewGeneration,
-          sandboxUrl: _sandboxUrl,
-          sandboxPort: _sandboxPort,
-          sandboxOrigin: _sandboxOrigin,
-          ...plainWidget
-        }) => plainWidget,
-      ),
-    };
-    const grantMutation = {
-      ...layoutMutation,
-      revision: 3,
-      widgets: [{ ...layoutMutation.widgets[0]!, grantState: "granted" as const }],
-    };
-    const request = vi
-      .fn()
-      .mockResolvedValueOnce(initial)
-      .mockResolvedValueOnce(layoutMutation)
-      .mockResolvedValueOnce(grantMutation);
-    const provider = new GatewayBoardProvider("agent:main:mutation-view-contract", {
-      request: request as never,
-      addEventListener: () => () => {},
-    });
-    await vi.waitFor(() => expect(provider.snapshot$.value).toEqual(initial));
-
-    await provider.applyOps([{ kind: "widget_resize", name: "alpha", sizeW: 8, sizeH: 4 }]);
-    await provider.grant("alpha", "granted");
-
-    expect(provider.snapshot$.value.widgets[0]).toEqual({
-      ...widget,
-      sizeW: 8,
-      grantState: "granted",
-    });
-  });
-
-  it("passes mutations through and surfaces board commands", async () => {
-    let listener: ((event: { event: string; payload: unknown }) => void) | undefined;
-    const empty = { sessionKey: "agent:main:live", revision: 0, tabs: [], widgets: [] };
-    const pinned = {
-      sessionKey: "agent:main:live",
-      revision: 1,
-      tabs: [{ tabId: "main", title: "Main", position: 0, chatDock: "right" as const }],
-      widgets: [
-        {
-          name: "canvas-cv-1",
-          tabId: "main",
-          contentKind: "html" as const,
-          sizeW: 6,
-          sizeH: 4,
-          position: 0,
-          grantState: "none" as const,
-          revision: 1,
-          instanceId: "canvas-instance",
-          frameUrl: "/frame",
-        },
-      ],
-    };
-    let getCount = 0;
-    const request = vi.fn(async (method: string) => {
-      if (method === "board.get") {
-        getCount += 1;
-        return getCount === 1 ? empty : pinned;
-      }
-      return pinned;
-    });
-    const provider = new GatewayBoardProvider("agent:main:live", {
-      request: request as never,
-      addEventListener: (next) => {
-        listener = next as typeof listener;
-        return () => {};
-      },
-    });
-    await vi.waitFor(() => expect(request).toHaveBeenCalledWith("board.get", expect.anything()));
-    const command = vi.fn();
-    provider.events.subscribe(command);
-
-    await provider.applyOps([{ kind: "tab_update", tabId: "main", chatDock: "left" }]);
-    await provider.grant("canvas-cv-1", "granted");
-    const longTitle = "Pinned ".repeat(20).trim();
-    await provider.pinWidget({ docId: "cv-1", title: longTitle });
-    await provider.pinMcpApp({
-      viewId: "mcp-app-source",
-      name: "mcp-app-opaque",
-      title: "App status",
-      tabId: "main",
-      size: "md",
-      after: "canvas-cv-1",
-    });
-    listener?.({
-      event: "board.command",
-      payload: {
-        sessionKey: "agent:main:live",
-        command: { kind: "focus_tab", tabId: "main" },
-      },
-    });
-
-    expect(request).toHaveBeenCalledWith("board.update", {
-      sessionKey: "agent:main:live",
-      ops: [{ kind: "tab_update", tabId: "main", chatDock: "left" }],
-    });
-    expect(request).toHaveBeenCalledWith("board.widget.grant", {
-      sessionKey: "agent:main:live",
-      name: "canvas-cv-1",
-      decision: "granted",
-      revision: 1,
-      instanceId: "canvas-instance",
-    });
-    expect(request).toHaveBeenCalledWith("board.widget.put", {
-      sessionKey: "agent:main:live",
-      name: "canvas-cv-1",
-      title: Array.from(longTitle).slice(0, 80).join(""),
-      content: { kind: "canvas-doc", docId: "cv-1" },
-    });
-    expect(request).toHaveBeenCalledWith("board.widget.put", {
-      sessionKey: "agent:main:live",
-      name: "mcp-app-opaque",
-      title: "App status",
-      content: { kind: "mcp-app", viewId: "mcp-app-source" },
-      placement: { tabId: "main", size: "md", after: "canvas-cv-1" },
-    });
-    expect(request.mock.calls.filter(([method]) => method === "board.get")).toHaveLength(1);
-    expect(provider.snapshot$.value).toEqual(pinned);
-    expect(command).toHaveBeenCalledWith({
-      sessionKey: "agent:main:live",
-      command: { kind: "focus_tab", tabId: "main" },
-    });
   });
 });

--- a/ui/src/lib/board/provider.test.ts
+++ b/ui/src/lib/board/provider.test.ts
@@ -161,7 +161,7 @@ describe("board providers", () => {
     const sessionKey = "agent:main:provisional-provider";
     recordSessionBoardAvailability(sessionKey, true);
     const lease = acquireBoardProviderForSession(sessionKey, {
-      request: vi.fn(() => new Promise(() => undefined)) as never,
+      request: vi.fn(() => new Promise(() => {})) as never,
       addEventListener: () => () => {},
     });
 

--- a/ui/src/lib/board/provider.ts
+++ b/ui/src/lib/board/provider.ts
@@ -18,9 +18,11 @@ import {
   type BoardEventStream,
   type BoardSnapshotSignal,
 } from "./provider-signals.ts";
+import type { BoardProvider } from "./provider-types.ts";
 import type { BoardWidgetAppViewState } from "./view-types.ts";
 import { canvasWidgetNameForDocument, mcpAppWidgetNameForViewId } from "./widget-names.ts";
 export type { BoardCommandEvent };
+export type { BoardProvider } from "./provider-types.ts";
 export type { BoardViewCallbacks, BoardWidgetAppViewState } from "./view-types.ts";
 export { canvasWidgetNameForDocument, mcpAppWidgetNameForViewId } from "./widget-names.ts";
 export { GatewayBoardProvider } from "./gateway-provider.ts";
@@ -37,24 +39,6 @@ type BoardPinPlacement = {
 
 type BoardPinWidgetInput = BoardPinPlacement & { docId: string };
 type BoardPinMcpAppInput = BoardPinPlacement & { viewId: string };
-
-export type BoardProvider = {
-  readonly sessionKey: string;
-  readonly canMutate: boolean;
-  readonly canGrant: boolean;
-  readonly canPinWidgets: boolean;
-  readonly canPinMcpApps: boolean;
-  readonly snapshot$: BoardSnapshotSignal<BoardSnapshot>;
-  applyOps(ops: BoardOp[]): Promise<void>;
-  grant(name: string, decision: "granted" | "rejected"): Promise<void>;
-  pinWidget(input: BoardPinWidgetInput): Promise<void>;
-  pinMcpApp(input: BoardPinMcpAppInput): Promise<void>;
-  widgetFrameUrl(name: string, revision: number): string;
-  refreshWidgetFrame(name: string): Promise<void>;
-  widgetAppView(name: string, revision: number): Promise<BoardWidgetAppViewState>;
-  refreshWidgetAppView(name: string, revision: number): Promise<BoardWidgetAppViewState>;
-  readonly events: BoardEventStream<BoardCommandEvent>;
-};
 
 function emptySnapshot(sessionKey: string): BoardSnapshot {
   return { sessionKey, revision: 0, tabs: [], widgets: [] };

--- a/ui/src/lib/board/provider.ts
+++ b/ui/src/lib/board/provider.ts
@@ -1,11 +1,8 @@
 import type {
-  BoardChangedEvent,
   BoardCommand,
   BoardCommandEvent,
   BoardOp,
   BoardSnapshot,
-  BoardWidgetAppViewResult,
-  BoardWidget,
 } from "@openclaw/gateway-protocol";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import { t } from "../../i18n/index.ts";
@@ -13,7 +10,7 @@ import {
   buildAgentMainSessionKey,
   normalizeSessionKeyForUiComparison,
 } from "../sessions/session-key.ts";
-import { BoardMcpAppViewCache } from "./mcp-app-view-cache.ts";
+import { GatewayBoardProvider } from "./gateway-provider.ts";
 import { applyMockBoardOp, normalizeMockBoardSnapshot } from "./mock-ops.ts";
 import {
   EventStream,
@@ -23,13 +20,10 @@ import {
 } from "./provider-signals.ts";
 import type { BoardWidgetAppViewState } from "./view-types.ts";
 import { canvasWidgetNameForDocument, mcpAppWidgetNameForViewId } from "./widget-names.ts";
-import {
-  copyBoardWidgetTicketReceipt,
-  recordBoardWidgetTicketReceipt,
-} from "./widget-ticket-lifetime.ts";
 export type { BoardCommandEvent };
 export type { BoardViewCallbacks, BoardWidgetAppViewState } from "./view-types.ts";
 export { canvasWidgetNameForDocument, mcpAppWidgetNameForViewId } from "./widget-names.ts";
+export { GatewayBoardProvider } from "./gateway-provider.ts";
 
 type BoardGatewayClient = Pick<GatewayBrowserClient, "request" | "addEventListener">;
 
@@ -46,6 +40,8 @@ type BoardPinMcpAppInput = BoardPinPlacement & { viewId: string };
 
 export type BoardProvider = {
   readonly sessionKey: string;
+  readonly canMutate: boolean;
+  readonly canGrant: boolean;
   readonly canPinWidgets: boolean;
   readonly canPinMcpApps: boolean;
   readonly snapshot$: BoardSnapshotSignal<BoardSnapshot>;
@@ -125,6 +121,8 @@ export function boardExists(snapshot: BoardSnapshot): boolean {
 }
 
 class NullProvider implements BoardProvider {
+  readonly canMutate = false;
+  readonly canGrant = false;
   readonly canPinWidgets = false;
   readonly canPinMcpApps = false;
   readonly snapshot$: BoardSnapshotSignal<BoardSnapshot>;
@@ -162,6 +160,8 @@ class NullProvider implements BoardProvider {
 }
 
 class MockBoardProvider implements BoardProvider {
+  readonly canMutate = true;
+  readonly canGrant = true;
   readonly canPinWidgets = true;
   readonly canPinMcpApps = true;
   readonly snapshot$: BoardSnapshotSignal<BoardSnapshot>;
@@ -293,388 +293,10 @@ class MockBoardProvider implements BoardProvider {
   }
 }
 
-export class GatewayBoardProvider implements BoardProvider {
-  readonly snapshot$: BoardSnapshotSignal<BoardSnapshot>;
-  readonly events: BoardEventStream<BoardCommandEvent>;
-  private readonly snapshotSignal: ValueSignal<BoardSnapshot>;
-  private readonly eventStream = new EventStream<BoardCommandEvent>();
-  private client: BoardGatewayClient;
-  private clientGeneration = 0;
-  private unsubscribe: (() => void) | undefined;
-  private refreshLoop: Promise<void> | undefined;
-  private refreshRequested = false;
-  private readonly changedWidgets = new Set<string>();
-  private stateGeneration = 0;
-  private connected = false;
-  private wakeRetryDelay: (() => void) | undefined;
-  private readonly appViews = new BoardMcpAppViewCache();
-
-  constructor(
-    readonly sessionKey: string,
-    client: BoardGatewayClient,
-    connected = true,
-    public canPinWidgets = true,
-    public canPinMcpApps = false,
-  ) {
-    this.snapshotSignal = new ValueSignal(emptySnapshot(sessionKey));
-    this.snapshot$ = this.snapshotSignal;
-    this.events = this.eventStream;
-    this.client = client;
-    this.connected = connected;
-    this.subscribe(client);
-    if (connected) {
-      void this.activate();
-    }
-  }
-
-  attachClient(
-    client: BoardGatewayClient,
-    connected = true,
-    canPinWidgets = true,
-    canPinMcpApps = false,
-  ): void {
-    const connectionActivated = connected && !this.connected;
-    this.connected = connected;
-    this.canPinWidgets = canPinWidgets;
-    this.canPinMcpApps = canPinMcpApps;
-    if (client === this.client) {
-      if (connectionActivated) {
-        void this.activate();
-      }
-      return;
-    }
-    this.unsubscribe?.();
-    this.client = client;
-    this.clientGeneration += 1;
-    this.stateGeneration += 1;
-    this.changedWidgets.clear();
-    this.appViews.clear();
-    this.snapshotSignal.set(emptySnapshot(this.sessionKey));
-    this.subscribe(client);
-    if (connected) {
-      void this.activate();
-    }
-  }
-
-  activate(): Promise<void> {
-    return this.requestRefresh();
-  }
-
-  async applyOps(ops: BoardOp[]): Promise<void> {
-    await this.mutate("board.update", {
-      sessionKey: this.sessionKey,
-      ops,
-    });
-  }
-
-  async grant(name: string, decision: "granted" | "rejected"): Promise<void> {
-    const widget = this.snapshotSignal.value.widgets.find((candidate) => candidate.name === name);
-    if (!widget) {
-      void this.requestRefresh();
-      throw new Error(`Dashboard widget not found: ${name}`);
-    }
-    await this.mutate("board.widget.grant", {
-      sessionKey: this.sessionKey,
-      name,
-      decision,
-      revision: widget.revision,
-      ...(widget.instanceId ? { instanceId: widget.instanceId } : {}),
-    });
-  }
-
-  async pinWidget(input: BoardPinWidgetInput): Promise<void> {
-    const name = input.name ?? canvasWidgetNameForDocument(input.docId);
-    const title = boardWidgetTitle(input.title);
-    await this.mutate(
-      "board.widget.put",
-      {
-        sessionKey: this.sessionKey,
-        name,
-        ...(title ? { title } : {}),
-        content: { kind: "canvas-doc", docId: input.docId },
-        ...(input.tabId || input.size || input.after
-          ? {
-              placement: {
-                ...(input.tabId ? { tabId: input.tabId } : {}),
-                ...(input.size ? { size: input.size } : {}),
-                ...(input.after ? { after: input.after } : {}),
-              },
-            }
-          : {}),
-      },
-      name,
-    );
-  }
-
-  async pinMcpApp(input: BoardPinMcpAppInput): Promise<void> {
-    const name = input.name ?? mcpAppWidgetNameForViewId(input.viewId);
-    const title = boardWidgetTitle(input.title);
-    await this.mutate(
-      "board.widget.put",
-      {
-        sessionKey: this.sessionKey,
-        name,
-        ...(title ? { title } : {}),
-        content: { kind: "mcp-app", viewId: input.viewId },
-        ...(input.tabId || input.size || input.after
-          ? {
-              placement: {
-                ...(input.tabId ? { tabId: input.tabId } : {}),
-                ...(input.size ? { size: input.size } : {}),
-                ...(input.after ? { after: input.after } : {}),
-              },
-            }
-          : {}),
-      },
-      name,
-    );
-  }
-
-  widgetFrameUrl(name: string, revision: number): string {
-    return (
-      this.snapshotSignal.value.widgets.find(
-        (widget) => widget.name === name && widget.revision === revision,
-      )?.frameUrl ?? ""
-    );
-  }
-
-  refreshWidgetFrame(name: string): Promise<void> {
-    return this.requestRefresh(name);
-  }
-
-  async widgetAppView(name: string, revision: number): Promise<BoardWidgetAppViewState> {
-    return await this.resolveWidgetAppView(name, revision, false);
-  }
-
-  async refreshWidgetAppView(name: string, revision: number): Promise<BoardWidgetAppViewState> {
-    return await this.resolveWidgetAppView(name, revision, true);
-  }
-
-  private async resolveWidgetAppView(
-    name: string,
-    revision: number,
-    force: boolean,
-  ): Promise<BoardWidgetAppViewState> {
-    const widget = this.snapshotSignal.value.widgets.find(
-      (candidate) =>
-        candidate.name === name &&
-        candidate.revision === revision &&
-        candidate.contentKind === "mcp-app",
-    );
-    if (!widget) {
-      return { status: "stale", error: "Dashboard MCP App widget unavailable" };
-    }
-    const client = this.client;
-    return await this.appViews.resolve(
-      widget,
-      async () =>
-        await client.request<BoardWidgetAppViewResult>("board.widget.appView", {
-          sessionKey: this.sessionKey,
-          name,
-          revision,
-          ...(widget.instanceId ? { instanceId: widget.instanceId } : {}),
-        }),
-      force,
-    );
-  }
-
-  private subscribe(client: BoardGatewayClient): void {
-    this.unsubscribe = client.addEventListener((event) => {
-      if (event.event === "board.changed") {
-        const payload = event.payload as Partial<BoardChangedEvent> | undefined;
-        if (payload && this.matchesSession(payload.sessionKey)) {
-          this.stateGeneration += 1;
-          void this.requestRefresh(payload.widget);
-        }
-        return;
-      }
-      if (event.event === "board.command") {
-        const payload = event.payload as Partial<BoardCommandEvent> | undefined;
-        if (payload?.command && this.matchesSession(payload.sessionKey)) {
-          this.eventStream.emit({ sessionKey: this.sessionKey, command: payload.command });
-        }
-      }
-    });
-  }
-
-  private matchesSession(sessionKey: string | undefined): boolean {
-    return (
-      typeof sessionKey === "string" &&
-      normalizeSessionKeyForUiComparison(sessionKey) ===
-        normalizeSessionKeyForUiComparison(this.sessionKey)
-    );
-  }
-
-  private requestRefresh(changedWidget?: string): Promise<void> {
-    this.refreshRequested = true;
-    if (changedWidget) {
-      this.changedWidgets.add(changedWidget);
-    }
-    this.wakeRetryDelay?.();
-    this.refreshLoop ??= this.runRefreshLoop().finally(() => {
-      this.refreshLoop = undefined;
-      if (this.refreshRequested) {
-        void this.requestRefresh();
-      }
-    });
-    return this.refreshLoop;
-  }
-
-  private async runRefreshLoop(): Promise<void> {
-    const retry = { delayMs: 1_000 };
-    while (this.refreshRequested) {
-      this.refreshRequested = false;
-      const changedWidgets = new Set(this.changedWidgets);
-      this.changedWidgets.clear();
-      const client = this.client;
-      const stateGeneration = this.stateGeneration;
-      try {
-        const snapshot = await client.request<BoardSnapshot>("board.get", {
-          sessionKey: this.sessionKey,
-        });
-        if (client !== this.client) {
-          this.refreshRequested = true;
-          continue;
-        }
-        if (stateGeneration !== this.stateGeneration) {
-          this.refreshRequested = true;
-          for (const name of changedWidgets) {
-            this.changedWidgets.add(name);
-          }
-          continue;
-        }
-        this.setSnapshot(snapshot, changedWidgets);
-        retry.delayMs = 1_000;
-      } catch {
-        this.refreshRequested = true;
-        if (client !== this.client) {
-          continue;
-        }
-        for (const name of changedWidgets) {
-          this.changedWidgets.add(name);
-        }
-        const delayMs = retry.delayMs;
-        // Carry backoff across failed loop iterations; successful refreshes reset it above.
-        retry.delayMs = Math.min(delayMs * 2, 30_000);
-        await this.waitForRetry(delayMs);
-        continue;
-      }
-    }
-  }
-
-  private waitForRetry(delayMs: number): Promise<void> {
-    return new Promise((resolve) => {
-      let timer: ReturnType<typeof setTimeout> | undefined;
-      const finish = () => {
-        if (!timer) {
-          return;
-        }
-        clearTimeout(timer);
-        timer = undefined;
-        if (this.wakeRetryDelay === finish) {
-          this.wakeRetryDelay = undefined;
-        }
-        resolve();
-      };
-      timer = setTimeout(finish, delayMs);
-      this.wakeRetryDelay = finish;
-    });
-  }
-
-  private async mutate(
-    method: "board.update" | "board.widget.grant" | "board.widget.put",
-    params: Record<string, unknown>,
-    changedWidget?: string,
-  ): Promise<void> {
-    const client = this.client;
-    const clientGeneration = this.clientGeneration;
-    const stateGeneration = ++this.stateGeneration;
-    try {
-      const snapshot = await client.request<BoardSnapshot>(method, params);
-      if (
-        client === this.client &&
-        clientGeneration === this.clientGeneration &&
-        stateGeneration === this.stateGeneration
-      ) {
-        this.stateGeneration += 1;
-        this.setSnapshot(snapshot, changedWidget ? new Set([changedWidget]) : new Set(), true);
-      }
-    } catch (error) {
-      if (
-        client === this.client &&
-        clientGeneration === this.clientGeneration &&
-        stateGeneration === this.stateGeneration
-      ) {
-        void this.requestRefresh();
-      }
-      throw error;
-    }
-  }
-
-  private setSnapshot(
-    snapshot: BoardSnapshot,
-    changedWidgets = new Set<string>(),
-    preserveMissingViewContracts = false,
-  ): void {
-    const receivedAtMs = Date.now();
-    const previousWidgets = new Map(
-      this.snapshotSignal.value.widgets.map((widget) => [widget.name, widget]),
-    );
-    const widgets = snapshot.widgets.map((widget) => {
-      const previous = previousWidgets.get(widget.name);
-      if (
-        preserveMissingViewContracts &&
-        previous &&
-        !changedWidgets.has(widget.name) &&
-        previous.revision === widget.revision &&
-        previous.instanceId === widget.instanceId &&
-        widget.viewGeneration === undefined
-      ) {
-        // Mutation snapshots contain board state but not the view contract minted
-        // by board.get. Keep that contract only while the document revision matches.
-        const preserved = preserveBoardWidgetViewContract(widget, previous);
-        copyBoardWidgetTicketReceipt(preserved, previous, receivedAtMs);
-        return preserved;
-      }
-      if (
-        previous &&
-        !changedWidgets.has(widget.name) &&
-        previous.revision === widget.revision &&
-        previous.instanceId === widget.instanceId &&
-        previous.viewGeneration === widget.viewGeneration &&
-        !widget.sandboxUrl &&
-        previous.frameUrl
-      ) {
-        const preserved = { ...widget, frameUrl: previous.frameUrl };
-        recordBoardWidgetTicketReceipt(preserved, receivedAtMs);
-        return preserved;
-      }
-      recordBoardWidgetTicketReceipt(widget, receivedAtMs);
-      return widget;
-    });
-    this.appViews.prune(widgets);
-    this.snapshotSignal.set({ ...snapshot, widgets });
-  }
-}
-
-function preserveBoardWidgetViewContract(widget: BoardWidget, previous: BoardWidget): BoardWidget {
-  return {
-    ...widget,
-    ...(previous.frameUrl !== undefined ? { frameUrl: previous.frameUrl } : {}),
-    ...(previous.viewTicket !== undefined ? { viewTicket: previous.viewTicket } : {}),
-    ...(previous.viewTicketTtlMs !== undefined
-      ? { viewTicketTtlMs: previous.viewTicketTtlMs }
-      : {}),
-    ...(previous.viewGeneration !== undefined ? { viewGeneration: previous.viewGeneration } : {}),
-    ...(previous.sandboxUrl !== undefined ? { sandboxUrl: previous.sandboxUrl } : {}),
-    ...(previous.sandboxPort !== undefined ? { sandboxPort: previous.sandboxPort } : {}),
-    ...(previous.sandboxOrigin !== undefined ? { sandboxOrigin: previous.sandboxOrigin } : {}),
-  };
-}
-
 const nullProviders = new Map<string, NullProvider>();
 const mockProviders = new Map<string, MockBoardProvider>();
-const gatewayProviders = new Map<string, GatewayBoardProvider>();
+const gatewayProviders = new Map<string, { provider: GatewayBoardProvider; consumers: number }>();
+const boardAvailability = new Map<string, boolean>();
 let mockProviderScope: object | null = null;
 
 function resolveMockBoardScope(): object | null {
@@ -693,7 +315,7 @@ function isMockBoardSession(sessionKey: string): boolean {
   return /^agent:[^:]+:[^:]+$/u.test(sessionKey);
 }
 
-function boardProviderCacheKey(sessionKey: string): string {
+export function boardProviderCacheKey(sessionKey: string): string {
   const normalized = normalizeSessionKeyForUiComparison(sessionKey);
   return normalized === "main" ? buildAgentMainSessionKey({ agentId: "main" }) : normalized;
 }
@@ -705,6 +327,8 @@ export function boardProviderForSession(
   connected = true,
   canPinWidgets = available,
   canPinMcpApps = false,
+  canMutate = available,
+  canGrant = available,
 ): BoardProvider {
   const key = boardProviderCacheKey(sessionKey);
   const mockScope = resolveMockBoardScope();
@@ -729,16 +353,32 @@ export function boardProviderForSession(
     return provider;
   }
   if (client) {
-    let provider = gatewayProviders.get(key);
-    if (!provider) {
-      provider = new GatewayBoardProvider(key, client, connected, canPinWidgets, canPinMcpApps);
-      gatewayProviders.set(key, provider);
+    let entry = gatewayProviders.get(key);
+    if (!entry) {
+      const provider = new GatewayBoardProvider(
+        key,
+        client,
+        connected,
+        canPinWidgets,
+        canPinMcpApps,
+        canMutate,
+        canGrant,
+      );
+      entry = { provider, consumers: 0 };
+      gatewayProviders.set(key, entry);
     } else {
-      provider.attachClient(client, connected, canPinWidgets, canPinMcpApps);
+      entry.provider.attachClient(
+        client,
+        connected,
+        canPinWidgets,
+        canPinMcpApps,
+        canMutate,
+        canGrant,
+      );
     }
-    return provider;
+    return entry.provider;
   }
-  const gatewayProvider = gatewayProviders.get(key);
+  const gatewayProvider = gatewayProviders.get(key)?.provider;
   if (gatewayProvider) {
     return gatewayProvider;
   }
@@ -750,6 +390,76 @@ export function boardProviderForSession(
   return provider;
 }
 
+export type BoardProviderLease = {
+  provider: BoardProvider;
+  release: () => void;
+};
+
+export function acquireBoardProviderForSession(
+  sessionKey: string,
+  client: BoardGatewayClient,
+  connected = true,
+  canPinWidgets = true,
+  canPinMcpApps = false,
+  canMutate = true,
+  canGrant = true,
+): BoardProviderLease {
+  const key = boardProviderCacheKey(sessionKey);
+  const provider = boardProviderForSession(
+    key,
+    client,
+    true,
+    connected,
+    canPinWidgets,
+    canPinMcpApps,
+    canMutate,
+    canGrant,
+  );
+  const entry = gatewayProviders.get(key);
+  if (!entry || entry.provider !== provider) {
+    return { provider, release: () => undefined };
+  }
+  entry.consumers += 1;
+  let released = false;
+  return {
+    provider,
+    release: () => {
+      if (released) {
+        return;
+      }
+      released = true;
+      const current = gatewayProviders.get(key);
+      if (!current || current.provider !== provider) {
+        return;
+      }
+      current.consumers -= 1;
+      if (current.consumers > 0) {
+        return;
+      }
+      if (current.provider.hasLoadedSnapshot) {
+        boardAvailability.set(key, boardExists(current.provider.snapshot$.value));
+      }
+      gatewayProviders.delete(key);
+      current.provider.dispose();
+    },
+  };
+}
+
+export function recordSessionBoardAvailability(sessionKey: string, available: boolean): boolean {
+  const key = boardProviderCacheKey(sessionKey);
+  const previous = boardAvailability.get(key);
+  boardAvailability.set(key, available);
+  return previous !== available;
+}
+
+export function clearSessionBoardAvailability(): boolean {
+  const changed = boardAvailability.size > 0;
+  boardAvailability.clear();
+  return changed;
+}
+
 export function sessionHasBoard(sessionKey: string): boolean {
-  return boardExists(boardProviderForSession(sessionKey).snapshot$.value);
+  const key = boardProviderCacheKey(sessionKey);
+  const provider = gatewayProviders.get(key)?.provider ?? mockProviders.get(key);
+  return provider ? boardExists(provider.snapshot$.value) : (boardAvailability.get(key) ?? false);
 }

--- a/ui/src/pages/chat/board-session-surface.test.ts
+++ b/ui/src/pages/chat/board-session-surface.test.ts
@@ -70,6 +70,8 @@ describe("board session shell", () => {
         dockSize: { height: 300, width: 420 },
         chat: html`<div data-test-chat>chat</div>`,
         divider: html`<div class="board-session-surface__divider" data-test-divider></div>`,
+        canMutate: true,
+        canGrant: true,
         callbacks: {
           applyOps: (ops) => provider.applyOps(ops),
           grant: (name, decision) => provider.grant(name, decision),
@@ -101,6 +103,8 @@ describe("board session shell", () => {
         dockSize: { height: 300, width: 420 },
         chat: html`<div data-test-chat>chat</div>`,
         divider: html`<div class="board-session-surface__divider"></div>`,
+        canMutate: true,
+        canGrant: true,
         callbacks: {
           applyOps: (ops) => provider.applyOps(ops),
           grant: (name, decision) => provider.grant(name, decision),
@@ -130,6 +134,8 @@ describe("board session shell", () => {
       dockSize: { height: 300, width: 420 },
       chat: html`<div data-test-chat>chat</div>`,
       divider: html`<div class="board-session-surface__divider"></div>`,
+      canMutate: true,
+      canGrant: true,
       callbacks: {
         applyOps: (ops: Parameters<typeof provider.applyOps>[0]) => provider.applyOps(ops),
         grant: (...args: Parameters<typeof provider.grant>) => provider.grant(...args),

--- a/ui/src/pages/chat/board-session-surface.ts
+++ b/ui/src/pages/chat/board-session-surface.ts
@@ -22,6 +22,8 @@ type BoardSessionSurfaceProps = {
   dockSize: BoardChatDockSize;
   chat: TemplateResult;
   divider: TemplateResult;
+  canMutate: boolean;
+  canGrant: boolean;
   callbacks: BoardViewCallbacks;
   widgetFrameUrl: BoardWidgetFrameUrl;
   onDockChange: (dock: BoardTab["chatDock"]) => void;
@@ -139,6 +141,8 @@ function renderBoardView(props: BoardSessionSurfaceProps) {
         .widgetFrameUrl=${props.widgetFrameUrl}
         .callbacks=${props.callbacks}
         .sessions=${props.sessions}
+        .canMutate=${props.canMutate}
+        .canGrant=${props.canGrant}
       ></openclaw-board-view>
     </div>
   `;
@@ -161,6 +165,7 @@ export function renderBoardSessionSurface(props: BoardSessionSurfaceProps) {
         aria-label=${t("chat.board.reopenChat")}
         title=${t("chat.board.reopenChat")}
         ?hidden=${props.dock !== "hidden"}
+        ?disabled=${!props.canMutate}
         @click=${() => props.onDockChange(props.reopenDock)}
       >
         ${icons.messageSquare}<span>${t("chat.board.chatFace")}</span>

--- a/ui/src/pages/chat/chat-pane-board.test.ts
+++ b/ui/src/pages/chat/chat-pane-board.test.ts
@@ -381,6 +381,53 @@ describe("chat pane board shell", () => {
     }
   });
 
+  it.each([
+    {
+      profile: "read-only",
+      scopes: ["operator.read"],
+      canMutate: false,
+      canGrant: false,
+    },
+    {
+      profile: "writer with approvals",
+      scopes: ["operator.read", "operator.write", "operator.approvals"],
+      canMutate: true,
+      canGrant: true,
+    },
+  ])("derives board actions from the $profile connection scopes", (profile) => {
+    window.history.replaceState({}, "", "/");
+    const pane = createTestPane();
+    const sessionKey = `agent:main:scope-${profile.profile.replaceAll(" ", "-")}`;
+    const client = {
+      request: vi.fn(async () => ({ sessionKey, revision: 0, tabs: [], widgets: [] })),
+      addEventListener: vi.fn(() => () => {}),
+    } as unknown as GatewayBrowserClient;
+    pane.state.sessionKey = sessionKey;
+    pane.context = {
+      ...pane.context,
+      gateway: {
+        ...pane.context.gateway,
+        snapshot: {
+          client,
+          connected: true,
+          hello: {
+            auth: { role: "operator", scopes: profile.scopes },
+            features: {
+              methods: ["board.get", "board.widget.appView", "board.widget.put"],
+              capabilities: ["board-widget-put-canvas-doc"],
+            },
+          },
+        } as never,
+      },
+    };
+
+    const provider = pane.resolveBoardProvider();
+    expect(provider.canMutate).toBe(profile.canMutate);
+    expect(provider.canGrant).toBe(profile.canGrant);
+    expect(provider.canPinWidgets).toBe(profile.canMutate);
+    expect(provider.canPinMcpApps).toBe(profile.canMutate);
+  });
+
   it("uses the side dock width for rail and detail breakpoints", () => {
     expect(
       resolveBoardChatLayoutWidth({

--- a/ui/src/pages/chat/chat-pane.ts
+++ b/ui/src/pages/chat/chat-pane.ts
@@ -33,7 +33,11 @@ import {
   type ApplicationContext,
   type ApplicationGatewaySnapshot,
 } from "../../app/context.ts";
-import { hasOperatorAdminAccess, hasOperatorWriteAccess } from "../../app/operator-access.ts";
+import {
+  hasOperatorAdminAccess,
+  hasOperatorApprovalsAccess,
+  hasOperatorWriteAccess,
+} from "../../app/operator-access.ts";
 import {
   cancelQuestionPrompt,
   createQuestionPromptState,
@@ -61,9 +65,12 @@ import { isCloudWorkerPlacementState } from "../../components/session-row-badges
 import { t } from "../../i18n/index.ts";
 import { resolveBoardChatLayoutWidth } from "../../lib/board/chat-layout.ts";
 import {
+  acquireBoardProviderForSession,
+  boardProviderCacheKey,
   boardProviderForSession,
   type BoardCommandEvent,
   type BoardProvider,
+  type BoardProviderLease,
   type BoardViewCallbacks,
 } from "../../lib/board/provider.ts";
 import {
@@ -393,6 +400,8 @@ class ChatPane extends OpenClawLightDomElement {
   @litState() private paneWidth = Number.POSITIVE_INFINITY;
   private paneResizeObserver: ResizeObserver | null = null;
   private connectedClient: GatewayBrowserClient | null = null;
+  private boardProviderLease: (BoardProviderLease & { sessionKey: string }) | undefined;
+  private boardProviderLifecycleConnected = false;
   private connectionGeneration = 0;
   @litState() private headerEditing = false;
   @litState() private headerRenameValue = "";
@@ -1518,21 +1527,70 @@ class ChatPane extends OpenClawLightDomElement {
       this.context?.gateway.snapshot.hello,
     );
     if (this.boardProvider) {
+      this.releaseBoardProviderLease();
       return this.boardProvider;
     }
     const gateway = this.context?.gateway.snapshot;
+    const available = !gateway || isGatewayMethodAdvertised(gateway, "board.get") !== false;
+    const canMutate = !gateway || hasOperatorWriteAccess(gateway.hello?.auth ?? null);
+    const canGrant = !gateway || hasOperatorApprovalsAccess(gateway.hello?.auth ?? null);
+    const canPinWidgets =
+      canMutate &&
+      (!gateway ||
+        isGatewayCapabilityAdvertised(gateway, GATEWAY_SERVER_CAPS.BOARD_WIDGET_PUT_CANVAS_DOC) ===
+          true);
+    const canPinMcpApps =
+      canMutate &&
+      (!gateway ||
+        (isGatewayMethodAdvertised(gateway, "board.widget.appView") === true &&
+          isGatewayMethodAdvertised(gateway, "board.widget.put") === true));
+    const client = gateway?.client;
+    if (this.boardProviderLifecycleConnected && client && available) {
+      const key = boardProviderCacheKey(sessionKey);
+      if (this.boardProviderLease?.sessionKey !== key) {
+        this.releaseBoardProviderLease();
+        this.boardProviderLease = {
+          ...acquireBoardProviderForSession(
+            key,
+            client,
+            gateway.connected,
+            canPinWidgets,
+            canPinMcpApps,
+            canMutate,
+            canGrant,
+          ),
+          sessionKey: key,
+        };
+      } else {
+        boardProviderForSession(
+          key,
+          client,
+          true,
+          gateway.connected,
+          canPinWidgets,
+          canPinMcpApps,
+          canMutate,
+          canGrant,
+        );
+      }
+      return this.boardProviderLease.provider;
+    }
+    this.releaseBoardProviderLease();
     return boardProviderForSession(
       sessionKey,
-      gateway?.client,
-      !gateway || isGatewayMethodAdvertised(gateway, "board.get") !== false,
+      client,
+      available,
       gateway?.connected ?? false,
-      !gateway ||
-        isGatewayCapabilityAdvertised(gateway, GATEWAY_SERVER_CAPS.BOARD_WIDGET_PUT_CANVAS_DOC) ===
-          true,
-      !gateway ||
-        (isGatewayMethodAdvertised(gateway, "board.widget.appView") === true &&
-          isGatewayMethodAdvertised(gateway, "board.widget.put") === true),
+      canPinWidgets,
+      canPinMcpApps,
+      canMutate,
+      canGrant,
     );
+  }
+
+  private releaseBoardProviderLease(): void {
+    this.boardProviderLease?.release();
+    this.boardProviderLease = undefined;
   }
 
   private resolveBoardSessionKey(snapshotSessionKey = ""): string {
@@ -1678,7 +1736,7 @@ class ChatPane extends OpenClawLightDomElement {
 
   private handleBoardDockChange(dock: BoardTab["chatDock"]): void {
     const board = this.resolveBoardView();
-    if (!board.activeTabId || board.activeTabReadOnly) {
+    if (!board.activeTabId || board.activeTabReadOnly || !board.provider.canMutate) {
       return;
     }
     const sessionKey = this.resolveBoardSessionKey(board.snapshot.sessionKey);
@@ -2086,7 +2144,9 @@ class ChatPane extends OpenClawLightDomElement {
   };
 
   override connectedCallback() {
+    this.boardProviderLifecycleConnected = true;
     super.connectedCallback();
+    this.requestUpdate();
     if (typeof ResizeObserver === "function") {
       this.paneResizeObserver = new ResizeObserver((entries) => {
         const width = entries.at(-1)?.contentRect.width;
@@ -2250,6 +2310,8 @@ class ChatPane extends OpenClawLightDomElement {
   }
 
   override disconnectedCallback() {
+    this.boardProviderLifecycleConnected = false;
+    this.releaseBoardProviderLease();
     this.settleResetConfirmation(false);
     this.paneResizeObserver?.disconnect();
     this.paneResizeObserver = null;
@@ -2973,7 +3035,7 @@ class ChatPane extends OpenClawLightDomElement {
         this.persistBoardSessionView({ face });
       }),
       boardDockAction: renderBoardDockMenu(
-        board.hasBoard && !board.activeTabReadOnly,
+        board.hasBoard && !board.activeTabReadOnly && board.provider.canMutate,
         board.face,
         board.dock,
         (dock) => this.handleBoardDockChange(dock),
@@ -3404,6 +3466,8 @@ class ChatPane extends OpenClawLightDomElement {
             divider: this.renderBoardDivider(
               board.dock === "hidden" ? board.reopenDock : board.dock,
             ),
+            canMutate: board.provider.canMutate,
+            canGrant: board.provider.canGrant,
             callbacks: {
               applyOps: (ops) => board.provider.applyOps(ops),
               grant: (name, decision) => board.provider.grant(name, decision),


### PR DESCRIPTION
## What Problem This Solves

Follow-ups from the stitch-PR review (#111218 inline findings) plus one deferred hardening — the polish pass on the now-complete session-dashboard program.

## Why This Change Was Made

- Board providers dispose their gateway subscriptions on final release (and reacquire cleanly) — closes a listener/retention leak across visited sessions.
- Pinning validates the wrapped document against the effective UTF-8 byte budget before any side effects, and pins before canvas-doc creation so failed pins leave no orphaned documents against the retention cap.
- All mutating board controls (pin, drag, resize, remove, grant, dock) are scope-gated: read-only operators see an honest read-only board instead of controls that fail server-side.
- Sidebar board glyphs work for sessions never opened in a pane via a lightweight cached `board.get` with event-driven refresh.
- Adds explicitly best-effort descendant-frame/WebRTC hardening to the widget sandbox bootstrap, documented as mitigation of the accepted residual (see `docs/web/dashboard-architecture.md`), not a boundary.

## User Impact

No new features; leak fix, honest permissions UX, sidebar correctness, safer pinning.

## Evidence

299 focused tests green (9 browser-only skips); `check-changed` typecheck/lint/format/architecture guards passed (trusted local fallback — Blacksmith capacity-queued); structured autoreview clean.
