### PR TITLE
[AI-assisted] docs: remove dead ClawHub nav entries and fix downstream links

### DIFF
--- a/docs/automation/taskflow.md
+++ b/docs/automation/taskflow.md
@@ -154,7 +154,7 @@ Recommended data provenance fields for every collected item:
 
 Have the workflow reject or mark stale items before summarization. The LLM step should receive only structured JSON and should be asked to preserve `sourceUrl`, `retrievedAt`, and `asOf` in its output. Use [LLM Task](/tools/llm-task) when you need a schema-validated model step inside the workflow.
 
-For reusable team or community workflows, package the CLI, `.lobster` files, and any setup notes as a skill or plugin and publish it through [ClawHub](/clawhub). Keep workflow-specific guardrails in that package unless the plugin API is missing a needed generic capability.
+For reusable team or community workflows, package the CLI, `.lobster` files, and any setup notes as a skill or plugin and publish it through [ClawHub](/clawhub/publishing). Keep workflow-specific guardrails in that package unless the plugin API is missing a needed generic capability.
 
 ## How flows relate to tasks
 

--- a/docs/cli/plugins.md
+++ b/docs/cli/plugins.md
@@ -563,4 +563,4 @@ refreshes fail if OpenClaw cannot persist the validated snapshot.
 
 - [Building plugins](/plugins/building-plugins)
 - [CLI reference](/cli)
