### PR TITLE
feat(chat): pinned presentation in chat, dashboard-face deep link, board trust dot

### DIFF
--- a/ui/src/components/board/board-widget-cell.ts
+++ b/ui/src/components/board/board-widget-cell.ts
@@ -361,6 +361,9 @@ class OpenClawBoardWidgetCell extends OpenClawLightDomElement {
               title=${t("board.widget.resizeHandle", { title: label })}
               @pointerdown=${(event: PointerEvent) => callbacks.resizePointerDown(widget, event)}
             ></span>`}
+        ${widget.grantState === "granted" && widget.contentKind !== "builtin"
+          ? html`<span class="board-widget__grant-dot" aria-hidden="true"></span>`
+          : nothing}
       </section>
     `;
   }

--- a/ui/src/pages/chat/chat-page.ts
+++ b/ui/src/pages/chat/chat-page.ts
@@ -10,10 +10,15 @@ import "../../components/resizable-divider.ts";
 import { McpAppUnmountGate } from "../../components/mcp-app-unmount.ts";
 import { UI_COMMAND_EVENT, type UiCommandDetail } from "../../components/panel-toggle-contract.ts";
 import { t } from "../../i18n/index.ts";
+import { updateBoardSessionView } from "../../lib/board/settings.ts";
 import { resolveSessionDisplayName } from "../../lib/session-display.ts";
 import { readSessionDragData, sessionDragActive } from "../../lib/sessions/drag.ts";
 import { resolveSessionKey, searchForSession } from "../../lib/sessions/index.ts";
-import { areUiSessionKeysEquivalent } from "../../lib/sessions/session-key.ts";
+import {
+  areUiSessionKeysEquivalent,
+  buildAgentMainSessionKey,
+  normalizeSessionKeyForUiComparison,
+} from "../../lib/sessions/session-key.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
 import "../../styles/chat.css";
