### PR TITLE
fix(ui): complete chat message actions

### DIFF
--- a/ui/src/components/copy-button.ts
+++ b/ui/src/components/copy-button.ts
@@ -6,7 +6,7 @@ import "./tooltip.ts";
 
 const COPIED_FOR_MS = 1500;
 const ERROR_FOR_MS = 2000;
-const COPY_LABEL = "Copy as markdown";
+export const COPY_LABEL = "Copy as markdown";
 const COPIED_LABEL = "Copied";
 const ERROR_LABEL = "Copy failed";
 

--- a/ui/src/components/tooltip.test.ts
+++ b/ui/src/components/tooltip.test.ts
@@ -37,7 +37,13 @@ function hoverTrigger(trigger: HTMLElement) {
 }
 
 function webAwesomeTooltip(tooltip: TooltipElement) {
-  return tooltip.shadowRoot?.querySelector<HTMLElement & { open: boolean }>("wa-tooltip");
+  return tooltip.shadowRoot?.querySelector<
+    HTMLElement & {
+      anchor: Element | null;
+      open: boolean;
+      readonly updateComplete: Promise<boolean>;
+    }
+  >("wa-tooltip");
 }
 
 function expectOpenCount(count: number) {
@@ -89,6 +95,17 @@ describe("openclaw-tooltip", () => {
 
     expectOpenCount(1);
     expect(webAwesomeTooltip(tooltip)?.textContent).toBe("Single portal");
+  });
+
+  it("anchors the Web Awesome popup after its initial update", async () => {
+    const provider = createProvider();
+    const { tooltip, trigger } = createTooltip("Anchored tooltip");
+    provider.append(tooltip);
+    document.body.append(provider);
+    await tooltip.updateComplete;
+    await webAwesomeTooltip(tooltip)?.updateComplete;
+
+    expect(webAwesomeTooltip(tooltip)?.anchor).toBe(trigger);
   });
 
   it("restores the normal hover delay after the provider reconnects", async () => {

--- a/ui/src/components/tooltip.ts
+++ b/ui/src/components/tooltip.ts
@@ -215,9 +215,16 @@ class Tooltip extends OpenClawLitElement {
     if (!tooltip) {
       return;
     }
-    tooltip.anchor = this.triggerElement;
     tooltip.showDelay = 0;
     tooltip.hideDelay = 0;
+    const trigger = this.triggerElement;
+    // WaTooltip's initial `for` watcher clears a directly assigned anchor.
+    // Reapply it after that update or an open tooltip has no popup geometry.
+    void tooltip.updateComplete.then(() => {
+      if (this.webAwesomeTooltip === tooltip && this.triggerElement === trigger) {
+        tooltip.anchor = trigger;
+      }
+    });
   }
 
   private readonly handlePointerEnter = (event: PointerEvent) => {

--- a/ui/src/components/tooltip.ts
+++ b/ui/src/components/tooltip.ts
@@ -127,6 +127,10 @@ class Tooltip extends OpenClawLitElement {
       line-height: 1.35;
       text-align: center;
       overflow-wrap: anywhere;
+      white-space: normal;
+    }
+
+    .tooltip-content {
       white-space: pre-line;
     }
   `;
@@ -403,9 +407,10 @@ class Tooltip extends OpenClawLitElement {
   }
 
   override render() {
+    const tooltipContent = html`<span class="tooltip-content">${this.content}</span>`;
     return html`
       <slot @slotchange=${() => this.attachTrigger()}></slot>
-      <wa-tooltip id=${this.tooltipId} trigger="manual">${this.content}</wa-tooltip>
+      <wa-tooltip id=${this.tooltipId} trigger="manual">${tooltipContent}</wa-tooltip>
     `;
   }
 }

--- a/ui/src/e2e/chat-message-actions.e2e.test.ts
+++ b/ui/src/e2e/chat-message-actions.e2e.test.ts
@@ -1,7 +1,7 @@
 // Real-browser proof for inline and context-menu chat message actions.
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { chromium, type Browser, type Page } from "playwright";
+import { chromium, type Browser, type Locator, type Page } from "playwright";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
   canRunPlaywrightChromium,
@@ -26,6 +26,48 @@ async function screenshot(page: Page, fileName: string): Promise<void> {
     return;
   }
   await page.screenshot({ animations: "disabled", path: path.join(artifactDir, fileName) });
+}
+
+async function expectHoverTooltip(button: Locator, text: string): Promise<void> {
+  await button.hover();
+  await expect
+    .poll(() =>
+      button.evaluate((element) => {
+        const tooltip = element
+          .closest("openclaw-tooltip")
+          ?.shadowRoot?.querySelector<
+            HTMLElement & { anchor?: Element | null; popup?: { active?: boolean } }
+          >("wa-tooltip");
+        const body = tooltip?.shadowRoot?.querySelector<HTMLElement>('[part="body"]');
+        const bounds = body?.getBoundingClientRect();
+        return {
+          anchorMatches: tooltip?.anchor === element,
+          height: bounds?.height ?? 0,
+          hidden: body?.hidden ?? true,
+          open: tooltip?.hasAttribute("open") ?? false,
+          popupActive: tooltip?.popup?.active ?? false,
+          text: tooltip?.textContent?.trim() ?? "",
+          width: bounds?.width ?? 0,
+        };
+      }),
+    )
+    .toMatchObject({
+      anchorMatches: true,
+      hidden: false,
+      open: true,
+      popupActive: true,
+      text,
+    });
+  const bounds = await button.evaluate((element) => {
+    const body = element
+      .closest("openclaw-tooltip")
+      ?.shadowRoot?.querySelector<HTMLElement>("wa-tooltip")
+      ?.shadowRoot?.querySelector<HTMLElement>('[part="body"]');
+    const rect = body?.getBoundingClientRect();
+    return { height: rect?.height ?? 0, width: rect?.width ?? 0 };
+  });
+  expect(bounds.width).toBeGreaterThan(0);
+  expect(bounds.height).toBeGreaterThan(0);
 }
 
 describeControlUiE2e("Control UI chat message actions", () => {
@@ -91,6 +133,20 @@ describeControlUiE2e("Control UI chat message actions", () => {
 
     try {
       await page.goto(`${server.baseUrl}chat`);
+      await expectHoverTooltip(page.getByRole("button", { name: "New thread" }), "New thread");
+      await expectHoverTooltip(
+        page.getByRole("button", { name: "Open command palette" }),
+        "Open command palette (⌘K)",
+      );
+      await expectHoverTooltip(
+        page.getByRole("button", { name: "Collapse sidebar" }),
+        "Collapse sidebar (⌘B)",
+      );
+      await expectHoverTooltip(
+        page.getByRole("button", { name: "Open split view" }),
+        "Open split view",
+      );
+      await screenshot(page, "00-header-tooltips.png");
       const group = page.locator(".chat-group.assistant").filter({ hasText: messageText });
       const bubble = group.locator(".chat-bubble");
       await bubble.waitFor({ state: "visible" });
@@ -113,10 +169,12 @@ describeControlUiE2e("Control UI chat message actions", () => {
       const inlineActions = group.locator(".chat-group-footer-actions button");
       expect(
         await inlineActions.evaluateAll((buttons) => buttons.map((button) => button.ariaLabel)),
-      ).toEqual(["Hide message", "Reply to message", "Open in canvas", "Copy as markdown"]);
+      ).toEqual(["Reply to message", "Hide message", "Open in canvas", "Copy as markdown"]);
+      const replyButton = group.getByRole("button", { name: "Reply to message" });
+      await expectHoverTooltip(replyButton, "Reply");
       await screenshot(page, "01-inline-actions.png");
 
-      await group.getByRole("button", { name: "Reply to message" }).click();
+      await replyButton.click();
       const replyPreview = page.locator(".chat-reply-preview");
       await replyPreview.waitFor({ state: "visible" });
       expect(await replyPreview.locator(".chat-reply-preview__text").textContent()).toBe(
@@ -134,6 +192,9 @@ describeControlUiE2e("Control UI chat message actions", () => {
         "Open in canvas",
         "Copy as markdown",
       ]);
+      expect(
+        await menu.getByRole("menuitem", { name: "Reply to message" }).locator("svg").count(),
+      ).toBe(0);
       await screenshot(page, "03-context-menu.png");
 
       await menu.getByRole("menuitem", { name: "Copy as markdown" }).click();

--- a/ui/src/e2e/chat-message-actions.e2e.test.ts
+++ b/ui/src/e2e/chat-message-actions.e2e.test.ts
@@ -63,11 +63,31 @@ async function expectHoverTooltip(button: Locator, text: string): Promise<void> 
       .closest("openclaw-tooltip")
       ?.shadowRoot?.querySelector<HTMLElement>("wa-tooltip")
       ?.shadowRoot?.querySelector<HTMLElement>('[part="body"]');
-    const rect = body?.getBoundingClientRect();
-    return { height: rect?.height ?? 0, width: rect?.width ?? 0 };
+    const slot = body?.querySelector<HTMLSlotElement>("slot");
+    const textNode = slot?.assignedNodes().find((node) => node.textContent?.trim());
+    const range = textNode ? document.createRange() : null;
+    if (range && textNode) {
+      range.selectNodeContents(textNode);
+    }
+    const bodyRect = body?.getBoundingClientRect();
+    const textRect = range?.getBoundingClientRect();
+    return {
+      height: bodyRect?.height ?? 0,
+      textTopInset: bodyRect && textRect ? textRect.top - bodyRect.top : Number.POSITIVE_INFINITY,
+      width: bodyRect?.width ?? 0,
+    };
   });
   expect(bounds.width).toBeGreaterThan(0);
   expect(bounds.height).toBeGreaterThan(0);
+  expect(bounds.textTopInset).toBeLessThan(12);
+}
+
+async function expectHoverColorChange(button: Locator): Promise<void> {
+  const restingColor = await button.evaluate((element) => getComputedStyle(element).color);
+  await button.hover();
+  await expect
+    .poll(() => button.evaluate((element) => getComputedStyle(element).color))
+    .not.toBe(restingColor);
 }
 
 describeControlUiE2e("Control UI chat message actions", () => {
@@ -146,6 +166,37 @@ describeControlUiE2e("Control UI chat message actions", () => {
         page.getByRole("button", { name: "Open split view" }),
         "Open split view",
       );
+      await page.evaluate(() => {
+        const tooltip = document.createElement("openclaw-tooltip");
+        tooltip.setAttribute("content", "First line\nSecond line");
+        const trigger = document.createElement("button");
+        trigger.textContent = "Multiline tooltip probe";
+        trigger.style.position = "fixed";
+        trigger.style.inset = "80px auto auto 280px";
+        trigger.style.zIndex = "10000";
+        tooltip.append(trigger);
+        document.body.append(tooltip);
+      });
+      const multilineTooltipButton = page.getByRole("button", {
+        name: "Multiline tooltip probe",
+      });
+      await expectHoverTooltip(multilineTooltipButton, "First line\nSecond line");
+      expect(
+        await multilineTooltipButton.evaluate((element) => {
+          const content = element
+            .closest("openclaw-tooltip")
+            ?.shadowRoot?.querySelector<HTMLElement>(".tooltip-content");
+          if (!content) {
+            return 0;
+          }
+          const range = document.createRange();
+          range.selectNodeContents(content);
+          return new Set([...range.getClientRects()].map((rect) => Math.round(rect.top))).size;
+        }),
+      ).toBe(2);
+      await multilineTooltipButton.evaluate((element) =>
+        element.closest("openclaw-tooltip")?.remove(),
+      );
       await screenshot(page, "00-header-tooltips.png");
       const group = page.locator(".chat-group.assistant").filter({ hasText: messageText });
       const bubble = group.locator(".chat-bubble");
@@ -170,6 +221,9 @@ describeControlUiE2e("Control UI chat message actions", () => {
       expect(
         await inlineActions.evaluateAll((buttons) => buttons.map((button) => button.ariaLabel)),
       ).toEqual(["Reply to message", "Hide message", "Open in canvas", "Copy as markdown"]);
+      for (const button of await inlineActions.all()) {
+        await expectHoverColorChange(button);
+      }
       const replyButton = group.getByRole("button", { name: "Reply to message" });
       await expectHoverTooltip(replyButton, "Reply");
       await screenshot(page, "01-inline-actions.png");

--- a/ui/src/e2e/chat-message-actions.e2e.test.ts
+++ b/ui/src/e2e/chat-message-actions.e2e.test.ts
@@ -1,0 +1,157 @@
+// Real-browser proof for inline and context-menu chat message actions.
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { chromium, type Browser, type Page } from "playwright";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  canRunPlaywrightChromium,
+  installMockGateway,
+  resolvePlaywrightChromiumExecutablePath,
+  startControlUiE2eServer,
+  type ControlUiE2eServer,
+} from "../test-helpers/control-ui-e2e.ts";
+
+const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
+const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
+const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
+const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
+const artifactDir = path.resolve(process.cwd(), ".artifacts/control-ui-e2e/chat-message-actions");
+
+let browser: Browser;
+let server: ControlUiE2eServer;
+
+async function screenshot(page: Page, fileName: string): Promise<void> {
+  if (!captureUiProof) {
+    return;
+  }
+  await page.screenshot({ animations: "disabled", path: path.join(artifactDir, fileName) });
+}
+
+describeControlUiE2e("Control UI chat message actions", () => {
+  beforeAll(async () => {
+    if (!chromiumAvailable) {
+      throw new Error(`Playwright Chromium is unavailable at ${chromiumExecutablePath}`);
+    }
+    if (captureUiProof) {
+      await mkdir(artifactDir, { recursive: true });
+    }
+    server = await startControlUiE2eServer();
+    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
+  });
+
+  afterAll(async () => {
+    await browser?.close();
+    await server?.close();
+  });
+
+  it("offers Reply inline and mirrors every assistant action in the context menu", async () => {
+    const context = await browser.newContext({
+      locale: "en-US",
+      recordVideo: captureUiProof
+        ? { dir: path.join(artifactDir, "video"), size: { height: 900, width: 1440 } }
+        : undefined,
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1440 },
+    });
+    await context.grantPermissions(["clipboard-read", "clipboard-write"], {
+      origin: new URL(server.baseUrl).origin,
+    });
+    const page = await context.newPage();
+    const messageText = "Reply and context menu action proof.";
+    const privateThinking = "private reply reasoning";
+    const visibleThinkingAnswer = "Visible reply context only.";
+    await installMockGateway(page, {
+      historyMessages: [
+        {
+          role: "assistant",
+          content: [{ type: "text", text: messageText }],
+          timestamp: Date.now(),
+          __openclaw: { id: "assistant-action-proof", seq: 1 },
+        },
+        {
+          role: "user",
+          content: [{ type: "text", text: "Keep the next assistant message separate." }],
+          timestamp: Date.now() + 1,
+          __openclaw: { id: "user-action-separator", seq: 2 },
+        },
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "text",
+              text: `<thinking>${privateThinking}</thinking>${visibleThinkingAnswer}`,
+            },
+          ],
+          timestamp: Date.now() + 2,
+          __openclaw: { id: "assistant-thinking-proof", seq: 3 },
+        },
+      ],
+    });
+
+    try {
+      await page.goto(`${server.baseUrl}chat`);
+      const group = page.locator(".chat-group.assistant").filter({ hasText: messageText });
+      const bubble = group.locator(".chat-bubble");
+      await bubble.waitFor({ state: "visible" });
+
+      const thinkingGroup = page
+        .locator(".chat-group.assistant")
+        .filter({ hasText: visibleThinkingAnswer });
+      await thinkingGroup.hover();
+      await thinkingGroup.getByRole("button", { name: "Reply to message" }).click();
+      const thinkingReplyPreview = page.locator(".chat-reply-preview");
+      await thinkingReplyPreview.waitFor({ state: "visible" });
+      expect(await thinkingReplyPreview.locator(".chat-reply-preview__text").textContent()).toBe(
+        visibleThinkingAnswer,
+      );
+      expect(await thinkingReplyPreview.textContent()).not.toContain(privateThinking);
+      await thinkingReplyPreview.getByRole("button", { name: "Cancel reply" }).click();
+
+      await group.hover();
+
+      const inlineActions = group.locator(".chat-group-footer-actions button");
+      expect(
+        await inlineActions.evaluateAll((buttons) => buttons.map((button) => button.ariaLabel)),
+      ).toEqual(["Hide message", "Reply to message", "Open in canvas", "Copy as markdown"]);
+      await screenshot(page, "01-inline-actions.png");
+
+      await group.getByRole("button", { name: "Reply to message" }).click();
+      const replyPreview = page.locator(".chat-reply-preview");
+      await replyPreview.waitFor({ state: "visible" });
+      expect(await replyPreview.locator(".chat-reply-preview__text").textContent()).toBe(
+        messageText,
+      );
+      await screenshot(page, "02-reply-preview.png");
+      await replyPreview.getByRole("button", { name: "Cancel reply" }).click();
+
+      await bubble.click({ button: "right" });
+      const menu = page.locator(".chat-reply-context-menu");
+      await menu.waitFor({ state: "visible" });
+      expect(await menu.getByRole("menuitem").allTextContents()).toEqual([
+        "Reply",
+        "Hide message",
+        "Open in canvas",
+        "Copy as markdown",
+      ]);
+      await screenshot(page, "03-context-menu.png");
+
+      await menu.getByRole("menuitem", { name: "Copy as markdown" }).click();
+      await expect
+        .poll(() => page.evaluate(() => navigator.clipboard.readText()))
+        .toBe(messageText);
+
+      await bubble.click({ button: "right" });
+      await page.getByRole("menuitem", { name: "Open in canvas" }).click();
+      const markdownSidebar = page.locator(".sidebar-markdown");
+      await markdownSidebar.getByText(messageText, { exact: true }).waitFor({ state: "visible" });
+
+      await bubble.click({ button: "right" });
+      await page.getByRole("menuitem", { name: "Hide message" }).click();
+      await page.locator(".chat-delete-confirm").getByRole("button", { name: "Hide" }).click();
+      await expect.poll(() => group.count()).toBe(0);
+    } finally {
+      await context.close();
+    }
+  });
+});

--- a/ui/src/e2e/chat-message-actions.e2e.test.ts
+++ b/ui/src/e2e/chat-message-actions.e2e.test.ts
@@ -82,12 +82,24 @@ async function expectHoverTooltip(button: Locator, text: string): Promise<void> 
   expect(bounds.textTopInset).toBeLessThan(12);
 }
 
-async function expectHoverColorChange(button: Locator): Promise<void> {
+async function expectHoverColor(
+  button: Locator,
+  colorVariable: "--accent" | "--danger",
+): Promise<void> {
   const restingColor = await button.evaluate((element) => getComputedStyle(element).color);
+  const hoverColor = await button.evaluate((_, cssVariable) => {
+    const probe = document.createElement("span");
+    probe.style.color = `var(${cssVariable})`;
+    document.body.append(probe);
+    const color = getComputedStyle(probe).color;
+    probe.remove();
+    return color;
+  }, colorVariable);
+  expect(restingColor).not.toBe(hoverColor);
   await button.hover();
   await expect
     .poll(() => button.evaluate((element) => getComputedStyle(element).color))
-    .not.toBe(restingColor);
+    .toBe(hoverColor);
 }
 
 describeControlUiE2e("Control UI chat message actions", () => {
@@ -153,6 +165,7 @@ describeControlUiE2e("Control UI chat message actions", () => {
 
     try {
       await page.goto(`${server.baseUrl}chat`);
+      await page.evaluate(() => document.documentElement.setAttribute("data-theme-mode", "dark"));
       await expectHoverTooltip(page.getByRole("button", { name: "New thread" }), "New thread");
       await expectHoverTooltip(
         page.getByRole("button", { name: "Open command palette" }),
@@ -222,7 +235,8 @@ describeControlUiE2e("Control UI chat message actions", () => {
         await inlineActions.evaluateAll((buttons) => buttons.map((button) => button.ariaLabel)),
       ).toEqual(["Reply to message", "Hide message", "Open in canvas", "Copy as markdown"]);
       for (const button of await inlineActions.all()) {
-        await expectHoverColorChange(button);
+        const label = await button.getAttribute("aria-label");
+        await expectHoverColor(button, label === "Hide message" ? "--danger" : "--accent");
       }
       const replyButton = group.getByRole("button", { name: "Reply to message" });
       await expectHoverTooltip(replyButton, "Reply");

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -3924,6 +3924,8 @@ export const en: TranslationMap = {
       hideMessage: "Hide message",
       hideTooltip: "Hide in this browser only",
       openInCanvas: "Open in canvas",
+      reply: "Reply",
+      replyToMessage: "Reply to message",
       rewind: "Rewind",
       rewindConfirm: "Rewind to before this message?",
       rewindToHere: "Rewind to here",

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -5515,6 +5515,9 @@ describe("right-click Reply", () => {
         button.textContent?.trim(),
       ),
     ).toEqual(["Reply", "Hide message", "Open in canvas", "Copy as markdown"]);
+    expect(
+      document.querySelector('.chat-reply-context-menu [aria-label="Reply to message"] svg'),
+    ).toBeNull();
 
     document.querySelector<HTMLButtonElement>('[aria-label="Open in canvas"]')!.click();
     expect(onOpenSidebar).toHaveBeenCalledWith({ kind: "markdown", content: "hello" });

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -1177,6 +1177,80 @@ describe("chat code-block copy", () => {
 });
 
 describe("chat transcript rendering", () => {
+  it("refreshes cached inline reply handlers when the callback identity changes", () => {
+    const transcript = new ChatTranscriptController({
+      addController: () => undefined,
+      removeController: () => undefined,
+      requestUpdate: () => undefined,
+      updateComplete: Promise.resolve(true),
+    } satisfies ReactiveControllerHost);
+    const firstReply = vi.fn();
+    const currentReply = vi.fn();
+    const message = { role: "assistant", content: "Reply target", timestamp: 1 };
+    const messages = [message];
+    const stableChatItems = [
+      {
+        kind: "group",
+        key: "group:assistant:reply-callback-cache",
+        role: "assistant",
+        messages: [{ key: "message:reply-callback-cache", message }],
+        timestamp: 1,
+        isStreaming: false,
+      },
+    ] as ReturnType<typeof chatThread.buildCachedChatItems>;
+    const defaultBuildChatItems = buildChatItemsMock.getMockImplementation();
+    const defaultRenderMessageGroup = renderMessageGroupMock.getMockImplementation();
+    buildChatItemsMock.mockReturnValue(stableChatItems);
+    renderMessageGroupMock.mockImplementation(
+      (
+        ...[_group, opts]: Parameters<typeof chatMessage.renderMessageGroup>
+      ): ReturnType<typeof chatMessage.renderMessageGroup> => html`
+        <button
+          aria-label="Reply to message"
+          @click=${() =>
+            opts.onReply?.({
+              messageId: "assistant-message",
+              senderLabel: "Val",
+              text: "Reply target",
+            })}
+        >
+          Reply
+        </button>
+      `,
+    );
+    const container = document.createElement("div");
+    const renderWithReply = (onSetReply: typeof firstReply) => {
+      render(
+        renderChat(
+          createChatProps({
+            paneId: "reply-callback-cache",
+            transcript,
+            messages,
+            onSetReply,
+          }),
+        ),
+        container,
+      );
+    };
+
+    renderWithReply(firstReply);
+    renderWithReply(currentReply);
+    requireElement(
+      container,
+      '[aria-label="Reply to message"]',
+      "inline reply button",
+    ).dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    if (defaultRenderMessageGroup) {
+      renderMessageGroupMock.mockImplementation(defaultRenderMessageGroup);
+    }
+    if (defaultBuildChatItems) {
+      buildChatItemsMock.mockImplementation(defaultBuildChatItems);
+    }
+
+    expect(firstReply).not.toHaveBeenCalled();
+    expect(currentReply).toHaveBeenCalledOnce();
+  });
+
   it("passes the full loaded history to one render path and leaves scroll ownership to the pane", () => {
     const messages = Array.from({ length: 80 }, (_, index) => ({
       role: index % 2 === 0 ? "user" : "assistant",

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -5457,15 +5457,24 @@ describe("chat model controls", () => {
 });
 
 describe("right-click Reply", () => {
-  it("adds rewind and fork actions only for persisted user bubbles", () => {
+  it("keeps inline actions in the context menu alongside user rewind and fork", () => {
     const onRewindMessage = vi.fn().mockResolvedValue(true);
     const onForkMessage = vi.fn();
-    const container = renderChatView({ onRewindMessage, onForkMessage, onSetReply: vi.fn() });
+    const onOpenSidebar = vi.fn();
+    const onCopy = vi.fn();
+    const container = renderChatView({
+      onRewindMessage,
+      onForkMessage,
+      onOpenSidebar,
+      onSetReply: vi.fn(),
+    });
     const section = container.querySelector<HTMLElement>(".card.chat")!;
     const group = document.createElement("div");
     group.className = "chat-group user";
+    group.dataset.chatRowKey = "group:user:persisted";
     const bubble = document.createElement("div");
     bubble.className = "chat-bubble";
+    bubble.dataset.messageId = "message-1";
     bubble.dataset.entryId = "persisted-user";
     bubble.dataset.messageText = "hello";
     group.appendChild(bubble);
@@ -5476,17 +5485,77 @@ describe("right-click Reply", () => {
     const labels = [...document.querySelectorAll(".chat-reply-context-menu button")].map((button) =>
       button.textContent?.trim(),
     );
-    expect(labels).toEqual(["Reply", "Rewind to here", "Fork from here"]);
+    expect(labels).toEqual(["Reply", "Rewind to here", "Hide message", "Fork from here"]);
     document.querySelector<HTMLButtonElement>('[aria-label="Fork from here"]')!.click();
     expect(onForkMessage).toHaveBeenCalledWith("persisted-user");
 
     group.className = "chat-group assistant";
+    const onSiblingExpand = vi.fn();
+    const siblingActionOwner = document.createElement("div");
+    siblingActionOwner.dataset.messageActionsFor = "message-0";
+    const siblingExpandButton = document.createElement("button");
+    siblingExpandButton.className = "chat-expand-btn";
+    siblingExpandButton.addEventListener("click", onSiblingExpand);
+    siblingActionOwner.append(siblingExpandButton);
+    const expandButton = document.createElement("button");
+    expandButton.className = "chat-expand-btn";
+    expandButton.addEventListener("click", () =>
+      onOpenSidebar({ kind: "markdown", content: "hello" }),
+    );
+    const copyButton = document.createElement("button");
+    copyButton.className = "chat-copy-btn";
+    copyButton.addEventListener("click", onCopy);
+    const actionOwner = document.createElement("div");
+    actionOwner.dataset.messageActionsFor = "message-1";
+    actionOwner.append(expandButton, copyButton);
+    group.append(siblingActionOwner, actionOwner);
     bubble.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
     expect(
       [...document.querySelectorAll(".chat-reply-context-menu button")].map((button) =>
         button.textContent?.trim(),
       ),
-    ).toEqual(["Reply"]);
+    ).toEqual(["Reply", "Hide message", "Open in canvas", "Copy as markdown"]);
+
+    document.querySelector<HTMLButtonElement>('[aria-label="Open in canvas"]')!.click();
+    expect(onOpenSidebar).toHaveBeenCalledWith({ kind: "markdown", content: "hello" });
+    expect(onSiblingExpand).not.toHaveBeenCalled();
+
+    bubble.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
+    document.querySelector<HTMLButtonElement>('[aria-label="Copy as markdown"]')!.click();
+    expect(onCopy).toHaveBeenCalledOnce();
+  });
+
+  it("confirms Hide from the context menu before hiding the message locally", () => {
+    const storedValues = new Map<string, string>();
+    vi.stubGlobal("localStorage", {
+      clear: () => storedValues.clear(),
+      getItem: (key: string) => storedValues.get(key) ?? null,
+      key: (index: number) => [...storedValues.keys()][index] ?? null,
+      get length() {
+        return storedValues.size;
+      },
+      removeItem: (key: string) => storedValues.delete(key),
+      setItem: (key: string, value: string) => storedValues.set(key, value),
+    } satisfies Storage);
+    const onRequestUpdate = vi.fn();
+    const container = renderChatView({ sessionKey: "context-hide-test", onRequestUpdate });
+    const group = document.createElement("div");
+    group.className = "chat-group assistant";
+    group.dataset.chatRowKey = "group:assistant:persisted";
+    const bubble = document.createElement("div");
+    bubble.className = "chat-bubble";
+    group.appendChild(bubble);
+    container.querySelector(".chat-thread-inner")!.appendChild(group);
+
+    bubble.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
+    document.querySelector<HTMLButtonElement>('[aria-label="Hide message"]')!.click();
+    expect(document.querySelector(".chat-delete-confirm")).not.toBeNull();
+    document.querySelector<HTMLButtonElement>(".chat-delete-confirm__yes")!.click();
+
+    expect(storedValues.get("openclaw:deleted:context-hide-test")).toBe(
+      JSON.stringify(["group:assistant:persisted"]),
+    );
+    expect(onRequestUpdate).toHaveBeenCalledOnce();
   });
 
   it("disables rewind and fork context actions during an active run", () => {

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -608,8 +608,8 @@ describe("grouped chat rendering", () => {
       ".chat-group-footer-actions button",
     );
     expect([...actions].map((button) => button.getAttribute("aria-label"))).toEqual([
-      "Hide message",
       "Reply to message",
+      "Hide message",
       "Open in canvas",
       "Copy as markdown",
     ]);

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -589,6 +589,90 @@ describe("grouped chat rendering", () => {
     expect(userBubble.querySelector(".chat-bubble-actions")).toBeNull();
   });
 
+  it("adds Reply to the inline message actions and forwards persisted reply context", () => {
+    const container = document.createElement("div");
+    const onReply = vi.fn();
+    const onOpenSidebar = vi.fn();
+    renderAssistantMessage(
+      container,
+      {
+        role: "assistant",
+        content: "Reply with this context.",
+        timestamp: 1000,
+        __openclaw: { id: "assistant-entry-1" },
+      },
+      { onDelete: vi.fn(), onOpenSidebar, onReply },
+    );
+
+    const actions = container.querySelectorAll<HTMLButtonElement>(
+      ".chat-group-footer-actions button",
+    );
+    expect([...actions].map((button) => button.getAttribute("aria-label"))).toEqual([
+      "Hide message",
+      "Reply to message",
+      "Open in canvas",
+      "Copy as markdown",
+    ]);
+
+    container.querySelector<HTMLButtonElement>('[aria-label="Reply to message"]')?.click();
+
+    expect(onReply).toHaveBeenCalledWith({
+      messageId: "assistant-message",
+      senderLabel: "OpenClaw",
+      sourceMessageId: "assistant-entry-1",
+      text: "Reply with this context.",
+    });
+
+    const userContainer = document.createElement("div");
+    renderGroupedMessage(
+      userContainer,
+      {
+        role: "user",
+        content: "User reply context.",
+        timestamp: 1001,
+        __openclaw: { id: "user-entry-1" },
+      },
+      "user",
+      { onReply, userName: "Jason" },
+    );
+    userContainer.querySelector<HTMLButtonElement>('[aria-label="Reply to message"]')?.click();
+
+    expect(onReply).toHaveBeenLastCalledWith({
+      messageId: "user-message",
+      senderLabel: "Jason",
+      sourceMessageId: "user-entry-1",
+      text: "User reply context.",
+    });
+  });
+
+  it("keeps hidden assistant thinking out of inline reply context", () => {
+    const container = document.createElement("div");
+    const onReply = vi.fn();
+    renderAssistantMessage(
+      container,
+      {
+        role: "assistant",
+        content: "<thinking>private reasoning</thinking>Visible answer.",
+        timestamp: 1000,
+      },
+      { onReply },
+    );
+
+    container.querySelector<HTMLButtonElement>('[aria-label="Reply to message"]')?.click();
+    expect(onReply).toHaveBeenCalledWith(expect.objectContaining({ text: "Visible answer." }));
+
+    renderAssistantMessage(
+      container,
+      {
+        role: "assistant",
+        content: "<thinking>private reasoning only</thinking>",
+        timestamp: 1001,
+      },
+      { onReply },
+    );
+    expect(container.querySelector('[aria-label="Reply to message"]')).toBeNull();
+  });
+
   it("does not replay an arrival animation when a message row mounts", () => {
     const container = document.createElement("div");
     renderAssistantMessage(container, {

--- a/ui/src/pages/chat/components/chat-message.ts
+++ b/ui/src/pages/chat/components/chat-message.ts
@@ -1055,12 +1055,16 @@ export function renderMessageGroup(group: MessageGroup, opts: RenderMessageGroup
                   class="chat-group-footer-actions"
                   data-message-actions-for=${group.messages[lastMessageIndex]?.key ?? nothing}
                 >
-                  ${opts.onDelete && normalizedRole !== "user"
-                    ? renderDeleteButton(opts.onDelete, "right")
-                    : nothing}
                   ${footerActionDetails
-                    ? renderMessageActionButtons(footerActionDetails, opts, opts.onOpenSidebar)
-                    : nothing}
+                    ? renderMessageActionButtons(
+                        footerActionDetails,
+                        opts,
+                        opts.onOpenSidebar,
+                        normalizedRole !== "user" ? opts.onDelete : undefined,
+                      )
+                    : opts.onDelete && normalizedRole !== "user"
+                      ? renderDeleteButton(opts.onDelete, "right")
+                      : nothing}
                 </div>
               `
             : nothing}
@@ -2356,11 +2360,13 @@ function renderMessageActionButtons(
     onReply?: (target: MessageReplyTarget) => void;
   },
   onOpenSidebar?: (content: SidebarContent) => void,
+  onDelete?: () => void,
 ) {
   return html`
     ${details.replyTarget && opts.onReply
       ? renderReplyButton(details.replyTarget, opts.onReply)
       : nothing}
+    ${onDelete ? renderDeleteButton(onDelete, "right") : nothing}
     ${details.markdown && onOpenSidebar
       ? renderExpandButton(details.markdown, onOpenSidebar, {
           sessionKey: opts.sessionKey,

--- a/ui/src/pages/chat/components/chat-message.ts
+++ b/ui/src/pages/chat/components/chat-message.ts
@@ -1,4 +1,5 @@
 // Control UI chat module implements grouped render behavior.
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { html, nothing } from "lit";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { until } from "lit/directives/until.js";
@@ -800,8 +801,16 @@ type RenderMessageGroupOptions = {
   allowExternalEmbedUrls?: boolean;
   contextWindow?: number | null;
   onDelete?: () => void;
+  onReply?: (target: MessageReplyTarget) => void;
   onRewind?: () => void;
   rewindDisabled?: boolean;
+};
+
+export type MessageReplyTarget = {
+  messageId: string;
+  text: string;
+  senderLabel?: string | null;
+  sourceMessageId?: string | null;
 };
 
 type GroupedMessageRenderOptions = Parameters<typeof renderGroupedMessage>[2];
@@ -982,7 +991,13 @@ export function renderMessageGroup(group: MessageGroup, opts: RenderMessageGroup
   }
 
   const messageActionDetails = group.messages.map((item) =>
-    resolveMessageActionDetails(item.message, opts.onOpenSidebar),
+    resolveMessageActionDetails({
+      message: item.message,
+      messageId: item.key,
+      onOpenSidebar: opts.onOpenSidebar,
+      onReply: opts.onReply,
+      senderLabel: who,
+    }),
   );
   const lastMessageIndex = group.messages.length - 1;
   const footerActionDetails = messageActionDetails[lastMessageIndex] ?? null;
@@ -1015,7 +1030,7 @@ export function renderMessageGroup(group: MessageGroup, opts: RenderMessageGroup
             )}
             ${actionDetails && index < lastMessageIndex
               ? html`
-                  <div class="chat-message-actions-row">
+                  <div class="chat-message-actions-row" data-message-actions-for=${item.key}>
                     ${renderMessageActionButtons(actionDetails, opts, opts.onOpenSidebar)}
                   </div>
                 `
@@ -1036,7 +1051,10 @@ export function renderMessageGroup(group: MessageGroup, opts: RenderMessageGroup
           </div>
           ${footerActionDetails || (opts.onDelete && normalizedRole !== "user")
             ? html`
-                <div class="chat-group-footer-actions">
+                <div
+                  class="chat-group-footer-actions"
+                  data-message-actions-for=${group.messages[lastMessageIndex]?.key ?? nothing}
+                >
                   ${opts.onDelete && normalizedRole !== "user"
                     ? renderDeleteButton(opts.onDelete, "right")
                     : nothing}
@@ -1330,6 +1348,16 @@ export function openChatRewindConfirmation(trigger: HTMLElement, action: () => v
     confirmText: t("chat.messages.rewindConfirm"),
     preferenceName: SKIP_REWIND_CONFIRM_PREFERENCE,
     side: "left",
+  });
+}
+
+export function openChatHideConfirmation(trigger: HTMLElement, action: () => void): void {
+  openConfirmedActionPopover(trigger, {
+    action,
+    confirmLabel: t("chat.messages.hide"),
+    confirmText: t("chat.messages.hideConfirm"),
+    preferenceName: SKIP_DELETE_CONFIRM_PREFERENCE,
+    side: "right",
   });
 }
 
@@ -2248,8 +2276,9 @@ function renderExpandButton(
 }
 
 type MessageActionDetails = {
-  markdown: string;
+  markdown?: string;
   messageId?: string;
+  replyTarget?: MessageReplyTarget;
   shouldFetchFullMessage: boolean;
 };
 
@@ -2265,17 +2294,23 @@ function resolveNormalizedMessageMarkdown(normalizedMessage: NormalizedMessage):
     .trim();
 }
 
