### PR TITLE
fix(ui): dismiss pinned message metadata popovers

### DIFF
--- a/ui/src/pages/chat/chat-pane.ts
+++ b/ui/src/pages/chat/chat-pane.ts
@@ -324,7 +324,7 @@ type ChatPaneConnectionScope = {
   sessions: ChatPageContext["sessions"];
 };
 const CHAT_OPEN_DETAILS_SELECTOR =
-  ".chat-controls__inline-select[open], .context-usage details[open], .agent-chat__attach-menu[open], .chat-pr__checks[open]";
+  ".chat-controls__inline-select[open], .context-usage details[open], .agent-chat__attach-menu[open], .chat-pr__checks[open], details.msg-meta[open]:not([data-preview])";
 const CHAT_COMPOSER_TEXTAREA_SELECTOR = ".agent-chat__composer-combobox > textarea";
 const CHAT_TEXT_ENTRY_SELECTOR =
   "input, textarea, select, [contenteditable]:not([contenteditable='false']), [role='combobox'], [role='listbox'], [role='textbox']";

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -616,7 +616,7 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
   });
 
   it(
-    "reveals message context on timestamp hover and keeps click-to-open",
+    "reveals, pins, and dismisses message context from the timestamp",
     FULL_APP_TEST_OPTIONS,
     async () => {
       if (!realChatServer) {
@@ -683,11 +683,26 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
         await context.waitFor({ state: "hidden", timeout: 10_000 });
 
         await page.locator(".chat-text").first().hover();
+        await page.locator(".msg-meta__summary").hover();
+        // Escape only owns pinned disclosures; it must not corrupt an active
+        // hover preview before the click converts that preview into a pin.
+        await page.keyboard.press("Escape");
         await page.locator(".msg-meta__summary").click();
         await page.mouse.move(0, 0);
         // Click-to-open must survive the pointer leaving the message group.
         await context.waitFor({ state: "visible", timeout: 10_000 });
         expect(await details.getAttribute("open")).toBe("");
+
+        await page.mouse.click(0, 0);
+        await context.waitFor({ state: "hidden", timeout: 10_000 });
+        expect(await details.getAttribute("open")).toBeNull();
+
+        await page.locator(".chat-text").first().hover();
+        await page.locator(".msg-meta__summary").click();
+        await context.waitFor({ state: "visible", timeout: 10_000 });
+        await page.keyboard.press("Escape");
+        await context.waitFor({ state: "hidden", timeout: 10_000 });
+        expect(await details.getAttribute("open")).toBeNull();
       } finally {
         await closeBrowserPage(page);
       }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users who clicked a chat message timestamp to pin its metadata popover could not dismiss that popover by clicking elsewhere or pressing Escape.

## Why This Change Was Made

The pinned message metadata disclosure now participates in the chat pane's existing lifecycle-owned outside-pointer and Escape dismissal handling. Hover previews remain owned by their pointer/focus lifecycle, so Escape during a hover preview cannot corrupt the subsequent click-to-pin interaction.

## User Impact

Pinned timestamp metadata popovers now behave like the other chat disclosures: users can dismiss them naturally with an outside pointer interaction or Escape without losing hover preview or click-to-pin behavior.

AI-assisted change; the implementation and test behavior were reviewed and validated before submission.

## Evidence

- `node scripts/run-vitest.mjs ui/src/pages/chat/chat-responsive.browser.test.ts -t "reveals, pins, and dismisses message context from the timestamp"` — 1 passed, 61 skipped.
- `node scripts/run-vitest.mjs ui/src/pages/chat/components/chat-message.test.ts -t "previews message context from the timestamp and pins it on click"` — 1 passed, 112 skipped.
- Source-blind Chromium behavior validation passed hover preview, hover leave, hover-to-pin after Escape, pinned pointer-leave persistence, outside-pointer dismissal, and pinned Escape dismissal.
- `node scripts/check-changed.mjs -- ui/src/pages/chat/chat-pane.ts ui/src/pages/chat/chat-responsive.browser.test.ts` — passed formatting, Control UI i18n verification, core-test/UI typechecks, dependency guards, and targeted lint on Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/29800996190
- Codex autoreview: clean, with no accepted/actionable findings (`gpt-5.6-sol`, high reasoning).
