### PR TITLE
fix(ios): show agent avatars and use more sidebar space

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -24987,7 +24987,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 76,
+      "line": 77,
       "path": "apps/ios/Sources/RootSidebar.swift",
       "source": "OpenClaw",
       "surface": "apple",
@@ -24995,7 +24995,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 101,
+      "line": 102,
       "path": "apps/ios/Sources/RootSidebar.swift",
       "source": "Settings",
       "surface": "apple",
@@ -25003,7 +25003,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 115,
+      "line": 116,
       "path": "apps/ios/Sources/RootSidebar.swift",
       "source": "Hide Sidebar",
       "surface": "apple",
@@ -25011,7 +25011,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 213,
+      "line": 207,
       "path": "apps/ios/Sources/RootSidebar.swift",
       "source": "Selected",
       "surface": "apple",
@@ -25027,7 +25027,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 318,
+      "line": 334,
       "path": "apps/ios/Sources/RootSidebar.swift",
       "source": "Search sessions",
       "surface": "apple",
@@ -25035,7 +25035,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 329,
+      "line": 345,
       "path": "apps/ios/Sources/RootSidebar.swift",
       "source": "Clear session search",
       "surface": "apple",
@@ -25043,7 +25043,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 357,
+      "line": 373,
       "path": "apps/ios/Sources/RootSidebar.swift",
       "source": "Loading sessions",
       "surface": "apple",
@@ -25051,7 +25051,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 365,
+      "line": 381,
       "path": "apps/ios/Sources/RootSidebar.swift",
       "source": "No recent sessions",
       "surface": "apple",
@@ -25059,7 +25059,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 375,
+      "line": 391,
       "path": "apps/ios/Sources/RootSidebar.swift",
       "source": "Recent",
       "surface": "apple",
@@ -25067,7 +25067,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 391,
+      "line": 407,
       "path": "apps/ios/Sources/RootSidebar.swift",
       "source": "All Sessions…",
       "surface": "apple",
@@ -25075,7 +25075,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 421,
+      "line": 437,
       "path": "apps/ios/Sources/RootSidebar.swift",
       "source": "Edit Pages",
       "surface": "apple",
@@ -25083,7 +25083,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 445,
+      "line": 461,
       "path": "apps/ios/Sources/RootSidebar.swift",
       "source": "Home",
       "surface": "apple",
@@ -25091,7 +25091,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 653,
+      "line": 670,
       "path": "apps/ios/Sources/RootSidebar.swift",
       "source": "Unread",
       "surface": "apple",
@@ -25099,7 +25099,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 679,
+      "line": 696,
       "path": "apps/ios/Sources/RootSidebar.swift",
       "source": "Attention",
       "surface": "apple",
@@ -25107,7 +25107,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 719,
+      "line": 736,
       "path": "apps/ios/Sources/RootSidebar.swift",
       "source": "New Chat",
       "surface": "apple",
@@ -25115,7 +25115,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 748,
+      "line": 765,
       "path": "apps/ios/Sources/RootSidebar.swift",
       "source": "Connection",
       "surface": "apple",
@@ -25123,7 +25123,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 753,
+      "line": 770,
       "path": "apps/ios/Sources/RootSidebar.swift",
       "source": "Online",
       "surface": "apple",
@@ -25131,7 +25131,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 754,
+      "line": 771,
       "path": "apps/ios/Sources/RootSidebar.swift",
       "source": "Connecting",
       "surface": "apple",
@@ -25139,7 +25139,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 755,
+      "line": 772,
       "path": "apps/ios/Sources/RootSidebar.swift",
       "source": "Needs attention",
       "surface": "apple",
@@ -25147,7 +25147,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 756,
+      "line": 773,
       "path": "apps/ios/Sources/RootSidebar.swift",
       "source": "Offline",
       "surface": "apple",
