### PR TITLE
fix(transcript-repair): strip dangling tool calls and empty thinking from errored assistant turns before replay

### DIFF
--- a/src/agents/session-transcript-repair.test.ts
+++ b/src/agents/session-transcript-repair.test.ts
@@ -313,10 +313,11 @@ describe("sanitizeToolUseResultPairing", () => {
     expect(out.map((m) => m.role)).toEqual(["user", "assistant"]);
   });
 
-  it("skips tool call extraction for assistant messages with stopReason 'error'", () => {
-    // When an assistant message has stopReason: "error", its tool_use blocks may be
-    // incomplete/malformed. We should NOT create synthetic tool_results for them,
-    // as this causes API 400 errors: "unexpected tool_use_id found in tool_result blocks"
+  it("strips dangling tool calls from errored assistant messages instead of leaving them", () => {
+    // When an assistant message has stopReason: "error", its unanswered tool_use blocks
+    // must not survive replay: an unmatched tool_use causes provider 400 errors
+    // ("unexpected tool_use_id found in tool_result blocks") that brick the session.
+    // The turn here is tool-call-only, so after stripping it becomes empty and is dropped.
     const input = castAgentMessages([
       {
         role: "assistant",
@@ -330,15 +331,15 @@ describe("sanitizeToolUseResultPairing", () => {
 
     // Should NOT add synthetic tool results for errored messages
     expect(result.added).toHaveLength(0);
-    // The assistant message should be passed through unchanged
-    expect(result.messages[0]?.role).toBe("assistant");
-    expect(result.messages[1]?.role).toBe("user");
-    expect(result.messages).toHaveLength(2);
+    // The dangling errored turn is dropped; only the user turn survives.
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0]?.role).toBe("user");
   });
 
-  it("skips tool call extraction for assistant messages with stopReason 'aborted'", () => {
+  it("strips dangling tool calls from aborted assistant messages instead of leaving them", () => {
     // When a request is aborted mid-stream, the assistant message may have incomplete
-    // tool_use blocks (with partialJson). We should NOT create synthetic tool_results.
+    // tool_use blocks (with partialJson). We should NOT create synthetic tool_results,
+    // and the unanswered tool call must be stripped so replay stays provider-safe.
     const input = castAgentMessages([
       {
         role: "assistant",
@@ -352,10 +353,9 @@ describe("sanitizeToolUseResultPairing", () => {
 
     // Should NOT add synthetic tool results for aborted messages
     expect(result.added).toHaveLength(0);
-    // Messages should be passed through without synthetic insertions
-    expect(result.messages).toHaveLength(2);
-    expect(result.messages[0]?.role).toBe("assistant");
-    expect(result.messages[1]?.role).toBe("user");
+    // The dangling aborted turn is dropped; only the user turn survives.
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0]?.role).toBe("user");
   });
 
   it("still repairs tool results for normal assistant messages with stopReason 'toolUse'", () => {
@@ -420,6 +420,164 @@ describe("sanitizeToolUseResultPairing", () => {
     expect(result.messages).toHaveLength(1);
     expect(result.messages[0]?.role).toBe("user");
     expect(result.added).toHaveLength(0);
+  });
+});
+
+describe("repairToolUseResultPairing stream-poison sanitization", () => {
+  // A stream that errors after partial accumulation persists an assistant turn whose
+  // stopReason is flipped to "error"/"aborted" but whose content still holds the blocks
+  // streamed so far: signed-but-empty thinking blocks and tool calls with no matching
+  // tool result. Replaying those blocks makes the provider reject the whole transcript
+  // (HTTP 400) and silently bricks the session. Repair must strip the poison blocks while
+  // keeping real text so the error context survives, and must never emit an empty-content
+  // assistant turn (which providers also reject). These four cases mirror the four poison
+  // signatures observed in the field.
+
+  const toolCallBlock = (id: string) =>
+    ({ type: "toolCall", id, name: "read", arguments: { path: "/x" } }) as const;
+  const textBlock = (text: string) => ({ type: "text", text }) as const;
+  const emptyThinkingBlock = () => ({ type: "thinking", thinking: "" }) as const;
+
+  function assistantContent(message: AgentMessage | undefined) {
+    if (!message || message.role !== "assistant" || !Array.isArray(message.content)) {
+      return [] as Array<{ type?: unknown }>;
+    }
+    return message.content as Array<{ type?: unknown }>;
+  }
+
+  it("signature 1 (empty-thinking): drops empty signed thinking, keeps text, no synthetic", () => {
+    const input = castAgentMessages([
+      { role: "user", content: "start" },
+      {
+        role: "assistant",
+        content: [emptyThinkingBlock(), textBlock("partial answer before the stream died")],
+        stopReason: "error",
+      },
+    ]);
+
+    const result = repairToolUseResultPairing(input);
+
+    expect(result.added).toHaveLength(0);
+    expect(result.messages).toHaveLength(2);
+    const content = assistantContent(result.messages[1]);
+    // Empty thinking is stripped; real text survives.
+    expect(content.some((b) => b.type === "thinking")).toBe(false);
+    expect(content).toEqual([textBlock("partial answer before the stream died")]);
+  });
+
+  it("signature 2 (dangling toolCall): drops unanswered tool call, keeps text", () => {
+    const input = castAgentMessages([
+      { role: "user", content: "start" },
+      {
+        role: "assistant",
+        content: [textBlock("let me look"), toolCallBlock("call_dangling")],
+        stopReason: "error",
+      },
+      { role: "user", content: "next turn" },
+    ]);
+
+    const result = repairToolUseResultPairing(input);
+
+    // No synthetic tool result is fabricated for the errored turn.
+    expect(result.added).toHaveLength(0);
+    const content = assistantContent(result.messages[1]);
+    // The unanswered tool call is removed; text stays.
+    expect(content.some((b) => (b as { id?: unknown }).id === "call_dangling")).toBe(false);
+    expect(content).toEqual([textBlock("let me look")]);
+    // No orphan tool result is left behind for the provider to choke on.
+    expect(result.messages.some((m) => m.role === "toolResult")).toBe(false);
+  });
+
+  it("signature 2b (dangling toolCall): keeps an answered tool call alongside a dangling one", () => {
+    const input = castAgentMessages([
+      {
+        role: "assistant",
+        content: [
+          textBlock("working"),
+          toolCallBlock("call_answered"),
+          { type: "toolCall", id: "call_dangling", name: "list", arguments: {} },
+        ],
+        stopReason: "error",
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_answered",
+        toolName: "read",
+        content: [{ type: "text", text: "file body" }],
+        isError: false,
+      },
+      { role: "user", content: "continue" },
+    ]);
+
+    const result = repairToolUseResultPairing(input);
+
+    const content = assistantContent(result.messages[0]);
+    // Answered call is preserved (it has a matching result); dangling call is dropped.
+    expect(content.some((b) => (b as { id?: unknown }).id === "call_answered")).toBe(true);
+    expect(content.some((b) => (b as { id?: unknown }).id === "call_dangling")).toBe(false);
+    // The matching tool result stays paired right after the assistant turn.
+    expect(result.messages[1]?.role).toBe("toolResult");
+    expect(result.added).toHaveLength(0);
+  });
+
+  it("signature 3 (empty-error turn): drops an errored turn with only poison content", () => {
+    const input = castAgentMessages([
+      { role: "user", content: "start" },
+      {
+        role: "assistant",
+        content: [emptyThinkingBlock(), toolCallBlock("call_only")],
+        stopReason: "error",
+      },
+      { role: "user", content: "recovered" },
+    ]);
+
+    const result = repairToolUseResultPairing(input);
+
+    expect(result.added).toHaveLength(0);
+    // The whole errored turn was pure poison (empty thinking + dangling call), so it is
+    // dropped rather than emitted as an empty-content assistant turn.
+    expect(result.messages).toHaveLength(2);
+    expect(result.messages.every((m) => m.role === "user")).toBe(true);
+  });
+
+  it("signature 4 (orphan toolResult): a poison turn does not strand its own result", () => {
+    // The dangling call is stripped from the errored turn, and its now-orphaned result
+    // must not be pushed into the transcript (which would 400 as an unmatched result).
+    const input = castAgentMessages([
+      {
+        role: "assistant",
+        content: [textBlock("trying"), toolCallBlock("call_orphan")],
+        stopReason: "aborted",
+      },
+      { role: "user", content: "next" },
+    ]);
+
+    const result = repairToolUseResultPairing(input, {
+      erroredAssistantResultPolicy: "drop",
+    });
+
+    const content = assistantContent(result.messages[0]);
+    expect(content).toEqual([textBlock("trying")]);
+    expect(result.messages.some((m) => m.role === "toolResult")).toBe(false);
+    expect(result.added).toHaveLength(0);
+  });
+
+  it("leaves clean (non-errored) turns untouched", () => {
+    const input = castAgentMessages([
+      {
+        role: "assistant",
+        content: [textBlock("here"), toolCallBlock("call_ok")],
+        stopReason: "toolUse",
+      },
+      { role: "user", content: "after" },
+    ]);
+
+    const result = repairToolUseResultPairing(input);
+
+    // Normal turns still get a synthetic missing result and keep their tool call.
+    expect(result.added).toHaveLength(1);
+    const content = assistantContent(result.messages[0]);
+    expect(content.some((b) => (b as { id?: unknown }).id === "call_ok")).toBe(true);
   });
 });
 

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -549,6 +549,75 @@ function shouldDropErroredAssistantResults(options?: ToolUseResultPairingOptions
   return options?.erroredAssistantResultPolicy === "drop";
 }
 
+const EMPTY_ANSWERED_TOOL_CALL_IDS: ReadonlySet<string> = new Set<string>();
+
+function rawToolCallBlockId(block: RawToolCallBlock): string {
+  for (const key of [
+    "id",
+    "call_id",
+    "toolCallId",
+    "toolUseId",
+    "tool_call_id",
+    "tool_use_id",
+  ] as const) {
+    const value = block[key];
+    if (typeof value === "string" && value.trim() !== "") {
+      return value.trim();
+    }
+  }
+  return "";
+}
+
+function thinkingLikeBlockIsEmpty(block: unknown): boolean {
+  if (!block || typeof block !== "object") {
+    return false;
+  }
+  const candidate = (block as { thinking?: unknown; text?: unknown }).thinking;
+  const text = typeof candidate === "string" ? candidate : (block as { text?: unknown }).text;
+  return typeof text !== "string" || text.trim() === "";
+}
+
+// Stream-poison fix: an errored/aborted assistant turn can be persisted with
+// dangling tool calls (no matching tool result) and empty signed thinking blocks
+// that were partially streamed before the stream died. Replaying those blocks makes
+// providers reject the whole transcript (HTTP 400) and silently bricks the session.
+// Strip the unanswered tool calls and empty thinking-like blocks while keeping real
+// text and any other content so the error context survives. Returns the original
+// message when nothing needed stripping, a rewritten message when content was
+// trimmed, or null when the turn would become an empty-content assistant turn (which
+// providers also reject) and should be dropped entirely.
+function sanitizeErroredAssistantTurn(
+  message: Extract<AgentMessage, { role: "assistant" }>,
+  answeredToolCallIds: ReadonlySet<string>,
+): Extract<AgentMessage, { role: "assistant" }> | null {
+  if (!Array.isArray(message.content)) {
+    return message;
+  }
+  let removed = false;
+  const safeContent = message.content.filter((block) => {
+    if (isRawToolCallBlock(block)) {
+      const id = rawToolCallBlockId(block);
+      const keep = id !== "" && answeredToolCallIds.has(id);
+      if (!keep) {
+        removed = true;
+      }
+      return keep;
+    }
+    if (isThinkingLikeBlock(block) && thinkingLikeBlockIsEmpty(block)) {
+      removed = true;
+      return false;
+    }
+    return true;
+  });
+  if (!removed) {
+    return message;
+  }
+  if (safeContent.length === 0) {
+    return null;
+  }
+  return { ...message, content: safeContent };
+}
+
 function assistantHasToolCalls(message: AgentMessage): boolean {
   if (!message || typeof message !== "object" || message.role !== "assistant") {
     return false;
@@ -753,6 +822,23 @@ export function repairToolUseResultPairing(
         droppedOrphanCount += 1;
         continue;
       }
+      if (message.role === "assistant") {
+        const stopReason = (message as { stopReason?: string }).stopReason;
+        if (stopReason === "error" || stopReason === "aborted") {
+          // Errored/aborted turns without tool calls never form a frame, so they
+          // reach here verbatim. They can still carry empty signed thinking blocks
+          // that brick replay; sanitize them the same way. No tool call in this turn
+          // is answerable here, so pass an empty answered set.
+          const safe = sanitizeErroredAssistantTurn(
+            message as Extract<AgentMessage, { role: "assistant" }>,
+            EMPTY_ANSWERED_TOOL_CALL_IDS,
+          );
+          if (safe) {
+            out.push(safe);
+          }
+          continue;
+        }
+      }
       out.push(message);
     }
   };
@@ -761,14 +847,34 @@ export function repairToolUseResultPairing(
     pushUnframedRange(frame.startIndex);
     cursor = frame.endIndex;
 
-    if (!(frame.failed && shouldDropErroredAssistantResults(options))) {
+    const dropErroredResults = frame.failed && shouldDropErroredAssistantResults(options);
+    if (frame.failed) {
+      // Replay-safe errored/aborted turn: strip unanswered tool calls and empty
+      // thinking blocks instead of pushing the turn verbatim (which 400s the
+      // provider) or dropping the whole turn (which loses error context/text).
+      const answeredToolCallIds = new Set<string>();
+      for (const occurrence of frame.occurrences) {
+        if (occurrence.result && occurrence.id) {
+          answeredToolCallIds.add(occurrence.id);
+        }
+      }
+      const safeAssistant = sanitizeErroredAssistantTurn(frame.assistant, answeredToolCallIds);
+      if (safeAssistant) {
+        out.push(safeAssistant);
+      }
+      // Keep matching results unless the caller asked to drop errored results.
+      if (!dropErroredResults) {
+        for (const occurrence of frame.occurrences) {
+          if (occurrence.result) {
+            out.push(occurrence.result);
+          }
+        }
+      }
+    } else {
       out.push(frame.assistant);
       for (const occurrence of frame.occurrences) {
         if (occurrence.result) {
           out.push(occurrence.result);
-          continue;
-        }
-        if (frame.failed) {
           continue;
         }
         const missing = makeMissingToolResult({


### PR DESCRIPTION
Closes #112029

## What Problem This Solves

Fixes an issue where users whose streamed assistant turn errors or aborts mid-flight would have that entire session permanently bricked. When a stream dies after it has partially accumulated content, the assistant turn is persisted with `stopReason: "error"`/`"aborted"` but keeps the partial blocks — a signed-but-empty `thinking` block and/or a `tool_use` with no matching `tool_result`. On every later replay, transcript repair emitted those blocks verbatim, the provider rejected the request with HTTP 400 (unmatched `tool_use` / empty thinking), and the session could not recover.

## Why This Change Was Made

`repairToolUseResultPairing` now sanitizes errored/aborted assistant turns at replay time instead of pushing them verbatim. It strips unanswered `tool_use` blocks and empty `thinking`-like blocks while keeping real text so the error context survives, and it never emits an empty-content assistant turn (dropping a turn that is entirely poison). It also covers errored/aborted turns that carry no tool call at all — those never formed a repair frame and previously bypassed sanitization through the unframed-range path. Clean (non-errored) turns are unchanged, and answered tool calls in an errored turn (those with a matching result) are preserved. Because the fix lives at read/replay time, it is retroactive: already-poisoned sessions heal on next load with no migration.

## User Impact

- Streamed turns that error or abort no longer brick the session; the next turn replays cleanly instead of failing with a provider 400.
- Existing poisoned sessions self-heal on next load — no manual repair or migration required.
- Error context (the assistant's real text before the failure) is preserved rather than discarded.

## Evidence

- New tests in `session-transcript-repair.test.ts` under `describe("repairToolUseResultPairing stream-poison sanitization")` cover the four field-observed poison signatures plus mixed/clean/legacy cases:
  1. **empty-thinking** — empty signed `thinking` stripped, text kept, no synthetic result.
  2. **dangling tool_use** — unanswered `tool_use` dropped, text kept, no orphan result left behind.
  3. **empty-error turn** — a turn whose content is entirely poison is dropped rather than emitted empty.
  4. **orphan tool_result** — a stripped dangling call does not strand its own result.
  Plus: an answered call alongside a dangling one keeps only the answered call; clean `toolUse` turns still synthesize missing results and keep their calls.
- The two pre-existing errored/aborted passthrough tests were updated to assert the corrected replay-safe behavior (dangling calls stripped) instead of the previous poison-preserving behavior.
- Impact scale: the four signatures were observed across 31 sessions on a single install; all shared the same replay-time gap this PR closes.
