### PR TITLE
feat(dashboard): reveal widget card chrome on hover for fine-pointer devices

### DIFF
--- a/ui/src/components/board/board-view.browser.test.ts
+++ b/ui/src/components/board/board-view.browser.test.ts
@@ -88,6 +88,39 @@ describe.skipIf(!hasBrowserLayout)("openclaw-board-view browser layout", () => {
     expect(Math.round(first?.height ?? 0)).toBe(BOARD_GRID_ROW_HEIGHT * 3 + BOARD_GRID_GAP * 2);
   });
 
+  it("hides widget chrome by default on fine-pointer devices", async () => {
+    const view = await mount();
+    const bar = view.querySelector<HTMLElement>(".board-widget__bar");
+    const handle = view.querySelector<HTMLElement>(".board-widget__resize-handle");
+    expect(getComputedStyle(bar!).visibility).toBe("hidden");
+    expect(getComputedStyle(handle!).visibility).toBe("hidden");
+  });
+
+  it("reveals widget chrome while the widget has focus", async () => {
+    const view = await mount();
+    const widget = view.querySelector<HTMLElement>('[data-test-id="board-widget"]');
+    const bar = widget!.querySelector<HTMLElement>(".board-widget__bar");
+
+    widget!.focus();
+    expect(getComputedStyle(bar!).visibility).toBe("visible");
+
+    widget!.blur();
+    await vi.waitFor(() => expect(getComputedStyle(bar!).visibility).toBe("hidden"));
+  });
+
+  it("keeps widget chrome visible while its menu is open", async () => {
+    const view = await mount();
+    const widget = view.querySelector<HTMLElement>('[data-test-id="board-widget"]');
+    const bar = widget!.querySelector<HTMLElement>(".board-widget__bar");
+    const menu = widget!.querySelector<HTMLElement & { open: boolean }>(".board-widget__menu");
+
+    menu!.open = true;
+    await vi.waitFor(() => expect(getComputedStyle(bar!).visibility).toBe("visible"));
+
+    menu!.open = false;
+    await vi.waitFor(() => expect(getComputedStyle(bar!).visibility).toBe("hidden"));
+  });
+
   it("snaps pointer resize to columns and rows before committing", async () => {
     const applyOps = vi.fn(async () => undefined);
     const view = await mount(applyOps);

--- a/ui/src/components/board/board-view.browser.test.ts
+++ b/ui/src/components/board/board-view.browser.test.ts
@@ -107,6 +107,23 @@ describe.skipIf(!hasBrowserLayout)("openclaw-board-view browser layout", () => {
     return sink;
   }
 
+  // Headless CI renderers can stall the animation timeline, leaving the 120ms
+  // hide transition permanently mid-flight; finishing transitions asserts the
+  // target visibility state instead of the renderer's clock. A genuinely
+  // matching reveal selector still fails: its finished end state is visible.
+  function expectChromeHidden(widget: HTMLElement, bar: HTMLElement): void {
+    for (const animation of document.getAnimations()) {
+      animation.finish();
+    }
+    const revealState = JSON.stringify({
+      hover: widget.matches(":hover"),
+      focusWithin: widget.matches(":focus-within"),
+      dragging: widget.classList.contains("board-widget--dragging"),
+      menuOpen: widget.querySelector(".board-widget__menu[open]") !== null,
+    });
+    expect(getComputedStyle(bar).visibility, revealState).toBe("hidden");
+  }
+
   it("reveals widget chrome while the widget has focus", async () => {
     const view = await mount();
     const sink = focusSink();
@@ -118,7 +135,7 @@ describe.skipIf(!hasBrowserLayout)("openclaw-board-view browser layout", () => {
 
     sink.focus();
     expect(widget!.matches(":focus-within")).toBe(false);
-    await vi.waitFor(() => expect(getComputedStyle(bar!).visibility).toBe("hidden"));
+    await vi.waitFor(() => expectChromeHidden(widget!, bar!));
   });
 
   it("keeps widget chrome visible while its menu is open", async () => {
@@ -134,7 +151,7 @@ describe.skipIf(!hasBrowserLayout)("openclaw-board-view browser layout", () => {
     menu!.open = false;
     sink.focus();
     expect(widget!.matches(":focus-within")).toBe(false);
-    await vi.waitFor(() => expect(getComputedStyle(bar!).visibility).toBe("hidden"));
+    await vi.waitFor(() => expectChromeHidden(widget!, bar!));
   });
 
   it("snaps pointer resize to columns and rows before committing", async () => {

--- a/ui/src/components/board/board-view.browser.test.ts
+++ b/ui/src/components/board/board-view.browser.test.ts
@@ -96,20 +96,34 @@ describe.skipIf(!hasBrowserLayout)("openclaw-board-view browser layout", () => {
     expect(getComputedStyle(handle!).visibility).toBe("hidden");
   });
 
+  // Chrome must stay revealed while focus is anywhere inside the cell (menu
+  // close restores focus to its trigger), so hiding is proven by moving focus
+  // to an outside sink rather than blur(), which leaves focus placement to the
+  // platform and flakes on Linux.
+  function focusSink(): HTMLButtonElement {
+    const sink = document.createElement("button");
+    sink.type = "button";
+    document.body.append(sink);
+    return sink;
+  }
+
   it("reveals widget chrome while the widget has focus", async () => {
     const view = await mount();
+    const sink = focusSink();
     const widget = view.querySelector<HTMLElement>('[data-test-id="board-widget"]');
     const bar = widget!.querySelector<HTMLElement>(".board-widget__bar");
 
     widget!.focus();
     expect(getComputedStyle(bar!).visibility).toBe("visible");
 
-    widget!.blur();
+    sink.focus();
+    expect(widget!.matches(":focus-within")).toBe(false);
     await vi.waitFor(() => expect(getComputedStyle(bar!).visibility).toBe("hidden"));
   });
 
   it("keeps widget chrome visible while its menu is open", async () => {
     const view = await mount();
+    const sink = focusSink();
     const widget = view.querySelector<HTMLElement>('[data-test-id="board-widget"]');
     const bar = widget!.querySelector<HTMLElement>(".board-widget__bar");
     const menu = widget!.querySelector<HTMLElement & { open: boolean }>(".board-widget__menu");
@@ -118,6 +132,8 @@ describe.skipIf(!hasBrowserLayout)("openclaw-board-view browser layout", () => {
     await vi.waitFor(() => expect(getComputedStyle(bar!).visibility).toBe("visible"));
 
     menu!.open = false;
+    sink.focus();
+    expect(widget!.matches(":focus-within")).toBe(false);
     await vi.waitFor(() => expect(getComputedStyle(bar!).visibility).toBe("hidden"));
   });
 

--- a/ui/src/styles/board.css
+++ b/ui/src/styles/board.css
@@ -461,6 +461,59 @@ openclaw-board-widget-cell {
   width: 6px;
 }
 
+@media (hover: hover) and (pointer: fine) {
+  /* Focus keeps keyboard actions reachable; menu-open and dragging keep chrome
+     pinned when interaction leaves the card bounds. */
+  .board-widget {
+    grid-template-rows: minmax(0, 1fr);
+  }
+
+  .board-widget__bar {
+    backdrop-filter: blur(6px);
+    background: color-mix(in srgb, var(--board-surface) 92%, transparent);
+    border-radius: 11px 11px 0 0;
+    height: 38px;
+    left: 0;
+    opacity: 0;
+    position: absolute;
+    right: 0;
+    top: 0;
+    transition:
+      opacity 120ms ease,
+      visibility 0s linear 120ms;
+    visibility: hidden;
+    z-index: 5;
+  }
+
+  .board-widget__resize-handle {
+    opacity: 0;
+    transition:
+      opacity 120ms ease,
+      visibility 0s linear 120ms;
+    visibility: hidden;
+  }
+
+  .board-widget:hover .board-widget__bar,
+  .board-widget:hover .board-widget__resize-handle,
+  .board-widget:focus-within .board-widget__bar,
+  .board-widget:focus-within .board-widget__resize-handle,
+  .board-widget--dragging .board-widget__bar,
+  .board-widget--dragging .board-widget__resize-handle,
+  .board-widget:has(.board-widget__menu[open]) .board-widget__bar,
+  .board-widget:has(.board-widget__menu[open]) .board-widget__resize-handle {
+    opacity: 1;
+    /* Delay-only override: reveal flips visibility immediately while the base
+       shorthand keeps the fade, and reduced-motion's transition: none stays
+       authoritative because no transition-property is redeclared here. */
+    transition-delay: 0s;
+    visibility: visible;
+  }
+
+  .board-widget__body {
+    border-radius: 11px;
+  }
+}
+
 .board-widget__grant,
 .board-widget__error {
   align-content: center;
@@ -622,6 +675,8 @@ openclaw-board-widget-cell {
 
 @media (prefers-reduced-motion: reduce) {
   .board-widget,
+  .board-widget__bar,
+  .board-widget__resize-handle,
   .board-tabs__tab,
   .swarm-widget__dot--running {
     animation: none;


### PR DESCRIPTION
## What Problem This Solves

Session-dashboard widget cards always render their full chrome — drag handle, title bar, kind badge, capability chips, kebab menu, and resize handle — even when the user is just glancing at the board. Five widgets means five header strips of window management. Widgets usually carry their own titles, so the bar mostly duplicates content and the dashboard reads as chrome, not content.

## Why This Change Was Made

On hover-capable fine-pointer devices (`@media (hover: hover) and (pointer: fine)`), the card chrome is now hidden by default and revealed as a translucent overlay floating over the widget. The 38px header grid row is collapsed so widgets get the full card height. Chrome reveals on:

- `:hover` — pure CSS; works over widget iframes since the parent section keeps `:hover` while the pointer is over an iframe child
- `:focus-within` — keyboard users reach move/resize/remove via the roving-tabindex cell focus, which reveals the bar so Tab can reach the menu trigger
- `.board-widget--dragging` — chrome stays pinned during pointer-captured drags that leave card bounds
- `:has(.board-widget__menu[open])` — the bar cannot vanish under an open kebab popup (WaDropdown reflects `open`, verified in `@awesome.me/webawesome` 3.10.0)

The reveal uses a delay-only transition override so `prefers-reduced-motion: reduce` (`transition: none`) fully disables the fade — the reveal rule never redeclares `transition-property`. Touch and coarse-pointer devices keep the current always-visible chrome unchanged, since hover-hidden controls would make widgets immovable there. Hidden chrome uses `visibility: hidden`, so it also drops out of the accessibility tree and tab order per-widget.

## User Impact

Dashboards render as pure widget content by default and become dramatically cleaner; management chrome appears only when the mouse is over a card (or it has focus). No behavior change on touch devices, no TS changes, no config surface.

| Before | After (default) | After (hover) |
| --- | --- | --- |
| ![before](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/widget-hover-chrome/before.png) | ![after default](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/widget-hover-chrome/after-default.png) | ![after hover](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/widget-hover-chrome/after-hover.png) |

## Evidence

- `vitest --project browser src/components/board/board-view.browser.test.ts` — 12/12 pass in real Chromium, including three new behavior tests: chrome hidden by default under fine-pointer, revealed on cell focus, pinned while the kebab menu is open.
- `node scripts/run-vitest.mjs ui/src/components/board/board-view.test.ts` — 40/40 pass.
- Live verification in the board fixture (`/__fixtures/board/`, mock dev harness): per-widget reveal on real mouse hover, computed `transition-delay: 0s, 0.12s` idle / `0s` revealed, only the hovered widget exposes its menu button in the a11y tree.
- Autoreview (Codex `gpt-5.6-sol`, xhigh): one finding on reduced-motion fade leakage — fixed via the delay-only override; rerun clean.
