### PR TITLE
fix(bootstrap): let users name new agents

### DIFF
--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -8992,7 +8992,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
 - Route: /reference/templates/BOOTSTRAP
 - Headings:
   - H1: BOOTSTRAP.md - Birth Sequence
-  - H2: 1. Name Yourself
+  - H2: 1. Ask What to Call You
   - H2: 2. Choose Your Vibe
   - H2: 3. Finish With Recommendations
   - H2: Related

--- a/docs/reference/templates/BOOTSTRAP.md
+++ b/docs/reference/templates/BOOTSTRAP.md
@@ -14,10 +14,11 @@ OpenClaw only seeds this file into a brand-new workspace, alongside `AGENTS.md`,
 Complete these three beats. Do not turn them into a questionnaire or a long
 biography.
 
-## 1. Name Yourself
+## 1. Ask What to Call You
 
-Introduce yourself, choose your own name, and offer it to the user for a simple
-yes or one adjustment. You are not waiting for the user to invent you.
+Introduce yourself as the user's new assistant, then ask what they would like
+to call you. Do not choose, invent, or suggest a name for yourself. Wait for
+their answer before moving on.
 
 ## 2. Choose Your Vibe
 

--- a/docs/start/bootstrapping.md
+++ b/docs/start/bootstrapping.md
@@ -18,9 +18,9 @@ On the first run against a brand-new workspace (default `~/.openclaw/workspace`)
 OpenClaw:
 
 - Seeds `AGENTS.md`, `SOUL.md`, `TOOLS.md`, `IDENTITY.md`, `USER.md`, `HEARTBEAT.md`, and `BOOTSTRAP.md`.
-- Has the agent follow a capped three-beat birth sequence: it proposes its own
-  name, shares one short soul/vibe line, and asks whether you want the minimal
-  recommended plugin set or maximum convenience.
+- Has the agent follow a capped three-beat birth sequence: it asks what you want
+  to call it, shares one short soul/vibe line, and asks whether you want the
+  minimal recommended plugin set or maximum convenience.
 - Persists the agreed identity twice: into `IDENTITY.md` and `SOUL.md` (what the
   agent reads about itself) and via `openclaw agents set-identity` (what channels
   and the UI display).


### PR DESCRIPTION
## What Problem This Solves

The first-run `BOOTSTRAP.md` prompt told a new agent to choose and propose its own name. That made the agent assign itself an identity before asking the user what they wanted to call it.

## Summary

- ask the user what they want to call a new agent
- explicitly prevent the agent from choosing, inventing, or suggesting its own name
- align the bootstrapping guide and generated docs map with the new first-run behavior

## Evidence

- artifact contract check: required ask/wait/prohibition clauses present; later bootstrap beats unchanged
- `node scripts/format-docs.mjs --check`
- `node scripts/generate-docs-map.mjs --check`
- `node scripts/docs-link-audit.mjs`
- `git diff --check`
- `pnpm check:docs` on Blacksmith Testbox `tbx_01ky16je7myggrmvn3633ngwqj` ([run](https://github.com/openclaw/openclaw/actions/runs/29794773941))
- autoreview: clean, no accepted/actionable findings

## Release note

Bootstrap now asks users what they want to call a new agent instead of having the agent assign itself a name.
