### PR TITLE
fix(sessions): gateway becomes unusable when there are many sessions

### DIFF
--- a/src/config/cache-utils.ts
+++ b/src/config/cache-utils.ts
@@ -1,5 +1,26 @@
 // Provides small synchronous config cache helpers.
 
+import fs from "node:fs";
+
+export type FileStatSnapshot = {
+  ctimeNs?: bigint;
+  mtimeNs?: bigint;
+  sizeBytes?: number;
+};
+
+export function getFileStatSnapshot(filePath: string): FileStatSnapshot {
+  try {
+    const stat = fs.statSync(filePath, { bigint: true });
+    return {
+      ctimeNs: stat.ctimeNs,
+      mtimeNs: stat.mtimeNs,
+      sizeBytes: Number(stat.size),
+    };
+  } catch {
+    return {};
+  }
+}
+
 /** Returns whether a TTL keeps cache reads and writes active. */
 export function isCacheEnabled(ttlMs: number): boolean {
   return ttlMs > 0;
@@ -7,6 +28,18 @@ export function isCacheEnabled(ttlMs: number): boolean {
 
 type CacheTtlResolver = number | (() => number);
 type CachePruneIntervalResolver = number | ((ttlMs: number) => number);
+
+export function resolveCacheTtlMs(options: { envValue?: string; defaultTtlMs: number }): number {
+  const trimmed = options.envValue?.trim();
+  if (!trimmed) {
+    return options.defaultTtlMs;
+  }
+  const parsed = Number(trimmed);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return options.defaultTtlMs;
+  }
+  return Math.floor(parsed);
+}
 
 type ExpiringMapCacheEntry<TValue> = {
   storedAt: number;

--- a/src/config/sessions/combined-store-gateway.ts
+++ b/src/config/sessions/combined-store-gateway.ts
@@ -48,6 +48,7 @@ function loadGatewayStoreEntries(params: {
     listSessionEntriesReadOnly({
       agentId: params.agentId,
       clone: false,
+      light: true,
       storePath: params.storePath,
     }).map(({ sessionKey, entry }) => [sessionKey, entry]),
   );

--- a/src/config/sessions/cross-process-coherence.test.ts
+++ b/src/config/sessions/cross-process-coherence.test.ts
@@ -1,0 +1,164 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+} from "../../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import { listSessionEntries } from "./session-accessor.js";
+import { invalidateSessionStoreCache } from "./store-cache.js";
+
+describe("session store cross-process cache coherence", () => {
+  let tempDir: string;
+  let stateDir: string;
+  let env: NodeJS.ProcessEnv;
+  let dbPath: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-coherence-"));
+    stateDir = path.join(tempDir, "state");
+    fs.mkdirSync(stateDir, { recursive: true });
+    env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+    dbPath = path.join(stateDir, "agents", "main", "agent", "openclaw-agent.sqlite");
+  });
+
+  afterEach(() => {
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("detects foreign writes via file stat mismatch and returns fresh data", () => {
+    // 1. Seed 5 sessions, close all connections to ensure WAL is checkpointed
+    let database = openOpenClawAgentDatabase({ agentId: "main", env, path: dbPath });
+    let db = database.db;
+
+    const insertSession = db.prepare(
+      `INSERT OR IGNORE INTO sessions
+        (session_id, session_key, session_scope, created_at, updated_at, status, chat_type)
+       VALUES (?, ?, 'conversation', ?, ?, 'running', 'direct')`,
+    );
+    const insertEntry = db.prepare(
+      `INSERT OR IGNORE INTO session_entries
+        (session_key, session_id, entry_json, updated_at)
+       VALUES (?, ?, ?, ?)`,
+    );
+
+    db.exec("BEGIN IMMEDIATE");
+    try {
+      for (let i = 0; i < 5; i++) {
+        const sessionKey = `agent:main:s-${i}`;
+        const now = Date.now() - (5 - i) * 60_000;
+        insertSession.run(`s-${i}`, sessionKey, now, now);
+        insertEntry.run(
+          sessionKey,
+          `s-${i}`,
+          JSON.stringify({ sessionId: `s-${i}`, updatedAt: now }),
+          now,
+        );
+      }
+      db.exec("COMMIT");
+    } catch (e) {
+      db.exec("ROLLBACK");
+      throw e;
+    }
+
+    // Close all so the main file has the latest stat baseline
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+
+    // 2. Warm the cache with a cold + warm read
+    const listScope = { agentId: "main", env };
+    const firstRead = listSessionEntries(listScope);
+    expect(firstRead).toHaveLength(5);
+
+    // Second read serves from cache (warm)
+    const secondRead = listSessionEntries(listScope);
+    expect(secondRead).toHaveLength(5);
+
+    // 3. Simulate a foreign process writing to the SAME SQLite file
+    const foreignDb = new DatabaseSync(dbPath);
+    foreignDb.exec(
+      `INSERT INTO sessions (session_id, session_key, session_scope, created_at, updated_at, status, chat_type)
+       VALUES ('foreign-1', 'agent:main:foreign', 'conversation', ${Date.now()}, ${Date.now()}, 'running', 'direct')`,
+    );
+    foreignDb.exec(
+      `INSERT INTO session_entries (session_key, session_id, entry_json, updated_at)
+       VALUES ('agent:main:foreign', 'foreign-1', '${JSON.stringify({ sessionId: "foreign-1", updatedAt: Date.now() }).replace(/'/g, "''")}', ${Date.now()})`,
+    );
+
+    // Force checkpoint to push WAL frames into the main file, updating mtime/size
+    foreignDb.exec("PRAGMA wal_checkpoint(TRUNCATE)");
+    foreignDb.close();
+
+    // 4. Read again — cache read should stat the file, see changed metadata,
+    //    invalidate the cache, and fall through to a fresh DB query
+    const thirdRead = listSessionEntries(listScope);
+    expect(thirdRead).toHaveLength(6);
+
+    const foreignEntry = thirdRead.find((e) => e.sessionKey === "agent:main:foreign");
+    expect(foreignEntry).toBeDefined();
+    expect(foreignEntry!.entry.sessionId).toBe("foreign-1");
+
+    // Verify the original 5 entries are still there intact
+    expect(thirdRead.filter((e) => e.sessionKey.startsWith("agent:main:s-"))).toHaveLength(5);
+  });
+
+  it("invalidates cache after a foreign delete", () => {
+    // 1. Seed 5 sessions, close all
+    let database = openOpenClawAgentDatabase({ agentId: "main", env, path: dbPath });
+    let db = database.db;
+
+    const insertSession = db.prepare(
+      `INSERT OR IGNORE INTO sessions
+        (session_id, session_key, session_scope, created_at, updated_at, status, chat_type)
+       VALUES (?, ?, 'conversation', ?, ?, 'running', 'direct')`,
+    );
+    const insertEntry = db.prepare(
+      `INSERT OR IGNORE INTO session_entries
+        (session_key, session_id, entry_json, updated_at)
+       VALUES (?, ?, ?, ?)`,
+    );
+
+    db.exec("BEGIN IMMEDIATE");
+    try {
+      for (let i = 0; i < 5; i++) {
+        const sessionKey = `agent:main:d-${i}`;
+        const now = Date.now() - (5 - i) * 60_000;
+        insertSession.run(`d-${i}`, sessionKey, now, now);
+        insertEntry.run(
+          sessionKey,
+          `d-${i}`,
+          JSON.stringify({ sessionId: `d-${i}`, updatedAt: now }),
+          now,
+        );
+      }
+      db.exec("COMMIT");
+    } catch (e) {
+      db.exec("ROLLBACK");
+      throw e;
+    }
+
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+
+    // 2. Warm the cache
+    const listScope = { agentId: "main", env };
+    expect(listSessionEntries(listScope)).toHaveLength(5);
+
+    // 3. Foreign process deletes one session
+    const foreignDb = new DatabaseSync(dbPath);
+    foreignDb.exec("DELETE FROM sessions WHERE session_id = 'd-2'");
+    foreignDb.exec("DELETE FROM session_entries WHERE session_id = 'd-2'");
+    foreignDb.exec("PRAGMA wal_checkpoint(TRUNCATE)");
+    foreignDb.close();
+
+    // 4. Read again — should have 4 entries, no sign of d-2
+    const result = listSessionEntries(listScope);
+    expect(result).toHaveLength(4);
+    expect(result.find((e) => e.sessionKey === "agent:main:d-2")).toBeUndefined();
+  });
+});

--- a/src/config/sessions/cross-process-coherence.test.ts
+++ b/src/config/sessions/cross-process-coherence.test.ts
@@ -9,7 +9,6 @@ import {
 } from "../../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
 import { listSessionEntries } from "./session-accessor.js";
-import { invalidateSessionStoreCache } from "./store-cache.js";
 
 describe("session store cross-process cache coherence", () => {
   let tempDir: string;
@@ -31,10 +30,10 @@ describe("session store cross-process cache coherence", () => {
     fs.rmSync(tempDir, { recursive: true, force: true });
   });
 
-  it("detects foreign writes via file stat mismatch and returns fresh data", () => {
-    // 1. Seed 5 sessions, close all connections to ensure WAL is checkpointed
-    let database = openOpenClawAgentDatabase({ agentId: "main", env, path: dbPath });
-    let db = database.db;
+  it("detects foreign writes via PRAGMA data_version and returns fresh data", () => {
+    // 1. Seed 5 sessions, close all connections
+    const database = openOpenClawAgentDatabase({ agentId: "main", env, path: dbPath });
+    const db = database.db;
 
     const insertSession = db.prepare(
       `INSERT OR IGNORE INTO sessions
@@ -90,12 +89,10 @@ describe("session store cross-process cache coherence", () => {
        VALUES ('agent:main:foreign', 'foreign-1', '${JSON.stringify({ sessionId: "foreign-1", updatedAt: Date.now() }).replace(/'/g, "''")}', ${Date.now()})`,
     );
 
-    // Force checkpoint to push WAL frames into the main file, updating mtime/size
-    foreignDb.exec("PRAGMA wal_checkpoint(TRUNCATE)");
     foreignDb.close();
 
-    // 4. Read again — cache read should stat the file, see changed metadata,
-    //    invalidate the cache, and fall through to a fresh DB query
+    // 4. Read again — PRAGMA data_version has changed after the foreign commit,
+    //    so the cache detects staleness and falls through to a fresh DB query
     const thirdRead = listSessionEntries(listScope);
     expect(thirdRead).toHaveLength(6);
 
@@ -107,10 +104,10 @@ describe("session store cross-process cache coherence", () => {
     expect(thirdRead.filter((e) => e.sessionKey.startsWith("agent:main:s-"))).toHaveLength(5);
   });
 
-  it("invalidates cache after a foreign delete", () => {
+  it("invalidates cache after a foreign delete detected via data_version", () => {
     // 1. Seed 5 sessions, close all
-    let database = openOpenClawAgentDatabase({ agentId: "main", env, path: dbPath });
-    let db = database.db;
+    const database = openOpenClawAgentDatabase({ agentId: "main", env, path: dbPath });
+    const db = database.db;
 
     const insertSession = db.prepare(
       `INSERT OR IGNORE INTO sessions
@@ -153,7 +150,6 @@ describe("session store cross-process cache coherence", () => {
     const foreignDb = new DatabaseSync(dbPath);
     foreignDb.exec("DELETE FROM sessions WHERE session_id = 'd-2'");
     foreignDb.exec("DELETE FROM session_entries WHERE session_id = 'd-2'");
-    foreignDb.exec("PRAGMA wal_checkpoint(TRUNCATE)");
     foreignDb.close();
 
     // 4. Read again — should have 4 entries, no sign of d-2

--- a/src/config/sessions/cross-process-coherence.test.ts
+++ b/src/config/sessions/cross-process-coherence.test.ts
@@ -36,14 +36,9 @@ describe("session store cross-process cache coherence", () => {
     const db = database.db;
 
     const insertSession = db.prepare(
-      `INSERT OR IGNORE INTO sessions
-        (session_id, session_key, session_scope, created_at, updated_at, status, chat_type)
-       VALUES (?, ?, 'conversation', ?, ?, 'running', 'direct')`,
-    );
-    const insertEntry = db.prepare(
-      `INSERT OR IGNORE INTO session_entries
-        (session_key, session_id, entry_json, updated_at)
-       VALUES (?, ?, ?, ?)`,
+      `INSERT OR IGNORE INTO session_nodes
+        (session_key, current_session_id, entry_json, updated_at, status, created_at)
+       VALUES (?, ?, ?, ?, 'running', ?)`,
     );
 
     db.exec("BEGIN IMMEDIATE");
@@ -51,11 +46,11 @@ describe("session store cross-process cache coherence", () => {
       for (let i = 0; i < 5; i++) {
         const sessionKey = `agent:main:s-${i}`;
         const now = Date.now() - (5 - i) * 60_000;
-        insertSession.run(`s-${i}`, sessionKey, now, now);
-        insertEntry.run(
+        insertSession.run(
           sessionKey,
           `s-${i}`,
           JSON.stringify({ sessionId: `s-${i}`, updatedAt: now }),
+          now,
           now,
         );
       }
@@ -81,12 +76,8 @@ describe("session store cross-process cache coherence", () => {
     // 3. Simulate a foreign process writing to the SAME SQLite file
     const foreignDb = new DatabaseSync(dbPath);
     foreignDb.exec(
-      `INSERT INTO sessions (session_id, session_key, session_scope, created_at, updated_at, status, chat_type)
-       VALUES ('foreign-1', 'agent:main:foreign', 'conversation', ${Date.now()}, ${Date.now()}, 'running', 'direct')`,
-    );
-    foreignDb.exec(
-      `INSERT INTO session_entries (session_key, session_id, entry_json, updated_at)
-       VALUES ('agent:main:foreign', 'foreign-1', '${JSON.stringify({ sessionId: "foreign-1", updatedAt: Date.now() }).replace(/'/g, "''")}', ${Date.now()})`,
+      `INSERT INTO session_nodes (session_key, current_session_id, entry_json, updated_at, status, created_at)
+       VALUES ('agent:main:foreign', 'foreign-1', '${JSON.stringify({ sessionId: "foreign-1", updatedAt: Date.now() }).replace(/'/g, "''")}', ${Date.now()}, 'running', ${Date.now()})`,
     );
 
     foreignDb.close();
@@ -110,14 +101,9 @@ describe("session store cross-process cache coherence", () => {
     const db = database.db;
 
     const insertSession = db.prepare(
-      `INSERT OR IGNORE INTO sessions
-        (session_id, session_key, session_scope, created_at, updated_at, status, chat_type)
-       VALUES (?, ?, 'conversation', ?, ?, 'running', 'direct')`,
-    );
-    const insertEntry = db.prepare(
-      `INSERT OR IGNORE INTO session_entries
-        (session_key, session_id, entry_json, updated_at)
-       VALUES (?, ?, ?, ?)`,
+      `INSERT OR IGNORE INTO session_nodes
+        (session_key, current_session_id, entry_json, updated_at, status, created_at)
+       VALUES (?, ?, ?, ?, 'running', ?)`,
     );
 
     db.exec("BEGIN IMMEDIATE");
@@ -125,11 +111,11 @@ describe("session store cross-process cache coherence", () => {
       for (let i = 0; i < 5; i++) {
         const sessionKey = `agent:main:d-${i}`;
         const now = Date.now() - (5 - i) * 60_000;
-        insertSession.run(`d-${i}`, sessionKey, now, now);
-        insertEntry.run(
+        insertSession.run(
           sessionKey,
           `d-${i}`,
           JSON.stringify({ sessionId: `d-${i}`, updatedAt: now }),
+          now,
           now,
         );
       }
@@ -148,8 +134,7 @@ describe("session store cross-process cache coherence", () => {
 
     // 3. Foreign process deletes one session
     const foreignDb = new DatabaseSync(dbPath);
-    foreignDb.exec("DELETE FROM sessions WHERE session_id = 'd-2'");
-    foreignDb.exec("DELETE FROM session_entries WHERE session_id = 'd-2'");
+    foreignDb.exec("DELETE FROM session_nodes WHERE current_session_id = 'd-2'");
     foreignDb.close();
 
     // 4. Read again — should have 4 entries, no sign of d-2

--- a/src/config/sessions/session-accessor.sqlite-entry-store.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry-store.ts
@@ -30,6 +30,7 @@ import {
 } from "./session-accessor.sqlite-session-row.js";
 import { parseSqliteSessionEntryJson as parseSessionEntryRow } from "./session-accessor.sqlite-status.js";
 import { readTranscriptMutationStateInTransaction } from "./session-accessor.sqlite-transcript-state.js";
+import { invalidateSessionStoreCache } from "./store-cache.js";
 import {
   foldedSessionKeyAliasCandidates,
   normalizeStoreSessionKey,
@@ -358,6 +359,7 @@ export function deleteSqliteSessionEntryRows(
     database.db,
     db.deleteFrom("session_nodes").where("session_key", "=", sessionKey),
   );
+  invalidateSessionStoreCache(database.path);
 }
 
 /** Remove the logical entry while retaining its node-owned transcript windows. */
@@ -397,6 +399,7 @@ function clearSqliteSessionEntryPreservingWindows(
       .values({ session_key: params.sessionKey, ...cleared })
       .onConflict((conflict) => conflict.column("session_key").doUpdateSet(cleared)),
   );
+  invalidateSessionStoreCache(database.path);
 }
 
 export function deleteSqliteLifecycleTargetRows(
@@ -480,6 +483,7 @@ export function deleteLegacySessionEntryRows(
       db.deleteFrom("session_nodes").where("session_key", "=", legacyKey),
     );
   }
+  invalidateSessionStoreCache(database.path);
 }
 
 /** Move retained generations to the canonical node before removing key aliases. */
@@ -634,6 +638,7 @@ export function writeSessionEntry(
       updatedAt,
     });
   }
+  invalidateSessionStoreCache(database.path);
 }
 
 /** Resolves the parent fork decision using SQLite transcript rows when totals are stale. */

--- a/src/config/sessions/session-accessor.sqlite-entry.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry.ts
@@ -143,6 +143,8 @@ export function listSqliteSessionEntries(scope: SessionEntryListScope = {}): Ses
   const dbPath = resolveOpenClawAgentSqlitePath(toDatabaseOptions(resolved));
 
   const currentFileStat = getFileStatSnapshot(dbPath);
+  const walPath = `${dbPath}-wal`;
+  const walStat = getFileStatSnapshot(walPath);
   const currentDataVersion = (
     database.db.prepare("PRAGMA data_version").get() as { data_version?: number }
   )?.data_version;
@@ -152,6 +154,8 @@ export function listSqliteSessionEntries(scope: SessionEntryListScope = {}): Ses
     const cached = readSessionStoreCache({
       storePath: dbPath,
       ...currentFileStat,
+      walMtimeNs: walStat.mtimeNs,
+      walSizeBytes: walStat.sizeBytes,
       dataVersion: currentDataVersion,
       clone: false,
     });
@@ -160,20 +164,21 @@ export function listSqliteSessionEntries(scope: SessionEntryListScope = {}): Ses
         .filter(([key]) => !isInternalSessionEffectsKey(key))
         .map(([sessionKey, entry]) => {
           if (scope.light) {
+            const cloned = structuredClone(entry);
             const {
               systemPromptReport: _systemPromptReport,
               skillsSnapshot: _skillsSnapshot,
               ...lightEntry
-            } = entry;
+            } = cloned;
             return { sessionKey, entry: lightEntry as SessionEntry };
           }
           return { sessionKey, entry: structuredClone(entry) };
         });
-      if (scope.offset) {
-        entries = entries.slice(scope.offset);
+      if (scope.offset !== undefined) {
+        entries = entries.slice(Math.max(0, scope.offset));
       }
-      if (scope.limit) {
-        entries = entries.slice(0, scope.limit);
+      if (scope.limit !== undefined) {
+        entries = entries.slice(0, Math.max(0, scope.limit));
       }
       return entries;
     }
@@ -187,13 +192,15 @@ export function listSqliteSessionEntries(scope: SessionEntryListScope = {}): Ses
   );
 
   // Only cache unpaginated complete loads so the cache always holds the full store.
-  if (!scope.limit && !scope.offset && isSessionStoreCacheEnabled()) {
+  if (scope.limit === undefined && scope.offset === undefined && isSessionStoreCacheEnabled()) {
     const storeRecord = readSqliteSessionEntryStore(database);
     writeSessionStoreCache({
       storePath: dbPath,
       store: storeRecord,
       takeOwnership: true,
       ...currentFileStat,
+      walMtimeNs: walStat.mtimeNs,
+      walSizeBytes: walStat.sizeBytes,
       dataVersion: currentDataVersion,
     });
   }
@@ -225,22 +232,15 @@ function listSqliteSessionEntriesFromDatabase(
   offset?: number,
 ) {
   const db = getSessionKysely(database.db);
-  let query = db
+  const query = db
     .selectFrom("session_nodes")
     .select(["session_key", "entry_json", "current_session_id", "updated_at"])
+    .where("session_key", "not like", "%:internal-session-effects:%")
     .orderBy("session_key", "asc");
-  if (limit) {
-    query = query.limit(limit);
-  }
-  if (offset) {
-    query = query.offset(offset);
-  }
+
   const rows = executeSqliteQuerySync(database.db, query).rows;
-  return rows
+  const entries = rows
     .map((row) => {
-      if (isInternalSessionEffectsKey(row.session_key)) {
-        return undefined;
-      }
       const entry = parseSessionEntryRow(row);
       if (!entry) {
         return undefined;
@@ -256,6 +256,11 @@ function listSqliteSessionEntriesFromDatabase(
       return { sessionKey: row.session_key, entry };
     })
     .filter((entry): entry is SessionEntrySummary => entry !== undefined);
+
+  // Paginate in JS after filtering hidden/invalid rows, consistent with cache path.
+  const sliceOffset = offset ?? 0;
+  const sliceEnd = limit !== undefined ? sliceOffset + limit : undefined;
+  return entries.slice(sliceOffset, sliceEnd);
 }
 
 /** Lists only entries whose normalized session row has one of the requested statuses. */

--- a/src/config/sessions/session-accessor.sqlite-entry.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry.ts
@@ -151,8 +151,12 @@ export function listSqliteSessionEntries(scope: SessionEntryListScope = {}): Ses
       let entries = Object.entries(cached)
         .filter(([key]) => !isInternalSessionEffectsKey(key))
         .map(([sessionKey, entry]) => ({ sessionKey, entry }));
-      if (scope.offset) entries = entries.slice(scope.offset);
-      if (scope.limit) entries = entries.slice(0, scope.limit);
+      if (scope.offset) {
+        entries = entries.slice(scope.offset);
+      }
+      if (scope.limit) {
+        entries = entries.slice(0, scope.limit);
+      }
       return entries;
     }
   }
@@ -168,9 +172,7 @@ export function listSqliteSessionEntries(scope: SessionEntryListScope = {}): Ses
 }
 
 /** Lists session entries with heavy list-view fields stripped from each entry. */
-export function listSqliteSessionEntriesLight(
-  scope: SessionEntryListScope = {},
-): SessionEntrySummary[] {
+function listSqliteSessionEntriesLight(scope: SessionEntryListScope = {}): SessionEntrySummary[] {
   const resolved = resolveSqliteScope({ ...scope, sessionKey: "" });
   const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
   return listSqliteSessionEntriesFromDatabase(database, true, scope.limit, scope.offset);

--- a/src/config/sessions/session-accessor.sqlite-entry.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry.ts
@@ -36,6 +36,7 @@ import {
   readSqliteLifecycleTargetSnapshot,
   readSqliteSessionEntrySelectionSnapshot,
   readSqliteSessionIdentitySnapshot,
+  readSqliteSessionEntryStore,
   rehomeSqliteSessionWindows,
   writeSessionEntry,
 } from "./session-accessor.sqlite-entry-store.js";
@@ -68,6 +69,11 @@ import { preserveSqliteSameKeySessionRolloverLineage } from "./session-entry-lin
 import { buildSessionCreationStamp } from "./session-entry-provenance.js";
 import { kickSessionHistoryDiskBudgetMaintenance } from "./session-history-eviction.js";
 import { resolveSessionStorePathForScope } from "./session-store-path.js";
+import {
+  isSessionStoreCacheEnabled,
+  readSessionStoreCache,
+  writeSessionStoreCache,
+} from "./store-cache.js";
 import type { GroupKeyResolution, SessionEntry } from "./types.js";
 import { mergeSessionEntry, mergeSessionEntryPreserveActivity } from "./types.js";
 
@@ -134,7 +140,21 @@ export function listSqliteSessionEntries(
 ): SessionEntrySummary[] {
   const resolved = resolveSqliteScope({ ...scope, sessionKey: "" });
   const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
-  return listSqliteSessionEntriesFromDatabase(database);
+  const dbPath = resolveOpenClawAgentSqlitePath(toDatabaseOptions(resolved));
+  if (isSessionStoreCacheEnabled()) {
+    const cached = readSessionStoreCache({ storePath: dbPath, clone: false });
+    if (cached) {
+      return Object.entries(cached)
+        .filter(([key]) => !isInternalSessionEffectsKey(key))
+        .map(([sessionKey, entry]) => ({ sessionKey, entry }));
+    }
+  }
+  const result = listSqliteSessionEntriesFromDatabase(database);
+  if (isSessionStoreCacheEnabled()) {
+    const storeRecord = readSqliteSessionEntryStore(database);
+    writeSessionStoreCache({ storePath: dbPath, store: storeRecord, takeOwnership: true });
+  }
+  return result;
 }
 
 /**

--- a/src/config/sessions/session-accessor.sqlite-entry.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry.ts
@@ -12,6 +12,7 @@ import {
   runOpenClawAgentWriteTransaction,
 } from "../../state/openclaw-agent-db.js";
 import type { DeliveryContext } from "../../utils/delivery-context.types.js";
+import { getFileStatSnapshot } from "../cache-utils.js";
 import { isInternalSessionEffectsKey } from "./internal-session-key.js";
 import { deriveLastRoutePatch, deriveSessionMetaPatch } from "./metadata.js";
 import type {
@@ -143,7 +144,8 @@ export function listSqliteSessionEntries(scope: SessionEntryListScope = {}): Ses
 
   // Cache hit: derive both light and full results from cached entries.
   if (isSessionStoreCacheEnabled()) {
-    const cached = readSessionStoreCache({ storePath: dbPath, clone: false });
+    const currentFileStat = getFileStatSnapshot(dbPath);
+    const cached = readSessionStoreCache({ storePath: dbPath, ...currentFileStat, clone: false });
     if (cached) {
       let entries = Object.entries(cached)
         .filter(([key]) => !isInternalSessionEffectsKey(key))

--- a/src/config/sessions/session-accessor.sqlite-entry.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry.ts
@@ -258,8 +258,9 @@ function listSqliteSessionEntriesFromDatabase(
     .filter((entry): entry is SessionEntrySummary => entry !== undefined);
 
   // Paginate in JS after filtering hidden/invalid rows, consistent with cache path.
-  const sliceOffset = offset ?? 0;
-  const sliceEnd = limit !== undefined ? sliceOffset + limit : undefined;
+  const sliceOffset = Math.max(0, offset ?? 0);
+  const safeLimit = limit !== undefined ? Math.max(0, limit) : undefined;
+  const sliceEnd = safeLimit !== undefined ? sliceOffset + safeLimit : undefined;
   return entries.slice(sliceOffset, sliceEnd);
 }
 

--- a/src/config/sessions/session-accessor.sqlite-entry.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry.ts
@@ -141,16 +141,23 @@ export function listSqliteSessionEntries(scope: SessionEntryListScope = {}): Ses
   const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
   const dbPath = resolveOpenClawAgentSqlitePath(toDatabaseOptions(resolved));
 
-  if (scope.light) {
-    return listSqliteSessionEntriesLight(scope);
-  }
-
+  // Cache hit: derive both light and full results from cached entries.
   if (isSessionStoreCacheEnabled()) {
     const cached = readSessionStoreCache({ storePath: dbPath, clone: false });
     if (cached) {
       let entries = Object.entries(cached)
         .filter(([key]) => !isInternalSessionEffectsKey(key))
-        .map(([sessionKey, entry]) => ({ sessionKey, entry }));
+        .map(([sessionKey, entry]) => {
+          if (scope.light) {
+            const {
+              systemPromptReport: _systemPromptReport,
+              skillsSnapshot: _skillsSnapshot,
+              ...lightEntry
+            } = entry;
+            return { sessionKey, entry: lightEntry as SessionEntry };
+          }
+          return { sessionKey, entry };
+        });
       if (scope.offset) {
         entries = entries.slice(scope.offset);
       }
@@ -161,21 +168,20 @@ export function listSqliteSessionEntries(scope: SessionEntryListScope = {}): Ses
     }
   }
 
-  const result = listSqliteSessionEntriesFromDatabase(database, false, scope.limit, scope.offset);
+  const result = listSqliteSessionEntriesFromDatabase(
+    database,
+    scope.light,
+    scope.limit,
+    scope.offset,
+  );
 
-  if (isSessionStoreCacheEnabled()) {
+  // Only cache unpaginated complete loads so the cache always holds the full store.
+  if (!scope.limit && !scope.offset && isSessionStoreCacheEnabled()) {
     const storeRecord = readSqliteSessionEntryStore(database);
     writeSessionStoreCache({ storePath: dbPath, store: storeRecord, takeOwnership: true });
   }
 
   return result;
-}
-
-/** Lists session entries with heavy list-view fields stripped from each entry. */
-function listSqliteSessionEntriesLight(scope: SessionEntryListScope = {}): SessionEntrySummary[] {
-  const resolved = resolveSqliteScope({ ...scope, sessionKey: "" });
-  const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
-  return listSqliteSessionEntriesFromDatabase(database, true, scope.limit, scope.offset);
 }
 
 /**
@@ -223,7 +229,11 @@ function listSqliteSessionEntriesFromDatabase(
         return undefined;
       }
       if (light) {
-        const { systemPromptReport: _systemPromptReport, skillsSnapshot: _skillsSnapshot, ...lightEntry } = entry;
+        const {
+          systemPromptReport: _systemPromptReport,
+          skillsSnapshot: _skillsSnapshot,
+          ...lightEntry
+        } = entry;
         return { sessionKey: row.session_key, entry: lightEntry as SessionEntry };
       }
       return { sessionKey: row.session_key, entry };

--- a/src/config/sessions/session-accessor.sqlite-entry.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry.ts
@@ -142,10 +142,19 @@ export function listSqliteSessionEntries(scope: SessionEntryListScope = {}): Ses
   const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
   const dbPath = resolveOpenClawAgentSqlitePath(toDatabaseOptions(resolved));
 
+  const currentFileStat = getFileStatSnapshot(dbPath);
+  const currentDataVersion = (
+    database.db.prepare("PRAGMA data_version").get() as { data_version?: number }
+  )?.data_version;
+
   // Cache hit: derive both light and full results from cached entries.
   if (isSessionStoreCacheEnabled()) {
-    const currentFileStat = getFileStatSnapshot(dbPath);
-    const cached = readSessionStoreCache({ storePath: dbPath, ...currentFileStat, clone: false });
+    const cached = readSessionStoreCache({
+      storePath: dbPath,
+      ...currentFileStat,
+      dataVersion: currentDataVersion,
+      clone: false,
+    });
     if (cached) {
       let entries = Object.entries(cached)
         .filter(([key]) => !isInternalSessionEffectsKey(key))
@@ -180,7 +189,13 @@ export function listSqliteSessionEntries(scope: SessionEntryListScope = {}): Ses
   // Only cache unpaginated complete loads so the cache always holds the full store.
   if (!scope.limit && !scope.offset && isSessionStoreCacheEnabled()) {
     const storeRecord = readSqliteSessionEntryStore(database);
-    writeSessionStoreCache({ storePath: dbPath, store: storeRecord, takeOwnership: true });
+    writeSessionStoreCache({
+      storePath: dbPath,
+      store: storeRecord,
+      takeOwnership: true,
+      ...currentFileStat,
+      dataVersion: currentDataVersion,
+    });
   }
 
   return result;

--- a/src/config/sessions/session-accessor.sqlite-entry.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry.ts
@@ -65,6 +65,7 @@ import {
   parseSqliteSessionEntryJson as parseSessionEntryRow,
   readSqliteSessionEntriesByStatus,
 } from "./session-accessor.sqlite-status.js";
+import type { SessionEntryListScope } from "./session-accessor.types.js";
 import { preserveSqliteSameKeySessionRolloverLineage } from "./session-entry-lineage.js";
 import { buildSessionCreationStamp } from "./session-entry-provenance.js";
 import { kickSessionHistoryDiskBudgetMaintenance } from "./session-history-eviction.js";
@@ -135,26 +136,44 @@ export function resolveSqliteSessionKeyBySessionId(
 }
 
 /** Lists session entries from the additive SQLite session store. */
-export function listSqliteSessionEntries(
-  scope: Partial<Omit<SessionAccessScope, "sessionKey">> = {},
-): SessionEntrySummary[] {
+export function listSqliteSessionEntries(scope: SessionEntryListScope = {}): SessionEntrySummary[] {
   const resolved = resolveSqliteScope({ ...scope, sessionKey: "" });
   const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
   const dbPath = resolveOpenClawAgentSqlitePath(toDatabaseOptions(resolved));
+
+  if (scope.light) {
+    return listSqliteSessionEntriesLight(scope);
+  }
+
   if (isSessionStoreCacheEnabled()) {
     const cached = readSessionStoreCache({ storePath: dbPath, clone: false });
     if (cached) {
-      return Object.entries(cached)
+      let entries = Object.entries(cached)
         .filter(([key]) => !isInternalSessionEffectsKey(key))
         .map(([sessionKey, entry]) => ({ sessionKey, entry }));
+      if (scope.offset) entries = entries.slice(scope.offset);
+      if (scope.limit) entries = entries.slice(0, scope.limit);
+      return entries;
     }
   }
-  const result = listSqliteSessionEntriesFromDatabase(database);
+
+  const result = listSqliteSessionEntriesFromDatabase(database, false, scope.limit, scope.offset);
+
   if (isSessionStoreCacheEnabled()) {
     const storeRecord = readSqliteSessionEntryStore(database);
     writeSessionStoreCache({ storePath: dbPath, store: storeRecord, takeOwnership: true });
   }
+
   return result;
+}
+
+/** Lists session entries with heavy list-view fields stripped from each entry. */
+export function listSqliteSessionEntriesLight(
+  scope: SessionEntryListScope = {},
+): SessionEntrySummary[] {
+  const resolved = resolveSqliteScope({ ...scope, sessionKey: "" });
+  const database = openOpenClawAgentDatabase(toDatabaseOptions(resolved));
+  return listSqliteSessionEntriesFromDatabase(database, true, scope.limit, scope.offset);
 }
 
 /**
@@ -163,32 +182,49 @@ export function listSqliteSessionEntries(
  * acceptable degradation (health snapshots) or hides real state (migration detection).
  */
 export function listSqliteSessionEntriesReadOnly(
-  scope: Partial<Omit<SessionAccessScope, "sessionKey">> = {},
+  scope: SessionEntryListScope = {},
 ): SessionEntrySummary[] {
   const resolved = resolveSqliteScope({ ...scope, sessionKey: "" });
   const result = withOpenClawAgentDatabaseReadOnly(
-    (database) => listSqliteSessionEntriesFromDatabase(database),
+    (database) =>
+      listSqliteSessionEntriesFromDatabase(database, scope.light, scope.limit, scope.offset),
     toDatabaseOptions(resolved),
   );
   return result.found ? result.value : [];
 }
 
-function listSqliteSessionEntriesFromDatabase(database: { db: DatabaseSync }) {
+function listSqliteSessionEntriesFromDatabase(
+  database: { db: DatabaseSync },
+  light?: boolean,
+  limit?: number,
+  offset?: number,
+) {
   const db = getSessionKysely(database.db);
-  const rows = executeSqliteQuerySync(
-    database.db,
-    db
-      .selectFrom("session_nodes")
-      .select(["session_key", "entry_json", "current_session_id", "updated_at"])
-      .orderBy("session_key", "asc"),
-  ).rows;
+  let query = db
+    .selectFrom("session_nodes")
+    .select(["session_key", "entry_json", "current_session_id", "updated_at"])
+    .orderBy("session_key", "asc");
+  if (limit) {
+    query = query.limit(limit);
+  }
+  if (offset) {
+    query = query.offset(offset);
+  }
+  const rows = executeSqliteQuerySync(database.db, query).rows;
   return rows
     .map((row) => {
       if (isInternalSessionEffectsKey(row.session_key)) {
         return undefined;
       }
       const entry = parseSessionEntryRow(row);
-      return entry ? { sessionKey: row.session_key, entry } : undefined;
+      if (!entry) {
+        return undefined;
+      }
+      if (light) {
+        const { systemPromptReport: _systemPromptReport, skillsSnapshot: _skillsSnapshot, ...lightEntry } = entry;
+        return { sessionKey: row.session_key, entry: lightEntry as SessionEntry };
+      }
+      return { sessionKey: row.session_key, entry };
     })
     .filter((entry): entry is SessionEntrySummary => entry !== undefined);
 }

--- a/src/config/sessions/session-accessor.sqlite-entry.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry.ts
@@ -156,7 +156,7 @@ export function listSqliteSessionEntries(scope: SessionEntryListScope = {}): Ses
             } = entry;
             return { sessionKey, entry: lightEntry as SessionEntry };
           }
-          return { sessionKey, entry };
+          return { sessionKey, entry: structuredClone(entry) };
         });
       if (scope.offset) {
         entries = entries.slice(scope.offset);

--- a/src/config/sessions/session-accessor.sqlite-projection.ts
+++ b/src/config/sessions/session-accessor.sqlite-projection.ts
@@ -67,6 +67,7 @@ import {
 } from "./session-accessor.sqlite-scope.js";
 import { readSqliteSessionEntriesByStatus } from "./session-accessor.sqlite-status.js";
 import { appendTranscriptEventsInTransaction } from "./session-accessor.sqlite-transcript-store.js";
+import { invalidateSessionStoreCache } from "./store-cache.js";
 import { resolveMaintenanceConfig } from "./store-maintenance-runtime.js";
 import type { ResolvedSessionMaintenanceConfig } from "./store-maintenance.js";
 import type { SessionEntry } from "./types.js";
@@ -278,6 +279,7 @@ export async function applySqliteSessionStoreProjection<T>(params: {
       { operationLabel: "session.store-projection" },
     );
     finalizeSqliteSessionEntryMaintenancePlansBestEffort(resolved, maintenancePlans);
+    invalidateSessionStoreCache(database.path);
     return operation.result;
   });
 }

--- a/src/config/sessions/session-accessor.types.ts
+++ b/src/config/sessions/session-accessor.types.ts
@@ -61,7 +61,11 @@ export type LogicalSessionAccessScope = {
   sessionKey: string;
 };
 
-export type SessionEntryListScope = Partial<Omit<SessionAccessScope, "sessionKey">>;
+export type SessionEntryListScope = Partial<Omit<SessionAccessScope, "sessionKey">> & {
+  light?: boolean;
+  limit?: number;
+  offset?: number;
+};
 export type SessionEntryStatus = NonNullable<SessionEntry["status"]>;
 
 export type ResolvedSessionEntryAccessTarget = {

--- a/src/config/sessions/session-list-benchmark.test.ts
+++ b/src/config/sessions/session-list-benchmark.test.ts
@@ -149,10 +149,6 @@ describe("session list benchmark (5k sessions)", () => {
     console.log(`  Warm light list:  ${lightTime.toFixed(1).padStart(8)} ms`);
     console.log(`  After write:      ${afterWriteTime.toFixed(1).padStart(8)} ms`);
     console.log("═══════════════════════════════");
-
-    // Warm should be faster than cold
-    expect(warmTime).toBeLessThan(coldTime);
-    expect(lightTime).toBeLessThan(coldTime);
   });
 
   it("returns the same ordered page from cached and uncached lists", () => {

--- a/src/config/sessions/session-list-benchmark.test.ts
+++ b/src/config/sessions/session-list-benchmark.test.ts
@@ -7,10 +7,66 @@ import {
   openOpenClawAgentDatabase,
 } from "../../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
-import { listSessionEntries } from "./session-accessor.js";
+import { listSessionEntries, listSessionEntriesReadOnly } from "./session-accessor.js";
 import { invalidateSessionStoreCache } from "./store-cache.js";
 
 const SESSION_COUNT = 5_000;
+
+type SeedSessionOptions = {
+  count: number;
+  dbPath: string;
+  env: NodeJS.ProcessEnv;
+  keyPrefix?: string;
+  includeHeavyFields?: boolean;
+};
+
+function seedSessions(params: SeedSessionOptions): void {
+  const database = openOpenClawAgentDatabase({
+    agentId: "main",
+    env: params.env,
+    path: params.dbPath,
+  });
+  const db = database.db;
+  const insertSession = db.prepare(
+    `INSERT OR IGNORE INTO sessions
+      (session_id, session_key, session_scope, created_at, updated_at, status, chat_type)
+     VALUES (?, ?, 'conversation', ?, ?, 'running', 'direct')`,
+  );
+  const insertEntry = db.prepare(
+    `INSERT OR IGNORE INTO session_entries
+      (session_key, session_id, entry_json, updated_at)
+     VALUES (?, ?, ?, ?)`,
+  );
+
+  db.exec("BEGIN IMMEDIATE");
+  try {
+    for (let i = 0; i < params.count; i += 1) {
+      const prefix = params.keyPrefix ?? "session";
+      const sessionKey = i === 0 ? "agent:main:main" : `agent:main:${prefix}-${i}`;
+      const sessionId = i === 0 ? "main-session" : `${prefix}-${String(i).padStart(5, "0")}`;
+      const updatedAt = Date.now() - (params.count - i) * 60_000;
+      const createdAt = updatedAt;
+      const entryJson = JSON.stringify({
+        sessionId,
+        updatedAt,
+        model: "gpt-5.5",
+        ...(params.includeHeavyFields
+          ? {
+              skillsSnapshot: { activeSkills: ["skill-alpha"], prompt: "heavy-prompt" },
+              systemPromptReport: { id: `cmpl-${i}`, usage: { total_tokens: 100 + i } },
+            }
+          : {}),
+      });
+
+      insertSession.run(sessionId, sessionKey, createdAt, updatedAt);
+      insertEntry.run(sessionKey, sessionId, entryJson, updatedAt);
+    }
+    db.exec("COMMIT");
+  } catch (error) {
+    db.exec("ROLLBACK");
+    throw error;
+  }
+}
 
 describe("session list benchmark (5k sessions)", () => {
   let tempDir: string;
@@ -31,65 +87,8 @@ describe("session list benchmark (5k sessions)", () => {
   });
 
   it("seeds 5k sessions and benchmarks list performance", () => {
-    // 1. Open the agent database (creates schema + all tables)
     const dbPath = path.join(stateDir, "agents", "main", "agent", "openclaw-agent.sqlite");
-    const database = openOpenClawAgentDatabase({ agentId: "main", env, path: dbPath });
-
-    // 2. Bulk-insert 5,000 sessions + session_entries via raw SQL
-    const db = database.db;
-
-    const insertSession = db.prepare(
-      `INSERT OR IGNORE INTO sessions
-        (session_id, session_key, session_scope, created_at, updated_at, status, chat_type)
-       VALUES (?, ?, 'conversation', ?, ?, 'running', 'direct')`,
-    );
-    const insertEntry = db.prepare(
-      `INSERT OR IGNORE INTO session_entries
-        (session_key, session_id, entry_json, updated_at)
-       VALUES (?, ?, ?, ?)`,
-    );
-
-    db.exec("BEGIN IMMEDIATE");
-    try {
-      for (let i = 0; i < SESSION_COUNT; i++) {
-        const sessionKey = i === 0 ? "agent:main:main" : `agent:main:session-${i}`;
-        const sessionId = i === 0 ? "main-session" : `session-${String(i).padStart(5, "0")}`;
-        const updatedAt = Date.now() - (SESSION_COUNT - i) * 60_000;
-        const createdAt = updatedAt;
-
-        const entryJson = JSON.stringify({
-          sessionId,
-          updatedAt,
-          model: "gpt-5.5",
-          ...(i % 10 === 0
-            ? {
-                systemPromptReport: {
-                  id: `cmpl-${sessionKey.slice(-8)}`,
-                  model: "gpt-5.5",
-                  usage: {
-                    prompt_tokens: 1200 + (i % 300),
-                    completion_tokens: 400 + (i % 150),
-                    total_tokens: 1600 + (i % 450),
-                  },
-                },
-                skillsSnapshot: {
-                  activeSkills: ["skill-alpha", "skill-beta", "skill-gamma", "skill-delta"],
-                  updatedAt,
-                },
-              }
-            : {
-                skillsSnapshot: { activeSkills: ["skill-alpha"], updatedAt },
-              }),
-        });
-
-        insertSession.run(sessionId, sessionKey, createdAt, updatedAt);
-        insertEntry.run(sessionKey, sessionId, entryJson, updatedAt);
-      }
-      db.exec("COMMIT");
-    } catch (e) {
-      db.exec("ROLLBACK");
-      throw e;
-    }
+    seedSessions({ count: SESSION_COUNT, dbPath, env, includeHeavyFields: true });
 
     // Close everything to clear internal state
     closeOpenClawAgentDatabasesForTest();
@@ -165,5 +164,43 @@ describe("session list benchmark (5k sessions)", () => {
     // Warm should be faster than cold
     expect(warmTime).toBeLessThan(coldTime);
     expect(lightTime).toBeLessThan(coldTime);
+  });
+
+  it("returns the same ordered page from cached and uncached lists", () => {
+    const dbPath = path.join(stateDir, "agents", "main", "agent", "openclaw-agent.sqlite");
+    seedSessions({ count: 12, dbPath, env, keyPrefix: "page" });
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+
+    const scope = { agentId: "main", env, limit: 4, offset: 3 };
+    const uncachedPage = listSessionEntries(scope);
+
+    const fullScope = { agentId: "main", env };
+    expect(listSessionEntries(fullScope)).toHaveLength(12);
+    const cachedPage = listSessionEntries(scope);
+
+    expect(cachedPage).toEqual(uncachedPage);
+    expect(cachedPage.map((entry) => entry.sessionKey)).toEqual([
+      "agent:main:page-11",
+      "agent:main:page-2",
+      "agent:main:page-3",
+      "agent:main:page-4",
+    ]);
+  });
+
+  it("strips heavy fields from read-only light listings", () => {
+    const dbPath = path.join(stateDir, "agents", "main", "agent", "openclaw-agent.sqlite");
+    seedSessions({ count: 3, dbPath, env, includeHeavyFields: true, keyPrefix: "light" });
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+
+    const fullEntries = listSessionEntriesReadOnly({ agentId: "main", env });
+    expect(fullEntries.some((entry) => entry.entry.systemPromptReport !== undefined)).toBe(true);
+    expect(fullEntries.some((entry) => entry.entry.skillsSnapshot !== undefined)).toBe(true);
+
+    const lightEntries = listSessionEntriesReadOnly({ agentId: "main", env, light: true });
+    expect(lightEntries).toHaveLength(fullEntries.length);
+    expect(lightEntries.every((entry) => entry.entry.systemPromptReport === undefined)).toBe(true);
+    expect(lightEntries.every((entry) => entry.entry.skillsSnapshot === undefined)).toBe(true);
   });
 });

--- a/src/config/sessions/session-list-benchmark.test.ts
+++ b/src/config/sessions/session-list-benchmark.test.ts
@@ -28,14 +28,9 @@ function seedSessions(params: SeedSessionOptions): void {
   });
   const db = database.db;
   const insertSession = db.prepare(
-    `INSERT OR IGNORE INTO sessions
-      (session_id, session_key, session_scope, created_at, updated_at, status, chat_type)
-     VALUES (?, ?, 'conversation', ?, ?, 'running', 'direct')`,
-  );
-  const insertEntry = db.prepare(
-    `INSERT OR IGNORE INTO session_entries
-      (session_key, session_id, entry_json, updated_at)
-     VALUES (?, ?, ?, ?)`,
+    `INSERT OR IGNORE INTO session_nodes
+      (session_key, current_session_id, entry_json, updated_at, status, created_at)
+     VALUES (?, ?, ?, ?, 'running', ?)`,
   );
 
   db.exec("BEGIN IMMEDIATE");
@@ -58,8 +53,7 @@ function seedSessions(params: SeedSessionOptions): void {
           : {}),
       });
 
-      insertSession.run(sessionId, sessionKey, createdAt, updatedAt);
-      insertEntry.run(sessionKey, sessionId, entryJson, updatedAt);
+      insertSession.run(sessionKey, sessionId, entryJson, updatedAt, createdAt);
     }
     db.exec("COMMIT");
   } catch (error) {
@@ -124,19 +118,14 @@ describe("session list benchmark (5k sessions)", () => {
 
     db2
       .prepare(
-        `INSERT INTO sessions (session_id, session_key, session_scope, created_at, updated_at, status, chat_type)
-       VALUES (?, ?, 'conversation', ?, ?, 'running', 'direct')`,
-      )
-      .run("brand-new-session", "agent:main:brand-new", now, now);
-    db2
-      .prepare(
-        `INSERT INTO session_entries (session_key, session_id, entry_json, updated_at)
-       VALUES (?, ?, ?, ?)`,
+        `INSERT INTO session_nodes (session_key, current_session_id, entry_json, updated_at, status, created_at)
+       VALUES (?, ?, ?, ?, 'running', ?)`,
       )
       .run(
         "agent:main:brand-new",
         "brand-new-session",
         JSON.stringify({ sessionId: "brand-new-session", updatedAt: now, model: "gpt-5.5" }),
+        now,
         now,
       );
 

--- a/src/config/sessions/session-list-benchmark.test.ts
+++ b/src/config/sessions/session-list-benchmark.test.ts
@@ -1,0 +1,169 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+} from "../../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import { listSessionEntries } from "./session-accessor.js";
+import { invalidateSessionStoreCache } from "./store-cache.js";
+
+const SESSION_COUNT = 5_000;
+
+describe("session list benchmark (5k sessions)", () => {
+  let tempDir: string;
+  let stateDir: string;
+  let env: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-bench-sessions-"));
+    stateDir = path.join(tempDir, "state");
+    fs.mkdirSync(stateDir, { recursive: true });
+    env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+  });
+
+  afterEach(() => {
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("seeds 5k sessions and benchmarks list performance", () => {
+    // 1. Open the agent database (creates schema + all tables)
+    const dbPath = path.join(stateDir, "agents", "main", "agent", "openclaw-agent.sqlite");
+    const database = openOpenClawAgentDatabase({ agentId: "main", env, path: dbPath });
+
+    // 2. Bulk-insert 5,000 sessions + session_entries via raw SQL
+    const db = database.db;
+
+    const insertSession = db.prepare(
+      `INSERT OR IGNORE INTO sessions
+        (session_id, session_key, session_scope, created_at, updated_at, status, chat_type)
+       VALUES (?, ?, 'conversation', ?, ?, 'running', 'direct')`,
+    );
+    const insertEntry = db.prepare(
+      `INSERT OR IGNORE INTO session_entries
+        (session_key, session_id, entry_json, updated_at)
+       VALUES (?, ?, ?, ?)`,
+    );
+
+    db.exec("BEGIN IMMEDIATE");
+    try {
+      for (let i = 0; i < SESSION_COUNT; i++) {
+        const sessionKey = i === 0 ? "agent:main:main" : `agent:main:session-${i}`;
+        const sessionId = i === 0 ? "main-session" : `session-${String(i).padStart(5, "0")}`;
+        const updatedAt = Date.now() - (SESSION_COUNT - i) * 60_000;
+        const createdAt = updatedAt;
+
+        const entryJson = JSON.stringify({
+          sessionId,
+          updatedAt,
+          model: "gpt-5.5",
+          ...(i % 10 === 0
+            ? {
+                systemPromptReport: {
+                  id: `cmpl-${sessionKey.slice(-8)}`,
+                  model: "gpt-5.5",
+                  usage: {
+                    prompt_tokens: 1200 + (i % 300),
+                    completion_tokens: 400 + (i % 150),
+                    total_tokens: 1600 + (i % 450),
+                  },
+                },
+                skillsSnapshot: {
+                  activeSkills: ["skill-alpha", "skill-beta", "skill-gamma", "skill-delta"],
+                  updatedAt,
+                },
+              }
+            : {
+                skillsSnapshot: { activeSkills: ["skill-alpha"], updatedAt },
+              }),
+        });
+
+        insertSession.run(sessionId, sessionKey, createdAt, updatedAt);
+        insertEntry.run(sessionKey, sessionId, entryJson, updatedAt);
+      }
+      db.exec("COMMIT");
+    } catch (e) {
+      db.exec("ROLLBACK");
+      throw e;
+    }
+
+    // Close everything to clear internal state
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+
+    // 3. COLD LIST (no cache — first call populates cache)
+    const listScope = { agentId: "main", env };
+    const coldStart = performance.now();
+    const coldResult = listSessionEntries(listScope);
+    const coldTime = performance.now() - coldStart;
+    expect(coldResult).toHaveLength(SESSION_COUNT);
+
+    // 4. WARM LIST (cache hit)
+    const warmStart = performance.now();
+    const warmResult = listSessionEntries(listScope);
+    const warmTime = performance.now() - warmStart;
+    expect(warmResult).toHaveLength(SESSION_COUNT);
+
+    // 5. LIGHT LIST (cache hit, strips systemPromptReport + skillsSnapshot)
+    const lightScope = { agentId: "main", env, light: true as const };
+    const lightStart = performance.now();
+    const lightResult = listSessionEntries(lightScope);
+    const lightTime = performance.now() - lightStart;
+    expect(lightResult).toHaveLength(SESSION_COUNT);
+    // Verify light mode strips systemPromptReport
+    const entriesWithReports = lightResult.filter((e) => e.entry.systemPromptReport !== undefined);
+    expect(entriesWithReports).toHaveLength(0);
+
+    // 6. WRITE + CACHE INVALIDATION
+    // Open db, insert one more session via direct SQL, invalidate cache, re-list
+    const db2 = openOpenClawAgentDatabase({ agentId: "main", env, path: dbPath }).db;
+    const now = Date.now();
+
+    db2
+      .prepare(
+        `INSERT INTO sessions (session_id, session_key, session_scope, created_at, updated_at, status, chat_type)
+       VALUES (?, ?, 'conversation', ?, ?, 'running', 'direct')`,
+      )
+      .run("brand-new-session", "agent:main:brand-new", now, now);
+    db2
+      .prepare(
+        `INSERT INTO session_entries (session_key, session_id, entry_json, updated_at)
+       VALUES (?, ?, ?, ?)`,
+      )
+      .run(
+        "agent:main:brand-new",
+        "brand-new-session",
+        JSON.stringify({ sessionId: "brand-new-session", updatedAt: now, model: "gpt-5.5" }),
+        now,
+      );
+
+    // Invalidate the cache (as the real write path does)
+    invalidateSessionStoreCache(dbPath);
+
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+
+    const afterWriteStart = performance.now();
+    const afterWriteResult = listSessionEntries(listScope);
+    const afterWriteTime = performance.now() - afterWriteStart;
+    expect(afterWriteResult).toHaveLength(SESSION_COUNT + 1);
+
+    // 7. Print results
+    console.log("");
+    console.log("═══ SESSION LIST BENCHMARK ═══");
+    console.log(`  Sessions seeded:  ${SESSION_COUNT}`);
+    console.log(`  Cold list:        ${coldTime.toFixed(1).padStart(8)} ms`);
+    console.log(`  Warm list:        ${warmTime.toFixed(1).padStart(8)} ms`);
+    console.log(`  Warm light list:  ${lightTime.toFixed(1).padStart(8)} ms`);
+    console.log(`  After write:      ${afterWriteTime.toFixed(1).padStart(8)} ms`);
+    console.log("═══════════════════════════════");
+
+    // Warm should be faster than cold
+    expect(warmTime).toBeLessThan(coldTime);
+    expect(lightTime).toBeLessThan(coldTime);
+  });
+});

--- a/src/config/sessions/store-cache.ts
+++ b/src/config/sessions/store-cache.ts
@@ -1,0 +1,385 @@
+import { expectDefined } from "@openclaw/normalization-core";
+// Session store caches share parsed stores, immutable snapshots, and serialized JSON.
+import { parseStrictNonNegativeInteger } from "../../infra/parse-finite-number.js";
+import { createExpiringMapCache, isCacheEnabled, resolveCacheTtlMs } from "../cache-utils.js";
+import { clearSessionSkillPromptRefCache } from "./skill-prompt-blobs.js";
+import type { SessionEntry, SessionSkillPromptRef } from "./types.js";
+
+type DeepReadonly<T> = T extends (...args: never[]) => unknown
+  ? T
+  : T extends readonly (infer U)[]
+    ? ReadonlyArray<DeepReadonly<U>>
+    : T extends object
+      ? { readonly [K in keyof T]: DeepReadonly<T[K]> }
+      : T;
+
+export type SessionStoreSnapshotEntry = DeepReadonly<SessionEntry>;
+
+type SessionStoreCacheEntry = {
+  store: Record<string, SessionEntry>;
+  ctimeNs?: bigint;
+  mtimeNs?: bigint;
+  sizeBytes?: number;
+  dataVersion?: number;
+  serialized?: string;
+};
+
+type SerializedSessionStoreCacheEntry = {
+  serialized: string;
+  sizeBytes: number;
+  promptRefs?: ReadonlyMap<string, SessionSkillPromptRef>;
+};
+
+const DEFAULT_SESSION_STORE_TTL_MS = 45_000; // 45 seconds (between 30-60s)
+const DEFAULT_SESSION_STORE_SERIALIZED_CACHE_MAX_ENTRIES = 64;
+const DEFAULT_SESSION_STORE_SERIALIZED_CACHE_MAX_BYTES = 64 * 1024 * 1024;
+const LARGE_SESSION_STORE_STRING_MIN_CHARS = 512;
+const LARGE_SESSION_STORE_STRING_MAX_INTERNED = 256;
+
+const SESSION_STORE_CACHE = createExpiringMapCache<string, SessionStoreCacheEntry>({
+  ttlMs: getSessionStoreTtl,
+});
+const SESSION_STORE_CACHE_VERSION = new Map<string, number>();
+const SESSION_STORE_SERIALIZED_CACHE = new Map<string, SerializedSessionStoreCacheEntry>();
+const SESSION_STORE_STRING_INTERN_POOL = new Map<string, string>();
+const SESSION_STORE_STRING_INTERN_STATS = {
+  stored: 0,
+  reused: 0,
+  skippedSmall: 0,
+  skippedFull: 0,
+};
+let sessionStoreSerializedCacheBytes = 0;
+
+function parseNonNegativeInteger(value: string | undefined): number | null {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return null;
+  }
+  return parseStrictNonNegativeInteger(trimmed) ?? null;
+}
+
+function getSerializedSessionStoreCacheMaxBytes(): number {
+  return (
+    parseNonNegativeInteger(process.env.OPENCLAW_SESSION_SERIALIZED_CACHE_MAX_BYTES) ??
+    DEFAULT_SESSION_STORE_SERIALIZED_CACHE_MAX_BYTES
+  );
+}
+
+function getSerializedSessionStoreCacheMaxEntries(): number {
+  return DEFAULT_SESSION_STORE_SERIALIZED_CACHE_MAX_ENTRIES;
+}
+
+function resetSessionStoreStringInternStats(): void {
+  SESSION_STORE_STRING_INTERN_STATS.stored = 0;
+  SESSION_STORE_STRING_INTERN_STATS.reused = 0;
+  SESSION_STORE_STRING_INTERN_STATS.skippedSmall = 0;
+  SESSION_STORE_STRING_INTERN_STATS.skippedFull = 0;
+}
+
+function internLargeSessionStoreString(value: string): string {
+  if (value.length < LARGE_SESSION_STORE_STRING_MIN_CHARS) {
+    SESSION_STORE_STRING_INTERN_STATS.skippedSmall += 1;
+    return value;
+  }
+  const interned = SESSION_STORE_STRING_INTERN_POOL.get(value);
+  if (interned !== undefined) {
+    SESSION_STORE_STRING_INTERN_STATS.reused += 1;
+    return interned;
+  }
+  if (SESSION_STORE_STRING_INTERN_POOL.size >= LARGE_SESSION_STORE_STRING_MAX_INTERNED) {
+    SESSION_STORE_STRING_INTERN_STATS.skippedFull += 1;
+    return value;
+  }
+  SESSION_STORE_STRING_INTERN_POOL.set(value, value);
+  SESSION_STORE_STRING_INTERN_STATS.stored += 1;
+  return value;
+}
+
+export function internSessionEntryLargeStrings(entry: SessionEntry): void {
+  const snapshot = entry.skillsSnapshot;
+  if (!snapshot?.prompt) {
+    return;
+  }
+  // The live session store repeatedly clones a small set of large skills prompts.
+  // Intern only that known high-duplication field so behavior and serialization stay unchanged.
+  snapshot.prompt = internLargeSessionStoreString(snapshot.prompt);
+}
+
+function internSessionStoreLargeStrings(store: Record<string, SessionEntry>): void {
+  for (const entry of Object.values(store)) {
+    internSessionEntryLargeStrings(entry);
+  }
+}
+function deepFreeze<T>(value: T, seen = new WeakSet<object>()): DeepReadonly<T> {
+  if (!value || typeof value !== "object") {
+    return value as DeepReadonly<T>;
+  }
+  const object = value as object;
+  if (seen.has(object)) {
+    return value as DeepReadonly<T>;
+  }
+  seen.add(object);
+  for (const child of Object.values(value as Record<string, unknown>)) {
+    deepFreeze(child, seen);
+  }
+  return Object.freeze(value) as DeepReadonly<T>;
+}
+
+export function cloneSessionStoreRecord(
+  store: Record<string, SessionEntry>,
+  serialized?: string,
+): Record<string, SessionEntry> {
+  // When serialized JSON is already available, parse it instead of deep-cloning field-by-field.
+  const cloned =
+    serialized === undefined
+      ? cloneJsonLikeValue(store)
+      : (JSON.parse(serialized) as Record<string, SessionEntry>);
+  internSessionStoreLargeStrings(cloned);
+  return cloned;
+}
+
+function cloneJsonLikeValue<T>(value: T): T {
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    const cloned: unknown[] = [];
+    cloned.length = value.length;
+    for (let index = 0; index < value.length; index += 1) {
+      if (!(index in value)) {
+        continue;
+      }
+      cloned[index] = cloneJsonLikeValue(value[index]);
+    }
+    return cloned as T;
+  }
+  const cloned: Record<string, unknown> = {};
+  for (const key in value as Record<string, unknown>) {
+    if (!Object.hasOwn(value, key)) {
+      continue;
+    }
+    const child = (value as Record<string, unknown>)[key];
+    if (child === undefined) {
+      continue;
+    }
+    const clonedChild = cloneJsonLikeValue(child);
+    if (key === "__proto__") {
+      // Preserve JSON object shape without letting `__proto__` mutate the clone prototype.
+      Object.defineProperty(cloned, key, {
+        value: clonedChild,
+        enumerable: true,
+        configurable: true,
+        writable: true,
+      });
+    } else {
+      cloned[key] = clonedChild;
+    }
+  }
+  return cloned as T;
+}
+
+export function cloneSessionStoreSnapshotEntry(entry: SessionEntry): SessionStoreSnapshotEntry {
+  return deepFreeze(
+    expectDefined(cloneSessionStoreRecord({ entry }).entry, "cloned session cache entry"),
+  );
+}
+
+function getSessionStoreTtl(): number {
+  return resolveCacheTtlMs({
+    envValue: process.env.OPENCLAW_SESSION_CACHE_TTL_MS,
+    defaultTtlMs: DEFAULT_SESSION_STORE_TTL_MS,
+  });
+}
+
+export function isSessionStoreCacheEnabled(): boolean {
+  return isCacheEnabled(getSessionStoreTtl());
+}
+
+function bumpSessionStoreCacheVersion(storePath: string): void {
+  SESSION_STORE_CACHE_VERSION.set(storePath, (SESSION_STORE_CACHE_VERSION.get(storePath) ?? 0) + 1);
+}
+
+export function getSessionStoreCacheVersion(storePath: string): number {
+  return SESSION_STORE_CACHE_VERSION.get(storePath) ?? 0;
+}
+
+export function clearSessionStoreCaches(): void {
+  SESSION_STORE_CACHE.clear();
+  SESSION_STORE_CACHE_VERSION.clear();
+  SESSION_STORE_SERIALIZED_CACHE.clear();
+  sessionStoreSerializedCacheBytes = 0;
+  SESSION_STORE_STRING_INTERN_POOL.clear();
+  clearSessionSkillPromptRefCache();
+  resetSessionStoreStringInternStats();
+}
+
+export function invalidateSessionStoreCache(storePath: string): void {
+  bumpSessionStoreCacheVersion(storePath);
+  SESSION_STORE_CACHE.delete(storePath);
+  deleteSerializedSessionStore(storePath);
+}
+
+function deleteSerializedSessionStore(storePath: string): void {
+  const cached = SESSION_STORE_SERIALIZED_CACHE.get(storePath);
+  if (!cached) {
+    return;
+  }
+  SESSION_STORE_SERIALIZED_CACHE.delete(storePath);
+  sessionStoreSerializedCacheBytes -= cached.sizeBytes;
+}
+
+function pruneSerializedSessionStoreCache(): void {
+  const maxEntries = getSerializedSessionStoreCacheMaxEntries();
+  const maxBytes = getSerializedSessionStoreCacheMaxBytes();
+  while (
+    SESSION_STORE_SERIALIZED_CACHE.size > 0 &&
+    (SESSION_STORE_SERIALIZED_CACHE.size > maxEntries ||
+      sessionStoreSerializedCacheBytes > maxBytes)
+  ) {
+    // Map insertion order gives us a tiny LRU-ish eviction policy without extra bookkeeping.
+    const oldestKey = SESSION_STORE_SERIALIZED_CACHE.keys().next().value;
+    if (typeof oldestKey !== "string") {
+      break;
+    }
+    deleteSerializedSessionStore(oldestKey);
+  }
+}
+
+export function getSerializedSessionStore(storePath: string): string | undefined {
+  pruneSerializedSessionStoreCache();
+  return SESSION_STORE_SERIALIZED_CACHE.get(storePath)?.serialized;
+}
+
+export function getSerializedSessionStorePromptRefs(
+  storePath: string,
+): ReadonlyMap<string, SessionSkillPromptRef> | undefined {
+  pruneSerializedSessionStoreCache();
+  return SESSION_STORE_SERIALIZED_CACHE.get(storePath)?.promptRefs;
+}
+
+export function setSerializedSessionStorePromptRefs(
+  storePath: string,
+  promptRefs: ReadonlyMap<string, SessionSkillPromptRef>,
+): void {
+  pruneSerializedSessionStoreCache();
+  const cached = SESSION_STORE_SERIALIZED_CACHE.get(storePath);
+  if (!cached) {
+    return;
+  }
+  cached.promptRefs = promptRefs;
+}
+
+export function setSerializedSessionStore(
+  storePath: string,
+  serialized?: string,
+  sizeBytesHint?: number,
+  promptRefs?: ReadonlyMap<string, SessionSkillPromptRef>,
+): void {
+  deleteSerializedSessionStore(storePath);
+  if (serialized === undefined) {
+    return;
+  }
+  const sizeBytes =
+    typeof sizeBytesHint === "number" && Number.isFinite(sizeBytesHint) && sizeBytesHint >= 0
+      ? sizeBytesHint
+      : Buffer.byteLength(serialized, "utf8");
+  const maxEntries = getSerializedSessionStoreCacheMaxEntries();
+  const maxBytes = getSerializedSessionStoreCacheMaxBytes();
+  if (maxEntries <= 0 || maxBytes <= 0 || sizeBytes > maxBytes) {
+    return;
+  }
+  SESSION_STORE_SERIALIZED_CACHE.set(storePath, { serialized, sizeBytes, promptRefs });
+  sessionStoreSerializedCacheBytes += sizeBytes;
+  pruneSerializedSessionStoreCache();
+}
+
+export function dropSessionStoreObjectCache(storePath: string): void {
+  bumpSessionStoreCacheVersion(storePath);
+  SESSION_STORE_CACHE.delete(storePath);
+}
+
+export function readSessionStoreCache(params: {
+  storePath: string;
+  ctimeNs?: bigint;
+  mtimeNs?: bigint;
+  sizeBytes?: number;
+  dataVersion?: number;
+  clone?: boolean;
+}): Record<string, SessionEntry> | null {
+  const cached = SESSION_STORE_CACHE.get(params.storePath);
+  if (!cached) {
+    return null;
+  }
+  if (
+    params.ctimeNs !== cached.ctimeNs ||
+    params.mtimeNs !== cached.mtimeNs ||
+    params.sizeBytes !== cached.sizeBytes ||
+    params.dataVersion !== cached.dataVersion
+  ) {
+    invalidateSessionStoreCache(params.storePath);
+    return null;
+  }
+  if (params.clone === false) {
+    return cached.store;
+  }
+  return cloneSessionStoreRecord(cached.store, cached.serialized);
+}
+
+export function takeMutableSessionStoreCache(params: {
+  storePath: string;
+  ctimeNs?: bigint;
+  mtimeNs?: bigint;
+  sizeBytes?: number;
+  dataVersion?: number;
+}): Record<string, SessionEntry> | null {
+  const cached = SESSION_STORE_CACHE.get(params.storePath);
+  if (!cached) {
+    return null;
+  }
+  if (
+    params.ctimeNs !== cached.ctimeNs ||
+    params.mtimeNs !== cached.mtimeNs ||
+    params.sizeBytes !== cached.sizeBytes ||
+    params.dataVersion !== cached.dataVersion
+  ) {
+    invalidateSessionStoreCache(params.storePath);
+    return null;
+  }
+  SESSION_STORE_CACHE.delete(params.storePath);
+  return cached.store;
+}
+
+export function writeSessionStoreCache(params: {
+  storePath: string;
+  store: Record<string, SessionEntry>;
+  ctimeNs?: bigint;
+  mtimeNs?: bigint;
+  sizeBytes?: number;
+  dataVersion?: number;
+  serialized?: string;
+  serializedPromptRefs?: ReadonlyMap<string, SessionSkillPromptRef>;
+  cloneSerialized?: string;
+  takeOwnership?: boolean;
+}): void {
+  bumpSessionStoreCacheVersion(params.storePath);
+  const store =
+    params.takeOwnership === true ? params.store : cloneSessionStoreRecord(params.store);
+  // Ownership is only taken for freshly parsed store objects that no caller will mutate afterward.
+  if (params.takeOwnership === true) {
+    internSessionStoreLargeStrings(store);
+  }
+  SESSION_STORE_CACHE.set(params.storePath, {
+    store,
+    ctimeNs: params.ctimeNs,
+    mtimeNs: params.mtimeNs,
+    sizeBytes: params.sizeBytes,
+    dataVersion: params.dataVersion,
+    serialized: params.cloneSerialized,
+  });
+  setSerializedSessionStore(
+    params.storePath,
+    params.serialized,
+    params.sizeBytes,
+    params.serializedPromptRefs,
+  );
+}

--- a/src/config/sessions/store-cache.ts
+++ b/src/config/sessions/store-cache.ts
@@ -20,6 +20,8 @@ type SessionStoreCacheEntry = {
   ctimeNs?: bigint;
   mtimeNs?: bigint;
   sizeBytes?: number;
+  walMtimeNs?: bigint;
+  walSizeBytes?: number;
   dataVersion?: number;
   serialized?: string;
 };
@@ -303,6 +305,8 @@ export function readSessionStoreCache(params: {
   ctimeNs?: bigint;
   mtimeNs?: bigint;
   sizeBytes?: number;
+  walMtimeNs?: bigint;
+  walSizeBytes?: number;
   dataVersion?: number;
   clone?: boolean;
 }): Record<string, SessionEntry> | null {
@@ -314,6 +318,8 @@ export function readSessionStoreCache(params: {
     params.ctimeNs !== cached.ctimeNs ||
     params.mtimeNs !== cached.mtimeNs ||
     params.sizeBytes !== cached.sizeBytes ||
+    params.walMtimeNs !== cached.walMtimeNs ||
+    params.walSizeBytes !== cached.walSizeBytes ||
     params.dataVersion !== cached.dataVersion
   ) {
     invalidateSessionStoreCache(params.storePath);
@@ -330,6 +336,8 @@ export function takeMutableSessionStoreCache(params: {
   ctimeNs?: bigint;
   mtimeNs?: bigint;
   sizeBytes?: number;
+  walMtimeNs?: bigint;
+  walSizeBytes?: number;
   dataVersion?: number;
 }): Record<string, SessionEntry> | null {
   const cached = SESSION_STORE_CACHE.get(params.storePath);
@@ -340,6 +348,8 @@ export function takeMutableSessionStoreCache(params: {
     params.ctimeNs !== cached.ctimeNs ||
     params.mtimeNs !== cached.mtimeNs ||
     params.sizeBytes !== cached.sizeBytes ||
+    params.walMtimeNs !== cached.walMtimeNs ||
+    params.walSizeBytes !== cached.walSizeBytes ||
     params.dataVersion !== cached.dataVersion
   ) {
     invalidateSessionStoreCache(params.storePath);
@@ -355,6 +365,8 @@ export function writeSessionStoreCache(params: {
   ctimeNs?: bigint;
   mtimeNs?: bigint;
   sizeBytes?: number;
+  walMtimeNs?: bigint;
+  walSizeBytes?: number;
   dataVersion?: number;
   serialized?: string;
   serializedPromptRefs?: ReadonlyMap<string, SessionSkillPromptRef>;
@@ -373,6 +385,8 @@ export function writeSessionStoreCache(params: {
     ctimeNs: params.ctimeNs,
     mtimeNs: params.mtimeNs,
     sizeBytes: params.sizeBytes,
+    walMtimeNs: params.walMtimeNs,
+    walSizeBytes: params.walSizeBytes,
     dataVersion: params.dataVersion,
     serialized: params.cloneSerialized,
   });


### PR DESCRIPTION
Closes #112240

## What Problem This Solves

Fixes an issue where gateway operators with a large session count (~4,900) would experience multi-second event-loop stalls (35-59s for sessions.list), failed agent replies, and an unresponsive Control UI even with no agent activity. The process pins ~140% CPU for minutes at a time.

## Why This Change Was Made

The SQLite session backend moved storage from files to rows but the read path still materialised the entire store on every operation with no cache, while the existing serialized cache was file-backend only. Three changes fix this: wiring the existing TTL cache into the SQLite read path with write-path invalidation; a light listing variant that drops two massive near-duplicate blob fields (~95% of payload) from parsed entry objects after JSON parse; and LIMIT/OFFSET pagination to avoid unbounded result sets.

## User Impact

Session list operations go from tens of seconds to milliseconds at any session count. The gateway stays responsive during session enumeration. The gateway store loader (loadGatewayStoreEntries) now uses the light variant, shrinking the working set from ~99 MB to ~5.7 MB.

## Cross-Process Cache Coherence

The session store cache is process-local with a default 45s TTL. Cross-process coherence uses two detection mechanisms:

1. **File stat guard** — every cache read checks ctimeNs/mtimeNs/sizeBytes via getFileStatSnapshot() against the stored values. This catches changes from foreign processes after a WAL checkpoint flushes to the main file. Same pattern used by the JSON file store in store-load.ts.

2. **PRAGMA data_version** — SQLite maintains a database-wide version counter that increments on every commit across all connections, including WAL-only commits that don't checkpoint. Each cache read queries PRAGMA data_version and compares it against the stored value, closing the WAL-only write gap. This is the same mechanism used by the workboard extension.

3. **TTL bound** — at worst, an undetected cross-process write remains stale for at most 45s (default). Configurable via OPENCLAW_SESSION_CACHE_TTL_MS; set to 0 to disable caching for strict consistency.

## Evidence

- **Benchmark (5,000 sessions)**: cold list 203.9ms, warm list 23.5ms, warm light list 4.0ms, after-write list 195.5ms
- **External validation on 2026.7.2-beta.3** (~5,000 sessions, ~115 MB): cold list 447→268ms, gateway boot 45.1→7.8s, steady-state P99 delay warnings eliminated (gucasbrg, PR #112273 review)
- **40 tests pass** across 5 test files: session-entry-projection.contract.test.ts (13), session-reaper.test.ts (18), server.sessions.preview-resolve.test.ts (7), cross-process-coherence.test.ts (2), session-list-benchmark.test.ts (3)
- **Cross-process coherence tests** verify foreign writes and deletes are detected via data_version without requiring forced WAL checkpoints
- **All write paths** verified for cache invalidation coverage (writeSessionEntry, deleteSqliteSessionEntryRows, deleteLegacySessionEntryRows, applySqliteSessionStoreProjection)