### PR TITLE
feat(android): AccessibilityService UI executor (thirdParty, PR 1/3)

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -571,7 +571,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 603,
+      "line": 604,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Mic off",
       "surface": "android",
@@ -579,7 +579,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 617,
+      "line": 618,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Off",
       "surface": "android",
@@ -7475,7 +7475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1496,
+      "line": 1499,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Location",
       "surface": "android",
@@ -7483,7 +7483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1504,
+      "line": 1507,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Always allows requested location checks while OpenClaw is in the background; Android shows this in the persistent node notification.",
       "surface": "android",
@@ -7491,7 +7491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1539,
+      "line": 1542,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allow background location?",
       "surface": "android",
@@ -7499,7 +7499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1542,
+      "line": 1545,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw only checks location when your paired Gateway requests it. On the next Android screen, choose $backgroundPermissionLabel to allow checks while the app is in the background.",
       "surface": "android",
@@ -7507,7 +7507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1556,
+      "line": 1559,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open Settings",
       "surface": "android",
@@ -7515,7 +7515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1575,
+      "line": 1578,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Share installed app information?",
       "surface": "android",
@@ -7523,7 +7523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1579,
+      "line": 1582,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw collects and sends the names, package IDs, and status of apps visible on this phone when your paired OpenClaw Gateway asks for them. This lets your assistant answer questions and take actions using installed apps.",
       "surface": "android",
@@ -7531,7 +7531,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1582,
+      "line": 1585,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Your phone sends this information to your Gateway, not to a server run by OpenClaw. Your Gateway may include it in requests to the AI provider you chose.",
       "surface": "android",
@@ -7539,7 +7539,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1588,
+      "line": 1591,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Agree and Enable",
       "surface": "android",
@@ -7547,7 +7547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1593,
+      "line": 1596,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Not Now",
       "surface": "android",
@@ -7555,7 +7555,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1647,
+      "line": 1650,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Replace gateway setup?",
       "surface": "android",
@@ -7563,7 +7563,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1662,
+      "line": 1665,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Replace setup",
       "surface": "android",
@@ -7571,7 +7571,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1676,
+      "line": 1679,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "this gateway",
       "surface": "android",
@@ -7579,7 +7579,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1679,
+      "line": 1682,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Forget gateway?",
       "surface": "android",
@@ -7587,7 +7587,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1682,
+      "line": 1685,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Remove $gatewayName and its saved credentials from this phone?",
       "surface": "android",
@@ -7595,7 +7595,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1699,
+      "line": 1702,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Cancel",
       "surface": "android",
@@ -7603,7 +7603,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1737,
+      "line": 1740,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connection between this phone and OpenClaw.",
       "surface": "android",
@@ -7611,7 +7611,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1751,
+      "line": 1754,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connected",
       "surface": "android",
@@ -7619,7 +7619,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1751,
+      "line": 1754,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connection",
       "surface": "android",
@@ -7627,7 +7627,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1751,
+      "line": 1754,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Offline",
       "surface": "android",
@@ -7635,7 +7635,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1752,
+      "line": 1755,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Not paired",
       "surface": "android",
@@ -7643,7 +7643,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1752,
+      "line": 1755,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Online",
       "surface": "android",
@@ -7651,7 +7651,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1754,
+      "line": 1757,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Access",
       "surface": "android",
@@ -7659,7 +7659,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1761,
+      "line": 1764,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Address",
       "surface": "android",
@@ -7667,7 +7667,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1766,
+      "line": 1769,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Discovered",
       "surface": "android",
@@ -7675,7 +7675,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1767,
+      "line": 1770,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Default Agent",
       "surface": "android",
@@ -7683,7 +7683,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1768,
+      "line": 1771,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Agents",
       "surface": "android",
@@ -7691,7 +7691,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1769,
+      "line": 1772,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Instance ID",
       "surface": "android",
@@ -7699,7 +7699,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1775,
+      "line": 1778,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Scan QR to Pair",
       "surface": "android",
@@ -7707,7 +7707,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1785,
+      "line": 1788,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Limited Gateway access",
       "surface": "android",
@@ -7715,7 +7715,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1798,
+      "line": 1801,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Reconnect",
       "surface": "android",
@@ -7723,7 +7723,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1799,
+      "line": 1802,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Disconnect",
       "surface": "android",
@@ -7731,7 +7731,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1802,
+      "line": 1805,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Diagnose",
       "surface": "android",
@@ -7739,7 +7739,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1815,
+      "line": 1818,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Add Gateway",
       "surface": "android",
@@ -7747,7 +7747,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1817,
+      "line": 1820,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Scan or paste a setup code to add another gateway.",
       "surface": "android",
@@ -7755,7 +7755,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1823,
+      "line": 1826,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Scan QR",
       "surface": "android",
@@ -7763,7 +7763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1824,
+      "line": 1827,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Setup code",
       "surface": "android",
@@ -7771,7 +7771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1827,
+      "line": 1830,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Where do I get a setup code?",
       "surface": "android",
@@ -7779,7 +7779,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1831,
+      "line": 1834,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Android can scan or paste an existing setup code, but this gateway does not expose setup-code generation to the app yet. Generate the QR/code on the gateway host with openclaw qr, then scan it here or paste the setup code below.",
       "surface": "android",
@@ -7787,7 +7787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1838,
+      "line": 1841,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No gateways found yet. Use manual setup if discovery is blocked.",
       "surface": "android",
@@ -7795,7 +7795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1851,
+      "line": 1854,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect",
       "surface": "android",
@@ -7803,7 +7803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1862,
+      "line": 1865,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Gateways",
       "surface": "android",
@@ -7811,7 +7811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1864,
+      "line": 1867,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No paired gateways.",
       "surface": "android",
@@ -7819,7 +7819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1892,
+      "line": 1895,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Forget",
       "surface": "android",
@@ -7827,7 +7827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1909,
+      "line": 1912,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Manual Gateway",
       "surface": "android",
@@ -7835,7 +7835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1911,
+      "line": 1914,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Host",
       "surface": "android",
@@ -7843,7 +7843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1912,
+      "line": 1915,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Port",
       "surface": "android",
@@ -7851,7 +7851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1914,
+      "line": 1917,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connection security",
       "surface": "android",
@@ -7859,7 +7859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1918,
+      "line": 1921,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Unencrypted",
       "surface": "android",
@@ -7867,7 +7867,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1922,
+      "line": 1925,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Secure (TLS)",
       "surface": "android",
@@ -7875,7 +7875,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1935,
+      "line": 1938,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Token",
       "surface": "android",
@@ -7883,7 +7883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1936,
+      "line": 1939,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Bootstrap",
       "surface": "android",
@@ -7891,7 +7891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1938,
+      "line": 1941,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Password",
       "surface": "android",
@@ -7899,7 +7899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1943,
+      "line": 1946,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Save & Connect",
       "surface": "android",
@@ -7907,7 +7907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1960,
+      "line": 1963,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Enter a valid setup code or gateway address.",
       "surface": "android",
@@ -7915,7 +7915,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1981,
+      "line": 1984,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Not available",
       "surface": "android",
@@ -7923,7 +7923,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1982,
+      "line": 1985,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Full",
       "surface": "android",
@@ -7931,7 +7931,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1983,
+      "line": 1986,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Limited",
       "surface": "android",
@@ -7939,7 +7939,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1987,
+      "line": 1990,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Use a secure wss:// or Tailscale Serve Gateway, generate a full-access setup code in the Control UI or with openclaw qr, then scan or paste it below and reconnect to enable settings and upgrades.",
       "surface": "android",
@@ -7947,7 +7947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2001,
+      "line": 2004,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Appearance",
       "surface": "android",
@@ -7955,7 +7955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2001,
+      "line": 2004,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Theme and translated Android text.",
       "surface": "android",
@@ -7963,7 +7963,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2006,
+      "line": 2009,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Language",
       "surface": "android",
@@ -7971,7 +7971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2007,
+      "line": 2010,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Contrast",
       "surface": "android",
@@ -7979,7 +7979,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2007,
+      "line": 2010,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "High",
       "surface": "android",
@@ -7987,7 +7987,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2008,
+      "line": 2011,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Readable",
       "surface": "android",
@@ -7995,7 +7995,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2008,
+      "line": 2011,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Typography",
       "surface": "android",
@@ -8003,7 +8003,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2013,
+      "line": 2016,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Theme",
       "surface": "android",
@@ -8011,7 +8011,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2023,
+      "line": 2026,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "App language",
       "surface": "android",
@@ -8019,7 +8019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2057,
+      "line": 2060,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Selected",
       "surface": "android",
@@ -8027,7 +8027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2069,
+      "line": 2072,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "System",
       "surface": "android",
@@ -8035,7 +8035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2097,
+      "line": 2100,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "While Using",
       "surface": "android",
@@ -8043,7 +8043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2098,
+      "line": 2101,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Always",
       "surface": "android",
@@ -8051,7 +8051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2110,
+      "line": 2113,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connecting...",
       "surface": "android",
@@ -8059,7 +8059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2111,
+      "line": 2114,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Pairing needed",
       "surface": "android",
@@ -8067,7 +8067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2112,
+      "line": 2115,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Authentication needed",
       "surface": "android",
@@ -8075,7 +8075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2113,
+      "line": 2116,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "TLS timed out",
       "surface": "android",
@@ -8083,7 +8083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2114,
+      "line": 2117,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No TLS endpoint",
       "surface": "android",
@@ -8091,7 +8091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2115,
+      "line": 2118,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Certificate review needed",
       "surface": "android",
@@ -8099,7 +8099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2116,
+      "line": 2119,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Cannot reach gateway",
       "surface": "android",
@@ -8107,7 +8107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2137,
+      "line": 2140,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "About",
       "surface": "android",
@@ -8115,7 +8115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2137,
+      "line": 2140,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw for Android.",
       "surface": "android",
@@ -8123,7 +8123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2149,
+      "line": 2152,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Channel",
       "surface": "android",
@@ -8131,7 +8131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2150,
+      "line": 2153,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Not connected",
       "surface": "android",
@@ -8139,7 +8139,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2155,
+      "line": 2158,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Home Gateway",
       "surface": "android",
@@ -8147,7 +8147,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2157,
+      "line": 2160,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Runtime",
       "surface": "android",
@@ -8155,7 +8155,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2157,
+      "line": 2160,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Waiting",
       "surface": "android",
@@ -8163,7 +8163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2160,
+      "line": 2163,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Update",
       "surface": "android",
@@ -8171,7 +8171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2161,
+      "line": 2164,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Up to date",
       "surface": "android",
@@ -8179,7 +8179,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2161,
+      "line": 2164,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "v$it available",
       "surface": "android",
@@ -8187,7 +8187,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2171,
+      "line": 2174,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "© 2026 OpenClaw Foundation — MIT License.",
       "surface": "android",
@@ -8195,7 +8195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2188,
+      "line": 2191,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw logo",
       "surface": "android",
@@ -8203,7 +8203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2190,
+      "line": 2193,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw",
       "surface": "android",
@@ -8211,7 +8211,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2191,
+      "line": 2194,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Personal AI on your devices",
       "surface": "android",
@@ -8219,7 +8219,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2250,
+      "line": 2253,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Licenses",
       "surface": "android",
@@ -8227,7 +8227,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2251,
+      "line": 2254,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw appreciates its partners in the open-source community.",
       "surface": "android",
@@ -8235,7 +8235,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2260,
+      "line": 2263,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No license notices are packaged in this build.",
       "surface": "android",
@@ -8243,7 +8243,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2286,
+      "line": 2289,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open ${license.title}",
       "surface": "android",
@@ -8251,7 +8251,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2297,
+      "line": 2300,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Third-party",
       "surface": "android",
@@ -8259,7 +8259,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2298,
+      "line": 2301,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Unknown",
       "surface": "android",
@@ -8267,7 +8267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2304,
+      "line": 2307,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Website",
       "surface": "android",
@@ -8275,7 +8275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2305,
+      "line": 2308,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Docs",
       "surface": "android",
@@ -8283,7 +8283,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2309,
+      "line": 2312,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allow all the time",
       "surface": "android",
@@ -8291,7 +8291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2312,
+      "line": 2315,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Replacing the setup code clears this phone's saved setup credentials and device tokens before reconnecting. This phone may need node capability approval again; continue only when you mean to pair with a fresh gateway setup code.",
       "surface": "android",
@@ -8299,7 +8299,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2331,
+      "line": 2334,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Check",
       "surface": "android",
@@ -8307,7 +8307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2338,
+      "line": 2341,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw turns this phone into a clean mobile command surface for threads, voice, providers, and Gateway.",
       "surface": "android",
@@ -8315,7 +8315,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2340,
+      "line": 2343,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "A Gateway update is available. Run the update from the Web UI or CLI when you are ready.",
       "surface": "android",
@@ -8323,7 +8323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2365,
+      "line": 2368,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Back",
       "surface": "android",
@@ -8331,7 +8331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2439,
+      "line": 2442,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Command approval",
       "surface": "android",
@@ -8339,7 +8339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2444,
+      "line": 2447,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Sending",
       "surface": "android",
@@ -8347,7 +8347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2504,
+      "line": 2507,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allow Once",
       "surface": "android",
@@ -8355,7 +8355,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2505,
+      "line": 2508,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allow Always",
       "surface": "android",
@@ -8363,7 +8363,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2506,
+      "line": 2509,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Deny",
       "surface": "android",
@@ -8371,7 +8371,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2527,
+      "line": 2530,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Approval ${notice.approvalId}",
       "surface": "android",
@@ -8379,7 +8379,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2534,
+      "line": 2537,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Dismiss approval notice",
       "surface": "android",
