### PR TITLE
fix(config): reject gateway.port values above TCP port range

### DIFF
--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -1125,7 +1125,7 @@ export const OpenClawSchema = z
     talk: TalkSchema.optional(),
     gateway: z
       .strictObject({
-        port: z.number().int().positive().optional(),
+        port: z.number().int().positive().max(65_535).optional(),
         mode: z.union([z.literal("local"), z.literal("remote")]).optional(),
         bind: z
           .union([


### PR DESCRIPTION
Fixes #109293

## What Problem This Solves

The `gateway.port` config schema only checked for a positive integer, allowing values above 65535 (the max TCP port) to pass validation. These invalid ports are then silently ignored by `resolveGatewayPort`, so users can accidentally pick a non-working port without getting a config error.

## Why This Change Was Made

Added `.max(65535)` to the zod schema, matching the existing constraint on `gateway.remote.remotePort`. Now port 65536 is rejected at config validation time with a clear error message.

## Evidence

Before (current main):
```
port=65535: true
port=65536: true   ← wrongly accepted
port=0: false
port=-1: false
```

After (this PR):
```
port=65535: true
port=65536: false  ← correctly rejected: "Too big: expected number to be <=65535"
port=0: false
port=-1: false
```

- `git diff --check` clean
- Existing zod-schema tests pass