-- [ClawHub](/clawhub)
+- [ClawHub](/clawhub/cli)

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1439,32 +1439,10 @@
             "tab": "ClawHub",
             "groups": [
               {
-                "group": "Overview",
-                "pages": [
-                  "clawhub/index",
-                  "clawhub/quickstart",
-                  "clawhub/how-it-works"
-                ]
-              },
-              {
                 "group": "Using ClawHub",
                 "pages": [
                   "clawhub/cli",
-                  "clawhub/publishing",
-                  "clawhub/skill-format",
-                  "clawhub/auth",
-                  "clawhub/telemetry",
-                  "clawhub/troubleshooting"
-                ]
-              },
-              {
-                "group": "API and trust",
-                "pages": [
-                  "clawhub/api",
-                  "clawhub/http-api",
-                  "clawhub/acceptable-usage",
-                  "clawhub/moderation",
-                  "clawhub/security-audits"
+                  "clawhub/publishing"
                 ]
               }
             ]

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -462,15 +462,15 @@
     },
     {
       "source": "/clawdhub",
-      "destination": "/clawhub"
+      "destination": "/clawhub/cli"
     },
     {
       "source": "/tools/clawhub",
-      "destination": "/clawhub"
+      "destination": "/clawhub/cli"
     },
     {
       "source": "/tools/clawdhub",
-      "destination": "/clawhub"
+      "destination": "/clawhub/cli"
     },
     {
       "source": "/configuration",

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -341,7 +341,7 @@ First-run Q&A - install, onboard, auth routes, subscriptions, initial failures -
 
     Native installs land in the active workspace `skills/` directory; use `--global` for all local agents, or configure `agents.defaults.skills` / `agents.list[].skills` to limit visibility. Some skills expect Homebrew-installed binaries; on Linux that means Linuxbrew.
 
-    See [Skills](/tools/skills), [Skills config](/tools/skills-config), [ClawHub](/tools/clawhub).
+    See [Skills](/tools/skills), [Skills config](/tools/skills-config), [ClawHub](/clawhub/cli).
 
   </Accordion>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -65,7 +65,7 @@ these hub links to reach the same top-level docs areas from the page body.
   <Card title="Capabilities" href="/tools" icon="wand-sparkles">
     Tools, skills, cron, webhooks, and automation capabilities.
   </Card>
-  <Card title="ClawHub" href="/clawhub" icon="store">
+  <Card title="ClawHub" href="/clawhub/cli" icon="store">
     Plugin marketplace, publishing, curation, and trust guidance.
   </Card>
   <Card title="Models" href="/providers" icon="brain">

--- a/docs/plugins/building-plugins.md
+++ b/docs/plugins/building-plugins.md
@@ -14,7 +14,7 @@ channel, model provider, local CLI backend, agent tool, hook, media provider,
 or another plugin-owned capability.
 
 You do not need to add an external plugin to the OpenClaw repository. Publish
-the package to [ClawHub](/clawhub) and users install it with:
+the package to [ClawHub](/clawhub/publishing) and users install it with:
 
 ```bash
 openclaw plugins install clawhub:<package-name>

--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -9,7 +9,7 @@ doc-schema-version: 1
 
 Community plugins are third-party packages that extend OpenClaw with
 channels, tools, providers, hooks, or other capabilities. Use
-[ClawHub](/clawhub) as the primary discovery surface for public community
+[ClawHub](/clawhub/cli) as the primary discovery surface for public community
 plugins.
 
 ## Find plugins

--- a/docs/plugins/sdk-setup.md
+++ b/docs/plugins/sdk-setup.md
@@ -508,7 +508,7 @@ const setupWizard: ChannelSetupWizard = {
 
 ## Publishing and installing
 
-**External plugins:** publish to [ClawHub](/clawhub), then install:
+**External plugins:** publish to [ClawHub](/clawhub/publishing), then install:
 
 <Tabs>
   <Tab title="npm">

--- a/docs/plugins/zalouser.md
+++ b/docs/plugins/zalouser.md
@@ -93,4 +93,4 @@ reactions.
 - [Zalo personal channel config](/channels/zalouser)
 - [Zalo (official Bot/webhook channel)](/channels/zalo)
 - [Building plugins](/plugins/building-plugins)
-- [ClawHub](/clawhub)
+- [ClawHub](/clawhub/cli)

--- a/docs/start/hubs.md
+++ b/docs/start/hubs.md
@@ -167,7 +167,7 @@ Use these hubs to discover every page, including deep dives and reference docs t
 - [Plugin manifest](/plugins/manifest)
 - [Agent tools](/plugins/building-plugins#registering-agent-tools)
 - [Plugin bundles](/plugins/bundles)
-- [ClawHub](/clawhub)
+- [ClawHub](/clawhub/cli)
 - [Capability cookbook](/tools/capability-cookbook)
 - [Voice call plugin](/plugins/voice-call)
 - [Zalo user plugin](/plugins/zalouser)
@@ -175,7 +175,7 @@ Use these hubs to discover every page, including deep dives and reference docs t
 ## Workspace + templates
 
 - [Skills](/tools/skills)
-- [ClawHub](/clawhub)
+- [ClawHub](/clawhub/cli)
 - [Skills config](/tools/skills-config)
 - [Default AGENTS](/reference/AGENTS.default)
 - [Templates: AGENTS](/reference/templates/AGENTS)

--- a/docs/tools/creating-skills.md
+++ b/docs/tools/creating-skills.md
@@ -259,7 +259,7 @@ See [Skill Workshop](/tools/skill-workshop) for the full proposal lifecycle.
   <Card title="Skills config" href="/tools/skills-config" icon="gear">
     Full `skills.*` config schema.
   </Card>
-  <Card title="ClawHub" href="/clawhub" icon="cloud">
+  <Card title="ClawHub" href="/clawhub/cli" icon="cloud">
     Browse and publish skills on the public registry.
   </Card>
   <Card title="Building plugins" href="/plugins/building-plugins" icon="plug">

--- a/docs/tools/plugin.md
+++ b/docs/tools/plugin.md
@@ -31,7 +31,7 @@ bundled, official external, and source-only plugins, see
 
 <Steps>
   <Step title="Find the plugin">
-    Search [ClawHub](/clawhub) for public plugin packages:
+    Search [ClawHub](/clawhub/cli) for public plugin packages:
 
     ```bash
     openclaw plugins search "calendar"

--- a/docs/tools/skills.md
+++ b/docs/tools/skills.md
@@ -24,7 +24,7 @@ binary presence.
   <Card title="Skills config" href="/tools/skills-config" icon="gear">
     Full `skills.*` config schema and agent allowlists.
   </Card>
-  <Card title="ClawHub" href="/clawhub" icon="cloud">
+  <Card title="ClawHub" href="/clawhub/cli" icon="cloud">
     Browse and install community skills.
   </Card>
 </CardGroup>
@@ -618,7 +618,7 @@ Keep descriptions short and descriptive to minimize prompt overhead.
   <Card title="Slash commands" href="/tools/slash-commands" icon="terminal">
     How skill slash commands are registered and routed.
   </Card>
-  <Card title="ClawHub" href="/clawhub" icon="cloud">
+  <Card title="ClawHub" href="/clawhub/cli" icon="cloud">
     Browse and publish skills on the public registry.
   </Card>
   <Card title="Plugins" href="/tools/plugin" icon="plug">


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users browsing the ClawHub nav tab or following a "ClawHub" link from 13 other doc pages (`docs/tools/plugin.md`, `docs/plugins/community.md`, `docs/plugins/sdk-setup.md`, `docs/plugins/zalouser.md`, `docs/plugins/building-plugins.md`, `docs/start/hubs.md` (x2), `docs/cli/plugins.md`, `docs/automation/taskflow.md`, `docs/index.md`, `docs/tools/skills.md` (x2), `docs/tools/creating-skills.md`, `docs/help/faq.md`) would land on a 404. `docs/docs.json`'s ClawHub nav tab listed 14 pages, but only `docs/clawhub/cli.md` and `docs/clawhub/publishing.md` exist on disk — the other 12 (including `clawhub/index.md`, the file that would serve the bare `/clawhub` route) were never created. That also meant the `/clawdhub`, `/tools/clawhub`, and `/tools/clawdhub` legacy redirects, which all pointed at `/clawhub`, resolved to nothing.

## Why This Change Was Made

Removed the 12 nonexistent page entries from the ClawHub nav tab in `docs/docs.json`, keeping the two real pages (`clawhub/cli`, `clawhub/publishing`). Since `clawhub/index.md` never existed, the bare `/clawhub` route can't resolve regardless of nav content, so I repointed every real doc-page link/card and legacy redirect that targeted `/clawhub` to whichever of `/clawhub/cli` or `/clawhub/publishing` fit the surrounding context (install/discovery vs. publish), rather than mechanically search-and-replacing one target everywhere. I did not author any of the 12 missing pages — that's a maintainer decision on content, out of scope for an outside contributor.

This PR is AI-assisted (Claude Code / Sonnet 5). I reviewed and verified every change against the actual repository file tree before committing.

## User Impact

Every "ClawHub" link and redirect in the docs now lands on a real page instead of a 404. The ClawHub nav tab is smaller (2 pages instead of 14) but everything it shows works, versus 12 broken entries before.

## Evidence

- Confirmed via `find`/`ls` that only `docs/clawhub/cli.md` and `docs/clawhub/publishing.md` exist; none of the other 12 referenced filenames exist anywhere in the repo.
- `node scripts/docs-link-audit.mjs` before fix: `broken_links=1` (the one remaining `/tools/clawhub` reference in `help/faq.md`, found by the audit after the first pass). After fix: `checked_internal_links=6136`, `broken_links=0`.
- `node scripts/generate-docs-map.mjs --check`: `docs/docs_map.md is up to date` (no regeneration needed).
- `python3 -c "import json; json.load(open('docs/docs.json'))"`: valid JSON, no trailing commas/bracket mismatches.
- Ran the repo's `autoreview` skill (`.agents/skills/autoreview`, Codex engine, `gpt-5.6-sol`, high reasoning) against the branch diff. First pass caught a real gap (three legacy redirects still pointed at dead `/clawhub`), which I fixed in a follow-up commit. A second pass returned two more findings claiming the removed nav entries and repointed links orphan "existing" ClawHub pages — I verified this against the actual filesystem (`find`, `ls`) and rejected both: the reviewer runs in an empty sandbox with no access to the real repo tree, and the 12 pages it assumes still exist do not exist anywhere in the repo (never did). TruffleHog secret scan: clean.
