### PR TITLE
fix(ui): exit onboarding when setup is skipped

### DIFF
--- a/packages/gateway-protocol/src/schema/openclaw.test.ts
+++ b/packages/gateway-protocol/src/schema/openclaw.test.ts
@@ -5,10 +5,30 @@ import {
   validateSystemAgentSetupVerifyParams,
 } from "../index.js";
 import {
+  SystemAgentChatQuestionSchema,
   SystemAgentChatHistoryResultSchema,
   SystemAgentSetupDetectResultSchema,
   SystemAgentSetupVerifyResultSchema,
 } from "./openclaw.js";
+
+describe("OpenClaw chat question protocol", () => {
+  const question = {
+    id: "onboarding-next-step",
+    header: "Next step",
+    question: "What would you like to do first?",
+    options: [{ label: "Talk to my agent" }, { label: "Connect a channel" }],
+  };
+
+  it("accepts the additive exit skip action and rejects unknown actions", () => {
+    expect(Value.Check(SystemAgentChatQuestionSchema, question)).toBe(true);
+    expect(Value.Check(SystemAgentChatQuestionSchema, { ...question, skipAction: "exit" })).toBe(
+      true,
+    );
+    expect(Value.Check(SystemAgentChatQuestionSchema, { ...question, skipAction: "dismiss" })).toBe(
+      false,
+    );
+  });
+});
 
 describe("OpenClaw chat history protocol", () => {
   it("accepts the default request and bounds explicit limits", () => {

--- a/packages/gateway-protocol/src/schema/openclaw.ts
+++ b/packages/gateway-protocol/src/schema/openclaw.ts
@@ -54,6 +54,8 @@ export const SystemAgentChatQuestionSchema = closedObject({
   ),
   /** Free-text answers are also accepted for this question. */
   isOther: Type.Optional(Type.Boolean()),
+  /** Client-owned action for the visible skip control; omitted means send a reply. */
+  skipAction: Type.Optional(Type.Literal("exit")),
 });
 
 /** One OpenClaw reply; `action` tells clients about conversation handoffs. */

--- a/src/system-agent/onboarding-welcome.test.ts
+++ b/src/system-agent/onboarding-welcome.test.ts
@@ -205,6 +205,7 @@ describe("buildOnboardingWelcome", () => {
 
     expect(propose).toHaveBeenCalledTimes(configured ? 0 : 1);
     expect(question.id).toBe(configured ? "onboarding-next-step" : "onboarding-apply-setup");
+    expect(question.skipAction).toBe(configured ? "exit" : undefined);
     expect(welcome.includes("Say **yes**")).toBe(!configured);
   });
 });

--- a/src/system-agent/onboarding-welcome.ts
+++ b/src/system-agent/onboarding-welcome.ts
@@ -26,6 +26,7 @@ const READY_WELCOME_QUESTION: SystemAgentChatQuestion = {
     { label: "See all channels", reply: "channels" },
   ],
   isOther: true,
+  skipAction: "exit",
 };
 
 const SETUP_WELCOME_QUESTION: SystemAgentChatQuestion = {

--- a/ui/src/e2e/model-setup.e2e.test.ts
+++ b/ui/src/e2e/model-setup.e2e.test.ts
@@ -72,6 +72,17 @@ describeControlUiE2e("Control UI Model Setup mocked Gateway E2E", () => {
           sessionId: "e2e-custodian",
           reply: "## Hi, I'm OpenClaw",
           action: "none",
+          question: {
+            id: "onboarding-next-step",
+            header: "Next step",
+            question: "What would you like to do first?",
+            options: [
+              { label: "Talk to my agent", reply: "talk to agent", recommended: true },
+              { label: "Connect WhatsApp", reply: "connect whatsapp" },
+            ],
+            isOther: true,
+            skipAction: "exit",
+          },
         },
       },
     });
@@ -106,11 +117,15 @@ describeControlUiE2e("Control UI Model Setup mocked Gateway E2E", () => {
         sessionId: expect.stringMatching(/^control-ui-onboarding-/u),
         welcomeVariant: "onboarding",
       });
