### PR TITLE
fix: plugins list JSON no longer reports empty harness ids

### DIFF
--- a/src/cli/plugins-list-command.test.ts
+++ b/src/cli/plugins-list-command.test.ts
@@ -45,7 +45,14 @@ describe("runPluginsListCommand", () => {
         workspaceDir: "/workspace",
         registrySource: "config",
         registryDiagnostics: [],
-        plugins: [{ id: "demo", enabled: true }],
+        plugins: [
+          {
+            id: "demo",
+            enabled: true,
+            commands: ["demo"],
+            agentHarnessIds: ["runtime-only"],
+          },
+        ],
         diagnostics: [],
       }),
     }));
@@ -102,7 +109,7 @@ describe("runPluginsListCommand", () => {
           source: "config",
           diagnostics: [],
         },
-        plugins: [{ id: "demo", enabled: true }],
+        plugins: [{ id: "demo", enabled: true, commands: ["demo"] }],
         diagnostics: [],
       },
     ]);

--- a/src/cli/plugins-list-command.ts
+++ b/src/cli/plugins-list-command.ts
@@ -1,5 +1,6 @@
 // `openclaw plugins list`: builds registry reports and defers terminal-only formatting modules.
 import { getRuntimeConfig } from "../config/config.js";
+import type { PluginRecord } from "../plugins/registry.js";
 import { defaultRuntime, writeRuntimeJson, type RuntimeEnv } from "../runtime.js";
 import { quietPluginJsonLogger } from "./plugins-json-logger.js";
 
@@ -9,6 +10,13 @@ export type PluginsListOptions = {
   enabled?: boolean;
   verbose?: boolean;
 };
+
+function toPluginListJsonRecord(plugin: PluginRecord): Omit<PluginRecord, "agentHarnessIds"> {
+  // Snapshot listing never imports plugin runtimes, so it cannot observe harness registrations.
+  // Omit the field instead of serializing the registry-compatible empty placeholder.
+  const { agentHarnessIds: _agentHarnessIds, ...record } = plugin;
+  return record;
+}
 
 async function loadHumanListModules() {
   const [sourceDisplay, table, themeModule, commandFormat, listFormat] = await Promise.all([
@@ -50,7 +58,7 @@ export async function runPluginsListCommand(
         source: report.registrySource,
         diagnostics: report.registryDiagnostics,
       },
-      plugins: list,
+      plugins: list.map(toPluginListJsonRecord),
       diagnostics: report.diagnostics,
     };
     writeRuntimeJson(runtime, payload);


### PR DESCRIPTION
Closes #112234

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users consuming `openclaw plugins list --json` would receive `agentHarnessIds: []` and could conclude that a discovered plugin registers no agent harness, even though the fast metadata snapshot does not execute plugin runtimes and cannot observe harness registration.

## Why This Change Was Made

The JSON serializer now omits `agentHarnessIds` from metadata-only list records while preserving manifest-backed fields such as `commands`. The internal registry-compatible placeholder remains available to snapshot consumers, and the list path stays lazy; this change does not infer runtime registration from activation hints or import plugin code.

Runtime-backed inspection remains available through `openclaw plugins inspect <id> --runtime --json` when callers need observed runtime registrations.

## User Impact

Scripts and operators no longer receive a misleading negative harness result from `plugins list --json`. The unobservable `agentHarnessIds` field is removed from this metadata-only JSON surface; all other plugin record fields are unchanged.

## Evidence

- `node scripts/run-vitest.mjs src/cli/plugins-list-command.test.ts src/cli/plugins-cli.list.test.ts` — 21 tests passed before and after the final rebase.
- `node scripts/check-changed.mjs -- src/cli/plugins-list-command.ts src/cli/plugins-list-command.test.ts` — remote Blacksmith Testbox gate passed core/test typechecks, lint with 0 warnings/errors, formatting, plugin boundaries, import-cycle checks, and repository guards: https://github.com/openclaw/openclaw/actions/runs/29815809078
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output` — clean, no accepted/actionable findings; patch correctness confidence 0.96.
- `git diff --check origin/main...HEAD` — passed.
