### PR TITLE
fix(setup): preserve invalid config during baseline setup

### DIFF
--- a/docs/cli/setup.md
+++ b/docs/cli/setup.md
@@ -97,7 +97,8 @@ storage mode.
 creates the config, workspace, and session directories, then exits without
 running onboarding. It accepts `--workspace` and harmless output controls, but
 rejects explicit onboarding, Gateway, auth, reset, or daemon options instead of
-silently ignoring them.
+silently ignoring them. If an existing config is invalid, baseline setup preserves
+it and asks you to run `openclaw doctor` before retrying.
 
 ## Examples
 

--- a/src/commands/setup.test.ts
+++ b/src/commands/setup.test.ts
@@ -3,12 +3,23 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { withTempHome } from "openclaw/plugin-sdk/test-env";
 import { describe, expect, it, vi } from "vitest";
+import { createConfigIO } from "../config/io.js";
+import { replaceConfigFile } from "../config/mutate.js";
 import { setupCommand } from "./setup.js";
 
 function createSetupDeps(home: string) {
   const configPath = path.join(home, ".openclaw", "openclaw.json");
+  const configIO = createConfigIO({
+    configPath,
+    env: { OPENCLAW_TEST_FAST: "1" } as NodeJS.ProcessEnv,
+    homedir: () => home,
+    logger: { error: vi.fn(), warn: vi.fn() },
+  });
   return {
-    createConfigIO: () => ({ configPath }),
+    createConfigIO: () => ({
+      configPath,
+      readConfigFileSnapshotForWrite: configIO.readConfigFileSnapshotForWrite,
+    }),
     ensureAgentWorkspace: vi.fn(
       async (params?: { dir?: string; skipOptionalBootstrapFiles?: string[] }) => ({
         dir: params?.dir ?? path.join(home, ".openclaw", "workspace"),
@@ -23,7 +34,7 @@ function createSetupDeps(home: string) {
     ),
     mkdir: vi.fn(async () => {}),
     resolveSessionTranscriptsDir: vi.fn(() => path.join(home, ".openclaw", "sessions")),
-    replaceConfigFile: vi.fn(async ({ nextConfig }: { nextConfig: unknown }) => {
+    replaceConfigFile: vi.fn(async ({ nextConfig }: Parameters<typeof replaceConfigFile>[0]) => {
       await fs.mkdir(path.dirname(configPath), { recursive: true });
       await fs.writeFile(configPath, JSON.stringify(nextConfig, null, 2));
     }),
@@ -70,6 +81,15 @@ describe("setupCommand", () => {
           mode: "local",
         },
       });
+      expect(deps.replaceConfigFile).toHaveBeenCalledWith(
+        expect.objectContaining({
+          snapshot: expect.objectContaining({ exists: false, path: configPath }),
+          writeOptions: expect.objectContaining({
+            expectedConfigPath: configPath,
+            ownedConfigPathForWrite: configPath,
+          }),
+        }),
+      );
     });
   });
 
@@ -164,7 +184,42 @@ describe("setupCommand", () => {
     });
   });
 
