### PR TITLE
feat(apple): port the working claw indicator, wait phrases, and turn recap to iOS/macOS

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -40531,7 +40531,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 38,
+      "line": 40,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
       "source": "Shelling",
       "surface": "apple",
@@ -40539,7 +40539,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 39,
+      "line": 41,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
       "source": "Scuttling",
       "surface": "apple",
@@ -40547,7 +40547,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 40,
+      "line": 42,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
       "source": "Clawing",
       "surface": "apple",
@@ -40555,7 +40555,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 41,
+      "line": 43,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
       "source": "Pinching",
       "surface": "apple",
@@ -40563,7 +40563,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 42,
+      "line": 44,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
       "source": "Molting",
       "surface": "apple",
@@ -40571,7 +40571,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 43,
+      "line": 45,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
       "source": "Bubbling",
       "surface": "apple",
@@ -40579,7 +40579,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 44,
+      "line": 46,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
       "source": "Tiding",
       "surface": "apple",
@@ -40587,7 +40587,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 45,
+      "line": 47,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
       "source": "Reefing",
       "surface": "apple",
@@ -40595,7 +40595,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 46,
+      "line": 48,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
       "source": "Cracking",
       "surface": "apple",
@@ -40603,7 +40603,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 47,
+      "line": 49,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
       "source": "Sifting",
       "surface": "apple",
@@ -40611,7 +40611,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 48,
+      "line": 50,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
       "source": "Brining",
       "surface": "apple",
@@ -40619,7 +40619,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 49,
+      "line": 51,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
       "source": "Nautiling",
       "surface": "apple",
@@ -40627,7 +40627,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 50,
+      "line": 52,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
       "source": "Krilling",
       "surface": "apple",
@@ -40635,7 +40635,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 51,
+      "line": 53,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
       "source": "Barnacling",
       "surface": "apple",
@@ -40643,7 +40643,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 52,
+      "line": 54,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
       "source": "Lobstering",
       "surface": "apple",
@@ -40651,7 +40651,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 53,
+      "line": 55,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
       "source": "Tidepooling",
       "surface": "apple",
@@ -40659,7 +40659,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 54,
+      "line": 56,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
       "source": "Pearling",
       "surface": "apple",
@@ -40667,7 +40667,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 55,
+      "line": 57,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
       "source": "Snapping",
       "surface": "apple",
@@ -40675,7 +40675,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 56,
+      "line": 58,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
       "source": "Surfacing",
       "surface": "apple",
@@ -40683,7 +40683,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 127,
+      "line": 129,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
       "source": "Done in %@",
       "surface": "apple",
@@ -40691,7 +40691,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 137,
+      "line": 139,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
       "source": "1 token",
       "surface": "apple",
@@ -40699,7 +40699,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 140,
+      "line": 142,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
       "source": "%@ tokens",
       "surface": "apple",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -38747,7 +38747,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 680,
+      "line": 692,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Writing",
       "surface": "apple",
@@ -38755,7 +38755,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 706,
+      "line": 726,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Preparing audio…",
       "surface": "apple",
@@ -38763,7 +38763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 709,
+      "line": 729,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Speaking…",
       "surface": "apple",
@@ -38771,7 +38771,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 717,
+      "line": 737,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Preparing audio, tap to cancel",
       "surface": "apple",
@@ -38779,7 +38779,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 718,
+      "line": 738,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
       "source": "Speaking, tap to stop",
       "surface": "apple",
@@ -39947,7 +39947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 524,
+      "line": 552,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Retry Send",
       "surface": "apple",
@@ -39955,7 +39955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 538,
+      "line": 566,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Delete",
       "surface": "apple",
@@ -39963,7 +39963,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 574,
+      "line": 602,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Stop Listening",
       "surface": "apple",
@@ -39971,7 +39971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 577,
+      "line": 605,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Listen",
       "surface": "apple",
@@ -39979,7 +39979,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 674,
+      "line": 702,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Jump to latest reply",
       "surface": "apple",
@@ -39987,7 +39987,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 694,
+      "line": 722,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Refresh",
       "surface": "apple",
@@ -39995,7 +39995,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1094,
+      "line": 1145,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Copy Message",
       "surface": "apple",
@@ -40003,7 +40003,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1117,
+      "line": 1168,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Open Full Message",
       "surface": "apple",
@@ -40011,7 +40011,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1136,
+      "line": 1187,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Rewind to Here",
       "surface": "apple",
@@ -40019,7 +40019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1156,
+      "line": 1207,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Fork from Here",
       "surface": "apple",
@@ -40027,7 +40027,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1184,
+      "line": 1235,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Reply",
       "surface": "apple",
@@ -40035,7 +40035,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1194,
+      "line": 1245,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "You",
       "surface": "apple",
@@ -40043,7 +40043,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1196,
+      "line": 1247,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Assistant",
       "surface": "apple",
@@ -40051,7 +40051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1262,
+      "line": 1313,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Loading chat",
       "surface": "apple",
@@ -40059,7 +40059,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 1342,
+      "line": 1393,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Dismiss",
       "surface": "apple",
@@ -40123,7 +40123,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 66,
+      "line": 74,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Sending.swift",
       "source": "\\(invocation) ",
       "surface": "apple",
@@ -40131,7 +40131,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 324,
+      "line": 332,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Sending.swift",
       "source": "See attached.",
       "surface": "apple",
@@ -40139,7 +40139,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 735,
+      "line": 743,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Sending.swift",
       "source": "delivery unconfirmed",
       "surface": "apple",
@@ -40147,7 +40147,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 735,
+      "line": 743,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Sending.swift",
       "source": "queued after route change",
       "surface": "apple",
@@ -40528,6 +40528,182 @@
       "source": "Compact Thread",
       "surface": "apple",
       "id": "native.apple.6239ced0b86e86f8"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 38,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
