### PR TITLE
fix(google): keep Gemini web search available for new API keys

### DIFF
--- a/docs/providers/google.md
+++ b/docs/providers/google.md
@@ -178,7 +178,7 @@ or let it reuse `models.providers.google.apiKey` after `GEMINI_API_KEY`:
           webSearch: {
             apiKey: "AIza...", // optional if GEMINI_API_KEY or models.providers.google.apiKey is set
             baseUrl: "https://generativelanguage.googleapis.com/v1beta", // falls back to models.providers.google.baseUrl
-            model: "gemini-2.5-flash",
+            model: "gemini-3.6-flash",
           },
         },
       },

--- a/docs/tools/gemini-search.md
+++ b/docs/tools/gemini-search.md
@@ -41,7 +41,7 @@ citations.
           webSearch: {
             apiKey: "AIza...", // optional if GEMINI_API_KEY or models.providers.google.apiKey is set
             baseUrl: "https://generativelanguage.googleapis.com/v1beta", // optional; falls back to models.providers.google.baseUrl
-            model: "gemini-2.5-flash", // default
+            model: "gemini-flash-latest", // default
           },
         },
       },
@@ -94,7 +94,7 @@ query instead of a hard 24-hour range. `week`, `month`, `year`, and explicit
 
 ## Model selection
 
-The default model is `gemini-2.5-flash` (fast and cost-effective). Any Gemini
+The default model is `gemini-flash-latest` (fast and cost-effective). Any Gemini
 model that supports grounding can be used via
 `plugins.entries.google.config.webSearch.model`.
 

--- a/docs/tools/gemini-search.md
+++ b/docs/tools/gemini-search.md
@@ -50,7 +50,7 @@ citations.
                 id: "GEMINI_GATEWAY_TOKEN",
               },
             },
-            model: "gemini-2.5-flash", // default
+            model: "gemini-flash-latest", // default
           },
         },
       },
@@ -127,7 +127,7 @@ query instead of a hard 24-hour range. `week`, `month`, `year`, and explicit
 
 ## Model selection
 
-The default model is `gemini-2.5-flash` (fast and cost-effective). Any Gemini
+The default model is `gemini-flash-latest` (fast and cost-effective). Any Gemini
 model that supports grounding can be used via
 `plugins.entries.google.config.webSearch.model`.
 

--- a/docs/tools/gemini-search.md
+++ b/docs/tools/gemini-search.md
@@ -50,7 +50,7 @@ citations.
                 id: "GEMINI_GATEWAY_TOKEN",
               },
             },
-            model: "gemini-flash-latest", // default
+            model: "gemini-3.6-flash", // default
           },
         },
       },
@@ -127,9 +127,13 @@ query instead of a hard 24-hour range. `week`, `month`, `year`, and explicit
 
 ## Model selection
 
