### PR TITLE
fix(security): inherit agents.defaults tools/sandbox for containment

### DIFF
--- a/src/agents/agent-scope-config.test.ts
+++ b/src/agents/agent-scope-config.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveAgentConfig } from "./agent-scope-config.js";
+import { resolveEffectiveToolPolicy } from "./agent-tools.policy.js";
 
 describe("resolveAgentConfig model policy", () => {
   it("keeps an empty per-agent policy inherited instead of flattening it", () => {
@@ -25,6 +26,101 @@ describe("resolveAgentConfig model policy", () => {
 
     expect(resolveAgentConfig(cfg, "main")?.modelPolicy).toEqual({
       allow: ["openai/gpt-5.6-sol"],
+    });
+  });
+});
+
+describe("resolveAgentConfig tools/sandbox defaults inheritance", () => {
+  it("inherits agents.defaults.tools and sandbox when the list entry omits them", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          tools: { deny: ["exec", "write", "edit"] },
+          sandbox: { mode: "all", scope: "agent" },
+        },
+        list: [{ id: "worker", workspace: "~/openclaw-worker" }],
+      },
+    };
+
+    const resolved = resolveAgentConfig(cfg, "worker");
+    expect(resolved?.tools).toEqual({ deny: ["exec", "write", "edit"] });
+    expect(resolved?.sandbox).toEqual({ mode: "all", scope: "agent" });
+  });
+
+  it("prefers per-agent tools/sandbox over agents.defaults", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          tools: { deny: ["exec"] },
+          sandbox: { mode: "all" },
+        },
+        list: [
+          {
+            id: "admin",
+            tools: { allow: ["read", "exec"] },
+            sandbox: { mode: "off" },
+          },
+        ],
+      },
+    };
+
+    const resolved = resolveAgentConfig(cfg, "admin");
+    expect(resolved?.tools).toEqual({ allow: ["read", "exec"] });
+    expect(resolved?.sandbox).toEqual({ mode: "off" });
+  });
+
+  it("surfaces defaults.tools for agent ids not yet present in agents.list", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          tools: { deny: ["exec", "process"] },
+          sandbox: { mode: "non-main" },
+        },
+        list: [{ id: "main" }],
+      },
+    };
+
+    const resolved = resolveAgentConfig(cfg, "enrolling-user");
+    expect(resolved?.tools).toEqual({ deny: ["exec", "process"] });
+    expect(resolved?.sandbox).toEqual({ mode: "non-main" });
+  });
+
+  it("keeps resolveAgentConfig undefined when no list entry and no containment defaults", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: { workspace: "~/openclaw" },
+        list: [{ id: "main" }],
+      },
+    };
+    expect(resolveAgentConfig(cfg, "ghost")).toBeUndefined();
+  });
+
+  it("applies agents.defaults.tools via resolveEffectiveToolPolicy for list-omitted and missing agents", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          tools: {
+            deny: ["exec", "write", "edit", "process"],
+          },
+        },
+        list: [{ id: "main", workspace: "~/openclaw" }],
+      },
+    };
+
+    const mainPolicy = resolveEffectiveToolPolicy({
+      config: cfg,
+      sessionKey: "agent:main:main",
+    });
+    expect(mainPolicy.agentPolicy).toEqual({
+      deny: ["exec", "write", "edit", "process"],
+    });
+
+    const missingPolicy = resolveEffectiveToolPolicy({
+      config: cfg,
+      sessionKey: "agent:not-yet-enrolled:main",
+    });
+    expect(missingPolicy.agentPolicy).toEqual({
+      deny: ["exec", "write", "edit", "process"],
     });
   });
 });

