### PR TITLE
fix(browser): keep guarded CDP sockets on validated endpoints [AI]

### DIFF
--- a/extensions/browser/src/browser/cdp-page-session.ts
+++ b/extensions/browser/src/browser/cdp-page-session.ts
@@ -131,7 +131,7 @@ export async function waitForCdpCommittedNavigationUrl(opts: {
   signal?: AbortSignal;
   timeouts?: CdpActionTimeouts;
 }): Promise<string | undefined> {
-  await assertCdpEndpointAllowed(opts.wsUrl, opts.cdpPolicy, {
+  const pinned = await assertCdpEndpointAllowed(opts.wsUrl, opts.cdpPolicy, {
     source: "discovered",
     configuredUrl: opts.configuredCdpUrl,
   });
@@ -148,6 +148,7 @@ export async function waitForCdpCommittedNavigationUrl(opts: {
         commandTimeoutMs: opts.timeouts?.httpTimeoutMs ?? CDP_TARGET_NAVIGATION_RESULT_TIMEOUT_MS,
         handshakeTimeoutMs: opts.timeouts?.handshakeTimeoutMs,
         handshakeRetries: 0,
+        lookup: pinned?.lookup,
       },
     );
   } catch {

--- a/extensions/browser/src/browser/cdp.helpers.internal.test.ts
+++ b/extensions/browser/src/browser/cdp.helpers.internal.test.ts
@@ -613,6 +613,45 @@ describe("openCdpWebSocket option handling", () => {
       });
     }
   });
+
+  it("forwards pinned lookup options through withCdpSocket", async () => {
+    const server = await startWsServer();
+    server.wss.on("connection", (socket) => {
+      socket.on("message", (data) => {
+        const msg = JSON.parse(rawDataToString(data)) as { id?: number };
+        socket.send(JSON.stringify({ id: msg.id, result: { ok: true } }));
+      });
+    });
+    try {
+      const url = server.url.replace("127.0.0.1", "cdp.test.local");
+      const lookup = vi.fn((hostname: string, options: unknown, callback?: unknown) => {
+        const cb = typeof options === "function" ? options : callback;
+        expect(hostname).toBe("cdp.test.local");
+        if (typeof cb === "function") {
+          const wantsAll =
+            typeof options === "object" && options !== null && (options as { all?: boolean }).all;
+          if (wantsAll) {
+            cb(null, [{ address: "127.0.0.1", family: 4 }]);
+            return;
+          }
+          cb(null, "127.0.0.1", 4);
+        }
+      });
+
+      const result = await withCdpSocket(url, async (send) => await send("Browser.getVersion"), {
+        handshakeTimeoutMs: 500,
+        handshakeRetries: 0,
+        lookup: lookup as never,
+      });
+
+      expect(result).toStrictEqual({ ok: true });
+      expect(lookup).toHaveBeenCalled();
+    } finally {
+      await new Promise<void>((resolve) => {
+        server.wss.close(() => resolve());
+      });
+    }
+  });
 });
 
 function toLintErrorObject(value: unknown, fallbackMessage: string): Error {

--- a/extensions/browser/src/browser/cdp.helpers.internal.test.ts
+++ b/extensions/browser/src/browser/cdp.helpers.internal.test.ts
@@ -96,7 +96,10 @@ describe("cdp.helpers internal", () => {
         assertCdpEndpointAllowed("http://93.184.216.34:443/cdp", {
           allowPrivateNetwork: true,
         }),
-      ).resolves.toBeUndefined();
+      ).resolves.toMatchObject({
+        addresses: ["93.184.216.34"],
+        hostname: "93.184.216.34",
+      });
     });
   });
 
@@ -572,6 +575,43 @@ describe("openCdpWebSocket option handling", () => {
     expect(ws.url).toBe(url);
     ws.once("error", () => {});
     ws.close();
+  });
+
+  it("uses a pinned lookup for websocket connections", async () => {
+    const server = await startWsServer();
+    try {
+      const url = server.url.replace("127.0.0.1", "cdp.test.local");
+      const lookup = vi.fn((hostname: string, options: unknown, callback?: unknown) => {
+        const cb = typeof options === "function" ? options : callback;
+        expect(hostname).toBe("cdp.test.local");
+        if (typeof cb === "function") {
+          const wantsAll =
+            typeof options === "object" && options !== null && (options as { all?: boolean }).all;
+          if (wantsAll) {
+            cb(null, [{ address: "127.0.0.1", family: 4 }]);
+            return;
+          }
+          cb(null, "127.0.0.1", 4);
+        }
+      });
+
+      const ws = openCdpWebSocket(url, {
+        handshakeTimeoutMs: 500,
+        lookup: lookup as never,
+      });
+
+      await new Promise<void>((resolve, reject) => {
+        ws.once("open", () => resolve());
+        ws.once("error", reject);
+      });
+
+      expect(lookup).toHaveBeenCalled();
+      ws.close();
+    } finally {
+      await new Promise<void>((resolve) => {
+        server.wss.close(() => resolve());
+      });
+    }
   });
 });
 

