### PR TITLE
fix(ui): tolerate absent chat-event messages in text extractors

### DIFF
--- a/ui/src/lib/chat/message-extract.test.ts
+++ b/ui/src/lib/chat/message-extract.test.ts
@@ -1,7 +1,12 @@
 // @vitest-environment node
 // Control UI tests cover message extract behavior.
 import { describe, expect, it } from "vitest";
-import { extractText, extractTextCached, extractThinkingCached } from "./message-extract.ts";
+import {
+  extractRawText,
+  extractText,
+  extractTextCached,
+  extractThinkingCached,
+} from "./message-extract.ts";
 
 describe("extractTextCached", () => {
   it("matches extractText output", () => {
@@ -135,5 +140,18 @@ describe("extractThinkingCached", () => {
     };
     expect(extractThinkingCached(message)).toBe("Plan A");
     expect(extractThinkingCached(message)).toBe("Plan A");
+  });
+});
+
+describe("nullish messages", () => {
+  // Chat events can arrive without a message (tool-only or heartbeat finals);
+  // every unknown-typed extractor must read that as "no text", not throw.
+  it("returns null instead of throwing for absent messages", () => {
+    for (const message of [undefined, null]) {
+      expect(extractText(message)).toBeNull();
+      expect(extractTextCached(message)).toBeNull();
+      expect(extractRawText(message)).toBeNull();
+      expect(extractThinkingCached(message)).toBeNull();
+    }
   });
 });

--- a/ui/src/lib/chat/message-extract.ts
+++ b/ui/src/lib/chat/message-extract.ts
@@ -29,6 +29,11 @@ function processMessageText(text: string, role: string): string {
 }
 
 export function extractText(message: unknown): string | null {
+  // Chat events may carry no message at all (tool-only or heartbeat finals);
+  // a nullish message means "no text", never a crash.
+  if (message == null) {
+    return null;
+  }
   const m = message as Record<string, unknown>;
   const role = typeof m.role === "string" ? m.role : "";
   const raw =
@@ -53,6 +58,9 @@ export function extractTextCached(message: unknown): string | null {
 }
 
 function extractThinking(message: unknown): string | null {
+  if (message == null) {
+    return null;
+  }
   const m = message as Record<string, unknown>;
   const content = m.content;
   const parts: string[] = [];
@@ -84,6 +92,9 @@ export function extractThinkingCached(message: unknown): string | null {
 }
 
 export function extractRawText(message: unknown): string | null {
+  if (message == null) {
+    return null;
+  }
   const m = message as Record<string, unknown>;
   const role = normalizeLowercaseStringOrEmpty(m.role);
   const content = m.content;


### PR DESCRIPTION
## What Problem This Solves

The deployed Control UI on team.openclaw.ai repeatedly logs "[gateway] event listener handler error: TypeError: Cannot read properties of undefined (reading 'role')" from the message-extract chunk whenever a chat event arrives in a final state without a message payload (tool-only and heartbeat finals produce these routinely on heartbeat-driven sessions).

## Why This Change Was Made

`hasVisibleFinalAssistantReply` (ui/src/pages/chat/chat-state.ts) passes `payload.message` to `extractText` for every owned final chat event, and the extractors in `ui/src/lib/chat/message-extract.ts` cast their `unknown` parameter straight to a record — so a nullish message crashes on `m.role` instead of reading as "no text". The extractors declare `message: unknown`, so nullish tolerance belongs in that module: `undefined` is just another non-matching shape that should return `null`, exactly like a string-content mismatch already does. With `extractText` returning null, the caller correctly falls through to its stream-segment check.

## User Impact

No more repeated event-listener errors in the console on sessions with tool-only or heartbeat finals; final-reply detection now correctly consults streamed segments when a final event carries no message.

## Evidence

- New regression test in `ui/src/lib/chat/message-extract.test.ts` asserting `extractText`, `extractTextCached`, `extractRawText`, and `extractThinkingCached` return null for `undefined`/`null` — crashes before the fix, passes after.
- Full `message-extract.test.ts` suite passes via `node scripts/run-vitest.mjs`.
- Autoreview (codex gpt-5.6-sol, xhigh): clean, "patch is correct (0.98)".
