### PR TITLE
fix(tlon): cancel failed auth response bodies

### DIFF
--- a/extensions/tlon/src/urbit/auth.ssrf.test.ts
+++ b/extensions/tlon/src/urbit/auth.ssrf.test.ts
@@ -4,6 +4,8 @@ import type { LookupFn } from "openclaw/plugin-sdk/ssrf-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { authenticate } from "./auth.js";
 
+const privateLookupFn = (async () => [{ address: "127.0.0.1", family: 4 }]) as unknown as LookupFn;
+
 describe("tlon urbit auth ssrf", () => {
   beforeEach(() => {
     vi.unstubAllGlobals();
@@ -30,11 +32,10 @@ describe("tlon urbit auth ssrf", () => {
     });
     const mockFetch = vi.fn().mockResolvedValue(response);
     vi.stubGlobal("fetch", mockFetch);
-    const lookupFn = (async () => [{ address: "127.0.0.1", family: 4 }]) as unknown as LookupFn;
 
     const cookie = await authenticate("http://127.0.0.1:8080", "code", {
       ssrfPolicy: { allowPrivateNetwork: true },
-      lookupFn,
+      lookupFn: privateLookupFn,
       fetchImpl: mockFetch as typeof fetch,
     });
     expect(cookie).toContain("urbauth-~zod=123");
@@ -61,14 +62,38 @@ describe("tlon urbit auth ssrf", () => {
 
     const mockFetch = vi.fn().mockResolvedValue(response);
     vi.stubGlobal("fetch", mockFetch);
-    const lookupFn = (async () => [{ address: "127.0.0.1", family: 4 }]) as unknown as LookupFn;
 
     const cookie = await authenticate("http://127.0.0.1:8080", "code", {
       ssrfPolicy: { allowPrivateNetwork: true },
-      lookupFn,
+      lookupFn: privateLookupFn,
       fetchImpl: mockFetch as typeof fetch,
     });
     expect(cookie).toContain("urbauth-~zod=789");
+    expect(canceled).toBe(true);
+  });
+
+  it("cancels failed login bodies before throwing", async () => {
+    let canceled = false;
+    const response = new Response(
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode("login failed"));
+        },
+        cancel() {
+          canceled = true;
+        },
+      }),
+      { status: 401 },
+    );
+    const mockFetch = vi.fn().mockResolvedValue(response);
+
+    await expect(
+      authenticate("http://127.0.0.1:8080", "bad-code", {
+        ssrfPolicy: { allowPrivateNetwork: true },
+        lookupFn: privateLookupFn,
+        fetchImpl: mockFetch as typeof fetch,
+      }),
+    ).rejects.toMatchObject({ code: "auth_failed" });
     expect(canceled).toBe(true);
   });
 });

--- a/extensions/tlon/src/urbit/auth.ts
+++ b/extensions/tlon/src/urbit/auth.ts
@@ -36,6 +36,7 @@ export async function authenticate(
 
   try {
     if (!response.ok) {
+      await response.body?.cancel().catch(() => undefined);
       throw new UrbitAuthError("auth_failed", `Login failed with status ${response.status}`);
     }
 


### PR DESCRIPTION
Related: #109697

## What Problem This Solves

Fixes an issue where a failed Tlon/Urbit login could leave its HTTP response body unread when the server returned a non-success status.

## Why This Change Was Made

The authentication owner now cancels the failed response body before returning the existing typed authentication error. This uses the same cancel-before-throw pattern as the other response-lifecycle fixes and leaves successful login draining, cookies, SSRF policy, and configuration unchanged.

## User Impact

Failed Urbit logins release their response streams promptly instead of retaining the upstream connection while reporting the authentication failure.

## Evidence

- `node scripts/run-vitest.mjs extensions/tlon/src/urbit/auth.ssrf.test.ts` — 4 tests passed.
- Added a streamed 401 regression that observes `Response.body.cancel()` and preserves the `auth_failed` result.
- `git diff --check` passed.
- AutoReview was clean in both uncommitted and final branch modes.

AI-assisted: yes. I reviewed and understand the change.
