### PR TITLE
docs: fix incorrect CLI command in 14 extension READMEs

### DIFF
--- a/extensions/amazon-bedrock-mantle/README.md
+++ b/extensions/amazon-bedrock-mantle/README.md
@@ -5,7 +5,7 @@ Official OpenClaw provider plugin for routing Amazon Bedrock Mantle models throu
 Install from OpenClaw:
 
 ```bash
-openclaw plugin add @openclaw/amazon-bedrock-mantle-provider
+openclaw plugins install @openclaw/amazon-bedrock-mantle-provider
 ```
 
 Use this plugin when your Bedrock deployment exposes Mantle-compatible model routing and you want OpenClaw agents to address those models through the Bedrock Mantle provider.

--- a/extensions/amazon-bedrock/README.md
+++ b/extensions/amazon-bedrock/README.md
@@ -5,7 +5,7 @@ Official OpenClaw provider plugin for Amazon Bedrock. It adds Bedrock model disc
 Install from OpenClaw:
 
 ```bash
-openclaw plugin add @openclaw/amazon-bedrock-provider
+openclaw plugins install @openclaw/amazon-bedrock-provider
 ```
 
 Configure AWS credentials and region through your normal OpenClaw credential/profile setup, then select Bedrock models with the `amazon-bedrock/...` provider prefix.

--- a/extensions/anthropic-vertex/README.md
+++ b/extensions/anthropic-vertex/README.md
@@ -5,7 +5,7 @@ Official OpenClaw provider plugin for Claude models hosted through Google Vertex
 Install from OpenClaw:
 
 ```bash
-openclaw plugin add @openclaw/anthropic-vertex-provider
+openclaw plugins install @openclaw/anthropic-vertex-provider
 ```
 
 Configure Google Cloud credentials and the target Vertex project/region in OpenClaw, then select Claude models with the Anthropic Vertex provider.

--- a/extensions/discord/README.md
+++ b/extensions/discord/README.md
@@ -5,7 +5,7 @@ Official OpenClaw channel plugin for Discord servers, channels, DMs, slash comma
 Install from OpenClaw:
 
 ```bash
-openclaw plugin add @openclaw/discord
+openclaw plugins install @openclaw/discord
 ```
 
 Configure a Discord bot token and the channels or servers OpenClaw should handle. The plugin lets OpenClaw agents receive Discord messages and respond through the configured Discord app.

--- a/extensions/feishu/README.md
+++ b/extensions/feishu/README.md
@@ -5,7 +5,7 @@ Official OpenClaw channel plugin for Feishu and Lark workplace chats. Community 
 Install from OpenClaw:
 
 ```bash
-openclaw plugin add @openclaw/feishu
+openclaw plugins install @openclaw/feishu
 ```
 
 Configure the Feishu/Lark app credentials in OpenClaw, then connect the plugin to the chats where agents should receive and send messages.

--- a/extensions/googlechat/README.md
+++ b/extensions/googlechat/README.md
@@ -5,7 +5,7 @@ Official OpenClaw channel plugin for Google Chat spaces and direct messages.
 Install from OpenClaw:
 
 ```bash
-openclaw plugin add @openclaw/googlechat
+openclaw plugins install @openclaw/googlechat
 ```
 
 Configure the Google Chat app credentials and allowed spaces in OpenClaw. The plugin lets agents receive Google Chat events and reply through the configured app.

--- a/extensions/line/README.md
+++ b/extensions/line/README.md
@@ -5,7 +5,7 @@ Official OpenClaw channel plugin for LINE Bot API chats.
 Install from OpenClaw:
 
 ```bash
-openclaw plugin add @openclaw/line
+openclaw plugins install @openclaw/line
 ```
 
 Configure LINE channel credentials in OpenClaw, then connect the bot to the chats where agents should receive and send messages.

--- a/extensions/matrix/README.md
+++ b/extensions/matrix/README.md
@@ -5,7 +5,7 @@ Official OpenClaw channel plugin for Matrix rooms and direct messages.
 Install from OpenClaw:
 
 ```bash
-openclaw plugin add @openclaw/matrix
+openclaw plugins install @openclaw/matrix
 ```
 
 Configure the Matrix homeserver and bot credentials in OpenClaw. The plugin lets agents join configured rooms, receive messages, and reply through Matrix.

