### PR TITLE
fix(control-ui): device-paired browser tabs cannot load local assistant images

### DIFF
--- a/src/gateway/control-ui-device-read-token.ts
+++ b/src/gateway/control-ui-device-read-token.ts
@@ -1,0 +1,93 @@
+// Shared authorization for Control UI device read tokens.
+// Control UI read surfaces (config bootstrap, assistant media, and the webchat
+// managed outgoing-image route) accept a paired operator.read device token as
+// the read credential a browser tab actually holds. This module owns that
+// verification plus its generation/scope semantics so the surfaces cannot
+// diverge.
+import { listDevicePairing, verifyDeviceToken } from "../infra/device-pairing.js";
+import { verifyPairingToken } from "../infra/pairing-token.js";
+import {
+  AUTH_RATE_LIMIT_SCOPE_DEVICE_TOKEN,
+  AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET,
+  type AuthRateLimiter,
+} from "./auth-rate-limit.js";
+
+const CONTROL_UI_OPERATOR_ROLE = "operator";
+const CONTROL_UI_OPERATOR_READ_SCOPE = "operator.read";
+
+async function verifyControlUiDeviceReadToken(
+  token: string,
+  requiredSharedGatewaySessionGeneration: string | undefined,
+): Promise<boolean> {
+  const pairing = await listDevicePairing();
+  for (const device of pairing.paired) {
+    const operatorToken = device.tokens?.[CONTROL_UI_OPERATOR_ROLE];
+    if (!operatorToken || operatorToken.revokedAtMs) {
+      continue;
+    }
+    if (!verifyPairingToken(token, operatorToken.token)) {
+      continue;
+    }
+    const verified = await verifyDeviceToken({
+      deviceId: device.deviceId,
+      token,
+      role: CONTROL_UI_OPERATOR_ROLE,
+      scopes: [CONTROL_UI_OPERATOR_READ_SCOPE],
+      requiredSharedGatewaySessionGeneration,
+    });
+    if (verified.ok) {
+      return true;
+    }
+  }
+  return false;
+}
+
+async function resolveControlUiDeviceReadTokenScopes(token: string): Promise<string[] | null> {
+  const pairing = await listDevicePairing();
+  for (const device of pairing.paired) {
+    const operatorBearer = device.tokens?.[CONTROL_UI_OPERATOR_ROLE];
+    if (
+      operatorBearer &&
+      !operatorBearer.revokedAtMs &&
+      verifyPairingToken(token, operatorBearer.token)
+    ) {
+      return operatorBearer.scopes;
+    }
+  }
+  return null;
+}
+
+export type ControlUiDeviceReadTokenAuth =
+  | { ok: true; scopes: string[] }
+  | { ok: false; rateLimited: true; retryAfterMs: number }
+  | { ok: false; rateLimited: false };
+
+/**
+ * Verify a Control UI operator.read device token, applying the device-token
+ * rate-limit scope. On success both credential-class counters are reset so a
+ * successful device read clears any shared-secret failures the same tab
+ * accumulated during login.
+ */
+export async function authorizeControlUiDeviceReadTokenRequest(params: {
+  token: string;
+  requiredSharedGatewaySessionGeneration: string | undefined;
+  rateLimiter?: AuthRateLimiter;
+  clientIp?: string;
+}): Promise<ControlUiDeviceReadTokenAuth> {
+  const rateCheck = params.rateLimiter?.check(params.clientIp, AUTH_RATE_LIMIT_SCOPE_DEVICE_TOKEN);
+  if (rateCheck && !rateCheck.allowed) {
+    return { ok: false, rateLimited: true, retryAfterMs: rateCheck.retryAfterMs };
+  }
+  const verified = await verifyControlUiDeviceReadToken(
+    params.token,
+    params.requiredSharedGatewaySessionGeneration,
+  );
+  const scopes = verified ? await resolveControlUiDeviceReadTokenScopes(params.token) : null;
+  if (scopes) {
+    params.rateLimiter?.reset(params.clientIp, AUTH_RATE_LIMIT_SCOPE_DEVICE_TOKEN);
+    params.rateLimiter?.reset(params.clientIp, AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET);
+    return { ok: true, scopes };
+  }
+  params.rateLimiter?.recordFailure(params.clientIp, AUTH_RATE_LIMIT_SCOPE_DEVICE_TOKEN);
+  return { ok: false, rateLimited: false };
+}

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -19,10 +19,8 @@ import {
   resolveControlUiRootSync,
 } from "../infra/control-ui-assets.js";
 import { resolveDevInstallGitBranch } from "../infra/dev-install-branch.js";
-import { listDevicePairing, verifyDeviceToken } from "../infra/device-pairing.js";
 import { openLocalFileSafely, FsSafeError } from "../infra/fs-safe.js";
 import { safeFileURLToPath } from "../infra/local-file-access.js";
-import { verifyPairingToken } from "../infra/pairing-token.js";
 import { isWithinDir } from "../infra/path-safety.js";
 import { assertLocalMediaAllowed, getDefaultLocalRoots } from "../media/local-media-access.js";
 import { getAgentScopedMediaLocalRoots } from "../media/local-roots.js";
@@ -38,11 +36,7 @@ import { resolveRuntimeServiceVersion } from "../version.js";
 import { openGatewayAssistantAvatar, resolveGatewayAssistantAvatar } from "./assistant-avatar.js";
 import { DEFAULT_ASSISTANT_IDENTITY, resolveAssistantIdentity } from "./assistant-identity.js";
 import { buildAssistantMediaContentDisposition } from "./assistant-media-content-disposition.js";
