### PR TITLE
docs: sync heartbeat, memory, commitments, and system-prompt docs with current behavior

### DIFF
--- a/docs/cli/commitments.md
+++ b/docs/cli/commitments.md
@@ -27,6 +27,8 @@ openclaw commitments dismiss <id...> [--json]
 - `--agent <id>`: filter to one agent id.
 - `--status <status>`: filter by status. Values: `pending`, `sent`,
   `dismissed`, `snoozed`, or `expired`. Unknown values exit with an error.
+  The `snoozed` status is reserved: no built-in flow currently snoozes a
+  commitment; snoozed records can appear only when imported from legacy state.
 - `--json`: output machine-readable JSON.
 
 `dismiss` marks the given commitment ids as `dismissed`.
@@ -51,10 +53,10 @@ Filter to one agent:
 openclaw commitments --agent main
 ```
 
-Find snoozed commitments:
+Filter by status:
 
 ```bash
-openclaw commitments --status snoozed
+openclaw commitments --status dismissed
 ```
 
 Dismiss one or more commitments:

--- a/docs/concepts/memory.md
+++ b/docs/concepts/memory.md
@@ -40,10 +40,13 @@ observations, session summaries, and raw context that may still be useful
 later. These are indexed for `memory_search` and `memory_get`, but are not
 injected into the bootstrap prompt on every turn.
 
-Over time, the agent distills useful material from daily notes into
-`MEMORY.md` and removes stale long-term entries. Generated workspace
-instructions and the heartbeat flow do this periodically; you do not need to
-manually edit `MEMORY.md` for every detail.
+Over time, useful material from daily notes can be distilled into `MEMORY.md`
+and stale long-term entries removed — but this does not happen on its own in a
+default install. The generated workspace instructions encourage the agent to
+record durable facts as it works. You can make consolidation routine with a
+[scheduled job](/automation/cron-jobs) that reviews recent daily notes, or by
+enabling the optional [dreaming](/concepts/memory#dreaming) pass. The default
+heartbeat prompt performs no memory maintenance on its own.
 
 If `MEMORY.md` grows past the bootstrap file budget, OpenClaw keeps the file on
 disk intact but truncates the copy injected into context. Treat that as a

--- a/docs/concepts/system-prompt.md
+++ b/docs/concepts/system-prompt.md
@@ -32,6 +32,7 @@ The prompt is compact, with fixed sections:
 
 - **Tooling**: structured-tool source-of-truth reminder plus runtime tool-use guidance. When the experimental `update_plan` tool is enabled (`tools.experimental.planTool`), its own tool description adds: use it only for non-trivial multi-step work, keep at most one step `in_progress`, and skip it for simple one-step work.
 - **Execution Bias**: act in-turn on actionable requests, continue until done or blocked, recover from weak tool results, check mutable state live, and verify before finalizing.
+- **Promised Work**: promising future, background, delegated, or continued work creates follow-through ownership: arrange a push-based completion or watch path before ending the turn, proactively return with the result or a concrete blocker, and never treat progress (like `running`) as completion.
 - **Safety**: short guardrail reminder against power-seeking behavior or bypassing oversight.
 - **Skills** (when available): tells the model how to load skill instructions on demand.
 - **OpenClaw Control**: prefer the `gateway` tool for config/restart work; do not invent CLI commands.
@@ -58,6 +59,8 @@ Tooling also carries long-running-work guidance:
 - do not poll `subagents list` / `sessions_list` in a loop just to wait for completion
 
 `agents.defaults.subagents.delegationMode` (default `"suggest"`) can strengthen this. `"prefer"` adds a dedicated **Sub-Agent Delegation** section telling the main agent to act as a responsive coordinator and push anything more involved than a direct reply through `sessions_spawn`. This is prompt-only; tool policy still controls whether `sessions_spawn` is available.
+
+At the `ultra` thinking level, a **Proactive Sub-Agent Orchestration** section is also added when `sessions_spawn` is available: it tells the model to parallelize independent investigation, implementation, and verification through sub-agents, keep simple or tightly coupled work local, give each sub-agent a bounded objective, and synthesize results before replying.
 
 Safety guardrails in the system prompt are advisory, not enforcement. Use tool policy, exec approvals, sandboxing, and channel allowlists for hard enforcement; operators can disable prompt guardrails by design.
 

--- a/docs/gateway/heartbeat.md
+++ b/docs/gateway/heartbeat.md
@@ -82,8 +82,9 @@ quiet instead of rehashing stale conversation context.
 Proactive heartbeat behavior is opt-in:
 
 - **Recurring checks**: create [scheduled jobs](/automation/cron-jobs) for inbox
-  review, calendar sweeps, or queued follow-ups. Due jobs add their task context
-  to the heartbeat run; when nothing is due, no recurring task is inferred.
+  review, calendar sweeps, or queued follow-ups. Each job executes its configured
+  payload on its own schedule; the default heartbeat does not infer recurring
+  work from prior chats.
 - **Human check-in**: create a scheduled job if you want an occasional
   lightweight "anything you need?" message, and constrain its schedule to avoid
   night-time pings in your configured local timezone (see

--- a/docs/gateway/heartbeat.md
+++ b/docs/gateway/heartbeat.md
@@ -73,10 +73,21 @@ Example config:
 
 ## What the heartbeat prompt is for
 
-The default prompt is intentionally broad:
+The default prompt is intentionally narrow: follow the heartbeat monitor scratch
+context when provided, keep recurring work in cron jobs, and reply
+`HEARTBEAT_OK` when nothing needs attention. It explicitly tells the agent
+**not** to infer or repeat old tasks from prior chats, so a default install stays
+quiet instead of rehashing stale conversation context.
 
-- **Background tasks**: "Consider outstanding tasks" nudges the agent to review follow-ups (inbox, calendar, reminders, queued work) and surface anything urgent.
-- **Human check-in**: "Checkup sometimes on your human during day time" nudges an occasional lightweight "anything you need?" message, but avoids night-time spam by using your configured local timezone (see [Timezone](/concepts/timezone)).
+Proactive heartbeat behavior is opt-in:
+
+- **Recurring checks**: create [scheduled jobs](/automation/cron-jobs) for inbox
+  review, calendar sweeps, or queued follow-ups. Due jobs add their task context
+  to the heartbeat run; when nothing is due, no recurring task is inferred.
+- **Human check-in**: create a scheduled job if you want an occasional
+  lightweight "anything you need?" message, and constrain its schedule to avoid
+  night-time pings in your configured local timezone (see
+  [Timezone](/concepts/timezone)).
 
 Heartbeat can react to completed [background tasks](/automation/tasks), but a heartbeat run itself does not create a task record.
 


### PR DESCRIPTION
Closes #112294
Related: #88061

## What Problem This Solves

Resolves a problem where four docs pages describe proactivity behavior that no longer exists or was never implemented: the heartbeat doc explains a removed "intentionally broad" default prompt (contradicting the correct prompt quoted on the same page), the memory doc promises automatic periodic distillation into `MEMORY.md` that never runs on a default install, the commitments docs tell readers to find `snoozed` commitments when nothing can create one, and the system-prompt doc omits two sections that render at runtime (Promised Work, Proactive Sub-Agent Orchestration).

## Why This Change Was Made

These pages are the primary interface for humans and AI agents configuring OpenClaw proactivity; drift here directly produces wrong configuration and wrong recommendations. Same class of drift as the audit tracked in #88061, in doc areas that audit did not cover. Docs only — no source/runtime changes.

## User Impact

Readers now get an accurate model of shipped behavior: the default heartbeat is narrow and proactive behavior is opt-in via `HEARTBEAT.md`; memory consolidation is opt-in (a `HEARTBEAT.md` task, a scheduled job, or the optional dreaming pass); `snoozed` is marked reserved (nothing writes it today; legacy import only) and the misleading "Find snoozed commitments" example is replaced with one that can return results; the Promised Work and Proactive Sub-Agent Orchestration prompt sections are documented in their actual assembly positions.

## Evidence

- Default heartbeat prompt is narrow, not broad: `src/auto-reply/heartbeat.ts:14-19` ("Follow it strictly. Do not infer or repeat old tasks from prior chats."); the page's own **Defaults** section already quoted this correct prompt while "What the heartbeat prompt is for" explained the removed one.
- No snooze writer exists: the only status mutation accepts `"sent" | "dismissed" | "expired"` (`src/commitments/store.ts:402-406`); CLI registers `list`/`dismiss` only (`src/cli/program/register.status-health-sessions.ts:495-536`); snoozed records can appear only via legacy import (`src/infra/state-migrations.commitments.ts:282-285`).
- No default distillation: shipped `HEARTBEAT.md` template is comments-only and skipped without a model call (`src/agents/templates/HEARTBEAT.md`, empty-heartbeat-file skip in `src/infra/heartbeat-runner.ts`); dreaming defaults off (`DEFAULT_MEMORY_DREAMING_ENABLED = false`, `src/memory-host-sdk/dreaming.ts`).
- Omitted prompt sections render at runtime: Promised Work unconditionally (`src/agents/system-prompt.ts:1167` via `src/agents/promised-work-prompt.ts`); Proactive Sub-Agent Orchestration at `thinkLevel === "ultra"` with `sessions_spawn` (`src/agents/system-prompt.ts:126-140`, `src/agents/embedded-agent-runner/run/attempt-setup.ts:52-58`).
- Every claim was independently re-verified by a second automated review pass against `0f8a87ad6f1` before submission; the repo docs formatter passed on all five changed files. Internal links follow the Mintlify root-relative rules; no generated docs touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
