### PR TITLE
chore(plugins): cover manifest tool availability gates

### DIFF
--- a/src/plugins/manifest-tool-availability.test.ts
+++ b/src/plugins/manifest-tool-availability.test.ts
@@ -1,0 +1,445 @@
+// Covers manifest tool-availability gating: config signals, auth signals, and env fallbacks.
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { PluginManifestRecord } from "./manifest-registry.js";
+import {
+  hasManifestToolAvailability,
+  hasNonEmptyManifestEnvCandidate,
+  manifestConfigSignalPasses,
+  manifestPluginSetupProviderEnvVars,
+  manifestProviderBaseUrlGuardPasses,
+} from "./manifest-tool-availability.js";
+
+function makePlugin(overrides: Partial<PluginManifestRecord>): PluginManifestRecord {
+  return {
+    id: "demo",
+    channels: [],
+    providers: [],
+    cliBackends: [],
+    skills: [],
+    hooks: [],
+    origin: "bundled",
+    rootDir: "/tmp/demo",
+    source: "/tmp/demo/index.js",
+    manifestPath: "/tmp/demo/openclaw.plugin.json",
+    ...overrides,
+  };
+}
+
+function makeConfig(value: Record<string, unknown>): OpenClawConfig {
+  return value as OpenClawConfig;
+}
+
+const webSearchSignal = {
+  rootPath: "plugins.entries.xai.config",
+  overlayPath: "webSearch",
+  required: ["apiKey"],
+};
+
+function xaiConfig(config: Record<string, unknown>): OpenClawConfig {
+  return makeConfig({ plugins: { entries: { xai: { config } } } });
+}
+
+describe("manifestConfigSignalPasses", () => {
+  it("fails when the signal root path is absent from config", () => {
+    expect(
+      manifestConfigSignalPasses({ config: makeConfig({}), env: {}, signal: webSearchSignal }),
+    ).toBe(false);
+  });
+
+  it("passes when a required path is configured under the overlay", () => {
+    expect(
+      manifestConfigSignalPasses({
+        config: xaiConfig({ webSearch: { apiKey: "sk-xai" } }),
+        env: {},
+        signal: webSearchSignal,
+      }),
+    ).toBe(true);
+  });
+
+  it("lets overlay values override root values", () => {
+    // The overlay merge ({ ...root, ...overlay }) must win over the root value;
+    // here the root apiKey is blank and only the overlay provides a real one.
+    expect(
+      manifestConfigSignalPasses({
+        config: xaiConfig({ apiKey: "", webSearch: { apiKey: "sk-xai" } }),
+        env: {},
+        signal: webSearchSignal,
+      }),
+    ).toBe(true);
+    expect(
+      manifestConfigSignalPasses({
+        config: xaiConfig({ apiKey: "sk-root", webSearch: { apiKey: "" } }),
+        env: {},
+        signal: webSearchSignal,
+      }),
+    ).toBe(false);
+  });
+
+  const emptyRequiredValues: Array<[string, unknown]> = [
+    ["empty string", ""],
+    ["whitespace string", "   "],
+    ["empty array", []],
+    ["empty object", {}],
+    ["null", null],
+    ["undefined", undefined],
+  ];
+  it.each(emptyRequiredValues)("treats %s as not configured", (_label, value) => {
+    expect(
+      manifestConfigSignalPasses({
+        config: xaiConfig({ webSearch: { apiKey: value } }),
+        env: {},
+        signal: webSearchSignal,
+      }),
+    ).toBe(false);
+  });
+
+  const presentRequiredValues: Array<[string, unknown]> = [
+    ["zero", 0],
+    ["false", false],
+    ["non-empty array", ["a"]],
+    ["non-empty object", { nested: true }],
+  ];
+  it.each(presentRequiredValues)("treats %s as configured", (_label, value) => {
+    expect(
+      manifestConfigSignalPasses({
+        config: xaiConfig({ webSearch: { apiKey: value } }),
+        env: {},
+        signal: webSearchSignal,
+      }),
+    ).toBe(true);
+  });
+
+  it("resolves env secret refs in required paths against the environment", () => {
+    const config = xaiConfig({
+      webSearch: { apiKey: { source: "env", id: "XAI_API_KEY" } },
+    });
+    expect(
+      manifestConfigSignalPasses({
+        config,
+        env: { XAI_API_KEY: "sk-xai" },
+        signal: webSearchSignal,
+      }),
+    ).toBe(true);
+    expect(manifestConfigSignalPasses({ config, env: {}, signal: webSearchSignal })).toBe(false);
+    expect(
+      manifestConfigSignalPasses({
+        config,
+        env: { XAI_API_KEY: "   " },
+        signal: webSearchSignal,
+      }),
+    ).toBe(false);
+  });
+
+  it("passes requiredAny when at least one path is configured", () => {
+    const signal = {
+      rootPath: "channels.demo",
+      requiredAny: ["token", "tokenFile"],
+    };
+    expect(
+      manifestConfigSignalPasses({
+        config: makeConfig({ channels: { demo: { tokenFile: "/tmp/token" } } }),
+        env: {},
+        signal,
+      }),
+    ).toBe(true);
+    expect(
+      manifestConfigSignalPasses({
+        config: makeConfig({ channels: { demo: { other: true } } }),
+        env: {},
+        signal,
+      }),
+    ).toBe(false);
+  });
+
+  it("gates on mode allowed/disallowed lists with the declared default", () => {
+    const signal = {
+      rootPath: "channels.demo",
+      mode: { default: "poll", allowed: ["poll", "webhook"] },
+    };
+    // Missing mode falls back to the default and passes the allowed list.
+    expect(
+      manifestConfigSignalPasses({
+        config: makeConfig({ channels: { demo: {} } }),
+        env: {},
+        signal,
+      }),
+    ).toBe(true);
+    expect(
+      manifestConfigSignalPasses({
+        config: makeConfig({ channels: { demo: { mode: "off" } } }),
+        env: {},
+        signal,
+      }),
+    ).toBe(false);
+    expect(
+      manifestConfigSignalPasses({
+        config: makeConfig({ channels: { demo: { mode: "webhook" } } }),
+        env: {},
+        signal: { rootPath: "channels.demo", mode: { disallowed: ["webhook"] } },
+      }),
+    ).toBe(false);
+    // No mode value and no default fails closed.
+    expect(
+      manifestConfigSignalPasses({
+        config: makeConfig({ channels: { demo: {} } }),
+        env: {},
+        signal: { rootPath: "channels.demo", mode: {} },
+      }),
+    ).toBe(false);
+  });
+
+  it("passes when any overlay-map account satisfies the signal", () => {
+    const signal = {
+      rootPath: "channels.demo",
+      overlayMapPath: "accounts",
+      required: ["token"],
+    };
+    expect(
+      manifestConfigSignalPasses({
+        config: makeConfig({
+          channels: { demo: { accounts: { first: {}, second: { token: "abc" } } } },
+        }),
+        env: {},
+        signal,
+      }),
+    ).toBe(true);
+    expect(
+      manifestConfigSignalPasses({
+        config: makeConfig({ channels: { demo: { token: "abc" } } }),
+        env: {},
+        signal,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("manifestProviderBaseUrlGuardPasses", () => {
+  const guard = {
+    provider: "xai",
+    defaultBaseUrl: "https://api.x.ai/v1",
+    allowedBaseUrls: ["https://api.x.ai/v1"],
+  };
+
+  it("passes when no guard is declared", () => {
+    expect(manifestProviderBaseUrlGuardPasses({ config: makeConfig({}), guard: undefined })).toBe(
+      true,
+    );
+  });
+
+  it("falls back to the default base URL when the provider has none configured", () => {
+    expect(manifestProviderBaseUrlGuardPasses({ config: makeConfig({}), guard })).toBe(true);
+  });
+
+  it("ignores trailing slashes when comparing configured base URLs", () => {
+    expect(
+      manifestProviderBaseUrlGuardPasses({
+        config: makeConfig({
+          models: { providers: { xai: { baseUrl: "https://api.x.ai/v1//" } } },
+        }),
+        guard,
+      }),
+    ).toBe(true);
+  });
+
+  it("fails for a configured base URL outside the allowlist", () => {
+    expect(
+      manifestProviderBaseUrlGuardPasses({
+        config: makeConfig({
+          models: { providers: { xai: { baseUrl: "https://proxy.example.com/v1" } } },
+        }),
+        guard,
+      }),
+    ).toBe(false);
+  });
+
+  it("fails when neither a configured nor a default base URL exists", () => {
+    expect(
+      manifestProviderBaseUrlGuardPasses({
+        config: makeConfig({}),
+        guard: { provider: "xai", allowedBaseUrls: ["https://api.x.ai/v1"] },
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("manifestPluginSetupProviderEnvVars", () => {
+  it("prefers setup provider env vars and falls back to providerAuthEnvVars", () => {
+    const plugin = makePlugin({
+      providerAuthEnvVars: { xai: ["XAI_API_KEY"] },
+      setup: { providers: [{ id: "xai", envVars: ["XAI_TOKEN"] }] },
+    });
+    expect(manifestPluginSetupProviderEnvVars(plugin, "xai")).toEqual(["XAI_TOKEN"]);
+
+    const fallbackPlugin = makePlugin({ providerAuthEnvVars: { xai: ["XAI_API_KEY"] } });
+    expect(manifestPluginSetupProviderEnvVars(fallbackPlugin, "xai")).toEqual(["XAI_API_KEY"]);
+    expect(manifestPluginSetupProviderEnvVars(fallbackPlugin, "other")).toEqual([]);
+  });
+});
+
+describe("hasNonEmptyManifestEnvCandidate", () => {
+  const cases: Array<[NodeJS.ProcessEnv, readonly string[], boolean]> = [
+    [{ XAI_API_KEY: "sk" }, ["XAI_API_KEY"], true],
+    [{ XAI_API_KEY: "   " }, ["XAI_API_KEY"], false],
+    [{}, ["XAI_API_KEY"], false],
+    [{ OTHER: "x" }, [" ", ""], false],
+    [{ SECOND: "ok" }, ["FIRST", "SECOND"], true],
+  ];
+  it.each(cases)("env %o with vars %o resolves to %s", (env, envVars, expected) => {
+    expect(hasNonEmptyManifestEnvCandidate(env, envVars)).toBe(expected);
+  });
+});
+
+describe("hasManifestToolAvailability", () => {
+  const xaiPlugin = makePlugin({
+    id: "xai",
+    providers: ["xai"],
+    providerAuthEnvVars: { xai: ["XAI_API_KEY"] },
+    toolMetadata: {
+      x_search: {
+        authSignals: [{ provider: "xai" }],
+        configSignals: [webSearchSignal],
+      },
+    },
+  });
+
+  it("treats tools without manifest metadata as available", () => {
+    // Fail-open contract: only tools that declare signals are gated; unknown
+    // or unannotated tools must not be hidden by the manifest layer.
+    expect(
+      hasManifestToolAvailability({ plugin: xaiPlugin, toolNames: ["unlisted"], env: {} }),
+    ).toBe(true);
+    expect(
+      hasManifestToolAvailability({
+        plugin: makePlugin({ toolMetadata: { listed: {} } }),
+        toolNames: ["listed"],
+        env: {},
+      }),
+    ).toBe(true);
+  });
+
+  it("passes on a satisfied config signal without any auth", () => {
+    expect(
+      hasManifestToolAvailability({
+        plugin: xaiPlugin,
+        toolNames: ["x_search"],
+        config: xaiConfig({ webSearch: { apiKey: "sk-xai" } }),
+        env: {},
+      }),
+    ).toBe(true);
+  });
+
+  it("passes when the auth callback grants the signal provider", () => {
+    expect(
+      hasManifestToolAvailability({
+        plugin: xaiPlugin,
+        toolNames: ["x_search"],
+        env: {},
+        hasAuthForProvider: (providerId) => providerId === "xai",
+      }),
+    ).toBe(true);
+  });
+
+  it("passes when a manifest-declared env candidate is present", () => {
+    expect(
+      hasManifestToolAvailability({
+        plugin: xaiPlugin,
+        toolNames: ["x_search"],
+        env: { XAI_API_KEY: "sk-xai" },
+      }),
+    ).toBe(true);
+  });
+
+  it("fails when config, auth, and env signals are all unsatisfied", () => {
+    expect(
+      hasManifestToolAvailability({ plugin: xaiPlugin, toolNames: ["x_search"], env: {} }),
+    ).toBe(false);
+  });
+
+  it("skips auth signals whose provider base URL guard rejects the config", () => {
+    const guardedPlugin = makePlugin({
+      id: "xai",
+      providers: ["xai"],
+      toolMetadata: {
+        x_search: {
+          authSignals: [
+            {
+              provider: "xai",
+              providerBaseUrl: {
+                provider: "xai",
+                defaultBaseUrl: "https://api.x.ai/v1",
+                allowedBaseUrls: ["https://api.x.ai/v1"],
+              },
+            },
+          ],
+        },
+      },
+    });
+    const offAllowlist = makeConfig({
+      models: { providers: { xai: { baseUrl: "https://proxy.example.com/v1" } } },
+    });
+    // The guard must veto the auth signal even though auth itself would pass.
+    expect(
+      hasManifestToolAvailability({
+        plugin: guardedPlugin,
+        toolNames: ["x_search"],
+        config: offAllowlist,
+        env: {},
+        hasAuthForProvider: () => true,
+      }),
+    ).toBe(false);
+    expect(
+      hasManifestToolAvailability({
+        plugin: guardedPlugin,
+        toolNames: ["x_search"],
+        env: {},
+        hasAuthForProvider: () => true,
+      }),
+    ).toBe(true);
+  });
+
+  it("maps legacy authProviders and aliases shorthand to auth signals", () => {
+    const legacyPlugin = makePlugin({
+      id: "legacy",
+      providerAuthEnvVars: { alias: ["ALIAS_KEY"] },
+      toolMetadata: {
+        legacy_tool: { authProviders: ["primary"], aliases: ["alias"] },
+      },
+    });
+    expect(
+      hasManifestToolAvailability({
+        plugin: legacyPlugin,
+        toolNames: ["legacy_tool"],
+        env: {},
+        hasAuthForProvider: (providerId) => providerId === "primary",
+      }),
+    ).toBe(true);
+    expect(
+      hasManifestToolAvailability({
+        plugin: legacyPlugin,
+        toolNames: ["legacy_tool"],
+        env: { ALIAS_KEY: "tok" },
+      }),
+    ).toBe(true);
+    expect(
+      hasManifestToolAvailability({ plugin: legacyPlugin, toolNames: ["legacy_tool"], env: {} }),
+    ).toBe(false);
+  });
+
+  it("passes when any one of several requested tools is available", () => {
+    expect(
+      hasManifestToolAvailability({
+        plugin: xaiPlugin,
+        toolNames: ["x_search", "unlisted"],
+        env: {},
+      }),
+    ).toBe(true);
+    expect(
+      hasManifestToolAvailability({
+        plugin: xaiPlugin,
+        toolNames: ["x_search", "x_search"],
+        env: {},
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/plugins/manifest-tool-availability.test.ts
+++ b/src/plugins/manifest-tool-availability.test.ts
@@ -1,4 +1,4 @@
-// Covers manifest tool-availability gating: config signals, auth signals, and env fallbacks.
+// Manifest tool-availability tests cover config, auth, environment, and base-URL gates.
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginManifestRecord } from "./manifest-registry.js";
@@ -41,174 +41,122 @@ function xaiConfig(config: Record<string, unknown>): OpenClawConfig {
 }
 
 describe("manifestConfigSignalPasses", () => {
-  it("fails when the signal root path is absent from config", () => {
-    expect(
-      manifestConfigSignalPasses({ config: makeConfig({}), env: {}, signal: webSearchSignal }),
-    ).toBe(false);
+  it.each([
+    {
+      name: "missing root",
+      config: makeConfig({}),
+      signal: webSearchSignal,
+      expected: false,
+    },
+    {
+      name: "overlay supplies required value",
+      config: xaiConfig({ apiKey: "", webSearch: { apiKey: "token" } }),
+      signal: webSearchSignal,
+      expected: true,
+    },
+    {
+      name: "overlay clears root required value",
+      config: xaiConfig({ apiKey: "token", webSearch: { apiKey: "" } }),
+      signal: webSearchSignal,
+      expected: false,
+    },
+    {
+      name: "requiredAny accepts one configured path",
+      config: makeConfig({ channels: { demo: { tokenFile: "/tmp/token" } } }),
+      signal: { rootPath: "channels.demo", requiredAny: ["token", "tokenFile"] },
+      expected: true,
+    },
+    {
+      name: "requiredAny rejects missing configured paths",
+      config: makeConfig({ channels: { demo: { other: true } } }),
+      signal: { rootPath: "channels.demo", requiredAny: ["token", "tokenFile"] },
+      expected: false,
+    },
+    {
+      name: "mode uses an allowed default",
+      config: makeConfig({ channels: { demo: {} } }),
+      signal: {
+        rootPath: "channels.demo",
+        mode: { default: "poll", allowed: ["poll", "webhook"] },
+      },
+      expected: true,
+    },
+    {
+      name: "mode rejects a value outside the allowlist",
+      config: makeConfig({ channels: { demo: { mode: "off" } } }),
+      signal: {
+        rootPath: "channels.demo",
+        mode: { allowed: ["poll", "webhook"] },
+      },
+      expected: false,
+    },
+    {
+      name: "mode rejects a disallowed value",
+      config: makeConfig({ channels: { demo: { mode: "webhook" } } }),
+      signal: { rootPath: "channels.demo", mode: { disallowed: ["webhook"] } },
+      expected: false,
+    },
+    {
+      name: "mode rejects a missing value without a default",
+      config: makeConfig({ channels: { demo: {} } }),
+      signal: { rootPath: "channels.demo", mode: {} },
+      expected: false,
+    },
+    {
+      name: "overlay map accepts one configured account",
+      config: makeConfig({
+        channels: { demo: { accounts: { first: {}, second: { token: "abc" } } } },
+      }),
+      signal: { rootPath: "channels.demo", overlayMapPath: "accounts", required: ["token"] },
+      expected: true,
+    },
+    {
+      name: "overlay map rejects a missing map",
+      config: makeConfig({ channels: { demo: { token: "abc" } } }),
+      signal: { rootPath: "channels.demo", overlayMapPath: "accounts", required: ["token"] },
+      expected: false,
+    },
+  ])("handles $name", ({ config, signal, expected }) => {
+    expect(manifestConfigSignalPasses({ config, env: {}, signal })).toBe(expected);
   });
 
-  it("passes when a required path is configured under the overlay", () => {
+  it.each([
+    ["", false],
+    ["   ", false],
+    [[], false],
+    [{}, false],
+    [null, false],
+    [undefined, false],
+    [0, true],
+    [false, true],
+    [["value"], true],
+    [{ value: true }, true],
+  ] as const)("treats required value %o as configured=%s", (apiKey, expected) => {
     expect(
       manifestConfigSignalPasses({
-        config: xaiConfig({ webSearch: { apiKey: "sk-xai" } }),
+        config: xaiConfig({ webSearch: { apiKey } }),
         env: {},
         signal: webSearchSignal,
       }),
-    ).toBe(true);
+    ).toBe(expected);
   });
 
-  it("lets overlay values override root values", () => {
-    // The overlay merge ({ ...root, ...overlay }) must win over the root value;
-    // here the root apiKey is blank and only the overlay provides a real one.
-    expect(
-      manifestConfigSignalPasses({
-        config: xaiConfig({ apiKey: "", webSearch: { apiKey: "sk-xai" } }),
-        env: {},
-        signal: webSearchSignal,
-      }),
-    ).toBe(true);
-    expect(
-      manifestConfigSignalPasses({
-        config: xaiConfig({ apiKey: "sk-root", webSearch: { apiKey: "" } }),
-        env: {},
-        signal: webSearchSignal,
-      }),
-    ).toBe(false);
-  });
-
-  const emptyRequiredValues: Array<[string, unknown]> = [
-    ["empty string", ""],
-    ["whitespace string", "   "],
-    ["empty array", []],
-    ["empty object", {}],
-    ["null", null],
-    ["undefined", undefined],
-  ];
-  it.each(emptyRequiredValues)("treats %s as not configured", (_label, value) => {
-    expect(
-      manifestConfigSignalPasses({
-        config: xaiConfig({ webSearch: { apiKey: value } }),
-        env: {},
-        signal: webSearchSignal,
-      }),
-    ).toBe(false);
-  });
-
-  const presentRequiredValues: Array<[string, unknown]> = [
-    ["zero", 0],
-    ["false", false],
-    ["non-empty array", ["a"]],
-    ["non-empty object", { nested: true }],
-  ];
-  it.each(presentRequiredValues)("treats %s as configured", (_label, value) => {
-    expect(
-      manifestConfigSignalPasses({
-        config: xaiConfig({ webSearch: { apiKey: value } }),
-        env: {},
-        signal: webSearchSignal,
-      }),
-    ).toBe(true);
-  });
-
-  it("resolves env secret refs in required paths against the environment", () => {
+  it("resolves env secret refs only when their value is non-empty", () => {
     const config = xaiConfig({
       webSearch: { apiKey: { source: "env", id: "XAI_API_KEY" } },
     });
     expect(
       manifestConfigSignalPasses({
         config,
-        env: { XAI_API_KEY: "sk-xai" },
+        env: { XAI_API_KEY: "token" },
         signal: webSearchSignal,
       }),
     ).toBe(true);
-    expect(manifestConfigSignalPasses({ config, env: {}, signal: webSearchSignal })).toBe(false);
     expect(
       manifestConfigSignalPasses({
         config,
         env: { XAI_API_KEY: "   " },
         signal: webSearchSignal,
-      }),
-    ).toBe(false);
-  });
-
-  it("passes requiredAny when at least one path is configured", () => {
-    const signal = {
-      rootPath: "channels.demo",
-      requiredAny: ["token", "tokenFile"],
-    };
-    expect(
-      manifestConfigSignalPasses({
-        config: makeConfig({ channels: { demo: { tokenFile: "/tmp/token" } } }),
-        env: {},
-        signal,
-      }),
-    ).toBe(true);
-    expect(
-      manifestConfigSignalPasses({
-        config: makeConfig({ channels: { demo: { other: true } } }),
-        env: {},
-        signal,
-      }),
-    ).toBe(false);
-  });
-
-  it("gates on mode allowed/disallowed lists with the declared default", () => {
-    const signal = {
-      rootPath: "channels.demo",
-      mode: { default: "poll", allowed: ["poll", "webhook"] },
-    };
-    // Missing mode falls back to the default and passes the allowed list.
-    expect(
-      manifestConfigSignalPasses({
-        config: makeConfig({ channels: { demo: {} } }),
-        env: {},
-        signal,
-      }),
-    ).toBe(true);
-    expect(
-      manifestConfigSignalPasses({
-        config: makeConfig({ channels: { demo: { mode: "off" } } }),
-        env: {},
-        signal,
-      }),
-    ).toBe(false);
-    expect(
-      manifestConfigSignalPasses({
-        config: makeConfig({ channels: { demo: { mode: "webhook" } } }),
-        env: {},
-        signal: { rootPath: "channels.demo", mode: { disallowed: ["webhook"] } },
-      }),
-    ).toBe(false);
-    // No mode value and no default fails closed.
-    expect(
-      manifestConfigSignalPasses({
-        config: makeConfig({ channels: { demo: {} } }),
-        env: {},
-        signal: { rootPath: "channels.demo", mode: {} },
-      }),
-    ).toBe(false);
-  });
-
-  it("passes when any overlay-map account satisfies the signal", () => {
-    const signal = {
-      rootPath: "channels.demo",
-      overlayMapPath: "accounts",
-      required: ["token"],
-    };
-    expect(
-      manifestConfigSignalPasses({
-        config: makeConfig({
-          channels: { demo: { accounts: { first: {}, second: { token: "abc" } } } },
-        }),
-        env: {},
-        signal,
-      }),
-    ).toBe(true);
-    expect(
-      manifestConfigSignalPasses({
-        config: makeConfig({ channels: { demo: { token: "abc" } } }),
-        env: {},
-        signal,
       }),
     ).toBe(false);
   });
@@ -221,17 +169,11 @@ describe("manifestProviderBaseUrlGuardPasses", () => {
     allowedBaseUrls: ["https://api.x.ai/v1"],
   };
 
-  it("passes when no guard is declared", () => {
+  it("normalizes allowed URLs and rejects missing or foreign URLs", () => {
     expect(manifestProviderBaseUrlGuardPasses({ config: makeConfig({}), guard: undefined })).toBe(
       true,
     );
-  });
-
-  it("falls back to the default base URL when the provider has none configured", () => {
     expect(manifestProviderBaseUrlGuardPasses({ config: makeConfig({}), guard })).toBe(true);
-  });
-
-  it("ignores trailing slashes when comparing configured base URLs", () => {
     expect(
       manifestProviderBaseUrlGuardPasses({
         config: makeConfig({
@@ -240,20 +182,6 @@ describe("manifestProviderBaseUrlGuardPasses", () => {
         guard,
       }),
     ).toBe(true);
-  });
-
-  it("fails for a configured base URL outside the allowlist", () => {
-    expect(
-      manifestProviderBaseUrlGuardPasses({
-        config: makeConfig({
-          models: { providers: { xai: { baseUrl: "https://proxy.example.com/v1" } } },
-        }),
-        guard,
-      }),
-    ).toBe(false);
-  });
-
-  it("fails when neither a configured nor a default base URL exists", () => {
     expect(
       manifestProviderBaseUrlGuardPasses({
         config: makeConfig({}),
@@ -263,29 +191,23 @@ describe("manifestProviderBaseUrlGuardPasses", () => {
   });
 });
 
-describe("manifestPluginSetupProviderEnvVars", () => {
-  it("prefers setup provider env vars and falls back to providerAuthEnvVars", () => {
+describe("manifest auth environment helpers", () => {
+  it("uses setup provider env vars and returns empty without setup metadata", () => {
+    // providerAuthEnvVars is retired; setup provider metadata is the canonical env source.
     const plugin = makePlugin({
-      providerAuthEnvVars: { xai: ["XAI_API_KEY"] },
-      setup: { providers: [{ id: "xai", envVars: ["XAI_TOKEN"] }] },
+      setup: { providers: [{ id: "xai", envVars: ["XAI_API_KEY"] }] },
     });
-    expect(manifestPluginSetupProviderEnvVars(plugin, "xai")).toEqual(["XAI_TOKEN"]);
-
-    const fallbackPlugin = makePlugin({ providerAuthEnvVars: { xai: ["XAI_API_KEY"] } });
-    expect(manifestPluginSetupProviderEnvVars(fallbackPlugin, "xai")).toEqual(["XAI_API_KEY"]);
-    expect(manifestPluginSetupProviderEnvVars(fallbackPlugin, "other")).toEqual([]);
+    expect(manifestPluginSetupProviderEnvVars(plugin, "xai")).toEqual(["XAI_API_KEY"]);
+    expect(manifestPluginSetupProviderEnvVars(plugin, "other")).toEqual([]);
+    expect(manifestPluginSetupProviderEnvVars(makePlugin({}), "xai")).toEqual([]);
   });
-});
 
-describe("hasNonEmptyManifestEnvCandidate", () => {
-  const cases: Array<[NodeJS.ProcessEnv, readonly string[], boolean]> = [
-    [{ XAI_API_KEY: "sk" }, ["XAI_API_KEY"], true],
+  it.each([
+    [{ XAI_API_KEY: "token" }, ["XAI_API_KEY"], true],
     [{ XAI_API_KEY: "   " }, ["XAI_API_KEY"], false],
-    [{}, ["XAI_API_KEY"], false],
-    [{ OTHER: "x" }, [" ", ""], false],
-    [{ SECOND: "ok" }, ["FIRST", "SECOND"], true],
-  ];
-  it.each(cases)("env %o with vars %o resolves to %s", (env, envVars, expected) => {
+    [{ SECOND: "token" }, ["FIRST", "SECOND"], true],
+    [{ OTHER: "token" }, [" ", ""], false],
+  ] as const)("resolves env candidates", (env, envVars, expected) => {
     expect(hasNonEmptyManifestEnvCandidate(env, envVars)).toBe(expected);
   });
 });
@@ -294,7 +216,7 @@ describe("hasManifestToolAvailability", () => {
   const xaiPlugin = makePlugin({
     id: "xai",
     providers: ["xai"],
-    providerAuthEnvVars: { xai: ["XAI_API_KEY"] },
+    setup: { providers: [{ id: "xai", envVars: ["XAI_API_KEY"] }] },
     toolMetadata: {
       x_search: {
         authSignals: [{ provider: "xai" }],
@@ -303,9 +225,7 @@ describe("hasManifestToolAvailability", () => {
     },
   });
 
-  it("treats tools without manifest metadata as available", () => {
-    // Fail-open contract: only tools that declare signals are gated; unknown
-    // or unannotated tools must not be hidden by the manifest layer.
+  it("fails open for tools without availability signals", () => {
     expect(
       hasManifestToolAvailability({ plugin: xaiPlugin, toolNames: ["unlisted"], env: {} }),
     ).toBe(true);
@@ -316,20 +236,34 @@ describe("hasManifestToolAvailability", () => {
         env: {},
       }),
     ).toBe(true);
-  });
-
-  it("passes on a satisfied config signal without any auth", () => {
     expect(
       hasManifestToolAvailability({
         plugin: xaiPlugin,
-        toolNames: ["x_search"],
-        config: xaiConfig({ webSearch: { apiKey: "sk-xai" } }),
+        toolNames: ["x_search", "unlisted"],
         env: {},
       }),
     ).toBe(true);
   });
 
-  it("passes when the auth callback grants the signal provider", () => {
+  it.each([
+    {
+      name: "config",
+      config: xaiConfig({ webSearch: { apiKey: "token" } }),
+      env: {},
+    },
+    { name: "setup env", config: undefined, env: { XAI_API_KEY: "token" } },
+  ] as const)("passes with a satisfied $name signal", ({ config, env }) => {
+    expect(
+      hasManifestToolAvailability({
+        plugin: xaiPlugin,
+        toolNames: ["x_search"],
+        config,
+        env,
+      }),
+    ).toBe(true);
+  });
+
+  it("passes with profile auth and fails without any signal", () => {
     expect(
       hasManifestToolAvailability({
         plugin: xaiPlugin,
@@ -338,28 +272,13 @@ describe("hasManifestToolAvailability", () => {
         hasAuthForProvider: (providerId) => providerId === "xai",
       }),
     ).toBe(true);
-  });
-
-  it("passes when a manifest-declared env candidate is present", () => {
-    expect(
-      hasManifestToolAvailability({
-        plugin: xaiPlugin,
-        toolNames: ["x_search"],
-        env: { XAI_API_KEY: "sk-xai" },
-      }),
-    ).toBe(true);
-  });
-
-  it("fails when config, auth, and env signals are all unsatisfied", () => {
     expect(
       hasManifestToolAvailability({ plugin: xaiPlugin, toolNames: ["x_search"], env: {} }),
     ).toBe(false);
   });
 
-  it("skips auth signals whose provider base URL guard rejects the config", () => {
+  it("lets a provider base-URL guard veto otherwise valid auth", () => {
     const guardedPlugin = makePlugin({
-      id: "xai",
-      providers: ["xai"],
       toolMetadata: {
         x_search: {
           authSignals: [
@@ -375,15 +294,13 @@ describe("hasManifestToolAvailability", () => {
         },
       },
     });
-    const offAllowlist = makeConfig({
-      models: { providers: { xai: { baseUrl: "https://proxy.example.com/v1" } } },
-    });
-    // The guard must veto the auth signal even though auth itself would pass.
     expect(
       hasManifestToolAvailability({
         plugin: guardedPlugin,
         toolNames: ["x_search"],
-        config: offAllowlist,
+        config: makeConfig({
+          models: { providers: { xai: { baseUrl: "https://proxy.example/v1" } } },
+        }),
         env: {},
         hasAuthForProvider: () => true,
       }),
@@ -398,13 +315,10 @@ describe("hasManifestToolAvailability", () => {
     ).toBe(true);
   });
 
-  it("maps legacy authProviders and aliases shorthand to auth signals", () => {
+  it("maps legacy provider and alias shorthand into auth signals", () => {
     const legacyPlugin = makePlugin({
-      id: "legacy",
-      providerAuthEnvVars: { alias: ["ALIAS_KEY"] },
-      toolMetadata: {
-        legacy_tool: { authProviders: ["primary"], aliases: ["alias"] },
-      },
+      setup: { providers: [{ id: "alias", envVars: ["ALIAS_KEY"] }] },
+      toolMetadata: { legacy_tool: { authProviders: ["primary"], aliases: ["alias"] } },
     });
     expect(
       hasManifestToolAvailability({
@@ -418,26 +332,13 @@ describe("hasManifestToolAvailability", () => {
       hasManifestToolAvailability({
         plugin: legacyPlugin,
         toolNames: ["legacy_tool"],
-        env: { ALIAS_KEY: "tok" },
-      }),
-    ).toBe(true);
-    expect(
-      hasManifestToolAvailability({ plugin: legacyPlugin, toolNames: ["legacy_tool"], env: {} }),
-    ).toBe(false);
-  });
-
-  it("passes when any one of several requested tools is available", () => {
-    expect(
-      hasManifestToolAvailability({
-        plugin: xaiPlugin,
-        toolNames: ["x_search", "unlisted"],
-        env: {},
+        env: { ALIAS_KEY: "token" },
       }),
     ).toBe(true);
     expect(
       hasManifestToolAvailability({
-        plugin: xaiPlugin,
-        toolNames: ["x_search", "x_search"],
+        plugin: legacyPlugin,
+        toolNames: ["legacy_tool"],
         env: {},
       }),
     ).toBe(false);


### PR DESCRIPTION
Related: #100676

## What Problem This Solves

The manifest tool-availability gate decides whether plugin-declared tools reach an agent based on config, authentication, environment, mode, and provider base-URL signals. That compatibility-sensitive decision surface has no direct colocated regression suite, so a fail-open reversal or allowlist-gate regression could land without a focused failure.

## Why This Change Was Made

This maintainer branch preserves @KrasimirKralev's original coverage commit and tightens it against current `main` behavior. The resulting single test file covers all five exported helpers while using canonical plugin setup metadata instead of retired `providerAuthEnvVars` fixtures. No production code, config, default, dependency, or public API changes.

The fork branch on #100676 does not allow maintainer edits, so Peter approved this maintainer PR as the landing vehicle.

## User Impact

No runtime or user-visible behavior changes. Maintainers gain focused protection for plugin tool availability, including fail-open behavior for unannotated tools, config overlay semantics, SecretRef-backed environment values, mode gates, provider URL allowlists, setup environment metadata, and legacy auth aliases.

## Evidence

- Exact rebased head: `f819e80e6592e127ca034379a7523d2587bf615c` (approved source head `bcb3bd928e424be348aac74c2aa84d34c86cb0f1`).
- Contributor commit retained after rebase: `a604d49f34a2704ec39948dd515b669465d0a189` by Krasimir Kralev.
- The maintainer commit also carries `Co-authored-by: Krasimir Kralev <krasi@idrobots.com>` so squash landing preserves credit.
- The improved suite is one test-only file with 346 lines, reduced from the original 445-line draft while retaining the complete exported decision surface.
- The original PR supplied direct production-helper output for config, profile auth, setup env, whitespace rejection, fail-open behavior, and base-URL guard normalization.
- Focused test, changed-gate, AutoReview, and exact-head hosted CI results will be recorded on this PR before merge.
