### PR TITLE
feat(android,gateway): mobile.ui node commands (PR 2/3)

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -715,7 +715,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 176,
+      "line": 177,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Resolution outcome unknown. Actions stay disabled until the Gateway record is verified.",
       "surface": "android",
@@ -723,7 +723,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 178,
+      "line": 179,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "The Gateway still shows this approval as pending. Review it before trying again.",
       "surface": "android",
@@ -731,7 +731,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 180,
+      "line": 181,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load approval details. Refresh and try again.",
       "surface": "android",
@@ -739,7 +739,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 182,
+      "line": 183,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load approvals.",
       "surface": "android",
@@ -747,7 +747,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 184,
+      "line": 185,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not resolve approval. Refresh and try again.",
       "surface": "android",
@@ -755,7 +755,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 281,
+      "line": 282,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Device approved.",
       "surface": "android",
@@ -763,7 +763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 282,
+      "line": 283,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Pairing request rejected.",
       "surface": "android",
@@ -771,7 +771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 283,
+      "line": 284,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Paired device removed.",
       "surface": "android",
@@ -779,7 +779,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 344,
+      "line": 345,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Proposal applied.",
       "surface": "android",
@@ -787,7 +787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 344,
+      "line": 345,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "apply",
       "surface": "android",
@@ -795,7 +795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 345,
+      "line": 346,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Proposal rejected.",
       "surface": "android",
@@ -803,7 +803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 345,
+      "line": 346,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "reject",
       "surface": "android",
@@ -811,7 +811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 346,
+      "line": 347,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Proposal quarantined.",
       "surface": "android",
@@ -819,7 +819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 346,
+      "line": 347,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "quarantine",
       "surface": "android",
@@ -827,7 +827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 353,
+      "line": 354,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "unknown",
       "surface": "android",
@@ -835,7 +835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 354,
+      "line": 355,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway returned status '$statusLabel' after ${action.verb}.",
       "surface": "android",
@@ -843,7 +843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 362,
+      "line": 363,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not ${action.verb} Skill Workshop proposal.",
       "surface": "android",
@@ -851,7 +851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 544,
+      "line": 545,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connected (node offline)",
       "surface": "android",
@@ -859,7 +859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 545,
+      "line": 546,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connected (operator offline)",
       "surface": "android",
@@ -867,7 +867,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 547,
+      "line": 548,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Reconnecting…",
       "surface": "android",
@@ -875,7 +875,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 555,
+      "line": 556,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connected (operator: $operator)",
       "surface": "android",
@@ -883,7 +883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2220,
+      "line": 2231,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This automation already has a queued run.",
       "surface": "android",
@@ -891,7 +891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2250,
+      "line": 2261,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation run queued.",
       "surface": "android",
@@ -899,7 +899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2250,
+      "line": 2261,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation started.",
       "surface": "android",
@@ -907,7 +907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2263,
+      "line": 2274,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway rejected the automation run.",
       "surface": "android",
@@ -915,7 +915,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2294,
+      "line": 2305,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation enabled.",
       "surface": "android",
@@ -923,7 +923,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2294,
+      "line": 2305,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation paused.",
       "surface": "android",
@@ -931,7 +931,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2316,
+      "line": 2327,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This automation changed on the gateway. Review the latest version before saving again.",
       "surface": "android",
@@ -939,7 +939,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2322,
+      "line": 2333,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation updated.",
       "surface": "android",
@@ -947,7 +947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2337,
+      "line": 2348,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation deleted.",
       "surface": "android",
@@ -955,7 +955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2587,
+      "line": 2598,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Node offline. Reconnect and retry.",
       "surface": "android",
