### PR TITLE
improve: clarify web search setup choices

### DIFF
--- a/src/commands/configure.wizard.test.ts
+++ b/src/commands/configure.wizard.test.ts
@@ -748,6 +748,51 @@ describe("runConfigureWizard", () => {
     expect(codexSearch.enabled).toBe(true);
     expect(codexSearch.mode).toBe("cached");
     expect(mocks.setupSearch).not.toHaveBeenCalled();
+    expect(mocks.note).toHaveBeenCalledWith(
+      [
+        "Web search lets your agent look things up online using the `web_search` tool.",
+        "Codex-capable models can use Codex's built-in hosted search.",
+        "Models without that capability use a separate search provider, such as Brave or DuckDuckGo, which you can configure here.",
+        "Docs: https://docs.openclaw.ai/tools/web",
+      ].join("\n"),
+      "Web search",
+    );
+    expect(mocks.note).toHaveBeenCalledWith(
+      [
+        "Codex-capable models can use Codex's built-in hosted search instead of a separate provider.",
+        "Models without that capability need a separate provider, such as Brave or DuckDuckGo.",
+        "If you do not choose one, OpenClaw can auto-detect an API-backed provider from available credentials; otherwise those models may not have web search.",
+      ].join("\n"),
+      "Codex native search",
+    );
+    expect(mocks.note).toHaveBeenCalledWith(
+      [
+        "`web_fetch` is a separate tool for reading a specific URL.",
+        "It works independently of Codex-hosted search and any separate search provider.",
+        "By default, it fetches pages directly without a search-provider API key.",
+      ].join("\n"),
+      "Web fetch",
+    );
+    expect(mocks.clackConfirm).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "Enable the web_search tool?" }),
+    );
+    expect(mocks.clackConfirm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "Enable Codex-hosted web search for Codex-capable models?",
+      }),
+    );
+    expect(mocks.clackSelect).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "Codex-hosted web search mode" }),
+    );
+    expect(mocks.clackConfirm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message:
+          "Also configure a separate web search provider for models without Codex-hosted search?",
+      }),
+    );
+    expect(mocks.clackConfirm).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "Enable the web_fetch tool?" }),
+    );
   });
 
   it("preserves disabled native Codex search when toggled off", async () => {

--- a/src/commands/configure.wizard.test.ts
+++ b/src/commands/configure.wizard.test.ts
@@ -751,25 +751,24 @@ describe("runConfigureWizard", () => {
     expect(mocks.note).toHaveBeenCalledWith(
       [
         "Web search lets your agent look things up online using the `web_search` tool.",
-        "Codex-capable models can use Codex's built-in hosted search.",
-        "Models without that capability use a separate search provider, such as Brave or DuckDuckGo, which you can configure here.",
+        "Codex-capable models can use native Codex web search.",
+        "Other models use a separate web search provider, which you can configure here.",
         "Docs: https://docs.openclaw.ai/tools/web",
       ].join("\n"),
       "Web search",
     );
     expect(mocks.note).toHaveBeenCalledWith(
       [
-        "Codex-capable models can use Codex's built-in hosted search instead of a separate provider.",
-        "Models without that capability need a separate provider, such as Brave or DuckDuckGo.",
-        "If you do not choose one, OpenClaw can auto-detect an API-backed provider from available credentials; otherwise those models may not have web search.",
+        "Codex-capable models can use native Codex web search instead of a separate provider.",
+        "Other models need a separate web search provider.",
+        "If you do not choose one, OpenClaw can select a provider from available credentials; otherwise other models may not have web search.",
       ].join("\n"),
       "Codex native search",
     );
     expect(mocks.note).toHaveBeenCalledWith(
       [
         "`web_fetch` is a separate tool for reading a specific URL.",
-        "It works independently of Codex-hosted search and any separate search provider.",
-        "By default, it fetches pages directly without a search-provider API key.",
+        "It does not require an API key and works independently of web search providers, including Codex.",
       ].join("\n"),
       "Web fetch",
     );
@@ -778,16 +777,15 @@ describe("runConfigureWizard", () => {
     );
     expect(mocks.clackConfirm).toHaveBeenCalledWith(
       expect.objectContaining({
-        message: "Enable Codex-hosted web search for Codex-capable models?",
+        message: "Enable native Codex web search for Codex-capable models?",
       }),
     );
     expect(mocks.clackSelect).toHaveBeenCalledWith(
-      expect.objectContaining({ message: "Codex-hosted web search mode" }),
+      expect.objectContaining({ message: "Native Codex web search mode" }),
     );
     expect(mocks.clackConfirm).toHaveBeenCalledWith(
       expect.objectContaining({
-        message:
-          "Also configure a separate web search provider for models without Codex-hosted search?",
+        message: "Also configure a separate web search provider for other models?",
       }),
     );
     expect(mocks.clackConfirm).toHaveBeenCalledWith(

--- a/src/commands/configure.wizard.ts
+++ b/src/commands/configure.wizard.ts
@@ -211,8 +211,8 @@ async function promptWebToolsConfig(
   note(
     [
       "Web search lets your agent look things up online using the `web_search` tool.",
-      "Codex-capable models can use Codex's built-in hosted search.",
-      "Models without that capability use a separate search provider, such as Brave or DuckDuckGo, which you can configure here.",
+      "Codex-capable models can use native Codex web search.",
+      "Other models use a separate web search provider, which you can configure here.",
       "Docs: https://docs.openclaw.ai/tools/web",
     ].join("\n"),
     "Web search",
@@ -240,9 +240,9 @@ async function promptWebToolsConfig(
     if (codexRelevant) {
       note(
         [
-          "Codex-capable models can use Codex's built-in hosted search instead of a separate provider.",
-          "Models without that capability need a separate provider, such as Brave or DuckDuckGo.",
-          "If you do not choose one, OpenClaw can auto-detect an API-backed provider from available credentials; otherwise those models may not have web search.",
+          "Codex-capable models can use native Codex web search instead of a separate provider.",
+          "Other models need a separate web search provider.",
+          "If you do not choose one, OpenClaw can select a provider from available credentials; otherwise other models may not have web search.",
           ...(describeCodexNativeWebSearch(nextConfig)
             ? [describeCodexNativeWebSearch(nextConfig)!]
             : []),
@@ -252,7 +252,7 @@ async function promptWebToolsConfig(
 
       const enableCodexNative = guardCancel(
         await confirm({
-          message: "Enable Codex-hosted web search for Codex-capable models?",
+          message: "Enable native Codex web search for Codex-capable models?",
           initialValue: existingSearch?.openaiCodex?.enabled === true,
         }),
         runtime,
@@ -262,7 +262,7 @@ async function promptWebToolsConfig(
       if (enableCodexNative) {
         const codexMode = guardCancel(
           await select({
-            message: "Codex-hosted web search mode",
+            message: "Native Codex web search mode",
             options: [
               {
                 value: "cached",
@@ -292,7 +292,7 @@ async function promptWebToolsConfig(
           await confirm({
             message: existingSearch?.provider
               ? `Change the separate web search provider (currently ${existingSearch.provider})?`
-              : "Also configure a separate web search provider for models without Codex-hosted search?",
+              : "Also configure a separate web search provider for other models?",
             initialValue: Boolean(existingSearch?.provider),
           }),
           runtime,
@@ -348,8 +348,7 @@ async function promptWebToolsConfig(
   note(
     [
       "`web_fetch` is a separate tool for reading a specific URL.",
-      "It works independently of Codex-hosted search and any separate search provider.",
-      "By default, it fetches pages directly without a search-provider API key.",
+      "It does not require an API key and works independently of web search providers, including Codex.",
     ].join("\n"),
     "Web fetch",
   );

--- a/src/commands/configure.wizard.ts
+++ b/src/commands/configure.wizard.ts
@@ -211,7 +211,8 @@ async function promptWebToolsConfig(
   note(
     [
       "Web search lets your agent look things up online using the `web_search` tool.",
-      "Choose a managed provider now, and Codex-capable models can also use native Codex web search.",
+      "Codex-capable models can use Codex's built-in hosted search.",
+      "Models without that capability use a separate search provider, such as Brave or DuckDuckGo, which you can configure here.",
       "Docs: https://docs.openclaw.ai/tools/web",
     ].join("\n"),
     "Web search",
@@ -219,7 +220,7 @@ async function promptWebToolsConfig(
 
   const enableSearch = guardCancel(
     await confirm({
-      message: "Enable web_search?",
+      message: "Enable the web_search tool?",
       initialValue: existingSearch?.enabled ?? hasManagedSearchProviders,
     }),
     runtime,
@@ -239,19 +240,19 @@ async function promptWebToolsConfig(
     if (codexRelevant) {
       note(
         [
-          "Codex-capable models can optionally use native Codex web search.",
-          "Managed web_search still controls non-Codex models.",
-          "If no managed provider is configured, non-Codex models still rely on provider auto-detect and may have no search available.",
+          "Codex-capable models can use Codex's built-in hosted search instead of a separate provider.",
+          "Models without that capability need a separate provider, such as Brave or DuckDuckGo.",
+          "If you do not choose one, OpenClaw can auto-detect an API-backed provider from available credentials; otherwise those models may not have web search.",
           ...(describeCodexNativeWebSearch(nextConfig)
             ? [describeCodexNativeWebSearch(nextConfig)!]
-            : ["Recommended mode: cached."]),
+            : []),
         ].join("\n"),
         "Codex native search",
       );
 
       const enableCodexNative = guardCancel(
         await confirm({
-          message: "Enable native Codex web search for Codex-capable models?",
+          message: "Enable Codex-hosted web search for Codex-capable models?",
           initialValue: existingSearch?.openaiCodex?.enabled === true,
         }),
         runtime,
@@ -261,7 +262,7 @@ async function promptWebToolsConfig(
       if (enableCodexNative) {
         const codexMode = guardCancel(
           await select({
-            message: "Codex native web search mode",
+            message: "Codex-hosted web search mode",
             options: [
               {
                 value: "cached",
@@ -289,7 +290,9 @@ async function promptWebToolsConfig(
         };
         configureManagedProvider = guardCancel(
           await confirm({
-            message: "Configure or change a managed web search provider now?",
+            message: existingSearch?.provider
+              ? `Change the separate web search provider (currently ${existingSearch.provider})?`
+              : "Also configure a separate web search provider for models without Codex-hosted search?",
             initialValue: Boolean(existingSearch?.provider),
           }),
           runtime,
@@ -342,9 +345,18 @@ async function promptWebToolsConfig(
     }
   }
 
+  note(
+    [
+      "`web_fetch` is a separate tool for reading a specific URL.",
+      "It works independently of Codex-hosted search and any separate search provider.",
+      "By default, it fetches pages directly without a search-provider API key.",
+    ].join("\n"),
+    "Web fetch",
+  );
+
   const enableFetch = guardCancel(
     await confirm({
-      message: "Enable web_fetch (keyless HTTP fetch)?",
+      message: "Enable the web_fetch tool?",
       initialValue: existingFetch?.enabled ?? true,
     }),
     runtime,

--- a/src/commands/models/auth.test.ts
+++ b/src/commands/models/auth.test.ts
@@ -513,7 +513,7 @@ describe("modelsAuthLoginCommand", () => {
       "Default model available: openai/gpt-5.5 (use --set-default to apply)",
     );
     expect(runtime.log).toHaveBeenCalledWith(
-      "Tip: Codex-capable models can use Codex-hosted web search. Configure the `web_search` tool with `openclaw configure --section web`. Docs: https://docs.openclaw.ai/tools/web",
+      "Tip: Codex-capable models can use native Codex web search. Configure the `web_search` tool with `openclaw configure --section web`. Docs: https://docs.openclaw.ai/tools/web",
     );
     expect(mocks.callGateway).toHaveBeenCalledWith({
       method: "models.authStatus",

--- a/src/commands/models/auth.test.ts
+++ b/src/commands/models/auth.test.ts
@@ -512,6 +512,9 @@ describe("modelsAuthLoginCommand", () => {
     expect(runtime.log).toHaveBeenCalledWith(
       "Default model available: openai/gpt-5.5 (use --set-default to apply)",
     );
+    expect(runtime.log).toHaveBeenCalledWith(
+      "Tip: Codex-capable models can use Codex-hosted web search. Configure the `web_search` tool with `openclaw configure --section web`. Docs: https://docs.openclaw.ai/tools/web",
+    );
     expect(mocks.callGateway).toHaveBeenCalledWith({
       method: "models.authStatus",
       params: { refresh: true },

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -1000,7 +1000,7 @@ function maybeLogOpenAICodexNativeSearchTip(runtime: RuntimeEnv, providerId: str
     return;
   }
   runtime.log(
-    "Tip: Codex-capable models can use native Codex web search. Enable it with openclaw configure --section web (recommended mode: cached). Docs: https://docs.openclaw.ai/tools/web",
+    `Tip: Codex-capable models can use Codex-hosted web search. Configure the \`web_search\` tool with \`${formatCliCommand("openclaw configure --section web")}\`. Docs: https://docs.openclaw.ai/tools/web`,
   );
 }
 

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -1000,7 +1000,7 @@ function maybeLogOpenAICodexNativeSearchTip(runtime: RuntimeEnv, providerId: str
     return;
   }
   runtime.log(
-    `Tip: Codex-capable models can use Codex-hosted web search. Configure the \`web_search\` tool with \`${formatCliCommand("openclaw configure --section web")}\`. Docs: https://docs.openclaw.ai/tools/web`,
+    `Tip: Codex-capable models can use native Codex web search. Configure the \`web_search\` tool with \`${formatCliCommand("openclaw configure --section web")}\`. Docs: https://docs.openclaw.ai/tools/web`,
   );
 }
 


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users configuring web tools were shown vague or misleading distinctions between native Codex search, a separately configured search provider, and `web_fetch`. The OpenAI auth tip also displayed `openclaw configure --section web` as plain text and repeated the cached-mode recommendation before the wizard presented that choice.

## Why This Change Was Made

The wizard now describes native Codex search and separate search providers in user-facing terms, explains that other models need a provider, and presents `web_fetch` as an independent URL-reading tool that does not require an API key. Prompt labels consistently name `web_search` and `web_fetch` as tools, while the auth tip formats both the tool and command as code.

The wording follows the current Codex hosted-search contract: cached and live modes map to Codex's hosted `web_search` tool, and OpenClaw suppresses its separate managed search tool only while native Codex search is active.

AI-assisted: yes. I reviewed the implementation and its Codex/OpenClaw routing contracts.

## User Impact

Users running `openclaw configure --section web` can now tell which choice enables native Codex search, why other models may need a separate provider, and that `web_fetch` reads a known URL independently of search. The actual configuration behavior and defaults are unchanged.

## Evidence

- `node scripts/run-vitest.mjs src/commands/configure.wizard.test.ts src/commands/models/auth.test.ts` — 2 shards passed, 59 tests passed.
- `node scripts/check-changed.mjs -- src/commands/configure.wizard.ts src/commands/configure.wizard.test.ts src/commands/models/auth.ts src/commands/models/auth.test.ts` — passed on Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/29811938795
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output` — clean; no accepted/actionable findings.
- `git diff --check` — passed.
- Direct Codex contract inspection: `../codex/codex-rs/core/src/tools/hosted_spec.rs` and `../codex/codex-rs/core/src/tools/spec_plan.rs`.
