### PR TITLE
fix(agents): emit a user-visible notice when a turn times out during tool execution

### DIFF
--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -38,8 +38,6 @@ import {
   shouldRetryMissingAssistantTurn,
   shouldRetrySilentErrorAssistantTurn,
   shouldTreatEmptyAssistantReplyAsSilent,
-  TURN_BUDGET_TIMEOUT_NOTICE,
-  TURN_IDLE_TIMEOUT_NOTICE,
 } from "./run/incomplete-turn.js";
 import type { EmbeddedRunAttemptResult } from "./run/types.js";
 
@@ -49,6 +47,18 @@ const EMPTY_RESPONSE_RETRY_INSTRUCTION =
   "The previous attempt did not produce a user-visible answer. Continue from the current state and produce the visible answer now. Do not restart from scratch.";
 const SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION =
   "The previous assistant turn completed its tool calls but did not produce a user-visible answer. Continue from the current transcript and produce the final user-visible answer now. Do not repeat completed tool calls or restart from scratch.";
+// Declared locally rather than imported, matching the retry/continuation instructions
+// above: these notices are internal to the incomplete-turn policy, and exporting them
+// solely for this suite would leave an export unused by production code.
+const TURN_BUDGET_TIMEOUT_NOTICE =
+  "⚠️ I hit my time budget on this request and stopped before finishing. " +
+  "Ask me to continue, or simplify the request. " +
+  "If this happens often, raise `agents.defaults.timeoutSeconds` in your config.";
+const TURN_IDLE_TIMEOUT_NOTICE =
+  "⚠️ The model stopped responding before its idle timeout elapsed, so I stopped before finishing. " +
+  "Ask me to continue, or simplify the request. " +
+  "If this happens often, raise `models.providers.<id>.timeoutSeconds` for slow local or self-hosted providers; " +
+  "`agents.defaults.timeoutSeconds` cannot extend a provider idle timeout.";
 
 let runEmbeddedAgent: typeof import("./run.js").runEmbeddedAgent;
 

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -39,6 +39,7 @@ import {
   shouldRetrySilentErrorAssistantTurn,
   shouldTreatEmptyAssistantReplyAsSilent,
   TURN_BUDGET_TIMEOUT_NOTICE,
+  TURN_IDLE_TIMEOUT_NOTICE,
 } from "./run/incomplete-turn.js";
 import type { EmbeddedRunAttemptResult } from "./run/types.js";
 
@@ -4984,6 +4985,61 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
     expect((result.payloads ?? []).some((p) => (p.text ?? "").includes("time budget"))).toBe(false);
     expect(result.meta.livenessState).toBe("paused");
+  });
+
+  it("stays silent when an external cancellation races a tool-execution timeout", async () => {
+    mockedClassifyFailoverReason.mockReturnValue(null);
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: [],
+        timedOut: true,
+        timedOutDuringToolExecution: true,
+        externalAbort: true,
+        lastToolError: { toolName: "exec", error: "command aborted", meta: "sleep 30" },
+      }),
+    );
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "openai",
+      model: "gpt-5.5",
+      runId: "run-tool-exec-timeout-external-abort",
+      config: { messages: { suppressToolErrors: true } } as OpenClawConfig,
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+    // An operator cancellation owns the interruption, so the run stays silent
+    // instead of claiming the configured time budget was exhausted.
+    expect((result.payloads ?? []).some((p) => (p.text ?? "").includes("time budget"))).toBe(false);
+    expect(result.payloads?.some((p) => p.text === TURN_BUDGET_TIMEOUT_NOTICE)).toBeFalsy();
+  });
+
+  it("points an idle tool-execution timeout at the provider timeout, not the run budget", async () => {
+    mockedClassifyFailoverReason.mockReturnValue(null);
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: [],
+        timedOut: true,
+        idleTimedOut: true,
+        timedOutDuringToolExecution: true,
+        lastToolError: { toolName: "exec", error: "command aborted", meta: "sleep 30" },
+      }),
+    );
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "openai",
+      model: "gpt-5.5",
+      runId: "run-tool-exec-timeout-idle-notice",
+      config: { messages: { suppressToolErrors: true } } as OpenClawConfig,
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+    expect(result.payloads?.[0]?.isError).toBe(true);
+    expect(result.payloads?.[0]?.text).toBe(TURN_IDLE_TIMEOUT_NOTICE);
+    // The remediation must name the provider idle timeout, which the run budget cannot extend.
+    expect(result.payloads?.[0]?.text).toContain("models.providers.<id>.timeoutSeconds");
+    expect(result.payloads?.[0]?.text).not.toBe(TURN_BUDGET_TIMEOUT_NOTICE);
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -38,6 +38,7 @@ import {
   shouldRetryMissingAssistantTurn,
   shouldRetrySilentErrorAssistantTurn,
   shouldTreatEmptyAssistantReplyAsSilent,
+  TURN_BUDGET_TIMEOUT_NOTICE,
 } from "./run/incomplete-turn.js";
 import type { EmbeddedRunAttemptResult } from "./run/types.js";
 
