### PR TITLE
fix(agents): bound image tool maxBytesMb and maxImages model parameters

### DIFF
--- a/src/agents/tools/image-tool.helpers.ts
+++ b/src/agents/tools/image-tool.helpers.ts
@@ -7,6 +7,7 @@ import { estimateBase64DecodedBytes } from "@openclaw/media-core/base64";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { AssistantMessage } from "../../llm/types.js";
+import { MediaSizeCapExceededError } from "../../media/media-size-cap-error.js";
 import { extractAssistantText } from "../embedded-agent-utils.js";
 import { isMinimaxVlmProvider } from "../minimax-vlm.js";
 import { findNormalizedProviderValue, normalizeProviderId } from "../model-selection.js";
@@ -107,7 +108,9 @@ export function decodeDataUrl(
   const b64 = (match[2] ?? "").trim();
   if (typeof opts?.maxBytes === "number" && estimateBase64DecodedBytes(b64) > opts.maxBytes) {
     // Estimate before decoding so oversized inline payloads do not allocate large buffers.
-    throw new Error("Invalid data URL: payload exceeds size limit.");
+    throw new MediaSizeCapExceededError("Invalid data URL: payload exceeds size limit.", {
+      capBytes: opts.maxBytes,
+    });
   }
   const buffer = Buffer.from(b64, "base64");
   if (buffer.length === 0) {

--- a/src/agents/tools/image-tool.result.ts
+++ b/src/agents/tools/image-tool.result.ts
@@ -31,12 +31,17 @@ export function buildImageToolReferenceDetails(
 export async function buildNativeImageToolResult(
   images: readonly LoadedImageForTool[],
   config?: OpenClawConfig,
+  skippedImages?: { count: number; budgetBytes: number },
 ): Promise<AgentToolResult<unknown>> {
   const result: AgentToolResult<unknown> = {
     content: [
       {
         type: "text",
-        text: `Loaded ${images.length} image${images.length === 1 ? "" : "s"} for direct visual inspection.`,
+        text:
+          `Loaded ${images.length} image${images.length === 1 ? "" : "s"} for direct visual inspection.` +
+          (skippedImages
+            ? ` Skipped ${skippedImages.count} image${skippedImages.count === 1 ? "" : "s"}: the request byte budget was exhausted.`
+            : ""),
       },
       ...images.map((image) => ({
         type: "image" as const,
@@ -47,6 +52,9 @@ export async function buildNativeImageToolResult(
     details: {
       transport: "native",
       ...buildImageToolReferenceDetails(images),
+      ...(skippedImages
+        ? { skippedImages: { ...skippedImages, reason: "request_budget_exhausted" } }
+        : {}),
       media: { outbound: false },
     },
   };

--- a/src/agents/tools/image-tool.test.ts
+++ b/src/agents/tools/image-tool.test.ts
@@ -2071,8 +2071,8 @@ describe("image tool implicit imageModel config", () => {
             items: { type: "string" },
           },
           model: { type: "string" },
-          maxBytesMb: { type: "number", exclusiveMinimum: 0 },
-          maxImages: { type: "integer", minimum: 1 },
+          maxBytesMb: { type: "number", exclusiveMinimum: 0, maximum: 100 },
+          maxImages: { type: "integer", minimum: 1, maximum: 100 },
         },
       });
     });
@@ -2772,6 +2772,46 @@ describe("image tool MiniMax VLM routing", () => {
     });
 
     expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("clamps pathological maxImages to prevent unbounded gate bypass", async () => {
+    const { fetch, tool } = await createMinimaxVlmFixture({ status_code: 0, status_msg: "" });
+
+    // Eleven unique small PNGs exceed the user-set maxImages=3 but are
+    // well below the DEFAULT_MAX_IMAGES=20 floor and the MAX_IMAGES_CAP=100.
+    // Without clamping, maxImages=1_000_000_000 would pass through and
+    // silently accept millions of image references.
+    const many = await tool.execute("t1", {
+      prompt: "Describe.",
+      images: [
+        `data:image/png;base64,${createLargeColorBlockPng(1).toString("base64")}`,
+        `data:image/png;base64,${createLargeColorBlockPng(2).toString("base64")}`,
+        `data:image/png;base64,${createLargeColorBlockPng(3).toString("base64")}`,
+      ],
+      maxImages: 1_000_000_000,
+    });
+
+    // With 3 unique images and a clamped cap of 100, each image is loaded
+    // and described individually by the MiniMax VLM. The pathological
+    // maxImages=1_000_000_000 does not cause a crash or unexpected rejection.
+    expect(fetch).toHaveBeenCalledTimes(3);
+    expect((many.details as { images?: unknown[] } | undefined)?.images).toHaveLength(3);
+  });
+
+  it("clamps pathological maxBytesMb to a safe upper bound", async () => {
+    // pickMaxBytes receives the megabytes value and converts to bytes.
+    // A pathological model input (1e9 MB ≈ 1 PB) must not allocate.
+    const api = (globalThis as Record<PropertyKey, unknown>)[
+      Symbol.for("openclaw.imageToolTestApi")
+    ] as { pickMaxBytes: (cfg: undefined, maxBytesMb: number) => number | undefined } | undefined;
+    expect(api?.pickMaxBytes).toBeDefined();
+
+    const normal = api!.pickMaxBytes(undefined, 10);
+    expect(normal).toBe(10 * 1024 * 1024);
+
+    const clamped = api!.pickMaxBytes(undefined, 1_000_000_000);
+    // 1e9 MB clamped to MAX_IMAGE_MB_CAP=100 → 100 * 1024 * 1024 bytes
+    expect(clamped).toBe(100 * 1024 * 1024);
   });
 
   it("surfaces MiniMax API errors from /v1/coding_plan/vlm", async () => {

--- a/src/agents/tools/image-tool.test.ts
+++ b/src/agents/tools/image-tool.test.ts
@@ -2794,7 +2794,10 @@ describe("image tool MiniMax VLM routing", () => {
 
     // The gate fires because 101 > 100 (clamped), not 101 > 1_000_000_000.
     expect(result.content).toEqual([
-      { type: "text", text: "Too many images: 101 provided, maximum is 100. Please reduce the number of images." },
+      {
+        type: "text",
+        text: "Too many images: 101 provided, maximum is 100. Please reduce the number of images.",
+      },
     ]);
     expect(result.details).toMatchObject({
       error: "too_many_images",

--- a/src/agents/tools/image-tool.test.ts
+++ b/src/agents/tools/image-tool.test.ts
@@ -2774,13 +2774,42 @@ describe("image tool MiniMax VLM routing", () => {
     expect(fetch).toHaveBeenCalledTimes(1);
   });
 
-  it("clamps pathological maxImages to prevent unbounded gate bypass", async () => {
+  it("clamps pathological maxImages across the 100-image threshold", async () => {
     const { fetch, tool } = await createMinimaxVlmFixture({ status_code: 0, status_msg: "" });
 
-    // Eleven unique small PNGs exceed the user-set maxImages=3 but are
-    // well below the DEFAULT_MAX_IMAGES=20 floor and the MAX_IMAGES_CAP=100.
-    // Without clamping, maxImages=1_000_000_000 would pass through and
-    // silently accept millions of image references.
+    // 101 unique tiny PNGs cross the clamped threshold (100) so the
+    // gate must fire. Without the clamp, maxImages=1_000_000_000 would
+    // pass through and silently accept millions of image references.
+    // Each image has a distinct red channel to bypass the URI dedup.
+    const tooMany = Array.from({ length: 101 }, (_, i) => {
+      const buf = Buffer.alloc(4, 255);
+      buf[0] = i;
+      return `data:image/png;base64,${encodePngRgba(buf, 1, 1).toString("base64")}`;
+    });
+    const result = await tool.execute("t1", {
+      prompt: "Describe.",
+      images: tooMany,
+      maxImages: 1_000_000_000,
+    });
+
+    // The gate fires because 101 > 100 (clamped), not 101 > 1_000_000_000.
+    expect(result.content).toEqual([
+      { type: "text", text: "Too many images: 101 provided, maximum is 100. Please reduce the number of images." },
+    ]);
+    expect(result.details).toMatchObject({
+      error: "too_many_images",
+      count: 101,
+      max: 100,
+    });
+    // No fetch — the gate exits before any image processing.
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("accepts below-cap images when maxImages is pathological but count is safe", async () => {
+    const { fetch, tool } = await createMinimaxVlmFixture({ status_code: 0, status_msg: "" });
+
+    // 3 images with pathological maxImages=1_000_000_000: clamp gives
+    // 100, and 3 < 100 so the gate passes normally.
     const many = await tool.execute("t1", {
       prompt: "Describe.",
       images: [
@@ -2791,27 +2820,44 @@ describe("image tool MiniMax VLM routing", () => {
       maxImages: 1_000_000_000,
     });
 
-    // With 3 unique images and a clamped cap of 100, each image is loaded
-    // and described individually by the MiniMax VLM. The pathological
-    // maxImages=1_000_000_000 does not cause a crash or unexpected rejection.
     expect(fetch).toHaveBeenCalledTimes(3);
     expect((many.details as { images?: unknown[] } | undefined)?.images).toHaveLength(3);
   });
 
-  it("clamps pathological maxBytesMb to a safe upper bound", async () => {
+  it("clamps pathological maxBytesMb to the cap", async () => {
     // pickMaxBytes receives the megabytes value and converts to bytes.
     // A pathological model input (1e9 MB ≈ 1 PB) must not allocate.
     const api = (globalThis as Record<PropertyKey, unknown>)[
       Symbol.for("openclaw.imageToolTestApi")
-    ] as { pickMaxBytes: (cfg: undefined, maxBytesMb: number) => number | undefined } | undefined;
+    ] as { pickMaxBytes: (cfg: unknown, maxBytesMb: number) => number | undefined } | undefined;
     expect(api?.pickMaxBytes).toBeDefined();
-
-    const normal = api!.pickMaxBytes(undefined, 10);
-    expect(normal).toBe(10 * 1024 * 1024);
 
     const clamped = api!.pickMaxBytes(undefined, 1_000_000_000);
     // 1e9 MB clamped to MAX_IMAGE_MB_CAP=100 → 100 * 1024 * 1024 bytes
     expect(clamped).toBe(100 * 1024 * 1024);
+  });
+
+  it("passes below-cap maxBytesMb through pickMaxBytes unchanged", async () => {
+    const api = (globalThis as Record<PropertyKey, unknown>)[
+      Symbol.for("openclaw.imageToolTestApi")
+    ] as { pickMaxBytes: (cfg: unknown, maxBytesMb: number) => number | undefined } | undefined;
+    expect(api?.pickMaxBytes).toBeDefined();
+
+    const result = api!.pickMaxBytes(undefined, 50);
+    // 50 < 100 cap → pass through unchanged
+    expect(result).toBe(50 * 1024 * 1024);
+  });
+
+  it("falls through to configured mediaMaxMb when maxBytesMb is omitted", async () => {
+    const api = (globalThis as Record<PropertyKey, unknown>)[
+      Symbol.for("openclaw.imageToolTestApi")
+    ] as { pickMaxBytes: (cfg: unknown, maxBytesMb?: number) => number | undefined } | undefined;
+    expect(api?.pickMaxBytes).toBeDefined();
+
+    // No model-supplied value → falls through to operator config
+    const cfg = { agents: { defaults: { mediaMaxMb: 75 } } } as OpenClawConfig;
+    const result = api!.pickMaxBytes(cfg, undefined);
+    expect(result).toBe(75 * 1024 * 1024);
   });
 
   it("surfaces MiniMax API errors from /v1/coding_plan/vlm", async () => {

--- a/src/agents/tools/image-tool.test.ts
+++ b/src/agents/tools/image-tool.test.ts
@@ -2072,7 +2072,7 @@ describe("image tool implicit imageModel config", () => {
           },
           model: { type: "string" },
           maxBytesMb: { type: "number", exclusiveMinimum: 0, maximum: 100 },
-          maxImages: { type: "integer", minimum: 1, maximum: 100 },
+          maxImages: { type: "integer", minimum: 1 },
         },
       });
     });
@@ -2774,14 +2774,14 @@ describe("image tool MiniMax VLM routing", () => {
     expect(fetch).toHaveBeenCalledTimes(1);
   });
 
-  it("clamps pathological maxImages across the 100-image threshold", async () => {
+  it("clamps pathological maxImages across the 20-image threshold", async () => {
     const { fetch, tool } = await createMinimaxVlmFixture({ status_code: 0, status_msg: "" });
 
-    // 101 unique tiny PNGs cross the clamped threshold (100) so the
+    // 21 unique tiny PNGs cross the clamped threshold (20) so the
     // gate must fire. Without the clamp, maxImages=1_000_000_000 would
     // pass through and silently accept millions of image references.
     // Each image has a distinct red channel to bypass the URI dedup.
-    const tooMany = Array.from({ length: 101 }, (_, i) => {
+    const tooMany = Array.from({ length: 21 }, (_, i) => {
       const buf = Buffer.alloc(4, 255);
       buf[0] = i;
       return `data:image/png;base64,${encodePngRgba(buf, 1, 1).toString("base64")}`;
@@ -2792,17 +2792,17 @@ describe("image tool MiniMax VLM routing", () => {
       maxImages: 1_000_000_000,
     });
 
-    // The gate fires because 101 > 100 (clamped), not 101 > 1_000_000_000.
+    // The gate fires because 21 > 20 (clamped), not 21 > 1_000_000_000.
     expect(result.content).toEqual([
       {
         type: "text",
-        text: "Too many images: 101 provided, maximum is 100. Please reduce the number of images.",
+        text: "Too many images: 21 provided, maximum is 20. Please reduce the number of images.",
       },
     ]);
     expect(result.details).toMatchObject({
       error: "too_many_images",
-      count: 101,
-      max: 100,
+      count: 21,
+      max: 20,
     });
     // No fetch — the gate exits before any image processing.
     expect(fetch).not.toHaveBeenCalled();
@@ -2812,7 +2812,7 @@ describe("image tool MiniMax VLM routing", () => {
     const { fetch, tool } = await createMinimaxVlmFixture({ status_code: 0, status_msg: "" });
 
     // 3 images with pathological maxImages=1_000_000_000: clamp gives
-    // 100, and 3 < 100 so the gate passes normally.
+    // 20, and 3 < 20 so the gate passes normally.
     const many = await tool.execute("t1", {
       prompt: "Describe.",
       images: [

--- a/src/agents/tools/image-tool.test.ts
+++ b/src/agents/tools/image-tool.test.ts
@@ -2071,7 +2071,7 @@ describe("image tool implicit imageModel config", () => {
             items: { type: "string" },
           },
           model: { type: "string" },
-          maxBytesMb: { type: "number", exclusiveMinimum: 0, maximum: 100 },
+          maxBytesMb: { type: "number", exclusiveMinimum: 0 },
           maxImages: { type: "integer", minimum: 1 },
         },
       });

--- a/src/agents/tools/image-tool.test.ts
+++ b/src/agents/tools/image-tool.test.ts
@@ -2071,7 +2071,12 @@ describe("image tool implicit imageModel config", () => {
             items: { type: "string" },
           },
           model: { type: "string" },
-          maxBytesMb: { type: "number", exclusiveMinimum: 0 },
+          maxBytesMb: {
+            type: "number",
+            description:
+              "Max image size in MB; caps each image and the combined total for this call. Values above 100 are clamped.",
+            exclusiveMinimum: 0,
+          },
           maxImages: { type: "integer", minimum: 1 },
         },
       });
@@ -2861,6 +2866,44 @@ describe("image tool MiniMax VLM routing", () => {
     const cfg = { agents: { defaults: { mediaMaxMb: 75 } } } as OpenClawConfig;
     const result = api!.pickMaxBytes(cfg, undefined);
     expect(result).toBe(75 * 1024 * 1024);
+  });
+
+  it("bounds the aggregate image payload across the 20-image boundary", async () => {
+    const { fetch, tool } = await createMinimaxVlmFixture({ status_code: 0, status_msg: "" });
+
+    // 20 distinct tiny PNGs (distinct red channel bypasses dedupe). The
+    // request budget fits exactly three loads, so the remaining 17 must be
+    // skipped and recorded instead of accumulating toward the dispatch.
+    const pngs = Array.from({ length: 20 }, (_, i) => {
+      const buf = Buffer.alloc(4, 255);
+      buf[0] = i;
+      return encodePngRgba(buf, 1, 1);
+    });
+    const budgetBytes = pngs[0].byteLength + pngs[1].byteLength + pngs[2].byteLength;
+    const result = await tool.execute("t1", {
+      prompt: "Describe.",
+      images: pngs.map((png) => `data:image/png;base64,${png.toString("base64")}`),
+      // Division by a power of two is exact, so pickMaxBytes floors back to
+      // exactly budgetBytes.
+      maxBytesMb: budgetBytes / (1024 * 1024),
+    });
+
+    // Only the three budgeted images reach the provider.
+    expect(fetch).toHaveBeenCalledTimes(3);
+    const details = result.details as
+      | {
+          images?: unknown[];
+          skippedImages?: { count: number; reason: string; budgetBytes: number };
+        }
+      | undefined;
+    expect(details?.images).toHaveLength(3);
+    expect(details?.skippedImages).toEqual({
+      count: 17,
+      reason: "request_budget_exhausted",
+      budgetBytes,
+    });
+    const text = result.content?.find((block) => block.type === "text")?.text ?? "";
+    expect(text).toContain("Skipped 17 image(s)");
   });
 
   it("surfaces MiniMax API errors from /v1/coding_plan/vlm", async () => {

--- a/src/agents/tools/image-tool.test.ts
+++ b/src/agents/tools/image-tool.test.ts
@@ -1869,6 +1869,46 @@ describe("image tool implicit imageModel config", () => {
     });
   });
 
+  it("records a skip when an image exceeds the remaining request budget (native route)", async () => {
+    await withTempAgentDir(async (agentDir) => {
+      const tool = createRequiredImageTool({ agentDir, modelHasVision: true });
+
+      // Same mixed-size contract as the fallback route: the second image
+      // overflows the 1-byte remaining allowance and must be recorded as
+      // skipped rather than throwing away the loaded image.
+      const firstBuf = Buffer.alloc(4, 255);
+      firstBuf[0] = 1;
+      const smallPng = encodePngRgba(firstBuf, 1, 1);
+      const bigPng = createLargeColorBlockPng(64);
+      const budgetBytes = smallPng.byteLength + 1;
+      const result = await tool.execute("native-budget-skip", {
+        prompt: "Describe.",
+        images: [
+          `data:image/png;base64,${smallPng.toString("base64")}`,
+          `data:image/png;base64,${bigPng.toString("base64")}`,
+        ],
+        maxBytesMb: budgetBytes / (1024 * 1024),
+      });
+
+      const typed = result as {
+        content?: Array<{ type?: string; text?: string }>;
+        details?: Record<string, unknown>;
+      };
+      const text = typed.content?.find((block) => block.type === "text")?.text ?? "";
+      expect(text).toBe(
+        "Loaded 1 image for direct visual inspection. Skipped 1 image: the request byte budget was exhausted.",
+      );
+      expect(typed.details).toMatchObject({
+        transport: "native",
+        skippedImages: {
+          count: 1,
+          reason: "request_budget_exhausted",
+          budgetBytes,
+        },
+      });
+    });
+  });
+
   it("sends moonshot image requests with user+image payloads only", async () => {
     await withTempAgentDir(async (agentDir) => {
       installFastLocalImageProviderStubs(minimaxProvider, moonshotProvider);
@@ -2648,12 +2688,16 @@ describe("image tool MiniMax VLM routing", () => {
     testing.setProviderDepsForTest();
   });
 
-  async function createMinimaxVlmFixture(baseResp: { status_code: number; status_msg: string }) {
+  async function createMinimaxVlmFixture(
+    baseResp: { status_code: number; status_msg: string },
+    configure?: (cfg: OpenClawConfig) => void,
+  ) {
     const fetchMock = stubMinimaxFetch(baseResp, baseResp.status_code === 0 ? "ok" : "");
 
     const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-minimax-vlm-"));
     vi.stubEnv("MINIMAX_API_KEY", "minimax-test");
     const cfg = createMinimaxImageConfig();
+    configure?.(cfg);
     const tool = createRequiredImageTool({ config: cfg, agentDir });
     return { fetch: fetchMock, tool };
   }
@@ -2904,6 +2948,84 @@ describe("image tool MiniMax VLM routing", () => {
     });
     const text = result.content?.find((block) => block.type === "text")?.text ?? "";
     expect(text).toContain("Skipped 17 image(s)");
+  });
+
+  it("keeps operator mediaMaxMb per-image when the model supplies no maxBytesMb", async () => {
+    // 140 bytes: above each 70-byte image but below the 210-byte combined
+    // total, so an (incorrect) aggregate reading would skip images.
+    const { fetch, tool } = await createMinimaxVlmFixture(
+      { status_code: 0, status_msg: "" },
+      (cfg) => {
+        const defaults = cfg.agents?.defaults;
+        if (defaults) {
+          defaults.mediaMaxMb = 140 / (1024 * 1024);
+        }
+      },
+    );
+
+    const pngs = Array.from({ length: 3 }, (_, i) => {
+      const buf = Buffer.alloc(4, 255);
+      buf[0] = i;
+      return encodePngRgba(buf, 1, 1);
+    });
+    const result = await tool.execute("t1", {
+      prompt: "Describe.",
+      images: pngs.map((png) => `data:image/png;base64,${png.toString("base64")}`),
+    });
+
+    // Operator mediaMaxMb is a per-image contract: all three images load.
+    expect(fetch).toHaveBeenCalledTimes(3);
+    const details = result.details as
+      | { images?: unknown[]; skippedImages?: unknown }
+      | undefined;
+    expect(details?.images).toHaveLength(3);
+    expect(details?.skippedImages).toBeUndefined();
+  });
+
+  it("records a skip when an image exceeds the remaining request budget", async () => {
+    const { fetch, tool } = await createMinimaxVlmFixture({ status_code: 0, status_msg: "" });
+
+    // Mixed sizes: the budget leaves 1 byte after the first image, so the
+    // second (larger) image overflows the remaining allowance mid-loop. That
+    // expected overflow must become a recorded skip, not a thrown call.
+    const firstBuf = Buffer.alloc(4, 255);
+    firstBuf[0] = 1;
+    const smallPng = encodePngRgba(firstBuf, 1, 1);
+    const thirdBuf = Buffer.alloc(4, 255);
+    thirdBuf[0] = 3;
+    const thirdPng = encodePngRgba(thirdBuf, 1, 1);
+    const bigPng = createLargeColorBlockPng(64);
+    const budgetBytes = smallPng.byteLength + 1;
+    const result = await tool.execute("t1", {
+      prompt: "Describe.",
+      images: [
+        `data:image/png;base64,${smallPng.toString("base64")}`,
+        `data:image/png;base64,${bigPng.toString("base64")}`,
+        `data:image/png;base64,${thirdPng.toString("base64")}`,
+      ],
+      maxBytesMb: budgetBytes / (1024 * 1024),
+    });
+
+    // Only the first image reaches the provider; the oversized second image
+    // and everything after it are recorded as skipped. A single loaded image
+    // uses the singular `image` details form.
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const details = result.details as
+      | {
+          image?: string;
+          images?: unknown[];
+          skippedImages?: { count: number; reason: string; budgetBytes: number };
+        }
+      | undefined;
+    expect(details?.image).toBeDefined();
+    expect(details?.images).toBeUndefined();
+    expect(details?.skippedImages).toEqual({
+      count: 2,
+      reason: "request_budget_exhausted",
+      budgetBytes,
+    });
+    const text = result.content?.find((block) => block.type === "text")?.text ?? "";
+    expect(text).toContain("Skipped 2 image(s)");
   });
 
   it("surfaces MiniMax API errors from /v1/coding_plan/vlm", async () => {

--- a/src/agents/tools/image-tool.test.ts
+++ b/src/agents/tools/image-tool.test.ts
@@ -2923,7 +2923,7 @@ describe("image tool MiniMax VLM routing", () => {
       buf[0] = i;
       return encodePngRgba(buf, 1, 1);
     });
-    const budgetBytes = pngs[0].byteLength + pngs[1].byteLength + pngs[2].byteLength;
+    const budgetBytes = pngs[0]!.byteLength + pngs[1]!.byteLength + pngs[2]!.byteLength;
     const result = await tool.execute("t1", {
       prompt: "Describe.",
       images: pngs.map((png) => `data:image/png;base64,${png.toString("base64")}`),
@@ -2975,9 +2975,7 @@ describe("image tool MiniMax VLM routing", () => {
 
     // Operator mediaMaxMb is a per-image contract: all three images load.
     expect(fetch).toHaveBeenCalledTimes(3);
-    const details = result.details as
-      | { images?: unknown[]; skippedImages?: unknown }
-      | undefined;
+    const details = result.details as { images?: unknown[]; skippedImages?: unknown } | undefined;
     expect(details?.images).toHaveLength(3);
     expect(details?.skippedImages).toBeUndefined();
   });

--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -924,7 +924,7 @@ export function createImageTool(options?: {
         }),
       ),
       ...(modelHasVision ? {} : { model: Type.Optional(Type.String()) }),
-      maxBytesMb: optionalFiniteNumberSchema({ exclusiveMinimum: 0, maximum: MAX_IMAGE_MB_CAP }),
+      maxBytesMb: optionalFiniteNumberSchema({ exclusiveMinimum: 0 }),
       maxImages: optionalPositiveIntegerSchema(),
     }),
     execute: async (_toolCallId, args, signal) => {

--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -3,6 +3,7 @@ import { Type } from "typebox";
 import { findCapabilityProviderById } from "../../../packages/media-generation-core/src/capability-model-ref.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { MediaUnderstandingModelConfig } from "../../config/types.tools.js";
+import { logWarn } from "../../logger.js";
 import {
   DEFAULT_TIMEOUT_SECONDS,
   resolveAutoMediaKeyProviders,
@@ -48,7 +49,6 @@ import {
 } from "../model-fallback-candidates.js";
 import type { PreparedModelRuntimeSnapshot } from "../prepared-model-runtime.js";
 import { optionalFiniteNumberSchema, optionalPositiveIntegerSchema } from "../schema/typebox.js";
-import { logWarn } from "../../logger.js";
 import { readFiniteNumberParam, readPositiveIntegerParam } from "./common.js";
 import {
   coerceImageAssistantText,

--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -89,6 +89,8 @@ import {
 
 const DEFAULT_PROMPT = "Describe the image.";
 const DEFAULT_MAX_IMAGES = 20;
+const MAX_IMAGES_CAP = 100;
+const MAX_IMAGE_MB_CAP = 100;
 
 type ImageToolLoadWebMediaOptions = {
   maxBytes?: number;
@@ -403,6 +405,7 @@ if (process.env.VITEST || process.env.NODE_ENV === "test") {
   (globalThis as Record<PropertyKey, unknown>)[Symbol.for("openclaw.imageToolTestApi")] = {
     ...testing,
     resolveImageModelConfigForTool,
+    pickMaxBytes,
   };
 }
 
@@ -422,7 +425,9 @@ function resolveImageModelConfigForOverride(params: {
 
 function pickMaxBytes(cfg?: OpenClawConfig, maxBytesMb?: number): number | undefined {
   if (typeof maxBytesMb === "number" && Number.isFinite(maxBytesMb) && maxBytesMb > 0) {
-    return Math.floor(maxBytesMb * 1024 * 1024);
+    // Model-supplied maxBytesMb is clamped to prevent pathological allocations in
+    // image compression pipelines. Operator config (mediaMaxMb) is not clamped here.
+    return Math.floor(Math.min(maxBytesMb, MAX_IMAGE_MB_CAP) * 1024 * 1024);
   }
   const configured = cfg?.agents?.defaults?.mediaMaxMb;
   if (typeof configured === "number" && Number.isFinite(configured) && configured > 0) {
@@ -915,8 +920,8 @@ export function createImageTool(options?: {
         }),
       ),
       ...(modelHasVision ? {} : { model: Type.Optional(Type.String()) }),
-      maxBytesMb: optionalFiniteNumberSchema({ exclusiveMinimum: 0 }),
-      maxImages: optionalPositiveIntegerSchema(),
+      maxBytesMb: optionalFiniteNumberSchema({ exclusiveMinimum: 0, maximum: MAX_IMAGE_MB_CAP }),
+      maxImages: optionalPositiveIntegerSchema({ maximum: MAX_IMAGES_CAP }),
     }),
     execute: async (_toolCallId, args, signal) => {
       const record = args && typeof args === "object" ? (args as Record<string, unknown>) : {};
@@ -948,7 +953,13 @@ export function createImageTool(options?: {
       }
 
       // MARK: - Enforce max images cap
-      const maxImages = readPositiveIntegerParam(record, "maxImages") ?? DEFAULT_MAX_IMAGES;
+      // Model-supplied maxImages is clamped to prevent pathological gate bypass
+      // in image processing loops. The DEFAULT_MAX_IMAGES floor is unchanged.
+      const maxImagesRaw = readPositiveIntegerParam(record, "maxImages");
+      const maxImages =
+        maxImagesRaw === undefined
+          ? DEFAULT_MAX_IMAGES
+          : Math.min(maxImagesRaw, MAX_IMAGES_CAP);
       if (imageInputs.length > maxImages) {
         return {
           content: [

--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -957,9 +957,7 @@ export function createImageTool(options?: {
       // in image processing loops. The DEFAULT_MAX_IMAGES floor is unchanged.
       const maxImagesRaw = readPositiveIntegerParam(record, "maxImages");
       const maxImages =
-        maxImagesRaw === undefined
-          ? DEFAULT_MAX_IMAGES
-          : Math.min(maxImagesRaw, MAX_IMAGES_CAP);
+        maxImagesRaw === undefined ? DEFAULT_MAX_IMAGES : Math.min(maxImagesRaw, MAX_IMAGES_CAP);
       if (imageInputs.length > maxImages) {
         return {
           content: [

--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -90,7 +90,7 @@ import {
 
 const DEFAULT_PROMPT = "Describe the image.";
 const DEFAULT_MAX_IMAGES = 20;
-const MAX_IMAGES_CAP = 100;
+const MAX_IMAGES_CAP = DEFAULT_MAX_IMAGES;
 const MAX_IMAGE_MB_CAP = 100;
 
 type ImageToolLoadWebMediaOptions = {
@@ -925,7 +925,7 @@ export function createImageTool(options?: {
       ),
       ...(modelHasVision ? {} : { model: Type.Optional(Type.String()) }),
       maxBytesMb: optionalFiniteNumberSchema({ exclusiveMinimum: 0, maximum: MAX_IMAGE_MB_CAP }),
-      maxImages: optionalPositiveIntegerSchema({ maximum: MAX_IMAGES_CAP }),
+      maxImages: optionalPositiveIntegerSchema(),
     }),
     execute: async (_toolCallId, args, signal) => {
       const record = args && typeof args === "object" ? (args as Record<string, unknown>) : {};

--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -48,6 +48,7 @@ import {
 } from "../model-fallback-candidates.js";
 import type { PreparedModelRuntimeSnapshot } from "../prepared-model-runtime.js";
 import { optionalFiniteNumberSchema, optionalPositiveIntegerSchema } from "../schema/typebox.js";
+import { logWarn } from "../../logger.js";
 import { readFiniteNumberParam, readPositiveIntegerParam } from "./common.js";
 import {
   coerceImageAssistantText,
@@ -427,6 +428,9 @@ function pickMaxBytes(cfg?: OpenClawConfig, maxBytesMb?: number): number | undef
   if (typeof maxBytesMb === "number" && Number.isFinite(maxBytesMb) && maxBytesMb > 0) {
     // Model-supplied maxBytesMb is clamped to prevent pathological allocations in
     // image compression pipelines. Operator config (mediaMaxMb) is not clamped here.
+    if (maxBytesMb > MAX_IMAGE_MB_CAP) {
+      logWarn(`image-tool: maxBytesMb clamped from ${maxBytesMb} to ${MAX_IMAGE_MB_CAP}`);
+    }
     return Math.floor(Math.min(maxBytesMb, MAX_IMAGE_MB_CAP) * 1024 * 1024);
   }
   const configured = cfg?.agents?.defaults?.mediaMaxMb;
@@ -958,6 +962,9 @@ export function createImageTool(options?: {
       const maxImagesRaw = readPositiveIntegerParam(record, "maxImages");
       const maxImages =
         maxImagesRaw === undefined ? DEFAULT_MAX_IMAGES : Math.min(maxImagesRaw, MAX_IMAGES_CAP);
+      if (maxImagesRaw !== undefined && maxImagesRaw > MAX_IMAGES_CAP) {
+        logWarn(`image-tool: maxImages clamped from ${maxImagesRaw} to ${MAX_IMAGES_CAP}`);
+      }
       if (imageInputs.length > maxImages) {
         return {
           content: [

--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -924,7 +924,11 @@ export function createImageTool(options?: {
         }),
       ),
       ...(modelHasVision ? {} : { model: Type.Optional(Type.String()) }),
-      maxBytesMb: optionalFiniteNumberSchema({ exclusiveMinimum: 0 }),
+      maxBytesMb: optionalFiniteNumberSchema({
+        description:
+          "Max image size in MB; caps each image and the combined total for this call. Values above 100 are clamped.",
+        exclusiveMinimum: 0,
+      }),
       maxImages: optionalPositiveIntegerSchema(),
     }),
     execute: async (_toolCallId, args, signal) => {
@@ -987,6 +991,11 @@ export function createImageTool(options?: {
         message: "maxBytesMb must be greater than 0",
       });
       const maxBytes = pickMaxBytes(options?.config, maxBytesMb);
+      // The effective byte limit is one aggregate budget for the whole
+      // model-originated request: 20 images at the 100 MiB per-image cap would
+      // otherwise retain ~2 GiB of buffers before native/fallback dispatch.
+      // Each load draws from the remaining budget; exhaustion skips the rest.
+      let remainingImageBudgetBytes = maxBytes;
       let imageRoute:
         | { kind: "native" }
         | {
@@ -1039,11 +1048,21 @@ export function createImageTool(options?: {
 
       // MARK: - Load and resolve each image
       const loadedImages: LoadedImageForTool[] = [];
+      let budgetSkippedImageCount = 0;
 
       for (const imageRawInput of imageInputs) {
         // Stop before starting the next sequential download/decode when the run
         // was aborted, so a dead run cannot keep pulling up to maxImages remote images.
         signal?.throwIfAborted();
+        if (remainingImageBudgetBytes !== undefined && remainingImageBudgetBytes <= 0) {
+          // Recorded non-outcome: later images are skipped, not silently
+          // truncated, so the model knows the payload was bounded.
+          budgetSkippedImageCount = imageInputs.length - loadedImages.length;
+          logWarn(
+            `image-tool: request byte budget exhausted; skipping ${budgetSkippedImageCount} image(s)`,
+          );
+          break;
+        }
         const trimmed = imageRawInput.trim();
         const imageRaw = trimmed.startsWith("@") ? trimmed.slice(1).trim() : trimmed;
         if (!imageRaw) {
@@ -1127,23 +1146,25 @@ export function createImageTool(options?: {
 
         const media = isDataUrl
           ? await (async () => {
-              const decoded = decodeDataUrl(resolvedImage, { maxBytes });
+              const decoded = decodeDataUrl(resolvedImage, {
+                maxBytes: remainingImageBudgetBytes,
+              });
               return await imageWebMedia.optimizeImageBufferForWebMedia({
                 buffer: decoded.buffer,
                 contentType: decoded.mimeType,
-                maxBytes,
+                maxBytes: remainingImageBudgetBytes,
                 imageCompression,
               });
             })()
           : sandboxConfig
             ? await imageWebMedia.loadWebMedia(resolvedPath ?? resolvedImage, {
-                maxBytes,
+                maxBytes: remainingImageBudgetBytes,
                 sandboxValidated: true,
                 readFile: createSandboxBridgeReadFile({ sandbox: sandboxConfig }),
                 imageCompression,
               })
             : await imageWebMedia.loadWebMedia(resolvedPath ?? resolvedImage, {
-                maxBytes,
+                maxBytes: remainingImageBudgetBytes,
                 localRoots: mediaLocalRoots,
                 inboundRoots: mediaInboundRoots,
                 ssrfPolicy: remoteMediaSsrfPolicy,
@@ -1155,6 +1176,12 @@ export function createImageTool(options?: {
               });
         if (media.kind !== "image") {
           throw new Error(`Unsupported media type: ${media.kind}`);
+        }
+        if (remainingImageBudgetBytes !== undefined) {
+          remainingImageBudgetBytes = Math.max(
+            0,
+            remainingImageBudgetBytes - media.buffer.byteLength,
+          );
         }
 
         const contentType =
@@ -1172,8 +1199,15 @@ export function createImageTool(options?: {
         });
       }
 
+      // Budget-exhausted skips are a recorded non-outcome: surfaced in result
+      // text (the model must know images are missing) and in details.
+      const budgetSkip =
+        budgetSkippedImageCount > 0 && maxBytes !== undefined
+          ? { count: budgetSkippedImageCount, budgetBytes: maxBytes }
+          : undefined;
+
       if (imageRoute.kind === "native") {
-        return await buildNativeImageToolResult(loadedImages, options?.config);
+        return await buildNativeImageToolResult(loadedImages, options?.config, budgetSkip);
       }
 
       // Do not issue a paid vision-provider call for an already-aborted run.
@@ -1193,7 +1227,22 @@ export function createImageTool(options?: {
         preparedModelRuntime: options?.preparedModelRuntime,
       });
 
-      return buildTextToolResult(result, buildImageToolReferenceDetails(loadedImages));
+      const referenceDetails = buildImageToolReferenceDetails(loadedImages);
+      if (budgetSkip) {
+        referenceDetails.skippedImages = {
+          ...budgetSkip,
+          reason: "request_budget_exhausted",
+        };
+      }
+      return buildTextToolResult(
+        budgetSkip
+          ? {
+              ...result,
+              text: `${result.text}\n\nSkipped ${budgetSkip.count} image(s): the request byte budget was exhausted.`,
+            }
+          : result,
+        referenceDetails,
+      );
     },
   };
 }

--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -20,6 +20,7 @@ import {
   classifyMediaReferenceSource,
   normalizeMediaReferenceSource,
 } from "../../media/media-reference.js";
+import { MediaSizeCapExceededError } from "../../media/media-size-cap-error.js";
 import type {
   ImageCompressionModelPolicy,
   ImageCompressionPolicy,
@@ -991,11 +992,13 @@ export function createImageTool(options?: {
         message: "maxBytesMb must be greater than 0",
       });
       const maxBytes = pickMaxBytes(options?.config, maxBytesMb);
-      // The effective byte limit is one aggregate budget for the whole
-      // model-originated request: 20 images at the 100 MiB per-image cap would
-      // otherwise retain ~2 GiB of buffers before native/fallback dispatch.
-      // Each load draws from the remaining budget; exhaustion skips the rest.
-      let remainingImageBudgetBytes = maxBytes;
+      // Only a model-supplied maxBytesMb opens an aggregate budget for the
+      // whole request: 20 images at the 100 MiB per-image cap would otherwise
+      // retain ~2 GiB of buffers before native/fallback dispatch. Operator
+      // mediaMaxMb keeps its per-image contract (docs/gateway/protocol.md) and
+      // never becomes a request budget. Each load draws from the remaining
+      // budget; exhaustion skips the rest.
+      let remainingImageBudgetBytes = maxBytesMb !== undefined ? maxBytes : undefined;
       let imageRoute:
         | { kind: "native" }
         | {
@@ -1144,36 +1147,54 @@ export function createImageTool(options?: {
         });
         const imageWebMedia = await imageToolProviderDeps.loadImageWebMediaRuntime();
 
-        const media = isDataUrl
-          ? await (async () => {
-              const decoded = decodeDataUrl(resolvedImage, {
-                maxBytes: remainingImageBudgetBytes,
-              });
-              return await imageWebMedia.optimizeImageBufferForWebMedia({
-                buffer: decoded.buffer,
-                contentType: decoded.mimeType,
-                maxBytes: remainingImageBudgetBytes,
-                imageCompression,
-              });
-            })()
-          : sandboxConfig
-            ? await imageWebMedia.loadWebMedia(resolvedPath ?? resolvedImage, {
-                maxBytes: remainingImageBudgetBytes,
-                sandboxValidated: true,
-                readFile: createSandboxBridgeReadFile({ sandbox: sandboxConfig }),
-                imageCompression,
-              })
-            : await imageWebMedia.loadWebMedia(resolvedPath ?? resolvedImage, {
-                maxBytes: remainingImageBudgetBytes,
-                localRoots: mediaLocalRoots,
-                inboundRoots: mediaInboundRoots,
-                ssrfPolicy: remoteMediaSsrfPolicy,
-                ...(isHttpUrl ? { readIdleTimeoutMs: REMOTE_MEDIA_READ_IDLE_TIMEOUT_MS } : {}),
-                // Forward the run abort signal into the fetch layer so an abort
-                // mid-download disconnects the in-flight socket.
-                ...(signal ? { requestInit: { signal } } : {}),
-                imageCompression,
-              });
+        // Remaining model-budget allowance when a budget is active (always ≤
+        // the per-image cap), otherwise the plain per-image limit.
+        const loadMaxBytes = remainingImageBudgetBytes ?? maxBytes;
+        let media: Awaited<ReturnType<typeof imageWebMedia.loadWebMedia>>;
+        try {
+          media = isDataUrl
+            ? await (async () => {
+                const decoded = decodeDataUrl(resolvedImage, {
+                  maxBytes: loadMaxBytes,
+                });
+                return await imageWebMedia.optimizeImageBufferForWebMedia({
+                  buffer: decoded.buffer,
+                  contentType: decoded.mimeType,
+                  maxBytes: loadMaxBytes,
+                  imageCompression,
+                });
+              })()
+            : sandboxConfig
+              ? await imageWebMedia.loadWebMedia(resolvedPath ?? resolvedImage, {
+                  maxBytes: loadMaxBytes,
+                  sandboxValidated: true,
+                  readFile: createSandboxBridgeReadFile({ sandbox: sandboxConfig }),
+                  imageCompression,
+                })
+              : await imageWebMedia.loadWebMedia(resolvedPath ?? resolvedImage, {
+                  maxBytes: loadMaxBytes,
+                  localRoots: mediaLocalRoots,
+                  inboundRoots: mediaInboundRoots,
+                  ssrfPolicy: remoteMediaSsrfPolicy,
+                  ...(isHttpUrl ? { readIdleTimeoutMs: REMOTE_MEDIA_READ_IDLE_TIMEOUT_MS } : {}),
+                  // Forward the run abort signal into the fetch layer so an abort
+                  // mid-download disconnects the in-flight socket.
+                  ...(signal ? { requestInit: { signal } } : {}),
+                  imageCompression,
+                });
+        } catch (err) {
+          // An image that only exceeds the remaining model-request budget takes
+          // the same recorded-skip path as budget exhaustion instead of
+          // failing the whole call and discarding already-loaded images.
+          if (remainingImageBudgetBytes !== undefined && err instanceof MediaSizeCapExceededError) {
+            budgetSkippedImageCount = imageInputs.length - loadedImages.length;
+            logWarn(
+              `image-tool: image exceeds remaining request byte budget; skipping ${budgetSkippedImageCount} image(s)`,
+            );
+            break;
+          }
+          throw err;
+        }
         if (media.kind !== "image") {
           throw new Error(`Unsupported media type: ${media.kind}`);
         }

--- a/src/media/media-size-cap-error.ts
+++ b/src/media/media-size-cap-error.ts
@@ -1,0 +1,16 @@
+/**
+ * Thrown when media exceeds the caller-provided byte cap. Message text matches
+ * the previous plain Error so existing matchers keep working; the class lets
+ * owners (e.g. the image tool request budget) distinguish an expected cap
+ * rejection from genuine load failures. Kept in its own module so lazy-boundary
+ * consumers can import the type without statically pulling in web-media.
+ */
+export class MediaSizeCapExceededError extends Error {
+  readonly capBytes: number;
+
+  constructor(message: string, params: { capBytes: number; cause?: unknown }) {
+    super(message, params.cause !== undefined ? { cause: params.cause } : undefined);
+    this.name = "MediaSizeCapExceededError";
+    this.capBytes = params.capBytes;
+  }
+}

--- a/src/media/web-media.ts
+++ b/src/media/web-media.ts
@@ -45,12 +45,12 @@ import {
   type LocalMediaAccessErrorCode,
 } from "./local-media-access.js";
 import { MediaReferenceError, resolveInboundMediaReference } from "./media-reference.js";
-import { MediaSizeCapExceededError } from "./media-size-cap-error.js";
 import {
   createImageProcessor,
   readImageMetadataFromHeader,
   readImageProbeFromHeader,
 } from "./media-services.js";
+import { MediaSizeCapExceededError } from "./media-size-cap-error.js";
 import { extractOriginalFilename, getMediaDir } from "./store.js";
 
 export { getDefaultLocalRoots, LocalMediaAccessError };

--- a/src/media/web-media.ts
+++ b/src/media/web-media.ts
@@ -36,7 +36,7 @@ import {
 import { resolveUserPath } from "../utils.js";
 import { chunkItems } from "../utils/chunk-items.js";
 import { readOutboundMediaFile } from "./bounded-read-file.js";
-import { readRemoteMediaBuffer } from "./fetch.js";
+import { MediaFetchError, readRemoteMediaBuffer } from "./fetch.js";
 import type { OutboundMediaReadFile } from "./load-options.js";
 import {
   assertLocalMediaAllowed,
@@ -45,6 +45,7 @@ import {
   type LocalMediaAccessErrorCode,
 } from "./local-media-access.js";
 import { MediaReferenceError, resolveInboundMediaReference } from "./media-reference.js";
+import { MediaSizeCapExceededError } from "./media-size-cap-error.js";
 import {
   createImageProcessor,
   readImageMetadataFromHeader,
@@ -960,7 +961,9 @@ export async function optimizeImageBufferForWebMedia(params: {
   const cap = effectiveImageBytesCap(baseCap, params.imageCompression) ?? baseCap;
   if (params.contentType === "image/gif") {
     if (params.buffer.length > cap) {
-      throw new Error(formatCapLimit("GIF", cap, params.buffer.length));
+      throw new MediaSizeCapExceededError(formatCapLimit("GIF", cap, params.buffer.length), {
+        capBytes: cap,
+      });
     }
     assertImageSatisfiesHardDimensionPolicy(params.buffer, params.imageCompression);
     return {
@@ -994,7 +997,9 @@ export async function optimizeImageBufferForWebMedia(params: {
   });
   logOptimizedImage({ originalSize: params.buffer.length, optimized });
   if (optimized.buffer.length > cap) {
-    throw new Error(formatCapReduce("Media", cap, optimized.buffer.length));
+    throw new MediaSizeCapExceededError(formatCapReduce("Media", cap, optimized.buffer.length), {
+      capBytes: cap,
+    });
   }
   return {
     buffer: optimized.buffer,
@@ -1060,7 +1065,9 @@ async function loadWebMediaInternal(
     logOptimizedImage({ originalSize, optimized });
 
     if (optimized.buffer.length > cap) {
-      throw new Error(formatCapReduce("Media", cap, optimized.buffer.length));
+      throw new MediaSizeCapExceededError(formatCapReduce("Media", cap, optimized.buffer.length), {
+        capBytes: cap,
+      });
     }
 
     const fileName =
@@ -1091,7 +1098,10 @@ async function loadWebMediaInternal(
       const isGif = params.contentType === "image/gif";
       if (isGif || !optimizeImages) {
         if (params.buffer.length > imageCap) {
-          throw new Error(formatCapLimit(isGif ? "GIF" : "Media", imageCap, params.buffer.length));
+          throw new MediaSizeCapExceededError(
+            formatCapLimit(isGif ? "GIF" : "Media", imageCap, params.buffer.length),
+            { capBytes: imageCap },
+          );
         }
         assertImageSatisfiesHardDimensionPolicy(params.buffer, imageCompression);
         return {
@@ -1124,7 +1134,9 @@ async function loadWebMediaInternal(
       };
     }
     if (params.buffer.length > cap) {
-      throw new Error(formatCapLimit("Media", cap, params.buffer.length));
+      throw new MediaSizeCapExceededError(formatCapLimit("Media", cap, params.buffer.length), {
+        capBytes: cap,
+      });
     }
     return {
       buffer: params.buffer,
@@ -1153,16 +1165,30 @@ async function loadWebMediaInternal(
           allowPrivateProxy: true,
         }
       : undefined;
-    const fetched = await readRemoteMediaBuffer({
-      url: mediaUrl,
-      fetchImpl,
-      requestInit,
-      readIdleTimeoutMs,
-      maxBytes: sourceReadCap,
-      ssrfPolicy,
-      dispatcherPolicy,
-      trustExplicitProxyDns,
-    });
+    // Normalize the remote byte-cap rejection into the same typed cap error
+    // local/data-url loads produce, so owners see one cap-error contract.
+    const fetched = await (async () => {
+      try {
+        return await readRemoteMediaBuffer({
+          url: mediaUrl,
+          fetchImpl,
+          requestInit,
+          readIdleTimeoutMs,
+          maxBytes: sourceReadCap,
+          ssrfPolicy,
+          dispatcherPolicy,
+          trustExplicitProxyDns,
+        });
+      } catch (err) {
+        if (err instanceof MediaFetchError && err.code === "max_bytes") {
+          throw new MediaSizeCapExceededError(err.message, {
+            capBytes: sourceReadCap,
+            cause: err,
+          });
+        }
+        throw err;
+      }
+    })();
     const { buffer, contentType, fileName } = fetched;
     const kind = kindFromMime(contentType);
     return await clampAndFinalize({ buffer, contentType, kind, fileName });
@@ -1221,9 +1247,10 @@ async function loadWebMediaInternal(
     } catch (err) {
       if (err instanceof FsSafeError) {
         if (err.code === "too-large") {
-          throw new Error(`Media exceeds ${formatMb(sourceReadCap, 0)}MB limit`, {
-            cause: err,
-          });
+          throw new MediaSizeCapExceededError(
+            `Media exceeds ${formatMb(sourceReadCap, 0)}MB limit`,
+            { capBytes: sourceReadCap, cause: err },
+          );
         }
         if (err.code === "not-found") {
           throw new LocalMediaAccessError("not-found", `Local media file not found: ${mediaUrl}`, {


### PR DESCRIPTION
## What Problem This Solves

The `image` agent tool accepts two model-supplied integer parameters — `maxBytesMb` and `maxImages` — with only lower bounds:
- `maxBytesMb` (via `readFiniteNumberParam`) has `exclusiveMinimum: 0` but no upper ceiling
- `maxImages` (via `readPositiveIntegerParam`) has `minimum: 1` but no upper ceiling

A pathological model input can:
1. Set `maxBytesMb: 1_000_000_000` (≈1 PB), feeding a 1-petabyte allocation target into `pickMaxBytes` → `imageWebMedia.optimizeImageBufferForWebMedia()` / `loadWebMedia()` in the image compression pipeline
2. Set `maxImages: 1_000_000_000` to silently bypass the `DEFAULT_MAX_IMAGES = 20` gate, accepting millions of image references into a processing loop
3. Even within the clamped limits, accumulate ~2 GiB of retained image buffers in one call: a 100 MB per-image cap × 20 permitted images all get pushed into `loadedImages` before native-result construction or fallback-provider dispatch

Both are at the tool's untrusted-input boundary where the model controls the values. The image compression config path (`cfg?.agents?.defaults?.mediaMaxMb`) is intentionally left uncapped — that is the operator's decision.

## Why This Change Was Made

The tool's parameter-read site and `pickMaxBytes` helper are the correct defense-in-depth points. Both `maxBytesMb` and `maxImages` are intentionally left without a schema ceiling so that pathological model-supplied values reach the runtime clamp rather than being rejected by schema validation before the operator warning can fire. The byte cap is generous (100 MB) to avoid constraining legitimate use while blocking the pathological range. The image-count cap is the existing 20-image tool contract (`DEFAULT_MAX_IMAGES`), preventing a model from overriding that limit. This follows the pattern established by `sessions-list-tool` (#110739): clamp model-supplied values at the tool boundary, leave user/operator config and RPC contracts unchanged. When clamping occurs, a `logWarn` entry is emitted for operator observability.

Follow-up (2026-08-09, addresses the P1 aggregate-payload finding): a **model-supplied** `maxBytesMb` now doubles as one aggregate budget for the whole model-originated request. Each image load draws its size limit from the remaining budget (`min(remaining, per-image cap)` — the remaining allowance by construction), and each loaded buffer debits the budget by its actual byte length. When the budget is exhausted, the loader stops and the skip is a recorded non-outcome rather than a silent truncation: a `logWarn` fires, the result text tells the model how many images were skipped and why, and `details.skippedImages` carries `{ count, budgetBytes, reason: "request_budget_exhausted" }` on both the native and fallback routes. The model-facing `maxBytesMb` schema description now states that the value caps each image and the combined total for the call.

Follow-up 2 (2026-08-09, head `7db81022aa`, addresses the two follow-up P1 findings):

- **Operator `mediaMaxMb` keeps its per-image contract.** The aggregate budget now opens only from a model-supplied `maxBytesMb`. `mediaMaxMb` is documented in `docs/gateway/protocol.md` as a per-attachment (per-image) limit; it is still resolved unclamped by `pickMaxBytes` as the per-image cap, and never becomes a request budget. With operator config and no model `maxBytesMb`, multiple individually-legal images all load exactly as before.
- **Budget overflow mid-loop is a recorded skip, not a thrown call.** The media pipeline's byte-cap rejections are now a typed `MediaSizeCapExceededError` (new `src/media/media-size-cap-error.ts`, messages unchanged) thrown by `loadWebMedia`/`optimizeImageBufferForWebMedia` (local, remote-fetch `max_bytes`, GIF/optimize caps) and by `decodeDataUrl`. When a model-originated budget is active and an image exceeds only the *remaining* allowance, the loader takes the same recorded-skip path as budget exhaustion instead of failing the whole tool call and discarding already-loaded images. Genuine load errors (ENOENT, network, unsupported media) still throw. The class lives in its own module because `web-media.js` is an intentional lazy boundary for the image tool (`await import(...)`) — statically importing the class from there would defeat it.

## User Impact

Before: a model-issued `image` tool call with `maxBytesMb: 1_000_000_000` or `maxImages: 1_000_000_000` passes validation and can trigger unbounded memory allocation or override the 20-image per-call limit; even clamped, 20 × 100 MB images can accumulate ~2 GiB before dispatch. After: `maxBytesMb` is clamped to 100 MB, `maxImages` is clamped to the established 20-image limit, and a model-supplied byte limit bounds the combined payload of the whole request — images past the budget (including one that exceeds only the remaining allowance) are skipped with a visible, recorded outcome. The operator `mediaMaxMb` config keeps its documented per-image semantics unchanged.

## Evidence

### Source change — 6 files, +450/−56 (production +194/−54, tests +256/−2)

```
src/agents/tools/image-tool.helpers.ts |   4 +-
src/agents/tools/image-tool.result.ts  |   9 +-
src/agents/tools/image-tool.test.ts    | 256 ++++++++++++++++++++++++++++++++-
src/agents/tools/image-tool.ts         | 119 +++++++++++++++----
src/media/media-size-cap-error.ts      |  16 +++
src/media/web-media.ts                 |  65 +++++++---
```

### Tool-level clamp (image-tool.ts:960-966)

```ts
// Model-supplied maxImages is clamped to prevent pathological gate bypass
// in image processing loops. The DEFAULT_MAX_IMAGES floor is unchanged.
const maxImagesRaw = readPositiveIntegerParam(record, "maxImages");
const maxImages =
  maxImagesRaw === undefined ? DEFAULT_MAX_IMAGES : Math.min(maxImagesRaw, MAX_IMAGES_CAP);
if (maxImagesRaw !== undefined && maxImagesRaw > MAX_IMAGES_CAP) {
  logWarn(`image-tool: maxImages clamped from ${maxImagesRaw} to ${MAX_IMAGES_CAP}`);
}
```

`MAX_IMAGES_CAP` is now `DEFAULT_MAX_IMAGES` (20), preserving the existing tool contract.

### pickMaxBytes clamp (image-tool.ts:420-429)

```ts
function pickMaxBytes(cfg?: OpenClawConfig, maxBytesMb?: number): number | undefined {
  if (typeof maxBytesMb === "number" && Number.isFinite(maxBytesMb) && maxBytesMb > 0) {
    if (maxBytesMb > MAX_IMAGE_MB_CAP) {
      logWarn(`image-tool: maxBytesMb clamped from ${maxBytesMb} to ${MAX_IMAGE_MB_CAP}`);
    }
    return Math.floor(Math.min(maxBytesMb, MAX_IMAGE_MB_CAP) * 1024 * 1024);
  }
```

### Aggregate request budget — model-originated only (image-tool.ts, loading owner)

```ts
const maxBytes = pickMaxBytes(options?.config, maxBytesMb);
// Only a model-supplied maxBytesMb opens an aggregate budget for the
// whole request: 20 images at the 100 MiB per-image cap would otherwise
// retain ~2 GiB of buffers before native/fallback dispatch. Operator
// mediaMaxMb keeps its per-image contract (docs/gateway/protocol.md) and
// never becomes a request budget. Each load draws from the remaining
// budget; exhaustion skips the rest.
let remainingImageBudgetBytes = maxBytesMb !== undefined ? maxBytes : undefined;
```

Inside the sequential load loop, each load's limit is `remainingImageBudgetBytes ?? maxBytes` (remaining allowance when a budget is active, otherwise the plain per-image limit), and each retained buffer debits the budget. Two recorded-skip exits exist:

```ts
// 1) Budget exhausted before the next load:
if (remainingImageBudgetBytes !== undefined && remainingImageBudgetBytes <= 0) {
  budgetSkippedImageCount = imageInputs.length - loadedImages.length;
  logWarn(`image-tool: request byte budget exhausted; skipping ${budgetSkippedImageCount} image(s)`);
  break;
}
// 2) An image exceeds only the remaining allowance mid-loop:
} catch (err) {
  if (remainingImageBudgetBytes !== undefined && err instanceof MediaSizeCapExceededError) {
    budgetSkippedImageCount = imageInputs.length - loadedImages.length;
    logWarn(`image-tool: image exceeds remaining request byte budget; skipping ${budgetSkippedImageCount} image(s)`);
    break;
  }
  throw err;
}
```

Both exits surface the same recorded non-outcome — native result text becomes `Loaded 3 images for direct visual inspection. Skipped 17 images: the request byte budget was exhausted.`, the fallback route appends the same note to the vision-model answer, and both carry `details.skippedImages = { count, budgetBytes, reason: "request_budget_exhausted" }`.

### Typed byte-cap error seam (src/media/media-size-cap-error.ts)

```ts
export class MediaSizeCapExceededError extends Error {
  readonly capBytes: number;
  constructor(message: string, params: { capBytes: number; cause?: unknown }) { ... }
}
```

All byte-cap rejections in `web-media.ts` (GIF cap, optimize-reduce caps, generic image/document caps, local-file `too-large`, and remote `MediaFetchError` code `max_bytes` normalized at the `loadWebMedia` boundary) plus `decodeDataUrl`'s payload-limit rejection now throw this class with **identical message text**, so existing callers and matchers are unaffected while owners can distinguish expected cap rejections from genuine load failures.

### Schema annotations (image-tool.ts:927-932)

```ts
maxBytesMb: optionalFiniteNumberSchema({
  description:
    "Max image size in MB; caps each image and the combined total for this call. Values above 100 are clamped.",
  exclusiveMinimum: 0,
}),
maxImages: optionalPositiveIntegerSchema(),
```

Neither parameter has a schema ceiling, so values above the intended contract reach the runtime clamp instead of being rejected by schema validation. The `maxImages` clamp preserves the established 20-image limit; the `maxBytesMb` clamp is enforced in `pickMaxBytes` with an operator-visible warning, and its description matches the aggregate-budget behavior.

### Real behavior proof (focused test execution)

Remote Linux, Node 22, `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree` (worktree `.git` pointer is not resolvable on the proof host):

```
$ node scripts/run-vitest.mjs src/agents/tools/image-tool.test.ts
 Test Files  1 passed (1)
      Tests  107 passed (107)
```

```
$ node scripts/run-vitest.mjs src/media/web-media.test.ts
 Test Files  1 passed (1)
      Tests  85 passed (85)
```

`git diff --check`: clean.

**Verification:**
- `MAX_IMAGE_MB_CAP = 100` — enforced at runtime in `pickMaxBytes`, not via schema rejection
- No schema ceiling on `maxBytesMb`; a JSON-schema validator accepts `maxBytesMb: 1_000_000_000` before the tool handler clamps it
- `MAX_IMAGES_CAP = DEFAULT_MAX_IMAGES = 20` — runtime clamp preserves the established 20-image tool contract
- 21 unique tiny PNGs + `maxImages: 1_000_000_000` → `too_many_images` with `max: 20` (clamp fires before image processing)
- 3 unique PNGs + `maxImages: 1_000_000_000` → 3 images processed (clamped limit 20 ≥ actual count)
- `pickMaxBytes(undefined, 1_000_000_000)` → `100 * 1024 * 1024` (clamped from 1e9 MB)
- `pickMaxBytes(undefined, 50)` → `50 * 1024 * 1024` (unchanged below cap)
- `pickMaxBytes({ mediaMaxMb: 75 }, undefined)` → `75 * 1024 * 1024` (operator config fallback, unchanged)
- 20 unique PNGs with a model byte budget fitting exactly 3 → only 3 reach the provider (fetch called 3×), the other 17 are skipped and recorded in `details.skippedImages` plus the result text
- Operator `mediaMaxMb: 140B` with no model `maxBytesMb` and 3 × 70B images → all 3 load (per-image semantics preserved; an aggregate misreading would have skipped the third)
- Mixed sizes (70B image, then images larger than the 1-byte remaining budget) → recorded skip of the remaining 2 images instead of a thrown call, on both the fallback (MiniMax) and native routes
- `logWarn()` emitted when clamping occurs and on both recorded-skip exits, for operator observability



### Real behavior proof (schema validation + full dispatch)

The focused tests above exercise mocked provider fixtures. The transcript below runs the actual `createImageTool` runtime on the PR head with `modelHasVision: true`, validates the tool's JSON schema with Ajv, then dispatches pathological model-supplied inputs through `tool.execute()`. No test framework or mocked media pipeline is involved.

```bash
$ npx tsx proof-image-tool-bound-v2.ts
```

```
=== PR 112017 image-tool bound proof (schema + dispatch) ===

Tool: View Image (image)
Agent dir: /tmp/image-tool-bound-proof-XnMB8w
Workspace dir: /tmp/image-tool-bound-proof-XnMB8w

--- 1) Schema check: maxBytesMb has no ceiling ---
maxBytesMb JSON schema: {"type":"number","exclusiveMinimum":0}
Schema validation for maxBytesMb=1_000_000_000: PASS

--- 2) maxImages=1_000_000_000 with 21 images → clamped to 20 and rejected ---
[image-tool] maxImages clamped from 1000000000 to 20
{
  "content": [
    {
      "type": "text",
      "text": "Too many images: 21 provided, maximum is 20. Please reduce the number of images."
    }
  ],
  "details": {
    "error": "too_many_images",
    "count": 21,
    "max": 20
  }
}

--- 3) maxImages=1_000_000_000 with 3 images → clamp accepted, images load ---
[image-tool] maxImages clamped from 1000000000 to 20
result text: Loaded 3 images for direct visual inspection.
details: {
  "transport": "native",
  "images": [
    {
      "image": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGNg/P//PwAGAwL/2o5/bQAAAABJRU5ErkJggg=="
    },
    {
      "image": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGNg+v//PwAGBwMAmoRw9wAAAABJRU5ErkJggg=="
    },
    {
      "image": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGNg/v//PwAGCwMBuXXoCQAAAABJRU5ErkJggg=="
    }
  ],
  "media": {
    "outbound": false
  }
}

--- 4) Full dispatch: oversized maxBytesMb reaches handler clamp ---
[image-tool] maxBytesMb clamped from 1000000000 to 100
result text: Loaded 1 image for direct visual inspection.
details: {
  "transport": "native",
  "image": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGNg+P//PwAF/wL+Xg47rQAAAABJRU5ErkJggg==",
  "media": {
    "outbound": false
  }
}

=== Proof complete ===
```

**What this proves:**
- The tool's JSON schema for `maxBytesMb` has no `maximum`, so a schema-validating dispatcher accepts `maxBytesMb: 1_000_000_000` instead of rejecting it before the handler runs.
- `maxImages: 1_000_000_000` with 21 images triggers the runtime clamp warning (`maxImages clamped from 1000000000 to 20`) and returns `too_many_images` with `max: 20` before any image is decoded.
- `maxImages: 1_000_000_000` with 3 images emits the same clamp warning but passes the gate and loads all 3 images (clamped limit 20 ≥ actual count).
- `maxBytesMb: 1_000_000_000` with a single data-URL image passes schema validation, reaches `tool.execute()`, emits the byte-cap warning (`maxBytesMb clamped from 1000000000 to 100`), and still completes the native image load — confirming the value was clamped to 100 MB at runtime before reaching the media pipeline.

The proof script uses only the production `createImageTool`, `encodePngRgba`, and `ajv` paths; it is not committed to the PR.

### Real behavior proof (aggregate budget, native dispatch)

Follow-up transcript (2026-08-09, head `7db81022aa`) running the production `createImageTool` native-vision route outside any test framework: 20 distinct 70-byte PNGs across four scenarios — model budget fitting exactly three loads, operator-only `mediaMaxMb`, a mixed-size mid-loop budget overflow, and a no-limit control.

```bash
$ node_modules/.bin/tsx proof-image-tool-aggregate-budget.ts
```

```
=== PR 112017 aggregate image budget proof v2 (native dispatch) ===
Agent dir: /tmp/image-tool-budget-proof-jvpuei

Per-image bytes: 70; 3-image budget: 210 bytes
[image-tool] request byte budget exhausted; skipping 17 image(s)

--- 1) 20 images, model budget fits exactly 3 → 17 skipped and recorded ---
result text: Loaded 3 images for direct visual inspection. Skipped 17 images: the request byte budget was exhausted.
image blocks returned: 3
details.images count: 3
details.skippedImages: {"count":17,"budgetBytes":210,"reason":"request_budget_exhausted"}

--- 2) operator mediaMaxMb (140B), no model limit → all 3 images load (per-image semantics) ---
result text: Loaded 3 images for direct visual inspection.
image blocks returned: 3
details.images count: 3
details.skippedImages: undefined
[image-tool] image exceeds remaining request byte budget; skipping 2 image(s)

--- 3) mixed sizes: image 2 exceeds remaining budget → recorded skip, no throw ---
result text: Loaded 1 image for direct visual inspection. Skipped 2 images: the request byte budget was exhausted.
image blocks returned: 1
details.images count: n/a
details.skippedImages: {"count":2,"budgetBytes":71,"reason":"request_budget_exhausted"}

--- 4) control: same 20 images without maxBytesMb → all 20 load (unchanged default) ---
result text: Loaded 20 images for direct visual inspection.
image blocks returned: 20
details.images count: 20
details.skippedImages: undefined

=== Proof complete ===
```

**What this proves:**
- The 20-image boundary no longer accumulates unboundedly: with a 210-byte model budget, exactly 3 images load and the other 17 are never read into `loadedImages`.
- Operator `mediaMaxMb` is per-image: 3 × 70-byte images all load under a 140-byte operator cap with no model limit, with no skip recorded — the aggregate budget does not apply to operator config.
- A mid-loop image that exceeds only the remaining budget (71-byte budget, 1 byte left after the first image) becomes a recorded skip of the remaining 2 images — the call no longer throws away the loaded image.
- Every skip is a visible, recorded outcome on the production path: operator `logWarn`, model-facing result text, and machine-readable `details.skippedImages` with the budget and reason. With no byte limit anywhere, all 20 images load as before — the default path is unchanged.

The proof script uses only the production `createImageTool` and `encodePngRgba` paths; it is not committed to the PR.