+      "source": "Shelling",
+      "surface": "apple",
+      "id": "native.apple.fb7ba381b79044e1"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 39,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
+      "source": "Scuttling",
+      "surface": "apple",
+      "id": "native.apple.27d2c232c46158f8"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 40,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
+      "source": "Clawing",
+      "surface": "apple",
+      "id": "native.apple.146d26a76f1f661d"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 41,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
+      "source": "Pinching",
+      "surface": "apple",
+      "id": "native.apple.9e590066459c45cf"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 42,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
+      "source": "Molting",
+      "surface": "apple",
+      "id": "native.apple.98bce06ad906ac35"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 43,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
+      "source": "Bubbling",
+      "surface": "apple",
+      "id": "native.apple.0a1991f9ac99e5b2"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 44,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
+      "source": "Tiding",
+      "surface": "apple",
+      "id": "native.apple.693de3befb7eaf8a"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 45,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
+      "source": "Reefing",
+      "surface": "apple",
+      "id": "native.apple.3f77525b4b5bff6e"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 46,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
+      "source": "Cracking",
+      "surface": "apple",
+      "id": "native.apple.e8726dfe7fa3a577"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 47,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
+      "source": "Sifting",
+      "surface": "apple",
+      "id": "native.apple.c861cd13f466af46"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 48,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
+      "source": "Brining",
+      "surface": "apple",
+      "id": "native.apple.c58b34716364e0ef"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 49,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
+      "source": "Nautiling",
+      "surface": "apple",
+      "id": "native.apple.f98d6769fad9ef63"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 50,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
+      "source": "Krilling",
+      "surface": "apple",
+      "id": "native.apple.40dbb800afe19da8"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 51,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
+      "source": "Barnacling",
+      "surface": "apple",
+      "id": "native.apple.e92c5bb2e5342ce6"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 52,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
+      "source": "Lobstering",
+      "surface": "apple",
+      "id": "native.apple.2f27f7676f6a5406"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 53,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
+      "source": "Tidepooling",
+      "surface": "apple",
+      "id": "native.apple.089a07837ab1cce7"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 54,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
+      "source": "Pearling",
+      "surface": "apple",
+      "id": "native.apple.a17076dab69dac74"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 55,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
+      "source": "Snapping",
+      "surface": "apple",
+      "id": "native.apple.5715a7bb435c57e8"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 56,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
+      "source": "Surfacing",
+      "surface": "apple",
+      "id": "native.apple.6fbcf8a03da3315a"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 127,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
+      "source": "Done in %@",
+      "surface": "apple",
+      "id": "native.apple.578503dfeef25502"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 137,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
+      "source": "1 token",
+      "surface": "apple",
+      "id": "native.apple.4fb1ae0d89560d73"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 140,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift",
+      "source": "%@ tokens",
+      "surface": "apple",
+      "id": "native.apple.3f968fd475a91bb1"
     },
     {
       "kind": "ui-call",

--- a/apps/ios/Tests/OpenClawTypographyTests.swift
+++ b/apps/ios/Tests/OpenClawTypographyTests.swift
@@ -220,6 +220,11 @@ struct OpenClawTypographyTests {
                 .deletingLastPathComponent()
                 .appendingPathComponent("shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift"),
             encoding: .utf8)
+        let chatWorkingClawView = try String(
+            contentsOf: Self.iosRootURL()
+                .deletingLastPathComponent()
+                .appendingPathComponent("shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingClawView.swift"),
+            encoding: .utf8)
         let chatMarkdownRenderer = try String(
             contentsOf: Self.iosRootURL()
                 .deletingLastPathComponent()
@@ -378,6 +383,9 @@ struct OpenClawTypographyTests {
         #expect(!chatMessageViews.contains("font: .body"))
         #expect(!chatMessageViews.contains("Font.body"))
         #expect(!chatMessageViews.contains("Font.callout"))
+        #expect(chatWorkingClawView.contains(".font(OpenClawChatTypography.caption)"))
+        #expect(chatWorkingClawView.contains(".font(OpenClawChatTypography.captionSemiBold)"))
+        #expect(!chatWorkingClawView.contains(".font(."))
         #expect(chatMarkdownRenderer.contains(".font(self.font)"))
         #expect(chatTypography
             .contains("Font.custom(self.macSystemFontName(size: size), size: size, relativeTo: textStyle)"))

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift
@@ -664,6 +664,7 @@ struct ChatTypingIndicatorBubble: View {
     let assistantAvatarTint: Color?
     let showsAssistantAvatar: Bool
     let isClean: Bool
+    let runIdentity: String
 
     var body: some View {
         HStack(alignment: .center, spacing: 8) {
@@ -676,10 +677,8 @@ struct ChatTypingIndicatorBubble: View {
             }
 
             HStack(spacing: 9) {
-                TypingDots()
-                Text("Writing")
-                    .font(OpenClawChatTypography.captionSemiBold)
-                    .foregroundStyle(.secondary)
+                ChatWorkingIndicatorContent(runIdentity: self.runIdentity)
+                    .id(self.runIdentity)
             }
             .padding(.vertical, self.isClean ? 5 : (self.style == .standard ? 10 : 9))
             .padding(.horizontal, self.isClean ? 4 : (self.style == .standard ? 12 : 14))
@@ -688,6 +687,27 @@ struct ChatTypingIndicatorBubble: View {
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .focusable(false)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(
+            Text("Writing")
+                .font(OpenClawChatTypography.caption))
+    }
+}
+
+private struct ChatWorkingIndicatorContent: View {
+    @State private var startedAt: Date
+    let seed: String
+
+    init(runIdentity: String) {
+        _startedAt = State(initialValue: Date())
+        self.seed = runIdentity
+    }
+
+    var body: some View {
+        HStack(spacing: 9) {
+            ChatWorkingClawView(seed: self.seed)
+            ChatWorkingStatusText(startedAt: self.startedAt, seed: self.seed)
+        }
     }
 }
 
@@ -790,7 +810,8 @@ extension ChatTypingIndicatorBubble: @MainActor Equatable {
             lhs.assistantName == rhs.assistantName &&
             lhs.assistantAvatarText == rhs.assistantAvatarText &&
             lhs.showsAssistantAvatar == rhs.showsAssistantAvatar &&
-            lhs.isClean == rhs.isClean
+            lhs.isClean == rhs.isClean &&
+            lhs.runIdentity == rhs.runIdentity
     }
 }
 
@@ -903,46 +924,6 @@ struct ChatPendingToolsBubble: View {
 extension ChatPendingToolsBubble: @MainActor Equatable {
     static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.toolCalls == rhs.toolCalls
-    }
-}
-
-@MainActor
-private struct TypingDots: View {
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    @Environment(\.scenePhase) private var scenePhase
-    @State private var animate = false
-
-    var body: some View {
-        HStack(spacing: 5) {
-            ForEach(0..<3, id: \.self) { idx in
-                Circle()
-                    .fill(Color.secondary.opacity(0.55))
-                    .frame(width: 7, height: 7)
-                    .scaleEffect(self.reduceMotion ? 0.85 : (self.animate ? 1.05 : 0.70))
-                    .opacity(self.reduceMotion ? 0.55 : (self.animate ? 0.95 : 0.30))
-                    .animation(
-                        self.reduceMotion ? nil : .easeInOut(duration: 0.55)
-                            .repeatForever(autoreverses: true)
-                            .delay(Double(idx) * 0.16),
-                        value: self.animate)
-            }
-        }
-        .onAppear { self.updateAnimationState() }
-        .onDisappear { self.animate = false }
-        .onChange(of: self.scenePhase) { _, _ in
-            self.updateAnimationState()
-        }
-        .onChange(of: self.reduceMotion) { _, _ in
-            self.updateAnimationState()
-        }
-    }
-
-    private func updateAnimationState() {
-        guard !self.reduceMotion, self.scenePhase == .active else {
-            self.animate = false
-            return
-        }
-        self.animate = true
     }
 }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
@@ -67,6 +67,12 @@ private enum ScrollFollowTarget: Equatable {
     case user(UUID)
 }
 
+private struct ChatTurnRecapObservation: Equatable {
+    let sessionKey: String
+    let indicatorVisible: Bool
+    let row: ChatTurnRecapSessionRow?
+}
+
 public struct OpenClawChatDisplayOptions: OptionSet, Sendable {
     public let rawValue: UInt8
 
@@ -120,6 +126,9 @@ public struct OpenClawChatView: View {
     @State private var isKeyboardVisible = false
     @State private var expandedUserMessageIDs: Set<UUID> = []
     @State private var fullMessageRequest: ChatFullMessageReaderRequest?
+    @State private var turnRecapResolver = ChatTurnRecapResolver()
+    @State private var turnRecap: ChatTurnRecap?
+    @State private var turnRecapSessionKey: String?
     private let showsSessionSwitcher: Bool
     private let drawsBackground: Bool
     private let style: Style
@@ -226,6 +235,9 @@ public struct OpenClawChatView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .onAppear { self.viewModel.load() }
+        .onChange(of: self.turnRecapObservation, initial: true) { _, observation in
+            self.updateTurnRecap(observation)
+        }
         .sheet(item: self.$fullMessageRequest) { request in
             ChatFullMessageReader(
                 request: request,
@@ -246,6 +258,7 @@ public struct OpenClawChatView: View {
                 .padding(.horizontal, Layout.outerPaddingHorizontal)
             self.planPill
                 .padding(.horizontal, Layout.composerPaddingHorizontal)
+            self.turnRecapRow
             self.composer
                 .padding(.horizontal, Layout.composerPaddingHorizontal)
         }
@@ -259,6 +272,7 @@ public struct OpenClawChatView: View {
             self.planPill
                 .padding(.horizontal, Layout.composerPaddingHorizontal)
                 .padding(.top, Layout.stackSpacing)
+            self.turnRecapRow
             self.composer
                 .padding(.horizontal, Layout.composerPaddingHorizontal)
                 .padding(.top, Layout.stackSpacing)
@@ -297,6 +311,19 @@ public struct OpenClawChatView: View {
             talkControl: self.talkControl,
             dictationControl: self.dictationControl,
             voiceNoteControl: self.voiceNoteControl)
+    }
+
+    @ViewBuilder
+    private var turnRecapRow: some View {
+        if !self.showsWorkingIndicator,
+           self.turnRecapSessionKey == self.viewModel.sessionKey,
+           let turnRecap
+        {
+            ChatTurnRecapRow(recap: turnRecap)
+                .padding(.horizontal, Layout.outerPaddingHorizontal + Layout.messageListPaddingHorizontal)
+                .padding(.vertical, 4)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
     }
 
     private var messageList: some View {
@@ -438,14 +465,15 @@ public struct OpenClawChatView: View {
 
         OpenClawQuestionCards(viewModel: self.viewModel)
 
-        if self.viewModel.hasBlockingRunActivity, !self.hasVisibleStreamingAssistantText {
+        if self.showsWorkingIndicator {
             ChatTypingIndicatorBubble(
                 style: self.style,
                 assistantName: self.assistantName,
                 assistantAvatarText: self.assistantAvatarText,
                 assistantAvatarTint: self.assistantAvatarTint,
                 showsAssistantAvatar: self.showsAssistantAvatars,
-                isClean: self.composerChrome == .clean)
+                isClean: self.composerChrome == .clean,
+                runIdentity: self.viewModel.workingIndicatorIdentity)
                 .equatable()
         }
 
@@ -730,6 +758,29 @@ public struct OpenClawChatView: View {
         return AssistantTextParser.hasVisibleContent(
             in: text,
             includeThinking: self.displayOptions.contains(.reasoning))
+    }
+
+    private var showsWorkingIndicator: Bool {
+        self.viewModel.hasBlockingRunActivity && !self.hasVisibleStreamingAssistantText
+    }
+
+    private var turnRecapObservation: ChatTurnRecapObservation {
+        let row = self.viewModel.currentSessionEntry().map(ChatTurnRecapSessionRow.init)
+        return ChatTurnRecapObservation(
+            sessionKey: self.viewModel.sessionKey,
+            indicatorVisible: self.showsWorkingIndicator,
+            row: row)
+    }
+
+    private func updateTurnRecap(_ observation: ChatTurnRecapObservation) {
+        var resolver = self.turnRecapResolver
+        let recap = resolver.resolve(
+            sessionKey: observation.sessionKey,
+            indicatorVisible: observation.indicatorVisible,
+            row: observation.row)
+        self.turnRecapResolver = resolver
+        self.turnRecap = recap
+        self.turnRecapSessionKey = recap == nil ? nil : observation.sessionKey
     }
 
     private var hasVisibleTransientContent: Bool {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Sending.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Sending.swift
@@ -28,6 +28,14 @@ extension OpenClawChatViewModel {
         pendingRunCount > 0 || hasActiveSessionRunWithoutChatSnapshot
     }
 
+    var workingIndicatorIdentity: String {
+        ChatWorkingIdentity.resolve(
+            sessionKey: sessionKey,
+            pendingRunIDs: pendingRuns,
+            localUserMessageIDsByRunID: pendingLocalUserEchoMessageIDsByRunID,
+            fallbackGeneration: runOwnershipGeneration)
+    }
+
     public func send() {
         logDiagnostic(
             "chat.ui send invoked sessionKey=\(sessionKey) "

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingClawView.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingClawView.swift
@@ -1,0 +1,373 @@
+import Foundation
+import SwiftUI
+
+private enum ChatWorkingClawSeed {
+    /// Process lifetime is the native equivalent of the web page-load salt.
+    static let salt = UInt32.random(in: UInt32.min...UInt32.max)
+}
+
+private struct ChatWorkingClawPose {
+    var bodyRotation: CGFloat = 0
+    var jawRotation: CGFloat = -10
+    var xOffset: CGFloat = 0
+    var yOffset: CGFloat = 0
+    var zRotation: CGFloat = 0
+    var yRotation: CGFloat = 0
+    var powOpacity: Double = 0
+    var powScale: CGFloat = 0.4
+
+    static let parked = Self(bodyRotation: 8, jawRotation: -4)
+}
+
+private struct ChatWorkingClawKeyframe {
+    let progress: Double
+    let value: CGFloat
+}
+
+private enum ChatWorkingClawMotion {
+    private static let bodySnips = [
+        ChatWorkingClawKeyframe(progress: 0, value: 0),
+        ChatWorkingClawKeyframe(progress: 0.06, value: 0),
+        ChatWorkingClawKeyframe(progress: 0.10, value: -4),
+        ChatWorkingClawKeyframe(progress: 0.16, value: 3),
+        ChatWorkingClawKeyframe(progress: 0.22, value: -4),
+        ChatWorkingClawKeyframe(progress: 0.26, value: -4),
+        ChatWorkingClawKeyframe(progress: 0.32, value: 3),
+        ChatWorkingClawKeyframe(progress: 0.42, value: 0),
+        ChatWorkingClawKeyframe(progress: 1, value: 0),
+    ]
+    private static let jawSnips = [
+        ChatWorkingClawKeyframe(progress: 0, value: -10),
+        ChatWorkingClawKeyframe(progress: 0.06, value: -10),
+        ChatWorkingClawKeyframe(progress: 0.10, value: -26),
+        ChatWorkingClawKeyframe(progress: 0.16, value: 4),
+        ChatWorkingClawKeyframe(progress: 0.22, value: -24),
+        ChatWorkingClawKeyframe(progress: 0.26, value: -24),
+        ChatWorkingClawKeyframe(progress: 0.32, value: 4),
+        ChatWorkingClawKeyframe(progress: 0.42, value: -10),
+        ChatWorkingClawKeyframe(progress: 1, value: -10),
+    ]
+    private static let comboX = [
+        ChatWorkingClawKeyframe(progress: 0, value: 0),
+        ChatWorkingClawKeyframe(progress: 0.08, value: 0),
+        ChatWorkingClawKeyframe(progress: 0.12, value: -2),
+        ChatWorkingClawKeyframe(progress: 0.16, value: 5),
+        ChatWorkingClawKeyframe(progress: 0.22, value: -2),
+        ChatWorkingClawKeyframe(progress: 0.26, value: -2),
+        ChatWorkingClawKeyframe(progress: 0.30, value: 5),
+        ChatWorkingClawKeyframe(progress: 0.38, value: 0),
+        ChatWorkingClawKeyframe(progress: 0.46, value: -3),
+        ChatWorkingClawKeyframe(progress: 0.52, value: 8),
+        ChatWorkingClawKeyframe(progress: 0.62, value: 0),
+        ChatWorkingClawKeyframe(progress: 1, value: 0),
+    ]
+    private static let comboBodyRotation = [
+        ChatWorkingClawKeyframe(progress: 0, value: 0),
+        ChatWorkingClawKeyframe(progress: 0.38, value: 0),
+        ChatWorkingClawKeyframe(progress: 0.46, value: -6),
+        ChatWorkingClawKeyframe(progress: 0.52, value: 4),
+        ChatWorkingClawKeyframe(progress: 0.62, value: 0),
+        ChatWorkingClawKeyframe(progress: 1, value: 0),
+    ]
+    private static let comboJaw = [
+        ChatWorkingClawKeyframe(progress: 0, value: -10),
+        ChatWorkingClawKeyframe(progress: 0.08, value: -10),
+        ChatWorkingClawKeyframe(progress: 0.12, value: -16),
+        ChatWorkingClawKeyframe(progress: 0.16, value: 4),
+        ChatWorkingClawKeyframe(progress: 0.22, value: -16),
+        ChatWorkingClawKeyframe(progress: 0.26, value: -16),
+        ChatWorkingClawKeyframe(progress: 0.30, value: 4),
+        ChatWorkingClawKeyframe(progress: 0.38, value: -10),
+        ChatWorkingClawKeyframe(progress: 0.46, value: -18),
+        ChatWorkingClawKeyframe(progress: 0.52, value: 6),
+        ChatWorkingClawKeyframe(progress: 0.62, value: -10),
+        ChatWorkingClawKeyframe(progress: 1, value: -10),
+    ]
+    private static let backflipY = [
+        ChatWorkingClawKeyframe(progress: 0, value: 0),
+        ChatWorkingClawKeyframe(progress: 0.55, value: 0),
+        ChatWorkingClawKeyframe(progress: 0.62, value: -3),
+        ChatWorkingClawKeyframe(progress: 0.70, value: -3),
+        ChatWorkingClawKeyframe(progress: 0.78, value: 0),
+        ChatWorkingClawKeyframe(progress: 1, value: 0),
+    ]
+    private static let backflipRotation = [
+        ChatWorkingClawKeyframe(progress: 0, value: 0),
+        ChatWorkingClawKeyframe(progress: 0.55, value: 0),
+        ChatWorkingClawKeyframe(progress: 0.62, value: -120),
+        ChatWorkingClawKeyframe(progress: 0.70, value: -240),
+        ChatWorkingClawKeyframe(progress: 0.78, value: -360),
+        ChatWorkingClawKeyframe(progress: 1, value: -360),
+    ]
+
+    static func pose(stance: ChatWorkingClawStance, elapsed: TimeInterval) -> ChatWorkingClawPose {
+        let duration: TimeInterval = switch stance {
+        case .flurry: 1.3
+        case .spin: 3.6
+        default: 2.4
+        }
+        let progress = max(0, elapsed).truncatingRemainder(dividingBy: duration) / duration
+        var pose = ChatWorkingClawPose()
+        pose.jawRotation = self.sample(self.jawSnips, at: progress)
+
+        switch stance {
+        case .standard, .southpaw, .flurry:
+            pose.bodyRotation = self.sample(self.bodySnips, at: progress)
+        case .spin:
+            pose.yRotation = CGFloat(progress * 360)
+        case .shadowbox:
+            pose.bodyRotation = self.sample(self.comboBodyRotation, at: progress)
+            pose.jawRotation = self.sample(self.comboJaw, at: progress)
+            pose.xOffset = self.sample(self.comboX, at: progress)
+            pose.powOpacity = Double(self.sample(
+                [
+                    .init(progress: 0, value: 0),
+                    .init(progress: 0.46, value: 0),
+                    .init(progress: 0.52, value: 1),
+                    .init(progress: 0.58, value: 0),
+                    .init(progress: 1, value: 0),
+                ],
+                at: progress,
+                eased: false))
+            pose.powScale = self.sample([
+                .init(progress: 0, value: 0.4),
+                .init(progress: 0.46, value: 0.4),
+                .init(progress: 0.52, value: 1.2),
+                .init(progress: 0.58, value: 1.5),
+                .init(progress: 1, value: 1.5),
+            ], at: progress)
+        case .backflip:
+            pose.yOffset = self.sample(self.backflipY, at: progress)
+            pose.zRotation = self.sample(self.backflipRotation, at: progress)
+        }
+        return pose
+    }
+
+    private static func sample(
+        _ frames: [ChatWorkingClawKeyframe],
+        at progress: Double,
+        eased: Bool = true) -> CGFloat
+    {
+        guard let first = frames.first else { return 0 }
+        guard progress > first.progress else { return first.value }
+        for pair in zip(frames, frames.dropFirst()) where progress <= pair.1.progress {
+            let span = pair.1.progress - pair.0.progress
+            let linear = span > 0 ? (progress - pair.0.progress) / span : 1
+            let amount = eased ? 1 - pow(1 - linear, 3) : linear
+            return pair.0.value + (pair.1.value - pair.0.value) * CGFloat(amount)
+        }
+        return frames.last?.value ?? first.value
+    }
+}
+
+struct ChatWorkingClawView: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.scenePhase) private var scenePhase
+    @State private var animationStartedAt = Date()
+
+    let stance: ChatWorkingClawStance
+    var parked = false
+
+    init(seed: String, parked: Bool = false) {
+        self.stance = ChatWorkingClawStance.seeded(seed, salt: ChatWorkingClawSeed.salt)
+        self.parked = parked
+    }
+
+    var body: some View {
+        Group {
+            if self.parked {
+                self.artwork(pose: .parked)
+            } else {
+                TimelineView(.animation(
+                    minimumInterval: 1 / 30,
+                    paused: self.reduceMotion || self.scenePhase != .active))
+                { context in
+                    let pose = self.reduceMotion || self.scenePhase != .active
+                        ? ChatWorkingClawPose()
+                        : ChatWorkingClawMotion.pose(
+                            stance: self.stance,
+                            elapsed: context.date.timeIntervalSince(self.animationStartedAt))
+                    self.artwork(pose: pose)
+                }
+            }
+        }
+        .frame(width: 28, height: 24)
+        .accessibilityHidden(true)
+        .onChange(of: self.scenePhase) { _, phase in
+            if phase == .active {
+                self.animationStartedAt = Date()
+            }
+        }
+        .onChange(of: self.reduceMotion) { _, isReduced in
+            if !isReduced {
+                self.animationStartedAt = Date()
+            }
+        }
+    }
+
+    private func artwork(pose: ChatWorkingClawPose) -> some View {
+        ZStack {
+            ZStack {
+                ChatWorkingClawBodyShape()
+                    .fill(OpenClawChatTheme.accent)
+                ChatWorkingClawJawShape()
+                    .fill(OpenClawChatTheme.accent)
+                    .rotationEffect(
+                        .degrees(pose.jawRotation),
+                        anchor: UnitPoint(x: 8.6 / 24, y: 11 / 24))
+            }
+            .frame(width: 18, height: 18)
+            .rotationEffect(.degrees(pose.bodyRotation + pose.zRotation))
+            .rotation3DEffect(
+                .degrees(pose.yRotation),
+                axis: (x: 0, y: 1, z: 0),
+                perspective: 0.45)
+            .offset(x: pose.xOffset, y: pose.yOffset)
+            .scaleEffect(x: !self.parked && self.stance == .southpaw ? -1 : 1, y: 1)
+
+            if pose.powOpacity > 0 {
+                Text("✦")
+                    .font(OpenClawChatTypography.caption)
+                    .foregroundStyle(OpenClawChatTheme.accent)
+                    .scaleEffect(pose.powScale)
+                    .opacity(pose.powOpacity)
+                    .offset(x: 14, y: -7)
+                    .accessibilityHidden(true)
+            }
+        }
+    }
+}
+
+private struct ChatWorkingClawBodyShape: Shape {
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        path.addEllipse(in: CGRect(x: 4, y: 9.2, width: 11.2, height: 11.2))
+        path.move(to: CGPoint(x: 10, y: 20))
+        path.addCurve(
+            to: CGPoint(x: 20.1, y: 16.1),
+            control1: CGPoint(x: 14, y: 20.9),
+            control2: CGPoint(x: 17.9, y: 19.5))
+        path.addCurve(
+            to: CGPoint(x: 19.25, y: 14.65),
+            control1: CGPoint(x: 20.6, y: 15.4),
+            control2: CGPoint(x: 20.05, y: 14.5))
+        path.addCurve(
+            to: CGPoint(x: 13.2, y: 13),
+            control1: CGPoint(x: 17.1, y: 15),
+            control2: CGPoint(x: 14.9, y: 14.4))
+        path.addLine(to: CGPoint(x: 10.6, y: 16))
+        path.closeSubpath()
+        return path.applying(self.transform(for: rect))
+    }
+
+    private func transform(for rect: CGRect) -> CGAffineTransform {
+        let scale = min(rect.width, rect.height) / 24
+        return CGAffineTransform(
+            a: scale,
+            b: 0,
+            c: 0,
+            d: scale,
+            tx: rect.midX - 12 * scale,
+            ty: rect.midY - 12 * scale)
+    }
+}
+
+private struct ChatWorkingClawJawShape: Shape {
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        path.move(to: CGPoint(x: 6, y: 10.6))
+        path.addCurve(
+            to: CGPoint(x: 17.6, y: 2.8),
+            control1: CGPoint(x: 6.6, y: 4.4),
+            control2: CGPoint(x: 12.4, y: 0.8))
+        path.addCurve(
+            to: CGPoint(x: 23, y: 9.8),
+            control1: CGPoint(x: 20.8, y: 4),
+            control2: CGPoint(x: 22.8, y: 6.8))
+        path.addCurve(
+            to: CGPoint(x: 21.1, y: 10.7),
+            control1: CGPoint(x: 23.07, y: 10.9),
+            control2: CGPoint(x: 21.9, y: 11.4))
+        path.addCurve(
+            to: CGPoint(x: 14.7, y: 9.5),
+            control1: CGPoint(x: 19.4, y: 9.2),
+            control2: CGPoint(x: 16.9, y: 8.7))
+        path.addCurve(
+            to: CGPoint(x: 11.6, y: 12.1),
+            control1: CGPoint(x: 13.4, y: 10),
+            control2: CGPoint(x: 12.3, y: 10.9))
+        path.addLine(to: CGPoint(x: 7.2, y: 12.4))
+        path.closeSubpath()
+        let scale = min(rect.width, rect.height) / 24
+        return path.applying(CGAffineTransform(
+            a: scale,
+            b: 0,
+            c: 0,
+            d: scale,
+            tx: rect.midX - 12 * scale,
+            ty: rect.midY - 12 * scale))
+    }
+}
+
+struct ChatWorkingStatusText: View {
+    @Environment(\.scenePhase) private var scenePhase
+
+    let startedAt: Date
+    let seed: String
+
+    var body: some View {
+        Group {
+            if self.scenePhase == .active {
+                TimelineView(.periodic(from: self.startedAt, by: 1)) { context in
+                    self.label(at: context.date)
+                }
+            } else {
+                self.label(at: Date())
+            }
+        }
+        .foregroundStyle(.secondary)
+    }
+
+    private func label(at date: Date) -> some View {
+        let elapsedMilliseconds = max(1000, Int(date.timeIntervalSince(self.startedAt) * 1000))
+        let duration = ChatWorkingDurationFormatter.compact(milliseconds: Double(elapsedMilliseconds))
+        return HStack(alignment: .firstTextBaseline, spacing: 5) {
+            Text(duration)
+                .font(OpenClawChatTypography.captionSemiBold)
+                .monospacedDigit()
+            if let index = ChatWorkingPhrase.index(
+                seed: self.seed,
+                elapsedMilliseconds: elapsedMilliseconds)
+            {
+                HStack(alignment: .firstTextBaseline, spacing: 5) {
+                    Text("·")
+                        .font(OpenClawChatTypography.caption)
+                    Text(String(localized: ChatWorkingPhrase.resources[index]) + "…")
+                        .font(OpenClawChatTypography.caption)
+                }
+                .accessibilityHidden(true)
+            }
+        }
+    }
+}
+
+struct ChatTurnRecapRow: View {
+    let recap: ChatTurnRecap
+
+    var body: some View {
+        HStack(spacing: 7) {
+            ChatWorkingClawView(seed: "turn-recap", parked: true)
+            Text(ChatTurnRecapText.done(runtimeMs: self.recap.runtimeMs))
+                .font(OpenClawChatTypography.caption)
+            if let tokensText = ChatTurnRecapText.tokens(self.recap.outputTokens) {
+                Text("·")
+                    .font(OpenClawChatTypography.caption)
+                    .accessibilityHidden(true)
+                Text(tokensText)
+                    .font(OpenClawChatTypography.caption)
+            }
+        }
+        .foregroundStyle(.secondary)
+        .accessibilityElement(children: .combine)
+    }
+}

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingClawView.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingClawView.swift
@@ -342,7 +342,7 @@ struct ChatWorkingStatusText: View {
                 HStack(alignment: .firstTextBaseline, spacing: 5) {
                     Text("·")
                         .font(OpenClawChatTypography.caption)
-                    Text(String(localized: ChatWorkingPhrase.resources[index]) + "…")
+                    Text(ChatWorkingPhrase.resources[index] + "…")
                         .font(OpenClawChatTypography.caption)
                 }
                 .accessibilityHidden(true)

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift
@@ -34,8 +34,8 @@ enum ChatWorkingPhrase {
     static let showAfterMilliseconds = 30000
     static let rotateEveryMilliseconds = 45000
 
-    // Keep source phrases localizable; the post-merge native locale refresh
-    // owns the generated catalog entries.
+    /// Keep source phrases localizable; the post-merge native locale refresh
+    /// owns the generated catalog entries.
     static let resources: [String] = [
         String(localized: "Shelling"),
         String(localized: "Scuttling"),

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift
@@ -35,25 +35,25 @@ enum ChatWorkingPhrase {
     static let rotateEveryMilliseconds = 45000
 
     static let resources: [LocalizedStringResource] = [
-        "Shelling",
-        "Scuttling",
-        "Clawing",
-        "Pinching",
-        "Molting",
-        "Bubbling",
-        "Tiding",
-        "Reefing",
-        "Cracking",
-        "Sifting",
-        "Brining",
-        "Nautiling",
-        "Krilling",
-        "Barnacling",
-        "Lobstering",
-        "Tidepooling",
-        "Pearling",
-        "Snapping",
-        "Surfacing",
+        LocalizedStringResource("Shelling"),
+        LocalizedStringResource("Scuttling"),
+        LocalizedStringResource("Clawing"),
+        LocalizedStringResource("Pinching"),
+        LocalizedStringResource("Molting"),
+        LocalizedStringResource("Bubbling"),
+        LocalizedStringResource("Tiding"),
+        LocalizedStringResource("Reefing"),
+        LocalizedStringResource("Cracking"),
+        LocalizedStringResource("Sifting"),
+        LocalizedStringResource("Brining"),
+        LocalizedStringResource("Nautiling"),
+        LocalizedStringResource("Krilling"),
+        LocalizedStringResource("Barnacling"),
+        LocalizedStringResource("Lobstering"),
+        LocalizedStringResource("Tidepooling"),
+        LocalizedStringResource("Pearling"),
+        LocalizedStringResource("Snapping"),
+        LocalizedStringResource("Surfacing"),
     ]
 
     /// A constant-time stride walk keeps adjacent phrases distinct. The prime
@@ -99,9 +99,48 @@ enum ChatWorkingDurationFormatter {
     }
 }
 
+enum ChatWorkingIdentity {
+    static func resolve(
+        sessionKey: String,
+        pendingRunIDs: Set<String>,
+        localUserMessageIDsByRunID: [String: UUID],
+        fallbackGeneration: UInt64) -> String
+    {
+        if let messageID = pendingRunIDs.compactMap({ localUserMessageIDsByRunID[$0]?.uuidString }).min() {
+            return "\(sessionKey):user:\(messageID)"
+        }
+        if let runID = pendingRunIDs.min() {
+            return "\(sessionKey):run:\(runID)"
+        }
+        return "\(sessionKey):generation:\(fallbackGeneration)"
+    }
+}
+
 struct ChatTurnRecap: Equatable, Sendable {
     let runtimeMs: Double
     let outputTokens: Int?
+}
+
+enum ChatTurnRecapText {
+    static func done(runtimeMs: Double, locale: Locale = .current) -> String {
+        String(
+            format: String(localized: "Done in %@", locale: locale),
+            locale: locale,
+            ChatWorkingDurationFormatter.compact(milliseconds: runtimeMs))
+    }
+
+    static func tokens(_ outputTokens: Int?, locale: Locale = .current) -> String? {
+        guard let outputTokens else { return nil }
+        // Mirrors the web and American-English source contract: exactly one
+        // uses the singular key; zero and every other count use the generic key.
+        if outputTokens == 1 {
+            return String(localized: "1 token", locale: locale)
+        }
+        return String(
+            format: String(localized: "%@ tokens", locale: locale),
+            locale: locale,
+            outputTokens.formatted(.number.locale(locale)))
+    }
 }
 
 struct ChatTurnRecapSessionRow: Equatable, Sendable {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift
@@ -34,26 +34,28 @@ enum ChatWorkingPhrase {
     static let showAfterMilliseconds = 30000
     static let rotateEveryMilliseconds = 45000
 
-    static let resources: [LocalizedStringResource] = [
-        LocalizedStringResource("Shelling"),
-        LocalizedStringResource("Scuttling"),
-        LocalizedStringResource("Clawing"),
-        LocalizedStringResource("Pinching"),
-        LocalizedStringResource("Molting"),
-        LocalizedStringResource("Bubbling"),
-        LocalizedStringResource("Tiding"),
-        LocalizedStringResource("Reefing"),
-        LocalizedStringResource("Cracking"),
-        LocalizedStringResource("Sifting"),
-        LocalizedStringResource("Brining"),
-        LocalizedStringResource("Nautiling"),
-        LocalizedStringResource("Krilling"),
-        LocalizedStringResource("Barnacling"),
-        LocalizedStringResource("Lobstering"),
-        LocalizedStringResource("Tidepooling"),
-        LocalizedStringResource("Pearling"),
-        LocalizedStringResource("Snapping"),
-        LocalizedStringResource("Surfacing"),
+    // Keep source phrases localizable; the post-merge native locale refresh
+    // owns the generated catalog entries.
+    static let resources: [String] = [
+        String(localized: "Shelling"),
+        String(localized: "Scuttling"),
+        String(localized: "Clawing"),
+        String(localized: "Pinching"),
+        String(localized: "Molting"),
+        String(localized: "Bubbling"),
+        String(localized: "Tiding"),
+        String(localized: "Reefing"),
+        String(localized: "Cracking"),
+        String(localized: "Sifting"),
+        String(localized: "Brining"),
+        String(localized: "Nautiling"),
+        String(localized: "Krilling"),
+        String(localized: "Barnacling"),
+        String(localized: "Lobstering"),
+        String(localized: "Tidepooling"),
+        String(localized: "Pearling"),
+        String(localized: "Snapping"),
+        String(localized: "Surfacing"),
     ]
 
     /// A constant-time stride walk keeps adjacent phrases distinct. The prime

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift
@@ -1,0 +1,234 @@
+import Foundation
+
+enum ChatWorkingClawStance: CaseIterable, Equatable, Sendable {
+    case standard
+    case southpaw
+    case flurry
+    case spin
+    case shadowbox
+    case backflip
+
+    private static let weightedStances: [(stance: Self, weight: Double)] = [
+        (.standard, 66),
+        (.southpaw, 20),
+        (.flurry, 5),
+        (.spin, 4),
+        (.shadowbox, 3),
+        (.backflip, 2),
+    ]
+
+    static func seeded(_ key: String, salt: UInt32) -> Self {
+        let totalWeight = self.weightedStances.reduce(0) { $0 + $1.weight }
+        var roll = Double((fnv1a(key) ^ salt) % 1000) / 1000 * totalWeight
+        for entry in self.weightedStances {
+            roll -= entry.weight
+            if roll <= 0 {
+                return entry.stance
+            }
+        }
+        return .standard
+    }
+}
+
+enum ChatWorkingPhrase {
+    static let showAfterMilliseconds = 30000
+    static let rotateEveryMilliseconds = 45000
+
+    static let resources: [LocalizedStringResource] = [
+        "Shelling",
+        "Scuttling",
+        "Clawing",
+        "Pinching",
+        "Molting",
+        "Bubbling",
+        "Tiding",
+        "Reefing",
+        "Cracking",
+        "Sifting",
+        "Brining",
+        "Nautiling",
+        "Krilling",
+        "Barnacling",
+        "Lobstering",
+        "Tidepooling",
+        "Pearling",
+        "Snapping",
+        "Surfacing",
+    ]
+
+    /// A constant-time stride walk keeps adjacent phrases distinct. The prime
+    /// list length makes every non-zero stride visit all phrases before repeating.
+    static func index(seed: String, elapsedMilliseconds: Int) -> Int? {
+        guard elapsedMilliseconds >= self.showAfterMilliseconds else { return nil }
+        let bucket = (elapsedMilliseconds - self.showAfterMilliseconds) / self.rotateEveryMilliseconds
+        return self.index(seed: seed, bucket: bucket)
+    }
+
+    static func index(seed: String, bucket: Int) -> Int {
+        let count = self.resources.count
+        let offset = Int(fnv1a("\(seed):offset") % UInt32(count))
+        let stride = 1 + Int(fnv1a("\(seed):stride") % UInt32(count - 1))
+        return (offset + bucket * stride) % count
+    }
+}
+
+enum ChatWorkingDurationFormatter {
+    static func compact(milliseconds: Double) -> String {
+        let finiteMilliseconds = milliseconds.isFinite ? milliseconds : 1000
+        let roundedSeconds = (max(1000, finiteMilliseconds) / 1000).rounded()
+        let totalSeconds = max(1, Int(min(roundedSeconds, Double(Int.max / 2))))
+        let units = [
+            (suffix: "d", seconds: 86400),
+            (suffix: "h", seconds: 3600),
+            (suffix: "m", seconds: 60),
+            (suffix: "s", seconds: 1),
+        ]
+        var remainder = totalSeconds
+        var parts: [String] = []
+        for unit in units {
+            let value = remainder / unit.seconds
+            remainder %= unit.seconds
+            if value > 0 {
+                parts.append("\(value)\(unit.suffix)")
+            }
+            if parts.count == 2 {
+                break
+            }
+        }
+        return parts.joined(separator: " ")
+    }
+}
+
+struct ChatTurnRecap: Equatable, Sendable {
+    let runtimeMs: Double
+    let outputTokens: Int?
+}
+
+struct ChatTurnRecapSessionRow: Equatable, Sendable {
+    let status: String?
+    let endedAt: Double?
+    let runtimeMs: Double?
+    let outputTokens: Int?
+
+    init(
+        status: String? = nil,
+        endedAt: Double? = nil,
+        runtimeMs: Double? = nil,
+        outputTokens: Int? = nil)
+    {
+        self.status = status
+        self.endedAt = endedAt
+        self.runtimeMs = runtimeMs
+        self.outputTokens = outputTokens
+    }
+
+    init(_ entry: OpenClawChatSessionEntry) {
+        self.init(
+            status: entry.status,
+            endedAt: entry.endedAt,
+            runtimeMs: entry.runtimeMs,
+            outputTokens: entry.outputTokens)
+    }
+}
+
+/// Watches the turn whose working indicator was visible. Most anomalous
+/// interleavings fail quiet; without a row run ID, an unrelated completion
+/// inside the settle window remains an accepted cosmetic attribution risk.
+struct ChatTurnRecapResolver {
+    private struct Watch {
+        var watching: Bool
+        var baselineKnown: Bool
+        var baselineEndedAt: Double?
+        var absorbedTerminal: Bool
+        var settleStartedAt: Date?
+        var settled: ChatTurnRecap?
+    }
+
+    private static let settleWindow: TimeInterval = 30
+    private var watches: [String: Watch] = [:]
+
+    mutating func resolve(
+        sessionKey: String,
+        indicatorVisible: Bool,
+        row: ChatTurnRecapSessionRow?,
+        now: Date = Date()) -> ChatTurnRecap?
+    {
+        var watch = self.watches[sessionKey]
+        let rowEndedAt = row?.endedAt
+
+        if indicatorVisible {
+            if watch == nil || watch?.watching == false {
+                watch = Watch(
+                    watching: true,
+                    baselineKnown: row != nil,
+                    baselineEndedAt: rowEndedAt,
+                    absorbedTerminal: false,
+                    settleStartedAt: nil,
+                    settled: nil)
+            } else if watch?.baselineKnown == false {
+                if row != nil {
+                    watch?.baselineKnown = true
+                    watch?.baselineEndedAt = rowEndedAt
+                }
+            } else if let rowEndedAt, rowEndedAt != watch?.baselineEndedAt {
+                watch?.baselineEndedAt = rowEndedAt
+                watch?.absorbedTerminal = true
+            }
+            self.watches[sessionKey] = watch
+            return nil
+        }
+
+        guard var watch else { return nil }
+        watch.watching = false
+        if let settled = watch.settled {
+            self.watches[sessionKey] = watch
+            return settled
+        }
+        if watch.absorbedTerminal || !watch.baselineKnown {
+            // Without an attributable baseline, later terminal rows could belong
+            // to background work, so consume this watch unresolved.
+            self.watches[sessionKey] = nil
+            return nil
+        }
+        if let settleStartedAt = watch.settleStartedAt {
+            if now.timeIntervalSince(settleStartedAt) > Self.settleWindow {
+                self.watches[sessionKey] = nil
+                return nil
+            }
+        } else {
+            watch.settleStartedAt = now
+        }
+
+        let isStale: Bool = if let rowEndedAt, let baselineEndedAt = watch.baselineEndedAt {
+            rowEndedAt <= baselineEndedAt
+        } else {
+            rowEndedAt == nil
+        }
+        if isStale {
+            // Terminal stamps are monotonic. Equality and regression both mean
+            // the watched run's terminal patch has not arrived yet.
+            self.watches[sessionKey] = watch
+            return nil
+        }
+
+        // Any fresh terminal concludes the watch. Only clean done rows with a
+        // finite runtime produce a recap; waiting longer could attach another run.
+        self.watches[sessionKey] = nil
+        guard row?.status == "done", let runtimeMs = row?.runtimeMs, runtimeMs.isFinite else {
+            return nil
+        }
+        let settled = ChatTurnRecap(runtimeMs: runtimeMs, outputTokens: row?.outputTokens)
+        watch.settled = settled
+        self.watches[sessionKey] = watch
+        return settled
+    }
+}
+
+private func fnv1a(_ key: String) -> UInt32 {
+    var hash: UInt32 = 0x811C_9DC5
+    for codeUnit in key.utf16 {
+        hash ^= UInt32(codeUnit)
+        hash = hash &* 0x0100_0193
+    }
+    return hash
+}

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatWorkingProgressTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatWorkingProgressTests.swift
@@ -1,0 +1,290 @@
+import Foundation
+import Testing
+@testable import OpenClawChatUI
+
+struct ChatWorkingProgressTests {
+    private let session = "agent:main:main"
+    private let previousEndedAt = 900_000.0
+    private let runEndedAt = 1_000_000.0
+
+    @Test func `stance selection is deterministic for a run and salt`() {
+        let salt: UInt32 = 0xA1B2_C3D4
+        let run = "run-4c71b7e8"
+        let first = ChatWorkingClawStance.seeded(run, salt: salt)
+        #expect(first == ChatWorkingClawStance.seeded(run, salt: salt))
+        #expect(first == .southpaw)
+        #expect(ChatWorkingClawStance.seeded("run-a", salt: salt) == .standard)
+        #expect(ChatWorkingClawStance.seeded("run-8", salt: salt) == .spin)
+    }
+
+    @Test func `phrase rotation keeps adjacent buckets distinct and visits the full list`() {
+        let indices = (0..<ChatWorkingPhrase.resources.count).map {
+            ChatWorkingPhrase.index(seed: "run-phrase-seed", bucket: $0)
+        }
+        #expect(Set(indices).count == ChatWorkingPhrase.resources.count)
+        for pair in zip(indices, indices.dropFirst()) {
+            #expect(pair.0 != pair.1)
+        }
+        #expect(ChatWorkingPhrase.index(seed: "run-phrase-seed", elapsedMilliseconds: 29999) == nil)
+        #expect(ChatWorkingPhrase.index(seed: "run-phrase-seed", elapsedMilliseconds: 30000) == indices[0])
+        #expect(ChatWorkingPhrase.index(seed: "run-phrase-seed", elapsedMilliseconds: 75000) == indices[1])
+    }
+
+    @Test func `compact duration clamps and keeps two meaningful units`() {
+        #expect(ChatWorkingDurationFormatter.compact(milliseconds: 0) == "1s")
+        #expect(ChatWorkingDurationFormatter.compact(milliseconds: 51000) == "51s")
+        #expect(ChatWorkingDurationFormatter.compact(milliseconds: 90000) == "1m 30s")
+        #expect(ChatWorkingDurationFormatter.compact(milliseconds: 3_601_000) == "1h 1s")
+        #expect(!ChatWorkingDurationFormatter.compact(milliseconds: 1e30).isEmpty)
+    }
+
+    @Test func `recap resolves on a fresh terminal then sticks`() {
+        var resolver = ChatTurnRecapResolver()
+        #expect(resolver.resolve(
+            sessionKey: self.session,
+            indicatorVisible: true,
+            row: self.doneRow(self.previousEndedAt)) == nil)
+        #expect(resolver.resolve(
+            sessionKey: self.session,
+            indicatorVisible: false,
+            row: self.doneRow(self.previousEndedAt)) == nil)
+        let row = self.doneRow(self.runEndedAt, runtimeMs: 51000, outputTokens: 485)
+        let recap = ChatTurnRecap(runtimeMs: 51000, outputTokens: 485)
+        #expect(resolver.resolve(sessionKey: self.session, indicatorVisible: false, row: row) == recap)
+        #expect(resolver.resolve(sessionKey: self.session, indicatorVisible: false, row: row) == recap)
+    }
+
+    @Test func `recap rejects stale and regressed terminal stamps`() {
+        var resolver = ChatTurnRecapResolver()
+        _ = resolver.resolve(
+            sessionKey: self.session,
+            indicatorVisible: true,
+            row: self.doneRow(self.previousEndedAt))
+        #expect(resolver.resolve(
+            sessionKey: self.session,
+            indicatorVisible: false,
+            row: self.doneRow(self.previousEndedAt)) == nil)
+        #expect(resolver.resolve(
+            sessionKey: self.session,
+            indicatorVisible: false,
+            row: self.doneRow(self.previousEndedAt - 5000)) == nil)
+    }
+
+    @Test func `recap expires an unresolved watch`() {
+        var resolver = ChatTurnRecapResolver()
+        let start = Date(timeIntervalSince1970: 1000)
+        _ = resolver.resolve(
+            sessionKey: self.session,
+            indicatorVisible: true,
+            row: self.doneRow(self.previousEndedAt),
+            now: start)
+        #expect(resolver.resolve(
+            sessionKey: self.session,
+            indicatorVisible: false,
+            row: self.doneRow(self.previousEndedAt),
+            now: start) == nil)
+        #expect(resolver.resolve(
+            sessionKey: self.session,
+            indicatorVisible: false,
+            row: self.doneRow(self.previousEndedAt),
+            now: start.addingTimeInterval(31)) == nil)
+        #expect(resolver.resolve(
+            sessionKey: self.session,
+            indicatorVisible: false,
+            row: self.doneRow(self.runEndedAt),
+            now: start.addingTimeInterval(60)) == nil)
+    }
+
+    @Test func `recap consumes a fresh done row without runtime`() {
+        var resolver = ChatTurnRecapResolver()
+        _ = resolver.resolve(
+            sessionKey: self.session,
+            indicatorVisible: true,
+            row: self.doneRow(self.previousEndedAt))
+        #expect(resolver.resolve(
+            sessionKey: self.session,
+            indicatorVisible: false,
+            row: ChatTurnRecapSessionRow(status: "done", endedAt: self.runEndedAt)) == nil)
+        #expect(resolver.resolve(
+            sessionKey: self.session,
+            indicatorVisible: false,
+            row: self.doneRow(self.runEndedAt + 1000)) == nil)
+    }
+
+    @Test func `recap accepts a cleared run-start baseline`() {
+        var resolver = ChatTurnRecapResolver()
+        #expect(resolver.resolve(
+            sessionKey: self.session,
+            indicatorVisible: true,
+            row: ChatTurnRecapSessionRow(status: "running")) == nil)
+        #expect(resolver.resolve(
+            sessionKey: self.session,
+            indicatorVisible: false,
+            row: self.doneRow(self.runEndedAt, runtimeMs: 2000)) ==
+            ChatTurnRecap(runtimeMs: 2000, outputTokens: nil))
+    }
+
+    @Test func `recap never resolves without watching an indicator`() {
+        var resolver = ChatTurnRecapResolver()
+        #expect(resolver.resolve(
+            sessionKey: self.session,
+            indicatorVisible: false,
+            row: self.doneRow(self.runEndedAt)) == nil)
+    }
+
+    @Test func `recap consumes a watch whose baseline was never observed`() {
+        var resolver = ChatTurnRecapResolver()
+        #expect(resolver.resolve(
+            sessionKey: self.session,
+            indicatorVisible: true,
+            row: nil) == nil)
+        #expect(resolver.resolve(
+            sessionKey: self.session,
+            indicatorVisible: false,
+            row: self.doneRow(self.previousEndedAt)) == nil)
+        #expect(resolver.resolve(
+            sessionKey: self.session,
+            indicatorVisible: false,
+            row: self.doneRow(self.runEndedAt)) == nil)
+    }
+
+    @Test func `recap adopts the first row observed mid-watch`() {
+        var resolver = ChatTurnRecapResolver()
+        _ = resolver.resolve(sessionKey: self.session, indicatorVisible: true, row: nil)
+        _ = resolver.resolve(
+            sessionKey: self.session,
+            indicatorVisible: true,
+            row: self.doneRow(self.previousEndedAt))
+        #expect(resolver.resolve(
+            sessionKey: self.session,
+            indicatorVisible: false,
+            row: self.doneRow(self.previousEndedAt)) == nil)
+        #expect(resolver.resolve(
+            sessionKey: self.session,
+            indicatorVisible: false,
+            row: self.doneRow(self.runEndedAt, runtimeMs: 6000)) ==
+            ChatTurnRecap(runtimeMs: 6000, outputTokens: nil))
+    }
+
+    @Test func `recap forfeits when a terminal stamp changes mid-watch`() {
+        var resolver = ChatTurnRecapResolver()
+        _ = resolver.resolve(
+            sessionKey: self.session,
+            indicatorVisible: true,
+            row: ChatTurnRecapSessionRow(status: "running"))
+        _ = resolver.resolve(
+            sessionKey: self.session,
+            indicatorVisible: true,
+            row: self.doneRow(self.previousEndedAt))
+        #expect(resolver.resolve(
+            sessionKey: self.session,
+            indicatorVisible: false,
+            row: self.doneRow(self.previousEndedAt)) == nil)
+        #expect(resolver.resolve(
+            sessionKey: self.session,
+            indicatorVisible: false,
+            row: self.doneRow(self.runEndedAt, runtimeMs: 4000)) == nil)
+    }
+
+    @Test func `recap forfeits a failed turn that races the indicator`() {
+        var resolver = ChatTurnRecapResolver()
+        _ = resolver.resolve(
+            sessionKey: self.session,
+            indicatorVisible: true,
+            row: ChatTurnRecapSessionRow(status: "running"))
+        _ = resolver.resolve(
+            sessionKey: self.session,
+            indicatorVisible: true,
+            row: ChatTurnRecapSessionRow(status: "failed", endedAt: self.runEndedAt))
+        #expect(resolver.resolve(
+            sessionKey: self.session,
+            indicatorVisible: false,
+            row: ChatTurnRecapSessionRow(status: "failed", endedAt: self.runEndedAt)) == nil)
+        #expect(resolver.resolve(
+            sessionKey: self.session,
+            indicatorVisible: false,
+            row: self.doneRow(self.runEndedAt + 60000)) == nil)
+    }
+
+    @Test func `recap freezes against later unwatched terminals`() {
+        var resolver = ChatTurnRecapResolver()
+        _ = resolver.resolve(
+            sessionKey: self.session,
+            indicatorVisible: true,
+            row: self.doneRow(self.previousEndedAt))
+        let settled = resolver.resolve(
+            sessionKey: self.session,
+            indicatorVisible: false,
+            row: self.doneRow(self.runEndedAt, runtimeMs: 51000, outputTokens: 485))
+        #expect(settled == ChatTurnRecap(runtimeMs: 51000, outputTokens: 485))
+        #expect(resolver.resolve(
+            sessionKey: self.session,
+            indicatorVisible: false,
+            row: self.doneRow(self.runEndedAt + 90000, runtimeMs: 7000, outputTokens: 42)) == settled)
+    }
+
+    @Test func `recap hides when the next indicator appears`() {
+        var resolver = ChatTurnRecapResolver()
+        _ = resolver.resolve(
+            sessionKey: self.session,
+            indicatorVisible: true,
+            row: self.doneRow(self.previousEndedAt))
+        #expect(resolver.resolve(
+            sessionKey: self.session,
+            indicatorVisible: false,
+            row: self.doneRow(self.runEndedAt)) != nil)
+        #expect(resolver.resolve(
+            sessionKey: self.session,
+            indicatorVisible: true,
+            row: self.doneRow(self.runEndedAt)) == nil)
+        #expect(resolver.resolve(
+            sessionKey: self.session,
+            indicatorVisible: false,
+            row: self.doneRow(self.runEndedAt)) == nil)
+    }
+
+    @Test func `recap ignores stale failure rows`() {
+        var resolver = ChatTurnRecapResolver()
+        _ = resolver.resolve(
+            sessionKey: self.session,
+            indicatorVisible: true,
+            row: ChatTurnRecapSessionRow(status: "failed", endedAt: self.previousEndedAt))
+        #expect(resolver.resolve(
+            sessionKey: self.session,
+            indicatorVisible: false,
+            row: ChatTurnRecapSessionRow(status: "failed", endedAt: self.previousEndedAt)) == nil)
+        #expect(resolver.resolve(
+            sessionKey: self.session,
+            indicatorVisible: false,
+            row: self.doneRow(self.runEndedAt, runtimeMs: 3000)) ==
+            ChatTurnRecap(runtimeMs: 3000, outputTokens: nil))
+    }
+
+    @Test func `recap consumes a fresh failed row`() {
+        var resolver = ChatTurnRecapResolver()
+        _ = resolver.resolve(
+            sessionKey: self.session,
+            indicatorVisible: true,
+            row: self.doneRow(self.previousEndedAt))
+        #expect(resolver.resolve(
+            sessionKey: self.session,
+            indicatorVisible: false,
+            row: ChatTurnRecapSessionRow(status: "failed", endedAt: self.runEndedAt)) == nil)
+        #expect(resolver.resolve(
+            sessionKey: self.session,
+            indicatorVisible: false,
+            row: self.doneRow(self.runEndedAt + 1000)) == nil)
+    }
+
+    private func doneRow(
+        _ endedAt: Double,
+        runtimeMs: Double = 51000,
+        outputTokens: Int? = nil) -> ChatTurnRecapSessionRow
+    {
+        ChatTurnRecapSessionRow(
+            status: "done",
+            endedAt: endedAt,
+            runtimeMs: runtimeMs,
+            outputTokens: outputTokens)
+    }
+}

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatWorkingProgressTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatWorkingProgressTests.swift
@@ -59,6 +59,30 @@ struct ChatWorkingProgressTests {
         #expect(ChatWorkingPhrase.index(seed: "run-phrase-seed", elapsedMilliseconds: 75000) == indices[1])
     }
 
