### PR TITLE
feat(ui): add setting to opt out of right-click message actions

### DIFF
--- a/ui/src/app/settings.ts
+++ b/ui/src/app/settings.ts
@@ -116,6 +116,9 @@ export type UiSettings = {
   realtimeTalkInputDeviceId?: string;
   realtimeTalkVideoDeviceId?: string;
   composerHoldToRecord?: boolean;
+  // Right-click message actions in the chat thread. Disable to fall back to the
+  // browser's native context menu.
+  chatMessageContextMenu?: boolean;
   // Camera intent is device-local, not per-agent or synced through config ui.prefs.
   talkCameraAutoEnable?: boolean;
   splitRatio: number; // Sidebar split ratio (0.4 to 0.7, default 0.6)
@@ -362,6 +365,7 @@ export function loadSettings(): UiSettings {
     pinnedAgentIds: [],
     textScale: 100,
     composerHoldToRecord: true,
+    chatMessageContextMenu: true,
   };
 
   try {
@@ -433,6 +437,10 @@ export function loadSettings(): UiSettings {
         typeof parsed.composerHoldToRecord === "boolean"
           ? parsed.composerHoldToRecord
           : defaults.composerHoldToRecord,
+      chatMessageContextMenu:
+        typeof parsed.chatMessageContextMenu === "boolean"
+          ? parsed.chatMessageContextMenu
+          : defaults.chatMessageContextMenu,
       talkCameraAutoEnable:
         typeof parsed.talkCameraAutoEnable === "boolean" ? parsed.talkCameraAutoEnable : undefined,
       splitRatio:
@@ -569,6 +577,7 @@ function persistSettings(next: UiSettings, options: { selectGateway?: boolean } 
       ? { realtimeTalkVideoDeviceId: normalizeOptionalString(next.realtimeTalkVideoDeviceId) }
       : {}),
     ...(next.composerHoldToRecord === false ? { composerHoldToRecord: false } : {}),
+    ...(next.chatMessageContextMenu === false ? { chatMessageContextMenu: false } : {}),
     ...(typeof next.talkCameraAutoEnable === "boolean"
       ? { talkCameraAutoEnable: next.talkCameraAutoEnable }
       : {}),

--- a/ui/src/e2e/chat-message-actions.e2e.test.ts
+++ b/ui/src/e2e/chat-message-actions.e2e.test.ts
@@ -283,4 +283,69 @@ describeControlUiE2e("Control UI chat message actions", () => {
       await context.close();
     }
   });
+
+  it("restores the native context menu when message actions are turned off", async () => {
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1440 },
+    });
+    const page = await context.newPage();
+    const messageText = "Native context menu opt-out proof.";
+    await installMockGateway(page, {
+      historyMessages: [
+        {
+          role: "assistant",
+          content: [{ type: "text", text: messageText }],
+          timestamp: Date.now(),
+          __openclaw: { id: "assistant-optout-proof", seq: 1 },
+        },
+      ],
+    });
+
+    const bubbleFor = (target: Page) =>
+      target.locator(".chat-bubble").filter({ hasText: messageText }).first();
+    // dispatchEvent() returns false only when a listener called preventDefault(),
+    // so this is a real-browser read of whether the native menu was suppressed.
+    const contextMenuPrevented = (target: Page) =>
+      bubbleFor(target).evaluate(
+        (element) =>
+          !element.dispatchEvent(
+            new MouseEvent("contextmenu", { bubbles: true, cancelable: true }),
+          ),
+      );
+
+    try {
+      await page.goto(`${server.baseUrl}chat`);
+      await bubbleFor(page).waitFor({ state: "visible" });
+      await bubbleFor(page).click({ button: "right" });
+      await page.locator(".chat-reply-context-menu").waitFor({ state: "visible" });
+      expect(await contextMenuPrevented(page)).toBe(true);
+      await screenshot(page, "04-actions-enabled-default.png");
+      await page.keyboard.press("Escape");
+
+      await page.goto(`${server.baseUrl}settings/appearance`);
+      const settingsRow = page
+        .locator(".settings-row--toggle")
+        .filter({ hasText: "Right-click message actions" });
+      const toggle = settingsRow.getByRole("switch");
+      await toggle.waitFor({ state: "visible" });
+      expect(await toggle.getAttribute("aria-checked")).toBe("true");
+      await screenshot(page, "05-setting-on.png");
+      // The row toggles on click everywhere outside the wa-switch itself, whose
+      // shadow control would otherwise intercept the pointer event.
+      await settingsRow.locator(".settings-row__title").click();
+      await expect.poll(() => toggle.getAttribute("aria-checked")).toBe("false");
+      await screenshot(page, "06-setting-off.png");
+
+      await page.goto(`${server.baseUrl}chat`);
+      await bubbleFor(page).waitFor({ state: "visible" });
+      expect(await contextMenuPrevented(page)).toBe(false);
+      await bubbleFor(page).click({ button: "right" });
+      await expect.poll(() => page.locator(".chat-reply-context-menu").count()).toBe(0);
+      await screenshot(page, "07-actions-disabled-native-menu.png");
+    } finally {
+      await context.close();
+    }
+  });
 });

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -3747,6 +3747,9 @@ export const en: TranslationMap = {
     catalogOpenTarget: "Open Codex/Claude threads in",
     catalogOpenTargetViewer: "OpenClaw viewer",
     catalogOpenTargetTerminal: "Terminal",
+    messageContextMenuSetting: "Right-click message actions",
+    messageContextMenuSettingDescription:
+      "Show the message actions menu when you right-click a chat message. Turn this off to use your browser's native context menu instead.",
     onboardingDisabled: "Disabled during setup",
     gatewayStatus: "Gateway status: {status}",
     commandPaletteTitle: "Search or jump to… (⌘K)",

--- a/ui/src/pages/chat/chat-pane.ts
+++ b/ui/src/pages/chat/chat-pane.ts
@@ -3275,6 +3275,7 @@ class ChatPane extends OpenClawLightDomElement {
       connected: state.connected,
       gatewayClient: state.client,
       composerHoldToRecord: state.settings.composerHoldToRecord,
+      chatMessageContextMenu: state.settings.chatMessageContextMenu,
       canSend: catalogKey ? this.catalogSession?.canContinue === true : !selectedSessionArchived,
       disabledReason: catalogDisabledReason ?? disabledReason,
       disabledActionLabel:

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -5780,6 +5780,40 @@ describe("right-click Reply", () => {
     expect(document.querySelector(".chat-reply-context-menu")).toBeNull();
   });
 
+  it("keeps the native context menu when message actions are disabled", () => {
+    const container = renderChatView({ onSetReply: vi.fn(), chatMessageContextMenu: false });
+    const group = document.createElement("div");
+    group.className = "chat-group";
+    const bubble = document.createElement("div");
+    bubble.className = "chat-bubble";
+    bubble.dataset.messageText = "hello world";
+    group.appendChild(bubble);
+    container.querySelector(".chat-thread-inner")!.appendChild(group);
+
+    const evt = new MouseEvent("contextmenu", { bubbles: true, cancelable: true });
+    bubble.dispatchEvent(evt);
+
+    expect(evt.defaultPrevented).toBe(false);
+    expect(document.querySelector(".chat-reply-context-menu")).toBeNull();
+  });
+
+  it("opens message actions by default when the setting is unset", () => {
+    const container = renderChatView({ onSetReply: vi.fn() });
+    const group = document.createElement("div");
+    group.className = "chat-group";
+    const bubble = document.createElement("div");
+    bubble.className = "chat-bubble";
+    bubble.dataset.messageText = "hello world";
+    group.appendChild(bubble);
+    container.querySelector(".chat-thread-inner")!.appendChild(group);
+
+    const evt = new MouseEvent("contextmenu", { bubbles: true, cancelable: true });
+    bubble.dispatchEvent(evt);
+
+    expect(evt.defaultPrevented).toBe(true);
+    expect(document.querySelector(".chat-reply-context-menu")).not.toBeNull();
+  });
+
   it("keeps the native context menu when Reply is unavailable", () => {
     const container = renderChatView();
     const section = container.querySelector<HTMLElement>(".card.chat");

--- a/ui/src/pages/chat/chat-view.ts
+++ b/ui/src/pages/chat/chat-view.ts
@@ -122,6 +122,7 @@ export type ChatProps = {
   connected: boolean;
   gatewayClient?: GatewayBrowserClient | null;
   composerHoldToRecord?: boolean;
+  chatMessageContextMenu?: boolean;
   canSend: boolean;
   disabledReason: string | null;
   disabledActionLabel?: string | null;
@@ -376,6 +377,7 @@ export function renderChat(props: ChatProps) {
       getDraft: props.getDraft,
       onSend: props.onSend,
       onSetReply: props.onSetReply,
+      messageContextMenuEnabled: props.chatMessageContextMenu !== false,
       onRewindMessage: props.onRewindMessage,
       onForkMessage: props.onForkMessage,
       // Archived/non-composable sessions must not offer selection actions:

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -152,6 +152,9 @@ type ChatThreadProps = {
   getDraft?: () => string;
   onSend: () => void;
   onSetReply?: (target: MessageReplyTarget) => void;
+  // Right-click message actions. When false the thread never calls
+  // preventDefault(), so the browser's native context menu opens instead.
+  messageContextMenuEnabled?: boolean;
   onRewindMessage?: (entryId: string) => Promise<boolean> | boolean;
   onForkMessage?: (entryId: string) => Promise<void> | void;
   onFocusComposer?: () => void;
@@ -788,6 +791,10 @@ function handleChatThreadSelectionPointerUp(event: PointerEvent, props: ChatThre
 }
 
 function handleChatContextMenu(event: MouseEvent, props: ChatThreadProps) {
+  // Opt-out: leave the event untouched so the native context menu opens.
+  if (props.messageContextMenuEnabled === false) {
+    return;
+  }
   if (event.composedPath().some((target) => target instanceof HTMLAnchorElement)) {
     return;
   }

--- a/ui/src/pages/config/config-page.ts
+++ b/ui/src/pages/config/config-page.ts
@@ -67,7 +67,8 @@ type ConfigPageSetting =
   | "chatSendShortcut"
   | "chatFollowUpMode"
   | "catalogOpenTarget"
-  | "composerHoldToRecord";
+  | "composerHoldToRecord"
+  | "chatMessageContextMenu";
 
 const CONFIG_PAGE_I18N_KEYS = {
   config: "config",
@@ -654,6 +655,7 @@ export class ConfigPage extends OpenClawLightDomElement {
       realtimeTalkInputDeviceId: next.realtimeTalkInputDeviceId,
       realtimeTalkVideoDeviceId: next.realtimeTalkVideoDeviceId,
       composerHoldToRecord: next.composerHoldToRecord,
+      chatMessageContextMenu: next.chatMessageContextMenu,
       lobsterPetVisits: next.lobsterPetVisits,
       lobsterPetSounds: next.lobsterPetSounds,
     });
@@ -891,6 +893,8 @@ export class ConfigPage extends OpenClawLightDomElement {
       },
       composerHoldToRecord: this.settings.composerHoldToRecord !== false,
       setComposerHoldToRecord: (enabled) => this.setSetting("composerHoldToRecord", enabled),
+      chatMessageContextMenu: this.settings.chatMessageContextMenu !== false,
+      setChatMessageContextMenu: (enabled) => this.setSetting("chatMessageContextMenu", enabled),
       onMicrophoneRefresh: () => void this.refreshMicrophones(true),
       onMicrophoneSelect: (deviceId) => this.selectMicrophone(deviceId),
       camera: {

--- a/ui/src/pages/config/view.ts
+++ b/ui/src/pages/config/view.ts
@@ -198,6 +198,8 @@ export type ConfigProps = {
   onCameraSelect?: (deviceId: string) => void;
   composerHoldToRecord?: boolean;
   setComposerHoldToRecord?: (enabled: boolean) => void;
+  chatMessageContextMenu?: boolean;
+  setChatMessageContextMenu?: (enabled: boolean) => void;
   gatewayUrl: string;
   assistantName: string;
   configPath?: string | null;
@@ -1115,6 +1117,14 @@ function renderChatPreferencesSection(props: ConfigProps) {
               description: t("chat.composer.holdToRecordSettingDescription"),
               checked: props.composerHoldToRecord !== false,
               onChange: props.setComposerHoldToRecord,
+            })
+          : nothing}
+        ${props.setChatMessageContextMenu
+          ? renderSettingsToggleRow({
+              title: t("chat.messageContextMenuSetting"),
+              description: t("chat.messageContextMenuSettingDescription"),
+              checked: props.chatMessageContextMenu !== false,
+              onChange: props.setChatMessageContextMenu,
             })
           : nothing}
       </div>


### PR DESCRIPTION
Related: #106765

## What Problem This Solves

The Control UI chat thread binds a `contextmenu` handler that calls `preventDefault()` on every message bubble to show the message actions menu. There is no way to get the browser's native context menu back on a message, so users who rely on native Copy, Search or spell-check on chat text have no escape hatch.

## Why This Change Was Made

This adds an explicit opt-out rather than changing the default: a **"Right-click message actions"** setting under Settings → Appearance → Chat, **enabled by default** so existing behaviour is unchanged. When it is turned off, `handleChatContextMenu()` returns before `preventDefault()` and the native menu opens normally.

The setting follows the existing `composerHoldToRecord` pattern — a browser-local preference persisted only when explicitly disabled. No gateway config schema change, and no change to the actions menu itself.

**Relationship to #106765 and #107137.** #106765 asks for native-menu access on *selected text* and lists three options; #107137 already implements option 2 (a Copy selection entry in the actions menu) and is further along. This PR is option 3 and is deliberately complementary, not a competing fix: it does not change selection behaviour at all, so it can land alongside #107137 or on its own. I am happy to close this if maintainers would rather keep the surface to one change.

Non-goals: no new menu entries, no change to selection handling, no change to link handling (which already falls through).

## User Impact

- Users who want the browser's native context menu on chat messages can turn off **Right-click message actions** in Settings → Appearance → Chat.
- Everyone else sees no change: the setting defaults to on and the actions menu behaves exactly as before.

## Evidence

Real-browser proof captured headless with `OPENCLAW_CAPTURE_UI_PROOF=1`.

### Screenshots

**1. Default — the actions menu opens on right-click**

![Actions menu opens on right-click by default](https://raw.githubusercontent.com/tangotrick/openclaw/pr-proof-assets/04-actions-enabled-default.png)

**2. The new setting, Settings → Appearance → Chat (on by default)**

![The new Right-click message actions setting, enabled](https://raw.githubusercontent.com/tangotrick/openclaw/pr-proof-assets/05-setting-on.png)

**3. Setting switched off**

![The setting switched off](https://raw.githubusercontent.com/tangotrick/openclaw/pr-proof-assets/06-setting-off.png)

**4. After opting out — no custom menu, native menu restored**

![Right-click after opting out shows no custom menu](https://raw.githubusercontent.com/tangotrick/openclaw/pr-proof-assets/07-actions-disabled-native-menu.png)

### Tests

New e2e case in `ui/src/e2e/chat-message-actions.e2e.test.ts` covering the whole chain in Chromium: the menu opens by default, the Settings toggle is clicked in the real UI and `aria-checked` flips to `false`, and the thread then leaves the event untouched. Suppression is read from `dispatchEvent()`'s return value, which is `false` only when a listener called `preventDefault()` — a browser-level fact rather than an assertion about internals.

```
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner \
  ui/src/e2e/chat-message-actions.e2e.test.ts -t "restores the native context menu"   → 1 passed

node scripts/run-vitest.mjs ui/src/pages/chat/chat-view.test.ts                        → passed
node scripts/run-vitest.mjs ui/src/pages/config/config-page.test.ts                    → passed
node scripts/run-vitest.mjs ui/src/app/settings.node.test.ts                           → 38 passed
oxfmt --check / oxlint / git diff --check                                              → clean
```

Two notes in the interest of full disclosure:

- The pre-existing case `offers Reply inline and mirrors every assistant action in the context menu` fails in my environment on a tooltip assertion. I verified it **fails identically on an unmodified `main` checkout**, so it is not caused by this change.
- `pnpm ui:i18n:check` exits non-zero, but it also does so on unmodified `main`, and none of the reported keys are the two added here.

I could not run a full-repo `tsc --noEmit` locally — it exhausts memory on my machine — so type checking on the changed surface is covered only by the test runs above and CI.