--- a/extensions/msteams/README.md
+++ b/extensions/msteams/README.md
@@ -5,7 +5,7 @@ Official OpenClaw channel plugin for Microsoft Teams bot conversations.
 Install from OpenClaw:
 
 ```bash
-openclaw plugin add @openclaw/msteams
+openclaw plugins install @openclaw/msteams
 ```
 
 Configure the Teams bot credentials and trusted service URLs in OpenClaw, then connect the bot to the teams or chats where agents should operate.

--- a/extensions/nextcloud-talk/README.md
+++ b/extensions/nextcloud-talk/README.md
@@ -5,7 +5,7 @@ Official OpenClaw channel plugin for Nextcloud Talk conversations.
 Install from OpenClaw:
 
 ```bash
-openclaw plugin add @openclaw/nextcloud-talk
+openclaw plugins install @openclaw/nextcloud-talk
 ```
 
 Configure the Nextcloud server and Talk credentials in OpenClaw, then enable the conversations where agents should receive and send messages.

--- a/extensions/qqbot/README.md
+++ b/extensions/qqbot/README.md
@@ -5,7 +5,7 @@ Official OpenClaw channel plugin for QQ Bot group and direct-message workflows.
 Install from OpenClaw:
 
 ```bash
-openclaw plugin add @openclaw/qqbot
+openclaw plugins install @openclaw/qqbot
 ```
 
 Configure QQ Bot credentials in OpenClaw, then connect the bot to the groups or direct-message contexts where agents should operate.

--- a/extensions/slack/README.md
+++ b/extensions/slack/README.md
@@ -5,7 +5,7 @@ Official OpenClaw channel plugin for Slack channels, DMs, commands, and app even
 Install from OpenClaw:
 
 ```bash
-openclaw plugin add @openclaw/slack
+openclaw plugins install @openclaw/slack
 ```
 
 Configure the Slack app credentials and allowed workspaces/channels in OpenClaw. The plugin lets agents receive Slack events and reply through the configured Slack app.

--- a/extensions/synology-chat/README.md
+++ b/extensions/synology-chat/README.md
@@ -5,7 +5,7 @@ Official OpenClaw channel plugin for Synology Chat conversations and direct mess
 Install from OpenClaw:
 
 ```bash
-openclaw plugin add @openclaw/synology-chat
+openclaw plugins install @openclaw/synology-chat
 ```
 
 Configure Synology Chat credentials and allowed conversations in OpenClaw, then use the plugin to route messages between Synology Chat and OpenClaw agents.

--- a/extensions/whatsapp/README.md
+++ b/extensions/whatsapp/README.md
@@ -5,7 +5,7 @@ Official OpenClaw channel plugin for WhatsApp Web chats.
 Install from OpenClaw:
 
 ```bash
-openclaw plugin add @openclaw/whatsapp
+openclaw plugins install @openclaw/whatsapp
 ```
 
 Link a WhatsApp account through the plugin's setup flow, then configure which chats OpenClaw agents should monitor and reply to.


### PR DESCRIPTION
## What Problem This Solves

14 extension README files reference the command `openclaw plugin add`, which does not exist in the CLI. Users following these docs to install extensions would get a command-not-found error.

The correct command is `openclaw plugins install`, as registered in `src/cli/plugins-cli.ts` and documented in other extension READMEs (e.g., Signal, Brave).

## Why This Change Was Made

The incorrect command prevents users from successfully installing these extensions by following the README instructions.

## User Impact

Users can now copy-paste the install command from any extension README and have it work correctly.

## Changes

Replaced `openclaw plugin add` with `openclaw plugins install` in:

- extensions/discord/README.md
- extensions/whatsapp/README.md
- extensions/slack/README.md
- extensions/matrix/README.md
- extensions/msteams/README.md
- extensions/line/README.md
- extensions/feishu/README.md
- extensions/googlechat/README.md
- extensions/synology-chat/README.md
- extensions/qqbot/README.md
- extensions/nextcloud-talk/README.md
- extensions/anthropic-vertex/README.md
- extensions/amazon-bedrock-mantle/README.md
- extensions/amazon-bedrock/README.md

## Evidence

```bash
# The CLI only registers "plugins install", not "plugin add":
grep -n "plugin" src/cli/plugins-cli.ts | head -5
# Line 167: .command('install')

# Correct usage in Signal README (unchanged, already correct):
# openclaw plugins install @openclaw/signal