### PR TITLE
fix(ui): dismiss new-session model picker on outside click

### DIFF
--- a/ui/src/e2e/new-session-page.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.e2e.test.ts
@@ -538,14 +538,13 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
       );
       await page.locator('[data-chat-model-provider="anthropic"]').click();
       await page.locator('[data-chat-model-option="anthropic/claude-sonnet-4-6"]').click();
-      await modelSelect.click();
-      await expect
-        .poll(() =>
-          modelSelect.evaluate(
-            (element) => element.closest("details")?.hasAttribute("open") ?? false,
-          ),
-        )
-        .toBe(false);
+      const pickerOpen = () =>
+        modelSelect.evaluate(
+          (element) => element.closest("details")?.hasAttribute("open") ?? false,
+        );
+      await expect.poll(pickerOpen).toBe(true);
+      await page.mouse.click(8, 8);
+      await expect.poll(pickerOpen).toBe(false);
       await page.locator(".new-session-page__message").fill("use this model");
       await page.getByRole("button", { name: "Start thread" }).click();
 

--- a/ui/src/pages/new-session/new-session-page.ts
+++ b/ui/src/pages/new-session/new-session-page.ts
@@ -290,7 +290,20 @@ class NewSessionPage extends OpenClawLightDomElement {
     }, delayMs);
   }
 
+  private readonly handleDocumentPointerdown = (event: PointerEvent) => {
+    const picker = this.querySelector<HTMLDetailsElement>(".chat-controls__inline-select[open]");
+    if (picker && !event.composedPath().includes(picker)) {
+      picker.open = false;
+    }
+  };
+
+  override connectedCallback() {
+    super.connectedCallback();
+    document.addEventListener("pointerdown", this.handleDocumentPointerdown, true);
+  }
+
   override disconnectedCallback() {
+    document.removeEventListener("pointerdown", this.handleDocumentPointerdown, true);
     this.subscriptions.clear();
     // This invalidates submitRequestToken before payload release below, so a
     // late sessions.create result cannot navigate with attachments we no longer own.

--- a/ui/src/pages/new-session/new-session-page.ts
+++ b/ui/src/pages/new-session/new-session-page.ts
@@ -290,20 +290,20 @@ class NewSessionPage extends OpenClawLightDomElement {
     }, delayMs);
   }
 
-  private readonly onPointerdown = (event: PointerEvent) => {
+  handleEvent(event: Event) {
     const picker = this.querySelector<HTMLDetailsElement>(".chat-controls__model[open]");
     if (picker && !event.composedPath().includes(picker)) {
       picker.open = false;
     }
-  };
+  }
 
   override connectedCallback() {
     super.connectedCallback();
-    document.addEventListener("pointerdown", this.onPointerdown, true);
+    document.addEventListener("pointerdown", this, true);
   }
 
   override disconnectedCallback() {
-    document.removeEventListener("pointerdown", this.onPointerdown, true);
+    document.removeEventListener("pointerdown", this, true);
     this.subscriptions.clear();
     // This invalidates submitRequestToken before payload release below, so a
     // late sessions.create result cannot navigate with attachments we no longer own.

--- a/ui/src/pages/new-session/new-session-page.ts
+++ b/ui/src/pages/new-session/new-session-page.ts
@@ -290,8 +290,8 @@ class NewSessionPage extends OpenClawLightDomElement {
     }, delayMs);
   }
 
