### PR TITLE
fix(gateway): resolve archived-session narrative race (#87182)

### DIFF
--- a/extensions/memory-core/src/dreaming-narrative.test.ts
+++ b/extensions/memory-core/src/dreaming-narrative.test.ts
@@ -1064,6 +1064,39 @@ describe("generateAndAppendDreamNarrative", () => {
     expect(deleteKeys.filter((key: string) => key === firstSessionKey)).toHaveLength(2);
     expect(deleteKeys.filter((key: string) => key === secondSessionKey)).toHaveLength(2);
   });
+
+  it("recovers narrative text when getSessionMessages initially returns empty (archive race, #87182)", async () => {
+    const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
+    const narrativeText = "The endpoints glowed faintly in the twilight of the codebase.";
+    const subagent = createMockSubagent("");
+    let getSessionCallCount = 0;
+    subagent.getSessionMessages.mockImplementation(async () => {
+      getSessionCallCount += 1;
+      if (getSessionCallCount === 1) {
+        return { messages: [] };
+      }
+      return {
+        messages: [
+          { role: "user", content: "prompt" },
+          { role: "assistant", content: narrativeText },
+        ],
+      };
+    });
+    const logger = createMockLogger();
+
+    await generateAndAppendDreamNarrative({
+      subagent,
+      workspaceDir,
+      data: { phase: "rem", snippets: ["a distant endpoint"] },
+      nowMs: Date.parse("2026-04-05T03:00:00Z"),
+      timezone: "UTC",
+      logger,
+    });
+
+    expect(subagent.getSessionMessages).toHaveBeenCalledTimes(2);
+    const content = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8");
+    expect(content).toContain(narrativeText);
+  });
 });
 
 describe("runDetachedDreamNarrative", () => {

--- a/src/agents/subagent-registry-lifecycle.ts
+++ b/src/agents/subagent-registry-lifecycle.ts
@@ -1230,7 +1230,13 @@ export function createSubagentRegistryLifecycleController(params: {
         );
       });
     };
-    if (!cleanupParams.preserveTranscript) {
+    // Keep-mode runs (plugin subagents) must retain their session store entry
+    // until the host plugin calls deleteSession explicitly. Removing the entry
+    // in the bookkeeping tail races with the host's getSessionMessages call,
+    // silently returning empty messages (#87182).
+    const shouldPreserveTranscript =
+      cleanupParams.preserveTranscript === true || cleanupParams.cleanup === "keep";
+    if (!shouldPreserveTranscript) {
       runCleanupTail("session cleanup", async () => {
         await removeInternalSessionEffectsSession(cleanupParams.entry.execution?.transcriptTarget);
       });

--- a/src/gateway/session-transcript-files.fs.ts
+++ b/src/gateway/session-transcript-files.fs.ts
@@ -237,6 +237,8 @@ async function resetArchiveHeaderMatchesSessionId(
   }
 }
 
+const ARCHIVE_CANDIDATE_REASONS = ["reset", "deleted"] as const;
+
 async function listResetArchiveCandidatesForTranscriptAsync(
   transcriptPath: string,
 ): Promise<ResetArchiveCandidate[] | undefined> {
@@ -260,14 +262,29 @@ async function listResetArchiveCandidatesForTranscriptAsync(
   const archives: ResetArchiveCandidate[] = [];
   try {
     for (const entry of await fs.promises.readdir(dir, { withFileTypes: true })) {
-      if (!entry.isFile() || !entry.name.startsWith(`${base}.reset.`)) {
+      if (!entry.isFile()) {
         continue;
       }
-      const timestamp = parseSessionArchiveTimestamp(entry.name, "reset");
-      if (timestamp == null) {
+      let matched = false;
+      let timestamp: number | null = null;
+      for (const reason of ARCHIVE_CANDIDATE_REASONS) {
+        if (!entry.name.startsWith(`${base}.${reason}.`)) {
+          continue;
+        }
+        timestamp = parseSessionArchiveTimestamp(entry.name, reason);
+        if (timestamp != null) {
+          matched = true;
+          break;
+        }
+      }
+      if (!matched) {
         continue;
       }
-      archives.push({ archivePath: path.join(dir, entry.name), name: entry.name, timestamp });
+      archives.push({
+        archivePath: path.join(dir, entry.name),
+        name: entry.name,
+        timestamp: timestamp!,
+      });
     }
   } catch {
     return undefined;


### PR DESCRIPTION
## What Problem This Solves

Fixes #87182 — the gateway archives a subagent session transcript before memory-core's dreaming narrative extraction can read it, causing model-generated narrative text to be silently discarded. The fallback entry that lands in `DREAMS.md` contains only snippet text, not the actual model output.

## Why This Change Was Made

The original PR (#87206) used trajectory-based recovery with fuzzy `sessionKey` filename matching and no identity verification, which could mis-associate another session's text into `DREAMS.md`. Per maintainer review (@obviyus), the lifecycle fix (option 2) is preferred: fix the race at the source instead of patching around it.

### Root cause

After a subagent run completes, `completeCleanupBookkeeping` calls `removeInternalSessionEffectsSession` which removes the session store entry. This races with the host plugin's `getSessionMessages` call — when the entry is gone, `sessions.get` returns `{ messages: [] }` and the narrative text is lost.

### Fix (two parts)

1. **Preserve session store entries for keep-mode subagent runs** (`src/agents/subagent-registry-lifecycle.ts`)
   - `completeCleanupBookkeeping` now skips `removeInternalSessionEffectsSession` when `cleanup === "keep"`, so the host plugin's `getSessionMessages` still resolves the entry.
   - The host's explicit `deleteSession` (in memory-core's `finally` block) handles full cleanup.
   - Plugin subagents use `cleanup: "keep"` (set by `registerPluginSubagentRunFromGateway` at `src/gateway/server-methods/agent-task-tracking.ts:181`).

2. **Include `.jsonl.deleted.<ISO>` archives in transcript history fallback** (`src/gateway/session-transcript-files.fs.ts`)
   - `listResetArchiveCandidatesForTranscriptAsync` previously only matched `.jsonl.reset.<ISO>` files.
   - Now also resolves `.jsonl.deleted.<ISO>` so `sessions.get` can read archived transcripts when the live file is gone but the store entry still exists.
   - Defense-in-depth for cases where the store entry survives but the file was already archived by store maintenance.

### What is preserved

- `readSettledNarrativeText` (settled retry with 50/150/300/750 ms delays, from #89091) — the lifecycle fix removes the race at the source, so retries succeed.

### What is removed

- `extractNarrativeFromTrajectory` — the fuzzy `sessionKey` matching approach with no identity verification is removed entirely. If trajectory recovery is ever needed again, it must resolve by `sessionId`/`runId` and verify event identity before using text.

## User Impact

- Dream diary entries will contain the actual model-generated narrative text instead of fallback snippets when the archive race previously caused data loss.
- No breaking changes — the fix is backward-compatible and the host plugin's existing `deleteSession` call handles cleanup.

## Evidence

- Added test: `dreaming-narrative.test.ts` — verifies `readSettledNarrativeText` recovers narrative text when `getSessionMessages` initially returns empty (simulating the archive race).
- Existing `readSettledNarrativeText` retry mechanism (from #89091) is preserved and will succeed once the session store entry is no longer prematurely removed.
- Corroborating production metrics from @dimonnld (comment on #87206) and @C-LaForest confirm the race is real and recovery is the right direction.