### PR TITLE
fix: pin Plivo callback URLs to public webhook path [AI]

### DIFF
--- a/extensions/voice-call/src/providers/plivo.test.ts
+++ b/extensions/voice-call/src/providers/plivo.test.ts
@@ -92,6 +92,50 @@ describe("PlivoProvider", () => {
     expect(callbackMap.get("call-uuid")).toBe("https://voice.openclaw.ai/voice/webhook");
   });
 
+  it("pins call-control transfer URLs to the configured publicUrl path", async () => {
+    const provider = new PlivoProvider(
+      {
+        authId: "MA000000000000000000",
+        authToken: "test-token",
+      },
+      {
+        publicUrl: "https://voice.openclaw.ai/voice/webhook?provider=plivo",
+      },
+    );
+    const apiRequest = vi.fn(async (_params: unknown) => ({}));
+    (
+      provider as unknown as {
+        apiRequest: (params: unknown) => Promise<unknown>;
+      }
+    ).apiRequest = apiRequest;
+
+    provider.parseWebhookEvent({
+      headers: { host: "attacker.example" },
+      rawBody:
+        "CallUUID=call-uuid&CallStatus=in-progress&Direction=outbound&From=%2B15550000000&To=%2B15550000001&Event=StartApp",
+      url: "https://attacker.example/admin?provider=plivo&flow=answer&callId=internal-call-id",
+      method: "POST",
+      query: { provider: "plivo", flow: "answer", callId: "internal-call-id" },
+    });
+
+    await provider.playTts({
+      callId: "internal-call-id",
+      providerCallId: "call-uuid",
+      text: "How can I help?",
+    });
+
+    expect(apiRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "POST",
+        endpoint: "/Call/call-uuid/",
+        body: expect.objectContaining({
+          aleg_url:
+            "https://voice.openclaw.ai/voice/webhook?provider=plivo&flow=xml-speak&callId=internal-call-id",
+        }),
+      }),
+    );
+  });
+
   it("renders an auto-response as the prompt for the next speech input", async () => {
     const provider = new PlivoProvider({
       authId: "MA000000000000000000",

--- a/extensions/voice-call/src/providers/plivo.ts
+++ b/extensions/voice-call/src/providers/plivo.ts
@@ -574,8 +574,6 @@ export class PlivoProvider implements VoiceCallProvider {
     try {
       if (this.options.publicUrl) {
         const base = new URL(this.options.publicUrl);
-        const requestUrl = new URL(ctx.url);
-        base.pathname = requestUrl.pathname;
         return `${base.origin}${base.pathname}`;
       }
 

--- a/extensions/voice-call/src/webhook-security.test.ts
+++ b/extensions/voice-call/src/webhook-security.test.ts
@@ -388,6 +388,42 @@ describe("verifyPlivoWebhook", () => {
     expectAcceptedWebhookVersion(result, "v3");
   });
 
+  it("pins Plivo publicUrl verification to the configured path", () => {
+    const authToken = "test-auth-token";
+    const nonce = "nonce-public-url-path";
+    const postBody = "CallUUID=uuid&CallStatus=in-progress&From=%2B15550000000";
+    const attackerPathUrl = "https://voice.openclaw.ai/admin?flow=answer&callId=abc";
+    const signature = plivoV3Signature({
+      authToken,
+      urlWithQuery: attackerPathUrl,
+      postBody,
+      nonce,
+    });
+
+    const result = verifyPlivoWebhook(
+      {
+        headers: {
+          host: "voice.openclaw.ai",
+          "x-forwarded-proto": "https",
+          "x-plivo-signature-v3": signature,
+          "x-plivo-signature-v3-nonce": nonce,
+        },
+        rawBody: postBody,
+        url: attackerPathUrl,
+        method: "POST",
+        query: { flow: "answer", callId: "abc" },
+      },
+      authToken,
+      { publicUrl: "https://voice.openclaw.ai/voice/webhook?provider=plivo" },
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.version).toBe("v3");
+    expect(result.verificationUrl).toBe(
+      "https://voice.openclaw.ai/voice/webhook?flow=answer&callId=abc",
+    );
+  });
+
   it("matches trusted proxies for Plivo when Node reports an IPv4-mapped remote address", () => {
     const authToken = "test-auth-token";
     const nonce = "nonce-ipv4-mapped-plivo";

--- a/extensions/voice-call/src/webhook-security.ts
+++ b/extensions/voice-call/src/webhook-security.ts
@@ -869,7 +869,6 @@ export function verifyPlivoWebhook(
     try {
       const req = new URL(reconstructed);
       const base = new URL(options.publicUrl);
-      base.pathname = req.pathname;
       base.search = req.search;
       verificationUrl = base.toString();
     } catch {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Plivo voice-call callbacks could reuse an accepted request path when building later call-control callback URLs, even when operators configured a public webhook URL with the intended path.

## Why This Change Was Made

The Plivo provider now treats `publicUrl` as the trusted callback path for both stored callback bases and webhook signature URL construction. Per-call query parameters still come from the incoming callback so existing Plivo answer, speech, and listen flows can continue to route normally.

## User Impact

Operators using a configured Plivo public webhook URL get stable follow-up Plivo callback URLs on that configured path. Host, auth, config, storage, provider selection, and non-Plivo voice-call behavior are unchanged.

## Evidence

- `node scripts/run-vitest.mjs extensions/voice-call/src/providers/plivo.test.ts extensions/voice-call/src/webhook-security.test.ts`
- Result: 2 test files passed, 35 tests passed.

AI-assisted.