-  private readonly handleDocumentPointerdown = (event: PointerEvent) => {
-    const picker = this.querySelector<HTMLDetailsElement>(".chat-controls__inline-select[open]");
+  private readonly onPointerdown = (event: PointerEvent) => {
+    const picker = this.querySelector<HTMLDetailsElement>(".chat-controls__model[open]");
     if (picker && !event.composedPath().includes(picker)) {
       picker.open = false;
     }
@@ -299,11 +299,11 @@ class NewSessionPage extends OpenClawLightDomElement {
 
   override connectedCallback() {
     super.connectedCallback();
-    document.addEventListener("pointerdown", this.handleDocumentPointerdown, true);
+    document.addEventListener("pointerdown", this.onPointerdown, true);
   }
 
   override disconnectedCallback() {
-    document.removeEventListener("pointerdown", this.handleDocumentPointerdown, true);
+    document.removeEventListener("pointerdown", this.onPointerdown, true);
     this.subscriptions.clear();
     // This invalidates submitRequestToken before payload release below, so a
     // late sessions.create result cannot navigate with attachments we no longer own.

--- a/ui/src/pages/new-session/route.ts
+++ b/ui/src/pages/new-session/route.ts
@@ -3,7 +3,6 @@ import { definePage } from "@openclaw/uirouter";
 import { html } from "lit";
 import type { ApplicationContext } from "../../app/context.ts";
 import { listSelectableAgents } from "../../lib/agents/display.ts";
-import { resolveAgentId, resolveCreateTarget } from "./catalog-target.ts";
 import { newSessionLocationFromSearch, type NewSessionRouteData } from "./location.ts";
 
 async function loadNewSessionData(
@@ -14,6 +13,7 @@ async function loadNewSessionData(
   if (!requestedLocation.catalogId) {
     return { ...requestedLocation, model: "", catalogLabel: "" };
   }
+  const targetHelpers = import("./catalog-target.ts");
   // ensureList is fail-closed: offline and request-error paths return cached
   // data or null, allowing the unresolved catalog page to mount and retry.
   const agentsList = context.agents.state.agentsList ?? (await context.agents.ensureList());
@@ -22,6 +22,7 @@ async function loadNewSessionData(
     : requestedLocation.agentId
       ? [{ id: requestedLocation.agentId }]
       : [];
+  const { resolveAgentId, resolveCreateTarget } = await targetHelpers;
   const agentId = resolveAgentId(
     requestedLocation,
     availableAgents,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening the model picker on the New Session page would see it remain expanded after clicking elsewhere on the page. Existing chat sessions already dismissed the same shared picker on outside pointer interactions; the route-specific New Session surface did not.

## Why This Change Was Made

The New Session page now owns a capture-phase outside-pointer listener for its native model-picker `<details>` element and removes that listener with the page lifecycle. The shared picker remains unchanged, so provider/model choices still commit immediately and intentionally keep the picker open for related reasoning adjustments.

The New Session route now lazily imports catalog-only helper code after confirming a catalog target. That removes route-specific code from the initial Control UI graph without changing plain `/new` timing, and restores durable headroom to the startup gzip gate that was already intermittently red on `main` from content-hash variance.

## User Impact

Users can dismiss the New Session model picker by clicking anywhere outside it. Interactions inside the picker still remain open, and the selected model is preserved when the thread starts. Initial Control UI loading also avoids catalog-only New Session code until it is needed.

### Before

The expanded picker remained open after an outside click on `/new`.

![Expanded New Session model picker](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/outside-click-picker-dismissal-4427aa/before.png)

### After

The same outside pointer interaction closes the picker.

![Dismissed New Session model picker](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/outside-click-picker-dismissal-4427aa/after.png)

## Evidence

- Live browser reproduction against the existing `/new` route: opening the picker and clicking the page outside it left the picker expanded.
- Blacksmith Testbox `tbx_01ky129yw18m7919gcb1x0vzjf`: https://github.com/openclaw/openclaw/actions/runs/29791345611
  - Three consecutive `pnpm ui:build` runs passed at 312.6 KiB startup JavaScript gzip versus the 313.0 KiB ceiling.
  - `pnpm test ui/src/pages/new-session/catalog-target.test.ts ui/src/pages/new-session/location.test.ts` — 6 passed.
  - Focused recovery-timing E2E rerun — passed.
  - `pnpm test:ui:e2e ui/src/e2e/new-session-page.e2e.test.ts` — 29 passed.
  - `pnpm check:changed` — formatting, conflict markers, UI/core-test typechecks, Control UI i18n verification, and changed-file lint passed.
- Current `main` CI runs 29790535709 and 29791053571 were already intermittently red at 320514–320517 bytes against the 320512-byte startup ceiling; this PR removes the static catalog-helper edge instead of raising the budget.
- Regression coverage proves provider/model interactions inside remain open, an outside pointer closes the picker, and the selected model reaches `sessions.create`.
- Sanitized mock-Gateway before/after screenshots contain no real account, thread, workspace, or credential data.
- Independent repository-aware review reported no actionable findings for the picker lifecycle and final catalog-helper lazy-loading boundary. The structured autoreview helper could not authenticate its isolated Claude CLI, and its browser-review fallback hit a Cloudflare challenge before submission.
- `git diff --check` passed.

AI-assisted change. I reviewed the implementation, route ownership, lifecycle cleanup, cancellation timing, performance budget, and test behavior.
