### PR TITLE
fix(zai): bound deprecated Pi Agent auth file read

### DIFF
--- a/extensions/zai/index.test.ts
+++ b/extensions/zai/index.test.ts
@@ -584,4 +584,29 @@ describe("zai provider plugin", () => {
       await fs.rm(home, { recursive: true, force: true });
     }
   });
+
+  it("rejects an oversized deprecated pi agent auth.json instead of slurping it into memory", async () => {
+    const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-zai-legacy-auth-oversized-"));
+    try {
+      const authDir = path.join(home, ".pi", "agent");
+      await fs.mkdir(authDir, { recursive: true });
+      // Valid JSON but larger than the 1 MiB bound. The old unbounded
+      // readFileSync read the entire file into memory solely to extract an
+      // access token; the bound treats it as unreadable instead.
+      const oversized = JSON.stringify({
+        "z-ai": { access: `legacy-zai-token-${"x".repeat(2 * 1024 * 1024)}` },
+      });
+      await fs.writeFile(path.join(authDir, "auth.json"), oversized, "utf-8");
+      const provider = await registerSingleProviderPlugin(plugin);
+
+      await expect(
+        provider.resolveUsageAuth?.({
+          env: { HOME: home },
+          resolveApiKeyFromConfigAndStore: () => undefined,
+        } as never),
+      ).resolves.toBeNull();
+    } finally {
+      await fs.rm(home, { recursive: true, force: true });
+    }
+  });
 });

--- a/extensions/zai/index.test.ts
+++ b/extensions/zai/index.test.ts
@@ -625,4 +625,29 @@ describe("zai provider plugin", () => {
       await fs.rm(home, { recursive: true, force: true });
     }
   });
+
+  it("rejects an oversized deprecated pi agent auth.json instead of slurping it into memory", async () => {
+    const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-zai-legacy-auth-oversized-"));
+    try {
+      const authDir = path.join(home, ".pi", "agent");
+      await fs.mkdir(authDir, { recursive: true });
+      // Valid JSON but larger than the 1 MiB bound. The old unbounded
+      // readFileSync read the entire file into memory solely to extract an
+      // access token; the bound treats it as unreadable instead.
+      const oversized = JSON.stringify({
+        "z-ai": { access: `legacy-zai-token-${"x".repeat(2 * 1024 * 1024)}` },
+      });
+      await fs.writeFile(path.join(authDir, "auth.json"), oversized, "utf-8");
+      const provider = await registerSingleProviderPlugin(plugin);
+
+      await expect(
+        provider.resolveUsageAuth?.({
+          env: { HOME: home },
+          resolveApiKeyFromConfigAndStore: () => undefined,
+        } as never),
+      ).resolves.toBeNull();
+    } finally {
+      await fs.rm(home, { recursive: true, force: true });
+    }
+  });
 });

--- a/extensions/zai/index.ts
+++ b/extensions/zai/index.ts
@@ -1,5 +1,4 @@
 // Zai plugin entrypoint registers its OpenClaw integration.
