### PR TITLE
fix(mattermost): defer fallback tool warnings until turn settles

### DIFF
--- a/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
@@ -1,5 +1,6 @@
 // Mattermost tests cover monitor.inbound system event plugin behavior.
 import { createInboundDebouncer } from "openclaw/plugin-sdk/channel-inbound-debounce";
+import { setReplyPayloadMetadata } from "openclaw/plugin-sdk/reply-payload-testing";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { MattermostPost } from "./client.js";
 import type { MattermostEventPayload } from "./monitor-websocket.js";
@@ -1328,6 +1329,104 @@ describe("mattermost inbound user posts", () => {
     const replyOptions = mockState.dispatchInboundMessage.mock.calls.at(0)?.[0].replyOptions;
     expect(replyOptions?.disableBlockStreaming).toBe(false);
     expect(replyOptions?.preserveProgressCallbackStartOrder).toBeUndefined();
+  });
+
+  it("holds a fallback-only tool warning when a real final follows", async () => {
+    const warningConfig: OpenClawConfig = {
+      channels: {
+        mattermost: {
+          ...testConfig.channels?.mattermost,
+          streaming: "off",
+        },
+      },
+    };
+    mockState.runtimeCore = createRuntimeCore(warningConfig);
+    const socket = new FakeWebSocket();
+    const abortController = new AbortController();
+    mockState.abortController = abortController;
+    mockState.dispatchInboundMessage.mockImplementation(async () => {
+      const dispatcherOptions =
+        mockState.createReplyDispatcherWithTyping.mock.results.at(-1)?.value?.options;
+      await dispatcherOptions?.deliver(
+        setReplyPayloadMetadata(
+          { text: "tool failed", isError: true },
+          { nonTerminalToolErrorWarning: true },
+        ),
+        { kind: "final" },
+      );
+      await dispatcherOptions?.deliver({ text: "real answer" }, { kind: "final" });
+      await dispatcherOptions?.onFreshSettledDelivery?.();
+      abortController.abort();
+    });
+
+    const monitor = monitorMattermostProvider({
+      config: warningConfig,
+      runtime: testRuntime(),
+      abortSignal: abortController.signal,
+      webSocketFactory: () => socket,
+    });
+    await vi.waitFor(() => expect(socket.openListenerCount).toBeGreaterThan(0));
+    socket.emitOpen();
+    await emitMattermostChannelPost(socket, {
+      id: "post-warning-before-final",
+      message: "run a tool",
+    });
+    socket.emitClose(1000);
+    await monitor;
+
+    expect(mockState.sendMessageMattermost.mock.calls.map((call) => call[1])).toEqual([
+      "real answer",
+    ]);
+  });
+
+  it("delivers a fallback-only tool warning when no real final follows", async () => {
+    const warningConfig: OpenClawConfig = {
+      channels: {
+        mattermost: {
+          ...testConfig.channels?.mattermost,
+          streaming: "off",
+        },
+      },
+    };
+    mockState.runtimeCore = createRuntimeCore(warningConfig);
+    const socket = new FakeWebSocket();
+    const abortController = new AbortController();
+    mockState.abortController = abortController;
+    let sentBeforeSettled = -1;
+    mockState.dispatchInboundMessage.mockImplementation(async () => {
+      const dispatcherOptions =
+        mockState.createReplyDispatcherWithTyping.mock.results.at(-1)?.value?.options;
+      await dispatcherOptions?.deliver(
+        setReplyPayloadMetadata(
+          { text: "tool failed", isError: true },
+          { nonTerminalToolErrorWarning: true },
+        ),
+        { kind: "final" },
+      );
+      sentBeforeSettled = mockState.sendMessageMattermost.mock.calls.length;
+      await dispatcherOptions?.onFreshSettledDelivery?.();
+      abortController.abort();
+    });
+
+    const monitor = monitorMattermostProvider({
+      config: warningConfig,
+      runtime: testRuntime(),
+      abortSignal: abortController.signal,
+      webSocketFactory: () => socket,
+    });
+    await vi.waitFor(() => expect(socket.openListenerCount).toBeGreaterThan(0));
+    socket.emitOpen();
+    await emitMattermostChannelPost(socket, {
+      id: "post-warning-only",
+      message: "run a tool",
+    });
+    socket.emitClose(1000);
+    await monitor;
+
+    expect(sentBeforeSettled).toBe(0);
+    expect(mockState.sendMessageMattermost.mock.calls.map((call) => call[1])).toEqual([
+      "tool failed",
+    ]);
   });
 
   it("preserves text-tool-text boundaries while grouping interleaved tool updates", async () => {

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -11,6 +11,10 @@ import {
   createChannelProgressDraftCompositor,
 } from "openclaw/plugin-sdk/channel-outbound";
 import { isLoopbackHost } from "openclaw/plugin-sdk/gateway-runtime";
+import {
+  isReplyPayloadNonTerminalToolErrorWarning,
+  resolveSendableOutboundReplyParts,
+} from "openclaw/plugin-sdk/reply-payload";
 import { finalizeInboundContext } from "openclaw/plugin-sdk/reply-runtime";
 import { resolveInboundLastRouteSessionKey } from "openclaw/plugin-sdk/routing";
 import { resolvePinnedMainDmOwnerFromAllowlist } from "openclaw/plugin-sdk/security-runtime";
@@ -168,6 +172,13 @@ function resolveRuntime(opts: MonitorMattermostOpts): RuntimeEnv {
 
 function isSystemPost(post: MattermostPost): boolean {
   return normalizeOptionalString(post.type) !== undefined;
+}
+
+function isFallbackOnlyToolWarningFinal(payload: ReplyPayload): boolean {
+  if (payload.isError !== true || !isReplyPayloadNonTerminalToolErrorWarning(payload)) {
+    return false;
+  }
+  return !resolveSendableOutboundReplyParts(payload).hasMedia;
 }
 
 function channelChatType(kind: ChatType): "direct" | "group" | "channel" {
@@ -1548,15 +1559,45 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
       isDirect: kind === "direct",
       dmRetryOptions: account.config.dmChannelRetry,
     });
+    let userFacingFinalDelivered = false;
+    let allowFallbackOnlyToolWarning = false;
+    let pendingToolWarningFinal:
+      | { payload: ReplyPayload; info: { kind: "tool" | "block" | "final" } }
+      | undefined;
     const dispatcherOptions: NonNullable<ChannelInboundTurnPlan["dispatcherOptions"]> = {
       ...replyPipeline,
       resolveFollowupAdmissionBarrierTimeoutPolicy: deliveryBarrier.resolveTimeoutPolicy,
       onDeliverySettled: deliveryBarrier.markDeliverySettled,
+      onFreshSettledDelivery: async () => {
+        if (!pendingToolWarningFinal || userFacingFinalDelivered) {
+          return;
+        }
+        const pending = pendingToolWarningFinal;
+        pendingToolWarningFinal = undefined;
+        try {
+          allowFallbackOnlyToolWarning = true;
+          await delivery.deliver(pending.payload, pending.info);
+        } catch (err) {
+          runtime.error?.(`mattermost ${pending.info.kind} reply failed: ${String(err)}`);
+        } finally {
+          allowFallbackOnlyToolWarning = false;
+        }
+      },
       humanDelay: resolveHumanDelayConfig(cfg, route.agentId),
       typingCallbacks,
     };
     const delivery: ChannelInboundTurnPlan["delivery"] = {
       deliver: async (payloadEntry: ReplyPayload, info) => {
+        if (
+          info.kind === "final" &&
+          !allowFallbackOnlyToolWarning &&
+          isFallbackOnlyToolWarningFinal(payloadEntry)
+        ) {
+          if (!userFacingFinalDelivered) {
+            pendingToolWarningFinal = { payload: payloadEntry, info };
+          }
+          return;
+        }
         if (info.kind === "final") {
           await enterBlockPreviewActivity("text");
           // Final text resolution uses only generations confirmed visible. Join prior
@@ -1639,6 +1680,8 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           },
         });
         if (info.kind === "final") {
+          userFacingFinalDelivered = true;
+          pendingToolWarningFinal = undefined;
           progressDraft.markFinalReplyDelivered();
         }
       },


### PR DESCRIPTION
Related: #111778

## What Problem This Solves

Mattermost can receive a non-terminal tool error warning as a `final` payload before the agent's actual final response. The channel currently sends both payloads immediately, so users see a misleading tool-error warning followed by a successful answer.

## Why This Change Was Made

The reply dispatcher already identifies these warnings with `nonTerminalToolErrorWarning` metadata. Mattermost now holds a text-only fallback warning until the fresh turn settles:

- if a real final reply arrives, the pending warning is discarded;
- if no real final arrives, the warning is delivered at settlement;
- warnings with media keep their existing immediate-delivery behavior.

This mirrors the established Discord fallback-warning semantics while keeping the change scoped to Mattermost.

## Evidence

Base: `4aaea7b072915b63404665a9be8f39168ac52813`
Head: `ce7cd6b79680fe7671fdb7b65f79ea4e4fd277a7`

Reproduced on the source-level Mattermost monitor path before the fix with ordered transport assertions:

- warning then real final: received `["tool failed", "real answer"]`; expected `["real answer"]`
- warning only: one message was sent before the settled hook; expected zero

After the fix:

- Mattermost focused suite: 4 files, 103 tests passed
- extension TypeScript check: passed
- oxlint on changed files: passed
- oxfmt and `git diff --check`: passed

The regression runs the real Mattermost monitor/dispatcher integration with a fake WebSocket and mocked outbound Mattermost transport. No live Mattermost credentials or server were used.