### PR TITLE
test(ui): run DOM-free suites in Node

### DIFF
--- a/ui/src/lib/config/index.test.ts
+++ b/ui/src/lib/config/index.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 // Control UI tests cover config behavior.
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";

--- a/ui/src/lib/cron-status.test.ts
+++ b/ui/src/lib/cron-status.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 import type { CronJob } from "../api/types.ts";
 import { isCronJobActiveFailure } from "./cron-status.ts";

--- a/ui/src/lib/cron/index.test.ts
+++ b/ui/src/lib/cron/index.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 // Control UI tests cover cron behavior.
 import { describe, expect, it, vi } from "vitest";
 import type { CronJob } from "../../api/types.ts";

--- a/ui/src/lib/device-pair-setup.test.ts
+++ b/ui/src/lib/device-pair-setup.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it, vi } from "vitest";
 import {
   closeDevicePairSetup,

--- a/ui/src/lib/format.test.ts
+++ b/ui/src/lib/format.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 // Control UI tests cover format behavior.
 import { afterEach, describe, expect, it } from "vitest";
 import {

--- a/ui/src/lib/gateway-errors.test.ts
+++ b/ui/src/lib/gateway-errors.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, expect, it } from "vitest";
 import { isMissingOperatorReadScopeError } from "./gateway-errors.ts";
 


### PR DESCRIPTION
## What Problem This Solves

Control UI tests that exercise only pure state, formatting, and RPC logic currently run under jsdom, paying browser-environment setup cost even though they never use DOM APIs.

## Why This Change Was Made

Mark six verified DOM-free test files with Vitest's Node environment pragma. This keeps browser-backed tests in jsdom while removing unnecessary environment construction from 195 tests without changing assertions or production behavior.

## User Impact

Developers get faster local and CI test feedback. There is no user-visible runtime behavior change.

## Evidence

- `node scripts/run-vitest.mjs ui/src/lib/config/index.test.ts ui/src/lib/cron-status.test.ts ui/src/lib/cron/index.test.ts ui/src/lib/device-pair-setup.test.ts ui/src/lib/format.test.ts ui/src/lib/gateway-errors.test.ts`
  - 6 test files passed
  - 195 tests passed
  - 1.20 seconds Vitest duration
  - 0 ms environment setup
- Independent review verified the six files, transitive imports, Node 24 `navigator`/clipboard stubbing, UI Vitest routing, and cleanup under `isolate: false`; no actionable findings.
- Exact-head Linux Node 24 CI will run when this draft is marked ready; merge will wait for the relevant required checks.

AI-assisted: yes.