-function resolveMessageActionDetails(
-  message: unknown,
-  onOpenSidebar?: (content: SidebarContent) => void,
-): MessageActionDetails | null {
+function resolveMessageActionDetails(params: {
+  message: unknown;
+  messageId: string;
+  onOpenSidebar?: (content: SidebarContent) => void;
+  onReply?: (target: MessageReplyTarget) => void;
+  senderLabel: string;
+}): MessageActionDetails | null {
+  const { message, messageId: renderMessageId, onOpenSidebar, onReply, senderLabel } = params;
   const record = message as Record<string, unknown>;
   const normalizedMessage = normalizeMessage(message);
-  if (normalizeRoleForGrouping(normalizedMessage.role) !== "assistant") {
-    return null;
-  }
-  const markdown = stripThinkingTags(resolveNormalizedMessageMarkdown(normalizedMessage)).trim();
-  if (!markdown) {
+  const normalizedMarkdown = resolveNormalizedMessageMarkdown(normalizedMessage);
+  const role = normalizeRoleForGrouping(normalizedMessage.role);
+  const visibleMarkdown =
+    role === "assistant" ? stripThinkingTags(normalizedMarkdown).trim() : normalizedMarkdown.trim();
+  const markdown = role === "assistant" ? visibleMarkdown : undefined;
+  const replyText = onReply ? truncateUtf16Safe(visibleMarkdown, 500) : "";
+  if (!markdown && !replyText) {
     return null;
   }
   const transcriptMeta =
@@ -2290,14 +2325,25 @@ function resolveMessageActionDetails(
       : typeof record.messageId === "string"
         ? record.messageId
         : undefined;
+  const sourceMessageId = persistedMessageEntryId(message);
   return {
-    markdown,
+    ...(markdown ? { markdown } : {}),
     messageId,
+    ...(replyText
+      ? {
+          replyTarget: {
+            messageId: renderMessageId,
+            text: replyText,
+            senderLabel,
+            ...(sourceMessageId ? { sourceMessageId } : {}),
+          },
+        }
+      : {}),
     shouldFetchFullMessage: Boolean(
       onOpenSidebar &&
       messageId &&
       !record.openclawMessageToolMirror &&
-      (transcriptMeta?.truncated === true || markdown.includes("\n...(truncated)...")),
+      (transcriptMeta?.truncated === true || markdown?.includes("\n...(truncated)...")),
     ),
   };
 }
@@ -2307,18 +2353,40 @@ function renderMessageActionButtons(
   opts: {
     sessionKey?: string;
     agentId?: string;
+    onReply?: (target: MessageReplyTarget) => void;
   },
   onOpenSidebar?: (content: SidebarContent) => void,
 ) {
   return html`
-    ${onOpenSidebar
+    ${details.replyTarget && opts.onReply
+      ? renderReplyButton(details.replyTarget, opts.onReply)
+      : nothing}
+    ${details.markdown && onOpenSidebar
       ? renderExpandButton(details.markdown, onOpenSidebar, {
           sessionKey: opts.sessionKey,
           agentId: opts.agentId,
           messageId: details.shouldFetchFullMessage ? details.messageId : undefined,
         })
       : nothing}
-    ${renderCopyAsMarkdownButton(details.markdown)}
+    ${details.markdown ? renderCopyAsMarkdownButton(details.markdown) : nothing}
+  `;
+}
+
+function renderReplyButton(
+  target: MessageReplyTarget,
+  onReply: (target: MessageReplyTarget) => void,
+) {
+  return html`
+    <openclaw-tooltip .content=${t("chat.messages.reply")}>
+      <button
+        class="chat-reply-btn"
+        type="button"
+        aria-label=${t("chat.messages.replyToMessage")}
+        @click=${() => onReply(target)}
+      >
+        ${icons.messageSquare}
+      </button>
+    </openclaw-tooltip>
   `;
 }
 

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -727,23 +727,7 @@ function createReplyContextMenuButton(onClick: () => void): HTMLButtonElement {
   button.type = "button";
   button.setAttribute("role", "menuitem");
   button.setAttribute("aria-label", t("chat.messages.replyToMessage"));
-
-  const icon = document.createElementNS("http://www.w3.org/2000/svg", "svg");
-  icon.setAttribute("viewBox", "0 0 24 24");
-  icon.setAttribute("width", "16");
-  icon.setAttribute("height", "16");
-  icon.setAttribute("fill", "currentColor");
-  icon.setAttribute("stroke", "none");
-  icon.setAttribute("aria-hidden", "true");
-  icon.setAttribute("focusable", "false");
-  const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
-  path.setAttribute("d", "M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z");
-  icon.appendChild(path);
-
-  const label = document.createElement("span");
-  label.textContent = t("chat.messages.reply");
-
-  button.append(icon, label);
+  button.textContent = t("chat.messages.reply");
   button.addEventListener("click", onClick);
   return button;
 }

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -17,6 +17,7 @@ import { classifySessionKind } from "../../../../../src/sessions/classify-sessio
 import type { SessionsListResult } from "../../../api/types.ts";
 import type { QuestionPrompt } from "../../../app/question-prompt.ts";
 import { resolveLocalUserName } from "../../../app/user-identity.ts";
+import { COPY_LABEL } from "../../../components/copy-button.ts";
 import { icons } from "../../../components/icons.ts";
 import "../../../components/tooltip.ts";
 import {
@@ -66,10 +67,12 @@ import type { BackgroundTasksProps } from "./chat-background-tasks.ts";
 import { renderChatDivider } from "./chat-divider.ts";
 import {
   getAssistantAttachmentAvailabilityRenderVersion,
+  openChatHideConfirmation,
   openChatRewindConfirmation,
   renderMessageGroup,
   renderStreamGroup,
   renderWorkGroupSummary,
+  type MessageReplyTarget,
 } from "./chat-message.ts";
 import { renderRealtimeTalkConversation } from "./chat-realtime-controls.ts";
 import { handleChatSelectionPointerUp, removeChatSelectionPopup } from "./chat-selection-popup.ts";
@@ -78,14 +81,6 @@ import { renderWelcomeState, resolveAssistantDisplayAvatar } from "./chat-welcom
 
 const pinnedMessagesMap = new Map<string, PinnedMessages>();
 const deletedMessagesMap = new Map<string, DeletedMessages>();
-
-type ReplyTarget = {
-  messageId: string;
-  text: string;
-  senderLabel?: string | null;
-  /** Persisted transcript id; when present chat.send carries it as replyToId. */
-  sourceMessageId?: string | null;
-};
 
 type ChatThreadState = {
   searchOpen: boolean;
@@ -152,7 +147,7 @@ type ChatThreadProps = {
   /** Current composer draft; the selection popup preserves it when prefilling. */
   getDraft?: () => string;
   onSend: () => void;
-  onSetReply?: (target: ReplyTarget) => void;
+  onSetReply?: (target: MessageReplyTarget) => void;
   onRewindMessage?: (entryId: string) => Promise<boolean> | boolean;
   onForkMessage?: (entryId: string) => Promise<void> | void;
   onFocusComposer?: () => void;
@@ -731,7 +726,7 @@ function createReplyContextMenuButton(onClick: () => void): HTMLButtonElement {
   const button = document.createElement("button");
   button.type = "button";
   button.setAttribute("role", "menuitem");
-  button.setAttribute("aria-label", "Reply to message");
+  button.setAttribute("aria-label", t("chat.messages.replyToMessage"));
 
   const icon = document.createElementNS("http://www.w3.org/2000/svg", "svg");
   icon.setAttribute("viewBox", "0 0 24 24");
@@ -746,7 +741,7 @@ function createReplyContextMenuButton(onClick: () => void): HTMLButtonElement {
   icon.appendChild(path);
 
   const label = document.createElement("span");
-  label.textContent = "Reply";
+  label.textContent = t("chat.messages.reply");
 
   button.append(icon, label);
   button.addEventListener("click", onClick);
@@ -816,11 +811,23 @@ function handleChatContextMenu(event: MouseEvent, props: ChatThreadProps) {
   const senderLabel = senderEl?.textContent?.trim() ?? undefined;
   const text = truncateUtf16Safe((bubble as HTMLElement).dataset.messageText?.trim() ?? "", 500);
   const entryId = (bubble as HTMLElement).dataset.entryId?.trim() ?? "";
+  const messageId = (bubble as HTMLElement).dataset.messageId?.trim() ?? "";
+  const groupKey = (group as HTMLElement).dataset.chatRowKey?.trim() ?? "";
   const isUserMessage = group.classList.contains("user") && Boolean(entryId);
+  // Grouped rows can contain several bubbles. Match the clicked bubble to its
+  // own action owner so canvas/copy never targets a sibling message.
+  const actionOwner = [...group.querySelectorAll<HTMLElement>("[data-message-actions-for]")].find(
+    (element) => element.dataset.messageActionsFor === messageId,
+  );
+  const expandButton = actionOwner?.querySelector<HTMLButtonElement>(".chat-expand-btn");
+  const copyButton = actionOwner?.querySelector<HTMLButtonElement>(".chat-copy-btn");
   const canReply = Boolean(text && props.onSetReply);
   const canRewind = isUserMessage && typeof props.onRewindMessage === "function";
+  const canHide = Boolean(groupKey);
+  const canOpenInCanvas = Boolean(expandButton);
+  const canCopy = Boolean(copyButton);
   const canFork = isUserMessage && typeof props.onForkMessage === "function";
-  if (!canReply && !canRewind && !canFork) {
+  if (!canReply && !canRewind && !canHide && !canOpenInCanvas && !canCopy && !canFork) {
     return;
   }
   event.preventDefault();
@@ -834,11 +841,10 @@ function handleChatContextMenu(event: MouseEvent, props: ChatThreadProps) {
   menu.style.top = `${event.clientY}px`;
   const focusCandidates: HTMLButtonElement[] = [];
   if (canReply) {
-    const messageId =
-      (bubble as HTMLElement).dataset.messageId?.trim() || stableReplyMessageId(senderLabel, text);
+    const replyMessageId = messageId || stableReplyMessageId(senderLabel, text);
     const replyButton = createReplyContextMenuButton(() => {
       props.onSetReply?.({
-        messageId,
+        messageId: replyMessageId,
         text,
         senderLabel,
         ...(entryId ? { sourceMessageId: entryId } : {}),
@@ -867,6 +873,49 @@ function handleChatContextMenu(event: MouseEvent, props: ChatThreadProps) {
       },
     });
     action.element.classList.add("chat-delete-wrap", "chat-rewind-wrap");
+    menu.append(action.element);
+    focusCandidates.push(action.button);
+  }
+  if (canHide) {
+    const action = createMessageActionContextButton({
+      label: t("chat.messages.hideMessage"),
+      disabled: false,
+      tooltip: t("chat.messages.hideTooltip"),
+      onClick: () => {
+        openChatHideConfirmation(action.button, () => {
+          removeReplyContextMenu();
+          getDeletedMessages(props.sessionKey).delete(groupKey);
+          props.onRequestUpdate?.();
+        });
+      },
+    });
+    action.element.classList.add("chat-delete-wrap");
+    menu.append(action.element);
+    focusCandidates.push(action.button);
+  }
+  if (canOpenInCanvas) {
+    const action = createMessageActionContextButton({
+      label: t("chat.messages.openInCanvas"),
+      disabled: false,
+      tooltip: t("chat.messages.openInCanvas"),
+      onClick: () => {
+        removeReplyContextMenu();
+        expandButton?.click();
+      },
+    });
+    menu.append(action.element);
+    focusCandidates.push(action.button);
+  }
+  if (canCopy) {
+    const action = createMessageActionContextButton({
+      label: COPY_LABEL,
+      disabled: false,
+      tooltip: COPY_LABEL,
+      onClick: () => {
+        removeReplyContextMenu();
+        copyButton?.click();
+      },
+    });
     menu.append(action.element);
     focusCandidates.push(action.button);
   }
@@ -1178,6 +1227,7 @@ function renderChatThreadContents(
       embedSandboxMode: props.embedSandboxMode ?? "scripts",
       allowExternalEmbedUrls: props.allowExternalEmbedUrls ?? false,
       contextWindow: threadContextWindow,
+      onReply: props.onSetReply,
       onDelete: () => {
         deleted.delete(item.key);
         requestUpdate();
@@ -1298,6 +1348,7 @@ function renderChatThreadContents(
     props.embedSandboxMode ?? "scripts",
     props.allowExternalEmbedUrls ?? false,
     threadContextWindow,
+    Boolean(props.onSetReply),
   ]);
   const transcriptContents =
     showLoadingSkeleton || isEmpty

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -1332,7 +1332,7 @@ function renderChatThreadContents(
     props.embedSandboxMode ?? "scripts",
     props.allowExternalEmbedUrls ?? false,
     threadContextWindow,
-    Boolean(props.onSetReply),
+    props.onSetReply,
   ]);
   const transcriptContents =
     showLoadingSkeleton || isEmpty

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -217,6 +217,7 @@
 .chat-message-actions-row button:hover {
   opacity: 1 !important;
   background: var(--bg-hover, rgba(255, 255, 255, 0.08));
+  color: var(--fg);
 }
 
 .chat-group-footer button svg,

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -217,7 +217,7 @@
 .chat-message-actions-row button:hover {
   opacity: 1 !important;
   background: var(--bg-hover, rgba(255, 255, 255, 0.08));
-  color: var(--fg);
+  color: var(--accent);
 }
 
 .chat-group-footer button svg,

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -521,9 +521,11 @@ img.chat-avatar {
 
   .chat-group-footer-actions .chat-copy-btn,
   .chat-group-footer-actions .chat-expand-btn,
+  .chat-group-footer-actions .chat-reply-btn,
   .chat-group-footer-actions .chat-group-delete,
   .chat-message-actions-row .chat-copy-btn,
-  .chat-message-actions-row .chat-expand-btn {
+  .chat-message-actions-row .chat-expand-btn,
+  .chat-message-actions-row .chat-reply-btn {
     min-width: 44px;
     min-height: 44px;
   }
@@ -533,7 +535,8 @@ img.chat-avatar {
    above own their look; the muted color also covers .btn hosts like the file
    preview header. */
 .chat-copy-btn,
-.chat-expand-btn {
+.chat-expand-btn,
+.chat-reply-btn {
   color: var(--muted);
 }
 
@@ -582,7 +585,8 @@ img.chat-avatar {
 }
 
 .chat-copy-btn:focus-visible,
-.chat-expand-btn:focus-visible {
+.chat-expand-btn:focus-visible,
+.chat-reply-btn:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
 }

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -1255,12 +1255,6 @@ openclaw-chat-page {
   outline: none;
 }
 
-.chat-reply-context-menu button svg {
-  width: 16px;
-  height: 16px;
-  flex-shrink: 0;
-}
-
 .chat-selection-popup {
   position: fixed;
   z-index: 9999;


### PR DESCRIPTION
## Summary

- add Reply to replyable user and assistant messages and keep hidden assistant thinking out of reply context
- align footer and right-click actions in the order Reply, Hide, Open in canvas, and Copy as markdown while retaining user Rewind and Fork actions
- give icon-only controls consistent shared tooltips, compact tooltip spacing, and visible accent/danger hover states
- bind grouped-message context actions to the clicked bubble and add focused unit plus Chromium interaction coverage

## Verification

- `OPENCLAW_CAPTURE_UI_PROOF=1 node scripts/run-vitest.mjs ui/src/components/tooltip.test.ts ui/src/pages/chat/components/chat-message.test.ts ui/src/pages/chat/chat-view.test.ts ui/src/e2e/chat-message-actions.e2e.test.ts` — 311 UI tests and 1 Chromium E2E test passed on the final rebased head
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main --stream-engine-output` — clean, no accepted or actionable findings
- Blacksmith Testbox `tbx_01ky17cy1dhjv051vh4f11kh91`: `corepack pnpm check:changed` passed ([run](https://github.com/openclaw/openclaw/actions/runs/29795433362)); after later overlapping `main` movement, the focused UI/browser suite was rerun on exact base `83ca537778d8a29136e5cf6a6641f2789fc86ea9`
- Rosita live UI verification by the maintainer

## Real behavior proof

Behavior addressed: Chat message actions were incomplete and inconsistent between the footer and right-click menu; shared tooltips could anchor incorrectly, render excess top whitespace, and some action buttons lacked a visible hover color.

Real environment tested: Rosita Control UI and dark-theme Chromium at 1440x900 against the repository's mocked Gateway browser harness.

Exact steps or command run after this patch: `OPENCLAW_CAPTURE_UI_PROOF=1 node scripts/run-vitest.mjs ui/src/components/tooltip.test.ts ui/src/pages/chat/components/chat-message.test.ts ui/src/pages/chat/chat-view.test.ts ui/src/e2e/chat-message-actions.e2e.test.ts`

Evidence after fix: The browser test exercises footer and context-menu ordering, click-specific grouped-message actions, compact and multiline tooltip geometry, clipboard/canvas/hide behavior, and exact resolved hover colors.

Observed result after fix: Both action surfaces present Reply, Hide, Open in canvas, and Copy as markdown consistently. Tooltips open against the intended control without extra top whitespace, authored multiline content is preserved, Reply/Canvas/Markdown use the accent hover color, and Hide retains the danger hover color.

What was not tested: Touch-only hardware; responsive touch-target styling was unchanged.
