### PR TITLE
fix: new chat survives concurrent config reload

### DIFF
--- a/src/agents/prepared-model-catalog.errors.ts
+++ b/src/agents/prepared-model-catalog.errors.ts
@@ -1,0 +1,6 @@
+export class PreparedModelCatalogConfigReplacedError extends Error {
+  constructor(agentDir: string) {
+    super(`prepared model catalog owner config was replaced during the read (${agentDir})`);
+    this.name = "PreparedModelCatalogConfigReplacedError";
+  }
+}

--- a/src/agents/prepared-model-catalog.test.ts
+++ b/src/agents/prepared-model-catalog.test.ts
@@ -43,6 +43,7 @@ vi.mock("./prepared-model-runtime.js", () => {
   };
 });
 
+import { PreparedModelCatalogConfigReplacedError } from "./prepared-model-catalog.errors.js";
 import {
   getPreparedModelCatalogSnapshot,
   loadPreparedModelCatalogSnapshot,
@@ -120,6 +121,9 @@ describe("prepared model catalog access", () => {
 
     await expect(loadPreparedModelCatalogSnapshot({ readOnly: true })).rejects.toThrow(
       "config was replaced",
+    );
+    await expect(loadPreparedModelCatalogSnapshot({ readOnly: true })).rejects.toBeInstanceOf(
+      PreparedModelCatalogConfigReplacedError,
     );
     expect(mocks.loadSnapshot).not.toHaveBeenCalled();
   });

--- a/src/agents/prepared-model-catalog.ts
+++ b/src/agents/prepared-model-catalog.ts
@@ -9,6 +9,7 @@ import {
   resolveDefaultAgentId,
 } from "./agent-scope.js";
 import type { ModelCatalogEntry, ModelCatalogSnapshot } from "./model-catalog.types.js";
+import { PreparedModelCatalogConfigReplacedError } from "./prepared-model-catalog.errors.js";
 import {
   acquireAgentRunPreparedModelRuntime,
   acquireReadOnlyPreparedModelRuntime,
@@ -124,9 +125,7 @@ export async function loadPreparedModelCatalogOwnerSnapshot(
         // Full lifecycle owners include provider augmentation omitted by read-only fallback builds.
         const prepared = await prepareModelRuntimeSnapshot(candidate);
         if (!preparedModelRuntimeConfigsMatch(prepared.config, candidate.config)) {
-          throw new Error(
-            `prepared model catalog owner config was replaced during the read (${candidate.agentDir})`,
-          );
+          throw new PreparedModelCatalogConfigReplacedError(candidate.agentDir);
         }
         return prepared;
       } catch (error) {
@@ -138,9 +137,7 @@ export async function loadPreparedModelCatalogOwnerSnapshot(
     const lease = await acquireReadOnlyPreparedModelRuntime(activationExact);
     try {
       if (!preparedModelRuntimeConfigsMatch(lease.snapshot.config, activationExact.config)) {
-        throw new Error(
-          `prepared model catalog owner config was replaced during the read (${activationExact.agentDir})`,
-        );
+        throw new PreparedModelCatalogConfigReplacedError(activationExact.agentDir);
       }
       return lease.snapshot;
     } finally {

--- a/src/gateway/server-model-catalog.test.ts
+++ b/src/gateway/server-model-catalog.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import type { ModelCatalogSnapshot } from "../agents/model-catalog.types.js";
+import { PreparedModelCatalogConfigReplacedError } from "../agents/prepared-model-catalog.errors.js";
 import {
   loadGatewayModelCatalog,
   loadGatewayModelCatalogSnapshot,
@@ -72,5 +73,45 @@ describe("gateway prepared model catalog", () => {
     await expect(
       loadGatewayModelCatalogSnapshot({ loadPreparedModelCatalogSnapshot }),
     ).rejects.toBe(error);
+  });
+
+  it("follows a committed config that replaces the catalog owner during a read", async () => {
+    const initialConfig = { agents: { defaults: { model: "openai/gpt-5.5" } } };
+    const replacementConfig = { agents: { defaults: { model: "openai/gpt-5.6" } } };
+    const getConfig = vi.fn().mockReturnValueOnce(initialConfig).mockReturnValue(replacementConfig);
+    const loadPreparedModelCatalogSnapshot = vi
+      .fn()
+      .mockRejectedValueOnce(new PreparedModelCatalogConfigReplacedError("/tmp/gateway-agent"))
+      .mockResolvedValueOnce(snapshot);
+
+    await expect(
+      loadGatewayModelCatalogSnapshot({
+        getConfig,
+        loadPreparedModelCatalogSnapshot,
+      }),
+    ).resolves.toBe(snapshot);
+    expect(loadPreparedModelCatalogSnapshot).toHaveBeenNthCalledWith(1, {
+      config: initialConfig,
+      readOnly: true,
+    });
+    expect(loadPreparedModelCatalogSnapshot).toHaveBeenNthCalledWith(2, {
+      config: replacementConfig,
+      readOnly: true,
+    });
+    expect(getConfig).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not loop when the runtime config has not advanced", async () => {
+    const config = { agents: { defaults: { model: "openai/gpt-5.5" } } };
+    const error = new PreparedModelCatalogConfigReplacedError("/tmp/gateway-agent");
+    const loadPreparedModelCatalogSnapshot = vi.fn().mockRejectedValue(error);
+
+    await expect(
+      loadGatewayModelCatalogSnapshot({
+        getConfig: () => config,
+        loadPreparedModelCatalogSnapshot,
+      }),
+    ).rejects.toBe(error);
+    expect(loadPreparedModelCatalogSnapshot).toHaveBeenCalledOnce();
   });
 });

--- a/src/gateway/server-model-catalog.ts
+++ b/src/gateway/server-model-catalog.ts
@@ -1,6 +1,8 @@
 // Gateway catalog reads use the atomic prepared runtime generation.
 import type { ModelCatalogSnapshot } from "../agents/model-catalog.types.js";
+import { PreparedModelCatalogConfigReplacedError } from "../agents/prepared-model-catalog.errors.js";
 import { getRuntimeConfig } from "../config/io.js";
+import { hashRuntimeConfigValue } from "../config/runtime-snapshot.js";
 
 export type GatewayModelChoice = import("../agents/model-catalog.js").ModelCatalogEntry;
 
@@ -45,15 +47,34 @@ export async function resetPreparedModelCatalogForTest(): Promise<void> {
 export async function loadGatewayModelCatalogSnapshot(
   params?: LoadGatewayModelCatalogParams,
 ): Promise<ModelCatalogSnapshot> {
-  const config = (params?.getConfig ?? getRuntimeConfig)();
   const loadSnapshot = await resolveLoader(params);
-  return await loadSnapshot({
-    ...(params?.agentId ? { agentId: params.agentId } : {}),
-    ...(params?.agentDir ? { agentDir: params.agentDir } : {}),
-    config,
-    readOnly: params?.readOnly !== false,
-    ...(params?.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
-  });
+  const getConfig = params?.getConfig ?? getRuntimeConfig;
+  let config = getConfig();
+  let configFingerprint = hashRuntimeConfigValue(config);
+  for (;;) {
+    try {
+      return await loadSnapshot({
+        ...(params?.agentId ? { agentId: params.agentId } : {}),
+        ...(params?.agentDir ? { agentDir: params.agentDir } : {}),
+        config,
+        readOnly: params?.readOnly !== false,
+        ...(params?.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
+      });
+    } catch (error) {
+      if (!(error instanceof PreparedModelCatalogConfigReplacedError)) {
+        throw error;
+      }
+      // Config publication may replace the prepared owner while this request is waiting. Follow
+      // that committed generation; explicit read-only draft callers retain strict isolation.
+      const replacementConfig = getConfig();
+      const replacementFingerprint = hashRuntimeConfigValue(replacementConfig);
+      if (replacementFingerprint === configFingerprint) {
+        throw error;
+      }
+      config = replacementConfig;
+      configFingerprint = replacementFingerprint;
+    }
+  }
 }
 
 export async function loadGatewayModelCatalog(


### PR DESCRIPTION
Related: #111173

## What Problem This Solves

Fixes an issue where users starting a new chat could receive `prepared model catalog owner config was replaced during the read` when a Gateway config publication replaced the prepared model owner while the catalog request was in flight.

## Why This Change Was Made

Catalog access now raises a typed internal signal for this specific ownership race. The Gateway catches that signal, reacquires the canonical runtime config, and retries only when the config has actually advanced. Explicit read-only draft/config callers still reject mismatched owners, and unrelated catalog failures continue to propagate.

## User Impact

Starting a chat or loading Gateway model choices no longer fails merely because a config reload commits while the model catalog is being read.

## Evidence

- Reproduced from the reported Gateway error at the exact post-read config comparison introduced with the lifecycle-owned catalog path.
- `vitest run src/agents/prepared-model-catalog.test.ts src/gateway/server-model-catalog.test.ts`: 24 tests passed.
- Focused `oxfmt`, `oxlint`, and `git diff --check`: passed.
- Added regression coverage for following an advanced Gateway config and for refusing to loop when config state has not advanced.
- Repository autoreview was attempted with Codex `gpt-5.6-sol`/high, but the available Codex credential returned HTTP 401 before producing a review. The final patch was manually reviewed for ownership boundaries and secret handling; the replacement signal carries no config payload.

## AI Assistance

AI-assisted: Codex traced the race, implemented the fix and tests, and prepared this PR. I understand the change and its Gateway/catalog ownership boundary.
