### PR TITLE
fix(security): audit nested skill escapes under symlinked skills roots

### DIFF
--- a/src/skills/security/workspace-audit.test.ts
+++ b/src/skills/security/workspace-audit.test.ts
@@ -74,6 +74,64 @@ describe("security audit workspace skill path escape findings", () => {
     await Promise.all(runs);
   });
 
+  it("audits nested escapes when the workspace skills root is symlinked", async () => {
+    const tmp = await tempCases.makeTmpDir("workspace-skill-symlinked-root");
+    const workspaceDir = path.join(tmp, "workspace");
+    const linkedSkillsRoot = path.join(tmp, "linked-skills");
+    const outsideSkillDir = path.join(tmp, "outside-skill");
+    await fs.mkdir(workspaceDir, { recursive: true });
+    await fs.mkdir(path.join(linkedSkillsRoot, "safe"), { recursive: true });
+    await fs.mkdir(outsideSkillDir, { recursive: true });
+    const safeSkillPath = path.join(linkedSkillsRoot, "safe", "SKILL.md");
+    await fs.writeFile(safeSkillPath, "# safe linked skill\n", "utf-8");
+    const outsideSkillPath = path.join(outsideSkillDir, "SKILL.md");
+    await fs.writeFile(outsideSkillPath, "# outside\n", "utf-8");
+    const safeSkillRealPath = await fs.realpath(safeSkillPath);
+    const outsideSkillRealPath = await fs.realpath(outsideSkillPath);
+
+    const directoryLinkType = isWindows ? "junction" : "dir";
+    await fs.symlink(outsideSkillDir, path.join(linkedSkillsRoot, "escaped"), directoryLinkType);
+    await fs.symlink(linkedSkillsRoot, path.join(workspaceDir, "skills"), directoryLinkType);
+
+    const findings = await collectWorkspaceSkillSymlinkEscapeFindings({
+      cfg: { agents: { defaults: { workspace: workspaceDir } } } satisfies OpenClawConfig,
+    });
+
+    const finding = requireFinding(findings, "skills.workspace.symlink_escape");
+    expect(finding.severity).toBe("warn");
+    expect(finding.detail).toContain(outsideSkillRealPath);
+    expect(finding.detail).not.toContain(safeSkillRealPath);
+  });
+
+  it("does not flag skill targets explicitly trusted by the loader config", async () => {
+    const tmp = await tempCases.makeTmpDir("workspace-skill-trusted-target");
+    const workspaceDir = path.join(tmp, "workspace");
+    const trustedSkillsRoot = path.join(tmp, "trusted-skills");
+    await fs.mkdir(path.join(workspaceDir, "skills"), { recursive: true });
+    await fs.mkdir(path.join(trustedSkillsRoot, "shared"), { recursive: true });
+    await fs.writeFile(
+      path.join(trustedSkillsRoot, "shared", "SKILL.md"),
+      "# trusted shared skill\n",
+      "utf-8",
+    );
+
+    const directoryLinkType = isWindows ? "junction" : "dir";
+    await fs.symlink(
+      path.join(trustedSkillsRoot, "shared"),
+      path.join(workspaceDir, "skills", "shared"),
+      directoryLinkType,
+    );
+
+    const findings = await collectWorkspaceSkillSymlinkEscapeFindings({
+      cfg: {
+        agents: { defaults: { workspace: workspaceDir } },
+        skills: { load: { allowSymlinkTargets: [trustedSkillsRoot] } },
+      } satisfies OpenClawConfig,
+    });
+
+    expect(findings.map((entry) => entry.checkId)).not.toContain("skills.workspace.symlink_escape");
+  });
+
   it("treats an unresolvable realpath (timeout/error simulation) as a potential symlink escape", async () => {
     const tmp = await tempCases.makeTmpDir("workspace-skill-realpath-unresolvable");
     const workspaceDir = path.join(tmp, "workspace");

--- a/src/skills/security/workspace-audit.ts
+++ b/src/skills/security/workspace-audit.ts
@@ -5,6 +5,10 @@ import { listAgentWorkspaceDirs } from "../../agents/workspace-dirs.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { SecurityAuditFinding } from "../../security/audit.types.js";
 import { isPathInside } from "../../security/scan-paths.js";
+import {
+  findContainingAllowedSkillSymlinkTarget,
+  resolveAllowedSkillSymlinkTargetRealPaths,
+} from "../loading/symlink-targets.js";
 
 type WorkspaceSkillScanLimits = {
   maxFiles?: number;
@@ -19,10 +23,13 @@ async function safeStat(targetPath: string): Promise<{
   isDir: boolean;
 }> {
   try {
-    const lst = await fs.lstat(targetPath);
+    // Follow the top-level skills root when it is a directory symlink / junction.
+    // lstat().isDirectory() is false for those entries, which previously made the
+    // security audit skip the whole tree and miss nested symlink escapes.
+    const st = await fs.stat(targetPath);
     return {
       ok: true,
-      isDir: lst.isDirectory(),
+      isDir: st.isDirectory(),
     };
   } catch {
     return {
@@ -54,12 +61,13 @@ function realpathWithTimeout(p: string, timeoutMs = 2000): Promise<string | null
 async function listWorkspaceSkillMarkdownFiles(
   workspaceDir: string,
   limits: WorkspaceSkillScanLimits = {},
-): Promise<{ skillFilePaths: string[]; truncated: boolean }> {
+): Promise<{ skillFilePaths: string[]; skillsRootRealPath: string | null; truncated: boolean }> {
   const skillsRoot = path.join(workspaceDir, "skills");
   const rootStat = await safeStat(skillsRoot);
   if (!rootStat.ok || !rootStat.isDir) {
-    return { skillFilePaths: [], truncated: false };
+    return { skillFilePaths: [], skillsRootRealPath: null, truncated: false };
   }
+  const skillsRootRealPath = (await realpathWithTimeout(skillsRoot)) ?? path.resolve(skillsRoot);
 
   const maxFiles = limits.maxFiles ?? MAX_WORKSPACE_SKILL_SCAN_FILES_PER_WORKSPACE;
   const maxTotalDirVisits = limits.maxDirVisits ?? maxFiles * 20;
@@ -108,7 +116,7 @@ async function listWorkspaceSkillMarkdownFiles(
     }
   }
 
-  return { skillFilePaths: skillFiles, truncated: queue.length > 0 };
+  return { skillFilePaths: skillFiles, skillsRootRealPath, truncated: queue.length > 0 };
 }
 
 export async function collectWorkspaceSkillSymlinkEscapeFindings(params: {
@@ -121,17 +129,20 @@ export async function collectWorkspaceSkillSymlinkEscapeFindings(params: {
     return findings;
   }
 
+  const allowedSymlinkTargetRealPaths = resolveAllowedSkillSymlinkTargetRealPaths(params.cfg);
+
   const escapedSkillFiles: Array<{
     workspaceDir: string;
+    skillsRootRealPath: string;
     skillFilePath: string;
+    skillDirRealPath: string;
     skillRealPath: string;
   }> = [];
   const seenSkillPaths = new Set<string>();
 
   for (const workspaceDir of workspaceDirs) {
     const workspacePath = path.resolve(workspaceDir);
-    const workspaceRealPath = (await realpathWithTimeout(workspacePath)) ?? workspacePath;
-    const { skillFilePaths, truncated } = await listWorkspaceSkillMarkdownFiles(
+    const { skillFilePaths, skillsRootRealPath, truncated } = await listWorkspaceSkillMarkdownFiles(
       workspacePath,
       params.skillScanLimits,
     );
@@ -158,21 +169,36 @@ export async function collectWorkspaceSkillSymlinkEscapeFindings(params: {
       }
       seenSkillPaths.add(canonicalSkillPath);
 
-      const skillRealPath = await realpathWithTimeout(canonicalSkillPath);
-      if (!skillRealPath) {
+      const [skillDirRealPath, skillRealPath] = await Promise.all([
+        realpathWithTimeout(path.dirname(canonicalSkillPath)),
+        realpathWithTimeout(canonicalSkillPath),
+      ]);
+      if (!skillDirRealPath || !skillRealPath) {
         escapedSkillFiles.push({
           workspaceDir: workspacePath,
+          skillsRootRealPath: skillsRootRealPath ?? path.join(workspacePath, "skills"),
           skillFilePath: canonicalSkillPath,
-          skillRealPath: "(realpath timed out - symlink target unverifiable)",
+          skillDirRealPath:
+            skillDirRealPath ?? "(realpath timed out - skill directory unverifiable)",
+          skillRealPath: skillRealPath ?? "(realpath timed out - symlink target unverifiable)",
         });
         continue;
       }
-      if (isPathInside(workspaceRealPath, skillRealPath)) {
+      // Trust boundary matches the skill loader: resolved skills root, plus any
+      // operator-declared skills.load.allowSymlinkTargets. A nested skill dir must
+      // stay inside one of those roots, and SKILL.md must stay inside its skill dir.
+      const skillDirIsTrusted =
+        (skillsRootRealPath !== null && isPathInside(skillsRootRealPath, skillDirRealPath)) ||
+        findContainingAllowedSkillSymlinkTarget(allowedSymlinkTargetRealPaths, skillDirRealPath) !==
+          null;
+      if (skillDirIsTrusted && isPathInside(skillDirRealPath, skillRealPath)) {
         continue;
       }
       escapedSkillFiles.push({
         workspaceDir: workspacePath,
+        skillsRootRealPath: skillsRootRealPath ?? path.join(workspacePath, "skills"),
         skillFilePath: canonicalSkillPath,
+        skillDirRealPath,
         skillRealPath,
       });
     }
@@ -185,15 +211,19 @@ export async function collectWorkspaceSkillSymlinkEscapeFindings(params: {
   findings.push({
     checkId: "skills.workspace.symlink_escape",
     severity: "warn",
-    title: "Workspace skill files resolve outside the workspace root",
+    title: "Workspace skill files resolve outside trusted skill roots",
     detail:
-      "Detected workspace `skills/**/SKILL.md` paths whose realpath escapes their workspace root:\n" +
+      "Detected workspace `skills/**/SKILL.md` paths whose skill directory escapes the resolved " +
+      "skills root and configured `skills.load.allowSymlinkTargets`, or whose file escapes its " +
+      "resolved skill directory:\n" +
       escapedSkillFiles
         .slice(0, MAX_WORKSPACE_SKILL_ESCAPE_DETAIL_ROWS)
         .map(
           (entry) =>
             `- workspace=${entry.workspaceDir}\n` +
+            `  skillsRoot=${entry.skillsRootRealPath}\n` +
             `  skill=${entry.skillFilePath}\n` +
+            `  skillDirRealpath=${entry.skillDirRealPath}\n` +
             `  realpath=${entry.skillRealPath}`,
         )
         .join("\n") +
@@ -201,7 +231,9 @@ export async function collectWorkspaceSkillSymlinkEscapeFindings(params: {
         ? `\n- +${escapedSkillFiles.length - MAX_WORKSPACE_SKILL_ESCAPE_DETAIL_ROWS} more`
         : ""),
     remediation:
-      "Keep workspace skills inside the workspace root (replace symlinked escapes with real in-workspace files), or move trusted shared skills to managed/bundled skill locations.",
+      "Keep each SKILL.md inside its resolved skill directory and the skill directory inside the " +
+      "resolved skills root, or explicitly trust intentional shared roots with " +
+      "skills.load.allowSymlinkTargets.",
   });
 
   return findings;


### PR DESCRIPTION
## What Problem This Solves

`openclaw security audit` **silently skipped** workspace skill scanning when `workspace/skills` was a **directory symlink** (or Windows junction).

Why that is dangerous:
1. Operators often symlink `skills/` to a shared skills store.
2. A nested skill directory symlink can point **outside** the trusted skills root (malicious or accidental).
3. The audit used `lstat()` + `isDirectory()` on the skills root. For a dir symlink, `isDirectory()` is **false**, so the scan returned **zero** SKILL.md files and never emitted `skills.workspace.symlink_escape`.
4. Result: **fail-open security tooling** - the guard that is supposed to catch skill-path escapes was blind exactly when shared/symlinked skill roots are used.

## Fix

- Follow the top-level `workspace/skills` path with `fs.stat()` so directory symlinks/junctions are traversed
- Resolve and remember the skills root realpath
- Align containment with the skill loader: resolved skills root **or** `skills.load.allowSymlinkTargets`
- Require each `SKILL.md` realpath to stay inside its skill directory
- Regression tests for the symlinked-root blind spot and trusted allowlist targets

## Evidence

```text
$ pnpm exec vitest run src/skills/security/workspace-audit.test.ts
Test Files  1 passed (1)
     Tests  5 passed (5)
```

Key new coverage:
- nested escapes when `workspace/skills` itself is a symlink/junction
- no false positive when a nested skill is explicitly trusted via `skills.load.allowSymlinkTargets`

## Security notes

This restores a security-audit control-plane signal (not a remote unauth RCE). Without it, operators relying on `security audit` for workspace hygiene can miss skill symlink escapes on the common shared-skills layout.

Closes #111797