### PR TITLE
feat(ui): calm the working claw, rare stances, wait phrases, turn recap

### DIFF
--- a/ui/src/components/working-phrase.test.ts
+++ b/ui/src/components/working-phrase.test.ts
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { WORKING_PHRASE_ROTATE_EVERY_MS, WORKING_PHRASE_SHOW_AFTER_MS } from "./working-phrase.ts";
+
+type WorkingPhraseElement = HTMLElement & {
+  startMs: number | null;
+  seed: string;
+  updateComplete: Promise<boolean>;
+  requestUpdate: () => void;
+};
+
+const NOW = 2_000_000_000;
+// "· Clawing…" — a middot, one gerund, an ellipsis.
+const PHRASE_TEXT = /^·\s\S+…$/;
+
+function mountPhrase(seed = "stream-working:test"): WorkingPhraseElement {
+  const element = document.createElement("openclaw-working-phrase") as WorkingPhraseElement;
+  element.seed = seed;
+  element.startMs = NOW;
+  document.body.appendChild(element);
+  return element;
+}
+
+async function textAt(element: WorkingPhraseElement, elapsedMs: number): Promise<string> {
+  vi.setSystemTime(NOW + elapsedMs);
+  element.requestUpdate();
+  await element.updateComplete;
+  return element.textContent?.replace(/\s+/g, " ").trim() ?? "";
+}
+
+describe("openclaw-working-phrase", () => {
+  let element: WorkingPhraseElement;
+
+  beforeEach(() => {
+    vi.useFakeTimers({ now: NOW });
+    element = mountPhrase();
+  });
+
+  afterEach(() => {
+    element.remove();
+    vi.useRealTimers();
+  });
+
+  it("stays silent before the quiet threshold", async () => {
+    expect(await textAt(element, WORKING_PHRASE_SHOW_AFTER_MS - 5_000)).toBe("");
+  });
+
+  it("shows a phrase once the wait drags on", async () => {
+    expect(await textAt(element, WORKING_PHRASE_SHOW_AFTER_MS + 1_000)).toMatch(PHRASE_TEXT);
+  });
+
+  it("is stable within a rotation and changes across rotations", async () => {
+    const first = await textAt(element, WORKING_PHRASE_SHOW_AFTER_MS + 1_000);
+    const stillFirst = await textAt(element, WORKING_PHRASE_SHOW_AFTER_MS + 10_000);
+    expect(stillFirst).toBe(first);
+
+    // Adjacent rotations must differ even when raw hashes collide, across
+    // many buckets (the displayed word feeds the next bucket's dodge).
+    let previous = first;
+    for (let bucket = 1; bucket <= 8; bucket++) {
+      const next = await textAt(
+        element,
+        WORKING_PHRASE_SHOW_AFTER_MS + bucket * WORKING_PHRASE_ROTATE_EVERY_MS + 1_000,
+      );
+      expect(next).toMatch(PHRASE_TEXT);
+      expect(next).not.toBe(previous);
+      previous = next;
+    }
+  });
+
+  it("is deterministic per seed", async () => {
+    const twin = mountPhrase();
+    try {
+      const a = await textAt(element, WORKING_PHRASE_SHOW_AFTER_MS + 1_000);
+      const b = await textAt(twin, WORKING_PHRASE_SHOW_AFTER_MS + 1_000);
+      expect(b).toBe(a);
+    } finally {
+      twin.remove();
+    }
+  });
+});