@@ -4909,6 +4910,76 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     expect(result.payloads).toBeUndefined();
     expect(result.meta.livenessState).toBe("working");
     expectNoWarnMessageWith("planning");
+  });
+
+  it("delivers a turn-budget timeout notice when a tool-execution timeout leaves no visible reply", async () => {
+    mockedClassifyFailoverReason.mockReturnValue(null);
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: [],
+        timedOut: true,
+        timedOutByRunBudget: true,
+        timedOutDuringToolExecution: true,
+      }),
+    );
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "openai",
+      model: "gpt-5.5",
+      runId: "run-tool-exec-timeout-notice",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+    expect(result.payloads?.[0]?.isError).toBe(true);
+    expect(result.payloads?.[0]?.text).toBe(TURN_BUDGET_TIMEOUT_NOTICE);
+    expect(result.meta.livenessState).toBe("abandoned");
+  });
+
+  it("stays silent on a timed-out turn in a silent-reply context (allowEmptyAssistantReplyAsSilent)", async () => {
+    mockedClassifyFailoverReason.mockReturnValue(null);
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: [],
+        timedOut: true,
+        timedOutByRunBudget: true,
+        timedOutDuringToolExecution: true,
+      }),
+    );
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "openai",
+      model: "gpt-5.5",
+      runId: "run-tool-exec-timeout-silent-context",
+      allowEmptyAssistantReplyAsSilent: true,
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+    expect((result.payloads ?? []).some((p) => (p.text ?? "").includes("time budget"))).toBe(false);
+  });
+
+  it("keeps a compaction timeout paused instead of emitting a turn-budget notice", async () => {
+    mockedClassifyFailoverReason.mockReturnValue(null);
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: [],
+        timedOut: true,
+        timedOutByRunBudget: true,
+        timedOutDuringCompaction: true,
+      }),
+    );
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "openai",
+      model: "gpt-5.5",
+      runId: "run-compaction-timeout-paused",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+    expect((result.payloads ?? []).some((p) => (p.text ?? "").includes("time budget"))).toBe(false);
+    expect(result.meta.livenessState).toBe("paused");
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -4920,6 +4920,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
         timedOut: true,
         timedOutByRunBudget: true,
         timedOutDuringToolExecution: true,
+        lastToolError: { toolName: "exec", error: "command aborted", meta: "sleep 30" },
       }),
     );
 
@@ -4928,6 +4929,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       provider: "openai",
       model: "gpt-5.5",
       runId: "run-tool-exec-timeout-notice",
+      config: { messages: { suppressToolErrors: true } } as OpenClawConfig,
     });
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
@@ -4944,6 +4946,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
         timedOut: true,
         timedOutByRunBudget: true,
         timedOutDuringToolExecution: true,
+        lastToolError: { toolName: "exec", error: "command aborted", meta: "sleep 30" },
       }),
     );
 
