### PR TITLE
fix(github-copilot): cancel unread device-flow error bodies before throwing

### DIFF
--- a/extensions/github-copilot/login.test.ts
+++ b/extensions/github-copilot/login.test.ts
@@ -130,6 +130,35 @@ describe("runGitHubCopilotDeviceFlow — HTTP error propagation", () => {
     );
   });
 
+  it("cancels the unread device code body before throwing on non-OK", async () => {
+    let canceled = false;
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(
+          new TextEncoder().encode(
+            JSON.stringify({ error: "server_error", error_description: "boom" }),
+          ),
+        );
+      },
+      cancel() {
+        canceled = true;
+      },
+    });
+    mocks.fetchWithSsrFGuard.mockImplementation(async () => ({
+      response: new Response(body, {
+        status: 502,
+        headers: { "Content-Type": "application/json" },
+      }),
+      finalUrl: DEVICE_CODE_URL,
+      release: vi.fn(async () => {}),
+    }));
+
+    await expect(runGitHubCopilotDeviceFlow({ showCode: vi.fn() })).rejects.toThrow(
+      "GitHub device code failed: HTTP 502",
+    );
+    expect(canceled).toBe(true);
+  });
+
   it("throws with failureLabel on non-OK access token response", async () => {
     let callIdx = 0;
     mocks.fetchWithSsrFGuard.mockImplementation(async () => {
@@ -143,6 +172,40 @@ describe("runGitHubCopilotDeviceFlow — HTTP error propagation", () => {
     await expect(runDeviceFlowAfterFirstPoll({ showCode: vi.fn(async () => {}) })).rejects.toThrow(
       "GitHub device token failed: HTTP 500",
     );
+  });
+
+  it("cancels the unread access token body before throwing on non-OK", async () => {
+    let canceled = false;
+    let callIdx = 0;
+    mocks.fetchWithSsrFGuard.mockImplementation(async () => {
+      callIdx += 1;
+      if (callIdx === 1) {
+        return guardResponse(VALID_DEVICE_CODE_BODY);
+      }
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(
+            new TextEncoder().encode(JSON.stringify({ error: "bad_verification_code" })),
+          );
+        },
+        cancel() {
+          canceled = true;
+        },
+      });
+      return {
+        response: new Response(body, {
+          status: 401,
+          headers: { "Content-Type": "application/json" },
+        }),
+        finalUrl: ACCESS_TOKEN_URL,
+        release: vi.fn(async () => {}),
+      };
+    });
+
+    await expect(runDeviceFlowAfterFirstPoll({ showCode: vi.fn(async () => {}) })).rejects.toThrow(
+      "GitHub device token failed: HTTP 401",
+    );
+    expect(canceled).toBe(true);
   });
 
   it("rejects a malformed access token response", async () => {

--- a/extensions/github-copilot/login.ts
+++ b/extensions/github-copilot/login.ts
@@ -161,6 +161,11 @@ async function postGitHubDeviceFlowForm(params: {
   });
   try {
     if (!response.ok) {
+      // GitHub OAuth error responses ship a JSON body (`{error, error_description}`)
+      // that this helper does not consume. Cancel the unread stream before throwing
+      // so the underlying fetch connection is not held open waiting for the caller
+      // to drain a payload we already decided to discard.
+      await response.body?.cancel().catch(() => undefined);
       throw new Error(`${params.failureLabel}: HTTP ${response.status}`);
     }
     return parseJsonResponse(

--- a/extensions/github-copilot/login.ts
+++ b/extensions/github-copilot/login.ts
@@ -161,10 +161,7 @@ async function postGitHubDeviceFlowForm(params: {
   });
   try {
     if (!response.ok) {
-      // GitHub OAuth error responses ship a JSON body (`{error, error_description}`)
-      // that this helper does not consume. Cancel the unread stream before throwing
-      // so the underlying fetch connection is not held open waiting for the caller
-      // to drain a payload we already decided to discard.
+      // Release closes the dispatcher, so cancel its unread response body first.
       await response.body?.cancel().catch(() => undefined);
       throw new Error(`${params.failureLabel}: HTTP ${response.status}`);
     }


### PR DESCRIPTION
## What Problem This Solves

When GitHub Copilot device-code or access-token requests return a non-OK response with an unread streaming body, `postGitHubDeviceFlowForm` throws immediately and then closes the SSRF-guarded dispatcher in `finally`. Dispatcher release waits for the still-open response, unnecessarily delaying the existing HTTP error.

## Why This Change Was Made

Cancel the unread response body at its owning device-flow helper before throwing, so the existing release closes promptly. Both `/login/device/code` and `/login/oauth/access_token` share this owner. The HTTP error labels, successful JSON reads, OAuth polling behavior, SSRF policy, and public provider configuration remain unchanged.

Original fix and both device-flow regression tests: @xydt-juyaohui. Maintainer follow-up reduced the lifecycle explanation to one precise owner-boundary comment.

## User Impact

Copilot sign-in reports upstream non-OK HTTP failures without waiting on an unread, never-ending response body. Successful device authorization and token polling continue through their existing paths.

## Evidence

Focused actual plugin suite:

```sh
OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/private/tmp/openclaw-vitest-pr-112268-s23-840c42eb node scripts/run-vitest.mjs extensions/github-copilot/login.test.ts
```

Result: **1 file passed; 14 tests passed**, including both new unread-body cancellation regressions and unchanged device/token HTTP error labels.

Real localhost HTTP/Undici proof used the production `fetchWithSsrFGuard` against an ephemeral `127.0.0.1` server that returned HTTP 503, streamed a partial JSON body, and intentionally never completed the response. Comparing the existing release-only path with cancel-before-release:

- `/login/device/code`: **100.9 ms → 3.0 ms**; HTTP status remained 503; `response.bodyUsed` changed from `false` to `true`.
- `/login/oauth/access_token`: **100.5 ms → 0.8 ms**; HTTP status remained 503; `response.bodyUsed` changed from `false` to `true`.

A separate real localhost HTTP 200 run used production `fetchWithSsrFGuard` and `readProviderJsonResponse`; all five actual response shapes were consumed unchanged: device code, `authorization_pending`, `slow_down`, `access_denied`, and authorized token.

The localhost fixtures prove the production guarded HTTP transport and response-body lifecycle; the focused plugin suite proves the public device-flow HTTP errors and polling behavior. No external GitHub OAuth service or live account was used.