### PR TITLE
feat(openrouter): browse live models during setup

### DIFF
--- a/extensions/openrouter/index.ts
+++ b/extensions/openrouter/index.ts
@@ -18,6 +18,7 @@ import {
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { buildOpenRouterImageGenerationProvider } from "./image-generation-provider.js";
 import { openrouterMediaUnderstandingProvider } from "./media-understanding-provider.js";
+import { listOpenRouterModelCatalog } from "./model-catalog.js";
 import { isOpenRouterMistralModelId, normalizeOpenRouterApiModelId } from "./models.js";
 import { buildOpenRouterMusicGenerationProvider } from "./music-generation-provider.js";
 import { createOpenRouterOAuthAuthMethod } from "./oauth.js";
@@ -324,6 +325,7 @@ export default definePluginEntry({
           };
         },
       },
+      augmentModelCatalog: () => listOpenRouterModelCatalog(),
       staticCatalog: {
         order: "simple",
         run: async () => ({

--- a/extensions/openrouter/model-catalog.test.ts
+++ b/extensions/openrouter/model-catalog.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getCachedLiveProviderModelRows = vi.hoisted(() => vi.fn());
+
+vi.mock("openclaw/plugin-sdk/provider-catalog-live-runtime", () => ({
+  getCachedLiveProviderModelRows,
+  LiveModelCatalogHttpError: class LiveModelCatalogHttpError extends Error {
+    status = 500;
+  },
+}));
+
+vi.mock("openclaw/plugin-sdk/runtime-env", () => ({
+  createSubsystemLogger: () => ({ warn: vi.fn() }),
+}));
+
+import { listOpenRouterModelCatalog } from "./model-catalog.js";
+
+describe("listOpenRouterModelCatalog", () => {
+  beforeEach(() => {
+    getCachedLiveProviderModelRows.mockReset();
+  });
+
+  it("projects live text-chat models with their picker metadata", async () => {
+    getCachedLiveProviderModelRows.mockResolvedValueOnce([
+      {
+        id: "openai/gpt-5.4",
+        name: "OpenAI: GPT-5.4",
+        context_length: 1_050_000,
+        supported_parameters: ["reasoning_effort", "tools"],
+        architecture: {
+          input_modalities: ["text", "image", "file"],
+          output_modalities: ["text"],
+        },
+      },
+      {
+        id: "black-forest-labs/flux.2-pro",
+        architecture: { input_modalities: ["text"], output_modalities: ["image"] },
+      },
+      {
+        id: "openai/gpt-5.4",
+        architecture: { input_modalities: ["text"], output_modalities: ["text"] },
+      },
+    ]);
+
+    await expect(listOpenRouterModelCatalog()).resolves.toEqual([
+      {
+        provider: "openrouter",
+        id: "openai/gpt-5.4",
+        name: "OpenAI: GPT-5.4",
+        contextWindow: 1_050_000,
+        reasoning: true,
+        input: ["text", "image", "document"],
+      },
+    ]);
+    expect(getCachedLiveProviderModelRows).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerId: "openrouter",
+        endpoint: "https://openrouter.ai/api/v1/models",
+      }),
+    );
+  });
+
+  it("returns no supplemental rows when discovery fails", async () => {
+    getCachedLiveProviderModelRows.mockRejectedValueOnce(new Error("network unavailable"));
+
+    await expect(listOpenRouterModelCatalog()).resolves.toEqual([]);
+  });
+});