@@ -25155,7 +25155,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 855,
+      "line": 872,
       "path": "apps/ios/Sources/RootSidebar.swift",
       "source": "Pinned pages stay in the sidebar. Home is always shown.",
       "surface": "apple",
@@ -25163,7 +25163,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 859,
+      "line": 876,
       "path": "apps/ios/Sources/RootSidebar.swift",
       "source": "Pages",
       "surface": "apple",
@@ -25171,7 +25171,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 866,
+      "line": 883,
       "path": "apps/ios/Sources/RootSidebar.swift",
       "source": "Done",
       "surface": "apple",
@@ -25179,7 +25179,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 905,
+      "line": 922,
       "path": "apps/ios/Sources/RootSidebar.swift",
       "source": "Pinned",
       "surface": "apple",
@@ -25187,7 +25187,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 906,
+      "line": 923,
       "path": "apps/ios/Sources/RootSidebar.swift",
       "source": "Not pinned",
       "surface": "apple",

--- a/apps/ios/Sources/RootSidebar.swift
+++ b/apps/ios/Sources/RootSidebar.swift
@@ -4,6 +4,7 @@ import SwiftUI
 
 struct RootSidebar: View {
     @Environment(NodeAppModel.self) private var appModel
+    @Environment(\.colorScheme) private var colorScheme
     @Environment(\.displayScale) private var displayScale
     @Bindable var model: RootSidebarModel
     @State private var searchText = ""
@@ -170,14 +171,7 @@ struct RootSidebar: View {
         } label: {
             HStack(spacing: 9) {
                 ZStack(alignment: .bottomTrailing) {
-                    ZStack {
-                        Circle()
-                            .fill(OpenClawSidebarPalette.elevated)
-                        Text(verbatim: Self.agentBadge(name: Self.agentDisplayName(agent), identity: agent.identity))
-                            .font(OpenClawType.caption2Bold)
-                            .foregroundStyle(OpenClawSidebarPalette.textStrong)
-                    }
-                    .frame(width: 28, height: 28)
+                    self.agentAvatarBadge(agent, size: 28)
                     if isSelected {
                         Circle()
                             .fill(OpenClawBrand.ok)
@@ -219,9 +213,15 @@ struct RootSidebar: View {
                 Button {
                     self.appModel.setSelectedAgentId(agent.id)
                 } label: {
-                    Text(verbatim: Self.agentDisplayName(agent))
-                        .font(OpenClawType.subheadSemiBold)
+                    Label {
+                        Text(verbatim: Self.agentDisplayName(agent))
+                            .font(OpenClawType.subheadSemiBold)
+                    } icon: {
+                        self.agentMenuAvatarImage(agent)
+                            .renderingMode(.original)
+                    }
                 }
+                .accessibilityLabel(Self.agentDisplayName(agent))
             }
         } label: {
             HStack(spacing: 9) {
@@ -282,18 +282,34 @@ struct RootSidebar: View {
     }
 
     static func agentBadge(name: String, identity: [String: AnyCodable]?) -> String {
-        if let emoji = (identity?["emoji"]?.value as? String)?.trimmingCharacters(in: .whitespacesAndNewlines),
-           !emoji.isEmpty
-        {
-            return emoji
+        AgentIdentityPresentation.badge(
+            avatarText: identity?["emoji"]?.value as? String,
+            displayName: name)
+    }
+
+    private func agentAvatarBadge(_ agent: AgentSummary, size: CGFloat) -> some View {
+        ZStack {
+            Circle()
+                .fill(OpenClawSidebarPalette.elevated)
+            Text(verbatim: Self.agentBadge(name: Self.agentDisplayName(agent), identity: agent.identity))
+                .font(OpenClawType.caption2Bold)
+                .foregroundStyle(OpenClawSidebarPalette.textStrong)
+                .minimumScaleFactor(0.65)
+                .lineLimit(1)
         }
-        let initials = name
-            .split(whereSeparator: { $0.isWhitespace || $0 == "-" || $0 == "_" })
-            .prefix(2)
-            .compactMap(\.first)
-            .map(String.init)
-            .joined()
-        return initials.isEmpty ? "OC" : initials.uppercased()
+        .frame(width: size, height: size)
+        .overlay(Circle().strokeBorder(OpenClawSidebarPalette.hairline, lineWidth: 1))
+        .accessibilityHidden(true)
+    }
+
+    private func agentMenuAvatarImage(_ agent: AgentSummary) -> Image {
+        let renderer = ImageRenderer(content: self.agentAvatarBadge(agent, size: 24)
+            .environment(\.colorScheme, self.colorScheme))
+        renderer.scale = self.displayScale
+        guard let image = renderer.uiImage else {
+            return Image(systemName: "person.crop.circle")
+        }
+        return Image(uiImage: image)
     }
 
     private var searchField: some View {
@@ -503,6 +519,7 @@ struct RootSidebar: View {
         }
         .padding(.horizontal, 10)
         .padding(.bottom, 8)
+        .fixedSize(horizontal: false, vertical: true)
         .background(OpenClawSidebarPalette.background)
     }
 

--- a/apps/ios/Sources/RootTabsNavigation.swift
+++ b/apps/ios/Sources/RootTabsNavigation.swift
@@ -9,8 +9,8 @@ extension RootTabs {
 
     static let sidebarSplitIdealWidth: CGFloat = 316
     static let sidebarSplitMaximumWidth: CGFloat = 340
-    // Mirrors the web mobile drawer cap (min(86vw, 320px)).
-    static let sidebarDrawerMaximumWidth: CGFloat = 320
+    // Keep the web drawer's 86% reveal while using more of current iPhone widths.
+    static let sidebarDrawerMaximumWidth: CGFloat = 340
     static let sidebarShowButtonAccessibilityIdentifier = "RootTabs.Sidebar.Show"
     static let sidebarHideButtonAccessibilityIdentifier = "RootTabs.Sidebar.Hide"
 

--- a/apps/ios/Tests/RootTabsPresentationTests.swift
+++ b/apps/ios/Tests/RootTabsPresentationTests.swift
@@ -574,12 +574,26 @@ struct RootTabsPresentationTests {
         #expect(width <= RootTabs.sidebarDrawerMaximumWidth)
     }
 
+    @Test func `phone drawer uses the wider cap when space allows`() {
+        #expect(RootTabs.sidebarWidth(containerWidth: 402, isDrawerLayout: true) == 340)
+    }
+
     @Test func `sidebar shows configured agent rows with sane clamping`() {
         #expect(RootSidebar.shownAgentCount(configured: 1, total: 5) == 1)
         #expect(RootSidebar.shownAgentCount(configured: 3, total: 5) == 3)
         #expect(RootSidebar.shownAgentCount(configured: 0, total: 5) == 1)
         #expect(RootSidebar.shownAgentCount(configured: 3, total: 2) == 2)
         #expect(RootSidebar.shownAgentCount(configured: 1, total: 0) == 1)
+    }
+
+    @Test func `sidebar agent badges use canonical identity fallback`() {
+        #expect(RootSidebar.agentBadge(
+            name: "Research Agent",
+            identity: ["emoji": AnyCodable(" 🦞 ")]) == "🦞")
+        #expect(RootSidebar.agentBadge(
+            name: "Research Agent",
+            identity: ["emoji": AnyCodable("?")]) == "RA")
+        #expect(RootSidebar.agentBadge(name: "Research Agent", identity: nil) == "RA")
     }
 
     @Test func `session work subtitle mirrors the web repo and branch line`() {

--- a/apps/ios/UITests/OpenClawSnapshotUITests.swift
+++ b/apps/ios/UITests/OpenClawSnapshotUITests.swift
@@ -92,6 +92,29 @@ final class OpenClawSnapshotUITests: XCTestCase {
         XCTAssertEqual(self.app?.state, .runningForeground)
     }
 
+    func testSidebarMoreAgentsMenuShowsAvatarsAndKeepsFooterVisible() throws {
+        try XCTSkipIf(UIDevice.current.userInterfaceIdiom != .phone, "Phone sidebar only")
+        self.launchApp(for: ScreenshotTarget(
+            initialTab: "chat",
+            initialDestination: "chat",
+            name: "sidebar-more-agents"))
+
+        let showSidebar = try XCTUnwrap(self.app?.buttons["RootTabs.Sidebar.Show"])
+        XCTAssertTrue(showSidebar.waitForExistence(timeout: 8))
+        showSidebar.tap()
+
+        let moreAgents = try XCTUnwrap(self.app?.buttons["More Agents"])
+        XCTAssertTrue(moreAgents.waitForExistence(timeout: 5))
+        let gatewayFooter = try XCTUnwrap(self.app?.buttons.matching(
+            NSPredicate(format: "label CONTAINS %@", "OpenClaw Gateway")).firstMatch)
+        XCTAssertTrue(gatewayFooter.exists)
+        moreAgents.tap()
+
+        XCTAssertTrue(self.app?.buttons["Research"].waitForExistence(timeout: 5) == true)
+        XCTAssertTrue(self.app?.buttons["Automation"].exists == true)
+        self.attachScreenshot(named: "sidebar-more-agents")
+    }
+
     func testSidebarSlowEdgeDragOpensFromEveryRootDestination() throws {
         try XCTSkipIf(UIDevice.current.userInterfaceIdiom != .phone, "Phone sidebar only")
         let destinations = [


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where iOS users opening **More Agents** saw text-only agent choices, even though the selected agent row showed an avatar. The phone drawer also left more of the chat exposed than necessary, and its permanent connection footer did not explicitly resist vertical compression.

## Why This Change Was Made

The native menu now receives rendered versions of the same canonical emoji/initial badges used by the inline agent row, while preserving agent-name accessibility labels. The phone drawer cap increases from 320 to 340 points while retaining the 86% width rule on smaller screens, and the gateway footer is fixed at its intrinsic vertical size so the scrollable body yields space first.

The implementation remains local to the iOS sidebar: it does not add remote avatar loading or replace the native menu.

## User Impact

Overflow agents are now visually identifiable in **More Agents**, current iPhones devote more useful width to the sidebar, and the permanent gateway footer remains fully visible.

AI-assisted: yes. The final diff was inspected, exercised in Simulator, and passed the repository autoreview gate.

## Evidence

| Before | After |
| --- | --- |
| ![Text-only More Agents menu](https://artifacts.openclaw.ai/ios-agent-avatar-menu-047150643da673/sidebar-more-agents-before.png) | ![More Agents menu with RS and AU avatars and wider drawer](https://artifacts.openclaw.ai/ios-agent-avatar-menu-047150643da673/sidebar-more-agents-after.png) |

Artifact manifest: https://artifacts.openclaw.ai/ios-agent-avatar-menu-047150643da673/artifact-manifest.json

Validated on an iPhone 17 Pro simulator running iOS 26.5 with Xcode 27 beta:

- `OpenClawSnapshotUITests.testSidebarMoreAgentsMenuShowsAvatarsAndKeepsFooterVisible` passed against the real native menu and produced the after screenshot.
- Focused iOS unit, source-guard, render-smoke, and typography suites: **142 passed, 0 failed**.
- SwiftFormat and SwiftLint build phases completed without a related failure.
- `pnpm native:i18n:verify` passed on Blacksmith Testbox `tbx_01ky1kmfchhr6zd3s5c6fk6xeq` after refreshing the generated source-line inventory.
- `git diff --check` passed.
- `autoreview --mode uncommitted`: **clean; no accepted/actionable findings**.
- Independent source-blind behavior validation: all four avatar, width, footer, and accessibility clauses passed.
