### PR TITLE
fix(mobile): load pinned and base-path Control UI pages

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -790,6 +790,7 @@ class NodeRuntime private constructor(
     val baseUrl: String,
     val token: String?,
     val password: String?,
+    val tlsFingerprintSha256: String?,
   )
 
   private val appContext = context.applicationContext
@@ -4323,6 +4324,10 @@ class NodeRuntime private constructor(
         baseUrl = gatewayControlPageBaseUrl(endpoint),
         token = pageAuth.token,
         password = pageAuth.password,
+        tlsFingerprintSha256 =
+          prefs
+            .loadGatewayTlsFingerprint(endpoint.stableId)
+            ?.let(::normalizeGatewayTlsFingerprintInput),
       )
   }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -782,9 +782,8 @@ class NodeRuntime private constructor(
   )
 
   /**
-   * HTTP(S) page origin of the connected gateway plus the shared credential a
-   * gateway-served page (e.g. the `?view=terminal` Control UI document) can
-   * authenticate with. Derived from the same endpoint/auth the WS sessions use.
+   * HTTP(S) page origin plus shared credentials for gateway-served Control UI pages.
+   * The values come from the same endpoint and auth material that the WS sessions use.
    */
   data class GatewayControlPage(
     val baseUrl: String,
@@ -4324,10 +4323,7 @@ class NodeRuntime private constructor(
         baseUrl = gatewayControlPageBaseUrl(endpoint),
         token = pageAuth.token,
         password = pageAuth.password,
-        tlsFingerprintSha256 =
-          prefs
-            .loadGatewayTlsFingerprint(endpoint.stableId)
-            ?.let(::normalizeGatewayTlsFingerprintInput),
+        tlsFingerprintSha256 = gatewayControlPageTlsFingerprint(prefs, endpoint),
       )
   }
 
