### PR TITLE
test(git-hooks): pin the pre-commit secret scan's blocking path

### DIFF
--- a/test/git-hooks-pre-commit.test.ts
+++ b/test/git-hooks-pre-commit.test.ts
@@ -350,6 +350,31 @@ printf 'args=%s\n' "$*" >> ${JSON.stringify(logPath)}
     expect(failure.stderr).toContain("https://github.com/trufflesecurity/trufflehog#installation");
   });
 
+  it("blocks the commit when TruffleHog reports a finding", () => {
+    const dir = makeTempRepoRoot(tempDirs, "openclaw-pre-commit-finding-");
+    run(dir, "git", ["init", "-q", "--initial-branch=main"]);
+    const fakeBinDir = installPreCommitFixture(dir);
+    // TruffleHog exits 183 under `--fail` when it reports results.
+    writeExecutable(
+      fakeBinDir,
+      "trufflehog",
+      `#!/usr/bin/env bash
+printf 'Found verified result 🐷🔑\n' >&2
+exit 183
+`,
+    );
+
+    writeFileSync(path.join(dir, "changed.txt"), "staged content\n", "utf8");
+    run(dir, "git", ["add", "--", "changed.txt"]);
+
+    const failure = runFailure(dir, "bash", ["git-hooks/pre-commit"], {
+      PATH: `${fakeBinDir}:${process.env.PATH ?? ""}`,
+    });
+
+    expect(failure.status).toBe(183);
+    expect(failure.stderr).toContain("Found verified result");
+  });
+
   it("does not run the changed-scope check for non-doc staged changes", () => {
     const dir = makeTempRepoRoot(tempDirs, "openclaw-pre-commit-no-check-changed-");
     run(dir, "git", ["init", "-q", "--initial-branch=main"]);


### PR DESCRIPTION
The pre-commit hook from #111935 blocks a commit when TruffleHog reports a finding. That outcome is the whole point of the hook, and it is the one path the new tests do not cover.

All three TruffleHog fakes in `test/git-hooks-pre-commit.test.ts` exit 0:

- `"scans only staged versions of changed files with TruffleHog"` — records args, exits 0
- `"scans the staged index snapshot before the first commit"` — same
- `"blocks with install guidance when TruffleHog is missing"` — covers the *missing binary* path, not the *finding* path

So the suite asserts the scanner is **invoked with the right arguments**, but never that a finding **fails the commit**.

## Measurement

I mutated the invocation in `git-hooks/pre-commit` to be non-blocking — the exact regression these tests should catch:

```diff
   --fail-on-scan-errors \
-  filesystem "$staged_snapshot"
+  filesystem "$staged_snapshot" || true
```

| run | result |
|---|---|
| `origin/main` | Tests 1 failed \| **15 passed** (16) |
| this branch | Tests 1 failed \| **16 passed** (17) |
| this branch + `\|\| true` mutation | Tests **2 failed** \| 15 passed (17) |

On `origin/main` the mutation is invisible: secret scanning becomes a no-op and the suite stays exactly as green as before. With the added test the mutation is caught — `runFailure` reports `expected command to fail`.

The constant 1 failure is a local Windows artifact of the pre-existing `"blocks with install guidance when TruffleHog is missing"` test, which pins `PATH` to `/usr/bin:/bin`. It is identical in all three runs and unrelated to this change. Everything else is green, including the new test.

Run with Node 24.15.0: `node scripts/run-vitest.mjs run test/git-hooks-pre-commit.test.ts`.

## The change

One test. The fake exits `183`, which is what TruffleHog returns under `--fail` when it reports results, and the test asserts the hook propagates that status rather than merely that it is non-zero — a hook that swallowed the scanner's code and exited 1 on its own would be a different behavior.

Verified against the pinned version the repo already uses: `trufflehog 3.95.9`, the same release CI pins in `.github/workflows/ci.yml` (`trufflesecurity/trufflehog@27b0417`).

Scope is deliberately narrow: no change to `git-hooks/pre-commit` or to the CI workflow. The CI side is already fail-closed — the pinned action's `action.yml` appends `--fail` itself, so it needs nothing here.