### PR TITLE
fix(ios): smooth sidebar drags and remove background seams

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -20163,7 +20163,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 452,
+      "line": 457,
       "path": "apps/ios/Sources/Design/OpenClawProComponents.swift",
       "source": "Request ID: %@",
       "surface": "apple",
@@ -20171,7 +20171,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 642,
+      "line": 647,
       "path": "apps/ios/Sources/Design/OpenClawProComponents.swift",
       "source": "OpenClaw",
       "surface": "apple",
@@ -20179,7 +20179,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 672,
+      "line": 677,
       "path": "apps/ios/Sources/Design/OpenClawProComponents.swift",
       "source": "Gateway %@",
       "surface": "apple",
@@ -20187,7 +20187,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 679,
+      "line": 684,
       "path": "apps/ios/Sources/Design/OpenClawProComponents.swift",
       "source": "Online",
       "surface": "apple",
@@ -20195,7 +20195,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 681,
+      "line": 686,
       "path": "apps/ios/Sources/Design/OpenClawProComponents.swift",
       "source": "Connecting",
       "surface": "apple",
@@ -20203,7 +20203,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 683,
+      "line": 688,
       "path": "apps/ios/Sources/Design/OpenClawProComponents.swift",
       "source": "Attention",
       "surface": "apple",
@@ -20211,7 +20211,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 685,
+      "line": 690,
       "path": "apps/ios/Sources/Design/OpenClawProComponents.swift",
       "source": "Offline",
       "surface": "apple",
@@ -25755,7 +25755,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 77,
+      "line": 76,
       "path": "apps/ios/Sources/RootSidebar.swift",
       "source": "OpenClaw",
       "surface": "apple",
@@ -25763,7 +25763,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 102,
+      "line": 101,
       "path": "apps/ios/Sources/RootSidebar.swift",
       "source": "Settings",
       "surface": "apple",
@@ -25771,7 +25771,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 116,
+      "line": 122,
       "path": "apps/ios/Sources/RootSidebar.swift",
       "source": "Hide Sidebar",
       "surface": "apple",
@@ -25779,7 +25779,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 207,
+      "line": 209,
       "path": "apps/ios/Sources/RootSidebar.swift",
       "source": "Selected",
       "surface": "apple",
@@ -25787,7 +25787,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 231,
+      "line": 233,
       "path": "apps/ios/Sources/RootSidebar.swift",
       "source": "More Agents",
       "surface": "apple",
@@ -25795,7 +25795,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 334,
+      "line": 336,
       "path": "apps/ios/Sources/RootSidebar.swift",
       "source": "Search sessions",
       "surface": "apple",
@@ -25803,7 +25803,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 345,
+      "line": 347,
       "path": "apps/ios/Sources/RootSidebar.swift",
       "source": "Clear session search",
       "surface": "apple",
@@ -25811,7 +25811,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 373,
+      "line": 375,
       "path": "apps/ios/Sources/RootSidebar.swift",
       "source": "Loading sessions",
       "surface": "apple",
@@ -25819,7 +25819,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 381,
+      "line": 383,
       "path": "apps/ios/Sources/RootSidebar.swift",
       "source": "No recent sessions",
       "surface": "apple",
@@ -25827,7 +25827,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 391,
+      "line": 393,
       "path": "apps/ios/Sources/RootSidebar.swift",
       "source": "Recent",
       "surface": "apple",
@@ -25835,7 +25835,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 407,
+      "line": 409,
       "path": "apps/ios/Sources/RootSidebar.swift",
       "source": "All Sessions…",
       "surface": "apple",
@@ -25843,7 +25843,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 437,
+      "line": 439,
       "path": "apps/ios/Sources/RootSidebar.swift",
       "source": "Edit Pages",
       "surface": "apple",
@@ -25851,7 +25851,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 461,
+      "line": 463,
       "path": "apps/ios/Sources/RootSidebar.swift",
       "source": "Home",
       "surface": "apple",
@@ -25859,7 +25859,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 670,
+      "line": 672,
       "path": "apps/ios/Sources/RootSidebar.swift",
       "source": "Unread",
       "surface": "apple",
@@ -25867,7 +25867,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 696,
+      "line": 698,
       "path": "apps/ios/Sources/RootSidebar.swift",
       "source": "Attention",
       "surface": "apple",
@@ -25875,7 +25875,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 736,
+      "line": 738,
       "path": "apps/ios/Sources/RootSidebar.swift",
       "source": "New Chat",
       "surface": "apple",
@@ -25883,7 +25883,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 765,
+      "line": 767,
       "path": "apps/ios/Sources/RootSidebar.swift",
       "source": "Connection",
       "surface": "apple",
@@ -25891,7 +25891,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 770,
+      "line": 772,
       "path": "apps/ios/Sources/RootSidebar.swift",
       "source": "Online",
       "surface": "apple",
@@ -25899,7 +25899,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 771,
+      "line": 773,
       "path": "apps/ios/Sources/RootSidebar.swift",
       "source": "Connecting",
       "surface": "apple",
@@ -25907,7 +25907,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 772,
+      "line": 774,
       "path": "apps/ios/Sources/RootSidebar.swift",
       "source": "Needs attention",
       "surface": "apple",
@@ -25915,7 +25915,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 773,
+      "line": 775,
       "path": "apps/ios/Sources/RootSidebar.swift",
       "source": "Offline",
       "surface": "apple",
@@ -25923,7 +25923,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 872,
+      "line": 874,
       "path": "apps/ios/Sources/RootSidebar.swift",
       "source": "Pinned pages stay in the sidebar. Home is always shown.",
       "surface": "apple",
@@ -25931,7 +25931,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 876,
+      "line": 878,
       "path": "apps/ios/Sources/RootSidebar.swift",
       "source": "Pages",
       "surface": "apple",
@@ -25939,7 +25939,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 883,
+      "line": 885,
       "path": "apps/ios/Sources/RootSidebar.swift",
       "source": "Done",
       "surface": "apple",
@@ -25947,7 +25947,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 922,
+      "line": 924,
       "path": "apps/ios/Sources/RootSidebar.swift",
       "source": "Pinned",
       "surface": "apple",
@@ -25955,7 +25955,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 923,
+      "line": 925,
       "path": "apps/ios/Sources/RootSidebar.swift",
       "source": "Not pinned",
       "surface": "apple",
@@ -25963,7 +25963,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 359,
+      "line": 251,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Overview",
       "surface": "apple",
@@ -25971,7 +25971,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 387,
+      "line": 279,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Agents",
       "surface": "apple",
@@ -25979,7 +25979,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 394,
+      "line": 286,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Instances",
       "surface": "apple",
@@ -25987,7 +25987,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 405,
+      "line": 297,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Files",
       "surface": "apple",
@@ -25995,7 +25995,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 412,
+      "line": 304,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Dreaming",
       "surface": "apple",
@@ -26003,7 +26003,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 419,
+      "line": 311,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Usage",
       "surface": "apple",
@@ -26011,7 +26011,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 426,
+      "line": 318,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Automations",
       "surface": "apple",
@@ -26019,7 +26019,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 517,
+      "line": 408,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Hide Sidebar",
       "surface": "apple",
@@ -26027,7 +26027,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 523,
+      "line": 414,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Show Sidebar",
       "surface": "apple",
@@ -26035,7 +26035,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 717,
+      "line": 541,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Close canvas",
       "surface": "apple",
@@ -26043,7 +26043,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 980,
+      "line": 804,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Gateway needs attention",
       "surface": "apple",
@@ -26051,7 +26051,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 980,
+      "line": 804,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "OpenClaw iOS",
       "surface": "apple",
@@ -26059,7 +26059,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1016,
+      "line": 840,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Available",
       "surface": "apple",