--- a/ui/src/components/working-phrase.test.ts
+++ b/ui/src/components/working-phrase.test.ts
@@ -1,6 +1,11 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { WORKING_PHRASE_ROTATE_EVERY_MS, WORKING_PHRASE_SHOW_AFTER_MS } from "./working-phrase.ts";
+import "./working-phrase.ts";
+
+// Mirrors WORKING_PHRASE_SHOW_AFTER_MS / WORKING_PHRASE_ROTATE_EVERY_MS in
+// working-phrase.ts (knip forbids test-only exports).
+const WORKING_PHRASE_SHOW_AFTER_MS = 30_000;
+const WORKING_PHRASE_ROTATE_EVERY_MS = 45_000;
 
 type WorkingPhraseElement = HTMLElement & {
   startMs: number | null;

--- a/ui/src/components/working-phrase.ts
+++ b/ui/src/components/working-phrase.ts
@@ -30,10 +30,11 @@ const PHRASE_KEYS = [
   "surfacing",
 ] as const;
 
-/** Quiet grace period before the first phrase appears. */
-export const WORKING_PHRASE_SHOW_AFTER_MS = 30_000;
+/** Quiet grace period before the first phrase appears. Mirrored as literals
+ * in working-phrase.test.ts (knip forbids test-only exports). */
+const WORKING_PHRASE_SHOW_AFTER_MS = 30_000;
 /** How long each phrase holds before rotating to the next. */
-export const WORKING_PHRASE_ROTATE_EVERY_MS = 45_000;
+const WORKING_PHRASE_ROTATE_EVERY_MS = 45_000;
 
 // FNV-1a, matching the stance picker: deterministic per seed.
 function fnvHash(key: string): number {

--- a/ui/src/components/working-phrase.ts
+++ b/ui/src/components/working-phrase.ts
@@ -1,0 +1,100 @@
+// Whimsical long-wait status word ("Clawing…") for the chat working row.
+// Silent for the first stretch of a run, then rotates through crab-themed
+// gerunds so long quiet runs feel alive without claiming progress data the
+// UI does not have. Decorative only — the row keeps its sr-only "Working…".
+import { html, nothing } from "lit";
+import { property } from "lit/decorators.js";
+import { t } from "../i18n/index.ts";
+import { OpenClawLightDomContentsElement } from "../lit/openclaw-element.ts";
+import { PollController } from "../lit/poll-controller.ts";
+
+const PHRASE_KEYS = [
+  "shelling",
+  "scuttling",
+  "clawing",
+  "pinching",
+  "molting",
+  "bubbling",
+  "tiding",
+  "reefing",
+  "cracking",
+  "sifting",
+  "brining",
+  "nautiling",
+  "krilling",
+  "barnacling",
+  "lobstering",
+  "tidepooling",
+  "pearling",
+  "snapping",
+  "surfacing",
+] as const;
+
+/** Quiet grace period before the first phrase appears. */
+export const WORKING_PHRASE_SHOW_AFTER_MS = 30_000;
+/** How long each phrase holds before rotating to the next. */
+export const WORKING_PHRASE_ROTATE_EVERY_MS = 45_000;
+
+// FNV-1a, matching the stance picker: deterministic per seed.
+function fnvHash(key: string): number {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < key.length; i++) {
+    hash ^= key.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return hash >>> 0;
+}
+
+/** Constant-time stride walk over the phrase list: any stride in
+ * [1, len-1] guarantees adjacent buckets differ, and with a prime-length
+ * list (currently 19) every stride cycles through all phrases before
+ * repeating. Must stay O(1) in bucket — ChatItem.startedAt can be an
+ * arbitrarily old timestamp, and this runs on a one-second poll. */
+function displayedPhraseIndex(seed: string, bucket: number): number {
+  const length = PHRASE_KEYS.length;
+  const offset = fnvHash(`${seed}:offset`) % length;
+  const stride = 1 + (fnvHash(`${seed}:stride`) % (length - 1));
+  return (offset + bucket * stride) % length;
+}
+
+class WorkingPhrase extends OpenClawLightDomContentsElement {
+  @property({ type: Number }) startMs: number | null = null;
+  @property() seed = "";
+
+  private readonly polling = new PollController(this, 1_000, () => this.requestUpdate(), false);
+
+  override connectedCallback() {
+    super.connectedCallback();
+    this.syncTimer();
+  }
+
+  override updated() {
+    this.syncTimer();
+  }
+
+  private syncTimer() {
+    if (this.isConnected && this.startMs != null) {
+      this.polling.start();
+    } else {
+      this.polling.stop();
+    }
+  }
+
+  override render() {
+    if (this.startMs == null) {
+      return nothing;
+    }
+    const elapsed = Date.now() - this.startMs;
+    if (elapsed < WORKING_PHRASE_SHOW_AFTER_MS) {
+      return nothing;
+    }
+    const sinceShown = elapsed - WORKING_PHRASE_SHOW_AFTER_MS;
+    const bucket = Math.floor(sinceShown / WORKING_PHRASE_ROTATE_EVERY_MS);
+    const index = displayedPhraseIndex(this.seed, bucket);
+    return html`<span>·</span> ${t(`chat.progressLabels.${PHRASE_KEYS[index]}`)}…`;
+  }
+}
+
+if (!customElements.get("openclaw-working-phrase")) {
+  customElements.define("openclaw-working-phrase", WorkingPhrase);
+}

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -3811,6 +3811,11 @@ export const en: TranslationMap = {
       snapping: "Snapping",
       surfacing: "Surfacing",
     },
+    turnRecap: {
+      doneIn: "Done in {duration}",
+      tokens: "{count} tokens",
+      tokensOne: "1 token",
+    },
     commands: {
       arguments: "Command arguments",
       menu: "Slash commands",

--- a/ui/src/pages/chat/chat-progress.test.ts
+++ b/ui/src/pages/chat/chat-progress.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resetWorkingProgress, resolveTurnRecap } from "./chat-progress.ts";
+
+const SESSION = "agent:main:main";
+const PREVIOUS_ENDED_AT = 900_000;
+const RUN_ENDED_AT = 1_000_000;
+
+const doneRow = (endedAt: number, runtimeMs = 51_000, outputTokens?: number) => ({
+  status: "done",
+  endedAt,
+  runtimeMs,
+  ...(outputTokens === undefined ? {} : { outputTokens }),
+});
+
+describe("resolveTurnRecap", () => {
+  beforeEach(() => resetWorkingProgress());
+  afterEach(() => resetWorkingProgress());
+
+  it("resolves once a fresh terminal stamp lands, then sticks", () => {
+    // Indicator up: previous run's terminal stamp becomes the baseline.
+    expect(resolveTurnRecap(SESSION, true, doneRow(PREVIOUS_ENDED_AT))).toBeNull();
+    // Indicator settles but only the stale row is visible so far.
+    expect(resolveTurnRecap(SESSION, false, doneRow(PREVIOUS_ENDED_AT))).toBeNull();
+    // Fresh terminal patch: recap resolves and keeps resolving.
+    const row = doneRow(RUN_ENDED_AT, 51_000, 485);
+    expect(resolveTurnRecap(SESSION, false, row)).toEqual({
+      runtimeMs: 51_000,
+      outputTokens: 485,
+    });
+    expect(resolveTurnRecap(SESSION, false, row)).toEqual({
+      runtimeMs: 51_000,
+      outputTokens: 485,
+    });
+  });
+
+  it("rejects the previous turn's row even seconds after this run started", () => {
+    resolveTurnRecap(SESSION, true, doneRow(PREVIOUS_ENDED_AT));
+    // Rapid back-to-back turns: the old done row stays stale forever, and so
+    // does any regressed (out-of-order) stamp.
+    expect(resolveTurnRecap(SESSION, false, doneRow(PREVIOUS_ENDED_AT))).toBeNull();
+    expect(resolveTurnRecap(SESSION, false, doneRow(PREVIOUS_ENDED_AT - 5_000))).toBeNull();
+  });
+
+  it("expires an unresolved watch instead of matching a later run", () => {
+    vi.useFakeTimers({ now: 1_000_000 });
+    try {
+      // A queued send showed the claw but the run never started.
+      resolveTurnRecap(SESSION, true, doneRow(PREVIOUS_ENDED_AT));
+      expect(resolveTurnRecap(SESSION, false, doneRow(PREVIOUS_ENDED_AT))).toBeNull();
+      vi.advanceTimersByTime(31_000);
+      expect(resolveTurnRecap(SESSION, false, doneRow(PREVIOUS_ENDED_AT))).toBeNull();
+      // A cron/background completion minutes later cannot claim the turn.
+      expect(resolveTurnRecap(SESSION, false, doneRow(RUN_ENDED_AT))).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("consumes the watch on a fresh done row without runtime data", () => {
+    resolveTurnRecap(SESSION, true, doneRow(PREVIOUS_ENDED_AT));
+    expect(resolveTurnRecap(SESSION, false, { status: "done", endedAt: RUN_ENDED_AT })).toBeNull();
+    // The watch concluded; a later completion cannot attach.
+    expect(resolveTurnRecap(SESSION, false, doneRow(RUN_ENDED_AT + 1_000))).toBeNull();
+  });
+
+  it("treats a cleared baseline (run start patch seen) as stale-free", () => {
+    // Start patch cleared endedAt before the watch began.
+    expect(resolveTurnRecap(SESSION, true, { status: "running" })).toBeNull();
+    expect(resolveTurnRecap(SESSION, false, doneRow(RUN_ENDED_AT, 2_000))).toEqual({
+      runtimeMs: 2_000,
+      outputTokens: null,
+    });
+  });
+
+  it("never resolves without having watched a working indicator", () => {
+    expect(resolveTurnRecap(SESSION, false, doneRow(RUN_ENDED_AT))).toBeNull();
+  });
+
+  it("consumes a watch whose baseline row was never observed", () => {
+    // Session row unavailable for the entire watch (capped list, still loading).
+    expect(resolveTurnRecap(SESSION, true, undefined)).toBeNull();
+    // The row appears only after settle, carrying the PREVIOUS run's stamp:
+    // with no baseline it must not pass as this turn's terminal.
+    expect(resolveTurnRecap(SESSION, false, doneRow(PREVIOUS_ENDED_AT))).toBeNull();
+    expect(resolveTurnRecap(SESSION, false, doneRow(RUN_ENDED_AT))).toBeNull();
+  });
+
+  it("adopts the first row observed mid-watch as the baseline", () => {
+    expect(resolveTurnRecap(SESSION, true, undefined)).toBeNull();
+    // Row loads while the claw is still up, showing the previous stamp.
+    expect(resolveTurnRecap(SESSION, true, doneRow(PREVIOUS_ENDED_AT))).toBeNull();
+    // Normal settle: only a fresh stamp resolves.
+    expect(resolveTurnRecap(SESSION, false, doneRow(PREVIOUS_ENDED_AT))).toBeNull();
+    expect(resolveTurnRecap(SESSION, false, doneRow(RUN_ENDED_AT, 6_000))).toEqual({
+      runtimeMs: 6_000,
+      outputTokens: null,
+    });
+  });
+
+  it("forfeits the turn when a terminal stamp changes mid-watch", () => {
+    // Watch starts after the run-start patch cleared endedAt.
+    expect(resolveTurnRecap(SESSION, true, { status: "running" })).toBeNull();
+    // A terminal lands while the claw is still up: attribution is ambiguous
+    // (early own-terminal, delayed prior run, other device) — consume quietly.
+    expect(resolveTurnRecap(SESSION, true, doneRow(PREVIOUS_ENDED_AT))).toBeNull();
+    expect(resolveTurnRecap(SESSION, false, doneRow(PREVIOUS_ENDED_AT))).toBeNull();
+    // Later stamps (e.g. a cron run) must not attach to the forfeited turn.
+    expect(resolveTurnRecap(SESSION, false, doneRow(RUN_ENDED_AT, 4_000))).toBeNull();
+  });
+
+  it("forfeits a failed turn whose terminal raced the indicator", () => {
+    resolveTurnRecap(SESSION, true, { status: "running" });
+    // The watched run fails while its claw is still visible.
+    resolveTurnRecap(SESSION, true, { status: "failed", endedAt: RUN_ENDED_AT });
+    expect(
+      resolveTurnRecap(SESSION, false, { status: "failed", endedAt: RUN_ENDED_AT }),
+    ).toBeNull();
+    // A background run's later success cannot masquerade as this turn.
+    expect(resolveTurnRecap(SESSION, false, doneRow(RUN_ENDED_AT + 60_000))).toBeNull();
+  });
+
+  it("freezes the first resolved recap against later unwatched terminals", () => {
+    resolveTurnRecap(SESSION, true, doneRow(PREVIOUS_ENDED_AT));
+    const settled = resolveTurnRecap(SESSION, false, doneRow(RUN_ENDED_AT, 51_000, 485));
+    expect(settled).toEqual({ runtimeMs: 51_000, outputTokens: 485 });
+    // A background/cron run finishing later must not rewrite the recap.
+    expect(resolveTurnRecap(SESSION, false, doneRow(RUN_ENDED_AT + 90_000, 7_000, 42))).toEqual(
+      settled,
+    );
+  });
+
+  it("hides the recap as soon as the next run's indicator appears", () => {
+    resolveTurnRecap(SESSION, true, doneRow(PREVIOUS_ENDED_AT));
+    expect(resolveTurnRecap(SESSION, false, doneRow(RUN_ENDED_AT))).not.toBeNull();
+    // Next turn: indicator visible again — recap gone, new baseline captured.
+    expect(resolveTurnRecap(SESSION, true, doneRow(RUN_ENDED_AT))).toBeNull();
+    expect(resolveTurnRecap(SESSION, false, doneRow(RUN_ENDED_AT))).toBeNull();
+  });
+
+  it("stays quiet for failed runs but ignores stale failed rows", () => {
+    resolveTurnRecap(SESSION, true, {
+      status: "failed",
+      endedAt: PREVIOUS_ENDED_AT,
+    });
+    // Stale failed row from before this run must not consume the watch.
+    expect(
+      resolveTurnRecap(SESSION, false, { status: "failed", endedAt: PREVIOUS_ENDED_AT }),
+    ).toBeNull();
+    expect(resolveTurnRecap(SESSION, false, doneRow(RUN_ENDED_AT, 3_000))).toEqual({
+      runtimeMs: 3_000,
+      outputTokens: null,
+    });
+  });
+
+  it("consumes the watch on a fresh failed row", () => {
+    resolveTurnRecap(SESSION, true, doneRow(PREVIOUS_ENDED_AT));
+    expect(
+      resolveTurnRecap(SESSION, false, { status: "failed", endedAt: RUN_ENDED_AT }),
+    ).toBeNull();
+    // A later done stamp belongs to some other run; the watch is gone.
+    expect(resolveTurnRecap(SESSION, false, doneRow(RUN_ENDED_AT + 1_000))).toBeNull();
+  });
+});

--- a/ui/src/pages/chat/chat-progress.ts
+++ b/ui/src/pages/chat/chat-progress.ts
@@ -116,5 +116,129 @@ export function clearWorkingProgress(sessionKey: string): void {
 
 export function resetWorkingProgress(): void {
   workingProgressBySession.clear();
+  turnRecapWatchBySession.clear();
   anonymousWorkingProgressId = 0;
+}
+
+export type TurnRecap = { runtimeMs: number; outputTokens: number | null };
+
+/** `baselineEndedAt` is the session row's endedAt when the working indicator
+ * appeared — i.e. the PREVIOUS run's terminal stamp (or null once the run
+ * start patch cleared it). Only a row whose endedAt moved past the baseline
+ * belongs to the run this pane just watched; timestamps never correlate
+ * reliably because consecutive turns can be seconds apart. `settled` freezes
+ * the first resolved recap so later terminal rows from runs this pane never
+ * watched (background/cron/other devices) cannot rewrite the displayed row. */
+type TurnRecapWatch = {
+  watching: boolean;
+  /** False while no session row was observed during the watch: with no
+   * baseline, a later row's stamp cannot be told apart from the previous
+   * run's, so such a watch is consumed unresolved at settle. */
+  baselineKnown: boolean;
+  baselineEndedAt: number | null;
+  /** A terminal stamp changed while the claw was still up: some run's
+   * terminal (this one's early, or an interleaved older patch) already
+   * passed, so settle cannot attribute later stamps and must consume the
+   * watch. Without a run identity on session rows, every anomalous
+   * interleaving fails quiet instead of risking a wrong recap. */
+  absorbedTerminal: boolean;
+  /** First idle render after the indicator cleared; the watch expires a
+   * short window later so a canceled queued send (indicator shown, run
+   * never started) cannot hand its watch to a much-later background/cron
+   * completion. */
+  settleStartedAt: number | null;
+  settled: TurnRecap | null;
+};
+
+/** The watched run's terminal patch lands within moments of the indicator
+ * clearing; anything arriving after this window is another run's. Accepted
+ * residual: session rows carry no run identity, so an unrelated same-session
+ * completion INSIDE this window (e.g. after a canceled queued send) can be
+ * shown as the watched turn's recap. Closing that needs a terminal-row run
+ * id from the gateway; until then the row is cosmetic and self-corrects on
+ * the next turn. */
+const TURN_RECAP_SETTLE_WINDOW_MS = 30_000;
+
+const turnRecapWatchBySession = new Map<string, TurnRecapWatch>();
+
+type TurnRecapSessionRow = {
+  status?: string;
+  endedAt?: number;
+  runtimeMs?: number;
+  outputTokens?: number;
+};
+
+/** Post-turn recap for the bottom-of-thread status row. While the working
+ * indicator is visible the session is "watched" (and any older recap hides);
+ * once it settles, the first session row carrying a fresh terminal stamp
+ * resolves the recap, which then sticks until the next run. Failed runs stay
+ * quiet — the error surfaces own those. */
+export function resolveTurnRecap(
+  sessionKey: string,
+  indicatorVisible: boolean,
+  row: TurnRecapSessionRow | undefined,
+): TurnRecap | null {
+  const watch = turnRecapWatchBySession.get(sessionKey);
+  const rowEndedAt = typeof row?.endedAt === "number" ? row.endedAt : null;
+  if (indicatorVisible) {
+    if (!watch || !watch.watching) {
+      turnRecapWatchBySession.set(sessionKey, {
+        watching: true,
+        baselineKnown: row !== undefined,
+        baselineEndedAt: rowEndedAt,
+        absorbedTerminal: false,
+        settleStartedAt: null,
+        settled: null,
+      });
+    } else if (!watch.baselineKnown) {
+      if (row !== undefined) {
+        watch.baselineKnown = true;
+        watch.baselineEndedAt = rowEndedAt;
+      }
+    } else if (rowEndedAt !== null && rowEndedAt !== watch.baselineEndedAt) {
+      watch.baselineEndedAt = rowEndedAt;
+      watch.absorbedTerminal = true;
+    }
+    return null;
+  }
+  if (!watch) {
+    return null;
+  }
+  watch.watching = false;
+  if (watch.settled) {
+    return watch.settled;
+  }
+  if (watch.absorbedTerminal || !watch.baselineKnown) {
+    // See TurnRecapWatch: attribution is ambiguous, so this turn quietly
+    // gets no recap rather than freezing another run's numbers.
+    turnRecapWatchBySession.delete(sessionKey);
+    return null;
+  }
+  if (watch.settleStartedAt === null) {
+    watch.settleStartedAt = Date.now();
+  } else if (Date.now() - watch.settleStartedAt > TURN_RECAP_SETTLE_WINDOW_MS) {
+    turnRecapWatchBySession.delete(sessionKey);
+    return null;
+  }
+  const isStale =
+    rowEndedAt === null || (watch.baselineEndedAt !== null && rowEndedAt <= watch.baselineEndedAt);
+  if (isStale) {
+    // No terminal patch for the watched run yet; keep waiting (bounded by
+    // the settle window above). Stamps never regress, so <= is stale.
+    return null;
+  }
+  // A fresh terminal always concludes the watch: recap on a clean "done",
+  // quiet consume otherwise — waiting past it would let unrelated later
+  // completions attach to this turn.
+  turnRecapWatchBySession.delete(sessionKey);
+  const runtimeMs = row?.runtimeMs;
+  if (row?.status !== "done" || typeof runtimeMs !== "number" || !Number.isFinite(runtimeMs)) {
+    return null;
+  }
+  const settled: TurnRecap = {
+    runtimeMs,
+    outputTokens: typeof row.outputTokens === "number" ? row.outputTokens : null,
+  };
+  turnRecapWatchBySession.set(sessionKey, { ...watch, settled });
+  return settled;
 }

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -1614,7 +1614,7 @@ describe("grouped chat rendering", () => {
     expect(container.querySelector(".chat-reading-indicator")).not.toBeNull();
   });
 
-  it("seeds a stable punch stance per reading-indicator key", () => {
+  it("seeds a stable claw stance per reading-indicator key", () => {
     const stanceFor = (key: string) => {
       const container = document.createElement("div");
       render(renderStreamGroup([{ kind: "reading-indicator", key, startedAt: 1 }]), container);
@@ -1625,15 +1625,17 @@ describe("grouped chat rendering", () => {
     };
 
     const first = stanceFor("stream:agent:main:pending");
-    // Stable across re-renders: same key always fights the same style.
+    // Stable across re-renders: same key always claws the same style.
     expect(stanceFor("stream:agent:main:pending")).toEqual(first);
-    // At most one stance modifier; orthodox is the unmarked default.
+    // At most one stance modifier; plain in-place clawing is the unmarked default.
     expect(first.length).toBeLessThanOrEqual(1);
     for (const cls of first) {
       expect([
         "chat-reading-indicator--southpaw",
         "chat-reading-indicator--flurry",
-        "chat-reading-indicator--haymaker",
+        "chat-reading-indicator--spin",
+        "chat-reading-indicator--shadowbox",
+        "chat-reading-indicator--backflip",
       ]).toContain(cls);
     }
   });
@@ -1649,12 +1651,16 @@ describe("grouped chat rendering", () => {
       return {
         hidden: status?.querySelector(".agent-chat__sr-only")?.textContent,
         visibleLabels: status?.querySelectorAll("span:not(.agent-chat__sr-only)").length,
+        // The whimsical long-wait phrase rides in its own aria-hidden element,
+        // never as a plain status span screen readers would announce.
+        decorativePhrases: status?.querySelectorAll("openclaw-working-phrase[aria-hidden]").length,
       };
     };
 
-    expect(statusFor(1_000)).toEqual({ hidden: "Working…", visibleLabels: 0 });
-    expect(statusFor(1_500)).toEqual({ hidden: "Working…", visibleLabels: 0 });
-    expect(statusFor(8_000)).toEqual({ hidden: "Working…", visibleLabels: 0 });
+    const expected = { hidden: "Working…", visibleLabels: 0, decorativePhrases: 1 };
+    expect(statusFor(1_000)).toEqual(expected);
+    expect(statusFor(1_500)).toEqual(expected);
+    expect(statusFor(8_000)).toEqual(expected);
   });
 
   it("renders configured local user names", () => {

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -45,6 +45,7 @@ import {
   resolveUiGlobalAliasAgentId,
   type UiSessionDefaultsHost,
 } from "../../../lib/sessions/session-key.ts";
+import { resolveTurnRecap } from "../chat-progress.ts";
 import {
   buildCachedChatItems,
   coalesceStreamRuns,
@@ -80,6 +81,7 @@ import { renderRealtimeTalkConversation } from "./chat-realtime-controls.ts";
 import { handleChatSelectionPointerUp, removeChatSelectionPopup } from "./chat-selection-popup.ts";
 import type { SidebarContent } from "./chat-sidebar.ts";
 import { renderWelcomeState, resolveAssistantDisplayAvatar } from "./chat-welcome.ts";
+import { renderTurnRecapRow } from "./chat-working-indicator.ts";
 
 const pinnedMessagesMap = new Map<string, PinnedMessages>();
 const deletedMessagesMap = new Map<string, DeletedMessages>();
@@ -1304,6 +1306,18 @@ function renderChatThreadContents(
       content: realtimeConversation,
     });
   }
+  // Watch/settle on actual indicator visibility (not runWorking): queued
+  // sends show the claw before the run starts, and the recap must never
+  // stack under a visible working row.
+  const workingIndicatorVisible = chatItems.some((item) => item.kind === "reading-indicator");
+  const turnRecap = resolveTurnRecap(props.sessionKey, workingIndicatorVisible, activeSession);
+  if (turnRecap !== null && !isEmpty && !showLoadingSkeleton) {
+    transcriptRows.push({
+      kind: "content",
+      key: "turn-recap",
+      content: renderTurnRecapRow(turnRecap),
+    });
+  }
   const backgroundTasks =
     !props.runWorking && !isEmpty && !showLoadingSkeleton
       ? renderBackgroundTasksStatusRow(props.backgroundTasks)
@@ -1352,6 +1366,7 @@ function renderChatThreadContents(
     props.allowExternalEmbedUrls ?? false,
     threadContextWindow,
     props.onSetReply,
+    turnRecap === null ? "" : `${turnRecap.runtimeMs}:${turnRecap.outputTokens ?? ""}`,
   ]);
   const transcriptContents =
     showLoadingSkeleton || isEmpty

--- a/ui/src/pages/chat/components/chat-working-indicator.ts
+++ b/ui/src/pages/chat/components/chat-working-indicator.ts
@@ -1,26 +1,32 @@
-import { html } from "lit";
+import { html, nothing } from "lit";
 import "../../../components/elapsed-time.ts";
 import { icons } from "../../../components/icons.ts";
+import "../../../components/working-phrase.ts";
 import { t } from "../../../i18n/index.ts";
 import type { ChatItem } from "../../../lib/chat/chat-types.ts";
+import { formatCompactTokenCount, formatDurationCompact } from "../../../lib/format.ts";
+import type { TurnRecap } from "../chat-progress.ts";
 
 // One salt per page load keeps each run stable while varying the animation between visits.
-const PUNCH_SALT = Math.trunc(Math.random() * 0xffffffff);
-const PUNCH_STANCES: Array<[stance: string, weight: number]> = [
-  ["", 47],
-  ["chat-reading-indicator--southpaw", 35],
-  ["chat-reading-indicator--flurry", 12],
-  ["chat-reading-indicator--haymaker", 6],
+// The default stance just claws in place; the busier stances stay rare on purpose.
+const STANCE_SALT = Math.trunc(Math.random() * 0xffffffff);
+const STANCES: Array<[stance: string, weight: number]> = [
+  ["", 66],
+  ["chat-reading-indicator--southpaw", 20],
+  ["chat-reading-indicator--flurry", 5],
+  ["chat-reading-indicator--spin", 4],
+  ["chat-reading-indicator--shadowbox", 3],
+  ["chat-reading-indicator--backflip", 2],
 ];
-function punchStanceClass(key: string): string {
+function stanceClass(key: string): string {
   let hash = 0x811c9dc5;
   for (let i = 0; i < key.length; i++) {
     hash ^= key.charCodeAt(i);
     hash = Math.imul(hash, 0x01000193);
   }
-  const total = PUNCH_STANCES.reduce((sum, [, weight]) => sum + weight, 0);
-  let roll = ((((hash ^ PUNCH_SALT) >>> 0) % 1000) / 1000) * total;
-  for (const [stance, weight] of PUNCH_STANCES) {
+  const total = STANCES.reduce((sum, [, weight]) => sum + weight, 0);
+  let roll = ((((hash ^ STANCE_SALT) >>> 0) % 1000) / 1000) * total;
+  for (const [stance, weight] of STANCES) {
     roll -= weight;
     if (roll <= 0) {
       return stance;
@@ -37,10 +43,7 @@ export function renderChatWorkingIndicator(
   // announcing every elapsed-time tick to screen readers.
   return html`
     <div class="chat-working-indicator" role="status" aria-live="off">
-      <div
-        class="chat-bubble chat-reading-indicator ${punchStanceClass(part.key)}"
-        aria-hidden="true"
-      >
+      <div class="chat-bubble chat-reading-indicator ${stanceClass(part.key)}" aria-hidden="true">
         ${icons.claw}
       </div>
       <span class="chat-working-indicator__status">
@@ -52,8 +55,41 @@ export function renderChatWorkingIndicator(
                 class="chat-working-indicator__elapsed"
                 .startMs=${part.startedAt}
               ></openclaw-elapsed-time>
+              <openclaw-working-phrase
+                aria-hidden="true"
+                .startMs=${part.startedAt}
+                .seed=${part.key}
+              ></openclaw-working-phrase>
             `}
       </span>
+    </div>
+  `;
+}
+
+/** Post-turn recap row: once the run settles, the parked claw reports how
+ * long the turn took (and its output tokens when the terminal patch carried
+ * them). Sticky until the next run replaces it. */
+export function renderTurnRecapRow(recap: TurnRecap) {
+  // Sub-second turns still read "1s"; the clamp also keeps the type a string.
+  const clampedMs = Math.max(1_000, recap.runtimeMs);
+  const duration = formatDurationCompact(clampedMs, { spaced: true }) ?? "1s";
+  // 0 is a valid count (command-only turns); only null means "unknown".
+  const tokens =
+    typeof recap.outputTokens === "number"
+      ? recap.outputTokens === 1
+        ? t("chat.turnRecap.tokensOne")
+        : t("chat.turnRecap.tokens", { count: formatCompactTokenCount(recap.outputTokens) })
+      : null;
+  return html`
+    <div class="chat-tasks-status chat-turn-recap" role="status">
+      <span class="chat-tasks-status__claw" aria-hidden="true">${icons.claw}</span>
+      <span>${t("chat.turnRecap.doneIn", { duration })}</span>
+      ${tokens === null
+        ? nothing
+        : html`
+            <span class="chat-tasks-status__sep" aria-hidden="true">·</span>
+            <span>${tokens}</span>
+          `}
     </div>
   `;
 }

--- a/ui/src/styles/chat/tool-cards.css
+++ b/ui/src/styles/chat/tool-cards.css
@@ -1104,15 +1104,16 @@
   color: inherit;
 }
 
-/* Reading indicator = working claw: the brand pincer shadowboxes where the
+/* Reading indicator = working claw: the brand pincer claws in place where the
    reply will materialize while the agent works with nothing visibly
    streaming. Bubble chrome and sizing come from
    .chat-bubble.chat-reading-indicator (components.css). Filled silhouette;
    18px because the claw is denser than a star glyph. The row settles into
-   stance once, then the solid claw carries the ongoing working signal. One
-   cycle = jab, jab, cross; the jaw snaps shut on every impact and a pow star
-   pops on the cross. --claw-cycle drives all three animations so stance
-   variants only retune the tempo. */
+   stance once, then the solid claw carries the ongoing working signal. The
+   default cycle is two jaw snips with a sympathetic body flex — no lateral
+   travel, that read as too busy. The old jab-jab-cross shadowbox combo
+   survives only as the rare --shadowbox stance. --claw-cycle drives every
+   animation so stance variants only retune the tempo. */
 .chat-reading-indicator {
   --claw-cycle: 2.4s;
 
@@ -1148,24 +1149,26 @@
   height: 18px;
   fill: currentColor;
   stroke: none;
-  animation: chatWorkingClawCombo var(--claw-cycle) ease-out infinite;
+  animation: chatWorkingClawFlex var(--claw-cycle) ease-out infinite;
   will-change: transform;
 }
 
 /* The upper jaw hinges at the palm joint. Rest is slightly open — the open
-   notch is what reads "claw" at 18px — and the jaw snaps shut exactly on the
-   combo's impact frames (keyframe percentages must stay in lockstep with
-   chatWorkingClawCombo). */
+   notch is what reads "claw" at 18px — and the jaw snaps shut on the snip
+   frames (keyframe percentages must stay in lockstep with
+   chatWorkingClawFlex, and with chatWorkingClawCombo in the shadowbox
+   stance). */
 .chat-reading-indicator svg .claw-icon__jaw {
   transform-box: view-box;
   transform-origin: 8.6px 11px;
   transform: rotate(-10deg);
-  animation: chatWorkingClawJaw var(--claw-cycle) ease-out infinite;
+  animation: chatWorkingClawSnip var(--claw-cycle) ease-out infinite;
   will-change: transform;
 }
 
-/* Pow star: pops at the cross impact (46-58% of the combo cycle). */
-.chat-reading-indicator::after {
+/* Pow star: shadowbox-only, pops at the cross impact (46-58% of the combo
+   cycle). */
+.chat-reading-indicator--shadowbox::after {
   content: "✦";
   position: absolute;
   right: -14px;
@@ -1195,7 +1198,70 @@
   }
 }
 
-/* Jab 1 at 12-16%, jab 2 at 26-30%, big wind-up, cross at 46-52%. */
+/* Default stance: the body flexes in place in sympathy with the jaw — pure
+   rotation, no translate, so the claw works without pacing around. Snip 1 at
+   10-16%, snip 2 at 26-32%, then rest. */
+@keyframes chatWorkingClawFlex {
+  0%,
+  6% {
+    transform: rotate(0deg);
+  }
+
+  10% {
+    transform: rotate(-4deg);
+  }
+
+  16% {
+    transform: rotate(3deg);
+  }
+
+  22%,
+  26% {
+    transform: rotate(-4deg);
+  }
+
+  32% {
+    transform: rotate(3deg);
+  }
+
+  42%,
+  100% {
+    transform: rotate(0deg);
+  }
+}
+
+/* Jaw opens wide on each wind-up and snaps shut on the snip frames above. */
+@keyframes chatWorkingClawSnip {
+  0%,
+  6% {
+    transform: rotate(-10deg);
+  }
+
+  10% {
+    transform: rotate(-26deg);
+  }
+
+  16% {
+    transform: rotate(4deg);
+  }
+
+  22%,
+  26% {
+    transform: rotate(-24deg);
+  }
+
+  32% {
+    transform: rotate(4deg);
+  }
+
+  42%,
+  100% {
+    transform: rotate(-10deg);
+  }
+}
+
+/* Shadowbox body: jab 1 at 12-16%, jab 2 at 26-30%, big wind-up, cross at
+   46-52%. */
 @keyframes chatWorkingClawCombo {
   0%,
   8% {
@@ -1237,6 +1303,7 @@
   }
 }
 
+/* Shadowbox jaw: snaps shut in lockstep with chatWorkingClawCombo impacts. */
 @keyframes chatWorkingClawJaw {
   0%,
   8% {
@@ -1297,9 +1364,11 @@
   }
 }
 
-/* Seeded stance variants (see punchStanceClass in chat-message.ts): the
-   southpaw fights mirrored, the flurry fighter runs the combo double-time,
-   the rare haymaker is a slow heavyweight with a bigger pow. */
+/* Seeded stance variants (see stanceClass in chat-working-indicator.ts): the
+   southpaw claws mirrored, the flurry snips double-time, the spin does a
+   fake-3D turntable revolve while snipping, the shadowbox brings back the
+   full jab-jab-cross combo with the pow star, and the rarest backflip throws
+   a single in-place somersault per cycle. */
 .chat-reading-indicator--southpaw {
   transform: scaleX(-1);
 }
@@ -1308,13 +1377,60 @@
   --claw-cycle: 1.3s;
 }
 
-.chat-reading-indicator--haymaker {
-  --claw-cycle: 3.8s;
+.chat-reading-indicator--spin {
+  --claw-cycle: 3.6s;
 }
 
-.chat-reading-indicator--haymaker::after {
-  font-size: 15px;
-  right: -17px;
+/* Fake 3D: perspective() + rotateY reads as a spinning coin at 18px. Linear
+   timing keeps the revolve steady; the jaw keeps its snip cycle on top. */
+.chat-reading-indicator--spin svg {
+  animation-name: chatWorkingClawSpin;
+  animation-timing-function: linear;
+}
+
+.chat-reading-indicator--shadowbox svg {
+  animation-name: chatWorkingClawCombo;
+}
+
+.chat-reading-indicator--shadowbox svg .claw-icon__jaw {
+  animation-name: chatWorkingClawJaw;
+}
+
+.chat-reading-indicator--backflip svg {
+  animation-name: chatWorkingClawBackflip;
+}
+
+@keyframes chatWorkingClawSpin {
+  0% {
+    transform: perspective(60px) rotateY(0deg);
+  }
+
+  100% {
+    transform: perspective(60px) rotateY(360deg);
+  }
+}
+
+/* Long rest, then one quick somersault with a small hop; -360deg lands back
+   at the rest pose so the loop seam is invisible. translateY comes first so
+   the hop stays vertical while the claw rotates in place. */
+@keyframes chatWorkingClawBackflip {
+  0%,
+  55% {
+    transform: translateY(0) rotate(0deg);
+  }
+
+  62% {
+    transform: translateY(-3px) rotate(-120deg);
+  }
+
+  70% {
+    transform: translateY(-3px) rotate(-240deg);
+  }
+
+  78%,
+  100% {
+    transform: translateY(0) rotate(-360deg);
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -1368,6 +1484,12 @@
   transform-box: view-box;
   transform-origin: 8.6px 11px;
   transform: rotate(-4deg);
+}
+
+/* Turn recap reuses the tasks-status chrome but the run is over: the parked
+   claw holds still instead of breathing. */
+.chat-turn-recap .chat-tasks-status__claw {
+  animation: none;
 }
 
 .chat-tasks-status__link {


### PR DESCRIPTION
## What Problem This Solves

The chat working indicator's claw shadowboxed constantly — a jab-jab-cross combo with lateral `translateX` punches that read as too busy while the model works. Beyond the animation, the working status carried no personality on long waits and gave no post-turn feedback about how long a reply took.

## Why This Change Was Made

Maintainer paper cut plus a status-line upgrade in the same surface:

- **Claw claws in place by default.** Two jaw snips per cycle with a subtle body flex (`chatWorkingClawFlex`/`chatWorkingClawSnip`), zero horizontal travel. Variety is seeded per run (FNV over the reading-indicator key) and rare on purpose: southpaw mirrored 20%, flurry double-time 5%, spin (fake-3D `perspective()`+`rotateY` turntable) 4%, shadowbox (the old punch combo + pow star, demoted to easter egg) 3%, backflip (vertical-hop somersault) 2%.
- **Long-wait phrases.** New `openclaw-working-phrase` element revives the 19 previously dead `chat.progressLabels` crab gerunds: after 30s of quiet the status reads e.g. `2m 57s · Clawing…`, rotating every 45s via an O(1) seed-derived stride over the prime-length phrase list (constant-time for arbitrarily old `startedAt`; adjacent rotations always differ). Decorative and aria-hidden — screen readers keep the sr-only "Working…".
- **Turn recap row.** Once a run settles, a parked (non-breathing) claw reports `Done in 51s · 485 tokens` from the session row's per-run `runtimeMs`/`outputTokens`, sticky until the next send. Attribution is guarded by a watch/settle state machine in `chat-progress.ts`: baseline terminal stamps captured while the indicator is visible, mid-watch stamp changes forfeit the turn, unresolved watches expire after 30s, unknown-baseline watches never resolve, failed runs stay quiet (error surfaces own them). Accepted residual (documented at `TURN_RECAP_SETTLE_WINDOW_MS`): session rows carry no run identity, so an unrelated same-session completion inside the 30s settle window of an abandoned queued send can be shown; the full fix needs a gateway terminal-row run id (follow-up), and the row is cosmetic and self-corrects on the next turn.

## User Impact

Calmer default working indicator; rare playful stances (including a fake-3D spin); whimsical rotating status words on long waits; and a persistent "Done in Xs · N tokens" recap after each turn in the Control UI chat.

## Evidence

- 124 focused tests green on Blacksmith Testbox (`chat-message.test.ts` 106, `chat-progress.test.ts` 14, `working-phrase.test.ts` 4), including regression tests for stale-row rejection, watch expiry, baseline-unknown consumption, recap freezing, zero/singular token labels, and phrase-rotation distinctness.
- `pnpm check:changed` gates (tsgo lanes, oxlint fan-out, `ui:i18n:verify`) green on Testbox across nine validation rounds.
- Nine structured Codex autoreview cycles (gpt-5.6-sol, xhigh); all findings fixed except the final run-identity residual, consciously rejected with the in-code tradeoff comment above.
- Motion verified programmatically in a browser harness: default/southpaw/flurry computed transforms carry zero `translateX` at every sampled frame; spin produces true 3D matrices; backflip hop is vertical after a transform-order fix.

## Pictures

All six stances plus the new status surfaces (the shadowbox row is the previous default animation, now the rare easter egg):

![working claw stances and status line](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/2026-07-working-claw-stances/claw-stances.gif)

<details><summary>Still frame</summary>

![still](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/2026-07-working-claw-stances/claw-stances-still.png)

</details>
