### PR TITLE
fix(qa): some additional qa evidence channel sharding

### DIFF
--- a/.github/workflows/maturity-scorecard.yml
+++ b/.github/workflows/maturity-scorecard.yml
@@ -302,7 +302,7 @@ jobs:
         inputs.qa_evidence_run_id == '' }}
     uses: ./.github/workflows/qa-profile-evidence.yml
     with:
-      ref: ${{ inputs.ref }}
+      ref: ${{ needs.validate_selected_ref.outputs.selected_revision }}
       expected_sha: ${{ needs.validate_selected_ref.outputs.selected_revision }}
       qa_profile: all
     secrets:

--- a/.github/workflows/qa-profile-evidence.yml
+++ b/.github/workflows/qa-profile-evidence.yml
@@ -197,7 +197,7 @@ jobs:
     name: Generate QA profile evidence
     needs: validate_selected_ref
     runs-on: blacksmith-8vcpu-ubuntu-2404
-    timeout-minutes: ${{ (inputs.qa_profile == 'all' || inputs.qa_profile == 'release') && 240 || 60 }}
+    timeout-minutes: 60
     permissions:
       contents: read
     outputs:
@@ -303,6 +303,7 @@ jobs:
           pnpm openclaw qa run \
             --repo-root . \
             --qa-profile "${QA_PROFILE}" \
+            --concurrency 2 \
             --fast \
             --output-dir "${output_dir}" || qa_exit_code=$?
 

