### PR TITLE
fix(discord): keep tool rows in the progress draft under verbose

### DIFF
--- a/extensions/discord/src/monitor/message-handler.process-progress.ts
+++ b/extensions/discord/src/monitor/message-handler.process-progress.ts
@@ -76,7 +76,9 @@ export function createDiscordMessageProgressRuntime(params: {
   })();
   const reasoningDurableEnabled = reasoningLevel === "on";
   const reasoningWindowEnabled = reasoningLevel === "stream";
-  let shouldYieldDraftProgress: () => boolean = () => false;
+  // The durable verbose lane mirrors commentary, not tool lifecycle rows.
+  // Yield only the draft content that has a durable counterpart.
+  let shouldYieldDraftCommentary: () => boolean = () => false;
   let progressTurnStartedAt = Date.now();
   let progressReasoningSteps = 0;
   let progressToolCalls = 0;
@@ -169,11 +171,11 @@ export function createDiscordMessageProgressRuntime(params: {
       : undefined,
     reasoningPayloadsEnabled: reasoningDurableEnabled,
     onVerboseProgressVisibility: (isActive) => {
-      shouldYieldDraftProgress = isActive;
+      shouldYieldDraftCommentary = isActive;
     },
     onNarrationUpdate: draftPreview.narrationProgressEnabled
       ? async (payload) => {
-          if (isProcessAborted(abortSignal) || shouldYieldDraftProgress()) {
+          if (isProcessAborted(abortSignal) || shouldYieldDraftCommentary()) {
             return;
           }
           await draftPreview.pushNarrationProgress(payload.text);
@@ -208,9 +210,6 @@ export function createDiscordMessageProgressRuntime(params: {
       if (payload.phase === "start") {
         closePendingWindowThought();
       }
-      if (shouldYieldDraftProgress()) {
-        return;
-      }
       // Match the compositor: message/react/typing are not work-tool lines.
       if (payload.phase === "start" && isChannelProgressDraftWorkToolName(payload.name)) {
         progressToolCalls += 1;
@@ -236,13 +235,10 @@ export function createDiscordMessageProgressRuntime(params: {
         return false;
       }
       if (payload.kind === "preamble") {
-        if (shouldYieldDraftProgress()) {
+        if (shouldYieldDraftCommentary()) {
           return undefined;
         }
         return await draftPreview.pushPreambleItemEvent(payload, noteWindowCommentary);
-      }
-      if (shouldYieldDraftProgress()) {
-        return undefined;
       }
       await draftPreview.pushToolProgress(
         buildChannelProgressDraftLineForEntry(discordConfig, {
@@ -285,7 +281,7 @@ export function createDiscordMessageProgressRuntime(params: {
       if (isFailedProgress(payload)) {
         return false;
       }
-      if (payload.phase !== "end" || shouldYieldDraftProgress()) {
+      if (payload.phase !== "end") {
         return undefined;
       }
       await draftPreview.pushToolProgress(
@@ -303,7 +299,7 @@ export function createDiscordMessageProgressRuntime(params: {
       return undefined;
     },
     onPatchSummary: async (payload) => {
-      if (payload.phase !== "end" || shouldYieldDraftProgress()) {
+      if (payload.phase !== "end") {
         return;
       }
       await draftPreview.pushToolProgress(

--- a/extensions/discord/src/monitor/message-handler.process.draft-progress.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.draft-progress.test.ts
@@ -127,7 +127,7 @@ describe("processDiscordMessage draft streaming progress", () => {
     ["active", true],
     ["inactive", false],
   ])(
-    "renders Discord tool lines in the draft exactly when durable verbose progress is %s",
+    "keeps Discord tool lines in the draft when durable verbose progress is %s",
     async (_label, durableLaneActive) => {
       const elapseProgressDraftStartDelay = useProgressDraftStartDelay();
       const draftStream = createMockDraftStreamForTest();
@@ -155,15 +155,47 @@ describe("processDiscordMessage draft streaming progress", () => {
       await runProcessDiscordMessage(ctx);
 
       const updates = draftStream.update.mock.calls.map((call) => call[0]).join("\n");
-      if (durableLaneActive) {
-        // The durable verbose lane persists tool summaries: the ephemeral
-        // draft must not render the same tool activity a second time.
-        expect(updates).toBe("");
-      } else {
-        expect(updates).toContain("Exec");
-      }
+      expect(updates).toContain("Exec");
     },
   );
+
+  it("keeps tool rows while yielding commentary to the durable verbose lane", async () => {
+    const elapseProgressDraftStartDelay = useProgressDraftStartDelay();
+    const draftStream = createMockDraftStreamForTest();
+
+    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
+      params?.replyOptions?.onVerboseProgressVisibility?.(() => true);
+      await params?.replyOptions?.onItemEvent?.({
+        itemId: "preamble-1",
+        kind: "preamble",
+        progressText: "Checking the current weather source before summarizing.",
+      });
+      await params?.replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+      await params?.replyOptions?.onCommandOutput?.({
+        phase: "end",
+        title: "Exec",
+        name: "exec",
+        exitCode: 0,
+      });
+      await elapseProgressDraftStartDelay();
+      return createNoQueuedDispatchResult();
+    });
+
+    const ctx = await createAutomaticSourceDeliveryContext({
+      discordConfig: {
+        streaming: {
+          mode: "progress",
+          progress: { label: "Shelling", commentary: true },
+        },
+      },
+    });
+
+    await runProcessDiscordMessage(ctx);
+
+    const updates = draftStream.update.mock.calls.map((call) => call[0]).join("\n");
+    expect(updates).toContain("Exec");
+    expect(updates).not.toContain("Checking the current weather source");
+  });
 
   it("retracts a preamble headline by item identity", async () => {
     const elapseProgressDraftStartDelay = useProgressDraftStartDelay();

--- a/src/auto-reply/reply/dispatch-from-config.choose-route.ts
+++ b/src/auto-reply/reply/dispatch-from-config.choose-route.ts
@@ -192,10 +192,13 @@ export async function chooseDispatchRoute(state: PrepareDispatchOperationReadySt
   const noteCommentaryProgress = async (payload: { itemId?: string; progressText?: string }) => {
     const itemId = payload.itemId?.trim() || undefined;
     const text = payload.progressText ?? "";
+    const repeatsBufferedText =
+      pendingCommentaryProgress !== null && pendingCommentaryProgress.text.trim() === text.trim();
     const updatesBufferedItem =
       pendingCommentaryProgress !== null &&
-      pendingCommentaryProgress.itemId !== undefined &&
-      pendingCommentaryProgress.itemId === itemId;
+      ((pendingCommentaryProgress.itemId !== undefined &&
+        pendingCommentaryProgress.itemId === itemId) ||
+        repeatsBufferedText);
     if (!text.trim()) {
       // Empty commentary with an item id means the producer retracted that
       // item; drop it if it has not been sent yet.

--- a/src/auto-reply/reply/dispatch-from-config.routing.test-utils.ts
+++ b/src/auto-reply/reply/dispatch-from-config.routing.test-utils.ts
@@ -1122,6 +1122,49 @@ describe("dispatchReplyFromConfig", () => {
     );
   });
 
+  it("deduplicates identical commentary when producer item ids change", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      verboseLevel: "on",
+    };
+    const cfg = automaticGroupReplyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "discord",
+      Surface: "discord",
+      ChatType: "direct",
+      From: "discord:user:123",
+      SessionKey: "agent:main:main",
+    });
+
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+      _cfg?: OpenClawConfig,
+    ) => {
+      await opts?.onItemEvent?.({
+        itemId: "commentary-stream",
+        kind: "preamble",
+        progressText: "Checking the current state.",
+      });
+      await opts?.onItemEvent?.({
+        itemId: "commentary-snapshot",
+        kind: "preamble",
+        progressText: "Checking the current state.",
+      });
+      await opts?.onToolStart?.({ name: "exec", phase: "start" });
+      return { text: "done" } satisfies ReplyPayload;
+    };
+
+    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+
+    const sendToolResult = dispatcher.sendToolResult as ReturnType<typeof vi.fn>;
+    expect(sendToolResult).toHaveBeenCalledTimes(1);
+    expect((sendToolResult.mock.calls[0]?.[0] as ReplyPayload | undefined)?.text).toBe(
+      "💬 Checking the current state.",
+    );
+  });
+
   it("flushes the previous commentary block when a new item starts", async () => {
     setNoAbort();
     sessionStoreMocks.currentEntry = {


### PR DESCRIPTION
## Summary

With `channels.discord.streaming.mode: progress` **and** session verbose on (`agents.defaults.verboseDefault: on`), tool progress rendered **nowhere** on Discord. Users saw thinking messages and the final reply, but zero tool rows in the progress draft — and `progress.toolProgress: true` changed nothing.

## Root cause — mutual deferral between two lanes

The durable verbose lane (added in `a397fcabd9e`) exposes `onVerboseProgressVisibility`, a live getter so a draft-rendering channel can *yield* its ephemeral lines while the durable standalone lane delivers the same content — avoiding double render. Crucially, that durable lane carries **only commentary (preamble items) and tool-result summaries** — it never emits tool-*start* rows (`shouldSendToolStartStatuses` is hard-`false`), and `onCommandOutput`/`onPatchSummary` have no standalone core delivery at all (their only standalone path, `maybeSendWorkingStatus`, is gated off).

The Discord progress runtime (`extensions/discord/src/monitor/message-handler.process-progress.ts`) wired that **commentary-visibility** getter into the **tool lane** as well:

- `onToolStart`
- non-preamble `onItemEvent`
- `onCommandOutput`
- `onPatchSummary`

So when verbose was on, the getter returned true and the draft early-returned on every tool line — deferring to a durable lane that never renders those rows. Meanwhile the standalone verbose messages that *do* exist (tool-*result* summaries, commentary) are a different content stream. Net: tool activity appeared in **neither** lane.

`resolveChannelStreamingSuppressDefaultToolProgressMessages` returning `true` in progress mode (`src/channels/streaming.ts`) is correct and unchanged — that flag only governs quiet channel-owned callback forwarding, not the standalone lane, and is not the defect.

## Fix

Scope the yield to the lines that genuinely have a durable-lane counterpart — commentary/preamble (and narration) — and let tool lines always stay in the draft. Implemented as option (a) from the issue: the visibility getter is renamed `shouldYieldDraftCommentary` and removed from the four tool-lane callbacks.

Guarantees:

- **(i)** progress + verbose on → tool rows render in the draft **exactly once** (tool-start/item/command/patch draft lines have no standalone equivalent, so no double render).
- **(ii)** verbose off → draft still renders tool rows (getter is false; unchanged).
- **(iii)** `streaming.mode: off` → standalone verbose tool-result messages still fire (untouched; the draft is inactive there anyway).
- **(iv)** thinking and final replies unaffected.

## Change Type

Bug fix (channel: Discord).

## Regression Test Plan

`extensions/discord/src/monitor/message-handler.process.draft-progress.test.ts`:

- Updated the tool-line test to assert the draft **keeps** tool rows whether or not the durable lane is active (previously asserted an empty draft).
- Added a mutual-deferral regression test: progress mode + verbose visibility active → tool rows appear in the draft **and** commentary is yielded to the durable lane (not double-rendered).
- Commentary-yield test (unchanged) still pins that preamble commentary yields to the durable lane.

## Validation

Run from the topic worktree with the pinned `pnpm@11.2.2`:

- `vitest message-handler.process.draft-progress.test.ts` — **19 passed**
- `vitest test/scripts/check-changelog-attributions.test.ts` — **10 passed**
- `pnpm tsgo:extensions` — clean; `pnpm tsgo:extensions:test` — clean
- `pnpm oxlint <touched files>` — clean; `git diff --check` — clean

The maintainer improvement also touches the shared durable-commentary buffer; current focused and hosted core proof is recorded in Evidence below.

## Linked Issue

Tracked internally as Beads `openclaw-7cd`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## What Problem This Solves

With Discord progress streaming and verbose delivery enabled, the channel yielded tool lifecycle rows to a durable lane that does not own those rows. Users therefore saw commentary and the final answer but no live tool activity. During maintainer live proof, the same commentary text also arrived under changing producer IDs and was sent twice; the improved patch deduplicates that shared durable lane at its owner boundary.

## Evidence

- Exact head: `b4f347e41aa97c3016c5c412f865754e0035a296`.
- Focused regressions: 302 core dispatch tests and 19 Discord progress tests passed.
- Hosted validation: `pnpm check:changed` passed the selected core, core-test, extension, and extension-test lanes on [Blacksmith Testbox](https://github.com/openclaw/openclaw/actions/runs/30424344595).
- Real Discord round-trip: progress mode plus verbose delivery produced exactly one durable commentary message and one editable progress draft with the exec row; the draft collapsed on completion and the final marker arrived unchanged. Redacted REST readback confirmed `commentaryCount=1` and `finalCount=1`.
- Fresh Codex autoreview reported no findings and judged the product patch correct (0.84 confidence).
