### PR TITLE
fix: use OS home for cached snapshot tilde paths

### DIFF
--- a/src/commands/doctor-session-snapshots.test-support.ts
+++ b/src/commands/doctor-session-snapshots.test-support.ts
@@ -18,7 +18,6 @@ type TestApi = {
     store: Record<string, SessionEntry>;
     bundledSkillsDir: string | undefined;
     pathExists?: (filePath: string) => boolean;
-    homeDir?: string;
     env?: NodeJS.ProcessEnv;
   }): Array<{
     sessionKey: string;

--- a/src/commands/doctor-session-snapshots.test.ts
+++ b/src/commands/doctor-session-snapshots.test.ts
@@ -234,29 +234,33 @@ describe("doctor session snapshot stale runtime metadata", () => {
     });
   });
 
-  it("expands home-relative cached bundled skill locations before classifying them", () => {
+  it("uses the OS home for cached OCM paths when OPENCLAW_HOME differs", () => {
     const homeDir = path.join(root, "home");
-    const stalePath = "~/old-runtime/node_modules/openclaw/skills/doctor/SKILL.md";
+    const currentBundledSkillsDir = path.join(homeDir, ".ocm/current/node_modules/openclaw/skills");
+    const expectedPath = path.join(currentBundledSkillsDir, "doctor", "SKILL.md");
+    const currentPath = "~/.ocm/current/node_modules/openclaw/skills/doctor/SKILL.md";
+    const stalePath = "~/.ocm/old/node_modules/openclaw/skills/doctor/SKILL.md";
 
     const findings = scanSessionStoreForStaleRuntimeSnapshotPaths({
-      bundledSkillsDir,
-      env: { HOME: homeDir },
+      bundledSkillsDir: currentBundledSkillsDir,
+      env: { HOME: homeDir, OPENCLAW_HOME: path.join(root, "ocm-profile") },
       store: {
-        "agent:home": sessionEntry({
-          skillsSnapshot: {
-            prompt: skillPrompt(stalePath),
-            skills: [{ name: "doctor" }],
-          },
+        "agent:current": sessionEntry({
+          skillsSnapshot: { prompt: skillPrompt(currentPath), skills: [{ name: "doctor" }] },
+        }),
+        "agent:stale": sessionEntry({
+          skillsSnapshot: { prompt: skillPrompt(stalePath), skills: [{ name: "doctor" }] },
         }),
       },
+      pathExists: (filePath) => filePath === expectedPath,
     });
 
     expect(findings).toEqual([
       {
-        sessionKey: "agent:home",
+        sessionKey: "agent:stale",
         field: "skillsSnapshot.prompt",
         cachedPath: stalePath,
-        expectedPath: path.join(bundledSkillsDir, "doctor", "SKILL.md"),
+        expectedPath,
       },
     ]);
   });

--- a/src/commands/doctor-session-snapshots.ts
+++ b/src/commands/doctor-session-snapshots.ts
@@ -214,12 +214,11 @@ function resolveExpectedBundledSkillPath(params: {
   cachedPath: string;
   bundledSkillsDir: string;
   pathExists: (filePath: string) => boolean;
-  homeDir?: string;
   env?: NodeJS.ProcessEnv;
 }): string | undefined {
   // Snapshot paths use shell `~` semantics. OPENCLAW_HOME may point at an isolated
   // runtime profile, so expanding against it would make the active runtime look stale.
-  const osHomeDir = params.homeDir ?? resolveOsHomeDir(params.env);
+  const osHomeDir = resolveOsHomeDir(params.env);
   const expandedCachedPath = osHomeDir
     ? expandHomePrefix(params.cachedPath, { home: osHomeDir })
     : params.cachedPath;
@@ -265,7 +264,6 @@ function scanSessionStoreForStaleRuntimeSnapshotPaths(params: {
   store: Record<string, SessionEntry>;
   bundledSkillsDir: string | undefined;
   pathExists?: (filePath: string) => boolean;
-  homeDir?: string;
   env?: NodeJS.ProcessEnv;
 }): StaleSessionSnapshotPathFinding[] {
   const bundledSkillsDir = params.bundledSkillsDir?.trim();
@@ -284,7 +282,6 @@ function scanSessionStoreForStaleRuntimeSnapshotPaths(params: {
         cachedPath: cached.path,
         bundledSkillsDir,
         pathExists,
-        homeDir: params.homeDir,
         env: params.env,
       });
       if (!expectedPath) {

--- a/src/commands/doctor-session-snapshots.ts
+++ b/src/commands/doctor-session-snapshots.ts
@@ -10,7 +10,7 @@ import { resolveAllAgentSessionStoreTargetsSync } from "../config/sessions/targe
 import type { SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { HealthFinding, HealthRepairEffect } from "../flows/health-checks.js";
-import { expandHomePrefix } from "../infra/home-dir.js";
+import { expandHomePrefix, resolveOsHomeDir } from "../infra/home-dir.js";
 import { writeTextAtomic } from "../infra/json-files.js";
 import { resolveOpenClawPackageRootSync } from "../infra/openclaw-root.js";
 import { resolveBundledSkillsDir } from "../skills/loading/bundled-dir.js";
@@ -217,10 +217,12 @@ function resolveExpectedBundledSkillPath(params: {
   homeDir?: string;
   env?: NodeJS.ProcessEnv;
 }): string | undefined {
-  const expandedCachedPath = expandHomePrefix(params.cachedPath, {
-    home: params.homeDir,
-    env: params.env,
-  });
+  // Snapshot paths use shell `~` semantics. OPENCLAW_HOME may point at an isolated
+  // runtime profile, so expanding against it would make the active runtime look stale.
+  const osHomeDir = params.homeDir ?? resolveOsHomeDir(params.env);
+  const expandedCachedPath = osHomeDir
+    ? expandHomePrefix(params.cachedPath, { home: osHomeDir })
+    : params.cachedPath;
   if (!isAbsolutePathLike(expandedCachedPath)) {
     return undefined;
   }


### PR DESCRIPTION
## What Problem This Solves

Under OCM, cached bundled-skill paths such as `~/.ocm/...` use the OS user's home directory, while `OPENCLAW_HOME` can point at an isolated profile root. Expanding those cached paths with OpenClaw-home semantics makes an active runtime path compare as if it were outside the current bundled-skills directory.

## Why This Change Was Made

`resolveExpectedBundledSkillPath()` now resolves the OS home with `resolveOsHomeDir()` and supplies it explicitly when expanding a cached path's leading `~`. The bundled-skills root, runtime-path classification, and expected replacement-path logic are unchanged.

The goal is to stop doctor from reporting an equivalent current OCM runtime path as stale without weakening detection of paths from inactive runtimes.

## User Impact

Doctor no longer recommends cleaning up an active OCM bundled-skill path solely because `OPENCLAW_HOME` differs from `HOME`. Cached paths from an actually old runtime remain flagged.

## Evidence

- Before fix: the regression reported both the current and old OCM paths as stale.
- `pnpm test src/commands/doctor-session-snapshots.test.ts` — 24/24 passed on Blacksmith Testbox.
- `pnpm check:changed -- src/commands/doctor-session-snapshots.ts src/commands/doctor-session-snapshots.test.ts` — passed on Blacksmith Testbox, including formatting, production/test typechecks, lint, and guards.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` — clean; no accepted/actionable findings.
- The final rebase onto current `main` preserved the commit patch ID exactly.

AI-assisted: implementation and validation were performed with Codex; the patch was reviewed and understood before submission.
