### PR TITLE
fix(openai): model auth login hangs after success

### DIFF
--- a/extensions/openai/openai-chatgpt-oauth-flow.runtime.test.ts
+++ b/extensions/openai/openai-chatgpt-oauth-flow.runtime.test.ts
@@ -1,4 +1,5 @@
 // Openai tests cover openai chatgpt oauth flow plugin behavior.
+import { once } from "node:events";
 import { Agent, createServer, get, type IncomingHttpHeaders, type Server } from "node:http";
 import { connect, type Socket } from "node:net";
 import type { ProviderAuthContext } from "openclaw/plugin-sdk/plugin-entry";
@@ -69,10 +70,7 @@ function connectIdleSocket(url: string): Promise<Socket> {
     host: resolveOpenAICallbackHost(),
     port: Number(callbackUrl.port),
   });
-  return new Promise((resolve, reject) => {
-    socket.once("connect", () => resolve(socket));
-    socket.once("error", reject);
-  });
+  return once(socket, "connect").then(() => socket);
 }
 
 function mockTokenResponse(body: unknown, status = 200): void {

--- a/extensions/openai/openai-chatgpt-oauth-flow.runtime.test.ts
+++ b/extensions/openai/openai-chatgpt-oauth-flow.runtime.test.ts
@@ -1,5 +1,6 @@
 // Openai tests cover openai chatgpt oauth flow plugin behavior.
 import { Agent, createServer, get, type IncomingHttpHeaders, type Server } from "node:http";
+import { connect, type Socket } from "node:net";
 import type { ProviderAuthContext } from "openclaw/plugin-sdk/plugin-entry";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -59,6 +60,18 @@ function requestCallback(
       });
     });
     request.on("error", reject);
+  });
+}
+
+function connectIdleSocket(url: string): Promise<Socket> {
+  const callbackUrl = new URL(url);
+  const socket = connect({
+    host: resolveOpenAICallbackHost(),
+    port: Number(callbackUrl.port),
+  });
+  return new Promise((resolve, reject) => {
+    socket.once("connect", () => resolve(socket));
+    socket.once("error", reject);
   });
 }
 
@@ -167,7 +180,7 @@ describe("OpenAI Codex OAuth flow", () => {
     );
   });
 
