### PR TITLE
fix(ui): dismiss new-session model picker with Escape

### DIFF
--- a/ui/src/e2e/new-session-page.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.e2e.test.ts
@@ -525,6 +525,10 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
         await page.locator('.new-session-page__triggers [data-chat-model-select="true"]').count(),
       ).toBe(0);
       await modelSelect.click();
+      const pickerOpen = () =>
+        modelSelect.evaluate(
+          (element) => element.closest("details")?.hasAttribute("open") ?? false,
+        );
       const modelTriggerBox = await modelSelect.boundingBox();
       const modelMenuBox = await page
         .locator(".chat-controls__inline-select-menu--combined")
@@ -537,11 +541,16 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
         0,
       );
       await page.locator('[data-chat-model-provider="anthropic"]').click();
+      await expect.poll(pickerOpen).toBe(true);
       await page.locator('[data-chat-model-option="anthropic/claude-sonnet-4-6"]').click();
-      const pickerOpen = () =>
-        modelSelect.evaluate(
-          (element) => element.closest("details")?.hasAttribute("open") ?? false,
-        );
+      // Inside changes stay grouped; only explicit light-dismissal closes the picker.
+      await expect.poll(pickerOpen).toBe(true);
+      await page.keyboard.press("Escape");
+      await expect.poll(pickerOpen).toBe(false);
+      await expect
+        .poll(() => modelSelect.evaluate((element) => element === document.activeElement))
+        .toBe(true);
+      await modelSelect.click();
       await expect.poll(pickerOpen).toBe(true);
       await page.mouse.click(8, 8);
       await expect.poll(pickerOpen).toBe(false);

--- a/ui/src/pages/new-session/new-session-page.ts
+++ b/ui/src/pages/new-session/new-session-page.ts
@@ -292,17 +292,38 @@ class NewSessionPage extends OpenClawLightDomElement {
 
   handleEvent(event: Event) {
     const picker = this.querySelector<HTMLDetailsElement>(".chat-controls__model[open]");
-    if (picker && !event.composedPath().includes(picker)) {
+    if (!picker) {
+      return;
+    }
+    if (event.type === "keydown") {
+      const keyEvent = event as KeyboardEvent;
+      if (keyEvent.defaultPrevented || keyEvent.key !== "Escape") {
+        return;
+      }
+      const restoreFocus = event.composedPath().includes(picker);
+      keyEvent.preventDefault();
+      picker.open = false;
+      // Closing details does not move focus out of its now-hidden controls.
+      if (restoreFocus) {
+        picker.querySelector<HTMLElement>("summary")?.focus();
+      }
+      return;
+    }
+    if (!event.composedPath().includes(picker)) {
       picker.open = false;
     }
   }
 
   override connectedCallback() {
     super.connectedCallback();
+    // /new renders chat controls without ChatPane, so the route owns both
+    // pointer and Escape light-dismissal for the combined picker.
+    document.addEventListener("keydown", this, true);
     document.addEventListener("pointerdown", this, true);
   }
 
   override disconnectedCallback() {
+    document.removeEventListener("keydown", this, true);
     document.removeEventListener("pointerdown", this, true);
     this.subscriptions.clear();
     // This invalidates submitRequestToken before payload release below, so a


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening the combined model and reasoning picker on `/new` could not dismiss it with Escape. The equivalent picker in an active chat already supported Escape dismissal, while the new-session route left the menu expanded.

## Why This Change Was Made

`NewSessionPage` now owns Escape dismissal alongside its existing outside-pointer listener because `/new` renders the shared chat controls without `ChatPane`. Inside provider, model, and reasoning interactions continue to keep the picker open, while Escape closes it and restores focus to the trigger for predictable keyboard navigation.

## User Impact

Users can dismiss the model and reasoning picker on `/new` with Escape, continue keyboard navigation from the trigger, and still adjust multiple settings without the picker closing between changes.

AI-assisted: yes. The implementation was manually reviewed, source-aware autoreview findings were addressed, and the final behavior was validated independently through the running UI.

## Evidence

- Before/after behavior: Escape previously left `.chat-controls__model[open]` expanded; it now closes the picker and returns focus to the combined trigger. This changes interaction behavior only, with no visual styling or layout change.
- Source-blind Chromium validation covered provider/model/reasoning changes, ArrowRight versus Escape, inside versus outside clicks, focus restoration, and Enter reopening the focused trigger: https://github.com/openclaw/openclaw/actions/runs/29800526414
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/new-session-page.e2e.test.ts` — 29 tests passed.
- `pnpm ui:build` — passed; startup JavaScript remained at 12 requests and 302.5 KiB gzip against limits of 18 requests and 314.0 KiB.
- `pnpm check:changed -- ui/src/pages/new-session/new-session-page.ts ui/src/e2e/new-session-page.e2e.test.ts` — formatting, i18n verification, TypeScript checks, and lint passed.
- Final `autoreview --mode uncommitted` — no accepted or actionable findings.