-  it("treats non-object config roots as empty config", async () => {
+  it("rejects a stale config snapshot before workspace or session mutation", async () => {
+    await withTempHome(async (home) => {
+      const runtime = {
+        log: vi.fn(),
+        error: vi.fn(),
+        exit: vi.fn(),
+      };
+      const configDir = path.join(home, ".openclaw");
+      const configPath = path.join(configDir, "openclaw.json");
+      const workspace = path.join(home, "custom-workspace");
+      const deps = createSetupDeps(home);
+      const externalRaw = `${JSON.stringify({ external: true }, null, 2)}\n`;
+
+      await fs.mkdir(configDir, { recursive: true });
+      await fs.writeFile(
+        configPath,
+        JSON.stringify({ agents: { defaults: { workspace } } }),
+        "utf-8",
+      );
+      deps.replaceConfigFile.mockImplementationOnce(async (params) => {
+        await fs.writeFile(configPath, externalRaw, "utf-8");
+        await replaceConfigFile(params);
+      });
+
+      await expect(setupCommand(undefined, runtime, deps)).rejects.toThrow(
+        "config changed since last load",
+      );
+
+      expect(await fs.readFile(configPath, "utf-8")).toBe(externalRaw);
+      expect(deps.ensureAgentWorkspace).not.toHaveBeenCalled();
+      expect(deps.resolveSessionTranscriptsDir).not.toHaveBeenCalled();
+      expect(deps.mkdir).not.toHaveBeenCalled();
+    });
+  });
+
+  it("preserves malformed config and stops before setup mutations", async () => {
     await withTempHome(async (home) => {
       const runtime = {
         log: vi.fn(),
@@ -174,20 +229,53 @@ describe("setupCommand", () => {
       const configDir = path.join(home, ".openclaw");
       const configPath = path.join(configDir, "openclaw.json");
       const deps = createSetupDeps(home);
-      const workspace = path.join(home, ".openclaw", "workspace");
+      const original = Buffer.from('{ "gateway": ', "utf-8");
 
       await fs.mkdir(configDir, { recursive: true });
-      await fs.writeFile(configPath, '"not-an-object"', "utf-8");
+      await fs.writeFile(configPath, original);
 
-      await setupCommand({ workspace }, runtime, deps);
+      await setupCommand(undefined, runtime, deps);
 
-      const raw = JSON.parse(await fs.readFile(configPath, "utf-8")) as {
-        agents?: { defaults?: { workspace?: string } };
-        gateway?: { mode?: string };
-      };
-
-      expect(raw.agents?.defaults?.workspace).toBe(workspace);
-      expect(raw.gateway?.mode).toBe("local");
+      expect(runtime.exit).toHaveBeenCalledWith(1);
+      expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("openclaw doctor"));
+      expect(await fs.readFile(configPath)).toStrictEqual(original);
+      expect(deps.replaceConfigFile).not.toHaveBeenCalled();
+      expect(deps.ensureAgentWorkspace).not.toHaveBeenCalled();
+      expect(deps.resolveSessionTranscriptsDir).not.toHaveBeenCalled();
+      expect(deps.mkdir).not.toHaveBeenCalled();
     });
   });
+
+  it.each([
+    ["string", '"not-an-object"'],
+    ["array", "[]"],
+    ["null", "null"],
+  ])(
+    "preserves an existing %s config root and stops before setup mutations",
+    async (_label, raw) => {
+      await withTempHome(async (home) => {
+        const runtime = {
+          log: vi.fn(),
+          error: vi.fn(),
+          exit: vi.fn(),
+        };
+        const configDir = path.join(home, ".openclaw");
+        const configPath = path.join(configDir, "openclaw.json");
+        const deps = createSetupDeps(home);
+
+        await fs.mkdir(configDir, { recursive: true });
+        await fs.writeFile(configPath, raw, "utf-8");
+
+        await setupCommand(undefined, runtime, deps);
+
+        expect(runtime.exit).toHaveBeenCalledWith(1);
+        expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("openclaw doctor"));
+        expect(await fs.readFile(configPath, "utf-8")).toBe(raw);
+        expect(deps.replaceConfigFile).not.toHaveBeenCalled();
+        expect(deps.ensureAgentWorkspace).not.toHaveBeenCalled();
+        expect(deps.resolveSessionTranscriptsDir).not.toHaveBeenCalled();
+        expect(deps.mkdir).not.toHaveBeenCalled();
+      });
+    },
+  );
 });

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -5,22 +5,26 @@
  * running the full onboarding wizard.
  */
 import fs from "node:fs/promises";
-import JSON5 from "json5";
-import { z } from "zod";
 import { formatCliCommand } from "../cli/command-format.js";
+import type { ConfigWriteOptions, ReadConfigFileSnapshotForWriteResult } from "../config/io.js";
 import type { OptionalBootstrapFileName } from "../config/types.agent-defaults.js";
-import type { OpenClawConfig } from "../config/types.js";
+import type { ConfigFileSnapshot, OpenClawConfig } from "../config/types.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { defaultRuntime } from "../runtime.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
 import { shortenHomePath } from "../utils.js";
-import { safeParseWithSchema } from "../utils/zod-parse.js";
-
-const JsonRecordSchema = z.record(z.string(), z.unknown());
 
 type ConfigIO = {
   configPath: string;
+  readConfigFileSnapshotForWrite: () => Promise<ReadConfigFileSnapshotForWriteResult>;
 };
+
+type ReplaceConfigFile = (params: {
+  nextConfig: OpenClawConfig;
+  snapshot: ConfigFileSnapshot;
+  afterWrite: { mode: "auto" };
+  writeOptions: ConfigWriteOptions;
+}) => Promise<unknown>;
 
 type EnsureAgentWorkspace = (params: {
   dir: string;
@@ -39,10 +43,7 @@ type SetupCommandDeps = {
   ) => void | Promise<void>;
   mkdir?: (dir: string, options: { recursive: true }) => Promise<unknown>;
   resolveSessionTranscriptsDir?: () => string | Promise<string>;
-  replaceConfigFile?: (params: {
-    nextConfig: OpenClawConfig;
-    afterWrite: { mode: "auto" };
-  }) => Promise<unknown>;
+  replaceConfigFile?: ReplaceConfigFile;
 };
 
 type AgentWorkspaceModule = typeof import("../agents/workspace.js");
@@ -97,12 +98,9 @@ async function ensureDefaultAgentWorkspace(
   return ensureAgentWorkspace(params);
 }
 
-async function writeDefaultConfigFile(config: OpenClawConfig): Promise<void> {
+async function writeDefaultConfigFile(params: Parameters<ReplaceConfigFile>[0]): Promise<void> {
   const { replaceConfigFile } = await loadConfigIOModule();
-  await replaceConfigFile({
-    nextConfig: config,
-    afterWrite: { mode: "auto" },
-  });
+  await replaceConfigFile(params);
 }
 
 async function formatDefaultConfigPath(configPath: string): Promise<string> {
@@ -123,21 +121,6 @@ async function resolveDefaultSessionTranscriptsDir(): Promise<string> {
   return resolveSessionTranscriptsDir();
 }
 
-async function readConfigFileRaw(configPath: string): Promise<{
-  exists: boolean;
-  parsed: OpenClawConfig;
-}> {
-  try {
-    const raw = await fs.readFile(configPath, "utf-8");
-    const parsed = safeParseWithSchema(JsonRecordSchema, JSON5.parse(raw));
-    return { exists: true, parsed: (parsed ?? {}) as OpenClawConfig };
-  } catch {
-    // Missing or malformed config should not block setup; setup writes only the
-    // minimal defaults it owns and leaves deeper repair to doctor/onboard.
-    return { exists: false, parsed: {} };
-  }
-}
-
 /** Prepares config, workspace, and session directories for a usable installation. */
 export async function setupCommand(
   opts?: { workspace?: string },
@@ -151,8 +134,18 @@ export async function setupCommand(
 
   const io = deps.createConfigIO?.() ?? (await createDefaultConfigIO());
   const configPath = io.configPath;
-  const existingRaw = await readConfigFileRaw(configPath);
-  const cfg = existingRaw.parsed;
+  const prepared = await io.readConfigFileSnapshotForWrite();
+  const snapshot = prepared.snapshot;
+  if (snapshot.exists && !snapshot.valid) {
+    const formatConfigPath = deps.formatConfigPath ?? formatDefaultConfigPath;
+    runtime.error(
+      `Config invalid at ${await formatConfigPath(configPath)}. Run \`${formatCliCommand("openclaw doctor")}\` to repair it, then re-run setup.`,
+    );
+    runtime.exit(1);
+    return;
+  }
+
+  const cfg = snapshot.sourceConfig;
   const defaults = cfg.agents?.defaults ?? {};
 
   const workspace =
@@ -174,19 +167,20 @@ export async function setupCommand(
   };
 
   if (
-    !existingRaw.exists ||
+    !snapshot.exists ||
     defaults.workspace !== workspace ||
     cfg.gateway?.mode !== next.gateway?.mode
   ) {
     // Preserve all existing config fields and touch only workspace/gateway mode
     // defaults that this command owns.
-    const replaceConfig =
-      deps.replaceConfigFile ?? ((params) => writeDefaultConfigFile(params.nextConfig));
+    const replaceConfig = deps.replaceConfigFile ?? writeDefaultConfigFile;
     await replaceConfig({
       nextConfig: next,
+      snapshot,
       afterWrite: { mode: "auto" },
+      writeOptions: prepared.writeOptions,
     });
-    if (!existingRaw.exists) {
+    if (!snapshot.exists) {
       const formatConfigPath = deps.formatConfigPath ?? formatDefaultConfigPath;
       runtime.log(`Wrote ${await formatConfigPath(configPath)}`);
     } else {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `openclaw setup --baseline` treated an existing malformed or non-object config as if no config existed. The command exited successfully, replaced the user's original bytes with a new baseline config, and then created workspace/session state.

## Why This Change Was Made

Baseline setup now uses the canonical config snapshot-for-write path instead of its own permissive JSON5 parser. Existing invalid config is preserved and rejected with doctor guidance before any setup mutation. Valid or missing config follows the existing behavior, and writes carry the authoritative snapshot/write options so concurrent config changes are rejected rather than overwritten.

This PR is AI-assisted. I reviewed the full diff and verified both the original user path and the canonical snapshot conflict behavior.

## User Impact

Running baseline setup against damaged or structurally invalid config no longer destroys that file. Users receive a clear nonzero failure and `openclaw doctor` guidance, while no workspace or session directories are created. Baseline setup also gains the same stale-snapshot conflict protection as other config mutation paths.

## Evidence

Before the change on the stress-test baseline, malformed config caused `setup --baseline` to exit 0, change the file hash, and replace it with valid generated config.

After the change, an isolated source-mode run produced:

```json
{"rc":1,"bytesPreserved":true,"workspaceCreated":false,"sessionDirCreated":false,"doctorGuidance":true}
```

Focused proof on the final rebased commit:

```text
fnm exec --using 24.15.0 -- node scripts/run-vitest.mjs src/commands/setup.test.ts

9 tests passed.
```

Coverage includes:

- missing config still creates the baseline config;
- valid config preserves existing fields;
- malformed JSON is byte-preserved and rejected before workspace/session work;
- string, array, and null config roots are preserved and rejected;
- a stale snapshot rejects the write and preserves the external concurrent update.

Additional proof:

- `pnpm docs:list` completed successfully.
- Fresh autoreview: clean, no accepted/actionable findings.
- First Testbox pass caught a test-only mock return mismatch; the injector was aligned to its `Promise<void>` contract and proof reran.
- Blacksmith Testbox `tbx_01ky164agpes9j6xehq2wk5bh6`: `pnpm check:changed && pnpm build` passed.
- Testbox workflow: https://github.com/openclaw/openclaw/actions/runs/29794418540
- `git diff --check origin/main..HEAD` passed after a patch-identical rebase.
