### PR TITLE
fix(ui): restore startup JS budget headroom for sandbox diagnostics

### DIFF
--- a/scripts/check-control-ui-performance.mjs
+++ b/scripts/check-control-ui-performance.mjs
@@ -12,10 +12,11 @@ const KIB = 1024;
 export const CONTROL_UI_PERFORMANCE_BUDGETS = Object.freeze({
   startupJsRequests: 18,
   startupCssRequests: 1,
-  // 312 KiB accompanies the live-narration sidebar feature (2026-07): the
-  // controller is a lazy chunk; only its thin element/pref wiring (~1.5 KiB)
-  // stays in startup, which exhausted the previous ratchet's headroom.
-  startupJsGzipBytes: 312 * KIB,
+  // 313 KiB accompanies the widget sandbox-origin diagnostics (2026-07): the
+  // startup catalog gained the operator hint strings and main sat within
+  // ~0.1 KiB of the previous ceiling, failing source builds whose zlib packs
+  // slightly worse than CI's. One KiB restores explicit headroom.
+  startupJsGzipBytes: 313 * KIB,
   // 45 KiB CSS ceilings maintainer-approved 2026-07 alongside the interleaved
   // sidebar zone styling; headroom over the ~36.5 KiB post-diet baseline.
   startupCssGzipBytes: 45 * KIB,


### PR DESCRIPTION
## What Problem This Solves

Source builds of current main fail deterministically on machines whose zlib packs slightly worse than CI's: `pnpm build` reports "startup JS gzip: 312.1 KiB exceeds 312.0 KiB" (reproduced twice on the team.openclaw.ai deployment host after #111909 landed). Main sat within ~0.1 KiB of the ceiling, so the budget passes or fails on compression variance rather than on an intentional loading decision.

## Why This Change Was Made

The startup catalog grew by the widget sandbox-origin diagnostic strings (#111909), consuming the last of the previous ratchet's headroom. Per the file's own convention, budget changes accompany an intentional decision: 313 KiB restores explicit headroom for that feature and is documented in place, following the same pattern as the prior live-narration bump.

## User Impact

`pnpm build` succeeds again on source checkouts regardless of local zlib packing; no runtime behavior changes.

## Evidence

- Two consecutive clean-cache `pnpm build` runs on the deployment host at bf6961d3 failed with the identical 312.1 vs 312.0 violation; CI's build lane passed the same commits, demonstrating environment-dependent gzip variance at the cliff.
- Diff is the budget constant plus its justification comment only (5+/4-).
- Autoreview (codex gpt-5.6-sol, xhigh): clean, "patch is correct (0.98)". A first iteration also shortened the diagnostic string; review flagged the lost routing guidance, so the string is untouched and only the budget moves.
