### PR TITLE
feat(ui): preview lobster sound when enabled

### DIFF
--- a/ui/src/components/lobster-pet-audio.ts
+++ b/ui/src/components/lobster-pet-audio.ts
@@ -45,7 +45,7 @@ export function playLobsterPetChirp(
   return ctx;
 }
 
-export function previewLobsterPetChirp(): void {
+export function previewLobsterChirp(): void {
   const ctx = playLobsterPetChirp(null, true, "poke");
   if (!ctx) {
     return;

--- a/ui/src/components/lobster-pet-audio.ts
+++ b/ui/src/components/lobster-pet-audio.ts
@@ -44,3 +44,12 @@ export function playLobsterPetChirp(
   }
   return ctx;
 }
+
+export function previewLobsterPetChirp(): void {
+  const ctx = playLobsterPetChirp(null, true, "poke");
+  if (!ctx) {
+    return;
+  }
+  // The preview owns a one-shot context; release it after the chirp envelope.
+  window.setTimeout(() => void ctx.close().catch(() => {}), 300);
+}

--- a/ui/src/components/settings-ui.ts
+++ b/ui/src/components/settings-ui.ts
@@ -151,8 +151,23 @@ export function renderSettingsToggleRow(props: {
   description?: unknown;
   checked: boolean;
   onChange: (checked: boolean) => void;
+  /** Runs synchronously during direct activation for effects gated on user activation. */
+  onUserToggle?: (checked: boolean) => void;
   disabled?: boolean;
 }): TemplateResult {
+  const notifySwitchActivation = (event: MouseEvent | KeyboardEvent) => {
+    const fromInput = event.composedPath().some((node) => node instanceof HTMLInputElement);
+    if (
+      !fromInput ||
+      (event instanceof KeyboardEvent && event.key !== "ArrowLeft" && event.key !== "ArrowRight")
+    ) {
+      return;
+    }
+    const checked = (event.currentTarget as HTMLElement & { checked: boolean }).checked;
+    if (checked !== props.checked) {
+      props.onUserToggle?.(checked);
+    }
+  };
   return html`
     <div
       class="settings-row settings-row--toggle"
@@ -161,7 +176,9 @@ export function renderSettingsToggleRow(props: {
         if (props.disabled || (target instanceof Element && target.closest("wa-switch") !== null)) {
           return;
         }
-        props.onChange(!props.checked);
+        const checked = !props.checked;
+        props.onUserToggle?.(checked);
+        props.onChange(checked);
       }}
     >
       <div class="settings-row__text">
@@ -176,6 +193,8 @@ export function renderSettingsToggleRow(props: {
           size="s"
           .checked=${props.checked}
           ?disabled=${props.disabled ?? false}
+          @click=${notifySwitchActivation}
+          @keydown=${notifySwitchActivation}
           @change=${(event: Event) => {
             props.onChange((event.currentTarget as HTMLElement & { checked: boolean }).checked);
           }}

--- a/ui/src/components/settings-ui.ts
+++ b/ui/src/components/settings-ui.ts
@@ -152,7 +152,7 @@ export function renderSettingsToggleRow(props: {
   checked: boolean;
   onChange: (checked: boolean) => void;
   /** Runs synchronously during direct activation for effects gated on user activation. */
-  onActivate?: (checked: boolean) => void;
+  onAct?: (checked: boolean) => void;
   disabled?: boolean;
 }): TemplateResult {
   const notifySwitchActivation = (event: MouseEvent | KeyboardEvent) => {
@@ -165,7 +165,7 @@ export function renderSettingsToggleRow(props: {
     }
     const checked = (event.currentTarget as HTMLElement & { checked: boolean }).checked;
     if (checked !== props.checked) {
-      props.onActivate?.(checked);
+      props.onAct?.(checked);
     }
   };
   return html`
@@ -177,7 +177,7 @@ export function renderSettingsToggleRow(props: {
           return;
         }
         const checked = !props.checked;
-        props.onActivate?.(checked);
+        props.onAct?.(checked);
         props.onChange(checked);
       }}
     >

--- a/ui/src/components/settings-ui.ts
+++ b/ui/src/components/settings-ui.ts
@@ -152,7 +152,7 @@ export function renderSettingsToggleRow(props: {
   checked: boolean;
   onChange: (checked: boolean) => void;
   /** Runs synchronously during direct activation for effects gated on user activation. */
-  onUserToggle?: (checked: boolean) => void;
+  onActivate?: (checked: boolean) => void;
   disabled?: boolean;
 }): TemplateResult {
   const notifySwitchActivation = (event: MouseEvent | KeyboardEvent) => {
@@ -165,7 +165,7 @@ export function renderSettingsToggleRow(props: {
     }
     const checked = (event.currentTarget as HTMLElement & { checked: boolean }).checked;
     if (checked !== props.checked) {
-      props.onUserToggle?.(checked);
+      props.onActivate?.(checked);
     }
   };
   return html`
@@ -177,7 +177,7 @@ export function renderSettingsToggleRow(props: {
           return;
         }
         const checked = !props.checked;
-        props.onUserToggle?.(checked);
+        props.onActivate?.(checked);
         props.onChange(checked);
       }}
     >

--- a/ui/src/pages/config/view.browser.test.ts
+++ b/ui/src/pages/config/view.browser.test.ts
@@ -1349,6 +1349,102 @@ describe("config view", () => {
     expect(container.textContent).toContain("Hold microphone button to dictate");
   });
 
+  it("previews lobster sounds only when the user enables them", () => {
+    const param = () => ({
+      setValueAtTime: vi.fn(),
+      exponentialRampToValueAtTime: vi.fn(),
+    });
+    const audioContextCtor = vi.fn(function MockAudioContext() {
+      return {
+        state: "running",
+        currentTime: 0,
+        destination: {},
+        resume: vi.fn(),
+        close: vi.fn(() => Promise.resolve()),
+        createOscillator: vi.fn(() => ({
+          type: "sine",
+          frequency: param(),
+          connect: (node: unknown) => node,
+          start: vi.fn(),
+          stop: vi.fn(),
+        })),
+        createGain: vi.fn(() => ({ gain: param(), connect: vi.fn() })),
+      };
+    });
+    vi.stubGlobal("AudioContext", audioContextCtor);
+
+    const activateSwitch = (element: HTMLElement & { checked: boolean }, nextChecked: boolean) => {
+      const dispatchClick = (path: EventTarget[]) => {
+        const event = new MouseEvent("click", { bubbles: true, composed: true });
+        Object.defineProperty(event, "composedPath", { value: () => path });
+        element.dispatchEvent(event);
+      };
+      dispatchClick([document.createElement("span"), element]);
+      element.checked = nextChecked;
+      dispatchClick([document.createElement("input"), element]);
+      element.dispatchEvent(new Event("change", { bubbles: true, composed: true }));
+    };
+
+    const setLobsterPetSounds = vi.fn();
+    const disabled = renderConfigView({
+      activeSection: "__appearance__",
+      includeSections: ["__appearance__"],
+      lobsterPetVisits: true,
+      setLobsterPetVisits: vi.fn(),
+      lobsterPetSounds: false,
+      setLobsterPetSounds,
+    });
+    const disabledRow = Array.from(
+      disabled.container.querySelectorAll<HTMLElement>(".settings-row--toggle"),
+    ).find((candidate) => candidate.textContent?.includes("Lobster sounds"));
+    const disabledSwitch = disabledRow?.querySelector<HTMLElement & { checked: boolean }>(
+      "wa-switch",
+    );
+    expect(disabledSwitch).toBeDefined();
+    if (!disabledSwitch) {
+      return;
+    }
+
+    expect(audioContextCtor).not.toHaveBeenCalled();
+    activateSwitch(disabledSwitch, true);
+    expect(audioContextCtor).toHaveBeenCalledTimes(1);
+    expect(setLobsterPetSounds).toHaveBeenCalledWith(true);
+
+    const enabled = renderConfigView({
+      activeSection: "__appearance__",
+      includeSections: ["__appearance__"],
+      lobsterPetVisits: true,
+      setLobsterPetVisits: vi.fn(),
+      lobsterPetSounds: true,
+      setLobsterPetSounds,
+    });
+    const enabledRow = Array.from(
+      enabled.container.querySelectorAll<HTMLElement>(".settings-row--toggle"),
+    ).find((candidate) => candidate.textContent?.includes("Lobster sounds"));
+    const enabledSwitch = enabledRow?.querySelector<HTMLElement & { checked: boolean }>(
+      "wa-switch",
+    );
+    expect(enabledSwitch).toBeDefined();
+    if (!enabledSwitch) {
+      return;
+    }
+
+    const noOpKey = new KeyboardEvent("keydown", {
+      key: "ArrowRight",
+      bubbles: true,
+      composed: true,
+    });
+    Object.defineProperty(noOpKey, "composedPath", {
+      value: () => [document.createElement("input"), enabledSwitch],
+    });
+    enabledSwitch.dispatchEvent(noOpKey);
+    expect(audioContextCtor).toHaveBeenCalledTimes(1);
+
+    activateSwitch(enabledSwitch, false);
+    expect(audioContextCtor).toHaveBeenCalledTimes(1);
+    expect(setLobsterPetSounds).toHaveBeenLastCalledWith(false);
+  });
+
   it("renders and changes the live sidebar activity preference", () => {
     const setSidebarLiveActivity = vi.fn();
     const { container } = renderConfigView({

--- a/ui/src/pages/config/view.ts
+++ b/ui/src/pages/config/view.ts
@@ -1131,7 +1131,7 @@ function renderLobsterPetSection(props: ConfigProps) {
             : t("quickSettings.appearance.lobsterSoundsOff"),
           checked: lobsterPetSounds,
           onChange: (enabled) => props.setLobsterPetSounds?.(enabled),
-          onUserToggle: (enabled) => {
+          onActivate: (enabled) => {
             if (enabled) {
               previewLobsterPetChirp();
             }

--- a/ui/src/pages/config/view.ts
+++ b/ui/src/pages/config/view.ts
@@ -35,7 +35,7 @@ import {
 import "../../components/tooltip.ts";
 import { icons } from "../../components/icons.ts";
 import { getLobsterdex, getLobsterdexEntries } from "../../components/lobster-dex.ts";
-import { previewLobsterPetChirp } from "../../components/lobster-pet-audio.ts";
+import { previewLobsterChirp } from "../../components/lobster-pet-audio.ts";
 import {
   LOBSTER_PET_PALETTES,
   canonicalLobsterLook,
@@ -1131,9 +1131,9 @@ function renderLobsterPetSection(props: ConfigProps) {
             : t("quickSettings.appearance.lobsterSoundsOff"),
           checked: lobsterPetSounds,
           onChange: (enabled) => props.setLobsterPetSounds?.(enabled),
-          onActivate: (enabled) => {
+          onAct: (enabled) => {
             if (enabled) {
-              previewLobsterPetChirp();
+              previewLobsterChirp();
             }
           },
         })}

--- a/ui/src/pages/config/view.ts
+++ b/ui/src/pages/config/view.ts
@@ -35,6 +35,7 @@ import {
 import "../../components/tooltip.ts";
 import { icons } from "../../components/icons.ts";
 import { getLobsterdex, getLobsterdexEntries } from "../../components/lobster-dex.ts";
+import { previewLobsterPetChirp } from "../../components/lobster-pet-audio.ts";
 import {
   LOBSTER_PET_PALETTES,
   canonicalLobsterLook,
@@ -1130,6 +1131,11 @@ function renderLobsterPetSection(props: ConfigProps) {
             : t("quickSettings.appearance.lobsterSoundsOff"),
           checked: lobsterPetSounds,
           onChange: (enabled) => props.setLobsterPetSounds?.(enabled),
+          onUserToggle: (enabled) => {
+            if (enabled) {
+              previewLobsterPetChirp();
+            }
+          },
         })}
         ${renderSettingsRow({
           title: t("quickSettings.appearance.lobsterdex"),


### PR DESCRIPTION
## What Problem This Solves

Enabling **Lobster sounds** did not demonstrate what the setting would sound like, so users had to leave Settings and interact with the lobster to confirm that audio was working.

## Why This Change Was Made

The Appearance toggle now plays one existing lobster poke chirp when a direct user action changes the setting from off to on. The preview stays inside the browser's active user gesture, while initial rendering, restored preferences, no-op keyboard actions, and turning the setting off remain silent.

## User Impact

Users get immediate audible confirmation when they enable Lobster sounds, without adding another button or changing the normal lobster interaction sounds.

## Evidence

- Focused UI tests: 83 passed across `lobster-pet.test.ts` and `view.browser.test.ts` in Blacksmith Testbox run https://github.com/openclaw/openclaw/actions/runs/29790886201.
- Changed-file validation passed formatting, Control UI i18n verification, core-test and UI typechecks, lint, dependency guards, and conflict checks in Blacksmith Testbox run https://github.com/openclaw/openclaw/actions/runs/29791033623.
- Headless Chromium against the live Control UI mock verified the visible switch path: initial render created 0 audio contexts; enabling created exactly 1 while `navigator.userActivation.isActive` was true; reloading with the enabled preference created 0; disabling created 0.
- Fresh source review completed with no actionable findings after covering WebAwesome's generated label/input click sequence and no-op arrow-key behavior.
