### PR TITLE
fix(ui): use layout-dashboard glyph for session dashboard indicator

### DIFF
--- a/ui/src/components/app-sidebar-session-list.ts
+++ b/ui/src/components/app-sidebar-session-list.ts
@@ -146,7 +146,7 @@ export abstract class AppSidebarSessionListElement extends AppSidebarSessionNarr
                 role="img"
                 aria-label=${t("sessionsView.dashboardAvailable")}
                 title=${t("sessionsView.dashboardAvailable")}
-                >${icons.barChart}</span
+                >${icons.layoutDashboard}</span
               >`
             : nothing}
           <openclaw-viewer-facepile

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -273,7 +273,7 @@ class AppSidebar extends AppSidebarSessionListElement {
               role="img"
               aria-label=${t("sessionsView.dashboardAvailable")}
               title=${t("sessionsView.dashboardAvailable")}
-              >${icons.barChart}</span
+              >${icons.layoutDashboard}</span
             >`
           : nothing}
         ${stateBadge !== nothing || approvalNeeded

--- a/ui/src/components/icons.ts
+++ b/ui/src/components/icons.ts
@@ -27,6 +27,14 @@ export const icons = {
       <line x1="6" x2="6" y1="20" y2="16" />
     </svg>
   `,
+  layoutDashboard: html`
+    <svg viewBox="0 0 24 24">
+      <rect width="7" height="9" x="3" y="3" rx="1" />
+      <rect width="7" height="5" x="14" y="3" rx="1" />
+      <rect width="7" height="9" x="14" y="12" rx="1" />
+      <rect width="7" height="5" x="3" y="16" rx="1" />
+    </svg>
+  `,
   coins: html`
     <svg viewBox="0 0 24 24">
       <circle cx="8" cy="8" r="6" />


### PR DESCRIPTION
## What Problem This Solves

The "Dashboard available" glyph on sidebar session rows used the Lucide bar-chart icon (three bare vertical lines) rendered at 13px. At that size it reads as a signal-strength/statistics indicator, not as "this session has a dashboard", so the affordance was easy to miss or misread.

## Why This Change Was Made

Swap the glyph to the canonical layout-dashboard icon (uneven panels), which is the near-universal visual shorthand for "dashboard" and stays crisp at 13px. The icon is added as a new `icons.layoutDashboard` entry; `icons.barChart` is kept untouched because it is still the correct icon for the `/status` and `/usage` chat commands and the tokens stat on the sessions page — only the two `sidebar-board-glyph` call sites change (`ui/src/components/app-sidebar.ts`, `ui/src/components/app-sidebar-session-list.ts`). It also stays distinct from the Apps nav icon, which uses the equal-squares `layoutGrid`.

## User Impact

Session rows (and the Home row) that have a dashboard now show a recognizable dashboard glyph instead of an ambiguous bar chart. No behavior, labels, or accessibility strings change.

## Evidence

Before/after at actual sidebar size (13px, same stroke width and accent color as `.sidebar-board-glyph`):

![before/after](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/dashboard-glyph/before-after.png)

- Icon-only markup change; no tests reference the old glyph (`rg "barChart|board-glyph" ui/src --glob "*test*"` is empty).
- Autoreview (Codex gpt-5.6-sol, xhigh): clean, no accepted/actionable findings.
- Hosted PR CI covers typecheck/lint/UI lanes (no-node_modules worktree; remote gates).
