### PR TITLE
feat(plugin-sdk): expose trusted inbound chat type

### DIFF
--- a/extensions/telegram/src/bot-chat-type.test.ts
+++ b/extensions/telegram/src/bot-chat-type.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { normalizeTelegramInboundChatType } from "./bot-chat-type.js";
+
+describe("normalizeTelegramInboundChatType", () => {
+  it.each([
+    ["private", "direct"],
+    ["group", "group"],
+    ["supergroup", "supergroup"],
+    ["channel", "channel"],
+    ["unknown", undefined],
+  ] as const)("normalizes %s to %s", (input, expected) => {
+    expect(normalizeTelegramInboundChatType(input)).toBe(expected);
+  });
+});

--- a/extensions/telegram/src/bot-chat-type.ts
+++ b/extensions/telegram/src/bot-chat-type.ts
@@ -1,0 +1,14 @@
+import type { InboundChatType } from "openclaw/plugin-sdk";
+
+export function normalizeTelegramInboundChatType(chatType: string): InboundChatType | undefined {
+  switch (chatType) {
+    case "private":
+      return "direct";
+    case "group":
+    case "supergroup":
+    case "channel":
+      return chatType;
+    default:
+      return undefined;
+  }
+}

--- a/extensions/telegram/src/bot-handlers.callback-interactions.runtime.test.ts
+++ b/extensions/telegram/src/bot-handlers.callback-interactions.runtime.test.ts
@@ -1,0 +1,59 @@
+import type { CallbackQuery, Message } from "grammy/types";
+import { describe, expect, it, vi } from "vitest";
+import { handleTelegramInteractiveCallback } from "./bot-handlers.callback-interactions.runtime.js";
+
+vi.mock("./interactive-dispatch.js", () => ({
+  dispatchTelegramPluginInteractiveHandler: vi.fn(async () => ({ handled: false })),
+}));
+
+describe("handleTelegramInteractiveCallback", () => {
+  it("builds managed-select turns from callback sender and originating message chat", async () => {
+    let syntheticMessage: Message | undefined;
+    const callbackMessage = {
+      message_id: 41,
+      date: 1,
+      chat: { id: -1001234, type: "supergroup", title: "Family" },
+      from: { id: 99, is_bot: false, first_name: "Original author" },
+    } as Message;
+    const callback = {
+      id: "callback-1",
+      chat_instance: "instance-1",
+      from: { id: 9, is_bot: false, first_name: "Verified actor" },
+      message: callbackMessage,
+      data: "OC_SELECT|choice",
+    } as CallbackQuery;
+
+    const handled = await handleTelegramInteractiveCallback({
+      accountId: "default",
+      callback,
+      ctx: { me: { id: 1, is_bot: true, first_name: "Bot" }, getFile: vi.fn() } as never,
+      callbackMessage,
+      data: "OC_SELECT|choice",
+      pluginCallbackData: "OC_SELECT|choice",
+      callbackConversationId: "-1001234",
+      senderId: "9",
+      senderUsername: "",
+      isGroup: true,
+      isForum: false,
+      storeAllowFrom: [],
+      actions: {
+        clearCallbackButtons: vi.fn(async () => undefined),
+      } as never,
+      messageRuntime: {
+        buildSyntheticTextMessage: ({ base, from, text }) => ({ ...base, from, text }),
+        buildSyntheticContext: (_ctx, message) => ({ message }),
+        buildFailedProcessingResult: (error) => ({ kind: "failed-retryable", error }),
+        processMessageWithReplyChain: vi.fn(async ({ msg }) => {
+          syntheticMessage = msg;
+          return { kind: "completed" };
+        }),
+      } as never,
+      authorizeCallback: vi.fn(async () => true),
+    });
+
+    expect(handled).toBe(true);
+    expect(syntheticMessage?.from?.id).toBe(9);
+    expect(syntheticMessage?.chat.id).toBe(-1001234);
+    expect(syntheticMessage?.chat.type).toBe("supergroup");
+  });
+});

