### PR TITLE
refactor(media): consolidate parallel media-kind unions onto canonical MediaKind

### DIFF
--- a/extensions/discord/src/monitor/message-media.ts
+++ b/extensions/discord/src/monitor/message-media.ts
@@ -49,11 +49,7 @@ const AUDIO_ATTACHMENT_EXTENSIONS = new Set([
 
 const DISCORD_STICKER_ASSET_BASE_URL = "https://media.discordapp.net/stickers";
 
-export type DiscordMediaInfo = {
-  path?: string;
-  contentType?: string;
-  kind?: "audio" | "document" | "image" | "sticker";
-};
+export type DiscordMediaInfo = Pick<MediaPlaceholderTextFact, "contentType" | "kind" | "path">;
 
 type DiscordMediaResolveOptions = {
   fetchImpl?: FetchLike;
@@ -105,7 +101,7 @@ function resolveEffectiveMediaType(params: {
 function resolveDiscordMediaClassification(params: {
   attachment: APIAttachment;
   fetchedContentType?: string | null;
-}): { contentType?: string; kind?: "audio" | "document" | "image" } {
+}): Pick<DiscordMediaInfo, "contentType" | "kind"> {
   const contentType = resolveEffectiveMediaType({
     declaredContentType: params.attachment.content_type,
     fetchedContentType: params.fetchedContentType,

--- a/extensions/feishu/src/bot-content.ts
+++ b/extensions/feishu/src/bot-content.ts
@@ -361,9 +361,7 @@ async function resolveSavedFeishuMedia(params: {
   );
 }
 
-function resolveFeishuMediaKind(
-  messageType: string,
-): "image" | "video" | "audio" | "document" | "sticker" {
+function resolveFeishuMediaKind(messageType: string): FeishuMediaInfo["kind"] {
   switch (messageType) {
     case "image":
       return "image";

--- a/extensions/feishu/src/types.ts
+++ b/extensions/feishu/src/types.ts
@@ -89,7 +89,7 @@ export interface FeishuProbeResult extends BaseProbeResult {
 export type FeishuMediaInfo = {
   path?: string;
   contentType?: string;
-  kind: "image" | "video" | "audio" | "document" | "sticker";
+  kind: Exclude<import("openclaw/plugin-sdk/media-runtime").MediaKind, "unknown">;
 };
 
 export type FeishuToolsConfig = {

--- a/extensions/line/src/outbound-media.ts
+++ b/extensions/line/src/outbound-media.ts
@@ -2,9 +2,7 @@
 import type { messagingApi } from "@line/bot-sdk";
 import { resolvePinnedHostnameWithPolicy, type SsrFPolicy } from "openclaw/plugin-sdk/ssrf-runtime";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
-import type { LineChannelData } from "./types.js";
-
-type LineOutboundMediaKind = "image" | "video" | "audio";
+import type { LineChannelData, LineOutboundMediaKind } from "./types.js";
 
 type LineOutboundMediaResolved = {
   mediaUrl: string;

--- a/extensions/line/src/send.ts
+++ b/extensions/line/src/send.ts
@@ -11,7 +11,7 @@ import { messageAction } from "./actions.js";
 import { resolveLineChannelAccessToken } from "./channel-access-token.js";
 import { validateLineMediaUrl } from "./outbound-media.js";
 import { createLineSendReceipt } from "./send-receipt.js";
-import type { LineSendResult } from "./types.js";
+import type { LineOutboundMediaKind, LineSendResult } from "./types.js";
 
 type Message = messagingApi.Message;
 type TextMessage = messagingApi.TextMessage;
@@ -56,7 +56,7 @@ interface LineSendOpts {
   accountId?: string;
   verbose?: boolean;
   mediaUrl?: string;
-  mediaKind?: "image" | "video" | "audio";
+  mediaKind?: LineOutboundMediaKind;
   previewImageUrl?: string;
   durationMs?: number;
   trackingId?: string;

--- a/extensions/line/src/types.ts
+++ b/extensions/line/src/types.ts
@@ -1,6 +1,7 @@
 // Line type declarations define plugin contracts.
 import type { BaseProbeResult } from "openclaw/plugin-sdk/channel-contract";
 import type { MessageReceipt } from "openclaw/plugin-sdk/channel-outbound";
+import type { MediaKind } from "openclaw/plugin-sdk/media-runtime";
 
 export type LineTokenSource = "config" | "env" | "file" | "none";
 export type LineCredentialStatus = "available" | "configured_unavailable" | "missing";
@@ -125,7 +126,7 @@ export type LineTemplateMessagePayload =
 
 export type LineChannelData = {
   quickReplies?: string[];
-  mediaKind?: "image" | "video" | "audio";
+  mediaKind?: LineOutboundMediaKind;
   previewImageUrl?: string;
   durationMs?: number;
   trackingId?: string;
@@ -138,3 +139,5 @@ export type LineChannelData = {
   flexMessage?: LineFlexMessagePayload;
   templateMessage?: LineTemplateMessagePayload;
 };
+
+export type LineOutboundMediaKind = Extract<MediaKind, "image" | "video" | "audio">;

--- a/extensions/matrix/src/matrix/send.ts
+++ b/extensions/matrix/src/matrix/send.ts
@@ -298,7 +298,7 @@ export async function sendMessageMatrix(
           buffer: media.buffer,
           contentType: media.contentType,
           fileName: media.fileName,
-          kind: media.kind ?? "unknown",
+          kind: media.kind === "sticker" ? "unknown" : (media.kind ?? "unknown"),
         });
         const baseMsgType = resolveMatrixMsgType(media.contentType, media.fileName);
         const { useVoice } = resolveMatrixVoiceDecision({

--- a/extensions/matrix/src/matrix/send/media.ts
+++ b/extensions/matrix/src/matrix/send/media.ts
@@ -1,5 +1,6 @@
 // Matrix plugin module implements media behavior.
 import { parseBuffer, type IFileInfo } from "music-metadata";
+import type { MediaKind } from "openclaw/plugin-sdk/media-runtime";
 import { getMatrixRuntime } from "../../runtime.js";
 import type {
   DimensionalFileInfo,
@@ -14,7 +15,6 @@ import type {
   MatrixMediaInfo,
   MatrixMediaMsgType,
   MatrixRelation,
-  MediaKind,
 } from "./types.js";
 
 const getCore = () => getMatrixRuntime();
@@ -162,7 +162,7 @@ export async function resolveMediaDurationMs(params: {
   buffer: Buffer;
   contentType?: string;
   fileName?: string;
-  kind: MediaKind;
+  kind: Exclude<MediaKind, "sticker">;
 }): Promise<number | undefined> {
   if (params.kind !== "audio" && params.kind !== "video") {
     return undefined;

--- a/extensions/matrix/src/matrix/send/types.ts
+++ b/extensions/matrix/src/matrix/send/types.ts
@@ -114,8 +114,6 @@ export type MatrixMediaMsgType =
 
 export type MatrixTextMsgType = typeof MsgType.Text | typeof MsgType.Notice;
 
-export type MediaKind = "image" | "audio" | "video" | "document" | "unknown";
-
 export type MatrixFormattedContent = MessageEventContent & {
   format?: string;
   formatted_body?: string;

--- a/extensions/mattermost/src/mattermost/monitor-resources.ts
+++ b/extensions/mattermost/src/mattermost/monitor-resources.ts
@@ -8,6 +8,7 @@ import {
   type MediaPlaceholderTextFact,
 } from "openclaw/plugin-sdk/channel-inbound";
 import { pruneMapToMaxSize } from "openclaw/plugin-sdk/collection-runtime";
+import type { MediaKind } from "openclaw/plugin-sdk/media-runtime";
 import {
   asDateTimestampMs,
   resolveExpiresAtMsFromDurationMs,
@@ -25,13 +26,7 @@ import {
 } from "./client.js";
 import { buildButtonProps, type MattermostInteractionResponse } from "./interactions.js";
 
-type MattermostMediaKind = "image" | "audio" | "video" | "document" | "unknown";
-
-type MattermostMediaInfo = {
-  path?: string;
-  contentType?: string;
-  kind: MattermostMediaKind;
-};
+type MattermostMediaInfo = Omit<MediaPlaceholderTextFact, "kind" | "url"> & { kind: MediaKind };
 
 export function buildMattermostInboundMediaPayload(
   media: readonly MattermostMediaInfo[],
@@ -88,7 +83,7 @@ export function createMattermostMonitorResources(params: {
   logger: { debug?: (...args: unknown[]) => void };
   mediaMaxBytes: number;
   saveRemoteMedia: SaveRemoteMedia;
-  mediaKindFromMime: (contentType?: string) => MattermostMediaKind | null | undefined;
+  mediaKindFromMime: (contentType?: string) => MediaKind | null | undefined;
 }) {
   const {
     accountId,

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -142,8 +142,6 @@ type MonitorMattermostOpts = {
   webSocketFactory?: MattermostWebSocketFactory;
 };
 
-type MediaKind = "image" | "audio" | "video" | "document" | "unknown";
-
 type MattermostReaction = {
   user_id?: string;
   post_id?: string;
@@ -586,7 +584,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
     },
     mediaMaxBytes,
     saveRemoteMedia: (params) => core.channel.media.saveRemoteMedia(params),
-    mediaKindFromMime: (contentType) => core.media.mediaKindFromMime(contentType) as MediaKind,
+    mediaKindFromMime: (contentType) => core.media.mediaKindFromMime(contentType),
   });
 
   const runModelPickerCommand = async (params: {

--- a/extensions/msteams/src/attachments/download.ts
+++ b/extensions/msteams/src/attachments/download.ts
@@ -38,7 +38,7 @@ import type {
 type DownloadCandidate =
   | {
       kind: "remote";
-      mediaKind: "image" | "document";
+      mediaKind: MSTeamsInboundMedia["kind"];
       url: string;
       fileHint?: string;
       contentTypeHint?: string;
@@ -51,7 +51,7 @@ type DownloadCandidate =
       contentType?: string;
       sourceId?: string;
     }
-  | { kind: "unavailable"; mediaKind: "image" | "document"; sourceId?: string };
+  | { kind: "unavailable"; mediaKind: MSTeamsInboundMedia["kind"]; sourceId?: string };
 
 function withSourceId(
   media: MSTeamsInboundMedia,

--- a/extensions/msteams/src/attachments/shared.ts
+++ b/extensions/msteams/src/attachments/shared.ts
@@ -16,7 +16,7 @@ import {
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { MSTEAMS_REQUEST_TIMEOUT_MS } from "../request-timeout.js";
 import { responseWithRelease } from "../response-with-release.js";
-import type { MSTeamsAttachmentLike } from "./types.js";
+import type { MSTeamsAttachmentLike, MSTeamsInboundMedia } from "./types.js";
 
 type InlineImageCandidate =
   | {
@@ -236,7 +236,7 @@ export function resolveMSTeamsMediaKind(params: {
   contentType?: string;
   fileName?: string;
   fileType?: string;
-}): "image" | "document" {
+}): MSTeamsInboundMedia["kind"] {
   const mime = normalizeLowercaseStringOrEmpty(params.contentType ?? "");
   const name = normalizeLowercaseStringOrEmpty(params.fileName ?? "");
   const fileType = normalizeLowercaseStringOrEmpty(params.fileType ?? "");

--- a/extensions/msteams/src/attachments/types.ts
+++ b/extensions/msteams/src/attachments/types.ts
@@ -15,7 +15,7 @@ export type MSTeamsAccessTokenProvider = {
 export type MSTeamsInboundMedia = {
   path?: string;
   contentType?: string;
-  kind: "image" | "document";
+  kind: Extract<import("openclaw/plugin-sdk/media-runtime").MediaKind, "image" | "document">;
   /** Transport resource identity used only to align fallback downloads. */
   sourceId?: string;
 };

--- a/extensions/openai/video-generation-provider.ts
+++ b/extensions/openai/video-generation-provider.ts
@@ -1,6 +1,6 @@
 // Openai provider module implements model/runtime integration.
 import { toImageDataUrl } from "openclaw/plugin-sdk/image-generation";
-import { extensionForMime } from "openclaw/plugin-sdk/media-mime";
+import { extensionForMime, type MediaKind } from "openclaw/plugin-sdk/media-mime";
 import { isProviderApiKeyConfigured } from "openclaw/plugin-sdk/provider-auth";
 import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
 import {
@@ -45,7 +45,7 @@ type OpenAIVideoRequestPolicy = {
 type OpenAIVideoStatus = "queued" | "in_progress" | "completed" | "failed";
 
 type OpenAIReferenceAsset = {
-  kind: "image" | "video";
+  kind: Extract<MediaKind, "image" | "video">;
   file: File;
   buffer: Buffer;
   mimeType: string;

--- a/extensions/qqbot/src/engine/messaging/outbound-media-send.ts
+++ b/extensions/qqbot/src/engine/messaging/outbound-media-send.ts
@@ -5,7 +5,7 @@
 import { randomUUID } from "node:crypto";
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
-import { extensionForMime } from "openclaw/plugin-sdk/media-mime";
+import { extensionForMime, type MediaKind } from "openclaw/plugin-sdk/media-mime";
 import { loadOutboundMediaFromUrl } from "openclaw/plugin-sdk/outbound-media";
 import {
   pathExistsSync,
@@ -206,7 +206,7 @@ function mediaFileTypeForKind(mediaKind: QQBotMediaKind): MediaFileType {
 
 function senderKindForLoadedMedia(
   mediaKind: QQBotMediaKind,
-  loadedKind: "image" | "audio" | "video" | "document" | undefined,
+  loadedKind: MediaKind | undefined,
 ): "image" | "video" | "file" | null {
   if (mediaKind === "image") {
     return loadedKind === "image" ? "image" : null;

--- a/extensions/telegram/src/bot-handlers.message.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.message.runtime.ts
@@ -339,10 +339,14 @@ export function createTelegramHandlerMessageRuntime({
         const promptMediaPath = entry.mediaPath
           ? resolveTelegramPromptMediaPath(entry.mediaPath)
           : undefined;
+        // A stored "unknown" must not preempt MIME inference; only after both
+        // fail does the document fallback apply, else images relabel as documents.
+        const storedKind = entry.mediaKind === "unknown" ? undefined : entry.mediaKind;
+        const mediaKind = storedKind ?? kindFromMime(entry.mediaType) ?? "document";
         if (entry.messageId && entry.mediaPath && promptMediaPath) {
           promptContextMediaByMessageId.set(entry.messageId, {
             path: promptMediaPath,
-            kind: entry.mediaKind ?? kindFromMime(entry.mediaType) ?? "document",
+            kind: mediaKind === "unknown" ? "document" : mediaKind,
             ...(entry.mediaType ? { contentType: entry.mediaType } : {}),
           });
         }

--- a/extensions/telegram/src/bot-handlers.message.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.message.runtime.ts
@@ -343,7 +343,8 @@ export function createTelegramHandlerMessageRuntime({
         // collapses an "unknown" inference to document for this deliverable-only surface.
         const inferredKind = kindFromMime(entry.mediaType);
         const mediaKind =
-          entry.mediaKind ?? (inferredKind && inferredKind !== "unknown" ? inferredKind : "document");
+          entry.mediaKind ??
+          (inferredKind && inferredKind !== "unknown" ? inferredKind : "document");
         if (entry.messageId && entry.mediaPath && promptMediaPath) {
           promptContextMediaByMessageId.set(entry.messageId, {
             path: promptMediaPath,

--- a/extensions/telegram/src/bot-handlers.message.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.message.runtime.ts
@@ -339,14 +339,15 @@ export function createTelegramHandlerMessageRuntime({
         const promptMediaPath = entry.mediaPath
           ? resolveTelegramPromptMediaPath(entry.mediaPath)
           : undefined;
-        // A stored "unknown" must not preempt MIME inference; only after both
-        // fail does the document fallback apply, else images relabel as documents.
-        const storedKind = entry.mediaKind === "unknown" ? undefined : entry.mediaKind;
-        const mediaKind = storedKind ?? kindFromMime(entry.mediaType) ?? "document";
+        // Stored kinds are typed non-unknown; MIME inference fills gaps and
+        // collapses an "unknown" inference to document for this deliverable-only surface.
+        const inferredKind = kindFromMime(entry.mediaType);
+        const mediaKind =
+          entry.mediaKind ?? (inferredKind && inferredKind !== "unknown" ? inferredKind : "document");
         if (entry.messageId && entry.mediaPath && promptMediaPath) {
           promptContextMediaByMessageId.set(entry.messageId, {
             path: promptMediaPath,
-            kind: mediaKind === "unknown" ? "document" : mediaKind,
+            kind: mediaKind,
             ...(entry.mediaType ? { contentType: entry.mediaType } : {}),
           });
         }

--- a/extensions/vydra/shared.ts
+++ b/extensions/vydra/shared.ts
@@ -1,6 +1,6 @@
 // Vydra plugin module implements shared behavior.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { extensionForMime } from "openclaw/plugin-sdk/media-mime";
+import { extensionForMime, type MediaKind } from "openclaw/plugin-sdk/media-mime";
 import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
 import {
   assertOkOrThrowHttpError,
@@ -31,7 +31,7 @@ const POLL_INTERVAL_MS = 2_500;
 const MAX_POLL_ATTEMPTS = 120;
 type VydraAuthStore = Parameters<typeof resolveApiKeyForProvider>[0]["store"];
 
-type VydraMediaKind = "audio" | "image" | "video";
+type VydraMediaKind = Extract<MediaKind, "audio" | "image" | "video">;
 
 type VydraJobPayload = {
   id?: string;

--- a/extensions/whatsapp/src/outbound-media-contract.ts
+++ b/extensions/whatsapp/src/outbound-media-contract.ts
@@ -2,6 +2,7 @@
 import path from "node:path";
 import { sanitizeForPlainText } from "openclaw/plugin-sdk/channel-outbound";
 import { mediaKindFromMime, normalizeMimeType } from "openclaw/plugin-sdk/media-mime";
+import type { MediaKind } from "openclaw/plugin-sdk/media-mime";
 import {
   MEDIA_FFMPEG_MAX_AUDIO_DURATION_SECS,
   transcodeAudioBufferToOpus,
@@ -46,7 +47,7 @@ export type DeliverableWhatsAppOutboundPayload<T extends WhatsAppOutboundPayload
 
 type CanonicalWhatsAppLoadedMedia = {
   buffer: Buffer;
-  kind: "image" | "audio" | "video" | "document";
+  kind: Exclude<MediaKind, "sticker" | "unknown">;
   mimetype: string;
   fileName?: string;
 };
@@ -116,7 +117,7 @@ export function normalizeWhatsAppOutboundPayload<T extends WhatsAppOutboundPaylo
 
 function inferWhatsAppMediaKind(
   media: WhatsAppLoadedMediaLike,
-): "image" | "audio" | "video" | "document" {
+): CanonicalWhatsAppLoadedMedia["kind"] {
   if (
     media.kind === "image" ||
     media.kind === "audio" ||
@@ -125,7 +126,10 @@ function inferWhatsAppMediaKind(
   ) {
     return media.kind;
   }
-  return mediaKindFromMime(normalizeMimeType(media.contentType)) ?? "document";
+  const inferredKind = mediaKindFromMime(normalizeMimeType(media.contentType));
+  return !inferredKind || inferredKind === "sticker" || inferredKind === "unknown"
+    ? "document"
+    : inferredKind;
 }
 
 function normalizeWhatsAppLoadedMedia(

--- a/extensions/whatsapp/src/send.ts
+++ b/extensions/whatsapp/src/send.ts
@@ -30,11 +30,11 @@ import { markdownToWhatsApp, toWhatsappJid } from "./text-runtime.js";
 
 const outboundLog = createSubsystemLogger("gateway/channels/whatsapp").child("outbound");
 
-function supportsForcedDocumentDelivery(kind: "image" | "audio" | "video" | "document"): boolean {
+type PreparedWhatsAppOutboundMedia = Awaited<ReturnType<typeof prepareWhatsAppOutboundMedia>>;
+
+function supportsForcedDocumentDelivery(kind: PreparedWhatsAppOutboundMedia["kind"]): boolean {
   return kind === "image" || kind === "video";
 }
-
-type PreparedWhatsAppOutboundMedia = Awaited<ReturnType<typeof prepareWhatsAppOutboundMedia>>;
 
 type WhatsAppMediaSendState = {
   mediaBuffer: Buffer;
@@ -135,7 +135,7 @@ export async function sendMessageWhatsApp(
     mediaPayload?: {
       buffer: Buffer;
       contentType?: string;
-      kind?: "image" | "audio" | "video" | "document";
+      kind?: PreparedWhatsAppOutboundMedia["kind"];
       fileName?: string;
     };
     gifPlayback?: boolean;

--- a/packages/media-core/src/constants.ts
+++ b/packages/media-core/src/constants.ts
@@ -7,8 +7,8 @@ export const MAX_VIDEO_BYTES = 16 * 1024 * 1024; // 16MB
 /** Default outbound document payload cap shared by media loaders and adapters. */
 export const MAX_DOCUMENT_BYTES = 100 * 1024 * 1024; // 100MB
 
-/** Media families that share size-policy and MIME-classification behavior. */
-export type MediaKind = "image" | "audio" | "video" | "document";
+/** Canonical media families used by attachment facts, routing, and MIME classification. */
+export type MediaKind = "image" | "audio" | "video" | "document" | "sticker" | "unknown";
 
 /** Maps a MIME type to the media family used for size limits and routing. */
 export function mediaKindFromMime(mime?: string | null): MediaKind | undefined {

--- a/src/auto-reply/reply/history.types.ts
+++ b/src/auto-reply/reply/history.types.ts
@@ -12,6 +12,6 @@ export type HistoryMediaEntry = {
   path?: string;
   url?: string;
   contentType?: string;
-  kind?: "image" | "video" | "audio" | "document" | "sticker" | "unknown";
+  kind?: import("@openclaw/media-core/constants").MediaKind;
   messageId?: string;
 };

--- a/src/channels/inbound-event/media.ts
+++ b/src/channels/inbound-event/media.ts
@@ -24,18 +24,19 @@ export type MediaPlaceholderTextFact = Readonly<
   Pick<ChannelInboundMediaInput, "contentType" | "kind" | "path" | "url">
 >;
 
-type MediaPlaceholderKind = "attachment" | "audio" | "document" | "image" | "sticker" | "video";
+type MediaPlaceholderKind =
+  | Exclude<NonNullable<InboundMediaFacts["kind"]>, "unknown">
+  | "attachment";
 
 function resolveMediaPlaceholderKind(media: MediaPlaceholderTextFact): MediaPlaceholderKind {
   if (media.kind && media.kind !== "unknown") {
     return media.kind;
   }
-  return (
+  const inferredKind =
     kindFromMime(media.contentType) ??
     kindFromMime(mimeTypeFromFilePath(media.url)) ??
-    kindFromMime(mimeTypeFromFilePath(media.path)) ??
-    "attachment"
-  );
+    kindFromMime(mimeTypeFromFilePath(media.path));
+  return inferredKind && inferredKind !== "unknown" ? inferredKind : "attachment";
 }
 
 const PLURAL_MEDIA_PLACEHOLDER_LABELS: Readonly<Record<MediaPlaceholderKind, string>> = {

--- a/src/channels/turn/types.ts
+++ b/src/channels/turn/types.ts
@@ -1,3 +1,4 @@
+import type { MediaKind } from "@openclaw/media-core/constants";
 import type { CommandTurnKind } from "../../auto-reply/command-turn-context.js";
 import type {
   GetReplyOptions,
@@ -138,7 +139,7 @@ export type InboundMediaFacts = {
   path?: string;
   url?: string;
   contentType?: string;
-  kind?: "image" | "video" | "audio" | "document" | "sticker" | "unknown";
+  kind?: MediaKind;
   transcribed?: boolean;
   messageId?: string;
 };

--- a/src/media-understanding/attachments.normalize.ts
+++ b/src/media-understanding/attachments.normalize.ts
@@ -1,5 +1,6 @@
 // Attachment normalization converts message context media fields into typed
 // attachment records and classifies media kind from MIME or filename.
+import type { MediaKind } from "@openclaw/media-core/constants";
 import { getFileExtension, isAudioFileName, kindFromMime } from "@openclaw/media-core/mime";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { MsgContext } from "../auto-reply/templating.js";
@@ -91,9 +92,7 @@ export function normalizeAttachments(ctx: MsgContext): MediaAttachment[] {
 }
 
 /** Classifies an attachment by MIME first, then by filename/URL extension fallback. */
-export function resolveAttachmentKind(
-  attachment: MediaAttachment,
-): "image" | "audio" | "video" | "document" | "unknown" {
+export function resolveAttachmentKind(attachment: MediaAttachment): Exclude<MediaKind, "sticker"> {
   const kind = kindFromMime(attachment.mime);
   if (kind === "image" || kind === "audio" || kind === "video") {
     return kind;

--- a/ui/src/lib/chat/chat-types.ts
+++ b/ui/src/lib/chat/chat-types.ts
@@ -2,6 +2,7 @@
  * Chat message types for the UI layer.
  */
 
+import type { MediaKind } from "@openclaw/media-core/constants";
 import type { SenderIdentity } from "./sender-label.ts";
 
 export type ChatAttachment = {
@@ -111,7 +112,7 @@ export type MessageContentItem =
       type: "attachment";
       attachment: {
         url: string;
-        kind: "image" | "audio" | "video" | "document";
+        kind: Exclude<MediaKind, "sticker" | "unknown">;
         label: string;
         mimeType?: string;
         isVoiceNote?: boolean;

--- a/ui/src/lib/chat/message-normalizer.ts
+++ b/ui/src/lib/chat/message-normalizer.ts
@@ -217,12 +217,16 @@ function mimeTypeFromUrl(url: string): string | undefined {
 }
 
 function inferAttachmentKind(url: string): {
-  kind: "image" | "audio" | "video" | "document";
+  kind: Extract<MessageContentItem, { type: "attachment" }>["attachment"]["kind"];
   mimeType?: string;
   label: string;
 } {
   const mimeType = mimeTypeFromUrl(url);
-  const kind = mediaKindFromMime(mimeType) ?? "document";
+  const inferredKind = mediaKindFromMime(mimeType);
+  const kind =
+    !inferredKind || inferredKind === "sticker" || inferredKind === "unknown"
+      ? "document"
+      : inferredKind;
   const label = (() => {
     try {
       if (/^https?:\/\//i.test(url)) {

--- a/ui/src/pages/chat/components/chat-message.ts
+++ b/ui/src/pages/chat/components/chat-message.ts
@@ -1955,7 +1955,7 @@ function resolveAssistantAttachmentAvailability(
 }
 
 function renderAssistantAttachmentStatusCard(params: {
-  kind: "image" | "audio" | "video" | "document";
+  kind: AttachmentItem["attachment"]["kind"];
   label: string;
   badge: string;
   reason?: string;

--- a/ui/src/pages/chat/user-message-content.ts
+++ b/ui/src/pages/chat/user-message-content.ts
@@ -1,4 +1,5 @@
 // Control UI chat module implements user message content behavior.
+import type { MediaKind } from "@openclaw/media-core/constants";
 import type { ChatAttachment } from "../../lib/chat/chat-types.ts";
 import { getChatAttachmentPreviewUrl } from "./attachment-payload-store.ts";
 
@@ -9,7 +10,7 @@ type UserChatMessageContentBlock = {
   source?: unknown;
   attachment?: {
     url: string;
-    kind: "audio" | "document";
+    kind: Extract<MediaKind, "audio" | "document">;
     label: string;
     mimeType?: string;
   };


### PR DESCRIPTION
## What Problem This Solves

Follow-up to the media-placeholder program (#111315→#111891). ~40 sites defined or referenced parallel media-kind unions (`InboundMediaFacts.kind`, the formatter's `MediaPlaceholderKind`, history kinds, Mattermost's and Discord's locals). The program hit "this kind isn't in that union" drift twice (sticker in batch 2, gif in batch 3); every new kind required touching several declarations in lockstep.

## Why This Change Was Made

One canonical `MediaKind` union now lives in media-core's constants (already consumed by core and plugins through existing subpaths — no new SDK exports or budget changes). Channel-specific narrower contracts derive via `Extract`/`Exclude`, so a channel supporting fewer kinds states that as a relationship instead of a copy. The formatter keeps its rendering-only `attachment` member local. Runtime literals are unchanged; the few runtime guards added correctly keep `unknown`/`sticker` off surfaces that only handle deliverable kinds. Includes a review-caught fallback fix: a stored `"unknown"` reply-chain kind short-circuited MIME inference and relabeled images as documents in Telegram reply-context media — `unknown` now defers to MIME before the document fallback.

## User Impact

None intended beyond the Telegram reply-context relabel fix; this is type-level unification that makes future kind additions single-site.

## Evidence

- 492 focused tests green during implementation plus post-fix reruns (media-carriers 8/8 covering the reply-kind path) via `node scripts/run-vitest.mjs`.
- Remote `check:changed` exit 0 on Blacksmith Testbox (run 29799763378).
- oxlint + `git diff --check` clean; net −5 LOC.
- One MSTeams helper mismatch encountered during proof was demonstrated pre-existing on the unchanged baseline (documented in the report).
- Autoreview: first pass found the Telegram fallback P2 (accepted, fixed, suite-verified); final pass clean, "patch is correct (0.91)".
