### PR TITLE
fix(process): prevent Windows process-tree leaks after taskkill refusal

### DIFF
--- a/packages/agent-core/src/harness/env/kill-tree.ts
+++ b/packages/agent-core/src/harness/env/kill-tree.ts
@@ -14,7 +14,10 @@ export type KillProcessTreeOptions = {
 /**
  * Best-effort process-tree termination with graceful shutdown.
  * - Windows: use taskkill /T to include descendants. Sends SIGTERM-equivalent
- *   first (without /F), then force-kills if process survives.
+ *   first (without /F), then force-kills if that attempt reports failure or the
+ *   process survives the grace period. Either escalation is skipped when the PID
+ *   is no longer alive, because Windows reuses PIDs and /F /T would take an
+ *   unrelated tree with it.
  * - Unix: send SIGTERM to process group first, wait grace period, then SIGKILL.
  *
  * Group kill (`process.kill(-pid, ...)`) is only used when the PID is verified
@@ -166,32 +169,75 @@ function signalProcessTreeUnix(
   }
 }
 
-function runTaskkill(args: string[]): void {
+function runTaskkill(args: string[], onExit?: (code: number | null) => void): void {
+  // Node emits "close" after "error" when a spawn fails, and that close carries a
+  // negative errno rather than null. Report only the first outcome so a spawn failure
+  // never reaches callers as a non-zero taskkill verdict.
+  let reported = false;
+  const report = (code: number | null) => {
+    if (reported) {
+      return;
+    }
+    reported = true;
+    onExit?.(code);
+  };
+
   try {
     const child = spawn("taskkill", args, {
       stdio: "ignore",
       detached: true,
       windowsHide: true,
     });
-    child.once("error", () => {});
+    child.once("error", () => report(null));
+    child.once("close", (code) => report(code));
   } catch {
-    // Ignore taskkill spawn failures.
+    // Report the spawn failure as "no verdict"; taskkill never ran.
+    report(null);
   }
 }
 
 function killProcessTreeWindows(pid: number, graceMs: number): void {
-  signalProcessTreeWindows(pid, "SIGTERM");
-
-  setTimeout(() => {
+  let forced = false;
+  let graceTimer: ReturnType<typeof setTimeout> | undefined;
+  const forceKill = () => {
+    // The reported-failure path and the grace timer can both land here; force stays single-shot.
+    if (forced) {
+      return;
+    }
+    forced = true;
+    if (graceTimer !== undefined) {
+      clearTimeout(graceTimer);
+      graceTimer = undefined;
+    }
+    // taskkill reports the same non-zero exit for "needs /F" and "process not found", so a
+    // reported failure is not proof the tree is still there. /T against an exited PID can
+    // tear down an unrelated tree once Windows reuses the number. Latch before this check:
+    // a PID that is dead now can only look alive later by having been reused.
     if (!isProcessAlive(pid)) {
       return;
     }
     signalProcessTreeWindows(pid, "SIGKILL");
-  }, graceMs).unref();
+  };
+
+  // Windows cannot end console processes without /F and reports that refusal as a non-zero
+  // taskkill exit. Escalating on the reported failure keeps cleanup correct when the owning
+  // process exits before the unref'd grace timer fires, which otherwise leaks the whole tree.
+  signalProcessTreeWindows(pid, "SIGTERM", (code) => {
+    if (code !== null && code !== 0) {
+      forceKill();
+    }
+  });
+
+  graceTimer = setTimeout(forceKill, graceMs);
+  graceTimer.unref();
 }
 
-function signalProcessTreeWindows(pid: number, signal: "SIGTERM" | "SIGKILL"): void {
+function signalProcessTreeWindows(
+  pid: number,
+  signal: "SIGTERM" | "SIGKILL",
+  onExit?: (code: number | null) => void,
+): void {
   const args =
     signal === "SIGKILL" ? ["/F", "/T", "/PID", String(pid)] : ["/T", "/PID", String(pid)];
-  runTaskkill(args);
+  runTaskkill(args, onExit);
 }

--- a/src/process/kill-tree.test.ts
+++ b/src/process/kill-tree.test.ts
@@ -63,7 +63,8 @@ describe("killProcessTree", () => {
     readFileSyncMock.mockImplementation(() => {
       throw new Error("proc unavailable");
     });
-    spawnMock.mockClear();
+    // mockReset (not mockClear) also drains queued mockReturnValueOnce children.
+    spawnMock.mockReset();
     spawnSyncMock.mockClear();
     killSpy = vi.spyOn(process, "kill");
     vi.useFakeTimers();
@@ -336,6 +337,164 @@ describe("killProcessTree", () => {
 
       expect(() => taskkillChild.emit("error", new Error("spawn ENOENT"))).not.toThrow();
       expectTaskkillCall(0, ["/F", "/T", "/PID", "9191"]);
+    });
+  });
+
+  // Windows refuses to end console processes without /F and reports exit 128. Without
+  // escalating on that result, cleanup relies solely on the unref'd grace timer, which a
+  // gateway restart inside the grace window cancels — leaking the whole tree (#110789).
+  it("on Windows force-kills immediately when graceful taskkill reports failure and the PID is still alive", async () => {
+    const graceful = new EventEmitter();
+    spawnMock.mockReturnValueOnce(graceful);
+    killSpy.mockImplementation(() => true);
+
+    await withMockedPlatform("win32", async () => {
+      killProcessTree(4711, { graceMs: 30_000 });
+
+      expect(spawnMock).toHaveBeenCalledTimes(1);
+      expectTaskkillCall(0, ["/T", "/PID", "4711"]);
+
+      graceful.emit("close", 128);
+
+      // Escalates on the reported failure, without waiting out the 30s grace window.
+      expect(spawnMock).toHaveBeenCalledTimes(2);
+      expectTaskkillCall(1, ["/F", "/T", "/PID", "4711"]);
+    });
+  });
+
+  // taskkill reports the same non-zero exit for "can only be terminated forcefully" and
+  // "process not found", so a reported failure alone must not authorize /F: Windows reuses
+  // PIDs, and /T against a reused number would tear down an unrelated tree.
+  it("on Windows does not force-kill when graceful taskkill fails but the PID is already gone", async () => {
+    const graceful = new EventEmitter();
+    spawnMock.mockReturnValueOnce(graceful);
+    killSpy.mockImplementation(((pid: number, signal?: NodeJS.Signals | number) => {
+      if (pid === 4717 && signal === 0) {
+        throw new Error("ESRCH");
+      }
+      return true;
+    }) as typeof process.kill);
+
+    await withMockedPlatform("win32", async () => {
+      killProcessTree(4717, { graceMs: 30 });
+
+      graceful.emit("close", 128);
+      expect(spawnMock).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(30);
+      expect(spawnMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // taskkill /T without /F returns 0 once it has sent WM_CLOSE, which a GUI tree may ignore.
+  it("on Windows force-kills once via the grace timer when taskkill succeeds but the tree survives", async () => {
+    const graceful = new EventEmitter();
+    spawnMock.mockReturnValueOnce(graceful);
+    killSpy.mockImplementation(() => true);
+
+    await withMockedPlatform("win32", async () => {
+      killProcessTree(4718, { graceMs: 30 });
+
+      graceful.emit("close", 0);
+      expect(spawnMock).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(30);
+
+      expect(spawnMock).toHaveBeenCalledTimes(2);
+      expectTaskkillCall(1, ["/F", "/T", "/PID", "4718"]);
+    });
+  });
+
+  it("on Windows does not force-kill when graceful taskkill succeeds", async () => {
+    const graceful = new EventEmitter();
+    spawnMock.mockReturnValueOnce(graceful);
+    killSpy.mockImplementation(((pid: number, signal?: NodeJS.Signals | number) => {
+      if (pid === 4712 && signal === 0) {
+        throw new Error("ESRCH");
+      }
+      return true;
+    }) as typeof process.kill);
+
+    await withMockedPlatform("win32", async () => {
+      killProcessTree(4712, { graceMs: 25 });
+      graceful.emit("close", 0);
+
+      expect(spawnMock).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(25);
+      expect(spawnMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("on Windows falls back to the grace timer when graceful taskkill never reports", async () => {
+    const graceful = new EventEmitter();
+    spawnMock.mockReturnValueOnce(graceful);
+    killSpy.mockImplementation(() => true);
+
+    await withMockedPlatform("win32", async () => {
+      killProcessTree(4713, { graceMs: 40 });
+
+      expect(spawnMock).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(40);
+
+      expect(spawnMock).toHaveBeenCalledTimes(2);
+      expectTaskkillCall(1, ["/F", "/T", "/PID", "4713"]);
+    });
+  });
+
+  it("on Windows forces at most once when the failure and grace timer both fire", async () => {
+    const graceful = new EventEmitter();
+    spawnMock.mockReturnValueOnce(graceful);
+    killSpy.mockImplementation(() => true);
+
+    await withMockedPlatform("win32", async () => {
+      killProcessTree(4714, { graceMs: 20 });
+      graceful.emit("close", 1);
+
+      expect(spawnMock).toHaveBeenCalledTimes(2);
+
+      await vi.advanceTimersByTimeAsync(20);
+
+      expect(spawnMock).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  // A failed spawn emits "error" and then "close" carrying a negative errno (ENOENT is
+  // -4058 on Windows). Only the first outcome counts, so the follow-up close must not read
+  // as a non-zero taskkill verdict and escalate on its own.
+  it("on Windows does not escalate immediately when the graceful taskkill spawn errors", async () => {
+    const graceful = new EventEmitter();
+    spawnMock.mockReturnValueOnce(graceful);
+    killSpy.mockImplementation(() => true);
+
+    await withMockedPlatform("win32", async () => {
+      killProcessTree(4715, { graceMs: 15 });
+
+      expect(() => graceful.emit("error", new Error("spawn ENOENT"))).not.toThrow();
+      graceful.emit("close", -4058);
+      expect(spawnMock).toHaveBeenCalledTimes(1);
+
+      // The grace timer remains the backstop for a tree that is still alive.
+      await vi.advanceTimersByTimeAsync(15);
+      expect(spawnMock).toHaveBeenCalledTimes(2);
+      expectTaskkillCall(1, ["/F", "/T", "/PID", "4715"]);
+    });
+  });
+
+  // signalProcessTree is the explicit one-shot API; escalation belongs to killProcessTree only.
+  it("on Windows keeps signalProcessTree SIGTERM single-shot when taskkill fails", async () => {
+    const graceful = new EventEmitter();
+    spawnMock.mockReturnValueOnce(graceful);
+
+    await withMockedPlatform("win32", async () => {
+      signalProcessTree(4716, "SIGTERM");
+      expectTaskkillCall(0, ["/T", "/PID", "4716"]);
+
+      graceful.emit("close", 128);
+      await vi.advanceTimersByTimeAsync(60_000);
+
+      expect(spawnMock).toHaveBeenCalledTimes(1);
     });
   });
 });


### PR DESCRIPTION
Closes #110789

## What Problem This Solves

On Windows, OpenClaw could leak whole child process trees — npx-spawned MCP servers, sub-agents, and bash-tool subprocesses — after a session cancellation or shutdown. When the graceful `taskkill /T` (without `/F`) could not end a console process, cleanup relied solely on a delayed, unref'd force-kill timer; if the owning gateway process exited or restarted inside the grace window, that timer was canceled and the tree was never force-killed.

## Why This Change Was Made

The Windows path remains graceful-first and retains the grace-period timer as a fallback, while escalating immediately when the graceful taskkill reports failure. It now wires the graceful exit code back to the caller:

- **Force escalation** to `taskkill /F /T` fires immediately only when the graceful attempt *reports failure* **and** the target PID is still alive, so the leak is closed without waiting out the full window.
- **Dead / recycled-PID protection:** `taskkill` returns the same non-zero exit for "needs /F" and "process not found," so a reported failure isn't proof the tree still exists. Both escalation paths skip the force-kill when the PID is no longer alive, and the decision is latched before that check. The liveness check prevents forced escalation when the PID is already dead at escalation time, reducing the risk of targeting a recycled PID.
- **Single-shot exit reporting:** a failed spawn emits `close` after `error` with a negative errno; the runner reports only the first outcome, so a spawn failure is never misread as a non-zero verdict that escalates.

The Unix path and the explicit `force: true` / `signalProcessTree(SIGKILL)` paths are unchanged.

## User Impact

Windows operators no longer accumulate orphaned MCP-server / sub-agent / shell process trees after cancellations and gateway restarts. Cleanup is more prompt (escalates as soon as the graceful attempt is refused) and safer (avoids forced escalation when the original PID is already gone).

## Evidence

Windows 11, Node 24.18:

- Focused unit tests `src/process/kill-tree.test.ts`: **26/26**.
- Consumer tests `src/process/exec.windows.test.ts`: **22/22**; `src/agents/mcp-stdio-transport.test.ts`: **9/9**.
- Type checks (`tsgo` core + test-src), lint (oxlint), format (`oxfmt --check`): clean.
- Real-Windows reproduction: a live process tree force-kills promptly via the reported-failure path; an already-dead PID receives no `/F` (and does receive one when the guard is removed).
- `trufflehog filesystem` over both changed files: 0 secrets.

_AI-assisted (Claude). An initial autoreview surfaced two findings — a missing liveness guard before escalation and escalation on a spawn-error `close` — were verified and fixed. The final automated rerun was blocked by a Windows-specific TruffleHog tooling issue, so secret scanning was completed separately (above)._
