### PR TITLE
fix: update stale imports to moved ai transport modules

### DIFF
--- a/src/agents/anthropic-payload-policy.test.ts
+++ b/src/agents/anthropic-payload-policy.test.ts
@@ -8,7 +8,7 @@ import { describe, expect, it } from "vitest";
 import {
   applyAnthropicPayloadPolicyToParams,
   resolveAnthropicPayloadPolicy,
-} from "./anthropic-payload-policy.js";
+} from "../../packages/ai/src/transports/anthropic-payload-policy.js";
 
 type TestPayload = {
   messages: Array<{ role: string; content: unknown }>;

--- a/src/agents/deepseek-text-filter.test.ts
+++ b/src/agents/deepseek-text-filter.test.ts
@@ -3,7 +3,7 @@
  * Verifies complete, split, full-width, and unterminated DSML markup handling.
  */
 import { describe, expect, it } from "vitest";
-import { createDeepSeekTextFilter } from "./deepseek-text-filter.js";
+import { createDeepSeekTextFilter } from "../../packages/ai/src/transports/deepseek-text-filter.js";
 
 function filteredText(chunks: readonly string[]) {
   const filter = createDeepSeekTextFilter();

--- a/src/agents/embedded-agent-runner/extra-params.ts
+++ b/src/agents/embedded-agent-runner/extra-params.ts
@@ -33,8 +33,8 @@ import {
 } from "../../plugins/provider-hook-runtime.js";
 import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
 import { resolveModelExtraParamSources } from "../model-extra-params.js";
-import { canonicalizeMaxTokensParam, resolveMaxTokensParam } from "../model-max-tokens-params.js";
-import { detectOpenAICompletionsCompat } from "../openai-completions-compat.js";
+import { canonicalizeMaxTokensParam, resolveMaxTokensParam } from ".../../packages/ai/src/transports/model-max-tokens-params.js";
+import { detectOpenAICompletionsCompat } from ".../../packages/ai/src/transports/openai-completions-compat.js";
 import { supportsGptParallelToolCallsPayload } from "../provider-api-families.js";
 import { resolveProviderRequestPolicyConfig } from "../provider-request-config.js";
 import type { AgentRuntimeTransport } from "../runtime-plan/types.js";

--- a/src/agents/model-transport-debug.test.ts
+++ b/src/agents/model-transport-debug.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { emitModelTransportDebug } from "./model-transport-debug.js";
+import { emitModelTransportDebug } from "../../packages/ai/src/transports/model-transport-debug.js";
 
 describe("emitModelTransportDebug", () => {
   function createLogger() {

--- a/src/agents/model-transport-url.test.ts
+++ b/src/agents/model-transport-url.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, it } from "vitest";
 import {
   formatModelTransportDebugBaseUrl,
   formatModelTransportDebugUrl,
-} from "./model-transport-url.js";
+} from "../../packages/ai/src/transports/model-transport-url.js";
 import { testing as openAITesting } from "./openai-transport-stream.test-support.js";
 
 describe("model transport diagnostic URLs", () => {

--- a/src/agents/openai-compatible-conversation-turn.test.ts
+++ b/src/agents/openai-compatible-conversation-turn.test.ts
@@ -1,6 +1,6 @@
 // Verifies OpenAI-compatible payloads contain at least one sendable conversation turn.
 import { describe, expect, it } from "vitest";
-import { hasOpenAICompatibleConversationTurn } from "./openai-compatible-conversation-turn.js";
+import { hasOpenAICompatibleConversationTurn } from "../../packages/ai/src/transports/openai-compatible-conversation-turn.js";
 
 describe("hasOpenAICompatibleConversationTurn", () => {
   it("rejects missing, system-only, and tool-only payloads", () => {

--- a/src/agents/openai-completions-compat.test-support.ts
+++ b/src/agents/openai-completions-compat.test-support.ts
@@ -1,6 +1,6 @@
-import type { detectOpenAICompletionsCompat } from "./openai-completions-compat.js";
+import type { detectOpenAICompletionsCompat } from "../../packages/ai/src/transports/openai-completions-compat.js";
 import type { ProviderEndpointClass } from "./provider-attribution.js";
-import "./openai-completions-compat.js";
+import "../../packages/ai/src/transports/openai-completions-compat.js";
 
 type OpenAICompletionsCompatDefaultsInput = {
   provider?: string;

--- a/src/agents/openai-completions-compat.test.ts
+++ b/src/agents/openai-completions-compat.test.ts
@@ -1,6 +1,6 @@
 // Verifies OpenAI-compatible endpoint defaults for streaming usage and reasoning payloads.
 import { describe, expect, it } from "vitest";
-import { detectOpenAICompletionsCompat } from "./openai-completions-compat.js";
+import { detectOpenAICompletionsCompat } from "../../packages/ai/src/transports/openai-completions-compat.js";
 import { resolveOpenAICompletionsCompatDefaults } from "./openai-completions-compat.test-support.js";
 
 describe("resolveOpenAICompletionsCompatDefaults", () => {

--- a/src/agents/openai-responses-payload-policy.test.ts
+++ b/src/agents/openai-responses-payload-policy.test.ts
@@ -7,7 +7,7 @@ import { describe, expect, it } from "vitest";
 import {
   applyOpenAIResponsesPayloadPolicy,
   resolveOpenAIResponsesPayloadPolicy,
-} from "./openai-responses-payload-policy.js";
+} from "../../packages/ai/src/transports/openai-responses-payload-policy.js";
 
 describe("openai responses payload policy", () => {
   it("forces store for native OpenAI responses payloads but keeps disable mode for transport defaults", () => {

--- a/src/agents/openai-responses.reasoning-replay.test.ts
+++ b/src/agents/openai-responses.reasoning-replay.test.ts
@@ -3,7 +3,7 @@ import type { AssistantMessage, Model, ToolResultMessage } from "openclaw/plugin
 import { stream } from "openclaw/plugin-sdk/llm";
 import { Type } from "typebox";
 import { describe, expect, it } from "vitest";
-import { resolveReplayableResponsesMessageId } from "./openai-responses-replay.js";
+import { resolveReplayableResponsesMessageId } from "../../packages/ai/src/transports/openai-responses-replay.js";
 
 function buildModel(): Model<"openai-responses"> {
   return {

--- a/src/agents/openai-transport-params.code-mode.test.ts
+++ b/src/agents/openai-transport-params.code-mode.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   assertCodeModeResponsesToolSurface,
   enforceCodeModeResponsesToolSurface,
-} from "./openai-transport-params.js";
+} from "../../packages/ai/src/transports/openai-transport-params.js";
 
 describe("OpenAI Code Mode direct tools", () => {
   it("keeps the native image loader model-visible", () => {

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -5,14 +5,14 @@
  * established imports stable while sharing only transport-neutral primitives between them.
  */
 import type { Context } from "../llm/types.js";
-import { buildOpenAICompletionsParams as buildOpenAICompletionsParamsImpl } from "./openai-completions-transport.js";
-import type { OpenAICompletionsOptions, OpenAIModeModel } from "./openai-transport-shared.js";
+import { buildOpenAICompletionsParams as buildOpenAICompletionsParamsImpl } from "../../packages/ai/src/transports/openai-completions-transport.js";
+import type { OpenAICompletionsOptions, OpenAIModeModel } from "../../packages/ai/src/transports/openai-transport-shared.js";
 
-export { createOpenAICompletionsTransportStreamFn } from "./openai-completions-transport.js";
+export { createOpenAICompletionsTransportStreamFn } from "../../packages/ai/src/transports/openai-completions-transport.js";
 export {
   createAzureOpenAIResponsesTransportStreamFn,
   createOpenAIResponsesTransportStreamFn,
-} from "./openai-responses-transport.js";
+} from "../../packages/ai/src/transports/openai-responses-transport.js";
 
 // Keep this SDK-exported declaration anchored to the long-lived facade while the
 // completions implementation remains independently owned.

--- a/src/agents/provider-transport-fetch.ts
+++ b/src/agents/provider-transport-fetch.ts
@@ -36,8 +36,8 @@ import {
   SECRET_SENTINEL_PATTERN,
   swapSecretSentinelsInText,
 } from "../secrets/sentinel.js";
-import { emitModelTransportDebug } from "./model-transport-debug.js";
-import { formatModelTransportDebugUrl } from "./model-transport-url.js";
+import { emitModelTransportDebug } from "../../packages/ai/src/transports/model-transport-debug.js";
+import { formatModelTransportDebugUrl } from "../../packages/ai/src/transports/model-transport-url.js";
 import { ProviderHttpError, readResponseTextLimited } from "./provider-http-errors.js";
 import {
   ensureModelProviderLocalService,

--- a/src/agents/tools/pdf-native-providers.ts
+++ b/src/agents/tools/pdf-native-providers.ts
@@ -12,7 +12,7 @@ import {
 import { normalizeProviderTransportWithPlugin } from "../../plugins/provider-runtime.js";
 import { isRecord } from "../../utils.js";
 import { normalizeSecretInput } from "../../utils/normalize-secret-input.js";
-import { resolveAnthropicMessagesUrl } from "../anthropic-transport-stream.js";
+import { resolveAnthropicMessagesUrl } from ".../../packages/ai/src/transports/anthropic-transport-stream.js";
 import type { ModelProviderRequestTransportOverrides } from "../provider-request-config.js";
 import { unwrapSecretSentinelsForProviderEgress } from "../provider-secret-egress.js";
 import { resolveProviderTransportSsrFPolicy } from "../provider-transport-fetch.js";


### PR DESCRIPTION
## What Problem This Solves

#111669 refactored provider transport modules from `src/agents/` to `packages/ai/src/transports/`. Several source and test files still reference the old locations via relative imports, causing **11 test files to fail** with `ERR_MODULE_NOT_FOUND` on current main.

## Why This Change Was Made

Update all stale relative imports (`./module-name.js`) to point to the canonical `../../packages/ai/src/transports/module-name.js` location.

### Files fixed (14 files, import-only changes):

**Test files (10)**:
- `src/agents/anthropic-payload-policy.test.ts`
- `src/agents/deepseek-text-filter.test.ts`
- `src/agents/model-transport-debug.test.ts`
- `src/agents/model-transport-url.test.ts`
- `src/agents/openai-compatible-conversation-turn.test.ts`
- `src/agents/openai-completions-compat.test.ts`
- `src/agents/openai-completions-compat.test-support.ts`
- `src/agents/openai-responses-payload-policy.test.ts`
- `src/agents/openai-responses.reasoning-replay.test.ts`
- `src/agents/openai-transport-params.code-mode.test.ts`

**Source files (4)**:
- `src/agents/embedded-agent-runner/extra-params.ts`
- `src/agents/openai-transport-stream.ts`
- `src/agents/provider-transport-fetch.ts`
- `src/agents/tools/pdf-native-providers.ts`

## Evidence

Before fix (current main):
```
 FAIL  src/agents/deepseek-text-filter.test.ts
 Error: Cannot find module './deepseek-text-filter.js'
 ... 11 test files failed, 0 tests run
```

After fix: all stale imports updated to new canonical paths. CI will validate the tests pass.

## Scope

- 14 files changed (import path updates only)
- No logic, type, or behavior changes
- No config/schema/default changes

AI-assisted: yes. I understand the authorization lineage and tool-policy changes in this PR.