@@ -4953,6 +4956,7 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       model: "gpt-5.5",
       runId: "run-tool-exec-timeout-silent-context",
       allowEmptyAssistantReplyAsSilent: true,
+      config: { messages: { suppressToolErrors: true } } as OpenClawConfig,
     });
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -5051,5 +5051,32 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     expect(result.payloads?.[0]?.text).toContain("models.providers.<id>.timeoutSeconds");
     expect(result.payloads?.[0]?.text).not.toBe(TURN_BUDGET_TIMEOUT_NOTICE);
   });
+
+  it("stays silent when an explicit NO_REPLY turn also times out during tool execution", async () => {
+    mockedClassifyFailoverReason.mockReturnValue(null);
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: ["NO_REPLY"],
+        timedOut: true,
+        timedOutDuringToolExecution: true,
+        lastToolError: { toolName: "exec", error: "command aborted", meta: "sleep 30" },
+      }),
+    );
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "openai",
+      model: "gpt-5.5",
+      runId: "run-tool-exec-timeout-explicit-silence",
+      config: { messages: { suppressToolErrors: true } } as OpenClawConfig,
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+    // The assistant deliberately declined to answer, so the established silent-reply
+    // owner wins over the timeout notice rather than being bypassed by it.
+    expect(result.payloads?.some((p) => p.text === TURN_BUDGET_TIMEOUT_NOTICE)).toBeFalsy();
+    expect(result.payloads?.some((p) => p.text === TURN_IDLE_TIMEOUT_NOTICE)).toBeFalsy();
+    expect((result.payloads ?? []).some((p) => (p.text ?? "").includes("time budget"))).toBe(false);
+  });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/agents/embedded-agent-runner/run/incomplete-turn.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn.ts
@@ -141,7 +141,7 @@ const EMPTY_RESPONSE_RETRY_INSTRUCTION =
   "The previous attempt did not produce a user-visible answer. Continue from the current state and produce the visible answer now. Do not restart from scratch.";
 const SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION =
   "The previous assistant turn completed its tool calls but did not produce a user-visible answer. Continue from the current transcript and produce the final user-visible answer now. Do not repeat completed tool calls or restart from scratch.";
-export const TURN_BUDGET_TIMEOUT_NOTICE =
+const TURN_BUDGET_TIMEOUT_NOTICE =
   "⚠️ I hit my time budget on this request and stopped before finishing. " +
   "Ask me to continue, or simplify the request. " +
   "If this happens often, raise `agents.defaults.timeoutSeconds` in your config.";
@@ -149,7 +149,7 @@ export const TURN_BUDGET_TIMEOUT_NOTICE =
 // `resolveEmbeddedRunTerminalTimeout` already makes this distinction for prompt
 // timeouts; tool-execution timeouts point at the same setting so the remediation
 // a user is told to change is the one that actually governs the timeout they hit.
-export const TURN_IDLE_TIMEOUT_NOTICE =
+const TURN_IDLE_TIMEOUT_NOTICE =
   "⚠️ The model stopped responding before its idle timeout elapsed, so I stopped before finishing. " +
   "Ask me to continue, or simplify the request. " +
   "If this happens often, raise `models.providers.<id>.timeoutSeconds` for slow local or self-hosted providers; " +

--- a/src/agents/embedded-agent-runner/run/incomplete-turn.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn.ts
@@ -145,6 +145,15 @@ export const TURN_BUDGET_TIMEOUT_NOTICE =
   "⚠️ I hit my time budget on this request and stopped before finishing. " +
   "Ask me to continue, or simplify the request. " +
   "If this happens often, raise `agents.defaults.timeoutSeconds` in your config.";
