### PR TITLE
fix(cli): correct optional plugin enable guidance

### DIFF
--- a/docs/cli/wiki.md
+++ b/docs/cli/wiki.md
@@ -8,7 +8,12 @@ title: "Wiki"
 
 # `openclaw wiki`
 
-Inspect and maintain the `memory-wiki` vault. Provided by the bundled `memory-wiki` plugin.
+Inspect and maintain the `memory-wiki` vault. Provided by the bundled optional `memory-wiki` plugin. Enable it before first use:
+
+```bash
+openclaw plugins enable memory-wiki
+openclaw gateway restart
+```
 
 Related: [Memory Wiki plugin](/plugins/memory-wiki), [Memory Overview](/concepts/memory), [CLI: memory](/cli/memory)
 

--- a/docs/plugins/memory-wiki.md
+++ b/docs/plugins/memory-wiki.md
@@ -17,6 +17,13 @@ dreaming stay owned by whichever memory backend is configured
 (`memory-core`, QMD, Honcho, etc.). `memory-wiki` sits beside it and compiles
 knowledge into a maintained wiki layer.
 
+Enable the plugin before using its CLI, tools, or runtime integration:
+
+```bash
+openclaw plugins enable memory-wiki
+openclaw gateway restart
+```
+
 | Layer                | Owns                                                                              |
 | -------------------- | --------------------------------------------------------------------------------- |
 | Active memory plugin | Recall, semantic search, promotion, dreaming, memory runtime                      |

--- a/extensions/workboard/openclaw.plugin.json
+++ b/extensions/workboard/openclaw.plugin.json
@@ -47,13 +47,7 @@
       "workboard_move"
     ]
   },
-  "commandAliases": [
-    {
-      "name": "workboard",
-      "kind": "runtime-slash",
-      "cliCommand": "workboard"
-    }
-  ],
+  "commandAliases": [{ "name": "workboard" }],
   "toolMetadata": {
     "workboard_list": {
       "optional": true

--- a/src/cli/run-main.test.ts
+++ b/src/cli/run-main.test.ts
@@ -51,6 +51,15 @@ const browserCommandAliasRegistry: PluginManifestCommandAliasRegistry = {
   ],
 };
 
+const workboardCommandAliasRegistry: PluginManifestCommandAliasRegistry = {
+  plugins: [
+    {
+      id: "workboard",
+      commandAliases: [{ name: "workboard" }],
+    },
+  ],
+};
+
 describe("isGatewayRunFastPathArgv", () => {
   it("matches only plain gateway foreground starts without root options or help", () => {
     expect(isGatewayRunFastPathArgv(["node", "openclaw", "gateway"])).toBe(true);
@@ -402,6 +411,19 @@ describe("resolveMissingPluginCommandMessage", () => {
     expect(message).toContain('"voice-call" plugin');
     expect(message).toContain("disabled by default");
     expect(message).toContain("openclaw plugins enable voice-call");
+  });
+
+  it("prefers CLI ownership for plugins that also register a slash command", () => {
+    const message = resolveMissingPluginCommandMessage(
+      "workboard",
+      {},
+      { registry: workboardCommandAliasRegistry },
+    );
+
+    expect(message).toContain('"workboard" plugin');
+    expect(message).toContain("disabled by default");
+    expect(message).toContain("openclaw plugins enable workboard");
+    expect(message).not.toContain("runtime slash command");
   });
 
   it("returns null for CLI command aliases when disabled-by-default parent plugins are enabled", () => {

--- a/src/plugins/bundled-plugin-metadata.test.ts
+++ b/src/plugins/bundled-plugin-metadata.test.ts
@@ -581,6 +581,15 @@ describe("bundled plugin metadata", () => {
     expect(entry?.manifest.activation?.onCommands).toStrictEqual(["voicecall"]);
   });
 
+  it("keeps Workboard CLI ownership separate from its slash command", () => {
+    const entry = listRepoBundledPluginManifests().find(
+      ({ manifest }) => manifest.id === "workboard",
+    );
+
+    expect(entry?.manifest.commandAliases).toStrictEqual([{ name: "workboard" }]);
+    expect(entry?.manifest.activation?.onCommands).toStrictEqual(["workboard"]);
+  });
+
   it("scopes Codex CLI activation to the codex command", () => {
     const entry = listRepoBundledPluginManifests().find(({ manifest }) => manifest.id === "codex");
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users invoking the disabled Workboard CLI would receive contradictory guidance claiming `workboard` was only a runtime slash command while also being told to run `openclaw workboard`. It also fixes Wiki documentation that presented `openclaw wiki` commands without explaining that the optional `memory-wiki` plugin must be enabled first.

## Why This Change Was Made

Workboard now declares ordinary CLI command ownership in its manifest; its separately registered `/workboard` runtime command remains unchanged. The Wiki CLI and plugin documentation now include the same enable-and-restart prerequisite used by other optional bundled plugins. Focused tests lock both the missing-command policy and the source manifest metadata.

## User Impact

Operators now get actionable `openclaw plugins enable workboard` guidance when Workboard is disabled, without being incorrectly told that the CLI command does not exist. Wiki users can follow the documentation from a default installation without first hitting an unexplained disabled-plugin error.

## Evidence

- AI-assisted change; reviewed with the repository `autoreview` workflow: clean, no accepted/actionable findings.
- Source-blind behavior validation passed all four clauses: Workboard and Wiki disabled guidance, plus enabled `--help` success for both commands.
- AWS Crabbox live scenario `run_b9fdcba530eb`: built the checkout, launched an isolated random-port Gateway, and passed 189/189 CLI cases. Coverage included 57 top-level help surfaces, optional-plugin enabled/disabled states, JSON stdout integrity, auth and invalid-argument failures, 60 repeated health/status calls, 20-way RPC concurrency, signal interruption, and real OpenAI `gpt-5.6-luna` local inference, Gateway inference, agent, and parallel inference calls.
- Blacksmith Testbox changed-scope gate `tbx_01ky17ay7qpej7fghp5hjyme3k`: passed formatting, type checks, core and extension lint, plugin boundaries, dependency guards, database/storage guards, and import-cycle checks.
- Post-rebase focused Testbox proof: [Actions run 29796280548](https://github.com/openclaw/openclaw/actions/runs/29796280548), covering the Workboard policy and bundled-manifest regressions.
- `git diff --check`: passed.
