### PR TITLE
refactor: resolve OpenAI-completions provider compat from a declarative matrix

### DIFF
--- a/packages/ai/src/providers/openai-completions-compat.ts
+++ b/packages/ai/src/providers/openai-completions-compat.ts
@@ -1,6 +1,6 @@
 import type { Model, OpenAICompletionsCompat } from "../types.js";
 
-export type OpenAICompletionsSessionAffinity = "none" | "openai" | "openrouter";
+type OpenAICompletionsSessionAffinity = "none" | "openai" | "openrouter";
 
 export type ResolvedOpenAICompletionsCompat = Omit<
   Required<OpenAICompletionsCompat>,
@@ -230,7 +230,7 @@ function matchesModelCompatRule(
 }
 
 /** Detects request compatibility from the provider, endpoint, and model family matrices. */
-export function detectOpenAICompletionsCompat(
+function detectOpenAICompletionsCompat(
   model: Pick<Model<"openai-completions">, "provider" | "baseUrl" | "id">,
 ): DetectedOpenAICompletionsCompat {
   const compat: DetectedOpenAICompletionsCompat = { ...DEFAULT_OPENAI_COMPLETIONS_COMPAT };

--- a/packages/ai/src/providers/openai-completions-compat.ts
+++ b/packages/ai/src/providers/openai-completions-compat.ts
@@ -1,0 +1,306 @@
+import type { Model, OpenAICompletionsCompat } from "../types.js";
+
+export type OpenAICompletionsSessionAffinity = "none" | "openai" | "openrouter";
+
+export type ResolvedOpenAICompletionsCompat = Omit<
+  Required<OpenAICompletionsCompat>,
+  "cacheControlFormat" | "openRouterRouting" | "sendSessionAffinityHeaders"
+> & {
+  cacheControlFormat?: OpenAICompletionsCompat["cacheControlFormat"];
+  openRouterRouting?: OpenAICompletionsCompat["openRouterRouting"];
+  sessionAffinity: OpenAICompletionsSessionAffinity;
+};
+
+type DetectedOpenAICompletionsCompat = Omit<
+  ResolvedOpenAICompletionsCompat,
+  "openRouterRouting" | "sessionAffinity"
+> & {
+  sessionAffinityFormat: Exclude<OpenAICompletionsSessionAffinity, "none">;
+};
+
+type OpenAICompletionsCompatRule = {
+  priority: number;
+  providers?: readonly string[];
+  baseUrlIncludes?: readonly string[];
+  compat: Partial<DetectedOpenAICompletionsCompat>;
+};
+
+const DEFAULT_OPENAI_COMPLETIONS_COMPAT = {
+  supportsStore: true,
+  supportsDeveloperRole: true,
+  supportsReasoningEffort: true,
+  supportsUsageInStreaming: true,
+  maxTokensField: "max_completion_tokens",
+  requiresToolResultName: false,
+  requiresAssistantAfterToolResult: false,
+  requiresThinkingAsText: false,
+  requiresReasoningContentOnAssistantMessages: false,
+  thinkingFormat: "openai",
+  vercelGatewayRouting: {},
+  zaiToolStream: false,
+  supportsStrictMode: true,
+  cacheControlFormat: undefined,
+  sessionAffinityFormat: "openai",
+  supportsPromptCacheKey: false,
+  supportsLongCacheRetention: true,
+} satisfies DetectedOpenAICompletionsCompat;
+
+const OPENAI_COMPLETIONS_COMPAT_MATRIX = {
+  openrouter: {
+    priority: 10,
+    providers: ["openrouter"],
+    baseUrlIncludes: ["openrouter.ai"],
+    compat: {
+      supportsDeveloperRole: false,
+      thinkingFormat: "openrouter",
+      sessionAffinityFormat: "openrouter",
+    },
+  },
+  cerebras: {
+    priority: 20,
+    providers: ["cerebras"],
+    baseUrlIncludes: ["cerebras.ai"],
+    compat: { supportsStore: false, supportsDeveloperRole: false },
+  },
+  xai: {
+    priority: 20,
+    providers: ["xai"],
+    baseUrlIncludes: ["api.x.ai"],
+    compat: {
+      supportsStore: false,
+      supportsDeveloperRole: false,
+      supportsReasoningEffort: false,
+    },
+  },
+  moonshot: {
+    priority: 20,
+    providers: ["moonshotai", "moonshotai-cn"],
+    baseUrlIncludes: ["api.moonshot."],
+    compat: {
+      supportsStore: false,
+      supportsDeveloperRole: false,
+      supportsReasoningEffort: false,
+      maxTokensField: "max_tokens",
+      supportsStrictMode: false,
+    },
+  },
+  cloudflareWorkersAi: {
+    priority: 20,
+    providers: ["cloudflare-workers-ai"],
+    baseUrlIncludes: ["api.cloudflare.com"],
+    compat: {
+      supportsStore: false,
+      supportsDeveloperRole: false,
+      supportsLongCacheRetention: false,
+    },
+  },
+  cloudflareAiGateway: {
+    priority: 20,
+    providers: ["cloudflare-ai-gateway"],
+    baseUrlIncludes: ["gateway.ai.cloudflare.com"],
+    compat: {
+      supportsStore: false,
+      supportsDeveloperRole: false,
+      supportsReasoningEffort: false,
+      maxTokensField: "max_tokens",
+      supportsStrictMode: false,
+      supportsLongCacheRetention: false,
+    },
+  },
+  opencode: {
+    priority: 20,
+    providers: ["opencode"],
+    baseUrlIncludes: ["opencode.ai"],
+    compat: { supportsStore: false, supportsDeveloperRole: false },
+  },
+  chutes: {
+    priority: 20,
+    baseUrlIncludes: ["chutes.ai"],
+    compat: {
+      supportsStore: false,
+      supportsDeveloperRole: false,
+      maxTokensField: "max_tokens",
+    },
+  },
+  together: {
+    priority: 30,
+    providers: ["together"],
+    baseUrlIncludes: ["api.together.ai", "api.together.xyz"],
+    compat: {
+      supportsStore: false,
+      supportsDeveloperRole: false,
+      supportsReasoningEffort: false,
+      maxTokensField: "max_tokens",
+      thinkingFormat: "together",
+      supportsStrictMode: false,
+      supportsLongCacheRetention: false,
+    },
+  },
+  zai: {
+    priority: 40,
+    providers: ["zai"],
+    baseUrlIncludes: ["api.z.ai"],
+    compat: {
+      supportsStore: false,
+      supportsDeveloperRole: false,
+      supportsReasoningEffort: false,
+      maxTokensField: "max_tokens",
+      thinkingFormat: "zai",
+    },
+  },
+  xiaomi: {
+    priority: 50,
+    providers: ["xiaomi"],
+    baseUrlIncludes: ["xiaomimimo.com"],
+    compat: {
+      thinkingFormat: "deepseek",
+      requiresReasoningContentOnAssistantMessages: true,
+    },
+  },
+  deepseekProvider: {
+    priority: 60,
+    providers: ["deepseek"],
+    compat: {
+      thinkingFormat: "deepseek",
+      requiresReasoningContentOnAssistantMessages: true,
+    },
+  },
+  deepseekEndpoint: {
+    priority: 60,
+    baseUrlIncludes: ["deepseek.com"],
+    compat: {
+      supportsStore: false,
+      supportsDeveloperRole: false,
+      thinkingFormat: "deepseek",
+      requiresReasoningContentOnAssistantMessages: true,
+    },
+  },
+} as const satisfies Record<string, OpenAICompletionsCompatRule>;
+
+type OpenAICompletionsCompatProfile = keyof typeof OPENAI_COMPLETIONS_COMPAT_MATRIX;
+
+type OpenAICompletionsModelCompatRule = {
+  profile?: OpenAICompletionsCompatProfile;
+  providers?: readonly string[];
+  modelIdPrefixes: readonly string[];
+  compat: Partial<DetectedOpenAICompletionsCompat>;
+};
+
+const OPENAI_COMPLETIONS_MODEL_COMPAT_MATRIX = [
+  {
+    profile: "openrouter",
+    modelIdPrefixes: ["anthropic/", "openai/"],
+    compat: { supportsDeveloperRole: true },
+  },
+  {
+    providers: ["openrouter"],
+    modelIdPrefixes: ["anthropic/"],
+    compat: { cacheControlFormat: "anthropic" },
+  },
+] as const satisfies readonly OpenAICompletionsModelCompatRule[];
+
+const SORTED_OPENAI_COMPLETIONS_COMPAT_RULES = Object.entries(
+  OPENAI_COMPLETIONS_COMPAT_MATRIX,
+).toSorted(([, left], [, right]) => left.priority - right.priority) as Array<
+  [OpenAICompletionsCompatProfile, OpenAICompletionsCompatRule]
+>;
+
+function matchesCompatRule(
+  model: Pick<Model<"openai-completions">, "provider" | "baseUrl">,
+  rule: OpenAICompletionsCompatRule,
+): boolean {
+  return (
+    rule.providers?.includes(model.provider) === true ||
+    rule.baseUrlIncludes?.some((fragment) => model.baseUrl.includes(fragment)) === true
+  );
+}
+
+function matchesModelCompatRule(
+  model: Pick<Model<"openai-completions">, "provider" | "id">,
+  matchedProfiles: ReadonlySet<OpenAICompletionsCompatProfile>,
+  rule: OpenAICompletionsModelCompatRule,
+): boolean {
+  if (rule.profile !== undefined && !matchedProfiles.has(rule.profile)) {
+    return false;
+  }
+  if (rule.providers !== undefined && !rule.providers.includes(model.provider)) {
+    return false;
+  }
+  return rule.modelIdPrefixes.some((prefix) => model.id.startsWith(prefix));
+}
+
+/** Detects request compatibility from the provider, endpoint, and model family matrices. */
+export function detectOpenAICompletionsCompat(
+  model: Pick<Model<"openai-completions">, "provider" | "baseUrl" | "id">,
+): DetectedOpenAICompletionsCompat {
+  const compat: DetectedOpenAICompletionsCompat = { ...DEFAULT_OPENAI_COMPLETIONS_COMPAT };
+  const matchedProfiles = new Set<OpenAICompletionsCompatProfile>();
+
+  for (const [profile, rule] of SORTED_OPENAI_COMPLETIONS_COMPAT_RULES) {
+    if (!matchesCompatRule(model, rule)) {
+      continue;
+    }
+    Object.assign(compat, rule.compat);
+    matchedProfiles.add(profile);
+  }
+
+  for (const rule of OPENAI_COMPLETIONS_MODEL_COMPAT_MATRIX) {
+    if (matchesModelCompatRule(model, matchedProfiles, rule)) {
+      Object.assign(compat, rule.compat);
+    }
+  }
+
+  return compat;
+}
+
+function resolveSessionAffinity(
+  model: Pick<Model<"openai-completions">, "compat">,
+  detectedFormat: DetectedOpenAICompletionsCompat["sessionAffinityFormat"],
+): OpenAICompletionsSessionAffinity {
+  if (model.compat?.sendSessionAffinityHeaders !== true) {
+    return "none";
+  }
+  if (
+    detectedFormat === "openrouter" ||
+    model.compat.thinkingFormat === "openrouter" ||
+    model.compat.openRouterRouting !== undefined
+  ) {
+    return "openrouter";
+  }
+  return "openai";
+}
+
+/** Applies explicit model overrides to the detected compatibility defaults. */
+export function resolveOpenAICompletionsCompat(
+  model: Model<"openai-completions">,
+): ResolvedOpenAICompletionsCompat {
+  const detected = detectOpenAICompletionsCompat(model);
+  const configured = model.compat;
+
+  return {
+    supportsStore: configured?.supportsStore ?? detected.supportsStore,
+    supportsDeveloperRole: configured?.supportsDeveloperRole ?? detected.supportsDeveloperRole,
+    supportsReasoningEffort:
+      configured?.supportsReasoningEffort ?? detected.supportsReasoningEffort,
+    supportsUsageInStreaming:
+      configured?.supportsUsageInStreaming ?? detected.supportsUsageInStreaming,
+    maxTokensField: configured?.maxTokensField ?? detected.maxTokensField,
+    requiresToolResultName: configured?.requiresToolResultName ?? detected.requiresToolResultName,
+    requiresAssistantAfterToolResult:
+      configured?.requiresAssistantAfterToolResult ?? detected.requiresAssistantAfterToolResult,
+    requiresThinkingAsText: configured?.requiresThinkingAsText ?? detected.requiresThinkingAsText,
+    requiresReasoningContentOnAssistantMessages:
+      configured?.requiresReasoningContentOnAssistantMessages ??
+      detected.requiresReasoningContentOnAssistantMessages,
+    thinkingFormat: configured?.thinkingFormat ?? detected.thinkingFormat,
+    openRouterRouting: configured?.openRouterRouting,
+    vercelGatewayRouting: configured?.vercelGatewayRouting ?? detected.vercelGatewayRouting,
+    zaiToolStream: configured?.zaiToolStream ?? detected.zaiToolStream,
+    supportsStrictMode: configured?.supportsStrictMode ?? detected.supportsStrictMode,
+    cacheControlFormat: configured?.cacheControlFormat ?? detected.cacheControlFormat,
+    sessionAffinity: resolveSessionAffinity(model, detected.sessionAffinityFormat),
+    supportsPromptCacheKey: configured?.supportsPromptCacheKey ?? detected.supportsPromptCacheKey,
+    supportsLongCacheRetention:
+      configured?.supportsLongCacheRetention ?? detected.supportsLongCacheRetention,
+  };
+}

--- a/packages/ai/src/providers/openai-completions.compat.test.ts
+++ b/packages/ai/src/providers/openai-completions.compat.test.ts
@@ -42,6 +42,10 @@ vi.mock("openai", () => {
   return { default: MockOpenAI };
 });
 
+import {
+  resolveOpenAICompletionsCompat,
+  type ResolvedOpenAICompletionsCompat,
+} from "./openai-completions-compat.js";
 import { streamOpenAICompletions } from "./openai-completions.js";
 
 const baseModel: Model<"openai-completions"> = {
@@ -68,6 +72,27 @@ function createModel(
   return { ...baseModel, ...overrides };
 }
 
+const defaultResolvedCompat = {
+  supportsStore: true,
+  supportsDeveloperRole: true,
+  supportsReasoningEffort: true,
+  supportsUsageInStreaming: true,
+  maxTokensField: "max_completion_tokens",
+  requiresToolResultName: false,
+  requiresAssistantAfterToolResult: false,
+  requiresThinkingAsText: false,
+  requiresReasoningContentOnAssistantMessages: false,
+  thinkingFormat: "openai",
+  openRouterRouting: undefined,
+  vercelGatewayRouting: {},
+  zaiToolStream: false,
+  supportsStrictMode: true,
+  cacheControlFormat: undefined,
+  sessionAffinity: "none",
+  supportsPromptCacheKey: false,
+  supportsLongCacheRetention: true,
+} satisfies ResolvedOpenAICompletionsCompat;
+
 function chunk(delta: Record<string, unknown>, finishReason?: string): unknown {
   return {
     id: "chatcmpl-test",
@@ -84,6 +109,92 @@ beforeEach(() => {
 });
 
 describe("OpenAI-compatible completions compatibility", () => {
+  it.each([
+    {
+      name: "OpenRouter Anthropic",
+      model: createModel({
+        id: "anthropic/claude-sonnet-4.6",
+        provider: "openrouter",
+        baseUrl: "https://openrouter.ai/api/v1",
+        compat: { sendSessionAffinityHeaders: true },
+      }),
+      expected: {
+        ...defaultResolvedCompat,
+        thinkingFormat: "openrouter",
+        cacheControlFormat: "anthropic",
+        sessionAffinity: "openrouter",
+      },
+    },
+    {
+      name: "OpenRouter Kimi",
+      model: createModel({
+        id: "moonshotai/kimi-k2.6",
+        provider: "openrouter",
+        baseUrl: "https://openrouter.ai/api/v1",
+      }),
+      expected: {
+        ...defaultResolvedCompat,
+        supportsDeveloperRole: false,
+        thinkingFormat: "openrouter",
+      },
+    },
+    {
+      name: "Z.AI GLM",
+      model: createModel({
+        id: "glm-5",
+        provider: "zai",
+        baseUrl: "https://api.z.ai/api/paas/v4",
+      }),
+      expected: {
+        ...defaultResolvedCompat,
+        supportsStore: false,
+        supportsDeveloperRole: false,
+        supportsReasoningEffort: false,
+        maxTokensField: "max_tokens",
+        thinkingFormat: "zai",
+      },
+    },
+    {
+      name: "OpenAI",
+      model: createModel({
+        id: "gpt-5.6-luna",
+        provider: "openai",
+        baseUrl: "https://api.openai.com/v1",
+      }),
+      expected: defaultResolvedCompat,
+    },
+    {
+      name: "Azure OpenAI",
+      model: createModel({
+        id: "gpt-5.6-luna",
+        provider: "azure-openai",
+        baseUrl: "https://example.openai.azure.com/openai/deployments/luna",
+      }),
+      expected: defaultResolvedCompat,
+    },
+    {
+      name: "custom proxy",
+      model: createModel(),
+      expected: defaultResolvedCompat,
+    },
+    {
+      name: "custom proxy with OpenRouter routing",
+      model: createModel({
+        compat: {
+          openRouterRouting: { only: ["google-vertex"] },
+          sendSessionAffinityHeaders: true,
+        },
+      }),
+      expected: {
+        ...defaultResolvedCompat,
+        openRouterRouting: { only: ["google-vertex"] },
+        sessionAffinity: "openrouter",
+      },
+    },
+  ])("resolves the $name compat record", ({ model, expected }) => {
+    expect(resolveOpenAICompletionsCompat(model)).toEqual(expected);
+  });
+
   it("buffers encrypted reasoning details until their tool call arrives", async () => {
     const reasoningDetail = {
       type: "reasoning.encrypted",

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -24,7 +24,6 @@ import type {
   Context,
   Message,
   Model,
-  OpenAICompletionsCompat,
   SimpleStreamOptions,
   StreamFunction,
   StreamOptions,
@@ -52,6 +51,10 @@ import {
 import { resolveCacheRetention } from "./cache-retention.js";
 import { isCloudflareProvider, resolveCloudflareBaseUrl } from "./cloudflare.js";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copilot-headers.js";
+import {
+  resolveOpenAICompletionsCompat,
+  type ResolvedOpenAICompletionsCompat,
+} from "./openai-completions-compat.js";
 import { clampOpenAIPromptCacheKey } from "./openai-prompt-cache.js";
 import { mapOpenAIStopReason } from "./openai-stop-reason.js";
 import {
@@ -118,14 +121,6 @@ interface OpenAICompatCacheControl {
   ttl?: string;
 }
 
-type ResolvedOpenAICompletionsCompat = Omit<
-  Required<OpenAICompletionsCompat>,
-  "cacheControlFormat"
-> & {
-  cacheControlFormat?: OpenAICompletionsCompat["cacheControlFormat"];
-  sessionAffinityFormat: "openai" | "openrouter";
-};
-
 type EncryptedReasoningDetail = {
   type: "reasoning.encrypted";
   id: string;
@@ -186,7 +181,7 @@ export const streamOpenAICompletions: StreamFunction<
     let firstEventAbort: ReturnType<typeof createFirstStreamEventAbortController> | undefined;
     try {
       const apiKey = options?.apiKey || getEnvApiKey(model.provider) || "";
-      const compat = getCompat(model);
+      const compat = resolveOpenAICompletionsCompat(model);
       const cacheRetention = resolveCacheRetention(options?.cacheRetention);
       const cacheSessionId = cacheRetention === "none" ? undefined : options?.sessionId;
       const client = createClient(model, context, apiKey, options?.headers, cacheSessionId, compat);
@@ -646,7 +641,7 @@ function createClient(
   apiKey?: string,
   optionsHeaders?: Record<string, string>,
   sessionId?: string,
-  compat: ResolvedOpenAICompletionsCompat = getCompat(model),
+  compat: ResolvedOpenAICompletionsCompat = resolveOpenAICompletionsCompat(model),
 ) {
   if (!apiKey) {
     throw new Error(`No API key for provider: ${model.provider}`);
@@ -662,8 +657,8 @@ function createClient(
     Object.assign(headers, copilotHeaders);
   }
 
-  if (sessionId && compat.sendSessionAffinityHeaders) {
-    if (compat.sessionAffinityFormat === "openrouter") {
+  if (sessionId && compat.sessionAffinity !== "none") {
+    if (compat.sessionAffinity === "openrouter") {
       headers["x-session-id"] = sessionId;
     } else {
       headers.session_id = sessionId;
@@ -700,7 +695,7 @@ function buildParams(
   model: Model<"openai-completions">,
   context: Context,
   options?: OpenAICompletionsOptions,
-  compat: ResolvedOpenAICompletionsCompat = getCompat(model),
+  compat: ResolvedOpenAICompletionsCompat = resolveOpenAICompletionsCompat(model),
   cacheRetention: CacheRetention = resolveCacheRetention(options?.cacheRetention),
 ) {
   const cacheControl = getCompatCacheControl(compat, cacheRetention);
@@ -851,8 +846,8 @@ function buildParams(
   }
 
   // OpenRouter provider routing preferences
-  if (model.compat?.openRouterRouting) {
-    params.provider = model.compat.openRouterRouting;
+  if (compat.openRouterRouting) {
+    params.provider = compat.openRouterRouting;
   }
 
   // Vercel AI Gateway provider routing preferences
@@ -1377,129 +1372,4 @@ function parseChunkUsage(
   return usage;
 }
 
-/**
- * Detect compatibility settings from provider and baseUrl for known providers.
- * Provider takes precedence over URL-based detection since it's explicitly configured.
- * Returns a fully resolved OpenAICompletionsCompat object with all fields set.
- */
-function detectCompat(model: Model<"openai-completions">): ResolvedOpenAICompletionsCompat {
-  const provider = model.provider;
-  const baseUrl = model.baseUrl;
-
-  const isZai = provider === "zai" || baseUrl.includes("api.z.ai");
-  const isTogether =
-    provider === "together" ||
-    baseUrl.includes("api.together.ai") ||
-    baseUrl.includes("api.together.xyz");
-  const isMoonshot =
-    provider === "moonshotai" || provider === "moonshotai-cn" || baseUrl.includes("api.moonshot.");
-  const isCloudflareWorkersAI =
-    provider === "cloudflare-workers-ai" || baseUrl.includes("api.cloudflare.com");
-  const isCloudflareAiGateway =
-    provider === "cloudflare-ai-gateway" || baseUrl.includes("gateway.ai.cloudflare.com");
-  const isOpenRouter = provider === "openrouter" || baseUrl.includes("openrouter.ai");
-
-  const isNonStandard =
-    provider === "cerebras" ||
-    baseUrl.includes("cerebras.ai") ||
-    provider === "xai" ||
-    baseUrl.includes("api.x.ai") ||
-    isTogether ||
-    baseUrl.includes("chutes.ai") ||
-    baseUrl.includes("deepseek.com") ||
-    isZai ||
-    isMoonshot ||
-    provider === "opencode" ||
-    baseUrl.includes("opencode.ai") ||
-    isCloudflareWorkersAI ||
-    isCloudflareAiGateway;
-
-  const useMaxTokens =
-    baseUrl.includes("chutes.ai") || isMoonshot || isCloudflareAiGateway || isTogether || isZai;
-
-  const isGrok = provider === "xai" || baseUrl.includes("api.x.ai");
-  const isDeepSeek = provider === "deepseek" || baseUrl.includes("deepseek.com");
-  const isXiaomi = provider === "xiaomi" || baseUrl.includes("xiaomimimo.com");
-  const supportsOpenRouterDeveloperRole =
-    isOpenRouter && (model.id.startsWith("anthropic/") || model.id.startsWith("openai/"));
-  const usesOpenRouterSessionAffinity =
-    isOpenRouter ||
-    model.compat?.thinkingFormat === "openrouter" ||
-    model.compat?.openRouterRouting !== undefined;
-  const cacheControlFormat =
-    provider === "openrouter" && model.id.startsWith("anthropic/") ? "anthropic" : undefined;
-
-  return {
-    supportsStore: !isNonStandard,
-    supportsDeveloperRole: supportsOpenRouterDeveloperRole || (!isNonStandard && !isOpenRouter),
-    supportsReasoningEffort:
-      !isGrok && !isZai && !isMoonshot && !isTogether && !isCloudflareAiGateway,
-    supportsUsageInStreaming: true,
-    maxTokensField: useMaxTokens ? "max_tokens" : "max_completion_tokens",
-    requiresToolResultName: false,
-    requiresAssistantAfterToolResult: false,
-    requiresThinkingAsText: false,
-    requiresReasoningContentOnAssistantMessages: isDeepSeek || isXiaomi,
-    thinkingFormat: isDeepSeek
-      ? "deepseek"
-      : isXiaomi
-        ? "deepseek"
-        : isZai
-          ? "zai"
-          : isTogether
-            ? "together"
-            : isOpenRouter
-              ? "openrouter"
-              : "openai",
-    openRouterRouting: {},
-    vercelGatewayRouting: {},
-    zaiToolStream: false,
-    supportsStrictMode: !isMoonshot && !isTogether && !isCloudflareAiGateway,
-    cacheControlFormat,
-    sendSessionAffinityHeaders: false,
-    sessionAffinityFormat: usesOpenRouterSessionAffinity ? "openrouter" : "openai",
-    supportsPromptCacheKey: false,
-    supportsLongCacheRetention: !(isTogether || isCloudflareWorkersAI || isCloudflareAiGateway),
-  };
-}
-
-/**
- * Get resolved compatibility settings for a model.
- * Uses explicit model.compat if provided, otherwise auto-detects from provider/URL.
- */
-function getCompat(model: Model<"openai-completions">): ResolvedOpenAICompletionsCompat {
-  const detected = detectCompat(model);
-  if (!model.compat) {
-    return detected;
-  }
-
-  return {
-    supportsStore: model.compat.supportsStore ?? detected.supportsStore,
-    supportsDeveloperRole: model.compat.supportsDeveloperRole ?? detected.supportsDeveloperRole,
-    supportsReasoningEffort:
-      model.compat.supportsReasoningEffort ?? detected.supportsReasoningEffort,
-    supportsUsageInStreaming:
-      model.compat.supportsUsageInStreaming ?? detected.supportsUsageInStreaming,
-    maxTokensField: model.compat.maxTokensField ?? detected.maxTokensField,
-    requiresToolResultName: model.compat.requiresToolResultName ?? detected.requiresToolResultName,
-    requiresAssistantAfterToolResult:
-      model.compat.requiresAssistantAfterToolResult ?? detected.requiresAssistantAfterToolResult,
-    requiresThinkingAsText: model.compat.requiresThinkingAsText ?? detected.requiresThinkingAsText,
-    requiresReasoningContentOnAssistantMessages:
-      model.compat.requiresReasoningContentOnAssistantMessages ??
-      detected.requiresReasoningContentOnAssistantMessages,
-    thinkingFormat: model.compat.thinkingFormat ?? detected.thinkingFormat,
-    openRouterRouting: model.compat.openRouterRouting ?? {},
-    vercelGatewayRouting: model.compat.vercelGatewayRouting ?? detected.vercelGatewayRouting,
-    zaiToolStream: model.compat.zaiToolStream ?? detected.zaiToolStream,
-    supportsStrictMode: model.compat.supportsStrictMode ?? detected.supportsStrictMode,
-    cacheControlFormat: model.compat.cacheControlFormat ?? detected.cacheControlFormat,
-    sendSessionAffinityHeaders:
-      model.compat.sendSessionAffinityHeaders ?? detected.sendSessionAffinityHeaders,
-    sessionAffinityFormat: detected.sessionAffinityFormat,
-    supportsPromptCacheKey: model.compat.supportsPromptCacheKey ?? detected.supportsPromptCacheKey,
-    supportsLongCacheRetention:
-      model.compat.supportsLongCacheRetention ?? detected.supportsLongCacheRetention,
-  };
-}
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
## What Problem This Solves

Per-provider wire quirks for the OpenAI-completions family (max-token field name, thinking format and `clear_thinking`, developer-role support, OpenRouter routing, session-affinity header shape, cache-control style, strict-tool/reasoning flags) were expressed as a growing ladder of inline conditionals — `provider === "zai"`, `baseUrl.includes("openrouter.ai")`, model-id prefix checks, `isNonStandard`, etc. Every recent provider fix meant adding another branch, and the effective flags for a given provider were hard to audit because the decision was spread across the detector, the request builder, and the client header code.

## Why This Change Was Made

The already-partial `detectCompat` is formalized into a declarative, typed matrix: a default record plus a prioritized provider/URL rule registry and a model-family override registry, authored as data with `satisfies` and resolved through a single `resolveOpenAICompletionsCompat` lookup. The scattered read sites now consume the resolved record. Session affinity becomes a closed `"none" | "openai" | "openrouter"` union (removing the previous boolean+format combination that could represent invalid states); routing-absence is `undefined` rather than an empty-object sentinel.

Scope is deliberately bounded to the OpenAI-completions cluster; Responses/Anthropic/agent-attribution compat were left alone because their inputs and defaults genuinely differ and folding them in would not be behavior-neutral.

## User Impact

No behavior change. Provider quirks are now one auditable data table; adding a provider is a data edit, not another conditional. The detector/resolver dropped 125 to 105 lines and the adapter is net -130 lines; added lines are auditable matrix data.

## Evidence

- Behavior-neutrality: a parity probe across 630 provider/URL/model combinations confirmed the resolved compat record is identical to the pre-refactor decisions for every case; seven full-record matrix cases added.
- 188 provider tests passing (completions, compat, responses, responses-shared) — re-verified independently.
- Changed-file gate green; plugin-sdk surface + API baseline unchanged (compat type is internal); format/oxlint/git diff --check clean; autoreview clean (0.97).

## Finding (preserved, not changed)

The package-level detector and `src/agents/openai-completions-compat.ts` intentionally disagree for generic custom endpoints — the latter folds in manifest/provider-attribution facts and applies stricter proxy defaults. This divergence is preserved as-is, not silently normalized; unifying it is a separate, behavior-affecting decision.
