### PR TITLE
fix(macos): localize shared chat progress strings

### DIFF
--- a/scripts/apple-app-i18n.ts
+++ b/scripts/apple-app-i18n.ts
@@ -41,9 +41,10 @@ const MACOS_CATALOG_PATH = "apps/macos/Sources/OpenClaw/Resources/Localizable.xc
 const IOS_CONTRADICTIONS_PATH = "apps/.i18n/apple-translation-contradictions.json";
 const NATIVE_SOURCE_PATH = "apps/.i18n/native-source.json";
 const NATIVE_TRANSLATIONS_DIR = "apps/.i18n/native";
+const SHARED_CHAT_UI_SOURCE_PREFIX = "apps/shared/OpenClawKit/Sources/OpenClawChatUI/";
 const IOS_SOURCE_PREFIXES = [
   "apps/ios/",
-  "apps/shared/OpenClawKit/Sources/OpenClawChatUI/",
+  SHARED_CHAT_UI_SOURCE_PREFIX,
   "apps/shared/OpenClawKit/Sources/OpenClawKit/",
 ] as const;
 const APPLE_CATALOG_KINDS = new Set([
@@ -61,7 +62,10 @@ const IOS_CATALOG_EXCLUSIONS = new Set([
   "OpenClaw",
   "z",
 ]);
-const MACOS_SOURCE_PREFIX = "apps/macos/Sources/OpenClaw/";
+const MACOS_SOURCE_PREFIXES = [
+  "apps/macos/Sources/OpenClaw/",
+  SHARED_CHAT_UI_SOURCE_PREFIX,
+] as const;
 const MACOS_CATALOG_EXCLUSIONS = new Set([
   // Product names are intentionally verbatim.
   "OpenClaw",
@@ -550,7 +554,7 @@ function isIosCatalogEntry(entry: NativeSourceEntry): boolean {
 function isMacosCatalogEntry(entry: NativeSourceEntry): boolean {
   return (
     entry.surface === "apple" &&
-    entry.path.startsWith(MACOS_SOURCE_PREFIX) &&
+    MACOS_SOURCE_PREFIXES.some((prefix) => entry.path.startsWith(prefix)) &&
     APPLE_CATALOG_KINDS.has(entry.kind) &&
     !entry.source.includes("\\(") &&
     !MACOS_CATALOG_EXCLUSIONS.has(entry.source)

--- a/test/scripts/apple-app-i18n.test.ts
+++ b/test/scripts/apple-app-i18n.test.ts
@@ -91,9 +91,11 @@ describe("Apple app i18n catalogs", () => {
     expect(keys).toEqual(
       expect.arrayContaining([
         "Browse ClawHub",
+        "Done in %@",
         "Enable debug tools",
         "Everyday OpenClaw app behavior.",
         "General",
+        "Shelling",
         "Voice Wake requires macOS 26 or newer",
       ]),
     );


### PR DESCRIPTION
Related: #112218

## What Problem This Solves

Fixes an issue where macOS users would see the shared chat working phrases and turn recap labels in English even when the app used another supported language.

## Why This Change Was Made

The macOS catalog now includes the shared `OpenClawChatUI` inventory that the macOS executable already renders. A regression assertion covers both a working phrase and the formatted completion label.

## User Impact

Shared chat progress text can be translated consistently on iOS and macOS after the native locale refresh runs.

## Evidence

- Blacksmith Testbox `tbx_01ky23fzgtgbhxe4hsswc1bpag`: `pnpm test:serial test/scripts/apple-app-i18n.test.ts` passed 16 tests; derived macOS coverage is 1,183 keys.
- Same Testbox: `pnpm check:changed` passed for the scripts and root-test lanes.
- Autoreview: clean, no actionable findings, confidence 0.99.
- `git diff --check` passed.
