### PR TITLE
fix(ui): media pickers request permission and keep stable widths

### DIFF
--- a/ui/src/components/form-controls.browser.test.ts
+++ b/ui/src/components/form-controls.browser.test.ts
@@ -58,6 +58,31 @@ function controlsHtml() {
   `;
 }
 
+function mediaDeviceRowsHtml() {
+  return `
+    <main style="width: 100%; max-width: 900px">
+      <div class="settings-row">
+        <div class="settings-row__text"><span class="settings-row__title">Microphone input</span></div>
+        <div class="settings-row__control">
+          <select class="settings-select settings-select--media-device">
+            <option>MacBook Pro Microphone (Built-in)</option>
+          </select>
+          <button class="btn btn--sm btn--icon" type="button">↻</button>
+        </div>
+      </div>
+      <div class="settings-row">
+        <div class="settings-row__text"><span class="settings-row__title">Camera</span></div>
+        <div class="settings-row__control">
+          <select class="settings-select settings-select--media-device">
+            <option>System default</option>
+          </select>
+          <button class="btn btn--sm btn--icon" type="button">↻</button>
+        </div>
+      </div>
+    </main>
+  `;
+}
+
 async function openMobileFixture(): Promise<MobileFixture> {
   let page: Page | undefined;
   try {
@@ -102,6 +127,51 @@ afterAll(async () => {
     mobileContext?.close().catch(() => {}),
   ]);
   await browser?.close().catch(() => {});
+});
+
+describeBrowserLayout("settings media device controls", () => {
+  it("keeps paired selectors the same width across device labels and viewports", async () => {
+    const page = await desktopContext.newPage();
+    try {
+      await page.setViewportSize({ width: 1200, height: 800 });
+      await page.setContent(
+        `<!doctype html><html data-theme-mode="light"><head><style>${readUiCss()}</style></head><body>${mediaDeviceRowsHtml()}</body></html>`,
+      );
+
+      const measure = () =>
+        page.locator(".settings-row").evaluateAll((rows) =>
+          rows.map((row) => {
+            const select = row.querySelector(".settings-select--media-device");
+            const button = row.querySelector(".btn--icon");
+            if (!(select instanceof HTMLElement) || !(button instanceof HTMLElement)) {
+              throw new Error("Missing media device controls");
+            }
+            const selectRect = select.getBoundingClientRect();
+            const buttonRect = button.getBoundingClientRect();
+            return {
+              selectWidth: selectRect.width,
+              selectTop: selectRect.top,
+              buttonTop: buttonRect.top,
+            };
+          }),
+        );
+
+      const desktop = await measure();
+      expect(desktop.map((row) => row.selectWidth)).toEqual([340, 340]);
+      expect(desktop.every((row) => row.selectTop === row.buttonTop)).toBe(true);
+
+      await page.setViewportSize({ width: 390, height: 800 });
+      await page.locator("main").evaluate((main) => {
+        main.style.width = "285px";
+      });
+      const mobile = await measure();
+      expect(mobile[0]?.selectWidth).toBeCloseTo(mobile[1]?.selectWidth ?? 0, 5);
+      expect(mobile[0]?.selectWidth).toBeLessThan(340);
+      expect(mobile.every((row) => row.selectTop === row.buttonTop)).toBe(true);
+    } finally {
+      await page.close().catch(() => {});
+    }
+  });
 });
 
 describeBrowserLayout("touch-primary form controls", () => {

--- a/ui/src/pages/chat/realtime-talk-input.test.ts
+++ b/ui/src/pages/chat/realtime-talk-input.test.ts
@@ -36,6 +36,7 @@ describe("realtime Talk microphone inputs", () => {
         { deviceId: "built-in", label: "Built-in Microphone" },
         { deviceId: "usb", label: "Microphone 2" },
       ],
+      permissionRequired: true,
       warning: null,
     });
     expect(getUserMedia).not.toHaveBeenCalled();
@@ -61,6 +62,7 @@ describe("realtime Talk microphone inputs", () => {
         { deviceId: "built-in", label: "Built-in Microphone" },
         { deviceId: "loopback", label: "Loopback Audio" },
       ],
+      permissionRequired: false,
       warning: null,
     });
     expect(getUserMedia).toHaveBeenCalledWith({ audio: true });
@@ -82,6 +84,7 @@ describe("realtime Talk microphone inputs", () => {
     const result = await discoverRealtimeTalkInputs(true);
 
     expect(result.devices).toEqual([]);
+    expect(result.permissionRequired).toBe(true);
     expect(result.warning).toContain("Microphone access is blocked");
   });
 
@@ -212,6 +215,7 @@ describe("realtime Talk camera inputs", () => {
         { deviceId: "front", label: "Front Camera" },
         { deviceId: "back", label: "Camera 2" },
       ],
+      permissionRequired: true,
       warning: null,
     });
     expect(getUserMedia).not.toHaveBeenCalled();
@@ -228,6 +232,7 @@ describe("realtime Talk camera inputs", () => {
 
     await expect(discoverRealtimeTalkCameras(true)).resolves.toEqual({
       devices: [{ deviceId: "camera", label: "Desk Camera" }],
+      permissionRequired: false,
       warning: null,
     });
     expect(getUserMedia).toHaveBeenCalledWith({ video: true });

--- a/ui/src/pages/chat/realtime-talk-input.ts
+++ b/ui/src/pages/chat/realtime-talk-input.ts
@@ -9,6 +9,7 @@ export type RealtimeTalkCameraDevice = RealtimeTalkInputDevice;
 
 type RealtimeTalkDeviceDiscovery = {
   devices: RealtimeTalkInputDevice[];
+  permissionRequired: boolean;
   warning: string | null;
 };
 
@@ -57,6 +58,11 @@ function normalizeDevices(
   return normalized;
 }
 
+function deviceDetailsHidden(devices: MediaDeviceInfo[], kind: RealtimeTalkDeviceKind): boolean {
+  const inputs = devices.filter((device) => device.kind === kind);
+  return inputs.length === 0 || inputs.some((device) => !device.deviceId || !device.label);
+}
+
 function describeDeviceError(error: unknown, kind: RealtimeTalkDeviceKind): string {
   const name = error instanceof DOMException ? error.name : "";
   if (name === "NotAllowedError") {
@@ -102,13 +108,15 @@ async function discoverRealtimeTalkDevices(
     devices = mediaDevices(kind);
     entries = await devices.enumerateDevices();
   } catch (error) {
-    return { devices: [], warning: describeDeviceError(error, kind) };
+    return {
+      devices: [],
+      permissionRequired: false,
+      warning: describeDeviceError(error, kind),
+    };
   }
-  const inputs = entries.filter((device) => device.kind === kind);
-  const detailsHidden =
-    inputs.length === 0 || inputs.some((device) => !device.deviceId || !device.label);
-  if (!requestPermission || !detailsHidden || !devices.getUserMedia) {
-    return { devices: normalizeDevices(entries, kind), warning: null };
+  const permissionRequired = deviceDetailsHidden(entries, kind);
+  if (!requestPermission || !permissionRequired || !devices.getUserMedia) {
+    return { devices: normalizeDevices(entries, kind), permissionRequired, warning: null };
   }
 
   try {
@@ -117,10 +125,15 @@ async function discoverRealtimeTalkDevices(
     );
     probe.getTracks().forEach((track) => track.stop());
     entries = await devices.enumerateDevices();
-    return { devices: normalizeDevices(entries, kind), warning: null };
+    return {
+      devices: normalizeDevices(entries, kind),
+      permissionRequired: deviceDetailsHidden(entries, kind),
+      warning: null,
+    };
   } catch (error) {
     return {
       devices: normalizeDevices(entries, kind),
+      permissionRequired,
       warning: describeDeviceError(error, kind),
     };
   }

--- a/ui/src/pages/config/config-page.test.ts
+++ b/ui/src/pages/config/config-page.test.ts
@@ -114,6 +114,52 @@ describe("ConfigPage advanced selection guard", () => {
   });
 });
 
+describe("ConfigPage media discovery", () => {
+  it("coalesces refreshes while discovery is in flight", async () => {
+    for (const method of ["refreshMicrophones", "refreshCameras"] as const) {
+      const discovery = deferred<MediaDeviceInfo[]>();
+      const enumerateDevices = vi.fn(() => discovery.promise);
+      vi.stubGlobal("navigator", { mediaDevices: { enumerateDevices } });
+      const page = new ConfigPage();
+      const state = page as unknown as Record<
+        typeof method,
+        (requestPermission: boolean) => Promise<void>
+      >;
+
+      const first = state[method](true);
+      await state[method](true);
+      expect(enumerateDevices).toHaveBeenCalledOnce();
+
+      discovery.resolve([]);
+      await first;
+    }
+  });
+
+  it("upgrades passive discovery when the user requests permission", async () => {
+    for (const method of ["refreshMicrophones", "refreshCameras"] as const) {
+      const passiveDiscovery = deferred<MediaDeviceInfo[]>();
+      const enumerateDevices = vi
+        .fn()
+        .mockImplementationOnce(() => passiveDiscovery.promise)
+        .mockResolvedValueOnce([]);
+      vi.stubGlobal("navigator", { mediaDevices: { enumerateDevices } });
+      const page = new ConfigPage();
+      const state = page as unknown as Record<
+        typeof method,
+        (requestPermission: boolean) => Promise<void>
+      >;
+
+      const passive = state[method](false);
+      await state[method](true);
+      expect(enumerateDevices).toHaveBeenCalledOnce();
+
+      passiveDiscovery.resolve([]);
+      await passive;
+      expect(enumerateDevices).toHaveBeenCalledTimes(2);
+    }
+  });
+});
+
 describe("ConfigPage camera selection", () => {
   it("clears recovered errors and ignores failures from superseded selections", async () => {
     let rejectFirst: (error: Error) => void = () => undefined;

--- a/ui/src/pages/config/config-page.ts
+++ b/ui/src/pages/config/config-page.ts
@@ -230,13 +230,19 @@ export class ConfigPage extends OpenClawLightDomElement {
   @state() private systemInfo: SystemInfoResult | null = null;
   @state() private systemInfoUnavailable = false;
   @state() private microphoneDevices: RealtimeTalkInputDevice[] = [];
+  @state() private microphonePermissionRequired = true;
   @state() private microphoneLoading = false;
   @state() private microphoneError: string | null = null;
   private microphoneLoaded = false;
+  private microphoneRefreshRequestsPermission = false;
+  private microphonePermissionRefreshPending = false;
   @state() private cameraDevices: RealtimeTalkCameraDevice[] = [];
+  @state() private cameraPermissionRequired = true;
   @state() private cameraLoading = false;
   @state() private cameraError: string | null = null;
   private cameraLoaded = false;
+  private cameraRefreshRequestsPermission = false;
+  private cameraPermissionRefreshPending = false;
   private cameraSelectionRequest = 0;
   @state() private formModes: Record<ConfigPageId, ConfigFormMode> = {
     config: "form",
@@ -362,11 +368,19 @@ export class ConfigPage extends OpenClawLightDomElement {
   }
 
   private async refreshMicrophones(requestPermission: boolean) {
+    if (this.microphoneLoading) {
+      if (requestPermission && !this.microphoneRefreshRequestsPermission) {
+        this.microphonePermissionRefreshPending = true;
+      }
+      return;
+    }
     this.microphoneLoading = true;
+    this.microphoneRefreshRequestsPermission = requestPermission;
     this.microphoneError = null;
     try {
       const result = await discoverRealtimeTalkInputs(requestPermission);
       this.microphoneDevices = result.devices;
+      this.microphonePermissionRequired = result.permissionRequired;
       this.microphoneError = result.warning;
     } catch (error) {
       // Discovery is best-effort in blocked/inactive contexts; a rejection
@@ -374,20 +388,38 @@ export class ConfigPage extends OpenClawLightDomElement {
       this.microphoneError = error instanceof Error ? error.message : String(error);
     } finally {
       this.microphoneLoading = false;
+      this.microphoneRefreshRequestsPermission = false;
+    }
+    if (this.microphonePermissionRefreshPending) {
+      this.microphonePermissionRefreshPending = false;
+      await this.refreshMicrophones(true);
     }
   }
 
   private async refreshCameras(requestPermission: boolean) {
+    if (this.cameraLoading) {
+      if (requestPermission && !this.cameraRefreshRequestsPermission) {
+        this.cameraPermissionRefreshPending = true;
+      }
+      return;
+    }
     this.cameraLoading = true;
+    this.cameraRefreshRequestsPermission = requestPermission;
     this.cameraError = null;
     try {
       const result = await discoverRealtimeTalkCameras(requestPermission);
       this.cameraDevices = result.devices;
+      this.cameraPermissionRequired = result.permissionRequired;
       this.cameraError = result.warning;
     } catch (error) {
       this.cameraError = error instanceof Error ? error.message : String(error);
     } finally {
       this.cameraLoading = false;
+      this.cameraRefreshRequestsPermission = false;
+    }
+    if (this.cameraPermissionRefreshPending) {
+      this.cameraPermissionRefreshPending = false;
+      await this.refreshCameras(true);
     }
   }
 
@@ -852,6 +884,7 @@ export class ConfigPage extends OpenClawLightDomElement {
       setCatalogOpenTarget: (value) => this.setSetting("catalogOpenTarget", value),
       microphone: {
         devices: this.microphoneDevices,
+        permissionRequired: this.microphonePermissionRequired,
         selectedDeviceId: this.settings.realtimeTalkInputDeviceId ?? "",
         loading: this.microphoneLoading,
         error: this.microphoneError,
@@ -862,6 +895,7 @@ export class ConfigPage extends OpenClawLightDomElement {
       onMicrophoneSelect: (deviceId) => this.selectMicrophone(deviceId),
       camera: {
         devices: this.cameraDevices,
+        permissionRequired: this.cameraPermissionRequired,
         selectedDeviceId: this.settings.realtimeTalkVideoDeviceId ?? "",
         loading: this.cameraLoading,
         error: this.cameraError,

--- a/ui/src/pages/config/view.browser.test.ts
+++ b/ui/src/pages/config/view.browser.test.ts
@@ -1292,25 +1292,29 @@ describe("config view", () => {
   });
 
   it("names the chat preference selects for assistive tech", () => {
+    const onMicrophoneRefresh = vi.fn();
+    const onCameraRefresh = vi.fn();
     const { container } = renderConfigView({
       activeSection: "__appearance__",
       includeSections: ["__appearance__"],
       microphone: {
         devices: [{ deviceId: "mic-1", label: "Desk Mic" }],
+        permissionRequired: false,
         selectedDeviceId: "mic-1",
         loading: false,
         error: null,
       },
       onMicrophoneSelect: vi.fn(),
-      onMicrophoneRefresh: vi.fn(),
+      onMicrophoneRefresh,
       camera: {
         devices: [{ deviceId: "camera-1", label: "Desk Camera" }],
+        permissionRequired: false,
         selectedDeviceId: "camera-1",
         loading: false,
         error: null,
       },
       onCameraSelect: vi.fn(),
-      onCameraRefresh: vi.fn(),
+      onCameraRefresh,
       composerHoldToRecord: true,
       setComposerHoldToRecord: vi.fn(),
     });
@@ -1340,13 +1344,82 @@ describe("config view", () => {
       HTMLSelectElement,
     );
     expect(microphoneSelect.getAttribute("aria-label")).toBe("Microphone input");
+    expect(microphoneSelect.classList.contains("settings-select--media-device")).toBe(true);
     const cameraSelect = queryRequired(container, "[data-settings-camera]", HTMLSelectElement);
     expect(cameraSelect.getAttribute("aria-label")).toBe("Camera");
+    expect(cameraSelect.classList.contains("settings-select--media-device")).toBe(true);
     expect(Array.from(cameraSelect.options, (option) => option.textContent?.trim())).toEqual([
       "System default",
       "Desk Camera",
     ]);
     expect(container.textContent).toContain("Hold microphone button to dictate");
+
+    microphoneSelect.dispatchEvent(new MouseEvent("pointerdown", { bubbles: true, button: 0 }));
+    cameraSelect.dispatchEvent(new MouseEvent("pointerdown", { bubbles: true, button: 0 }));
+    expect(onMicrophoneRefresh).not.toHaveBeenCalled();
+    expect(onCameraRefresh).not.toHaveBeenCalled();
+  });
+
+  it("requests media access for each native picker opening gesture", () => {
+    const cases = [
+      {
+        devices: [{ deviceId: "anonymous", label: "Microphone 1" }],
+        gesture: new MouseEvent("pointerdown", { bubbles: true, button: 0 }),
+      },
+      { devices: [], gesture: new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }) },
+      { devices: [], gesture: new KeyboardEvent("keydown", { key: "F4", bubbles: true }) },
+    ];
+
+    for (const { devices, gesture } of cases) {
+      const onMicrophoneRefresh = vi.fn();
+      const { container } = renderConfigView({
+        activeSection: "__appearance__",
+        includeSections: ["__appearance__"],
+        microphone: {
+          devices,
+          permissionRequired: true,
+          selectedDeviceId: "",
+          loading: false,
+          error: null,
+        },
+        onMicrophoneSelect: vi.fn(),
+        onMicrophoneRefresh,
+      });
+      const microphoneSelect = queryRequired(
+        container,
+        "[data-settings-microphone]",
+        HTMLSelectElement,
+      );
+
+      microphoneSelect.dispatchEvent(gesture);
+      expect(onMicrophoneRefresh).toHaveBeenCalledOnce();
+    }
+  });
+
+  it("coalesces picker gestures while media access is starting", () => {
+    const onCameraRefresh = vi.fn();
+    const { container } = renderConfigView({
+      activeSection: "__appearance__",
+      includeSections: ["__appearance__"],
+      camera: {
+        devices: [],
+        permissionRequired: true,
+        selectedDeviceId: "",
+        loading: true,
+        error: null,
+      },
+      onCameraSelect: vi.fn(),
+      onCameraRefresh,
+    });
+    const cameraSelect = queryRequired(container, "[data-settings-camera]", HTMLSelectElement);
+
+    cameraSelect.dispatchEvent(new MouseEvent("pointerdown", { bubbles: true, button: 2 }));
+    expect(onCameraRefresh).not.toHaveBeenCalled();
+
+    cameraSelect.dispatchEvent(new MouseEvent("pointerdown", { bubbles: true, button: 0 }));
+    cameraSelect.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }));
+    cameraSelect.dispatchEvent(new KeyboardEvent("keydown", { key: "F4", bubbles: true }));
+    expect(onCameraRefresh).toHaveBeenCalledOnce();
   });
 
   it("renders and changes the live sidebar activity preference", () => {

--- a/ui/src/pages/config/view.ts
+++ b/ui/src/pages/config/view.ts
@@ -70,6 +70,7 @@ const TEXT_SCALE_LABELS: Record<TextScaleStop, string> = {
 
 type SettingsMediaDeviceState = {
   devices: RealtimeTalkInputDevice[];
+  permissionRequired: boolean;
   selectedDeviceId: string;
   loading: boolean;
   error: string | null;
@@ -947,6 +948,24 @@ function renderSettingsMediaDeviceField(options: {
       : []),
   ];
   const refreshLabel = `${t("common.refresh")}: ${options.title}`;
+  let accessRequested = false;
+  const requestAccess = () => {
+    if (accessRequested || !state.permissionRequired) {
+      return;
+    }
+    accessRequested = true;
+    options.onRefresh?.();
+  };
+  const requestAccessFromPointer = (event: PointerEvent) => {
+    if (event.button === 0) {
+      requestAccess();
+    }
+  };
+  const requestAccessFromKeyboard = (event: KeyboardEvent) => {
+    if (["Enter", " ", "ArrowDown", "ArrowUp", "F4"].includes(event.key)) {
+      requestAccess();
+    }
+  };
   const note = state.error
     ? html`<span role="alert">${state.error}</span>`
     : !state.loading && state.devices.length === 0
@@ -957,11 +976,13 @@ function renderSettingsMediaDeviceField(options: {
     description: note,
     control: html`
       <select
-        class="settings-select"
+        class="settings-select settings-select--media-device"
         data-settings-microphone=${options.dataAttribute === "microphone" ? "" : nothing}
         data-settings-camera=${options.dataAttribute === "camera" ? "" : nothing}
         aria-label=${options.title}
         .value=${selectedDeviceId}
+        @pointerdown=${requestAccessFromPointer}
+        @keydown=${requestAccessFromKeyboard}
         @change=${(event: Event) =>
           options.onSelect?.((event.currentTarget as HTMLSelectElement).value)}
       >

--- a/ui/src/styles/settings.css
+++ b/ui/src/styles/settings.css
@@ -437,6 +437,12 @@ select.settings-select {
   min-width: min(220px, 100%);
 }
 
+/* Permission can replace System default with long hardware labels; keep the
+   paired media pickers aligned instead of letting native intrinsic width win. */
+.settings-row:not(.settings-row--stacked) .settings-row__control > .settings-select--media-device {
+  width: 340px;
+}
+
 /* Lone value inputs share one width so stacked rows in a group read as a
    grid instead of ragged right-aligned fields. A percentage guard cannot work
    here (the shrink-to-fit control resolves 100% circularly); the fixed width
@@ -753,5 +759,15 @@ textarea.settings-input {
     width: 100%;
     max-width: 100%;
     flex-wrap: wrap;
+  }
+
+  .settings-row__control:has(> .settings-select--media-device) {
+    flex-wrap: nowrap;
+  }
+
+  .settings-select--media-device {
+    flex: 1 1 auto;
+    width: auto;
+    min-width: 0;
   }
 }


### PR DESCRIPTION
Closes #111971

## What Problem This Solves

Fixes an issue where opening an empty microphone or camera picker in Settings → Appearance would only show “System default” instead of requesting browser permission. The paired media selectors could also resize independently once hardware labels appeared, making the rows jump and look misaligned.

## Why This Change Was Made

Media discovery now reports explicitly when permission is still required. Opening a picker with the primary pointer or native keyboard shortcuts requests access through the existing bounded probe-and-stop flow, while passive discovery is upgraded rather than discarded if it is already running. Duplicate gestures are coalesced at both the view and ConfigPage boundaries.

The two media selectors share a stable desktop width and shrink together on narrow screens without wrapping their refresh buttons.

## User Impact

Users can open an empty microphone or camera picker and immediately receive the browser’s native permission prompt. Visiting Appearance remains passive, populated pickers stay passive, denied permission remains non-fatal, and microphone/camera controls keep matching dimensions before and after device labels are revealed.

Release-note context: **Control UI media settings** — opening an empty microphone or camera picker now requests browser access, and both pickers retain stable responsive sizing.

## Evidence

- Focused UI tests: 69 passing across realtime media discovery, ConfigPage, config view, and Chromium form-layout coverage.
- Hosted changed-surface gate: Blacksmith Testbox `tbx_01ky19abehqcsnmr19yqmch8gv`, run https://github.com/openclaw/openclaw/actions/runs/29796903377 — formatting, i18n verification, TypeScript checks, and lint all passed.
- Final Codex autoreview: clean, no accepted/actionable findings.
- Live browser proof:
  - visiting Appearance did not request media access;
  - opening an empty picker started permission-bearing discovery and displayed the native browser prompt;
  - secondary-clicking did not request permission;
  - selector widths measured 340/340 px on desktop and 220/220 px at 375 px, with refresh buttons remaining inline.

| Before | After |
| --- | --- |
| ![Before: empty media selectors rely on the separate refresh action](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/media-permission-settings-111971/before.png) | ![After: paired media selectors keep one stable width](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/media-permission-settings-111971/after.png) |

AI-assisted: implemented and verified with Claude Code, with Codex autoreview as the independent source-aware review gate.
