### PR TITLE
fix(dashboard): make the board face scrollable

### DIFF
--- a/ui/src/styles/chat/board.css
+++ b/ui/src/styles/chat/board.css
@@ -75,12 +75,22 @@
   overflow: hidden;
 }
 
+/* Scroll owner for the board face. Widget/tab menus stay usable because
+   wa-popup renders them in the top layer, so this overflow cannot clip them.
+   Inline padding lives on .board-view below: macOS overlay scrollbars render
+   inside the scroll container's padding and would float away from the edge. */
 .board-session-surface__board > openclaw-board-view {
   display: block;
   flex: 1 1 0;
   min-width: 0;
   min-height: 0;
-  padding: 12px 16px 16px;
+  overflow-x: hidden;
+  overflow-y: auto;
+  padding: 12px 0 16px;
+}
+
+.board-session-surface__board .board-view {
+  padding-inline: 16px;
 }
 
 .board-session-surface__chat {


### PR DESCRIPTION
## What Problem This Solves

The session dashboard (board face) had no scroll container: `.board-session-surface__board` clips (`overflow: hidden`), and neither the board-view mount nor `.board-view`/`.board-grid` scrolled. A board taller than the pane was simply cut off — widgets past the fold were unreachable in every dock layout. Measured on a 6-widget fixture: 1751px of content in an 852px pane with `scrollTop` pinned at 0.

## Why This Change Was Made

The board-view mount inside the session surface (`.board-session-surface__board > openclaw-board-view`) becomes the scroll owner (`overflow-y: auto`, `overflow-x: hidden`). Two deliberate details:

- **Menus cannot be clipped**: `wa-dropdown` positions its menu through `wa-popup`, which renders in the top layer via the native Popover API (checked in `@awesome.me/webawesome` 3.10.0 source) and re-anchors on ancestor scroll via floating-ui `autoUpdate`. Verified live: the widget options menu opens fully while scrolled. A code comment records this invariant.
- **Inline padding moved to `.board-view`** (scoped to the surface): macOS overlay scrollbars render inside a scroll container's padding, which would float the thumb 16px off the pane edge — same pattern the chat pane uses (`ui/src/styles/chat/layout.css` scroll-container comment). Vertical padding stays on the scroll container; visual insets are unchanged from #111876.

Drag/resize gestures stay correct inside the scroll container: the gesture handlers derive cells from `event.clientX/Y` against fresh `getBoundingClientRect()`/`elementFromPoint` on every pointer move, so scrolled offsets never enter the math. The absolutely-positioned `.board-grid__append-zone` anchors to `.board-grid` and contributes to scrollable overflow as before.

## User Impact

Dashboards taller than the pane now scroll in every dock orientation and on mobile; previously hidden widgets are reachable. Widget/tab menus, drag, and resize behave unchanged.

## Evidence

Autoreview (Codex `gpt-5.6-sol`): clean. `oxfmt --check` + `git diff --check` clean. Live metrics on the 6-widget fixture — before: `{overflowY: "visible", scrollHeight: 1751, clientHeight: 852, scrollTopAfterSet: 0}` (unscrollable); after: `{overflowY: "auto", scrollHeight: 1767, clientHeight: 852, scrollTopAfterSet: 915}` (scrolls to bottom). Widget options menu verified un-clipped while scrolled.

| Before (stuck at top, widgets 4–6 unreachable) | After (top, scrollable) | After (scrolled to bottom) |
| --- | --- | --- |
| ![before](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/2026-07-dashboard-board-scroll/before-top.png) | ![after-top](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/2026-07-dashboard-board-scroll/after-top.png) | ![after-bottom](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/2026-07-dashboard-board-scroll/after-bottom.png) |

Captured against the mock-gateway dev harness with a temporary 6-widget `board.get` fixture (not committed).
