### PR TITLE
fix(ui): render identity in mock profile settings

### DIFF
--- a/scripts/control-ui-mock-dev.ts
+++ b/scripts/control-ui-mock-dev.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import qrcode from "qrcode";
 import { createServer, type Plugin, type ViteDevServer } from "vite";
+import type { UserProfile } from "../packages/gateway-protocol/src/index.js";
 import { expectDefined } from "../packages/normalization-core/src/expect.js";
 import { CONTROL_UI_BOOTSTRAP_CONFIG_PATH } from "../src/gateway/control-ui-contract.js";
 import {
@@ -779,6 +780,16 @@ function searchPrefixes(term: string): string[] {
 
 async function createChatPickerScenario(): Promise<ControlUiMockGatewayScenario> {
   const baseTime = Date.parse("2026-05-22T09:00:00.000Z");
+  const selfProfile: UserProfile = {
+    id: "presence-riley",
+    displayName: "Riley",
+    avatarMime: null,
+    mergedInto: null,
+    createdAt: baseTime,
+    updatedAt: baseTime,
+    emails: ["riley@example.com"],
+    hasAvatar: false,
+  };
   const devicePairSetupCode = Buffer.from(
     JSON.stringify({
       url: "wss://gateway.example.test",
@@ -1140,12 +1151,18 @@ async function createChatPickerScenario(): Promise<ControlUiMockGatewayScenario>
     // Lights up the footer facepile and who's-online roster; the email-only
     // entry keeps the roster's no-display-name row exercised.
     presenceUsers: [
-      { self: true, id: "presence-riley", name: "Riley", email: "riley@example.com" },
+      {
+        self: true,
+        id: selfProfile.id,
+        name: selfProfile.displayName ?? undefined,
+        email: selfProfile.emails[0],
+      },
       { id: "presence-colin", name: "Colin", email: "colin@example.com" },
       { id: "presence-patricia", email: "patricia.erichsen@example.com" },
     ],
     methodResponses: {
       ...buildBackgroundTasksMock(baseTime),
+      "users.self": { profile: selfProfile },
       "system.info": {
         machineName: "Peters-Mac-Studio",
         hostname: "peters-mac-studio.local",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where developers opening Settings > Profile through `pnpm dev:ui:mock` would see an unset or errored Identity section because the standalone mock gateway did not return the authenticated user's profile.

## Why This Change Was Made

The mock scenario now defines one schema-typed self profile and reuses it for both presence and the `users.self` response. This keeps the mock identity internally consistent and makes future gateway profile-schema additions fail typechecking instead of degrading the page at runtime.

## User Impact

Developers can use the mock Control UI profile page as intended: the Identity card renders the avatar fallback, editable display name, and linked email without a live gateway. Production gateway behavior is unchanged.

## Evidence

- Reproduced on the port-5187 mock harness: the pre-fix `users.self` fallback was `{}`, leaving the Identity section unset (older profile-page code surfaced the reported `displayName` TypeError).
- Playwright against `http://127.0.0.1:5187/settings/profile`, including a JavaScript click on `.profile-refresh`: the Identity editor rendered `Riley` and `riley@example.com`, with no visible alerts or page exceptions; reload and a second forced refresh produced the same result.
- Hosted Blacksmith Testbox: `pnpm test:ui:e2e -- ui/src/e2e/profile-page.e2e.test.ts` — 5/5 passed. Run: https://github.com/openclaw/openclaw/actions/runs/29830819561
- Hosted Blacksmith Testbox: `pnpm check:changed` — passed formatting, script declarations, script typecheck, dependency guards, boundary checks, and lint.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output` — clean; no accepted/actionable findings.

AI-assisted implementation and validation; the maintainer reviewed the resulting diff and proof.
