### PR TITLE
fix(ui): prevent narrow chat content overlap

### DIFF
--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -281,7 +281,7 @@ function chatHtml(opts: ChatFixtureOptions = {}, mobileNavLayout = false) {
                       <div class="chat-bubble"><div class="chat-text">Keep this visible.</div></div>
                     </div>
                   </div>
-                  <div class="chat-group assistant">
+                  <div class="chat-group assistant chat-group--with-footer">
                     <div class="chat-avatar assistant">A</div>
                     <div class="chat-group-messages">
                       <div class="chat-bubble"><div class="chat-text">It stays readable.</div></div>
@@ -291,13 +291,13 @@ function chatHtml(opts: ChatFixtureOptions = {}, mobileNavLayout = false) {
                           <pre><code>const importantLongIdentifier = "control-ui-chat-responsive-regression-fixture-keeps-code-scrollable"; console.log(importantLongIdentifier);</code></pre>
                         </div>
                       </div>
-                      <div class="chat-group-footer">
-                        <div class="chat-group-footer__meta">
-                          <span class="chat-sender-name">Assistant</span>
-                          <span class="chat-group-timestamp">9:41 PM</span>
-                        </div>
-                        ${chatFooterActionsHtml()}
+                    </div>
+                    <div class="chat-group-footer">
+                      <div class="chat-group-footer__meta">
+                        <span class="chat-sender-name">Assistant</span>
+                        <span class="chat-group-timestamp">9:41 PM</span>
                       </div>
+                      ${chatFooterActionsHtml()}
                     </div>
                   </div>
                 </div>
@@ -696,20 +696,23 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
             <div class="chat-thread-inner chat-thread-inner--virtual" style="width: 220px;">
               <div class="chat-virtual-sizer" style="height: 400px;">
                 <div class="chat-virtual-row" data-first-row style="transform: translateY(0px);">
-                  <div class="chat-group assistant" style="--chat-message-max-width: 120px;">
+                  <div
+                    class="chat-group assistant chat-group--with-footer"
+                    style="--chat-message-max-width: 120px;"
+                  >
                     <div class="chat-avatar assistant">A</div>
                     <div class="chat-group-messages">
                       <div class="chat-bubble"><div class="chat-text">A narrow assistant message.</div></div>
-                      <div class="chat-group-footer">
-                        <div class="chat-group-footer__meta">
-                          <span class="chat-sender-name">Assistant</span>
-                          <span class="chat-group-timestamp">9:41 PM</span>
-                        </div>
-                        <div class="chat-group-footer-actions">
-                          <button type="button">${iconSvg()}</button>
-                          <button type="button">${iconSvg()}</button>
-                          <button type="button">${iconSvg()}</button>
-                        </div>
+                    </div>
+                    <div class="chat-group-footer">
+                      <div class="chat-group-footer__meta">
+                        <span class="chat-sender-name">Assistant</span>
+                        <span class="chat-group-timestamp">9:41 PM</span>
+                      </div>
+                      <div class="chat-group-footer-actions">
+                        <button type="button">${iconSvg()}</button>
+                        <button type="button">${iconSvg()}</button>
+                        <button type="button">${iconSvg()}</button>
                       </div>
                     </div>
                   </div>
@@ -726,12 +729,18 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
       const layout = await page.evaluate(() => {
         const first = document.querySelector<HTMLElement>("[data-first-row]")!;
         const second = document.querySelector<HTMLElement>("[data-second-row]")!;
+        const avatar = first.querySelector<HTMLElement>(".chat-avatar")!;
+        const bubble = first.querySelector<HTMLElement>(".chat-bubble")!;
         const footer = first.querySelector<HTMLElement>(".chat-group-footer")!;
         second.style.transform = `translateY(${first.getBoundingClientRect().height}px)`;
         const firstRect = first.getBoundingClientRect();
         const secondRect = second.getBoundingClientRect();
+        const avatarRect = avatar.getBoundingClientRect();
+        const bubbleRect = bubble.getBoundingClientRect();
         const footerRect = footer.getBoundingClientRect();
         return {
+          avatarBottom: avatarRect.bottom,
+          bubbleBottom: bubbleRect.bottom,
           firstBottom: firstRect.bottom,
           footerBottom: footerRect.bottom,
           footerHeight: footerRect.height,
@@ -740,6 +749,7 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
       });
 
       expect(layout.footerHeight).toBeGreaterThan(24);
+      expect(layout.bubbleBottom - layout.avatarBottom).toBeCloseTo(4, 0);
       expect(layout.footerBottom).toBeLessThanOrEqual(layout.firstBottom + 1);
       expect(layout.secondTop).toBeGreaterThanOrEqual(layout.firstBottom - 1);
     } finally {
@@ -770,6 +780,7 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
       const lane = await getRect(page, "[data-image-lane]");
       const image = await getRect(page, ".chat-message-image");
       expect(image.width).toBeLessThanOrEqual(lane.width + 1);
+      expect(image.width / image.height).toBeCloseTo(6, 1);
     } finally {
       await closeBrowserPage(page);
     }
@@ -849,6 +860,56 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
       await closeBrowserPage(page);
     }
   });