--- a/src/agents/agent-scope-config.ts
+++ b/src/agents/agent-scope-config.ts
@@ -119,10 +119,20 @@ export function resolveAgentConfig(
 ): ResolvedAgentConfig | undefined {
   const id = normalizeAgentId(agentId);
   const entry = resolveAgentEntry(cfg, id);
-  if (!entry) {
-    return undefined;
-  }
   const agentDefaults = cfg.agents?.defaults;
+  if (!entry) {
+    // Fail-closed for containment fields only: if the operator declared default
+    // tools/sandbox policy, surface it even when the agent is not yet present in
+    // agents.list (enrollment race / dynamic agent ids). Other fields stay unset
+    // so workspace/model resolution continues to use their existing fallbacks.
+    if (!agentDefaults?.tools && !agentDefaults?.sandbox) {
+      return undefined;
+    }
+    return {
+      sandbox: agentDefaults?.sandbox,
+      tools: agentDefaults?.tools,
+    };
+  }
   return {
     name: readStringValue(entry.name),
     workspace: readStringValue(entry.workspace),
@@ -162,8 +172,11 @@ export function resolveAgentConfig(
       typeof entry.embeddedAgent === "object" && entry.embeddedAgent
         ? entry.embeddedAgent
         : undefined,
-    sandbox: entry.sandbox,
-    tools: entry.tools,
+    // Prefer per-agent tools/sandbox, but inherit agents.defaults when omitted.
+    // Without this, defaults.tools.deny / defaults.sandbox are inert for any
+    // list entry that does not restate them (fail-open host tool access).
+    sandbox: entry.sandbox ?? agentDefaults?.sandbox,
+    tools: entry.tools ?? agentDefaults?.tools,
   };
 }
 

--- a/src/agents/agent-tools.policy.ts
+++ b/src/agents/agent-tools.policy.ts
@@ -382,7 +382,11 @@ export function resolveEffectiveToolPolicy(params: {
     (params.sessionKey ? resolveAgentIdFromSessionKey(params.sessionKey) : undefined);
   const agentConfig =
     params.config && agentId ? resolveAgentConfig(params.config, agentId) : undefined;
-  const agentTools = agentConfig?.tools;
+  // Prefer resolved agent tools (list entry, or agents.defaults when entry omits tools /
+  // agent is not yet in the list). Fall back to agents.defaults.tools explicitly so
+  // config that only sets defaults remains fail-closed even if resolveAgentConfig
+  // returns undefined for non-containment reasons.
+  const agentTools = agentConfig?.tools ?? params.config?.agents?.defaults?.tools;
   const globalTools = params.config?.tools;
 
   const profile = agentTools?.profile ?? globalTools?.profile;

--- a/src/agents/sender-tool-policy.ts
+++ b/src/agents/sender-tool-policy.ts
@@ -36,7 +36,7 @@ export function resolveSenderToolPolicy(
   };
   const agentTools =
     params.agentId && params.agentId.trim()
-      ? resolveAgentConfig(cfg, params.agentId)?.tools
+      ? (resolveAgentConfig(cfg, params.agentId)?.tools ?? cfg.agents?.defaults?.tools)
       : undefined;
   const agentPolicy = resolveToolsBySender({
     toolsBySender: agentTools?.toolsBySender,

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -12,7 +12,7 @@ import type {
   HumanDelayConfig,
   TypingMode,
 } from "./types.base.js";
-import type { MemorySearchConfig } from "./types.tools.js";
+import type { AgentToolsConfig, MemorySearchConfig } from "./types.tools.js";
 
 /** Workspace bootstrap-file injection policy for agent system prompts. */
 export type AgentContextInjection = "always" | "continuation-skip" | "never";
@@ -465,6 +465,11 @@ export type AgentDefaultsConfig = {
     /** Require explicit agentId in sessions_spawn (no default same-as-caller). Default: false. */
     requireAgentId?: boolean;
   };
+  /**
+   * Default tool policy for agents that omit `agents.list[].tools`.
+   * Also used as a fail-closed baseline when an agent id has no list entry yet.
+   */
+  tools?: AgentToolsConfig;
   /** Optional sandbox settings for non-main sessions. */
   sandbox?: AgentSandboxConfig;
 };

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -9,6 +9,7 @@ import {
   AgentModelPolicySchema,
   AgentModelSchema,
   AgentToolModelSchema,
+  AgentToolsSchema,
   MemorySearchSchema,
 } from "./zod-schema.agent-runtime.js";
 import {
@@ -257,6 +258,12 @@ export const AgentDefaultsSchema = z
       })
       .strict()
       .optional(),
+    /**
+     * Default tool policy applied when an agent list entry omits `tools`,
+     * and as the fail-closed baseline for agents that are not yet present
+     * in `agents.list` (see resolveAgentConfig / resolveEffectiveToolPolicy).
+     */
+    tools: AgentToolsSchema,
     sandbox: AgentSandboxSchema,
   })
   .strict()

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -723,7 +723,7 @@ const MessageToolConfigSchema = z
   .strict()
   .optional();
 
-const AgentToolsSchema = z
+export const AgentToolsSchema = z
   .object({
     ...CommonToolPolicyFields,
     codeMode: CodeModeSchema,


### PR DESCRIPTION
## What Problem This Solves

Operators who set restrictive `agents.defaults.tools` / `agents.defaults.sandbox` expected those defaults to contain agents that omit per-entry overrides. They did not:

1. **List entry omits tools/sandbox** - `resolveAgentConfig` only copied `entry.tools` / `entry.sandbox`, so defaults were ignored.
2. **Agent id not yet in agents.list** - `resolveAgentConfig` returned `undefined`, so effective tool policy had no agent deny list (fail-open host tools during enrollment races).
3. **Schema gap** - `agents.defaults.tools` was not part of the defaults Zod schema/types, so intended defaults could not round-trip cleanly.

Sandbox mode already had a separate fallback path via `resolveSandboxConfigForAgent`, but tool policy resolution did not, and `resolveAgentConfig` consumers still saw empty containment fields.

## Fix

- Add `agents.defaults.tools` to schema + `AgentDefaultsConfig`
- Inherit `agents.defaults.tools` / `sandbox` when a list entry omits them
- Surface defaults-only containment for agent ids missing from `agents.list`
- Resolve effective tool policy with an explicit defaults fallback
- Regression tests for inheritance, overrides, missing-agent fail-closed path

## Evidence

```text
$ pnpm exec vitest run src/agents/agent-scope-config.test.ts
Test Files  1 passed (1)
     Tests  7 passed (7)
```

Covered cases:
- inherits `agents.defaults.tools` + `sandbox` when list entry omits them
- prefers per-agent overrides over defaults
- surfaces defaults for agent ids not yet in `agents.list`
- keeps `resolveAgentConfig` undefined when no list entry and no containment defaults
- applies defaults via `resolveEffectiveToolPolicy` for list-omitted and missing agents

Security fast CI and OpenGrep diff scan also green on this PR.

## Security notes

This hardens fail-open tool/sandbox resolution so declared default denylists and sandbox settings actually apply. No new public exploit chain is included.

Closes #107661