### PR TITLE
fix(ci): prevent maturity evidence runs from timing out

### DIFF
--- a/.github/workflows/qa-profile-evidence.yml
+++ b/.github/workflows/qa-profile-evidence.yml
@@ -197,7 +197,7 @@ jobs:
     name: Generate QA profile evidence
     needs: validate_selected_ref
     runs-on: blacksmith-8vcpu-ubuntu-2404
-    timeout-minutes: ${{ inputs.qa_profile == 'all' && 240 || 60 }}
+    timeout-minutes: ${{ (inputs.qa_profile == 'all' || inputs.qa_profile == 'release') && 240 || 60 }}
     permissions:
       contents: read
     outputs:
@@ -303,6 +303,7 @@ jobs:
           pnpm openclaw qa run \
             --repo-root . \
             --qa-profile "${QA_PROFILE}" \
+            --fast \
             --output-dir "${output_dir}" || qa_exit_code=$?
 
           echo "qa_exit_code=${qa_exit_code}" >> "$GITHUB_OUTPUT"

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -4616,6 +4616,9 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
     expect(qaEvidenceWorkflow.on.workflow_dispatch.inputs.qa_profile).not.toHaveProperty("options");
     expect(qaEvidenceWorkflow.on.workflow_dispatch.inputs.qa_profile.default).toBe("all");
     expect(qaEvidenceWorkflow.on.workflow_call.inputs.qa_profile.type).toBe("string");
+    expect(qaRunJob["timeout-minutes"]).toBe(
+      "${{ (inputs.qa_profile == 'all' || inputs.qa_profile == 'release') && 240 || 60 }}",
+    );
     const validateProfileStep = qaRunJob.steps.find(
       (step: WorkflowStep) => step.name === "Validate QA profile input",
     );
@@ -4627,6 +4630,10 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
       (step: WorkflowStep) => step.name === "Ensure Playwright Chromium",
     );
     expect(ensurePlaywrightStep.run).toBe("node scripts/ensure-playwright-chromium.mjs");
+    const runProfileStep = qaRunJob.steps.find(
+      (step: WorkflowStep) => step.name === "Run QA profile",
+    );
+    expect(runProfileStep.run).toContain("--fast");
     expect(generateJob.needs).toEqual(["validate_selected_ref", "publisher_preflight"]);
     expect(generateJob.if.replace(/\s+/gu, " ")).toBe(
       "${{ always() && needs.validate_selected_ref.result == 'success' && (!inputs.publish_pull_request || needs.publisher_preflight.result == 'success') && inputs.qa_evidence_run_id == '' }}",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where maintainers regenerating maturity scorecard evidence could lose an almost-complete QA run because the `release` profile received only a 60-minute job budget and live-provider scenarios ran without fast mode.

## Why This Change Was Made

The `release` profile selects 283 scenarios, only seven fewer than `all`, so both profiles now receive the existing 240-minute evidence budget. Profile evidence runs also enable the supported `--fast` mode required by the live OpenAI QA path.

## User Impact

Maintainers can run release and full maturity evidence with a realistic completion budget and lower live-provider pressure. Product runtime behavior is unchanged.

## Evidence

- Failed full evidence run after 76 of 81 Matrix scenarios: https://github.com/openclaw/openclaw/actions/runs/29726905855
- Under-budget release run showing the 283-scenario workload: https://github.com/openclaw/openclaw/actions/runs/29787208334
- `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts` — 87 passed, 1 skipped
- `git diff --check`
- Autoreview: clean, no accepted or actionable findings

AI-assisted: yes. I understand the workflow and test changes.