### PR TITLE
fix(whatsapp): batch rapid messages without reordering replies

### DIFF
--- a/extensions/whatsapp/src/inbound/durable-receive.test.ts
+++ b/extensions/whatsapp/src/inbound/durable-receive.test.ts
@@ -190,25 +190,33 @@ describe("createWhatsAppIngressMonitor", () => {
     });
   });
 
-  it("lets debounce-eligible claims reach the channel buffer before adoption", async () => {
+  it("orders legacy and debounce-eligible claims before adoption", async () => {
     await withTempState(async (stateDir) => {
       const queue = createChannelIngressQueueForTests<WhatsAppDurableInboundPayload>({
         channelId: "whatsapp",
         accountId: "acct",
         stateDir,
       });
-      const firstId = eventId("msg-5a");
-      const secondId = eventId("msg-5b");
+      const legacyId = eventId("legacy-order");
+      const firstId = eventId("order-0");
+      const secondId = eventId("order-2");
+      expect(secondId < firstId).toBe(true);
+      await queue.enqueue(legacyId, payload("legacy-order"), {
+        laneKey: legacyId,
+        receivedAt: 1,
+      });
       await enqueueWhatsAppDurableInbound({
         queue,
-        message: message("msg-5a"),
+        message: message("order-0"),
         receivedAt: 1,
+        receiveOrder: 0,
         allowConcurrentDebounce: true,
       });
       await enqueueWhatsAppDurableInbound({
         queue,
-        message: message("msg-5b"),
-        receivedAt: 2,
+        message: message("order-2"),
+        receivedAt: 1,
+        receiveOrder: 1,
         allowConcurrentDebounce: true,
       });
 
@@ -229,14 +237,16 @@ describe("createWhatsAppIngressMonitor", () => {
       });
 
       monitor.start();
-      await vi.waitFor(() => expect(dispatched).toEqual(["msg-5a", "msg-5b"]));
+      await vi.waitFor(() => expect(dispatched).toEqual(["legacy-order", "order-0", "order-2"]));
 
       expect((await queue.listClaims()).map((row) => row.id).toSorted()).toEqual(
-        [firstId, secondId].toSorted(),
+        [legacyId, firstId, secondId].toSorted(),
       );
       expect(await queue.listPending({ limit: "all" })).toEqual([]);
 
-      await Promise.all(lifecycles.map((lifecycle) => lifecycle.onAdopted()));
+      await Promise.all(
+        lifecycles.map((lifecycle) => Promise.resolve().then(() => lifecycle.onAdopted())),
+      );
       await monitor.waitForIdle();
       expect(await queue.listClaims()).toEqual([]);
       await monitor.stop();

--- a/extensions/whatsapp/src/inbound/durable-receive.test.ts
+++ b/extensions/whatsapp/src/inbound/durable-receive.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import type { WAMessage } from "baileys";
 import { createChannelIngressQueueForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   deserializeWhatsAppDurableInboundMessage,
   serializeWhatsAppDurableInboundMessage,
@@ -14,6 +14,7 @@ import {
   createWhatsAppIngressMonitor,
   enqueueWhatsAppDurableInbound,
   type WhatsAppDurableInboundPayload,
+  type WhatsAppIngressLifecycle,
 } from "./durable-receive.js";
 
 const REMOTE_JID = "1@s.whatsapp.net";
@@ -185,6 +186,59 @@ describe("createWhatsAppIngressMonitor", () => {
       expect(dispatched).toEqual(["msg-4a", "msg-4b"]);
       expect(await queue.listClaims()).toEqual([]);
       expect(await queue.listPending({ limit: "all" })).toEqual([]);
+      await monitor.stop();
+    });
+  });
+
+  it("lets debounce-eligible claims reach the channel buffer before adoption", async () => {
+    await withTempState(async (stateDir) => {
+      const queue = createChannelIngressQueueForTests<WhatsAppDurableInboundPayload>({
+        channelId: "whatsapp",
+        accountId: "acct",
+        stateDir,
+      });
+      const firstId = eventId("msg-5a");
+      const secondId = eventId("msg-5b");
+      await enqueueWhatsAppDurableInbound({
+        queue,
+        message: message("msg-5a"),
+        receivedAt: 1,
+        allowConcurrentDebounce: true,
+      });
+      await enqueueWhatsAppDurableInbound({
+        queue,
+        message: message("msg-5b"),
+        receivedAt: 2,
+        allowConcurrentDebounce: true,
+      });
+
+      const dispatched: string[] = [];
+      const lifecycles: WhatsAppIngressLifecycle[] = [];
+      const monitor = createWhatsAppIngressMonitor({
+        queue,
+        pollIntervalMs: 10,
+        dispatch: async (inbound, _payload, lifecycle) => {
+          const id = inbound.key.id;
+          if (!id) {
+            throw new Error("expected transport id");
+          }
+          dispatched.push(id);
+          lifecycles.push(lifecycle);
+          return { kind: "deferred" as const };
+        },
+      });
+
+      monitor.start();
+      await vi.waitFor(() => expect(dispatched).toEqual(["msg-5a", "msg-5b"]));
+
+      expect((await queue.listClaims()).map((row) => row.id).toSorted()).toEqual(
+        [firstId, secondId].toSorted(),
+      );
+      expect(await queue.listPending({ limit: "all" })).toEqual([]);
+
+      await Promise.all(lifecycles.map((lifecycle) => lifecycle.onAdopted()));
+      await monitor.waitForIdle();
+      expect(await queue.listClaims()).toEqual([]);
       await monitor.stop();
     });
   });

--- a/extensions/whatsapp/src/inbound/durable-receive.ts
+++ b/extensions/whatsapp/src/inbound/durable-receive.ts
@@ -57,7 +57,10 @@ export function createWhatsAppDurableInboundMessageId(params: {
   return createHash("sha256").update(`${params.remoteJid}\n${params.id}`).digest("hex");
 }
 
-function inspectWhatsAppIngressMessage(message: WAMessage): WhatsAppIngressFacts {
+function inspectWhatsAppIngressMessage(
+  message: WAMessage,
+  options: { allowConcurrentDebounce?: boolean; claimedLaneKey?: string } = {},
+): WhatsAppIngressFacts {
   const remoteJid = message.key?.remoteJid?.trim();
   const id = message.key?.id?.trim();
   if (!remoteJid || !id) {
@@ -66,9 +69,17 @@ function inspectWhatsAppIngressMessage(message: WAMessage): WhatsAppIngressFacts
       "WhatsApp ingress message is missing key.remoteJid or key.id",
     );
   }
+  const eventId = createWhatsAppDurableInboundMessageId({ remoteJid, id });
+  const allowedLaneKeys = new Set([remoteJid, eventId]);
+  const claimedLaneKey = options.claimedLaneKey?.trim();
   return {
-    eventId: createWhatsAppDurableInboundMessageId({ remoteJid, id }),
-    laneKey: remoteJid,
+    eventId,
+    laneKey:
+      claimedLaneKey && allowedLaneKeys.has(claimedLaneKey)
+        ? claimedLaneKey
+        : options.allowConcurrentDebounce
+          ? eventId
+          : remoteJid,
   };
 }
 
@@ -91,8 +102,13 @@ export async function enqueueWhatsAppDurableInbound(params: {
   skipRecentOutboundEcho?: boolean;
   receivedAt?: number;
   receiveOrder?: number;
+  allowConcurrentDebounce?: boolean;
 }) {
-  const facts = inspectWhatsAppIngressMessage(params.message);
+  const facts = inspectWhatsAppIngressMessage(params.message, {
+    ...(params.allowConcurrentDebounce === undefined
+      ? {}
+      : { allowConcurrentDebounce: params.allowConcurrentDebounce }),
+  });
   const receivedAt = params.receivedAt ?? Date.now();
   return await params.queue.enqueue(
     facts.eventId,
@@ -116,7 +132,7 @@ function resolveWhatsAppIngressNonRetryableFailure(error: unknown) {
     : null;
 }
 
-/** Shared monitor with per-conversation lanes and completion at reply-lane adoption. */
+/** Shared monitor with durable lane claims completed only at reply-lane adoption. */
 export function createWhatsAppIngressMonitor(params: {
   queue: WhatsAppDurableInboundQueue;
   dispatch: (
@@ -136,7 +152,10 @@ export function createWhatsAppIngressMonitor(params: {
     WhatsAppDurableInboundPayload
   >({
     queue: params.queue,
-    inspect: (message) => inspectWhatsAppIngressMessage(message),
+    inspect: (message, context) =>
+      inspectWhatsAppIngressMessage(message, {
+        ...(context.phase === "claim" ? { claimedLaneKey: context.claimedLaneKey } : {}),
+      }),
     payload: {
       version: WHATSAPP_DURABLE_INBOUND_PAYLOAD_VERSION,
       serialize: (message, { receivedAt }) => ({
@@ -172,6 +191,9 @@ export function createWhatsAppIngressMonitor(params: {
     drain: {
       resolveNonRetryableFailure: resolveWhatsAppIngressNonRetryableFailure,
       deriveLaneKey: (record) => {
+        if (record.laneKey) {
+          return record.laneKey;
+        }
         try {
           return inspectWhatsAppIngressMessage(
             deserializeWhatsAppDurableInboundMessage(record.payload.message),

--- a/extensions/whatsapp/src/inbound/durable-receive.ts
+++ b/extensions/whatsapp/src/inbound/durable-receive.ts
@@ -85,6 +85,66 @@ function inspectWhatsAppIngressMessage(
 
 export type WhatsAppDurableInboundQueue = ChannelIngressQueue<WhatsAppDurableInboundPayload>;
 
+type WhatsAppDurableInboundRecord = Awaited<
+  ReturnType<WhatsAppDurableInboundQueue["listPending"]>
+>[number];
+
+function compareWhatsAppIngressOrder(
+  left: WhatsAppDurableInboundRecord,
+  right: WhatsAppDurableInboundRecord,
+): number {
+  const receivedAtDiff = left.receivedAt - right.receivedAt;
+  if (receivedAtDiff !== 0) {
+    return receivedAtDiff;
+  }
+  const leftOrder = left.payload.receiveOrder;
+  const rightOrder = right.payload.receiveOrder;
+  if (leftOrder === undefined || rightOrder === undefined) {
+    if (leftOrder === undefined && rightOrder !== undefined) {
+      return -1;
+    }
+    if (leftOrder !== undefined && rightOrder === undefined) {
+      return 1;
+    }
+  } else {
+    const receiveOrderDiff = leftOrder - rightOrder;
+    if (receiveOrderDiff !== 0) {
+      return receiveOrderDiff;
+    }
+  }
+  return left.id.localeCompare(right.id);
+}
+
+function orderWhatsAppDurableInboundQueue(
+  queue: WhatsAppDurableInboundQueue,
+): WhatsAppDurableInboundQueue {
+  return {
+    ...queue,
+    // The shared drain requests its complete pending snapshot before building candidateIds.
+    // Reorder that same snapshot here; do not widen a caller's requested queue scan.
+    listPending: async (options) =>
+      (await queue.listPending(options)).toSorted(compareWhatsAppIngressOrder),
+    claimNext: async (options) => {
+      const candidateIds = options?.candidateIds ? [...options.candidateIds] : undefined;
+      if (!candidateIds) {
+        return await queue.claimNext(options);
+      }
+      // The shared queue's same-millisecond fallback is event id. Claim one
+      // candidate at a time so persisted transport order remains authoritative.
+      for (const candidateId of candidateIds) {
+        const claim = await queue.claimNext({
+          ...options,
+          candidateIds: [candidateId],
+        });
+        if (claim) {
+          return claim;
+        }
+      }
+      return null;
+    },
+  };
+}
+
 /** Account-scoped queue shared with the pre-drain WhatsApp receive journal. */
 export function createWhatsAppDurableInboundQueue(accountId: string): WhatsAppDurableInboundQueue {
   return getWhatsAppRuntime().state.openChannelIngressQueue<WhatsAppDurableInboundPayload>({
@@ -104,11 +164,12 @@ export async function enqueueWhatsAppDurableInbound(params: {
   receiveOrder?: number;
   allowConcurrentDebounce?: boolean;
 }) {
-  const facts = inspectWhatsAppIngressMessage(params.message, {
-    ...(params.allowConcurrentDebounce === undefined
+  const facts = inspectWhatsAppIngressMessage(
+    params.message,
+    params.allowConcurrentDebounce === undefined
       ? {}
-      : { allowConcurrentDebounce: params.allowConcurrentDebounce }),
-  });
+      : { allowConcurrentDebounce: params.allowConcurrentDebounce },
+  );
   const receivedAt = params.receivedAt ?? Date.now();
   return await params.queue.enqueue(
     facts.eventId,
@@ -151,11 +212,12 @@ export function createWhatsAppIngressMonitor(params: {
     WhatsAppDurableInboundPayload,
     WhatsAppDurableInboundPayload
   >({
-    queue: params.queue,
+    queue: orderWhatsAppDurableInboundQueue(params.queue),
     inspect: (message, context) =>
-      inspectWhatsAppIngressMessage(message, {
-        ...(context.phase === "claim" ? { claimedLaneKey: context.claimedLaneKey } : {}),
-      }),
+      inspectWhatsAppIngressMessage(
+        message,
+        context.phase === "claim" ? { claimedLaneKey: context.claimedLaneKey } : {},
+      ),
     payload: {
       version: WHATSAPP_DURABLE_INBOUND_PAYLOAD_VERSION,
       serialize: (message, { receivedAt }) => ({

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -437,7 +437,6 @@ export async function attachWebInboxToSocket(
   type QueuedInboundMessageMetadata = {
     admission: AdmittedWebInboundCallbackMessage["admission"];
     debounceKey?: string;
-    debounceConversationKey?: string;
     debounceCompletion?: {
       key: string;
       conversationKey: string;
@@ -456,7 +455,6 @@ export async function attachWebInboxToSocket(
   const durableInboundQueue =
     options.durableInboundQueue ?? createWhatsAppDurableInboundQueue(options.accountId);
   const inboundDebounceMs = Math.max(0, Math.trunc(options.debounceMs ?? 0));
-  const pendingDebounceKeys = new Set<string>();
   const pendingDebounceCompletionsByKey = new Map<
     string,
     Set<NonNullable<QueuedInboundMessage["debounceCompletion"]>>
@@ -482,7 +480,7 @@ export async function attachWebInboxToSocket(
     }
   };
   const waitForDebounceWorkOrIdle = (handlers: ReadonlyArray<Promise<void>>) => {
-    if (pendingDebounceKeys.size > 0 || activeInboundFlushes.size > 0) {
+    if (pendingDebounceCompletionsByKey.size > 0 || activeInboundFlushes.size > 0) {
       return Promise.resolve();
     }
     if (pendingMessageHandlers.size === 0) {
@@ -498,11 +496,11 @@ export async function attachWebInboxToSocket(
     });
   };
   let nextReceiveOrder = 0;
-  let messagesUpsertTail: Promise<void> = Promise.resolve();
+  const messagesUpsertQueue = new KeyedAsyncQueue();
   const publishPendingWorkState = (at = Date.now()) => {
     options.onPendingWorkChanged?.(
       pendingMessageHandlers.size +
-        pendingDebounceKeys.size +
+        pendingDebounceCompletionsByKey.size +
         activeInboundFlushes.size +
         (durableIngressActive ? 1 : 0),
       at,
@@ -619,7 +617,6 @@ export async function attachWebInboxToSocket(
         keyCompletions?.delete(completion);
         if (keyCompletions?.size === 0) {
           pendingDebounceCompletionsByKey.delete(completion.key);
-          pendingDebounceKeys.delete(completion.key);
         }
         const conversationCompletions = pendingDebounceCompletionsByConversation.get(
           completion.conversationKey,
@@ -628,6 +625,7 @@ export async function attachWebInboxToSocket(
         if (conversationCompletions?.size === 0) {
           pendingDebounceCompletionsByConversation.delete(completion.conversationKey);
         }
+        publishPendingWorkState();
       },
       flushing: false,
       settled: false,
@@ -639,7 +637,6 @@ export async function attachWebInboxToSocket(
       pendingDebounceCompletionsByConversation.get(params.conversationKey) ?? new Set();
     conversationCompletions.add(completion);
     pendingDebounceCompletionsByConversation.set(params.conversationKey, conversationCompletions);
-    pendingDebounceKeys.add(params.key);
     return completion;
   };
 
@@ -679,6 +676,7 @@ export async function attachWebInboxToSocket(
     }
     let handedOff = false;
     let settled = false;
+    let terminalTask: Promise<void> | undefined;
     let resolveSettlement!: () => void;
     const settlement = new Promise<void>((resolve) => {
       resolveSettlement = resolve;
@@ -690,22 +688,49 @@ export async function attachWebInboxToSocket(
       settled = true;
       resolveSettlement();
     };
+    const runTerminalTask = (
+      operation: (lifecycle: WhatsAppIngressLifecycle) => void | Promise<void>,
+    ): Promise<void> => {
+      terminalTask ??= (async () => {
+        const results = await Promise.allSettled(
+          lifecycles.map((lifecycle) => Promise.resolve().then(() => operation(lifecycle))),
+        );
+        markSettled();
+        const failures = results
+          .filter((result): result is PromiseRejectedResult => result.status === "rejected")
+          .map((result) => result.reason);
+        if (failures.length === 1) {
+          throw failures[0];
+        }
+        if (failures.length > 1) {
+          throw new AggregateError(failures, "multiple WhatsApp ingress claims failed to settle");
+        }
+      })();
+      return terminalTask;
+    };
+    const adoptAll = () => runTerminalTask((lifecycle) => lifecycle.onAdopted());
+    const abandonAll = () => runTerminalTask((lifecycle) => lifecycle.onAbandoned());
     const abortSignal =
       lifecycles.length === 1
         ? firstLifecycle.abortSignal
         : AbortSignal.any(lifecycles.map((lifecycle) => lifecycle.abortSignal));
-    if (abortSignal.aborted) {
-      markSettled();
-    } else {
-      abortSignal.addEventListener("abort", markSettled, { once: true });
-    }
-    const adoptAll = async () => {
-      try {
-        await Promise.all(lifecycles.map((lifecycle) => lifecycle.onAdopted()));
-      } finally {
-        markSettled();
-      }
+    const abandonOnAbort = () => {
+      void abandonAll().catch((error: unknown) => {
+        try {
+          inboundLogger.error(
+            { error: String(error) },
+            "failed abandoning aborted WhatsApp ingress claims",
+          );
+        } catch {
+          // Claim settlement remains authoritative when failure reporting is unavailable.
+        }
+      });
     };
+    if (abortSignal.aborted) {
+      abandonOnAbort();
+    } else {
+      abortSignal.addEventListener("abort", abandonOnAbort, { once: true });
+    }
     return {
       lifecycle: {
         abortSignal,
@@ -726,13 +751,7 @@ export async function attachWebInboxToSocket(
         },
         onAbandoned: async () => {
           handedOff = true;
-          try {
-            await Promise.all(
-              lifecycles.map((lifecycle) => Promise.resolve(lifecycle.onAbandoned())),
-            );
-          } finally {
-            markSettled();
-          }
+          await abandonAll();
         },
       } satisfies WhatsAppIngressLifecycle,
       // Gated or otherwise terminal no-dispatch turns still own every merged claim.
@@ -744,13 +763,7 @@ export async function attachWebInboxToSocket(
       abandon: async () => {
         if (!handedOff) {
           handedOff = true;
-          try {
-            await Promise.all(
-              lifecycles.map((lifecycle) => Promise.resolve(lifecycle.onAbandoned())),
-            );
-          } finally {
-            markSettled();
-          }
+          await abandonAll();
         }
       },
       waitForSettlement: async () => {
@@ -854,8 +867,6 @@ export async function attachWebInboxToSocket(
         // Durable adoption can remain deferred after dispatch returns. Keep the
         // ordering completion pending without holding the debouncer's key task.
         const resolveOrderingCompletions = () => {
-          // Adoption requests the durable monitor's terminal drain before this settlement resolves;
-          // its activity callback publishes the final count after these keys clear.
           for (const entry of entries) {
             entry.debounceCompletion?.resolve();
             entry.turnSettlement?.resolve();
@@ -1507,7 +1518,7 @@ export async function attachWebInboxToSocket(
       receiveOrder?: number;
       turnAdoptionLifecycle?: WhatsAppIngressLifecycle;
     },
-  ): Promise<"debounced" | "immediate"> => {
+  ): Promise<void> => {
     const chatJid = inbound.remoteJid;
     const sendComposing = async () => {
       const currentSock = getCurrentSock();
@@ -1665,10 +1676,11 @@ export async function attachWebInboxToSocket(
     const debounceConversationKey = buildInboundDebounceConversationKey(inboundMessage);
     const debounceEligible =
       inboundDebounceMs > 0 && Boolean(debounceKey) && shouldDebounceInboundMessage(inboundMessage);
-    inboundMessage.debounceConversationKey = debounceConversationKey;
     inboundMessage.debounceEligible = debounceEligible;
-    const turnSettlement = createInboundTurnSettlement();
-    inboundMessage.turnSettlement = turnSettlement;
+    const turnSettlement = debounceEligible ? undefined : createInboundTurnSettlement();
+    if (turnSettlement) {
+      inboundMessage.turnSettlement = turnSettlement;
+    }
     await flushPriorConversationDebounce(
       debounceConversationKey,
       debounceEligible ? (debounceKey ?? undefined) : undefined,
@@ -1706,16 +1718,15 @@ export async function attachWebInboxToSocket(
       await debouncer.enqueue(inboundMessage);
     } catch (error) {
       inboundMessage.debounceCompletion?.resolve();
-      turnSettlement.resolve();
+      turnSettlement?.resolve();
       throw error;
     }
-    if (!debounceEligible) {
+    if (turnSettlement) {
       await waitForInboundTurnSettlement(
         turnSettlement,
         durable.turnAdoptionLifecycle?.abortSignal,
       );
     }
-    return debounceEligible ? "debounced" : "immediate";
   };
 
   const processDurableInboundMessage = async (
@@ -1942,8 +1953,8 @@ export async function attachWebInboxToSocket(
   const handleMessagesUpsertEvent = (upsert: { type?: string; messages?: Array<WAMessage> }) => {
     // Baileys listeners are fire-and-forget. Preserve emitter order through
     // durable admission so a later callback cannot persist and drain first.
-    const task = messagesUpsertTail
-      .then(() => handleMessagesUpsert(upsert))
+    const task = messagesUpsertQueue
+      .enqueue("messages.upsert", () => handleMessagesUpsert(upsert))
       .catch((err: unknown) => {
         try {
           inboundLogger.error({ error: String(err) }, "messages.upsert handler error");
@@ -1956,10 +1967,6 @@ export async function attachWebInboxToSocket(
           // Logging must not poison the serialized admission tail.
         }
       });
-    messagesUpsertTail = task.then(
-      () => undefined,
-      () => undefined,
-    );
     pendingMessageHandlers.add(task);
     publishPendingWorkState();
     void task.then(
@@ -2006,7 +2013,7 @@ export async function attachWebInboxToSocket(
       await Promise.race([Promise.allSettled(handlers), waitForDebounceWorkOrIdle(handlers)]);
       if (
         pendingMessageHandlers.size === 0 &&
-        pendingDebounceKeys.size === 0 &&
+        pendingDebounceCompletionsByKey.size === 0 &&
         activeInboundFlushes.size === 0
       ) {
         break;
@@ -2017,7 +2024,7 @@ export async function attachWebInboxToSocket(
     // Alternate until neither the monitor nor debounce layer can create more work.
     for (;;) {
       await durableInboundMonitor.waitForIdle();
-      if (pendingDebounceKeys.size === 0 && activeInboundFlushes.size === 0) {
+      if (pendingDebounceCompletionsByKey.size === 0 && activeInboundFlushes.size === 0) {
         break;
       }
       await drainDebouncedInboundMessages();

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -479,11 +479,12 @@ export async function attachWebInboxToSocket(
       resolve();
     }
   };
-  const waitForDebounceWorkOrIdle = (handlers: ReadonlyArray<Promise<void>>) => {
-    if (pendingDebounceCompletionsByKey.size > 0 || activeInboundFlushes.size > 0) {
-      return Promise.resolve();
-    }
-    if (pendingMessageHandlers.size === 0) {
+  const getPendingDebounceCompletions = () =>
+    [...pendingDebounceCompletionsByKey.values()].flatMap((completions) => Array.from(completions));
+  const hasFlushableDebounceWork = () =>
+    getPendingDebounceCompletions().some((completion) => !completion.flushing);
+  const waitForHandlerProgressOrDebounceWork = (handlers: ReadonlyArray<Promise<void>>) => {
+    if (hasFlushableDebounceWork() || activeInboundFlushes.size > 0) {
       return Promise.resolve();
     }
     return new Promise<void>((resolve) => {
@@ -2006,28 +2007,27 @@ export async function attachWebInboxToSocket(
     // cannot deadlock inside the debounce window. Debounce semantics stay intact.
     for (;;) {
       await drainDebouncedInboundMessages();
-      if (pendingMessageHandlers.size === 0) {
-        break;
-      }
       const handlers = Array.from(pendingMessageHandlers);
-      await Promise.race([Promise.allSettled(handlers), waitForDebounceWorkOrIdle(handlers)]);
-      if (
-        pendingMessageHandlers.size === 0 &&
-        pendingDebounceCompletionsByKey.size === 0 &&
-        activeInboundFlushes.size === 0
-      ) {
+      if (handlers.length === 0) {
         break;
       }
+      // This phase owns transport callbacks only. Post-flush adoption remains
+      // pending for the lifecycle-settlement loop below.
+      await waitForHandlerProgressOrDebounceWork(handlers);
     }
     await drainDebouncedInboundMessages();
     // A flush can adopt one claim and wake the next row in the same lane.
     // Alternate until neither the monitor nor debounce layer can create more work.
     for (;;) {
       await durableInboundMonitor.waitForIdle();
-      if (pendingDebounceCompletionsByKey.size === 0 && activeInboundFlushes.size === 0) {
+      await drainDebouncedInboundMessages();
+      const pendingCompletions = getPendingDebounceCompletions();
+      if (pendingCompletions.length === 0) {
         break;
       }
-      await drainDebouncedInboundMessages();
+      // Post-flush completions stay pending through durable adoption. Await the
+      // actual lifecycle so close timers and abort I/O retain event-loop progress.
+      await Promise.all(pendingCompletions.map((completion) => completion.promise));
     }
     await durableInboundMonitor.stop();
   };

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -13,9 +13,11 @@ import { recordChannelActivity } from "openclaw/plugin-sdk/channel-activity-runt
 import {
   formatInboundMediaUnavailableText,
   formatLocationText,
+  shouldDebounceTextInbound,
   type MediaPlaceholderTextFact,
 } from "openclaw/plugin-sdk/channel-inbound";
 import { createInboundDebouncer } from "openclaw/plugin-sdk/channel-inbound-debounce";
+import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
 import { getChildLogger } from "openclaw/plugin-sdk/logging-core";
 import {
   asDateTimestampMs,
@@ -427,9 +429,25 @@ export async function attachWebInboxToSocket(
     }
     return successor.getCurrentSock();
   };
+  type InboundTurnSettlement = {
+    promise: Promise<void>;
+    resolve: () => void;
+    settled: boolean;
+  };
   type QueuedInboundMessageMetadata = {
     admission: AdmittedWebInboundCallbackMessage["admission"];
     debounceKey?: string;
+    debounceConversationKey?: string;
+    debounceCompletion?: {
+      key: string;
+      conversationKey: string;
+      promise: Promise<void>;
+      resolve: () => void;
+      flushing: boolean;
+      settled: boolean;
+    };
+    debounceEligible?: boolean;
+    turnSettlement?: InboundTurnSettlement;
     turnAdoptionLifecycle?: WhatsAppIngressLifecycle;
     readReceipt?: WhatsAppReadReceiptTarget;
     receiveOrder?: number;
@@ -439,6 +457,14 @@ export async function attachWebInboxToSocket(
     options.durableInboundQueue ?? createWhatsAppDurableInboundQueue(options.accountId);
   const inboundDebounceMs = Math.max(0, Math.trunc(options.debounceMs ?? 0));
   const pendingDebounceKeys = new Set<string>();
+  const pendingDebounceCompletionsByKey = new Map<
+    string,
+    Set<NonNullable<QueuedInboundMessage["debounceCompletion"]>>
+  >();
+  const pendingDebounceCompletionsByConversation = new Map<
+    string,
+    Set<NonNullable<QueuedInboundMessage["debounceCompletion"]>>
+  >();
   const activeInboundFlushes = new Set<Promise<void>>();
   const pendingMessageHandlers = new Set<Promise<void>>();
   let durableIngressActive = false;
@@ -472,6 +498,7 @@ export async function attachWebInboxToSocket(
     });
   };
   let nextReceiveOrder = 0;
+  let messagesUpsertTail: Promise<void> = Promise.resolve();
   const publishPendingWorkState = (at = Date.now()) => {
     options.onPendingWorkChanged?.(
       pendingMessageHandlers.size +
@@ -497,8 +524,33 @@ export async function attachWebInboxToSocket(
     }
     return `${admission.accountId}:${admission.conversation.id}:${senderKey}`;
   };
+  const buildInboundDebounceConversationKey = (msg: QueuedInboundMessage): string => {
+    const admission = requireWhatsAppInboundAdmission(msg);
+    return `${admission.accountId}:${admission.conversation.id}`;
+  };
   const shouldDebounceInboundMessage = (msg: AdmittedWebInboundCallbackMessage): boolean =>
-    options.shouldDebounce?.(msg) ?? true;
+    shouldDebounceTextInbound({
+      text: msg.payload.commandBody ?? msg.payload.body,
+      cfg: options.cfg,
+      hasMedia: Boolean(msg.payload.media),
+      allowDebounce: !msg.payload.location && !msg.quote,
+    }) &&
+    (options.shouldDebounce?.(msg) ?? true);
+  // Eligible raw text claims need independent durable lanes until the channel
+  // buffer adopts them together. The conversation queue and flush barrier below
+  // preserve ordering when full normalization or a custom predicate vetoes them.
+  const canEnterDebounceBeforeConversationAdoption = (msg: WAMessage): boolean => {
+    if (inboundDebounceMs <= 0) {
+      return false;
+    }
+    const rawMessage = msg.message ?? undefined;
+    return shouldDebounceTextInbound({
+      text: extractText(rawMessage),
+      cfg: options.cfg,
+      hasMedia: Boolean(extractMediaKind(rawMessage)),
+      allowDebounce: !extractLocationData(rawMessage) && !describeReplyContext(rawMessage),
+    });
+  };
   const orderDebouncedInboundEntries = (entries: QueuedInboundMessage[]) =>
     entries.toSorted((a, b) => {
       const timestampDiff = (a.event.timestamp ?? 0) - (b.event.timestamp ?? 0);
@@ -507,6 +559,110 @@ export async function attachWebInboxToSocket(
       }
       return (a.receiveOrder ?? 0) - (b.receiveOrder ?? 0);
     });
+
+  const createInboundTurnSettlement = (): InboundTurnSettlement => {
+    let resolvePromise!: () => void;
+    const settlement: InboundTurnSettlement = {
+      promise: new Promise<void>((resolve) => {
+        resolvePromise = resolve;
+      }),
+      resolve: () => {
+        if (settlement.settled) {
+          return;
+        }
+        settlement.settled = true;
+        resolvePromise();
+      },
+      settled: false,
+    };
+    return settlement;
+  };
+
+  const waitForInboundTurnSettlement = async (
+    settlement: InboundTurnSettlement,
+    abortSignal?: AbortSignal,
+  ): Promise<void> => {
+    if (!abortSignal) {
+      await settlement.promise;
+      return;
+    }
+    if (abortSignal.aborted) {
+      return;
+    }
+    await new Promise<void>((resolve) => {
+      const finish = () => {
+        abortSignal.removeEventListener("abort", finish);
+        resolve();
+      };
+      abortSignal.addEventListener("abort", finish, { once: true });
+      void settlement.promise.then(finish, finish);
+    });
+  };
+
+  const registerDebounceCompletion = (params: {
+    key: string;
+    conversationKey: string;
+  }): NonNullable<QueuedInboundMessage["debounceCompletion"]> => {
+    let resolvePromise!: () => void;
+    const completion: NonNullable<QueuedInboundMessage["debounceCompletion"]> = {
+      ...params,
+      promise: new Promise<void>((resolve) => {
+        resolvePromise = resolve;
+      }),
+      resolve: () => {
+        if (completion.settled) {
+          return;
+        }
+        completion.settled = true;
+        resolvePromise();
+        const keyCompletions = pendingDebounceCompletionsByKey.get(completion.key);
+        keyCompletions?.delete(completion);
+        if (keyCompletions?.size === 0) {
+          pendingDebounceCompletionsByKey.delete(completion.key);
+          pendingDebounceKeys.delete(completion.key);
+        }
+        const conversationCompletions = pendingDebounceCompletionsByConversation.get(
+          completion.conversationKey,
+        );
+        conversationCompletions?.delete(completion);
+        if (conversationCompletions?.size === 0) {
+          pendingDebounceCompletionsByConversation.delete(completion.conversationKey);
+        }
+      },
+      flushing: false,
+      settled: false,
+    };
+    const keyCompletions = pendingDebounceCompletionsByKey.get(params.key) ?? new Set();
+    keyCompletions.add(completion);
+    pendingDebounceCompletionsByKey.set(params.key, keyCompletions);
+    const conversationCompletions =
+      pendingDebounceCompletionsByConversation.get(params.conversationKey) ?? new Set();
+    conversationCompletions.add(completion);
+    pendingDebounceCompletionsByConversation.set(params.conversationKey, conversationCompletions);
+    pendingDebounceKeys.add(params.key);
+    return completion;
+  };
+
+  const flushPriorConversationDebounce = async (
+    conversationKey: string,
+    retainedKey?: string,
+  ): Promise<void> => {
+    const completions = [
+      ...(pendingDebounceCompletionsByConversation.get(conversationKey) ?? []),
+    ].filter((completion) => completion.key !== retainedKey || completion.flushing);
+    const keys = new Set(completions.map((completion) => completion.key));
+    await Promise.all([...keys].map((key) => debouncer.flushKey(key)));
+    await Promise.all(completions.map((completion) => completion.promise));
+    if (!retainedKey) {
+      return;
+    }
+    // The retained buffer may cross into onFlush while the awaits above yield. Recheck before
+    // enqueueing: if it is flushing, this message must form a later batch after adoption settles.
+    const racedRetainedCompletions = [
+      ...(pendingDebounceCompletionsByConversation.get(conversationKey) ?? []),
+    ].filter((completion) => completion.key === retainedKey && completion.flushing);
+    await Promise.all(racedRetainedCompletions.map((completion) => completion.promise));
+  };
 
   const buildFlushIngressLifecycle = (entries: QueuedInboundMessage[]) => {
     const lifecycles = entries
@@ -518,20 +674,41 @@ export async function attachWebInboxToSocket(
         lifecycle: undefined,
         settle: async () => {},
         abandon: async () => {},
+        waitForSettlement: async () => {},
       };
     }
     let handedOff = false;
+    let settled = false;
+    let resolveSettlement!: () => void;
+    const settlement = new Promise<void>((resolve) => {
+      resolveSettlement = resolve;
+    });
+    const markSettled = () => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      resolveSettlement();
+    };
+    const abortSignal =
+      lifecycles.length === 1
+        ? firstLifecycle.abortSignal
+        : AbortSignal.any(lifecycles.map((lifecycle) => lifecycle.abortSignal));
+    if (abortSignal.aborted) {
+      markSettled();
+    } else {
+      abortSignal.addEventListener("abort", markSettled, { once: true });
+    }
     const adoptAll = async () => {
-      for (const lifecycle of lifecycles) {
-        await lifecycle.onAdopted();
+      try {
+        await Promise.all(lifecycles.map((lifecycle) => lifecycle.onAdopted()));
+      } finally {
+        markSettled();
       }
     };
     return {
       lifecycle: {
-        abortSignal:
-          lifecycles.length === 1
-            ? firstLifecycle.abortSignal
-            : AbortSignal.any(lifecycles.map((lifecycle) => lifecycle.abortSignal)),
+        abortSignal,
         onAdopted: async () => {
           handedOff = true;
           await adoptAll();
@@ -549,9 +726,13 @@ export async function attachWebInboxToSocket(
         },
         onAbandoned: async () => {
           handedOff = true;
-          await Promise.all(
-            lifecycles.map((lifecycle) => Promise.resolve(lifecycle.onAbandoned())),
-          );
+          try {
+            await Promise.all(
+              lifecycles.map((lifecycle) => Promise.resolve(lifecycle.onAbandoned())),
+            );
+          } finally {
+            markSettled();
+          }
         },
       } satisfies WhatsAppIngressLifecycle,
       // Gated or otherwise terminal no-dispatch turns still own every merged claim.
@@ -563,10 +744,17 @@ export async function attachWebInboxToSocket(
       abandon: async () => {
         if (!handedOff) {
           handedOff = true;
-          await Promise.all(
-            lifecycles.map((lifecycle) => Promise.resolve(lifecycle.onAbandoned())),
-          );
+          try {
+            await Promise.all(
+              lifecycles.map((lifecycle) => Promise.resolve(lifecycle.onAbandoned())),
+            );
+          } finally {
+            markSettled();
+          }
         }
+      },
+      waitForSettlement: async () => {
+        await settlement;
       },
     };
   };
@@ -574,8 +762,14 @@ export async function attachWebInboxToSocket(
   const debouncer = createInboundDebouncer<QueuedInboundMessage>({
     debounceMs: inboundDebounceMs,
     buildKey: (msg) => msg.debounceKey ?? buildInboundDebounceKey(msg),
-    shouldDebounce: shouldDebounceInboundMessage,
+    shouldDebounce: (msg) => msg.debounceEligible === true,
+    serializeImmediate: true,
     onFlush: async (entries) => {
+      for (const entry of entries) {
+        if (entry.debounceCompletion) {
+          entry.debounceCompletion.flushing = true;
+        }
+      }
       let finishFlush!: () => void;
       const flushTask = new Promise<void>((resolve) => {
         finishFlush = resolve;
@@ -583,13 +777,16 @@ export async function attachWebInboxToSocket(
       activeInboundFlushes.add(flushTask);
       publishPendingWorkState();
       notifyDebounceWork();
+      let waitForSettlement = async () => {};
       try {
         const orderedEntries = orderDebouncedInboundEntries(entries);
         const last = orderedEntries.at(-1);
         if (!last) {
           return;
         }
-        const { lifecycle, settle, abandon } = buildFlushIngressLifecycle(orderedEntries);
+        const flushLifecycle = buildFlushIngressLifecycle(orderedEntries);
+        const { lifecycle, settle, abandon } = flushLifecycle;
+        waitForSettlement = flushLifecycle.waitForSettlement;
         try {
           if (orderedEntries.length === 1) {
             await options.onMessage(attachWhatsAppIngressLifecycle(last, lifecycle));
@@ -654,11 +851,27 @@ export async function attachWebInboxToSocket(
           throw error;
         }
       } finally {
-        for (const entry of entries) {
-          if (entry.debounceKey) {
-            pendingDebounceKeys.delete(entry.debounceKey);
+        // Durable adoption can remain deferred after dispatch returns. Keep the
+        // ordering completion pending without holding the debouncer's key task.
+        const resolveOrderingCompletions = () => {
+          // Adoption requests the durable monitor's terminal drain before this settlement resolves;
+          // its activity callback publishes the final count after these keys clear.
+          for (const entry of entries) {
+            entry.debounceCompletion?.resolve();
+            entry.turnSettlement?.resolve();
           }
-        }
+        };
+        void waitForSettlement().then(resolveOrderingCompletions, (error: unknown) => {
+          resolveOrderingCompletions();
+          try {
+            inboundLogger.error(
+              { error: String(error) },
+              "failed waiting for WhatsApp ingress adoption settlement",
+            );
+          } catch {
+            // Bookkeeping must complete even if failure reporting is unavailable.
+          }
+        });
         activeInboundFlushes.delete(flushTask);
         finishFlush();
         publishPendingWorkState();
@@ -1294,7 +1507,7 @@ export async function attachWebInboxToSocket(
       receiveOrder?: number;
       turnAdoptionLifecycle?: WhatsAppIngressLifecycle;
     },
-  ) => {
+  ): Promise<"debounced" | "immediate"> => {
     const chatJid = inbound.remoteJid;
     const sendComposing = async () => {
       const currentSock = getCurrentSock();
@@ -1449,10 +1662,24 @@ export async function attachWebInboxToSocket(
       receiveOrder: durable.receiveOrder,
     });
     const debounceKey = buildInboundDebounceKey(inboundMessage);
+    const debounceConversationKey = buildInboundDebounceConversationKey(inboundMessage);
+    const debounceEligible =
+      inboundDebounceMs > 0 && Boolean(debounceKey) && shouldDebounceInboundMessage(inboundMessage);
+    inboundMessage.debounceConversationKey = debounceConversationKey;
+    inboundMessage.debounceEligible = debounceEligible;
+    const turnSettlement = createInboundTurnSettlement();
+    inboundMessage.turnSettlement = turnSettlement;
+    await flushPriorConversationDebounce(
+      debounceConversationKey,
+      debounceEligible ? (debounceKey ?? undefined) : undefined,
+    );
     if (debounceKey) {
       inboundMessage.debounceKey = debounceKey;
-      if (inboundDebounceMs > 0 && shouldDebounceInboundMessage(inboundMessage)) {
-        pendingDebounceKeys.add(debounceKey);
+      if (debounceEligible) {
+        inboundMessage.debounceCompletion = registerDebounceCompletion({
+          key: debounceKey,
+          conversationKey: debounceConversationKey,
+        });
         publishPendingWorkState();
         notifyDebounceWork();
       }
@@ -1475,7 +1702,20 @@ export async function attachWebInboxToSocket(
         },
       );
     }
-    await debouncer.enqueue(inboundMessage);
+    try {
+      await debouncer.enqueue(inboundMessage);
+    } catch (error) {
+      inboundMessage.debounceCompletion?.resolve();
+      turnSettlement.resolve();
+      throw error;
+    }
+    if (!debounceEligible) {
+      await waitForInboundTurnSettlement(
+        turnSettlement,
+        durable.turnAdoptionLifecycle?.abortSignal,
+      );
+    }
+    return debounceEligible ? "debounced" : "immediate";
   };
 
   const processDurableInboundMessage = async (
@@ -1540,12 +1780,15 @@ export async function attachWebInboxToSocket(
     return "deferred";
   };
 
+  const durableConversationQueue = new KeyedAsyncQueue();
+
   const durableInboundMonitor = createWhatsAppIngressMonitor({
     queue: durableInboundQueue,
     dispatch: async (msg, payload, lifecycle) => {
       const remoteJid = msg.key?.remoteJid;
       const id = msg.key?.id;
-      return {
+      const conversationKey = remoteJid?.trim() || id?.trim() || "invalid-whatsapp-conversation";
+      return await durableConversationQueue.enqueue(conversationKey, async () => ({
         kind: await processDurableInboundMessage(msg, {
           ...payload,
           ...(remoteJid && id
@@ -1553,7 +1796,7 @@ export async function attachWebInboxToSocket(
             : {}),
           lifecycle,
         }),
-      };
+      }));
     },
     pollIntervalMs: WHATSAPP_INGRESS_DRAIN_INTERVAL_MS,
     onLog: (message) => inboundLogger.warn({ message }, "whatsapp ingress drain"),
@@ -1569,10 +1812,14 @@ export async function attachWebInboxToSocket(
     if (upsert.type !== "notify" && upsert.type !== "append") {
       return;
     }
-    for (const msg of upsert.messages ?? []) {
+    // Stamp the whole transport batch before any async policy work. receiveOrder
+    // preserves intra-socket ordering without changing wall-clock age semantics.
+    const receivedMessages = (upsert.messages ?? []).map((msg) => {
+      return { msg, receiveOrder: nextReceiveOrder++, receivedAt: Date.now() };
+    });
+    for (const { msg, receiveOrder, receivedAt } of receivedMessages) {
       rememberBaileysMessage(msg.key?.remoteJid, msg.key?.id, msg.message);
 
-      const receiveOrder = nextReceiveOrder++;
       if (
         await maybeResolveWhatsAppApprovalReaction({
           cfg: options.loadConfig?.() ?? options.cfg,
@@ -1588,7 +1835,6 @@ export async function attachWebInboxToSocket(
         continue;
       }
 
-      const receivedAt = Date.now();
       const skipStaleAppend = shouldSkipStaleAppend(msg, upsert.type);
       const skipRecentOutboundEcho = shouldSkipRecentOutboundEcho(msg);
       const remoteJid = msg.key?.remoteJid;
@@ -1647,6 +1893,7 @@ export async function attachWebInboxToSocket(
             skipRecentOutboundEcho,
             receivedAt,
             receiveOrder,
+            allowConcurrentDebounce: canEnterDebounceBeforeConversationAdoption(msg),
           });
           appendError = undefined;
           break;
@@ -1693,20 +1940,47 @@ export async function attachWebInboxToSocket(
     }
   };
   const handleMessagesUpsertEvent = (upsert: { type?: string; messages?: Array<WAMessage> }) => {
-    const task = handleMessagesUpsert(upsert).catch((err: unknown) => {
-      inboundLogger.error({ error: String(err) }, "messages.upsert handler error");
-      inboundConsoleLog.error(`Messages upsert handler error: ${String(err)}`);
-    });
+    // Baileys listeners are fire-and-forget. Preserve emitter order through
+    // durable admission so a later callback cannot persist and drain first.
+    const task = messagesUpsertTail
+      .then(() => handleMessagesUpsert(upsert))
+      .catch((err: unknown) => {
+        try {
+          inboundLogger.error({ error: String(err) }, "messages.upsert handler error");
+        } catch {
+          // Logging must not poison the serialized admission tail.
+        }
+        try {
+          inboundConsoleLog.error(`Messages upsert handler error: ${String(err)}`);
+        } catch {
+          // Logging must not poison the serialized admission tail.
+        }
+      });
+    messagesUpsertTail = task.then(
+      () => undefined,
+      () => undefined,
+    );
     pendingMessageHandlers.add(task);
     publishPendingWorkState();
-    void task.finally(() => {
-      pendingMessageHandlers.delete(task);
-      publishPendingWorkState();
-    });
+    void task.then(
+      () => {
+        pendingMessageHandlers.delete(task);
+        publishPendingWorkState();
+      },
+      () => {
+        pendingMessageHandlers.delete(task);
+        publishPendingWorkState();
+      },
+    );
   };
   const drainDebouncedInboundMessages = async () => {
-    while (pendingDebounceKeys.size > 0 || activeInboundFlushes.size > 0) {
-      const debounceKeys = Array.from(pendingDebounceKeys);
+    for (;;) {
+      const debounceKeys = [...pendingDebounceCompletionsByKey.entries()]
+        .filter(([, completions]) => [...completions].some((completion) => !completion.flushing))
+        .map(([key]) => key);
+      if (debounceKeys.length === 0 && activeInboundFlushes.size === 0) {
+        return;
+      }
       if (debounceKeys.length > 0) {
         await Promise.all(debounceKeys.map((key) => debouncer.flushKey(key)));
       }

--- a/extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test-support.ts
+++ b/extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test-support.ts
@@ -12,7 +12,11 @@ import {
 } from "./inbound/monitor.js";
 
 const EXPECTED_WHATSAPP_GROUP_METADATA_CACHE_MAX_ENTRIES = 500;
-import { createWhatsAppDurableInboundQueue } from "./inbound/durable-receive.js";
+import {
+  createWhatsAppDurableInboundMessageId,
+  createWhatsAppDurableInboundQueue,
+  type WhatsAppDurableInboundQueue,
+} from "./inbound/durable-receive.js";
 import { resolveWhatsAppIngressLifecycle } from "./inbound/ingress-lifecycle.js";
 import type { WebInboundMessage } from "./inbound/types.js";
 import {
@@ -73,6 +77,37 @@ function nextMessageId(label: string): string {
 
 function createSocketRef(): NonNullable<InboxMonitorOptions["socketRef"]> {
   return { current: null };
+}
+
+function holdPendingScanUntilEnqueues(
+  queue: WhatsAppDurableInboundQueue,
+  expectedEnqueues: number,
+  receivedAt?: number,
+): () => void {
+  let releasePendingScan!: () => void;
+  const pendingScanReady = new Promise<void>((resolve) => {
+    releasePendingScan = resolve;
+  });
+  let enqueueCount = 0;
+  const enqueue = queue.enqueue.bind(queue);
+  queue.enqueue = async (id, payload, options) => {
+    const result = await enqueue(
+      id,
+      payload,
+      receivedAt === undefined ? options : { ...options, receivedAt },
+    );
+    enqueueCount += 1;
+    if (enqueueCount >= expectedEnqueues) {
+      releasePendingScan();
+    }
+    return result;
+  };
+  const listPending = queue.listPending.bind(queue);
+  queue.listPending = async (options) => {
+    await pendingScanReady;
+    return await listPending(options);
+  };
+  return releasePendingScan;
 }
 
 function fastReconnectPolicy(
@@ -1065,10 +1100,8 @@ describe("web monitor inbox", () => {
         timestamp: 1_700_000_001,
         pushName: "Tester",
       });
-      sock.ev.emit("messages.upsert", {
-        type: "notify",
-        messages: [...first.messages, ...second.messages],
-      });
+      sock.ev.emit("messages.upsert", first);
+      sock.ev.emit("messages.upsert", second);
       await vi.advanceTimersByTimeAsync(250);
       await waitForMessageCalls(onMessage, 1);
 
@@ -1076,6 +1109,147 @@ describe("web monitor inbox", () => {
       await listener.close();
     } finally {
       vi.useRealTimers();
+    }
+  });
+
+  it("keeps equal-time buffered text ahead of a later immediate command", async () => {
+    const queue = createWhatsAppDurableInboundQueue(DEFAULT_ACCOUNT_ID);
+    const releasePendingScan = holdPendingScanUntilEnqueues(queue, 2, 1);
+    let adoptText: (() => void | Promise<void>) | undefined;
+    const onMessage = vi.fn(async (message: WebInboundMessage) => {
+      if (message.payload.body !== "earlier text") {
+        return;
+      }
+      const lifecycle = resolveWhatsAppIngressLifecycle(message);
+      if (!lifecycle) {
+        throw new Error("expected durable ingress lifecycle");
+      }
+      lifecycle.onDeferred();
+      adoptText = lifecycle.onAdopted;
+    });
+    const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage, {
+      debounceMs: 250,
+      durableInboundQueue: queue,
+    });
+    try {
+      const earlierId = "text-first-0";
+      const laterId = "text-first-1";
+      expect(
+        createWhatsAppDurableInboundMessageId({
+          remoteJid: "999@s.whatsapp.net",
+          id: laterId,
+        }) <
+          createWhatsAppDurableInboundMessageId({
+            remoteJid: "999@s.whatsapp.net",
+            id: earlierId,
+          }),
+      ).toBe(true);
+      sock.ev.emit(
+        "messages.upsert",
+        buildNotifyMessageUpsert({
+          id: earlierId,
+          remoteJid: "999@s.whatsapp.net",
+          text: "earlier text",
+          timestamp: 1_700_000_000,
+        }),
+      );
+      sock.ev.emit(
+        "messages.upsert",
+        buildNotifyMessageUpsert({
+          id: laterId,
+          remoteJid: "999@s.whatsapp.net",
+          text: "/status",
+          timestamp: 1_700_000_001,
+        }),
+      );
+
+      await waitForMessageCalls(onMessage, 1);
+      expect(inboundMessage(onMessage).payload.body).toBe("earlier text");
+      await settleInboundWork();
+      expect(onMessage).toHaveBeenCalledTimes(1);
+
+      if (!adoptText) {
+        throw new Error("expected buffered text adoption callback");
+      }
+      await adoptText();
+      await waitForMessageCalls(onMessage, 2);
+      expect(inboundMessage(onMessage, 1).payload.body).toBe("/status");
+    } finally {
+      releasePendingScan();
+      await adoptText?.();
+      await listener.close();
+    }
+  });
+
+  it("keeps equal-time eligible text behind an earlier immediate command", async () => {
+    const queue = createWhatsAppDurableInboundQueue(DEFAULT_ACCOUNT_ID);
+    const releasePendingScan = holdPendingScanUntilEnqueues(queue, 2, 1);
+    let adoptCommand: (() => void | Promise<void>) | undefined;
+    const onMessage = vi.fn(async (message: WebInboundMessage) => {
+      if (message.payload.body !== "/status") {
+        return;
+      }
+      const lifecycle = resolveWhatsAppIngressLifecycle(message);
+      if (!lifecycle) {
+        throw new Error("expected durable ingress lifecycle");
+      }
+      lifecycle.onDeferred();
+      adoptCommand = lifecycle.onAdopted;
+    });
+    const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage, {
+      debounceMs: 250,
+      durableInboundQueue: queue,
+    });
+    try {
+      const earlierId = "command-first-0";
+      const laterId = "command-first-4";
+      expect(
+        createWhatsAppDurableInboundMessageId({
+          remoteJid: "999@s.whatsapp.net",
+          id: laterId,
+        }) <
+          createWhatsAppDurableInboundMessageId({
+            remoteJid: "999@s.whatsapp.net",
+            id: earlierId,
+          }),
+      ).toBe(true);
+      sock.ev.emit(
+        "messages.upsert",
+        buildNotifyMessageUpsert({
+          id: earlierId,
+          remoteJid: "999@s.whatsapp.net",
+          text: "/status",
+          timestamp: 1_700_000_000,
+        }),
+      );
+      sock.ev.emit(
+        "messages.upsert",
+        buildNotifyMessageUpsert({
+          id: laterId,
+          remoteJid: "999@s.whatsapp.net",
+          text: "later text",
+          timestamp: 1_700_000_001,
+        }),
+      );
+
+      await waitForMessageCalls(onMessage, 1);
+      expect(inboundMessage(onMessage).payload.body).toBe("/status");
+      expect(onMessage).toHaveBeenCalledTimes(1);
+
+      if (!adoptCommand) {
+        throw new Error("expected immediate command adoption callback");
+      }
+      await adoptCommand();
+      await settleInboundWork();
+      await new Promise((resolve) => {
+        setTimeout(resolve, 300);
+      });
+      await waitForMessageCalls(onMessage, 2);
+      expect(inboundMessage(onMessage, 1).payload.body).toBe("later text");
+    } finally {
+      releasePendingScan();
+      await adoptCommand?.();
+      await listener.close();
     }
   });
 
@@ -2203,7 +2377,9 @@ describe("web monitor inbox", () => {
 
     await waitForMessageCalls(onMessage, 1);
     expect(inboundMessage(onMessage).payload.body).toBe("do not debounce");
-    await new Promise((resolve) => setTimeout(resolve, 100));
+    await new Promise((resolve) => {
+      setTimeout(resolve, 100);
+    });
     expect(onMessage).toHaveBeenCalledTimes(1);
 
     if (!adoptImmediate) {
@@ -2251,7 +2427,9 @@ describe("web monitor inbox", () => {
         timestamp: 1_700_000_001,
       }),
     );
-    await new Promise((resolve) => setTimeout(resolve, 100));
+    await new Promise((resolve) => {
+      setTimeout(resolve, 100);
+    });
     expect(onMessage).toHaveBeenCalledTimes(1);
 
     if (!adoptFirstBatch) {
@@ -2428,6 +2606,210 @@ describe("web monitor inbox", () => {
       await adoptBatch?.();
       await listener.close();
       setTimeoutSpy.mockRestore();
+    }
+  });
+
+  it("keeps ordering and pending work until every batched claim settles", async () => {
+    const queue = createWhatsAppDurableInboundQueue(DEFAULT_ACCOUNT_ID);
+    const complete = queue.complete.bind(queue);
+    let completeCalls = 0;
+    let releaseSecondComplete!: () => void;
+    const secondCompleteGate = new Promise<void>((resolve) => {
+      releaseSecondComplete = resolve;
+    });
+    queue.complete = async (claim, options) => {
+      completeCalls += 1;
+      if (completeCalls === 1) {
+        // Claim-token loss is terminal for this constituent and rejects adoption immediately.
+        return false;
+      }
+      await secondCompleteGate;
+      return await complete(claim, options);
+    };
+
+    const onPendingWorkChanged = vi.fn();
+    let adoptBatch: (() => void | Promise<void>) | undefined;
+    const onMessage = vi.fn(async (message: WebInboundMessage) => {
+      if (message.payload.body !== "first\nsecond") {
+        return;
+      }
+      const lifecycle = resolveWhatsAppIngressLifecycle(message);
+      if (!lifecycle) {
+        throw new Error("expected durable ingress lifecycle");
+      }
+      lifecycle.onDeferred();
+      adoptBatch = lifecycle.onAdopted;
+    });
+    const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage, {
+      debounceMs: 20,
+      durableInboundQueue: queue,
+      onPendingWorkChanged,
+    });
+    let adoptionResult: Promise<unknown> | undefined;
+    try {
+      sock.ev.emit(
+        "messages.upsert",
+        buildNotifyMessageUpsert({
+          id: nextMessageId("aggregate-settlement-first"),
+          remoteJid: "999@s.whatsapp.net",
+          text: "first",
+          timestamp: 1_700_000_000,
+        }),
+      );
+      sock.ev.emit(
+        "messages.upsert",
+        buildNotifyMessageUpsert({
+          id: nextMessageId("aggregate-settlement-second"),
+          remoteJid: "999@s.whatsapp.net",
+          text: "second",
+          timestamp: 1_700_000_001,
+        }),
+      );
+      await waitForMessageCalls(onMessage, 1);
+
+      if (!adoptBatch) {
+        throw new Error("expected batched adoption callback");
+      }
+      adoptionResult = Promise.resolve(adoptBatch()).then(
+        () => undefined,
+        (error: unknown) => error,
+      );
+      await vi.waitFor(() => expect(completeCalls).toBe(2));
+
+      sock.ev.emit(
+        "messages.upsert",
+        buildNotifyMessageUpsert({
+          id: nextMessageId("aggregate-settlement-command"),
+          remoteJid: "999@s.whatsapp.net",
+          text: "/status",
+          timestamp: 1_700_000_002,
+        }),
+      );
+      await new Promise((resolve) => {
+        setTimeout(resolve, 50);
+      });
+      expect(onMessage).toHaveBeenCalledTimes(1);
+      expect(onPendingWorkChanged.mock.calls.at(-1)?.[0]).toBeGreaterThan(0);
+
+      releaseSecondComplete();
+      await expect(adoptionResult).resolves.toBeInstanceOf(Error);
+      await waitForMessageCalls(onMessage, 2);
+      expect(inboundMessage(onMessage, 1).payload.body).toBe("/status");
+    } finally {
+      releaseSecondComplete();
+      await adoptionResult;
+      await listener.close();
+      for (const claim of await queue.listClaims()) {
+        await queue.delete(claim);
+      }
+    }
+  });
+
+  it("keeps pending work active until shutdown abandons every batched claim", async () => {
+    const debounceMs = 12_345;
+    const closeDrainTimeoutMs = 5_000;
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    const queue = createWhatsAppDurableInboundQueue(DEFAULT_ACCOUNT_ID);
+    const release = queue.release.bind(queue);
+    let releaseCalls = 0;
+    let releaseSecond!: () => void;
+    const secondReleaseGate = new Promise<void>((resolve) => {
+      releaseSecond = resolve;
+    });
+    queue.release = async (claim, options) => {
+      releaseCalls += 1;
+      if (releaseCalls === 2) {
+        await secondReleaseGate;
+      }
+      return await release(claim, options);
+    };
+
+    const onPendingWorkChanged = vi.fn();
+    const onMessage = vi.fn(async (message: WebInboundMessage) => {
+      const lifecycle = resolveWhatsAppIngressLifecycle(message);
+      if (!lifecycle) {
+        throw new Error("expected durable ingress lifecycle");
+      }
+      lifecycle.onDeferred();
+    });
+    const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage, {
+      debounceMs,
+      durableInboundQueue: queue,
+      onPendingWorkChanged,
+    });
+    try {
+      sock.ev.emit(
+        "messages.upsert",
+        buildNotifyMessageUpsert({
+          id: nextMessageId("aggregate-abort-first"),
+          remoteJid: "999@s.whatsapp.net",
+          text: "first",
+          timestamp: 1_700_000_000,
+        }),
+      );
+      sock.ev.emit(
+        "messages.upsert",
+        buildNotifyMessageUpsert({
+          id: nextMessageId("aggregate-abort-second"),
+          remoteJid: "999@s.whatsapp.net",
+          text: "second",
+          timestamp: 1_700_000_001,
+        }),
+      );
+      await vi.waitFor(() => {
+        expect(setTimeoutSpy.mock.calls.some((call) => call[1] === debounceMs)).toBe(true);
+      });
+      const debounceTimerIndex = setTimeoutSpy.mock.calls.findIndex(
+        (call) => call[1] === debounceMs,
+      );
+      const debounceTimer = setTimeoutSpy.mock.results[debounceTimerIndex]?.value as
+        | ReturnType<typeof setTimeout>
+        | undefined;
+      const flush = setTimeoutSpy.mock.calls[debounceTimerIndex]?.[0];
+      if (debounceTimer) {
+        clearTimeout(debounceTimer);
+      }
+      if (typeof flush !== "function") {
+        throw new Error("expected debounce timer callback");
+      }
+      flush();
+      await waitForMessageCalls(onMessage, 1);
+      expect(inboundMessage(onMessage).payload.body).toBe("first\nsecond");
+
+      const closePromise = listener.close();
+      const closeTimerIndex = setTimeoutSpy.mock.calls.findIndex(
+        (call) => call[1] === closeDrainTimeoutMs,
+      );
+      const closeTimer = setTimeoutSpy.mock.results[closeTimerIndex]?.value as
+        | ReturnType<typeof setTimeout>
+        | undefined;
+      const expireCloseDrain = setTimeoutSpy.mock.calls[closeTimerIndex]?.[0];
+      if (closeTimer) {
+        clearTimeout(closeTimer);
+      }
+      if (typeof expireCloseDrain !== "function") {
+        throw new Error("expected inbound close drain timeout callback");
+      }
+      expireCloseDrain();
+      await closePromise;
+      await vi.waitFor(() => expect(releaseCalls).toBe(2));
+
+      expect(onPendingWorkChanged.mock.calls.at(-1)?.[0]).toBeGreaterThan(0);
+      releaseSecond();
+      await vi.waitFor(() => {
+        expect(onPendingWorkChanged.mock.calls.at(-1)?.[0]).toBe(0);
+      });
+      await expect(queue.listClaims()).resolves.toHaveLength(0);
+    } finally {
+      releaseSecond();
+      await listener.close();
+      setTimeoutSpy.mockRestore();
+      for (const record of await queue.listPending({ limit: "all" })) {
+        await queue.delete(record);
+      }
+      for (const claim of await queue.listClaims()) {
+        await queue.delete(claim);
+      }
     }
   });
 

--- a/extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test-support.ts
+++ b/extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test-support.ts
@@ -2609,6 +2609,54 @@ describe("web monitor inbox", () => {
     }
   });
 
+  it("lets a real timer settle deferred debounce adoption while closing", async () => {
+    let adoptBatch: (() => void | Promise<void>) | undefined;
+    const onMessage = vi.fn(async (message: WebInboundMessage) => {
+      const lifecycle = resolveWhatsAppIngressLifecycle(message);
+      if (!lifecycle) {
+        throw new Error("expected durable ingress lifecycle");
+      }
+      lifecycle.onDeferred();
+      adoptBatch = lifecycle.onAdopted;
+    });
+
+    const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage, {
+      debounceMs: 20,
+    });
+    let adoptionTimer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      sock.ev.emit(
+        "messages.upsert",
+        buildNotifyMessageUpsert({
+          id: nextMessageId("deferred-debounce-close-timer"),
+          remoteJid: "999@s.whatsapp.net",
+          text: "deferred batch",
+          timestamp: 1_700_000_000,
+        }),
+      );
+      await waitForMessageCalls(onMessage, 1);
+      if (!adoptBatch) {
+        throw new Error("expected deferred batch adoption callback");
+      }
+
+      let timerFired = false;
+      const closePromise = listener.close();
+      adoptionTimer = setTimeout(() => {
+        timerFired = true;
+        void adoptBatch?.();
+      }, 0);
+
+      await closePromise;
+      expect(timerFired).toBe(true);
+    } finally {
+      if (adoptionTimer) {
+        clearTimeout(adoptionTimer);
+      }
+      await adoptBatch?.();
+      await listener.close();
+    }
+  });
+
   it("keeps ordering and pending work until every batched claim settles", async () => {
     const queue = createWhatsAppDurableInboundQueue(DEFAULT_ACCOUNT_ID);
     const complete = queue.complete.bind(queue);

--- a/extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test-support.ts
+++ b/extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test-support.ts
@@ -1044,6 +1044,41 @@ describe("web monitor inbox", () => {
     }
   });
 
+  it("batches rapid durable text messages before dispatching the conversation", async () => {
+    vi.useFakeTimers();
+    try {
+      const onMessage = vi.fn(async () => undefined);
+      const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage, {
+        debounceMs: 250,
+      });
+      const first = buildNotifyMessageUpsert({
+        id: nextMessageId("durable-debounce-1"),
+        remoteJid: "999@s.whatsapp.net",
+        text: "first",
+        timestamp: 1_700_000_000,
+        pushName: "Tester",
+      });
+      const second = buildNotifyMessageUpsert({
+        id: nextMessageId("durable-debounce-2"),
+        remoteJid: "999@s.whatsapp.net",
+        text: "second",
+        timestamp: 1_700_000_001,
+        pushName: "Tester",
+      });
+      sock.ev.emit("messages.upsert", {
+        type: "notify",
+        messages: [...first.messages, ...second.messages],
+      });
+      await vi.advanceTimersByTimeAsync(250);
+      await waitForMessageCalls(onMessage, 1);
+
+      expect(inboundMessage(onMessage).payload.body).toBe("first\nsecond");
+      await listener.close();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("completes shutdown under a long durable debounce without waiting for the window", async () => {
     // Durable pump tasks await claim flush waiters; close must force-flush
     // debounced batches before waiting on those pumps (socket-close timeout).
@@ -2031,6 +2066,415 @@ describe("web monitor inbox", () => {
     await adoptFirst();
     await waitForMessageCalls(onMessage, 2);
     expect(inboundMessage(onMessage, 1).payload.body).toBe("pong");
+    await listener.close();
+  });
+
+  it("keeps control commands serialized when text debounce is enabled", async () => {
+    let adoptFirst: (() => void | Promise<void>) | undefined;
+    const onMessage = vi.fn(async (message: WebInboundMessage) => {
+      if (!adoptFirst) {
+        const lifecycle = resolveWhatsAppIngressLifecycle(message);
+        if (!lifecycle) {
+          throw new Error("expected durable ingress lifecycle");
+        }
+        lifecycle.onDeferred();
+        adoptFirst = lifecycle.onAdopted;
+      }
+    });
+
+    const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage, {
+      debounceMs: 250,
+    });
+    sock.ev.emit(
+      "messages.upsert",
+      buildNotifyMessageUpsert({
+        id: nextMessageId("serialized-command-1"),
+        remoteJid: "999@s.whatsapp.net",
+        text: "/status",
+        timestamp: 1_700_000_000,
+      }),
+    );
+    await waitForMessageCalls(onMessage, 1);
+    sock.ev.emit(
+      "messages.upsert",
+      buildNotifyMessageUpsert({
+        id: nextMessageId("serialized-command-2"),
+        remoteJid: "999@s.whatsapp.net",
+        text: "/status plugins",
+        timestamp: 1_700_000_001,
+      }),
+    );
+    await settleInboundWork();
+
+    expect(onMessage).toHaveBeenCalledTimes(1);
+    if (!adoptFirst) {
+      throw new Error("expected first adoption callback");
+    }
+    await adoptFirst();
+    await waitForMessageCalls(onMessage, 2);
+    expect(inboundMessage(onMessage, 1).payload.body).toBe("/status plugins");
+    await listener.close();
+  });
+
+  it("flushes and adopts buffered text before dispatching a later control command", async () => {
+    let adoptText: (() => void | Promise<void>) | undefined;
+    const onMessage = vi.fn(async (message: WebInboundMessage) => {
+      if (!adoptText) {
+        const lifecycle = resolveWhatsAppIngressLifecycle(message);
+        if (!lifecycle) {
+          throw new Error("expected durable ingress lifecycle");
+        }
+        lifecycle.onDeferred();
+        adoptText = lifecycle.onAdopted;
+      }
+    });
+
+    const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage, {
+      debounceMs: 250,
+    });
+    sock.ev.emit(
+      "messages.upsert",
+      buildNotifyMessageUpsert({
+        id: nextMessageId("text-before-command"),
+        remoteJid: "999@s.whatsapp.net",
+        text: "first text",
+        timestamp: 1_700_000_000,
+      }),
+    );
+    sock.ev.emit(
+      "messages.upsert",
+      buildNotifyMessageUpsert({
+        id: nextMessageId("command-after-text"),
+        remoteJid: "999@s.whatsapp.net",
+        text: "/status",
+        timestamp: 1_700_000_001,
+      }),
+    );
+
+    await waitForMessageCalls(onMessage, 1);
+    expect(inboundMessage(onMessage).payload.body).toBe("first text");
+    await settleInboundWork();
+    expect(onMessage).toHaveBeenCalledTimes(1);
+
+    if (!adoptText) {
+      throw new Error("expected text adoption callback");
+    }
+    await adoptText();
+    await waitForMessageCalls(onMessage, 2);
+    expect(inboundMessage(onMessage, 1).payload.body).toBe("/status");
+    await listener.close();
+  });
+
+  it("serializes a custom debounce veto with later eligible text", async () => {
+    let adoptImmediate: (() => void | Promise<void>) | undefined;
+    const onMessage = vi.fn(async (message: WebInboundMessage) => {
+      if (!adoptImmediate) {
+        const lifecycle = resolveWhatsAppIngressLifecycle(message);
+        if (!lifecycle) {
+          throw new Error("expected durable ingress lifecycle");
+        }
+        lifecycle.onDeferred();
+        adoptImmediate = lifecycle.onAdopted;
+      }
+    });
+
+    const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage, {
+      debounceMs: 50,
+      shouldDebounce: (message) => message.payload.body !== "do not debounce",
+    });
+    sock.ev.emit(
+      "messages.upsert",
+      buildNotifyMessageUpsert({
+        id: nextMessageId("custom-veto"),
+        remoteJid: "999@s.whatsapp.net",
+        text: "do not debounce",
+        timestamp: 1_700_000_000,
+      }),
+    );
+    sock.ev.emit(
+      "messages.upsert",
+      buildNotifyMessageUpsert({
+        id: nextMessageId("after-custom-veto"),
+        remoteJid: "999@s.whatsapp.net",
+        text: "debounce me",
+        timestamp: 1_700_000_001,
+      }),
+    );
+
+    await waitForMessageCalls(onMessage, 1);
+    expect(inboundMessage(onMessage).payload.body).toBe("do not debounce");
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(onMessage).toHaveBeenCalledTimes(1);
+
+    if (!adoptImmediate) {
+      throw new Error("expected immediate adoption callback");
+    }
+    await adoptImmediate();
+    await waitForMessageCalls(onMessage, 2);
+    expect(inboundMessage(onMessage, 1).payload.body).toBe("debounce me");
+    await listener.close();
+  });
+
+  it("holds a new same-sender debounce batch behind an in-flight adoption", async () => {
+    let adoptFirstBatch: (() => void | Promise<void>) | undefined;
+    const onMessage = vi.fn(async (message: WebInboundMessage) => {
+      if (!adoptFirstBatch) {
+        const lifecycle = resolveWhatsAppIngressLifecycle(message);
+        if (!lifecycle) {
+          throw new Error("expected durable ingress lifecycle");
+        }
+        lifecycle.onDeferred();
+        adoptFirstBatch = lifecycle.onAdopted;
+      }
+    });
+
+    const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage, {
+      debounceMs: 20,
+    });
+    sock.ev.emit(
+      "messages.upsert",
+      buildNotifyMessageUpsert({
+        id: nextMessageId("first-debounce-batch"),
+        remoteJid: "999@s.whatsapp.net",
+        text: "first batch",
+        timestamp: 1_700_000_000,
+      }),
+    );
+    await waitForMessageCalls(onMessage, 1);
+
+    sock.ev.emit(
+      "messages.upsert",
+      buildNotifyMessageUpsert({
+        id: nextMessageId("second-debounce-batch"),
+        remoteJid: "999@s.whatsapp.net",
+        text: "second batch",
+        timestamp: 1_700_000_001,
+      }),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(onMessage).toHaveBeenCalledTimes(1);
+
+    if (!adoptFirstBatch) {
+      throw new Error("expected first batch adoption callback");
+    }
+    await adoptFirstBatch();
+    await waitForMessageCalls(onMessage, 2);
+    expect(inboundMessage(onMessage, 1).payload.body).toBe("second batch");
+    await listener.close();
+  });
+
+  it("atomically joins or waits when a same-sender debounce timer starts flushing", async () => {
+    const debounceMs = 12_345;
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    let debounceChecks = 0;
+    let firstDebounceTimerIndex = -1;
+    let adoptFirstBatch: (() => void | Promise<void>) | undefined;
+    const onMessage = vi.fn(async (message: WebInboundMessage) => {
+      if (adoptFirstBatch) {
+        return;
+      }
+      const lifecycle = resolveWhatsAppIngressLifecycle(message);
+      if (!lifecycle) {
+        throw new Error("expected durable ingress lifecycle");
+      }
+      lifecycle.onDeferred();
+      adoptFirstBatch = lifecycle.onAdopted;
+    });
+
+    const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage, {
+      debounceMs,
+      shouldDebounce: () => {
+        debounceChecks += 1;
+        if (debounceChecks === 2) {
+          firstDebounceTimerIndex = setTimeoutSpy.mock.calls.findLastIndex(
+            (call) => call[1] === debounceMs,
+          );
+          const timer = setTimeoutSpy.mock.results[firstDebounceTimerIndex]?.value as
+            | ReturnType<typeof setTimeout>
+            | undefined;
+          const flush = setTimeoutSpy.mock.calls[firstDebounceTimerIndex]?.[0];
+          if (timer) {
+            clearTimeout(timer);
+          }
+          queueMicrotask(() => {
+            if (typeof flush === "function") {
+              flush();
+            }
+          });
+        }
+        return true;
+      },
+    });
+    try {
+      sock.ev.emit(
+        "messages.upsert",
+        buildNotifyMessageUpsert({
+          id: nextMessageId("debounce-boundary-first"),
+          remoteJid: "999@s.whatsapp.net",
+          text: "first boundary batch",
+          timestamp: 1_700_000_000,
+        }),
+      );
+      await vi.waitFor(() => expect(debounceChecks).toBe(1));
+
+      sock.ev.emit(
+        "messages.upsert",
+        buildNotifyMessageUpsert({
+          id: nextMessageId("debounce-boundary-second"),
+          remoteJid: "999@s.whatsapp.net",
+          text: "second boundary batch",
+          timestamp: 1_700_000_001,
+        }),
+      );
+      await waitForMessageCalls(onMessage, 1);
+      expect(inboundMessage(onMessage).payload.body).toBe("first boundary batch");
+      expect(firstDebounceTimerIndex).toBeGreaterThanOrEqual(0);
+      expect(
+        setTimeoutSpy.mock.calls.findIndex(
+          (call, index) => index > firstDebounceTimerIndex && call[1] === debounceMs,
+        ),
+      ).toBe(-1);
+
+      if (!adoptFirstBatch) {
+        throw new Error("expected first boundary batch adoption callback");
+      }
+      await adoptFirstBatch();
+      await vi.waitFor(() => {
+        expect(
+          setTimeoutSpy.mock.calls.findIndex(
+            (call, index) => index > firstDebounceTimerIndex && call[1] === debounceMs,
+          ),
+        ).toBeGreaterThan(firstDebounceTimerIndex);
+      });
+      const secondDebounceTimerIndex = setTimeoutSpy.mock.calls.findIndex(
+        (call, index) => index > firstDebounceTimerIndex && call[1] === debounceMs,
+      );
+      const secondTimer = setTimeoutSpy.mock.results[secondDebounceTimerIndex]?.value as
+        | ReturnType<typeof setTimeout>
+        | undefined;
+      const flushSecond = setTimeoutSpy.mock.calls[secondDebounceTimerIndex]?.[0];
+      if (secondTimer) {
+        clearTimeout(secondTimer);
+      }
+      if (typeof flushSecond !== "function") {
+        throw new Error("expected second boundary debounce timer callback");
+      }
+      flushSecond();
+      await waitForMessageCalls(onMessage, 2);
+      expect(inboundMessage(onMessage, 1).payload.body).toBe("second boundary batch");
+    } finally {
+      await adoptFirstBatch?.();
+      await listener.close();
+      setTimeoutSpy.mockRestore();
+    }
+  });
+
+  it("publishes idle after deferred debounce adoption settles", async () => {
+    const debounceMs = 12_345;
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    const onPendingWorkChanged = vi.fn();
+    let adoptBatch: (() => void | Promise<void>) | undefined;
+    const onMessage = vi.fn(async (message: WebInboundMessage) => {
+      const lifecycle = resolveWhatsAppIngressLifecycle(message);
+      if (!lifecycle) {
+        throw new Error("expected durable ingress lifecycle");
+      }
+      lifecycle.onDeferred();
+      adoptBatch = lifecycle.onAdopted;
+    });
+
+    const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage, {
+      debounceMs,
+      onPendingWorkChanged,
+    });
+    try {
+      sock.ev.emit(
+        "messages.upsert",
+        buildNotifyMessageUpsert({
+          id: nextMessageId("deferred-debounce-pending-work"),
+          remoteJid: "999@s.whatsapp.net",
+          text: "deferred batch",
+          timestamp: 1_700_000_000,
+        }),
+      );
+      await vi.waitFor(() => {
+        expect(setTimeoutSpy.mock.calls.some((call) => call[1] === debounceMs)).toBe(true);
+      });
+      const timerIndex = setTimeoutSpy.mock.calls.findIndex((call) => call[1] === debounceMs);
+      const timer = setTimeoutSpy.mock.results[timerIndex]?.value as
+        | ReturnType<typeof setTimeout>
+        | undefined;
+      const flush = setTimeoutSpy.mock.calls[timerIndex]?.[0];
+      if (timer) {
+        clearTimeout(timer);
+      }
+      if (typeof flush !== "function") {
+        throw new Error("expected debounce timer callback");
+      }
+      flush();
+      await waitForMessageCalls(onMessage, 1);
+      await vi.waitFor(() => {
+        expect(onPendingWorkChanged.mock.calls.at(-1)?.[0]).toBe(1);
+      });
+
+      if (!adoptBatch) {
+        throw new Error("expected deferred batch adoption callback");
+      }
+      await adoptBatch();
+      await vi.waitFor(() => {
+        expect(onPendingWorkChanged.mock.calls.at(-1)?.[0]).toBe(0);
+      });
+    } finally {
+      await adoptBatch?.();
+      await listener.close();
+      setTimeoutSpy.mockRestore();
+    }
+  });
+
+  it("does not block an unrelated conversation on a deferred debounce adoption", async () => {
+    let adoptFirstConversation: (() => void | Promise<void>) | undefined;
+    const onMessage = vi.fn(async (message: WebInboundMessage) => {
+      if (message.platform.chatJid !== "999@s.whatsapp.net" || adoptFirstConversation) {
+        return;
+      }
+      const lifecycle = resolveWhatsAppIngressLifecycle(message);
+      if (!lifecycle) {
+        throw new Error("expected durable ingress lifecycle");
+      }
+      lifecycle.onDeferred();
+      adoptFirstConversation = lifecycle.onAdopted;
+    });
+
+    const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage, {
+      debounceMs: 20,
+    });
+    sock.ev.emit(
+      "messages.upsert",
+      buildNotifyMessageUpsert({
+        id: nextMessageId("deferred-first-conversation"),
+        remoteJid: "999@s.whatsapp.net",
+        text: "first conversation",
+        timestamp: 1_700_000_000,
+      }),
+    );
+    await waitForMessageCalls(onMessage, 1);
+
+    sock.ev.emit(
+      "messages.upsert",
+      buildNotifyMessageUpsert({
+        id: nextMessageId("independent-conversation"),
+        remoteJid: "888@s.whatsapp.net",
+        text: "/status",
+        timestamp: 1_700_000_001,
+      }),
+    );
+    await waitForMessageCalls(onMessage, 2);
+    expect(inboundMessage(onMessage, 1).platform.chatJid).toBe("888@s.whatsapp.net");
+
+    if (!adoptFirstConversation) {
+      throw new Error("expected first conversation adoption callback");
+    }
+    await adoptFirstConversation();
     await listener.close();
   });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes rapid WhatsApp messages missing their debounce window and group messages arriving out of order when another sender interrupts a buffered batch.

## User Impact

Follow-up messages can enter the reply lane promptly, while messages from different group participants remain ordered and are never combined under the wrong sender. Durable claims and read receipts still wait for the appropriate adoption or completion.

No configuration changes, migrations, or user action are required.

## Why This Change Was Made

Allow deferred debounce candidates to release the conversation lane without settling their individual durable claims. Use the existing conversation-wide debouncer ordering and end a batch when its sender changes.

Preserves the original fix and contributor credit from @mcaxtr, with caller alignment and group-ordering regression coverage added on this PR.

## Evidence

- 56 tests passed across durable receive, inbox delivery/deduplication, debounce policy, and socket lifecycle suites.
- Three new group-ordering regressions failed before the ordering fix and passed afterward. Coverage includes quoted and buffered interruptions, separate sender attribution, claim/read-receipt settlement, and unrelated-conversation progress during held admission.
- All 26 selected check stages passed, including isolated declaration/lint validation and extension production/test types.
- Independent review found no actionable P0–P2 defects in the complete candidate.
- Hosted CI [passed](https://github.com/openclaw/openclaw/actions/runs/35404638697) on exact commit `5fc207c8dfa993fc4a36dc8435beffd0f43636fc`.

Validation uses isolated source-level inbox and durable-queue fixtures; no live WhatsApp account or production Gateway was exercised.
