### PR TITLE
fix(ui): persist synchronized sidebar preferences

### DIFF
--- a/src/config/config-misc.test.ts
+++ b/src/config/config-misc.test.ts
@@ -508,6 +508,32 @@ describe("ui.seamColor", () => {
   });
 });
 
+describe("ui.prefs.sidebarEntries", () => {
+  it("accepts the route and session entries synchronized by the Control UI", () => {
+    const result = validateConfigObject({
+      ui: {
+        prefs: {
+          sidebarEntries: ["route:usage", "session:agent:main:test"],
+        },
+      },
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects sidebar entries that are not strings", () => {
+    const result = validateConfigObject({
+      ui: {
+        prefs: {
+          sidebarEntries: ["route:usage", 7],
+        },
+      },
+    });
+
+    expect(result.ok).toBe(false);
+  });
+});
+
 describe("gateway.controlUi.embedSandbox", () => {
   it("accepts strict, scripts, and trusted modes", () => {
     for (const mode of ["strict", "scripts", "trusted"] as const) {

--- a/src/config/types.openclaw.ts
+++ b/src/config/types.openclaw.ts
@@ -201,6 +201,8 @@ export type OpenClawConfig = {
       chatSendShortcut?: "enter" | "modifier-enter";
       /** Follow-up handling while a run is active; unset uses the server queue mode. */
       chatFollowUpMode?: "steer" | "queue";
+      /** Ordered page and pinned-session entries shown in the Control UI sidebar. */
+      sidebarEntries?: string[];
       /** Show live agent activity beneath running Control UI sidebar sessions. */
       sidebarLiveActivity?: boolean;
     };

--- a/src/config/zod-schema.root-shape.ts
+++ b/src/config/zod-schema.root-shape.ts
@@ -286,6 +286,7 @@ export const OpenClawSchemaShape = {
           chatPersistCommentary: z.boolean().optional(),
           chatSendShortcut: z.union([z.literal("enter"), z.literal("modifier-enter")]).optional(),
           chatFollowUpMode: z.union([z.literal("steer"), z.literal("queue")]).optional(),
+          sidebarEntries: z.array(z.string()).optional(),
           sidebarLiveActivity: z.boolean().optional(),
         })
         .optional(),

--- a/ui/src/app/app-host.test.ts
+++ b/ui/src/app/app-host.test.ts
@@ -13,6 +13,7 @@ import {
   TERMINAL_PANEL_TOGGLE_EVENT,
   UI_COMMAND_EVENT,
 } from "../components/panel-toggle-contract.ts";
+import { createStorageMock } from "../test-helpers/storage.ts";
 import "./app-host.ts";
 import type {
   ApplicationContext,
@@ -22,6 +23,7 @@ import type {
 import { shouldMergeChatChrome } from "./mobile-nav-layout.ts";
 import { navigationSurfaceIsHidden, renderFloatingUpdateCard } from "./navigation-surface.ts";
 import { resolveOnboardingMode } from "./onboarding-mode.ts";
+import { resetServerUiPrefsSync } from "./server-prefs.ts";
 
 type AppLifecycleState = {
   loginToken: string;
@@ -42,6 +44,11 @@ type ShellInitializationState = {
     snapshot: { client: GatewayBrowserClient | null; connected: boolean },
     runtimeConfig: ApplicationContext["runtimeConfig"],
   ) => void;
+};
+
+type ShellServerPreferencesState = {
+  runtime: { context: ApplicationContext };
+  reconcileServerUiPrefs: (runtimeConfig: ApplicationContext["runtimeConfig"]) => void;
 };
 
 type ShellKeyboardState = {
@@ -337,6 +344,39 @@ describe("OpenClaw shell source initialization", () => {
     expect(secondAgents.ensureList).toHaveBeenCalledOnce();
     expect(firstRuntimeConfig.ensureLoaded).toHaveBeenCalledOnce();
     expect(secondRuntimeConfig.ensureLoaded).toHaveBeenCalledOnce();
+  });
+});
+
+describe("OpenClaw shell server preferences", () => {
+  it("refreshes live navigation when a sidebar preference arrives from the gateway", () => {
+    vi.stubGlobal("localStorage", createStorageMock());
+    resetServerUiPrefsSync();
+    const sidebarEntries = ["route:usage", "session:agent:main:test"];
+    const updateNavigation = vi.fn();
+    const refreshTheme = vi.fn();
+    const runtimeConfig = {
+      state: {
+        configSnapshot: {
+          config: { ui: { prefs: { sidebarEntries } } },
+          hash: "sidebar-config-hash",
+        },
+      },
+    } as unknown as ApplicationContext["runtimeConfig"];
+    const context = {
+      gateway: { connection: { gatewayUrl: "ws://sidebar.test" } },
+      navigation: { update: updateNavigation },
+      theme: { refresh: refreshTheme },
+    } as unknown as ApplicationContext;
+    const shell = document.createElement(
+      "openclaw-app-shell",
+    ) as unknown as ShellServerPreferencesState;
+    shell.runtime = { context };
+
+    shell.reconcileServerUiPrefs(runtimeConfig);
+
+    expect(updateNavigation).toHaveBeenCalledWith({ sidebarEntries });
+    expect(refreshTheme).toHaveBeenCalledOnce();
+    resetServerUiPrefsSync();
   });
 });
 

--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -604,6 +604,9 @@ class OpenClawShell extends OpenClawLightDomElement {
       scope: context.gateway.connection.gatewayUrl,
       snapshotHash: snapshot.hash ?? undefined,
       onApplied: (patch) => {
+        if (patch.sidebarEntries !== undefined) {
+          context.navigation.update({ sidebarEntries: patch.sidebarEntries });
+        }
         if (isSupportedLocale(patch.locale)) {
           void i18n.setLocale(patch.locale);
         }

--- a/ui/src/app/server-prefs.test.ts
+++ b/ui/src/app/server-prefs.test.ts
@@ -121,6 +121,23 @@ describe("applyServerUiPrefs", () => {
     expect(loadSettings().themeMode).toBe("light");
   });
 
+  it("preserves a local sidebar edit when only another server preference changes", () => {
+    const onApplied = vi.fn();
+    const sidebarEntries = ["route:usage", "session:agent:main:test"];
+    applyServerUiPrefs(configWithPrefs({ sidebarEntries, themeMode: "dark" }), { onApplied });
+    patchSettings({ sidebarEntries: ["route:usage"] });
+
+    expect(
+      applyServerUiPrefs(
+        configWithPrefs({ sidebarEntries: [...sidebarEntries], themeMode: "light" }),
+        { onApplied },
+      ),
+    ).toBe(true);
+    expect(loadSettings().sidebarEntries).toEqual(["route:usage"]);
+    expect(loadSettings().themeMode).toBe("light");
+    expect(onApplied).toHaveBeenLastCalledWith({ themeMode: "light" });
+  });
+
   it("ignores a server custom theme until this browser imported one", () => {
     const onApplied = vi.fn();
     expect(applyServerUiPrefs(configWithPrefs({ theme: "custom" }), { onApplied })).toBe(false);
@@ -237,6 +254,40 @@ describe("pushServerUiPrefs", () => {
       }),
     ).toBe(true);
     expect(loadSettings().themeMode).toBe("light");
+  });
+
+  it("marks sidebar arrays for replacement when pinned entries are removed", async () => {
+    let hash = 0;
+    const request = vi.fn(async (method: string) => {
+      if (method === "config.get") {
+        return { hash: `hash-${hash}` };
+      }
+      hash += 1;
+      return {};
+    });
+    const client = { request } as unknown as Parameters<typeof pushServerUiPrefs>[0];
+    const sidebarEntries = ["route:usage", "session:agent:main:test"];
+
+    pushServerUiPrefs(client, { sidebarEntries });
+    await vi.waitFor(() => {
+      expect(request).toHaveBeenCalledWith("config.patch", {
+        baseHash: "hash-0",
+        raw: JSON.stringify({ ui: { prefs: { sidebarEntries } } }),
+        replacePaths: ["ui.prefs.sidebarEntries"],
+        note: "control-ui prefs sync",
+      });
+    });
+
+    const remainingEntries = ["route:usage"];
+    pushServerUiPrefs(client, { sidebarEntries: remainingEntries });
+    await vi.waitFor(() => {
+      expect(request).toHaveBeenCalledWith("config.patch", {
+        baseHash: "hash-1",
+        raw: JSON.stringify({ ui: { prefs: { sidebarEntries: remainingEntries } } }),
+        replacePaths: ["ui.prefs.sidebarEntries"],
+        note: "control-ui prefs sync",
+      });
+    });
   });
 
   it("coalesces rapid changes into serial patches instead of racing the hash", async () => {

--- a/ui/src/app/server-prefs.ts
+++ b/ui/src/app/server-prefs.ts
@@ -273,7 +273,7 @@ export function applyServerUiPrefs(
   }
   const changed: ServerUiPrefs = {};
   for (const prefKey of Object.keys(prefs) as Array<keyof ServerUiPrefs>) {
-    if (lastSeenRaw === null || prefs[prefKey] !== lastSeen[prefKey]) {
+    if (lastSeenRaw === null || !prefValuesEqual(prefs[prefKey], lastSeen[prefKey])) {
       (changed as Record<string, unknown>)[prefKey] = prefs[prefKey];
     }
   }
@@ -331,6 +331,9 @@ async function drainPrefsQueue(client: GatewayBrowserClient): Promise<void> {
         await client.request("config.patch", {
           baseHash,
           raw: JSON.stringify({ ui: { prefs } }),
+          ...(prefs.sidebarEntries !== undefined
+            ? { replacePaths: ["ui.prefs.sidebarEntries"] }
+            : {}),
           note: "control-ui prefs sync",
         });
         staleConfigHashes.add(baseHash);


### PR DESCRIPTION
## Summary

- accept the Control UI's synchronized `ui.prefs.sidebarEntries` array in the gateway configuration schema and public config type
- declare the exact sidebar array in `config.patch.replacePaths` so removing pinned entries remains an intentional, permitted replacement
- compare synchronized sidebar arrays by content so unrelated preference changes do not overwrite device-local sidebar edits
- refresh the live navigation capability immediately when another device or the gateway changes the sidebar
- preserve strict validation by rejecting sidebar entries that are not strings
- add regression coverage for the route and pinned-session payload already emitted by the dashboard

## Why

The Control UI already saves ordered sidebar pages and pinned sessions through `config.patch`, but the strict root configuration schema did not declare `sidebarEntries`. Every otherwise valid update was rejected with `ui.prefs: Unrecognized key: "sidebarEntries"`, so sidebar layout changes could not synchronize with the gateway. Once the field is accepted, shrinking an existing array also needs the gateway's explicit `replacePaths` intent marker; the dashboard now supplies that marker whenever it synchronizes sidebar entries.

## Validation

- `vitest run --config test/vitest/vitest.runtime-config.config.ts src/config/config-misc.test.ts` — 92 tests passed
- `vitest run --config test/vitest/vitest.ui.config.ts ui/src/app/server-prefs.test.ts ui/src/app/app-host.test.ts` — 51 tests passed
- existing gateway `config.patch` array-replacement integration test — passed
- production Control UI build and asset checks — passed; startup JavaScript is **311.5 KiB / 313.0 KiB**
- `oxfmt --check` on all seven changed files
- `oxlint` on all seven changed files
- the full local type/lint wrappers are blocked by stale installed `@openclaw/fs-safe` declarations; hosted CI validates a clean dependency tree

## Release note

Control UI sidebar page ordering and pinned sessions now synchronize successfully with the gateway without overwriting device-local edits on read-only clients.
