### PR TITLE
fix(memory): keep disabled QMD status side-effect free

### DIFF
--- a/extensions/memory-core/src/memory/qmd-manager-io.ts
+++ b/extensions/memory-core/src/memory/qmd-manager-io.ts
@@ -1,3 +1,4 @@
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import readline from "node:readline";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
@@ -23,6 +24,19 @@ import {
 import { QmdManagerSearch } from "./qmd-manager-search.js";
 
 type SqliteDatabase = import("node:sqlite").DatabaseSync;
+
+function qmdIndexExists(indexPath: string): boolean {
+  try {
+    fsSync.statSync(indexPath);
+    return true;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT" || code === "ENOTDIR") {
+      return false;
+    }
+    throw err;
+  }
+}
 
 export abstract class QmdManagerIo extends QmdManagerSearch {
   async readFile(params: {
@@ -141,6 +155,11 @@ export abstract class QmdManagerIo extends QmdManagerSearch {
       this.vectorStatusDetail = null;
       return false;
     }
+    if (!qmdIndexExists(this.indexPath)) {
+      this.vectorAvailable = false;
+      this.vectorStatusDetail = "QMD index is missing; semantic search is unavailable";
+      return false;
+    }
     try {
       const result = await this.runQmd(["status"], {
         timeoutMs: this.qmd.limits.timeoutMs,
@@ -243,6 +262,12 @@ export abstract class QmdManagerIo extends QmdManagerSearch {
     totalDocuments: number;
     sourceCounts: Array<{ source: MemorySource; files: number; chunks: number }>;
   } {
+    if (!qmdIndexExists(this.indexPath)) {
+      return {
+        totalDocuments: 0,
+        sourceCounts: Array.from(this.sources).map((source) => ({ source, files: 0, chunks: 0 })),
+      };
+    }
     try {
       const rows = this.ensureDb()
         .prepare(

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -1,5 +1,6 @@
 // Memory Core tests cover qmd manager plugin behavior.
 import { EventEmitter } from "node:events";
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -867,6 +868,14 @@ describe("QmdMemoryManager", () => {
 
   function qmdIndexConfigPath(selectedAgentId = agentId): string {
     return path.join(stateDir, "agents", selectedAgentId, "qmd", "xdg-config", "qmd", "index.yml");
+  }
+
+  function seedQmdIndex(manager: QmdMemoryManager): string {
+    const indexPath = (manager as unknown as { indexPath: string }).indexPath;
+    fsSync.mkdirSync(path.dirname(indexPath), { recursive: true });
+    const { DatabaseSync } = requireNodeSqlite();
+    new DatabaseSync(indexPath).close();
+    return indexPath;
   }
 
   function resolveMemoryBackendConfigForTest(sourceCfg: OpenClawConfig, selectedAgentId: string) {
@@ -6138,6 +6147,7 @@ describe("QmdMemoryManager", () => {
     });
 
     const { manager } = await createManager();
+    seedQmdIndex(manager);
 
     const probe = manager.probeVectorAvailability();
     await vi.advanceTimersByTimeAsync(5000);
@@ -6150,6 +6160,35 @@ describe("QmdMemoryManager", () => {
       semanticAvailable: false,
       loadError: expect.stringContaining("timed out after 6000ms"),
     });
+    await manager.close();
+  });
+
+  it("keeps missing-index status reads side-effect free", async () => {
+    const { manager } = await createManager();
+    const indexPath = (manager as unknown as { indexPath: string }).indexPath;
+    const baselineCalls = spawnMock.mock.calls.length;
+
+    expect(manager.status()).toMatchObject({ files: 0, chunks: 0 });
+    expect(spawnMock.mock.calls.length).toBe(baselineCalls);
+    await expect(fs.stat(indexPath)).rejects.toMatchObject({ code: "ENOENT" });
+    await manager.close();
+  });
+
+  it("does not run qmd status when the index is missing", async () => {
+    configureQmd({ searchMode: "query" });
+    const { manager } = await createManager();
+    const indexPath = (manager as unknown as { indexPath: string }).indexPath;
+    const baselineCalls = spawnMock.mock.calls.length;
+
+    await expect(manager.probeVectorAvailability()).resolves.toBe(false);
+    expect(spawnMock.mock.calls.length).toBe(baselineCalls);
+    expect(manager.status().vector).toEqual({
+      enabled: true,
+      available: false,
+      semanticAvailable: false,
+      loadError: "QMD index is missing; semantic search is unavailable",
+    });
+    await expect(fs.stat(indexPath)).rejects.toMatchObject({ code: "ENOENT" });
     await manager.close();
   });
 
@@ -6200,6 +6239,7 @@ describe("QmdMemoryManager", () => {
         },
       } as OpenClawConfig,
     });
+    seedQmdIndex(manager);
 
     await expect(manager.probeVectorAvailability()).resolves.toBe(false);
     await expect(manager.probeEmbeddingAvailability()).resolves.toEqual({
@@ -6234,6 +6274,7 @@ describe("QmdMemoryManager", () => {
         },
       } as OpenClawConfig,
     });
+    seedQmdIndex(manager);
 
     await expect(manager.probeVectorAvailability()).resolves.toBe(true);
     await expect(manager.probeEmbeddingAvailability()).resolves.toEqual({
@@ -6273,6 +6314,7 @@ describe("QmdMemoryManager", () => {
         },
       } as OpenClawConfig,
     });
+    seedQmdIndex(manager);
 
     await expect(manager.probeVectorAvailability()).resolves.toBe(true);
     await manager.close();
@@ -6297,6 +6339,7 @@ describe("QmdMemoryManager", () => {
         },
       } as OpenClawConfig,
     });
+    seedQmdIndex(manager);
 
     await expect(manager.probeVectorAvailability()).resolves.toBe(false);
     expect(manager.status().vector).toEqual({


### PR DESCRIPTION
## What Problem This Solves

A QMD status or embedding-availability check could run `qmd status` when the per-agent index did not exist. QMD can create index state as a side effect, so a nominally read-only status path was able to mutate a disabled, uninitialized, or removed backend.

## Changes

- replace the stale manager-lifecycle rewrite with a narrow current-main repair at the QMD I/O owner
- detect a missing QMD index before opening SQLite for status counts
- skip `qmd status` when no index exists and report semantic search as unavailable
- preserve existing probe behavior when a real index exists

## Evidence

- Regression test first reproduced the defect: missing index caused one unexpected QMD process spawn
- Focused QMD manager suite: **165/165 tests passed** after the repair
- Existing timeout, zero-vector, positive-vector, parser, and lexical-mode probe coverage remains green with real seeded index fixtures
- Extension production and extension-test `tsgo` lanes: passed locally
- Targeted `oxfmt`, `oxlint`, and `git diff --check`: passed
- Production delta: +25 lines; test delta: +43 lines. The production growth is the shared missing-index ownership guard used by both status-count and semantic-probe paths.
