### PR TITLE
fix(ci): forward QA Convex secrets to maturity generation

### DIFF
--- a/.github/workflows/maturity-scorecard.yml
+++ b/.github/workflows/maturity-scorecard.yml
@@ -45,6 +45,12 @@ on:
       OPENCLAW_MATURITY_SCORECARD_AGENT_OPENAI_API_KEY:
         description: Optional OpenAI API key used by maturity scorecard agent steps
         required: false
+      OPENCLAW_QA_CONVEX_SITE_URL:
+        description: Optional Convex credential broker URL supplied by qa-live-shared
+        required: false
+      OPENCLAW_QA_CONVEX_SECRET_CI:
+        description: Optional Convex CI credential supplied by qa-live-shared
+        required: false
       # Mixed-trigger workflows must declare referenced secrets for actionlint. Reusable calls
       # remain artifact-only because exact caller and job workflow identities gate every use.
       CLAWSWEEPER_APP_PRIVATE_KEY:
@@ -317,6 +323,8 @@ jobs:
       qa_profile: all
     secrets:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      OPENCLAW_QA_CONVEX_SITE_URL: ${{ secrets.OPENCLAW_QA_CONVEX_SITE_URL }}
+      OPENCLAW_QA_CONVEX_SECRET_CI: ${{ secrets.OPENCLAW_QA_CONVEX_SECRET_CI }}
 
   publish:
     name: Publish maturity docs PR

--- a/.github/workflows/openclaw-release-checks.yml
+++ b/.github/workflows/openclaw-release-checks.yml
@@ -971,6 +971,8 @@ jobs:
       expected_sha: ${{ needs.resolve_target.outputs.revision }}
     secrets:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      OPENCLAW_QA_CONVEX_SITE_URL: ${{ secrets.OPENCLAW_QA_CONVEX_SITE_URL }}
+      OPENCLAW_QA_CONVEX_SECRET_CI: ${{ secrets.OPENCLAW_QA_CONVEX_SECRET_CI }}
 
   qa_lab_parity_lane_release_checks:
     name: Run QA Lab parity lane (${{ matrix.lane }})

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -4607,8 +4607,15 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
       "MANTIS_GITHUB_APP_PRIVATE_KEY",
       "OPENAI_API_KEY",
       "OPENCLAW_MATURITY_SCORECARD_AGENT_OPENAI_API_KEY",
+      "OPENCLAW_QA_CONVEX_SECRET_CI",
+      "OPENCLAW_QA_CONVEX_SITE_URL",
     ]);
-    for (const secret of ["CLAWSWEEPER_APP_PRIVATE_KEY", "MANTIS_GITHUB_APP_PRIVATE_KEY"]) {
+    for (const secret of [
+      "CLAWSWEEPER_APP_PRIVATE_KEY",
+      "MANTIS_GITHUB_APP_PRIVATE_KEY",
+      "OPENCLAW_QA_CONVEX_SECRET_CI",
+      "OPENCLAW_QA_CONVEX_SITE_URL",
+    ]) {
       expect(maturityWorkflow.on.workflow_call.secrets[secret].required).toBe(false);
     }
     expect(qaEvidenceWorkflow.on.workflow_dispatch.inputs).not.toHaveProperty("fail_on_qa_failure");
@@ -4645,6 +4652,11 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
       qa_profile: "all",
     });
     expect(generateJob.with).not.toHaveProperty("fail_on_qa_failure");
+    expect(generateJob.secrets).toMatchObject({
+      OPENAI_API_KEY: "${{ secrets.OPENAI_API_KEY }}",
+      OPENCLAW_QA_CONVEX_SECRET_CI: "${{ secrets.OPENCLAW_QA_CONVEX_SECRET_CI }}",
+      OPENCLAW_QA_CONVEX_SITE_URL: "${{ secrets.OPENCLAW_QA_CONVEX_SITE_URL }}",
+    });
 
     const workflowStep = maturityWorkflow.jobs.validate_selected_ref.steps.find(
       (step: WorkflowStep) => step.name === "Resolve job workflow identity",
@@ -5019,7 +5031,11 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
     });
     expect(job.with).not.toHaveProperty("qa_profile");
     expect(job.with).not.toHaveProperty("publish_pull_request");
-    expect(Object.keys(job.secrets)).toEqual(["OPENAI_API_KEY"]);
+    expect(job.secrets).toMatchObject({
+      OPENAI_API_KEY: "${{ secrets.OPENAI_API_KEY }}",
+      OPENCLAW_QA_CONVEX_SECRET_CI: "${{ secrets.OPENCLAW_QA_CONVEX_SECRET_CI }}",
+      OPENCLAW_QA_CONVEX_SITE_URL: "${{ secrets.OPENCLAW_QA_CONVEX_SITE_URL }}",
+    });
     expect(summaryJob.needs).toContain("maturity_scorecard_release_checks");
     expect(verifyStep.env.MATURITY_SCORECARD_RELEASE_CHECKS_RESULT).toBe(
       "${{ needs.maturity_scorecard_release_checks.result }}",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where full maturity scorecard generation aborts before QA starts because the wrapper workflow does not forward the configured Convex credential-broker secrets into reusable QA evidence generation.

## Why This Change Was Made

Declare the two optional Convex secrets at the maturity workflow-call boundary and forward them into QA profile evidence. Release checks now forward the same secrets when they invoke maturity generation, preserving both direct and reusable call paths.

## User Impact

Maintainers can regenerate maturity coverage and scorecard docs without the live-profile credential preflight rejecting secrets that are already configured in the repository and `qa-live-shared` environment.

## Evidence

- [Maturity run 29810662622](https://github.com/openclaw/openclaw/actions/runs/29810662622) reached full QA evidence generation, then failed before build with `Missing required qa-live-shared secret: OPENCLAW_QA_CONVEX_SITE_URL`.
- Repository and `qa-live-shared` secret metadata both contain `OPENCLAW_QA_CONVEX_SITE_URL` and `OPENCLAW_QA_CONVEX_SECRET_CI`; no secret values were read or printed.
- `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts` — 88 passed, 1 platform skip.
- Autoreview — clean, no accepted/actionable findings (0.96).
- AI-assisted: yes; implementation and evidence were reviewed by the author.