### PR TITLE
fix(ui): cancel stale selection popup creation

### DIFF
--- a/ui/src/pages/chat/components/chat-selection-popup.test.ts
+++ b/ui/src/pages/chat/components/chat-selection-popup.test.ts
@@ -104,6 +104,45 @@ describe("chat selection popup", () => {
     expect(document.body.querySelector(".chat-selection-popup")).toBeNull();
   });
 
+  it("does not restore the popup after its owner tears down", () => {
+    vi.useFakeTimers();
+    const { thread, textNode } = buildThreadWithBubble("tear down before the selection settles");
+    selectRange(textNode, 0, 9);
+    handleChatSelectionPointerUp({ currentTarget: thread } as unknown as PointerEvent, {
+      onMoreDetails: onMoreDetailsSpy,
+      onAskSideChat: onAskSideChatSpy,
+    });
+
+    removeChatSelectionPopup();
+    vi.runAllTimers();
+
+    expect(document.body.querySelector(".chat-selection-popup")).toBeNull();
+  });
+
+  it("keeps only the latest pending selection popup", () => {
+    vi.useFakeTimers();
+    const { thread, textNode } = buildThreadWithBubble("replacement selection");
+    const firstMoreDetails = vi.fn();
+    const secondMoreDetails = vi.fn();
+    selectRange(textNode, 0, 11);
+    const pendingTimerCount = vi.getTimerCount();
+    handleChatSelectionPointerUp({ currentTarget: thread } as unknown as PointerEvent, {
+      onMoreDetails: firstMoreDetails,
+      onAskSideChat: onAskSideChatSpy,
+    });
+    handleChatSelectionPointerUp({ currentTarget: thread } as unknown as PointerEvent, {
+      onMoreDetails: secondMoreDetails,
+      onAskSideChat: onAskSideChatSpy,
+    });
+
+    expect(vi.getTimerCount()).toBe(pendingTimerCount + 1);
+    vi.advanceTimersToNextTimer();
+    (document.body.querySelector(".chat-selection-popup button") as HTMLButtonElement).click();
+
+    expect(firstMoreDetails).not.toHaveBeenCalled();
+    expect(secondMoreDetails).toHaveBeenCalledWith("replacement");
+  });
+
   it("dismisses when the selection collapses", () => {
     vi.useFakeTimers();
     const { thread, textNode } = buildThreadWithBubble("dismiss me later");

--- a/ui/src/pages/chat/components/chat-selection-popup.ts
+++ b/ui/src/pages/chat/components/chat-selection-popup.ts
@@ -10,8 +10,15 @@ type ChatSelectionPopupActions = {
 
 let activeSelectionPopup: HTMLDivElement | null = null;
 let removeDismissListeners: (() => void) | null = null;
+let selectionPopupTimer: number | null = null;
 
 export function removeChatSelectionPopup() {
+  // The popup is a document singleton; teardown and replacement must cancel
+  // deferred selection work so an old pane cannot recreate it.
+  if (selectionPopupTimer !== null) {
+    window.clearTimeout(selectionPopupTimer);
+    selectionPopupTimer = null;
+  }
   activeSelectionPopup?.remove();
   activeSelectionPopup = null;
   removeDismissListeners?.();
@@ -154,7 +161,9 @@ export function handleChatSelectionPointerUp(
     return;
   }
   // Defer one tick so the browser finalizes the selection for this pointerup.
-  window.setTimeout(() => {
+  removeChatSelectionPopup();
+  selectionPopupTimer = window.setTimeout(() => {
+    selectionPopupTimer = null;
     const selection = window.getSelection();
     const text = selection ? selectionTextWithinChatBubble(selection, threadRoot) : null;
     if (!text || !selection) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the selected-text action toolbar could reappear after its owning chat pane was torn down. The toolbar opens on a deferred timer; pane teardown removed the visible singleton but did not cancel pending creation, allowing stale callbacks and document listeners to be recreated from detached chat content.

## Why This Change Was Made

The popup singleton now owns its pending timer as part of the same cleanup path as the visible toolbar and dismissal listeners. A new selection cancels prior pending work before scheduling the latest popup, so teardown and rapid replacement cannot resurrect stale UI.

## User Impact

Selected-text actions no longer survive chat navigation, pane teardown, or rapid replacement. The latest valid selection still opens the toolbar normally.

## Evidence

- Deterministic regression failed before the fix by recreating the body-portaled popup after teardown.
- `node scripts/run-vitest.mjs ui/src/pages/chat/components/chat-selection-popup.test.ts` — 6 passed.
- Blacksmith Testbox changed gate `tbx_01ky23bf1ry8qb8n5x360ye3dt` — passed formatting, Control UI i18n verification, UI/core-test typechecks, lint, and repository guards: https://github.com/openclaw/openclaw/actions/runs/29822179338
- `git diff --check` passed.
- Independent source-aware review found no actionable findings. The structured autoreview helper was attempted but its isolated Claude CLI was not logged in, so it exited before reviewing code.
- No screenshots are included because this fixes teardown ordering for a transient body portal rather than changing its rendered appearance.

AI-assisted change. I reviewed the singleton lifecycle, split-pane ownership, timer replacement, and regression coverage.
