### PR TITLE
fix(ci): restore Z.AI API Platform validation

### DIFF
--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -748,6 +748,7 @@ jobs:
               add_profile_suite native-live-src-gateway-profiles-opencode-go-smoke "stable"
               add_profile_suite native-live-src-gateway-profiles-openrouter "full"
               add_profile_suite native-live-src-gateway-profiles-xai "full"
+              add_profile_suite native-live-src-gateway-profiles-zai "full"
               add_profile_suite native-live-src-gateway-backends "stable full"
               add_profile_suite native-live-src-infra "stable full"
               add_profile_suite native-live-test "stable full"
@@ -765,7 +766,7 @@ jobs:
               add_profile_suite live-gateway-advisory-docker "full"
               add_profile_suite live-gateway-advisory-docker-deepseek-fireworks "full"
               add_profile_suite live-gateway-advisory-docker-opencode-openrouter "full"
-              add_profile_suite live-gateway-advisory-docker-xai "full"
+              add_profile_suite live-gateway-advisory-docker-xai-zai "full"
               add_profile_suite live-cli-backend-docker "stable full"
               add_profile_suite live-acp-bind-docker "stable full"
               add_profile_suite live-codex-harness-docker "stable full"
@@ -827,17 +828,6 @@ jobs:
           LIVE_SUITE_FILTER: ${{ inputs.live_suite_filter }}
           RELEASE_TEST_PROFILE: ${{ inputs.release_test_profile }}
         run: node scripts/plan-release-workflow-matrix.mjs >> "$GITHUB_OUTPUT"
-
-      - name: Record temporary Z.AI API Platform omission
-        if: inputs.include_live_suites
-        shell: bash
-        run: |
-          {
-            echo
-            echo "### Temporary provider omission"
-            echo
-            echo "Z.AI API Platform validation is temporarily disabled while its CI account is unavailable. Z.AI Coding Plan validation remains enabled."
-          } >> "$GITHUB_STEP_SUMMARY"
 
   validate_release_live_cache:
     needs: validate_selected_ref
@@ -3158,6 +3148,13 @@ jobs:
             profile_env_only: false
             advisory: true
             profiles: full
+          - suite_id: native-live-src-gateway-profiles-zai
+            label: Native live gateway profiles Z.ai
+            command: OPENCLAW_LIVE_GATEWAY_PROVIDERS=zai node .release-harness/scripts/test-live-shard.mjs native-live-src-gateway-profiles
+            timeout_minutes: 30
+            profile_env_only: false
+            advisory: true
+            profiles: full
           - suite_id: native-live-src-gateway-backends
             label: Native live gateway backends
             command: OPENCLAW_LIVE_CODEX_HARNESS=1 OPENCLAW_LIVE_CODEX_HARNESS_AUTH=api-key node .release-harness/scripts/test-live-shard.mjs native-live-src-gateway-backends
@@ -3415,10 +3412,10 @@ jobs:
             profile_env_only: false
             advisory: true
             profiles: full
-          - suite_id: live-gateway-advisory-docker-xai
+          - suite_id: live-gateway-advisory-docker-xai-zai
             suite_group: live-gateway-advisory-docker
-            label: Docker live gateway advisory xAI
-            command: OPENCLAW_LIVE_GATEWAY_PROVIDERS=xai OPENCLAW_LIVE_GATEWAY_MAX_MODELS=2 OPENCLAW_LIVE_GATEWAY_STEP_TIMEOUT_MS=90000 OPENCLAW_LIVE_GATEWAY_MODEL_TIMEOUT_MS=180000 OPENCLAW_LIVE_DOCKER_REPO_ROOT="$GITHUB_WORKSPACE" timeout --foreground --kill-after=30s 35m bash .release-harness/scripts/test-live-gateway-models-docker.sh
+            label: Docker live gateway advisory xAI/Z.ai
+            command: OPENCLAW_LIVE_GATEWAY_PROVIDERS=xai,zai OPENCLAW_LIVE_GATEWAY_MAX_MODELS=2 OPENCLAW_LIVE_GATEWAY_STEP_TIMEOUT_MS=90000 OPENCLAW_LIVE_GATEWAY_MODEL_TIMEOUT_MS=180000 OPENCLAW_LIVE_DOCKER_REPO_ROOT="$GITHUB_WORKSPACE" timeout --foreground --kill-after=30s 35m bash .release-harness/scripts/test-live-gateway-models-docker.sh
             timeout_minutes: 40
             profile_env_only: false
             advisory: true

