### PR TITLE
fix(cron): command jobs no longer warn about missing agents

### DIFF
--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -1021,6 +1021,21 @@ describe("cron cli", () => {
     expectNoRuntimeErrorContaining("No --agent specified");
   });
 
+  it("does not warn when --command is used (no agent needed)", async () => {
+    await runCronCommand([
+      "cron",
+      "add",
+      "--name",
+      "Command",
+      "--cron",
+      "* * * * *",
+      "--command",
+      "printf ok",
+    ]);
+
+    expectNoRuntimeErrorContaining("No --agent specified");
+  });
+
   it("warns even when --session-key is provided (user should still specify agent explicitly)", async () => {
     await runCronCommand([
       "cron",

--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -454,9 +454,7 @@ export function registerCronAddCommand(cron: Command) {
               : undefined;
 
             if (
-              (resolvedPayload.kind === "agentTurn" ||
-                resolvedPayload.kind === "command" ||
-                resolvedPayload.kind === "script") &&
+              (resolvedPayload.kind === "agentTurn" || resolvedPayload.kind === "script") &&
               !agentId
             ) {
               defaultRuntime.error(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users creating command-only cron jobs saw a warning that no agent was specified, even though command payloads execute directly on the Gateway and do not use an agent.

## Why This Change Was Made

The missing-agent warning now applies only to payloads that actually need agent context: agent turns and headless scripts. System events and Gateway command jobs remain warning-free. A focused regression test locks in the command-job behavior.

This PR is AI-assisted. The final two-file diff was independently reviewed after rebasing onto current `main`, with no actionable findings.

## User Impact

Command cron creation is now quiet and accurate. Interactive users no longer see misleading guidance, and JSON/automation callers no longer receive irrelevant warning text on stderr.

## Evidence

- Exact-head Blacksmith Testbox `tbx_01ky1a4j0nxf77w6115zb26ght`: `src/cli/cron-cli.test.ts` passed 108/108 tests, followed by the scoped `check:changed` lane with formatting, typechecks, lint, import cycles, and repository guards green.
- Exact-head Blacksmith Testbox `tbx_01ky1an0sej190cvc84ve7q1ka`: full production `pnpm build` passed.
- Isolated local dev Gateway on a random loopback port: a post-fix command cron job produced zero stderr bytes, emitted no missing-agent warning, executed successfully, and was removed cleanly.
- Scheduler stress proof on the same isolated Gateway:
  - simultaneous 9-job and 40-job command waves reached exactly the configured 8-run admission cap; every job produced one successful terminal history row;
  - cron reads remained responsive under full admission load (20 samples, p95 958 ms, max 1148 ms);
  - disabled/due/force behavior, wall and no-output timeouts, high-frequency `every` and six-field cron schedules, timezone edits, on-exit triggers, removal-before-due, and cleanup all passed;
  - a hard Gateway crash during a running one-shot repaired it to exactly one `cron: job interrupted by gateway restart` error, cleared queued/running markers, and disabled the one-shot without replay;
  - real OpenAI chat and terminal TUI flows each created the requested cron job through the native cron tool, independently verified through the CLI.
- Full cron Testbox shard passed: 138 test files, 1554 tests.
