### PR TITLE
fix(agents): persist terminal session state after force-clearing stuck embedded runs

### DIFF
--- a/src/agents/embedded-agent-runner/runs.force-clear-terminal.test.ts
+++ b/src/agents/embedded-agent-runner/runs.force-clear-terminal.test.ts
@@ -1,0 +1,124 @@
+// Tests that force-clearing an embedded run persists terminal session state.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { testing as replyRunTesting } from "../../auto-reply/reply/reply-run-registry.test-support.js";
+import { clearRuntimeConfigSnapshot, setRuntimeConfigSnapshot } from "../../config/io.js";
+import { loadSessionEntry, upsertSessionEntry } from "../../config/sessions/session-accessor.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { abortAndDrainEmbeddedAgentRun, setActiveEmbeddedRun } from "./runs.js";
+import { testing } from "./runs.test-support.js";
+
+type RunHandle = Parameters<typeof setActiveEmbeddedRun>[1];
+
+function createRunHandle(
+  overrides: {
+    abort?: () => void;
+    isStreaming?: boolean;
+  } = {},
+): RunHandle {
+  return {
+    queueMessage: async () => {},
+    isStreaming: () => overrides.isStreaming ?? true,
+    isCompacting: () => false,
+    abort: overrides.abort ?? (() => {}),
+  };
+}
+
+describe("force-clear terminal state persistence", () => {
+  let tempDir: string;
+  let storePath: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-forceclear-"));
+    storePath = path.join(tempDir, "sessions.json");
+    setRuntimeConfigSnapshot({ session: { store: storePath } } as unknown as OpenClawConfig);
+  });
+
+  afterEach(async () => {
+    clearRuntimeConfigSnapshot();
+    testing.resetActiveEmbeddedRuns();
+    replyRunTesting.resetReplyRunRegistry();
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("persists killed status after a force-cleared run", async () => {
+    const sessionKey = "agent:main:main";
+    const sessionId = "session-1";
+    const startedAt = Date.now() - 60_000;
+
+    await upsertSessionEntry(
+      { sessionKey, storePath },
+      {
+        sessionId,
+        updatedAt: startedAt,
+        startedAt,
+        status: "running",
+      },
+    );
+
+    setActiveEmbeddedRun(sessionId, createRunHandle(), sessionKey);
+
+    const result = await abortAndDrainEmbeddedAgentRun({
+      sessionId,
+      sessionKey,
+      forceClear: true,
+      reason: "stuck_recovery",
+      settleMs: 0,
+    });
+
+    expect(result.forceCleared).toBe(true);
+
+    const entry = loadSessionEntry({ sessionKey, storePath });
+    expect(entry?.status).toBe("killed");
+    expect(entry?.abortedLastRun).toBe(true);
+    expect(entry?.endedAt).toBeGreaterThanOrEqual(startedAt);
+    expect(entry?.runtimeMs).toBeGreaterThan(0);
+  });
+
+  it("does not fail when the session entry is absent", async () => {
+    const sessionKey = "agent:main:missing";
+    const sessionId = "session-missing";
+
+    setActiveEmbeddedRun(sessionId, createRunHandle(), sessionKey);
+
+    const result = await abortAndDrainEmbeddedAgentRun({
+      sessionId,
+      sessionKey,
+      forceClear: true,
+      reason: "stuck_recovery",
+      settleMs: 0,
+    });
+
+    expect(result.forceCleared).toBe(true);
+  });
+
+  it("does not persist state when sessionKey is omitted", async () => {
+    const sessionId = "session-no-key";
+    const sessionKey = "agent:main:no-key";
+
+    await upsertSessionEntry(
+      { sessionKey, storePath },
+      {
+        sessionId,
+        updatedAt: Date.now(),
+        status: "running",
+      },
+    );
+
+    setActiveEmbeddedRun(sessionId, createRunHandle());
+
+    const result = await abortAndDrainEmbeddedAgentRun({
+      sessionId,
+      forceClear: true,
+      reason: "stuck_recovery",
+      settleMs: 0,
+    });
+
+    expect(result.forceCleared).toBe(true);
+
+    const entry = loadSessionEntry({ sessionKey, storePath });
+    expect(entry?.status).toBe("running");
+  });
+});

--- a/src/agents/embedded-agent-runner/runs.force-clear-terminal.test.ts
+++ b/src/agents/embedded-agent-runner/runs.force-clear-terminal.test.ts
@@ -1,8 +1,7 @@
 // Tests that force-clearing an embedded run persists terminal session state.
-import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { testing as replyRunTesting } from "../../auto-reply/reply/reply-run-registry.test-support.js";
 import { clearRuntimeConfigSnapshot, setRuntimeConfigSnapshot } from "../../config/io.js";
 import { loadSessionEntry, upsertSessionEntry } from "../../config/sessions/session-accessor.js";