@@ -52,6 +57,7 @@ function splitRatio(weights: number[], index: number, context: string): number {
 type ChatRouteData = {
   sessionKey: string;
   draft?: string;
+  face?: "dashboard";
 };
 
 const NARROW_SPLIT_QUERY = "(max-width: 1099px)";
@@ -123,7 +129,7 @@ export class ChatPage extends OpenClawLightDomElement {
     const data = this.data;
     const activePane = this.layout ? findPane(this.layout, this.layout.activePaneId)?.pane : null;
     const routeDraftWasRendered =
-      Boolean(data?.draft) &&
+      Boolean(data?.draft || data?.face) &&
       this.consumedDraftData !== data &&
       (!this.layout || activePane?.sessionKey === data.sessionKey);
     if (changedProperties.has("data")) {
@@ -135,6 +141,9 @@ export class ChatPage extends OpenClawLightDomElement {
       queueMicrotask(() => {
         if (this.isConnected && this.data === data && this.consumedDraftData !== data) {
           this.consumedDraftData = data;
+          if (data.face) {
+            this.applyRouteFace(data.sessionKey, data.face);
+          }
           // Route drafts are one-shot actions. Once the matching pane owns the
           // text, remove it from history so reload/back cannot replay it.
           this.context.replace("chat", { search: searchForSession(data.sessionKey) });
@@ -503,6 +512,24 @@ export class ChatPage extends OpenClawLightDomElement {
       }
     }
   };
+
+  // Route-owned face intent persists here, keyed exactly like chat-pane's
+  // board settings, because pane-level board resolution is not ready at
+  // navigation time and would file the face under the wrong session.
+  private applyRouteFace(sessionKey: string, face: "dashboard"): void {
+    const resolved = resolveSessionKey(sessionKey, this.context.gateway.snapshot.hello);
+    const normalized = normalizeSessionKeyForUiComparison(resolved);
+    const boardSessionKey =
+      normalized === "main" ? buildAgentMainSessionKey({ agentId: "main" }) : normalized;
+    if (!boardSessionKey) {
+      return;
+    }
+    patchSettings({
+      boardSessionViews: updateBoardSessionView(loadSettings().boardSessionViews, boardSessionKey, {
+        face,
+      }),
+    });
+  }
 
   private routeDraftForActivePane(sessionKey = this.data?.sessionKey): string | undefined {
     const data = this.data;

--- a/ui/src/pages/chat/components/widget-card.test.ts
+++ b/ui/src/pages/chat/components/widget-card.test.ts
@@ -278,3 +278,60 @@ describe("widget-card", () => {
     expect(missingView.querySelector("[data-pin-widget]")).toBeNull();
   });
 });
+
+describe("widget-card presentation", () => {
+  const preview = {
+    kind: "canvas",
+    surface: "assistant_message",
+    render: "url",
+    title: "Clock",
+    viewId: "cv_clock",
+    url: "/__openclaw__/canvas/documents/cv_clock/index.html",
+    sandbox: "scripts",
+  } as const;
+
+  function providerWith(presentation?: "card" | "full-bleed" | "frameless"): BoardProvider {
+    return {
+      sessionKey: "agent:main:main",
+      canPinWidgets: true,
+      pinWidget: vi.fn(async () => undefined),
+      snapshot$: {
+        value: {
+          sessionKey: "agent:main:main",
+          revision: 1,
+          tabs: [],
+          widgets: [
+            {
+              name: "canvas-cv_clock",
+              tabId: "main",
+              contentKind: "html",
+              ...(presentation ? { presentation } : {}),
+              sizeW: 6,
+              sizeH: 4,
+              position: 0,
+              grantState: "none",
+              revision: 1,
+            },
+          ],
+        },
+        subscribe: () => () => {},
+      },
+    } as unknown as BoardProvider;
+  }
+
+  it("drops the panel inset for non-card pinned presentations", () => {
+    const host = document.createElement("div");
+    render(
+      renderToolPreview(preview, "chat_message", { boardProvider: providerWith("full-bleed") }),
+      host,
+    );
+    expect(host.querySelector(".chat-tool-card__preview-panel")?.hasAttribute("data-bleed")).toBe(
+      true,
+    );
+
+    render(renderToolPreview(preview, "chat_message", { boardProvider: providerWith() }), host);
+    expect(host.querySelector(".chat-tool-card__preview-panel")?.hasAttribute("data-bleed")).toBe(
+      false,
+    );
+  });
+});

--- a/ui/src/pages/chat/components/widget-card.ts
+++ b/ui/src/pages/chat/components/widget-card.ts
@@ -472,9 +472,13 @@ function renderWidgetCard(
       ? mcpAppWidgetNameForViewId(mcpAppViewId)
       : undefined
     : canvasWidgetName(preview);
-  const pinned = Boolean(
-    pinName && provider?.snapshot$.value.widgets.some((widget) => widget.name === pinName),
-  );
+  const pinnedWidget = pinName
+    ? provider?.snapshot$.value.widgets.find((widget) => widget.name === pinName)
+    : undefined;
+  const pinned = Boolean(pinnedWidget);
+  // Chat keeps its labeled card shell, but the inner inset follows the pinned
+  // widget's presentation so authored edge-to-edge content matches the board.
+  const bleed = pinned && (pinnedWidget?.presentation ?? "card") !== "card";
   const pinAction =
     provider &&
     (contentKind === "mcp-app" ? provider.canPinMcpApps : provider.canPinWidgets) &&
@@ -510,7 +514,7 @@ function renderWidgetCard(
           ${renderWidgetActions(preview)}
         </div>
       </div>
-      <div class="chat-tool-card__preview-panel" data-side="canvas">
+      <div class="chat-tool-card__preview-panel" data-side="canvas" ?data-bleed=${bleed}>
         ${renderWidgetContent(contentKind, preview, options)}
       </div>
     </div>

--- a/ui/src/pages/chat/route.ts
+++ b/ui/src/pages/chat/route.ts
@@ -13,11 +13,17 @@ function draftFromLocation(location: RouteLocation): string | undefined {
   return draft || undefined;
 }
 
+// Only "dashboard" is meaningful: chat is the default face, so a chat value
+// would be a no-op that still dirties history replaces.
+function faceFromLocation(location: RouteLocation): "dashboard" | undefined {
+  return new URLSearchParams(location.search).get("face") === "dashboard" ? "dashboard" : undefined;
+}
+
 export const page = definePage({
   id: "chat",
   path: "/chat",
   loaderDeps: (_context: ApplicationContext, location: RouteLocation) =>
-    `${sessionKeyFromLocation(location) ?? ""}\u0000${draftFromLocation(location) ?? ""}`,
+    `${sessionKeyFromLocation(location) ?? ""}\u0000${draftFromLocation(location) ?? ""}\u0000${faceFromLocation(location) ?? ""}`,
   loader: async (_context: ApplicationContext, { location }) => {
     const sessionKey = sessionKeyFromLocation(location);
     if (!sessionKey) {
@@ -26,6 +32,7 @@ export const page = definePage({
     return {
       sessionKey,
       draft: draftFromLocation(location),
+      face: faceFromLocation(location),
     };
   },
   component: () =>

--- a/ui/src/styles/board.css
+++ b/ui/src/styles/board.css
@@ -300,6 +300,12 @@ openclaw-board-widget-cell {
   position: absolute;
 }
 
+/* Passive trust indicator: only meaningful where chrome hides (fine pointer),
+   so the base rule keeps it off and the overlay block reveals it at rest. */
+.board-widget__grant-dot {
+  display: none;
+}
+
 .board-widget__frame {
   background: transparent;
   border: 0;
@@ -523,6 +529,30 @@ openclaw-board-widget-cell {
        authoritative because no transition-property is redeclared here. */
     transition-delay: 0s;
     visibility: visible;
+  }
+
+  /* While chrome is hidden, a granted widget keeps a small trust dot in the
+     bar's corner; the revealed bar carries the full capabilities chip, so the
+     dot fades out together with the chrome fade-in. */
+  .board-widget__grant-dot {
+    background: var(--ok, #4ec9a8);
+    border-radius: 50%;
+    display: block;
+    height: 6px;
+    pointer-events: none;
+    position: absolute;
+    right: 10px;
+    top: 10px;
+    transition: opacity 120ms ease;
+    width: 6px;
+    z-index: 4;
+  }
+
+  .board-widget:hover .board-widget__grant-dot,
+  .board-widget:focus-within .board-widget__grant-dot,
+  .board-widget--dragging .board-widget__grant-dot,
+  .board-widget:has(.board-widget__menu[open]) .board-widget__grant-dot {
+    opacity: 0;
   }
 
   /* Frameless is a fine-pointer treatment only: touch keeps the card shell

--- a/ui/src/styles/chat/tool-cards.css
+++ b/ui/src/styles/chat/tool-cards.css
@@ -827,6 +827,12 @@
   padding: var(--widget-frame-inset);
 }
 
+/* Full-bleed and frameless pins render edge-to-edge here too, so the same
+   authored document meets identical geometry in chat and on the board. */
+.chat-tool-card__preview-panel[data-bleed] {
+  padding: 0;
+}
+
 .chat-tool-card__preview-frame {
   display: block;
   width: 100%;

--- a/ui/src/test-helpers/board-fixture.ts
+++ b/ui/src/test-helpers/board-fixture.ts
@@ -2,7 +2,13 @@ import { html } from "lit";
 import { state } from "lit/decorators.js";
 import type { BoardOp, BoardSnapshot } from "../lib/board/types.ts";
 import { OpenClawLightDomElement } from "../lit/openclaw-element.ts";
+// The fixture page renders outside the app shell, so it must load the app
+// stylesheet itself (Web Awesome theme included) or dropdown menus render
+// theme-less: dark item text on the fixture's dark panels.
+import "../styles.css";
 import "../components/board/board-view.ts";
+
+document.documentElement.classList.add("wa-dark");
 
 const initialSnapshot: BoardSnapshot = {
   sessionKey: "agent:main:board-fixture",


### PR DESCRIPTION
## What Problem This Solves

Follow-ups to #111977. Three gaps remained: chat previews ignored a pinned widget's declared presentation (full-bleed content still got the 12px inset in chat, diverging from the board); there was no way to deep-link a session directly to its dashboard face (needed by the upcoming mobile dashboard webviews); and with chrome hover-hidden on the board, granted widgets showed no passive trust indicator. Plus the board dev fixture rendered its dropdown menus illegibly (theme-less dark-on-dark).

## Why This Change Was Made

- **Chat honors pinned presentation**: the chat widget card already resolves the board snapshot to decide "pinned"; it now reads the matched widget's `presentation` and drops the panel inset for non-card pins (`data-bleed`), so the same authored document meets identical geometry in chat and on the board — and tracks later board changes live. No protocol changes.
- **`face=dashboard` deep link**: `/chat?session=<key>&face=dashboard` opens the session's Dashboard face. It follows the route-draft one-shot pattern — consumed once, persisted into `boardSessionViews` under the canonical session key, then stripped from the URL so back/reload can't replay it. Persistence lives in chat-page (route owner), not chat-pane, because pane-level board resolution isn't ready at navigation time and filed the intent under the wrong session (caught live in the mock harness).
- **Trust dot**: granted widgets show a 6px `--ok` dot in the corner while chrome is hidden (fine-pointer only); it fades out exactly as the revealed bar (which carries the full capabilities chip) fades in.
- **Fixture theming**: the standalone board fixture page now loads the app stylesheet + `wa-dark`, making its menus legible for dev/screenshot work.

## User Impact

| Fixture menu before | After: themed menu + trust dot |
| --- | --- |
| ![before](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/widget-followups/before-menu.png) | ![after](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/widget-followups/after-menu-and-dot.png) |

Chat previews of full-bleed/frameless pins render edge-to-edge (verified by unit test; the labeled chat card shell is retained deliberately — a transcript needs context). The deep link is the contract the iOS/Android dashboard screens (follow-up PR) will target.

## Evidence

- `widget-card.test.ts` 4/4 incl. new data-bleed assertions; chat-page/board-surface/pane-board suites 44/44; board suites 45+3+13 (Chromium) — all green after final edits.
- Live verification in the mock harness: face param navigates → persists under `agent:main:tax-research` (canonical key) → URL stripped → `openclaw-board-view` mounts with the Dashboard face active; trust dot verified on the granted fixture widget, fading on hover; an import-path boot crash (jsdom module interop hid it) was caught by the live browser and fixed.
- Autoreview (Codex gpt-5.6-sol, xhigh): clean first pass (0.84).
