### PR TITLE
fix(memory-core): keep memory search usable during dirty sync

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -759,7 +759,6 @@ extensions/memory-core/src/memory/manager-embedding-cache.ts	1
 extensions/memory-core/src/memory/manager-embedding-errors.ts	2
 extensions/memory-core/src/memory/manager-embedding-ops.ts	2
 extensions/memory-core/src/memory/manager-keyword-retrieval.ts	1
-extensions/memory-core/src/memory/manager-reindex-lock.ts	1
 extensions/memory-core/src/memory/manager-search-orchestration.ts	3
 extensions/memory-core/src/memory/manager-search.ts	12
 extensions/memory-core/src/memory/manager-source-state.ts	2

--- a/extensions/memory-core/src/memory/manager-async-state.test.ts
+++ b/extensions/memory-core/src/memory/manager-async-state.test.ts
@@ -67,19 +67,21 @@ describe("memory manager async state", () => {
     expect(syncMock).not.toHaveBeenCalled();
   });
 
-  it("reports background search sync failures", async () => {
+  it("reports and settles background search sync failures", async () => {
     const syncError = new Error("sync failed");
     const onError = vi.fn();
 
-    await startAsyncSearchSync({
-      enabled: true,
-      dirty: false,
-      sessionsDirty: true,
-      sync: vi.fn(async () => {
-        throw syncError;
+    await expect(
+      startAsyncSearchSync({
+        enabled: true,
+        dirty: false,
+        sessionsDirty: true,
+        sync: vi.fn(async () => {
+          throw syncError;
+        }),
+        onError,
       }),
-      onError,
-    });
+    ).resolves.toBeUndefined();
 
     await vi.waitFor(() => expect(onError).toHaveBeenCalledWith(syncError));
   });
@@ -92,13 +94,15 @@ describe("memory manager async state", () => {
     const syncMock = vi.fn(async () => await pendingSync);
     let settled = false;
 
-    const searchSync = startAsyncSearchSync({
-      enabled: true,
-      dirty: true,
-      sessionsDirty: false,
-      sync: syncMock,
-      onError: vi.fn(),
-    }).then(() => {
+    const searchSync = Promise.resolve(
+      startAsyncSearchSync({
+        enabled: true,
+        dirty: true,
+        sessionsDirty: false,
+        sync: syncMock,
+        onError: vi.fn(),
+      }),
+    ).then(() => {
       settled = true;
     });
 

--- a/extensions/memory-core/src/memory/manager-async-state.ts
+++ b/extensions/memory-core/src/memory/manager-async-state.ts
@@ -1,22 +1,19 @@
 // Memory Core plugin module implements manager async state behavior.
-export async function startAsyncSearchSync(params: {
+export function startAsyncSearchSync(params: {
   enabled: boolean;
   dirty: boolean;
   sessionsDirty: boolean;
   sync: (params: { reason: string }) => Promise<void>;
   onError: (err: unknown) => void;
-}): Promise<void> {
+}): Promise<void> | void {
   if (!params.enabled || (!params.dirty && !params.sessionsDirty)) {
     return;
   }
-  if (params.sessionsDirty && !params.dirty) {
-    // Session reconciliation can enumerate and parse a large transcript corpus. Keep
-    // the existing sync admission/close ownership while letting indexed searches proceed.
-    void params.sync({ reason: "search" }).catch(params.onError);
-    return;
-  }
   try {
-    await params.sync({ reason: "search" });
+    const sync = params.sync({ reason: "search" });
+    return sync.catch((err: unknown) => {
+      params.onError(err);
+    });
   } catch (err: unknown) {
     params.onError(err);
   }

--- a/extensions/memory-core/src/memory/manager-db.test.ts
+++ b/extensions/memory-core/src/memory/manager-db.test.ts
@@ -15,7 +15,7 @@ import {
   publishMemoryDatabaseTables,
   readMemoryDatabaseRevision,
 } from "./manager-db.js";
-import { acquireMemoryReindexLock } from "./manager-reindex-lock.js";
+import { tryAcquireMemoryReindexLock } from "./manager-reindex-lock.js";
 
 function ensureTestMemorySchema(db: DatabaseSync, cacheEnabled = true, ftsEnabled = false): void {
   ensureMemoryIndexSchema({
@@ -431,7 +431,10 @@ describe("memory manager database publication", () => {
     await fs.writeFile(lockedShadow, "locked");
     await fs.utimes(lockedShadow, old, old);
 
-    const lock = acquireMemoryReindexLock(databasePath);
+    const lock = tryAcquireMemoryReindexLock(databasePath);
+    if (!lock) {
+      throw new Error("expected test to acquire the memory reindex lock");
+    }
     cleanupAgedMemoryReindexTempFiles(databasePath);
     await expect(fs.access(lockedShadow)).resolves.toBeUndefined();
     lock.release();

--- a/extensions/memory-core/src/memory/manager-index-generation-lease.test.ts
+++ b/extensions/memory-core/src/memory/manager-index-generation-lease.test.ts
@@ -1,0 +1,315 @@
+// Memory Core tests published-index read and publication ordering.
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { once } from "node:events";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  acquireMemoryIndexReadGeneration,
+  withMemoryIndexPublishGeneration,
+} from "./manager-index-generation-lease.js";
+
+const leaseChildSource = String.raw`
+  import { once } from "node:events";
+  import { DatabaseSync } from "node:sqlite";
+
+  const [, mode, databasePath] = process.argv;
+  let reportedContention = false;
+  const acquire = async (location, leaseMode) => {
+    while (true) {
+      const database = new DatabaseSync(location);
+      database.exec("PRAGMA busy_timeout = 0");
+      try {
+        if (leaseMode === "exclusive") {
+          database.exec("BEGIN EXCLUSIVE");
+        } else {
+          database.exec("BEGIN");
+          database.prepare("SELECT name FROM sqlite_schema LIMIT 1").get();
+        }
+        return database;
+      } catch (error) {
+        database.close();
+        if (!/SQLITE_(?:BUSY|LOCKED)|database is locked/iu.test(String(error))) throw error;
+        if (!reportedContention) {
+          reportedContention = true;
+          process.stdout.write("contended\n");
+        }
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+    }
+  };
+
+  const admission = await acquire(
+    databasePath + ".generation-writer.sqlite",
+    mode === "write" ? "exclusive" : "shared",
+  );
+  if (mode === "read-admission") {
+    process.stdout.write("acquired\n");
+    process.stdin.resume();
+    await once(process.stdin, "end");
+    admission.exec("ROLLBACK");
+    admission.close();
+    process.exit(0);
+  }
+  const generation = await acquire(
+    databasePath + ".generation-lock.sqlite",
+    mode === "read" ? "shared" : "exclusive",
+  );
+  if (mode === "read") {
+    admission.exec("ROLLBACK");
+    admission.close();
+  }
+  try {
+    process.stdout.write("acquired\n");
+    process.stdin.resume();
+    await once(process.stdin, "end");
+    generation.exec("ROLLBACK");
+    if (mode === "write") {
+      admission.exec("ROLLBACK");
+    }
+  } finally {
+    generation.close();
+    if (mode === "write") {
+      admission.close();
+    }
+  }
+`;
+
+function spawnLeaseFixture(
+  mode: "read" | "read-admission" | "write",
+  databasePath: string,
+): ChildProcessWithoutNullStreams {
+  return spawn(
+    process.execPath,
+    ["--input-type=module", "--eval", leaseChildSource, mode, databasePath],
+    {
+      stdio: ["pipe", "pipe", "pipe"],
+    },
+  );
+}
+
+async function readChildLine(child: ChildProcessWithoutNullStreams): Promise<string> {
+  const [chunk] = await once(child.stdout, "data");
+  return String(chunk).trim();
+}
+
+async function stopChild(child: ChildProcessWithoutNullStreams): Promise<void> {
+  if (child.exitCode !== null) {
+    return;
+  }
+  child.stdin.end();
+  await once(child, "exit");
+}
+
+let fixtureRoot = "";
+
+beforeEach(async () => {
+  fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-memory-generation-"));
+});
+
+afterEach(async () => {
+  await fs.rm(fixtureRoot, { recursive: true, force: true });
+});
+
+function leasePath(name: string): string {
+  return path.join(fixtureRoot, `${name}.sqlite`);
+}
+
+async function withReadGeneration<T>(key: string, run: () => Promise<T>): Promise<T> {
+  const release = await acquireMemoryIndexReadGeneration(key);
+  try {
+    return await run();
+  } finally {
+    release();
+  }
+}
+
+describe("memory index generation lease", () => {
+  it("admits another reader into the active generation when no writer is queued", async () => {
+    let releaseFirstReader = () => {};
+    const firstReaderGate = new Promise<void>((resolve) => {
+      releaseFirstReader = resolve;
+    });
+    const events: string[] = [];
+
+    const generationPath = leasePath("shared-reader-generation");
+    const firstReader = withReadGeneration(generationPath, async () => {
+      events.push("first-reader");
+      await firstReaderGate;
+    });
+    await vi.waitFor(() => expect(events).toContain("first-reader"));
+
+    const nextReader = withReadGeneration(generationPath, async () => {
+      events.push("next-reader");
+    });
+    await nextReader;
+    expect(events).toEqual(["first-reader", "next-reader"]);
+
+    releaseFirstReader();
+    await firstReader;
+  });
+
+  it("lets readers continue while publication waits for the active generation", async () => {
+    let releaseFirstReader = () => {};
+    const firstReaderGate = new Promise<void>((resolve) => {
+      releaseFirstReader = resolve;
+    });
+    const events: string[] = [];
+
+    const generationPath = leasePath("reader-before-publish");
+    const firstReader = withReadGeneration(generationPath, async () => {
+      events.push("first-reader-start");
+      await firstReaderGate;
+      events.push("first-reader-end");
+    });
+    await vi.waitFor(() => expect(events).toContain("first-reader-start"));
+
+    const publish = withMemoryIndexPublishGeneration(generationPath, async () => {
+      events.push("publish");
+    });
+    await Promise.resolve();
+    expect(events).not.toContain("publish");
+
+    releaseFirstReader();
+    await Promise.all([firstReader, publish]);
+    expect(events).toEqual(["first-reader-start", "first-reader-end", "publish"]);
+  });
+
+  it("does not admit a new generation reader ahead of queued publication", async () => {
+    let releaseFirstReader = () => {};
+    const firstReaderGate = new Promise<void>((resolve) => {
+      releaseFirstReader = resolve;
+    });
+    const events: string[] = [];
+
+    const generationPath = leasePath("publish-before-reader");
+    const firstReader = withReadGeneration(generationPath, async () => {
+      events.push("first-reader");
+      await firstReaderGate;
+    });
+    await vi.waitFor(() => expect(events).toContain("first-reader"));
+    const publish = withMemoryIndexPublishGeneration(generationPath, async () => {
+      events.push("publish");
+    });
+    const nextReader = withReadGeneration(generationPath, async () => {
+      events.push("next-reader");
+    });
+
+    releaseFirstReader();
+    await Promise.all([firstReader, publish, nextReader]);
+    expect(events).toEqual(["first-reader", "publish", "next-reader"]);
+  });
+
+  it("keeps another process from publishing during an active read generation", async () => {
+    const databasePath = leasePath("reader-cross-process");
+    const release = await acquireMemoryIndexReadGeneration(databasePath);
+    let released = false;
+    const child = spawnLeaseFixture("write", databasePath);
+    try {
+      expect(await readChildLine(child)).toBe("contended");
+      const acquired = readChildLine(child);
+      release();
+      released = true;
+      expect(await acquired).toBe("acquired");
+    } finally {
+      if (!released) {
+        release();
+      }
+      await stopChild(child);
+    }
+  });
+
+  it("waits for another process reader before publishing a new generation", async () => {
+    const databasePath = leasePath("publisher-cross-process");
+    const child = spawnLeaseFixture("read", databasePath);
+    try {
+      expect(await readChildLine(child)).toBe("acquired");
+      const events: string[] = [];
+      const publication = withMemoryIndexPublishGeneration(databasePath, async () => {
+        events.push("published");
+      });
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      expect(events).toEqual([]);
+
+      await stopChild(child);
+      await publication;
+      expect(events).toEqual(["published"]);
+    } finally {
+      await stopChild(child);
+    }
+  });
+
+  it("keeps newly arriving process readers behind a waiting publication", async () => {
+    const databasePath = leasePath("writer-intent-cross-process");
+    const firstReader = spawnLeaseFixture("read-admission", databasePath);
+    let nextReader: ChildProcessWithoutNullStreams | undefined;
+    let publication: Promise<void> | undefined;
+    try {
+      expect(await readChildLine(firstReader)).toBe("acquired");
+      const events: string[] = [];
+      publication = withMemoryIndexPublishGeneration(databasePath, async () => {
+        events.push("published");
+      });
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 50);
+      });
+
+      nextReader = spawnLeaseFixture("read", databasePath);
+      expect(await readChildLine(nextReader)).toBe("contended");
+      const nextReaderAcquired = readChildLine(nextReader).then((line) => {
+        expect(line).toBe("acquired");
+        events.push("next-reader");
+      });
+      expect(events).toEqual([]);
+
+      await stopChild(firstReader);
+      await publication;
+      expect(events).toEqual(["published"]);
+      await nextReaderAcquired;
+      expect(events).toEqual(["published", "next-reader"]);
+    } finally {
+      await stopChild(firstReader);
+      if (nextReader) {
+        await stopChild(nextReader);
+      }
+      await publication;
+    }
+  });
+
+  it("removes an aborted reader while another process holds publication", async () => {
+    const databasePath = leasePath("cancelled-reader-cross-process");
+    const publisher = spawnLeaseFixture("write", databasePath);
+    const controller = new AbortController();
+    const abortError = new Error("memory search cancelled while waiting for publication");
+    const acquireWithSignal = acquireMemoryIndexReadGeneration as (
+      path: string,
+      signal: AbortSignal,
+    ) => Promise<() => void>;
+    let pendingReader: Promise<() => void> | undefined;
+    try {
+      expect(await readChildLine(publisher)).toBe("acquired");
+      pendingReader = acquireWithSignal(databasePath, controller.signal);
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 50);
+      });
+      controller.abort(abortError);
+      const outcome = await Promise.race([
+        pendingReader.then(
+          () => "acquired" as const,
+          (error: unknown) => error,
+        ),
+        new Promise<"timeout">((resolve) => {
+          setTimeout(() => resolve("timeout"), 250);
+        }),
+      ]);
+      expect(outcome).toMatchObject({ cause: abortError });
+    } finally {
+      await stopChild(publisher);
+      const release = await pendingReader?.catch(() => undefined);
+      release?.();
+    }
+  });
+});

--- a/extensions/memory-core/src/memory/manager-index-generation-lease.ts
+++ b/extensions/memory-core/src/memory/manager-index-generation-lease.ts
@@ -1,0 +1,253 @@
+// Memory Core coordinates published-index readers with atomic shadow publication.
+import { resolveUserPath } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
+import { sleepWithAbort } from "openclaw/plugin-sdk/runtime-env";
+import {
+  acquireMemorySqliteWriterLease,
+  tryAcquireMemorySqliteLease,
+  type MemorySqliteLeaseHandle,
+} from "./manager-sqlite-lease.js";
+type Waiter = {
+  kind: "read" | "write";
+  resolve: (release: () => void) => void;
+};
+
+type GenerationLeaseState = {
+  readers: number;
+  writer: boolean;
+  queue: Waiter[];
+};
+
+const states = new Map<string, GenerationLeaseState>();
+const CROSS_PROCESS_RETRY_DELAY_MS = 25;
+
+function createGenerationLeaseAbortError(signal?: AbortSignal): Error {
+  return new Error("Memory index generation lease acquisition aborted", { cause: signal?.reason });
+}
+
+function throwIfGenerationLeaseAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) {
+    throw createGenerationLeaseAbortError(signal);
+  }
+}
+
+async function acquireCrossProcessLease(
+  databasePath: string,
+  kind: Waiter["kind"],
+  signal?: AbortSignal,
+): Promise<MemorySqliteLeaseHandle> {
+  const acquireSqliteLease = async (
+    location: string,
+    mode: "shared" | "exclusive",
+  ): Promise<MemorySqliteLeaseHandle> => {
+    while (true) {
+      throwIfGenerationLeaseAborted(signal);
+      const lease = tryAcquireMemorySqliteLease(location, mode);
+      if (lease) {
+        if (signal?.aborted) {
+          lease.release();
+          throw createGenerationLeaseAbortError(signal);
+        }
+        return lease;
+      }
+      try {
+        await sleepWithAbort(CROSS_PROCESS_RETRY_DELAY_MS, signal);
+      } catch (err) {
+        throw signal?.aborted ? createGenerationLeaseAbortError(signal) : err;
+      }
+    }
+  };
+
+  // Admission prevents new readers from overtaking a waiting publisher across
+  // processes. Readers release it as soon as their generation lease is secured.
+  const admissionLocation = `${databasePath}.generation-writer.sqlite`;
+  let admission: MemorySqliteLeaseHandle;
+  try {
+    admission =
+      kind === "read"
+        ? await acquireSqliteLease(admissionLocation, "shared")
+        : await acquireMemorySqliteWriterLease(admissionLocation, signal);
+  } catch (err) {
+    throw signal?.aborted ? createGenerationLeaseAbortError(signal) : err;
+  }
+  let generation: MemorySqliteLeaseHandle;
+  try {
+    generation = await acquireSqliteLease(
+      `${databasePath}.generation-lock.sqlite`,
+      kind === "read" ? "shared" : "exclusive",
+    );
+  } catch (err) {
+    admission.release();
+    throw err;
+  }
+  if (kind === "read") {
+    try {
+      admission.release();
+    } catch (err) {
+      generation.release();
+      throw err;
+    }
+    if (signal?.aborted) {
+      generation.release();
+      throw createGenerationLeaseAbortError(signal);
+    }
+    return generation;
+  }
+  return {
+    release: () => {
+      try {
+        generation.release();
+      } finally {
+        admission.release();
+      }
+    },
+  };
+}
+
+function stateFor(key: string): GenerationLeaseState {
+  const existing = states.get(key);
+  if (existing) {
+    return existing;
+  }
+  const created = { readers: 0, writer: false, queue: [] };
+  states.set(key, created);
+  return created;
+}
+
+function drain(key: string, state: GenerationLeaseState): void {
+  if (state.writer) {
+    return;
+  }
+  if (state.readers > 0) {
+    // Readers already in the current generation may admit more readers until a
+    // writer reaches the queue head. Readers behind that writer wait for the next generation.
+    while (state.queue[0]?.kind === "read") {
+      const reader = state.queue.shift()!;
+      state.readers += 1;
+      reader.resolve(() => {
+        state.readers -= 1;
+        drain(key, state);
+      });
+    }
+    return;
+  }
+  const first = state.queue.shift();
+  if (!first) {
+    states.delete(key);
+    return;
+  }
+  if (first.kind === "write") {
+    state.writer = true;
+    first.resolve(() => {
+      state.writer = false;
+      drain(key, state);
+    });
+    return;
+  }
+  const readers = [first];
+  while (state.queue[0]?.kind === "read") {
+    readers.push(state.queue.shift()!);
+  }
+  state.readers = readers.length;
+  for (const reader of readers) {
+    reader.resolve(() => {
+      state.readers -= 1;
+      drain(key, state);
+    });
+  }
+}
+
+async function acquireLocal(
+  key: string,
+  kind: Waiter["kind"],
+  signal?: AbortSignal,
+): Promise<() => void> {
+  throwIfGenerationLeaseAborted(signal);
+  const state = stateFor(key);
+  return await new Promise<() => void>((resolve, reject) => {
+    let admitted = false;
+    const waiter: Waiter = {
+      kind,
+      resolve: (release) => {
+        admitted = true;
+        signal?.removeEventListener("abort", onAbort);
+        if (signal?.aborted) {
+          release();
+          reject(createGenerationLeaseAbortError(signal));
+          return;
+        }
+        resolve(release);
+      },
+    };
+    const onAbort = () => {
+      if (admitted) {
+        return;
+      }
+      const index = state.queue.indexOf(waiter);
+      if (index < 0) {
+        return;
+      }
+      state.queue.splice(index, 1);
+      signal?.removeEventListener("abort", onAbort);
+      drain(key, state);
+      reject(createGenerationLeaseAbortError(signal));
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+    state.queue.push(waiter);
+    if (signal?.aborted) {
+      onAbort();
+      return;
+    }
+    drain(key, state);
+  });
+}
+
+async function acquire(
+  databasePath: string,
+  kind: Waiter["kind"],
+  signal?: AbortSignal,
+): Promise<() => void> {
+  const key = resolveUserPath(databasePath);
+  const releaseLocal = await acquireLocal(key, kind, signal);
+  let crossProcess: MemorySqliteLeaseHandle;
+  try {
+    throwIfGenerationLeaseAborted(signal);
+    crossProcess = await acquireCrossProcessLease(key, kind, signal);
+    if (signal?.aborted) {
+      crossProcess.release();
+      throw createGenerationLeaseAbortError(signal);
+    }
+  } catch (err) {
+    releaseLocal();
+    throw err;
+  }
+  return () => {
+    try {
+      crossProcess.release();
+    } finally {
+      releaseLocal();
+    }
+  };
+}
+
+async function withLease<T>(key: string, kind: Waiter["kind"], run: () => Promise<T>): Promise<T> {
+  const release = await acquire(key, kind);
+  try {
+    return await run();
+  } finally {
+    release();
+  }
+}
+
+export async function acquireMemoryIndexReadGeneration(
+  databasePath: string,
+  signal?: AbortSignal,
+): Promise<() => void> {
+  return await acquire(databasePath, "read", signal);
+}
+
+export async function withMemoryIndexPublishGeneration<T>(
+  databasePath: string,
+  run: () => Promise<T>,
+): Promise<T> {
+  return await withLease(databasePath, "write", run);
+}

--- a/extensions/memory-core/src/memory/manager-index.test-support.ts
+++ b/extensions/memory-core/src/memory/manager-index.test-support.ts
@@ -436,6 +436,7 @@ export function createManagerIndexFixture(deps: {
             vector: params.vectorEnabled !== undefined ? { enabled: params.vectorEnabled } : {},
           },
           remote: params.batchEnabled ? { batch: { enabled: true } } : undefined,
+          sync: params.onSearch === undefined ? undefined : { onSearch: params.onSearch },
           query: { minScore: params.minScore ?? 0 },
           cache: params.cacheEnabled ? { enabled: true } : undefined,
           extraPaths: params.extraPaths,

--- a/extensions/memory-core/src/memory/manager-provider-lifecycle-fallback.test.ts
+++ b/extensions/memory-core/src/memory/manager-provider-lifecycle-fallback.test.ts
@@ -104,6 +104,61 @@ describe("memory index", () => {
     }
   });
 
+  it("adopts a configured fallback index published by detached maintenance", async () => {
+    const cfg = createCfg({
+      fallback: "fallback-provider",
+      model: "new-embed",
+    });
+    const maintenanceManager = await getFreshManager(cfg);
+    const maintenanceFields = maintenanceManager as unknown as {
+      providerInitialized: boolean;
+      provider: {
+        id: string;
+        model: string;
+        embed: (text: string) => Promise<number[]>;
+        embedBatch: (texts: string[]) => Promise<number[][]>;
+        close: () => Promise<void>;
+      };
+    };
+    maintenanceFields.providerInitialized = true;
+    maintenanceFields.provider = {
+      id: "mock",
+      model: "new-embed",
+      embed: async () => {
+        throw providerFixture.createLocalWorkerExitError();
+      },
+      embedBatch: async () => {
+        throw providerFixture.createLocalWorkerExitError();
+      },
+      close: async () => {},
+    };
+    await maintenanceManager.sync({ reason: "search", force: true });
+    expect(maintenanceManager.status()).toMatchObject({
+      provider: "fallback-provider",
+      model: "fallback-provider-embed",
+      custom: { indexIdentity: { status: "valid" } },
+    });
+    await maintenanceManager.close?.();
+
+    const manager = await getFreshManager(cfg);
+    // The existing serving manager handed its dirty generation to maintenance
+    // before the fallback index was published. Do not model a separate startup scan.
+    Reflect.set(manager, "dirty", false);
+    const callsBeforeSearch = providerFixture.providerCalls.length;
+
+    const results = await manager.search("alpha");
+
+    expect(results).not.toStrictEqual([]);
+    expect(providerFixture.providerCalls.slice(callsBeforeSearch)).toContainEqual(
+      expect.objectContaining({ provider: "fallback-provider" }),
+    );
+    expect(manager.status()).toMatchObject({
+      provider: "fallback-provider",
+      model: "fallback-provider-embed",
+    });
+    expect(manager.status().custom?.indexIdentity).toEqual({ status: "valid" });
+  });
+
   it("reinitializes the configured provider after probe-time local degradation", async () => {
     const cfg = createCfg({
       fallback: "fallback-provider",

--- a/extensions/memory-core/src/memory/manager-provider-lifecycle.ts
+++ b/extensions/memory-core/src/memory/manager-provider-lifecycle.ts
@@ -30,6 +30,8 @@ import { MemoryManagerEmbeddingOps } from "./manager-embedding-ops.js";
 import {
   createDegradedMemoryProviderLifecycle,
   createPendingMemoryProviderLifecycle,
+  resolveFallbackCurrentProviderId,
+  resolveMemoryFallbackProviderRequest,
   resolveMemoryPrimaryProviderRequest,
   resolveMemoryProviderState,
 } from "./manager-provider-state.js";
@@ -108,7 +110,7 @@ export function resolveMemoryEmbeddingProviderRequirement(params: {
 
 export abstract class MemoryProviderLifecycle extends MemoryManagerEmbeddingOps {
   protected abstract readonly cacheKey: string;
-  protected abstract readonly purpose: "default" | "status" | "cli";
+  protected abstract readonly purpose: "default" | "status" | "cli" | "maintenance";
   protected abstract readonly providerRequirement: MemoryEmbeddingProviderRequirement;
   protected abstract readonly requestedProvider: EmbeddingProviderRequest;
   protected abstract providerInitPromise: Promise<void> | null;
@@ -119,12 +121,14 @@ export abstract class MemoryProviderLifecycle extends MemoryManagerEmbeddingOps 
   protected abstract closing: boolean;
   protected abstract activeManagerOperations: number;
   protected abstract managerIdleWaiters: Set<() => void>;
+  protected abstract activeBackgroundSearchSyncs: Set<Promise<void>>;
   protected abstract indexIdentityDirty: boolean;
   protected abstract indexIdentityState: MemoryIndexIdentityState;
   protected abstract syncAdmitted(
     params?: MemorySyncParams,
     options?: { allowEmbeddingBootstrapFallback?: boolean; queuedSessionOwner?: boolean },
   ): Promise<void>;
+  protected abstract syncPublishedIndexInBackground(params: { reason: string }): Promise<void>;
 
   protected applyProviderResult(providerResult: EmbeddingProviderResult): void {
     const providerState = resolveMemoryProviderState(providerResult);
@@ -252,6 +256,38 @@ export abstract class MemoryProviderLifecycle extends MemoryManagerEmbeddingOps 
         : { mode: "active", providerId: this.provider.id };
     }
     EMBEDDING_PROBE_CACHE.delete(this.cacheKey);
+  }
+
+  protected async adoptPublishedFallbackProviderIfMatched(): Promise<boolean> {
+    if (this.fallbackFrom || !this.provider) {
+      return false;
+    }
+    const currentProviderId = resolveFallbackCurrentProviderId({
+      provider: this.provider,
+      lifecycle: this.providerLifecycle,
+    });
+    const fallbackRequest = resolveMemoryFallbackProviderRequest({
+      cfg: this.cfg,
+      settings: this.settings,
+      currentProviderId,
+    });
+    const meta = this.readMeta();
+    if (
+      !fallbackRequest ||
+      !meta ||
+      meta.provider !== fallbackRequest.provider ||
+      meta.model !== fallbackRequest.model
+    ) {
+      return false;
+    }
+    const activated = await this.activateFallbackProvider(
+      "published memory index uses the configured fallback provider",
+    );
+    return (
+      activated &&
+      this.refreshIndexIdentityDirty({ providerKeyKnown: this.providerInitialized }).status ===
+        "valid"
+    );
   }
 
   protected async confirmEmbeddingBootstrapRecovery(): Promise<boolean> {
@@ -501,12 +537,17 @@ export abstract class MemoryProviderLifecycle extends MemoryManagerEmbeddingOps 
   }
 
   protected async awaitManagerIdle(): Promise<void> {
-    if (this.activeManagerOperations === 0) {
-      return;
+    if (this.activeManagerOperations > 0) {
+      await new Promise<void>((resolve) => {
+        this.managerIdleWaiters.add(resolve);
+      });
     }
-    await new Promise<void>((resolve) => {
-      this.managerIdleWaiters.add(resolve);
-    });
+    // CLI request teardown must not wait after a published search result is ready;
+    // its detached task owns a separate maintenance manager. Persistent managers
+    // still drain maintenance before closing shared resources.
+    while (this.purpose !== "cli" && this.activeBackgroundSearchSyncs.size > 0) {
+      await Promise.all(Array.from(this.activeBackgroundSearchSyncs));
+    }
   }
 
   async probeVectorAvailability(): Promise<boolean> {

--- a/extensions/memory-core/src/memory/manager-provider-runtime-facts.ts
+++ b/extensions/memory-core/src/memory/manager-provider-runtime-facts.ts
@@ -1,0 +1,12 @@
+// Memory Core reads optional provider runtime diagnostics without widening the provider contract.
+import type { EmbeddingProvider } from "./embeddings.js";
+
+const LOCAL_EMBEDDING_RUNTIME_FACTS = Symbol.for("openclaw.localEmbeddingRuntimeFacts");
+
+export function getLocalEmbeddingRuntimeFacts(provider: EmbeddingProvider | null): unknown {
+  if (!provider) {
+    return undefined;
+  }
+  const getRuntimeFacts = Reflect.get(provider, LOCAL_EMBEDDING_RUNTIME_FACTS);
+  return typeof getRuntimeFacts === "function" ? getRuntimeFacts() : undefined;
+}

--- a/extensions/memory-core/src/memory/manager-registry.test.ts
+++ b/extensions/memory-core/src/memory/manager-registry.test.ts
@@ -276,6 +276,31 @@ describe("memory index", () => {
     expect((replacement as unknown as { closed: boolean }).closed).toBe(true);
   });
 
+  it("declines a maintenance manager that arrives during global teardown", async () => {
+    const cfg = createCfg({
+      hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },
+    });
+    const manager = requireManager(await getMemorySearchManager({ cfg, agentId: "main" }));
+    trackManager(manager);
+    await manager.probeEmbeddingAvailability();
+    let releaseProviderClose: () => void = () => {};
+    providerFixture.providerCloseGate = new Promise<void>((resolve) => {
+      releaseProviderClose = resolve;
+    });
+
+    const globalClose = closeAllMemoryIndexManagers();
+    try {
+      await vi.waitFor(() => expect(providerFixture.providerCloseCalls).toBe(1));
+      await expect(
+        RuntimeMemoryIndexManager.get({ cfg, agentId: "main", purpose: "maintenance" }),
+      ).resolves.toBeNull();
+    } finally {
+      releaseProviderClose();
+      providerFixture.providerCloseGate = null;
+    }
+    await globalClose;
+  });
+
   it("retains a failed scoped close owner until provider retirement succeeds", async () => {
     const cfg = createCfg({
       hybrid: { enabled: true, vectorWeight: 0.5, textWeight: 0.5 },

--- a/extensions/memory-core/src/memory/manager-registry.ts
+++ b/extensions/memory-core/src/memory/manager-registry.ts
@@ -19,7 +19,15 @@ const MEMORY_INDEX_MANAGER_GLOBAL_LIFECYCLE_KEY = Symbol.for(
 );
 const log = createSubsystemLogger("memory");
 
-export type MemoryIndexManagerPurpose = "default" | "status" | "cli";
+export type MemoryIndexManagerPurpose = "default" | "status" | "cli" | "maintenance";
+
+export function normalizeMemoryIndexManagerPurpose(
+  purpose: MemoryIndexManagerPurpose | undefined,
+): MemoryIndexManagerPurpose {
+  return purpose === "status" || purpose === "cli" || purpose === "maintenance"
+    ? purpose
+    : "default";
+}
 
 type ClosableMemoryManager = {
   close(): Promise<void>;
@@ -84,6 +92,14 @@ export class MemoryManagerRegistry<T extends ClosableMemoryManager> {
     params: { agentId: string; purpose: MemoryIndexManagerPurpose },
     callbacks: MemoryManagerRegistryCallbacks<T>,
   ): Promise<T | null> {
+    // A detached search handoff may race global teardown. Decline late
+    // maintenance acquisition so closing the default manager cannot wait on itself.
+    if (
+      params.purpose === "maintenance" &&
+      (this.globalLifecycle.closePromise || this.globalLifecycle.closeFailed)
+    ) {
+      return null;
+    }
     return await this.runScopeOperation(params, async () => {
       if (this.globalLifecycle.closeFailed) {
         await this.retryFailedGlobalClose(callbacks.close);

--- a/extensions/memory-core/src/memory/manager-reindex-lock.ts
+++ b/extensions/memory-core/src/memory/manager-reindex-lock.ts
@@ -1,83 +1,51 @@
 // Memory Core plugin module serializes full memory reindex builds across processes.
-import type { DatabaseSync } from "node:sqlite";
-import { openNodeSqliteDatabase } from "openclaw/plugin-sdk/sqlite-runtime";
+import {
+  tryAcquireMemorySqliteLease,
+  type MemorySqliteLeaseHandle,
+} from "./manager-sqlite-lease.js";
 
-export type MemoryReindexLockHandle = {
-  release: () => void;
-};
+export type MemoryReindexLockHandle = MemorySqliteLeaseHandle;
+
+const REINDEX_LOCK_WAIT_TIMEOUT_MS = 2_000;
+const REINDEX_LOCK_RETRY_DELAY_MS = 25;
 
 function resolveMemoryReindexLockPath(dbPath: string): string {
   return `${dbPath}.reindex-lock.sqlite`;
 }
 
-function isSqliteBusyError(err: unknown): boolean {
-  const code = (err as { code?: unknown }).code;
-  if (code === "SQLITE_BUSY" || code === "SQLITE_LOCKED") {
-    return true;
-  }
-  const message = err instanceof Error ? err.message : String(err);
-  return /SQLITE_(?:BUSY|LOCKED)|database is locked/i.test(message);
+async function sleepAsync(ms: number): Promise<void> {
+  await new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
+  });
 }
 
-function openMemoryLockDatabase(lockPath: string): DatabaseSync {
-  const lockDb = openNodeSqliteDatabase(lockPath);
-  try {
-    lockDb.exec("PRAGMA busy_timeout = 0");
-    return lockDb;
-  } catch (err) {
-    try {
-      lockDb.close();
-    } catch {}
-    throw err;
-  }
-}
-
-function createMemoryReindexLockHandle(lockDb: DatabaseSync): MemoryReindexLockHandle {
-  return {
-    release: () => {
-      let releaseError: unknown;
-      try {
-        lockDb.exec("ROLLBACK");
-      } catch (err) {
-        releaseError = err;
-      }
-      try {
-        lockDb.close();
-      } catch (err) {
-        releaseError ??= err;
-      }
-      if (releaseError) {
-        throw new Error("Failed to release memory reindex lock", { cause: releaseError });
-      }
-    },
-  };
+function createMemoryReindexBusyError(lockPath: string): Error & { code: string } {
+  return Object.assign(
+    new Error(`Memory reindex lock is held at ${lockPath}; another reindex is active.`),
+    { code: "SQLITE_BUSY" },
+  );
 }
 
 /** Try to acquire the build lock without locking readers of the live agent database. */
 export function tryAcquireMemoryReindexLock(dbPath: string): MemoryReindexLockHandle | undefined {
-  const lockDb = openMemoryLockDatabase(resolveMemoryReindexLockPath(dbPath));
-  try {
-    lockDb.exec("BEGIN EXCLUSIVE");
-  } catch (err) {
-    lockDb.close();
-    if (isSqliteBusyError(err)) {
-      return undefined;
-    }
-    throw err;
-  }
-  return createMemoryReindexLockHandle(lockDb);
+  return tryAcquireMemorySqliteLease(resolveMemoryReindexLockPath(dbPath), "exclusive");
 }
 
-/** Acquire an exclusive build lock without locking readers of the live agent database. */
-export function acquireMemoryReindexLock(dbPath: string): MemoryReindexLockHandle {
-  const lock = tryAcquireMemoryReindexLock(dbPath);
-  if (lock) {
-    return lock;
+/** Wait asynchronously for the exclusive build lock without blocking the Node event loop. */
+export async function waitForMemoryReindexLock(dbPath: string): Promise<MemoryReindexLockHandle> {
+  const lockPath = resolveMemoryReindexLockPath(dbPath);
+  const deadline = Date.now() + REINDEX_LOCK_WAIT_TIMEOUT_MS;
+  do {
+    const lock = tryAcquireMemoryReindexLock(dbPath);
+    if (lock) {
+      return lock;
+    }
+    await sleepAsync(REINDEX_LOCK_RETRY_DELAY_MS);
+  } while (Date.now() < deadline);
+
+  const finalLock = tryAcquireMemoryReindexLock(dbPath);
+  if (finalLock) {
+    return finalLock;
   }
-  throw Object.assign(
-    new Error(
-      `Memory reindex lock is held at ${resolveMemoryReindexLockPath(dbPath)}; another reindex is active.`,
-    ),
-    { code: "SQLITE_BUSY" },
-  );
+  throw createMemoryReindexBusyError(lockPath);
 }

--- a/extensions/memory-core/src/memory/manager-search-maintenance.ts
+++ b/extensions/memory-core/src/memory/manager-search-maintenance.ts
@@ -1,0 +1,51 @@
+// Memory Core owns detached search-time index maintenance lifecycle.
+import { toErrorObject } from "openclaw/plugin-sdk/error-runtime";
+
+type MemorySearchMaintenanceManager = {
+  sync(params: { reason: string; force: true }): Promise<void>;
+  status(): { dirty?: boolean };
+  close(): Promise<void>;
+};
+
+export async function runMemorySearchMaintenance<DirtyGeneration>(params: {
+  reason: string;
+  takeDirtyGeneration: () => DirtyGeneration;
+  restoreDirtyGeneration: (generation: DirtyGeneration) => void;
+  acquireManager: () => Promise<MemorySearchMaintenanceManager | null>;
+}): Promise<void> {
+  const dirtyGeneration = params.takeDirtyGeneration();
+  let manager: MemorySearchMaintenanceManager | null;
+  try {
+    manager = await params.acquireManager();
+  } catch (err) {
+    params.restoreDirtyGeneration(dirtyGeneration);
+    throw toErrorObject(err, "Memory search maintenance manager acquisition failed");
+  }
+  if (!manager) {
+    params.restoreDirtyGeneration(dirtyGeneration);
+    return;
+  }
+
+  let maintenanceError: Error | undefined;
+  try {
+    // The transient manager has no watcher state. Force every source represented
+    // by the handed-off generation while the default manager serves published reads.
+    await manager.sync({ reason: params.reason, force: true });
+    if (manager.status().dirty === true) {
+      // A provider fallback may deliberately resolve in keyword-only mode while
+      // retaining retry state. Return that incomplete generation to its serving owner.
+      params.restoreDirtyGeneration(dirtyGeneration);
+    }
+  } catch (err) {
+    params.restoreDirtyGeneration(dirtyGeneration);
+    maintenanceError = toErrorObject(err, "Memory search maintenance failed");
+  }
+  try {
+    await manager.close();
+  } catch (err) {
+    maintenanceError ??= toErrorObject(err, "Memory search maintenance close failed");
+  }
+  if (maintenanceError) {
+    throw maintenanceError;
+  }
+}

--- a/extensions/memory-core/src/memory/manager-search-orchestration.test.ts
+++ b/extensions/memory-core/src/memory/manager-search-orchestration.test.ts
@@ -12,6 +12,7 @@ import {
 import * as knnSubprocess from "./manager-search-knn-subprocess.js";
 
 const { closeAllMemorySearchManagers, getMemorySearchManager } = await import("./index.js");
+const { MemoryIndexManager } = await import("./manager.js");
 
 describe("memory index", () => {
   const fixture = createManagerIndexFixture({
@@ -65,7 +66,7 @@ describe("memory index", () => {
     await expectHybridKeywordSearchFindsMemory(createCfg(config));
   });
 
-  it("preserves semantic results when a concurrent reindex publishes before KNN returns", async () => {
+  it("keeps one search generation while a concurrent reindex waits to publish", async () => {
     const manager = await getPersistentManager(
       createCfg({
         vectorEnabled: true,
@@ -125,11 +126,18 @@ describe("memory index", () => {
       releaseQuery.resolve();
       await childReady.promise;
       releaseReindex.resolve();
-      await reindex;
-      expect(shadowDb?.isOpen).toBe(false);
+      let reindexSettled = false;
+      void reindex.then(() => {
+        reindexSettled = true;
+      });
+      await Promise.resolve();
+      expect(reindexSettled).toBe(false);
+
       releaseChild.resolve();
       const results = await search;
       expect(results.some((entry) => entry.path === "memory/2026-01-12.md")).toBe(true);
+      await reindex;
+      expect(shadowDb?.isOpen).toBe(false);
     } finally {
       releaseQuery.resolve();
       releaseReindex.resolve();
@@ -533,12 +541,12 @@ describe("memory index", () => {
     const pendingSync = new Promise<void>((resolve) => {
       releaseSync = () => resolve();
     });
-    const syncAdmitted = vi
+    const backgroundSync = vi
       .spyOn(
         manager as unknown as {
-          syncAdmitted: (params: { reason: string }) => Promise<void>;
+          syncPublishedIndexInBackground: (params: { reason: string }) => Promise<void>;
         },
-        "syncAdmitted",
+        "syncPublishedIndexInBackground",
       )
       .mockImplementation(async () => await pendingSync);
 
@@ -549,7 +557,7 @@ describe("memory index", () => {
       maxResults: 5,
       minScore: 0,
     });
-    await vi.waitFor(() => expect(syncAdmitted).toHaveBeenCalledWith({ reason: "search" }));
+    await vi.waitFor(() => expect(backgroundSync).toHaveBeenCalledWith({ reason: "search" }));
 
     const results = await searchPromise;
     expect(results.some((entry) => entry.path === "memory/2026-01-12.md")).toBe(true);
@@ -574,7 +582,7 @@ describe("memory index", () => {
     }
   });
 
-  it("waits for dirty sync before querying", async () => {
+  it("keeps the published index searchable while dirty maintenance builds", async () => {
     providerFixture.forceNoProvider = true;
     const manager = await getPersistentManager(
       createCfg({ provider: "none", minScore: 0, onSearch: true, hybrid: { enabled: true } }),
@@ -586,11 +594,257 @@ describe("memory index", () => {
     );
     await vi.waitFor(() => expect(manager.status().dirty).toBe(true));
 
-    const results = await manager.search("current dirty search sync", {
-      maxResults: 5,
-      minScore: 0,
+    const maintenanceReady = createDeferred<void>();
+    const releaseMaintenance = createDeferred<void>();
+    const originalGet = MemoryIndexManager.get.bind(MemoryIndexManager);
+    let maintenanceClosed = false;
+    const getSpy = vi.spyOn(MemoryIndexManager, "get").mockImplementation(async (params) => {
+      const acquired = await originalGet(params);
+      if (params.purpose !== "maintenance" || !acquired) {
+        return acquired;
+      }
+      const closeMaintenance = acquired.close.bind(acquired);
+      vi.spyOn(acquired, "close").mockImplementation(async () => {
+        await closeMaintenance();
+        maintenanceClosed = true;
+      });
+      const fields = acquired as unknown as {
+        syncMemoryFiles: (params: { needsFullReindex: boolean }) => Promise<unknown>;
+      };
+      const syncMemoryFiles = fields.syncMemoryFiles.bind(acquired);
+      vi.spyOn(fields, "syncMemoryFiles").mockImplementation(async (syncParams) => {
+        const result = await syncMemoryFiles(syncParams);
+        maintenanceReady.resolve();
+        await releaseMaintenance.promise;
+        return result;
+      });
+      return acquired;
     });
 
-    expect(results.some((entry) => entry.path === "memory/search-sync.md")).toBe(true);
+    try {
+      const firstSearch = manager.search("zebra", { maxResults: 5, minScore: 0 });
+      await maintenanceReady.promise;
+      expect(manager.status()).toMatchObject({
+        dirty: true,
+        pendingSyncSources: ["memory"],
+      });
+
+      const publishedResults = await manager.search("zebra", { maxResults: 5, minScore: 0 });
+      expect(publishedResults.some((entry) => entry.path === "memory/2026-01-12.md")).toBe(true);
+      await expect(
+        manager.search("current dirty search sync", { maxResults: 5, minScore: 0 }),
+      ).resolves.toEqual([]);
+
+      releaseMaintenance.resolve();
+      await firstSearch;
+      await (manager as unknown as { awaitManagerIdle: () => Promise<void> }).awaitManagerIdle();
+      expect(manager.status().dirty).toBe(false);
+
+      const refreshedResults = await manager.search("current dirty search sync", {
+        maxResults: 5,
+        minScore: 0,
+      });
+      expect(refreshedResults.some((entry) => entry.path === "memory/search-sync.md")).toBe(true);
+      expect(maintenanceClosed).toBe(true);
+    } finally {
+      releaseMaintenance.resolve();
+      getSpy.mockRestore();
+    }
+  });
+
+  it("keeps transient CLI search off the serving manager write path", async () => {
+    providerFixture.forceNoProvider = true;
+    const cfg = createCfg({
+      provider: "none",
+      minScore: 0,
+      onSearch: false,
+      hybrid: { enabled: true },
+    });
+    const initialManager = await getFreshManager(cfg, "cli");
+    await initialManager.sync({ reason: "test", force: true });
+    await initialManager.close?.();
+    await fs.writeFile(
+      path.join(fixture.paths.memory, "cli-refresh.md"),
+      "Content published after transient CLI maintenance.",
+    );
+
+    const manager = await getFreshManager(cfg, "cli");
+    const servingFields = manager as unknown as {
+      syncMemoryFiles: (params: { needsFullReindex: boolean }) => Promise<unknown>;
+    };
+    const servingSync = vi.spyOn(servingFields, "syncMemoryFiles");
+    const maintenanceReady = createDeferred<void>();
+    const releaseMaintenance = createDeferred<void>();
+    let closePromise: Promise<void> | undefined;
+    let maintenanceClosed = false;
+    const originalGet = MemoryIndexManager.get.bind(MemoryIndexManager);
+    const getSpy = vi.spyOn(MemoryIndexManager, "get").mockImplementation(async (params) => {
+      const acquired = await originalGet(params);
+      if (params.purpose !== "maintenance" || !acquired) {
+        return acquired;
+      }
+      const closeMaintenance = acquired.close.bind(acquired);
+      vi.spyOn(acquired, "close").mockImplementation(async () => {
+        await closeMaintenance();
+        maintenanceClosed = true;
+      });
+      const fields = acquired as unknown as {
+        syncMemoryFiles: (params: { needsFullReindex: boolean }) => Promise<unknown>;
+      };
+      const syncMemoryFiles = fields.syncMemoryFiles.bind(acquired);
+      vi.spyOn(fields, "syncMemoryFiles").mockImplementation(async (syncParams) => {
+        const result = await syncMemoryFiles(syncParams);
+        maintenanceReady.resolve();
+        await releaseMaintenance.promise;
+        return result;
+      });
+      return acquired;
+    });
+
+    try {
+      const search = manager.search("zebra", {
+        maxResults: 5,
+        minScore: 0,
+        sessionKey: "agent:main:cli:memory-search",
+      });
+      await vi.waitFor(() =>
+        expect(getSpy).toHaveBeenCalledWith(expect.objectContaining({ purpose: "maintenance" })),
+      );
+      await maintenanceReady.promise;
+      const results = await search;
+
+      expect(results.some((entry) => entry.path === "memory/2026-01-12.md")).toBe(true);
+      expect(servingSync).not.toHaveBeenCalled();
+      if (typeof manager.close !== "function") {
+        throw new Error("Expected CLI memory manager close support");
+      }
+      closePromise = manager.close();
+      let closeSettled = false;
+      void closePromise.then(() => {
+        closeSettled = true;
+      });
+      await vi.waitFor(() => expect(closeSettled).toBe(true));
+      expect(maintenanceClosed).toBe(false);
+    } finally {
+      releaseMaintenance.resolve();
+      await closePromise;
+      getSpy.mockRestore();
+      await manager.close?.();
+    }
+  });
+
+  it("restores a failed maintenance generation and still closes its transient manager", async () => {
+    const manager = await getPersistentManager(
+      createCfg({ provider: "none", minScore: 0, onSearch: true, hybrid: { enabled: true } }),
+    );
+    await manager.sync({ reason: "test" });
+    const syncError = new Error("maintenance failed");
+    const maintenance = {
+      sync: vi.fn(async () => {
+        throw syncError;
+      }),
+      close: vi.fn(async () => {}),
+    };
+    const getSpy = vi.spyOn(MemoryIndexManager, "get").mockResolvedValue(maintenance as never);
+    Reflect.set(manager, "dirty", true);
+    Reflect.set(manager, "memoryFullRetryDirty", true);
+    Reflect.set(manager, "sessionsDirty", true);
+    Reflect.set(manager, "sessionsFullRetryDirty", true);
+    Reflect.set(manager, "sessionsReconcileDirty", true);
+    Reflect.set(manager, "sessionsDirtyFiles", new Set(["session.jsonl"]));
+
+    try {
+      await expect(
+        (
+          manager as unknown as {
+            syncPublishedIndexInBackground: (params: { reason: string }) => Promise<void>;
+          }
+        ).syncPublishedIndexInBackground({ reason: "search" }),
+      ).rejects.toThrow(syncError);
+
+      expect(maintenance.sync).toHaveBeenCalledWith({ reason: "search", force: true });
+      expect(maintenance.close).toHaveBeenCalledTimes(1);
+      expect(Reflect.get(manager, "dirty")).toBe(true);
+      expect(Reflect.get(manager, "memoryFullRetryDirty")).toBe(true);
+      expect(Reflect.get(manager, "sessionsDirty")).toBe(true);
+      expect(Reflect.get(manager, "sessionsFullRetryDirty")).toBe(true);
+      expect(Reflect.get(manager, "sessionsReconcileDirty")).toBe(true);
+      expect(Reflect.get(manager, "sessionsDirtyFiles")).toEqual(new Set(["session.jsonl"]));
+    } finally {
+      getSpy.mockRestore();
+    }
+  });
+
+  it("restores a maintenance generation when a null fallback leaves it dirty", async () => {
+    const cfg = createCfg({
+      fallback: "fallback-provider",
+      minScore: 0,
+      onSearch: true,
+      hybrid: { enabled: true },
+    });
+    const manager = await getPersistentManager(cfg);
+    await manager.sync({ reason: "test", force: true });
+    await fs.writeFile(
+      path.join(fixture.paths.memory, "null-fallback.md"),
+      "New content that requires a fallback embedding.",
+    );
+    Reflect.set(manager, "dirty", true);
+    Reflect.set(manager, "memoryFullRetryDirty", true);
+    providerFixture.providerNullResult = "fallback-provider";
+    const originalGet = MemoryIndexManager.get.bind(MemoryIndexManager);
+    const getSpy = vi.spyOn(MemoryIndexManager, "get").mockImplementation(async (params) => {
+      const acquired = await originalGet(params);
+      if (params.purpose !== "maintenance" || !acquired) {
+        return acquired;
+      }
+      const fields = acquired as unknown as {
+        ensureProviderInitialized: () => Promise<void>;
+        provider: EmbeddingProvider | null;
+      };
+      await fields.ensureProviderInitialized();
+      if (!fields.provider) {
+        throw new Error("expected maintenance embedding provider");
+      }
+      fields.provider.embedBatch = async () => {
+        throw providerFixture.createLocalWorkerExitError();
+      };
+      return acquired;
+    });
+
+    try {
+      await expect(
+        (
+          manager as unknown as {
+            syncPublishedIndexInBackground: (params: { reason: string }) => Promise<void>;
+          }
+        ).syncPublishedIndexInBackground({ reason: "search" }),
+      ).resolves.toBeUndefined();
+
+      expect(manager.status().dirty).toBe(true);
+      expect(Reflect.get(manager, "memoryFullRetryDirty")).toBe(true);
+    } finally {
+      providerFixture.providerNullResult = null;
+      getSpy.mockRestore();
+    }
+  });
+
+  it("does not let a rejected maintenance handoff abort manager teardown", async () => {
+    const manager = await getPersistentManager(
+      createCfg({ provider: "none", minScore: 0, onSearch: true, hybrid: { enabled: true } }),
+    );
+    await manager.sync({ reason: "test" });
+    Reflect.set(manager, "dirty", true);
+    const syncSpy = vi
+      .spyOn(
+        manager as unknown as {
+          syncPublishedIndexInBackground: (params: { reason: string }) => Promise<void>;
+        },
+        "syncPublishedIndexInBackground",
+      )
+      .mockRejectedValue(new Error("maintenance failed"));
+
+    await manager.search("zebra", { maxResults: 5, minScore: 0 });
+    await expect(manager.close?.()).resolves.toBeUndefined();
+    expect(syncSpy).toHaveBeenCalledWith({ reason: "search" });
   });
 });

--- a/extensions/memory-core/src/memory/manager-search-orchestration.ts
+++ b/extensions/memory-core/src/memory/manager-search-orchestration.ts
@@ -21,6 +21,7 @@ import {
 } from "./hybrid.js";
 import { applyImportanceMultiplier } from "./importance.js";
 import { startAsyncSearchSync } from "./manager-async-state.js";
+import { acquireMemoryIndexReadGeneration } from "./manager-index-generation-lease.js";
 import { MemoryKeywordRetrieval, type KeywordSearchHit } from "./manager-keyword-retrieval.js";
 import { runVectorKnnInSubprocess } from "./manager-search-knn-subprocess.js";
 import { resolveMemorySearchPreflight } from "./manager-search-preflight.js";
@@ -37,20 +38,18 @@ type MemoryIndexSearchOptions = NonNullable<Parameters<MemorySearchManager["sear
 export abstract class MemorySearchOrchestration extends MemoryKeywordRetrieval {
   protected abstract sessionWarm: Set<string>;
 
-  protected async warmSession(sessionKey?: string): Promise<void> {
+  protected claimSessionWarmSync(sessionKey?: string): boolean {
     if (!this.settings.sync.onSessionStart) {
-      return;
+      return false;
     }
     const key = sessionKey?.trim() || "";
     if (key && this.sessionWarm.has(key)) {
-      return;
+      return false;
     }
-    void this.sync({ reason: "session-start" }).catch((err: unknown) => {
-      log.warn(`memory sync failed (session-start): ${String(err)}`);
-    });
     if (key) {
       this.sessionWarm.add(key);
     }
+    return this.dirty || this.sessionsDirty;
   }
 
   async search(query: string, opts?: MemoryIndexSearchOptions): Promise<MemorySearchResult[]> {
@@ -79,6 +78,7 @@ export abstract class MemorySearchOrchestration extends MemoryKeywordRetrieval {
     normalizedQuery: string,
     opts?: MemoryIndexSearchOptions,
   ): Promise<MemorySearchResult[]> {
+    let releaseGeneration: (() => void) | undefined;
     return await this.withManagerOperation(async () => {
       opts?.onDebug?.({ backend: "builtin" });
       if (this.providerRequirement.mode === "required") {
@@ -136,16 +136,7 @@ export abstract class MemorySearchOrchestration extends MemoryKeywordRetrieval {
       const embeddingBootstrapKeywordOnly = await this.ensureEmbeddingProviderForSearch(
         opts?.onDebug,
       );
-      void this.warmSession(opts?.sessionKey);
-      await startAsyncSearchSync({
-        enabled: this.settings.sync.onSearch,
-        dirty: this.dirty,
-        sessionsDirty: this.sessionsDirty,
-        sync: async (params) => await this.syncAdmitted(params),
-        onError: (err) => {
-          log.warn(`memory sync failed (search): ${String(err)}`);
-        },
-      });
+      const sessionStartSync = this.claimSessionWarmSync(opts?.sessionKey);
       if (
         !embeddingBootstrapKeywordOnly &&
         preflight.shouldInitializeProvider &&
@@ -185,8 +176,78 @@ export abstract class MemorySearchOrchestration extends MemoryKeywordRetrieval {
         : this.refreshIndexIdentityDirty({
             providerKeyKnown: this.providerInitialized,
           });
-      if (indexIdentity.status !== "valid") {
+      if (indexIdentity.status === "missing" && hasIndexedContent) {
+        // Missing metadata cannot identify a safe published generation. Repair it
+        // synchronously before a detached handoff or a read-generation lease.
+        await this.syncAdmitted(
+          { reason: "search", force: true },
+          { allowEmbeddingBootstrapFallback: true },
+        ).catch((err: unknown) => {
+          log.warn(`memory sync failed (search-identity-repair): ${formatErrorMessage(err)}`);
+        });
+      }
+      let repairedIndexIdentity =
+        indexIdentity.status === "missing" && hasIndexedContent
+          ? embeddingBootstrapKeywordOnly
+            ? this.refreshKeywordFallbackIndexIdentity()
+            : this.refreshIndexIdentityDirty({
+                providerKeyKnown: this.providerInitialized,
+              })
+          : indexIdentity;
+      if (
+        repairedIndexIdentity.status === "mismatched" &&
+        !embeddingBootstrapKeywordOnly &&
+        (await this.adoptPublishedFallbackProviderIfMatched())
+      ) {
+        repairedIndexIdentity = this.refreshIndexIdentityDirty({
+          providerKeyKnown: this.providerInitialized,
+        });
+      }
+      if (repairedIndexIdentity.status !== "valid") {
         return [];
+      }
+      const backgroundSearchSync = startAsyncSearchSync({
+        enabled:
+          (this.settings.sync.onSearch || sessionStartSync) &&
+          (this.purpose === "default" || this.purpose === "cli"),
+        dirty: this.dirty,
+        sessionsDirty: this.sessionsDirty,
+        sync: async (params) => await this.syncPublishedIndexInBackground(params),
+        onError: (err) => {
+          log.warn(`memory sync failed (search): ${String(err)}`);
+        },
+      });
+      if (backgroundSearchSync) {
+        const trackedSearchSync = backgroundSearchSync.finally(() => {
+          this.activeBackgroundSearchSyncs.delete(trackedSearchSync);
+        });
+        this.activeBackgroundSearchSyncs.add(trackedSearchSync);
+      }
+      // Bootstrap and identity repair may publish a new generation. Acquire the
+      // read lease only after those writers finish so first search cannot wait on itself.
+      for (let identityAttempt = 0; identityAttempt < 2; identityAttempt += 1) {
+        releaseGeneration = await acquireMemoryIndexReadGeneration(
+          this.settings.store.databasePath,
+          opts?.signal,
+        );
+        if (embeddingBootstrapKeywordOnly) {
+          break;
+        }
+        const leasedIdentity = this.refreshIndexIdentityDirty({
+          providerKeyKnown: this.providerInitialized,
+        });
+        if (leasedIdentity.status === "valid") {
+          break;
+        }
+        releaseGeneration();
+        releaseGeneration = undefined;
+        if (
+          identityAttempt > 0 ||
+          leasedIdentity.status !== "mismatched" ||
+          !(await this.adoptPublishedFallbackProviderIfMatched())
+        ) {
+          return [];
+        }
       }
       const minScore = opts?.minScore ?? this.settings.query.minScore;
       const maxResults = opts?.maxResults ?? this.settings.query.maxResults;
@@ -403,6 +464,8 @@ export abstract class MemorySearchOrchestration extends MemoryKeywordRetrieval {
         maxResults,
         minScore,
       });
+    }).finally(() => {
+      releaseGeneration?.();
     });
   }
 

--- a/extensions/memory-core/src/memory/manager-sqlite-lease.ts
+++ b/extensions/memory-core/src/memory/manager-sqlite-lease.ts
@@ -1,0 +1,124 @@
+// Memory Core owns crash-safe SQLite coordination leases shared across processes.
+import type { DatabaseSync } from "node:sqlite";
+import { extractErrorCode, toErrorObject } from "openclaw/plugin-sdk/error-runtime";
+import { sleepWithAbort } from "openclaw/plugin-sdk/runtime-env";
+import { openNodeSqliteDatabase } from "openclaw/plugin-sdk/sqlite-runtime";
+
+export type MemorySqliteLeaseHandle = {
+  release: () => void;
+};
+
+const MEMORY_SQLITE_LEASE_RETRY_DELAY_MS = 25;
+
+function isSqliteBusyError(err: unknown): boolean {
+  const code = extractErrorCode(err);
+  if (code === "SQLITE_BUSY" || code === "SQLITE_LOCKED") {
+    return true;
+  }
+  const message = err instanceof Error ? err.message : String(err);
+  return /SQLITE_(?:BUSY|LOCKED)|database is locked/iu.test(message);
+}
+
+function openMemoryLeaseDatabase(location: string): DatabaseSync {
+  const database = openNodeSqliteDatabase(location);
+  try {
+    database.exec("PRAGMA busy_timeout = 0");
+    return database;
+  } catch (err) {
+    database.close();
+    throw err;
+  }
+}
+
+function createMemorySqliteLeaseHandle(
+  database: DatabaseSync,
+  transactionActive: boolean,
+): MemorySqliteLeaseHandle {
+  return {
+    release: () => {
+      let releaseError: unknown;
+      if (transactionActive) {
+        try {
+          database.exec("ROLLBACK");
+        } catch (err) {
+          releaseError = err;
+        }
+      }
+      try {
+        database.close();
+      } catch (err) {
+        releaseError ??= err;
+      }
+      if (releaseError) {
+        throw toErrorObject(releaseError, "Failed to release memory SQLite lease");
+      }
+    },
+  };
+}
+
+export function tryAcquireMemorySqliteLease(
+  location: string,
+  mode: "shared" | "exclusive",
+): MemorySqliteLeaseHandle | undefined {
+  const database = openMemoryLeaseDatabase(location);
+  try {
+    if (mode === "exclusive") {
+      database.exec("BEGIN EXCLUSIVE");
+    } else {
+      database.exec("BEGIN");
+      // BEGIN is deferred. Reading sqlite_schema acquires the shared lock without
+      // requiring a coordination table or touching the live memory database.
+      database.prepare("SELECT name FROM sqlite_schema LIMIT 1").get();
+    }
+  } catch (err) {
+    database.close();
+    if (isSqliteBusyError(err)) {
+      return undefined;
+    }
+    throw err;
+  }
+  return createMemorySqliteLeaseHandle(database, true);
+}
+
+/** Acquire writer admission without dropping PENDING intent after the first reader collision. */
+export async function acquireMemorySqliteWriterLease(
+  location: string,
+  signal?: AbortSignal,
+): Promise<MemorySqliteLeaseHandle> {
+  while (true) {
+    signal?.throwIfAborted();
+    const database = openMemoryLeaseDatabase(location);
+    try {
+      database.exec("PRAGMA locking_mode = EXCLUSIVE");
+      database.exec("BEGIN IMMEDIATE");
+      // Rewriting the unchanged header field creates a schema-free write transaction.
+      // A blocked commit retains SQLite's PENDING lock so later readers cannot overtake it.
+      database.exec("PRAGMA user_version = 0");
+    } catch (err) {
+      database.close();
+      if (!isSqliteBusyError(err)) {
+        throw err;
+      }
+      await sleepWithAbort(MEMORY_SQLITE_LEASE_RETRY_DELAY_MS, signal);
+      continue;
+    }
+
+    while (true) {
+      try {
+        database.exec("COMMIT");
+        return createMemorySqliteLeaseHandle(database, false);
+      } catch (err) {
+        if (!isSqliteBusyError(err)) {
+          createMemorySqliteLeaseHandle(database, true).release();
+          throw err;
+        }
+        try {
+          await sleepWithAbort(MEMORY_SQLITE_LEASE_RETRY_DELAY_MS, signal);
+        } catch (sleepError) {
+          createMemorySqliteLeaseHandle(database, true).release();
+          throw sleepError;
+        }
+      }
+    }
+  }
+}

--- a/extensions/memory-core/src/memory/manager-status-state.test.ts
+++ b/extensions/memory-core/src/memory/manager-status-state.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import {
   collectMemoryStatusAggregate,
   resolveInitialMemoryDirty,
+  resolveMemoryManagerSyncStatus,
   resolveStatusProviderInfo,
 } from "./manager-status-state.js";
 
@@ -39,6 +40,22 @@ describe("memory manager status state", () => {
     },
   ])("resolves $name", ({ params, expected }) => {
     expect(resolveInitialMemoryDirty(params)).toBe(expected);
+  });
+
+  it("reports detached maintenance as stale with every refreshed source", () => {
+    expect(
+      resolveMemoryManagerSyncStatus({
+        syncing: false,
+        memoryDirty: false,
+        sessionsDirty: false,
+        indexIdentityDirty: false,
+        backgroundMaintenance: true,
+        sources: ["memory", "sessions"],
+      }),
+    ).toEqual({
+      dirty: true,
+      pendingSyncSources: ["memory", "sessions"],
+    });
   });
 
   it.each([

--- a/extensions/memory-core/src/memory/manager-status-state.ts
+++ b/extensions/memory-core/src/memory/manager-status-state.ts
@@ -36,6 +36,36 @@ export function resolveInitialMemoryDirty(params: {
   );
 }
 
+export function resolveMemoryManagerSyncStatus(params: {
+  syncing: boolean;
+  memoryDirty: boolean;
+  sessionsDirty: boolean;
+  indexIdentityDirty: boolean;
+  backgroundMaintenance: boolean;
+  sources: Iterable<MemorySource>;
+}): { dirty: boolean; pendingSyncSources?: MemorySource[] } {
+  const pending = new Set<MemorySource>();
+  if (params.syncing && params.memoryDirty) {
+    pending.add("memory");
+  }
+  if (params.syncing && params.sessionsDirty) {
+    pending.add("sessions");
+  }
+  if (params.backgroundMaintenance) {
+    for (const source of params.sources) {
+      pending.add(source);
+    }
+  }
+  return {
+    dirty:
+      params.memoryDirty ||
+      params.sessionsDirty ||
+      params.indexIdentityDirty ||
+      params.backgroundMaintenance,
+    ...(pending.size > 0 ? { pendingSyncSources: Array.from(pending) } : {}),
+  };
+}
+
 export function resolveStatusProviderInfo(params: {
   provider: StatusProvider | null;
   providerInitialized: boolean;

--- a/extensions/memory-core/src/memory/manager-sync-base.ts
+++ b/extensions/memory-core/src/memory/manager-sync-base.ts
@@ -200,6 +200,15 @@ export abstract class MemoryManagerSyncBase extends MemoryManagerDatabaseContext
     };
   }
 
+  protected takeReindexRetryStateForMaintenance(): MemoryReindexRetryState {
+    const snapshot = this.snapshotReindexRetryState();
+    // The detached generation owns only the state observed here. New watcher or
+    // session events remain dirty on this manager and trigger a later generation.
+    this.clearMemoryRetryState();
+    this.clearSessionRetryState();
+    return snapshot;
+  }
+
   protected restoreReindexRetryState(snapshot: MemoryReindexRetryState): void {
     this.dirty = snapshot.dirty || this.dirty;
     this.memoryFullRetryDirty = snapshot.memoryFullRetryDirty || this.memoryFullRetryDirty;

--- a/extensions/memory-core/src/memory/manager-sync-control.ts
+++ b/extensions/memory-core/src/memory/manager-sync-control.ts
@@ -5,6 +5,13 @@ import type {
   MemorySyncProgressUpdate,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 
+export function hasTargetedSessionSyncParams(params: MemorySyncParams | undefined): boolean {
+  return Boolean(
+    params?.sessions?.some((session) => session.sessionId.trim().length > 0) ||
+    params?.archiveFiles?.some((sessionFile) => sessionFile.trim().length > 0),
+  );
+}
+
 export function enqueueMemoryTargetedSessionSync(
   state: {
     isClosed: () => boolean;

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -29,12 +29,13 @@ import {
   removeMemoryDatabaseFiles,
 } from "./manager-db.js";
 import { isMemoryEmbeddingOperationError } from "./manager-embedding-errors.js";
+import { withMemoryIndexPublishGeneration } from "./manager-index-generation-lease.js";
 import {
   applyMemoryFallbackProviderState,
   resolveFallbackCurrentProviderId,
   resolveMemoryFallbackProviderRequest,
 } from "./manager-provider-state.js";
-import { acquireMemoryReindexLock, type MemoryReindexLockHandle } from "./manager-reindex-lock.js";
+import { type MemoryReindexLockHandle, waitForMemoryReindexLock } from "./manager-reindex-lock.js";
 import {
   MEMORY_INDEX_PROVENANCE_VERSION,
   resolveConfiguredScopeHash,
@@ -530,7 +531,7 @@ export abstract class MemoryManagerSyncOps extends MemoryManagerSourceSyncOps {
     );
     try {
       cleanupAgedMemoryReindexTempFiles(dbPath);
-      reindexLock = acquireMemoryReindexLock(dbPath);
+      reindexLock = await waitForMemoryReindexLock(dbPath);
       const originalRevision = readMemoryDatabaseRevision(originalDb);
       tempDb = openMemoryDatabaseAtPath(tempDbPath, this.settings.store.vector.enabled);
       const shadow = new MemoryIndexDatabase(tempDb);
@@ -618,15 +619,17 @@ export abstract class MemoryManagerSyncOps extends MemoryManagerSourceSyncOps {
 
       closeMemoryDatabase(tempDb);
       tempDbClosed = true;
-      await withMemoryWorkspaceLock(this.workspaceDir, () =>
-        publishMemoryDatabaseTables({
-          targetDb: originalDb,
-          sourcePath: tempDbPath,
-          metaKey: MEMORY_INDEX_META_KEY,
-          expectedRevision: originalRevision,
-          vectorExtensionPath: shadow.vector.extensionPath,
-        }),
-      );
+      await withMemoryWorkspaceLock(this.workspaceDir, async () => {
+        await withMemoryIndexPublishGeneration(dbPath, async () => {
+          await publishMemoryDatabaseTables({
+            targetDb: originalDb,
+            sourcePath: tempDbPath,
+            metaKey: MEMORY_INDEX_META_KEY,
+            expectedRevision: originalRevision,
+            vectorExtensionPath: shadow.vector.extensionPath,
+          });
+        });
+      });
 
       if (rebuilt.vectorIndexComplete) {
         // Publish completeness only after the shadow tables committed. A crash

--- a/extensions/memory-core/src/memory/manager.reindex-recovery.test.ts
+++ b/extensions/memory-core/src/memory/manager.reindex-recovery.test.ts
@@ -9,7 +9,7 @@ import { resolveOpenClawAgentSqlitePath } from "openclaw/plugin-sdk/sqlite-runti
 import { closeOpenClawAgentDatabasesForTest } from "openclaw/plugin-sdk/sqlite-runtime-testing";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resetEmbeddingMocks } from "./embedding.test-mocks.js";
-import { acquireMemoryReindexLock } from "./manager-reindex-lock.js";
+import { tryAcquireMemoryReindexLock, waitForMemoryReindexLock } from "./manager-reindex-lock.js";
 import type { MemoryIndexMeta } from "./manager-reindex-state.js";
 import type { MemoryIndexManager } from "./manager.js";
 
@@ -96,6 +96,14 @@ describe("memory manager reindex recovery", () => {
     }
     manager = result.manager as unknown as MemoryIndexManager;
     return manager;
+  }
+
+  function acquireTestReindexLock(databasePath: string) {
+    const lock = tryAcquireMemoryReindexLock(databasePath);
+    if (!lock) {
+      throw new Error("expected test to acquire the memory reindex lock");
+    }
+    return lock;
   }
 
   it("restores retry state after a shadow full reindex fails late", async () => {
@@ -189,7 +197,7 @@ describe("memory manager reindex recovery", () => {
     const memoryManager = await openManager(createCfg({ provider: "none", sources: ["memory"] }));
     const harness = memoryManager as unknown as ReindexHarness;
     const databasePath = resolveOpenClawAgentSqlitePath({ agentId: "main" });
-    const lock = acquireMemoryReindexLock(databasePath);
+    const lock = acquireTestReindexLock(databasePath);
 
     try {
       await expect(harness.runInPlaceReindex({ reason: "test", force: true })).rejects.toThrow(
@@ -197,6 +205,35 @@ describe("memory manager reindex recovery", () => {
       );
     } finally {
       lock.release();
+    }
+  });
+
+  it("waits for the build lock without blocking the event loop", async () => {
+    const databasePath = resolveOpenClawAgentSqlitePath({ agentId: "main" });
+    await fs.mkdir(path.dirname(databasePath), { recursive: true });
+    const lock = acquireTestReindexLock(databasePath);
+    let timerFired = false;
+    let lockReleased = false;
+
+    try {
+      const wait = waitForMemoryReindexLock(databasePath);
+      const timer = new Promise<void>((resolve) => {
+        setTimeout(() => {
+          timerFired = true;
+          resolve();
+        }, 10);
+      });
+
+      await timer;
+      expect(timerFired).toBe(true);
+      lock.release();
+      lockReleased = true;
+      const waitedLock = await wait;
+      waitedLock.release();
+    } finally {
+      if (!lockReleased) {
+        lock.release();
+      }
     }
   });
 

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -32,34 +32,31 @@ import {
   type MemoryEmbeddingBootstrapDebug,
   type MemoryEmbeddingProviderRequirement,
 } from "./manager-provider-lifecycle.js";
+import { getLocalEmbeddingRuntimeFacts } from "./manager-provider-runtime-facts.js";
 import {
   createPendingMemoryProviderLifecycle,
   type MemoryProviderLifecycleState,
 } from "./manager-provider-state.js";
 import {
   MemoryManagerRegistry,
+  normalizeMemoryIndexManagerPurpose,
   resolveMemoryIndexManagerCacheKey,
   type MemoryIndexManagerPurpose,
 } from "./manager-registry.js";
 import type { MemoryIndexIdentityState } from "./manager-reindex-state.js";
+import { runMemorySearchMaintenance } from "./manager-search-maintenance.js";
 import { MemorySearchOrchestration } from "./manager-search-orchestration.js";
 import {
   collectMemoryStatusAggregate,
   resolveInitialMemoryDirty,
+  resolveMemoryManagerSyncStatus,
   resolveStatusProviderInfo,
 } from "./manager-status-state.js";
-import { enqueueMemoryTargetedSessionSync } from "./manager-sync-control.js";
+import {
+  enqueueMemoryTargetedSessionSync,
+  hasTargetedSessionSyncParams,
+} from "./manager-sync-control.js";
 import { resolvePersistedMemoryVectorIndexState } from "./manager-vector-rebuild-state.js";
-
-const LOCAL_EMBEDDING_RUNTIME_FACTS = Symbol.for("openclaw.localEmbeddingRuntimeFacts");
-
-function getLocalEmbeddingRuntimeFacts(provider: EmbeddingProvider | null): unknown {
-  if (!provider) {
-    return undefined;
-  }
-  const getRuntimeFacts = Reflect.get(provider, LOCAL_EMBEDDING_RUNTIME_FACTS);
-  return typeof getRuntimeFacts === "function" ? getRuntimeFacts() : undefined;
-}
 
 const log = createSubsystemLogger("memory");
 const INDEX_MANAGER_REGISTRY = new MemoryManagerRegistry<MemoryIndexManager>();
@@ -73,6 +70,11 @@ export async function closeMemoryIndexManagersForAgent(params: { agentId: string
   await INDEX_MANAGER_REGISTRY.closeForAgent({
     agentId: params.agentId,
     purpose: "default",
+    close: async (manager) => await manager.close(),
+  });
+  await INDEX_MANAGER_REGISTRY.closeForAgent({
+    agentId: params.agentId,
+    purpose: "maintenance",
     close: async (manager) => await manager.close(),
   });
 }
@@ -97,6 +99,7 @@ export class MemoryIndexManager extends MemorySearchOrchestration implements Mem
   protected closing = false;
   protected activeManagerOperations = 0;
   protected managerIdleWaiters = new Set<() => void>();
+  protected activeBackgroundSearchSyncs = new Set<Promise<void>>();
   protected providerUnavailableReason?: string;
   protected override providerLifecycle: MemoryProviderLifecycleState;
   protected batch: {
@@ -133,8 +136,7 @@ export class MemoryIndexManager extends MemorySearchOrchestration implements Mem
     acquireLocalService?: MemoryCoreAcquireLocalService;
   }): Promise<MemoryIndexManager | null> {
     const agentId = normalizeAgentId(params.agentId);
-    const purpose =
-      params.purpose === "status" || params.purpose === "cli" ? params.purpose : "default";
+    const purpose = normalizeMemoryIndexManagerPurpose(params.purpose);
     return await INDEX_MANAGER_REGISTRY.acquire(
       { agentId, purpose },
       {
@@ -159,7 +161,7 @@ export class MemoryIndexManager extends MemorySearchOrchestration implements Mem
           });
           return {
             key,
-            transient: purpose === "status" || purpose === "cli",
+            transient: purpose === "status" || purpose === "cli" || purpose === "maintenance",
             create: async () => {
               const manager = new MemoryIndexManager({
                 cacheKey: key,
@@ -198,8 +200,7 @@ export class MemoryIndexManager extends MemorySearchOrchestration implements Mem
     const effectiveSettings = resolveEffectiveMemorySearchSettings(params.settings);
     this.cacheKey = params.cacheKey;
     this.acquireLocalService = params.acquireLocalService;
-    this.purpose =
-      params.purpose === "status" || params.purpose === "cli" ? params.purpose : "default";
+    this.purpose = normalizeMemoryIndexManagerPurpose(params.purpose);
     this.cfg = params.cfg;
     this.agentId = params.agentId;
     this.workspaceDir = params.workspaceDir;
@@ -233,7 +234,8 @@ export class MemoryIndexManager extends MemorySearchOrchestration implements Mem
       this.indexIdentityDirty =
         initialIndexIdentity.status === "mismatched" ||
         (initialIndexIdentity.status === "missing" && this.sources.has("memory"));
-      const transient = params.purpose === "status" || params.purpose === "cli";
+      const transient =
+        params.purpose === "status" || params.purpose === "cli" || params.purpose === "maintenance";
       if (!transient) {
         this.ensureWatcher();
         this.ensureSessionListener();
@@ -292,6 +294,21 @@ export class MemoryIndexManager extends MemorySearchOrchestration implements Mem
       return await this.enqueueTargetedSessionSync(params);
     }
     return await this.syncAdmitted(params);
+  }
+
+  protected async syncPublishedIndexInBackground(params: { reason: string }): Promise<void> {
+    await runMemorySearchMaintenance({
+      reason: params.reason,
+      takeDirtyGeneration: () => this.takeReindexRetryStateForMaintenance(),
+      restoreDirtyGeneration: (generation) => this.restoreReindexRetryState(generation),
+      acquireManager: async () =>
+        await MemoryIndexManager.get({
+          cfg: this.cfg,
+          agentId: this.agentId,
+          purpose: "maintenance",
+          acquireLocalService: this.acquireLocalService,
+        }),
+    });
   }
 
   protected async syncAdmitted(
@@ -479,22 +496,20 @@ export class MemoryIndexManager extends MemorySearchOrchestration implements Mem
       requestedProvider: this.requestedProvider,
       configuredModel: this.settings.model || undefined,
     });
-    const pendingSyncSources: MemorySource[] = [];
-    if (this.syncing) {
-      if (this.dirty) {
-        pendingSyncSources.push("memory");
-      }
-      if (this.sessionsDirty) {
-        pendingSyncSources.push("sessions");
-      }
-    }
+    const syncStatus = resolveMemoryManagerSyncStatus({
+      syncing: this.syncing !== null,
+      memoryDirty: this.dirty,
+      sessionsDirty: this.sessionsDirty,
+      indexIdentityDirty: this.indexIdentityDirty,
+      backgroundMaintenance: this.activeBackgroundSearchSyncs.size > 0,
+      sources: this.sources,
+    });
 
     return {
       backend: "builtin",
       files: aggregateState.files,
       chunks: aggregateState.chunks,
-      dirty: this.dirty || this.sessionsDirty || this.indexIdentityDirty,
-      pendingSyncSources: pendingSyncSources.length > 0 ? pendingSyncSources : undefined,
+      ...syncStatus,
       workspaceDir: this.workspaceDir,
       dbPath: this.settings.store.databasePath,
       provider: providerInfo.provider,
@@ -701,11 +716,4 @@ export class MemoryIndexManager extends MemorySearchOrchestration implements Mem
     }
     INDEX_MANAGER_REGISTRY.deleteIfCurrent(this.cacheKey, this);
   }
-}
-
-function hasTargetedSessionSyncParams(params: MemorySyncParams | undefined): boolean {
-  return Boolean(
-    params?.sessions?.some((session) => session.sessionId.trim().length > 0) ||
-    params?.archiveFiles?.some((sessionFile) => sessionFile.trim().length > 0),
-  );
 }

--- a/extensions/memory-core/src/tools.real-manager.test.ts
+++ b/extensions/memory-core/src/tools.real-manager.test.ts
@@ -1,8 +1,10 @@
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 // Memory Core integration tests exercise the real SQLite search manager through tools.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
 import { openOpenClawAgentDatabase } from "openclaw/plugin-sdk/sqlite-runtime";
 import { closeOpenClawAgentDatabasesForTest } from "openclaw/plugin-sdk/sqlite-runtime-testing";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as generationLease from "./memory/manager-index-generation-lease.js";
 import {
   createManagerIndexFixture,
   type ManagerIndexFixture,
@@ -10,6 +12,7 @@ import {
 import { createMemorySearchTool, testing } from "./tools.js";
 
 const { closeAllMemorySearchManagers, getMemorySearchManager } = await import("./memory/index.js");
+const { MemoryIndexManager } = await import("./memory/manager.js");
 
 describe("memory_search real manager", () => {
   const fixture: ManagerIndexFixture = createManagerIndexFixture({
@@ -169,5 +172,72 @@ describe("memory_search real manager", () => {
     expect(first.details).toMatchObject(expected);
     expect(replay.details).toMatchObject(expected);
     expect(fixture.provider.embedQueryCalls).toBe(0);
+  });
+
+  it("finishes one-shot cleanup when its deadline aborts a publication wait", async () => {
+    const cfg = fixture.createConfig({
+      provider: "none",
+      sources: ["memory"],
+      vectorEnabled: false,
+      minScore: 0,
+      onSearch: false,
+    });
+    const initializedManager = await fixture.getFreshManager(cfg, "cli");
+    await initializedManager.sync({ reason: "test", force: true });
+    const databasePath = initializedManager.status().dbPath;
+    if (!databasePath) {
+      throw new Error("memory search manager database path missing");
+    }
+    await initializedManager.close();
+
+    const publicationEntered = createDeferred<void>();
+    const releasePublication = createDeferred<void>();
+    const publication = generationLease.withMemoryIndexPublishGeneration(databasePath, async () => {
+      publicationEntered.resolve();
+      await releasePublication.promise;
+    });
+    await publicationEntered.promise;
+
+    const tool = createMemorySearchTool({
+      config: cfg,
+      agentId: "main",
+      oneShotCliRun: true,
+    });
+    if (!tool) {
+      throw new Error("memory_search tool missing");
+    }
+    const searchStarted = createDeferred<void>();
+    const originalGet = MemoryIndexManager.get.bind(MemoryIndexManager);
+    const getSpy = vi.spyOn(MemoryIndexManager, "get").mockImplementation(async (params) => {
+      const acquired = await originalGet(params);
+      if (params.purpose !== "cli" || !acquired) {
+        return acquired;
+      }
+      const search = acquired.search.bind(acquired);
+      vi.spyOn(acquired, "search").mockImplementation(async (...args) => {
+        searchStarted.resolve();
+        return await search(...args);
+      });
+      return acquired;
+    });
+    vi.useFakeTimers();
+    let executionSettled = false;
+    const execution = tool.execute("timed-out-generation-wait", { query: "zebra" }).finally(() => {
+      executionSettled = true;
+    });
+    try {
+      await searchStarted.promise;
+      await vi.advanceTimersByTimeAsync(15_100);
+      expect(executionSettled).toBe(true);
+      await expect(execution).resolves.toMatchObject({
+        details: { unavailable: true },
+      });
+    } finally {
+      releasePublication.resolve();
+      await vi.advanceTimersByTimeAsync(100);
+      await publication;
+      await execution.catch(() => undefined);
+      getSpy.mockRestore();
+    }
   });
 });

--- a/src/commands/backup-verify.test.ts
+++ b/src/commands/backup-verify.test.ts
@@ -1173,6 +1173,26 @@ describe("backupVerifyCommand", () => {
             archivePath: `${stateAssetArchivePath}/memory/main.sqlite.reindex-lock.sqlite-wal`,
           },
           {
+            fileName: "generation-writer.sqlite",
+            contents: invalidSqlite,
+            archivePath: `${stateAssetArchivePath}/memory/main.sqlite.generation-writer.sqlite`,
+          },
+          {
+            fileName: "generation-writer.sqlite-shm",
+            contents: invalidSqlite,
+            archivePath: `${stateAssetArchivePath}/memory/main.sqlite.generation-writer.sqlite-shm`,
+          },
+          {
+            fileName: "generation-lock.sqlite",
+            contents: invalidSqlite,
+            archivePath: `${stateAssetArchivePath}/memory/main.sqlite.generation-lock.sqlite`,
+          },
+          {
+            fileName: "generation-lock.sqlite-journal",
+            contents: invalidSqlite,
+            archivePath: `${stateAssetArchivePath}/memory/main.sqlite.generation-lock.sqlite-journal`,
+          },
+          {
             fileName: "reindex-tmp",
             contents: invalidSqlite,
             archivePath: `${stateAssetArchivePath}/memory/main.sqlite.tmp-${transientId}`,

--- a/src/infra/backup-create.test.ts
+++ b/src/infra/backup-create.test.ts
@@ -2346,6 +2346,8 @@ describe("createBackupArchive", () => {
         const outputDir = state.path("backups");
         const transientPaths = [
           state.statePath("memory", "main.sqlite.reindex-lock.sqlite"),
+          state.statePath("memory", "main.sqlite.generation-writer.sqlite"),
+          state.statePath("memory", "main.sqlite.generation-lock.sqlite"),
           state.statePath("memory", "main.sqlite.tmp-11111111-2222-3333-4444-555555555555"),
           state.statePath("memory", "main.sqlite.backup-66666666-7777-8888-9999-aaaaaaaaaaaa"),
           state.statePath(

--- a/src/infra/backup-volatile-filter.test.ts
+++ b/src/infra/backup-volatile-filter.test.ts
@@ -149,6 +149,10 @@ describe("isTransientSqliteBackupPath", () => {
   it.each([
     "memory/main.sqlite.reindex-lock.sqlite",
     "memory/main.sqlite.reindex-lock.sqlite-shm",
+    "memory/main.sqlite.generation-writer.sqlite",
+    "memory/main.sqlite.generation-writer.sqlite-wal",
+    "memory/main.sqlite.generation-lock.sqlite",
+    "memory/main.sqlite.generation-lock.sqlite-journal",
     "memory/main.sqlite.tmp-11111111-2222-3333-4444-555555555555",
   ])("classifies transient reindex state: %s", (filePath) => {
     expect(isTransientSqliteBackupPath(filePath)).toBe(true);

--- a/src/infra/backup-volatile-filter.ts
+++ b/src/infra/backup-volatile-filter.ts
@@ -14,8 +14,8 @@ import path from "node:path";
 
 const STATE_TRANSIENT_EXTENSIONS = new Set([".sock", ".pid", ".tmp"]);
 const CHROMIUM_SINGLETON_FILES = new Set(["SingletonCookie", "SingletonLock", "SingletonSocket"]);
-const SQLITE_REINDEX_TRANSIENT_PATH_PATTERN =
-  /(?:^|\/)(?:[^/]+\.sqlite\.reindex-lock\.sqlite|[^/]+\.sqlite\.(?:backup|memory-reindex|tmp)-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:-wal|-shm|-journal)?$/iu;
+const SQLITE_MEMORY_TRANSIENT_PATH_PATTERN =
+  /(?:^|\/)(?:[^/]+\.sqlite\.(?:generation-(?:lock|writer)|reindex-lock)\.sqlite|[^/]+\.sqlite\.(?:backup|memory-reindex|tmp)-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:-wal|-shm|-journal)?$/iu;
 
 function normalizePosix(input: string): string {
   if (!input) {
@@ -45,7 +45,7 @@ function hasExtensionInSet(filePosix: string, extensions: ReadonlySet<string>): 
 
 export function isTransientSqliteBackupPath(filePath: string): boolean {
   const normalizedPath = normalizePosix(filePath);
-  return SQLITE_REINDEX_TRANSIENT_PATH_PATTERN.test(normalizedPath);
+  return SQLITE_MEMORY_TRANSIENT_PATH_PATTERN.test(normalizedPath);
 }
 
 function isAgentSessionTranscriptPath(filePosix: string, stateDirPosix: string): boolean {


### PR DESCRIPTION
Fixes #112196.

## What Problem This Solves

`memory_search` could block behind dirty-index synchronization even when a valid published generation was available. Independent review found connected lifecycle and coordination gaps: serving-manager writes, lost dirty fallback state, mixed cross-process generations, teardown waits after results were ready, uncancellable lease acquisition, and publisher starvation under sustained readers.

## Why This Change Was Made

Memory search should read one stable published generation while maintenance builds and atomically publishes the next one. Dirty work now belongs to a separate transient maintenance manager for persistent and CLI search paths. Incomplete maintenance returns its dirty generation to the serving owner.

A shared/exclusive SQLite coordination lease extends generation isolation across processes. Publisher admission uses SQLite's native PENDING-lock transition: an exclusive-locking-mode, schema-free transaction retains writer intent after its first reader collision, blocks later readers, then retains exclusive admission until publication releases it. AbortSignal removes local read waiters and interrupts cross-process polling immediately.

Transient CLI teardown waits for active serving operations but not for detached refresh owned by its separate maintenance manager. Persistent managers still drain detached maintenance before closing shared resources.

The generation-writer and generation-lock SQLite files are live coordination state, not durable memory. Backup creation and verification now classify those exact databases and their `-wal`, `-shm`, and `-journal` sidecars as transient, alongside the existing reindex coordinator.

## User Impact

Search returns the last valid memory results while refresh is blocked or running, then moves to the new index only after atomic publication. CLI, Gateway, and concurrent-process searches no longer observe partial or mixed generations; publishers make progress even when their first admission collides with a reader; timed-out searches stop waiting immediately; failed fallback setup remains visibly dirty and retryable; and transient commands do not remain blocked after results are ready.

Backups no longer snapshot or restore volatile generation-lease state, while unrelated durable SQLite files remain included and verified.

## Evidence

- Exact head: `ce77bae087c53433c2c2e2dd00394080856a4c46`.
- The controlled initial-collision regression failed on the prior head: a remote admission reader remained active, the publisher lost its first exclusive attempt, and a later reader acquired ahead of it. The repaired native PENDING lock blocks that later reader and publishes first.
- Cancellation regressions prove both active SQLite polling and the real one-shot manager deadline release their queued operations without spending a second cleanup deadline.
- Exact-head focused and sibling proof passed 189/189 tests across generation leasing, search orchestration, real one-shot manager/tool behavior, direct CLI/tool behavior, database publication, and reindex recovery.
- Backup lifecycle proof passed: volatile classifier 66/66; backup verification 47/47 with one platform skip; targeted archive creation 2/2. The full archive suite passed 81/82 before one unrelated manifest-exclusion test hit its 120-second timeout; that test then passed independently in 22.282 seconds.
- `node scripts/check-changed.mjs` passed all core, extension, test, and tooling lanes, including formatting, ratchets, doctor contracts, boundaries, dead exports, all typecheck graphs, lint, storage, sidecar, and import-cycle guards.
- `pnpm build` passed through runtime postbuild, plugin control-plane loads, Plugin SDK exports, and Control UI gates.
- A real built CLI, using the bundled trusted plugin, real agent SQLite state, filesystem memory, and the real reindex lock, returned `OLD-CANARY` with a stale warning and exited while the lock was still held. After release, the next maintenance pass atomically published `NEW-CANARY`.
- The admission database remains schema-free: the unchanged zero `user_version` header field is rewritten only inside the lock transaction to obtain SQLite's native PENDING transition.
- Cross-process regressions use real child Node processes and SQLite locks. No test-only production seam was added.
- Fresh isolated xhigh autoreview found no P0/P1 issue (0.94 confidence).
- The branch is conflict-free with current `main`; the only changed-path overlap is assertion-baseline bookkeeping.
- `git diff --check` passed. The final commit retains the required attribution block.

Worked on by:
- @VACInc