### PR TITLE
fix(install): report source UI build failures correctly

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1538,7 +1538,8 @@ function Install-OpenClawFromGit {
             Write-Host "[!] pnpm install failed for the Git checkout" -ForegroundColor Red
             return $false
         }
-        if (-not (& $pnpmCommand ui:build)) {
+        & $pnpmCommand ui:build
+        if ($LASTEXITCODE -ne 0) {
             Write-Host "[!] UI build failed; continuing (CLI may still work)" -ForegroundColor Yellow
         }
         $env:NODE_OPTIONS = Resolve-NodeOptionsWithMinOldSpace -NodeOptions $prevNodeOptions -MinOldSpaceMb 8192

--- a/test/scripts/install-ps1.test.ts
+++ b/test/scripts/install-ps1.test.ts
@@ -935,6 +935,8 @@ describe("install.ps1 failure handling", () => {
     expect(gitInstallBody).toContain(
       "$env:NODE_OPTIONS = Resolve-NodeOptionsWithMinOldSpace -NodeOptions $prevNodeOptions -MinOldSpaceMb 8192",
     );
+    expect(gitInstallBody).toMatch(/& \$pnpmCommand ui:build\s+if \(\$LASTEXITCODE -ne 0\)/);
+    expect(gitInstallBody).not.toContain("if (-not (& $pnpmCommand ui:build))");
     expect(nodeOptionsBody).toContain("--max-old-space-size=$MinOldSpaceMb");
     expect(nodeOptionsBody).toContain("[Math]::Max");
     expect(gitInstallBody).toContain("& $pnpmCommand build");


### PR DESCRIPTION
Closes #112049

## What Problem This Solves

Fixes an issue where Windows users installing OpenClaw from source could have a failed Control UI build reported as successful when `pnpm ui:build` wrote output, or a successful silent build reported as failed.

## Why This Change Was Made

The source installer now runs the UI build and classifies it from the native process exit code instead of converting command output to a PowerShell Boolean. The existing non-fatal behavior is unchanged: a UI build failure still warns and allows the CLI install to continue.

## User Impact

Windows source installs now report the Control UI build status consistently, regardless of whether pnpm/Vite writes progress output.

## Evidence

- Before/after PowerShell semantics probe with a simulated build that emits output and exits `1`:

  ```json
  {"LegacyOutputTruthinessWarns":false,"ExitCodeCheckWarns":true,"ExitCode":1}
  ```

- Focused regression suite:
  - `node scripts/run-vitest.mjs test/scripts/install-ps1.test.ts`
  - Result: `1` file passed, `30` tests passed.
- Formatting: `node_modules/.bin/oxfmt --check scripts/install.ps1 test/scripts/install-ps1.test.ts` passed.
- Static check: `git diff --check upstream/main...HEAD` passed.
- Pre-commit TruffleHog scan: `0` verified and `0` unverified secrets.
- Final structured review:
  - `python .agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main`
  - Result: `autoreview clean: no accepted/actionable findings reported` (`patch is correct`, confidence `0.98`).
- Not tested: a complete remote source installation was not run. The focused proof covers the native PowerShell decision that caused the incorrect status and asserts the final installer code path.