--- a/scripts/plan-release-workflow-matrix.mjs
+++ b/scripts/plan-release-workflow-matrix.mjs
@@ -130,6 +130,11 @@ const LIVE_MODEL_PROVIDERS = [
     profiles: "full",
   },
   {
+    provider_label: "Z.ai",
+    providers: "zai",
+    profiles: "full",
+  },
+  {
     provider_label: "Fireworks",
     providers: "fireworks",
     profiles: "full",

--- a/scripts/test-live-shard.mjs
+++ b/scripts/test-live-shard.mjs
@@ -44,7 +44,6 @@ const OPTIONAL_LIVE_SHARD_FILE_ENVS = new Map([
 const SKIPPED_ASSERTION_STATUSES = new Set(["disabled", "pending", "skipped", "todo"]);
 const QA_RUNTIME_LIVE_TEST = "extensions/qa-lab/src/matrix-channel-driver.lifecycle.live.test.ts";
 const QA_RUNTIME_ARTIFACT = "dist/extensions/qa-lab/runtime-api.js";
-const ZAI_LIVE_TEST_FILE = "src/agents/zai.live.test.ts";
 
 /** Live-test shards included in release validation. */
 export const RELEASE_LIVE_TEST_SHARDS = Object.freeze([
@@ -260,13 +259,12 @@ export function selectLiveShardFiles(shard, files = collectAllLiveTestFiles()) {
     case "native-live-src-agents":
       return files.filter(
         (file) =>
-          file !== ZAI_LIVE_TEST_FILE &&
-          (file.startsWith("src/agents/") ||
-            file.startsWith("src/llm/") ||
-            file.startsWith("src/skills/")),
+          file.startsWith("src/agents/") ||
+          file.startsWith("src/llm/") ||
+          file.startsWith("src/skills/"),
       );
     case "native-live-src-agents-zai-coding":
-      return files.filter((file) => file === ZAI_LIVE_TEST_FILE);
+      return files.filter((file) => file === "src/agents/zai.live.test.ts");
     case "native-live-src-gateway":
       return files.filter(
         (file) => file.startsWith("src/gateway/") || file.startsWith("src/system-agent/"),

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -1752,7 +1752,7 @@ describe("package artifact reuse", () => {
     expect(workflow).toContain(
       'add_profile_suite live-gateway-advisory-docker-opencode-openrouter "full"',
     );
-    expect(workflow).toContain('add_profile_suite live-gateway-advisory-docker-xai "full"');
+    expect(workflow).toContain('add_profile_suite live-gateway-advisory-docker-xai-zai "full"');
     expect(workflow).toContain('add_profile_suite live-cli-backend-docker "stable full"');
     expect(workflow).toContain('add_profile_suite live-subagent-announce-docker "stable full"');
     expect(workflow).toContain(
@@ -1762,12 +1762,12 @@ describe("package artifact reuse", () => {
     expect(workflow).not.toContain("src/agents/openai-ws-stream.e2e.test.ts");
     expect(workflow).toContain("suite_id: live-gateway-advisory-docker-deepseek-fireworks");
     expect(workflow).toContain("suite_id: live-gateway-advisory-docker-opencode-openrouter");
-    expect(workflow).toContain("suite_id: live-gateway-advisory-docker-xai");
+    expect(workflow).toContain("suite_id: live-gateway-advisory-docker-xai-zai");
     expect(workflow).toContain("suite_id: live-subagent-announce-docker");
     expect(workflow).toContain("suite_group: live-gateway-advisory-docker");
     expect(workflow).toContain("OPENCLAW_LIVE_GATEWAY_PROVIDERS=deepseek,fireworks");
     expect(workflow).toContain("OPENCLAW_LIVE_GATEWAY_PROVIDERS=opencode-go,openrouter");
-    expect(workflow).toContain("OPENCLAW_LIVE_GATEWAY_PROVIDERS=xai");
+    expect(workflow).toContain("OPENCLAW_LIVE_GATEWAY_PROVIDERS=xai,zai");
     expect(workflow).toContain("inputs.live_suite_filter == matrix.suite_group");
     expect(workflow).toContain("OPENCLAW_LIVE_CLI_BACKEND_MODEL=claude-cli/claude-sonnet-4-6");
     expect(workflow).toContain("OPENCLAW_LIVE_CLI_BACKEND_AUTH=api-key");
@@ -1829,8 +1829,8 @@ describe("package artifact reuse", () => {
     expect(workflow).toContain("suite_id: native-live-src-gateway-profiles-opencode-go");
     expect(workflow).toContain("suite_id: native-live-src-gateway-profiles-openrouter");
     expect(workflow).toContain("suite_id: native-live-src-gateway-profiles-xai");
-    expect(workflow).not.toContain("suite_id: native-live-src-gateway-profiles-zai");
-    expect(workflow).toContain("Z.AI API Platform validation is temporarily disabled");
+    expect(workflow).toContain("suite_id: native-live-src-gateway-profiles-zai");
+    expect(workflow).not.toContain("Z.AI API Platform validation is temporarily disabled");
     expect(workflow).not.toContain(
       "OPENCLAW_LIVE_GATEWAY_PROVIDERS=deepseek,opencode-go,openrouter,xai,zai",
     );

--- a/test/scripts/release-workflow-matrix-plan.test.ts
+++ b/test/scripts/release-workflow-matrix-plan.test.ts
@@ -134,6 +134,7 @@ const PROFILE_EXPECTATIONS = [
       "opencode-go",
       "openrouter",
       "xai",
+      "zai",
       "fireworks",
     ],
   },
@@ -249,6 +250,7 @@ describe("scripts/plan-release-workflow-matrix.mjs", () => {
       "opencode-go",
       "openrouter",
       "xai",
+      "zai",
       "fireworks",
     ]);
   });
@@ -315,7 +317,7 @@ describe("scripts/plan-release-workflow-matrix.mjs", () => {
     });
 
     expect(plan.liveModels.count).toBe(0);
-    expect(plan.liveModels.omitted).toHaveLength(9);
+    expect(plan.liveModels.omitted).toHaveLength(10);
     expect(plan.liveModels.omitted[0]?.reason).toBe(
       "Docker live model matrix disabled by input selection",
     );

--- a/test/scripts/test-live-shard.test.ts
+++ b/test/scripts/test-live-shard.test.ts
@@ -48,7 +48,10 @@ describe("scripts/test-live-shard", () => {
 
     expect(allFiles.length).toBeGreaterThan(0);
     expect([...new Set(selectedFiles)].toSorted((a, b) => a.localeCompare(b))).toEqual(allFiles);
-    expect(duplicateFiles).toEqual(["extensions/music-generation-providers.live.test.ts"]);
+    expect(duplicateFiles).toEqual([
+      "src/agents/zai.live.test.ts",
+      "extensions/music-generation-providers.live.test.ts",
+    ]);
     expect(musicProviderFanout).toEqual([
       "native-live-extensions-media-music-google",
       "native-live-extensions-media-music-minimax",
@@ -88,7 +91,7 @@ describe("scripts/test-live-shard", () => {
     expect(selectLiveShardFiles("native-live-src-agents", allFiles)).toContain(
       "src/skills/workshop/experience-review.live.test.ts",
     );
-    expect(selectLiveShardFiles("native-live-src-agents", allFiles)).not.toContain(
+    expect(selectLiveShardFiles("native-live-src-agents", allFiles)).toContain(
       "src/agents/zai.live.test.ts",
     );
     expect(selectLiveShardFiles("native-live-src-agents-zai-coding", allFiles)).toEqual([


### PR DESCRIPTION
Related: #109246
Related: #109272
Related: #110243

## What Problem This Solves

Resolves a problem where full release validation continued to omit Z.AI API Platform coverage after the temporary HTTP 429 account limitation was fixed.

## Why This Change Was Made

Restore Z.AI API Platform to every full-profile path removed by the temporary waiver: the Docker live-model matrix, the native gateway profile, the combined xAI/Z.ai advisory gateway lane, and the broad native-agent shard. Remove the temporary omission summary while retaining the separate Z.AI Coding Plan lane and endpoint proof.

#110243 carried the same waiver onto the frozen `extended-stable/2026.6.33` release branch; this PR restores current `main`, which owns ongoing release validation, without rewriting that historical release branch.

## User Impact

No product runtime behavior changes. Full-profile release validation once again exercises the Z.AI general API Platform alongside the existing dedicated Coding Plan validation.

## Evidence

- Official Z.AI contract: the general API uses `https://api.z.ai/api/paas/v4`, while Coding Plan uses the separate `https://api.z.ai/api/coding/paas/v4` endpoint.
- Blacksmith Testbox `tbx_01ky1n3z622adcp770y6pbzy0k`: 124/124 focused workflow and shard tests passed.
- Blacksmith Testbox changed gate: formatting, test-root typecheck, script lint, and repository guards passed.
- [Exact-head API Platform live run](https://github.com/openclaw/openclaw/actions/runs/29806765366): the restored `glm-5-turbo` and `glm-5.1` probes were selected, but both returned `errorClass=billing` with no assistant text. The current repository credential/account still needs working API Platform balance before merge.
- Fresh branch autoreview: clean, with no accepted/actionable findings.
- `actionlint .github/workflows/openclaw-live-and-e2e-checks-reusable.yml`
- `git diff --check`

AI-assisted by Codex; implementation and evidence reviewed by the author.
