### PR TITLE
fix(i18n): keep generated Wear translations lint-clean

### DIFF
--- a/scripts/android-app-i18n.ts
+++ b/scripts/android-app-i18n.ts
@@ -79,6 +79,9 @@ type ResourceString = {
   value: string;
 };
 
+const GENERATED_TRANSLATION_LINT_IGNORE =
+  'tools:ignore="Typos,TypographyDashes,TypographyEllipsis"';
+
 type TranslationContradiction = {
   locale: string;
   selected: string;
@@ -1114,7 +1117,7 @@ function localizeManualStrings(
         ? selectExactArtifactTranslation(source, inventoryEntry.id, artifactEntries)
         : source;
     return {
-      attrs: entry.attrs,
+      attrs: translatable ? `${entry.attrs} ${GENERATED_TRANSLATION_LINT_IGNORE}` : entry.attrs,
       key: entry.key,
       rawValue: `"${escapeAndroidResourceValue(value)}"`,
       value,
@@ -1126,8 +1129,10 @@ function renderStringsXml(
   manual: readonly ResourceString[],
   generated: ReadonlyMap<string, { source: string; value: string }>,
 ): string {
+  const usesToolsNamespace =
+    generated.size > 0 || manual.some((entry) => entry.attrs.includes("tools:"));
   const lines = [
-    generated.size > 0
+    usesToolsNamespace
       ? '<resources xmlns:tools="http://schemas.android.com/tools">'
       : "<resources>",
   ];
@@ -1144,7 +1149,7 @@ function renderStringsXml(
       // Translation-memory text intentionally preserves technical tokens and source punctuation,
       // so Android's English dictionary and typography suggestions do not apply to managed keys.
       lines.push(
-        `    <string name="${key}"${formatted} tools:ignore="Typos,TypographyDashes,TypographyEllipsis">"${renderAndroidResourceValue(entry.source, entry.value)}"</string>`,
+        `    <string name="${key}"${formatted} ${GENERATED_TRANSLATION_LINT_IGNORE}>"${renderAndroidResourceValue(entry.source, entry.value)}"</string>`,
       );
     }
   }

--- a/test/scripts/android-app-i18n.test.ts
+++ b/test/scripts/android-app-i18n.test.ts
@@ -45,8 +45,10 @@ describe("Android app i18n resources", () => {
 
     expect(wearResources).toHaveLength(NATIVE_I18N_LOCALES.length);
     for (const [, content] of wearResources) {
-      const keys = [...content.matchAll(/<string name="([^"]+)"/gu)]
-        .map((match) => match[1])
+      const stringTags = [...content.matchAll(/<string\b[^>]*>/gu)].map((match) => match[0]);
+      const keys = stringTags
+        .map((tag) => tag.match(/\bname="([^"]+)"/u)?.[1])
+        .filter((key): key is string => key !== undefined)
         .toSorted();
       const placeholders = [...content.matchAll(/%\d+\$[a-z]/giu)]
         .map((match) => match[0])
@@ -54,6 +56,12 @@ describe("Android app i18n resources", () => {
       expect(keys).toEqual(baseKeys);
       expect(placeholders).toEqual(basePlaceholders);
       expect(content).not.toMatch(/(?:&apos;|(?<!\\)')/u);
+      expect(content).toContain('<resources xmlns:tools="http://schemas.android.com/tools">');
+      for (const tag of stringTags) {
+        if (!tag.includes('translatable="false"')) {
+          expect(tag).toContain('tools:ignore="Typos,TypographyDashes,TypographyEllipsis"');
+        }
+      }
     }
   });
 


### PR DESCRIPTION
Related: #112230
Follow-up to #112228

## What Problem This Solves

Fixes an issue where generated Wear translations could fail Android lint when a valid localized word matched an English typo heuristic. This blocked the native locale refresh from landing even though the translation was correct.

## Why This Change Was Made

Generated Wear strings now use the same Android typo and typography lint suppression as generated phone-app strings. The XML renderer also declares the `tools` namespace whenever translated manual rows use that policy, and the focused catalog test checks every generated translatable Wear row.

## User Impact

Native locale refreshes can publish valid Wear translations without language-specific false positives blocking the Android build. There is no runtime behavior change beyond allowing the generated localized resources to ship.

## Evidence

- Before: `android-build-wear` failed on the valid Portuguese verb `autentica`: https://github.com/openclaw/openclaw/actions/runs/29820633605/job/88602318872
- Fresh Blacksmith Testbox: `tbx_01ky23fzgtgbhxe4hsswc1bpag`
- Testbox hydration: https://github.com/openclaw/openclaw/actions/runs/29822333135
- `pnpm check:changed`
- `pnpm test:serial test/scripts/android-app-i18n.test.ts` (25 passed)
- `node --import tsx scripts/native-app-i18n.ts sync --write`
- `./gradlew --no-daemon --build-cache :wear:assembleDebug :wear:lintDebug` (BUILD SUCCESSFUL, 84 tasks)
- Fresh structured autoreview: no accepted or actionable findings
- AI-assisted; I reviewed and understand the change.
