### PR TITLE
fix(browser): skip non-executable auto-discovery candidates

### DIFF
--- a/extensions/browser/src/browser/chrome.default-browser.test.ts
+++ b/extensions/browser/src/browser/chrome.default-browser.test.ts
@@ -12,12 +12,13 @@ vi.mock("node:child_process", async () => {
 });
 vi.mock("node:fs", async () => {
   const { mockNodeBuiltinModule } = await import("openclaw/plugin-sdk/test-node-mocks");
+  const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
   const accessSync = vi.fn();
   const existsSync = vi.fn();
   const readFileSync = vi.fn();
   return mockNodeBuiltinModule(
-    () => vi.importActual<typeof import("node:fs")>("node:fs"),
-    { accessSync, constants: { X_OK: 1 }, existsSync, readFileSync },
+    async () => actual,
+    { accessSync, constants: actual.constants, existsSync, readFileSync },
     { mirrorToDefault: true },
   );
 });

--- a/extensions/browser/src/browser/chrome.default-browser.test.ts
+++ b/extensions/browser/src/browser/chrome.default-browser.test.ts
@@ -15,10 +15,12 @@ vi.mock("node:fs", async () => {
   const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
   const accessSync = vi.fn();
   const existsSync = vi.fn();
+  const readdirSync = vi.fn();
   const readFileSync = vi.fn();
+  const statSync = vi.fn();
   return mockNodeBuiltinModule(
     async () => actual,
-    { accessSync, constants: actual.constants, existsSync, readFileSync },
+    { accessSync, constants: actual.constants, existsSync, readdirSync, readFileSync, statSync },
     { mirrorToDefault: true },
   );
 });
