### PR TITLE
docs(acpx): clarify ACP reasoning controls

### DIFF
--- a/extensions/acpx/skills/acp-router/SKILL.md
+++ b/extensions/acpx/skills/acp-router/SKILL.md
@@ -80,6 +80,11 @@ Required behavior:
 5. Set `agentId` explicitly unless ACP default agent is known.
 6. Do not ask user to run slash commands or CLI when this path works directly.
 
+Runtime controls:
+
+- Pass explicit reasoning effort in `thinking`, separate from `model`. Codex ACP maps `off`, `minimal`, `low`, `medium`, `high`, and `xhigh` to its reasoning control.
+- Do not retry `ACP_BACKEND_UNSUPPORTED_CONTROL` with the same fields. Remove only the rejected optional override or report that the backend cannot honor it.
+
 Example:
 
 User: "spawn a test codex ACP session in thread and tell it to say hi"

--- a/extensions/acpx/skills/acp-router/SKILL.md
+++ b/extensions/acpx/skills/acp-router/SKILL.md
@@ -82,7 +82,7 @@ Required behavior:
 
 Runtime controls:
 
-- Pass explicit reasoning effort in `thinking`, separate from `model`. Codex ACP maps `off`, `minimal`, `low`, `medium`, `high`, and `xhigh` to its reasoning control.
+- Pass explicit reasoning effort in `thinking`, separate from `model`. Codex ACP omits the reasoning override for `off`, maps `minimal` to `low`, and maps `low`, `medium`, `high`, and `xhigh` directly.
 - Do not retry `ACP_BACKEND_UNSUPPORTED_CONTROL` with the same fields. Remove only the rejected optional override or report that the backend cannot honor it.
 
 Example:


### PR DESCRIPTION
Related: #108392

## What Problem This Solves

The ACP routing skill does not explain how to pass reasoning effort or handle an unsupported control. Agents can retry the same rejected field.

## Why This Change Was Made

Document `thinking` as a separate runtime control and stop unchanged retries after `ACP_BACKEND_UNSUPPORTED_CONTROL`.

## User Impact

ACP requests use the backend’s reasoning control or report that it is unsupported.

## Evidence

- `oxfmt 0.58.0 --check extensions/acpx/skills/acp-router/SKILL.md`
- `git diff --check`
- AI-assisted; the five-line change and related runtime behavior were reviewed.
