### PR TITLE
fix(plugins): clarify untracked plugin trust warning

### DIFF
--- a/src/plugins/loader-provenance.ts
+++ b/src/plugins/loader-provenance.ts
@@ -311,7 +311,7 @@ export function warnAboutUntrackedLoadedPlugins(params: {
     ) {
       continue;
     }
-    const message = `loaded without install/load-path provenance; treat as untracked local code. Verify source with '${formatPluginInspectCommand(plugin.id)}', then pin trust via plugins.allow (e.g. "plugins": { "allow": [${JSON.stringify(plugin.id)}] }) or reinstall from a trusted source so OpenClaw records install provenance.`;
+    const message = `loaded without install/load-path provenance; treat as untracked local code. Verify source with '${formatPluginInspectCommand(plugin.id)}'. plugins.allow controls which plugin ids may load (e.g. "plugins": { "allow": [${JSON.stringify(plugin.id)}] }); it does not grant trusted-only capabilities such as openKeyedStore. If this is an official plugin that requires those capabilities, reinstall it from an OpenClaw-trusted npm or ClawHub source so OpenClaw records trusted install provenance.`;
     params.registry.diagnostics.push({
       level: "warn",
       pluginId: plugin.id,

--- a/src/plugins/loader-provenance.ts
+++ b/src/plugins/loader-provenance.ts
@@ -311,7 +311,7 @@ export function warnAboutUntrackedLoadedPlugins(params: {
     ) {
       continue;
     }
-    const message = `loaded without install/load-path provenance; treat as untracked local code. Verify source with '${formatPluginInspectCommand(plugin.id)}'. plugins.allow controls which plugin ids may load (e.g. "plugins": { "allow": [${JSON.stringify(plugin.id)}] }); it does not grant trusted-only capabilities such as openKeyedStore. If this is an official plugin that requires those capabilities, reinstall it from an OpenClaw-trusted npm or ClawHub source so OpenClaw records trusted install provenance.`;
+    const message = `OpenClaw can't verify where this plugin came from. Review it with '${formatPluginInspectCommand(plugin.id)}'. Adding it to plugins.allow lets it load, but does not make it trusted. If it's an official plugin, reinstall it from its official npm package or its official ClawHub listing to enable trusted features.`;
     params.registry.diagnostics.push({
       level: "warn",
       pluginId: plugin.id,

--- a/src/plugins/loader.discovery-and-security.test-utils.ts
+++ b/src/plugins/loader.discovery-and-security.test-utils.ts
@@ -1066,31 +1066,31 @@ describe("loadOpenClawPlugins", () => {
       const untrackedWarning = warnings.find(
         (msg) =>
           msg.includes("warn-untracked-remediation") &&
-          msg.includes("loaded without install/load-path provenance"),
+          msg.includes("OpenClaw can't verify where this plugin came from"),
       );
       expect(untrackedWarning).toBeDefined();
-      expect(untrackedWarning).toContain('"warn-untracked-remediation"');
+      expect(untrackedWarning).toContain("OpenClaw can't verify where this plugin came from");
       expect(untrackedWarning).toContain("openclaw plugins inspect warn-untracked-remediation");
-      expect(untrackedWarning).toContain("plugins.allow controls which plugin ids may load");
       expect(untrackedWarning).toContain(
-        "does not grant trusted-only capabilities such as openKeyedStore",
+        "plugins.allow lets it load, but does not make it trusted",
       );
-      expect(untrackedWarning).toContain("OpenClaw-trusted npm or ClawHub source");
-      expect(untrackedWarning).not.toContain("pin trust via plugins.allow");
+      expect(untrackedWarning).toContain(
+        "reinstall it from its official npm package or its official ClawHub listing",
+      );
 
       const diagnostic = registry.diagnostics.find(
         (entry) =>
           entry.pluginId === "warn-untracked-remediation" &&
-          entry.message.includes("loaded without install/load-path provenance"),
+          entry.message.includes("OpenClaw can't verify where this plugin came from"),
       );
-      expect(diagnostic?.message).toContain('"warn-untracked-remediation"');
+      expect(diagnostic?.message).toContain("OpenClaw can't verify where this plugin came from");
       expect(diagnostic?.message).toContain("openclaw plugins inspect warn-untracked-remediation");
-      expect(diagnostic?.message).toContain("plugins.allow controls which plugin ids may load");
       expect(diagnostic?.message).toContain(
-        "does not grant trusted-only capabilities such as openKeyedStore",
+        "plugins.allow lets it load, but does not make it trusted",
       );
-      expect(diagnostic?.message).toContain("OpenClaw-trusted npm or ClawHub source");
-      expect(diagnostic?.message).not.toContain("pin trust via plugins.allow");
+      expect(diagnostic?.message).toContain(
+        "reinstall it from its official npm package or its official ClawHub listing",
+      );
     });
   });
 
@@ -1546,7 +1546,7 @@ describe("loadOpenClawPlugins", () => {
         warnings.filter(
           (message) =>
             message.includes("trusted-plugin") &&
-            message.includes("loaded without install/load-path provenance"),
+            message.includes("OpenClaw can't verify where this plugin came from"),
         ),
       ).toEqual([]);
     });
@@ -1694,7 +1694,7 @@ describe("loadOpenClawPlugins", () => {
         registry,
         level: "warn",
         pluginId: "rogue",
-        message: "loaded without install/load-path provenance",
+        message: "OpenClaw can't verify where this plugin came from",
       });
     });
   });

