### PR TITLE
fix(macos): localize settings surfaces

### DIFF
--- a/.github/workflows/native-app-locale-refresh.yml
+++ b/.github/workflows/native-app-locale-refresh.yml
@@ -309,6 +309,7 @@ jobs:
             apps/android/app/src/main/res/values*/assistant.xml
             apps/android/app/src/main/res/values*/strings.xml
             apps/ios/Resources/Localizable.xcstrings
+            apps/macos/Sources/OpenClaw/Resources/Localizable.xcstrings
             apps/ios/Sources/*.lproj/InfoPlist.strings
             apps/ios/WatchApp/*.lproj/InfoPlist.strings
             apps/ios/ShareExtension/*.lproj/InfoPlist.strings

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -28355,7 +28355,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 322,
+      "line": 325,
       "path": "apps/macos/Sources/OpenClaw/ChannelConfigForm.swift",
       "source": "Select…",
       "surface": "apple",
@@ -28363,7 +28363,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 488,
+      "line": 491,
       "path": "apps/macos/Sources/OpenClaw/ChannelConfigForm.swift",
       "source": "Extra entries",
       "surface": "apple",
@@ -28371,7 +28371,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 491,
+      "line": 494,
       "path": "apps/macos/Sources/OpenClaw/ChannelConfigForm.swift",
       "source": "No extra entries yet.",
       "surface": "apple",
@@ -28379,7 +28379,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 498,
+      "line": 501,
       "path": "apps/macos/Sources/OpenClaw/ChannelConfigForm.swift",
       "source": "Key",
       "surface": "apple",
@@ -28387,7 +28387,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 502,
+      "line": 505,
       "path": "apps/macos/Sources/OpenClaw/ChannelConfigForm.swift",
       "source": "Remove",
       "surface": "apple",
@@ -28395,7 +28395,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 512,
+      "line": 515,
       "path": "apps/macos/Sources/OpenClaw/ChannelConfigForm.swift",
       "source": "Add",
       "surface": "apple",
@@ -28403,7 +28403,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 619,
+      "line": 622,
       "path": "apps/macos/Sources/OpenClaw/ChannelConfigForm.swift",
       "source": "Loading channel settings",
       "surface": "apple",
@@ -28411,7 +28411,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 631,
+      "line": 634,
       "path": "apps/macos/Sources/OpenClaw/ChannelConfigForm.swift",
       "source": "Configuration",
       "surface": "apple",
@@ -28419,7 +28419,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 633,
+      "line": 636,
       "path": "apps/macos/Sources/OpenClaw/ChannelConfigForm.swift",
       "source": "Schema unavailable",
       "surface": "apple",
@@ -28427,7 +28427,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 634,
+      "line": 637,
       "path": "apps/macos/Sources/OpenClaw/ChannelConfigForm.swift",
       "source": "OpenClaw could not load editable settings for this channel.",
       "surface": "apple",
@@ -31251,7 +31251,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 482,
+      "line": 483,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Control channel",
       "surface": "apple",
@@ -31259,7 +31259,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 509,
+      "line": 512,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Recommended setup",
       "surface": "apple",
@@ -31267,7 +31267,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 511,
+      "line": 514,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Use Tailscale plus an SSH tunnel for stable private access.",
       "surface": "apple",
@@ -31275,7 +31275,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 512,
+      "line": 515,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Use Tailscale Serve so the gateway has a valid HTTPS certificate.",
       "surface": "apple",
@@ -31283,7 +31283,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 521,
+      "line": 524,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Advanced",
       "surface": "apple",
@@ -31291,7 +31291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 524,
+      "line": 527,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Identity file",
       "surface": "apple",
@@ -31299,7 +31299,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 526,
+      "line": 529,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "/Users/you/.ssh/id_ed25519",
       "surface": "apple",
@@ -31307,7 +31307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 528,
+      "line": 531,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Project root",
       "surface": "apple",
@@ -31315,7 +31315,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 530,
+      "line": 533,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "/home/you/Projects/openclaw",
       "surface": "apple",
@@ -31323,7 +31323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 532,
+      "line": 535,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "CLI path",
       "surface": "apple",
@@ -31331,7 +31331,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 534,
+      "line": 537,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "/Applications/OpenClaw.app/.../openclaw",
       "surface": "apple",
@@ -31339,7 +31339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 539,
+      "line": 542,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "SSH command details",
       "surface": "apple",
@@ -31347,7 +31347,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 559,
+      "line": 562,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Transport",
       "surface": "apple",
@@ -31355,7 +31355,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 560,
+      "line": 563,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "SSH keeps the Gateway private; direct is best for HTTPS or Tailscale Serve.",
       "surface": "apple",
@@ -31363,7 +31363,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 563,
+      "line": 566,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "SSH tunnel",
       "surface": "apple",
@@ -31371,7 +31371,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 564,
+      "line": 567,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Direct (ws/wss)",
       "surface": "apple",
@@ -31379,7 +31379,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 577,
+      "line": 580,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "SSH target",
       "surface": "apple",
@@ -31387,7 +31387,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 577,
+      "line": 580,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "User and host for the remote Gateway machine.",
       "surface": "apple",
@@ -31395,7 +31395,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 594,
+      "line": 597,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Gateway URL",
       "surface": "apple",
@@ -31403,7 +31403,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 594,
+      "line": 597,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "The WebSocket URL exposed by the remote Gateway.",
       "surface": "apple",
@@ -31411,7 +31411,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 597,
+      "line": 600,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "wss://gateway.example.ts.net",
       "surface": "apple",
@@ -31419,7 +31419,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 603,
+      "line": 606,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Use wss:// for public hosts. ws:// is allowed for localhost, LAN, .local, and Tailnet hosts.",
       "surface": "apple",
@@ -31427,7 +31427,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 614,
+      "line": 617,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Gateway token",
       "surface": "apple",
@@ -31435,7 +31435,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 615,
+      "line": 618,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Used when the remote gateway requires token auth.",
       "surface": "apple",
@@ -31443,7 +31443,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 618,
+      "line": 621,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "remote gateway auth token (gateway.remote.token)",
       "surface": "apple",
@@ -31451,7 +31451,7 @@
     },
     {
       "kind": "ui-call-concatenated",
-      "line": 623,
+      "line": 626,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "The current gateway.remote.token value is not plain text. OpenClaw for macOS cannot use it directly; enter a plaintext token here to replace it.",
       "surface": "apple",
@@ -31459,7 +31459,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 642,
+      "line": 645,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Test remote",
       "surface": "apple",
@@ -31467,7 +31467,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 665,
+      "line": 668,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Testing…",
       "surface": "apple",
@@ -31475,7 +31475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 703,
+      "line": 706,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Installed: \\(gatewayVersion) · Required: \\(required)",
       "surface": "apple",
@@ -31483,7 +31483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 707,
+      "line": 710,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Gateway \\(gatewayVersion) detected",
       "surface": "apple",
@@ -31491,7 +31491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 713,
+      "line": 716,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Node \\(node)",
       "surface": "apple",
@@ -31499,7 +31499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 725,
+      "line": 728,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Last failure: \\(failure)",
       "surface": "apple",
@@ -31507,7 +31507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 730,
+      "line": 733,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Recheck",
       "surface": "apple",
@@ -31515,7 +31515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 733,
+      "line": 736,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Gateway auto-starts in local mode via launchd (\\(gatewayLaunchdLabel)).",
       "surface": "apple",
@@ -31523,7 +31523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 788,
+      "line": 791,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Retry now",
       "surface": "apple",
@@ -31531,7 +31531,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 793,
+      "line": 796,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "Open logs",
       "surface": "apple",
@@ -36066,7 +36066,7 @@
       "id": "native.apple.4b27b3be5f3f1f66"
     },
     {
-      "kind": "ui-named-argument-concatenated",
+      "kind": "ui-named-argument-multiline",
       "line": 23,
       "path": "apps/macos/Sources/OpenClaw/SystemAgentSettings.swift",
       "source": "Your AI-powered setup helper. It can check status, fix config, switch models, and connect channels.",
@@ -36075,7 +36075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 26,
+      "line": 27,
       "path": "apps/macos/Sources/OpenClaw/SystemAgentSettings.swift",
       "source": "Chat",
       "surface": "apple",
@@ -36083,7 +36083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 32,
+      "line": 33,
       "path": "apps/macos/Sources/OpenClaw/SystemAgentSettings.swift",
       "source": "Tip: try “status”, “doctor”, “set default model …”, or “connect telegram”.",
       "surface": "apple",
@@ -36139,7 +36139,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 81,
+      "line": 82,
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Retry",
       "surface": "apple",
@@ -36147,7 +36147,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 120,
+      "line": 121,
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Scope",
       "surface": "apple",
@@ -36155,7 +36155,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 144,
+      "line": 145,
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Policy",
       "surface": "apple",
@@ -36163,7 +36163,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 146,
+      "line": 147,
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Command access",
       "surface": "apple",
@@ -36171,7 +36171,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 163,
+      "line": 164,
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Prompt behavior",
       "surface": "apple",
@@ -36179,7 +36179,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 180,
+      "line": 181,
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Fallback when unreachable",
       "surface": "apple",
@@ -36187,7 +36187,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 181,
+      "line": 182,
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Used when the companion UI cannot display an approval prompt.",
       "surface": "apple",
@@ -36195,7 +36195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 184,
+      "line": 185,
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Fallback",
       "surface": "apple",
@@ -36203,7 +36203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 207,
+      "line": 208,
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Automatic Trust",
       "surface": "apple",
@@ -36211,7 +36211,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 209,
+      "line": 210,
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Auto-allow skill CLIs",
       "surface": "apple",
@@ -36219,7 +36219,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 210,
+      "line": 211,
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Let bundled skill command-line tools run without prompting.",
       "surface": "apple",
@@ -36227,7 +36227,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 218,
+      "line": 219,
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Trusted skill binaries",
       "surface": "apple",
@@ -36235,7 +36235,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 239,
+      "line": 240,
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Add Command",
       "surface": "apple",
@@ -36243,7 +36243,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 241,
+      "line": 242,
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Pattern",
       "surface": "apple",
@@ -36251,7 +36251,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 242,
+      "line": 243,
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Bare names match PATH commands. Use a path glob for a specific binary.",
       "surface": "apple",
@@ -36259,7 +36259,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 246,
+      "line": 247,
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "rg or /opt/homebrew/bin/*",
       "surface": "apple",
@@ -36267,7 +36267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 250,
+      "line": 251,
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Add",
       "surface": "apple",
@@ -36275,7 +36275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 262,
+      "line": 263,
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Allowed Commands",
       "surface": "apple",
@@ -36283,7 +36283,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 281,
+      "line": 282,
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Allowlists are per-agent",
       "surface": "apple",
@@ -36291,7 +36291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 283,
+      "line": 284,
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Select an agent scope above to add trusted commands.",
       "surface": "apple",
@@ -36299,7 +36299,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 300,
+      "line": 301,
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "No trusted commands yet",
       "surface": "apple",
@@ -36307,7 +36307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 302,
+      "line": 303,
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Commands that miss the allowlist follow the prompt and fallback policy above.",
       "surface": "apple",
@@ -36315,7 +36315,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 342,
+      "line": 343,
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Access",
       "surface": "apple",
@@ -36323,7 +36323,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 343,
+      "line": 344,
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Allowlist",
       "surface": "apple",
@@ -36331,7 +36331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 377,
+      "line": 378,
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Last used \\(Self.relativeFormatter.localizedString(for: date, relativeTo: Date()))",
       "surface": "apple",
@@ -36339,7 +36339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 383,
+      "line": 384,
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Last command: \\(lastUsedCommand)",
       "surface": "apple",
@@ -36347,7 +36347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 389,
+      "line": 390,
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Resolved path: \\(lastResolvedPath)",
       "surface": "apple",
@@ -36355,7 +36355,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 439,
+      "line": 440,
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Shell commands blocked",
       "surface": "apple",
@@ -36363,7 +36363,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 440,
+      "line": 441,
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Trusted commands can run",
       "surface": "apple",
@@ -36371,7 +36371,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 441,
+      "line": 442,
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Shell commands allowed",
       "surface": "apple",
@@ -36379,7 +36379,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 447,
+      "line": 448,
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "system.run requests are denied unless the policy changes.",
       "surface": "apple",
@@ -36387,7 +36387,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 448,
+      "line": 449,
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Known commands can run; new commands use the prompt policy.",
       "surface": "apple",
@@ -36395,7 +36395,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 449,
+      "line": 450,
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Agents can run shell commands on this Mac without allowlist checks.",
       "surface": "apple",
@@ -36403,51 +36403,51 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 455,
+      "line": 456,
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Block agent shell commands on this Mac.",
       "surface": "apple",
-      "id": "native.apple.c8e6fc08f04b8d9f"
-    },
-    {
-      "kind": "conditional-branch",
-      "line": 456,
-      "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
-      "source": "Allow trusted command patterns and handle misses with prompts.",
-      "surface": "apple",
-      "id": "native.apple.e9371d48f629b039"
+      "id": "native.apple.5184684dc4a62edb"
     },
     {
       "kind": "conditional-branch",
       "line": 457,
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
-      "source": "Allow shell commands without checking the allowlist.",
+      "source": "Allow trusted command patterns and handle misses with prompts.",
       "surface": "apple",
-      "id": "native.apple.935c981496e8689b"
+      "id": "native.apple.bf1e546102919d3f"
     },
     {
       "kind": "conditional-branch",
-      "line": 465,
+      "line": 458,
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
-      "source": "Never show approval prompts.",
+      "source": "Allow shell commands without checking the allowlist.",
       "surface": "apple",
-      "id": "native.apple.c494c0bb6a4182a2"
+      "id": "native.apple.84214f3fae821163"
     },
     {
       "kind": "conditional-branch",
       "line": 466,
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
-      "source": "Ask only when a command is not trusted yet.",
+      "source": "Never show approval prompts.",
       "surface": "apple",
-      "id": "native.apple.c04df969fed1b2ca"
+      "id": "native.apple.d7404aa083ad6d58"
     },
     {
       "kind": "conditional-branch",
       "line": 467,
       "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
+      "source": "Ask only when a command is not trusted yet.",
+      "surface": "apple",
+      "id": "native.apple.093c3c01af530076"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 468,
+      "path": "apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift",
       "source": "Ask before every shell command.",
       "surface": "apple",
-      "id": "native.apple.19950d3e6e99ee47"
+      "id": "native.apple.a5161a377e784404"
     },
     {
       "kind": "conditional-branch",
@@ -37042,24 +37042,32 @@
       "id": "native.apple.87c3465e9398bc2f"
     },
     {
-      "kind": "ui-named-argument",
-      "line": 860,
+      "kind": "ui-localized-call",
+      "line": 861,
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
-      "source": "Language \\(self.index + 2)",
+      "source": "Language %lld",
       "surface": "apple",
-      "id": "native.apple.65b2687f8f16f9b2"
+      "id": "native.apple.dd0278dbfd438cdb"
     },
     {
       "kind": "ui-named-argument",
-      "line": 861,
+      "line": 863,
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Fallback recognition language.",
       "surface": "apple",
       "id": "native.apple.a767de022c4a06db"
     },
     {
+      "kind": "ui-call",
+      "line": 867,
+      "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
+      "source": "Language \\(self.index + 2)",
+      "surface": "apple",
+      "id": "native.apple.65b2687f8f16f9b2"
+    },
+    {
       "kind": "ui-modifier",
-      "line": 882,
+      "line": 884,
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "Remove language",
       "surface": "apple",
@@ -37067,7 +37075,7 @@
     },
     {
       "kind": "ui-call-concatenated",
-      "line": 897,
+      "line": 899,
       "path": "apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift",
       "source": "OpenClaw reacts when any trigger appears in a transcription. Keep phrases short to avoid false positives.",
       "surface": "apple",

--- a/apps/macos/Sources/OpenClaw/ChannelConfigForm.swift
+++ b/apps/macos/Sources/OpenClaw/ChannelConfigForm.swift
@@ -98,8 +98,8 @@ struct ConfigSchemaForm: View {
             if self.isChannelQuickLeaf(path) {
                 return AnyView(
                     SettingsCardToggleRow(
-                        title: label ?? "Enabled",
-                        subtitle: help,
+                        title: label.map(SettingsTextValue.verbatim) ?? "Enabled",
+                        subtitle: help.map(SettingsTextValue.verbatim),
                         binding: self.boolBinding(path, defaultValue: schema.explicitDefault as? Bool)))
             }
             return AnyView(
@@ -299,7 +299,10 @@ struct ConfigSchemaForm: View {
         subtitle: String?,
         @ViewBuilder control: () -> some View) -> some View
     {
-        SettingsCardRow(title: title ?? "Value", subtitle: subtitle) {
+        SettingsCardRow(
+            title: title.map(SettingsTextValue.verbatim) ?? "Value",
+            subtitle: subtitle.map(SettingsTextValue.verbatim))
+        {
             control()
         }
     }

--- a/apps/macos/Sources/OpenClaw/ClawHubSkillsBrowser.swift
+++ b/apps/macos/Sources/OpenClaw/ClawHubSkillsBrowser.swift
@@ -126,8 +126,8 @@ private struct ClawHubSkillResultRow: View {
 
     var body: some View {
         SettingsCardRow(
-            title: self.skill.displayName,
-            subtitle: self.skill.summary ?? self.skill.slug,
+            title: .verbatim(self.skill.displayName),
+            subtitle: .verbatim(self.skill.summary ?? self.skill.slug),
             showsDivider: self.showsDivider)
         {
             if let version = self.skill.version {

--- a/apps/macos/Sources/OpenClaw/GatewaySettings.swift
+++ b/apps/macos/Sources/OpenClaw/GatewaySettings.swift
@@ -131,8 +131,8 @@ struct GatewaySettings: View {
                 SettingsCardGroup("Saved Gateways") {
                     ForEach(Array(self.profiles.enumerated()), id: \.element.id) { index, profile in
                         SettingsCardRow(
-                            title: profile.name,
-                            subtitle: profile.url.absoluteString,
+                            title: .verbatim(profile.name),
+                            subtitle: .verbatim(profile.url.absoluteString),
                             showsDivider: index != self.profiles.count - 1)
                         {
                             HStack(spacing: 8) {

--- a/apps/macos/Sources/OpenClaw/GeneralSettings.swift
+++ b/apps/macos/Sources/OpenClaw/GeneralSettings.swift
@@ -479,7 +479,10 @@ struct GeneralSettings: View {
     }
 
     private var controlChannelRow: some View {
-        SettingsCardRow(title: "Control channel", subtitle: self.controlChannelSubtitle) {
+        SettingsCardRow(
+            title: "Control channel",
+            subtitle: self.controlChannelSubtitle.map(SettingsTextValue.verbatim))
+        {
             Text(self.controlStatusLine)
                 .font(.caption.weight(.semibold))
                 .padding(.horizontal, 8)

--- a/apps/macos/Sources/OpenClaw/SettingsComponents.swift
+++ b/apps/macos/Sources/OpenClaw/SettingsComponents.swift
@@ -17,21 +17,43 @@ extension View {
     }
 }
 
-struct SettingsPageHeader: View {
-    let title: String
-    let subtitle: String?
+enum SettingsTextValue: ExpressibleByStringLiteral {
+    case localized(LocalizedStringKey)
+    case verbatim(String)
 
-    init(title: String, subtitle: String? = nil) {
+    init(stringLiteral value: String) {
+        self = .localized(LocalizedStringKey(value))
+    }
+
+    static func localized(_ value: String) -> Self {
+        .localized(LocalizedStringKey(value))
+    }
+
+    var text: Text {
+        switch self {
+        case let .localized(key):
+            Text(key)
+        case let .verbatim(value):
+            Text(verbatim: value)
+        }
+    }
+}
+
+struct SettingsPageHeader: View {
+    let title: SettingsTextValue
+    let subtitle: SettingsTextValue?
+
+    init(title: SettingsTextValue, subtitle: SettingsTextValue? = nil) {
         self.title = title
         self.subtitle = subtitle
     }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 5) {
-            Text(self.title)
+            self.title.text
                 .font(.title3.weight(.semibold))
-            if let subtitle, !subtitle.isEmpty {
-                Text(subtitle)
+            if let subtitle {
+                subtitle.text
                     .font(.callout)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
@@ -41,17 +63,17 @@ struct SettingsPageHeader: View {
 }
 
 struct SettingsCardGroup<Content: View>: View {
-    let title: String
+    let title: SettingsTextValue
     let content: Content
 
-    init(_ title: String, @ViewBuilder content: () -> Content) {
+    init(_ title: SettingsTextValue, @ViewBuilder content: () -> Content) {
         self.title = title
         self.content = content()
     }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text(self.title)
+            self.title.text
                 .font(.subheadline.weight(.semibold))
                 .foregroundStyle(.secondary)
 
@@ -69,14 +91,14 @@ struct SettingsCardGroup<Content: View>: View {
 }
 
 struct SettingsCardRow<Content: View>: View {
-    let title: String
-    let subtitle: String?
+    let title: SettingsTextValue
+    let subtitle: SettingsTextValue?
     var showsDivider = true
     let content: Content
 
     init(
-        title: String,
-        subtitle: String? = nil,
+        title: SettingsTextValue,
+        subtitle: SettingsTextValue? = nil,
         showsDivider: Bool = true,
         @ViewBuilder content: () -> Content)
     {
@@ -89,10 +111,10 @@ struct SettingsCardRow<Content: View>: View {
     var body: some View {
         HStack(alignment: .center, spacing: 18) {
             VStack(alignment: .leading, spacing: 3) {
-                Text(self.title)
+                self.title.text
                     .font(.callout.weight(.medium))
-                if let subtitle, !subtitle.isEmpty {
-                    Text(subtitle)
+                if let subtitle {
+                    subtitle.text
                         .font(.footnote)
                         .foregroundStyle(.secondary)
                         .fixedSize(horizontal: false, vertical: true)
@@ -116,8 +138,8 @@ struct SettingsCardRow<Content: View>: View {
 }
 
 struct SettingsCardToggleRow: View {
-    let title: String
-    let subtitle: String?
+    let title: SettingsTextValue
+    let subtitle: SettingsTextValue?
     @Binding var binding: Bool
     var showsDivider = true
 
@@ -127,28 +149,30 @@ struct SettingsCardToggleRow: View {
             subtitle: self.subtitle,
             showsDivider: self.showsDivider)
         {
-            Toggle(self.title, isOn: self.$binding)
-                .labelsHidden()
-                .toggleStyle(.switch)
+            Toggle(isOn: self.$binding) {
+                self.title.text
+            }
+            .labelsHidden()
+            .toggleStyle(.switch)
         }
     }
 }
 
 struct SettingsToggleRow: View {
-    let title: String
-    let subtitle: String?
+    let title: SettingsTextValue
+    let subtitle: SettingsTextValue?
     @Binding var binding: Bool
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
             Toggle(isOn: self.$binding) {
-                Text(self.title)
+                self.title.text
                     .font(.body)
             }
             .toggleStyle(.checkbox)
 
-            if let subtitle, !subtitle.isEmpty {
-                Text(subtitle)
+            if let subtitle {
+                subtitle.text
                     .font(.footnote)
                     .foregroundStyle(.tertiary)
                     .fixedSize(horizontal: false, vertical: true)

--- a/apps/macos/Sources/OpenClaw/SystemAgentSettings.swift
+++ b/apps/macos/Sources/OpenClaw/SystemAgentSettings.swift
@@ -20,8 +20,9 @@ struct SystemAgentSettings: View {
         VStack(alignment: .leading, spacing: 20) {
             SettingsPageHeader(
                 title: "OpenClaw",
-                subtitle: "Your AI-powered setup helper. It can check status, fix config, " +
-                    "switch models, and connect channels.")
+                subtitle: """
+                Your AI-powered setup helper. It can check status, fix config, switch models, and connect channels.
+                """)
 
             SettingsCardGroup("Chat") {
                 SystemAgentOnboardingChatView(model: self.chat)

--- a/apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift
+++ b/apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift
@@ -75,7 +75,8 @@ struct SystemRunSettingsView: View {
         SettingsCardGroup("Exec Approvals Unavailable") {
             SettingsCardRow(
                 title: "Settings could not be read",
-                subtitle: self.model.readErrorMessage ?? "Retry to load the persisted policy.",
+                subtitle: self.model.readErrorMessage.map(SettingsTextValue.verbatim) ??
+                    "Retry to load the persisted policy.",
                 showsDivider: false)
             {
                 Button("Retry") {
@@ -144,7 +145,7 @@ struct SystemRunSettingsView: View {
             SettingsCardGroup("Policy") {
                 SettingsCardRow(
                     title: "Command access",
-                    subtitle: self.model.security.policyDescription)
+                    subtitle: .localized(self.model.security.policyDescription))
                 {
                     Picker("Command access", selection: Binding(
                         get: { self.model.security },
@@ -161,7 +162,7 @@ struct SystemRunSettingsView: View {
 
                 SettingsCardRow(
                     title: "Prompt behavior",
-                    subtitle: self.model.ask.policyDescription)
+                    subtitle: .localized(self.model.ask.policyDescription))
                 {
                     Picker("Prompt behavior", selection: Binding(
                         get: { self.model.ask },

--- a/apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift
+++ b/apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift
@@ -457,7 +457,7 @@ struct VoiceWakeSettings: View {
     }
 
     private func chimeRow(
-        title: String,
+        title: SettingsTextValue,
         selection: Binding<VoiceWakeChime>,
         showsDivider: Bool = true) -> some View
     {
@@ -611,7 +611,7 @@ struct VoiceWakeSettings: View {
         }
     }
 
-    private var additionalLanguagesSubtitle: String {
+    private var additionalLanguagesSubtitle: SettingsTextValue {
         if self.state.voiceWakeAdditionalLocaleIDs.isEmpty {
             return "None configured."
         }
@@ -857,7 +857,9 @@ private struct AdditionalLanguageRow: View {
 
     var body: some View {
         SettingsCardRow(
-            title: "Language \(self.index + 2)",
+            title: .verbatim(String(
+                format: String(localized: "Language %lld"),
+                self.index + 2)),
             subtitle: "Fallback recognition language.",
             showsDivider: self.showsDivider)
         {

--- a/scripts/apple-app-i18n.ts
+++ b/scripts/apple-app-i18n.ts
@@ -37,6 +37,7 @@ const INFLECTED_COUNT_SEGMENT_RE =
   /\^\[[^\]]*\\\([A-Za-z_][A-Za-z0-9_]*\)[^\]]*\]\(inflect: true\)/gu;
 const INFLECTED_COUNT_MARKER = "](inflect: true)";
 const IOS_CATALOG_PATH = "apps/ios/Resources/Localizable.xcstrings";
+const MACOS_CATALOG_PATH = "apps/macos/Sources/OpenClaw/Resources/Localizable.xcstrings";
 const IOS_CONTRADICTIONS_PATH = "apps/.i18n/apple-translation-contradictions.json";
 const NATIVE_SOURCE_PATH = "apps/.i18n/native-source.json";
 const NATIVE_TRANSLATIONS_DIR = "apps/.i18n/native";
@@ -45,7 +46,7 @@ const IOS_SOURCE_PREFIXES = [
   "apps/shared/OpenClawKit/Sources/OpenClawChatUI/",
   "apps/shared/OpenClawKit/Sources/OpenClawKit/",
 ] as const;
-const IOS_CATALOG_KINDS = new Set([
+const APPLE_CATALOG_KINDS = new Set([
   "conditional-branch",
   "ui-call",
   "ui-call-multiline",
@@ -59,6 +60,11 @@ const IOS_CATALOG_EXCLUSIONS = new Set([
   // Product names and preview-only single-character fixtures are intentionally verbatim.
   "OpenClaw",
   "z",
+]);
+const MACOS_SOURCE_PREFIX = "apps/macos/Sources/OpenClaw/";
+const MACOS_CATALOG_EXCLUSIONS = new Set([
+  // Product names are intentionally verbatim.
+  "OpenClaw",
 ]);
 const IOS_INFO_PLIST_TARGETS = [
   {
@@ -143,6 +149,18 @@ const APPLE_LOCALE_DIRECTORIES: Record<string, string> = {
   "zh-TW": "zh-Hant",
 };
 const LOCALIZED_WRAPPER_CONTRACTS: Record<string, readonly string[]> = {
+  "apps/macos/Sources/OpenClaw/SettingsComponents.swift": [
+    "enum SettingsTextValue: ExpressibleByStringLiteral",
+    "case localized(LocalizedStringKey)",
+    "case verbatim(String)",
+    "static func localized(_ value: String) -> Self",
+    "struct SettingsPageHeader: View {\n    let title: SettingsTextValue\n    let subtitle: SettingsTextValue?",
+    "struct SettingsCardGroup<Content: View>: View {\n    let title: SettingsTextValue",
+    "struct SettingsCardRow<Content: View>: View {\n    let title: SettingsTextValue\n    let subtitle: SettingsTextValue?",
+    "struct SettingsCardToggleRow: View {\n    let title: SettingsTextValue\n    let subtitle: SettingsTextValue?",
+    "struct SettingsToggleRow: View {\n    let title: SettingsTextValue\n    let subtitle: SettingsTextValue?",
+    "Text(verbatim: value)",
+  ],
   "apps/ios/Sources/Design/OpenClawProComponents.swift": [
     "enum OpenClawTextValue: ExpressibleByStringLiteral",
     "struct ProSectionHeader: View {\n    let title: OpenClawTextValue",
@@ -283,6 +301,12 @@ const LOCALIZED_WRAPPER_CONTRACTS: Record<string, readonly string[]> = {
   ],
 };
 const RAW_LOCALIZATION_BYPASSES: Record<string, readonly string[]> = {
+  "apps/macos/Sources/OpenClaw/SettingsComponents.swift": [
+    "let title: String",
+    "let subtitle: String?",
+    "Text(self.title)",
+    "Text(subtitle)",
+  ],
   "apps/ios/Sources/Design/SettingsProTabSections.swift": [
     "func settingsListRow(\n        icon: String,\n        iconColor: Color,\n        title: String",
     "func aboutLinkRow(title: String",
@@ -371,19 +395,6 @@ const RAW_LOCALIZATION_BYPASSES: Record<string, readonly string[]> = {
     'self.replyStatusText = "',
   ],
 };
-
-const MACOS_CATALOG = {
-  path: "apps/macos/Sources/OpenClaw/Resources/Localizable.xcstrings",
-  coverage: {
-    "apps/macos/Sources/OpenClaw/ChannelsSettings+ChannelSections.swift": [
-      "Logout",
-      "Refresh",
-      "Save",
-    ],
-    "apps/macos/Sources/OpenClaw/CronSettings+Rows.swift": ["Run now"],
-    "apps/macos/Sources/OpenClaw/OnboardingSystemAgentChat.swift": ["Wake up, my friend!"],
-  },
-} as const;
 
 type StringUnit = {
   state?: string;
@@ -530,9 +541,19 @@ function isIosCatalogEntry(entry: NativeSourceEntry): boolean {
   return (
     entry.surface === "apple" &&
     IOS_SOURCE_PREFIXES.some((prefix) => entry.path.startsWith(prefix)) &&
-    IOS_CATALOG_KINDS.has(entry.kind) &&
+    APPLE_CATALOG_KINDS.has(entry.kind) &&
     (!entry.source.includes("\\(") || isInflectedCountSource(entry.source)) &&
     !IOS_CATALOG_EXCLUSIONS.has(entry.source)
+  );
+}
+
+function isMacosCatalogEntry(entry: NativeSourceEntry): boolean {
+  return (
+    entry.surface === "apple" &&
+    entry.path.startsWith(MACOS_SOURCE_PREFIX) &&
+    APPLE_CATALOG_KINDS.has(entry.kind) &&
+    !entry.source.includes("\\(") &&
+    !MACOS_CATALOG_EXCLUSIONS.has(entry.source)
   );
 }
 
@@ -578,18 +599,19 @@ function chooseTranslation(source: string, translations: readonly string[]): str
   );
 }
 
-export function buildIosCatalog(
+function buildAppleCatalog(
   existingCatalog: Catalog,
   nativeSource: NativeSourceArtifact,
   translations: readonly NativeTranslationArtifact[],
+  includesEntry: (entry: NativeSourceEntry) => boolean,
 ): AppleCatalogBuild {
-  const iosEntries = nativeSource.entries.filter(isIosCatalogEntry);
-  const catalogEntries = iosEntries.map(
-    (entry) => [entry, appleCatalogValue(entry.source)] as const,
-  );
+  const catalogEntries = nativeSource.entries
+    .filter(includesEntry)
+    .map((entry) => [entry, appleCatalogValue(entry.source)] as const);
   const sources = [...new Set(catalogEntries.map(([, source]) => source))].toSorted(
     compareCodeUnits,
   );
+  const sourceSet = new Set(sources);
   const appleIdsBySource = new Map<string, Set<string>>();
   for (const [entry, source] of catalogEntries) {
     const ids = appleIdsBySource.get(source) ?? new Set<string>();
@@ -602,7 +624,7 @@ export function buildIosCatalog(
       const bySource = new Map<string, string[]>();
       for (const entry of artifact.entries) {
         const source = appleCatalogValue(entry.source);
-        if (!sources.includes(source)) {
+        if (!sourceSet.has(source)) {
           continue;
         }
         const appleIds = appleIdsBySource.get(source);
@@ -664,6 +686,22 @@ export function buildIosCatalog(
         compareCodeUnits(left.source, right.source) || compareCodeUnits(left.locale, right.locale),
     ),
   };
+}
+
+export function buildIosCatalog(
+  existingCatalog: Catalog,
+  nativeSource: NativeSourceArtifact,
+  translations: readonly NativeTranslationArtifact[],
+): AppleCatalogBuild {
+  return buildAppleCatalog(existingCatalog, nativeSource, translations, isIosCatalogEntry);
+}
+
+export function buildMacosCatalog(
+  existingCatalog: Catalog,
+  nativeSource: NativeSourceArtifact,
+  translations: readonly NativeTranslationArtifact[],
+): AppleCatalogBuild {
+  return buildAppleCatalog(existingCatalog, nativeSource, translations, isMacosCatalogEntry);
 }
 
 async function listSwiftFiles(directory: string): Promise<string[]> {
@@ -742,6 +780,17 @@ async function readIosCatalogBuild(): Promise<AppleCatalogBuild> {
   ) as NativeSourceArtifact;
   const translations = await readNativeTranslations();
   return buildIosCatalog(existingCatalog, nativeSource, translations);
+}
+
+async function readMacosCatalogBuild(): Promise<AppleCatalogBuild> {
+  const existingCatalog = JSON.parse(
+    await readFile(path.join(ROOT, MACOS_CATALOG_PATH), "utf8"),
+  ) as Catalog;
+  const nativeSource = JSON.parse(
+    await readFile(path.join(ROOT, NATIVE_SOURCE_PATH), "utf8"),
+  ) as NativeSourceArtifact;
+  const translations = await readNativeTranslations();
+  return buildMacosCatalog(existingCatalog, nativeSource, translations);
 }
 
 function validateCatalog(pathName: string, catalog: Catalog): number {
@@ -859,18 +908,42 @@ export async function syncIosCatalog(write: boolean): Promise<AppleCatalogBuild>
   return build;
 }
 
+export async function syncMacosCatalog(write: boolean): Promise<AppleCatalogBuild> {
+  const build = await readMacosCatalogBuild();
+  const catalogPath = path.join(ROOT, MACOS_CATALOG_PATH);
+  const expected = serializeCatalog(build.catalog);
+  const actual = await readFile(catalogPath, "utf8");
+  if (actual !== expected) {
+    if (!write) {
+      assertMacosCatalogCurrent(actual, build);
+      return build;
+    }
+    await writeFile(catalogPath, expected, "utf8");
+  }
+  return build;
+}
+
+export function assertMacosCatalogCurrent(actual: string, build: AppleCatalogBuild): void {
+  if (actual !== serializeCatalog(build.catalog)) {
+    throw new Error(
+      `Apple catalog ${MACOS_CATALOG_PATH} is stale; run native-app-i18n.ts sync --write`,
+    );
+  }
+}
+
 /**
- * Regenerates every Apple derived artifact (iOS catalog, contradiction report,
+ * Regenerates every Apple derived artifact (app catalogs, contradiction report,
  * InfoPlist strings). Shared by this CLI and native-app-i18n's sync so the
  * inventory can never be rewritten without its derived catalogs.
  */
 export async function syncAppleAppI18n(): Promise<{
   build: AppleCatalogBuild;
   infoPlistFiles: number;
+  macosBuild: AppleCatalogBuild;
 }> {
-  const build = await syncIosCatalog(true);
+  const [build, macosBuild] = await Promise.all([syncIosCatalog(true), syncMacosCatalog(true)]);
   const infoPlistFiles = await syncIosInfoPlist(true);
-  return { build, infoPlistFiles };
+  return { build, infoPlistFiles, macosBuild };
 }
 
 export async function verifyAppleAppI18n() {
@@ -894,48 +967,29 @@ export async function verifyAppleAppI18n() {
     }
   }
 
