### PR TITLE
feat(linux): render widgets in Quick Chat

### DIFF
--- a/apps/linux/README.md
+++ b/apps/linux/README.md
@@ -40,6 +40,10 @@ The running app gives the headless `openclaw node run` host a single Canvas WebV
 
 The plugin-generated A2UI renderer in `extensions/canvas/src/host/a2ui/` remains the source of truth. The app embeds its committed, synced OpenClawKit mirror from `apps/shared/OpenClawKit/Sources/OpenClawKit/Resources/CanvasA2UI/`. Run `node scripts/sync-native-a2ui.mjs --check` from the repository root after changing those assets.
 
+## Quick Chat widgets
+
+Quick Chat advertises the Gateway `inline-widgets` capability and renders hosted `show_widget` results in isolated child WebViews. The parent Quick Chat WebView is the only one granted Tauri commands; widget WebViews match no capability and therefore have no IPC access. Quick Chat accepts only assistant-message Canvas previews under the capability-scoped `/__openclaw__/canvas/documents/` route, blocks navigation away from the original document, uses nonpersistent WebViews, and keeps stable widget instances while switching among multiple previews. Connections that require a custom Gateway TLS leaf pin remain text-only because the platform WebView cannot bind that pin. Like the other native clients, Quick Chat does not expose the Control UI `sendPrompt` bridge.
+
 ## Installer resource
 
 `tauri.conf.json` bundles the repository's canonical `scripts/install-cli.sh` directly as `install-cli.sh`. The app never keeps a forked copy. Stable, beta, and dev installs select `latest`, `beta`, and a managed Git `main` checkout respectively, always under `~/.openclaw`.

--- a/apps/linux/src-tauri/Cargo.toml
+++ b/apps/linux/src-tauri/Cargo.toml
@@ -24,7 +24,7 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
 sha2 = "0.11.0"
 subtle = "2.6.1"
-tauri = { version = "2.11.5", features = ["image-png", "tray-icon"] }
+tauri = { version = "2.11.5", features = ["image-png", "tray-icon", "unstable"] }
 tauri-plugin-autostart = "2.5.1"
 tauri-plugin-deep-link = "2.4.9"
 tauri-plugin-global-shortcut = "2.3.2"

--- a/apps/linux/src-tauri/permissions/quickchat.toml
+++ b/apps/linux/src-tauri/permissions/quickchat.toml
@@ -1,6 +1,6 @@
 [[permission]]
 identifier = "allow-quickchat"