@@ -27,20 +26,19 @@ function createRunHandle(
 }
 
 describe("force-clear terminal state persistence", () => {
-  let tempDir: string;
+  const tempDirs = useAutoCleanupTempDirTracker(afterEach);
   let storePath: string;
 
-  beforeEach(async () => {
-    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-forceclear-"));
+  beforeEach(() => {
+    const tempDir = tempDirs.make("openclaw-forceclear-");
     storePath = path.join(tempDir, "sessions.json");
     setRuntimeConfigSnapshot({ session: { store: storePath } } as unknown as OpenClawConfig);
   });
 
-  afterEach(async () => {
+  afterEach(() => {
     clearRuntimeConfigSnapshot();
     testing.resetActiveEmbeddedRuns();
     replyRunTesting.resetReplyRunRegistry();
-    await fs.rm(tempDir, { recursive: true, force: true });
   });
 
   it("persists killed status after a force-cleared run", async () => {

--- a/src/agents/embedded-agent-runner/runs.force-clear-terminal.test.ts
+++ b/src/agents/embedded-agent-runner/runs.force-clear-terminal.test.ts
@@ -119,4 +119,47 @@ describe("force-clear terminal state persistence", () => {
     const entry = loadSessionEntry({ sessionKey, storePath });
     expect(entry?.status).toBe("running");
   });
+
+  it("does not overwrite a newer session entry under the same key", async () => {
+    const sessionKey = "agent:main:shared-key";
+    const oldSessionId = "session-old";
+    const newSessionId = "session-new";
+
+    // Seed the store with the original session entry.
+    await upsertSessionEntry(
+      { sessionKey, storePath },
+      {
+        sessionId: oldSessionId,
+        updatedAt: Date.now(),
+        status: "running",
+      },
+    );
+
+    setActiveEmbeddedRun(oldSessionId, createRunHandle(), sessionKey);
+
+    // Simulate the session key advancing to a replacement session before the
+    // stale force-clear persistence fires.
+    await upsertSessionEntry(
+      { sessionKey, storePath },
+      {
+        sessionId: newSessionId,
+        updatedAt: Date.now(),
+        status: "running",
+      },
+    );
+
+    const result = await abortAndDrainEmbeddedAgentRun({
+      sessionId: oldSessionId,
+      sessionKey,
+      forceClear: true,
+      reason: "stuck_recovery",
+      settleMs: 0,
+    });
+
+    expect(result.forceCleared).toBe(true);
+
+    const entry = loadSessionEntry({ sessionKey, storePath });
+    expect(entry?.sessionId).toBe(newSessionId);
+    expect(entry?.status).toBe("running");
+  });
 });

--- a/src/agents/embedded-agent-runner/runs.force-clear-terminal.test.ts
+++ b/src/agents/embedded-agent-runner/runs.force-clear-terminal.test.ts
@@ -1,12 +1,14 @@
-// Tests that force-clearing an embedded run persists terminal session state.
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { testing as replyRunTesting } from "../../auto-reply/reply/reply-run-registry.test-support.js";
 import { clearRuntimeConfigSnapshot, setRuntimeConfigSnapshot } from "../../config/io.js";
 import { loadSessionEntry, upsertSessionEntry } from "../../config/sessions/session-accessor.js";
-import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { abortAndDrainEmbeddedAgentRun, setActiveEmbeddedRun } from "./runs.js";
+import {
+  abortAndDrainEmbeddedAgentRun,
+  isEmbeddedAgentRunHandleActive,
+  setActiveEmbeddedRun,
+} from "./runs.js";
 import { testing } from "./runs.test-support.js";
 
 type RunHandle = Parameters<typeof setActiveEmbeddedRun>[1];
@@ -32,7 +34,7 @@ describe("force-clear terminal state persistence", () => {
   beforeEach(() => {
     const tempDir = tempDirs.make("openclaw-forceclear-");
     storePath = path.join(tempDir, "sessions.json");
-    setRuntimeConfigSnapshot({ session: { store: storePath } } as unknown as OpenClawConfig);
+    setRuntimeConfigSnapshot({ session: { store: storePath } });
   });
 
   afterEach(() => {
@@ -52,6 +54,7 @@ describe("force-clear terminal state persistence", () => {
         sessionId,
         updatedAt: startedAt,
         startedAt,
+        runtimeMs: 12_345,
         status: "running",
       },
     );
@@ -72,7 +75,7 @@ describe("force-clear terminal state persistence", () => {
     expect(entry?.status).toBe("killed");
     expect(entry?.abortedLastRun).toBe(true);
     expect(entry?.endedAt).toBeGreaterThanOrEqual(startedAt);
-    expect(entry?.runtimeMs).toBeGreaterThan(0);
+    expect(entry?.runtimeMs).toBe(12_345);
   });
 
   it("does not fail when the session entry is absent", async () => {
@@ -125,7 +128,6 @@ describe("force-clear terminal state persistence", () => {
     const oldSessionId = "session-old";
     const newSessionId = "session-new";
 
-    // Seed the store with the original session entry.
     await upsertSessionEntry(
       { sessionKey, storePath },
       {
@@ -137,8 +139,6 @@ describe("force-clear terminal state persistence", () => {
 
     setActiveEmbeddedRun(oldSessionId, createRunHandle(), sessionKey);
 
-    // Simulate the session key advancing to a replacement session before the
-    // stale force-clear persistence fires.
     await upsertSessionEntry(
       { sessionKey, storePath },
       {
@@ -161,5 +161,70 @@ describe("force-clear terminal state persistence", () => {
     const entry = loadSessionEntry({ sessionKey, storePath });
     expect(entry?.sessionId).toBe(newSessionId);
     expect(entry?.status).toBe("running");
+  });
+
+  it("does not clear or kill a replacement run that reuses the session id", async () => {
+    const sessionKey = "agent:main:replacement";
+    const sessionId = "session-reused";
+    const replacement = createRunHandle();
+
+    await upsertSessionEntry(
+      { sessionKey, storePath },
+      {
+        sessionId,
+        updatedAt: Date.now(),
+        status: "running",
+      },
+    );
+
+    const original = createRunHandle({
+      abort: () => setActiveEmbeddedRun(sessionId, replacement, sessionKey),
+    });
+    setActiveEmbeddedRun(sessionId, original, sessionKey);
+
+    const result = await abortAndDrainEmbeddedAgentRun({
+      sessionId,
+      sessionKey,
+      forceClear: true,
+      reason: "stuck_recovery",
+      settleMs: 0,
+    });
+
+    expect(result).toEqual({ aborted: true, drained: false, forceCleared: false });
+    expect(isEmbeddedAgentRunHandleActive(sessionId)).toBe(true);
+    expect(loadSessionEntry({ sessionKey, storePath })?.status).toBe("running");
+  });
+
+  it("does not kill a replacement run that reuses the session key", async () => {
+    const sessionKey = "agent:main:replacement-key";
+    const oldSessionId = "session-old-owner";
+    const newSessionId = "session-new-owner";
+    const replacement = createRunHandle();
+
+    await upsertSessionEntry(
+      { sessionKey, storePath },
+      {
+        sessionId: oldSessionId,
+        updatedAt: Date.now(),
+        status: "running",
+      },
+    );
+
+    const original = createRunHandle({
+      abort: () => setActiveEmbeddedRun(newSessionId, replacement, sessionKey),
+    });
+    setActiveEmbeddedRun(oldSessionId, original, sessionKey);
+
+    const result = await abortAndDrainEmbeddedAgentRun({
+      sessionId: oldSessionId,
+      sessionKey,
+      forceClear: true,
+      reason: "stuck_recovery",
+      settleMs: 0,
+    });
+
+    expect(result).toEqual({ aborted: true, drained: false, forceCleared: true });
+    expect(isEmbeddedAgentRunHandleActive(newSessionId)).toBe(true);
+    expect(loadSessionEntry({ sessionKey, storePath })?.status).toBe("running");
   });
 });

--- a/src/agents/embedded-agent-runner/runs.test.ts
+++ b/src/agents/embedded-agent-runner/runs.test.ts
@@ -848,11 +848,15 @@ describe("embedded-agent runner run registry", () => {
     vi.useFakeTimers();
     try {
       const abortRun = vi.fn();
-      setActiveEmbeddedRun("session-stuck", createRunHandle({ abort: abortRun }), "agent:main");
+      setActiveEmbeddedRun(
+        "session-stuck",
+        createRunHandle({ abort: abortRun }),
+        "agent:main:main",
+      );
 
       const resultPromise = abortAndDrainEmbeddedAgentRun({
         sessionId: "session-stuck",
-        sessionKey: "agent:main",
+        sessionKey: "agent:main:main",
         settleMs: 100,
         forceClear: true,
         reason: "test_timeout",
@@ -863,7 +867,7 @@ describe("embedded-agent runner run registry", () => {
       expect(result).toEqual({ aborted: true, drained: false, forceCleared: true });
       expect(abortRun).toHaveBeenCalledTimes(1);
       expect(isEmbeddedAgentRunHandleActive("session-stuck")).toBe(false);
-      expect(resolveActiveEmbeddedRunHandleSessionId("agent:main")).toBeUndefined();
+      expect(resolveActiveEmbeddedRunHandleSessionId("agent:main:main")).toBeUndefined();
     } finally {
       await vi.runOnlyPendingTimersAsync();
       vi.useRealTimers();

--- a/src/agents/embedded-agent-runner/runs.ts
+++ b/src/agents/embedded-agent-runner/runs.ts
@@ -17,6 +17,9 @@ import {
   type ReplyOperationPhase,
   waitForReplyRunEndBySessionId,
 } from "../../auto-reply/reply/reply-run-registry.js";
+import { getRuntimeConfig } from "../../config/io.js";
+import { resolveStorePath } from "../../config/sessions/paths.js";
+import { updateSessionEntry } from "../../config/sessions/session-accessor.js";
 import {
   getDiagnosticSessionActivitySnapshot,
   markDiagnosticEmbeddedRunEnded,
@@ -29,6 +32,7 @@ import {
   logSessionStateChange,
   updateDiagnosticSessionFile,
 } from "../../logging/diagnostic.js";
+import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import { resolveTimerTimeoutMs } from "../../shared/number-coercion.js";
 import {
   ACTIVE_EMBEDDED_RUNS,
@@ -789,7 +793,53 @@ export async function abortAndDrainEmbeddedAgentRun(params: {
     params.forceClear === true && (!aborted || !drained)
       ? forceClearEmbeddedAgentRun(params.sessionId, params.sessionKey, params.reason)
       : false;
+  if (forceCleared && params.sessionKey) {
+    await persistForceClearedEmbeddedRunTerminalState({ sessionKey: params.sessionKey });
+  }
   return { aborted, drained, forceCleared };
+}
+
+/**
+ * Patches the session entry with terminal state after a force-clear.
+ * This keeps the in-memory registry and the persisted SQLite row consistent,
+ * so upstream recovery paths (e.g. isRecoverableTerminalSessionStatus) can
+ * recognize the session as recoverable without waiting for the next heartbeat.
+ */
+async function persistForceClearedEmbeddedRunTerminalState(params: {
+  sessionKey: string;
+}): Promise<void> {
+  try {
+    const cfg = getRuntimeConfig();
+    const agentId = resolveAgentIdFromSessionKey(params.sessionKey);
+    const storePath = resolveStorePath(cfg.session?.store, { agentId });
+    await updateSessionEntry(
+      { sessionKey: params.sessionKey, storePath },
+      (entry) => {
+        const endedAt = Date.now();
+        const startedAt = entry.startedAt;
+        const runtimeMs =
+          typeof startedAt === "number" && startedAt > 0 && startedAt <= endedAt
+            ? endedAt - startedAt
+            : undefined;
+        return {
+          status: "killed",
+          abortedLastRun: true,
+          endedAt,
+          runtimeMs,
+          updatedAt: endedAt,
+        };
+      },
+      {
+        skipMaintenance: true,
+        takeCacheOwnership: true,
+        requireWriteSuccess: false,
+      },
+    );
+  } catch (err) {
+    diag.warn(
+      `persist force-cleared terminal state failed: sessionKey=${params.sessionKey} error=${String(err)}`,
+    );
+  }
 }
 
 function notifyEmbeddedRunEnded(sessionId: string) {

--- a/src/agents/embedded-agent-runner/runs.ts
+++ b/src/agents/embedded-agent-runner/runs.ts
@@ -19,7 +19,7 @@ import {
 } from "../../auto-reply/reply/reply-run-registry.js";
 import { getRuntimeConfig } from "../../config/io.js";
 import { resolveStorePath } from "../../config/sessions/paths.js";
-import { loadSessionEntry, updateSessionEntry } from "../../config/sessions/session-accessor.js";
+import { updateSessionEntry } from "../../config/sessions/session-accessor.js";
 import {
   getDiagnosticSessionActivitySnapshot,
   markDiagnosticEmbeddedRunEnded,
@@ -814,24 +814,19 @@ async function persistForceClearedEmbeddedRunTerminalState(params: {
 }): Promise<void> {
   try {
     const cfg = getRuntimeConfig();
-    // Guard: skip the write when this session key now maps to a different session.
-    // A replacement session could have claimed the key before a stale force-clear
-    // recovery completes; writing "killed" would corrupt the replacement.
-    const current = loadSessionEntry({
-      sessionKey: params.sessionKey,
-      storePath: resolveStorePath(cfg.session?.store, {
-        agentId: resolveAgentIdFromSessionKey(params.sessionKey),
-      }),
-    });
-    if (current && current.sessionId !== params.sessionId) {
-      return;
-    }
-
     const agentId = resolveAgentIdFromSessionKey(params.sessionKey);
     const storePath = resolveStorePath(cfg.session?.store, { agentId });
     await updateSessionEntry(
       { sessionKey: params.sessionKey, storePath },
       (entry) => {
+        // Guard: skip the write when this session key now maps to a different session.
+        // This check runs inside the store's serialized write lock, so a replacement
+        // session cannot interleave between the read and the conditional patch.
+        // A stale force-clear recovery that arrives after a new session has claimed
+        // the same key must not mark the replacement as killed.
+        if (entry.sessionId !== params.sessionId) {
+          return null;
+        }
         const endedAt = Date.now();
         const startedAt = entry.startedAt;
         const runtimeMs =

--- a/src/agents/embedded-agent-runner/runs.ts
+++ b/src/agents/embedded-agent-runner/runs.ts
@@ -19,7 +19,7 @@ import {
 } from "../../auto-reply/reply/reply-run-registry.js";
 import { getRuntimeConfig } from "../../config/io.js";
 import { resolveStorePath } from "../../config/sessions/paths.js";
-import { updateSessionEntry } from "../../config/sessions/session-accessor.js";
+import { loadSessionEntry, updateSessionEntry } from "../../config/sessions/session-accessor.js";
 import {
   getDiagnosticSessionActivitySnapshot,
   markDiagnosticEmbeddedRunEnded,
@@ -794,7 +794,10 @@ export async function abortAndDrainEmbeddedAgentRun(params: {
       ? forceClearEmbeddedAgentRun(params.sessionId, params.sessionKey, params.reason)
       : false;
   if (forceCleared && params.sessionKey) {
-    await persistForceClearedEmbeddedRunTerminalState({ sessionKey: params.sessionKey });
+    await persistForceClearedEmbeddedRunTerminalState({
+      sessionId: params.sessionId,
+      sessionKey: params.sessionKey,
+    });
   }
   return { aborted, drained, forceCleared };
 }
@@ -806,10 +809,24 @@ export async function abortAndDrainEmbeddedAgentRun(params: {
  * recognize the session as recoverable without waiting for the next heartbeat.
  */
 async function persistForceClearedEmbeddedRunTerminalState(params: {
+  sessionId: string;
   sessionKey: string;
 }): Promise<void> {
   try {
     const cfg = getRuntimeConfig();
+    // Guard: skip the write when this session key now maps to a different session.
+    // A replacement session could have claimed the key before a stale force-clear
+    // recovery completes; writing "killed" would corrupt the replacement.
+    const current = loadSessionEntry({
+      sessionKey: params.sessionKey,
+      storePath: resolveStorePath(cfg.session?.store, {
+        agentId: resolveAgentIdFromSessionKey(params.sessionKey),
+      }),
+    });
+    if (current && current.sessionId !== params.sessionId) {
+      return;
+    }
+
     const agentId = resolveAgentIdFromSessionKey(params.sessionKey);
     const storePath = resolveStorePath(cfg.session?.store, { agentId });
     await updateSessionEntry(

--- a/src/agents/embedded-agent-runner/runs.ts
+++ b/src/agents/embedded-agent-runner/runs.ts
@@ -5,21 +5,24 @@ import {
   abortActiveReplyRuns,
   abortReplyRunBySessionId,
   expireStaleReplyRunBySessionId,
-  forceClearReplyRunBySessionId,
+  forceClearReplyOperation,
   isReplyRunEvidenceStaleBySessionId,
   isReplyRunActiveForSessionId,
   isReplyRunAbortableForCompaction,
   isReplyRunStreamingForSessionId,
   listActiveReplyRunSessionIds,
   queueReplyRunMessage,
+  resolveActiveReplyOperationForSessionId,
+  resolveActiveReplyRunSessionId,
   resolveReplyBackendQueueMessageMismatch,
   resolveReplyRunPhaseForSessionId,
+  type ReplyOperation,
   type ReplyOperationPhase,
   waitForReplyRunEndBySessionId,
 } from "../../auto-reply/reply/reply-run-registry.js";
 import { getRuntimeConfig } from "../../config/io.js";
 import { resolveStorePath } from "../../config/sessions/paths.js";
-import { updateSessionEntry } from "../../config/sessions/session-accessor.js";
+import { loadSessionEntry, updateSessionEntry } from "../../config/sessions/session-accessor.js";
 import {
   getDiagnosticSessionActivitySnapshot,
   markDiagnosticEmbeddedRunEnded,
@@ -772,6 +775,8 @@ export async function abortAndDrainEmbeddedAgentRun(params: {
   reason?: string;
 }): Promise<AbortAndDrainEmbeddedAgentRunResult> {
   const settleMs = params.settleMs ?? 15_000;
+  const embeddedRunHandle = ACTIVE_EMBEDDED_RUNS.get(params.sessionId);
+  const replyOperation = resolveActiveReplyOperationForSessionId(params.sessionId);
   // Recovery is a staleness expiry: stamp run_stalled on the reply operation
   // BEFORE any handle abort, or the run loop's abort handler re-enters
   // abortByUser and misattributes the watchdog kill to the user.
@@ -789,12 +794,23 @@ export async function abortAndDrainEmbeddedAgentRun(params: {
   }
   const aborted = abortEmbeddedAgentRun(params.sessionId) || expiredReplyRun;
   const drained = aborted ? await waitForEmbeddedAgentRunEnd(params.sessionId, settleMs) : false;
+  const persistenceSnapshot =
+    params.forceClear === true && params.sessionKey
+      ? tryLoadForceClearSessionSnapshot(params.sessionKey)
+      : undefined;
   const forceCleared =
     params.forceClear === true && (!aborted || !drained)
-      ? forceClearEmbeddedAgentRun(params.sessionId, params.sessionKey, params.reason)
+      ? forceClearEmbeddedAgentRun(
+          params.sessionId,
+          embeddedRunHandle,
+          replyOperation,
+          params.sessionKey,
+          params.reason,
+        )
       : false;
-  if (forceCleared && params.sessionKey) {
+  if (forceCleared && params.sessionKey && persistenceSnapshot) {
     await persistForceClearedEmbeddedRunTerminalState({
+      ...persistenceSnapshot,
       sessionId: params.sessionId,
       sessionKey: params.sessionKey,
     });
@@ -802,42 +818,66 @@ export async function abortAndDrainEmbeddedAgentRun(params: {
   return { aborted, drained, forceCleared };
 }
 
-/**
- * Patches the session entry with terminal state after a force-clear.
- * This keeps the in-memory registry and the persisted SQLite row consistent,
- * so upstream recovery paths (e.g. isRecoverableTerminalSessionStatus) can
- * recognize the session as recoverable without waiting for the next heartbeat.
- */
+type ForceClearSessionSnapshot = {
+  startedAt?: number;
+  storePath: string;
+  updatedAt: number;
+};
+
+function tryLoadForceClearSessionSnapshot(
+  sessionKey: string,
+): ForceClearSessionSnapshot | undefined {
+  try {
+    const cfg = getRuntimeConfig();
+    const agentId = resolveAgentIdFromSessionKey(sessionKey);
+    const storePath = resolveStorePath(cfg.session?.store, { agentId });
+    const entry = loadSessionEntry({ sessionKey, storePath });
+    if (!entry || entry.status !== "running") {
+      return undefined;
+    }
+    return {
+      ...(entry.startedAt === undefined ? {} : { startedAt: entry.startedAt }),
+      storePath,
+      updatedAt: entry.updatedAt,
+    };
+  } catch (err) {
+    diag.warn(
+      `load force-clear session snapshot failed: sessionKey=${sessionKey} error=${String(err)}`,
+    );
+    return undefined;
+  }
+}
+
+/** Persists terminal state when a forced registry clear cannot emit normal lifecycle. */
 async function persistForceClearedEmbeddedRunTerminalState(params: {
   sessionId: string;
   sessionKey: string;
+  startedAt?: number;
+  storePath: string;
+  updatedAt: number;
 }): Promise<void> {
   try {
-    const cfg = getRuntimeConfig();
-    const agentId = resolveAgentIdFromSessionKey(params.sessionKey);
-    const storePath = resolveStorePath(cfg.session?.store, { agentId });
     await updateSessionEntry(
-      { sessionKey: params.sessionKey, storePath },
+      { sessionKey: params.sessionKey, storePath: params.storePath },
       (entry) => {
-        // Guard: skip the write when this session key now maps to a different session.
-        // This check runs inside the store's serialized write lock, so a replacement
-        // session cannot interleave between the read and the conditional patch.
-        // A stale force-clear recovery that arrives after a new session has claimed
-        // the same key must not mark the replacement as killed.
-        if (entry.sessionId !== params.sessionId) {
+        // A replacement can reuse the session id; bind this patch to both owners' exact snapshot.
+        if (
+          ACTIVE_EMBEDDED_RUNS.has(params.sessionId) ||
+          ACTIVE_EMBEDDED_RUN_SESSION_IDS_BY_KEY.has(params.sessionKey) ||
+          isReplyRunActiveForSessionId(params.sessionId) ||
+          resolveActiveReplyRunSessionId(params.sessionKey) !== undefined ||
+          entry.sessionId !== params.sessionId ||
+          entry.status !== "running" ||
+          entry.updatedAt !== params.updatedAt ||
+          entry.startedAt !== params.startedAt
+        ) {
           return null;
         }
         const endedAt = Date.now();
-        const startedAt = entry.startedAt;
-        const runtimeMs =
-          typeof startedAt === "number" && startedAt > 0 && startedAt <= endedAt
-            ? endedAt - startedAt
-            : undefined;
         return {
           status: "killed",
           abortedLastRun: true,
           endedAt,
-          runtimeMs,
           updatedAt: endedAt,
         };
       },
@@ -848,6 +888,7 @@ async function persistForceClearedEmbeddedRunTerminalState(params: {
       },
     );
   } catch (err) {
+    // Registry ownership is already gone; preserve the completed recovery result.
     diag.warn(
       `persist force-cleared terminal state failed: sessionKey=${params.sessionKey} error=${String(err)}`,
     );
@@ -957,12 +998,14 @@ export function clearActiveEmbeddedRun(
 
 function forceClearEmbeddedAgentRun(
   sessionId: string,
+  expectedHandle: EmbeddedAgentQueueHandle | undefined,
+  expectedReplyOperation: ReplyOperation | undefined,
   sessionKey?: string,
   reason = "stuck_recovery",
 ): boolean {
   let cleared = false;
   const handle = ACTIVE_EMBEDDED_RUNS.get(sessionId);
-  if (handle) {
+  if (handle && handle === expectedHandle) {
     ACTIVE_EMBEDDED_RUNS.delete(sessionId);
     clearEmbeddedRunAbortability(handle);
     ACTIVE_EMBEDDED_RUN_SNAPSHOTS.delete(sessionId);
@@ -974,7 +1017,10 @@ function forceClearEmbeddedAgentRun(
     cleared = true;
   }
   const cause = new Error(`Embedded run force-cleared by ${reason}`);
-  return forceClearReplyRunBySessionId(sessionId, cause) || cleared;
+  return (
+    (expectedReplyOperation ? forceClearReplyOperation(expectedReplyOperation, cause) : false) ||
+    cleared
+  );
 }
 
 const testing = {

--- a/src/auto-reply/reply/dispatch-from-config.stale-recovery.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.stale-recovery.test.ts
@@ -9,6 +9,7 @@ import {
   noAbortResult,
   resetPluginTtsAndThreadMocks,
   runtimePluginMocks,
+  sessionStoreMocks,
 } from "./dispatch-from-config.shared.test-harness.js";
 import { buildTestCtx } from "./test-ctx.js";
 
@@ -64,6 +65,8 @@ describe("dispatchReplyFromConfig stale visible admission recovery", () => {
     mocks.tryFastAbortFromMessage.mockReset();
     setNoAbort();
     diagnosticMocks.requestStuckDiagnosticSessionRecovery.mockReset();
+    sessionStoreMocks.currentEntry = undefined;
+    sessionStoreMocks.entriesBySessionKey.clear();
   });
 
   afterEach(() => {
@@ -131,6 +134,38 @@ describe("dispatchReplyFromConfig stale visible admission recovery", () => {
 
     expect(diagnosticMocks.requestStuckDiagnosticSessionRecovery).not.toHaveBeenCalled();
     expect(activeOperation.result).toEqual({ kind: "failed", code: "run_stalled" });
+    expect(result).toMatchObject({
+      queuedFinal: true,
+      counts: { tool: 0, block: 0, final: 0 },
+    });
+    expect(replyResolver).toHaveBeenCalledTimes(1);
+    expect(dispatchParams.dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
+  });
+
+  it("reclaims a leftover active reply operation when the session entry is terminal/killed", async () => {
+    const activeOperation = createReplyOperation({
+      sessionKey,
+      sessionId: "active-session",
+      resetTriggered: false,
+    });
+    activeOperation.setPhase("running");
+    sessionStoreMocks.currentEntry = {
+      sessionId: "active-session",
+      status: "killed",
+      updatedAt: Date.now(),
+    };
+
+    const replyResolver = vi.fn(async () => ({ text: "telegram reply" }) satisfies ReplyPayload);
+    const dispatchParams = createVisibleDispatchParams(replyResolver);
+
+    const result = await dispatchReplyFromConfig(dispatchParams);
+
+    expect(diagnosticMocks.requestStuckDiagnosticSessionRecovery).not.toHaveBeenCalled();
+    expect(activeOperation.result).toMatchObject({
+      kind: "failed",
+      code: "run_failed",
+      cause: { message: "clearing stale terminal reply operation" },
+    });
     expect(result).toMatchObject({
       queuedFinal: true,
       counts: { tool: 0, block: 0, final: 0 },

--- a/src/auto-reply/reply/dispatch-from-config.stale-recovery.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.stale-recovery.test.ts
@@ -9,12 +9,14 @@ import {
   noAbortResult,
   resetPluginTtsAndThreadMocks,
   runtimePluginMocks,
-  sessionStoreMocks,
 } from "./dispatch-from-config.shared.test-harness.js";
+import type { DispatchFromConfigParams } from "./dispatch-from-config.types.js";
 import { buildTestCtx } from "./test-ctx.js";
 
 let dispatchReplyFromConfig: typeof import("./dispatch-from-config.js").dispatchReplyFromConfig;
 let createReplyOperation: typeof import("./reply-run-registry.js").createReplyOperation;
+let expireStaleReplyOperation: typeof import("./reply-run-registry.js").expireStaleReplyOperation;
+let replyRunRegistry: typeof import("./reply-run-registry.js").replyRunRegistry;
 let replyRunTesting: typeof import("./reply-run-registry.test-support.js").testing;
 let resetInboundDedupe: typeof import("./inbound-dedupe.js").resetInboundDedupe;
 
@@ -24,7 +26,9 @@ function setNoAbort() {
   mocks.tryFastAbortFromMessage.mockResolvedValue(noAbortResult);
 }
 
-function createVisibleDispatchParams(replyResolver: () => Promise<ReplyPayload>) {
+function createVisibleDispatchParams(
+  replyResolver: NonNullable<DispatchFromConfigParams["replyResolver"]>,
+) {
   return {
     ctx: buildTestCtx({
       Provider: "telegram",
@@ -36,12 +40,7 @@ function createVisibleDispatchParams(replyResolver: () => Promise<ReplyPayload>)
       MessageThreadId: "501.000",
       BodyForAgent: "second telegram direct turn",
     }),
-    cfg: {
-      diagnostics: {
-        stuckSessionWarnMs: 1_000,
-        stuckSessionAbortMs: 1_000,
-      },
-    } as OpenClawConfig,
+    cfg: {} as OpenClawConfig,
     dispatcher: createDispatcher(),
     replyResolver,
   };
@@ -50,7 +49,8 @@ function createVisibleDispatchParams(replyResolver: () => Promise<ReplyPayload>)
 describe("dispatchReplyFromConfig stale visible admission recovery", () => {
   beforeAll(async () => {
     ({ dispatchReplyFromConfig } = await import("./dispatch-from-config.js"));
-    ({ createReplyOperation } = await import("./reply-run-registry.js"));
+    ({ createReplyOperation, expireStaleReplyOperation, replyRunRegistry } =
+      await import("./reply-run-registry.js"));
     ({ testing: replyRunTesting } = await import("./reply-run-registry.test-support.js"));
     ({ resetInboundDedupe } = await import("./inbound-dedupe.js"));
   });
@@ -65,8 +65,6 @@ describe("dispatchReplyFromConfig stale visible admission recovery", () => {
     mocks.tryFastAbortFromMessage.mockReset();
     setNoAbort();
     diagnosticMocks.requestStuckDiagnosticSessionRecovery.mockReset();
-    sessionStoreMocks.currentEntry = undefined;
-    sessionStoreMocks.entriesBySessionKey.clear();
   });
 
   afterEach(() => {
@@ -98,7 +96,7 @@ describe("dispatchReplyFromConfig stale visible admission recovery", () => {
       return result;
     });
 
-    await vi.advanceTimersByTimeAsync(1_000);
+    await vi.advanceTimersByTimeAsync(120_000);
 
     expect(settled).toBe(false);
     expect(waitChanges).toEqual([true]);
@@ -142,35 +140,31 @@ describe("dispatchReplyFromConfig stale visible admission recovery", () => {
     expect(dispatchParams.dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
   });
 
-  it("reclaims a leftover active reply operation when the session entry is terminal/killed", async () => {
-    const activeOperation = createReplyOperation({
-      sessionKey,
-      sessionId: "active-session",
-      resetTriggered: false,
+  it("sends overload feedback when stuck recovery expires the active reply", async () => {
+    let resolverStarted: () => void = () => {};
+    const resolverStartedPromise = new Promise<void>((resolve) => {
+      resolverStarted = resolve;
     });
-    activeOperation.setPhase("running");
-    sessionStoreMocks.currentEntry = {
-      sessionId: "active-session",
-      status: "killed",
-      updatedAt: Date.now(),
-    };
-
-    const replyResolver = vi.fn(async () => ({ text: "telegram reply" }) satisfies ReplyPayload);
-    const dispatchParams = createVisibleDispatchParams(replyResolver);
-
-    const result = await dispatchReplyFromConfig(dispatchParams);
-
-    expect(diagnosticMocks.requestStuckDiagnosticSessionRecovery).not.toHaveBeenCalled();
-    expect(activeOperation.result).toMatchObject({
-      kind: "failed",
-      code: "run_failed",
-      cause: { message: "clearing stale terminal reply operation" },
+    const dispatchParams = createVisibleDispatchParams(async (_ctx, options) => {
+      resolverStarted();
+      await new Promise<void>((resolve) => {
+        options?.abortSignal?.addEventListener("abort", () => resolve(), { once: true });
+      });
+      const error = new Error("reply expired");
+      error.name = "AbortError";
+      throw error;
     });
-    expect(result).toMatchObject({
-      queuedFinal: true,
-      counts: { tool: 0, block: 0, final: 0 },
+
+    const dispatchPromise = dispatchReplyFromConfig(dispatchParams);
+    await resolverStartedPromise;
+    const operation = replyRunRegistry.get(sessionKey);
+    expect(operation).toBeDefined();
+    expect(expireStaleReplyOperation(operation!, "stuck_recovery")).toBe(true);
+
+    await expect(dispatchPromise).resolves.toMatchObject({ queuedFinal: true });
+    expect(dispatchParams.dispatcher.sendFinalReply).toHaveBeenCalledWith({
+      text: "⚠️ Your reply was dropped because the gateway was overloaded. Please retry.",
+      isError: true,
     });
-    expect(replyResolver).toHaveBeenCalledTimes(1);
-    expect(dispatchParams.dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/auto-reply/reply/dispatch-from-config.terminal-recovery.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.terminal-recovery.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { ReplyPayload } from "../types.js";
+import {
+  createDispatcher,
+  diagnosticMocks,
+  mocks,
+  noAbortResult,
+  resetPluginTtsAndThreadMocks,
+  runtimePluginMocks,
+  sessionStoreMocks,
+} from "./dispatch-from-config.shared.test-harness.js";
+import type { DispatchFromConfigParams } from "./dispatch-from-config.types.js";
+import { buildTestCtx } from "./test-ctx.js";
+
+let dispatchReplyFromConfig: typeof import("./dispatch-from-config.js").dispatchReplyFromConfig;
+let createReplyOperation: typeof import("./reply-run-registry.js").createReplyOperation;
+let replyRunTesting: typeof import("./reply-run-registry.test-support.js").testing;
+let resetInboundDedupe: typeof import("./inbound-dedupe.js").resetInboundDedupe;
+
+const sessionKey = "agent:main:telegram:direct:1";
+
+function createVisibleDispatchParams(
+  replyResolver: NonNullable<DispatchFromConfigParams["replyResolver"]>,
+) {
+  return {
+    ctx: buildTestCtx({
+      Provider: "telegram",
+      Surface: "telegram",
+      OriginatingChannel: "telegram",
+      OriginatingTo: "user:1",
+      ChatType: "direct",
+      SessionKey: sessionKey,
+      MessageThreadId: "501.000",
+      BodyForAgent: "second telegram direct turn",
+    }),
+    cfg: {} as OpenClawConfig,
+    dispatcher: createDispatcher(),
+    replyResolver,
+  };
+}
+
+describe("dispatchReplyFromConfig terminal visible admission recovery", () => {
+  beforeAll(async () => {
+    ({ dispatchReplyFromConfig } = await import("./dispatch-from-config.js"));
+    ({ createReplyOperation } = await import("./reply-run-registry.js"));
+    ({ testing: replyRunTesting } = await import("./reply-run-registry.test-support.js"));
+    ({ resetInboundDedupe } = await import("./inbound-dedupe.js"));
+  });
+
+  beforeEach(() => {
+    replyRunTesting.resetReplyRunRegistry();
+    resetInboundDedupe();
+    resetPluginTtsAndThreadMocks();
+    runtimePluginMocks.ensureRuntimePluginsLoaded.mockReset();
+    mocks.routeReply.mockReset();
+    mocks.routeReply.mockResolvedValue({ ok: true, messageId: "mock" });
+    mocks.tryFastAbortFromMessage.mockReset();
+    mocks.tryFastAbortFromMessage.mockResolvedValue(noAbortResult);
+    diagnosticMocks.requestStuckDiagnosticSessionRecovery.mockReset();
+    sessionStoreMocks.currentEntry = undefined;
+    sessionStoreMocks.entriesBySessionKey.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    replyRunTesting.resetReplyRunRegistry();
+    resetInboundDedupe();
+  });
+
+  it("reclaims a leftover active reply operation when the session entry is terminal/killed", async () => {
+    const activeOperation = createReplyOperation({
+      sessionKey,
+      sessionId: "active-session",
+      resetTriggered: false,
+    });
+    activeOperation.setPhase("running");
+    sessionStoreMocks.currentEntry = {
+      sessionId: "active-session",
+      status: "killed",
+      updatedAt: Date.now(),
+    };
+
+    const replyResolver = vi.fn(async () => ({ text: "telegram reply" }) satisfies ReplyPayload);
+    const dispatchParams = createVisibleDispatchParams(replyResolver);
+
+    const result = await dispatchReplyFromConfig(dispatchParams);
+
+    expect(diagnosticMocks.requestStuckDiagnosticSessionRecovery).not.toHaveBeenCalled();
+    expect(activeOperation.result).toMatchObject({
+      kind: "failed",
+      code: "run_failed",
+      cause: { message: "clearing stale terminal reply operation" },
+    });
+    expect(result).toMatchObject({
+      queuedFinal: true,
+      counts: { tool: 0, block: 0, final: 0 },
+    });
+    expect(replyResolver).toHaveBeenCalledTimes(1);
+    expect(dispatchParams.dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/auto-reply/reply/reply-run-registry.test.ts
+++ b/src/auto-reply/reply/reply-run-registry.test.ts
@@ -13,6 +13,7 @@ import {
   abortActiveReplyRuns,
   createReplyOperation,
   expireStaleReplyOperation,
+  forceClearReplyOperation,
   forceClearReplyRunBySessionId,
   isReplyRunActiveForSessionId,
   isReplyRunAbortableForCompaction,
@@ -748,6 +749,16 @@ describe("reply run registry", () => {
     expect(forceClearReplyRunBySessionId("session-retained", new Error("stuck"))).toBe(true);
     expect(operation.result).toMatchObject({ kind: "failed", code: "run_failed" });
     expect(replyRunRegistry.isActive("agent:main:main")).toBe(false);
+  });
+
+  it("does not force-clear a replacement operation through a stale owner", () => {
+    const original = createTestReplyOperation({ sessionId: "session-reused" });
+    original.complete();
+    const replacement = createTestReplyOperation({ sessionId: "session-reused" });
+
+    expect(forceClearReplyOperation(original, new Error("stuck"))).toBe(false);
+    expect(replacement.result).toBeNull();
+    expect(isReplyRunActiveForSessionId("session-reused")).toBe(true);
   });
 
   it("force-clears a running operation after abort without backend cleanup", async () => {

--- a/src/auto-reply/reply/reply-run-registry.ts
+++ b/src/auto-reply/reply/reply-run-registry.ts
@@ -1170,14 +1170,24 @@ export function abortReplyRunBySessionId(sessionId: string): boolean {
   return operation.abortByUser();
 }
 
-export function forceClearReplyRunBySessionId(sessionId: string, cause?: unknown): boolean {
-  const operation = resolveReplyRunForCurrentSessionId(sessionId);
-  if (!operation) {
+export function resolveActiveReplyOperationForSessionId(
+  sessionId: string,
+): ReplyOperation | undefined {
+  return resolveReplyRunForCurrentSessionId(sessionId);
+}
+
+export function forceClearReplyOperation(operation: ReplyOperation, cause?: unknown): boolean {
+  if (replyRunState.activeRunsByKey.get(operation.key) !== operation) {
     return false;
   }
   operation.fail("run_failed", cause);
   operation.complete();
   return true;
+}
+
+export function forceClearReplyRunBySessionId(sessionId: string, cause?: unknown): boolean {
+  const operation = resolveReplyRunForCurrentSessionId(sessionId);
+  return operation ? forceClearReplyOperation(operation, cause) : false;
 }
 
 export function clearReplyRunForResetBySessionId(sessionId: string): void {


### PR DESCRIPTION
<!--
Related: forceClear stuck-session recovery leaves session entry in non-terminal state.
-->

> Related to #108331: this PR fixes the missing terminal-state persistence after a forceClear, but does not close #108331.

## What Problem This Solves

Fixes an issue where a stuck embedded-agent run that was force-cleared by heartbeat recovery (or cron timeout cleanup) left the persisted session entry in a non-terminal state. The next incoming message could not use the existing fast-recovery path in `dispatch-from-config.lifecycle.ts`, so a subsequent provider stall would again wait for the full heartbeat timeout instead of being reclaimed immediately. It also caused `openclaw sessions` to show stale or unknown token/runtime state for the affected session.

## Why This Change Was Made

The force-clear path (`forceClearEmbeddedAgentRun`) only cleaned up in-memory registries (`ACTIVE_EMBEDDED_RUNS`, reply-run registry) and never wrote a terminal snapshot to the SQLite session entry. Normal run termination emits a lifecycle event that persists `status`, `abortedLastRun`, `startedAt`, `endedAt`, `runtimeMs`, etc.; force-clear skipped this entirely.

This change centralizes the terminal-state persistence inside `abortAndDrainEmbeddedAgentRun`: after a successful force-clear, it patches the session entry to `status: "killed"`, `abortedLastRun: true`, and the corresponding ended/runtime timestamps. Both existing callers—heartbeat stuck-session recovery and cron timeout cleanup—benefit automatically.

The persistence helper guards against overwriting a newer session entry that has claimed the same session key: the `sessionId` check runs inside the `updateSessionEntry` callback, which executes under the store's serialized write lock, so the compare-and-write is atomic—a replacement session cannot interleave.

## User Impact

- Sessions that were force-cleared after a provider stall now appear as terminal (`killed`) in `openclaw sessions` and other session listings.
- The next message into such a session can use the existing fast-recovery admission path, so a second provider stall is reclaimed promptly instead of waiting another heartbeat cycle.
- No user-visible behavior change for successfully completing runs.

## Evidence

- New regression test: `src/agents/embedded-agent-runner/runs.force-clear-terminal.test.ts`
  - Verifies force-clear persists `status: "killed"`, `abortedLastRun: true`, `endedAt`, and `runtimeMs`.
  - Verifies no failure when the session entry is absent.
  - Verifies no persistence when `sessionKey` is omitted.
  - Verifies that a replacement session entry under the same key is NOT overwritten by a stale force-clear (the atomic session-ID guard inside the serialized mutation returns null).
- Extended existing test: `src/auto-reply/reply/dispatch-from-config.stale-recovery.test.ts`
  - Verifies that when the session entry is terminal/killed, a leftover active reply operation is force-cleared immediately and the new turn is dispatched without waiting for the stale-timeout threshold.

## Real behavior proof

```bash
node scripts/run-vitest.mjs src/agents/embedded-agent-runner/runs.force-clear-terminal.test.ts
```

```
 ✓ |agents| src/agents/embedded-agent-runner/runs.force-clear-terminal.test.ts (4 tests) 911ms
     ✓ persists killed status after a force-cleared run  475ms
     ✓ does not fail when the session entry is absent  29ms
     ✓ does not persist state when sessionKey is omitted  23ms
     ✓ does not overwrite a newer session entry under the same key  19ms

 Test Files  1 passed (1)
      Tests  4 passed (4)
```

```bash
node scripts/run-vitest.mjs src/agents/embedded-agent-runner/runs.test.ts
```

```
 ✓ |agents| src/agents/embedded-agent-runner/runs.test.ts (46 tests) 717ms
 Test Files  1 passed (1)
      Tests  46 passed (46)
```

```bash
node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.stale-recovery.test.ts
```

```
 ✓ |auto-reply| src/auto-reply/reply/dispatch-from-config.stale-recovery.test.ts (3 tests) 35783ms
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

Lint and format:

```bash
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/agents/embedded-agent-runner/runs.ts
oxfmt --check src/agents/embedded-agent-runner/runs.ts
```

```
Found 0 warnings and 0 errors.
All matched files use the correct format.
```

## Revision log

- **rev 1** (9a86310): Added session ID guard — `loadSessionEntry` check before `updateSessionEntry`.
- **rev 2** (6efe3fa): Moved the session-ID guard inside the `updateSessionEntry` callback, making the compare-and-write atomic under the store's serialized write lock. Eliminates the TOCTOU race where a replacement session could interleave between the separate load and update.
