### PR TITLE
fix(gemini): accept tools with multi-type parameters

### DIFF
--- a/packages/ai/src/providers/clean-for-gemini.test.ts
+++ b/packages/ai/src/providers/clean-for-gemini.test.ts
@@ -226,6 +226,16 @@ describe("cleanSchemaForGemini", () => {
     expect(cleaned.properties?.agentId?.type).toBe("string");
   });
 
+  it("collapses multi-type arrays to a representative scalar type", () => {
+    const cleaned = cleanSchemaForGemini({
+      type: ["string", "number"],
+      description: "string or number",
+    }) as Record<string, unknown>;
+
+    expect(cleaned.type).toBe("string");
+    expect(cleaned.description).toBe("string or number");
+  });
+
   it.each([
     {
       name: "integer enum",

--- a/packages/ai/src/providers/clean-for-gemini.ts
+++ b/packages/ai/src/providers/clean-for-gemini.ts
@@ -385,8 +385,10 @@ function cleanSchemaForGeminiWithDefs(
       Array.isArray(value) &&
       value.every((entry) => typeof entry === "string")
     ) {
-      const types = value.filter((entry) => entry !== "null");
-      cleaned.type = types.length === 1 ? types[0] : types;
+      const representativeType = value.find((entry) => entry !== "null");
+      if (representativeType) {
+        cleaned.type = representativeType;
+      }
       continue;
     }
 


### PR DESCRIPTION
Closes #112050

## What Problem This Solves

Fixes an issue where Gemini users could have a request rejected before model execution when a tool parameter used a multi-type JSON Schema array such as `type: ["string", "number"]`.

## Why This Change Was Made

Gemini-specific schema cleanup now reduces a multi-type array to its first non-null scalar type, matching the existing fallback projection used for Gemini-compatible schemas. It preserves adjacent schema metadata and leaves the generic JSON Schema representation unchanged outside the Gemini provider boundary.

Google's FunctionDeclaration schema represents `type` as one scalar enum value rather than a JSON Schema type array. The change stays at the Gemini cleanup boundary and does not alter the source tool schema used by other providers.

## User Impact

Gemini tool calls can proceed with a scalar provider-facing `type` value instead of sending an array shape that the function-declaration API rejects.

## Evidence

Exact head: `f0c944f4a342d0d734b737d6ff7736d60600a7c5`

- Rebased onto `main` at `fcdd8533696bac64ae474273e6714010cf8136db`. The stable patch ID remains `adfa9e35b3ac2143e777e4f3b5b04b7abcad69a4`, unchanged from the previously reviewed and tested heads. The patch remains exactly two files (`+14/-2`).
- Direct provider-boundary source probe:

  ```text
  Input:  {"type":["string","number"],"description":"string or number"}
  Output: {"type":"string","description":"string or number"}
  ```

- Exact-head focused regression suite:

  ```text
  node scripts/run-vitest.mjs packages/ai/src/providers/clean-for-gemini.test.ts
  Test Files  1 passed (1)
  Tests       26 passed (26)
  ```

- Exact-head `oxfmt --check` and `git diff --check upstream/main...HEAD` passed. Targeted type-aware oxlint passed on the preceding mechanically identical head; it was not repeated after the no-overlap rebase.
- The previous scoped AutoReview was clean with no accepted/actionable findings (`patch is correct`, confidence 0.98). It was not repeated because every rebase retained the identical stable patch ID.

### Real provider behavior

An independent affected user ran this PR's exact two-file diff on OpenClaw 2026.8.1 through a real Gateway using a Gemini-backed model and the full 51-tool payload, including the bundled `message` tool containing the reachable multi-type schema.

Before the patch, every tool-bearing turn was rejected by the provider with HTTP 400 because the FunctionDeclaration `type` field received a list. With only this PR's diff applied, the same setup produced zero schema rejections and three HTTP 200 Gemini responses; agent turns then completed normally.

Evidence comment: https://github.com/openclaw/openclaw/pull/112054#issuecomment-5524992358

The reporter subsequently closed the competing/misdiagnosed candidates and confirmed this remains the only candidate fix: https://github.com/openclaw/openclaw/pull/112054#issuecomment-5525041934

One prior hosted run had a single unrelated timing failure in `test/scripts/pnpm-audit-prod.test.ts` (`fetchImpl` observed twice instead of once); the same 46-test file passed locally without source changes. Rebasing onto current main triggered a fresh hosted run. Exact-head GitHub CI remains the final authority.

Proof limitation: the independent live run used the exact code diff before the mechanical rebases, not commit `f0c944f4a3`; the stable patch ID is identical, and exact-head local regression checks cover the rebased tree.
