### PR TITLE
fix(ui): keep agent workspace files readable when unfocused

### DIFF
--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -3619,11 +3619,6 @@ td.data-table-key-col {
 
 .field textarea.agent-file-textarea {
   min-height: clamp(320px, 56vh, 720px);
-  transition: filter var(--duration-fast) ease;
-}
-
-.field textarea.agent-file-textarea:not(:focus) {
-  filter: blur(6px);
 }
 
 .agent-file-header {


### PR DESCRIPTION
## What Problem This Solves

Agent workspace file contents become blurred whenever the editor loses focus. That makes files such as `AGENTS.md`, `SOUL.md`, and `USER.md` difficult to read unless the user keeps the textarea actively focused.

## Why This Change Was Made

The blur is unconditional and is not tied to a privacy or screen-sharing mode. Removing it keeps the file editor readable while users navigate controls, compare content, or use the Markdown preview.

## User Impact

Agent workspace files remain readable when the textarea is unfocused. Editing, saving, resetting, and preview behavior are unchanged.

## Evidence

- Removed the unfocused `filter: blur(6px)` rule and its now-unused transition.
- `git diff --check`
- Confirmed no unfocused agent-file blur selector remains in `ui/src/styles/components.css`.
- No targeted automated test exists for this CSS-only focus state; PR CI provides the broader formatting and Control UI gates.
