### PR TITLE
fix(ui): prevent Logs filters overlapping entries at larger text scales

### DIFF
--- a/ui/src/e2e/logs-layout.e2e.test.ts
+++ b/ui/src/e2e/logs-layout.e2e.test.ts
@@ -1,0 +1,144 @@
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { chromium, type Browser } from "playwright";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  canRunPlaywrightChromium,
+  installMockGateway,
+  resolvePlaywrightChromiumExecutablePath,
+  startControlUiE2eServer,
+  type ControlUiE2eServer,
+} from "../test-helpers/control-ui-e2e.ts";
+
+const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
+const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
+const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
+const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+
+const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+const proofLabel = process.env.OPENCLAW_UI_E2E_PROOF_LABEL?.trim() || "logs-layout";
+const viewport = { height: 584, width: 863 };
+
+let browser: Browser;
+let server: ControlUiE2eServer;
+
+const logLines = Array.from({ length: 40 }, (_value, index) =>
+  JSON.stringify({
+    "0": JSON.stringify({ subsystem: "native-layout-e2e" }),
+    "1": `log line ${index + 1}`,
+    time: new Date(Date.UTC(2026, 6, 21, 12, 0, index)).toISOString(),
+    _meta: { logLevelName: "info" },
+  }),
+);
+
+describeControlUiE2e("Control UI logs native app layout E2E", () => {
+  beforeAll(async () => {
+    if (!chromiumAvailable) {
+      throw new Error(`Playwright Chromium is unavailable at ${chromiumExecutablePath}`);
+    }
+    server = await startControlUiE2eServer();
+    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
+  });
+
+  afterAll(async () => {
+    await browser?.close();
+    await server?.close();
+  });
+
+  it("keeps wrapped filters inside their rows in the macOS dashboard viewport", async () => {
+    if (artifactDir) {
+      await mkdir(path.join(artifactDir, proofLabel, "video"), { recursive: true });
+    }
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport,
+      ...(artifactDir
+        ? { recordVideo: { dir: path.join(artifactDir, proofLabel, "video"), size: viewport } }
+        : {}),
+    });
+    const page = await context.newPage();
+    await page.addInitScript(() => {
+      localStorage.setItem(
+        "openclaw.control.settings.v1:ws://127.0.0.1:18789",
+        JSON.stringify({ textScale: 125, themeMode: "dark" }),
+      );
+      const nativeWindow = window as Window & {
+        __OPENCLAW_NATIVE_WEB_CHROME__?: boolean;
+        __OPENCLAW_NATIVE_HISTORY__?: { canGoBack: boolean; canGoForward: boolean };
+      };
+      nativeWindow["__OPENCLAW_NATIVE_WEB_CHROME__"] = true;
+      nativeWindow["__OPENCLAW_NATIVE_HISTORY__"] = {
+        canGoBack: false,
+        canGoForward: false,
+      };
+      const stamp = () =>
+        document.documentElement.classList.add(
+          "openclaw-native-macos",
+          "openclaw-native-web-chrome",
+        );
+      if (document.documentElement) {
+        stamp();
+      } else {
+        document.addEventListener("DOMContentLoaded", stamp);
+      }
+    });
+    await installMockGateway(page, {
+      methodResponses: {
+        "logs.tail": {
+          cursor: logLines.length,
+          file: "/tmp/openclaw/openclaw-2026-07-21.log",
+          lines: logLines,
+          reset: true,
+        },
+      },
+    });
+
+    try {
+      await page.goto(`${server.baseUrl}settings/general`);
+      await page.locator('.settings-sidebar__item[href="/logs"]').click();
+      await expect.poll(() => new URL(page.url()).pathname).toBe("/logs");
+      await expect.poll(() => page.locator(".log-row").count()).toBe(logLines.length);
+      if (artifactDir) {
+        await page.screenshot({
+          path: path.join(artifactDir, proofLabel, "logs-layout.png"),
+          fullPage: true,
+        });
+      }
+
+      const metrics = await page.locator(".logs-card").evaluate((card) => {
+        const rows = [...card.querySelectorAll<HTMLElement>(":scope > .settings-row")];
+        const stream = card.querySelector<HTMLElement>(":scope > .log-stream");
+        return {
+          cardDisplay: getComputedStyle(card).display,
+          rows: rows.map((row) => {
+            const bounds = row.getBoundingClientRect();
+            return {
+              bottom: bounds.bottom,
+              clientHeight: row.clientHeight,
+              scrollHeight: row.scrollHeight,
+              top: bounds.top,
+            };
+          }),
+          streamFlexGrow: stream ? getComputedStyle(stream).flexGrow : "",
+          streamTop: stream?.getBoundingClientRect().top ?? Number.NaN,
+        };
+      });
+
+      expect(metrics.cardDisplay).toBe("flex");
+      expect(metrics.streamFlexGrow).toBe("1");
+      expect(metrics.rows).toHaveLength(2);
+      const [firstRow, secondRow] = metrics.rows;
+      if (!firstRow || !secondRow) {
+        throw new Error(`Expected two log control rows, received ${metrics.rows.length}.`);
+      }
+      for (const row of metrics.rows) {
+        expect(row.scrollHeight).toBeLessThanOrEqual(row.clientHeight + 1);
+      }
+      expect(firstRow.bottom).toBeLessThanOrEqual(secondRow.top + 1);
+      expect(secondRow.bottom).toBeLessThanOrEqual(metrics.streamTop + 1);
+    } finally {
+      await context.close();
+    }
+  });
+});

