### PR TITLE
fix(update): hide divergence when histories cannot be compared

### DIFF
--- a/src/infra/update-check.test.ts
+++ b/src/infra/update-check.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import http from "node:http";
 import type { AddressInfo } from "node:net";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { runCommandWithTimeout } from "../process/exec.js";
 import { withTempDir } from "../test-helpers/temp-dir.js";
@@ -18,6 +19,25 @@ import {
 } from "./update-check.js";
 
 const mockHttp = useMockHttp();
+
+async function runGit(cwd: string, ...args: string[]): Promise<string> {
+  const result = await runCommandWithTimeout(["git", ...args], { cwd, timeoutMs: 5000 });
+  if (result.code !== 0) {
+    throw new Error(result.stderr || `git ${args.join(" ")} failed`);
+  }
+  return result.stdout.trim();
+}
+
+async function initGitRepo(root: string): Promise<void> {
+  await fs.mkdir(root, { recursive: true });
+  await runGit(root, "init", "--initial-branch=main");
+  await runGit(root, "config", "user.name", "OpenClaw Test");
+  await runGit(root, "config", "user.email", "test@openclaw.invalid");
+}
+
+async function commitGit(root: string, message: string): Promise<void> {
+  await runGit(root, "commit", "--allow-empty", "--message", message);
+}
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -606,6 +626,109 @@ describe("formatGitInstallLabel", () => {
 });
 
 describe("checkUpdateStatus", () => {
+  it("does not report divergence for unrelated histories", async () => {
+    await withTempDir({ prefix: "openclaw-update-check-unrelated-" }, async (base) => {
+      const localRoot = path.join(base, "local");
+      const remoteRoot = path.join(base, "remote");
+      await initGitRepo(localRoot);
+      await commitGit(localRoot, "local history");
+      await initGitRepo(remoteRoot);
+      await commitGit(remoteRoot, "remote history");
+
+      await runGit(localRoot, "remote", "add", "origin", remoteRoot);
+      await runGit(localRoot, "fetch", "origin", "main");
+      await runGit(localRoot, "branch", "--set-upstream-to=origin/main", "main");
+
+      const mergeBase = await runCommandWithTimeout(["git", "merge-base", "HEAD", "origin/main"], {
+        cwd: localRoot,
+        timeoutMs: 5000,
+      });
+      expect(mergeBase.code).toBe(1);
+      expect(
+        await runGit(localRoot, "rev-list", "--left-right", "--count", "HEAD...origin/main"),
+      ).toMatch(/^1\s+1$/u);
+
+      const status = await checkUpdateStatus({
+        root: localRoot,
+        includeRegistry: false,
+        fetchGit: false,
+        timeoutMs: 5000,
+      });
+      expect(status.git).toMatchObject({
+        upstream: "origin/main",
+        ahead: null,
+        behind: null,
+      });
+    });
+  });
+
+  it("reports divergence only when shallow history retains a merge base", async () => {
+    await withTempDir({ prefix: "openclaw-update-check-shallow-" }, async (base) => {
+      const sourceRoot = path.join(base, "source");
+      await initGitRepo(sourceRoot);
+      await commitGit(sourceRoot, "common base");
+      await runGit(sourceRoot, "switch", "--create", "feature");
+      await commitGit(sourceRoot, "feature change");
+      await runGit(sourceRoot, "switch", "main");
+      await commitGit(sourceRoot, "main change");
+
+      const cloneDivergedHistory = async (name: string, depth?: number) => {
+        const cloneRoot = path.join(base, name);
+        const depthArgs = depth ? [`--depth=${depth}`] : [];
+        await runGit(
+          base,
+          "clone",
+          "--quiet",
+          ...depthArgs,
+          "--branch",
+          "feature",
+          pathToFileURL(sourceRoot).href,
+          cloneRoot,
+        );
+        await runGit(
+          cloneRoot,
+          "fetch",
+          "--quiet",
+          ...(depth ? [`--depth=${depth}`] : []),
+          "origin",
+          "+refs/heads/main:refs/remotes/origin/main",
+        );
+        await runGit(
+          cloneRoot,
+          "config",
+          "--add",
+          "remote.origin.fetch",
+          "+refs/heads/main:refs/remotes/origin/main",
+        );
+        await runGit(cloneRoot, "config", "branch.feature.remote", "origin");
+        await runGit(cloneRoot, "config", "branch.feature.merge", "refs/heads/main");
+        return cloneRoot;
+      };
+
+      const readDivergence = async (root: string) => {
+        const status = await checkUpdateStatus({
+          root,
+          includeRegistry: false,
+          fetchGit: false,
+          timeoutMs: 5000,
+        });
+        return { ahead: status.git?.ahead, behind: status.git?.behind };
+      };
+
+      const fullRoot = await cloneDivergedHistory("full");
+      await expect(readDivergence(fullRoot)).resolves.toEqual({ ahead: 1, behind: 1 });
+
+      const truncatedRoot = await cloneDivergedHistory("shallow-depth-1", 1);
+      await expect(readDivergence(truncatedRoot)).resolves.toEqual({
+        ahead: null,
+        behind: null,
+      });
+
+      const comparableRoot = await cloneDivergedHistory("shallow-depth-2", 2);
+      await expect(readDivergence(comparableRoot)).resolves.toEqual({ ahead: 1, behind: 1 });
+    });
+  });
+
   it("returns unknown install status when root is missing", async () => {
     await expect(
       checkUpdateStatus({ root: null, includeRegistry: false, timeoutMs: 1000 }),

--- a/src/infra/update-check.test.ts
+++ b/src/infra/update-check.test.ts
@@ -717,6 +717,9 @@ describe("checkUpdateStatus", () => {
 
       const fullRoot = await cloneDivergedHistory("full");
       await expect(readDivergence(fullRoot)).resolves.toEqual({ ahead: 1, behind: 1 });
+      await runGit(fullRoot, "remote", "rename", "--", "origin", "-dash");
+      expect(await runGit(fullRoot, "rev-parse", "--abbrev-ref", "@{upstream}")).toBe("-dash/main");
+      await expect(readDivergence(fullRoot)).resolves.toEqual({ ahead: 1, behind: 1 });
 
       const truncatedRoot = await cloneDivergedHistory("shallow-depth-1", 1);
       await expect(readDivergence(truncatedRoot)).resolves.toEqual({

--- a/src/infra/update-check.ts
+++ b/src/infra/update-check.ts
@@ -249,13 +249,13 @@ async function checkGitUpdateStatus(params: {
         .catch(() => false)
     : null;
 
-  // Freeze the post-fetch upstream for both graph queries; --end-of-options accepts dashed refs.
-  // Three-dot rev-list still counts disconnected or truncated shallow histories, so require a
-  // visible common ancestor before presenting those counts as divergence.
+  // Freeze the post-fetch upstream for both graph queries. Resolve via @{upstream} rather than
+  // its display name so dashed remotes stay operands on older Git versions. Three-dot rev-list
+  // still counts disconnected or truncated histories, so require a visible common ancestor.
   const upstreamCommitRes =
     upstream && sha
       ? await runCommandWithTimeout(
-          ["git", "-C", root, "rev-parse", "--verify", "--end-of-options", `${upstream}^{commit}`],
+          ["git", "-C", root, "rev-parse", "--verify", "@{upstream}^{commit}"],
           { timeoutMs },
         ).catch(() => null)
       : null;
@@ -263,10 +263,9 @@ async function checkGitUpdateStatus(params: {
     upstreamCommitRes?.code === 0 ? upstreamCommitRes.stdout.trim() || null : null;
   const mergeBase =
     sha && upstreamCommit
-      ? await runCommandWithTimeout(
-          ["git", "-C", root, "merge-base", "--end-of-options", sha, upstreamCommit],
-          { timeoutMs },
-        ).catch(() => null)
+      ? await runCommandWithTimeout(["git", "-C", root, "merge-base", sha, upstreamCommit], {
+          timeoutMs,
+        }).catch(() => null)
       : null;
   const counts =
     sha && upstreamCommit && mergeBase?.code === 0 && mergeBase.stdout.trim().length > 0

--- a/src/infra/update-check.ts
+++ b/src/infra/update-check.ts
@@ -249,8 +249,16 @@ async function checkGitUpdateStatus(params: {
         .catch(() => false)
     : null;
 
-  const counts =
+  const mergeBase =
     upstream && upstream.length > 0
+      ? await runCommandWithTimeout(["git", "-C", root, "merge-base", "HEAD", upstream], {
+          timeoutMs,
+        }).catch(() => null)
+      : null;
+  // Three-dot rev-list still counts disconnected or truncated shallow histories.
+  // Require Git to expose a common ancestor before presenting those counts as divergence.
+  const counts =
+    upstream && mergeBase?.code === 0 && mergeBase.stdout.trim().length > 0
       ? await runCommandWithTimeout(
           ["git", "-C", root, "rev-list", "--left-right", "--count", `HEAD...${upstream}`],
           { timeoutMs },

--- a/src/infra/update-check.ts
+++ b/src/infra/update-check.ts
@@ -249,18 +249,29 @@ async function checkGitUpdateStatus(params: {
         .catch(() => false)
     : null;
 
-  const mergeBase =
-    upstream && upstream.length > 0
-      ? await runCommandWithTimeout(["git", "-C", root, "merge-base", "HEAD", upstream], {
-          timeoutMs,
-        }).catch(() => null)
-      : null;
-  // Three-dot rev-list still counts disconnected or truncated shallow histories.
-  // Require Git to expose a common ancestor before presenting those counts as divergence.
-  const counts =
-    upstream && mergeBase?.code === 0 && mergeBase.stdout.trim().length > 0
+  // Freeze the post-fetch upstream for both graph queries; --end-of-options accepts dashed refs.
+  // Three-dot rev-list still counts disconnected or truncated shallow histories, so require a
+  // visible common ancestor before presenting those counts as divergence.
+  const upstreamCommitRes =
+    upstream && sha
       ? await runCommandWithTimeout(
-          ["git", "-C", root, "rev-list", "--left-right", "--count", `HEAD...${upstream}`],
+          ["git", "-C", root, "rev-parse", "--verify", "--end-of-options", `${upstream}^{commit}`],
+          { timeoutMs },
+        ).catch(() => null)
+      : null;
+  const upstreamCommit =
+    upstreamCommitRes?.code === 0 ? upstreamCommitRes.stdout.trim() || null : null;
+  const mergeBase =
+    sha && upstreamCommit
+      ? await runCommandWithTimeout(
+          ["git", "-C", root, "merge-base", "--end-of-options", sha, upstreamCommit],
+          { timeoutMs },
+        ).catch(() => null)
+      : null;
+  const counts =
+    sha && upstreamCommit && mergeBase?.code === 0 && mergeBase.stdout.trim().length > 0
+      ? await runCommandWithTimeout(
+          ["git", "-C", root, "rev-list", "--left-right", "--count", `${sha}...${upstreamCommit}`],
           { timeoutMs },
         ).catch(() => null)
       : null;


### PR DESCRIPTION
Closes #111945

## What Problem This Solves

Fixes an issue where source-install update status could report misleading ahead/behind counts when `HEAD` and the configured upstream had no visible common ancestor, including truncated shallow-history cases.

## Why This Change Was Made

Git status now freezes `HEAD` and the configured upstream to commit IDs, verifies that pair has a visible merge base, and only then calculates three-dot divergence. When no merge base is available, only ahead/behind remain unknown; SHA, branch, dirty state, upstream, and fetch status are unchanged. Shallow repositories that still expose a merge base continue to receive normal counts.

## User Impact

Operators no longer see unrelated or incomplete histories presented as meaningful update divergence. Genuine divergence remains visible for normal repositories, comparable shallow clones, and upstreams whose remote names begin with a dash.

## Evidence

- Final proof head: `2e3e741d0c17c50392362de7bd2c293c710c05a2`.
- Current-main defect proof: unrelated histories and a real depth-1 shallow clone both make `git merge-base` exit 1 while `git rev-list --left-right --count HEAD...origin/main` succeeds with `1 1`.
- Exact-head production-path transcript from `checkUpdateStatus` using temporary real Git repositories (temporary paths redacted):

```json
{"head":"2e3e741d0c17c50392362de7bd2c293c710c05a2"}
{"fixture":"unrelated","upstream":"origin/main","ahead":null,"behind":null}
{"fixture":"dashed-remote-diverged","upstream":"-dash/main","ahead":1,"behind":1}
{"fixture":"shallow-depth-1","upstream":"origin/main","ahead":null,"behind":null}
{"fixture":"shallow-depth-2","upstream":"origin/main","ahead":1,"behind":1}
```

- Focused regression proof: `node scripts/run-vitest.mjs src/infra/update-check.test.ts src/commands/status.update.test.ts --reporter=dot` passed 35 update-check tests and 11 status consumer tests.
- Final changed gate: `node scripts/check-changed.mjs -- src/infra/update-check.ts src/infra/update-check.test.ts` passed on Blacksmith Testbox `tbx_01kyc8twtbqwp8d0jmesh8nq7t` (Actions run 30152462131).
- Exact-head hosted CI: `openclaw/ci-gate` passed in Actions run 30152114171.
- Mandatory adversarial refuter: `NO-ACTIONABLE-OBJECTION` after its dashed-ref and older-Git findings were fixed.
- Final autoreview: `autoreview clean: no accepted/actionable findings reported`.
- `git diff --check` passed.