@@ -26067,7 +26067,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1016,
+      "line": 840,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Gateway default",
       "surface": "apple",
@@ -26075,7 +26075,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1016,
+      "line": 840,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Routed on this phone",
       "surface": "apple",

--- a/apps/ios/Sources/Design/OpenClawProComponents.swift
+++ b/apps/ios/Sources/Design/OpenClawProComponents.swift
@@ -5,7 +5,6 @@ enum OpenClawProMetric {
     static let pagePadding: CGFloat = 16
     static let cardRadius: CGFloat = 16
     static let controlRadius: CGFloat = 12
-    static let drawerRadius: CGFloat = 28
     static let compactControlSize: CGFloat = 36
     static let bottomScrollInset: CGFloat = 96
 }
@@ -277,7 +276,7 @@ struct OpenClawSidebarHeaderAction {
     }
 }
 
-struct OpenClawSidebarRevealButton: View {
+struct OpenClawSidebarControlButton: View {
     let headerAction: OpenClawSidebarHeaderAction
 
     init(action: OpenClawSidebarHeaderAction) {
@@ -285,31 +284,38 @@ struct OpenClawSidebarRevealButton: View {
     }
 
     var body: some View {
-        let button = Button(action: headerAction.action) {
-            Image(systemName: self.headerAction.systemName)
-                .font(OpenClawType.subheadSemiBold)
-                .frame(
-                    width: OpenClawProMetric.compactControlSize,
-                    height: OpenClawProMetric.compactControlSize)
-                .contentShape(Rectangle())
+        if #available(iOS 26.0, *) {
+            self.identified(self.button.buttonStyle(.plain))
+        } else {
+            self.identified(self.button.openClawGlassButton(tint: OpenClawBrand.accent))
+        }
+    }
+
+    private var button: some View {
+        Button(action: self.headerAction.action) {
+            self.icon
         }
         .buttonBorderShape(.circle)
+        .frame(width: 44, height: 44)
+        .contentShape(Rectangle())
         .accessibilityLabel(self.headerAction.accessibilityLabel.text)
+    }
 
+    @ViewBuilder
+    private var icon: some View {
+        let icon = Image(systemName: self.headerAction.systemName)
+            .font(OpenClawType.subheadSemiBold)
+            .frame(
+                width: OpenClawProMetric.compactControlSize,
+                height: OpenClawProMetric.compactControlSize)
         if #available(iOS 26.0, *) {
-            self.identified(
-                button
-                    .buttonStyle(.plain)
-                    .foregroundStyle(OpenClawBrand.accent)
-                    .frame(width: 44, height: 44)
-                    .glassEffect(
-                        .regular.interactive(),
-                        in: Circle()))
+            icon
+                .foregroundStyle(OpenClawBrand.accent)
+                .glassEffect(
+                    .regular.interactive(),
+                    in: Circle())
         } else {
-            self.identified(
-                button
-                    .frame(width: 44, height: 44)
-                    .openClawGlassButton(tint: OpenClawBrand.accent))
+            icon
         }
     }
 
@@ -327,8 +333,7 @@ struct OpenClawSidebarHeaderLeadingSlot: View {
     let action: OpenClawSidebarHeaderAction
 
     var body: some View {
-        OpenClawSidebarRevealButton(action: self.action)
-            .frame(width: 44, height: 44, alignment: .center)
+        OpenClawSidebarControlButton(action: self.action)
     }
 }
 
@@ -340,14 +345,14 @@ struct OpenClawSidebarToolbarItem: ToolbarContent {
     var body: some ToolbarContent {
         if #available(iOS 26.0, *) {
             ToolbarItem(placement: self.placement) {
-                OpenClawSidebarRevealButton(action: self.action)
+                OpenClawSidebarControlButton(action: self.action)
             }
             // The button owns an explicit circular glass shape; suppress the
             // toolbar's shared pill so it cannot stretch the leading control.
             .sharedBackgroundVisibility(.hidden)
         } else {
             ToolbarItem(placement: self.placement) {
-                OpenClawSidebarRevealButton(action: self.action)
+                OpenClawSidebarControlButton(action: self.action)
             }
         }
     }

--- a/apps/ios/Sources/RootSidebar.swift
+++ b/apps/ios/Sources/RootSidebar.swift
@@ -16,9 +16,8 @@ struct RootSidebar: View {
 
     let selectedDestination: RootTabs.SidebarDestination
     let isDrawerLayout: Bool
-    let showsDismissButton: Bool
+    let isDismissButtonEnabled: Bool
     let selectDestination: (RootTabs.SidebarDestination) -> Void
-    let selectSettingsRoute: (SettingsRoute) -> Void
     let hideSidebar: () -> Void
 
     var body: some View {
@@ -104,17 +103,10 @@ struct RootSidebar: View {
                 self.selectSidebarDestination(.settings)
             }
 
-            if self.isDrawerLayout, self.showsDismissButton {
-                Button(action: self.dismissSidebar) {
-                    Image(systemName: "xmark")
-                        .font(OpenClawType.subheadSemiBold)
-                        .frame(width: 40, height: 44)
-                        .contentShape(Rectangle())
-                }
-                .buttonStyle(.plain)
-                .foregroundStyle(OpenClawSidebarPalette.accent)
-                .accessibilityLabel(String(localized: "Hide Sidebar"))
-                .accessibilityIdentifier(RootTabs.sidebarHideButtonAccessibilityIdentifier)
+            if self.isDrawerLayout {
+                OpenClawSidebarControlButton(action: self.dismissAction)
+                    .allowsHitTesting(self.isDismissButtonEnabled)
+                    .accessibilityHidden(!self.isDismissButtonEnabled)
             }
         }
         .padding(.leading, 8)
@@ -122,6 +114,16 @@ struct RootSidebar: View {
         .padding(.vertical, 8)
         .background(OpenClawSidebarPalette.background)
         .overlay(alignment: .bottom) { self.separator }
+    }
+
+    private var dismissAction: OpenClawSidebarHeaderAction {
+        OpenClawSidebarHeaderAction(
+            systemName: "xmark",
+            accessibilityLabel: .localized("Hide Sidebar"),
+            accessibilityIdentifier: self.isDismissButtonEnabled
+                ? RootTabs.sidebarHideButtonAccessibilityIdentifier
+                : nil,
+            action: self.dismissSidebar)
     }
 
     /// Prototype-style agent roster: up to `visibleAgentCount` rows inline

--- a/apps/ios/Sources/RootSidebarDrawer.swift
+++ b/apps/ios/Sources/RootSidebarDrawer.swift
@@ -1,0 +1,201 @@
+import SwiftUI
+
+private enum RootSidebarDrawerMetric {
+    static let edgeGestureWidth: CGFloat = 44
+    static let topGestureExclusion: CGFloat = 44
+    static let settleTranslation: CGFloat = 80
+    static let settlePredictedTranslation: CGFloat = 160
+    static let topLeadingRadius: CGFloat = 8
+    static let cornerRadius: CGFloat = 28
+}
+
+struct RootSidebarDrawer<Sidebar: View, Detail: View>: View {
+    private enum DragDisposition: Equatable {
+        case opening
+        case closing
+        case rejected
+    }
+
+    private struct DragState: Equatable {
+        var disposition: DragDisposition?
+        var translationWidth: CGFloat = 0
+    }
+
+    let sidebarWidth: CGFloat
+    let isPresented: Bool
+    let canOpenFromEdge: Bool
+    let reduceMotion: Bool
+    let animation: Animation?
+    let onShow: () -> Void
+    let onHide: () -> Void
+    let sidebar: Sidebar
+    let detail: Detail
+
+    @GestureState(resetTransaction: Transaction(animation: .spring(response: 0.35, dampingFraction: 0.86)))
+    private var dragState = DragState()
+
+    var body: some View {
+        ZStack(alignment: .leading) {
+            self.sidebarLayer
+                .opacity(self.reduceMotion && !self.isPresented ? 0 : 1)
+                .accessibilityHidden(!self.isPresented)
+
+            self.contentCard
+                .opacity(self.reduceMotion && self.isPresented ? 0 : 1)
+                .accessibilityHidden(self.isPresented)
+                .zIndex(1)
+
+            self.dismissalLayer
+                .zIndex(2)
+        }
+        // Gesture state stays inside this stable shell. The destination tree does
+        // not own per-frame drag state, and the moving card never owns its recognizer.
+        .simultaneousGesture(
+            self.drawerGesture,
+            // Keep the recognizer attached while pushed content owns the edge.
+            // It rejects that touch once, so the same back-swipe cannot open the drawer after popping.
+            isEnabled: !self.reduceMotion)
+        .animation(self.animation, value: self.isPresented)
+    }
+
+    private var sidebarLayer: some View {
+        self.sidebar
+            .frame(width: self.sidebarWidth, alignment: .topLeading)
+            .frame(maxHeight: .infinity, alignment: .topLeading)
+            .background(OpenClawSidebarPalette.background)
+            .ignoresSafeArea(.container, edges: .vertical)
+    }
+
+    private var contentCard: some View {
+        let offset = self.contentOffset
+        let progress = self.sidebarWidth > 0 ? offset / self.sidebarWidth : 0
+        let shape = Self.contentShape(progress: progress)
+        return self.detail
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+            // RootTabs always supplies its shared NavigationStack here. Expanding
+            // that stack paints destination backgrounds through the rounded safe
+            // areas while navigation chrome keeps destination content inset.
+            .background(OpenClawProBackground())
+            .ignoresSafeArea(.container, edges: .vertical)
+            .allowsHitTesting(!self.isPresented)
+            .clipShape(shape)
+            .overlay {
+                shape.strokeBorder(
+                    OpenClawSidebarPalette.hairline.opacity(Double(progress)),
+                    lineWidth: 1)
+            }
+            .offset(x: offset)
+    }
+
+    @ViewBuilder
+    private var dismissalLayer: some View {
+        if self.isPresented {
+            HStack(spacing: 0) {
+                Color.clear
+                    .frame(width: self.sidebarWidth)
+                    .allowsHitTesting(false)
+                Color.clear
+                    .contentShape(Rectangle())
+                    .accessibilityHidden(true)
+                    .onTapGesture(perform: self.onHide)
+            }
+        }
+    }
+
+    private var contentOffset: CGFloat {
+        RootTabs.sidebarContentOffset(
+            sidebarWidth: self.sidebarWidth,
+            isVisible: self.isPresented,
+            dragOffset: self.dragState.translationWidth,
+            reduceMotion: self.reduceMotion)
+    }
+
+    private var drawerGesture: some Gesture {
+        let sidebarWidth = self.sidebarWidth
+        let isPresented = self.isPresented
+        let canOpenFromEdge = self.canOpenFromEdge
+        let onShow = self.onShow
+        let onHide = self.onHide
+        return DragGesture(minimumDistance: 8)
+            .updating(self.$dragState) { value, state, _ in
+                let disposition = state.disposition ?? Self.dragDisposition(
+                    for: value,
+                    isPresented: isPresented,
+                    canOpenFromEdge: canOpenFromEdge)
+                state.disposition = disposition
+                switch disposition {
+                case .opening:
+                    state.translationWidth = max(0, min(sidebarWidth, value.translation.width))
+                case .closing:
+                    state.translationWidth = max(-sidebarWidth, min(0, value.translation.width))
+                case .rejected:
+                    break
+                }
+            }
+            .onEnded { value in
+                let disposition = Self.dragDisposition(
+                    for: value,
+                    isPresented: isPresented,
+                    canOpenFromEdge: canOpenFromEdge)
+                switch disposition {
+                case .opening:
+                    if Self.shouldSettle(
+                        translation: value.translation.width,
+                        predictedTranslation: value.predictedEndTranslation.width)
+                    {
+                        onShow()
+                    }
+                case .closing:
+                    if Self.shouldSettle(
+                        translation: -value.translation.width,
+                        predictedTranslation: -value.predictedEndTranslation.width)
+                    {
+                        onHide()
+                    }
+                case .rejected:
+                    break
+                }
+            }
+    }
+
+    private static func dragDisposition(
+        for value: DragGesture.Value,
+        isPresented: Bool,
+        canOpenFromEdge: Bool) -> DragDisposition
+    {
+        if isPresented {
+            return self.isClosingDrag(value) ? .closing : .rejected
+        }
+        guard canOpenFromEdge else { return .rejected }
+        return self.isOpeningDrag(value) ? .opening : .rejected
+    }
+
+    private static func shouldSettle(
+        translation: CGFloat,
+        predictedTranslation: CGFloat) -> Bool
+    {
+        translation > RootSidebarDrawerMetric.settleTranslation ||
+            predictedTranslation > RootSidebarDrawerMetric.settlePredictedTranslation
+    }
+
+    private static func isOpeningDrag(_ value: DragGesture.Value) -> Bool {
+        value.startLocation.x <= RootSidebarDrawerMetric.edgeGestureWidth &&
+            value.startLocation.y > RootSidebarDrawerMetric.topGestureExclusion &&
+            value.translation.width > 0 &&
+            value.translation.width > abs(value.translation.height)
+    }
+
+    private static func isClosingDrag(_ value: DragGesture.Value) -> Bool {
+        value.translation.width < 0 &&
+            -value.translation.width > abs(value.translation.height)
+    }
+
+    private static func contentShape(progress: CGFloat) -> UnevenRoundedRectangle {
+        UnevenRoundedRectangle(
+            topLeadingRadius: RootSidebarDrawerMetric.topLeadingRadius * progress,
+            bottomLeadingRadius: RootSidebarDrawerMetric.cornerRadius * progress,
+            bottomTrailingRadius: RootSidebarDrawerMetric.cornerRadius * progress,
+            topTrailingRadius: RootSidebarDrawerMetric.cornerRadius * progress,
+            style: .continuous)
+    }
+}

--- a/apps/ios/Sources/RootSidebarDrawer.swift
+++ b/apps/ios/Sources/RootSidebarDrawer.swift
@@ -21,6 +21,10 @@ struct RootSidebarDrawer<Sidebar: View, Detail: View>: View {
         var translationWidth: CGFloat = 0
     }
 
+    private final class DragSession {
+        var disposition: DragDisposition?
+    }
+
     let sidebarWidth: CGFloat
     let isPresented: Bool
     let canOpenFromEdge: Bool
@@ -31,6 +35,7 @@ struct RootSidebarDrawer<Sidebar: View, Detail: View>: View {
     let sidebar: Sidebar
     let detail: Detail
 
+    @State private var dragSession = DragSession()
     @GestureState(resetTransaction: Transaction(animation: .spring(response: 0.35, dampingFraction: 0.86)))
     private var dragState = DragState()
 
@@ -116,13 +121,20 @@ struct RootSidebarDrawer<Sidebar: View, Detail: View>: View {
         let canOpenFromEdge = self.canOpenFromEdge
         let onShow = self.onShow
         let onHide = self.onHide
+        let dragSession = self.dragSession
         return DragGesture(minimumDistance: 8)
             .updating(self.$dragState) { value, state, _ in
-                let disposition = state.disposition ?? Self.dragDisposition(
-                    for: value,
-                    isPresented: isPresented,
-                    canOpenFromEdge: canOpenFromEdge)
-                state.disposition = disposition
+                let disposition: DragDisposition
+                if let latchedDisposition = state.disposition {
+                    disposition = latchedDisposition
+                } else {
+                    disposition = Self.dragDisposition(
+                        for: value,
+                        isPresented: isPresented,
+                        canOpenFromEdge: canOpenFromEdge)
+                    state.disposition = disposition
+                    dragSession.disposition = disposition
+                }
                 switch disposition {
                 case .opening:
                     state.translationWidth = max(0, min(sidebarWidth, value.translation.width))
@@ -133,10 +145,8 @@ struct RootSidebarDrawer<Sidebar: View, Detail: View>: View {
                 }
             }
             .onEnded { value in
-                let disposition = Self.dragDisposition(
-                    for: value,
-                    isPresented: isPresented,
-                    canOpenFromEdge: canOpenFromEdge)
+                let disposition = dragSession.disposition
+                dragSession.disposition = nil
                 switch disposition {
                 case .opening:
                     if Self.shouldSettle(
@@ -152,7 +162,7 @@ struct RootSidebarDrawer<Sidebar: View, Detail: View>: View {
                     {
                         onHide()
                     }
-                case .rejected:
+                case .rejected, nil:
                     break
                 }
             }

--- a/apps/ios/Sources/RootTabs.swift
+++ b/apps/ios/Sources/RootTabs.swift
@@ -4,19 +4,6 @@ import SwiftUI
 import UIKit
 
 struct RootTabs: View {
-    private enum SidebarEdgeDragDisposition: Equatable {
-        case horizontal
-        case rejected
-    }
-
-    private struct SidebarEdgeDragState: Equatable {
-        var disposition: SidebarEdgeDragDisposition?
-        var translationWidth: CGFloat = 0
-    }
-
-    private static let sidebarEdgeGestureWidth: CGFloat = 44
-    private static let sidebarDrawerTopLeadingRadius: CGFloat = 8
-
     @Environment(NodeAppModel.self) private var appModel
     @Environment(VoiceWakeManager.self) private var voiceWake
     @Environment(GatewayConnectionController.self) private var gatewayController
@@ -45,9 +32,6 @@ struct RootTabs: View {
     @State private var sidebarVisibilityUserOverridden: Bool = Self.initialSidebarVisibility != nil
     @State private var isSidebarDrawerLayout: Bool = false
     @State private var didResolveSidebarLayout: Bool = false
-    @State private var sidebarContentDragOffset: CGFloat = 0
-    @GestureState(resetTransaction: Transaction(animation: .spring(response: 0.35, dampingFraction: 0.86)))
-    private var sidebarEdgeDragState = SidebarEdgeDragState()
     @State private var voiceWakeToastText: String?
     @State private var toastDismissTask: Task<Void, Never>?
     @State private var presentedSheet: PresentedSheet?
@@ -145,7 +129,6 @@ struct RootTabs: View {
                     self.sidebarNavigationSplitContent(sidebarWidth: sidebarWidth)
                 }
             }
-            .animation(self.sidebarAnimation, value: self.isSidebarVisible)
             .onAppear {
                 self.updateSidebarLayout(containerSize: proxy.size, force: false)
             }
@@ -190,113 +173,23 @@ struct RootTabs: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         }
         .background(OpenClawProBackground())
+        .animation(self.sidebarAnimation, value: self.isSidebarVisible)
     }
 
     private func sidebarDrawerContent(
         sidebarWidth: CGFloat,
         safeAreaInsets: EdgeInsets) -> some View
     {
-        ZStack(alignment: .leading) {
-            // Occluded layers stay out of the accessibility tree: closed = content
-            // only, open = sidebar only (the card is not interactive while open).
-            self.sidebarDrawerLayer(sidebarWidth: sidebarWidth, safeAreaInsets: safeAreaInsets)
-                .opacity(self.reduceMotion && !self.isSidebarVisible ? 0 : 1)
-                .accessibilityHidden(!self.isSidebarVisible)
-
-            // Keep the full-height surface outside NavigationStack so it can
-            // cover the sidebar in safe areas without changing content insets.
-            self.sidebarDrawerContentSurface(sidebarWidth: sidebarWidth)
-                .opacity(self.reduceMotion && self.isSidebarVisible ? 0 : 1)
-                .accessibilityHidden(true)
-
-            self.sidebarDrawerContentCard(sidebarWidth: sidebarWidth)
-                .opacity(self.reduceMotion && self.isSidebarVisible ? 0 : 1)
-                .accessibilityHidden(self.isSidebarVisible)
-                .zIndex(1)
-
-            // Gesture ownership must stay on an unmoving shell. Attaching either
-            // drag to the offset card makes a slow finger outrun its own recognizer.
-            self.sidebarDrawerInteractionLayer(sidebarWidth: sidebarWidth)
-                .zIndex(2)
-        }
-        .simultaneousGesture(
-            self.sidebarEdgeOpenGesture(sidebarWidth: sidebarWidth),
-            isEnabled: !self.isSidebarVisible &&
-                !self.reduceMotion &&
-                self.isSidebarDetailRootVisible &&
-                self.sidebarNavigationPath.isEmpty)
-    }
-
-    private func sidebarDrawerLayer(
-        sidebarWidth: CGFloat,
-        safeAreaInsets: EdgeInsets) -> some View
-    {
-        self.sidebarColumn(drawerSafeAreaInsets: safeAreaInsets)
-            .frame(width: sidebarWidth, alignment: .topLeading)
-            .frame(maxHeight: .infinity, alignment: .topLeading)
-            .background(OpenClawSidebarPalette.background)
-            .ignoresSafeArea(.container, edges: .vertical)
-    }
-
-    private func sidebarDrawerContentSurface(sidebarWidth: CGFloat) -> some View {
-        let progress = self.sidebarContentRevealProgress(sidebarWidth: sidebarWidth)
-        let shape = self.sidebarDrawerContentShape(progress: progress)
-        return shape
-            .fill(Color(uiColor: .systemGroupedBackground))
-            .overlay(
-                shape.strokeBorder(
-                    OpenClawSidebarPalette.hairline.opacity(Double(progress)),
-                    lineWidth: 1))
-            .ignoresSafeArea(.container, edges: .vertical)
-            .offset(x: Self.sidebarContentOffset(
-                sidebarWidth: sidebarWidth,
-                isVisible: self.isSidebarVisible,
-                dragOffset: self.sidebarResolvedDragOffset,
-                reduceMotion: self.reduceMotion))
-    }
-
-    private func sidebarDrawerContentCard(sidebarWidth: CGFloat) -> some View {
-        let progress = self.sidebarContentRevealProgress(sidebarWidth: sidebarWidth)
-        return self.sidebarDetailNavigationShell
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .allowsHitTesting(!self.isSidebarVisible)
-            .clipShape(self.sidebarDrawerContentShape(progress: progress))
-            .offset(x: Self.sidebarContentOffset(
-                sidebarWidth: sidebarWidth,
-                isVisible: self.isSidebarVisible,
-                dragOffset: self.sidebarResolvedDragOffset,
-                reduceMotion: self.reduceMotion))
-    }
-
-    /// Keep the Dynamic Island row nearly square while retaining the softer
-    /// lower drawer edge. The surface and content must share this exact shape.
-    private func sidebarDrawerContentShape(progress: CGFloat) -> UnevenRoundedRectangle {
-        UnevenRoundedRectangle(
-            topLeadingRadius: Self.sidebarDrawerTopLeadingRadius * progress,
-            bottomLeadingRadius: OpenClawProMetric.drawerRadius * progress,
-            bottomTrailingRadius: OpenClawProMetric.drawerRadius * progress,
-            topTrailingRadius: OpenClawProMetric.drawerRadius * progress,
-            style: .continuous)
-    }
-
-    @ViewBuilder
-    private func sidebarDrawerInteractionLayer(sidebarWidth: CGFloat) -> some View {
-        if self.isSidebarVisible {
-            HStack(spacing: 0) {
-                Color.clear
-                    .frame(width: sidebarWidth)
-                    .allowsHitTesting(false)
-                Color.clear
-                    .contentShape(Rectangle())
-                    .accessibilityHidden(true)
-                    .onTapGesture {
-                        self.hideSidebar()
-                    }
-                    .gesture(
-                        self.sidebarContentDismissGesture(sidebarWidth: sidebarWidth),
-                        isEnabled: !self.reduceMotion)
-            }
-        }
+        RootSidebarDrawer(
+            sidebarWidth: sidebarWidth,
+            isPresented: self.isSidebarVisible,
+            canOpenFromEdge: self.isSidebarDetailRootVisible && self.sidebarNavigationPath.isEmpty,
+            reduceMotion: self.reduceMotion,
+            animation: self.sidebarAnimation,
+            onShow: self.showSidebar,
+            onHide: self.hideSidebar,
+            sidebar: self.sidebarColumn(drawerSafeAreaInsets: safeAreaInsets),
+            detail: self.sidebarDetailNavigationShell)
     }
 
     private var sidebarDetailShell: some View {
@@ -325,9 +218,8 @@ struct RootTabs: View {
             model: self.sidebarModel,
             selectedDestination: self.selectedSidebarDestination,
             isDrawerLayout: self.isSidebarDrawerLayout,
-            showsDismissButton: self.isSidebarVisible,
+            isDismissButtonEnabled: self.isSidebarVisible,
             selectDestination: self.selectSidebarDestination,
-            selectSettingsRoute: self.selectSettingsRoute,
             hideSidebar: self.hideSidebar)
             .padding(.top, drawerSafeAreaInsets.map { $0.top + 8 } ?? 0)
             .padding(.bottom, drawerSafeAreaInsets.map { $0.bottom + 8 } ?? 0)
@@ -477,7 +369,6 @@ struct RootTabs: View {
             self.handleSidebarSettingsNavigationPathChange(navigationPath)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-        .clipped()
     }
 
     private var sidebarDetailShellID: String {
@@ -531,73 +422,6 @@ struct RootTabs: View {
 
     private var sidebarTransition: AnyTransition {
         self.reduceMotion ? .opacity : .move(edge: .leading).combined(with: .opacity)
-    }
-
-    private func sidebarContentRevealProgress(sidebarWidth: CGFloat) -> CGFloat {
-        guard sidebarWidth > 0 else { return 0 }
-        return Self.sidebarContentOffset(
-            sidebarWidth: sidebarWidth,
-            isVisible: self.isSidebarVisible,
-            dragOffset: self.sidebarResolvedDragOffset,
-            reduceMotion: self.reduceMotion) / sidebarWidth
-    }
-
-    private var sidebarResolvedDragOffset: CGFloat {
-        guard !self.isSidebarVisible, self.sidebarEdgeDragState.disposition == .horizontal else {
-            return self.sidebarContentDragOffset
-        }
-        return self.sidebarEdgeDragState.translationWidth
-    }
-
-    private func sidebarContentDismissGesture(sidebarWidth: CGFloat) -> some Gesture {
-        DragGesture(minimumDistance: 8)
-            .onChanged { value in
-                self.sidebarContentDragOffset = max(-sidebarWidth, min(0, value.translation.width))
-            }
-            .onEnded { value in
-                let shouldDismiss = value.translation.width < -80 ||
-                    value.predictedEndTranslation.width < -160
-                withAnimation(self.sidebarAnimation) {
-                    self.sidebarContentDragOffset = 0
-                    if shouldDismiss {
-                        self.sidebarVisibilityUserOverridden = true
-                        self.setSidebarVisible(false)
-                    }
-                }
-            }
-    }
-
-    private func sidebarEdgeOpenGesture(sidebarWidth: CGFloat) -> some Gesture {
-        DragGesture(minimumDistance: 8)
-            .updating(self.$sidebarEdgeDragState) { value, state, _ in
-                guard value.startLocation.x <= Self.sidebarEdgeGestureWidth,
-                      value.startLocation.y > Self.sidebarEdgeGestureWidth
-                else {
-                    state.disposition = .rejected
-                    return
-                }
-                if state.disposition == nil {
-                    state.disposition = value.translation.width > 0 &&
-                        value.translation.width > abs(value.translation.height) ? .horizontal : .rejected
-                }
-                guard state.disposition == .horizontal else { return }
-                state.translationWidth = max(0, min(sidebarWidth, value.translation.width))
-            }
-            .onEnded { value in
-                guard value.startLocation.x <= Self.sidebarEdgeGestureWidth,
-                      value.startLocation.y > Self.sidebarEdgeGestureWidth,
-                      value.translation.width > 0,
-                      value.translation.width > abs(value.translation.height)
-                else { return }
-                let shouldOpen = value.translation.width > 80 ||
-                    value.predictedEndTranslation.width > 160
-                withAnimation(self.sidebarAnimation) {
-                    if shouldOpen {
-                        self.sidebarVisibilityUserOverridden = true
-                        self.setSidebarVisible(true)
-                    }
-                }
-            }
     }
 
     private func shouldUseSidebarDrawer(containerSize: CGSize) -> Bool {
@@ -1134,7 +958,6 @@ extension RootTabs {
     }
 
     private func setSidebarVisible(_ isVisible: Bool) {
-        self.sidebarContentDragOffset = 0
         self.isSidebarVisible = isVisible
     }
 

--- a/apps/ios/Tests/RootTabsSidebarRegressionTests.swift
+++ b/apps/ios/Tests/RootTabsSidebarRegressionTests.swift
@@ -42,104 +42,106 @@ struct RootTabsSidebarRegressionTests {
         #expect(layoutUpdate.contains("guard force || !self.sidebarVisibilityUserOverridden else { return }"))
     }
 
-    @Test func `sidebar reveal uses one circular liquid glass background`() throws {
+    @Test func `sidebar controls keep glass inside their hit target`() throws {
         let source = try String(contentsOf: Self.openClawProComponentsSourceURL(), encoding: .utf8)
         let revealButton = try Self.extract(
             source,
-            from: "struct OpenClawSidebarRevealButton: View",
+            from: "struct OpenClawSidebarControlButton: View",
             to: "struct OpenClawSidebarHeaderLeadingSlot: View")
         let toolbarItem = try Self.extract(
             source,
             from: "struct OpenClawSidebarToolbarItem: ToolbarContent",
             to: "struct OpenClawGlassControlGroup")
 
-        #expect(revealButton.contains(".buttonStyle(.plain)"))
-        #expect(revealButton.contains(".glassEffect("))
-        #expect(revealButton.contains(".regular.interactive()"))
-        #expect(revealButton.contains("in: Circle()"))
+        let button = try Self.extract(
+            revealButton,
+            from: "private var button: some View",
+            to: "@ViewBuilder\n    private var icon")
+        let icon = try Self.extract(
+            revealButton,
+            from: "private var icon: some View",
+            to: "@ViewBuilder\n    private func identified")
+
+        #expect(revealButton.contains("self.identified(self.button.buttonStyle(.plain))"))
+        #expect(button.contains(".frame(width: 44, height: 44)"))
+        #expect(button.contains(".contentShape(Rectangle())"))
+        #expect(icon.contains(".regular.interactive()"))
+        #expect(icon.contains("in: Circle()"))
+        #expect(icon.contains("width: OpenClawProMetric.compactControlSize"))
         #expect(toolbarItem.contains(".sharedBackgroundVisibility(.hidden)"))
     }
 
-    @Test func `push reveal keeps sidebar behind an interactive dismissal card`() throws {
+    @Test func `push reveal uses one full bleed card with local gesture state`() throws {
         let source = try String(contentsOf: Self.rootTabsSourceURL(), encoding: .utf8)
+        let drawerSource = try String(contentsOf: Self.rootSidebarDrawerSourceURL(), encoding: .utf8)
+        let sidebarSource = try String(contentsOf: Self.rootSidebarSourceURL(), encoding: .utf8)
         let drawerContent = try Self.extract(
             source,
             from: "private func sidebarDrawerContent(",
             to: "private var sidebarDetailShell: some View")
-
-        let sidebarLayer = try Self.extract(
-            drawerContent,
-            from: "private func sidebarDrawerLayer(",
-            to: "private func sidebarDrawerContentSurface(")
-        let contentSurface = try Self.extract(
-            drawerContent,
-            from: "private func sidebarDrawerContentSurface(",
-            to: "private func sidebarDrawerContentCard(")
         let contentCard = try Self.extract(
-            drawerContent,
-            from: "private func sidebarDrawerContentCard(",
-            to: "private func sidebarDrawerInteractionLayer(")
-
-        #expect(drawerContent.contains("ZStack(alignment: .leading)"))
-        #expect(drawerContent.contains("self.sidebarDrawerLayer"))
-        #expect(drawerContent.contains("self.sidebarDrawerContentSurface"))
-        #expect(drawerContent.contains("self.sidebarDrawerContentCard"))
-        #expect(drawerContent.contains("self.sidebarDrawerInteractionLayer"))
-        #expect(drawerContent.contains(".simultaneousGesture("))
-        #expect(drawerContent.contains(".background(OpenClawSidebarPalette.background)"))
-        #expect(!drawerContent.contains("Color.black.opacity(0.35)"))
-        #expect(!sidebarLayer.contains(".clipShape"))
-        #expect(!sidebarLayer.contains(".shadow"))
-        #expect(drawerContent.contains("self.sidebarColumn(drawerSafeAreaInsets: safeAreaInsets)"))
-        #expect(sidebarLayer.contains(".ignoresSafeArea(.container, edges: .vertical)"))
-        #expect(contentSurface.contains(".fill(Color(uiColor: .systemGroupedBackground))"))
-        #expect(contentSurface.contains(".ignoresSafeArea(.container, edges: .vertical)"))
-        #expect(!contentSurface.contains(".shadow("))
-        #expect(contentSurface.contains(".offset(x: Self.sidebarContentOffset("))
-        #expect(contentCard.contains(".allowsHitTesting(!self.isSidebarVisible)"))
-        #expect(contentCard.contains("self.sidebarDrawerContentShape(progress: progress)"))
-        #expect(contentCard.contains(".offset(x: Self.sidebarContentOffset("))
-        #expect(!contentCard.contains(".gesture("))
-        #expect(!contentCard.contains("OpenClawProBackground()"))
-        #expect(!contentCard.contains(".shadow("))
-        let contentShape = try Self.extract(
-            drawerContent,
-            from: "private func sidebarDrawerContentShape(progress: CGFloat)",
-            to: "private func sidebarDrawerInteractionLayer(")
-        #expect(source.contains("private static let sidebarDrawerTopLeadingRadius: CGFloat = 8"))
-        #expect(contentShape.contains("UnevenRoundedRectangle("))
-        #expect(contentShape.contains("topLeadingRadius: Self.sidebarDrawerTopLeadingRadius * progress"))
-        #expect(contentShape.contains("bottomLeadingRadius: OpenClawProMetric.drawerRadius * progress"))
-        #expect(contentShape.contains("bottomTrailingRadius: OpenClawProMetric.drawerRadius * progress"))
-        #expect(contentShape.contains("topTrailingRadius: OpenClawProMetric.drawerRadius * progress"))
-        let interactionLayer = try Self.extract(
-            source,
-            from: "private func sidebarDrawerInteractionLayer(",
-            to: "private var sidebarDetailShell")
-        #expect(interactionLayer.contains("self.sidebarContentDismissGesture(sidebarWidth: sidebarWidth)"))
-        #expect(source.contains("private static let sidebarEdgeGestureWidth: CGFloat = 44"))
-        #expect(interactionLayer.contains(".accessibilityHidden(true)"))
-        #expect(!interactionLayer.contains("self.selectedSidebarDestination == .chat"))
-        #expect(!interactionLayer.contains(".highPriorityGesture("))
-        #expect(!interactionLayer.contains("self.sidebarEdgeOpenGesture(sidebarWidth: sidebarWidth)"))
-
-        let edgeGesture = try Self.extract(
-            source,
-            from: "private func sidebarEdgeOpenGesture(",
-            to: "private func shouldUseSidebarDrawer(")
-        #expect(edgeGesture.contains("value.startLocation.x <= Self.sidebarEdgeGestureWidth"))
-        #expect(edgeGesture.contains("value.startLocation.y > Self.sidebarEdgeGestureWidth"))
-        #expect(edgeGesture.contains(".updating(self.$sidebarEdgeDragState)"))
-        #expect(edgeGesture.contains("state.disposition == .horizontal"))
-        #expect(edgeGesture.contains("value.translation.width > abs(value.translation.height)"))
-        #expect(source.contains("@GestureState(resetTransaction:"))
-        #expect(source.contains("self.sidebarEdgeDragState.translationWidth"))
-        #expect(!source.contains("UIScreenEdgePanGestureRecognizer"))
-
+            drawerSource,
+            from: "private var contentCard: some View",
+            to: "@ViewBuilder\n    private var dismissalLayer")
+        let drawerGesture = try Self.extract(
+            drawerSource,
+            from: "private var drawerGesture: some Gesture",
+            to: "private static func dragDisposition(")
         let detailShell = try Self.extract(
             source,
             from: "private var sidebarDetailShell: some View",
             to: "private func sidebarColumn(")
+
+        #expect(drawerContent.contains("RootSidebarDrawer("))
+        #expect(drawerContent.contains("self.sidebarColumn(drawerSafeAreaInsets: safeAreaInsets)"))
+        #expect(drawerContent.contains("self.sidebarDetailNavigationShell"))
+        #expect(drawerContent.contains("self.isSidebarDetailRootVisible && self.sidebarNavigationPath.isEmpty"))
+        #expect(!source.contains("sidebarDrawerContentSurface"))
+        #expect(!source.contains("sidebarDrawerContentCard"))
+        #expect(!source.contains("sidebarContentDragOffset"))
+
+        #expect(drawerSource.contains("@GestureState(resetTransaction:"))
+        #expect(drawerSource.contains(".simultaneousGesture("))
+        #expect(drawerSource.contains("isEnabled: !self.reduceMotion"))
+        #expect(drawerSource.contains(".accessibilityHidden(!self.isPresented)"))
+        #expect(drawerSource.contains(".accessibilityHidden(self.isPresented)"))
+        #expect(drawerSource.contains(".onTapGesture(perform: self.onHide)"))
+        #expect(drawerSource.contains(".background(OpenClawSidebarPalette.background)"))
+        #expect(drawerSource.contains(".ignoresSafeArea(.container, edges: .vertical)"))
+        #expect(!drawerSource.contains("Color.black.opacity(0.35)"))
+        #expect(!drawerSource.contains("UIScreenEdgePanGestureRecognizer"))
+
+        #expect(contentCard.contains(".background(OpenClawProBackground())"))
+        #expect(contentCard.contains(".ignoresSafeArea(.container, edges: .vertical)"))
+        #expect(contentCard.contains(".allowsHitTesting(!self.isPresented)"))
+        #expect(contentCard.contains(".clipShape(shape)"))
+        #expect(contentCard.contains("shape.strokeBorder("))
+        #expect(contentCard.contains(".offset(x: offset)"))
+        #expect(!contentCard.contains("Color(uiColor: .systemGroupedBackground)"))
+        #expect(!contentCard.contains(".shadow("))
+
+        #expect(drawerGesture.contains(".updating(self.$dragState)"))
+        #expect(drawerGesture.contains("case .opening:"))
+        #expect(drawerGesture.contains("case .closing:"))
+        #expect(drawerGesture.contains("onShow()"))
+        #expect(drawerGesture.contains("onHide()"))
+        #expect(drawerSource.contains("value.startLocation.x <= RootSidebarDrawerMetric.edgeGestureWidth"))
+        #expect(drawerSource.contains("value.startLocation.y > RootSidebarDrawerMetric.topGestureExclusion"))
+        #expect(drawerSource.contains("value.translation.width > abs(value.translation.height)"))
+        #expect(drawerSource.contains("-value.translation.width > abs(value.translation.height)"))
+        #expect(drawerSource.contains("UnevenRoundedRectangle("))
+        #expect(drawerSource.contains("topLeadingRadius: RootSidebarDrawerMetric.topLeadingRadius * progress"))
+        #expect(drawerSource.contains("bottomLeadingRadius: RootSidebarDrawerMetric.cornerRadius * progress"))
+
+        #expect(!source.contains("showsDismissButton:"))
+        #expect(!sidebarSource.contains("let showsDismissButton: Bool"))
+        #expect(!sidebarSource.contains("let selectSettingsRoute:"))
+        #expect(source.contains("isDismissButtonEnabled: self.isSidebarVisible"))
+        #expect(sidebarSource.contains("OpenClawSidebarControlButton(action: self.dismissAction)"))
+        #expect(sidebarSource.contains(".allowsHitTesting(self.isDismissButtonEnabled)"))
+        #expect(sidebarSource.contains(".accessibilityHidden(!self.isDismissButtonEnabled)"))
+        #expect(sidebarSource.contains("accessibilityIdentifier: self.isDismissButtonEnabled"))
+        #expect(sidebarSource.contains("systemName: \"xmark\""))
         #expect(detailShell.contains(".onAppear"))
         #expect(detailShell.contains("guard self.sidebarDetailShellID == shellID else { return }"))
         #expect(detailShell.contains("self.isSidebarDetailRootVisible = true"))
@@ -195,6 +197,20 @@ struct RootTabsSidebarRegressionTests {
             .deletingLastPathComponent()
             .deletingLastPathComponent()
             .appendingPathComponent("Sources/RootTabs.swift")
+    }
+
+    private static func rootSidebarDrawerSourceURL() -> URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Sources/RootSidebarDrawer.swift")
+    }
+
+    private static func rootSidebarSourceURL() -> URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Sources/RootSidebar.swift")
     }
 
     private static func rootTabsNavigationSourceURL() -> URL {

--- a/apps/ios/Tests/RootTabsSidebarRegressionTests.swift
+++ b/apps/ios/Tests/RootTabsSidebarRegressionTests.swift
@@ -121,6 +121,10 @@ struct RootTabsSidebarRegressionTests {
         #expect(!contentCard.contains(".shadow("))
 
         #expect(drawerGesture.contains(".updating(self.$dragState)"))
+        #expect(drawerGesture.contains("if let latchedDisposition = state.disposition"))
+        #expect(drawerGesture.contains("dragSession.disposition = disposition"))
+        #expect(drawerGesture.contains("let disposition = dragSession.disposition"))
+        #expect(drawerGesture.contains("dragSession.disposition = nil"))
         #expect(drawerGesture.contains("case .opening:"))
         #expect(drawerGesture.contains("case .closing:"))
         #expect(drawerGesture.contains("onShow()"))

--- a/apps/ios/Tests/RootTabsSourceGuardTests.swift
+++ b/apps/ios/Tests/RootTabsSourceGuardTests.swift
@@ -29,7 +29,6 @@ struct RootTabsSourceGuardTests {
         #expect(source.contains("shouldShowSidebarRevealInDestinationHeader"))
         #expect(source.contains("layoutMode: self.isSidebarDrawerLayout ? .drawer : .split"))
         #expect(componentSource.contains("OpenClawSidebarHeaderLeadingSlot"))
-        #expect(componentSource.contains(".frame(width: 44, height: 44, alignment: .center)"))
         #expect(componentSource.contains(".frame(width: 44, height: 44)"))
         #expect(source.contains(".safeAreaPadding(.top, 8)"))
         #expect(source.contains("Self.sidebarShowButtonAccessibilityIdentifier"))
@@ -56,7 +55,7 @@ struct RootTabsSourceGuardTests {
         #expect(!source.contains("shouldShowOverviewHeaderSidebarReveal"))
     }
 
-    @Test func `i pad split stays integrated while compact drawer uses push reveal`() throws {
+    @Test func `i pad split stays integrated while compact drawer uses one local shell`() throws {
         let source = try String(contentsOf: Self.rootTabsSourceURL(), encoding: .utf8)
         let splitContent = try Self.extract(
             source,
@@ -76,36 +75,21 @@ struct RootTabsSourceGuardTests {
         #expect(splitContent.contains(".overlay(alignment: .trailing)"))
         #expect(splitContent.contains("self.sidebarVerticalSeparator"))
         #expect(splitContent.contains("self.sidebarDetailNavigationShell"))
+        #expect(splitContent.contains(".animation(self.sidebarAnimation, value: self.isSidebarVisible)"))
         #expect(!splitContent.contains("NavigationSplitView"))
         #expect(!splitContent.contains("self.collapsedSidebarRail"))
         #expect(!source.contains("Self.sidebarCollapsedRailWidth"))
-        #expect(drawerContent.contains("ZStack(alignment: .leading)"))
-        #expect(drawerContent.contains("self.sidebarDrawerLayer"))
-        #expect(drawerContent.contains("self.sidebarDrawerContentSurface"))
-        #expect(drawerContent.contains("self.sidebarDrawerContentCard"))
-        #expect(drawerContent.contains("self.sidebarDrawerInteractionLayer"))
-        #expect(drawerContent.contains("self.sidebarContentDismissGesture(sidebarWidth: sidebarWidth)"))
-        #expect(drawerContent.contains("self.sidebarEdgeOpenGesture(sidebarWidth: sidebarWidth)"))
-        #expect(drawerContent.contains("self.isSidebarDetailRootVisible"))
-        #expect(drawerContent.contains("self.sidebarNavigationPath.isEmpty"))
-        #expect(!drawerContent.contains("self.selectedSidebarDestination == .chat"))
-        #expect(drawerContent.contains(".allowsHitTesting(!self.isSidebarVisible)"))
-        #expect(source.contains("private static let sidebarDrawerTopLeadingRadius: CGFloat = 8"))
-        #expect(drawerContent.contains("let shape = self.sidebarDrawerContentShape(progress: progress)"))
-        #expect(drawerContent.contains("return shape\n            .fill(Color(uiColor: .systemGroupedBackground))"))
-        #expect(drawerContent.contains(".clipShape(self.sidebarDrawerContentShape(progress: progress))"))
-        #expect(drawerContent.contains(".offset(x: Self.sidebarContentOffset("))
-        #expect(!drawerContent.contains(".shadow("))
-        #expect(drawerContent.contains(".fill(Color(uiColor: .systemGroupedBackground))"))
-        #expect(drawerContent.contains(".ignoresSafeArea(.container, edges: .vertical)"))
-        #expect(!drawerContent.contains("Color.black.opacity(0.35)"))
-        #expect(drawerContent.contains("private func sidebarDrawerContentShape(progress: CGFloat)"))
-        #expect(drawerContent.contains("UnevenRoundedRectangle("))
-        #expect(drawerContent.contains("topLeadingRadius: Self.sidebarDrawerTopLeadingRadius * progress"))
-        #expect(drawerContent.contains("bottomLeadingRadius: OpenClawProMetric.drawerRadius * progress"))
-        #expect(drawerContent.contains("bottomTrailingRadius: OpenClawProMetric.drawerRadius * progress"))
-        #expect(drawerContent.contains("topTrailingRadius: OpenClawProMetric.drawerRadius * progress"))
+
+        #expect(drawerContent.contains("RootSidebarDrawer("))
+        #expect(drawerContent.contains("isPresented: self.isSidebarVisible"))
+        #expect(drawerContent.contains("self.isSidebarDetailRootVisible && self.sidebarNavigationPath.isEmpty"))
+        #expect(drawerContent.contains("onShow: self.showSidebar"))
+        #expect(drawerContent.contains("onHide: self.hideSidebar"))
+        #expect(drawerContent.contains("self.sidebarColumn(drawerSafeAreaInsets: safeAreaInsets)"))
+        #expect(drawerContent.contains("self.sidebarDetailNavigationShell"))
         #expect(!drawerContent.contains("NavigationSplitView"))
+        #expect(!source.contains("sidebarDrawerContentSurface"))
+        #expect(!source.contains("sidebarDrawerContentCard"))
     }
 
     @Test func `unified root shell removes phone tab chrome`() throws {

--- a/apps/ios/Tests/SwiftUIRenderSmokeTests.swift
+++ b/apps/ios/Tests/SwiftUIRenderSmokeTests.swift
@@ -530,9 +530,8 @@ struct SwiftUIRenderSmokeTests {
                 model: RootSidebarModel(),
                 selectedDestination: .overview,
                 isDrawerLayout: true,
-                showsDismissButton: true,
+                isDismissButtonEnabled: true,
                 selectDestination: { _ in },
-                selectSettingsRoute: { _ in },
                 hideSidebar: {})
                 .environment(appModel)
 
@@ -546,9 +545,8 @@ struct SwiftUIRenderSmokeTests {
             model: RootSidebarModel(),
             selectedDestination: .chat,
             isDrawerLayout: true,
-            showsDismissButton: true,
+            isDismissButtonEnabled: true,
             selectDestination: { _ in },
-            selectSettingsRoute: { _ in },
             hideSidebar: {})
             .environment(appModel)
             .environment(\.horizontalSizeClass, .regular)

--- a/apps/ios/UITests/OpenClawSnapshotUITests.swift
+++ b/apps/ios/UITests/OpenClawSnapshotUITests.swift
@@ -177,6 +177,7 @@ final class OpenClawSnapshotUITests: XCTestCase {
             thenDragTo: end,
             withVelocity: .slow,
             thenHoldForDuration: 0.1)
+        self.attachScreenshot(named: "sidebar-pushed-screen-after-back-swipe")
 
         self.waitForHittable(false, of: app.buttons["RootTabs.Sidebar.Hide"])
         self.waitForHittable(true, of: appearance)
@@ -981,7 +982,8 @@ final class OpenClawSnapshotUITests: XCTestCase {
         line: UInt = #line) throws
     {
         let app = try XCTUnwrap(self.app, file: file, line: line)
-        let start = app.coordinate(withNormalizedOffset: CGVector(dx: 0.92, dy: 0.5))
+        // Start inside the exposed sidebar, not on the translated detail card.
+        let start = app.coordinate(withNormalizedOffset: CGVector(dx: 0.72, dy: 0.5))
         let end = app.coordinate(withNormalizedOffset: CGVector(dx: 0.05, dy: 0.5))
         start.press(
             forDuration: 0.1,


### PR DESCRIPTION
Closes #111643

## What Problem This Solves

Fixes an issue where iPhone and compact iPad users could see a different-colored surface in the rounded top and bottom of the open sidebar, a clipped or oversized Liquid Glass reveal control, and choppy interactive drawer tracking. The open drawer also lacked a consistent glass close affordance during the reveal.

This is a residual follow-up to #111831. That change stabilized the original recognizer ownership, but the compact drawer still moved a separate generic background alongside the destination and kept transient drag work coupled to the full root view.

## Why This Change Was Made

The compact drawer now has one presentation owner. A dedicated stable shell owns the transient gesture session, the rounded full-bleed destination card, tap dismissal, and edge-open arbitration. The destination itself paints the rounded safe-area regions, so custom backgrounds remain continuous instead of revealing a generic grouped surface.

The reveal and close actions share one 44-point semantic control with a 36-point circular Liquid Glass visual. The open-state X stays structurally present through interactive reveal, but is only exposed to hit testing and accessibility when the drawer is actually open. The first meaningful drag direction is latched for the whole touch, preventing a rejected vertical scroll from turning into a drawer toggle at release.

## User Impact

Sidebar drags now track as one card instead of two moving full-screen layers. The rounded top and bottom match the active destination background, the reveal control no longer clips against its toolbar slot, and the open drawer has a clear circular glass X. Users can also dismiss by dragging left from inside the sidebar, while pushed screens keep the native iOS back gesture.

## Evidence

### Before and after

<table>
<tr>
<td><strong>Before: separate rounded surface</strong></td>
<td><strong>After: destination-owned full-bleed card</strong></td>
</tr>
<tr>
<td><img width="300" alt="Before: open sidebar with mismatched rounded destination surface" src="https://artifacts.openclaw.ai/pr-ios-sidebar-glass-ui-polish-20260721/before-open.png" /></td>
<td><img width="300" alt="After: open sidebar with continuous background and glass close control" src="https://artifacts.openclaw.ai/pr-ios-sidebar-glass-ui-polish-20260721/after-open.png" /></td>
</tr>
<tr>
<td><strong>Before: oversized reveal glass</strong></td>
<td><strong>After: glass contained inside 44-point target</strong></td>
</tr>
<tr>
<td><img width="300" alt="Before: sidebar reveal control" src="https://artifacts.openclaw.ai/pr-ios-sidebar-glass-ui-polish-20260721/before-closed.png" /></td>
<td><img width="300" alt="After: unclipped circular sidebar reveal control" src="https://artifacts.openclaw.ai/pr-ios-sidebar-glass-ui-polish-20260721/after-closed.png" /></td>
</tr>
</table>

Artifact manifest: https://artifacts.openclaw.ai/pr-ios-sidebar-glass-ui-polish-20260721/artifact-manifest.json

### Exact-head verification

Exact pushed head: `96fed3aff1e4c033298a7a599edf54ef5f4fcf99`

- **118 focused tests in 3 suites passed** for sidebar presentation, structure, and navigation behavior on the rebased production patch.
- **6 drawer regression tests passed** after the final first-direction latch fix.
- **2 UI tests passed in 313.690 seconds** on iPhone 17 Pro / iOS 27 Simulator:
  - slow edge-open across all 16 root destinations;
  - slow close drags beginning inside the exposed sidebar;
  - pushed Settings native back-swipe without opening the drawer;
  - leading-edge vertical scrolling without drawer activation.
- Light and dark simulator screenshots show continuous rounded safe-area backgrounds, complete circular reveal glass, and the glass X close control.
- Native localization verification passed with **5,102 entries** and no drift.
- `git diff --check` passed.
- Final changed-file verification passed on Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/29829959044
- Final structured Codex autoreview: **no accepted/actionable findings**, `patch is correct` (0.93 confidence).
- Source-blind behavior validation passed the visual, drag, inside-close, and back-swipe clauses. The simulator CLI does not expose a Reduce Motion toggle; tap-based reveal/close remained available and the code-aware review found no Reduce Motion regression.
- AI-assisted change; implementation, tests, visual comparison, and review output were independently inspected before push.