--- a/extensions/telegram/src/bot-message-context.session.ts
+++ b/extensions/telegram/src/bot-message-context.session.ts
@@ -1,3 +1,4 @@
+import type { InboundChatType } from "openclaw/plugin-sdk";
 // Telegram plugin module implements bot message context.session behavior.
 import {
   type BuildChannelInboundEventContextParams,
@@ -27,6 +28,7 @@ import { normalizeOptionalLowercaseString } from "openclaw/plugin-sdk/string-coe
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { NormalizedAllowFrom } from "./bot-access.js";
 import { isSenderAllowed, normalizeAllowFrom } from "./bot-access.js";
+import { normalizeTelegramInboundChatType } from "./bot-chat-type.js";
 import type {
   TelegramMediaRef,
   TelegramMessageContextOptions,
@@ -67,6 +69,7 @@ type TelegramInboundContextPayload = BuiltChannelInboundEventContext & {
   From: string;
   To: string;
   ChatType: string;
+  InboundChatType?: InboundChatType;
   RawBody: string;
   ReplyToIsExternal?: boolean;
   ReplyToQuotePosition?: number;
@@ -672,6 +675,7 @@ export async function buildTelegramInboundContextPayload(params: {
     },
     contextVisibility: contextVisibilityMode,
     extra: {
+      InboundChatType: normalizeTelegramInboundChatType(msg.chat.type),
       BotUsername: primaryCtx.me?.username ?? undefined,
       AmbientTranscriptWatermarkKey: ambientTranscriptWatermarkKey,
       AmbientTranscriptBody: options?.ambientTranscriptBody,

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -1836,35 +1836,48 @@ describe("createTelegramBot", () => {
     }
   });
 
-  it("routes generic callback_query payloads as callback_data messages and answers callbacks", async () => {
-    createTelegramBot({ token: "tok" });
-    const callbackHandler = requireValue(
-      onSpy.mock.calls.find((call) => call[0] === "callback_query")?.[1] as
-        | ((ctx: Record<string, unknown>) => Promise<void>)
-        | undefined,
-      "callback_query handler",
-    );
+  it.each([
+    ["private", "direct", 1234],
+    ["group", "group", -1234],
+    ["supergroup", "supergroup", -1001234],
+  ] as const)(
+    "routes %s callback_query payloads with verified actor and originating chat",
+    async (chatType, expectedInboundChatType, chatId) => {
+      createTelegramBot({ token: "tok" });
+      const callbackHandler = requireValue(
+        onSpy.mock.calls.find((call) => call[0] === "callback_query")?.[1] as
+          | ((ctx: Record<string, unknown>) => Promise<void>)
+          | undefined,
+        "callback_query handler",
+      );
 
-    await callbackHandler({
-      callbackQuery: {
-        id: "cbq-1",
-        data: "cmd:option_a",
-        from: { id: 9, first_name: "Ada", username: "ada_bot" },
-        message: {
-          chat: { id: 1234, type: "private" },
-          date: 1736380800,
-          message_id: 10,
+      await callbackHandler({
+        callbackQuery: {
+          id: "cbq-1",
+          data: "cmd:option_a?senderId=99&chatId=1&inboundChatType=direct",
+          from: { id: 9, first_name: "Ada", username: "ada_bot" },
+          message: {
+            chat: { id: chatId, type: chatType },
+            from: { id: 99, first_name: "Original author" },
+            date: 1736380800,
+            message_id: 10,
+          },
         },
-      },
-      me: { username: "openclaw_bot" },
-      getFile: async () => ({ download: async () => new Uint8Array() }),
-    });
+        me: { username: "openclaw_bot" },
+        getFile: async () => ({ download: async () => new Uint8Array() }),
+      });
 
-    expect(replySpy).toHaveBeenCalledTimes(1);
-    const payload = requireValue(replySpy.mock.calls.at(0), "replySpy call")[0];
-    expect(payload.Body).toContain("callback_data: cmd:option_a");
-    expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-1");
-  });
+      expect(replySpy).toHaveBeenCalledTimes(1);
+      const payload = requireValue(replySpy.mock.calls.at(0), "replySpy call")[0];
+      expect(payload.Body).toContain(
+        "callback_data: cmd:option_a?senderId=99&chatId=1&inboundChatType=direct",
+      );
+      expect(payload.SenderId).toBe("9");
+      expect(payload.ChatId).toBe(String(chatId));
+      expect(payload.InboundChatType).toBe(expectedInboundChatType);
+      expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-1");
+    },
+  );
 
   it("routes plugin callback_query payloads to plugin handlers without fallback callback_data text", async () => {
     const pluginHandler = vi.fn(async (ctx) => {

--- a/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
+++ b/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
@@ -831,6 +831,7 @@ describe("createOpenClawCodingTools", () => {
         modelProvider: "openrouter",
         modelId: "openrouter/auto",
         nativeChannelId: "oc_native_chat",
+        inboundChatType: "supergroup",
         clientCaps: ["inline-widgets"],
         toolConstructionPlan: {
           includeBaseCodingTools: false,
@@ -847,6 +848,7 @@ describe("createOpenClawCodingTools", () => {
       expect(pluginToolOptions?.modelProvider).toBe("openrouter");
       expect(pluginToolOptions?.modelId).toBe("openrouter/auto");
       expect(pluginToolOptions?.nativeChannelId).toBe("oc_native_chat");
+      expect(pluginToolOptions?.inboundChatType).toBe("supergroup");
       expect(pluginToolOptions?.clientCaps).toEqual(["inline-widgets"]);
     } finally {
       resolvePluginToolsSpy.mockRestore();
@@ -932,7 +934,7 @@ describe("createOpenClawCodingTools", () => {
     }
   });
 
-  it("forwards the native channel id through standard tool construction", () => {
+  it("forwards trusted inbound conversation facts through standard tool construction", () => {
     const createOpenClawToolsMock = vi.mocked(createOpenClawTools);
     createOpenClawToolsMock.mockClear();
 
@@ -940,10 +942,12 @@ describe("createOpenClawCodingTools", () => {
       config: testConfig,
       chatType: "group",
       nativeChannelId: "oc_native_chat",
+      inboundChatType: "supergroup",
       messageActionTurnCapability: "turn-capability-1",
     });
 
     expect(latestCreateOpenClawToolsOptions().nativeChannelId).toBe("oc_native_chat");
+    expect(latestCreateOpenClawToolsOptions().inboundChatType).toBe("supergroup");
     expect(latestCreateOpenClawToolsOptions().currentChatType).toBe("group");
     expect(latestCreateOpenClawToolsOptions().messageActionTurnCapability).toBe(
       "turn-capability-1",

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -10,6 +10,7 @@ import type {
 } from "../auto-reply/get-reply-options.types.js";
 import { HEARTBEAT_RESPONSE_TOOL_NAME } from "../auto-reply/heartbeat-tool-response.js";
 import type { ChatType } from "../channels/chat-type.js";
+import type { InboundChatType } from "../channels/inbound-chat-type.js";
 import type { InboundEventKind } from "../channels/inbound-event/kind.js";
 import type { ModelCompatConfig } from "../config/types.models.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -293,6 +294,8 @@ type OpenClawCodingToolsOptions = {
   conversationRecall?: ConversationRecallContext;
   /** Normalized conversation kind when the caller already has channel metadata. */
   chatType?: ChatType;
+  /** Runtime-owned normalized conversation type retained from channel ingress. */
+  inboundChatType?: InboundChatType;
   /** Specific ingress provider used only for transport tool availability. */
   toolPolicyMessageProvider?: string;
   agentAccountId?: string;
@@ -873,6 +876,7 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
             agentTo: options?.messageTo,
             agentThreadId: options?.messageThreadId,
             nativeChannelId: options?.nativeChannelId,
+            inboundChatType: options?.inboundChatType,
             agentDir: options?.agentDir,
             workspaceDir: workspaceRoot,
             config: options?.config,
@@ -969,6 +973,7 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
             agentTo: options?.messageTo,
             agentThreadId: options?.messageThreadId,
             nativeChannelId: options?.nativeChannelId,
+            inboundChatType: options?.inboundChatType,
             messageActionTurnCapability: options?.messageActionTurnCapability,
             agentGroupId: options?.groupId ?? null,
             agentGroupChannel: options?.groupChannel ?? null,

--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -1137,6 +1137,7 @@ async function compactEmbeddedAgentSessionDirectOnce(
           messageProvider: resolvedMessageProvider,
           clientCaps: params.clientCaps,
           chatType: params.chatType,
+          inboundChatType: params.inboundChatType,
           agentAccountId: params.agentAccountId,
           sessionKey: sandboxSessionKey,
           runSessionKey:

--- a/src/agents/embedded-agent-runner/compact.types.ts
+++ b/src/agents/embedded-agent-runner/compact.types.ts
@@ -5,6 +5,7 @@ import type { Model } from "openclaw/plugin-sdk/llm";
 import type { SourceReplyDeliveryMode } from "../../auto-reply/get-reply-options.types.js";
 import type { ReasoningLevel, ThinkLevel } from "../../auto-reply/thinking.js";
 import type { ChatType } from "../../channels/chat-type.js";
+import type { InboundChatType } from "../../channels/inbound-chat-type.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { ContextEngine, ContextEngineRuntimeContext } from "../../context-engine/types.js";
 import type { CommandQueueEnqueueFn } from "../../process/command-queue.types.js";
@@ -29,6 +30,7 @@ export type CompactEmbeddedAgentSessionParams = {
   /** Capabilities declared by the gateway client that originated this run. */
   clientCaps?: string[];
   chatType?: ChatType;
+  inboundChatType?: InboundChatType;
   agentAccountId?: string;
   currentChannelId?: string;
   currentThreadTs?: string;

--- a/src/agents/embedded-agent-runner/compaction-runtime-context.test.ts
+++ b/src/agents/embedded-agent-runner/compaction-runtime-context.test.ts
@@ -6,6 +6,7 @@ import { createProcessSessionFixture } from "../bash-process-registry.test-helpe
 import { resetProcessRegistryForTests } from "../bash-process-registry.test-support.js";
 import {
   buildEmbeddedCompactionRuntimeContext,
+  buildEmbeddedRecoveryChatContext,
   resolveCompactionHarnessRuntime,
   resolveEmbeddedCompactionThinkingLevel,
   resolveEmbeddedCompactionTarget,
@@ -65,6 +66,7 @@ describe("buildEmbeddedCompactionRuntimeContext", () => {
       messageChannel: "slack",
       messageProvider: "slack",
       chatType: "channel",
+      inboundChatType: "supergroup",
       agentAccountId: "acct-1",
       currentChannelId: "C123",
       currentThreadTs: "thread-9",
@@ -87,6 +89,7 @@ describe("buildEmbeddedCompactionRuntimeContext", () => {
     expect(result.messageChannel).toBe("slack");
     expect(result.messageProvider).toBe("slack");
     expect(result.chatType).toBe("channel");
+    expect(result.inboundChatType).toBe("supergroup");
     expect(result.agentAccountId).toBe("acct-1");
     expect(result.currentChannelId).toBe("C123");
     expect(result.currentThreadTs).toBe("thread-9");
@@ -743,5 +746,24 @@ describe("buildEmbeddedCompactionRuntimeContext", () => {
       defaultModel: "claude-opus-4-5",
     });
     expect(result.provider).toBe("anthropic");
+  });
+});
+
+describe("buildEmbeddedRecoveryChatContext", () => {
+  it("preserves runtime-owned inbound chat type for timeout and overflow reconstruction", () => {
+    expect(
+      buildEmbeddedRecoveryChatContext({
+        messageChannel: "telegram",
+        messageProvider: "telegram",
+        chatType: "group",
+        inboundChatType: "supergroup",
+      }),
+    ).toStrictEqual({
+      messageChannel: "telegram",
+      messageProvider: "telegram",
+      clientCaps: undefined,
+      chatType: "group",
+      inboundChatType: "supergroup",
+    });
   });
 });

--- a/src/agents/embedded-agent-runner/compaction-runtime-context.ts
+++ b/src/agents/embedded-agent-runner/compaction-runtime-context.ts
@@ -4,6 +4,7 @@
 import type { SourceReplyDeliveryMode } from "../../auto-reply/get-reply-options.types.js";
 import type { ReasoningLevel, ThinkLevel } from "../../auto-reply/thinking.js";
 import type { ChatType } from "../../channels/chat-type.js";
+import type { InboundChatType } from "../../channels/inbound-chat-type.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { SkillSnapshot } from "../../skills/types.js";
 import { isDefaultAgentRuntimeId, normalizeOptionalAgentRuntimeId } from "../agent-runtime-id.js";
@@ -29,6 +30,7 @@ type EmbeddedCompactionRuntimeContext = {
   messageProvider?: string;
   clientCaps?: string[];
   chatType?: ChatType;
+  inboundChatType?: InboundChatType;
   agentAccountId?: string;
   currentChannelId?: string;
   currentThreadTs?: string;
@@ -57,6 +59,22 @@ type EmbeddedCompactionRuntimeContext = {
   ownerNumbers?: string[];
   activeProcessSessions?: ActiveProcessSessionReference[];
 };
+
+export function buildEmbeddedRecoveryChatContext(params: {
+  messageChannel?: string;
+  messageProvider?: string;
+  clientCaps?: string[];
+  chatType?: ChatType;
+  inboundChatType?: InboundChatType;
+}) {
+  return {
+    messageChannel: params.messageChannel,
+    messageProvider: params.messageProvider,
+    clientCaps: params.clientCaps,
+    chatType: params.chatType,
+    inboundChatType: params.inboundChatType,
+  };
+}
 
 /** Resolve the configured compaction override against the actual model/runtime candidate. */
 export function resolveEmbeddedCompactionThinkingLevel(params: {
@@ -303,6 +321,7 @@ export function buildEmbeddedCompactionRuntimeContext(params: {
   messageProvider?: string | null;
   clientCaps?: string[];
   chatType?: ChatType | null;
+  inboundChatType?: InboundChatType | null;
   agentAccountId?: string | null;
   currentChannelId?: string | null;
   currentThreadTs?: string | null;
@@ -361,6 +380,7 @@ export function buildEmbeddedCompactionRuntimeContext(params: {
     messageProvider: params.messageProvider ?? undefined,
     clientCaps: params.clientCaps,
     chatType: params.chatType ?? undefined,
+    inboundChatType: params.inboundChatType ?? undefined,
     agentAccountId: params.agentAccountId ?? undefined,
     currentChannelId: params.currentChannelId ?? undefined,
     currentThreadTs: params.currentThreadTs ?? undefined,

--- a/src/agents/embedded-agent-runner/run/attempt-tool-base-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-base-prepare.ts
@@ -211,6 +211,7 @@ export function prepareEmbeddedAttemptToolBase(params: {
           clientCaps: attempt.clientCaps,
           toolBindings: attempt.toolBindings,
           chatType: attempt.chatType,
+          inboundChatType: attempt.inboundChatType,
           exec: {
             ...attempt.execOverrides,
             config: attempt.config,

--- a/src/agents/embedded-agent-runner/run/attempt.prompt-helpers.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.prompt-helpers.ts
@@ -503,6 +503,7 @@ type AfterTurnRuntimeContextAttempt = Pick<
   | "sandboxSessionKey"
   | "messageChannel"
   | "messageProvider"
+  | "inboundChatType"
   | "agentAccountId"
   | "currentChannelId"
   | "currentThreadTs"
@@ -573,6 +574,7 @@ export function buildAfterTurnRuntimeContext(params: {
       sessionKey: params.attempt.sessionKey,
       messageChannel: params.attempt.messageChannel,
       messageProvider: params.attempt.messageProvider,
+      inboundChatType: params.attempt.inboundChatType,
       agentAccountId: params.attempt.agentAccountId,
       currentChannelId: params.attempt.currentChannelId,
       currentThreadTs: params.attempt.currentThreadTs,

--- a/src/agents/embedded-agent-runner/run/overflow-context-recovery.ts
+++ b/src/agents/embedded-agent-runner/run/overflow-context-recovery.ts
@@ -11,7 +11,10 @@ import {
   isCompactionFailureError,
   isLikelyContextOverflowError,
 } from "../../embedded-agent-helpers.js";
-import { buildEmbeddedCompactionRuntimeContext } from "../compaction-runtime-context.js";
+import {
+  buildEmbeddedCompactionRuntimeContext,
+  buildEmbeddedRecoveryChatContext,
+} from "../compaction-runtime-context.js";
 import {
   compactContextEngineWithSafetyTimeout,
   resolveCompactionTimeoutMs,
@@ -213,10 +216,7 @@ export async function recoverEmbeddedRunOverflow(input: {
       const overflowCompactionRuntimeContext = {
         ...buildEmbeddedCompactionRuntimeContext({
           sessionKey: runParams.sessionKey,
-          messageChannel: runParams.messageChannel,
-          messageProvider: runParams.messageProvider,
-          clientCaps: runParams.clientCaps,
-          chatType: runParams.chatType,
+          ...buildEmbeddedRecoveryChatContext(runParams),
           agentAccountId: runParams.agentAccountId,
           currentChannelId: runParams.currentChannelId,
           currentThreadTs: runParams.currentThreadTs,

--- a/src/agents/embedded-agent-runner/run/params.ts
+++ b/src/agents/embedded-agent-runner/run/params.ts
@@ -12,6 +12,7 @@ import type { ReplyPayload } from "../../../auto-reply/reply-payload.js";
 import type { ReplyOperation } from "../../../auto-reply/reply/reply-run-registry.js";
 import type { ReasoningLevel, ThinkLevel, VerboseLevel } from "../../../auto-reply/thinking.js";
 import type { ChatType } from "../../../channels/chat-type.js";
+import type { InboundChatType } from "../../../channels/inbound-chat-type.js";
 import type { InboundEventKind } from "../../../channels/inbound-event/kind.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import type { ImageContent } from "../../../llm/types.js";
@@ -85,6 +86,8 @@ export type RunEmbeddedAgentParams = {
   /** Out-of-band plugin bindings attached by the run initiator. */
   toolBindings?: Readonly<Record<string, unknown>>;
   chatType?: ChatType;
+  /** Runtime-owned normalized conversation type retained from channel ingress. */
+  inboundChatType?: InboundChatType;
   agentAccountId?: string;
   /** What initiated this agent run: "user", "heartbeat", "cron", "memory", "overflow", or "manual". */
   trigger?: EmbeddedRunTrigger;

--- a/src/agents/embedded-agent-runner/run/run-attempt-dispatch.ts
+++ b/src/agents/embedded-agent-runner/run/run-attempt-dispatch.ts
@@ -172,6 +172,7 @@ export async function dispatchEmbeddedRunAttempt(input: {
     messageProvider: params.messageProvider,
     clientCaps: params.clientCaps,
     chatType: params.chatType,
+    inboundChatType: params.inboundChatType,
     agentAccountId: params.agentAccountId,
     messageTo: params.messageTo,
     messageThreadId: params.messageThreadId,

--- a/src/agents/embedded-agent-runner/run/timeout-context-recovery.ts
+++ b/src/agents/embedded-agent-runner/run/timeout-context-recovery.ts
@@ -4,7 +4,10 @@ import { resolveProcessToolScopeKey } from "../../agent-tools.js";
 import { listActiveProcessSessionReferences } from "../../bash-process-references.js";
 import { deriveContextPromptTokens, normalizeUsage } from "../../usage.js";
 import { runPostCompactionSideEffects } from "../compaction-hooks.js";
-import { buildEmbeddedCompactionRuntimeContext } from "../compaction-runtime-context.js";
+import {
+  buildEmbeddedCompactionRuntimeContext,
+  buildEmbeddedRecoveryChatContext,
+} from "../compaction-runtime-context.js";
 import {
   compactContextEngineWithSafetyTimeout,
   resolveCompactionTimeoutMs,
@@ -114,10 +117,7 @@ export async function recoverEmbeddedRunTimeout(input: {
     const timeoutCompactionRuntimeContext = {
       ...buildEmbeddedCompactionRuntimeContext({
         sessionKey: runParams.sessionKey,
-        messageChannel: runParams.messageChannel,
-        messageProvider: runParams.messageProvider,
-        clientCaps: runParams.clientCaps,
-        chatType: runParams.chatType,
+        ...buildEmbeddedRecoveryChatContext(runParams),
         agentAccountId: runParams.agentAccountId,
         currentChannelId: runParams.currentChannelId,
         currentThreadTs: runParams.currentThreadTs,

--- a/src/agents/openclaw-tools.browser-plugin.integration.test.ts
+++ b/src/agents/openclaw-tools.browser-plugin.integration.test.ts
@@ -149,6 +149,44 @@ describe("createOpenClawTools browser plugin integration", () => {
     expect(firstResolvePluginToolsParams().allowGatewaySubagentBinding).toBe(true);
   });
 
+  it("keeps inbound chat type runtime-owned when invocation arguments spoof it", async () => {
+    let trustedInboundChatType: string | undefined;
+    hoisted.resolvePluginTools.mockImplementation((params: unknown) => {
+      trustedInboundChatType = (params as { context?: { inboundChatType?: string } }).context
+        ?.inboundChatType;
+      return [
+        {
+          name: "trusted_context_fixture",
+          description: "trusted context fixture",
+          parameters: {
+            type: "object",
+            properties: { inboundChatType: { type: "string" } },
+          },
+          async execute(_toolCallId: string, args: { inboundChatType?: string }) {
+            return {
+              content: [{ type: "text", text: "ok" }],
+              details: {
+                trustedInboundChatType,
+                argumentInboundChatType: args.inboundChatType,
+              },
+            };
+          },
+        },
+      ];
+    });
+    const config = { plugins: { allow: ["fixture"] } } as OpenClawConfig;
+    const tools = resolveOpenClawPluginToolsForOptions({
+      options: { config, inboundChatType: "supergroup" },
+      resolvedConfig: config,
+    });
+
+    const result = await tools[0]?.execute("tool-call", { inboundChatType: "direct" });
+    expect(result?.details).toStrictEqual({
+      trustedInboundChatType: "supergroup",
+      argumentInboundChatType: "direct",
+    });
+  });
+
   it("forwards auth profile helpers to plugin resolution and context", async () => {
     let capturedParams:
       | {

--- a/src/agents/openclaw-tools.plugin-context.test.ts
+++ b/src/agents/openclaw-tools.plugin-context.test.ts
@@ -42,6 +42,26 @@ describe("openclaw plugin tool context", () => {
     expect(result.context.nativeChannelId).toBe("oc_native_chat");
   });
 
+  it.each(["direct", "group", "supergroup"] as const)(
+    "forwards runtime-owned inbound chat type %s",
+    (inboundChatType) => {
+      const result = resolveOpenClawPluginToolInputs({
+        options: {
+          config: {} as never,
+          inboundChatType,
+        },
+      });
+
+      expect(result.context.inboundChatType).toBe(inboundChatType);
+    },
+  );
+
+  it("leaves inbound chat type absent when the runtime does not provide it", () => {
+    const result = resolveOpenClawPluginToolInputs({ options: { config: {} as never } });
+
+    expect(result.context.inboundChatType).toBeUndefined();
+  });
+
   it("defaults missing and unknown conversation-read origins to delegated", () => {
     const missing = resolveOpenClawPluginToolInputs({
       options: { config: {} as never },

--- a/src/agents/openclaw-tools.plugin-context.ts
+++ b/src/agents/openclaw-tools.plugin-context.ts
@@ -1,3 +1,4 @@
+import type { InboundChatType } from "../channels/inbound-chat-type.js";
 import {
   normalizeConversationReadInvocationOrigin,
   type ConversationReadInvocationOrigin,
@@ -28,6 +29,7 @@ export type OpenClawPluginToolOptions = {
   currentChannelId?: string;
   agentThreadId?: string | number;
   nativeChannelId?: string;
+  inboundChatType?: InboundChatType;
   agentDir?: string;
   workspaceDir?: string;
   config?: OpenClawConfig;
@@ -111,6 +113,7 @@ export function resolveOpenClawPluginToolInputs(params: {
       agentAccountId: options?.agentAccountId,
       deliveryContext,
       nativeChannelId: options?.nativeChannelId,
+      inboundChatType: options?.inboundChatType,
       requesterSenderId: options?.requesterSenderId ?? undefined,
       senderIsOwner: options?.senderIsOwner,
       conversationReadOrigin: normalizeConversationReadInvocationOrigin(

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -7,6 +7,7 @@ import type {
 import { isCoreCanvasHostEnabled } from "../canvas/config.js";
 import { createShowWidgetTool } from "../canvas/widget-tool.js";
 import type { ChatType } from "../channels/chat-type.js";
+import type { InboundChatType } from "../channels/inbound-chat-type.js";
 import type { InboundEventKind } from "../channels/inbound-event/kind.js";
 import type { ConversationReadInvocationOrigin } from "../channels/plugins/conversation-read-origin.js";
 import { selectApplicableRuntimeConfig } from "../config/config.js";
@@ -128,6 +129,8 @@ export function createOpenClawTools(
     agentThreadId?: string | number;
     /** Trusted platform-native conversation id for the active inbound turn. */
     nativeChannelId?: string;
+    /** Runtime-owned normalized conversation type retained from channel ingress. */
+    inboundChatType?: InboundChatType;
     /** Opaque host-issued capability for current-turn channel message actions. */
     messageActionTurnCapability?: string;
     sandboxRoot?: string;

--- a/src/auto-reply/reply/agent-runner-utils.test.ts
+++ b/src/auto-reply/reply/agent-runner-utils.test.ts
@@ -219,6 +219,24 @@ describe("agent-runner-utils", () => {
     expect("chatType" in resolved.runBaseParams).toBe(false);
   });
 
+  it("carries runtime-owned inbound chat type outside queued model arguments", () => {
+    const resolved = buildEmbeddedRunExecutionParams({
+      run: makeRun({ chatType: "group" }),
+      sessionCtx: {
+        Provider: "telegram",
+        ChatType: "Group",
+        InboundChatType: "supergroup",
+      },
+      hasRepliedRef: undefined,
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      runId: "run-1",
+    });
+
+    expect(resolved.embeddedContext.inboundChatType).toBe("supergroup");
+    expect("inboundChatType" in resolved.runBaseParams).toBe(false);
+  });
+
   it("passes through recovered auto fallback provenance for embedded run params", () => {
     hoisted.resolveEffectiveModelFallbacksMock.mockReturnValue(["fallback-model"]);
     const run = makeRun({

--- a/src/auto-reply/reply/agent-runner-utils.ts
+++ b/src/auto-reply/reply/agent-runner-utils.ts
@@ -272,6 +272,7 @@ function buildEmbeddedContextFromTemplate(params: {
       provider: sessionCtx.Provider,
     }),
     ...(sessionCtx.ChatType ? { chatType: sessionCtx.ChatType } : {}),
+    ...(sessionCtx.InboundChatType ? { inboundChatType: sessionCtx.InboundChatType } : {}),
     agentAccountId: sessionCtx.AccountId,
     messageTo: resolveOriginMessageTo({
       originatingTo: sessionCtx.OriginatingTo,

--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -1,3 +1,4 @@
+import type { InboundChatType } from "../channels/inbound-chat-type.js";
 /** Shared inbound message context types used by prompt templating and reply dispatch. */
 import type { InboundEventKind } from "../channels/inbound-event/kind.js";
 import type { DmScope, ReplyToMode } from "../config/types.base.js";
@@ -234,6 +235,8 @@ export type MsgContext = {
   Prompt?: string;
   MaxChars?: number;
   ChatType?: string;
+  /** Runtime-owned normalized conversation type retained from channel ingress. */
+  InboundChatType?: InboundChatType;
   /** Human label for envelope headers (conversation label, not sender). */
   ConversationLabel?: string;
   GroupSubject?: string;

--- a/src/channels/inbound-chat-type.ts
+++ b/src/channels/inbound-chat-type.ts
@@ -1,0 +1,2 @@
+/** Runtime-owned normalized conversation type retained from channel ingress. */
+export type InboundChatType = "direct" | "group" | "supergroup" | "channel";

--- a/src/plugin-sdk/core.ts
+++ b/src/plugin-sdk/core.ts
@@ -137,6 +137,7 @@ export type {
   UnifiedModelCatalogSource,
 } from "@openclaw/model-catalog-core/model-catalog-types";
 export type { ProviderRuntimeModel } from "../plugins/provider-runtime-model.types.js";
+export type { InboundChatType } from "../channels/inbound-chat-type.js";
 export type {
   OpenClawPluginActiveModelContext,
   OpenClawPluginToolContext,

--- a/src/plugin-sdk/plugin-entry.ts
+++ b/src/plugin-sdk/plugin-entry.ts
@@ -1,3 +1,4 @@
+import type { InboundChatType as _InboundChatType } from "../channels/inbound-chat-type.js";
 // Plugin entry contracts define the manifest-facing hooks implemented by plugin packages.
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { emptyPluginConfigSchema } from "../plugins/config-schema.js";
@@ -171,6 +172,7 @@ export type OpenClawPluginService = _OpenClawPluginService;
 export type OpenClawPluginServiceContext = _OpenClawPluginServiceContext;
 export type OpenClawPluginToolContext = _OpenClawPluginToolContext;
 export type OpenClawPluginToolFactory = _OpenClawPluginToolFactory;
+export type InboundChatType = _InboundChatType;
 export type PluginAgentEventEmitParams = _PluginAgentEventEmitParams;
 export type PluginAgentEventEmitResult = _PluginAgentEventEmitResult;
 export type PluginAgentEventSubscriptionRegistration = _PluginAgentEventSubscriptionRegistration;

--- a/src/plugins/tool-types.ts
+++ b/src/plugins/tool-types.ts
@@ -2,6 +2,7 @@
 import type { ConversationRecallContext } from "../agents/conversation-recall.types.js";
 import type { ToolFsPolicy } from "../agents/tool-fs-policy.types.js";
 import type { AnyAgentTool } from "../agents/tools/common.js";
+import type { InboundChatType } from "../channels/inbound-chat-type.js";
 import type { ConversationReadInvocationOrigin } from "../channels/plugins/conversation-read-origin.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { HookEntry } from "../hooks/types.js";
@@ -52,6 +53,8 @@ export type OpenClawPluginToolContext = {
   deliveryContext?: DeliveryContext;
   /** Trusted platform-native conversation id for the active inbound turn. */
   nativeChannelId?: string;
+  /** Trusted normalized conversation type from channel ingress (runtime-provided, not tool args). */
+  inboundChatType?: InboundChatType;
   /** Trusted sender id from inbound context (runtime-provided, not tool args). */
   requesterSenderId?: string;
   /** Trusted owner bit from inbound context (runtime-provided, not tool args). */


### PR DESCRIPTION
## Summary
- add an optional runtime-owned inbound chat type to plugin tool factory context
- normalize Telegram private chats to direct while preserving group and supergroup
- retain the field through normal execution, compaction, timeout/overflow recovery, and callbacks

## Security rationale
Plugin tools can already receive trusted sender and native chat IDs, but not the authoritative Telegram chat type. Inferring chat type from numeric IDs, session keys, or model-provided arguments is spoofable and cannot support authorization boundaries. This field is captured from Telegram ingress and remains outside model-visible schemas and invocation arguments.

Callback turns preserve split provenance: the verified callback sender is the actor, while the originating callback message supplies chat ID and type.

## Compatibility
The field is optional and separate from the existing generic ChatType, so non-Telegram channels remain unchanged and receive undefined unless they explicitly supply authoritative metadata.

## Verification
- focused propagation, callback, compaction, compatibility, and spoof-resistance tests
- production core/UI/extensions typecheck
- plugin SDK declaration build
- TruffleHog pre-commit scan: no findings