@@ -69,7 +71,7 @@ describe("browser default executable detection", () => {
 
   function mockExecutableAccessDeniedFor(inaccessiblePath: string): void {
     vi.mocked(fs.accessSync).mockImplementation((candidate) => {
-      if (String(candidate) === inaccessiblePath || !fs.existsSync(candidate)) {
+      if (String(candidate) === inaccessiblePath) {
         throw new Error("EACCES");
       }
     });
@@ -79,10 +81,13 @@ describe("browser default executable detection", () => {
     vi.mocked(execFileSync).mockReset();
     vi.mocked(fs.accessSync).mockReset();
     vi.mocked(fs.existsSync).mockReset();
-    vi.mocked(fs.accessSync).mockImplementation((candidate) => {
+    vi.mocked(fs.readdirSync).mockReset();
+    vi.mocked(fs.statSync).mockReset();
+    vi.mocked(fs.statSync).mockImplementation((candidate) => {
       if (!fs.existsSync(candidate)) {
         throw new Error("ENOENT");
       }
+      return { isFile: () => true } as fs.Stats;
     });
     vi.mocked(fs.readFileSync).mockReset();
     vi.mocked(os.homedir).mockReset();
@@ -121,6 +126,27 @@ describe("browser default executable detection", () => {
     });
     expect(resolveGoogleChromeExecutableForPlatform("linux")).toEqual({
       kind: "chrome",
+      path: executableCandidate,
+    });
+  });
+
+  it("skips directories in the Playwright browser cache", () => {
+    const browserCache = "/tmp/browsers";
+    const directoryCandidate = `${browserCache}/chromium-100/chrome-linux64/chrome`;
+    const executableCandidate = `${browserCache}/chromium-100/chrome-linux/chrome`;
+    vi.stubEnv("PLAYWRIGHT_BROWSERS_PATH", browserCache);
+    vi.mocked(fs.readdirSync).mockReturnValue(["chromium-100"] as never);
+    vi.mocked(fs.statSync).mockImplementation((candidate) => {
+      const value = String(candidate);
+      if (value !== directoryCandidate && value !== executableCandidate) {
+        throw new Error("ENOENT");
+      }
+      return { isFile: () => value === executableCandidate } as fs.Stats;
+    });
+
+    const config = {} as Parameters<typeof resolveBrowserExecutableForPlatform>[0];
+    expect(resolveBrowserExecutableForPlatform(config, "linux")).toEqual({
+      kind: "chromium",
       path: executableCandidate,
     });
   });

--- a/extensions/browser/src/browser/chrome.default-browser.test.ts
+++ b/extensions/browser/src/browser/chrome.default-browser.test.ts
@@ -12,11 +12,12 @@ vi.mock("node:child_process", async () => {
 });
 vi.mock("node:fs", async () => {
   const { mockNodeBuiltinModule } = await import("openclaw/plugin-sdk/test-node-mocks");
+  const accessSync = vi.fn();
   const existsSync = vi.fn();
   const readFileSync = vi.fn();
   return mockNodeBuiltinModule(
     () => vi.importActual<typeof import("node:fs")>("node:fs"),
-    { existsSync, readFileSync },
+    { accessSync, constants: { X_OK: 1 }, existsSync, readFileSync },
     { mirrorToDefault: true },
   );
 });
@@ -67,6 +68,8 @@ describe("browser default executable detection", () => {
 
   beforeEach(() => {
     vi.mocked(execFileSync).mockReset();
+    vi.mocked(fs.accessSync).mockReset();
+    vi.mocked(fs.accessSync).mockImplementation(() => undefined);
     vi.mocked(fs.existsSync).mockReset();
     vi.mocked(fs.readFileSync).mockReset();
     vi.mocked(os.homedir).mockReset();

--- a/extensions/browser/src/browser/chrome.default-browser.test.ts
+++ b/extensions/browser/src/browser/chrome.default-browser.test.ts
@@ -67,11 +67,23 @@ describe("browser default executable detection", () => {
     });
   }
 
+  function mockExecutableAccessDeniedFor(inaccessiblePath: string): void {
+    vi.mocked(fs.accessSync).mockImplementation((candidate) => {
+      if (String(candidate) === inaccessiblePath || !fs.existsSync(candidate)) {
+        throw new Error("EACCES");
+      }
+    });
+  }
+
   beforeEach(() => {
     vi.mocked(execFileSync).mockReset();
     vi.mocked(fs.accessSync).mockReset();
-    vi.mocked(fs.accessSync).mockImplementation(() => undefined);
     vi.mocked(fs.existsSync).mockReset();
+    vi.mocked(fs.accessSync).mockImplementation((candidate) => {
+      if (!fs.existsSync(candidate)) {
+        throw new Error("ENOENT");
+      }
+    });
     vi.mocked(fs.readFileSync).mockReset();
     vi.mocked(os.homedir).mockReset();
     vi.mocked(os.homedir).mockReturnValue("/Users/test");
@@ -92,6 +104,25 @@ describe("browser default executable detection", () => {
 
     expect(exe?.path).toContain("Google Chrome.app/Contents/MacOS/Google Chrome");
     expect(exe?.kind).toBe("chrome");
+  });
+
+  it("skips non-executable Linux auto-discovery candidates", () => {
+    const firstCandidate = "/usr/bin/google-chrome";
+    const executableCandidate = "/usr/bin/google-chrome-stable";
+    vi.mocked(fs.existsSync).mockImplementation((candidate) => {
+      return [firstCandidate, executableCandidate].includes(String(candidate));
+    });
+    mockExecutableAccessDeniedFor(firstCandidate);
+
+    const config = {} as Parameters<typeof resolveBrowserExecutableForPlatform>[0];
+    expect(resolveBrowserExecutableForPlatform(config, "linux")).toEqual({
+      kind: "chrome",
+      path: executableCandidate,
+    });
+    expect(resolveGoogleChromeExecutableForPlatform("linux")).toEqual({
+      kind: "chrome",
+      path: executableCandidate,
+    });
   });
 
   it("detects Edge via LaunchServices bundle ID (com.microsoft.edgemac)", () => {

--- a/extensions/browser/src/browser/chrome.executables.ts
+++ b/extensions/browser/src/browser/chrome.executables.ts
@@ -118,6 +118,21 @@ function exists(filePath: string) {
   }
 }
 
+function isExecutable(filePath: string, requireExecutePermission = true): boolean {
+  if (!exists(filePath)) {
+    return false;
+  }
+  if (!requireExecutePermission) {
+    return true;
+  }
+  try {
+    fs.accessSync(filePath, fs.constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function execText(
   command: string,
   args: string[],
@@ -217,7 +232,7 @@ function detectDefaultChromiumExecutableMac(): BrowserExecutable | null {
     return null;
   }
   const exePath = path.join(appPath, "Contents", "MacOS", exeName);
-  if (!exists(exePath)) {
+  if (!isExecutable(exePath)) {
     return null;
   }
   return { kind: inferKindFromIdentifier(bundleId), path: exePath };
@@ -298,7 +313,7 @@ function detectDefaultChromiumExecutableLinux(): BrowserExecutable | null {
     return null;
   }
   const resolved = resolveLinuxExecutablePath(command);
-  if (!resolved) {
+  if (!resolved || !isExecutable(resolved)) {
     return null;
   }
   const exeName = normalizeLowercaseStringOrEmpty(path.posix.basename(resolved));
@@ -320,7 +335,7 @@ function detectDefaultChromiumExecutableWindows(): BrowserExecutable | null {
   if (!exePath) {
     return null;
   }
-  if (!exists(exePath)) {
+  if (!isExecutable(exePath, false)) {
     return null;
   }
   const directPath = resolveDirectWindowsBrowserExecutable(exePath);
@@ -519,9 +534,12 @@ function extractWindowsExecutablePath(command: string): string | null {
   return null;
 }
 
-function findFirstExecutable(candidates: Array<BrowserExecutable>): BrowserExecutable | null {
+function findFirstExecutable(
+  candidates: Array<BrowserExecutable>,
+  requireExecutePermission = true,
+): BrowserExecutable | null {
   for (const candidate of candidates) {
-    if (exists(candidate.path)) {
+    if (isExecutable(candidate.path, requireExecutePermission)) {
       return candidate;
     }
   }
@@ -529,9 +547,12 @@ function findFirstExecutable(candidates: Array<BrowserExecutable>): BrowserExecu
   return null;
 }
 
-function findFirstChromeExecutable(candidates: string[]): BrowserExecutable | null {
+function findFirstChromeExecutable(
+  candidates: string[],
+  requireExecutePermission = true,
+): BrowserExecutable | null {
   for (const candidate of candidates) {
-    if (exists(candidate)) {
+    if (isExecutable(candidate, requireExecutePermission)) {
       const normalizedPath = normalizeLowercaseStringOrEmpty(candidate);
       return {
         kind:
@@ -758,7 +779,7 @@ function findChromeExecutableWindows(): BrowserExecutable | null {
     path: joinWin(programFilesX86, "Microsoft", "Edge", "Application", "msedge.exe"),
   });
 
-  return findFirstExecutable(candidates);
+  return findFirstExecutable(candidates, false);
 }
 
 function findGoogleChromeExecutableWindows(): BrowserExecutable | null {
@@ -774,7 +795,7 @@ function findGoogleChromeExecutableWindows(): BrowserExecutable | null {
   candidates.push(joinWin(programFiles, "Google", "Chrome", "Application", "chrome.exe"));
   candidates.push(joinWin(programFilesX86, "Google", "Chrome", "Application", "chrome.exe"));
 
-  return findFirstChromeExecutable(candidates);
+  return findFirstChromeExecutable(candidates, false);
 }
 
 /** Resolve the Google Chrome executable for a named platform when available. */

--- a/extensions/browser/src/browser/chrome.executables.ts
+++ b/extensions/browser/src/browser/chrome.executables.ts
@@ -665,15 +665,18 @@ function findChromeExecutableMac(): BrowserExecutable | null {
 }
 
 function findGoogleChromeExecutableMac(): BrowserExecutable | null {
-  return findFirstChromeExecutable([
-    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
-    path.join(os.homedir(), "Applications/Google Chrome.app/Contents/MacOS/Google Chrome"),
-    "/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary",
-    path.join(
-      os.homedir(),
-      "Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary",
-    ),
-  ], "darwin");
+  return findFirstChromeExecutable(
+    [
+      "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+      path.join(os.homedir(), "Applications/Google Chrome.app/Contents/MacOS/Google Chrome"),
+      "/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary",
+      path.join(
+        os.homedir(),
+        "Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary",
+      ),
+    ],
+    "darwin",
+  );
 }
 
 /** Find the best Chromium-family executable on Linux. */
@@ -702,14 +705,17 @@ function findChromeExecutableLinux(): BrowserExecutable | null {
 }
 
 function findGoogleChromeExecutableLinux(): BrowserExecutable | null {
-  return findFirstChromeExecutable([
-    "/usr/bin/google-chrome",
-    "/usr/bin/google-chrome-stable",
-    "/usr/bin/google-chrome-beta",
-    "/usr/bin/google-chrome-unstable",
-    "/opt/google/chrome/chrome",
-    "/snap/bin/google-chrome",
-  ], "linux");
+  return findFirstChromeExecutable(
+    [
+      "/usr/bin/google-chrome",
+      "/usr/bin/google-chrome-stable",
+      "/usr/bin/google-chrome-beta",
+      "/usr/bin/google-chrome-unstable",
+      "/opt/google/chrome/chrome",
+      "/snap/bin/google-chrome",
+    ],
+    "linux",
+  );
 }
 
 /** Find the best Chromium-family executable on Windows. */

--- a/extensions/browser/src/browser/chrome.executables.ts
+++ b/extensions/browser/src/browser/chrome.executables.ts
@@ -118,10 +118,13 @@ function exists(filePath: string) {
   }
 }
 
-function isExecutable(filePath: string): boolean {
+function isExecutable(filePath: string, platform: NodeJS.Platform): boolean {
   try {
-    // Node treats X_OK as F_OK on Windows, preserving existence-only discovery there.
-    fs.accessSync(filePath, fs.constants.X_OK);
+    if (!fs.statSync(filePath).isFile()) {
+      return false;
+    }
+    // Windows has no POSIX execute bit; a visible regular file preserves its native contract.
+    fs.accessSync(filePath, platform === "win32" ? fs.constants.F_OK : fs.constants.X_OK);
     return true;
   } catch {
     return false;
@@ -227,7 +230,7 @@ function detectDefaultChromiumExecutableMac(): BrowserExecutable | null {
     return null;
   }
   const exePath = path.join(appPath, "Contents", "MacOS", exeName);
-  if (!isExecutable(exePath)) {
+  if (!isExecutable(exePath, "darwin")) {
     return null;
   }
   return { kind: inferKindFromIdentifier(bundleId), path: exePath };
@@ -308,7 +311,7 @@ function detectDefaultChromiumExecutableLinux(): BrowserExecutable | null {
     return null;
   }
   const resolved = resolveLinuxExecutablePath(command);
-  if (!resolved || !isExecutable(resolved)) {
+  if (!resolved || !isExecutable(resolved, "linux")) {
     return null;
   }
   const exeName = normalizeLowercaseStringOrEmpty(path.posix.basename(resolved));
@@ -330,7 +333,7 @@ function detectDefaultChromiumExecutableWindows(): BrowserExecutable | null {
   if (!exePath) {
     return null;
   }
-  if (!isExecutable(exePath)) {
+  if (!isExecutable(exePath, "win32")) {
     return null;
   }
   const directPath = resolveDirectWindowsBrowserExecutable(exePath);
@@ -529,9 +532,12 @@ function extractWindowsExecutablePath(command: string): string | null {
   return null;
 }
 
-function findFirstExecutable(candidates: Array<BrowserExecutable>): BrowserExecutable | null {
+function findFirstExecutable(
+  candidates: Array<BrowserExecutable>,
+  platform: NodeJS.Platform,
+): BrowserExecutable | null {
   for (const candidate of candidates) {
-    if (isExecutable(candidate.path)) {
+    if (isExecutable(candidate.path, platform)) {
       return candidate;
     }
   }
@@ -539,9 +545,12 @@ function findFirstExecutable(candidates: Array<BrowserExecutable>): BrowserExecu
   return null;
 }
 
-function findFirstChromeExecutable(candidates: string[]): BrowserExecutable | null {
+function findFirstChromeExecutable(
+  candidates: string[],
+  platform: NodeJS.Platform,
+): BrowserExecutable | null {
   for (const candidate of candidates) {
-    if (isExecutable(candidate)) {
+    if (isExecutable(candidate, platform)) {
       const normalizedPath = normalizeLowercaseStringOrEmpty(candidate);
       return {
         kind:
@@ -652,7 +661,7 @@ function findChromeExecutableMac(): BrowserExecutable | null {
     },
   ];
 
-  return findFirstExecutable(candidates);
+  return findFirstExecutable(candidates, "darwin");
 }
 
 function findGoogleChromeExecutableMac(): BrowserExecutable | null {
@@ -664,7 +673,7 @@ function findGoogleChromeExecutableMac(): BrowserExecutable | null {
       os.homedir(),
       "Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary",
     ),
-  ]);
+  ], "darwin");
 }
 
 /** Find the best Chromium-family executable on Linux. */
@@ -689,7 +698,7 @@ function findChromeExecutableLinux(): BrowserExecutable | null {
     ...findPlaywrightChromiumExecutableCandidatesLinux(),
   ];
 
-  return findFirstExecutable(candidates);
+  return findFirstExecutable(candidates, "linux");
 }
 
 function findGoogleChromeExecutableLinux(): BrowserExecutable | null {
@@ -700,7 +709,7 @@ function findGoogleChromeExecutableLinux(): BrowserExecutable | null {
     "/usr/bin/google-chrome-unstable",
     "/opt/google/chrome/chrome",
     "/snap/bin/google-chrome",
-  ]);
+  ], "linux");
 }
 
 /** Find the best Chromium-family executable on Windows. */
@@ -768,7 +777,7 @@ function findChromeExecutableWindows(): BrowserExecutable | null {
     path: joinWin(programFilesX86, "Microsoft", "Edge", "Application", "msedge.exe"),
   });
 
-  return findFirstExecutable(candidates);
+  return findFirstExecutable(candidates, "win32");
 }
 
 function findGoogleChromeExecutableWindows(): BrowserExecutable | null {
@@ -784,7 +793,7 @@ function findGoogleChromeExecutableWindows(): BrowserExecutable | null {
   candidates.push(joinWin(programFiles, "Google", "Chrome", "Application", "chrome.exe"));
   candidates.push(joinWin(programFilesX86, "Google", "Chrome", "Application", "chrome.exe"));
 
-  return findFirstChromeExecutable(candidates);
+  return findFirstChromeExecutable(candidates, "win32");
 }
 
 /** Resolve the Google Chrome executable for a named platform when available. */

--- a/extensions/browser/src/browser/chrome.executables.ts
+++ b/extensions/browser/src/browser/chrome.executables.ts
@@ -118,14 +118,9 @@ function exists(filePath: string) {
   }
 }
 
-function isExecutable(filePath: string, requireExecutePermission = true): boolean {
-  if (!exists(filePath)) {
-    return false;
-  }
-  if (!requireExecutePermission) {
-    return true;
-  }
+function isExecutable(filePath: string): boolean {
   try {
+    // Node treats X_OK as F_OK on Windows, preserving existence-only discovery there.
     fs.accessSync(filePath, fs.constants.X_OK);
     return true;
   } catch {
@@ -335,7 +330,7 @@ function detectDefaultChromiumExecutableWindows(): BrowserExecutable | null {
   if (!exePath) {
     return null;
   }
-  if (!isExecutable(exePath, false)) {
+  if (!isExecutable(exePath)) {
     return null;
   }
   const directPath = resolveDirectWindowsBrowserExecutable(exePath);
@@ -534,12 +529,9 @@ function extractWindowsExecutablePath(command: string): string | null {
   return null;
 }
 
-function findFirstExecutable(
-  candidates: Array<BrowserExecutable>,
-  requireExecutePermission = true,
-): BrowserExecutable | null {
+function findFirstExecutable(candidates: Array<BrowserExecutable>): BrowserExecutable | null {
   for (const candidate of candidates) {
-    if (isExecutable(candidate.path, requireExecutePermission)) {
+    if (isExecutable(candidate.path)) {
       return candidate;
     }
   }
@@ -547,12 +539,9 @@ function findFirstExecutable(
   return null;
 }
 
-function findFirstChromeExecutable(
-  candidates: string[],
-  requireExecutePermission = true,
-): BrowserExecutable | null {
+function findFirstChromeExecutable(candidates: string[]): BrowserExecutable | null {
   for (const candidate of candidates) {
-    if (isExecutable(candidate, requireExecutePermission)) {
+    if (isExecutable(candidate)) {
       const normalizedPath = normalizeLowercaseStringOrEmpty(candidate);
       return {
         kind:
@@ -779,7 +768,7 @@ function findChromeExecutableWindows(): BrowserExecutable | null {
     path: joinWin(programFilesX86, "Microsoft", "Edge", "Application", "msedge.exe"),
   });
 
-  return findFirstExecutable(candidates, false);
+  return findFirstExecutable(candidates);
 }
 
 function findGoogleChromeExecutableWindows(): BrowserExecutable | null {
@@ -795,7 +784,7 @@ function findGoogleChromeExecutableWindows(): BrowserExecutable | null {
   candidates.push(joinWin(programFiles, "Google", "Chrome", "Application", "chrome.exe"));
   candidates.push(joinWin(programFilesX86, "Google", "Chrome", "Application", "chrome.exe"));
 
-  return findFirstChromeExecutable(candidates, false);
+  return findFirstChromeExecutable(candidates);
 }
 
 /** Resolve the Google Chrome executable for a named platform when available. */

--- a/extensions/browser/src/browser/chrome.test.ts
+++ b/extensions/browser/src/browser/chrome.test.ts
@@ -812,6 +812,7 @@ describe("browser chrome helpers", () => {
 describe("chrome executables", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    vi.spyOn(fs, "accessSync").mockImplementation(() => undefined);
   });
 
   it("parses odd dotted browser version tokens using the last match", () => {
@@ -852,6 +853,24 @@ describe("chrome executables", () => {
     expect(resolveGoogleChromeExecutableForPlatform("linux")).toEqual({
       kind: "chrome",
       path: "/opt/google/chrome/chrome",
+    });
+  });
+
+  it("skips non-executable Linux browser candidates", () => {
+    vi.spyOn(fs, "existsSync").mockImplementation((candidate) => {
+      return ["/usr/bin/google-chrome", "/usr/bin/google-chrome-stable"].includes(
+        String(candidate),
+      );
+    });
+    vi.mocked(fs.accessSync).mockImplementation((candidate) => {
+      if (String(candidate) === "/usr/bin/google-chrome") {
+        throw new Error("EACCES");
+      }
+    });
+
+    expect(resolveGoogleChromeExecutableForPlatform("linux")).toEqual({
+      kind: "chrome",
+      path: "/usr/bin/google-chrome-stable",
     });
   });
 });

--- a/extensions/browser/src/browser/chrome.test.ts
+++ b/extensions/browser/src/browser/chrome.test.ts
@@ -812,10 +812,12 @@ describe("browser chrome helpers", () => {
 describe("chrome executables", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
-    vi.spyOn(fs, "accessSync").mockImplementation((candidate) => {
+    vi.spyOn(fs, "accessSync").mockImplementation(() => undefined);
+    vi.spyOn(fs, "statSync").mockImplementation((candidate) => {
       if (!fs.existsSync(candidate)) {
         throw new Error("ENOENT");
       }
+      return { isFile: () => true } as fs.Stats;
     });
   });
 

--- a/extensions/browser/src/browser/chrome.test.ts
+++ b/extensions/browser/src/browser/chrome.test.ts
@@ -812,7 +812,11 @@ describe("browser chrome helpers", () => {
 describe("chrome executables", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
-    vi.spyOn(fs, "accessSync").mockImplementation(() => undefined);
+    vi.spyOn(fs, "accessSync").mockImplementation((candidate) => {
+      if (!fs.existsSync(candidate)) {
+        throw new Error("ENOENT");
+      }
+    });
   });
 
   it("parses odd dotted browser version tokens using the last match", () => {
@@ -853,24 +857,6 @@ describe("chrome executables", () => {
     expect(resolveGoogleChromeExecutableForPlatform("linux")).toEqual({
       kind: "chrome",
       path: "/opt/google/chrome/chrome",
-    });
-  });
-
-  it("skips non-executable Linux browser candidates", () => {
-    vi.spyOn(fs, "existsSync").mockImplementation((candidate) => {
-      return ["/usr/bin/google-chrome", "/usr/bin/google-chrome-stable"].includes(
-        String(candidate),
-      );
-    });
-    vi.mocked(fs.accessSync).mockImplementation((candidate) => {
-      if (String(candidate) === "/usr/bin/google-chrome") {
-        throw new Error("EACCES");
-      }
-    });
-
-    expect(resolveGoogleChromeExecutableForPlatform("linux")).toEqual({
-      kind: "chrome",
-      path: "/usr/bin/google-chrome-stable",
     });
   });
 });

--- a/test/scripts/bench-sqlite-reliability.test.ts
+++ b/test/scripts/bench-sqlite-reliability.test.ts
@@ -13,6 +13,10 @@ const tempDirs: string[] = [];
 // The real smoke proof runs twice and can exceed Vitest's 120s default on fork CI runners.
 const RELIABILITY_SMOKE_TEST_TIMEOUT_MS = 300_000;
 
+function reliabilitySmokeTest(name: string, test: () => void): void {
+  it(name, test, RELIABILITY_SMOKE_TEST_TIMEOUT_MS);
+}
+
 function makeTempDir(): string {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sqlite-reliability-test-"));
   tempDirs.push(tempDir);
@@ -141,7 +145,7 @@ describe("scripts/bench-sqlite-reliability", () => {
     });
   });
 
-  it("reuses a state directory without stale rows or restore collisions", () => {
+  reliabilitySmokeTest("reuses a state directory without stale rows or restore collisions", () => {
     const stateDir = makeTempDir();
     const firstOutput = path.join(stateDir, "report-first.json");
     const firstResult = runProof([
@@ -373,7 +377,7 @@ describe("scripts/bench-sqlite-reliability", () => {
     };
     expect(secondReport.restoresVerified).toBe(7);
     expect(secondReport.paths.syncedRepository).not.toBe(firstReport.paths.syncedRepository);
-  }, RELIABILITY_SMOKE_TEST_TIMEOUT_MS);
+  });
 
   it("stops the writer when its parent IPC channel disconnects", async () => {
     const databasePath = path.join(makeTempDir(), "writer.sqlite");

--- a/test/scripts/bench-sqlite-reliability.test.ts
+++ b/test/scripts/bench-sqlite-reliability.test.ts
@@ -10,6 +10,8 @@ import type { ReliabilityReport } from "../../scripts/lib/sqlite-reliability-con
 import { monitorSqliteWalDuring } from "../../scripts/lib/sqlite-reliability-wal-monitor.js";
 
 const tempDirs: string[] = [];
+// The real smoke proof runs twice and can exceed Vitest's 120s default on fork CI runners.
+const RELIABILITY_SMOKE_TEST_TIMEOUT_MS = 300_000;
 
 function makeTempDir(): string {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sqlite-reliability-test-"));
@@ -371,7 +373,7 @@ describe("scripts/bench-sqlite-reliability", () => {
     };
     expect(secondReport.restoresVerified).toBe(7);
     expect(secondReport.paths.syncedRepository).not.toBe(firstReport.paths.syncedRepository);
-  });
+  }, RELIABILITY_SMOKE_TEST_TIMEOUT_MS);
 
   it("stops the writer when its parent IPC channel disconnects", async () => {
     const databasePath = path.join(makeTempDir(), "writer.sqlite");


### PR DESCRIPTION
Closes #111950

## What Problem This Solves

Fixes an issue where macOS and Linux users relying on browser auto-discovery could get a launch failure when an earlier browser candidate existed but lacked execute permission, even though a later supported browser candidate was runnable.

## Why This Change Was Made

Automatic browser discovery now verifies execute permission before selecting macOS/Linux candidates and continues through the candidate list after `EACCES`. Windows keeps its existing existence-only behavior, and explicitly configured browser paths remain unchanged.

## User Impact

Browser automation can fall through stale or non-executable auto-discovery candidates and launch the next runnable supported browser instead of failing on the first existing path.

## Evidence

### Real Linux filesystem proof

The final PR head was exercised outside the test harness on a dedicated Ubuntu host. The proof used OpenClaw's production `resolveBrowserExecutableForPlatform` path and real files under an isolated Playwright browser cache. It first verified that no earlier system Chromium candidate existed, then created the first discovered candidate without execute permission and the next supported candidate with execute permission.

Redacted terminal output:

```text
PR_HEAD=9635d5b4d907cb7c9fdac9cdc51bfca0d281d9e0
SOURCE_ARCHIVE_SHA256=a7e2b3943a1f5f5498500aa674efe3e3c8f4239dd73158c30a871ec8d1fed2aa
LINUX=Linux 5.15.0-170-generic x86_64 GNU/Linux
NODE_VERSION=v22.22.0

FIRST_EXISTING_CANDIDATE=<tmp>/browsers/chromium-100/chrome-linux64/chrome
FIRST_MODE=-rw-r--r--
FIRST_X_OK=false

LATER_CANDIDATE=<tmp>/browsers/chromium-100/chrome-linux/chrome
LATER_MODE=-rwxr-xr-x
LATER_X_OK=true

DISCOVERY_RESULT={"kind":"chromium","path":"<tmp>/browsers/chromium-100/chrome-linux/chrome"}
RESULT=PASS
```

The 22 KB source archive was produced locally with `git archive` from the exact PR SHA and contained the production discovery module plus its package metadata. A published OpenClaw `dist/plugin-sdk` was supplied only for the module's runtime imports; the discovery implementation under test came from the PR archive. The proof asserted both the returned path and browser kind, failed closed on any earlier system candidate, and removed the isolated filesystem tree on exit.

### Focused validation

- Deterministic Linux regression fixture: the first existing candidate fails `access(X_OK)`, the next candidate is executable, and discovery selects the latter.
- `node_modules/.bin/vitest.cmd run extensions/browser/src/browser/chrome.test.ts -t "chrome executables"` (6 passed)
- `node_modules/.bin/vitest.cmd run extensions/browser/src/browser/chrome.default-browser.test.ts -t "prefers default Chromium browser"` (1 passed)
- `node_modules/.bin/oxlint.cmd extensions/browser/src/browser/chrome.executables.ts extensions/browser/src/browser/chrome.test.ts extensions/browser/src/browser/chrome.default-browser.test.ts`
- `git diff --check`
- Autoreview: clean, no accepted/actionable findings; patch correct at 0.96 confidence.

The complete `chrome.default-browser.test.ts` file has one existing Windows-only path-separator failure in the Edge LaunchServices fixture; the focused default-browser case and all changed decision paths pass.

### Current-head Linux filesystem proof

The rewritten head was re-proved on a clean Linux `node:24-bookworm` container using the production `resolveBrowserExecutableForPlatform` path and real filesystem entries. The probe failed closed unless every earlier hard-coded system candidate was absent, created a directory at the first Playwright candidate path, created an executable file at the next candidate path, and asserted the resolver selected the latter.

```text
PR_HEAD=aa79f3ad63c041f2dd253d5396359e1cfc2568cf
PLATFORM=linux
FIRST_CANDIDATE_TYPE=directory
LATER_CANDIDATE_X_OK=true
DISCOVERY_RESULT={"kind":"chromium","path":"<tmp>/chromium-100/chrome-linux/chrome"}
RESULT=PASS
```

Proof environment: Crabbox `local-container` (Docker), lease `cbx_6f235846c082`, Node 24, exit 0. The lease was stopped after the run. Focused browser tests pass 48/48, and the changed-surface gate passed on Blacksmith run 30154479967.

### Fork CI reliability follow-up

The first exact-head CI run exposed an unrelated runner-speed mismatch in `test/scripts/bench-sqlite-reliability.test.ts`: the same two-pass smoke completed in 48.6 seconds on the green Blacksmith main-base run, but twice exceeded Vitest's 120-second per-test default on GitHub-hosted fork runners. The PR now gives only that real smoke test a 300-second timeout; its underlying process timeout and assertions are unchanged.

- Focused Blacksmith proof: 4/4 passed; long case 44.4 seconds (run 30155752827).
- Final changed-surface gate: passed (run 30156091240).
- Exact-head GitHub-hosted CI: green at `982b9592c6910c4eada2adee16292b35c1563816` (run 30156260709), including `checks-node-compact-small-3`.