-import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import {
@@ -31,6 +30,7 @@ import {
   defaultToolStreamExtraParams,
 } from "openclaw/plugin-sdk/provider-stream-shared";
 import { fetchZaiUsage } from "openclaw/plugin-sdk/provider-usage";
+import { tryReadSecretFileSync } from "openclaw/plugin-sdk/secret-file-runtime";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { detectZaiEndpoint, type ZaiEndpointId } from "./detect.js";
 import { zaiMediaUnderstandingProvider } from "./media-understanding-provider.js";
@@ -41,6 +41,7 @@ import { isGlm52ModelId, resolveThinkingProfile } from "./provider-policy-api.js
 const PROVIDER_ID = "zai";
 const GLM5_TEMPLATE_MODEL_ID = "glm-4.7";
 const PROFILE_ID = "zai:default";
+const PI_AGENT_AUTH_FILE_MAX_BYTES = 1024 * 1024;
 type UpsertAuthProfileParams = Parameters<typeof upsertAuthProfileWithLock>[0];
 
 function resolveDeprecatedPiAgentAuthPath(env: NodeJS.ProcessEnv): string {
@@ -54,13 +55,14 @@ function resolveDeprecatedPiAgentAccessToken(
 ): string | undefined {
   try {
     const authPath = resolveDeprecatedPiAgentAuthPath(env);
-    if (!fs.existsSync(authPath)) {
+    const text = tryReadSecretFileSync(authPath, "Pi Agent auth file", {
+      maxBytes: PI_AGENT_AUTH_FILE_MAX_BYTES,
+      rejectHardlinks: false,
+    });
+    if (!text) {
       return undefined;
     }
-    const parsed = JSON.parse(fs.readFileSync(authPath, "utf-8")) as Record<
-      string,
-      { access?: unknown }
-    >;
+    const parsed = JSON.parse(text) as Record<string, { access?: unknown }>;
     for (const providerId of providerIds) {
       const token = parsed[providerId]?.access;
       if (typeof token === "string" && token.trim()) {

--- a/extensions/zai/index.ts
+++ b/extensions/zai/index.ts
@@ -1,5 +1,4 @@
 // Zai plugin entrypoint registers its OpenClaw integration.
-import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import type {
@@ -30,6 +29,7 @@ import {
   defaultToolStreamExtraParams,
 } from "openclaw/plugin-sdk/provider-stream-shared";
 import { fetchZaiUsage } from "openclaw/plugin-sdk/provider-usage";
+import { tryReadSecretFileSync } from "openclaw/plugin-sdk/secret-file-runtime";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { detectZaiEndpoint, type ZaiEndpointId } from "./detect.js";
 import { zaiMediaUnderstandingProvider } from "./media-understanding-provider.js";
@@ -45,6 +45,7 @@ import { resolveThinkingProfile, resolveZaiReasoningEffort } from "./provider-po
 const PROVIDER_ID = "zai";
 const GLM5_TEMPLATE_MODEL_ID = "glm-4.7";
 const PROFILE_ID = "zai:default";
+const PI_AGENT_AUTH_FILE_MAX_BYTES = 1024 * 1024;
 function resolveDeprecatedPiAgentAuthPath(env: NodeJS.ProcessEnv): string {
   const home = env.HOME?.trim() || env.USERPROFILE?.trim() || os.homedir();
   return path.join(home, ".pi", "agent", "auth.json");
@@ -56,13 +57,14 @@ function resolveDeprecatedPiAgentAccessToken(
 ): string | undefined {
   try {
     const authPath = resolveDeprecatedPiAgentAuthPath(env);
-    if (!fs.existsSync(authPath)) {
+    const text = tryReadSecretFileSync(authPath, "Pi Agent auth file", {
+      maxBytes: PI_AGENT_AUTH_FILE_MAX_BYTES,
+      rejectHardlinks: false,
+    });
+    if (!text) {
       return undefined;
     }
-    const parsed = JSON.parse(fs.readFileSync(authPath, "utf-8")) as Record<
-      string,
-      { access?: unknown }
-    >;
+    const parsed = JSON.parse(text) as Record<string, { access?: unknown }>;
     for (const providerId of providerIds) {
       const token = parsed[providerId]?.access;
       if (typeof token === "string" && token.trim()) {


### PR DESCRIPTION
## What Problem This Solves

`resolveDeprecatedPiAgentAccessToken` in `extensions/zai/index.ts` reads the entire deprecated Pi Agent auth file (`~/.pi/agent/auth.json`) via unbounded `fs.readFileSync(..., "utf-8")` solely to extract an `access` token for backward-compatible usage auth. The path is derived from the external `HOME`/`USERPROFILE` env var, so a misconfigured or oversized auth file triggers an unbounded memory read just to extract a legacy token.

The Codex CLI auth-file reader sibling was already bounded with `tryReadSecretFileSync` + a 1 MiB limit in #111206 ("bound Codex CLI auth file read"), itself mirroring the Anthropic Vertex ADC reader bounded in #109260 ("reject oversized credential files in remaining readers"). This deprecated Pi Agent auth-file reader is a duplicate of that shape the original sweep missed.

Mirror the #111206 / `region.ts` bound: replace the unbounded `readFileSync` with `tryReadSecretFileSync(..., { maxBytes: 1 MiB, rejectHardlinks: false })`, guarded by `if (!text) return undefined`. `tryReadSecretFileSync` throws `FsSafeError` on oversize; the existing `try/catch` returns `undefined` (the file is treated as unreadable, same as a missing/corrupt auth file) instead of slurping it into memory. Token extraction semantics are unchanged for normal-sized auth files. The now-unused `import fs from "node:fs"` is removed.

## Why This Change Was Made

Unbounded sync reads of external credential files are a known hardening gap; #109260 and #111206 established `tryReadSecretFileSync` as the bounded reader for credential/auth JSON. This applies the same bound to the last unbounded sibling in the auth-file-read family, so a misconfigured `~/.pi/agent/auth.json` cannot force an unbounded memory read during usage-auth resolution.

## User Impact

No user-visible behavior change for normal-sized auth files: the legacy Pi Agent token is still extracted when modern auth sources are empty. An oversized/misconfigured auth file is now treated as unreadable (usage auth falls back to `null`, same as a missing file) instead of being read into memory in full.

## Evidence

Standalone proof (`proof-zai-pi-agent-auth-file-bound.mts`, exercised through the plugin's `resolveUsageAuth` fallback path via `registerSingleProviderPlugin`, the same entry the vitest suite uses):
- Normal auth.json (53 B) -> `{"token":"legacy-zai-token"}` (preserved).
- Oversized auth.json (2 MiB, exceeds the 1 MiB bound) -> `null` (rejected by bound); the old unbounded `readFileSync` read the entire 2 MiB file into memory.
- `RESULT: normal read preserved = true; oversized rejected by bound = true; old code read it fully = true` -> `PASS`.

Full proof run output:

```
=== Bound the deprecated Pi Agent auth file read (zai usage-auth path) ===
Auth file read bound: 1048576 bytes (1024 KiB)

[1] Normal auth.json (small, valid):
    size:  53 bytes
    NEW resolveUsageAuth: {"token":"legacy-zai-token"}  (expected {"token":"legacy-zai-token"})

[2] Oversized auth.json (2 MiB, exceeds bound):
    size:  2097154 bytes
    OLD unbounded readFileSync: true  (read entire 2097153-byte file into memory)
    NEW resolveUsageAuth: null  (expected null: bound rejects oversize)

RESULT: normal read preserved = true; oversized rejected by bound = true; old code read it fully = true
PASS
```

New regression test `rejects an oversized deprecated pi agent auth.json instead of slurping it into memory`: writes a 2 MiB auth.json to a temp `HOME` and asserts `resolveUsageAuth` returns `null` (bound rejects). The existing `uses deprecated pi agent auth.json for usage auth when modern sources are empty` test confirms a normal-sized auth file still yields the `legacy-zai-token` (no regression).

### Regression test is defect-sensitive (fails without the production change)

Verified by reverting **only** `extensions/zai/index.ts` to its pre-fix state and re-running the new
test against a real 2 MiB file on disk:

```
without the fix:  Tests  1 failed | 16 passed (17)
                  ❯ extensions/zai/index.test.ts:648:8
with the fix:     Tests  17 passed (17)
```

The failure output is the unbounded `readFileSync` slurping the whole 2 MiB file into memory — the
exact behavior this PR removes. The test drives the real exported entry point
(`provider.resolveUsageAuth` via `registerSingleProviderPlugin`), not a re-implementation of the
predicate.

Full-file run on the rebased head (`Node v22.22.3`):

```
 Test Files  1 passed (1)
      Tests  17 passed (17)
   Duration  104.92s
```

`oxfmt --check` on both changed files: `All matched files use the correct format.`
`oxlint -c .oxlintrc.json` on both changed files: `Found 0 warnings and 0 errors.`

Diff scope: 2 files, `+8/-6` in `extensions/zai/index.ts` and `+25/-0` in `extensions/zai/index.test.ts` — production LOC decreases, no incidental edits.

Sibling of #111206 (same `tryReadSecretFileSync` 1 MiB bound, same unbounded-sync-`readFileSync`-of-a-credential-JSON shape); applies it to the deprecated Pi Agent auth-file reader the original sweep missed.

---

_Rebased onto current `main` (single commit, `17c1b251371`): the branch predated the `fs.existsSync` guard added to this function, so the rebase keeps the bounded reader and drops the now-redundant existence check, since `tryReadSecretFileSync` already returns `undefined` for an absent file._