@@ -963,7 +963,7 @@
     },
     {
       "kind": "ui-named-argument-concatenated",
-      "line": 2598,
+      "line": 2609,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Restore canvas now for session=$sessionKey source=$source. If existing A2UI state exists, replay it immediately. If not, create and render a compact mobile-friendly dashboard in Canvas.",
       "surface": "android",
@@ -971,7 +971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2619,
+      "line": 2630,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed to request restore. Tap to retry.",
       "surface": "android",
@@ -979,7 +979,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2630,
+      "line": 2641,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "No canvas update yet. Tap to retry.",
       "surface": "android",
@@ -987,7 +987,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3707,
+      "line": 3725,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect to a Gateway to save wake words",
       "surface": "android",
@@ -995,7 +995,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3735,
+      "line": 3753,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Wake words saved",
       "surface": "android",
@@ -1003,7 +1003,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3744,
+      "line": 3762,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not save wake words",
       "surface": "android",
@@ -1011,7 +1011,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4455,
+      "line": 4473,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: no secure gateway endpoint was detected. Enable gateway TLS or Tailscale Serve, or use a trusted private LAN address with Unencrypted selected.",
       "surface": "android",
@@ -1019,7 +1019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4459,
+      "line": 4477,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: secure endpoint reached, but TLS fingerprint verification timed out. Check Tailscale Serve or gateway TLS and retry.",
       "surface": "android",
@@ -1027,7 +1027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4463,
+      "line": 4481,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "surface": "android",
@@ -1035,7 +1035,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 4513,
+      "line": 4531,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connecting…",
       "surface": "android",
@@ -1043,7 +1043,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 4723,
+      "line": 4741,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Offline",
       "surface": "android",
@@ -1051,7 +1051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5465,
+      "line": 5483,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load provider catalog.",
       "surface": "android",
@@ -1059,7 +1059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5496,
+      "line": 5514,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Update your Gateway to view provider model config.",
       "surface": "android",
@@ -1067,7 +1067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5498,
+      "line": 5516,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load provider model config.",
       "surface": "android",
@@ -1075,7 +1075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5514,
+      "line": 5532,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Provider models loaded, but readiness is unavailable.",
       "surface": "android",
@@ -1083,7 +1083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5601,
+      "line": 5619,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load automations.",
       "surface": "android",
@@ -1091,7 +1091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5687,
+      "line": 5705,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to inspect automations.",
       "surface": "android",
@@ -1099,7 +1099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5697,
+      "line": 5715,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway returned an invalid automation.",
       "surface": "android",
@@ -1107,7 +1107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5701,
+      "line": 5719,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load automation.",
       "surface": "android",
@@ -1115,7 +1115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5713,
+      "line": 5731,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to inspect automation run history.",
       "surface": "android",
@@ -1123,7 +1123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5744,
+      "line": 5762,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load automation run history.",
       "surface": "android",
@@ -1131,7 +1131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5761,
+      "line": 5779,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron changes require operator.admin access.",
       "surface": "android",
@@ -1139,7 +1139,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5770,
+      "line": 5788,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to manage automations.",
       "surface": "android",
@@ -1147,7 +1147,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5782,
+      "line": 5800,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Another cron action is still finishing.",
       "surface": "android",
@@ -1155,7 +1155,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5829,
+      "line": 5847,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron action failed.",
       "surface": "android",
@@ -1163,7 +1163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5956,
+      "line": 5974,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load usage.",
       "surface": "android",
@@ -1171,7 +1171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5991,
+      "line": 6009,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load skills.",
       "surface": "android",
@@ -1179,7 +1179,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6004,
+      "line": 6022,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to update skills.",
       "surface": "android",
@@ -1187,7 +1187,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6008,
+      "line": 6026,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This gateway connection needs operator.admin to update skills.",
       "surface": "android",
@@ -1195,7 +1195,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6023,
+      "line": 6041,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not disable skill.",
       "surface": "android",
@@ -1203,7 +1203,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6023,
+      "line": 6041,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not enable skill.",
       "surface": "android",
@@ -1211,7 +1211,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6041,
+      "line": 6059,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to search ClawHub skills.",
       "surface": "android",
@@ -1219,7 +1219,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6087,
+      "line": 6105,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not search ClawHub skills.",
       "surface": "android",
@@ -1227,7 +1227,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6100,
+      "line": 6118,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to inspect ClawHub skills.",
       "surface": "android",
@@ -1235,7 +1235,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6133,
+      "line": 6151,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "ClawHub did not return an installable version for ${skill.slug}.",
       "surface": "android",
@@ -1243,7 +1243,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6149,
+      "line": 6167,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load ClawHub details for ${skill.slug}.",
       "surface": "android",
@@ -1251,7 +1251,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6165,
+      "line": 6183,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to install ClawHub skills.",
       "surface": "android",
@@ -1259,7 +1259,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6181,
+      "line": 6199,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This gateway connection needs operator.admin to install ClawHub skills.",
       "surface": "android",
@@ -1267,7 +1267,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6271,
+      "line": 6289,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Installed $slug.",
       "surface": "android",
@@ -1275,7 +1275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6278,
+      "line": 6296,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not install ${slug} from ClawHub.",
       "surface": "android",
@@ -1283,7 +1283,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6318,
+      "line": 6336,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to load Skill Workshop proposals.",
       "surface": "android",
@@ -1291,7 +1291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6358,
+      "line": 6376,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load Skill Workshop proposals.",
       "surface": "android",
@@ -1299,7 +1299,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6378,
+      "line": 6396,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to inspect Skill Workshop proposals.",
       "surface": "android",
@@ -1307,7 +1307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6430,
+      "line": 6448,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not inspect Skill Workshop proposal.",
       "surface": "android",
@@ -1315,7 +1315,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6450,
+      "line": 6468,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Skill Workshop proposal actions require operator.admin scope.",
       "surface": "android",
@@ -1323,7 +1323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6455,
+      "line": 6473,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to update Skill Workshop proposals.",
       "surface": "android",
@@ -1331,7 +1331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6645,
+      "line": 6663,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not verify the device pairing change. Refresh and try again.",
       "surface": "android",
@@ -1339,7 +1339,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 6727,
+      "line": 6745,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connected",
       "surface": "android",
@@ -1347,7 +1347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6757,
+      "line": 6775,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load nodes and devices.",
       "surface": "android",
@@ -1355,7 +1355,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7415,
+      "line": 7433,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load channels.",
       "surface": "android",
@@ -1363,7 +1363,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7445,
+      "line": 7463,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load dreaming.",
       "surface": "android",
@@ -1371,7 +1371,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7482,
+      "line": 7500,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load gateway logs.",
       "surface": "android",
@@ -1379,7 +1379,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7951,
+      "line": 7969,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "One time",
       "surface": "android",
@@ -1387,7 +1387,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7960,
+      "line": 7978,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron",
       "surface": "android",
@@ -1395,7 +1395,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7961,
+      "line": 7979,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Scheduled",
       "surface": "android",
@@ -1403,7 +1403,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7969,
+      "line": 7987,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Every ${days}d",
       "surface": "android",
@@ -1411,7 +1411,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7970,
+      "line": 7988,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Every ${hours}h",
       "surface": "android",
@@ -1419,7 +1419,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7971,
+      "line": 7989,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Every ${minutes}m",
       "surface": "android",
@@ -1427,7 +1427,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7972,
+      "line": 7990,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Repeating",
       "surface": "android",
@@ -1435,7 +1435,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7988,
+      "line": 8006,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "No prompt",
       "surface": "android",
@@ -1443,7 +1443,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8005,
+      "line": 8023,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway",
       "surface": "android",
@@ -1451,7 +1451,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8013,
+      "line": 8031,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connected to $gatewayLabel",
       "surface": "android",
@@ -1459,7 +1459,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8014,
+      "line": 8032,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Your agents are ready",
       "surface": "android",
@@ -1467,7 +1467,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8016,
+      "line": 8034,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This phone stays dormant until the gateway needs it, then wakes, syncs, and goes back to sleep.",
       "surface": "android",
@@ -1475,7 +1475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8020,
+      "line": 8038,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Selected on this phone",
       "surface": "android",
@@ -1483,7 +1483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8023,
+      "line": 8041,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "The overview refreshes on reconnect and when this screen opens.",
       "surface": "android",
@@ -1491,7 +1491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8028,
+      "line": 8046,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Reconnecting",
       "surface": "android",
@@ -1499,7 +1499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8029,
+      "line": 8047,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "OpenClaw is syncing back up",
       "surface": "android",
@@ -1507,7 +1507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8031,
+      "line": 8049,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "The gateway session is coming back online. Agent shortcuts should settle automatically in a moment.",
       "surface": "android",
@@ -1515,7 +1515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8035,
+      "line": 8053,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway session in progress",
       "surface": "android",
@@ -1523,7 +1523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8038,
+      "line": 8056,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "If the gateway is reachable, reconnect should complete without intervention.",
       "surface": "android",
@@ -1531,7 +1531,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8043,
+      "line": 8061,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Welcome to OpenClaw",
       "surface": "android",
@@ -1539,7 +1539,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8044,
+      "line": 8062,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Your phone stays quiet until it is needed",
       "surface": "android",
@@ -1547,7 +1547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8046,
+      "line": 8064,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Pair this device to your gateway to wake it only for real work, keep a live agent overview handy, and avoid battery-draining background loops.",
       "surface": "android",
@@ -1555,7 +1555,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8050,
+      "line": 8068,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect to load your agents",
       "surface": "android",
@@ -1563,7 +1563,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8053,
+      "line": 8071,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "When connected, the gateway can wake the phone with a silent push instead of holding an always-on session.",
       "surface": "android",
@@ -1571,7 +1571,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8085,
+      "line": 8103,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Main",
       "surface": "android",
@@ -1579,7 +1579,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8100,
+      "line": 8118,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Active on this phone",
       "surface": "android",
@@ -1587,7 +1587,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8101,
+      "line": 8119,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Default agent",
       "surface": "android",
@@ -1595,7 +1595,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8102,
+      "line": 8120,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Ready",
       "surface": "android",
@@ -1603,7 +1603,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8757,
+      "line": 8775,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Dream",
       "surface": "android",

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -78,6 +78,7 @@ import ai.openclaw.app.node.DeviceNotificationListenerService
 import ai.openclaw.app.node.InvokeDispatcher
 import ai.openclaw.app.node.LocationCaptureManager
 import ai.openclaw.app.node.LocationHandler
+import ai.openclaw.app.node.MobileUiHandler
 import ai.openclaw.app.node.MotionHandler
 import ai.openclaw.app.node.NodePresenceAliveBeacon
 import ai.openclaw.app.node.NotificationsHandler
@@ -917,6 +918,9 @@ class NodeRuntime private constructor(
       sms = sms,
     )
 
+  private val mobileUiHandler = MobileUiHandler()
+  private var lastMobileUiConnected = mobileUiHandler.isConnected.value
+
   private val a2uiHandler: A2UIHandler =
     A2UIHandler(
       canvas = canvas,
@@ -940,6 +944,9 @@ class NodeRuntime private constructor(
         voiceWakeManager.isAvailable &&
           hasRecordAudioPermission() &&
           isVoiceWakeWordsReadyForCurrentGateway()
+      },
+      mobileUiAvailable = {
+        SensitiveFeatureConfig.accessibilityControlEnabled && mobileUiHandler.isConnected.value
       },
       inlineWidgetsAvailable = { WebViewFeature.isFeatureSupported(WebViewFeature.MULTI_PROFILE) },
       manualTls = { endpoint ->
@@ -976,6 +983,7 @@ class NodeRuntime private constructor(
       a2uiHandler = a2uiHandler,
       debugHandler = debugHandler,
       callLogHandler = callLogHandler,
+      mobileUiHandler = mobileUiHandler,
       isForeground = { _isForeground.value },
       cameraEnabled = { cameraEnabled.value },
       locationEnabled = { locationMode.value != LocationMode.Off },
@@ -995,6 +1003,9 @@ class NodeRuntime private constructor(
       onCanvasA2uiReset = { _canvasA2uiHydrated.value = false },
       motionActivityAvailable = { motionHandler.isActivityAvailable() },
       motionPedometerAvailable = { motionHandler.isPedometerAvailable() },
+      mobileUiAvailable = {
+        SensitiveFeatureConfig.accessibilityControlEnabled && mobileUiHandler.isConnected.value
+      },
     )
 
   /**
@@ -2879,6 +2890,13 @@ class NodeRuntime private constructor(
 
     if (mode == NodeRuntimeMode.Live) {
       invalidateVoiceWakeWordsForGateway()
+      scope.launch {
+        mobileUiHandler.isConnected.collect { connected ->
+          if (connected == lastMobileUiConnected) return@collect
+          lastMobileUiConnected = connected
+          refreshNodeSurfaceAfterSettingsChange()
+        }
+      }
     }
     reconcileVoiceWakeCaptureSuppression()
     voiceWakeManager.setForeground(initialForeground)

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/ConnectionManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/ConnectionManager.kt
@@ -27,6 +27,7 @@ class ConnectionManager(
   private val photosAvailable: () -> Boolean,
   private val installedAppsSharingEnabled: () -> Boolean,
   private val voiceWakeAvailable: () -> Boolean,
+  private val mobileUiAvailable: () -> Boolean,
   private val inlineWidgetsAvailable: () -> Boolean,
   private val manualTls: (GatewayEndpoint) -> Boolean,
 ) {
@@ -148,6 +149,7 @@ class ConnectionManager(
       installedAppsSharingEnabled = installedAppsSharingEnabled(),
       debugBuild = BuildConfig.DEBUG,
       voiceWakeEnabled = prefs.voiceWakeEnabled.value && voiceWakeAvailable(),
+      mobileUiAvailable = mobileUiAvailable(),
     )
 
   /** Builds the gateway-advertised node.invoke command list from current permission and feature state. */

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/InvokeCommandRegistry.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/InvokeCommandRegistry.kt
@@ -9,6 +9,7 @@ import ai.openclaw.app.protocol.OpenClawCapability
 import ai.openclaw.app.protocol.OpenClawContactsCommand
 import ai.openclaw.app.protocol.OpenClawDeviceCommand
 import ai.openclaw.app.protocol.OpenClawLocationCommand
+import ai.openclaw.app.protocol.OpenClawMobileUiCommand
 import ai.openclaw.app.protocol.OpenClawMotionCommand
 import ai.openclaw.app.protocol.OpenClawNotificationsCommand
 import ai.openclaw.app.protocol.OpenClawPhotosCommand
@@ -30,6 +31,7 @@ data class NodeRuntimeFlags(
   val installedAppsSharingEnabled: Boolean,
   val debugBuild: Boolean,
   val voiceWakeEnabled: Boolean = false,
+  val mobileUiAvailable: Boolean = false,
 )
 
 /** Per-command availability gates checked before advertising invoke methods. */
@@ -46,6 +48,7 @@ enum class InvokeCommandAvailability {
   MotionPedometerAvailable,
   InstalledAppsSharingEnabled,
   DebugBuild,
+  MobileUiAvailable,
 }
 
 /** Per-capability availability gates for the node capabilities manifest. */
@@ -58,6 +61,7 @@ enum class NodeCapabilityAvailability {
   PhotosAvailable,
   MotionAvailable,
   VoiceWakeEnabled,
+  MobileUiAvailable,
 }
 
 /** Capability entry reported to the gateway when its availability gate passes. */
@@ -111,6 +115,10 @@ object InvokeCommandRegistry {
       NodeCapabilitySpec(
         name = OpenClawCapability.VoiceWake.rawValue,
         availability = NodeCapabilityAvailability.VoiceWakeEnabled,
+      ),
+      NodeCapabilitySpec(
+        name = OpenClawCapability.MobileUI.rawValue,
+        availability = NodeCapabilityAvailability.MobileUiAvailable,
       ),
     )
 
@@ -243,6 +251,14 @@ object InvokeCommandRegistry {
         availability = InvokeCommandAvailability.CallLogAvailable,
       ),
       InvokeCommandSpec(
+        name = OpenClawMobileUiCommand.Observe.rawValue,
+        availability = InvokeCommandAvailability.MobileUiAvailable,
+      ),
+      InvokeCommandSpec(
+        name = OpenClawMobileUiCommand.Act.rawValue,
+        availability = InvokeCommandAvailability.MobileUiAvailable,
+      ),
+      InvokeCommandSpec(
         name = "debug.logs",
         availability = InvokeCommandAvailability.DebugBuild,
       ),
@@ -270,6 +286,7 @@ object InvokeCommandRegistry {
           NodeCapabilityAvailability.PhotosAvailable -> flags.photosAvailable
           NodeCapabilityAvailability.MotionAvailable -> flags.motionActivityAvailable || flags.motionPedometerAvailable
           NodeCapabilityAvailability.VoiceWakeEnabled -> flags.voiceWakeEnabled
+          NodeCapabilityAvailability.MobileUiAvailable -> flags.mobileUiAvailable
         }
       }.map { it.name }
 
@@ -290,6 +307,7 @@ object InvokeCommandRegistry {
           InvokeCommandAvailability.MotionPedometerAvailable -> flags.motionPedometerAvailable
           InvokeCommandAvailability.InstalledAppsSharingEnabled -> flags.installedAppsSharingEnabled
           InvokeCommandAvailability.DebugBuild -> flags.debugBuild
+          InvokeCommandAvailability.MobileUiAvailable -> flags.mobileUiAvailable
         }
       }.map { it.name }
 }

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/InvokeDispatcher.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/InvokeDispatcher.kt
@@ -9,6 +9,7 @@ import ai.openclaw.app.protocol.OpenClawCanvasCommand
 import ai.openclaw.app.protocol.OpenClawContactsCommand
 import ai.openclaw.app.protocol.OpenClawDeviceCommand
 import ai.openclaw.app.protocol.OpenClawLocationCommand
+import ai.openclaw.app.protocol.OpenClawMobileUiCommand
 import ai.openclaw.app.protocol.OpenClawMotionCommand
 import ai.openclaw.app.protocol.OpenClawNotificationsCommand
 import ai.openclaw.app.protocol.OpenClawSmsCommand
@@ -78,6 +79,7 @@ class InvokeDispatcher(
   private val a2uiHandler: A2UIHandler,
   private val debugHandler: DebugHandler,
   private val callLogHandler: CallLogHandler,
+  private val mobileUiHandler: MobileUiHandler,
   private val isForeground: () -> Boolean,
   private val cameraEnabled: () -> Boolean,
   private val locationEnabled: () -> Boolean,
@@ -93,6 +95,7 @@ class InvokeDispatcher(
   private val onCanvasA2uiReset: () -> Unit,
   private val motionActivityAvailable: () -> Boolean,
   private val motionPedometerAvailable: () -> Boolean,
+  private val mobileUiAvailable: () -> Boolean,
 ) {
   private val canvasCommandMutex = Mutex()
 
@@ -258,6 +261,10 @@ class InvokeDispatcher(
       // CallLog command
       OpenClawCallLogCommand.Search.rawValue -> callLogHandler.handleCallLogSearch(paramsJson)
 
+      // Mobile accessibility commands
+      OpenClawMobileUiCommand.Observe.rawValue -> mobileUiHandler.handleObserve(paramsJson)
+      OpenClawMobileUiCommand.Act.rawValue -> mobileUiHandler.handleAct(paramsJson)
+
       // Debug commands
       "debug.ed25519" -> debugHandler.handleEd25519()
       "debug.logs" -> debugHandler.handleLogs()
@@ -377,6 +384,15 @@ class InvokeDispatcher(
           GatewaySession.InvokeResult.error(
             code = "INVALID_REQUEST",
             message = "INVALID_REQUEST: unknown command",
+          )
+        }
+      InvokeCommandAvailability.MobileUiAvailable ->
+        if (mobileUiAvailable()) {
+          null
+        } else {
+          GatewaySession.InvokeResult.error(
+            code = "MOBILE_UI_UNAVAILABLE",
+            message = "MOBILE_UI_UNAVAILABLE: accessibility service is not connected",
           )
         }
     }

--- a/apps/android/app/src/main/java/ai/openclaw/app/protocol/OpenClawProtocolConstants.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/protocol/OpenClawProtocolConstants.kt
@@ -18,6 +18,7 @@ enum class OpenClawCapability(
   Motion("motion"),
   CallLog("callLog"),
   VoiceWake("voiceWake"),
+  MobileUI("mobileUI"),
 }
 
 enum class OpenClawCanvasCommand(
@@ -191,5 +192,17 @@ enum class OpenClawCallLogCommand(
 
   companion object {
     const val NamespacePrefix: String = "callLog."
+  }
+}
+
+enum class OpenClawMobileUiCommand(
+  val rawValue: String,
+) {
+  Observe("mobile.ui.observe"),
+  Act("mobile.ui.act"),
+  ;
+
+  companion object {
+    const val NamespacePrefix: String = "mobile.ui."
   }
 }

--- a/apps/android/app/src/play/java/ai/openclaw/app/node/MobileUiHandler.kt
+++ b/apps/android/app/src/play/java/ai/openclaw/app/node/MobileUiHandler.kt
@@ -1,0 +1,26 @@
+package ai.openclaw.app.node
+
+import ai.openclaw.app.gateway.GatewaySession
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class MobileUiHandler {
+  private val connected = MutableStateFlow(false)
+
+  val isConnected: StateFlow<Boolean> = connected.asStateFlow()
+
+  suspend fun handleObserve(
+    @Suppress("UNUSED_PARAMETER") paramsJson: String?,
+  ): GatewaySession.InvokeResult = unavailable()
+
+  suspend fun handleAct(
+    @Suppress("UNUSED_PARAMETER") paramsJson: String?,
+  ): GatewaySession.InvokeResult = unavailable()
+
+  private fun unavailable(): GatewaySession.InvokeResult =
+    GatewaySession.InvokeResult.error(
+      code = "MOBILE_UI_UNAVAILABLE",
+      message = "MOBILE_UI_UNAVAILABLE: accessibility control is not available on this build",
+    )
+}

--- a/apps/android/app/src/test/java/ai/openclaw/app/node/ConnectionManagerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/node/ConnectionManagerTest.kt
@@ -10,6 +10,7 @@ import ai.openclaw.app.protocol.OpenClawCameraCommand
 import ai.openclaw.app.protocol.OpenClawCapability
 import ai.openclaw.app.protocol.OpenClawDeviceCommand
 import ai.openclaw.app.protocol.OpenClawLocationCommand
+import ai.openclaw.app.protocol.OpenClawMobileUiCommand
 import ai.openclaw.app.protocol.OpenClawMotionCommand
 import ai.openclaw.app.protocol.OpenClawPhotosCommand
 import ai.openclaw.app.protocol.OpenClawSmsCommand
@@ -565,6 +566,19 @@ class ConnectionManagerTest {
   }
 
   @Test
+  fun buildNodeConnectOptions_advertisesMobileUiOnlyWhileAvailable() {
+    val unavailable = newManager(mobileUiAvailable = false).buildNodeConnectOptions()
+    val available = newManager(mobileUiAvailable = true).buildNodeConnectOptions()
+
+    assertFalse(unavailable.caps.contains(OpenClawCapability.MobileUI.rawValue))
+    assertFalse(unavailable.commands.contains(OpenClawMobileUiCommand.Observe.rawValue))
+    assertFalse(unavailable.commands.contains(OpenClawMobileUiCommand.Act.rawValue))
+    assertTrue(available.caps.contains(OpenClawCapability.MobileUI.rawValue))
+    assertTrue(available.commands.contains(OpenClawMobileUiCommand.Observe.rawValue))
+    assertTrue(available.commands.contains(OpenClawMobileUiCommand.Act.rawValue))
+  }
+
+  @Test
   fun buildNodeConnectOptions_advertisesDeviceAppsOnlyWhenUserOptedIn() {
     val disabled = newManager(installedAppsSharingEnabled = false).buildNodeConnectOptions()
     val enabled = newManager(installedAppsSharingEnabled = true).buildNodeConnectOptions()
@@ -634,6 +648,7 @@ class ConnectionManagerTest {
     installedAppsSharingEnabled: Boolean = false,
     voiceWakeEnabled: Boolean = false,
     voiceWakeAvailable: Boolean = true,
+    mobileUiAvailable: Boolean = false,
     inlineWidgetsAvailable: Boolean = true,
   ): ConnectionManager {
     val context = RuntimeEnvironment.getApplication()
@@ -662,6 +677,7 @@ class ConnectionManagerTest {
       photosAvailable = { photosAvailable },
       installedAppsSharingEnabled = { installedAppsSharingEnabled },
       voiceWakeAvailable = { voiceWakeAvailable },
+      mobileUiAvailable = { mobileUiAvailable },
       inlineWidgetsAvailable = { inlineWidgetsAvailable },
       manualTls = { false },
     )

--- a/apps/android/app/src/test/java/ai/openclaw/app/node/InvokeCommandRegistryTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/node/InvokeCommandRegistryTest.kt
@@ -7,6 +7,7 @@ import ai.openclaw.app.protocol.OpenClawCapability
 import ai.openclaw.app.protocol.OpenClawContactsCommand
 import ai.openclaw.app.protocol.OpenClawDeviceCommand
 import ai.openclaw.app.protocol.OpenClawLocationCommand
+import ai.openclaw.app.protocol.OpenClawMobileUiCommand
 import ai.openclaw.app.protocol.OpenClawMotionCommand
 import ai.openclaw.app.protocol.OpenClawNotificationsCommand
 import ai.openclaw.app.protocol.OpenClawPhotosCommand
@@ -41,6 +42,7 @@ class InvokeCommandRegistryTest {
       OpenClawCapability.Motion.rawValue,
       OpenClawCapability.Photos.rawValue,
       OpenClawCapability.VoiceWake.rawValue,
+      OpenClawCapability.MobileUI.rawValue,
     )
 
   private val coreCommands =
@@ -74,6 +76,8 @@ class InvokeCommandRegistryTest {
       OpenClawSmsCommand.Search.rawValue,
       OpenClawCallLogCommand.Search.rawValue,
       OpenClawPhotosCommand.Latest.rawValue,
+      OpenClawMobileUiCommand.Observe.rawValue,
+      OpenClawMobileUiCommand.Act.rawValue,
     )
 
   private val debugCommands = setOf("debug.logs", "debug.ed25519")
@@ -101,6 +105,7 @@ class InvokeCommandRegistryTest {
           motionActivityAvailable = true,
           motionPedometerAvailable = true,
           voiceWakeEnabled = true,
+          mobileUiAvailable = true,
         ),
       )
 
@@ -139,6 +144,7 @@ class InvokeCommandRegistryTest {
           motionActivityAvailable = true,
           motionPedometerAvailable = true,
           debugBuild = true,
+          mobileUiAvailable = true,
         ),
       )
 
@@ -276,6 +282,7 @@ class InvokeCommandRegistryTest {
     installedAppsSharingEnabled: Boolean = false,
     debugBuild: Boolean = false,
     voiceWakeEnabled: Boolean = false,
+    mobileUiAvailable: Boolean = false,
   ): NodeRuntimeFlags =
     NodeRuntimeFlags(
       cameraEnabled = cameraEnabled,
@@ -290,6 +297,7 @@ class InvokeCommandRegistryTest {
       installedAppsSharingEnabled = installedAppsSharingEnabled,
       debugBuild = debugBuild,
       voiceWakeEnabled = voiceWakeEnabled,
+      mobileUiAvailable = mobileUiAvailable,
     )
 
   private fun assertContainsAll(

--- a/apps/android/app/src/test/java/ai/openclaw/app/node/InvokeDispatcherTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/node/InvokeDispatcherTest.kt
@@ -7,6 +7,7 @@ import ai.openclaw.app.protocol.OpenClawCameraCommand
 import ai.openclaw.app.protocol.OpenClawCanvasCommand
 import ai.openclaw.app.protocol.OpenClawDeviceCommand
 import ai.openclaw.app.protocol.OpenClawLocationCommand
+import ai.openclaw.app.protocol.OpenClawMobileUiCommand
 import ai.openclaw.app.protocol.OpenClawMotionCommand
 import ai.openclaw.app.protocol.OpenClawPhotosCommand
 import ai.openclaw.app.protocol.OpenClawSmsCommand
@@ -228,6 +229,20 @@ class InvokeDispatcherTest {
     }
 
   @Test
+  fun handleInvoke_blocksMobileUiWhenServiceIsUnavailable() =
+    runTest {
+      val result =
+        newDispatcher(mobileUiAvailable = false)
+          .handleInvoke(OpenClawMobileUiCommand.Observe.rawValue, null)
+
+      assertEquals("MOBILE_UI_UNAVAILABLE", result.error?.code)
+      assertEquals(
+        "MOBILE_UI_UNAVAILABLE: accessibility service is not connected",
+        result.error?.message,
+      )
+    }
+
+  @Test
   fun handleInvoke_treatsDebugCommandsAsUnknownOutsideDebugBuilds() =
     runTest {
       val result = newDispatcher(debugBuild = false).handleInvoke("debug.logs", null)
@@ -342,6 +357,7 @@ class InvokeDispatcherTest {
     debugBuild: Boolean = false,
     motionActivityAvailable: Boolean = false,
     motionPedometerAvailable: Boolean = false,
+    mobileUiAvailable: Boolean = false,
     talkHandler: TalkHandler = InvokeDispatcherFakeTalkHandler(),
     canvas: CanvasController = CanvasController(),
   ): InvokeDispatcher {
@@ -375,6 +391,7 @@ class InvokeDispatcherTest {
         ),
       debugHandler = DebugHandler(appContext, testDeviceIdentityStore(appContext)),
       callLogHandler = CallLogHandler.forTesting(appContext, InvokeDispatcherFakeCallLogDataSource()),
+      mobileUiHandler = MobileUiHandler(),
       isForeground = { isForeground },
       cameraEnabled = { cameraEnabled },
       locationEnabled = { locationEnabled },
@@ -390,6 +407,7 @@ class InvokeDispatcherTest {
       onCanvasA2uiReset = {},
       motionActivityAvailable = { motionActivityAvailable },
       motionPedometerAvailable = { motionPedometerAvailable },
+      mobileUiAvailable = { mobileUiAvailable },
     )
   }
 

--- a/apps/android/app/src/testThirdParty/java/ai/openclaw/app/accessibility/AccessibilitySnapshotterTest.kt
+++ b/apps/android/app/src/testThirdParty/java/ai/openclaw/app/accessibility/AccessibilitySnapshotterTest.kt
@@ -26,19 +26,23 @@ class AccessibilitySnapshotterTest {
     val second = Any()
 
     assertEquals(AccessibilityServiceConnection<Any>(instance = null, generation = 0), state.connection.value)
+    assertFalse(state.isConnected.value)
 
     state.connect(first)
     assertTrue(state.connection.value.instance === first)
     assertEquals(1L, state.connection.value.generation)
+    assertTrue(state.isConnected.value)
 
     state.connect(second)
     state.disconnect(first)
     assertTrue(state.connection.value.instance === second)
     assertEquals(2L, state.connection.value.generation)
+    assertTrue(state.isConnected.value)
 
     state.disconnect(second)
     assertEquals(null, state.connection.value.instance)
     assertEquals(2L, state.connection.value.generation)
+    assertFalse(state.isConnected.value)
   }
 
   @Test

--- a/apps/android/app/src/testThirdParty/java/ai/openclaw/app/node/MobileUiHandlerTest.kt
+++ b/apps/android/app/src/testThirdParty/java/ai/openclaw/app/node/MobileUiHandlerTest.kt
@@ -1,0 +1,105 @@
+package ai.openclaw.app.node
+
+import ai.openclaw.app.accessibility.GlobalActionName
+import ai.openclaw.app.accessibility.MobileUiAction
+import ai.openclaw.app.accessibility.MobileUiNode
+import ai.openclaw.app.accessibility.MobileUiSnapshot
+import ai.openclaw.app.accessibility.ScrollDirection
+import android.graphics.Rect
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class MobileUiHandlerTest {
+  @Test
+  fun snapshotJsonUsesStableTransportShape() {
+    val snapshot =
+      MobileUiSnapshot(
+        id = "snapshot-1",
+        capturedAtMs = 1234,
+        packageName = "example.app",
+        windowTitle = "Example",
+        nodes =
+          listOf(
+            MobileUiNode(
+              ref = "n0",
+              parentRef = null,
+              role = "button",
+              text = "Continue",
+              contentDescription = "Continue button",
+              viewId = "example.app:id/continue",
+              boundsInScreen = Rect(1, 2, 30, 40),
+              clickable = true,
+              editable = false,
+              scrollable = false,
+              enabled = true,
+              focused = false,
+              actions = listOf("activate"),
+            ),
+          ),
+      )
+
+    val payload = Json.parseToJsonElement(mobileUiSnapshotJson(snapshot)) as JsonObject
+    val node = (payload["nodes"] as JsonArray).single() as JsonObject
+
+    assertEquals("snapshot-1", payload["snapshotId"]?.jsonPrimitive?.content)
+    assertEquals("example.app", payload["package"]?.jsonPrimitive?.content)
+    assertEquals(listOf("1", "2", "30", "40"), (node["bounds"] as JsonArray).map { it.jsonPrimitive.content })
+    assertEquals("true", ((node["flags"] as JsonObject)["clickable"])?.jsonPrimitive?.content)
+    assertEquals("activate", (node["actions"] as JsonArray).single().jsonPrimitive.content)
+  }
+
+  @Test
+  fun actParserMapsEverySupportedAction() {
+    assertEquals(MobileUiAction.Activate("n1"), parse(action("activate", "\"ref\":\"n1\"")))
+    assertEquals(
+      MobileUiAction.SetText("n2", "hello"),
+      parse(action("set_text", "\"ref\":\"n2\",\"text\":\"hello\"")),
+    )
+    assertEquals(
+      MobileUiAction.Scroll("n3", ScrollDirection.Backward),
+      parse(action("scroll", "\"ref\":\"n3\",\"direction\":\"backward\"")),
+    )
+    assertEquals(MobileUiAction.Tap(10, 20), parse(action("tap", "\"x\":10,\"y\":20")))
+    assertEquals(
+      MobileUiAction.Swipe(1, 2, 3, 4, 500),
+      parse(action("swipe", "\"x1\":1,\"y1\":2,\"x2\":3,\"y2\":4,\"durationMs\":500")),
+    )
+    assertEquals(
+      MobileUiAction.GlobalAction(GlobalActionName.Notifications),
+      parse(action("global_action", "\"name\":\"notifications\"")),
+    )
+    assertEquals(MobileUiAction.Wait(250), parse(action("wait", "\"ms\":250")))
+  }
+
+  @Test
+  fun actParserRejectsMalformedRequests() {
+    assertNull(parseMobileUiActRequest(null))
+    assertNull(parseMobileUiActRequest("{}"))
+    assertNull(parseMobileUiActRequest(action("scroll", "\"ref\":\"n1\",\"direction\":\"sideways\"")))
+  }
+
+  @Test
+  fun observeMapsDisconnectedServiceToStructuredError() =
+    runTest {
+      val result = MobileUiHandler().handleObserve(null)
+
+      assertEquals(false, result.ok)
+      assertEquals("SERVICE_DISABLED", result.error?.code)
+    }
+
+  private fun parse(raw: String): MobileUiAction? = parseMobileUiActRequest(raw)?.action
+
+  private fun action(
+    type: String,
+    fields: String,
+  ): String = """{"snapshotId":"snapshot-1","action":{"type":"$type",$fields}}"""
+}

--- a/apps/android/app/src/thirdParty/java/ai/openclaw/app/accessibility/OpenClawAccessibilityService.kt
+++ b/apps/android/app/src/thirdParty/java/ai/openclaw/app/accessibility/OpenClawAccessibilityService.kt
@@ -61,6 +61,8 @@ class OpenClawAccessibilityService : AccessibilityService() {
     internal val connection: StateFlow<AccessibilityServiceConnection<OpenClawAccessibilityService>> =
       connectionState.connection
 
+    val isConnected: StateFlow<Boolean> = connectionState.isConnected
+
     val uiEpoch: Long
       get() = uiEpochCounter.get()
 
@@ -78,17 +80,24 @@ internal data class AccessibilityServiceConnection<T : Any>(
 
 internal class ObservableServiceInstance<T : Any> {
   private val mutableConnection = MutableStateFlow(AccessibilityServiceConnection<T>(instance = null, generation = 0))
+  private val mutableIsConnected = MutableStateFlow(false)
 
   val connection: StateFlow<AccessibilityServiceConnection<T>> = mutableConnection.asStateFlow()
+  val isConnected: StateFlow<Boolean> = mutableIsConnected.asStateFlow()
 
   fun connect(instance: T) {
     val current = mutableConnection.value
     mutableConnection.value = AccessibilityServiceConnection(instance, generation = current.generation + 1)
+    mutableIsConnected.value = true
   }
 
   fun disconnect(instance: T) {
     val current = mutableConnection.value
+    // Only the current instance may clear connectivity: during a service-replacement
+    // race the old instance's teardown must not publish false after the replacement
+    // already connected, or NodeRuntime would withdraw the mobile UI capability.
     if (current.instance !== instance) return
     mutableConnection.value = current.copy(instance = null)
+    mutableIsConnected.value = false
   }
 }

--- a/apps/android/app/src/thirdParty/java/ai/openclaw/app/node/MobileUiHandler.kt
+++ b/apps/android/app/src/thirdParty/java/ai/openclaw/app/node/MobileUiHandler.kt
@@ -1,0 +1,200 @@
+package ai.openclaw.app.node
+
+import ai.openclaw.app.accessibility.AccessibilityActionExecutor
+import ai.openclaw.app.accessibility.AccessibilityServiceDisabledException
+import ai.openclaw.app.accessibility.ActionResult
+import ai.openclaw.app.accessibility.GlobalActionName
+import ai.openclaw.app.accessibility.MobileUiAction
+import ai.openclaw.app.accessibility.MobileUiSnapshot
+import ai.openclaw.app.accessibility.OpenClawAccessibilityService
+import ai.openclaw.app.accessibility.ScrollDirection
+import ai.openclaw.app.gateway.GatewaySession
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.put
+
+internal data class MobileUiActRequest(
+  val snapshotId: String,
+  val action: MobileUiAction,
+)
+
+/**
+ * Flavor-owned bridge from node.invoke to the Android accessibility executor.
+ *
+ * Observe returns `{snapshotId,capturedAtMs,package,windowTitle,nodes}`. Each node contains
+ * `{ref,parentRef,role,text,contentDescription,viewId,bounds:[l,t,r,b],flags,actions}`.
+ * Act accepts `{snapshotId,action:{type,...}}` and returns `{code,message}`.
+ */
+class MobileUiHandler {
+  private val executor = AccessibilityActionExecutor()
+  private val invokeMutex = Mutex()
+
+  val isConnected: StateFlow<Boolean> = OpenClawAccessibilityService.isConnected
+
+  suspend fun handleObserve(
+    @Suppress("UNUSED_PARAMETER") paramsJson: String?,
+  ): GatewaySession.InvokeResult =
+    invokeMutex.withLock {
+      try {
+        GatewaySession.InvokeResult.ok(mobileUiSnapshotJson(executor.observe()))
+      } catch (error: AccessibilityServiceDisabledException) {
+        GatewaySession.InvokeResult.error(
+          code = "SERVICE_DISABLED",
+          message = "SERVICE_DISABLED: ${error.message ?: "accessibility service is disabled"}",
+        )
+      } catch (error: CancellationException) {
+        throw error
+      } catch (error: Throwable) {
+        GatewaySession.InvokeResult.error(
+          code = "MOBILE_UI_OBSERVE_FAILED",
+          message = "MOBILE_UI_OBSERVE_FAILED: ${error.message ?: "snapshot failed"}",
+        )
+      }
+    }
+
+  suspend fun handleAct(paramsJson: String?): GatewaySession.InvokeResult =
+    invokeMutex.withLock {
+      val request =
+        parseMobileUiActRequest(paramsJson)
+          ?: return@withLock GatewaySession.InvokeResult.error(
+            code = "INVALID_REQUEST",
+            message = "INVALID_REQUEST: expected {snapshotId,action:{type,...}}",
+          )
+      try {
+        GatewaySession.InvokeResult.ok(actionResultJson(executor.act(request.snapshotId, request.action)))
+      } catch (error: CancellationException) {
+        throw error
+      } catch (error: Throwable) {
+        GatewaySession.InvokeResult.error(
+          code = "MOBILE_UI_ACT_FAILED",
+          message = "MOBILE_UI_ACT_FAILED: ${error.message ?: "action failed"}",
+        )
+      }
+    }
+}
+
+internal fun mobileUiSnapshotJson(snapshot: MobileUiSnapshot): String =
+  buildJsonObject {
+    put("snapshotId", snapshot.id)
+    put("capturedAtMs", snapshot.capturedAtMs)
+    put("package", JsonPrimitive(snapshot.packageName))
+    put("windowTitle", JsonPrimitive(snapshot.windowTitle))
+    put(
+      "nodes",
+      buildJsonArray {
+        snapshot.nodes.forEach { node ->
+          add(
+            buildJsonObject {
+              put("ref", node.ref)
+              put("parentRef", JsonPrimitive(node.parentRef))
+              put("role", node.role)
+              put("text", JsonPrimitive(node.text))
+              put("contentDescription", JsonPrimitive(node.contentDescription))
+              put("viewId", JsonPrimitive(node.viewId))
+              put(
+                "bounds",
+                buildJsonArray {
+                  add(JsonPrimitive(node.boundsInScreen.left))
+                  add(JsonPrimitive(node.boundsInScreen.top))
+                  add(JsonPrimitive(node.boundsInScreen.right))
+                  add(JsonPrimitive(node.boundsInScreen.bottom))
+                },
+              )
+              put(
+                "flags",
+                buildJsonObject {
+                  put("clickable", node.clickable)
+                  put("editable", node.editable)
+                  put("scrollable", node.scrollable)
+                  put("enabled", node.enabled)
+                  put("focused", node.focused)
+                },
+              )
+              put(
+                "actions",
+                buildJsonArray {
+                  node.actions.forEach { action -> add(JsonPrimitive(action)) }
+                },
+              )
+            },
+          )
+        }
+      },
+    )
+  }.toString()
+
+internal fun parseMobileUiActRequest(paramsJson: String?): MobileUiActRequest? {
+  val params = parseJsonParamsObject(paramsJson) ?: return null
+  val snapshotId = params.requiredString("snapshotId") ?: return null
+  val actionParams = params["action"] as? JsonObject ?: return null
+  val type = actionParams.requiredString("type") ?: return null
+  val action =
+    when (type) {
+      "activate" -> MobileUiAction.Activate(actionParams.requiredString("ref") ?: return null)
+      "set_text" ->
+        MobileUiAction.SetText(
+          ref = actionParams.requiredString("ref") ?: return null,
+          text = actionParams.string("text") ?: return null,
+        )
+      "scroll" ->
+        MobileUiAction.Scroll(
+          ref = actionParams.requiredString("ref") ?: return null,
+          direction =
+            when (actionParams.requiredString("direction")) {
+              "forward" -> ScrollDirection.Forward
+              "backward" -> ScrollDirection.Backward
+              else -> return null
+            },
+        )
+      "tap" ->
+        MobileUiAction.Tap(
+          x = actionParams.int("x") ?: return null,
+          y = actionParams.int("y") ?: return null,
+        )
+      "swipe" ->
+        MobileUiAction.Swipe(
+          x1 = actionParams.int("x1") ?: return null,
+          y1 = actionParams.int("y1") ?: return null,
+          x2 = actionParams.int("x2") ?: return null,
+          y2 = actionParams.int("y2") ?: return null,
+          durationMs = actionParams.long("durationMs") ?: return null,
+        )
+      "global_action" ->
+        MobileUiAction.GlobalAction(
+          when (actionParams.requiredString("name")) {
+            "back" -> GlobalActionName.Back
+            "home" -> GlobalActionName.Home
+            "recents" -> GlobalActionName.Recents
+            "notifications" -> GlobalActionName.Notifications
+            else -> return null
+          },
+        )
+      "wait" -> MobileUiAction.Wait(actionParams.long("ms") ?: return null)
+      else -> return null
+    }
+  return MobileUiActRequest(snapshotId = snapshotId, action = action)
+}
+
+private fun actionResultJson(result: ActionResult): String =
+  buildJsonObject {
+    put("code", result.code.value)
+    put("message", JsonPrimitive(result.message))
+  }.toString()
+
+private fun JsonObject.string(key: String): String? =
+  (this[key] as? JsonPrimitive)
+    ?.takeIf { it.isString }
+    ?.contentOrNull
+
+private fun JsonObject.requiredString(key: String): String? = string(key)?.takeIf(String::isNotBlank)
+
+private fun JsonObject.int(key: String): Int? = (this[key] as? JsonPrimitive)?.contentOrNull?.toIntOrNull()
+
+private fun JsonObject.long(key: String): Long? = (this[key] as? JsonPrimitive)?.contentOrNull?.toLongOrNull()

--- a/scripts/protocol-gen-kotlin.ts
+++ b/scripts/protocol-gen-kotlin.ts
@@ -74,6 +74,7 @@ const androidEnums: EnumSpec[] = [
     ["Motion", "motion"],
     ["CallLog", "callLog"],
     ["VoiceWake", "voiceWake"],
+    ["MobileUI", "mobileUI"],
   ]),
   enumSpec("OpenClawCanvasCommand", "canvas.", [
     ["Present", "present"],
@@ -129,6 +130,10 @@ const androidEnums: EnumSpec[] = [
     ["Pedometer", "pedometer"],
   ]),
   enumSpec("OpenClawCallLogCommand", "callLog.", [["Search", "search"]]),
+  enumSpec("OpenClawMobileUiCommand", "mobile.ui.", [
+    ["Observe", "observe"],
+    ["Act", "act"],
+  ]),
 ];
 
 function enumSpec(

--- a/src/gateway/node-command-policy.test.ts
+++ b/src/gateway/node-command-policy.test.ts
@@ -627,6 +627,73 @@ describe("gateway/node-command-policy", () => {
     expect(resolveNodeCommandAllowlist(armedCfg, macNode).has("computer.act")).toBe(true);
   });
 
+  it("keeps mobile UI commands dangerous until Android operators explicitly arm them", () => {
+    const node = {
+      platform: "android",
+      deviceFamily: "Android",
+      commands: ["mobile.ui.observe", "mobile.ui.act"],
+      approvedCommands: ["mobile.ui.observe", "mobile.ui.act"],
+    };
+    const unarmed = resolveNodeCommandAllowlist({} as OpenClawConfig, node);
+    expect(unarmed.has("mobile.ui.observe")).toBe(false);
+    expect(unarmed.has("mobile.ui.act")).toBe(false);
+
+    const armed = resolveNodeCommandAllowlist(
+      {
+        gateway: {
+          nodes: { allowCommands: ["mobile.ui.observe", "mobile.ui.act"] },
+        },
+      } as OpenClawConfig,
+      node,
+    );
+    expect(armed.has("mobile.ui.observe")).toBe(true);
+    expect(armed.has("mobile.ui.act")).toBe(true);
+    expect(
+      isNodeCommandAllowed({
+        command: "mobile.ui.act",
+        declaredCommands: node.commands,
+        allowlist: armed,
+      }),
+    ).toEqual({ ok: true });
+
+    const denied = resolveNodeCommandAllowlist(
+      {
+        gateway: {
+          nodes: {
+            allowCommands: ["mobile.ui.observe", "mobile.ui.act"],
+            denyCommands: ["mobile.ui.act"],
+          },
+        },
+      } as OpenClawConfig,
+      node,
+    );
+    expect(denied.has("mobile.ui.observe")).toBe(true);
+    expect(denied.has("mobile.ui.act")).toBe(false);
+  });
+
+  it("keeps mobile UI commands declarable only on Android pairing surfaces", () => {
+    const freshSetup = {
+      gateway: {
+        nodes: { denyCommands: ["mobile.ui.observe", "mobile.ui.act"] },
+      },
+    } as OpenClawConfig;
+    const androidPairing = resolveNodePairingCommandAllowlist(freshSetup, {
+      platform: "android",
+      deviceFamily: "Android",
+      commands: ["mobile.ui.observe", "mobile.ui.act"],
+    });
+    expect(androidPairing.has("mobile.ui.observe")).toBe(true);
+    expect(androidPairing.has("mobile.ui.act")).toBe(true);
+
+    const iosPairing = resolveNodePairingCommandAllowlist({} as OpenClawConfig, {
+      platform: "ios",
+      deviceFamily: "iPhone",
+      commands: ["mobile.ui.observe", "mobile.ui.act"],
+    });
+    expect(iosPairing.has("mobile.ui.observe")).toBe(false);
+    expect(iosPairing.has("mobile.ui.act")).toBe(false);
+  });
+
   it("requires explicit gateway opt-in for iOS health summaries", () => {
     const node = {
       platform: "iOS 18.4.0",

--- a/src/gateway/node-command-policy.test.ts
+++ b/src/gateway/node-command-policy.test.ts
@@ -641,7 +641,7 @@ describe("gateway/node-command-policy", () => {
     const armed = resolveNodeCommandAllowlist(
       {
         gateway: {
-          nodes: { allowCommands: ["mobile.ui.observe", "mobile.ui.act"] },
+          nodes: { commands: { allow: ["mobile.ui.observe", "mobile.ui.act"] } },
         },
       } as OpenClawConfig,
       node,
@@ -660,8 +660,10 @@ describe("gateway/node-command-policy", () => {
       {
         gateway: {
           nodes: {
-            allowCommands: ["mobile.ui.observe", "mobile.ui.act"],
-            denyCommands: ["mobile.ui.act"],
+            commands: {
+              allow: ["mobile.ui.observe", "mobile.ui.act"],
+              deny: ["mobile.ui.act"],
+            },
           },
         },
       } as OpenClawConfig,

--- a/src/gateway/node-command-policy.ts
+++ b/src/gateway/node-command-policy.ts
@@ -139,7 +139,7 @@ export const PLATFORM_DEFAULTS: Record<string, string[]> = {
     ...PHOTOS_COMMANDS,
     ...MOTION_COMMANDS,
     // Dangerous: pairing may approve the advertised surface, while runtime
-    // policy strips it until gateway.nodes.allowCommands explicitly arms it.
+    // policy strips it until gateway.nodes.commands.allow explicitly arms it.
     ...MOBILE_UI_DANGEROUS_COMMANDS,
   ],
   macos: [

--- a/src/gateway/node-command-policy.ts
+++ b/src/gateway/node-command-policy.ts
@@ -31,6 +31,10 @@ const SCREEN_DANGEROUS_COMMANDS = ["screen.record"];
 // commands.allow opt-in (arming).
 const COMPUTER_DANGEROUS_COMMANDS = ["computer.act"];
 
+// Android accessibility tree reads and UI actions expose or control sensitive
+// on-screen content. Keep both declarable, but require explicit arming.
+const MOBILE_UI_DANGEROUS_COMMANDS = ["mobile.ui.observe", "mobile.ui.act"];
+
 const ANDROID_DEVICE_COMMANDS = [
   ...MOBILE_NODE_COMMANDS.device,
   "device.permissions",
@@ -101,6 +105,7 @@ export const DEFAULT_DANGEROUS_NODE_COMMANDS = [
   ...CAMERA_DANGEROUS_COMMANDS,
   ...SCREEN_DANGEROUS_COMMANDS,
   ...COMPUTER_DANGEROUS_COMMANDS,
+  ...MOBILE_UI_DANGEROUS_COMMANDS,
   ...CONTACTS_DANGEROUS_COMMANDS,
   ...CALENDAR_DANGEROUS_COMMANDS,
   ...REMINDERS_DANGEROUS_COMMANDS,
@@ -133,6 +138,9 @@ export const PLATFORM_DEFAULTS: Record<string, string[]> = {
     ...REMINDERS_COMMANDS,
     ...PHOTOS_COMMANDS,
     ...MOTION_COMMANDS,
+    // Dangerous: pairing may approve the advertised surface, while runtime
+    // policy strips it until gateway.nodes.allowCommands explicitly arms it.
+    ...MOBILE_UI_DANGEROUS_COMMANDS,
   ],
   macos: [
     ...CAMERA_COMMANDS,


### PR DESCRIPTION
## What Problem This Solves

PR 1 added the Android AccessibilityService executor (`observe()`/`act()`) but nothing could reach it remotely. This PR exposes it over OpenClaw's existing `node.invoke` transport as two node commands, so the gateway (and later an agent tool) can drive it.

**Stacked on #112232 (PR 1/3).** Base is the PR 1 branch; it retargets to `main` when PR 1 merges. PR 3 adds the dedicated agent tool + confirmation/policy gates.

## Why This Change Was Made

Keeping transport wiring separate from the executor (PR 1) and the agent tool (PR 3) keeps each diff reviewable, and lets the dangerous-command classification land before any model-facing surface exists.

## User Impact

- **Play build:** unchanged — a permanently-unavailable no-op `MobileUiHandler` stub; the Play APK still contains zero accessibility classes.
- **thirdParty build:** advertises `mobile.ui.observe` / `mobile.ui.act` (capability `mobileUI`) only while the accessibility service is connected. The commands are classified **dangerous** on the gateway, so they are declarable at pairing but cannot be invoked until `gateway.nodes.allowCommands` explicitly arms them (the `computer.act` model). No agent can call them yet.

## Design

- Additive protocol: `mobile.ui.observe`/`mobile.ui.act` generated into the Kotlin protocol constants via `protocol-gen-kotlin.ts`. **No protocol version bump.**
- `MobileUiHandler` (thirdParty) owns one `AccessibilityActionExecutor` (its own generation, separate from the dev screen), serializes calls with a `Mutex`, and bridges a documented JSON shape ↔ the PR 1 snapshot/action model. Structured error results (`SERVICE_DISABLED`, `INVALID_REQUEST`).
- `NodeRuntime` observes `OpenClawAccessibilityService.isConnected` and refreshes the advertised command surface on connect/disconnect.
- Gateway `node-command-policy.ts`: both commands in the dangerous set + `PLATFORM_DEFAULTS.android` (declarable, stripped from the runtime allowlist until armed). Observe is dangerous too — reading another app's screen is sensitive.

## Evidence

- Both Android flavors assemble; thirdParty + play + main unit tests, ktlint, and android lint pass; new tests: `MobileUiHandlerTest`, `ConnectionManagerTest`, `InvokeDispatcherTest`, `InvokeCommandRegistryTest`.
- Gateway `node-command-policy.test.ts`: 29 pass (covers dangerous classification + allowlist for the new commands).
- Protocol generator idempotent (`protocol:gen:kotlin` produces no diff); no version bump.
- Play isolation re-verified: 0 accessibility classes in the Play dex; no `mobile.ui` advertisement in play.
- Emulator: no regression to the PR 1 dev-screen observe (service connects, snapshot captured).

### Autoreview note
One P2 finding ("connectivity cleared for a stale service instance") was verified as a **false positive**: `disconnect()` guards `if (current.instance !== instance) return` before publishing `isConnected=false`, so a replacement-race teardown of the old instance returns early and cannot withdraw the capability. Added a clarifying comment on the invariant.
