### PR TITLE
[AI-assisted] docs: drop stray /index suffix from internal links

### DIFF
--- a/docs/gateway/troubleshooting.md
+++ b/docs/gateway/troubleshooting.md
@@ -806,7 +806,7 @@ Related:
 
 - [Exec approvals](/tools/exec-approvals)
 - [Node troubleshooting](/nodes/troubleshooting)
-- [Nodes](/nodes/index)
+- [Nodes](/nodes)
 
 ## Browser tool fails
 

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -1530,7 +1530,7 @@ Model Q&A - defaults, selection, aliases, switching, failover, auth profiles - l
 
     Still noisy: check session settings in the Control UI and set verbose to **inherit**; confirm you are not using a bot profile with `verboseDefault: "on"` in config.
 
-    Docs: [Thinking and verbose](/tools/thinking), [Security](/gateway/security/index#reasoning-and-verbose-output-in-groups).
+    Docs: [Thinking and verbose](/tools/thinking), [Security](/gateway/security#reasoning-and-verbose-output-in-groups).
 
   </Accordion>
 

--- a/docs/providers/cohere.md
+++ b/docs/providers/cohere.md
@@ -80,4 +80,4 @@ If the Gateway runs as a daemon or in Docker, set `COHERE_API_KEY` for that serv
 
 - [Model providers](/concepts/model-providers)
 - [Models CLI](/cli/models)
-- [Provider directory](/providers/index)
+- [Provider directory](/providers)

--- a/docs/providers/deepinfra.md
+++ b/docs/providers/deepinfra.md
@@ -97,4 +97,4 @@ deepinfra/zai-org/GLM-5.1
 ## Related
 
 - [Model providers](/concepts/model-providers)
-- [All providers](/providers/index)
+- [All providers](/providers)

--- a/docs/providers/featherless.md
+++ b/docs/providers/featherless.md
@@ -135,5 +135,5 @@ tags before adding custom metadata.
 ## Related
 
 - [Model providers](/concepts/model-providers)
-- [All providers](/providers/index)
+- [All providers](/providers)
 - [Thinking modes](/tools/thinking)

--- a/docs/providers/gmi.md
+++ b/docs/providers/gmi.md
@@ -96,4 +96,4 @@ openclaw models list --provider gmi
 ## Related
 
 - [Model providers](/concepts/model-providers)
-- [All providers](/providers/index)
+- [All providers](/providers)

--- a/docs/providers/models.md
+++ b/docs/providers/models.md
@@ -51,7 +51,7 @@ Pick a provider, authenticate, then set the default model as `provider/model`.
 - [Z.AI (GLM)](/providers/zai)
 
 For the full provider catalog and advanced configuration, see
-[Provider directory](/providers/index) and [Model providers](/concepts/model-providers).
+[Provider directory](/providers) and [Model providers](/concepts/model-providers).
 
 ## Additional provider variants
 
@@ -61,7 +61,7 @@ For the full provider catalog and advanced configuration, see
 
 ## Related
 
-- [Provider directory](/providers/index)
+- [Provider directory](/providers)
 - [Model selection](/concepts/model-providers)
 - [Model failover](/concepts/model-failover)
 - [Models CLI](/cli/models)

--- a/docs/providers/novita.md
+++ b/docs/providers/novita.md
@@ -80,4 +80,4 @@ run on your own hardware or network boundary.
 ## Related
 
 - [Model providers](/concepts/model-providers)
-- [Provider directory](/providers/index)
+- [Provider directory](/providers)

--- a/docs/providers/ollama-cloud.md
+++ b/docs/providers/ollama-cloud.md
@@ -114,4 +114,4 @@ authorize `/api/embed`; force them with `OPENCLAW_LIVE_OLLAMA_EMBEDDINGS=1`.
 
 - [Ollama](/providers/ollama)
 - [Model providers](/concepts/model-providers)
-- [All providers](/providers/index)
+- [All providers](/providers)

--- a/docs/releases/2026.6.11.md
+++ b/docs/releases/2026.6.11.md
@@ -323,7 +323,7 @@ Additional [Telegram](/channels/telegram) and channel configuration fixes cover 
 
 ### Remote result and media delivery
 
-Remote image results and completed subagent work now return through the active [gateway](/gateway/index) conversation more reliably instead of appearing to fail or disappear.
+Remote image results and completed subagent work now return through the active [gateway](/gateway) conversation more reliably instead of appearing to fail or disappear.
 
 <Accordion title="Sources and contributors">
 
@@ -378,7 +378,7 @@ Additional [Control UI](/web/control-ui), mobile, and desktop fixes improve disp
 
 ### Setup and command reliability
 
-Common [CLI commands](/cli/index) now handle configuration, paths, output, and failure cases more consistently. [Shell completion](/cli/completion), [doctor](/cli/doctor), [config commands](/cli/config), and [gateway configuration](/gateway/configuration) provide clearer guidance and safer recovery when an installation or setting needs attention.
+Common [CLI commands](/cli) now handle configuration, paths, output, and failure cases more consistently. [Shell completion](/cli/completion), [doctor](/cli/doctor), [config commands](/cli/config), and [gateway configuration](/gateway/configuration) provide clearer guidance and safer recovery when an installation or setting needs attention.
 
 <Accordion title="Sources and contributors">
 
@@ -434,7 +434,7 @@ Common [CLI commands](/cli/index) now handle configuration, paths, output, and f
 
 ### Tools and scheduled work
 
-[Scheduled jobs](/cli/cron) and built-in [tools](/tools/index) now finish, retry, report failures, and preserve their intended inputs more consistently. Improvements to the [plugin SDK runtime](/plugins/sdk-runtime) also make tool-backed extensions more reliable when loading, returning results, or running scheduled work.
+[Scheduled jobs](/cli/cron) and built-in [tools](/tools) now finish, retry, report failures, and preserve their intended inputs more consistently. Improvements to the [plugin SDK runtime](/plugins/sdk-runtime) also make tool-backed extensions more reliable when loading, returning results, or running scheduled work.
 
 <Accordion title="Sources and contributors">
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users following an "All providers" / "Provider directory" link from 7 provider pages, a "Nodes" link from the gateway troubleshooting page, three links in the 2026.6.11 release notes, and a "Security" link in the FAQ would land on a 404. Mintlify strips `index.md` from a page's route (`foo/index.md` serves at `/foo`, not `/foo/index`), but these pages were hand-written with the `/index` suffix still attached.

## Why This Change Was Made

Ran a repo-wide grep for the `(/...index)` link pattern, confirmed each target route is served by an `index.md` file (`providers/index.md`, `nodes/index.md`, `gateway/index.md`, `cli/index.md`, `tools/index.md`, `gateway/security/index.md`), and stripped the stray `/index` suffix from every real occurrence (14 total, across 9 pages — a few more than the initially known list, e.g. `providers/models.md` had 2 and `help/faq.md` had one with a URL fragment). Left `docs/maturity/taxonomy.md` untouched: it's auto-generated and has dozens of instances of the same pattern, and fixing the generator is a separate, out-of-scope change from this doc-link fix.

This PR is AI-assisted (Claude Code / Sonnet 5). I reviewed and verified every change against the actual repository file tree before committing.

## User Impact

All 14 affected links now resolve to the correct page instead of 404ing.

## Evidence

- `grep -rnE '\(/[a-zA-Z0-9_/-]*index(#[a-zA-Z0-9_-]+)?\)' --include="*.md" docs/ | grep -v maturity/taxonomy.md` returns no matches after the fix (confirmed all real occurrences are gone).
- Confirmed each destination file exists (`docs/providers/index.md`, `docs/nodes/index.md`, `docs/gateway/index.md`, `docs/cli/index.md`, `docs/tools/index.md`, `docs/gateway/security/index.md`) so the un-suffixed route is valid.
- `node scripts/docs-link-audit.mjs`: `checked_internal_links=6148`, `broken_links=0`.
- `node scripts/generate-docs-map.mjs --check`: `docs/docs_map.md is up to date`.
- Ran the repo's `autoreview` skill (`.agents/skills/autoreview`, Codex engine, `gpt-5.6-sol`, high reasoning) against the commit: clean, no accepted/actionable findings, `overall: patch is correct (0.99)`. TruffleHog secret scan: clean.