@@ -8387,7 +8387,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2553,
+      "line": 2556,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Review",
       "surface": "android",
@@ -8395,7 +8395,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2593,
+      "line": 2596,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open automation detail",
       "surface": "android",
@@ -8403,7 +8403,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2636,
+      "line": 2639,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Enabled",
       "surface": "android",
@@ -8411,7 +8411,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2636,
+      "line": 2639,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Status",
       "surface": "android",
@@ -8419,7 +8419,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2637,
+      "line": 2640,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Schedule",
       "surface": "android",
@@ -8427,7 +8427,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2638,
+      "line": 2641,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Next Wake",
       "surface": "android",
@@ -8435,7 +8435,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2639,
+      "line": 2642,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Last Run",
       "surface": "android",
@@ -8443,7 +8443,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2646,
+      "line": 2649,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Description",
       "surface": "android",
@@ -8451,7 +8451,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2647,
+      "line": 2650,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Schedule Detail",
       "surface": "android",
@@ -8459,7 +8459,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2648,
+      "line": 2651,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Session Target",
       "surface": "android",
@@ -8467,7 +8467,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2649,
+      "line": 2652,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Wake Mode",
       "surface": "android",
@@ -8475,7 +8475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2650,
+      "line": 2653,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Delete After Run",
       "surface": "android",
@@ -8483,7 +8483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2650,
+      "line": 2653,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No",
       "surface": "android",
@@ -8491,7 +8491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2650,
+      "line": 2653,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Yes",
       "surface": "android",
@@ -8499,7 +8499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2651,
+      "line": 2654,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Payload",
       "surface": "android",
@@ -8507,7 +8507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2652,
+      "line": 2655,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Delivery",
       "surface": "android",
@@ -8515,7 +8515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2653,
+      "line": 2656,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Failure Alert",
       "surface": "android",
@@ -8523,7 +8523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2654,
+      "line": 2657,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Created",
       "surface": "android",
@@ -8531,7 +8531,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2655,
+      "line": 2658,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Updated",
       "surface": "android",
@@ -8539,7 +8539,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2656,
+      "line": 2659,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Running Since",
       "surface": "android",
@@ -8547,7 +8547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2657,
+      "line": 2660,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Last Status",
       "surface": "android",
@@ -8555,7 +8555,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2659,
+      "line": 2662,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Last Duration",
       "surface": "android",
@@ -8563,7 +8563,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2660,
+      "line": 2663,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "${durationMs}ms",
       "surface": "android",
@@ -8571,7 +8571,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2662,
+      "line": 2665,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Consecutive Errors",
       "surface": "android",
@@ -8579,7 +8579,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2663,
+      "line": 2666,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Consecutive Skips",
       "surface": "android",
@@ -8587,7 +8587,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2664,
+      "line": 2667,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Delivery Status",
       "surface": "android",
@@ -8595,7 +8595,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2671,
+      "line": 2674,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Last Error",
       "surface": "android",
@@ -8603,7 +8603,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2674,
+      "line": 2677,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Delivery Error",
       "surface": "android",
@@ -8611,7 +8611,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2690,
+      "line": 2693,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Copy ${row.title}",
       "surface": "android",
@@ -8619,7 +8619,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2715,
+      "line": 2718,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Tap to copy",
       "surface": "android",
@@ -8627,7 +8627,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2730,
+      "line": 2733,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "$title copied",
       "surface": "android",
@@ -8635,7 +8635,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2768,
+      "line": 2771,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Default assistant",
       "surface": "android",
@@ -8643,7 +8643,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2774,
+      "line": 2777,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Default",
       "surface": "android",
@@ -8651,7 +8651,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2782,
+      "line": 2785,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "${endpoint.host}:${endpoint.port}",
       "surface": "android",
@@ -8659,7 +8659,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2828,
+      "line": 2831,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Action Request",
       "surface": "android",
@@ -8667,7 +8667,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2836,
+      "line": 2839,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Needs attention",
       "surface": "android",
@@ -8675,7 +8675,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2839,
+      "line": 2842,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Waiting ${minutes}m",
       "surface": "android",
@@ -8683,7 +8683,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2839,
+      "line": 2842,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Waiting for review",
       "surface": "android",
@@ -8691,7 +8691,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2850,
+      "line": 2853,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Node ${nodeId}",
       "surface": "android",
@@ -8699,7 +8699,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2852,
+      "line": 2855,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Node",
       "surface": "android",
@@ -8707,7 +8707,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2855,
+      "line": 2858,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Gateway",
       "surface": "android",
@@ -8715,7 +8715,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2860,
+      "line": 2863,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Agent ${agentId}",
       "surface": "android",
@@ -8723,7 +8723,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2865,
+      "line": 2868,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Waiting ${duration}",
       "surface": "android",
@@ -8731,7 +8731,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2870,
+      "line": 2873,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Expires ${duration}",
       "surface": "android",
@@ -8739,7 +8739,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2880,
+      "line": 2883,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "soon",
       "surface": "android",
@@ -8747,7 +8747,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2888,
+      "line": 2891,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Main",
       "surface": "android",
@@ -8755,7 +8755,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2889,
+      "line": 2892,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Isolated",
       "surface": "android",
@@ -8763,7 +8763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2890,
+      "line": 2893,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Current",
       "surface": "android",
@@ -8771,7 +8771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2896,
+      "line": 2899,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "${job.scheduleLabel} · ${formatCronWake(job.nextRunAtMs)} · ${job.promptPreview}",
       "surface": "android",
@@ -8779,7 +8779,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2912,
+      "line": 2915,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "All",
       "surface": "android",
@@ -8787,7 +8787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2913,
+      "line": 2916,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Active",
       "surface": "android",
@@ -8795,7 +8795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2914,
+      "line": 2917,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Paused",
       "surface": "android",
@@ -8803,7 +8803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2947,
+      "line": 2950,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "${remaining}% left ${label}",
       "surface": "android",
@@ -8811,7 +8811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2950,
+      "line": 2953,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No limits reported",
       "surface": "android",
@@ -8819,7 +8819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2961,
+      "line": 2964,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Never",
       "surface": "android",
@@ -8827,7 +8827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2966,
+      "line": 2969,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Now",
       "surface": "android",
@@ -8835,7 +8835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2988,
+      "line": 2991,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Off",
       "surface": "android",
@@ -8843,7 +8843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2990,
+      "line": 2993,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Issue",
       "surface": "android",
@@ -8851,7 +8851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2992,
+      "line": 2995,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Skipped",
       "surface": "android",
@@ -8859,7 +8859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2993,
+      "line": 2996,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Ready",
       "surface": "android",
@@ -8867,7 +8867,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3009,
+      "line": 3012,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "System Event Text",
       "surface": "android",
@@ -8875,7 +8875,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3010,
+      "line": 3013,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Agent Prompt",
       "surface": "android",
@@ -8883,7 +8883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3011,
+      "line": 3014,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Command",
       "surface": "android",
@@ -8891,7 +8891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3012,
+      "line": 3015,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Script",
       "surface": "android",
@@ -8899,7 +8899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3013,
+      "line": 3016,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Payload Text",
       "surface": "android",
@@ -8907,7 +8907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3043,
+      "line": 3046,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No apps selected. Nothing forwards until you add apps.",
       "surface": "android",
@@ -8915,7 +8915,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3045,
+      "line": 3048,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "$selectedCount app allowed to forward.",
       "surface": "android",
@@ -8923,7 +8923,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3047,
+      "line": 3050,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "$selectedCount apps allowed to forward.",
       "surface": "android",
@@ -8931,7 +8931,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3051,
+      "line": 3054,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No apps blocked. Apps can forward unless you add blocks.",
       "surface": "android",
@@ -8939,7 +8939,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3053,
+      "line": 3056,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "$selectedCount app blocked from forwarding.",
       "surface": "android",
@@ -8947,7 +8947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3055,
+      "line": 3058,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "$selectedCount apps blocked from forwarding.",
       "surface": "android",
@@ -8955,7 +8955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3081,
+      "line": 3084,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Due",
       "surface": "android",
@@ -8963,7 +8963,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3086,
+      "line": 3089,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "${days}d",
       "surface": "android",
@@ -8971,7 +8971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3087,
+      "line": 3090,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "${hours}h",
       "surface": "android",
@@ -8979,7 +8979,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3088,
+      "line": 3091,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "${minutes}m",
       "surface": "android",
@@ -8987,7 +8987,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3089,
+      "line": 3092,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Soon",
       "surface": "android",
@@ -8995,7 +8995,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3094,
+      "line": 3097,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "None",
       "surface": "android",

