### PR TITLE
fix(ui): Hide and Rewind confirmations dismiss with Escape

### DIFF
--- a/ui/src/pages/chat/chat-pane-lifecycle.test.ts
+++ b/ui/src/pages/chat/chat-pane-lifecycle.test.ts
@@ -1,0 +1,150 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import type { SessionCapability } from "../../lib/sessions/index.ts";
+import { createTestChatPane } from "./chat-pane.test-support.ts";
+import {
+  dismissConfirmedActionPopovers,
+  openChatRewindConfirmation,
+} from "./components/chat-message.ts";
+import * as chatThread from "./components/chat-thread.ts";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("chat pane presentation teardown", () => {
+  it("dismisses only confirmations owned by the disconnected pane", () => {
+    const frameCallbacks: FrameRequestCallback[] = [];
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      vi.fn((callback: FrameRequestCallback) => {
+        frameCallbacks.push(callback);
+        return frameCallbacks.length;
+      }),
+    );
+    const addDocumentListener = vi.spyOn(document, "addEventListener");
+    const removeDocumentListener = vi.spyOn(document, "removeEventListener");
+    const addWindowListener = vi.spyOn(window, "addEventListener");
+    const removeWindowListener = vi.spyOn(window, "removeEventListener");
+    const { pane } = createTestChatPane({
+      client: {} as GatewayBrowserClient,
+      sessions: {} as SessionCapability,
+    });
+    const createConfirmationOwner = () => {
+      const owner = document.createElement("span");
+      owner.className = "chat-delete-wrap";
+      const trigger = document.createElement("button");
+      owner.appendChild(trigger);
+      document.body.appendChild(owner);
+      openChatRewindConfirmation(trigger, vi.fn());
+      return { owner, trigger };
+    };
+    window.localStorage.removeItem("openclaw:skip-rewind-confirm");
+    const paneConfirmation = createConfirmationOwner();
+    const siblingConfirmation = createConfirmationOwner();
+
+    try {
+      for (const callback of frameCallbacks.splice(0)) {
+        callback(0);
+      }
+      const captureClickListeners = addDocumentListener.mock.calls.flatMap(
+        ([type, listener, options]) =>
+          type === "click" && options === true && listener ? [listener] : [],
+      );
+      const captureKeydownListeners = addWindowListener.mock.calls.flatMap(
+        ([type, listener, options]) =>
+          type === "keydown" && options === true && listener ? [listener] : [],
+      );
+      expect(captureClickListeners).toHaveLength(2);
+      expect(captureKeydownListeners).toHaveLength(2);
+
+      pane.appendChild(paneConfirmation.owner);
+      pane.disconnectedCallback();
+
+      expect(pane.querySelector(".chat-delete-confirm")).toBeNull();
+      expect(siblingConfirmation.owner.querySelector(".chat-delete-confirm")).not.toBeNull();
+      expect(removeDocumentListener).toHaveBeenCalledWith("click", captureClickListeners[0], true);
+      expect(removeDocumentListener).not.toHaveBeenCalledWith(
+        "click",
+        captureClickListeners[1],
+        true,
+      );
+      expect(removeWindowListener).toHaveBeenCalledWith(
+        "keydown",
+        captureKeydownListeners[0],
+        true,
+      );
+      expect(removeWindowListener).not.toHaveBeenCalledWith(
+        "keydown",
+        captureKeydownListeners[1],
+        true,
+      );
+    } finally {
+      dismissConfirmedActionPopovers(paneConfirmation.owner);
+      dismissConfirmedActionPopovers(siblingConfirmation.owner);
+      paneConfirmation.owner.remove();
+      siblingConfirmation.owner.remove();
+    }
+  });
+
+  it("dismisses the previous session confirmation before switching in place", () => {
+    const frameCallbacks: FrameRequestCallback[] = [];
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      vi.fn((callback: FrameRequestCallback) => {
+        frameCallbacks.push(callback);
+        return frameCallbacks.length;
+      }),
+    );
+    const addDocumentListener = vi.spyOn(document, "addEventListener");
+    const removeDocumentListener = vi.spyOn(document, "removeEventListener");
+    const addWindowListener = vi.spyOn(window, "addEventListener");
+    const removeWindowListener = vi.spyOn(window, "removeEventListener");
+    const { pane } = createTestChatPane({
+      client: {} as GatewayBrowserClient,
+      sessions: {} as SessionCapability,
+    });
+    const owner = document.createElement("span");
+    owner.className = "chat-delete-wrap";
+    const trigger = document.createElement("button");
+    owner.appendChild(trigger);
+    document.body.appendChild(owner);
+    window.localStorage.removeItem("openclaw:skip-rewind-confirm");
+    openChatRewindConfirmation(trigger, vi.fn());
+
+    try {
+      for (const callback of frameCallbacks.splice(0)) {
+        callback(0);
+      }
+      const captureClickListener = addDocumentListener.mock.calls.find(
+        ([type, listener, options]) => type === "click" && options === true && listener,
+      )?.[1];
+      const captureKeydownListener = addWindowListener.mock.calls.find(
+        ([type, listener, options]) => type === "keydown" && options === true && listener,
+      )?.[1];
+      expect(captureClickListener).toBeDefined();
+      expect(captureKeydownListener).toBeDefined();
+      pane.appendChild(owner);
+
+      const resetPresentation = chatThread.resetChatThreadPresentationState;
+      const stopAfterReset = new Error("stop after thread presentation reset");
+      vi.spyOn(chatThread, "resetChatThreadPresentationState").mockImplementation(
+        (paneId, presentationOwner) => {
+          resetPresentation(paneId, presentationOwner);
+          throw stopAfterReset;
+        },
+      );
+
+      expect(() => pane.switchPaneSession("agent:main:next")).toThrow(stopAfterReset);
+      expect(owner.querySelector(".chat-delete-confirm")).toBeNull();
+      expect(removeDocumentListener).toHaveBeenCalledWith("click", captureClickListener, true);
+      expect(removeWindowListener).toHaveBeenCalledWith("keydown", captureKeydownListener, true);
+    } finally {
+      dismissConfirmedActionPopovers(owner);
+      owner.remove();
+    }
+  });
+});

