### PR TITLE
feat(android): chat rewind/fork actions and branch switcher with branch-safe outbox

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -563,7 +563,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 466,
+      "line": 470,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Searching…",
       "surface": "android",
@@ -571,7 +571,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 599,
+      "line": 603,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Mic off",
       "surface": "android",
@@ -579,7 +579,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 613,
+      "line": 617,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Off",
       "surface": "android",
@@ -715,7 +715,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 174,
+      "line": 176,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Resolution outcome unknown. Actions stay disabled until the Gateway record is verified.",
       "surface": "android",
@@ -723,7 +723,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 176,
+      "line": 178,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "The Gateway still shows this approval as pending. Review it before trying again.",
       "surface": "android",
@@ -731,7 +731,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 178,
+      "line": 180,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load approval details. Refresh and try again.",
       "surface": "android",
@@ -739,7 +739,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 180,
+      "line": 182,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load approvals.",
       "surface": "android",
@@ -747,7 +747,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 182,
+      "line": 184,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not resolve approval. Refresh and try again.",
       "surface": "android",
@@ -755,7 +755,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 279,
+      "line": 281,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Device approved.",
       "surface": "android",
@@ -763,7 +763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 280,
+      "line": 282,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Pairing request rejected.",
       "surface": "android",
@@ -771,7 +771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 281,
+      "line": 283,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Paired device removed.",
       "surface": "android",
@@ -779,7 +779,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 342,
+      "line": 344,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Proposal applied.",
       "surface": "android",
@@ -787,7 +787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 342,
+      "line": 344,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "apply",
       "surface": "android",
@@ -795,7 +795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 343,
+      "line": 345,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Proposal rejected.",
       "surface": "android",
@@ -803,7 +803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 343,
+      "line": 345,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "reject",
       "surface": "android",
@@ -811,7 +811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 344,
+      "line": 346,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Proposal quarantined.",
       "surface": "android",
@@ -819,7 +819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 344,
+      "line": 346,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "quarantine",
       "surface": "android",
@@ -827,7 +827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 351,
+      "line": 353,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "unknown",
       "surface": "android",
@@ -835,7 +835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 352,
+      "line": 354,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway returned status '$statusLabel' after ${action.verb}.",
       "surface": "android",
@@ -843,7 +843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 360,
+      "line": 362,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not ${action.verb} Skill Workshop proposal.",
       "surface": "android",
@@ -851,7 +851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 542,
+      "line": 544,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connected (node offline)",
       "surface": "android",
@@ -859,7 +859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 543,
+      "line": 545,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connected (operator offline)",
       "surface": "android",
@@ -867,7 +867,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 545,
+      "line": 547,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Reconnecting…",
       "surface": "android",
@@ -875,7 +875,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 553,
+      "line": 555,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connected (operator: $operator)",
       "surface": "android",
@@ -883,7 +883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2218,
+      "line": 2220,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This automation already has a queued run.",
       "surface": "android",
@@ -891,7 +891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2248,
+      "line": 2250,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation run queued.",
       "surface": "android",
@@ -899,7 +899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2248,
+      "line": 2250,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation started.",
       "surface": "android",
@@ -907,7 +907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2261,
+      "line": 2263,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway rejected the automation run.",
       "surface": "android",
@@ -915,7 +915,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2292,
+      "line": 2294,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation enabled.",
       "surface": "android",
@@ -923,7 +923,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2292,
+      "line": 2294,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation paused.",
       "surface": "android",
@@ -931,7 +931,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2314,
+      "line": 2316,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This automation changed on the gateway. Review the latest version before saving again.",
       "surface": "android",
@@ -939,7 +939,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2320,
+      "line": 2322,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation updated.",
       "surface": "android",
@@ -947,7 +947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2335,
+      "line": 2337,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Automation deleted.",
       "surface": "android",
@@ -955,7 +955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2585,
+      "line": 2587,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Node offline. Reconnect and retry.",
       "surface": "android",