-description = "Enables Quick Chat agents, shortcut settings, send, hide, and dashboard commands."
+description = "Enables Quick Chat agents, shortcut settings, send, hide, isolated widget, and dashboard commands."
 commands.allow = [
   "quickchat_agents",
   "quickchat_hide",
@@ -12,4 +12,6 @@ commands.allow = [
   "quickchat_set_shortcut",
   "quickchat_shortcut",
   "quickchat_show_dashboard",
+  "quickchat_refresh_widget_surface",
+  "quickchat_sync_widgets",
 ]

--- a/apps/linux/src-tauri/src/gateway_ws.rs
+++ b/apps/linux/src-tauri/src/gateway_ws.rs
@@ -11,13 +11,14 @@ use rustls::{ClientConfig, DigitallySignedStruct, Error as RustlsError, Signatur
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
+use std::collections::HashMap;
 use std::fmt;
 use std::io::ErrorKind;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use subtle::ConstantTimeEq;
-use tauri::{AppHandle, Emitter, Manager, WebviewWindow};
+use tauri::{AppHandle, Emitter, Manager, Webview};
 use tokio::sync::{mpsc, oneshot};
 use tokio_tungstenite::tungstenite::{Error as TungsteniteError, Message};
 use tokio_tungstenite::{
@@ -44,6 +45,7 @@ const TLS_PIN_MISMATCH_ERROR: &str = "Gateway TLS certificate fingerprint mismat
 // Mirrors packages/gateway-protocol/src/version.ts. The Gateway rejects other ranges.
 const MIN_PROTOCOL_VERSION: u32 = 4;
 const MAX_PROTOCOL_VERSION: u32 = 4;
+const INLINE_WIDGETS_CLIENT_CAPABILITY: &str = "inline-widgets";
 
 #[derive(Clone)]
 pub struct GatewayWsConfig {
@@ -238,14 +240,22 @@ pub(crate) struct ChatSendResult {
     pub(crate) run_id: String,
 }
 
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PluginSurfaceRefreshResponse {
+    plugin_surface_urls: Option<HashMap<String, String>>,
+}
+
 enum GatewayRequest {
     AgentsList,
     ChatSend(ChatSendParams),
+    RefreshCanvasSurface { observed_url: Option<String> },
 }
 
 enum GatewayResponse {
     AgentsList(AgentsListResult),
     ChatSend(ChatSendAck),
+    CanvasSurface(Option<String>),
 }
 
 enum DriverCommand {
@@ -363,6 +373,7 @@ struct GatewayClientInner {
     commands: Mutex<Option<mpsc::Sender<DriverCommand>>>,
     agents_cache: Mutex<Option<CachedAgents>>,
     identity: Mutex<Option<GatewayDeviceIdentityStore>>,
+    canvas_surface_url: Mutex<Option<String>>,
     connection_notice: Mutex<Option<String>>,
     connection_state: AtomicU64,
     reconnect_paused: AtomicBool,
@@ -383,6 +394,7 @@ impl GatewayClient {
                 commands: Mutex::new(None),
                 agents_cache: Mutex::new(None),
                 identity: Mutex::new(None),
+                canvas_surface_url: Mutex::new(None),
                 connection_notice: Mutex::new(None),
                 connection_state: AtomicU64::new(GatewayConnectionState::Down as u64),
                 reconnect_paused: AtomicBool::new(false),
@@ -457,17 +469,17 @@ impl GatewayClient {
         });
     }
 
-    pub fn emit_current_state(&self, window: &WebviewWindow) -> Result<(), String> {
+    pub fn emit_current_state(&self, webview: &Webview) -> Result<(), String> {
         let notice = self
             .inner
             .connection_notice
             .lock()
             .map_err(|_| "Gateway connection notice is unavailable.".to_string())?
             .clone();
-        window
+        webview
             .emit(
                 GATEWAY_STATE_EVENT,
-                GatewayStateEvent::new(self.connection_state(), notice),
+                GatewayStateEvent::new(self.connection_state(), notice, self.canvas_surface_url()),
             )
             .map_err(|error| format!("Could not report Gateway connectivity: {error}"))
     }
@@ -521,6 +533,23 @@ impl GatewayClient {
             target,
             run_id: ack.run_id,
         })
+    }
+
+    pub async fn refresh_canvas_surface(&self) -> Result<Option<String>, String> {
+        let observed_url = self.canvas_surface_url();
+        if observed_url.is_none() {
+            return Ok(None);
+        }
+        let response = self
+            .request(GatewayRequest::RefreshCanvasSurface { observed_url })
+            .await?;
+        let GatewayResponse::CanvasSurface(refreshed) = response else {
+            return Err(
+                "Gateway returned the wrong response for plugin.surface.refresh.".to_string(),
+            );
+        };
+        self.set_canvas_surface_url(refreshed.clone());
+        Ok(refreshed)
     }
 
     pub fn resume_reconnect(&self) {
@@ -665,8 +694,20 @@ impl GatewayClient {
             .map_err(|_| RequestFailure::transport("Gateway connection timed out."))??;
         let nonce = wait_for_connect_challenge(&mut socket).await?;
         let signed_at_ms = unix_time_ms().map_err(RequestFailure::transport)?;
-        let params = connect_params(&identity, &auth, &nonce, signed_at_ms)
-            .map_err(RequestFailure::transport)?;
+        // Native child WebViews use platform HTTP trust and cannot bind the optional
+        // WebSocket leaf pin, so pinned Gateway connections remain capability-free.
+        let inline_widgets_available = config
+            .tls_fingerprint
+            .as_deref()
+            .is_none_or(|value| value.trim().is_empty());
+        let params = connect_params(
+            &identity,
+            &auth,
+            &nonce,
+            signed_at_ms,
+            inline_widgets_available,
+        )
+        .map_err(RequestFailure::transport)?;
         let hello = match request_on_socket(app, &mut socket, "connect", params).await {
             Ok(hello) => hello,
             Err(failure) => {
@@ -682,6 +723,10 @@ impl GatewayClient {
         if let Some(device_token) = hello.device_token.as_deref() {
             self.persist_device_token(&config.ws_url, device_token)?;
         }
+        self.set_canvas_surface_url(gated_canvas_surface_url(
+            hello.canvas_surface_url,
+            inline_widgets_available,
+        ));
 
         let agents = request_agents_list(app, &mut socket).await?;
         if self.inner.config_generation.load(Ordering::SeqCst) != generation {
@@ -812,6 +857,22 @@ impl GatewayClient {
         });
     }
 
+    fn set_canvas_surface_url(&self, canvas_surface_url: Option<String>) {
+        *self
+            .inner
+            .canvas_surface_url
+            .lock()
+            .expect("gateway canvas surface mutex poisoned") = canvas_surface_url;
+    }
+
+    fn canvas_surface_url(&self) -> Option<String> {
+        self.inner
+            .canvas_surface_url
+            .lock()
+            .expect("gateway canvas surface mutex poisoned")
+            .clone()
+    }
+
     fn is_connected(&self) -> bool {
         self.connection_state() == GatewayConnectionState::Up
     }
@@ -832,6 +893,7 @@ impl GatewayClient {
                 .agents_cache
                 .lock()
                 .expect("gateway agents cache mutex poisoned") = None;
+            self.set_canvas_surface_url(None);
         }
         let notice_changed = {
             let mut current = self
@@ -857,23 +919,31 @@ impl GatewayClient {
         let _ = app.emit_to(
             QUICKCHAT_LABEL,
             GATEWAY_STATE_EVENT,
-            GatewayStateEvent::new(state, notice),
+            GatewayStateEvent::new(state, notice, self.canvas_surface_url()),
         );
     }
 }
 
 #[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
 struct GatewayStateEvent {
     state: &'static str,
     #[serde(skip_serializing_if = "Option::is_none")]
     notice: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    canvas_surface_url: Option<String>,
 }
 
 impl GatewayStateEvent {
-    fn new(state: GatewayConnectionState, notice: Option<String>) -> Self {
+    fn new(
+        state: GatewayConnectionState,
+        notice: Option<String>,
+        canvas_surface_url: Option<String>,
+    ) -> Self {
         Self {
             state: state.event_name(),
             notice,
+            canvas_surface_url,
         }
     }
 }
@@ -983,7 +1053,13 @@ fn connect_params(
     auth: &GatewayAuth,
     nonce: &str,
     signed_at_ms: u64,
+    inline_widgets_available: bool,
 ) -> Result<Value, String> {
+    let client_caps = if inline_widgets_available {
+        vec![INLINE_WIDGETS_CLIENT_CAPABILITY]
+    } else {
+        Vec::new()
+    };
     let mut params = json!({
         "minProtocol": MIN_PROTOCOL_VERSION,
         "maxProtocol": MAX_PROTOCOL_VERSION,
@@ -994,7 +1070,7 @@ fn connect_params(
             "mode": CLIENT_MODE,
             "deviceFamily": CLIENT_DEVICE_FAMILY
         },
-        "caps": [],
+        "caps": client_caps,
         "commands": [],
         "permissions": {},
         "role": CLIENT_ROLE,
@@ -1102,6 +1178,25 @@ async fn perform_request(
                     RequestFailure::transport(format!("Invalid chat.send response: {error}"))
                 })
         }
+        GatewayRequest::RefreshCanvasSurface { observed_url } => {
+            let mut params = json!({ "surface": "canvas" });
+            if let Some(observed_url) = observed_url {
+                params["observedUrl"] = Value::String(observed_url);
+            }
+            let payload = request_on_socket(app, socket, "plugin.surface.refresh", params).await?;
+            let response: PluginSurfaceRefreshResponse =
+                serde_json::from_value(payload).map_err(|error| {
+                    RequestFailure::transport(format!(
+                        "Invalid plugin.surface.refresh response: {error}"
+                    ))
+                })?;
+            let canvas = response
+                .plugin_surface_urls
+                .and_then(|urls| urls.get("canvas").cloned())
+                .map(|url| url.trim().to_string())
+                .filter(|url| !url.is_empty());
+            Ok(GatewayResponse::CanvasSurface(canvas))
+        }
     }
 }
 
@@ -1118,15 +1213,30 @@ async fn request_agents_list(
 struct ValidatedHello {
     device_token: Option<String>,
     tick_watch_timeout: Duration,
+    canvas_surface_url: Option<String>,
 }
 
 impl ValidatedHello {
-    fn new(device_token: Option<String>, tick_watch_timeout: Duration) -> Self {
+    fn new(
+        device_token: Option<String>,
+        tick_watch_timeout: Duration,
+        canvas_surface_url: Option<String>,
+    ) -> Self {
         Self {
             device_token,
             tick_watch_timeout,
+            canvas_surface_url,
         }
     }
+}
+
+fn gated_canvas_surface_url(
+    canvas_surface_url: Option<String>,
+    inline_widgets_available: bool,
+) -> Option<String> {
+    inline_widgets_available
+        .then_some(canvas_surface_url)
+        .flatten()
 }
 
 fn validate_hello(payload: Value) -> Result<ValidatedHello, String> {
@@ -1135,6 +1245,7 @@ fn validate_hello(payload: Value) -> Result<ValidatedHello, String> {
         methods: Vec<String>,
     }
     #[derive(Deserialize)]
+    #[serde(rename_all = "camelCase")]
     struct HelloOk {
         #[serde(rename = "type")]
         kind: String,
@@ -1142,6 +1253,7 @@ fn validate_hello(payload: Value) -> Result<ValidatedHello, String> {
         features: HelloFeatures,
         auth: HelloAuth,
         policy: Option<HelloPolicy>,
+        plugin_surface_urls: Option<HashMap<String, String>>,
     }
     #[derive(Deserialize)]
     #[serde(rename_all = "camelCase")]
@@ -1176,9 +1288,15 @@ fn validate_hello(payload: Value) -> Result<ValidatedHello, String> {
         .unwrap_or(30_000)
         .max(1);
     let issued_device_auth = hello.auth.device_token;
+    let canvas_surface_url = hello
+        .plugin_surface_urls
+        .and_then(|surface_urls| surface_urls.get("canvas").cloned())
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty());
     Ok(ValidatedHello::new(
         issued_device_auth,
         Duration::from_millis(tick_interval_ms).saturating_mul(2),
+        canvas_surface_url,
     ))
 }
 
@@ -1460,6 +1578,7 @@ mod tests {
             &GatewayAuth::SharedToken("secret".to_string()),
             "fixture-nonce",
             1_800_000_000_000,
+            true,
         )
         .expect("connect params");
         let frame = request_frame("connect-1", "connect", params);
@@ -1475,6 +1594,10 @@ mod tests {
             CLIENT_DEVICE_FAMILY
         );
         assert_eq!(frame["params"]["auth"], json!({ "token": "secret" }));
+        assert_eq!(
+            frame["params"]["caps"],
+            json!([INLINE_WIDGETS_CLIENT_CAPABILITY])
+        );
         assert_eq!(frame["params"]["device"]["nonce"], "fixture-nonce");
         assert_eq!(frame["params"]["device"]["signedAt"], 1_800_000_000_000_u64);
         assert_eq!(
@@ -1490,6 +1613,16 @@ mod tests {
         assert!(frame["params"]["device"]["signature"]
             .as_str()
             .is_some_and(|value| !value.contains('=')));
+
+        let pinned_params = connect_params(
+            &store.identity(),
+            &GatewayAuth::SharedToken("secret".to_string()),
+            "fixture-nonce",
+            1_800_000_000_000,
+            false,
+        )
+        .expect("pinned connect params");
+        assert_eq!(pinned_params["caps"], json!([]));
         std::fs::remove_dir_all(directory).expect("remove connect fixture");
     }
 
@@ -1500,12 +1633,61 @@ mod tests {
             "protocol": MAX_PROTOCOL_VERSION,
             "features": { "methods": ["agents.list", "chat.send"] },
             "auth": { "deviceToken": "test-device-token" },
-            "policy": { "tickIntervalMs": 1_250 }
+            "policy": { "tickIntervalMs": 1_250 },
+            "pluginSurfaceUrls": {
+                "canvas": "https://gateway.example/__openclaw__/cap/fixture-capability"
+            }
         }))
         .expect("valid hello");
 
         assert_eq!(hello.device_token.as_deref(), Some("test-device-token"));
         assert_eq!(hello.tick_watch_timeout, Duration::from_millis(2_500));
+        assert_eq!(
+            hello.canvas_surface_url.as_deref(),
+            Some("https://gateway.example/__openclaw__/cap/fixture-capability")
+        );
+        assert_eq!(
+            gated_canvas_surface_url(hello.canvas_surface_url.clone(), true),
+            hello.canvas_surface_url
+        );
+        assert_eq!(
+            gated_canvas_surface_url(hello.canvas_surface_url, false),
+            None
+        );
+    }
+
+    #[test]
+    fn plugin_surface_refresh_response_decodes_canvas_url() {
+        let response: PluginSurfaceRefreshResponse = serde_json::from_value(json!({
+            "pluginSurfaceUrls": {
+                "canvas": "https://gateway.example/__openclaw__/cap/refreshed-capability"
+            }
+        }))
+        .expect("refresh response");
+
+        assert_eq!(
+            response
+                .plugin_surface_urls
+                .and_then(|urls| urls.get("canvas").cloned())
+                .as_deref(),
+            Some("https://gateway.example/__openclaw__/cap/refreshed-capability")
+        );
+    }
+
+    #[test]
+    fn gateway_state_event_carries_canvas_surface_in_camel_case() {
+        let event = serde_json::to_value(GatewayStateEvent::new(
+            GatewayConnectionState::Up,
+            None,
+            Some("https://gateway.example/__openclaw__/cap/fixture-capability".to_string()),
+        ))
+        .expect("serialize gateway state");
+
+        assert_eq!(
+            event["canvasSurfaceUrl"],
+            "https://gateway.example/__openclaw__/cap/fixture-capability"
+        );
+        assert!(event.get("canvas_surface_url").is_none());
     }
 
     #[test]

--- a/apps/linux/src-tauri/src/main.rs
+++ b/apps/linux/src-tauri/src/main.rs
@@ -9,6 +9,7 @@ mod installer;
 mod notify;
 mod pending_approvals;
 mod quickchat;
+mod quickchat_widgets;
 mod tray;
 mod updater;
 
@@ -786,6 +787,8 @@ fn main() {
         quickchat::quickchat_set_shortcut,
         quickchat::quickchat_shortcut,
         quickchat::quickchat_show_dashboard,
+        quickchat_widgets::quickchat_refresh_widget_surface,
+        quickchat_widgets::quickchat_sync_widgets,
         updater::open_release_page,
         updater::relaunch,
         updater::updater_ready
@@ -809,6 +812,8 @@ fn main() {
         quickchat::quickchat_set_shortcut,
         quickchat::quickchat_shortcut,
         quickchat::quickchat_show_dashboard,
+        quickchat_widgets::quickchat_refresh_widget_surface,
+        quickchat_widgets::quickchat_sync_widgets,
         updater::open_release_page,
         updater::relaunch,
         updater::updater_ready

--- a/apps/linux/src-tauri/src/quickchat.rs
+++ b/apps/linux/src-tauri/src/quickchat.rs
@@ -1,4 +1,5 @@
 use crate::gateway_ws::{AgentsListResult, ChatSendResult, GatewayClient};
+use crate::quickchat_widgets::QuickChatWidgetState;
 use crate::{tray, DesktopState};
 use serde::Serialize;
 use std::fs;
@@ -6,8 +7,8 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use tauri::{
-    AppHandle, Emitter, LogicalSize, Manager, PhysicalPosition, State, WebviewUrl, WebviewWindow,
-    WebviewWindowBuilder,
+    AppHandle, Emitter, LogicalSize, Manager, PhysicalPosition, State, Webview, WebviewUrl,
+    WebviewWindow, WebviewWindowBuilder, Window,
 };
 use tauri_plugin_global_shortcut::{GlobalShortcutExt, Shortcut};
 use uuid::Uuid;
@@ -67,6 +68,7 @@ pub struct QuickChatState {
     shortcuts_supported: bool,
     hide_requested: Arc<AtomicBool>,
     retry_identity: Arc<Mutex<Option<QuickChatRetryIdentity>>>,
+    widget_state: QuickChatWidgetState,
 }
 
 impl QuickChatState {
@@ -83,7 +85,12 @@ impl QuickChatState {
             shortcuts_supported,
             hide_requested: Arc::new(AtomicBool::new(true)),
             retry_identity: Arc::new(Mutex::new(None)),
+            widget_state: QuickChatWidgetState::default(),
         }
+    }
+
+    pub(crate) fn widget_state(&self) -> &QuickChatWidgetState {
+        &self.widget_state
     }
 
     fn send_idempotency_key(
@@ -470,7 +477,7 @@ fn ensure_quickchat_window(app: &AppHandle) -> Result<WebviewWindow, String> {
     Ok(window)
 }
 
-fn position_quickchat(app: &AppHandle, window: &WebviewWindow) -> Result<(), String> {
+fn position_quickchat(app: &AppHandle, window: &Window) -> Result<(), String> {
     let monitor = app
         .cursor_position()
         .ok()
@@ -517,7 +524,7 @@ fn show_quickchat(app: &AppHandle) -> Result<(), String> {
     window
         .set_size(LogicalSize::new(QUICKCHAT_WIDTH, QUICKCHAT_HEIGHT))
         .map_err(|error| format!("Could not reset Quick Chat size: {error}"))?;
-    position_quickchat(app, &window)?;
+    position_quickchat(app, &window.as_ref().window())?;
     app.state::<QuickChatState>()
         .hide_requested
         .store(false, Ordering::SeqCst);
@@ -541,31 +548,33 @@ fn show_quickchat(app: &AppHandle) -> Result<(), String> {
         .map_err(|error| format!("Could not activate Quick Chat: {error}"))
 }
 
-fn require_quickchat_window(window: &WebviewWindow) -> Result<(), String> {
-    if window.label() == QUICKCHAT_LABEL {
+// Commands take the calling WebView, not WebviewWindow: once widgets are attached the
+// host becomes multi-WebView and Tauri intentionally rejects WebviewWindow command args.
+fn require_quickchat_webview(webview: &Webview) -> Result<(), String> {
+    if webview.label() == QUICKCHAT_LABEL && webview.window().label() == QUICKCHAT_LABEL {
         Ok(())
     } else {
-        Err("Quick Chat command is available only to the Quick Chat window.".to_string())
+        Err("Quick Chat command is available only to the Quick Chat webview.".to_string())
     }
 }
 
 #[tauri::command]
 pub async fn quickchat_agents(
-    window: WebviewWindow,
+    webview: Webview,
     gateway: State<'_, GatewayClient>,
     state: State<'_, QuickChatState>,
 ) -> Result<Vec<QuickChatAgent>, String> {
-    require_quickchat_window(&window)?;
+    require_quickchat_webview(&webview)?;
     state.agents(gateway.inner()).await
 }
 
 #[tauri::command]
 pub async fn quickchat_identity(
-    window: WebviewWindow,
+    webview: Webview,
     gateway: State<'_, GatewayClient>,
     state: State<'_, QuickChatState>,
 ) -> Result<QuickChatAgent, String> {
-    require_quickchat_window(&window)?;
+    require_quickchat_webview(&webview)?;
     state
         .selected_agent(gateway.inner(), MissingSelection::FallBackToDefault)
         .await
@@ -574,23 +583,23 @@ pub async fn quickchat_identity(
 
 #[tauri::command]
 pub async fn quickchat_select_agent(
-    window: WebviewWindow,
+    webview: Webview,
     gateway: State<'_, GatewayClient>,
     state: State<'_, QuickChatState>,
     agent_id: String,
 ) -> Result<QuickChatAgent, String> {
-    require_quickchat_window(&window)?;
+    require_quickchat_webview(&webview)?;
     state.select_agent(gateway.inner(), &agent_id).await
 }
 
 #[tauri::command]
 pub async fn quickchat_send(
-    window: WebviewWindow,
+    webview: Webview,
     gateway: State<'_, GatewayClient>,
     state: State<'_, QuickChatState>,
     message: String,
 ) -> Result<ChatSendResult, String> {
-    require_quickchat_window(&window)?;
+    require_quickchat_webview(&webview)?;
     let message = message.trim().to_string();
     if message.is_empty() {
         return Err("Message cannot be empty.".to_string());
@@ -618,22 +627,22 @@ pub async fn quickchat_send(
 
 #[tauri::command]
 pub fn quickchat_shortcut(
-    window: WebviewWindow,
+    webview: Webview,
     state: State<'_, QuickChatState>,
 ) -> Result<QuickChatShortcutStatus, String> {
-    require_quickchat_window(&window)?;
+    require_quickchat_webview(&webview)?;
     state.shortcut_status()
 }
 
 #[tauri::command]
 pub fn quickchat_set_shortcut(
-    window: WebviewWindow,
+    webview: Webview,
     app: AppHandle,
     desktop: State<'_, DesktopState>,
     state: State<'_, QuickChatState>,
     accelerator: Option<String>,
 ) -> Result<QuickChatShortcutStatus, String> {
-    require_quickchat_window(&window)?;
+    require_quickchat_webview(&webview)?;
     if !state.shortcuts_supported {
         return state.shortcut_status();
     }
@@ -692,8 +701,9 @@ pub fn quickchat_set_shortcut(
 }
 
 #[tauri::command]
-pub fn quickchat_set_expanded(window: WebviewWindow, expanded: bool) -> Result<(), String> {
-    require_quickchat_window(&window)?;
+pub fn quickchat_set_expanded(webview: Webview, expanded: bool) -> Result<(), String> {
+    require_quickchat_webview(&webview)?;
+    let window = webview.window();
     let height = if expanded {
         QUICKCHAT_EXPANDED_HEIGHT
     } else {
@@ -706,13 +716,13 @@ pub fn quickchat_set_expanded(window: WebviewWindow, expanded: bool) -> Result<(
 }
 
 #[tauri::command]
-pub fn quickchat_hide(window: WebviewWindow) -> Result<(), String> {
-    require_quickchat_window(&window)?;
-    window
-        .app_handle()
-        .state::<QuickChatState>()
-        .hide_requested
-        .store(true, Ordering::SeqCst);
+pub async fn quickchat_hide(webview: Webview, generation: u64) -> Result<(), String> {
+    require_quickchat_webview(&webview)?;
+    let window = webview.window();
+    let app = window.app_handle();
+    let state = app.state::<QuickChatState>();
+    state.hide_requested.store(true, Ordering::SeqCst);
+    state.widget_state().close(app, generation).await;
     window
         .hide()
         .map_err(|error| format!("Could not hide Quick Chat: {error}"))?;
@@ -722,22 +732,22 @@ pub fn quickchat_hide(window: WebviewWindow) -> Result<(), String> {
 
 #[tauri::command]
 pub fn quickchat_ready(
-    window: WebviewWindow,
+    webview: Webview,
     gateway: State<'_, GatewayClient>,
     state: State<'_, QuickChatState>,
 ) -> Result<bool, String> {
-    require_quickchat_window(&window)?;
-    gateway.emit_current_state(&window)?;
+    require_quickchat_webview(&webview)?;
+    gateway.emit_current_state(&webview)?;
     Ok(!state.hide_requested.load(Ordering::SeqCst))
 }
 
 #[tauri::command]
 pub fn quickchat_show_dashboard(
-    window: WebviewWindow,
+    webview: Webview,
     app: AppHandle,
     desktop: State<'_, DesktopState>,
 ) -> Result<(), String> {
-    require_quickchat_window(&window)?;
+    require_quickchat_webview(&webview)?;
     tray::open_dashboard(&app, desktop.inner());
     Ok(())
 }

--- a/apps/linux/src-tauri/src/quickchat_widgets.rs
+++ b/apps/linux/src-tauri/src/quickchat_widgets.rs
@@ -1,0 +1,563 @@
+use crate::gateway_ws::GatewayClient;
+use crate::quickchat::{QuickChatState, QUICKCHAT_LABEL};
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+use std::collections::{HashMap, HashSet};
+use std::net::IpAddr;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use tauri::webview::{NewWindowResponse, WebviewBuilder};
+use tauri::{
+    AppHandle, LogicalPosition, LogicalSize, Manager, State, Url, Webview, WebviewUrl, Window,
+};
+use tokio::sync::Mutex as AsyncMutex;
+
+const QUICKCHAT_WIDTH: f64 = 640.0;
+const QUICKCHAT_COMPACT_WINDOW_HEIGHT: f64 = 92.0;
+const QUICKCHAT_TEXT_WINDOW_HEIGHT: f64 = 360.0;
+const QUICKCHAT_WIDGET_WINDOW_HEIGHT: f64 = 440.0;
+const QUICKCHAT_WIDGET_HEIGHT: f64 = 160.0;
+const QUICKCHAT_WIDGET_LABEL_PREFIX: &str = "quickchat-widget-";
+const QUICKCHAT_WIDGET_MAX_COUNT: usize = 32;
+const QUICKCHAT_WIDGET_MAX_URL_BYTES: usize = 4096;
+
+#[derive(Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QuickChatWidgetLayout {
+    key: String,
+    url: String,
+    sandbox: String,
+    x: f64,
+    y: f64,
+    width: f64,
+    height: f64,
+    visible: bool,
+}
+
+#[derive(Clone, Default)]
+pub struct QuickChatWidgetState {
+    views: Arc<Mutex<HashSet<String>>>,
+    sync: Arc<AsyncMutex<()>>,
+    closed_generation: Arc<AtomicU64>,
+}
+
+fn quickchat_window_height(has_widgets: bool, expanded: bool) -> f64 {
+    if has_widgets {
+        QUICKCHAT_WIDGET_WINDOW_HEIGHT
+    } else if expanded {
+        QUICKCHAT_TEXT_WINDOW_HEIGHT
+    } else {
+        QUICKCHAT_COMPACT_WINDOW_HEIGHT
+    }
+}
+
+fn resize_window_if_needed(window: &Window, height: f64) -> Result<(), String> {
+    let scale = window
+        .scale_factor()
+        .map_err(|error| format!("Could not read Quick Chat scale: {error}"))?;
+    let current = window
+        .inner_size()
+        .map_err(|error| format!("Could not read Quick Chat size: {error}"))?;
+    let current_height = f64::from(current.height) / scale;
+    if (current_height - height).abs() <= 0.5 {
+        return Ok(());
+    }
+    window
+        .set_size(LogicalSize::new(QUICKCHAT_WIDTH, height))
+        .map_err(|error| format!("Could not resize Quick Chat for widgets: {error}"))
+}
+
+impl QuickChatWidgetState {
+    fn invalidate_generation(&self, generation: u64) {
+        self.closed_generation
+            .fetch_max(generation, Ordering::SeqCst);
+    }
+
+    fn generation_is_closed(&self, generation: u64) -> bool {
+        generation <= self.closed_generation.load(Ordering::SeqCst)
+    }
+
+    pub async fn close(&self, app: &AppHandle, generation: u64) {
+        // Invalidate before waiting on the sync lock so an older queued request cannot
+        // recreate child WebViews after this hide cycle finishes its cleanup.
+        self.invalidate_generation(generation);
+        let _sync = self.sync.lock().await;
+        let labels = self
+            .views
+            .lock()
+            .map(|mut views| views.drain().collect::<Vec<_>>())
+            .unwrap_or_default();
+        for label in labels {
+            if let Some(webview) = app.get_webview(&label) {
+                let _ = webview.close();
+            }
+        }
+    }
+
+    async fn sync(
+        &self,
+        webview: &Webview,
+        app: &AppHandle,
+        widgets: Vec<QuickChatWidgetLayout>,
+        has_widgets: bool,
+        expanded: bool,
+        generation: u64,
+    ) -> Result<(), String> {
+        if self.generation_is_closed(generation) {
+            return Ok(());
+        }
+        let _sync = self.sync.lock().await;
+        if self.generation_is_closed(generation) {
+            return Ok(());
+        }
+        let window = webview.window();
+        if !has_widgets && !widgets.is_empty() {
+            return Err("Quick Chat received widget layouts without widget content.".to_string());
+        }
+        if widgets.len() > QUICKCHAT_WIDGET_MAX_COUNT {
+            return Err("Quick Chat received too many widgets.".to_string());
+        }
+        let mut keys = HashSet::new();
+        let mut visible_count = 0;
+        let mut prepared = Vec::with_capacity(widgets.len());
+        for widget in widgets {
+            if !keys.insert(widget.key.clone()) {
+                return Err("Quick Chat widget keys must be unique.".to_string());
+            }
+            visible_count += usize::from(widget.visible);
+            let url = validate_widget_layout(&widget)?;
+            let label = widget_view_label(&widget);
+            prepared.push((widget, label, url));
+        }
+        if visible_count > 1 {
+            return Err("Quick Chat can show only one widget at a time.".to_string());
+        }
+        let current = self
+            .views
+            .lock()
+            .map_err(|_| "Quick Chat widget state is unavailable.".to_string())?
+            .clone();
+        let mut desired = HashSet::new();
+        for (_, label, _) in &prepared {
+            if !desired.insert(label.clone()) {
+                return Err("Quick Chat widget identities must be unique.".to_string());
+            }
+        }
+
+        let cleanup_created = |labels: &HashSet<String>| {
+            for label in labels {
+                if let Some(webview) = app.get_webview(label) {
+                    let _ = webview.close();
+                }
+            }
+        };
+        let parent = window.clone();
+        let mut created = HashSet::new();
+        let mut reconciled = Vec::with_capacity(prepared.len());
+        for (widget, label, url) in prepared {
+            let position = LogicalPosition::new(widget.x, widget.y);
+            let size = LogicalSize::new(widget.width, widget.height);
+            let existing = current
+                .contains(&label)
+                .then(|| app.get_webview(&label))
+                .flatten();
+            let webview = match existing {
+                Some(webview) => webview,
+                None => {
+                    if let Some(orphan) = app.get_webview(&label) {
+                        let _ = orphan.close();
+                    }
+                    let allowed_url = url.clone();
+                    // Widget labels intentionally match no Tauri capability. Linux cannot isolate
+                    // iframe IPC, so agent-authored scripts must stay in separate child WebViews.
+                    let mut builder = WebviewBuilder::new(label.clone(), WebviewUrl::External(url))
+                        .incognito(true)
+                        .transparent(true)
+                        .on_navigation(move |candidate| {
+                            same_widget_document(candidate, &allowed_url)
+                        })
+                        .on_new_window(|_, _| NewWindowResponse::Deny);
+                    if widget.sandbox == "strict" {
+                        builder = builder.disable_javascript();
+                    }
+                    match parent.add_child(builder, position, size) {
+                        Ok(webview) => {
+                            created.insert(label.clone());
+                            webview
+                        }
+                        Err(error) => {
+                            cleanup_created(&created);
+                            return Err(format!("Could not create Quick Chat widget: {error}"));
+                        }
+                    }
+                }
+            };
+            if let Err(error) = webview.set_position(position) {
+                cleanup_created(&created);
+                return Err(format!("Could not position Quick Chat widget: {error}"));
+            }
+            if let Err(error) = webview.set_size(size) {
+                cleanup_created(&created);
+                return Err(format!("Could not resize Quick Chat widget: {error}"));
+            }
+            reconciled.push((widget.visible, webview));
+        }
+
+        for (visible, webview) in &reconciled {
+            let result = if *visible {
+                webview.show()
+            } else {
+                webview.hide()
+            };
+            if let Err(error) = result {
+                cleanup_created(&created);
+                return Err(format!(
+                    "Could not update Quick Chat widget visibility: {error}"
+                ));
+            }
+        }
+        if let Err(error) =
+            resize_window_if_needed(&window, quickchat_window_height(has_widgets, expanded))
+        {
+            cleanup_created(&created);
+            return Err(error);
+        }
+
+        let mut committed = desired.clone();
+        for label in current.difference(&desired) {
+            if app
+                .get_webview(label)
+                .is_some_and(|webview| webview.close().is_err())
+            {
+                committed.insert(label.clone());
+            }
+        }
+        *self.views.lock().map_err(|_| {
+            cleanup_created(&created);
+            "Quick Chat widget state is unavailable.".to_string()
+        })? = committed;
+        Ok(())
+    }
+}
+
+#[tauri::command]
+pub async fn quickchat_refresh_widget_surface(
+    webview: Webview,
+    gateway: State<'_, GatewayClient>,
+) -> Result<Option<String>, String> {
+    if webview.label() != QUICKCHAT_LABEL || webview.window().label() != QUICKCHAT_LABEL {
+        return Err("Quick Chat command is available only to the Quick Chat webview.".to_string());
+    }
+    gateway.refresh_canvas_surface().await
+}
+
+#[tauri::command]
+pub async fn quickchat_sync_widgets(
+    webview: Webview,
+    app: AppHandle,
+    state: State<'_, QuickChatState>,
+    widgets: Vec<QuickChatWidgetLayout>,
+    has_widgets: bool,
+    expanded: bool,
+    generation: u64,
+) -> Result<(), String> {
+    if webview.label() != QUICKCHAT_LABEL || webview.window().label() != QUICKCHAT_LABEL {
+        return Err("Quick Chat command is available only to the Quick Chat webview.".to_string());
+    }
+    state
+        .widget_state()
+        .sync(&webview, &app, widgets, has_widgets, expanded, generation)
+        .await
+}
+
+fn percent_decode_once(raw: &str) -> Option<String> {
+    let bytes = raw.as_bytes();
+    let mut decoded = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] != b'%' {
+            decoded.push(bytes[index]);
+            index += 1;
+            continue;
+        }
+        if index + 2 >= bytes.len() {
+            return None;
+        }
+        let byte = u8::from_str_radix(&raw[index + 1..index + 3], 16).ok()?;
+        decoded.push(byte);
+        index += 3;
+    }
+    String::from_utf8(decoded).ok()
+}
+
+fn percent_decode_repeatedly(raw: &str) -> Option<String> {
+    let mut value = raw.to_string();
+    for _ in 0..8 {
+        let decoded = percent_decode_once(&value)?;
+        if decoded == value {
+            return Some(decoded);
+        }
+        value = decoded;
+    }
+    None
+}
+
+fn has_url_userinfo(url: &Url) -> bool {
+    url.as_str()
+        .split_once("://")
+        .map(|(_, suffix)| {
+            suffix
+                .split(['/', '?', '#'])
+                .next()
+                .is_some_and(|authority| authority.contains('@'))
+        })
+        .unwrap_or(false)
+}
+
+fn has_secure_widget_transport(url: &Url) -> bool {
+    if url.scheme() == "https" {
+        return true;
+    }
+    if url.scheme() != "http" {
+        return false;
+    }
+    let Some(host) = url
+        .host_str()
+        .map(|host| host.trim_matches(['[', ']']).to_ascii_lowercase())
+    else {
+        return false;
+    };
+    host == "localhost"
+        || host.ends_with(".localhost")
+        || host
+            .parse::<IpAddr>()
+            .is_ok_and(|address| address.is_loopback())
+}
+
+fn validate_widget_url(raw: &str) -> Result<Url, String> {
+    if raw.len() > QUICKCHAT_WIDGET_MAX_URL_BYTES {
+        return Err("Quick Chat widget URL is too long.".to_string());
+    }
+    let url =
+        Url::parse(raw.trim()).map_err(|_| "Quick Chat widget URL is invalid.".to_string())?;
+    if !has_secure_widget_transport(&url) || has_url_userinfo(&url) || url.host_str().is_none() {
+        return Err("Quick Chat widget URL is not a secure HTTP capability URL.".to_string());
+    }
+    let encoded_segments = url
+        .path()
+        .split('/')
+        .skip(1)
+        .map(ToOwned::to_owned)
+        .collect::<Vec<_>>();
+    if encoded_segments.iter().any(|segment| segment.is_empty()) {
+        return Err("Quick Chat widget URL has an invalid path.".to_string());
+    }
+    let segments = encoded_segments
+        .iter()
+        .map(|segment| {
+            let decoded = percent_decode_repeatedly(segment)
+                .ok_or_else(|| "Quick Chat widget URL has invalid encoding.".to_string())?;
+            if decoded == "." || decoded == ".." || decoded.contains('/') || decoded.contains('\\')
+            {
+                return Err("Quick Chat widget URL has an unsafe path.".to_string());
+            }
+            Ok(decoded)
+        })
+        .collect::<Result<Vec<_>, String>>()?;
+    let Some(capability_index) = segments
+        .windows(2)
+        .rposition(|pair| pair == ["__openclaw__", "cap"])
+    else {
+        return Err("Quick Chat widget URL is missing its capability scope.".to_string());
+    };
+    let document_index = capability_index + 3;
+    if segments
+        .get(capability_index + 2)
+        .is_none_or(String::is_empty)
+        || segments.get(document_index).map(String::as_str) != Some("__openclaw__")
+        || segments.get(document_index + 1).map(String::as_str) != Some("canvas")
+        || segments.get(document_index + 2).map(String::as_str) != Some("documents")
+        || segments.len() < document_index + 5
+    {
+        return Err("Quick Chat widget URL is outside the Canvas document scope.".to_string());
+    }
+    Ok(url)
+}
+
+fn validate_widget_layout(widget: &QuickChatWidgetLayout) -> Result<Url, String> {
+    if widget.key.trim().is_empty() || widget.key.len() > 256 {
+        return Err("Quick Chat widget key is invalid.".to_string());
+    }
+    if widget.sandbox != "scripts" && widget.sandbox != "strict" {
+        return Err("Quick Chat widget sandbox is invalid.".to_string());
+    }
+    if !widget.x.is_finite()
+        || !widget.y.is_finite()
+        || !widget.width.is_finite()
+        || !widget.height.is_finite()
+        || widget.x < 0.0
+        || widget.y < 0.0
+        || widget.width < 1.0
+        || (widget.height - QUICKCHAT_WIDGET_HEIGHT).abs() > 0.5
+        || widget.x + widget.width > QUICKCHAT_WIDTH + 1.0
+        || widget.y + widget.height > QUICKCHAT_WIDGET_WINDOW_HEIGHT + 1.0
+    {
+        return Err("Quick Chat widget bounds are invalid.".to_string());
+    }
+    validate_widget_url(&widget.url)
+}
+
+fn widget_view_label(widget: &QuickChatWidgetLayout) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(widget.key.as_bytes());
+    hasher.update([0]);
+    hasher.update(widget.url.as_bytes());
+    hasher.update([0]);
+    hasher.update(widget.sandbox.as_bytes());
+    let digest = hasher.finalize();
+    let suffix = digest[..8]
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    format!("{QUICKCHAT_WIDGET_LABEL_PREFIX}{suffix}")
+}
+
+fn same_widget_document(candidate: &Url, allowed: &Url) -> bool {
+    candidate.scheme() == allowed.scheme()
+        && !has_url_userinfo(candidate)
+        && candidate.host_str() == allowed.host_str()
+        && candidate.port_or_known_default() == allowed.port_or_known_default()
+        && candidate.path() == allowed.path()
+        && candidate.query() == allowed.query()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_widget(key: &str, url: &str, sandbox: &str) -> QuickChatWidgetLayout {
+        QuickChatWidgetLayout {
+            key: key.to_string(),
+            url: url.to_string(),
+            sandbox: sandbox.to_string(),
+            x: 52.0,
+            y: 174.0,
+            width: 540.0,
+            height: QUICKCHAT_WIDGET_HEIGHT,
+            visible: true,
+        }
+    }
+
+    #[test]
+    fn hide_generation_invalidates_queued_syncs() {
+        let state = QuickChatWidgetState::default();
+        assert!(!state.generation_is_closed(1));
+        state.invalidate_generation(2);
+        assert!(state.generation_is_closed(1));
+        assert!(state.generation_is_closed(2));
+        assert!(!state.generation_is_closed(3));
+    }
+
+    #[test]
+    fn semantic_widget_state_owns_window_height() {
+        assert_eq!(
+            quickchat_window_height(false, false),
+            QUICKCHAT_COMPACT_WINDOW_HEIGHT
+        );
+        assert_eq!(
+            quickchat_window_height(false, true),
+            QUICKCHAT_TEXT_WINDOW_HEIGHT
+        );
+        assert_eq!(
+            quickchat_window_height(true, false),
+            QUICKCHAT_WIDGET_WINDOW_HEIGHT
+        );
+        assert_eq!(
+            quickchat_window_height(true, true),
+            QUICKCHAT_WIDGET_WINDOW_HEIGHT
+        );
+    }
+
+    #[test]
+    fn layout_requires_a_scoped_canvas_document() {
+        let valid = test_widget(
+            "status",
+            "https://gateway.example/base/__openclaw__/cap/fixture-capability/__openclaw__/canvas/documents/status/index.html",
+            "scripts",
+        );
+        assert!(validate_widget_layout(&valid).is_ok());
+        assert!(validate_widget_layout(&test_widget(
+            "local",
+            "http://127.0.0.1:18789/__openclaw__/cap/fixture-capability/__openclaw__/canvas/documents/local/index.html",
+            "scripts",
+        ))
+        .is_ok());
+        assert!(validate_widget_layout(&test_widget(
+            "local-v6",
+            "http://[::1]:18789/__openclaw__/cap/fixture-capability/__openclaw__/canvas/documents/local-v6/index.html",
+            "scripts",
+        ))
+        .is_ok());
+
+        for url in [
+            "https://evil.example/widget.html",
+            "http://gateway.example/__openclaw__/cap/fixture-capability/__openclaw__/canvas/documents/status/index.html",
+            "https://gateway.example/__openclaw__/canvas/documents/status/index.html",
+            "https://gateway.example/__openclaw__/cap/fixture-capability/__openclaw__/canvas/documents/%252e%252e/private-file",
+        ] {
+            assert!(validate_widget_layout(&test_widget("status", url, "scripts")).is_err());
+        }
+        let mut outside_window = valid.clone();
+        outside_window.y = QUICKCHAT_WIDGET_WINDOW_HEIGHT;
+        assert!(validate_widget_layout(&outside_window).is_err());
+    }
+
+    #[test]
+    fn labels_preserve_existing_instances_when_siblings_append() {
+        let first = test_widget(
+            "first",
+            "https://gateway.example/__openclaw__/cap/fixture-capability/__openclaw__/canvas/documents/first/index.html",
+            "scripts",
+        );
+        let second = test_widget(
+            "second",
+            "https://gateway.example/__openclaw__/cap/fixture-capability/__openclaw__/canvas/documents/second/index.html",
+            "scripts",
+        );
+        let first_label = widget_view_label(&first);
+        let desired_before = HashMap::from([(first.key.clone(), first_label.clone())]);
+        let desired_after = HashMap::from([
+            (first.key.clone(), widget_view_label(&first)),
+            (second.key.clone(), widget_view_label(&second)),
+        ]);
+
+        assert_eq!(desired_after.get("first"), desired_before.get("first"));
+        let mut navigated = first.clone();
+        navigated.url.push_str("?revision=2");
+        assert_ne!(widget_view_label(&navigated), first_label);
+    }
+
+    #[test]
+    fn navigation_stays_on_the_original_document() {
+        let allowed = Url::parse(
+            "https://gateway.example/__openclaw__/cap/fixture-capability/__openclaw__/canvas/documents/status/index.html?mode=compact",
+        )
+        .expect("allowed URL");
+        let fragment = Url::parse(
+            "https://gateway.example/__openclaw__/cap/fixture-capability/__openclaw__/canvas/documents/status/index.html?mode=compact#details",
+        )
+        .expect("fragment URL");
+        let other = Url::parse(
+            "https://gateway.example/__openclaw__/cap/fixture-capability/__openclaw__/canvas/documents/other/index.html",
+        )
+        .expect("other URL");
+        let mut userinfo_url = allowed.clone();
+        userinfo_url
+            .set_username("fixture-user")
+            .expect("set fixture user");
+
+        assert!(same_widget_document(&fragment, &allowed));
+        assert!(!same_widget_document(&other, &allowed));
+        assert!(!same_widget_document(&userinfo_url, &allowed));
+    }
+}

--- a/apps/linux/src-tauri/tauri.conf.json
+++ b/apps/linux/src-tauri/tauri.conf.json
@@ -68,9 +68,9 @@
         },
         {
           "identifier": "quickchat",
-          "description": "Quick Chat can select agents, configure its shortcut, send messages, and receive window events.",
+          "description": "Quick Chat can select agents, configure its shortcut, send messages, render hosted widgets, and receive window events.",
           "local": true,
-          "windows": ["quickchat"],
+          "webviews": ["quickchat"],
           "permissions": [
             "allow-quickchat",
             "core:event:allow-listen",

--- a/apps/linux/ui/quickchat.css
+++ b/apps/linux/ui/quickchat.css
@@ -296,6 +296,76 @@ body.shown .composer {
   white-space: pre-wrap;
 }
 
+.reply.has-widgets .reply-scroll {
+  max-height: 90px;
+}
+
+.reply-widgets {
+  display: grid;
+  margin-top: 8px;
+  gap: 6px;
+}
+
+.inline-widget-tabs {
+  display: flex;
+  gap: 5px;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.inline-widget-tab {
+  height: 23px;
+  padding: 0 8px;
+  overflow: hidden;
+  border: 1px solid rgb(255 255 255 / 9%);
+  border-radius: 999px;
+  color: #9f9fa4;
+  cursor: pointer;
+  font: 600 10px/1 inherit;
+  background: rgb(255 255 255 / 4%);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.inline-widget-tab.active {
+  color: #f7f7f8;
+  border-color: rgb(255 107 107 / 38%);
+  background: rgb(255 107 107 / 12%);
+}
+
+.inline-widget {
+  overflow: hidden;
+  border: 1px solid rgb(255 255 255 / 9%);
+  border-radius: 10px;
+  background: rgb(0 0 0 / 18%);
+}
+
+.inline-widget-title {
+  padding: 7px 9px;
+  overflow: hidden;
+  border-bottom: 1px solid rgb(255 255 255 / 7%);
+  color: #d7d7da;
+  font-size: 11px;
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.inline-widget-host {
+  width: 100%;
+  min-height: 160px;
+  background: transparent;
+}
+
+.inline-widget-unavailable {
+  min-height: 160px;
+  padding: 18px 12px;
+  color: #8e8e93;
+  font-size: 11px;
+  line-height: 1.4;
+  text-align: center;
+}
+
 .reply-thinking {
   display: inline-block;
   color: transparent;

--- a/apps/linux/ui/quickchat.html
+++ b/apps/linux/ui/quickchat.html
@@ -56,6 +56,7 @@
           <span id="reply-thinking" class="reply-thinking">Thinking…</span>
           <p id="reply-error" class="status reply-error" role="alert"></p>
         </div>
+        <div id="reply-widgets" class="reply-widgets" hidden></div>
       </section>
     </main>
     <section id="agent-menu" class="popover" aria-label="Choose agent" hidden>

--- a/apps/linux/ui/quickchat.js
+++ b/apps/linux/ui/quickchat.js
@@ -41,6 +41,204 @@ function assembleChatDelta(currentText, payload) {
   return snapshot;
 }
 
+const INLINE_WIDGET_DOCUMENTS_PATH = "/__openclaw__/canvas/documents";
+const INLINE_WIDGET_MIN_HEIGHT = 160;
+const INLINE_WIDGET_MAX_HEIGHT = 1200;
+const INLINE_WIDGET_VIEWPORT_MAX_HEIGHT = 160;
+const CANVAS_SURFACE_REFRESH_INTERVAL_MS = 8 * 60 * 1_000;
+
+function decodeRepeatedly(raw) {
+  let value = raw;
+  for (let index = 0; index < 8; index += 1) {
+    let decoded;
+    try {
+      decoded = decodeURIComponent(value);
+    } catch {
+      return null;
+    }
+    if (decoded === value) {
+      return decoded;
+    }
+    value = decoded;
+  }
+  return null;
+}
+
+function canonicalInlineWidgetTarget(raw) {
+  if (typeof raw !== "string") {
+    return null;
+  }
+  const target = raw.trim();
+  if (!target.startsWith("/") || target.startsWith("//") || target.includes("\\")) {
+    return null;
+  }
+  const suffixIndex = [target.indexOf("?"), target.indexOf("#")]
+    .filter((index) => index >= 0)
+    .reduce((lowest, index) => Math.min(lowest, index), target.length);
+  const path = target.slice(0, suffixIndex);
+  if (!path.startsWith(`${INLINE_WIDGET_DOCUMENTS_PATH}/`)) {
+    return null;
+  }
+  const segments = path.split("/");
+  if (
+    segments[0] !== "" ||
+    segments.slice(1).some((segment) => {
+      if (!segment) {
+        return true;
+      }
+      const decoded = decodeRepeatedly(segment);
+      return (
+        decoded === null ||
+        decoded === "." ||
+        decoded === ".." ||
+        decoded.includes("/") ||
+        decoded.includes("\\")
+      );
+    })
+  ) {
+    return null;
+  }
+  try {
+    const parsed = new URL(target, "http://openclaw.invalid");
+    return parsed.origin === "http://openclaw.invalid" && parsed.pathname === path ? target : null;
+  } catch {
+    return null;
+  }
+}
+
+function boundedWidgetKey(raw) {
+  if (raw.length <= 200) {
+    return raw;
+  }
+  let hash = 2166136261;
+  for (const character of raw) {
+    hash ^= character.codePointAt(0);
+    hash = Math.imul(hash, 16777619) >>> 0;
+  }
+  const prefix = raw.replace(/[^A-Za-z0-9._-]+/gu, "-").replace(/^-+|-+$/gu, "").slice(0, 80);
+  return `${prefix || "widget"}-${hash.toString(16).padStart(8, "0")}`;
+}
+
+function coerceInlineWidgetPreview(block) {
+  const preview = block?.type === "canvas" ? block.preview : null;
+  if (
+    !preview ||
+    preview.kind !== "canvas" ||
+    preview.surface !== "assistant_message" ||
+    preview.render !== "url" ||
+    !["scripts", "strict"].includes(preview.sandbox)
+  ) {
+    return null;
+  }
+  const target = canonicalInlineWidgetTarget(preview.url);
+  if (!target) {
+    return null;
+  }
+  const preferredHeight = Number.isFinite(preview.preferredHeight)
+    ? Math.min(
+        Math.max(Math.trunc(preview.preferredHeight), INLINE_WIDGET_MIN_HEIGHT),
+        INLINE_WIDGET_MAX_HEIGHT,
+      )
+    : 320;
+  return {
+    key: boundedWidgetKey(
+      typeof preview.viewId === "string" && preview.viewId.trim() ? preview.viewId.trim() : target,
+    ),
+    title: typeof preview.title === "string" && preview.title.trim() ? preview.title.trim() : "Widget",
+    target,
+    preferredHeight,
+    sandbox: preview.sandbox,
+  };
+}
+
+function chatMessageWidgets(message) {
+  const role = typeof message?.role === "string" ? message.role.trim().toLowerCase() : null;
+  if (role !== "assistant" || !Array.isArray(message?.content)) {
+    return [];
+  }
+  const emitted = new Set();
+  return message.content
+    .map(coerceInlineWidgetPreview)
+    .filter(Boolean)
+    .map((widget) => {
+      const base = widget.key.slice(0, 240);
+      let key = widget.key;
+      let suffix = 2;
+      while (emitted.has(key)) {
+        key = `${base}-${suffix}`;
+        suffix += 1;
+      }
+      emitted.add(key);
+      return key === widget.key ? widget : { ...widget, key };
+    });
+}
+
+function isLoopbackHostname(rawHostname) {
+  const hostname = rawHostname.toLowerCase().replace(/^\[|\]$/gu, "");
+  if (hostname === "localhost" || hostname.endsWith(".localhost") || hostname === "::1") {
+    return true;
+  }
+  const octets = hostname.split(".");
+  return (
+    octets.length === 4 &&
+    octets[0] === "127" &&
+    octets.every((octet) => /^\d{1,3}$/u.test(octet) && Number(octet) <= 255)
+  );
+}
+
+function resolveInlineWidgetUrl(rawSurfaceUrl, rawTarget) {
+  const target = canonicalInlineWidgetTarget(rawTarget);
+  if (!target || typeof rawSurfaceUrl !== "string") {
+    return null;
+  }
+  let surface;
+  try {
+    surface = new URL(rawSurfaceUrl.trim());
+  } catch {
+    return null;
+  }
+  const secureTransport =
+    surface.protocol === "https:" ||
+    (surface.protocol === "http:" && isLoopbackHostname(surface.hostname));
+  if (
+    !secureTransport ||
+    surface.username ||
+    surface.password ||
+    surface.search ||
+    surface.hash
+  ) {
+    return null;
+  }
+  const encodedSegments = surface.pathname.split("/");
+  if (encodedSegments[0] !== "" || encodedSegments.slice(1).some((segment) => !segment)) {
+    return null;
+  }
+  const segments = [];
+  for (const encoded of encodedSegments.slice(1)) {
+    const decoded = decodeRepeatedly(encoded);
+    if (
+      decoded === null ||
+      decoded === "." ||
+      decoded === ".." ||
+      decoded.includes("/") ||
+      decoded.includes("\\")
+    ) {
+      return null;
+    }
+    segments.push(decoded);
+  }
+  if (
+    segments.length < 3 ||
+    segments.at(-3) !== "__openclaw__" ||
+    segments.at(-2) !== "cap" ||
+    !segments.at(-1)
+  ) {
+    return null;
+  }
+  const prefix = surface.pathname.replace(/\/+$/u, "");
+  return `${surface.origin}${prefix}${target}`;
+}
+
 const tauri = window["__TAURI__"];
 const { invoke } = tauri.core;
 const { listen } = tauri.event;
@@ -60,6 +258,7 @@ const elements = {
   replyState: document.querySelector("#reply-state"),
   replyText: document.querySelector("#reply-text"),
   replyThinking: document.querySelector("#reply-thinking"),
+  replyWidgets: document.querySelector("#reply-widgets"),
   send: document.querySelector("#send"),
   sendIcon: document.querySelector("#send-icon"),
   shortcutCapture: document.querySelector("#shortcut-capture"),
@@ -85,6 +284,9 @@ let popoverSequence = 0;
 let sendError = "";
 let gatewayState = "down";
 let gatewayNotice = "";
+let canvasSurfaceUrl = null;
+let canvasSurfaceRefreshedAt = 0;
+let canvasSurfaceRefreshPromise = null;
 let gatewayDisconnectSequence = 0;
 let openPopover = null;
 let menuIndex = 0;
@@ -130,12 +332,26 @@ function setGatewayState(payload) {
   const wasUp = gatewayState === "up";
   gatewayState = payload?.state || "down";
   gatewayNotice = typeof payload?.notice === "string" ? payload.notice : "";
+  const nextCanvasSurfaceUrl =
+    gatewayState === "up" && typeof payload?.canvasSurfaceUrl === "string"
+      ? payload.canvasSurfaceUrl
+      : null;
+  if (nextCanvasSurfaceUrl !== canvasSurfaceUrl) {
+    canvasSurfaceRefreshedAt = nextCanvasSurfaceUrl ? Date.now() : 0;
+  }
+  canvasSurfaceUrl = nextCanvasSurfaceUrl;
+  if (!canvasSurfaceUrl) {
+    canvasSurfaceRefreshPromise = null;
+  }
   if (gatewayState !== "up") {
     gatewayDisconnectSequence += 1;
     terminalizeDisconnectedReply();
   }
   renderStatus();
   updateSendButton();
+  if (activeReply?.widgets.length) {
+    renderReplyWidgets();
+  }
   if (gatewayState === "up" && !wasUp) {
     void refreshAgents();
   }
@@ -195,11 +411,14 @@ function resetAccepted() {
 function clearReply() {
   activeReply = null;
   elements.reply.hidden = true;
-  elements.reply.classList.remove("has-error", "is-terminal");
+  elements.reply.classList.remove("has-error", "has-widgets", "is-terminal");
   elements.replyError.textContent = "";
   elements.replyState.textContent = "";
   elements.replyText.textContent = "";
+  elements.replyWidgets.replaceChildren();
+  elements.replyWidgets.hidden = true;
   elements.replyThinking.hidden = true;
+  scheduleWidgetSync();
 }
 
 function scrollReplyToEnd() {
@@ -212,7 +431,183 @@ function renderReplyText() {
   // Deliberately plain text: this small native surface avoids a Markdown dependency and preserves
   // whitespace, leaving Markdown punctuation visible instead of interpreting agent output.
   elements.replyText.textContent = activeReply?.text || "";
+  if (activeReply?.widgets.length) {
+    scheduleWidgetSync();
+  }
   scrollReplyToEnd();
+}
+
+function canvasSurfaceNeedsRefresh() {
+  return (
+    Boolean(canvasSurfaceUrl) &&
+    Date.now() - canvasSurfaceRefreshedAt >= CANVAS_SURFACE_REFRESH_INTERVAL_MS
+  );
+}
+
+function refreshCanvasSurface() {
+  if (canvasSurfaceRefreshPromise) {
+    return canvasSurfaceRefreshPromise;
+  }
+  if (!canvasSurfaceUrl) {
+    return Promise.resolve(null);
+  }
+  canvasSurfaceRefreshPromise = invoke("quickchat_refresh_widget_surface")
+    .then((refreshed) => {
+      canvasSurfaceUrl = typeof refreshed === "string" && refreshed.trim() ? refreshed : null;
+      canvasSurfaceRefreshedAt = canvasSurfaceUrl ? Date.now() : 0;
+      return canvasSurfaceUrl;
+    })
+    .catch(() => {
+      canvasSurfaceUrl = null;
+      canvasSurfaceRefreshedAt = 0;
+      return null;
+    })
+    .finally(() => {
+      canvasSurfaceRefreshPromise = null;
+      if (activeReply?.widgets.length) {
+        renderReplyWidgets();
+      }
+    });
+  return canvasSurfaceRefreshPromise;
+}
+
+let widgetSyncScheduled = false;
+let widgetSyncPromise = Promise.resolve();
+
+function scheduleWidgetSync() {
+  if (widgetSyncScheduled) {
+    return;
+  }
+  const generation = visibilitySequence;
+  widgetSyncScheduled = true;
+  window.requestAnimationFrame(() => {
+    widgetSyncScheduled = false;
+    const widgets = activeReply?.widgets || [];
+    const activeKey = activeReply?.activeWidgetKey ?? null;
+    const host = elements.replyWidgets.querySelector(".inline-widget-host");
+    const rect = host?.getBoundingClientRect();
+    const layouts = [];
+    if (rect && rect.width > 0 && rect.height > 0) {
+      for (const widget of widgets) {
+        const url = resolveInlineWidgetUrl(canvasSurfaceUrl, widget.target);
+        if (!url) {
+          continue;
+        }
+        layouts.push({
+          key: widget.key,
+          url,
+          sandbox: widget.sandbox,
+          x: rect.x,
+          y: rect.y,
+          width: rect.width,
+          height: rect.height,
+          visible: widget.key === activeKey && !openPopover,
+        });
+      }
+    }
+    widgetSyncPromise = widgetSyncPromise
+      .catch(() => {})
+      .then(() =>
+        invoke("quickchat_sync_widgets", {
+          widgets: layouts,
+          hasWidgets: widgets.length > 0,
+          expanded: !elements.reply.hidden || Boolean(openPopover),
+          generation,
+        }),
+      )
+      .catch((error) => {
+        sendError = friendlyError(error, "Could not render the widget.");
+        renderStatus();
+      });
+  });
+}
+
+function selectReplyWidget(key) {
+  if (!activeReply?.widgets.some((widget) => widget.key === key)) {
+    return;
+  }
+  activeReply.activeWidgetKey = key;
+  renderReplyWidgets();
+}
+
+function renderReplyWidgets() {
+  elements.replyWidgets.replaceChildren();
+  const widgets = activeReply?.widgets || [];
+  elements.replyWidgets.hidden = widgets.length === 0;
+  elements.reply.classList.toggle("has-widgets", widgets.length > 0);
+  if (widgets.length === 0) {
+    scheduleWidgetSync();
+    return;
+  }
+
+  const activeKey = widgets.some((widget) => widget.key === activeReply.activeWidgetKey)
+    ? activeReply.activeWidgetKey
+    : widgets[0].key;
+  activeReply.activeWidgetKey = activeKey;
+  if (widgets.length > 1) {
+    const tabs = document.createElement("div");
+    tabs.className = "inline-widget-tabs";
+    for (const widget of widgets) {
+      const tab = document.createElement("button");
+      tab.type = "button";
+      tab.className = "inline-widget-tab";
+      tab.classList.toggle("active", widget.key === activeKey);
+      tab.textContent = widget.title;
+      tab.addEventListener("click", () => selectReplyWidget(widget.key));
+      tabs.append(tab);
+    }
+    elements.replyWidgets.append(tabs);
+  }
+
+  const widget = widgets.find((candidate) => candidate.key === activeKey) ?? widgets[0];
+  const card = document.createElement("section");
+  card.className = "inline-widget";
+  card.dataset.widgetKey = widget.key;
+  const title = document.createElement("div");
+  title.className = "inline-widget-title";
+  title.textContent = widget.title;
+  card.append(title);
+
+  if (!resolveInlineWidgetUrl(canvasSurfaceUrl, widget.target)) {
+    const unavailable = document.createElement("div");
+    unavailable.className = "inline-widget-unavailable";
+    unavailable.textContent = "Widget unavailable until the Gateway reconnects.";
+    card.append(unavailable);
+  } else {
+    const host = document.createElement("div");
+    host.className = "inline-widget-host";
+    host.style.height = `${Math.min(widget.preferredHeight, INLINE_WIDGET_VIEWPORT_MAX_HEIGHT)}px`;
+    card.append(host);
+  }
+  elements.replyWidgets.append(card);
+  scheduleWidgetSync();
+  scrollReplyToEnd();
+}
+
+function updateReplyWidgets(message) {
+  if (!Array.isArray(message?.content)) {
+    return;
+  }
+  const role = typeof message?.role === "string" ? message.role.trim().toLowerCase() : null;
+  if (role !== "assistant") {
+    return;
+  }
+  const widgets = chatMessageWidgets(message);
+  const changed = JSON.stringify(widgets) !== JSON.stringify(activeReply?.widgets || []);
+  if (activeReply && changed) {
+    activeReply.widgets = widgets;
+    if (!widgets.some((widget) => widget.key === activeReply.activeWidgetKey)) {
+      activeReply.activeWidgetKey = widgets[0]?.key ?? null;
+    }
+    if (widgets.length && canvasSurfaceNeedsRefresh()) {
+      const refresh = refreshCanvasSurface();
+      canvasSurfaceUrl = null;
+      renderReplyWidgets();
+      void refresh;
+    } else {
+      renderReplyWidgets();
+    }
+  }
 }
 
 function stopReplyThinking() {
@@ -249,12 +644,16 @@ function startReply(target, identity, runId) {
     },
     terminal: false,
     text: null,
+    widgets: [],
+    activeWidgetKey: null,
   };
   elements.reply.hidden = false;
-  elements.reply.classList.remove("has-error", "is-terminal");
+  elements.reply.classList.remove("has-error", "has-widgets", "is-terminal");
   elements.replyError.textContent = "";
   elements.replyState.textContent = "";
   elements.replyText.textContent = "";
+  elements.replyWidgets.replaceChildren();
+  elements.replyWidgets.hidden = true;
   elements.replyThinking.textContent = reducedMotion.matches ? "…" : "Thinking…";
   elements.replyThinking.hidden = false;
   renderAvatar(elements.replyAgentAvatar, identity);
@@ -275,6 +674,7 @@ function applyChatEvent(payload) {
     return;
   }
 
+  updateReplyWidgets(payload?.message);
   const hasTextUpdate =
     typeof payload?.deltaText === "string" || chatMessageText(payload?.message) !== null;
   if (hasTextUpdate) {
@@ -421,6 +821,9 @@ function setPopoverVisibility(kind) {
   if (kind !== "shortcut") {
     resetShortcutCapture();
   }
+  if (activeReply?.widgets.length) {
+    scheduleWidgetSync();
+  }
 }
 
 async function openNamedPopover(kind) {
@@ -547,7 +950,7 @@ async function requestHide() {
   hideTimer = window.setTimeout(
     async () => {
       try {
-        await invoke("quickchat_hide");
+        await invoke("quickchat_hide", { generation: hideSequence });
         resetAccepted();
         clearReply();
       } catch (error) {
@@ -568,6 +971,7 @@ async function requestHide() {
 }
 
 function reveal() {
+  visibilitySequence += 1;
   window.clearTimeout(hideTimer);
   resetAccepted();
   hiding = false;
@@ -651,6 +1055,7 @@ async function send(openDashboard) {
   }
 }
 
+window.addEventListener("resize", scheduleWidgetSync);
 elements.input.addEventListener("input", () => {
   sendError = "";
   renderStatus();
@@ -746,7 +1151,6 @@ document.addEventListener("pointerdown", (event) => {
 });
 
 await listen("quickchat:shown", () => {
-  visibilitySequence += 1;
   reveal();
 });
 await listen("quickchat:hide-requested", () => {

--- a/docs/tools/show-widget.md
+++ b/docs/tools/show-widget.md
@@ -9,11 +9,11 @@ read_when:
   - You need the show_widget input, security, or retention contract
 ---
 
-`show_widget` is a core tool that shows a self-contained HTML widget on the user's current surface. OpenClaw renders it inline in the Control UI, iOS, Android, and macOS chat transcripts; Linux uses the browser Control UI. In a Discord session with [Activities](/channels/discord-activities) enabled, the Discord plugin posts an **Open widget** button that launches it as an Activity.
+`show_widget` is a core tool that shows a self-contained HTML widget on the user's current surface. OpenClaw renders it inline in the Control UI and in iOS, Android, macOS, and Linux Quick Chat transcripts; the Linux dashboard uses the browser Control UI. In a Discord session with [Activities](/channels/discord-activities) enabled, the Discord plugin posts an **Open widget** button that launches it as an Activity.
 
 ## How widgets work
 
-When the agent calls `show_widget`, OpenClaw core wraps `widget_code` in a minimal HTML document, stores it as a Canvas document, and returns a preview handle. The Control UI renders that handle as a sandboxed iframe directly under the tool call, while native apps use an isolated web view. Both restore the widget after history reload.
+When the agent calls `show_widget`, OpenClaw core wraps `widget_code` in a minimal HTML document, stores it as a Canvas document, and returns a preview handle. The Control UI renders that handle in a sandboxed iframe, while iOS, Android, macOS, and Linux Quick Chat use isolated web views. Full chat clients restore the widget after history reload; Quick Chat keeps the widget for its active reply.
 
 In Control UI sessions, a Canvas widget can also be pinned to the session dashboard. Set `pin: true` in the tool call, or use **Pin to dashboard** on an existing transcript widget. Pinned HTML runs behind the same dedicated-origin, double-iframe sandbox host used by MCP Apps; the browser never resolves a widget data binding inside the untrusted frame.
 
@@ -26,7 +26,7 @@ For browser embedding, the wrapper document injects four small host bridges arou
 
 Everything else stays inside the frame: the document runs in an opaque origin with a strict Content Security Policy, so widget scripts cannot reach the Control UI, the Gateway, or the network.
 
-The core implementation is available only when the originating Gateway client declares the `inline-widgets` capability. The Control UI and supported native apps declare this capability automatically. The Discord implementation is available only in Discord sessions with Activities configured. Other channel runs do not receive `show_widget`.
+The core implementation is available only when the originating Gateway client declares the `inline-widgets` capability. The Control UI and supported native apps declare this capability automatically. Linux Quick Chat stays text-only for Gateway connections that require a custom TLS leaf pin because its platform WebView cannot bind that pin. The Discord implementation is available only in Discord sessions with Activities configured. Other channel runs do not receive `show_widget`.
 
 Capability transport covers embedded, Codex app-server, and CLI-backed model backends. Grant-authenticated MCP callers and direct HTTP tool-invoke callers remain fail closed because they do not declare client capabilities.
 

--- a/test/linux-quickchat-stream.test.ts
+++ b/test/linux-quickchat-stream.test.ts
@@ -8,29 +8,56 @@ const quickchatSource = readFileSync(
   new URL("../apps/linux/ui/quickchat.js", import.meta.url),
   "utf8",
 );
+const tauriConfig = JSON.parse(
+  readFileSync(new URL("../apps/linux/src-tauri/tauri.conf.json", import.meta.url), "utf8"),
+) as {
+  app?: {
+    security?: {
+      capabilities?: Array<{
+        identifier?: string;
+        windows?: string[];
+        webviews?: string[];
+      }>;
+    };
+  };
+};
 const browserBindingsStart = quickchatSource.indexOf("const tauri = window");
 assert.notEqual(browserBindingsStart, -1, "quickchat pure-helper boundary");
 
-const context: Record<
-  string,
-  {
-    assembleChatDelta: (state: unknown, payload: unknown) => unknown;
-    chatMessageText: (message: unknown) => string;
-  }
-> &
-  Record<string, unknown> = {};
-vm.runInNewContext(
-  `${quickchatSource.slice(0, browserBindingsStart)}\nthis.helpers = { assembleChatDelta, chatMessageText };`,
-  context,
-);
-const { assembleChatDelta, chatMessageText } = context.helpers as {
-  assembleChatDelta: (state: unknown, payload: unknown) => { text: string; runId?: string };
+type QuickChatHelpers = {
+  assembleChatDelta: (state: unknown, payload: unknown) => unknown;
   chatMessageText: (message: unknown) => string;
+  chatMessageWidgets: (message: unknown) => unknown[];
+  resolveInlineWidgetUrl: (surface: unknown, target: unknown) => string | null;
 };
 
-function createFakeElement() {
+const context: { helpers?: QuickChatHelpers } & Record<string, unknown> = { URL };
+vm.runInNewContext(
+  `${quickchatSource.slice(0, browserBindingsStart)}\nthis.helpers = { assembleChatDelta, chatMessageText, chatMessageWidgets, resolveInlineWidgetUrl };`,
+  context,
+);
+const { assembleChatDelta, chatMessageText, chatMessageWidgets, resolveInlineWidgetUrl } =
+  context.helpers as {
+    assembleChatDelta: (state: unknown, payload: unknown) => { text: string; runId?: string };
+    chatMessageText: (message: unknown) => string;
+    chatMessageWidgets: (message: unknown) => Array<{
+      key: string;
+      title: string;
+      target: string;
+      preferredHeight: number;
+      sandbox: string;
+    }>;
+    resolveInlineWidgetUrl: (surface: unknown, target: unknown) => string | null;
+  };
+
+function createFakeElement(tagName = "div") {
   const classes = new Set();
+  const children: any[] = [];
   return {
+    tagName: tagName.toUpperCase(),
+    children,
+    dataset: {},
+    className: "",
     classList: {
       add: (...names: string[]) => names.forEach((name) => classes.add(name)),
       remove: (...names: string[]) => names.forEach((name) => classes.delete(name)),
@@ -52,15 +79,36 @@ function createFakeElement() {
     readOnly: false,
     scrollHeight: 0,
     scrollTop: 0,
+    src: "",
+    title: "",
+    referrerPolicy: "",
+    contentWindow: tagName === "iframe" ? {} : null,
     addEventListener() {},
+    append(...nodes: any[]) {
+      children.push(...nodes);
+    },
     contains() {
       return false;
     },
     focus() {},
-    querySelectorAll() {
-      return [];
+    getBoundingClientRect() {
+      return { x: 52, y: 174, width: 540, height: 160 };
     },
-    replaceChildren() {},
+    querySelector(selector: string) {
+      return this.querySelectorAll(selector)[0] ?? null;
+    },
+    querySelectorAll(selector: string) {
+      return children
+        .flatMap((child) => [child, ...(child.querySelectorAll?.(selector) ?? [])])
+        .filter((child) =>
+          selector.startsWith(".")
+            ? child.className.split(/\s+/u).includes(selector.slice(1))
+            : child.tagName === selector.toUpperCase(),
+        );
+    },
+    replaceChildren(...nodes: any[]) {
+      children.splice(0, children.length, ...nodes);
+    },
     setAttribute() {},
   };
 }
@@ -70,18 +118,48 @@ function createQuickChatHarness(): Record<string, any> {
   assert.notEqual(browserBindingsEnd, -1, "quickchat browser binding boundary");
   const elements = new Map();
   let resolveSend;
+  let syncedWidgets: unknown[] = [];
+  let syncedHasWidgets = false;
+  let syncedExpanded = false;
+  let syncedGeneration = 0;
+  let widgetSyncCount = 0;
+  let widgetSurfaceRefreshCount = 0;
+  let widgetSurfaceRefreshResult = "https://gateway.example/__openclaw__/cap/refreshed-capability";
   const sendResult = new Promise((resolve) => {
     resolveSend = resolve;
   });
   const window = {
     __TAURI__: {
       core: {
-        invoke(method: string) {
-          return method === "quickchat_send" ? sendResult : Promise.resolve(null);
+        invoke(
+          method: string,
+          args?: {
+            widgets?: unknown[];
+            hasWidgets?: boolean;
+            expanded?: boolean;
+            generation?: number;
+          },
+        ) {
+          if (method === "quickchat_send") {
+            return sendResult;
+          }
+          if (method === "quickchat_refresh_widget_surface") {
+            widgetSurfaceRefreshCount += 1;
+            return Promise.resolve(widgetSurfaceRefreshResult);
+          }
+          if (method === "quickchat_sync_widgets") {
+            syncedWidgets = args?.widgets ?? [];
+            syncedHasWidgets = args?.hasWidgets === true;
+            syncedExpanded = args?.expanded === true;
+            syncedGeneration = args?.generation ?? 0;
+            widgetSyncCount += 1;
+          }
+          return Promise.resolve(null);
         },
       },
       event: { listen: async () => () => {} },
     },
+    addEventListener() {},
     clearTimeout() {},
     matchMedia: () => ({ matches: true }),
     requestAnimationFrame(callback: () => void) {
@@ -91,7 +169,7 @@ function createQuickChatHarness(): Record<string, any> {
   };
   const document = {
     body: createFakeElement(),
-    createElement: () => createFakeElement(),
+    createElement: (tagName: string) => createFakeElement(tagName),
     createTextNode: (text: string) => ({ textContent: text }),
     querySelector(selector: string) {
       if (!elements.has(selector)) {
@@ -100,23 +178,57 @@ function createQuickChatHarness(): Record<string, any> {
       return elements.get(selector);
     },
   };
-  const browserContext: Record<string, any> = { document, window };
+  const browserContext: Record<string, any> = { document, window, URL };
   vm.runInNewContext(
     `${quickchatSource.slice(0, browserBindingsEnd)}
 this.harness = {
   send,
   handleChatEvent,
   requestHide,
-  setGatewayUp() { gatewayState = "up"; },
+  clearReply,
+  setGatewayUp(surface = "https://gateway.example/__openclaw__/cap/fixture-capability") {
+    gatewayState = "up";
+    canvasSurfaceUrl = surface;
+    canvasSurfaceRefreshedAt = Date.now();
+    if (visibilitySequence === 0) visibilitySequence = 1;
+  },
   setMessage(value) { elements.input.value = value; },
   pendingCount() { return pendingChatEvents.length; },
   activeRunId() { return activeReply?.runId ?? null; },
   replyText() { return elements.replyText.textContent; },
+  expireCanvasSurface() { canvasSurfaceRefreshedAt = 0; },
+  flushSurfaceRefresh() { return canvasSurfaceRefreshPromise ?? Promise.resolve(); },
+  flushWidgets() { return widgetSyncPromise; },
 };`,
     browserContext,
   );
-  return { ...(browserContext.harness as Record<string, (...args: any[]) => any>), resolveSend };
+  return {
+    ...(browserContext.harness as Record<string, (...args: any[]) => any>),
+    resolveSend,
+    syncedWidgets: () => syncedWidgets,
+    syncedHasWidgets: () => syncedHasWidgets,
+    syncedExpanded: () => syncedExpanded,
+    syncedGeneration: () => syncedGeneration,
+    widgetSyncCount: () => widgetSyncCount,
+    widgetSurfaceRefreshCount: () => widgetSurfaceRefreshCount,
+    setWidgetSurfaceRefreshResult: (value: string) => {
+      widgetSurfaceRefreshResult = value;
+    },
+  };
 }
+
+test("widget child webviews inherit no Quick Chat Tauri capability", () => {
+  const capability = tauriConfig.app?.security?.capabilities?.find(
+    (candidate) => candidate.identifier === "quickchat",
+  );
+
+  assert.deepEqual(capability?.webviews, ["quickchat"]);
+  assert.equal(capability?.windows, undefined);
+  assert.equal(
+    capability?.webviews?.some((label) => label.startsWith("quickchat-widget-")),
+    false,
+  );
+});
 
 test("replace deltas are authoritative", () => {
   assert.equal(
@@ -196,6 +308,189 @@ test("snapshot extraction falls back through string content and top-level text",
   assert.equal(chatMessageText({ content: [], text: "top-level" }), "top-level");
 });
 
+test("canvas previews are accepted only for safe assistant widgets", () => {
+  const [widget] = chatMessageWidgets({
+    role: "assistant",
+    content: [
+      {
+        type: "canvas",
+        preview: {
+          kind: "canvas",
+          surface: "assistant_message",
+          render: "url",
+          sandbox: "scripts",
+          title: "Build status",
+          preferredHeight: 2_000,
+          viewId: "build-status",
+          url: "/__openclaw__/canvas/documents/build-status/index.html",
+        },
+      },
+    ],
+  });
+
+  assert.deepEqual(
+    { ...widget },
+    {
+      key: "build-status",
+      title: "Build status",
+      target: "/__openclaw__/canvas/documents/build-status/index.html",
+      preferredHeight: 1_200,
+      sandbox: "scripts",
+    },
+  );
+  const duplicateWidgets = chatMessageWidgets({
+    role: "assistant",
+    content: [
+      {
+        type: "canvas",
+        preview: {
+          kind: "canvas",
+          surface: "assistant_message",
+          render: "url",
+          sandbox: "scripts",
+          viewId: "duplicate",
+          url: "/__openclaw__/canvas/documents/first/index.html",
+        },
+      },
+      {
+        type: "canvas",
+        preview: {
+          kind: "canvas",
+          surface: "assistant_message",
+          render: "url",
+          sandbox: "scripts",
+          viewId: "duplicate",
+          url: "/__openclaw__/canvas/documents/second/index.html",
+        },
+      },
+      {
+        type: "canvas",
+        preview: {
+          kind: "canvas",
+          surface: "assistant_message",
+          render: "url",
+          sandbox: "scripts",
+          viewId: "duplicate-2",
+          url: "/__openclaw__/canvas/documents/third/index.html",
+        },
+      },
+    ],
+  });
+  assert.equal(duplicateWidgets.length, 3);
+  assert.equal(duplicateWidgets[0]?.key, "duplicate");
+  assert.equal(duplicateWidgets[1]?.key, "duplicate-2");
+  assert.equal(duplicateWidgets[2]?.key, "duplicate-2-2");
+  assert.equal(
+    new Set(duplicateWidgets.map((candidate) => candidate.key)).size,
+    duplicateWidgets.length,
+  );
+  assert.equal(
+    chatMessageWidgets({
+      role: "tool",
+      content: [
+        {
+          type: "canvas",
+          preview: {
+            kind: "canvas",
+            surface: "assistant_message",
+            render: "url",
+            sandbox: "scripts",
+            url: "/__openclaw__/canvas/documents/tool/index.html",
+          },
+        },
+      ],
+    }).length,
+    0,
+  );
+  assert.equal(
+    chatMessageWidgets({
+      content: [
+        {
+          type: "canvas",
+          preview: {
+            kind: "canvas",
+            surface: "assistant_message",
+            render: "url",
+            sandbox: "scripts",
+            url: "/__openclaw__/canvas/documents/roleless/index.html",
+          },
+        },
+      ],
+    }).length,
+    0,
+  );
+  assert.equal(
+    chatMessageWidgets({
+      role: "assistant",
+      content: [
+        {
+          type: "canvas",
+          preview: {
+            kind: "canvas",
+            surface: "assistant_message",
+            render: "url",
+            sandbox: "scripts",
+            url: "/__openclaw__/canvas/documents/%252e%252e/private-file",
+          },
+        },
+      ],
+    }).length,
+    0,
+  );
+});
+
+test("widget URLs stay inside the capability-scoped Canvas host", () => {
+  assert.equal(
+    resolveInlineWidgetUrl(
+      "https://gateway.example/base/__openclaw__/cap/fixture-capability",
+      "/__openclaw__/canvas/documents/widget-1/index.html?mode=compact#result",
+    ),
+    "https://gateway.example/base/__openclaw__/cap/fixture-capability/__openclaw__/canvas/documents/widget-1/index.html?mode=compact#result",
+  );
+  assert.equal(
+    resolveInlineWidgetUrl(
+      "http://gateway.example/__openclaw__/cap/fixture-capability",
+      "/__openclaw__/canvas/documents/widget-1/index.html",
+    ),
+    null,
+  );
+  assert.equal(
+    resolveInlineWidgetUrl(
+      "http://localhost:18789/__openclaw__/cap/fixture-capability",
+      "/__openclaw__/canvas/documents/widget-1/index.html",
+    ),
+    "http://localhost:18789/__openclaw__/cap/fixture-capability/__openclaw__/canvas/documents/widget-1/index.html",
+  );
+  assert.equal(
+    resolveInlineWidgetUrl(
+      "http://[::1]:18789/__openclaw__/cap/fixture-capability",
+      "/__openclaw__/canvas/documents/widget-1/index.html",
+    ),
+    "http://[::1]:18789/__openclaw__/cap/fixture-capability/__openclaw__/canvas/documents/widget-1/index.html",
+  );
+  assert.equal(
+    resolveInlineWidgetUrl(
+      "https://gateway.example/base/__openclaw__/cap/fixture-capability?leak=1",
+      "/__openclaw__/canvas/documents/widget-1/index.html",
+    ),
+    null,
+  );
+  assert.equal(
+    resolveInlineWidgetUrl(
+      "https://gateway.example/base/__openclaw__/cap/%252f..%252fother",
+      "/__openclaw__/canvas/documents/widget-1/index.html",
+    ),
+    null,
+  );
+  assert.equal(
+    resolveInlineWidgetUrl(
+      "https://gateway.example/base/__openclaw__/cap/fixture-capability",
+      "https://evil.example/widget.html",
+    ),
+    null,
+  );
+});
+
 test("pre-ack frames replay once for only the acknowledged run", async () => {
   const harness = createQuickChatHarness();
   harness.setGatewayUp();
@@ -246,6 +541,190 @@ test("pre-ack frames replay once for only the acknowledged run", async () => {
     deltaText: "!",
   });
   assert.equal(harness.replyText(), "right!");
+});
+
+test("final assistant canvas previews sync into isolated native webviews", async () => {
+  const harness = createQuickChatHarness();
+  harness.setGatewayUp();
+  harness.setMessage("show status");
+  const sending = harness.send(false);
+  harness.resolveSend({ sessionKey: "global", agentId: "work", runId: "widget-run" });
+  await sending;
+
+  harness.handleChatEvent({
+    sessionKey: "global",
+    agentId: "work",
+    runId: "widget-run",
+    state: "final",
+    message: {
+      role: "assistant",
+      content: [
+        {
+          type: "canvas",
+          preview: {
+            kind: "canvas",
+            surface: "assistant_message",
+            render: "url",
+            sandbox: "strict",
+            title: "Status",
+            url: "/__openclaw__/canvas/documents/status/index.html",
+          },
+        },
+      ],
+    },
+  });
+
+  await harness.flushWidgets();
+  const [layout] = harness.syncedWidgets();
+  assert.deepEqual(
+    { ...layout },
+    {
+      key: "/__openclaw__/canvas/documents/status/index.html",
+      url: "https://gateway.example/__openclaw__/cap/fixture-capability/__openclaw__/canvas/documents/status/index.html",
+      sandbox: "strict",
+      x: 52,
+      y: 174,
+      width: 540,
+      height: 160,
+      visible: true,
+    },
+  );
+  assert.equal(harness.syncedHasWidgets(), true);
+  assert.equal(harness.syncedExpanded(), true);
+  assert.equal(harness.syncedGeneration(), 1);
+});
+
+test("expired Canvas capability refreshes before a new widget loads", async () => {
+  const harness = createQuickChatHarness();
+  harness.setGatewayUp();
+  harness.expireCanvasSurface();
+  harness.setMessage("show status");
+  const sending = harness.send(false);
+  harness.resolveSend({ sessionKey: "global", agentId: "work", runId: "refresh-run" });
+  await sending;
+  harness.handleChatEvent({
+    sessionKey: "global",
+    agentId: "work",
+    runId: "refresh-run",
+    state: "final",
+    message: {
+      role: "assistant",
+      content: [
+        {
+          type: "canvas",
+          preview: {
+            kind: "canvas",
+            surface: "assistant_message",
+            render: "url",
+            sandbox: "scripts",
+            url: "/__openclaw__/canvas/documents/status/index.html",
+          },
+        },
+      ],
+    },
+  });
+
+  await harness.flushSurfaceRefresh();
+  await harness.flushWidgets();
+  assert.equal(harness.widgetSurfaceRefreshCount(), 1);
+  assert.equal(
+    harness.syncedWidgets()[0]?.url,
+    "https://gateway.example/__openclaw__/cap/refreshed-capability/__openclaw__/canvas/documents/status/index.html",
+  );
+});
+
+test("clearing the widget reply restores semantic text-only layout", async () => {
+  const harness = createQuickChatHarness();
+  harness.setGatewayUp();
+  harness.setMessage("show status");
+  const sending = harness.send(false);
+  harness.resolveSend({ sessionKey: "global", agentId: "work", runId: "widget-run" });
+  await sending;
+  harness.handleChatEvent({
+    sessionKey: "global",
+    agentId: "work",
+    runId: "widget-run",
+    state: "delta",
+    message: {
+      role: "assistant",
+      content: [
+        {
+          type: "canvas",
+          preview: {
+            kind: "canvas",
+            surface: "assistant_message",
+            render: "url",
+            sandbox: "scripts",
+            url: "/__openclaw__/canvas/documents/status/index.html",
+          },
+        },
+      ],
+    },
+  });
+  await harness.flushWidgets();
+  assert.equal(harness.syncedHasWidgets(), true);
+
+  harness.clearReply();
+  await harness.flushWidgets();
+  assert.equal(harness.syncedHasWidgets(), false);
+  assert.equal(harness.syncedExpanded(), false);
+  assert.deepEqual([...harness.syncedWidgets()], []);
+});
+
+test("adding a widget preserves the existing native webview identity", async () => {
+  const harness = createQuickChatHarness();
+  harness.setGatewayUp();
+  harness.setMessage("show status");
+  const sending = harness.send(false);
+  harness.resolveSend({ sessionKey: "global", agentId: "work", runId: "widget-run" });
+  await sending;
+  const widgetBlock = (id: string) => ({
+    type: "canvas",
+    preview: {
+      kind: "canvas",
+      surface: "assistant_message",
+      render: "url",
+      sandbox: "scripts",
+      title: id,
+      viewId: id,
+      url: `/__openclaw__/canvas/documents/${id}/index.html`,
+    },
+  });
+
+  harness.handleChatEvent({
+    sessionKey: "global",
+    agentId: "work",
+    runId: "widget-run",
+    state: "delta",
+    message: { role: "assistant", content: [widgetBlock("first")] },
+  });
+  await harness.flushWidgets();
+  const firstLayout = { ...harness.syncedWidgets()[0] };
+  const syncCountBeforeText = harness.widgetSyncCount();
+  harness.handleChatEvent({
+    sessionKey: "global",
+    agentId: "work",
+    runId: "widget-run",
+    state: "delta",
+    deltaText: "status update",
+  });
+  await harness.flushWidgets();
+  assert.ok(harness.widgetSyncCount() > syncCountBeforeText);
+
+  harness.handleChatEvent({
+    sessionKey: "global",
+    agentId: "work",
+    runId: "widget-run",
+    state: "delta",
+    message: { role: "assistant", content: [widgetBlock("first"), widgetBlock("second")] },
+  });
+  await harness.flushWidgets();
+  const layouts = harness.syncedWidgets().map((layout: object) => ({ ...layout }));
+
+  assert.deepEqual(layouts[0], firstLayout);
+  assert.equal(layouts[0].visible, true);
+  assert.equal(layouts[1].key, "second");
+  assert.equal(layouts[1].visible, false);
 });
 
 test("hiding clears buffered pre-ack frames", async () => {


### PR DESCRIPTION
Related: #101790

## What Problem This Solves

Fixes an issue where Linux desktop users opening Quick Chat could not use `show_widget` because the native Gateway connection did not advertise inline-widget support, even though the browser Control UI and the macOS, iOS, and Android chat clients already supported hosted widgets.

## Why This Change Was Made

Quick Chat now carries the Gateway Canvas surface, advertises `inline-widgets` only when its platform WebViews can honor the connection trust model, and renders assistant Canvas previews in dedicated nonpersistent child WebViews. Only the local parent Quick Chat WebView receives Tauri command permissions; agent-authored widget WebViews match no capability, cannot use native IPC, and cannot navigate away from their original capability-scoped Canvas document.

Stable widget identities preserve live state when a reply gains another widget or the user switches tabs. Custom TLS leaf-pin connections remain text-only because the platform WebView cannot bind that pin.

## User Impact

Linux Quick Chat users can ask agents for interactive `show_widget` results instead of being told the tool is unavailable. Multiple widgets in one reply remain alive behind compact tabs, while ordinary text streaming and the existing Quick Chat workflow continue unchanged.

## Evidence

- `node scripts/run-vitest.mjs test/linux-quickchat-stream.test.ts` — 16/16 passed on the rebased commit.
- `node scripts/run-vitest.mjs ui/src/api/gateway.node.test.ts src/agents/openclaw-tools.client-caps.test.ts` — 55/55 passed across the shared browser handshake and tool-capability suites.
- Blacksmith Testbox `coral-crab-9a0c` (`tbx_01kxzt83qaj3abf0kt4tfca1q1`) validated the Linux Tauri/WebKitGTK build, focused Rust widget/Gateway suites, and `corepack pnpm check:changed` during implementation. Exact-head GitHub CI is the final merge gate.
- The production web deployment was separately updated to current `main`; its Gateway is active and the rebuilt Control UI bundle contains the existing `inline-widgets` browser capability.
- Visual capture gap: the available Linux proof runner was headless, and the requested inline Browser pane could navigate to the deployment but its inspection policy was temporarily unavailable. The DOM behavior, capability isolation, native host lifecycle, and Linux build are covered by the focused tests above.

AI-assisted: yes. The implementation was reviewed with the repository `autoreview` workflow; no transcript is attached.
