### PR TITLE
docs: map shawnduggan clawtributor email

### DIFF
--- a/scripts/clawtributors-map.json
+++ b/scripts/clawtributors-map.json
@@ -33,6 +33,7 @@
   "emailToLogin": {
     "123guan@gmail.com": "guanbear",
     "guanbear@macmini.bearhome": "guanbear",
+    "shawn.duggan@gmail.com": "shawnduggan",
     "steipete@gmail.com": "steipete",
     "sbarrios93@gmail.com": "sebslight",
     "rltorres26+github@gmail.com": "RandyVentures",


### PR DESCRIPTION
## What Problem This Solves

Resolves a contributor-attribution gap where already-merged contributions from @shawnduggan are present on `main`, but GitHub's contributors API reports the commit author as an anonymous `shawnduggan <shawn.duggan@gmail.com>` record. Because the clawtributors generator cannot resolve that anonymous email to a GitHub login, it omits the account from the generated README avatar wall.

The affected merged contributions are #65914 and #89096.

## Why This Change Was Made

Maps `shawn.duggan@gmail.com` to `shawnduggan` through the existing `emailToLogin` attribution-correction table. This follows the same repository-owned mechanism and precedent as #90547; it does not add a manual `ensureLogins` entry or hand-edit the generated README wall.

## User Impact

The trusted clawtributors refresh now credits @shawnduggan with the account's current GitHub avatar and profile link. There is no product or runtime behavior change.

## Evidence

Current live contributors API response:

```json
{"contributions":1,"email":"shawn.duggan@gmail.com","html_url":null,"login":null,"name":"shawnduggan"}
```

GitHub attributes both merged commits to @shawnduggan:

- #65914: https://github.com/openclaw/openclaw/commit/1d55caa16283caac27b529c7dab9e2b33655cb15
- #89096: https://github.com/openclaw/openclaw/commit/f53e9f6e1cd5b4292d56066776d4f85df91182ef

Exact-head generator proof (2026-07-24):

- Reviewed head: `3c02ef82d8da5d1c8b71a0d746fb039d9b8c10d0`.
- Trust check: reconstructed from trusted parent `72ca08021830381c95e6c2583570c86b589b6a10` plus only this PR's audited one-line map change; the resulting map blob matched the reviewed head (`f04fd4b61a5459bd5292950e69b9c4f090322662`).
- Command: `node_modules/.bin/tsx scripts/update-clawtributors.ts`.
- Generator result: `Updated README clawtributors: 997 visible (143 default-avatar entries hidden)`.
- Before the run, the README had no `github.com/shawnduggan` entry; after the run, it had exactly one:

```markdown
[![shawnduggan](https://avatars.githubusercontent.com/u/3504807?v=4&s=48)](https://github.com/shawnduggan)
```

The live generator also refreshed unrelated concurrent contributor-wall entries, so that generated README churn is proof output only and is intentionally not part of this one-line mapping PR.

Validation:

- Parsed `scripts/clawtributors-map.json` and asserted the new mapping: passed.
- `git diff --check`: passed.
- `node scripts/run-vitest.mjs test/scripts/update-clawtributors.test.ts`: 1 file passed, 4 tests passed.
- Exact-head, GitHub-backed clawtributors generator refresh: passed; resolved @shawnduggan to the account's current avatar and profile URL.

AI-assisted: Codex checked the live contributor attribution, verified the existing generator contract and #90547 precedent, prepared the one-line mapping, ran the focused test, and completed the exact-head generator proof above.
