### PR TITLE
feat(macos): manage Gateway profiles and multiple windows

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -30570,6 +30570,190 @@
       "id": "native.apple.4bd8ea604f3c21fa"
     },
     {
+      "kind": "ui-modifier",
+      "line": 43,
+      "path": "apps/macos/Sources/OpenClaw/GatewaySettings.swift",
+      "source": "Remove Gateway?",
+      "surface": "apple",
+      "id": "native.apple.e0b70da297ef8a61"
+    },
+    {
+      "kind": "ui-call",
+      "line": 53,
+      "path": "apps/macos/Sources/OpenClaw/GatewaySettings.swift",
+      "source": "Remove",
+      "surface": "apple",
+      "id": "native.apple.983c58888b89f27f"
+    },
+    {
+      "kind": "ui-call",
+      "line": 63,
+      "path": "apps/macos/Sources/OpenClaw/GatewaySettings.swift",
+      "source": "\\(profile.name) and its saved credentials will be removed. Its open windows will close.",
+      "surface": "apple",
+      "id": "native.apple.7b53872a9637b308"
+    },
+    {
+      "kind": "ui-modifier",
+      "line": 66,
+      "path": "apps/macos/Sources/OpenClaw/GatewaySettings.swift",
+      "source": "Gateway Error",
+      "surface": "apple",
+      "id": "native.apple.a4d437ba492adc8b"
+    },
+    {
+      "kind": "ui-call",
+      "line": 73,
+      "path": "apps/macos/Sources/OpenClaw/GatewaySettings.swift",
+      "source": "OK",
+      "surface": "apple",
+      "id": "native.apple.33c3c61e0fb62195"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 84,
+      "path": "apps/macos/Sources/OpenClaw/GatewaySettings.swift",
+      "source": "Gateways",
+      "surface": "apple",
+      "id": "native.apple.bfd13b43b2fd425c"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 85,
+      "path": "apps/macos/Sources/OpenClaw/GatewaySettings.swift",
+      "source": "Save Gateway connections for chat windows. The primary Gateway under Connection still owns Mac integrations and Talk Mode.",
+      "surface": "apple",
+      "id": "native.apple.1ff05976802ac6c9"
+    },
+    {
+      "kind": "ui-call",
+      "line": 104,
+      "path": "apps/macos/Sources/OpenClaw/GatewaySettings.swift",
+      "source": "Loading Gateways…",
+      "surface": "apple",
+      "id": "native.apple.7fdfccfafd3ff368"
+    },
+    {
+      "kind": "ui-call",
+      "line": 112,
+      "path": "apps/macos/Sources/OpenClaw/GatewaySettings.swift",
+      "source": "No Gateways saved",
+      "surface": "apple",
+      "id": "native.apple.593c7f1b06caf821"
+    },
+    {
+      "kind": "ui-call",
+      "line": 114,
+      "path": "apps/macos/Sources/OpenClaw/GatewaySettings.swift",
+      "source": "Add a Gateway here, then use File → New Gateway Window… (⌘N) whenever you want another window for it.",
+      "surface": "apple",
+      "id": "native.apple.9053ce4456cc06f0"
+    },
+    {
+      "kind": "ui-call",
+      "line": 125,
+      "path": "apps/macos/Sources/OpenClaw/GatewaySettings.swift",
+      "source": "Saved Gateways",
+      "surface": "apple",
+      "id": "native.apple.5b3b79e66c434e33"
+    },
+    {
+      "kind": "ui-call",
+      "line": 133,
+      "path": "apps/macos/Sources/OpenClaw/GatewaySettings.swift",
+      "source": "Open Window",
+      "surface": "apple",
+      "id": "native.apple.c49f6831863c8dae"
+    },
+    {
+      "kind": "ui-modifier",
+      "line": 145,
+      "path": "apps/macos/Sources/OpenClaw/GatewaySettings.swift",
+      "source": "Remove \\(profile.name)",
+      "surface": "apple",
+      "id": "native.apple.3c90290e04c6dc5f"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 194,
+      "path": "apps/macos/Sources/OpenClaw/GatewaySettings.swift",
+      "source": "Add Gateway",
+      "surface": "apple",
+      "id": "native.apple.98935e9c19760b62"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 195,
+      "path": "apps/macos/Sources/OpenClaw/GatewaySettings.swift",
+      "source": "Credentials are stored with this profile in your Mac Keychain.",
+      "surface": "apple",
+      "id": "native.apple.fb5076533e3003a3"
+    },
+    {
+      "kind": "ui-call",
+      "line": 199,
+      "path": "apps/macos/Sources/OpenClaw/GatewaySettings.swift",
+      "source": "Name",
+      "surface": "apple",
+      "id": "native.apple.a7ee8d846fd61525"
+    },
+    {
+      "kind": "ui-call",
+      "line": 200,
+      "path": "apps/macos/Sources/OpenClaw/GatewaySettings.swift",
+      "source": "Studio",
+      "surface": "apple",
+      "id": "native.apple.c65e3cdc3d2c9b36"
+    },
+    {
+      "kind": "ui-call",
+      "line": 204,
+      "path": "apps/macos/Sources/OpenClaw/GatewaySettings.swift",
+      "source": "Gateway URL",
+      "surface": "apple",
+      "id": "native.apple.ce48afbb966a6933"
+    },
+    {
+      "kind": "ui-call",
+      "line": 205,
+      "path": "apps/macos/Sources/OpenClaw/GatewaySettings.swift",
+      "source": "wss://gateway.example.com",
+      "surface": "apple",
+      "id": "native.apple.aeb21e4c3192125f"
+    },
+    {
+      "kind": "ui-call",
+      "line": 209,
+      "path": "apps/macos/Sources/OpenClaw/GatewaySettings.swift",
+      "source": "Token",
+      "surface": "apple",
+      "id": "native.apple.f585ed08c1f6a65e"
+    },
+    {
+      "kind": "ui-call",
+      "line": 214,
+      "path": "apps/macos/Sources/OpenClaw/GatewaySettings.swift",
+      "source": "Password",
+      "surface": "apple",
+      "id": "native.apple.9a090d8a5c8fb7cb"
+    },
+    {
+      "kind": "ui-call",
+      "line": 215,
+      "path": "apps/macos/Sources/OpenClaw/GatewaySettings.swift",
+      "source": "Optional",
+      "surface": "apple",
+      "id": "native.apple.f3448df352fdd5d4"
+    },
+    {
+      "kind": "ui-call",
+      "line": 232,
+      "path": "apps/macos/Sources/OpenClaw/GatewaySettings.swift",
+      "source": "Cancel",
+      "surface": "apple",
+      "id": "native.apple.1f1c9084eb6a2982"
+    },
+    {
       "kind": "ui-named-argument",
       "line": 76,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
@@ -35355,7 +35539,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 474,
+      "line": 476,
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
       "source": "General",
       "surface": "apple",
@@ -35363,7 +35547,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 475,
+      "line": 477,
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
       "source": "Connection",
       "surface": "apple",
@@ -35371,7 +35555,15 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 476,
+      "line": 478,
+      "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
+      "source": "Gateways",
+      "surface": "apple",
+      "id": "native.apple.1d96f676261a5a05"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 479,
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
       "source": "Permissions",
       "surface": "apple",
@@ -35379,7 +35571,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 477,
+      "line": 480,
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
       "source": "Voice & Talk",
       "surface": "apple",
@@ -35387,7 +35579,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 478,
+      "line": 481,
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
       "source": "OpenClaw",
       "surface": "apple",
@@ -35395,7 +35587,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 479,
+      "line": 482,
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
       "source": "Channels",
       "surface": "apple",
@@ -35403,7 +35595,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 480,
+      "line": 483,
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
       "source": "Skills",
       "surface": "apple",
@@ -35411,7 +35603,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 481,
+      "line": 484,
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
       "source": "Cron Jobs",
       "surface": "apple",
@@ -35419,7 +35611,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 482,
+      "line": 485,
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
       "source": "Exec Approvals",
       "surface": "apple",
@@ -35427,7 +35619,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 483,
+      "line": 486,
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
       "source": "Threads",
       "surface": "apple",
@@ -35435,7 +35627,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 484,
+      "line": 487,
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
       "source": "Instances",
       "surface": "apple",
@@ -35443,7 +35635,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 485,
+      "line": 488,
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
       "source": "Config",
       "surface": "apple",
@@ -35451,7 +35643,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 486,
+      "line": 489,
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
       "source": "Debug",
       "surface": "apple",
@@ -35459,7 +35651,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 487,
+      "line": 490,
       "path": "apps/macos/Sources/OpenClaw/SettingsRootView.swift",
       "source": "About",
       "surface": "apple",
@@ -36938,8 +37130,16 @@
       "id": "native.apple.26960f2b7ebad5f9"
     },
     {
+      "kind": "ui-named-argument",
+      "line": 143,
+      "path": "apps/macos/Sources/OpenClaw/WebChatManager.swift",
+      "source": "Could Not Open Gateway Window",
+      "surface": "apple",
+      "id": "native.apple.7dd4d4d2fc36ffce"
+    },
+    {
       "kind": "ui-localized-call",
-      "line": 838,
+      "line": 854,
       "path": "apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift",
       "source": "Talk mode uses the primary Gateway window",
       "surface": "apple",
@@ -36947,7 +37147,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 840,
+      "line": 856,
       "path": "apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift",
       "source": "Talk mode off",
       "surface": "apple",
@@ -36955,7 +37155,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 841,
+      "line": 858,
       "path": "apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift",
       "source": "Talk mode paused",
       "surface": "apple",
@@ -36963,7 +37163,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 843,
+      "line": 861,
       "path": "apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift",
       "source": "Talk mode ready",
       "surface": "apple",
@@ -36971,7 +37171,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 844,
+      "line": 862,
       "path": "apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift",
       "source": "Listening",
       "surface": "apple",
@@ -36979,7 +37179,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 845,
+      "line": 863,
       "path": "apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift",
       "source": "Thinking",
       "surface": "apple",
@@ -36987,7 +37187,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 846,
+      "line": 864,
       "path": "apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift",
       "source": "Speaking",
       "surface": "apple",
@@ -36995,7 +37195,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 850,
+      "line": 868,
       "path": "apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift",
       "source": "What would you like to work on?",
       "surface": "apple",
@@ -37003,7 +37203,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 854,
+      "line": 872,
       "path": "apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift",
       "source": "Check OpenClaw status",
       "surface": "apple",
@@ -37011,7 +37211,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 855,
+      "line": 873,
       "path": "apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift",
       "source": "Summarize the current OpenClaw status and tell me what needs attention.",
       "surface": "apple",
@@ -37019,7 +37219,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 858,
+      "line": 876,
       "path": "apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift",
       "source": "What can you do?",
       "surface": "apple",
@@ -37027,7 +37227,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 859,
+      "line": 877,
       "path": "apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift",
       "source": "Show me what you can help with on this Mac right now.",
       "surface": "apple",
@@ -37035,7 +37235,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 862,
+      "line": 880,
       "path": "apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift",
       "source": "Catch me up",
       "surface": "apple",
@@ -37043,7 +37243,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 863,
+      "line": 881,
       "path": "apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift",
       "source": "Summarize what happened in my threads since yesterday.",
       "surface": "apple",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -30618,7 +30618,7 @@
       "id": "native.apple.bfd13b43b2fd425c"
     },
     {
-      "kind": "ui-named-argument",
+      "kind": "ui-named-argument-multiline",
       "line": 85,
       "path": "apps/macos/Sources/OpenClaw/GatewaySettings.swift",
       "source": "Save Gateway connections for chat windows. The primary Gateway under Connection still owns Mac integrations and Talk Mode.",
@@ -30627,7 +30627,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 104,
+      "line": 107,
       "path": "apps/macos/Sources/OpenClaw/GatewaySettings.swift",
       "source": "Loading Gateways…",
       "surface": "apple",
@@ -30635,7 +30635,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 112,
+      "line": 115,
       "path": "apps/macos/Sources/OpenClaw/GatewaySettings.swift",
       "source": "No Gateways saved",
       "surface": "apple",
@@ -30643,7 +30643,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 114,
+      "line": 117,
       "path": "apps/macos/Sources/OpenClaw/GatewaySettings.swift",
       "source": "Add a Gateway here, then use File → New Gateway Window… (⌘N) whenever you want another window for it.",
       "surface": "apple",
@@ -30651,7 +30651,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 125,
+      "line": 131,
       "path": "apps/macos/Sources/OpenClaw/GatewaySettings.swift",
       "source": "Saved Gateways",
       "surface": "apple",
@@ -30659,7 +30659,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 133,
+      "line": 139,
       "path": "apps/macos/Sources/OpenClaw/GatewaySettings.swift",
       "source": "Open Window",
       "surface": "apple",
@@ -30667,7 +30667,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 145,
+      "line": 151,
       "path": "apps/macos/Sources/OpenClaw/GatewaySettings.swift",
       "source": "Remove \\(profile.name)",
       "surface": "apple",
@@ -30675,7 +30675,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 194,
+      "line": 200,
       "path": "apps/macos/Sources/OpenClaw/GatewaySettings.swift",
       "source": "Add Gateway",
       "surface": "apple",
@@ -30683,7 +30683,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 195,
+      "line": 201,
       "path": "apps/macos/Sources/OpenClaw/GatewaySettings.swift",
       "source": "Credentials are stored with this profile in your Mac Keychain.",
       "surface": "apple",
@@ -30691,7 +30691,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 199,
+      "line": 205,
       "path": "apps/macos/Sources/OpenClaw/GatewaySettings.swift",
       "source": "Name",
       "surface": "apple",
@@ -30699,7 +30699,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 200,
+      "line": 206,
       "path": "apps/macos/Sources/OpenClaw/GatewaySettings.swift",
       "source": "Studio",
       "surface": "apple",
@@ -30707,7 +30707,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 204,
+      "line": 210,
       "path": "apps/macos/Sources/OpenClaw/GatewaySettings.swift",
       "source": "Gateway URL",
       "surface": "apple",
@@ -30715,7 +30715,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 205,
+      "line": 211,
       "path": "apps/macos/Sources/OpenClaw/GatewaySettings.swift",
       "source": "wss://gateway.example.com",
       "surface": "apple",
@@ -30723,7 +30723,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 209,
+      "line": 215,
       "path": "apps/macos/Sources/OpenClaw/GatewaySettings.swift",
       "source": "Token",
       "surface": "apple",
@@ -30731,7 +30731,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 214,
+      "line": 220,
       "path": "apps/macos/Sources/OpenClaw/GatewaySettings.swift",
       "source": "Password",
       "surface": "apple",
@@ -30739,7 +30739,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 215,
+      "line": 221,
       "path": "apps/macos/Sources/OpenClaw/GatewaySettings.swift",
       "source": "Optional",
       "surface": "apple",
@@ -30747,7 +30747,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 232,
+      "line": 238,
       "path": "apps/macos/Sources/OpenClaw/GatewaySettings.swift",
       "source": "Cancel",
       "surface": "apple",

--- a/apps/macos/Sources/OpenClaw/GatewaySettings.swift
+++ b/apps/macos/Sources/OpenClaw/GatewaySettings.swift
@@ -1,0 +1,286 @@
+import SwiftUI
+
+@MainActor
+struct GatewaySettings: View {
+    @State private var profiles: [MacGatewayProfile]
+    @State private var hasLoaded: Bool
+    @State private var isLoading = false
+    @State private var isRemoving = false
+    @State private var showsAddGateway = false
+    @State private var pendingRemoval: MacGatewayProfile?
+    @State private var errorMessage: String?
+    private let isPreview: Bool
+
+    init(
+        profiles: [MacGatewayProfile]? = nil,
+        isPreview: Bool = ProcessInfo.processInfo.isPreview)
+    {
+        _profiles = State(initialValue: profiles ?? [])
+        _hasLoaded = State(initialValue: profiles != nil)
+        self.isPreview = isPreview
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            self.header
+            self.content
+            Spacer(minLength: 0)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .settingsDetailContent()
+        .task {
+            guard !self.hasLoaded, !self.isPreview else { return }
+            self.hasLoaded = true
+            await self.refresh()
+        }
+        .sheet(isPresented: self.$showsAddGateway) {
+            GatewayProfileEditor { profile in
+                self.profiles.removeAll { $0.id == profile.id }
+                self.profiles.append(profile)
+                self.profiles = MacGatewayProfileStore.sortedProfiles(self.profiles)
+            }
+        }
+        .alert("Remove Gateway?", isPresented: Binding(
+            get: { self.pendingRemoval != nil },
+            set: {
+                if !$0 {
+                    self.pendingRemoval = nil
+                }
+            })) {
+                Button("Cancel", role: .cancel) {
+                    self.pendingRemoval = nil
+                }
+                Button("Remove", role: .destructive) {
+                    guard let profile = self.pendingRemoval else { return }
+                    self.pendingRemoval = nil
+                    // Serialize profile mutations across the Keychain and
+                    // connection-shutdown awaits so a same-ID re-add cannot race.
+                    self.isRemoving = true
+                    Task { await self.remove(profile) }
+                }
+        } message: {
+            if let profile = self.pendingRemoval {
+                Text("\(profile.name) and its saved credentials will be removed. Its open windows will close.")
+            }
+        }
+        .alert("Gateway Error", isPresented: Binding(
+            get: { self.errorMessage != nil },
+            set: {
+                if !$0 {
+                    self.errorMessage = nil
+                }
+            })) {
+                Button("OK") {
+                    self.errorMessage = nil
+                }
+        } message: {
+            Text(self.errorMessage ?? "")
+        }
+    }
+
+    private var header: some View {
+        HStack(alignment: .top, spacing: 16) {
+            SettingsPageHeader(
+                title: "Gateways",
+                subtitle: "Save Gateway connections for chat windows. The primary Gateway under Connection still owns Mac integrations and Talk Mode.")
+            Spacer(minLength: 16)
+            Button {
+                guard !self.isRemoving else { return }
+                self.showsAddGateway = true
+            } label: {
+                Label("Add Gateway", systemImage: "plus")
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(self.isRemoving)
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if self.isLoading, self.profiles.isEmpty {
+            HStack(spacing: 8) {
+                ProgressView()
+                    .controlSize(.small)
+                Text("Loading Gateways…")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.top, 8)
+        } else if self.profiles.isEmpty {
+            SettingsCardGroup("Saved Gateways") {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("No Gateways saved")
+                        .font(.callout.weight(.medium))
+                    Text(
+                        "Add a Gateway here, then use File → New Gateway Window… (⌘N) whenever you want another window for it.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                .padding(.horizontal, 14)
+                .padding(.vertical, 13)
+            }
+        } else {
+            ScrollView(.vertical) {
+                SettingsCardGroup("Saved Gateways") {
+                    ForEach(Array(self.profiles.enumerated()), id: \.element.id) { index, profile in
+                        SettingsCardRow(
+                            title: profile.name,
+                            subtitle: profile.url.absoluteString,
+                            showsDivider: index != self.profiles.count - 1)
+                        {
+                            HStack(spacing: 8) {
+                                Button("Open Window") {
+                                    guard !self.isRemoving else { return }
+                                    WebChatManager.shared.openGatewayWindow(profile: profile)
+                                }
+                                .disabled(self.isRemoving)
+                                Button(role: .destructive) {
+                                    guard !self.isRemoving else { return }
+                                    self.pendingRemoval = profile
+                                } label: {
+                                    Image(systemName: "trash")
+                                }
+                                .accessibilityLabel("Remove \(profile.name)")
+                                .help("Remove \(profile.name)")
+                                .disabled(self.isRemoving)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private func refresh() async {
+        self.isLoading = true
+        defer { self.isLoading = false }
+        do {
+            self.profiles = try await MacGatewayProfileStore.shared.profiles()
+        } catch {
+            self.errorMessage = error.localizedDescription
+        }
+    }
+
+    private func remove(_ profile: MacGatewayProfile) async {
+        defer { self.isRemoving = false }
+        do {
+            try await MacGatewayProfileStore.shared.remove(profileID: profile.id)
+            // Reflect the durable removal before connection shutdown suspends;
+            // a same-endpoint re-add during shutdown must remain visible.
+            self.profiles.removeAll { $0.id == profile.id }
+            await WebChatManager.shared.closeGatewayWindows(profileID: profile.id)
+        } catch {
+            self.errorMessage = error.localizedDescription
+        }
+    }
+}
+
+@MainActor
+private struct GatewayProfileEditor: View {
+    @Environment(\.dismiss) private var dismiss
+    @State private var name = ""
+    @State private var url = "wss://"
+    @State private var token = ""
+    @State private var password = ""
+    @State private var isSaving = false
+    @State private var errorMessage: String?
+
+    let onSaved: (MacGatewayProfile) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            SettingsPageHeader(
+                title: "Add Gateway",
+                subtitle: "Credentials are stored with this profile in your Mac Keychain.")
+
+            Grid(alignment: .leadingFirstTextBaseline, horizontalSpacing: 14, verticalSpacing: 12) {
+                GridRow {
+                    Text("Name")
+                    TextField("Studio", text: self.$name)
+                        .textFieldStyle(.roundedBorder)
+                }
+                GridRow {
+                    Text("Gateway URL")
+                    TextField("wss://gateway.example.com", text: self.$url)
+                        .textFieldStyle(.roundedBorder)
+                }
+                GridRow {
+                    Text("Token")
+                    SecureField("Optional", text: self.$token)
+                        .textFieldStyle(.roundedBorder)
+                }
+                GridRow {
+                    Text("Password")
+                    SecureField("Optional", text: self.$password)
+                        .textFieldStyle(.roundedBorder)
+                }
+            }
+            .gridColumnAlignment(.leading)
+
+            if let errorMessage {
+                Text(errorMessage)
+                    .font(.footnote)
+                    .foregroundStyle(.red)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Divider()
+
+            HStack {
+                Spacer()
+                Button("Cancel", role: .cancel) {
+                    self.dismiss()
+                }
+                .keyboardShortcut(.cancelAction)
+                Button("Add Gateway") {
+                    Task { await self.save() }
+                }
+                .keyboardShortcut(.defaultAction)
+                .disabled(self.isSaving || self.url.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+        }
+        .padding(24)
+        .frame(width: 540)
+    }
+
+    private func save() async {
+        self.isSaving = true
+        self.errorMessage = nil
+        defer { self.isSaving = false }
+        do {
+            let rawURL = self.url.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard let url = URL(string: rawURL) else {
+                throw MacGatewayProfileError.invalidURL
+            }
+            let profile = try await MacGatewayProfileStore.shared.upsert(
+                name: self.name,
+                url: url,
+                token: self.token,
+                password: self.password)
+            WebChatManager.shared.gatewayProfileDidSave(profileID: profile.id)
+            self.onSaved(profile)
+            self.dismiss()
+        } catch {
+            self.errorMessage = error.localizedDescription
+        }
+    }
+}
+
+#if DEBUG
+struct GatewaySettings_Previews: PreviewProvider {
+    static var previews: some View {
+        GatewaySettings(profiles: [
+            MacGatewayProfile(
+                id: "studio",
+                name: "Studio",
+                url: URL(string: "wss://studio.example:443/")!),
+            MacGatewayProfile(
+                id: "production",
+                name: "Production",
+                url: URL(string: "wss://gateway.example:443/")!),
+        ])
+        .frame(width: 840, height: 620)
+    }
+}
+#endif

--- a/apps/macos/Sources/OpenClaw/GatewaySettings.swift
+++ b/apps/macos/Sources/OpenClaw/GatewaySettings.swift
@@ -82,7 +82,10 @@ struct GatewaySettings: View {
         HStack(alignment: .top, spacing: 16) {
             SettingsPageHeader(
                 title: "Gateways",
-                subtitle: "Save Gateway connections for chat windows. The primary Gateway under Connection still owns Mac integrations and Talk Mode.")
+                subtitle: """
+                Save Gateway connections for chat windows. The primary Gateway under \
+                Connection still owns Mac integrations and Talk Mode.
+                """)
             Spacer(minLength: 16)
             Button {
                 guard !self.isRemoving else { return }
@@ -112,7 +115,10 @@ struct GatewaySettings: View {
                     Text("No Gateways saved")
                         .font(.callout.weight(.medium))
                     Text(
-                        "Add a Gateway here, then use File → New Gateway Window… (⌘N) whenever you want another window for it.")
+                        """
+                        Add a Gateway here, then use File → New Gateway Window… (⌘N) whenever \
+                        you want another window for it.
+                        """)
                         .font(.footnote)
                         .foregroundStyle(.secondary)
                         .fixedSize(horizontal: false, vertical: true)

--- a/apps/macos/Sources/OpenClaw/MacGatewayProfiles.swift
+++ b/apps/macos/Sources/OpenClaw/MacGatewayProfiles.swift
@@ -78,6 +78,19 @@ actor MacGatewayProfileStore {
         return profile
     }
 
+    func profiles() throws -> [MacGatewayProfile] {
+        try Self.sortedProfiles(self.loadRegistry().profiles.map(\.profile))
+    }
+
+    func remove(profileID: String) throws {
+        var registry = try self.loadRegistry()
+        guard registry.profiles.contains(where: { $0.profile.id == profileID }) else {
+            throw MacGatewayProfileError.profileNotFound
+        }
+        registry.profiles.removeAll { $0.profile.id == profileID }
+        try Self.save(JSONEncoder().encode(registry), account: Self.registryAccount)
+    }
+
     func endpoint(profileID: String) throws -> GatewayConnection.EndpointSnapshot {
         let registry = try self.loadRegistry()
         guard let stored = registry.profiles.first(where: { $0.profile.id == profileID }) else {
@@ -107,6 +120,16 @@ actor MacGatewayProfileStore {
 
     static func validateRegistryData(_ data: Data) throws {
         _ = try MacGatewayProfileStore.decodeRegistry(data)
+    }
+
+    static func sortedProfiles(_ profiles: [MacGatewayProfile]) -> [MacGatewayProfile] {
+        profiles.sorted { lhs, rhs in
+            let nameOrder = lhs.name.localizedCaseInsensitiveCompare(rhs.name)
+            if nameOrder != .orderedSame {
+                return nameOrder == .orderedAscending
+            }
+            return lhs.url.absoluteString.localizedCaseInsensitiveCompare(rhs.url.absoluteString) == .orderedAscending
+        }
     }
 
     static func canonicalURL(_ url: URL) throws -> URL {
@@ -206,6 +229,11 @@ actor MacGatewayConnectionFleet {
             supportsSharedEndpointRecovery: false)
         self.connections[profileID] = connection
         return connection
+    }
+
+    func remove(profileID: String) async {
+        guard let connection = self.connections.removeValue(forKey: profileID) else { return }
+        await connection.shutdown()
     }
 
     func shutdown() async {

--- a/apps/macos/Sources/OpenClaw/SettingsRootView.swift
+++ b/apps/macos/Sources/OpenClaw/SettingsRootView.swift
@@ -28,13 +28,13 @@ struct SettingsRootView: View {
         let initial = initialTab ?? .general
         self.state = state
         self.updater = updater
-        self._selectedTab = State(initialValue: initial)
-        self._cachedTabs = State(initialValue: [initial])
-        self._inferenceConfiguration = State(initialValue: configuredInferenceModel.map {
+        _selectedTab = State(initialValue: initial)
+        _cachedTabs = State(initialValue: [initial])
+        _inferenceConfiguration = State(initialValue: configuredInferenceModel.map {
             .loaded($0)
         } ?? .loading)
-        self._trackedInferenceGatewayID = State(initialValue: nil)
-        self._deferredTab = State(initialValue: nil)
+        _trackedInferenceGatewayID = State(initialValue: nil)
+        _deferredTab = State(initialValue: nil)
     }
 
     var body: some View {
@@ -217,6 +217,8 @@ struct SettingsRootView: View {
             AnyView(GeneralSettings(state: self.state, page: .general, isActive: self.selectedTab == tab))
         case .connection:
             AnyView(GeneralSettings(state: self.state, page: .connection, isActive: self.selectedTab == tab))
+        case .gateways:
+            AnyView(GatewaySettings())
         case .permissions:
             AnyView(PermissionsSettings(
                 status: self.permissionMonitor.status,
@@ -321,7 +323,7 @@ struct SettingsRootView: View {
             self.inferenceConfiguration = Self.configurationAfterInferenceRefresh(
                 current: self.inferenceConfiguration,
                 result: .confirmed(model))
-            if let deferredTab = self.deferredTab {
+            if let deferredTab {
                 self.selectRequestedTab(deferredTab)
             }
         } catch is CancellationError {
@@ -441,8 +443,8 @@ struct SettingsTabGroup: Identifiable {
 
     static func defaultGroups(showDebug: Bool, showSystemAgent: Bool) -> [SettingsTabGroup] {
         let basicTabs: [SettingsTab] = showSystemAgent
-            ? [.general, .connection, .permissions, .voiceWake, .systemAgent]
-            : [.general, .connection, .permissions, .voiceWake]
+            ? [.general, .connection, .gateways, .permissions, .voiceWake, .systemAgent]
+            : [.general, .connection, .gateways, .permissions, .voiceWake]
         var groups = [
             SettingsTabGroup(title: "Basics", tabs: basicTabs),
             SettingsTabGroup(title: "Automation", tabs: [.channels, .skills, .cron, .execApprovals]),
@@ -460,7 +462,7 @@ struct SettingsTabGroup: Identifiable {
 }
 
 enum SettingsTab: CaseIterable, Identifiable, Hashable {
-    case general, connection, permissions, voiceWake, systemAgent, channels, skills, cron
+    case general, connection, gateways, permissions, voiceWake, systemAgent, channels, skills, cron
     case execApprovals, sessions, instances, config, debug, about
     static let windowWidth: CGFloat = 1120
     static let windowHeight: CGFloat = 790
@@ -473,6 +475,7 @@ enum SettingsTab: CaseIterable, Identifiable, Hashable {
         switch self {
         case .general: "General"
         case .connection: "Connection"
+        case .gateways: "Gateways"
         case .permissions: "Permissions"
         case .voiceWake: "Voice & Talk"
         case .systemAgent: "OpenClaw"
@@ -492,6 +495,7 @@ enum SettingsTab: CaseIterable, Identifiable, Hashable {
         switch self {
         case .general: "gearshape"
         case .connection: "point.3.connected.trianglepath.dotted"
+        case .gateways: "server.rack"
         case .permissions: "lock.shield"
         case .voiceWake: "waveform.circle"
         case .systemAgent: "lifepreserver"

--- a/apps/macos/Sources/OpenClaw/WebChatManager.swift
+++ b/apps/macos/Sources/OpenClaw/WebChatManager.swift
@@ -40,14 +40,22 @@ struct WebChatRoute: Equatable, Sendable {
 final class WebChatManager {
     static let shared = WebChatManager()
 
+    private struct ProfileWindowInstance {
+        let profileID: String
+        let controller: WebChatSwiftUIWindowController
+    }
+
     private var windowController: WebChatSwiftUIWindowController?
     private var windowRoute: WebChatRoute?
     private var panelController: WebChatSwiftUIWindowController?
     private var panelRoute: WebChatRoute?
     private var currentChatRoute: WebChatRoute?
     private var cachedPreferredSessionKey: String?
-    private var profileWindowControllers: [String: WebChatSwiftUIWindowController] = [:]
-    private var profileWindowRoutes: [String: WebChatRoute] = [:]
+    private var profileWindows: [UUID: ProfileWindowInstance] = [:]
+    private var profileWindowOrder: [UUID] = []
+    private var unavailableProfileIDs: Set<String> = []
+
+    private static let lastGatewayProfileIDKey = "openclaw.webchat.lastGatewayProfileID"
 
     var onPanelVisibilityChanged: ((Bool) -> Void)?
 
@@ -58,7 +66,7 @@ final class WebChatManager {
     func show(sessionKey: String, agentID: String? = nil, draft: String? = nil) {
         let route = WebChatRoute(sessionKey: sessionKey, agentID: agentID)
         self.closePanel()
-        if let controller = self.windowController {
+        if let controller = windowController {
             // The window shell switches sessions in place (sidebar, /new);
             // full route identity tracks those switches and the global owner.
             if Self.shouldReuseController(currentRoute: self.windowRoute, requestedRoute: route) {
@@ -79,6 +87,14 @@ final class WebChatManager {
         controller.onVisibilityChanged = { [weak self] visible in
             self?.onPanelVisibilityChanged?(visible)
         }
+        controller.onClosed = { [weak self, weak controller] in
+            guard let self, let controller, self.windowController === controller else { return }
+            if self.currentChatRoute == self.windowRoute {
+                self.currentChatRoute = self.panelRoute
+            }
+            self.windowController = nil
+            self.windowRoute = nil
+        }
         controller.onSessionKeyChanged = { [weak self, weak controller] key in
             guard let self, let controller, self.windowController === controller else { return }
             // Retaining the agent is safe: this surface has no in-window agent switcher,
@@ -94,42 +110,59 @@ final class WebChatManager {
     }
 
     func newGatewayWindow() {
-        guard let draft = Self.promptForGatewayProfile() else { return }
         Task { @MainActor [weak self] in
             guard let self else { return }
             do {
-                let profile = try await MacGatewayProfileStore.shared.upsert(
-                    name: draft.name,
-                    url: draft.url,
-                    token: draft.token,
-                    password: draft.password)
-                try await self.show(profile: profile)
+                let profiles = try await MacGatewayProfileStore.shared.profiles()
+                guard !profiles.isEmpty else {
+                    AppNavigationActions.openSettings(tab: .gateways)
+                    return
+                }
+                let preferredID = UserDefaults.standard.string(forKey: Self.lastGatewayProfileIDKey)
+                switch Self.promptForGatewayProfile(profiles: profiles, preferredID: preferredID) {
+                case let .profile(profile):
+                    UserDefaults.standard.set(profile.id, forKey: Self.lastGatewayProfileIDKey)
+                    try await self.show(profile: profile)
+                case .manage:
+                    AppNavigationActions.openSettings(tab: .gateways)
+                case nil:
+                    break
+                }
             } catch {
-                Self.showProfileError(error)
+                Self.showProfileError(error, message: "Could Not Open Gateway Window")
+            }
+        }
+    }
+
+    func openGatewayWindow(profile: MacGatewayProfile) {
+        Task { @MainActor [weak self] in
+            do {
+                UserDefaults.standard.set(profile.id, forKey: Self.lastGatewayProfileIDKey)
+                try await self?.show(profile: profile)
+            } catch {
+                Self.showProfileError(error, message: "Could Not Open Gateway Window")
             }
         }
     }
 
     func show(profile: MacGatewayProfile) async throws {
+        guard !self.unavailableProfileIDs.contains(profile.id) else {
+            throw MacGatewayProfileError.profileNotFound
+        }
         let connection = await MacGatewayConnectionFleet.shared.connection(profileID: profile.id)
-        if let existing = self.profileWindowControllers[profile.id] {
-            existing.show()
-            Task {
-                try? await connection.refresh()
-            }
-            return
+        guard !self.unavailableProfileIDs.contains(profile.id) else {
+            throw MacGatewayProfileError.profileNotFound
         }
         let sessionKey = await connection.mainSessionKey()
-        // MainActor methods are reentrant across the fleet and connection awaits.
-        // A concurrent Cmd-N for the same profile must reuse the first completed window.
-        if let existing = self.profileWindowControllers[profile.id] {
-            existing.show()
-            Task {
-                try? await connection.refresh()
-            }
-            return
+        guard !self.unavailableProfileIDs.contains(profile.id) else {
+            throw MacGatewayProfileError.profileNotFound
         }
+        let windowID = UUID()
         let route = WebChatRoute(sessionKey: sessionKey, agentID: nil)
+        let previousController = self.profileWindowOrder.reversed().lazy
+            .compactMap { self.profileWindows[$0] }
+            .first { $0.profileID == profile.id }?
+            .controller
         let controller = WebChatSwiftUIWindowController(
             sessionKey: route.sessionKey,
             agentID: route.agentID,
@@ -138,14 +171,41 @@ final class WebChatManager {
             gatewayID: profile.id,
             windowTitle: "\(profile.name) — OpenClaw",
             windowAutosaveName: "OpenClawChatWindow-\(profile.id)")
-        controller.onSessionKeyChanged = { [weak self, weak controller] key in
-            guard let self, let controller, self.profileWindowControllers[profile.id] === controller else { return }
-            self.profileWindowRoutes[profile.id] = (self.profileWindowRoutes[profile.id] ?? route)
-                .replacingSessionKey(key)
+        controller.onClosed = { [weak self, weak controller] in
+            guard let self,
+                  let controller,
+                  self.profileWindows[windowID]?.controller === controller
+            else { return }
+            self.profileWindows.removeValue(forKey: windowID)
+            self.profileWindowOrder.removeAll { $0 == windowID }
         }
-        self.profileWindowControllers[profile.id] = controller
-        self.profileWindowRoutes[profile.id] = route
+        self.profileWindows[windowID] = ProfileWindowInstance(
+            profileID: profile.id,
+            controller: controller)
+        self.profileWindowOrder.append(windowID)
+        controller.cascade(from: previousController)
         controller.show()
+        Task {
+            try? await connection.refresh()
+        }
+    }
+
+    func closeGatewayWindows(profileID: String) async {
+        // Removal fences in-flight window creation before awaiting connection
+        // shutdown, so an old picker selection cannot resurrect this profile.
+        self.unavailableProfileIDs.insert(profileID)
+        let windowIDs = self.profileWindowOrder.filter { self.profileWindows[$0]?.profileID == profileID }
+        let controllers = windowIDs.compactMap { self.profileWindows.removeValue(forKey: $0)?.controller }
+        let windowIDSet = Set(windowIDs)
+        self.profileWindowOrder.removeAll { windowIDSet.contains($0) }
+        for controller in controllers {
+            controller.close()
+        }
+        await MacGatewayConnectionFleet.shared.remove(profileID: profileID)
+    }
+
+    func gatewayProfileDidSave(profileID: String) {
+        self.unavailableProfileIDs.remove(profileID)
     }
 
     func togglePanel(
@@ -154,7 +214,7 @@ final class WebChatManager {
         anchorProvider: @escaping () -> NSRect?)
     {
         let route = WebChatRoute(sessionKey: sessionKey, agentID: agentID)
-        if let controller = self.panelController {
+        if let controller = panelController {
             if !Self.shouldReuseController(currentRoute: self.panelRoute, requestedRoute: route) {
                 controller.close()
                 self.panelController = nil
@@ -204,9 +264,11 @@ final class WebChatManager {
     }
 
     func preferredSessionKey() async -> String {
-        if let cachedPreferredSessionKey { return cachedPreferredSessionKey }
+        if let cachedPreferredSessionKey {
+            return cachedPreferredSessionKey
+        }
         let key = await GatewayConnection.shared.mainSessionKey()
-        self.cachedPreferredSessionKey = key
+        cachedPreferredSessionKey = key
         return key
     }
 
@@ -219,11 +281,13 @@ final class WebChatManager {
         self.panelRoute = nil
         self.currentChatRoute = nil
         self.cachedPreferredSessionKey = nil
-        for controller in self.profileWindowControllers.values {
+        let profileControllers = self.profileWindows.values.map(\.controller)
+        self.profileWindows.removeAll()
+        self.profileWindowOrder.removeAll()
+        self.unavailableProfileIDs.removeAll()
+        for controller in profileControllers {
             controller.close()
         }
-        self.profileWindowControllers.removeAll()
-        self.profileWindowRoutes.removeAll()
         Task { await MacGatewayConnectionFleet.shared.shutdown() }
     }
 
@@ -243,51 +307,54 @@ final class WebChatManager {
         currentRoute == requestedRoute
     }
 
-    private struct GatewayProfileDraft {
-        let name: String
-        let url: URL
-        let token: String?
-        let password: String?
+    private enum GatewayProfileSelection {
+        case profile(MacGatewayProfile)
+        case manage
     }
 
-    private static func promptForGatewayProfile() -> GatewayProfileDraft? {
-        let nameField = NSTextField(string: "")
-        nameField.placeholderString = "Gateway name"
-        let urlField = NSTextField(string: "wss://")
-        urlField.placeholderString = "wss://gateway.example.com"
-        let tokenField = NSSecureTextField(string: "")
-        tokenField.placeholderString = "Token (optional)"
-        let passwordField = NSSecureTextField(string: "")
-        passwordField.placeholderString = "Password (optional)"
-        let grid = NSGridView(views: [
-            [NSTextField(labelWithString: "Name"), nameField],
-            [NSTextField(labelWithString: "Gateway URL"), urlField],
-            [NSTextField(labelWithString: "Token"), tokenField],
-            [NSTextField(labelWithString: "Password"), passwordField],
-        ])
-        grid.column(at: 0).xPlacement = .trailing
-        grid.column(at: 1).width = 320
-        grid.rowSpacing = 8
+    private static func promptForGatewayProfile(
+        profiles: [MacGatewayProfile],
+        preferredID: String?) -> GatewayProfileSelection?
+    {
+        let popup = NSPopUpButton(frame: NSRect(x: 0, y: 0, width: 360, height: 28), pullsDown: false)
+        popup.addItems(withTitles: profiles.map(Self.profilePickerTitle))
+        popup.selectItem(at: Self.preferredProfileIndex(profiles: profiles, preferredID: preferredID))
 
         let alert = NSAlert()
         alert.messageText = "New Gateway Window"
-        alert.informativeText = "This window keeps an independent connection to its Gateway."
-        alert.accessoryView = grid
+        alert.informativeText = "Choose a saved Gateway. You can open more than one window for the same Gateway."
+        alert.accessoryView = popup
         alert.addButton(withTitle: "Open Window")
+        alert.addButton(withTitle: "Manage Gateways…")
         alert.addButton(withTitle: "Cancel")
-        guard alert.runModal() == .alertFirstButtonReturn,
-              let url = URL(string: urlField.stringValue.trimmingCharacters(in: .whitespacesAndNewlines))
-        else { return nil }
-        return GatewayProfileDraft(
-            name: nameField.stringValue,
-            url: url,
-            token: tokenField.stringValue,
-            password: passwordField.stringValue)
+        switch alert.runModal() {
+        case .alertFirstButtonReturn:
+            guard profiles.indices.contains(popup.indexOfSelectedItem) else { return nil }
+            return .profile(profiles[popup.indexOfSelectedItem])
+        case .alertSecondButtonReturn:
+            return .manage
+        default:
+            return nil
+        }
     }
 
-    private static func showProfileError(_ error: Error) {
+    nonisolated static func preferredProfileIndex(profiles: [MacGatewayProfile], preferredID: String?) -> Int {
+        profiles.firstIndex { $0.id == preferredID } ?? 0
+    }
+
+    private static func profilePickerTitle(_ profile: MacGatewayProfile) -> String {
+        "\(profile.name) — \(profile.url.absoluteString)"
+    }
+
+    private static func showProfileError(_ error: Error, message: String) {
         let alert = NSAlert(error: error)
-        alert.messageText = "Could Not Open Gateway Window"
+        alert.messageText = message
         alert.runModal()
     }
+
+    #if DEBUG
+    func _testProfileWindowCount(profileID: String) -> Int {
+        self.profileWindows.values.count { $0.profileID == profileID }
+    }
+    #endif
 }

--- a/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
+++ b/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
@@ -46,6 +46,18 @@ enum WebChatTracePreferences {
 /// SwiftUI's native toolbar bridge may restore visible title chrome while it
 /// installs toolbar items. Keep the full-window chat's titlebar merged.
 private final class WebChatWindow: NSWindow {
+    var pinnedTitle: String?
+
+    override var title: String {
+        didSet {
+            // SwiftUI toolbar bridging may replace the operator-facing Gateway
+            // name with a session key. Keep Mission Control/window lists useful.
+            if let pinnedTitle, title != pinnedTitle {
+                self.title = pinnedTitle
+            }
+        }
+    }
+
     override var titleVisibility: NSWindow.TitleVisibility {
         didSet {
             if self.titleVisibility != .hidden {
@@ -140,7 +152,7 @@ struct MacGatewayChatTransport: OpenClawChatTransport {
             sessionKey: target.sessionKey,
             agentID: target.agentID,
             messageID: messageID)
-        let data = try await self.connection.request(request)
+        let data = try await connection.request(request)
         let result = try JSONDecoder().decode(ChatMessageGetResult.self, from: data)
         guard result.ok, let encodedMessage = result.message else { return nil }
         return try JSONDecoder().decode(
@@ -195,7 +207,7 @@ struct MacGatewayChatTransport: OpenClawChatTransport {
 
     func listModels() async throws -> [OpenClawChatModelChoice] {
         do {
-            let data = try await self.connection.request(OpenClawChatGatewayRequests.modelsList())
+            let data = try await connection.request(OpenClawChatGatewayRequests.modelsList())
             return try OpenClawChatGatewayPayloadCodec.decodeModelChoices(data)
         } catch {
             webChatSwiftLogger.warning(
@@ -222,9 +234,9 @@ struct MacGatewayChatTransport: OpenClawChatTransport {
             limit: limit,
             search: search,
             archived: archived)
-        let data = try await self.connection.request(request)
+        let data = try await connection.request(request)
         let decoded = try JSONDecoder().decode(OpenClawChatSessionsListResponse.self, from: data)
-        let mainSessionKey = await self.connection.cachedMainSessionKey()
+        let mainSessionKey = await connection.cachedMainSessionKey()
         let defaults = decoded.defaults.map {
             OpenClawChatSessionsDefaults(
                 modelProvider: $0.modelProvider,
@@ -247,7 +259,7 @@ struct MacGatewayChatTransport: OpenClawChatTransport {
     }
 
     func listAgents() async throws -> OpenClawChatAgentsListResponse? {
-        let data = try await self.connection.request(OpenClawChatGatewayRequests.agentsList())
+        let data = try await connection.request(OpenClawChatGatewayRequests.agentsList())
         let result = try JSONDecoder().decode(AgentsListResult.self, from: data)
         return OpenClawChatAgentsListResponse(
             defaultId: result.defaultid,
@@ -260,13 +272,13 @@ struct MacGatewayChatTransport: OpenClawChatTransport {
     }
 
     func listSessionGroups() async throws -> OpenClawChatSessionGroupsResponse? {
-        let data = try await self.connection.request(OpenClawChatGatewayRequests.sessionGroupsList())
+        let data = try await connection.request(OpenClawChatGatewayRequests.sessionGroupsList())
         return try JSONDecoder().decode(OpenClawChatSessionGroupsResponse.self, from: data)
     }
 
     func putSessionGroups(names: [String]) async throws -> OpenClawChatSessionGroupsMutationResponse {
         let request = OpenClawChatGatewayRequests.sessionGroupsPut(names: names)
-        let data = try await self.connection.request(request)
+        let data = try await connection.request(request)
         return try JSONDecoder().decode(OpenClawChatSessionGroupsMutationResponse.self, from: data)
     }
 
@@ -275,13 +287,13 @@ struct MacGatewayChatTransport: OpenClawChatTransport {
         to: String) async throws -> OpenClawChatSessionGroupsMutationResponse
     {
         let request = OpenClawChatGatewayRequests.sessionGroupsRename(name: name, to: to)
-        let data = try await self.connection.request(request)
+        let data = try await connection.request(request)
         return try JSONDecoder().decode(OpenClawChatSessionGroupsMutationResponse.self, from: data)
     }
 
     func deleteSessionGroup(name: String) async throws -> OpenClawChatSessionGroupsMutationResponse {
         let request = OpenClawChatGatewayRequests.sessionGroupsDelete(name: name)
-        let data = try await self.connection.request(request)
+        let data = try await connection.request(request)
         return try JSONDecoder().decode(OpenClawChatSessionGroupsMutationResponse.self, from: data)
     }
 
@@ -359,7 +371,7 @@ struct MacGatewayChatTransport: OpenClawChatTransport {
 
     func acquireSessionSettingsRouteLease() async -> OpenClawChatSessionSettingsRouteLease? {
         guard await self.currentOutboxGatewayMatchesConnection() else { return nil }
-        guard let serverLease = await self.connection.captureServerLease() else { return nil }
+        guard let serverLease = await connection.captureServerLease() else { return nil }
         let transport = self
         return OpenClawChatSessionSettingsRouteLease { sessionKey, agentID, patch in
             try await transport.requireCurrentOutboxGateway()
@@ -407,8 +419,8 @@ struct MacGatewayChatTransport: OpenClawChatTransport {
     {
         let target = self.sessionTarget(for: sessionKey)
         try await self.requireCurrentOutboxGateway()
-        guard let route = await self.connection.captureRoute(),
-              let supportsRoutingContract = await self.connection.supportsServerCapability(
+        guard let route = await connection.captureRoute(),
+              let supportsRoutingContract = await connection.supportsServerCapability(
                   .chatSendRoutingContract,
                   ifCurrentRoute: route)
         else { throw OpenClawChatTransportSendError.notDispatched }
@@ -434,15 +446,15 @@ struct MacGatewayChatTransport: OpenClawChatTransport {
         guard self.outboxGatewayID != nil,
               await self.currentOutboxGatewayMatchesConnection()
         else { return .unavailable(reason: nil) }
-        guard let route = await self.connection.captureRoute() else { return .unavailable(reason: nil) }
-        guard let supportsRoutingContract = await self.connection.supportsServerCapability(
+        guard let route = await connection.captureRoute() else { return .unavailable(reason: nil) }
+        guard let supportsRoutingContract = await connection.supportsServerCapability(
             .chatSendRoutingContract,
             ifCurrentRoute: route)
         else { return .unavailable(reason: nil) }
         guard supportsRoutingContract else {
             return .unavailable(reason: OpenClawChatTransportUpgradeMessage.routingContract)
         }
-        guard let routingIdentity = try? await self.connection.sessionRoutingIdentity(
+        guard let routingIdentity = try? await connection.sessionRoutingIdentity(
             ifCurrentRoute: route)
         else { return .unavailable(reason: nil) }
         let routingContract = routingIdentity.contract
@@ -474,7 +486,7 @@ struct MacGatewayChatTransport: OpenClawChatTransport {
         // Capture the lease before validating the pinned gateway: a gateway
         // switch after validation then fails the request via the lease guard
         // instead of re-routing the text to the newly selected gateway.
-        guard let serverLease = await self.connection.captureServerLease() else {
+        guard let serverLease = await connection.captureServerLease() else {
             throw OpenClawChatTransportSendError.notDispatched
         }
         try await self.requireCurrentOutboxGateway()
@@ -492,7 +504,7 @@ struct MacGatewayChatTransport: OpenClawChatTransport {
         let request = OpenClawChatGatewayRequests.commandsList(
             sessionKey: sessionKey,
             fallbackAgentID: self.routingIdentity.currentAgentID())
-        let data = try await self.connection.request(request)
+        let data = try await connection.request(request)
         let decoded = try JSONDecoder().decode(CommandsListResult.self, from: data)
         return decoded.commands.map(OpenClawChatGatewayPayloadCodec.commandChoice)
     }
@@ -531,7 +543,7 @@ struct MacGatewayChatTransport: OpenClawChatTransport {
             parentSessionKey: parentSessionKey,
             worktree: worktree,
             worktreeBaseRef: worktreeBaseRef)
-        let data = try await self.connection.request(request)
+        let data = try await connection.request(request)
         return try JSONDecoder().decode(OpenClawChatCreateSessionResponse.self, from: data)
     }
 
@@ -568,12 +580,12 @@ struct MacGatewayChatTransport: OpenClawChatTransport {
     }
 
     func listQuestions() async throws -> [QuestionRecord] {
-        let data = try await self.connection.request(OpenClawChatGatewayRequests.questionList())
+        let data = try await connection.request(OpenClawChatGatewayRequests.questionList())
         return try JSONDecoder().decode(QuestionListResult.self, from: data).questions
     }
 
     func getQuestion(id: String) async throws -> QuestionRecord {
-        let data = try await self.connection.request(OpenClawChatGatewayRequests.questionGet(id: id))
+        let data = try await connection.request(OpenClawChatGatewayRequests.questionGet(id: id))
         return try JSONDecoder().decode(QuestionGetResult.self, from: data).question
     }
 
@@ -593,11 +605,11 @@ struct MacGatewayChatTransport: OpenClawChatTransport {
     {
         let runId = rawRunId.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !runId.isEmpty,
-              let route = await self.connection.captureRoute()
+              let route = await connection.captureRoute()
         else { return .unavailable }
         do {
             let request = OpenClawChatGatewayRequests.agentWait(runID: runId, timeoutMs: timeoutMs)
-            let data = try await self.connection.request(
+            let data = try await connection.request(
                 request,
                 ifCurrentRoute: route)
             return try OpenClawChatGatewayPayloadCodec.decodeAgentWaitObservation(data)
@@ -622,7 +634,7 @@ struct MacGatewayChatTransport: OpenClawChatTransport {
         let request = OpenClawChatGatewayRequests.compactSession(
             sessionKey: target.sessionKey,
             agentID: target.agentID)
-        let response = try await self.connection.request(request, retryTransportFailures: false)
+        let response = try await connection.request(request, retryTransportFailures: false)
         try OpenClawSessionsCompactResponse.requireSuccess(from: response)
     }
 
@@ -820,8 +832,12 @@ private struct MacChatSurface: View {
 
     private var displayOptions: OpenClawChatDisplayOptions {
         var options: OpenClawChatDisplayOptions = []
-        if self.showsReasoning { options.insert(.reasoning) }
-        if self.showsToolActivity { options.insert(.toolActivity) }
+        if self.showsReasoning {
+            options.insert(.reasoning)
+        }
+        if self.showsToolActivity {
+            options.insert(.toolActivity)
+        }
         return options
     }
 
@@ -838,7 +854,9 @@ private struct MacChatSurface: View {
             return String(localized: "Talk mode uses the primary Gateway window")
         }
         guard self.appState.talkEnabled else { return String(localized: "Talk mode off") }
-        if self.talkController.isPaused { return String(localized: "Talk mode paused") }
+        if self.talkController.isPaused {
+            return String(localized: "Talk mode paused")
+        }
         return switch self.talkController.phase {
         case .idle: String(localized: "Talk mode ready")
         case .listening: String(localized: "Listening")
@@ -892,7 +910,7 @@ private final class WebChatSessionKeyRelay {
 }
 
 @MainActor
-final class WebChatSwiftUIWindowController {
+final class WebChatSwiftUIWindowController: NSObject, NSWindowDelegate {
     private let presentation: WebChatPresentation
     private let sessionKey: String
     private let initialActiveAgentID: String?
@@ -1092,11 +1110,13 @@ final class WebChatSwiftUIWindowController {
                 voiceNoteRecorder: voiceNoteRecorder))
             self.contentController = Self.makePanelContentController(hosting: hosting)
         }
+        super.init()
         self.window = Self.makeWindow(
             for: presentation,
             contentViewController: self.contentController,
             title: windowTitle,
             autosaveName: windowAutosaveName)
+        self.window?.delegate = self
         sessionKeyRelay.onChange = { [weak self] key in
             self?.onSessionKeyChanged?(key)
         }
@@ -1122,6 +1142,18 @@ final class WebChatSwiftUIWindowController {
         window.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
         self.onVisibilityChanged?(true)
+    }
+
+    func cascade(from source: WebChatSwiftUIWindowController?) {
+        guard case .window = self.presentation,
+              let window,
+              let sourceWindow = source?.window,
+              sourceWindow !== window
+        else { return }
+        let bounds = sourceWindow.screen?.visibleFrame ?? NSScreen.main?.visibleFrame ?? .zero
+        window.setFrame(
+            WindowPlacement.cascadedFrame(from: sourceWindow.frame, in: bounds),
+            display: false)
     }
 
     func presentAnchored(anchorProvider: () -> NSRect?) {
@@ -1150,10 +1182,27 @@ final class WebChatSwiftUIWindowController {
     }
 
     func close() {
-        self.window?.orderOut(nil)
+        switch self.presentation {
+        case .window:
+            self.window?.close()
+        case .panel:
+            self.window?.orderOut(nil)
+            self.onVisibilityChanged?(false)
+            self.onClosed?()
+            self.removeDismissMonitor()
+        }
+    }
+
+    func windowWillClose(_ notification: Notification) {
+        guard case .window = self.presentation,
+              notification.object as? NSWindow === self.window
+        else { return }
         self.onVisibilityChanged?(false)
-        self.onClosed?()
         self.removeDismissMonitor()
+        let onClosed = self.onClosed
+        self.onClosed = nil
+        self.window = nil
+        onClosed?()
     }
 
     @discardableResult
@@ -1250,6 +1299,7 @@ final class WebChatSwiftUIWindowController {
                 backing: .buffered,
                 defer: false)
             window.title = title
+            window.pinnedTitle = title
             window.contentViewController = contentViewController
             // Attaching an NSHostingController resets scene bridging to `.all`;
             // opt back into toolbar items only so SwiftUI cannot restore the title.
@@ -1360,7 +1410,7 @@ final class WebChatSwiftUIWindowController {
     }
 
     var _testChatCapabilities: MacChatSurfaceCapabilities? {
-        if let hosting = self.contentController as? NSHostingController<MacChatSurface> {
+        if let hosting = contentController as? NSHostingController<MacChatSurface> {
             return hosting.rootView._testCapabilities
         }
         return self.contentController.children

--- a/apps/macos/Sources/OpenClaw/WindowPlacement.swift
+++ b/apps/macos/Sources/OpenClaw/WindowPlacement.swift
@@ -64,6 +64,19 @@ enum WindowPlacement {
         return NSRect(x: x, y: y, width: clampedWidth, height: clampedHeight)
     }
 
+    static func cascadedFrame(from frame: NSRect, offset: CGFloat = 24, in bounds: NSRect) -> NSRect {
+        guard bounds != .zero else {
+            return frame.offsetBy(dx: offset, dy: -offset)
+        }
+        let width = min(frame.width, bounds.width)
+        let height = min(frame.height, bounds.height)
+        let maxX = bounds.maxX - width
+        let maxY = bounds.maxY - height
+        let x = maxX >= bounds.minX ? min(max(frame.minX + offset, bounds.minX), maxX) : bounds.minX
+        let y = maxY >= bounds.minY ? min(max(frame.minY - offset, bounds.minY), maxY) : bounds.minY
+        return NSRect(x: x, y: y, width: width, height: height)
+    }
+
     static func ensureOnScreen(
         window: NSWindow,
         defaultSize: NSSize,
@@ -75,7 +88,9 @@ enum WindowPlacement {
             frame.intersects(screen.visibleFrame.insetBy(dx: 12, dy: 12))
         }
 
-        if isVisibleSomewhere { return }
+        if isVisibleSomewhere {
+            return
+        }
 
         let screen = NSScreen.main ?? targetScreens.first
         let next = fallback?(screen) ?? self.centeredFrame(size: defaultSize, on: screen)

--- a/apps/macos/Tests/OpenClawIPCTests/MacGatewayProfilesTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacGatewayProfilesTests.swift
@@ -2,7 +2,7 @@ import Foundation
 import Testing
 @testable import OpenClaw
 
-@Suite struct MacGatewayProfilesTests {
+struct MacGatewayProfilesTests {
     @Test func `canonical route identity normalizes authority but preserves path`() throws {
         let implicit = try MacGatewayProfileStore.canonicalURL(
             #require(URL(string: "WSS://Studio.Example/alpha")))
@@ -52,5 +52,45 @@ import Testing
         #expect(throws: MacGatewayProfileError.self) {
             try MacGatewayProfileStore.validateRegistryData(data)
         }
+    }
+
+    @Test func `saved profiles are ordered by name then route`() throws {
+        let zURL = try #require(URL(string: "wss://z.example"))
+        let aURL = try #require(URL(string: "wss://a.example"))
+        let bURL = try #require(URL(string: "wss://b.example"))
+        let profiles = [
+            MacGatewayProfile(
+                id: "z",
+                name: "Studio",
+                url: zURL),
+            MacGatewayProfile(
+                id: "a",
+                name: "alpha",
+                url: aURL),
+            MacGatewayProfile(
+                id: "b",
+                name: "Studio",
+                url: bURL),
+        ]
+
+        #expect(MacGatewayProfileStore.sortedProfiles(profiles).map(\.id) == ["a", "b", "z"])
+    }
+
+    @Test func `new Gateway picker remembers a reusable profile`() throws {
+        let oneURL = try #require(URL(string: "wss://one.example"))
+        let twoURL = try #require(URL(string: "wss://two.example"))
+        let profiles = [
+            MacGatewayProfile(
+                id: "one",
+                name: "One",
+                url: oneURL),
+            MacGatewayProfile(
+                id: "two",
+                name: "Two",
+                url: twoURL),
+        ]
+
+        #expect(WebChatManager.preferredProfileIndex(profiles: profiles, preferredID: "two") == 1)
+        #expect(WebChatManager.preferredProfileIndex(profiles: profiles, preferredID: "missing") == 0)
     }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/SettingsViewSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/SettingsViewSmokeTests.swift
@@ -210,6 +210,19 @@ struct SettingsViewSmokeTests {
         _ = view.body
     }
 
+    @Test func `Gateway settings is visible and builds body`() throws {
+        let tabs = SettingsTabGroup.defaultGroups(showDebug: false, showSystemAgent: false)
+            .flatMap(\.tabs)
+        #expect(tabs.contains(.gateways))
+
+        let profile = try MacGatewayProfile(
+            id: "studio",
+            name: "Studio",
+            url: #require(URL(string: "wss://studio.example")))
+        let view = GatewaySettings(profiles: [profile], isPreview: true)
+        _ = view.body
+    }
+
     @Test func `OpenClaw settings require configured inference`() {
         #expect(!SystemAgentAvailability.shouldShow(configuredModel: nil))
         #expect(!SystemAgentAvailability.shouldShow(configuredModel: "   "))

--- a/apps/macos/Tests/OpenClawIPCTests/WebChatSwiftUISmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/WebChatSwiftUISmokeTests.swift
@@ -61,7 +61,8 @@ struct WebChatSwiftUISmokeTests {
         let controller = WebChatSwiftUIWindowController(
             sessionKey: "main",
             presentation: .window,
-            transport: TestTransport())
+            transport: TestTransport(),
+            windowTitle: "Studio — OpenClaw")
         let window = try #require(controller._testWindow)
         let capabilities = try #require(controller._testChatCapabilities)
 
@@ -71,6 +72,9 @@ struct WebChatSwiftUISmokeTests {
         #expect(window.toolbarStyle == .unified)
         #expect(window.titlebarSeparatorStyle == .none)
         #expect(window.isMovableByWindowBackground)
+        #expect(window.title == "Studio — OpenClaw")
+        window.title = "main"
+        #expect(window.title == "Studio — OpenClaw")
         #expect(controller._testSceneBridgingOptions?.contains(.toolbars) == true)
         #expect(controller._testSceneBridgingOptions?.contains(.title) == false)
         #expect(capabilities.hasTalkControl)
@@ -92,6 +96,36 @@ struct WebChatSwiftUISmokeTests {
             transport: TestTransport())
         controller.presentAnchored(anchorProvider: anchor)
         controller.close()
+    }
+
+    @Test func `closing a full window releases it and notifies its owner once`() {
+        let controller = WebChatSwiftUIWindowController(
+            sessionKey: "main",
+            presentation: .window,
+            transport: TestTransport())
+        var closeCount = 0
+        controller.onClosed = { closeCount += 1 }
+
+        controller.close()
+        controller.close()
+
+        #expect(controller._testWindow == nil)
+        #expect(closeCount == 1)
+    }
+
+    @Test func `one Gateway profile can own multiple independent windows`() async throws {
+        let manager = WebChatManager()
+        let profile = try MacGatewayProfile(
+            id: "same-gateway",
+            name: "Same Gateway",
+            url: #require(URL(string: "wss://same.example")))
+
+        try await manager.show(profile: profile)
+        try await manager.show(profile: profile)
+
+        #expect(manager._testProfileWindowCount(profileID: profile.id) == 2)
+        await manager.closeGatewayWindows(profileID: profile.id)
+        #expect(manager._testProfileWindowCount(profileID: profile.id) == 0)
     }
 
     @Test func `initial draft populates an empty composer without replacing user text`() {

--- a/apps/macos/Tests/OpenClawIPCTests/WindowPlacementTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/WindowPlacementTests.swift
@@ -45,6 +45,19 @@ struct WindowPlacementTests {
     }
 
     @Test
+    func `cascade offsets a second window without leaving the screen`() {
+        let bounds = NSRect(x: 0, y: 0, width: 1000, height: 800)
+        let first = NSRect(x: 100, y: 100, width: 600, height: 500)
+        let next = WindowPlacement.cascadedFrame(from: first, in: bounds)
+
+        #expect(next == NSRect(x: 124, y: 76, width: 600, height: 500))
+
+        let edge = NSRect(x: 500, y: 0, width: 600, height: 900)
+        #expect(WindowPlacement.cascadedFrame(from: edge, in: bounds) ==
+            NSRect(x: 400, y: 0, width: 600, height: 800))
+    }
+
+    @Test
     func `ensure on screen uses fallback when window offscreen`() {
         let window = NSWindow(
             contentRect: NSRect(x: 100_000, y: 100_000, width: 200, height: 120),

--- a/docs/platforms/mac/webchat.md
+++ b/docs/platforms/mac/webchat.md
@@ -18,12 +18,20 @@ The anchored compact chat panel from the menu bar keeps the compact single-colum
 
 ## Multiple Gateway windows
 
-Choose **File → New Gateway Window…** or press Cmd-N, then enter a `ws://` or
-`wss://` endpoint and its optional token or password. Each saved profile owns
-an independent Gateway connection, device-auth scope, transcript cache,
-offline outbox, route leases, and window restoration key. These windows can
-stay connected and run chats simultaneously; opening the same profile again
-focuses its existing window.
+Open **Settings → Gateways** to add or remove reusable Gateway profiles. Each
+profile contains a `ws://` or `wss://` endpoint and its optional token or
+password; credentials are stored in the macOS Keychain. Removing a profile
+also closes its open windows and shuts down its secondary connection.
+
+Choose **File → New Gateway Window…** or press Cmd-N, then select one of those
+saved profiles. The picker remembers the most recently used profile. Every
+selection creates a new independent window, so the same Gateway can appear in
+multiple windows with different active sessions and navigation state.
+
+Each saved profile owns one shared Gateway connection, device-auth scope,
+transcript cache, offline outbox, and route leases. Windows for that profile
+reuse those resources while staying independently navigable. Windows for
+different profiles stay connected and run chats simultaneously.
 
 The menu-bar app's configured Gateway remains the owner of Mac node
 capabilities and Talk Mode. Additional Gateway windows are operator-only, so a

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ overrides:
   '@aws-sdk/xml-builder': 3.972.33
   hono: 4.12.25
   '@hono/node-server': 1.19.14
-  axios: 1.16.0
+  axios: 1.18.0
   fast-uri: 3.1.2
   follow-redirects: 1.16.0
   defu: 6.1.5
@@ -5031,6 +5031,10 @@ packages:
     engines: {node: '>=22.13.0'}
     hasBin: true
 
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
@@ -5136,8 +5140,8 @@ packages:
     resolution: {integrity: sha512-dK9Z/P83C/rBfTrXXgPD3jZ+aXxx2o/P4rq8+H1JqxbXklitEeJw4CrcwMC5CkON3CX3yy2gaWnIEVYejYh0zQ==}
     engines: {node: '>=14'}
 
-  axios@1.16.0:
-    resolution: {integrity: sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==}
+  axios@1.18.0:
+    resolution: {integrity: sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==}
 
   b4a@1.8.1:
     resolution: {integrity: sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==}
@@ -6059,6 +6063,10 @@ packages:
   http_ece@1.2.0:
     resolution: {integrity: sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==}
     engines: {node: '>=16'}
+
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
 
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
@@ -9622,7 +9630,7 @@ snapshots:
 
   '@larksuiteoapi/node-sdk@1.68.0':
     dependencies:
-      axios: 1.16.0
+      axios: 1.18.0
       lodash.identity: 3.0.0
       lodash.merge: 4.6.2
       lodash.pickby: 4.6.0
@@ -9859,7 +9867,7 @@ snapshots:
       '@microsoft/teams.api': 2.0.13
       '@microsoft/teams.common': 2.0.13
       '@microsoft/teams.graph': 2.0.13
-      axios: 1.16.0
+      axios: 1.18.0
       cors: 2.8.6
       express: 5.2.1
       jsonwebtoken: 9.0.3
@@ -9873,7 +9881,7 @@ snapshots:
 
   '@microsoft/teams.common@2.0.13':
     dependencies:
-      axios: 1.16.0
+      axios: 1.18.0
     transitivePeerDependencies:
       - debug
 
@@ -10719,7 +10727,7 @@ snapshots:
       '@slack/types': 2.21.1
       '@slack/web-api': 7.18.0
       '@types/express': 5.0.6
-      axios: 1.16.0
+      axios: 1.18.0
       express: 5.2.1
       path-to-regexp: 8.4.0
       raw-body: 3.0.2
@@ -10765,7 +10773,7 @@ snapshots:
       '@slack/types': 2.21.1
       '@types/node': 26.1.0
       '@types/retry': 0.12.0
-      axios: 1.16.0
+      axios: 1.18.0
       eventemitter3: 5.0.4
       form-data: 2.5.6
       is-electron: 2.2.2
@@ -11377,6 +11385,12 @@ snapshots:
       - bare-buffer
       - react-native-b4a
 
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   agent-base@7.1.4: {}
 
   ajv-formats@3.0.1(ajv@8.20.0):
@@ -11482,13 +11496,15 @@ snapshots:
 
   audio-type@2.4.1: {}
 
-  axios@1.16.0:
+  axios@1.18.0:
     dependencies:
       follow-redirects: 1.16.0
       form-data: 2.5.6
+      https-proxy-agent: 5.0.1
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
+      - supports-color
 
   b4a@1.8.1: {}
 
@@ -12495,6 +12511,13 @@ snapshots:
       - supports-color
 
   http_ece@1.2.0: {}
+
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   https-proxy-agent@7.0.6:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -104,7 +104,7 @@ overrides:
   "@aws-sdk/xml-builder": 3.972.33
   hono: 4.12.25
   "@hono/node-server": 1.19.14
-  axios: 1.16.0
+  axios: 1.18.0
   fast-uri: 3.1.2
   follow-redirects: 1.16.0
   defu: 6.1.5


### PR DESCRIPTION
Closes #111973
Related: #111931

AI-assisted implementation; I reviewed the architecture, code, and validation results.

## What Problem This Solves

macOS could save a Gateway only while opening its first secondary window, offered no central place to add or remove saved Gateways, and reused one window per Gateway. Users could not manage their Gateway list in the app's single Settings window or keep several independently navigable windows open for the same Gateway.

## Why This Change Was Made

This separates a reusable Gateway profile from a window instance. Settings now owns profile creation and removal, while File → New Gateway Window… selects a saved profile and always creates a fresh window. Windows for one profile share its connection, device-auth identity, transcript cache, outbox, and route leases, but retain independent session and navigation state.

The primary Gateway under Connection remains the sole owner of Mac integrations and Talk Mode. The Gateway protocol and persisted registry schema are unchanged.

## User Impact

Users can add and remove Gateways under Settings → Gateways, press Cmd-N to choose a saved Gateway, and open as many windows as they want for the same Gateway. The picker remembers the last selection, profile windows have a stable Gateway-specific title, and removing a profile closes all of its windows and shuts down its secondary connection.

## Evidence

- Signed Developer ID debug bundle verified with strict deep code-signing validation.
- Source-blind macOS behavior pass: rejected an invalid HTTP URL; saved a sanitized localhost profile; selected it with New Gateway Window; opened two simultaneous, distinctly titled cascaded windows; removed the profile; observed both windows close; and verified Cmd-N with an empty registry routes directly to Gateway settings.
- macOS production target build passed with Xcode 27 beta: `swift build --package-path apps/macos --target OpenClaw`.
- The exact macOS SwiftLint/SwiftFormat wrapper passed across 329 files; Swift parser checks for all touched source and test files, native-app i18n baseline regeneration (4,999 entries), and `git diff --check` also passed.
- Current `main` became red on the production dependency audit after GHSA-gcfj-64vw-6mp9 was published. This PR repairs that unrelated landing baseline by moving the central Axios override and every lockfile edge from 1.16.0 to the first fixed release, 1.18.0; the gate's own graph parser now resolves production Axios exclusively to 1.18.0.
- Focused Swift test compilation remains blocked by an unrelated existing Xcode 27 beta region-isolation diagnostic in `GatewayChannelConnectTests.swift:204`; exact-head hosted CI is the authoritative test gate.
- Final structured autoreview passed after fixing removal/re-add ordering and serialization races, then catching and correcting a localization regression introduced while satisfying SwiftLint's line-length rule.
- Sanitized after screenshot captured and inspected locally: Settings → Gateways empty state. The existing-profile Chrome attachment bridge returned no attached tabs, so the image could not be uploaded without switching to an unapproved browser/profile or external host.
- A true packaged before capture was unavailable because the locally installed baseline app is missing its KeyboardShortcuts resource bundle and aborts when opening Settings; the before state was the absence of this sidebar entry and management page.

Release note: macOS: add reusable Gateway management and multiple independent windows per Gateway.