--- a/ui/src/pages/chat/chat-pane.test-support.ts
+++ b/ui/src/pages/chat/chat-pane.test-support.ts
@@ -41,6 +41,7 @@ export type TestChatPane = HTMLElement & {
   taskSuggestions: TaskSuggestion[];
   onPaneSessionChange?: (paneId: string, sessionKey: string) => void;
   sessionKey: string;
+  switchPaneSession: (nextSessionKey: string) => void;
   paneTitle: string;
   catalogSession: SessionCatalogSession | null;
   catalogItemMessage: (item: SessionCatalogTranscriptItem) => Record<string, unknown> | null;

--- a/ui/src/pages/chat/chat-pane.ts
+++ b/ui/src/pages/chat/chat-pane.ts
@@ -213,7 +213,10 @@ import {
   type SidebarContent,
   type SidebarFullMessageRequest,
 } from "./components/chat-sidebar.ts";
-import { ChatTranscriptController } from "./components/chat-thread.ts";
+import {
+  ChatTranscriptController,
+  resetChatThreadPresentationState,
+} from "./components/chat-thread.ts";
 import { WIDGET_PROMPT_EVENT, type WidgetPromptEventDetail } from "./components/chat-tool-cards.ts";
 import {
   CHAT_COMPOSER_DRAFT_STORAGE_ERROR,
@@ -881,6 +884,9 @@ class ChatPane extends OpenClawLightDomElement {
     if (!state) {
       return;
     }
+    // Close old-session portals and listener-owning popovers before the next
+    // render detaches their DOM and makes owner-scoped cleanup impossible.
+    resetChatThreadPresentationState(this.paneId, this);
     const previousSessionKey = state.sessionKey;
     // An in-progress title edit belongs to the previous session; committing
     // it against the newly routed row would rename the wrong session.
@@ -2378,7 +2384,7 @@ class ChatPane extends OpenClawLightDomElement {
     this.headerWorktreePaths.clear();
     this.headerBranches.clear();
     this.announceCommandPaletteTarget(null);
-    resetChatViewState(this.paneId);
+    resetChatViewState(this.paneId, this);
     this.state = undefined;
     this.connectedClient = null;
     disposeQuestionPromptState(this.questionPromptState);

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -5636,6 +5636,39 @@ describe("right-click Reply", () => {
     expect(onRequestUpdate).toHaveBeenCalledOnce();
   });
 
+  it("dismisses an inline confirmation before opening the reply context menu", () => {
+    const container = renderChatView({ onSetReply: vi.fn() });
+    document.body.appendChild(container);
+    const section = container.querySelector<HTMLElement>(".card.chat")!;
+    const confirmationOwner = document.createElement("span");
+    confirmationOwner.className = "chat-delete-wrap";
+    const confirmationTrigger = document.createElement("button");
+    confirmationOwner.appendChild(confirmationTrigger);
+    section.appendChild(confirmationOwner);
+    window.localStorage.removeItem("openclaw:skip-rewind-confirm");
+    chatMessage.openChatRewindConfirmation(confirmationTrigger, vi.fn());
+
+    const group = document.createElement("div");
+    group.className = "chat-group";
+    const bubble = document.createElement("div");
+    bubble.className = "chat-bubble";
+    bubble.dataset.messageText = "open message actions";
+    group.appendChild(bubble);
+    section.querySelector(".chat-thread-inner")!.appendChild(group);
+
+    try {
+      expect(confirmationOwner.querySelector(".chat-delete-confirm")).not.toBeNull();
+      bubble.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
+
+      expect(confirmationOwner.querySelector(".chat-delete-confirm")).toBeNull();
+      expect(document.querySelector(".chat-reply-context-menu")).not.toBeNull();
+    } finally {
+      chatMessage.dismissConfirmedActionPopovers(confirmationOwner);
+      confirmationOwner.remove();
+      container.remove();
+    }
+  });
+
   it("disables rewind and fork context actions during an active run", () => {
     const container = renderChatView({
       canAbort: true,
@@ -5807,6 +5840,112 @@ describe("right-click Reply", () => {
 
     expect(evt.defaultPrevented).toBe(true);
     expect(document.querySelector(".chat-reply-context-menu")).toBeNull();
+  });
+
+  it("dismisses a context-menu Rewind confirmation with Escape before closing the menu", () => {
+    const frameCallbacks: FrameRequestCallback[] = [];
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      vi.fn((callback: FrameRequestCallback) => {
+        frameCallbacks.push(callback);
+        return frameCallbacks.length;
+      }),
+    );
+    const flushFrames = () => {
+      for (const callback of frameCallbacks.splice(0)) {
+        callback(0);
+      }
+    };
+    const container = renderChatView({
+      paneId: "pane-a",
+      onRewindMessage: vi.fn(),
+    });
+    const group = document.createElement("div");
+    group.className = "chat-group user";
+    const bubble = document.createElement("div");
+    bubble.className = "chat-bubble";
+    bubble.dataset.entryId = "persisted-user";
+    bubble.dataset.messageText = "hello";
+    group.appendChild(bubble);
+    container.querySelector(".chat-thread-inner")!.appendChild(group);
+
+    bubble.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
+    flushFrames();
+    const rewindButton = document.querySelector<HTMLButtonElement>(
+      '.chat-reply-context-menu [aria-label="Rewind to here"]',
+    );
+    expect(rewindButton).toBeInstanceOf(HTMLButtonElement);
+    rewindButton!.click();
+    flushFrames();
+
+    const cancel = document.querySelector<HTMLButtonElement>(
+      ".chat-reply-context-menu .chat-delete-confirm__cancel",
+    );
+    expect(cancel).toBeInstanceOf(HTMLButtonElement);
+    expect(document.activeElement).toBe(cancel);
+    const confirmationEscape = new KeyboardEvent("keydown", {
+      key: "Escape",
+      bubbles: true,
+      cancelable: true,
+    });
+    cancel!.dispatchEvent(confirmationEscape);
+
+    expect(confirmationEscape.defaultPrevented).toBe(true);
+    expect(document.querySelector(".chat-delete-confirm")).toBeNull();
+    expect(document.querySelector(".chat-reply-context-menu")).not.toBeNull();
+    expect(document.activeElement).toBe(rewindButton);
+
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true }),
+    );
+    expect(document.querySelector(".chat-reply-context-menu")).toBeNull();
+  });
+
+  it("removes a portaled Rewind confirmation only when its owning pane resets", () => {
+    const frameCallbacks: FrameRequestCallback[] = [];
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      vi.fn((callback: FrameRequestCallback) => {
+        frameCallbacks.push(callback);
+        return frameCallbacks.length;
+      }),
+    );
+    const flushFrames = () => {
+      for (const callback of frameCallbacks.splice(0)) {
+        callback(0);
+      }
+    };
+    const removeDocumentListener = vi.spyOn(document, "removeEventListener");
+    const removeWindowListener = vi.spyOn(window, "removeEventListener");
+    const onRewindMessage = vi.fn();
+    const container = renderChatView({ paneId: "pane-a", onRewindMessage });
+    const group = document.createElement("div");
+    group.className = "chat-group user";
+    const bubble = document.createElement("div");
+    bubble.className = "chat-bubble";
+    bubble.dataset.entryId = "persisted-user";
+    bubble.dataset.messageText = "hello";
+    group.appendChild(bubble);
+    container.querySelector(".chat-thread-inner")!.appendChild(group);
+
+    bubble.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
+    flushFrames();
+    document
+      .querySelector<HTMLButtonElement>('.chat-reply-context-menu [aria-label="Rewind to here"]')!
+      .click();
+    flushFrames();
+
+    resetChatThreadPresentationState("pane-b");
+    expect(document.querySelector(".chat-reply-context-menu")).not.toBeNull();
+    expect(document.querySelector(".chat-delete-confirm")).not.toBeNull();
+
+    resetChatThreadPresentationState("pane-a");
+
+    expect(document.querySelector(".chat-reply-context-menu")).toBeNull();
+    expect(document.querySelector(".chat-delete-confirm")).toBeNull();
+    expect(onRewindMessage).not.toHaveBeenCalled();
+    expect(removeDocumentListener).toHaveBeenCalledWith("click", expect.any(Function), true);
+    expect(removeWindowListener).toHaveBeenCalledWith("keydown", expect.any(Function), true);
   });
 
   it("dismisses the reply context menu before a later context menu opens", () => {

--- a/ui/src/pages/chat/chat-view.ts
+++ b/ui/src/pages/chat/chat-view.ts
@@ -252,9 +252,9 @@ export type ChatProps = {
   onDismissPullRequest?: (pullRequest: ControlUiSessionPullRequest) => void;
 };
 
-export function resetChatViewState(paneId?: string) {
+export function resetChatViewState(paneId?: string, owner?: ParentNode) {
   resetChatComposerState(paneId);
-  resetChatThreadPresentationState(paneId);
+  resetChatThreadPresentationState(paneId, owner);
 }
 
 export function renderChatResizableDivider(props: {

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -8,7 +8,11 @@ import { setUiTimeFormatPreference } from "../../../lib/format.ts";
 import { setAvatarGatewayOrigin } from "../../../lib/identity-avatar.ts";
 import * as localStorageModule from "../../../local-storage.ts";
 import * as chatAvatar from "../chat-avatar.ts";
-import { renderMessageGroup, renderStreamGroup } from "./chat-message.ts";
+import {
+  dismissConfirmedActionPopovers,
+  renderMessageGroup,
+  renderStreamGroup,
+} from "./chat-message.ts";
 
 const localStorageValues = new Map<string, string>();
 const markdownRenderMock = vi.fn(
@@ -378,10 +382,44 @@ function expectLastCaptureClickListener(calls: readonly unknown[][]): unknown {
   return listener;
 }
 
+function getLastCaptureContextMenuListener(calls: readonly unknown[][]) {
+  for (let index = calls.length - 1; index >= 0; index--) {
+    const [type, listener, options] = calls[index] ?? [];
+    if (type === "contextmenu" && options === true && listener) {
+      return listener;
+    }
+  }
+  return null;
+}
+
 function countCaptureClickListenerRemovals(calls: readonly unknown[][], listener: unknown) {
   return calls.filter(
     ([type, removedListener, options]) =>
       type === "click" && options === true && removedListener === listener,
+  ).length;
+}
+
+function countCaptureContextMenuListenerRemovals(calls: readonly unknown[][], listener: unknown) {
+  return calls.filter(
+    ([type, removedListener, options]) =>
+      type === "contextmenu" && options === true && removedListener === listener,
+  ).length;
+}
+
+function getLastCaptureKeydownListener(calls: readonly unknown[][]) {
+  for (let index = calls.length - 1; index >= 0; index--) {
+    const [type, listener, options] = calls[index] ?? [];
+    if (type === "keydown" && options === true && listener) {
+      return listener;
+    }
+  }
+  return null;
+}
+
+function countCaptureKeydownListenerRemovals(calls: readonly unknown[][], listener: unknown) {
+  return calls.filter(
+    ([type, removedListener, options]) =>
+      type === "keydown" && options === true && removedListener === listener,
   ).length;
 }
 
@@ -476,20 +514,36 @@ function setupArmedDeleteConfirm() {
   const flushAnimationFrames = stubAnimationFrameQueue();
   const addListenerSpy = vi.spyOn(document, "addEventListener");
   const removeListenerSpy = vi.spyOn(document, "removeEventListener");
+  const addKeyListenerSpy = vi.spyOn(window, "addEventListener");
+  const removeKeyListenerSpy = vi.spyOn(window, "removeEventListener");
   const fixture = renderDeleteConfirmFixture();
 
   openDeleteConfirm(fixture.deleteButton);
   flushAnimationFrames();
 
   const outsideClickListener = expectLastCaptureClickListener(addListenerSpy.mock.calls);
+  const outsideContextMenuListener = getLastCaptureContextMenuListener(addListenerSpy.mock.calls);
+  const escapeListener = getLastCaptureKeydownListener(addKeyListenerSpy.mock.calls);
+  expect(typeof outsideContextMenuListener).toBe("function");
+  expect(typeof escapeListener).toBe("function");
   expect(fixture.container.querySelectorAll(".chat-delete-confirm")).toHaveLength(1);
 
-  return { ...fixture, outsideClickListener, removeListenerSpy };
+  return {
+    ...fixture,
+    escapeListener,
+    outsideClickListener,
+    outsideContextMenuListener,
+    removeKeyListenerSpy,
+    removeListenerSpy,
+  };
 }
 
 function expectDeleteConfirmDismissed(params: {
   container: HTMLElement;
+  escapeListener: unknown;
   outsideClickListener: unknown;
+  outsideContextMenuListener: unknown;
+  removeKeyListenerSpy: ReturnType<typeof vi.spyOn>;
   removeListenerSpy: ReturnType<typeof vi.spyOn>;
 }) {
   expect(params.container.querySelector(".chat-delete-confirm")).toBeNull();
@@ -497,6 +551,18 @@ function expectDeleteConfirmDismissed(params: {
     countCaptureClickListenerRemovals(
       params.removeListenerSpy.mock.calls,
       params.outsideClickListener,
+    ),
+  ).toBe(1);
+  expect(
+    countCaptureContextMenuListenerRemovals(
+      params.removeListenerSpy.mock.calls,
+      params.outsideContextMenuListener,
+    ),
+  ).toBe(1);
+  expect(
+    countCaptureKeydownListenerRemovals(
+      params.removeKeyListenerSpy.mock.calls,
+      params.escapeListener,
     ),
   ).toBe(1);
 }
@@ -518,6 +584,7 @@ function mediaTicketPayload(mediaTicket: string, ttlMs = 5 * 60 * 1000) {
 afterEach(() => {
   markdownRenderMock.mockClear();
   document.querySelectorAll("[data-delete-confirm-fixture]").forEach((element) => {
+    dismissConfirmedActionPopovers(element);
     element.remove();
   });
   clearDeleteConfirmSkip();
@@ -883,35 +950,39 @@ describe("grouped chat rendering", () => {
       { onDelete: vi.fn() },
     );
 
-    const userDeleteButton = container.querySelector<HTMLButtonElement>(
-      ".chat-group.user .chat-group-delete",
-    );
-    expect(userDeleteButton).toBeInstanceOf(HTMLButtonElement);
-    userDeleteButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    try {
+      const userDeleteButton = container.querySelector<HTMLButtonElement>(
+        ".chat-group.user .chat-group-delete",
+      );
+      expect(userDeleteButton).toBeInstanceOf(HTMLButtonElement);
+      userDeleteButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
 
-    const userConfirm = container.querySelector<HTMLElement>(
-      ".chat-group.user .chat-delete-confirm",
-    );
-    expect(userConfirm).toBeInstanceOf(HTMLElement);
-    expect([...userConfirm!.classList]).toEqual([
-      "chat-delete-confirm",
-      "chat-delete-confirm--left",
-    ]);
+      const userConfirm = container.querySelector<HTMLElement>(
+        ".chat-group.user .chat-delete-confirm",
+      );
+      expect(userConfirm).toBeInstanceOf(HTMLElement);
+      expect([...userConfirm!.classList]).toEqual([
+        "chat-delete-confirm",
+        "chat-delete-confirm--left",
+      ]);
 
-    const assistantDeleteButton = container.querySelector<HTMLButtonElement>(
-      ".chat-group.assistant .chat-group-delete",
-    );
-    expect(assistantDeleteButton).toBeInstanceOf(HTMLButtonElement);
-    assistantDeleteButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      const assistantDeleteButton = container.querySelector<HTMLButtonElement>(
+        ".chat-group.assistant .chat-group-delete",
+      );
+      expect(assistantDeleteButton).toBeInstanceOf(HTMLButtonElement);
+      assistantDeleteButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
 
-    const assistantConfirm = container.querySelector<HTMLElement>(
-      ".chat-group.assistant .chat-delete-confirm",
-    );
-    expect(assistantConfirm).toBeInstanceOf(HTMLElement);
-    expect([...assistantConfirm!.classList]).toEqual([
-      "chat-delete-confirm",
-      "chat-delete-confirm--right",
-    ]);
+      const assistantConfirm = container.querySelector<HTMLElement>(
+        ".chat-group.assistant .chat-delete-confirm",
+      );
+      expect(assistantConfirm).toBeInstanceOf(HTMLElement);
+      expect([...assistantConfirm!.classList]).toEqual([
+        "chat-delete-confirm",
+        "chat-delete-confirm--right",
+      ]);
+    } finally {
+      dismissConfirmedActionPopovers(container);
+    }
   });
 
   it("renders a confirmed rewind action only for user groups", () => {
@@ -1013,6 +1084,109 @@ describe("grouped chat rendering", () => {
     expect(popover.style.top).toBe("452px");
   });
 
+  it("exposes dialog semantics and keeps keyboard focus inside the confirmation", () => {
+    const fixture = renderDeleteConfirmFixture();
+
+    openDeleteConfirm(fixture.deleteButton);
+
+    const popover = expectElement(fixture.container, ".chat-delete-confirm", HTMLElement);
+    const check = expectElement(popover, ".chat-delete-confirm__check", HTMLInputElement);
+    const cancel = expectElement(popover, ".chat-delete-confirm__cancel", HTMLButtonElement);
+    const confirm = expectElement(popover, ".chat-delete-confirm__yes", HTMLButtonElement);
+    expect(popover.getAttribute("role")).toBe("dialog");
+    expect(popover.getAttribute("aria-modal")).toBe("true");
+    expect(popover.getAttribute("aria-label")).toBe(
+      popover.querySelector(".chat-delete-confirm__text")?.textContent,
+    );
+    expect(document.activeElement).toBe(cancel);
+
+    confirm.focus();
+    const tabForward = new KeyboardEvent("keydown", {
+      key: "Tab",
+      bubbles: true,
+      cancelable: true,
+    });
+    confirm.dispatchEvent(tabForward);
+    expect(tabForward.defaultPrevented).toBe(true);
+    expect(document.activeElement).toBe(check);
+
+    const tabBackward = new KeyboardEvent("keydown", {
+      key: "Tab",
+      bubbles: true,
+      cancelable: true,
+      shiftKey: true,
+    });
+    check.dispatchEvent(tabBackward);
+    expect(tabBackward.defaultPrevented).toBe(true);
+    expect(document.activeElement).toBe(confirm);
+  });
+
+  it("dismisses the confirmation with Escape before underlying keyboard handlers run", () => {
+    const fixture = setupArmedDeleteConfirm();
+    const cancel = expectElement(
+      fixture.container,
+      ".chat-delete-confirm__cancel",
+      HTMLButtonElement,
+    );
+    const leakedKeydown = vi.fn();
+    document.addEventListener("keydown", leakedKeydown);
+
+    try {
+      const event = new KeyboardEvent("keydown", {
+        key: "Escape",
+        bubbles: true,
+        cancelable: true,
+      });
+      cancel.dispatchEvent(event);
+
+      expect(event.defaultPrevented).toBe(true);
+      expect(leakedKeydown).not.toHaveBeenCalled();
+      expectDeleteConfirmDismissed(fixture);
+      expect(fixture.onDelete).not.toHaveBeenCalled();
+      expect(document.activeElement).toBe(fixture.deleteButton);
+    } finally {
+      document.removeEventListener("keydown", leakedKeydown);
+    }
+  });
+
+  it("dismisses only confirmations contained by the requested owner", () => {
+    const fixture = setupArmedDeleteConfirm();
+    const sibling = renderDeleteConfirmFixture();
+    openDeleteConfirm(sibling.deleteButton);
+
+    dismissConfirmedActionPopovers(fixture.container);
+
+    expectDeleteConfirmDismissed(fixture);
+    expect(sibling.container.querySelector(".chat-delete-confirm")).not.toBeNull();
+    dismissConfirmedActionPopovers(sibling.container);
+  });
+
+  it("does not attach an outside-click listener after owner cleanup before the next frame", () => {
+    const flushAnimationFrames = stubAnimationFrameQueue();
+    const addListenerSpy = vi.spyOn(document, "addEventListener");
+    const removeListenerSpy = vi.spyOn(document, "removeEventListener");
+    const addKeyListenerSpy = vi.spyOn(window, "addEventListener");
+    const removeKeyListenerSpy = vi.spyOn(window, "removeEventListener");
+    const fixture = renderDeleteConfirmFixture();
+
+    openDeleteConfirm(fixture.deleteButton);
+    const contextMenuListener = getLastCaptureContextMenuListener(addListenerSpy.mock.calls);
+    const escapeListener = getLastCaptureKeydownListener(addKeyListenerSpy.mock.calls);
+    expect(typeof contextMenuListener).toBe("function");
+    expect(typeof escapeListener).toBe("function");
+    dismissConfirmedActionPopovers(fixture.container);
+    flushAnimationFrames();
+
+    expect(fixture.container.querySelector(".chat-delete-confirm")).toBeNull();
+    expect(getLastCaptureClickListener(addListenerSpy.mock.calls)).toBeNull();
+    expect(
+      countCaptureContextMenuListenerRemovals(removeListenerSpy.mock.calls, contextMenuListener),
+    ).toBe(1);
+    expect(
+      countCaptureKeydownListenerRemovals(removeKeyListenerSpy.mock.calls, escapeListener),
+    ).toBe(1);
+  });
+
   it("removes the delete confirm outside-click listener when Cancel dismisses it", () => {
     const fixture = setupArmedDeleteConfirm();
     const cancel = fixture.container.querySelector<HTMLButtonElement>(
@@ -1024,6 +1198,7 @@ describe("grouped chat rendering", () => {
 
     expectDeleteConfirmDismissed(fixture);
     expect(fixture.onDelete).not.toHaveBeenCalled();
+    expect(document.activeElement).toBe(fixture.deleteButton);
   });
 
   it("removes the delete confirm outside-click listener when Delete dismisses it", () => {
@@ -1031,19 +1206,29 @@ describe("grouped chat rendering", () => {
     const confirm = fixture.container.querySelector<HTMLButtonElement>(".chat-delete-confirm__yes");
 
     expect(confirm).toBeInstanceOf(HTMLButtonElement);
+    confirm!.focus();
     confirm!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
 
     expectDeleteConfirmDismissed(fixture);
     expect(fixture.onDelete).toHaveBeenCalledTimes(1);
+    expect(document.activeElement).not.toBe(fixture.deleteButton);
   });
 
   it("removes the delete confirm outside-click listener when an outside click dismisses it", () => {
     const fixture = setupArmedDeleteConfirm();
+    const outsideButton = document.createElement("button");
+    document.body.appendChild(outsideButton);
 
-    document.body.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    try {
+      outsideButton.focus();
+      outsideButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
 
-    expectDeleteConfirmDismissed(fixture);
-    expect(fixture.onDelete).not.toHaveBeenCalled();
+      expectDeleteConfirmDismissed(fixture);
+      expect(fixture.onDelete).not.toHaveBeenCalled();
+      expect(document.activeElement).toBe(outsideButton);
+    } finally {
+      outsideButton.remove();
+    }
   });
 
   it("removes the delete confirm outside-click listener when the delete button toggles it", () => {

--- a/ui/src/pages/chat/components/chat-message.ts
+++ b/ui/src/pages/chat/components/chat-message.ts
@@ -1238,8 +1238,10 @@ const DELETE_CONFIRM_VIEWPORT_MARGIN_PX = 8;
 const DELETE_CONFIRM_TRIGGER_GAP_PX = 6;
 
 type DeleteConfirmSide = "left" | "right";
+type DeleteConfirmDismissOptions = { restoreFocus?: boolean };
+type DeleteConfirmDismisser = (options?: DeleteConfirmDismissOptions) => void;
 
-const deleteConfirmDismissers = new WeakMap<Element, () => void>();
+const deleteConfirmDismissers = new WeakMap<Element, DeleteConfirmDismisser>();
 
 function shouldSkipActionConfirm(preferenceName: string): boolean {
   try {
@@ -1249,13 +1251,19 @@ function shouldSkipActionConfirm(preferenceName: string): boolean {
   }
 }
 
-function dismissDeleteConfirm(element: Element) {
+function dismissDeleteConfirm(element: Element, options?: DeleteConfirmDismissOptions) {
   const dismiss = deleteConfirmDismissers.get(element);
   if (dismiss) {
-    dismiss();
+    dismiss(options);
     return;
   }
   element.remove();
+}
+
+export function dismissConfirmedActionPopovers(owner: ParentNode): void {
+  owner.querySelectorAll(".chat-delete-confirm").forEach((popover) => {
+    dismissDeleteConfirm(popover);
+  });
 }
 
 function resolveViewportBounds() {
@@ -1398,11 +1406,14 @@ function openConfirmedActionPopover(
   }
   const existing = wrap.querySelector(".chat-delete-confirm");
   if (existing) {
-    dismissDeleteConfirm(existing);
+    dismissDeleteConfirm(existing, { restoreFocus: true });
     return;
   }
   const popover = document.createElement("div");
   popover.className = `chat-delete-confirm chat-delete-confirm--${params.side}`;
+  popover.setAttribute("role", "dialog");
+  popover.setAttribute("aria-modal", "true");
+  popover.setAttribute("aria-label", params.confirmText);
   popover.innerHTML = `
     <p class="chat-delete-confirm__text"></p>
     <label class="chat-delete-confirm__remember">
@@ -1425,18 +1436,23 @@ function openConfirmedActionPopover(
   wrap.appendChild(popover);
   placeDeleteConfirmPopover(btn, popover, params.side);
 
-  const cancel = popover.querySelector(".chat-delete-confirm__cancel")!;
-  const yes = popover.querySelector(".chat-delete-confirm__yes")!;
-  const check = popover.querySelector(".chat-delete-confirm__check") as HTMLInputElement;
+  const cancel = popover.querySelector<HTMLButtonElement>(".chat-delete-confirm__cancel")!;
+  const yes = popover.querySelector<HTMLButtonElement>(".chat-delete-confirm__yes")!;
+  const check = popover.querySelector<HTMLInputElement>(".chat-delete-confirm__check")!;
   let dismissed = false;
-  function dismissPopover() {
+  function dismissPopover(options?: DeleteConfirmDismissOptions) {
     if (dismissed) {
       return;
     }
     dismissed = true;
     document.removeEventListener("click", closeOnOutside, true);
+    document.removeEventListener("contextmenu", closeOnContextMenu, true);
+    window.removeEventListener("keydown", closeOnEscape, true);
     deleteConfirmDismissers.delete(popover);
     popover.remove();
+    if (options?.restoreFocus && btn.isConnected) {
+      btn.focus({ preventScroll: true });
+    }
   }
   function closeOnOutside(evt: MouseEvent) {
     const target = evt.target;
@@ -1444,8 +1460,36 @@ function openConfirmedActionPopover(
       dismissPopover();
     }
   }
+  function closeOnContextMenu(evt: MouseEvent) {
+    const target = evt.target;
+    if (target instanceof Node && !popover.contains(target)) {
+      dismissPopover();
+    }
+  }
+  function closeOnEscape(evt: KeyboardEvent) {
+    if (evt.key !== "Escape" || !popover.contains(document.activeElement)) {
+      return;
+    }
+    evt.preventDefault();
+    evt.stopImmediatePropagation();
+    dismissPopover({ restoreFocus: true });
+  }
+  function containKeyboardFocus(evt: KeyboardEvent) {
+    if (evt.key !== "Tab") {
+      return;
+    }
+    const first = check;
+    const last = yes;
+    if (evt.shiftKey && document.activeElement === first) {
+      evt.preventDefault();
+      last.focus();
+    } else if (!evt.shiftKey && document.activeElement === last) {
+      evt.preventDefault();
+      first.focus();
+    }
+  }
   deleteConfirmDismissers.set(popover, dismissPopover);
-  cancel.addEventListener("click", dismissPopover);
+  cancel.addEventListener("click", () => dismissPopover({ restoreFocus: true }));
   yes.addEventListener("click", () => {
     if (check.checked) {
       try {
@@ -1455,6 +1499,10 @@ function openConfirmedActionPopover(
     dismissPopover();
     params.action();
   });
+  popover.addEventListener("keydown", containKeyboardFocus);
+  document.addEventListener("contextmenu", closeOnContextMenu, true);
+  window.addEventListener("keydown", closeOnEscape, true);
+  cancel.focus({ preventScroll: true });
   requestAnimationFrame(() => {
     if (!dismissed && popover.isConnected) {
       placeDeleteConfirmPopover(btn, popover, params.side);

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -67,6 +67,7 @@ import { renderBackgroundTasksStatusRow } from "./chat-background-tasks-status.t
 import type { BackgroundTasksProps } from "./chat-background-tasks.ts";
 import { renderChatDivider } from "./chat-divider.ts";
 import {
+  dismissConfirmedActionPopovers,
   getAssistantAttachmentAvailabilityRenderVersion,
   openChatHideConfirmation,
   openChatRewindConfirmation,
@@ -547,8 +548,11 @@ function getPinnedMessageSummary(message: unknown): string {
   return extractTextCached(message) ?? "";
 }
 
-export function resetChatThreadPresentationState(paneId?: string) {
+export function resetChatThreadPresentationState(paneId?: string, owner?: ParentNode) {
   removeReplyContextMenu(paneId);
+  if (owner) {
+    dismissConfirmedActionPopovers(owner);
+  }
   // The selection popup is body-portaled; pane teardown/route changes must
   // drop it so it cannot outlive the render that owns its callbacks.
   removeChatSelectionPopup();
@@ -695,10 +699,17 @@ function removeReplyContextMenu(paneId?: string) {
   if (paneId && paneId !== activeReplyContextMenuPaneId) {
     return;
   }
-  activeReplyContextMenu?.remove();
+  if (activeReplyContextMenu) {
+    dismissConfirmedActionPopovers(activeReplyContextMenu);
+    activeReplyContextMenu.remove();
+  }
   activeReplyContextMenu = null;
   activeReplyContextMenuPaneId = null;
-  document.querySelector(".chat-reply-context-menu")?.remove();
+  const fallbackMenu = document.querySelector<HTMLElement>(".chat-reply-context-menu");
+  if (fallbackMenu) {
+    dismissConfirmedActionPopovers(fallbackMenu);
+    fallbackMenu.remove();
+  }
   if (contextMenuDocumentClickHandler) {
     document.removeEventListener("click", contextMenuDocumentClickHandler);
     contextMenuDocumentClickHandler = null;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening the inline Hide or Rewind confirmation in Control UI could not dismiss it with Escape, received weak dialog/focus behavior, and could leave document-level listeners retaining detached message or session state after a pane teardown or in-place session switch.

## Why This Change Was Made

The confirmation now owns one idempotent dismissal path for click, context-menu, keyboard, and owner teardown cleanup. Pane and body-portaled menu owners dismiss confirmations before removing their DOM, while the existing animation-frame guard still prevents the opening click or an immediate trigger toggle from installing a stale outside-click listener.

This change is AI-assisted and was reviewed against the complete lifecycle, focus, split-pane, portal, and session-switch paths.

## User Impact

Hide and Rewind confirmations now behave like accessible dialogs: Cancel receives focus, Tab remains inside the confirmation, Escape closes only the focused confirmation and restores the trigger, and outside interactions do not leave a stale modal or steal focus. Navigating sessions or tearing down a pane also releases all confirmation listeners without affecting another split pane.

There is no intentional visual restyling, so before/after screenshots would not clarify the keyboard and lifecycle fix.

## Evidence

- Blacksmith Testbox focused UI suites: 350 tests passed across `chat-message.test.ts`, `chat-view.test.ts`, `chat-pane.test.ts`, and `chat-pane-lifecycle.test.ts`.
- Blacksmith Testbox `pnpm check:changed` passed for all touched files, including Control UI and core-test typechecks, lint, formatting, i18n verification, and repository guards.
- Testbox proof leases: `tbx_01ky1jg4e7he68nzt6dmhnhqbb` (final focused tests and changed-file gate) and `tbx_01ky1fs8b4efg9bcr1j1wfb8qk` (initial focused regression proof).
- `git diff --check` passed.
- Source-aware review found and verified fixes for context-menu focus escape, same-pane session replacement cleanup, and test global-listener cleanup; the final re-review reported no actionable findings.