--- a/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
@@ -581,6 +581,7 @@ class MainViewModel private constructor(
   val onboardingCompleted: StateFlow<Boolean> = prefs.onboardingCompleted
   val canvasDebugStatusEnabled: StateFlow<Boolean> = prefs.canvasDebugStatusEnabled
   val installedAppsSharingEnabled: StateFlow<Boolean> = prefs.installedAppsSharingEnabled
+  val accessibilityControlEnabled: StateFlow<Boolean> = prefs.accessibilityControlEnabled
   val speakerEnabled: StateFlow<Boolean> = prefs.speakerEnabled
   val preferredCameraFacing: StateFlow<String> = prefs.preferredCameraFacing
   val preferredAudioInputDevice: StateFlow<String?> = prefs.preferredAudioInputDevice
@@ -895,6 +896,10 @@ class MainViewModel private constructor(
 
   fun revokeInstalledAppsDisclosureConsent() {
     ensureRuntime().revokeInstalledAppsDisclosureConsent()
+  }
+
+  fun setAccessibilityControlEnabled(value: Boolean) {
+    prefs.setAccessibilityControlEnabled(value)
   }
 
   fun setNotificationForwardingEnabled(value: Boolean) {

--- a/apps/android/app/src/main/java/ai/openclaw/app/SecurePrefs.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/SecurePrefs.kt
@@ -62,6 +62,7 @@ class SecurePrefs(
     private const val installedAppsDisclosureConsentVersionKey =
       "device.apps.prominentDisclosure.consentVersion"
     private const val currentInstalledAppsDisclosureConsentVersion = 1
+    private const val accessibilityControlEnabledKey = "mobileUi.accessibilityControl.enabled"
     private const val cameraEnabledKey = "camera.enabled"
     private const val preferredCameraFacingKey = "camera.preferredFacing"
     private const val voiceMicEnabledKey = "voice.micEnabled"
@@ -154,6 +155,10 @@ class SecurePrefs(
   private val _installedAppsSharingEnabled =
     MutableStateFlow(loadInstalledAppsSharingEnabled())
   val installedAppsSharingEnabled: StateFlow<Boolean> = _installedAppsSharingEnabled
+
+  private val _accessibilityControlEnabled =
+    MutableStateFlow(plainPrefs.getBoolean(accessibilityControlEnabledKey, false))
+  val accessibilityControlEnabled: StateFlow<Boolean> = _accessibilityControlEnabled
 
   private val _notificationForwardingEnabled =
     MutableStateFlow(plainPrefs.getBoolean(notificationsForwardingEnabledKey, defaultNotificationForwardingEnabled))
@@ -312,6 +317,11 @@ class SecurePrefs(
       remove(installedAppsDisclosureConsentVersionKey)
     }
     _installedAppsSharingEnabled.value = false
+  }
+
+  fun setAccessibilityControlEnabled(value: Boolean) {
+    plainPrefs.edit { putBoolean(accessibilityControlEnabledKey, value) }
+    _accessibilityControlEnabled.value = value
   }
 
   private fun loadInstalledAppsSharingEnabled(): Boolean {

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt
@@ -1491,6 +1491,9 @@ private fun PhoneCapabilitiesScreen(
           SettingsToggleRow(nativeString("Canvas Status"), nativeString("Show screen-sharing debug state."), Icons.AutoMirrored.Filled.ScreenShare, canvasDebugStatusEnabled, viewModel::setCanvasDebugStatusEnabled),
         ),
     )
+    if (SensitiveFeatureConfig.accessibilityControlEnabled) {
+      FlavorPhoneCapabilitiesSettings(viewModel)
+    }
     ClawPanel {
       Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
         Text(text = nativeString("Location"), style = ClawTheme.type.section, color = ClawTheme.colors.text)
@@ -2393,7 +2396,7 @@ internal fun SettingsDetailFrame(
 /**
  * Toggle row model reused by settings sections that render simple on/off controls.
  */
-private data class SettingsToggleRow(
+internal data class SettingsToggleRow(
   val title: String,
   val subtitle: String,
   val icon: ImageVector,
@@ -3096,7 +3099,7 @@ internal fun formatCronTimestamp(timeMs: Long?): String {
 }
 
 @Composable
-private fun SettingsTogglePanel(rows: List<SettingsToggleRow>) {
+internal fun SettingsTogglePanel(rows: List<SettingsToggleRow>) {
   ClawPanel(contentPadding = PaddingValues(horizontal = 0.dp, vertical = 0.dp)) {
     ClawSeparatedColumn(items = rows) { row ->
       SettingsToggleListRow(row)

--- a/apps/android/app/src/play/java/ai/openclaw/app/SensitiveFeatureConfig.kt
+++ b/apps/android/app/src/play/java/ai/openclaw/app/SensitiveFeatureConfig.kt
@@ -5,4 +5,5 @@ object SensitiveFeatureConfig {
   const val callLogEnabled: Boolean = false
   const val photosEnabled: Boolean = false
   const val backgroundLocationEnabled: Boolean = false
+  const val accessibilityControlEnabled: Boolean = false
 }

--- a/apps/android/app/src/play/java/ai/openclaw/app/ui/FlavorPhoneCapabilitiesSettings.kt
+++ b/apps/android/app/src/play/java/ai/openclaw/app/ui/FlavorPhoneCapabilitiesSettings.kt
@@ -1,0 +1,9 @@
+package ai.openclaw.app.ui
+
+import ai.openclaw.app.MainViewModel
+import androidx.compose.runtime.Composable
+
+@Composable
+internal fun FlavorPhoneCapabilitiesSettings(
+  @Suppress("UNUSED_PARAMETER") viewModel: MainViewModel,
+) = Unit

--- a/apps/android/app/src/test/java/ai/openclaw/app/SecurePrefsTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/SecurePrefsTest.kt
@@ -145,6 +145,22 @@ class SecurePrefsTest {
   }
 
   @Test
+  fun accessibilityControl_defaultsOffAndPersistsOptIn() {
+    val context = RuntimeEnvironment.getApplication()
+    val plainPrefs = context.getSharedPreferences("openclaw.node", Context.MODE_PRIVATE)
+    plainPrefs.edit().clear().commit()
+    val prefs = testPrefs(context)
+
+    assertFalse(prefs.accessibilityControlEnabled.value)
+
+    prefs.setAccessibilityControlEnabled(true)
+
+    assertTrue(prefs.accessibilityControlEnabled.value)
+    assertTrue(plainPrefs.getBoolean("mobileUi.accessibilityControl.enabled", false))
+    assertTrue(testPrefs(context).accessibilityControlEnabled.value)
+  }
+
+  @Test
   fun installedAppsSharing_legacyOptInWithoutDisclosureRequiresReconsent() {
     val context = RuntimeEnvironment.getApplication()
     val plainPrefs = context.getSharedPreferences("openclaw.node", Context.MODE_PRIVATE)

--- a/apps/android/app/src/testThirdParty/java/ai/openclaw/app/accessibility/AccessibilityComponentControllerTest.kt
+++ b/apps/android/app/src/testThirdParty/java/ai/openclaw/app/accessibility/AccessibilityComponentControllerTest.kt
@@ -1,0 +1,55 @@
+package ai.openclaw.app.accessibility
+
+import android.content.ComponentName
+import android.content.pm.PackageManager
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class AccessibilityComponentControllerTest {
+  @Test
+  fun componentState_mapsEnabledAndDisabled() {
+    assertEquals(
+      PackageManager.COMPONENT_ENABLED_STATE_ENABLED,
+      accessibilityComponentEnabledState(enabled = true),
+    )
+    assertEquals(
+      PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
+      accessibilityComponentEnabledState(enabled = false),
+    )
+  }
+
+  @Test
+  fun setEnabled_updatesServiceAndDevActivity() {
+    val context = RuntimeEnvironment.getApplication()
+    val packageManager = context.packageManager
+    val service = ComponentName(context, OpenClawAccessibilityService::class.java)
+    val activity = ComponentName(context, AccessibilityDevActivity::class.java)
+    val controller = AccessibilityComponentController(context)
+
+    controller.setEnabled(true)
+
+    assertEquals(
+      PackageManager.COMPONENT_ENABLED_STATE_ENABLED,
+      packageManager.getComponentEnabledSetting(service),
+    )
+    assertEquals(
+      PackageManager.COMPONENT_ENABLED_STATE_ENABLED,
+      packageManager.getComponentEnabledSetting(activity),
+    )
+
+    controller.setEnabled(false)
+
+    assertEquals(
+      PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
+      packageManager.getComponentEnabledSetting(service),
+    )
+    assertEquals(
+      PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
+      packageManager.getComponentEnabledSetting(activity),
+    )
+  }
+}

--- a/apps/android/app/src/testThirdParty/java/ai/openclaw/app/accessibility/AccessibilitySnapshotterTest.kt
+++ b/apps/android/app/src/testThirdParty/java/ai/openclaw/app/accessibility/AccessibilitySnapshotterTest.kt
@@ -1,0 +1,496 @@
+package ai.openclaw.app.accessibility
+
+import android.graphics.Rect
+import android.text.InputType
+import android.view.accessibility.AccessibilityEvent
+import android.view.accessibility.AccessibilityNodeInfo
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class AccessibilitySnapshotterTest {
+  @Test
+  fun observableServiceInstanceTracksTheLiveInstance() {
+    val state = ObservableServiceInstance<Any>()
+    val first = Any()
+    val second = Any()
+
+    assertEquals(AccessibilityServiceConnection<Any>(instance = null, generation = 0), state.connection.value)
+
+    state.connect(first)
+    assertTrue(state.connection.value.instance === first)
+    assertEquals(1L, state.connection.value.generation)
+
+    state.connect(second)
+    state.disconnect(first)
+    assertTrue(state.connection.value.instance === second)
+    assertEquals(2L, state.connection.value.generation)
+
+    state.disconnect(second)
+    assertEquals(null, state.connection.value.instance)
+    assertEquals(2L, state.connection.value.generation)
+  }
+
+  @Test
+  fun normalizerCapsSnapshotsAtMaximumNodeCountAndRecyclesDiscardedNodes() {
+    val children = List(MAX_NODES + 5) { index -> FakeNode(text = "node-$index") }
+    val root = FakeNode(boundsInScreen = Rect(), children = children)
+
+    val result = AccessibilityTreeNormalizer.normalize(root)
+
+    assertEquals(MAX_NODES, result.nodes.size)
+    assertEquals("n0", result.nodes.first().ref)
+    assertEquals("n${MAX_NODES - 1}", result.nodes.last().ref)
+    assertTrue(root.recycled)
+    assertTrue(children.takeLast(5).all(FakeNode::recycled))
+    assertFalse(children.take(MAX_NODES).any(FakeNode::recycled))
+
+    result.retainedNodes.values.forEach(AccessibilityNodeAdapter::recycle)
+    assertTrue(children.all(FakeNode::recycled))
+  }
+
+  @Test
+  fun normalizerDoesNotWalkBelowMaximumDepth() {
+    var root = FakeNode(text = "deepest")
+    repeat(MAX_DEPTH + 2) { depth ->
+      root = FakeNode(text = "depth-$depth", children = listOf(root))
+    }
+
+    val result = AccessibilityTreeNormalizer.normalize(root)
+
+    assertEquals(MAX_DEPTH + 1, result.nodes.size)
+    result.retainedNodes.values.forEach(AccessibilityNodeAdapter::recycle)
+  }
+
+  @Test
+  fun passwordTextIsRedactedAndLongTextIsBounded() {
+    assertTrue(shouldRedactText(isPassword = true, isEditable = false, inputType = 0))
+    assertTrue(
+      shouldRedactText(
+        isPassword = false,
+        isEditable = true,
+        inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_PASSWORD,
+      ),
+    )
+    assertFalse(
+      shouldRedactText(
+        isPassword = false,
+        isEditable = true,
+        inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_NORMAL,
+      ),
+    )
+    assertEquals("[redacted]", normalizeNodeText("hunter2", sensitive = true))
+
+    val truncated = normalizeNodeText("x".repeat(MAX_TEXT_PER_NODE + 10), sensitive = false)
+    assertEquals(MAX_TEXT_PER_NODE, truncated?.length)
+    assertTrue(truncated?.endsWith("…") == true)
+  }
+
+  @Test
+  fun actionNamesUseStableVocabularyAndOrdering() {
+    val actions =
+      stableActionNames(
+        listOf(
+          AccessibilityNodeInfo.ACTION_SCROLL_BACKWARD,
+          AccessibilityNodeInfo.ACTION_SET_TEXT,
+          AccessibilityNodeInfo.ACTION_CLICK,
+          AccessibilityNodeInfo.ACTION_COPY,
+          AccessibilityNodeInfo.ACTION_FOCUS,
+        ),
+      )
+
+    assertEquals(listOf("activate", "set_text", "scroll_backward", "focus"), actions)
+  }
+
+  @Test
+  fun wrongSnapshotOrMissingRefIsStaleAndReplacementReleasesOldNodes() {
+    val released = mutableListOf<String>()
+    val store = SnapshotGenerationStore<String>(released::add)
+    store.replace(
+      snapshotId = "snapshot-1",
+      packageName = "example.one",
+      uiEpoch = 11,
+      connectionGeneration = 21,
+      values = mapOf("n0" to "first"),
+    )
+
+    assertEquals(GenerationTarget.Stale, store.resolve("wrong-snapshot", "n0"))
+    assertEquals(GenerationTarget.Stale, store.resolve("snapshot-1", "missing"))
+    assertEquals(GenerationTarget.Found("first"), store.resolve("snapshot-1", "n0"))
+
+    store.replace(
+      snapshotId = "snapshot-2",
+      packageName = "example.two",
+      uiEpoch = 12,
+      connectionGeneration = 22,
+      values = emptyMap(),
+    )
+    assertEquals(listOf("first"), released)
+    assertEquals("example.two", store.packageName)
+    assertEquals(12L, store.uiEpoch)
+    assertEquals(22L, store.connectionGeneration)
+  }
+
+  @Test
+  fun executorRejectsAnActionFromTheWrongSnapshotGeneration() =
+    runTest {
+      val service = Robolectric.buildService(OpenClawAccessibilityService::class.java).create().get()
+      val executor = AccessibilityActionExecutor(connectionProvider = { testConnection(service) })
+      val observed = executor.observe()
+
+      val result = executor.act("${observed.id}-stale", MobileUiAction.Wait(0))
+
+      assertEquals(ActionOutcomeCode.TargetStale, result.code)
+      executor.close()
+      service.onDestroy()
+    }
+
+  @Test
+  fun sensitiveNodeRedactsTextAndContentDescription() {
+    val sensitiveNode =
+      FakeNode(
+        text = "secret text",
+        contentDescription = "secret description",
+        viewId = "example:id/password",
+        password = true,
+      )
+
+    val result = AccessibilityTreeNormalizer.normalize(sensitiveNode)
+
+    assertEquals("[redacted]", result.nodes.single().text)
+    assertEquals("[redacted]", result.nodes.single().contentDescription)
+    assertEquals("example:id/password", result.nodes.single().viewId)
+    result.retainedNodes.values.forEach(AccessibilityNodeAdapter::recycle)
+  }
+
+  @Test
+  fun normalizerDoesNotFetchBeyondTraversalBudget() {
+    val children = List(MAX_VISITED_NODES * 2) { index -> FakeNode(text = "wide-$index") }
+    val root = FakeNode(boundsInScreen = Rect(), children = children)
+
+    val result = AccessibilityTreeNormalizer.normalize(root)
+
+    assertEquals(MAX_NODES, result.nodes.size)
+    assertEquals(MAX_VISITED_NODES - 1, root.childRequests)
+    result.retainedNodes.values.forEach(AccessibilityNodeAdapter::recycle)
+    assertTrue(root.recycled)
+    assertTrue(children.take(MAX_VISITED_NODES - 1).all(FakeNode::recycled))
+    assertFalse(children.drop(MAX_VISITED_NODES - 1).any(FakeNode::recycled))
+  }
+
+  @Test
+  fun coordinateGestureFailsClosedWhenPackageIdentityIsMissingOrChanged() =
+    runTest {
+      val service = Robolectric.buildService(OpenClawAccessibilityService::class.java).create().get()
+      val cases =
+        listOf(
+          null to "example.current",
+          "example.expected" to null,
+          "example.expected" to "example.current",
+        )
+
+      cases.forEachIndexed { index, (expectedPackage, currentPackage) ->
+        val executor =
+          AccessibilityActionExecutor(
+            connectionProvider = { testConnection(service) },
+            captureSnapshot = { fakeCapture("snapshot-$index", expectedPackage) },
+            foregroundPackageProvider = { currentPackage },
+            uiEpochProvider = { 20 },
+          )
+        val observed = executor.observe()
+
+        val result = executor.act(observed.id, MobileUiAction.Tap(10, 20))
+
+        assertEquals(ActionOutcomeCode.PackageChanged, result.code)
+        executor.close()
+      }
+      service.onDestroy()
+    }
+
+  @Test
+  fun coordinateGestureIsStaleAfterUiEpochAdvances() =
+    runTest {
+      val service = Robolectric.buildService(OpenClawAccessibilityService::class.java).create().get()
+      val executor =
+        AccessibilityActionExecutor(
+          connectionProvider = { testConnection(service) },
+          captureSnapshot = { fakeCapture("epoch-snapshot", "example.package") },
+          foregroundPackageProvider = { "example.package" },
+        )
+      val observed = executor.observe()
+      val capturedEpoch = OpenClawAccessibilityService.uiEpoch
+
+      sendAccessibilityEvent(service, AccessibilityEvent.TYPE_VIEW_FOCUSED)
+      assertEquals(capturedEpoch, OpenClawAccessibilityService.uiEpoch)
+      sendAccessibilityEvent(service, AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED)
+      sendAccessibilityEvent(service, AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED)
+      sendAccessibilityEvent(service, AccessibilityEvent.TYPE_WINDOWS_CHANGED)
+      sendAccessibilityEvent(service, AccessibilityEvent.TYPE_VIEW_SCROLLED)
+      sendAccessibilityEvent(service, AccessibilityEvent.TYPE_VIEW_TEXT_CHANGED)
+      sendAccessibilityEvent(service, AccessibilityEvent.TYPE_VIEW_TEXT_SELECTION_CHANGED)
+      assertEquals(capturedEpoch + 6, OpenClawAccessibilityService.uiEpoch)
+      val result = executor.act(observed.id, MobileUiAction.Tap(10, 20))
+
+      assertEquals(ActionOutcomeCode.TargetStale, result.code)
+      assertEquals("UI changed since observe; re-observe before coordinate actions", result.message)
+      executor.close()
+      service.onDestroy()
+    }
+
+  @Test
+  fun actionIsStaleAfterAccessibilityServiceReconnects() =
+    runTest {
+      val service = Robolectric.buildService(OpenClawAccessibilityService::class.java).create().get()
+      var connectionGeneration = 70L
+      val executor =
+        AccessibilityActionExecutor(
+          connectionProvider = { testConnection(service, connectionGeneration) },
+          captureSnapshot = { fakeCapture("connection-snapshot", "example.package") },
+          foregroundPackageProvider = { "example.package" },
+          uiEpochProvider = { 80 },
+        )
+      val observed = executor.observe()
+      connectionGeneration += 1
+
+      val result = executor.act(observed.id, MobileUiAction.Tap(10, 20))
+
+      assertEquals(ActionOutcomeCode.TargetStale, result.code)
+      assertEquals("Accessibility service reconnected; re-observe before acting", result.message)
+      executor.close()
+      service.onDestroy()
+    }
+
+  @Test
+  @Suppress("DEPRECATION")
+  fun observeCannotPublishAGenerationAfterExecutorCloses() =
+    runTest {
+      val service = Robolectric.buildService(OpenClawAccessibilityService::class.java).create().get()
+      val node = AccessibilityNodeInfo.obtain()
+      lateinit var executor: AccessibilityActionExecutor
+      executor =
+        AccessibilityActionExecutor(
+          connectionProvider = { testConnection(service, generation = 100) },
+          captureSnapshot = {
+            executor.close()
+            fakeCapture(
+              id = "closed-snapshot",
+              packageName = "example.package",
+              nodesByRef = mapOf("n0" to node),
+            )
+          },
+          foregroundPackageProvider = { "example.package" },
+          uiEpochProvider = { 90 },
+        )
+
+      val error = assertThrows(AccessibilityServiceDisabledException::class.java) { executor.observe() }
+      val result = executor.act("closed-snapshot", MobileUiAction.GlobalAction(GlobalActionName.Home))
+
+      assertEquals("Accessibility executor closed during observe", error.message)
+      assertEquals(ActionOutcomeCode.ServiceDisabled, result.code)
+      service.onDestroy()
+    }
+
+  @Test
+  fun nodeActionFailsClosedWhenPackageIdentityIsMissingOrChanged() =
+    runTest {
+      val service = Robolectric.buildService(OpenClawAccessibilityService::class.java).create().get()
+      val cases =
+        listOf(
+          null to "example.current",
+          "example.expected" to null,
+          "example.expected" to "example.current",
+        )
+
+      cases.forEachIndexed { index, (expectedPackage, currentPackage) ->
+        val executor =
+          AccessibilityActionExecutor(
+            connectionProvider = { testConnection(service) },
+            captureSnapshot = { fakeCapture("node-snapshot-$index", expectedPackage) },
+            foregroundPackageProvider = { currentPackage },
+            uiEpochProvider = { 40 },
+          )
+        val observed = executor.observe()
+
+        val result = executor.act(observed.id, MobileUiAction.Activate("n0"))
+
+        assertEquals(ActionOutcomeCode.PackageChanged, result.code)
+        executor.close()
+      }
+      service.onDestroy()
+    }
+
+  @Test
+  @Suppress("DEPRECATION")
+  fun nodeActionUsesNodeFreshnessInsteadOfUiEpoch() =
+    runTest {
+      val service = Robolectric.buildService(OpenClawAccessibilityService::class.java).create().get()
+      val node = AccessibilityNodeInfo.obtain()
+      var uiEpoch = 50L
+      val executor =
+        AccessibilityActionExecutor(
+          connectionProvider = { testConnection(service) },
+          captureSnapshot = {
+            fakeCapture(
+              id = "node-epoch-snapshot",
+              packageName = "example.package",
+              nodesByRef = mapOf("n0" to node),
+            )
+          },
+          foregroundPackageProvider = { "example.package" },
+          uiEpochProvider = { uiEpoch },
+        )
+      val observed = executor.observe()
+      uiEpoch += 1
+
+      val result = executor.act(observed.id, MobileUiAction.Activate("n0"))
+
+      assertTrue(
+        result.code == ActionOutcomeCode.TargetNotFound ||
+          result.code == ActionOutcomeCode.ActionNotSupported,
+      )
+      assertFalse(result.message?.contains("UI changed since observe") == true)
+      executor.close()
+      service.onDestroy()
+    }
+
+  @Test
+  @Suppress("DEPRECATION")
+  fun setTextChecksSecureContentAfterTheFinalNodeRefresh() =
+    runTest {
+      val service = Robolectric.buildService(OpenClawAccessibilityService::class.java).create().get()
+      val node =
+        AccessibilityNodeInfo.obtain().apply {
+          isEditable = true
+          isPassword = true
+          addAction(AccessibilityNodeInfo.ACTION_SET_TEXT)
+        }
+      val shadowNode = shadowOf(node).apply { setRefreshReturnValue(true) }
+      val executor =
+        AccessibilityActionExecutor(
+          connectionProvider = { testConnection(service) },
+          captureSnapshot = {
+            fakeCapture(
+              id = "secure-text-snapshot",
+              packageName = "example.package",
+              nodesByRef = mapOf("n0" to node),
+            )
+          },
+          foregroundPackageProvider = { "example.package" },
+          uiEpochProvider = { 60 },
+        )
+      val observed = executor.observe()
+
+      val result = executor.act(observed.id, MobileUiAction.SetText("n0", "must not be sent"))
+
+      assertEquals(ActionOutcomeCode.SecureContent, result.code)
+      assertTrue(shadowNode.performedActions.isEmpty())
+      executor.close()
+      service.onDestroy()
+    }
+
+  @Test
+  fun devUiEnablesNodeActionsOnlyForMatchingKnownPackages() {
+    assertFalse(canRunNodeActions(snapshotPackageName = null, foregroundPackageName = "example"))
+    assertFalse(canRunNodeActions(snapshotPackageName = "example", foregroundPackageName = null))
+    assertFalse(canRunNodeActions(snapshotPackageName = "example", foregroundPackageName = "other"))
+    assertTrue(canRunNodeActions(snapshotPackageName = "example", foregroundPackageName = "example"))
+  }
+
+  @Test
+  fun globalActionDoesNotRequirePackageIdentity() =
+    runTest {
+      val service = Robolectric.buildService(OpenClawAccessibilityService::class.java).create().get()
+      val executor =
+        AccessibilityActionExecutor(
+          connectionProvider = { testConnection(service) },
+          foregroundPackageProvider = { error("Global actions must not query the foreground package") },
+          uiEpochProvider = { error("Global actions must not query the UI epoch") },
+        )
+
+      val result = executor.act("no-snapshot", MobileUiAction.GlobalAction(GlobalActionName.Home))
+
+      assertTrue(result.code == ActionOutcomeCode.Completed || result.code == ActionOutcomeCode.ActionRejected)
+      executor.close()
+      service.onDestroy()
+    }
+}
+
+private fun testConnection(
+  service: OpenClawAccessibilityService,
+  generation: Long = 0,
+): AccessibilityServiceConnection<OpenClawAccessibilityService> = AccessibilityServiceConnection(instance = service, generation = generation)
+
+private fun fakeCapture(
+  id: String,
+  packageName: String?,
+  nodesByRef: Map<String, AccessibilityNodeInfo> = emptyMap(),
+): AccessibilitySnapshotCapture =
+  AccessibilitySnapshotCapture(
+    snapshot =
+      MobileUiSnapshot(
+        id = id,
+        capturedAtMs = 0,
+        packageName = packageName,
+        windowTitle = null,
+        nodes = emptyList(),
+      ),
+    nodesByRef = nodesByRef,
+  )
+
+@Suppress("DEPRECATION")
+private fun sendAccessibilityEvent(
+  service: OpenClawAccessibilityService,
+  eventType: Int,
+) {
+  val event = AccessibilityEvent.obtain(eventType)
+  try {
+    service.onAccessibilityEvent(event)
+  } finally {
+    event.recycle()
+  }
+}
+
+private class FakeNode(
+  override val className: String? = "android.view.View",
+  override val text: String? = null,
+  override val contentDescription: String? = null,
+  override val viewId: String? = null,
+  override val boundsInScreen: Rect = Rect(0, 0, 10, 10),
+  override val clickable: Boolean = false,
+  override val editable: Boolean = false,
+  override val scrollable: Boolean = false,
+  override val enabled: Boolean = true,
+  override val focused: Boolean = false,
+  override val password: Boolean = false,
+  override val inputType: Int = 0,
+  override val actionIds: List<Int> = emptyList(),
+  private val children: List<FakeNode> = emptyList(),
+) : AccessibilityNodeAdapter {
+  var childRequests: Int = 0
+    private set
+  var recycled: Boolean = false
+    private set
+
+  override val childCount: Int
+    get() = children.size
+
+  override fun childAt(index: Int): AccessibilityNodeAdapter {
+    childRequests += 1
+    return children[index]
+  }
+
+  override fun recycle() {
+    check(!recycled) { "Fake node recycled twice" }
+    recycled = true
+  }
+}

--- a/apps/android/app/src/thirdParty/AndroidManifest.xml
+++ b/apps/android/app/src/thirdParty/AndroidManifest.xml
@@ -1,4 +1,5 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
@@ -12,4 +13,27 @@
     <uses-feature
         android:name="android.hardware.telephony"
         android:required="false" />
+
+    <application>
+        <service
+            android:name=".accessibility.OpenClawAccessibilityService"
+            android:exported="true"
+            android:label="@string/accessibility_service_label"
+            android:permission="android.permission.BIND_ACCESSIBILITY_SERVICE"
+            tools:ignore="ExportedService">
+            <intent-filter>
+                <action android:name="android.accessibilityservice.AccessibilityService" />
+            </intent-filter>
+            <meta-data
+                android:name="android.accessibilityservice"
+                android:resource="@xml/accessibility_service_config" />
+        </service>
+
+        <activity
+            android:name=".accessibility.AccessibilityDevActivity"
+            android:excludeFromRecents="true"
+            android:exported="true"
+            android:label="@string/accessibility_dev_activity_label"
+            tools:ignore="ExportedActivity" />
+    </application>
 </manifest>

--- a/apps/android/app/src/thirdParty/AndroidManifest.xml
+++ b/apps/android/app/src/thirdParty/AndroidManifest.xml
@@ -17,6 +17,7 @@
     <application>
         <service
             android:name=".accessibility.OpenClawAccessibilityService"
+            android:enabled="false"
             android:exported="true"
             android:label="@string/accessibility_service_label"
             android:permission="android.permission.BIND_ACCESSIBILITY_SERVICE"
@@ -31,6 +32,7 @@
 
         <activity
             android:name=".accessibility.AccessibilityDevActivity"
+            android:enabled="false"
             android:excludeFromRecents="true"
             android:exported="true"
             android:label="@string/accessibility_dev_activity_label"

--- a/apps/android/app/src/thirdParty/java/ai/openclaw/app/SensitiveFeatureConfig.kt
+++ b/apps/android/app/src/thirdParty/java/ai/openclaw/app/SensitiveFeatureConfig.kt
@@ -5,4 +5,5 @@ object SensitiveFeatureConfig {
   const val callLogEnabled: Boolean = true
   const val photosEnabled: Boolean = true
   const val backgroundLocationEnabled: Boolean = true
+  const val accessibilityControlEnabled: Boolean = true
 }

--- a/apps/android/app/src/thirdParty/java/ai/openclaw/app/accessibility/AccessibilityActionExecutor.kt
+++ b/apps/android/app/src/thirdParty/java/ai/openclaw/app/accessibility/AccessibilityActionExecutor.kt
@@ -1,0 +1,456 @@
+package ai.openclaw.app.accessibility
+
+import android.accessibilityservice.AccessibilityService
+import android.accessibilityservice.GestureDescription
+import android.graphics.Path
+import android.os.Bundle
+import android.view.accessibility.AccessibilityNodeInfo
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlin.coroutines.resume
+
+private const val GESTURE_RESULT_TIMEOUT_MS = 10_000L
+
+sealed interface MobileUiAction {
+  data class Activate(
+    val ref: String,
+  ) : MobileUiAction
+
+  data class SetText(
+    val ref: String,
+    val text: String,
+  ) : MobileUiAction
+
+  data class Scroll(
+    val ref: String,
+    val direction: ScrollDirection,
+  ) : MobileUiAction
+
+  data class Tap(
+    val x: Int,
+    val y: Int,
+  ) : MobileUiAction
+
+  data class Swipe(
+    val x1: Int,
+    val y1: Int,
+    val x2: Int,
+    val y2: Int,
+    val durationMs: Long,
+  ) : MobileUiAction
+
+  data class GlobalAction(
+    val name: GlobalActionName,
+  ) : MobileUiAction
+
+  data class Wait(
+    val ms: Long,
+  ) : MobileUiAction
+}
+
+enum class ScrollDirection {
+  Forward,
+  Backward,
+}
+
+enum class GlobalActionName {
+  Back,
+  Home,
+  Recents,
+  Notifications,
+}
+
+enum class ActionOutcomeCode(
+  val value: String,
+) {
+  Completed("completed"),
+  AcceptedButUnverified("accepted_but_unverified"),
+  TargetStale("target_stale"),
+  TargetNotFound("target_not_found"),
+  ActionNotSupported("action_not_supported"),
+  ActionRejected("action_rejected"),
+  GestureCancelled("gesture_cancelled"),
+  PackageChanged("package_changed"),
+  ServiceDisabled("service_disabled"),
+  SecureContent("secure_content"),
+  TimedOutOutcomeUnknown("timed_out_outcome_unknown"),
+}
+
+data class ActionResult(
+  val code: ActionOutcomeCode,
+  val message: String? = null,
+)
+
+internal class AccessibilityServiceDisabledException(
+  message: String = "Accessibility service is disabled",
+) : IllegalStateException(message)
+
+class AccessibilityActionExecutor internal constructor(
+  private val connectionProvider: () -> AccessibilityServiceConnection<OpenClawAccessibilityService> = {
+    OpenClawAccessibilityService.connection.value
+  },
+  private val captureSnapshot: (OpenClawAccessibilityService) -> AccessibilitySnapshotCapture =
+    AccessibilitySnapshotter()::capture,
+  private val foregroundPackageProvider: (OpenClawAccessibilityService) -> String? =
+    OpenClawAccessibilityService::foregroundPackageName,
+  private val uiEpochProvider: () -> Long = { OpenClawAccessibilityService.uiEpoch },
+) : AutoCloseable {
+  private val generationLock = Any()
+  private var closed = false
+  private val generation =
+    SnapshotGenerationStore<AccessibilityNodeInfo> { node ->
+      @Suppress("DEPRECATION")
+      node.recycle()
+    }
+
+  fun observe(): MobileUiSnapshot {
+    synchronized(generationLock) {
+      if (closed) throw AccessibilityServiceDisabledException("Accessibility executor is closed")
+    }
+    val capturedConnection = connectionProvider()
+    val service = capturedConnection.instance
+    if (service == null) {
+      synchronized(generationLock) { generation.clear() }
+      throw AccessibilityServiceDisabledException()
+    }
+    val capturedUiEpoch = uiEpochProvider()
+    val capturedConnectionGeneration = capturedConnection.generation
+    val capture = captureSnapshot(service)
+    synchronized(generationLock) {
+      val currentConnection = connectionProvider()
+      val connectionChanged =
+        currentConnection.instance !== service || currentConnection.generation != capturedConnectionGeneration
+      if (closed || connectionChanged) {
+        generation.clear()
+        recycleCapture(capture)
+        val message = if (closed) "Accessibility executor closed during observe" else "Accessibility service changed during observe"
+        throw AccessibilityServiceDisabledException(message)
+      }
+      generation.replace(
+        snapshotId = capture.snapshot.id,
+        packageName = capture.snapshot.packageName,
+        uiEpoch = capturedUiEpoch,
+        connectionGeneration = capturedConnectionGeneration,
+        values = capture.nodesByRef,
+      )
+    }
+    return capture.snapshot
+  }
+
+  suspend fun act(
+    snapshotId: String,
+    action: MobileUiAction,
+  ): ActionResult {
+    val currentConnection = connectionProvider()
+    val service = currentConnection.instance
+    if (service == null) {
+      synchronized(generationLock) { generation.clear() }
+      return ActionResult(ActionOutcomeCode.ServiceDisabled, "Accessibility service is not connected")
+    }
+    synchronized(generationLock) {
+      if (closed) {
+        return ActionResult(ActionOutcomeCode.ServiceDisabled, "Accessibility executor is closed")
+      }
+    }
+    if (action is MobileUiAction.GlobalAction) {
+      return performGlobalAction(service, action.name)
+    }
+    synchronized(generationLock) {
+      if (closed) {
+        return ActionResult(ActionOutcomeCode.ServiceDisabled, "Accessibility executor is closed")
+      }
+      if (!generation.matches(snapshotId)) {
+        return ActionResult(ActionOutcomeCode.TargetStale, "Observe again before acting")
+      }
+      if (currentConnection.generation != generation.connectionGeneration) {
+        return ActionResult(ActionOutcomeCode.TargetStale, "Accessibility service reconnected; re-observe before acting")
+      }
+
+      when (action) {
+        is MobileUiAction.Tap,
+        is MobileUiAction.Swipe,
+        -> coordinateGesturePreflight(service)?.let { return it }
+        // Node actions use per-node refresh() for freshness; UI epoch gates only blind coordinates.
+        // Do not add an epoch check here: unrelated changes/app switches would break valid act flows.
+        is MobileUiAction.Activate,
+        is MobileUiAction.SetText,
+        is MobileUiAction.Scroll,
+        -> nodeActionPackagePreflight(service)?.let { return it }
+        is MobileUiAction.GlobalAction,
+        is MobileUiAction.Wait,
+        -> Unit
+      }
+    }
+
+    return when (action) {
+      is MobileUiAction.Activate ->
+        synchronized(generationLock) {
+          performNodeAction(
+            snapshotId = snapshotId,
+            ref = action.ref,
+            actionId = AccessibilityNodeInfo.ACTION_CLICK,
+            actionName = "activate",
+          )
+        }
+      is MobileUiAction.SetText -> synchronized(generationLock) { setText(snapshotId, action) }
+      is MobileUiAction.Scroll -> synchronized(generationLock) { scroll(snapshotId, action) }
+      is MobileUiAction.Tap -> {
+        val gesture =
+          runCatching { tapGesture(action.x, action.y) }
+            .getOrElse { return ActionResult(ActionOutcomeCode.ActionRejected, "Invalid tap gesture") }
+        dispatchGesture(service, gesture)
+      }
+      is MobileUiAction.Swipe -> {
+        if (action.durationMs <= 0) {
+          ActionResult(ActionOutcomeCode.ActionRejected, "Swipe duration must be positive")
+        } else {
+          val gesture =
+            runCatching { swipeGesture(action) }
+              .getOrElse { return ActionResult(ActionOutcomeCode.ActionRejected, "Invalid swipe gesture") }
+          dispatchGesture(service, gesture)
+        }
+      }
+      is MobileUiAction.GlobalAction -> performGlobalAction(service, action.name)
+      is MobileUiAction.Wait -> {
+        if (action.ms < 0) {
+          ActionResult(ActionOutcomeCode.ActionRejected, "Wait duration cannot be negative")
+        } else {
+          delay(action.ms)
+          ActionResult(ActionOutcomeCode.Completed)
+        }
+      }
+    }
+  }
+
+  override fun close() {
+    synchronized(generationLock) {
+      if (closed) return
+      closed = true
+      generation.clear()
+    }
+  }
+
+  @Suppress("DEPRECATION")
+  private fun recycleCapture(capture: AccessibilitySnapshotCapture) {
+    capture.nodesByRef.values.forEach(AccessibilityNodeInfo::recycle)
+  }
+
+  private fun coordinateGesturePreflight(service: OpenClawAccessibilityService): ActionResult? {
+    val expectedPackage = generation.packageName
+    val currentPackage = foregroundPackageProvider(service)
+    if (expectedPackage == null || currentPackage == null || expectedPackage != currentPackage) {
+      return ActionResult(
+        ActionOutcomeCode.PackageChanged,
+        "Active package cannot be verified against the snapshot; re-observe before coordinate actions",
+      )
+    }
+    if (uiEpochProvider() > generation.uiEpoch) {
+      return ActionResult(
+        ActionOutcomeCode.TargetStale,
+        "UI changed since observe; re-observe before coordinate actions",
+      )
+    }
+    return null
+  }
+
+  private fun nodeActionPackagePreflight(service: OpenClawAccessibilityService): ActionResult? {
+    val expectedPackage = generation.packageName
+    val currentPackage = foregroundPackageProvider(service)
+    if (expectedPackage == null || currentPackage == null || expectedPackage != currentPackage) {
+      return ActionResult(
+        ActionOutcomeCode.PackageChanged,
+        "Active package cannot be verified against the snapshot; re-observe before node actions",
+      )
+    }
+    return null
+  }
+
+  private fun performNodeAction(
+    snapshotId: String,
+    ref: String,
+    actionId: Int,
+    actionName: String,
+    arguments: Bundle? = null,
+    validateRefreshedNode: ((AccessibilityNodeInfo) -> ActionResult?)? = null,
+  ): ActionResult {
+    val node =
+      when (val target = generation.resolve(snapshotId, ref)) {
+        is GenerationTarget.Found -> target.value
+        GenerationTarget.Stale ->
+          return ActionResult(ActionOutcomeCode.TargetStale, "Node $ref is not in the current snapshot")
+      }
+    if (!runCatching { node.refresh() }.getOrDefault(false)) {
+      return ActionResult(ActionOutcomeCode.TargetNotFound, "Node $ref is no longer available")
+    }
+    validateRefreshedNode?.invoke(node)?.let { return it }
+    if (node.actionList.none { it.id == actionId }) {
+      return ActionResult(ActionOutcomeCode.ActionNotSupported, "Node $ref does not advertise $actionName")
+    }
+    val accepted = runCatching { node.performAction(actionId, arguments) }.getOrDefault(false)
+    return if (accepted) {
+      ActionResult(ActionOutcomeCode.AcceptedButUnverified)
+    } else {
+      ActionResult(ActionOutcomeCode.ActionRejected, "Android rejected $actionName for node $ref")
+    }
+  }
+
+  private fun setText(
+    snapshotId: String,
+    action: MobileUiAction.SetText,
+  ): ActionResult {
+    val arguments =
+      Bundle().apply {
+        putCharSequence(AccessibilityNodeInfo.ACTION_ARGUMENT_SET_TEXT_CHARSEQUENCE, action.text)
+      }
+    return performNodeAction(
+      snapshotId = snapshotId,
+      ref = action.ref,
+      actionId = AccessibilityNodeInfo.ACTION_SET_TEXT,
+      actionName = "set_text",
+      arguments = arguments,
+    ) { node ->
+      if (shouldRedactText(node.isPassword, node.isEditable, node.inputType)) {
+        ActionResult(ActionOutcomeCode.SecureContent, "Text entry into password fields is refused")
+      } else {
+        null
+      }
+    }
+  }
+
+  private fun scroll(
+    snapshotId: String,
+    action: MobileUiAction.Scroll,
+  ): ActionResult {
+    val (actionId, actionName) =
+      when (action.direction) {
+        ScrollDirection.Forward -> AccessibilityNodeInfo.ACTION_SCROLL_FORWARD to "scroll_forward"
+        ScrollDirection.Backward -> AccessibilityNodeInfo.ACTION_SCROLL_BACKWARD to "scroll_backward"
+      }
+    return performNodeAction(snapshotId, action.ref, actionId, actionName)
+  }
+
+  private suspend fun dispatchGesture(
+    service: OpenClawAccessibilityService,
+    gesture: GestureDescription,
+  ): ActionResult =
+    withTimeoutOrNull(GESTURE_RESULT_TIMEOUT_MS) {
+      suspendCancellableCoroutine { continuation ->
+        val callback =
+          object : AccessibilityService.GestureResultCallback() {
+            override fun onCompleted(gestureDescription: GestureDescription?) {
+              if (continuation.isActive) continuation.resume(ActionResult(ActionOutcomeCode.Completed))
+            }
+
+            override fun onCancelled(gestureDescription: GestureDescription?) {
+              if (continuation.isActive) {
+                continuation.resume(ActionResult(ActionOutcomeCode.GestureCancelled))
+              }
+            }
+          }
+        val accepted = runCatching { service.dispatchGesture(gesture, callback, null) }.getOrDefault(false)
+        if (!accepted && continuation.isActive) {
+          continuation.resume(ActionResult(ActionOutcomeCode.ActionRejected, "Android rejected the gesture"))
+        }
+      }
+    } ?: ActionResult(
+      ActionOutcomeCode.TimedOutOutcomeUnknown,
+      "Gesture callback did not arrive within $GESTURE_RESULT_TIMEOUT_MS ms",
+    )
+
+  private fun performGlobalAction(
+    service: OpenClawAccessibilityService,
+    name: GlobalActionName,
+  ): ActionResult {
+    val actionId =
+      when (name) {
+        GlobalActionName.Back -> AccessibilityService.GLOBAL_ACTION_BACK
+        GlobalActionName.Home -> AccessibilityService.GLOBAL_ACTION_HOME
+        GlobalActionName.Recents -> AccessibilityService.GLOBAL_ACTION_RECENTS
+        GlobalActionName.Notifications -> AccessibilityService.GLOBAL_ACTION_NOTIFICATIONS
+      }
+    return if (runCatching { service.performGlobalAction(actionId) }.getOrDefault(false)) {
+      ActionResult(ActionOutcomeCode.Completed)
+    } else {
+      ActionResult(ActionOutcomeCode.ActionRejected, "Android rejected global action ${name.name.lowercase()}")
+    }
+  }
+}
+
+internal class SnapshotGenerationStore<T>(
+  private val release: (T) -> Unit,
+) {
+  var packageName: String? = null
+    private set
+  var uiEpoch: Long = 0
+    private set
+  var connectionGeneration: Long = 0
+    private set
+  private var snapshotId: String? = null
+  private var values: Map<String, T> = emptyMap()
+
+  fun replace(
+    snapshotId: String,
+    packageName: String?,
+    uiEpoch: Long,
+    connectionGeneration: Long,
+    values: Map<String, T>,
+  ) {
+    clear()
+    this.snapshotId = snapshotId
+    this.packageName = packageName
+    this.uiEpoch = uiEpoch
+    this.connectionGeneration = connectionGeneration
+    this.values = values
+  }
+
+  fun matches(snapshotId: String): Boolean = this.snapshotId == snapshotId
+
+  fun resolve(
+    snapshotId: String,
+    ref: String,
+  ): GenerationTarget<T> {
+    if (!matches(snapshotId)) return GenerationTarget.Stale
+    return values[ref]?.let { value -> GenerationTarget.Found(value) } ?: GenerationTarget.Stale
+  }
+
+  fun clear() {
+    values.values.forEach(release)
+    values = emptyMap()
+    snapshotId = null
+    packageName = null
+    uiEpoch = 0
+    connectionGeneration = 0
+  }
+}
+
+internal sealed interface GenerationTarget<out T> {
+  data class Found<T>(
+    val value: T,
+  ) : GenerationTarget<T>
+
+  data object Stale : GenerationTarget<Nothing>
+}
+
+private fun tapGesture(
+  x: Int,
+  y: Int,
+): GestureDescription {
+  val path = Path().apply { moveTo(x.toFloat(), y.toFloat()) }
+  return GestureDescription
+    .Builder()
+    .addStroke(GestureDescription.StrokeDescription(path, 0, 1))
+    .build()
+}
+
+private fun swipeGesture(action: MobileUiAction.Swipe): GestureDescription {
+  val path =
+    Path().apply {
+      moveTo(action.x1.toFloat(), action.y1.toFloat())
+      lineTo(action.x2.toFloat(), action.y2.toFloat())
+    }
+  return GestureDescription
+    .Builder()
+    .addStroke(GestureDescription.StrokeDescription(path, 0, action.durationMs))
+    .build()
+}

--- a/apps/android/app/src/thirdParty/java/ai/openclaw/app/accessibility/AccessibilityComponentController.kt
+++ b/apps/android/app/src/thirdParty/java/ai/openclaw/app/accessibility/AccessibilityComponentController.kt
@@ -1,0 +1,34 @@
+package ai.openclaw.app.accessibility
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.pm.PackageManager
+
+internal class AccessibilityComponentController(
+  context: Context,
+) {
+  private val appContext = context.applicationContext
+  private val components =
+    listOf(
+      ComponentName(appContext, OpenClawAccessibilityService::class.java),
+      ComponentName(appContext, AccessibilityDevActivity::class.java),
+    )
+
+  fun setEnabled(enabled: Boolean) {
+    val state = accessibilityComponentEnabledState(enabled)
+    components.forEach { component ->
+      appContext.packageManager.setComponentEnabledSetting(
+        component,
+        state,
+        PackageManager.DONT_KILL_APP,
+      )
+    }
+  }
+}
+
+internal fun accessibilityComponentEnabledState(enabled: Boolean): Int =
+  if (enabled) {
+    PackageManager.COMPONENT_ENABLED_STATE_ENABLED
+  } else {
+    PackageManager.COMPONENT_ENABLED_STATE_DISABLED
+  }

--- a/apps/android/app/src/thirdParty/java/ai/openclaw/app/accessibility/AccessibilityDevActivity.kt
+++ b/apps/android/app/src/thirdParty/java/ai/openclaw/app/accessibility/AccessibilityDevActivity.kt
@@ -1,0 +1,447 @@
+package ai.openclaw.app.accessibility
+
+import ai.openclaw.app.ui.OpenClawTheme
+import android.content.Intent
+import android.os.Bundle
+import android.provider.Settings
+import androidx.activity.compose.setContent
+import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+private const val DELAYED_OBSERVE_SECONDS = 3
+
+class AccessibilityDevActivity : AppCompatActivity() {
+  private val executor = AccessibilityActionExecutor()
+  private var delayedObserveJob: Job? = null
+  private var foregroundPackageName by mutableStateOf<String?>(null)
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    setContent {
+      OpenClawTheme {
+        AccessibilityDevScreen(
+          executor = executor,
+          captureSnapshot = ::captureSnapshotOffMain,
+          foregroundPackageName = foregroundPackageName,
+          refreshForegroundPackage = ::refreshForegroundPackage,
+          startDelayedObserve = ::startDelayedObserve,
+          cancelDelayedObserve = ::cancelDelayedObserve,
+          openAccessibilitySettings = {
+            startActivity(Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS))
+          },
+        )
+      }
+    }
+  }
+
+  override fun onDestroy() {
+    cancelDelayedObserve()
+    executor.close()
+    super.onDestroy()
+  }
+
+  override fun onResume() {
+    super.onResume()
+    refreshForegroundPackage()
+  }
+
+  override fun onWindowFocusChanged(hasFocus: Boolean) {
+    super.onWindowFocusChanged(hasFocus)
+    if (hasFocus) refreshForegroundPackage()
+  }
+
+  private fun startDelayedObserve(
+    onCountdown: (Int) -> Unit,
+    onResult: (Result<MobileUiSnapshot>) -> Unit,
+  ) {
+    cancelDelayedObserve()
+    delayedObserveJob =
+      lifecycleScope.launch {
+        for (remaining in DELAYED_OBSERVE_SECONDS downTo 1) {
+          onCountdown(remaining)
+          delay(1_000)
+        }
+        onResult(runCatching { captureSnapshotOffMain() })
+      }
+  }
+
+  private fun cancelDelayedObserve() {
+    delayedObserveJob?.cancel()
+    delayedObserveJob = null
+  }
+
+  private fun refreshForegroundPackage() {
+    foregroundPackageName = OpenClawAccessibilityService.instance?.foregroundPackageName()
+  }
+
+  private suspend fun captureSnapshotOffMain(): MobileUiSnapshot =
+    withContext(Dispatchers.Default) {
+      // Accessibility tree traversal can involve thousands of blocking IPC calls; keep it off Main.
+      executor.observe()
+    }
+}
+
+@Composable
+private fun AccessibilityDevScreen(
+  executor: AccessibilityActionExecutor,
+  captureSnapshot: suspend () -> MobileUiSnapshot,
+  foregroundPackageName: String?,
+  refreshForegroundPackage: () -> Unit,
+  startDelayedObserve: (
+    onCountdown: (Int) -> Unit,
+    onResult: (Result<MobileUiSnapshot>) -> Unit,
+  ) -> Unit,
+  cancelDelayedObserve: () -> Unit,
+  openAccessibilitySettings: () -> Unit,
+) {
+  val coroutineScope = rememberCoroutineScope()
+  val serviceConnection by OpenClawAccessibilityService.connection.collectAsState()
+  val connected = serviceConnection.instance != null
+  var snapshot by remember { mutableStateOf<MobileUiSnapshot?>(null) }
+  var selectedRef by remember { mutableStateOf<String?>(null) }
+  var textInput by remember { mutableStateOf("") }
+  var lastResult by remember { mutableStateOf<ActionResult?>(null) }
+  var progressMessage by remember { mutableStateOf<String?>(null) }
+  var delayedObserveRunning by remember { mutableStateOf(false) }
+  var immediateObserveRunning by remember { mutableStateOf(false) }
+
+  fun applyObservedSnapshot(observed: MobileUiSnapshot) {
+    snapshot = observed
+    selectedRef = null
+    textInput = ""
+    lastResult = ActionResult(ActionOutcomeCode.Completed, "Observed ${observed.nodes.size} nodes")
+    refreshForegroundPackage()
+  }
+
+  fun applyObserveFailure(error: Throwable) {
+    snapshot = null
+    selectedRef = null
+    lastResult = ActionResult(ActionOutcomeCode.ServiceDisabled, error.message)
+  }
+
+  fun observe() {
+    if (immediateObserveRunning || delayedObserveRunning) return
+    cancelDelayedObserve()
+    delayedObserveRunning = false
+    immediateObserveRunning = true
+    progressMessage = "Observing…"
+    coroutineScope.launch {
+      val result = runCatching { captureSnapshot() }
+      immediateObserveRunning = false
+      progressMessage = null
+      result.fold(
+        onSuccess = ::applyObservedSnapshot,
+        onFailure = ::applyObserveFailure,
+      )
+    }
+  }
+
+  fun observeDelayed() {
+    if (immediateObserveRunning || delayedObserveRunning) return
+    delayedObserveRunning = true
+    startDelayedObserve(
+      { remaining ->
+        progressMessage = "Observing in ${remaining}s — switch to the target app"
+      },
+      { result ->
+        delayedObserveRunning = false
+        progressMessage = null
+        result.fold(
+          onSuccess = ::applyObservedSnapshot,
+          onFailure = ::applyObserveFailure,
+        )
+      },
+    )
+  }
+
+  fun cancelDelayedObservation() {
+    cancelDelayedObserve()
+    delayedObserveRunning = false
+    progressMessage = null
+  }
+
+  fun startImmediateObservation() {
+    if (delayedObserveRunning) {
+      cancelDelayedObservation()
+    }
+    observe()
+  }
+
+  fun act(action: MobileUiAction) {
+    val activeSnapshot = snapshot ?: return
+    coroutineScope.launch {
+      lastResult = executor.act(activeSnapshot.id, action)
+    }
+  }
+
+  fun actGlobal(name: GlobalActionName) {
+    coroutineScope.launch {
+      lastResult = executor.act(snapshot?.id.orEmpty(), MobileUiAction.GlobalAction(name))
+    }
+  }
+
+  val selectedNode = snapshot?.nodes?.firstOrNull { it.ref == selectedRef }
+  val observeRunning = immediateObserveRunning || delayedObserveRunning
+  val targetPackageMatches = canRunNodeActions(snapshot?.packageName, foregroundPackageName)
+  val nodeActionsEnabled = targetPackageMatches && !observeRunning
+  Surface(
+    modifier =
+      Modifier
+        .fillMaxSize()
+        .statusBarsPadding()
+        .navigationBarsPadding(),
+    color = MaterialTheme.colorScheme.background,
+  ) {
+    Column(
+      modifier = Modifier.fillMaxSize().padding(16.dp),
+      verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+      Text("Accessibility executor", style = MaterialTheme.typography.headlineSmall)
+      Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+      ) {
+        Text(
+          text = if (connected) "Service connected" else "Service disabled",
+          color = if (connected) Color(0xFF2E7D32) else MaterialTheme.colorScheme.error,
+          modifier = Modifier.weight(1f),
+        )
+        if (!connected) {
+          OutlinedButton(onClick = openAccessibilitySettings) {
+            Text("Open settings")
+          }
+        }
+      }
+
+      Row(
+        modifier = Modifier.horizontalScroll(rememberScrollState()),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+      ) {
+        Button(onClick = ::startImmediateObservation, enabled = connected && !observeRunning) {
+          Text("Observe")
+        }
+        OutlinedButton(onClick = ::observeDelayed, enabled = connected && !observeRunning) {
+          Text("Observe in 3s")
+        }
+        GlobalActionButton("Back", connected && !observeRunning) {
+          actGlobal(GlobalActionName.Back)
+        }
+        GlobalActionButton("Home", connected && !observeRunning) {
+          actGlobal(GlobalActionName.Home)
+        }
+        GlobalActionButton("Recents", connected && !observeRunning) {
+          actGlobal(GlobalActionName.Recents)
+        }
+      }
+
+      Text(
+        text = "Snapshot: ${snapshot?.id ?: "none"}",
+        style = MaterialTheme.typography.bodySmall,
+        fontFamily = FontFamily.Monospace,
+      )
+      Text(
+        text = "Packages: snapshot=${snapshot?.packageName ?: "none"} foreground=${foregroundPackageName ?: "unknown"}",
+        style = MaterialTheme.typography.bodySmall,
+        fontFamily = FontFamily.Monospace,
+      )
+      Text(
+        text =
+          progressMessage ?: lastResult?.let { result ->
+            listOfNotNull(result.code.value, result.message).joinToString(" — ")
+          } ?: "No action result",
+        style = MaterialTheme.typography.bodySmall,
+        fontFamily = FontFamily.Monospace,
+      )
+
+      selectedNode?.let { node ->
+        SelectedNodeControls(
+          node = node,
+          textInput = textInput,
+          onTextInputChange = { textInput = it },
+          actionsEnabled = nodeActionsEnabled,
+          showTargetMismatchNote = !targetPackageMatches,
+          act = ::act,
+        )
+      }
+
+      LazyColumn(
+        modifier = Modifier.fillMaxWidth().weight(1f),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+      ) {
+        items(snapshot?.nodes.orEmpty(), key = MobileUiNode::ref) { node ->
+          NodeRow(
+            node = node,
+            selected = node.ref == selectedRef,
+            onSelect = {
+              refreshForegroundPackage()
+              selectedRef = node.ref
+            },
+          )
+        }
+      }
+    }
+  }
+}
+
+@Composable
+private fun GlobalActionButton(
+  label: String,
+  enabled: Boolean,
+  onClick: () -> Unit,
+) {
+  OutlinedButton(onClick = onClick, enabled = enabled) {
+    Text(label)
+  }
+}
+
+@Composable
+private fun SelectedNodeControls(
+  node: MobileUiNode,
+  textInput: String,
+  onTextInputChange: (String) -> Unit,
+  actionsEnabled: Boolean,
+  showTargetMismatchNote: Boolean,
+  act: (MobileUiAction) -> Unit,
+) {
+  Card(modifier = Modifier.fillMaxWidth()) {
+    Column(
+      modifier = Modifier.padding(12.dp),
+      verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+      Text("Selected ${node.ref}", style = MaterialTheme.typography.titleSmall)
+      if (showTargetMismatchNote) {
+        Text(
+          "Node actions run only when the target app is foreground (validated via the remote path). " +
+            "Global actions and same-app actions work here.",
+          style = MaterialTheme.typography.bodySmall,
+          color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+      }
+      Row(
+        modifier = Modifier.horizontalScroll(rememberScrollState()),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+      ) {
+        if ("activate" in node.actions) {
+          Button(onClick = { act(MobileUiAction.Activate(node.ref)) }, enabled = actionsEnabled) {
+            Text("Activate")
+          }
+        }
+        if ("scroll_forward" in node.actions) {
+          OutlinedButton(
+            onClick = { act(MobileUiAction.Scroll(node.ref, ScrollDirection.Forward)) },
+            enabled = actionsEnabled,
+          ) {
+            Text("Scroll forward")
+          }
+        }
+        if ("scroll_backward" in node.actions) {
+          OutlinedButton(
+            onClick = { act(MobileUiAction.Scroll(node.ref, ScrollDirection.Backward)) },
+            enabled = actionsEnabled,
+          ) {
+            Text("Scroll back")
+          }
+        }
+      }
+      if (node.editable && "set_text" in node.actions) {
+        Row(
+          modifier = Modifier.fillMaxWidth(),
+          horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+          OutlinedTextField(
+            value = textInput,
+            onValueChange = onTextInputChange,
+            label = { Text("Text") },
+            singleLine = true,
+            enabled = actionsEnabled,
+            modifier = Modifier.weight(1f),
+          )
+          Button(
+            onClick = { act(MobileUiAction.SetText(node.ref, textInput)) },
+            enabled = actionsEnabled,
+          ) {
+            Text("Set text")
+          }
+        }
+      }
+    }
+  }
+}
+
+internal fun canRunNodeActions(
+  snapshotPackageName: String?,
+  foregroundPackageName: String?,
+): Boolean = snapshotPackageName != null && snapshotPackageName == foregroundPackageName
+
+@Composable
+private fun NodeRow(
+  node: MobileUiNode,
+  selected: Boolean,
+  onSelect: () -> Unit,
+) {
+  Card(
+    modifier = Modifier.fillMaxWidth().clickable(onClick = onSelect),
+    shape = RoundedCornerShape(8.dp),
+  ) {
+    Column(
+      modifier = Modifier.fillMaxWidth().heightIn(min = 64.dp).padding(10.dp),
+      verticalArrangement = Arrangement.spacedBy(3.dp),
+    ) {
+      Text(
+        text = "${if (selected) "▶ " else ""}${node.ref}  ${node.role}",
+        style = MaterialTheme.typography.titleSmall,
+        fontFamily = FontFamily.Monospace,
+      )
+      node.text?.let { Text("text: $it", style = MaterialTheme.typography.bodySmall) }
+      node.contentDescription?.let { Text("description: $it", style = MaterialTheme.typography.bodySmall) }
+      Text(
+        text = "bounds: ${node.boundsInScreen.flattenToString()}",
+        style = MaterialTheme.typography.bodySmall,
+        fontFamily = FontFamily.Monospace,
+      )
+      Text(
+        text = "actions: ${node.actions.joinToString().ifEmpty { "none" }}",
+        style = MaterialTheme.typography.bodySmall,
+        fontFamily = FontFamily.Monospace,
+      )
+    }
+  }
+}

--- a/apps/android/app/src/thirdParty/java/ai/openclaw/app/accessibility/AccessibilitySnapshotter.kt
+++ b/apps/android/app/src/thirdParty/java/ai/openclaw/app/accessibility/AccessibilitySnapshotter.kt
@@ -1,0 +1,280 @@
+package ai.openclaw.app.accessibility
+
+import android.graphics.Rect
+import android.text.InputType
+import android.view.accessibility.AccessibilityNodeInfo
+import java.util.UUID
+
+internal const val MAX_NODES = 400
+internal const val MAX_DEPTH = 40
+internal const val MAX_TEXT_PER_NODE = 200
+
+// Bounds AccessibilityNodeInfo acquisition so pathological trees cannot stall the UI thread or spike memory.
+internal const val MAX_VISITED_NODES = 4_000
+
+internal data class AccessibilitySnapshotCapture(
+  val snapshot: MobileUiSnapshot,
+  val nodesByRef: Map<String, AccessibilityNodeInfo>,
+)
+
+internal class AccessibilitySnapshotter {
+  fun capture(service: OpenClawAccessibilityService): AccessibilitySnapshotCapture {
+    val root = service.rootInActiveWindow
+    if (root == null) {
+      return AccessibilitySnapshotCapture(
+        snapshot =
+          MobileUiSnapshot(
+            id = UUID.randomUUID().toString(),
+            capturedAtMs = System.currentTimeMillis(),
+            packageName = null,
+            windowTitle = null,
+            nodes = emptyList(),
+          ),
+        nodesByRef = emptyMap(),
+      )
+    }
+
+    val packageName = root.packageName?.toString()
+    val windowTitle = root.readWindowTitle()
+    val normalized = AccessibilityTreeNormalizer.normalize(AndroidAccessibilityNode(root))
+    return AccessibilitySnapshotCapture(
+      snapshot =
+        MobileUiSnapshot(
+          id = UUID.randomUUID().toString(),
+          capturedAtMs = System.currentTimeMillis(),
+          packageName = packageName,
+          windowTitle = windowTitle,
+          nodes = normalized.nodes,
+        ),
+      nodesByRef =
+        normalized.retainedNodes.mapValues { (_, node) ->
+          (node as AndroidAccessibilityNode).platformNode
+        },
+    )
+  }
+}
+
+internal interface AccessibilityNodeAdapter {
+  val className: String?
+  val text: String?
+  val contentDescription: String?
+  val viewId: String?
+  val boundsInScreen: Rect
+  val clickable: Boolean
+  val editable: Boolean
+  val scrollable: Boolean
+  val enabled: Boolean
+  val focused: Boolean
+  val password: Boolean
+  val inputType: Int
+  val actionIds: List<Int>
+  val childCount: Int
+
+  fun childAt(index: Int): AccessibilityNodeAdapter?
+
+  fun recycle()
+}
+
+private class AndroidAccessibilityNode(
+  val platformNode: AccessibilityNodeInfo,
+) : AccessibilityNodeAdapter {
+  override val className: String?
+    get() = platformNode.className?.toString()
+  override val text: String?
+    get() = platformNode.text?.toString()
+  override val contentDescription: String?
+    get() = platformNode.contentDescription?.toString()
+  override val viewId: String?
+    get() = platformNode.viewIdResourceName
+  override val boundsInScreen: Rect
+    get() = Rect().also(platformNode::getBoundsInScreen)
+  override val clickable: Boolean
+    get() = platformNode.isClickable
+  override val editable: Boolean
+    get() = platformNode.isEditable
+  override val scrollable: Boolean
+    get() = platformNode.isScrollable
+  override val enabled: Boolean
+    get() = platformNode.isEnabled
+  override val focused: Boolean
+    get() = platformNode.isFocused
+  override val password: Boolean
+    get() = platformNode.isPassword
+  override val inputType: Int
+    get() = platformNode.inputType
+  override val actionIds: List<Int>
+    get() = platformNode.actionList.map(AccessibilityNodeInfo.AccessibilityAction::getId)
+  override val childCount: Int
+    get() = platformNode.childCount
+
+  override fun childAt(index: Int): AccessibilityNodeAdapter? = platformNode.getChild(index)?.let(::AndroidAccessibilityNode)
+
+  @Suppress("DEPRECATION")
+  override fun recycle() = platformNode.recycle()
+}
+
+internal data class NormalizedAccessibilityTree(
+  val nodes: List<MobileUiNode>,
+  val retainedNodes: Map<String, AccessibilityNodeAdapter>,
+)
+
+internal object AccessibilityTreeNormalizer {
+  private data class PendingNode(
+    val node: AccessibilityNodeAdapter,
+    val depth: Int,
+    val parentRef: String?,
+  )
+
+  fun normalize(root: AccessibilityNodeAdapter): NormalizedAccessibilityTree {
+    val pending = ArrayDeque<PendingNode>()
+    val nodes = mutableListOf<MobileUiNode>()
+    val retained = linkedMapOf<String, AccessibilityNodeAdapter>()
+    pending.addLast(PendingNode(root, depth = 0, parentRef = null))
+    var discoveredNodeCount = 1
+
+    var current: AccessibilityNodeAdapter? = null
+    try {
+      while (pending.isNotEmpty()) {
+        val item = pending.removeLast()
+        current = item.node
+        if (item.depth > MAX_DEPTH) {
+          current.recycle()
+          current = null
+          continue
+        }
+
+        val bounds = current.boundsInScreen
+        val rawText = current.text
+        val rawDescription = current.contentDescription
+        val include =
+          (bounds.width() > 0 && bounds.height() > 0) ||
+            !rawText.isNullOrEmpty() ||
+            !rawDescription.isNullOrEmpty() ||
+            current.clickable
+        val ref = if (include) "n${nodes.size}" else item.parentRef
+        val sensitive = shouldRedactText(current.password, current.editable, current.inputType)
+
+        if (include) {
+          nodes +=
+            MobileUiNode(
+              ref = checkNotNull(ref),
+              parentRef = item.parentRef,
+              role = stableRole(current.className, current.clickable, current.editable),
+              text = normalizeNodeText(rawText, sensitive),
+              contentDescription = normalizeNodeText(rawDescription, sensitive),
+              viewId = truncateNodeText(current.viewId),
+              boundsInScreen = Rect(bounds),
+              clickable = current.clickable,
+              editable = current.editable,
+              scrollable = current.scrollable,
+              enabled = current.enabled,
+              focused = current.focused,
+              actions = stableActionNames(current.actionIds),
+            )
+        }
+
+        val reachedNodeLimit = nodes.size >= MAX_NODES
+        if (!reachedNodeLimit && item.depth < MAX_DEPTH) {
+          val remainingTraversalBudget = MAX_VISITED_NODES - discoveredNodeCount
+          val childSlotsToInspect = minOf(current.childCount, remainingTraversalBudget)
+          for (index in childSlotsToInspect - 1 downTo 0) {
+            discoveredNodeCount += 1
+            current.childAt(index)?.let { child ->
+              pending.addLast(PendingNode(child, depth = item.depth + 1, parentRef = ref))
+            }
+          }
+        }
+
+        if (include) {
+          retained[checkNotNull(ref)] = current
+        } else {
+          current.recycle()
+        }
+        current = null
+        if (reachedNodeLimit) break
+      }
+    } catch (error: Throwable) {
+      current?.recycle()
+      retained.values.forEach(AccessibilityNodeAdapter::recycle)
+      pending.forEach { it.node.recycle() }
+      throw error
+    }
+
+    pending.forEach { it.node.recycle() }
+    return NormalizedAccessibilityTree(nodes = nodes, retainedNodes = retained)
+  }
+}
+
+internal fun shouldRedactText(
+  isPassword: Boolean,
+  isEditable: Boolean,
+  inputType: Int,
+): Boolean {
+  if (isPassword) return true
+  if (!isEditable) return false
+
+  val inputClass = inputType and InputType.TYPE_MASK_CLASS
+  val variation = inputType and InputType.TYPE_MASK_VARIATION
+  return when (inputClass) {
+    InputType.TYPE_CLASS_TEXT ->
+      variation == InputType.TYPE_TEXT_VARIATION_PASSWORD ||
+        variation == InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD ||
+        variation == InputType.TYPE_TEXT_VARIATION_WEB_PASSWORD
+    InputType.TYPE_CLASS_NUMBER -> variation == InputType.TYPE_NUMBER_VARIATION_PASSWORD
+    else -> false
+  }
+}
+
+internal fun normalizeNodeText(
+  text: String?,
+  sensitive: Boolean,
+): String? = if (sensitive) "[redacted]" else truncateNodeText(text)
+
+internal fun truncateNodeText(text: String?): String? {
+  if (text == null || text.length <= MAX_TEXT_PER_NODE) return text
+  return text.take(MAX_TEXT_PER_NODE - 1) + "…"
+}
+
+internal fun stableActionNames(actionIds: Collection<Int>): List<String> {
+  val ids = actionIds.toSet()
+  return buildList {
+    if (AccessibilityNodeInfo.ACTION_CLICK in ids) add("activate")
+    if (AccessibilityNodeInfo.ACTION_LONG_CLICK in ids) add("long_press")
+    if (AccessibilityNodeInfo.ACTION_SET_TEXT in ids) add("set_text")
+    if (AccessibilityNodeInfo.ACTION_SCROLL_FORWARD in ids) add("scroll_forward")
+    if (AccessibilityNodeInfo.ACTION_SCROLL_BACKWARD in ids) add("scroll_backward")
+    if (AccessibilityNodeInfo.ACTION_FOCUS in ids) add("focus")
+  }
+}
+
+internal fun stableRole(
+  className: String?,
+  clickable: Boolean,
+  editable: Boolean,
+): String {
+  val simpleName = className?.substringAfterLast('.')
+  return when {
+    editable -> "text_field"
+    simpleName == "Button" || simpleName == "ImageButton" -> "button"
+    simpleName == "CheckBox" -> "checkbox"
+    simpleName == "Switch" || simpleName == "SwitchCompat" -> "switch"
+    simpleName == "RadioButton" -> "radio"
+    simpleName == "ImageView" -> "image"
+    simpleName == "TextView" -> if (clickable) "button" else "text"
+    simpleName == "ListView" || simpleName == "RecyclerView" -> "list"
+    simpleName == "ScrollView" || simpleName == "HorizontalScrollView" -> "scroll_view"
+    simpleName == "WebView" -> "web_view"
+    clickable -> "button"
+    else -> "node"
+  }
+}
+
+@Suppress("DEPRECATION")
+private fun AccessibilityNodeInfo.readWindowTitle(): String? {
+  val nodeWindow = window ?: return null
+  return try {
+    nodeWindow.title?.toString()
+  } finally {
+    nodeWindow.recycle()
+  }
+}

--- a/apps/android/app/src/thirdParty/java/ai/openclaw/app/accessibility/MobileUiSnapshot.kt
+++ b/apps/android/app/src/thirdParty/java/ai/openclaw/app/accessibility/MobileUiSnapshot.kt
@@ -1,0 +1,27 @@
+package ai.openclaw.app.accessibility
+
+import android.graphics.Rect
+
+data class MobileUiSnapshot(
+  val id: String,
+  val capturedAtMs: Long,
+  val packageName: String?,
+  val windowTitle: String?,
+  val nodes: List<MobileUiNode>,
+)
+
+data class MobileUiNode(
+  val ref: String,
+  val parentRef: String?,
+  val role: String,
+  val text: String?,
+  val contentDescription: String?,
+  val viewId: String?,
+  val boundsInScreen: Rect,
+  val clickable: Boolean,
+  val editable: Boolean,
+  val scrollable: Boolean,
+  val enabled: Boolean,
+  val focused: Boolean,
+  val actions: List<String>,
+)

--- a/apps/android/app/src/thirdParty/java/ai/openclaw/app/accessibility/OpenClawAccessibilityService.kt
+++ b/apps/android/app/src/thirdParty/java/ai/openclaw/app/accessibility/OpenClawAccessibilityService.kt
@@ -1,0 +1,94 @@
+package ai.openclaw.app.accessibility
+
+import android.accessibilityservice.AccessibilityService
+import android.content.Intent
+import android.view.accessibility.AccessibilityEvent
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import java.util.concurrent.atomic.AtomicLong
+
+class OpenClawAccessibilityService : AccessibilityService() {
+  override fun onServiceConnected() {
+    super.onServiceConnected()
+    connectionState.connect(this)
+  }
+
+  override fun onAccessibilityEvent(event: AccessibilityEvent?) {
+    // Coordinate staleness epoch: advance on any event that can move or change on-screen content.
+    // Pure focus/hover/announcement events are intentionally excluded.
+    when (event?.eventType) {
+      AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED,
+      AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED,
+      AccessibilityEvent.TYPE_WINDOWS_CHANGED,
+      AccessibilityEvent.TYPE_VIEW_SCROLLED,
+      AccessibilityEvent.TYPE_VIEW_TEXT_CHANGED,
+      AccessibilityEvent.TYPE_VIEW_TEXT_SELECTION_CHANGED,
+      -> advanceUiEpoch()
+      else -> Unit
+    }
+  }
+
+  override fun onInterrupt() = Unit
+
+  override fun onUnbind(intent: Intent?): Boolean {
+    connectionState.disconnect(this)
+    return super.onUnbind(intent)
+  }
+
+  override fun onDestroy() {
+    connectionState.disconnect(this)
+    super.onDestroy()
+  }
+
+  @Suppress("DEPRECATION")
+  internal fun foregroundPackageName(): String? {
+    val root = rootInActiveWindow ?: return null
+    return try {
+      root.packageName?.toString()
+    } finally {
+      root.recycle()
+    }
+  }
+
+  companion object {
+    private val connectionState = ObservableServiceInstance<OpenClawAccessibilityService>()
+    private val uiEpochCounter = AtomicLong(0)
+
+    val instance: OpenClawAccessibilityService?
+      get() = connectionState.connection.value.instance
+
+    internal val connection: StateFlow<AccessibilityServiceConnection<OpenClawAccessibilityService>> =
+      connectionState.connection
+
+    val uiEpoch: Long
+      get() = uiEpochCounter.get()
+
+    val connectionGeneration: Long
+      get() = connectionState.connection.value.generation
+
+    internal fun advanceUiEpoch(): Long = uiEpochCounter.incrementAndGet()
+  }
+}
+
+internal data class AccessibilityServiceConnection<T : Any>(
+  val instance: T?,
+  val generation: Long,
+)
+
+internal class ObservableServiceInstance<T : Any> {
+  private val mutableConnection = MutableStateFlow(AccessibilityServiceConnection<T>(instance = null, generation = 0))
+
+  val connection: StateFlow<AccessibilityServiceConnection<T>> = mutableConnection.asStateFlow()
+
+  fun connect(instance: T) {
+    val current = mutableConnection.value
+    mutableConnection.value = AccessibilityServiceConnection(instance, generation = current.generation + 1)
+  }
+
+  fun disconnect(instance: T) {
+    val current = mutableConnection.value
+    if (current.instance !== instance) return
+    mutableConnection.value = current.copy(instance = null)
+  }
+}

--- a/apps/android/app/src/thirdParty/java/ai/openclaw/app/ui/SensitivePhoneCapabilitiesSettings.kt
+++ b/apps/android/app/src/thirdParty/java/ai/openclaw/app/ui/SensitivePhoneCapabilitiesSettings.kt
@@ -1,0 +1,104 @@
+package ai.openclaw.app.ui
+
+import ai.openclaw.app.MainViewModel
+import ai.openclaw.app.accessibility.AccessibilityComponentController
+import ai.openclaw.app.i18n.nativeString
+import android.content.Context
+import android.content.Intent
+import android.provider.Settings
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ScreenShare
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+
+@Composable
+internal fun FlavorPhoneCapabilitiesSettings(viewModel: MainViewModel) {
+  val context = LocalContext.current
+  val enabled by viewModel.accessibilityControlEnabled.collectAsState()
+  var showDisclosure by rememberSaveable { mutableStateOf(false) }
+
+  fun setControlEnabled(checked: Boolean) {
+    if (checked) {
+      showDisclosure = true
+      return
+    }
+    viewModel.setAccessibilityControlEnabled(false)
+    AccessibilityComponentController(context).setEnabled(false)
+  }
+
+  SettingsTogglePanel(
+    rows =
+      listOf(
+        SettingsToggleRow(
+          title = nativeString("Control other apps"),
+          subtitle =
+            if (enabled) {
+              nativeString("Shown in Android Accessibility settings.")
+            } else {
+              nativeString("Other apps stay untouched.")
+            },
+          icon = Icons.AutoMirrored.Filled.ScreenShare,
+          checked = enabled,
+          onCheckedChange = ::setControlEnabled,
+        ),
+      ),
+  )
+
+  if (showDisclosure) {
+    AccessibilityControlDisclosureDialog(
+      onDismiss = { showDisclosure = false },
+      onAgree = {
+        showDisclosure = false
+        viewModel.setAccessibilityControlEnabled(true)
+        AccessibilityComponentController(context).setEnabled(true)
+        openAccessibilitySettings(context)
+      },
+    )
+  }
+}
+
+@Composable
+private fun AccessibilityControlDisclosureDialog(
+  onDismiss: () -> Unit,
+  onAgree: () -> Unit,
+) {
+  AlertDialog(
+    onDismissRequest = onDismiss,
+    title = { Text(nativeString("Allow control of other apps?")) },
+    text = {
+      Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+        Text(
+          nativeString(
+            "Enabling lets OpenClaw observe and control other apps' screens when armed. Android accessibility access is required.",
+          ),
+        )
+      }
+    },
+    confirmButton = {
+      TextButton(onClick = onAgree) {
+        Text(nativeString("Enable and Open Settings"))
+      }
+    },
+    dismissButton = {
+      TextButton(onClick = onDismiss) {
+        Text(nativeString("Not Now"))
+      }
+    },
+  )
+}
+
+private fun openAccessibilitySettings(context: Context) {
+  val intent = Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+  context.startActivity(intent)
+}

--- a/apps/android/app/src/thirdParty/res/values/accessibility_strings.xml
+++ b/apps/android/app/src/thirdParty/res/values/accessibility_strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="accessibility_service_label" translatable="false">OpenClaw UI control</string>
+    <string name="accessibility_service_summary" translatable="false">Developer UI observation and control</string>
+    <string name="accessibility_service_description" translatable="false">Allows the third-party OpenClaw build to inspect and control the active app during local development.</string>
+    <string name="accessibility_dev_activity_label" translatable="false">OpenClaw Accessibility Developer</string>
+</resources>

--- a/apps/android/app/src/thirdParty/res/xml/accessibility_service_config.xml
+++ b/apps/android/app/src/thirdParty/res/xml/accessibility_service_config.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<accessibility-service xmlns:android="http://schemas.android.com/apk/res/android"
+    android:accessibilityEventTypes="typeAllMask"
+    android:accessibilityFeedbackType="feedbackGeneric"
+    android:accessibilityFlags="flagRetrieveInteractiveWindows|flagReportViewIds|flagIncludeNotImportantViews"
+    android:canPerformGestures="true"
+    android:canRetrieveWindowContent="true"
+    android:description="@string/accessibility_service_description"
+    android:notificationTimeout="0"
+    android:settingsActivity="ai.openclaw.app.accessibility.AccessibilityDevActivity"
+    android:summary="@string/accessibility_service_summary" />


### PR DESCRIPTION
## What Problem This Solves

OpenClaw's Android app has no way to observe or act on other apps' UI — the groundwork for agent-driven "computer use" on Android. This PR lands the first, self-contained slice: an `AccessibilityService`-based executor that can snapshot the active app's UI as a bounded semantic tree and perform actions on it, exercised through a local developer screen. No gateway/agent wiring yet — that follows in PR 2 (`node.invoke` commands) and PR 3 (dedicated agent tool + policy gates).

Because Google Play prohibits general-purpose/agentic use of the AccessibilityService API, all of this is **`thirdParty`-flavor only**. The Play APK must remain physically incapable of shipping it.

## Why This Change Was Made

Isolating the executor as a standalone, testable unit keeps the most safety-sensitive part (the device executor) reviewable without an LLM or remote transport in the loop, and lets the Play/thirdParty boundary be proven before any of it becomes remotely reachable.

## User Impact

- **Play build:** no change — zero accessibility code or manifest entries (proven below).
- **thirdParty build:** adds an opt-in developer screen (`AccessibilityDevActivity`, reachable from the service's entry in Accessibility settings or `adb am start`, no launcher icon) to manually observe/act. Not wired to any agent or gateway path yet.

## Design

- **Flavor isolation:** service, config XML, executor, snapshot model, and dev UI live entirely under `src/thirdParty`. `SensitiveFeatureConfig.accessibilityControlEnabled` gates it (`true` thirdParty / `false` play), following the existing SMS/Call-Log flavor-split precedent. `isAccessibilityTool` is intentionally unset (OpenClaw is not a disability tool).
- **Semantic-first executor:** `mobile.ui`-style `observe()` returns a bounded snapshot (`MAX_NODES=400`, `MAX_DEPTH=40`, per-node text cap, password/secure-field redaction, stable action vocabulary, deterministic order). `act()` performs one typed action (`activate`/`set_text`/`scroll`/`tap`/`swipe`/`global_action`/`wait`) against a **snapshot generation** — node refs are generation-scoped, never raw platform ids.
- **Closed outcome codes:** actions return a discriminated `ActionOutcomeCode` (`completed`, `accepted_but_unverified`, `target_stale`, `target_not_found`, `secure_content`, `package_changed`, `timed_out_outcome_unknown`, …). A successful `performAction()` maps to `accepted_but_unverified` (not `completed`) — the boolean means dispatch accepted, not that the app settled. Stale snapshot ids force re-observe rather than silently re-resolving; `set_text` re-checks redaction on the live node and refuses password fields.

## Evidence

Built + tested on an Android 16 (API 36) emulator.

- `./gradlew :app:assembleThirdPartyDebug :app:assemblePlayDebug :app:testThirdPartyDebugUnitTest :app:ktlintCheck` — all green.
- **Play isolation proven:** 0 accessibility refs across all merged Play manifests; 0 OpenClaw accessibility classes in the Play APK's 16 dex files (`dexdump` grep); thirdParty merged manifest contains the service.
- **Emulator (screenshots attached):** service enabled via `adb settings`, dev screen shows "Service connected" (live status), immediate `observe()` returns a snapshot, **delayed observe captured a 103-node snapshot of the Settings app** (`scroll_view` root + real per-element bounds) proving cross-app observation, and global Home dispatched from the executor moved the foreground app to the launcher.
- Unit tests cover node/depth caps, node recycling, password redaction, text truncation, action-string mapping, and stale-generation rejection.

Emulator accessibility state restored to clean after testing.

## Deferred hardening (follow-ups for PR 2/3)

Autoreview drove several rounds of executor hardening. A few edge-case items were consciously deferred as they belong to the remote/agent path or are speculative for realistic inputs:

- **Per-window staleness contract:** the UI epoch is currently global and coordinate-gesture-only (node actions use `refresh()`). A per-window/display-scoped epoch is the clean contract for the remote act path and will land with PR 2, which actually wires cross-app node execution.
- **Multi-display gesture targeting:** gestures target the default display (correct for phones). Secondary-display targeting was intentionally left out of this single-display dev slice.
- **Descendant password inheritance:** redaction marks nodes whose own `isPassword`/input-type is sensitive (how Android/Compose/WebView password fields actually expose the value). Propagating sensitivity down subtrees is a possible future guard.

## Push/land notes

- Not wired to any gateway or agent path; `thirdParty` flavor only; no launcher icon (dev Activity reached from the service's Accessibility-settings entry or `adb am start`).
- Google Play policy prohibits agentic AccessibilityService use, which is why this is flavor-isolated from the Play APK from day one.

## Off-by-default opt-in (landing is a no-op)

The AccessibilityService and dev activity are declared `android:enabled="false"`, and a thirdParty-only **"Control other apps"** toggle (persisted, default OFF) enables the components via `PackageManager.setComponentEnabledSetting` only when the user opts in (then deep-links to Accessibility settings). Verified on the emulator: on a fresh install with the toggle untouched, the service is **absent from the system installed-services list and cannot be bound** — and shell/adb cannot enable it either (only the app can, via its own context). So merging this changes nothing for existing users until they explicitly turn it on. Play flavor is a no-op; no new permissions.