@@ -4386,8 +4382,7 @@ class NodeRuntime private constructor(
 
   private fun prepareGatewayTarget(endpoint: GatewayEndpoint) {
     if (connectedEndpoint?.stableId?.let { it != endpoint.stableId } == true) {
-      // Closing both sockets is synchronous; cleanup callbacks may finish later, but no event can
-      // cross the active-pointer change on the old authenticated transport.
+      // Close both sockets before changing routes so stale callbacks cannot cross the handoff.
       disconnect(retireRunState = true)
     }
     if (prefs.gatewayRegistry.entries.value
@@ -8863,3 +8858,11 @@ private data class HomeCanvasAgentCard(
   val caption: String,
   val isActive: Boolean,
 )
+
+private fun gatewayControlPageTlsFingerprint(
+  prefs: SecurePrefs,
+  endpoint: GatewayEndpoint,
+): String? =
+  prefs
+    .loadGatewayTlsFingerprint(endpoint.stableId)
+    ?.let(::normalizeGatewayTlsFingerprintInput)

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/ControlUiWebView.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/ControlUiWebView.kt
@@ -124,6 +124,8 @@ private class ControlUiWebViewClient(
   private val page: NodeRuntime.GatewayControlPage,
 ) : WebViewClient() {
   // Android lint cannot infer the exact pin and origin checks below; every other path cancels.
+  // WebView exposes no pre-document certificate hook for successful CA-trusted handshakes;
+  // this callback extends native pin trust only to recoverable self-signed errors.
   @SuppressLint("WebViewClientOnReceivedSslError")
   override fun onReceivedSslError(
     view: WebView,

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/ControlUiWebView.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/ControlUiWebView.kt
@@ -1,8 +1,12 @@
 package ai.openclaw.app.ui
 
 import ai.openclaw.app.NodeRuntime
+import ai.openclaw.app.gateway.normalizeGatewayTlsFingerprintInput
 import android.annotation.SuppressLint
+import android.net.http.SslCertificate
+import android.net.http.SslError
 import android.view.View
+import android.webkit.SslErrorHandler
 import android.webkit.WebSettings
 import android.webkit.WebView
 import android.webkit.WebViewClient
@@ -18,6 +22,10 @@ import androidx.webkit.WebViewCompat
 import androidx.webkit.WebViewFeature
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
+import java.security.MessageDigest
+import java.util.Locale
+
+private const val X509_CERTIFICATE_BUNDLE_KEY = "x509-certificate"
 
 /** Authenticated, hardened WebView host for gateway-served Control UI pages. */
 @SuppressLint("SetJavaScriptEnabled")
@@ -61,10 +69,7 @@ internal fun ControlUiWebView(
         WebSettingsCompat.setAlgorithmicDarkeningAllowed(webSettings, false)
       }
       webView.overScrollMode = View.OVER_SCROLL_NEVER
-      // System trust only, matching the terminal host this was extracted from:
-      // fingerprint-pinned (self-signed) gateways render natively but not here.
-      // Tracked follow-up: verified SSL handling shared with the native pin.
-      webView.webViewClient = WebViewClient()
+      webView.webViewClient = ControlUiWebViewClient(page)
       installControlUiAuthScript(webView, page)
       webView.loadUrl(url)
       webViewRef[0] = webView
@@ -116,4 +121,73 @@ internal fun controlUiOriginRule(baseUrl: String): String? {
   val hostPart = if (host.contains(":") && !host.startsWith("[")) "[$host]" else host
   val port = if (uri.port != -1) ":${uri.port}" else ""
   return "$scheme://$hostPart$port"
+}
+
+private class ControlUiWebViewClient(
+  private val page: NodeRuntime.GatewayControlPage,
+) : WebViewClient() {
+  // Android lint cannot infer the exact pin and origin checks below; every other path cancels.
+  @SuppressLint("WebViewClientOnReceivedSslError")
+  override fun onReceivedSslError(
+    view: WebView,
+    handler: SslErrorHandler,
+    error: SslError,
+  ) {
+    // SslCertificate exposes the encoded leaf only through its AOSP saveState bundle.
+    val encodedCertificate =
+      SslCertificate
+        .saveState(error.certificate)
+        ?.getByteArray(X509_CERTIFICATE_BUNDLE_KEY)
+    if (
+      shouldProceedForPinnedControlUiSslError(
+        pageBaseUrl = page.baseUrl,
+        expectedFingerprint = page.tlsFingerprintSha256,
+        errorUrl = error.url,
+        encodedCertificate = encodedCertificate,
+      )
+    ) {
+      // The native gateway connection already accepted this exact certificate.
+      // Never extend the exception to another origin or a different certificate.
+      handler.proceed()
+    } else {
+      handler.cancel()
+    }
+  }
+}
+
+internal fun shouldProceedForPinnedControlUiSslError(
+  pageBaseUrl: String,
+  expectedFingerprint: String?,
+  errorUrl: String?,
+  encodedCertificate: ByteArray?,
+): Boolean {
+  val expected = expectedFingerprint?.let(::normalizeGatewayTlsFingerprintInput) ?: return false
+  val certificate = encodedCertificate ?: return false
+  if (!sameHttpsOrigin(pageBaseUrl, errorUrl)) return false
+  return MessageDigest
+    .getInstance("SHA-256")
+    .digest(certificate)
+    .joinToString(separator = "") { byte -> "%02x".format(Locale.US, byte.toInt() and 0xff) } == expected
+}
+
+private fun sameHttpsOrigin(
+  pageBaseUrl: String,
+  errorUrl: String?,
+): Boolean {
+  val pageOrigin = parsedHttpsOrigin(pageBaseUrl) ?: return false
+  val errorOrigin = errorUrl?.let(::parsedHttpsOrigin) ?: return false
+  return pageOrigin == errorOrigin
+}
+
+private data class HttpsOrigin(
+  val host: String,
+  val port: Int,
+)
+
+private fun parsedHttpsOrigin(rawUrl: String): HttpsOrigin? {
+  val uri = rawUrl.toUri()
+  if (!uri.scheme.equals("https", ignoreCase = true)) return null
+  val host = uri.host?.lowercase(Locale.US) ?: return null
+  val port = uri.port.takeIf { it >= 0 } ?: 443
+  return HttpsOrigin(host = host, port = port)
 }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/ControlUiWebView.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/ControlUiWebView.kt
@@ -3,10 +3,7 @@ package ai.openclaw.app.ui
 import ai.openclaw.app.NodeRuntime
 import ai.openclaw.app.gateway.normalizeGatewayTlsFingerprintInput
 import android.annotation.SuppressLint
-import android.net.http.SslCertificate
-import android.net.http.SslError
 import android.view.View
-import android.webkit.SslErrorHandler
 import android.webkit.WebSettings
 import android.webkit.WebView
 import android.webkit.WebViewClient
@@ -22,10 +19,6 @@ import androidx.webkit.WebViewCompat
 import androidx.webkit.WebViewFeature
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
-import java.security.MessageDigest
-import java.util.Locale
-
-private const val X509_CERTIFICATE_BUNDLE_KEY = "x509-certificate"
 
 /** Authenticated, hardened WebView host for gateway-served Control UI pages. */
 @SuppressLint("SetJavaScriptEnabled")
@@ -79,9 +72,8 @@ internal fun ControlUiWebView(
 }
 
 /**
- * Hands gateway credentials to the Control UI through its native startup
- * contract. The script is restricted to the connected gateway origin, so
- * credentials never appear in page URLs or WebView history.
+ * Hands gateway credentials through the origin-restricted native startup contract,
+ * keeping them out of page URLs and WebView history.
  */
 private fun installControlUiAuthScript(
   webView: WebView,
@@ -123,6 +115,8 @@ internal fun controlUiOriginRule(baseUrl: String): String? {
   return "$scheme://$hostPart$port"
 }
 
+private const val X509_CERTIFICATE_BUNDLE_KEY = "x509-certificate"
+
 private class ControlUiWebViewClient(
   private val page: NodeRuntime.GatewayControlPage,
 ) : WebViewClient() {
@@ -130,12 +124,12 @@ private class ControlUiWebViewClient(
   @SuppressLint("WebViewClientOnReceivedSslError")
   override fun onReceivedSslError(
     view: WebView,
-    handler: SslErrorHandler,
-    error: SslError,
+    handler: android.webkit.SslErrorHandler,
+    error: android.net.http.SslError,
   ) {
     // SslCertificate exposes the encoded leaf only through its AOSP saveState bundle.
     val encodedCertificate =
-      SslCertificate
+      android.net.http.SslCertificate
         .saveState(error.certificate)
         ?.getByteArray(X509_CERTIFICATE_BUNDLE_KEY)
     if (
@@ -161,13 +155,18 @@ internal fun shouldProceedForPinnedControlUiSslError(
   errorUrl: String?,
   encodedCertificate: ByteArray?,
 ): Boolean {
-  val expected = expectedFingerprint?.let(::normalizeGatewayTlsFingerprintInput) ?: return false
+  val expected =
+    expectedFingerprint
+      ?.let(::normalizeGatewayTlsFingerprintInput)
+      ?: return false
   val certificate = encodedCertificate ?: return false
   if (!sameHttpsOrigin(pageBaseUrl, errorUrl)) return false
-  return MessageDigest
+  return java.security.MessageDigest
     .getInstance("SHA-256")
     .digest(certificate)
-    .joinToString(separator = "") { byte -> "%02x".format(Locale.US, byte.toInt() and 0xff) } == expected
+    .joinToString(separator = "") { byte ->
+      "%02x".format(java.util.Locale.US, byte.toInt() and 0xff)
+    } == expected
 }
 
 private fun sameHttpsOrigin(
@@ -187,7 +186,7 @@ private data class HttpsOrigin(
 private fun parsedHttpsOrigin(rawUrl: String): HttpsOrigin? {
   val uri = rawUrl.toUri()
   if (!uri.scheme.equals("https", ignoreCase = true)) return null
-  val host = uri.host?.lowercase(Locale.US) ?: return null
+  val host = uri.host?.lowercase(java.util.Locale.US) ?: return null
   val port = uri.port.takeIf { it >= 0 } ?: 443
   return HttpsOrigin(host = host, port = port)
 }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/ControlUiWebView.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/ControlUiWebView.kt
@@ -62,6 +62,9 @@ internal fun ControlUiWebView(
         WebSettingsCompat.setAlgorithmicDarkeningAllowed(webSettings, false)
       }
       webView.overScrollMode = View.OVER_SCROLL_NEVER
+      // The native gateway connection already established this route's trust.
+      // Reuse only that exact accepted fingerprint; every other SSL error cancels.
+      // The same client protects both terminal and dashboard pages.
       webView.webViewClient = ControlUiWebViewClient(page)
       installControlUiAuthScript(webView, page)
       webView.loadUrl(url)

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/TerminalSettingsScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/TerminalSettingsScreen.kt
@@ -56,8 +56,8 @@ internal fun TerminalSettingsScreen(
       Box(modifier = Modifier.fillMaxWidth().weight(1f)) {
         val page = controlPage
         if (isConnected && page != null) {
-          // Recreate the WebView only when the gateway page or credentials
-          // change; recompositions must not restart live shell sessions.
+          // GatewayControlPage equality includes the accepted TLS pin, so trust changes
+          // recreate the WebView while unrelated recompositions preserve live shells.
           key(page) {
             ControlUiWebView(
               page = page,

--- a/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
@@ -451,6 +451,7 @@ class GatewayBootstrapAuthTest {
 
       assertEquals("ab".repeat(32), prefs.loadGatewayTlsFingerprint(endpoint.stableId))
       assertEquals("setup-bootstrap-token", waitForDesiredBootstrapToken(runtime, "nodeSession"))
+      assertEquals("ab".repeat(32), runtime.gatewayControlPage.value?.tlsFingerprintSha256)
       assertNull(desiredBootstrapToken(runtime, "operatorSession"))
     }
 

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/ControlUiWebViewTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/ControlUiWebViewTest.kt
@@ -1,0 +1,56 @@
+package ai.openclaw.app.ui
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.security.MessageDigest
+
+@RunWith(RobolectricTestRunner::class)
+class ControlUiWebViewTest {
+  @Test
+  fun pinnedSslError_proceedsOnlyForExactCertificateAtGatewayOrigin() {
+    val certificate = "accepted gateway certificate".toByteArray()
+    val fingerprint = sha256Hex(certificate)
+
+    assertTrue(
+      shouldProceedForPinnedControlUiSslError(
+        pageBaseUrl = "https://gateway.example.com:8443/openclaw/",
+        expectedFingerprint = fingerprint,
+        errorUrl = "https://gateway.example.com:8443/openclaw/assets/app.js",
+        encodedCertificate = certificate,
+      ),
+    )
+    assertFalse(
+      shouldProceedForPinnedControlUiSslError(
+        pageBaseUrl = "https://gateway.example.com:8443/openclaw/",
+        expectedFingerprint = "00".repeat(32),
+        errorUrl = "https://gateway.example.com:8443/openclaw/assets/app.js",
+        encodedCertificate = certificate,
+      ),
+    )
+    assertFalse(
+      shouldProceedForPinnedControlUiSslError(
+        pageBaseUrl = "https://gateway.example.com:8443/openclaw/",
+        expectedFingerprint = fingerprint,
+        errorUrl = "https://attacker.example.com:8443/openclaw/assets/app.js",
+        encodedCertificate = certificate,
+      ),
+    )
+    assertFalse(
+      shouldProceedForPinnedControlUiSslError(
+        pageBaseUrl = "https://gateway.example.com:8443/openclaw/",
+        expectedFingerprint = null,
+        errorUrl = "https://gateway.example.com:8443/openclaw/assets/app.js",
+        encodedCertificate = certificate,
+      ),
+    )
+  }
+
+  private fun sha256Hex(bytes: ByteArray): String =
+    MessageDigest
+      .getInstance("SHA-256")
+      .digest(bytes)
+      .joinToString(separator = "") { byte -> "%02x".format(byte.toInt() and 0xff) }
+}

--- a/apps/ios/Sources/Web/AuthenticatedControlUIWebView.swift
+++ b/apps/ios/Sources/Web/AuthenticatedControlUIWebView.swift
@@ -24,9 +24,7 @@ enum AuthenticatedControlUI {
         default:
             components.scheme = "http"
         }
-        let basePath = self.normalizeBasePath(components.path)
-        let relativePath = path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
-        components.path = relativePath.isEmpty ? basePath : basePath + relativePath
+        components.path = self.pagePath(basePath: components.path, path: path)
         components.fragment = nil
         let encodedItems = queryItems.compactMap { item -> String? in
             guard let name = Self.percentEncodedQueryComponent(item.name) else { return nil }
@@ -101,14 +99,6 @@ enum AuthenticatedControlUI {
         return hasher.finalize()
     }
 
-    private static func normalizeBasePath(_ rawPath: String?) -> String {
-        let trimmed = (rawPath ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return "/" }
-        let withLeadingSlash = trimmed.hasPrefix("/") ? trimmed : "/" + trimmed
-        guard withLeadingSlash != "/" else { return "/" }
-        return withLeadingSlash.hasSuffix("/") ? withLeadingSlash : withLeadingSlash + "/"
-    }
-
     private static func percentEncodedQueryComponent(_ value: String) -> String? {
         value.addingPercentEncoding(withAllowedCharacters: self.queryComponentAllowed)
     }
@@ -132,6 +122,16 @@ enum AuthenticatedControlUI {
             return "\"\""
         }
         return String(raw.dropFirst().dropLast())
+    }
+
+    private static func pagePath(basePath rawPath: String?, path: String) -> String {
+        let trimmed = (rawPath ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        let withLeadingSlash = trimmed.isEmpty || trimmed.hasPrefix("/") ? trimmed : "/" + trimmed
+        let basePath = withLeadingSlash.isEmpty || withLeadingSlash == "/"
+            ? "/"
+            : withLeadingSlash.hasSuffix("/") ? withLeadingSlash : withLeadingSlash + "/"
+        let relativePath = path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        return relativePath.isEmpty ? basePath : basePath + relativePath
     }
 }
 

--- a/apps/ios/Sources/Web/AuthenticatedControlUIWebView.swift
+++ b/apps/ios/Sources/Web/AuthenticatedControlUIWebView.swift
@@ -24,7 +24,9 @@ enum AuthenticatedControlUI {
         default:
             components.scheme = "http"
         }
-        components.path = path
+        let basePath = self.normalizeBasePath(components.path)
+        let relativePath = path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        components.path = relativePath.isEmpty ? basePath : basePath + relativePath
         components.fragment = nil
         let encodedItems = queryItems.compactMap { item -> String? in
             guard let name = Self.percentEncodedQueryComponent(item.name) else { return nil }
@@ -97,6 +99,14 @@ enum AuthenticatedControlUI {
         hasher.combine(config?.password)
         hasher.combine(storedOperatorToken?.trimmingCharacters(in: .whitespacesAndNewlines))
         return hasher.finalize()
+    }
+
+    private static func normalizeBasePath(_ rawPath: String?) -> String {
+        let trimmed = (rawPath ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return "/" }
+        let withLeadingSlash = trimmed.hasPrefix("/") ? trimmed : "/" + trimmed
+        guard withLeadingSlash != "/" else { return "/" }
+        return withLeadingSlash.hasSuffix("/") ? withLeadingSlash : withLeadingSlash + "/"
     }
 
     private static func percentEncodedQueryComponent(_ value: String) -> String? {

--- a/apps/ios/Sources/Web/AuthenticatedControlUIWebView.swift
+++ b/apps/ios/Sources/Web/AuthenticatedControlUIWebView.swift
@@ -24,7 +24,7 @@ enum AuthenticatedControlUI {
         default:
             components.scheme = "http"
         }
-        components.path = self.pagePath(basePath: components.path, path: path)
+        components.percentEncodedPath = self.pagePath(basePath: components.percentEncodedPath, path: path)
         components.fragment = nil
         let encodedItems = queryItems.compactMap { item -> String? in
             guard let name = Self.percentEncodedQueryComponent(item.name) else { return nil }
@@ -124,9 +124,8 @@ enum AuthenticatedControlUI {
         return String(raw.dropFirst().dropLast())
     }
 
-    private static func pagePath(basePath rawPath: String?, path: String) -> String {
-        let trimmed = (rawPath ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
-        let withLeadingSlash = trimmed.isEmpty || trimmed.hasPrefix("/") ? trimmed : "/" + trimmed
+    private static func pagePath(basePath rawPath: String, path: String) -> String {
+        let withLeadingSlash = rawPath.isEmpty || rawPath.hasPrefix("/") ? rawPath : "/" + rawPath
         let basePath = withLeadingSlash.isEmpty || withLeadingSlash == "/"
             ? "/"
             : withLeadingSlash.hasSuffix("/") ? withLeadingSlash : withLeadingSlash + "/"

--- a/apps/ios/Tests/SessionDashboardScreenTests.swift
+++ b/apps/ios/Tests/SessionDashboardScreenTests.swift
@@ -7,7 +7,7 @@ import Testing
 struct SessionDashboardScreenTests {
     @Test func `dashboard URL encodes the session and carries the one-shot face`() throws {
         let config = try GatewayConnectConfig(
-            url: #require(URL(string: "wss://gateway.example.com:8443/ws?old=true#fragment")),
+            url: #require(URL(string: "wss://gateway.example.com:8443/openclaw?old=true#fragment")),
             stableID: "manual|gateway.example.com|8443",
             tls: nil,
             token: "secret-token",
@@ -29,7 +29,7 @@ struct SessionDashboardScreenTests {
 
         #expect(
             url?.absoluteString ==
-                "https://gateway.example.com:8443/chat?session=agent%3Amain%2Fphone%20%26%20qa%3Fx%3D1&face=dashboard")
+                "https://gateway.example.com:8443/openclaw/chat?session=agent%3Amain%2Fphone%20%26%20qa%3Fx%3D1&face=dashboard")
         #expect(url?.absoluteString.contains("secret-token") == false)
     }
 }

--- a/apps/ios/Tests/SessionDashboardScreenTests.swift
+++ b/apps/ios/Tests/SessionDashboardScreenTests.swift
@@ -7,7 +7,7 @@ import Testing
 struct SessionDashboardScreenTests {
     @Test func `dashboard URL encodes the session and carries the one-shot face`() throws {
         let config = try GatewayConnectConfig(
-            url: #require(URL(string: "wss://gateway.example.com:8443/openclaw?old=true#fragment")),
+            url: #require(URL(string: "wss://gateway.example.com:8443/tenant%2Fblue?old=true#fragment")),
             stableID: "manual|gateway.example.com|8443",
             tls: nil,
             token: "secret-token",
@@ -29,7 +29,7 @@ struct SessionDashboardScreenTests {
 
         #expect(
             url?.absoluteString ==
-                "https://gateway.example.com:8443/openclaw/chat?session=agent%3Amain%2Fphone%20%26%20qa%3Fx%3D1&face=dashboard")
+                "https://gateway.example.com:8443/tenant%2Fblue/chat?session=agent%3Amain%2Fphone%20%26%20qa%3Fx%3D1&face=dashboard")
         #expect(url?.absoluteString.contains("secret-token") == false)
     }
 }

--- a/apps/ios/Tests/TerminalHubScreenTests.swift
+++ b/apps/ios/Tests/TerminalHubScreenTests.swift
@@ -32,14 +32,14 @@ struct TerminalHubScreenTests {
                 deviceAuthGatewayID: deviceAuthGatewayID))
     }
 
-    @Test func `terminal URL flips scheme and carries only view parameter`() throws {
+    @Test func `terminal URL flips scheme and preserves the Control UI base path`() throws {
         let config = try Self.makeConfig(
-            url: #require(URL(string: "wss://gateway.example.com:8443/ws")),
+            url: #require(URL(string: "wss://gateway.example.com:8443/openclaw")),
             token: "secret-token")
 
         let url = TerminalHubScreen.terminalURL(config: config)
 
-        #expect(url?.absoluteString == "https://gateway.example.com:8443/?view=terminal")
+        #expect(url?.absoluteString == "https://gateway.example.com:8443/openclaw/?view=terminal")
         // Credentials must never ride in the page URL; they travel via the
         // document-start auth user script instead.
         #expect(url?.absoluteString.contains("secret-token") == false)


### PR DESCRIPTION
## What Problem This Solves

Fixes two issues in the mobile authenticated Control UI hosts. Android users connected to a gateway through an accepted SHA-256 TLS certificate pin could use the native connection while the embedded Control UI failed on the self-signed certificate. iOS users whose Control UI is mounted below `gateway.controlUi.basePath` were sent to the origin root, so terminal and session-dashboard pages were unreachable.

## Why This Change Was Made

The Android host now receives the same persisted certificate fingerprint accepted by the native gateway connection and continues past a recoverable WebView SSL error only when the presented leaf certificate hash and HTTPS origin both match exactly; every missing, mismatched, or cross-origin case cancels. The shared host applies this to terminal and dashboard pages. Android exposes this callback only for certificate errors, so successful CA-trusted handshakes remain governed by WebView system trust; enforcing a dynamic pin there would require replacing WebView HTTP and WebSocket networking.

The iOS host now derives a normalized trailing-slash Control UI base from the active gateway endpoint path, matching the macOS dashboard path rules, and appends terminal or dashboard routes beneath it instead of replacing it. Credentials remain in the document-start authentication script and never enter page URLs.

AI-assisted implementation; the changes and security boundary were manually reviewed.

## User Impact

Android Control UI pages now load for gateways using an explicitly accepted self-signed certificate without weakening SSL handling for any other certificate or origin. iOS terminal and dashboard routes now work when the Control UI is served from a configured base path. There is no visual redesign, so before/after screenshots are not applicable.

## Evidence

- Local Android proof: `:app:ktlintCheck`, both app lint variants, and focused `ControlUiWebViewTest`, `GatewayBootstrapAuthTest`, and `SessionDashboardScreenTest` — passed with the Android Studio JDK/SDK.
- `native-app-i18n.ts verify` — passed with no inventory diff; the implementation deliberately preserves tracked source line numbers.
- `swiftformat` — clean; SourceKit-free SwiftLint reported 0 violations; `swiftc -parse` passed, including the encoded `%2F` base-path regression.
- [Exact-head CI attempt 2](https://github.com/openclaw/openclaw/actions/runs/29834680523/attempts/2) — passed, including iOS build, macOS Swift build/tests, Android build/test/lint, native i18n, and the required gate. Attempt 1 was green except for an infrastructure-cancelled macOS Swift job, which passed on rerun.
- Final contract-scoped autoreview — clean, no accepted/actionable findings.