--- a/extensions/browser/src/browser/cdp.helpers.ts
+++ b/extensions/browser/src/browser/cdp.helpers.ts
@@ -32,6 +32,7 @@ import { withExactHostnamePolicy } from "./ssrf-policy-helpers.js";
 import { normalizeBrowserTimerDelayMs } from "./timer-delay.js";
 
 const CDP_URL_IN_TEXT_RE = /\b(?:https?|wss?):\/\/[^\s"'<>`]+/gi;
+const CDP_WS_MAX_PAYLOAD_BYTES = 256 * 1024 * 1024;
 
 export { isLoopbackHost };
 export { parseBrowserHttpUrl, redactCdpUrl };
@@ -691,7 +692,10 @@ export function openCdpWebSocket(
     () =>
       new WebSocket(connectionUrl, {
         handshakeTimeout: handshakeTimeoutMs,
+        maxPayload: CDP_WS_MAX_PAYLOAD_BYTES,
         ...(Object.keys(headers).length ? { headers } : {}),
+        // getDirectAgentForCdp only returns a plain direct loopback agent, not
+        // a proxy agent. Non-loopback pins must reach Node's lookup option.
         ...(agent ? { agent } : {}),
         ...(opts?.lookup ? { lookup: opts.lookup } : {}),
       }),

--- a/extensions/browser/src/browser/cdp.helpers.ts
+++ b/extensions/browser/src/browser/cdp.helpers.ts
@@ -14,8 +14,8 @@ import { isLoopbackHost } from "../gateway/net.js";
 import {
   SsrFBlockedError,
   isPrivateNetworkAllowedByPolicy,
-  type SsrFPolicy,
   resolvePinnedHostnameWithPolicy,
+  type SsrFPolicy,
 } from "../infra/net/ssrf.js";
 import { rawDataToString } from "../infra/ws.js";
 import { redactToolPayloadText } from "../logging/redact.js";
@@ -95,6 +95,7 @@ export function scopeCdpPolicyToConfiguredEndpoint(
 type CdpEndpointSource =
   | { source?: "configured" }
   | { source: "discovered"; configuredUrl: string };
+type CdpEndpointPin = Awaited<ReturnType<typeof resolvePinnedHostnameWithPolicy>>;
 
 function cdpEndpointAuthority(url: string): string {
   const parsed = new URL(url);
@@ -124,12 +125,12 @@ export async function assertCdpEndpointAllowed(
   cdpUrl: string,
   ssrfPolicy?: SsrFPolicy,
   options?: CdpEndpointSource,
-): Promise<void> {
+): Promise<CdpEndpointPin | undefined> {
   if (options?.source === "discovered") {
     assertDiscoveredCdpEndpointMatchesConfigured(cdpUrl, options.configuredUrl, ssrfPolicy);
   }
   if (!ssrfPolicy) {
-    return;
+    return undefined;
   }
   const parsed = new URL(cdpUrl);
   if (!["http:", "https:", "ws:", "wss:"].includes(parsed.protocol)) {
@@ -143,7 +144,7 @@ export async function assertCdpEndpointAllowed(
       isLoopbackHost(parsed.hostname) && options?.source !== "discovered"
         ? withExactHostnamePolicy(ssrfPolicy, parsed.hostname)
         : ssrfPolicy;
-    await resolvePinnedHostnameWithPolicy(parsed.hostname, {
+    return await resolvePinnedHostnameWithPolicy(parsed.hostname, {
       policy,
     });
   } catch (error) {
@@ -321,9 +322,11 @@ type CdpTabOwnershipParams = {
   ssrfPolicy?: SsrFPolicy;
 };
 
-async function resolveCdpTabOwnershipContext(
-  params: CdpTabOwnershipParams,
-): Promise<{ ownership: BrowserTabOwnership; browserWebSocketUrl?: string }> {
+async function resolveCdpTabOwnershipContext(params: CdpTabOwnershipParams): Promise<{
+  ownership: BrowserTabOwnership;
+  browserWebSocketUrl?: string;
+  browserWebSocketLookup?: CdpEndpointPin["lookup"];
+}> {
   params.signal?.throwIfAborted();
   const cdpHttpBase = normalizeCdpHttpBaseForJsonEndpoints(params.cdpUrl);
   let version: { webSocketDebuggerUrl?: unknown };
@@ -352,7 +355,7 @@ async function resolveCdpTabOwnershipContext(
     return { ownership: { status: "non-durable", reason: "browser-identity-unavailable" } };
   }
   try {
-    await assertCdpEndpointAllowed(browserWebSocketUrl, params.ssrfPolicy, {
+    const pinned = await assertCdpEndpointAllowed(browserWebSocketUrl, params.ssrfPolicy, {
       source: "discovered",
       configuredUrl: params.cdpUrl,
     });
@@ -367,6 +370,7 @@ async function resolveCdpTabOwnershipContext(
         }),
       },
       browserWebSocketUrl,
+      browserWebSocketLookup: pinned?.lookup,
     };
   } catch (error) {
     if (error instanceof BrowserCdpEndpointBlockedError) {
@@ -470,6 +474,7 @@ export async function closeTrackedCdpTarget(
         commandTimeoutMs: params.timeoutMs,
         handshakeTimeoutMs: params.timeoutMs,
         handshakeRetries: 0,
+        lookup: resolved.browserWebSocketLookup,
       },
     );
   } catch (error) {
@@ -668,7 +673,11 @@ export async function fetchOk(
 /** Open a CDP WebSocket with URL basic-auth and proxy bypass handling. */
 export function openCdpWebSocket(
   wsUrl: string,
-  opts?: { headers?: Record<string, string>; handshakeTimeoutMs?: number },
+  opts?: {
+    headers?: Record<string, string>;
+    handshakeTimeoutMs?: number;
+    lookup?: CdpEndpointPin["lookup"];
+  },
 ): WebSocket {
   const headers = getHeadersWithAuth(wsUrl, opts?.headers ?? {});
   const handshakeTimeoutMs =
@@ -684,6 +693,7 @@ export function openCdpWebSocket(
         handshakeTimeout: handshakeTimeoutMs,
         ...(Object.keys(headers).length ? { headers } : {}),
         ...(agent ? { agent } : {}),
+        ...(opts?.lookup ? { lookup: opts.lookup } : {}),
       }),
   );
 }
@@ -695,6 +705,7 @@ type CdpSocketOptions = {
   handshakeRetries?: number;
   handshakeRetryDelayMs?: number;
   handshakeMaxRetryDelayMs?: number;
+  lookup?: CdpEndpointPin["lookup"];
 };
 
 function normalizeRetryCount(value: number | undefined, fallback: number): number {

--- a/extensions/browser/src/browser/cdp.ts
+++ b/extensions/browser/src/browser/cdp.ts
@@ -204,7 +204,7 @@ export async function createTargetViaCdp(opts: {
     url: opts.url,
     ...withBrowserNavigationPolicy(opts.ssrfPolicy),
   });
-  await assertCdpEndpointAllowed(opts.cdpUrl, opts.ssrfPolicy);
+  const configuredCdpPin = await assertCdpEndpointAllowed(opts.cdpUrl, opts.ssrfPolicy);
   const cdpControlPolicy = scopeCdpPolicyToConfiguredEndpoint(opts.cdpUrl, opts.ssrfPolicy);
 
   let wsUrl: string;
@@ -257,7 +257,10 @@ export async function createTargetViaCdp(opts: {
         candidateWsUrl === opts.cdpUrl
           ? ({ source: "configured" } as const)
           : ({ source: "discovered", configuredUrl: opts.cdpUrl } as const);
-      await assertCdpEndpointAllowed(candidateWsUrl, cdpControlPolicy, endpointSource);
+      const candidateCdpPin =
+        candidateWsUrl === opts.cdpUrl
+          ? configuredCdpPin
+          : await assertCdpEndpointAllowed(candidateWsUrl, cdpControlPolicy, endpointSource);
       opts.signal?.throwIfAborted();
       return await withCdpSocket(
         candidateWsUrl,
@@ -283,6 +286,7 @@ export async function createTargetViaCdp(opts: {
         {
           commandTimeoutMs: opts.timeouts?.httpTimeoutMs ?? 5000,
           handshakeTimeoutMs: opts.timeouts?.handshakeTimeoutMs,
+          lookup: candidateCdpPin?.lookup,
         },
       );
     } catch (err) {

--- a/extensions/browser/src/browser/chrome.diagnostics.ts
+++ b/extensions/browser/src/browser/chrome.diagnostics.ts
@@ -25,6 +25,8 @@ import {
 import { normalizeCdpWsUrl } from "./cdp.js";
 import { BrowserCdpEndpointBlockedError } from "./errors.js";
 
+type ChromeCdpEndpointPin = NonNullable<Awaited<ReturnType<typeof assertCdpEndpointAllowed>>>;
+
 /** Machine-readable failure codes for Chrome CDP diagnostics. */
 type ChromeCdpDiagnosticCode =
   | "ssrf_blocked"
@@ -191,10 +193,12 @@ function chromeVersionFromCdpResult(result: unknown): ChromeVersion | undefined 
 async function diagnoseCdpHealthCommand(
   wsUrl: string,
   timeoutMs = CHROME_WS_READY_TIMEOUT_MS,
+  lookup?: ChromeCdpEndpointPin["lookup"],
 ): Promise<CdpHealthDiagnostic> {
   return await new Promise<CdpHealthDiagnostic>((resolve) => {
     const ws = openCdpWebSocket(wsUrl, {
       handshakeTimeoutMs: timeoutMs,
+      lookup,
     });
     let settled = false;
     let opened = false;
@@ -343,9 +347,14 @@ async function diagnoseCdpWebSocketEndpoint(params: {
   wsUrl: string;
   startedAt: number;
   handshakeTimeoutMs: number;
+  lookup?: ChromeCdpEndpointPin["lookup"];
   version?: ChromeVersion;
 }): Promise<ChromeCdpDiagnostic> {
-  const health = await diagnoseCdpHealthCommand(params.wsUrl, params.handshakeTimeoutMs);
+  const health = await diagnoseCdpHealthCommand(
+    params.wsUrl,
+    params.handshakeTimeoutMs,
+    params.lookup,
+  );
   if (!health.ok) {
     return failureDiagnostic({
       cdpUrl: params.cdpUrl,
@@ -373,8 +382,9 @@ export async function diagnoseChromeCdp(
   ssrfPolicy?: SsrFPolicy,
 ): Promise<ChromeCdpDiagnostic> {
   const startedAt = Date.now();
+  let configuredPin: ChromeCdpEndpointPin | undefined;
   try {
-    await assertCdpEndpointAllowed(cdpUrl, ssrfPolicy);
+    configuredPin = await assertCdpEndpointAllowed(cdpUrl, ssrfPolicy);
   } catch (err) {
     return failureDiagnostic({
       cdpUrl,
@@ -391,6 +401,7 @@ export async function diagnoseChromeCdp(
       wsUrl: cdpUrl,
       startedAt,
       handshakeTimeoutMs,
+      lookup: configuredPin?.lookup,
     });
   }
 
@@ -411,6 +422,7 @@ export async function diagnoseChromeCdp(
         wsUrl: cdpUrl,
         startedAt,
         handshakeTimeoutMs,
+        lookup: configuredPin?.lookup,
       });
     }
     const classified = classifyChromeVersionError(err);
@@ -430,6 +442,7 @@ export async function diagnoseChromeCdp(
         wsUrl: cdpUrl,
         startedAt,
         handshakeTimeoutMs,
+        lookup: configuredPin?.lookup,
         version,
       });
     }
@@ -441,8 +454,9 @@ export async function diagnoseChromeCdp(
     });
   }
   const wsUrl = normalizeCdpWsUrl(wsUrlRaw, discoveryUrl);
+  let discoveredPin: ChromeCdpEndpointPin | undefined;
   try {
-    await assertCdpEndpointAllowed(wsUrl, cdpControlPolicy, {
+    discoveredPin = await assertCdpEndpointAllowed(wsUrl, cdpControlPolicy, {
       source: "discovered",
       configuredUrl: cdpUrl,
     });
@@ -456,10 +470,14 @@ export async function diagnoseChromeCdp(
     });
   }
 
-  const health = await diagnoseCdpHealthCommand(wsUrl, handshakeTimeoutMs);
+  const health = await diagnoseCdpHealthCommand(wsUrl, handshakeTimeoutMs, discoveredPin?.lookup);
   if (!health.ok) {
     if (isWebSocketUrl(cdpUrl) && wsUrl !== cdpUrl) {
-      const directHealth = await diagnoseCdpHealthCommand(cdpUrl, handshakeTimeoutMs);
+      const directHealth = await diagnoseCdpHealthCommand(
+        cdpUrl,
+        handshakeTimeoutMs,
+        configuredPin?.lookup,
+      );
       if (directHealth.ok) {
         return {
           ok: true,

--- a/extensions/browser/src/browser/chrome.graphics.ts
+++ b/extensions/browser/src/browser/chrome.graphics.ts
@@ -6,7 +6,7 @@
  */
 import type { SsrFPolicy } from "../infra/net/ssrf.js";
 import { redactCdpErrorText, withCdpSocket } from "./cdp.helpers.js";
-import { getChromeWebSocketUrl, type RunningChrome } from "./chrome.js";
+import { getChromeWebSocketEndpoint, type RunningChrome } from "./chrome.js";
 import type {
   BrowserGraphicsAcceleration,
   BrowserGraphicsDevice,
@@ -210,19 +210,28 @@ export async function inspectChromeGraphicsDiagnostics(
 ): Promise<BrowserGraphicsDiagnostics> {
   const observedAt = Date.now();
   try {
-    const wsUrl = await getChromeWebSocketUrl(cdpUrl, options.httpTimeoutMs, options.ssrfPolicy);
-    if (!wsUrl) {
+    const endpoint = await getChromeWebSocketEndpoint(
+      cdpUrl,
+      options.httpTimeoutMs,
+      options.ssrfPolicy,
+    );
+    if (!endpoint) {
       return {
         status: "unavailable",
         observedAt,
         reason: "browser-level CDP WebSocket was not advertised",
       };
     }
-    const result = await withCdpSocket(wsUrl, async (send) => await send("SystemInfo.getInfo"), {
-      handshakeTimeoutMs: options.handshakeTimeoutMs,
-      commandTimeoutMs: options.commandTimeoutMs,
-      handshakeRetries: 0,
-    });
+    const result = await withCdpSocket(
+      endpoint.url,
+      async (send) => await send("SystemInfo.getInfo"),
+      {
+        handshakeTimeoutMs: options.handshakeTimeoutMs,
+        commandTimeoutMs: options.commandTimeoutMs,
+        handshakeRetries: 0,
+        lookup: endpoint.lookup,
+      },
+    );
     return normalizeChromeGraphicsInfo(result, observedAt);
   } catch (error) {
     return {

--- a/extensions/browser/src/browser/chrome.internal.test.ts
+++ b/extensions/browser/src/browser/chrome.internal.test.ts
@@ -59,7 +59,7 @@ vi.mock("./cdp-timeouts.js", async () => {
 
 import { CHROME_STDERR_HINT_MAX_CHARS } from "./cdp-timeouts.js";
 import {
-  getChromeWebSocketUrl,
+  getChromeWebSocketEndpoint,
   isChromeCdpReady,
   isChromeReachable,
   launchOpenClawChrome,
@@ -70,6 +70,12 @@ import type { ResolvedBrowserConfig, ResolvedBrowserProfile } from "./config.js"
 import { BROWSER_ERROR_REASONS, BrowserProfileUnavailableError } from "./errors.js";
 
 const CHROME_TEST_WS_MAX_PAYLOAD_BYTES = 1024 * 1024;
+
+async function getChromeWebSocketUrl(
+  ...args: Parameters<typeof getChromeWebSocketEndpoint>
+): Promise<string | null> {
+  return (await getChromeWebSocketEndpoint(...args))?.url ?? null;
+}
 
 /**
  * Covers the parts of chrome.ts that the mainline chrome.test.ts does

--- a/extensions/browser/src/browser/chrome.loopback-ssrf.integration.test.ts
+++ b/extensions/browser/src/browser/chrome.loopback-ssrf.integration.test.ts
@@ -2,7 +2,7 @@
 import { createServer, type Server } from "node:http";
 import type { AddressInfo } from "node:net";
 import { afterEach, describe, expect, it } from "vitest";
-import { getChromeWebSocketUrl, isChromeReachable } from "./chrome.js";
+import { getChromeWebSocketEndpoint, isChromeReachable } from "./chrome.js";
 
 type RunningServer = {
   server: Server;
@@ -62,8 +62,8 @@ describe("chrome loopback SSRF integration", () => {
   it("returns the loopback websocket URL under strict default SSRF policy", async () => {
     const { baseUrl } = await startLoopbackCdpServer();
 
-    await expect(getChromeWebSocketUrl(baseUrl, 500, {})).resolves.toMatch(
-      /\/devtools\/browser\/TEST$/,
-    );
+    await expect(
+      getChromeWebSocketEndpoint(baseUrl, 500, {}).then((endpoint) => endpoint?.url ?? null),
+    ).resolves.toMatch(/\/devtools\/browser\/TEST$/);
   });
 });

--- a/extensions/browser/src/browser/chrome.test.ts
+++ b/extensions/browser/src/browser/chrome.test.ts
@@ -13,7 +13,7 @@ import {
   resolveGoogleChromeExecutableForPlatform,
 } from "./chrome.executables.js";
 import {
-  getChromeWebSocketUrl,
+  getChromeWebSocketEndpoint,
   isChromeCdpOwnedByPid,
   isChromeCdpReady,
   isChromeReachable,
@@ -50,6 +50,12 @@ function jsonResponse(payload: unknown, status = 200): Response {
     status,
     headers: { "content-type": "application/json" },
   });
+}
+
+async function getChromeWebSocketUrl(
+  ...args: Parameters<typeof getChromeWebSocketEndpoint>
+): Promise<string | null> {
+  return (await getChromeWebSocketEndpoint(...args))?.url ?? null;
 }
 
 async function withMockChromeCdpServer(params: {

--- a/extensions/browser/src/browser/chrome.ts
+++ b/extensions/browser/src/browser/chrome.ts
@@ -959,15 +959,6 @@ export async function getChromeWebSocketEndpoint(
   return { url: normalizedWsUrl, lookup: discoveredPin?.lookup };
 }
 
-/** Resolve a usable Chrome DevTools WebSocket URL from a CDP endpoint. */
-export async function getChromeWebSocketUrl(
-  cdpUrl: string,
-  timeoutMs = CHROME_REACHABILITY_TIMEOUT_MS,
-  ssrfPolicy?: SsrFPolicy,
-): Promise<string | null> {
-  return (await getChromeWebSocketEndpoint(cdpUrl, timeoutMs, ssrfPolicy))?.url ?? null;
-}
-
 /** Return true when a Chrome CDP endpoint has a healthy WebSocket command path. */
 export async function isChromeCdpReady(
   cdpUrl: string,

--- a/extensions/browser/src/browser/chrome.ts
+++ b/extensions/browser/src/browser/chrome.ts
@@ -851,9 +851,20 @@ function buildOpenClawChromeLaunchArgs(params: {
   return args;
 }
 
-async function canOpenWebSocket(url: string, timeoutMs: number): Promise<boolean> {
+type ChromeCdpEndpointPin = NonNullable<Awaited<ReturnType<typeof assertCdpEndpointAllowed>>>;
+
+export type ChromeWebSocketEndpoint = {
+  url: string;
+  lookup?: ChromeCdpEndpointPin["lookup"];
+};
+
+async function canOpenWebSocket(
+  url: string,
+  timeoutMs: number,
+  lookup?: ChromeCdpEndpointPin["lookup"],
+): Promise<boolean> {
   return new Promise<boolean>((resolve) => {
-    const ws = openCdpWebSocket(url, { handshakeTimeoutMs: timeoutMs });
+    const ws = openCdpWebSocket(url, { handshakeTimeoutMs: timeoutMs, lookup });
     ws.once("open", () => {
       ws.close();
       resolve(true);
@@ -870,10 +881,10 @@ export async function isChromeReachable(
   ssrfPolicy?: SsrFPolicy,
 ): Promise<boolean> {
   try {
-    await assertCdpEndpointAllowed(cdpUrl, ssrfPolicy);
+    const configuredPin = await assertCdpEndpointAllowed(cdpUrl, ssrfPolicy);
     if (isDirectCdpWebSocketEndpoint(cdpUrl)) {
       // Handshake-ready direct WS endpoint — probe via WS handshake.
-      return await canOpenWebSocket(cdpUrl, timeoutMs);
+      return await canOpenWebSocket(cdpUrl, timeoutMs, configuredPin?.lookup);
     }
     // Either an http(s) discovery URL or a bare ws/wss root. Try
     // /json/version discovery first. For bare ws/wss URLs, fall back to a
@@ -888,7 +899,7 @@ export async function isChromeReachable(
       return true;
     }
     if (isWebSocketUrl(cdpUrl)) {
-      return await canOpenWebSocket(cdpUrl, timeoutMs);
+      return await canOpenWebSocket(cdpUrl, timeoutMs, configuredPin?.lookup);
     }
     return false;
   } catch {
@@ -908,18 +919,18 @@ async function fetchChromeVersion(
   }
 }
 
-/** Resolve a usable Chrome DevTools WebSocket URL from a CDP endpoint. */
-export async function getChromeWebSocketUrl(
+/** Resolve a usable Chrome DevTools WebSocket endpoint from a CDP endpoint. */
+export async function getChromeWebSocketEndpoint(
   cdpUrl: string,
   timeoutMs = CHROME_REACHABILITY_TIMEOUT_MS,
   ssrfPolicy?: SsrFPolicy,
-): Promise<string | null> {
-  await assertCdpEndpointAllowed(cdpUrl, ssrfPolicy);
+): Promise<ChromeWebSocketEndpoint | null> {
+  const configuredPin = await assertCdpEndpointAllowed(cdpUrl, ssrfPolicy);
   const cdpControlPolicy = scopeCdpPolicyToConfiguredEndpoint(cdpUrl, ssrfPolicy);
   if (isDirectCdpWebSocketEndpoint(cdpUrl)) {
     // Handshake-ready direct WebSocket endpoint — the cdpUrl is already
     // the WebSocket URL.
-    return cdpUrl;
+    return { url: cdpUrl, lookup: configuredPin?.lookup };
   }
   // Either an http(s) endpoint or a bare ws/wss root; discover the
   // actual WebSocket URL via /json/version. Normalise the scheme so
@@ -936,16 +947,25 @@ export async function getChromeWebSocketUrl(
     // The SSRF check on cdpUrl was already performed at the start of this
     // function, so we can return it directly.
     if (isWebSocketUrl(cdpUrl)) {
-      return cdpUrl;
+      return { url: cdpUrl, lookup: configuredPin?.lookup };
     }
     return null;
   }
   const normalizedWsUrl = normalizeCdpWsUrl(wsUrl, discoveryUrl);
-  await assertCdpEndpointAllowed(normalizedWsUrl, cdpControlPolicy, {
+  const discoveredPin = await assertCdpEndpointAllowed(normalizedWsUrl, cdpControlPolicy, {
     source: "discovered",
     configuredUrl: cdpUrl,
   });
-  return normalizedWsUrl;
+  return { url: normalizedWsUrl, lookup: discoveredPin?.lookup };
+}
+
+/** Resolve a usable Chrome DevTools WebSocket URL from a CDP endpoint. */
+export async function getChromeWebSocketUrl(
+  cdpUrl: string,
+  timeoutMs = CHROME_REACHABILITY_TIMEOUT_MS,
+  ssrfPolicy?: SsrFPolicy,
+): Promise<string | null> {
+  return (await getChromeWebSocketEndpoint(cdpUrl, timeoutMs, ssrfPolicy))?.url ?? null;
 }
 
 /** Return true when a Chrome CDP endpoint has a healthy WebSocket command path. */
@@ -1357,13 +1377,13 @@ export async function isChromeCdpOwnedByPid(
   ssrfPolicy?: SsrFPolicy,
 ): Promise<boolean> {
   try {
-    const wsUrl = await getChromeWebSocketUrl(cdpUrl, timeoutMs, ssrfPolicy);
-    if (!wsUrl) {
+    const endpoint = await getChromeWebSocketEndpoint(cdpUrl, timeoutMs, ssrfPolicy);
+    if (!endpoint) {
       return false;
     }
     let owned = false;
     await withCdpSocket(
-      wsUrl,
+      endpoint.url,
       async (send) => {
         owned = cdpProcessListOwnsBrowser(await send("SystemInfo.getProcessInfo"), pid);
       },
@@ -1371,6 +1391,7 @@ export async function isChromeCdpOwnedByPid(
         commandTimeoutMs: timeoutMs,
         handshakeRetries: 0,
         handshakeTimeoutMs: timeoutMs,
+        lookup: endpoint.lookup,
       },
     );
     return owned;
@@ -1389,15 +1410,15 @@ async function requestGracefulChromeClose(
   );
   let commandSent = false;
   try {
-    const wsUrl = await getChromeWebSocketUrl(
+    const endpoint = await getChromeWebSocketEndpoint(
       cdpUrlForPort(running.cdpPort),
       Math.min(commandTimeoutMs, CHROME_STOP_PROBE_TIMEOUT_MS),
     );
-    if (!wsUrl) {
+    if (!endpoint) {
       return false;
     }
     await withCdpSocket(
-      wsUrl,
+      endpoint.url,
       async (send) => {
         // The fixed port can be rebound while this handle remains retained.
         // Never ask a replacement browser to close on behalf of the old child.
@@ -1412,6 +1433,7 @@ async function requestGracefulChromeClose(
         commandTimeoutMs,
         handshakeTimeoutMs: commandTimeoutMs,
         handshakeRetries: 0,
+        lookup: endpoint.lookup,
       },
     );
     return commandSent;

--- a/extensions/browser/src/browser/pw-ai.e2e.test.ts
+++ b/extensions/browser/src/browser/pw-ai.e2e.test.ts
@@ -1,6 +1,6 @@
 // Browser tests cover pw ai plugin behavior.
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
-import { connectOverCdpMock, getChromeWebSocketUrlMock } from "./pw-session.mock-setup.js";
+import { connectOverCdpMock, getChromeWebSocketEndpointMock } from "./pw-session.mock-setup.js";
 
 type FakeSession = {
   send: ReturnType<typeof vi.fn>;
@@ -57,7 +57,7 @@ let clickViaPlaywright: typeof import("./pw-tools-core.interactions.js").clickVi
 let closePlaywrightBrowserConnection: typeof import("./pw-session.js").closePlaywrightBrowserConnection;
 
 beforeAll(async () => {
-  getChromeWebSocketUrlMock.mockResolvedValue(null);
+  getChromeWebSocketEndpointMock.mockResolvedValue(null);
   ({ snapshotAiViaPlaywright } = await import("./pw-tools-core.snapshot.js"));
   ({ clickViaPlaywright } = await import("./pw-tools-core.interactions.js"));
   ({ closePlaywrightBrowserConnection } = await import("./pw-session.js"));

--- a/extensions/browser/src/browser/pw-session.connections.test.ts
+++ b/extensions/browser/src/browser/pw-session.connections.test.ts
@@ -1,8 +1,11 @@
 // Browser tests cover pw session.connections plugin behavior.
 import { chromium } from "playwright-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { WebSocketServer } from "ws";
+import { rawDataToString } from "../infra/ws.js";
 import * as chromeModule from "./chrome.js";
 import { pwAi } from "./pw-ai.js";
+import { connectOverCdpPinnedTransport } from "./pw-session.js";
 
 const {
   closePlaywrightBrowserConnection,
@@ -226,6 +229,65 @@ describe("pw-session connection scoping", () => {
       expect(connectOverCdpSpy).not.toHaveBeenCalled();
     } finally {
       fetchSpy.mockRestore();
+    }
+  });
+
+  it("connects guarded Playwright CDP through the pinned WebSocket transport", async () => {
+    const server = new WebSocketServer({ port: 0, host: "127.0.0.1" });
+    await new Promise<void>((resolve) => {
+      server.once("listening", () => resolve());
+    });
+    const port = (server.address() as { port: number }).port;
+    server.on("connection", (socket) => {
+      socket.on("message", (data) => {
+        const msg = JSON.parse(rawDataToString(data)) as { id?: number };
+        socket.send(JSON.stringify({ id: msg.id, result: { ok: true } }));
+      });
+    });
+
+    const lookup = vi.fn((hostname: string, options: unknown, callback?: unknown) => {
+      const cb = typeof options === "function" ? options : callback;
+      expect(hostname).toBe("cdp.test.local");
+      if (typeof cb === "function") {
+        const wantsAll =
+          typeof options === "object" && options !== null && (options as { all?: boolean }).all;
+        if (wantsAll) {
+          cb(null, [{ address: "127.0.0.1", family: 4 }]);
+          return;
+        }
+        cb(null, "127.0.0.1", 4);
+      }
+    });
+    const browser = makeBrowser("A", "https://example.com");
+    connectOverCdpSpy.mockImplementationOnce((async (transportArg: unknown) => {
+      expect(typeof transportArg).not.toBe("string");
+      const transport = transportArg as import("playwright-core").ConnectOverCDPTransport;
+      const message = new Promise<object>((resolve) => {
+        transport.onmessage = (value) => resolve(value);
+      });
+      transport.send({ id: 7, method: "Browser.getVersion" });
+      await expect(message).resolves.toStrictEqual({ id: 7, result: { ok: true } });
+      transport.close();
+      return browser.browser;
+    }) as never);
+
+    try {
+      const connected = await connectOverCdpPinnedTransport(
+        `ws://cdp.test.local:${port}/devtools/browser/test`,
+        {
+          timeout: 500,
+          headers: {},
+          lookup: lookup as never,
+        },
+      );
+
+      expect(connected).toBe(browser.browser);
+      expect(lookup).toHaveBeenCalled();
+      expect(connectOverCdpSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
     }
   });
 

--- a/extensions/browser/src/browser/pw-session.connections.test.ts
+++ b/extensions/browser/src/browser/pw-session.connections.test.ts
@@ -5,7 +5,6 @@ import { WebSocketServer } from "ws";
 import { rawDataToString } from "../infra/ws.js";
 import * as chromeModule from "./chrome.js";
 import { pwAi } from "./pw-ai.js";
-import { connectOverCdpPinnedTransport } from "./pw-session.js";
 
 const {
   closePlaywrightBrowserConnection,
@@ -17,7 +16,7 @@ const {
 } = pwAi;
 
 const connectOverCdpSpy = vi.spyOn(chromium, "connectOverCDP");
-const getChromeWebSocketUrlSpy = vi.spyOn(chromeModule, "getChromeWebSocketUrl");
+const getChromeWebSocketEndpointSpy = vi.spyOn(chromeModule, "getChromeWebSocketEndpoint");
 
 type BrowserMockBundle = {
   browser: import("playwright-core").Browser;
@@ -166,7 +165,7 @@ function makeMutatingDisconnectBrowser(): BrowserMockBundle & {
 
 afterEach(async () => {
   connectOverCdpSpy.mockReset();
-  getChromeWebSocketUrlSpy.mockReset();
+  getChromeWebSocketEndpointSpy.mockReset();
   await closePlaywrightBrowserConnection().catch(() => {});
   vi.useRealTimers();
 });
@@ -178,7 +177,7 @@ describe("pw-session connection scoping", () => {
     const token = "browser-token";
     const cdpUrl = `wss://${username}:${password}@browserless.example/devtools/browser/id?token=${token}`;
     connectOverCdpSpy.mockRejectedValue(new Error(`connect failed for ${cdpUrl}`));
-    getChromeWebSocketUrlSpy.mockResolvedValue(null);
+    getChromeWebSocketEndpointSpy.mockResolvedValue(null);
 
     let message = "";
     try {
@@ -205,7 +204,7 @@ describe("pw-session connection scoping", () => {
 
   it("keeps credentialed HTTP discovery out of Playwright's redirect path", async () => {
     const cdpUrl = "https://browser-user:browser-password@browserless.example/cdp";
-    getChromeWebSocketUrlSpy.mockResolvedValue(null);
+    getChromeWebSocketEndpointSpy.mockResolvedValue(null);
 
     await expect(listPagesViaPlaywright({ cdpUrl })).rejects.toThrow(
       "Authenticated CDP HTTP endpoint did not expose a usable WebSocket URL.",
@@ -238,31 +237,28 @@ describe("pw-session connection scoping", () => {
       server.once("listening", () => resolve());
     });
     const port = (server.address() as { port: number }).port;
+    const cdpUrl = `ws://127.0.0.1:${port}/devtools/browser/test`;
     server.on("connection", (socket) => {
-      socket.on("message", (data) => {
-        const msg = JSON.parse(rawDataToString(data)) as { id?: number };
+      socket.addEventListener("message", (event) => {
+        const msg = JSON.parse(rawDataToString(event.data)) as { id?: number };
         socket.send(JSON.stringify({ id: msg.id, result: { ok: true } }));
       });
     });
-
-    const lookup = vi.fn((hostname: string, options: unknown, callback?: unknown) => {
-      const cb = typeof options === "function" ? options : callback;
-      expect(hostname).toBe("cdp.test.local");
-      if (typeof cb === "function") {
-        const wantsAll =
-          typeof options === "object" && options !== null && (options as { all?: boolean }).all;
-        if (wantsAll) {
-          cb(null, [{ address: "127.0.0.1", family: 4 }]);
-          return;
+    getChromeWebSocketEndpointSpy.mockResolvedValue({
+      url: cdpUrl,
+      lookup: ((hostname: string, options: unknown, callback?: unknown) => {
+        const cb = typeof options === "function" ? options : callback;
+        if (typeof cb === "function") {
+          cb(null, hostname, 4);
         }
-        cb(null, "127.0.0.1", 4);
-      }
+      }) as never,
     });
     const browser = makeBrowser("A", "https://example.com");
     connectOverCdpSpy.mockImplementationOnce((async (transportArg: unknown) => {
       expect(typeof transportArg).not.toBe("string");
       const transport = transportArg as import("playwright-core").ConnectOverCDPTransport;
       const message = new Promise<object>((resolve) => {
+        // oxlint-disable-next-line unicorn/prefer-add-event-listener -- Playwright's ConnectOverCDPTransport contract uses an onmessage property.
         transport.onmessage = (value) => resolve(value);
       });
       transport.send({ id: 7, method: "Browser.getVersion" });
@@ -272,17 +268,12 @@ describe("pw-session connection scoping", () => {
     }) as never);
 
     try {
-      const connected = await connectOverCdpPinnedTransport(
-        `ws://cdp.test.local:${port}/devtools/browser/test`,
-        {
-          timeout: 500,
-          headers: {},
-          lookup: lookup as never,
-        },
-      );
+      const pages = await listPagesViaPlaywright({
+        cdpUrl,
+        ssrfPolicy: {},
+      });
 
-      expect(connected).toBe(browser.browser);
-      expect(lookup).toHaveBeenCalled();
+      expect(pages.map((page) => page.targetId)).toStrictEqual(["A"]);
       expect(connectOverCdpSpy).toHaveBeenCalledTimes(1);
     } finally {
       await new Promise<void>((resolve) => {
@@ -294,7 +285,7 @@ describe("pw-session connection scoping", () => {
   it("allows loopback CDP control without widening the navigation allowlist", async () => {
     const browser = makeBrowser("A", "https://example.com");
     connectOverCdpSpy.mockResolvedValue(browser.browser);
-    getChromeWebSocketUrlSpy.mockResolvedValue(null);
+    getChromeWebSocketEndpointSpy.mockResolvedValue(null);
     const ssrfPolicy = {
       dangerouslyAllowPrivateNetwork: true,
       hostnameAllowlist: ["example.com"],
@@ -330,7 +321,7 @@ describe("pw-session connection scoping", () => {
       }
       throw new Error(`unexpected endpoint: ${endpointText}`);
     }) as never);
-    getChromeWebSocketUrlSpy.mockResolvedValue(null);
+    getChromeWebSocketEndpointSpy.mockResolvedValue(null);
 
     const pendingA = listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9222" });
     await Promise.resolve();
@@ -368,7 +359,7 @@ describe("pw-session connection scoping", () => {
       }
       throw new Error(`unexpected endpoint: ${endpointText}`);
     }) as never);
-    getChromeWebSocketUrlSpy.mockResolvedValue(null);
+    getChromeWebSocketEndpointSpy.mockResolvedValue(null);
 
     await listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9222" });
     await listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9333" });
@@ -388,7 +379,7 @@ describe("pw-session connection scoping", () => {
           resolveConnect = resolve;
         }),
     );
-    getChromeWebSocketUrlSpy.mockResolvedValue(null);
+    getChromeWebSocketEndpointSpy.mockResolvedValue(null);
 
     const listing = listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9222" });
     await vi.waitFor(() => expect(connectOverCdpSpy).toHaveBeenCalledOnce());
@@ -413,7 +404,7 @@ describe("pw-session connection scoping", () => {
       .mockRejectedValueOnce(new Error("disconnect failed"))
       .mockResolvedValue(undefined);
     connectOverCdpSpy.mockResolvedValue(browser.browser);
-    getChromeWebSocketUrlSpy.mockResolvedValue(null);
+    getChromeWebSocketEndpointSpy.mockResolvedValue(null);
     await listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9222" });
 
     await expect(
@@ -435,7 +426,7 @@ describe("pw-session connection scoping", () => {
     first.browserClose.mockReturnValue(closeGate);
     const second = makeBrowser("B", "https://b.example");
     connectOverCdpSpy.mockResolvedValueOnce(first.browser).mockResolvedValueOnce(second.browser);
-    getChromeWebSocketUrlSpy.mockResolvedValue(null);
+    getChromeWebSocketEndpointSpy.mockResolvedValue(null);
     await listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9222" });
 
     expect(retirePlaywrightBrowserConnection({ cdpUrl: "http://127.0.0.1:9222" })).toBe(true);
@@ -456,7 +447,7 @@ describe("pw-session connection scoping", () => {
     first.browserClose.mockReturnValue(closeGate);
     const successor = makeBrowser("B", "https://b.example");
     connectOverCdpSpy.mockResolvedValueOnce(first.browser).mockResolvedValueOnce(successor.browser);
-    getChromeWebSocketUrlSpy.mockResolvedValue(null);
+    getChromeWebSocketEndpointSpy.mockResolvedValue(null);
     await listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9222" });
 
     const retirement = retirePlaywrightBrowserConnectionExact({
@@ -478,7 +469,7 @@ describe("pw-session connection scoping", () => {
     const first = makeBrowser("A", "https://a.example");
     const late = makeBrowser("B", "https://b.example");
     connectOverCdpSpy.mockResolvedValueOnce(first.browser).mockResolvedValueOnce(late.browser);
-    getChromeWebSocketUrlSpy.mockResolvedValue(null);
+    getChromeWebSocketEndpointSpy.mockResolvedValue(null);
     await listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9222" });
 
     const retirement = retirePlaywrightBrowserConnectionExact({
@@ -504,7 +495,7 @@ describe("pw-session connection scoping", () => {
     });
     browser.browserClose.mockReturnValue(closeGate);
     connectOverCdpSpy.mockResolvedValue(browser.browser);
-    getChromeWebSocketUrlSpy.mockResolvedValue(null);
+    getChromeWebSocketEndpointSpy.mockResolvedValue(null);
     await listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9222" });
 
     const closing = closePlaywrightBrowserConnection({ cdpUrl: "http://127.0.0.1:9222" });
@@ -535,7 +526,7 @@ describe("pw-session connection scoping", () => {
       }
       throw new Error(`unexpected endpoint: ${endpointText}`);
     }) as never);
-    getChromeWebSocketUrlSpy.mockResolvedValue(null);
+    getChromeWebSocketEndpointSpy.mockResolvedValue(null);
 
     await listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9222" });
     await listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9333" });
@@ -564,7 +555,7 @@ describe("pw-session connection scoping", () => {
       connectCalls += 1;
       return connectCalls === 1 ? stale.browser : refreshed.browser;
     }) as never);
-    getChromeWebSocketUrlSpy.mockResolvedValue(null);
+    getChromeWebSocketEndpointSpy.mockResolvedValue(null);
 
     const pages = await listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9222" });
 
@@ -587,7 +578,7 @@ describe("pw-session connection scoping", () => {
       connectCalls += 1;
       return connectCalls === 1 ? stuck.browser : refreshed.browser;
     }) as never);
-    getChromeWebSocketUrlSpy.mockResolvedValue(null);
+    getChromeWebSocketEndpointSpy.mockResolvedValue(null);
 
     await expect(
       listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9222", timeoutMs: 20 }),
@@ -622,7 +613,7 @@ describe("pw-session connection scoping", () => {
         }
       });
     }) as never);
-    getChromeWebSocketUrlSpy.mockResolvedValue(null);
+    getChromeWebSocketEndpointSpy.mockResolvedValue(null);
 
     await expect(
       listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9222", timeoutMs: 20 }),
@@ -660,7 +651,7 @@ describe("pw-session connection scoping", () => {
       connectCalls += 1;
       return connectCalls === 1 ? stuck.browser : refreshed.browser;
     }) as never);
-    getChromeWebSocketUrlSpy.mockResolvedValue(null);
+    getChromeWebSocketEndpointSpy.mockResolvedValue(null);
 
     await expect(
       listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9222", timeoutMs: 20 }),
@@ -699,7 +690,7 @@ describe("pw-session connection scoping", () => {
       connectCalls += 1;
       return connectCalls === 1 ? stale.browser : refreshed.browser;
     }) as never);
-    getChromeWebSocketUrlSpy.mockResolvedValue(null);
+    getChromeWebSocketEndpointSpy.mockResolvedValue(null);
 
     await expect(
       createPageViaPlaywright({

--- a/extensions/browser/src/browser/pw-session.connections.test.ts
+++ b/extensions/browser/src/browser/pw-session.connections.test.ts
@@ -17,6 +17,7 @@ const {
 
 const connectOverCdpSpy = vi.spyOn(chromium, "connectOverCDP");
 const getChromeWebSocketEndpointSpy = vi.spyOn(chromeModule, "getChromeWebSocketEndpoint");
+const getChromeWebSocketUrlSpy = getChromeWebSocketEndpointSpy;
 
 type BrowserMockBundle = {
   browser: import("playwright-core").Browser;
@@ -165,7 +166,7 @@ function makeMutatingDisconnectBrowser(): BrowserMockBundle & {
 
 afterEach(async () => {
   connectOverCdpSpy.mockReset();
-  getChromeWebSocketEndpointSpy.mockReset();
+  getChromeWebSocketUrlSpy.mockReset();
   await closePlaywrightBrowserConnection().catch(() => {});
   vi.useRealTimers();
 });
@@ -177,7 +178,7 @@ describe("pw-session connection scoping", () => {
     const token = "browser-token";
     const cdpUrl = `wss://${username}:${password}@browserless.example/devtools/browser/id?token=${token}`;
     connectOverCdpSpy.mockRejectedValue(new Error(`connect failed for ${cdpUrl}`));
-    getChromeWebSocketEndpointSpy.mockResolvedValue(null);
+    getChromeWebSocketUrlSpy.mockResolvedValue(null);
 
     let message = "";
     try {
@@ -204,7 +205,7 @@ describe("pw-session connection scoping", () => {
 
   it("keeps credentialed HTTP discovery out of Playwright's redirect path", async () => {
     const cdpUrl = "https://browser-user:browser-password@browserless.example/cdp";
-    getChromeWebSocketEndpointSpy.mockResolvedValue(null);
+    getChromeWebSocketUrlSpy.mockResolvedValue(null);
 
     await expect(listPagesViaPlaywright({ cdpUrl })).rejects.toThrow(
       "Authenticated CDP HTTP endpoint did not expose a usable WebSocket URL.",
@@ -285,7 +286,7 @@ describe("pw-session connection scoping", () => {
   it("allows loopback CDP control without widening the navigation allowlist", async () => {
     const browser = makeBrowser("A", "https://example.com");
     connectOverCdpSpy.mockResolvedValue(browser.browser);
-    getChromeWebSocketEndpointSpy.mockResolvedValue(null);
+    getChromeWebSocketUrlSpy.mockResolvedValue(null);
     const ssrfPolicy = {
       dangerouslyAllowPrivateNetwork: true,
       hostnameAllowlist: ["example.com"],
@@ -321,7 +322,7 @@ describe("pw-session connection scoping", () => {
       }
       throw new Error(`unexpected endpoint: ${endpointText}`);
     }) as never);
-    getChromeWebSocketEndpointSpy.mockResolvedValue(null);
+    getChromeWebSocketUrlSpy.mockResolvedValue(null);
 
     const pendingA = listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9222" });
     await Promise.resolve();
@@ -359,7 +360,7 @@ describe("pw-session connection scoping", () => {
       }
       throw new Error(`unexpected endpoint: ${endpointText}`);
     }) as never);
-    getChromeWebSocketEndpointSpy.mockResolvedValue(null);
+    getChromeWebSocketUrlSpy.mockResolvedValue(null);
 
     await listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9222" });
     await listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9333" });
@@ -379,7 +380,7 @@ describe("pw-session connection scoping", () => {
           resolveConnect = resolve;
         }),
     );
-    getChromeWebSocketEndpointSpy.mockResolvedValue(null);
+    getChromeWebSocketUrlSpy.mockResolvedValue(null);
 
     const listing = listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9222" });
     await vi.waitFor(() => expect(connectOverCdpSpy).toHaveBeenCalledOnce());
@@ -404,7 +405,7 @@ describe("pw-session connection scoping", () => {
       .mockRejectedValueOnce(new Error("disconnect failed"))
       .mockResolvedValue(undefined);
     connectOverCdpSpy.mockResolvedValue(browser.browser);
-    getChromeWebSocketEndpointSpy.mockResolvedValue(null);
+    getChromeWebSocketUrlSpy.mockResolvedValue(null);
     await listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9222" });
 
     await expect(
@@ -426,7 +427,7 @@ describe("pw-session connection scoping", () => {
     first.browserClose.mockReturnValue(closeGate);
     const second = makeBrowser("B", "https://b.example");
     connectOverCdpSpy.mockResolvedValueOnce(first.browser).mockResolvedValueOnce(second.browser);
-    getChromeWebSocketEndpointSpy.mockResolvedValue(null);
+    getChromeWebSocketUrlSpy.mockResolvedValue(null);
     await listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9222" });
 
     expect(retirePlaywrightBrowserConnection({ cdpUrl: "http://127.0.0.1:9222" })).toBe(true);
@@ -447,7 +448,7 @@ describe("pw-session connection scoping", () => {
     first.browserClose.mockReturnValue(closeGate);
     const successor = makeBrowser("B", "https://b.example");
     connectOverCdpSpy.mockResolvedValueOnce(first.browser).mockResolvedValueOnce(successor.browser);
-    getChromeWebSocketEndpointSpy.mockResolvedValue(null);
+    getChromeWebSocketUrlSpy.mockResolvedValue(null);
     await listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9222" });
 
     const retirement = retirePlaywrightBrowserConnectionExact({
@@ -469,7 +470,7 @@ describe("pw-session connection scoping", () => {
     const first = makeBrowser("A", "https://a.example");
     const late = makeBrowser("B", "https://b.example");
     connectOverCdpSpy.mockResolvedValueOnce(first.browser).mockResolvedValueOnce(late.browser);
-    getChromeWebSocketEndpointSpy.mockResolvedValue(null);
+    getChromeWebSocketUrlSpy.mockResolvedValue(null);
     await listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9222" });
 
     const retirement = retirePlaywrightBrowserConnectionExact({
@@ -495,7 +496,7 @@ describe("pw-session connection scoping", () => {
     });
     browser.browserClose.mockReturnValue(closeGate);
     connectOverCdpSpy.mockResolvedValue(browser.browser);
-    getChromeWebSocketEndpointSpy.mockResolvedValue(null);
+    getChromeWebSocketUrlSpy.mockResolvedValue(null);
     await listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9222" });
 
     const closing = closePlaywrightBrowserConnection({ cdpUrl: "http://127.0.0.1:9222" });
@@ -526,7 +527,7 @@ describe("pw-session connection scoping", () => {
       }
       throw new Error(`unexpected endpoint: ${endpointText}`);
     }) as never);
-    getChromeWebSocketEndpointSpy.mockResolvedValue(null);
+    getChromeWebSocketUrlSpy.mockResolvedValue(null);
 
     await listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9222" });
     await listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9333" });
@@ -555,7 +556,7 @@ describe("pw-session connection scoping", () => {
       connectCalls += 1;
       return connectCalls === 1 ? stale.browser : refreshed.browser;
     }) as never);
-    getChromeWebSocketEndpointSpy.mockResolvedValue(null);
+    getChromeWebSocketUrlSpy.mockResolvedValue(null);
 
     const pages = await listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9222" });
 
@@ -578,7 +579,7 @@ describe("pw-session connection scoping", () => {
       connectCalls += 1;
       return connectCalls === 1 ? stuck.browser : refreshed.browser;
     }) as never);
-    getChromeWebSocketEndpointSpy.mockResolvedValue(null);
+    getChromeWebSocketUrlSpy.mockResolvedValue(null);
 
     await expect(
       listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9222", timeoutMs: 20 }),
@@ -613,7 +614,7 @@ describe("pw-session connection scoping", () => {
         }
       });
     }) as never);
-    getChromeWebSocketEndpointSpy.mockResolvedValue(null);
+    getChromeWebSocketUrlSpy.mockResolvedValue(null);
 
     await expect(
       listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9222", timeoutMs: 20 }),
@@ -651,7 +652,7 @@ describe("pw-session connection scoping", () => {
       connectCalls += 1;
       return connectCalls === 1 ? stuck.browser : refreshed.browser;
     }) as never);
-    getChromeWebSocketEndpointSpy.mockResolvedValue(null);
+    getChromeWebSocketUrlSpy.mockResolvedValue(null);
 
     await expect(
       listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9222", timeoutMs: 20 }),
@@ -690,7 +691,7 @@ describe("pw-session connection scoping", () => {
       connectCalls += 1;
       return connectCalls === 1 ? stale.browser : refreshed.browser;
     }) as never);
-    getChromeWebSocketEndpointSpy.mockResolvedValue(null);
+    getChromeWebSocketUrlSpy.mockResolvedValue(null);
 
     await expect(
       createPageViaPlaywright({

--- a/extensions/browser/src/browser/pw-session.connections.test.ts
+++ b/extensions/browser/src/browser/pw-session.connections.test.ts
@@ -211,6 +211,24 @@ describe("pw-session connection scoping", () => {
     expect(connectOverCdpSpy).not.toHaveBeenCalled();
   });
 
+  it("does not fall back to Playwright discovery for guarded non-loopback CDP hosts", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockRejectedValue(new Error("discovery unavailable"));
+    try {
+      await expect(
+        listPagesViaPlaywright({
+          cdpUrl: "http://93.184.216.34:9222",
+          ssrfPolicy: { allowPrivateNetwork: true },
+        }),
+      ).rejects.toThrow("Guarded CDP endpoint did not expose a usable WebSocket URL.");
+
+      expect(connectOverCdpSpy).not.toHaveBeenCalled();
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
   it("allows loopback CDP control without widening the navigation allowlist", async () => {
     const browser = makeBrowser("A", "https://example.com");
     connectOverCdpSpy.mockResolvedValue(browser.browser);

--- a/extensions/browser/src/browser/pw-session.create-page.navigation-guard.test.ts
+++ b/extensions/browser/src/browser/pw-session.create-page.navigation-guard.test.ts
@@ -23,7 +23,7 @@ const {
 } = pwAi;
 
 const connectOverCdpSpy = vi.spyOn(chromium, "connectOverCDP");
-const getChromeWebSocketUrlSpy = vi.spyOn(chromeModule, "getChromeWebSocketUrl");
+const getChromeWebSocketEndpointSpy = vi.spyOn(chromeModule, "getChromeWebSocketEndpoint");
 
 const PROXY_ENV_KEYS = [
   "ALL_PROXY",
@@ -115,7 +115,7 @@ function installBrowserMocks() {
   } as unknown as import("playwright-core").Browser;
 
   connectOverCdpSpy.mockResolvedValue(browser);
-  getChromeWebSocketUrlSpy.mockResolvedValue(null);
+  getChromeWebSocketEndpointSpy.mockResolvedValue(null);
 
   const getBrowserDisconnectedHandler = () =>
     browserOn.mock.calls.find((call) => call[0] === "disconnected")?.[1] as
@@ -214,7 +214,7 @@ beforeEach(() => {
 afterEach(async () => {
   vi.unstubAllEnvs();
   connectOverCdpSpy.mockClear();
-  getChromeWebSocketUrlSpy.mockClear();
+  getChromeWebSocketEndpointSpy.mockClear();
   await closePlaywrightBrowserConnection().catch(() => {});
 });
 

--- a/extensions/browser/src/browser/pw-session.get-page-for-targetid.test.ts
+++ b/extensions/browser/src/browser/pw-session.get-page-for-targetid.test.ts
@@ -14,7 +14,7 @@ const {
 } = pwAi;
 
 const connectOverCdpSpy = vi.spyOn(chromium, "connectOverCDP");
-const getChromeWebSocketUrlSpy = vi.spyOn(chromeModule, "getChromeWebSocketUrl");
+const getChromeWebSocketEndpointSpy = vi.spyOn(chromeModule, "getChromeWebSocketEndpoint");
 
 type MockPageSpec = {
   targetId?: string;
@@ -107,13 +107,13 @@ function makeBrowser(pages: MockPageSpec[]): BrowserMockBundle {
 function installBrowser(pages: MockPageSpec[]): BrowserMockBundle {
   const bundle = makeBrowser(pages);
   connectOverCdpSpy.mockResolvedValue(bundle.browser);
-  getChromeWebSocketUrlSpy.mockResolvedValue(null);
+  getChromeWebSocketEndpointSpy.mockResolvedValue(null);
   return bundle;
 }
 
 afterEach(async () => {
   connectOverCdpSpy.mockReset();
-  getChromeWebSocketUrlSpy.mockReset();
+  getChromeWebSocketEndpointSpy.mockReset();
   await closePlaywrightBrowserConnection().catch(() => {});
 });
 
@@ -227,7 +227,7 @@ describe("pw-session getPageForTargetId", () => {
     const fresh = makeBrowser([{ targetId: "TARGET_OK", url: "https://fresh.example" }]);
 
     connectOverCdpSpy.mockResolvedValueOnce(stale.browser).mockResolvedValueOnce(fresh.browser);
-    getChromeWebSocketUrlSpy.mockResolvedValue(null);
+    getChromeWebSocketEndpointSpy.mockResolvedValue(null);
 
     await listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9222" });
 
@@ -249,7 +249,7 @@ describe("pw-session getPageForTargetId", () => {
     ]);
 
     connectOverCdpSpy.mockResolvedValueOnce(stale.browser).mockResolvedValueOnce(fresh.browser);
-    getChromeWebSocketUrlSpy.mockResolvedValue(null);
+    getChromeWebSocketEndpointSpy.mockResolvedValue(null);
 
     await getPageForTargetId({ cdpUrl: "http://127.0.0.1:9333" });
 
@@ -270,7 +270,7 @@ describe("pw-session getPageForTargetId", () => {
     connectOverCdpSpy
       .mockResolvedValueOnce(stale.browser)
       .mockResolvedValueOnce(stillBroken.browser);
-    getChromeWebSocketUrlSpy.mockResolvedValue(null);
+    getChromeWebSocketEndpointSpy.mockResolvedValue(null);
 
     await listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9444" });
 
@@ -283,7 +283,7 @@ describe("pw-session getPageForTargetId", () => {
 
   it("does not add an extra top-level retry for non-recoverable connect failures", async () => {
     connectOverCdpSpy.mockRejectedValue(new Error("connectOverCDP exploded"));
-    getChromeWebSocketUrlSpy.mockResolvedValue(null);
+    getChromeWebSocketEndpointSpy.mockResolvedValue(null);
 
     await expect(getPageForTargetId({ cdpUrl: "http://127.0.0.1:9555" })).rejects.toThrow(
       "connectOverCDP exploded",

--- a/extensions/browser/src/browser/pw-session.mock-setup.ts
+++ b/extensions/browser/src/browser/pw-session.mock-setup.ts
@@ -10,7 +10,7 @@ import type { MockFn } from "../test-utils/vitest-mock-fn.js";
 /** Mock for playwright.chromium.connectOverCDP. */
 export const connectOverCdpMock: MockFn = vi.fn();
 /** Mock for Chrome CDP WebSocket URL discovery. */
-export const getChromeWebSocketUrlMock: MockFn = vi.fn();
+export const getChromeWebSocketEndpointMock: MockFn = vi.fn();
 
 vi.mock("./playwright-core.runtime.js", () => ({
   playwrightCore: {
@@ -22,5 +22,5 @@ vi.mock("./playwright-core.runtime.js", () => ({
 }));
 
 vi.mock("./chrome.js", () => ({
-  getChromeWebSocketUrl: (...args: unknown[]) => getChromeWebSocketUrlMock(...args),
+  getChromeWebSocketEndpoint: (...args: unknown[]) => getChromeWebSocketEndpointMock(...args),
 }));

--- a/extensions/browser/src/browser/pw-session.termination-cdp-ssrf.test.ts
+++ b/extensions/browser/src/browser/pw-session.termination-cdp-ssrf.test.ts
@@ -116,8 +116,9 @@ describe("pw-session termination CDP SSRF guard", () => {
         ssrfPolicy: { dangerouslyAllowPrivateNetwork: false },
       });
 
-      expect(fetchSpy).toHaveBeenCalledTimes(1);
-      expect(fetchSpy.mock.calls[0]?.[0]).toBe("http://127.0.0.1:18792/json/list");
+      const fetchUrls = fetchSpy.mock.calls.map((call) => call[0]);
+      expect(fetchUrls).toContain("http://127.0.0.1:18792/json/list");
+      expect(fetchUrls).not.toContain("http://169.254.169.254/json/list");
       expect(wsMockState.constructorUrls).toEqual([]);
       expect(browserClose).toHaveBeenCalledTimes(1);
     } finally {

--- a/extensions/browser/src/browser/pw-session.termination-cdp-ssrf.test.ts
+++ b/extensions/browser/src/browser/pw-session.termination-cdp-ssrf.test.ts
@@ -45,7 +45,7 @@ vi.mock("ws", () => {
 });
 
 const connectOverCdpSpy = vi.spyOn(chromium, "connectOverCDP");
-const getChromeWebSocketUrlSpy = vi.spyOn(chromeModule, "getChromeWebSocketUrl");
+const getChromeWebSocketEndpointSpy = vi.spyOn(chromeModule, "getChromeWebSocketEndpoint");
 
 function installBrowserMock() {
   const sessionSend = vi.fn(async (method: string) => {
@@ -78,13 +78,13 @@ function installBrowserMock() {
   } as unknown as import("playwright-core").Browser;
 
   connectOverCdpSpy.mockResolvedValue(browser);
-  getChromeWebSocketUrlSpy.mockResolvedValue(null);
+  getChromeWebSocketEndpointSpy.mockResolvedValue(null);
   return { browserClose };
 }
 
 afterEach(async () => {
   connectOverCdpSpy.mockReset();
-  getChromeWebSocketUrlSpy.mockReset();
+  getChromeWebSocketEndpointSpy.mockReset();
   wsMockState.constructorUrls = [];
   await closePlaywrightBrowserConnection().catch(() => {});
 });

--- a/extensions/browser/src/browser/pw-session.ts
+++ b/extensions/browser/src/browser/pw-session.ts
@@ -155,7 +155,7 @@ type ConnectedBrowser = {
   onDisconnected?: () => void;
 };
 
-async function connectOverCdpPinnedTransport(
+export async function connectOverCdpPinnedTransport(
   connectionUrl: string,
   opts: {
     timeout: number;
@@ -174,12 +174,42 @@ async function connectOverCdpPinnedTransport(
       ws.once("error", reject);
       ws.once("close", () => reject(new Error("CDP socket closed")));
     });
+    let onMessage: ((message: object) => void) | undefined;
+    let onClose: ((reason?: string) => void) | undefined;
+    const pendingMessages: object[] = [];
+    let pendingCloseReason: string | undefined;
     const transport: ConnectOverCDPTransport = {
       send: (message) => {
         ws.send(JSON.stringify(message));
       },
       close: () => {
         ws.close();
+      },
+      get onmessage() {
+        return onMessage;
+      },
+      set onmessage(handler) {
+        onMessage = handler;
+        if (!handler) {
+          return;
+        }
+        while (pendingMessages.length > 0) {
+          const pending = pendingMessages.shift();
+          if (pending) {
+            handler(pending);
+          }
+        }
+      },
+      get onclose() {
+        return onClose;
+      },
+      set onclose(handler) {
+        onClose = handler;
+        if (handler && pendingCloseReason !== undefined) {
+          const reason = pendingCloseReason;
+          pendingCloseReason = undefined;
+          handler(reason);
+        }
       },
     };
     let transportClosed = false;
@@ -188,11 +218,20 @@ async function connectOverCdpPinnedTransport(
         return;
       }
       transportClosed = true;
-      transport.onclose?.(reason);
+      if (onClose) {
+        onClose(reason);
+        return;
+      }
+      pendingCloseReason = reason;
     };
     ws.on("message", (raw) => {
       try {
-        transport.onmessage?.(JSON.parse(rawDataToString(raw)) as object);
+        const parsed = JSON.parse(rawDataToString(raw)) as object;
+        if (onMessage) {
+          onMessage(parsed);
+          return;
+        }
+        pendingMessages.push(parsed);
       } catch {
         // Ignore malformed CDP frames; Playwright handles the eventual close.
       }

--- a/extensions/browser/src/browser/pw-session.ts
+++ b/extensions/browser/src/browser/pw-session.ts
@@ -14,6 +14,7 @@ import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runti
 import type {
   Browser,
   BrowserContext,
+  ConnectOverCDPTransport,
   ConsoleMessage,
   Dialog,
   Frame,
@@ -24,21 +25,24 @@ import type {
 } from "playwright-core";
 import { formatErrorMessage } from "../infra/errors.js";
 import { SsrFBlockedError, type SsrFPolicy } from "../infra/net/ssrf.js";
+import { rawDataToString } from "../infra/ws.js";
 import { withNoProxyForCdpUrl } from "./cdp-proxy-bypass.js";
 import {
   appendCdpPath,
   assertCdpEndpointAllowed,
   fetchJson,
   getHeadersWithAuth,
+  isLoopbackHost,
   isWebSocketUrl,
   normalizeCdpHttpBaseForJsonEndpoints,
+  openCdpWebSocket,
   redactCdpErrorText,
   scopeCdpPolicyToConfiguredEndpoint,
   stripCdpUrlCredentials,
   withCdpSocket,
 } from "./cdp.helpers.js";
 import { AX_REF_PATTERN, normalizeCdpWsUrl } from "./cdp.js";
-import { getChromeWebSocketUrl } from "./chrome.js";
+import { getChromeWebSocketEndpoint } from "./chrome.js";
 import type { BrowserDownloadCandidate, BrowserDownloadResult } from "./download-types.js";
 import { BrowserTabNotFoundError } from "./errors.js";
 import {
@@ -58,6 +62,7 @@ import {
 import { BROWSER_REF_MARKER_ATTRIBUTE } from "./pw-session.page-cdp.js";
 
 const { chromium } = playwrightCore;
+type CdpEndpointPin = NonNullable<Awaited<ReturnType<typeof assertCdpEndpointAllowed>>>;
 
 /** Console message captured from a Playwright page. */
 export type BrowserConsoleMessage = {
@@ -149,6 +154,53 @@ type ConnectedBrowser = {
   cdpUrl: string;
   onDisconnected?: () => void;
 };
+
+async function connectOverCdpPinnedTransport(
+  connectionUrl: string,
+  opts: {
+    timeout: number;
+    headers: Record<string, string>;
+    lookup: CdpEndpointPin["lookup"];
+  },
+): Promise<Browser> {
+  const ws = openCdpWebSocket(connectionUrl, {
+    headers: opts.headers,
+    handshakeTimeoutMs: opts.timeout,
+    lookup: opts.lookup,
+  });
+  try {
+    await new Promise<void>((resolve, reject) => {
+      ws.once("open", () => resolve());
+      ws.once("error", reject);
+      ws.once("close", () => reject(new Error("CDP socket closed")));
+    });
+    const transport: ConnectOverCDPTransport = {
+      send: (message) => {
+        ws.send(JSON.stringify(message));
+      },
+      close: () => {
+        ws.close();
+      },
+    };
+    ws.on("message", (raw) => {
+      try {
+        transport.onmessage?.(JSON.parse(rawDataToString(raw)) as object);
+      } catch {
+        // Ignore malformed CDP frames; Playwright handles the eventual close.
+      }
+    });
+    ws.on("close", () => {
+      transport.onclose?.("CDP socket closed");
+    });
+    ws.on("error", (error) => {
+      transport.onclose?.(formatErrorMessage(error));
+    });
+    return await chromium.connectOverCDP(transport, { timeout: opts.timeout });
+  } catch (error) {
+    ws.close();
+    throw error;
+  }
+}
 
 type DownloadPayload = PlaywrightDownload & {
   path?: () => Promise<string>;
@@ -1300,7 +1352,7 @@ async function connectBrowser(cdpUrl: string, ssrfPolicy?: SsrFPolicy): Promise<
   }
   // Run SSRF policy check only on cache miss so transient DNS failures
   // do not break active sessions that already hold a live CDP connection.
-  await assertCdpEndpointAllowed(normalized, ssrfPolicy);
+  const configuredPin = await assertCdpEndpointAllowed(normalized, ssrfPolicy);
   const connecting = connectingByCdpUrl.get(normalized);
   if (connecting) {
     return await connecting.promise;
@@ -1315,32 +1367,50 @@ async function connectBrowser(cdpUrl: string, ssrfPolicy?: SsrFPolicy): Promise<
       }
       try {
         const timeout = 5000 + attempt * 2000;
-        const wsUrl = await getChromeWebSocketUrl(normalized, timeout, ssrfPolicy).catch(
-          () => null,
-        );
+        const resolvedEndpoint = await getChromeWebSocketEndpoint(
+          normalized,
+          timeout,
+          ssrfPolicy,
+        ).catch(() => null);
         const hasUrlCredentials = stripCdpUrlCredentials(normalized) !== normalized;
-        if (!wsUrl && hasUrlCredentials && !isWebSocketUrl(normalized)) {
+        if (!resolvedEndpoint && hasUrlCredentials && !isWebSocketUrl(normalized)) {
           // Playwright preserves explicit headers across HTTP discovery redirects.
           // Keep credentialed discovery in OpenClaw's guarded fetch path instead.
           throw new Error("Authenticated CDP HTTP endpoint did not expose a usable WebSocket URL.");
         }
-        const endpoint = wsUrl ?? normalized;
-        const connectEndpoint = async (target: string) => {
+        const normalizedCdpHostname = new URL(normalized).hostname;
+        const needsPinnedDependencyConnect =
+          Boolean(configuredPin?.lookup) && !isLoopbackHost(normalizedCdpHostname);
+        if (!resolvedEndpoint && ssrfPolicy && needsPinnedDependencyConnect) {
+          throw new Error("Guarded CDP endpoint did not expose a usable WebSocket URL.");
+        }
+        const endpointUrl = resolvedEndpoint?.url ?? normalized;
+        const endpointLookup =
+          resolvedEndpoint?.lookup ??
+          (needsPinnedDependencyConnect ? configuredPin?.lookup : undefined);
+        const connectEndpoint = async (target: string, lookup?: CdpEndpointPin["lookup"]) => {
           const headers = getHeadersWithAuth(target);
           const connectionUrl = stripCdpUrlCredentials(target);
           // Bypass proxy for loopback CDP connections (#31219)
-          return await withNoProxyForCdpUrl(connectionUrl, () =>
-            chromium.connectOverCDP(connectionUrl, { timeout, headers }),
-          );
+          return await withNoProxyForCdpUrl(connectionUrl, async () => {
+            if (lookup) {
+              return await connectOverCdpPinnedTransport(connectionUrl, {
+                timeout,
+                headers,
+                lookup,
+              });
+            }
+            return await chromium.connectOverCDP(connectionUrl, { timeout, headers });
+          });
         };
         let browser: Browser;
         try {
-          browser = await connectEndpoint(endpoint);
+          browser = await connectEndpoint(endpointUrl, endpointLookup);
         } catch (err) {
-          if (!isWebSocketUrl(normalized) || endpoint === normalized) {
+          if (!isWebSocketUrl(normalized) || endpointUrl === normalized) {
             throw err;
           }
-          browser = await connectEndpoint(normalized);
+          browser = await connectEndpoint(normalized, configuredPin?.lookup);
         }
         if (connectionAttempt.cancelled) {
           connectionAttempt.retired = { browser, cdpUrl: normalized };
@@ -2083,7 +2153,7 @@ async function tryTerminateExecutionViaCdp(opts: {
     return;
   }
   const wsUrl = normalizeCdpWsUrl(wsUrlRaw, cdpHttpBase);
-  await assertCdpEndpointAllowed(wsUrl, cdpControlPolicy, {
+  const wsPin = await assertCdpEndpointAllowed(wsUrl, cdpControlPolicy, {
     source: "discovered",
     configuredUrl: opts.cdpUrl,
   });
@@ -2127,7 +2197,7 @@ async function tryTerminateExecutionViaCdp(opts: {
         // Best-effort; ignore
       }
     },
-    { handshakeTimeoutMs: 2000 },
+    { handshakeTimeoutMs: 2000, lookup: wsPin?.lookup },
   ).catch(() => {});
 }
 

--- a/extensions/browser/src/browser/pw-session.ts
+++ b/extensions/browser/src/browser/pw-session.ts
@@ -182,6 +182,14 @@ async function connectOverCdpPinnedTransport(
         ws.close();
       },
     };
+    let transportClosed = false;
+    const notifyTransportClosed = (reason: string) => {
+      if (transportClosed) {
+        return;
+      }
+      transportClosed = true;
+      transport.onclose?.(reason);
+    };
     ws.on("message", (raw) => {
       try {
         transport.onmessage?.(JSON.parse(rawDataToString(raw)) as object);
@@ -190,10 +198,10 @@ async function connectOverCdpPinnedTransport(
       }
     });
     ws.on("close", () => {
-      transport.onclose?.("CDP socket closed");
+      notifyTransportClosed("CDP socket closed");
     });
     ws.on("error", (error) => {
-      transport.onclose?.(formatErrorMessage(error));
+      notifyTransportClosed(formatErrorMessage(error));
     });
     return await chromium.connectOverCDP(transport, { timeout: opts.timeout });
   } catch (error) {

--- a/extensions/browser/src/browser/pw-session.ts
+++ b/extensions/browser/src/browser/pw-session.ts
@@ -155,7 +155,7 @@ type ConnectedBrowser = {
   onDisconnected?: () => void;
 };
 
-export async function connectOverCdpPinnedTransport(
+async function connectOverCdpPinnedTransport(
   connectionUrl: string,
   opts: {
     timeout: number;

--- a/extensions/browser/src/browser/pw-tools-core.waits-next-download-saves-it.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.waits-next-download-saves-it.test.ts
@@ -14,7 +14,9 @@ const tmpDirMocks = vi.hoisted(() => ({
   resolvePreferredOpenClawTmpDir: vi.fn(() => "/tmp/openclaw"),
 }));
 const chromeMocks = vi.hoisted(() => ({
-  getChromeWebSocketUrl: vi.fn(async () => "ws://127.0.0.1/devtools/browser/mock"),
+  getChromeWebSocketEndpoint: vi.fn(async () => ({
+    url: "ws://127.0.0.1/devtools/browser/mock",
+  })),
 }));
 const clientFetchMocks = vi.hoisted(() => ({
   resolveBrowserRateLimitMessage: vi.fn(() => undefined),

--- a/extensions/browser/src/browser/routes/permissions.test.ts
+++ b/extensions/browser/src/browser/routes/permissions.test.ts
@@ -4,7 +4,9 @@ import { BROWSER_ERROR_REASONS, BrowserProfileUnavailableError } from "../errors
 import { createBrowserRouteApp, createBrowserRouteResponse } from "./test-helpers.js";
 
 const cdpMocks = vi.hoisted(() => ({
-  getChromeWebSocketUrl: vi.fn(async () => "ws://127.0.0.1:18800/devtools/browser/test"),
+  getChromeWebSocketEndpoint: vi.fn(async () => ({
+    url: "ws://127.0.0.1:18800/devtools/browser/test",
+  })),
   send: vi.fn(
     async (
       _method: string,
@@ -32,7 +34,7 @@ const pwMocks = vi.hoisted(() => ({
 }));
 
 vi.mock("../chrome.js", () => ({
-  getChromeWebSocketUrl: cdpMocks.getChromeWebSocketUrl,
+  getChromeWebSocketEndpoint: cdpMocks.getChromeWebSocketEndpoint,
 }));
 
 vi.mock("../cdp.helpers.js", () => ({
@@ -107,7 +109,7 @@ async function callGrant(
 
 describe("browser permission routes", () => {
   beforeEach(() => {
-    cdpMocks.getChromeWebSocketUrl.mockClear();
+    cdpMocks.getChromeWebSocketEndpoint.mockClear();
     cdpMocks.send.mockReset().mockResolvedValue({});
     cdpMocks.withCdpSocket.mockClear();
     pwMocks.getPwAiModule.mockReset().mockResolvedValue(null);
@@ -163,7 +165,7 @@ describe("browser permission routes", () => {
       grantMethod: "cdp",
     });
     expect(profileCtx.ensureBrowserAvailable).toHaveBeenCalled();
-    expect(cdpMocks.getChromeWebSocketUrl).toHaveBeenCalledWith(
+    expect(cdpMocks.getChromeWebSocketEndpoint).toHaveBeenCalledWith(
       "http://127.0.0.1:18800",
       1234,
       undefined,
@@ -212,7 +214,7 @@ describe("browser permission routes", () => {
         displayPresent: false,
       },
     });
-    expect(cdpMocks.getChromeWebSocketUrl).not.toHaveBeenCalled();
+    expect(cdpMocks.getChromeWebSocketEndpoint).not.toHaveBeenCalled();
   });
 
   it("rejects loose timeoutMs values before granting permissions", async () => {
@@ -225,7 +227,7 @@ describe("browser permission routes", () => {
     expect(response.statusCode).toBe(400);
     expect(response.body).toStrictEqual({ error: "timeoutMs must be a positive integer." });
     expect(profileCtx.ensureBrowserAvailable).not.toHaveBeenCalled();
-    expect(cdpMocks.getChromeWebSocketUrl).not.toHaveBeenCalled();
+    expect(cdpMocks.getChromeWebSocketEndpoint).not.toHaveBeenCalled();
     expect(cdpMocks.send).not.toHaveBeenCalled();
   });
 
@@ -237,7 +239,7 @@ describe("browser permission routes", () => {
     });
 
     expect(response.statusCode).toBe(200);
-    expect(cdpMocks.getChromeWebSocketUrl).toHaveBeenCalledWith(
+    expect(cdpMocks.getChromeWebSocketEndpoint).toHaveBeenCalledWith(
       "http://127.0.0.1:18800",
       1000,
       undefined,
@@ -265,7 +267,7 @@ describe("browser permission routes", () => {
     );
 
     expect(response.statusCode).toBe(200);
-    expect(cdpMocks.getChromeWebSocketUrl).toHaveBeenCalledWith(
+    expect(cdpMocks.getChromeWebSocketEndpoint).toHaveBeenCalledWith(
       "https://browser.example:9222",
       5000,
       {

--- a/extensions/browser/src/browser/routes/permissions.ts
+++ b/extensions/browser/src/browser/routes/permissions.ts
@@ -9,7 +9,7 @@ import { formatErrorMessage } from "../../infra/errors.js";
 import type { SsrFPolicy } from "../../infra/net/ssrf.js";
 import { resolveCdpControlPolicy } from "../cdp-reachability-policy.js";
 import { withCdpSocket } from "../cdp.helpers.js";
-import { getChromeWebSocketUrl } from "../chrome.js";
+import { getChromeWebSocketEndpoint, type ChromeWebSocketEndpoint } from "../chrome.js";
 import { BrowserProfileUnavailableError, toBrowserErrorResponse } from "../errors.js";
 import { getPwAiModule } from "../pw-ai-module.js";
 import type { BrowserRouteContext } from "../server-context.js";
@@ -55,6 +55,7 @@ async function grantPermissions(params: {
   requiredPermissions: string[];
   optionalPermissions: string[];
   timeoutMs: number;
+  wsLookup?: ChromeWebSocketEndpoint["lookup"];
   ssrfPolicy?: SsrFPolicy;
   signal: AbortSignal;
 }) {
@@ -112,7 +113,7 @@ async function grantPermissions(params: {
       });
       unsupportedPermissions = params.optionalPermissions;
     },
-    { commandTimeoutMs: params.timeoutMs },
+    { commandTimeoutMs: params.timeoutMs, lookup: params.wsLookup },
   );
   params.signal.throwIfAborted();
   return {
@@ -172,19 +173,20 @@ export function registerBrowserPermissionRoutes(
             profileCtx.profile,
             ctx.state().resolved.ssrfPolicy,
           );
-          const wsUrl = await getChromeWebSocketUrl(
+          const endpoint = await getChromeWebSocketEndpoint(
             profileCtx.profile.cdpUrl,
             timeoutMs,
             cdpPolicy,
           );
           signal.throwIfAborted();
-          if (!wsUrl) {
+          if (!endpoint) {
             throw new BrowserProfileUnavailableError("browser CDP WebSocket unavailable");
           }
           return await grantPermissions({
             profileCtx,
             targetId,
-            wsUrl,
+            wsUrl: endpoint.url,
+            wsLookup: endpoint.lookup,
             origin,
             requiredPermissions,
             optionalPermissions,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Browser plugin users with strict CDP endpoint controls could validate one hostname result but open the guarded CDP WebSocket with a later hostname resolution.

## Why This Change Was Made

The Browser CDP endpoint check now returns the validated hostname pin, and guarded WebSocket connections reuse that lookup when creating targets, observing committed navigation, or closing tracked CDP targets. The change stays inside the Browser plugin CDP path and does not add configuration, storage, provider, or channel behavior.

## User Impact

Strict CDP endpoint controls now keep the WebSocket connection on the same resolved endpoint that passed validation. Normal loopback, discovered, credentialed, and direct WebSocket CDP flows continue to work.

## Evidence

- `node scripts/run-vitest.mjs extensions/browser/src/browser/cdp.helpers.internal.test.ts extensions/browser/src/browser/cdp.test.ts` passed: 2 files, 80 tests.
- `git diff --check` passed.

AI-assisted: yes.
