### PR TITLE
fix(onboarding): label and mask wizard inputs

### DIFF
--- a/extensions/matrix/src/onboarding.test.ts
+++ b/extensions/matrix/src/onboarding.test.ts
@@ -256,7 +256,11 @@ describe("matrix onboarding", () => {
     expect(matrixConfig?.accessToken).toBe("ops-token");
   });
 
-  it.each([
+  it.each<{
+    authMode: string;
+    secretPrompt: string;
+    text: Record<string, string>;
+  }>([
     {
       authMode: "token",
       secretPrompt: "Matrix access token",
@@ -264,7 +268,7 @@ describe("matrix onboarding", () => {
         "Matrix homeserver URL": "https://matrix.example.org",
         "Matrix access token": "test-token",
         "Matrix device name (optional)": "",
-      },
+      } satisfies Record<string, string>,
     },
     {
       authMode: "password",
@@ -274,7 +278,7 @@ describe("matrix onboarding", () => {
         "Matrix user ID": "@test:example.org",
         "Matrix password": "test-password",
         "Matrix device name (optional)": "",
-      },
+      } satisfies Record<string, string>,
     },
   ])("marks the $secretPrompt prompt as sensitive", async ({ authMode, secretPrompt, text }) => {
     installMatrixTestRuntime();

--- a/extensions/matrix/src/onboarding.test.ts
+++ b/extensions/matrix/src/onboarding.test.ts
@@ -256,6 +256,49 @@ describe("matrix onboarding", () => {
     expect(matrixConfig?.accessToken).toBe("ops-token");
   });
 
+  it.each([
+    {
+      authMode: "token",
+      secretPrompt: "Matrix access token",
+      text: {
+        "Matrix homeserver URL": "https://matrix.example.org",
+        "Matrix access token": "test-token",
+        "Matrix device name (optional)": "",
+      },
+    },
+    {
+      authMode: "password",
+      secretPrompt: "Matrix password",
+      text: {
+        "Matrix homeserver URL": "https://matrix.example.org",
+        "Matrix user ID": "@test:example.org",
+        "Matrix password": "test-password",
+        "Matrix device name (optional)": "",
+      },
+    },
+  ])("marks the $secretPrompt prompt as sensitive", async ({ authMode, secretPrompt, text }) => {
+    installMatrixTestRuntime();
+
+    const prompter = createMatrixWizardPrompter({
+      select: { "Matrix auth method": authMode },
+      text,
+      confirm: { "Enable end-to-end encryption (E2EE)?": false },
+      onConfirm: async () => false,
+    });
+
+    const result = await runMatrixInteractiveConfigure({
+      cfg: {} as CoreConfig,
+      prompter,
+    });
+
+    expect(result).not.toBe("skip");
+    const secretCall = vi
+      .mocked(prompter.text)
+      .mock.calls.find(([options]) => options.message === secretPrompt);
+    expect(secretCall?.[0]).toMatchObject({ message: secretPrompt, sensitive: true });
+    expect(secretCall?.[0]).not.toHaveProperty("initialValue");
+  });
+
   it("preserves SecretRef access tokens when keeping existing credentials", async () => {
     installMatrixTestRuntime();
 

--- a/extensions/matrix/src/onboarding.ts
+++ b/extensions/matrix/src/onboarding.ts
@@ -592,6 +592,7 @@ async function runMatrixConfigure(params: {
         normalizeStringifiedOptionalString(
           await params.prompter.text({
             message: "Matrix access token",
+            sensitive: true,
             validate: (value) => (normalizeOptionalString(value) ? undefined : "Required"),
           }),
         ) ?? "";
@@ -622,6 +623,7 @@ async function runMatrixConfigure(params: {
         normalizeStringifiedOptionalString(
           await params.prompter.text({
             message: "Matrix password",
+            sensitive: true,
             validate: (value) => (normalizeOptionalString(value) ? undefined : "Required"),
           }),
         ) ?? "";

--- a/ui/src/pages/channels/wizard-view.test.ts
+++ b/ui/src/pages/channels/wizard-view.test.ts
@@ -19,6 +19,54 @@ describe("renderChannelWizard", () => {
     delete (document as unknown as { execCommand?: unknown }).execCommand;
   });
 
+  it.each([
+    { sensitive: false, expectedType: "text" },
+    { sensitive: true, expectedType: "password" },
+  ])(
+    "labels a $expectedType input with the visible text-step message",
+    ({ sensitive, expectedType }) => {
+      const container = document.createElement("div");
+      document.body.append(container);
+      render(
+        renderChannelWizard({
+          wizard: {
+            phase: "step",
+            channel: "matrix",
+            step: {
+              id: "account-id",
+              type: "text",
+              message: "New Matrix account id",
+              sensitive,
+            },
+            stepIndex: 1,
+            busy: false,
+            validationError: null,
+          },
+          channelLabel: (channelId) => channelId,
+          multiselectValues: [],
+          onToggleMultiselect: vi.fn(),
+          onAnswer: vi.fn(),
+          onClose: vi.fn(),
+          whatsappQrDataUrl: null,
+          whatsappMessage: null,
+          whatsappConnected: null,
+          whatsappBusy: false,
+          onWhatsAppStart: vi.fn(),
+          onWhatsAppWait: vi.fn(),
+        }),
+        container,
+      );
+
+      const input = container.querySelector<HTMLInputElement>("#channel-wizard-text-input");
+      const label = container.querySelector<HTMLLabelElement>(
+        'label[for="channel-wizard-text-input"]',
+      );
+      expect(label?.textContent).toBe("New Matrix account id");
+      expect(input?.type).toBe(expectedType);
+      expect(input?.labels).toContain(label);
+    },
+  );
+
   it("copies setup text through the plain-HTTP clipboard fallback", async () => {
     vi.stubGlobal("navigator", {});
     let copiedText: string | undefined;

--- a/ui/src/pages/channels/wizard-view.ts
+++ b/ui/src/pages/channels/wizard-view.ts
@@ -157,8 +157,11 @@ function renderTextStep(step: ChannelWizardStep, props: ChannelWizardViewProps) 
   };
   return html`
     <form @submit=${submit}>
-      <div class="channels-wizard__message">${step.message ?? ""}</div>
+      <div class="channels-wizard__message">
+        <label for="channel-wizard-text-input">${step.message ?? ""}</label>
+      </div>
       <input
+        id="channel-wizard-text-input"
         class="input"
         style="margin-top: 10px; width: 100%;"
         name="wizard-text"

--- a/ui/src/pages/model-setup/view.test.ts
+++ b/ui/src/pages/model-setup/view.test.ts
@@ -363,15 +363,33 @@ describe("renderModelSetup", () => {
     expect(document.querySelector("textarea")).toBeNull();
   });
 
-  it("renders sensitive text, select, and confirm steps", () => {
-    const sensitive = wizardStep(
-      { id: "token", type: "text", sensitive: true, placeholder: "Paste token" },
-      "secret",
-    );
-    expect(sensitive.querySelector<HTMLInputElement>('input[name="wizard-text"]')?.type).toBe(
-      "password",
-    );
+  it.each([
+    { sensitive: false, expectedType: "text" },
+    { sensitive: true, expectedType: "password" },
+  ])(
+    "labels a $expectedType input with the visible text-step message",
+    ({ sensitive, expectedType }) => {
+      const container = wizardStep(
+        {
+          id: "access-value",
+          type: "text",
+          message: "Provider access value",
+          sensitive,
+          placeholder: "Enter value",
+        },
+        "initial value",
+      );
+      const input = container.querySelector<HTMLInputElement>("#model-setup-wizard-text-input");
+      const label = container.querySelector<HTMLLabelElement>(
+        'label[for="model-setup-wizard-text-input"]',
+      );
+      expect(label?.textContent).toBe("Provider access value");
+      expect(input?.type).toBe(expectedType);
+      expect(input?.labels).toContain(label);
+    },
+  );
 
+  it("renders select and confirm steps", () => {
     const select = wizardStep(
       {
         id: "account",

--- a/ui/src/pages/model-setup/wizard-view.ts
+++ b/ui/src/pages/model-setup/wizard-view.ts
@@ -78,9 +78,12 @@ function renderTextStep(props: WizardViewProps) {
       }}
     >
       ${step.message
-        ? html`<div class="model-setup-wizard__message">${step.message}</div>`
+        ? html`<div class="model-setup-wizard__message">
+            <label for="model-setup-wizard-text-input">${step.message}</label>
+          </div>`
         : nothing}
       <input
+        id="model-setup-wizard-text-input"
         class="input"
         name="wizard-text"
         type=${step.sensitive ? "password" : "text"}


### PR DESCRIPTION
## What Problem This Solves

Fixes two onboarding wizard accessibility and credential-entry problems:

- generic channel/model text steps displayed prompt text but exposed the actual input as an unnamed textbox to assistive technology;
- Matrix access-token and password prompts did not mark themselves sensitive, so the browser rendered them as ordinary visible text fields.

## Why This Change Was Made

The generic channel and model wizard renderers now use semantic label/input associations with distinct component-specific ids. Matrix owns its credential semantics and now marks access-token and password prompts `sensitive: true`, allowing the existing generic renderer to choose password masking without hardcoded Matrix strings in the UI.

This PR is AI-assisted. I reviewed the full diff, drove the real isolated Matrix wizard, and verified the accessibility tree and focused tests.

## User Impact

Screen readers now announce wizard text fields by their visible prompt, including “New Matrix account id” and provider setup fields. Matrix access tokens and passwords are masked and use the existing sensitive-field autocomplete policy. Non-sensitive fields, validation, initial values, submit behavior, and visual layout are unchanged.

## Evidence

### Visual proof

The visual layout intentionally remains unchanged; the key account-id improvement is semantic labeling in the accessibility tree.

| Before | After |
| --- | --- |
| ![Before: Matrix account input](https://gist.githubusercontent.com/steipete/1b57d58845c2f3fbb709425aba64071f/raw/openclaw-before-account.svg) | ![After: Matrix account input](https://gist.githubusercontent.com/steipete/1b57d58845c2f3fbb709425aba64071f/raw/openclaw-after-account.svg) |

Real Chrome accessibility-tree proof:

- Before: visible `New Matrix account id` text plus unnamed `textbox`.
- After: `textbox "New Matrix account id"`.
- After a Gateway restart loading the updated Matrix plugin: `Matrix access token` and `Matrix password` are named password inputs with autocomplete off. No real credentials were entered or submitted.

Focused proof on the final branch:

```text
fnm exec --using 24.15.0 -- node scripts/run-vitest.mjs \
  ui/src/pages/channels/wizard-view.test.ts \
  ui/src/pages/model-setup/view.test.ts \
  extensions/matrix/src/onboarding.test.ts

39 tests passed across 2 Vitest shards.
```

Additional proof:

- Full extension-test typecheck passed after explicitly typing the Matrix parameterized fixture rows.
- Fresh autoreview: clean for the six-file behavior patch and clean for the test-only type correction.
- Blacksmith Testbox could not start because its workflow fetch was rate-limited before lease creation (HTTP 429; no remote code ran).
- Trusted-source fallback: the complete changed gate passed locally using the exact `HEAD^..HEAD` base, followed by a full `pnpm build`.
- Control UI i18n verify, UI/extensions/core-test typechecks, UI/extensions lint, import-cycle checks, and full build all passed.
- `git diff --check` passed.