--- a/ui/src/pages/logs/logs-page.ts
+++ b/ui/src/pages/logs/logs-page.ts
@@ -1,3 +1,4 @@
+import "../../styles/logs.css";
 import { consume } from "@lit/context";
 import { html, type PropertyValues } from "lit";
 import { state } from "lit/decorators.js";

--- a/ui/src/styles/config-quick.css
+++ b/ui/src/styles/config-quick.css
@@ -2,44 +2,9 @@
  *
  * Quick Settings now renders through the shared settings design language
  * (ui/src/styles/settings.css). This file keeps only genuinely page-specific
- * rules: the logs-page fill layout, the Simple/Advanced view toggle, the
- * advanced-view accordion nav (used by view.ts), and the documented
- * gateway-host stats-grid escape hatch.
+ * rules: the Simple/Advanced view toggle, the advanced-view accordion nav
+ * (used by view.ts), and the documented gateway-host stats-grid escape hatch.
  */
-
-.content:has(openclaw-logs-page) {
-  overflow: hidden;
-}
-
-.content:has(openclaw-logs-page) > openclaw-router-outlet {
-  display: flex;
-  flex-direction: column;
-  margin-top: 0;
-  min-height: 0;
-  height: 100%;
-  width: 100%;
-}
-
-openclaw-logs-page {
-  display: contents;
-}
-
-.content:has(openclaw-logs-page) .content-header {
-  flex: 0 0 auto;
-}
-
-.settings-workspace--fill-height .logs-card {
-  flex: 1 1 auto;
-  min-height: 0;
-  display: flex;
-  flex-direction: column;
-}
-
-.settings-workspace--fill-height .log-stream {
-  flex: 1 1 auto;
-  min-height: 0;
-  max-height: none;
-}
 
 /* ── Config Accordion Nav (Advanced Settings, rendered by view.ts) ── */
 

--- a/ui/src/styles/logs.css
+++ b/ui/src/styles/logs.css
@@ -1,0 +1,37 @@
+.content:has(openclaw-logs-page) {
+  overflow: hidden;
+}
+
+.content:has(openclaw-logs-page) > openclaw-router-outlet {
+  display: flex;
+  flex-direction: column;
+  margin-top: 0;
+  min-height: 0;
+  height: 100%;
+  width: 100%;
+}
+
+openclaw-logs-page {
+  display: contents;
+}
+
+.content:has(openclaw-logs-page) .content-header {
+  flex: 0 0 auto;
+}
+
+.settings-workspace--fill-height .logs-card {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.settings-workspace--fill-height .logs-card > .settings-row {
+  flex: 0 0 auto;
+}
+
+.settings-workspace--fill-height .log-stream {
+  flex: 1 1 auto;
+  min-height: 0;
+  max-height: none;
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening Logs in the macOS app or a narrow Control UI window at a larger text scale could see the file path, severity filters, and log entries overlap after navigating from Settings.

## Why This Change Was Made

The Logs fill-height rules now load with the Logs page instead of arriving as a side effect of the Config page stylesheet. The two control rows keep their content height while the log stream remains the flexible, scrollable region. No macOS shell change is needed because the app embeds the shared Control UI.

## User Impact

Logs remain readable and usable in the macOS dashboard viewport and narrow browser windows, including at 125% text scale. Filters wrap normally without log entries rendering through them.

## Evidence

- **Before:** the new native-layout E2E reproduced the overlap at `863x584` and 125% text scale after navigating `Settings -> Logs`; it failed because a control row had `scrollHeight 69` inside `clientHeight 49`.
- **After:** the same E2E passes and records non-overlapping control rows plus the scrollable log stream.
- **Visual proof:**

  | Before | After |
  | --- | --- |
  | ![Logs controls overlapping before the fix](https://gist.githubusercontent.com/vincentkoc/288bdc8d74027d4322ab08fdc76a0594/raw/before.png) | ![Logs controls separated after the fix](https://gist.githubusercontent.com/vincentkoc/288bdc8d74027d4322ab08fdc76a0594/raw/after.png) |

  [Before recording](https://gist.githubusercontent.com/vincentkoc/288bdc8d74027d4322ab08fdc76a0594/raw/before.webm) · [After recording](https://gist.githubusercontent.com/vincentkoc/288bdc8d74027d4322ab08fdc76a0594/raw/after.webm) · [Proof bundle](https://gist.github.com/vincentkoc/288bdc8d74027d4322ab08fdc76a0594)
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/logs-layout.e2e.test.ts ui/src/e2e/logs-autofollow.e2e.test.ts` - 2 tests passed.
- `node scripts/run-vitest.mjs run ui/src/pages/logs/view.test.ts ui/src/pages/logs/logs-page.test.ts` - 12 tests passed.
- Blacksmith Testbox production build passed, including Control UI asset and performance checks: https://github.com/openclaw/openclaw/actions/runs/29805732387
- Blacksmith Testbox `node scripts/run-tsgo.mjs -b tsconfig.projects.json` - exit 0.
- `oxfmt --check` and `git diff --check` passed.
- Fresh branch autoreview: no accepted/actionable findings.

AI-assisted: yes.
