### PR TITLE
fix(release): validate frozen AI package exports

### DIFF
--- a/scripts/check-openclaw-package-tarball.mjs
+++ b/scripts/check-openclaw-package-tarball.mjs
@@ -84,7 +84,11 @@ const REQUIRED_BUNDLED_WORKSPACE_RUNTIME_ENTRIES = new Map([
     [
       { specifier: "@openclaw/ai", entry: "dist/index.mjs" },
       { specifier: "@openclaw/ai/providers", entry: "dist/providers.mjs" },
-      { specifier: "@openclaw/ai/transports", entry: "dist/transports.mjs" },
+      {
+        specifier: "@openclaw/ai/transports",
+        entry: "dist/transports.mjs",
+        whenExported: "./transports",
+      },
       {
         specifier: "@openclaw/ai/internal/runtime",
         entry: "dist/internal/runtime.mjs",
@@ -177,7 +181,17 @@ function collectBundledPackageRuntimeErrors({ name, entries, files, packageRoot,
   if (bundledPackageJson.name !== name) {
     errors.push(`bundled ${name} package.json must name ${name}`);
   }
-  const runtimeEntries = REQUIRED_BUNDLED_WORKSPACE_RUNTIME_ENTRIES.get(name) ?? [];
+  const packageExports =
+    bundledPackageJson.exports &&
+    typeof bundledPackageJson.exports === "object" &&
+    !Array.isArray(bundledPackageJson.exports)
+      ? bundledPackageJson.exports
+      : {};
+  // Trusted current-main harnesses validate frozen release targets. Require
+  // post-cut runtime subpaths only when the candidate manifest owns them.
+  const runtimeEntries = (REQUIRED_BUNDLED_WORKSPACE_RUNTIME_ENTRIES.get(name) ?? []).filter(
+    ({ whenExported }) => !whenExported || Object.hasOwn(packageExports, whenExported),
+  );
   const resolutions = resolveBundledPackageSpecifiers(
     packageRoot,
     runtimeEntries.map(({ specifier }) => specifier),

--- a/test/scripts/check-openclaw-package-tarball.test.ts
+++ b/test/scripts/check-openclaw-package-tarball.test.ts
@@ -30,6 +30,15 @@ const AI_RUNTIME_PACKAGE_JSON = JSON.stringify({
     "./internal/*": { import: "./dist/internal/*.mjs" },
   },
 });
+const LEGACY_AI_RUNTIME_PACKAGE_JSON = JSON.stringify({
+  name: "@openclaw/ai",
+  version: "2026.7.2-beta.4",
+  exports: {
+    ".": { import: "./dist/index.mjs" },
+    "./providers": { import: "./dist/providers.mjs" },
+    "./internal/*": { import: "./dist/internal/*.mjs" },
+  },
+});
 
 function withTarball(
   inventory: string[],
@@ -699,6 +708,36 @@ describe("check-openclaw-package-tarball", () => {
       {
         packageJson: {
           dependencies: { "@openclaw/ai": "2026.6.11" },
+          bundleDependencies: ["@openclaw/ai"],
+        },
+      },
+    );
+  });
+
+  it("accepts frozen AI runtimes that predate an optional exported subpath", () => {
+    withTarball(
+      ["dist/index.js"],
+      {
+        "dist/index.js": "export {};\n",
+        "node_modules/@openclaw/ai/package.json": LEGACY_AI_RUNTIME_PACKAGE_JSON,
+        "node_modules/@openclaw/ai/dist/index.mjs": "export {};\n",
+        "node_modules/@openclaw/ai/dist/providers.mjs": "export {};\n",
+        "node_modules/@openclaw/ai/dist/internal/runtime.mjs": "export {};\n",
+      },
+      (tarball) => {
+        const result = spawnSync(
+          "node",
+          [CHECK_SCRIPT, "--require-bundled-workspace-deps", tarball],
+          { encoding: "utf8" },
+        );
+
+        expect(result.status, result.stderr).toBe(0);
+        expect(result.stdout).toContain("OpenClaw package tarball integrity passed.");
+      },
+      "2026.7.2-beta.4",
+      {
+        packageJson: {
+          dependencies: { "@openclaw/ai": "2026.7.2-beta.4" },
           bundleDependencies: ["@openclaw/ai"],
         },
       },


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Full Release Validation for a frozen release branch would fail installer smoke after `main` added a new `@openclaw/ai` export that the older candidate never declared.

The failure is visible in Full Release Validation run 29820445413 and Release Checks run 29821375894: the current trusted installer harness required `@openclaw/ai/transports` from the frozen `2026.7.2-beta.4` package even though that subpath was introduced after the branch cut.

## Why This Change Was Made

The tarball checker keeps its baseline AI runtime entries mandatory, but validates post-cut runtime subpaths only when the bundled candidate manifest exports them. Current packages that export `./transports` still must ship and resolve `dist/transports.mjs`; historical candidates are judged against their own declared package surface.

This is deliberately a harness compatibility fix. It does not backport the later AI transport refactor into the active release branch.

## User Impact

No direct product behavior changes. Release operators can validate frozen release candidates with the current trusted harness without newer `main` package surfaces being imposed retroactively.

AI-assisted; I reviewed the code and understand the compatibility boundary.

## Evidence

- Before: Release Checks run 29821375894 failed installer smoke because bundled `@openclaw/ai` lacked main-only `dist/transports.mjs`.
- Focused Testbox proof: https://github.com/openclaw/openclaw/actions/runs/29824088328
  - `pnpm test test/scripts/check-openclaw-package-tarball.test.ts` — 36 tests passed.
  - `pnpm format:check` — passed.
- Codex autoreview: clean, no accepted/actionable findings.
