### PR TITLE
chore(ci): audit dependency fingerprint exports

### DIFF
--- a/.github/actions/setup-node-env/dependency-fingerprint.mjs
+++ b/.github/actions/setup-node-env/dependency-fingerprint.mjs
@@ -131,7 +131,7 @@ function trackedPackageManifests(workspace) {
     .sort();
 }
 
-export function computeDependencyFingerprint({ workspace, frozenLockfile }) {
+function computeDependencyFingerprint({ workspace, frozenLockfile }) {
   const hash = createHash("sha256");
   addRecord(hash, "contract", "frozen-lockfile", String(frozenLockfile));
 

--- a/config/knip.scripts-exports.config.ts
+++ b/config/knip.scripts-exports.config.ts
@@ -12,6 +12,7 @@ const scriptEntries = productionConfig.workspaces["."].entry.filter((entry) =>
 );
 
 const repositoryToolEntries = [
+  ".github/actions/setup-node-env/dependency-fingerprint.mjs!",
   ".github/actions/register-bind-mount-cleanup/main.cjs!",
   ".github/actions/register-bind-mount-cleanup/post.cjs!",
   "apps/android/scripts/build-release-artifacts.ts!",

--- a/test/scripts/check-deadcode-exports.test.ts
+++ b/test/scripts/check-deadcode-exports.test.ts
@@ -119,6 +119,7 @@ describe("check-deadcode-exports", () => {
     expect(scriptRootWorkspace.entry).toEqual(
       expect.arrayContaining([
         ".agents/skills/**/scripts/**/*.{js,mjs,cjs,ts,mts,cts}!",
+        ".github/actions/setup-node-env/dependency-fingerprint.mjs!",
         ".github/actions/register-bind-mount-cleanup/main.cjs!",
         "apps/android/scripts/build-release-artifacts.ts!",
         "security/opengrep/check-rule-metadata.mjs!",


### PR DESCRIPTION
## What Problem This Solves

The repository script export audit did not model the dependency-fingerprint action as an executable entrypoint. That allowed its unused named export to survive even though every real consumer executes the file directly.

## Why This Change Was Made

Register the action in the dedicated script-export Knip config and keep `computeDependencyFingerprint` internal to its CLI module. The implementation and executable behavior are unchanged.

## User Impact

No user-visible behavior changes. Maintainers now get a failing dead-code export gate if this action grows another unused module export.

## Evidence

- Before removal, the updated Knip entry-export audit reported exactly:
  - `.github/actions/setup-node-env/dependency-fingerprint.mjs: computeDependencyFingerprint`
- After removal, the same Knip command passes with zero findings.
- `OPENCLAW_LOCAL_CHECK_MODE=throttled node scripts/run-vitest.mjs test/scripts/check-deadcode-exports.test.ts test/scripts/ci-workflow-guards.test.ts`
  - 111 passed, 1 skipped.
- The action produced the same deterministic `v2-<sha256>` value across repeated executions.
- `oxfmt --check` passed for all three changed files.
- Structured autoreview: clean, no accepted or actionable findings.
- Blacksmith Testbox warmup was attempted twice but GitHub returned HTTP 429 while Testbox fetched `ci-check-testbox.yml`; hosted CI remains required before merge.