-      await page.getByRole("button", { name: "Exit setup" }).click();
+      await page.getByRole("button", { name: "Skip for now" }).click();
       await expect.poll(() => new URL(page.url()).pathname).toBe("/chat");
       await expect
         .poll(() => page.locator(".shell").getAttribute("class"))
         .not.toContain("shell--onboarding");
+      const userTurns = (await gateway.getRequests("openclaw.chat")).filter(
+        (request) => request.params.message !== undefined,
+      );
+      expect(userTurns).toHaveLength(0);
     } finally {
       await context.close();
     }

--- a/ui/src/e2e/model-setup.e2e.test.ts
+++ b/ui/src/e2e/model-setup.e2e.test.ts
@@ -122,9 +122,10 @@ describeControlUiE2e("Control UI Model Setup mocked Gateway E2E", () => {
       await expect
         .poll(() => page.locator(".shell").getAttribute("class"))
         .not.toContain("shell--onboarding");
-      const userTurns = (await gateway.getRequests("openclaw.chat")).filter(
-        (request) => request.params.message !== undefined,
-      );
+      const userTurns = (await gateway.getRequests("openclaw.chat")).filter((request) => {
+        const params = request.params;
+        return typeof params === "object" && params !== null && "message" in params;
+      });
       expect(userTurns).toHaveLength(0);
     } finally {
       await context.close();

--- a/ui/src/pages/custodian/custodian-page.test.ts
+++ b/ui/src/pages/custodian/custodian-page.test.ts
@@ -537,6 +537,69 @@ describe("custodian page", () => {
     await waitForFast(() => expect(page.querySelector("openclaw-option-card")).toBeNull());
   });
 
+  it("exits onboarding locally when the question declares an exit skip action", async () => {
+    const request = vi.fn().mockResolvedValue({
+      sessionId: "control-ui-onboarding-00000000-0000-4000-8000-000000000001",
+      reply: "What would you like to do first?",
+      action: "none",
+      question: {
+        id: "onboarding-next-step",
+        header: "Next step",
+        question: "What would you like to do first?",
+        options: [{ label: "Talk to my agent" }, { label: "Connect a channel" }],
+        isOther: true,
+        skipAction: "exit",
+      },
+    });
+    const { context } = createContext(request);
+    const { page } = await mountPage(context);
+    await waitForFast(() => expect(request).toHaveBeenCalledOnce());
+    await page.updateComplete;
+
+    page.querySelector<HTMLButtonElement>(".option-card__skip")!.click();
+
+    expect(context.navigate).toHaveBeenCalledWith("chat");
+    expect(request).toHaveBeenCalledOnce();
+  });
+
+  it("does not render a silent assistant reply", async () => {
+    const request = vi.fn().mockResolvedValue({
+      sessionId: "control-ui-onboarding-00000000-0000-4000-8000-000000000001",
+      reply: " NO_REPLY ",
+      action: "none",
+    });
+    const { context } = createContext(request);
+    const { page } = await mountPage(context);
+    await waitForFast(() => expect(request).toHaveBeenCalledOnce());
+    await page.updateComplete;
+
+    expect(page.querySelector(".chat-group.assistant")).toBeNull();
+    expect(page.textContent).not.toContain("NO_REPLY");
+  });
+
+  it("keeps a structured question attached to a silent assistant reply", async () => {
+    const request = vi.fn().mockResolvedValue({
+      sessionId: "control-ui-onboarding-00000000-0000-4000-8000-000000000001",
+      reply: "NO_REPLY",
+      action: "none",
+      question: {
+        id: "channel",
+        header: "Channel",
+        question: "Which channel?",
+        options: [{ label: "WhatsApp" }, { label: "Telegram" }],
+      },
+    });
+    const { context } = createContext(request);
+    const { page } = await mountPage(context);
+    await waitForFast(() => expect(request).toHaveBeenCalledOnce());
+    await page.updateComplete;
+
+    expect(page.querySelector(".chat-group.assistant")).toBeNull();
+    expect(page.querySelector("openclaw-option-card")).not.toBeNull();
+    expect(page.textContent).toContain("Which channel?");
+    expect(page.textContent).not.toContain("NO_REPLY");
+  });
+
   it("retires a structured question after a freeform reply", async () => {
     const question = {
       id: "access",

--- a/ui/src/pages/custodian/custodian-page.ts
+++ b/ui/src/pages/custodian/custodian-page.ts
@@ -21,9 +21,7 @@ import "../../styles/chat/layout.css";
 import "../../styles/chat/text.css";
 import "../../styles/custodian.css";
 import { renderChatAvatar } from "../chat/chat-avatar.ts";
-import { renderMessageGroup } from "../chat/components/chat-message.ts";
 import { renderCustodianChangeHistory } from "./custodian-history.ts";
-import { renderCustodianQuestionCard } from "./custodian-question-card.ts";
 import * as eventNudgeState from "./event-nudge.ts";
 import {
   isCustodianSessionInvalidatedError,
@@ -38,9 +36,8 @@ import {
   custodianErrorMessage,
   hasUnresolvedCustodianQuestion,
   readCustodianTranscript,
-  renderCustodianEarlierDivider,
+  renderCustodianTranscriptEntry,
   retireCustodianQuestions,
-  toCustodianMessageGroup,
   type CustodianMessage,
 } from "./transcript.ts";
 
@@ -663,28 +660,15 @@ export class CustodianPage extends OpenClawLightDomElement {
             const questionKey = message.question ? `${message.id}:${message.question.id}` : "";
             const showQuestion =
               message.question !== null && !this.dismissedQuestions.has(questionKey);
-            return html`
-              ${message.text
-                ? renderMessageGroup(toCustodianMessageGroup(message), {
-                    showReasoning: false,
-                    showToolCalls: false,
-                    assistantName: t("custodian.title"),
-                    assistantAvatar: "OC",
-                  })
-                : nothing}
-              ${renderCustodianEarlierDivider(message, this.earlierBoundaryAfterId)}
-              ${showQuestion
-                ? renderCustodianQuestionCard({
-                    question: message.question!,
-                    disabled:
-                      this.sending ||
-                      !this.chatAvailable ||
-                      this.answeredQuestions.has(questionKey),
-                    onSelect: (label) => this.answerQuestion(message, label),
-                    onSkip: () => void this.dismissQuestion(message),
-                  })
-                : nothing}
-            `;
+            return renderCustodianTranscriptEntry({
+              message,
+              boundaryAfterId: this.earlierBoundaryAfterId,
+              showQuestion,
+              questionDisabled:
+                this.sending || !this.chatAvailable || this.answeredQuestions.has(questionKey),
+              onSelect: (label) => this.answerQuestion(message, label),
+              onSkip: () => void this.dismissQuestion(message),
+            });
           })}
           ${this.sending
             ? html`<div class="chat-group assistant custodian__thinking-row" role="status">

--- a/ui/src/pages/custodian/custodian-page.ts
+++ b/ui/src/pages/custodian/custodian-page.ts
@@ -46,6 +46,7 @@ import {
 
 const SYSTEM_AGENT_CHAT_TIMEOUT_MS = 190_000;
 const SYSTEM_CHANGE_PAGE_SIZE = 50;
+const SILENT_REPLY_PATTERN = /^\s*NO_REPLY\s*$/;
 
 export class CustodianPage extends OpenClawLightDomElement {
   @consume({ context: applicationContext, subscribe: true })
@@ -429,7 +430,12 @@ export class CustodianPage extends OpenClawLightDomElement {
       this.sensitive = result.sensitive === true;
       this.wizardInputPending = result.wizardInputPending === true;
       this.retryParams = null;
-      this.appendAssistant(result.reply, parseCustodianQuestion(result.question));
+      const question = parseCustodianQuestion(result.question);
+      // Match regular chat: NO_REPLY is a delivery sentinel, not transcript content.
+      const silentReply = SILENT_REPLY_PATTERN.test(result.reply);
+      if (!silentReply || question) {
+        this.appendAssistant(silentReply ? "" : result.reply, question);
+      }
       if (result.action === "open-agent") {
         let sessionKey = this.context.gateway.snapshot.sessionKey?.trim();
         if (result.agentId) {
@@ -546,6 +552,10 @@ export class CustodianPage extends OpenClawLightDomElement {
     if (!question) {
       return;
     }
+    if (question.skipAction === "exit") {
+      this.exitSetup();
+      return;
+    }
     // Closed wizard selects accept cancel; open "other" prompts use their visible free-form reply.
     const outcome = await this.send(
       question.isOther ? t("optionCard.skip") : "cancel",
@@ -654,12 +664,14 @@ export class CustodianPage extends OpenClawLightDomElement {
             const showQuestion =
               message.question !== null && !this.dismissedQuestions.has(questionKey);
             return html`
-              ${renderMessageGroup(toCustodianMessageGroup(message), {
-                showReasoning: false,
-                showToolCalls: false,
-                assistantName: t("custodian.title"),
-                assistantAvatar: "OC",
-              })}
+              ${message.text
+                ? renderMessageGroup(toCustodianMessageGroup(message), {
+                    showReasoning: false,
+                    showToolCalls: false,
+                    assistantName: t("custodian.title"),
+                    assistantAvatar: "OC",
+                  })
+                : nothing}
               ${renderCustodianEarlierDivider(message, this.earlierBoundaryAfterId)}
               ${showQuestion
                 ? renderCustodianQuestionCard({

--- a/ui/src/pages/custodian/structured-question.test.ts
+++ b/ui/src/pages/custodian/structured-question.test.ts
@@ -14,6 +14,7 @@ describe("custodian typed question", () => {
         { label: "Connect WhatsApp", reply: "connect whatsapp", description: "Chat there." },
       ],
       isOther: true,
+      skipAction: "exit",
     };
     expect(parseCustodianQuestion(question)).toEqual({
       id: "onboarding-next-step",
@@ -24,6 +25,7 @@ describe("custodian typed question", () => {
         { label: "Connect WhatsApp", reply: "connect whatsapp", description: "Chat there." },
       ],
       isOther: true,
+      skipAction: "exit",
     });
   });
 

--- a/ui/src/pages/custodian/structured-question.ts
+++ b/ui/src/pages/custodian/structured-question.ts
@@ -6,6 +6,7 @@ export type CustodianStructuredQuestion = {
   question: string;
   options: Array<{ label: string; description?: string; recommended?: boolean; reply?: string }>;
   isOther: boolean;
+  skipAction?: "exit";
 };
 
 function nonEmptyString(value: unknown): string | null {
@@ -54,5 +55,12 @@ export function parseCustodianQuestion(
   if (options.filter((option) => option.recommended).length > 1) {
     return null;
   }
-  return { id, header, question, options, isOther: value.isOther === true };
+  return {
+    id,
+    header,
+    question,
+    options,
+    isOther: value.isOther === true,
+    ...(value.skipAction === "exit" ? { skipAction: "exit" as const } : {}),
+  };
 }

--- a/ui/src/pages/custodian/transcript.ts
+++ b/ui/src/pages/custodian/transcript.ts
@@ -69,7 +69,7 @@ export function custodianErrorMessage(error: unknown): string {
     : t("custodian.requestFailed");
 }
 
-export function toCustodianMessageGroup(message: CustodianMessage): MessageGroup {
+function toCustodianMessageGroup(message: CustodianMessage): MessageGroup {
   const key = `msg-${message.id}`;
   return {
     kind: "group",
@@ -125,7 +125,7 @@ export function createCustodianTranscriptMessages(
   return { messages, nextMessageId };
 }
 
-export function renderCustodianEarlierDivider(
+function renderCustodianEarlierDivider(
   message: CustodianMessage,
   boundaryAfterId: number | null,
 ) {

--- a/ui/src/pages/custodian/transcript.ts
+++ b/ui/src/pages/custodian/transcript.ts
@@ -125,10 +125,7 @@ export function createCustodianTranscriptMessages(
   return { messages, nextMessageId };
 }
 
-function renderCustodianEarlierDivider(
-  message: CustodianMessage,
-  boundaryAfterId: number | null,
-) {
+function renderCustodianEarlierDivider(message: CustodianMessage, boundaryAfterId: number | null) {
   return message.id === boundaryAfterId
     ? renderChatDivider({
         kind: "divider",

--- a/ui/src/pages/custodian/transcript.ts
+++ b/ui/src/pages/custodian/transcript.ts
@@ -2,11 +2,13 @@ import type {
   SystemAgentChatHistoryResult,
   SystemAgentChatHistoryTurn,
 } from "@openclaw/gateway-protocol";
-import { nothing } from "lit";
+import { html, nothing } from "lit";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import { t } from "../../i18n/index.ts";
 import type { MessageGroup } from "../../lib/chat/chat-types.ts";
 import { renderChatDivider } from "../chat/components/chat-divider.ts";
+import { renderMessageGroup } from "../chat/components/chat-message.ts";
+import { renderCustodianQuestionCard } from "./custodian-question-card.ts";
 import type { CustodianStructuredQuestion } from "./structured-question.ts";
 
 const CUSTODIAN_TRANSCRIPT_TIMEOUT_MS = 15_000;
@@ -135,4 +137,34 @@ export function renderCustodianEarlierDivider(
         timestamp: message.at,
       })
     : nothing;
+}
+
+export function renderCustodianTranscriptEntry(params: {
+  message: CustodianMessage;
+  boundaryAfterId: number | null;
+  showQuestion: boolean;
+  questionDisabled: boolean;
+  onSelect: (label: string) => void;
+  onSkip: () => void;
+}) {
+  const question = params.message.question;
+  return html`
+    ${params.message.text
+      ? renderMessageGroup(toCustodianMessageGroup(params.message), {
+          showReasoning: false,
+          showToolCalls: false,
+          assistantName: t("custodian.title"),
+          assistantAvatar: "OC",
+        })
+      : nothing}
+    ${renderCustodianEarlierDivider(params.message, params.boundaryAfterId)}
+    ${params.showQuestion && question
+      ? renderCustodianQuestionCard({
+          question,
+          disabled: params.questionDisabled,
+          onSelect: params.onSelect,
+          onSkip: params.onSkip,
+        })
+      : nothing}
+  `;
 }


### PR DESCRIPTION
<details>
<summary>Allow edits from maintainers</summary>

Maintainers may edit this branch.

</details>

## What Problem This Solves

The first-run Control UI hides normal navigation while onboarding is active. Clicking `Skip for now` on the ready card sent literal text through inference; a valid `NO_REPLY` response left the user on the onboarding shell with no visible response and no sidebar.

## Why This Change Was Made

- Adds an additive typed `skipAction: \"exit\"` contract to structured system-agent questions.
- Marks only the configured onboarding ready card with that action.
- Handles the action locally in the custodian instead of spending a model turn.
- Filters the exact `NO_REPLY` sentinel while preserving any attached structured question.
- Extends the mocked browser flow to prove skipping restores normal chat chrome without a user-message RPC.

AI-assisted implementation; maintainer-directed investigation and scope.

## User Impact

`Skip for now` now exits onboarding immediately and restores the normal Control UI navigation. Users no longer see `NO_REPLY` as a chat response.

## Evidence

- `node scripts/run-vitest.mjs packages/gateway-protocol/src/schema/openclaw.test.ts src/system-agent/onboarding-welcome.test.ts` (14 tests passed across 2 shards)
- `node scripts/run-vitest.mjs ui/src/pages/custodian/structured-question.test.ts ui/src/pages/custodian/custodian-page.test.ts` (27 tests passed)
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/model-setup.e2e.test.ts` (3 tests passed)
- fresh autoreview: clean, no accepted/actionable findings
- `git diff --check` passed
- `node scripts/check-changed.mjs` could not start delegated checks because its dependency preflight aborted with `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY`; no changed-surface check executed.

Screenshots: not applicable; this changes route behavior without changing visual styling.