### PR TITLE
fix(mcp): bind stored OAuth refresh token to its issuer

### DIFF
--- a/src/agents/mcp-oauth-provider.ts
+++ b/src/agents/mcp-oauth-provider.ts
@@ -72,6 +72,10 @@ export function withMcpOAuthLeaseSignal(
   };
 }
 
+function sameMcpOAuthAuthorizationServer(a: string, b: string): boolean {
+  return URL.canParse(a) && URL.canParse(b) && new URL(a).href === new URL(b).href;
+}
+
 function beginMcpOAuthAuthorization(store: McpOAuthStore): McpOAuthStore {
   const next = { ...store };
   if (next.credentialState === "uninitialized") {
@@ -124,13 +128,33 @@ export function createMcpOAuthClientProvider(params: {
       updateStore((store) => ({ ...beginMcpOAuthAuthorization(store), clientInformation }));
     },
     tokens() {
-      return params.suppressStoredTokens ? undefined : readMcpOAuthStore(storeKey).tokens;
+      if (params.suppressStoredTokens) {
+        return undefined;
+      }
+      const store = readMcpOAuthStore(storeKey);
+      const discoveredAuthorizationServerUrl = store.discoveryState?.authorizationServerUrl;
+      if (!store.tokens?.refresh_token || discoveredAuthorizationServerUrl === undefined) {
+        return store.tokens;
+      }
+      return store.tokensAuthorizationServerUrl !== undefined &&
+        sameMcpOAuthAuthorizationServer(
+          discoveredAuthorizationServerUrl,
+          store.tokensAuthorizationServerUrl,
+        )
+        ? store.tokens
+        : undefined;
     },
     saveTokens(tokens) {
       updateStore((store) => {
         const next: McpOAuthStore = { ...store, tokens };
         delete next.credentialState;
         delete next.pendingAuthorizationChallenge;
+        const issuedBy = store.discoveryState?.authorizationServerUrl;
+        if (issuedBy === undefined) {
+          delete next.tokensAuthorizationServerUrl;
+        } else {
+          next.tokensAuthorizationServerUrl = issuedBy;
+        }
         const tokenExpiresAt = resolveTokenExpiresAt(tokens);
         if (tokenExpiresAt === undefined) {
           delete next.tokenExpiresAt;
@@ -168,6 +192,7 @@ export function createMcpOAuthClientProvider(params: {
         if ((scope === "all" || scope === "tokens") && params.suppressStoredTokens !== true) {
           delete next.tokens;
           delete next.tokenExpiresAt;
+          delete next.tokensAuthorizationServerUrl;
           next.credentialState = "cleared";
         }
         if (scope === "all" || scope === "verifier") {

--- a/src/agents/mcp-oauth-provider.ts
+++ b/src/agents/mcp-oauth-provider.ts
@@ -72,10 +72,6 @@ export function withMcpOAuthLeaseSignal(
   };
 }
 
-function sameMcpOAuthAuthorizationServer(a: string, b: string): boolean {
-  return URL.canParse(a) && URL.canParse(b) && new URL(a).href === new URL(b).href;
-}
-
 function beginMcpOAuthAuthorization(store: McpOAuthStore): McpOAuthStore {
   const next = { ...store };
   if (next.credentialState === "uninitialized") {
@@ -137,10 +133,7 @@ export function createMcpOAuthClientProvider(params: {
         return store.tokens;
       }
       return store.tokensAuthorizationServerUrl !== undefined &&
-        sameMcpOAuthAuthorizationServer(
-          discoveredAuthorizationServerUrl,
-          store.tokensAuthorizationServerUrl,
-        )
+        discoveredAuthorizationServerUrl === store.tokensAuthorizationServerUrl
         ? store.tokens
         : undefined;
     },

--- a/src/agents/mcp-oauth-refresh-issuer.test.ts
+++ b/src/agents/mcp-oauth-refresh-issuer.test.ts
@@ -1,0 +1,328 @@
+import path from "node:path";
+import type { FetchLike } from "@modelcontextprotocol/sdk/shared/transport.js";
+import { withTempHome as withBaseTempHome } from "openclaw/plugin-sdk/test-env";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { withMcpOAuthBearer } from "./mcp-oauth-fetch.js";
+import { createMcpOAuthClientProvider } from "./mcp-oauth-provider.js";
+import { readMcpOAuthStore, resolveMcpOAuthStoreKey } from "./mcp-oauth-store.js";
+
+const SERVER_NAME = "Remote Docs";
+const SERVER_URL = "https://mcp.example.com/mcp";
+const ORIGINAL_METADATA_URL = "https://mcp.example.com/.well-known/oauth-protected-resource";
+const REPLACEMENT_METADATA_URL = "https://metadata.example/pr-metadata";
+const ORIGINAL_ISSUER = "https://auth-old.example";
+const REPLACEMENT_ISSUER = "https://auth-new.example";
+const STORED_ACCESS = "stored-access";
+const STORED_REFRESH = "stored-refresh-secret";
+
+async function withTempHome<T>(
+  run: () => T | Promise<T>,
+  options: Parameters<typeof withBaseTempHome>[1],
+): Promise<T> {
+  return withBaseTempHome(async (home) => {
+    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    process.env.OPENCLAW_STATE_DIR = path.join(home, ".openclaw");
+    closeOpenClawStateDatabaseForTest();
+    try {
+      return await run();
+    } finally {
+      closeOpenClawStateDatabaseForTest();
+      if (previousStateDir === undefined) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      }
+    }
+  }, options);
+}
+
+function bodyText(body: BodyInit | null | undefined): string {
+  if (typeof body === "string") {
+    return body;
+  }
+  return body instanceof URLSearchParams ? body.toString() : "";
+}
+
+function createOAuthNetwork(config: {
+  challengeMetadataUrl: string;
+  issuer: string;
+  mintedAccessToken: string;
+}) {
+  const tokenRequests: Array<{ url: string; body: string }> = [];
+  const fetchFn: FetchLike = async (input, init) => {
+    const url = new URL(String(input instanceof Request ? input.url : input));
+    if (url.href === SERVER_URL) {
+      const authorization = new Headers(init?.headers).get("authorization");
+      if (authorization === `Bearer ${config.mintedAccessToken}`) {
+        return Response.json({ ok: true });
+      }
+      return new Response(null, {
+        status: 401,
+        headers: {
+          "www-authenticate": `Bearer resource_metadata="${config.challengeMetadataUrl}"`,
+        },
+      });
+    }
+    if (url.href === new URL(config.challengeMetadataUrl).href) {
+      return Response.json({
+        resource: SERVER_URL,
+        authorization_servers: [config.issuer],
+      });
+    }
+    if (url.href === `${config.issuer}/.well-known/oauth-authorization-server`) {
+      return Response.json({
+        issuer: config.issuer,
+        authorization_endpoint: `${config.issuer}/authorize`,
+        token_endpoint: `${config.issuer}/token`,
+        response_types_supported: ["code"],
+        grant_types_supported: ["authorization_code", "refresh_token"],
+      });
+    }
+    if (url.href === `${config.issuer}/token`) {
+      tokenRequests.push({ url: url.href, body: bodyText(init?.body) });
+      return Response.json({
+        access_token: config.mintedAccessToken,
+        refresh_token: "rotated-refresh-secret",
+        token_type: "Bearer",
+        expires_in: 3600,
+      });
+    }
+    return new Response(null, { status: 404 });
+  };
+  return { fetchFn, tokenRequests };
+}
+
+async function seedAuthorizedStore(
+  order: "discovery-then-tokens" | "tokens-then-discovery",
+  expiresIn = 3600,
+) {
+  const provider = createMcpOAuthClientProvider({
+    serverName: SERVER_NAME,
+    serverUrl: SERVER_URL,
+  });
+  const discoveryState = {
+    authorizationServerUrl: ORIGINAL_ISSUER,
+    resourceMetadataUrl: ORIGINAL_METADATA_URL,
+  };
+  const tokens = {
+    access_token: STORED_ACCESS,
+    refresh_token: STORED_REFRESH,
+    token_type: "Bearer",
+    expires_in: expiresIn,
+  };
+  await provider.saveClientInformation?.({ client_id: "stored-client-id" });
+  if (order === "discovery-then-tokens") {
+    await provider.saveDiscoveryState?.(discoveryState);
+    await provider.saveTokens(tokens);
+  } else {
+    await provider.saveTokens(tokens);
+    await provider.saveDiscoveryState?.(discoveryState);
+  }
+}
+
+function buildOAuthFetch(fetchFn: FetchLike) {
+  return withMcpOAuthBearer({
+    fetchFn,
+    authFetchFn: fetchFn,
+    serverName: SERVER_NAME,
+    resourceUrl: SERVER_URL,
+  });
+}
+
+function readStore() {
+  return readMcpOAuthStore(resolveMcpOAuthStoreKey(SERVER_NAME, SERVER_URL));
+}
+
+const TEMP_HOME_OPTIONS = {
+  skipSessionCleanup: true,
+  env: { OPENCLAW_CONFIG_PATH: undefined, OPENCLAW_STATE_DIR: undefined },
+};
+
+describe("MCP OAuth refresh issuer binding", () => {
+  beforeEach(() => closeOpenClawStateDatabaseForTest());
+  afterEach(() => closeOpenClawStateDatabaseForTest());
+
+  it("does not send the stored refresh token to a different issuer from a challenge", async () => {
+    await withTempHome(
+      async () => {
+        await seedAuthorizedStore("discovery-then-tokens");
+        const network = createOAuthNetwork({
+          challengeMetadataUrl: REPLACEMENT_METADATA_URL,
+          issuer: REPLACEMENT_ISSUER,
+          mintedAccessToken: "attacker-access",
+        });
+
+        await expect(
+          buildOAuthFetch(network.fetchFn)(SERVER_URL, { method: "POST", body: "{}" }),
+        ).rejects.toThrow(/requires OAuth authorization/);
+
+        expect(network.tokenRequests).toEqual([]);
+        expect(readStore().tokens).toMatchObject({
+          access_token: STORED_ACCESS,
+          refresh_token: STORED_REFRESH,
+        });
+      },
+      { prefix: "openclaw-mcp-oauth-issuer-switch-", ...TEMP_HOME_OPTIONS },
+    );
+  });
+
+  it("still refreshes when a new metadata URL resolves to the original issuer", async () => {
+    await withTempHome(
+      async () => {
+        await seedAuthorizedStore("discovery-then-tokens");
+        const network = createOAuthNetwork({
+          challengeMetadataUrl: REPLACEMENT_METADATA_URL,
+          issuer: ORIGINAL_ISSUER,
+          mintedAccessToken: "rotated-access",
+        });
+
+        const response = await buildOAuthFetch(network.fetchFn)(SERVER_URL, {
+          method: "POST",
+          body: "{}",
+        });
+
+        expect(response.status).toBe(200);
+        expect(network.tokenRequests).toHaveLength(1);
+        expect(network.tokenRequests[0]?.url).toBe(`${ORIGINAL_ISSUER}/token`);
+        expect(network.tokenRequests[0]?.body).toContain(`refresh_token=${STORED_REFRESH}`);
+        expect(readStore().tokens?.access_token).toBe("rotated-access");
+      },
+      { prefix: "openclaw-mcp-oauth-issuer-same-", ...TEMP_HOME_OPTIONS },
+    );
+  });
+
+  it("refreshes an upgraded row whose issuer is recoverable from stored discovery", async () => {
+    await withTempHome(
+      async () => {
+        await seedAuthorizedStore("tokens-then-discovery", 0);
+        expect(readStore().tokensAuthorizationServerUrl).toBeUndefined();
+        expect(readStore().discoveryState?.authorizationServerUrl).toBe(ORIGINAL_ISSUER);
+        const network = createOAuthNetwork({
+          challengeMetadataUrl: ORIGINAL_METADATA_URL,
+          issuer: ORIGINAL_ISSUER,
+          mintedAccessToken: "rotated-access",
+        });
+
+        const response = await buildOAuthFetch(network.fetchFn)(SERVER_URL, {
+          method: "POST",
+          body: "{}",
+        });
+
+        expect(response.status).toBe(200);
+        expect(network.tokenRequests).toHaveLength(1);
+        expect(network.tokenRequests[0]?.url).toBe(`${ORIGINAL_ISSUER}/token`);
+        expect(network.tokenRequests[0]?.body).toContain(`refresh_token=${STORED_REFRESH}`);
+        expect(readStore().tokensAuthorizationServerUrl).toBe(ORIGINAL_ISSUER);
+      },
+      { prefix: "openclaw-mcp-oauth-issuer-upgrade-", ...TEMP_HOME_OPTIONS },
+    );
+  });
+
+  it("blocks an issuer-changing challenge on an upgraded row after it refreshed", async () => {
+    await withTempHome(
+      async () => {
+        await seedAuthorizedStore("tokens-then-discovery", 0);
+        const sameIssuer = createOAuthNetwork({
+          challengeMetadataUrl: ORIGINAL_METADATA_URL,
+          issuer: ORIGINAL_ISSUER,
+          mintedAccessToken: "rotated-access",
+        });
+        await buildOAuthFetch(sameIssuer.fetchFn)(SERVER_URL, { method: "POST", body: "{}" });
+
+        const newIssuer = createOAuthNetwork({
+          challengeMetadataUrl: REPLACEMENT_METADATA_URL,
+          issuer: REPLACEMENT_ISSUER,
+          mintedAccessToken: "attacker-access",
+        });
+        await expect(
+          buildOAuthFetch(newIssuer.fetchFn)(SERVER_URL, { method: "POST", body: "{}" }),
+        ).rejects.toThrow(/requires OAuth authorization/);
+
+        expect(newIssuer.tokenRequests).toEqual([]);
+        expect(readStore().tokensAuthorizationServerUrl).toBe(ORIGINAL_ISSUER);
+      },
+      { prefix: "openclaw-mcp-oauth-issuer-upgrade-challenge-", ...TEMP_HOME_OPTIONS },
+    );
+  });
+
+  it("binds legacy stored tokens to the pre-challenge issuer before rediscovery", async () => {
+    await withTempHome(
+      async () => {
+        await seedAuthorizedStore("tokens-then-discovery");
+        expect(readStore().tokensAuthorizationServerUrl).toBeUndefined();
+        const network = createOAuthNetwork({
+          challengeMetadataUrl: REPLACEMENT_METADATA_URL,
+          issuer: REPLACEMENT_ISSUER,
+          mintedAccessToken: "attacker-access",
+        });
+
+        await expect(
+          buildOAuthFetch(network.fetchFn)(SERVER_URL, { method: "POST", body: "{}" }),
+        ).rejects.toThrow(/requires OAuth authorization/);
+
+        expect(network.tokenRequests).toEqual([]);
+        expect(readStore().tokensAuthorizationServerUrl).toBe(ORIGINAL_ISSUER);
+        expect(readStore().tokens).toMatchObject({
+          access_token: STORED_ACCESS,
+          refresh_token: STORED_REFRESH,
+        });
+      },
+      { prefix: "openclaw-mcp-oauth-issuer-legacy-", ...TEMP_HOME_OPTIONS },
+    );
+  });
+
+  it("fails closed for a token-only legacy store with no recoverable issuer", async () => {
+    await withTempHome(
+      async () => {
+        const provider = createMcpOAuthClientProvider({
+          serverName: SERVER_NAME,
+          serverUrl: SERVER_URL,
+        });
+        await provider.saveClientInformation?.({ client_id: "stored-client-id" });
+        await provider.saveTokens({
+          access_token: STORED_ACCESS,
+          refresh_token: STORED_REFRESH,
+          token_type: "Bearer",
+          expires_in: 3600,
+        });
+        expect(readStore().discoveryState).toBeUndefined();
+        expect(readStore().tokensAuthorizationServerUrl).toBeUndefined();
+        const network = createOAuthNetwork({
+          challengeMetadataUrl: REPLACEMENT_METADATA_URL,
+          issuer: REPLACEMENT_ISSUER,
+          mintedAccessToken: "attacker-access",
+        });
+
+        await expect(
+          buildOAuthFetch(network.fetchFn)(SERVER_URL, { method: "POST", body: "{}" }),
+        ).rejects.toThrow(/OAuth authorization/);
+
+        expect(network.tokenRequests).toEqual([]);
+        expect(readStore().tokens).toMatchObject({ refresh_token: STORED_REFRESH });
+      },
+      { prefix: "openclaw-mcp-oauth-issuer-tokenonly-", ...TEMP_HOME_OPTIONS },
+    );
+  });
+
+  it("persists bound issuer provenance across a store reload", async () => {
+    await withTempHome(
+      async () => {
+        await seedAuthorizedStore("tokens-then-discovery");
+        const network = createOAuthNetwork({
+          challengeMetadataUrl: REPLACEMENT_METADATA_URL,
+          issuer: REPLACEMENT_ISSUER,
+          mintedAccessToken: "attacker-access",
+        });
+
+        await expect(
+          buildOAuthFetch(network.fetchFn)(SERVER_URL, { method: "POST", body: "{}" }),
+        ).rejects.toThrow(/OAuth authorization/);
+
+        closeOpenClawStateDatabaseForTest();
+        expect(readStore().tokensAuthorizationServerUrl).toBe(ORIGINAL_ISSUER);
+      },
+      { prefix: "openclaw-mcp-oauth-issuer-reload-", ...TEMP_HOME_OPTIONS },
+    );
+  });
+});

--- a/src/agents/mcp-oauth-refresh-issuer.test.ts
+++ b/src/agents/mcp-oauth-refresh-issuer.test.ts
@@ -192,6 +192,42 @@ describe("MCP OAuth refresh issuer binding", () => {
     );
   });
 
+  it.each([
+    {
+      variant: "an explicit default port",
+      issuer: "https://auth-old.example:443",
+    },
+    {
+      variant: "different host casing",
+      issuer: "https://AUTH-OLD.example",
+    },
+    {
+      variant: "a trailing slash",
+      issuer: "https://auth-old.example/",
+    },
+  ])("does not disclose a refresh token when the issuer differs by $variant", async ({ issuer }) => {
+    await withTempHome(
+      async () => {
+        await seedAuthorizedStore("discovery-then-tokens");
+        const provider = createMcpOAuthClientProvider({
+          serverName: SERVER_NAME,
+          serverUrl: SERVER_URL,
+        });
+        await provider.saveDiscoveryState?.({
+          authorizationServerUrl: issuer,
+          resourceMetadataUrl: REPLACEMENT_METADATA_URL,
+        });
+
+        expect(provider.tokens()).toBeUndefined();
+        expect(readStore().tokens).toMatchObject({
+          access_token: STORED_ACCESS,
+          refresh_token: STORED_REFRESH,
+        });
+      },
+      { prefix: "openclaw-mcp-oauth-issuer-normalization-", ...TEMP_HOME_OPTIONS },
+    );
+  });
+
   it("refreshes an upgraded row whose issuer is recoverable from stored discovery", async () => {
     await withTempHome(
       async () => {

--- a/src/agents/mcp-oauth-store.ts
+++ b/src/agents/mcp-oauth-store.ts
@@ -45,6 +45,7 @@ export type McpOAuthStore = {
   clientInformation?: OAuthClientInformationMixed;
   tokens?: OAuthTokens;
   tokenExpiresAt?: number;
+  tokensAuthorizationServerUrl?: string;
   codeVerifier?: string;
   discoveryState?: OAuthDiscoveryState;
   lastAuthorizationUrl?: string;
@@ -185,6 +186,19 @@ export function parseMcpOAuthStoreJson(storeKey: string, raw: string): McpOAuthS
   }
   if (value.tokenExpiresAt !== undefined && value.tokens === undefined) {
     throw new McpOAuthStoreCorruptionError(storeKey, "tokenExpiresAt requires tokens");
+  }
+  if (
+    value.tokensAuthorizationServerUrl !== undefined &&
+    (typeof value.tokensAuthorizationServerUrl !== "string" ||
+      !URL.canParse(value.tokensAuthorizationServerUrl))
+  ) {
+    throw new McpOAuthStoreCorruptionError(storeKey, "tokensAuthorizationServerUrl is invalid");
+  }
+  if (value.tokensAuthorizationServerUrl !== undefined && value.tokens === undefined) {
+    throw new McpOAuthStoreCorruptionError(
+      storeKey,
+      "tokensAuthorizationServerUrl requires tokens",
+    );
   }
   assertOptionalString(storeKey, value, "codeVerifier");
   assertOptionalString(storeKey, value, "lastAuthorizationUrl");

--- a/src/agents/mcp-oauth.ts
+++ b/src/agents/mcp-oauth.ts
@@ -66,6 +66,18 @@ function mcpOAuthAdditionalAuthorizationError(serverName: string): Error {
   );
 }
 
+function bindMcpOAuthTokensIssuer(store: McpOAuthStore): McpOAuthStore {
+  const issuedBy = store.discoveryState?.authorizationServerUrl;
+  if (
+    !store.tokens?.refresh_token ||
+    store.tokensAuthorizationServerUrl !== undefined ||
+    issuedBy === undefined
+  ) {
+    return store;
+  }
+  return { ...store, tokensAuthorizationServerUrl: issuedBy };
+}
+
 function applyMcpOAuthAuthorizationChallenge(
   current: McpOAuthStore,
   params: {
@@ -98,7 +110,9 @@ function applyMcpOAuthAuthorizationChallenge(
     params.resourceMetadataUrl &&
     current.discoveryState?.resourceMetadataUrl !== params.resourceMetadataUrl
   ) {
-    delete next.discoveryState;
+    const bound = bindMcpOAuthTokensIssuer(next);
+    delete bound.discoveryState;
+    return bound;
   }
   return next;
 }
@@ -191,6 +205,7 @@ export async function resolveMcpOAuthAccessToken(
       }
 
       const pendingChallenge = store.pendingAuthorizationChallenge;
+      updateMcpOAuthStore(storeKey, bindMcpOAuthTokensIssuer, bindMcpOAuthLeaseAssertion(lease));
       const provider = createMcpOAuthClientProvider({ ...params, lease });
       const result = await auth(provider, {
         serverUrl: params.serverUrl,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a remote MCP server configured with `auth: "oauth"` could cause OpenClaw to hand a previously stored refresh token to a different authorization server than the one that issued it.

When such a server answers an authenticated request with `401 Unauthorized` and a `WWW-Authenticate: Bearer resource_metadata="..."` challenge that points at a new Protected Resource Metadata document, OpenClaw lets the MCP SDK rediscover the authorization server from that document and then refresh the still-exposed stored credential. If the new metadata names a different issuer, the stored refresh token is POSTed to that issuer's `token_endpoint`. A server that can influence its own `WWW-Authenticate` header (or a network position that can rewrite it) can therefore harvest a refresh token that was minted for an entirely different authorization server.

## Why This Change Was Made

Stored MCP OAuth credentials had no record of which authorization-server issuer produced them, so nothing bound a refresh token to its issuer across a discovery change. This change persists the issuing authorization server alongside the refresh token and refuses to expose that token to the SDK once discovery selects a different issuer, forcing an interactive reauthorization instead. It deliberately uses issuer-bound provenance rather than a same-origin requirement between the MCP endpoint and its authorization server, because RFC 9728 explicitly allows a protected resource to advertise an externally hosted authorization server.

Sessions that already exist keep their provenance instead of being invalidated. A row written before this field existed still carries the discovery state that names its issuer, so `resolveMcpOAuthAccessToken` adopts that issuer as provenance before the SDK can drop or replace discovery, and the challenge handler snapshots it before a changed `resource_metadata` clears discovery. Both migrations run inside the existing OAuth flow lease and are one-time, so an upgraded same-issuer session refreshes untouched while a cross-issuer challenge on the same row is still blocked.

## User Impact

Refresh tokens for OAuth MCP servers are now only ever sent to the authorization server that issued them. A `resource_metadata` challenge that redirects discovery to a new issuer no longer silently replays the old refresh token; the connection reports that it requires authorization (`openclaw mcp login <server>`) instead. Existing sessions are not interrupted by the upgrade: any stored credential whose issuer is recoverable from its own discovery state keeps refreshing normally, and legitimate deployments whose metadata moves but keeps the same issuer continue to refresh without interruption. Only a credential whose issuer cannot be established at all, which is a token-only row imported by Doctor, has to be reauthorized once.

## Why this is the right boundary

The MCP OAuth credential provider (`src/agents/mcp-oauth-provider.ts`) already owns every read and write of the stored token through the SDK's `OAuthClientProvider`. Binding provenance there means the guard sits on the single seam the SDK calls (`tokens()`) to obtain the refresh token, so no SDK code path can reach the credential without passing the issuer check. The flow coordinator in `src/agents/mcp-oauth.ts` owns the matching provenance capture: one helper, `bindMcpOAuthTokensIssuer`, is applied both on the refresh path before `auth()` runs and inside the challenge handler before a changed `resource_metadata` deletes discovery, so every route that can replace the discovered issuer records the previous one first. The persisted shape lives in `src/agents/mcp-oauth-store.ts`. No sibling surface refreshes MCP OAuth tokens: the auth-profile path (`src/agents/mcp-auth-profile.ts`) refreshes provider profiles, not MCP server credentials, and does not touch this store.

The stored field is an additive optional value inside the existing `store_json` column, so there is no SQLite schema-version bump; older readers ignore it. Token-only rows imported by Doctor (`src/infra/state-migrations.mcp-oauth-format.ts` accepts `tokens` without `discoveryState`) have no recoverable issuer, so the provider fails closed for them: once discovery has run and no validated provenance matches, the refresh token is withheld from the SDK and the connection asks for a one-time reauthorization rather than replaying the credential against the newly selected issuer.

## Review follow-up

Every item from the ClawSweeper verdict at head `736b3bfad7da`, with its disposition:

- `[P1] Preserve existing issuer-bound OAuth sessions on upgrade` (`src/agents/mcp-oauth-provider.ts:137-145`): fixed. The guard itself is unchanged and still fail-closed; the missing piece was that recoverable provenance was never populated for an ordinary post-upgrade request. `resolveMcpOAuthAccessToken` now migrates it from the stored discovery state before `auth()` runs.
- `Resolve merge risk (P2)`: fixed by the same migration. An upgraded row with a refresh token plus its prior `discoveryState` no longer requires `openclaw mcp login`; scenario `[C]` in the proof below shows it refreshing against its original issuer on this head, exactly as it does on pristine `main`.
- `Complete next step (P2)`, `Improve patch quality: preserve or migrate issuer provenance for legacy rows`: fixed as the same narrow mechanical repair, factored into one helper rather than duplicated at the two capture points.
- `Improve patch quality: add a focused regression proving an upgraded same-issuer row refreshes without reauthorization while an issuer-changing challenge remains blocked`: fixed. `mcp-oauth-refresh-issuer.test.ts` adds `refreshes an upgraded row whose issuer is recoverable from stored discovery` and `blocks an issuer-changing challenge on an upgraded row after it refreshed`. Both fail on the previous head `736b3bfad7da` and pass here.
- `Decision needed: should recoverable pre-field rows be migrated or preserved automatically?`: implemented as the recommended option, `Migrate recoverable issuer provenance`, and not as the alternative one-time reauthorization for every legacy row. Rows whose issuer cannot be recovered stay fail-closed.
- `Stored data model: confirm migration or upgrade compatibility proof before merge`: covered by scenario `[C]`, which is driven on pristine `main`, on the previously reviewed head, and on this head with the same seeded SQLite row.

## Evidence

- Rebased onto `origin/main` `f8cc39ce6213`; head is `35046f428279`. The runtime before/after that isolates the defect is in the proof block below.
- `node scripts/run-vitest.mjs src/agents/mcp-oauth-refresh-issuer.test.ts src/agents/mcp-oauth-refresh.test.ts src/agents/mcp-oauth.test.ts src/agents/mcp-oauth-fetch.test.ts` on head `35046f428279` -> 4 files, 42 passed.
- The suite `mcp-oauth-refresh-issuer.test.ts` has 7 cases. With the three production files reverted to pristine `main` and the suite unchanged, 4 fail; with the production files at the previously reviewed head `736b3bfad7da`, the 2 new upgrade cases fail; all 7 pass on this head.
- `node scripts/run-oxlint.mjs` on the four changed files and `./node_modules/.bin/oxfmt --check` on the two edited files are clean; `node scripts/run-tsgo.mjs -p tsconfig.core.json` is clean.

## Real behavior proof

Behavior addressed: an OAuth MCP server's `401` plus a new `resource_metadata` challenge caused the stored refresh token to be sent to a different authorization-server issuer than the one that issued it, and the first form of the guard also stopped an upgraded same-issuer session from refreshing at all.
Real environment tested: drove the real production fetch wrapper `withMcpOAuthBearer` from `src/agents/mcp-oauth-fetch.ts` (which calls the real `resolveMcpOAuthAccessToken`, the real MCP SDK `auth()`, and the real SQLite-backed credential provider) against a fresh `OPENCLAW_STATE_DIR`, on pristine `main` `f8cc39ce6213`, on the previously reviewed head `736b3bfad7da`, and on this head `35046f428279`. The stored credential, the SDK discovery and refresh flow, and the on-disk SQLite state stayed real; only the outbound HTTP boundary was served by an in-process origin that plays the MCP server, the relocated metadata document (`https://metadata.example/pr-metadata`), each issuer's metadata, and its token endpoint. Three seeded states were exercised: (A) a credential whose stored discovery names `https://auth-old.example`, (B) a token-only row with no discovery, both hit by a `401` steering discovery to `https://auth-new.example`, and (C) an upgraded row that has a refresh token plus its original discovery but no issuer field, with an expired access token and no challenge at all.
Exact steps or command run after this patch: for each seeded state, issue one `POST https://mcp.example.com/mcp` through `withMcpOAuthBearer` and record where `refresh_token=stored-refresh-secret` was sent.
Evidence after fix:
```
# BEFORE (pristine main f8cc39ce6213, identical inputs)
[A] issuer-bound session, 401 challenge steers discovery to https://auth-new.example:
  outcome                                   : MCP request completed HTTP 200
  stored refresh secret POSTed to           : https://auth-new.example/token
  body                                      : grant_type=refresh_token&refresh_token=stored-refresh-secret&resource=https%3A%2F%2Fmcp.example.com%2Fmcp&client_id=stored-client-id
[B] token-only row imported by Doctor, same 401 challenge:
  outcome                                   : MCP request completed HTTP 200
  stored refresh secret POSTed to           : https://auth-new.example/token
  body                                      : grant_type=refresh_token&refresh_token=stored-refresh-secret&resource=https%3A%2F%2Fmcp.example.com%2Fmcp&client_id=stored-client-id
[C] upgraded row: expired access token, stored issuer https://auth-old.example, no challenge:
  outcome                                   : MCP request completed HTTP 200
  stored refresh secret POSTed to           : https://auth-old.example/token
  body                                      : grant_type=refresh_token&refresh_token=stored-refresh-secret&resource=https%3A%2F%2Fmcp.example.com%2Fmcp&client_id=stored-client-id

# PREVIOUSLY REVIEWED HEAD (736b3bfad7da, identical inputs)
[A] issuer-bound session, 401 challenge steers discovery to https://auth-new.example:
  outcome                                   : aborted with "MCP server "Remote Docs" requires OAuth authorization. Run openclaw mcp login Remote Docs."
  stored refresh secret POSTed to           : nowhere
[B] token-only row imported by Doctor, same 401 challenge:
  outcome                                   : aborted with "MCP server "Remote Docs" requires OAuth authorization. Run openclaw mcp login Remote Docs."
  stored refresh secret POSTed to           : nowhere
[C] upgraded row: expired access token, stored issuer https://auth-old.example, no challenge:
  outcome                                   : aborted with "MCP server "Remote Docs" requires OAuth authorization. Run openclaw mcp login Remote Docs."
  stored refresh secret POSTed to           : nowhere

# AFTER (this patch, head 35046f428279, identical inputs)
[A] issuer-bound session, 401 challenge steers discovery to https://auth-new.example:
  outcome                                   : aborted with "MCP server "Remote Docs" requires OAuth authorization. Run openclaw mcp login Remote Docs."
  stored refresh secret POSTed to           : nowhere
[B] token-only row imported by Doctor, same 401 challenge:
  outcome                                   : aborted with "MCP server "Remote Docs" requires OAuth authorization. Run openclaw mcp login Remote Docs."
  stored refresh secret POSTed to           : nowhere
[C] upgraded row: expired access token, stored issuer https://auth-old.example, no challenge:
  outcome                                   : MCP request completed HTTP 200
  stored refresh secret POSTed to           : https://auth-old.example/token
  body                                      : grant_type=refresh_token&refresh_token=stored-refresh-secret&resource=https%3A%2F%2Fmcp.example.com%2Fmcp&client_id=stored-client-id
```
Observed result after fix: on pristine `main` the stored refresh secret still reaches the newly discovered issuer in both attacked states; the previously reviewed head blocked those two but also broke the untouched upgraded session `[C]`; on this head the two attacked states deliver nothing to `https://auth-new.example` and stop with a reauthorization request, while `[C]` refreshes against its original issuer `https://auth-old.example` and returns HTTP 200 exactly as it does on pristine `main`.
What was not tested: no live third-party authorization server was contacted, since the outbound HTTP boundary was served in-process; a full product build was not run locally.

## Related GitHub items

`#73597` (closed) added a config-driven MCP OAuth resource/audience guard in a separate `mcp-oauth-guard.ts` and does not modify the refresh path in `mcp-oauth-fetch.ts` / `mcp-oauth.ts`, so it does not establish issuer-bound provenance. Open PRs `#94610` and `#98407` also touch `mcp-oauth.ts` but predate the SQLite store migration (`#109844`) and still operate on the old file-based store; neither binds a refresh token to its issuer. This change is the canonical open fix for the cross-issuer refresh-token replay.
