### PR TITLE
fix: profile settings handle an unset identity

### DIFF
--- a/ui/src/e2e/profile-page.e2e.test.ts
+++ b/ui/src/e2e/profile-page.e2e.test.ts
@@ -1,4 +1,6 @@
 // Control UI tests cover the settings profile page against a mocked Gateway.
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
 import { chromium, type Browser, type Page } from "playwright";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
@@ -13,6 +15,19 @@ const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.
 const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
 const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
 const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
+const proofDir = path.join(process.cwd(), ".artifacts", "control-ui-e2e", "profile-identity");
+
+async function screenshot(page: Page, name: string) {
+  if (!captureUiProof) {
+    return;
+  }
+  await mkdir(proofDir, { recursive: true });
+  await page.locator("#settings-profile-identity").screenshot({
+    animations: "disabled",
+    path: path.join(proofDir, name),
+  });
+}
 
 let browser: Browser;
 let server: ControlUiE2eServer;
@@ -117,6 +132,25 @@ const sessionsUsageResponse = {
   },
 };
 
+const testProfile = {
+  id: "11111111-1111-4111-8111-111111111111",
+  displayName: "Test Person",
+  avatarMime: null,
+  mergedInto: null,
+  createdAt: 1,
+  updatedAt: 2,
+  emails: ["test@example.com"],
+  hasAvatar: false,
+};
+const testPresenceUsers = [
+  {
+    self: true,
+    id: testProfile.id,
+    name: testProfile.displayName,
+    email: testProfile.emails[0],
+  },
+];
+
 describeControlUiE2e("Control UI profile page mocked Gateway E2E", () => {
   beforeAll(async () => {
     if (!chromiumAvailable) {
@@ -184,12 +218,23 @@ describeControlUiE2e("Control UI profile page mocked Gateway E2E", () => {
   it("renders the gateway avatar route in the profile preview", async () => {
     const context = await browser.newContext();
     const page = await context.newPage();
+    const gatewayUrl = server.baseUrl.replace(/^http/u, "ws").replace(/\/$/u, "");
+    await page.addInitScript((sameOriginGatewayUrl) => {
+      (
+        window as Window & {
+          ["__OPENCLAW_NATIVE_CONTROL_AUTH__"]?: { gatewayUrl: string; token: string };
+        }
+      )["__OPENCLAW_NATIVE_CONTROL_AUTH__"] = {
+        gatewayUrl: sameOriginGatewayUrl,
+        token: "test",
+      };
+    }, gatewayUrl);
     const avatarRequests: string[] = [];
     // The gateway serves the avatar (uploaded first, Gravatar fallback second)
     // behind its own same-origin route; the Control UI renders only that route,
     // so the preview never requests gravatar.com directly — the Control UI CSP
     // (img-src 'self') would block it.
-    await page.route("**/api/users/profile-1/avatar*", async (route) => {
+    await page.route(`**/api/users/${testProfile.id}/avatar*`, async (route) => {
       avatarRequests.push(route.request().url());
       await route.fulfill({
         body: '<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"/>',
@@ -197,51 +242,65 @@ describeControlUiE2e("Control UI profile page mocked Gateway E2E", () => {
         status: 200,
       });
     });
-    const gateway = await installMockGateway(page, {
+    await installMockGateway(page, {
+      presenceUsers: testPresenceUsers,
       methodResponses: {
         "usage.cost": usageCostResponse,
         "sessions.usage": sessionsUsageResponse,
-        "users.self": {
-          profile: {
-            id: "profile-1",
-            displayName: "Test Person",
-            avatarMime: null,
-            mergedInto: null,
-            createdAt: 1,
-            updatedAt: 2,
-            emails: ["test@example.com"],
-            hasAvatar: false,
-          },
-        },
+        "users.self": { profile: testProfile },
       },
     });
 
     try {
       const response = await page.goto(`${server.baseUrl}settings/profile`);
       expect(response?.status()).toBe(200);
-      const connect = await gateway.waitForRequest("connect");
-      const instanceId = (connect.params as { client?: { instanceId?: string } } | undefined)
-        ?.client?.instanceId;
-      expect(instanceId).toBeTruthy();
-      await gateway.emitGatewayEvent("presence", {
-        presence: [
-          {
-            instanceId,
-            user: { id: "profile-1", email: "test@example.com", name: "Test Person" },
-          },
-        ],
-      });
 
       const profileAvatar = page.locator("#settings-profile-identity openclaw-viewer-avatar img");
       await profileAvatar.waitFor({ timeout: 10_000 });
       // profile-page derives the src from userProfileAvatarUrl(id, updatedAt);
       // the gateway origin may absolutize it, so match the canonical path suffix.
-      expect(await profileAvatar.getAttribute("src")).toMatch(
-        /\/api\/users\/profile-1\/avatar\?v=2$/u,
+      expect(await profileAvatar.getAttribute("src")).toContain(
+        `/api/users/${testProfile.id}/avatar?v=2`,
       );
       await expect
-        .poll(() => avatarRequests.some((url) => url.includes("/api/users/profile-1/avatar")))
+        .poll(() =>
+          avatarRequests.some((url) => url.includes(`/api/users/${testProfile.id}/avatar`)),
+        )
         .toBe(true);
+    } finally {
+      await context.close();
+    }
+  });
+
+  it("retries the missing identity bootstrap and opens the profile editor", async () => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      presenceUsers: testPresenceUsers,
+      methodResponses: {
+        "usage.cost": usageCostResponse,
+        "sessions.usage": sessionsUsageResponse,
+        "users.self": { sequence: [{}, { profile: testProfile }] },
+      },
+    });
+
+    try {
+      const response = await page.goto(`${server.baseUrl}settings/profile`);
+      expect(response?.status()).toBe(200);
+
+      const emptyState = page.locator(".profile-identity-empty");
+      await emptyState.waitFor({ timeout: 10_000 });
+      await expect(emptyState.textContent()).resolves.toContain("Identity is not set.");
+      await screenshot(page, "01-identity-not-set.png");
+
+      await page.getByRole("button", { name: "Set identity" }).click();
+
+      await page.locator('.identity-name-control input[type="text"]').waitFor({ timeout: 10_000 });
+      await expect.poll(async () => (await gateway.getRequests("users.self")).length).toBe(2);
+      await expect(page.locator(".identity-name-control input").inputValue()).resolves.toBe(
+        testProfile.displayName,
+      );
+      await screenshot(page, "02-identity-editor.png");
     } finally {
       await context.close();
     }

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -2272,6 +2272,8 @@ export const en: TranslationMap = {
       description: "Your profile on this gateway.",
       loading: "Loading your identity…",
       profileUnavailable: "Your identity profile could not be loaded.",
+      notSet: "Identity is not set.",
+      setIdentity: "Set identity",
       avatar: "Avatar",
       avatarDescription: "PNG, JPEG, or WebP. Images are resized to 256 × 256 or smaller.",
       chooseAvatar: "Choose image",

--- a/ui/src/pages/profile/profile-page.test.ts
+++ b/ui/src/pages/profile/profile-page.test.ts
@@ -307,6 +307,58 @@ it("keeps identity UI and profile RPCs absent for unidentified connections", asy
   expect(page.querySelector("#settings-profile-identity")).toBeNull();
 });
 
+it("retries the identity bootstrap when users.self returns no profile", async () => {
+  const profile: UserProfile = {
+    id: "profile-1",
+    displayName: "Ada",
+    avatarMime: null,
+    mergedInto: null,
+    createdAt: 1,
+    updatedAt: 2,
+    emails: ["ada@example.test"],
+    hasAvatar: false,
+  };
+  let identityRequests = 0;
+  const request = vi.fn(async (method: string) => {
+    if (method === "usage.cost") {
+      return createCostSummary();
+    }
+    if (method === "sessions.usage") {
+      return createSessionsResult();
+    }
+    if (method === "users.self") {
+      identityRequests += 1;
+      return identityRequests === 1 ? {} : { profile };
+    }
+    throw new Error(`unexpected method: ${method}`);
+  });
+  const harness = createConnectedContext(request as GatewayBrowserClient["request"], {
+    id: "profile-1",
+    email: "ada@example.test",
+    name: "Ada",
+  });
+  const provider = createApplicationContextProvider(harness.context);
+  const page = document.createElement(PROFILE_PAGE_TEST_TAG) as ProfilePageElement;
+  provider.append(page);
+  document.body.append(provider);
+
+  await waitForFast(() => expect(page.querySelector(".profile-identity-empty")).not.toBeNull());
+  const emptyState = page.querySelector<HTMLElement>(".profile-identity-empty");
+  const setIdentityButton = emptyState?.querySelector<HTMLButtonElement>("button");
+  expect(emptyState?.textContent).toContain(t("profilePage.identity.notSet"));
+  expect(setIdentityButton?.textContent?.trim()).toBe(t("profilePage.identity.setIdentity"));
+  expect(page.textContent).not.toContain("Cannot read properties of undefined");
+
+  setIdentityButton?.click();
+
+  await waitForFast(() =>
+    expect(request.mock.calls.filter(([method]) => method === "users.self")).toHaveLength(2),
+  );
+  await waitForFast(() =>
+    expect(page.querySelector<HTMLInputElement>(".identity-name-control input")?.value).toBe("Ada"),
+  );
+});
+
 it("bootstraps and refreshes the connected user's profile through users.self", async () => {
   let profile: UserProfile = {
     id: "profile-1",
@@ -318,6 +370,7 @@ it("bootstraps and refreshes the connected user's profile through users.self", a
     emails: ["ada@example.test", "ada@work.test"],
     hasAvatar: false,
   };
+  let omitNextProfile = false;
   const request = vi.fn(async (method: string, params?: unknown) => {
     if (method === "usage.cost") {
       return createCostSummary();
@@ -326,6 +379,10 @@ it("bootstraps and refreshes the connected user's profile through users.self", a
       return createSessionsResult();
     }
     if (method === "users.self") {
+      if (omitNextProfile) {
+        omitNextProfile = false;
+        return {};
+      }
       return { profile };
     }
     if (method === "users.setDisplayName") {
@@ -426,6 +483,7 @@ it("bootstraps and refreshes the connected user's profile through users.self", a
     "Unsaved draft",
   );
 
+  omitNextProfile = true;
   request.mockClear();
   page.querySelector<HTMLButtonElement>(".profile-refresh")?.click();
   await waitForFast(() =>
@@ -439,6 +497,7 @@ it("bootstraps and refreshes the connected user's profile through users.self", a
   expect(page.querySelector<HTMLInputElement>(".identity-name-control input")?.value).toBe(
     "Unsaved draft",
   );
+  expect(page.querySelector(".profile-identity-empty")).toBeNull();
 
   const pageWithState = page as ProfilePageElement & {
     identityBusy: "display-name" | "avatar" | null;

--- a/ui/src/pages/profile/profile-page.ts
+++ b/ui/src/pages/profile/profile-page.ts
@@ -310,14 +310,16 @@ export class ProfilePage extends OpenClawLightDomElement {
     this.identityLoading = true;
     this.identityError = null;
     try {
-      const result = await client.request<UsersSelfResult>("users.self", {});
+      const result = await client.request<Partial<UsersSelfResult> | null>("users.self", {});
       if (requestId !== this.identityRequestId) {
         return;
       }
-      this.ownProfile = result.profile;
-      this.displayName = hasUnsavedDisplayName
-        ? displayNameDraft
-        : (result.profile.displayName ?? "");
+      const profile = result?.profile;
+      if (!profile) {
+        return;
+      }
+      this.ownProfile = profile;
+      this.displayName = hasUnsavedDisplayName ? displayNameDraft : (profile.displayName ?? "");
     } catch (error) {
       if (requestId === this.identityRequestId) {
         this.identityError = toIdentityErrorMessage(error);
@@ -436,14 +438,22 @@ export class ProfilePage extends OpenClawLightDomElement {
       return nothing;
     }
     if (!this.ownProfile) {
+      // users.self is the idempotent gateway-owned profile ensure path. Retrying
+      // keeps profile ids and authenticated email linkage authoritative server-side.
+      const emptyState = this.identityLoading
+        ? t("profilePage.identity.loading")
+        : this.identityError
+          ? this.identityError
+          : html`<div class="profile-identity-empty">
+              <span>${t("profilePage.identity.notSet")}</span>
+              <button type="button" class="btn btn--sm" @click=${() => void this.loadIdentity()}>
+                ${t("profilePage.identity.setIdentity")}
+              </button>
+            </div>`;
       return html`<div id=${PROFILE_SETTINGS_TARGET_IDS.identity}>
         ${renderSettingsSection(
           { title: t("profilePage.identity.title") },
-          renderSettingsEmpty(
-            this.identityLoading
-              ? t("profilePage.identity.loading")
-              : (this.identityError ?? t("profilePage.identity.profileUnavailable")),
-          ),
+          renderSettingsEmpty(emptyState),
         )}
       </div>`;
     }

--- a/ui/src/styles/profile.css
+++ b/ui/src/styles/profile.css
@@ -92,6 +92,13 @@
   background: var(--accent-2-subtle);
 }
 
+.profile-identity-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-3);
+}
+
 /* Stat strip (escape hatch inside one settings group) */
 
 .profile-stats {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening **Settings → Profile** could see a raw JavaScript `displayName` error when the gateway had an authenticated user but did not return an identity profile.

## Why This Change Was Made

The profile page now treats an absent profile in the unvalidated `users.self` response as an unset identity. It renders a neutral empty state with a **Set identity** action, then uses the existing server-owned `users.self` bootstrap path to open the normal identity editor once the profile is returned.

The profile browser coverage also now uses a realistic UUID profile and an explicit same-origin gateway for the authenticated avatar route, replacing a stale fixture that could not exercise the behavior it claimed to test.

AI-assisted change; the implementation and rendered behavior were reviewed and verified.

## User Impact

Users without a configured identity now see **Identity is not set.** and can set it directly instead of seeing an internal exception message.

## Evidence

- `pnpm test ui/src/pages/profile/profile-page.test.ts` — 5 tests passed.
- Focused Control UI Chromium E2E — 5 tests passed, including the unset-identity action and the existing avatar-route scenario.
- `pnpm ui:i18n:verify` passed.
- Blacksmith Testbox changed checks and focused profile E2E passed on the final patch.
- Rendered browser evidence captured the neutral empty state and resulting editor. Automated upload is blocked because no approved artifact backend is configured, so no unapproved public image host was used.
