### PR TITLE
fix(mcp): retry failed tool catalogs after recovery

### DIFF
--- a/src/agents/agent-bundle-mcp-combined.ts
+++ b/src/agents/agent-bundle-mcp-combined.ts
@@ -92,7 +92,7 @@ export function createCombinedSessionMcpRuntime(params: {
     parts.every((part, index) => part.peekCatalog() === mergedSourceCatalogs?.[index]);
 
   const loadCatalog = async (): Promise<McpToolCatalog> => {
-    if (cachedCatalog && cachedCatalogIsCurrent()) {
+    if (cachedCatalog && !cachedCatalog.diagnostics?.length && cachedCatalogIsCurrent()) {
       return cachedCatalog;
     }
     if (catalogInFlight) {
@@ -100,6 +100,12 @@ export function createCombinedSessionMcpRuntime(params: {
     }
     const inFlight = (async () => {
       const catalogs = await Promise.all(parts.map((part) => part.getCatalog()));
+      if (
+        cachedCatalog &&
+        mergedSourceCatalogs?.every((source, index) => source === catalogs[index])
+      ) {
+        return cachedCatalog;
+      }
       serverOwner.clear();
       for (let index = 0; index < parts.length; index += 1) {
         rememberServerOwners(catalogs[index]!, parts[index]!);

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -9,6 +9,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { withTestTimeout } from "../../test/helpers/promise.js";
 import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { createCombinedSessionMcpRuntime } from "./agent-bundle-mcp-combined.js";
 import {
   completeDeferredSessionMcpRuntimeRetirement,
   createBundleMcpJsonSchemaValidator,
@@ -1053,7 +1054,7 @@ describe("session MCP runtime", () => {
       inputSchema: { type: "array", items: { type: "number" } },
     });
 
-    const runtime = await getOrCreateSessionMcpRuntime({
+    const failedRuntime = await getOrCreateSessionMcpRuntime({
       sessionId: "session-catalog-retry",
       sessionKey: "agent:test:session-catalog-retry",
       workspaceDir: "/workspace",
@@ -1068,21 +1069,38 @@ describe("session MCP runtime", () => {
         },
       },
     });
+    const healthyRuntime = makeRuntime(
+      [{ toolName: "healthy_tool", description: "Always available" }],
+      "healthyServer",
+    );
+    const healthyCatalog = await healthyRuntime.getCatalog();
+    healthyRuntime.getCatalog = async () => healthyCatalog;
+    healthyRuntime.peekCatalog = () => healthyCatalog;
+    const runtime = createCombinedSessionMcpRuntime({
+      sessionId: "session-catalog-retry",
+      workspaceDir: "/workspace",
+      parts: [failedRuntime, healthyRuntime],
+    });
 
     try {
       const failedCatalog = await runtime.getCatalog();
-      expect(failedCatalog.servers).toEqual({});
+      expect(Object.keys(failedCatalog.servers)).toEqual(["healthyServer"]);
+      expect(failedCatalog.tools.map((tool) => tool.toolName)).toEqual(["healthy_tool"]);
       expect(failedCatalog.diagnostics?.[0]?.serverName).toBe("retryServer");
 
       await writeListToolsMcpServer({ filePath: serverPath, logPath });
       await expect(runtime.getCatalog()).resolves.toBe(failedCatalog);
 
       nowMs += 5_001;
+      expect(runtime.peekCatalog()).toBeNull();
       const recoveredCatalog = await runtime.getCatalog();
 
       expect(recoveredCatalog.diagnostics ?? []).toEqual([]);
       expect(recoveredCatalog.servers.retryServer).toBeDefined();
-      expect(recoveredCatalog.tools.map((tool) => tool.toolName)).toEqual(["slow_tool"]);
+      expect(recoveredCatalog.tools.map((tool) => tool.toolName)).toEqual([
+        "healthy_tool",
+        "slow_tool",
+      ]);
     } finally {
       nowSpy.mockRestore();
       await runtime.dispose();

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -36,7 +36,7 @@ vi.mock("./embedded-agent-mcp.js", () => ({
 }));
 
 const tempDirs: string[] = [];
-const appMetadataTempDirs = useAutoCleanupTempDirTracker(afterEach);
+const tempDirTracker = useAutoCleanupTempDirTracker(afterEach);
 
 type RuntimeFactoryOptions = NonNullable<
   Parameters<typeof testing.createSessionMcpRuntimeManager>[0]
@@ -413,7 +413,7 @@ describe("session MCP runtime", () => {
   });
 
   it("catalogs canonical and deprecated MCP App tool metadata", async () => {
-    const tempDir = appMetadataTempDirs.make("bundle-mcp-app-metadata-");
+    const tempDir = tempDirTracker.make("bundle-mcp-app-metadata-");
     const serverPath = path.join(tempDir, "app-metadata.mjs");
     const logPath = path.join(tempDir, "server.log");
     await writeListToolsMcpServer({
@@ -1043,7 +1043,7 @@ describe("session MCP runtime", () => {
   });
 
   it("retries a failed MCP catalog without stalling healthy siblings", async () => {
-    const tempDir = makeTempDir(tempDirs, "bundle-mcp-catalog-retry-");
+    const tempDir = tempDirTracker.make("bundle-mcp-catalog-retry-");
     const retryServerPath = path.join(tempDir, "retry-list-tools.mjs");
     const retryLogPath = path.join(tempDir, "retry-server.log");
     const healthyServerPath = path.join(tempDir, "healthy-list-tools.mjs");

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -1043,7 +1043,7 @@ describe("session MCP runtime", () => {
   });
 
   it("retries a failed MCP catalog without stalling healthy siblings", async () => {
-    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "bundle-mcp-catalog-retry-"));
+    const tempDir = makeTempDir(tempDirs, "bundle-mcp-catalog-retry-");
     const retryServerPath = path.join(tempDir, "retry-list-tools.mjs");
     const retryLogPath = path.join(tempDir, "retry-server.log");
     const healthyServerPath = path.join(tempDir, "healthy-list-tools.mjs");
@@ -1147,7 +1147,6 @@ describe("session MCP runtime", () => {
     } finally {
       nowSpy.mockRestore();
       await runtime.dispose();
-      await fs.rm(tempDir, { recursive: true, force: true });
     }
   });
 

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -1041,6 +1041,55 @@ describe("session MCP runtime", () => {
     }
   });
 
+  it("retries a failed MCP catalog after a short cooldown", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "bundle-mcp-catalog-retry-"));
+    const serverPath = path.join(tempDir, "retry-list-tools.mjs");
+    const logPath = path.join(tempDir, "server.log");
+    let nowMs = 10_000;
+    const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => nowMs);
+    await writeListToolsMcpServer({
+      filePath: serverPath,
+      logPath,
+      inputSchema: { type: "array", items: { type: "number" } },
+    });
+
+    const runtime = await getOrCreateSessionMcpRuntime({
+      sessionId: "session-catalog-retry",
+      sessionKey: "agent:test:session-catalog-retry",
+      workspaceDir: "/workspace",
+      cfg: {
+        mcp: {
+          servers: {
+            retryServer: {
+              command: process.execPath,
+              args: [serverPath],
+            },
+          },
+        },
+      },
+    });
+
+    try {
+      const failedCatalog = await runtime.getCatalog();
+      expect(failedCatalog.servers).toEqual({});
+      expect(failedCatalog.diagnostics?.[0]?.serverName).toBe("retryServer");
+
+      await writeListToolsMcpServer({ filePath: serverPath, logPath });
+      await expect(runtime.getCatalog()).resolves.toBe(failedCatalog);
+
+      nowMs += 5_001;
+      const recoveredCatalog = await runtime.getCatalog();
+
+      expect(recoveredCatalog.diagnostics ?? []).toEqual([]);
+      expect(recoveredCatalog.servers.retryServer).toBeDefined();
+      expect(recoveredCatalog.tools.map((tool) => tool.toolName)).toEqual(["slow_tool"]);
+    } finally {
+      nowSpy.mockRestore();
+      await runtime.dispose();
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("filters listed MCP tools with per-server include and exclude rules", async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "bundle-mcp-tool-filter-"));
     const serverPath = path.join(tempDir, "tool-filter.mjs");

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -1042,57 +1042,99 @@ describe("session MCP runtime", () => {
     }
   });
 
-  it("retries a failed MCP catalog after a short cooldown", async () => {
+  it("retries a failed MCP catalog without stalling healthy siblings", async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "bundle-mcp-catalog-retry-"));
-    const serverPath = path.join(tempDir, "retry-list-tools.mjs");
-    const logPath = path.join(tempDir, "server.log");
+    const retryServerPath = path.join(tempDir, "retry-list-tools.mjs");
+    const retryLogPath = path.join(tempDir, "retry-server.log");
+    const healthyServerPath = path.join(tempDir, "healthy-list-tools.mjs");
+    const healthyLogPath = path.join(tempDir, "healthy-server.log");
     let nowMs = 10_000;
     const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => nowMs);
-    await writeListToolsMcpServer({
-      filePath: serverPath,
-      logPath,
-      inputSchema: { type: "array", items: { type: "number" } },
-    });
+    await Promise.all([
+      writeListToolsMcpServer({
+        filePath: retryServerPath,
+        logPath: retryLogPath,
+        inputSchema: { type: "array", items: { type: "number" } },
+      }),
+      writeListToolsMcpServer({
+        filePath: healthyServerPath,
+        logPath: healthyLogPath,
+        tools: [
+          {
+            name: "healthy_tool",
+            inputSchema: { type: "object", properties: {} },
+          },
+        ],
+      }),
+    ]);
 
-    const failedRuntime = await getOrCreateSessionMcpRuntime({
+    const staticRuntime = await getOrCreateSessionMcpRuntime({
       sessionId: "session-catalog-retry",
       sessionKey: "agent:test:session-catalog-retry",
       workspaceDir: "/workspace",
       cfg: {
         mcp: {
           servers: {
+            healthyServer: {
+              command: process.execPath,
+              args: [healthyServerPath],
+              connectionTimeoutMs: 2_000,
+            },
             retryServer: {
               command: process.execPath,
-              args: [serverPath],
+              args: [retryServerPath],
+              connectionTimeoutMs: 2_000,
             },
           },
         },
       },
     });
-    const healthyRuntime = makeRuntime(
-      [{ toolName: "healthy_tool", description: "Always available" }],
-      "healthyServer",
+    const scopedRuntime = makeRuntime(
+      [{ toolName: "scoped_tool", description: "Requester-scoped tool" }],
+      "scopedServer",
     );
-    const healthyCatalog = await healthyRuntime.getCatalog();
-    healthyRuntime.getCatalog = async () => healthyCatalog;
-    healthyRuntime.peekCatalog = () => healthyCatalog;
+    const scopedCatalog = await scopedRuntime.getCatalog();
+    scopedRuntime.getCatalog = async () => scopedCatalog;
+    scopedRuntime.peekCatalog = () => scopedCatalog;
     const runtime = createCombinedSessionMcpRuntime({
       sessionId: "session-catalog-retry",
       workspaceDir: "/workspace",
-      parts: [failedRuntime, healthyRuntime],
+      parts: [staticRuntime, scopedRuntime],
     });
 
     try {
       const failedCatalog = await runtime.getCatalog();
-      expect(Object.keys(failedCatalog.servers)).toEqual(["healthyServer"]);
-      expect(failedCatalog.tools.map((tool) => tool.toolName)).toEqual(["healthy_tool"]);
+      expect(Object.keys(failedCatalog.servers)).toEqual(["healthyServer", "scopedServer"]);
+      expect(failedCatalog.tools.map((tool) => tool.toolName)).toEqual([
+        "healthy_tool",
+        "scoped_tool",
+      ]);
       expect(failedCatalog.diagnostics?.[0]?.serverName).toBe("retryServer");
 
-      await writeListToolsMcpServer({ filePath: serverPath, logPath });
+      await writeListToolsMcpServer({
+        filePath: retryServerPath,
+        logPath: retryLogPath,
+        initializeDelayMs: 500,
+      });
       await expect(runtime.getCatalog()).resolves.toBe(failedCatalog);
 
       nowMs += 5_001;
       expect(runtime.peekCatalog()).toBeNull();
+      const staleCatalog = await withTestTimeout(
+        runtime.getCatalog(),
+        300,
+        "catalog retry blocked the triggering turn",
+      );
+      expect(staleCatalog.diagnostics?.[0]?.serverName).toBe("retryServer");
+      await expect(runtime.callTool("healthyServer", "healthy_tool", {})).resolves.toMatchObject({
+        isError: false,
+      });
+
+      await waitForPredicate(
+        () => staticRuntime.peekCatalog()?.servers.retryServer !== undefined,
+        "background catalog recovery",
+        LIST_TOOLS_TEST_DEADLINE_MS,
+      );
       const recoveredCatalog = await runtime.getCatalog();
 
       expect(recoveredCatalog.diagnostics ?? []).toEqual([]);
@@ -1100,6 +1142,7 @@ describe("session MCP runtime", () => {
       expect(recoveredCatalog.tools.map((tool) => tool.toolName)).toEqual([
         "healthy_tool",
         "slow_tool",
+        "scoped_tool",
       ]);
     } finally {
       nowSpy.mockRestore();

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -1119,12 +1119,13 @@ describe("session MCP runtime", () => {
       await expect(runtime.getCatalog()).resolves.toBe(failedCatalog);
 
       nowMs += 5_001;
-      expect(runtime.peekCatalog()).toBeNull();
+      expect(runtime.peekCatalog()).toBe(failedCatalog);
       const staleCatalog = await withTestTimeout(
         runtime.getCatalog(),
         300,
         "catalog retry blocked the triggering turn",
       );
+      expect(staleCatalog).toBe(failedCatalog);
       expect(staleCatalog.diagnostics?.[0]?.serverName).toBe("retryServer");
       await expect(runtime.callTool("healthyServer", "healthy_tool", {})).resolves.toMatchObject({
         isError: false,

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -1145,6 +1145,8 @@ describe("session MCP runtime", () => {
         "slow_tool",
         "scoped_tool",
       ]);
+      expect((await fs.readFile(healthyLogPath, "utf8")).match(/recv tools\/list/g)).toHaveLength(1);
+      expect((await fs.readFile(retryLogPath, "utf8")).match(/recv tools\/list/g)).toHaveLength(2);
     } finally {
       nowSpy.mockRestore();
       await runtime.dispose();

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -1145,7 +1145,9 @@ describe("session MCP runtime", () => {
         "slow_tool",
         "scoped_tool",
       ]);
-      expect((await fs.readFile(healthyLogPath, "utf8")).match(/recv tools\/list/g)).toHaveLength(1);
+      expect((await fs.readFile(healthyLogPath, "utf8")).match(/recv tools\/list/g)).toHaveLength(
+        1,
+      );
       expect((await fs.readFile(retryLogPath, "utf8")).match(/recv tools\/list/g)).toHaveLength(2);
     } finally {
       nowSpy.mockRestore();

--- a/src/agents/agent-bundle-mcp-runtime.ts
+++ b/src/agents/agent-bundle-mcp-runtime.ts
@@ -420,6 +420,15 @@ export function createSessionMcpRuntime(params: {
   let catalogRetryAfterMs: number | undefined;
   let catalogInFlight: Promise<McpToolCatalog> | undefined;
   let catalogInvalidationGeneration = 0;
+  const readCachedCatalog = (): McpToolCatalog | null => {
+    if (catalogRetryAfterMs !== undefined && Date.now() >= catalogRetryAfterMs) {
+      // Combined runtimes compare part snapshots through peekCatalog(). Expiry
+      // must invalidate that snapshot too, or their merged cache hides the retry.
+      catalog = null;
+      catalogRetryAfterMs = undefined;
+    }
+    return catalog;
+  };
   const sessions = new Map<string, BundleMcpSession>();
   const serverBackoff = new Map<string, McpServerBackoffState>();
   const recordServerToolFailure = (serverName: string, nowMs: number) => {
@@ -512,12 +521,9 @@ export function createSessionMcpRuntime(params: {
 
   const getCatalog = async (): Promise<McpToolCatalog> => {
     failIfDisposed();
-    if (catalog) {
-      if (catalogRetryAfterMs === undefined || Date.now() < catalogRetryAfterMs) {
-        return catalog;
-      }
-      catalog = null;
-      catalogRetryAfterMs = undefined;
+    const cachedCatalog = readCachedCatalog();
+    if (cachedCatalog) {
+      return cachedCatalog;
     }
     if (catalogInFlight) {
       return catalogInFlight;
@@ -889,7 +895,7 @@ export function createSessionMcpRuntime(params: {
     getCatalog,
     /** Synchronous catalog snapshot only; must not connect transports or issue tools/list. */
     peekCatalog() {
-      return catalog;
+      return readCachedCatalog();
     },
     markUsed() {
       lastUsedAt = Date.now();

--- a/src/agents/agent-bundle-mcp-runtime.ts
+++ b/src/agents/agent-bundle-mcp-runtime.ts
@@ -533,7 +533,7 @@ export function createSessionMcpRuntime(params: {
 
       // A cooldown retry replaces only diagnostic-bearing servers. Healthy clients
       // keep their SDK tool-metadata snapshot and remain callable during recovery.
-      const servers: Record<string, McpServerCatalog> = { ...(retryBaseCatalog?.servers ?? {}) };
+      const servers: Record<string, McpServerCatalog> = { ...retryBaseCatalog?.servers };
       const tools: McpCatalogTool[] = [...(retryBaseCatalog?.tools ?? [])];
       const diagnostics: McpToolCatalogDiagnostic[] = [];
       // Prefer session-wide precomputed assignments; fall back only for isolated runtimes.

--- a/src/agents/agent-bundle-mcp-runtime.ts
+++ b/src/agents/agent-bundle-mcp-runtime.ts
@@ -420,15 +420,8 @@ export function createSessionMcpRuntime(params: {
   let catalogRetryAfterMs: number | undefined;
   let catalogInFlight: Promise<McpToolCatalog> | undefined;
   let catalogInvalidationGeneration = 0;
-  const readCachedCatalog = (): McpToolCatalog | null => {
-    if (catalogRetryAfterMs !== undefined && Date.now() >= catalogRetryAfterMs) {
-      // Combined runtimes compare part snapshots through peekCatalog(). Expiry
-      // must invalidate that snapshot too, or their merged cache hides the retry.
-      catalog = null;
-      catalogRetryAfterMs = undefined;
-    }
-    return catalog;
-  };
+  const peekCurrentCatalog = (): McpToolCatalog | null =>
+    catalogRetryAfterMs !== undefined && Date.now() >= catalogRetryAfterMs ? null : catalog;
   const sessions = new Map<string, BundleMcpSession>();
   const serverBackoff = new Map<string, McpServerBackoffState>();
   const recordServerToolFailure = (serverName: string, nowMs: number) => {
@@ -521,9 +514,25 @@ export function createSessionMcpRuntime(params: {
 
   const getCatalog = async (): Promise<McpToolCatalog> => {
     failIfDisposed();
-    const cachedCatalog = readCachedCatalog();
+    const cachedCatalog = peekCurrentCatalog();
     if (cachedCatalog) {
       return cachedCatalog;
+    }
+    if (catalog) {
+      // Keep healthy siblings available while one failed server is retried. Clearing
+      // the snapshot only long enough to enter the canonical loader preserves its
+      // in-flight dedupe without making the triggering turn await slow reconnects.
+      const staleCatalog = catalog;
+      catalog = null;
+      catalogRetryAfterMs = undefined;
+      const refresh = getCatalog();
+      catalog = staleCatalog;
+      void refresh.catch(() => {
+        if (!disposed && catalog === staleCatalog && catalogRetryAfterMs === undefined) {
+          catalogRetryAfterMs = Date.now() + BUNDLE_MCP_CATALOG_FAILURE_RETRY_MS;
+        }
+      });
+      return staleCatalog;
     }
     if (catalogInFlight) {
       return catalogInFlight;
@@ -895,7 +904,7 @@ export function createSessionMcpRuntime(params: {
     getCatalog,
     /** Synchronous catalog snapshot only; must not connect transports or issue tools/list. */
     peekCatalog() {
-      return readCachedCatalog();
+      return peekCurrentCatalog();
     },
     markUsed() {
       lastUsedAt = Date.now();

--- a/src/agents/agent-bundle-mcp-runtime.ts
+++ b/src/agents/agent-bundle-mcp-runtime.ts
@@ -420,8 +420,8 @@ export function createSessionMcpRuntime(params: {
   let catalogRetryAfterMs: number | undefined;
   let catalogInFlight: Promise<McpToolCatalog> | undefined;
   let catalogInvalidationGeneration = 0;
-  const peekCurrentCatalog = (): McpToolCatalog | null =>
-    catalogRetryAfterMs !== undefined && Date.now() >= catalogRetryAfterMs ? null : catalog;
+  const catalogRetryIsDue = (): boolean =>
+    catalogRetryAfterMs !== undefined && Date.now() >= catalogRetryAfterMs;
   const sessions = new Map<string, BundleMcpSession>();
   const serverBackoff = new Map<string, McpServerBackoffState>();
   const recordServerToolFailure = (serverName: string, nowMs: number) => {
@@ -514,7 +514,7 @@ export function createSessionMcpRuntime(params: {
 
   const getCatalog = async (): Promise<McpToolCatalog> => {
     failIfDisposed();
-    const cachedCatalog = peekCurrentCatalog();
+    const cachedCatalog = catalogRetryIsDue() ? null : catalog;
     if (cachedCatalog) {
       return cachedCatalog;
     }
@@ -904,7 +904,7 @@ export function createSessionMcpRuntime(params: {
     getCatalog,
     /** Synchronous catalog snapshot only; must not connect transports or issue tools/list. */
     peekCatalog() {
-      return peekCurrentCatalog();
+      return catalog;
     },
     markUsed() {
       lastUsedAt = Date.now();

--- a/src/agents/agent-bundle-mcp-runtime.ts
+++ b/src/agents/agent-bundle-mcp-runtime.ts
@@ -80,6 +80,7 @@ const MCP_APPS_CLIENT_EXTENSION = "io.modelcontextprotocol/ui";
 const MCP_APP_RESOURCE_MIME_TYPE = "text/html;profile=mcp-app";
 const BUNDLE_MCP_FAILURE_THRESHOLD = 3;
 const BUNDLE_MCP_FAILURE_COOLDOWN_MS = 60_000;
+const BUNDLE_MCP_CATALOG_FAILURE_RETRY_MS = 5_000;
 const BUNDLE_MCP_CATALOG_LIST_TIMEOUT_MS = 1_500;
 const BUNDLE_MCP_DISPOSE_TIMEOUT_MS = 5_000;
 const BUNDLE_MCP_CATALOG_CONNECT_CONCURRENCY = 6;
@@ -416,6 +417,7 @@ export function createSessionMcpRuntime(params: {
   let activeLeases = 0;
   let disposed = false;
   let catalog: McpToolCatalog | null = null;
+  let catalogRetryAfterMs: number | undefined;
   let catalogInFlight: Promise<McpToolCatalog> | undefined;
   let catalogInvalidationGeneration = 0;
   const sessions = new Map<string, BundleMcpSession>();
@@ -511,7 +513,11 @@ export function createSessionMcpRuntime(params: {
   const getCatalog = async (): Promise<McpToolCatalog> => {
     failIfDisposed();
     if (catalog) {
-      return catalog;
+      if (catalogRetryAfterMs === undefined || Date.now() < catalogRetryAfterMs) {
+        return catalog;
+      }
+      catalog = null;
+      catalogRetryAfterMs = undefined;
     }
     if (catalogInFlight) {
       return catalogInFlight;
@@ -633,6 +639,7 @@ export function createSessionMcpRuntime(params: {
                           }
                           catalogInvalidationGeneration += 1;
                           catalog = null;
+                          catalogRetryAfterMs = undefined;
                           catalogInFlight = undefined;
                         },
                       },
@@ -838,6 +845,9 @@ export function createSessionMcpRuntime(params: {
       failIfDisposed();
       if (catalogInvalidationGeneration === catalogGeneration) {
         catalog = nextCatalog;
+        catalogRetryAfterMs = nextCatalog.diagnostics?.length
+          ? Date.now() + BUNDLE_MCP_CATALOG_FAILURE_RETRY_MS
+          : undefined;
       }
       return nextCatalog;
     } finally {
@@ -967,6 +977,7 @@ export function createSessionMcpRuntime(params: {
       }
       disposed = true;
       catalog = null;
+      catalogRetryAfterMs = undefined;
       catalogInFlight = undefined;
       const sessionsToClose = Array.from(sessions.values());
       sessions.clear();

--- a/src/agents/agent-bundle-mcp-runtime.ts
+++ b/src/agents/agent-bundle-mcp-runtime.ts
@@ -512,31 +512,14 @@ export function createSessionMcpRuntime(params: {
     return true;
   };
 
-  const getCatalog = async (): Promise<McpToolCatalog> => {
+  const loadCatalog = async (retryBaseCatalog?: McpToolCatalog): Promise<McpToolCatalog> => {
     failIfDisposed();
-    const cachedCatalog = catalogRetryIsDue() ? null : catalog;
-    if (cachedCatalog) {
-      return cachedCatalog;
-    }
-    if (catalog) {
-      // Keep healthy siblings available while one failed server is retried. Clearing
-      // the snapshot only long enough to enter the canonical loader preserves its
-      // in-flight dedupe without making the triggering turn await slow reconnects.
-      const staleCatalog = catalog;
-      catalog = null;
-      catalogRetryAfterMs = undefined;
-      const refresh = getCatalog();
-      catalog = staleCatalog;
-      void refresh.catch(() => {
-        if (!disposed && catalog === staleCatalog && catalogRetryAfterMs === undefined) {
-          catalogRetryAfterMs = Date.now() + BUNDLE_MCP_CATALOG_FAILURE_RETRY_MS;
-        }
-      });
-      return staleCatalog;
-    }
     if (catalogInFlight) {
       return catalogInFlight;
     }
+    const retryServerNames = retryBaseCatalog
+      ? new Set(retryBaseCatalog.diagnostics?.map((diagnostic) => diagnostic.serverName))
+      : undefined;
     const catalogGeneration = catalogInvalidationGeneration;
     const inFlight = (async () => {
       if (Object.keys(loaded.mcpServers).length === 0) {
@@ -548,8 +531,10 @@ export function createSessionMcpRuntime(params: {
         };
       }
 
-      const servers: Record<string, McpServerCatalog> = {};
-      const tools: McpCatalogTool[] = [];
+      // A cooldown retry replaces only diagnostic-bearing servers. Healthy clients
+      // keep their SDK tool-metadata snapshot and remain callable during recovery.
+      const servers: Record<string, McpServerCatalog> = { ...(retryBaseCatalog?.servers ?? {}) };
+      const tools: McpCatalogTool[] = [...(retryBaseCatalog?.tools ?? [])];
       const diagnostics: McpToolCatalogDiagnostic[] = [];
       // Prefer session-wide precomputed assignments; fall back only for isolated runtimes.
       const safeServerNamesByServer =
@@ -569,6 +554,9 @@ export function createSessionMcpRuntime(params: {
         }> = [];
         for (const [serverName, rawServer] of Object.entries(loaded.mcpServers)) {
           failIfDisposed();
+          if (retryServerNames && !retryServerNames.has(serverName)) {
+            continue;
+          }
           const override = params.connectionOverrides?.get(serverName);
           // Overrides supply per-requester transport only; never write them back to config.
           const transportSource = override
@@ -870,6 +858,25 @@ export function createSessionMcpRuntime(params: {
         catalogInFlight = undefined;
       }
     }
+  };
+
+  const getCatalog = async (): Promise<McpToolCatalog> => {
+    failIfDisposed();
+    if (catalog && !catalogRetryIsDue()) {
+      return catalog;
+    }
+    if (!catalog) {
+      return loadCatalog();
+    }
+
+    const staleCatalog = catalog;
+    catalogRetryAfterMs = undefined;
+    void loadCatalog(staleCatalog).catch(() => {
+      if (!disposed && catalog === staleCatalog && catalogRetryAfterMs === undefined) {
+        catalogRetryAfterMs = Date.now() + BUNDLE_MCP_CATALOG_FAILURE_RETRY_MS;
+      }
+    });
+    return staleCatalog;
   };
 
   return {


### PR DESCRIPTION
Closes #111961

## What Problem This Solves

Fixes an issue where users whose MCP server failed during initial tool discovery would keep seeing a permanently missing tool catalog in later turns, even after the server recovered.

## Why This Change Was Made

Diagnostic-bearing MCP catalogs remain cached for a five-second cooldown. Once due, the runtime retries only the failed server entries in the background and atomically merges their completed results into the warm catalog. Healthy sibling clients are not re-listed, so their MCP SDK metadata and tool availability remain stable. Combined static/requester runtimes reconsult diagnostic-bearing parts while preserving the existing read-only catalog snapshot.

Successful catalogs keep their existing stable cache behavior. Explicit `tools/list_changed` invalidation and runtime disposal still clear retry state immediately.

## User Impact

Late-starting or temporarily failing MCP servers can recover within the same session without a restart or an unrelated `tools/list_changed` notification. The turn that triggers recovery does not wait for a slow reconnect, and tools from healthy sibling servers remain usable throughout.

## Evidence

### Exact-head real stdio MCP recovery proof

Head `bcc74d2d487e30fef8a411087498a35a4e615524` was exercised outside Vitest against two independent real stdio MCP server processes through production `createSessionMcpRuntime` plus `createCombinedSessionMcpRuntime`.

The recovery server first returned a syntactically valid `tools/list` response with an invalid input schema. After the cooldown it restarted healthy with a 700 ms initialize delay. The healthy sibling stayed callable while that retry ran, and its catalog was not re-listed.

```text
PR_HEAD=bcc74d2d487e30fef8a411087498a35a4e615524
NODE_VERSION=v24.18.0
RUNTIME=production createSessionMcpRuntime + createCombinedSessionMcpRuntime
INITIAL_DIAGNOSTICS=1
INITIAL_TOOLS=healthy_tool
COOLDOWN_RETURNED_SAME_CATALOG=true
RETRY_TRIGGER_MS=7
HEALTHY_CALL_DURING_RETRY=[{"type":"text","text":"healthy:ok"}]
RECOVERED_DIAGNOSTICS=0
RECOVERED_TOOLS=healthy_tool,slow_tool
HEALTHY_TOOLS_LIST_CALLS=1
RECOVERY_TOOLS_LIST_CALLS=2
SERVER_LOG_BEGIN
4926 healthy initialize valid=true
4927 recovery initialize valid=false
4926 healthy notifications/initialized valid=true
4926 healthy tools/list valid=true
4927 recovery notifications/initialized valid=false
4927 recovery tools/list valid=false
4926 healthy tools/call valid=true
4951 recovery initialize valid=true
4951 recovery notifications/initialized valid=true
4951 recovery tools/list valid=true
SERVER_LOG_END
MCP_RECOVERY=PASS
```

The isolated server scripts, state, logs, and processes were removed after runtime disposal. No endpoint, IP address, credential, or operator state was involved.

Proof environment:

- Blacksmith Testbox `tbx_01kych54c6jjyyywzf79nrm8d5`
- Actions run: https://github.com/openclaw/openclaw/actions/runs/30156602809
- Command: `CI=1 pnpm tsx scripts/pr111962-real-proof.mts` using a proof-only uncommitted script, removed after the run

### Focused and changed-file validation

```text
node scripts/run-vitest.mjs src/agents/agent-bundle-mcp-runtime.test.ts   -t 'retries a failed MCP catalog without stalling healthy siblings|re-merges the combined catalog after a part refreshes on tools/list_changed'

Test Files  2 passed (2)
Tests       4 passed | 148 skipped (152)

node scripts/check-changed.mjs --   src/agents/agent-bundle-mcp-runtime.ts   src/agents/agent-bundle-mcp-combined.ts   src/agents/agent-bundle-mcp-runtime.test.ts

exitCode=0
```

The exact-head changed-file gate passed on Testbox `tbx_01kycfmvxwatdcn8d58ar1qvas` (run https://github.com/openclaw/openclaw/actions/runs/30155856880). It covered formatting, core and core-test typechecks, type-aware lint, dependency and package guards, plugin boundaries, import cycles, database-first guards, and the other selected core gates.

