### PR TITLE
fix(android): localize compact token suffixes

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -13035,7 +13035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 252,
+      "line": 253,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatTurnRecap.kt",
       "source": "${decimal(count / 1_000_000.0)}M",
       "surface": "android",
@@ -13043,7 +13043,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 259,
+      "line": 260,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatTurnRecap.kt",
       "source": "${thousands}k",
       "surface": "android",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -13011,7 +13011,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 222,
+      "line": 223,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatTurnRecap.kt",
       "source": "1 token",
       "surface": "android",
@@ -13019,7 +13019,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 224,
+      "line": 225,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatTurnRecap.kt",
       "source": "$count tokens",
       "surface": "android",
@@ -13027,23 +13027,23 @@
     },
     {
       "kind": "ui-call",
-      "line": 234,
+      "line": 235,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatTurnRecap.kt",
       "source": "Done in $duration",
       "surface": "android",
       "id": "native.android.c32ff602fa622e4b"
     },
     {
-      "kind": "conditional-branch",
-      "line": 253,
+      "kind": "ui-call",
+      "line": 252,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatTurnRecap.kt",
       "source": "${decimal(count / 1_000_000.0)}M",
       "surface": "android",
       "id": "native.android.d2797e7488fe5021"
     },
     {
-      "kind": "conditional-branch",
-      "line": 253,
+      "kind": "ui-call",
+      "line": 259,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatTurnRecap.kt",
       "source": "${thousands}k",
       "surface": "android",

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatTurnRecap.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatTurnRecap.kt
@@ -247,6 +247,7 @@ internal fun turnRecapTokenFormat(count: Long): TurnRecapTokenFormat = TurnRecap
 
 internal fun formatCompactTokenCount(count: Long): String {
   fun decimal(value: Double): String = String.format(Locale.US, "%.1f", value).removeSuffix(".0")
+
   fun millions(): String {
     val value = decimal(count / 1_000_000.0)
     return nativeString("\${decimal(count / 1_000_000.0)}M", value)

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatTurnRecap.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatTurnRecap.kt
@@ -1,6 +1,7 @@
 package ai.openclaw.app.ui.chat
 
 import ai.openclaw.app.chat.ChatSessionEntry
+import ai.openclaw.app.i18n.nativeString
 import ai.openclaw.app.i18n.nativeStringResource
 import ai.openclaw.app.ui.design.ClawTheme
 import androidx.compose.foundation.layout.Arrangement
@@ -246,11 +247,16 @@ internal fun turnRecapTokenFormat(count: Long): TurnRecapTokenFormat = TurnRecap
 
 internal fun formatCompactTokenCount(count: Long): String {
   fun decimal(value: Double): String = String.format(Locale.US, "%.1f", value).removeSuffix(".0")
+  fun millions(): String {
+    val value = decimal(count / 1_000_000.0)
+    return nativeString("\${decimal(count / 1_000_000.0)}M", value)
+  }
+
   return when {
-    count >= 1_000_000L -> "${decimal(count / 1_000_000.0)}M"
+    count >= 1_000_000L -> millions()
     count >= 1_000L -> {
       val thousands = decimal(count / 1_000.0)
-      if (thousands == "1000") "${decimal(count / 1_000_000.0)}M" else "${thousands}k"
+      if (thousands == "1000") millions() else nativeString("\${thousands}k", thousands)
     }
     else -> count.toString()
   }

--- a/test/scripts/android-app-i18n.test.ts
+++ b/test/scripts/android-app-i18n.test.ts
@@ -28,6 +28,24 @@ describe("Android app i18n resources", () => {
     expect(wearBase).toContain('<string name="current_session">Current session</string>');
   });
 
+  it("routes compact token suffixes through generated resources", async () => {
+    const inventory = JSON.parse(await readFile("apps/.i18n/native-source.json", "utf8")) as {
+      entries: Array<{ kind: string; path: string; source: string }>;
+    };
+    const sources = new Set(["${decimal(count / 1_000_000.0)}M", "${thousands}k"]);
+    const entries = inventory.entries
+      .filter(
+        (entry) => entry.path.endsWith("/ui/chat/ChatTurnRecap.kt") && sources.has(entry.source),
+      )
+      .map(({ kind, source }) => ({ kind, source }))
+      .toSorted((left, right) => left.source.localeCompare(right.source));
+
+    expect(entries).toEqual([
+      { kind: "ui-call", source: "${decimal(count / 1_000_000.0)}M" },
+      { kind: "ui-call", source: "${thousands}k" },
+    ]);
+  });
+
   it("builds complete Wear resources for every native locale", async () => {
     const catalog = await buildAndroidAppI18nCatalog();
     const wearResources = [...catalog.resources].filter(


### PR DESCRIPTION
Related: #112218

## What Problem This Solves

Fixes an issue where Android users would see compact token counts such as `1.2k` and `1M` with hard-coded English suffixes when using another supported language.

## Why This Change Was Made

Compact token suffixes now resolve through the native localization catalog, matching the existing localized duration path. The stable inventory entries are retained as resource calls, and a generator regression test prevents them from becoming unconsumed string literals again.

## User Impact

Turn recap token counts can use translated compact suffixes after the native locale refresh runs.

## Evidence

- Blacksmith Testbox `tbx_01ky23fzgtgbhxe4hsswc1bpag`: native inventory baseline reported 5,151 entries with `changed=false`.
- Same Testbox: `pnpm test:serial test/scripts/android-app-i18n.test.ts` passed 26 tests.
- Same Testbox: `:app:testPlayDebugUnitTest` and `:app:testThirdPartyDebugUnitTest` passed for `ChatTurnRecapResolverTest`.
- Same Testbox: `pnpm check:changed` passed.
- Full-branch autoreview: clean, no actionable findings, confidence 0.90.
- `git diff --check` passed.