+
+  it(
+    "remeasures a populated composer when the viewport width changes",
+    FULL_APP_TEST_OPTIONS,
+    async () => {
+      if (!realChatServer) {
+        throw new Error("Expected the Control UI server to be ready");
+      }
+      const page = await openBrowserPage(900, 800);
+      const pageErrors: string[] = [];
+      page.on("pageerror", (error) => pageErrors.push(error.message));
+      try {
+        await installMockGateway(page);
+        await page.goto(`${realChatServer.baseUrl}chat`, {
+          waitUntil: "domcontentloaded",
+          timeout: APP_FIRST_RENDER_TIMEOUT_MS,
+        });
+        const textarea = page.locator(".agent-chat__composer-combobox > textarea");
+        await textarea.waitFor({ timeout: APP_FIRST_RENDER_TIMEOUT_MS });
+        await textarea.fill(
+          "Resize this populated draft across a narrow pane so its wrapped lines change height without waiting for another input event. ".repeat(
+            2,
+          ),
+        );
+        await waitForLayoutSettled(page);
+        const wideHeight = (await textarea.boundingBox())?.height ?? 0;
+
+        await page.setViewportSize({ width: 430, height: 800 });
+        await page.waitForFunction((previousHeight) => {
+          const element = document.querySelector<HTMLTextAreaElement>(
+            ".agent-chat__composer-combobox > textarea",
+          );
+          return element !== null && element.getBoundingClientRect().height > previousHeight + 1;
+        }, wideHeight);
+        const narrowHeight = (await textarea.boundingBox())?.height ?? 0;
+        expect(narrowHeight).toBeGreaterThan(wideHeight + 1);
+
+        await page.setViewportSize({ width: 900, height: 800 });
+        await page.waitForFunction((previousHeight) => {
+          const element = document.querySelector<HTMLTextAreaElement>(
+            ".agent-chat__composer-combobox > textarea",
+          );
+          return element !== null && element.getBoundingClientRect().height < previousHeight - 1;
+        }, narrowHeight);
+        expect(pageErrors.filter((message) => message.includes("ResizeObserver loop"))).toEqual([]);
+      } finally {
+        await closeBrowserPage(page);
+      }
+    },
+  );
 
   it(
     "reveals, pins, and dismisses message context from the timestamp",
@@ -1241,19 +1302,19 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
           `<!doctype html><html><head><style>${readUiCss()}</style></head><body>
             <div class="chat-thread" role="log">
               <div class="chat-thread-inner">
-                <div class="chat-group assistant">
+                <div class="chat-group assistant chat-group--with-footer">
                   <div class="chat-avatar assistant">A</div>
                   <div class="chat-group-messages">
                     <div class="chat-bubble">
                       <div class="chat-text"><p>Done.</p></div>
                     </div>
-                    <div class="chat-group-footer">
-                      <div class="chat-group-footer__meta">
-                        <span class="chat-sender-name">Assistant</span>
-                        <span class="chat-group-timestamp">9:41 PM</span>
-                      </div>
-                      ${chatFooterActionsHtml()}
+                  </div>
+                  <div class="chat-group-footer">
+                    <div class="chat-group-footer__meta">
+                      <span class="chat-sender-name">Assistant</span>
+                      <span class="chat-group-timestamp">9:41 PM</span>
                     </div>
+                    ${chatFooterActionsHtml()}
                   </div>
                 </div>
               </div>

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -96,6 +96,7 @@ function readUiCss(): string {
     "ui/src/styles/chat/text.css",
     "ui/src/styles/chat/grouped.css",
     "ui/src/styles/chat/tool-cards.css",
+    "ui/src/styles/chat/question-card.css",
     "ui/src/styles/chat/sidebar.css",
   ];
   return files.map((file) => readStyleSheet(file)).join("\n");
@@ -682,6 +683,168 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
       }
       expect(configured.thread.width).toBeGreaterThan(defaults.thread.width);
       expect(configured.composer.width).toBeGreaterThan(defaults.composer.width);
+    } finally {
+      await closeBrowserPage(page);
+    }
+  });
+  it("keeps wrapped message footers inside measured virtual rows", async () => {
+    const page = await openBrowserPage(1366, 900);
+    try {
+      await page.setContent(
+        `<!doctype html><html><head><style>${readUiCss()}</style></head><body>
+          <div class="chat-thread" style="width: 220px; height: 400px;">
+            <div class="chat-thread-inner chat-thread-inner--virtual" style="width: 220px;">
+              <div class="chat-virtual-sizer" style="height: 400px;">
+                <div class="chat-virtual-row" data-first-row style="transform: translateY(0px);">
+                  <div class="chat-group assistant" style="--chat-message-max-width: 120px;">
+                    <div class="chat-avatar assistant">A</div>
+                    <div class="chat-group-messages">
+                      <div class="chat-bubble"><div class="chat-text">A narrow assistant message.</div></div>
+                      <div class="chat-group-footer">
+                        <div class="chat-group-footer__meta">
+                          <span class="chat-sender-name">Assistant</span>
+                          <span class="chat-group-timestamp">9:41 PM</span>
+                        </div>
+                        <div class="chat-group-footer-actions">
+                          <button type="button">${iconSvg()}</button>
+                          <button type="button">${iconSvg()}</button>
+                          <button type="button">${iconSvg()}</button>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div class="chat-virtual-row" data-second-row>
+                  <div class="chat-group user"><div class="chat-group-messages">Next row</div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </body></html>`,
+      );
+
+      const layout = await page.evaluate(() => {
+        const first = document.querySelector<HTMLElement>("[data-first-row]")!;
+        const second = document.querySelector<HTMLElement>("[data-second-row]")!;
+        const footer = first.querySelector<HTMLElement>(".chat-group-footer")!;
+        second.style.transform = `translateY(${first.getBoundingClientRect().height}px)`;
+        const firstRect = first.getBoundingClientRect();
+        const secondRect = second.getBoundingClientRect();
+        const footerRect = footer.getBoundingClientRect();
+        return {
+          firstBottom: firstRect.bottom,
+          footerBottom: footerRect.bottom,
+          footerHeight: footerRect.height,
+          secondTop: secondRect.top,
+        };
+      });
+
+      expect(layout.footerHeight).toBeGreaterThan(24);
+      expect(layout.footerBottom).toBeLessThanOrEqual(layout.firstBottom + 1);
+      expect(layout.secondTop).toBeGreaterThanOrEqual(layout.firstBottom - 1);
+    } finally {
+      await closeBrowserPage(page);
+    }
+  });
+
+  it("keeps attached images within narrow message lanes", async () => {
+    const page = await openBrowserPage(320, 568);
+    try {
+      await page.setContent(
+        `<!doctype html><html><head><style>${readUiCss()}</style></head><body>
+          <div data-image-lane style="width: 180px;">
+            <div class="chat-message-images">
+              <img
+                class="chat-message-image"
+                width="600"
+                height="100"
+                alt="Wide attachment"
+                src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='600' height='100'%3E%3C/svg%3E"
+              />
+            </div>
+          </div>
+        </body></html>`,
+      );
+      await page.locator(".chat-message-image").waitFor();
+
+      const lane = await getRect(page, "[data-image-lane]");
+      const image = await getRect(page, ".chat-message-image");
+      expect(image.width).toBeLessThanOrEqual(lane.width + 1);
+    } finally {
+      await closeBrowserPage(page);
+    }
+  });
+
+  it("wraps long question and approval metadata inside narrow cards", async () => {
+    const page = await openBrowserPage(320, 568);
+    try {
+      const longToken = `workspace${"x".repeat(240)}session`;
+      await page.setContent(
+        `<!doctype html><html><head><style>${readUiCss()}</style></head><body>
+          <div data-narrow-card style="width: 220px;">
+            <div class="chat-question-panel__heading">
+              <span class="chat-question-panel__progress">1/1</span>
+              <span class="chat-question-panel__prompt">${longToken}</span>
+            </div>
+            <div class="exec-approval-meta">
+              <div class="exec-approval-meta-row"><span>Session</span><span>${longToken}</span></div>
+            </div>
+          </div>
+        </body></html>`,
+      );
+
+      const metrics = await page.evaluate(() => {
+        const card = document.querySelector<HTMLElement>("[data-narrow-card]")!;
+        const heading = document.querySelector<HTMLElement>(".chat-question-panel__heading")!;
+        const row = document.querySelector<HTMLElement>(".exec-approval-meta-row")!;
+        return {
+          cardRight: card.getBoundingClientRect().right,
+          headingRight: heading.getBoundingClientRect().right,
+          promptRight: document
+            .querySelector<HTMLElement>(".chat-question-panel__prompt")!
+            .getBoundingClientRect().right,
+          rowRight: row.getBoundingClientRect().right,
+          valueRight: row.lastElementChild!.getBoundingClientRect().right,
+        };
+      });
+
+      expect(metrics.promptRight).toBeLessThanOrEqual(metrics.headingRight + 1);
+      expect(metrics.valueRight).toBeLessThanOrEqual(metrics.rowRight + 1);
+      expect(metrics.headingRight).toBeLessThanOrEqual(metrics.cardRight + 1);
+      expect(metrics.rowRight).toBeLessThanOrEqual(metrics.cardRight + 1);
+    } finally {
+      await closeBrowserPage(page);
+    }
+  });
+
+  it("reserves command text space for flush tool-card actions", async () => {
+    const page = await openBrowserPage(320, 568);
+    try {
+      await page.setContent(
+        `<!doctype html><html><head><style>${readUiCss()}</style></head><body>
+          <div class="chat-tool-card chat-tool-card--flush" style="width: 220px;">
+            <div class="chat-tool-card__actions">
+              <button class="chat-tool-card__action-btn" type="button">${iconSvg()}</button>
+            </div>
+            <div class="chat-tool-term">
+              <div class="chat-tool-term__cmd"><span class="chat-tool-term__prompt">$</span><code>command with a long first line</code></div>
+            </div>
+          </div>
+        </body></html>`,
+      );
+
+      const layout = await page.evaluate(() => {
+        const command = document.querySelector<HTMLElement>(".chat-tool-term__cmd")!;
+        const actions = document.querySelector<HTMLElement>(".chat-tool-card__actions")!;
+        const commandRect = command.getBoundingClientRect();
+        return {
+          actionLeft: actions.getBoundingClientRect().left,
+          commandContentRight:
+            commandRect.right - Number.parseFloat(getComputedStyle(command).paddingRight),
+        };
+      });
+
+      expect(layout.commandContentRight).toBeLessThanOrEqual(layout.actionLeft + 1);
     } finally {
       await closeBrowserPage(page);
     }

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -2892,6 +2892,14 @@ describe("chat composer sizing", () => {
 
   it("resizes the draft when responsive layout changes the textarea width", () => {
     let resizeCallback: ResizeObserverCallback | undefined;
+    let animationFrameCallback: FrameRequestCallback | undefined;
+    let nextAnimationFrameId = 0;
+    const requestAnimationFrameMock = vi.fn((callback: FrameRequestCallback) => {
+      animationFrameCallback = callback;
+      nextAnimationFrameId += 1;
+      return nextAnimationFrameId;
+    });
+    const cancelAnimationFrameMock = vi.fn();
     class TestResizeObserver {
       constructor(callback: ResizeObserverCallback) {
         resizeCallback = callback;
@@ -2904,44 +2912,59 @@ describe("chat composer sizing", () => {
       }
     }
     vi.stubGlobal("ResizeObserver", TestResizeObserver);
+    vi.stubGlobal("requestAnimationFrame", requestAnimationFrameMock);
+    vi.stubGlobal("cancelAnimationFrame", cancelAnimationFrameMock);
+
+    let width = 320;
+    let scrollHeight = 42;
+    let clientHeight = 42;
+    vi.spyOn(HTMLTextAreaElement.prototype, "getBoundingClientRect").mockImplementation(() => ({
+      bottom: clientHeight,
+      height: clientHeight,
+      left: 0,
+      right: width,
+      top: 0,
+      width,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    }));
+
     const container = renderChatView({});
     const textarea = requireElement(
       container,
       ".agent-chat__composer-combobox > textarea",
       "composer textarea",
     ) as HTMLTextAreaElement;
-    let width = 320;
-    let scrollHeight = 42;
-    let clientHeight = 42;
     Object.defineProperties(textarea, {
       scrollHeight: { configurable: true, get: () => scrollHeight },
       clientHeight: { configurable: true, get: () => clientHeight },
-      getBoundingClientRect: {
-        configurable: true,
-        value: () => ({
-          bottom: 0,
-          height: clientHeight,
-          left: 0,
-          right: width,
-          top: 0,
-          width,
-          x: 0,
-          y: 0,
-          toJSON: () => ({}),
-        }),
-      },
     });
     textarea.dispatchEvent(new InputEvent("input", { bubbles: true }));
     expect(textarea.style.height).toBe("42px");
     expect(textarea.style.overflowY).toBe("hidden");
 
+    scrollHeight = 180;
+    clientHeight = 150;
+    resizeCallback?.([], {} as ResizeObserver);
+    expect(textarea.style.overflowY).toBe("auto");
+    expect(requestAnimationFrameMock).not.toHaveBeenCalled();
+
     width = 180;
     scrollHeight = 120;
     clientHeight = 120;
     resizeCallback?.([], {} as ResizeObserver);
+    expect(requestAnimationFrameMock).toHaveBeenCalledOnce();
+    expect(textarea.style.height).toBe("42px");
 
+    animationFrameCallback?.(0);
     expect(textarea.style.height).toBe("120px");
     expect(textarea.style.overflowY).toBe("hidden");
+
+    width = 160;
+    resizeCallback?.([], {} as ResizeObserver);
+    render(html``, container);
+    expect(cancelAnimationFrameMock).toHaveBeenCalledWith(2);
   });
 });
 

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -2890,7 +2890,7 @@ describe("chat composer sizing", () => {
     expect(textarea.style.overflowY).toBe("auto");
   });
 
-  it("rechecks overflow when responsive layout changes the textarea height", () => {
+  it("resizes the draft when responsive layout changes the textarea width", () => {
     let resizeCallback: ResizeObserverCallback | undefined;
     class TestResizeObserver {
       constructor(callback: ResizeObserverCallback) {
@@ -2910,20 +2910,38 @@ describe("chat composer sizing", () => {
       ".agent-chat__composer-combobox > textarea",
       "composer textarea",
     ) as HTMLTextAreaElement;
+    let width = 320;
     let scrollHeight = 42;
     let clientHeight = 42;
     Object.defineProperties(textarea, {
       scrollHeight: { configurable: true, get: () => scrollHeight },
       clientHeight: { configurable: true, get: () => clientHeight },
+      getBoundingClientRect: {
+        configurable: true,
+        value: () => ({
+          bottom: 0,
+          height: clientHeight,
+          left: 0,
+          right: width,
+          top: 0,
+          width,
+          x: 0,
+          y: 0,
+          toJSON: () => ({}),
+        }),
+      },
     });
     textarea.dispatchEvent(new InputEvent("input", { bubbles: true }));
+    expect(textarea.style.height).toBe("42px");
     expect(textarea.style.overflowY).toBe("hidden");
 
+    width = 180;
     scrollHeight = 120;
-    clientHeight = 56;
+    clientHeight = 120;
     resizeCallback?.([], {} as ResizeObserver);
 
-    expect(textarea.style.overflowY).toBe("auto");
+    expect(textarea.style.height).toBe("120px");
+    expect(textarea.style.overflowY).toBe("hidden");
   });
 });
 

--- a/ui/src/pages/chat/components/chat-composer.ts
+++ b/ui/src/pages/chat/components/chat-composer.ts
@@ -377,7 +377,16 @@ function observeTextareaOverflow(el: HTMLTextAreaElement) {
   if (typeof ResizeObserver !== "function" || composerTextareaResizeObservers.has(el)) {
     return;
   }
-  const observer = new ResizeObserver(() => updateTextareaOverflow(el));
+  let width = el.getBoundingClientRect().width;
+  const observer = new ResizeObserver(() => {
+    const nextWidth = el.getBoundingClientRect().width;
+    if (nextWidth !== width) {
+      width = nextWidth;
+      adjustTextareaHeight(el);
+      return;
+    }
+    updateTextareaOverflow(el);
+  });
   observer.observe(el);
   composerTextareaResizeObservers.set(el, observer);
 }

--- a/ui/src/pages/chat/components/chat-composer.ts
+++ b/ui/src/pages/chat/components/chat-composer.ts
@@ -357,7 +357,15 @@ export function resetChatComposerState(paneId?: string) {
   goalElapsedTimers.clear();
 }
 
-const composerTextareaResizeObservers = new WeakMap<HTMLTextAreaElement, ResizeObserver>();
+type ComposerTextareaResizeObserverState = {
+  observer: ResizeObserver;
+  adjustmentFrame: number | null;
+};
+
+const composerTextareaResizeObservers = new WeakMap<
+  HTMLTextAreaElement,
+  ComposerTextareaResizeObserverState
+>();
 const questionDockResizeObservers = new WeakMap<HTMLElement, ResizeObserver>();
 
 function updateTextareaOverflow(el: HTMLTextAreaElement) {
@@ -382,18 +390,33 @@ function observeTextareaOverflow(el: HTMLTextAreaElement) {
     const nextWidth = el.getBoundingClientRect().width;
     if (nextWidth !== width) {
       width = nextWidth;
-      adjustTextareaHeight(el);
+      const state = composerTextareaResizeObservers.get(el);
+      if (state && state.adjustmentFrame === null) {
+        state.adjustmentFrame = requestAnimationFrame(() => {
+          state.adjustmentFrame = null;
+          if (composerTextareaResizeObservers.get(el) === state) {
+            adjustTextareaHeight(el);
+          }
+        });
+      }
       return;
     }
     updateTextareaOverflow(el);
   });
   observer.observe(el);
-  composerTextareaResizeObservers.set(el, observer);
+  composerTextareaResizeObservers.set(el, { observer, adjustmentFrame: null });
 }
 
 function disconnectTextareaOverflowObserver(el: HTMLTextAreaElement) {
-  composerTextareaResizeObservers.get(el)?.disconnect();
+  const state = composerTextareaResizeObservers.get(el);
   composerTextareaResizeObservers.delete(el);
+  if (!state) {
+    return;
+  }
+  state.observer.disconnect();
+  if (state.adjustmentFrame !== null) {
+    cancelAnimationFrame(state.adjustmentFrame);
+  }
 }
 
 function syncQuestionDockHeight(el: HTMLElement): void {

--- a/ui/src/pages/chat/components/chat-message.ts
+++ b/ui/src/pages/chat/components/chat-message.ts
@@ -683,7 +683,9 @@ export function renderStreamGroup(parts: StreamGroupPart[], opts: StreamGroupOpt
 
   return html`
     <div
-      class="chat-group assistant ${workingOnly ? "chat-group--working" : ""}"
+      class="chat-group assistant ${workingOnly
+        ? "chat-group--working"
+        : "chat-group--with-footer"}"
       data-chat-row-key=${parts[0]?.key ?? nothing}
     >
       ${avatar}
