### PR TITLE
fix(media): apply SSRF guard to byteplus and runway generated video downloads

### DIFF
--- a/extensions/byteplus/video-generation-provider.test.ts
+++ b/extensions/byteplus/video-generation-provider.test.ts
@@ -5,13 +5,17 @@ import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 // Submit/poll transport is mocked locally so each test can inject the BytePlus task JSON
 // bodies, while readProviderJsonResponse is kept REAL (via importActual) so the byte-bounded
 // reader actually streams and cancels oversized bodies under test instead of a stub.
-const { postJsonRequestMock, fetchWithTimeoutMock, resolveApiKeyForProviderMock } = vi.hoisted(
-  () => ({
-    postJsonRequestMock: vi.fn(),
-    fetchWithTimeoutMock: vi.fn(),
-    resolveApiKeyForProviderMock: vi.fn(async () => ({ apiKey: "provider-key" })),
-  }),
-);
+const {
+  postJsonRequestMock,
+  fetchWithTimeoutMock,
+  guardedDownloadParamsMock,
+  resolveApiKeyForProviderMock,
+} = vi.hoisted(() => ({
+  postJsonRequestMock: vi.fn(),
+  fetchWithTimeoutMock: vi.fn(),
+  guardedDownloadParamsMock: vi.fn(),
+  resolveApiKeyForProviderMock: vi.fn(async () => ({ apiKey: "provider-key" })),
+}));
 
 vi.mock("openclaw/plugin-sdk/provider-auth-runtime", () => ({
   resolveApiKeyForProvider: resolveApiKeyForProviderMock,
@@ -53,19 +57,24 @@ vi.mock("openclaw/plugin-sdk/provider-http", async (importActual) => {
       }
       throw new Error(params.timeoutMessage);
     },
-    fetchProviderDownloadResponse: async (params: {
+    fetchGuardedProviderDownloadResponse: async (params: {
       url: string;
       init?: RequestInit;
       deadline: { deadlineAtMs?: number; timeoutMs?: number };
       fetchFn: typeof fetch;
-    }) =>
-      fetchWithTimeoutMock(
+      allowPrivateNetwork?: boolean;
+      dispatcherPolicy?: unknown;
+    }) => {
+      guardedDownloadParamsMock(params);
+      const response = await fetchWithTimeoutMock(
         params.url,
         params.init ?? {},
         params.deadline.deadlineAtMs === undefined
           ? (params.deadline.timeoutMs ?? 60_000)
           : Math.max(1, params.deadline.deadlineAtMs - Date.now()),
-      ),
+      );
+      return { response, release: async () => {} };
+    },
     assertOkOrThrowHttpError: async () => {},
     createProviderOperationDeadline: ({
       label,
@@ -125,6 +134,7 @@ beforeAll(async () => {
 afterEach(() => {
   postJsonRequestMock.mockReset();
   fetchWithTimeoutMock.mockReset();
+  guardedDownloadParamsMock.mockReset();
   resolveApiKeyForProviderMock.mockClear();
   vi.useRealTimers();
 });
@@ -267,6 +277,22 @@ describe("byteplus video generation provider", () => {
     expect(video.fileName).toBe("video-1.webm");
     const metadata = result.metadata as Record<string, unknown>;
     expect(metadata.taskId).toBe("task_123");
+  });
+
+  it("routes the generated video download through the SSRF-guarded fetch", async () => {
+    mockSuccessfulBytePlusTask();
+
+    await buildBytePlusVideoGenerationProvider().generateVideo({
+      provider: "byteplus",
+      model: "seedance-1-0-pro-250528",
+      prompt: "A lantern floats upward into the night sky",
+      cfg: {},
+    });
+
+    expect(guardedDownloadParamsMock).toHaveBeenCalledTimes(1);
+    const params = guardedDownloadParamsMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(params).toMatchObject({ provider: "byteplus", allowPrivateNetwork: false });
+    expect(params).toHaveProperty("dispatcherPolicy");
   });
 
   it("rejects generated video downloads that exceed the configured media cap", async () => {

--- a/extensions/byteplus/video-generation-provider.test.ts
+++ b/extensions/byteplus/video-generation-provider.test.ts
@@ -111,14 +111,17 @@ vi.mock("openclaw/plugin-sdk/provider-http", async (importActual) => {
       },
     resolveProviderOperationTimeoutMs: ({ defaultTimeoutMs }: { defaultTimeoutMs: number }) =>
       defaultTimeoutMs,
+    sanitizeConfiguredModelProviderRequest: (request: unknown) => request,
     resolveProviderHttpRequestConfig: (params: {
       baseUrl?: string;
       defaultBaseUrl: string;
       allowPrivateNetwork?: boolean;
       defaultHeaders?: Record<string, string>;
+      request?: { allowPrivateNetwork?: boolean };
     }) => ({
       baseUrl: params.baseUrl ?? params.defaultBaseUrl,
-      allowPrivateNetwork: params.allowPrivateNetwork === true,
+      allowPrivateNetwork:
+        (params.allowPrivateNetwork ?? params.request?.allowPrivateNetwork) === true,
       headers: new Headers(params.defaultHeaders),
       dispatcherPolicy: undefined,
     }),
@@ -293,6 +296,31 @@ describe("byteplus video generation provider", () => {
     const params = guardedDownloadParamsMock.mock.calls[0]?.[0] as Record<string, unknown>;
     expect(params).toMatchObject({ provider: "byteplus", allowPrivateNetwork: false });
     expect(params).toHaveProperty("dispatcherPolicy");
+  });
+
+  it("threads the configured allowPrivateNetwork opt-in into the guarded download", async () => {
+    mockSuccessfulBytePlusTask();
+
+    await buildBytePlusVideoGenerationProvider().generateVideo({
+      provider: "byteplus",
+      model: "seedance-1-0-pro-250528",
+      prompt: "A lantern floats upward into the night sky",
+      cfg: {
+        models: {
+          providers: {
+            byteplus: {
+              baseUrl: "https://ark.ap-southeast.bytepluses.com/api/v3",
+              models: [],
+              request: { allowPrivateNetwork: true },
+            },
+          },
+        },
+      },
+    });
+
+    expect(guardedDownloadParamsMock).toHaveBeenCalledTimes(1);
+    const params = guardedDownloadParamsMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(params).toMatchObject({ provider: "byteplus", allowPrivateNetwork: true });
   });
 
   it("rejects generated video downloads that exceed the configured media cap", async () => {

--- a/extensions/byteplus/video-generation-provider.ts
+++ b/extensions/byteplus/video-generation-provider.ts
@@ -16,6 +16,7 @@ import {
   readProviderJsonResponse,
   resolveProviderOperationTimeoutMs,
   resolveProviderHttpRequestConfig,
+  sanitizeConfiguredModelProviderRequest,
   type ProviderOperationTimeoutMs,
 } from "openclaw/plugin-sdk/provider-http";
 import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
@@ -284,7 +285,6 @@ export function buildBytePlusVideoGenerationProvider(): VideoGenerationProvider 
         resolveProviderHttpRequestConfig({
           baseUrl: resolveBytePlusVideoBaseUrl(req),
           defaultBaseUrl: BYTEPLUS_BASE_URL,
-          allowPrivateNetwork: false,
           defaultHeaders: {
             Authorization: `Bearer ${auth.apiKey}`,
             "Content-Type": "application/json",
@@ -292,6 +292,9 @@ export function buildBytePlusVideoGenerationProvider(): VideoGenerationProvider 
           provider: "byteplus",
           capability: "video",
           transport: "http",
+          request: sanitizeConfiguredModelProviderRequest(
+            req.cfg?.models?.providers?.byteplus?.request,
+          ),
         });
       const resolvedModel = normalizeOptionalString(req.model) || DEFAULT_BYTEPLUS_VIDEO_MODEL;
 

--- a/extensions/byteplus/video-generation-provider.ts
+++ b/extensions/byteplus/video-generation-provider.ts
@@ -10,7 +10,7 @@ import {
   assertOkOrThrowHttpError,
   createProviderOperationDeadline,
   createProviderOperationTimeoutResolver,
-  fetchProviderDownloadResponse,
+  fetchGuardedProviderDownloadResponse,
   pollProviderOperationJson,
   postJsonRequest,
   readProviderJsonResponse,
@@ -179,6 +179,8 @@ async function downloadBytePlusVideo(params: {
   timeoutMs?: ProviderOperationTimeoutMs;
   fetchFn: typeof fetch;
   maxBytes: number;
+  allowPrivateNetwork?: boolean;
+  dispatcherPolicy?: ReturnType<typeof resolveProviderHttpRequestConfig>["dispatcherPolicy"];
 }): Promise<GeneratedVideoAsset> {
   const deadline = createProviderOperationDeadline({
     timeoutMs: params.timeoutMs ?? DEFAULT_TIMEOUT_MS,
@@ -188,29 +190,35 @@ async function downloadBytePlusVideo(params: {
     deadline,
     defaultTimeoutMs: deadline.timeoutMs ?? DEFAULT_TIMEOUT_MS,
   });
-  const response = await fetchProviderDownloadResponse({
+  const { response, release } = await fetchGuardedProviderDownloadResponse({
     url: params.url,
     init: { method: "GET" },
     deadline,
     fetchFn: params.fetchFn,
     provider: "byteplus",
     requestFailedMessage: "BytePlus generated video download failed",
+    allowPrivateNetwork: params.allowPrivateNetwork,
+    dispatcherPolicy: params.dispatcherPolicy,
   });
-  const mimeType = normalizeOptionalString(response.headers.get("content-type")) ?? "video/mp4";
-  const buffer = await readResponseWithLimit(response, params.maxBytes, {
-    timeoutMs,
-    onTimeout: ({ timeoutMs: bodyTimeoutMs }) =>
-      new Error(
-        `BytePlus generated video download timed out after ${deadline.timeoutMs ?? bodyTimeoutMs}ms`,
-      ),
-    onOverflow: ({ maxBytes }) =>
-      new Error(`BytePlus generated video download exceeds ${maxBytes} bytes`),
-  });
-  return {
-    buffer,
-    mimeType,
-    fileName: `video-1.${extensionForMime(mimeType)?.slice(1) ?? "mp4"}`,
-  };
+  try {
+    const mimeType = normalizeOptionalString(response.headers.get("content-type")) ?? "video/mp4";
+    const buffer = await readResponseWithLimit(response, params.maxBytes, {
+      timeoutMs,
+      onTimeout: ({ timeoutMs: bodyTimeoutMs }) =>
+        new Error(
+          `BytePlus generated video download timed out after ${deadline.timeoutMs ?? bodyTimeoutMs}ms`,
+        ),
+      onOverflow: ({ maxBytes }) =>
+        new Error(`BytePlus generated video download exceeds ${maxBytes} bytes`),
+    });
+    return {
+      buffer,
+      mimeType,
+      fileName: `video-1.${extensionForMime(mimeType)?.slice(1) ?? "mp4"}`,
+    };
+  } finally {
+    await release();
+  }
 }
 
 /** Builds the BytePlus video generation provider registered by the plugin. */
@@ -379,6 +387,8 @@ export function buildBytePlusVideoGenerationProvider(): VideoGenerationProvider 
           }),
           fetchFn,
           maxBytes: resolveGeneratedMediaMaxBytes(req.cfg, "video"),
+          allowPrivateNetwork,
+          dispatcherPolicy,
         });
         return {
           videos: [video],

--- a/extensions/runway/video-generation-provider.test.ts
+++ b/extensions/runway/video-generation-provider.test.ts
@@ -6,7 +6,8 @@ import {
 import { expectExplicitVideoGenerationCapabilities } from "openclaw/plugin-sdk/provider-test-contracts";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 
-const { postJsonRequestMock, fetchWithTimeoutMock } = getProviderHttpMocks();
+const { postJsonRequestMock, fetchWithTimeoutMock, fetchGuardedProviderDownloadResponseMock } =
+  getProviderHttpMocks();
 
 let buildRunwayVideoGenerationProvider: typeof import("./video-generation-provider.js").buildRunwayVideoGenerationProvider;
 
@@ -141,6 +142,46 @@ describe("runway video generation provider", () => {
     expect(metadata.taskId).toBe("task-1");
     expect(metadata.status).toBe("SUCCEEDED");
     expect(metadata.endpoint).toBe("/v1/text_to_video");
+  });
+
+  it("routes the generated video download through the SSRF-guarded fetch", async () => {
+    postJsonRequestMock.mockResolvedValue({
+      response: streamedJsonResponse({ id: "task-1" }),
+      release: vi.fn(async () => {}),
+    });
+    fetchWithTimeoutMock
+      .mockResolvedValueOnce(
+        streamedJsonResponse({
+          id: "task-1",
+          status: "SUCCEEDED",
+          output: ["https://example.com/out.mp4"],
+        }),
+      )
+      .mockResolvedValueOnce({
+        arrayBuffer: async () => Buffer.from("mp4-bytes"),
+        headers: new Headers({ "content-type": "video/webm" }),
+      });
+
+    await buildRunwayVideoGenerationProvider().generateVideo({
+      provider: "runway",
+      model: "gen4.5",
+      prompt: "a tiny lobster DJ under neon lights",
+      cfg: {},
+      durationSeconds: 4,
+      aspectRatio: "16:9",
+    });
+
+    expect(fetchGuardedProviderDownloadResponseMock).toHaveBeenCalledTimes(1);
+    const params = fetchGuardedProviderDownloadResponseMock.mock.calls[0]?.[0] as Record<
+      string,
+      unknown
+    >;
+    expect(params).toMatchObject({
+      url: "https://example.com/out.mp4",
+      provider: "runway",
+      allowPrivateNetwork: false,
+    });
+    expect(params).toHaveProperty("dispatcherPolicy");
   });
 
   it("rejects generated video downloads that exceed the configured media cap", async () => {

--- a/extensions/runway/video-generation-provider.test.ts
+++ b/extensions/runway/video-generation-provider.test.ts
@@ -184,6 +184,51 @@ describe("runway video generation provider", () => {
     expect(params).toHaveProperty("dispatcherPolicy");
   });
 
+  it("threads the configured allowPrivateNetwork opt-in into the guarded download", async () => {
+    postJsonRequestMock.mockResolvedValue({
+      response: streamedJsonResponse({ id: "task-1" }),
+      release: vi.fn(async () => {}),
+    });
+    fetchWithTimeoutMock
+      .mockResolvedValueOnce(
+        streamedJsonResponse({
+          id: "task-1",
+          status: "SUCCEEDED",
+          output: ["https://example.com/out.mp4"],
+        }),
+      )
+      .mockResolvedValueOnce({
+        arrayBuffer: async () => Buffer.from("mp4-bytes"),
+        headers: new Headers({ "content-type": "video/webm" }),
+      });
+
+    await buildRunwayVideoGenerationProvider().generateVideo({
+      provider: "runway",
+      model: "gen4.5",
+      prompt: "a tiny lobster DJ under neon lights",
+      cfg: {
+        models: {
+          providers: {
+            runway: {
+              baseUrl: "https://api.dev.runwayml.com",
+              models: [],
+              request: { allowPrivateNetwork: true },
+            },
+          },
+        },
+      },
+      durationSeconds: 4,
+      aspectRatio: "16:9",
+    });
+
+    expect(fetchGuardedProviderDownloadResponseMock).toHaveBeenCalledTimes(1);
+    const params = fetchGuardedProviderDownloadResponseMock.mock.calls[0]?.[0] as Record<
+      string,
+      unknown
+    >;
+    expect(params).toMatchObject({ provider: "runway", allowPrivateNetwork: true });
+  });
+
   it("rejects generated video downloads that exceed the configured media cap", async () => {
     postJsonRequestMock.mockResolvedValue({
       response: streamedJsonResponse({ id: "task-too-large" }),

--- a/extensions/runway/video-generation-provider.ts
+++ b/extensions/runway/video-generation-provider.ts
@@ -13,6 +13,7 @@ import {
   readProviderJsonResponse,
   resolveProviderOperationTimeoutMs,
   resolveProviderHttpRequestConfig,
+  sanitizeConfiguredModelProviderRequest,
   type ProviderOperationTimeoutMs,
 } from "openclaw/plugin-sdk/provider-http";
 import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
@@ -407,6 +408,9 @@ export function buildRunwayVideoGenerationProvider(): VideoGenerationProvider {
           provider: "runway",
           capability: "video",
           transport: "http",
+          request: sanitizeConfiguredModelProviderRequest(
+            req.cfg?.models?.providers?.runway?.request,
+          ),
         });
       const { response, release } = await postJsonRequest({
         url: `${baseUrl}${endpoint}`,

--- a/extensions/runway/video-generation-provider.ts
+++ b/extensions/runway/video-generation-provider.ts
@@ -7,7 +7,7 @@ import {
   assertOkOrThrowHttpError,
   createProviderOperationDeadline,
   createProviderOperationTimeoutResolver,
-  fetchProviderDownloadResponse,
+  fetchGuardedProviderDownloadResponse,
   pollProviderOperationJson,
   postJsonRequest,
   readProviderJsonResponse,
@@ -296,6 +296,8 @@ async function downloadRunwayVideos(params: {
   timeoutMs?: ProviderOperationTimeoutMs;
   fetchFn: typeof fetch;
   maxBytes: number;
+  allowPrivateNetwork?: boolean;
+  dispatcherPolicy?: ReturnType<typeof resolveProviderHttpRequestConfig>["dispatcherPolicy"];
 }): Promise<GeneratedVideoAsset[]> {
   const videos: GeneratedVideoAsset[] = [];
   for (const [index, url] of params.urls.entries()) {
@@ -307,30 +309,36 @@ async function downloadRunwayVideos(params: {
       deadline,
       defaultTimeoutMs: deadline.timeoutMs ?? DEFAULT_TIMEOUT_MS,
     });
-    const response = await fetchProviderDownloadResponse({
+    const { response, release } = await fetchGuardedProviderDownloadResponse({
       url,
       init: { method: "GET" },
       deadline,
       fetchFn: params.fetchFn,
       provider: "runway",
       requestFailedMessage: "Runway generated video download failed",
+      allowPrivateNetwork: params.allowPrivateNetwork,
+      dispatcherPolicy: params.dispatcherPolicy,
     });
-    const mimeType = normalizeOptionalString(response.headers.get("content-type")) ?? "video/mp4";
-    const buffer = await readResponseWithLimit(response, params.maxBytes, {
-      timeoutMs,
-      onTimeout: ({ timeoutMs: bodyTimeoutMs }) =>
-        new Error(
-          `Runway generated video download timed out after ${deadline.timeoutMs ?? bodyTimeoutMs}ms`,
-        ),
-      onOverflow: ({ maxBytes }) =>
-        new Error(`Runway generated video download exceeds ${maxBytes} bytes`),
-    });
-    videos.push({
-      buffer,
-      mimeType,
-      fileName: `video-${index + 1}.${extensionForMime(mimeType)?.slice(1) ?? "mp4"}`,
-      metadata: { sourceUrl: url },
-    });
+    try {
+      const mimeType = normalizeOptionalString(response.headers.get("content-type")) ?? "video/mp4";
+      const buffer = await readResponseWithLimit(response, params.maxBytes, {
+        timeoutMs,
+        onTimeout: ({ timeoutMs: bodyTimeoutMs }) =>
+          new Error(
+            `Runway generated video download timed out after ${deadline.timeoutMs ?? bodyTimeoutMs}ms`,
+          ),
+        onOverflow: ({ maxBytes }) =>
+          new Error(`Runway generated video download exceeds ${maxBytes} bytes`),
+      });
+      videos.push({
+        buffer,
+        mimeType,
+        fileName: `video-${index + 1}.${extensionForMime(mimeType)?.slice(1) ?? "mp4"}`,
+        metadata: { sourceUrl: url },
+      });
+    } finally {
+      await release();
+    }
   }
   return videos;
 }
@@ -441,6 +449,8 @@ export function buildRunwayVideoGenerationProvider(): VideoGenerationProvider {
           }),
           fetchFn,
           maxBytes: resolveGeneratedMediaMaxBytes(req.cfg, "video"),
+          allowPrivateNetwork,
+          dispatcherPolicy,
         });
         return {
           videos,

--- a/src/media-understanding/guarded-provider-download.ssrf.test.ts
+++ b/src/media-understanding/guarded-provider-download.ssrf.test.ts
@@ -1,0 +1,68 @@
+import { once } from "node:events";
+import http from "node:http";
+import { afterEach, describe, expect, it } from "vitest";
+import { fetchGuardedProviderDownloadResponse } from "./shared.js";
+
+describe("fetchGuardedProviderDownloadResponse", () => {
+  let server: http.Server | undefined;
+
+  afterEach(async () => {
+    if (!server) {
+      return;
+    }
+    server.closeAllConnections?.();
+    server.close();
+    await once(server, "close").catch(() => undefined);
+    server = undefined;
+  });
+
+  async function startLoopbackServer(body: string): Promise<{ port: number; hits: string[] }> {
+    const hits: string[] = [];
+    server = http.createServer((req, res) => {
+      hits.push(req.url ?? "");
+      res.writeHead(200, { "Content-Type": "video/mp4" });
+      res.end(body);
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("expected loopback server address");
+    }
+    return { port: address.port, hits };
+  }
+
+  it("blocks a private-network result URL by default", async () => {
+    const { port, hits } = await startLoopbackServer("LEAKED-INTERNAL-BYTES");
+
+    await expect(
+      fetchGuardedProviderDownloadResponse({
+        url: `http://127.0.0.1:${port}/secret-metadata`,
+        fetchFn: fetch,
+        provider: "test",
+        requestFailedMessage: "download failed",
+      }),
+    ).rejects.toThrow(/private\/internal\/special-use IP address|Blocked hostname/);
+
+    expect(hits).toEqual([]);
+  });
+
+  it("downloads a private-network result URL when allowPrivateNetwork is set", async () => {
+    const { port, hits } = await startLoopbackServer("LEAKED-INTERNAL-BYTES");
+
+    const { response, release } = await fetchGuardedProviderDownloadResponse({
+      url: `http://127.0.0.1:${port}/secret-metadata`,
+      fetchFn: fetch,
+      provider: "test",
+      requestFailedMessage: "download failed",
+      allowPrivateNetwork: true,
+    });
+    try {
+      expect(await response.text()).toBe("LEAKED-INTERNAL-BYTES");
+    } finally {
+      await release();
+    }
+
+    expect(hits).toEqual(["/secret-metadata"]);
+  });
+});

--- a/src/media-understanding/shared.ts
+++ b/src/media-understanding/shared.ts
@@ -363,6 +363,40 @@ export async function fetchProviderDownloadResponse(params: {
   });
 }
 
+export async function fetchGuardedProviderDownloadResponse(
+  params: GuardedProviderRequestParams & {
+    url: string;
+    init?: RequestInit;
+    deadline?: ProviderOperationDeadline;
+    timeoutMs?: ProviderOperationTimeoutMs;
+    fetchFn: typeof fetch;
+    provider?: string;
+    requestFailedMessage: string;
+    retry?: TransientProviderRetryConfig;
+  },
+): Promise<GuardedFetchResult> {
+  const deadline =
+    params.deadline ??
+    createProviderOperationDeadline({
+      timeoutMs: params.timeoutMs,
+      label: params.requestFailedMessage,
+    });
+  return await fetchGuardedProviderOperationResponse({
+    stage: "download",
+    url: params.url,
+    init: params.init ?? { method: "GET" },
+    timeoutMs: createProviderOperationTimeoutResolver({
+      deadline,
+      defaultTimeoutMs: deadline.timeoutMs ?? DEFAULT_GUARDED_HTTP_TIMEOUT_MS,
+    }),
+    fetchFn: params.fetchFn,
+    provider: params.provider,
+    requestFailedMessage: params.requestFailedMessage,
+    retry: params.retry,
+    guardedOptions: buildGuardedRequestOptions(params),
+  });
+}
+
 function resolveGuardedHttpTimeoutMs(timeoutMs: number | undefined): number {
   if (typeof timeoutMs !== "number" || !Number.isFinite(timeoutMs) || timeoutMs <= 0) {
     return DEFAULT_GUARDED_HTTP_TIMEOUT_MS;
@@ -565,6 +599,19 @@ function mergeGuardedRequestSsrfPolicy(params: {
   return { ...params.ssrfPolicy, allowPrivateNetwork: true };
 }
 
+function buildGuardedRequestOptions(
+  params: GuardedProviderRequestParams,
+): GuardedProviderRequestOptions {
+  const ssrfPolicy = mergeGuardedRequestSsrfPolicy(params);
+  return {
+    ...(ssrfPolicy ? { ssrfPolicy } : {}),
+    ...(params.pinDns !== undefined ? { pinDns: params.pinDns } : {}),
+    ...(params.dispatcherPolicy ? { dispatcherPolicy: params.dispatcherPolicy } : {}),
+    ...(params.auditContext ? { auditContext: params.auditContext } : {}),
+    ...(params.mode !== undefined ? { mode: params.mode } : {}),
+  };
+}
+
 function resolveGuardedRequestOptions(
   params: GuardedProviderRequestParams,
 ): GuardedProviderRequestOptions | undefined {
@@ -578,14 +625,7 @@ function resolveGuardedRequestOptions(
   ) {
     return undefined;
   }
-  const ssrfPolicy = mergeGuardedRequestSsrfPolicy(params);
-  return {
-    ...(ssrfPolicy ? { ssrfPolicy } : {}),
-    ...(params.pinDns !== undefined ? { pinDns: params.pinDns } : {}),
-    ...(params.dispatcherPolicy ? { dispatcherPolicy: params.dispatcherPolicy } : {}),
-    ...(params.auditContext ? { auditContext: params.auditContext } : {}),
-    ...(params.mode !== undefined ? { mode: params.mode } : {}),
-  };
+  return buildGuardedRequestOptions(params);
 }
 
 async function fetchGuardedProviderOperationResponse(params: {

--- a/src/plugin-sdk/provider-http.ts
+++ b/src/plugin-sdk/provider-http.ts
@@ -27,6 +27,7 @@ export {
   buildAudioTranscriptionFormData,
   createProviderOperationDeadline,
   createProviderOperationTimeoutResolver,
+  fetchGuardedProviderDownloadResponse,
   fetchProviderDownloadResponse,
   fetchProviderOperationResponse,
   fetchWithTimeout,

--- a/src/plugin-sdk/test-helpers/provider-http-mocks.ts
+++ b/src/plugin-sdk/test-helpers/provider-http-mocks.ts
@@ -3,6 +3,7 @@
  */
 import { afterEach, vi, type Mock } from "vitest";
 import type {
+  fetchGuardedProviderDownloadResponse,
   fetchProviderDownloadResponse,
   fetchProviderOperationResponse,
   fetchWithTimeoutGuarded,
@@ -22,6 +23,9 @@ type PollProviderOperationJsonParams = Parameters<typeof pollProviderOperationJs
 type PostMultipartRequestParams = Parameters<typeof postMultipartRequest>[0];
 type FetchProviderOperationResponseParams = Parameters<typeof fetchProviderOperationResponse>[0];
 type FetchProviderDownloadResponseParams = Parameters<typeof fetchProviderDownloadResponse>[0];
+type FetchGuardedProviderDownloadResponseParams = Parameters<
+  typeof fetchGuardedProviderDownloadResponse
+>[0];
 type SanitizeConfiguredModelProviderRequestParams = Parameters<
   typeof sanitizeConfiguredModelProviderRequest
 >[0];
@@ -42,6 +46,7 @@ interface ProviderHttpMocks {
   postMultipartRequestMock: AnyMock;
   fetchWithTimeoutMock: AnyMock;
   fetchWithTimeoutGuardedMock: AnyMock;
+  fetchGuardedProviderDownloadResponseMock: AnyMock;
   pollProviderOperationJsonMock: AnyMock;
   assertOkOrThrowHttpErrorMock: Mock<(response: Response, label: string) => Promise<void>>;
   assertOkOrThrowProviderErrorMock: Mock<(response: Response, label: string) => Promise<void>>;
@@ -70,6 +75,7 @@ const providerHttpMocks = vi.hoisted(() => ({
   fetchWithTimeoutGuardedMock: vi.fn(),
   fetchProviderOperationResponseMock: vi.fn(),
   fetchProviderDownloadResponseMock: vi.fn(),
+  fetchGuardedProviderDownloadResponseMock: vi.fn(),
   pollProviderOperationJsonMock: vi.fn(),
   assertOkOrThrowHttpErrorMock: vi.fn(async (_response: Response, _label: string) => {}),
   assertOkOrThrowProviderErrorMock: vi.fn(async (_response: Response, _label: string) => {}),
@@ -250,6 +256,19 @@ providerHttpMocks.fetchProviderDownloadResponseMock.mockImplementation(
   },
 );
 
+providerHttpMocks.fetchGuardedProviderDownloadResponseMock.mockImplementation(
+  async (params: FetchGuardedProviderDownloadResponseParams) => {
+    const response = await providerHttpMocks.fetchWithTimeoutMock(
+      params.url,
+      params.init ?? {},
+      resolveMockProviderDownloadTimeoutMs(params),
+      params.fetchFn,
+    );
+    await providerHttpMocks.assertOkOrThrowHttpErrorMock(response, params.requestFailedMessage);
+    return { response, release: async () => {} };
+  },
+);
+
 providerHttpMocks.pollProviderOperationJsonMock.mockImplementation(
   async (params: PollProviderOperationJsonParams) => {
     for (let attempt = 0; attempt < params.maxAttempts; attempt += 1) {
@@ -318,6 +337,7 @@ vi.mock("openclaw/plugin-sdk/provider-http", () => ({
       return Math.min(defaultTimeoutMs, remainingMs);
     },
   executeProviderOperationWithRetry: providerHttpMocks.executeProviderOperationWithRetryMock,
+  fetchGuardedProviderDownloadResponse: providerHttpMocks.fetchGuardedProviderDownloadResponseMock,
   fetchProviderDownloadResponse: providerHttpMocks.fetchProviderDownloadResponseMock,
   fetchProviderOperationResponse: providerHttpMocks.fetchProviderOperationResponseMock,
   fetchWithTimeout: providerHttpMocks.fetchWithTimeoutMock,
@@ -350,6 +370,7 @@ export function installProviderHttpMockCleanup(): void {
     providerHttpMocks.fetchWithTimeoutGuardedMock.mockClear();
     providerHttpMocks.fetchProviderOperationResponseMock.mockClear();
     providerHttpMocks.fetchProviderDownloadResponseMock.mockClear();
+    providerHttpMocks.fetchGuardedProviderDownloadResponseMock.mockClear();
     providerHttpMocks.pollProviderOperationJsonMock.mockClear();
     providerHttpMocks.assertOkOrThrowHttpErrorMock.mockClear();
     providerHttpMocks.assertOkOrThrowProviderErrorMock.mockClear();


### PR DESCRIPTION
Closes #103083

## What Problem This Solves..

Fixes an issue where the `byteplus` and `runway` bundled video-generation providers fetch the generated-video bytes from a URL taken directly out of the provider's own JSON completion response, using an unguarded download call that never re-applies the SSRF guard (DNS pinning, private/loopback/link-local address blocking) that the same providers already apply to their submit and poll requests.

If the upstream provider API is compromised, MITM'd, or configured with a malicious custom base URL, it can set the result URL to an internal address (for example `http://169.254.169.254/latest/meta-data/...` or `http://127.0.0.1:<port>/admin`) and OpenClaw will connect to it and save the response bytes as the generated video attachment. This is the agent-tool video-generation path (`src/agents/tools/video-generate-tool.ts`), reachable with default configuration and no `dangerouslyAllowPrivateNetwork` opt-in. CWE-918 (Server-Side Request Forgery).

The guarded siblings `fal`, `google`, and `openrouter` already re-apply the SSRF guard to this exact "download the URL the JSON body told us to fetch" step, and `minimax` (#102072) and `xai` (#104836) were fixed the same way after #103083 was filed. `byteplus` and `runway` were simply never updated. `vydra` shares the gap but is already covered by open PR #105884, so it is intentionally out of scope here.

## Why This Change Was Made

Root cause: `downloadBytePlusVideo` and `downloadRunwayVideos` bottom out in `fetchProviderDownloadResponse`, which calls a bare `fetchWithTimeout` with no DNS pinning and no private-network block, and the resolved `allowPrivateNetwork` / `dispatcherPolicy` were never threaded into the download step even though both providers resolve them for submit and poll.

The fix has two parts:

1. Add one canonical guarded download helper, `fetchGuardedProviderDownloadResponse`, in `src/media-understanding/shared.ts` (exported from `openclaw/plugin-sdk/provider-http`). It mirrors `fetchProviderDownloadResponse` (same download-stage retry, deadline, and body-timeout semantics) but always routes through the SSRF guard, so private/loopback/link-local result URLs are blocked by default. Unlike the earlier closed attempts (#102096, #102134, #108267) it does not gate the guard behind `if (allowPrivateNetwork || dispatcherPolicy)`, which left the default-configuration gap open.

2. Thread the operator's configured request policy (`models.providers.<id>.request`) into `resolveProviderHttpRequestConfig` for both providers, matching the merged `minimax` and `xai` fixes. Previously these calls hard-coded `allowPrivateNetwork: false` (byteplus) or omitted the request config (runway), so the resolved `allowPrivateNetwork` / `dispatcherPolicy` were always defaults. Without this, an operator who intentionally points a provider at a private endpoint would have their legitimate private artifact URL blocked by the new guard with no escape hatch. The resolved policy is now honored consistently for submit, poll, and download, and is passed into the guarded download.

Boundary: the change stays at the provider download boundary plus one shared helper; submit/poll transport is unchanged in shape. `minimax` and `xai` are already guarded, and `vydra` is covered by #105884, so no sibling is left one-sided by this PR.

## User Impact

Generated-video downloads for `byteplus` and `runway` now refuse to connect to private, loopback, or link-local addresses by default, closing the SSRF exposure when a provider response is attacker-influenced. Operators who intentionally point these providers at a private endpoint keep working by setting the existing `models.providers.<id>.request.allowPrivateNetwork` / request-policy options, exactly as they already do for other providers; that opt-in now flows through to the download step. No configuration changes are required for the common (public provider) case.

## Evidence

Real before/after, driving the actual production download helpers against a real loopback HTTP server, with the real SSRF guard code (`src/infra/net/fetch-guard.ts`, `src/infra/net/ssrf.ts`) unmodified. `fetchProviderDownloadResponse` is the download helper `byteplus` and `runway` call on `origin/main` (5ca5c5c); `fetchGuardedProviderDownloadResponse` is the helper this patch routes them through. Driven at head `06fd7cd227` on identical loopback input:

```
BEFORE main-path fetchProviderDownloadResponse (default config) -> url=http://127.0.0.1:41733/secret-metadata server_hits=["/secret-metadata"] downloaded_bytes=LEAKED-INTERNAL-BYTES-9f3c2a
AFTER patched-path fetchGuardedProviderDownloadResponse (default config) -> url=http://127.0.0.1:37263/secret-metadata server_hits=[] rejected_with=Blocked hostname or private/internal/special-use IP address
AFTER patched-path fetchGuardedProviderDownloadResponse (allowPrivateNetwork opt-in) -> url=http://127.0.0.1:38295/secret-metadata server_hits=["/secret-metadata"] downloaded_bytes=LEAKED-INTERNAL-BYTES-9f3c2a
```

With default configuration the old helper connected to the attacker-supplied loopback address and returned its bytes as the video buffer; the patched helper never opened a socket to the loopback server (`server_hits=[]`) and rejected with the guard's blocked-hostname error before any connection. With the operator's `allowPrivateNetwork` opt-in the patched helper downloads the private URL exactly as before, confirming the escape hatch works.

What was not driven live: no real cloud-metadata service or non-loopback private address was contacted (only a loopback stand-in), and the provider submit/poll requests were not exercised against a live provider API.

### Verification

- `node scripts/run-vitest.mjs src/media-understanding/guarded-provider-download.ssrf.test.ts` (real guard blocks a loopback result URL by default, downloads it only with `allowPrivateNetwork`): 2 passed.
- `node scripts/run-vitest.mjs extensions/byteplus/video-generation-provider.test.ts` (adds: download routes through the guarded fetch; configured opt-in threads through): 16 passed.
- `node scripts/run-vitest.mjs extensions/runway/video-generation-provider.test.ts` (adds: download routes through the guarded fetch; configured opt-in threads through): 16 passed.
- `node scripts/run-vitest.mjs src/media-understanding/shared.test.ts`: 48 passed.
- `oxlint`, `oxfmt --check`, and `tsgo` (core, core-test, extensions, extensions-test lanes) all clean on the changed files.
- New test fails on pristine `main` (unguarded download connects to the loopback server) and passes with the patch.
