### PR TITLE
fix: localized Chinese rate-limit messages skip same-model retry

### DIFF
--- a/src/llm/utils/rate-limit-window.test.ts
+++ b/src/llm/utils/rate-limit-window.test.ts
@@ -1,0 +1,56 @@
+// Covers rate-limit message classification, including localized provider text.
+import { describe, expect, it } from "vitest";
+import { classifyRateLimitWindow } from "./rate-limit-window.js";
+
+describe("classifyRateLimitWindow", () => {
+  it("classifies localized Chinese usage-cap messages as short-window", () => {
+    // Real-world provider message (Zhipu GLM): localized 429 text that recovers
+    // within seconds, previously classified as "unknown" and skipped same-model retry.
+    expect(
+      classifyRateLimitWindow("您已达到每周使用上限，您的限额将在 2026-07-21 09:22:46 重置"),
+    ).toEqual({ kind: "short" });
+    expect(classifyRateLimitWindow("您已达到每月使用上限，您的限额将在 2026-08-01 00:00:00 重置")).toEqual({
+      kind: "short",
+    });
+    expect(classifyRateLimitWindow("您已达到使用上限")).toEqual({ kind: "short" });
+  });
+
+  it("classifies Chinese quota-reset messages as short-window", () => {
+    expect(classifyRateLimitWindow("超出限额，将在60秒后重置")).toEqual({ kind: "short" });
+  });
+
+  it("keeps existing Chinese rate-limit phrases classified as short-window", () => {
+    expect(classifyRateLimitWindow("请求过于频繁，请稍后再试")).toEqual({ kind: "short" });
+    expect(classifyRateLimitWindow("调用频率超出限制")).toEqual({ kind: "short" });
+    expect(classifyRateLimitWindow("触发频率限制")).toEqual({ kind: "short" });
+  });
+
+  it("classifies English short-window rate limits as short", () => {
+    expect(classifyRateLimitWindow("Too many requests: requests per minute exceeded")).toEqual({
+      kind: "short",
+    });
+    expect(classifyRateLimitWindow("429 Too Many Requests")).toEqual({ kind: "short" });
+  });
+
+  it("honors retry-after values when present", () => {
+    expect(classifyRateLimitWindow("Rate limit exceeded. Retry-After: 5")).toEqual({
+      kind: "short",
+      retryAfterSeconds: 5,
+    });
+    expect(classifyRateLimitWindow("Rate limit exceeded. Retry-After: 120")).toEqual({
+      kind: "long",
+    });
+  });
+
+  it("classifies long-window rate limits as long", () => {
+    expect(classifyRateLimitWindow("You have exceeded your daily usage limit")).toEqual({
+      kind: "long",
+    });
+    expect(classifyRateLimitWindow("insufficient_quota")).toEqual({ kind: "long" });
+  });
+
+  it("returns unknown for non-rate-limit errors", () => {
+    expect(classifyRateLimitWindow("Internal server error")).toEqual({ kind: "unknown" });
+    expect(classifyRateLimitWindow(undefined)).toEqual({ kind: "unknown" });
+  });
+});

--- a/src/llm/utils/rate-limit-window.ts
+++ b/src/llm/utils/rate-limit-window.ts
@@ -12,7 +12,7 @@ const LONG_WINDOW_RATE_LIMIT_RE =
 const SHORT_RATE_LIMIT_UNIT_RE =
   /\b(?:requests per minute|tokens per minute|per-minute|rpm|tpm)\b/i;
 const SHORT_WINDOW_RATE_LIMIT_RE =
-  /\b(?:requests per minute|tokens per minute|per-minute|rpm|tpm|model_cooldown)\b|请求过于频繁|调用频率|频率限制/i;
+  /\b(?:requests per minute|tokens per minute|per-minute|rpm|tpm|model_cooldown)\b|请求过于频繁|调用频率|频率限制|使用上限|限额.*重置/i;
 const RETRY_AFTER_VALUE_RE = /\bretry[- ]after\b\s*:?\s*(?:in\s*)?([^\r\n;]+)/i;
 const RETRY_AFTER_NUMBER_RE = /^(\d+(?:\.\d+)?)\s*([a-z]+)?\b/i;
 const MAX_SHORT_WINDOW_RETRY_AFTER_SECONDS = 60;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where agents would immediately fall back to a different model instead of retrying the same model when the provider returns localized (Chinese) rate-limit messages.

For example, Zhipu GLM returns localized 429 messages such as:

```text
您已达到每周使用上限，您的限额将在 2026-07-21 09:22:46 重置
```

("You have reached your weekly usage cap. Your quota will reset at 2026-07-21 09:22:46.")

These messages match neither the English patterns in `SHORT_WINDOW_RATE_LIMIT_RE` / `LONG_WINDOW_RATE_LIMIT_RE` nor the existing Chinese phrases (请求过于频繁 / 调用频率 / 频率限制), so `classifyRateLimitWindow` returns `{ kind: "unknown" }`. The embedded agent runner then skips the same-model short-window retry and fails over to a fallback model immediately — even though the provider's limit clears within seconds.

## Why This Change Was Made

Extend `SHORT_WINDOW_RATE_LIMIT_RE` with two localized patterns observed in the wild: `使用上限` ("usage cap") and `限额.*重置` ("quota ... reset"), so these messages classify as short-window rate limits and the runner retries the same model within the existing short-window retry budget instead of switching models unnecessarily. Also adds `src/llm/utils/rate-limit-window.test.ts` covering localized messages, the existing Chinese phrases, English short/long-window patterns, retry-after handling, and unknown errors.

## User Impact

Users on providers that emit localized Chinese rate-limit text get same-model retries for transient limits instead of unexpected model fallback. Fallback behavior for genuine long-window or unknown errors is unchanged.

## Evidence

- New focused test suite passes: `vitest run src/llm/utils/rate-limit-window.test.ts` → `Test Files 1 passed (1)`, `Tests 7 passed (7)`
- Production observation: running an OpenClaw gateway against Zhipu GLM, these localized 429 messages previously caused immediate fallback to the configured fallback model. After applying the same regex change to the installed build, the messages classified as short-window, same-model retries recovered within ~2 seconds, and a 20-request burst test succeeded 18/20 with the remainder recovering on the next retry cycle.