@@ -709,17 +711,17 @@ export function renderStreamGroup(parts: StreamGroupPart[], opts: StreamGroupOpt
                     onOpenSidebar,
                   ),
         )}
-        ${footerStartedAt !== null
-          ? html`
-              <div class="chat-group-footer">
-                <div class="chat-group-footer__meta">
-                  <span class="chat-sender-name">${name}</span>
-                  ${renderChatTimestamp(footerStartedAt)}
-                </div>
-              </div>
-            `
-          : nothing}
       </div>
+      ${footerStartedAt !== null
+        ? html`
+            <div class="chat-group-footer">
+              <div class="chat-group-footer__meta">
+                <span class="chat-sender-name">${name}</span>
+                ${renderChatTimestamp(footerStartedAt)}
+              </div>
+            </div>
+          `
+        : nothing}
     </div>
   `;
 }
@@ -923,7 +925,10 @@ export function renderMessageGroup(group: MessageGroup, opts: RenderMessageGroup
     const activityExpanded = opts.isToolMessageExpanded?.(activityDisclosureId) ?? hasError;
 
     return html`
-      <div class="chat-group tool chat-group--activity" data-chat-row-key=${group.key}>
+      <div
+        class="chat-group tool chat-group--activity chat-group--with-footer"
+        data-chat-row-key=${group.key}
+      >
         ${renderChatAvatar(
           group.role,
           {
@@ -985,11 +990,11 @@ export function renderMessageGroup(group: MessageGroup, opts: RenderMessageGroup
                 `
               : nothing}
           </div>
-          <div class="chat-group-footer">
-            <span class="chat-sender-name">${t("chat.messages.activity")}</span>
-            ${renderChatTimestamp(group.timestamp)}
-            ${opts.onDelete ? renderDeleteButton(opts.onDelete, "right") : nothing}
-          </div>
+        </div>
+        <div class="chat-group-footer">
+          <span class="chat-sender-name">${t("chat.messages.activity")}</span>
+          ${renderChatTimestamp(group.timestamp)}
+          ${opts.onDelete ? renderDeleteButton(opts.onDelete, "right") : nothing}
         </div>
       </div>
     `;
@@ -1016,7 +1021,9 @@ export function renderMessageGroup(group: MessageGroup, opts: RenderMessageGroup
 
   return html`
     <div
-      class="chat-group ${roleClass}${senderHue === null ? "" : " chat-group--sender-tint"}"
+      class="chat-group ${roleClass} chat-group--with-footer${senderHue === null
+        ? ""
+        : " chat-group--sender-tint"}"
       style=${senderHue === null ? nothing : `--chat-sender-hue: ${senderHue}`}
       data-chat-row-key=${group.key}
     >
@@ -1053,38 +1060,38 @@ export function renderMessageGroup(group: MessageGroup, opts: RenderMessageGroup
               : nothing}
           `;
         })}
-        <div class="chat-group-footer">
-          <div class="chat-group-footer__meta">
-            ${opts.onRewind && normalizedRole === "user"
-              ? renderRewindButton(opts.onRewind, Boolean(opts.rewindDisabled), "left")
-              : nothing}
-            ${opts.onDelete && normalizedRole === "user"
-              ? renderDeleteButton(opts.onDelete, "left")
-              : nothing}
-            ${normalizedRole === "user" ? renderChatAuthorAvatar(group.sender) : nothing}
-            <span class="chat-sender-name">${who}</span>
-            ${renderMessageMeta(group.timestamp, meta)}
-          </div>
-          ${footerActionDetails || (opts.onDelete && normalizedRole !== "user")
-            ? html`
-                <div
-                  class="chat-group-footer-actions"
-                  data-message-actions-for=${group.messages[lastMessageIndex]?.key ?? nothing}
-                >
-                  ${footerActionDetails
-                    ? renderMessageActionButtons(
-                        footerActionDetails,
-                        opts,
-                        opts.onOpenSidebar,
-                        normalizedRole !== "user" ? opts.onDelete : undefined,
-                      )
-                    : opts.onDelete && normalizedRole !== "user"
-                      ? renderDeleteButton(opts.onDelete, "right")
-                      : nothing}
-                </div>
-              `
+      </div>
+      <div class="chat-group-footer">
+        <div class="chat-group-footer__meta">
+          ${opts.onRewind && normalizedRole === "user"
+            ? renderRewindButton(opts.onRewind, Boolean(opts.rewindDisabled), "left")
             : nothing}
+          ${opts.onDelete && normalizedRole === "user"
+            ? renderDeleteButton(opts.onDelete, "left")
+            : nothing}
+          ${normalizedRole === "user" ? renderChatAuthorAvatar(group.sender) : nothing}
+          <span class="chat-sender-name">${who}</span>
+          ${renderMessageMeta(group.timestamp, meta)}
         </div>
+        ${footerActionDetails || (opts.onDelete && normalizedRole !== "user")
+          ? html`
+              <div
+                class="chat-group-footer-actions"
+                data-message-actions-for=${group.messages[lastMessageIndex]?.key ?? nothing}
+              >
+                ${footerActionDetails
+                  ? renderMessageActionButtons(
+                      footerActionDetails,
+                      opts,
+                      opts.onOpenSidebar,
+                      normalizedRole !== "user" ? opts.onDelete : undefined,
+                    )
+                  : opts.onDelete && normalizedRole !== "user"
+                    ? renderDeleteButton(opts.onDelete, "right")
+                    : nothing}
+              </div>
+            `
+          : nothing}
       </div>
     </div>
   `;

--- a/ui/src/pages/chat/components/chat-message.ts
+++ b/ui/src/pages/chat/components/chat-message.ts
@@ -680,14 +680,10 @@ export function renderStreamGroup(parts: StreamGroupPart[], opts: StreamGroupOpt
   const avatar = workingOnly
     ? nothing
     : renderChatAvatar("assistant", assistant, undefined, basePath, authToken);
+  const groupClass = `chat-group assistant${workingOnly ? " chat-group--working" : ""}${footerStartedAt !== null ? " chat-group--with-footer" : ""}`;
 
   return html`
-    <div
-      class="chat-group assistant ${workingOnly
-        ? "chat-group--working"
-        : "chat-group--with-footer"}"
-      data-chat-row-key=${parts[0]?.key ?? nothing}
-    >
+    <div class=${groupClass} data-chat-row-key=${parts[0]?.key ?? nothing}>
       ${avatar}
       <div class="chat-group-messages">
         ${parts.map((part) =>

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -2,11 +2,9 @@
    GROUPED CHAT LAYOUT (Slack-style)
    ============================================= */
 
-/* Chat Group Layout - default (assistant/other on left). The bottom PADDING
-   is the thread's rhythm unit and doubles as the reveal zone for the
-   overlaid hover footer: padding (not margin) keeps the gap inside the
-   group's hover box so the pointer can travel to the footer without it
-   vanishing mid-way. */
+/* Chat Group Layout - default (assistant/other on left). Groups without a
+   footer keep the shared 26px rhythm directly; footer-bearing groups get the
+   same space from the message-column gap plus the footer's measured height. */
 .chat-group {
   display: flex;
   gap: 10px;
@@ -16,6 +14,10 @@
   margin-right: 16px;
 }
 
+.chat-group:has(> .chat-group-messages > .chat-group-footer) {
+  padding-bottom: 0;
+}
+
 /* User messages on right */
 .chat-group.user {
   flex-direction: row-reverse;
@@ -23,7 +25,7 @@
 }
 
 .chat-group-messages {
-  position: relative; /* anchors the overlaid hover footer */
+  position: relative; /* anchors message-local popovers */
   display: flex;
   flex-direction: column;
   gap: 2px;
@@ -47,26 +49,18 @@
   justify-content: flex-end;
 }
 
-/* Footer at bottom of message group (role + time). Hidden until the group is
-   hovered/focused so the thread reads as a clean stream; overlaid into the
-   group's bottom margin (no reserved flow height) so message rhythm stays
-   even. Touch devices restore the in-flow always-visible footer below. */
+/* Footer at bottom of a message group (role + time). It stays in flow while
+   visually hidden so wrapped controls contribute to virtual-row measurement
+   instead of painting over the next message. */
 .chat-group-footer {
-  position: absolute;
-  top: 100%;
-  left: 0;
-  right: 0;
-  z-index: 1; /* revealed overlay paints above the next group's leading edge */
   display: flex;
-  /* Wrap instead of clipping in narrow lanes (extreme chatMessageMaxWidth,
-     slim split panes): a wrapped revealed footer may transiently overlap the
-     next group, but every control stays reachable. Hidden overlays must not
-     intercept pointer input, so hit-testing is gated on the reveal. */
+  align-self: stretch;
   flex-wrap: wrap;
   gap: 8px;
   align-items: center;
+  width: 100%;
   min-width: 0;
-  margin-top: 1px;
+  min-height: 24px;
   opacity: 0;
   pointer-events: none;
   transition: opacity 120ms ease-out;
@@ -111,8 +105,8 @@
   margin-top: 4px;
 }
 
-/* Single line, ellipsized: the footer overlays a fixed 26px rhythm gap, so
-   long configurable sender names must never wrap it taller than the gap. */
+/* Keep long configurable sender names compact while footer actions retain
+   their reachable wrapped layout in narrow panes. */
 .chat-sender-name {
   font-weight: 500;
   font-size: 12px;
@@ -499,17 +493,14 @@ img.chat-avatar {
 @media (hover: none),
   (max-width: 768px),
   (max-width: 932px) and (max-height: 500px) and (orientation: landscape) {
-  /* No hover to reveal an overlay: restore the in-flow always-visible footer
-     and the tighter rhythm that accounts for its height. */
+  /* No hover to reveal the footer: keep it always visible and add a little
+     more separation from the next group. */
   .chat-group {
     padding-bottom: 0;
     margin-bottom: 14px;
   }
 
   .chat-group-footer {
-    position: static;
-    flex-wrap: wrap;
-    width: 100%;
     margin-top: 4px;
     opacity: 1;
     pointer-events: auto;

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -3,9 +3,11 @@
    ============================================= */
 
 /* Chat Group Layout - default (assistant/other on left). Groups without a
-   footer keep the shared 26px rhythm directly; footer-bearing groups get the
-   same space from the message-column gap plus the footer's measured height. */
+   footer keep the shared 26px rhythm directly. Footer-bearing groups split
+   message content and footer into separate rows so each row keeps the avatar
+   gutter while only the message row controls avatar alignment. */
 .chat-group {
+  --chat-message-column-max: var(--chat-message-max-width, min(900px, 68%));
   display: flex;
   gap: 10px;
   align-items: flex-start;
@@ -14,14 +16,45 @@
   margin-right: 16px;
 }
 
-.chat-group:has(> .chat-group-messages > .chat-group-footer) {
-  padding-bottom: 0;
-}
-
 /* User messages on right */
 .chat-group.user {
   flex-direction: row-reverse;
   justify-content: flex-start;
+}
+
+.chat-group.chat-group--with-footer {
+  --chat-group-avatar-column: 1;
+  --chat-group-content-column: 2;
+  display: grid;
+  grid-template-columns: 36px minmax(0, var(--chat-message-column-max));
+  grid-template-rows: auto auto;
+  gap: 2px 10px;
+  justify-content: start;
+  padding-bottom: 0;
+}
+
+.chat-group.user.chat-group--with-footer {
+  --chat-group-avatar-column: 2;
+  --chat-group-content-column: 1;
+  grid-template-columns: minmax(0, var(--chat-message-column-max)) 36px;
+  justify-content: end;
+}
+
+.chat-group.chat-group--with-footer .chat-avatar {
+  grid-column: var(--chat-group-avatar-column);
+  grid-row: 1;
+}
+
+.chat-group.chat-group--with-footer > .chat-group-messages {
+  grid-column: var(--chat-group-content-column);
+  grid-row: 1;
+  max-width: none;
+}
+
+.chat-group.chat-group--with-footer > .chat-group-footer {
+  grid-column: var(--chat-group-content-column);
+  grid-row: 2;
+  max-width: none;
 }
 
 .chat-group-messages {
@@ -30,9 +63,9 @@
   flex-direction: column;
   gap: 2px;
   flex: 1 1 auto;
-  width: 100%;
-  max-width: var(--chat-message-max-width, min(900px, 68%));
   align-items: flex-start;
+  width: 100%;
+  max-width: var(--chat-message-column-max);
   min-width: 0;
 }
 
@@ -41,8 +74,8 @@
   align-items: flex-end;
 }
 
-.chat-group.tool .chat-group-messages {
-  max-width: var(--chat-message-max-width, min(980px, calc(100% - 46px)));
+.chat-group.tool {
+  --chat-message-column-max: var(--chat-message-max-width, min(980px, calc(100% - 46px)));
 }
 
 .chat-group.user .chat-group-footer {
@@ -422,8 +455,8 @@ img.chat-avatar {
 /* Assistant replies render as a flat text stream: only user messages keep the
    bubble card. Border collapses to 0 so the streaming border pulse and hover
    outline become no-ops without extra rules. */
-.chat-group.assistant .chat-group-messages {
-  max-width: var(--chat-message-max-width, min(980px, calc(100% - 46px)));
+.chat-group.assistant {
+  --chat-message-column-max: var(--chat-message-max-width, min(980px, calc(100% - 46px)));
 }
 
 .chat-group.assistant .chat-bubble {
@@ -461,12 +494,15 @@ img.chat-avatar {
   margin-inline: 0;
 }
 
-.chat-thread--direct .chat-group.assistant .chat-group-messages {
-  max-width: var(--chat-message-max-width, min(980px, 100%));
+.chat-thread--direct .chat-group.chat-group--with-footer {
+  --chat-group-avatar-column: 1;
+  --chat-group-content-column: 1;
+  grid-template-columns: minmax(0, var(--chat-message-column-max));
 }
 
-.chat-thread--direct .chat-group.tool .chat-group-messages {
-  max-width: var(--chat-message-max-width, min(980px, 100%));
+.chat-thread--direct .chat-group.assistant,
+.chat-thread--direct .chat-group.tool {
+  --chat-message-column-max: var(--chat-message-max-width, min(980px, 100%));
 }
 
 .chat-duplicate-count {
@@ -872,23 +908,31 @@ details.msg-meta:not([open]) .msg-meta__details {
 
 @media (max-width: 768px), (max-width: 932px) and (max-height: 500px) and (orientation: landscape) {
   .chat-group {
+    --chat-message-column-max: 82%;
     margin-left: 0;
     margin-right: 0;
   }
 
-  .chat-group-messages {
-    max-width: 82%;
-  }
-
-  .chat-group.tool .chat-group-messages,
-  .chat-group.assistant .chat-group-messages {
-    max-width: calc(100% - 46px);
+  .chat-group.tool,
+  .chat-group.assistant {
+    --chat-message-column-max: calc(100% - 46px);
   }
 }
 
 @media (max-width: 400px) {
-  .chat-group-messages {
-    max-width: 88%;
+  .chat-group {
+    --chat-message-column-max: 88%;
+  }
+
+  .chat-group.chat-group--with-footer {
+    --chat-group-avatar-column: 1;
+    --chat-group-content-column: 1;
+    grid-template-columns: minmax(0, var(--chat-message-column-max));
+  }
+
+  .chat-group.tool,
+  .chat-group.assistant {
+    --chat-message-column-max: calc(100% - 46px);
   }
 
   .chat-avatar,

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -1031,7 +1031,9 @@ openclaw-chat-page {
 }
 
 .chat-message-image {
-  max-width: 300px;
+  width: auto;
+  max-width: min(100%, 300px);
+  height: auto;
   max-height: 200px;
   border-radius: var(--radius-md);
   object-fit: contain;

--- a/ui/src/styles/chat/question-card.css
+++ b/ui/src/styles/chat/question-card.css
@@ -189,10 +189,12 @@ openclaw-chat-question-panel {
 }
 
 .chat-question-panel__prompt {
+  min-width: 0;
   color: var(--text-strong);
   font-size: var(--control-ui-text-md);
   font-weight: 600;
   line-height: 1.45;
+  overflow-wrap: anywhere;
 }
 
 .chat-question-panel__options {

--- a/ui/src/styles/chat/tool-cards.css
+++ b/ui/src/styles/chat/tool-cards.css
@@ -559,6 +559,10 @@
   transition: opacity 120ms ease;
 }
 
+.chat-tool-card--flush:has(> .chat-tool-card__actions) .chat-tool-term__cmd {
+  padding-right: 42px;
+}
+
 .chat-tool-card--flush:hover > .chat-tool-card__actions,
 .chat-tool-card--flush:focus-within > .chat-tool-card__actions {
   opacity: 1;

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -2992,8 +2992,11 @@ td.data-table-key-col {
 }
 
 .exec-approval-meta-row span:last-child {
+  min-width: 0;
   color: var(--text);
   font-family: var(--mono);
+  overflow-wrap: anywhere;
+  text-align: right;
 }
 
 .exec-approval-error {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users resizing the web chat into narrow panes could see message footer controls overlap the next message, while long composer drafts retained a height measured at the previous width. The same narrow layouts could also clip attached images, long question or approval metadata, and the first line of command output beneath a floating action button.

## Why This Change Was Made

Message footers now stay in measured flow while remaining visually hidden until hover or focus, so wrapping controls expand the virtualized row instead of painting over its neighbor. The composer re-runs auto-height when its width changes, and existing content owners now constrain images, unbroken prompts and metadata, and flush command actions within the available lane.

This is an AI-assisted change. I reviewed the ownership boundaries, reproduced the layout failures in the deterministic mock UI, and verified the final behavior with focused and full responsive suites.

## User Impact

The web chat remains readable while panes and windows are resized. Wrapped message actions stay separated from adjacent messages, long drafts grow or shrink to their new line wrapping, and narrow panes keep media and metadata visible without horizontal clipping or text being covered by controls.

## Evidence

### Before / after

![Before and after: a wrapped footer overlaps the next narrow-pane message before the fix and expands its measured row after the fix](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/2026-07-web-chat-layout-audit/before-after.png)

### Browser and test proof

- Blacksmith Testbox: full `ui/src/pages/chat/chat-responsive.browser.test.ts` — 66/66 passed; focused composer sizing — 3/3 passed. [Run 29794686342](https://github.com/openclaw/openclaw/actions/runs/29794686342), Testbox `tbx_01ky16f1tmnxcfv779d39djvkh`.
- Blacksmith Testbox changed-file gate: formatting, conflict checks, UI i18n verification, core-test and UI typechecks, and core/UI lint all passed. [Run 29792958910](https://github.com/openclaw/openclaw/actions/runs/29792958910), Testbox `tbx_01ky149emxaxxqksdg39d3z2vp`.
- Focused local Node 24 proof:
  - `node scripts/run-vitest.mjs ui/src/pages/chat/chat-view.test.ts -t "chat composer sizing"` — 3 passed.
  - `node scripts/run-vitest.mjs ui/src/pages/chat/chat-responsive.browser.test.ts -t "keeps wrapped message footers|keeps attached images|wraps long question|reserves command text"` — 4 passed.
  - The existing message-context hover case passed alone; the complete Testbox browser file then passed all 66 cases.
- Manual browser audit covered hosted desktop/mobile chat and the deterministic mock UI at a 320px split-pane minimum, including footer wrapping, transcript geometry, composer anchoring, images, long unbroken metadata, and command action overlays.
- `git diff --check` passed.
