### PR TITLE
fix(memory-core): refresh stale cached manager in memory_search

### DIFF
--- a/extensions/memory-core/src/tools.runtime.ts
+++ b/extensions/memory-core/src/tools.runtime.ts
@@ -3,4 +3,4 @@ export {
   readAgentMemoryFile,
   resolveMemoryBackendConfig,
 } from "openclaw/plugin-sdk/memory-core-host-runtime-files";
-export { getMemorySearchManager } from "./memory/index.js";
+export { closeMemorySearchManager, getMemorySearchManager } from "./memory/index.js";

--- a/extensions/memory-core/src/tools.test.ts
+++ b/extensions/memory-core/src/tools.test.ts
@@ -991,6 +991,32 @@ describe("memory_search unavailable payloads", () => {
     expect(getMemorySyncMockCalls()).toBe(1);
   });
 
+  it("skips forced sync for corpus=sessions zero-hit searches", async () => {
+    let searchCalls = 0;
+    setMemorySearchImpl(async () => {
+      searchCalls += 1;
+      return [];
+    });
+
+    const tool = createMemorySearchToolOrThrow({
+      config: {
+        agents: { list: [{ id: "main", default: true }] },
+        memory: { citations: "off" },
+      },
+    });
+    const result = await tool.execute("sessions-zero-hit", {
+      query: "nonexistent topic",
+      corpus: "sessions",
+    });
+
+    // A session-only search can legitimately have zero hits, so the tool
+    // must not force a full memory sync as recovery.
+    const details = result.details as { results?: unknown[]; error?: string };
+    expect(details.results).toEqual([]);
+    expect(searchCalls).toBe(1);
+    expect(getMemorySyncMockCalls()).toBe(0);
+  });
+
   it("returns qmd runtime debug without forcing a zero-hit retry", async () => {
     setMemoryBackend("qmd");
     let searchCalls = 0;
@@ -1093,6 +1119,85 @@ describe("memory_search unavailable payloads", () => {
     });
     expect(searchCalls).toBe(1);
     expect(getMemorySyncMockCalls()).toBe(0);
+  });
+
+  it("closes and reacquires the manager once when the index identity is stale, then recovers", async () => {
+    let searchCalls = 0;
+    setMemorySearchImpl(async () => {
+      searchCalls += 1;
+      if (searchCalls <= 1) {
+        return [];
+      }
+      return [
+        {
+          path: "MEMORY.md",
+          startLine: 1,
+          endLine: 1,
+          score: 0.9,
+          snippet: "Recovered result after manager refresh.",
+          source: "memory" as const,
+        },
+      ];
+    });
+    const reason = "index was built for provider openai, expected ollama";
+    setMemoryCustomStatus({
+      indexIdentity: {
+        status: "mismatched",
+        reason,
+      },
+    });
+
+    const beforeRefreshCalls = getMemorySearchManagerMockCalls();
+    const tool = createMemorySearchToolOrThrow({
+      config: {
+        agents: { list: [{ id: "main", default: true }] },
+        memory: { citations: "off" },
+      },
+    });
+    const result = await tool.execute("stale-identity-refresh", {
+      query: "hidden thread codename",
+    });
+
+    // After closing the stale manager and reacquiring, the search should
+    // succeed against the fresh manager.
+    expect((result.details as { results?: Array<{ path: string }> }).results?.[0]?.path).toBe(
+      "MEMORY.md",
+    );
+    expect(searchCalls).toBe(2);
+    // Manager was reacquired once after the stale one was closed.
+    expect(getMemorySearchManagerMockCalls()).toBe(beforeRefreshCalls + 2);
+    expect(getMemorySyncMockCalls()).toBe(0);
+  });
+
+  it("returns unavailable when the index identity stays paused after manager refresh", async () => {
+    setMemorySearchImpl(async () => []);
+    const reason = "index was built for provider openai, expected ollama";
+    setMemoryCustomStatus({
+      indexIdentity: {
+        status: "mismatched",
+        reason,
+      },
+    });
+
+    const tool = createMemorySearchToolOrThrow({
+      config: {
+        agents: { list: [{ id: "main", default: true }] },
+        memory: { citations: "off" },
+      },
+    });
+    const result = await tool.execute("stale-identity-persists", {
+      query: "hidden thread codename",
+    });
+
+    // The reacquired manager still reports a paused identity, so the tool
+    // must return the unavailable result rather than looping.
+    expectUnavailableMemorySearchDetails(result.details, {
+      error: reason,
+      warning:
+        "Tell the user: memory search is paused because the memory index was built with a different embedding provider/model/settings.",
+      action:
+        "Tell the user to run: openclaw memory status --index or openclaw memory index --force.",
+    });
   });
 
   it("returns structured search debug metadata for qmd results", async () => {

--- a/extensions/memory-core/src/tools.ts
+++ b/extensions/memory-core/src/tools.ts
@@ -27,6 +27,7 @@ import type { OpenClawPluginToolContext } from "openclaw/plugin-sdk/plugin-entry
 import type { PluginStateLeaseRunner } from "openclaw/plugin-sdk/plugin-state-runtime";
 import { asRecord } from "./dreaming-shared.js";
 import type { MemoryCoreAcquireLocalService } from "./memory/embedding-local-service.js";
+import { closeMemorySearchManager } from "./memory/index.js";
 import {
   DEFAULT_MEMORY_SEARCH_TIMEOUT_MS,
   MEMORY_SEARCH_DEADLINE_CONTROL,
@@ -694,12 +695,42 @@ export function createMemorySearchTool(options: {
                 pausedIndexIdentityReason =
                   resolvePausedMemoryIndexIdentityReason(statusBeforeRetry);
                 if (pausedIndexIdentityReason) {
+                  // The cached manager is serving a stale index identity
+                  // (e.g. session memory was enabled after the manager was
+                  // created). Close it so the next acquisition builds a fresh
+                  // manager against the current identity, then retry once.
+                  await closeMemorySearchManager({ cfg, agentId });
+                  const refreshed = await runWithDefaultDeadline(async () =>
+                    trackMemoryManager(
+                      await getMemoryManagerContextWithPurpose({
+                        cfg,
+                        agentId,
+                        purpose: memoryManagerPurpose,
+                        acquireLocalService: options.acquireLocalService,
+                        withLease: options.withLease,
+                      }),
+                    ),
+                  );
+                  if (!("error" in refreshed)) {
+                    managerMs = refreshed.debug?.managerMs;
+                    managerCacheState = refreshed.debug?.managerCacheState;
+                    activeMemory = refreshed;
+                    rawResults = await searchActiveMemory();
+                    const statusAfterRefresh = activeMemory.manager.status();
+                    pausedIndexIdentityReason =
+                      resolvePausedMemoryIndexIdentityReason(statusAfterRefresh);
+                  }
+                }
+                if (pausedIndexIdentityReason) {
                   return;
                 }
                 // One-shot CLI managers have no background lifecycle, so keep their bootstrap
                 // retry. Long-lived QMD managers must not run update work in the tool hot path.
+                // A corpus=sessions zero-hit search is a legitimate result (the session corpus
+                // may genuinely have no hits for the query); do not force a full sync.
                 if (
                   rawResults.length === 0 &&
+                  requestedCorpus !== "sessions" &&
                   activeMemory.manager.sync &&
                   (statusBeforeRetry.backend !== "qmd" || options.oneShotCliRun === true)
                 ) {


### PR DESCRIPTION
Closes #111990

## What Problem This Solves

When the memory index identity changes (e.g. session memory is enabled after the gateway process started), the cached memory-search manager can serve stale state. The `memory_search` tool then returns zero hits or enters avoidable recovery paths even though the actual memory index is healthy. The tool path had a recovery path for a closed database handle (`isClosedMemoryStoreError`), but no recovery for a cached manager whose identity no longer matches the current index configuration.

## Why This Change Was Made

Three targeted changes in `extensions/memory-core`:

1. **Export `closeMemorySearchManager`** from `tools.runtime.ts` so the tool hot path can evict the cached manager when it detects a mismatched index identity.

2. **Stale-manager refresh in `memory_search`**: when the active manager reports a paused/mismatched index identity (via `resolvePausedMemoryIndexIdentityReason`), close the stale cached manager, reacquire a fresh one against the current identity, and retry the search once. Only return the unavailable result if the refreshed manager still reports a paused identity.

3. **Skip forced full-sync for `corpus=sessions` zero-hit searches**: a session-only search can legitimately have no matching hits for the query. Previously, a zero-hit result triggered a forced full sync, which could turn a normal miss into a slow or timing-sensitive call. This change treats `corpus=sessions` the same way QMD searches already treat zero hits.

## Evidence

- **TDD red on current main**: a fresh `memory_search(corpus="sessions")` against a manager whose index identity reports `status: "mismatched"` returns the unavailable/paused result without attempting a refresh.
- **After fix**: the tool closes the stale manager, reacquires one against the current identity, and retries the search. If the new manager is healthy, the search succeeds. If the new manager still reports paused identity, the tool returns the same unavailable message (no infinite loop).
- **Sessions zero-hit**: `memory_search(corpus="sessions")` with zero results skips the forced full-sync recovery. The tool returns zero results immediately rather than spending time on an unnecessary sync.
- **Test coverage**: 3 new regression tests added to `tools.test.ts`:
  - `closes and reacquires the manager once when the index identity is stale, then recovers`
  - `returns unavailable when the index identity stays paused after manager refresh`
  - `skips forced sync for corpus=sessions zero-hit searches`

## Scope

- 3 files changed, +137/-1
- No config/schema/default changes
- No docs API or response parsing changes
- No plugin loading, network proxy, migration, or doctor behavior changes
- No changelog change

AI-assisted: yes. I understand the authorization lineage and tool-policy changes in this PR.