### PR TITLE
fix(providers): prevent broken emoji in truncated provider errors

### DIFF
--- a/packages/ai/src/utils/provider-error.test.ts
+++ b/packages/ai/src/utils/provider-error.test.ts
@@ -34,4 +34,14 @@ describe("formatProviderError", () => {
 
     expect(formatProviderError(error)).toBe(body);
   });
+
+  it("does not split surrogate pairs when truncating a provider error body", () => {
+    const body = `${"x".repeat(3999)}😀details`;
+    const error = Object.assign(new Error("502 status code (no body)"), { status: 502, body });
+
+    const formatted = formatProviderError(error);
+
+    expect(formatted).toBe(`502: ${"x".repeat(3999)}... [truncated]`);
+    expect(Buffer.from(formatted).toString("utf8")).toBe(formatted);
+  });
 });

--- a/packages/ai/src/utils/provider-error.ts
+++ b/packages/ai/src/utils/provider-error.ts
@@ -1,3 +1,5 @@
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+
 const MAX_ERROR_BODY_LENGTH = 4000;
 
 type HttpErrorShape = Error & {
@@ -47,7 +49,7 @@ function readBody(error: HttpErrorShape): string | undefined {
     if (body.length > 0) {
       return body.length <= MAX_ERROR_BODY_LENGTH
         ? body
-        : `${body.slice(0, MAX_ERROR_BODY_LENGTH)}... [truncated]`;
+        : `${truncateUtf16Safe(body, MAX_ERROR_BODY_LENGTH)}... [truncated]`;
     }
   }
   return undefined;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users receiving a long provider error response could see a broken emoji replacement character when the response was truncated at the error-message limit.

## Why This Change Was Made

The shared provider error formatter now uses OpenClaw's existing surrogate-safe truncation utility. The existing limit and truncation marker remain unchanged.

## User Impact

Provider error messages remain valid text when an emoji crosses the truncation boundary, making failures easier to read and diagnose.

## Evidence

- Added a focused regression test covering an emoji split at the 4,000-character error-body boundary.
- Focused Vitest verification and `git diff --check` passed before commit.
- ClawSweeper full review passed for commit `2d0ddc9dd10d294b70b4063f85637e1de9f68672` with no findings.
