### PR TITLE
fix(onboarding): recover expired wizard sessions

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -1405,6 +1405,20 @@ public struct UnknownAgentIdErrorDetails: Codable, Sendable {
     }
 }
 
+public struct WizardNotFoundErrorDetails: Codable, Sendable {
+    public let code: String
+
+    public init(
+        code: String)
+    {
+        self.code = code
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case code
+    }
+}
+
 public struct GatewaySuspendTaskBlocker: Codable, Sendable {
     public let taskid: String
     public let status: String
@@ -16032,6 +16046,7 @@ public enum GatewayErrorDetails: Codable, Sendable {
     case missingScope(MissingScopeErrorDetails)
     case mcpAppViewExpired(McpAppViewExpiredErrorDetails)
     case unknownAgentId(UnknownAgentIdErrorDetails)
+    case wizardNotFound(WizardNotFoundErrorDetails)
 
     public init(code: String, missingscope: String, requiredscopes: [String]) {
         self = .missingScope(
@@ -16048,6 +16063,7 @@ public enum GatewayErrorDetails: Codable, Sendable {
         case .missingScope(let value): value.code
         case .mcpAppViewExpired(let value): value.code
         case .unknownAgentId(let value): value.code
+        case .wizardNotFound(let value): value.code
         }
     }
 
@@ -16072,6 +16088,7 @@ public enum GatewayErrorDetails: Codable, Sendable {
         case "MISSING_SCOPE": self = try .missingScope(MissingScopeErrorDetails(from: decoder))
         case "MCP_APP_VIEW_EXPIRED": self = try .mcpAppViewExpired(McpAppViewExpiredErrorDetails(from: decoder))
         case "UNKNOWN_AGENT_ID": self = try .unknownAgentId(UnknownAgentIdErrorDetails(from: decoder))
+        case "WIZARD_NOT_FOUND": self = try .wizardNotFound(WizardNotFoundErrorDetails(from: decoder))
         default:
             throw DecodingError.dataCorruptedError(
                 forKey: .discriminator,
@@ -16086,6 +16103,7 @@ public enum GatewayErrorDetails: Codable, Sendable {
         case .missingScope(let value): try value.encode(to: encoder)
         case .mcpAppViewExpired(let value): try value.encode(to: encoder)
         case .unknownAgentId(let value): try value.encode(to: encoder)
+        case .wizardNotFound(let value): try value.encode(to: encoder)
         }
     }
 }

--- a/packages/gateway-protocol/src/gateway-error-details.ts
+++ b/packages/gateway-protocol/src/gateway-error-details.ts
@@ -19,11 +19,12 @@ export const ErrorCodes = {
 /** Closed set of canonical gateway error code strings. */
 export type ErrorCode = (typeof ErrorCodes)[keyof typeof ErrorCodes];
 
-/** Stable discriminants for structured method-level authorization failures. */
+/** Stable discriminants for structured method-level failures. */
 export const GatewayErrorDetailCodes = {
   MISSING_SCOPE: "MISSING_SCOPE",
   MCP_APP_VIEW_EXPIRED: "MCP_APP_VIEW_EXPIRED",
   UNKNOWN_AGENT_ID: "UNKNOWN_AGENT_ID",
+  WIZARD_NOT_FOUND: "WIZARD_NOT_FOUND",
 } as const;
 
 /** Missing operator-scope details shared by WebSocket and HTTP responses. */
@@ -43,11 +44,17 @@ export type UnknownAgentIdErrorDetails = {
   agentId: string;
 };
 
-/** Structured details emitted by method-level authorization failures. */
+/** Missing or expired process-local setup wizard session. */
+export type WizardNotFoundErrorDetails = {
+  code: typeof GatewayErrorDetailCodes.WIZARD_NOT_FOUND;
+};
+
+/** Structured details emitted by method-level failures. */
 export type GatewayErrorDetails =
   | MissingScopeErrorDetails
   | McpAppViewExpiredErrorDetails
-  | UnknownAgentIdErrorDetails;
+  | UnknownAgentIdErrorDetails
+  | WizardNotFoundErrorDetails;
 
 type GatewayErrorLike = {
   code?: unknown;

--- a/packages/gateway-protocol/src/index.ts
+++ b/packages/gateway-protocol/src/index.ts
@@ -23,6 +23,7 @@ export type {
   GatewayErrorDetails,
   McpAppViewExpiredErrorDetails,
   MissingScopeErrorDetails,
+  WizardNotFoundErrorDetails,
 } from "./schema/error-codes.js";
 export * from "./schema/board.js";
 export * from "./migration-api.js";
@@ -269,6 +270,7 @@ import {
   GatewayErrorDetailCodes,
   GatewayErrorDetailsSchema,
   MissingScopeErrorDetailsSchema,
+  WizardNotFoundErrorDetailsSchema,
   EnvironmentSummarySchema,
   EnvironmentsCreateParamsSchema,
   EnvironmentsCreateResultSchema,
@@ -984,6 +986,7 @@ export {
   ErrorShapeSchema,
   GatewayErrorDetailsSchema,
   MissingScopeErrorDetailsSchema,
+  WizardNotFoundErrorDetailsSchema,
   WorkerAdmissionFailureReasonSchema,
   WorkerAdmissionHandshakeSchema,
   WorkerAdmissionResponseFrameSchema,

--- a/packages/gateway-protocol/src/schema/error-codes.test.ts
+++ b/packages/gateway-protocol/src/schema/error-codes.test.ts
@@ -11,6 +11,7 @@ import {
   readMissingScopeError,
   readMissingScopeErrorDetails,
   UnknownAgentIdErrorDetailsSchema,
+  WizardNotFoundErrorDetailsSchema,
 } from "./error-codes.js";
 
 describe("gateway error details", () => {
@@ -41,6 +42,15 @@ describe("gateway error details", () => {
     expect(Value.Check(UnknownAgentIdErrorDetailsSchema, details)).toBe(true);
     expect(Value.Check(GatewayErrorDetailsSchema, details)).toBe(true);
     expect(Value.Check(UnknownAgentIdErrorDetailsSchema, { ...details, agentId: "" })).toBe(false);
+  });
+
+  it("validates missing wizard details", () => {
+    const details = { code: GatewayErrorDetailCodes.WIZARD_NOT_FOUND };
+    expect(Value.Check(WizardNotFoundErrorDetailsSchema, details)).toBe(true);
+    expect(Value.Check(GatewayErrorDetailsSchema, details)).toBe(true);
+    expect(Value.Check(WizardNotFoundErrorDetailsSchema, { ...details, sessionId: "stale" })).toBe(
+      false,
+    );
   });
 
   it("builds a distinct forbidden missing-scope response", () => {

--- a/packages/gateway-protocol/src/schema/error-codes.ts
+++ b/packages/gateway-protocol/src/schema/error-codes.ts
@@ -18,6 +18,7 @@ export {
   type McpAppViewExpiredErrorDetails,
   type MissingScopeErrorDetails,
   type UnknownAgentIdErrorDetails,
+  type WizardNotFoundErrorDetails,
   isMcpAppViewExpiredError,
   readMissingScopeError,
   readMissingScopeErrorDetails,
@@ -39,11 +40,16 @@ export const UnknownAgentIdErrorDetailsSchema = closedObject({
   agentId: NonEmptyString,
 });
 
-/** Structured details emitted by method-level authorization failures. */
+export const WizardNotFoundErrorDetailsSchema = closedObject({
+  code: Type.Literal(GatewayErrorDetailCodes.WIZARD_NOT_FOUND),
+});
+
+/** Structured details emitted by method-level failures. */
 export const GatewayErrorDetailsSchema = Type.Union([
   MissingScopeErrorDetailsSchema,
   McpAppViewExpiredErrorDetailsSchema,
   UnknownAgentIdErrorDetailsSchema,
+  WizardNotFoundErrorDetailsSchema,
 ]);
 
 /** Builds the canonical gateway error payload while preserving optional retry metadata. */

--- a/packages/gateway-protocol/src/schema/protocol-schemas.ts
+++ b/packages/gateway-protocol/src/schema/protocol-schemas.ts
@@ -295,6 +295,7 @@ import {
   McpAppViewExpiredErrorDetailsSchema,
   MissingScopeErrorDetailsSchema,
   UnknownAgentIdErrorDetailsSchema,
+  WizardNotFoundErrorDetailsSchema,
 } from "./error-codes.js";
 import {
   ExecApprovalsGetParamsSchema,
@@ -657,6 +658,7 @@ export const ProtocolSchemas = {
   MissingScopeErrorDetails: MissingScopeErrorDetailsSchema,
   McpAppViewExpiredErrorDetails: McpAppViewExpiredErrorDetailsSchema,
   UnknownAgentIdErrorDetails: UnknownAgentIdErrorDetailsSchema,
+  WizardNotFoundErrorDetails: WizardNotFoundErrorDetailsSchema,
   GatewayErrorDetails: GatewayErrorDetailsSchema,
   GatewaySuspendTaskBlocker: GatewaySuspendTaskBlockerSchema,
   GatewaySuspendBlocker: GatewaySuspendBlockerSchema,

--- a/scripts/protocol-gen-swift.ts
+++ b/scripts/protocol-gen-swift.ts
@@ -611,6 +611,7 @@ function emitDiscriminatedUnionCompatibility(name: string): string[] {
     "        case .missingScope(let value): value.code",
     "        case .mcpAppViewExpired(let value): value.code",
     "        case .unknownAgentId(let value): value.code",
+    "        case .wizardNotFound(let value): value.code",
     "        }",
     "    }",
     "",

--- a/src/gateway/server-methods/wizard.test.ts
+++ b/src/gateway/server-methods/wizard.test.ts
@@ -1,0 +1,35 @@
+// Wizard server-method tests cover stable lifecycle errors for process-local sessions.
+import { expectDefined } from "@openclaw/normalization-core";
+import { describe, expect, it, vi } from "vitest";
+import type { GatewayRequestHandlerOptions } from "./types.js";
+import { wizardHandlers } from "./wizard.js";
+
+describe("wizard session lookup", () => {
+  it.each([
+    { method: "wizard.next", params: { sessionId: "expired" } },
+    { method: "wizard.cancel", params: { sessionId: "expired" } },
+    { method: "wizard.status", params: { sessionId: "expired" } },
+  ] as const)("returns structured details from $method", async ({ method, params }) => {
+    const respond = vi.fn();
+    const handler = expectDefined(
+      wizardHandlers[method],
+      `wizardHandlers[${method}] test invariant`,
+    );
+
+    await handler({
+      req: { type: "req", id: "wizard-missing", method, params },
+      params,
+      client: null,
+      isWebchatConnect: () => false,
+      respond,
+      context: { wizardSessions: new Map() } as never,
+    } as GatewayRequestHandlerOptions);
+
+    expect(respond).toHaveBeenCalledOnce();
+    expect(respond).toHaveBeenCalledWith(false, undefined, {
+      code: "INVALID_REQUEST",
+      message: "wizard not found",
+      details: { code: "WIZARD_NOT_FOUND" },
+    });
+  });
+});

--- a/src/gateway/server-methods/wizard.ts
+++ b/src/gateway/server-methods/wizard.ts
@@ -5,6 +5,7 @@ import { readStringValue } from "@openclaw/normalization-core/string-coerce";
 import {
   ErrorCodes,
   errorShape,
+  GatewayErrorDetailCodes,
   validateWizardCancelParams,
   validateWizardNextParams,
   validateWizardStartParams,
@@ -59,7 +60,13 @@ function findWizardSessionOrRespond(params: {
 }): WizardSession | null {
   const session = params.context.wizardSessions.get(params.sessionId);
   if (!session) {
-    params.respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "wizard not found"));
+    params.respond(
+      false,
+      undefined,
+      errorShape(ErrorCodes.INVALID_REQUEST, "wizard not found", {
+        details: { code: GatewayErrorDetailCodes.WIZARD_NOT_FOUND },
+      }),
+    );
     return null;
   }
   return session;

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -165,6 +165,8 @@ export const en: TranslationMap = {
       subtitle: "A short guided setup — you can fine-tune everything later.",
       starting: "Starting setup…",
       working: "Working…",
+      sessionExpired:
+        "This setup session expired after the Gateway restarted. Close this dialog, then start channel setup again.",
       continue: "Continue",
       finish: "Finish",
       copyText: "Copy",
@@ -1836,6 +1838,8 @@ export const en: TranslationMap = {
       copy: "Copy",
       expires: "Expires in {count} minutes",
       cancelled: "Provider sign-in was cancelled.",
+      sessionExpired:
+        "This setup session expired after the Gateway restarted. Close this dialog, then start model setup again.",
       notComplete: "Sign-in finished, but model setup is not complete yet.",
     },
   },

--- a/ui/src/lib/gateway-errors.test.ts
+++ b/ui/src/lib/gateway-errors.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment node
 import { describe, expect, it } from "vitest";
-import { isMissingOperatorReadScopeError } from "./gateway-errors.ts";
+import { GatewayRequestError } from "../api/gateway.ts";
+import { isMissingOperatorReadScopeError, isWizardNotFoundError } from "./gateway-errors.ts";
 
 function gatewayRequestError(params: { code: string; message: string; details?: unknown }): Error {
   return Object.assign(new Error(params.message), {
@@ -12,6 +13,45 @@ function gatewayRequestError(params: { code: string; message: string; details?: 
 }
 
 describe("gateway error helpers", () => {
+  it("classifies structured missing-wizard errors", () => {
+    expect(
+      isWizardNotFoundError(
+        new GatewayRequestError({
+          code: "INVALID_REQUEST",
+          message: "localized or changed public copy",
+          details: { code: "WIZARD_NOT_FOUND" },
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      isWizardNotFoundError({
+        gatewayCode: "INVALID_REQUEST",
+        details: { code: "WIZARD_NOT_FOUND" },
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects unrelated errors and malformed missing-wizard details", () => {
+    expect(
+      isWizardNotFoundError({
+        gatewayCode: "UNAVAILABLE",
+        details: { code: "WIZARD_NOT_FOUND" },
+      }),
+    ).toBe(false);
+    expect(
+      isWizardNotFoundError({
+        gatewayCode: "INVALID_REQUEST",
+        details: { code: "UNKNOWN_AGENT_ID" },
+      }),
+    ).toBe(false);
+    expect(
+      isWizardNotFoundError({ gatewayCode: "INVALID_REQUEST", message: "wizard not found" }),
+    ).toBe(false);
+    for (const details of [null, "WIZARD_NOT_FOUND", [], { code: 42 }]) {
+      expect(isWizardNotFoundError({ gatewayCode: "INVALID_REQUEST", details })).toBe(false);
+    }
+  });
+
   it("classifies structured read-scope failures without message parsing", () => {
     expect(
       isMissingOperatorReadScopeError(

--- a/ui/src/lib/gateway-errors.ts
+++ b/ui/src/lib/gateway-errors.ts
@@ -1,7 +1,35 @@
 // Control UI shared Gateway error helpers.
-import { readMissingScopeError } from "@openclaw/gateway-client/browser";
+import {
+  ErrorCodes,
+  GatewayErrorDetailCodes,
+  readMissingScopeError,
+} from "@openclaw/gateway-client/browser";
 import { ConnectErrorDetailCodes } from "../../../packages/gateway-protocol/src/connect-error-details.js";
 import { resolveGatewayErrorDetailCode } from "../api/gateway.ts";
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+/** Identifies an expired process-local wizard session without parsing public copy. */
+export function isWizardNotFoundError(err: unknown): boolean {
+  const error = asRecord(err);
+  if (!error) {
+    return false;
+  }
+  const code =
+    typeof error.gatewayCode === "string"
+      ? error.gatewayCode
+      : typeof error.code === "string"
+        ? error.code
+        : null;
+  return (
+    code === ErrorCodes.INVALID_REQUEST &&
+    asRecord(error.details)?.code === GatewayErrorDetailCodes.WIZARD_NOT_FOUND
+  );
+}
 
 export function isMissingOperatorReadScopeError(err: unknown): boolean {
   // Structural check, not instanceof: under isolate:false a custom element

--- a/ui/src/pages/channels/wizard-controller.test.ts
+++ b/ui/src/pages/channels/wizard-controller.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment node
 // Channel wizard controller: step/answer state machine over wizard.* RPCs.
 import { describe, expect, it, vi } from "vitest";
+import { GatewayRequestError } from "../../api/gateway.ts";
 import { ChannelWizardController } from "./wizard-controller.ts";
 
 type RequestHandler = (method: string, params?: unknown) => Promise<unknown>;
@@ -8,7 +9,12 @@ type RequestHandler = (method: string, params?: unknown) => Promise<unknown>;
 function createController(handler: RequestHandler) {
   const request = vi.fn(handler);
   const onChange = vi.fn();
-  const controller = new ChannelWizardController(() => ({ request: request as never }), onChange);
+  const controller = new ChannelWizardController(
+    () => ({ request: request as never }),
+    onChange,
+    () => false,
+    () => "Setup expired. Close and restart setup.",
+  );
   return { controller, request, onChange };
 }
 
@@ -88,6 +94,66 @@ describe("ChannelWizardController", () => {
       validationError: "Token looks invalid.",
       busy: false,
     });
+  });
+
+  it("clears an expired session without cancelling, restarting, or replaying the answer", async () => {
+    const { controller, request } = createController(async (method) => {
+      if (method === "wizard.start") {
+        return { sessionId: "s-expired", done: false, status: "running", step: tokenStep };
+      }
+      if (method === "wizard.next") {
+        throw new GatewayRequestError({
+          code: "INVALID_REQUEST",
+          message: "wizard not found",
+          details: { code: "WIZARD_NOT_FOUND" },
+        });
+      }
+      if (method === "wizard.cancel") {
+        return { status: "cancelled" };
+      }
+      throw new Error(`unexpected ${method}`);
+    });
+
+    await controller.start("telegram");
+    await controller.answer("secret-token");
+
+    expect(controller.state).toEqual({
+      phase: "error",
+      channel: "telegram",
+      message: "Setup expired. Close and restart setup.",
+    });
+    await controller.cancel();
+    expect(request.mock.calls.filter(([method]) => method === "wizard.start")).toHaveLength(1);
+    expect(request.mock.calls.filter(([method]) => method === "wizard.next")).toHaveLength(1);
+    expect(request.mock.calls.filter(([method]) => method === "wizard.cancel")).toEqual([]);
+  });
+
+  it("keeps generic request errors cancellable", async () => {
+    const { controller, request } = createController(async (method) => {
+      if (method === "wizard.start") {
+        return { sessionId: "s-failed", done: false, status: "running", step: tokenStep };
+      }
+      if (method === "wizard.next") {
+        throw new Error("wizard unavailable");
+      }
+      if (method === "wizard.cancel") {
+        return { status: "cancelled" };
+      }
+      throw new Error(`unexpected ${method}`);
+    });
+
+    await controller.start("telegram");
+    await controller.answer("token");
+    expect(controller.state).toEqual({
+      phase: "error",
+      channel: "telegram",
+      message: "Error: wizard unavailable",
+    });
+
+    await controller.cancel();
+    expect(request.mock.calls.filter(([method]) => method === "wizard.cancel")).toEqual([
+      ["wizard.cancel", { sessionId: "s-failed" }],
+    ]);
   });
 
   it("maps runner failures to the error phase", async () => {

--- a/ui/src/pages/channels/wizard-controller.ts
+++ b/ui/src/pages/channels/wizard-controller.ts
@@ -1,5 +1,6 @@
 // Drives a gateway channel-setup wizard session (wizard.start flow "channels")
 // as a step/answer state machine for the Control UI wizard modal.
+import { isWizardNotFoundError } from "../../lib/gateway-errors.ts";
 
 type WizardGatewayClient = {
   request<T = unknown>(method: string, params?: unknown): Promise<T>;
@@ -113,7 +114,8 @@ export class ChannelWizardController {
     // Known channel ids from the status snapshot. Presentation only: lets a
     // browse-all session title/link the wizard for the picked channel; the
     // completion behavior keys off the gateway-reported accounts instead.
-    private readonly isKnownChannel: (value: string) => boolean = () => false,
+    private readonly isKnownChannel: (value: string) => boolean,
+    private readonly sessionExpiredMessage: () => string,
   ) {}
 
   get state(): ChannelWizardState {
@@ -178,6 +180,15 @@ export class ChannelWizardController {
       this.applyResult(result);
     } catch (err) {
       if (this.generation !== generation) {
+        return;
+      }
+      if (isWizardNotFoundError(err)) {
+        this.sessionId = null;
+        this.setState({
+          phase: "error",
+          channel: this.channel,
+          message: this.sessionExpiredMessage(),
+        });
         return;
       }
       this.setState({ phase: "error", channel: this.channel, message: String(err) });

--- a/ui/src/pages/channels/wizard-host.ts
+++ b/ui/src/pages/channels/wizard-host.ts
@@ -2,6 +2,7 @@
 // per-step multiselect state, dirty-config guarding, and completion effects
 // (config resync + WhatsApp QR handoff) so the page element stays thin.
 import type { ApplicationContext } from "../../app/context.ts";
+import { t } from "../../i18n/index.ts";
 import { ChannelWizardController, type ChannelWizardState } from "./wizard-controller.ts";
 
 type WizardHostDeps = {
@@ -30,6 +31,7 @@ export class ChannelWizardHost {
           .getContext()
           ?.channels.state.channelsSnapshot?.channelMeta?.some((entry) => entry.id === value) ??
         false,
+      () => t("channels.setup.sessionExpired"),
     );
   }
 

--- a/ui/src/pages/model-setup/model-setup-page.ts
+++ b/ui/src/pages/model-setup/model-setup-page.ts
@@ -93,6 +93,7 @@ export class ModelSetupPage extends OpenClawLightDomElement {
     onDone: () => void this.handleWizardDone(),
     requestFailedMessage: () => t("modelSetup.errors.requestFailed"),
     cancelledMessage: () => t("modelSetup.wizard.cancelled"),
+    sessionExpiredMessage: () => t("modelSetup.wizard.sessionExpired"),
   });
 
   override disconnectedCallback() {

--- a/ui/src/pages/model-setup/wizard-runner.test.ts
+++ b/ui/src/pages/model-setup/wizard-runner.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import { GatewayRequestError, type GatewayBrowserClient } from "../../api/gateway.ts";
 import { ModelSetupWizardRunner } from "./wizard-runner.ts";
 
 describe("ModelSetupWizardRunner", () => {
@@ -32,6 +32,7 @@ describe("ModelSetupWizardRunner", () => {
       onDone,
       requestFailedMessage: () => "failed",
       cancelledMessage: () => "cancelled",
+      sessionExpiredMessage: () => "expired",
     });
 
     await runner.start("openai-oauth");
@@ -70,6 +71,7 @@ describe("ModelSetupWizardRunner", () => {
       onDone: () => undefined,
       requestFailedMessage: () => "failed",
       cancelledMessage: () => "cancelled",
+      sessionExpiredMessage: () => "expired",
     });
 
     await runner.start("openai-oauth");
@@ -79,5 +81,59 @@ describe("ModelSetupWizardRunner", () => {
       { sessionId: expect.any(String) },
       { timeoutMs: 30_000 },
     );
+  });
+
+  it("clears an expired session and abort without cancelling or replaying the answer", async () => {
+    let nextCount = 0;
+    let answerSignal: AbortSignal | undefined;
+    const request = vi.fn(
+      (method: string, _params?: unknown, options?: { signal?: AbortSignal }) => {
+        if (method === "openclaw.setup.auth.start") {
+          return Promise.resolve({ sessionId: "session-expired", done: false, status: "running" });
+        }
+        if (method === "wizard.next" && nextCount++ === 0) {
+          return Promise.resolve({
+            done: false,
+            status: "running",
+            step: { id: "api-key", type: "text", message: "API key", sensitive: true },
+          });
+        }
+        if (method === "wizard.next") {
+          answerSignal = options?.signal;
+          return Promise.reject(
+            new GatewayRequestError({
+              code: "INVALID_REQUEST",
+              message: "wizard not found",
+              details: { code: "WIZARD_NOT_FOUND" },
+            }),
+          );
+        }
+        return Promise.resolve({ ok: true });
+      },
+    );
+    const client = { request } as unknown as GatewayBrowserClient;
+    const runner = new ModelSetupWizardRunner({
+      getClient: () => client,
+      onChange: () => undefined,
+      onDone: () => undefined,
+      requestFailedMessage: () => "failed",
+      cancelledMessage: () => "cancelled",
+      sessionExpiredMessage: () => "Setup expired. Close and restart setup.",
+    });
+
+    await runner.start("api-key");
+    await runner.answer("secret-key");
+
+    expect(runner.state).toEqual({
+      phase: "error",
+      message: "Setup expired. Close and restart setup.",
+    });
+    expect(answerSignal?.aborted).toBe(true);
+    await runner.cancel();
+    expect(
+      request.mock.calls.filter(([method]) => method === "openclaw.setup.auth.start"),
+    ).toHaveLength(1);
+    expect(request.mock.calls.filter(([method]) => method === "wizard.next")).toHaveLength(2);
+    expect(request.mock.calls.filter(([method]) => method === "wizard.cancel")).toEqual([]);
   });
 });

--- a/ui/src/pages/model-setup/wizard-runner.ts
+++ b/ui/src/pages/model-setup/wizard-runner.ts
@@ -1,5 +1,6 @@
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { SystemAgentSetupAuthStartResult, WizardNextResult } from "../../api/types.ts";
+import { isWizardNotFoundError } from "../../lib/gateway-errors.ts";
 import {
   MODEL_SETUP_AUTH_START_TIMEOUT_MS,
   MODEL_SETUP_WIZARD_NEXT_TIMEOUT_MS,
@@ -13,6 +14,7 @@ type WizardRunnerOptions = {
   onDone: () => void;
   requestFailedMessage: () => string;
   cancelledMessage: () => string;
+  sessionExpiredMessage: () => string;
 };
 
 export class ModelSetupWizardRunner {
@@ -155,15 +157,17 @@ export class ModelSetupWizardRunner {
     this.sessionId = null;
     this.abortController?.abort();
     this.abortController = null;
-    if (client && sessionId) {
+    const sessionExpired = isWizardNotFoundError(error);
+    if (!sessionExpired && client && sessionId) {
       void client
         .request("wizard.cancel", { sessionId }, { timeoutMs: MODEL_SETUP_AUTH_START_TIMEOUT_MS })
         .catch(() => {
           // The failed request may have already completed or purged the session.
         });
     }
-    const message =
-      error instanceof Error && error.message.trim()
+    const message = sessionExpired
+      ? this.options.sessionExpiredMessage()
+      : error instanceof Error && error.message.trim()
         ? error.message
         : this.options.requestFailedMessage();
     this.setState({ phase: "error", message });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where channel and model setup modals retained process-local wizard session ids across a Gateway restart. Submitting the visible step after reconnect produced the raw internal error `GatewayRequestError: wizard not found`, and the client attempted cleanup against a session the new Gateway process could not own.

## Why This Change Was Made

The Gateway keeps the existing `INVALID_REQUEST` code and public message for compatibility while adding a stable `WIZARD_NOT_FOUND` detail. A shared Control UI helper identifies that structured condition. Channel and model wizard clients clear their dead session/busy/abort state and show actionable expiry guidance without replaying the answer, automatically starting a new session, or sending a redundant cancel request.

The additive protocol detail is registered in the canonical protocol schema and projected through the Swift generator, including the authoritative Swift model update. Kotlin output remains unchanged.

This PR is AI-assisted. I reviewed the protocol, Gateway, generated-client, and Control UI diffs and verified both sibling wizard clients.

## User Impact

After a Gateway restart, stale setup modals explain that the session expired and ask users to close and restart setup. Secret answers are never replayed. Other request errors keep their existing behavior and remain best-effort cancellable.

## Evidence

Before this change, a live Matrix channel wizard left on the access-token step across Gateway restart displayed:

```text
GatewayRequestError: wizard not found
```

After this change, the same typed server condition maps to actionable channel/model-specific expiry copy. The controllers clear local session state, and tests assert no answer replay, new start, or `wizard.cancel` request occurs for an already-missing server session.

Focused proof on final exact-main commits:

```text
fnm exec --using 24.15.0 -- node scripts/run-vitest.mjs \
  packages/gateway-protocol/src/schema/error-codes.test.ts \
  src/gateway/server-methods/wizard.test.ts \
  ui/src/lib/gateway-errors.test.ts \
  ui/src/pages/channels/wizard-controller.test.ts \
  ui/src/pages/model-setup/wizard-runner.test.ts

32 tests passed across 3 Vitest shards.
```

Additional proof:

- Canonical `protocol:gen`, `protocol:gen:swift`, and `protocol:gen:kotlin` all passed.
- `check-protocol-since` passed with CI-equivalent `PROTOCOL_SINCE_BASE_SHA`, and generated-output comparison passed for schema/Swift/Kotlin projections.
- Complete scoped changed gate passed locally using only the intended 18 paths, followed by full `pnpm build`.
- UI i18n verify, protocol/core/UI/scripts typechecks, lint, import-cycle checks, and `git diff --check` passed.
- Two fresh autoreviews passed: the recovery behavior bundle and the authoritative generator/projection companion bundle. TruffleHog scans were clean.
- Patch-identical two-commit rebase onto exact main `a65ad9a3fd1ce668c798ac2937eaac0626e4b6f4`; focused tests reran green.
- An unrelated local generated browser bundle remains byte-preserved and is not part of this PR.
