### PR TITLE
fix(memory): recover divergent dreaming journals

### DIFF
--- a/extensions/memory-core/doctor-contract-api.test.ts
+++ b/extensions/memory-core/doctor-contract-api.test.ts
@@ -1108,7 +1108,7 @@ describe("memory-core doctor dreaming migration", () => {
     await expect(fs.access(`${eventPath}.migrated`)).resolves.toBeUndefined();
   });
 
-  it("imports persistent legacy dreaming state and ignores transient locks", async () => {
+  it("archives divergent derived dreaming journals while keeping SQLite state authoritative", async () => {
     const dreamsDir = path.join(workspaceDir, "memory", ".dreams");
     const dailyPath = path.join(dreamsDir, "daily-ingestion.json");
     const sessionPath = path.join(dreamsDir, "session-ingestion.json");
@@ -1256,18 +1256,69 @@ describe("memory-core doctor dreaming migration", () => {
       expect.stringContaining("Retained acknowledged Memory Core phase signals"),
     ]);
 
-    const changedDaily = JSON.parse(await fs.readFile(dailyPath, "utf8")) as {
-      files: Record<string, { mtimeMs: number }>;
+    const changedSession = JSON.parse(await fs.readFile(sessionPath, "utf8")) as {
+      seenMessages: Record<string, string[]>;
     };
-    changedDaily.files["memory/2026-04-05.md"]!.mtimeMs = 999;
-    await fs.writeFile(dailyPath, JSON.stringify(changedDaily), "utf8");
+    changedSession.seenMessages["main/session.jsonl"]!.push("seen-c");
+    const changedSessionContents = JSON.stringify(changedSession);
+    await fs.writeFile(sessionPath, changedSessionContents, "utf8");
+
+    const changedRecall = JSON.parse(await fs.readFile(recallPath, "utf8")) as {
+      entries: Record<string, { recallCount: number }>;
+    };
+    changedRecall.entries["memory:memory/2026-04-05.md:1:1"]!.recallCount = 99;
+    const changedRecallContents = JSON.stringify(changedRecall);
+    await fs.writeFile(recallPath, changedRecallContents, "utf8");
+
+    const changedPhase = JSON.parse(await fs.readFile(phasePath, "utf8")) as {
+      entries: Record<string, { lightHits: number }>;
+    };
+    changedPhase.entries["memory:memory/2026-04-05.md:1:1"]!.lightHits = 99;
+    const changedPhaseContents = JSON.stringify(changedPhase);
+    await fs.writeFile(phasePath, changedPhaseContents, "utf8");
+
     const conflictResult = await migration.migrateLegacyState(migrationParams());
-    expect(conflictResult.changes).toEqual([]);
-    expect(conflictResult.warnings).toEqual([
-      expect.stringContaining("SQLite rows conflict with the legacy source"),
+    expect(conflictResult.changes).toEqual([
+      "Resolved Memory Core session ingestion legacy conflict by keeping canonical SQLite plugin state",
+      expect.stringContaining("Archived Memory Core session ingestion conflicting legacy source"),
+      "Resolved Memory Core short-term recall legacy conflict by keeping canonical SQLite plugin state",
+      expect.stringContaining("Archived Memory Core short-term recall conflicting legacy source"),
+      "Resolved Memory Core phase signals legacy conflict by keeping canonical SQLite plugin state",
+      expect.stringContaining("Archived Memory Core phase signals conflicting legacy source"),
     ]);
-    expect(conflictResult.notices).toHaveLength(3);
+    expect(conflictResult.warnings).toEqual([]);
+    expect(conflictResult.notices).toEqual([
+      expect.stringContaining("Retained acknowledged Memory Core daily ingestion"),
+    ]);
     await expect(fs.access(dailyPath)).resolves.toBeUndefined();
+    for (const [sourcePath, contents] of [
+      [sessionPath, changedSessionContents],
+      [recallPath, changedRecallContents],
+      [phasePath, changedPhaseContents],
+    ] as const) {
+      await expect(fs.access(sourcePath)).rejects.toThrow();
+      await expect(fs.readFile(`${sourcePath}.migrated.2`, "utf8")).resolves.toBe(contents);
+    }
+
+    const settledResult = await migration.migrateLegacyState(migrationParams());
+    expect(settledResult.changes).toEqual([]);
+    expect(settledResult.warnings).toEqual([]);
+    expect(settledResult.notices).toEqual([
+      expect.stringContaining("Retained acknowledged Memory Core daily ingestion"),
+    ]);
+
+    const settledSession = await dreamingTesting.readSessionIngestionState(workspaceDir);
+    expect(settledSession.seenMessages["main/session.jsonl"]).toEqual(["seen-a", "seen-b"]);
+    const settledRecall = await shortTermTesting.readRecallStore(
+      workspaceDir,
+      "2026-04-05T12:00:00.000Z",
+    );
+    expect(settledRecall.entries["memory:memory/2026-04-05.md:1:1"]?.recallCount).toBe(1);
+    const settledPhase = await shortTermTesting.readPhaseSignalStore(
+      workspaceDir,
+      "2026-04-05T13:00:00.000Z",
+    );
+    expect(settledPhase.entries["memory:memory/2026-04-05.md:1:1"]?.lightHits).toBe(1);
   });
 
   it("leaves invalid legacy JSON in place", async () => {

--- a/extensions/memory-core/doctor-contract-api.ts
+++ b/extensions/memory-core/doctor-contract-api.ts
@@ -1987,9 +1987,17 @@ export const stateMigrations: PluginDoctorStateMigration[] = [
             );
             continue;
           }
-          warnings.push(
-            `Skipped Memory Core ${source.label} import for ${source.workspaceDir} because SQLite rows conflict with the legacy source; left legacy source in place`,
+          // Dreaming journals are derived state. Keep the authoritative SQLite
+          // state active and retain the divergent rollback source in the archive.
+          changes.push(
+            `Resolved Memory Core ${source.label} legacy conflict by keeping canonical SQLite plugin state`,
           );
+          await archiveLegacyStateSource({
+            filePath: source.filePath,
+            label: `Memory Core ${source.label} conflicting legacy source`,
+            changes,
+            warnings,
+          });
           continue;
         }
         let imported: number;


### PR DESCRIPTION
## Summary

Recover from divergent legacy Memory Core Dreaming journals during startup migration. When SQLite plugin state already exists, the migration now keeps that canonical state and archives a conflicting derived JSON journal with the existing `.migrated.N` mechanism instead of leaving the source active and returning a readiness-blocking warning.

## User Impact

Before this change, an otherwise normal upgrade could leave Gateway in a restart loop. The three affected legacy files were:

- `memory/.dreams/session-ingestion.json`
- `memory/.dreams/short-term-recall.json`
- `memory/.dreams/phase-signals.json`

On a production VPS running `2026.7.2-beta.3`, the startup migration reported each as a SQLite conflict, `openclaw doctor --fix` repeated the same result, and Gateway refused to become ready. Moving those files to a timestamped backup directory restored startup, which demonstrated that the active JSON journals were the blocker rather than required live state.

This change makes that recovery automatic while retaining each original JSON source in the normal migration archive for inspection or rollback.

## Why This Change

Once canonical SQLite plugin state has been established, a divergent legacy journal must be retained, but it should not override canonical state or prevent Gateway startup.

The regression test covers all three journals above. It verifies that a divergent source is archived with its exact contents, SQLite session/recall/phase data remains unchanged, and a second migration run is clean and idempotent.

## Data Classification

The repository documentation describes `memory/.dreams/` as Dreaming "machine state", including the recall store, phase signals, and ingestion checkpoints (`docs/concepts/dreaming.md`). It also says long-term promotion writes only to `MEMORY.md`. This supports treating the three migrated journals as derived state, and the original source remains in the existing migration archive. The final policy confirmation is deliberately left to the Memory Core migration owner.

## Related Work

- #107002 intentionally converged equivalent legacy sources but left divergent sources fail-closed. That made the surviving branch precise, but a warning from it is currently readiness-blocking, so it does not recover this case.
- #108652 applies canonical-wins plus archive recovery to derived Memory Core index sidecars. This PR follows that recovery policy for a distinct Dreaming JSON-to-SQLite migration surface.
- #108459, #109649, and #111600 concern duplicate `update.run` handoffs. They may reduce ways conflicting state can arise, but they do not recover a persistent JSON/SQLite conflict from a single upgrade.
- #109865 and #110216 handle divergent tables inside a legacy Memory index SQLite file. They do not cover these separate legacy Dreaming JSON journals.

## Verification

- Linux local-container, `openclaw-crabbox-node-rsync:83212`
- Node `v24.15.0`, SQLite `3.51.3`
- `corepack pnpm install --frozen-lockfile`
- `node scripts/run-vitest.mjs extensions/memory-core/doctor-contract-api.test.ts`
- Result: `1` test file passed, `56` tests passed.
- `git diff --check`
- `python .agents/skills/autoreview/scripts/autoreview --mode local`
- `python .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- Both structured review runs: `autoreview clean: no accepted/actionable findings reported`.

## Isolated Doctor and Gateway Proof

An isolated Ubuntu VPS checkout at exact PR head `d62c71ca98dfc07234ebe9f2438468ac630fb8cc` was built with `corepack pnpm build`. It used a temporary `HOME`, config, state directory, workspace, and loopback port; no production OpenClaw configuration, state, or gateway process was used.

The harness ran the compiled package commands:

```text
node dist/entry.js doctor --fix --non-interactive --yes
node dist/entry.js gateway run --allow-unconfigured --port 19664
```

It first migrated valid JSON journals into SQLite, restored and deliberately diverged all three JSON files, then ran Doctor again. Redacted after-fix output:

```text
- Resolved Memory Core session ingestion legacy conflict by keeping canonical SQLite plugin state
- Resolved Memory Core short-term recall legacy conflict by keeping canonical SQLite plugin state
- Resolved Memory Core phase signals legacy conflict by keeping canonical SQLite plugin state

archive:
  memory/.dreams/session-ingestion.json.migrated.2
  memory/.dreams/short-term-recall.json.migrated.2
  memory/.dreams/phase-signals.json.migrated.2
canonicalSqliteUnchanged: true
GET /readyz: 200 {"ready":true}
```

The harness asserted the exact divergent JSON contents were preserved in each `.migrated.2` archive, the original paths were absent, canonical SQLite snapshots were identical before and after the second Doctor run, and the fresh Gateway became ready.

## Real behavior proof

- **Behavior or issue addressed:** a divergent legacy Dreaming journal with canonical SQLite rows made startup migration return a warning, then Gateway never reported ready and systemd retried it.
- **Real environment tested:** isolated Ubuntu VPS checkout built from exact head `d62c71ca98dfc07234ebe9f2438468ac630fb8cc`; Node `v22.22.3`; SQLite `3.51.3`; separate from the production Gateway and state.
- **Exact steps or command run after this patch:** create valid legacy journal JSON, run compiled `openclaw doctor --fix --non-interactive --yes` to import it, restore and diverge all three journals, rerun the same Doctor command, verify the migration archives and SQLite snapshot, then run compiled `openclaw gateway run --allow-unconfigured --port 19664` and request `/readyz`.
- **Evidence after fix:** Doctor emitted one canonical-SQLite conflict resolution for session ingestion, short-term recall, and phase signals; each exact divergent source became a `.migrated.2` archive; SQLite was unchanged; the fresh Gateway returned `200 {"ready":true}`.
- **Observed result after fix:** derived rollback sources are retained safely without blocking migration readiness; malformed or uncomparable legacy JSON still follows the existing fail-closed warning behavior.
- **What was not tested:** a full npm package upgrade and rollback cycle was not rerun against production. The post-fix command path was exercised from an exact-head built checkout with fully isolated state.