+    @Test func `working phrases keep English defaults without a generated catalog`() {
+        #expect(ChatWorkingPhrase.resources == [
+            "Shelling",
+            "Scuttling",
+            "Clawing",
+            "Pinching",
+            "Molting",
+            "Bubbling",
+            "Tiding",
+            "Reefing",
+            "Cracking",
+            "Sifting",
+            "Brining",
+            "Nautiling",
+            "Krilling",
+            "Barnacling",
+            "Lobstering",
+            "Tidepooling",
+            "Pearling",
+            "Snapping",
+            "Surfacing",
+        ])
+    }
+
     @Test func `compact duration clamps and keeps two meaningful units`() {
         #expect(ChatWorkingDurationFormatter.compact(milliseconds: 0) == "1s")
         #expect(ChatWorkingDurationFormatter.compact(milliseconds: 51000) == "51s")

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatWorkingProgressTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatWorkingProgressTests.swift
@@ -17,6 +17,35 @@ struct ChatWorkingProgressTests {
         #expect(ChatWorkingClawStance.seeded("run-8", salt: salt) == .spin)
     }
 
+    @Test func `working identity survives run rekey but resets for turn and session`() throws {
+        let messageID = try #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"))
+        let nextMessageID = try #require(UUID(uuidString: "11111111-2222-3333-4444-555555555555"))
+        let local = ChatWorkingIdentity.resolve(
+            sessionKey: self.session,
+            pendingRunIDs: ["local-run"],
+            localUserMessageIDsByRunID: ["local-run": messageID],
+            fallbackGeneration: 1)
+        let remote = ChatWorkingIdentity.resolve(
+            sessionKey: self.session,
+            pendingRunIDs: ["remote-run"],
+            localUserMessageIDsByRunID: ["remote-run": messageID],
+            fallbackGeneration: 3)
+        let nextTurn = ChatWorkingIdentity.resolve(
+            sessionKey: self.session,
+            pendingRunIDs: ["next-run"],
+            localUserMessageIDsByRunID: ["next-run": nextMessageID],
+            fallbackGeneration: 4)
+        let nextSession = ChatWorkingIdentity.resolve(
+            sessionKey: "agent:other:main",
+            pendingRunIDs: ["remote-run"],
+            localUserMessageIDsByRunID: ["remote-run": messageID],
+            fallbackGeneration: 3)
+
+        #expect(local == remote)
+        #expect(local != nextTurn)
+        #expect(local != nextSession)
+    }
+
     @Test func `phrase rotation keeps adjacent buckets distinct and visits the full list`() {
         let indices = (0..<ChatWorkingPhrase.resources.count).map {
             ChatWorkingPhrase.index(seed: "run-phrase-seed", bucket: $0)
@@ -36,6 +65,15 @@ struct ChatWorkingProgressTests {
         #expect(ChatWorkingDurationFormatter.compact(milliseconds: 90000) == "1m 30s")
         #expect(ChatWorkingDurationFormatter.compact(milliseconds: 3_601_000) == "1h 1s")
         #expect(!ChatWorkingDurationFormatter.compact(milliseconds: 1e30).isEmpty)
+    }
+
+    @Test func `recap token text distinguishes unknown zero one and many`() {
+        let locale = Locale(identifier: "en_US")
+        #expect(ChatTurnRecapText.tokens(nil, locale: locale) == nil)
+        #expect(ChatTurnRecapText.tokens(0, locale: locale) == "0 tokens")
+        #expect(ChatTurnRecapText.tokens(1, locale: locale) == "1 token")
+        #expect(ChatTurnRecapText.tokens(485, locale: locale) == "485 tokens")
+        #expect(ChatTurnRecapText.done(runtimeMs: 51000, locale: locale) == "Done in 51s")
     }
 
     @Test func `recap resolves on a fresh terminal then sticks`() {


### PR DESCRIPTION
## What Problem This Solves

The iOS and macOS chat apps still show the generic three-dot "Writing" typing indicator, with no elapsed time, no long-wait feedback, and no post-turn duration — while the web Control UI just shipped the reworked working claw with turn status (#112060).

## Why This Change Was Made

Ports the web behavior to the shared SwiftUI chat module (`apps/shared/OpenClawKit/Sources/OpenClawChatUI`), which both iOS and macOS host — one change covers both apps:

- **Claw indicator** (`ChatWorkingClawView.swift`): claws in place by default (jaw snips + slight body flex, no lateral travel), with the same seeded stance table as web — southpaw 20%, flurry 5%, fake-3D spin 4% (`rotation3DEffect` Y-revolve), shadowbox punch combo 3% (with pow star), backflip 2% — FNV-1a seeded per run, stable during a run. Reduce Motion renders a static claw; scenePhase gates the timers like the previous `TypingDots`.
- **Status line**: live elapsed label; after 30s of quiet a crab-gerund phrase (`· Clawing…`) rotates every 45s via the same O(1) prime-stride selection. Decorative and excluded from accessibility; the indicator keeps its accessibility label.
- **Turn recap** (`ChatWorkingProgress.swift`): "Done in 51s · 485 tokens" after a run settles, from the session entry's per-run `runtimeMs`/`outputTokens` (already present in the shared model). Full port of the web watch/settle resolver with all guards: baseline terminal stamps, mid-watch absorption forfeit, unknown-baseline consumption, 30s settle-window expiry, strictly-increasing stamps, freeze-after-resolve, failed runs quiet. The run-identity residual is documented in code, matching web.
- **Strings**: 19 gerunds + recap strings in `Localizable.xcstrings` and `apps/.i18n/native-source.json`; typography via `OpenClawChatTypography` with the audit test updated.

## User Impact

iOS and macOS chats replace the three-dot "Writing" bubble with the animated claw, elapsed time, playful long-wait phrases, and a persistent per-turn "Done in Xs · N tokens" recap — behavior-matched to the web Control UI.

## Evidence

- 19 focused Swift tests green (`ChatWorkingProgressTests.swift`: full recap resolver matrix ported from the web test suite, stance seeding determinism, phrase rotation adjacency).
- iOS simulator build succeeded; macOS main app and QuickChat both compile (shared module consumers).
- Native i18n verification and Apple string-catalog checks pass; typography audit updated.
- Structured Codex autoreview of the branch: clean, no actionable findings.
- Animation parity is code-verified against the web spec of record (keyframes/weights/timings from #112060); live animation capture was blocked because the local demo fixture completes within one render — the web PR's GIF documents the target motion: https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/2026-07-working-claw-stances/claw-stances.gif
- Known-unrelated red (pre-existing on base, outside this diff): macOS environment-dependent identity/onboarding tests and the repository-wide typography audit.
