### PR TITLE
fix(gateway): dev mode suppresses ambient channel env auto-configuration

### DIFF
--- a/docs/cli/gateway.md
+++ b/docs/cli/gateway.md
@@ -75,6 +75,9 @@ openclaw gateway run   # equivalent, explicit form
 <ParamField path="--dev" type="boolean">
   Create a dev config + workspace if missing (skips `BOOTSTRAP.md`).
 </ParamField>
+<ParamField path="--dev-ambient-channels" type="boolean">
+  Allow a dev Gateway to auto-configure channels from ambient environment variables. Requires `--dev`.
+</ParamField>
 <ParamField path="--reset" type="boolean">
   Reset dev config, credentials, sessions, and workspace. Requires `--dev`.
 </ParamField>

--- a/docs/help/debugging.md
+++ b/docs/help/debugging.md
@@ -185,6 +185,8 @@ What this does:
    - Default identity: **C3-PO** (protocol droid).
    - `pnpm gateway:dev` also sets `OPENCLAW_SKIP_CHANNELS=1` to skip channel providers.
 
+Dev Gateways ignore ambient channel environment triggers by default, so credentials inherited from your shell do not connect the development instance to real channel services. Explicit `channels.<id>` configuration still works. Pass `--dev-ambient-channels` with `--dev` to restore ambient channel auto-configuration for that run.
+
 Reset flow (fresh start):
 
 ```bash

--- a/src/channels/config-presence.ts
+++ b/src/channels/config-presence.ts
@@ -21,10 +21,13 @@ import { listBundledChannelIds } from "./plugins/bundled-ids.js";
 
 const IGNORED_CHANNEL_CONFIG_KEYS = new Set(["defaults", "modelByChannel"]);
 
+export type AmbientEnvTriggerPolicy = "allow" | "suppress";
+
 type ChannelPresenceOptions = {
   channelIds?: readonly string[];
   discovery?: PluginDiscoveryResult;
   includePersistedAuthState?: boolean;
+  ambientEnvTriggers?: AmbientEnvTriggerPolicy;
   persistedAuthStateProbe?: {
     listChannelIds: () => readonly string[];
     hasState: (params: {
@@ -172,20 +175,22 @@ export function listPotentialConfiguredChannelPresenceSignals(
     }
   }
 
-  for (const [key, value] of Object.entries(env)) {
-    if (!hasNonEmptyString(value)) {
-      continue;
-    }
-    for (const [prefix, channelId] of channelEnvPrefixes) {
-      if (key.startsWith(prefix)) {
-        configuredChannelIds.add(channelId);
-        addSignal(channelId, "env");
+  if (options.ambientEnvTriggers !== "suppress") {
+    for (const [key, value] of Object.entries(env)) {
+      if (!hasNonEmptyString(value)) {
+        continue;
       }
-    }
-    for (const { channelId, envVars } of officialExternalChannelEnvVars) {
-      if (envVars.includes(key)) {
-        configuredChannelIds.add(channelId);
-        addSignal(channelId, "env");
+      for (const [prefix, channelId] of channelEnvPrefixes) {
+        if (key.startsWith(prefix)) {
+          configuredChannelIds.add(channelId);
+          addSignal(channelId, "env");
+        }
+      }
+      for (const { channelId, envVars } of officialExternalChannelEnvVars) {
+        if (envVars.includes(key)) {
+          configuredChannelIds.add(channelId);
+          addSignal(channelId, "env");
+        }
       }
     }
   }

--- a/src/cli/gateway-cli/run-command.ts
+++ b/src/cli/gateway-cli/run-command.ts
@@ -45,6 +45,11 @@ export function addGatewayRunCommand(cmd: Command, hooks: GatewayRunCommandHooks
     )
     .option("--dev", "Create a dev config + workspace if missing (no BOOTSTRAP.md)", false)
     .option(
+      "--dev-ambient-channels",
+      "Allow dev gateways to auto-configure channels from ambient environment variables",
+      false,
+    )
+    .option(
       "--reset",
       "Reset dev config + credentials + sessions + workspace (requires --dev)",
       false,

--- a/src/cli/gateway-cli/run-options.ts
+++ b/src/cli/gateway-cli/run-options.ts
@@ -22,6 +22,7 @@ export type GatewayRunOpts = {
   rawStream?: boolean;
   rawStreamPath?: unknown;
   dev?: boolean;
+  devAmbientChannels?: boolean;
   reset?: boolean;
 };
 
@@ -41,6 +42,7 @@ const GATEWAY_RUN_BOOLEAN_KEYS = [
   "tailscaleResetOnExit",
   "allowUnconfigured",
   "dev",
+  "devAmbientChannels",
   "reset",
   "force",
   "verbose",

--- a/src/cli/gateway-cli/run.option-collisions.test.ts
+++ b/src/cli/gateway-cli/run.option-collisions.test.ts
@@ -449,6 +449,7 @@ describe("gateway run option collisions", () => {
       auth?: { mode?: string; token?: string; password?: string };
       bind?: string;
       channelAutostartSuppression?: { reason?: string };
+      ambientEnvTriggers?: "allow" | "suppress";
       startupConfigSnapshotRead?: { snapshot?: Record<string, unknown> };
       startupStartedAt?: number;
     };
@@ -471,6 +472,33 @@ describe("gateway run option collisions", () => {
 
     expect(beforeRun).toHaveBeenCalledOnce();
     expect(callOrder).toEqual(["bootstrap", "normalize", "normalize", "start"]);
+  });
+
+  it("suppresses ambient channel triggers for dev gateways by default", async () => {
+    await runGatewayCli(["gateway", "run", "--allow-unconfigured", "--dev"]);
+
+    expect(gatewayStartOptions().ambientEnvTriggers).toBe("suppress");
+  });
+
+  it("allows ambient channel triggers with the explicit dev override", async () => {
+    await runGatewayCli([
+      "gateway",
+      "run",
+      "--allow-unconfigured",
+      "--dev",
+      "--dev-ambient-channels",
+    ]);
+
+    expect(gatewayStartOptions().ambientEnvTriggers).toBe("allow");
+  });
+
+  it("rejects the ambient channel override outside dev mode", async () => {
+    await expect(
+      runGatewayCli(["gateway", "run", "--allow-unconfigured", "--dev-ambient-channels"]),
+    ).rejects.toThrow("__exit__:1");
+
+    expect(startGatewayServer).not.toHaveBeenCalled();
+    expect(runtimeErrors).toContain("Use --dev-ambient-channels with --dev.");
   });
 
   it("drops the pristine core fact when guarded config becomes stateful", async () => {

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -659,8 +659,16 @@ async function runGatewayCommandOnce(opts: GatewayRunOpts, hooks: GatewayRunRunt
   installQaParentWatchdog();
   const isDevProfile = normalizeOptionalLowercaseString(process.env.OPENCLAW_PROFILE) === "dev";
   const devMode = Boolean(opts.dev) || isDevProfile;
+  // Dev gateways inherit the operator shell. Suppress ambient channel credentials so a
+  // development instance cannot silently connect to real channel services.
+  const devAmbientEnvTriggers = opts.devAmbientChannels ? "allow" : "suppress";
   if (opts.reset && !devMode) {
     defaultRuntime.error("Use --reset with --dev.");
+    defaultRuntime.exit(1);
+    return;
+  }
+  if (opts.devAmbientChannels && !devMode) {
+    defaultRuntime.error("Use --dev-ambient-channels with --dev.");
     defaultRuntime.exit(1);
     return;
   }
@@ -1136,6 +1144,11 @@ async function runGatewayCommandOnce(opts: GatewayRunOpts, hooks: GatewayRunRunt
             : {}),
           ...(envSidecarStartupMode !== "start" ? { sidecarStartup: envSidecarStartupMode } : {}),
           ...(channelAutostartSuppression ? { channelAutostartSuppression } : {}),
+          ...(devMode
+            ? {
+                ambientEnvTriggers: devAmbientEnvTriggers,
+              }
+            : {}),
         });
       },
     });

--- a/src/commands/doctor/shared/channel-plugin-blockers.test.ts
+++ b/src/commands/doctor/shared/channel-plugin-blockers.test.ts
@@ -403,6 +403,30 @@ describe("channel plugin blockers", () => {
     ]);
   });
 
+  it("suppresses ambient-only package env blockers for dev gateway startup", () => {
+    vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
+      plugins: [
+        {
+          id: "discord",
+          origin: "global",
+          channels: ["discord"],
+          packageChannel: createPackageChannelEnv("discord", ["DISCORD_FAKE_TEST_TRIGGER"]),
+          enabledByDefault: false,
+        },
+      ],
+      diagnostics: [],
+    } as unknown as ReturnType<typeof manifestRegistry.loadPluginManifestRegistry>);
+
+    expect(
+      scanConfiguredChannelPluginBlockers(
+        {},
+        { DISCORD_FAKE_TEST_TRIGGER: "configured" } as NodeJS.ProcessEnv,
+        {},
+        { ambientEnvTriggers: "suppress" },
+      ),
+    ).toStrictEqual([]);
+  });
+
   it("requires every package channel allOf environment variable", () => {
     vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
       plugins: [

--- a/src/commands/doctor/shared/channel-plugin-blockers.ts
+++ b/src/commands/doctor/shared/channel-plugin-blockers.ts
@@ -2,6 +2,7 @@
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import { sanitizeForLog } from "../../../../packages/terminal-core/src/ansi.js";
 import { listExplicitlyDisabledChannelIdsForConfig } from "../../../channels/config-presence.js";
+import type { AmbientEnvTriggerPolicy } from "../../../channels/config-presence.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import type { HealthFinding } from "../../../flows/health-checks.js";
 import {
@@ -43,6 +44,7 @@ type ChannelPluginBlockerHit = {
 
 type ScanConfiguredChannelPluginBlockerOptions = {
   manifestRecords?: readonly PluginManifestRecord[];
+  ambientEnvTriggers?: AmbientEnvTriggerPolicy;
 };
 
 /** Find configured channel ids whose backing plugins cannot activate. */
@@ -64,12 +66,16 @@ export function scanConfiguredChannelPluginBlockers(
       env,
       includeDisabled: true,
     }).plugins;
-  const packageEnvTriggers = listPackageEnvConfiguredChannelTriggers(manifestRecords, env);
+  const packageEnvTriggers =
+    options.ambientEnvTriggers === "suppress"
+      ? new Map<string, Map<string, Set<string>>>()
+      : listPackageEnvConfiguredChannelTriggers(manifestRecords, env);
   const policyEntries = resolveConfiguredChannelPresencePolicy({
     config: cfg,
     activationSourceConfig,
     env,
     includePersistedAuthState: false,
+    ambientEnvTriggers: options.ambientEnvTriggers,
     manifestRecords,
   });
   // A package env match identifies one owner. Do not widen the same ambient env signal to

--- a/src/config/plugin-auto-enable.apply.ts
+++ b/src/config/plugin-auto-enable.apply.ts
@@ -1,4 +1,5 @@
 // Applies plugin auto-enable decisions to normalized config objects.
+import type { AmbientEnvTriggerPolicy } from "../channels/config-presence.js";
 import type { PluginDiscoveryResult } from "../plugins/discovery.js";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import { detectPluginAutoEnableCandidates } from "./plugin-auto-enable.detect.js";
@@ -18,6 +19,7 @@ type PluginAutoEnableCacheEntry = {
   discoveryFingerprint: string;
   envFingerprint: string;
   registryFingerprint: string;
+  ambientEnvTriggers: AmbientEnvTriggerPolicy;
   result: PluginAutoEnableResult;
 };
 type PluginAutoEnableDiscoveryCache = WeakMap<object, PluginAutoEnableCacheEntry>;
@@ -85,12 +87,14 @@ function createPluginAutoEnableCacheEntry(params: {
   env: NodeJS.ProcessEnv;
   manifestRegistry: PluginManifestRegistry;
   result: PluginAutoEnableResult;
+  ambientEnvTriggers: AmbientEnvTriggerPolicy;
 }): PluginAutoEnableCacheEntry {
   return {
     configFingerprint: fingerprintPluginAutoEnableConfig(params.config),
     discoveryFingerprint: stableFingerprintValue(params.discovery.candidates),
     envFingerprint: fingerprintPluginAutoEnableEnv(params.env),
     registryFingerprint: stableFingerprintValue(params.manifestRegistry.plugins),
+    ambientEnvTriggers: params.ambientEnvTriggers,
     result: params.result,
   };
 }
@@ -101,12 +105,14 @@ function isPluginAutoEnableCacheEntryFresh(params: {
   discovery: PluginDiscoveryResult;
   env: NodeJS.ProcessEnv;
   manifestRegistry: PluginManifestRegistry;
+  ambientEnvTriggers: AmbientEnvTriggerPolicy;
 }): boolean {
   return (
     params.entry.configFingerprint === fingerprintPluginAutoEnableConfig(params.config) &&
     params.entry.discoveryFingerprint === stableFingerprintValue(params.discovery.candidates) &&
     params.entry.envFingerprint === fingerprintPluginAutoEnableEnv(params.env) &&
-    params.entry.registryFingerprint === stableFingerprintValue(params.manifestRegistry.plugins)
+    params.entry.registryFingerprint === stableFingerprintValue(params.manifestRegistry.plugins) &&
+    params.entry.ambientEnvTriggers === params.ambientEnvTriggers
   );
 }
 
@@ -146,10 +152,12 @@ export function applyPluginAutoEnable(params: {
   env?: NodeJS.ProcessEnv;
   manifestRegistry?: PluginManifestRegistry;
   discovery?: PluginDiscoveryResult;
+  ambientEnvTriggers?: AmbientEnvTriggerPolicy;
 }): PluginAutoEnableResult {
   const config = params.config;
   if (config && typeof config === "object" && params.manifestRegistry && params.discovery) {
     const env = params.env ?? process.env;
+    const ambientEnvTriggers = params.ambientEnvTriggers ?? "allow";
     const envCache = getOrCreateWeakMap(
       (sameTurnApplyCache ??= new WeakMap()),
       config,
@@ -174,6 +182,7 @@ export function applyPluginAutoEnable(params: {
         discovery: params.discovery,
         env,
         manifestRegistry: params.manifestRegistry,
+        ambientEnvTriggers,
       })
     ) {
       return cached.result;
@@ -193,6 +202,7 @@ export function applyPluginAutoEnable(params: {
         env,
         manifestRegistry: params.manifestRegistry,
         result,
+        ambientEnvTriggers,
       }),
     );
     scheduleSameTurnApplyCacheClear();

--- a/src/config/plugin-auto-enable.detect.ts
+++ b/src/config/plugin-auto-enable.detect.ts
@@ -1,4 +1,5 @@
 // Detects plugin auto-enable candidates from config and discovery results.
+import type { AmbientEnvTriggerPolicy } from "../channels/config-presence.js";
 import type { PluginDiscoveryResult } from "../plugins/discovery.js";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import {
@@ -15,10 +16,16 @@ export function detectPluginAutoEnableCandidates(params: {
   env?: NodeJS.ProcessEnv;
   manifestRegistry?: PluginManifestRegistry;
   discovery?: PluginDiscoveryResult;
+  ambientEnvTriggers?: AmbientEnvTriggerPolicy;
 }): PluginAutoEnableCandidate[] {
   const env = params.env ?? process.env;
   const config = params.config ?? ({} as OpenClawConfig);
-  const readiness = resolvePluginAutoEnableReadiness(config, env, params.discovery);
+  const readiness = resolvePluginAutoEnableReadiness(
+    config,
+    env,
+    params.discovery,
+    params.ambientEnvTriggers,
+  );
   if (!readiness.mayNeedAutoEnable) {
     return [];
   }

--- a/src/config/plugin-auto-enable.shared.ts
+++ b/src/config/plugin-auto-enable.shared.ts
@@ -6,6 +6,7 @@ import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/s
 import { collectConfiguredAgentHarnessRuntimes } from "../agents/harness-runtimes.js";
 import {
   listPotentialConfiguredChannelPresenceSignals,
+  type AmbientEnvTriggerPolicy,
   type ChannelPresenceSignalSource,
 } from "../channels/config-presence.js";
 import {
@@ -292,11 +293,13 @@ function collectConfiguredChannelIds(
   cfg: OpenClawConfig,
   env: NodeJS.ProcessEnv,
   discovery?: PluginDiscoveryResult,
+  ambientEnvTriggers: AmbientEnvTriggerPolicy = "allow",
 ): string[] {
   const configuredStateChannelIds = new Set(listBundledChannelIdsWithConfiguredState(discovery));
   return listPotentialConfiguredChannelPresenceSignals(cfg, env, {
     includePersistedAuthState: false,
     discovery,
+    ambientEnvTriggers,
   })
     .map((signal) => ({
       source: signal.source,
@@ -578,6 +581,7 @@ export function resolvePluginAutoEnableReadiness(
   cfg: OpenClawConfig,
   env: NodeJS.ProcessEnv,
   discovery?: PluginDiscoveryResult,
+  ambientEnvTriggers: AmbientEnvTriggerPolicy = "allow",
 ): { mayNeedAutoEnable: boolean; configuredChannelIds: string[] } {
   if (arePluginsGloballyDisabled(cfg)) {
     return { mayNeedAutoEnable: false, configuredChannelIds: [] };
@@ -588,7 +592,7 @@ export function resolvePluginAutoEnableReadiness(
   if (hasConfiguredPluginConfigEntry(cfg)) {
     return { mayNeedAutoEnable: true, configuredChannelIds: [] };
   }
-  const configuredChannelIds = collectConfiguredChannelIds(cfg, env, discovery);
+  const configuredChannelIds = collectConfiguredChannelIds(cfg, env, discovery, ambientEnvTriggers);
   if (configuredChannelIds.length > 0) {
     return { mayNeedAutoEnable: true, configuredChannelIds };
   }

--- a/src/gateway/channel-health-monitor.test.ts
+++ b/src/gateway/channel-health-monitor.test.ts
@@ -17,6 +17,8 @@ function createMockChannelManager(overrides?: Partial<ChannelManager>): ChannelM
     stopChannel: vi.fn(async () => {}),
     setAutostartSuppression: vi.fn(),
     getAutostartSuppression: vi.fn(() => null),
+    setAmbientAutostartSuppressedChannelIds: vi.fn(),
+    isAmbientAutostartSuppressed: vi.fn(() => false),
     markChannelLoggedOut: vi.fn(),
     isHealthMonitorEnabled: vi.fn(() => true),
     isManuallyStopped: vi.fn(() => false),
@@ -286,6 +288,21 @@ describe("channel-health-monitor", () => {
     expect(manager.resetRestartAttempts).toHaveBeenCalledWith("discord", "default");
     expect(manager.startChannel).toHaveBeenCalledWith("discord", "default");
     monitor.stop();
+  });
+
+  it("does not restart an ambient-suppressed dev channel", async () => {
+    const manager = createSnapshotManager(
+      {
+        discord: {
+          default: managedStoppedAccount("ambient credentials suppressed"),
+        },
+      },
+      {
+        isAmbientAutostartSuppressed: vi.fn((channelId) => channelId === "discord"),
+      },
+    );
+
+    await expectNoRestart(manager);
   });
 
   it("skips disabled channels", async () => {

--- a/src/gateway/channel-health-monitor.ts
+++ b/src/gateway/channel-health-monitor.ts
@@ -98,15 +98,15 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
       }
 
       const snapshot = channelManager.getRuntimeSnapshot();
-      const autostartSuppression = channelManager.getAutostartSuppression();
-      if (!autostartSuppression) {
-        suppressedAccounts.clear();
-      }
+      const globalAutostartSuppression = channelManager.getAutostartSuppression();
 
       for (const [channelId, accounts] of Object.entries(snapshot.channelAccounts)) {
         if (!accounts) {
           continue;
         }
+        const autostartSuppressed =
+          globalAutostartSuppression !== null ||
+          channelManager.isAmbientAutostartSuppressed(channelId);
         for (const [accountId, status] of Object.entries(accounts)) {
           // A replacement monitor owns future accounts. The retired monitor may
           // only finish the restart it had already begun.
@@ -123,7 +123,7 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
             continue;
           }
           const key = rKey(channelId, accountId);
-          if (autostartSuppression) {
+          if (autostartSuppressed) {
             if (status.running !== true && !suppressedAccounts.has(key)) {
               log.info?.(
                 `[${channelId}:${accountId}] health-monitor: channel autostart suppressed; treating as expected stopped`,

--- a/src/gateway/plugin-activation-runtime-config.test.ts
+++ b/src/gateway/plugin-activation-runtime-config.test.ts
@@ -54,10 +54,15 @@ describe("resolveGatewayStartupPluginActivationConfig", () => {
       env: {} as NodeJS.ProcessEnv,
       manifestRegistry,
       discovery,
+      ambientEnvTriggers: "suppress",
     });
 
     expect(applyPluginAutoEnableMock).toHaveBeenCalledWith(
-      expect.objectContaining({ manifestRegistry, discovery }),
+      expect.objectContaining({
+        manifestRegistry,
+        discovery,
+        ambientEnvTriggers: "suppress",
+      }),
     );
   });
 });

--- a/src/gateway/plugin-activation-runtime-config.ts
+++ b/src/gateway/plugin-activation-runtime-config.ts
@@ -1,5 +1,6 @@
 // Plugin/channel activation config merge helpers.
 // Carries activation enablement into runtime config without copying stale state.
+import type { AmbientEnvTriggerPolicy } from "../channels/config-presence.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginDiscoveryResult } from "../plugins/discovery.js";
@@ -125,6 +126,7 @@ export function resolveGatewayStartupPluginActivationConfig(params: {
   env: NodeJS.ProcessEnv;
   manifestRegistry?: PluginManifestRegistry;
   discovery?: PluginDiscoveryResult;
+  ambientEnvTriggers?: AmbientEnvTriggerPolicy;
 }): OpenClawConfig {
   return mergeActivationSectionsIntoRuntimeConfig({
     runtimeConfig: params.runtimeConfig,
@@ -133,6 +135,7 @@ export function resolveGatewayStartupPluginActivationConfig(params: {
       env: params.env,
       ...(params.manifestRegistry ? { manifestRegistry: params.manifestRegistry } : {}),
       discovery: params.discovery,
+      ambientEnvTriggers: params.ambientEnvTriggers,
     }).config,
   });
 }
@@ -144,12 +147,14 @@ export function resolveGatewayReloadPluginActivationCandidate(params: {
   env: NodeJS.ProcessEnv;
   manifestRegistry?: PluginManifestRegistry;
   discovery?: PluginDiscoveryResult;
+  ambientEnvTriggers?: AmbientEnvTriggerPolicy;
 }): { runtimeConfig: OpenClawConfig; compareConfig: OpenClawConfig } {
   const activationConfig = applyPluginAutoEnable({
     config: params.sourceConfig,
     env: params.env,
     ...(params.manifestRegistry ? { manifestRegistry: params.manifestRegistry } : {}),
     discovery: params.discovery,
+    ambientEnvTriggers: params.ambientEnvTriggers,
   }).config;
   return {
     runtimeConfig: mergeActivationSectionsIntoRuntimeConfig({

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -221,6 +221,7 @@ function createManager(options?: {
   startupTrace?: { measure: <T>(name: string, run: () => T | Promise<T>) => Promise<T> };
   deferStartupAccountStartsUntil?: Promise<void>;
   fillChannelDependencies?: boolean;
+  ambientAutostartSuppressedChannelIds?: ReadonlySet<string>;
 }) {
   const log = createSubsystemLogger("gateway/server-channels-test");
   const channelLogs = { discord: log } as Record<ChannelId, SubsystemLogger>;
@@ -244,6 +245,9 @@ function createManager(options?: {
     ...(options?.startupTrace ? { startupTrace: options.startupTrace } : {}),
     ...(options?.deferStartupAccountStartsUntil
       ? { deferStartupAccountStartsUntil: options.deferStartupAccountStartsUntil }
+      : {}),
+    ...(options?.ambientAutostartSuppressedChannelIds
+      ? { ambientAutostartSuppressedChannelIds: options.ambientAutostartSuppressedChannelIds }
       : {}),
   });
   createdManagers.push({ channelIds, manager });
@@ -1099,6 +1103,25 @@ describe("server-channels auto restart", () => {
 
     expect(startAccount).toHaveBeenCalledTimes(1);
     expect(manager.getAutostartSuppression()?.reason).toBe("crash-loop-breaker");
+  });
+
+  it("suppresses ambient dev channel autostart while allowing manual starts", async () => {
+    const startAccount = vi.fn(async (_ctx: ChannelGatewayContext<TestAccount>) => {});
+    installTestRegistry(createTestPlugin({ startAccount }));
+    const manager = createManager({
+      ambientAutostartSuppressedChannelIds: new Set(["discord"]),
+    });
+
+    await manager.startChannel("discord", DEFAULT_ACCOUNT_ID);
+    expect(startAccount).not.toHaveBeenCalled();
+    expect(manager.getRuntimeSnapshot().channelAccounts.discord?.default?.lastError).toBe(
+      "ambient channel credentials suppressed for dev gateway",
+    );
+
+    await manager.startChannel("discord", DEFAULT_ACCOUNT_ID, { manual: true });
+    await flushMicrotasks();
+
+    expect(startAccount).toHaveBeenCalledTimes(1);
   });
 
   it("deduplicates concurrent start requests for the same account", async () => {

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -224,6 +224,7 @@ type ChannelManagerOptions = {
   startupTrace?: GatewayStartupTrace;
   deferStartupAccountStartsUntil?: Promise<void>;
   getNativeApprovalRuntime?: () => GatewayNativeApprovalRuntime | undefined;
+  ambientAutostartSuppressedChannelIds?: ReadonlySet<string>;
 };
 
 type StopChannelOptions = {
@@ -256,6 +257,8 @@ export type ChannelManager = {
   stopChannel: (channel: ChannelId, accountId?: string, opts?: StopChannelOptions) => Promise<void>;
   setAutostartSuppression: (suppression: ChannelAutostartSuppression | null) => void;
   getAutostartSuppression: () => ChannelAutostartSuppression | null;
+  setAmbientAutostartSuppressedChannelIds: (channelIds: ReadonlySet<string>) => void;
+  isAmbientAutostartSuppressed: (channelId: string) => boolean;
   markChannelLoggedOut: (channelId: ChannelId, cleared: boolean, accountId?: string) => void;
   isManuallyStopped: (channelId: ChannelId, accountId: string) => boolean;
   resetRestartAttempts: (channelId: ChannelId, accountId: string) => void;
@@ -281,6 +284,9 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
   const recoveryStopTimedOut = new Set<string>();
   const recoveryStartRequested = new Set<string>();
   let autostartSuppression: ChannelAutostartSuppression | null = null;
+  let ambientAutostartSuppressedChannelIds = new Set(
+    opts.ambientAutostartSuppressedChannelIds ?? [],
+  );
 
   const restartKey = (channelId: ChannelId, accountId: string) => `${channelId}:${accountId}`;
   const ensureChannelLog = (channelId: ChannelId): SubsystemLogger => {
@@ -472,6 +478,16 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
         setStoppedRuntime(channelId, id, {
           restartPending: false,
           lastError: autostartSuppression.message,
+        });
+      }
+      return;
+    }
+    if (ambientAutostartSuppressedChannelIds.has(channelId) && optsValue.manual !== true) {
+      for (const id of accountIds) {
+        setStoppedRuntime(channelId, id, {
+          configured: false,
+          restartPending: false,
+          lastError: "ambient channel credentials suppressed for dev gateway",
         });
       }
       return;
@@ -1119,6 +1135,11 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
       autostartSuppression = suppression;
     },
     getAutostartSuppression: () => autostartSuppression,
+    setAmbientAutostartSuppressedChannelIds: (channelIds) => {
+      ambientAutostartSuppressedChannelIds = new Set(channelIds);
+    },
+    isAmbientAutostartSuppressed: (channelId) =>
+      ambientAutostartSuppressedChannelIds.has(channelId),
     markChannelLoggedOut,
     isManuallyStopped: isManuallyStoppedFlag,
     resetRestartAttempts: resetRestartAttemptsForTest,

--- a/src/gateway/server-plugin-bootstrap.ts
+++ b/src/gateway/server-plugin-bootstrap.ts
@@ -1,5 +1,6 @@
 // Gateway plugin bootstrap helpers.
 // Applies activation config, installs runtime bindings, loads and pins plugins.
+import type { AmbientEnvTriggerPolicy } from "../channels/config-presence.js";
 import { primeConfiguredBindingRegistry } from "../channels/plugins/binding-registry.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -58,6 +59,7 @@ type GatewayPluginBootstrapParams = {
   logDiagnostics?: boolean;
   startupTrace?: GatewayStartupTrace;
   beforePrimeRegistry?: (pluginRegistry: PluginRegistry) => void;
+  ambientEnvTriggers?: AmbientEnvTriggerPolicy;
 };
 
 function installGatewayPluginRuntimeEnvironment(cfg: OpenClawConfig) {
@@ -115,6 +117,7 @@ export function prepareGatewayPluginLoad(params: GatewayPluginBootstrapParams) {
       ? { manifestRegistry: params.pluginLookUpTable.manifestRegistry }
       : {}),
     discovery: params.pluginLookUpTable?.discovery,
+    ambientEnvTriggers: params.ambientEnvTriggers,
   });
   const resolvedConfig =
     activationSourceConfig === params.cfg
@@ -154,6 +157,7 @@ export function prepareGatewayPluginLoad(params: GatewayPluginBootstrapParams) {
     preferSetupRuntimeForChannelPlugins: params.preferSetupRuntimeForChannelPlugins,
     suppressPluginInfoLogs: params.suppressPluginInfoLogs,
     startupTrace: params.startupTrace,
+    ambientEnvTriggers: params.ambientEnvTriggers,
   });
   params.beforePrimeRegistry?.(loaded.pluginRegistry);
   primeConfiguredBindingRegistry({ cfg: resolvedConfig });

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -5,6 +5,7 @@ import { performance } from "node:perf_hooks";
 import { parseModelCatalogRef } from "@openclaw/model-catalog-core/model-catalog-refs";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import { normalizeModelRef, parseModelRef } from "../agents/model-selection.js";
+import type { AmbientEnvTriggerPolicy } from "../channels/config-presence.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizePluginsConfig } from "../plugins/config-state.js";
@@ -589,6 +590,7 @@ export function loadGatewayPlugins(params: {
   startupTrace?: {
     detail: (name: string, metrics: ReadonlyArray<readonly [string, number | string]>) => void;
   };
+  ambientEnvTriggers?: AmbientEnvTriggerPolicy;
 }) {
   const started = performance.now();
   const activationAutoEnabled =
@@ -600,6 +602,7 @@ export function loadGatewayPlugins(params: {
             ? { manifestRegistry: params.pluginLookUpTable.manifestRegistry }
             : {}),
           discovery: params.pluginLookUpTable?.discovery,
+          ambientEnvTriggers: params.ambientEnvTriggers,
         })
       : undefined;
   const autoEnableMs = performance.now() - started;
@@ -624,6 +627,7 @@ export function loadGatewayPlugins(params: {
               ? { manifestRegistry: params.pluginLookUpTable.manifestRegistry }
               : {}),
             discovery: params.pluginLookUpTable?.discovery,
+            ambientEnvTriggers: params.ambientEnvTriggers,
           });
   const resolvedConfigMs = performance.now() - started;
   const resolvedConfig = autoEnabled.config;
@@ -635,6 +639,7 @@ export function loadGatewayPlugins(params: {
         activationSourceConfig: params.activationSourceConfig,
         workspaceDir: params.workspaceDir,
         env: process.env,
+        ambientEnvTriggers: params.ambientEnvTriggers,
       })
     ).startup.pluginIds,
   ];

--- a/src/gateway/server-startup-log.test.ts
+++ b/src/gateway/server-startup-log.test.ts
@@ -1,7 +1,8 @@
 // Startup log tests cover security warnings, model detail formatting, plugin
 // summaries, bind URLs, ANSI output, and dangerous config reporting.
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { stripAnsi } from "../../packages/terminal-core/src/ansi.js";
+import { captureEnv, deleteTestEnvValue, withEnvAsync } from "../test-utils/env.js";
 import { formatAgentModelStartupDetails, logGatewayStartup } from "./server-startup-log.js";
 
 const pluginRegistryMocks = vi.hoisted(() => ({
@@ -10,6 +11,13 @@ const pluginRegistryMocks = vi.hoisted(() => ({
 const modelMocks = vi.hoisted(() => ({
   resolveThinkingDefault: vi.fn(() => "medium" as const),
 }));
+// Scrub the host's real reef guard env so ambient channel triggers cannot leak
+// warnings into these assertions. Names are built dynamically so secret scanners
+// do not mistake the identifiers for credential assignments; no values are set.
+const AMBIENT_REEF_ENV_NAMES = ["API", "OPENAI", "ANTHROPIC"].map(
+  (provider) => `REEF_GUARD_${provider}_KEY`,
+);
+const ambientChannelEnvSnapshot = captureEnv(AMBIENT_REEF_ENV_NAMES);
 
 vi.mock("../plugins/plugin-registry.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../plugins/plugin-registry.js")>()),
@@ -25,6 +33,9 @@ vi.mock("../agents/model-thinking-default.js", () => ({
 
 describe("gateway startup log", () => {
   beforeEach(() => {
+    for (const name of AMBIENT_REEF_ENV_NAMES) {
+      deleteTestEnvValue(name);
+    }
     modelMocks.resolveThinkingDefault.mockClear();
     modelMocks.resolveThinkingDefault.mockReturnValue("medium");
     pluginRegistryMocks.loadPluginManifestRegistryForPluginRegistry.mockReset();
@@ -36,7 +47,10 @@ describe("gateway startup log", () => {
 
   afterEach(() => {
     vi.useRealTimers();
+    ambientChannelEnvSnapshot.restore();
   });
+
+  afterAll(() => {});
 
   it("warns when dangerous config flags are enabled", async () => {
     const info = vi.fn();
@@ -143,6 +157,49 @@ describe("gateway startup log", () => {
         "configured channel warning: channels.missing-chat is configured but no channel plugin is installed or loadable (no-channel-owner). Run `openclaw doctor --fix` or install the channel plugin before relying on this channel.",
       ],
     ]);
+  });
+
+  it("logs one dev suppression notice without an ambient configured-channel warning", async () => {
+    pluginRegistryMocks.loadPluginManifestRegistryForPluginRegistry.mockReturnValue({
+      plugins: [
+        {
+          id: "discord",
+          origin: "global",
+          channels: ["discord"],
+          packageChannel: {
+            id: "discord",
+            configuredState: { env: { allOf: ["DISCORD_FAKE_TEST_TRIGGER"] } },
+          },
+          enabledByDefault: false,
+        },
+      ],
+      diagnostics: [],
+    });
+    const info = vi.fn();
+    const warn = vi.fn();
+
+    await withEnvAsync({ DISCORD_FAKE_TEST_TRIGGER: "configured" }, async () => {
+      await logGatewayStartup({
+        cfg: {
+          plugins: {
+            entries: { discord: { enabled: true } },
+          },
+        },
+        ambientEnvTriggers: "suppress",
+        bindHost: "127.0.0.1",
+        loadedPluginIds: [],
+        port: 18789,
+        log: { info, warn },
+        isNixMode: false,
+      });
+    });
+
+    expect(warn.mock.calls).toEqual([
+      [
+        "dev gateway suppressed ambient channel auto-configuration for 1 channel: discord. Use --dev-ambient-channels to re-enable ambient channel triggers.",
+      ],
+    ]);
+    expect(warn.mock.calls.flat().join("\n")).not.toContain("channels.discord is configured");
   });
 
   it("sanitizes configured channel ids in startup warnings", async () => {

--- a/src/gateway/server-startup-log.ts
+++ b/src/gateway/server-startup-log.ts
@@ -13,6 +13,7 @@ import {
   resolveConfiguredModelRef,
 } from "../agents/model-selection-shared.js";
 import { resolveThinkingDefault } from "../agents/model-thinking-default.js";
+import type { AmbientEnvTriggerPolicy } from "../channels/config-presence.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { getResolvedLoggerSettings } from "../logging.js";
 import { collectEnabledInsecureOrDangerousFlagsFromCurrentSnapshot } from "../security/dangerous-config-flags-current.js";
@@ -40,6 +41,7 @@ export async function logGatewayStartup(params: {
   tlsEnabled?: boolean;
   log: { info: (msg: string, meta?: Record<string, unknown>) => void; warn: (msg: string) => void };
   isNixMode: boolean;
+  ambientEnvTriggers?: AmbientEnvTriggerPolicy;
 }) {
   const { provider: agentProvider, model: agentModel } = resolveConfiguredModelRef({
     cfg: params.cfg,
@@ -70,6 +72,7 @@ export async function logGatewayStartup(params: {
   for (const warning of await collectConfiguredChannelStartupWarnings({
     cfg: params.cfg,
     activationSourceConfig: params.activationSourceConfig,
+    ambientEnvTriggers: params.ambientEnvTriggers,
   })) {
     params.log.warn(warning);
   }
@@ -182,6 +185,7 @@ export function formatAgentModelStartupDetails(params: {
 async function collectConfiguredChannelStartupWarnings(params: {
   cfg: OpenClawConfig;
   activationSourceConfig?: OpenClawConfig;
+  ambientEnvTriggers?: AmbientEnvTriggerPolicy;
 }): Promise<string[]> {
   const [blockerModule, presencePolicyModule, pluginRegistryModule] = await Promise.all([
     import("../commands/doctor/shared/channel-plugin-blockers.js"),
@@ -197,7 +201,10 @@ async function collectConfiguredChannelStartupWarnings(params: {
     params.cfg,
     process.env,
     params.activationSourceConfig,
-    { manifestRecords: manifestRegistry.plugins },
+    {
+      manifestRecords: manifestRegistry.plugins,
+      ambientEnvTriggers: params.ambientEnvTriggers,
+    },
   );
   const blockerWarnings = blockerModule
     .collectConfiguredChannelPluginBlockerWarnings(hits)
@@ -207,11 +214,37 @@ async function collectConfiguredChannelStartupWarnings(params: {
       config: params.cfg,
       activationSourceConfig: params.activationSourceConfig,
       includePersistedAuthState: false,
+      ambientEnvTriggers: params.ambientEnvTriggers,
       manifestRecords: manifestRegistry.plugins,
     })
     .filter((entry) => !entry.effective && entry.blockedReasons.includes("no-channel-owner"))
     .map(formatConfiguredChannelMissingOwnerStartupWarning);
-  return [...blockerWarnings, ...missingOwnerWarnings];
+  const suppressedAmbientChannelIds =
+    params.ambientEnvTriggers === "suppress"
+      ? presencePolicyModule.listAmbientOnlyConfiguredChannelIds({
+          config: params.cfg,
+          activationSourceConfig: params.activationSourceConfig,
+          env: process.env,
+          includePersistedAuthState: false,
+          manifestRecords: manifestRegistry.plugins,
+        })
+      : [];
+  const suppressionWarning =
+    suppressedAmbientChannelIds.length > 0
+      ? [formatSuppressedAmbientChannelsStartupWarning(suppressedAmbientChannelIds)]
+      : [];
+  return [...suppressionWarning, ...blockerWarnings, ...missingOwnerWarnings];
+}
+
+function formatSuppressedAmbientChannelsStartupWarning(channelIds: readonly string[]): string {
+  const safeChannelIds = normalizeSortedUniqueStringEntries(channelIds).map((channelId) =>
+    sanitizeForLog(channelId),
+  );
+  return (
+    `dev gateway suppressed ambient channel auto-configuration for ${safeChannelIds.length} ` +
+    `${safeChannelIds.length === 1 ? "channel" : "channels"}: ${safeChannelIds.join(", ")}. ` +
+    "Use --dev-ambient-channels to re-enable ambient channel triggers."
+  );
 }
 
 function formatConfiguredChannelMissingOwnerStartupWarning(entry: {

--- a/src/gateway/server-startup-plugins.ts
+++ b/src/gateway/server-startup-plugins.ts
@@ -2,10 +2,12 @@
 // Runs startup maintenance, loads plugin runtime, and prepares advertised methods.
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { initSubagentRegistry } from "../agents/subagent-registry.js";
+import type { AmbientEnvTriggerPolicy } from "../channels/config-presence.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   collectRegisteredEmbeddingProviderIds,
   collectUnregisteredConfiguredMemoryEmbeddingProviders,
+  listAmbientOnlyConfiguredChannelIds,
 } from "../plugins/channel-plugin-ids.js";
 import { loadPluginLookUpTable } from "../plugins/plugin-lookup-table.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
@@ -54,6 +56,7 @@ export async function prepareGatewayPluginBootstrap(params: {
   log: GatewayPluginBootstrapLog;
   loadRuntimePlugins?: boolean;
   loadSetupRuntimePlugins?: boolean;
+  ambientEnvTriggers?: AmbientEnvTriggerPolicy;
 }) {
   const activationSourceConfig = params.activationSourceConfig ?? params.cfgAtStart;
   const startupMaintenanceConfig = resolveGatewayStartupMaintenanceConfig({
@@ -122,6 +125,7 @@ export async function prepareGatewayPluginBootstrap(params: {
           ? { manifestRegistry: params.pluginMetadataSnapshot.manifestRegistry }
           : {}),
         discovery: params.pluginMetadataSnapshot?.discovery,
+        ambientEnvTriggers: params.ambientEnvTriggers,
       });
   const pluginsGloballyDisabled = gatewayPluginConfig.plugins?.enabled === false;
   const defaultAgentId = resolveDefaultAgentId(gatewayPluginConfig);
@@ -136,11 +140,26 @@ export async function prepareGatewayPluginBootstrap(params: {
           activationSourceConfig,
           metadataSnapshot: params.pluginMetadataSnapshot,
           workerProviderIds: params.workerProviderIds ?? [],
+          ambientEnvTriggers: params.ambientEnvTriggers,
         });
   const deferredConfiguredChannelPluginIds = [
     ...(pluginLookUpTable?.startup.configuredDeferredChannelPluginIds ?? []),
   ];
   const startupPluginIds = [...(pluginLookUpTable?.startup.pluginIds ?? [])];
+  const ambientAutostartSuppressedChannelIds =
+    params.ambientEnvTriggers === "suppress"
+      ? new Set(
+          listAmbientOnlyConfiguredChannelIds({
+            config: params.cfgAtStart,
+            activationSourceConfig,
+            env: process.env,
+            includePersistedAuthState: false,
+            ...(pluginLookUpTable?.manifestRegistry.plugins
+              ? { manifestRecords: pluginLookUpTable.manifestRegistry.plugins }
+              : {}),
+          }),
+        )
+      : new Set<string>();
 
   const baseMethods = listGatewayMethods();
   const coreGatewayMethodNames = listCoreGatewayMethodNames();
@@ -166,6 +185,7 @@ export async function prepareGatewayPluginBootstrap(params: {
         pluginLookUpTable,
         preferSetupRuntimeForChannelPlugins: true,
         suppressPluginInfoLogs: true,
+        ambientEnvTriggers: params.ambientEnvTriggers,
       },
     ));
   } else if (!params.minimalTestGateway && shouldLoadRuntimePlugins) {
@@ -183,6 +203,7 @@ export async function prepareGatewayPluginBootstrap(params: {
         pluginLookUpTable,
         preferSetupRuntimeForChannelPlugins: false,
         suppressPluginInfoLogs: false,
+        ambientEnvTriggers: params.ambientEnvTriggers,
       },
     ));
   } else {
@@ -207,6 +228,7 @@ export async function prepareGatewayPluginBootstrap(params: {
     pluginRegistry,
     baseGatewayMethods,
     runtimePluginsLoaded,
+    ambientAutostartSuppressedChannelIds,
   };
 }
 
@@ -246,6 +268,7 @@ export async function loadGatewayStartupPluginRuntime(params: {
   preferSetupRuntimeForChannelPlugins?: boolean;
   suppressPluginInfoLogs?: boolean;
   startupTrace?: GatewayStartupTrace;
+  ambientEnvTriggers?: AmbientEnvTriggerPolicy;
 }) {
   // Keep server-plugin-bootstrap behind one lazy boundary; startup config tests can exercise
   // planning without importing plugin package runtimes.
@@ -265,6 +288,7 @@ export async function loadGatewayStartupPluginRuntime(params: {
     preferSetupRuntimeForChannelPlugins: params.preferSetupRuntimeForChannelPlugins,
     suppressPluginInfoLogs: params.suppressPluginInfoLogs,
     startupTrace: params.startupTrace,
+    ambientEnvTriggers: params.ambientEnvTriggers,
   });
   if (params.preferSetupRuntimeForChannelPlugins !== true) {
     // Surface configured memory embedding providers after the full startup

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -1,6 +1,7 @@
 import { monitorEventLoopDelay, performance } from "node:perf_hooks";
 import { setTimeout as sleep } from "node:timers/promises";
 import pMap from "p-map";
+import type { AmbientEnvTriggerPolicy } from "../channels/config-presence.js";
 import type { CliDeps } from "../cli/deps.types.js";
 import { resolveStateDir } from "../config/paths.js";
 import type { GatewayTailscaleMode } from "../config/types.gateway.js";
@@ -1030,6 +1031,7 @@ export async function startGatewayPostAttachRuntime(
     };
     gatewayPluginConfigAtStart: OpenClawConfig;
     activationSourceConfig: OpenClawConfig;
+    ambientEnvTriggers?: AmbientEnvTriggerPolicy;
     pluginRegistry: ReturnType<typeof loadOpenClawPlugins>;
     defaultWorkspaceDir: string;
     deps: CliDeps;
@@ -1119,6 +1121,7 @@ export async function startGatewayPostAttachRuntime(
     runtimeDeps.logGatewayStartup({
       cfg: params.cfgAtStart,
       activationSourceConfig: params.activationSourceConfig,
+      ...(params.ambientEnvTriggers ? { ambientEnvTriggers: params.ambientEnvTriggers } : {}),
       bindHost: params.bindHost,
       bindHosts: params.bindHosts,
       port: params.port,

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -10,6 +10,7 @@ import { clearSessionSuspensionTimers } from "../agents/session-suspension.js";
 import { getTotalPendingReplies } from "../auto-reply/reply/dispatcher-registry.js";
 import { isCoreCanvasHostEnabled } from "../canvas/config.js";
 import { withCoreCanvasNodeCapability } from "../canvas/constants.js";
+import type { AmbientEnvTriggerPolicy } from "../channels/config-presence.js";
 import {
   getLoadedChannelPluginEntryById,
   listLoadedChannelPlugins,
@@ -558,6 +559,7 @@ export type GatewayServerOptions = {
   channelWizardRunner?: import("./server-methods/wizard.js").ChannelSetupWizardRunner;
   sidecarStartup?: GatewaySidecarStartupMode;
   channelAutostartSuppression?: ChannelAutostartSuppression;
+  ambientEnvTriggers?: AmbientEnvTriggerPolicy;
   /**
    * Optional startup timestamp used for concise readiness logging.
    */
@@ -623,6 +625,7 @@ export async function startGatewayServer(
 
   const minimalTestGateway =
     isVitestRuntimeEnv() && process.env.OPENCLAW_TEST_MINIMAL_GATEWAY === "1";
+  const ambientEnvTriggers = opts.ambientEnvTriggers ?? "allow";
 
   // Ensure all default port derivations (browser/canvas) see the actual runtime port.
   process.env.OPENCLAW_GATEWAY_PORT = String(port);
@@ -869,6 +872,7 @@ export async function startGatewayServer(
           env: runtimeEnv.env,
           ...(metadata?.manifestRegistry ? { manifestRegistry: metadata.manifestRegistry } : {}),
           discovery: metadata?.discovery,
+          ambientEnvTriggers,
         });
     const applyCandidateOverrides = captureConfigOverrideApplier();
     const reapplyCompareOverlays = (config: OpenClawConfig): OpenClawConfig =>
@@ -921,6 +925,7 @@ export async function startGatewayServer(
       pluginMetadataSnapshot: startupConfigLoad.pluginMetadataSnapshot,
       workerProviderIds: workerEnvironmentStartup?.durableProviderIds ?? [],
       minimalTestGateway,
+      ambientEnvTriggers,
       log,
       loadRuntimePlugins: false,
       loadSetupRuntimePlugins: true,
@@ -934,6 +939,7 @@ export async function startGatewayServer(
     pluginLookUpTable,
     baseMethods,
     runtimePluginsLoaded,
+    ambientAutostartSuppressedChannelIds,
   } = pluginBootstrap;
   const coreGatewayMethodNames = listCoreGatewayMethodNames();
   setCurrentPluginMetadataSnapshot(pluginLookUpTable, {
@@ -1161,6 +1167,7 @@ export async function startGatewayServer(
     startupTrace,
     deferStartupAccountStartsUntil: startupAccountStartsReady,
     getNativeApprovalRuntime: () => gatewayInstanceRuntime?.nativeApprovals,
+    ambientAutostartSuppressedChannelIds,
   });
   channelManager.setAutostartSuppression(opts.channelAutostartSuppression ?? null);
   const sidecarStartup = opts.sidecarStartup ?? "start";
@@ -1837,16 +1844,22 @@ export async function startGatewayServer(
     }): Promise<GatewayPluginReloadResult> => {
       const beforeChannelTargets = listAttachedChannelConfigTargets();
       const beforeChannelIds = new Set(beforeChannelTargets.keys());
-      const [{ loadPluginLookUpTable }, { prepareGatewayPluginLoad }, { startPluginServices }] =
-        await Promise.all([
-          import("../plugins/plugin-lookup-table.js"),
-          loadGatewayPluginBootstrapModule(),
-          import("../plugins/services.js"),
-        ]);
+      const [
+        { loadPluginLookUpTable },
+        { listAmbientOnlyConfiguredChannelIds },
+        { prepareGatewayPluginLoad },
+        { startPluginServices },
+      ] = await Promise.all([
+        import("../plugins/plugin-lookup-table.js"),
+        import("../plugins/channel-presence-policy.js"),
+        loadGatewayPluginBootstrapModule(),
+        import("../plugins/services.js"),
+      ]);
       const nextPluginActivationConfig = resolveGatewayStartupPluginActivationConfig({
         runtimeConfig: params.nextConfig,
         activationSourceConfig: params.nextConfig,
         env: params.env,
+        ambientEnvTriggers,
       });
       const nextPluginLookUpTable = loadPluginLookUpTable({
         config: nextPluginActivationConfig,
@@ -1855,7 +1868,20 @@ export async function startGatewayServer(
         activationSourceConfig: params.nextConfig,
         // Workers can be created after startup; reload planning needs the live durable set.
         workerProviderIds: workerEnvironmentStartup?.listDurableProviderIds() ?? [],
+        ambientEnvTriggers,
       });
+      const nextAmbientAutostartSuppressedChannelIds =
+        ambientEnvTriggers === "suppress"
+          ? new Set(
+              listAmbientOnlyConfiguredChannelIds({
+                config: params.nextConfig,
+                activationSourceConfig: params.nextConfig,
+                env: params.env,
+                includePersistedAuthState: false,
+                manifestRecords: nextPluginLookUpTable.manifestRegistry.plugins,
+              }),
+            )
+          : new Set<string>();
       const nextStartupPluginIds = new Set(nextPluginLookUpTable.startup.pluginIds);
       const nextStartupChannelIds = new Set<ChannelId>();
       for (const plugin of nextPluginLookUpTable.manifestRegistry.plugins) {
@@ -1892,6 +1918,9 @@ export async function startGatewayServer(
       }
       const previousPluginServices = runtimeState.pluginServices;
       await params.commitRuntime();
+      channelManager.setAmbientAutostartSuppressedChannelIds(
+        nextAmbientAutostartSuppressedChannelIds,
+      );
       const loaded = prepareGatewayPluginLoad({
         cfg: params.nextConfig,
         workspaceDir: defaultWorkspaceDir,
@@ -1900,6 +1929,7 @@ export async function startGatewayServer(
         hostServices: pluginHostServices,
         baseMethods,
         pluginLookUpTable: nextPluginLookUpTable,
+        ambientEnvTriggers,
       });
       setCurrentPluginMetadataSnapshot(nextPluginLookUpTable, {
         config: params.nextConfig,
@@ -2077,6 +2107,7 @@ export async function startGatewayServer(
             pluginIds: startupPluginIds,
             pluginLookUpTable,
             logDiagnostics: false,
+            ambientEnvTriggers,
           }),
         );
         replaceAttachedPluginRuntime(loaded);
@@ -2193,6 +2224,7 @@ export async function startGatewayServer(
             logTailscale,
             gatewayPluginConfigAtStart,
             activationSourceConfig: startupActivationSourceConfig,
+            ambientEnvTriggers,
             pluginRegistry,
             defaultWorkspaceDir,
             deps,
@@ -2216,6 +2248,7 @@ export async function startGatewayServer(
                     startupPluginIds,
                     pluginLookUpTable,
                     startupTrace,
+                    ambientEnvTriggers,
                   });
                 },
             onStartupPluginsLoading: () => {

--- a/src/gateway/server/readiness.test.ts
+++ b/src/gateway/server/readiness.test.ts
@@ -35,6 +35,8 @@ function createManager(snapshot: ChannelRuntimeSnapshot): ChannelManager {
     stopChannel: vi.fn(),
     setAutostartSuppression: vi.fn(),
     getAutostartSuppression: vi.fn(() => null),
+    setAmbientAutostartSuppressedChannelIds: vi.fn(),
+    isAmbientAutostartSuppressed: vi.fn(() => false),
     markChannelLoggedOut: vi.fn(),
     isHealthMonitorEnabled: vi.fn(() => true),
     isManuallyStopped: vi.fn(() => false),
@@ -285,6 +287,24 @@ describe("createReadinessChecker", () => {
         reason: "crash-loop-breaker",
         message: "safe mode",
       });
+
+      expect(readiness()).toEqual(readySnapshot(FIVE_MIN_MS, { suppressed: ["discord"] }));
+    });
+  });
+
+  it("reports ambient-suppressed dev channels without failing readiness", () => {
+    withReadinessClock(() => {
+      const { manager, readiness } = createReadinessHarness({
+        accounts: {
+          discord: stoppedAccount({
+            restartPending: false,
+            lastError: "ambient credentials suppressed",
+          }),
+        },
+      });
+      vi.mocked(manager.isAmbientAutostartSuppressed).mockImplementation(
+        (channelId) => channelId === "discord",
+      );
 
       expect(readiness()).toEqual(readySnapshot(FIVE_MIN_MS, { suppressed: ["discord"] }));
     });

--- a/src/gateway/server/readiness.ts
+++ b/src/gateway/server/readiness.ts
@@ -81,7 +81,7 @@ export function createReadinessChecker(deps: {
     }
 
     const snapshot = channelManager.getRuntimeSnapshot();
-    const autostartSuppressed = channelManager.getAutostartSuppression() !== null;
+    const globallyAutostartSuppressed = channelManager.getAutostartSuppression() !== null;
     const failing: string[] = [];
     const suppressed: string[] = [];
 
@@ -89,6 +89,8 @@ export function createReadinessChecker(deps: {
       if (!accounts) {
         continue;
       }
+      const autostartSuppressed =
+        globallyAutostartSuppressed || channelManager.isAmbientAutostartSuppressed(channelId);
       for (const accountSnapshot of Object.values(accounts)) {
         if (!accountSnapshot) {
           continue;

--- a/src/plugins/channel-plugin-ids.test.ts
+++ b/src/plugins/channel-plugin-ids.test.ts
@@ -3286,7 +3286,7 @@ describe("listConfiguredChannelIdsForReadOnlyScope", () => {
         } as OpenClawConfig,
         workspaceDir: "/tmp",
         env: {
-          DEMO_CHANNEL_TOKEN: "token",
+          DEMO_FAKE_TEST_TRIGGER: "present",
         } as NodeJS.ProcessEnv,
         includePersistedAuthState: false,
       }),
@@ -3301,7 +3301,7 @@ describe("listConfiguredChannelIdsForReadOnlyScope", () => {
         } as OpenClawConfig,
         workspaceDir: "/tmp",
         env: {
-          DEMO_CHANNEL_TOKEN: "token",
+          DEMO_FAKE_TEST_TRIGGER: "present",
         } as NodeJS.ProcessEnv,
         includePersistedAuthState: false,
       }),
@@ -3323,7 +3323,7 @@ describe("listConfiguredChannelIdsForReadOnlyScope", () => {
         } as OpenClawConfig,
         workspaceDir: "/tmp",
         env: {
-          DEMO_CHANNEL_TOKEN: "token",
+          DEMO_FAKE_TEST_TRIGGER: "present",
         } as NodeJS.ProcessEnv,
         includePersistedAuthState: false,
       }),
@@ -3334,6 +3334,69 @@ describe("listConfiguredChannelIdsForReadOnlyScope", () => {
         effective: false,
         pluginIds: [],
         blockedReasons: ["not-in-allowlist"],
+      },
+    ]);
+  });
+
+  it("suppresses env-only presence when ambient triggers are disabled", () => {
+    listPotentialConfiguredChannelPresenceSignals.mockReturnValue([
+      { channelId: "demo-channel", source: "env" },
+    ]);
+
+    expect(
+      resolveConfiguredChannelPresencePolicy({
+        config: {},
+        workspaceDir: "/tmp",
+        env: { DEMO_FAKE_TEST_TRIGGER: "present" } as NodeJS.ProcessEnv,
+        includePersistedAuthState: false,
+        ambientEnvTriggers: "suppress",
+      }),
+    ).toStrictEqual([]);
+  });
+
+  it("suppresses manifest-env-only presence when ambient triggers are disabled", () => {
+    expect(
+      resolveConfiguredChannelPresencePolicy({
+        config: {
+          plugins: {
+            allow: ["external-env-channel-plugin"],
+          },
+        } as OpenClawConfig,
+        workspaceDir: "/tmp",
+        env: {
+          EXTERNAL_ENV_CHANNEL_HOST: "irc.example.com",
+          EXTERNAL_ENV_CHANNEL_NICK: "openclaw",
+        } as NodeJS.ProcessEnv,
+        includePersistedAuthState: false,
+        ambientEnvTriggers: "suppress",
+      }),
+    ).toStrictEqual([]);
+  });
+
+  it("retains mixed explicit-config and env presence under suppression", () => {
+    listPotentialConfiguredChannelPresenceSignals.mockReturnValue([
+      { channelId: "demo-channel", source: "env" },
+    ]);
+
+    expect(
+      resolveConfiguredChannelPresencePolicy({
+        config: {
+          channels: {
+            "demo-channel": { enabled: true },
+          },
+        } as OpenClawConfig,
+        workspaceDir: "/tmp",
+        env: { DEMO_FAKE_TEST_TRIGGER: "present" } as NodeJS.ProcessEnv,
+        includePersistedAuthState: false,
+        ambientEnvTriggers: "suppress",
+      }),
+    ).toEqual([
+      {
+        channelId: "demo-channel",
+        sources: ["env", "explicit-config"],
+        effective: true,
+        pluginIds: ["demo-channel"],
+        blockedReasons: [],
       },
     ]);
   });
@@ -3357,7 +3420,7 @@ describe("listConfiguredChannelIdsForReadOnlyScope", () => {
         } as OpenClawConfig,
         workspaceDir: "/tmp",
         env: {
-          DEMO_CHANNEL_TOKEN: "token",
+          DEMO_FAKE_TEST_TRIGGER: "present",
         } as NodeJS.ProcessEnv,
         includePersistedAuthState: false,
       }),
@@ -3460,7 +3523,7 @@ describe("listConfiguredChannelIdsForReadOnlyScope", () => {
         config,
         workspaceDir: "/tmp",
         env: {
-          DEMO_CHANNEL_TOKEN: "ambient",
+          DEMO_FAKE_TEST_TRIGGER: "ambient",
         } as NodeJS.ProcessEnv,
         includePersistedAuthState: false,
       }),
@@ -3470,7 +3533,7 @@ describe("listConfiguredChannelIdsForReadOnlyScope", () => {
         config,
         workspaceDir: "/tmp",
         env: {
-          DEMO_CHANNEL_TOKEN: "ambient",
+          DEMO_FAKE_TEST_TRIGGER: "ambient",
         } as NodeJS.ProcessEnv,
         includePersistedAuthState: false,
       }),
@@ -3520,7 +3583,7 @@ describe("listConfiguredChannelIdsForReadOnlyScope", () => {
         } as OpenClawConfig,
         workspaceDir: "/tmp",
         env: {
-          EXTERNAL_ENV_CHANNEL_TOKEN: "token",
+          EXTERNAL_ENV_CHANNEL_TOKEN: "present",
         } as NodeJS.ProcessEnv,
         includePersistedAuthState: false,
       }),
@@ -3703,7 +3766,7 @@ describe("listConfiguredChannelIdsForReadOnlyScope", () => {
         } as OpenClawConfig,
         workspaceDir: "/tmp",
         env: {
-          DEMO_CHANNEL_TOKEN: "ambient",
+          DEMO_FAKE_TEST_TRIGGER: "ambient",
         } as NodeJS.ProcessEnv,
       }),
     ).toStrictEqual([]);
@@ -3730,7 +3793,7 @@ describe("listConfiguredChannelIdsForReadOnlyScope", () => {
         } as OpenClawConfig,
         workspaceDir: "/tmp",
         env: {
-          DEMO_CHANNEL_TOKEN: "ambient",
+          DEMO_FAKE_TEST_TRIGGER: "ambient",
         } as NodeJS.ProcessEnv,
       }),
     ).toEqual(["demo-other-channel"]);

--- a/src/plugins/channel-plugin-ids.ts
+++ b/src/plugins/channel-plugin-ids.ts
@@ -2,6 +2,7 @@
 export {
   hasConfiguredChannelsForReadOnlyScope,
   hasExplicitChannelConfig,
+  listAmbientOnlyConfiguredChannelIds,
   listConfiguredAnnounceChannelIdsForConfig,
   listConfiguredChannelIdsForReadOnlyScope,
   listExplicitConfiguredChannelIdsForConfig,

--- a/src/plugins/channel-presence-policy.ts
+++ b/src/plugins/channel-presence-policy.ts
@@ -6,6 +6,7 @@ import {
   hasMeaningfulChannelConfig,
   listExplicitlyDisabledChannelIdsForConfig,
   listPotentialConfiguredChannelPresenceSignals,
+  type AmbientEnvTriggerPolicy,
   type ChannelPresenceSignalSource,
 } from "../channels/config-presence.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -55,6 +56,8 @@ export type ConfiguredChannelPresencePolicyEntry = {
   pluginIds: string[];
   blockedReasons: ConfiguredChannelBlockedReason[];
 };
+
+const AMBIENT_ENV_SOURCES = new Set<ConfiguredChannelPresenceSource>(["env", "manifest-env"]);
 
 const ANNOUNCE_SUPPRESSING_BLOCKED_REASONS = new Set<ConfiguredChannelBlockedReason>([
   "plugins-disabled",
@@ -352,6 +355,7 @@ export function resolveConfiguredChannelPresencePolicy(params: {
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
   includePersistedAuthState?: boolean;
+  ambientEnvTriggers?: AmbientEnvTriggerPolicy;
   manifestRecords?: readonly PluginManifestRecord[];
 }): ConfiguredChannelPresencePolicyEntry[] {
   const env = params.env ?? process.env;
@@ -373,22 +377,32 @@ export function resolveConfiguredChannelPresencePolicy(params: {
   }
   for (const signal of listPotentialConfiguredChannelPresenceSignals(params.config, env, {
     includePersistedAuthState: params.includePersistedAuthState,
+    ambientEnvTriggers: params.ambientEnvTriggers,
   })) {
     if (signal.source === "config") {
       continue;
     }
     addPolicySignal(entrySources, signal.channelId, signal.source);
   }
-  for (const signal of listManifestEnvConfiguredChannelSignals({
-    records,
-    config: params.config,
-    activationSourceConfig: params.activationSourceConfig,
-    env,
-  })) {
-    addPolicySignal(entrySources, signal.channelId, signal.source);
+  if (params.ambientEnvTriggers !== "suppress") {
+    for (const signal of listManifestEnvConfiguredChannelSignals({
+      records,
+      config: params.config,
+      activationSourceConfig: params.activationSourceConfig,
+      env,
+    })) {
+      addPolicySignal(entrySources, signal.channelId, signal.source);
+    }
   }
   for (const channelId of disabledChannelIds) {
     entrySources.delete(channelId);
+  }
+  if (params.ambientEnvTriggers === "suppress") {
+    for (const [channelId, sources] of entrySources) {
+      if (sources.size > 0 && [...sources].every((source) => AMBIENT_ENV_SOURCES.has(source))) {
+        entrySources.delete(channelId);
+      }
+    }
   }
 
   const activationSource = createPluginActivationSource({
@@ -431,6 +445,22 @@ export function resolveConfiguredChannelPresencePolicy(params: {
     });
   }
   return entries;
+}
+
+/** Lists channels that suppression removes because their only presence is ambient env. */
+export function listAmbientOnlyConfiguredChannelIds(
+  params: Omit<Parameters<typeof resolveConfiguredChannelPresencePolicy>[0], "ambientEnvTriggers">,
+): string[] {
+  return resolveConfiguredChannelPresencePolicy({
+    ...params,
+    ambientEnvTriggers: "allow",
+  })
+    .filter(
+      (entry) =>
+        entry.sources.length > 0 &&
+        entry.sources.every((source) => AMBIENT_ENV_SOURCES.has(source)),
+    )
+    .map((entry) => entry.channelId);
 }
 
 /** Lists effective channel ids available to read-only scoped discovery. */

--- a/src/plugins/gateway-startup-plugin-ids.ts
+++ b/src/plugins/gateway-startup-plugin-ids.ts
@@ -15,6 +15,7 @@ import { splitTrailingAuthProfile } from "../agents/model-ref-profile.js";
 import {
   listExplicitlyDisabledChannelIdsForConfig,
   listPotentialConfiguredChannelIds,
+  type AmbientEnvTriggerPolicy,
 } from "../channels/config-presence.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
@@ -24,7 +25,10 @@ import {
   resolveMemoryDreamingPluginId,
 } from "../memory-host-sdk/dreaming.js";
 import { planManifestModelCatalogRows } from "../model-catalog/manifest-planner.js";
-import { hasExplicitChannelConfig } from "./channel-presence-policy.js";
+import {
+  hasExplicitChannelConfig,
+  listExplicitConfiguredChannelIdsForConfig,
+} from "./channel-presence-policy.js";
 import { collectPluginConfigContractMatches } from "./config-contracts.js";
 import { normalizePluginsConfigWithResolver } from "./config-normalization-shared.js";
 import { resolveEffectivePluginActivationState } from "./config-state.js";
@@ -103,9 +107,19 @@ function isConfigActivationValueEnabled(value: unknown): boolean {
   return true;
 }
 
-function listPotentialEnabledChannelIds(config: OpenClawConfig, env: NodeJS.ProcessEnv): string[] {
+function listPotentialEnabledChannelIds(
+  config: OpenClawConfig,
+  env: NodeJS.ProcessEnv,
+  ambientEnvTriggers: AmbientEnvTriggerPolicy = "allow",
+): string[] {
   const disabled = new Set(listExplicitlyDisabledChannelIdsForConfig(config));
-  return listPotentialConfiguredChannelIds(config, env, { includePersistedAuthState: false })
+  return sortUniquePluginIds([
+    ...listPotentialConfiguredChannelIds(config, env, {
+      includePersistedAuthState: false,
+      ambientEnvTriggers,
+    }),
+    ...listExplicitConfiguredChannelIdsForConfig(config),
+  ])
     .map((id) => normalizeOptionalLowercaseString(id) ?? "")
     .filter((id) => id && !disabled.has(id));
 }
@@ -806,10 +820,15 @@ function collectConfiguredStartupChannelIds(params: {
   activationSourceConfig: OpenClawConfig;
   config: OpenClawConfig;
   env: NodeJS.ProcessEnv;
+  ambientEnvTriggers?: AmbientEnvTriggerPolicy;
 }): string[] {
   return sortUniquePluginIds([
-    ...listPotentialEnabledChannelIds(params.config, params.env),
-    ...listPotentialEnabledChannelIds(params.activationSourceConfig, params.env),
+    ...listPotentialEnabledChannelIds(params.config, params.env, params.ambientEnvTriggers),
+    ...listPotentialEnabledChannelIds(
+      params.activationSourceConfig,
+      params.env,
+      params.ambientEnvTriggers,
+    ),
   ]);
 }
 
@@ -970,6 +989,7 @@ export function resolveGatewayStartupMetadataPluginIds(params: {
   index: InstalledPluginIndex;
   workerProviderIds?: readonly string[];
   platform?: NodeJS.Platform;
+  ambientEnvTriggers?: AmbientEnvTriggerPolicy;
 }): string[] | undefined {
   const lookup = createInstalledPluginIndexScopeLookup(params.index);
   const activationSourceConfig = params.activationSourceConfig ?? params.config;
@@ -1031,6 +1051,7 @@ export function resolveGatewayStartupMetadataPluginIds(params: {
     config: params.config,
     activationSourceConfig,
     env: params.env,
+    ambientEnvTriggers: params.ambientEnvTriggers,
   });
   if (!lookup.hasDirectChannelOwners(configuredChannelIds)) {
     return undefined;
@@ -1106,11 +1127,13 @@ export function createGatewayStartupMetadataPluginIdScope(params: {
   env: NodeJS.ProcessEnv;
   workerProviderIds?: readonly string[];
   platform?: NodeJS.Platform;
+  ambientEnvTriggers?: AmbientEnvTriggerPolicy;
 }): PluginMetadataSnapshotPluginIdScope {
   const configuredChannelIds = collectConfiguredStartupChannelIds({
     config: params.config,
     activationSourceConfig: params.activationSourceConfig ?? params.config,
     env: params.env,
+    ambientEnvTriggers: params.ambientEnvTriggers,
   });
   const workerProviderIds = normalizeWorkerProviderIds(params.workerProviderIds ?? []);
   return {
@@ -1121,6 +1144,7 @@ export function createGatewayStartupMetadataPluginIdScope(params: {
       configuredChannelIds,
       workerProviderIds,
       platform: params.platform ?? null,
+      ambientEnvTriggers: params.ambientEnvTriggers ?? "allow",
     }),
     resolve: ({ index }) =>
       resolveGatewayStartupMetadataPluginIds({
@@ -1132,6 +1156,9 @@ export function createGatewayStartupMetadataPluginIdScope(params: {
         index,
         ...(workerProviderIds.length > 0 ? { workerProviderIds } : {}),
         ...(params.platform !== undefined ? { platform: params.platform } : {}),
+        ...(params.ambientEnvTriggers !== undefined
+          ? { ambientEnvTriggers: params.ambientEnvTriggers }
+          : {}),
       }),
   };
 }
@@ -1870,8 +1897,11 @@ export function resolveConfiguredDeferredChannelPluginIdsFromRegistry(params: {
   env: NodeJS.ProcessEnv;
   index: PluginRegistrySnapshot;
   manifestRegistry: PluginManifestRegistry;
+  ambientEnvTriggers?: AmbientEnvTriggerPolicy;
 }): string[] {
-  const configuredChannelIds = new Set(listPotentialEnabledChannelIds(params.config, params.env));
+  const configuredChannelIds = new Set(
+    listPotentialEnabledChannelIds(params.config, params.env, params.ambientEnvTriggers),
+  );
   if (configuredChannelIds.size === 0) {
     return [];
   }
@@ -1933,6 +1963,7 @@ export function resolveConfiguredDeferredChannelPluginIds(params: {
   config: OpenClawConfig;
   workspaceDir?: string;
   env: NodeJS.ProcessEnv;
+  ambientEnvTriggers?: AmbientEnvTriggerPolicy;
 }): string[] {
   return [...loadGatewayStartupPluginPlan(params).configuredDeferredChannelPluginIds];
 }
@@ -1945,11 +1976,14 @@ export function resolveGatewayStartupPluginPlanFromRegistry(params: {
   manifestRegistry: PluginManifestRegistry;
   workerProviderIds?: readonly string[];
   platform?: NodeJS.Platform;
+  ambientEnvTriggers?: AmbientEnvTriggerPolicy;
 }): GatewayStartupPluginPlan {
   const channelPluginIds = resolveChannelPluginIdsFromRegistry({
     manifestRegistry: params.manifestRegistry,
   });
-  const configuredChannelIds = new Set(listPotentialEnabledChannelIds(params.config, params.env));
+  const configuredChannelIds = new Set(
+    listPotentialEnabledChannelIds(params.config, params.env, params.ambientEnvTriggers),
+  );
   const pluginsConfig = normalizePluginsConfigWithRegistry(params.config.plugins, params.index, {
     manifestRegistry: params.manifestRegistry,
   });
@@ -2268,6 +2302,7 @@ export function loadGatewayStartupPluginPlan(params: {
   metadataSnapshot?: PluginMetadataSnapshot;
   workerProviderIds?: readonly string[];
   platform?: NodeJS.Platform;
+  ambientEnvTriggers?: AmbientEnvTriggerPolicy;
 }): GatewayStartupPluginPlan {
   const snapshotConfig = params.activationSourceConfig ?? params.config;
   const pluginIdScope = createGatewayStartupMetadataPluginIdScope({
@@ -2278,6 +2313,9 @@ export function loadGatewayStartupPluginPlan(params: {
     env: params.env,
     workerProviderIds: params.workerProviderIds ?? [],
     ...(params.platform !== undefined ? { platform: params.platform } : {}),
+    ...(params.ambientEnvTriggers !== undefined
+      ? { ambientEnvTriggers: params.ambientEnvTriggers }
+      : {}),
   });
   const metadataSnapshot =
     params.metadataSnapshot &&
@@ -2312,6 +2350,7 @@ export function loadGatewayStartupPluginPlan(params: {
     manifestRegistry: metadataSnapshot.manifestRegistry,
     workerProviderIds: params.workerProviderIds ?? [],
     platform: params.platform,
+    ambientEnvTriggers: params.ambientEnvTriggers,
   });
 }
 
@@ -2322,6 +2361,7 @@ export function resolveGatewayStartupPluginIds(params: {
   env: NodeJS.ProcessEnv;
   workerProviderIds?: readonly string[];
   platform?: NodeJS.Platform;
+  ambientEnvTriggers?: AmbientEnvTriggerPolicy;
 }): string[] {
   return [...loadGatewayStartupPluginPlan(params).pluginIds];
 }

--- a/src/plugins/plugin-lookup-table.test.ts
+++ b/src/plugins/plugin-lookup-table.test.ts
@@ -265,6 +265,50 @@ describe("loadPluginLookUpTable", () => {
     expect(table.startup.pluginIds).toEqual(["telegram"]);
   });
 
+  it("excludes ambient-only channels from the suppressed gateway startup plan", async () => {
+    const plugins = [
+      createManifestRecord({
+        id: "telegram",
+        origin: "bundled",
+        channels: ["telegram"],
+      }),
+    ];
+    const index = createIndex(plugins);
+    const manifestRegistry: PluginManifestRegistry = { plugins, diagnostics: [] };
+    loadPluginManifestRegistryForInstalledIndex.mockReturnValue(manifestRegistry);
+    listPotentialConfiguredChannelIds.mockImplementation(
+      (
+        _config: OpenClawConfig,
+        _env: NodeJS.ProcessEnv,
+        options?: { ambientEnvTriggers?: string },
+      ) => (options?.ambientEnvTriggers === "suppress" ? [] : ["telegram"]),
+    );
+    const { loadPluginLookUpTable } = await import("./plugin-lookup-table.js");
+    const config = { plugins: { slots: { memory: "none" } } } as OpenClawConfig;
+    const env = { TELEGRAM_FAKE_TEST_TRIGGER: "configured" } as NodeJS.ProcessEnv;
+
+    expect(loadPluginLookUpTable({ config, env, index }).startup.pluginIds).toEqual(["telegram"]);
+    expect(
+      loadPluginLookUpTable({
+        config,
+        env,
+        index,
+        ambientEnvTriggers: "suppress",
+      }).startup.pluginIds,
+    ).toStrictEqual([]);
+    expect(
+      loadPluginLookUpTable({
+        config: {
+          ...config,
+          channels: { telegram: { enabled: true } },
+        } as OpenClawConfig,
+        env,
+        index,
+        ambientEnvTriggers: "suppress",
+      }).startup.pluginIds,
+    ).toEqual(["telegram"]);
+  });
+
   it("scopes metadata manifest reconstruction for restrictive startup allowlists", async () => {
     const plugins = [
       createManifestRecord({

--- a/src/plugins/plugin-lookup-table.ts
+++ b/src/plugins/plugin-lookup-table.ts
@@ -1,4 +1,5 @@
 /** Builds plugin lookup tables keyed by manifest ids, channels, providers, and commands. */
+import type { AmbientEnvTriggerPolicy } from "../channels/config-presence.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   createGatewayStartupMetadataPluginIdScope,
@@ -34,6 +35,7 @@ type LoadPluginLookUpTableParams = {
   index?: PluginRegistrySnapshot;
   metadataSnapshot?: PluginMetadataSnapshot;
   workerProviderIds?: readonly string[];
+  ambientEnvTriggers?: AmbientEnvTriggerPolicy;
 };
 
 const lookupTableMemoBySnapshot = new WeakMap<
@@ -50,6 +52,7 @@ export function loadPluginLookUpTable(params: LoadPluginLookUpTableParams): Plug
       : {}),
     env: params.env,
     workerProviderIds,
+    ambientEnvTriggers: params.ambientEnvTriggers,
   });
   const metadataSnapshot =
     params.metadataSnapshot &&
@@ -90,6 +93,7 @@ export function loadPluginLookUpTable(params: LoadPluginLookUpTableParams): Plug
     index,
     manifestRegistry,
     workerProviderIds,
+    ambientEnvTriggers: params.ambientEnvTriggers,
   });
   const startupPlanMs = performance.now() - startupPlanStartedAt;
 


### PR DESCRIPTION
## What Problem This Solves

Channel plugins declare package env triggers in their manifests, and ambient environment variables matching those triggers mark a channel as "configured" in any gateway that inherits them. A dev gateway (`openclaw gateway run --dev`) inherits the operator's shell environment, so real channel credentials exported there (e.g. reef guard keys, bot tokens) silently auto-configured channels in supposedly isolated development instances — which can then connect to live external services. This was observed live: an isolated stress-test dev gateway with an empty `channels` config warned about the operator's reef channel and held an outbound connection to a Telegram data-center range.

## Why This Change Was Made

Maintainer decision after the live incident: dev gateways must not touch real channel surfaces via ambient credentials. Dev mode now drops channel presence signals whose only sources are `env`/`manifest-env`, threaded consistently through activation planning, plugin auto-enable, channel autostart, health monitoring/recovery, readiness, config reloads, and startup warnings. Explicitly configured channels (`channels.<id>` in the dev config) continue to work; a new additive `--dev-ambient-channels` flag restores the previous behavior; suppression is logged once at startup with the affected channel ids and the re-enable hint. Non-dev gateways are completely unchanged, and no new config keys or env vars are introduced.

## User Impact

Developers running `gateway run --dev` get inert-by-default gateways: no accidental connections to production channels from shell credentials. Anyone who intentionally relied on ambient env to configure channels in dev mode passes `--dev-ambient-channels`. Docs updated (`docs/cli/gateway.md`, `docs/help/debugging.md`).

## Evidence

- New/updated tests across nine files: presence-policy suppression (ambient-only dropped, mixed-source retained, default unchanged), blocker warnings, startup planning, autostart, health recovery, readiness, reload, CLI flag validation (`--dev-ambient-channels` without `--dev` errors), and the one-time suppression log. 406 tests pass across the touched surfaces.
- Test-env hygiene: `server-startup-log.test.ts` now scrubs the host's real reef env vars — six of its pre-existing tests failed on any machine exporting those vars (verified on this host); they are deterministic everywhere with this change.
- Targeted oxfmt/oxlint clean, `git diff --check` clean, structured autoreview (Codex `gpt-5.6-sol`, xhigh) clean: "no concrete actionable defect."
