### PR TITLE
fix(ui): token activity heatmap never fits without horizontal scrolling

### DIFF
--- a/ui/src/pages/profile/profile-stat-sections.ts
+++ b/ui/src/pages/profile/profile-stat-sections.ts
@@ -101,46 +101,42 @@ function renderHeatmapSvg(heatmap: ProfileHeatmap) {
     timeZone: "UTC",
   });
   return html`
-    <div class="profile-heatmap__scroll">
-      <svg
-        class="profile-heatmap__svg"
-        width=${width}
-        height=${height}
-        viewBox="0 0 ${width} ${height}"
-        role="img"
-        aria-label=${t("profilePage.heatmapTitle")}
-      >
-        ${heatmap.monthLabels.map((label, index) =>
-          label
-            ? svg`<text class="profile-heatmap__month" x=${HEATMAP_LEFT + index * HEATMAP_PITCH} y="10">${label}</text>`
-            : nothing,
-        )}
-        ${WEEKDAY_LABEL_ROWS.map(
-          ({ row, utcDay }) =>
-            svg`<text class="profile-heatmap__weekday" x=${HEATMAP_LEFT - 6} y=${HEATMAP_TOP + row * HEATMAP_PITCH + HEATMAP_CELL - 2}>${weekdayFormat.format(new Date(utcDay))}</text>`,
-        )}
-        ${heatmap.weeks.map((week, weekIndex) =>
-          week.days.map((day, dayIndex) => {
-            if (!day) {
-              return nothing;
-            }
-            const tooltip = `${formatFullDate(day.date)} · ${t("profilePage.heatmapCellTokens", {
-              tokens: numberFormat.format(day.tokens),
-            })}`;
-            return svg`
-              <rect
-                class="profile-heatmap__cell profile-heatmap__cell--l${day.level}"
-                x=${HEATMAP_LEFT + weekIndex * HEATMAP_PITCH}
-                y=${HEATMAP_TOP + dayIndex * HEATMAP_PITCH}
-                width=${HEATMAP_CELL}
-                height=${HEATMAP_CELL}
-                rx="2.5"
-              ><title>${tooltip}</title></rect>
-            `;
-          }),
-        )}
-      </svg>
-    </div>
+    <svg
+      class="profile-heatmap__svg"
+      viewBox="0 0 ${width} ${height}"
+      role="img"
+      aria-label=${t("profilePage.heatmapTitle")}
+    >
+      ${heatmap.monthLabels.map((label, index) =>
+        label
+          ? svg`<text class="profile-heatmap__month" x=${HEATMAP_LEFT + index * HEATMAP_PITCH} y="10">${label}</text>`
+          : nothing,
+      )}
+      ${WEEKDAY_LABEL_ROWS.map(
+        ({ row, utcDay }) =>
+          svg`<text class="profile-heatmap__weekday" x=${HEATMAP_LEFT - 6} y=${HEATMAP_TOP + row * HEATMAP_PITCH + HEATMAP_CELL - 2}>${weekdayFormat.format(new Date(utcDay))}</text>`,
+      )}
+      ${heatmap.weeks.map((week, weekIndex) =>
+        week.days.map((day, dayIndex) => {
+          if (!day) {
+            return nothing;
+          }
+          const tooltip = `${formatFullDate(day.date)} · ${t("profilePage.heatmapCellTokens", {
+            tokens: numberFormat.format(day.tokens),
+          })}`;
+          return svg`
+            <rect
+              class="profile-heatmap__cell profile-heatmap__cell--l${day.level}"
+              x=${HEATMAP_LEFT + weekIndex * HEATMAP_PITCH}
+              y=${HEATMAP_TOP + dayIndex * HEATMAP_PITCH}
+              width=${HEATMAP_CELL}
+              height=${HEATMAP_CELL}
+              rx="2.5"
+            ><title>${tooltip}</title></rect>
+          `;
+        }),
+      )}
+    </svg>
   `;
 }
 

--- a/ui/src/styles/profile.css
+++ b/ui/src/styles/profile.css
@@ -160,15 +160,15 @@
   display: inline-block;
 }
 
-.profile-heatmap__scroll {
-  overflow-x: auto;
-  /* Latest weeks matter most; keep them in view when the grid overflows. */
-  direction: rtl;
-}
-
+/* viewBox-only sizing scales the whole year to the container so the grid
+   never overflows; the natural ~772px width would not even fit the 760px
+   settings column, forcing a permanent horizontal scrollbar. Accepted
+   tradeoff: tiny phone widths shrink cells/labels rather than reintroduce
+   scroll — the full-year shape beats a cropped readable slice there. */
 .profile-heatmap__svg {
-  direction: ltr;
   display: block;
+  width: 100%;
+  height: auto;
 }
 
 .profile-heatmap__month,


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where the Token Activity heatmap on the Profile settings page always required horizontal scrolling. The SVG grid renders at a fixed 758–772px (52–53 week columns × 14px pitch + 30px label gutter), while the settings column caps content at ~696px — so even at full window width the card showed a permanent scrollbar, clipped the oldest month off the left edge, and sliced cells at both edges. The RTL scroll position also pushed the Mon/Wed/Fri weekday labels out of view. Narrow windows hid up to a third of the year.

## Why This Change Was Made

The grid never had room to render at its natural size, so the scroll container was pure friction. Instead of scrolling a fixed-pixel SVG, the heatmap now scales to its container: the SVG keeps its `viewBox` and sizes with `width: 100%; height: auto`, so the whole year always fits. The scroll wrapper and its RTL keep-latest-in-view hack are deleted. At the settings column's max width the downscale is ~10% (visually indistinguishable); narrower windows shrink the grid proportionally instead of cropping it. Accepted tradeoff: on very narrow/mobile widths the cells and month labels get small — the full-year shape stays readable and per-day tooltips still work, which beats hiding most of the year behind a scroll.

## User Impact

The Profile page's Token Activity heatmap now always shows the entire year — no scrollbar, no clipped months, and the weekday labels are visible again at every window size.

## Evidence

Focused proof: `node scripts/run-vitest.mjs ui/src/e2e/profile-page.e2e.test.ts` — the heatmap test (`renders hero identity, lifetime stats, heatmap, and insights`) passes; the one failing test (`renders the gateway avatar route in the profile preview`) fails identically with this change reverted, i.e. broken at base and unrelated. `oxfmt --check` and `oxlint` clean on touched files.

Screenshots from the deterministic mock harness (`pnpm dev:ui:mock`), light mode:

**Before — 1280px window (settings column at max width): scrolls, Aug + weekday labels clipped**

![before 1280](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/profile-heatmap-fit/before-w1280.png)

**After — 1280px window: full Jul→Jul year fits, weekday labels back**

![after 1280](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/profile-heatmap-fit/after-w1280.png)

**Before — 600px window: year starts at Nov, four months unreachable without scrolling**

![before 600](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/profile-heatmap-fit/before-w600.png)

**After — 600px window: whole year visible, proportionally scaled**

![after 600](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/profile-heatmap-fit/after-w600.png)

**After — 375px phone width (2× capture, i.e. how a retina phone renders it): the named tradeoff in practice — small but coherent, labels still legible, no layout break**

![after 375](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/profile-heatmap-fit/after-mobile-w375.png)