--- a/src/plugins/loader.discovery-and-security.test-utils.ts
+++ b/src/plugins/loader.discovery-and-security.test-utils.ts
@@ -1039,7 +1039,7 @@ describe("loadOpenClawPlugins", () => {
     expect(openAllowWarning).toContain("openclaw plugins inspect warn-open-allow-remediation");
   });
 
-  it("includes actionable plugins.allow remediation hints in the untracked-provenance warning", () => {
+  it("distinguishes load permission from capability trust in the untracked-provenance warning", () => {
     useNoBundledPlugins();
     const stateDir = makeTempDir();
     withEnv({ OPENCLAW_STATE_DIR: stateDir }, () => {
@@ -1071,7 +1071,12 @@ describe("loadOpenClawPlugins", () => {
       expect(untrackedWarning).toBeDefined();
       expect(untrackedWarning).toContain('"warn-untracked-remediation"');
       expect(untrackedWarning).toContain("openclaw plugins inspect warn-untracked-remediation");
-      expect(untrackedWarning).toContain("reinstall from a trusted source");
+      expect(untrackedWarning).toContain("plugins.allow controls which plugin ids may load");
+      expect(untrackedWarning).toContain(
+        "does not grant trusted-only capabilities such as openKeyedStore",
+      );
+      expect(untrackedWarning).toContain("OpenClaw-trusted npm or ClawHub source");
+      expect(untrackedWarning).not.toContain("pin trust via plugins.allow");
 
       const diagnostic = registry.diagnostics.find(
         (entry) =>
@@ -1080,7 +1085,12 @@ describe("loadOpenClawPlugins", () => {
       );
       expect(diagnostic?.message).toContain('"warn-untracked-remediation"');
       expect(diagnostic?.message).toContain("openclaw plugins inspect warn-untracked-remediation");
-      expect(diagnostic?.message).toContain("reinstall from a trusted source");
+      expect(diagnostic?.message).toContain("plugins.allow controls which plugin ids may load");
+      expect(diagnostic?.message).toContain(
+        "does not grant trusted-only capabilities such as openKeyedStore",
+      );
+      expect(diagnostic?.message).toContain("OpenClaw-trusted npm or ClawHub source");
+      expect(diagnostic?.message).not.toContain("pin trust via plugins.allow");
     });
   });
 

--- a/src/plugins/loader.test-harness.ts
+++ b/src/plugins/loader.test-harness.ts
@@ -438,7 +438,7 @@ export function expectLoadedPluginProvenance(params: {
     params.warnings.some(
       (msg) =>
         msg.includes(params.pluginId) &&
-        msg.includes("loaded without install/load-path provenance"),
+        msg.includes("OpenClaw can't verify where this plugin came from"),
     ),
     params.scenario.label,
   ).toBe(params.expectWarning);


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where operators investigating an unverified plugin warning were told that adding the plugin to `plugins.allow` would pin trust, even though the allowlist only controls whether the plugin may load.

## Why This Change Was Made

The warning now uses consumer-facing language: OpenClaw cannot verify the plugin source, `plugins.allow` permits loading without making the plugin trusted, and official plugins should be reinstalled from their official npm package or ClawHub listing when trusted features are needed. Focused assertions cover both the emitted warning and registry diagnostic.

## User Impact

Operators now receive short, actionable guidance without internal provenance or runtime API terminology.

## Evidence

- `node scripts/run-vitest.mjs src/plugins/loader.test.ts` — 173 tests passed.
- `node scripts/run-vitest.mjs src/plugin-state/plugin-state-store.runtime.test.ts` — 7 tests passed.
- Node 24.17 local fallback: `node scripts/check-changed.mjs` — core and core-test gates passed.
- Final `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output` — clean, no accepted/actionable findings.

AI-assisted: Yes. I reviewed the affected loader, provenance, official-install trust, and runtime capability paths and understand the change.
