### PR TITLE
fix(plugins): deep-clone registry elements in transaction snapshot

### DIFF
--- a/src/plugins/plugin-registration-transaction.test.ts
+++ b/src/plugins/plugin-registration-transaction.test.ts
@@ -80,4 +80,53 @@ describe("plugin registration transaction", () => {
       capability: { promptBuilder: activePromptBuilder },
     });
   });
+
+  it("rollback restores original array element values after in-place mutation", () => {
+    const registry = createEmptyPluginRegistry();
+    registry.plugins.push({
+      id: "test-plugin",
+      name: "Test Plugin",
+      enabled: true,
+      status: "loaded" as const,
+      source: "test",
+      origin: "external" as const,
+      toolNames: [],
+      hookNames: [],
+      channelIds: [],
+      cliBackendIds: [],
+      providerIds: [],
+      embeddingProviderIds: [],
+      speechProviderIds: [],
+      realtimeTranscriptionProviderIds: [],
+      realtimeVoiceProviderIds: [],
+      mediaUnderstandingProviderIds: [],
+      transcriptSourceProviderIds: [],
+      imageGenerationProviderIds: [],
+      videoGenerationProviderIds: [],
+      musicGenerationProviderIds: [],
+      webFetchProviderIds: [],
+      webSearchProviderIds: [],
+      migrationProviderIds: [],
+      memoryEmbeddingProviderIds: [],
+      agentHarnessIds: [],
+      cliCommands: [],
+      services: [],
+      gatewayDiscoveryServiceIds: [],
+      commands: [],
+      httpRoutes: 0,
+      hookCount: 0,
+      configSchema: false,
+    });
+
+    const transaction = createPluginRegistrationTransaction({ registry });
+
+    // Mutate the plugin record in-place - the snapshot should be unaffected
+    registry.plugins[0].enabled = false;
+    registry.plugins[0].status = "disabled";
+
+    transaction.rollback();
+
+    expect(registry.plugins[0].enabled).toBe(true);
+    expect(registry.plugins[0].status).toBe("loaded");
+  });
 });

--- a/src/plugins/plugin-registration-transaction.ts
+++ b/src/plugins/plugin-registration-transaction.ts
@@ -79,13 +79,17 @@ function snapshotPluginRegistry(registry: PluginRegistry): PluginRegistry {
   return Object.fromEntries(
     Object.entries(registry).map(([key, value]) => {
       if (Array.isArray(value)) {
-        return [key, [...value]];
+        return [key, value.map((item) => structuredClone(item))];
       }
       if (value instanceof Map) {
-        return [key, new Map(value)];
+        return [key, new Map([...value].map(([k, v]) => [k, structuredClone(v)]))];
       }
       if (value && typeof value === "object") {
-        return [key, { ...value }];
+        try {
+          return [key, structuredClone(value)];
+        } catch {
+          return [key, { ...value }];
+        }
       }
       return [key, value];
     }),


### PR DESCRIPTION
Fixes #106647

## What Problem This Solves

`snapshotPluginRegistry` used shallow copies for arrays, Maps, and plain objects. When plugins are registered, `registry.ts` performs in-place mutations on `PluginRecord` objects within those arrays. If a transaction fails and triggers `rollback()`, the array structure is restored but the individual record properties remain mutated — violating transactional integrity.

## Why This Change Was Made

Replaced shallow copies with `structuredClone`:
- **Arrays**: deep-clone each element instead of `[...value]`
- **Maps**: deep-clone each value instead of `new Map(value)`
- **Objects**: deep-clone via `structuredClone`, with fallback to `{ ...value }` for non-cloneable values (e.g., `gatewayHandlers` which contains functions)

## Evidence

- Existing 2 tests pass, 1 new test added that verifies rollback restores original PluginRecord properties after in-place mutation
- `git diff --check` clean
- Test run: `node scripts/run-vitest.mjs src/plugins/plugin-registration-transaction.test.ts`