### PR TITLE
test(codex): add unit test coverage for extractRawAssistantText

### DIFF
--- a/extensions/codex/src/app-server/event-projector-values.test.ts
+++ b/extensions/codex/src/app-server/event-projector-values.test.ts
@@ -1,0 +1,127 @@
+// Tests for event-projector-values utilities.
+import { describe, expect, it } from "vitest";
+import { extractRawAssistantText } from "./event-projector-values.js";
+
+describe("extractRawAssistantText", () => {
+  it("extracts single output_text segment", () => {
+    expect(
+      extractRawAssistantText({
+        content: [{ type: "output_text", text: "Single answer." }],
+      }),
+    ).toBe("Single answer.");
+  });
+
+  it("extracts single text segment", () => {
+    expect(
+      extractRawAssistantText({
+        content: [{ type: "text", text: "Single text." }],
+      }),
+    ).toBe("Single text.");
+  });
+
+  it("concatenates multiple output_text segments (upstream Responses API contract)", () => {
+    expect(
+      extractRawAssistantText({
+        content: [
+          { type: "output_text", text: "First" },
+          { type: "output_text", text: "Second" },
+        ],
+      }),
+    ).toBe("FirstSecond");
+  });
+
+  it("concatenates mixed output_text and text segments", () => {
+    expect(
+      extractRawAssistantText({
+        content: [
+          { type: "output_text", text: "Narration." },
+          { type: "text", text: "Inline." },
+          { type: "output_text", text: "Final." },
+        ],
+      }),
+    ).toBe("Narration.Inline.Final.");
+  });
+
+  it("filters out non-text content blocks", () => {
+    expect(
+      extractRawAssistantText({
+        content: [
+          { type: "output_text", text: "Visible" },
+          { type: "tool_use", name: "some_tool" },
+          { type: "output_text", text: "More" },
+        ],
+      }),
+    ).toBe("VisibleMore");
+  });
+
+  it("skips entries that are not JSON objects", () => {
+    expect(
+      extractRawAssistantText({
+        content: [
+          { type: "output_text", text: "Only this" },
+          "string entry",
+          42,
+          null,
+        ],
+      }),
+    ).toBe("Only this");
+  });
+
+  it("returns undefined for empty content array", () => {
+    expect(extractRawAssistantText({ content: [] })).toBeUndefined();
+  });
+
+  it("returns undefined when content field is missing", () => {
+    expect(extractRawAssistantText({})).toBeUndefined();
+  });
+
+  it("returns undefined when content is not an array", () => {
+    expect(extractRawAssistantText({ content: "not-array" })).toBeUndefined();
+  });
+
+  it("trims leading and trailing whitespace from the result", () => {
+    expect(
+      extractRawAssistantText({
+        content: [{ type: "output_text", text: "  Hello world  " }],
+      }),
+    ).toBe("Hello world");
+  });
+
+  it("trims whitespace from the ends of the joined result", () => {
+    expect(
+      extractRawAssistantText({
+        content: [
+          { type: "output_text", text: "  First  " },
+          { type: "output_text", text: "  Second  " },
+        ],
+      }),
+    ).toBe("First    Second");
+  });
+
+  it("returns undefined for whitespace-only content", () => {
+    expect(
+      extractRawAssistantText({
+        content: [{ type: "output_text", text: "   " }],
+      }),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined for empty text values", () => {
+    expect(
+      extractRawAssistantText({
+        content: [{ type: "output_text", text: "" }],
+      }),
+    ).toBeUndefined();
+  });
+
+  it("ignores content entries with unknown types", () => {
+    expect(
+      extractRawAssistantText({
+        content: [
+          { type: "refusal", text: "I cannot do that." },
+          { type: "output_text", text: "But I can do this." },
+        ],
+      }),
+    ).toBe("But I can do this.");
+  });
+});

--- a/extensions/codex/src/app-server/event-projector-values.test.ts
+++ b/extensions/codex/src/app-server/event-projector-values.test.ts
@@ -57,12 +57,7 @@ describe("extractRawAssistantText", () => {
   it("skips entries that are not JSON objects", () => {
     expect(
       extractRawAssistantText({
-        content: [
-          { type: "output_text", text: "Only this" },
-          "string entry",
-          42,
-          null,
-        ],
+        content: [{ type: "output_text", text: "Only this" }, "string entry", 42, null],
       }),
     ).toBe("Only this");
   });


### PR DESCRIPTION
## What Problem This Solves

`extractRawAssistantText()` had **zero unit test coverage** despite being a key helper in the Codex app-server's assistant-text extraction pipeline. It processes raw response items with multiple `output_text`/`text` content blocks and feeds into `CodexAssistantProjection.handleRawResponseItemCompleted()` for terminal assistant text.

Without tests, any future change to this function risks silently altering persisted assistant text without a safety net.

## Why This Change Was Made

Per ClawSweeper review (#112003), a `\n\n` delimiter was initially proposed but the upstream OpenAI Responses API concatenates `output_text` blocks with direct `"".join(texts)` — content-part boundaries are not paragraph boundaries ([Response.output_text](https://github.com/openai/openai-python/blob/main/src/openai/types/responses/response.py)). Inserting a delimiter would alter verbatim content that the provider split across parts.

This revision preserves the exact upstream concatenation semantics (`.join("")`) and instead adds comprehensive test coverage that:
- Documents the Responses API concatenation contract
- Guards against accidental delimiter insertion
- Covers all edge cases (single/multi segment, mixed types, non-text blocks, empty/missing content, whitespace handling)

## User Impact

**No behavioral change.** Source code is unchanged — same `.join("")` as before. The only addition is a test file that documents and locks in the existing behavior.

- Zero change to persisted or delivered assistant text
- Zero risk of breaking structured-output or verbatim-response compatibility
- Future contributors can safely refactor with test protection

## Evidence

### Unit tests

Added `event-projector-values.test.ts` with 14 test cases:

| Category | Tests | Status |
|----------|-------|--------|
| Single segment (output_text) | 1 | Pass |
| Single segment (text type) | 1 | Pass |
| Multi-segment concatenation (upstream contract) | 2 | Pass |
| Non-text block filtering (tool_use, etc.) | 1 | Pass |
| Non-JSON-object filtering | 1 | Pass |
| Empty / missing / non-array content | 3 | Pass |
| Whitespace trimming | 2 | Pass |
| Whitespace-only / empty text edges | 2 | Pass |
| Unknown type filtering | 1 | Pass |
| **Total** | **14** | **All Pass** |

### CI

```
Test Files  1 passed (1)
     Tests  14 passed (14)
  Duration  1.09s
```

All CI checks pass including `Real behavior proof`, `security-sensitive-guard`, and `dependency-guard`.

[AI-assisted]