### PR TITLE
fix(scripts): keep Anthropic prompt previews UTF-16 safe

### DIFF
--- a/scripts/anthropic-prompt-probe.ts
+++ b/scripts/anthropic-prompt-probe.ts
@@ -14,6 +14,7 @@ import os from "node:os";
 import path from "node:path";
 import process from "node:process";
 import { pathToFileURL } from "node:url";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { AuthProfileCredential } from "../src/agents/auth-profiles.js";
 import {
   parseBooleanEnv,
@@ -140,7 +141,7 @@ function summarizeText(text: string, max = 120): string {
   if (normalized.length <= max) {
     return normalized;
   }
-  return `${normalized.slice(0, max - 1)}…`;
+  return `${truncateUtf16Safe(normalized, max - 1)}…`;
 }
 
 function summarizeCapture(


### PR DESCRIPTION
## What Problem This Solves

Anthropic prompt-capture summaries truncated normalized system/user text with raw `String.slice`. If the 119-code-unit preview boundary landed inside an emoji or another supplementary-plane character, the JSON preview could contain a dangling UTF-16 surrogate.

## Why This Change Was Made

The probe now uses the canonical `truncateUtf16Safe` helper from normalization-core at its existing boundary. This preserves whitespace normalization, the 120-code-unit budget, and the ellipsis while keeping captured prompt previews well formed.

The batch-wide sibling sweep found this remaining model-visible scripts boundary after the Firecrawl, labeler, and tool-surface bench fixes.

## User Impact

`scripts/anthropic-prompt-probe.ts` no longer emits malformed system-block or user-prompt previews when captured text crosses a surrogate-pair boundary. Ordinary ASCII/BMP preview output is unchanged.

## Evidence

- Direct exact-code-path probe: `testing.summarizeText("abc😀tail", 5)` returns `"abc…"`.
- Blacksmith Testbox `tbx_01ky1b6g19fvmxx97ceta30255`: normalization-core UTF-16 suite passed 21/21 (https://github.com/openclaw/openclaw/actions/runs/29798411107).
- Blacksmith Testbox `tbx_01ky1bnr1pey9qzckc38g5n540`: targeted changed gate passed formatting, script declarations, script typecheck, lint, and repository guards (https://github.com/openclaw/openclaw/actions/runs/29798768851).
- AutoReview: clean; no accepted/actionable findings.
- `git diff --check`: passed.

No public API, configuration, dependency, storage, protocol, or secret-handling behavior changes.
