### PR TITLE
feat(ui): expand the lobster pet's random universe

### DIFF
--- a/ui/src/components/lobster-dex.test.ts
+++ b/ui/src/components/lobster-dex.test.ts
@@ -47,13 +47,29 @@ describe("lobsterdex", () => {
   it("migrates v1 array entries and backfills memories on the next visit", () => {
     localStorage.setItem("openclaw.control.lobsterdex.v1", JSON.stringify(["crimson"]));
     const migrated = getLobsterdexEntries().get("crimson");
-    expect(migrated).toEqual({ firstSeenAt: null, name: null });
+    expect(migrated).toEqual({ firstSeenAt: null, name: null, shinySeenAt: null });
     expect(getLobsterdex().has("crimson")).toBe(true);
 
     recordLobsterVisit("crimson", { name: "Pinchy" });
     const backfilled = getLobsterdexEntries().get("crimson");
     expect(backfilled?.name).toBe("Pinchy");
     expect(backfilled?.firstSeenAt).not.toBeNull();
+  });
+
+  it("logs the first shiny sighting once, even on settled entries", () => {
+    recordLobsterVisit("gold", { name: "Goldie" });
+    expect(getLobsterdexEntries().get("gold")?.shinySeenAt).toBeNull();
+
+    const before = Date.now();
+    recordLobsterVisit("gold", { name: "Impostor", shiny: true });
+    const shinySeenAt = getLobsterdexEntries().get("gold")?.shinySeenAt;
+    expect(shinySeenAt).toBeGreaterThanOrEqual(before);
+    // The shiny backfill leaves the first-visitor memory untouched...
+    expect(getLobsterdexEntries().get("gold")?.name).toBe("Goldie");
+
+    // ...and the sighting timestamp itself is immutable afterwards.
+    recordLobsterVisit("gold", { shiny: true });
+    expect(getLobsterdexEntries().get("gold")?.shinySeenAt).toBe(shinySeenAt);
   });
 
   it("tolerates corrupt storage", () => {

--- a/ui/src/components/lobster-dex.ts
+++ b/ui/src/components/lobster-dex.ts
@@ -12,9 +12,11 @@ const FAMILIARITY_KEY = "openclaw.control.lobsterpet.familiarity.v1";
 type LobsterdexEntry = {
   firstSeenAt: number | null;
   name: string | null;
+  // When a shiny of this palette first sparkled by; null until one does.
+  shinySeenAt: number | null;
 };
 
-type PersistedDex = Record<string, { firstSeenAt?: number; name?: string }>;
+type PersistedDex = Record<string, { firstSeenAt?: number; name?: string; shinySeenAt?: number }>;
 
 function readDex(): Map<string, LobsterdexEntry> {
   try {
@@ -25,7 +27,7 @@ function readDex(): Map<string, LobsterdexEntry> {
       // v1 stored a bare palette-id array; carry ids over without memories.
       for (const value of parsed) {
         if (typeof value === "string" && value) {
-          entries.set(value, { firstSeenAt: null, name: null });
+          entries.set(value, { firstSeenAt: null, name: null, shinySeenAt: null });
         }
       }
       return entries;
@@ -38,6 +40,7 @@ function readDex(): Map<string, LobsterdexEntry> {
         entries.set(id, {
           firstSeenAt: typeof value?.firstSeenAt === "number" ? value.firstSeenAt : null,
           name: typeof value?.name === "string" && value.name ? value.name : null,
+          shinySeenAt: typeof value?.shinySeenAt === "number" ? value.shinySeenAt : null,
         });
       }
     }
@@ -53,6 +56,7 @@ function writeDex(entries: Map<string, LobsterdexEntry>): void {
     persisted[id] = {
       ...(entry.firstSeenAt !== null ? { firstSeenAt: entry.firstSeenAt } : {}),
       ...(entry.name !== null ? { name: entry.name } : {}),
+      ...(entry.shinySeenAt !== null ? { shinySeenAt: entry.shinySeenAt } : {}),
     };
   }
   getSafeLocalStorage()?.setItem(LOBSTERDEX_KEY, JSON.stringify(persisted));
@@ -66,22 +70,31 @@ export function getLobsterdexEntries(): ReadonlyMap<string, LobsterdexEntry> {
   return readDex();
 }
 
-export function recordLobsterVisit(paletteId: string, details: { name?: string } = {}): void {
+export function recordLobsterVisit(
+  paletteId: string,
+  details: { name?: string; shiny?: boolean } = {},
+): void {
   try {
     const entries = readDex();
     const existing = entries.get(paletteId);
     if (existing) {
       // First-visitor memories are immutable; later visits only backfill
-      // fields the v1 schema never had.
-      if (existing.firstSeenAt !== null && existing.name !== null) {
+      // fields older schemas never had (and the first shiny sighting).
+      const shinyNews = details.shiny === true && existing.shinySeenAt === null;
+      if (existing.firstSeenAt !== null && existing.name !== null && !shinyNews) {
         return;
       }
       entries.set(paletteId, {
         firstSeenAt: existing.firstSeenAt ?? Date.now(),
         name: existing.name ?? details.name ?? null,
+        shinySeenAt: existing.shinySeenAt ?? (details.shiny === true ? Date.now() : null),
       });
     } else {
-      entries.set(paletteId, { firstSeenAt: Date.now(), name: details.name ?? null });
+      entries.set(paletteId, {
+        firstSeenAt: Date.now(),
+        name: details.name ?? null,
+        shinySeenAt: details.shiny === true ? Date.now() : null,
+      });
     }
     writeDex(entries);
   } catch {

--- a/ui/src/components/lobster-pet-contract.ts
+++ b/ui/src/components/lobster-pet-contract.ts
@@ -14,9 +14,19 @@ export type LobsterPetPaletteId =
   | "gold"
   | "calico"
   | "abyss"
+  | "lumen"
   | "ghost"
   | "split"
+  | "cottoncandy"
   | "retro";
+
+// Pass-through ledge visitors. Strangers are other lobsters; everyone else
+// is, at best, lobster-adjacent. None of them count for the Lobsterdex.
+export type LobsterPasserKind = "stranger" | "crab" | "snail" | "duck" | "jellyfish";
+
+// How an arriving pet gets onto the ledge. Rolled per arrival from its own
+// seeded stream; "walk" is the classic pop-up from behind the ledge.
+export type LobsterPetEntrance = "walk" | "balloon" | "bubble";
 
 export type LobsterPetPalette = {
   id: LobsterPetPaletteId;
@@ -31,7 +41,9 @@ export type LobsterPetAccessory =
   | "patch"
   | "santa"
   | "pumpkin"
-  | "party";
+  | "party"
+  | "barnacle"
+  | "monocle";
 
 export type LobsterPetAntennae = "perky" | "droopy";
 
@@ -52,6 +64,16 @@ export type LobsterPetLook = {
   build: LobsterPetBuild;
   clawSize: LobsterPetClawSize;
   tailFan: boolean;
+  // Pokemon-style shiny roll (~1 in 512): sparkles plus a saturated sheen,
+  // logged separately in the Lobsterdex.
+  shiny: boolean;
+  // Real lobsters carry a crusher and a pincer; when set, that side's claw
+  // grows mighty while the other stays dainty (overrides clawSize).
+  crusherSide: "left" | "right" | null;
+  freckles: boolean;
+  // Seeded eye-glint tint for common palettes; rare palettes keep their
+  // signature glints via CSS, and null keeps the default teal.
+  glint: string | null;
 };
 
 export type LobsterLogoVisitPhase = "in" | "leaving" | "out";

--- a/ui/src/components/lobster-pet-look.ts
+++ b/ui/src/components/lobster-pet-look.ts
@@ -2,10 +2,12 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { html, nothing, svg, type TemplateResult } from "lit";
 import { lobsterHonorific } from "./lobster-dex.ts";
 import type {
+  LobsterPasserKind,
   LobsterPetAccessory,
   LobsterPetAntennae,
   LobsterPetBuild,
   LobsterPetClawSize,
+  LobsterPetEntrance,
   LobsterPetLook,
   LobsterPetMode,
   LobsterPetPalette,
@@ -15,9 +17,10 @@ import type {
 
 // Rarity ladder loosely mirrors real lobster genetics: blue ~1 in 2 million,
 // yellow ~1 in 30 million, calico ~1 in 30 million, split two-tone ~1 in
-// 50 million, albino/ghost ~1 in 100 million. Abyss is our deep-sea fantasy.
-// Split/calico extra geometry and ghost/abyss styling key off the palette id
-// (see lobster-pet.css and renderLobsterSvg).
+// 50 million, albino/ghost ~1 in 100 million, cotton candy ~1 in 100 million.
+// Abyss and lumen are our deep-sea fantasies. Split/calico extra geometry and
+// ghost/abyss/lumen/cottoncandy styling key off the palette id (see
+// lobster-pet.css and renderLobsterSvg).
 const PALETTES: Array<[LobsterPetPalette, number]> = [
   [{ id: "crimson", shell: "#ff4f40", claw: "#ff775f" }, 26],
   [{ id: "coral", shell: "#d0836a", claw: "#de9b80" }, 26],
@@ -28,8 +31,13 @@ const PALETTES: Array<[LobsterPetPalette, number]> = [
   [{ id: "gold", shell: "#f4b840", claw: "#f9d47a" }, 5],
   [{ id: "calico", shell: "#d97a3d", claw: "#e89a63" }, 3],
   [{ id: "abyss", shell: "#2c3b68", claw: "#465b96" }, 2],
+  // Bioluminescent: photophore freckles that only really glow in the dark
+  // theme (see .lob-lumen in lobster-pet.css).
+  [{ id: "lumen", shell: "#1d2f4e", claw: "#2e4a77" }, 2],
   [{ id: "ghost", shell: "#dce8f2", claw: "#ecf3fa" }, 1],
   [{ id: "split", shell: "#ff4f40", claw: "#ff775f" }, 1],
+  // Pastel pink/blue iridescence, after the famous Maine catches.
+  [{ id: "cottoncandy", shell: "#f6a8c9", claw: "#a5c6f0" }, 0.8],
   // The grail: homage to the classic OpenClaw logo (big raised claw, smirk,
   // angry brows, white sticker outline). ~0.5% of sessions.
   [{ id: "retro", shell: "#e8262c", claw: "#f04a3e" }, 0.5],
@@ -55,6 +63,10 @@ export function canonicalLobsterLook(palette: LobsterPetPalette): LobsterPetLook
     build: "round",
     clawSize: "regular",
     tailFan: false,
+    shiny: false,
+    crusherSide: null,
+    freckles: false,
+    glint: null,
   };
 }
 
@@ -84,6 +96,10 @@ function seasonalAccessories(now: Date): Array<[LobsterPetAccessory, number]> {
   }
   if (month === 9 && day >= 20) {
     return [["pumpkin", 18]];
+  }
+  // National Lobster Day (US, Sept 25): dress fancy. We do not cook friends.
+  if (month === 8 && day === 25) {
+    return [["monocle", 24]];
   }
   return [];
 }
@@ -116,13 +132,13 @@ const CLAW_SIZES: Array<[LobsterPetClawSize, number]> = [
 // Builds reshape the whole sprite by stretching its aspect ratio (the svg
 // renders with preserveAspectRatio="none"), so eyes, claws, accessories, and
 // rare-variant geometry stay aligned for every silhouette.
-export const LOBSTER_PET_BUILD_MULS: Record<LobsterPetBuild, { w: number; h: number }> = {
+const LOBSTER_PET_BUILD_MULS: Record<LobsterPetBuild, { w: number; h: number }> = {
   round: { w: 1, h: 1 },
   squat: { w: 1.14, h: 0.9 },
   slender: { w: 0.88, h: 1.1 },
 };
 
-export const LOBSTER_PET_CLAW_MULS: Record<LobsterPetClawSize, number> = {
+const LOBSTER_PET_CLAW_MULS: Record<LobsterPetClawSize, number> = {
   dainty: 0.85,
   regular: 1,
   mighty: 1.18,
@@ -162,8 +178,10 @@ const RARE_NAMES: Partial<Record<LobsterPetPaletteId, string>> = {
   gold: "Goldie",
   calico: "Patches",
   abyss: "Lantern",
+  lumen: "Glimmer",
   ghost: "Boo",
   split: "Picasso",
+  cottoncandy: "Taffy",
   retro: "OG",
 };
 
@@ -211,6 +229,10 @@ export function randomBetween(rng: () => number, min: number, max: number): numb
   return min + rng() * (max - min);
 }
 
+// Seeded glint tints for common palettes (rare palettes pin their own via
+// CSS). Applied through --lob-glint-seed so offline grey still wins.
+const GLINT_TINTS = ["#ffd166", "#ff8ac2", "#b79bff"] as const;
+
 export function createLobsterPetLook(seed: number, now: Date = new Date()): LobsterPetLook {
   const rng = mulberry32(seed);
   const palette = pickWeighted(rng, PALETTES);
@@ -223,30 +245,22 @@ export function createLobsterPetLook(seed: number, now: Date = new Date()): Lobs
   const facing = rng() < 0.5 ? 1 : -1;
   const personality = pickWeighted(rng, PERSONALITY_IDS);
   const blinkDelayS = Math.round(randomBetween(rng, 0, 4) * 10) / 10;
-  // Shape traits roll after the original ones so pre-existing seeds keep
-  // their palette/personality and only gain a silhouette.
+  // Trait generations append their rolls (shape, then sparkle) so earlier
+  // seeds keep their palette/personality and only gain new details.
   const build = pickWeighted(rng, BUILDS);
   const clawSize = pickWeighted(rng, CLAW_SIZES);
   const tailFan = rng() < 0.3;
-  if (isLobsterAnniversary(now)) {
-    // Birthday dress code: everyone is the classic logo, party hats on.
-    const retro = PALETTES.find(([entry]) => entry.id === "retro")?.[0];
-    return {
-      palette: retro ?? palette,
-      scale,
-      accessory: "party",
-      antennae,
-      side,
-      spotPct,
-      facing,
-      personality,
-      blinkDelayS,
-      build,
-      clawSize,
-      tailFan,
-    };
-  }
-  return {
+  const shiny = rng() < 1 / 512;
+  // Chance-and-pick pairs always burn both rolls so later traits stay
+  // aligned across seeds whichever way the chance lands.
+  const crusherRoll = rng();
+  const crusherPick: "left" | "right" = rng() < 0.5 ? "left" : "right";
+  const crusherSide = crusherRoll < 0.15 ? crusherPick : null;
+  const freckles = rng() < 0.12;
+  const glintRoll = rng();
+  const glintPick = GLINT_TINTS[Math.floor(rng() * GLINT_TINTS.length)] ?? null;
+  const glint = glintRoll < 0.3 ? glintPick : null;
+  const look: LobsterPetLook = {
     palette,
     scale,
     accessory,
@@ -259,7 +273,17 @@ export function createLobsterPetLook(seed: number, now: Date = new Date()): Lobs
     build,
     clawSize,
     tailFan,
+    shiny,
+    crusherSide,
+    freckles,
+    glint,
   };
+  if (isLobsterAnniversary(now)) {
+    // Birthday dress code: everyone is the classic logo, party hats on.
+    const retro = PALETTES.find(([entry]) => entry.id === "retro")?.[0];
+    return { ...look, palette: retro ?? palette, accessory: "party" };
+  }
+  return look;
 }
 
 const ACCESSORY_SPRITES: Record<Exclude<LobsterPetAccessory, "none">, TemplateResult> = {
@@ -302,7 +326,59 @@ const ACCESSORY_SPRITES: Record<Exclude<LobsterPetAccessory, "none">, TemplateRe
       <circle cx="60" cy="1" r="2.4" fill="#ff5c8a" />
     </g>
   `,
+  // Elder wear: a patient little colony riding the shell's shoulder.
+  barnacle: svg`
+    <g class="lob-barnacles">
+      <path d="M32 22 L36.5 13 L41 22 Z" fill="#cfd8de" />
+      <path d="M42 18 L45.5 11 L49 18 Z" fill="#b8c4cc" />
+      <path d="M27 26 L30 20.5 L33 26 Z" fill="#b8c4cc" />
+      <circle cx="36.5" cy="18.5" r="1.1" fill="#8a949d" />
+      <circle cx="45.5" cy="15" r="0.9" fill="#8a949d" />
+    </g>
+  `,
+  // National Lobster Day formal wear: gold rim, chain, no further questions.
+  monocle: svg`
+    <g class="lob-monocle" fill="none" stroke="#f4b840">
+      <circle cx="75" cy="32" r="8.5" stroke-width="2.5" />
+      <path d="M81 39 Q85 48 80 56" stroke-width="1.5" />
+    </g>
+  `,
 };
+
+// Light speckle trait, distinct from calico's bold mottling; skipped on
+// palettes whose identity is already pattern-driven (see renderLobsterSvg).
+const FRECKLE_SPOTS = svg`
+  <g class="lob-freckles" fill="#ffffff" opacity="0.3">
+    <circle cx="42" cy="45" r="1.6" />
+    <circle cx="50" cy="41" r="1.2" />
+    <circle cx="70" cy="45" r="1.6" />
+    <circle cx="78" cy="41" r="1.2" />
+    <circle cx="55" cy="62" r="1.4" />
+    <circle cx="67" cy="66" r="1.2" />
+  </g>
+`;
+
+// Lumen photophores: dotted running lights along the shell. The glow (and
+// its dark-theme-only intensity) lives in lobster-pet.css.
+const LUMEN_SPOTS = svg`
+  <g class="lob-lumen" fill="#7ef5dd">
+    <circle cx="36" cy="54" r="2.4" />
+    <circle cx="50" cy="66" r="2" />
+    <circle cx="66" cy="70" r="2.2" />
+    <circle cx="80" cy="60" r="2" />
+    <circle cx="88" cy="46" r="1.7" />
+    <circle cx="60" cy="86" r="1.7" />
+  </g>
+`;
+
+// Palettes whose identity is already pattern-driven skip the freckle trait;
+// stacking speckle sets reads as noise, not a variant.
+const PATTERNED_PALETTES: ReadonlySet<LobsterPetPaletteId> = new Set([
+  "calico",
+  "split",
+  "retro",
+  "lumen",
+]);
 
 // Calico mottling: dark blotches scattered clear of the eye line.
 const CALICO_SPOTS = svg`
@@ -462,6 +538,131 @@ function renderCrabSvg() {
   `;
 }
 
+// Also not a lobster. Crosses the ledge on its own schedule, which is to
+// say: eventually.
+function renderSnailSvg() {
+  return svg`
+    <svg
+      class="lobster-pet__svg"
+      viewBox="0 0 120 105"
+      preserveAspectRatio="none"
+      aria-hidden="true"
+    >
+      <path
+        d="M14 96 Q32 84 58 88 L96 88 Q110 90 112 97 Q112 103 102 103 L24 103 Q14 103 14 96 Z"
+        fill="#c9a06a"
+      />
+      <g stroke="#c9a06a" stroke-width="3.5" stroke-linecap="round" fill="none">
+        <path d="M94 88 Q96 76 91 68" />
+        <path d="M103 88 Q107 76 103 66" />
+      </g>
+      <circle cx="90" cy="65" r="3.6" fill="#0a1014" />
+      <circle cx="103" cy="63" r="3.6" fill="#0a1014" />
+      <circle cx="91" cy="64" r="1.3" fill="#ffd166" />
+      <circle cx="104" cy="62" r="1.3" fill="#ffd166" />
+      <circle cx="50" cy="62" r="27" fill="#8a5a2b" />
+      <path
+        d="M50 41 a21 21 0 1 1 -15 36 a14 14 0 1 0 11 -25 a8 8 0 1 0 4 14"
+        stroke="#5f3d1c"
+        stroke-width="4"
+        stroke-linecap="round"
+        fill="none"
+      />
+    </svg>
+  `;
+}
+
+// The rubber duck: patron saint of debugging. It floats through, listens,
+// and leaves without judging anyone's architecture.
+function renderDuckSvg() {
+  return svg`
+    <svg
+      class="lobster-pet__svg"
+      viewBox="0 0 120 105"
+      preserveAspectRatio="none"
+      aria-hidden="true"
+    >
+      <path d="M30 82 Q20 74 27 65 Q30 76 40 79 Z" fill="#f0b52e" />
+      <ellipse cx="58" cy="85" rx="34" ry="17" fill="#ffd23e" />
+      <circle cx="82" cy="50" r="18" fill="#ffd23e" />
+      <path d="M98 49 Q112 52 99 59 Q95 56 95 51 Z" fill="#ff8c2e" />
+      <circle cx="86" cy="44" r="3.6" fill="#0a1014" />
+      <circle cx="87" cy="43" r="1.3" fill="#ffffff" />
+      <path d="M44 82 Q58 72 72 82 Q58 93 44 82 Z" fill="#f0b52e" opacity="0.75" />
+    </svg>
+  `;
+}
+
+// A jellyfish drifting past above the ledge, pulsing gently, thinking about
+// nothing at all.
+function renderJellyfishSvg() {
+  return svg`
+    <svg
+      class="lobster-pet__svg"
+      viewBox="0 0 120 105"
+      preserveAspectRatio="none"
+      aria-hidden="true"
+    >
+      <g class="lob-jelly-tentacles" stroke="#9f7dfa" stroke-width="2.5" stroke-linecap="round" fill="none" opacity="0.8">
+        <path d="M40 58 Q35 74 42 90" />
+        <path d="M54 61 Q52 78 57 96" />
+        <path d="M68 61 Q71 78 64 94" />
+        <path d="M80 58 Q85 72 78 88" />
+      </g>
+      <path
+        d="M30 52 C30 22 90 22 90 52 L90 58 Q82 52 75 58 Q67 52 60 58 Q52 52 45 58 Q38 52 30 58 Z"
+        fill="#b79bff"
+        opacity="0.78"
+      />
+      <ellipse cx="47" cy="37" rx="12" ry="6" fill="#ffffff" opacity="0.25" />
+      <circle cx="52" cy="45" r="2.6" fill="#0a1014" />
+      <circle cx="66" cy="45" r="2.6" fill="#0a1014" />
+    </svg>
+  `;
+}
+
+const PASSER_SPRITES: Record<Exclude<LobsterPasserKind, "stranger">, () => TemplateResult> = {
+  crab: renderCrabSvg,
+  snail: renderSnailSvg,
+  duck: renderDuckSvg,
+  jellyfish: renderJellyfishSvg,
+};
+
+// While hovering, a closed bottle keeps its secret; opening swaps the title
+// to the fortune — the pet-name tooltip channel, so no i18n surface.
+function renderBottleSvg(opened: boolean) {
+  return svg`
+    <svg class="lobster-bottle__svg" viewBox="0 0 48 44" aria-hidden="true">
+      <g transform="rotate(-16 24 30)">
+        <rect x="5" y="18" width="30" height="16" rx="7" fill="#7fc8b8" opacity="0.72" />
+        <rect x="33" y="22" width="9" height="8" rx="2.5" fill="#7fc8b8" opacity="0.72" />
+        ${
+          opened
+            ? svg`
+              <rect x="36" y="20" width="11" height="7" rx="1.5" fill="#f2e5c9" transform="rotate(-24 41 23)" />
+              <rect x="43" y="30" width="4.5" height="8" rx="1.6" fill="#8a5a2b" transform="rotate(38 45 34)" />
+            `
+            : svg`<rect x="41" y="21.5" width="5" height="9" rx="1.8" fill="#8a5a2b" />`
+        }
+        <rect x="11" y="22" width="12" height="8" rx="1.5" fill="#f2e5c9" />
+        <path d="M13 24.5 L21 24.5 M13 27 L19 27" stroke="#b6a071" stroke-width="1" />
+        <ellipse cx="13" cy="20.5" rx="5" ry="2" fill="#ffffff" opacity="0.35" />
+      </g>
+    </svg>
+  `;
+}
+
+// Balloon entrance rig: rendered inside the body while the descent plays,
+// then unmounts with the entering flag.
+const BALLOON = svg`
+  <svg class="lobster-pet__balloon" viewBox="0 0 40 62" aria-hidden="true">
+    <path d="M20 34 Q23 46 18 60" stroke="#8a949d" stroke-width="1.5" fill="none" />
+    <ellipse cx="20" cy="16" rx="13" ry="15" fill="#ff5c8a" />
+    <path d="M17 30 L20 34.5 L23 30 Z" fill="#e0446f" />
+    <ellipse cx="15" cy="10" rx="4" ry="6" fill="#ffffff" opacity="0.3" />
+  </svg>
+`;
+
 // Same species as icons.lobster / the dreams-scene sleeper: smooth dome body
 // with stubby legs, side claws, antennae, and teal-glint eyes.
 export function renderLobsterSvg(
@@ -508,6 +709,8 @@ export function renderLobsterSvg(
       />
       ${look.palette.id === "split" ? SPLIT_HALF : nothing}
       ${look.palette.id === "calico" ? CALICO_SPOTS : nothing}
+      ${look.palette.id === "lumen" ? LUMEN_SPOTS : nothing}
+      ${look.freckles && !PATTERNED_PALETTES.has(look.palette.id) ? FRECKLE_SPOTS : nothing}
       <ellipse cx="48" cy="28" rx="20" ry="11" fill="#ffffff" opacity="0.1" />
       <g class="lob-eye-open" style=${options.shell || options.sleeping ? "display:none" : ""}>
         <circle cx="45" cy="32" r="5.5" fill="#0a1014" />
@@ -559,24 +762,41 @@ export function renderLobsterSvg(
 
 export const SPOT_ZONES = { left: [12, 38], right: [60, 84] } as const;
 
+// Shared inline vars for every surface that renders a look (ledge sprite,
+// twin, stranger passer, logo stand-in). The seeded glint rides
+// --lob-glint-seed instead of --lob-glint so the class-driven palette and
+// offline overrides in lobster-pet.css still out-cascade it.
+export function lobsterLookStyleVars(look: LobsterPetLook): string[] {
+  const crusher = look.crusherSide;
+  const clawMul = (side: "left" | "right") =>
+    crusher === null
+      ? LOBSTER_PET_CLAW_MULS[look.clawSize]
+      : crusher === side
+        ? LOBSTER_PET_CLAW_MULS.mighty
+        : LOBSTER_PET_CLAW_MULS.dainty;
+  return [
+    `--lob-shell:${look.palette.shell}`,
+    `--lob-claw:${look.palette.claw}`,
+    `--lob-blink-delay:${look.blinkDelayS}s`,
+    `--lob-w:${LOBSTER_PET_BUILD_MULS[look.build].w}`,
+    `--lob-h:${LOBSTER_PET_BUILD_MULS[look.build].h}`,
+    `--lob-claw-l:${clawMul("left")}`,
+    `--lob-claw-r:${clawMul("right")}`,
+    ...(look.glint ? [`--lob-glint-seed:${look.glint}`] : []),
+  ];
+}
+
 function lobsterPetSpriteStyle(
   look: LobsterPetLook,
   scale: number,
   spotPct: number,
   facing: 1 | -1,
 ) {
-  // Glint color stays class-driven (see lobster-pet.css): an inline
-  // --lob-glint would out-cascade the offline grey override.
   return [
-    `--lob-shell:${look.palette.shell}`,
-    `--lob-claw:${look.palette.claw}`,
+    ...lobsterLookStyleVars(look),
     `--lob-scale:${scale}`,
     `--lob-x:${spotPct}%`,
     `--lob-face:${facing}`,
-    `--lob-blink-delay:${look.blinkDelayS}s`,
-    `--lob-w:${LOBSTER_PET_BUILD_MULS[look.build].w}`,
-    `--lob-h:${LOBSTER_PET_BUILD_MULS[look.build].h}`,
-    `--lob-claw-scale:${LOBSTER_PET_CLAW_MULS[look.clawSize]}`,
   ].join(";");
 }
 
@@ -588,12 +808,14 @@ export function renderLobsterPetScene(args: {
   shellVisible: boolean;
   visitsEnabled: boolean;
   dismissed: boolean;
-  passer: { kind: "stranger" | "crab"; direction: 1 | -1 } | null;
+  passer: { kind: LobsterPasserKind; direction: 1 | -1; crossMs: number } | null;
   twinPlanned: boolean;
   anniversary: boolean;
   entering: boolean;
+  entrance: LobsterPetEntrance;
   grumpy: boolean;
   vigil: boolean;
+  elder: boolean;
   act: string | null;
   zone: readonly [number, number];
   spotPct: number;
@@ -606,10 +828,15 @@ export function renderLobsterPetScene(args: {
   seed: number;
   movingDay: boolean;
   sailorDay: boolean;
+  nameOverride: string | null;
+  // Extra "· <flavor>" tooltip suffix (elder lore, old-friend returns).
+  flavor: string | null;
+  bottle: { spotPct: number; opened: boolean; fortune: string } | null;
   onPointerDown: () => void;
   onPointerUp: () => void;
   onPointerCancel: () => void;
   onContextMenu: (event: Event) => void;
+  onBottleOpen: () => void;
 }) {
   const anchoredScale = (scale: number) =>
     args.anchor === "bar" ? Math.min(scale, args.barMaxScale) : scale;
@@ -626,8 +853,11 @@ export function renderLobsterPetScene(args: {
       `lobster-pet--palette-${args.look.palette.id}`,
       twin ? "lobster-pet--twin" : "",
       dressed.accessory === "party" ? "lobster-pet--party" : "",
+      args.look.shiny ? "lobster-pet--shiny" : "",
+      args.elder ? "lobster-pet--elder" : "",
       args.presence === "leaving" ? "lobster-pet--away" : "",
       args.entering ? "lobster-pet--entering" : "",
+      args.entering && args.entrance !== "walk" ? `lobster-pet--enter-${args.entrance}` : "",
       args.grumpy ? "lobster-pet--grumpy" : "",
       args.vigil ? "lobster-pet--vigil" : "",
       args.act ? `lobster-pet--act-${args.act}` : "",
@@ -649,11 +879,18 @@ export function renderLobsterPetScene(args: {
     // Milestone honorifics come from the load-start familiarity snapshot, so
     // a title never pops mid-visit; it is simply there next time.
     const honorific = lobsterHonorific(args.familiarityVisits);
-    const baseName = lobsterPetName(args.look, args.seed);
-    const name = honorific ? `${honorific} ${baseName}` : baseName;
+    const baseName = args.nameOverride ?? lobsterPetName(args.look, args.seed);
+    const titled = honorific ? `${honorific} ${baseName}` : baseName;
+    const name = args.look.shiny ? `✦ ${titled}` : titled;
     // The twin travels light; only the resident pet hauls the moving bindle.
     const bindle = args.movingDay && !twin;
-    const title = twin ? `${name} Jr.` : bindle ? `${name} · just moved in` : name;
+    const title = twin
+      ? `${name} Jr.`
+      : bindle
+        ? `${name} · just moved in`
+        : args.flavor
+          ? `${name} · ${args.flavor}`
+          : name;
     return html`
       <div
         class=${classes}
@@ -672,6 +909,20 @@ export function renderLobsterPetScene(args: {
             bindle,
             sailorCap: args.sailorDay,
           })}
+          ${args.entering && args.entrance === "balloon" ? BALLOON : nothing}
+          ${
+            args.entering && args.entrance === "bubble"
+              ? html`<span class="lobster-pet__entry-bubble"></span>`
+              : nothing
+          }
+          ${
+            args.look.shiny
+              ? html`
+                  <span class="lobster-pet__sparkle" style="--i:0;left:12%;bottom:64%">✦</span>
+                  <span class="lobster-pet__sparkle" style="--i:1;left:76%;bottom:82%">✦</span>
+                `
+              : nothing
+          }
           <span class="lobster-pet__z" style="--i:0">z</span>
           <span class="lobster-pet__z" style="--i:1">z</span>
           <span class="lobster-pet__z" style="--i:2">Z</span>
@@ -699,7 +950,10 @@ export function renderLobsterPetScene(args: {
   // visits setting silence it like everything else.
   const showShell = args.shellVisible && args.visitsEnabled && !args.dismissed;
   const showPasser = args.passer !== null && args.visitsEnabled;
-  if (!showSprites && !showShell && !showPasser) {
+  // The bottle washes ashore whether or not the pet is around; it belongs to
+  // the ledge, not the visit.
+  const showBottle = args.bottle !== null && args.visitsEnabled && !args.dismissed;
+  if (!showSprites && !showShell && !showPasser && !showBottle) {
     return nothing;
   }
   // The abandoned shell: the pre-molt silhouette, frozen and slowly fading.
@@ -710,31 +964,43 @@ export function renderLobsterPetScene(args: {
     args.facing,
   );
   // A pass-through visitor: crosses the ledge once and is gone. Strangers
-  // are other lobsters (never your palette); the crab is, allegedly, also a
-  // lobster. Neither perches, neither counts for the Lobsterdex.
+  // are other lobsters (never your palette); everyone else is at most
+  // lobster-adjacent. None perch, none count for the Lobsterdex.
   const passerLook =
     args.passer?.kind === "stranger" ? strangerLookFor(args.seed, args.look.palette.id) : args.look;
   const passerClasses = args.passer
     ? [
         "lobster-pet",
         "lobster-pet--passer",
-        args.passer.kind === "crab"
-          ? "lobster-pet--crab"
-          : `lobster-pet--palette-${passerLook.palette.id}`,
+        args.passer.kind === "stranger"
+          ? `lobster-pet--palette-${passerLook.palette.id}`
+          : `lobster-pet--${args.passer.kind}`,
+        args.passer.kind === "stranger" && passerLook.shiny ? "lobster-pet--shiny" : "",
         args.passer.direction === 1 ? "lobster-pet--passer-ltr" : "lobster-pet--passer-rtl",
-      ].join(" ")
+      ]
+        .filter(Boolean)
+        .join(" ")
     : "";
-  const passerStyle =
-    args.passer?.kind === "crab"
-      ? `--lob-scale:2;--lob-w:1;--lob-h:0.82;--lob-face:1`
-      : args.passer
-        ? lobsterPetSpriteStyle(passerLook, Math.min(passerLook.scale, 2), 0, args.passer.direction)
-        : "";
+  const passerStyle = args.passer
+    ? `${passerBaseStyle(args.passer.kind, args.passer.direction, passerLook)};--lob-cross:${args.passer.crossMs}ms`
+    : "";
   return html`
     ${showShell
       ? html`
           <div class="lobster-pet lobster-pet--shell" style=${shellStyle} aria-hidden="true">
             <div class="lobster-pet__body">${renderLobsterSvg(args.look, { shell: true })}</div>
+          </div>
+        `
+      : nothing}
+    ${showBottle && args.bottle
+      ? html`
+          <div
+            class="lobster-bottle ${args.bottle.opened ? "lobster-bottle--open" : ""}"
+            style="--lob-x:${args.bottle.spotPct}%"
+            title=${args.bottle.opened ? args.bottle.fortune : "a message in a bottle"}
+            @pointerdown=${args.onBottleOpen}
+          >
+            ${renderBottleSvg(args.bottle.opened)}
           </div>
         `
       : nothing}
@@ -746,15 +1012,45 @@ export function renderLobsterPetScene(args: {
             class=${passerClasses}
             style=${passerStyle}
             aria-hidden="true"
-            title=${args.passer.kind === "crab" ? "definitely a lobster" : "a stranger"}
+            title=${PASSER_TITLES[args.passer.kind]}
           >
             <div class="lobster-pet__body">
-              ${args.passer.kind === "crab"
-                ? renderCrabSvg()
-                : renderLobsterSvg(passerLook, { standalone: true })}
+              ${args.passer.kind === "stranger"
+                ? renderLobsterSvg(passerLook, { standalone: true })
+                : PASSER_SPRITES[args.passer.kind]()}
             </div>
           </div>
         `
       : nothing}
   `;
+}
+
+const PASSER_TITLES: Record<LobsterPasserKind, string> = {
+  stranger: "a stranger",
+  crab: "definitely a lobster",
+  snail: "in no particular hurry",
+  duck: "a duck. obviously",
+  jellyfish: "just drifting",
+};
+
+// Non-lobster passers ignore the perch variables and carry fixed sprite
+// proportions; strangers reuse the full look pipeline (capped size so a
+// visiting grail does not upstage the resident).
+function passerBaseStyle(
+  kind: LobsterPasserKind,
+  direction: 1 | -1,
+  passerLook: LobsterPetLook,
+): string {
+  switch (kind) {
+    case "crab":
+      return "--lob-scale:2;--lob-w:1;--lob-h:0.82;--lob-face:1";
+    case "snail":
+      return `--lob-scale:1.7;--lob-w:1;--lob-h:0.9;--lob-face:${direction}`;
+    case "duck":
+      return `--lob-scale:1.9;--lob-w:1;--lob-h:1;--lob-face:${direction}`;
+    case "jellyfish":
+      return "--lob-scale:1.7;--lob-w:0.9;--lob-h:1.1;--lob-face:1";
+    case "stranger":
+      return lobsterPetSpriteStyle(passerLook, Math.min(passerLook.scale, 2), 0, direction);
+  }
 }

--- a/ui/src/components/lobster-pet-look.ts
+++ b/ui/src/components/lobster-pet-look.ts
@@ -910,19 +910,15 @@ export function renderLobsterPetScene(args: {
             sailorCap: args.sailorDay,
           })}
           ${args.entering && args.entrance === "balloon" ? BALLOON : nothing}
-          ${
-            args.entering && args.entrance === "bubble"
-              ? html`<span class="lobster-pet__entry-bubble"></span>`
-              : nothing
-          }
-          ${
-            args.look.shiny
-              ? html`
-                  <span class="lobster-pet__sparkle" style="--i:0;left:12%;bottom:64%">✦</span>
-                  <span class="lobster-pet__sparkle" style="--i:1;left:76%;bottom:82%">✦</span>
-                `
-              : nothing
-          }
+          ${args.entering && args.entrance === "bubble"
+            ? html`<span class="lobster-pet__entry-bubble"></span>`
+            : nothing}
+          ${args.look.shiny
+            ? html`
+                <span class="lobster-pet__sparkle" style="--i:0;left:12%;bottom:64%">✦</span>
+                <span class="lobster-pet__sparkle" style="--i:1;left:76%;bottom:82%">✦</span>
+              `
+            : nothing}
           <span class="lobster-pet__z" style="--i:0">z</span>
           <span class="lobster-pet__z" style="--i:1">z</span>
           <span class="lobster-pet__z" style="--i:2">Z</span>

--- a/ui/src/components/lobster-pet-look.ts
+++ b/ui/src/components/lobster-pet-look.ts
@@ -591,7 +591,10 @@ export function renderLobsterPetScene(args: {
   const showShell = args.shellVisible && args.visitsEnabled && !args.dismissed;
   const showPasser = args.passer !== null && args.visitsEnabled;
   // The bottle washes ashore whether or not the pet is around; it belongs to
-  // the ledge, not the visit.
+  // the ledge, not the visit. Like every sprite here it is intentionally
+  // aria-hidden and pointer-only, with fortunes on the native-tooltip channel
+  // (no i18n surface); it must not join the tab order, where a surprise
+  // easter-egg button would degrade keyboard flow.
   const showBottle = args.bottle !== null && args.visitsEnabled && !args.dismissed;
   if (!showSprites && !showShell && !showPasser && !showBottle) {
     return nothing;

--- a/ui/src/components/lobster-pet-look.ts
+++ b/ui/src/components/lobster-pet-look.ts
@@ -1,5 +1,5 @@
 import { expectDefined } from "@openclaw/normalization-core";
-import { html, nothing, svg, type TemplateResult } from "lit";
+import { html, nothing, svg } from "lit";
 import { lobsterHonorific } from "./lobster-dex.ts";
 import type {
   LobsterPasserKind,
@@ -14,6 +14,27 @@ import type {
   LobsterPetPaletteId,
   LobsterPetPersonalityId,
 } from "./lobster-pet-contract.ts";
+import {
+  ACCESSORY_SPRITES,
+  ANTENNAE_SPRITES,
+  BALLOON,
+  BINDLE,
+  CALICO_SPOTS,
+  FRECKLE_SPOTS,
+  GRUMPY_FACE,
+  HEADWEAR,
+  LUMEN_SPOTS,
+  PASSER_SPRITES,
+  PASSER_TITLES,
+  PATTERNED_PALETTES,
+  RETRO_ANTENNAE,
+  RETRO_FACE,
+  RETRO_MEGA_CLAW,
+  renderBottleSvg,
+  SAILOR_CAP,
+  SPLIT_HALF,
+  TAIL_FAN,
+} from "./lobster-pet-sprites.ts";
 
 // Rarity ladder loosely mirrors real lobster genetics: blue ~1 in 2 million,
 // yellow ~1 in 30 million, calico ~1 in 30 million, split two-tone ~1 in
@@ -285,383 +306,6 @@ export function createLobsterPetLook(seed: number, now: Date = new Date()): Lobs
   }
   return look;
 }
-
-const ACCESSORY_SPRITES: Record<Exclude<LobsterPetAccessory, "none">, TemplateResult> = {
-  crown: svg`
-    <path
-      d="M46 12 L46 2 L53 8 L60 0 L67 8 L74 2 L74 12 Q60 8 46 12 Z"
-      fill="#f6c945"
-    />
-  `,
-  sprout: svg`
-    <g>
-      <path d="M60 12 Q58 4 63 1" stroke="#3f9d63" stroke-width="3" stroke-linecap="round" fill="none" />
-      <ellipse cx="67" cy="3" rx="5" ry="3" fill="#57c785" transform="rotate(-24 67 3)" />
-    </g>
-  `,
-  patch: svg`
-    <g>
-      <path d="M28 27 Q60 14 92 22" stroke="#101820" stroke-width="4" stroke-linecap="round" fill="none" />
-      <circle cx="75" cy="32" r="9" fill="#101820" />
-    </g>
-  `,
-  santa: svg`
-    <g>
-      <path d="M47 10 Q54 1 68 3 L72 9 Z" fill="#e0312f" />
-      <circle cx="71" cy="3.5" r="3.5" fill="#f5f7fa" />
-      <ellipse cx="59" cy="10.5" rx="15" ry="3.5" fill="#f5f7fa" />
-    </g>
-  `,
-  pumpkin: svg`
-    <g>
-      <ellipse cx="60" cy="6.5" rx="8.5" ry="5.5" fill="#e8871e" />
-      <path d="M56 2.5 Q56 6.5 56 10.5 M64 2.5 Q64 6.5 64 10.5" stroke="#c96a10" stroke-width="1.5" fill="none" />
-      <path d="M60 1.5 Q60.5 0 63 0.5" stroke="#4c9a4c" stroke-width="2.5" stroke-linecap="round" fill="none" />
-    </g>
-  `,
-  party: svg`
-    <g>
-      <path d="M52 11 L60 0.5 L68 11 Z" fill="#7c5cff" />
-      <path d="M55.5 6.5 L64.5 6.5" stroke="#ffd166" stroke-width="2" />
-      <circle cx="60" cy="1" r="2.4" fill="#ff5c8a" />
-    </g>
-  `,
-  // Elder wear: a patient little colony riding the shell's shoulder.
-  barnacle: svg`
-    <g class="lob-barnacles">
-      <path d="M32 22 L36.5 13 L41 22 Z" fill="#cfd8de" />
-      <path d="M42 18 L45.5 11 L49 18 Z" fill="#b8c4cc" />
-      <path d="M27 26 L30 20.5 L33 26 Z" fill="#b8c4cc" />
-      <circle cx="36.5" cy="18.5" r="1.1" fill="#8a949d" />
-      <circle cx="45.5" cy="15" r="0.9" fill="#8a949d" />
-    </g>
-  `,
-  // National Lobster Day formal wear: gold rim, chain, no further questions.
-  monocle: svg`
-    <g class="lob-monocle" fill="none" stroke="#f4b840">
-      <circle cx="75" cy="32" r="8.5" stroke-width="2.5" />
-      <path d="M81 39 Q85 48 80 56" stroke-width="1.5" />
-    </g>
-  `,
-};
-
-// Light speckle trait, distinct from calico's bold mottling; skipped on
-// palettes whose identity is already pattern-driven (see renderLobsterSvg).
-const FRECKLE_SPOTS = svg`
-  <g class="lob-freckles" fill="#ffffff" opacity="0.3">
-    <circle cx="42" cy="45" r="1.6" />
-    <circle cx="50" cy="41" r="1.2" />
-    <circle cx="70" cy="45" r="1.6" />
-    <circle cx="78" cy="41" r="1.2" />
-    <circle cx="55" cy="62" r="1.4" />
-    <circle cx="67" cy="66" r="1.2" />
-  </g>
-`;
-
-// Lumen photophores: dotted running lights along the shell. The glow (and
-// its dark-theme-only intensity) lives in lobster-pet.css.
-const LUMEN_SPOTS = svg`
-  <g class="lob-lumen" fill="#7ef5dd">
-    <circle cx="36" cy="54" r="2.4" />
-    <circle cx="50" cy="66" r="2" />
-    <circle cx="66" cy="70" r="2.2" />
-    <circle cx="80" cy="60" r="2" />
-    <circle cx="88" cy="46" r="1.7" />
-    <circle cx="60" cy="86" r="1.7" />
-  </g>
-`;
-
-// Palettes whose identity is already pattern-driven skip the freckle trait;
-// stacking speckle sets reads as noise, not a variant.
-const PATTERNED_PALETTES: ReadonlySet<LobsterPetPaletteId> = new Set([
-  "calico",
-  "split",
-  "retro",
-  "lumen",
-]);
-
-// Calico mottling: dark blotches scattered clear of the eye line.
-const CALICO_SPOTS = svg`
-  <g class="lob-spots" fill="#2a1f16" opacity="0.8">
-    <ellipse cx="40" cy="50" rx="6" ry="4" transform="rotate(-15 40 50)" />
-    <ellipse cx="72" cy="62" rx="7" ry="4.5" transform="rotate(18 72 62)" />
-    <ellipse cx="55" cy="76" rx="5" ry="3.5" transform="rotate(-8 55 76)" />
-    <ellipse cx="84" cy="42" rx="4" ry="3" transform="rotate(25 84 42)" />
-    <ellipse cx="47" cy="18" rx="4.5" ry="3" transform="rotate(-20 47 18)" />
-    <ellipse cx="30" cy="64" rx="4" ry="3" transform="rotate(12 30 64)" />
-  </g>
-`;
-
-// Split two-tone: the right half of the body (down to the belly midline)
-// repainted in the second shell color; the right claw and antenna follow via
-// CSS. Mirrors the famous bilateral half-and-half lobsters.
-const SPLIT_HALF = svg`
-  <path
-    class="lob-split-half"
-    d="M60 8 C88 8 104 32 104 52 C104 72 90 90 76 95 L76 104 L66 104 L66 96 C64 96.8 62 97.1 60 97.1 L60 8 Z"
-    fill="var(--lob-shell2, #46536b)"
-  />
-`;
-
-// Retro homage parts (classic OpenClaw logo): one oversized raised claw with
-// a pincer notch, tall V antennae, angry brows, and a smirk. The mega claw
-// lives inside the .lob-claw--r group so wave/snip acts swing it.
-const RETRO_MEGA_CLAW = svg`
-  <path
-    d="M95 55 C112 53 119 39 116 25 C113 11 99 5 91 12 C88 15 87 19 88 23 C83 27 83 36 88 43 C91 49 93 52 95 55 Z"
-    fill="var(--lob-claw)"
-  />
-  <path
-    d="M92 14 C97 22 99 31 95 41"
-    stroke="#b8151b"
-    stroke-width="3"
-    stroke-linecap="round"
-    fill="none"
-  />
-`;
-
-const RETRO_ANTENNAE = svg`
-  <g class="lob-antennae" stroke="var(--lob-shell)" stroke-width="4" stroke-linecap="round" fill="none">
-    <path d="M50 16 Q45 4 37 1" />
-    <path d="M70 16 Q75 4 83 1" />
-  </g>
-`;
-
-const RETRO_FACE = svg`
-  <g stroke="#0a1014" stroke-linecap="round" fill="none">
-    <path d="M37 24 L51 28" stroke-width="3.5" />
-    <path d="M69 28 L83 24" stroke-width="3.5" />
-    <path d="M49 45 Q59 51 69 45 L72 42" stroke-width="3" />
-  </g>
-`;
-
-// Tail-fan lobes peek out diagonally behind the lower body (drawn before the
-// body path so they read as "behind"). Fill color lives in lobster-pet.css.
-const TAIL_FAN = svg`
-  <g class="lob-tail">
-    <ellipse cx="16" cy="84" rx="11" ry="7" transform="rotate(-32 16 84)" />
-    <ellipse cx="104" cy="84" rx="11" ry="7" transform="rotate(32 104 84)" />
-  </g>
-`;
-
-// Moving-day bindle: a stick over the shoulder with a polka-dot bundle,
-// carried for the whole first load after a gateway upgrade.
-const BINDLE = svg`
-  <g class="lob-bindle">
-    <path d="M70 62 L99 30" stroke="#8a5a2b" stroke-width="3.5" stroke-linecap="round" />
-    <circle cx="101" cy="27" r="9.5" fill="#e8b04b" />
-    <circle cx="98" cy="24" r="1.6" fill="#b6791f" />
-    <circle cx="104" cy="29" r="1.6" fill="#b6791f" />
-    <circle cx="100" cy="32" r="1.3" fill="#b6791f" />
-  </g>
-`;
-
-// On lobster days (see src/shared/lobster-day.ts, shared with the CLI
-// banner cousin) the pet wears a little sailor cap - unless the seed already
-// rolled headwear, which keeps its place.
-const HEADWEAR: ReadonlySet<LobsterPetAccessory> = new Set([
-  "crown",
-  "sprout",
-  "santa",
-  "pumpkin",
-  "party",
-]);
-
-const SAILOR_CAP = svg`
-  <g class="lob-cap">
-    <path d="M46 10 Q60 -3 74 10 L74 13 Q60 7 46 13 Z" fill="#f5f7fa" />
-    <path d="M45 12 Q60 6 75 12 L75 16 Q60 10.5 45 16 Z" fill="#dfe7ee" />
-    <circle cx="60" cy="2.5" r="1.8" fill="#3b6ea5" />
-  </g>
-`;
-
-// Shown while grumpy (poked too much): angry brows and a frown.
-const GRUMPY_FACE = svg`
-  <g stroke="#0a1014" stroke-linecap="round" fill="none">
-    <path d="M37 24 L51 28" stroke-width="3.5" />
-    <path d="M69 28 L83 24" stroke-width="3.5" />
-    <path d="M50 48 Q60 42 70 48" stroke-width="3" />
-  </g>
-`;
-
-const ANTENNAE_SPRITES: Record<LobsterPetAntennae, TemplateResult> = {
-  perky: svg`
-    <g class="lob-antennae" stroke="var(--lob-shell)" stroke-width="4" stroke-linecap="round" fill="none">
-      <path d="M46 14 Q38 4 31 7" />
-      <path d="M74 14 Q82 4 89 7" />
-    </g>
-  `,
-  droopy: svg`
-    <g class="lob-antennae" stroke="var(--lob-shell)" stroke-width="4" stroke-linecap="round" fill="none">
-      <path d="M46 14 Q36 8 34 18" />
-      <path d="M74 14 Q84 8 86 18" />
-    </g>
-  `,
-};
-
-// Not a lobster. Wide shell, eye stalks, walks sideways across the ledge,
-// and the Lobsterdex refuses to acknowledge it.
-function renderCrabSvg() {
-  return svg`
-    <svg
-      class="lobster-pet__svg"
-      viewBox="0 0 120 105"
-      preserveAspectRatio="none"
-      aria-hidden="true"
-    >
-      <g stroke="#a63a2e" stroke-width="4" stroke-linecap="round" fill="none">
-        <path d="M22 78 L8 88" />
-        <path d="M28 88 L16 99" />
-        <path d="M98 78 L112 88" />
-        <path d="M92 88 L104 99" />
-      </g>
-      <g stroke="#c44536" stroke-width="3.5" stroke-linecap="round" fill="none">
-        <path d="M44 38 L40 24" />
-        <path d="M76 38 L80 24" />
-      </g>
-      <circle cx="40" cy="22" r="4.5" fill="#0a1014" />
-      <circle cx="80" cy="22" r="4.5" fill="#0a1014" />
-      <circle cx="41.5" cy="20.5" r="1.8" fill="#ffd166" />
-      <circle cx="81.5" cy="20.5" r="1.8" fill="#ffd166" />
-      <ellipse cx="60" cy="70" rx="46" ry="30" fill="#c44536" />
-      <ellipse cx="48" cy="60" rx="16" ry="9" fill="#ffffff" opacity="0.1" />
-      <path
-        d="M16 58 C2 52 -2 62 4 72 C10 82 20 76 24 66 C26 60 22 58 16 58 Z"
-        fill="#d95f4b"
-      />
-      <path
-        d="M104 58 C118 52 122 62 116 72 C110 82 100 76 96 66 C94 60 98 58 104 58 Z"
-        fill="#d95f4b"
-      />
-      <path d="M48 82 Q60 90 72 82" stroke="#7e2a20" stroke-width="3" stroke-linecap="round" fill="none" />
-    </svg>
-  `;
-}
-
-// Also not a lobster. Crosses the ledge on its own schedule, which is to
-// say: eventually.
-function renderSnailSvg() {
-  return svg`
-    <svg
-      class="lobster-pet__svg"
-      viewBox="0 0 120 105"
-      preserveAspectRatio="none"
-      aria-hidden="true"
-    >
-      <path
-        d="M14 96 Q32 84 58 88 L96 88 Q110 90 112 97 Q112 103 102 103 L24 103 Q14 103 14 96 Z"
-        fill="#c9a06a"
-      />
-      <g stroke="#c9a06a" stroke-width="3.5" stroke-linecap="round" fill="none">
-        <path d="M94 88 Q96 76 91 68" />
-        <path d="M103 88 Q107 76 103 66" />
-      </g>
-      <circle cx="90" cy="65" r="3.6" fill="#0a1014" />
-      <circle cx="103" cy="63" r="3.6" fill="#0a1014" />
-      <circle cx="91" cy="64" r="1.3" fill="#ffd166" />
-      <circle cx="104" cy="62" r="1.3" fill="#ffd166" />
-      <circle cx="50" cy="62" r="27" fill="#8a5a2b" />
-      <path
-        d="M50 41 a21 21 0 1 1 -15 36 a14 14 0 1 0 11 -25 a8 8 0 1 0 4 14"
-        stroke="#5f3d1c"
-        stroke-width="4"
-        stroke-linecap="round"
-        fill="none"
-      />
-    </svg>
-  `;
-}
-
-// The rubber duck: patron saint of debugging. It floats through, listens,
-// and leaves without judging anyone's architecture.
-function renderDuckSvg() {
-  return svg`
-    <svg
-      class="lobster-pet__svg"
-      viewBox="0 0 120 105"
-      preserveAspectRatio="none"
-      aria-hidden="true"
-    >
-      <path d="M30 82 Q20 74 27 65 Q30 76 40 79 Z" fill="#f0b52e" />
-      <ellipse cx="58" cy="85" rx="34" ry="17" fill="#ffd23e" />
-      <circle cx="82" cy="50" r="18" fill="#ffd23e" />
-      <path d="M98 49 Q112 52 99 59 Q95 56 95 51 Z" fill="#ff8c2e" />
-      <circle cx="86" cy="44" r="3.6" fill="#0a1014" />
-      <circle cx="87" cy="43" r="1.3" fill="#ffffff" />
-      <path d="M44 82 Q58 72 72 82 Q58 93 44 82 Z" fill="#f0b52e" opacity="0.75" />
-    </svg>
-  `;
-}
-
-// A jellyfish drifting past above the ledge, pulsing gently, thinking about
-// nothing at all.
-function renderJellyfishSvg() {
-  return svg`
-    <svg
-      class="lobster-pet__svg"
-      viewBox="0 0 120 105"
-      preserveAspectRatio="none"
-      aria-hidden="true"
-    >
-      <g class="lob-jelly-tentacles" stroke="#9f7dfa" stroke-width="2.5" stroke-linecap="round" fill="none" opacity="0.8">
-        <path d="M40 58 Q35 74 42 90" />
-        <path d="M54 61 Q52 78 57 96" />
-        <path d="M68 61 Q71 78 64 94" />
-        <path d="M80 58 Q85 72 78 88" />
-      </g>
-      <path
-        d="M30 52 C30 22 90 22 90 52 L90 58 Q82 52 75 58 Q67 52 60 58 Q52 52 45 58 Q38 52 30 58 Z"
-        fill="#b79bff"
-        opacity="0.78"
-      />
-      <ellipse cx="47" cy="37" rx="12" ry="6" fill="#ffffff" opacity="0.25" />
-      <circle cx="52" cy="45" r="2.6" fill="#0a1014" />
-      <circle cx="66" cy="45" r="2.6" fill="#0a1014" />
-    </svg>
-  `;
-}
-
-const PASSER_SPRITES: Record<Exclude<LobsterPasserKind, "stranger">, () => TemplateResult> = {
-  crab: renderCrabSvg,
-  snail: renderSnailSvg,
-  duck: renderDuckSvg,
-  jellyfish: renderJellyfishSvg,
-};
-
-// While hovering, a closed bottle keeps its secret; opening swaps the title
-// to the fortune — the pet-name tooltip channel, so no i18n surface.
-function renderBottleSvg(opened: boolean) {
-  return svg`
-    <svg class="lobster-bottle__svg" viewBox="0 0 48 44" aria-hidden="true">
-      <g transform="rotate(-16 24 30)">
-        <rect x="5" y="18" width="30" height="16" rx="7" fill="#7fc8b8" opacity="0.72" />
-        <rect x="33" y="22" width="9" height="8" rx="2.5" fill="#7fc8b8" opacity="0.72" />
-        ${
-          opened
-            ? svg`
-              <rect x="36" y="20" width="11" height="7" rx="1.5" fill="#f2e5c9" transform="rotate(-24 41 23)" />
-              <rect x="43" y="30" width="4.5" height="8" rx="1.6" fill="#8a5a2b" transform="rotate(38 45 34)" />
-            `
-            : svg`<rect x="41" y="21.5" width="5" height="9" rx="1.8" fill="#8a5a2b" />`
-        }
-        <rect x="11" y="22" width="12" height="8" rx="1.5" fill="#f2e5c9" />
-        <path d="M13 24.5 L21 24.5 M13 27 L19 27" stroke="#b6a071" stroke-width="1" />
-        <ellipse cx="13" cy="20.5" rx="5" ry="2" fill="#ffffff" opacity="0.35" />
-      </g>
-    </svg>
-  `;
-}
-
-// Balloon entrance rig: rendered inside the body while the descent plays,
-// then unmounts with the entering flag.
-const BALLOON = svg`
-  <svg class="lobster-pet__balloon" viewBox="0 0 40 62" aria-hidden="true">
-    <path d="M20 34 Q23 46 18 60" stroke="#8a949d" stroke-width="1.5" fill="none" />
-    <ellipse cx="20" cy="16" rx="13" ry="15" fill="#ff5c8a" />
-    <path d="M17 30 L20 34.5 L23 30 Z" fill="#e0446f" />
-    <ellipse cx="15" cy="10" rx="4" ry="6" fill="#ffffff" opacity="0.3" />
-  </svg>
-`;
 
 // Same species as icons.lobster / the dreams-scene sleeper: smooth dome body
 // with stubby legs, side claws, antennae, and teal-glint eyes.
@@ -1021,14 +665,6 @@ export function renderLobsterPetScene(args: {
   `;
 }
 
-const PASSER_TITLES: Record<LobsterPasserKind, string> = {
-  stranger: "a stranger",
-  crab: "definitely a lobster",
-  snail: "in no particular hurry",
-  duck: "a duck. obviously",
-  jellyfish: "just drifting",
-};
-
 // Non-lobster passers ignore the perch variables and carry fixed sprite
 // proportions; strangers reuse the full look pipeline (capped size so a
 // visiting grail does not upstage the resident).
@@ -1037,16 +673,14 @@ function passerBaseStyle(
   direction: 1 | -1,
   passerLook: LobsterPetLook,
 ): string {
-  switch (kind) {
-    case "crab":
-      return "--lob-scale:2;--lob-w:1;--lob-h:0.82;--lob-face:1";
-    case "snail":
-      return `--lob-scale:1.7;--lob-w:1;--lob-h:0.9;--lob-face:${direction}`;
-    case "duck":
-      return `--lob-scale:1.9;--lob-w:1;--lob-h:1;--lob-face:${direction}`;
-    case "jellyfish":
-      return "--lob-scale:1.7;--lob-w:0.9;--lob-h:1.1;--lob-face:1";
-    case "stranger":
-      return lobsterPetSpriteStyle(passerLook, Math.min(passerLook.scale, 2), 0, direction);
+  if (kind === "stranger") {
+    return lobsterPetSpriteStyle(passerLook, Math.min(passerLook.scale, 2), 0, direction);
   }
+  const fixed: Record<Exclude<LobsterPasserKind, "stranger">, string> = {
+    crab: "--lob-scale:2;--lob-w:1;--lob-h:0.82;--lob-face:1",
+    snail: `--lob-scale:1.7;--lob-w:1;--lob-h:0.9;--lob-face:${direction}`,
+    duck: `--lob-scale:1.9;--lob-w:1;--lob-h:1;--lob-face:${direction}`,
+    jellyfish: "--lob-scale:1.7;--lob-w:0.9;--lob-h:1.1;--lob-face:1",
+  };
+  return fixed[kind];
 }

--- a/ui/src/components/lobster-pet-look.ts
+++ b/ui/src/components/lobster-pet-look.ts
@@ -638,6 +638,7 @@ export function renderLobsterPetScene(args: {
             class="lobster-bottle ${args.bottle.opened ? "lobster-bottle--open" : ""}"
             style="--lob-x:${args.bottle.spotPct}%"
             title=${args.bottle.opened ? args.bottle.fortune : "a message in a bottle"}
+            aria-hidden="true"
             @pointerdown=${args.onBottleOpen}
           >
             ${renderBottleSvg(args.bottle.opened)}

--- a/ui/src/components/lobster-pet-plans.ts
+++ b/ui/src/components/lobster-pet-plans.ts
@@ -8,7 +8,12 @@ import type {
   LobsterPetPersonalityId,
   LobsterRunOutcome,
 } from "./lobster-pet-contract.ts";
-import { LOBSTER_PET_PALETTES, lobsterPetName, mulberry32, SPOT_ZONES } from "./lobster-pet-look.ts";
+import {
+  LOBSTER_PET_PALETTES,
+  lobsterPetName,
+  mulberry32,
+  SPOT_ZONES,
+} from "./lobster-pet-look.ts";
 
 export { SPOT_ZONES };
 

--- a/ui/src/components/lobster-pet-plans.ts
+++ b/ui/src/components/lobster-pet-plans.ts
@@ -1,5 +1,7 @@
 import { getSafeLocalStorage } from "../local-storage.ts";
 import type {
+  LobsterPasserKind,
+  LobsterPetEntrance,
   LobsterPetMode,
   LobsterPetPersonalityId,
   LobsterRunOutcome,
@@ -134,10 +136,32 @@ export function resolveLobsterFinishAct(outcome: LobsterRunOutcome): LobsterPetA
   return outcome === "error" ? "droop" : outcome === "aborted" ? "startle" : "cheer";
 }
 
-export const ENTER_MS = 450;
 export const LEAVE_MS = 350;
-// One full ledge crossing for pass-through visitors.
-export const PASSER_CROSS_MS = 11_000;
+
+// Arrival theatrics: most visits walk up from behind the ledge; a few float
+// in under a balloon or pop out of a bubble. Rolled per arrival from the
+// component's dedicated entrance stream so visit scheduling stays untouched.
+export function pickLobsterEntrance(roll: number): LobsterPetEntrance {
+  return roll < 0.06 ? "balloon" : roll < 0.13 ? "bubble" : "walk";
+}
+
+// How long each entrance owns the `entering` flag; mirrors the entrance
+// animation durations in lobster-pet.css.
+export const LOBSTER_PET_ENTRANCE_MS: Record<LobsterPetEntrance, number> = {
+  walk: 450,
+  balloon: 1250,
+  bubble: 700,
+};
+
+// One full ledge crossing per passer kind. The snail is the point of the
+// snail: glance away, glance back, still crossing.
+export const LOBSTER_PASSER_CROSS_MS: Record<LobsterPasserKind, number> = {
+  stranger: 11_000,
+  crab: 11_000,
+  snail: 90_000,
+  duck: 14_000,
+  jellyfish: 16_000,
+};
 
 export type LobsterPetAnchor = "ledge" | "bar";
 
@@ -179,27 +203,99 @@ export function isLobsterLogoLoad(seed: number): boolean {
   return mulberry32((seed ^ 0x1063) >>> 0)() < 0.12;
 }
 
-type LobsterPasserKind = "stranger" | "crab";
-
 export type LobsterPasserPlan = {
   kind: LobsterPasserKind;
   atMs: number;
   direction: 1 | -1;
 };
 
-// Once per load, someone else might just... walk through. Strangers are
-// other lobsters that never stop; the crab is not a lobster and refuses to
-// discuss it. Neither counts for the Lobsterdex.
+// Once per load, someone else might just... pass through. Strangers are
+// other lobsters that never stop; the rest of the traffic is a crab (not a
+// lobster, refuses to discuss it), a snail, a rubber duck, or a jellyfish.
+// The 9.5% event gate is unchanged from the two-kind era — variety widened,
+// frequency did not. None of them count for the Lobsterdex.
 export function planLobsterPasser(seed: number): LobsterPasserPlan | null {
   const rng = mulberry32((seed ^ 0xcab) >>> 0);
   const roll = rng();
   if (roll >= 0.095) {
     return null;
   }
-  const kind: LobsterPasserKind = roll < 0.015 ? "crab" : "stranger";
+  const kind: LobsterPasserKind =
+    roll < 0.015
+      ? "crab"
+      : roll < 0.027
+        ? "snail"
+        : roll < 0.039
+          ? "duck"
+          : roll < 0.05
+            ? "jellyfish"
+            : "stranger";
   const atMs = Math.round(60_000 + rng() * 840_000);
   const direction: 1 | -1 = rng() < 0.5 ? 1 : -1;
   return { kind, atMs, direction };
+}
+
+// A very rare load hosts the Elder: a huge, barnacled, unhurried lobster.
+// Lobsters famously never really stop growing; this one simply started
+// earlier than everyone else.
+export function isLobsterElderLoad(seed: number): boolean {
+  return mulberry32((seed ^ 0xe1d3) >>> 0)() < 0.015;
+}
+
+// Sometimes the visitor is not a stranger at all: a palette the Lobsterdex
+// already remembers comes back wearing its recorded name. Returns the chosen
+// palette id, or null for an ordinary load. Candidates must be passed in
+// (sorted) so this stays a pure plan.
+export function planLobsterOldFriend(
+  seed: number,
+  knownPaletteIds: readonly string[],
+): string | null {
+  if (knownPaletteIds.length === 0) {
+    return null;
+  }
+  const rng = mulberry32((seed ^ 0xf21e) >>> 0);
+  if (rng() >= 0.08) {
+    return null;
+  }
+  return knownPaletteIds[Math.floor(rng() * knownPaletteIds.length)] ?? null;
+}
+
+// Ledge lore, delivered by sea. Shown through the bottle's title tooltip
+// (the pet-name channel), so there is no i18n surface.
+export const LOBSTER_BOTTLE_FORTUNES = [
+  "the tide returns every branch to shore",
+  "molt before you feel ready",
+  "a shell is just armor you outgrew",
+  "somewhere, a test is green because of you",
+  "swim sideways when forward fails",
+  "the reef remembers kind commits",
+  "even the abyss keeps a night light",
+  "barnacles are only patient passengers",
+  "no current lasts forever",
+  "bury your treasure in version control",
+  "the crab was a lobster all along",
+  "small claws, firm grip",
+  "rest is also progress",
+  "what washes away was never pinned",
+] as const;
+
+export type LobsterBottlePlan = {
+  atMs: number;
+  spotPct: number;
+  fortuneIndex: number;
+};
+
+// A few loads beach a message in a bottle somewhere on the ledge. It is not
+// the pet's: it appears on its own clock and outlives visits.
+export function planLobsterBottle(seed: number): LobsterBottlePlan | null {
+  const rng = mulberry32((seed ^ 0xb077) >>> 0);
+  if (rng() >= 0.03) {
+    return null;
+  }
+  const atMs = Math.round(45_000 + rng() * 855_000);
+  const spotPct = Math.round(15 + rng() * 70);
+  const fortuneIndex = Math.floor(rng() * LOBSTER_BOTTLE_FORTUNES.length);
+  return { atMs, spotPct, fortuneIndex };
 }
 
 // The pet notices gateway upgrades: the first page load on a new version, it

--- a/ui/src/components/lobster-pet-plans.ts
+++ b/ui/src/components/lobster-pet-plans.ts
@@ -1,12 +1,14 @@
 import { getSafeLocalStorage } from "../local-storage.ts";
+import { getLobsterdex, getLobsterdexEntries } from "./lobster-dex.ts";
 import type {
   LobsterPasserKind,
   LobsterPetEntrance,
+  LobsterPetLook,
   LobsterPetMode,
   LobsterPetPersonalityId,
   LobsterRunOutcome,
 } from "./lobster-pet-contract.ts";
-import { mulberry32, SPOT_ZONES } from "./lobster-pet-look.ts";
+import { LOBSTER_PET_PALETTES, lobsterPetName, mulberry32, SPOT_ZONES } from "./lobster-pet-look.ts";
 
 export { SPOT_ZONES };
 
@@ -258,6 +260,76 @@ export function planLobsterOldFriend(
     return null;
   }
   return knownPaletteIds[Math.floor(rng() * knownPaletteIds.length)] ?? null;
+}
+
+export type LobsterLoadIdentity = {
+  elder: boolean;
+  oldFriend: boolean;
+  friendName: string | null;
+  dexComplete: boolean;
+  look: LobsterPetLook;
+};
+
+// Rare per-load identities, resolved on top of the seeded look: the Elder
+// outranks an old-friend return, and retro looks (grail or anniversary dress
+// code) are never repainted. Lobsterdex completion is snapshotted here too,
+// so the golden ledge trim appears between loads, never mid-visit.
+export function resolveLobsterLoadIdentity(
+  seed: number,
+  look: LobsterPetLook,
+): LobsterLoadIdentity {
+  const seen = getLobsterdex();
+  const dexComplete = LOBSTER_PET_PALETTES.every((palette) => seen.has(palette.id));
+  const base: LobsterLoadIdentity = {
+    elder: false,
+    oldFriend: false,
+    friendName: null,
+    dexComplete,
+    look,
+  };
+  if (isLobsterElderLoad(seed)) {
+    // The Elder never molts or crushes: it is already every size it needs.
+    return {
+      ...base,
+      elder: true,
+      look: {
+        ...look,
+        scale: 3,
+        accessory: "barnacle",
+        personality: "sleepy",
+        clawSize: "mighty",
+        crusherSide: null,
+      },
+    };
+  }
+  if (look.palette.id === "retro") {
+    return base;
+  }
+  const known = [...seen]
+    .filter((id) => LOBSTER_PET_PALETTES.some((palette) => palette.id === id))
+    .toSorted();
+  const friendId = planLobsterOldFriend(seed, known);
+  const palette = friendId
+    ? LOBSTER_PET_PALETTES.find((entry) => entry.id === friendId)
+    : undefined;
+  if (!palette) {
+    return base;
+  }
+  return {
+    ...base,
+    oldFriend: true,
+    friendName: getLobsterdexEntries().get(palette.id)?.name ?? null,
+    look: { ...look, palette },
+  };
+}
+
+// The displayed base name before honorifics: rare identities override the
+// seeded catalog name.
+export function lobsterLoadDisplayName(identity: LobsterLoadIdentity, seed: number): string {
+  if (identity.elder) {
+    return "Methuselah";
+  }
+  return identity.friendName ?? lobsterPetName(identity.look, seed);
 }
 
 // Ledge lore, delivered by sea. Shown through the bottle's title tooltip

--- a/ui/src/components/lobster-pet-plans.ts
+++ b/ui/src/components/lobster-pet-plans.ts
@@ -245,18 +245,15 @@ export function planLobsterPasser(seed: number): LobsterPasserPlan | null {
 // A very rare load hosts the Elder: a huge, barnacled, unhurried lobster.
 // Lobsters famously never really stop growing; this one simply started
 // earlier than everyone else.
-export function isLobsterElderLoad(seed: number): boolean {
+function isLobsterElderLoad(seed: number): boolean {
   return mulberry32((seed ^ 0xe1d3) >>> 0)() < 0.015;
 }
 
 // Sometimes the visitor is not a stranger at all: a palette the Lobsterdex
 // already remembers comes back wearing its recorded name. Returns the chosen
-// palette id, or null for an ordinary load. Candidates must be passed in
+// palette id, or null for an ordinary load. Candidates are passed in
 // (sorted) so this stays a pure plan.
-export function planLobsterOldFriend(
-  seed: number,
-  knownPaletteIds: readonly string[],
-): string | null {
+function planLobsterOldFriend(seed: number, knownPaletteIds: readonly string[]): string | null {
   if (knownPaletteIds.length === 0) {
     return null;
   }

--- a/ui/src/components/lobster-pet-sprites.ts
+++ b/ui/src/components/lobster-pet-sprites.ts
@@ -345,7 +345,10 @@ function renderJellyfishSvg() {
   `;
 }
 
-export const PASSER_SPRITES: Record<Exclude<LobsterPasserKind, "stranger">, () => TemplateResult> = {
+export const PASSER_SPRITES: Record<
+  Exclude<LobsterPasserKind, "stranger">,
+  () => TemplateResult
+> = {
   crab: renderCrabSvg,
   snail: renderSnailSvg,
   duck: renderDuckSvg,
@@ -386,7 +389,6 @@ export const BALLOON = svg`
     <ellipse cx="15" cy="10" rx="4" ry="6" fill="#ffffff" opacity="0.3" />
   </svg>
 `;
-
 
 export const PASSER_TITLES: Record<LobsterPasserKind, string> = {
   stranger: "a stranger",

--- a/ui/src/components/lobster-pet-sprites.ts
+++ b/ui/src/components/lobster-pet-sprites.ts
@@ -1,0 +1,397 @@
+// The lobster pet's art locker: every static SVG sprite the look renderer
+// and scene composer draw from - accessories, rare-palette geometry, retro
+// homage parts, ledge visitors, and the bottle. Pure presentation; all
+// selection logic stays in lobster-pet-look.ts.
+import { svg, type TemplateResult } from "lit";
+import type {
+  LobsterPasserKind,
+  LobsterPetAccessory,
+  LobsterPetAntennae,
+  LobsterPetPaletteId,
+} from "./lobster-pet-contract.ts";
+
+export const ACCESSORY_SPRITES: Record<Exclude<LobsterPetAccessory, "none">, TemplateResult> = {
+  crown: svg`
+    <path
+      d="M46 12 L46 2 L53 8 L60 0 L67 8 L74 2 L74 12 Q60 8 46 12 Z"
+      fill="#f6c945"
+    />
+  `,
+  sprout: svg`
+    <g>
+      <path d="M60 12 Q58 4 63 1" stroke="#3f9d63" stroke-width="3" stroke-linecap="round" fill="none" />
+      <ellipse cx="67" cy="3" rx="5" ry="3" fill="#57c785" transform="rotate(-24 67 3)" />
+    </g>
+  `,
+  patch: svg`
+    <g>
+      <path d="M28 27 Q60 14 92 22" stroke="#101820" stroke-width="4" stroke-linecap="round" fill="none" />
+      <circle cx="75" cy="32" r="9" fill="#101820" />
+    </g>
+  `,
+  santa: svg`
+    <g>
+      <path d="M47 10 Q54 1 68 3 L72 9 Z" fill="#e0312f" />
+      <circle cx="71" cy="3.5" r="3.5" fill="#f5f7fa" />
+      <ellipse cx="59" cy="10.5" rx="15" ry="3.5" fill="#f5f7fa" />
+    </g>
+  `,
+  pumpkin: svg`
+    <g>
+      <ellipse cx="60" cy="6.5" rx="8.5" ry="5.5" fill="#e8871e" />
+      <path d="M56 2.5 Q56 6.5 56 10.5 M64 2.5 Q64 6.5 64 10.5" stroke="#c96a10" stroke-width="1.5" fill="none" />
+      <path d="M60 1.5 Q60.5 0 63 0.5" stroke="#4c9a4c" stroke-width="2.5" stroke-linecap="round" fill="none" />
+    </g>
+  `,
+  party: svg`
+    <g>
+      <path d="M52 11 L60 0.5 L68 11 Z" fill="#7c5cff" />
+      <path d="M55.5 6.5 L64.5 6.5" stroke="#ffd166" stroke-width="2" />
+      <circle cx="60" cy="1" r="2.4" fill="#ff5c8a" />
+    </g>
+  `,
+  // Elder wear: a patient little colony riding the shell's shoulder.
+  barnacle: svg`
+    <g class="lob-barnacles">
+      <path d="M32 22 L36.5 13 L41 22 Z" fill="#cfd8de" />
+      <path d="M42 18 L45.5 11 L49 18 Z" fill="#b8c4cc" />
+      <path d="M27 26 L30 20.5 L33 26 Z" fill="#b8c4cc" />
+      <circle cx="36.5" cy="18.5" r="1.1" fill="#8a949d" />
+      <circle cx="45.5" cy="15" r="0.9" fill="#8a949d" />
+    </g>
+  `,
+  // National Lobster Day formal wear: gold rim, chain, no further questions.
+  monocle: svg`
+    <g class="lob-monocle" fill="none" stroke="#f4b840">
+      <circle cx="75" cy="32" r="8.5" stroke-width="2.5" />
+      <path d="M81 39 Q85 48 80 56" stroke-width="1.5" />
+    </g>
+  `,
+};
+
+// Light speckle trait, distinct from calico's bold mottling; skipped on
+// palettes whose identity is already pattern-driven (see renderLobsterSvg).
+export const FRECKLE_SPOTS = svg`
+  <g class="lob-freckles" fill="#ffffff" opacity="0.3">
+    <circle cx="42" cy="45" r="1.6" />
+    <circle cx="50" cy="41" r="1.2" />
+    <circle cx="70" cy="45" r="1.6" />
+    <circle cx="78" cy="41" r="1.2" />
+    <circle cx="55" cy="62" r="1.4" />
+    <circle cx="67" cy="66" r="1.2" />
+  </g>
+`;
+
+// Lumen photophores: dotted running lights along the shell. The glow (and
+// its dark-theme-only intensity) lives in lobster-pet.css.
+export const LUMEN_SPOTS = svg`
+  <g class="lob-lumen" fill="#7ef5dd">
+    <circle cx="36" cy="54" r="2.4" />
+    <circle cx="50" cy="66" r="2" />
+    <circle cx="66" cy="70" r="2.2" />
+    <circle cx="80" cy="60" r="2" />
+    <circle cx="88" cy="46" r="1.7" />
+    <circle cx="60" cy="86" r="1.7" />
+  </g>
+`;
+
+// Palettes whose identity is already pattern-driven skip the freckle trait;
+// stacking speckle sets reads as noise, not a variant.
+export const PATTERNED_PALETTES: ReadonlySet<LobsterPetPaletteId> = new Set([
+  "calico",
+  "split",
+  "retro",
+  "lumen",
+]);
+
+// Calico mottling: dark blotches scattered clear of the eye line.
+export const CALICO_SPOTS = svg`
+  <g class="lob-spots" fill="#2a1f16" opacity="0.8">
+    <ellipse cx="40" cy="50" rx="6" ry="4" transform="rotate(-15 40 50)" />
+    <ellipse cx="72" cy="62" rx="7" ry="4.5" transform="rotate(18 72 62)" />
+    <ellipse cx="55" cy="76" rx="5" ry="3.5" transform="rotate(-8 55 76)" />
+    <ellipse cx="84" cy="42" rx="4" ry="3" transform="rotate(25 84 42)" />
+    <ellipse cx="47" cy="18" rx="4.5" ry="3" transform="rotate(-20 47 18)" />
+    <ellipse cx="30" cy="64" rx="4" ry="3" transform="rotate(12 30 64)" />
+  </g>
+`;
+
+// Split two-tone: the right half of the body (down to the belly midline)
+// repainted in the second shell color; the right claw and antenna follow via
+// CSS. Mirrors the famous bilateral half-and-half lobsters.
+export const SPLIT_HALF = svg`
+  <path
+    class="lob-split-half"
+    d="M60 8 C88 8 104 32 104 52 C104 72 90 90 76 95 L76 104 L66 104 L66 96 C64 96.8 62 97.1 60 97.1 L60 8 Z"
+    fill="var(--lob-shell2, #46536b)"
+  />
+`;
+
+// Retro homage parts (classic OpenClaw logo): one oversized raised claw with
+// a pincer notch, tall V antennae, angry brows, and a smirk. The mega claw
+// lives inside the .lob-claw--r group so wave/snip acts swing it.
+export const RETRO_MEGA_CLAW = svg`
+  <path
+    d="M95 55 C112 53 119 39 116 25 C113 11 99 5 91 12 C88 15 87 19 88 23 C83 27 83 36 88 43 C91 49 93 52 95 55 Z"
+    fill="var(--lob-claw)"
+  />
+  <path
+    d="M92 14 C97 22 99 31 95 41"
+    stroke="#b8151b"
+    stroke-width="3"
+    stroke-linecap="round"
+    fill="none"
+  />
+`;
+
+export const RETRO_ANTENNAE = svg`
+  <g class="lob-antennae" stroke="var(--lob-shell)" stroke-width="4" stroke-linecap="round" fill="none">
+    <path d="M50 16 Q45 4 37 1" />
+    <path d="M70 16 Q75 4 83 1" />
+  </g>
+`;
+
+export const RETRO_FACE = svg`
+  <g stroke="#0a1014" stroke-linecap="round" fill="none">
+    <path d="M37 24 L51 28" stroke-width="3.5" />
+    <path d="M69 28 L83 24" stroke-width="3.5" />
+    <path d="M49 45 Q59 51 69 45 L72 42" stroke-width="3" />
+  </g>
+`;
+
+// Tail-fan lobes peek out diagonally behind the lower body (drawn before the
+// body path so they read as "behind"). Fill color lives in lobster-pet.css.
+export const TAIL_FAN = svg`
+  <g class="lob-tail">
+    <ellipse cx="16" cy="84" rx="11" ry="7" transform="rotate(-32 16 84)" />
+    <ellipse cx="104" cy="84" rx="11" ry="7" transform="rotate(32 104 84)" />
+  </g>
+`;
+
+// Moving-day bindle: a stick over the shoulder with a polka-dot bundle,
+// carried for the whole first load after a gateway upgrade.
+export const BINDLE = svg`
+  <g class="lob-bindle">
+    <path d="M70 62 L99 30" stroke="#8a5a2b" stroke-width="3.5" stroke-linecap="round" />
+    <circle cx="101" cy="27" r="9.5" fill="#e8b04b" />
+    <circle cx="98" cy="24" r="1.6" fill="#b6791f" />
+    <circle cx="104" cy="29" r="1.6" fill="#b6791f" />
+    <circle cx="100" cy="32" r="1.3" fill="#b6791f" />
+  </g>
+`;
+
+// On lobster days (see src/shared/lobster-day.ts, shared with the CLI
+// banner cousin) the pet wears a little sailor cap - unless the seed already
+// rolled headwear, which keeps its place.
+export const HEADWEAR: ReadonlySet<LobsterPetAccessory> = new Set([
+  "crown",
+  "sprout",
+  "santa",
+  "pumpkin",
+  "party",
+]);
+
+export const SAILOR_CAP = svg`
+  <g class="lob-cap">
+    <path d="M46 10 Q60 -3 74 10 L74 13 Q60 7 46 13 Z" fill="#f5f7fa" />
+    <path d="M45 12 Q60 6 75 12 L75 16 Q60 10.5 45 16 Z" fill="#dfe7ee" />
+    <circle cx="60" cy="2.5" r="1.8" fill="#3b6ea5" />
+  </g>
+`;
+
+// Shown while grumpy (poked too much): angry brows and a frown.
+export const GRUMPY_FACE = svg`
+  <g stroke="#0a1014" stroke-linecap="round" fill="none">
+    <path d="M37 24 L51 28" stroke-width="3.5" />
+    <path d="M69 28 L83 24" stroke-width="3.5" />
+    <path d="M50 48 Q60 42 70 48" stroke-width="3" />
+  </g>
+`;
+
+export const ANTENNAE_SPRITES: Record<LobsterPetAntennae, TemplateResult> = {
+  perky: svg`
+    <g class="lob-antennae" stroke="var(--lob-shell)" stroke-width="4" stroke-linecap="round" fill="none">
+      <path d="M46 14 Q38 4 31 7" />
+      <path d="M74 14 Q82 4 89 7" />
+    </g>
+  `,
+  droopy: svg`
+    <g class="lob-antennae" stroke="var(--lob-shell)" stroke-width="4" stroke-linecap="round" fill="none">
+      <path d="M46 14 Q36 8 34 18" />
+      <path d="M74 14 Q84 8 86 18" />
+    </g>
+  `,
+};
+
+// Not a lobster. Wide shell, eye stalks, walks sideways across the ledge,
+// and the Lobsterdex refuses to acknowledge it.
+function renderCrabSvg() {
+  return svg`
+    <svg
+      class="lobster-pet__svg"
+      viewBox="0 0 120 105"
+      preserveAspectRatio="none"
+      aria-hidden="true"
+    >
+      <g stroke="#a63a2e" stroke-width="4" stroke-linecap="round" fill="none">
+        <path d="M22 78 L8 88" />
+        <path d="M28 88 L16 99" />
+        <path d="M98 78 L112 88" />
+        <path d="M92 88 L104 99" />
+      </g>
+      <g stroke="#c44536" stroke-width="3.5" stroke-linecap="round" fill="none">
+        <path d="M44 38 L40 24" />
+        <path d="M76 38 L80 24" />
+      </g>
+      <circle cx="40" cy="22" r="4.5" fill="#0a1014" />
+      <circle cx="80" cy="22" r="4.5" fill="#0a1014" />
+      <circle cx="41.5" cy="20.5" r="1.8" fill="#ffd166" />
+      <circle cx="81.5" cy="20.5" r="1.8" fill="#ffd166" />
+      <ellipse cx="60" cy="70" rx="46" ry="30" fill="#c44536" />
+      <ellipse cx="48" cy="60" rx="16" ry="9" fill="#ffffff" opacity="0.1" />
+      <path
+        d="M16 58 C2 52 -2 62 4 72 C10 82 20 76 24 66 C26 60 22 58 16 58 Z"
+        fill="#d95f4b"
+      />
+      <path
+        d="M104 58 C118 52 122 62 116 72 C110 82 100 76 96 66 C94 60 98 58 104 58 Z"
+        fill="#d95f4b"
+      />
+      <path d="M48 82 Q60 90 72 82" stroke="#7e2a20" stroke-width="3" stroke-linecap="round" fill="none" />
+    </svg>
+  `;
+}
+
+// Also not a lobster. Crosses the ledge on its own schedule, which is to
+// say: eventually.
+function renderSnailSvg() {
+  return svg`
+    <svg
+      class="lobster-pet__svg"
+      viewBox="0 0 120 105"
+      preserveAspectRatio="none"
+      aria-hidden="true"
+    >
+      <path
+        d="M14 96 Q32 84 58 88 L96 88 Q110 90 112 97 Q112 103 102 103 L24 103 Q14 103 14 96 Z"
+        fill="#c9a06a"
+      />
+      <g stroke="#c9a06a" stroke-width="3.5" stroke-linecap="round" fill="none">
+        <path d="M94 88 Q96 76 91 68" />
+        <path d="M103 88 Q107 76 103 66" />
+      </g>
+      <circle cx="90" cy="65" r="3.6" fill="#0a1014" />
+      <circle cx="103" cy="63" r="3.6" fill="#0a1014" />
+      <circle cx="91" cy="64" r="1.3" fill="#ffd166" />
+      <circle cx="104" cy="62" r="1.3" fill="#ffd166" />
+      <circle cx="50" cy="62" r="27" fill="#8a5a2b" />
+      <path
+        d="M50 41 a21 21 0 1 1 -15 36 a14 14 0 1 0 11 -25 a8 8 0 1 0 4 14"
+        stroke="#5f3d1c"
+        stroke-width="4"
+        stroke-linecap="round"
+        fill="none"
+      />
+    </svg>
+  `;
+}
+
+// The rubber duck: patron saint of debugging. It floats through, listens,
+// and leaves without judging anyone's architecture.
+function renderDuckSvg() {
+  return svg`
+    <svg
+      class="lobster-pet__svg"
+      viewBox="0 0 120 105"
+      preserveAspectRatio="none"
+      aria-hidden="true"
+    >
+      <path d="M30 82 Q20 74 27 65 Q30 76 40 79 Z" fill="#f0b52e" />
+      <ellipse cx="58" cy="85" rx="34" ry="17" fill="#ffd23e" />
+      <circle cx="82" cy="50" r="18" fill="#ffd23e" />
+      <path d="M98 49 Q112 52 99 59 Q95 56 95 51 Z" fill="#ff8c2e" />
+      <circle cx="86" cy="44" r="3.6" fill="#0a1014" />
+      <circle cx="87" cy="43" r="1.3" fill="#ffffff" />
+      <path d="M44 82 Q58 72 72 82 Q58 93 44 82 Z" fill="#f0b52e" opacity="0.75" />
+    </svg>
+  `;
+}
+
+// A jellyfish drifting past above the ledge, pulsing gently, thinking about
+// nothing at all.
+function renderJellyfishSvg() {
+  return svg`
+    <svg
+      class="lobster-pet__svg"
+      viewBox="0 0 120 105"
+      preserveAspectRatio="none"
+      aria-hidden="true"
+    >
+      <g class="lob-jelly-tentacles" stroke="#9f7dfa" stroke-width="2.5" stroke-linecap="round" fill="none" opacity="0.8">
+        <path d="M40 58 Q35 74 42 90" />
+        <path d="M54 61 Q52 78 57 96" />
+        <path d="M68 61 Q71 78 64 94" />
+        <path d="M80 58 Q85 72 78 88" />
+      </g>
+      <path
+        d="M30 52 C30 22 90 22 90 52 L90 58 Q82 52 75 58 Q67 52 60 58 Q52 52 45 58 Q38 52 30 58 Z"
+        fill="#b79bff"
+        opacity="0.78"
+      />
+      <ellipse cx="47" cy="37" rx="12" ry="6" fill="#ffffff" opacity="0.25" />
+      <circle cx="52" cy="45" r="2.6" fill="#0a1014" />
+      <circle cx="66" cy="45" r="2.6" fill="#0a1014" />
+    </svg>
+  `;
+}
+
+export const PASSER_SPRITES: Record<Exclude<LobsterPasserKind, "stranger">, () => TemplateResult> = {
+  crab: renderCrabSvg,
+  snail: renderSnailSvg,
+  duck: renderDuckSvg,
+  jellyfish: renderJellyfishSvg,
+};
+
+// While hovering, a closed bottle keeps its secret; opening swaps the title
+// to the fortune — the pet-name tooltip channel, so no i18n surface.
+export function renderBottleSvg(opened: boolean) {
+  return svg`
+    <svg class="lobster-bottle__svg" viewBox="0 0 48 44" aria-hidden="true">
+      <g transform="rotate(-16 24 30)">
+        <rect x="5" y="18" width="30" height="16" rx="7" fill="#7fc8b8" opacity="0.72" />
+        <rect x="33" y="22" width="9" height="8" rx="2.5" fill="#7fc8b8" opacity="0.72" />
+        ${
+          opened
+            ? svg`
+              <rect x="36" y="20" width="11" height="7" rx="1.5" fill="#f2e5c9" transform="rotate(-24 41 23)" />
+              <rect x="43" y="30" width="4.5" height="8" rx="1.6" fill="#8a5a2b" transform="rotate(38 45 34)" />
+            `
+            : svg`<rect x="41" y="21.5" width="5" height="9" rx="1.8" fill="#8a5a2b" />`
+        }
+        <rect x="11" y="22" width="12" height="8" rx="1.5" fill="#f2e5c9" />
+        <path d="M13 24.5 L21 24.5 M13 27 L19 27" stroke="#b6a071" stroke-width="1" />
+        <ellipse cx="13" cy="20.5" rx="5" ry="2" fill="#ffffff" opacity="0.35" />
+      </g>
+    </svg>
+  `;
+}
+
+// Balloon entrance rig: rendered inside the body while the descent plays,
+// then unmounts with the entering flag.
+export const BALLOON = svg`
+  <svg class="lobster-pet__balloon" viewBox="0 0 40 62" aria-hidden="true">
+    <path d="M20 34 Q23 46 18 60" stroke="#8a949d" stroke-width="1.5" fill="none" />
+    <ellipse cx="20" cy="16" rx="13" ry="15" fill="#ff5c8a" />
+    <path d="M17 30 L20 34.5 L23 30 Z" fill="#e0446f" />
+    <ellipse cx="15" cy="10" rx="4" ry="6" fill="#ffffff" opacity="0.3" />
+  </svg>
+`;
+
+
+export const PASSER_TITLES: Record<LobsterPasserKind, string> = {
+  stranger: "a stranger",
+  crab: "definitely a lobster",
+  snail: "in no particular hurry",
+  duck: "a duck. obviously",
+  jellyfish: "just drifting",
+};

--- a/ui/src/components/lobster-pet-standin.ts
+++ b/ui/src/components/lobster-pet-standin.ts
@@ -1,11 +1,7 @@
 import { html, LitElement, nothing } from "lit";
 import { property } from "lit/decorators.js";
 import type { LobsterLogoVisitDetail } from "./lobster-pet-contract.ts";
-import {
-  LOBSTER_PET_BUILD_MULS,
-  LOBSTER_PET_CLAW_MULS,
-  renderLobsterSvg,
-} from "./lobster-pet-look.ts";
+import { lobsterLookStyleVars, renderLobsterSvg } from "./lobster-pet-look.ts";
 
 class LobsterLogoStandIn extends LitElement {
   override createRenderRoot() {
@@ -23,18 +19,12 @@ class LobsterLogoStandIn extends LitElement {
     const classes = [
       "sidebar-brand__pet",
       `lobster-pet--palette-${look.palette.id}`,
+      look.shiny ? "lobster-pet--shiny" : "",
       visit.phase === "leaving" ? "sidebar-brand__pet--leaving" : "",
     ]
       .filter(Boolean)
       .join(" ");
-    const style = [
-      `--lob-shell:${look.palette.shell}`,
-      `--lob-claw:${look.palette.claw}`,
-      `--lob-blink-delay:${look.blinkDelayS}s`,
-      `--lob-w:${LOBSTER_PET_BUILD_MULS[look.build].w}`,
-      `--lob-h:${LOBSTER_PET_BUILD_MULS[look.build].h}`,
-      `--lob-claw-scale:${LOBSTER_PET_CLAW_MULS[look.clawSize]}`,
-    ].join(";");
+    const style = lobsterLookStyleVars(look).join(";");
     return html`
       <span class=${classes} style=${style} title=${`${visit.name} · filling in for the logo`}
         >${renderLobsterSvg(look)}</span

--- a/ui/src/components/lobster-pet-traffic.ts
+++ b/ui/src/components/lobster-pet-traffic.ts
@@ -16,7 +16,7 @@ import {
 
 // Facing, reactions, and the act loop stay owned by the pet element; the
 // controller only reports crossing milestones.
-export type LobsterTrafficHooks = {
+type LobsterTrafficHooks = {
   visitsEnabled: () => boolean;
   // Fired at crossing start (toward the entry side) and mid-cross (travel
   // direction) so the resident can watch the traffic go by.
@@ -25,7 +25,7 @@ export type LobsterTrafficHooks = {
   onPasserDone: () => void;
 };
 
-export type LobsterBottleScene = { spotPct: number; opened: boolean; fortune: string };
+type LobsterBottleScene = { spotPct: number; opened: boolean; fortune: string };
 
 export class LobsterLedgeTraffic implements ReactiveController {
   passer: LobsterPasserPlan | null = null;

--- a/ui/src/components/lobster-pet-traffic.ts
+++ b/ui/src/components/lobster-pet-traffic.ts
@@ -47,6 +47,12 @@ export class LobsterLedgeTraffic implements ReactiveController {
 
   hostDisconnected() {
     this.clearTimers();
+    // The show ends with the host, mirroring the pet's own visit timers
+    // (which also die on disconnect and only re-arm on a seed change):
+    // clear visible guests so a reconnect never shows a frozen passer or an
+    // unebbing bottle.
+    this.passer = null;
+    this.bottleVisible = false;
   }
 
   // Re-plans both events for a (re)seeded load.

--- a/ui/src/components/lobster-pet-traffic.ts
+++ b/ui/src/components/lobster-pet-traffic.ts
@@ -50,9 +50,10 @@ export class LobsterLedgeTraffic implements ReactiveController {
     // The show ends with the host, mirroring the pet's own visit timers
     // (which also die on disconnect and only re-arm on a seed change):
     // clear visible guests so a reconnect never shows a frozen passer or an
-    // unebbing bottle.
+    // unebbing bottle. The update request flushes on reattach.
     this.passer = null;
     this.bottleVisible = false;
+    this.host.requestUpdate();
   }
 
   // Re-plans both events for a (re)seeded load.

--- a/ui/src/components/lobster-pet-traffic.ts
+++ b/ui/src/components/lobster-pet-traffic.ts
@@ -1,0 +1,164 @@
+// The ledge's uninvited guests: pass-through visitors (strangers, the crab,
+// the snail, the duck, the jellyfish) and the message in a bottle. Both run
+// on their own seeded clocks, independent of the resident's visit schedule;
+// a ReactiveController keeps the pet element focused on the resident.
+import { expectDefined } from "@openclaw/normalization-core";
+import type { ReactiveController, ReactiveControllerHost } from "lit";
+import {
+  LOBSTER_BOTTLE_FORTUNES,
+  LOBSTER_PASSER_CROSS_MS,
+  planLobsterBottle,
+  planLobsterPasser,
+  prefersReducedMotion,
+  type LobsterBottlePlan,
+  type LobsterPasserPlan,
+} from "./lobster-pet-plans.ts";
+
+// Facing, reactions, and the act loop stay owned by the pet element; the
+// controller only reports crossing milestones.
+export type LobsterTrafficHooks = {
+  visitsEnabled: () => boolean;
+  // Fired at crossing start (toward the entry side) and mid-cross (travel
+  // direction) so the resident can watch the traffic go by.
+  onPasserFacing: (facing: 1 | -1) => void;
+  onPasserMidCross: () => void;
+  onPasserDone: () => void;
+};
+
+export type LobsterBottleScene = { spotPct: number; opened: boolean; fortune: string };
+
+export class LobsterLedgeTraffic implements ReactiveController {
+  passer: LobsterPasserPlan | null = null;
+  private bottlePlan: LobsterBottlePlan | null = null;
+  private bottleVisible = false;
+  private bottleOpened = false;
+  private passerTimer: number | null = null;
+  private passerEndTimer: number | null = null;
+  private passerWatchTimer: number | null = null;
+  private bottleTimer: number | null = null;
+  private bottleEndTimer: number | null = null;
+
+  constructor(
+    private readonly host: ReactiveControllerHost,
+    private readonly hooks: LobsterTrafficHooks,
+  ) {
+    host.addController(this);
+  }
+
+  hostDisconnected() {
+    this.clearTimers();
+  }
+
+  // Re-plans both events for a (re)seeded load.
+  reset(seed: number) {
+    this.clearTimers();
+    this.passer = null;
+    this.bottleVisible = false;
+    this.bottleOpened = false;
+    this.schedulePasser(seed);
+    this.scheduleBottle(seed);
+  }
+
+  passerCrossMs(): number {
+    return this.passer ? LOBSTER_PASSER_CROSS_MS[this.passer.kind] : 0;
+  }
+
+  bottle(): LobsterBottleScene | null {
+    if (!this.bottleVisible || !this.bottlePlan) {
+      return null;
+    }
+    return {
+      spotPct: this.bottlePlan.spotPct,
+      opened: this.bottleOpened,
+      fortune: expectDefined(
+        LOBSTER_BOTTLE_FORTUNES[this.bottlePlan.fortuneIndex],
+        "lobster bottle fortune",
+      ),
+    };
+  }
+
+  readonly openBottle = () => {
+    if (this.bottleOpened || !this.bottleVisible) {
+      return;
+    }
+    this.bottleOpened = true;
+    // Read, then reclaimed by the sea a couple of minutes later.
+    this.armBottleEbb(120_000);
+    this.host.requestUpdate();
+  };
+
+  private clearTimers() {
+    for (const timer of [
+      this.passerTimer,
+      this.passerEndTimer,
+      this.passerWatchTimer,
+      this.bottleTimer,
+      this.bottleEndTimer,
+    ]) {
+      if (timer !== null) {
+        window.clearTimeout(timer);
+      }
+    }
+    this.passerTimer = null;
+    this.passerEndTimer = null;
+    this.passerWatchTimer = null;
+    this.bottleTimer = null;
+    this.bottleEndTimer = null;
+  }
+
+  private schedulePasser(seed: number) {
+    const plan = planLobsterPasser(seed);
+    if (!plan || prefersReducedMotion()) {
+      return;
+    }
+    this.passerTimer = window.setTimeout(() => {
+      this.passerTimer = null;
+      if (!this.hooks.visitsEnabled() || document.hidden) {
+        return;
+      }
+      this.passer = plan;
+      this.host.requestUpdate();
+      const crossMs = LOBSTER_PASSER_CROSS_MS[plan.kind];
+      this.hooks.onPasserFacing(plan.direction === 1 ? -1 : 1);
+      this.passerWatchTimer = window.setTimeout(() => {
+        this.passerWatchTimer = null;
+        this.hooks.onPasserFacing(plan.direction);
+        // Mid-crossing is when the passer is closest: friends wave at the
+        // traffic, shy pets duck for a peek, regulars just watch it pass.
+        this.hooks.onPasserMidCross();
+      }, crossMs / 2);
+      this.passerEndTimer = window.setTimeout(() => {
+        this.passerEndTimer = null;
+        this.passer = null;
+        this.host.requestUpdate();
+        this.hooks.onPasserDone();
+      }, crossMs);
+    }, plan.atMs);
+  }
+
+  // The bottle keeps its own clock: it washes up whether or not the pet is
+  // around, waits to be opened, and drifts back out with the tide.
+  private scheduleBottle(seed: number) {
+    this.bottlePlan = planLobsterBottle(seed);
+    if (!this.bottlePlan) {
+      return;
+    }
+    this.bottleTimer = window.setTimeout(() => {
+      this.bottleTimer = null;
+      this.bottleVisible = true;
+      this.host.requestUpdate();
+      this.armBottleEbb(300_000);
+    }, this.bottlePlan.atMs);
+  }
+
+  private armBottleEbb(delayMs: number) {
+    if (this.bottleEndTimer !== null) {
+      window.clearTimeout(this.bottleEndTimer);
+    }
+    this.bottleEndTimer = window.setTimeout(() => {
+      this.bottleEndTimer = null;
+      this.bottleVisible = false;
+      this.host.requestUpdate();
+    }, delayMs);
+  }
+}

--- a/ui/src/components/lobster-pet.test.ts
+++ b/ui/src/components/lobster-pet.test.ts
@@ -5,7 +5,16 @@ import { render } from "lit";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { getLobsterdex, getLobsterdexEntries } from "./lobster-dex.ts";
 import {
+  LOBSTER_BOTTLE_FORTUNES,
+  isLobsterElderLoad,
+  pickLobsterEntrance,
+  planLobsterBottle,
+  planLobsterOldFriend,
+  planLobsterPasser,
+} from "./lobster-pet-plans.ts";
+import {
   LOBSTER_LOGO_VISIT_EVENT,
+  LOBSTER_PET_PALETTES,
   createLobsterPetLook,
   lobsterPetSeed,
   renderLobsterSvg,
@@ -27,8 +36,10 @@ const LOBSTER_PET_PALETTE_IDS: LobsterPetPaletteId[] = [
   "gold",
   "calico",
   "abyss",
+  "lumen",
   "ghost",
   "split",
+  "cottoncandy",
   "retro",
 ];
 
@@ -139,6 +150,9 @@ describe("lobster pet look", () => {
     const builds = new Set<string>();
     const clawSizes = new Set<string>();
     const tailFans = new Set<boolean>();
+    const crusherSides = new Set<string | null>();
+    const freckleRolls = new Set<boolean>();
+    const glints = new Set<string | null>();
     const neutralDate = new Date("2026-07-15T12:00:00");
     for (let seed = 0; seed < 300; seed++) {
       const look = createLobsterPetLook(seed, neutralDate);
@@ -147,12 +161,17 @@ describe("lobster pet look", () => {
       builds.add(look.build);
       clawSizes.add(look.clawSize);
       tailFans.add(look.tailFan);
+      crusherSides.add(look.crusherSide);
+      freckleRolls.add(look.freckles);
+      glints.add(look.glint);
       expect(LOBSTER_PET_PALETTE_IDS).toContain(look.palette.id);
       expect([1.7, 2, 2.5]).toContain(look.scale);
       expect(["none", "crown", "sprout", "patch"]).toContain(look.accessory);
       expect(["perky", "droopy"]).toContain(look.antennae);
       expect(["round", "squat", "slender"]).toContain(look.build);
       expect(["dainty", "regular", "mighty"]).toContain(look.clawSize);
+      expect([null, "left", "right"]).toContain(look.crusherSide);
+      expect([null, "#ffd166", "#ff8ac2", "#b79bff"]).toContain(look.glint);
       const zone = SPOT_ZONES[look.side];
       expect(look.spotPct).toBeGreaterThanOrEqual(zone[0]);
       expect(look.spotPct).toBeLessThanOrEqual(zone[1]);
@@ -163,25 +182,38 @@ describe("lobster pet look", () => {
     expect(builds.size).toBe(3);
     expect(clawSizes.size).toBe(3);
     expect(tailFans.size).toBe(2);
+    expect(crusherSides).toContain(null);
+    expect(crusherSides.size).toBeGreaterThan(1);
+    expect(freckleRolls.size).toBe(2);
+    expect(glints).toContain(null);
+    expect(glints.size).toBeGreaterThan(1);
   });
 
   it("hatches every rarity tier, with rares staying rare", () => {
     const counts = new Map<string, number>();
+    let shinies = 0;
     const total = 20_000;
     const neutralDate = new Date("2026-07-15T12:00:00");
     for (let seed = 0; seed < total; seed++) {
-      const id = createLobsterPetLook(seed, neutralDate).palette.id;
-      counts.set(id, (counts.get(id) ?? 0) + 1);
+      const look = createLobsterPetLook(seed, neutralDate);
+      counts.set(look.palette.id, (counts.get(look.palette.id) ?? 0) + 1);
+      if (look.shiny) {
+        shinies++;
+      }
     }
-    // Every palette, including the 1% grails, must be reachable.
+    // Every palette, including the sub-1% grails, must be reachable.
     for (const id of LOBSTER_PET_PALETTE_IDS) {
       expect(counts.get(id) ?? 0).toBeGreaterThan(0);
     }
-    // Grails stay grails: ghost/split roll ~1%, retro ~0.5%; commons dominate.
-    for (const grail of ["ghost", "split", "retro"]) {
+    // Grails stay grails: ghost/split ~1%, cottoncandy ~0.8%, retro ~0.5%;
+    // commons dominate.
+    for (const grail of ["ghost", "split", "cottoncandy", "retro"]) {
       expect(counts.get(grail) ?? 0).toBeLessThan(total * 0.03);
     }
     expect((counts.get("crimson") ?? 0) + (counts.get("coral") ?? 0)).toBeGreaterThan(total * 0.4);
+    // Shinies exist and stay near their 1-in-512 odds.
+    expect(shinies).toBeGreaterThan(0);
+    expect(shinies).toBeLessThan(total * 0.006);
   });
 
   it("derives distinct salted seeds per session key, stable within a load", () => {
@@ -207,6 +239,18 @@ describe("seasonal wardrobe", () => {
     expect(julySet.has("santa")).toBe(false);
     expect(julySet.has("pumpkin")).toBe(false);
     expect(julySet.has("party")).toBe(false);
+    expect(julySet.has("monocle")).toBe(false);
+  });
+
+  it("dresses fancy on National Lobster Day", () => {
+    const lobsterDaySet = new Set(
+      Array.from(
+        { length: 400 },
+        (_, seed) => createLobsterPetLook(seed, new Date("2026-09-25T12:00:00")).accessory,
+      ),
+    );
+    expect(lobsterDaySet.has("monocle")).toBe(true);
+    expect(lobsterDaySet.has("pumpkin")).toBe(false);
   });
 
   it("dresses everyone as the classic logo on the repo anniversary", () => {
@@ -882,5 +926,220 @@ describe("lobster pet logo scare", () => {
     await vi.advanceTimersByTimeAsync(5_000);
     await element.updateComplete;
     expect(phases).toEqual([]);
+  });
+});
+
+describe("lobster plans", () => {
+  it("keeps the passer gate near 9.5% while widening the traffic", () => {
+    const counts = new Map<string, number>();
+    const total = 20_000;
+    for (let seed = 0; seed < total; seed++) {
+      const plan = planLobsterPasser(seed);
+      if (!plan) {
+        continue;
+      }
+      counts.set(plan.kind, (counts.get(plan.kind) ?? 0) + 1);
+      expect(plan.atMs).toBeGreaterThanOrEqual(60_000);
+      expect(plan.atMs).toBeLessThanOrEqual(900_000);
+    }
+    for (const kind of ["stranger", "crab", "snail", "duck", "jellyfish"]) {
+      expect(counts.get(kind) ?? 0).toBeGreaterThan(0);
+    }
+    const passers = [...counts.values()].reduce((sum, count) => sum + count, 0);
+    expect(passers).toBeGreaterThan(total * 0.07);
+    expect(passers).toBeLessThan(total * 0.12);
+    // Strangers stay the most common traffic.
+    for (const kind of ["crab", "snail", "duck", "jellyfish"]) {
+      expect(counts.get("stranger") ?? 0).toBeGreaterThan(counts.get(kind) ?? 0);
+    }
+  });
+
+  it("maps entrance rolls to their rarity bands", () => {
+    expect(pickLobsterEntrance(0.01)).toBe("balloon");
+    expect(pickLobsterEntrance(0.06)).toBe("bubble");
+    expect(pickLobsterEntrance(0.129)).toBe("bubble");
+    expect(pickLobsterEntrance(0.13)).toBe("walk");
+    expect(pickLobsterEntrance(0.9)).toBe("walk");
+  });
+
+  it("plans rare elder loads deterministically", () => {
+    let elders = 0;
+    for (let seed = 0; seed < 10_000; seed++) {
+      if (isLobsterElderLoad(seed)) {
+        elders++;
+      }
+    }
+    expect(elders).toBeGreaterThan(0);
+    expect(elders).toBeLessThan(10_000 * 0.03);
+    expect(isLobsterElderLoad(644)).toBe(true);
+  });
+
+  it("returns old friends only from known palettes", () => {
+    expect(planLobsterOldFriend(191, [])).toBeNull();
+    expect(planLobsterOldFriend(191, ["gold", "teal"])).toBe("gold");
+    expect(planLobsterOldFriend(42, ["gold", "teal"])).toBeNull();
+  });
+
+  it("beaches bottles rarely, with fortunes and spots in range", () => {
+    let bottles = 0;
+    const total = 20_000;
+    for (let seed = 0; seed < total; seed++) {
+      const plan = planLobsterBottle(seed);
+      if (!plan) {
+        continue;
+      }
+      bottles++;
+      expect(plan.atMs).toBeGreaterThanOrEqual(45_000);
+      expect(plan.spotPct).toBeGreaterThanOrEqual(15);
+      expect(plan.spotPct).toBeLessThanOrEqual(85);
+      expect(LOBSTER_BOTTLE_FORTUNES[plan.fortuneIndex]).toBeTruthy();
+    }
+    expect(bottles).toBeGreaterThan(0);
+    expect(bottles).toBeLessThan(total * 0.05);
+  });
+});
+
+describe("rare lobster loads", () => {
+  // Probe seeds (deterministic per stream): 644 hosts the Elder; 191 rolls
+  // an old-friend return plus a balloon entrance; 916 hatches a shiny lumen;
+  // 104 is a shy load that beaches a bottle at ~194s; 37 is a shy load with
+  // a snail crossing at ~407s.
+  it("hosts the Elder: barnacled, renamed, and never molting", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-09T12:00:00"));
+    const element = createPet(644);
+    await arrive(element);
+
+    expect(spriteClasses(element)).toContain("lobster-pet--elder");
+    expect(element.querySelector(".lob-barnacles")).not.toBeNull();
+    expect(element.querySelector(".lobster-pet")?.getAttribute("title")).toBe(
+      "Methuselah · old as the tides",
+    );
+  });
+
+  it("brings back an old friend from the Lobsterdex, balloon and all", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-09T12:00:00"));
+    vi.stubGlobal("localStorage", window.localStorage);
+    localStorage.setItem(
+      "openclaw.control.lobsterdex.v1",
+      JSON.stringify({
+        gold: { firstSeenAt: 1, name: "Goldenrod" },
+        teal: { firstSeenAt: 2, name: "Minty" },
+      }),
+    );
+    const element = createPet(191);
+    await arrive(element);
+
+    // The seeded crimson look is repainted as the remembered gold visitor.
+    expect(spriteClasses(element)).toContain("lobster-pet--palette-gold");
+    expect(element.querySelector(".lobster-pet")?.getAttribute("title")).toBe(
+      "Goldenrod · an old friend",
+    );
+    // This seed also floats in under a balloon...
+    expect(spriteClasses(element)).toContain("lobster-pet--enter-balloon");
+    expect(element.querySelector(".lobster-pet__balloon")).not.toBeNull();
+    // ...and old friends greet even before the familiarity tier does.
+    const waved = await advanceUntil(
+      element,
+      () => spriteClasses(element).includes("lobster-pet--act-wave"),
+      5_000,
+      100,
+    );
+    expect(waved).toBe(true);
+  });
+
+  it("hatches shiny lobsters that sparkle and log in the Lobsterdex", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-09T12:00:00"));
+    vi.stubGlobal("localStorage", window.localStorage);
+    const element = createPet(916);
+    await arrive(element);
+
+    expect(spriteClasses(element)).toContain("lobster-pet--shiny");
+    expect(spriteClasses(element)).toContain("lobster-pet--palette-lumen");
+    expect(element.querySelectorAll(".lobster-pet__sparkle").length).toBeGreaterThan(0);
+    expect(element.querySelector(".lob-lumen")).not.toBeNull();
+    expect(element.querySelector(".lobster-pet")?.getAttribute("title")).toContain("✦");
+    expect(getLobsterdexEntries().get("lumen")?.shinySeenAt).not.toBeNull();
+  });
+
+  it("beaches a message in a bottle on its own clock, pet or no pet", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-09T12:00:00"));
+    const element = createPet(104);
+    await element.updateComplete;
+
+    // Seed 104 is a shy load: no pet ever, but the tide does not care.
+    const washedUp = await advanceUntil(
+      element,
+      () => element.querySelector(".lobster-bottle") !== null,
+      300_000,
+    );
+    expect(washedUp).toBe(true);
+    expect(spritePresent(element)).toBe(false);
+    expect(element.querySelector(".lobster-bottle")?.getAttribute("title")).toBe(
+      "a message in a bottle",
+    );
+
+    element.querySelector(".lobster-bottle")?.dispatchEvent(new Event("pointerdown"));
+    await element.updateComplete;
+    const opened = element.querySelector(".lobster-bottle");
+    expect(opened?.className).toContain("lobster-bottle--open");
+    expect(opened?.getAttribute("title")).toBe("a shell is just armor you outgrew");
+
+    // Read fortunes drift back out with the tide.
+    const ebbed = await advanceUntil(
+      element,
+      () => element.querySelector(".lobster-bottle") === null,
+      150_000,
+    );
+    expect(ebbed).toBe(true);
+  });
+
+  it("lets the snail take its sweet time crossing the ledge", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-09T12:00:00"));
+    const element = createPet(37);
+    await element.updateComplete;
+
+    const appeared = await advanceUntil(
+      element,
+      () => element.querySelector(".lobster-pet--snail") !== null,
+      500_000,
+    );
+    expect(appeared).toBe(true);
+    // A regular passer's 11s crossing would be long over; the snail abides.
+    await vi.advanceTimersByTimeAsync(60_000);
+    await element.updateComplete;
+    expect(element.querySelector(".lobster-pet--snail")).not.toBeNull();
+    const gone = await advanceUntil(
+      element,
+      () => element.querySelector(".lobster-pet--snail") === null,
+      40_000,
+    );
+    expect(gone).toBe(true);
+  });
+
+  it("earns the golden ledge trim once the Lobsterdex is complete", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-09T12:00:00"));
+    vi.stubGlobal("localStorage", window.localStorage);
+    localStorage.setItem(
+      "openclaw.control.lobsterdex.v1",
+      JSON.stringify(
+        Object.fromEntries(
+          LOBSTER_PET_PALETTES.map((palette) => [palette.id, { firstSeenAt: 1, name: "First" }]),
+        ),
+      ),
+    );
+    const element = createPet(42);
+    await element.updateComplete;
+    expect(element.hasAttribute("data-dex-complete")).toBe(true);
+
+    // The visits setting silences the trim like everything else.
+    element.visitsEnabled = false;
+    await element.updateComplete;
+    expect(element.hasAttribute("data-dex-complete")).toBe(false);
   });
 });

--- a/ui/src/components/lobster-pet.test.ts
+++ b/ui/src/components/lobster-pet.test.ts
@@ -6,11 +6,10 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { getLobsterdex, getLobsterdexEntries } from "./lobster-dex.ts";
 import {
   LOBSTER_BOTTLE_FORTUNES,
-  isLobsterElderLoad,
   pickLobsterEntrance,
   planLobsterBottle,
-  planLobsterOldFriend,
   planLobsterPasser,
+  resolveLobsterLoadIdentity,
 } from "./lobster-pet-plans.ts";
 import {
   LOBSTER_LOGO_VISIT_EVENT,
@@ -962,22 +961,44 @@ describe("lobster plans", () => {
     expect(pickLobsterEntrance(0.9)).toBe("walk");
   });
 
-  it("plans rare elder loads deterministically", () => {
+  it("resolves rare elder identities deterministically", () => {
+    const neutralDate = new Date("2026-07-15T12:00:00");
+    const identityOf = (seed: number) =>
+      resolveLobsterLoadIdentity(seed, createLobsterPetLook(seed, neutralDate));
+    const elder = identityOf(644);
+    expect(elder.elder).toBe(true);
+    expect(elder.look.scale).toBe(3);
+    expect(elder.look.accessory).toBe("barnacle");
     let elders = 0;
-    for (let seed = 0; seed < 10_000; seed++) {
-      if (isLobsterElderLoad(seed)) {
+    for (let seed = 0; seed < 3_000; seed++) {
+      if (identityOf(seed).elder) {
         elders++;
       }
     }
     expect(elders).toBeGreaterThan(0);
-    expect(elders).toBeLessThan(10_000 * 0.03);
-    expect(isLobsterElderLoad(644)).toBe(true);
+    expect(elders).toBeLessThan(3_000 * 0.035);
   });
 
-  it("returns old friends only from known palettes", () => {
-    expect(planLobsterOldFriend(191, [])).toBeNull();
-    expect(planLobsterOldFriend(191, ["gold", "teal"])).toBe("gold");
-    expect(planLobsterOldFriend(42, ["gold", "teal"])).toBeNull();
+  it("returns old friends only from palettes the dex knows", () => {
+    vi.stubGlobal("localStorage", window.localStorage);
+    const neutralDate = new Date("2026-07-15T12:00:00");
+    const identityOf = (seed: number) =>
+      resolveLobsterLoadIdentity(seed, createLobsterPetLook(seed, neutralDate));
+    // An empty dex has no friends to bring back, whatever the roll says.
+    expect(identityOf(191).oldFriend).toBe(false);
+    localStorage.setItem(
+      "openclaw.control.lobsterdex.v1",
+      JSON.stringify({
+        gold: { firstSeenAt: 1, name: "Goldenrod" },
+        teal: { firstSeenAt: 2, name: "Minty" },
+      }),
+    );
+    const friend = identityOf(191);
+    expect(friend.oldFriend).toBe(true);
+    expect(friend.look.palette.id).toBe("gold");
+    expect(friend.friendName).toBe("Goldenrod");
+    // A seed whose friend roll misses stays a fresh stranger.
+    expect(identityOf(42).oldFriend).toBe(false);
   });
 
   it("beaches bottles rarely, with fortunes and spots in range", () => {

--- a/ui/src/components/lobster-pet.ts
+++ b/ui/src/components/lobster-pet.ts
@@ -15,6 +15,7 @@ import * as contract from "./lobster-pet-contract.ts";
 import * as lobsterLook from "./lobster-pet-look.ts";
 import "./lobster-pet-standin.ts";
 import * as plans from "./lobster-pet-plans.ts";
+import { LobsterLedgeTraffic } from "./lobster-pet-traffic.ts";
 
 export {
   LOBSTER_LOGO_VISIT_EVENT,
@@ -67,25 +68,21 @@ class LobsterPet extends LitElement {
   @state() private grumpy = false;
   @state() private vigil = false;
   @state() private outcomePresenceOwner: "vigil" | null = null;
-  @state() private passer: plans.LobsterPasserPlan | null = null;
   @state() private movingDay = false;
   private movingDayChecked = false;
   @state() private anniversary = false;
   private sailorDay = false;
-  // Rare-load identities resolved once per seed: the Elder, and old-friend
-  // returns drawn from the Lobsterdex.
-  private elder = false;
-  private oldFriend = false;
-  private friendName: string | null = null;
-  // Load-start snapshot, like familiarity: the golden ledge trim appears on
-  // the next load after the final palette lands, never mid-visit.
-  private dexComplete = false;
-  @state() private bottleVisible = false;
-  @state() private bottleOpened = false;
-  private bottlePlan: plans.LobsterBottlePlan | null = null;
-  private bottleTimer: number | null = null;
-  private bottleEndTimer: number | null = null;
+  // Rare-load identity resolved once per seed (Elder, old-friend returns,
+  // Lobsterdex completion) - a load-start snapshot, like familiarity.
+  private identity: plans.LobsterLoadIdentity | null = null;
   private entranceRng: () => number = lobsterLook.mulberry32(0);
+  // Passers and the bottle run on their own clocks beside the resident.
+  private readonly traffic = new LobsterLedgeTraffic(this, {
+    visitsEnabled: () => this.visitsEnabled,
+    onPasserFacing: (facing) => this.watchTraffic(facing),
+    onPasserMidCross: () => this.reactToPasser(),
+    onPasserDone: () => this.scheduleNextAct(),
+  });
   @state() private shellVisible = false;
   private shellSpotPct = 50;
   private shellScale = 2;
@@ -93,9 +90,6 @@ class LobsterPet extends LitElement {
   private moltPlanned = false;
   private twinPlanned = false;
   private shellTimer: number | null = null;
-  private passerTimer: number | null = null;
-  private passerEndTimer: number | null = null;
-  private passerWatchTimer: number | null = null;
   private familiarity: dex.LobsterFamiliarity = {
     tier: "regular",
     wary: false,
@@ -139,28 +133,14 @@ class LobsterPet extends LitElement {
       window.clearTimeout(this.shellTimer);
       this.shellTimer = null;
     }
-    for (const timer of [
-      this.vigilTimer,
-      this.holdTimer,
-      this.passerTimer,
-      this.passerEndTimer,
-      this.passerWatchTimer,
-      this.logoScareTimer,
-      this.bottleTimer,
-      this.bottleEndTimer,
-    ]) {
+    for (const timer of [this.vigilTimer, this.holdTimer, this.logoScareTimer]) {
       if (timer !== null) {
         window.clearTimeout(timer);
       }
     }
     this.vigilTimer = null;
     this.holdTimer = null;
-    this.passerTimer = null;
-    this.passerEndTimer = null;
-    this.passerWatchTimer = null;
     this.logoScareTimer = null;
-    this.bottleTimer = null;
-    this.bottleEndTimer = null;
     if (this.audioCtx) {
       this.audioCtx.close().catch(() => {});
       this.audioCtx = null;
@@ -188,7 +168,8 @@ class LobsterPet extends LitElement {
       this.visitRng = lobsterLook.mulberry32(this.seed ^ 0x5eaf00d);
       this.scareRng = lobsterLook.mulberry32((this.seed ^ 0x5ca2e) >>> 0);
       this.entranceRng = lobsterLook.mulberry32((this.seed ^ 0xe27a) >>> 0);
-      this.resolveLoadIdentity();
+      this.identity = plans.resolveLobsterLoadIdentity(this.seed, this.look);
+      this.look = this.identity.look;
       this.spotPct = this.look.spotPct;
       this.facing = this.look.facing;
       // Reset the act loop inside the update pass; deferring state flips to
@@ -205,7 +186,7 @@ class LobsterPet extends LitElement {
         this.shellTimer = null;
       }
       // The Elder never molts: it is already every size it will ever need.
-      this.moltPlanned = plans.isLobsterMoltLoad(this.seed) && !this.elder;
+      this.moltPlanned = plans.isLobsterMoltLoad(this.seed) && !this.identity.elder;
       this.twinPlanned = plans.isLobsterTwinLoad(this.seed);
       this.logoPlanned = plans.isLobsterLogoLoad(this.seed);
       this.logoDone = false;
@@ -220,8 +201,7 @@ class LobsterPet extends LitElement {
       this.sailorDay = isLobsterDay(new Date());
       this.greetedThisLoad = false;
       this.scheduleVisits();
-      this.schedulePasser();
-      this.scheduleBottle();
+      this.traffic.reset(this.seed);
       // The first update takes this branch, so the mode-change branch below
       // never sees the initial mode: arm the vigil tracker here as well.
       this.vigil = false;
@@ -259,51 +239,9 @@ class LobsterPet extends LitElement {
     // being out; the visits setting and dismissals silence it too.
     this.toggleAttribute(
       "data-dex-complete",
-      this.dexComplete && this.visitsEnabled && !this.dismissed,
+      (this.identity?.dexComplete ?? false) && this.visitsEnabled && !this.dismissed,
     );
     this.reconcilePresence();
-  }
-
-  // Rare per-load identities, resolved after the seeded look: the Elder
-  // outranks an old-friend return, and retro looks (grail or anniversary
-  // dress code) are never repainted.
-  private resolveLoadIdentity() {
-    this.elder = plans.isLobsterElderLoad(this.seed);
-    this.oldFriend = false;
-    this.friendName = null;
-    const seen = dex.getLobsterdex();
-    this.dexComplete = lobsterLook.LOBSTER_PET_PALETTES.every((p) => seen.has(p.id));
-    if (!this.look) {
-      return;
-    }
-    if (this.elder) {
-      this.look = {
-        ...this.look,
-        scale: 3,
-        accessory: "barnacle",
-        personality: "sleepy",
-        clawSize: "mighty",
-        crusherSide: null,
-      };
-      return;
-    }
-    if (this.look.palette.id === "retro") {
-      return;
-    }
-    const known = [...seen]
-      .filter((id) => lobsterLook.LOBSTER_PET_PALETTES.some((p) => p.id === id))
-      .toSorted();
-    const friendId = plans.planLobsterOldFriend(this.seed, known);
-    if (!friendId) {
-      return;
-    }
-    const palette = lobsterLook.LOBSTER_PET_PALETTES.find((p) => p.id === friendId);
-    if (!palette) {
-      return;
-    }
-    this.oldFriend = true;
-    this.look = { ...this.look, palette };
-    this.friendName = dex.getLobsterdexEntries().get(friendId)?.name ?? null;
   }
 
   // Presence follows the visit schedule, offline summons, the setting, and
@@ -349,7 +287,9 @@ class LobsterPet extends LitElement {
           // with the first visitor's name (the Elder signs as itself) and
           // any shiny sighting, and bumps the familiarity count.
           dex.recordLobsterVisit(this.look.palette.id, {
-            name: this.petBaseName(),
+            name: this.identity
+              ? plans.lobsterLoadDisplayName(this.identity, this.seed)
+              : lobsterLook.lobsterPetName(this.look, this.seed),
             shiny: this.look.shiny,
           });
           dex.recordLobsterArrivalStats();
@@ -396,7 +336,7 @@ class LobsterPet extends LitElement {
       // (and keeps it for a ledge visit).
       if (
         !this.greetedThisLoad &&
-        (this.familiarity.tier === "friend" || this.oldFriend) &&
+        (this.familiarity.tier === "friend" || this.identity?.oldFriend === true) &&
         this.presence === "in" &&
         !this.logoPerched &&
         !plans.prefersReducedMotion()
@@ -443,29 +383,15 @@ class LobsterPet extends LitElement {
       look && this.anniversary && look.accessory !== "party"
         ? { ...look, accessory: "party" as const }
         : look;
+    const name =
+      dressed && this.identity ? plans.lobsterLoadDisplayName(this.identity, this.seed) : null;
     this.dispatchEvent(
       new CustomEvent<contract.LobsterLogoVisitDetail>(contract.LOBSTER_LOGO_VISIT_EVENT, {
-        detail: {
-          phase,
-          look: dressed,
-          name: dressed ? this.petBaseName() : null,
-        },
+        detail: { phase, look: dressed, name },
         bubbles: true,
         composed: true,
       }),
     );
-  }
-
-  // The displayed base name before honorifics: rare identities (the Elder,
-  // named old friends) override the seeded catalog name.
-  private petBaseName(): string {
-    if (this.elder) {
-      return "Methuselah";
-    }
-    if (this.friendName) {
-      return this.friendName;
-    }
-    return this.look ? lobsterLook.lobsterPetName(this.look, this.seed) : "";
   }
 
   private readonly handleVisibilityChange = () => {
@@ -674,55 +600,15 @@ class LobsterPet extends LitElement {
     }, stayMs);
   }
 
-  // ---- Pass-through visitors (strangers and the crab) ----
-
-  private schedulePasser() {
-    for (const timer of [this.passerTimer, this.passerEndTimer, this.passerWatchTimer]) {
-      if (timer !== null) {
-        window.clearTimeout(timer);
-      }
-    }
-    this.passerTimer = null;
-    this.passerEndTimer = null;
-    this.passerWatchTimer = null;
-    this.passer = null;
-    const plan = plans.planLobsterPasser(this.seed);
-    if (!plan || plans.prefersReducedMotion()) {
-      return;
-    }
-    this.passerTimer = window.setTimeout(() => {
-      this.passerTimer = null;
-      if (!this.visitsEnabled || document.hidden) {
-        return;
-      }
-      this.passer = plan;
-      this.watchPasser(plan);
-      this.passerEndTimer = window.setTimeout(() => {
-        this.passerEndTimer = null;
-        this.passer = null;
-        this.scheduleNextAct();
-      }, plans.LOBSTER_PASSER_CROSS_MS[plan.kind]);
-    }, plan.atMs);
-  }
+  // ---- Ledge traffic (scheduling lives in LobsterLedgeTraffic) ----
 
   // The resident notices traffic: it turns toward a passer's entry side,
-  // then follows it out with a mid-crossing flip. Acts, vigil, and absence
-  // all take precedence - the pet is curious, not obsessive.
-  private watchPasser(plan: plans.LobsterPasserPlan) {
-    const watch = (facing: 1 | -1) => {
-      // Scuttle owns facing while it walks; anything else can turn its head.
-      if (this.presence === "in" && this.act !== "scuttle" && !this.vigil) {
-        this.facing = facing;
-      }
-    };
-    watch(plan.direction === 1 ? -1 : 1);
-    this.passerWatchTimer = window.setTimeout(() => {
-      this.passerWatchTimer = null;
-      watch(plan.direction);
-      // Mid-crossing is when the passer is closest: friends wave at the
-      // traffic, shy pets duck for a peek, regulars just watch it go by.
-      this.reactToPasser();
-    }, plans.LOBSTER_PASSER_CROSS_MS[plan.kind] / 2);
+  // then follows it out with a mid-crossing flip. Scuttle owns facing while
+  // it walks; anything else can turn its head.
+  private watchTraffic(facing: 1 | -1) {
+    if (this.presence === "in" && this.act !== "scuttle" && !this.vigil) {
+      this.facing = facing;
+    }
   }
 
   private reactToPasser() {
@@ -741,50 +627,6 @@ class LobsterPet extends LitElement {
     }
     this.performAct(reaction);
   }
-
-  // ---- Message in a bottle ----
-
-  // The bottle keeps its own clock: it washes up whether or not the pet is
-  // around, waits to be opened, and drifts back out with the tide.
-  private scheduleBottle() {
-    for (const timer of [this.bottleTimer, this.bottleEndTimer]) {
-      if (timer !== null) {
-        window.clearTimeout(timer);
-      }
-    }
-    this.bottleTimer = null;
-    this.bottleEndTimer = null;
-    this.bottleVisible = false;
-    this.bottleOpened = false;
-    this.bottlePlan = plans.planLobsterBottle(this.seed);
-    if (!this.bottlePlan) {
-      return;
-    }
-    this.bottleTimer = window.setTimeout(() => {
-      this.bottleTimer = null;
-      this.bottleVisible = true;
-      this.armBottleEbb(300_000);
-    }, this.bottlePlan.atMs);
-  }
-
-  private armBottleEbb(delayMs: number) {
-    if (this.bottleEndTimer !== null) {
-      window.clearTimeout(this.bottleEndTimer);
-    }
-    this.bottleEndTimer = window.setTimeout(() => {
-      this.bottleEndTimer = null;
-      this.bottleVisible = false;
-    }, delayMs);
-  }
-
-  private readonly handleBottleOpen = () => {
-    if (this.bottleOpened || !this.bottleVisible) {
-      return;
-    }
-    this.bottleOpened = true;
-    // Read, then reclaimed by the sea a couple of minutes later.
-    this.armBottleEbb(120_000);
-  };
 
   // Each arrival re-rolls either the standard side zone or compact bar zone.
   // Both visit profiles render above the footer divider.
@@ -812,7 +654,7 @@ class LobsterPet extends LitElement {
       this.presence !== "in" ||
       this.logoPerched ||
       this.vigil ||
-      this.passer !== null ||
+      this.traffic.passer !== null ||
       this.idleTimer !== null ||
       this.actEndTimer !== null ||
       plans.prefersReducedMotion()
@@ -828,8 +670,13 @@ class LobsterPet extends LitElement {
       this.idleTimer = null;
       const nextProfile = plans.resolveLobsterActProfile(this.mode, this.look?.personality ?? null);
       // A crossing pauses the fidget loop: the pet is busy watching. The
-      // passer-end timer restarts scheduling.
-      if (!nextProfile || document.hidden || this.presence !== "in" || this.passer !== null) {
+      // traffic controller's passer-end hook restarts scheduling.
+      if (
+        !nextProfile ||
+        document.hidden ||
+        this.presence !== "in" ||
+        this.traffic.passer !== null
+      ) {
         return;
       }
       if (this.moltPlanned && !this.molted && this.mode === "idle") {
@@ -922,17 +769,9 @@ class LobsterPet extends LitElement {
     if (!look) {
       return nothing;
     }
-    const bottle =
-      this.bottleVisible && this.bottlePlan
-        ? {
-            spotPct: this.bottlePlan.spotPct,
-            opened: this.bottleOpened,
-            fortune: expectDefined(
-              plans.LOBSTER_BOTTLE_FORTUNES[this.bottlePlan.fortuneIndex],
-              "lobster bottle fortune",
-            ),
-          }
-        : null;
+    const identity = this.identity;
+    const flavor =
+      identity?.elder ? "old as the tides" : identity?.oldFriend ? "an old friend" : null;
     return lobsterLook.renderLobsterPetScene({
       look,
       mode: this.mode,
@@ -941,11 +780,11 @@ class LobsterPet extends LitElement {
       shellVisible: this.shellVisible,
       visitsEnabled: this.visitsEnabled,
       dismissed: this.dismissed,
-      passer: this.passer
+      passer: this.traffic.passer
         ? {
-            kind: this.passer.kind,
-            direction: this.passer.direction,
-            crossMs: plans.LOBSTER_PASSER_CROSS_MS[this.passer.kind],
+            kind: this.traffic.passer.kind,
+            direction: this.traffic.passer.direction,
+            crossMs: this.traffic.passerCrossMs(),
           }
         : null,
       twinPlanned: this.twinPlanned,
@@ -954,7 +793,7 @@ class LobsterPet extends LitElement {
       entrance: this.entrance,
       grumpy: this.grumpy,
       vigil: this.vigil,
-      elder: this.elder,
+      elder: identity?.elder ?? false,
       act: this.act,
       zone: this.currentZone(),
       spotPct: this.spotPct,
@@ -967,14 +806,14 @@ class LobsterPet extends LitElement {
       seed: this.seed,
       movingDay: this.movingDay,
       sailorDay: this.sailorDay,
-      nameOverride: this.elder ? "Methuselah" : this.friendName,
-      flavor: this.elder ? "old as the tides" : this.oldFriend ? "an old friend" : null,
-      bottle,
+      nameOverride: identity ? plans.lobsterLoadDisplayName(identity, this.seed) : null,
+      flavor,
+      bottle: this.traffic.bottle(),
       onPointerDown: this.handleHoldStart,
       onPointerUp: this.handleHoldEnd,
       onPointerCancel: this.handleHoldCancel,
       onContextMenu: this.handleShoo,
-      onBottleOpen: this.handleBottleOpen,
+      onBottleOpen: this.traffic.openBottle,
     });
   }
 }

--- a/ui/src/components/lobster-pet.ts
+++ b/ui/src/components/lobster-pet.ts
@@ -770,8 +770,11 @@ class LobsterPet extends LitElement {
       return nothing;
     }
     const identity = this.identity;
-    const flavor =
-      identity?.elder ? "old as the tides" : identity?.oldFriend ? "an old friend" : null;
+    const flavor = identity?.elder
+      ? "old as the tides"
+      : identity?.oldFriend
+        ? "an old friend"
+        : null;
     return lobsterLook.renderLobsterPetScene({
       look,
       mode: this.mode,

--- a/ui/src/components/lobster-pet.ts
+++ b/ui/src/components/lobster-pet.ts
@@ -28,8 +28,6 @@ export {
   type LobsterRunOutcome,
 } from "./lobster-pet-contract.ts";
 export {
-  LOBSTER_PET_BUILD_MULS,
-  LOBSTER_PET_CLAW_MULS,
   LOBSTER_PET_PALETTES,
   canonicalLobsterLook,
   createLobsterPetLook,
@@ -53,6 +51,7 @@ class LobsterPet extends LitElement {
   @state() private spotPct = 80;
   @state() private facing: 1 | -1 = 1;
   @state() private entering = false;
+  @state() private entrance: contract.LobsterPetEntrance = "walk";
   @state() private presence: "out" | "in" | "leaving" = "out";
   @state() private anchor: plans.LobsterPetAnchor = "ledge";
   @state() private scheduledVisiting = false;
@@ -73,6 +72,20 @@ class LobsterPet extends LitElement {
   private movingDayChecked = false;
   @state() private anniversary = false;
   private sailorDay = false;
+  // Rare-load identities resolved once per seed: the Elder, and old-friend
+  // returns drawn from the Lobsterdex.
+  private elder = false;
+  private oldFriend = false;
+  private friendName: string | null = null;
+  // Load-start snapshot, like familiarity: the golden ledge trim appears on
+  // the next load after the final palette lands, never mid-visit.
+  private dexComplete = false;
+  @state() private bottleVisible = false;
+  @state() private bottleOpened = false;
+  private bottlePlan: plans.LobsterBottlePlan | null = null;
+  private bottleTimer: number | null = null;
+  private bottleEndTimer: number | null = null;
+  private entranceRng: () => number = lobsterLook.mulberry32(0);
   @state() private shellVisible = false;
   private shellSpotPct = 50;
   private shellScale = 2;
@@ -133,6 +146,8 @@ class LobsterPet extends LitElement {
       this.passerEndTimer,
       this.passerWatchTimer,
       this.logoScareTimer,
+      this.bottleTimer,
+      this.bottleEndTimer,
     ]) {
       if (timer !== null) {
         window.clearTimeout(timer);
@@ -144,6 +159,8 @@ class LobsterPet extends LitElement {
     this.passerEndTimer = null;
     this.passerWatchTimer = null;
     this.logoScareTimer = null;
+    this.bottleTimer = null;
+    this.bottleEndTimer = null;
     if (this.audioCtx) {
       this.audioCtx.close().catch(() => {});
       this.audioCtx = null;
@@ -170,6 +187,8 @@ class LobsterPet extends LitElement {
       this.rng = lobsterLook.mulberry32(this.seed ^ 0x9e3779b9);
       this.visitRng = lobsterLook.mulberry32(this.seed ^ 0x5eaf00d);
       this.scareRng = lobsterLook.mulberry32((this.seed ^ 0x5ca2e) >>> 0);
+      this.entranceRng = lobsterLook.mulberry32((this.seed ^ 0xe27a) >>> 0);
+      this.resolveLoadIdentity();
       this.spotPct = this.look.spotPct;
       this.facing = this.look.facing;
       // Reset the act loop inside the update pass; deferring state flips to
@@ -185,7 +204,8 @@ class LobsterPet extends LitElement {
         window.clearTimeout(this.shellTimer);
         this.shellTimer = null;
       }
-      this.moltPlanned = plans.isLobsterMoltLoad(this.seed);
+      // The Elder never molts: it is already every size it will ever need.
+      this.moltPlanned = plans.isLobsterMoltLoad(this.seed) && !this.elder;
       this.twinPlanned = plans.isLobsterTwinLoad(this.seed);
       this.logoPlanned = plans.isLobsterLogoLoad(this.seed);
       this.logoDone = false;
@@ -201,6 +221,7 @@ class LobsterPet extends LitElement {
       this.greetedThisLoad = false;
       this.scheduleVisits();
       this.schedulePasser();
+      this.scheduleBottle();
       // The first update takes this branch, so the mode-change branch below
       // never sees the initial mode: arm the vigil tracker here as well.
       this.vigil = false;
@@ -234,7 +255,55 @@ class LobsterPet extends LitElement {
       this.movingDayChecked = true;
       this.movingDay = plans.detectLobsterMovingDay(this.gatewayVersion);
     }
+    // The completed-Lobsterdex trim lives on the host so it survives the pet
+    // being out; the visits setting and dismissals silence it too.
+    this.toggleAttribute(
+      "data-dex-complete",
+      this.dexComplete && this.visitsEnabled && !this.dismissed,
+    );
     this.reconcilePresence();
+  }
+
+  // Rare per-load identities, resolved after the seeded look: the Elder
+  // outranks an old-friend return, and retro looks (grail or anniversary
+  // dress code) are never repainted.
+  private resolveLoadIdentity() {
+    this.elder = plans.isLobsterElderLoad(this.seed);
+    this.oldFriend = false;
+    this.friendName = null;
+    const seen = dex.getLobsterdex();
+    this.dexComplete = lobsterLook.LOBSTER_PET_PALETTES.every((p) => seen.has(p.id));
+    if (!this.look) {
+      return;
+    }
+    if (this.elder) {
+      this.look = {
+        ...this.look,
+        scale: 3,
+        accessory: "barnacle",
+        personality: "sleepy",
+        clawSize: "mighty",
+        crusherSide: null,
+      };
+      return;
+    }
+    if (this.look.palette.id === "retro") {
+      return;
+    }
+    const known = [...seen]
+      .filter((id) => lobsterLook.LOBSTER_PET_PALETTES.some((p) => p.id === id))
+      .toSorted();
+    const friendId = plans.planLobsterOldFriend(this.seed, known);
+    if (!friendId) {
+      return;
+    }
+    const palette = lobsterLook.LOBSTER_PET_PALETTES.find((p) => p.id === friendId);
+    if (!palette) {
+      return;
+    }
+    this.oldFriend = true;
+    this.look = { ...this.look, palette };
+    this.friendName = dex.getLobsterdexEntries().get(friendId)?.name ?? null;
   }
 
   // Presence follows the visit schedule, offline summons, the setting, and
@@ -266,6 +335,9 @@ class LobsterPet extends LitElement {
           this.scheduledVisiting &&
           this.mode === "idle" &&
           !plans.prefersReducedMotion();
+        // Entrance rolls burn once per arrival on their own stream, aligned
+        // across visit kinds like the scare roll above.
+        this.entrance = plans.pickLobsterEntrance(this.entranceRng());
         if (this.look) {
           // Anniversary check reads the dex before this arrival records into
           // it: a first-ever visit today must not celebrate itself.
@@ -274,9 +346,11 @@ class LobsterPet extends LitElement {
             new Date(),
           );
           // Every genuine arrival (visit or offline summon) logs the palette
-          // with the first visitor's name, and bumps the familiarity count.
+          // with the first visitor's name (the Elder signs as itself) and
+          // any shiny sighting, and bumps the familiarity count.
           dex.recordLobsterVisit(this.look.palette.id, {
-            name: lobsterLook.lobsterPetName(this.look, this.seed),
+            name: this.petBaseName(),
+            shiny: this.look.shiny,
           });
           dex.recordLobsterArrivalStats();
         }
@@ -317,11 +391,12 @@ class LobsterPet extends LitElement {
     this.enterTimer = window.setTimeout(() => {
       this.enterTimer = null;
       this.entering = false;
-      // Old friends get a hello: the first arrival of the load waves at you.
-      // A logo stand-in skips the greeting (and keeps it for a ledge visit).
+      // Familiar humans and returning old friends get a hello: the first
+      // arrival of the load waves at you. A logo stand-in skips the greeting
+      // (and keeps it for a ledge visit).
       if (
         !this.greetedThisLoad &&
-        this.familiarity.tier === "friend" &&
+        (this.familiarity.tier === "friend" || this.oldFriend) &&
         this.presence === "in" &&
         !this.logoPerched &&
         !plans.prefersReducedMotion()
@@ -329,7 +404,7 @@ class LobsterPet extends LitElement {
         this.greetedThisLoad = true;
         this.performAct("wave");
       }
-    }, plans.ENTER_MS);
+    }, plans.LOBSTER_PET_ENTRANCE_MS[this.entrance]);
     if (this.logoScarePending) {
       this.logoScarePending = false;
       // The beat between arrival and the duck is what sells "the crab scared
@@ -373,12 +448,24 @@ class LobsterPet extends LitElement {
         detail: {
           phase,
           look: dressed,
-          name: dressed ? lobsterLook.lobsterPetName(dressed, this.seed) : null,
+          name: dressed ? this.petBaseName() : null,
         },
         bubbles: true,
         composed: true,
       }),
     );
+  }
+
+  // The displayed base name before honorifics: rare identities (the Elder,
+  // named old friends) override the seeded catalog name.
+  private petBaseName(): string {
+    if (this.elder) {
+      return "Methuselah";
+    }
+    if (this.friendName) {
+      return this.friendName;
+    }
+    return this.look ? lobsterLook.lobsterPetName(this.look, this.seed) : "";
   }
 
   private readonly handleVisibilityChange = () => {
@@ -614,7 +701,7 @@ class LobsterPet extends LitElement {
         this.passerEndTimer = null;
         this.passer = null;
         this.scheduleNextAct();
-      }, plans.PASSER_CROSS_MS);
+      }, plans.LOBSTER_PASSER_CROSS_MS[plan.kind]);
     }, plan.atMs);
   }
 
@@ -632,8 +719,76 @@ class LobsterPet extends LitElement {
     this.passerWatchTimer = window.setTimeout(() => {
       this.passerWatchTimer = null;
       watch(plan.direction);
-    }, plans.PASSER_CROSS_MS / 2);
+      // Mid-crossing is when the passer is closest: friends wave at the
+      // traffic, shy pets duck for a peek, regulars just watch it go by.
+      this.reactToPasser();
+    }, plans.LOBSTER_PASSER_CROSS_MS[plan.kind] / 2);
   }
+
+  private reactToPasser() {
+    const reaction =
+      this.familiarity.tier === "friend"
+        ? "wave"
+        : this.familiarity.tier === "shy"
+          ? "peek"
+          : null;
+    if (
+      reaction === null ||
+      this.presence !== "in" ||
+      this.logoPerched ||
+      this.act !== null ||
+      this.vigil ||
+      this.mode !== "idle" ||
+      plans.prefersReducedMotion()
+    ) {
+      return;
+    }
+    this.performAct(reaction);
+  }
+
+  // ---- Message in a bottle ----
+
+  // The bottle keeps its own clock: it washes up whether or not the pet is
+  // around, waits to be opened, and drifts back out with the tide.
+  private scheduleBottle() {
+    for (const timer of [this.bottleTimer, this.bottleEndTimer]) {
+      if (timer !== null) {
+        window.clearTimeout(timer);
+      }
+    }
+    this.bottleTimer = null;
+    this.bottleEndTimer = null;
+    this.bottleVisible = false;
+    this.bottleOpened = false;
+    this.bottlePlan = plans.planLobsterBottle(this.seed);
+    if (!this.bottlePlan) {
+      return;
+    }
+    this.bottleTimer = window.setTimeout(() => {
+      this.bottleTimer = null;
+      this.bottleVisible = true;
+      this.armBottleEbb(300_000);
+    }, this.bottlePlan.atMs);
+  }
+
+  private armBottleEbb(delayMs: number) {
+    if (this.bottleEndTimer !== null) {
+      window.clearTimeout(this.bottleEndTimer);
+    }
+    this.bottleEndTimer = window.setTimeout(() => {
+      this.bottleEndTimer = null;
+      this.bottleVisible = false;
+    }, delayMs);
+  }
+
+  private readonly handleBottleOpen = () => {
+    if (this.bottleOpened || !this.bottleVisible) {
+      return;
+    }
+    this.bottleOpened = true;
+    // Read, then reclaimed by the sea a couple of minutes later.
+    this.armBottleEbb(120_000);
+  };
 
   // Each arrival re-rolls either the standard side zone or compact bar zone.
   // Both visit profiles render above the footer divider.
@@ -771,6 +926,17 @@ class LobsterPet extends LitElement {
     if (!look) {
       return nothing;
     }
+    const bottle =
+      this.bottleVisible && this.bottlePlan
+        ? {
+            spotPct: this.bottlePlan.spotPct,
+            opened: this.bottleOpened,
+            fortune: expectDefined(
+              plans.LOBSTER_BOTTLE_FORTUNES[this.bottlePlan.fortuneIndex],
+              "lobster bottle fortune",
+            ),
+          }
+        : null;
     return lobsterLook.renderLobsterPetScene({
       look,
       mode: this.mode,
@@ -779,12 +945,20 @@ class LobsterPet extends LitElement {
       shellVisible: this.shellVisible,
       visitsEnabled: this.visitsEnabled,
       dismissed: this.dismissed,
-      passer: this.passer,
+      passer: this.passer
+        ? {
+            kind: this.passer.kind,
+            direction: this.passer.direction,
+            crossMs: plans.LOBSTER_PASSER_CROSS_MS[this.passer.kind],
+          }
+        : null,
       twinPlanned: this.twinPlanned,
       anniversary: this.anniversary,
       entering: this.entering,
+      entrance: this.entrance,
       grumpy: this.grumpy,
       vigil: this.vigil,
+      elder: this.elder,
       act: this.act,
       zone: this.currentZone(),
       spotPct: this.spotPct,
@@ -797,10 +971,14 @@ class LobsterPet extends LitElement {
       seed: this.seed,
       movingDay: this.movingDay,
       sailorDay: this.sailorDay,
+      nameOverride: this.elder ? "Methuselah" : this.friendName,
+      flavor: this.elder ? "old as the tides" : this.oldFriend ? "an old friend" : null,
+      bottle,
       onPointerDown: this.handleHoldStart,
       onPointerUp: this.handleHoldEnd,
       onPointerCancel: this.handleHoldCancel,
       onContextMenu: this.handleShoo,
+      onBottleOpen: this.handleBottleOpen,
     });
   }
 }

--- a/ui/src/components/lobster-pet.ts
+++ b/ui/src/components/lobster-pet.ts
@@ -727,11 +727,7 @@ class LobsterPet extends LitElement {
 
   private reactToPasser() {
     const reaction =
-      this.familiarity.tier === "friend"
-        ? "wave"
-        : this.familiarity.tier === "shy"
-          ? "peek"
-          : null;
+      this.familiarity.tier === "friend" ? "wave" : this.familiarity.tier === "shy" ? "peek" : null;
     if (
       reaction === null ||
       this.presence !== "in" ||

--- a/ui/src/pages/config/view.ts
+++ b/ui/src/pages/config/view.ts
@@ -1149,6 +1149,7 @@ function renderLobsterPetSection(props: ConfigProps) {
               ${LOBSTER_PET_PALETTES.map((palette) => {
                 const entry = getLobsterdexEntries().get(palette.id);
                 const seen = entry !== undefined;
+                const shinySeen = entry?.shinySeenAt != null;
                 const title = !seen
                   ? "?"
                   : entry.firstSeenAt !== null
@@ -1163,9 +1164,12 @@ function renderLobsterPetSection(props: ConfigProps) {
                       ? ""
                       : "lobsterdex__mini--unseen"}"
                     style="--lob-shell:${palette.shell};--lob-claw:${palette.claw}"
-                    title=${title}
+                    title=${shinySeen ? `${title} ✦` : title}
                   >
                     ${renderLobsterSvg(canonicalLobsterLook(palette), { standalone: true })}
+                    ${shinySeen
+                      ? html`<span class="lobsterdex__mini-star" aria-hidden="true">✦</span>`
+                      : nothing}
                   </span>
                 `;
               })}

--- a/ui/src/styles/lobster-pet.css
+++ b/ui/src/styles/lobster-pet.css
@@ -71,7 +71,14 @@ openclaw-lobster-pet[data-dex-complete]::after {
   right: 8%;
   bottom: 0;
   height: 2px;
-  background: linear-gradient(90deg, transparent, #f4b840 30%, #f9d47a 50%, #f4b840 70%, transparent);
+  background: linear-gradient(
+    90deg,
+    transparent,
+    #f4b840 30%,
+    #f9d47a 50%,
+    #f4b840 70%,
+    transparent
+  );
   opacity: 0.5;
   pointer-events: none;
 }

--- a/ui/src/styles/lobster-pet.css
+++ b/ui/src/styles/lobster-pet.css
@@ -49,6 +49,33 @@ openclaw-lobster-pet {
   transition: left 1.15s ease-in-out;
 }
 
+/* Seeded glint tint rides its own variable, mapped here (before the palette
+   rules) so palette and offline class rules still out-cascade it on both
+   look surfaces. */
+.lobster-pet,
+.sidebar-brand__pet {
+  --lob-glint: var(--lob-glint-seed, #00e5cc);
+}
+
+/* The Elder does everything at Elder speed. */
+.lobster-pet--elder {
+  transition: left 2.6s ease-in-out;
+}
+
+/* Completed Lobsterdex: a quiet golden trim along the ledge, earned once
+   every palette has visited this browser. */
+openclaw-lobster-pet[data-dex-complete]::after {
+  content: "";
+  position: absolute;
+  left: 8%;
+  right: 8%;
+  bottom: 0;
+  height: 2px;
+  background: linear-gradient(90deg, transparent, #f4b840 30%, #f9d47a 50%, #f4b840 70%, transparent);
+  opacity: 0.5;
+  pointer-events: none;
+}
+
 /* ---- Rare palette variants (weights + lore in lobster-pet.ts) ---- */
 
 /* Ghost/albino: pale translucent shell, icy glints. */
@@ -68,6 +95,87 @@ openclaw-lobster-pet {
 .lobster-pet--palette-abyss .lob-eye-open circle:nth-of-type(3),
 .lobster-pet--palette-abyss .lob-eye-open circle:nth-of-type(4) {
   filter: drop-shadow(0 0 2.5px rgba(82, 245, 227, 0.9));
+}
+
+/* Lumen: photophore running lights. They pulse and glow in the dark theme;
+   daylight (light theme) washes them down to faint speckles. */
+.lobster-pet--palette-lumen {
+  --lob-glint: #7ef5dd;
+}
+
+.lob-lumen {
+  filter: drop-shadow(0 0 3px rgba(126, 245, 221, 0.9));
+  animation: lobster-pet-lumen 3.2s ease-in-out infinite;
+}
+
+:root[data-theme-mode="light"] .lob-lumen {
+  filter: none;
+  opacity: 0.3;
+  animation: none;
+}
+
+@keyframes lobster-pet-lumen {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.55;
+  }
+}
+
+/* Cotton candy: pastel two-tone with a slow iridescent drift. The breathe
+   animation must ride along - a lone animation list would replace it. */
+.lobster-pet--palette-cottoncandy {
+  --lob-glint: #ff9fd6;
+}
+
+.lobster-pet--palette-cottoncandy .lobster-pet__svg {
+  animation:
+    lobster-pet-breathe 3.4s ease-in-out infinite,
+    lobster-pet-iridesce 8s linear infinite;
+}
+
+@keyframes lobster-pet-iridesce {
+  0%,
+  100% {
+    filter: hue-rotate(0deg) saturate(1);
+  }
+  50% {
+    filter: hue-rotate(26deg) saturate(1.2);
+  }
+}
+
+/* Shiny: saturated sheen plus twinkling sparks. The filter skips retro so
+   the sticker-outline halo survives; sparkle spans carry the show there. */
+.lobster-pet--shiny:not(.lobster-pet--palette-retro) .lobster-pet__svg {
+  filter: saturate(1.3) brightness(1.07);
+}
+
+.lobster-pet__sparkle {
+  position: absolute;
+  color: #ffe27a;
+  font-size: calc(4px * var(--lob-scale, 2));
+  line-height: 1;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.lobster-pet--shiny .lobster-pet__sparkle {
+  animation: lobster-pet-twinkle 2.2s ease-in-out infinite;
+  animation-delay: calc(var(--i, 0) * 1.1s);
+}
+
+@keyframes lobster-pet-twinkle {
+  0%,
+  100% {
+    opacity: 0;
+    transform: scale(0.5) rotate(0deg);
+  }
+  50% {
+    opacity: 0.95;
+    transform: scale(1.1) rotate(24deg);
+  }
 }
 
 /* Retro: homage to the classic OpenClaw logo — white sticker outline around
@@ -100,6 +208,13 @@ openclaw-lobster-pet {
 .lobster-pet--offline .lob-eye-open circle:nth-of-type(3),
 .lobster-pet--offline .lob-eye-open circle:nth-of-type(4) {
   filter: none;
+}
+
+/* Offline also dims the lumen running lights - no power, no glow. */
+.lobster-pet--offline .lob-lumen {
+  filter: none;
+  animation: none;
+  opacity: 0.4;
 }
 
 .lobster-pet__body {
@@ -136,17 +251,19 @@ openclaw-lobster-pet {
 }
 
 /* Claw size scales the paths inside the group: act animations own the group
-   transform, so scaling here composes instead of being overridden mid-wave. */
+   transform, so scaling here composes instead of being overridden mid-wave.
+   Per-side vars let crusher/pincer asymmetry size each claw on its own. */
 .lob-claw > path {
-  transform: scale(var(--lob-claw-scale, 1));
   transform-box: view-box;
 }
 
 .lob-claw--l > path {
+  transform: scale(var(--lob-claw-l, 1));
   transform-origin: 25px 52px;
 }
 
 .lob-claw--r > path {
+  transform: scale(var(--lob-claw-r, 1));
   transform-origin: 95px 52px;
 }
 
@@ -172,10 +289,98 @@ openclaw-lobster-pet {
   animation-delay: var(--lob-blink-delay, 0s);
 }
 
-/* ---- Entrance: pops up from behind the footer ledge ---- */
+/* ---- Entrances ----
+   Walk pops up from behind the footer ledge; rare arrivals descend under a
+   balloon or pop out of a bubble. Durations mirror LOBSTER_PET_ENTRANCE_MS
+   in lobster-pet-plans.ts. */
 
 .lobster-pet--entering .lobster-pet__body {
   animation: lobster-pet-enter 0.45s ease-out;
+}
+
+.lobster-pet--enter-balloon .lobster-pet__body {
+  animation: lobster-pet-descend 1.25s ease-out;
+}
+
+.lobster-pet__balloon {
+  position: absolute;
+  left: 24%;
+  bottom: 92%;
+  width: calc(6.5px * var(--lob-scale, 2));
+  height: calc(10px * var(--lob-scale, 2));
+  pointer-events: none;
+  animation: lobster-pet-balloon 1.25s ease-out forwards;
+}
+
+.lobster-pet--enter-bubble .lobster-pet__body {
+  animation: lobster-pet-bubble-rise 0.7s ease-out;
+}
+
+.lobster-pet__entry-bubble {
+  position: absolute;
+  inset: -12% -8%;
+  border: 1.5px solid var(--lob-glint, #00e5cc);
+  border-radius: 50%;
+  opacity: 0;
+  pointer-events: none;
+  animation: lobster-pet-bubble-pop 0.7s ease-out forwards;
+}
+
+@keyframes lobster-pet-descend {
+  0% {
+    transform: translateY(-170%);
+  }
+  75% {
+    transform: translateY(4%);
+  }
+  88% {
+    transform: translateY(-2%) scaleY(0.96);
+  }
+  100% {
+    transform: translateY(0) scaleY(1);
+  }
+}
+
+@keyframes lobster-pet-balloon {
+  0%,
+  70% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+    transform: translateY(-40%);
+  }
+}
+
+@keyframes lobster-pet-bubble-rise {
+  0% {
+    transform: translateY(30%) scale(0.35);
+  }
+  60% {
+    transform: translateY(-4%) scale(1.05);
+  }
+  100% {
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes lobster-pet-bubble-pop {
+  0% {
+    opacity: 0.9;
+    transform: scale(0.45);
+  }
+  55% {
+    opacity: 0.75;
+    transform: scale(1);
+  }
+  70% {
+    opacity: 0;
+    transform: scale(1.25);
+  }
+  100% {
+    opacity: 0;
+    transform: scale(1.25);
+  }
 }
 
 /* ---- Acts ---- */
@@ -702,7 +907,9 @@ openclaw-lobster-pet {
 
 @media (prefers-reduced-motion: reduce) {
   openclaw-lobster-pet .lobster-pet,
-  openclaw-lobster-pet .lobster-pet * {
+  openclaw-lobster-pet .lobster-pet *,
+  openclaw-lobster-pet .lobster-bottle,
+  openclaw-lobster-pet .lobster-bottle * {
     animation: none !important;
     transition: none !important;
   }
@@ -711,7 +918,8 @@ openclaw-lobster-pet {
 /* ---- Pass-through visitors ---- */
 
 /* Passers cross the whole ledge once; left/right position comes from the
-   crossing keyframes, not the perch variable. */
+   crossing keyframes, not the perch variable, and each kind sets its own
+   crossing time through --lob-cross (LOBSTER_PASSER_CROSS_MS). */
 .lobster-pet--passer {
   pointer-events: none;
   cursor: default;
@@ -723,17 +931,36 @@ openclaw-lobster-pet {
 }
 
 .lobster-pet--passer-ltr {
-  animation: lobster-pet-cross-ltr 11s linear forwards;
+  animation: lobster-pet-cross-ltr var(--lob-cross, 11s) linear forwards;
 }
 
 .lobster-pet--passer-rtl {
-  animation: lobster-pet-cross-rtl 11s linear forwards;
+  animation: lobster-pet-cross-rtl var(--lob-cross, 11s) linear forwards;
 }
 
 /* The crab walks sideways by definition: it crosses while facing you and
    feels no need to explain itself. */
 .lobster-pet--crab .lobster-pet__body {
   animation: lobster-pet-crab-scuttle 0.24s ease-in-out infinite;
+}
+
+/* The snail neither waddles nor hurries. */
+.lobster-pet--snail .lobster-pet__body {
+  animation: none;
+}
+
+/* The duck bobs like the bath toy it is. */
+.lobster-pet--duck .lobster-pet__body {
+  animation: lobster-pet-duck-bob 1.6s ease-in-out infinite;
+}
+
+/* The jellyfish drifts above the ledge, pulsing softly. */
+.lobster-pet--jellyfish {
+  bottom: 12px;
+}
+
+.lobster-pet--jellyfish .lobster-pet__body {
+  animation: lobster-pet-jelly-pulse 2.4s ease-in-out infinite;
 }
 
 @keyframes lobster-pet-cross-ltr {
@@ -764,6 +991,66 @@ openclaw-lobster-pet {
   }
 }
 
+@keyframes lobster-pet-duck-bob {
+  0%,
+  100% {
+    transform: translateY(0) rotate(-3deg);
+  }
+  50% {
+    transform: translateY(-6%) rotate(3deg);
+  }
+}
+
+@keyframes lobster-pet-jelly-pulse {
+  0%,
+  100% {
+    transform: translateY(0) scaleY(1);
+  }
+  45% {
+    transform: translateY(-14%) scaleY(0.92);
+  }
+}
+
+/* ---- Message in a bottle ----
+   Washes up on its own schedule, bobs until opened, and ebbs away. The
+   fortune travels in the title tooltip. */
+
+.lobster-bottle {
+  position: absolute;
+  bottom: 0;
+  left: var(--lob-x, 50%);
+  width: 22px;
+  height: 20px;
+  transform: translateX(-50%);
+  pointer-events: auto;
+  cursor: pointer;
+  user-select: none;
+  -webkit-user-select: none;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.lobster-bottle__svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+  overflow: visible;
+  animation: lobster-bottle-bob 3.6s ease-in-out infinite;
+}
+
+.lobster-bottle--open .lobster-bottle__svg {
+  animation: none;
+}
+
+@keyframes lobster-bottle-bob {
+  0%,
+  100% {
+    transform: rotate(0deg);
+  }
+  50% {
+    transform: translateY(-6%) rotate(-4deg);
+  }
+}
+
 /* ---- Lobsterdex (appearance settings gallery) ---- */
 
 .lobsterdex {
@@ -787,6 +1074,17 @@ openclaw-lobster-pet {
 /* Unseen palettes are dim silhouettes until one visits. */
 .lobsterdex__mini--unseen {
   filter: grayscale(1) brightness(0.45) opacity(0.55);
+}
+
+/* A shiny of this palette has visited: a small gold spark on the mini. */
+.lobsterdex__mini-star {
+  position: absolute;
+  top: -5px;
+  right: -4px;
+  font-size: 9px;
+  line-height: 1;
+  color: #f4b840;
+  pointer-events: none;
 }
 
 /* ---- Logo stand-in ----


### PR DESCRIPTION
# What Problem This Solves

The sidebar lobster pet's random universe was small enough to exhaust quickly: 12 palettes, one visitor species besides strangers (the crab), a single walk-up entrance, and a Lobsterdex that only ever collects palettes and never gives anything back. Regular users see the whole variety space within days, and the collection has no long game.

# Why This Change Was Made

Maintainer request: more random lobsters for the bottom-left lobster, built from a reviewed idea list (shinies as a multiplier, real-genetics palettes, an ecosystem of ledge visitors, and making the Lobsterdex feel alive instead of write-only).

# User Impact

All decorative, all client-side, all behind the existing "Lobster visits" toggle; reduced motion keeps its guarantees.

- **Shiny lobsters (~1 in 512)**: sparkle overlay + saturated sheen on any palette, `✦` in the name tooltip, tracked per palette in the Lobsterdex (gold star on the mini).
- **Two new palettes**: `cottoncandy` (pastel pink/blue with a slow iridescent drift, after the famous Maine catches, ~0.8%) and `lumen` (bioluminescent photophores that only really glow in the dark theme, ~2%). Rare names: Taffy and Glimmer.
- **Old friends return (~8% of loads)**: a palette the Lobsterdex already remembers comes back wearing its recorded first-visitor name, waves hello on arrival, and the title reads `<name> · an old friend`.
- **The Elder (~1.5% of loads)**: scale-3, barnacled, sleepy, mighty-clawed "Methuselah · old as the tides". Never molts.
- **Crusher/pincer claw asymmetry (~15%)**: real lobsters have a crusher and a pincer; one claw renders mighty, the other dainty.
- **Freckles (~12%)** and **seeded eye-glint tints (~30%)** for common palettes (rare palettes keep their signature glints; offline grey still wins the cascade).
- **New ledge traffic** inside the unchanged 9.5% passer gate: a snail (90-second crossing — glance away, glance back, still crossing), a rubber duck, and a jellyfish drifting above the ledge, joining the stranger and the crab. Per-kind crossing durations; the resident reacts mid-cross (friends wave, shy pets peek).
- **Entrance variants**: rare arrivals descend under a balloon (6%) or pop out of a bubble (7%) instead of walking up.
- **Message in a bottle (~3% of loads)**: washes up on its own clock, pet or no pet; clicking it swaps the tooltip to one of 14 fortunes, then the tide reclaims it.
- **National Lobster Day (Sept 25)**: monocles join the seasonal accessory pool. We do not cook friends.
- **Completed-Lobsterdex reward**: once all 14 palettes have visited, a quiet golden trim appears along the ledge.

Determinism is preserved: every new feature rolls on its own XOR-salted seeded stream, new look traits append after the existing roll sequence, and all legacy probe seeds (0/2/7/21/42/70/91) keep their exact roles.

Also includes a structural refactor to stay under the max-lines cap: static SVG art moved to `lobster-pet-sprites.ts`, passer/bottle scheduling into a `LobsterLedgeTraffic` ReactiveController (`lobster-pet-traffic.ts`), and rare-load identity resolution into `lobster-pet-plans.ts`.

# Evidence

**New variants** (live components, probed seeds, dark theme):

![variants](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/2026-07-lobster-randomization/lobster-variants.png)

**Ledge traffic + bottle** (crossings mid-ledge; snail + opened bottle in the second shot):

![traffic](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/2026-07-lobster-randomization/lobster-traffic.png)

![snail and open bottle](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/2026-07-lobster-randomization/lobster-traffic-snail-bottle.png)

**Lobsterdex before / after** (12 → 14 palettes, shiny stars):

![before](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/2026-07-lobster-randomization/lobsterdex-before.png)

![after](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/2026-07-lobster-randomization/lobsterdex-after.png)

**Real sidebar with a visiting pet and the golden completed-dex trim:**

![sidebar](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/2026-07-lobster-randomization/lobster-sidebar-context.png)

**Validation** (Blacksmith Testbox, provider `blacksmith-testbox`):

- `pnpm test ui/src/components/lobster-pet.test.ts ui/src/components/lobster-dex.test.ts` — 69/69 pass (58 pet incl. 11 new rare-load/plan tests, 11 dex incl. shiny immutability).
- `pnpm check:changed` — full gate green (conflict markers, max-lines ratchet, format, i18n catalog, typecheck core tests, typecheck UI, lint core).
- oxlint clean on all touched files including the max-lines cap after the module split; oxfmt clean.
- Screenshots captured with a Playwright harness against the e2e mock gateway using deterministic probe seeds (harness not committed).
- Codex autoreview (gpt-5.6-sol, high), four rounds: disconnect-lifecycle and dead-export findings accepted and fixed; one accessibility finding consciously rejected (note below).

**Review note (consciously rejected finding):** Codex autoreview repeatedly flagged that the bottle is `aria-hidden`, pointer-only, and tooltip-based. This is intentional and consistent with the whole lobster pet surface: every sprite and interaction here (poke, pet, shoo, names, honorifics, moving-day flavor) is decorative, out of the accessibility tree, and rides the native `title` channel specifically to avoid an i18n surface. A focusable easter-egg button would inject itself into every user's tab order ~3% of loads, and visible fortune text would create a new localized-copy surface — both worse trades. Documented inline at the `showBottle` scene comment. The reviewer's other findings (traffic-controller disconnect lifecycle, dead exports) were accepted and fixed.
