### PR TITLE
fix(macos): reject public plaintext Gateway profiles

### DIFF
--- a/apps/macos/Sources/OpenClaw/GatewayRemoteConfig.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayRemoteConfig.swift
@@ -201,7 +201,10 @@ enum GatewayRemoteConfig {
         if lower == "localhost" || lower.hasSuffix(".local") || lower.hasSuffix(".ts.net") {
             return true
         }
-        if self.isPrivateIPv6Literal(lower) {
+        let ipv6Literal = lower.hasPrefix("[") && lower.hasSuffix("]")
+            ? String(lower.dropFirst().dropLast())
+            : lower
+        if self.isPrivateIPv6Literal(ipv6Literal) {
             return true
         }
         guard let parts = self.ipv4Parts(lower) else { return false }

--- a/apps/macos/Sources/OpenClaw/GatewayRemoteConfig.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayRemoteConfig.swift
@@ -178,10 +178,7 @@ enum GatewayRemoteConfig {
         guard scheme == "ws" || scheme == "wss" else { return nil }
         let host = url.host?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         guard !host.isEmpty else { return nil }
-        if scheme == "ws",
-           !LoopbackHost.isLoopbackHost(host),
-           !self.isTrustedPlaintextRemoteHost(host)
-        {
+        if scheme == "ws", !self.allowsPlaintextGatewayHost(host) {
             return nil
         }
         if scheme == "ws", url.port == nil {
@@ -192,6 +189,10 @@ enum GatewayRemoteConfig {
             return components.url
         }
         return url
+    }
+
+    static func allowsPlaintextGatewayHost(_ host: String) -> Bool {
+        LoopbackHost.isLoopbackHost(host) || self.isTrustedPlaintextRemoteHost(host)
     }
 
     static func isTrustedPlaintextRemoteHost(_ host: String) -> Bool {

--- a/apps/macos/Sources/OpenClaw/MacGatewayProfiles.swift
+++ b/apps/macos/Sources/OpenClaw/MacGatewayProfiles.swift
@@ -8,8 +8,9 @@ struct MacGatewayProfile: Codable, Equatable, Identifiable, Sendable {
     var url: URL
 }
 
-enum MacGatewayProfileError: LocalizedError {
+enum MacGatewayProfileError: LocalizedError, Equatable {
     case invalidURL
+    case insecureRemoteURL
     case profileNotFound
     case unsupportedRegistryVersion(Int)
     case keychain(OSStatus)
@@ -18,6 +19,8 @@ enum MacGatewayProfileError: LocalizedError {
         switch self {
         case .invalidURL:
             "Enter a ws:// or wss:// Gateway URL."
+        case .insecureRemoteURL:
+            "Public Gateway hosts require wss://. Use ws:// only on loopback, a trusted private network, or Tailnet."
         case .profileNotFound:
             "That Gateway profile no longer exists."
         case let .unsupportedRegistryVersion(version):
@@ -96,9 +99,10 @@ actor MacGatewayProfileStore {
         guard let stored = registry.profiles.first(where: { $0.profile.id == profileID }) else {
             throw MacGatewayProfileError.profileNotFound
         }
+        let url = try Self.canonicalURL(stored.profile.url)
         return GatewayConnection.EndpointSnapshot(
             config: (
-                url: stored.profile.url,
+                url: url,
                 token: stored.credentials.token,
                 password: stored.credentials.password),
             routeAuthority: nil,
@@ -139,6 +143,9 @@ actor MacGatewayProfileStore {
               let host = components.host?.lowercased(),
               !host.isEmpty
         else { throw MacGatewayProfileError.invalidURL }
+        if scheme == "ws", !GatewayRemoteConfig.allowsPlaintextGatewayHost(host) {
+            throw MacGatewayProfileError.insecureRemoteURL
+        }
         components.scheme = scheme
         components.host = host
         if components.port == nil {

--- a/apps/macos/Tests/OpenClawIPCTests/MacGatewayProfilesTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacGatewayProfilesTests.swift
@@ -37,6 +37,9 @@ struct MacGatewayProfilesTests {
         "ws://gateway.example:18789",
         "ws://203.0.113.10:18789",
         "ws://[2001:db8::10]:18789",
+        "ws://[localhost]:18789",
+        "ws://[gateway.local]:18789",
+        "ws://[192.168.1.20]:18789",
     ])
     func `profile URL rejects public plaintext hosts`(rawURL: String) throws {
         #expect(throws: MacGatewayProfileError.insecureRemoteURL) {

--- a/apps/macos/Tests/OpenClawIPCTests/MacGatewayProfilesTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacGatewayProfilesTests.swift
@@ -37,7 +37,6 @@ struct MacGatewayProfilesTests {
         "ws://gateway.example:18789",
         "ws://203.0.113.10:18789",
         "ws://[2001:db8::10]:18789",
-        "ws://[localhost]:18789",
         "ws://[gateway.local]:18789",
         "ws://[192.168.1.20]:18789",
     ])

--- a/apps/macos/Tests/OpenClawIPCTests/MacGatewayProfilesTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacGatewayProfilesTests.swift
@@ -27,10 +27,48 @@ struct MacGatewayProfilesTests {
     }
 
     @Test func `profile URL rejects dashboard schemes`() {
-        #expect(throws: MacGatewayProfileError.self) {
+        #expect(throws: MacGatewayProfileError.invalidURL) {
             try MacGatewayProfileStore.canonicalURL(
                 #require(URL(string: "https://studio.example")))
         }
+    }
+
+    @Test(arguments: [
+        "ws://gateway.example:18789",
+        "ws://203.0.113.10:18789",
+        "ws://[2001:db8::10]:18789",
+    ])
+    func `profile URL rejects public plaintext hosts`(rawURL: String) throws {
+        #expect(throws: MacGatewayProfileError.insecureRemoteURL) {
+            try MacGatewayProfileStore.canonicalURL(#require(URL(string: rawURL)))
+        }
+    }
+
+    @Test(arguments: [
+        "ws://localhost",
+        "ws://127.0.0.1",
+        "ws://10.0.0.5",
+        "ws://172.16.1.5",
+        "ws://192.168.1.20",
+        "ws://169.254.1.5",
+        "ws://100.64.0.9",
+        "ws://gateway.local",
+        "ws://gateway.tailnet.ts.net",
+        "ws://[fd00::1]",
+        "ws://[fe80::1]",
+    ])
+    func `profile URL accepts trusted plaintext hosts`(rawURL: String) throws {
+        let url = try MacGatewayProfileStore.canonicalURL(#require(URL(string: rawURL)))
+
+        #expect(url.scheme == "ws")
+        #expect(url.port == 18789)
+    }
+
+    @Test func `profile URL accepts public secure hosts`() throws {
+        let url = try MacGatewayProfileStore.canonicalURL(
+            #require(URL(string: "wss://gateway.example")))
+
+        #expect(url.absoluteString == "wss://gateway.example:443/")
     }
 
     @Test func `blank profile form preserves saved credentials`() {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users adding an additional Gateway profile in the macOS app could save a public `ws://` endpoint even though public Gateway hosts require `wss://`. The primary macOS connection path already enforced this rule, so the profile path could persist a route that the packaged app would later fail to connect to under App Transport Security.

## Why This Change Was Made

The profile store now reuses the primary macOS plaintext-host policy both when saving a profile and when resolving a stored profile for connection. This keeps loopback, private LAN, link-local, CGNAT, `.local`, and `.ts.net` routes working over `ws://`, while public hosts require `wss://` and receive an actionable error.

The stored-profile check keeps profiles written by pre-fix development builds from bypassing the connection boundary. This change does not alter ATS, certificate validation, or TLS pinning.

## User Impact

Public plaintext Gateway profiles are rejected before credentials are saved or used. Secure public profiles and existing trusted private-network or Tailnet profiles continue to work unchanged.

## Evidence

- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift build --package-path apps/macos --scratch-path /tmp/openclaw-macos-build --target OpenClaw` — passed.
- `OPENCLAW_TESTBOX=1 node scripts/check-changed.mjs -- apps/macos/Sources/OpenClaw/GatewayRemoteConfig.swift apps/macos/Sources/OpenClaw/MacGatewayProfiles.swift apps/macos/Tests/OpenClawIPCTests/MacGatewayProfilesTests.swift` — passed on Blacksmith Testbox `tbx_01ky1kqfwst2jnn8hbvb1wbtnp`: https://github.com/openclaw/openclaw/actions/runs/29805263438
- Focused Swift package tests were attempted locally, but the package-wide test target fails before test execution on a pre-existing Swift 6.2 region-isolation diagnostic in `GatewayChannelConnectTests.swift`. The production target build above is green; hosted macOS CI is the native test authority.
- `autoreview --mode uncommitted` — clean, no accepted/actionable findings.
- AI-assisted change; implementation and generated tests were reviewed against the full profile, primary macOS, iOS, and Android connection paths.