--- a/extensions/openrouter/model-catalog.ts
+++ b/extensions/openrouter/model-catalog.ts
@@ -1,0 +1,135 @@
+// OpenRouter text-model catalog discovery for the interactive model picker.
+import { withTrustedEnvProxyGuardedFetchMode } from "openclaw/plugin-sdk/fetch-runtime";
+import {
+  getCachedLiveProviderModelRows,
+  LiveModelCatalogHttpError,
+} from "openclaw/plugin-sdk/provider-catalog-live-runtime";
+import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
+import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
+import {
+  asPositiveSafeInteger,
+  normalizeOptionalString,
+} from "openclaw/plugin-sdk/string-coerce-runtime";
+import { OPENROUTER_BASE_URL } from "./provider-catalog.js";
+
+const log = createSubsystemLogger("openrouter-model-catalog");
+const OPENROUTER_MODELS_URL = new URL("models", `${OPENROUTER_BASE_URL}/`).href;
+const DISCOVERY_TIMEOUT_MS = 10_000;
+const DISCOVERY_CACHE_TTL_MS = 5 * 60 * 1000;
+
+type OpenRouterModel = {
+  id?: unknown;
+  name?: unknown;
+  context_length?: unknown;
+  supported_parameters?: unknown;
+  architecture?: {
+    input_modalities?: unknown;
+    output_modalities?: unknown;
+  };
+};
+
+type OpenRouterCatalogEntry = {
+  provider: "openrouter";
+  id: string;
+  name: string;
+  contextWindow?: number;
+  reasoning?: boolean;
+  input: Array<"text" | "image" | "audio" | "video" | "document">;
+};
+
+function normalizeModalities(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value
+        .filter((entry): entry is string => typeof entry === "string")
+        .map((entry) => entry.trim())
+    : [];
+}
+
+function projectInputModalities(value: unknown): OpenRouterCatalogEntry["input"] {
+  const input = new Set<OpenRouterCatalogEntry["input"][number]>(["text"]);
+  for (const modality of normalizeModalities(value)) {
+    switch (modality) {
+      case "image":
+        input.add("image");
+        break;
+      case "audio":
+        input.add("audio");
+        break;
+      case "video":
+        input.add("video");
+        break;
+      case "file":
+      case "document":
+        input.add("document");
+        break;
+    }
+  }
+  return [...input];
+}
+
+function supportsTextChat(model: OpenRouterModel): boolean {
+  const input = normalizeModalities(model.architecture?.input_modalities);
+  const output = normalizeModalities(model.architecture?.output_modalities);
+  return input.includes("text") && output.includes("text");
+}
+
+function supportsReasoning(model: OpenRouterModel): boolean {
+  return normalizeModalities(model.supported_parameters).some(
+    (parameter) =>
+      parameter === "reasoning" ||
+      parameter === "reasoning_effort" ||
+      parameter === "include_reasoning",
+  );
+}
+
+function projectOpenRouterModel(model: OpenRouterModel): OpenRouterCatalogEntry | undefined {
+  const id = normalizeOptionalString(model.id);
+  if (!id || !supportsTextChat(model)) {
+    return undefined;
+  }
+  const name = normalizeOptionalString(model.name) ?? id;
+  const contextWindow = asPositiveSafeInteger(model.context_length);
+  return {
+    provider: "openrouter",
+    id,
+    name,
+    ...(contextWindow ? { contextWindow } : {}),
+    ...(supportsReasoning(model) ? { reasoning: true } : {}),
+    input: projectInputModalities(model.architecture?.input_modalities),
+  };
+}
+
+/** Loads OpenRouter's live text-chat catalog for interactive browsing. */
+export async function listOpenRouterModelCatalog(): Promise<OpenRouterCatalogEntry[]> {
+  try {
+    const rows = await getCachedLiveProviderModelRows({
+      providerId: "openrouter",
+      endpoint: OPENROUTER_MODELS_URL,
+      timeoutMs: DISCOVERY_TIMEOUT_MS,
+      ttlMs: DISCOVERY_CACHE_TTL_MS,
+      auditContext: "openrouter-model-discovery",
+      shouldCacheRows: (entries) => entries.length > 0,
+      fetchGuard: (params) => fetchWithSsrFGuard(withTrustedEnvProxyGuardedFetchMode(params)),
+    });
+    const seen = new Set<string>();
+    const models: OpenRouterCatalogEntry[] = [];
+    for (const row of rows) {
+      const model = projectOpenRouterModel(row as OpenRouterModel);
+      if (!model || seen.has(model.id)) {
+        continue;
+      }
+      seen.add(model.id);
+      models.push(model);
+    }
+    return models;
+  } catch (error) {
+    const message =
+      error instanceof LiveModelCatalogHttpError
+        ? `HTTP ${error.status}`
+        : error instanceof Error
+          ? error.message
+          : String(error);
+    log.warn(`Failed to load live OpenRouter models: ${message}`);
+    return [];
+  }
+}


### PR DESCRIPTION
Closes #112179

## What Problem This Solves

OpenRouter users choosing a default model during `openclaw configure --section model` cannot search the provider’s current model inventory. The existing “Browse all models” flow only receives the small bundled/configured OpenRouter set, so users must discover and manually type model identifiers elsewhere.

## Why This Change Was Made

The OpenRouter plugin now fetches the provider’s public live model catalog when the picker builds its catalog, projects text-input/text-output routes into OpenClaw’s model catalog, and caches a successful result for five minutes. Image- and video-only routes remain excluded; discovery failure leaves the existing static catalog intact.

## User Impact

OpenRouter model selection can surface and search the current text-model inventory during setup, including metadata used by the picker such as context window, reasoning support, and media inputs. New setup is covered because discovery does not depend on credentials being persisted before the picker runs.

## Evidence

- Focused verification: `node scripts/run-vitest.mjs extensions/openrouter/index.test.ts extensions/openrouter/model-catalog.test.ts` — 44 tests passed.
- Formatting and diff checks passed.
- Live local observation: the installed build exposed 9 OpenRouter rows; the HEAD build loaded 339 live text-model rows from OpenRouter.
- The repository changed-files gate could not start because its configured Blacksmith/Crabbox binary failed its own sanity check in this environment.

AI-assisted implementation; I reviewed the behavior and validation evidence above.
