### PR TITLE
fix(logging): keep JSON console output structured

### DIFF
--- a/src/logger.test.ts
+++ b/src/logger.test.ts
@@ -35,6 +35,20 @@ describe("logger helpers", () => {
     expect(error).toHaveBeenCalledTimes(1);
   });
 
+  it("routes bracket-prefixed messages through JSON subsystem logging", () => {
+    setLoggerOverride({ level: "silent", consoleLevel: "error", consoleStyle: "json" });
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    logError("[tools] exec failed");
+
+    expect(error).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(String(error.mock.calls[0]?.[0]))).toMatchObject({
+      level: "error",
+      subsystem: "tools",
+      message: "exec failed",
+    });
+  });
+
   it("only logs debug when verbose is enabled", () => {
     const logVerboseLocal = vi.spyOn(console, "log").mockImplementation(() => {});
     setVerbose(false);

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -6,15 +6,15 @@ import { getLogger } from "./logging/logger.js";
 import { createSubsystemLogger } from "./logging/subsystem.js";
 import { defaultRuntime, type RuntimeEnv } from "./runtime.js";
 
-const subsystemPrefixRe = /^([a-z][a-z0-9-]{1,20}):\s+(.*)$/i;
+const subsystemPrefixRe = /^(?:\[([a-z][a-z0-9-]{1,20})\]|([a-z][a-z0-9-]{1,20}):)\s+(.*)$/i;
 
 function splitSubsystem(message: string) {
   const match = message.match(subsystemPrefixRe);
   if (!match) {
     return null;
   }
-  const subsystem = match.at(1);
-  const rest = match.at(2);
+  const subsystem = match.at(1) ?? match.at(2);
+  const rest = match.at(3);
   if (subsystem === undefined || rest === undefined) {
     return null;
   }

--- a/src/logging/console-capture.test.ts
+++ b/src/logging/console-capture.test.ts
@@ -123,6 +123,35 @@ describe("enableConsoleCapture", () => {
     expect(firstArg.endsWith(` ${payload}`)).toBe(true);
   });
 
+  it("wraps console passthrough output when console style is JSON", () => {
+    setLoggerOverride({ level: "info", consoleLevel: "info", consoleStyle: "json" });
+    const warn = vi.fn();
+    console.warn = warn;
+    enableConsoleCapture();
+
+    console.warn("tool failed", { attempt: 1 });
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(firstMockArgAsString(warn))).toMatchObject({
+      level: "warn",
+      message: "tool failed { attempt: 1 }",
+    });
+  });
+
+  it("wraps forced stderr passthrough output when console style is JSON", () => {
+    setLoggerOverride({ level: "info", consoleLevel: "error", consoleStyle: "json" });
+    const stderrWrite = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    routeLogsToStderr();
+    enableConsoleCapture();
+
+    console.error(`Authorization: Bearer ${secret}`);
+
+    expect(stderrWrite).toHaveBeenCalledTimes(1);
+    const written = firstMockArgAsString(stderrWrite);
+    expect(JSON.parse(written)).toMatchObject({ level: "error" });
+    expect(written).not.toContain(secret);
+  });
+
   it("keeps diagnostics on stderr while runtime JSON stays on stdout", () => {
     setLoggerOverride({ level: "info", file: tempLogPath() });
     const stdoutWrite = vi.spyOn(process.stdout, "write").mockImplementation(() => true);

--- a/src/logging/console.ts
+++ b/src/logging/console.ts
@@ -185,6 +185,16 @@ export function formatConsoleTimestamp(style: ConsoleStyle): string {
   return formatTimestamp(now, { style: "long" });
 }
 
+function formatJsonConsolePassthrough(level: LogLevel, message: string): string {
+  return redactSensitiveText(
+    JSON.stringify({
+      time: formatConsoleTimestamp("json"),
+      level,
+      message: stripAnsi(message),
+    }),
+  );
+}
+
 function hasTimestampPrefix(value: string): boolean {
   return /^(?:\d{2}:\d{2}:\d{2}|\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})?)/.test(
     value,
@@ -255,11 +265,13 @@ export function enableConsoleCapture(): void {
         return;
       }
       const trimmed = stripAnsi(formatted).trimStart();
+      const consoleStyle = getConsoleSettings().style;
       const shouldPrefixTimestamp =
-        loggingState.consoleTimestampPrefix && trimmed.length > 0 && !hasTimestampPrefix(trimmed);
-      const timestamp = shouldPrefixTimestamp
-        ? formatConsoleTimestamp(getConsoleSettings().style)
-        : "";
+        consoleStyle !== "json" &&
+        loggingState.consoleTimestampPrefix &&
+        trimmed.length > 0 &&
+        !hasTimestampPrefix(trimmed);
+      const timestamp = shouldPrefixTimestamp ? formatConsoleTimestamp(consoleStyle) : "";
       try {
         const resolvedLogger = getLoggerLazy();
         // Map console levels to file logger
@@ -283,7 +295,12 @@ export function enableConsoleCapture(): void {
         // In --json mode, all console.* writes are diagnostics and should stay off stdout.
         try {
           const redacted = redactSensitiveText(formatted);
-          const line = timestamp ? `${timestamp} ${redacted}` : redacted;
+          const line =
+            consoleStyle === "json"
+              ? formatJsonConsolePassthrough(level, formatted)
+              : timestamp
+                ? `${timestamp} ${redacted}`
+                : redacted;
           process.stderr.write(`${line}\n`);
         } catch (err) {
           if (isEpipeError(err)) {
@@ -294,6 +311,10 @@ export function enableConsoleCapture(): void {
       } else {
         try {
           const redacted = redactSensitiveText(formatted);
+          if (consoleStyle === "json") {
+            orig.call(console, formatJsonConsolePassthrough(level, formatted));
+            return;
+          }
           if (!timestamp) {
             if (args.length === 0) {
               orig.apply(console, args as []);

--- a/src/logging/subsystem.test.ts
+++ b/src/logging/subsystem.test.ts
@@ -295,6 +295,20 @@ describe("createSubsystemLogger().isEnabled", () => {
     expect(written).toContain("sk-raw…3456");
   });
 
+  it("wraps raw subsystem output when console style is JSON", () => {
+    setLoggerOverride({ level: "silent", consoleLevel: "info", consoleStyle: "json" });
+    const logSpy = installConsoleMethodSpy("log");
+
+    createSubsystemLogger("gateway/auth").raw("raw diagnostic");
+
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(firstMockArgAsString(logSpy))).toMatchObject({
+      level: "info",
+      subsystem: "gateway/auth",
+      message: "raw diagnostic",
+    });
+  });
+
   it("keeps long-lived subsystem loggers on the current-day rolling file", () => {
     const logDir = path.dirname(logPathTracker.nextPath());
     const firstDay = path.join(logDir, "openclaw-2026-01-01.log");

--- a/src/logging/subsystem.ts
+++ b/src/logging/subsystem.ts
@@ -471,7 +471,19 @@ export function createSubsystemLogger(subsystem: string): SubsystemLogger {
         ) {
           return;
         }
-        writeConsoleLine("info", message);
+        const consoleSettings = getConsoleSettings();
+        writeConsoleLine(
+          "info",
+          consoleSettings.style === "json"
+            ? formatConsoleLine({
+                level: "info",
+                subsystem: resolvedSubsystem,
+                message,
+                style: "json",
+              })
+            : message,
+          { redacted: consoleSettings.style === "json" },
+        );
       }
     },
     child(name) {


### PR DESCRIPTION
Closes #111906

## What Problem This Solves

When `logging.consoleStyle: "json"` was selected, normal subsystem logger calls were structured JSON but three production console paths still emitted plain text: bracket-tagged root messages, captured native `console.*` output, and `SubsystemLogger.raw()`. Mixed output breaks JSON log collectors and line-oriented ingestion.

## Why This Change Was Made

- bracket-tagged root messages are routed through the matching subsystem logger
- captured console calls are wrapped as `{ time, level, message }`
- raw subsystem calls use the standard JSON subsystem envelope
- ANSI is stripped from captured JSON messages and sink redaction remains active
- pretty and compact behavior is unchanged

## Evidence

- Exact head: `4daf24f8299613f9aefa064f5c038952b66f1ecd`.
- Environment: isolated macOS source checkouts, Node.js 24.14.0.
- A standalone source-runtime probe invoked the production root logger, subsystem `raw()`, and captured native console path with JSON console style.
- On current `main` (`e0206b4967`), the three emitted lines were plain text and none parsed as JSON:

```text
PLAIN [tools] exec failed
PLAIN raw diagnostic
PLAIN tool failed { attempt: 1 }
```

- On exact candidate head, the identical production API calls emitted three JSON lines. `jq -cs` parsed all three and preserved the expected envelopes:

```json
{
  "lines": 3,
  "allJson": true,
  "events": [
    { "level": "error", "subsystem": "tools", "message": "exec failed" },
    { "level": "info", "subsystem": "gateway/auth", "message": "raw diagnostic" },
    { "level": "warn", "subsystem": null, "message": "tool failed { attempt: 1 }" }
  ]
}
```

- Focused validation:

```text
node scripts/run-vitest.mjs run src/logger.test.ts src/logging/console-capture.test.ts src/logging/subsystem.test.ts

Test Files  3 passed (3)
Tests       52 passed (52)
```

- The forced-stderr regression also verifies that output remains JSON while a bearer token is redacted.
- Scoped `oxfmt`, `oxlint`, and `git diff --check` passed.
- No config schema, file logging, or non-JSON formatting changes. A Docker collector was not required for the before/after probe because it validates the actual production formatter and sink output consumed by collectors.