### PR TITLE
fix: message sends fail when optional location is blank

### DIFF
--- a/src/infra/outbound/message-action-runner.plugin-dispatch.test.ts
+++ b/src/infra/outbound/message-action-runner.plugin-dispatch.test.ts
@@ -2312,10 +2312,8 @@ describe("runMessageAction plugin dispatch", () => {
               enabled: true,
             },
           },
-          messages: {
-            tts: {
-              auto: "tagged",
-            },
+          tts: {
+            auto: "tagged",
           },
         } as OpenClawConfig,
         action: "send",
@@ -2389,10 +2387,8 @@ describe("runMessageAction plugin dispatch", () => {
               enabled: true,
             },
           },
-          messages: {
-            tts: {
-              auto: "tagged",
-            },
+          tts: {
+            auto: "tagged",
           },
         } as OpenClawConfig,
         action: "send",
@@ -2835,7 +2831,10 @@ describe("runMessageAction plugin dispatch", () => {
     const handleAction = vi.fn(
       async ({ cfg, params }: { cfg: OpenClawConfig; params: Record<string, unknown> }) => {
         const message = typeof params.message === "string" ? params.message : "";
-        const responsePrefix = cfg.messages?.responsePrefix;
+        const responsePrefix = Object.values(cfg.channels ?? {}).find(
+          (entry): entry is { responsePrefix?: string } =>
+            typeof entry === "object" && entry !== null && "responsePrefix" in entry,
+        )?.responsePrefix;
         const rawMessage =
           responsePrefix && message.startsWith(`${responsePrefix} `)
             ? message.slice(responsePrefix.length + 1)
@@ -3151,9 +3150,9 @@ describe("runMessageAction plugin dispatch", () => {
           channels: {
             cardchat: {
               enabled: true,
+              responsePrefix: "[Nexus]",
             },
           },
-          messages: { responsePrefix: "[Nexus]" },
         } as OpenClawConfig,
         action: "send",
         params: {

--- a/src/infra/outbound/message-action-runner.plugin-dispatch.test.ts
+++ b/src/infra/outbound/message-action-runner.plugin-dispatch.test.ts
@@ -2938,6 +2938,51 @@ describe("runMessageAction plugin dispatch", () => {
       expectRecordFields(gatewayActionParams, { presentation }, "gateway action params");
     });
 
+    it("omits a blank shared-schema location from gateway-routed sends", async () => {
+      const cfg = {
+        channels: {
+          cardchat: {
+            enabled: true,
+          },
+        },
+        messages: { responsePrefix: "[Nexus]" },
+      } as OpenClawConfig;
+      mocks.callGatewayLeastPrivilege.mockResolvedValueOnce({
+        ok: true,
+        messageId: "card-location",
+      });
+
+      const result = await runMessageAction({
+        cfg,
+        action: "send",
+        params: {
+          channel: "cardchat",
+          target: "channel:test-card",
+          message: "hello",
+          location: "",
+        },
+        gateway: {
+          clientName: "cli",
+          mode: "cli",
+        },
+        dryRun: false,
+      });
+
+      expect(result.kind).toBe("send");
+      expect(result.handledBy).toBe("plugin");
+      expect(handleAction).not.toHaveBeenCalled();
+      const gatewayCall = readMockCallArg(
+        mocks.callGatewayLeastPrivilege,
+        "gateway least privilege call",
+      );
+      const gatewayActionParams = readRecordField(
+        readRecordField(gatewayCall, "params", "gateway call params"),
+        "params",
+        "gateway action params",
+      );
+      expect(gatewayActionParams).not.toHaveProperty("location");
+    });
+
     it("keeps gateway-routed chart presentations on the gateway", async () => {
       const presentation = {
         blocks: [

--- a/src/infra/outbound/message-action-runner.send-validation.test.ts
+++ b/src/infra/outbound/message-action-runner.send-validation.test.ts
@@ -473,20 +473,23 @@ describe("runMessageAction send validation", () => {
     expect(result.kind).toBe("send");
   });
 
-  it("allows send when the shared schema pads event location with an empty string", async () => {
-    const result = await runDrySend({
-      cfg: workspaceConfig,
-      actionParams: {
-        channel: "workspace",
-        target: "#C12345678",
-        message: "hello",
-        location: "",
-      },
-      toolContext: { currentChannelId: "C12345678" },
-    });
+  it.each(["", " \t\n"])(
+    "treats blank shared-schema event location %j as omitted on send",
+    async (location) => {
+      const result = await runDrySend({
+        cfg: workspaceConfig,
+        actionParams: {
+          channel: "workspace",
+          target: "#C12345678",
+          message: "hello",
+          location,
+        },
+        toolContext: { currentChannelId: "C12345678" },
+      });
 
-    expect(result.kind).toBe("send");
-  });
+      expect(result.kind).toBe("send");
+    },
+  );
 
   it("keeps rejecting a non-empty event location string on send", async () => {
     await expect(

--- a/src/infra/outbound/message-action-runner.send-validation.test.ts
+++ b/src/infra/outbound/message-action-runner.send-validation.test.ts
@@ -472,6 +472,36 @@ describe("runMessageAction send validation", () => {
 
     expect(result.kind).toBe("send");
   });
+
+  it("allows send when the shared schema pads event location with an empty string", async () => {
+    const result = await runDrySend({
+      cfg: workspaceConfig,
+      actionParams: {
+        channel: "workspace",
+        target: "#C12345678",
+        message: "hello",
+        location: "",
+      },
+      toolContext: { currentChannelId: "C12345678" },
+    });
+
+    expect(result.kind).toBe("send");
+  });
+
+  it("keeps rejecting a non-empty event location string on send", async () => {
+    await expect(
+      runDrySend({
+        cfg: workspaceConfig,
+        actionParams: {
+          channel: "workspace",
+          target: "#C12345678",
+          message: "hello",
+          location: "Main stage",
+        },
+        toolContext: { currentChannelId: "C12345678" },
+      }),
+    ).rejects.toThrow("location must be an object");
+  });
 });
 
 describe("message body alias normalization", () => {

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -686,6 +686,17 @@ function updateSendPayloadPartsFromReplyPayload(
   };
 }
 
+function applySendLocationToActionParams(
+  actionParams: Record<string, unknown>,
+  location: ReplyPayload["location"],
+) {
+  if (location) {
+    actionParams.location = location;
+  } else {
+    delete actionParams.location;
+  }
+}
+
 function applySendPayloadPartsToActionParams(
   actionParams: Record<string, unknown>,
   parts: SendPayloadParts,
@@ -703,11 +714,7 @@ function applySendPayloadPartsToActionParams(
   actionParams.asVoice = parts.asVoice || undefined;
   actionParams.audioAsVoice = parts.asVoice || undefined;
   actionParams.asVideoNote = parts.payload.videoAsNote || undefined;
-  if (parts.payload.location) {
-    actionParams.location = parts.payload.location;
-  } else {
-    delete actionParams.location;
-  }
+  applySendLocationToActionParams(actionParams, parts.payload.location);
 }
 
 function collectMessageAttachmentMediaHints(value: unknown): string[] {
@@ -1194,16 +1201,12 @@ async function buildSendPayloadParts(params: {
   const hasInteractive = hasLegacyInteractiveReplyBlocks(actionParams.interactive);
   const rawLocation = actionParams.location;
   // The flat tool schema also carries scheduled-event `location` as a string,
-  // and some models pad unused optional slots with "". Keep real send locations strict.
+  // and some models pad unused optional slots with blanks. Keep real send locations strict.
   const location =
     typeof rawLocation === "string" && normalizeOptionalString(rawLocation) === undefined
       ? undefined
       : normalizeOutboundLocation(rawLocation);
-  if (location) {
-    actionParams.location = location;
-  } else {
-    delete actionParams.location;
-  }
+  applySendLocationToActionParams(actionParams, location);
   const caption = readStringParam(actionParams, "caption", { allowEmpty: true }) ?? "";
   let message =
     readStringParam(actionParams, "message", {

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -703,7 +703,11 @@ function applySendPayloadPartsToActionParams(
   actionParams.asVoice = parts.asVoice || undefined;
   actionParams.audioAsVoice = parts.asVoice || undefined;
   actionParams.asVideoNote = parts.payload.videoAsNote || undefined;
-  actionParams.location = parts.payload.location;
+  if (parts.payload.location) {
+    actionParams.location = parts.payload.location;
+  } else {
+    delete actionParams.location;
+  }
 }
 
 function collectMessageAttachmentMediaHints(value: unknown): string[] {
@@ -1188,7 +1192,18 @@ async function buildSendPayloadParts(params: {
     Boolean(mediaHint) || mediaUrlHints.length > 0 || attachmentMediaHints.length > 0;
   const hasPresentation = hasMessagePresentationBlocks(actionParams.presentation);
   const hasInteractive = hasLegacyInteractiveReplyBlocks(actionParams.interactive);
-  const location = normalizeOutboundLocation(actionParams.location);
+  const rawLocation = actionParams.location;
+  // The flat tool schema also carries scheduled-event `location` as a string,
+  // and some models pad unused optional slots with "". Keep real send locations strict.
+  const location =
+    typeof rawLocation === "string" && normalizeOptionalString(rawLocation) === undefined
+      ? undefined
+      : normalizeOutboundLocation(rawLocation);
+  if (location) {
+    actionParams.location = location;
+  } else {
+    delete actionParams.location;
+  }
   const caption = readStringParam(actionParams, "caption", { allowEmpty: true }) ?? "";
   let message =
     readStringParam(actionParams, "message", {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where normal agent message sends can fail with `location must be an object` when a model client fills the unused optional `location` field with an empty string.

The shared message-tool schema also uses `location` as a string for scheduled events. Some clients populate unused optional schema fields with empty values, so a normal send can arrive with `location: ""` even though no geographic location was requested.

## Why This Change Was Made

Blank string locations are treated as omitted at the shared send owner boundary before local or gateway plugin dispatch. Valid geographic location objects continue through the existing strict validator, and non-empty malformed strings remain rejected.

This is intentionally limited to message sends; scheduled-event location handling is unchanged.

AI-assisted: yes. The implementation, dispatch paths, and focused evidence were independently reviewed.

## User Impact

Agents using schema-padding model clients can send ordinary channel messages without an unused blank event-location field blocking delivery. Real location sends keep their existing validation and behavior.

## Evidence

- Current upstream base `9db4b991b0018f94dbc6ec1427b6af600e643e9c` with the regression test only: **1 failed / 31 passed**, failing exactly with `location must be an object`.
- PR head focused validation: **99/99 passed** across send validation, gateway plugin dispatch (including response-prefix rewriting), and strict location normalization.
- Core TypeScript check passed.
- Focused Oxfmt, Oxlint, and diff hygiene passed.
- Independent final review found no correctness, security, owner-boundary, or regression issue and judged this the best bounded fix.


<!-- frond-scribe-real-behavior-proof-v1 -->
## Real behavior proof corpus

A live before/after corpus is published on `karmaterminal-openclaw-docs:main`:

- Entry: [PR-112013/PROOFS/INDEX.json](https://github.com/karmaterminal/karmaterminal-openclaw-docs/blob/main/PR-112013/PROOFS/INDEX.json)
- Exact-runtime README: [c354b220.../README.md](https://github.com/karmaterminal/karmaterminal-openclaw-docs/blob/main/PR-112013/PROOFS/c354b220ba63bf1d56286da383cd8ce3b9eaa71a/README.md)
- Published commit: [`abe1f9f0`](https://github.com/karmaterminal/karmaterminal-openclaw-docs/commit/abe1f9f0749d849b01da4e5d354c205ecffac946)

How to parse: `INDEX.json` selects the exact deployed SHA; follow `manifest_path` for the verdict row and artifact pointers, then `readme_path` for the neutral before/after table and honest limits. `SHA256SUMS` makes the exact-SHA corpus byte-verifiable.

Testbed disclosure: fixed continuation assembly `ceaf8cba72c48914acd1baf8b6796b5f35fc5f1e` plus PRs #111616, #111617, and #112013 at combined runtime `c354b220ba63bf1d56286da383cd8ce3b9eaa71a`. This PR source head, applied commit, and stable patch ID are bound in `RESOLVED-SHA.md`; protected #85651 presentation bytes were not changed.

Observed distinction: the same real embedded-agent message-tool arguments contained explicit `location: ""`. Assembly returned `location must be an object.` with no delivery ID; the candidate returned `status: sent` and Discord message ID `1529204270954451180`. The corpus publishes the redacted decisive call/result rather than the unnecessary full trajectory.