-import {
-  AUTH_RATE_LIMIT_SCOPE_DEVICE_TOKEN,
-  AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET,
-  type AuthRateLimiter,
-} from "./auth-rate-limit.js";
+import { AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET, type AuthRateLimiter } from "./auth-rate-limit.js";
 import { authorizeHttpGatewayConnect, type ResolvedGatewayAuth } from "./auth.js";
 import {
   CONTROL_UI_BASE_PATH_ATTRIBUTE,
@@ -52,6 +46,7 @@ import {
   type ControlUiPluginFrameGrantAck,
 } from "./control-ui-contract.js";
 import { buildControlUiCspHeader, computeInlineScriptHashes } from "./control-ui-csp.js";
+import { authorizeControlUiDeviceReadTokenRequest } from "./control-ui-device-read-token.js";
 import {
   isReadHttpMethod,
   respondNotFound as respondControlUiNotFound,
@@ -92,8 +87,6 @@ const CONTROL_UI_ASSISTANT_MEDIA_TICKET_SCOPE = "assistant-media";
 const CONTROL_UI_ASSISTANT_MEDIA_TICKET_TTL_MS = 5 * 60 * 1000;
 const CONTROL_UI_ASSETS_MISSING_MESSAGE =
   "Control UI assets not found. Build them with `pnpm ui:build` (auto-installs UI deps), or run `pnpm ui:dev` during development.";
-const CONTROL_UI_OPERATOR_READ_SCOPE = "operator.read";
-const CONTROL_UI_OPERATOR_ROLE = "operator";
 const controlUiAssistantMediaTicketSecret = randomBytes(32);
 
 type ControlUiRequestOptions = {
@@ -312,27 +305,22 @@ async function authorizeControlUiReadRequest(
     opts.auth.mode !== "trusted-proxy" &&
     opts.auth.mode !== "none"
   ) {
-    const deviceRateCheck = opts.rateLimiter?.check(clientIp, AUTH_RATE_LIMIT_SCOPE_DEVICE_TOKEN);
-    if (deviceRateCheck && !deviceRateCheck.allowed) {
+    const deviceAuth = await authorizeControlUiDeviceReadTokenRequest({
+      token,
+      requiredSharedGatewaySessionGeneration: sharedAuthGeneration,
+      rateLimiter: opts.rateLimiter,
+      clientIp,
+    });
+    if (deviceAuth.ok) {
+      verifiedDeviceScopes = deviceAuth.scopes;
+      resolvedAuthResult = { ok: true, method: "device-token" };
+    } else if (deviceAuth.rateLimited) {
       resolvedAuthResult = {
         ok: false,
         reason: "rate_limited",
         rateLimited: true,
-        retryAfterMs: deviceRateCheck.retryAfterMs,
+        retryAfterMs: deviceAuth.retryAfterMs,
       };
-    } else {
-      const deviceTokenOk = await authorizeControlUiDeviceReadToken(token, sharedAuthGeneration);
-      const deviceScopes = deviceTokenOk
-        ? await resolveControlUiDeviceReadTokenScopes(token)
-        : null;
-      if (deviceScopes) {
-        verifiedDeviceScopes = deviceScopes;
-        opts.rateLimiter?.reset(clientIp, AUTH_RATE_LIMIT_SCOPE_DEVICE_TOKEN);
-        opts.rateLimiter?.reset(clientIp, AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET);
-        resolvedAuthResult = { ok: true, method: "device-token" };
-      } else {
-        opts.rateLimiter?.recordFailure(clientIp, AUTH_RATE_LIMIT_SCOPE_DEVICE_TOKEN);
-      }
     }
   }
   if (!resolvedAuthResult.ok) {
@@ -371,48 +359,6 @@ async function authorizeControlUiReadRequest(
   }
 
   return true;
-}
-
-async function authorizeControlUiDeviceReadToken(
-  token: string,
-  requiredSharedGatewaySessionGeneration: string | undefined,
-): Promise<boolean> {
-  const pairing = await listDevicePairing();
-  for (const device of pairing.paired) {
-    const operatorToken = device.tokens?.[CONTROL_UI_OPERATOR_ROLE];
-    if (!operatorToken || operatorToken.revokedAtMs) {
-      continue;
-    }
-    if (!verifyPairingToken(token, operatorToken.token)) {
-      continue;
-    }
-    const verified = await verifyDeviceToken({
-      deviceId: device.deviceId,
-      token,
-      role: CONTROL_UI_OPERATOR_ROLE,
-      scopes: [CONTROL_UI_OPERATOR_READ_SCOPE],
-      requiredSharedGatewaySessionGeneration,
-    });
-    if (verified.ok) {
-      return true;
-    }
-  }
-  return false;
-}
-
-async function resolveControlUiDeviceReadTokenScopes(token: string): Promise<string[] | null> {
-  const pairing = await listDevicePairing();
-  for (const device of pairing.paired) {
-    const operatorBearer = device.tokens?.[CONTROL_UI_OPERATOR_ROLE];
-    if (
-      operatorBearer &&
-      !operatorBearer.revokedAtMs &&
-      verifyPairingToken(token, operatorBearer.token)
-    ) {
-      return operatorBearer.scopes;
-    }
-  }
-  return null;
 }
 
 type AssistantMediaAvailability =

--- a/src/gateway/managed-image-attachments.test.ts
+++ b/src/gateway/managed-image-attachments.test.ts
@@ -1,5 +1,6 @@
 // Managed image attachment tests cover storage, HTTP serving, cleanup, and
 // operator authorization for generated image artifacts attached to gateway replies.
+import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import http from "node:http";
 import type { AddressInfo } from "node:net";
@@ -10,6 +11,11 @@ import {
   createSolidPngBuffer,
 } from "../../test/helpers/image-fixtures.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import {
+  approveDevicePairing,
+  ensureDeviceToken,
+  requestDevicePairing,
+} from "../infra/device-pairing.js";
 import { createPinnedLookup } from "../infra/net/ssrf.js";
 import { setMediaStoreNetworkDepsForTest } from "../media/store.test-support.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
@@ -19,10 +25,19 @@ import {
   MANAGED_OUTGOING_ORIGINALS_SUBDIR,
   readManagedImageRecord,
 } from "./managed-image-record-store.js";
+import { resolveSharedGatewaySessionGeneration } from "./server/ws-shared-generation.js";
 
-const authorizeGatewayHttpRequestOrReplyMock = vi.fn();
+const checkGatewayHttpRequestAuthMock = vi.fn();
 const resolveOpenAiCompatibleHttpOperatorScopesMock = vi.fn();
 const resolveOpenAiCompatibleHttpSenderIsOwnerMock = vi.fn();
+const getBearerTokenMock = vi.fn((req: http.IncomingMessage): string | undefined => {
+  const raw = req.headers.authorization;
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  if (typeof value !== "string" || !value.toLowerCase().startsWith("bearer ")) {
+    return undefined;
+  }
+  return value.slice(7).trim() || undefined;
+});
 const loadSessionEntryMock = vi.fn();
 const readSessionMessagesMock = vi.fn();
 const resolveSessionHistoryTranscriptPathMock = vi.fn();
@@ -34,7 +49,8 @@ vi.mock("../config/config.js", () => ({
 }));
 
 vi.mock("./http-utils.js", () => ({
-  authorizeGatewayHttpRequestOrReply: authorizeGatewayHttpRequestOrReplyMock,
+  checkGatewayHttpRequestAuth: checkGatewayHttpRequestAuthMock,
+  getBearerToken: getBearerTokenMock,
   resolveOpenAiCompatibleHttpOperatorScopes: resolveOpenAiCompatibleHttpOperatorScopesMock,
   resolveOpenAiCompatibleHttpSenderIsOwner: resolveOpenAiCompatibleHttpSenderIsOwnerMock,
 }));
@@ -163,19 +179,20 @@ async function requestManagedImage(params: {
   scopes?: string[];
   denyAuth?: boolean;
   authResponse?: Record<string, unknown>;
+  auth?: Record<string, unknown>;
   headers?: Record<string, string>;
   transcriptMessages?: Record<string, unknown>[];
   sessionEntry?: { sessionId: string; sessionFile?: string };
   resolvedTranscriptPath?: string | null;
   onReadTranscriptMessages?: () => Promise<void> | void;
 }) {
-  authorizeGatewayHttpRequestOrReplyMock.mockImplementation(async ({ res }) => {
+  // `denyAuth` fails the shared-secret check; the handler then either rejects
+  // (no bearer token) or attempts the paired device-read-token fallback.
+  checkGatewayHttpRequestAuthMock.mockImplementation(async () => {
     if (params.denyAuth) {
-      res.statusCode = 401;
-      res.end();
-      return null;
+      return { ok: false, authResult: { ok: false, reason: "token_mismatch" } };
     }
-    return { ok: true, ...params.authResponse };
+    return { ok: true, requestAuth: { ...params.authResponse } };
   });
   resolveOpenAiCompatibleHttpOperatorScopesMock.mockReturnValue(params.scopes ?? ["operator.read"]);
   resolveOpenAiCompatibleHttpSenderIsOwnerMock.mockImplementation((_req, requestAuth) => {
@@ -213,7 +230,7 @@ async function requestManagedImage(params: {
     );
   });
 
-  const auth = { mode: "test" } as never;
+  const auth = (params.auth ?? { mode: "test" }) as never;
   const server = http.createServer((req, res) => {
     void (async () => {
       const handled = await handleManagedOutgoingImageHttpRequest(req, res, {
@@ -268,6 +285,45 @@ async function requestManagedImage(params: {
       server.close((error) => (error ? reject(error) : resolve()));
     });
   }
+}
+
+// Pair an operator.read device under an isolated OPENCLAW_HOME so the real
+// device-read-token fallback resolves a genuine paired token, matching the
+// credential a control-ui webchat tab holds.
+async function withPairedOperatorDevice(
+  options: { issuerGeneration?: string; browserMetadata?: boolean },
+  fn: (token: string) => Promise<void>,
+) {
+  const home = tempDirs.make("managed-image-device-home-");
+  await withEnvAsync({ OPENCLAW_HOME: home }, async () => {
+    const deviceId = `managed-image-device-${randomUUID()}`;
+    const requested = await requestDevicePairing({
+      deviceId,
+      publicKey: "test-public-key",
+      role: "operator",
+      scopes: ["operator.read"],
+      ...(options.browserMetadata
+        ? { clientId: "openclaw-control-ui", clientMode: "webchat" }
+        : {}),
+    });
+    const approved = await approveDevicePairing(requested.request.requestId, {
+      callerScopes: ["operator.read"],
+    });
+    expect(approved?.status).toBe("approved");
+    let token =
+      approved?.status === "approved" ? approved.device.tokens?.operator?.token : undefined;
+    if (options.issuerGeneration) {
+      const issued = await ensureDeviceToken({
+        deviceId,
+        role: "operator",
+        scopes: ["operator.read"],
+        issuer: { kind: "shared-gateway-auth", generation: options.issuerGeneration },
+      });
+      token = issued?.token;
+    }
+    expect(typeof token).toBe("string");
+    await fn(token ?? "");
+  });
 }
 
 describe("resolveManagedImageAttachmentLimits", () => {
@@ -406,7 +462,7 @@ describe("handleManagedOutgoingImageHttpRequest", () => {
     });
 
     expect(result.statusCode).toBe(401);
-    expect(result.body.byteLength).toBe(0);
+    expect(result.body.toString("utf-8")).not.toContain("original-image");
   });
 
   it("rejects non-owner trusted-proxy requests with self-declared session ownership", async () => {
@@ -422,17 +478,78 @@ describe("handleManagedOutgoingImageHttpRequest", () => {
     expect(result.statusCode).toBe(403);
   });
 
-  it("rejects device-token access with self-declared session ownership", async () => {
+  it("serves images to a paired control-ui operator read token", async () => {
     const { attachmentId, sessionKey } = await createFixture(stateDir);
+    const auth = { mode: "token", token: `shared-secret-${randomUUID()}` };
+    const generation = resolveSharedGatewaySessionGeneration(auth as never);
 
-    const { result } = await requestManagedImage({
-      stateDir,
-      pathName: `/api/chat/media/outgoing/${encodeURIComponent(sessionKey)}/${attachmentId}/full`,
-      authResponse: { authMethod: "device-token" },
-      headers: { "x-openclaw-requester-session-key": sessionKey },
+    await withPairedOperatorDevice({ issuerGeneration: generation }, async (token) => {
+      const { result } = await requestManagedImage({
+        stateDir,
+        pathName: `/api/chat/media/outgoing/${encodeURIComponent(sessionKey)}/${attachmentId}/full`,
+        auth,
+        denyAuth: true,
+        headers: { authorization: `Bearer ${token}` },
+      });
+
+      expect(result.statusCode).toBe(200);
+      expect(result.body.toString("utf-8")).toBe("original-image");
     });
+  });
 
-    expect(result.statusCode).toBe(403);
+  it("rejects a device read token issued for a stale gateway generation", async () => {
+    const { attachmentId, sessionKey } = await createFixture(stateDir);
+    const auth = { mode: "token", token: `shared-secret-${randomUUID()}` };
+
+    await withPairedOperatorDevice({ issuerGeneration: "stale-generation" }, async (token) => {
+      const { result } = await requestManagedImage({
+        stateDir,
+        pathName: `/api/chat/media/outgoing/${encodeURIComponent(sessionKey)}/${attachmentId}/full`,
+        auth,
+        denyAuth: true,
+        headers: { authorization: `Bearer ${token}` },
+      });
+
+      expect(result.statusCode).toBe(401);
+      expect(result.body.toString("utf-8")).not.toContain("original-image");
+    });
+  });
+
+  it("rejects a legacy issuer-less browser device token", async () => {
+    const { attachmentId, sessionKey } = await createFixture(stateDir);
+    const auth = { mode: "token", token: `shared-secret-${randomUUID()}` };
+
+    await withPairedOperatorDevice({ browserMetadata: true }, async (token) => {
+      const { result } = await requestManagedImage({
+        stateDir,
+        pathName: `/api/chat/media/outgoing/${encodeURIComponent(sessionKey)}/${attachmentId}/full`,
+        auth,
+        denyAuth: true,
+        headers: { authorization: `Bearer ${token}` },
+      });
+
+      expect(result.statusCode).toBe(401);
+      expect(result.body.toString("utf-8")).not.toContain("original-image");
+    });
+  });
+
+  it("rejects an unpaired bearer token when the shared secret fails", async () => {
+    const { attachmentId, sessionKey } = await createFixture(stateDir);
+    const auth = { mode: "token", token: `shared-secret-${randomUUID()}` };
+
+    // Pair a real device but present a bearer token that matches no device.
+    await withPairedOperatorDevice({}, async () => {
+      const { result } = await requestManagedImage({
+        stateDir,
+        pathName: `/api/chat/media/outgoing/${encodeURIComponent(sessionKey)}/${attachmentId}/full`,
+        auth,
+        denyAuth: true,
+        headers: { authorization: `Bearer not-a-paired-token` },
+      });
+
+      expect(result.statusCode).toBe(401);
+      expect(result.body.toString("utf-8")).not.toContain("original-image");
+    });
   });
 
   it("serves owner trusted-proxy requests with admin scope", async () => {
@@ -468,7 +585,7 @@ describe("handleManagedOutgoingImageHttpRequest", () => {
     const { result } = await requestManagedImage({
       stateDir,
       pathName: `/api/chat/media/outgoing/%E0%A4%A/${attachmentId}/full`,
-      authResponse: { authMethod: "device-token" },
+      authResponse: { authMethod: "token" },
     });
 
     expect(result.statusCode).toBe(404);

--- a/src/gateway/managed-image-attachments.ts
+++ b/src/gateway/managed-image-attachments.ts
@@ -19,9 +19,17 @@ import {
 import { getMediaDir, MEDIA_MAX_BYTES, saveMediaBuffer, saveMediaSource } from "../media/store.js";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
-import { sendJson, sendMethodNotAllowed, sendMissingScopeForbidden } from "./http-common.js";
+import { authorizeControlUiDeviceReadTokenRequest } from "./control-ui-device-read-token.js";
 import {
-  authorizeGatewayHttpRequestOrReply,
+  sendGatewayAuthFailure,
+  sendJson,
+  sendMethodNotAllowed,
+  sendMissingScopeForbidden,
+} from "./http-common.js";
+import {
+  type AuthorizedGatewayHttpRequest,
+  checkGatewayHttpRequestAuth,
+  getBearerToken,
   resolveOpenAiCompatibleHttpOperatorScopes,
   resolveOpenAiCompatibleHttpSenderIsOwner,
 } from "./http-utils.js";
@@ -36,6 +44,8 @@ import {
   type ManagedImageRecord,
 } from "./managed-image-record-store.js";
 import { authorizeOperatorScopesForMethod } from "./method-scopes.js";
+import { resolveRequestClientIp } from "./net.js";
+import { resolveSharedGatewaySessionGeneration } from "./server/ws-shared-generation.js";
 import { readSessionMessagesWithSourceAsync } from "./session-transcript-readers.js";
 import { loadSessionEntry, resolveSessionHistoryTranscriptPathAsync } from "./session-utils.js";
 
@@ -1024,6 +1034,69 @@ function safeAttachmentFilename(value: string | null) {
   return base || fallback;
 }
 
+type ManagedOutgoingImageRequestAuth =
+  | { kind: "shared-secret"; requestAuth: AuthorizedGatewayHttpRequest }
+  | { kind: "device-read" };
+
+// The managed outgoing-image route is a Control UI read surface: webchat tabs
+// authenticate by device pairing, so accept the same paired operator.read
+// device token control-ui.ts honors before rejecting a failed shared-secret
+// attempt. On failure the response is already sent and null is returned.
+async function authorizeManagedOutgoingImageHttpRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  opts: {
+    auth: ResolvedGatewayAuth;
+    trustedProxies?: string[];
+    allowRealIpFallback?: boolean;
+    rateLimiter?: AuthRateLimiter;
+  },
+): Promise<ManagedOutgoingImageRequestAuth | null> {
+  const authCheck = await checkGatewayHttpRequestAuth({
+    req,
+    auth: opts.auth,
+    trustedProxies: opts.trustedProxies,
+    allowRealIpFallback: opts.allowRealIpFallback,
+    rateLimiter: opts.rateLimiter,
+  });
+  if (authCheck.ok) {
+    return { kind: "shared-secret", requestAuth: authCheck.requestAuth };
+  }
+
+  const token = getBearerToken(req);
+  if (!token || opts.auth.mode === "trusted-proxy" || opts.auth.mode === "none") {
+    sendGatewayAuthFailure(res, authCheck.authResult);
+    return null;
+  }
+
+  const clientIp =
+    resolveRequestClientIp(req, opts.trustedProxies, opts.allowRealIpFallback === true) ??
+    req.socket?.remoteAddress;
+  const deviceAuth = await authorizeControlUiDeviceReadTokenRequest({
+    token,
+    requiredSharedGatewaySessionGeneration: resolveSharedGatewaySessionGeneration(
+      opts.auth,
+      opts.trustedProxies,
+    ),
+    rateLimiter: opts.rateLimiter,
+    clientIp,
+  });
+  if (deviceAuth.ok) {
+    return { kind: "device-read" };
+  }
+  if (deviceAuth.rateLimited) {
+    sendGatewayAuthFailure(res, {
+      ok: false,
+      reason: "rate_limited",
+      rateLimited: true,
+      retryAfterMs: deviceAuth.retryAfterMs,
+    });
+    return null;
+  }
+  sendGatewayAuthFailure(res, authCheck.authResult);
+  return null;
+}
+
 export async function handleManagedOutgoingImageHttpRequest(
   req: IncomingMessage,
   res: ServerResponse,
@@ -1046,23 +1119,22 @@ export async function handleManagedOutgoingImageHttpRequest(
     return true;
   }
 
-  const requestAuth = await authorizeGatewayHttpRequestOrReply({
-    req,
-    res,
-    auth: opts.auth,
-    trustedProxies: opts.trustedProxies,
-    allowRealIpFallback: opts.allowRealIpFallback,
-    rateLimiter: opts.rateLimiter,
-  });
+  const requestAuth = await authorizeManagedOutgoingImageHttpRequest(req, res, opts);
   if (!requestAuth) {
     return true;
   }
 
-  const requestedScopes = resolveOpenAiCompatibleHttpOperatorScopes(req, requestAuth);
-  const scopeAuth = authorizeOperatorScopesForMethod("chat.history", requestedScopes);
-  if (!scopeAuth.allowed) {
-    sendMissingScopeForbidden(res, scopeAuth.missingScope);
-    return true;
+  // Shared-secret callers self-declare operator scopes, so keep the chat.history
+  // scope gate for them. A paired device read token is already an authenticated
+  // operator.read credential (verified above), matching how control-ui.ts treats
+  // device reads, so it needs no additional operator-scope assertion.
+  if (requestAuth.kind === "shared-secret") {
+    const requestedScopes = resolveOpenAiCompatibleHttpOperatorScopes(req, requestAuth.requestAuth);
+    const scopeAuth = authorizeOperatorScopesForMethod("chat.history", requestedScopes);
+    if (!scopeAuth.allowed) {
+      sendMissingScopeForbidden(res, scopeAuth.missingScope);
+      return true;
+    }
   }
 
   const encodedSessionKey = match[1];
@@ -1086,9 +1158,14 @@ export async function handleManagedOutgoingImageHttpRequest(
     sendStatus(res, 404, "not found");
     return true;
   }
-  // Requester-session headers are client-declared, so media bytes require
-  // authenticated owner/admin context rather than trusting a URL-scoped header.
-  if (!resolveOpenAiCompatibleHttpSenderIsOwner(req, requestAuth)) {
+  // Requester-session headers are client-declared, so shared-secret media bytes
+  // require authenticated owner/admin context rather than trusting a URL-scoped
+  // header. A paired device read token is the control-ui read credential itself,
+  // so it satisfies the read the same way the sibling control-ui read path does.
+  if (
+    requestAuth.kind === "shared-secret" &&
+    !resolveOpenAiCompatibleHttpSenderIsOwner(req, requestAuth.requestAuth)
+  ) {
     sendJson(res, 403, {
       ok: false,
       error: {

--- a/ui/src/api/gateway.ts
+++ b/ui/src/api/gateway.ts
@@ -172,7 +172,7 @@ export type GatewayBrowserClientOptions = {
   platform?: string;
   mode?: GatewayClientMode;
   instanceId?: string;
-  onHello?: (hello: GatewayHelloOk) => void;
+  onHello?: (hello: GatewayHelloOk, resolvedDeviceToken: string | null) => void;
   onEvent?: (evt: GatewayEventFrame) => void;
   onClose?: (info: {
     code: number;
@@ -300,6 +300,10 @@ export class GatewayBrowserClient {
   inboundActivitySeq = 0;
   private pendingDeviceTokenRetry = false;
   private deviceTokenRetryBudgetUsed = false;
+  // The device token that actually authenticated the live socket. Captured at
+  // connect-hello (before onHello) so it can be surfaced as an HTTP Bearer
+  // candidate even when the server omits a rotated token on reconnect.
+  private resolvedDeviceToken: string | null = null;
   private readonly recoveryScopeTracker = new GatewayRecoveryScopeTracker();
 
   constructor(private opts: GatewayBrowserClientOptions) {
@@ -317,7 +321,7 @@ export class GatewayBrowserClient {
       buildConnectPlan: ({ nonce, generation }) => this.buildConnectPlan(nonce, generation),
       buildConnectParams: (plan) => plan.params,
       onConnectHello: (hello, context) => this.handleConnectHello(hello, context.plan),
-      onHello: (hello) => this.opts.onHello?.(hello),
+      onHello: (hello) => this.opts.onHello?.(hello, this.resolvedDeviceToken),
       onConnectFailure: (error, context) => {
         this.client.recordTiming("failed", context.generation, context.plan, {
           errorCode: error.code,
@@ -489,6 +493,10 @@ export class GatewayBrowserClient {
     this.pendingDeviceTokenRetry = false;
     this.deviceTokenRetryBudgetUsed = false;
     this.opts.bootstrapToken = undefined;
+    // Prefer a freshly rotated token; otherwise fall back to the stored token
+    // that authenticated this socket. Either way HTTP fetches get a live Bearer.
+    this.resolvedDeviceToken =
+      hello?.auth?.deviceToken ?? plan.selectedAuth.resolvedDeviceToken ?? null;
     if (hello?.auth?.deviceToken && plan.deviceIdentity) {
       storeDeviceAuthToken({
         deviceId: plan.deviceIdentity.deviceId,

--- a/ui/src/app/bootstrap.ts
+++ b/ui/src/app/bootstrap.ts
@@ -347,6 +347,7 @@ export function bootstrapApplication(): ApplicationRuntime {
     void config.refresh({
       auth: {
         hello: snapshot.hello,
+        deviceToken: snapshot.deviceToken,
         settings: { token: gateway.connection.token },
         password: gateway.connection.password,
       },

--- a/ui/src/app/config.test.ts
+++ b/ui/src/app/config.test.ts
@@ -50,4 +50,46 @@ describe("createApplicationConfigCapability", () => {
     await expect(firstRefresh).resolves.toBeNull();
     expect(config.current.serverVersion).toBe("new");
   });
+
+  it("sends the device token as a Bearer credential when it is the only candidate", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => bootstrapResponse("v1"));
+    vi.stubGlobal("fetch", fetchMock);
+    const config = createApplicationConfigCapability({ basePath: "" });
+
+    await config.refresh({ auth: { deviceToken: "device-token" } });
+
+    const init = fetchMock.mock.calls[0]?.[1];
+    expect(new Headers(init?.headers).get("Authorization")).toBe("Bearer device-token");
+  });
+
+  it("does not skip the fetch when only a device token authenticates the request", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => bootstrapResponse("v1"));
+    vi.stubGlobal("fetch", fetchMock);
+    const config = createApplicationConfigCapability({ basePath: "" });
+
+    const result = await config.refresh({
+      auth: { deviceToken: "device-token" },
+      skipWithoutAuthCandidate: true,
+    });
+
+    expect(result).not.toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps localMediaPreviewRootsLoaded false on a failed fetch and true after success", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(null, { status: 401 }))
+      .mockResolvedValueOnce(bootstrapResponse("v1"));
+    vi.stubGlobal("fetch", fetchMock);
+    const config = createApplicationConfigCapability({ basePath: "" });
+
+    // 401 falls through to the default config; roots were never loaded.
+    expect(config.current.localMediaPreviewRootsLoaded).toBe(false);
+    await config.refresh({ auth: { deviceToken: "device-token" } });
+    expect(config.current.localMediaPreviewRootsLoaded).toBe(false);
+
+    await config.refresh({ auth: { deviceToken: "device-token" } });
+    expect(config.current.localMediaPreviewRootsLoaded).toBe(true);
+  });
 });

--- a/ui/src/app/config.ts
+++ b/ui/src/app/config.ts
@@ -12,6 +12,7 @@ import { resolveControlUiAuthCandidates } from "./control-ui-auth.ts";
 
 type ApplicationConfigAuthSource = {
   hello?: { auth?: { deviceToken?: string | null } | null } | null;
+  deviceToken?: string | null;
   settings?: { token?: string | null } | null;
   password?: string | null;
 };
@@ -41,6 +42,10 @@ type ApplicationConfig = {
   serverVersion: string | null;
   devGitBranch: string | null;
   localMediaPreviewRoots: string[];
+  // Distinguishes "roots not fetched yet / auth failed" from "fetched, empty".
+  // Only a successful config fetch flips this true, so the chat attachment UI
+  // can avoid reporting local files as out-of-roots when roots are unknown.
+  localMediaPreviewRootsLoaded: boolean;
   embedSandboxMode: ControlUiEmbedSandboxMode;
   allowExternalEmbedUrls: boolean;
   chatMessageMaxWidth: string | null;
@@ -78,6 +83,7 @@ const DEFAULT_APPLICATION_CONFIG: ApplicationConfig = {
   serverVersion: null,
   devGitBranch: null,
   localMediaPreviewRoots: [],
+  localMediaPreviewRootsLoaded: false,
   embedSandboxMode: "strict",
   allowExternalEmbedUrls: false,
   chatMessageMaxWidth: null,
@@ -150,6 +156,7 @@ function normalizeApplicationConfig(parsed: ControlUiBootstrapConfig): Applicati
     localMediaPreviewRoots: Array.isArray(parsed.localMediaPreviewRoots)
       ? parsed.localMediaPreviewRoots.filter((value): value is string => typeof value === "string")
       : [],
+    localMediaPreviewRootsLoaded: true,
     embedSandboxMode:
       parsed.embedSandbox === "trusted"
         ? "trusted"

--- a/ui/src/app/control-ui-auth.test.ts
+++ b/ui/src/app/control-ui-auth.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveControlUiAuthCandidates,
+  resolveControlUiAuthHeader,
+  resolveControlUiAuthToken,
+} from "./control-ui-auth.ts";
+
+describe("resolveControlUiAuthToken", () => {
+  it("prefers the rotated hello token over the WS device token", () => {
+    expect(
+      resolveControlUiAuthToken({
+        hello: { auth: { deviceToken: "hello-token" } },
+        deviceToken: "ws-device-token",
+        settings: { token: "settings-token" },
+        password: "pw",
+      }),
+    ).toBe("hello-token");
+  });
+
+  it("falls back to the WS device token when hello omits it (reconnect case)", () => {
+    expect(
+      resolveControlUiAuthToken({
+        hello: { auth: { deviceToken: null } },
+        deviceToken: "ws-device-token",
+        settings: { token: "settings-token" },
+        password: "pw",
+      }),
+    ).toBe("ws-device-token");
+  });
+
+  it("prefers the WS device token over the settings token", () => {
+    expect(
+      resolveControlUiAuthToken({
+        deviceToken: "ws-device-token",
+        settings: { token: "settings-token" },
+      }),
+    ).toBe("ws-device-token");
+  });
+
+  it("falls back to settings then password when no device token is present", () => {
+    expect(resolveControlUiAuthToken({ settings: { token: "settings-token" } })).toBe(
+      "settings-token",
+    );
+    expect(resolveControlUiAuthToken({ password: "pw" })).toBe("pw");
+  });
+
+  it("returns null when every candidate is absent or blank", () => {
+    expect(resolveControlUiAuthToken({})).toBeNull();
+    expect(
+      resolveControlUiAuthToken({ deviceToken: "   ", settings: { token: "" }, password: null }),
+    ).toBeNull();
+  });
+
+  it("rejects tokens that would smuggle CRLF into the header", () => {
+    expect(resolveControlUiAuthToken({ deviceToken: "bad\r\ntoken" })).toBeNull();
+  });
+});
+
+describe("resolveControlUiAuthHeader", () => {
+  it("wraps the resolved token as a Bearer header", () => {
+    expect(resolveControlUiAuthHeader({ deviceToken: "ws-device-token" })).toBe(
+      "Bearer ws-device-token",
+    );
+  });
+
+  it("returns null when no candidate resolves", () => {
+    expect(resolveControlUiAuthHeader({})).toBeNull();
+  });
+});
+
+describe("resolveControlUiAuthCandidates", () => {
+  it("orders candidates hello > deviceToken > settings > password", () => {
+    expect(
+      resolveControlUiAuthCandidates({
+        hello: { auth: { deviceToken: "hello-token" } },
+        deviceToken: "ws-device-token",
+        settings: { token: "settings-token" },
+        password: "pw",
+      }),
+    ).toEqual(["hello-token", "ws-device-token", "settings-token", "pw"]);
+  });
+
+  it("dedupes candidates that share a value", () => {
+    expect(
+      resolveControlUiAuthCandidates({
+        hello: { auth: { deviceToken: "same" } },
+        deviceToken: "same",
+        settings: { token: "same" },
+      }),
+    ).toEqual(["same"]);
+  });
+
+  it("drops blank and CRLF-tainted candidates while sanitizing", () => {
+    expect(
+      resolveControlUiAuthCandidates({
+        hello: { auth: { deviceToken: "  " } },
+        deviceToken: "bad\ntoken",
+        settings: { token: "settings-token" },
+        password: "",
+      }),
+    ).toEqual(["settings-token"]);
+  });
+});

--- a/ui/src/app/control-ui-auth.ts
+++ b/ui/src/app/control-ui-auth.ts
@@ -3,6 +3,10 @@ import { normalizeOptionalString, uniqueStrings } from "../lib/string-coerce.ts"
 
 type ControlUiAuthSource = {
   hello?: { auth?: { deviceToken?: string | null } | null } | null;
+  // WS-resolved device token surfaced from the live connection. The server
+  // omits `hello.auth.deviceToken` on already-authorized reconnects, so this
+  // is the only Bearer candidate that survives a reconnect without rotation.
+  deviceToken?: string | null;
   settings?: { token?: string | null } | null;
   password?: string | null;
 };
@@ -24,6 +28,7 @@ function sanitizeHeaderToken(value: string | null): string | null {
 export function resolveControlUiAuthToken(source: ControlUiAuthSource): string | null {
   return (
     sanitizeHeaderToken(normalizeOptionalString(source.hello?.auth?.deviceToken) ?? null) ??
+    sanitizeHeaderToken(normalizeOptionalString(source.deviceToken) ?? null) ??
     sanitizeHeaderToken(normalizeOptionalString(source.settings?.token) ?? null) ??
     sanitizeHeaderToken(normalizeOptionalString(source.password) ?? null) ??
     null
@@ -43,6 +48,7 @@ export function resolveControlUiAuthCandidates(source: ControlUiAuthSource): str
   return uniqueStrings(
     [
       normalizeOptionalString(source.hello?.auth?.deviceToken),
+      normalizeOptionalString(source.deviceToken),
       normalizeOptionalString(source.settings?.token),
       normalizeOptionalString(source.password),
     ].flatMap((raw) => sanitizeHeaderToken(raw ?? null) ?? []),

--- a/ui/src/app/gateway-store.ts
+++ b/ui/src/app/gateway-store.ts
@@ -56,6 +56,7 @@ export function createApplicationGateway(
     connected: false,
     reconnecting: false,
     hello: null,
+    deviceToken: null,
     assistantAgentId: "main",
     sessionKey: settings.sessionKey,
     lastError: null,
@@ -174,7 +175,7 @@ export function createApplicationGateway(
       clientVersion: CONTROL_UI_BUILD_INFO.version ?? "dev",
       mode: "webchat",
       instanceId: generateUUID(),
-      onHello: (hello: GatewayHelloOk) => {
+      onHello: (hello: GatewayHelloOk, resolvedDeviceToken: string | null) => {
         if (client !== nextClient) {
           return;
         }
@@ -201,6 +202,7 @@ export function createApplicationGateway(
           connected: true,
           reconnecting: false,
           hello,
+          deviceToken: resolvedDeviceToken,
           assistantAgentId: sessionDefaults?.defaultAgentId ?? "main",
           sessionKey,
           lastError: null,
@@ -227,6 +229,7 @@ export function createApplicationGateway(
           connected: false,
           reconnecting: everConnected && willRetry,
           hello: null,
+          deviceToken: null,
           selfUser: null,
           lastError: error?.message ?? `disconnected (${code}): ${reason || "no reason"}`,
           lastErrorCode: error?.code ?? null,
@@ -255,6 +258,7 @@ export function createApplicationGateway(
       // recovery, banner "retry now") when a session already existed.
       reconnecting: everConnected,
       hello: null,
+      deviceToken: null,
       selfUser: null,
       sessionKey: nextSessionKey,
       lastError: null,
@@ -298,6 +302,7 @@ export function createApplicationGateway(
         connected: false,
         reconnecting: false,
         hello: null,
+        deviceToken: null,
         selfUser: null,
         lastError: null,
         lastErrorCode: null,

--- a/ui/src/app/gateway.ts
+++ b/ui/src/app/gateway.ts
@@ -12,6 +12,11 @@ export type ApplicationGatewaySnapshot = {
    */
   reconnecting: boolean;
   hello: GatewayHelloOk | null;
+  /**
+   * Device token that authenticated the live socket. Surfaced as an HTTP Bearer
+   * candidate because the server omits `hello.auth.deviceToken` on reconnects.
+   */
+  deviceToken?: string | null;
   assistantAgentId: string | null;
   sessionKey: string;
   lastError: string | null;

--- a/ui/src/pages/chat/chat-pane-state.ts
+++ b/ui/src/pages/chat/chat-pane-state.ts
@@ -22,6 +22,7 @@ export function applySelectedSessionProjection(
 
 export function resolveAssistantAttachmentAuthToken(state: {
   hello?: { auth?: { deviceToken?: string | null } | null } | null;
+  deviceToken?: string | null;
   password?: string | null;
   settings?: { token?: string | null } | null;
 }) {

--- a/ui/src/pages/chat/chat-pane.ts
+++ b/ui/src/pages/chat/chat-pane.ts
@@ -2354,6 +2354,7 @@ class ChatPane extends OpenClawLightDomElement {
       isGatewayMethodAdvertised(this.context.gateway.snapshot, "terminal.open") === true;
     const rootsChanged =
       state.localMediaPreviewRoots.length !== config.localMediaPreviewRoots.length ||
+      state.localMediaPreviewRootsLoaded !== config.localMediaPreviewRootsLoaded ||
       state.localMediaPreviewRoots.some(
         (value, index) => value !== config.localMediaPreviewRoots[index],
       );
@@ -2367,6 +2368,7 @@ class ChatPane extends OpenClawLightDomElement {
       return;
     }
     state.localMediaPreviewRoots = config.localMediaPreviewRoots;
+    state.localMediaPreviewRootsLoaded = config.localMediaPreviewRootsLoaded;
     state.embedSandboxMode = config.embedSandboxMode;
     state.allowExternalEmbedUrls = config.allowExternalEmbedUrls;
     state.chatMessageMaxWidth = config.chatMessageMaxWidth;
@@ -2397,6 +2399,7 @@ class ChatPane extends OpenClawLightDomElement {
     state.connected = snapshot.connected;
     state.connectionEpoch = this.connectionGeneration;
     state.hello = snapshot.hello;
+    state.deviceToken = snapshot.deviceToken;
     if (sourceChanged && state.sidebarContent?.kind === "session-discussion") {
       // A reconnect may point at a different gateway/provider; an open panel
       // would keep rendering the previous provider's URL. Close it — the
@@ -3383,6 +3386,7 @@ class ChatPane extends OpenClawLightDomElement {
       userAvatar: state.userAvatar,
       attributedIdentity: Boolean(this.context.gateway.snapshot.selfUser),
       localMediaPreviewRoots: state.localMediaPreviewRoots,
+      localMediaPreviewRootsLoaded: state.localMediaPreviewRootsLoaded,
       embedSandboxMode: state.embedSandboxMode,
       allowExternalEmbedUrls: state.allowExternalEmbedUrls,
       chatMessageMaxWidth: state.chatMessageMaxWidth,

--- a/ui/src/pages/chat/chat-send.ts
+++ b/ui/src/pages/chat/chat-send.ts
@@ -133,6 +133,8 @@ export type ChatHost = ChatInputHistoryState &
     lastError?: string | null;
     chatError?: string | null;
     hello: GatewayHelloOk | null;
+    /** WS-resolved device token, surfaced for HTTP Bearer on assistant media. */
+    deviceToken?: string | null;
     renderLifecycle?: RenderLifecycle;
     requestUpdate?: () => void;
     refreshSessionsAfterChat: Map<string, SessionRefreshTarget>;

--- a/ui/src/pages/chat/chat-state.ts
+++ b/ui/src/pages/chat/chat-state.ts
@@ -194,6 +194,7 @@ export type ChatPageHost = ChatHost &
     userName: string | null;
     userAvatar: string | null;
     localMediaPreviewRoots: string[];
+    localMediaPreviewRootsLoaded: boolean;
     embedSandboxMode: EmbedSandboxMode;
     allowExternalEmbedUrls: boolean;
     chatMessageMaxWidth: string | null;
@@ -1234,6 +1235,7 @@ export function createPageState(
     userName: identity.name,
     userAvatar: identity.avatar,
     localMediaPreviewRoots: appConfig.localMediaPreviewRoots,
+    localMediaPreviewRootsLoaded: appConfig.localMediaPreviewRootsLoaded,
     embedSandboxMode: appConfig.embedSandboxMode,
     allowExternalEmbedUrls: appConfig.allowExternalEmbedUrls,
     chatMessageMaxWidth: appConfig.chatMessageMaxWidth,
@@ -1241,6 +1243,7 @@ export function createPageState(
     connected: false,
     connectionEpoch: 0,
     hello: null,
+    deviceToken: null,
     terminalAvailable: false,
     browserPanelAvailable: false,
     assistantAgentId: context.agentSelection.state.selectedId,

--- a/ui/src/pages/chat/chat-view.ts
+++ b/ui/src/pages/chat/chat-view.ts
@@ -158,6 +158,7 @@ export type ChatProps = {
   userAvatar?: string | null;
   attributedIdentity?: boolean;
   localMediaPreviewRoots?: string[];
+  localMediaPreviewRootsLoaded?: boolean;
   assistantAttachmentAuthToken?: string | null;
   autoExpandToolCalls?: boolean;
   attachments?: ChatAttachment[];
@@ -355,6 +356,7 @@ export function renderChat(props: ChatProps) {
       basePath: props.basePath,
       fullMessageAgentId: props.fullMessageAgentId,
       localMediaPreviewRoots: props.localMediaPreviewRoots,
+      localMediaPreviewRootsLoaded: props.localMediaPreviewRootsLoaded,
       assistantAttachmentAuthToken: props.assistantAttachmentAuthToken,
       canvasPluginSurfaceUrl: props.canvasPluginSurfaceUrl,
       embedSandboxMode: props.embedSandboxMode,

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -2348,6 +2348,7 @@ describe("grouped chat rendering", () => {
           basePath: "/openclaw",
           assistantAttachmentAuthToken: "session-token",
           localMediaPreviewRoots: ["/tmp/openclaw"],
+          localMediaPreviewRootsLoaded: true,
           onRequestUpdate: renderMessage,
         },
       );
@@ -2400,6 +2401,7 @@ describe("grouped chat rendering", () => {
           showToolCalls: false,
           basePath: "/openclaw",
           localMediaPreviewRoots: ["/tmp/openclaw"],
+          localMediaPreviewRootsLoaded: true,
           onRequestUpdate: rerender,
         },
       );
@@ -2453,6 +2455,7 @@ describe("grouped chat rendering", () => {
           basePath: "/openclaw",
           assistantAttachmentAuthToken: "test-auth-token",
           localMediaPreviewRoots: ["/tmp/openclaw"],
+          localMediaPreviewRootsLoaded: true,
           onRequestUpdate: rerender,
         },
       );
@@ -2504,6 +2507,7 @@ describe("grouped chat rendering", () => {
           basePath: "/openclaw",
           assistantAttachmentAuthToken: token,
           localMediaPreviewRoots: ["/tmp/openclaw"],
+          localMediaPreviewRootsLoaded: true,
           onRequestUpdate: () => renderWithToken(token),
         },
       );
@@ -2547,6 +2551,7 @@ describe("grouped chat rendering", () => {
           showToolCalls: false,
           basePath: "/openclaw",
           localMediaPreviewRoots: ["/tmp/openclaw"],
+          localMediaPreviewRootsLoaded: true,
           onRequestUpdate: rerender,
         },
       );
@@ -2610,6 +2615,7 @@ describe("grouped chat rendering", () => {
         showToolCalls: false,
         basePath: "/openclaw",
         localMediaPreviewRoots: ["/tmp/openclaw"],
+        localMediaPreviewRootsLoaded: true,
       },
     );
 
@@ -2622,6 +2628,44 @@ describe("grouped chat rendering", () => {
       blocked?.querySelector(".chat-assistant-attachment-card__reason")?.textContent?.trim(),
     ).toBe("Outside allowed folders");
     expect(container.querySelector(".chat-text")?.textContent?.trim()).toBe("Blocked\nDone");
+  });
+
+  it("defers to server meta fetch (no outside-folders chip) when roots never loaded", async () => {
+    const source = "/Users/test/Documents/private.pdf";
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      expect(url).toContain("meta=1");
+      // A failed/401 meta fetch maps to the generic reason, never the
+      // misleading "Outside allowed folders" chip.
+      expect(new Headers(init?.headers).get("Authorization")).toBe("Bearer device-token");
+      return { ok: false, status: 401, json: async () => null };
+    });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+    const container = document.createElement("div");
+    renderAssistantMessage(
+      container,
+      {
+        id: "assistant-roots-unloaded-local-media",
+        role: "assistant",
+        content: `Blocked\nMEDIA:${source}\nDone`,
+        timestamp: Date.now(),
+      },
+      {
+        showToolCalls: false,
+        basePath: "/openclaw",
+        assistantAttachmentAuthToken: "device-token",
+        localMediaPreviewRoots: [],
+        localMediaPreviewRootsLoaded: false,
+      },
+    );
+    await flushAssistantAttachmentAvailabilityChecks();
+
+    const expectedMetaUrl = `/openclaw/__openclaw__/assistant-media?source=${encodeURIComponent(source)}&meta=1`;
+    const [, fetchInit] = requireFetchCallForUrl(fetchMock, expectedMetaUrl);
+    expectSameOriginGet(fetchInit);
+    const blocked = container.querySelector(".chat-assistant-attachment-card--blocked");
+    expect(
+      blocked?.querySelector(".chat-assistant-attachment-card__reason")?.textContent?.trim(),
+    ).not.toBe("Outside allowed folders");
   });
 
   it("renders transcript video URLs with encoded extensions", () => {
@@ -2664,6 +2708,7 @@ describe("grouped chat rendering", () => {
           basePath: "/openclaw",
           assistantAttachmentAuthToken: "test-auth-token",
           localMediaPreviewRoots: ["/tmp/openclaw"],
+          localMediaPreviewRootsLoaded: true,
           onRequestUpdate: rerender,
         });
       rerender();

--- a/ui/src/pages/chat/components/chat-message.ts
+++ b/ui/src/pages/chat/components/chat-message.ts
@@ -786,6 +786,7 @@ type RenderMessageGroupOptions = {
   userAvatar?: string | null;
   basePath?: string;
   localMediaPreviewRoots?: readonly string[];
+  localMediaPreviewRootsLoaded?: boolean;
   assistantAttachmentAuthToken?: string | null;
   canvasPluginSurfaceUrl?: string | null;
   embedSandboxMode?: EmbedSandboxMode;
@@ -826,6 +827,7 @@ function buildGroupedMessageRenderOptions(
     canvasPluginSurfaceUrl: opts.canvasPluginSurfaceUrl,
     basePath: opts.basePath,
     localMediaPreviewRoots: opts.localMediaPreviewRoots,
+    localMediaPreviewRootsLoaded: opts.localMediaPreviewRootsLoaded,
     assistantAttachmentAuthToken: opts.assistantAttachmentAuthToken,
     embedSandboxMode: opts.embedSandboxMode,
     allowExternalEmbedUrls: opts.allowExternalEmbedUrls,
@@ -1427,9 +1429,12 @@ function resolveRenderableMessageImages(
       return [];
     }
     const availability = canProxyLocalImage
-      ? resolveAssistantAttachmentAvailability(
+      ? // canProxyLocalImage already confirmed the source is within loaded,
+        // allowed roots, so the availability pre-check is known to pass here.
+        resolveAssistantAttachmentAvailability(
           img.url,
           opts?.localMediaPreviewRoots ?? [],
+          true,
           opts?.basePath,
           opts?.authToken,
           opts?.onRequestUpdate,
@@ -1847,6 +1852,7 @@ function scheduleAssistantAttachmentRefresh(
 function resolveAssistantAttachmentAvailability(
   source: string,
   localMediaPreviewRoots: readonly string[],
+  rootsLoaded: boolean,
   basePath: string | undefined,
   authToken: string | null | undefined,
   onRequestUpdate: (() => void) | undefined,
@@ -1854,7 +1860,11 @@ function resolveAssistantAttachmentAvailability(
   if (!isLocalAssistantAttachmentSource(source)) {
     return { status: "available" };
   }
-  if (!isLocalAttachmentPreviewAllowed(source, localMediaPreviewRoots)) {
+  // Only apply the client-side roots pre-check once roots are actually known.
+  // Before then (config never fetched, e.g. auth failure) the empty list is not
+  // evidence a file is out of bounds; defer to the server meta fetch, which
+  // returns an accurate reason instead of a misleading "outside folders" chip.
+  if (rootsLoaded && !isLocalAttachmentPreviewAllowed(source, localMediaPreviewRoots)) {
     return { status: "unavailable", reason: "Outside allowed folders", checkedAt: Date.now() };
   }
   const normalizedAuthToken = authToken?.trim() ?? "";
@@ -1983,6 +1993,7 @@ function renderAssistantAttachmentStatusCard(params: {
 function renderAssistantAttachments(
   attachments: AttachmentItem[],
   localMediaPreviewRoots: readonly string[],
+  rootsLoaded: boolean,
   basePath?: string,
   authToken?: string | null,
   onRequestUpdate?: () => void,
@@ -1997,6 +2008,7 @@ function renderAssistantAttachments(
         const availability = resolveAssistantAttachmentAvailability(
           attachment.url,
           localMediaPreviewRoots,
+          rootsLoaded,
           basePath,
           authToken,
           onRequestUpdate,
@@ -2326,6 +2338,7 @@ function renderGroupedMessage(
     canvasPluginSurfaceUrl?: string | null;
     basePath?: string;
     localMediaPreviewRoots?: readonly string[];
+    localMediaPreviewRootsLoaded?: boolean;
     assistantAttachmentAuthToken?: string | null;
     onAssistantAttachmentLoaded?: () => void;
     embedSandboxMode?: EmbedSandboxMode;
@@ -2550,6 +2563,7 @@ function renderGroupedMessage(
                       ${renderAssistantAttachments(
                         visibleAttachments,
                         opts.localMediaPreviewRoots ?? [],
+                        opts.localMediaPreviewRootsLoaded ?? false,
                         opts.basePath,
                         opts.assistantAttachmentAuthToken,
                         opts.onRequestUpdate,
@@ -2614,6 +2628,7 @@ function renderGroupedMessage(
             ${renderAssistantAttachments(
               visibleAttachments,
               opts.localMediaPreviewRoots ?? [],
+              opts.localMediaPreviewRootsLoaded ?? false,
               opts.basePath,
               opts.assistantAttachmentAuthToken,
               opts.onRequestUpdate,

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -136,6 +136,7 @@ type ChatThreadProps = {
   basePath?: string;
   fullMessageAgentId?: string;
   localMediaPreviewRoots?: string[];
+  localMediaPreviewRootsLoaded?: boolean;
   assistantAttachmentAuthToken?: string | null;
   canvasPluginSurfaceUrl?: string | null;
   embedSandboxMode?: EmbedSandboxMode;
@@ -1173,6 +1174,7 @@ function renderChatThreadContents(
       userAvatar: props.userAvatar ?? null,
       basePath: props.basePath,
       localMediaPreviewRoots: props.localMediaPreviewRoots ?? [],
+      localMediaPreviewRootsLoaded: props.localMediaPreviewRootsLoaded ?? false,
       assistantAttachmentAuthToken: props.assistantAttachmentAuthToken ?? null,
       canvasPluginSurfaceUrl: props.canvasPluginSurfaceUrl,
       embedSandboxMode: props.embedSandboxMode ?? "scripts",
@@ -1292,6 +1294,7 @@ function renderChatThreadContents(
     props.userAvatar,
     props.basePath,
     (props.localMediaPreviewRoots ?? []).join("\u0000"),
+    Boolean(props.localMediaPreviewRootsLoaded),
     props.assistantAttachmentAuthToken,
     props.canvasPluginSurfaceUrl,
     props.embedSandboxMode ?? "scripts",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Control UI users viewing a chat in a browser tab that authenticates by device pairing would see local assistant images fail to load, showing an "Unavailable — Outside allowed folders" chip, while the same conversation delivered the image fine over messaging channels like Telegram. Chat text worked, only attachments were broken, and the problem persisted across hard refreshes.

## Why This Change Was Made

A tab that reconnects authenticates its WebSocket with the stored device-pairing token, but the gateway omits `hello.auth.deviceToken` on already-authorized reconnects. The Control UI built its HTTP bearer only from the hello token, a typed settings token, or a password — so with none of those present, every control-ui HTTP fetch returned 401: the config bootstrap (which then fell back to an empty `localMediaPreviewRoots`, causing the misleading "outside folders" label) and the assistant-media byte fetches. Separately, the managed outgoing-image route only accepted the shared gateway secret and rejected the device token that paired tabs actually hold.

Two coordinated fixes: (1) the UI now surfaces the WebSocket-resolved device token and uses it as an HTTP bearer candidate for the config and media fetches, and only runs the client-side roots pre-check once roots are actually known — otherwise it defers to the server, which returns an accurate reason instead of the misleading chip; (2) the gateway's managed outgoing-image route accepts a paired `operator.read` device token as a fallback, with the same generation/scope semantics as the sibling config/assistant-media read path. The shared-secret path keeps its `chat.history` scope gate and owner check; integrity checks (attachment id, session key, transcript match) apply to both.

## User Impact

Control UI tabs authenticated by device pairing now render local assistant images (screenshots, generated media) in chat, matching what already worked over messaging channels. When media genuinely cannot be loaded, the reason shown is accurate instead of a misleading "outside allowed folders" message that actually indicated an auth failure.

## Evidence

- End-to-end, in a real browser against a device-token-only tab (the exact failing condition): a previously-"Unavailable" local screenshot now renders at its true 526×2000 dimensions via the authenticated `/__openclaw__/assistant-media` route. Direct HTTP checks confirmed the chain: device token → `200 image/jpeg`, no auth → `401`; config route device token → `200` with populated roots; managed outgoing-image route device token → auth passes (no longer `401`).
- Focused tests: new coverage for the device-token bearer candidate ordering, the config fallback / `localMediaPreviewRootsLoaded` flag, the honest attachment-unavailable reason when roots are unknown, and the gateway route accepting a valid paired device token while rejecting revoked / legacy / stale-generation tokens. UI suites (control-ui-auth, config, chat-message) and gateway suites (managed-image-attachments, control-ui.http) pass; core and UI typechecks clean.
