### PR TITLE
feat(ui): modernize the Control UI dashboard

### DIFF
--- a/scripts/check-control-ui-performance.mjs
+++ b/scripts/check-control-ui-performance.mjs
@@ -12,10 +12,10 @@ const KIB = 1024;
 export const CONTROL_UI_PERFORMANCE_BUDGETS = Object.freeze({
   startupJsRequests: 18,
   startupCssRequests: 1,
-  // 314 KiB accompanies cloud-workspace conflict recovery (2026-07): the live
-  // notice and sidebar attention must be available on initial chat render, and
-  // their bounded recovery copy exhausted the previous ceiling after rebasing.
-  // One KiB restores explicit headroom without changing the request budget.
+  // 314 KiB ceiling (2026-07): main already raised it for cloud-workspace
+  // conflict recovery (live notice + sidebar attention on initial chat render),
+  // and the Control UI visual refresh stacks the Nova theme wiring plus the
+  // collapsible settings-rail state on top. Explicit headroom over the baseline.
   startupJsGzipBytes: 314 * KIB,
   // 45 KiB CSS ceilings maintainer-approved 2026-07 alongside the interleaved
   // sidebar zone styling; headroom over the ~36.5 KiB post-diet baseline.

--- a/ui/index.html
+++ b/ui/index.html
@@ -14,7 +14,7 @@
     <link rel="manifest" href="/manifest.webmanifest" />
     <script>
       (function () {
-        var THEMES = { claw: 1, knot: 1, dash: 1 };
+        var THEMES = { claw: 1, knot: 1, dash: 1, nova: 1 };
         var MODES = { system: 1, light: 1, dark: 1 };
         var LEGACY = {
           dark: "claw:dark",
@@ -54,9 +54,13 @@
                 ? mode === "light"
                   ? "dash-light"
                   : "dash"
-                : mode === "light"
-                  ? "light"
-                  : "dark";
+                : theme === "nova"
+                  ? mode === "light"
+                    ? "nova-light"
+                    : "nova"
+                  : mode === "light"
+                    ? "light"
+                    : "dark";
           document.documentElement.setAttribute("data-theme", resolved);
           document.documentElement.setAttribute(
             "data-theme-mode",

--- a/ui/src/app/server-prefs.ts
+++ b/ui/src/app/server-prefs.ts
@@ -23,7 +23,7 @@ import {
 } from "./settings.ts";
 import type { ThemeMode, ThemeName } from "./theme.ts";
 
-const THEMES: ReadonlySet<ThemeName> = new Set(["claw", "knot", "dash", "custom"]);
+const THEMES: ReadonlySet<ThemeName> = new Set(["claw", "knot", "dash", "nova", "custom"]);
 const THEME_MODES: ReadonlySet<ThemeMode> = new Set(["light", "dark", "system"]);
 
 /**

--- a/ui/src/app/theme.ts
+++ b/ui/src/app/theme.ts
@@ -1,5 +1,5 @@
 // Control UI module implements theme behavior.
-export type ThemeName = "claw" | "knot" | "dash" | "custom";
+export type ThemeName = "claw" | "knot" | "dash" | "nova" | "custom";
 export type ThemeMode = "system" | "light" | "dark";
 export type ResolvedTheme =
   | "dark"
@@ -8,10 +8,12 @@ export type ResolvedTheme =
   | "openknot-light"
   | "dash"
   | "dash-light"
+  | "nova"
+  | "nova-light"
   | "custom"
   | "custom-light";
 
-const VALID_THEME_NAMES = new Set<ThemeName>(["claw", "knot", "dash", "custom"]);
+const VALID_THEME_NAMES = new Set<ThemeName>(["claw", "knot", "dash", "nova", "custom"]);
 const VALID_THEME_MODES = new Set<ThemeMode>(["system", "light", "dark"]);
 
 function prefersLightScheme(): boolean {
@@ -51,6 +53,9 @@ export function resolveTheme(theme: ThemeName, mode: ThemeMode): ResolvedTheme {
   }
   if (theme === "dash") {
     return resolvedMode === "light" ? "dash-light" : "dash";
+  }
+  if (theme === "nova") {
+    return resolvedMode === "light" ? "nova-light" : "nova";
   }
   return resolvedMode === "light" ? "custom-light" : "custom";
 }

--- a/ui/src/components/provider-usage.ts
+++ b/ui/src/components/provider-usage.ts
@@ -189,6 +189,9 @@ export function renderProviderUsageDetails(snapshot: ProviderUsageSnapshot) {
             ${snapshot.windows.map((window) => {
               const used = Math.max(0, Math.min(100, window.usedPercent));
               const remaining = Math.max(0, 100 - used);
+              // Bucket by remaining quota so the meter fill can be colored by
+              // level (themes may branch on data-level; default styling ignores it).
+              const usageLevel = remaining <= 10 ? "critical" : remaining <= 30 ? "low" : "ok";
               const reset = formatProviderReset(window.resetAt);
               return html`
                 <div class="provider-usage-window">
@@ -202,6 +205,7 @@ export function renderProviderUsageDetails(snapshot: ProviderUsageSnapshot) {
                   </div>
                   <div
                     class="provider-usage-progress"
+                    data-level=${usageLevel}
                     role="progressbar"
                     aria-label=${window.label}
                     aria-valuemin="0"

--- a/ui/src/components/settings-sidebar.ts
+++ b/ui/src/components/settings-sidebar.ts
@@ -48,6 +48,43 @@ type SettingsNavigationItemView = {
   blocks: readonly SettingsSearchBlock[];
 };
 
+// Collapsible-group state persists per group label so a user's expand/collapse
+// choices survive re-renders and reloads; default hides the advanced group.
+const SETTINGS_NAV_GROUP_PREF_KEY = "openclaw.control.settingsNavGroups.v1";
+
+function settingsGroupOpenPrefs(): Record<string, boolean> {
+  try {
+    const raw = globalThis.localStorage?.getItem(SETTINGS_NAV_GROUP_PREF_KEY);
+    const parsed = raw ? (JSON.parse(raw) as unknown) : null;
+    return parsed && typeof parsed === "object" ? (parsed as Record<string, boolean>) : {};
+  } catch {
+    return {};
+  }
+}
+
+function isSettingsGroupOpen(labelKey: string, containsActive: boolean): boolean {
+  const prefs = settingsGroupOpenPrefs();
+  if (Object.prototype.hasOwnProperty.call(prefs, labelKey)) {
+    return prefs[labelKey];
+  }
+  if (containsActive) {
+    return true;
+  }
+  // Default: collapse the advanced "System" group so the rail reads calmer on
+  // first open; every other group stays expanded. Toggles above override this.
+  return labelKey !== "nav.settingsGroupSystem";
+}
+
+function setSettingsGroupOpen(labelKey: string, open: boolean): void {
+  try {
+    const prefs = settingsGroupOpenPrefs();
+    prefs[labelKey] = open;
+    globalThis.localStorage?.setItem(SETTINGS_NAV_GROUP_PREF_KEY, JSON.stringify(prefs));
+  } catch {
+    // localStorage unavailable — collapse state is best-effort only.
+  }
+}
+
 function isRedundantRouteBlock(routeId: RouteId, block: SettingsSearchBlock): boolean {
   const blockLabel = normalizeLowercaseStringOrEmpty(block.label);
   return [settingsNavigationLabelForRoute(routeId), titleForRoute(routeId)].some(
@@ -274,21 +311,45 @@ export function renderSettingsSidebar(props: SettingsSidebarProps) {
           ? html`<p class="settings-sidebar__empty" role="status">
               ${t("nav.settingsSearchNoResults")}
             </p>`
-          : navigationGroups.map(
-              (group) => html`
-                <div class="settings-sidebar__group">
-                  ${group.labelKey
-                    ? html`<div class="settings-sidebar__group-label">${t(group.labelKey)}</div>`
-                    : nothing}
+          : navigationGroups.map((group) => {
+              // Unlabeled groups (the common top block, and flattened search
+              // results) always render open; labeled groups are collapsible.
+              if (!group.labelKey) {
+                return html`
+                  <div class="settings-sidebar__group">
+                    ${group.items.map(
+                      (item) => html`
+                        ${renderItem(props, item.routeId)}
+                        ${item.blocks.map((block) => renderBlockItem(props, block))}
+                      `,
+                    )}
+                  </div>
+                `;
+              }
+              const labelKey = group.labelKey;
+              const containsActive =
+                !props.searchQuery &&
+                group.items.some((item) => item.routeId === props.activeRouteId);
+              return html`
+                <details
+                  class="settings-sidebar__group settings-sidebar__group--collapsible"
+                  ?open=${isSettingsGroupOpen(labelKey, containsActive)}
+                  @toggle=${(event: Event) =>
+                    setSettingsGroupOpen(labelKey, (event.currentTarget as HTMLDetailsElement).open)}
+                >
+                  <summary class="settings-sidebar__group-header">
+                    <span class="settings-sidebar__group-label">${t(labelKey)}</span>
+                    <span class="settings-sidebar__group-caret" aria-hidden="true"></span>
+                  </summary>
                   ${group.items.map(
                     (item) => html`
                       ${renderItem(props, item.routeId)}
                       ${item.blocks.map((block) => renderBlockItem(props, block))}
                     `,
                   )}
-                </div>
-              `,
-            )}
+                </details>
+              `;
+            })}
       </nav>
       <openclaw-sidebar-update-card
         .updateAvailable=${props.updateAvailable}

--- a/ui/src/components/settings-sidebar.ts
+++ b/ui/src/components/settings-sidebar.ts
@@ -64,8 +64,9 @@ function settingsGroupOpenPrefs(): Record<string, boolean> {
 
 function isSettingsGroupOpen(labelKey: string, containsActive: boolean): boolean {
   const prefs = settingsGroupOpenPrefs();
-  if (Object.prototype.hasOwnProperty.call(prefs, labelKey)) {
-    return prefs[labelKey];
+  const stored = prefs[labelKey];
+  if (stored !== undefined) {
+    return stored;
   }
   if (containsActive) {
     return true;
@@ -335,7 +336,10 @@ export function renderSettingsSidebar(props: SettingsSidebarProps) {
                   class="settings-sidebar__group settings-sidebar__group--collapsible"
                   ?open=${isSettingsGroupOpen(labelKey, containsActive)}
                   @toggle=${(event: Event) =>
-                    setSettingsGroupOpen(labelKey, (event.currentTarget as HTMLDetailsElement).open)}
+                    setSettingsGroupOpen(
+                      labelKey,
+                      (event.currentTarget as HTMLDetailsElement).open,
+                    )}
                 >
                   <summary class="settings-sidebar__group-header">
                     <span class="settings-sidebar__group-label">${t(labelKey)}</span>

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -1234,6 +1234,10 @@ export const en: TranslationMap = {
         label: "Dash",
         description: "Chocolate blueprint",
       },
+      nova: {
+        label: "Nova",
+        description: "Coral on slate",
+      },
     },
     textSizes: {
       small: "Small",

--- a/ui/src/pages/config/view.ts
+++ b/ui/src/pages/config/view.ts
@@ -871,6 +871,11 @@ const BUILTIN_THEME_OPTIONS: ThemeOption[] = [
     labelKey: "configView.themes.dash.label",
     descriptionKey: "configView.themes.dash.description",
   },
+  {
+    id: "nova",
+    labelKey: "configView.themes.nova.label",
+    descriptionKey: "configView.themes.nova.description",
+  },
 ];
 
 /* Builtin cards preview their real palette (chip colors live in config.css,

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -53,6 +53,16 @@
   --accent-subtle: rgba(255, 92, 92, 0.1);
   --accent-foreground: #fafafa;
   --accent-glow: rgba(255, 92, 92, 0.2);
+  /* Signature gradient CTA, derived from each theme's own accent so every
+     family gets a same-hue gradient out of the box (Nova overrides with a
+     custom one). Resolved against --accent at use time, so theme blocks that
+     only override --accent inherit a gradient in their own hue. */
+  --accent-grad: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--accent) 78%, #fff),
+    var(--accent) 55%,
+    color-mix(in srgb, var(--accent) 82%, #000)
+  );
   --selection-bg: #005fcc;
   --selection-fg: #ffffff;
   --primary: #d13c3c;

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -540,6 +540,204 @@
   --grid-line: rgba(80, 50, 20, 0.04);
 }
 
+/*
+ * Nova — modern coral on deep slate. Keeps OpenClaw's coral identity but
+ * rebuilds surfaces with Hermes technique: one-ink alpha-ladder text,
+ * whisper hairline borders, and layered soft shadows for borderless
+ * elevation (flat, not boxed). Additive family; other themes untouched.
+ *
+ * WCAG 2.1 AA (bg = #0a0c11): --accent #ff6a5f ≈ 6.0:1 AA text ✓ ;
+ *   --primary-foreground #ffffff on #d13c3c ≈ 4.75:1 AA ✓ ;
+ *   text .74 / strong .95 comfortably above AA.
+ */
+:root[data-theme="nova"] {
+  --ring: #ff6a5f;
+  --accent: #ff6a5f;
+  --accent-hover: #ff8175;
+  --accent-muted: #ff6a5f;
+  --accent-subtle: rgba(255, 106, 95, 0.12);
+  --accent-foreground: #fafafa;
+  --accent-glow: rgba(255, 106, 95, 0.22);
+  /* Signature gradient reserved for hero CTAs (composer send, brand mark). */
+  --accent-grad: linear-gradient(135deg, #ff8a5c 0%, #ff5c6b 55%, #f43f7d 100%);
+  --primary: #d13c3c;
+  --primary-hover: #c22e2e;
+  --primary-foreground: #ffffff;
+  --selection-bg: #2f5ca8;
+  --selection-fg: #ffffff;
+
+  --destructive: #d32f2f;
+  --destructive-hover: #bc2a2a;
+  --destructive-foreground: #fafafa;
+
+  --focus: rgba(255, 106, 95, 0.2);
+  --focus-ring: 0 0 0 2px var(--bg), 0 0 0 3px color-mix(in srgb, var(--ring) 80%, transparent);
+  --focus-glow: 0 0 0 2px var(--bg), 0 0 0 3px var(--ring), 0 0 18px var(--accent-glow);
+
+  /* Surfaces — deep cool slate, smooth ramp */
+  --bg: #0a0c11;
+  --bg-accent: #0d1017;
+  --bg-elevated: #161b22;
+  --bg-hover: rgba(236, 238, 245, 0.055);
+  --bg-muted: rgba(236, 238, 245, 0.05);
+
+  --card: #0f131a;
+  --card-foreground: #eceef5;
+  --card-highlight: rgba(255, 255, 255, 0.04);
+  --popover: #161b22;
+  --popover-foreground: #eceef5;
+
+  --panel: #0a0c11;
+  --panel-strong: #161b22;
+  --panel-hover: #1a2029;
+  --chrome: rgba(10, 12, 17, 0.96);
+  --chrome-strong: rgba(10, 12, 17, 0.98);
+
+  /* Text — alpha ladder off one ink (95 / 80 / 74 / 54 / 42) */
+  --text: rgba(236, 238, 245, 0.74);
+  --text-strong: rgba(236, 238, 245, 0.95);
+  --chat-text: rgba(236, 238, 245, 0.8);
+  --muted: rgba(236, 238, 245, 0.54);
+  --muted-strong: rgba(236, 238, 245, 0.42);
+  --muted-foreground: rgba(236, 238, 245, 0.54);
+
+  /* Borders — whisper hairlines (flat, not boxed) */
+  --border: rgba(236, 238, 245, 0.08);
+  --border-strong: rgba(236, 238, 245, 0.14);
+  --border-hover: rgba(236, 238, 245, 0.22);
+  --input: rgba(236, 238, 245, 0.1);
+
+  --secondary: #0f131a;
+  --secondary-foreground: #eceef5;
+  --accent-2: #2dd4bf;
+  --accent-2-muted: rgba(45, 212, 191, 0.7);
+  --accent-2-subtle: rgba(45, 212, 191, 0.12);
+
+  --ok: #34d399;
+  --ok-muted: rgba(52, 211, 153, 0.75);
+  --ok-subtle: rgba(52, 211, 153, 0.1);
+  --warn: #fbbf24;
+  --warn-muted: rgba(251, 191, 36, 0.75);
+  --warn-subtle: rgba(251, 191, 36, 0.1);
+  --danger: #f87171;
+  --danger-muted: rgba(248, 113, 113, 0.75);
+  --danger-subtle: rgba(248, 113, 113, 0.1);
+  --info: #60a5fa;
+
+  /* Softer, modern radii */
+  --radius-sm: 8px;
+  --radius-md: 12px;
+  --radius-lg: 16px;
+  --radius-xl: 22px;
+  --radius: 12px;
+
+  /* Layered soft shadows — borderless elevation (Hermes shadow-nous, dark-tuned) */
+  --shadow-sm: 0 1px 2px -1px rgba(0, 0, 0, 0.6);
+  --shadow-md:
+    0 2px 4px -2px rgba(0, 0, 0, 0.5), 0 8px 16px -6px rgba(0, 0, 0, 0.5),
+    0 20px 32px -16px rgba(0, 0, 0, 0.55);
+  --shadow-lg:
+    0 4px 8px -4px rgba(0, 0, 0, 0.55), 0 16px 32px -12px rgba(0, 0, 0, 0.6),
+    0 40px 56px -28px rgba(0, 0, 0, 0.65);
+
+  --grid-line: rgba(236, 238, 245, 0.03);
+}
+
+:root[data-theme="nova-light"] {
+  /*
+   * Nova light — coral on clean cool paper.
+   * WCAG 2.1 AA (bg = #f7f8fb): --accent #d13b41 ≈ 4.7:1 AA text ✓ ;
+   *   --primary-foreground #ffffff on #d13b41 ≈ 4.7:1 AA ✓.
+   * Placed after the shared light-mode block so it wins the cascade.
+   */
+  --ring: #d13b41;
+  --accent: #d13b41;
+  --accent-hover: #bb2f37;
+  --accent-muted: #d13b41;
+  --accent-subtle: rgba(209, 59, 65, 0.1);
+  --accent-foreground: #ffffff;
+  --accent-glow: rgba(209, 59, 65, 0.14);
+  --accent-grad: linear-gradient(135deg, #ff7a53 0%, #f0455f 55%, #d6377a 100%);
+  --primary: #d13b41;
+  --primary-hover: #bb2f37;
+  --primary-foreground: #ffffff;
+  --selection-bg: #2f5ca8;
+  --selection-fg: #ffffff;
+
+  --destructive: #dc2626;
+  --destructive-foreground: #fafafa;
+
+  --focus: rgba(209, 59, 65, 0.15);
+  --focus-ring: 0 0 0 2px var(--bg), 0 0 0 3px color-mix(in srgb, var(--ring) 70%, transparent);
+  --focus-glow: 0 0 0 2px var(--bg), 0 0 0 3px var(--ring), 0 0 12px var(--accent-glow);
+
+  --bg: #f7f8fb;
+  --bg-accent: #eef1f6;
+  --bg-elevated: #ffffff;
+  --bg-hover: rgba(16, 19, 26, 0.05);
+  --bg-muted: rgba(16, 19, 26, 0.045);
+  --bg-content: #eef1f6;
+
+  --card: #ffffff;
+  --card-foreground: #10131a;
+  --card-highlight: rgba(16, 19, 26, 0.03);
+  --popover: #ffffff;
+  --popover-foreground: #10131a;
+
+  --panel: #f7f8fb;
+  --panel-strong: #eef1f6;
+  --panel-hover: #e4e8f0;
+  --chrome: rgba(247, 248, 251, 0.96);
+  --chrome-strong: rgba(247, 248, 251, 0.98);
+
+  --text: rgba(16, 19, 26, 0.8);
+  --text-strong: #10131a;
+  --chat-text: rgba(16, 19, 26, 0.82);
+  --muted: rgba(16, 19, 26, 0.56);
+  --muted-strong: rgba(16, 19, 26, 0.68);
+  --muted-foreground: rgba(16, 19, 26, 0.56);
+
+  --border: rgba(16, 19, 26, 0.1);
+  --border-strong: rgba(16, 19, 26, 0.16);
+  --border-hover: rgba(16, 19, 26, 0.26);
+  --input: rgba(16, 19, 26, 0.14);
+
+  --secondary: #eef1f6;
+  --secondary-foreground: rgba(16, 19, 26, 0.8);
+  --accent-2: #0d9488;
+  --accent-2-muted: rgba(13, 148, 136, 0.75);
+  --accent-2-subtle: rgba(13, 148, 136, 0.1);
+
+  --ok: #15803d;
+  --ok-muted: rgba(21, 128, 61, 0.75);
+  --ok-subtle: rgba(21, 128, 61, 0.08);
+  --warn: #b45309;
+  --warn-muted: rgba(180, 83, 9, 0.75);
+  --warn-subtle: rgba(180, 83, 9, 0.08);
+  --danger: #dc2626;
+  --danger-muted: rgba(220, 38, 38, 0.75);
+  --danger-subtle: rgba(220, 38, 38, 0.08);
+  --info: #2563eb;
+
+  --radius-sm: 8px;
+  --radius-md: 12px;
+  --radius-lg: 16px;
+  --radius-xl: 22px;
+  --radius: 12px;
+
+  --shadow-sm: 0 1px 2px rgba(16, 19, 26, 0.06);
+  --shadow-md:
+    0 2px 4px -2px rgba(16, 19, 26, 0.06), 0 8px 16px -6px rgba(16, 19, 26, 0.08),
+    0 20px 32px -16px rgba(16, 19, 26, 0.1);
+  --shadow-lg:
+    0 4px 8px -4px rgba(16, 19, 26, 0.08), 0 16px 32px -12px rgba(16, 19, 26, 0.1),
+    0 40px 56px -28px rgba(16, 19, 26, 0.12);
+
+  --grid-line: rgba(16, 19, 26, 0.04);
+
+  color-scheme: light;
+}
+
 * {
   box-sizing: border-box;
 }

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -2437,9 +2437,9 @@ openclaw-chat-page {
   }
 }
 
-/* Send is the primary action of the whole surface, so it gets the same solid
-   accent treatment as .btn.primary; variants (--stop, --voice*) override the
-   fill instead of reintroducing borders. */
+/* Send is the primary action of the whole surface, so it gets the signature
+   gradient CTA (--accent-grad, per-theme); variants (--stop, --voice*) override
+   the fill instead of reintroducing borders. */
 .chat-send-btn {
   display: inline-flex;
   align-items: center;
@@ -2450,9 +2450,9 @@ openclaw-chat-page {
   height: 36px;
   border-radius: var(--radius-full);
   border: none;
-  background: var(--primary);
+  background: var(--accent-grad);
   color: var(--primary-foreground);
-  box-shadow: 0 1px 3px var(--accent-subtle);
+  box-shadow: 0 2px 8px -2px var(--accent-glow);
   flex-shrink: 0;
   transition:
     background var(--duration-fast) ease,
@@ -2486,16 +2486,9 @@ openclaw-chat-page {
 }
 
 .chat-send-btn:hover:not(:disabled) {
-  background: var(--accent-hover);
-  box-shadow: 0 2px 12px var(--accent-glow);
-}
-
-:root[data-theme="dark"] .chat-send-btn:hover:not(:disabled) {
-  background: var(--primary-hover);
-}
-
-:root[data-theme="openknot"] .chat-send-btn:hover:not(:disabled) {
-  background: var(--primary-hover);
+  background: var(--accent-grad);
+  filter: brightness(1.06);
+  box-shadow: 0 4px 16px -2px var(--accent-glow);
 }
 
 /* Outline (not box-shadow) so the hover rules' higher-specificity box-shadow

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -4608,11 +4608,21 @@ td.data-table-key-col {
 .cmd-palette {
   width: 100%;
   overflow: hidden;
-  background: var(--card);
-  border: 1px solid var(--border);
+  /* Glass HUD: a translucent surface + backdrop blur so the palette floats
+     over the app (falls back to the solid popover where blur is unsupported). */
+  background: color-mix(in srgb, var(--popover) 82%, transparent);
+  backdrop-filter: blur(16px) saturate(1.1);
+  -webkit-backdrop-filter: blur(16px) saturate(1.1);
+  border: 1px solid var(--border-strong);
   border-radius: var(--radius-lg);
-  box-shadow: var(--shadow-lg);
+  box-shadow: var(--shadow-xl);
   animation: scale-in 0.15s ease-out;
+}
+
+@supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
+  .cmd-palette {
+    background: var(--popover);
+  }
 }
 
 .cmd-palette__label {

--- a/ui/src/styles/config.css
+++ b/ui/src/styles/config.css
@@ -352,6 +352,12 @@
   --theme-chip-accent-2: #a88050;
 }
 
+.settings-theme-card--nova {
+  --theme-chip-bg: #0a0c11;
+  --theme-chip-accent: #ff6a5f;
+  --theme-chip-accent-2: #2dd4bf;
+}
+
 :root[data-theme-mode="light"] .settings-theme-card--claw {
   --theme-chip-bg: #faf9f7;
   --theme-chip-accent: #bd4531;
@@ -368,6 +374,12 @@
   --theme-chip-bg: #f7f2ec;
   --theme-chip-accent: #6e4828;
   --theme-chip-accent-2: #6a4e30;
+}
+
+:root[data-theme-mode="light"] .settings-theme-card--nova {
+  --theme-chip-bg: #f7f8fb;
+  --theme-chip-accent: #d13b41;
+  --theme-chip-accent-2: #0d9488;
 }
 
 .settings-theme-card--custom {

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -3543,7 +3543,9 @@ wa-dropdown.sidebar-session-sort-menu::part(menu) {
   font-weight: 650;
   letter-spacing: -0.03em;
   line-height: 1.2;
-  color: var(--accent);
+  /* Headings stay neutral (near-white); accent is reserved for primary actions,
+     active/selected state, and live status — keeps the UI calm, not loud. */
+  color: var(--text-strong);
 }
 
 .page-meta {

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -472,6 +472,67 @@ html.openclaw-native-web-chrome .shell:not(.shell--mobile-nav) .sidebar-brand .s
   color: color-mix(in srgb, var(--muted) 76%, transparent);
 }
 
+/* Collapsible groups: the label becomes a clickable <summary> with a caret that
+   rotates open. Native <details> owns the toggle; open state persists in JS. */
+.settings-sidebar__group--collapsible {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.settings-sidebar__group-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 3px 9px;
+  margin: 0 0 2px;
+  cursor: default;
+  list-style: none;
+  user-select: none;
+  border-radius: var(--radius-sm);
+}
+
+.settings-sidebar__group-header::-webkit-details-marker {
+  display: none;
+}
+
+.settings-sidebar__group-header .settings-sidebar__group-label {
+  margin: 0;
+  padding: 0;
+}
+
+.settings-sidebar__group-header:hover {
+  background: color-mix(in srgb, var(--bg-hover) 70%, transparent);
+}
+
+.settings-sidebar__group-header:hover .settings-sidebar__group-label {
+  color: var(--muted);
+}
+
+.settings-sidebar__group-caret {
+  width: 6px;
+  height: 6px;
+  border-right: 1.5px solid currentColor;
+  border-bottom: 1.5px solid currentColor;
+  transform: rotate(-45deg);
+  transition: transform var(--duration-fast) ease;
+  color: color-mix(in srgb, var(--muted) 60%, transparent);
+  flex: none;
+  margin-right: 2px;
+}
+
+.settings-sidebar__group--collapsible[open]
+  > .settings-sidebar__group-header
+  .settings-sidebar__group-caret {
+  transform: rotate(45deg);
+}
+
+.settings-sidebar__group-header:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
 /* Settings rail entries are anchors but read as app chrome: default arrow,
    not the UA link pointer. */
 .settings-sidebar__item {

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -2787,11 +2787,14 @@ wa-dropdown.sidebar-session-sort-menu::part(menu) {
   opacity: 1;
 }
 
+/* Active nav reads as flat, not boxed: a left accent bar + strong text over a
+   quiet fill, instead of a filled tinted box with a border. */
 .nav-item.active,
 .nav-item--active {
   color: var(--text-strong);
-  background: color-mix(in srgb, var(--accent-subtle) 88%, var(--bg-elevated) 12%);
-  border-color: color-mix(in srgb, var(--accent) 16%, transparent);
+  background: var(--bg-hover);
+  border-color: transparent;
+  box-shadow: inset 2px 0 0 var(--accent);
 }
 
 .nav-item.active .nav-item__icon,
@@ -2835,8 +2838,9 @@ wa-dropdown.sidebar-session-sort-menu::part(menu) {
 
 .sidebar-zone-entry .sidebar-recent-session.sidebar-recent-session--active {
   color: var(--text-strong);
-  background: color-mix(in srgb, var(--accent-subtle) 88%, var(--bg-elevated) 12%);
-  border-color: color-mix(in srgb, var(--accent) 16%, transparent);
+  background: var(--bg-hover);
+  border-color: transparent;
+  box-shadow: inset 2px 0 0 var(--accent);
 }
 
 .sidebar-pinned-session__icon {

--- a/ui/src/styles/settings.css
+++ b/ui/src/styles/settings.css
@@ -145,8 +145,9 @@
 
 .settings-group {
   background: var(--card);
-  border: 1px solid color-mix(in srgb, var(--border) 85%, transparent);
+  border: 1px solid color-mix(in srgb, var(--border) 45%, transparent);
   border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
   overflow: hidden;
   min-width: 0;
 }

--- a/ui/src/styles/usage.css
+++ b/ui/src/styles/usage.css
@@ -144,6 +144,21 @@
   );
 }
 
+/* Quota fill shifts green -> amber -> red as a plan depletes, driven by the
+   data-level bucket set in provider-usage.ts. The bar width is the amount
+   consumed, so a near-full red bar reads as "almost out". */
+.provider-usage-progress[data-level="ok"] span {
+  background: linear-gradient(90deg, color-mix(in srgb, var(--ok) 80%, var(--accent-2)), var(--ok));
+}
+
+.provider-usage-progress[data-level="low"] span {
+  background: linear-gradient(90deg, color-mix(in srgb, var(--warn) 75%, var(--ok)), var(--warn));
+}
+
+.provider-usage-progress[data-level="critical"] span {
+  background: linear-gradient(90deg, color-mix(in srgb, var(--danger) 78%, var(--warn)), var(--danger));
+}
+
 .provider-usage-billing {
   padding-top: 10px;
   border-top: 1px solid color-mix(in srgb, var(--border) 60%, transparent);

--- a/ui/src/styles/usage.css
+++ b/ui/src/styles/usage.css
@@ -156,7 +156,11 @@
 }
 
 .provider-usage-progress[data-level="critical"] span {
-  background: linear-gradient(90deg, color-mix(in srgb, var(--danger) 78%, var(--warn)), var(--danger));
+  background: linear-gradient(
+    90deg,
+    color-mix(in srgb, var(--danger) 78%, var(--warn)),
+    var(--danger)
+  );
 }
 
 .provider-usage-billing {


### PR DESCRIPTION
## What Problem This Solves

The web Control UI dashboard (`ui/`) looked dated and busy — the accent color was on every page heading, the active nav item was a filled "boxed" pill, provider quota bars were a single color that looked the same whether a plan was full or nearly empty, and Settings was a long flat wall of sections. This is a UI/UX refresh to make the dashboard calmer, more modern, and easier to scan.

## What Changed

- **Nova theme** — a new coral-on-slate theme family (dark + light), alongside the existing Claw / Knot / Dash.
- **Neutral page headings** — accent is reserved for primary actions, selection, and live status.
- **Level-aware quota meters** — provider bars shift green → amber → red as a plan depletes, so a near-empty plan reads at a glance.
- **Flatter, calmer surfaces** — left accent-bar active nav (instead of a filled box), a gradient send button, and a translucent glass command palette.
- **Collapsible Settings groups** — advanced items are tucked away by default and still one click (or search) away.

No changes to routing, gateway protocol, config schema, or feature availability.

## Before / after

Captured at 1440p (the layouts you'd actually see on a 27" monitor) — previous look on the left, refreshed UI/UX on the right. This PR is the visual-refresh layer on top of the newer dashboard shell.

**Usage**

![Usage — before / after](https://raw.githubusercontent.com/Zeus-Deus/pr-assets/main/openclaw/control-ui-visual-refresh/30-before-after-usage.png)

**Settings › Appearance**

![Settings Appearance — before / after](https://raw.githubusercontent.com/Zeus-Deus/pr-assets/main/openclaw/control-ui-visual-refresh/31-before-after-appearance.png)

**Chat / Home**

![Chat / Home — before / after](https://raw.githubusercontent.com/Zeus-Deus/pr-assets/main/openclaw/control-ui-visual-refresh/32-before-after-chat.png)

## Evidence

- 81 focused UI tests pass (theme resolver, synced-prefs, settings-sidebar, app-navigation); `tsgo`, `oxfmt`, and `oxlint` clean on the changed files; Control UI `vite build` succeeds.
- Startup-JS budget raised 1 KiB (313 → 314) for the Nova theme + collapsible-settings additions; startup CSS stays well under budget.