--- a/extensions/qa-lab/src/suite-launch.runtime.test.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.test.ts
@@ -273,7 +273,9 @@ describe("qa suite runtime launcher", () => {
     runQaFlowSuite.mockImplementation(async (params) => {
       activeChannels += 1;
       maxActiveChannels = Math.max(maxActiveChannels, activeChannels);
-      await new Promise<void>((resolve) => setTimeout(resolve, 1));
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 1);
+      });
       try {
         return await defaultFlowImplementation(params);
       } finally {

--- a/extensions/qa-lab/src/suite-launch.runtime.test.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.test.ts
@@ -262,6 +262,38 @@ describe("qa suite runtime launcher", () => {
     );
   });
 
+  it("runs distinct pluggable-driver channels within the global concurrency budget", async () => {
+    const repoRoot = await makeTempRepo("qa-suite-pluggable-channel-concurrency-");
+    const defaultFlowImplementation = runQaFlowSuite.getMockImplementation();
+    if (!defaultFlowImplementation) {
+      throw new Error("expected default QA flow suite mock implementation");
+    }
+    let activeChannels = 0;
+    let maxActiveChannels = 0;
+    runQaFlowSuite.mockImplementation(async (params) => {
+      activeChannels += 1;
+      maxActiveChannels = Math.max(maxActiveChannels, activeChannels);
+      await new Promise<void>((resolve) => setTimeout(resolve, 1));
+      try {
+        return await defaultFlowImplementation(params);
+      } finally {
+        activeChannels -= 1;
+      }
+    });
+
+    await runQaSuite({
+      repoRoot,
+      outputDir: ".artifacts/qa-e2e/pluggable-channel-concurrency",
+      providerMode: "mock-openai",
+      channelDriver: "live",
+      adapterFactories: [{ id: "portable-driver", matches: vi.fn(), create: vi.fn() }],
+      concurrency: 2,
+      scenarioIds: ["telegram-help-command", "matrix-restart-resume"],
+    });
+
+    expect(maxActiveChannels).toBe(2);
+  });
+
   it("binds one portable channel scenario without an explicit channel override", async () => {
     const adapterFactories = [
       {

--- a/extensions/qa-lab/src/suite-launch.runtime.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.ts
@@ -87,6 +87,7 @@ type QaUnifiedPartitionResult = {
 };
 
 type QaUnifiedPartitionTask = {
+  exclusiveKey?: string;
   run: () => Promise<QaUnifiedPartitionResult>;
   weight: number;
 };
@@ -323,9 +324,9 @@ async function runWeightedUnifiedPartitionTasks(
   }
   const limit = Math.max(1, Math.floor(maxWeight));
   const results: QaUnifiedPartitionResult[] = [];
+  const pending = tasks.map((task, index) => ({ index, task }));
+  const activeExclusiveKeys = new Set<string>();
   let activeWeight = 0;
-  let settled = 0;
-  let nextIndex = 0;
   return await new Promise<QaUnifiedPartitionResult[]>((resolve, reject) => {
     let firstError: Error | undefined;
     let finished = false;
@@ -345,24 +346,35 @@ async function runWeightedUnifiedPartitionTasks(
         finishIfSettled();
         return;
       }
-      while (nextIndex < tasks.length) {
-        const task = tasks[nextIndex];
-        if (!task) {
+      while (pending.length > 0) {
+        const pendingIndex = pending.findIndex(({ task }) => {
+          const taskWeight = Math.max(1, Math.min(limit, Math.floor(task.weight)));
+          return (
+            (activeWeight === 0 || activeWeight + taskWeight <= limit) &&
+            (!task.exclusiveKey || !activeExclusiveKeys.has(task.exclusiveKey))
+          );
+        });
+        if (pendingIndex === -1) {
           return;
         }
+        const pendingTask = pending.splice(pendingIndex, 1)[0];
+        if (!pendingTask) {
+          throw new Error("failed to select a pending QA suite partition task");
+        }
+        const { index, task } = pendingTask;
         const taskWeight = Math.max(1, Math.min(limit, Math.floor(task.weight)));
-        if (activeWeight > 0 && activeWeight + taskWeight > limit) {
-          return;
-        }
-        const index = nextIndex;
-        nextIndex += 1;
         activeWeight += taskWeight;
+        if (task.exclusiveKey) {
+          activeExclusiveKeys.add(task.exclusiveKey);
+        }
         task.run().then(
           (result) => {
             results[index] = result;
             activeWeight -= taskWeight;
-            settled += 1;
-            if (settled === tasks.length) {
+            if (task.exclusiveKey) {
+              activeExclusiveKeys.delete(task.exclusiveKey);
+            }
+            if (pending.length === 0 && activeWeight === 0) {
               finishIfSettled();
               return;
             }
@@ -371,12 +383,14 @@ async function runWeightedUnifiedPartitionTasks(
           (error: unknown) => {
             firstError = error instanceof Error ? error : new Error(String(error));
             activeWeight -= taskWeight;
-            settled += 1;
+            if (task.exclusiveKey) {
+              activeExclusiveKeys.delete(task.exclusiveKey);
+            }
             finishIfSettled();
           },
         );
       }
-      if (settled === tasks.length) {
+      if (activeWeight === 0) {
         finishIfSettled();
       }
     };
@@ -576,7 +590,6 @@ async function runUnifiedQaSuite(params: {
     const channelGroups = (
       await resolveQaFlowChannelGroups(params.runParams, params.plan.flowScenarios)
     ).filter((group) => group.scenarios.length > 0);
-    const mixedChannelRun = channelGroups.length > 1;
     const runFlowSuite = await loadQaFlowSuiteRuntime();
     for (const channelGroup of channelGroups) {
       const sharedFlowScenarios = channelGroup.scenarios.filter(
@@ -652,10 +665,12 @@ async function runUnifiedQaSuite(params: {
           .filter((part): part is string => Boolean(part))
           .join("-");
         const task = {
-          weight:
-            mixedChannelRun || (isolatedPartition && channelDriverFlowRequiresExclusiveWorkers)
-              ? concurrency
-              : partition.concurrency,
+          // One channel's credential and gateway state stay serial. Distinct channels own
+          // separate adapters, leases, and artifact directories, so they may run together.
+          exclusiveKey: channelDriverFlowRequiresExclusiveWorkers
+            ? `channel:${channelGroup.channel ?? channelGroup.channelId ?? "default"}`
+            : undefined,
+          weight: partition.concurrency,
           run: async () => {
             const result = await runFlowSuite({
               ...params.runParams,

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -4616,9 +4616,7 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
     expect(qaEvidenceWorkflow.on.workflow_dispatch.inputs.qa_profile).not.toHaveProperty("options");
     expect(qaEvidenceWorkflow.on.workflow_dispatch.inputs.qa_profile.default).toBe("all");
     expect(qaEvidenceWorkflow.on.workflow_call.inputs.qa_profile.type).toBe("string");
-    expect(qaRunJob["timeout-minutes"]).toBe(
-      "${{ (inputs.qa_profile == 'all' || inputs.qa_profile == 'release') && 240 || 60 }}",
-    );
+    expect(qaRunJob["timeout-minutes"]).toBe(60);
     const validateProfileStep = qaRunJob.steps.find(
       (step: WorkflowStep) => step.name === "Validate QA profile input",
     );
@@ -4633,6 +4631,7 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
     const runProfileStep = qaRunJob.steps.find(
       (step: WorkflowStep) => step.name === "Run QA profile",
     );
+    expect(runProfileStep.run).toContain("--concurrency 2");
     expect(runProfileStep.run).toContain("--fast");
     expect(generateJob.needs).toEqual(["validate_selected_ref", "publisher_preflight"]);
     expect(generateJob.if.replace(/\s+/gu, " ")).toBe(

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -4639,8 +4639,8 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
     );
     expect(generateJob.uses).toBe("./.github/workflows/qa-profile-evidence.yml");
     expect(generateJob.with).toMatchObject({
-      // Keep the caller's ref while the callee verifies it against expected_sha.
-      ref: "${{ inputs.ref }}",
+      // Reusable jobs start later, so forward the immutable revision instead of a moving branch.
+      ref: "${{ needs.validate_selected_ref.outputs.selected_revision }}",
       expected_sha: "${{ needs.validate_selected_ref.outputs.selected_revision }}",
       qa_profile: "all",
     });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where maintainers regenerating maturity scorecard evidence could spend more than an hour in a single QA job because independent channel partitions were globally serialized. The last full-profile attempt ran for 87 minutes, spent 30 minutes waiting for a WhatsApp credential, and failed before reaching the second half of its 290 selected scenarios.

The maturity caller could also validate one `main` revision and then forward the moving branch name to its delayed reusable evidence job, causing that job to reject a newer checkout against the earlier expected SHA.

## Why This Change Was Made

The existing weighted suite scheduler now uses a per-channel exclusivity key. Work for one channel remains serial to protect its credential and gateway state, while two distinct channels may run concurrently. The canonical profile workflow requests a bounded concurrency of two and restores the evidence timeout to 60 minutes.

The maturity workflow forwards its already-validated immutable revision to the reusable evidence workflow, so later `main` advances cannot change the nested checkout.

## User Impact

Maintainers retain full `all` and `release` evidence coverage without accepting multi-hour workflow budgets. Matrix can overlap Slack, Telegram, WhatsApp, or channel-independent work, and an unavailable credential no longer blocks every other channel from making progress. Maturity dispatches can now reach QA while `main` continues moving.

## Evidence

- Before runtime: https://github.com/openclaw/openclaw/actions/runs/29663733324 — 87-minute evidence job; 30-minute WhatsApp pool wait; only the first 145 of 290 selected scenarios reached before failure
- Before orchestration: https://github.com/openclaw/openclaw/actions/runs/29794761974 — outer validation pinned `e1ca…`, nested evidence resolved moving `main` to `7ad20…`, and rejected the mismatch before QA
- `node scripts/run-vitest.mjs extensions/qa-lab/src/suite-launch.runtime.test.ts test/scripts/ci-workflow-guards.test.ts` — 115 passed, 1 skipped across two shards
- New scheduler test proves two distinct pluggable-driver channels overlap at concurrency 2
- Existing isolation tests continue proving same-channel workers remain serial
- Workflow guard proves nested evidence receives `selected_revision` as both `ref` and `expected_sha`
- `git diff --check`
- Autoreview: clean, no accepted or actionable findings
- Local workflow wrapper was blocked by local Python lacking the version required by pinned zizmor; PR actionlint/zizmor is the authoritative workflow gate

AI-assisted: yes. I understand the scheduler, isolation, workflow, and test changes.