### PR TITLE
fix(ci): prevent workflow sanity fetch timeouts

### DIFF
--- a/.github/workflows/workflow-sanity.yml
+++ b/.github/workflows/workflow-sanity.yml
@@ -38,7 +38,9 @@ jobs:
           fetch_checkout_ref() {
             local fetch_status
             for attempt in 1 2 3; do
-              timeout --signal=TERM --kill-after=10s 30s git -C "$GITHUB_WORKSPACE" \
+              # GitHub can take over 30s to prepare this unauthenticated shallow pack.
+              # Match CI preflight's bounded window before retrying the exact SHA.
+              timeout --signal=TERM --kill-after=10s 120s git -C "$GITHUB_WORKSPACE" \
                 -c protocol.version=2 \
                 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin \
                 "+${CHECKOUT_SHA}:refs/remotes/origin/checkout" && return 0

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -3216,7 +3216,7 @@ describe("ci workflow guards", () => {
       expect(checkoutStep.run, jobName).toContain("fetch_checkout_ref()");
       expect(checkoutStep.run, jobName).toContain("for attempt in 1 2 3");
       expect(checkoutStep.run, jobName).toContain(
-        'timeout --signal=TERM --kill-after=10s 30s git -C "$GITHUB_WORKSPACE"',
+        'timeout --signal=TERM --kill-after=10s 120s git -C "$GITHUB_WORKSPACE"',
       );
       expect(checkoutStep.run, jobName).toContain(
         'if [ "$fetch_status" != "124" ] && [ "$fetch_status" != "137" ]; then',


### PR DESCRIPTION
Related: #112065

## What Problem This Solves

Fixes an issue where the Workflow Sanity `no-tabs` and `actionlint` jobs could both fail before validation when GitHub took longer than 30 seconds to prepare the unauthenticated shallow checkout.

## Why This Change Was Made

Keep the existing unauthenticated checkout trust boundary, but align its bounded fetch window with CI preflight's existing 120-second timeout. The retry count and exact-SHA checkout behavior remain unchanged.

## User Impact

Maintainers get fewer unrelated red Workflow Sanity checks during transient GitHub pack-generation slowdowns. There is no product behavior change.

## Evidence

- [PR #112065 Workflow Sanity run](https://github.com/openclaw/openclaw/actions/runs/29808834873): both jobs exhausted three 30-second checkout attempts before their validation steps started.
- [Unrelated `main` Workflow Sanity run](https://github.com/openclaw/openclaw/actions/runs/29809253904): reproduced the same paired checkout timeout, confirming the failure was not caused by the Matrix QA change.
- `actionlint .github/workflows/workflow-sanity.yml` — passed.
- Workflow no-tabs scan — passed.
- `git diff --check` — passed.

AI-assisted with Codex. Autoreview was intentionally skipped at maintainer request for this expedited CI-only fix.