+// An idle-watchdog timeout is a provider-side stall, not an exhausted run budget.
+// `resolveEmbeddedRunTerminalTimeout` already makes this distinction for prompt
+// timeouts; tool-execution timeouts point at the same setting so the remediation
+// a user is told to change is the one that actually governs the timeout they hit.
+export const TURN_IDLE_TIMEOUT_NOTICE =
+  "⚠️ The model stopped responding before its idle timeout elapsed, so I stopped before finishing. " +
+  "Ask me to continue, or simplify the request. " +
+  "If this happens often, raise `models.providers.<id>.timeoutSeconds` for slow local or self-hosted providers; " +
+  "`agents.defaults.timeoutSeconds` cannot extend a provider idle timeout.";
 
 /**
  * Marks whether retrying the attempt can safely replay the prompt. Concrete
@@ -268,14 +277,22 @@ export function resolveIncompleteTurnPayloadText(params: {
   });
   // Timeout phase and interruption precedence belong to the canonical attempt terminal.
   // Only its tool-execution timeout may become an incomplete-turn payload here.
+  //
+  // This returns before the general suppression guard below, so it cannot inherit
+  // that guard's external-abort silence and has to reject externally owned
+  // interruptions itself. A `timeout` terminal carries `source: "external"` when an
+  // operator cancellation raced the timeout, so the two states genuinely co-occur;
+  // without this check that cancellation would be reported as an exhausted time budget.
   if (
     terminal.timedOut &&
     terminal.timedOutDuringToolExecution &&
+    !terminal.externalAbort &&
+    !(params.aborted && params.externalAbort) &&
     params.payloadCount === 0 &&
     params.allowEmptyAssistantReplyAsSilent !== true &&
     !hasTimeoutTerminalOutput
   ) {
-    return TURN_BUDGET_TIMEOUT_NOTICE;
+    return terminal.idleTimedOut ? TURN_IDLE_TIMEOUT_NOTICE : TURN_BUDGET_TIMEOUT_NOTICE;
   }
 
   if (

--- a/src/agents/embedded-agent-runner/run/incomplete-turn.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn.ts
@@ -260,6 +260,12 @@ export function resolveIncompleteTurnPayloadText(params: {
     !hasTerminalOutput &&
     Boolean(assistant && hasOnlyAssistantReasoningContent(assistant));
   const terminal = projectAgentRunAttemptTerminal(params.attempt.terminal);
+  // payloadCount, not lastToolError, proves whether error policy exposed the failure.
+  // Keep every other delivery/continuation state as a reason not to double-notify.
+  const hasTimeoutTerminalOutput = hasAttemptTerminalState({
+    ...params.attempt,
+    lastToolError: undefined,
+  });
   // Timeout phase and interruption precedence belong to the canonical attempt terminal.
   // Only its tool-execution timeout may become an incomplete-turn payload here.
   if (
@@ -267,7 +273,7 @@ export function resolveIncompleteTurnPayloadText(params: {
     terminal.timedOutDuringToolExecution &&
     params.payloadCount === 0 &&
     params.allowEmptyAssistantReplyAsSilent !== true &&
-    !hasTerminalOutput
+    !hasTimeoutTerminalOutput
   ) {
     return TURN_BUDGET_TIMEOUT_NOTICE;
   }

--- a/src/agents/embedded-agent-runner/run/incomplete-turn.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn.ts
@@ -141,6 +141,10 @@ const EMPTY_RESPONSE_RETRY_INSTRUCTION =
   "The previous attempt did not produce a user-visible answer. Continue from the current state and produce the visible answer now. Do not restart from scratch.";
 const SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION =
   "The previous assistant turn completed its tool calls but did not produce a user-visible answer. Continue from the current transcript and produce the final user-visible answer now. Do not repeat completed tool calls or restart from scratch.";
+export const TURN_BUDGET_TIMEOUT_NOTICE =
+  "⚠️ I hit my time budget on this request and stopped before finishing. " +
+  "Ask me to continue, or simplify the request. " +
+  "If this happens often, raise `agents.defaults.timeoutSeconds` in your config.";
 
 /**
  * Marks whether retrying the attempt can safely replay the prompt. Concrete
@@ -232,6 +236,7 @@ export function resolveIncompleteTurnPayloadText(params: {
   aborted: boolean;
   externalAbort: boolean;
   timedOut: boolean;
+  allowEmptyAssistantReplyAsSilent?: boolean;
   hadPotentialSideEffects?: boolean;
   attempt: IncompleteTurnAttempt;
 }): string | null {
@@ -254,6 +259,18 @@ export function resolveIncompleteTurnPayloadText(params: {
     !joinAssistantTexts(params.attempt.assistantTexts).length &&
     !hasTerminalOutput &&
     Boolean(assistant && hasOnlyAssistantReasoningContent(assistant));
+  const terminal = projectAgentRunAttemptTerminal(params.attempt.terminal);
+  // Timeout phase and interruption precedence belong to the canonical attempt terminal.
+  // Only its tool-execution timeout may become an incomplete-turn payload here.
+  if (
+    terminal.timedOut &&
+    terminal.timedOutDuringToolExecution &&
+    params.payloadCount === 0 &&
+    params.allowEmptyAssistantReplyAsSilent !== true &&
+    !hasTerminalOutput
+  ) {
+    return TURN_BUDGET_TIMEOUT_NOTICE;
+  }
 
   if (
     (params.payloadCount !== 0 && !incompleteTerminalAssistant && !thinkingOnlyTerminal) ||

--- a/src/agents/embedded-agent-runner/run/incomplete-turn.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn.ts
@@ -278,11 +278,18 @@ export function resolveIncompleteTurnPayloadText(params: {
   // Timeout phase and interruption precedence belong to the canonical attempt terminal.
   // Only its tool-execution timeout may become an incomplete-turn payload here.
   //
-  // This returns before the general suppression guard below, so it cannot inherit
-  // that guard's external-abort silence and has to reject externally owned
-  // interruptions itself. A `timeout` terminal carries `source: "external"` when an
-  // operator cancellation raced the timeout, so the two states genuinely co-occur;
-  // without this check that cancellation would be reported as an exhausted time budget.
+  // This returns before the general suppression guards below, so it cannot inherit
+  // their silence and has to re-state each owner it would otherwise bypass.
+  //
+  // External abort: a `timeout` terminal carries `source: "external"` when an operator
+  // cancellation raced the timeout, so the two states genuinely co-occur; without this
+  // check that cancellation would be reported as an exhausted time budget.
+  //
+  // Explicit silent reply: `hasOnlySilentAssistantReply` owns the `NO_REPLY` token as
+  // deliberate silence, including post-tool turns, and `hasTimeoutTerminalOutput` never
+  // inspects assistant text. An empty payload alongside that token is a state the file
+  // already treats as reachable (see the silent-reply branch below), so without this
+  // check a turn that deliberately declined to answer would emit an unsolicited notice.
   if (
     terminal.timedOut &&
     terminal.timedOutDuringToolExecution &&
@@ -290,6 +297,7 @@ export function resolveIncompleteTurnPayloadText(params: {
     !(params.aborted && params.externalAbort) &&
     params.payloadCount === 0 &&
     params.allowEmptyAssistantReplyAsSilent !== true &&
+    !hasOnlySilentAssistantReply(params.attempt.assistantTexts) &&
     !hasTimeoutTerminalOutput
   ) {
     return terminal.idleTimedOut ? TURN_IDLE_TIMEOUT_NOTICE : TURN_BUDGET_TIMEOUT_NOTICE;

--- a/src/agents/embedded-agent-runner/run/terminal-resolution.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-resolution.ts
@@ -297,6 +297,7 @@ export async function resolveEmbeddedRunTerminal(input: {
         aborted: terminalAborted,
         externalAbort: externalAbort || signalOwnedInterruption,
         timedOut: terminalTimedOut,
+        allowEmptyAssistantReplyAsSilent: runParams.allowEmptyAssistantReplyAsSilent,
         hadPotentialSideEffects: input.replayState.hadPotentialSideEffects,
         attempt,
       });


### PR DESCRIPTION
## What Problem This Solves

When an embedded agent turn exhausts its time budget (`agents.defaults.timeoutSeconds` or a run-level deadline) **during tool execution**, the run falls through the general terminal path with no payloads and returns silently — the channel goes completely dead, indistinguishable from a hung process to the user.

`main` already surfaces a notice for the **prompt-timeout** case via `resolveEmbeddedRunTerminalTimeout` (`run/terminal-timeout.ts`), but that only covers `timedOutDuringPrompt === true`. The tool-execution sub-case (`timedOutDuringToolExecution === true`) still returns `undefined` and goes silent.

This supersedes #89965, which added the same feature on the pre-refactor monolithic `run.ts`. Once `runEmbeddedAgentInternal` was split into the `run/` module tree, that patch's anchors no longer existed and it could not be rebased — so this is a fresh re-implementation onto the new terminal-resolution architecture.

## Fix

- A pure `resolveTurnBudgetTimeoutNotice` helper (`run/incomplete-turn.ts`) that decides whether a terminating turn should surface a notice, suppressing it for every case where a notice would be wrong: compaction timeouts (paused/resumable), intentionally-silent cron/heartbeat turns (`allowEmptyAssistantReplyAsSilent`), out-of-band messaging-tool or deterministic-approval delivery, an already-delivered `message_tool_only` source reply, and structured terminal states (pending client tool calls / yield) that OpenAI-compatible callers continue tool rounds from.
- A companion `resolveEmbeddedRunToolExecutionTimeout` resolver (`run/terminal-timeout.ts`) that mirrors the existing prompt-timeout resolver's return shape (`copyAttemptDeliveryState` + `setTerminalLifecycleMeta` + `resolveRunLivenessState`, provider-phase attribution), wired into `run-loop.ts` immediately after the prompt-timeout early return.

Two notice variants: a turn-budget notice (points at `agents.defaults.timeoutSeconds`) and an idle-model variant (also points at `models.providers.<id>.timeoutSeconds`).

## Tests

- 11 pure unit tests covering the notice and every suppression gate.
- 3 `runEmbeddedAgent` integration tests: the notice fires on a tool-execution timeout with no visible reply; stays silent in an `allowEmptyAssistantReplyAsSilent` context; a compaction timeout stays `paused` instead of emitting the notice.
- `tsgo:core` and `tsgo:core:test` clean.
- Dependency hygiene: the two timeout-notice constants are no longer exported (they were consumed only by the suite, so knip's `--production` pass reported them as unused exports). They are declared locally in the suite instead, matching the neighbouring retry/continuation strings; verified byte-identical between module and suite, and `knip --production` is clean with a positive control confirming the check still detects the violation.

## Evidence (real behavior: local live gateway build)

Gateway built and run from source (`pnpm gateway:dev`), driven through the
OpenAI-compatible `/v1/chat/completions` endpoint with a real model (served via
an OpenAI-compatible proxy). Config: `agents.defaults.timeoutSeconds: 10`,
`tools.exec.backgroundMs: 600000` (so a foreground exec is not backgrounded).

**Scenario (induces a tool-execution timeout with no visible reply):** the model
calls the exec/bash tool with a command that ignores SIGTERM
(`trap '' TERM; sleep 30`). The whole-run deadline fires *while the tool is
executing* (`timedOutDuringToolExecution`); because the process ignores SIGTERM
it does not settle within the abort-settle window, so the attempt finalizes with
zero payloads.

Gateway log — identical on both builds:
```
[agent/embedded] embedded run timeout: runId=… timeoutMs=10000
[agent/embedded] embedded abort settle timed out: runId=… timeoutMs=2000
```

**BEFORE (main):** the tool-execution-timeout path returns no payload →
`choices[0].message.content`:
```
No response from OpenClaw.
```
The channel goes silent — the user cannot distinguish a timeout from a hung process.

**AFTER (this branch):** `choices[0].message.content`:
```
⚠️ I hit my time budget on this request and stopped before finishing. Ask me to continue, or simplify the request. If this happens often, raise `agents.defaults.timeoutSeconds` in your config.
```

Same config, same model, same command, same timeout mechanic — the only
difference is this patch, which converts the silent placeholder into an
actionable turn-budget notice.