-The default model is `gemini-flash-latest` (fast and cost-effective). Any Gemini
-model that supports grounding can be used via
-`plugins.entries.google.config.webSearch.model`.
+The default model is the stable `gemini-3.6-flash`. Omitting
+`plugins.entries.google.config.webSearch.model` uses this default; an explicit
+model stays pinned. You can select any Gemini model that supports grounding and
+is available to your API key.
+
+Gemini 3 grounding is billed per search query, while Gemini 2.5 grounding is
+billed per prompt. See [Google Search grounding pricing](https://ai.google.dev/gemini-api/docs/google-search#pricing).
 
 ## Base URL overrides
 

--- a/extensions/google/google.live.test.ts
+++ b/extensions/google/google.live.test.ts
@@ -484,36 +484,50 @@ describeLive("google plugin live", () => {
     expect(closeReasons).toEqual(["completed"]);
   }, 120_000);
 
-  it("runs Gemini web search through the registered provider tool", async () => {
-    const provider = createGeminiWebSearchProvider();
-    const tool = provider.createTool?.({
-      config: {},
-      searchConfig: { gemini: { apiKey: GOOGLE_API_KEY }, cacheTtlMinutes: 0, timeoutSeconds: 90 },
-    } as never);
+  it.each([undefined, "gemini-3.5-flash"])(
+    "runs Gemini web search with model %j",
+    async (model) => {
+      const provider = createGeminiWebSearchProvider();
+      const tool = provider.createTool?.({
+        config: {
+          plugins: {
+            entries: {
+              google: { config: { webSearch: { apiKey: GOOGLE_API_KEY, model } } },
+            },
+          },
+        },
+        searchConfig: { provider: "gemini", cacheTtlMinutes: 0, timeoutSeconds: 90 },
+      } as never);
 
-    let result: { provider?: string; content?: unknown; citations?: unknown } | undefined;
-    let lastError: unknown;
-    for (let attempt = 0; attempt < 2; attempt += 1) {
-      try {
-        result = await tool?.execute({ query: "OpenClaw GitHub", count: 1 });
-        lastError = undefined;
-        break;
-      } catch (error) {
-        lastError = error;
-        if (!isTransientGeminiSearchError(error) || attempt === 1) {
-          throw error;
+      let result:
+        | { provider?: string; model?: string; content?: unknown; citations?: unknown }
+        | undefined;
+      let lastError: unknown;
+      for (let attempt = 0; attempt < 2; attempt += 1) {
+        try {
+          result = await tool?.execute({ query: "OpenClaw GitHub", count: 1 });
+          lastError = undefined;
+          break;
+        } catch (error) {
+          lastError = error;
+          if (!isTransientGeminiSearchError(error) || attempt === 1) {
+            throw error;
+          }
         }
       }
-    }
-    if (lastError) {
-      throw toLintErrorObject(lastError, "Non-Error thrown");
-    }
+      if (lastError) {
+        throw toLintErrorObject(lastError, "Non-Error thrown");
+      }
 
-    expect(result?.provider).toBe("gemini");
-    expect(typeof result?.content).toBe("string");
-    expect((result!.content as string).length).toBeGreaterThan(20);
-    expect(Array.isArray(result?.citations)).toBe(true);
-  }, 120_000);
+      expect(result?.provider).toBe("gemini");
+      expect(result?.model).toBe(model ?? "gemini-3.6-flash");
+      expect(typeof result?.content).toBe("string");
+      expect((result!.content as string).length).toBeGreaterThan(20);
+      expect(Array.isArray(result?.citations)).toBe(true);
+      expect((result!.citations as unknown[]).length).toBeGreaterThan(0);
+    },
+    120_000,
+  );
 
   it("runs Gemini web search through the Google model provider config fallback", async () => {
     await withGoogleApiEnvUnset(async () => {
@@ -536,6 +550,7 @@ describeLive("google plugin live", () => {
       expect(process.env.GEMINI_API_KEY).toBeUndefined();
       expect(process.env.GOOGLE_API_KEY).toBeUndefined();
       expect(result?.provider).toBe("gemini");
+      expect(result?.model).toBe("gemini-3.6-flash");
       expect(typeof result?.content).toBe("string");
       expect((result!.content as string).length).toBeGreaterThan(20);
       expect(Array.isArray(result?.citations)).toBe(true);

--- a/extensions/google/src/gemini-web-search-provider.shared.ts
+++ b/extensions/google/src/gemini-web-search-provider.shared.ts
@@ -5,7 +5,7 @@ import {
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { normalizeGoogleApiBaseUrl } from "./google-api-base-url.js";
 
-const DEFAULT_GEMINI_WEB_SEARCH_MODEL = "gemini-2.5-flash";
+const DEFAULT_GEMINI_WEB_SEARCH_MODEL = "gemini-flash-latest";
 
 export type GeminiConfig = {
   apiKey?: unknown;

--- a/extensions/google/src/gemini-web-search-provider.shared.ts
+++ b/extensions/google/src/gemini-web-search-provider.shared.ts
@@ -5,7 +5,7 @@ import {
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { normalizeGoogleApiBaseUrl } from "./google-api-base-url.js";
 
-const DEFAULT_GEMINI_WEB_SEARCH_MODEL = "gemini-flash-latest";
+const DEFAULT_GEMINI_WEB_SEARCH_MODEL = "gemini-3.6-flash";
 
 export type GeminiConfig = {
   apiKey?: unknown;

--- a/extensions/google/web-search-provider.test.ts
+++ b/extensions/google/web-search-provider.test.ts
@@ -138,7 +138,7 @@ describe("google web search provider", () => {
     await tool?.execute({ query: "OpenClaw docs" });
 
     expect(getGeminiFetchUrl(mockFetch)).toBe(
-      "https://generativelanguage.googleapis.com/proxy/v1beta/models/gemini-2.5-flash:generateContent",
+      "https://generativelanguage.googleapis.com/proxy/v1beta/models/gemini-flash-latest:generateContent",
     );
   });
 
@@ -184,7 +184,7 @@ describe("google web search provider", () => {
 
     expect(result).toMatchObject({
       citations: [],
-      model: "gemini-2.5-flash",
+      model: "gemini-flash-latest",
       provider: "gemini",
     });
     expect(String(result?.content)).toContain("Today's date is Sunday, June 7, 2026.");
@@ -387,7 +387,7 @@ describe("google web search provider", () => {
     await tool?.execute({ query: "OpenClaw provider baseUrl fallback" });
 
     expect(getGeminiFetchUrl(mockFetch)).toBe(
-      "https://generativelanguage.googleapis.com/provider/v1beta/models/gemini-2.5-flash:generateContent",
+      "https://generativelanguage.googleapis.com/provider/v1beta/models/gemini-flash-latest:generateContent",
     );
   });
 
@@ -422,7 +422,7 @@ describe("google web search provider", () => {
     await tool?.execute({ query: "OpenClaw plugin baseUrl precedence" });
 
     expect(getGeminiFetchUrl(mockFetch)).toBe(
-      "https://generativelanguage.googleapis.com/plugin/v1beta/models/gemini-2.5-flash:generateContent",
+      "https://generativelanguage.googleapis.com/plugin/v1beta/models/gemini-flash-latest:generateContent",
     );
   });
 

--- a/extensions/google/web-search-provider.test.ts
+++ b/extensions/google/web-search-provider.test.ts
@@ -177,7 +177,7 @@ describe("google web search provider", () => {
     await tool?.execute({ query: "OpenClaw docs" });
 
     expect(getGeminiFetchUrl(mockFetch)).toBe(
-      "https://generativelanguage.googleapis.com/proxy/v1beta/models/gemini-2.5-flash:generateContent",
+      "https://generativelanguage.googleapis.com/proxy/v1beta/models/gemini-flash-latest:generateContent",
     );
   });
 
@@ -395,7 +395,7 @@ describe("google web search provider", () => {
 
     expect(result).toMatchObject({
       citations: [],
-      model: "gemini-2.5-flash",
+      model: "gemini-flash-latest",
       provider: "gemini",
     });
     expect(String(result?.content)).toContain("Today's date is Sunday, June 7, 2026.");
@@ -676,7 +676,7 @@ describe("google web search provider", () => {
     await tool?.execute({ query: "OpenClaw provider baseUrl fallback" });
 
     expect(getGeminiFetchUrl(mockFetch)).toBe(
-      "https://generativelanguage.googleapis.com/provider/v1beta/models/gemini-2.5-flash:generateContent",
+      "https://generativelanguage.googleapis.com/provider/v1beta/models/gemini-flash-latest:generateContent",
     );
   });
 
@@ -711,7 +711,7 @@ describe("google web search provider", () => {
     await tool?.execute({ query: "OpenClaw plugin baseUrl precedence" });
 
     expect(getGeminiFetchUrl(mockFetch)).toBe(
-      "https://generativelanguage.googleapis.com/plugin/v1beta/models/gemini-2.5-flash:generateContent",
+      "https://generativelanguage.googleapis.com/plugin/v1beta/models/gemini-flash-latest:generateContent",
     );
   });
 

--- a/extensions/google/web-search-provider.test.ts
+++ b/extensions/google/web-search-provider.test.ts
@@ -177,8 +177,42 @@ describe("google web search provider", () => {
     await tool?.execute({ query: "OpenClaw docs" });
 
     expect(getGeminiFetchUrl(mockFetch)).toBe(
-      "https://generativelanguage.googleapis.com/proxy/v1beta/models/gemini-flash-latest:generateContent",
+      "https://generativelanguage.googleapis.com/proxy/v1beta/models/gemini-3.6-flash:generateContent",
     );
+  });
+
+  it.each([
+    [undefined, "gemini-3.6-flash"],
+    ["", "gemini-3.6-flash"],
+    ["  ", "gemini-3.6-flash"],
+    ["gemini-2.5-flash", "gemini-2.5-flash"],
+    [" gemini-3.5-flash ", "gemini-3.5-flash"],
+  ])("selects model %j as %s through plugin config", async (model, expectedModel) => {
+    const mockFetch = installGeminiFetch();
+    const options = createGeminiToolOptions();
+    const tool = createGeminiWebSearchProvider().createTool({
+      ...options,
+      config: {
+        plugins: {
+          entries: {
+            google: {
+              config: {
+                webSearch: { ...options.config.plugins.entries.google.config.webSearch, model },
+              },
+            },
+          },
+        },
+      },
+      searchConfig: { provider: "gemini", cacheTtlMinutes: 0 },
+    });
+
+    const result = await tool?.execute({ query: "OpenClaw model selection" });
+
+    expect(getGeminiFetchUrl(mockFetch)).toBe(
+      `https://generativelanguage.googleapis.com/v1beta/models/${expectedModel}:generateContent`,
+    );
+    expect(result).toMatchObject({ provider: "gemini", model: expectedModel });
+    expect(parseGeminiFetchBody(mockFetch).tools).toEqual([{ google_search: {} }]);
   });
 
   it("sends operator headers while keeping provider-owned headers authoritative", async () => {
@@ -395,7 +429,7 @@ describe("google web search provider", () => {
 
     expect(result).toMatchObject({
       citations: [],
-      model: "gemini-flash-latest",
+      model: "gemini-3.6-flash",
       provider: "gemini",
     });
     expect(String(result?.content)).toContain("Today's date is Sunday, June 7, 2026.");
@@ -676,7 +710,7 @@ describe("google web search provider", () => {
     await tool?.execute({ query: "OpenClaw provider baseUrl fallback" });
 
     expect(getGeminiFetchUrl(mockFetch)).toBe(
-      "https://generativelanguage.googleapis.com/provider/v1beta/models/gemini-flash-latest:generateContent",
+      "https://generativelanguage.googleapis.com/provider/v1beta/models/gemini-3.6-flash:generateContent",
     );
   });
 
@@ -711,7 +745,7 @@ describe("google web search provider", () => {
     await tool?.execute({ query: "OpenClaw plugin baseUrl precedence" });
 
     expect(getGeminiFetchUrl(mockFetch)).toBe(
-      "https://generativelanguage.googleapis.com/plugin/v1beta/models/gemini-flash-latest:generateContent",
+      "https://generativelanguage.googleapis.com/plugin/v1beta/models/gemini-3.6-flash:generateContent",
     );
   });
 


### PR DESCRIPTION
Fixes https://github.com/openclaw/openclaw/issues/96974

## What Problem This Solves

Fixes an issue where new Gemini API-key users receive a model-not-found error from `web_search` when no search model is configured. Google restricts Gemini 2.5 Flash to previously active users; it has not been retired for everyone.

## Why This Change Was Made

Use the stable `gemini-3.6-flash` default in the Google plugin. Preserve explicit `plugins.entries.google.config.webSearch.model` selections, including existing 2.5 pins. Maintainer review selected a stable model instead of the original rolling alias so preview changes cannot silently change the default.

This updates the search guides and tests the public provider's request model, result model, grounding payload, and credential fallback. Thanks @dillona for the original fix and @anguslogan01 for the report.

## User Impact

Unconfigured Gemini searches use a supported grounding model. Explicit pins remain unchanged and must be available to the API key. Gemini 3 grounding bills per search query; Gemini 2.5 bills per prompt. See [Google's pricing contract](https://ai.google.dev/gemini-api/docs/google-search#pricing) and [Gemini 3.6 Flash capabilities](https://ai.google.dev/gemini-api/docs/models/gemini-3.6-flash).

## Evidence

- Blacksmith Testbox [34462536723](https://github.com/openclaw/openclaw/actions/runs/34462536723), Linux Node 24.19.0: `node scripts/run-vitest.mjs extensions/google/web-search-provider.test.ts -t 'selects model'` fails the three unset/empty/blank cases with the former 2.5 default while both explicit pins pass. Restoring the candidate then running the complete provider file passes **77/77 tests**.
- Independent source review: no findings. Fresh autoreview: no actionable P0-P2 findings. Targeted formatting and `git diff --check` pass.
- Authenticated production-provider proof on exact head `b1b84eabf837eb394af4048b6c585302f424db1a`: Blacksmith Testbox [34462915360](https://github.com/openclaw/openclaw/actions/runs/34462915360), Linux Node 24.19.0. `openclaw-testbox-env pnpm test:live -- extensions/google/google.live.test.ts -t 'runs Gemini web search' --reporter=dot` passed **3/3 selected tests** in 55.55s (8 unrelated model/media/voice tests not selected). No model override selected `gemini-3.6-flash`; explicit `gemini-3.5-flash` remained pinned; the Google model-provider key fallback selected `gemini-3.6-flash`. All three returned answer text over 20 characters and at least one citation. Full commit identity and source hashes were verified before execution; credentials came from the existing hydrated helper and were not printed.
- Exact-head [CI 34462907998](https://github.com/openclaw/openclaw/actions/runs/34462907998), attempt 1: **114 jobs passed, 16 skipped, zero failures**. [ClawSweeper](https://github.com/openclaw/openclaw/pull/111964#issuecomment-5030153018) reviewed this head and accepted the live proof: no actionable findings or remaining rank-up moves. [Completed production proof](https://github.com/openclaw/openclaw/pull/111964#issuecomment-5616743002).

Production LOC: +1/-1 (net 0). Tests: +80/-31. Docs: +9/-5. No runtime fallback, config schema, or migration changes.

Follow-up outside this fix: audit the separate Google text-model catalog's suppressed-model guidance for Gemini 2.5 availability.
