### PR TITLE
fix(mcp): keep resource-only servers on unknown method errors

### DIFF
--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -65,6 +65,8 @@ async function writeListToolsMcpServer(params: {
   notifyListChangedAfterFirstList?: boolean;
   exitOnListCall?: number;
   listToolsMethodNotFound?: boolean;
+  listToolsErrorCode?: number;
+  listToolsMethodNotFoundMessage?: string;
   callToolIsError?: boolean;
   callToolJsonRpcError?: boolean;
   resourceListJsonRpcError?: boolean;
@@ -86,6 +88,10 @@ const notifyListChangedOnInitialized = ${params.notifyListChangedOnInitialized =
 const notifyListChangedAfterFirstList = ${params.notifyListChangedAfterFirstList === true};
 const exitOnListCall = ${params.exitOnListCall ?? 0};
 const listToolsMethodNotFound = ${params.listToolsMethodNotFound === true};
+const listToolsErrorCode = ${params.listToolsErrorCode ?? -32601};
+const listToolsMethodNotFoundMessage = ${JSON.stringify(
+      params.listToolsMethodNotFoundMessage ?? "Method not found",
+    )};
 const tools = ${JSON.stringify(
       params.tools ?? [
         {
@@ -159,7 +165,7 @@ function handle(message) {
       send({
         jsonrpc: "2.0",
         id: message.id,
-        error: { code: -32601, message: "Method not found" },
+        error: { code: listToolsErrorCode, message: listToolsMethodNotFoundMessage },
       });
       return;
     }
@@ -1493,7 +1499,7 @@ process.on("SIGINT", shutdown);`,
     }
   });
 
-  it("keeps resource-only MCP servers available for utility tools", async () => {
+  it("keeps resource-only MCP servers available for unknown-method errors", async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "bundle-mcp-resource-only-"));
     const serverPath = path.join(tempDir, "resource-only.mjs");
     const logPath = path.join(tempDir, "server.log");
@@ -1502,6 +1508,8 @@ process.on("SIGINT", shutdown);`,
       logPath,
       capabilities: { resources: { listChanged: true } },
       listToolsMethodNotFound: true,
+      listToolsErrorCode: -32000,
+      listToolsMethodNotFoundMessage: "Unknown method",
     });
 
     const runtime = await getOrCreateSessionMcpRuntime({

--- a/src/agents/agent-bundle-mcp-runtime.ts
+++ b/src/agents/agent-bundle-mcp-runtime.ts
@@ -179,7 +179,7 @@ function isMcpMethodNotFoundError(error: unknown): boolean {
     return true;
   }
   const message = String(error);
-  return message.includes("-32601") || /method not found/i.test(message);
+  return message.includes("-32601") || /(?:method not found|unknown method)/i.test(message);
 }
 
 async function listAllToolsBestEffort(params: {


### PR DESCRIPTION
Closes #111940

## What Problem This Solves

Fixes an issue where resource-only or prompt-only MCP servers could fail to initialize when their implementation or proxy reported the optional `tools/list` request as `Unknown method` with a nonstandard JSON-RPC error code.

## Why This Change Was Made

Unsupported-method detection now recognizes both `Method not found` and `Unknown method` text while preserving the existing `-32601` handling. The compatibility fallback remains limited to optional catalog discovery; normal tool request failures still propagate.

## User Impact

Operators can use non-tool MCP capabilities from servers that express the unsupported `tools/list` method with this common alternate wording instead of losing the entire server catalog.

## Evidence

- Before: a resource-only stdio MCP fixture returning `-32000` / `Unknown method` from `tools/list` rejects catalog initialization because neither the error code nor message matches the existing classifier.
- After: the same fixture produces an empty tool catalog while retaining the server's resource capabilities.
- `node_modules/.bin/vitest.CMD run src/agents/agent-bundle-mcp-runtime.test.ts` — 148 tests passed.
- `node_modules/.bin/oxlint.CMD src/agents/agent-bundle-mcp-runtime.ts src/agents/agent-bundle-mcp-runtime.test.ts` — passed.
- `git diff --check` — passed.
- Final autoreview: `autoreview clean: no accepted/actionable findings reported`.
- Not tested against a third-party remote MCP server; proof uses the repository's real stdio MCP client/runtime and test server.
