### PR TITLE
fix(gateway): keep fresh-state startup responsive with prepared runtimes

### DIFF
--- a/scripts/bench-gateway-startup.ts
+++ b/scripts/bench-gateway-startup.ts
@@ -24,6 +24,7 @@ type GatewayBenchCase = {
   name: string;
   pluginActivationOnStartup?: boolean;
   pluginCount?: number;
+  providerCatalogStallMs?: number;
 };
 
 type ProbeResult = {
@@ -141,6 +142,9 @@ const BASE_CONFIG = {
   },
 } satisfies Record<string, unknown>;
 
+const STALLED_CATALOG_PROVIDER_ID = "bench-catalog-stall";
+const STALLED_CATALOG_MODEL_ID = "bench-model";
+
 const GATEWAY_CASES: readonly GatewayBenchCase[] = [
   {
     id: "default",
@@ -152,6 +156,25 @@ const GATEWAY_CASES: readonly GatewayBenchCase[] = [
     name: "gateway, skip channels",
     env: { OPENCLAW_SKIP_CHANNELS: "1" },
     config: BASE_CONFIG,
+  },
+  {
+    id: "preparedRuntimeCatalogStall",
+    name: "gateway, prepared runtime with CPU-stalling live catalog",
+    env: { OPENCLAW_SKIP_CHANNELS: "1" },
+    providerCatalogStallMs: 2_000,
+    config: {
+      ...BASE_CONFIG,
+      agents: {
+        defaults: {
+          model: { primary: `${STALLED_CATALOG_PROVIDER_ID}/${STALLED_CATALOG_MODEL_ID}` },
+          models: {
+            [`${STALLED_CATALOG_PROVIDER_ID}/${STALLED_CATALOG_MODEL_ID}`]: {
+              agentRuntime: { id: "openclaw" },
+            },
+          },
+        },
+      },
+    },
   },
   {
     id: "oneInternalHook",
@@ -612,17 +635,36 @@ function writePluginFixtures(
   root: string,
   count: number,
   activationOnStartup?: boolean,
+  providerCatalogStallMs?: number,
 ): PluginFixtureResult {
   const pluginIds: string[] = [];
   const pluginsDir = path.join(root, "plugins");
   mkdirSync(pluginsDir, { recursive: true });
   for (let index = 0; index < count; index += 1) {
     const id = `bench-plugin-${String(index + 1).padStart(2, "0")}`;
+    const stallsProviderCatalog = providerCatalogStallMs !== undefined && index === 0;
     pluginIds.push(id);
     const pluginDir = path.join(pluginsDir, id);
     mkdirSync(pluginDir, { recursive: true });
     const entry = path.join(pluginDir, "index.cjs");
-    writeFileSync(entry, `module.exports = { id: ${JSON.stringify(id)}, register() {} };\n`);
+    const model = {
+      id: STALLED_CATALOG_MODEL_ID,
+      name: "Benchmark Model",
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 128_000,
+      maxTokens: 8_192,
+    };
+    const provider = {
+      baseUrl: "http://127.0.0.1:1/v1",
+      api: "openai-completions",
+      models: [model],
+    };
+    const entrySource = stallsProviderCatalog
+      ? `const provider = ${JSON.stringify(provider)};\nmodule.exports = { id: ${JSON.stringify(id)}, register(api) { api.registerProvider({ id: ${JSON.stringify(STALLED_CATALOG_PROVIDER_ID)}, label: "Benchmark Catalog Stall", auth: [], catalog: { order: "simple", run: async () => { const stopAt = Date.now() + ${providerCatalogStallMs}; while (Date.now() < stopAt) {} return { provider }; } }, staticCatalog: { order: "simple", run: async () => ({ provider }) } }); } };\n`
+      : `module.exports = { id: ${JSON.stringify(id)}, register() {} };\n`;
+    writeFileSync(entry, entrySource);
     writeFileSync(
       path.join(pluginDir, "openclaw.plugin.json"),
       `${JSON.stringify(
@@ -631,6 +673,14 @@ function writePluginFixtures(
           ...(activationOnStartup === undefined
             ? {}
             : { activation: { onStartup: activationOnStartup } }),
+          ...(stallsProviderCatalog
+            ? {
+                providers: [STALLED_CATALOG_PROVIDER_ID],
+                modelCatalog: {
+                  providers: { [STALLED_CATALOG_PROVIDER_ID]: provider },
+                },
+              }
+            : {}),
           configSchema: { type: "object", additionalProperties: false },
         },
         null,
@@ -642,8 +692,14 @@ function writePluginFixtures(
 }
 
 function writeConfig(root: string, benchCase: GatewayBenchCase): string {
-  const pluginFixtures = benchCase.pluginCount
-    ? writePluginFixtures(root, benchCase.pluginCount, benchCase.pluginActivationOnStartup)
+  const pluginCount = benchCase.providerCatalogStallMs === undefined ? benchCase.pluginCount : 1;
+  const pluginFixtures = pluginCount
+    ? writePluginFixtures(
+        root,
+        pluginCount,
+        benchCase.providerCatalogStallMs === undefined ? benchCase.pluginActivationOnStartup : true,
+        benchCase.providerCatalogStallMs,
+      )
     : null;
   const config = {
     ...benchCase.config,

--- a/src/agents/embedded-agent-runner/model.static-catalog.ts
+++ b/src/agents/embedded-agent-runner/model.static-catalog.ts
@@ -205,6 +205,7 @@ type BundledProviderStaticCatalogResolverParams = {
   cfg?: OpenClawConfig;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
+  providerIds?: readonly string[];
 };
 
 /**
@@ -371,11 +372,25 @@ export async function loadBundledProviderStaticCatalogContextModels(
       plugin.origin === "bundled" && plugin.providerDiscoverySource ? [plugin.id] : [],
     ),
   );
-  const pluginIds = resolveBundledProviderCompatPluginIds({
-    config: params.cfg,
-    workspaceDir: params.workspaceDir,
-    env,
-  }).filter((pluginId) => discoveryEntryPluginIds.has(pluginId));
+  const providerScopedPluginIds = params.providerIds?.flatMap((provider) =>
+    resolveBundledProviderStaticCatalogPluginIds({
+      provider,
+      cfg: params.cfg,
+      workspaceDir: params.workspaceDir,
+      env,
+    }),
+  );
+  const candidatePluginIds =
+    providerScopedPluginIds === undefined
+      ? resolveBundledProviderCompatPluginIds({
+          config: params.cfg,
+          workspaceDir: params.workspaceDir,
+          env,
+        })
+      : providerScopedPluginIds;
+  const pluginIds = [...new Set(candidatePluginIds)]
+    .filter((pluginId) => discoveryEntryPluginIds.has(pluginId))
+    .toSorted((left, right) => left.localeCompare(right));
   if (pluginIds.length === 0) {
     return [];
   }

--- a/src/agents/model-catalog.test.ts
+++ b/src/agents/model-catalog.test.ts
@@ -36,6 +36,7 @@ async function build(params: {
   config?: OpenClawConfig;
   entries?: ModelCatalogEntry[];
   readOnly?: boolean;
+  includeProviderPluginAugmentation?: boolean;
 }) {
   return await buildPreparedModelCatalogSnapshot({
     agentDir: "/tmp/model-catalog-test",
@@ -44,6 +45,9 @@ async function build(params: {
     metadataSnapshot,
     modelRegistry: registry(params.entries ?? []),
     readOnly: params.readOnly ?? true,
+    ...(params.includeProviderPluginAugmentation !== undefined
+      ? { includeProviderPluginAugmentation: params.includeProviderPluginAugmentation }
+      : {}),
   });
 }
 
@@ -169,6 +173,31 @@ describe("prepared model catalog builder", () => {
         readOnly: true,
       }),
     ).rejects.toBe(projectionError);
+  });
+
+  it("keeps static publication off provider runtime catalog augmentation", async () => {
+    const snapshot = await build({
+      config: {
+        plugins: { enabled: false },
+        models: {
+          providers: {
+            openai: {
+              baseUrl: "https://api.openai.com/v1",
+              api: "openai-responses",
+              models: [],
+            },
+          },
+        },
+      },
+      entries: [{ id: "gpt-5.5", name: "GPT-5.5", provider: "openai" }],
+      readOnly: false,
+      includeProviderPluginAugmentation: false,
+    });
+
+    expect(snapshot.entries).toEqual([
+      expect.objectContaining({ id: "gpt-5.5", provider: "openai" }),
+    ]);
+    expect(mocks.augmentModelCatalogWithProviderPlugins).not.toHaveBeenCalled();
   });
 
   it("uses the lifecycle auth snapshot for provider catalog augmentation", async () => {

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -67,6 +67,7 @@ export type BuildPreparedModelCatalogParams = {
   config: OpenClawConfig;
   modelRegistry: ModelRegistry;
   readOnly?: boolean;
+  includeProviderPluginAugmentation?: boolean;
   metadataSnapshot: PluginMetadataSnapshot;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
@@ -476,7 +477,7 @@ export async function buildPreparedModelCatalogSnapshot(
     }
     logStage("configured-models-prepared", `entries=${models.length}`);
 
-    if (!params.readOnly) {
+    if (!params.readOnly && params.includeProviderPluginAugmentation !== false) {
       const { createProviderApiKeyResolverFromPreparedCredentials } =
         await loadProviderApiKeyResolver();
       const resolveProviderApiKeyForProvider = createProviderApiKeyResolverFromPreparedCredentials(

--- a/src/agents/models-config.providers.implicit.discovery-scope.test.ts
+++ b/src/agents/models-config.providers.implicit.discovery-scope.test.ts
@@ -177,6 +177,19 @@ describe("resolveImplicitProviders startup discovery scope", () => {
     expect(discoveryOptions?.discoveryEntriesOnly).toBe(true);
   });
 
+  it("does not fall through to live catalogs when entries-only providers lack static rows", async () => {
+    await resolveImplicitProviders({
+      agentDir: "/tmp/openclaw-agent",
+      config: {},
+      env: {} as NodeJS.ProcessEnv,
+      explicitProviders: {},
+      providerDiscoveryEntriesOnly: true,
+    });
+
+    expect(mocks.runProviderCatalog).not.toHaveBeenCalled();
+    expect(mocks.runProviderStaticCatalog).not.toHaveBeenCalled();
+  });
+
   it("uses static provider catalogs for entries-only startup discovery", async () => {
     mocks.resolveRuntimePluginDiscoveryProviders.mockResolvedValue([
       createProviderWithStaticCatalog("codex"),

--- a/src/agents/models-config.providers.implicit.ts
+++ b/src/agents/models-config.providers.implicit.ts
@@ -410,6 +410,10 @@ async function resolvePluginImplicitProviders(
       };
     };
 
+    if (ctx.providerDiscoveryEntriesOnly === true && !provider.staticCatalog) {
+      // Mandatory startup accepts only provider facts that do not execute live discovery.
+      continue;
+    }
     const useStaticCatalog =
       Boolean(provider.staticCatalog) &&
       (ctx.providerDiscoveryEntriesOnly === true || !hasRuntimeProviderCatalog(provider));

--- a/src/agents/prepared-model-runtime.lifecycle.test.ts
+++ b/src/agents/prepared-model-runtime.lifecycle.test.ts
@@ -4,11 +4,7 @@ type LoadStaticCatalog =
   typeof import("./embedded-agent-runner/model.static-catalog.js").loadBundledProviderStaticCatalogContextModels;
 
 const mocks = vi.hoisted(() => ({
-  authStorage: {
-    getAll: vi.fn<() => Record<string, { type: "api_key"; key: string }>>(() => ({
-      custom: { type: "api_key", key: "test-key" },
-    })),
-  },
+  authStorage: { getAll: vi.fn(() => ({ custom: { type: "api_key", key: "test-key" } })) },
   modelRegistry: {
     fork: vi.fn((authStorage: unknown) => ({ authStorage })),
     getAll: vi.fn(() => []),
@@ -109,8 +105,6 @@ describe("prepared model runtime snapshots", () => {
 
   beforeEach(() => {
     getTesting().resetPreparedModelRuntimeSnapshotsForTest();
-    mocks.authStorage.getAll.mockReset();
-    mocks.authStorage.getAll.mockReturnValue({ custom: { type: "api_key", key: "test-key" } });
     mocks.discoverAuthStorage.mockClear();
     mocks.discoverModels.mockClear();
     mocks.ensureOpenClawModelsJson.mockReset();
@@ -162,47 +156,6 @@ describe("prepared model runtime snapshots", () => {
       }),
     ).resolves.toMatchObject({ config: configured });
     expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledOnce();
-  });
-
-  it("scopes mandatory configured publication to static facts for prepared providers", async () => {
-    mocks.configuredAgentIds = ["default"];
-    mocks.authStorage.getAll.mockReturnValue({
-      openai: { type: "api_key", key: "test-openai-key" },
-    });
-    const config = {
-      agents: {
-        defaults: {
-          model: { primary: "openai/gpt-5.5" },
-          models: { "openai/gpt-5.5": { agentRuntime: { id: "openclaw" } } },
-        },
-      },
-    };
-
-    await refreshPreparedModelRuntimeSnapshots(config, {
-      gatewayLifecycle: true,
-      catalogMode: "static",
-    });
-
-    expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledWith(
-      config,
-      "/tmp/unused-agent",
-      expect.objectContaining({
-        pluginMetadataSnapshot: expect.any(Object),
-        providerDiscoveryEntriesOnly: true,
-        providerDiscoveryProviderIds: ["openai"],
-      }),
-    );
-    expect(mocks.discoverModels).toHaveBeenCalledWith(
-      mocks.authStorage,
-      "/tmp/unused-agent",
-      expect.objectContaining({ normalizeModels: false }),
-    );
-    expect(mocks.buildPreparedModelCatalogSnapshot).toHaveBeenCalledWith(
-      expect.objectContaining({ includeProviderPluginAugmentation: false }),
-    );
-    expect(mocks.loadStaticCatalog).toHaveBeenCalledWith(
-      expect.objectContaining({ providerIds: ["openai"] }),
-    );
   });
 
   it("retires a standalone run owner when its final lease releases", async () => {

--- a/src/agents/prepared-model-runtime.lifecycle.test.ts
+++ b/src/agents/prepared-model-runtime.lifecycle.test.ts
@@ -4,7 +4,11 @@ type LoadStaticCatalog =
   typeof import("./embedded-agent-runner/model.static-catalog.js").loadBundledProviderStaticCatalogContextModels;
 
 const mocks = vi.hoisted(() => ({
-  authStorage: { getAll: vi.fn(() => ({ custom: { type: "api_key", key: "test-key" } })) },
+  authStorage: {
+    getAll: vi.fn<() => Record<string, { type: "api_key"; key: string }>>(() => ({
+      custom: { type: "api_key", key: "test-key" },
+    })),
+  },
   modelRegistry: {
     fork: vi.fn((authStorage: unknown) => ({ authStorage })),
     getAll: vi.fn(() => []),
@@ -105,6 +109,8 @@ describe("prepared model runtime snapshots", () => {
 
   beforeEach(() => {
     getTesting().resetPreparedModelRuntimeSnapshotsForTest();
+    mocks.authStorage.getAll.mockReset();
+    mocks.authStorage.getAll.mockReturnValue({ custom: { type: "api_key", key: "test-key" } });
     mocks.discoverAuthStorage.mockClear();
     mocks.discoverModels.mockClear();
     mocks.ensureOpenClawModelsJson.mockReset();
@@ -156,6 +162,47 @@ describe("prepared model runtime snapshots", () => {
       }),
     ).resolves.toMatchObject({ config: configured });
     expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledOnce();
+  });
+
+  it("scopes mandatory configured publication to static facts for prepared providers", async () => {
+    mocks.configuredAgentIds = ["default"];
+    mocks.authStorage.getAll.mockReturnValue({
+      openai: { type: "api_key", key: "test-openai-key" },
+    });
+    const config = {
+      agents: {
+        defaults: {
+          model: { primary: "openai/gpt-5.5" },
+          models: { "openai/gpt-5.5": { agentRuntime: { id: "openclaw" } } },
+        },
+      },
+    };
+
+    await refreshPreparedModelRuntimeSnapshots(config, {
+      gatewayLifecycle: true,
+      catalogMode: "static",
+    });
+
+    expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledWith(
+      config,
+      "/tmp/unused-agent",
+      expect.objectContaining({
+        pluginMetadataSnapshot: expect.any(Object),
+        providerDiscoveryEntriesOnly: true,
+        providerDiscoveryProviderIds: ["openai"],
+      }),
+    );
+    expect(mocks.discoverModels).toHaveBeenCalledWith(
+      mocks.authStorage,
+      "/tmp/unused-agent",
+      expect.objectContaining({ normalizeModels: false }),
+    );
+    expect(mocks.buildPreparedModelCatalogSnapshot).toHaveBeenCalledWith(
+      expect.objectContaining({ includeProviderPluginAugmentation: false }),
+    );
+    expect(mocks.loadStaticCatalog).toHaveBeenCalledWith(
+      expect.objectContaining({ providerIds: ["openai"] }),
+    );
   });
 
   it("retires a standalone run owner when its final lease releases", async () => {
@@ -760,7 +807,7 @@ describe("prepared model runtime snapshots", () => {
       .mockImplementationOnce(async () => await new Promise<never>(() => {}));
 
     await expect(
-      refreshPreparedModelRuntimeSnapshots({}, { gatewayLifecycle: true }),
+      refreshPreparedModelRuntimeSnapshots({}, { gatewayLifecycle: true, catalogMode: "static" }),
     ).resolves.toBeUndefined();
     expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledOnce();
   });

--- a/src/agents/prepared-model-runtime.owner.ts
+++ b/src/agents/prepared-model-runtime.owner.ts
@@ -27,7 +27,7 @@ import type { ModelRegistry } from "./sessions/model-registry.js";
 
 const MODEL_RUNTIME_PROVIDER_DISCOVERY_TIMEOUT_MS = 5_000;
 
-export type PreparedModelRuntimeCatalogMode = "live" | "static";
+type PreparedModelRuntimeCatalogMode = "live" | "static";
 
 export type PreparedModelRuntimeSnapshot = Readonly<{
   agentId?: string;

--- a/src/agents/prepared-model-runtime.owner.ts
+++ b/src/agents/prepared-model-runtime.owner.ts
@@ -1,5 +1,7 @@
 /** Construction and owner identity for prepared model runtime generations. */
 import path from "node:path";
+import { collectConfiguredModelRefs } from "@openclaw/model-catalog-core/configured-model-refs";
+import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { hashRuntimeConfigValue } from "../config/runtime-snapshot.js";
 import { MODEL_APIS } from "../config/types.models.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -20,10 +22,12 @@ import { buildPreparedModelCatalogSnapshot, type ModelCatalogEntry } from "./mod
 import type { ModelCatalogSnapshot } from "./model-catalog.types.js";
 import { ensureOpenClawModelsJson } from "./models-config.js";
 import { ensureRuntimePluginsLoaded } from "./runtime-plugins.js";
-import { AuthStorage } from "./sessions/auth-storage.js";
+import { AuthStorage, type AuthStorageData } from "./sessions/auth-storage.js";
 import type { ModelRegistry } from "./sessions/model-registry.js";
 
 const MODEL_RUNTIME_PROVIDER_DISCOVERY_TIMEOUT_MS = 5_000;
+
+export type PreparedModelRuntimeCatalogMode = "live" | "static";
 
 export type PreparedModelRuntimeSnapshot = Readonly<{
   agentId?: string;
@@ -61,6 +65,7 @@ export type PreparedModelRuntimeLease = Readonly<{
 export type PreparedModelRuntimeOwner = {
   input: PreparedModelRuntimeInput;
   environmentFingerprint: string;
+  catalogMode: PreparedModelRuntimeCatalogMode;
   provenance: "configured" | "standalone" | "explicit" | "run" | "ephemeral";
   generation: number;
   needsRefresh: boolean;
@@ -224,6 +229,32 @@ function toStaticCatalogEntry(
   };
 }
 
+function collectPreparedModelRuntimeProviderIds(
+  config: OpenClawConfig,
+  credentials: Readonly<AuthStorageData>,
+): string[] {
+  const providerIds = new Set<string>();
+  const addProviderId = (value: string) => {
+    const providerId = normalizeProviderId(value);
+    if (providerId) {
+      providerIds.add(providerId);
+    }
+  };
+  for (const providerId of Object.keys(credentials)) {
+    addProviderId(providerId);
+  }
+  for (const providerId of Object.keys(config.models?.providers ?? {})) {
+    addProviderId(providerId);
+  }
+  for (const ref of collectConfiguredModelRefs(config)) {
+    const separator = ref.value.indexOf("/");
+    if (separator > 0) {
+      addProviderId(ref.value.slice(0, separator));
+    }
+  }
+  return [...providerIds].toSorted((left, right) => left.localeCompare(right));
+}
+
 export function ownerKey(input: PreparedModelRuntimeInput): string {
   return JSON.stringify({
     agentId: input.agentId,
@@ -325,6 +356,7 @@ export function listConfiguredOwnerInputs(
 
 async function buildSnapshot(
   input: PreparedModelRuntimeInput,
+  catalogMode: PreparedModelRuntimeCatalogMode,
 ): Promise<PreparedModelRuntimeSnapshot> {
   const env = input.env ?? process.env;
   if (!input.readOnly) {
@@ -340,35 +372,44 @@ async function buildSnapshot(
     env,
     ...(input.workspaceDir ? { workspaceDir: input.workspaceDir } : {}),
   });
-  if (!input.readOnly) {
-    await ensureOpenClawModelsJson(input.config, input.agentDir, {
-      ...(input.workspaceDir ? { workspaceDir: input.workspaceDir } : {}),
-      ...(input.env ? { env } : {}),
-      providerDiscoveryTimeoutMs: MODEL_RUNTIME_PROVIDER_DISCOVERY_TIMEOUT_MS,
-    });
-  }
   const templateAuthStorage = discoverAuthStorage(input.agentDir, {
     config: input.config,
-    // Snapshot construction never initializes, migrates, or externally syncs auth. A writable
-    // generation performs its file preparation above; ModelRegistry discovery only parses it.
+    // Snapshot construction never initializes, migrates, or externally syncs auth. ModelRegistry
+    // discovery only parses the credential generation captured here.
     readOnly: true,
     ...(input.skipCredentials ? { skipCredentials: true } : {}),
     ...(input.inheritedAuthDir ? { inheritedAuthDir: input.inheritedAuthDir } : {}),
     ...(input.workspaceDir ? { workspaceDir: input.workspaceDir } : {}),
     ...(input.env ? { env } : {}),
   });
+  const credentials = templateAuthStorage.getAll();
+  const providerIds = collectPreparedModelRuntimeProviderIds(input.config, credentials);
+  if (!input.readOnly) {
+    await ensureOpenClawModelsJson(input.config, input.agentDir, {
+      pluginMetadataSnapshot,
+      ...(input.workspaceDir ? { workspaceDir: input.workspaceDir } : {}),
+      ...(input.env ? { env } : {}),
+      ...(catalogMode === "static"
+        ? {
+            providerDiscoveryEntriesOnly: true,
+            providerDiscoveryProviderIds: providerIds,
+          }
+        : { providerDiscoveryTimeoutMs: MODEL_RUNTIME_PROVIDER_DISCOVERY_TIMEOUT_MS }),
+    });
+  }
   const templateModelRegistry = discoverModels(templateAuthStorage, input.agentDir, {
     config: input.config,
     ...(input.workspaceDir ? { workspaceDir: input.workspaceDir } : {}),
     ...(pluginMetadataSnapshot ? { pluginMetadataSnapshot } : {}),
+    ...(catalogMode === "static" ? { normalizeModels: false } : {}),
   });
-  const credentials = templateAuthStorage.getAll();
   const modelCatalog = await buildPreparedModelCatalogSnapshot({
     agentDir: input.agentDir,
     authCredentials: credentials,
     config: input.config,
     modelRegistry: templateModelRegistry,
     metadataSnapshot: pluginMetadataSnapshot,
+    includeProviderPluginAugmentation: catalogMode === "live",
     ...(input.env ? { env } : {}),
     ...(input.readOnly ? { readOnly: true } : {}),
     ...(input.workspaceDir ? { workspaceDir: input.workspaceDir } : {}),
@@ -377,6 +418,7 @@ async function buildSnapshot(
     await loadBundledProviderStaticCatalogContextModels({
       cfg: input.config,
       env,
+      ...(catalogMode === "static" ? { providerIds } : {}),
       ...(input.workspaceDir ? { workspaceDir: input.workspaceDir } : {}),
     })
   ).map(toStaticCatalogEntry);
@@ -402,6 +444,7 @@ export function startSerializedSnapshotBuild(
   input: PreparedModelRuntimeInput,
   agentBuildCompletions: Map<string, Promise<void>>,
   buildTimeoutMs: number,
+  catalogMode: PreparedModelRuntimeCatalogMode = "live",
 ): {
   pending: Promise<PreparedModelRuntimeSnapshot>;
   completion: Promise<void>;
@@ -413,7 +456,7 @@ export function startSerializedSnapshotBuild(
     if (previousBuildCompletion) {
       await previousBuildCompletion;
     }
-    return { actualBuild: buildSnapshot(input) };
+    return { actualBuild: buildSnapshot(input, catalogMode) };
   })();
   const completion = startBuild
     .then(async ({ actualBuild }) => await actualBuild)
@@ -447,23 +490,31 @@ export async function publishModelRuntimeSnapshot(
   buildTimeoutMs: number,
   existing?: PreparedModelRuntimeOwner,
   provenance: PreparedModelRuntimeOwner["provenance"] = "explicit",
+  catalogMode: PreparedModelRuntimeCatalogMode = existing?.catalogMode ?? "live",
 ): Promise<PreparedModelRuntimeSnapshot> {
   const key = ownerKey(input);
   const owner: PreparedModelRuntimeOwner = existing ?? {
     input,
     environmentFingerprint: effectiveEnvironmentFingerprint(input),
+    catalogMode,
     provenance,
     generation: 0,
     needsRefresh: false,
   };
   owner.input = input;
   owner.environmentFingerprint = effectiveEnvironmentFingerprint(input);
+  owner.catalogMode = catalogMode;
   owner.provenance = provenance;
   owner.generation += 1;
   owner.needsRefresh = true;
   owner.refreshError = undefined;
   const generation = owner.generation;
-  const build = startSerializedSnapshotBuild(input, agentBuildCompletions, buildTimeoutMs);
+  const build = startSerializedSnapshotBuild(
+    input,
+    agentBuildCompletions,
+    buildTimeoutMs,
+    catalogMode,
+  );
   owner.buildCompletion = build.completion;
   void build.completion.then(() => {
     if (owner.buildCompletion === build.completion) {

--- a/src/agents/prepared-model-runtime.owner.ts
+++ b/src/agents/prepared-model-runtime.owner.ts
@@ -62,6 +62,18 @@ export type PreparedModelRuntimeLease = Readonly<{
   release: () => void;
 }>;
 
+export type PreparedModelRuntimePublicationOptions = {
+  force?: boolean;
+  provenance?: PreparedModelRuntimeOwner["provenance"];
+  catalogMode?: PreparedModelRuntimeCatalogMode;
+};
+
+export type PreparedModelRuntimeRefreshOptions = {
+  gatewayLifecycle?: boolean;
+  defaultWorkspaceDir?: string;
+  catalogMode?: PreparedModelRuntimeCatalogMode;
+};
+
 export type PreparedModelRuntimeOwner = {
   input: PreparedModelRuntimeInput;
   environmentFingerprint: string;
@@ -75,6 +87,21 @@ export type PreparedModelRuntimeOwner = {
   buildCompletion?: Promise<void>;
   leaseCount?: number;
 };
+
+export function createPreparedModelRuntimeOwner(
+  input: PreparedModelRuntimeInput,
+  provenance: PreparedModelRuntimeOwner["provenance"],
+  catalogMode: PreparedModelRuntimeCatalogMode = "live",
+): PreparedModelRuntimeOwner {
+  return {
+    input,
+    environmentFingerprint: effectiveEnvironmentFingerprint(input),
+    catalogMode,
+    provenance,
+    generation: 0,
+    needsRefresh: true,
+  };
+}
 
 export type PreparedModelRuntimeReplacement = {
   gateId: PreparedModelRuntimeReplacementGateId;
@@ -493,14 +520,7 @@ export async function publishModelRuntimeSnapshot(
   catalogMode: PreparedModelRuntimeCatalogMode = existing?.catalogMode ?? "live",
 ): Promise<PreparedModelRuntimeSnapshot> {
   const key = ownerKey(input);
-  const owner: PreparedModelRuntimeOwner = existing ?? {
-    input,
-    environmentFingerprint: effectiveEnvironmentFingerprint(input),
-    catalogMode,
-    provenance,
-    generation: 0,
-    needsRefresh: false,
-  };
+  const owner = existing ?? createPreparedModelRuntimeOwner(input, provenance, catalogMode);
   owner.input = input;
   owner.environmentFingerprint = effectiveEnvironmentFingerprint(input);
   owner.catalogMode = catalogMode;

--- a/src/agents/prepared-model-runtime.startup-static.test.ts
+++ b/src/agents/prepared-model-runtime.startup-static.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const metadataSnapshot = {
+    plugins: [],
+    pluginIds: [],
+    index: { plugins: [] },
+    manifestRegistry: { plugins: [], diagnostics: [] },
+    owners: {
+      channels: new Map(),
+      channelConfigs: new Map(),
+      providers: new Map([["openai", ["openai"]]]),
+      modelCatalogProviders: new Map(),
+      cliBackends: new Map(),
+      setupProviders: new Map(),
+      commandAliases: new Map(),
+      contracts: new Map(),
+    },
+  };
+  const authStorage = {
+    getAll: vi.fn(() => ({ openai: { type: "api_key" as const, key: "test-openai-key" } })),
+  };
+  const modelRegistry = {
+    fork: vi.fn((nextAuthStorage: unknown) => ({ authStorage: nextAuthStorage })),
+    getAll: vi.fn(() => []),
+  };
+  return {
+    authStorage,
+    modelRegistry,
+    metadataSnapshot,
+    discoverAuthStorage: vi.fn(() => authStorage),
+    discoverModels: vi.fn(() => modelRegistry),
+    ensureOpenClawModelsJson: vi.fn(async () => ({ agentDir: "/tmp/agent", wrote: false })),
+    buildPreparedModelCatalogSnapshot: vi.fn(async () => ({ entries: [], routeVariants: [] })),
+    ensureRuntimePluginsLoaded: vi.fn(),
+    loadStaticCatalog: vi.fn(async () => []),
+    mutationListener: undefined as
+      | ((event: { agentDir?: string; affectsInheritedStores: boolean }) => void)
+      | undefined,
+  };
+});
+
+vi.mock("../plugins/plugin-metadata-snapshot.js", () => ({
+  resolvePluginMetadataSnapshot: () => mocks.metadataSnapshot,
+}));
+
+vi.mock("./agent-model-discovery.js", () => ({
+  discoverAuthStorage: mocks.discoverAuthStorage,
+  discoverModels: mocks.discoverModels,
+}));
+
+vi.mock("./agent-scope.js", () => ({
+  listAgentIds: () => ["default"],
+  resolveAgentDir: () => "/tmp/prepared-static-agent",
+  resolveAgentWorkspaceDir: () => "/tmp/prepared-static-workspace",
+  resolveDefaultAgentDir: () => "/tmp/prepared-static-agent",
+  resolveDefaultAgentId: () => "default",
+}));
+
+vi.mock("./auth-profiles/runtime-snapshots.js", () => ({
+  registerRuntimeAuthProfileStoreMutationListener: (
+    listener: (event: { agentDir?: string; affectsInheritedStores: boolean }) => void,
+  ) => {
+    mocks.mutationListener = listener;
+    return () => {};
+  },
+}));
+
+vi.mock("./model-catalog.js", () => ({
+  buildPreparedModelCatalogSnapshot: mocks.buildPreparedModelCatalogSnapshot,
+}));
+
+vi.mock("./models-config.js", () => ({
+  ensureOpenClawModelsJson: mocks.ensureOpenClawModelsJson,
+}));
+
+vi.mock("./runtime-plugins.js", () => ({
+  ensureRuntimePluginsLoaded: mocks.ensureRuntimePluginsLoaded,
+}));
+
+vi.mock("./embedded-agent-runner/model.static-catalog.js", () => ({
+  loadBundledProviderStaticCatalogContextModels: mocks.loadStaticCatalog,
+}));
+
+vi.mock("../logging/subsystem.js", () => ({
+  createSubsystemLogger: () => ({ warn: vi.fn() }),
+}));
+
+const { refreshPreparedModelRuntimeSnapshots } = await import("./prepared-model-runtime.js");
+const { resetPreparedModelRuntimeSnapshotsForTest } =
+  await import("./prepared-model-runtime.test-support.js");
+
+beforeEach(() => {
+  resetPreparedModelRuntimeSnapshotsForTest();
+  vi.clearAllMocks();
+});
+
+describe("prepared model runtime Gateway catalog mode", () => {
+  it("keeps startup and auth refreshes on configured static provider facts", async () => {
+    const config = {
+      agents: {
+        defaults: {
+          model: { primary: "openai/gpt-5.5" },
+          models: { "openai/gpt-5.5": { agentRuntime: { id: "openclaw" } } },
+        },
+      },
+    };
+
+    await refreshPreparedModelRuntimeSnapshots(config, {
+      gatewayLifecycle: true,
+      catalogMode: "static",
+    });
+
+    const expectedStaticOptions = expect.objectContaining({
+      pluginMetadataSnapshot: mocks.metadataSnapshot,
+      providerDiscoveryEntriesOnly: true,
+      providerDiscoveryProviderIds: ["openai"],
+    });
+    expect(mocks.ensureOpenClawModelsJson).toHaveBeenLastCalledWith(
+      config,
+      "/tmp/prepared-static-agent",
+      expectedStaticOptions,
+    );
+    expect(mocks.discoverModels).toHaveBeenLastCalledWith(
+      mocks.authStorage,
+      "/tmp/prepared-static-agent",
+      expect.objectContaining({ normalizeModels: false }),
+    );
+    expect(mocks.buildPreparedModelCatalogSnapshot).toHaveBeenLastCalledWith(
+      expect.objectContaining({ includeProviderPluginAugmentation: false }),
+    );
+    expect(mocks.loadStaticCatalog).toHaveBeenLastCalledWith(
+      expect.objectContaining({ providerIds: ["openai"] }),
+    );
+
+    mocks.mutationListener?.({
+      agentDir: "/tmp/prepared-static-agent",
+      affectsInheritedStores: false,
+    });
+    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2));
+    expect(mocks.ensureOpenClawModelsJson).toHaveBeenLastCalledWith(
+      config,
+      "/tmp/prepared-static-agent",
+      expectedStaticOptions,
+    );
+  });
+});

--- a/src/agents/prepared-model-runtime.ts
+++ b/src/agents/prepared-model-runtime.ts
@@ -6,6 +6,7 @@ import { registerRuntimeAuthProfileStoreMutationListener } from "./auth-profiles
 import {
   PreparedModelRuntimeOwnerNotPublishedError,
   PreparedModelRuntimePublicationSupersededError,
+  createPreparedModelRuntimeOwner,
   createPreparedModelRuntimeReplacement,
   effectiveEnvironmentFingerprint,
   hasConfiguredOwnerMatching,
@@ -20,9 +21,10 @@ import {
   resolvePublishedOwner,
   startSerializedSnapshotBuild,
   toError,
-  type PreparedModelRuntimeCatalogMode,
   type PreparedModelRuntimeOwner,
   type PreparedModelRuntimeInput,
+  type PreparedModelRuntimePublicationOptions,
+  type PreparedModelRuntimeRefreshOptions,
   type PreparedModelRuntimeLease,
   type PreparedModelRuntimeReplacement,
   type PreparedModelRuntimeReplacementGateId,
@@ -34,7 +36,6 @@ export {
 } from "./prepared-model-runtime.owner.js";
 export type { PreparedModelRuntimeReplacementGateId } from "./prepared-model-runtime.owner.js";
 export type {
-  PreparedModelRuntimeCatalogMode,
   PreparedModelRuntimeInput,
   PreparedModelRuntimeLease,
   PreparedModelRuntimeSnapshot,
@@ -144,11 +145,7 @@ export function getPreparedModelRuntimeSnapshot(
 /** Publishes one owner from an explicit startup/activation lifecycle boundary. */
 export async function publishPreparedModelRuntimeSnapshot(
   rawInput: PreparedModelRuntimeInput,
-  options: {
-    force?: boolean;
-    provenance?: PreparedModelRuntimeOwner["provenance"];
-    catalogMode?: PreparedModelRuntimeCatalogMode;
-  } = {},
+  options: PreparedModelRuntimePublicationOptions = {},
 ): Promise<PreparedModelRuntimeSnapshot> {
   const input = normalizePreparedModelRuntimeInput(rawInput);
   const existing = owners.get(ownerKey(input));
@@ -491,11 +488,7 @@ export function rejectPendingPreparedModelRuntimeReplacement(
 /** Rebuilds active owners after config/plugin runtime publication. */
 async function refreshPreparedModelRuntimeSnapshotsNow(
   config: OpenClawConfig,
-  options: {
-    gatewayLifecycle?: boolean;
-    defaultWorkspaceDir?: string;
-    catalogMode?: PreparedModelRuntimeCatalogMode;
-  } = {},
+  options: PreparedModelRuntimeRefreshOptions = {},
 ): Promise<void> {
   const catalogMode = options.catalogMode ?? "live";
   if (options.gatewayLifecycle) {
@@ -545,17 +538,10 @@ async function refreshPreparedModelRuntimeSnapshotsNow(
   const candidates = entries.map(({ owner: existing, input }) => {
     // Dynamic and standalone owners have different lifetime contracts. A configured publication
     // must replace them so an older lease release cannot remove the committed generation.
-    const owner: PreparedModelRuntimeOwner =
+    const owner =
       existing?.provenance === "configured"
         ? existing
-        : {
-            input,
-            environmentFingerprint: effectiveEnvironmentFingerprint(input),
-            catalogMode,
-            provenance: "configured",
-            generation: 0,
-            needsRefresh: true,
-          };
+        : createPreparedModelRuntimeOwner(input, "configured", catalogMode);
     owner.input = input;
     owner.environmentFingerprint = effectiveEnvironmentFingerprint(input);
     owner.catalogMode = catalogMode;
@@ -616,11 +602,7 @@ async function refreshPreparedModelRuntimeSnapshotsNow(
 /** Serializes config/plugin publications so only the latest completed refresh retires owners. */
 export function refreshPreparedModelRuntimeSnapshots(
   config: OpenClawConfig,
-  options: {
-    gatewayLifecycle?: boolean;
-    defaultWorkspaceDir?: string;
-    catalogMode?: PreparedModelRuntimeCatalogMode;
-  } = {},
+  options: PreparedModelRuntimeRefreshOptions = {},
 ): Promise<void> {
   // Stale synchronously. Queued publication must never leave the prior generation request-visible.
   markPreparedModelRuntimeSnapshotsStale(undefined, { waitForReplacement: true });

--- a/src/agents/prepared-model-runtime.ts
+++ b/src/agents/prepared-model-runtime.ts
@@ -20,6 +20,7 @@ import {
   resolvePublishedOwner,
   startSerializedSnapshotBuild,
   toError,
+  type PreparedModelRuntimeCatalogMode,
   type PreparedModelRuntimeOwner,
   type PreparedModelRuntimeInput,
   type PreparedModelRuntimeLease,
@@ -33,6 +34,7 @@ export {
 } from "./prepared-model-runtime.owner.js";
 export type { PreparedModelRuntimeReplacementGateId } from "./prepared-model-runtime.owner.js";
 export type {
+  PreparedModelRuntimeCatalogMode,
   PreparedModelRuntimeInput,
   PreparedModelRuntimeLease,
   PreparedModelRuntimeSnapshot,
@@ -145,6 +147,7 @@ export async function publishPreparedModelRuntimeSnapshot(
   options: {
     force?: boolean;
     provenance?: PreparedModelRuntimeOwner["provenance"];
+    catalogMode?: PreparedModelRuntimeCatalogMode;
   } = {},
 ): Promise<PreparedModelRuntimeSnapshot> {
   const input = normalizePreparedModelRuntimeInput(rawInput);
@@ -160,6 +163,7 @@ export async function publishPreparedModelRuntimeSnapshot(
       modelRuntimeBuildTimeoutMs,
       existing,
       options.provenance,
+      options.catalogMode,
     );
   }
   if (existing?.buildCompletion) {
@@ -183,6 +187,7 @@ export async function publishPreparedModelRuntimeSnapshot(
     modelRuntimeBuildTimeoutMs,
     existing,
     options.provenance,
+    options.catalogMode,
   );
 }
 
@@ -486,8 +491,13 @@ export function rejectPendingPreparedModelRuntimeReplacement(
 /** Rebuilds active owners after config/plugin runtime publication. */
 async function refreshPreparedModelRuntimeSnapshotsNow(
   config: OpenClawConfig,
-  options: { gatewayLifecycle?: boolean; defaultWorkspaceDir?: string } = {},
+  options: {
+    gatewayLifecycle?: boolean;
+    defaultWorkspaceDir?: string;
+    catalogMode?: PreparedModelRuntimeCatalogMode;
+  } = {},
 ): Promise<void> {
+  const catalogMode = options.catalogMode ?? "live";
   if (options.gatewayLifecycle) {
     gatewayLifecycleActive = true;
   }
@@ -541,12 +551,14 @@ async function refreshPreparedModelRuntimeSnapshotsNow(
         : {
             input,
             environmentFingerprint: effectiveEnvironmentFingerprint(input),
+            catalogMode,
             provenance: "configured",
             generation: 0,
             needsRefresh: true,
           };
     owner.input = input;
     owner.environmentFingerprint = effectiveEnvironmentFingerprint(input);
+    owner.catalogMode = catalogMode;
     owner.provenance = "configured";
     owner.generation += 1;
     owner.needsRefresh = true;
@@ -556,6 +568,7 @@ async function refreshPreparedModelRuntimeSnapshotsNow(
       input,
       agentBuildCompletions,
       modelRuntimeBuildTimeoutMs,
+      catalogMode,
     );
     owner.buildCompletion = build.completion;
     owners.set(ownerKey(input), owner);
@@ -603,7 +616,11 @@ async function refreshPreparedModelRuntimeSnapshotsNow(
 /** Serializes config/plugin publications so only the latest completed refresh retires owners. */
 export function refreshPreparedModelRuntimeSnapshots(
   config: OpenClawConfig,
-  options: { gatewayLifecycle?: boolean; defaultWorkspaceDir?: string } = {},
+  options: {
+    gatewayLifecycle?: boolean;
+    defaultWorkspaceDir?: string;
+    catalogMode?: PreparedModelRuntimeCatalogMode;
+  } = {},
 ): Promise<void> {
   // Stale synchronously. Queued publication must never leave the prior generation request-visible.
   markPreparedModelRuntimeSnapshotsStale(undefined, { waitForReplacement: true });

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -182,7 +182,9 @@ const hoisted = vi.hoisted(() => ({
   rejectPendingPreparedModelRuntimeReplacement: vi.fn(
     (_gateId: symbol | undefined, _error: unknown) => {},
   ),
-  refreshPreparedModelRuntimeSnapshots: vi.fn(async (_cfg: OpenClawConfig) => {}),
+  refreshPreparedModelRuntimeSnapshots: vi.fn(
+    async (_cfg: OpenClawConfig, _options?: { catalogMode?: "live" | "static" }) => {},
+  ),
   refreshContextWindowCache: vi.fn(async (_cfg: OpenClawConfig) => {}),
   clearCurrentProviderAuthState: vi.fn(() => {}),
   warmCurrentProviderAuthStateOffMainThread: vi.fn(async (_cfg: OpenClawConfig) => {}),
@@ -274,9 +276,12 @@ vi.mock("../agents/prepared-model-runtime.js", () => ({
   },
   rejectPendingPreparedModelRuntimeReplacement: (gateId: symbol | undefined, error: unknown) =>
     hoisted.rejectPendingPreparedModelRuntimeReplacement(gateId, error),
-  refreshPreparedModelRuntimeSnapshots: (cfg: OpenClawConfig) => {
+  refreshPreparedModelRuntimeSnapshots: (
+    cfg: OpenClawConfig,
+    options?: { catalogMode?: "live" | "static" },
+  ) => {
     hoisted.reloadEvents.push("refresh-prepared-model-runtime");
-    return hoisted.refreshPreparedModelRuntimeSnapshots(cfg);
+    return hoisted.refreshPreparedModelRuntimeSnapshots(cfg, options);
   },
 }));
 
@@ -1324,7 +1329,9 @@ describe("gateway hot reload model state", () => {
       "prepared model runtime owner is stale before config publication",
       { waitForReplacement: true },
     );
-    expect(hoisted.refreshPreparedModelRuntimeSnapshots).toHaveBeenCalledWith(nextConfig);
+    expect(hoisted.refreshPreparedModelRuntimeSnapshots).toHaveBeenCalledWith(nextConfig, {
+      catalogMode: "static",
+    });
     expect(hoisted.warmCurrentProviderAuthStateOffMainThread).toHaveBeenCalledWith(nextConfig);
   });
 

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -949,7 +949,7 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
     }
 
     try {
-      await refreshPreparedModelRuntimeSnapshots(nextConfig);
+      await refreshPreparedModelRuntimeSnapshots(nextConfig, { catalogMode: "static" });
     } catch (err) {
       scheduleRecoveryRestart("prepared model runtime reload", err);
       return;

--- a/src/gateway/server-startup-model-runtime.event-loop.test.ts
+++ b/src/gateway/server-startup-model-runtime.event-loop.test.ts
@@ -1,0 +1,178 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { performance } from "node:perf_hooks";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { ProviderPlugin } from "../plugins/types.js";
+import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
+import { withEnvAsync } from "../test-utils/env.js";
+
+const providerMocks = vi.hoisted(() => ({
+  liveCatalog: vi.fn(),
+  staticCatalog: vi.fn(),
+}));
+
+const providerConfig = {
+  providers: {
+    openai: {
+      baseUrl: "https://api.openai.com/v1",
+      api: "openai-responses" as const,
+      models: [
+        {
+          id: "gpt-5.5",
+          name: "GPT-5.5",
+          reasoning: true,
+          input: ["text" as const],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 128_000,
+          maxTokens: 8_192,
+        },
+      ],
+    },
+  },
+};
+
+vi.mock("../plugins/provider-discovery.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../plugins/provider-discovery.js")>();
+  const provider: ProviderPlugin = {
+    id: "openai",
+    pluginId: "openai",
+    label: "OpenAI",
+    auth: [],
+    catalog: { order: "simple", run: async () => null },
+    staticCatalog: { order: "simple", run: async () => null },
+  };
+  return {
+    ...actual,
+    resolveRuntimePluginDiscoveryProviders: vi.fn(async () => [provider]),
+    runProviderCatalog: providerMocks.liveCatalog,
+    runProviderStaticCatalog: providerMocks.staticCatalog,
+  };
+});
+
+const { resetPreparedModelRuntimeSnapshotsForTest } =
+  await import("../agents/prepared-model-runtime.test-support.js");
+const { writePersistedAuthProfileStoreRaw } = await import("../agents/auth-profiles/sqlite.js");
+const { resolveAgentDir } = await import("../agents/agent-scope.js");
+const { startGatewaySidecars } = await import("./server-startup-post-attach.js");
+
+async function listenHealthz(): Promise<{ port: number; close: () => Promise<void> }> {
+  const server = http.createServer((req, res) => {
+    if (req.url === "/healthz") {
+      res.statusCode = 200;
+      res.end(JSON.stringify({ ok: true, status: "live" }));
+      return;
+    }
+    res.statusCode = 404;
+    res.end();
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("expected loopback health server address");
+  }
+  return {
+    port: address.port,
+    close: async () => {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    },
+  };
+}
+
+async function requestHealthzAfter(port: number, delayMs: number) {
+  const startedAt = performance.now();
+  await new Promise<void>((resolve) => {
+    setTimeout(resolve, delayMs);
+  });
+  const response = await fetch(`http://127.0.0.1:${port}/healthz`);
+  return { elapsedMs: performance.now() - startedAt, response };
+}
+
+afterEach(() => {
+  resetPreparedModelRuntimeSnapshotsForTest();
+  closeOpenClawAgentDatabasesForTest();
+  vi.clearAllMocks();
+});
+
+describe("Gateway prepared model runtime startup", () => {
+  it("keeps health probes responsive without executing live provider catalogs", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "openclaw-model-runtime-startup-"));
+    const stateDir = path.join(root, "state");
+    const workspaceDir = path.join(root, "workspace");
+    const cfg = {
+      agents: {
+        defaults: {
+          model: { primary: "openai/gpt-5.5" },
+          models: { "openai/gpt-5.5": { agentRuntime: { id: "openclaw" } } },
+        },
+      },
+      gateway: { mode: "local", bind: "loopback", auth: { mode: "none" } },
+      plugins: { enabled: false },
+    } satisfies OpenClawConfig;
+    const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+    const agentDir = resolveAgentDir(cfg, "main", env);
+    writePersistedAuthProfileStoreRaw(
+      {
+        version: 1,
+        profiles: {
+          "openai:startup": {
+            type: "api_key",
+            provider: "openai",
+            key: "test-openai-api-key",
+          },
+        },
+        order: { openai: ["openai:startup"] },
+      },
+      agentDir,
+    );
+    providerMocks.staticCatalog.mockResolvedValue(providerConfig);
+    providerMocks.liveCatalog.mockImplementation(async () => {
+      const stopAt = performance.now() + 600;
+      while (performance.now() < stopAt) {
+        // Deliberately model synchronous provider/plugin catalog work that starves timers.
+      }
+      return providerConfig;
+    });
+    const healthServer = await listenHealthz();
+
+    try {
+      await withEnvAsync(
+        {
+          OPENCLAW_SKIP_CHANNELS: "1",
+          OPENCLAW_STATE_DIR: stateDir,
+        },
+        async () => {
+          const probe = requestHealthzAfter(healthServer.port, 25);
+          const sidecars = startGatewaySidecars({
+            cfg,
+            pluginRegistry: { plugins: [], typedHooks: [] } as never,
+            defaultWorkspaceDir: workspaceDir,
+            deps: {} as never,
+            startChannels: vi.fn(async () => {}),
+            shouldStartPluginServices: () => false,
+            log: { warn: vi.fn() },
+            logHooks: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+            logChannels: { info: vi.fn(), error: vi.fn() },
+          });
+
+          const [{ elapsedMs, response }] = await Promise.all([probe, sidecars]);
+          expect(response.status).toBe(200);
+          expect(elapsedMs).toBeLessThan(400);
+          expect(providerMocks.staticCatalog).toHaveBeenCalled();
+          expect(providerMocks.liveCatalog).not.toHaveBeenCalled();
+        },
+      );
+    } finally {
+      await healthServer.close();
+      closeOpenClawAgentDatabasesForTest();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -574,6 +574,7 @@ async function publishConfiguredModelRuntimeSnapshots(params: {
     await import("../agents/prepared-model-runtime.js");
   await refreshPreparedModelRuntimeSnapshots(params.cfg, {
     gatewayLifecycle: true,
+    catalogMode: "static",
     ...(params.workspaceDir ? { defaultWorkspaceDir: params.workspaceDir } : {}),
   });
 }
@@ -652,8 +653,8 @@ export async function startGatewaySidecars(params: {
   const skipChannels =
     isTruthyEnvValue(process.env.OPENCLAW_SKIP_CHANNELS) ||
     isTruthyEnvValue(process.env.OPENCLAW_SKIP_PROVIDERS);
-  // Agent RPC remains available when transports are disabled. Publish its mandatory lifecycle
-  // owner before accepting work so request paths can only observe pending or ready snapshots.
+  // Agent RPC remains available when transports are disabled. Publish configured/static facts before
+  // accepting work; live provider catalogs stay advisory and never enter the Gateway lifecycle.
   await measureStartup(params.startupTrace, "sidecars.model-runtime", () =>
     publishStartupModelRuntime(
       {

--- a/src/gateway/server-startup.test.ts
+++ b/src/gateway/server-startup.test.ts
@@ -8,7 +8,11 @@ const prepareModelRuntimeSnapshotMock = vi.fn(async (_params: unknown) => ({}));
 const refreshPreparedModelRuntimeSnapshotsMock = vi.fn(
   async (
     _cfg: OpenClawConfig,
-    _options?: { gatewayLifecycle?: boolean; defaultWorkspaceDir?: string },
+    _options?: {
+      gatewayLifecycle?: boolean;
+      defaultWorkspaceDir?: string;
+      catalogMode?: "live" | "static";
+    },
   ) => {},
 );
 
@@ -22,7 +26,11 @@ vi.mock("../agents/prepared-model-runtime.js", () => ({
   publishPreparedModelRuntimeSnapshot: (params: unknown) => prepareModelRuntimeSnapshotMock(params),
   refreshPreparedModelRuntimeSnapshots: (
     cfg: OpenClawConfig,
-    options?: { gatewayLifecycle?: boolean; defaultWorkspaceDir?: string },
+    options?: {
+      gatewayLifecycle?: boolean;
+      defaultWorkspaceDir?: string;
+      catalogMode?: "live" | "static";
+    },
   ) => refreshPreparedModelRuntimeSnapshotsMock(cfg, options),
 }));
 
@@ -64,6 +72,7 @@ describe("gateway startup primary model warmup", () => {
 
     expect(refreshPreparedModelRuntimeSnapshotsMock).toHaveBeenCalledWith(cfg, {
       gatewayLifecycle: true,
+      catalogMode: "static",
     });
   });
 
@@ -76,6 +85,7 @@ describe("gateway startup primary model warmup", () => {
 
     expect(refreshPreparedModelRuntimeSnapshotsMock).toHaveBeenCalledWith(cfg, {
       gatewayLifecycle: true,
+      catalogMode: "static",
     });
   });
 
@@ -137,6 +147,7 @@ describe("gateway startup primary model warmup", () => {
 
     expect(refreshPreparedModelRuntimeSnapshotsMock).toHaveBeenCalledWith(cfg, {
       gatewayLifecycle: true,
+      catalogMode: "static",
     });
   });
 
@@ -150,6 +161,7 @@ describe("gateway startup primary model warmup", () => {
 
     expect(refreshPreparedModelRuntimeSnapshotsMock).toHaveBeenCalledWith(cfg, {
       gatewayLifecycle: true,
+      catalogMode: "static",
       defaultWorkspaceDir: "/tmp/explicit-workspace",
     });
   });

--- a/test/scripts/bench-gateway-startup.test.ts
+++ b/test/scripts/bench-gateway-startup.test.ts
@@ -449,6 +449,33 @@ describe("gateway startup benchmark script", () => {
     }
   });
 
+  it("builds a deterministic prepared-runtime catalog stall case", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-bench-config-test-"));
+    try {
+      const benchCase = testing.parseOptions(["--case", "preparedRuntimeCatalogStall"]).cases[0];
+      if (!benchCase) {
+        throw new Error("expected prepared runtime catalog stall case");
+      }
+      const configPath = testing.writeConfig(root, benchCase);
+      const config = JSON.parse(fs.readFileSync(configPath, "utf8")) as {
+        plugins?: { allow?: string[]; load?: { paths?: string[] } };
+      };
+      const pluginId = config.plugins?.allow?.[0];
+      expect(pluginId).toBe("bench-plugin-01");
+      const pluginDir = path.join(root, "plugins", pluginId ?? "missing");
+      const manifest = JSON.parse(
+        fs.readFileSync(path.join(pluginDir, "openclaw.plugin.json"), "utf8"),
+      ) as { providers?: string[] };
+      const source = fs.readFileSync(path.join(pluginDir, "index.cjs"), "utf8");
+
+      expect(manifest.providers).toEqual(["bench-catalog-stall"]);
+      expect(source).toContain("api.registerProvider");
+      expect(source).toContain("Date.now() + 2000");
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("keeps startup-lazy plugin fixtures opted out of startup activation", () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-bench-config-test-"));
     try {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a fresh-state Gateway using a valid model-provider profile could bind HTTP but then stop servicing timers and health probes while mandatory prepared-model-runtime publication performed broad live catalog work. On affected starts, provider timeouts fired tens of seconds late and the Gateway eventually failed with `prepared model runtime publication timed out`.

## Why This Change Was Made

Gateway-owned prepared runtime generations now publish only configured and static provider facts. Provider scope is derived from configured model references, explicit provider config, and the prepared auth snapshot; entries-only discovery can no longer fall through to live hooks, provider augmentation is skipped, and bundled static catalogs are limited to those providers. Gateway hot reloads and auth-triggered rebuilds preserve the same static mode, while standalone discovery retains the existing live default.

This keeps the existing atomic multi-agent publication boundary and the pre-owner auth-mutation fix intact. Live catalogs remain advisory rather than part of Gateway startup or reload, so synchronous plugin code cannot starve `/healthz` or turn a slow catalog into a fatal lifecycle failure.

## User Impact

Fresh Gateway starts remain responsive and no longer fail because a live model catalog is slow or synchronously expensive. Configured models, static plugin catalogs, explicit API-key profiles, and the built-in `openclaw` agent runtime are available at readiness without waiting for broad provider discovery.

## Evidence

- Focused regression suite: `node scripts/run-vitest.mjs src/agents/prepared-model-runtime.startup-static.test.ts src/agents/prepared-model-runtime.lifecycle.test.ts src/agents/model-catalog.test.ts src/agents/models-config.providers.implicit.discovery-scope.test.ts src/agents/embedded-agent-runner/model.static-catalog.test.ts src/gateway/server-startup.test.ts src/gateway/server-startup-post-attach.test.ts src/gateway/server-startup-model-runtime.event-loop.test.ts src/gateway/server-reload-handlers.test.ts test/scripts/bench-gateway-startup.test.ts` — 10 files, 284 tests passed.
- Blacksmith Testbox `tbx_01ky23jde296xqd2d36tbt9xyn`: formatting, core/core-test/scripts/root TypeScript checks, targeted lint, import-cycle check, and `pnpm build` passed. Run: https://github.com/openclaw/openclaw/actions/runs/29822417611
- Real startup benchmark: `pnpm test:startup:gateway --case preparedRuntimeCatalogStall --runs 1 --warmup 0 --timeout-ms 30000`. The fixture's live catalog deliberately blocks the event loop for 2 seconds, but mandatory `sidecars.model-runtime` completed in 541 ms without invoking it; `/healthz` responded about 603 ms after HTTP listen.
- A bound `/healthz` event-loop regression test uses a canonical explicit OpenAI API-key profile and a 600 ms CPU-stalling live catalog hook; the health response remains below the 400 ms guard and the live hook is not called.
- Final uncommitted and land-gate autoreviews were clean, including secret scanning and `git diff --check`.

AI-assisted: implementation and review were performed with coding agents; the final diff and proof were manually inspected.
