### PR TITLE
fix(providers): reject malformed UTF-8 usage responses

### DIFF
--- a/extensions/anthropic/usage.ts
+++ b/extensions/anthropic/usage.ts
@@ -7,6 +7,7 @@ import {
   readClaudeCliCredentialsCached,
   validateAnthropicSetupToken,
 } from "openclaw/plugin-sdk/provider-auth";
+import { readProviderJsonObjectResponse } from "openclaw/plugin-sdk/provider-http";
 import {
   buildUsageHttpErrorSnapshot,
   fetchClaudeUsage,
@@ -14,7 +15,6 @@ import {
   type ProviderUsageModelBreakdown,
   type ProviderUsageSnapshot,
 } from "openclaw/plugin-sdk/provider-usage";
-import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import { CLAUDE_CLI_BACKEND_ID } from "./cli-constants.js";
 
 const ANTHROPIC_COST_URL = "https://api.anthropic.com/v1/organizations/cost_report";
@@ -134,14 +134,13 @@ function resolveDailyRange(now: number, periodDays: number) {
 }
 
 async function readPage(response: Response, timeoutMs: number): Promise<AnthropicUsagePage> {
-  const buffer = await readResponseWithLimit(response, ANTHROPIC_USAGE_RESPONSE_MAX_BYTES, {
+  const payload = await readProviderJsonObjectResponse(response, "Anthropic usage", {
+    maxBytes: ANTHROPIC_USAGE_RESPONSE_MAX_BYTES,
     chunkTimeoutMs: timeoutMs,
-    onOverflow: ({ maxBytes }) => new Error(`Anthropic usage response exceeds ${maxBytes} bytes`),
     onIdleTimeout: ({ chunkTimeoutMs }) =>
       new Error(`Anthropic usage response stalled for ${chunkTimeoutMs}ms`),
   });
-  const payload = objectRecord(JSON.parse(new TextDecoder().decode(buffer)));
-  if (!payload || !Array.isArray(payload.data)) {
+  if (!Array.isArray(payload.data)) {
     throw new Error("Anthropic usage response is not an object with data");
   }
   const nextPage =

--- a/extensions/openai/usage.ts
+++ b/extensions/openai/usage.ts
@@ -3,6 +3,7 @@ import type {
   ProviderResolveUsageAuthContext,
   ProviderResolvedUsageAuth,
 } from "openclaw/plugin-sdk/plugin-entry";
+import { readProviderJsonObjectResponse } from "openclaw/plugin-sdk/provider-http";
 import {
   buildUsageHttpErrorSnapshot,
   fetchCodexUsage,
@@ -10,7 +11,6 @@ import {
   type ProviderUsageModelBreakdown,
   type ProviderUsageSnapshot,
 } from "openclaw/plugin-sdk/provider-usage";
-import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import { resolveCodexAuthIdentity } from "./openai-chatgpt-auth-identity.js";
 
 const OPENAI_COSTS_URL = "https://api.openai.com/v1/organization/costs";
@@ -118,14 +118,13 @@ function resolveDailyRange(now: number, periodDays: number) {
 }
 
 async function readPage(response: Response, timeoutMs: number): Promise<OpenAIUsagePage> {
-  const buffer = await readResponseWithLimit(response, OPENAI_USAGE_RESPONSE_MAX_BYTES, {
+  const payload = await readProviderJsonObjectResponse(response, "OpenAI usage", {
+    maxBytes: OPENAI_USAGE_RESPONSE_MAX_BYTES,
     chunkTimeoutMs: timeoutMs,
-    onOverflow: ({ maxBytes }) => new Error(`OpenAI usage response exceeds ${maxBytes} bytes`),
     onIdleTimeout: ({ chunkTimeoutMs }) =>
       new Error(`OpenAI usage response stalled for ${chunkTimeoutMs}ms`),
   });
-  const payload = objectRecord(JSON.parse(new TextDecoder().decode(buffer)));
-  if (!payload || !Array.isArray(payload.data)) {
+  if (!Array.isArray(payload.data)) {
     throw new Error("OpenAI usage response is not an object with data");
   }
   const nextPage =

--- a/extensions/openrouter/usage.ts
+++ b/extensions/openrouter/usage.ts
@@ -1,6 +1,6 @@
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import type { ProviderUsageSnapshot } from "openclaw/plugin-sdk/provider-usage";
 import { buildUsageHttpErrorSnapshot } from "openclaw/plugin-sdk/provider-usage";
-import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 
 const OPENROUTER_USAGE_RESPONSE_MAX_BYTES = 1024 * 1024;
 const OPENROUTER_API_ROOT = "https://openrouter.ai/api/v1";
@@ -75,13 +75,12 @@ function resolveKeyBudget(
 }
 
 async function readJson(response: Response, timeoutMs: number): Promise<unknown> {
-  const buffer = await readResponseWithLimit(response, OPENROUTER_USAGE_RESPONSE_MAX_BYTES, {
+  return await readProviderJsonResponse(response, "OpenRouter usage", {
+    maxBytes: OPENROUTER_USAGE_RESPONSE_MAX_BYTES,
     chunkTimeoutMs: timeoutMs,
-    onOverflow: ({ maxBytes }) => new Error(`OpenRouter usage response exceeds ${maxBytes} bytes`),
     onIdleTimeout: ({ chunkTimeoutMs }) =>
       new Error(`OpenRouter usage response stalled for ${chunkTimeoutMs}ms`),
   });
-  return JSON.parse(new TextDecoder().decode(buffer));
 }
 
 async function fetchEndpoint(params: {

--- a/extensions/venice/usage.ts
+++ b/extensions/venice/usage.ts
@@ -1,6 +1,6 @@
+import { readProviderJsonObjectResponse } from "openclaw/plugin-sdk/provider-http";
 import type { ProviderUsageSnapshot } from "openclaw/plugin-sdk/provider-usage";
 import { buildUsageHttpErrorSnapshot } from "openclaw/plugin-sdk/provider-usage";
-import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 
 const VENICE_BALANCE_URL = "https://api.venice.ai/api/v1/billing/balance";
 const VENICE_USAGE_RESPONSE_MAX_BYTES = 1024 * 1024;
@@ -25,23 +25,13 @@ function nonNegativeNumber(value: unknown): number | undefined {
   return Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined;
 }
 
-function objectRecord(value: unknown): Record<string, unknown> | undefined {
-  return value !== null && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : undefined;
-}
-
 async function readPayload(response: Response, timeoutMs: number): Promise<VeniceBalanceResponse> {
-  const buffer = await readResponseWithLimit(response, VENICE_USAGE_RESPONSE_MAX_BYTES, {
+  const data = await readProviderJsonObjectResponse(response, "Venice usage", {
+    maxBytes: VENICE_USAGE_RESPONSE_MAX_BYTES,
     chunkTimeoutMs: timeoutMs,
-    onOverflow: ({ maxBytes }) => new Error(`Venice usage response exceeds ${maxBytes} bytes`),
     onIdleTimeout: ({ chunkTimeoutMs }) =>
       new Error(`Venice usage response stalled for ${chunkTimeoutMs}ms`),
   });
-  const data = objectRecord(JSON.parse(new TextDecoder().decode(buffer)));
-  if (!data) {
-    throw new Error("Venice usage response is not an object");
-  }
   return data as VeniceBalanceResponse;
 }
 


### PR DESCRIPTION
## What Problem This Solves

#111183 fixed ClawRouter usage responses that silently accepted malformed UTF-8 as U+FFFD. The Anthropic Admin API, OpenAI Admin API, OpenRouter, and Venice usage parsers still used the same forgiving decode before JSON parsing, so corrupted provider metadata could enter usage, billing, cursor, or plan fields.

## Why This Change Was Made

Route all four bounded usage readers through the existing `openclaw/plugin-sdk/provider-http` JSON helpers. That owner already provides fatal UTF-8 decoding, byte limits, labeled malformed-JSON errors, and support for each caller's existing idle timeout. This deletes four duplicate decoder/parser paths while preserving provider-specific validation and mapping.

## User Impact

Malformed provider usage bodies are rejected as unavailable or malformed instead of exposing damaged metadata. Valid responses, byte caps, idle timeouts, proxy/SSRF policy, and usage snapshots are unchanged.

## Evidence

- Testbox run https://github.com/openclaw/openclaw/actions/runs/29802484156: 33 focused usage tests passed, followed by extension production/test types, formatting, lint, Plugin SDK surface, boundary, database-first, and import-cycle gates.
- Focused shared-parser regression: `src/agents/provider-http-errors.test.ts` already proves invalid UTF-8 is rejected before JSON parsing.
- Source audit: `readProviderJsonResponse` accepts `ProviderResponseReadOptions`, forwards the existing byte/idle limits, and uses `TextDecoder("utf-8", { fatal: true })`.
- `git diff --check`: clean.
- AutoReview pre-commit pass: clean. A later branch review raised two stale helper-contract findings contradicted by current `origin/main` source and the green Testbox typecheck; both were rejected.

Follow-up to #111183. Credit to @wahaha1223 for identifying and proving the provider-usage malformed UTF-8 class.
