### PR TITLE
fix(extensions/novita): register static discovery in the manifest catalog

### DIFF
--- a/extensions/novita/index.test.ts
+++ b/extensions/novita/index.test.ts
@@ -2,6 +2,7 @@
 import { registerSingleProviderPlugin } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { describe, expect, it } from "vitest";
 import plugin from "./index.js";
+import manifest from "./openclaw.plugin.json" with { type: "json" };
 
 function requireCatalogProvider(
   result:
@@ -33,5 +34,18 @@ describe("novita provider plugin", () => {
     const catalogProvider = requireCatalogProvider(result);
     expect(catalogProvider.baseUrl).toBe("https://api.novita.ai/openai/v1");
     expect(catalogProvider.models?.map((model) => model.id)).toContain("deepseek/deepseek-v3-0324");
+  });
+
+  // planManifestModelCatalogRows sets entry.discovery from
+  // modelCatalog.discovery[provider]. The static-authoritative filter at
+  // src/commands/models/list.manifest-catalog.ts:45 and the bundled
+  // static-catalog resolver at
+  // src/agents/embedded-agent-runner/model.static-catalog.ts:239 only
+  // accept entries with discovery === "static". Without this declaration,
+  // every other OpenAI-compatible sibling (anthropic, cerebras, mistral,
+  // together, volcengine, byteplus, cohere, ...) qualifies; Novita alone
+  // is filtered out.
+  it("registers discovery mode so the manifest catalog planner accepts Novita rows", () => {
+    expect(manifest.modelCatalog?.discovery?.novita).toBe("static");
   });
 });

--- a/extensions/novita/openclaw.plugin.json
+++ b/extensions/novita/openclaw.plugin.json
@@ -158,6 +158,9 @@
           }
         ]
       }
+    },
+    "discovery": {
+      "novita": "static"
     }
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes openclaw/openclaw#103532

Configuring the Novita LLM provider accepts credentials but the embedded agent runner's model list comes back empty for this provider — `loadBundledProviderStaticCatalogContextModels` and the configure-gateway-auth static-manifest check both reject Novita rows because `planManifestModelCatalogRows` cannot assign `entry.discovery === "static"` to a provider that lacks the declaration.

The Novita manifest ships a complete `modelCatalog.providers.novita` block — 6 static models, OpenAI-compatible base URL `https://api.novita.ai/openai/v1` — but no `modelCatalog.discovery` block. Every other OpenAI-compatible static provider (anthropic, cerebras, mistral, together, volcengine, byteplus, cohere, meta, nvidia, …) declares `modelCatalog.discovery.<provider>: "static"`. Without it, Novita rows are planned but excluded from every code path that requires static-authoritative entries:

- `src/commands/models/list.manifest-catalog.ts:45` — `static-authoritative` mode filter
- `src/agents/embedded-agent-runner/model.static-catalog.ts:239` — bundled static-catalog resolver filter
- `src/commands/configure.gateway-auth.ts:90` — `hasStaticManifestCatalogRows` check
- `src/model-catalog/manifest-planner.ts:159` — seeds `entry.discovery` from `modelCatalog.discovery[provider]`

The downstream symptom is empty model lists / an empty model selector for any code path that strictly requires `discovery === "static"`. The reason the existing `staticCatalog.run()` test passes is that the per-plugin fallback returns rows independently of the discovery field, which is what allowed the bug to ship undetected.

## User Impact

After this change, every static-authoritative consumer accepts Novita rows: the bundled static-catalog resolver surfaces the 6 Novita models to the embedded agent runner, the gateway-auth static-manifest check sees Novita as a configured static provider, and the provider-scoped cascade in `models list --provider X` no longer falls through to the per-plugin `staticCatalog.run()` fallback.

## What changed

- `extensions/novita/openclaw.plugin.json` — add `"discovery": { "novita": "static" }` to `modelCatalog`, matching the shape every sibling static provider already uses.
- `extensions/novita/index.test.ts` — regression test asserting the manifest declares `modelCatalog.discovery.novita === "static"`, so a future refactor of `planManifestModelCatalogRows` or the manifest cannot silently drop the declaration.

## What did NOT change

No sibling provider manifests, no model list commands, no agent runner, no bundled catalog consumer logic. The fix is one JSON key plus a regression test; behavior for any other provider is unchanged.

## Evidence

### Reproduction script (matches the actual production filter)

This script walks every `dist/extensions/*/openclaw.plugin.json`, applies the same `entry.discovery === "static"` gate that `loadManifestCatalogRowsForPluginIds` applies at `src/commands/models/list.manifest-catalog.ts:43-49`, and renders the catalog snapshot before vs. after the fix:

```text
================================================================
Real behavior proof: entry.discovery === "static" gate
================================================================
Code path (verbatim):
  src/commands/models/list.manifest-catalog.ts:43-49
    plan.entries.filter((entry) =>
      mode === "static-authoritative"
        ? entry.discovery === "static"
        : entry.discovery !== "runtime",
    )

=== BEFORE FIX (no discovery declaration) ===
Manifests scanned: 19 provider entries
Total catalog models (sum across providers): 113
Providers passing entry.discovery === "static": 12
Novita entries in catalog: 1
  plugin=novita provider=novita discovery=(undefined) models=6
    passes static-authoritative gate? ❌ NO (filtered out)
    models that would surface after the fix: 6
      moonshotai/kimi-k2.5, minimax/minimax-m2.7, zai-org/glm-5, …

=== AFTER FIX (with discovery:"static") ===
Manifests scanned: 19 provider entries
Total catalog models (sum across providers): 113
Providers passing entry.discovery === "static": 13
Novita entries in catalog: 1
  plugin=novita provider=novita discovery=static models=6
    passes static-authoritative gate? ✅ YES
    models that would surface after the fix: 6
      moonshotai/kimi-k2.5, minimax/minimax-m2.7, zai-org/glm-5, …

Sample static-authoritative providers (sibling providers with discovery:"static"):
  anthropic (1 plugin, 9 models)
  byteplus (1 plugin, 3 models)
  byteplus-plan (1 plugin, 3 models)
  claude-cli (1 plugin, 6 models)
  cohere (1 plugin, 5 models)
  meta (1 plugin, 1 models)
  mistral (1 plugin, 9 models)
  novita (1 plugin, 6 models)
  ... and 5 more
```

### Field-level Before/After comparison

| Field                                                    | BEFORE (BUG) | AFTER (FIXED) |
|----------------------------------------------------------|--------------|---------------|
| `entry.discovery` for `novita`                           | undefined ❌  | `"static"` ✅   |
| Novita rows passing the static-authoritative gate        | 0 ❌          | 1 ✅            |
| Novita models surfaced (after gate)                      | 0 ❌          | 6 ✅            |
| Total static-authoritative providers                     | 12           | 13 (now includes novita) |
| Novita reaches bundled resolver at model.static-catalog.ts:239 | filtered out | included |
| Novita passes configure.gateway-auth hasStaticManifestCatalogRows | false | true |

### Targeted regression test (after fix)

```text
$ node scripts/run-vitest.mjs extensions/novita/index.test.ts

 RUN  v4.1.10 /media/vdb1/openclaw/openclaw

 Test Files  1 passed (1)
      Tests  2 passed (2)
   Duration  7.61s

[test] passed 1 Vitest shard in 13.97s
```

The new `it("registers discovery mode so the manifest catalog planner accepts Novita rows")` assertion is the smallest reliable guardrail — it fails if any future manifest refactor drops the declaration that this code path requires.

## Reproduction path summary

- `src/model-catalog/manifest-planner.ts:159` — sets `entry.discovery` from `modelCatalog.discovery[provider]`
- `src/commands/models/list.manifest-catalog.ts:45` — `entry.discovery === "static"` (static-authoritative filter)
- `src/agents/embedded-agent-runner/model.static-catalog.ts:239` — `entry.discovery !== "static"` (bundled resolver filter)
- `src/commands/configure.gateway-auth.ts:90` — `loadStaticManifestCatalogRowsForList` (gateway-auth static-manifest check)

## Proof tier and limitations

This is a structural manifest-catalog filter, not a runtime/transport/channel behavior, so the bug is reachable through `loadManifestCatalogRowsForPluginIds` and the bundled static-catalog resolver rather than a user-typed CLI command. Two structural realities cap the achievable proof:

1. `openclaw models list --provider novita` falls back to the per-plugin `staticCatalog.run()` and shows all 6 Novita models both before and after the fix, so a CLI transcript cannot show the bug at the user surface.
2. The actual user-visible failure (`loadBundledProviderStaticCatalogContextModels` returning no Novita rows for the embedded agent runner) requires a configured `NOVITA_API_KEY` plus a running agent turn to demonstrate, which the same proof tier ClawSweeper notes on related PRs as `requires external credentials` + `requires real agent turn` and cannot be reproduced from a fork.

The reproduction script above walks the production `entry.discovery === "static"` gate against the actual built manifests in `dist/extensions/`, and the field-level Before/After table shows the exact divergence. The regression test in `extensions/novita/index.test.ts` then guards the declaration against any future drift. No live-runtime gap was closed here beyond what the issue itself identifies.

## What was not tested

- No live agent turn with `NOVITA_API_KEY` configured (no credentials in this environment; this is the same gap ClawSweeper flagged on the related PR — `requires external credentials`).
- No CLI `models list` transcript at the user surface (CLI falls back to `staticCatalog.run()` and hides the bug — see Proof tier section).
- No cross-extension churn: only `extensions/novita/openclaw.plugin.json` and its colocated test were modified.