### PR TITLE
fix(ui): close GitHub hovercards after route replacement

### DIFF
--- a/ui/src/components/github-link-hovercard.test.ts
+++ b/ui/src/components/github-link-hovercard.test.ts
@@ -185,6 +185,43 @@ describe("openclaw-github-link-hovercard-provider", () => {
     expect(request).not.toHaveBeenCalled();
   });
 
+  it("closes when route replacement removes its active link", async () => {
+    const provider = document.createElement(
+      GITHUB_LINK_HOVERCARD_ELEMENT_NAME,
+    ) as GitHubLinkHovercardProviderElement;
+    provider.client = {
+      request: vi.fn().mockResolvedValue({
+        closedAt: null,
+        comments: 1,
+        createdAt: "2026-07-05T08:00:00Z",
+        kind: "issue",
+        login: "octocat",
+        number: 99815,
+        owner: "openclaw",
+        repo: "openclaw",
+        state: "open",
+        stateReason: null,
+        title: "Keep hover previews compact",
+        updatedAt: "2026-07-05T09:55:00Z",
+      }),
+    } as unknown as GatewayBrowserClient;
+    const route = document.createElement("main");
+    const anchor = document.createElement("a");
+    anchor.href = "https://github.com/openclaw/openclaw/issues/99815";
+    route.append(anchor);
+    provider.append(route);
+    document.body.append(provider);
+
+    await hover(anchor);
+    expect(document.querySelector(".github-link-hovercard")).not.toBeNull();
+
+    route.replaceChildren(document.createElement("p"));
+    await Promise.resolve();
+
+    expect(document.querySelector(".github-link-hovercard")).toBeNull();
+    expect(anchor.hasAttribute("aria-describedby")).toBe(false);
+  });
+
   it("rerenders an open preview when the locale changes", async () => {
     const request = vi.fn().mockResolvedValue({
       closedAt: null,

--- a/ui/src/components/github-link-hovercard.ts
+++ b/ui/src/components/github-link-hovercard.ts
@@ -308,6 +308,14 @@ export class GitHubLinkHovercardProvider extends HTMLElement {
   private renderedUnavailable = false;
   private requestVersion = 0;
   private stopI18n: (() => void) | null = null;
+  private readonly activeAnchorObserver = new MutationObserver(() => {
+    const anchor = this.activeAnchor;
+    // The card is portaled outside the routed tree, whose replacement can remove
+    // a hovered link without a pointer event reaching this delegated handler.
+    if (anchor && !this.contains(anchor)) {
+      this.close();
+    }
+  });
 
   connectedCallback(): void {
     this.style.display = "contents";
@@ -416,6 +424,7 @@ export class GitHubLinkHovercardProvider extends HTMLElement {
     this.activeAnchor = anchor;
     this.activeTarget = target;
     this.describedBy = anchor.getAttribute("aria-describedby");
+    this.activeAnchorObserver.observe(this, { childList: true, subtree: true });
     this.openTimer = window.setTimeout(() => {
       this.openTimer = null;
       void this.show(anchor, target);
@@ -517,6 +526,7 @@ export class GitHubLinkHovercardProvider extends HTMLElement {
       window.clearTimeout(this.openTimer);
       this.openTimer = null;
     }
+    this.activeAnchorObserver.disconnect();
     this.requestVersion += 1;
     if (this.activeAnchor) {
       if (this.describedBy === null) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a GitHub issue or pull-request hovercard could remain attached to the document after programmatic route replacement removed its hovered link. Browser testing confirmed that removing a still-hovered anchor does not emit a delegated pointer-out event, while the provider remains mounted above the routed content and the card remains portaled to `document.body`.

## Why This Change Was Made

The hovercard provider now observes its own routed subtree only while an anchor is active. If route rendering removes that anchor, the existing canonical close path clears the portal, ARIA association, pending timer, viewport listeners, and in-flight request generation. The observer disconnects whenever the card closes.

## User Impact

GitHub previews no longer linger after navigating or replacing routed chat content. Normal hover, focus, caching, Escape, pointer-leave, and asynchronous preview behavior remain unchanged.

## Evidence

- Real Chromium probe confirmed that route replacement removed a hovered anchor without delivering pointer-out to the provider.
- Deterministic regression failed before the fix: the body-portaled card and `aria-describedby` association survived route replacement.
- `node scripts/run-vitest.mjs ui/src/components/github-link-hovercard.test.ts` — 10 passed.
- Blacksmith Testbox changed gate `tbx_01ky22dn1vs4ybmg1hz4ft0357` — passed UI/core-test typechecks, lint, formatting, Control UI i18n verification, and repository guards: https://github.com/openclaw/openclaw/actions/runs/29821131945
- `git diff --check` passed.
- Independent source-aware review found no actionable findings. The structured autoreview helper was attempted but its isolated Claude CLI was not logged in, so it exited before reviewing code.
- No screenshots are included because this fixes stale portal teardown during route replacement rather than changing the hovercard’s appearance.

AI-assisted change. I reviewed observer ownership, cleanup/reentrancy, route replacement, in-flight invalidation, and regression coverage.