-  const macosCatalog = JSON.parse(
-    await readFile(path.join(ROOT, MACOS_CATALOG.path), "utf8"),
-  ) as Catalog;
-  if (!macosCatalog.strings) {
-    throw new Error(`invalid Apple string catalog: ${MACOS_CATALOG.path}`);
-  }
-  const expectedMacosKeys: Set<string> = new Set(Object.values(MACOS_CATALOG.coverage).flat());
-  const actualMacosKeys = new Set(Object.keys(macosCatalog.strings));
-  const missingMacosKeys = [...expectedMacosKeys].filter((key) => !actualMacosKeys.has(key));
-  const extraMacosKeys = [...actualMacosKeys].filter((key) => !expectedMacosKeys.has(key));
-  if (missingMacosKeys.length || extraMacosKeys.length) {
-    throw new Error(
-      [
-        `Apple catalog ${MACOS_CATALOG.path} does not match its phased source coverage.`,
-        `missing=${missingMacosKeys.join(",") || "none"}`,
-        `extra=${extraMacosKeys.join(",") || "none"}`,
-      ].join("\n"),
-    );
-  }
-  for (const [sourcePath, keys] of Object.entries(MACOS_CATALOG.coverage)) {
-    const source = await readFile(path.join(ROOT, sourcePath), "utf8");
-    const absent = keys.filter((key) => !source.includes(key));
-    if (absent.length) {
-      throw new Error(`Apple i18n coverage ${sourcePath} no longer contains: ${absent.join(", ")}`);
-    }
-  }
-  const macosKeys = validateCatalog(MACOS_CATALOG.path, macosCatalog);
+  const macosBuild = await readMacosCatalogBuild();
+  const macosKeys = validateCatalog(MACOS_CATALOG_PATH, macosBuild.catalog);
 
   process.stdout.write(`apple-app-i18n: sourceMacosKeys=${macosKeys}\n`);
 }
 
 export async function checkAppleAppI18n() {
   await verifyAppleAppI18n();
-  const iosBuild = await syncIosCatalog(false);
+  const [iosBuild, macosBuild] = await Promise.all([
+    syncIosCatalog(false),
+    syncMacosCatalog(false),
+  ]);
   const iosKeys = validateCatalog(IOS_CATALOG_PATH, iosBuild.catalog);
+  const macosKeys = validateCatalog(MACOS_CATALOG_PATH, macosBuild.catalog);
   const infoPlistFiles = await syncIosInfoPlist(false);
 
   process.stdout.write(
     [
       `apple-app-i18n: iosKeys=${iosKeys}`,
+      `macosKeys=${macosKeys}`,
       `infoPlistFiles=${infoPlistFiles}`,
       `translationContradictions=${iosBuild.contradictions.length}`,
+      `macosTranslationContradictions=${macosBuild.contradictions.length}`,
       `locales=${APPLE_I18N_LOCALES.join(",")}`,
       "\n",
     ].join(" "),
@@ -943,14 +997,13 @@ export async function checkAppleAppI18n() {
 }
 
 export async function compileMacosLocalizations(outputDir: string) {
-  // Source PRs intentionally leave generated iOS catalogs for the serialized
-  // post-merge refresh. Packaging only needs the source-owned macOS contract.
+  // Source PRs intentionally leave generated Apple catalogs for the serialized
+  // post-merge refresh. Package from the derived catalog so source changes
+  // cannot ship stale localization coverage before that refresh lands.
   await verifyAppleAppI18n();
-  const catalog = JSON.parse(
-    await readFile(path.join(ROOT, MACOS_CATALOG.path), "utf8"),
-  ) as Catalog;
+  const catalog = (await readMacosCatalogBuild()).catalog;
   if (!catalog.strings) {
-    throw new Error(`invalid Apple string catalog: ${MACOS_CATALOG.path}`);
+    throw new Error(`invalid Apple string catalog: ${MACOS_CATALOG_PATH}`);
   }
 
   for (const locale of REQUIRED_LOCALES) {
@@ -962,7 +1015,7 @@ export async function compileMacosLocalizations(outputDir: string) {
         const value = entry.localizations?.[locale]?.stringUnit?.value;
         if (!value) {
           throw new Error(
-            `Apple catalog ${MACOS_CATALOG.path} is missing ${locale} for ${JSON.stringify(key)}`,
+            `Apple catalog ${MACOS_CATALOG_PATH} is missing ${locale} for ${JSON.stringify(key)}`,
           );
         }
         return `${stringsLiteral(key)} = ${stringsLiteral(value)};`;
@@ -977,9 +1030,9 @@ if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.ar
   if (command === "check") {
     await checkAppleAppI18n();
   } else if (command === "sync-ios" && flag === "--write") {
-    const { build, infoPlistFiles } = await syncAppleAppI18n();
+    const { build, infoPlistFiles, macosBuild } = await syncAppleAppI18n();
     process.stdout.write(
-      `apple-app-i18n: synced iOS catalog and ${infoPlistFiles} InfoPlist files; contradictions=${build.contradictions.length}\n`,
+      `apple-app-i18n: synced Apple catalogs and ${infoPlistFiles} InfoPlist files; contradictions=${build.contradictions.length + macosBuild.contradictions.length}\n`,
     );
   } else if (command === "compile-macos" && flag === "--output" && value) {
     await compileMacosLocalizations(path.resolve(value));

--- a/scripts/ci-changed-scope.mjs
+++ b/scripts/ci-changed-scope.mjs
@@ -72,7 +72,7 @@ const NATIVE_I18N_SCOPE_RE =
 const NATIVE_COOWNED_GENERATED_I18N_RE =
   /^apps\/android\/app\/src\/main\/res\/values\/(?:assistant|strings)\.xml$/;
 const NATIVE_HARD_GENERATED_I18N_RE =
-  /^(?:apps\/\.i18n\/native\/[^/]+\.json|apps\/\.i18n\/apple-translation-contradictions\.json|apps\/android\/app\/src\/main\/java\/ai\/openclaw\/app\/i18n\/NativeStringResources\.kt|apps\/android\/app\/src\/main\/res\/values-[^/]+\/(?:assistant|strings)\.xml|apps\/ios\/Resources\/Localizable\.xcstrings|apps\/ios\/(?:Sources|WatchApp|ShareExtension|ActivityWidget)\/[^/]+\.lproj\/InfoPlist\.strings)$/;
+  /^(?:apps\/\.i18n\/native\/[^/]+\.json|apps\/\.i18n\/apple-translation-contradictions\.json|apps\/android\/app\/src\/main\/java\/ai\/openclaw\/app\/i18n\/NativeStringResources\.kt|apps\/android\/app\/src\/main\/res\/values-[^/]+\/(?:assistant|strings)\.xml|apps\/ios\/Resources\/Localizable\.xcstrings|apps\/macos\/Sources\/OpenClaw\/Resources\/Localizable\.xcstrings|apps\/ios\/(?:Sources|WatchApp|ShareExtension|ActivityWidget)\/[^/]+\.lproj\/InfoPlist\.strings)$/;
 const FAST_INSTALL_SMOKE_SCOPE_RE =
   /^(Dockerfile$|\.npmrc$|package\.json$|pnpm-lock\.yaml$|pnpm-workspace\.yaml$|scripts\/ci-changed-scope\.mjs$|scripts\/postinstall-bundled-plugins\.mjs$|scripts\/e2e\/(?:Dockerfile(?:\.qr-import)?|agents-delete-shared-workspace-docker\.sh|gateway-network-docker\.sh)$|extensions\/[^/]+\/(?:package\.json|openclaw\.plugin\.json)$|\.github\/workflows\/install-smoke\.yml$|\.github\/actions\/setup-node-env\/action\.yml$)/;
 const FULL_INSTALL_SMOKE_SCOPE_RE =

--- a/scripts/native-app-i18n.ts
+++ b/scripts/native-app-i18n.ts
@@ -1653,7 +1653,7 @@ async function main() {
     await syncAndroidAppI18n();
     const apple = await syncAppleAppI18n();
     process.stdout.write(
-      `native-app-i18n: synced derived artifacts (android, iOS catalog, ${apple.infoPlistFiles} InfoPlist files); contradictions=${apple.build.contradictions.length}\n`,
+      `native-app-i18n: synced derived artifacts (android, Apple catalogs, ${apple.infoPlistFiles} InfoPlist files); contradictions=${apple.build.contradictions.length + apple.macosBuild.contradictions.length}\n`,
     );
   }
 }

--- a/src/scripts/ci-changed-scope.native-i18n.test.ts
+++ b/src/scripts/ci-changed-scope.native-i18n.test.ts
@@ -15,6 +15,7 @@ describe("native i18n changed scope", () => {
       "apps/android/app/src/main/java/ai/openclaw/app/i18n/NativeStringResources.kt",
       "apps/android/app/src/main/res/values-sv/strings.xml",
       "apps/ios/Resources/Localizable.xcstrings",
+      "apps/macos/Sources/OpenClaw/Resources/Localizable.xcstrings",
       "apps/ios/WatchApp/sv.lproj/InfoPlist.strings",
     ];
 
@@ -57,6 +58,9 @@ describe("native i18n changed scope", () => {
     expect(shouldStrictNativeI18n(null)).toBe(true);
     expect(shouldStrictNativeI18n(["apps/.i18n/native/sv.json"])).toBe(true);
     expect(shouldStrictNativeI18n(["apps/ios/Resources/Localizable.xcstrings"])).toBe(true);
+    expect(
+      shouldStrictNativeI18n(["apps/macos/Sources/OpenClaw/Resources/Localizable.xcstrings"]),
+    ).toBe(true);
     expect(
       shouldStrictNativeI18n(["apps/ios/Sources/RootTabs.swift", "apps/.i18n/native-source.json"]),
     ).toBe(false);

--- a/test/scripts/apple-app-i18n.test.ts
+++ b/test/scripts/apple-app-i18n.test.ts
@@ -4,7 +4,9 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   APPLE_I18N_LOCALES,
+  assertMacosCatalogCurrent,
   buildIosCatalog,
+  buildMacosCatalog,
   compileMacosLocalizations,
   findAmbiguousRuntimeInterpolations,
   infoPlistTranslationCandidates,
@@ -64,6 +66,98 @@ describe("Apple app i18n catalogs", () => {
 
   it("keeps the Apple and native shipped locale sets identical", () => {
     expect(APPLE_I18N_LOCALES).toEqual(NATIVE_I18N_LOCALES);
+  });
+
+  it("derives broad macOS catalog coverage from the native source inventory", async () => {
+    const inventory = JSON.parse(await readFile("apps/.i18n/native-source.json", "utf8")) as {
+      entries: Array<{
+        id: string;
+        kind: string;
+        line: number;
+        path: string;
+        source: string;
+        surface: string;
+      }>;
+      version: number;
+    };
+    const build = buildMacosCatalog(
+      { sourceLanguage: "en", strings: {}, version: "1.0" },
+      inventory,
+      [],
+    );
+    const keys = Object.keys(build.catalog.strings ?? {});
+
+    expect(keys.length).toBeGreaterThan(900);
+    expect(keys).toEqual(
+      expect.arrayContaining([
+        "Browse ClawHub",
+        "Enable debug tools",
+        "Everyday OpenClaw app behavior.",
+        "General",
+        "Voice Wake requires macOS 26 or newer",
+      ]),
+    );
+    expect(keys).not.toContain("OpenClaw");
+    expect(keys.some((key) => key.includes("\\("))).toBe(false);
+  });
+
+  it("rejects a checked-in macOS catalog that lags the derived inventory", () => {
+    const build = buildMacosCatalog(
+      { sourceLanguage: "en", strings: {}, version: "1.0" },
+      {
+        version: 1,
+        entries: [
+          {
+            id: "native.apple.settings",
+            kind: "ui-call",
+            line: 1,
+            path: "apps/macos/Sources/OpenClaw/Settings.swift",
+            source: "Settings",
+            surface: "apple",
+          },
+        ],
+      },
+      [],
+    );
+
+    expect(() =>
+      assertMacosCatalogCurrent(
+        `${JSON.stringify({ sourceLanguage: "en", strings: {}, version: "1.0" }, null, 2)}\n`,
+        build,
+      ),
+    ).toThrow("Apple catalog apps/macos/Sources/OpenClaw/Resources/Localizable.xcstrings is stale");
+  });
+
+  it("keeps macOS settings literals localized and runtime values verbatim", async () => {
+    const [components, channels, clawHub, gateways, general, approvals, voiceWake] =
+      await Promise.all([
+        readFile("apps/macos/Sources/OpenClaw/SettingsComponents.swift", "utf8"),
+        readFile("apps/macos/Sources/OpenClaw/ChannelConfigForm.swift", "utf8"),
+        readFile("apps/macos/Sources/OpenClaw/ClawHubSkillsBrowser.swift", "utf8"),
+        readFile("apps/macos/Sources/OpenClaw/GatewaySettings.swift", "utf8"),
+        readFile("apps/macos/Sources/OpenClaw/GeneralSettings.swift", "utf8"),
+        readFile("apps/macos/Sources/OpenClaw/SystemRunSettingsView.swift", "utf8"),
+        readFile("apps/macos/Sources/OpenClaw/VoiceWakeSettings.swift", "utf8"),
+      ]);
+
+    expect(components).toContain("enum SettingsTextValue: ExpressibleByStringLiteral");
+    expect(components).toContain("case localized(LocalizedStringKey)");
+    expect(components).toContain("case verbatim(String)");
+    expect(components).toContain("let title: SettingsTextValue");
+    expect(components).not.toContain("let title: String");
+    expect(channels).toContain('title: label.map(SettingsTextValue.verbatim) ?? "Enabled"');
+    expect(channels).toContain("subtitle: help.map(SettingsTextValue.verbatim)");
+    expect(clawHub).toContain("title: .verbatim(self.skill.displayName)");
+    expect(gateways).toContain("subtitle: .verbatim(profile.url.absoluteString)");
+    expect(general).toContain(
+      "subtitle: self.controlChannelSubtitle.map(SettingsTextValue.verbatim)",
+    );
+    expect(approvals).toContain(
+      "subtitle: self.model.readErrorMessage.map(SettingsTextValue.verbatim)",
+    );
+    expect(approvals).toContain("subtitle: .localized(self.model.security.policyDescription)");
+    expect(approvals).toContain("subtitle: .localized(self.model.ask.policyDescription)");
+    expect(voiceWake).toContain('format: String(localized: "Language %lld")');
   });
 
   it("selects duplicate-source translations deterministically while preserving shipped translations", () => {
@@ -459,6 +553,11 @@ describe("Apple app i18n catalogs", () => {
         "utf8",
       );
       expect(swedish).toContain('"Logout" = "Logga ut";');
+      const turkish = await readFile(
+        path.join(outputDir, "tr.lproj", "Localizable.strings"),
+        "utf8",
+      );
+      expect(turkish).toContain('"General" = "Genel";');
       await expect(
         readFile(path.join(outputDir, "zh-Hans.lproj", "Localizable.strings"), "utf8"),
       ).resolves.toContain('"Save" = ');

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -1012,6 +1012,7 @@ describe("ci workflow guards", () => {
       "apps/android/app/src/main/res/values*/assistant.xml",
       "apps/android/app/src/main/res/values*/strings.xml",
       "apps/ios/Resources/Localizable.xcstrings",
+      "apps/macos/Sources/OpenClaw/Resources/Localizable.xcstrings",
       "apps/ios/Sources/*.lproj/InfoPlist.strings",
       "apps/ios/WatchApp/*.lproj/InfoPlist.strings",
       "apps/ios/ShareExtension/*.lproj/InfoPlist.strings",


### PR DESCRIPTION
## What Problem This Solves

The macOS app shipped a five-key string catalog even though the native localization inventory already tracks broad macOS UI copy. In Turkish and other non-English locales, Settings and adjacent app surfaces therefore remained mostly English.

## Why This Change Was Made

- derives the macOS string catalog from the source-owned native inventory instead of a five-key allowlist
- expands catalog coverage to 939 current macOS keys
- makes shared Settings wrappers localize app-owned literals while keeping profile names, URLs, schema copy, errors, and other runtime values verbatim
- compiles packaging localizations from the derived catalog so a stale checked-in catalog cannot ship
- adds the macOS catalog to the serialized native locale refresh and CI generated-artifact ownership guard
- updates the stable native inventory for the new formatted language label

## User Impact

macOS Settings and other catalog-backed app copy will use existing translations after the generated native locale refresh PR lands. Newly introduced source copy is translated by that same post-merge workflow.

## Evidence

- `swift build --package-path apps/macos`
- focused Swift smoke lane: 37 tests passed
- focused Vitest lane: 118 passed, 1 skipped
- `node --import tsx scripts/native-app-i18n.ts verify`
- macOS catalog derivation: 939 keys
- Turkish compile smoke includes `"General" = "Genel";`
- SwiftFormat, oxfmt, and `git diff --check`
- autoreview: no accepted/actionable findings