@@ -963,7 +963,7 @@
     },
     {
       "kind": "ui-named-argument-concatenated",
-      "line": 2596,
+      "line": 2598,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Restore canvas now for session=$sessionKey source=$source. If existing A2UI state exists, replay it immediately. If not, create and render a compact mobile-friendly dashboard in Canvas.",
       "surface": "android",
@@ -971,7 +971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2617,
+      "line": 2619,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed to request restore. Tap to retry.",
       "surface": "android",
@@ -979,7 +979,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2628,
+      "line": 2630,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "No canvas update yet. Tap to retry.",
       "surface": "android",
@@ -987,7 +987,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3701,
+      "line": 3707,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect to a Gateway to save wake words",
       "surface": "android",
@@ -995,7 +995,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3729,
+      "line": 3735,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Wake words saved",
       "surface": "android",
@@ -1003,7 +1003,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3738,
+      "line": 3744,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not save wake words",
       "surface": "android",
@@ -1011,7 +1011,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4449,
+      "line": 4455,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: no secure gateway endpoint was detected. Enable gateway TLS or Tailscale Serve, or use a trusted private LAN address with Unencrypted selected.",
       "surface": "android",
@@ -1019,7 +1019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4453,
+      "line": 4459,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: secure endpoint reached, but TLS fingerprint verification timed out. Check Tailscale Serve or gateway TLS and retry.",
       "surface": "android",
@@ -1027,7 +1027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4457,
+      "line": 4463,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "surface": "android",
@@ -1035,7 +1035,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 4507,
+      "line": 4513,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connecting…",
       "surface": "android",
@@ -1043,7 +1043,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 4717,
+      "line": 4723,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Offline",
       "surface": "android",
@@ -1051,7 +1051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5451,
+      "line": 5465,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load provider catalog.",
       "surface": "android",
@@ -1059,7 +1059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5482,
+      "line": 5496,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Update your Gateway to view provider model config.",
       "surface": "android",
@@ -1067,7 +1067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5484,
+      "line": 5498,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load provider model config.",
       "surface": "android",
@@ -1075,7 +1075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5500,
+      "line": 5514,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Provider models loaded, but readiness is unavailable.",
       "surface": "android",
@@ -1083,7 +1083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5587,
+      "line": 5601,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load automations.",
       "surface": "android",
@@ -1091,7 +1091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5673,
+      "line": 5687,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to inspect automations.",
       "surface": "android",
@@ -1099,7 +1099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5683,
+      "line": 5697,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway returned an invalid automation.",
       "surface": "android",
@@ -1107,7 +1107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5687,
+      "line": 5701,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load automation.",
       "surface": "android",
@@ -1115,7 +1115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5699,
+      "line": 5713,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to inspect automation run history.",
       "surface": "android",
@@ -1123,7 +1123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5730,
+      "line": 5744,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load automation run history.",
       "surface": "android",
@@ -1131,7 +1131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5747,
+      "line": 5761,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron changes require operator.admin access.",
       "surface": "android",
@@ -1139,7 +1139,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5756,
+      "line": 5770,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to manage automations.",
       "surface": "android",
@@ -1147,7 +1147,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5768,
+      "line": 5782,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Another cron action is still finishing.",
       "surface": "android",
@@ -1155,7 +1155,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5815,
+      "line": 5829,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron action failed.",
       "surface": "android",
@@ -1163,7 +1163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5942,
+      "line": 5956,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load usage.",
       "surface": "android",
@@ -1171,7 +1171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5977,
+      "line": 5991,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load skills.",
       "surface": "android",
@@ -1179,7 +1179,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5990,
+      "line": 6004,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to update skills.",
       "surface": "android",
@@ -1187,7 +1187,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 5994,
+      "line": 6008,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This gateway connection needs operator.admin to update skills.",
       "surface": "android",
@@ -1195,7 +1195,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6009,
+      "line": 6023,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not disable skill.",
       "surface": "android",
@@ -1203,7 +1203,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6009,
+      "line": 6023,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not enable skill.",
       "surface": "android",
@@ -1211,7 +1211,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6027,
+      "line": 6041,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to search ClawHub skills.",
       "surface": "android",
@@ -1219,7 +1219,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6073,
+      "line": 6087,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not search ClawHub skills.",
       "surface": "android",
@@ -1227,7 +1227,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6086,
+      "line": 6100,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to inspect ClawHub skills.",
       "surface": "android",
@@ -1235,7 +1235,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6119,
+      "line": 6133,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "ClawHub did not return an installable version for ${skill.slug}.",
       "surface": "android",
@@ -1243,7 +1243,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6135,
+      "line": 6149,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load ClawHub details for ${skill.slug}.",
       "surface": "android",
@@ -1251,7 +1251,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6151,
+      "line": 6165,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to install ClawHub skills.",
       "surface": "android",
@@ -1259,7 +1259,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6167,
+      "line": 6181,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This gateway connection needs operator.admin to install ClawHub skills.",
       "surface": "android",
@@ -1267,7 +1267,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 6257,
+      "line": 6271,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Installed $slug.",
       "surface": "android",
@@ -1275,7 +1275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6264,
+      "line": 6278,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not install ${slug} from ClawHub.",
       "surface": "android",
@@ -1283,7 +1283,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6304,
+      "line": 6318,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to load Skill Workshop proposals.",
       "surface": "android",
@@ -1291,7 +1291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6344,
+      "line": 6358,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load Skill Workshop proposals.",
       "surface": "android",
@@ -1299,7 +1299,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6364,
+      "line": 6378,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to inspect Skill Workshop proposals.",
       "surface": "android",
@@ -1307,7 +1307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6416,
+      "line": 6430,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not inspect Skill Workshop proposal.",
       "surface": "android",
@@ -1315,7 +1315,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6436,
+      "line": 6450,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Skill Workshop proposal actions require operator.admin scope.",
       "surface": "android",
@@ -1323,7 +1323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6441,
+      "line": 6455,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect the gateway to update Skill Workshop proposals.",
       "surface": "android",
@@ -1331,7 +1331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6631,
+      "line": 6645,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not verify the device pairing change. Refresh and try again.",
       "surface": "android",
@@ -1339,7 +1339,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 6713,
+      "line": 6727,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connected",
       "surface": "android",
@@ -1347,7 +1347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 6743,
+      "line": 6757,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load nodes and devices.",
       "surface": "android",
@@ -1355,7 +1355,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7401,
+      "line": 7415,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load channels.",
       "surface": "android",
@@ -1363,7 +1363,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7431,
+      "line": 7445,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load dreaming.",
       "surface": "android",
@@ -1371,7 +1371,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7468,
+      "line": 7482,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Could not load gateway logs.",
       "surface": "android",
@@ -1379,7 +1379,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7937,
+      "line": 7951,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "One time",
       "surface": "android",
@@ -1387,7 +1387,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7946,
+      "line": 7960,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Cron",
       "surface": "android",
@@ -1395,7 +1395,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7947,
+      "line": 7961,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Scheduled",
       "surface": "android",
@@ -1403,7 +1403,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7955,
+      "line": 7969,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Every ${days}d",
       "surface": "android",
@@ -1411,7 +1411,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7956,
+      "line": 7970,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Every ${hours}h",
       "surface": "android",
@@ -1419,7 +1419,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7957,
+      "line": 7971,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Every ${minutes}m",
       "surface": "android",
@@ -1427,7 +1427,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7958,
+      "line": 7972,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Repeating",
       "surface": "android",
@@ -1435,7 +1435,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7974,
+      "line": 7988,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "No prompt",
       "surface": "android",
@@ -1443,7 +1443,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7991,
+      "line": 8005,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway",
       "surface": "android",
@@ -1451,7 +1451,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 7999,
+      "line": 8013,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connected to $gatewayLabel",
       "surface": "android",
@@ -1459,7 +1459,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8000,
+      "line": 8014,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Your agents are ready",
       "surface": "android",
@@ -1467,7 +1467,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8002,
+      "line": 8016,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "This phone stays dormant until the gateway needs it, then wakes, syncs, and goes back to sleep.",
       "surface": "android",
@@ -1475,7 +1475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8006,
+      "line": 8020,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Selected on this phone",
       "surface": "android",
@@ -1483,7 +1483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8009,
+      "line": 8023,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "The overview refreshes on reconnect and when this screen opens.",
       "surface": "android",
@@ -1491,7 +1491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8014,
+      "line": 8028,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Reconnecting",
       "surface": "android",
@@ -1499,7 +1499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8015,
+      "line": 8029,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "OpenClaw is syncing back up",
       "surface": "android",
@@ -1507,7 +1507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8017,
+      "line": 8031,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "The gateway session is coming back online. Agent shortcuts should settle automatically in a moment.",
       "surface": "android",
@@ -1515,7 +1515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8021,
+      "line": 8035,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Gateway session in progress",
       "surface": "android",
@@ -1523,7 +1523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8024,
+      "line": 8038,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "If the gateway is reachable, reconnect should complete without intervention.",
       "surface": "android",
@@ -1531,7 +1531,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8029,
+      "line": 8043,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Welcome to OpenClaw",
       "surface": "android",
@@ -1539,7 +1539,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8030,
+      "line": 8044,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Your phone stays quiet until it is needed",
       "surface": "android",
@@ -1547,7 +1547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8032,
+      "line": 8046,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Pair this device to your gateway to wake it only for real work, keep a live agent overview handy, and avoid battery-draining background loops.",
       "surface": "android",
@@ -1555,7 +1555,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8036,
+      "line": 8050,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Connect to load your agents",
       "surface": "android",
@@ -1563,7 +1563,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8039,
+      "line": 8053,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "When connected, the gateway can wake the phone with a silent push instead of holding an always-on session.",
       "surface": "android",
@@ -1571,7 +1571,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8071,
+      "line": 8085,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Main",
       "surface": "android",
@@ -1579,7 +1579,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8086,
+      "line": 8100,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Active on this phone",
       "surface": "android",
@@ -1587,7 +1587,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8087,
+      "line": 8101,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Default agent",
       "surface": "android",
@@ -1595,7 +1595,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8088,
+      "line": 8102,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Ready",
       "surface": "android",
@@ -1603,7 +1603,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 8743,
+      "line": 8757,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Dream",
       "surface": "android",
@@ -1779,7 +1779,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1053,
+      "line": 1770,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Wait for the current response to finish before starting a new chat.",
       "surface": "android",
@@ -1787,7 +1787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1186,
+      "line": 1903,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Could not update model.",
       "surface": "android",
@@ -1795,7 +1795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1251,
+      "line": 1968,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Could not update thinking level.",
       "surface": "android",
@@ -1803,7 +1803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1744,
+      "line": 2479,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Chat failed before the run started; try again.",
       "surface": "android",
@@ -1811,7 +1811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3198,
+      "line": 3990,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Could not stage an attachment for sending.",
       "surface": "android",
@@ -1819,7 +1819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3231,
+      "line": 4023,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Offline queue is full ($OUTBOX_MAX_QUEUED messages); delete queued items first.",
       "surface": "android",
@@ -1827,7 +1827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3237,
+      "line": 4029,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Attachments are too large to queue for one message; remove some and try again.",
       "surface": "android",
@@ -1835,7 +1835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3243,
+      "line": 4035,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Offline attachment storage is full; delete queued items first.",
       "surface": "android",
@@ -1843,7 +1843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3248,
+      "line": 4040,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Gateway health not OK; cannot send",
       "surface": "android",
@@ -1851,7 +1851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3255,
+      "line": 4047,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Could not queue message for later delivery.",
       "surface": "android",
@@ -1859,7 +1859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 3972,
+      "line": 4950,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Chat failed",
       "surface": "android",
@@ -1867,7 +1867,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4110,
+      "line": 5166,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Event stream interrupted; try refreshing.",
       "surface": "android",
@@ -1875,7 +1875,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4247,
+      "line": 5303,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Timed out waiting for a reply; try again or refresh.",
       "surface": "android",
@@ -1883,7 +1883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 4457,
+      "line": 5513,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt",
       "source": "Timed out confirming the sent message; refresh to check delivery.",
       "surface": "android",
@@ -12011,7 +12011,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 73,
+      "line": 76,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageActions.kt",
       "source": "Message actions",
       "surface": "android",
@@ -12019,7 +12019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 82,
+      "line": 85,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageActions.kt",
       "source": "Listen",
       "surface": "android",
@@ -12027,7 +12027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 82,
+      "line": 85,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageActions.kt",
       "source": "Stop",
       "surface": "android",
@@ -12035,7 +12035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 87,
+      "line": 90,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageActions.kt",
       "source": "Copy",
       "surface": "android",
@@ -12043,7 +12043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 95,
+      "line": 98,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageActions.kt",
       "source": "Share",
       "surface": "android",
@@ -12051,7 +12051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 99,
+      "line": 102,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageActions.kt",
       "source": "Reply",
       "surface": "android",
@@ -12059,7 +12059,23 @@
     },
     {
       "kind": "ui-call",
-      "line": 109,
+      "line": 108,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageActions.kt",
+      "source": "Rewind to here",
+      "surface": "android",
+      "id": "native.android.6c07db7bdc4b43a4"
+    },
+    {
+      "kind": "ui-call",
+      "line": 114,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageActions.kt",
+      "source": "Fork from here",
+      "surface": "android",
+      "id": "native.android.c824bdc38278a218"
+    },
+    {
+      "kind": "ui-call",
+      "line": 126,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageActions.kt",
       "source": "Select text",
       "surface": "android",
@@ -12067,7 +12083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 125,
+      "line": 142,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageActions.kt",
       "source": "Done",
       "surface": "android",
@@ -12075,7 +12091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 146,
+      "line": 163,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageActions.kt",
       "source": "Message copied",
       "surface": "android",
@@ -12083,7 +12099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 157,
+      "line": 174,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageActions.kt",
       "source": "Share message",
       "surface": "android",
@@ -12091,7 +12107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 161,
+      "line": 178,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageActions.kt",
       "source": "No app can share this message",
       "surface": "android",
@@ -12099,7 +12115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 172,
+      "line": 180,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Preparing audio…",
       "surface": "android",
@@ -12107,7 +12123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 172,
+      "line": 180,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Speaking…",
       "surface": "android",
@@ -12115,7 +12131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 279,
+      "line": 287,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Preview · $domain",
       "surface": "android",
@@ -12123,7 +12139,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 288,
+      "line": 296,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Expand link preview",
       "surface": "android",
@@ -12131,7 +12147,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 331,
+      "line": 339,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Loading preview…",
       "surface": "android",
@@ -12139,7 +12155,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 332,
+      "line": 340,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "No preview available",
       "surface": "android",
@@ -12147,7 +12163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 379,
+      "line": 387,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Working",
       "surface": "android",
@@ -12155,7 +12171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 389,
+      "line": 397,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "· $phrase",
       "surface": "android",
@@ -12163,7 +12179,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 406,
+      "line": 414,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Tools",
       "surface": "android",
@@ -12171,7 +12187,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 409,
+      "line": 417,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Running tools...",
       "surface": "android",
@@ -12179,7 +12195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 413,
+      "line": 421,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "${display.emoji} ${display.label}",
       "surface": "android",
@@ -12187,7 +12203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 430,
+      "line": 438,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "... +${toolCalls.size - 6} more",
       "surface": "android",
@@ -12195,7 +12211,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 451,
+      "line": 459,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Queued — sends when reconnected",
       "surface": "android",
@@ -12203,7 +12219,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 452,
+      "line": 460,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Sending…",
       "surface": "android",
@@ -12211,7 +12227,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 453,
+      "line": 461,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Sent — confirming delivery…",
       "surface": "android",
@@ -12219,15 +12235,15 @@
     },
     {
       "kind": "ui-call",
-      "line": 458,
+      "line": 469,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
-      "source": "Failed",
+      "source": "Session branch changed; review and retry this message.",
       "surface": "android",
-      "id": "native.android.15d71d54c0ce946b"
+      "id": "native.android.ac5949efe3cfe48c"
     },
     {
       "kind": "ui-call",
-      "line": 458,
+      "line": 473,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Failed — $it",
       "surface": "android",
@@ -12235,7 +12251,15 @@
     },
     {
       "kind": "ui-call",
-      "line": 462,
+      "line": 474,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
+      "source": "Failed",
+      "surface": "android",
+      "id": "native.android.15d71d54c0ce946b"
+    },
+    {
+      "kind": "ui-call",
+      "line": 478,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "user",
       "surface": "android",
@@ -12243,7 +12267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 470,
+      "line": 486,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "📎 ${attachment.fileName}",
       "surface": "android",
@@ -12251,7 +12275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 486,
+      "line": 502,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Retry",
       "surface": "android",
@@ -12259,7 +12283,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 491,
+      "line": 507,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Delete",
       "surface": "android",
@@ -12267,7 +12291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 522,
+      "line": 538,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "assistant",
       "surface": "android",
@@ -12275,7 +12299,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 523,
+      "line": 539,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "OpenClaw · Live",
       "surface": "android",
@@ -12283,7 +12307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 559,
+      "line": 575,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "You",
       "surface": "android",
@@ -12291,7 +12315,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 560,
+      "line": 576,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "System",
       "surface": "android",
@@ -12299,7 +12323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 561,
+      "line": 577,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "OpenClaw",
       "surface": "android",
@@ -12307,7 +12331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 584,
+      "line": 600,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Attachment",
       "surface": "android",
@@ -12315,7 +12339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 597,
+      "line": 613,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Open image preview",
       "surface": "android",
@@ -12323,7 +12347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 615,
+      "line": 631,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Image preview",
       "surface": "android",
@@ -12331,7 +12355,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 629,
+      "line": 645,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Close image preview",
       "surface": "android",
@@ -12339,7 +12363,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 638,
+      "line": 654,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Unsupported attachment",
       "surface": "android",
@@ -12419,7 +12443,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 374,
+      "line": 394,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Model",
       "surface": "android",
@@ -12427,7 +12451,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 497,
+      "line": 517,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Some shared images were omitted or could not be added.",
       "surface": "android",
@@ -12435,7 +12459,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 639,
+      "line": 667,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat needs attention",
       "surface": "android",
@@ -12443,7 +12467,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 927,
+      "line": 1001,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "All",
       "surface": "android",
@@ -12451,7 +12475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1010,
+      "line": 1088,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Working",
       "surface": "android",
@@ -12459,7 +12483,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1011,
+      "line": 1089,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Ready",
       "surface": "android",
@@ -12467,7 +12491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1012,
+      "line": 1090,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Offline",
       "surface": "android",
@@ -12475,7 +12499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1025,
+      "line": 1103,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat actions",
       "surface": "android",
@@ -12483,7 +12507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1030,
+      "line": 1108,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Refresh chat",
       "surface": "android",
@@ -12491,7 +12515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1038,
+      "line": 1127,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Dashboard",
       "surface": "android",
@@ -12499,7 +12523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1046,
+      "line": 1135,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Background tasks",
       "surface": "android",
@@ -12507,7 +12531,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1067,
+      "line": 1156,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat",
       "surface": "android",
@@ -12515,7 +12539,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1237,
+      "line": 1333,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Messages to recover",
       "surface": "android",
@@ -12523,7 +12547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1239,
+      "line": 1335,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "${item.count} message(s) need recovery. Re-enter anything you want to keep, then delete these rows.",
       "surface": "android",
@@ -12531,7 +12555,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1273,
+      "line": 1373,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Loading thread",
       "surface": "android",
@@ -12539,7 +12563,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1306,
+      "line": 1406,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Jump to latest",
       "surface": "android",
@@ -12547,7 +12571,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1385,
+      "line": 1485,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Ready when you are",
       "surface": "android",
@@ -12555,7 +12579,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1389,
+      "line": 1489,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Start with a prompt, or use voice.",
       "surface": "android",
@@ -12563,7 +12587,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1391,
+      "line": 1491,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Use the recovery options below to reconnect.",
       "surface": "android",
@@ -12571,7 +12595,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1393,
+      "line": 1493,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat is checking Gateway health.",
       "surface": "android",
@@ -12579,7 +12603,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1416,
+      "line": 1516,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Fix connection",
       "surface": "android",
@@ -12587,7 +12611,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1417,
+      "line": 1517,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Copy diagnostics",
       "surface": "android",
@@ -12595,7 +12619,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1476,
+      "line": 1576,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Catch me up",
       "surface": "android",
@@ -12603,7 +12627,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1477,
+      "line": 1577,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Summarize recent threads and next steps.",
       "surface": "android",
@@ -12611,7 +12635,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1478,
+      "line": 1578,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Catch me up on my recent OpenClaw threads and suggest next steps.",
       "surface": "android",
@@ -12619,7 +12643,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1482,
+      "line": 1582,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Plan the work",
       "surface": "android",
@@ -12627,7 +12651,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1483,
+      "line": 1583,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Turn a goal into an actionable checklist.",
       "surface": "android",
@@ -12635,7 +12659,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1484,
+      "line": 1584,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Help me turn this goal into a practical checklist: ",
       "surface": "android",
@@ -12643,7 +12667,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1488,
+      "line": 1588,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Use this phone",
       "surface": "android",
@@ -12651,7 +12675,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1489,
+      "line": 1589,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Ask OpenClaw to use Android capabilities.",
       "surface": "android",
@@ -12659,7 +12683,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1490,
+      "line": 1590,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "What can you help me do from this phone right now?",
       "surface": "android",
@@ -12667,7 +12691,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1557,
+      "line": 1664,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw · Live",
       "surface": "android",
@@ -12675,7 +12699,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1558,
+      "line": 1665,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "You",
       "surface": "android",
@@ -12683,7 +12707,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1559,
+      "line": 1666,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "System",
       "surface": "android",
@@ -12691,7 +12715,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1560,
+      "line": 1667,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw",
       "surface": "android",
@@ -12699,7 +12723,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1642,
+      "line": 1749,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Preparing audio…",
       "surface": "android",
@@ -12707,7 +12731,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1642,
+      "line": 1749,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Speaking…",
       "surface": "android",
@@ -12715,7 +12739,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1673,
+      "line": 1780,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Close",
       "surface": "android",
@@ -12723,7 +12747,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1673,
+      "line": 1780,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "View all",
       "surface": "android",
@@ -12731,7 +12755,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1703,
+      "line": 1810,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Tools running",
       "surface": "android",
@@ -12739,7 +12763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1705,
+      "line": 1812,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw is working",
       "surface": "android",
@@ -12747,7 +12771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1708,
+      "line": 1815,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "+${toolCalls.size - 4} more",
       "surface": "android",
@@ -12755,7 +12779,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1774,
+      "line": 1881,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "$completedCount/${steps.size}",
       "surface": "android",
@@ -12763,7 +12787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1781,
+      "line": 1888,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Collapse plan checklist",
       "surface": "android",
@@ -12771,7 +12795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1781,
+      "line": 1888,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Expand plan checklist",
       "surface": "android",
@@ -12779,7 +12803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1913,
+      "line": 2020,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Dismiss shared-image warning",
       "surface": "android",
@@ -12787,7 +12811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2016,
+      "line": 2123,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Stop",
       "surface": "android",
@@ -12795,7 +12819,55 @@
     },
     {
       "kind": "ui-call",
-      "line": 2114,
+      "line": 2210,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "Switch branch",
+      "surface": "android",
+      "id": "native.android.be42506226307680"
+    },
+    {
+      "kind": "ui-call",
+      "line": 2234,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "Untitled branch",
+      "surface": "android",
+      "id": "native.android.39ea147abba2af8a"
+    },
+    {
+      "kind": "ui-call",
+      "line": 2249,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "Current branch",
+      "surface": "android",
+      "id": "native.android.4e2cbf557e2e3cd6"
+    },
+    {
+      "kind": "ui-call",
+      "line": 2261,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "$count messages",
+      "surface": "android",
+      "id": "native.android.72ad7c7cb98ed70d"
+    },
+    {
+      "kind": "ui-call",
+      "line": 2261,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "1 message",
+      "surface": "android",
+      "id": "native.android.a19751c49ae4a6f9"
+    },
+    {
+      "kind": "ui-call",
+      "line": 2269,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "$count · $updated",
+      "surface": "android",
+      "id": "native.android.76e548dffafc9de9"
+    },
+    {
+      "kind": "ui-call",
+      "line": 2298,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Default",
       "surface": "android",
@@ -12803,7 +12875,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2180,
+      "line": 2364,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Pin model",
       "surface": "android",
@@ -12811,7 +12883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2180,
+      "line": 2364,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Unpin model",
       "surface": "android",
@@ -12819,7 +12891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2197,
+      "line": 2381,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "No commands found",
       "surface": "android",
@@ -12827,7 +12899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2239,
+      "line": 2423,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Command",
       "surface": "android",
@@ -12835,7 +12907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2259,
+      "line": 2443,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Gateway offline",
       "surface": "android",
@@ -12843,7 +12915,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2305,
+      "line": 2489,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Close thinking level selector",
       "surface": "android",
@@ -12851,7 +12923,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2305,
+      "line": 2489,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Open thinking level selector",
       "surface": "android",
@@ -12859,7 +12931,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2370,
+      "line": 2554,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Attach image",
       "surface": "android",
@@ -12867,7 +12939,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2375,
+      "line": 2559,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Attachment",
       "surface": "android",
@@ -12875,7 +12947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2406,
+      "line": 2590,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Message OpenClaw",
       "surface": "android",
@@ -12883,7 +12955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2435,
+      "line": 2619,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "End Talk",
       "surface": "android",
@@ -12891,7 +12963,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2435,
+      "line": 2619,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Start Talk",
       "surface": "android",
@@ -12899,7 +12971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2520,
+      "line": 2704,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Voice note · ${formatVoiceNoteDuration(duration)}",
       "surface": "android",
@@ -12907,7 +12979,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2529,
+      "line": 2713,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Remove attachment",
       "surface": "android",
@@ -12915,7 +12987,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2541,
+      "line": 2725,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "New chat",
       "surface": "android",
@@ -12923,7 +12995,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2550,
+      "line": 2734,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Main",
       "surface": "android",
@@ -12931,7 +13003,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2551,
+      "line": 2735,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Current",
       "surface": "android",
@@ -12939,7 +13011,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2558,
+      "line": 2742,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "$emoji $name",
       "surface": "android",
@@ -12947,7 +13019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2617,
+      "line": 2801,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Send",
       "surface": "android",
@@ -12955,7 +13027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2628,
+      "line": 2812,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat is still checking Gateway health.",
       "surface": "android",
@@ -12963,7 +13035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2629,
+      "line": 2813,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Gateway is offline. Fix the connection below or copy diagnostics.",
       "surface": "android",
@@ -12971,7 +13043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2630,
+      "line": 2814,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Gateway authentication needs attention.",
       "surface": "android",
@@ -12979,7 +13051,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2649,
+      "line": 2833,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Context ${(it * 100).roundToInt()}%",
       "surface": "android",
@@ -12987,7 +13059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2650,
+      "line": 2834,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Context --",
       "surface": "android",
@@ -12995,7 +13067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2651,
+      "line": 2835,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "$contextLabel · ${contextMeterThinkingLabel(thinkingLevel)}",
       "surface": "android",
@@ -13003,7 +13075,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2690,
+      "line": 2874,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Off",
       "surface": "android",
@@ -13011,7 +13083,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2691,
+      "line": 2875,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Minimal",
       "surface": "android",
@@ -13019,7 +13091,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2692,
+      "line": 2876,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Low",
       "surface": "android",
@@ -13027,7 +13099,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2693,
+      "line": 2877,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Medium",
       "surface": "android",
@@ -13035,7 +13107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2694,
+      "line": 2878,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "High",
       "surface": "android",
@@ -13043,7 +13115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2695,
+      "line": 2879,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Xhigh",
       "surface": "android",
@@ -13051,7 +13123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2696,
+      "line": 2880,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Adaptive",
       "surface": "android",
@@ -13059,7 +13131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 2697,
+      "line": 2881,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Max",
       "surface": "android",

--- a/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
@@ -15,6 +15,8 @@ import ai.openclaw.app.chat.ChatWidgetResource
 import ai.openclaw.app.chat.GatewayDefaultAgentOwner
 import ai.openclaw.app.chat.MessageSpeechState
 import ai.openclaw.app.chat.OutgoingAttachment
+import ai.openclaw.app.chat.SessionBranch
+import ai.openclaw.app.chat.SessionRewindResult
 import ai.openclaw.app.chat.defaultChatThinkingLevelSelection
 import ai.openclaw.app.chat.resolveChatComposerOwner
 import ai.openclaw.app.gateway.GatewayEndpoint
@@ -71,6 +73,8 @@ internal data class ChatDraft(
   val text: String,
   val placement: ChatDraftPlacement,
   val owner: ChatComposerOwner? = null,
+  val expectedExistingText: String? = null,
+  val acceptsEmptyText: Boolean = false,
 )
 
 internal fun claimChatDraftForOwner(
@@ -633,9 +637,13 @@ class MainViewModel private constructor(
   val chatQuestions: StateFlow<List<ChatQuestionPrompt>> = runtimeState(initial = emptyList()) { it.chatQuestions }
   val chatPlanSteps: StateFlow<List<ChatPlanStep>> = runtimeState(initial = emptyList()) { it.chatPlanSteps }
   val chatSessions: StateFlow<List<ChatSessionEntry>> = runtimeState(initial = emptyList()) { it.chatSessions }
+  val chatSessionBranches: StateFlow<List<SessionBranch>> = runtimeState(initial = emptyList()) { it.chatSessionBranches }
+  val chatSessionBranchesLoading: StateFlow<Boolean> = runtimeState(initial = false) { it.chatSessionBranchesLoading }
+  val chatSessionBranchSwitching: StateFlow<Boolean> = runtimeState(initial = false) { it.chatSessionBranchSwitching }
   val pendingRunCount: StateFlow<Int> = runtimeState(initial = 0) { it.pendingRunCount }
   val chatCommands: StateFlow<List<ChatCommandEntry>> = runtimeState(initial = emptyList<ChatCommandEntry>()) { it.chatCommands }
   val chatOutboxItems: StateFlow<List<ChatOutboxItem>> = runtimeState(initial = emptyList()) { it.chatOutboxItems }
+  val chatOutboxPresentationRestored: StateFlow<Boolean> = runtimeState(initial = false) { it.chatOutboxPresentationRestored }
   internal val chatMessageSpeech: StateFlow<MessageSpeechState?> =
     runtimeState(initial = null) { it.messageSpeechState }
   val execApprovals: StateFlow<List<GatewayExecApprovalSummary>> = runtimeState(initial = emptyList()) { it.execApprovals }
@@ -981,7 +989,7 @@ class MainViewModel private constructor(
       claimed
     }
 
-  private fun setChatDraft(value: ChatDraft?) {
+  internal fun setChatDraft(value: ChatDraft?) {
     synchronized(chatDraftLock) {
       chatDraftState.value = value
     }
@@ -1565,6 +1573,14 @@ class MainViewModel private constructor(
     parentKey: String,
     ownerAgentId: String? = null,
   ): String? = ensureRuntime().forkChatSession(parentKey, ownerAgentId)
+
+  suspend fun rewindChatAtEntry(entryId: String): SessionRewindResult? = ensureRuntime().rewindChatAtEntry(entryId)
+
+  suspend fun forkChatAtEntry(entryId: String): Pair<String, String?>? = ensureRuntime().forkChatAtEntry(entryId)
+
+  suspend fun refreshChatSessionBranches(): Boolean = ensureRuntime().refreshChatSessionBranches()
+
+  suspend fun switchChatSessionBranch(leafEntryId: String): Boolean = ensureRuntime().switchChatSessionBranch(leafEntryId)
 
   suspend fun listWorkspaceFiles(
     path: String?,

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -27,6 +27,8 @@ import ai.openclaw.app.chat.MessageSpeechClient
 import ai.openclaw.app.chat.MessageSpeechController
 import ai.openclaw.app.chat.MessageSpeechState
 import ai.openclaw.app.chat.OutgoingAttachment
+import ai.openclaw.app.chat.SessionBranch
+import ai.openclaw.app.chat.SessionRewindResult
 import ai.openclaw.app.chat.SystemSpeechSpeaker
 import ai.openclaw.app.gateway.DeviceAuthEntry
 import ai.openclaw.app.gateway.DeviceAuthStore
@@ -2742,9 +2744,13 @@ class NodeRuntime private constructor(
   val chatQuestions: StateFlow<List<ChatQuestionPrompt>> = chat.questions
   val chatPlanSteps: StateFlow<List<ChatPlanStep>> = chat.planSteps
   val chatSessions: StateFlow<List<ChatSessionEntry>> = chat.sessions
+  val chatSessionBranches: StateFlow<List<SessionBranch>> = chat.sessionBranches
+  val chatSessionBranchesLoading: StateFlow<Boolean> = chat.sessionBranchesLoading
+  val chatSessionBranchSwitching: StateFlow<Boolean> = chat.sessionBranchSwitching
   val pendingRunCount: StateFlow<Int> = chat.pendingRunCount
   val chatCommands: StateFlow<List<ChatCommandEntry>> = chat.commands
   val chatOutboxItems: StateFlow<List<ChatOutboxItem>> = chat.outboxItems
+  val chatOutboxPresentationRestored: StateFlow<Boolean> = chat.outboxPresentationRestored
 
   suspend fun listBackgroundTasks(agentId: String): List<BackgroundTask> = chat.listBackgroundTasks(agentId)
 
@@ -4917,6 +4923,14 @@ class NodeRuntime private constructor(
     parentKey: String,
     ownerAgentId: String? = null,
   ): String? = chat.forkSession(parentKey, ownerAgentId)
+
+  suspend fun rewindChatAtEntry(entryId: String): SessionRewindResult? = chat.rewindSessionAtEntryResult(chatSessionKey.value, entryId)
+
+  suspend fun forkChatAtEntry(entryId: String): Pair<String, String?>? = chat.forkSessionAtEntry(chatSessionKey.value, entryId)
+
+  suspend fun refreshChatSessionBranches(): Boolean = chat.refreshSessionBranches()
+
+  suspend fun switchChatSessionBranch(leafEntryId: String): Boolean = chat.switchSessionBranch(chatSessionKey.value, leafEntryId)
 
   fun setChatThinkingLevel(level: String) {
     chat.setThinkingLevel(level)

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatCommandOutbox.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatCommandOutbox.kt
@@ -32,6 +32,12 @@ internal const val OUTBOX_CONNECTION_CHANGED_ERROR = "connection changed before 
 /** Owner-less migrated rows stay parked because their original default agent cannot be proven. */
 internal const val OUTBOX_OWNER_CHANGED_ERROR = "chat owner changed before this message was sent; retry from the original chat"
 
+/** User-visible reason for rows parked when their transcript branch loses ownership. */
+internal const val OUTBOX_BRANCH_CHANGED_ERROR = "Session branch changed; review and retry this message."
+
+private const val OUTBOX_BRANCH_PARK_MARKER = "\n# branch-park:"
+private const val OUTBOX_BRANCH_SWITCH_LEASE_MS = 5L * 60L * 1000L
+
 /**
  * gatedEpoch sentinel for rows migrated from schemas without epochs: it matches no live
  * connection generation, so legacy command-shaped rows park instead of auto-replaying.
@@ -98,7 +104,41 @@ data class ChatOutboxItem(
   // follow the gateway's mutable default agent and can cross owners after process restart.
   val ownerAgentId: String?,
   val attachments: List<ChatOutboxAttachment> = emptyList(),
+  /** Immutable ownership token for the current delivery decision. */
+  val attemptVersion: Int = 1,
+  /** Transcript branch generation captured atomically at enqueue/retry. */
+  val branchEpoch: Int = 0,
+  /** Current scope generation observed with this row snapshot. */
+  val scopeBranchEpoch: Int = branchEpoch,
+  /** True when a parked delivery may already have reached the gateway. */
+  val parkedWasAccepted: Boolean = false,
+  /** Preserves ambiguous transport evidence across later branch parking. */
+  val hadUnacknowledgedSend: Boolean = false,
 )
+
+/** Durable branch ownership uses the same session+agent scope as outbox delivery. */
+data class ChatOutboxScope(
+  val sessionKey: String,
+  val ownerAgentId: String,
+)
+
+/** Snapshot captured before history/bootstrap can advance the active transcript tip. */
+data class ChatOutboxBranchState(
+  val epoch: Int,
+  val lastActiveLeafEntryId: String?,
+  val hadPendingCommands: Boolean,
+  val hadDeliverableCommands: Boolean = hadPendingCommands,
+  val switchPendingSinceMs: Long?,
+  val needsReconciliation: Boolean,
+  val revision: Int,
+)
+
+data class ChatOutboxMutationLease(
+  val revision: Int,
+  val startedAtMs: Long,
+)
+
+internal fun chatOutboxDisplayError(lastError: String?): String? = lastError?.substringBefore(OUTBOX_BRANCH_PARK_MARKER)
 
 /** Attachment bytes captured at enqueue time; stored as binary chunks, never base64 at rest. */
 class OutboxAttachmentPayload(
@@ -143,6 +183,9 @@ sealed interface ChatOutboxEnqueueResult {
  * switch cannot re-scope rows mid-operation.
  */
 interface ChatCommandOutbox {
+  val supportsBranchCoordination: Boolean
+    get() = false
+
   /** All rows for [gatewayId] with attachment metadata, strictly createdAt-ordered. */
   suspend fun load(gatewayId: String): List<ChatOutboxItem>
 
@@ -172,6 +215,16 @@ interface ChatCommandOutbox {
     lastError: String?,
   ): Int
 
+  /** Attempt-scoped transition; stale delivery callbacks must update nothing. */
+  suspend fun updateStatusIfAttempt(
+    id: String,
+    expectedAttemptVersion: Int,
+    status: ChatOutboxStatus,
+    retryCount: Int,
+    lastError: String?,
+    expectedStatus: ChatOutboxStatus? = null,
+  ): Int = updateStatus(id, status, retryCount, lastError)
+
   /**
    * Atomically claims a queued row for one dispatch (queued -> sending). Returns 0 when the row
    * vanished or another dispatcher already claimed it, so the direct-send path and the flush
@@ -182,6 +235,13 @@ interface ChatCommandOutbox {
     retryCount: Int,
     lastError: String?,
   ): Int
+
+  suspend fun claimForSendingIfAttempt(
+    id: String,
+    expectedAttemptVersion: Int,
+    retryCount: Int,
+    lastError: String?,
+  ): Int = claimForSending(id, retryCount, lastError)
 
   /**
    * Pins a row enqueued under the pre-hello "main" alias to the canonical session key it first
@@ -209,6 +269,19 @@ interface ChatCommandOutbox {
     ownerAgentId: String? = null,
   ): Int
 
+  /** Retries only the failure version displayed to the user and may mint a fresh client id. */
+  suspend fun requeueForRetryIfCurrent(
+    gatewayId: String,
+    id: String,
+    expectedAttemptVersion: Int,
+    expectedRetryCount: Int,
+    expectedLastError: String?,
+    nowMs: Long,
+    gatedEpoch: Long?,
+    ownerAgentId: String? = null,
+    replacementId: String? = null,
+  ): Int = requeueForRetry(gatewayId, id, nowMs, gatedEpoch, ownerAgentId)
+
   suspend fun delete(id: String)
 
   /** Deletes only an undispatched row; false means another lane already claimed or retired it. */
@@ -216,6 +289,66 @@ interface ChatCommandOutbox {
 
   /** Retires rows proven delivered by canonical history; returns how many rows were removed. */
   suspend fun confirmDelivered(ids: Set<String>): Int
+
+  /** Canonical history confirmation for the currently observed delivery attempts. */
+  suspend fun confirmDeliveredAttempts(ids: Map<String, Int>): Int = confirmDelivered(ids.keys)
+
+  suspend fun branchState(
+    gatewayId: String,
+    scope: ChatOutboxScope,
+  ): ChatOutboxBranchState? = null
+
+  /** Installs the session-mutation lease only when this scope has no unconfirmed delivery. */
+  suspend fun beginSessionMutation(
+    gatewayId: String,
+    scope: ChatOutboxScope,
+    nowMs: Long,
+  ): ChatOutboxMutationLease? = null
+
+  suspend fun cancelSessionMutation(
+    gatewayId: String,
+    scope: ChatOutboxScope,
+    lease: ChatOutboxMutationLease,
+  ): Boolean = false
+
+  suspend fun demoteSessionMutationToReconciliation(
+    gatewayId: String,
+    scope: ChatOutboxScope,
+    lease: ChatOutboxMutationLease? = null,
+  ): Boolean = false
+
+  /** Demotes and returns the same-transaction baseline used to classify later enqueues. */
+  suspend fun demoteSessionMutationToReconciliationState(
+    gatewayId: String,
+    scope: ChatOutboxScope,
+    lease: ChatOutboxMutationLease? = null,
+  ): ChatOutboxBranchState? = null
+
+  suspend fun updateLastActiveLeafEntryId(
+    gatewayId: String,
+    scope: ChatOutboxScope,
+    leafEntryId: String,
+    expectedEpoch: Int,
+    expectedRevision: Int,
+  ): Boolean = false
+
+  suspend fun reconcileBranchScope(
+    gatewayId: String,
+    scope: ChatOutboxScope,
+    previousState: ChatOutboxBranchState,
+    activeLeafEntryId: String?,
+    branchLeafEntryIds: Set<String>,
+    activeTranscriptEntryIds: Set<String>,
+    lastError: String,
+  ): Boolean = false
+
+  suspend fun confirmBranchChange(
+    gatewayId: String,
+    scope: ChatOutboxScope,
+    activeLeafEntryId: String?,
+    lastError: String,
+    lease: ChatOutboxMutationLease? = null,
+  ): Boolean = false
 
   /** Drops queued commands for a deleted session so they cannot send into a dead session. */
   suspend fun deleteForSession(
@@ -329,6 +462,9 @@ internal interface ChatOutboxDao {
   // id tiebreak keeps flush order deterministic when two rows share a createdAt millisecond.
   @Query("SELECT * FROM outbox_commands WHERE gatewayId = :gatewayId ORDER BY createdAtMs ASC, id ASC")
   suspend fun commands(gatewayId: String): List<OutboxCommandEntity>
+
+  @Query("SELECT * FROM outbox_commands WHERE id = :id")
+  suspend fun command(id: String): OutboxCommandEntity?
 
   @Query(
     "SELECT id FROM outbox_commands WHERE gatewayId = :gatewayId AND sessionKey = :sessionKey " +
@@ -491,6 +627,12 @@ internal interface ChatOutboxDao {
 
   @Query("DELETE FROM outbox_attachments WHERE commandId = :commandId")
   suspend fun deleteAttachmentsForCommand(commandId: String)
+
+  @Query("UPDATE outbox_attachments SET commandId = :replacementId WHERE commandId = :commandId")
+  suspend fun replaceAttachmentCommandId(
+    commandId: String,
+    replacementId: String,
+  )
 }
 
 /**
@@ -502,13 +644,36 @@ internal interface ChatOutboxDao {
 class RoomChatCommandOutbox internal constructor(
   private val database: ClientStateDatabase,
 ) : ChatCommandOutbox {
+  override val supportsBranchCoordination: Boolean = true
+
+  internal data class DeliveryState(
+    val attemptVersion: Int,
+    val branchEpoch: Int,
+    val parkedWasAccepted: Boolean,
+    val hadUnacknowledgedSend: Boolean,
+  )
+
   override suspend fun load(gatewayId: String): List<ChatOutboxItem> {
     val gateway = scopedGatewayId(gatewayId) ?: return emptyList()
-    val dao = database.outboxDao()
-    val rows = dao.commands(gateway)
-    if (rows.isEmpty()) return emptyList()
-    val attachmentsByCommand = dao.attachmentsForCommands(rows.map { it.id }).groupBy { it.commandId }
-    return rows.map { row -> row.toItem(attachmentsByCommand[row.id].orEmpty()) }
+    return database.withTransaction {
+      ensureBranchStorageLocked()
+      val dao = database.outboxDao()
+      val rows = dao.commands(gateway)
+      if (rows.isEmpty()) return@withTransaction emptyList()
+      val attachmentsByCommand = dao.attachmentsForCommands(rows.map { it.id }).groupBy { it.commandId }
+      rows.map { row ->
+        val scope = row.branchScope()
+        ensureBranchScopeLocked(gateway, scope)
+        ensureDeliveryStateLocked(row.id, gateway, scope)
+        val delivery = checkNotNull(readDeliveryStateLocked(row.id))
+        val branch = checkNotNull(readBranchStateLocked(gateway, scope))
+        row.toItem(
+          attachments = attachmentsByCommand[row.id].orEmpty(),
+          deliveryState = delivery,
+          scopeBranchEpoch = branch.epoch,
+        )
+      }
+    }
   }
 
   override suspend fun wasAdmitted(id: String): Boolean {
@@ -529,7 +694,7 @@ class RoomChatCommandOutbox internal constructor(
   ): ChatOutboxEnqueueResult {
     val gateway = scopedGatewayId(gatewayId) ?: return ChatOutboxEnqueueResult.Unavailable
     val key = sessionKey.trim().takeIf { it.isNotEmpty() } ?: return ChatOutboxEnqueueResult.Unavailable
-    val owner = ownerAgentId.trim().takeIf { it.isNotEmpty() } ?: return ChatOutboxEnqueueResult.Unavailable
+    val owner = normalizedOutboxOwnerAgentId(ownerAgentId) ?: return ChatOutboxEnqueueResult.Unavailable
     val attachmentBytes = attachments.sumOf { it.bytes.size.toLong() }
     if (attachmentBytes > OUTBOX_MAX_COMMAND_ATTACHMENT_BYTES) {
       return ChatOutboxEnqueueResult.AttachmentsTooLarge
@@ -540,6 +705,7 @@ class RoomChatCommandOutbox internal constructor(
     // bound counts every row (failed included) so total storage stays capped; failed rows are
     // user-visible and deletable, so a full queue is always recoverable from the UI.
     return database.withTransaction {
+      ensureBranchStorageLocked()
       if (dao.count(gateway) >= OUTBOX_MAX_QUEUED) {
         return@withTransaction ChatOutboxEnqueueResult.QueueFull
       }
@@ -584,6 +750,16 @@ class RoomChatCommandOutbox internal constructor(
         )
       }
       dao.insert(entity)
+      val scope = ChatOutboxScope(sessionKey = key, ownerAgentId = owner)
+      ensureBranchScopeLocked(gateway, scope)
+      val branchEpoch = checkNotNull(readBranchStateLocked(gateway, scope)).epoch
+      insertDeliveryStateLocked(
+        commandId = entity.id,
+        attemptVersion = 1,
+        branchEpoch = branchEpoch,
+        parkedWasAccepted = false,
+        hadUnacknowledgedSend = false,
+      )
       val storedAttachments =
         attachments.mapIndexed { position, payload ->
           val attachmentEntity =
@@ -614,7 +790,13 @@ class RoomChatCommandOutbox internal constructor(
           }
           attachmentEntity
         }
-      ChatOutboxEnqueueResult.Queued(entity.toItem(storedAttachments))
+      ChatOutboxEnqueueResult.Queued(
+        entity.toItem(
+          attachments = storedAttachments,
+          deliveryState = DeliveryState(1, branchEpoch, parkedWasAccepted = false, hadUnacknowledgedSend = false),
+          scopeBranchEpoch = branchEpoch,
+        ),
+      )
     }
   }
 
@@ -639,6 +821,35 @@ class RoomChatCommandOutbox internal constructor(
     lastError: String?,
   ): Int = database.outboxDao().updateStatus(id = id, status = status.dbValue, retryCount = retryCount, lastError = lastError)
 
+  override suspend fun updateStatusIfAttempt(
+    id: String,
+    expectedAttemptVersion: Int,
+    status: ChatOutboxStatus,
+    retryCount: Int,
+    lastError: String?,
+    expectedStatus: ChatOutboxStatus?,
+  ): Int =
+    database.withTransaction {
+      ensureBranchStorageLocked()
+      val state = readDeliveryStateLocked(id) ?: return@withTransaction 0
+      if (state.attemptVersion != expectedAttemptVersion) return@withTransaction 0
+      if (expectedStatus != null) {
+        val currentStatus = database.outboxDao().status(id) ?: return@withTransaction 0
+        if (currentStatus != expectedStatus.dbValue) return@withTransaction 0
+      }
+      val updated = database.outboxDao().updateStatus(id, status.dbValue, retryCount, lastError)
+      if (updated > 0) {
+        insertDeliveryStateLocked(
+          commandId = id,
+          attemptVersion = expectedAttemptVersion + if (status == ChatOutboxStatus.Queued) 1 else 0,
+          branchEpoch = state.branchEpoch,
+          parkedWasAccepted = state.parkedWasAccepted,
+          hadUnacknowledgedSend = true,
+        )
+      }
+      updated
+    }
+
   override suspend fun claimForSending(
     id: String,
     retryCount: Int,
@@ -652,12 +863,65 @@ class RoomChatCommandOutbox internal constructor(
       lastError = lastError,
     )
 
+  override suspend fun claimForSendingIfAttempt(
+    id: String,
+    expectedAttemptVersion: Int,
+    retryCount: Int,
+    lastError: String?,
+  ): Int =
+    database.withTransaction {
+      ensureBranchStorageLocked()
+      val dao = database.outboxDao()
+      val row = dao.allCommands().firstOrNull { it.id == id } ?: return@withTransaction 0
+      val delivery = readDeliveryStateLocked(id) ?: return@withTransaction 0
+      if (delivery.attemptVersion != expectedAttemptVersion) return@withTransaction 0
+      val scope = row.branchScope()
+      ensureBranchScopeLocked(row.gatewayId, scope)
+      val branch = readBranchStateLocked(row.gatewayId, scope) ?: return@withTransaction 0
+      if (branch.switchPendingSinceMs != null || branch.needsReconciliation || delivery.branchEpoch != branch.epoch) {
+        return@withTransaction 0
+      }
+      dao.claimStatus(
+        id = id,
+        fromStatus = ChatOutboxStatus.Queued.dbValue,
+        toStatus = ChatOutboxStatus.Sending.dbValue,
+        retryCount = retryCount,
+        lastError = lastError,
+      )
+    }
+
   override suspend fun pinSessionKey(
     id: String,
     sessionKey: String,
   ) {
     val key = sessionKey.trim().takeIf { it.isNotEmpty() } ?: return
-    database.outboxDao().updateSessionKey(id = id, sessionKey = key)
+    database.withTransaction {
+      ensureBranchStorageLocked()
+      val dao = database.outboxDao()
+      val row = dao.command(id) ?: return@withTransaction
+      if (row.sessionKey == key) return@withTransaction
+      val owner =
+        normalizedOutboxOwnerAgentId(row.ownerAgentId)
+          ?: throw IllegalStateException("cannot pin an ownerless outbox row")
+      val previousScope = row.branchScope()
+      ensureBranchScopeLocked(row.gatewayId, previousScope)
+      ensureDeliveryStateLocked(id, row.gatewayId, previousScope)
+      val delivery = checkNotNull(readDeliveryStateLocked(id))
+      val nextScope = ChatOutboxScope(key, owner)
+      ensureBranchScopeLocked(row.gatewayId, nextScope)
+      val nextBranch = checkNotNull(readBranchStateLocked(row.gatewayId, nextScope))
+      check(nextBranch.switchPendingSinceMs == null && !nextBranch.needsReconciliation) {
+        "cannot pin into an unreconciled branch scope"
+      }
+      dao.updateSessionKey(id = id, sessionKey = key)
+      insertDeliveryStateLocked(
+        commandId = id,
+        attemptVersion = delivery.attemptVersion,
+        branchEpoch = nextBranch.epoch,
+        parkedWasAccepted = delivery.parkedWasAccepted,
+        hadUnacknowledgedSend = delivery.hadUnacknowledgedSend,
+      )
+    }
   }
 
   override suspend fun requeueForRetry(
@@ -668,39 +932,99 @@ class RoomChatCommandOutbox internal constructor(
     ownerAgentId: String?,
   ): Int {
     val gateway = scopedGatewayId(gatewayId) ?: return 0
+    val current = load(gateway).firstOrNull { it.id == id } ?: return 0
+    return requeueForRetryIfCurrent(
+      gatewayId = gateway,
+      id = id,
+      expectedAttemptVersion = current.attemptVersion,
+      expectedRetryCount = current.retryCount,
+      expectedLastError = current.lastError,
+      nowMs = nowMs,
+      gatedEpoch = gatedEpoch,
+      ownerAgentId = ownerAgentId,
+    )
+  }
+
+  override suspend fun requeueForRetryIfCurrent(
+    gatewayId: String,
+    id: String,
+    expectedAttemptVersion: Int,
+    expectedRetryCount: Int,
+    expectedLastError: String?,
+    nowMs: Long,
+    gatedEpoch: Long?,
+    ownerAgentId: String?,
+    replacementId: String?,
+  ): Int {
+    val gateway = scopedGatewayId(gatewayId) ?: return 0
     val dao = database.outboxDao()
     return database.withTransaction {
+      ensureBranchStorageLocked()
       val rows = dao.commands(gateway)
       val target = rows.firstOrNull { it.id == id } ?: return@withTransaction 0
-      // Same monotonic clamp as enqueue: the fresh createdAt keeps the expiry sweep from
-      // immediately re-failing a retried stale row.
+      if (
+        ChatOutboxStatus.fromDb(target.status) != ChatOutboxStatus.Failed ||
+        target.retryCount != expectedRetryCount ||
+        target.lastError != expectedLastError
+      ) {
+        return@withTransaction 0
+      }
+      val delivery = readDeliveryStateLocked(id) ?: return@withTransaction 0
+      if (delivery.attemptVersion != expectedAttemptVersion) return@withTransaction 0
+      val owner =
+        normalizedOutboxOwnerAgentId(ownerAgentId)
+          ?: normalizedOutboxOwnerAgentId(target.ownerAgentId)
+          ?: return@withTransaction 0
+      val scope = ChatOutboxScope(target.sessionKey, owner)
+      ensureBranchScopeLocked(gateway, scope)
+      val branchEpoch = checkNotNull(readBranchStateLocked(gateway, scope)).epoch
+      val wasBranchParked = target.lastError?.contains(OUTBOX_BRANCH_PARK_MARKER) == true
+      val needsFreshIdentity = wasBranchParked && (delivery.parkedWasAccepted || delivery.hadUnacknowledgedSend)
+      val requestedReplacement = replacementId?.trim()?.takeIf { it.isNotEmpty() }
+      val nextId = if (needsFreshIdentity) requestedReplacement ?: UUID.randomUUID().toString() else id
       var createdAt = maxOf(nowMs, (dao.maxCreatedAt(gateway) ?: Long.MIN_VALUE) + 1)
-      val transitioned =
-        dao.requeueForRetry(
-          id = id,
-          gatewayId = gateway,
-          createdAtMs = createdAt,
-          queuedStatus = ChatOutboxStatus.Queued.dbValue,
-          failedStatus = ChatOutboxStatus.Failed.dbValue,
-          gatedEpoch = gatedEpoch,
-          ownerAgentId = ownerAgentId?.trim()?.takeIf { it.isNotEmpty() },
-        )
-      if (transitioned > 0) {
-        // Queued same-session successors follow the retried row in their original order, so
-        // retrying an ambiguous head cannot let younger conversation turns overtake it.
-        for (successor in rows) {
-          val follows =
-            successor.id != id &&
-              successor.sessionKey == target.sessionKey &&
-              successor.createdAtMs > target.createdAtMs &&
-              ChatOutboxStatus.fromDb(successor.status) == ChatOutboxStatus.Queued
-          if (follows) {
-            createdAt += 1
-            dao.updateCreatedAt(id = successor.id, createdAtMs = createdAt)
-          }
+      database.openHelper.writableDatabase.execSQL(
+        "UPDATE outbox_commands SET id = ?, status = ?, retryCount = 0, lastError = NULL, " +
+          "createdAtMs = ?, gatedEpoch = ?, ownerAgentId = ? WHERE id = ? AND gatewayId = ? AND status = ?",
+        arrayOf<Any?>(
+          nextId,
+          ChatOutboxStatus.Queued.dbValue,
+          createdAt,
+          gatedEpoch,
+          owner.ifEmpty { null },
+          id,
+          gateway,
+          ChatOutboxStatus.Failed.dbValue,
+        ),
+      )
+      val changed =
+        database.openHelper.writableDatabase
+          .query("SELECT changes()")
+          .use { cursor -> cursor.moveToFirst() && cursor.getInt(0) > 0 }
+      if (!changed) {
+        return@withTransaction 0
+      }
+      if (nextId != id) dao.replaceAttachmentCommandId(id, nextId)
+      deleteDeliveryStateLocked(id)
+      insertDeliveryStateLocked(
+        commandId = nextId,
+        attemptVersion = if (needsFreshIdentity) 1 else expectedAttemptVersion + 1,
+        branchEpoch = branchEpoch,
+        parkedWasAccepted = false,
+        hadUnacknowledgedSend = false,
+      )
+      for (successor in rows) {
+        val follows =
+          successor.id != id &&
+            successor.sessionKey == target.sessionKey &&
+            successor.createdAtMs > target.createdAtMs &&
+            ChatOutboxStatus.fromDb(successor.status) == ChatOutboxStatus.Queued
+        if (follows) {
+          createdAt += 1
+          dao.updateCreatedAt(id = successor.id, createdAtMs = createdAt)
         }
       }
-      transitioned
+      1
     }
   }
 
@@ -730,6 +1054,209 @@ class RoomChatCommandOutbox internal constructor(
     }
   }
 
+  override suspend fun confirmDeliveredAttempts(ids: Map<String, Int>): Int {
+    if (ids.isEmpty()) return 0
+    return database.withTransaction {
+      ensureBranchStorageLocked()
+      var removed = 0
+      for ((id, attemptVersion) in ids) {
+        if (readDeliveryStateLocked(id)?.attemptVersion == attemptVersion) {
+          removed += deleteCommandRowLocked(id)
+        }
+      }
+      removed
+    }
+  }
+
+  override suspend fun branchState(
+    gatewayId: String,
+    scope: ChatOutboxScope,
+  ): ChatOutboxBranchState? {
+    val gateway = scopedGatewayId(gatewayId) ?: return null
+    val normalized = normalizedScope(scope) ?: return null
+    return database.withTransaction {
+      ensureBranchStorageLocked()
+      ensureBranchScopeLocked(gateway, normalized)
+      val state = readBranchStateLocked(gateway, normalized) ?: return@withTransaction null
+      state.copy(
+        hadPendingCommands = unresolvedCountLocked(gateway, normalized, includingFailed = true) > 0,
+        hadDeliverableCommands = unresolvedCountLocked(gateway, normalized, includingFailed = false) > 0,
+      )
+    }
+  }
+
+  override suspend fun beginSessionMutation(
+    gatewayId: String,
+    scope: ChatOutboxScope,
+    nowMs: Long,
+  ): ChatOutboxMutationLease? {
+    val gateway = scopedGatewayId(gatewayId) ?: return null
+    val normalized = normalizedScope(scope) ?: return null
+    return database.withTransaction {
+      ensureBranchStorageLocked()
+      ensureBranchScopeLocked(gateway, normalized)
+      if (expireBranchSwitchLeaseLocked(gateway, normalized, nowMs)) return@withTransaction null
+      val state = readBranchStateLocked(gateway, normalized) ?: return@withTransaction null
+      if (
+        state.needsReconciliation ||
+        state.switchPendingSinceMs != null ||
+        unresolvedCountLocked(gateway, normalized, includingFailed = false) > 0
+      ) {
+        return@withTransaction null
+      }
+      database.openHelper.writableDatabase.execSQL(
+        "UPDATE outbox_branch_scopes SET switchPendingSinceMs = ?, revision = revision + 1 " +
+          "WHERE gatewayId = ? AND sessionKey = ? AND ownerAgentId = ? AND switchPendingSinceMs IS NULL",
+        arrayOf<Any?>(nowMs, gateway, normalized.sessionKey, normalized.ownerAgentId),
+      )
+      if (changedRowsLocked() > 0) ChatOutboxMutationLease(state.revision + 1, nowMs) else null
+    }
+  }
+
+  override suspend fun cancelSessionMutation(
+    gatewayId: String,
+    scope: ChatOutboxScope,
+    lease: ChatOutboxMutationLease,
+  ): Boolean = updateBranchMutationState(gatewayId, scope, needsReconciliation = false, lease = lease) != null
+
+  override suspend fun demoteSessionMutationToReconciliation(
+    gatewayId: String,
+    scope: ChatOutboxScope,
+    lease: ChatOutboxMutationLease?,
+  ): Boolean = updateBranchMutationState(gatewayId, scope, needsReconciliation = true, lease = lease) != null
+
+  override suspend fun demoteSessionMutationToReconciliationState(
+    gatewayId: String,
+    scope: ChatOutboxScope,
+    lease: ChatOutboxMutationLease?,
+  ): ChatOutboxBranchState? = updateBranchMutationState(gatewayId, scope, needsReconciliation = true, lease = lease)
+
+  override suspend fun updateLastActiveLeafEntryId(
+    gatewayId: String,
+    scope: ChatOutboxScope,
+    leafEntryId: String,
+    expectedEpoch: Int,
+    expectedRevision: Int,
+  ): Boolean {
+    val gateway = scopedGatewayId(gatewayId) ?: return false
+    val normalized = normalizedScope(scope) ?: return false
+    val leaf = leafEntryId.trim().takeIf { it.isNotEmpty() } ?: return false
+    return database.withTransaction {
+      ensureBranchStorageLocked()
+      ensureBranchScopeLocked(gateway, normalized)
+      val state = readBranchStateLocked(gateway, normalized) ?: return@withTransaction false
+      if (
+        state.epoch != expectedEpoch ||
+        state.revision != expectedRevision ||
+        state.switchPendingSinceMs != null ||
+        state.needsReconciliation ||
+        unresolvedCountLocked(gateway, normalized, includingFailed = false) > 0
+      ) {
+        return@withTransaction false
+      }
+      writeBranchStateLocked(gateway, normalized, expectedEpoch, leaf, expectedRevision = expectedRevision)
+    }
+  }
+
+  override suspend fun reconcileBranchScope(
+    gatewayId: String,
+    scope: ChatOutboxScope,
+    previousState: ChatOutboxBranchState,
+    activeLeafEntryId: String?,
+    branchLeafEntryIds: Set<String>,
+    activeTranscriptEntryIds: Set<String>,
+    lastError: String,
+  ): Boolean {
+    val gateway = scopedGatewayId(gatewayId) ?: return false
+    val normalized = normalizedScope(scope) ?: return false
+    val leaf = activeLeafEntryId?.trim()?.takeIf { it.isNotEmpty() }
+    if (activeLeafEntryId != null && leaf == null) return false
+    return database.withTransaction {
+      ensureBranchStorageLocked()
+      ensureBranchScopeLocked(gateway, normalized)
+      val expiredLease = expireBranchSwitchLeaseLocked(gateway, normalized, System.currentTimeMillis())
+      val state = readBranchStateLocked(gateway, normalized) ?: return@withTransaction false
+      if ((!expiredLease && state.revision != previousState.revision) || state.switchPendingSinceMs != null) {
+        return@withTransaction false
+      }
+      val pending = unresolvedCountLocked(gateway, normalized, includingFailed = true)
+      val previousLeaf = previousState.lastActiveLeafEntryId
+      val canAdoptQueuedDuringReconciliation =
+        previousState.needsReconciliation && !previousState.hadDeliverableCommands
+      if (leaf != null && previousLeaf != null && previousLeaf != leaf && previousLeaf in branchLeafEntryIds) {
+        installConfirmedBranchChangeLocked(
+          gateway,
+          normalized,
+          state.epoch,
+          leaf,
+          lastError,
+          adoptQueuedCommands = canAdoptQueuedDuringReconciliation,
+        )
+      } else {
+        val advancedOnActivePath = previousLeaf?.let(activeTranscriptEntryIds::contains) == true
+        if (previousLeaf != leaf && !advancedOnActivePath && canAdoptQueuedDuringReconciliation) {
+          installConfirmedBranchChangeLocked(
+            gateway,
+            normalized,
+            state.epoch,
+            leaf,
+            lastError,
+            adoptQueuedCommands = true,
+          )
+          return@withTransaction true
+        }
+        if (
+          previousLeaf != leaf &&
+          !advancedOnActivePath &&
+          ((pending > 0 && (previousState.hadPendingCommands || previousState.needsReconciliation)) || leaf == null)
+        ) {
+          parkPendingCommandsLocked(gateway, normalized, lastError)
+        }
+        if (!writeBranchStateLocked(gateway, normalized, state.epoch, leaf, expectedRevision = state.revision)) {
+          return@withTransaction false
+        }
+      }
+      true
+    }
+  }
+
+  override suspend fun confirmBranchChange(
+    gatewayId: String,
+    scope: ChatOutboxScope,
+    activeLeafEntryId: String?,
+    lastError: String,
+    lease: ChatOutboxMutationLease?,
+  ): Boolean {
+    val gateway = scopedGatewayId(gatewayId) ?: return false
+    val normalized = normalizedScope(scope) ?: return false
+    val leaf = activeLeafEntryId?.trim()?.takeIf { it.isNotEmpty() }
+    if (activeLeafEntryId != null && leaf == null) return false
+    return database.withTransaction {
+      ensureBranchStorageLocked()
+      ensureBranchScopeLocked(gateway, normalized)
+      val state = readBranchStateLocked(gateway, normalized) ?: return@withTransaction false
+      if (
+        lease != null &&
+        (state.revision != lease.revision || state.switchPendingSinceMs != lease.startedAtMs)
+      ) {
+        return@withTransaction false
+      }
+      if (state.lastActiveLeafEntryId == leaf) {
+        writeBranchStateLocked(gateway, normalized, state.epoch, leaf)
+      } else {
+        installConfirmedBranchChangeLocked(gateway, normalized, state.epoch, leaf, lastError)
+        true
+      }
+    }
+  }
+
+  internal suspend fun confirmBranchChange(
+    gatewayId: String,
+    scope: ChatOutboxScope,
+    activeLeafEntryId: String?,
+    lastError: String,
+  ): Boolean = confirmBranchChange(gatewayId, scope, activeLeafEntryId, lastError, lease = null)
+
   override suspend fun deleteForSession(
     gatewayId: String,
     sessionKey: String,
@@ -737,13 +1264,18 @@ class RoomChatCommandOutbox internal constructor(
   ) {
     val gateway = scopedGatewayId(gatewayId) ?: return
     val key = sessionKey.trim().takeIf { it.isNotEmpty() } ?: return
-    val owner = ownerAgentId.trim().takeIf { it.isNotEmpty() } ?: return
+    val owner = normalizedOutboxOwnerAgentId(ownerAgentId) ?: return
     val dao = database.outboxDao()
     database.withTransaction {
+      ensureBranchStorageLocked()
       for (id in dao.commandIdsForSession(gateway, key, owner)) {
         deleteCommandRowLocked(id)
       }
       dao.deleteAdmissionReceiptsForSession(gateway, key, owner)
+      database.openHelper.writableDatabase.execSQL(
+        "DELETE FROM outbox_branch_scopes WHERE gatewayId = ? AND sessionKey = ? AND ownerAgentId = ?",
+        arrayOf<Any?>(gateway, key, owner),
+      )
     }
   }
 
@@ -751,21 +1283,44 @@ class RoomChatCommandOutbox internal constructor(
     val gateway = scopedGatewayId(gatewayId) ?: return
     val dao = database.outboxDao()
     database.withTransaction {
+      ensureBranchStorageLocked()
       for (id in dao.commandIdsForGateway(gateway)) {
         deleteCommandRowLocked(id)
       }
       dao.deleteAdmissionReceiptsForGateway(gateway)
+      database.openHelper.writableDatabase.execSQL(
+        "DELETE FROM outbox_branch_scopes WHERE gatewayId = ?",
+        arrayOf<Any?>(gateway),
+      )
     }
   }
 
   override suspend fun failSendingAfterRestart() {
     // Deliberately unscoped: recovery happens before a gateway is resolved, but a crash leaves
     // delivery ambiguous and must not silently replay an already accepted command.
-    database.outboxDao().failAllSending(
-      sendingStatus = ChatOutboxStatus.Sending.dbValue,
-      failedStatus = ChatOutboxStatus.Failed.dbValue,
-      error = OUTBOX_DELIVERY_UNCONFIRMED_ERROR,
-    )
+    database.withTransaction {
+      ensureBranchStorageLocked()
+      val sendingRows =
+        database
+          .outboxDao()
+          .allCommands()
+          .filter { ChatOutboxStatus.fromDb(it.status) == ChatOutboxStatus.Sending }
+      for (row in sendingRows) {
+        val scope = row.branchScope()
+        ensureBranchScopeLocked(row.gatewayId, scope)
+        ensureDeliveryStateLocked(row.id, row.gatewayId, scope)
+      }
+      database.openHelper.writableDatabase.execSQL(
+        "UPDATE outbox_delivery_state SET hadUnacknowledgedSend = 1 WHERE commandId IN " +
+          "(SELECT id FROM outbox_commands WHERE status = ?)",
+        arrayOf<Any?>(ChatOutboxStatus.Sending.dbValue),
+      )
+      database.outboxDao().failAllSending(
+        sendingStatus = ChatOutboxStatus.Sending.dbValue,
+        failedStatus = ChatOutboxStatus.Failed.dbValue,
+        error = OUTBOX_DELIVERY_UNCONFIRMED_ERROR,
+      )
+    }
   }
 
   override suspend fun expireStale(
@@ -798,16 +1353,308 @@ class RoomChatCommandOutbox internal constructor(
   // Attachment chunk and metadata rows must die with their command row in the same
   // transaction; callers wrap this in database.withTransaction.
   private suspend fun deleteCommandRowLocked(id: String): Int {
+    ensureBranchStorageLocked()
     val dao = database.outboxDao()
     dao.deleteChunksForCommand(id)
     dao.deleteAttachmentsForCommand(id)
+    deleteDeliveryStateLocked(id)
     return dao.delete(id)
+  }
+
+  private fun ensureBranchStorageLocked() {
+    val db = database.openHelper.writableDatabase
+    db.execSQL(
+      "CREATE TABLE IF NOT EXISTS outbox_branch_scopes (" +
+        "gatewayId TEXT NOT NULL, sessionKey TEXT NOT NULL, ownerAgentId TEXT NOT NULL, " +
+        "branchEpoch INTEGER NOT NULL DEFAULT 0, lastActiveLeafEntryId TEXT, switchPendingSinceMs INTEGER, " +
+        "needsReconciliation INTEGER NOT NULL DEFAULT 0, revision INTEGER NOT NULL DEFAULT 0, " +
+        "PRIMARY KEY(gatewayId, sessionKey, ownerAgentId))",
+    )
+    db.execSQL(
+      "CREATE TABLE IF NOT EXISTS outbox_delivery_state (" +
+        "commandId TEXT NOT NULL PRIMARY KEY, attemptVersion INTEGER NOT NULL DEFAULT 1, " +
+        "branchEpoch INTEGER NOT NULL DEFAULT 0, parkedWasAccepted INTEGER NOT NULL DEFAULT 0, " +
+        "hadUnacknowledgedSend INTEGER NOT NULL DEFAULT 0)",
+    )
+  }
+
+  private fun normalizedScope(scope: ChatOutboxScope): ChatOutboxScope? {
+    val key = scope.sessionKey.trim().takeIf { it.isNotEmpty() } ?: return null
+    val owner = normalizedOutboxOwnerAgentId(scope.ownerAgentId) ?: return null
+    return ChatOutboxScope(key, owner)
+  }
+
+  private fun ensureBranchScopeLocked(
+    gatewayId: String,
+    scope: ChatOutboxScope,
+  ) {
+    database.openHelper.writableDatabase.execSQL(
+      "INSERT OR IGNORE INTO outbox_branch_scopes(" +
+        "gatewayId, sessionKey, ownerAgentId, branchEpoch, needsReconciliation, revision" +
+        ") VALUES (?, ?, ?, 0, 0, 0)",
+      arrayOf<Any?>(gatewayId, scope.sessionKey, scope.ownerAgentId),
+    )
+  }
+
+  private suspend fun ensureDeliveryStateLocked(
+    commandId: String,
+    gatewayId: String,
+    scope: ChatOutboxScope,
+  ) {
+    val branchEpoch = readBranchStateLocked(gatewayId, scope)?.epoch ?: 0
+    val command = database.outboxDao().command(id = commandId)
+    val hadUnacknowledgedSend =
+      command?.let { row ->
+        ChatOutboxStatus.fromDb(row.status) == ChatOutboxStatus.Failed &&
+          chatOutboxDisplayError(row.lastError) == OUTBOX_DELIVERY_UNCONFIRMED_ERROR
+      } == true
+    database.openHelper.writableDatabase.execSQL(
+      "INSERT OR IGNORE INTO outbox_delivery_state(" +
+        "commandId, attemptVersion, branchEpoch, parkedWasAccepted, hadUnacknowledgedSend" +
+        ") VALUES (?, 1, ?, 0, ?)",
+      arrayOf<Any?>(commandId, branchEpoch, hadUnacknowledgedSend.asSqlInt()),
+    )
+  }
+
+  private fun insertDeliveryStateLocked(
+    commandId: String,
+    attemptVersion: Int,
+    branchEpoch: Int,
+    parkedWasAccepted: Boolean,
+    hadUnacknowledgedSend: Boolean,
+  ) {
+    database.openHelper.writableDatabase.execSQL(
+      "INSERT OR REPLACE INTO outbox_delivery_state(" +
+        "commandId, attemptVersion, branchEpoch, parkedWasAccepted, hadUnacknowledgedSend" +
+        ") VALUES (?, ?, ?, ?, ?)",
+      arrayOf<Any?>(commandId, attemptVersion, branchEpoch, parkedWasAccepted.asSqlInt(), hadUnacknowledgedSend.asSqlInt()),
+    )
+  }
+
+  private fun readDeliveryStateLocked(commandId: String): DeliveryState? =
+    database.openHelper.writableDatabase
+      .query(
+        "SELECT attemptVersion, branchEpoch, parkedWasAccepted, hadUnacknowledgedSend " +
+          "FROM outbox_delivery_state WHERE commandId = ?",
+        arrayOf<Any?>(commandId),
+      ).use { cursor ->
+        if (!cursor.moveToFirst()) return@use null
+        DeliveryState(
+          attemptVersion = cursor.getInt(0),
+          branchEpoch = cursor.getInt(1),
+          parkedWasAccepted = cursor.getInt(2) != 0,
+          hadUnacknowledgedSend = cursor.getInt(3) != 0,
+        )
+      }
+
+  private fun deleteDeliveryStateLocked(commandId: String) {
+    database.openHelper.writableDatabase.execSQL(
+      "DELETE FROM outbox_delivery_state WHERE commandId = ?",
+      arrayOf<Any?>(commandId),
+    )
+  }
+
+  private fun readBranchStateLocked(
+    gatewayId: String,
+    scope: ChatOutboxScope,
+  ): ChatOutboxBranchState? =
+    database.openHelper.writableDatabase
+      .query(
+        "SELECT branchEpoch, lastActiveLeafEntryId, switchPendingSinceMs, needsReconciliation, revision " +
+          "FROM outbox_branch_scopes WHERE gatewayId = ? AND sessionKey = ? AND ownerAgentId = ?",
+        arrayOf<Any?>(gatewayId, scope.sessionKey, scope.ownerAgentId),
+      ).use { cursor ->
+        if (!cursor.moveToFirst()) return@use null
+        ChatOutboxBranchState(
+          epoch = cursor.getInt(0),
+          lastActiveLeafEntryId = cursor.getString(1),
+          hadPendingCommands = false,
+          switchPendingSinceMs = cursor.getLong(2).takeUnless { cursor.isNull(2) },
+          needsReconciliation = cursor.getInt(3) != 0,
+          revision = cursor.getInt(4),
+        )
+      }
+
+  private fun unresolvedCountLocked(
+    gatewayId: String,
+    scope: ChatOutboxScope,
+    includingFailed: Boolean,
+  ): Int {
+    // Statement fragments are implementation data, not native copy. Assignment statements keep
+    // them out of the source-string extractor's conditional-expression heuristic.
+    val statuses: String
+    if (includingFailed) {
+      statuses = "'queued', 'sending', 'accepted', 'failed'"
+    } else {
+      statuses = "'queued', 'sending', 'accepted'"
+    }
+    return database.openHelper.writableDatabase
+      .query(
+        "SELECT COUNT(*) FROM outbox_commands WHERE gatewayId = ? AND sessionKey = ? " +
+          "AND COALESCE(ownerAgentId, '') = ? AND status IN ($statuses)",
+        arrayOf<Any?>(gatewayId, scope.sessionKey, scope.ownerAgentId),
+      ).use { cursor -> if (cursor.moveToFirst()) cursor.getInt(0) else 0 }
+  }
+
+  private fun changedRowsLocked(): Int =
+    database.openHelper.writableDatabase
+      .query("SELECT changes()")
+      .use { cursor -> if (cursor.moveToFirst()) cursor.getInt(0) else 0 }
+
+  private fun expireBranchSwitchLeaseLocked(
+    gatewayId: String,
+    scope: ChatOutboxScope,
+    nowMs: Long,
+  ): Boolean {
+    val cutoff = nowMs - OUTBOX_BRANCH_SWITCH_LEASE_MS
+    database.openHelper.writableDatabase.execSQL(
+      "UPDATE outbox_branch_scopes SET switchPendingSinceMs = NULL, needsReconciliation = 1, revision = revision + 1 " +
+        "WHERE gatewayId = ? AND sessionKey = ? AND ownerAgentId = ? AND switchPendingSinceMs <= ?",
+      arrayOf<Any?>(gatewayId, scope.sessionKey, scope.ownerAgentId, cutoff),
+    )
+    return changedRowsLocked() > 0
+  }
+
+  private suspend fun updateBranchMutationState(
+    gatewayId: String,
+    scope: ChatOutboxScope,
+    needsReconciliation: Boolean,
+    lease: ChatOutboxMutationLease?,
+  ): ChatOutboxBranchState? {
+    val gateway = scopedGatewayId(gatewayId) ?: return null
+    val normalized = normalizedScope(scope) ?: return null
+    return database.withTransaction {
+      ensureBranchStorageLocked()
+      ensureBranchScopeLocked(gateway, normalized)
+      if (lease == null) {
+        database.openHelper.writableDatabase.execSQL(
+          "UPDATE outbox_branch_scopes SET switchPendingSinceMs = NULL, needsReconciliation = ?, revision = revision + 1 " +
+            "WHERE gatewayId = ? AND sessionKey = ? AND ownerAgentId = ?",
+          arrayOf<Any?>(needsReconciliation.asSqlInt(), gateway, normalized.sessionKey, normalized.ownerAgentId),
+        )
+      } else {
+        database.openHelper.writableDatabase.execSQL(
+          "UPDATE outbox_branch_scopes SET switchPendingSinceMs = NULL, needsReconciliation = ?, revision = revision + 1 " +
+            "WHERE gatewayId = ? AND sessionKey = ? AND ownerAgentId = ? AND revision = ? AND switchPendingSinceMs = ?",
+          arrayOf<Any?>(
+            needsReconciliation.asSqlInt(),
+            gateway,
+            normalized.sessionKey,
+            normalized.ownerAgentId,
+            lease.revision,
+            lease.startedAtMs,
+          ),
+        )
+      }
+      if (changedRowsLocked() == 0) return@withTransaction null
+      val state = readBranchStateLocked(gateway, normalized) ?: return@withTransaction null
+      state.copy(
+        hadPendingCommands = unresolvedCountLocked(gateway, normalized, includingFailed = true) > 0,
+        hadDeliverableCommands = unresolvedCountLocked(gateway, normalized, includingFailed = false) > 0,
+      )
+    }
+  }
+
+  private fun writeBranchStateLocked(
+    gatewayId: String,
+    scope: ChatOutboxScope,
+    epoch: Int,
+    lastActiveLeafEntryId: String?,
+    expectedRevision: Int? = null,
+  ): Boolean {
+    database.openHelper.writableDatabase.execSQL(
+      "UPDATE outbox_branch_scopes SET branchEpoch = ?, lastActiveLeafEntryId = ?, switchPendingSinceMs = NULL, " +
+        "needsReconciliation = 0, revision = revision + 1 WHERE gatewayId = ? AND sessionKey = ? " +
+        "AND ownerAgentId = ? AND (? IS NULL OR revision = ?)",
+      arrayOf<Any?>(
+        epoch,
+        lastActiveLeafEntryId,
+        gatewayId,
+        scope.sessionKey,
+        scope.ownerAgentId,
+        expectedRevision,
+        expectedRevision,
+      ),
+    )
+    return changedRowsLocked() > 0
+  }
+
+  private fun installConfirmedBranchChangeLocked(
+    gatewayId: String,
+    scope: ChatOutboxScope,
+    previousEpoch: Int,
+    activeLeafEntryId: String?,
+    lastError: String,
+    adoptQueuedCommands: Boolean = false,
+  ) {
+    val nextEpoch = previousEpoch + 1
+    check(writeBranchStateLocked(gatewayId, scope, nextEpoch, activeLeafEntryId))
+    if (adoptQueuedCommands) {
+      database.openHelper.writableDatabase.execSQL(
+        "UPDATE outbox_delivery_state SET branchEpoch = ? WHERE commandId IN (" +
+          "SELECT id FROM outbox_commands WHERE gatewayId = ? AND sessionKey = ? " +
+          "AND COALESCE(ownerAgentId, '') = ? AND status = 'queued')",
+        arrayOf<Any?>(nextEpoch, gatewayId, scope.sessionKey, scope.ownerAgentId),
+      )
+    }
+    parkPendingCommandsLocked(gatewayId, scope, lastError, retainedEpoch = nextEpoch)
+  }
+
+  private fun parkPendingCommandsLocked(
+    gatewayId: String,
+    scope: ChatOutboxScope,
+    lastError: String,
+    retainedEpoch: Int? = null,
+  ) {
+    val db = database.openHelper.writableDatabase
+    val scopeArgs = arrayOf<Any?>(gatewayId, scope.sessionKey, scope.ownerAgentId)
+    val epochFilter: String
+    if (retainedEpoch == null) {
+      epochFilter = ""
+    } else {
+      epochFilter = " AND branchEpoch <> ?"
+    }
+    val epochArgs: List<Any?> = if (retainedEpoch == null) emptyList() else listOf(retainedEpoch)
+    db.execSQL(
+      "UPDATE outbox_delivery_state SET parkedWasAccepted = CASE WHEN hadUnacknowledgedSend = 1 OR commandId IN (" +
+        "SELECT id FROM outbox_commands WHERE gatewayId = ? AND sessionKey = ? AND COALESCE(ownerAgentId, '') = ? " +
+        "AND status IN ('sending', 'accepted')) THEN 1 ELSE parkedWasAccepted END WHERE commandId IN (" +
+        "SELECT id FROM outbox_commands WHERE gatewayId = ? AND sessionKey = ? AND COALESCE(ownerAgentId, '') = ? " +
+        "AND status IN ('queued', 'sending', 'accepted', 'failed'))$epochFilter",
+      (scopeArgs.toList() + scopeArgs.toList() + epochArgs).toTypedArray(),
+    )
+    db.execSQL(
+      "UPDATE outbox_commands SET status = ?, lastError = ? WHERE gatewayId = ? AND sessionKey = ? " +
+        "AND COALESCE(ownerAgentId, '') = ? AND status IN ('queued', 'sending', 'accepted', 'failed') " +
+        "AND id IN (SELECT commandId FROM outbox_delivery_state WHERE 1 = 1$epochFilter)",
+      arrayOf<Any?>(
+        ChatOutboxStatus.Failed.dbValue,
+        lastError + OUTBOX_BRANCH_PARK_MARKER + UUID.randomUUID(),
+        gatewayId,
+        scope.sessionKey,
+        scope.ownerAgentId,
+      ).toList().plus(epochArgs).toTypedArray(),
+    )
   }
 
   private fun scopedGatewayId(gatewayId: String): String? = gatewayId.trim().takeIf { it.isNotEmpty() }
 }
 
-private fun OutboxCommandEntity.toItem(attachments: List<OutboxAttachmentEntity>): ChatOutboxItem =
+private fun normalizedOutboxOwnerAgentId(value: String?): String? =
+  value
+    ?.trim()
+    ?.lowercase()
+    ?.takeIf { it.isNotEmpty() }
+
+private fun OutboxCommandEntity.branchScope(): ChatOutboxScope = ChatOutboxScope(sessionKey = sessionKey, ownerAgentId = normalizedOutboxOwnerAgentId(ownerAgentId).orEmpty())
+
+private fun Boolean.asSqlInt(): Int = if (this) 1 else 0
+
+private fun OutboxCommandEntity.toItem(
+  attachments: List<OutboxAttachmentEntity>,
+  deliveryState: RoomChatCommandOutbox.DeliveryState,
+  scopeBranchEpoch: Int,
+): ChatOutboxItem =
   ChatOutboxItem(
     id = id,
     sessionKey = sessionKey,
@@ -820,6 +1667,11 @@ private fun OutboxCommandEntity.toItem(attachments: List<OutboxAttachmentEntity>
     gatedEpoch = gatedEpoch,
     ownerAgentId = ownerAgentId,
     attachments = attachments.map { it.toAttachment() },
+    attemptVersion = deliveryState.attemptVersion,
+    branchEpoch = deliveryState.branchEpoch,
+    scopeBranchEpoch = scopeBranchEpoch,
+    parkedWasAccepted = deliveryState.parkedWasAccepted,
+    hadUnacknowledgedSend = deliveryState.hadUnacknowledgedSend,
   )
 
 private fun OutboxAttachmentEntity.toAttachment(): ChatOutboxAttachment =

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -31,6 +32,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
@@ -284,6 +286,24 @@ class ChatController internal constructor(
   private val _sessions = MutableStateFlow<List<ChatSessionEntry>>(emptyList())
   val sessions: StateFlow<List<ChatSessionEntry>> = _sessions.asStateFlow()
 
+  private val _sessionBranches = MutableStateFlow<List<SessionBranch>>(emptyList())
+  val sessionBranches: StateFlow<List<SessionBranch>> = _sessionBranches.asStateFlow()
+
+  private val _sessionBranchesLoading = MutableStateFlow(false)
+  val sessionBranchesLoading: StateFlow<Boolean> = _sessionBranchesLoading.asStateFlow()
+
+  private val _sessionBranchSwitching = MutableStateFlow(false)
+  val sessionBranchSwitching: StateFlow<Boolean> = _sessionBranchSwitching.asStateFlow()
+
+  private val sessionBranchesRefreshGeneration = AtomicLong(0)
+  private val sessionBranchSwitchGeneration = AtomicLong(0)
+  private val sessionBranchSwitchClaimed = AtomicBoolean(false)
+  private val reconciledOutboxBranchScopes = ConcurrentHashMap.newKeySet<ReconciledOutboxBranchScope>()
+  private val ambiguousMutationReconciliationStates = ConcurrentHashMap<ReconciledOutboxBranchScope, ChatOutboxBranchState>()
+  private val outboxSessionMutationEventLock = Any()
+  private val activeOutboxSessionMutations = ConcurrentHashMap<ReconciledOutboxBranchScope, ActiveOutboxSessionMutation>()
+  private val deferredOutboxSessionMutationEvents = mutableMapOf<ReconciledOutboxBranchScope, MutableSet<ChatOutboxMutationLease>>()
+
   private val _commands = MutableStateFlow<List<ChatCommandEntry>>(emptyList())
   val commands: StateFlow<List<ChatCommandEntry>> = _commands.asStateFlow()
 
@@ -399,8 +419,13 @@ class ChatController internal constructor(
   // Flush requests are level-triggered: the owner clears one per pass and rechecks after release.
   private val outboxFlushInFlight = AtomicBoolean(false)
   private val outboxFlushRequested = AtomicBoolean(false)
+  private val outboxBranchReconcileInFlight = AtomicBoolean(false)
+  private val outboxBranchReconcileRequested = AtomicBoolean(false)
+  private val outboxBranchReconcileRetryScheduled = AtomicBoolean(false)
   private val outboxRecoveryMutex = Mutex()
   private var outboxRecoveryComplete = false
+  private val _outboxPresentationRestored = MutableStateFlow(commandOutbox == null)
+  val outboxPresentationRestored: StateFlow<Boolean> = _outboxPresentationRestored.asStateFlow()
 
   // Counts idle-history snapshots that lacked proof for an orphaned accepted row; rows park as
   // delivery-unconfirmed on the second sighting so one lagging transcript write is not loss.
@@ -430,6 +455,12 @@ class ChatController internal constructor(
   /** Clears transient chat state when the operator gateway session disconnects. */
   fun onDisconnected(message: String) {
     retireMainSessionReadiness()
+    reconciledOutboxBranchScopes.clear()
+    ambiguousMutationReconciliationStates.clear()
+    synchronized(outboxSessionMutationEventLock) {
+      activeOutboxSessionMutations.clear()
+      deferredOutboxSessionMutationEvents.clear()
+    }
     historyLoadGeneration.incrementAndGet()
     restoreRunStateOnReconnect = true
     reconnectRecoveryGeneration = null
@@ -583,6 +614,19 @@ class ChatController internal constructor(
       lastHealthPollAtMs = null
       // Outbox rows are gateway-scoped too; the next publish repopulates them for the new scope.
       _outboxItems.value = emptyList()
+      _outboxPresentationRestored.value = commandOutbox == null
+      reconciledOutboxBranchScopes.clear()
+      ambiguousMutationReconciliationStates.clear()
+      synchronized(outboxSessionMutationEventLock) {
+        activeOutboxSessionMutations.clear()
+        deferredOutboxSessionMutationEvents.clear()
+      }
+      _sessionBranches.value = emptyList()
+      _sessionBranchesLoading.value = false
+      sessionBranchesRefreshGeneration.incrementAndGet()
+      sessionBranchSwitchGeneration.incrementAndGet()
+      sessionBranchSwitchClaimed.set(false)
+      _sessionBranchSwitching.value = false
     }
   }
 
@@ -979,6 +1023,679 @@ class ChatController internal constructor(
       updateErrorText(err.message)
       null
     }
+  }
+
+  private data class SessionActionSnapshot(
+    val gatewayScope: ChatCacheScope?,
+    val sessionKey: String,
+    val ownerAgentId: String,
+    val selectionGeneration: Long,
+  )
+
+  private data class ReconciledOutboxBranchScope(
+    val gatewayScope: ChatCacheScope,
+    val branchScope: ChatOutboxScope,
+  )
+
+  private data class SessionMutationLease(
+    val durable: ChatOutboxMutationLease?,
+  )
+
+  private data class ActiveOutboxSessionMutation(
+    val lease: ChatOutboxMutationLease,
+    val expectedEventReason: String?,
+  )
+
+  private enum class BranchRefreshPurpose {
+    ReadOnly,
+    Reconcile,
+    FinalizeMutation,
+  }
+
+  /** Rewinds the current transcript at one canonical history entry. */
+  suspend fun rewindSessionAtEntry(
+    sessionKey: String,
+    entryId: String,
+  ): String? = rewindSessionAtEntryResult(sessionKey, entryId)?.editorText
+
+  suspend fun rewindSessionAtEntryResult(
+    sessionKey: String,
+    entryId: String,
+  ): SessionRewindResult? {
+    val entry = entryId.trim().takeIf { it.isNotEmpty() } ?: return null
+    val snapshot = currentSessionActionSnapshot(sessionKey) ?: return null
+    if (!canPerformMessageSessionAction(snapshot)) return null
+    val mutationLease = beginOutboxSessionMutation(snapshot, expectedEventReason = "rewind") ?: return null
+    if (!isCurrentSessionAction(snapshot)) {
+      cancelOutboxSessionMutation(snapshot, mutationLease)
+      return null
+    }
+    val actionHistoryGeneration = historyLoadGeneration.incrementAndGet()
+    return try {
+      val params =
+        buildJsonObject {
+          put("sessionKey", JsonPrimitive(snapshot.sessionKey))
+          put("agentId", JsonPrimitive(snapshot.ownerAgentId))
+          put("entryId", JsonPrimitive(entry))
+        }
+      val root =
+        json
+          .parseToJsonElement(requestGatewayBound(snapshot.gatewayScope?.gatewayId, "sessions.rewind", params.toString()))
+          .asObjectOrNull()
+      if (!isCurrentSessionAction(snapshot)) {
+        recoverOutboxAfterSessionMutationRefreshFailure(snapshot, mutationLease)
+        return null
+      }
+      val editorText = root?.get("editorText").asStringOrNull()
+      val historyApplied = refreshHistoryForSessionAction(snapshot, actionHistoryGeneration)
+      val branchApplied =
+        if (historyApplied) {
+          refreshSessionBranches(
+            snapshot,
+            previousState = null,
+            purpose = BranchRefreshPurpose.FinalizeMutation,
+            mutationLease = mutationLease,
+          )
+        } else {
+          false
+        }
+      if (!historyApplied || !branchApplied) recoverOutboxAfterSessionMutationRefreshFailure(snapshot, mutationLease)
+      SessionRewindResult(editorText)
+    } catch (err: CancellationException) {
+      withContext(NonCancellable) {
+        recoverOutboxAfterSessionMutationRefreshFailure(snapshot, mutationLease)
+      }
+      throw err
+    } catch (err: GatewayRequestDefinitiveFailure) {
+      cancelOutboxSessionMutation(snapshot, mutationLease)
+      reloadHistoryAfterDefinitiveSessionMutationFailure(snapshot)
+      updateErrorText(err.message)
+      null
+    } catch (err: Throwable) {
+      recoverOutboxAfterAmbiguousSessionMutation(snapshot, mutationLease)
+      updateErrorText(err.message)
+      null
+    } finally {
+      releaseOutboxSessionMutation(snapshot, mutationLease.durable)
+    }
+  }
+
+  /** Forks the current transcript at one canonical history entry. */
+  suspend fun forkSessionAtEntry(
+    sessionKey: String,
+    entryId: String,
+  ): Pair<String, String?>? {
+    val entry = entryId.trim().takeIf { it.isNotEmpty() } ?: return null
+    val snapshot = currentSessionActionSnapshot(sessionKey) ?: return null
+    if (!canPerformMessageSessionAction(snapshot)) return null
+    val mutationLease = beginOutboxSessionMutation(snapshot, expectedEventReason = null) ?: return null
+    if (!isCurrentSessionAction(snapshot)) {
+      cancelOutboxSessionMutation(snapshot, mutationLease)
+      return null
+    }
+    return try {
+      val params =
+        buildJsonObject {
+          put("sessionKey", JsonPrimitive(snapshot.sessionKey))
+          put("agentId", JsonPrimitive(snapshot.ownerAgentId))
+          put("entryId", JsonPrimitive(entry))
+        }
+      val root =
+        json
+          .parseToJsonElement(requestGatewayBound(snapshot.gatewayScope?.gatewayId, "sessions.fork", params.toString()))
+          .asObjectOrNull()
+      // Fork leaves the source branch unchanged; its durable lease is only an entry gate.
+      cancelOutboxSessionMutation(snapshot, mutationLease)
+      val createdKey =
+        root
+          ?.get("sessionKey")
+          .asStringOrNull()
+          ?.trim()
+          ?.takeIf { it.isNotEmpty() }
+          ?: return null
+      if (!isCurrentSessionAction(snapshot)) {
+        fetchSessionsForCurrentWindow()
+        return null
+      }
+      createdKey to root?.get("editorText").asStringOrNull()
+    } catch (err: CancellationException) {
+      withContext(NonCancellable) {
+        cancelOutboxSessionMutation(snapshot, mutationLease)
+      }
+      throw err
+    } catch (err: Throwable) {
+      // sessions.fork has no idempotency token, so an outcome-unknown retry can create a duplicate.
+      // Web and Swift accept that recoverable extra session; protocol-level idempotency is the
+      // follow-up rather than heuristic session-list matching here.
+      cancelOutboxSessionMutation(snapshot, mutationLease)
+      updateErrorText(err.message)
+      null
+    }
+  }
+
+  suspend fun listSessionBranches(sessionKey: String): List<SessionBranch>? {
+    val snapshot = currentSessionActionSnapshot(sessionKey) ?: return null
+    return try {
+      requestSessionBranches(snapshot)
+    } catch (err: CancellationException) {
+      throw err
+    } catch (err: Throwable) {
+      updateErrorText(err.message)
+      null
+    }
+  }
+
+  /** Atomically parks superseded outbox ownership before applying a branch switch. */
+  suspend fun switchSessionBranch(
+    sessionKey: String,
+    leafEntryId: String,
+  ): Boolean {
+    val leaf = leafEntryId.trim().takeIf { it.isNotEmpty() } ?: return false
+    val snapshot = currentSessionActionSnapshot(sessionKey) ?: return false
+    if (!canSwitchSessionBranch(snapshot)) return false
+    if (_sessionBranches.value.any { it.leafEntryId == leaf && it.active }) return false
+    if (!sessionBranchSwitchClaimed.compareAndSet(false, true)) return false
+    val switchGeneration = sessionBranchSwitchGeneration.incrementAndGet()
+    _sessionBranchSwitching.value = true
+    val mutationLease = beginOutboxSessionMutation(snapshot, expectedEventReason = "branch-switch")
+    if (mutationLease == null) {
+      if (switchGeneration == sessionBranchSwitchGeneration.get()) {
+        sessionBranchSwitchClaimed.set(false)
+        _sessionBranchSwitching.value = false
+      }
+      return false
+    }
+    if (!isCurrentBranchSwitch(snapshot, switchGeneration)) {
+      cancelOutboxSessionMutation(snapshot, mutationLease)
+      return false
+    }
+    val actionHistoryGeneration = historyLoadGeneration.incrementAndGet()
+    return try {
+      val params =
+        buildJsonObject {
+          put("sessionKey", JsonPrimitive(snapshot.sessionKey))
+          put("agentId", JsonPrimitive(snapshot.ownerAgentId))
+          put("leafEntryId", JsonPrimitive(leaf))
+        }
+      requestGatewayBound(snapshot.gatewayScope?.gatewayId, "sessions.branches.switch", params.toString())
+      val branchConfirmed = confirmOutboxBranchChange(snapshot, leaf, mutationLease)
+      if (!isCurrentBranchSwitch(snapshot, switchGeneration)) return false
+      val historyApplied = refreshHistoryForSessionAction(snapshot, actionHistoryGeneration)
+      val branchesApplied =
+        if (historyApplied) {
+          refreshSessionBranches(snapshot, previousState = branchState(snapshot), purpose = BranchRefreshPurpose.ReadOnly)
+        } else {
+          false
+        }
+      if (!branchConfirmed || !historyApplied) recoverOutboxAfterSessionMutationRefreshFailure(snapshot, mutationLease)
+      branchConfirmed && historyApplied && branchesApplied
+    } catch (err: CancellationException) {
+      withContext(NonCancellable) {
+        recoverOutboxAfterSessionMutationRefreshFailure(snapshot, mutationLease)
+      }
+      throw err
+    } catch (err: GatewayRequestDefinitiveFailure) {
+      cancelOutboxSessionMutation(snapshot, mutationLease)
+      reloadHistoryAfterDefinitiveSessionMutationFailure(snapshot)
+      if (isCurrentSessionAction(snapshot)) updateErrorText(err.message)
+      false
+    } catch (err: Throwable) {
+      recoverOutboxAfterAmbiguousSessionMutation(snapshot, mutationLease)
+      if (isCurrentSessionAction(snapshot)) updateErrorText(err.message)
+      false
+    } finally {
+      releaseOutboxSessionMutation(snapshot, mutationLease.durable)
+      if (switchGeneration == sessionBranchSwitchGeneration.get()) {
+        sessionBranchSwitchClaimed.set(false)
+        _sessionBranchSwitching.value = false
+      }
+    }
+  }
+
+  suspend fun refreshSessionBranches(): Boolean {
+    val snapshot = currentSessionActionSnapshot(_sessionKey.value) ?: return false
+    val previousState = branchState(snapshot)
+    val purpose =
+      if (previousState?.needsReconciliation == true) {
+        BranchRefreshPurpose.Reconcile
+      } else {
+        BranchRefreshPurpose.ReadOnly
+      }
+    return refreshSessionBranches(snapshot, previousState = previousState, purpose = purpose)
+  }
+
+  private fun currentSessionActionSnapshot(requestedSessionKey: String): SessionActionSnapshot? {
+    val key = normalizeRequestedSessionKey(requestedSessionKey)
+    if (key != _sessionKey.value) return null
+    val owner = resolveAgentIdForSessionKey(key)?.trim()?.lowercase()?.takeIf { it.isNotEmpty() } ?: return null
+    return SessionActionSnapshot(
+      gatewayScope = currentCacheScope(),
+      sessionKey = key,
+      ownerAgentId = owner,
+      selectionGeneration = chatSelectionGeneration.get(),
+    )
+  }
+
+  private fun isCurrentSessionAction(snapshot: SessionActionSnapshot): Boolean =
+    snapshot.gatewayScope == currentCacheScope() &&
+      snapshot.sessionKey == _sessionKey.value &&
+      snapshot.ownerAgentId == resolveAgentIdForSessionKey(_sessionKey.value)?.trim()?.lowercase() &&
+      snapshot.selectionGeneration == chatSelectionGeneration.get()
+
+  private fun isCurrentBranchSwitch(
+    snapshot: SessionActionSnapshot,
+    switchGeneration: Long,
+  ): Boolean =
+    isCurrentSessionAction(snapshot) &&
+      switchGeneration == sessionBranchSwitchGeneration.get() &&
+      _sessionBranchSwitching.value
+
+  private fun SessionActionSnapshot.outboxScope(): ChatOutboxScope = ChatOutboxScope(sessionKey = sessionKey, ownerAgentId = ownerAgentId)
+
+  private fun ChatOutboxItem.outboxScope(): ChatOutboxScope? {
+    val owner = ownerAgentId ?: resolveAgentIdFromMainSessionKey(sessionKey) ?: return null
+    return ChatOutboxScope(normalizeRequestedSessionKey(sessionKey), owner.trim().lowercase())
+  }
+
+  private fun reconciledOutboxBranchScope(
+    gatewayScope: ChatCacheScope?,
+    branchScope: ChatOutboxScope,
+  ): ReconciledOutboxBranchScope? = gatewayScope?.let { ReconciledOutboxBranchScope(it, branchScope) }
+
+  private fun isOutboxBranchReconciled(
+    gatewayScope: ChatCacheScope?,
+    branchScope: ChatOutboxScope,
+  ): Boolean = reconciledOutboxBranchScope(gatewayScope, branchScope)?.let(reconciledOutboxBranchScopes::contains) == true
+
+  private fun markOutboxBranchReconciled(
+    gatewayScope: ChatCacheScope?,
+    branchScope: ChatOutboxScope,
+  ): Boolean {
+    val key = reconciledOutboxBranchScope(gatewayScope, branchScope) ?: return false
+    if (gatewayScope != currentCacheScope()) return false
+    reconciledOutboxBranchScopes.add(key)
+    return true
+  }
+
+  private fun markOutboxBranchUnreconciled(
+    gatewayScope: ChatCacheScope?,
+    branchScope: ChatOutboxScope,
+  ) {
+    reconciledOutboxBranchScope(gatewayScope, branchScope)?.let(reconciledOutboxBranchScopes::remove)
+  }
+
+  private fun trackOutboxSessionMutation(
+    snapshot: SessionActionSnapshot,
+    lease: ChatOutboxMutationLease,
+    expectedEventReason: String?,
+  ) {
+    val key = reconciledOutboxBranchScope(snapshot.gatewayScope, snapshot.outboxScope()) ?: return
+    synchronized(outboxSessionMutationEventLock) {
+      activeOutboxSessionMutations[key] = ActiveOutboxSessionMutation(lease, expectedEventReason)
+    }
+  }
+
+  private fun releaseOutboxSessionMutation(
+    snapshot: SessionActionSnapshot,
+    lease: ChatOutboxMutationLease?,
+  ) {
+    val durable = lease ?: return
+    val key = reconciledOutboxBranchScope(snapshot.gatewayScope, snapshot.outboxScope()) ?: return
+    val reconcileDeferredEvent =
+      synchronized(outboxSessionMutationEventLock) {
+        val active = activeOutboxSessionMutations[key]
+        if (active?.lease == durable) {
+          activeOutboxSessionMutations.remove(key, active)
+        }
+        val deferredLeases = deferredOutboxSessionMutationEvents[key]
+        val deferred = deferredLeases?.remove(durable) == true
+        if (deferredLeases?.isEmpty() == true) deferredOutboxSessionMutationEvents.remove(key)
+        deferred
+      }
+    if (reconcileDeferredEvent) {
+      scheduleSessionsChangedBranchReconciliation(
+        eventGatewayScope = snapshot.gatewayScope,
+        sessionKey = snapshot.sessionKey,
+        ownerAgentId = snapshot.ownerAgentId,
+        matchingScopes = setOf(snapshot.outboxScope()),
+      )
+    }
+  }
+
+  private fun deferOutboxSessionMutationEventIfActive(
+    gatewayScope: ChatCacheScope?,
+    branchScope: ChatOutboxScope,
+    expectedEventReason: String?,
+  ): Boolean {
+    val key = reconciledOutboxBranchScope(gatewayScope, branchScope) ?: return false
+    synchronized(outboxSessionMutationEventLock) {
+      val active = activeOutboxSessionMutations[key] ?: return false
+      if (active.expectedEventReason != expectedEventReason) return false
+      deferredOutboxSessionMutationEvents.getOrPut(key) { mutableSetOf() }.add(active.lease)
+      return true
+    }
+  }
+
+  private fun outboxItemMatches(
+    item: ChatOutboxItem,
+    snapshot: SessionActionSnapshot,
+  ): Boolean = item.outboxScope() == snapshot.outboxScope()
+
+  private fun canPerformMessageSessionAction(snapshot: SessionActionSnapshot): Boolean =
+    _pendingRunCount.value == 0 &&
+      !_sessionBranchSwitching.value &&
+      _outboxPresentationRestored.value &&
+      _outboxItems.value.none { item ->
+        outboxItemMatches(item, snapshot) && item.status != ChatOutboxStatus.Failed
+      }
+
+  private fun canSwitchSessionBranch(snapshot: SessionActionSnapshot): Boolean =
+    _pendingRunCount.value == 0 &&
+      !_sessionBranchSwitching.value &&
+      _outboxPresentationRestored.value &&
+      _outboxItems.value.none { outboxItemMatches(it, snapshot) }
+
+  private suspend fun beginOutboxSessionMutation(
+    snapshot: SessionActionSnapshot,
+    expectedEventReason: String?,
+  ): SessionMutationLease? {
+    val outbox = commandOutbox ?: return SessionMutationLease(durable = null)
+    if (!outbox.supportsBranchCoordination) {
+      return if (_outboxItems.value.none { outboxItemMatches(it, snapshot) && it.status != ChatOutboxStatus.Failed }) {
+        SessionMutationLease(durable = null)
+      } else {
+        null
+      }
+    }
+    val gatewayId = snapshot.gatewayScope?.gatewayId ?: return null
+    var durable = outbox.beginSessionMutation(gatewayId, snapshot.outboxScope(), System.currentTimeMillis())
+    if (durable == null) {
+      val branchState = outbox.branchState(gatewayId, snapshot.outboxScope())
+      if (branchState?.needsReconciliation == true) {
+        markOutboxBranchUnreconciled(snapshot.gatewayScope, snapshot.outboxScope())
+        if (refreshSessionBranches(snapshot, branchState, BranchRefreshPurpose.Reconcile)) {
+          durable = outbox.beginSessionMutation(gatewayId, snapshot.outboxScope(), System.currentTimeMillis())
+        }
+      }
+    }
+    durable ?: return null
+    trackOutboxSessionMutation(snapshot, durable, expectedEventReason)
+    return SessionMutationLease(durable)
+  }
+
+  private suspend fun cancelOutboxSessionMutation(
+    snapshot: SessionActionSnapshot,
+    mutationLease: SessionMutationLease,
+  ) {
+    val outbox = commandOutbox ?: return
+    if (!outbox.supportsBranchCoordination) return
+    val durable = mutationLease.durable ?: return
+    val gatewayId = snapshot.gatewayScope?.gatewayId ?: return
+    outbox.cancelSessionMutation(gatewayId, snapshot.outboxScope(), durable)
+    releaseOutboxSessionMutation(snapshot, durable)
+  }
+
+  private suspend fun recoverOutboxAfterSessionMutationRefreshFailure(
+    snapshot: SessionActionSnapshot,
+    mutationLease: SessionMutationLease,
+    requestReconciliation: Boolean = true,
+    preserveReconciliationState: Boolean = false,
+  ): ChatOutboxBranchState? {
+    val outbox = commandOutbox ?: return null
+    if (!outbox.supportsBranchCoordination) return null
+    val gatewayId = snapshot.gatewayScope?.gatewayId ?: return null
+    markOutboxBranchUnreconciled(snapshot.gatewayScope, snapshot.outboxScope())
+    val reconciliationState =
+      outbox.demoteSessionMutationToReconciliationState(gatewayId, snapshot.outboxScope(), mutationLease.durable)
+    if (preserveReconciliationState && reconciliationState != null) {
+      // Publish before lease release so newly admitted turns can follow the authoritative branch.
+      // A restart loses this process hint and safely parks them instead.
+      reconciledOutboxBranchScope(snapshot.gatewayScope, snapshot.outboxScope())?.let { key ->
+        ambiguousMutationReconciliationStates[key] = reconciliationState
+      }
+    }
+    releaseOutboxSessionMutation(snapshot, mutationLease.durable)
+    if (requestReconciliation && _healthOk.value) requestOutboxFlush()
+    return reconciliationState
+  }
+
+  private suspend fun recoverOutboxAfterAmbiguousSessionMutation(
+    snapshot: SessionActionSnapshot,
+    mutationLease: SessionMutationLease,
+  ) {
+    val previousState =
+      recoverOutboxAfterSessionMutationRefreshFailure(
+        snapshot,
+        mutationLease,
+        requestReconciliation = false,
+        preserveReconciliationState = true,
+      )
+    val reconciliationKey = reconciledOutboxBranchScope(snapshot.gatewayScope, snapshot.outboxScope())
+    val generation = historyLoadGeneration.incrementAndGet()
+    val historyApplied = refreshHistoryForSessionAction(snapshot, generation)
+    val branchesApplied =
+      if (historyApplied) {
+        refreshSessionBranches(snapshot, previousState, BranchRefreshPurpose.Reconcile)
+      } else {
+        false
+      }
+    if (branchesApplied && reconciliationKey != null && previousState != null) {
+      ambiguousMutationReconciliationStates.remove(reconciliationKey, previousState)
+    }
+    if ((!historyApplied || !branchesApplied) && _healthOk.value) requestOutboxFlush()
+  }
+
+  private suspend fun confirmOutboxBranchChange(
+    snapshot: SessionActionSnapshot,
+    activeLeafEntryId: String?,
+    mutationLease: SessionMutationLease,
+  ): Boolean {
+    val outbox = commandOutbox ?: return true
+    if (!outbox.supportsBranchCoordination) return true
+    val gatewayId = snapshot.gatewayScope?.gatewayId ?: return false
+    val scope = snapshot.outboxScope()
+    markOutboxBranchUnreconciled(snapshot.gatewayScope, scope)
+    val confirmed =
+      outbox.confirmBranchChange(
+        gatewayId,
+        scope,
+        activeLeafEntryId,
+        OUTBOX_BRANCH_CHANGED_ERROR,
+        mutationLease.durable,
+      )
+    if (confirmed) {
+      markOutboxBranchReconciled(snapshot.gatewayScope, scope)
+      publishOutbox()
+      requestOutboxFlush()
+    }
+    return confirmed
+  }
+
+  private suspend fun branchState(snapshot: SessionActionSnapshot): ChatOutboxBranchState? {
+    val outbox = commandOutbox ?: return null
+    if (!outbox.supportsBranchCoordination) return null
+    val gatewayId = snapshot.gatewayScope?.gatewayId ?: return null
+    return outbox.branchState(gatewayId, snapshot.outboxScope())
+  }
+
+  private suspend fun requestSessionBranches(snapshot: SessionActionSnapshot): List<SessionBranch> =
+    requestSessionBranches(
+      gatewayId = snapshot.gatewayScope?.gatewayId,
+      sessionKey = snapshot.sessionKey,
+      ownerAgentId = snapshot.ownerAgentId,
+    )
+
+  private suspend fun requestSessionBranches(
+    gatewayId: String?,
+    sessionKey: String,
+    ownerAgentId: String,
+  ): List<SessionBranch> {
+    val params =
+      buildJsonObject {
+        put("sessionKey", JsonPrimitive(sessionKey))
+        put("agentId", JsonPrimitive(ownerAgentId))
+      }
+    val root =
+      json
+        .parseToJsonElement(requestGatewayBound(gatewayId, "sessions.branches.list", params.toString()))
+        .asObjectOrNull()
+        ?: throw IllegalStateException("sessions.branches.list returned an invalid response")
+    val entries =
+      root["branches"].asArrayOrNull()
+        ?: throw IllegalStateException("sessions.branches.list returned invalid branches")
+    return entries.map { element ->
+      val obj =
+        element.asObjectOrNull()
+          ?: throw IllegalStateException("sessions.branches.list returned an invalid branch")
+      val leaf =
+        obj["leafEntryId"]
+          .asStringOrNull()
+          ?.trim()
+          ?.takeIf { it.isNotEmpty() }
+          ?: throw IllegalStateException("sessions.branches.list returned a branch without a leaf")
+      val headline =
+        obj["headline"].asStringOrNull()
+          ?: throw IllegalStateException("sessions.branches.list returned a branch without a headline")
+      val messageCount =
+        obj["messageCount"]
+          .asLongOrNull()
+          ?.takeIf { it >= 0 }
+          ?.coerceAtMost(Int.MAX_VALUE.toLong())
+          ?.toInt()
+          ?: throw IllegalStateException("sessions.branches.list returned an invalid message count")
+      val active =
+        obj["active"].asBooleanOrNull()
+          ?: throw IllegalStateException("sessions.branches.list returned an invalid active flag")
+      val updatedAt =
+        obj["updatedAt"]?.let { value ->
+          when (value) {
+            JsonNull -> null
+            else ->
+              value.asStringOrNull()
+                ?: throw IllegalStateException("sessions.branches.list returned an invalid timestamp")
+          }
+        }
+      SessionBranch(
+        leafEntryId = leaf,
+        headline = headline,
+        messageCount = messageCount,
+        updatedAt = updatedAt,
+        active = active,
+      )
+    }
+  }
+
+  private fun activeBranchLeafEntryId(branches: List<SessionBranch>): String? =
+    branches
+      .singleOrNull { it.active }
+      ?.leafEntryId
+      ?.trim()
+      ?.takeIf { it.isNotEmpty() }
+
+  private suspend fun refreshSessionBranches(
+    snapshot: SessionActionSnapshot,
+    previousState: ChatOutboxBranchState?,
+    purpose: BranchRefreshPurpose,
+    mutationLease: SessionMutationLease? = null,
+  ): Boolean {
+    val generation = sessionBranchesRefreshGeneration.incrementAndGet()
+    if (isCurrentSessionAction(snapshot)) _sessionBranchesLoading.value = true
+    return try {
+      val branches = requestSessionBranches(snapshot)
+      if (!isCurrentSessionAction(snapshot) || generation != sessionBranchesRefreshGeneration.get()) return false
+      val activeLeaf = if (branches.isEmpty()) null else activeBranchLeafEntryId(branches) ?: return false
+      val outbox = commandOutbox
+      val gatewayId = snapshot.gatewayScope?.gatewayId
+      val scope = snapshot.outboxScope()
+      val stateApplied =
+        when {
+          outbox == null || !outbox.supportsBranchCoordination -> true
+          gatewayId == null -> false
+          purpose == BranchRefreshPurpose.FinalizeMutation ->
+            confirmOutboxBranchChange(snapshot, activeLeaf, mutationLease ?: return false)
+          purpose == BranchRefreshPurpose.Reconcile && previousState != null ->
+            outbox.reconcileBranchScope(
+              gatewayId = gatewayId,
+              scope = scope,
+              previousState = previousState,
+              activeLeafEntryId = activeLeaf,
+              branchLeafEntryIds = branches.mapTo(mutableSetOf()) { it.leafEntryId },
+              activeTranscriptEntryIds = _messages.value.mapNotNullTo(mutableSetOf()) { it.entryId },
+              lastError = OUTBOX_BRANCH_CHANGED_ERROR,
+            )
+          purpose == BranchRefreshPurpose.ReadOnly -> {
+            if (previousState == null || previousState.needsReconciliation) return false
+            outbox.reconcileBranchScope(
+              gatewayId = gatewayId,
+              scope = scope,
+              previousState = previousState,
+              activeLeafEntryId = activeLeaf,
+              branchLeafEntryIds = branches.mapTo(mutableSetOf()) { it.leafEntryId },
+              activeTranscriptEntryIds = _messages.value.mapNotNullTo(mutableSetOf()) { it.entryId },
+              lastError = OUTBOX_BRANCH_CHANGED_ERROR,
+            )
+          }
+          else -> false
+        }
+      if (!stateApplied) {
+        markOutboxBranchUnreconciled(snapshot.gatewayScope, scope)
+        return false
+      }
+      if (outbox?.supportsBranchCoordination == true && !markOutboxBranchReconciled(snapshot.gatewayScope, scope)) {
+        return false
+      }
+      _sessionBranches.value = branches
+      publishOutbox()
+      requestOutboxFlush()
+      true
+    } catch (err: CancellationException) {
+      throw err
+    } catch (err: Throwable) {
+      if (branchListingUnsupported(err)) {
+        if (
+          purpose == BranchRefreshPurpose.FinalizeMutation ||
+          previousState?.needsReconciliation == true ||
+          previousState?.switchPendingSinceMs != null
+        ) {
+          return false
+        }
+        val outbox = commandOutbox
+        outbox?.supportsBranchCoordination != true ||
+          markOutboxBranchReconciled(snapshot.gatewayScope, snapshot.outboxScope())
+      } else {
+        false
+      }
+    } finally {
+      if (isCurrentSessionAction(snapshot) && generation == sessionBranchesRefreshGeneration.get()) {
+        _sessionBranchesLoading.value = false
+      }
+    }
+  }
+
+  private fun branchListingUnsupported(error: Throwable): Boolean = error.message?.contains("unknown method: sessions.branches.list", ignoreCase = true) == true
+
+  private suspend fun refreshHistoryForSessionAction(
+    snapshot: SessionActionSnapshot,
+    generation: Long,
+  ): Boolean {
+    if (!isCurrentSessionAction(snapshot)) return false
+    return try {
+      fetchAndApplyHistory(
+        sessionKey = snapshot.sessionKey,
+        generation = generation,
+        updateSessionInfo = true,
+      ) == HistoryRefreshResult.Applied
+    } catch (err: CancellationException) {
+      throw err
+    } catch (_: Throwable) {
+      false
+    }
+  }
+
+  private suspend fun reloadHistoryAfterDefinitiveSessionMutationFailure(snapshot: SessionActionSnapshot) {
+    if (!isCurrentSessionAction(snapshot)) return
+    val generation = historyLoadGeneration.incrementAndGet()
+    refreshHistoryForSessionAction(snapshot, generation)
   }
 
   /**
@@ -1396,7 +2113,16 @@ class ChatController internal constructor(
   ): Long {
     val generation = historyLoadGeneration.incrementAndGet()
     val owner = normalizeSessionSelectionOwner(key, ownerAgentId)
-    if (_sessionKey.value != key || _sessionOwnerAgentId.value != owner) chatSelectionGeneration.incrementAndGet()
+    val selectionChanged = _sessionKey.value != key || _sessionOwnerAgentId.value != owner
+    if (selectionChanged) {
+      chatSelectionGeneration.incrementAndGet()
+      sessionBranchesRefreshGeneration.incrementAndGet()
+      sessionBranchSwitchGeneration.incrementAndGet()
+      sessionBranchSwitchClaimed.set(false)
+      _sessionBranches.value = emptyList()
+      _sessionBranchesLoading.value = false
+      _sessionBranchSwitching.value = false
+    }
     _sessionKey.value = key
     _sessionOwnerAgentId.value = owner
     applyThinkingMetadata(_sessions.value.firstOrNull { it.key == key })
@@ -1617,6 +2343,15 @@ class ChatController internal constructor(
         // Captured for reconnect: the queued bubble is visible and flush delivers it later.
         return true
       }
+      if (
+        commandOutbox?.supportsBranchCoordination == true &&
+        journaled.outboxScope()?.let { isOutboxBranchReconciled(sendCacheScope, it) } != true
+      ) {
+        // A remote branch mutation invalidates ownership before its async refresh starts.
+        // Keep new input durable, but let the reconciled FIFO lane decide its branch.
+        requestOutboxFlush()
+        return true
+      }
       // The startup recovery sweep flips every 'sending' row to delivery-unconfirmed. Claiming
       // only after it completes means the sweep can never hit this live dispatch; a failed
       // sweep leaves the row queued so reconnect flush owns delivery instead.
@@ -1637,7 +2372,7 @@ class ChatController internal constructor(
       // concurrent flush claim must not lead to a second send of the same idempotency key.
       val claimed =
         try {
-          outbox.claimForSending(journaled.id, 0, null)
+          outbox.claimForSendingIfAttempt(journaled.id, journaled.attemptVersion, 0, null)
         } catch (err: CancellationException) {
           throw err
         } catch (_: Throwable) {
@@ -1957,10 +2692,15 @@ class ChatController internal constructor(
     return rows.any { other ->
       other.id != row.id &&
         other.createdAtMs < row.createdAtMs &&
-        sameOutboxSession(other.sessionKey, row.sessionKey) &&
+        sameOutboxScope(other, row) &&
         outboxRowUnresolved(other)
     }
   }
+
+  private fun sameOutboxScope(
+    left: ChatOutboxItem,
+    right: ChatOutboxItem,
+  ): Boolean = left.outboxScope() == right.outboxScope()
 
   // Queued/sending rows are still ahead in FIFO order, and an orphaned accepted row holds its
   // session only until history proof confirms or parks it (a bounded window). Parked failed
@@ -2009,7 +2749,14 @@ class ChatController internal constructor(
     if (status != ChatOutboxStatus.Accepted) acknowledgedRunIdByRowId.remove(row.id)
     val persisted =
       try {
-        outbox.updateStatus(row.id, status, row.retryCount, lastError)
+        outbox.updateStatusIfAttempt(
+          row.id,
+          row.attemptVersion,
+          status,
+          row.retryCount,
+          lastError,
+          expectedStatus = ChatOutboxStatus.Sending,
+        )
       } catch (err: CancellationException) {
         throw err
       } catch (_: Throwable) {
@@ -2556,6 +3303,9 @@ class ChatController internal constructor(
     refreshSessions: Boolean,
     runIdsToReconcile: Set<String> = emptySet(),
   ) {
+    val branchSnapshot = currentSessionActionSnapshot(sessionKey)
+    val preBootstrapBranchState = branchSnapshot?.let { branchState(it) }
+    branchSnapshot?.let { markOutboxBranchUnreconciled(it.gatewayScope, it.outboxScope()) }
     val ownsReconnectRecovery =
       synchronized(gatewayScopeApplyLock) {
         reconnectRecoveryGeneration == generation
@@ -2579,6 +3329,14 @@ class ChatController internal constructor(
           _historyLoading.value = false
         }
         return
+      }
+
+      if (branchSnapshot != null && isCurrentSessionAction(branchSnapshot)) {
+        refreshSessionBranches(
+          snapshot = branchSnapshot,
+          previousState = preBootstrapBranchState,
+          purpose = BranchRefreshPurpose.Reconcile,
+        )
       }
 
       if (!ownsReconnectRecovery) {
@@ -2752,7 +3510,41 @@ class ChatController internal constructor(
     completeReconnectRecoveryIfOwned(sessionKey, generation)
     persistTranscript(requestCacheScope, requestAgentId, sessionKey, history.messages)
     confirmDurableSendsFromHistory(requestCacheScope, history, requestAgentId)
+    observeOutboxTranscriptTip(requestCacheScope, sessionKey, requestAgentId, history.messages)
     return HistoryRefreshResult.Applied
+  }
+
+  private suspend fun observeOutboxTranscriptTip(
+    gatewayScope: ChatCacheScope?,
+    sessionKey: String,
+    ownerAgentId: String,
+    messages: List<ChatMessage>,
+  ) {
+    val outbox = commandOutbox ?: return
+    if (!outbox.supportsBranchCoordination) return
+    val gatewayId = gatewayScope?.gatewayId ?: return
+    val tip = messages.asReversed().firstNotNullOfOrNull { it.entryId?.trim()?.takeIf(String::isNotEmpty) } ?: return
+    val branchScope = ChatOutboxScope(sessionKey, ownerAgentId.trim().lowercase())
+    if (!isOutboxBranchReconciled(gatewayScope, branchScope)) return
+    val state = outbox.branchState(gatewayId, branchScope) ?: return
+    if (state.switchPendingSinceMs != null || state.needsReconciliation) return
+    val activeEntryIds = messages.mapNotNullTo(mutableSetOf()) { it.entryId }
+    val previousLeaf = state.lastActiveLeafEntryId
+    val canAdvance =
+      if (previousLeaf == null) {
+        !state.hadPendingCommands
+      } else {
+        previousLeaf in activeEntryIds
+      }
+    if (canAdvance) {
+      if (!outbox.updateLastActiveLeafEntryId(gatewayId, branchScope, tip, state.epoch, state.revision)) {
+        markOutboxBranchUnreconciled(gatewayScope, branchScope)
+      }
+      return
+    }
+    markOutboxBranchUnreconciled(gatewayScope, branchScope)
+    outbox.demoteSessionMutationToReconciliation(gatewayId, branchScope)
+    if (_healthOk.value) requestOutboxFlush()
   }
 
   private suspend fun awaitMainSessionReadiness(
@@ -3260,27 +4052,35 @@ class ChatController internal constructor(
     val outbox = commandOutbox ?: return
     scope.launch {
       val outboxScope = currentCacheScope() ?: return@launch
-      val row = _outboxItems.value.firstOrNull { it.id == id }
+      val row = _outboxItems.value.firstOrNull { it.id == id } ?: return@launch
       // A gated command row is re-armed for the current connection epoch only; retrying it
       // while disconnected parks it again at the next reconnect instead of silently replaying.
-      val gatedEpoch = row?.gatedEpoch?.let { outboxScope.connectionGeneration }
+      val gatedEpoch = row.gatedEpoch?.let { outboxScope.connectionGeneration }
       val retryOwnerAgentId =
-        row?.ownerAgentId ?: row?.sessionKey?.let(::resolveAgentIdFromMainSessionKey)
-      if (row?.ownerAgentId == null && retryOwnerAgentId == null) return@launch
+        row.ownerAgentId ?: resolveAgentIdFromMainSessionKey(row.sessionKey)
+      if (row.ownerAgentId == null && retryOwnerAgentId == null) return@launch
       // requeueForRetry refreshes createdAt and requires this gateway's Failed state. The
       // compare-and-set keeps stale gateway or double Retry taps from reviving an in-flight row.
       val requeued =
         runCatching {
-          outbox.requeueForRetry(
+          outbox.requeueForRetryIfCurrent(
             gatewayId = outboxScope.gatewayId,
             id = id,
+            expectedAttemptVersion = row.attemptVersion,
+            expectedRetryCount = row.retryCount,
+            expectedLastError = row.lastError,
             nowMs = System.currentTimeMillis(),
             gatedEpoch = gatedEpoch,
             ownerAgentId = retryOwnerAgentId,
+            replacementId = UUID.randomUUID().toString(),
           )
         }.getOrDefault(0)
       publishOutbox()
-      if (requeued > 0 && _healthOk.value) requestOutboxFlush()
+      if (requeued > 0) {
+        acknowledgedRunIdByRowId.remove(id)
+        unconfirmedSightings.remove(id)
+        if (_healthOk.value) requestOutboxFlush()
+      }
     }
   }
 
@@ -3300,13 +4100,20 @@ class ChatController internal constructor(
     val outboxScope = currentCacheScope()
     if (outboxScope == null) {
       _outboxItems.value = emptyList()
+      _outboxPresentationRestored.value = false
       return
     }
-    val items = runCatching { outbox.load(outboxScope.gatewayId) }.getOrDefault(emptyList())
+    val items =
+      runCatching { outbox.load(outboxScope.gatewayId) }
+        .getOrElse {
+          _outboxPresentationRestored.value = false
+          return
+        }
     // Publish under the scope lock so rows loaded for an old gateway cannot land after a switch.
     synchronized(gatewayScopeApplyLock) {
       if (outboxScope == currentCacheScope()) {
         _outboxItems.value = items
+        _outboxPresentationRestored.value = true
       }
     }
   }
@@ -3316,21 +4123,81 @@ class ChatController internal constructor(
    * repeatedly while a flush is already draining the queue.
    */
   private fun requestOutboxFlush() {
-    if (commandOutbox == null) return
+    val outbox = commandOutbox ?: return
     outboxFlushRequested.set(true)
+    if (outbox.supportsBranchCoordination) {
+      outboxBranchReconcileRequested.set(true)
+      scope.launch { reconcileOutboxBranchesThenDrain(outbox) }
+      return
+    }
     scope.launch { drainOutboxFlushRequests() }
   }
 
+  private suspend fun reconcileOutboxBranchesThenDrain(outbox: ChatCommandOutbox) {
+    if (!outboxBranchReconcileInFlight.compareAndSet(false, true)) return
+    // Reconciliation and delivery have separate single-flight owners. If delivery won the race,
+    // leave this request pending so its finally block schedules reconciliation after the drain.
+    if (outboxFlushInFlight.get()) {
+      outboxBranchReconcileInFlight.set(false)
+      return
+    }
+    try {
+      while (outboxBranchReconcileRequested.getAndSet(false)) {
+        val gatewayScope = currentCacheScope()
+        if (_healthOk.value && gatewayScope != null) {
+          reconcilePendingOutboxBranchScopes(outbox, gatewayScope)
+        }
+      }
+    } finally {
+      outboxBranchReconcileInFlight.set(false)
+    }
+    if (outboxBranchReconcileRequested.get()) {
+      scope.launch { reconcileOutboxBranchesThenDrain(outbox) }
+      return
+    }
+    drainOutboxFlushRequests()
+  }
+
   private suspend fun drainOutboxFlushRequests() {
+    val branchAwareOutbox = commandOutbox?.takeIf { it.supportsBranchCoordination }
     if (!outboxFlushInFlight.compareAndSet(false, true)) return
     try {
+      if (
+        branchAwareOutbox != null &&
+        (outboxBranchReconcileInFlight.get() || outboxBranchReconcileRequested.get())
+      ) {
+        outboxFlushRequested.set(true)
+        if (!outboxBranchReconcileInFlight.get()) {
+          scope.launch { reconcileOutboxBranchesThenDrain(branchAwareOutbox) }
+        }
+        return
+      }
       while (outboxFlushRequested.getAndSet(false)) {
+        if (
+          branchAwareOutbox != null &&
+          (outboxBranchReconcileInFlight.get() || outboxBranchReconcileRequested.get())
+        ) {
+          outboxFlushRequested.set(true)
+          if (!outboxBranchReconcileInFlight.get()) {
+            scope.launch { reconcileOutboxBranchesThenDrain(branchAwareOutbox) }
+          }
+          return
+        }
         flushOutboxPass()
       }
     } finally {
       outboxFlushInFlight.set(false)
       // Close the release race: a requester that observed in-flight ownership leaves this bit set.
       if (outboxFlushRequested.get()) requestOutboxFlush()
+    }
+  }
+
+  private fun scheduleOutboxBranchReconciliationRetry() {
+    if (!outboxBranchReconcileRetryScheduled.compareAndSet(false, true)) return
+    scope.launch {
+      delay(recoveryHistoryRetryDelayMs)
+      outboxBranchReconcileRetryScheduled.set(false)
+      if (_healthOk.value) requestOutboxFlush()
     }
   }
 
@@ -3357,7 +4224,7 @@ class ChatController internal constructor(
           publishOutbox()
           continue
         }
-        val next = nextFlushableRow(rows) ?: break
+        val next = nextFlushableRow(rows, flushScope) ?: break
         when (sendOutboxItem(outbox, next, flushScope)) {
           OutboxSendOutcome.Sent -> flushedAny = true
           OutboxSendOutcome.Continue -> {}
@@ -3389,14 +4256,118 @@ class ChatController internal constructor(
    * an unresolved row (queued behind a dispatch, ambiguous, or awaiting proof) holds only its own
    * session while other sessions keep flushing.
    */
-  private fun nextFlushableRow(rows: List<ChatOutboxItem>): ChatOutboxItem? {
-    val blockedSessions = mutableSetOf<String>()
+  private fun nextFlushableRow(
+    rows: List<ChatOutboxItem>,
+    gatewayScope: ChatCacheScope,
+  ): ChatOutboxItem? {
+    val blockedSessions = mutableSetOf<Any>()
     for (row in rows) {
-      val session = normalizeRequestedSessionKey(row.sessionKey)
-      if (row.status == ChatOutboxStatus.Queued && session !in blockedSessions) return row
+      val session: Any = row.outboxScope() ?: normalizeRequestedSessionKey(row.sessionKey)
+      val branchReady =
+        !requireNotNull(commandOutbox).supportsBranchCoordination ||
+          row.outboxScope()?.let { isOutboxBranchReconciled(gatewayScope, it) } == true
+      if (row.status == ChatOutboxStatus.Queued && session !in blockedSessions && branchReady) return row
       if (outboxRowUnresolved(row)) blockedSessions.add(session)
     }
     return null
+  }
+
+  private suspend fun reconcilePendingOutboxBranchScopes(
+    outbox: ChatCommandOutbox,
+    flushScope: ChatCacheScope,
+  ) {
+    if (!outbox.supportsBranchCoordination) return
+    val rows = runCatching { outbox.load(flushScope.gatewayId) }.getOrDefault(emptyList())
+    val grouped =
+      rows
+        .filter { it.status != ChatOutboxStatus.Failed }
+        .mapNotNull { row -> row.outboxScope()?.let { scope -> scope to row } }
+        .groupBy(keySelector = { it.first }, valueTransform = { it.second })
+    val branchScopes = grouped.keys.toMutableSet()
+    ambiguousMutationReconciliationStates.keys
+      .asSequence()
+      .filter { it.gatewayScope == flushScope }
+      .mapTo(branchScopes) { it.branchScope }
+    for (branchScope in branchScopes) {
+      val scopedRows = grouped[branchScope].orEmpty()
+      if (isOutboxBranchReconciled(flushScope, branchScope)) continue
+      val state = outbox.branchState(flushScope.gatewayId, branchScope) ?: continue
+      val reconciliationKey = ReconciledOutboxBranchScope(flushScope, branchScope)
+      val savedCandidate = ambiguousMutationReconciliationStates[reconciliationKey]
+      val savedState =
+        savedCandidate?.takeIf { it.revision == state.revision }
+          ?: state.also {
+            if (savedCandidate != null) ambiguousMutationReconciliationStates.remove(reconciliationKey, savedCandidate)
+          }
+      try {
+        val sessionKey = normalizeRequestedSessionKey(scopedRows.firstOrNull()?.sessionKey ?: branchScope.sessionKey)
+        val isVisibleScope =
+          sameOutboxSession(branchScope.sessionKey, _sessionKey.value) &&
+            branchScope.ownerAgentId == resolveAgentIdForSessionKey(_sessionKey.value)?.trim()?.lowercase()
+        val activeTranscriptEntryIds =
+          if (isVisibleScope) {
+            val snapshot =
+              currentSessionActionSnapshot(_sessionKey.value)
+                ?.takeIf { it.outboxScope() == branchScope }
+                ?: continue
+            val generation = historyLoadGeneration.incrementAndGet()
+            if (!refreshHistoryForSessionAction(snapshot, generation)) {
+              continue
+            }
+            _messages.value.mapNotNullTo(mutableSetOf()) { it.entryId }
+          } else {
+            val historyJson =
+              requestGatewayBound(
+                flushScope.gatewayId,
+                "chat.history",
+                buildJsonObject {
+                  put("sessionKey", JsonPrimitive(sessionKey))
+                  put("agentId", JsonPrimitive(branchScope.ownerAgentId))
+                }.toString(),
+              )
+            parseHistory(historyJson, sessionKey = sessionKey, previousMessages = emptyList())
+              .messages
+              .mapNotNullTo(mutableSetOf()) { it.entryId }
+          }
+        val branches =
+          requestSessionBranches(
+            gatewayId = flushScope.gatewayId,
+            sessionKey = sessionKey,
+            ownerAgentId = branchScope.ownerAgentId,
+          )
+        val activeLeaf = if (branches.isEmpty()) null else activeBranchLeafEntryId(branches) ?: continue
+        if (
+          outbox.reconcileBranchScope(
+            gatewayId = flushScope.gatewayId,
+            scope = branchScope,
+            previousState = savedState,
+            activeLeafEntryId = activeLeaf,
+            branchLeafEntryIds = branches.mapTo(mutableSetOf()) { it.leafEntryId },
+            activeTranscriptEntryIds = activeTranscriptEntryIds,
+            lastError = OUTBOX_BRANCH_CHANGED_ERROR,
+          )
+        ) {
+          markOutboxBranchReconciled(flushScope, branchScope)
+          if (savedCandidate != null) ambiguousMutationReconciliationStates.remove(reconciliationKey, savedCandidate)
+        }
+      } catch (err: Throwable) {
+        if (err is CancellationException) throw err
+        if (
+          branchListingUnsupported(err) &&
+          !state.needsReconciliation &&
+          state.switchPendingSinceMs == null
+        ) {
+          markOutboxBranchReconciled(flushScope, branchScope)
+        }
+      } finally {
+        if (!isOutboxBranchReconciled(flushScope, branchScope)) {
+          // Keep retries on the existing single-flight reconciliation lane; delivery stays
+          // gated until authoritative history and branch metadata both reconcile this scope.
+          scheduleOutboxBranchReconciliationRetry()
+        }
+      }
+    }
+    publishOutbox()
   }
 
   private data class OutboxSessionOwner(
@@ -3508,15 +4479,15 @@ class ChatController internal constructor(
           (row.ownerAgentId ?: resolveAgentIdFromMainSessionKey(row.sessionKey)) == ownerAgentId
       }
     var changed = false
-    val confirmed = sessionRows.filter { it.id in provenIds }.map { it.id }.toSet()
+    val confirmed = sessionRows.filter { it.id in provenIds }.associate { it.id to it.attemptVersion }
     if (confirmed.isNotEmpty()) {
-      val removed = runCatching { outbox.confirmDelivered(confirmed) }.getOrDefault(0)
-      confirmed.forEach(unconfirmedSightings::remove)
-      confirmed.forEach(acknowledgedRunIdByRowId::remove)
+      val removed = runCatching { outbox.confirmDeliveredAttempts(confirmed) }.getOrDefault(0)
+      confirmed.keys.forEach(unconfirmedSightings::remove)
+      confirmed.keys.forEach(acknowledgedRunIdByRowId::remove)
       changed = removed > 0
     }
     for (row in sessionRows) {
-      if (row.status != ChatOutboxStatus.Accepted || row.id in confirmed) continue
+      if (row.status != ChatOutboxStatus.Accepted || row.id in confirmed.keys) continue
       if (locallyOwnedOutboxRow(row.id)) continue
       // inFlightRunId must be non-null before the map compare: a missing in-flight run would
       // otherwise match rows with no acknowledged id (null == null) and block parking forever.
@@ -3588,7 +4559,14 @@ class ChatController internal constructor(
     lastError: String?,
   ): Int? =
     try {
-      outbox.updateStatus(item.id, status, item.retryCount, lastError)
+      outbox.updateStatusIfAttempt(
+        item.id,
+        item.attemptVersion,
+        status,
+        item.retryCount,
+        lastError,
+        expectedStatus = item.status,
+      )
     } catch (err: CancellationException) {
       throw err
     } catch (_: Throwable) {
@@ -3600,7 +4578,7 @@ class ChatController internal constructor(
     item: ChatOutboxItem,
   ): Int? =
     try {
-      outbox.claimForSending(item.id, item.retryCount, item.lastError)
+      outbox.claimForSendingIfAttempt(item.id, item.attemptVersion, item.retryCount, item.lastError)
     } catch (err: CancellationException) {
       throw err
     } catch (_: Throwable) {
@@ -3994,7 +4972,47 @@ class ChatController internal constructor(
 
   private fun handleSessionsChangedEvent(payloadJson: String) {
     val payload = json.parseToJsonElement(payloadJson).asObjectOrNull() ?: return
-    if (payload["reason"].asStringOrNull() == "delete") {
+    val reason = payload["reason"].asStringOrNull()
+    if (reason == "rewind" || reason == "branch-switch") {
+      // Mutation events do not contain a session preview. Refresh the drawer even for a
+      // background session and even when this event is deferred behind a local mutation lease.
+      refreshSessionsForCurrentWindow()
+      val sessionKey =
+        (payload["sessionKey"].asStringOrNull() ?: payload["key"].asStringOrNull())
+          ?.trim()
+          ?.takeIf { it.isNotEmpty() }
+          ?: return
+      val ownerAgentId = payload["agentId"].asStringOrNull()?.trim()?.lowercase()
+      val eventGatewayScope = currentCacheScope()
+      val matchingScopes =
+        reconciledOutboxBranchScopes
+          .filter { candidate ->
+            candidate.gatewayScope == eventGatewayScope &&
+              sameOutboxSession(candidate.branchScope.sessionKey, sessionKey) &&
+              (ownerAgentId == null || candidate.branchScope.ownerAgentId == ownerAgentId)
+          }.mapTo(mutableSetOf()) { it.branchScope }
+      _outboxItems.value
+        .mapNotNull { it.outboxScope() }
+        .filterTo(matchingScopes) { candidate ->
+          sameOutboxSession(candidate.sessionKey, sessionKey) &&
+            (ownerAgentId == null || candidate.ownerAgentId == ownerAgentId)
+        }
+      if (ownerAgentId != null) {
+        matchingScopes += ChatOutboxScope(sessionKey, ownerAgentId)
+      }
+      matchingScopes.removeAll { candidate ->
+        deferOutboxSessionMutationEventIfActive(eventGatewayScope, candidate, reason)
+      }
+      if (matchingScopes.isEmpty()) return
+      scheduleSessionsChangedBranchReconciliation(
+        eventGatewayScope = eventGatewayScope,
+        sessionKey = sessionKey,
+        ownerAgentId = ownerAgentId,
+        matchingScopes = matchingScopes,
+      )
+      return
+    }
+    if (reason == "delete") {
       val sessionKey = payload["sessionKey"].asStringOrNull() ?: payload["key"].asStringOrNull()
       val ownerAgentId = payload["agentId"].asStringOrNull()
       if (removeSessionEntry(sessionKey, ownerAgentId = ownerAgentId)) {
@@ -4007,6 +5025,44 @@ class ChatController internal constructor(
       return
     }
     applySessionEvent(payload, refreshWhenMissing = true)
+  }
+
+  private fun scheduleSessionsChangedBranchReconciliation(
+    eventGatewayScope: ChatCacheScope?,
+    sessionKey: String,
+    ownerAgentId: String?,
+    matchingScopes: Set<ChatOutboxScope>,
+  ) {
+    matchingScopes.forEach { markOutboxBranchUnreconciled(eventGatewayScope, it) }
+    val currentSnapshot =
+      _sessionKey.value
+        .takeIf { sameOutboxSession(it, sessionKey) }
+        ?.let(::currentSessionActionSnapshot)
+        ?.takeIf { ownerAgentId == null || ownerAgentId == it.ownerAgentId }
+    val eventHistoryGeneration = currentSnapshot?.let { historyLoadGeneration.incrementAndGet() }
+    scope.launch {
+      val outbox = commandOutbox
+      val gatewayId = eventGatewayScope?.gatewayId
+      if (outbox?.supportsBranchCoordination == true && gatewayId != null) {
+        for (branchScope in matchingScopes) {
+          outbox.demoteSessionMutationToReconciliation(gatewayId, branchScope)
+        }
+      }
+      val snapshot = currentSnapshot
+      if (snapshot == null || eventHistoryGeneration == null) {
+        requestOutboxFlush()
+        return@launch
+      }
+      val previousState = branchState(snapshot)
+      val historyApplied = refreshHistoryForSessionAction(snapshot, eventHistoryGeneration)
+      val branchesApplied =
+        if (historyApplied) {
+          refreshSessionBranches(snapshot, previousState, BranchRefreshPurpose.Reconcile)
+        } else {
+          false
+        }
+      if (!historyApplied || !branchesApplied) requestOutboxFlush()
+    }
   }
 
   private fun handleSessionMessageEvent(payloadJson: String) {
@@ -4530,6 +5586,7 @@ class ChatController internal constructor(
           content = content,
           timestampMs = ts,
           idempotencyKey = obj["idempotencyKey"].asStringOrNull(),
+          entryId = obj["__openclaw"].asObjectOrNull()?.get("id").asStringOrNull(),
         )
       }
 
@@ -5227,6 +6284,7 @@ internal fun reconcileMessageIds(
     message.copy(
       id = previousMessage.id,
       content = preserveOptimisticAudioDuration(previous = previousMessage, incoming = message),
+      entryId = message.entryId,
     )
   }
 }

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatModels.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatModels.kt
@@ -1,4 +1,5 @@
 package ai.openclaw.app.chat
+
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
@@ -24,6 +25,21 @@ data class ChatMessage(
   val content: List<ChatMessageContent>,
   val timestampMs: Long?,
   val idempotencyKey: String? = null,
+  /** Canonical transcript-tree identity supplied by chat.history. */
+  val entryId: String? = null,
+)
+
+/** One selectable transcript branch returned by sessions.branches.list. */
+data class SessionBranch(
+  val leafEntryId: String,
+  val headline: String,
+  val messageCount: Int,
+  val updatedAt: String?,
+  val active: Boolean,
+)
+
+data class SessionRewindResult(
+  val editorText: String?,
 )
 
 data class ChatTranscriptAnchorState(

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatTranscriptCache.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatTranscriptCache.kt
@@ -290,6 +290,8 @@ class RoomChatTranscriptCache internal constructor(
         content = decodeTextParts(row.textPartsJson).map { ChatMessageContent(type = "text", text = it) },
         timestampMs = row.timestampMs,
         idempotencyKey = row.idempotencyKey,
+        // Canonical tree ids stay live-only; cached rows regain actions after history refresh.
+        entryId = null,
       )
     }
   }

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ClientDatabases.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ClientDatabases.kt
@@ -589,6 +589,8 @@ private class DeferredChatTranscriptCache(
 private class DeferredChatCommandOutbox(
   private val ready: suspend () -> OpenedAndroidClientDatabases,
 ) : ChatCommandOutbox {
+  override val supportsBranchCoordination: Boolean = true
+
   override suspend fun load(gatewayId: String): List<ChatOutboxItem> = ready().commandOutbox.load(gatewayId)
 
   override suspend fun wasAdmitted(id: String): Boolean = ready().commandOutbox.wasAdmitted(id)
@@ -617,11 +619,27 @@ private class DeferredChatCommandOutbox(
     lastError: String?,
   ): Int = ready().commandOutbox.updateStatus(id, status, retryCount, lastError)
 
+  override suspend fun updateStatusIfAttempt(
+    id: String,
+    expectedAttemptVersion: Int,
+    status: ChatOutboxStatus,
+    retryCount: Int,
+    lastError: String?,
+    expectedStatus: ChatOutboxStatus?,
+  ): Int = ready().commandOutbox.updateStatusIfAttempt(id, expectedAttemptVersion, status, retryCount, lastError, expectedStatus)
+
   override suspend fun claimForSending(
     id: String,
     retryCount: Int,
     lastError: String?,
   ): Int = ready().commandOutbox.claimForSending(id, retryCount, lastError)
+
+  override suspend fun claimForSendingIfAttempt(
+    id: String,
+    expectedAttemptVersion: Int,
+    retryCount: Int,
+    lastError: String?,
+  ): Int = ready().commandOutbox.claimForSendingIfAttempt(id, expectedAttemptVersion, retryCount, lastError)
 
   override suspend fun pinSessionKey(
     id: String,
@@ -636,11 +654,104 @@ private class DeferredChatCommandOutbox(
     ownerAgentId: String?,
   ): Int = ready().commandOutbox.requeueForRetry(gatewayId, id, nowMs, gatedEpoch, ownerAgentId)
 
+  override suspend fun requeueForRetryIfCurrent(
+    gatewayId: String,
+    id: String,
+    expectedAttemptVersion: Int,
+    expectedRetryCount: Int,
+    expectedLastError: String?,
+    nowMs: Long,
+    gatedEpoch: Long?,
+    ownerAgentId: String?,
+    replacementId: String?,
+  ): Int =
+    ready()
+      .commandOutbox
+      .requeueForRetryIfCurrent(
+        gatewayId,
+        id,
+        expectedAttemptVersion,
+        expectedRetryCount,
+        expectedLastError,
+        nowMs,
+        gatedEpoch,
+        ownerAgentId,
+        replacementId,
+      )
+
   override suspend fun delete(id: String) = ready().commandOutbox.delete(id)
 
   override suspend fun deleteIfQueued(id: String): Boolean = ready().commandOutbox.deleteIfQueued(id)
 
   override suspend fun confirmDelivered(ids: Set<String>): Int = ready().commandOutbox.confirmDelivered(ids)
+
+  override suspend fun confirmDeliveredAttempts(ids: Map<String, Int>): Int = ready().commandOutbox.confirmDeliveredAttempts(ids)
+
+  override suspend fun branchState(
+    gatewayId: String,
+    scope: ChatOutboxScope,
+  ): ChatOutboxBranchState? = ready().commandOutbox.branchState(gatewayId, scope)
+
+  override suspend fun beginSessionMutation(
+    gatewayId: String,
+    scope: ChatOutboxScope,
+    nowMs: Long,
+  ): ChatOutboxMutationLease? = ready().commandOutbox.beginSessionMutation(gatewayId, scope, nowMs)
+
+  override suspend fun cancelSessionMutation(
+    gatewayId: String,
+    scope: ChatOutboxScope,
+    lease: ChatOutboxMutationLease,
+  ): Boolean = ready().commandOutbox.cancelSessionMutation(gatewayId, scope, lease)
+
+  override suspend fun demoteSessionMutationToReconciliation(
+    gatewayId: String,
+    scope: ChatOutboxScope,
+    lease: ChatOutboxMutationLease?,
+  ): Boolean = ready().commandOutbox.demoteSessionMutationToReconciliation(gatewayId, scope, lease)
+
+  override suspend fun demoteSessionMutationToReconciliationState(
+    gatewayId: String,
+    scope: ChatOutboxScope,
+    lease: ChatOutboxMutationLease?,
+  ): ChatOutboxBranchState? = ready().commandOutbox.demoteSessionMutationToReconciliationState(gatewayId, scope, lease)
+
+  override suspend fun updateLastActiveLeafEntryId(
+    gatewayId: String,
+    scope: ChatOutboxScope,
+    leafEntryId: String,
+    expectedEpoch: Int,
+    expectedRevision: Int,
+  ): Boolean = ready().commandOutbox.updateLastActiveLeafEntryId(gatewayId, scope, leafEntryId, expectedEpoch, expectedRevision)
+
+  override suspend fun reconcileBranchScope(
+    gatewayId: String,
+    scope: ChatOutboxScope,
+    previousState: ChatOutboxBranchState,
+    activeLeafEntryId: String?,
+    branchLeafEntryIds: Set<String>,
+    activeTranscriptEntryIds: Set<String>,
+    lastError: String,
+  ): Boolean =
+    ready()
+      .commandOutbox
+      .reconcileBranchScope(
+        gatewayId,
+        scope,
+        previousState,
+        activeLeafEntryId,
+        branchLeafEntryIds,
+        activeTranscriptEntryIds,
+        lastError,
+      )
+
+  override suspend fun confirmBranchChange(
+    gatewayId: String,
+    scope: ChatOutboxScope,
+    activeLeafEntryId: String?,
+    lastError: String,
+    lease: ChatOutboxMutationLease?,
+  ): Boolean = ready().commandOutbox.confirmBranchChange(gatewayId, scope, activeLeafEntryId, lastError, lease)
 
   override suspend fun deleteForSession(
     gatewayId: String,

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatComposer.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatComposer.kt
@@ -362,7 +362,8 @@ internal fun mergeChatDraft(
   currentOwner: ChatComposerOwner? = null,
 ): String? {
   if (draft?.owner != null && draft.owner != currentOwner) return null
-  val text = draft?.text?.takeIf { it.isNotBlank() } ?: return null
+  if (draft?.expectedExistingText != null && draft.expectedExistingText != currentInput) return null
+  val text = draft?.text?.takeIf { draft.acceptsEmptyText || it.isNotBlank() } ?: return null
   return when (draft.placement) {
     ChatDraftPlacement.Replace -> text
     ChatDraftPlacement.BeforeExisting -> text + currentInput

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageActions.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageActions.kt
@@ -51,6 +51,9 @@ internal fun ChatMessageActionHost(
   text: String,
   onReply: (String) -> Unit,
   modifier: Modifier = Modifier,
+  showSessionActions: Boolean = false,
+  onRewind: (() -> Unit)? = null,
+  onFork: (() -> Unit)? = null,
   enabled: Boolean = true,
   listenActive: Boolean = false,
   onToggleListen: (() -> Unit)? = null,
@@ -99,6 +102,20 @@ internal fun ChatMessageActionHost(
       MessageActionItem(label = nativeString("Reply")) {
         onReply(quoteChatMessage(text))
         menuExpanded = false
+      }
+      if (showSessionActions) {
+        onRewind?.let { rewind ->
+          MessageActionItem(label = nativeString("Rewind to here")) {
+            rewind()
+            menuExpanded = false
+          }
+        }
+        onFork?.let { fork ->
+          MessageActionItem(label = nativeString("Fork from here")) {
+            fork()
+            menuExpanded = false
+          }
+        }
       }
     }
   }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt
@@ -7,6 +7,8 @@ import ai.openclaw.app.chat.ChatOutboxStatus
 import ai.openclaw.app.chat.ChatPendingToolCall
 import ai.openclaw.app.chat.MessageSpeechPhase
 import ai.openclaw.app.chat.MessageSpeechState
+import ai.openclaw.app.chat.OUTBOX_BRANCH_CHANGED_ERROR
+import ai.openclaw.app.chat.chatOutboxDisplayError
 import ai.openclaw.app.chat.normalizeVisibleChatMessageRole
 import ai.openclaw.app.i18n.nativeString
 import ai.openclaw.app.i18n.nativeStringResource
@@ -95,6 +97,9 @@ private data class ChatBubbleStyle(
 internal fun ChatMessageBubble(
   message: ChatMessage,
   onReplyMessage: (String) -> Unit = {},
+  sessionActionsEnabled: Boolean = false,
+  onRewindMessage: (String) -> Unit = {},
+  onForkMessage: (String) -> Unit = {},
   speechState: MessageSpeechState? = null,
   onToggleListen: ((String, String) -> Unit)? = null,
 ) {
@@ -125,6 +130,9 @@ internal fun ChatMessageBubble(
   ChatMessageActionHost(
     text = messageText,
     onReply = onReplyMessage,
+    showSessionActions = role == "user" && message.entryId != null && sessionActionsEnabled,
+    onRewind = message.entryId?.let { entryId -> { onRewindMessage(entryId) } },
+    onFork = message.entryId?.let { entryId -> { onForkMessage(entryId) } },
     listenActive = messageSpeech != null,
     onToggleListen = toggleListen,
     modifier = Modifier.fillMaxWidth(),
@@ -452,10 +460,18 @@ fun ChatOutboxBubble(
       ChatOutboxStatus.Sending -> nativeString("Sending…")
       ChatOutboxStatus.Accepted -> nativeString("Sent — confirming delivery…")
       ChatOutboxStatus.Failed ->
-        item.lastError
+        chatOutboxDisplayError(item.lastError)
           ?.trim()
           ?.takeIf { it.isNotEmpty() }
-          ?.let { nativeString("Failed — \$it", it) } ?: nativeString("Failed")
+          ?.let { error ->
+            val localized =
+              if (error == OUTBOX_BRANCH_CHANGED_ERROR) {
+                nativeString("Session branch changed; review and retry this message.")
+              } else {
+                error
+              }
+            nativeString("Failed — \$it", localized)
+          } ?: nativeString("Failed")
     }
 
   ChatBubbleContainer(

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
@@ -1,5 +1,7 @@
 package ai.openclaw.app.ui.chat
 
+import ai.openclaw.app.ChatDraft
+import ai.openclaw.app.ChatDraftPlacement
 import ai.openclaw.app.GatewayAgentSummary
 import ai.openclaw.app.GatewayModelSummary
 import ai.openclaw.app.MainViewModel
@@ -11,6 +13,7 @@ import ai.openclaw.app.chat.ChatComposerOwner
 import ai.openclaw.app.chat.ChatMessage
 import ai.openclaw.app.chat.ChatMessageContent
 import ai.openclaw.app.chat.ChatOutboxItem
+import ai.openclaw.app.chat.ChatOutboxStatus
 import ai.openclaw.app.chat.ChatPendingToolCall
 import ai.openclaw.app.chat.ChatPlanStep
 import ai.openclaw.app.chat.ChatPlanStepStatus
@@ -22,6 +25,7 @@ import ai.openclaw.app.chat.ChatTranscriptAnchorState
 import ai.openclaw.app.chat.ChatWidgetResource
 import ai.openclaw.app.chat.MessageSpeechPhase
 import ai.openclaw.app.chat.MessageSpeechState
+import ai.openclaw.app.chat.SessionBranch
 import ai.openclaw.app.chat.VoiceNoteRecorderState
 import ai.openclaw.app.chat.chatOutboxQueueFailureText
 import ai.openclaw.app.chat.questionsForSession
@@ -54,6 +58,7 @@ import ai.openclaw.app.ui.gatewayDiagnosticsEndpoint
 import ai.openclaw.app.ui.gatewayStatusForDisplay
 import ai.openclaw.app.ui.localizedUppercase
 import ai.openclaw.app.ui.mobileCallout
+import ai.openclaw.app.ui.relativeSessionTime
 import android.os.SystemClock
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -93,6 +98,7 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ArrowDownward
 import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.AttachFile
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Cloud
 import androidx.compose.material.icons.filled.ContentCopy
@@ -152,6 +158,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.text.DateFormat
+import java.time.Instant
 import java.util.Date
 import java.util.Locale
 import java.util.UUID
@@ -262,6 +269,9 @@ fun ChatScreen(
   val questions by viewModel.chatQuestions.collectAsState()
   val planSteps by viewModel.chatPlanSteps.collectAsState()
   val sessions by viewModel.chatSessions.collectAsState()
+  val sessionBranches by viewModel.chatSessionBranches.collectAsState()
+  val sessionBranchesLoading by viewModel.chatSessionBranchesLoading.collectAsState()
+  val sessionBranchSwitching by viewModel.chatSessionBranchSwitching.collectAsState()
   val chatCommands by viewModel.chatCommands.collectAsState()
   val chatDraft by viewModel.chatDraft.collectAsState()
   val chatShareDrafts by viewModel.chatShareDrafts.collectAsState()
@@ -269,6 +279,7 @@ fun ChatScreen(
   val assistantAutoSendInFlight by viewModel.assistantAutoSendInFlight.collectAsState()
   val remoteAddress by viewModel.remoteAddress.collectAsState()
   val outboxItems by viewModel.chatOutboxItems.collectAsState()
+  val outboxPresentationRestored by viewModel.chatOutboxPresentationRestored.collectAsState()
   val messageSpeechState by viewModel.chatMessageSpeech.collectAsState()
   val manualHost by viewModel.manualHost.collectAsState()
   val manualPort by viewModel.manualPort.collectAsState()
@@ -311,6 +322,14 @@ fun ChatScreen(
       sessionKey = sessionKey,
       mainSessionKey = mainSessionKey,
     )
+  val currentSessionOutboxItems =
+    outboxItemsForSession(
+      items = outboxItems,
+      sessionKey = sessionKey,
+      mainSessionKey = mainSessionKey,
+      ownerAgentId = composerOwner.agentId,
+      messages = messages,
+    )
   val activeAgentId = sessionAgentId
   val workspaceGit = gatewayAgents.firstOrNull { it.id == sessionAgentId }?.workspaceGit == true
   val context = LocalContext.current
@@ -345,6 +364,7 @@ fun ChatScreen(
   val sendInFlight = composerOwner in sendStates
   var showModelPicker by rememberSaveable { mutableStateOf(false) }
   var showBackgroundTasks by rememberSaveable { mutableStateOf(false) }
+  var showBranchSwitcher by rememberSaveable { mutableStateOf(false) }
   var sendMessageTooLong by rememberSaveable(composerOwner) { mutableStateOf(false) }
   var sendCheckpointFull by rememberSaveable(composerOwner) { mutableStateOf(false) }
 
@@ -605,6 +625,10 @@ fun ChatScreen(
       pendingRunCount = pendingRunCount,
       newChatEnabled = newChatEnabled,
       workspaceGit = workspaceGit,
+      branches = sessionBranches,
+      branchesLoading = sessionBranchesLoading,
+      branchSwitchEnabled =
+        outboxPresentationRestored && pendingRunCount == 0 && !sessionBranchSwitching && currentSessionOutboxItems.isEmpty(),
       onNewChat = {
         startNewChat(false)
       },
@@ -615,6 +639,10 @@ fun ChatScreen(
       },
       onOpenDashboard = { onOpenDashboard(sessionKey) },
       onOpenBackgroundTasks = { showBackgroundTasks = true },
+      onOpenBranchSwitcher = {
+        showBranchSwitcher = true
+        scope.launch { viewModel.refreshChatSessionBranches() }
+      },
     )
 
     ChatAgentSelector(
@@ -653,14 +681,7 @@ fun ChatScreen(
       streamingAssistantText = streamingAssistantText,
       healthOk = healthOk,
       gatewayOffline = gatewayOffline,
-      outboxItems =
-        outboxItemsForSession(
-          items = outboxItems,
-          sessionKey = sessionKey,
-          mainSessionKey = mainSessionKey,
-          ownerAgentId = composerOwner.agentId,
-          messages = messages,
-        ),
+      outboxItems = currentSessionOutboxItems,
       recoveryOutboxItems =
         outboxItemsForRecovery(
           items = outboxItems,
@@ -671,6 +692,43 @@ fun ChatScreen(
       onSkipQuestion = viewModel::skipChatQuestion,
       onStarterPrompt = { prompt -> inputDrafts[composerOwner] = prompt },
       onReplyMessage = { value -> viewModel.setChatReplyDraft(value, composerOwner) },
+      sessionActionsEnabled =
+        pendingRunCount == 0 &&
+          !sessionBranchSwitching &&
+          outboxPresentationRestored &&
+          currentSessionOutboxItems.none { it.status != ChatOutboxStatus.Failed },
+      onRewindMessage = { entryId ->
+        val expectedInput = inputDrafts[composerOwner].orEmpty()
+        scope.launch {
+          val result = viewModel.rewindChatAtEntry(entryId) ?: return@launch
+          viewModel.setChatDraft(
+            ChatDraft(
+              text = result.editorText.orEmpty(),
+              placement = ChatDraftPlacement.Replace,
+              owner = composerOwner,
+              expectedExistingText = expectedInput,
+              acceptsEmptyText = true,
+            ),
+          )
+        }
+      },
+      onForkMessage = { entryId ->
+        scope.launch {
+          val (newKey, editorText) = viewModel.forkChatAtEntry(entryId) ?: return@launch
+          val newOwner = composerOwner.copy(sessionKey = newKey)
+          val expectedInput = inputDrafts[newOwner].orEmpty()
+          viewModel.switchChatSession(newKey, composerOwner.agentId)
+          viewModel.setChatDraft(
+            ChatDraft(
+              text = editorText.orEmpty(),
+              placement = ChatDraftPlacement.Replace,
+              owner = newOwner,
+              expectedExistingText = expectedInput,
+              acceptsEmptyText = true,
+            ),
+          )
+        }
+      },
       speechState = messageSpeechState,
       onToggleListen = viewModel::toggleChatMessageSpeech,
       resolveInlineWidgetResource = viewModel::resolveInlineWidgetResource,
@@ -829,6 +887,22 @@ fun ChatScreen(
       onToggleFavorite = viewModel::toggleModelFavorite,
     )
   }
+
+  if (showBranchSwitcher) {
+    BranchSwitcherSheet(
+      branches = sessionBranches,
+      loading = sessionBranchesLoading || sessionBranchSwitching,
+      onDismiss = { showBranchSwitcher = false },
+      onSelect = { leafEntryId ->
+        scope.launch {
+          if (viewModel.switchChatSessionBranch(leafEntryId)) {
+            showBranchSwitcher = false
+            viewModel.refreshChatSessionBranches()
+          }
+        }
+      },
+    )
+  }
   if (showBackgroundTasks) {
     BackgroundTasksSheet(
       viewModel = viewModel,
@@ -981,11 +1055,15 @@ private fun ChatHeader(
   pendingRunCount: Int,
   newChatEnabled: Boolean,
   workspaceGit: Boolean,
+  branches: List<SessionBranch>,
+  branchesLoading: Boolean,
+  branchSwitchEnabled: Boolean,
   onNewChat: () -> Unit,
   onNewChatInWorktree: () -> Unit,
   onRefresh: () -> Unit,
   onOpenDashboard: () -> Unit,
   onOpenBackgroundTasks: () -> Unit,
+  onOpenBranchSwitcher: () -> Unit,
 ) {
   var actionsMenuExpanded by remember { mutableStateOf(false) }
   val newChatInWorktreeLabel = stringResource(R.string.new_chat_in_worktree)
@@ -1034,6 +1112,17 @@ private fun ChatHeader(
               onRefresh()
             },
           )
+          if (branches.size > 1) {
+            DropdownMenuItem(
+              text = { Text(nativeString("Switch branch")) },
+              leadingIcon = { Icon(Icons.Default.ArrowDropDown, contentDescription = null) },
+              enabled = branchSwitchEnabled && !branchesLoading,
+              onClick = {
+                actionsMenuExpanded = false
+                onOpenBranchSwitcher()
+              },
+            )
+          }
           DropdownMenuItem(
             text = { Text(nativeString("Dashboard")) },
             leadingIcon = { Icon(Icons.Default.Dashboard, contentDescription = null) },
@@ -1151,6 +1240,9 @@ private fun ChatMessageList(
   onSkipQuestion: (String) -> Unit,
   onStarterPrompt: (String) -> Unit,
   onReplyMessage: (String) -> Unit,
+  sessionActionsEnabled: Boolean,
+  onRewindMessage: (String) -> Unit,
+  onForkMessage: (String) -> Unit,
   speechState: MessageSpeechState?,
   onToggleListen: (String, String) -> Unit,
   resolveInlineWidgetResource: suspend (String, ChatWidgetResource?) -> ChatWidgetResource?,
@@ -1209,11 +1301,15 @@ private fun ChatMessageList(
           is ChatTimelineItem.Message ->
             ChatBubble(
               messageId = item.message.id,
+              entryId = item.message.entryId,
               role = item.message.role,
               live = false,
               content = item.message.content,
               timestampMs = item.message.timestampMs,
               onReplyMessage = onReplyMessage,
+              sessionActionsEnabled = sessionActionsEnabled,
+              onRewindMessage = onRewindMessage,
+              onForkMessage = onForkMessage,
               speechState = speechState,
               onToggleListen = onToggleListen,
               inlineWidgetResolverReady = healthOk,
@@ -1248,11 +1344,15 @@ private fun ChatMessageList(
           is ChatTimelineItem.StreamingAssistant ->
             ChatBubble(
               messageId = null,
+              entryId = null,
               role = "assistant",
               live = true,
               content = listOf(ChatMessageContent(text = item.text)),
               timestampMs = null,
               onReplyMessage = onReplyMessage,
+              sessionActionsEnabled = false,
+              onRewindMessage = onRewindMessage,
+              onForkMessage = onForkMessage,
               speechState = null,
               onToggleListen = onToggleListen,
               inlineWidgetResolverReady = healthOk,
@@ -1494,11 +1594,15 @@ internal val starterPrompts =
 @Composable
 private fun ChatBubble(
   messageId: String?,
+  entryId: String?,
   role: String,
   live: Boolean,
   content: List<ChatMessageContent>,
   timestampMs: Long?,
   onReplyMessage: (String) -> Unit,
+  sessionActionsEnabled: Boolean,
+  onRewindMessage: (String) -> Unit,
+  onForkMessage: (String) -> Unit,
   speechState: MessageSpeechState?,
   onToggleListen: (String, String) -> Unit,
   inlineWidgetResolverReady: Boolean,
@@ -1536,6 +1640,9 @@ private fun ChatBubble(
     ChatMessageActionHost(
       text = messageText,
       onReply = onReplyMessage,
+      showSessionActions = isUser && entryId != null && sessionActionsEnabled,
+      onRewind = entryId?.let { value -> { onRewindMessage(value) } },
+      onFork = entryId?.let { value -> { onForkMessage(value) } },
       enabled = !live,
       listenActive = messageSpeech != null,
       onToggleListen = toggleListen,
@@ -2083,6 +2190,83 @@ private fun ChatModelChip(
       )
     }
   }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun BranchSwitcherSheet(
+  branches: List<SessionBranch>,
+  loading: Boolean,
+  onDismiss: () -> Unit,
+  onSelect: (String) -> Unit,
+) {
+  ModalBottomSheet(
+    onDismissRequest = onDismiss,
+    containerColor = ClawTheme.colors.surface,
+    contentColor = ClawTheme.colors.text,
+  ) {
+    Column(modifier = Modifier.fillMaxWidth().heightIn(max = 560.dp)) {
+      Text(
+        text = nativeString("Switch branch"),
+        modifier = Modifier.padding(horizontal = 20.dp, vertical = 12.dp),
+        style = ClawTheme.type.title,
+        color = ClawTheme.colors.text,
+      )
+      HorizontalDivider(color = ClawTheme.colors.border, thickness = 1.dp)
+      LazyColumn(
+        modifier = Modifier.fillMaxWidth(),
+        contentPadding = PaddingValues(bottom = 24.dp),
+      ) {
+        itemsIndexed(branches, key = { _, branch -> branch.leafEntryId }) { _, branch ->
+          Surface(
+            onClick = { if (!branch.active) onSelect(branch.leafEntryId) },
+            enabled = !loading && !branch.active,
+            color = if (branch.active) ClawTheme.colors.surfacePressed else Color.Transparent,
+            contentColor = ClawTheme.colors.text,
+          ) {
+            Row(
+              modifier = Modifier.fillMaxWidth().heightIn(min = ClawTheme.spacing.touchTarget).padding(horizontal = 20.dp, vertical = 12.dp),
+              verticalAlignment = Alignment.CenterVertically,
+              horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+              Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(3.dp)) {
+                Text(
+                  text = branch.headline.trim().takeIf(String::isNotEmpty) ?: nativeString("Untitled branch"),
+                  style = ClawTheme.type.body,
+                  color = ClawTheme.colors.text,
+                  maxLines = 2,
+                  overflow = TextOverflow.Ellipsis,
+                )
+                Text(
+                  text = branchMetadataText(branch),
+                  style = ClawTheme.type.caption,
+                  color = ClawTheme.colors.textMuted,
+                )
+              }
+              if (branch.active) {
+                Icon(
+                  imageVector = Icons.Default.Check,
+                  contentDescription = nativeString("Current branch"),
+                  tint = ClawTheme.colors.primary,
+                )
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+internal fun branchMessageCountText(count: Int): String = if (count == 1) nativeString("1 message") else nativeString("\$count messages", count)
+
+internal fun branchMetadataText(branch: SessionBranch): String {
+  val count = branchMessageCountText(branch.messageCount)
+  val updated =
+    branch.updatedAt
+      ?.let { timestamp -> runCatching { Instant.parse(timestamp).toEpochMilli() }.getOrNull() }
+      ?.let(::relativeSessionTime)
+  return if (updated == null) count else nativeString("\$count · \$updated", count, updated)
 }
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerBranchCoordinationTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerBranchCoordinationTest.kt
@@ -1,0 +1,874 @@
+package ai.openclaw.app.chat
+
+import ai.openclaw.app.gateway.GatewayRequestOutcomeUnknown
+import androidx.room.Room
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import kotlinx.serialization.json.Json
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+
+@RunWith(RobolectricTestRunner::class)
+@OptIn(ExperimentalCoroutinesApi::class)
+class ChatControllerBranchCoordinationTest {
+  private val json = Json { ignoreUnknownKeys = true }
+  private val database =
+    Room
+      .inMemoryDatabaseBuilder(RuntimeEnvironment.getApplication(), ClientStateDatabase::class.java)
+      .build()
+  private val outbox = RoomChatCommandOutbox(database)
+  private val controllerScopes = mutableListOf<CoroutineScope>()
+
+  @After
+  fun tearDown() {
+    controllerScopes.forEach { it.cancel() }
+    database.close()
+  }
+
+  private fun controller(gateway: ScriptedGateway): ChatController {
+    val controllerScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    controllerScopes += controllerScope
+    return ChatController(
+      scope = controllerScope,
+      json = json,
+      requestGateway = gateway::request,
+      cacheScope = { ChatCacheScope("gateway-a", 1) },
+      commandOutbox = outbox,
+    )
+  }
+
+  private suspend fun enqueue(text: String = "queued"): ChatOutboxItem =
+    (
+      outbox.enqueue(
+        gatewayId = "gateway-a",
+        sessionKey = "main",
+        text = text,
+        thinkingLevel = "off",
+        nowMs = System.currentTimeMillis(),
+        ownerAgentId = "main",
+      ) as ChatOutboxEnqueueResult.Queued
+    ).item
+
+  private suspend fun ChatController.awaitOutboxRestore() {
+    withContext(Dispatchers.Default.limitedParallelism(1)) {
+      withTimeout(5_000) { outboxPresentationRestored.first { it } }
+    }
+  }
+
+  @Test
+  fun unconfirmedOutboxBlocksRewindForkAndBranchSwitch() =
+    runTest {
+      enqueue()
+      assertNull(
+        outbox.beginSessionMutation(
+          "gateway-a",
+          ChatOutboxScope("main", "main"),
+          nowMs = 100,
+        ),
+      )
+      val gateway = ScriptedGateway(json)
+      val controller = controller(gateway)
+      runCurrent()
+      controller.awaitOutboxRestore()
+
+      assertNull(controller.rewindSessionAtEntryResult("main", "entry-a"))
+      assertNull(controller.forkSessionAtEntry("main", "entry-a"))
+      assertFalse(controller.switchSessionBranch("main", "leaf-b"))
+      assertTrue(
+        gateway.calls.toString(),
+        gateway.calls.none { it.method in setOf("sessions.rewind", "sessions.fork", "sessions.branches.switch") },
+      )
+    }
+
+  @Test
+  fun rewindParksAnEnqueueThatRacesInsideTheMutationLease() =
+    runTest {
+      val gateway = ScriptedGateway(json)
+      val rewindStarted = CompletableDeferred<Unit>()
+      val releaseRewind = CompletableDeferred<Unit>()
+      gateway.respond("sessions.rewind") {
+        rewindStarted.complete(Unit)
+        releaseRewind.await()
+        """{"editorText":"restored"}"""
+      }
+      gateway.respondWith(
+        "chat.history",
+        historyResponse(
+          sessionId = "session-main",
+          messages = listOf(ReplayHistoryMessage("user", "before", 1, entryId = "leaf-after")),
+        ),
+      )
+      gateway.respondWith(
+        "sessions.branches.list",
+        """{"branches":[{"leafEntryId":"leaf-after","headline":"After rewind","messageCount":1,"active":true}]}""",
+      )
+      val controller = controller(gateway)
+      runCurrent()
+      controller.awaitOutboxRestore()
+
+      val rewind = async { controller.rewindSessionAtEntryResult("main", "entry-a") }
+      rewindStarted.await()
+      val racing = enqueue("racing")
+      releaseRewind.complete(Unit)
+
+      val result = rewind.await()
+      assertNotNull(result)
+      assertEquals("restored", result?.editorText)
+      val parked = outbox.load("gateway-a").single()
+      assertEquals(racing.id, parked.id)
+      assertEquals(ChatOutboxStatus.Failed, parked.status)
+      assertEquals(1, outbox.branchState("gateway-a", ChatOutboxScope("main", "main"))?.epoch)
+    }
+
+  @Test
+  fun ambiguousRewindBlocksDeliveryUntilAuthoritativeHistoryReconcilesTheBranch() =
+    runTest {
+      val gateway = ScriptedGateway(json)
+      val historyCalls = AtomicInteger()
+      val retryHistoryStarted = CompletableDeferred<Unit>()
+      val releaseRetryHistory = CompletableDeferred<Unit>()
+      gateway.respond("sessions.rewind") { throw GatewayRequestOutcomeUnknown("response lost") }
+      gateway.respond("chat.history") {
+        when (historyCalls.incrementAndGet()) {
+          1, 2 -> throw IllegalStateException("history temporarily unavailable")
+          else -> {
+            retryHistoryStarted.complete(Unit)
+            releaseRetryHistory.await()
+            historyResponse(
+              sessionId = "session-main",
+              messages = listOf(ReplayHistoryMessage("user", "authoritative rewind", 2, entryId = "leaf-rewound")),
+            )
+          }
+        }
+      }
+      gateway.respondWith(
+        "sessions.branches.list",
+        """{"branches":[{"leafEntryId":"leaf-rewound","headline":"Rewound","messageCount":1,"active":true}]}""",
+      )
+      gateway.respondChatSend("started")
+      val controller = controller(gateway)
+      controller.awaitOutboxRestore()
+      controller.handleGatewayEvent("health", null)
+      withContext(Dispatchers.Default.limitedParallelism(1)) {
+        withTimeout(5_000) { controller.healthOk.first { it } }
+      }
+
+      assertNull(controller.rewindSessionAtEntryResult("main", "entry-a"))
+      retryHistoryStarted.await()
+      assertTrue(controller.sendMessageAwaitAcceptance("queued after rewind", "off", emptyList()))
+
+      val state = outbox.branchState("gateway-a", ChatOutboxScope("main", "main"))
+      assertTrue(state?.needsReconciliation == true)
+      assertNull(state?.switchPendingSinceMs)
+      assertEquals(0, gateway.callCount("chat.send"))
+      assertTrue(controller.messages.value.isEmpty())
+
+      releaseRetryHistory.complete(Unit)
+      withContext(Dispatchers.Default.limitedParallelism(1)) {
+        withTimeout(5_000) {
+          while (gateway.callCount("chat.send") == 0) kotlinx.coroutines.delay(10)
+        }
+      }
+
+      assertFalse(outbox.branchState("gateway-a", ChatOutboxScope("main", "main"))?.needsReconciliation == true)
+      assertEquals(1, gateway.callCount("chat.send"))
+      assertEquals(
+        "authoritative rewind",
+        controller.messages.value
+          .first()
+          .content
+          .single()
+          .text,
+      )
+    }
+
+  @Test
+  fun transientBranchListFailureRetriesReconciliationAndDeliversQueuedInput() =
+    runTest {
+      val gateway = ScriptedGateway(json)
+      val listCalls = AtomicInteger()
+      val firstListFailure = CompletableDeferred<Unit>()
+      gateway.respond("sessions.rewind") { throw GatewayRequestOutcomeUnknown("response lost") }
+      gateway.respond("chat.history") {
+        if (gateway.callCount("chat.history") == 1) throw IllegalStateException("history temporarily unavailable")
+        historyResponse(
+          sessionId = "session-main",
+          messages = listOf(ReplayHistoryMessage("user", "authoritative rewind", 2, entryId = "leaf-rewound")),
+        )
+      }
+      gateway.respond("sessions.branches.list") {
+        if (listCalls.incrementAndGet() == 1) {
+          firstListFailure.complete(Unit)
+          throw IllegalStateException("branches temporarily unavailable")
+        }
+        """{"branches":[{"leafEntryId":"leaf-rewound","headline":"Rewound","messageCount":1,"active":true}]}"""
+      }
+      gateway.respondChatSend("started")
+      val controller = controller(gateway)
+      controller.awaitOutboxRestore()
+      controller.handleGatewayEvent("health", null)
+      withContext(Dispatchers.Default.limitedParallelism(1)) {
+        withTimeout(5_000) { controller.healthOk.first { it } }
+      }
+
+      assertNull(controller.rewindSessionAtEntryResult("main", "entry-a"))
+      assertTrue(controller.sendMessageAwaitAcceptance("queued after rewind", "off", emptyList()))
+      firstListFailure.await()
+      assertEquals(0, gateway.callCount("chat.send"))
+
+      withContext(Dispatchers.Default.limitedParallelism(1)) {
+        withTimeout(5_000) {
+          while (gateway.callCount("chat.send") == 0) kotlinx.coroutines.delay(10)
+        }
+      }
+
+      assertTrue(listCalls.get() >= 2)
+      assertFalse(outbox.branchState("gateway-a", ChatOutboxScope("main", "main"))?.needsReconciliation == true)
+    }
+
+  @Test
+  fun expiredMutationLeaseReconcilesBeforeStartingTheNextAction() =
+    runTest {
+      assertNotNull(outbox.beginSessionMutation("gateway-a", ChatOutboxScope("main", "main"), nowMs = 1))
+      val gateway = ScriptedGateway(json)
+      gateway.respondWith("sessions.rewind", """{"editorText":"recovered"}""")
+      gateway.respondWith(
+        "chat.history",
+        historyResponse(
+          sessionId = "session-main",
+          messages = listOf(ReplayHistoryMessage("user", "current", 1, entryId = "leaf-current")),
+        ),
+      )
+      gateway.respondWith(
+        "sessions.branches.list",
+        """{"branches":[{"leafEntryId":"leaf-current","headline":"Current","messageCount":1,"active":true}]}""",
+      )
+      val controller = controller(gateway)
+      controller.awaitOutboxRestore()
+
+      val result = controller.rewindSessionAtEntryResult("main", "entry-a")
+
+      assertEquals("recovered", result?.editorText)
+      assertTrue(gateway.callCount("sessions.branches.list") >= 2)
+      assertFalse(outbox.branchState("gateway-a", ChatOutboxScope("main", "main"))?.needsReconciliation == true)
+    }
+
+  @Test
+  fun rewindCanFinalizeAnEmptyTranscriptRoot() =
+    runTest {
+      val branchScope = ChatOutboxScope("main", "main")
+      val initial = requireNotNull(outbox.branchState("gateway-a", branchScope))
+      assertTrue(outbox.updateLastActiveLeafEntryId("gateway-a", branchScope, "leaf-old", initial.epoch, initial.revision))
+      val gateway = ScriptedGateway(json)
+      gateway.respondWith("sessions.rewind", """{"editorText":null}""")
+      gateway.respondWith("chat.history", historyResponse(sessionId = "session-main", messages = emptyList()))
+      gateway.respondWith("sessions.branches.list", """{"branches":[]}""")
+      val controller = controller(gateway)
+      controller.awaitOutboxRestore()
+
+      assertNotNull(controller.rewindSessionAtEntryResult("main", "leaf-old"))
+
+      val finalized = outbox.branchState("gateway-a", branchScope)
+      assertEquals(1, finalized?.epoch)
+      assertNull(finalized?.lastActiveLeafEntryId)
+      assertFalse(finalized?.needsReconciliation == true)
+    }
+
+  @Test
+  fun cancellingRewindDoesNotStrandTheDurableMutationLease() =
+    runTest {
+      val gateway = ScriptedGateway(json)
+      val rewindStarted = CompletableDeferred<Unit>()
+      gateway.respond("sessions.rewind") {
+        rewindStarted.complete(Unit)
+        CompletableDeferred<Unit>().await()
+        "{}"
+      }
+      val controller = controller(gateway)
+      controller.awaitOutboxRestore()
+      val rewind = async { controller.rewindSessionAtEntryResult("main", "entry-a") }
+      rewindStarted.await()
+
+      rewind.cancel()
+      rewind.join()
+      withContext(Dispatchers.Default.limitedParallelism(1)) {
+        withTimeout(5_000) {
+          while (outbox.branchState("gateway-a", ChatOutboxScope("main", "main"))?.needsReconciliation != true) {
+            kotlinx.coroutines.delay(10)
+          }
+        }
+      }
+
+      val state = outbox.branchState("gateway-a", ChatOutboxScope("main", "main"))
+      assertTrue(state?.needsReconciliation == true)
+      assertNull(state?.switchPendingSinceMs)
+    }
+
+  @Test
+  fun rewindInvalidatesAHistoryResponseStartedBeforeTheMutation() =
+    runTest {
+      val gateway = ScriptedGateway(json)
+      val historyCalls = AtomicInteger()
+      val oldHistoryStarted = CompletableDeferred<Unit>()
+      val releaseOldHistory = CompletableDeferred<Unit>()
+      gateway.respond("chat.history") {
+        if (historyCalls.incrementAndGet() == 1) {
+          oldHistoryStarted.complete(Unit)
+          releaseOldHistory.await()
+          historyResponse(
+            sessionId = "session-main",
+            messages = listOf(ReplayHistoryMessage("user", "stale", 1, entryId = "leaf-stale")),
+          )
+        } else {
+          historyResponse(
+            sessionId = "session-main",
+            messages = listOf(ReplayHistoryMessage("user", "rewound", 2, entryId = "leaf-new")),
+          )
+        }
+      }
+      gateway.respondWith("sessions.rewind", """{"editorText":"rewound draft"}""")
+      gateway.respondWith(
+        "sessions.branches.list",
+        """{"branches":[{"leafEntryId":"leaf-new","headline":"Rewound","messageCount":1,"active":true}]}""",
+      )
+      val controller = controller(gateway)
+      controller.awaitOutboxRestore()
+      controller.load("main")
+      oldHistoryStarted.await()
+
+      val rewind = controller.rewindSessionAtEntryResult("main", "entry-a")
+      assertNotNull(rewind)
+      releaseOldHistory.complete(Unit)
+      withContext(Dispatchers.Default.limitedParallelism(1)) {
+        withTimeout(5_000) {
+          controller.messages.first { messages ->
+            messages
+              .singleOrNull()
+              ?.content
+              ?.singleOrNull()
+              ?.text == "rewound"
+          }
+        }
+      }
+
+      assertEquals(
+        "rewound",
+        controller.messages.value
+          .single()
+          .content
+          .single()
+          .text,
+      )
+    }
+
+  @Test
+  fun branchRefreshPreservesTheLastGoodListOnFailure() =
+    runTest {
+      val gateway = ScriptedGateway(json)
+      var fail = false
+      gateway.respond("sessions.branches.list") {
+        if (fail) throw IllegalStateException("offline")
+        """{"branches":[
+          {"leafEntryId":"leaf-a","headline":"Current","messageCount":2,"active":true},
+          {"leafEntryId":"leaf-b","headline":"Earlier","messageCount":1,"active":false}
+        ]}"""
+      }
+      val controller = controller(gateway)
+      runCurrent()
+      controller.awaitOutboxRestore()
+
+      assertTrue(controller.refreshSessionBranches())
+      val cached = controller.sessionBranches.value
+      fail = true
+      assertFalse(controller.refreshSessionBranches())
+      assertEquals(cached, controller.sessionBranches.value)
+    }
+
+  @Test
+  fun bootstrapReconcilesTheCapturedBranchStateBeforeAdvancingTheTip() =
+    runTest {
+      val gateway = ScriptedGateway(json)
+      gateway.respondWith(
+        "chat.history",
+        historyResponse(
+          sessionId = "session-main",
+          messages = listOf(ReplayHistoryMessage("user", "hello", 1, entryId = "leaf-live")),
+        ),
+      )
+      gateway.respondWith(
+        "sessions.branches.list",
+        """{"branches":[{"leafEntryId":"leaf-live","headline":"Current","messageCount":1,"active":true}]}""",
+      )
+      val controller = controller(gateway)
+      controller.awaitOutboxRestore()
+
+      controller.load("main")
+      withContext(Dispatchers.Default.limitedParallelism(1)) {
+        withTimeout(5_000) { controller.sessionBranches.first { it.isNotEmpty() } }
+      }
+
+      val state = outbox.branchState("gateway-a", ChatOutboxScope("main", "main"))
+      assertEquals("leaf-live", state?.lastActiveLeafEntryId)
+      assertFalse(state?.needsReconciliation == true)
+    }
+
+  @Test
+  fun staleBranchSwitchCompletionCannotOverrideNewerNavigation() =
+    runTest {
+      val gateway = ScriptedGateway(json)
+      val switchStarted = CompletableDeferred<Unit>()
+      val releaseSwitch = CompletableDeferred<Unit>()
+      gateway.respond("sessions.branches.switch") {
+        switchStarted.complete(Unit)
+        releaseSwitch.await()
+        "{}"
+      }
+      gateway.respondWith("chat.history", historyResponse("other", emptyList()))
+      gateway.respondWith("sessions.branches.list", """{"branches":[]}""")
+      val controller = controller(gateway)
+      runCurrent()
+      controller.awaitOutboxRestore()
+
+      val switching = async { controller.switchSessionBranch("main", "leaf-b") }
+      switchStarted.await()
+      controller.switchSession("agent:main:other")
+      releaseSwitch.complete(Unit)
+
+      assertFalse(switching.await())
+      assertEquals("agent:main:other", controller.sessionKey.value)
+      assertFalse(controller.sessionBranchSwitching.value)
+    }
+
+  @Test
+  fun secondBranchSwitchDoesNotInvalidateTheActiveSwitch() =
+    runTest {
+      val gateway = ScriptedGateway(json)
+      val firstStarted = CompletableDeferred<Unit>()
+      val releaseFirst = CompletableDeferred<Unit>()
+      gateway.respond("sessions.branches.switch") {
+        firstStarted.complete(Unit)
+        releaseFirst.await()
+        "{}"
+      }
+      gateway.respondWith(
+        "chat.history",
+        historyResponse(
+          sessionId = "session-main",
+          messages = listOf(ReplayHistoryMessage("user", "branch", 1, entryId = "leaf-b")),
+        ),
+      )
+      gateway.respondWith(
+        "sessions.branches.list",
+        """{"branches":[{"leafEntryId":"leaf-b","headline":"Selected","messageCount":1,"active":true}]}""",
+      )
+      val controller = controller(gateway)
+      controller.awaitOutboxRestore()
+
+      val first = async { controller.switchSessionBranch("main", "leaf-b") }
+      firstStarted.await()
+      controller.handleGatewayEvent(
+        "sessions.changed",
+        """{"reason":"branch-switch","sessionKey":"main","agentId":"main"}""",
+      )
+      assertFalse(controller.switchSessionBranch("main", "leaf-c"))
+      releaseFirst.complete(Unit)
+
+      assertTrue(first.await())
+      assertFalse(controller.sessionBranchSwitching.value)
+      assertEquals(1, gateway.callCount("sessions.branches.switch"))
+    }
+
+  @Test
+  fun localBranchEventAfterConfirmationDoesNotInvalidateTheActionRefresh() =
+    runTest {
+      val gateway = ScriptedGateway(json)
+      val historyStarted = CompletableDeferred<Unit>()
+      val releaseHistory = CompletableDeferred<Unit>()
+      gateway.respondWith("sessions.branches.switch", "{}")
+      gateway.respond("chat.history") {
+        historyStarted.complete(Unit)
+        releaseHistory.await()
+        historyResponse(
+          sessionId = "session-main",
+          messages = listOf(ReplayHistoryMessage("user", "selected", 1, entryId = "leaf-b")),
+        )
+      }
+      gateway.respondWith(
+        "sessions.branches.list",
+        """{"branches":[{"leafEntryId":"leaf-b","headline":"Selected","messageCount":1,"active":true}]}""",
+      )
+      val controller = controller(gateway)
+      controller.awaitOutboxRestore()
+
+      val switching = async { controller.switchSessionBranch("main", "leaf-b") }
+      historyStarted.await()
+      controller.handleGatewayEvent(
+        "sessions.changed",
+        """{"reason":"branch-switch","sessionKey":"main","agentId":"main"}""",
+      )
+      releaseHistory.complete(Unit)
+
+      assertTrue(switching.await())
+      assertFalse(controller.sessionBranchSwitching.value)
+    }
+
+  @Test
+  fun matchingSecondClientBranchMutationDuringOurLeaseReconcilesToItsWinningLeaf() =
+    runTest {
+      val gateway = ScriptedGateway(json)
+      val localHistoryStarted = CompletableDeferred<Unit>()
+      val releaseLocalHistory = CompletableDeferred<Unit>()
+      var historyRequests = 0
+      var branchRequests = 0
+      gateway.respondWith("sessions.branches.switch", "{}")
+      gateway.respond("chat.history") {
+        when (++historyRequests) {
+          1 -> {
+            localHistoryStarted.complete(Unit)
+            releaseLocalHistory.await()
+            historyResponse(
+              sessionId = "session-main",
+              messages = listOf(ReplayHistoryMessage("user", "local", 1, entryId = "leaf-local")),
+            )
+          }
+          else ->
+            historyResponse(
+              sessionId = "session-main",
+              messages = listOf(ReplayHistoryMessage("user", "winner", 2, entryId = "leaf-winner")),
+            )
+        }
+      }
+      gateway.respond("sessions.branches.list") {
+        val leaf = if (++branchRequests == 1) "leaf-local" else "leaf-winner"
+        """{"branches":[{"leafEntryId":"$leaf","headline":"Current","messageCount":1,"active":true}]}"""
+      }
+      val controller = controller(gateway)
+      controller.awaitOutboxRestore()
+
+      val switching = async { controller.switchSessionBranch("main", "leaf-local") }
+      localHistoryStarted.await()
+      controller.handleGatewayEvent(
+        "sessions.changed",
+        """{"reason":"branch-switch","sessionKey":"main","agentId":"main"}""",
+      )
+      releaseLocalHistory.complete(Unit)
+
+      assertTrue(switching.await())
+      withContext(Dispatchers.Default.limitedParallelism(1)) {
+        withTimeout(5_000) {
+          while (outbox.branchState("gateway-a", ChatOutboxScope("main", "main"))?.lastActiveLeafEntryId != "leaf-winner") {
+            kotlinx.coroutines.delay(10)
+          }
+        }
+      }
+      assertFalse(outbox.branchState("gateway-a", ChatOutboxScope("main", "main"))?.needsReconciliation == true)
+      assertTrue(gateway.callCount("chat.history") >= 2)
+    }
+
+  @Test
+  fun remoteBranchEventIsNotDiscardedWhileForkUsesAnEntryGate() =
+    runTest {
+      val gateway = ScriptedGateway(json)
+      val forkStarted = CompletableDeferred<Unit>()
+      val releaseFork = CompletableDeferred<Unit>()
+      gateway.respond("sessions.fork") {
+        forkStarted.complete(Unit)
+        releaseFork.await()
+        """{"sessionKey":"agent:main:forked"}"""
+      }
+      val controller = controller(gateway)
+      controller.awaitOutboxRestore()
+      val fork = async { controller.forkSessionAtEntry("main", "entry-a") }
+      forkStarted.await()
+
+      controller.handleGatewayEvent(
+        "sessions.changed",
+        """{"reason":"branch-switch","sessionKey":"main","agentId":"main"}""",
+      )
+      withContext(Dispatchers.Default.limitedParallelism(1)) {
+        withTimeout(5_000) {
+          while (outbox.branchState("gateway-a", ChatOutboxScope("main", "main"))?.needsReconciliation != true) {
+            kotlinx.coroutines.delay(10)
+          }
+        }
+      }
+      releaseFork.complete(Unit)
+
+      assertNotNull(fork.await())
+      assertTrue(outbox.branchState("gateway-a", ChatOutboxScope("main", "main"))?.needsReconciliation == true)
+    }
+
+  @Test
+  fun failedEventHistoryRefreshStillSchedulesReconciliationAndDelivery() =
+    runTest {
+      val branchScope = ChatOutboxScope("main", "main")
+      val initial = requireNotNull(outbox.branchState("gateway-a", branchScope))
+      assertTrue(outbox.updateLastActiveLeafEntryId("gateway-a", branchScope, "leaf-current", initial.epoch, initial.revision))
+      val gateway = ScriptedGateway(json)
+      var historyRequests = 0
+      val branchesEntered = CompletableDeferred<Unit>()
+      val releaseBranches = CompletableDeferred<Unit>()
+      gateway.respond("chat.history") {
+        if (++historyRequests == 1) throw IllegalStateException("history temporarily unavailable")
+        historyResponse(
+          sessionId = "session-main",
+          messages = listOf(ReplayHistoryMessage("user", "current", 1, entryId = "leaf-current")),
+        )
+      }
+      gateway.respond("sessions.branches.list") {
+        branchesEntered.complete(Unit)
+        releaseBranches.await()
+        """{"branches":[{"leafEntryId":"leaf-current","headline":"Current","messageCount":1,"active":true}]}"""
+      }
+      gateway.respondChatSend("started")
+      val controller = controller(gateway)
+      controller.awaitOutboxRestore()
+      controller.handleGatewayEvent("health", null)
+      withContext(Dispatchers.Default.limitedParallelism(1)) {
+        withTimeout(5_000) { controller.healthOk.first { it } }
+      }
+      enqueue("deliver after recovery")
+
+      controller.handleGatewayEvent(
+        "sessions.changed",
+        """{"reason":"branch-switch","sessionKey":"main","agentId":"main"}""",
+      )
+      branchesEntered.await()
+      releaseBranches.complete(Unit)
+
+      withContext(Dispatchers.Default.limitedParallelism(1)) {
+        withTimeout(5_000) {
+          while (gateway.callCount("chat.send") == 0) {
+            kotlinx.coroutines.delay(10)
+          }
+        }
+      }
+      assertFalse(outbox.branchState("gateway-a", branchScope)?.needsReconciliation == true)
+    }
+
+  @Test
+  fun backgroundMutationRefreshesTheSessionDrawerBeforeBranchHandlingReturns() =
+    runTest {
+      val gateway = ScriptedGateway(json)
+      val changed = AtomicBoolean(false)
+      gateway.respond("sessions.list") {
+        val label = if (changed.get()) "After rewind" else "Before rewind"
+        """{"sessions":[{"key":"agent:main:background","label":"$label"}]}"""
+      }
+      val controller = controller(gateway)
+      controller.awaitOutboxRestore()
+      controller.refreshSessions()
+      withContext(Dispatchers.Default.limitedParallelism(1)) {
+        withTimeout(5_000) {
+          controller.sessions.first { sessions -> sessions.singleOrNull()?.label == "Before rewind" }
+        }
+      }
+
+      changed.set(true)
+      controller.handleGatewayEvent(
+        "sessions.changed",
+        """{"reason":"rewind","sessionKey":"agent:main:background","agentId":"main"}""",
+      )
+
+      withContext(Dispatchers.Default.limitedParallelism(1)) {
+        withTimeout(5_000) {
+          controller.sessions.first { sessions -> sessions.singleOrNull()?.label == "After rewind" }
+        }
+      }
+    }
+
+  @Test
+  fun remoteBackgroundBranchChangeDemotesThatSessionsDurableScope() =
+    runTest {
+      val backgroundKey = "agent:main:background"
+      val backgroundScope = ChatOutboxScope(backgroundKey, "main")
+      val initial = requireNotNull(outbox.branchState("gateway-a", backgroundScope))
+      assertTrue(outbox.updateLastActiveLeafEntryId("gateway-a", backgroundScope, "leaf-old", initial.epoch, initial.revision))
+      outbox.enqueue(
+        gatewayId = "gateway-a",
+        sessionKey = backgroundKey,
+        text = "background message",
+        thinkingLevel = "off",
+        nowMs = System.currentTimeMillis(),
+        ownerAgentId = "main",
+      )
+      val gateway = ScriptedGateway(json)
+      gateway.respondWith(
+        "chat.history",
+        historyResponse(
+          sessionId = "background",
+          messages = listOf(ReplayHistoryMessage("user", "old", 1, entryId = "leaf-old")),
+        ),
+      )
+      gateway.respondWith(
+        "sessions.branches.list",
+        """{"branches":[{"leafEntryId":"leaf-old","headline":"Old","messageCount":1,"active":true}]}""",
+      )
+      val controller = controller(gateway)
+      controller.awaitOutboxRestore()
+      controller.load(backgroundKey)
+      withContext(Dispatchers.Default.limitedParallelism(1)) {
+        withTimeout(5_000) { controller.sessionBranches.first { it.isNotEmpty() } }
+      }
+      controller.switchSession("main")
+      gateway.respondWith(
+        "chat.history",
+        historyResponse(
+          sessionId = "background",
+          messages = listOf(ReplayHistoryMessage("user", "new", 2, entryId = "leaf-new")),
+        ),
+      )
+      gateway.respondWith(
+        "sessions.branches.list",
+        """{"branches":[
+          {"leafEntryId":"leaf-old","headline":"Old","messageCount":1,"active":false},
+          {"leafEntryId":"leaf-new","headline":"New","messageCount":1,"active":true}
+        ]}""",
+      )
+
+      controller.handleGatewayEvent(
+        "sessions.changed",
+        """{"reason":"branch-switch","sessionKey":"$backgroundKey","agentId":"main"}""",
+      )
+      withContext(Dispatchers.Default.limitedParallelism(1)) {
+        withTimeout(5_000) {
+          while (outbox.load("gateway-a").single().status != ChatOutboxStatus.Failed) {
+            kotlinx.coroutines.delay(10)
+          }
+        }
+      }
+
+      assertEquals(ChatOutboxStatus.Failed, outbox.load("gateway-a").single().status)
+    }
+
+  @Test
+  fun directSendQueuesWithoutDispatchWhileRemoteBranchReconciliationIsPending() =
+    runTest {
+      val gateway = ScriptedGateway(json)
+      val remoteChange = AtomicBoolean(false)
+      val releaseBranches = CompletableDeferred<Unit>()
+      gateway.respond("chat.history") {
+        historyResponse(
+          sessionId = "main",
+          messages =
+            listOf(
+              ReplayHistoryMessage(
+                "user",
+                if (remoteChange.get()) "new" else "old",
+                1,
+                entryId = if (remoteChange.get()) "leaf-new" else "leaf-old",
+              ),
+            ),
+        )
+      }
+      gateway.respond("sessions.branches.list") {
+        if (remoteChange.get()) releaseBranches.await()
+        val leaf = if (remoteChange.get()) "leaf-new" else "leaf-old"
+        """{"branches":[{"leafEntryId":"$leaf","headline":"Current","messageCount":1,"active":true}]}"""
+      }
+      gateway.respondChatSend("started")
+      val controller = controller(gateway)
+      controller.awaitOutboxRestore()
+      controller.load("main")
+      withContext(Dispatchers.Default.limitedParallelism(1)) {
+        withTimeout(5_000) { controller.sessionBranches.first { it.isNotEmpty() } }
+      }
+      controller.handleGatewayEvent("health", null)
+      withContext(Dispatchers.Default.limitedParallelism(1)) {
+        withTimeout(5_000) { controller.healthOk.first { it } }
+      }
+
+      remoteChange.set(true)
+      controller.handleGatewayEvent(
+        "sessions.changed",
+        """{"reason":"branch-switch","sessionKey":"main","agentId":"main"}""",
+      )
+      assertTrue(controller.sendMessageAwaitAcceptance("queued during reconcile", "off", emptyList()))
+
+      assertEquals(0, gateway.callCount("chat.send"))
+      releaseBranches.complete(Unit)
+    }
+
+  @Test
+  fun reconcileOwnerDrainsRequestsQueuedDuringAnActivePass() =
+    runTest {
+      val branchScope = ChatOutboxScope("main", "main")
+      val initial = requireNotNull(outbox.branchState("gateway-a", branchScope))
+      assertTrue(outbox.updateLastActiveLeafEntryId("gateway-a", branchScope, "leaf-current", initial.epoch, initial.revision))
+      enqueue("first queued")
+      assertTrue(outbox.demoteSessionMutationToReconciliation("gateway-a", branchScope, lease = null))
+
+      val gateway = ScriptedGateway(json)
+      val branchesEntered = CompletableDeferred<Unit>()
+      val releaseBranches = CompletableDeferred<Unit>()
+      gateway.respondWith(
+        "chat.history",
+        historyResponse(
+          sessionId = "main",
+          messages = listOf(ReplayHistoryMessage("user", "current", 1, entryId = "leaf-current")),
+        ),
+      )
+      gateway.respond("sessions.branches.list") {
+        branchesEntered.complete(Unit)
+        releaseBranches.await()
+        """{"branches":[{"leafEntryId":"leaf-current","headline":"Current","messageCount":1,"active":true}]}"""
+      }
+      gateway.respondChatSend("started")
+      gateway.respond("chat.history") {
+        val idempotencyKey = gateway.lastRunId?.let { "$it:user" }
+        historyResponse(
+          sessionId = "main",
+          messages =
+            listOf(
+              ReplayHistoryMessage(
+                "user",
+                "current",
+                1,
+                idempotencyKey = idempotencyKey,
+                entryId = "leaf-current",
+              ),
+            ),
+        )
+      }
+      val controller = controller(gateway)
+      controller.awaitOutboxRestore()
+      controller.handleGatewayEvent("health", null)
+      withContext(Dispatchers.Default.limitedParallelism(1)) {
+        withTimeout(5_000) { controller.healthOk.first { it } }
+      }
+      branchesEntered.await()
+
+      assertTrue(controller.sendMessageAwaitAcceptance("second queued", "off", emptyList()))
+      releaseBranches.complete(Unit)
+      withContext(Dispatchers.Default.limitedParallelism(1)) {
+        withTimeout(5_000) {
+          while (outbox.branchState("gateway-a", branchScope)?.needsReconciliation != false) {
+            kotlinx.coroutines.delay(10)
+          }
+        }
+      }
+
+      assertEquals(2, outbox.load("gateway-a").size)
+      assertTrue(outbox.load("gateway-a").none { it.status == ChatOutboxStatus.Failed })
+    }
+}

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerMessageIdentityTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerMessageIdentityTest.kt
@@ -10,6 +10,24 @@ import org.junit.Assert.assertNotEquals
 import org.junit.Test
 
 class ChatControllerMessageIdentityTest {
+  @Test
+  fun reconcileMessageIdsKeepsCanonicalEntryIdentityFromReload() {
+    val previous =
+      ChatMessage(
+        id = "stable-compose-id",
+        role = "user",
+        content = listOf(ChatMessageContent(text = "hello")),
+        timestampMs = 10,
+        entryId = "old-entry",
+      )
+    val incoming = previous.copy(id = "temporary-id", entryId = "canonical-entry")
+
+    val reconciled = reconcileMessageIds(listOf(previous), listOf(incoming)).single()
+
+    assertEquals("stable-compose-id", reconciled.id)
+    assertEquals("canonical-entry", reconciled.entryId)
+  }
+
   private val json = Json { ignoreUnknownKeys = true }
 
   @Test

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerOutboxTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerOutboxTest.kt
@@ -1421,6 +1421,32 @@ class ChatControllerOutboxTest {
     }
 
   @Test
+  fun flushBuildsTheRequestIdentityFromTheCurrentReplacementRowId() =
+    runTest {
+      val gateway = FakeGateway()
+      val outbox = FakeCommandOutbox()
+      outbox.seed(
+        ChatOutboxItem(
+          id = "replacement-client-id",
+          sessionKey = "main",
+          text = "retry on the selected branch",
+          thinkingLevel = "off",
+          createdAtMs = System.currentTimeMillis(),
+          status = ChatOutboxStatus.Queued,
+          retryCount = 0,
+          lastError = null,
+          ownerAgentId = "main",
+        ),
+      )
+      val chat = controller(this, gateway, outbox)
+      gateway.online = true
+      chat.handleGatewayEvent("health", null)
+      advanceUntilIdle()
+
+      assertEquals(listOf("replacement-client-id"), gateway.sentIdempotencyKeys)
+    }
+
+  @Test
   fun queueFullRefusalSurfacesErrorWithoutQueueing() =
     runTest {
       val gateway = FakeGateway()

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerSessionActionsTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerSessionActionsTest.kt
@@ -1,0 +1,184 @@
+package ai.openclaw.app.chat
+
+import ai.openclaw.app.gateway.GatewayRequestNotEnqueued
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ChatControllerSessionActionsTest {
+  private val json = Json { ignoreUnknownKeys = true }
+
+  private fun controller(
+    scope: kotlinx.coroutines.CoroutineScope,
+    gateway: ScriptedGateway,
+  ): ChatController =
+    ChatController(
+      scope = scope,
+      json = json,
+      requestGateway = gateway::request,
+    )
+
+  private fun ScriptedGateway.respondWithBranchHistory() {
+    respondWith(
+      "chat.history",
+      historyResponse(
+        sessionId = "session-main",
+        messages = listOf(ReplayHistoryMessage("user", "hello", 1, entryId = "entry-user")),
+      ),
+    )
+    respondWith(
+      "sessions.branches.list",
+      """{"branches":[{"leafEntryId":"entry-user","headline":"Current work","messageCount":1,"updatedAt":"2026-07-20T12:00:00Z","active":true}]}""",
+    )
+  }
+
+  @Test
+  fun rewindReturnsEditorTextAndIssuesAgentScopedParams() =
+    runTest {
+      val gateway = ScriptedGateway(json)
+      gateway.respondWith("sessions.rewind", """{"editorText":"restore me"}""")
+      gateway.respondWithBranchHistory()
+      val controller = controller(this, gateway)
+
+      assertEquals("restore me", controller.rewindSessionAtEntry("main", "entry-user"))
+
+      val params = json.parseToJsonElement(gateway.calls.first { it.method == "sessions.rewind" }.paramsJson!!).jsonObject
+      assertEquals("main", params.getValue("sessionKey").jsonPrimitive.content)
+      assertEquals("main", params.getValue("agentId").jsonPrimitive.content)
+      assertEquals("entry-user", params.getValue("entryId").jsonPrimitive.content)
+    }
+
+  @Test
+  fun forkReturnsCreatedKeyAndEditorText() =
+    runTest {
+      val gateway = ScriptedGateway(json)
+      gateway.respondWith("sessions.fork", """{"sessionKey":"agent:main:forked","editorText":"continue here"}""")
+      val controller = controller(this, gateway)
+
+      assertEquals("agent:main:forked" to "continue here", controller.forkSessionAtEntry("main", "entry-user"))
+
+      val params = json.parseToJsonElement(gateway.calls.single { it.method == "sessions.fork" }.paramsJson!!).jsonObject
+      assertEquals("main", params.getValue("agentId").jsonPrimitive.content)
+      assertEquals("entry-user", params.getValue("entryId").jsonPrimitive.content)
+    }
+
+  @Test
+  fun branchesListParsesAllFields() =
+    runTest {
+      val gateway = ScriptedGateway(json)
+      gateway.respondWith(
+        "sessions.branches.list",
+        """{"branches":[{"leafEntryId":"leaf-a","headline":"Earlier idea","messageCount":4,"updatedAt":"2026-07-20T12:00:00Z","active":false}]}""",
+      )
+      val controller = controller(this, gateway)
+
+      assertEquals(
+        listOf(SessionBranch("leaf-a", "Earlier idea", 4, "2026-07-20T12:00:00Z", active = false)),
+        controller.listSessionBranches("main"),
+      )
+      val params = json.parseToJsonElement(gateway.calls.single().paramsJson!!).jsonObject
+      assertEquals("main", params.getValue("agentId").jsonPrimitive.content)
+    }
+
+  @Test
+  fun switchReturnsTrueAndRefreshesHistoryAndBranches() =
+    runTest {
+      val gateway = ScriptedGateway(json)
+      gateway.respondWith("sessions.branches.switch", "{}")
+      gateway.respondWithBranchHistory()
+      val controller = controller(this, gateway)
+
+      assertTrue(controller.switchSessionBranch("main", "leaf-other"))
+      assertEquals(1, gateway.callCount("sessions.branches.switch"))
+      assertEquals(1, gateway.callCount("chat.history"))
+      assertEquals(1, gateway.callCount("sessions.branches.list"))
+    }
+
+  @Test
+  fun switchFailureReturnsFalseAndSurfacesError() =
+    runTest {
+      val gateway = ScriptedGateway(json)
+      gateway.respond("sessions.branches.switch") { throw IllegalStateException("run active") }
+      val controller = controller(this, gateway)
+
+      assertFalse(controller.switchSessionBranch("main", "leaf-other"))
+      assertEquals("run active", controller.errorText.value)
+    }
+
+  @Test
+  fun listFailureReturnsNullAndSurfacesError() =
+    runTest {
+      val gateway = ScriptedGateway(json)
+      gateway.respond("sessions.branches.list") { throw IllegalStateException("offline") }
+      val controller = controller(this, gateway)
+
+      assertNull(controller.listSessionBranches("main"))
+      assertEquals("offline", controller.errorText.value)
+    }
+
+  @Test
+  fun malformedBranchesResponseRetainsTheLastKnownBranchState() =
+    runTest {
+      val gateway = ScriptedGateway(json)
+      gateway.respondWith(
+        "sessions.branches.list",
+        """{"branches":[{"leafEntryId":"leaf-a","headline":"Known","messageCount":1,"active":true}]}""",
+      )
+      val controller = controller(this, gateway)
+
+      assertTrue(controller.refreshSessionBranches())
+      val known = controller.sessionBranches.value
+      gateway.respondWith("sessions.branches.list", """{"branches":{}}""")
+
+      assertFalse(controller.refreshSessionBranches())
+      assertEquals(known, controller.sessionBranches.value)
+    }
+
+  @Test
+  fun nullBranchTimestampRemainsAValidOptionalField() =
+    runTest {
+      val gateway = ScriptedGateway(json)
+      gateway.respondWith(
+        "sessions.branches.list",
+        """{"branches":[{"leafEntryId":"leaf-a","headline":"Known","messageCount":1,"updatedAt":null,"active":true}]}""",
+      )
+      val controller = controller(this, gateway)
+
+      assertEquals(
+        listOf(SessionBranch("leaf-a", "Known", 1, updatedAt = null, active = true)),
+        controller.listSessionBranches("main"),
+      )
+    }
+
+  @Test
+  fun definitiveRewindFailureReloadsTheCurrentTranscript() =
+    runTest {
+      val gateway = ScriptedGateway(json)
+      gateway.respond("sessions.rewind") { throw GatewayRequestNotEnqueued("rejected") }
+      gateway.respondWith(
+        "chat.history",
+        historyResponse(
+          sessionId = "session-main",
+          messages = listOf(ReplayHistoryMessage("user", "authoritative", 1, entryId = "entry-current")),
+        ),
+      )
+      val controller = controller(this, gateway)
+
+      assertNull(controller.rewindSessionAtEntryResult("main", "entry-old"))
+      assertEquals(1, gateway.callCount("chat.history"))
+      assertEquals(
+        "authoritative",
+        controller.messages.value
+          .single()
+          .content
+          .single()
+          .text,
+      )
+    }
+}

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatReplayHarness.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatReplayHarness.kt
@@ -98,6 +98,7 @@ internal data class ReplayHistoryMessage(
   val text: String,
   val timestampMs: Long,
   val idempotencyKey: String? = null,
+  val entryId: String? = null,
 )
 
 internal fun historyResponse(
@@ -168,6 +169,9 @@ internal fun historyResponse(
             put("timestamp", JsonPrimitive(message.timestampMs))
             if (message.idempotencyKey != null) {
               put("idempotencyKey", JsonPrimitive(message.idempotencyKey))
+            }
+            if (message.entryId != null) {
+              put("__openclaw", buildJsonObject { put("id", JsonPrimitive(message.entryId)) })
             }
           }
         },

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ClientDatabasesTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ClientDatabasesTest.kt
@@ -15,6 +15,29 @@ import java.util.UUID
 @RunWith(RobolectricTestRunner::class)
 class ClientDatabasesTest {
   @Test
+  fun deferredOutboxPersistsAtomicMutationDemotion() =
+    runTest {
+      val names = databaseNames()
+      val databases = open(names, registeredGatewayIds = setOf("gateway-a"))
+      try {
+        val outbox = databases.commandOutbox()
+        val scope = ChatOutboxScope("main", "main")
+        val lease = requireNotNull(outbox.beginSessionMutation("gateway-a", scope, nowMs = 1_000))
+
+        val state = requireNotNull(outbox.demoteSessionMutationToReconciliationState("gateway-a", scope, lease))
+
+        assertTrue(state.needsReconciliation)
+        assertNull(state.switchPendingSinceMs)
+        val persisted = requireNotNull(outbox.branchState("gateway-a", scope))
+        assertTrue(persisted.needsReconciliation)
+        assertNull(persisted.switchPendingSinceMs)
+      } finally {
+        databases.close()
+        delete(names)
+      }
+    }
+
+  @Test
   fun v2DurableRowsImportIntoClientStateWhileLegacyCacheIsDiscarded() =
     runTest {
       val names = databaseNames()

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/RoomChatCommandOutboxTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/RoomChatCommandOutboxTest.kt
@@ -225,6 +225,70 @@ class RoomChatCommandOutboxTest {
     }
 
   @Test
+  fun restartRecoveryCreatesAmbiguityStateForRowsWithoutDeliveryMetadata() =
+    runTest {
+      database.outboxDao().insert(
+        OutboxCommandEntity(
+          id = "legacy-sending",
+          gatewayId = "gateway-a",
+          sessionKey = "main",
+          text = "legacy",
+          thinkingLevel = "off",
+          createdAtMs = 10,
+          status = ChatOutboxStatus.Sending.dbValue,
+          retryCount = 0,
+          lastError = null,
+          gatedEpoch = null,
+          ownerAgentId = "main",
+        ),
+      )
+
+      store.failSendingAfterRestart()
+
+      val recovered = store.load("gateway-a").single()
+      assertEquals(ChatOutboxStatus.Failed, recovered.status)
+      assertTrue(recovered.hadUnacknowledgedSend)
+    }
+
+  @Test
+  fun legacyAmbiguousFailureBackfillsFreshRetryIdentityEvidence() =
+    runTest {
+      database.outboxDao().insert(
+        OutboxCommandEntity(
+          id = "legacy-ambiguous",
+          gatewayId = "gateway-a",
+          sessionKey = "main",
+          text = "legacy",
+          thinkingLevel = "off",
+          createdAtMs = 10,
+          status = ChatOutboxStatus.Failed.dbValue,
+          retryCount = 1,
+          lastError = OUTBOX_DELIVERY_UNCONFIRMED_ERROR,
+          gatedEpoch = null,
+          ownerAgentId = "main",
+        ),
+      )
+      val legacy = store.load("gateway-a").single()
+      assertTrue(legacy.hadUnacknowledgedSend)
+      store.confirmBranchChange("gateway-a", ChatOutboxScope("main", "main"), "leaf-new", OUTBOX_BRANCH_CHANGED_ERROR)
+      val parked = store.load("gateway-a").single()
+
+      store.requeueForRetryIfCurrent(
+        gatewayId = "gateway-a",
+        id = parked.id,
+        expectedAttemptVersion = parked.attemptVersion,
+        expectedRetryCount = parked.retryCount,
+        expectedLastError = parked.lastError,
+        nowMs = 20,
+        gatedEpoch = null,
+        ownerAgentId = "main",
+        replacementId = "legacy-fresh-id",
+      )
+
+      assertEquals("legacy-fresh-id", store.load("gateway-a").single().id)
+    }
+
+  @Test
   fun requeueForRetryRefreshesCreatedAtSoExpirySweepCannotRefailIt() =
     runTest {
       val now = 1_000_000_000L
@@ -304,6 +368,350 @@ class RoomChatCommandOutboxTest {
 
       // Nothing was written under a fallback scope either.
       assertEquals(emptyList<ChatOutboxItem>(), store.load("gateway-a"))
+    }
+
+  @Test
+  fun branchChangeParksQueuedRowsFromTheSupersededEpoch() =
+    runTest {
+      val scope = ChatOutboxScope("main", "main")
+      val queued = store.enqueueQueued("old branch", nowMs = 10)
+
+      assertTrue(store.confirmBranchChange("gateway-a", scope, "leaf-new", OUTBOX_BRANCH_CHANGED_ERROR))
+
+      val parked = store.load("gateway-a").single()
+      assertEquals(queued.id, parked.id)
+      assertEquals(ChatOutboxStatus.Failed, parked.status)
+      assertEquals(OUTBOX_BRANCH_CHANGED_ERROR, chatOutboxDisplayError(parked.lastError))
+      assertEquals(0, parked.branchEpoch)
+      assertEquals(1, parked.scopeBranchEpoch)
+    }
+
+  @Test
+  fun parkedAcceptedRetryMintsFreshIdentityButQueuedRetryKeepsIdentity() =
+    runTest {
+      val scope = ChatOutboxScope("main", "main")
+      val accepted = store.enqueueQueued("maybe delivered", nowMs = 10)
+      store.updateStatusIfAttempt(accepted.id, accepted.attemptVersion, ChatOutboxStatus.Accepted, 0, null)
+      store.confirmBranchChange("gateway-a", scope, "leaf-new", OUTBOX_BRANCH_CHANGED_ERROR)
+      val parkedAccepted = store.load("gateway-a").single()
+      assertTrue(parkedAccepted.parkedWasAccepted)
+
+      assertEquals(
+        1,
+        store.requeueForRetryIfCurrent(
+          gatewayId = "gateway-a",
+          id = parkedAccepted.id,
+          expectedAttemptVersion = parkedAccepted.attemptVersion,
+          expectedRetryCount = parkedAccepted.retryCount,
+          expectedLastError = parkedAccepted.lastError,
+          nowMs = 20,
+          gatedEpoch = null,
+          ownerAgentId = "main",
+          replacementId = "fresh-client-id",
+        ),
+      )
+      val retriedAccepted = store.load("gateway-a").single()
+      assertEquals("fresh-client-id", retriedAccepted.id)
+      assertEquals(1, retriedAccepted.attemptVersion)
+
+      store.delete(retriedAccepted.id)
+      val queued = store.enqueueQueued("never dispatched", nowMs = 30)
+      store.confirmBranchChange("gateway-a", scope, "leaf-newer", OUTBOX_BRANCH_CHANGED_ERROR)
+      val parkedQueued = store.load("gateway-a").single()
+      store.requeueForRetryIfCurrent(
+        gatewayId = "gateway-a",
+        id = parkedQueued.id,
+        expectedAttemptVersion = parkedQueued.attemptVersion,
+        expectedRetryCount = parkedQueued.retryCount,
+        expectedLastError = parkedQueued.lastError,
+        nowMs = 40,
+        gatedEpoch = null,
+        ownerAgentId = "main",
+        replacementId = "unused-replacement",
+      )
+      val retriedQueued = store.load("gateway-a").single()
+      assertEquals(queued.id, retriedQueued.id)
+      assertEquals(2, retriedQueued.attemptVersion)
+    }
+
+  @Test
+  fun freshRetryIdentityKeepsAttachmentMetadataAndChunksReachable() =
+    runTest {
+      val bytes = ByteArray(OUTBOX_ATTACHMENT_CHUNK_BYTES + 17) { (it % 251).toByte() }
+      val queued =
+        store.enqueue(
+          gatewayId = "gateway-a",
+          sessionKey = "main",
+          text = "attachment retry",
+          thinkingLevel = "off",
+          nowMs = 10,
+          ownerAgentId = "main",
+          attachments = listOf(payload(bytes, fileName = "proof.jpg")),
+        ) as ChatOutboxEnqueueResult.Queued
+      store.updateStatusIfAttempt(queued.item.id, 1, ChatOutboxStatus.Accepted, 0, null)
+      store.confirmBranchChange("gateway-a", ChatOutboxScope("main", "main"), "leaf-new", OUTBOX_BRANCH_CHANGED_ERROR)
+      val parked = store.load("gateway-a").single()
+
+      assertEquals(
+        1,
+        store.requeueForRetryIfCurrent(
+          gatewayId = "gateway-a",
+          id = parked.id,
+          expectedAttemptVersion = parked.attemptVersion,
+          expectedRetryCount = parked.retryCount,
+          expectedLastError = parked.lastError,
+          nowMs = 20,
+          gatedEpoch = null,
+          ownerAgentId = "main",
+          replacementId = "fresh-attachment-id",
+        ),
+      )
+
+      val loaded = store.loadAttachments("fresh-attachment-id").single()
+      assertEquals("proof.jpg", loaded.attachment.fileName)
+      assertTrue(bytes.contentEquals(loaded.bytes))
+    }
+
+  @Test
+  fun staleDeliveryCallbackCannotOverwriteANewerAttempt() =
+    runTest {
+      val queued = store.enqueueQueued("retry safely", nowMs = 10)
+      assertEquals(1, store.claimForSendingIfAttempt(queued.id, 1, 0, null))
+      assertEquals(
+        1,
+        store.updateStatusIfAttempt(
+          queued.id,
+          1,
+          ChatOutboxStatus.Queued,
+          1,
+          "not dispatched",
+          expectedStatus = ChatOutboxStatus.Sending,
+        ),
+      )
+
+      val retried = store.load("gateway-a").single()
+      assertEquals(2, retried.attemptVersion)
+      assertEquals(
+        0,
+        store.updateStatusIfAttempt(
+          queued.id,
+          1,
+          ChatOutboxStatus.Accepted,
+          0,
+          null,
+          expectedStatus = ChatOutboxStatus.Sending,
+        ),
+      )
+      assertEquals(ChatOutboxStatus.Queued, store.load("gateway-a").single().status)
+    }
+
+  @Test
+  fun deliveryCallbackCannotResurrectARowParkedByBranchChange() =
+    runTest {
+      val scope = ChatOutboxScope("main", "main")
+      val queued = store.enqueueQueued("claimed on old branch", nowMs = 10)
+      assertEquals(1, store.claimForSendingIfAttempt(queued.id, queued.attemptVersion, 0, null))
+      assertTrue(store.confirmBranchChange("gateway-a", scope, "leaf-new", OUTBOX_BRANCH_CHANGED_ERROR))
+
+      assertEquals(
+        0,
+        store.updateStatusIfAttempt(
+          queued.id,
+          queued.attemptVersion,
+          ChatOutboxStatus.Accepted,
+          0,
+          null,
+          expectedStatus = ChatOutboxStatus.Sending,
+        ),
+      )
+      assertEquals(ChatOutboxStatus.Failed, store.load("gateway-a").single().status)
+    }
+
+  @Test
+  fun sessionMutationLeaseParksRowsEnqueuedWhileTheGatewayMutationRuns() =
+    runTest {
+      val scope = ChatOutboxScope("main", "main")
+      assertTrue(store.beginSessionMutation("gateway-a", scope, nowMs = 1_000) != null)
+      val racing = store.enqueueQueued("racing enqueue", nowMs = 1_001)
+
+      assertTrue(store.confirmBranchChange("gateway-a", scope, "leaf-after-rewind", OUTBOX_BRANCH_CHANGED_ERROR))
+
+      val parked = store.load("gateway-a").single()
+      assertEquals(racing.id, parked.id)
+      assertEquals(ChatOutboxStatus.Failed, parked.status)
+      assertEquals(1, store.branchState("gateway-a", scope)?.epoch)
+    }
+
+  @Test
+  fun demotedMutationNeedsReconciliationAndCannotClaimQueuedWork() =
+    runTest {
+      val scope = ChatOutboxScope("main", "main")
+      val lease = requireNotNull(store.beginSessionMutation("gateway-a", scope, nowMs = 1_000))
+      assertTrue(store.demoteSessionMutationToReconciliation("gateway-a", scope, lease))
+      val queued = store.enqueueQueued("wait for reconcile", nowMs = 1_001)
+
+      assertTrue(store.branchState("gateway-a", scope)?.needsReconciliation == true)
+      assertEquals(0, store.claimForSendingIfAttempt(queued.id, queued.attemptVersion, 0, null))
+    }
+
+  @Test
+  fun staleMutationCancellationCannotClearNewerRemoteReconciliation() =
+    runTest {
+      val scope = ChatOutboxScope("main", "main")
+      val lease = requireNotNull(store.beginSessionMutation("gateway-a", scope, nowMs = 1_000))
+      assertTrue(store.demoteSessionMutationToReconciliation("gateway-a", scope, lease = null))
+
+      assertFalse(store.cancelSessionMutation("gateway-a", scope, lease))
+      assertTrue(store.branchState("gateway-a", scope)?.needsReconciliation == true)
+    }
+
+  @Test
+  fun staleMutationLeaseCannotConfirmOverANewerLease() =
+    runTest {
+      val scope = ChatOutboxScope("main", "main")
+      val staleLease = requireNotNull(store.beginSessionMutation("gateway-a", scope, nowMs = 1_000))
+      assertTrue(store.demoteSessionMutationToReconciliation("gateway-a", scope, lease = null))
+      val reconciliationState = requireNotNull(store.branchState("gateway-a", scope))
+      assertTrue(
+        store.reconcileBranchScope(
+          gatewayId = "gateway-a",
+          scope = scope,
+          previousState = reconciliationState,
+          activeLeafEntryId = null,
+          branchLeafEntryIds = emptySet(),
+          activeTranscriptEntryIds = emptySet(),
+          lastError = OUTBOX_BRANCH_CHANGED_ERROR,
+        ),
+      )
+      val currentLease = requireNotNull(store.beginSessionMutation("gateway-a", scope, nowMs = 2_000))
+
+      assertFalse(
+        store.confirmBranchChange(
+          "gateway-a",
+          scope,
+          "stale-leaf",
+          OUTBOX_BRANCH_CHANGED_ERROR,
+          staleLease,
+        ),
+      )
+      assertEquals(currentLease.startedAtMs, store.branchState("gateway-a", scope)?.switchPendingSinceMs)
+    }
+
+  @Test
+  fun ancestryDisambiguatesTranscriptAdvanceFromRemoteBranchChange() =
+    runTest {
+      val advancingScope = ChatOutboxScope("advance", "main")
+      val initialAdvance = requireNotNull(store.branchState("gateway-a", advancingScope))
+      assertTrue(store.updateLastActiveLeafEntryId("gateway-a", advancingScope, "leaf-old", initialAdvance.epoch, initialAdvance.revision))
+      val advanceState = requireNotNull(store.branchState("gateway-a", advancingScope))
+      val advancingRow = store.enqueueQueued("stay active", nowMs = 10, sessionKey = "advance")
+      assertTrue(
+        store.reconcileBranchScope(
+          gatewayId = "gateway-a",
+          scope = advancingScope,
+          previousState = advanceState,
+          activeLeafEntryId = "leaf-new",
+          branchLeafEntryIds = setOf("leaf-new"),
+          activeTranscriptEntryIds = setOf("leaf-old", "leaf-new"),
+          lastError = OUTBOX_BRANCH_CHANGED_ERROR,
+        ),
+      )
+      assertEquals(ChatOutboxStatus.Queued, store.load("gateway-a").single { it.id == advancingRow.id }.status)
+
+      val switchedScope = ChatOutboxScope("switched", "main")
+      val initialSwitch = requireNotNull(store.branchState("gateway-a", switchedScope))
+      assertTrue(store.updateLastActiveLeafEntryId("gateway-a", switchedScope, "leaf-a", initialSwitch.epoch, initialSwitch.revision))
+      val switchState = requireNotNull(store.branchState("gateway-a", switchedScope))
+      val switchedRow = store.enqueueQueued("park me", nowMs = 20, sessionKey = "switched")
+      assertTrue(
+        store.reconcileBranchScope(
+          gatewayId = "gateway-a",
+          scope = switchedScope,
+          previousState = switchState,
+          activeLeafEntryId = "leaf-b",
+          branchLeafEntryIds = setOf("leaf-a", "leaf-b"),
+          activeTranscriptEntryIds = setOf("leaf-b"),
+          lastError = OUTBOX_BRANCH_CHANGED_ERROR,
+        ),
+      )
+      assertEquals(ChatOutboxStatus.Failed, store.load("gateway-a").single { it.id == switchedRow.id }.status)
+    }
+
+  @Test
+  fun branchOwnershipIsAgentScopedAndEmptyRootReconciles() =
+    runTest {
+      val mainScope = ChatOutboxScope("shared", "main")
+      val opsScope = ChatOutboxScope("shared", "ops")
+      val mainState = requireNotNull(store.branchState("gateway-a", mainScope))
+      val opsState = requireNotNull(store.branchState("gateway-a", opsScope))
+
+      assertTrue(
+        store.reconcileBranchScope(
+          "gateway-a",
+          mainScope,
+          mainState,
+          activeLeafEntryId = null,
+          branchLeafEntryIds = emptySet(),
+          activeTranscriptEntryIds = emptySet(),
+          lastError = OUTBOX_BRANCH_CHANGED_ERROR,
+        ),
+      )
+      assertTrue(store.confirmBranchChange("gateway-a", mainScope, "main-leaf", OUTBOX_BRANCH_CHANGED_ERROR))
+      assertEquals(1, store.branchState("gateway-a", mainScope)?.epoch)
+      assertEquals(0, store.branchState("gateway-a", opsScope)?.epoch)
+      assertEquals(opsState, store.branchState("gateway-a", opsScope))
+    }
+
+  @Test
+  fun commandAdmittedAfterEmptyRootSnapshotBindsToTheListedBranch() =
+    runTest {
+      val scope = ChatOutboxScope("main", "main")
+      val emptyRoot = requireNotNull(store.branchState("gateway-a", scope))
+      val admitted = store.enqueueQueued("after snapshot", nowMs = 10)
+
+      assertTrue(
+        store.reconcileBranchScope(
+          gatewayId = "gateway-a",
+          scope = scope,
+          previousState = emptyRoot,
+          activeLeafEntryId = "leaf-current",
+          branchLeafEntryIds = setOf("leaf-current"),
+          activeTranscriptEntryIds = setOf("leaf-current"),
+          lastError = OUTBOX_BRANCH_CHANGED_ERROR,
+        ),
+      )
+
+      val rebound = store.load("gateway-a").single()
+      assertEquals(admitted.id, rebound.id)
+      assertEquals(ChatOutboxStatus.Queued, rebound.status)
+      assertEquals("leaf-current", store.branchState("gateway-a", scope)?.lastActiveLeafEntryId)
+    }
+
+  @Test
+  fun staleTranscriptTipRevisionCannotOverwriteTheCurrentLeaf() =
+    runTest {
+      val scope = ChatOutboxScope("main", "main")
+      val captured = requireNotNull(store.branchState("gateway-a", scope))
+
+      assertTrue(store.updateLastActiveLeafEntryId("gateway-a", scope, "leaf-current", captured.epoch, captured.revision))
+      assertFalse(store.updateLastActiveLeafEntryId("gateway-a", scope, "leaf-stale", captured.epoch, captured.revision))
+      assertEquals("leaf-current", store.branchState("gateway-a", scope)?.lastActiveLeafEntryId)
+    }
+
+  @Test
+  fun pinningMainAliasRebasesDeliveryOntoTheCanonicalBranchEpoch() =
+    runTest {
+      val canonicalScope = ChatOutboxScope("agent:main:device", "main")
+      assertTrue(store.confirmBranchChange("gateway-a", canonicalScope, "leaf-current", OUTBOX_BRANCH_CHANGED_ERROR))
+      val queued = store.enqueueQueued("pre-hello", nowMs = 10, sessionKey = "main")
+
+      store.pinSessionKey(queued.id, canonicalScope.sessionKey)
+
+      val pinned = store.load("gateway-a").single()
+      assertEquals(canonicalScope.sessionKey, pinned.sessionKey)
+      assertEquals(1, pinned.branchEpoch)
+      assertEquals(1, pinned.scopeBranchEpoch)
+      assertEquals(1, store.claimForSendingIfAttempt(pinned.id, pinned.attemptVersion, 0, null))
     }
 
   @Test
@@ -522,6 +930,37 @@ class RoomChatCommandOutboxTest {
       val queued = store.enqueueQueued("pinned", nowMs = 10)
       store.pinSessionKey(queued.id, "agent:work:main")
       assertEquals("agent:work:main", store.load("gateway-a").single().sessionKey)
+    }
+
+  @Test
+  fun retryAndExactSessionDeletionCanonicalizeOwnerAgentIds() =
+    runTest {
+      val queued =
+        store.enqueue(
+          gatewayId = "gateway-a",
+          sessionKey = "main",
+          text = "mixed owner",
+          thinkingLevel = "off",
+          nowMs = 10,
+          ownerAgentId = "Main",
+        ) as ChatOutboxEnqueueResult.Queued
+      assertEquals("main", store.load("gateway-a").single().ownerAgentId)
+      store.updateStatus(queued.item.id, ChatOutboxStatus.Failed, retryCount = 1, lastError = "retry")
+
+      assertEquals(
+        1,
+        store.requeueForRetry(
+          gatewayId = "gateway-a",
+          id = queued.item.id,
+          nowMs = 20,
+          gatedEpoch = null,
+          ownerAgentId = "MAIN",
+        ),
+      )
+      assertEquals("main", store.load("gateway-a").single().ownerAgentId)
+
+      store.deleteForSession("gateway-a", "main", "MAIN")
+      assertTrue(store.load("gateway-a").isEmpty())
     }
 
   @Test

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatComposerDraftTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatComposerDraftTest.kt
@@ -482,6 +482,32 @@ class ChatComposerDraftTest {
   }
 
   @Test
+  fun guardedReplacementPreservesComposerEditsMadeWhileActionWasInFlight() {
+    val draft =
+      ChatDraft(
+        text = "rewound text",
+        placement = ChatDraftPlacement.Replace,
+        expectedExistingText = "before",
+      )
+
+    assertEquals(null, mergeChatDraft(draft, "typed while waiting"))
+    assertEquals("rewound text", mergeChatDraft(draft, "before"))
+  }
+
+  @Test
+  fun rewindReplacementCanIntentionallyClearTheComposer() {
+    val draft =
+      ChatDraft(
+        text = "",
+        placement = ChatDraftPlacement.Replace,
+        expectedExistingText = "before",
+        acceptsEmptyText = true,
+      )
+
+    assertEquals("", mergeChatDraft(draft, "before"))
+  }
+
+  @Test
   fun replyDraftCanOnlyMergeIntoItsOriginatingOwner() {
     val owner = ChatComposerOwner(gatewayStableId = "gateway-a", agentId = "agent-a", sessionKey = "session-a")
     val draft = ChatDraft(text = "> quoted\n\n", placement = ChatDraftPlacement.BeforeExisting, owner = owner)

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatScreenTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatScreenTest.kt
@@ -4,6 +4,7 @@ import ai.openclaw.app.GatewayAgentSummary
 import ai.openclaw.app.PendingAssistantAutoSend
 import ai.openclaw.app.chat.ChatComposerOwner
 import ai.openclaw.app.chat.ChatMessageContent
+import ai.openclaw.app.chat.SessionBranch
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -11,6 +12,16 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class ChatScreenTest {
+  @Test
+  fun branchMessageCountUsesSingularAndPluralCopy() {
+    assertEquals("1 message", branchMessageCountText(1))
+    assertEquals("2 messages", branchMessageCountText(2))
+    assertEquals(
+      "2 messages",
+      branchMetadataText(SessionBranch("leaf", "", 2, updatedAt = null, active = false)),
+    )
+  }
+
   @Test
   fun longUserMessagesProduceABoundedPlainTextPreview() {
     assertNull(ChatUserMessageDisclosurePolicy.collapsedPreview("Short prompt"))


### PR DESCRIPTION
## What Problem This Solves

The Android chat had no access to transcript branch switching at all, and its rewind/fork story lagged the web and Apple surfaces: no bubble rewind/fork actions, and a durable command outbox that was entirely branch-unaware — a queued message could replay onto a different transcript branch after a rewind, fork, or cross-client switch.

## Why This Change Was Made

Full Android parity with the Swift implementation (PR #112056): rewind/fork bubble actions, a branch switcher, and branch-safe durable outbox coordination, so all three native surfaces share the same session-branch semantics.

## User Impact

- Chat bubbles gain Rewind and Fork actions; the composer gains a branch switcher driven by `sessions.branches.list` / `sessions.branches.switch`.
- Rewind/fork/switch are gated on run activity and pending outbox work via a durable session-mutation lease; ambiguous mutation outcomes demote the scope to needs-reconciliation and require an authoritative history fetch before delivery resumes.
- The Room-backed outbox carries epoch-scoped branch ownership: rows stamp the scope epoch at enqueue, flush checks are local, confirmed branch changes atomically bump the epoch and park stale rows, parked possibly-accepted rows retry with a fresh delivery identity (including the serialized request), and stale transcript-tip writes are revision-CAS rejected.
- Remote rewind/branch-switch events reconcile through a deferred funnel that survives echo ambiguity, transient RPC failures (delayed retry), and updates the session drawer for background sessions.

Accepted tradeoff (commented in `ChatController.kt`): an outcome-unknown `sessions.fork` can duplicate on explicit user retry — the RPC carries no idempotency token on any surface; a protocol-level token is the filed follow-up.

## Evidence

- 1,820 Android unit tests green (`:app:testPlayDebugUnitTest`), `ktlintCheck` clean, `android-app-i18n check` clean, `git diff --check` clean.
- Five adversarial autoreview cycles driven to a clean verdict (echo correlation, revision CAS, reconcile retry lanes, deferred-wrapper forwarding, ambiguity recovery).
- Generated locale artifacts are excluded per the CI artifact-ownership gate; only `apps/.i18n/native-source.json` ships (the post-merge native locale workflow owns translations).
