### PR TITLE
fix(ci): freeze maturity main revision after checkout

### DIFF
--- a/.github/workflows/maturity-scorecard.yml
+++ b/.github/workflows/maturity-scorecard.yml
@@ -169,6 +169,7 @@ jobs:
           selected_revision="$(git rev-parse HEAD)"
           expected_sha="${EXPECTED_SHA,,}"
           branch_candidate="${INPUT_REF#refs/heads/}"
+          floating_default_branch=false
           trusted_reason=""
 
           if [[ -n "${expected_sha// }" && ! "$expected_sha" =~ ^[0-9a-f]{40}$ ]]; then
@@ -181,6 +182,12 @@ jobs:
           fi
 
           git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          if [[ -z "${expected_sha// }" && "$branch_candidate" == "$DEFAULT_BRANCH" ]]; then
+            # A direct main dispatch may wait while checkout fetches full history. Freeze the
+            # latest fetched main here so later reusable jobs never receive a moving branch.
+            floating_default_branch=true
+            selected_revision="$(git rev-parse refs/remotes/origin/main)"
+          fi
 
           if git merge-base --is-ancestor "$selected_revision" refs/remotes/origin/main; then
             trusted_reason="main-ancestor"
@@ -226,6 +233,9 @@ jobs:
             fi
             git fetch --no-tags origin "+refs/heads/${publication_base}:refs/remotes/origin/${publication_base}"
             publication_ref="refs/remotes/origin/${publication_base}"
+            if [[ "$floating_default_branch" == "true" && "$publication_base" == "$DEFAULT_BRANCH" ]]; then
+              selected_revision="$(git rev-parse "$publication_ref")"
+            fi
             if ! git merge-base --is-ancestor "$selected_revision" "$publication_ref"; then
               echo "Ref '${INPUT_REF}' is not an ancestor of pull request base '${publication_base}'." >&2
               echo "Historical divergent refs remain available through artifact-only workflow calls." >&2

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -4683,6 +4683,10 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
     for (const fragment of [
       "expected_sha must be a full 40-character SHA",
       'branch_candidate="${INPUT_REF#refs/heads/}"',
+      "floating_default_branch=false",
+      '[[ -z "${expected_sha// }" && "$branch_candidate" == "$DEFAULT_BRANCH" ]]',
+      'selected_revision="$(git rev-parse refs/remotes/origin/main)"',
+      '[[ "$floating_default_branch" == "true" && "$publication_base" == "$DEFAULT_BRANCH" ]]',
       'branch_lookup_status="$?"',
       "2) ;;",
       "Unable to determine whether '${INPUT_REF}' is a remote branch",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a canonical maturity-scorecard dispatch could fail before QA whenever `main` advanced during the validator full-history checkout. The workflow compared the old checkout SHA with the newer branch state instead of freezing one usable revision.

## Why This Change Was Made

For an unpinned direct `main` dispatch, validation now freezes the latest fetched default-branch revision and refreshes it once when resolving the publication base. Explicit `expected_sha` dispatches remain strict, and release-tag/release-branch trust checks are unchanged. The nested QA workflow still receives only the resulting immutable SHA.

## User Impact

Maintainers can dispatch maturity generation while normal merges continue landing on `main`; the workflow reaches QA instead of repeatedly failing during its two-minute validation checkout.

## Evidence

- Failed race: https://github.com/openclaw/openclaw/actions/runs/29795823444 — checkout began at `297374…`, `main` advanced to `b61619…`, and validation failed before QA
- `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts` — 88 passed, 1 skipped
- `git diff --check`
- Autoreview: clean, no accepted or actionable findings

AI-assisted: yes. I understand the ref validation and publication behavior.