### PR TITLE
refactor(media): ingress and preflight consumers ride ordered media facts

### DIFF
--- a/extensions/discord/src/monitor/message-handler.preflight.test.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.test.ts
@@ -559,12 +559,14 @@ describe("preflightDiscordMessage", () => {
 
     expect(transcribeFirstAudioMock).toHaveBeenCalledTimes(1);
     const dmAudioCall = firstMockArg(transcribeFirstAudioMock, "transcribeFirstAudio") as
-      | { ctx?: { MediaUrls?: unknown; MediaTypes?: unknown } }
+      | { ctx?: { media?: unknown } }
       | undefined;
-    expect(dmAudioCall?.ctx?.MediaUrls).toEqual([
-      "https://cdn.discordapp.com/attachments/voice.ogg",
+    expect(dmAudioCall?.ctx?.media).toEqual([
+      {
+        url: "https://cdn.discordapp.com/attachments/voice.ogg",
+        contentType: "audio/ogg",
+      },
     ]);
-    expect(dmAudioCall?.ctx?.MediaTypes).toEqual(["audio/ogg"]);
     const preflight = expectPreflightResult(result);
     expect(preflight.isDirectMessage).toBe(true);
     expect(preflight.preflightAudioTranscript).toBe("hello openclaw from dm audio");
@@ -2120,12 +2122,14 @@ describe("preflightDiscordMessage", () => {
 
     expect(transcribeFirstAudioMock).toHaveBeenCalledTimes(1);
     const guildAudioCall = firstMockArg(transcribeFirstAudioMock, "transcribeFirstAudio") as
-      | { ctx?: { MediaUrls?: unknown; MediaTypes?: unknown } }
+      | { ctx?: { media?: unknown } }
       | undefined;
-    expect(guildAudioCall?.ctx?.MediaUrls).toEqual([
-      "https://cdn.discordapp.com/attachments/voice.ogg",
+    expect(guildAudioCall?.ctx?.media).toEqual([
+      {
+        url: "https://cdn.discordapp.com/attachments/voice.ogg",
+        contentType: "audio/ogg",
+      },
     ]);
-    expect(guildAudioCall?.ctx?.MediaTypes).toEqual(["audio/ogg"]);
     const preflight = expectPreflightResult(result);
     expect(preflight.wasMentioned).toBe(true);
     expect(preflight.preflightAudioTranscript).toBe("hey openclaw");

--- a/extensions/discord/src/monitor/preflight-audio.test.ts
+++ b/extensions/discord/src/monitor/preflight-audio.test.ts
@@ -37,8 +37,12 @@ describe("resolveDiscordPreflightAudioMentionContext", () => {
 
     expect(transcribeFirstAudioMock).toHaveBeenCalledWith({
       ctx: {
-        MediaUrls: ["https://cdn.discordapp.com/attachments/voice.ogg"],
-        MediaTypes: ["audio/ogg"],
+        media: [
+          {
+            url: "https://cdn.discordapp.com/attachments/voice.ogg",
+            contentType: "audio/ogg",
+          },
+        ],
       },
       cfg,
       agentDir: undefined,
@@ -70,8 +74,12 @@ describe("resolveDiscordPreflightAudioMentionContext", () => {
 
     expect(transcribeFirstAudioMock).toHaveBeenCalledWith({
       ctx: {
-        MediaUrls: ["https://cdn.discordapp.com/attachments/voice.opus"],
-        MediaTypes: ["audio/opus"],
+        media: [
+          {
+            url: "https://cdn.discordapp.com/attachments/voice.opus",
+            contentType: "audio/opus",
+          },
+        ],
       },
       cfg,
       agentDir: undefined,
@@ -100,8 +108,12 @@ describe("resolveDiscordPreflightAudioMentionContext", () => {
 
     expect(transcribeFirstAudioMock).toHaveBeenCalledWith({
       ctx: {
-        MediaUrls: ["https://cdn.discordapp.com/attachments/voice"],
-        MediaTypes: ["audio/ogg"],
+        media: [
+          {
+            url: "https://cdn.discordapp.com/attachments/voice",
+            contentType: "audio/ogg",
+          },
+        ],
       },
       cfg,
       agentDir: undefined,

--- a/extensions/discord/src/monitor/preflight-audio.ts
+++ b/extensions/discord/src/monitor/preflight-audio.ts
@@ -95,17 +95,14 @@ export async function resolveDiscordPreflightAudioMentionContext(params: {
           hasTypedText,
         };
       }
-      const audioUrls = audioAttachments
-        .map((att) => att.url)
-        .map((url) => normalizeOptionalString(url))
-        .filter((url): url is string => Boolean(url));
-      if (audioUrls.length > 0) {
+      const media = audioAttachments.flatMap((attachment) => {
+        const url = normalizeOptionalString(attachment.url);
+        return url ? [{ url, contentType: inferAudioAttachmentMime(attachment) }] : [];
+      });
+      if (media.length > 0) {
         transcript = await transcribeFirstAudio({
           ctx: {
-            MediaUrls: audioUrls,
-            MediaTypes: audioAttachments
-              .map((att) => inferAudioAttachmentMime(att))
-              .filter((contentType): contentType is string => Boolean(contentType)),
+            media,
           },
           cfg: params.cfg,
           agentDir: undefined,

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -2885,10 +2885,14 @@ describe("handleFeishuMessage command authorization", () => {
     expect(downloadRequest.type).toBe("file");
     const transcribeRequest = mockCallArg<{
       cfg?: { channels?: { feishu?: { dmPolicy?: string } } };
-      ctx?: { ChatType?: string; MediaPaths?: string[]; MediaTypes?: string[] };
+      ctx?: {
+        ChatType?: string;
+        media?: Array<{ path?: string; contentType?: string; kind?: string }>;
+      };
     }>(mockTranscribeFirstAudio, 0, 0);
-    expect(transcribeRequest.ctx?.MediaPaths).toEqual(["/tmp/inbound-voice.ogg"]);
-    expect(transcribeRequest.ctx?.MediaTypes).toEqual(["audio/ogg"]);
+    expect(transcribeRequest.ctx?.media).toEqual([
+      { path: "/tmp/inbound-voice.ogg", contentType: "audio/ogg", kind: "audio" },
+    ]);
     expect(transcribeRequest.ctx?.ChatType).toBe("direct");
     expect(transcribeRequest.cfg?.channels?.feishu?.dmPolicy).toBe("open");
     const finalized = mockCallArg<{

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -151,8 +151,7 @@ async function resolveFeishuAudioPreflightTranscript(params: {
     const { transcribeFirstAudio } = await import("./audio-preflight.runtime.js");
     return await transcribeFirstAudio({
       ctx: {
-        MediaPaths: audioMedia.map((media) => media.path).filter(Boolean) as string[],
-        MediaTypes: audioMedia.map((media) => media.contentType).filter(Boolean) as string[],
+        media: audioMedia,
         ChatType: params.chatType,
       },
       cfg: params.cfg,

--- a/extensions/matrix/src/matrix/monitor/handler.audio-preflight.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.audio-preflight.test.ts
@@ -107,8 +107,7 @@ describe("createMatrixRoomMessageHandler audio preflight", () => {
     expect(transcribeFirstAudioMock).toHaveBeenCalledWith(
       expect.objectContaining({
         ctx: expect.objectContaining({
-          MediaPaths: ["/tmp/inbound/voice.ogg"],
-          MediaTypes: ["audio/ogg"],
+          media: [{ path: "/tmp/inbound/voice.ogg", contentType: "audio/ogg" }],
           Provider: "matrix",
           Surface: "matrix",
           OriginatingChannel: "matrix",

--- a/extensions/matrix/src/matrix/monitor/preflight-audio.test.ts
+++ b/extensions/matrix/src/matrix/monitor/preflight-audio.test.ts
@@ -64,8 +64,7 @@ describe("resolveMatrixPreflightAudioTranscript", () => {
     expect(transcribeFirstAudioMock).toHaveBeenCalledWith(
       expect.objectContaining({
         ctx: expect.objectContaining({
-          MediaPaths: ["/tmp/inbound/voice.ogg"],
-          MediaTypes: ["audio/ogg"],
+          media: [{ path: "/tmp/inbound/voice.ogg", contentType: "audio/ogg" }],
           Provider: "matrix",
           Surface: "matrix",
           OriginatingChannel: "matrix",

--- a/extensions/matrix/src/matrix/monitor/preflight-audio.ts
+++ b/extensions/matrix/src/matrix/monitor/preflight-audio.ts
@@ -68,8 +68,7 @@ export async function resolveMatrixPreflightAudioTranscript(params: {
     }
     const transcript = await transcribeFirstAudio({
       ctx: {
-        MediaPaths: [params.mediaPath],
-        MediaTypes: params.mediaContentType ? [params.mediaContentType] : undefined,
+        media: [{ path: params.mediaPath, contentType: params.mediaContentType }],
         Provider: "matrix",
         Surface: "matrix",
         OriginatingChannel: "matrix",

--- a/extensions/slack/src/monitor/message-handler/preflight-audio.test.ts
+++ b/extensions/slack/src/monitor/message-handler/preflight-audio.test.ts
@@ -113,8 +113,7 @@ describe("Slack captionless audio preflight", () => {
     expect(transcribeFirstAudioMock).toHaveBeenCalledTimes(1);
     expect(transcribeFirstAudioMock).toHaveBeenCalledWith({
       ctx: expect.objectContaining({
-        MediaPaths: ["/tmp/image.png", "/tmp/voice.mp4"],
-        MediaTypes: ["image/png", "audio/mp4"],
+        media,
         OriginatingChannel: "slack",
         OriginatingTo: "channel:C1",
         AccountId: "work",

--- a/extensions/slack/src/monitor/message-handler/preflight-audio.ts
+++ b/extensions/slack/src/monitor/message-handler/preflight-audio.ts
@@ -77,8 +77,7 @@ export async function resolveSlackPreflightAudioTranscript(params: {
     const { transcribeFirstAudio } = await loadSlackPreflightAudioRuntime();
     const transcript = await transcribeFirstAudio({
       ctx: {
-        MediaPaths: params.media.map((entry) => entry.path),
-        MediaTypes: params.media.map((entry) => entry.contentType ?? ""),
+        media: [...params.media],
         Provider: "slack",
         Surface: "slack",
         OriginatingChannel: "slack",

--- a/extensions/whatsapp/src/auto-reply/monitor/on-message.audio-preflight.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/on-message.audio-preflight.test.ts
@@ -465,8 +465,13 @@ describe("createWebOnMessageHandler audio preflight", () => {
     await handler(makeAudioMsg());
 
     expect(capturedCtx).toEqual({
-      MediaPaths: ["/tmp/voice.ogg"],
-      MediaTypes: ["audio/ogg; codecs=opus"],
+      media: [
+        {
+          path: "/tmp/voice.ogg",
+          contentType: "audio/ogg; codecs=opus",
+          kind: "audio",
+        },
+      ],
       From: "+15550000002",
       To: "+15550000001",
       Provider: "whatsapp",

--- a/extensions/whatsapp/src/auto-reply/monitor/on-message.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/on-message.ts
@@ -249,8 +249,13 @@ export function createWebOnMessageHandler(params: {
         preflightAudioTranscript =
           (await transcribeFirstAudio({
             ctx: {
-              MediaPaths: [msg.payload.media?.path],
-              MediaTypes: msg.payload.media?.type ? [msg.payload.media?.type] : undefined,
+              media: [
+                {
+                  path: msg.payload.media.path,
+                  contentType: msg.payload.media.type,
+                  kind: msg.payload.media.kind ?? undefined,
+                },
+              ],
               From: conversationId,
               To: msg.platform.recipientJid,
               Provider: "whatsapp",

--- a/extensions/whatsapp/src/auto-reply/monitor/process-message.audio-preflight.test.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/process-message.audio-preflight.test.ts
@@ -271,8 +271,13 @@ describe("processMessage audio preflight transcription", () => {
     expectContextFields(firstTranscriptionContext(), {
       AccountId: "default",
       From: "+15550000002",
-      MediaPaths: ["/tmp/voice.ogg"],
-      MediaTypes: ["audio/ogg; codecs=opus"],
+      media: [
+        {
+          path: "/tmp/voice.ogg",
+          contentType: "audio/ogg; codecs=opus",
+          kind: "audio",
+        },
+      ],
       OriginatingChannel: "whatsapp",
       OriginatingTo: "+15550000002",
       Provider: "whatsapp",

--- a/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/process-message.ts
@@ -266,8 +266,13 @@ export async function processMessage(params: {
       const { transcribeFirstAudio } = await import("./audio-preflight.runtime.js");
       audioTranscript = await transcribeFirstAudio({
         ctx: {
-          MediaPaths: [params.msg.payload.media?.path],
-          MediaTypes: params.msg.payload.media?.type ? [params.msg.payload.media?.type] : undefined,
+          media: [
+            {
+              path: params.msg.payload.media.path,
+              contentType: params.msg.payload.media.type,
+              kind: params.msg.payload.media.kind ?? undefined,
+            },
+          ],
           From: conversationId,
           To: params.msg.platform.recipientJid,
           Provider: "whatsapp",

--- a/src/auto-reply/reply/current-turn-images.test.ts
+++ b/src/auto-reply/reply/current-turn-images.test.ts
@@ -40,10 +40,7 @@ describe("resolveCurrentTurnImages", () => {
       const result = await resolveCurrentTurnImages({
         ctx: {
           Body: "caption",
-          MediaPath: relativePath,
-          MediaPaths: [relativePath],
-          MediaType: "image/jpeg",
-          MediaTypes: ["image/jpeg"],
+          media: [{ path: relativePath, contentType: "image/jpeg" }],
         } satisfies MsgContext,
         cfg: {} as OpenClawConfig,
       });

--- a/src/auto-reply/reply/current-turn-images.ts
+++ b/src/auto-reply/reply/current-turn-images.ts
@@ -5,6 +5,7 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { logVerbose } from "../../globals.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import type { ImageContent } from "../../llm/types.js";
+import { normalizeAttachments } from "../../media-understanding/attachments.normalize.js";
 import {
   stripExtractedFileImageMetadata,
   type ExtractedFileImage,
@@ -52,29 +53,14 @@ function resolveCurrentImageMediaType(pathValue: unknown, mediaType?: unknown): 
 }
 
 function collectCurrentImageAttachments(ctx: MsgContext): CurrentImageAttachment[] {
-  const pathsFromArray = Array.isArray(ctx.MediaPaths) ? ctx.MediaPaths : undefined;
-  const paths =
-    pathsFromArray && pathsFromArray.length > 0
-      ? pathsFromArray
-      : normalizeOptionalString(ctx.MediaPath)
-        ? [ctx.MediaPath]
-        : [];
-  if (paths.length === 0) {
-    return [];
-  }
-  const types =
-    Array.isArray(ctx.MediaTypes) && ctx.MediaTypes.length === paths.length
-      ? ctx.MediaTypes
-      : undefined;
-  const attachments: CurrentImageAttachment[] = [];
-  for (const [index, pathValue] of paths.entries()) {
-    const mediaPath = normalizeOptionalString(pathValue);
-    const mediaType = resolveCurrentImageMediaType(pathValue, types?.[index] ?? ctx.MediaType);
+  return normalizeAttachments(ctx).flatMap((attachment) => {
+    const mediaPath = normalizeOptionalString(attachment.path);
+    const mediaType = resolveCurrentImageMediaType(attachment.path, attachment.mime);
     if (mediaPath && mediaType) {
-      attachments.push({ index, path: mediaPath, mediaType });
+      return [{ index: attachment.index, path: mediaPath, mediaType }];
     }
-  }
-  return attachments;
+    return [];
+  });
 }
 
 function collectDescribedImageAttachmentIndexes(ctx: MsgContext): Set<number> {
@@ -92,9 +78,15 @@ function createUndescribedImageContext(
   const first = undescribedAttachments[0];
   return {
     ...ctx,
+    media: undescribedAttachments.map((attachment) => ({
+      path: attachment.path,
+      contentType: attachment.mediaType,
+    })),
     MediaPath: first?.path,
+    MediaUrl: first?.path,
     MediaType: first?.mediaType,
     MediaPaths: undescribedAttachments.map((attachment) => attachment.path),
+    MediaUrls: undescribedAttachments.map((attachment) => attachment.path),
     MediaTypes: undescribedAttachments.map((attachment) => attachment.mediaType),
   };
 }

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -597,6 +597,7 @@ async function dispatchReplyFromConfigInner(
     delete messageReceivedCtx.MediaUrls;
     delete messageReceivedCtx.MediaType;
     delete messageReceivedCtx.MediaTypes;
+    delete messageReceivedCtx.media;
     return {
       ...buildHookState(messageReceivedCtx).hookContext,
       mediaRemoteHost,

--- a/src/auto-reply/reply/inbound-context.ts
+++ b/src/auto-reply/reply/inbound-context.ts
@@ -2,6 +2,7 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { normalizeChatType } from "../../channels/chat-type.js";
 import { resolveConversationLabel } from "../../channels/conversation-label.js";
+import { resolveMediaFacts } from "../../media/media-facts.js";
 import { resolveCommandTurnContext } from "../command-turn-context.js";
 import type { FinalizedMsgContext, MsgContext } from "../templating.js";
 import { normalizeInboundTextNewlines, sanitizeInboundSystemTags } from "./inbound-text.js";
@@ -170,6 +171,11 @@ export function finalizeInboundContext<T extends Record<string, unknown>>(
 
     normalized.MediaTypes = mediaTypesFinal;
     normalized.MediaType = mediaType ?? mediaTypesFinal[0] ?? DEFAULT_MEDIA_TYPE;
+  }
+
+  const media = resolveMediaFacts(normalized);
+  if (media.length > 0) {
+    normalized.media = media;
   }
 
   return normalized as T & FinalizedMsgContext;

--- a/src/auto-reply/reply/inbound-media.test.ts
+++ b/src/auto-reply/reply/inbound-media.test.ts
@@ -1,13 +1,32 @@
 import { describe, expect, it } from "vitest";
-import { hasInboundAudio, hasInboundMedia } from "./inbound-media.js";
+import {
+  hasInboundAudio,
+  hasInboundMedia,
+  hasInboundMediaForUnderstanding,
+} from "./inbound-media.js";
 
 describe("hasInboundMedia", () => {
+  it("detects retained type-only media facts", () => {
+    expect(hasInboundMedia({ media: [{ kind: "sticker" }] })).toBe(true);
+  });
+
   it("detects aligned type-only facts without a placeholder body", () => {
     expect(hasInboundMedia({ Body: "", MediaTypes: ["sticker", "image"] })).toBe(true);
+  });
+
+  it("ignores alignment-only blank projection slots", () => {
+    expect(hasInboundMedia({ MediaPaths: [""] })).toBe(false);
+    expect(hasInboundMedia({ MediaPath: "   " })).toBe(false);
+    expect(hasInboundMedia({ MediaPaths: ["", "/tmp/real.png"] })).toBe(true);
   });
 });
 
 describe("hasInboundAudio", () => {
+  it("detects native audio facts without legacy projections", () => {
+    expect(hasInboundAudio({ media: [{ kind: "audio" }] })).toBe(true);
+    expect(hasInboundAudio({ media: [{ contentType: "audio/ogg; codecs=opus" }] })).toBe(true);
+  });
+
   it("detects audio from the singular structured media type without a placeholder body", () => {
     expect(hasInboundAudio({ MediaType: " Audio/Ogg ; codecs=opus " })).toBe(true);
   });
@@ -31,5 +50,16 @@ describe("hasInboundAudio", () => {
 
   it("does not treat non-audio media as audio", () => {
     expect(hasInboundAudio({ MediaType: "image/png", MediaTypes: ["video/mp4"] })).toBe(false);
+  });
+
+  it("keeps longer legacy URL/type arrays visible to understanding and audio gates", () => {
+    const context = {
+      SkipStickerMediaUnderstanding: true,
+      MediaPaths: ["/tmp/photo.jpg"],
+      MediaUrls: ["/tmp/photo.jpg", "https://example.test/voice.ogg"],
+      MediaTypes: ["image/jpeg", "audio/ogg"],
+    };
+    expect(hasInboundMediaForUnderstanding(context)).toBe(true);
+    expect(hasInboundAudio(context)).toBe(true);
   });
 });

--- a/src/auto-reply/reply/inbound-media.ts
+++ b/src/auto-reply/reply/inbound-media.ts
@@ -1,34 +1,23 @@
 /** Detects inbound media and audio facts in channel message context. */
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { resolveMediaFacts, resolveMeaningfulMediaFacts } from "../../media/media-facts.js";
+import type { MsgContext } from "../templating.js";
 
 /** Minimal inbound media fields used by media/audio detection. */
-type InboundMediaContext = {
+type InboundMediaContext = Pick<
+  MsgContext,
+  "MediaPath" | "MediaPaths" | "MediaType" | "MediaTypes" | "MediaUrl" | "MediaUrls" | "media"
+> & {
   Body?: unknown;
-  MediaType?: unknown;
   StickerMediaIncluded?: unknown;
   SkipStickerMediaUnderstanding?: unknown;
   Sticker?: unknown;
-  MediaPath?: unknown;
-  MediaUrl?: unknown;
-  MediaPaths?: readonly unknown[];
-  MediaUrls?: readonly unknown[];
-  MediaTypes?: readonly unknown[];
 };
-
-function hasNormalizedStringEntry(values: readonly unknown[] | undefined): boolean {
-  return Array.isArray(values) && values.some((value) => normalizeOptionalString(value));
-}
 
 /** Returns true when the context carries current-turn media or sticker data. */
 export function hasInboundMedia(ctx: InboundMediaContext): boolean {
   return Boolean(
-    ctx.StickerMediaIncluded ||
-    ctx.Sticker ||
-    normalizeOptionalString(ctx.MediaPath) ||
-    normalizeOptionalString(ctx.MediaUrl) ||
-    hasNormalizedStringEntry(ctx.MediaPaths) ||
-    hasNormalizedStringEntry(ctx.MediaUrls) ||
-    (Array.isArray(ctx.MediaTypes) && ctx.MediaTypes.length > 0),
+    ctx.StickerMediaIncluded || ctx.Sticker || resolveMeaningfulMediaFacts(ctx).length > 0,
   );
 }
 
@@ -37,9 +26,7 @@ export function hasInboundMediaForUnderstanding(ctx: InboundMediaContext): boole
   if (!ctx.SkipStickerMediaUnderstanding) {
     return hasInboundMedia(ctx);
   }
-  return [ctx.MediaPaths, ctx.MediaUrls, ctx.MediaTypes].some(
-    (values) => Array.isArray(values) && values.length > 1,
-  );
+  return resolveMeaningfulMediaFacts(ctx).length > 1;
 }
 
 function normalizeMediaType(value: unknown): string | undefined {
@@ -49,11 +36,12 @@ function normalizeMediaType(value: unknown): string | undefined {
 
 /** Returns true when the current turn carries structured audio media facts. */
 export function hasInboundAudio(ctx: InboundMediaContext): boolean {
-  const mediaTypes = [
-    normalizeMediaType(ctx.MediaType),
-    ...(Array.isArray(ctx.MediaTypes)
-      ? ctx.MediaTypes.map((type) => normalizeMediaType(type))
-      : []),
-  ].filter((type): type is string => Boolean(type));
-  return mediaTypes.some((type) => type === "audio" || type.startsWith("audio/"));
+  const isAudio = (type: string | undefined) =>
+    type === "audio" || type?.startsWith("audio/") === true;
+  return (
+    isAudio(normalizeMediaType(ctx.MediaType)) ||
+    resolveMediaFacts(ctx).some(
+      (media) => media.kind === "audio" || isAudio(normalizeMediaType(media.contentType)),
+    )
+  );
 }

--- a/src/auto-reply/reply/inbound-meta.test.ts
+++ b/src/auto-reply/reply/inbound-meta.test.ts
@@ -524,7 +524,10 @@ describe("buildInboundUserContextPrefix", () => {
     const text = buildInboundUserContextPrefix({
       ChatType: "direct",
       OriginatingChannel: "discord",
-      MediaTypes: ["application/pdf", "image/png"],
+      media: [
+        { path: "/tmp/report.pdf", contentType: "application/pdf" },
+        { path: "/tmp/photo.png", contentType: "image/png" },
+      ],
     } as TemplateContext);
 
     expect(parseConversationInfoPayload(text)["source_modality"]).toBe("document");

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -541,7 +541,11 @@ function resolveInboundSourceModality(ctx: TemplateContext): string | undefined 
     }
     return INBOUND_SOURCE_MODALITIES.has(mediaKind) ? mediaKind : undefined;
   };
-  return resolveMediaType(ctx.MediaType) ?? ctx.MediaTypes?.map(resolveMediaType).find(Boolean);
+  return (
+    ctx.media?.map((media) => resolveMediaType(media.contentType ?? media.kind)).find(Boolean) ??
+    resolveMediaType(ctx.MediaType) ??
+    ctx.MediaTypes?.map(resolveMediaType).find(Boolean)
+  );
 }
 
 function resolveInboundFormattingHints(

--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -5,6 +5,7 @@ import type {
   MediaUnderstandingDecision,
   MediaUnderstandingOutput,
 } from "../media-understanding/types.js";
+import type { MediaFact } from "../media/media-facts.js";
 import type { PluginHookChannelContext } from "../plugins/hook-channel-context.types.js";
 import type { InputProvenance } from "../sessions/input-provenance.js";
 import type { CommandTurnContext } from "./command-turn-context.js";
@@ -206,6 +207,8 @@ export type MsgContext = {
   MediaPaths?: string[];
   MediaUrls?: string[];
   MediaTypes?: string[];
+  /** Ordered current-turn media facts; array position is attachment identity. */
+  media?: MediaFact[];
   /** Original message modality before transcription or other media normalization. */
   SourceModality?: InboundSourceModality;
   MediaWorkspaceDir?: string;

--- a/src/channels/inbound-event/context.test.ts
+++ b/src/channels/inbound-event/context.test.ts
@@ -224,6 +224,20 @@ describe("buildChannelInboundEventContext", () => {
       MediaUrls: ["/tmp/image.png", "https://example.test/audio.mp3"],
       MediaTypes: ["image/png", "audio/mpeg"],
       MediaTranscribedIndexes: [1],
+      media: [
+        expect.objectContaining({
+          path: "/tmp/image.png",
+          contentType: "image/png",
+          kind: "image",
+          transcribed: false,
+        }),
+        expect.objectContaining({
+          url: "https://example.test/audio.mp3",
+          contentType: "audio/mpeg",
+          kind: "audio",
+          transcribed: true,
+        }),
+      ],
       ChatType: "group",
       ChatId: "room-1",
       ConversationLabel: "Room One",
@@ -628,6 +642,9 @@ describe("finalizeChannelInboundContext", () => {
     expect(result.context.ReplyToSender).toBe("Alice");
     expect(result.context.MediaPath).toBe("/tmp/a.png");
     expect(result.context.MediaType).toBe("image/png");
+    expect(result.context.media).toEqual([
+      expect.objectContaining({ path: "/tmp/a.png", contentType: "image/png" }),
+    ]);
     expect(Object.hasOwn(result.context, "SupplementalContext")).toBe(false);
   });
 });

--- a/src/channels/inbound-event/context.ts
+++ b/src/channels/inbound-event/context.ts
@@ -354,6 +354,7 @@ function finalizePreparedChannelInboundContext<T extends Record<string, unknown>
   const baseContext = {
     ...params.originalContext,
     SupplementalContext: params.supplemental,
+    ...(params.media ? { media: [...params.media] } : {}),
     ...mediaPayload,
   };
   const untrustedStructuredContext = resolveUntrustedStructuredContext({

--- a/src/channels/inbound-event/media.test.ts
+++ b/src/channels/inbound-event/media.test.ts
@@ -1,7 +1,16 @@
 // Inbound event media tests cover channel media attachment normalization.
+import { kindFromMime } from "@openclaw/media-core/mime";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { describe, expect, it } from "vitest";
 import { normalizeAttachments } from "../../media-understanding/attachments.normalize.js";
-import { normalizeMediaFacts, projectMediaFacts } from "../../media/media-facts.js";
+import {
+  hasStagedMediaProjection,
+  normalizeMediaFacts,
+  projectMediaFacts,
+  resolveMediaFacts,
+  type MediaFactInput,
+  type MediaFactLegacyProjection,
+} from "../../media/media-facts.js";
 import { buildAgentMediaPayload } from "../../plugin-sdk/agent-media-payload.js";
 import { buildMediaPayload } from "../plugins/media-payload.js";
 import {
@@ -12,6 +21,108 @@ import {
   toInboundMediaFacts,
   type ChannelInboundMediaInput,
 } from "./media.js";
+
+type MergeMatrixSource = MediaFactLegacyProjection & {
+  media?: readonly MediaFactInput[];
+  MediaStaged?: boolean;
+  MediaWorkspaceDir?: string;
+};
+
+const canonicalModes = ["none", "partial", "full"] as const;
+const legacyModes = [
+  "none",
+  "aligned",
+  "mismatched-cardinality",
+  "staged-MediaStaged",
+  "staged-MediaWorkspaceDir",
+  "scalar-only",
+] as const;
+const typeModes = ["present", "absent", "conflicting"] as const;
+
+function buildCanonicalMedia(
+  mode: (typeof canonicalModes)[number],
+  typeMode: (typeof typeModes)[number],
+): MediaFactInput[] {
+  if (mode === "none") {
+    return [];
+  }
+  if (mode === "partial") {
+    return [{ path: "/canonical/voice.ogg" }];
+  }
+  const typeFields =
+    typeMode === "present"
+      ? [{ contentType: "audio/ogg" }, { contentType: "image/jpeg" }]
+      : typeMode === "conflicting"
+        ? [
+            { contentType: "audio/ogg", kind: "video" as const },
+            { contentType: "image/jpeg", kind: "document" as const },
+          ]
+        : [{}, {}];
+  return [
+    {
+      path: "/canonical/voice.ogg",
+      url: "https://canonical.test/voice.ogg",
+      ...typeFields[0],
+    },
+    {
+      path: "/canonical/photo.jpg",
+      url: "https://canonical.test/photo.jpg",
+      ...typeFields[1],
+    },
+  ];
+}
+
+function buildLegacyMedia(
+  mode: (typeof legacyModes)[number],
+  typeMode: (typeof typeModes)[number],
+): MergeMatrixSource {
+  const base: MergeMatrixSource =
+    mode === "none"
+      ? {}
+      : mode === "scalar-only"
+        ? {
+            MediaPath: "/legacy/scalar.ogg",
+            MediaUrl: "/legacy/scalar.ogg",
+          }
+        : {
+            MediaPaths:
+              mode === "mismatched-cardinality" ? ["/legacy/voice.ogg"] : ["/legacy/voice.ogg", ""],
+            MediaUrls: ["/legacy/voice.ogg", "https://legacy.test/photo.jpg"],
+            ...(mode === "staged-MediaStaged" ? { MediaStaged: true } : {}),
+            ...(mode === "staged-MediaWorkspaceDir"
+              ? { MediaWorkspaceDir: "/tmp/staged-media" }
+              : {}),
+          };
+  if (typeMode === "absent" || mode === "none") {
+    return base;
+  }
+  if (mode === "scalar-only") {
+    return { ...base, MediaType: typeMode === "present" ? "audio/ogg" : "image/png" };
+  }
+  return {
+    ...base,
+    MediaType: typeMode === "conflicting" ? "video/mp4" : "audio/ogg",
+    MediaTypes:
+      typeMode === "present"
+        ? mode === "mismatched-cardinality"
+          ? ["audio/ogg", "image/jpeg", "application/pdf"]
+          : ["audio/ogg", "image/jpeg"]
+        : mode === "mismatched-cardinality"
+          ? ["image/png", "video/mp4", "application/pdf"]
+          : ["image/png", "video/mp4"],
+  };
+}
+
+const mediaMergeMatrix = canonicalModes.flatMap((canonicalMode) =>
+  legacyModes.flatMap((legacyMode) =>
+    typeModes.map((typeMode) => ({
+      name: `canonical=${canonicalMode} legacy=${legacyMode} types=${typeMode}`,
+      canonicalMode,
+      legacyMode,
+      typeMode,
+    })),
+  ),
+);
 
 describe("channel inbound media facts", () => {
   it("formats media placeholder text with kind precedence and normalized MIME fallback", () => {
@@ -111,6 +222,101 @@ describe("channel inbound media facts", () => {
         workspaceDir: "/tmp/workspace",
       },
     ]);
+  });
+
+  it("normalizes retained facts and legacy projections without losing alignment", () => {
+    expect(
+      resolveMediaFacts({
+        media: [{ path: " /tmp/voice.ogg ", kind: "audio" }],
+        MediaTypes: [" audio/ogg "],
+        MediaTranscribedIndexes: [0],
+      }),
+    ).toEqual([
+      {
+        path: "/tmp/voice.ogg",
+        url: undefined,
+        contentType: "audio/ogg",
+        kind: "audio",
+        transcribed: true,
+        messageId: undefined,
+      },
+    ]);
+    expect(
+      resolveMediaFacts({
+        MediaPaths: ["/tmp/local.bin", ""],
+        MediaUrls: ["", "https://example.test/photo.jpg"],
+        MediaTypes: ["", "image/jpeg"],
+        MediaTranscribedIndexes: [1],
+      }),
+    ).toEqual([
+      expect.objectContaining({ path: "/tmp/local.bin", transcribed: false }),
+      expect.objectContaining({
+        path: undefined,
+        url: "https://example.test/photo.jpg",
+        contentType: "image/jpeg",
+        transcribed: true,
+      }),
+    ]);
+    expect(
+      resolveMediaFacts({
+        MediaPaths: ["/tmp/voice.ogg"],
+        MediaUrls: ["/tmp/voice.ogg", "https://example.test/photo.jpg"],
+        MediaTypes: ["audio/ogg", "image/jpeg"],
+      }),
+    ).toEqual([
+      expect.objectContaining({ path: "/tmp/voice.ogg", contentType: "audio/ogg" }),
+      expect.objectContaining({
+        path: undefined,
+        url: "https://example.test/photo.jpg",
+        contentType: "image/jpeg",
+      }),
+    ]);
+  });
+
+  it.each(mediaMergeMatrix)("merges $name", ({ canonicalMode, legacyMode, typeMode }) => {
+    const canonical = buildCanonicalMedia(canonicalMode, typeMode);
+    const legacy = buildLegacyMedia(legacyMode, typeMode);
+    const source: MergeMatrixSource = {
+      ...legacy,
+      ...(canonical.length > 0 ? { media: canonical } : {}),
+    };
+    const facts = resolveMediaFacts(source);
+    const paths = legacy.MediaPaths ?? [];
+    const urls = legacy.MediaUrls ?? [];
+    const types = legacy.MediaTypes ?? [];
+    const expectedCount = Math.max(
+      canonical.length,
+      paths.length,
+      urls.length,
+      types.length,
+      legacy.MediaPath || legacy.MediaUrl ? 1 : 0,
+    );
+
+    expect(hasStagedMediaProjection(source)).toBe(
+      legacyMode === "staged-MediaStaged" || legacyMode === "staged-MediaWorkspaceDir",
+    );
+    expect(facts).toHaveLength(expectedCount);
+    for (let index = 0; index < expectedCount; index += 1) {
+      const canonicalFact = canonical[index];
+      const expectedPath = normalizeOptionalString(
+        canonicalFact?.path ?? paths[index] ?? (index === 0 ? legacy.MediaPath : undefined),
+      );
+      const expectedUrl = normalizeOptionalString(
+        canonicalFact?.url ?? urls[index] ?? (index === 0 ? legacy.MediaUrl : undefined),
+      );
+      const expectedContentType = normalizeOptionalString(
+        canonicalFact?.contentType ??
+          types[index] ??
+          (expectedCount === 1 ? legacy.MediaType : undefined),
+      );
+      const expectedKind = canonicalFact?.kind ?? kindFromMime(expectedContentType);
+      expect(facts[index]).toMatchObject({
+        path: expectedPath,
+        url: expectedUrl,
+        contentType: expectedContentType,
+        kind: expectedKind,
+      });
+    }
   });
 
   it("builds legacy media payload fields from inbound media facts", () => {

--- a/src/hooks/message-hook-mappers.test.ts
+++ b/src/hooks/message-hook-mappers.test.ts
@@ -306,6 +306,70 @@ describe("message hook mappers", () => {
     expect(claimEvent.metadata?.mediaTypes).toEqual(["image/jpeg", "image/jpeg"]);
   });
 
+  it("projects retained facts into legacy hook media metadata", () => {
+    const canonical = deriveInboundMessageHookContext(
+      makeInboundCtx({
+        media: [
+          { path: "/tmp/tree.jpg", contentType: "image/jpeg" },
+          { url: "https://example.test/ramp.jpg", kind: "image" },
+        ],
+        MediaPath: undefined,
+        MediaUrl: undefined,
+        MediaType: undefined,
+        MediaPaths: undefined,
+        MediaUrls: undefined,
+        MediaTypes: undefined,
+      }),
+    );
+
+    expect(canonical).toMatchObject({
+      mediaPath: "/tmp/tree.jpg",
+      mediaUrl: "/tmp/tree.jpg",
+      mediaType: "image/jpeg",
+      mediaPaths: ["/tmp/tree.jpg"],
+      mediaUrls: ["/tmp/tree.jpg", "https://example.test/ramp.jpg"],
+      mediaTypes: ["image/jpeg", "image"],
+    });
+
+    const staged = deriveInboundMessageHookContext(
+      makeInboundCtx({
+        media: [{ path: "/remote/tree.jpg", contentType: "image/jpeg" }],
+        MediaStaged: true,
+        MediaPath: "/tmp/staged/tree.jpg",
+        MediaUrl: "/tmp/staged/tree.jpg",
+        MediaType: "image/jpeg",
+        MediaPaths: ["/tmp/staged/tree.jpg"],
+        MediaUrls: ["/tmp/staged/tree.jpg"],
+        MediaTypes: ["image/jpeg"],
+      }),
+    );
+    expect(staged).toMatchObject({
+      mediaPath: "/tmp/staged/tree.jpg",
+      mediaUrl: "/tmp/staged/tree.jpg",
+      mediaPaths: ["/tmp/staged/tree.jpg"],
+      mediaUrls: ["/tmp/staged/tree.jpg"],
+    });
+
+    const workspaceStaged = deriveInboundMessageHookContext(
+      makeInboundCtx({
+        media: [{ path: "/remote/tree.jpg", contentType: "image/jpeg" }],
+        MediaWorkspaceDir: "/tmp/staged",
+        MediaPath: "/tmp/staged/tree.jpg",
+        MediaUrl: "/tmp/staged/tree.jpg",
+        MediaType: "image/jpeg",
+        MediaPaths: ["/tmp/staged/tree.jpg"],
+        MediaUrls: ["/tmp/staged/tree.jpg"],
+        MediaTypes: ["image/jpeg"],
+      }),
+    );
+    expect(workspaceStaged).toMatchObject({
+      mediaPath: "/tmp/staged/tree.jpg",
+      mediaUrl: "/tmp/staged/tree.jpg",
+      mediaPaths: ["/tmp/staged/tree.jpg"],
+      mediaUrls: ["/tmp/staged/tree.jpg"],
+    });
+  });
+
   it("maps canonical inbound context to plugin/internal received payloads", () => {
     const trace: DiagnosticTraceContext = {
       traceId: "11111111111111111111111111111111",

--- a/src/hooks/message-hook-mappers.ts
+++ b/src/hooks/message-hook-mappers.ts
@@ -9,6 +9,11 @@ import {
   freezeDiagnosticTraceContext,
   type DiagnosticTraceContext,
 } from "../infra/diagnostic-trace-context.js";
+import {
+  hasStagedMediaProjection,
+  projectMediaFacts,
+  resolveMediaFacts,
+} from "../media/media-facts.js";
 import type {
   PluginHookInboundClaimContext,
   PluginHookInboundClaimEvent,
@@ -144,21 +149,14 @@ export function deriveInboundMessageHookContext(
     ctx.From ??
     internalSessionConversationId(channelId, ctx.SessionKey);
   const isGroup = Boolean(ctx.GroupSubject || ctx.GroupChannel);
-  const mediaPaths = Array.isArray(ctx.MediaPaths)
-    ? ctx.MediaPaths.filter(
-        (value): value is string => typeof value === "string" && value.length > 0,
-      )
-    : undefined;
-  const mediaTypes = Array.isArray(ctx.MediaTypes)
-    ? ctx.MediaTypes.filter(
-        (value): value is string => typeof value === "string" && value.length > 0,
-      )
-    : undefined;
-  const mediaUrls = Array.isArray(ctx.MediaUrls)
-    ? ctx.MediaUrls.filter(
-        (value): value is string => typeof value === "string" && value.length > 0,
-      )
-    : undefined;
+  const mediaPayload = hasStagedMediaProjection(ctx)
+    ? ctx
+    : ctx.media?.length
+      ? projectMediaFacts(resolveMediaFacts(ctx))
+      : ctx;
+  const mediaPaths = mediaPayload.MediaPaths?.filter(Boolean);
+  const mediaTypes = mediaPayload.MediaTypes?.filter(Boolean);
+  const mediaUrls = mediaPayload.MediaUrls?.filter(Boolean);
   return {
     from: ctx.From ?? "",
     to: ctx.To,
@@ -194,9 +192,9 @@ export function deriveInboundMessageHookContext(
     surface: ctx.Surface,
     threadId: ctx.MessageThreadId,
     threadParentId: ctx.ThreadParentId,
-    mediaPath: ctx.MediaPath ?? mediaPaths?.[0],
-    mediaUrl: ctx.MediaUrl ?? mediaUrls?.[0],
-    mediaType: ctx.MediaType ?? mediaTypes?.[0],
+    mediaPath: mediaPayload.MediaPath ?? mediaPaths?.[0],
+    mediaUrl: mediaPayload.MediaUrl ?? mediaUrls?.[0],
+    mediaType: mediaPayload.MediaType ?? mediaTypes?.[0],
     mediaPaths,
     mediaUrls,
     mediaTypes,

--- a/src/media-understanding/attachments.normalize.test.ts
+++ b/src/media-understanding/attachments.normalize.test.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { describe, expect, it } from "vitest";
 import { withMockedPlatform } from "../test-utils/vitest-spies.js";
-import { normalizeAttachmentPath } from "./attachments.normalize.js";
+import { normalizeAttachmentPath, normalizeAttachments } from "./attachments.normalize.js";
 
 describe("normalizeAttachmentPath", () => {
   it("allows localhost file URLs", () => {
@@ -24,5 +24,53 @@ describe("normalizeAttachmentPath", () => {
     withMockedPlatform("win32", () => {
       expect(normalizeAttachmentPath("\\\\attacker\\share\\photo.png")).toBeUndefined();
     });
+  });
+});
+
+describe("normalizeAttachments", () => {
+  it("prefers ordered facts over conflicting legacy projections", () => {
+    expect(
+      normalizeAttachments({
+        media: [
+          { path: " /tmp/voice.ogg ", contentType: " audio/ogg ", transcribed: true },
+          { url: "https://example.test/photo.jpg", kind: "image" },
+        ],
+        MediaPaths: ["/tmp/stale.bin"],
+        MediaTypes: ["application/octet-stream"],
+      }),
+    ).toEqual([
+      {
+        path: "/tmp/voice.ogg",
+        url: undefined,
+        mime: "audio/ogg",
+        index: 0,
+        alreadyTranscribed: true,
+      },
+      {
+        path: undefined,
+        url: "https://example.test/photo.jpg",
+        mime: "image",
+        index: 1,
+        alreadyTranscribed: false,
+      },
+    ]);
+  });
+
+  it("uses explicitly staged compatibility paths at the attachment consumer", () => {
+    expect(
+      normalizeAttachments({
+        media: [{ path: "/remote/voice.ogg", contentType: "audio/ogg" }],
+        MediaStaged: true,
+        MediaPath: "/tmp/staged/voice.ogg",
+        MediaPaths: ["/tmp/staged/voice.ogg"],
+        MediaUrl: "/tmp/staged/voice.ogg",
+        MediaUrls: ["/tmp/staged/voice.ogg"],
+      }),
+    ).toEqual([
+      expect.objectContaining({
+        path: "/tmp/staged/voice.ogg",
+        url: "/tmp/staged/voice.ogg",
+      }),
+    ]);
   });
 });

--- a/src/media-understanding/attachments.normalize.ts
+++ b/src/media-understanding/attachments.normalize.ts
@@ -5,6 +5,7 @@ import { getFileExtension, isAudioFileName, kindFromMime } from "@openclaw/media
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { MsgContext } from "../auto-reply/templating.js";
 import { assertNoWindowsNetworkPath, safeFileURLToPath } from "../infra/local-file-access.js";
+import { hasStagedMediaProjection, resolveMediaFacts } from "../media/media-facts.js";
 import type { MediaAttachment } from "./types.js";
 
 /** Normalizes a local attachment path while rejecting remote file URLs and Windows UNC paths. */
@@ -30,65 +31,16 @@ export function normalizeAttachmentPath(raw?: string | null): string | undefined
 
 /** Flattens legacy single-value and array media fields into indexed attachment records. */
 export function normalizeAttachments(ctx: MsgContext): MediaAttachment[] {
-  const pathsFromArray = Array.isArray(ctx.MediaPaths) ? ctx.MediaPaths : undefined;
-  const urlsFromArray = Array.isArray(ctx.MediaUrls) ? ctx.MediaUrls : undefined;
-  const typesFromArray = Array.isArray(ctx.MediaTypes) ? ctx.MediaTypes : undefined;
-  const transcribedIndexes = new Set(
-    Array.isArray(ctx.MediaTranscribedIndexes)
-      ? ctx.MediaTranscribedIndexes.filter((index) => Number.isInteger(index) && index >= 0)
-      : [],
-  );
-  const resolveMime = (count: number, index: number) => {
-    const typeHint = normalizeOptionalString(typesFromArray?.[index]);
-    if (typeHint) {
-      return typeHint;
-    }
-    return count === 1 ? ctx.MediaType : undefined;
-  };
-
-  if (pathsFromArray && pathsFromArray.length > 0) {
-    // Array fields are authoritative for multi-attachment messages; the legacy
-    // single URL remains a per-item fallback for older channel payloads.
-    const count = pathsFromArray.length;
-    const urls = urlsFromArray && urlsFromArray.length > 0 ? urlsFromArray : undefined;
-    return pathsFromArray
-      .map((value, index) => ({
-        path: normalizeOptionalString(value),
-        url: urls?.[index] ?? ctx.MediaUrl,
-        mime: resolveMime(count, index),
-        index,
-        alreadyTranscribed: transcribedIndexes.has(index),
-      }))
-      .filter((entry) => Boolean(entry.path ?? normalizeOptionalString(entry.url)));
-  }
-
-  if (urlsFromArray && urlsFromArray.length > 0) {
-    const count = urlsFromArray.length;
-    return urlsFromArray
-      .map((value, index) => ({
-        path: undefined,
-        url: normalizeOptionalString(value),
-        mime: resolveMime(count, index),
-        index,
-        alreadyTranscribed: transcribedIndexes.has(index),
-      }))
-      .filter((entry) => Boolean(entry.url));
-  }
-
-  const pathValue = normalizeOptionalString(ctx.MediaPath);
-  const url = normalizeOptionalString(ctx.MediaUrl);
-  if (!pathValue && !url) {
-    return [];
-  }
-  return [
-    {
-      path: pathValue || undefined,
-      url: url || undefined,
-      mime: ctx.MediaType,
-      index: 0,
-      alreadyTranscribed: transcribedIndexes.has(0),
-    },
-  ];
+  const mediaSource = hasStagedMediaProjection(ctx) ? { ...ctx, media: undefined } : ctx;
+  return resolveMediaFacts(mediaSource)
+    .map((fact, index) => ({
+      path: normalizeOptionalString(fact.path),
+      url: normalizeOptionalString(fact.url),
+      mime: normalizeOptionalString(fact.contentType) ?? fact.kind,
+      index,
+      alreadyTranscribed: fact.transcribed === true,
+    }))
+    .filter((entry) => Boolean(entry.path ?? entry.url));
 }
 
 /** Classifies an attachment by MIME first, then by filename/URL extension fallback. */

--- a/src/media/media-facts.ts
+++ b/src/media/media-facts.ts
@@ -1,4 +1,5 @@
 import type { MediaKind } from "@openclaw/media-core/constants";
+import { kindFromMime } from "@openclaw/media-core/mime";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 
 /** One ordered runtime attachment; array position is its alignment identity. */
@@ -33,21 +34,33 @@ export type MediaFactLegacyProjection = {
   MediaTranscribedIndexes?: number[];
 };
 
+type MediaFactSource = MediaFactLegacyProjection & {
+  media?: readonly MediaFactInput[];
+  MediaStaged?: boolean | null;
+  MediaWorkspaceDir?: string | null;
+};
+
 function normalizeMediaFact<TInput extends MediaFactInput>(
   media: TInput,
   index: number,
   defaults: MediaFactDefaults<TInput> = {},
 ): MediaFact {
   const workspaceDir = normalizeOptionalString(media.workspaceDir) ?? defaults.workspaceDir;
+  const contentType = normalizeOptionalString(media.contentType);
   return {
     path: normalizeOptionalString(media.path),
     url: normalizeOptionalString(media.url),
-    contentType: normalizeOptionalString(media.contentType),
-    kind: media.kind ?? defaults.kind,
+    contentType,
+    kind: media.kind ?? defaults.kind ?? kindFromMime(contentType),
     transcribed: media.transcribed === true || defaults.transcribed?.(media, index) === true,
     messageId: normalizeOptionalString(media.messageId) ?? defaults.messageId,
     ...(workspaceDir ? { workspaceDir } : {}),
   };
+}
+
+/** True when a consumer must use the already-staged legacy path projection. */
+export function hasStagedMediaProjection(source: MediaFactSource): boolean {
+  return source.MediaStaged === true || Boolean(normalizeOptionalString(source.MediaWorkspaceDir));
 }
 
 export function normalizeMediaFacts<TInput extends MediaFactInput>(
@@ -57,6 +70,60 @@ export function normalizeMediaFacts<TInput extends MediaFactInput>(
   return Array.isArray(media)
     ? media.map((entry, index) => normalizeMediaFact(entry, index, defaults))
     : [];
+}
+
+// Empty slots exist only to keep legacy parallel-array positions aligned;
+// presence/counting sites must ignore them or blank projections ({MediaPaths: [""]})
+// route media-less messages into inbound-media handling.
+export function isMeaningfulMediaFact(fact: MediaFact): boolean {
+  return Boolean(
+    fact.path?.trim() ||
+      fact.url?.trim() ||
+      fact.contentType ||
+      (fact.kind && fact.kind !== "unknown"),
+  );
+}
+
+/** Resolves facts and drops alignment-only empty slots for presence/count consumers. */
+export function resolveMeaningfulMediaFacts(source: MediaFactSource): MediaFact[] {
+  return resolveMediaFacts(source).filter(isMeaningfulMediaFact);
+}
+
+/** Normalizes canonical facts or, for compatibility callers, legacy parallel fields. */
+export function resolveMediaFacts(source: MediaFactSource): MediaFact[] {
+  const canonical = normalizeMediaFacts(source.media);
+  const paths = Array.isArray(source.MediaPaths) ? source.MediaPaths : [];
+  const urls = Array.isArray(source.MediaUrls) ? source.MediaUrls : [];
+  const types = Array.isArray(source.MediaTypes) ? source.MediaTypes : [];
+  const count = Math.max(
+    canonical.length,
+    paths.length,
+    urls.length,
+    types.length,
+    source.MediaPath || source.MediaUrl ? 1 : 0,
+  );
+  const transcribed = new Set(source.MediaTranscribedIndexes ?? []);
+  return Array.from({ length: count }, (_, index) => {
+    const fact = canonical[index];
+    return normalizeMediaFact(
+      {
+        path: fact?.path ?? paths[index] ?? (index === 0 ? source.MediaPath : undefined),
+        url:
+          fact?.url ??
+          urls[index] ??
+          (paths.length > 0 || index === 0 ? source.MediaUrl : undefined),
+        contentType:
+          fact?.contentType ??
+          normalizeOptionalString(types[index]) ??
+          (count === 1 ? source.MediaType : undefined),
+        kind: fact?.kind,
+        transcribed: fact?.transcribed === true || transcribed.has(index),
+        messageId: fact?.messageId,
+        workspaceDir: fact?.workspaceDir,
+      },
+      index,
+    );
+  });
 }
 
 function projectStrings(

--- a/src/media/media-facts.ts
+++ b/src/media/media-facts.ts
@@ -75,12 +75,12 @@ export function normalizeMediaFacts<TInput extends MediaFactInput>(
 // Empty slots exist only to keep legacy parallel-array positions aligned;
 // presence/counting sites must ignore them or blank projections ({MediaPaths: [""]})
 // route media-less messages into inbound-media handling.
-export function isMeaningfulMediaFact(fact: MediaFact): boolean {
+function isMeaningfulMediaFact(fact: MediaFact): boolean {
   return Boolean(
     fact.path?.trim() ||
-      fact.url?.trim() ||
-      fact.contentType ||
-      (fact.kind && fact.kind !== "unknown"),
+    fact.url?.trim() ||
+    fact.contentType ||
+    (fact.kind && fact.kind !== "unknown"),
   );
 }
 


### PR DESCRIPTION
## What Problem This Solves

PR 2 of the audit-frozen media-facts program (PR 1: #112197). Runtime plumbing between channel ingress and the reply pipeline still consumed the parallel singular/plural `Media*` fields, with each consumer re-deriving media presence, audio-ness, and staging from index-aligned arrays.

## Why This Change Was Made

- Channel context retains ordered `MediaFact[]` through finalization; inbound gates, hook mapping, current-turn normalization, and all five channel families' audio preflights consume facts. Legacy projections remain intact for templates, staging compatibility, and persistence (later PRs' territory).
- The canonical/legacy merge — the semantic heart of the collapse — was hardened across four review cycles: canonical facts are authoritative with legacy values gap-filling only; one shared staging predicate covers both `MediaStaged` and the older `MediaWorkspaceDir` marker; kind inference runs after fallback MIME fills; legacy reconstruction sizes from maximum array cardinality (mismatched parallel arrays no longer drop attachments); and alignment-only empty slots (`MediaPaths: [""]`) no longer count as media presence while intentional type-only facts still do.
- All of it is pinned by a 54-cell canonical×legacy×type merge-matrix test plus targeted presence/blank-slot regressions.

## User Impact

None intended — behavior-preserving migration with several latent legacy-shape bugs (dropped attachments on mismatched arrays, blank-slot false positives) fixed en route.

## Evidence

- 488+ focused tests green across 18 core/channel files plus the merge matrix (65/65 in its suite) and presence regressions (11/11), via `node scripts/run-vitest.mjs`.
- Delegated `check:changed` green on Blacksmith Testbox (run 29825594223); local SDK manifest/export/surface and all three knip lanes green; oxlint and `git diff --check` clean.
- Review history worth noting: four autoreview cycles — round 1 caught canonical-priority and cardinality bugs (including one where a newly added test had not been rerun and genuinely failed; the proof gap was reconciled honestly), round 2 caught the staging-predicate split and normalization ordering, round 3 caught blank-slot presence (fixed directly by the maintainer-side reviewer with the alignment-vs-presence split), round 4 clean, "patch is correct (0.88)".
- Net −3 production LOC before tests; prompt bytes and persisted rows untouched.
