### PR TITLE
fix(ui): select AGENTS.md when agent files open

### DIFF
--- a/ui/src/pages/agents/agents-page.test.ts
+++ b/ui/src/pages/agents/agents-page.test.ts
@@ -20,6 +20,7 @@ type TestAgentsPage = HTMLElement & {
   routeData?: AgentsRouteData;
   agentFilesLoading: boolean;
   agentFilesList: AgentsFilesListResult | null;
+  agentFileActive: string | null;
   agentFileContents: Record<string, string>;
   agentIdentityLoading: boolean;
   agentsPanel: string;
@@ -242,6 +243,52 @@ describe("AgentsPage gateway lifecycle", () => {
     await replacementLoad;
     expect(page.agentFilesList?.workspace).toBe("new");
     expect(page.agentFilesLoading).toBe(false);
+  });
+
+  it("selects and loads AGENTS.md when the file list opens", async () => {
+    const fileList: AgentsFilesListResult = {
+      agentId: "main",
+      workspace: "/tmp/workspace",
+      files: [
+        {
+          name: "AGENTS.md",
+          path: "/tmp/workspace/AGENTS.md",
+          missing: false,
+        },
+        {
+          name: "SOUL.md",
+          path: "/tmp/workspace/SOUL.md",
+          missing: false,
+        },
+      ],
+    };
+    const request = vi.fn(async () => ({
+      file: {
+        ...fileList.files[0],
+        content: "# Instructions",
+      },
+    }));
+    const client = { request } as unknown as GatewayBrowserClient;
+    const page = document.createElement("openclaw-agents-page") as TestAgentsPage;
+    page.client = client;
+    page.connected = true;
+    page.agentsSelectedId = "main";
+    page.context = {
+      agents: {
+        files: () => ({ list: null, loading: false, error: null }),
+        ensureFiles: vi.fn(async () => fileList),
+        refreshFiles: vi.fn(async () => fileList),
+      },
+    } as unknown as ApplicationContext;
+
+    await page.loadAgentFiles("main");
+
+    expect(page.agentFileActive).toBe("AGENTS.md");
+    expect(page.agentFileContents["AGENTS.md"]).toBe("# Instructions");
+    expect(request).toHaveBeenCalledWith("agents.files.get", {
+      agentId: "main",
+      name: "AGENTS.md",
+    });
   });
 
   it("retries an in-flight panel load after a same-client disconnect", async () => {

--- a/ui/src/pages/agents/agents-page.ts
+++ b/ui/src/pages/agents/agents-page.ts
@@ -316,11 +316,17 @@ class AgentsPage extends OpenClawLightDomElement implements AgentsState {
     }
     this.agentFilesList = status.list;
     this.agentFilesError = status.error;
-    if (
-      this.agentFileActive &&
-      !status.list.files.some((file) => file.name === this.agentFileActive)
-    ) {
-      this.agentFileActive = null;
+    void this.selectDefaultAgentFile(agentId);
+  }
+
+  private async selectDefaultAgentFile(agentId: string) {
+    const files = this.agentFilesList?.files ?? [];
+    if (this.agentFileActive && files.some((file) => file.name === this.agentFileActive)) {
+      return;
+    }
+    this.agentFileActive = files.find((file) => file.name === "AGENTS.md")?.name ?? null;
+    if (this.agentFileActive) {
+      await loadAgentFileContent(this, agentId, this.agentFileActive);
     }
   }
 
@@ -551,16 +557,13 @@ class AgentsPage extends OpenClawLightDomElement implements AgentsState {
       }
       this.agentFilesList = list ?? agents.files(agentId).list;
       this.agentFilesError = agents.files(agentId).error;
-      if (
-        this.agentFileActive &&
-        !this.agentFilesList?.files.some((file) => file.name === this.agentFileActive)
-      ) {
-        this.agentFileActive = null;
-      }
     } finally {
       if (this.isCurrentRequest(client, generation, agentId, { agents })) {
         this.agentFilesLoading = false;
       }
+    }
+    if (this.isCurrentRequest(client, generation, agentId, { agents })) {
+      await this.selectDefaultAgentFile(agentId);
     }
   }
 


### PR DESCRIPTION
## What Problem This Solves

Opening an agent's Files panel loads the core-file tabs but leaves every tab unselected. The panel therefore shows "Select a file to edit" instead of the primary workspace instructions.

## Why This Change Was Made

`AGENTS.md` is the main workspace instruction file and is present in the core-file list. Selecting it after the list loads gives the Files panel useful content immediately while preserving any valid file the user already selected.

## User Impact

When the Files panel opens, `AGENTS.md` is selected automatically and its content is loaded. Existing selections remain unchanged, and other file tabs continue to work normally.

## Evidence

- Added a controller regression test that starts with no active file and a list containing `AGENTS.md`.
- Before the fix, the test failed because `agentFileActive` remained `null`.
- After the fix, `AGENTS.md` becomes active and `agents.files.get` loads its content.
- `node scripts/run-vitest.mjs ui/src/pages/agents/agents-page.test.ts -- --reporter=verbose`
  - 1 file passed, 8 tests passed.
- `node_modules/.bin/oxfmt --check ui/src/pages/agents/agents-page.ts ui/src/pages/agents/agents-page.test.ts`
- `git diff --check`
- Autoreview: clean, no accepted or actionable findings.
