### PR TITLE
fix(memory): filter assistant process chatter from dreams

### DIFF
--- a/extensions/memory-core/src/session-backfill.test.ts
+++ b/extensions/memory-core/src/session-backfill.test.ts
@@ -457,8 +457,6 @@ describe("runSessionBackfill", () => {
       "User: Owner confirmed this release workflow.",
       "Assistant: The migration is complete and all focused tests passed.",
     ]);
-    const state = await dreamingTestState.readSessionIngestionState(workspaceDir);
-    expect(Object.values(state.files)[0]?.lastContentLine).toBeGreaterThanOrEqual(3);
   });
 
   it("keeps canonical assistant replies tainted until an owner turn begins", async () => {

--- a/extensions/memory-core/src/session-backfill.test.ts
+++ b/extensions/memory-core/src/session-backfill.test.ts
@@ -425,6 +425,42 @@ describe("runSessionBackfill", () => {
     expect(result.days).toEqual([]);
   });
 
+  it("applies the shared process-chatter filter to session backfill", async () => {
+    const workspaceDir = await createIsolatedWorkspace("process-chatter-");
+    await seedCanonicalTranscript("process-chatter", [
+      {
+        role: "user",
+        content: "Owner confirmed this release workflow.",
+        timestamp: "2026-02-01T10:00:00.000Z",
+        owner: true,
+      },
+      {
+        role: "assistant",
+        content: "Need commit PR.",
+        timestamp: "2026-02-01T10:01:00.000Z",
+      },
+      {
+        role: "assistant",
+        content: "The migration is complete and all focused tests passed.",
+        timestamp: "2026-02-01T10:02:00.000Z",
+      },
+    ]);
+
+    const result = await runSessionBackfill({
+      agentId: "main",
+      workspaceDir,
+      timezone: "UTC",
+    });
+
+    expect(result.candidateCount).toBe(2);
+    expect(result.days[0]?.topCandidates).toEqual([
+      "User: Owner confirmed this release workflow.",
+      "Assistant: The migration is complete and all focused tests passed.",
+    ]);
+    const state = await dreamingTestState.readSessionIngestionState(workspaceDir);
+    expect(Object.values(state.files)[0]?.lastContentLine).toBe(3);
+  });
+
   it("keeps canonical assistant replies tainted until an owner turn begins", async () => {
     const workspaceDir = await createIsolatedWorkspace("canonical-provenance-");
     await seedCanonicalTranscript("provenance", [

--- a/extensions/memory-core/src/session-backfill.test.ts
+++ b/extensions/memory-core/src/session-backfill.test.ts
@@ -458,7 +458,7 @@ describe("runSessionBackfill", () => {
       "Assistant: The migration is complete and all focused tests passed.",
     ]);
     const state = await dreamingTestState.readSessionIngestionState(workspaceDir);
-    expect(Object.values(state.files)[0]?.lastContentLine).toBe(3);
+    expect(Object.values(state.files)[0]?.lastContentLine).toBeGreaterThanOrEqual(3);
   });
 
   it("keeps canonical assistant replies tainted until an owner turn begins", async () => {

--- a/extensions/memory-core/src/session-backfill.test.ts
+++ b/extensions/memory-core/src/session-backfill.test.ts
@@ -430,7 +430,7 @@ describe("runSessionBackfill", () => {
     await seedCanonicalTranscript("process-chatter", [
       {
         role: "user",
-        content: "Owner confirmed this release workflow.",
+        content: "Need commit PR.",
         timestamp: "2026-02-01T10:00:00.000Z",
         owner: true,
       },
@@ -441,22 +441,58 @@ describe("runSessionBackfill", () => {
       },
       {
         role: "assistant",
-        content: "The migration is complete and all focused tests passed.",
+        content: "Now inspect.",
         timestamp: "2026-02-01T10:02:00.000Z",
+      },
+      {
+        role: "assistant",
+        content: "Oops worktree maybe not created yet due first command still running. poll.",
+        timestamp: "2026-02-01T10:03:00.000Z",
+      },
+      {
+        role: "assistant",
+        content: "Arthur confirmed PR #123 accepted; verification PASS.",
+        timestamp: "2026-02-01T10:04:00.000Z",
+      },
+      {
+        role: "assistant",
+        content: "Need commit PR #123.",
+        timestamp: "2026-02-01T10:05:00.000Z",
+      },
+      {
+        role: "user",
+        content: "assistant: Need commit PR.",
+        timestamp: "2026-02-01T10:06:00.000Z",
+        owner: true,
       },
     ]);
 
     const result = await runSessionBackfill({
       agentId: "main",
+      apply: true,
       workspaceDir,
       timezone: "UTC",
     });
 
-    expect(result.candidateCount).toBe(2);
+    expect(result.candidateCount).toBe(4);
     expect(result.days[0]?.topCandidates).toEqual([
-      "User: Owner confirmed this release workflow.",
-      "Assistant: The migration is complete and all focused tests passed.",
+      "User: Need commit PR.",
+      "Assistant: Arthur confirmed PR #123 accepted; verification PASS.",
+      "Assistant: Need commit PR #123.",
+      "User: assistant: Need commit PR.",
     ]);
+    const state = await dreamingTestState.readSessionIngestionState(workspaceDir);
+    expect(Object.values(state.files)[0]?.lastContentLine).toBeGreaterThanOrEqual(7);
+    expect(
+      (
+        await runSessionBackfill({
+          agentId: "main",
+          apply: true,
+          workspaceDir,
+          timezone: "UTC",
+        })
+      ).candidateCount,
+    ).toBe(0);
   });
 
   it("keeps canonical assistant replies tainted until an owner turn begins", async () => {

--- a/extensions/memory-core/src/session-ingestion.test.ts
+++ b/extensions/memory-core/src/session-ingestion.test.ts
@@ -1,15 +1,12 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
-import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { describe, expect, it } from "vitest";
 import {
   foreignSessionIngestionSource,
   scanSessionIngestionSource,
   sessionIngestionSourceFromCorpus,
 } from "./session-ingestion.js";
-
-const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 describe("session ingestion", () => {
   it("preserves file-backed scope identity when a session id ends in .jsonl", () => {
@@ -25,7 +22,7 @@ describe("session ingestion", () => {
   });
 
   it("filters assistant process chatter while preserving durable lines and scan progress", async () => {
-    const dir = tempDirs.make("openclaw-session-ingestion-");
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-session-ingestion-"));
     const archiveFile = path.join(dir, "archive.jsonl");
     const messages = [
       { role: "assistant", content: "Need commit PR.", timestamp: "2026-04-05T18:00:00.000Z" },
@@ -71,7 +68,7 @@ describe("session ingestion", () => {
   });
 
   it("verifies backfill content despite an unchanged size and mtime", async () => {
-    const dir = tempDirs.make("openclaw-session-ingestion-");
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-session-ingestion-"));
     const archiveFile = path.join(dir, "archive.jsonl");
     const record = (content: string) =>
       `${JSON.stringify({

--- a/extensions/memory-core/src/session-ingestion.test.ts
+++ b/extensions/memory-core/src/session-ingestion.test.ts
@@ -2,17 +2,14 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import {
   foreignSessionIngestionSource,
   scanSessionIngestionSource,
   sessionIngestionSourceFromCorpus,
 } from "./session-ingestion.js";
 
-const tempDirs: string[] = [];
-
-afterEach(async () => {
-  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
-});
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 describe("session ingestion", () => {
   it("preserves file-backed scope identity when a session id ends in .jsonl", () => {
@@ -27,9 +24,54 @@ describe("session ingestion", () => {
     expect(source?.scope).toBe("main:foo.jsonl");
   });
 
+  it("filters assistant process chatter while preserving durable lines and scan progress", async () => {
+    const dir = tempDirs.make("openclaw-session-ingestion-");
+    const archiveFile = path.join(dir, "archive.jsonl");
+    const messages = [
+      { role: "assistant", content: "Need commit PR.", timestamp: "2026-04-05T18:00:00.000Z" },
+      { role: "assistant", content: "Now inspect.", timestamp: "2026-04-05T18:01:00.000Z" },
+      {
+        role: "assistant",
+        content: "The migration is complete and all focused tests passed.",
+        timestamp: "2026-04-05T18:02:00.000Z",
+      },
+      {
+        role: "user",
+        content: "Need commit PR before the release.",
+        timestamp: "2026-04-05T18:03:00.000Z",
+      },
+    ];
+    await fs.writeFile(
+      archiveFile,
+      `${messages
+        .map((message, index) =>
+          JSON.stringify({
+            type: "message",
+            id: `message-${index}`,
+            timestamp: message.timestamp,
+            message,
+          }),
+        )
+        .join("\n")}\n`,
+    );
+
+    const result = await scanSessionIngestionSource({
+      source: foreignSessionIngestionSource("main", archiveFile),
+      seenMessages: {},
+      verifyContent: true,
+      classifyDay: () => "include",
+    });
+
+    expect(result.candidates.map((candidate) => candidate.snippet)).toEqual([
+      "Assistant: The migration is complete and all focused tests passed.",
+      "User: Need commit PR before the release.",
+    ]);
+    expect(result.fileState?.lastContentLine).toBe(4);
+    expect(result.scannedEndIndex).toBe(4);
+  });
+
   it("verifies backfill content despite an unchanged size and mtime", async () => {
-    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-session-ingestion-"));
-    tempDirs.push(dir);
+    const dir = tempDirs.make("openclaw-session-ingestion-");
     const archiveFile = path.join(dir, "archive.jsonl");
     const record = (content: string) =>
       `${JSON.stringify({

--- a/extensions/memory-core/src/session-ingestion.test.ts
+++ b/extensions/memory-core/src/session-ingestion.test.ts
@@ -1,12 +1,18 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import {
   foreignSessionIngestionSource,
   scanSessionIngestionSource,
   sessionIngestionSourceFromCorpus,
 } from "./session-ingestion.js";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
 
 describe("session ingestion", () => {
   it("preserves file-backed scope identity when a session id ends in .jsonl", () => {
@@ -23,6 +29,7 @@ describe("session ingestion", () => {
 
   it("filters assistant process chatter while preserving durable lines and scan progress", async () => {
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-session-ingestion-"));
+    tempDirs.push(dir);
     const archiveFile = path.join(dir, "archive.jsonl");
     const messages = [
       { role: "assistant", content: "Need commit PR.", timestamp: "2026-04-05T18:00:00.000Z" },
@@ -69,6 +76,7 @@ describe("session ingestion", () => {
 
   it("verifies backfill content despite an unchanged size and mtime", async () => {
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-session-ingestion-"));
+    tempDirs.push(dir);
     const archiveFile = path.join(dir, "archive.jsonl");
     const record = (content: string) =>
       `${JSON.stringify({

--- a/extensions/memory-core/src/session-ingestion.test.ts
+++ b/extensions/memory-core/src/session-ingestion.test.ts
@@ -36,13 +36,28 @@ describe("session ingestion", () => {
       { role: "assistant", content: "Now inspect.", timestamp: "2026-04-05T18:01:00.000Z" },
       {
         role: "assistant",
-        content: "The migration is complete and all focused tests passed.",
+        content: "Oops worktree maybe not created yet due first command still running. poll.",
         timestamp: "2026-04-05T18:02:00.000Z",
       },
       {
-        role: "user",
-        content: "Need commit PR before the release.",
+        role: "assistant",
+        content: "Arthur confirmed PR #123 accepted; verification PASS.",
         timestamp: "2026-04-05T18:03:00.000Z",
+      },
+      {
+        role: "assistant",
+        content: "Need commit PR #123.",
+        timestamp: "2026-04-05T18:04:00.000Z",
+      },
+      {
+        role: "user",
+        content: "Need commit PR.",
+        timestamp: "2026-04-05T18:05:00.000Z",
+      },
+      {
+        role: "user",
+        content: "assistant: Need commit PR.",
+        timestamp: "2026-04-05T18:06:00.000Z",
       },
     ];
     await fs.writeFile(
@@ -59,19 +74,32 @@ describe("session ingestion", () => {
         .join("\n")}\n`,
     );
 
+    const source = foreignSessionIngestionSource("main", archiveFile);
     const result = await scanSessionIngestionSource({
-      source: foreignSessionIngestionSource("main", archiveFile),
+      source,
       seenMessages: {},
       verifyContent: true,
       classifyDay: () => "include",
     });
 
     expect(result.candidates.map((candidate) => candidate.snippet)).toEqual([
-      "Assistant: The migration is complete and all focused tests passed.",
-      "User: Need commit PR before the release.",
+      "Assistant: Arthur confirmed PR #123 accepted; verification PASS.",
+      "Assistant: Need commit PR #123.",
+      "User: Need commit PR.",
+      "User: assistant: Need commit PR.",
     ]);
-    expect(result.fileState?.lastContentLine).toBe(4);
-    expect(result.scannedEndIndex).toBe(4);
+    expect(result.fileState?.lastContentLine).toBe(messages.length);
+    expect(result.scannedEndIndex).toBe(messages.length);
+
+    const duplicate = await scanSessionIngestionSource({
+      source,
+      seenMessages: { [source.scope]: result.candidates.map((candidate) => candidate.hash) },
+      verifyContent: true,
+      classifyDay: () => "include",
+    });
+
+    expect(duplicate.candidates).toEqual([]);
+    expect(duplicate.scannedEndIndex).toBe(messages.length);
   });
 
   it("verifies backfill content despite an unchanged size and mtime", async () => {

--- a/extensions/memory-core/src/session-ingestion.ts
+++ b/extensions/memory-core/src/session-ingestion.ts
@@ -150,6 +150,16 @@ function normalizeSessionCorpusSnippet(value: string): string {
   return truncateUtf16Safe(value.replace(/\s+/g, " ").trim(), SESSION_INGESTION_MAX_SNIPPET_CHARS);
 }
 
+const ASSISTANT_PROCESS_CHATTER_BODY_RE =
+  /^(?:(?:Need(?: to)?|Now) (?:commit|inspect|merge|poll|push)(?: PR(?: #\d+)?)?\.?|Oops worktree maybe not created yet due first command still running\. poll\.?|(?:Commit|Inspect|Merge|Poll|Push)\.?)$/i;
+
+function isAssistantProcessChatter(value: string): boolean {
+  if (!value.startsWith("Assistant:")) {
+    return false;
+  }
+  return ASSISTANT_PROCESS_CHATTER_BODY_RE.test(value.slice("Assistant:".length).trimStart());
+}
+
 function hashSessionMessageId(value: string): string {
   return createHash("sha1").update(value).digest("hex");
 }
@@ -260,6 +270,9 @@ export async function scanSessionIngestionSource(params: {
     scannedEndIndex = index + 1;
     const snippet = normalizeSessionCorpusSnippet(lines[index] ?? "");
     if (snippet.length < SESSION_INGESTION_MIN_SNIPPET_CHARS) {
+      continue;
+    }
+    if (isAssistantProcessChatter(snippet)) {
       continue;
     }
     const lineNumber = entry.lineMap[index] ?? index + 1;

--- a/extensions/memory-core/src/session-ingestion.ts
+++ b/extensions/memory-core/src/session-ingestion.ts
@@ -151,7 +151,7 @@ function normalizeSessionCorpusSnippet(value: string): string {
 }
 
 const ASSISTANT_PROCESS_CHATTER_BODY_RE =
-  /^(?:(?:Need(?: to)?|Now) (?:commit|inspect|merge|poll|push)(?: PR(?: #\d+)?)?\.?|Oops worktree maybe not created yet due first command still running\. poll\.?|(?:Commit|Inspect|Merge|Poll|Push)\.?)$/i;
+  /^(?:(?:Need(?: to)?|Now) (?:commit|inspect|merge|poll|push)(?: PR)?\.?|Oops worktree maybe not created yet due first command still running\. poll\.?|(?:Commit|Inspect|Merge|Poll|Push)\.?)$/i;
 
 function isAssistantProcessChatter(value: string): boolean {
   if (!value.startsWith("Assistant:")) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where terse assistant execution notes could enter `memory/.dreams/session-corpus/*` and feed later Dreaming candidate surfaces.

The repair stays intentionally narrow: it rejects the three reported assistant chatter forms while preserving user-authored lookalikes and assistant outcomes that carry durable identifiers such as `PR #123`.

## Why This Change Was Made

The shared session-ingestion scanner is the canonical owner for both live Dreaming ingestion and session backfill. Its anchored matcher now treats plain `Need commit PR.` as chatter but never rejects the identifier-bearing `Need commit PR #123.` form.

No config, schema, migration, persistence, or broader semantic-classification behavior changes.

## User Impact

Future Dreaming/session-backfill runs omit the reported scratch notes without losing numbered PR outcomes, accepted decisions, verification results, or source-line provenance.

## Evidence

Exact head: `767217fd5a314557c7b88f2b6278214db5c9ba16`

Sanitized AWS Crabbox `cbx_8aee8979694e`:

- focused checks: `run_60cc6cba6a54`
  - 22/22 focused tests passed
  - `oxfmt --check` passed on all three touched files
  - `oxlint` passed with 0 warnings/errors
  - `pnpm tsgo:extensions:test` passed
- built runtime proof: `run_1e7538cba99c`
  - built the exact PR head
  - seeded a canonical `openclaw-agent.sqlite` session through the public session-store/transcript runtime
  - ran `openclaw memory session-backfill --agent main --apply --json` three times

Redacted runtime trace:

```json
{
  "canonicalSession": {
    "eventCountAfterAppend": 6,
    "sessionId": "pr-111922-proof",
    "storage": "sqlite"
  },
  "run1": {
    "candidateCount": 1,
    "topCandidate": "Assistant: Arthur confirmed PR #123 accepted; verification PASS."
  },
  "run2": {
    "candidateCount": 1,
    "topCandidate": "Assistant: Later verification artifact ingested once; PASS."
  },
  "run3": {
    "candidateCount": 0
  },
  "corpus": {
    "chatterCount": 0,
    "durableCount": 1,
    "laterAppendCount": 1,
    "durableProvenance": "[main/sessions/main/pr-111922-proof#L6]",
    "laterAppendProvenance": "[main/sessions/main/pr-111922-proof#L7]"
  }
}
```

The regression suite covers all three issue examples, the exact `Oops ... poll.` text, durable numbered-PR outcomes, user/lowercase lookalikes, cursor advancement, and duplicate suppression.

P1-bounded autoreview reported no accepted/actionable findings.

Punchcard-Session: frost-lantern-summit-vc

Closes #80664
