### PR TITLE
fix(agents): give cold prepared-model-runtime builds a 120s startup budget

### DIFF
--- a/src/agents/prepared-model-runtime.ts
+++ b/src/agents/prepared-model-runtime.ts
@@ -38,7 +38,11 @@ export type {
 } from "./prepared-model-runtime.owner.js";
 
 const log = createSubsystemLogger("agents/prepared-model-runtime");
-const DEFAULT_MODEL_RUNTIME_BUILD_TIMEOUT_MS = 30_000;
+// This bound only detects hung builds; overlap safety comes from the completion
+// chain, and a timeout here is fatal to gateway startup. Cold builds (plugin
+// metadata + model catalog + stores) legitimately exceed 30s on slow or loaded
+// hosts, so match the 120s startup-grace scale used by channel connect.
+const DEFAULT_MODEL_RUNTIME_BUILD_TIMEOUT_MS = 120_000;
 let modelRuntimeBuildTimeoutMs = DEFAULT_MODEL_RUNTIME_BUILD_TIMEOUT_MS;
 
 const owners = new Map<string, PreparedModelRuntimeOwner>();


### PR DESCRIPTION
## What Problem This Solves

`DEFAULT_MODEL_RUNTIME_BUILD_TIMEOUT_MS` is 30s, and hitting it is fatal to gateway startup ("Gateway failed to start: prepared model runtime publication timed out"). A legitimately slow cold build — fresh state dir on a loaded or slow host, source checkout, many plugins — can exceed 30s without anything being wrong: a startup stability bundle captured `plugins.load` alone at 16.9s under moderate load, and a fresh-state boot on a heavily loaded Mac needed ~2.5 minutes to reach `[gateway] ready` once the bound was raised.

## Why This Change Was Made

The timeout only bounds *waiting*: `startSerializedSnapshotBuild` keeps the real build running behind the `completion` chain, which is what protects generation overlap. So this bound exists purely to catch hung builds, and the cost of a false positive (dead gateway on startup) vastly outweighs the cost of waiting longer for a true hang. 120s matches the repo's established startup-patience scale (`DEFAULT_CHANNEL_CONNECT_*` grace and command-lane task budgets are 120s). The wedged-build failure mode that originally surfaced this (#111627) was a distinct staleness bug fixed in #111701; with that fixed, builds exceeding 30s are slow hosts, not hangs.

## User Impact

Fresh-state and slow-host gateway startups no longer die at 30s while a healthy build is still in progress; a genuinely hung build still fails with the same clear error, after 2 minutes.

## Evidence

- `node scripts/run-vitest.mjs src/agents/prepared-model-runtime.lifecycle.test.ts src/agents/prepared-model-runtime.test.ts` — 64 tests passed (tests pin timeouts via `setModelRuntimeBuildTimeoutMsForTest`, so no fixture depends on the default).
- Observed during #111615's live verification: with the 30s default a fresh-state boot on a loaded host died at the timeout; with the bound raised the same boot reached `[gateway] ready` and served RPCs (~2.5 min under load ~400, well under 120s on an idle Mac).
- Codex autoreview clean (patch is correct, 0.98).