-  it("disconnects a keep-alive callback and cancels stale manual input", async () => {
+  it("disconnects callback sockets and cancels stale manual input", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn(async () => new Response(null, { status: 302 })),
@@ -182,6 +195,7 @@ describe("OpenAI Codex OAuth flow", () => {
     });
     const agent = new Agent({ keepAlive: true });
     let callbackResponse: Promise<{ headers: IncomingHttpHeaders; body: string }> | undefined;
+    let idleSocket: Socket | undefined;
     let manualPromptAborted = false;
     let manualPrompt: Promise<string> | undefined;
     const prompter = {
@@ -211,6 +225,7 @@ describe("OpenAI Codex OAuth flow", () => {
             if (!redirectUri || !state) {
               throw new Error("OAuth URL missing callback parameters");
             }
+            idleSocket = await connectIdleSocket(redirectUri);
             manualPrompt = params.prompter.text({
               message: "Paste callback",
               signal: params.manualPromptSignal,
@@ -244,7 +259,9 @@ describe("OpenAI Codex OAuth flow", () => {
       expect(response.body).toContain("OpenAI authentication completed");
       await vi.waitFor(() => expect(manualPromptAborted).toBe(true));
       expect(Object.keys(agent.freeSockets)).toHaveLength(0);
+      await vi.waitFor(() => expect(idleSocket?.destroyed).toBe(true));
     } finally {
+      idleSocket?.destroy();
       agent.destroy();
     }
   });

--- a/extensions/openai/openai-chatgpt-oauth-flow.runtime.ts
+++ b/extensions/openai/openai-chatgpt-oauth-flow.runtime.ts
@@ -154,7 +154,12 @@ async function startLocalOAuthServer(state: string): Promise<OAuthServerInfo> {
     server
       .listen(CALLBACK_PORT, CALLBACK_HOST, () => {
         resolve({
-          close: () => server.close(),
+          close: () => {
+            server.close();
+            // An accepted socket can stay idle without ever receiving a response.
+            // Force it closed so the completed auth flow cannot pin the CLI process.
+            server.closeAllConnections();
+          },
           cancelWait: () => {
             settleWait?.(null);
           },

--- a/extensions/openai/openai-chatgpt-oauth-flow.runtime.ts
+++ b/extensions/openai/openai-chatgpt-oauth-flow.runtime.ts
@@ -156,8 +156,7 @@ async function startLocalOAuthServer(state: string): Promise<OAuthServerInfo> {
         resolve({
           close: () => {
             server.close();
-            // An accepted socket can stay idle without ever receiving a response.
-            // Force it closed so the completed auth flow cannot pin the CLI process.
+            // Force-close preconnected sockets so they cannot pin the CLI process.
             server.closeAllConnections();
           },
           cancelWait: () => {

--- a/src/commands/models/auth.test.ts
+++ b/src/commands/models/auth.test.ts
@@ -510,7 +510,7 @@ describe("modelsAuthLoginCommand", () => {
       "Auth profile: openai:user@example.com (openai/oauth)",
     );
     expect(runtime.log).toHaveBeenCalledWith(
-      "Default model available: openai/gpt-5.5 (use --set-default to apply)",
+      "Default model available: openai/gpt-5.5 (current default unchanged; run openclaw models set openai/gpt-5.5 to apply)",
     );
     expect(mocks.callGateway).toHaveBeenCalledWith({
       method: "models.authStatus",
@@ -1150,7 +1150,7 @@ describe("modelsAuthLoginCommand", () => {
     });
     expect(lastUpdatedConfig?.auth).toBeUndefined();
     expect(runtime.log).toHaveBeenCalledWith(
-      "Default model available: openai/gpt-5.5 (use --set-default to apply)",
+      "Default model available: openai/gpt-5.5 (current default unchanged; run openclaw models set openai/gpt-5.5 to apply)",
     );
   });
 

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -511,7 +511,7 @@ async function persistProviderAuthResult(params: {
     params.runtime.log(
       params.setDefault
         ? `Default model set to ${defaultModel}`
-        : `Default model available: ${defaultModel} (use --set-default to apply)`,
+        : `Default model available: ${defaultModel} (current default unchanged; run ${formatCliCommand(`openclaw models set ${defaultModel}`)} to apply)`,
     );
   }
   if (params.result.notes && params.result.notes.length > 0) {


### PR DESCRIPTION
Related: #89491

## What Problem This Solves

Fixes an issue where users completing `openclaw models auth login --provider openai` could see a successful login but have the CLI remain running when the browser left an idle loopback connection open. The success message also suggested `--set-default` without showing which command accepts that flag or the direct command for applying the model.

## Why This Change Was Made

The OAuth callback shutdown now closes the listener and all accepted callback connections, including idle browser preconnections that never receive a response. The default-model recommendation now preserves the current default and prints the complete `openclaw models set <model>` command users can run.

## User Impact

OpenAI model authentication exits after a successful callback even when the browser keeps an unused callback connection alive. Users who want the advertised model as their default now get a runnable command instead of an ambiguous flag hint.

## Evidence

- Before: a standalone callback-server reproduction left an accepted idle socket alive after `server.close()`, so the close callback never completed.
- Regression coverage opens an idle callback socket, completes OAuth successfully, and verifies both the callback response and idle socket disconnect while stale manual input is aborted.
- Focused Testbox run: 55/55 tests passed across `extensions/openai/openai-chatgpt-oauth-flow.runtime.test.ts` and `src/commands/models/auth.test.ts` ([run](https://github.com/openclaw/openclaw/actions/runs/29810991793)).
- Changed-surface Testbox gate passed formatting, lint, import/boundary checks, core and extension typechecks, and test typechecks ([run](https://github.com/openclaw/openclaw/actions/runs/29811117495)).
- Fresh Codex autoreview reported no accepted or actionable findings.

AI-assisted: Yes (Codex). The generated agent transcript is intentionally omitted because attaching it requires explicit user approval.
