### PR TITLE
fix(embeddings): scope Mistral and DeepInfra memory cache identity by endpoint

### DIFF
--- a/extensions/deepinfra/embedding-adapter.test.ts
+++ b/extensions/deepinfra/embedding-adapter.test.ts
@@ -143,6 +143,9 @@ describe("DeepInfra generic embedding adapter", () => {
         client,
       });
       const result = await deepinfraEmbeddingProviderAdapter.create({} as never);
+      if (!result.runtime) {
+        throw new Error("expected the adapter to expose an embedding runtime");
+      }
       return result.runtime.cacheKeyData as Record<string, unknown>;
     }
 

--- a/extensions/deepinfra/embedding-adapter.test.ts
+++ b/extensions/deepinfra/embedding-adapter.test.ts
@@ -12,6 +12,7 @@ vi.mock("./embedding-provider.js", () => ({
 }));
 
 import { deepinfraEmbeddingProviderAdapter } from "./embedding-adapter.js";
+import { DEEPINFRA_BASE_URL } from "./media-models.js";
 
 const memoryProvider: MemoryEmbeddingProvider = {
   id: "deepinfra",
@@ -25,9 +26,15 @@ const memoryProvider: MemoryEmbeddingProvider = {
 describe("DeepInfra generic embedding adapter", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // resolveRemoteEmbeddingClient always resolves a base URL and headers, so the
+    // stub carries them too — the adapter now reads both to scope cache identity.
     mocks.createDeepInfraEmbeddingProvider.mockResolvedValue({
       provider: memoryProvider,
-      client: { model: "BAAI/bge-m3-resolved" },
+      client: {
+        model: "BAAI/bge-m3-resolved",
+        baseUrl: DEEPINFRA_BASE_URL,
+        headers: { Authorization: "Bearer redacted" }, // pragma: allowlist secret
+      },
     });
   });
 
@@ -123,5 +130,57 @@ describe("DeepInfra generic embedding adapter", () => {
       signal: abortController.signal,
     });
     expect(memoryProvider.close).toHaveBeenCalledOnce();
+  });
+
+  describe("cache identity", () => {
+    async function cacheKeyData(client: {
+      baseUrl: string;
+      headers: Record<string, string>;
+      model: string;
+    }): Promise<Record<string, unknown>> {
+      mocks.createDeepInfraEmbeddingProvider.mockResolvedValue({
+        provider: memoryProvider,
+        client,
+      });
+      const result = await deepinfraEmbeddingProviderAdapter.create({} as never);
+      return result.runtime.cacheKeyData as Record<string, unknown>;
+    }
+
+    it("keeps the shipped default identity for the default endpoint", async () => {
+      expect(
+        await cacheKeyData({
+          baseUrl: DEEPINFRA_BASE_URL,
+          headers: { Authorization: "Bearer redacted" }, // pragma: allowlist secret
+          model: "BAAI/bge-m3",
+        }),
+      ).toEqual({ provider: "deepinfra", model: "BAAI/bge-m3" });
+    });
+
+    it("scopes cache identity by base URL when a custom endpoint is configured", async () => {
+      expect(
+        await cacheKeyData({
+          baseUrl: "https://deepinfra.proxy.internal/v1/openai",
+          headers: { Authorization: "Bearer redacted" }, // pragma: allowlist secret
+          model: "BAAI/bge-m3",
+        }),
+      ).toEqual({
+        provider: "deepinfra",
+        baseUrl: "https://deepinfra.proxy.internal/v1/openai",
+        model: "BAAI/bge-m3",
+      });
+    });
+
+    it("hashes custom header identity without leaking raw values", async () => {
+      const data = await cacheKeyData({
+        baseUrl: DEEPINFRA_BASE_URL,
+        headers: {
+          Authorization: "Bearer redacted", // pragma: allowlist secret
+          "X-Tenant": "tenant-a",
+        },
+        model: "BAAI/bge-m3",
+      });
+      expect(data.headersHash).toMatch(/^[0-9a-f]{64}$/);
+      expect(JSON.stringify(data)).not.toContain("tenant-a");
+    });
   });
 });

--- a/extensions/deepinfra/embedding-adapter.ts
+++ b/extensions/deepinfra/embedding-adapter.ts
@@ -5,14 +5,16 @@ import type {
   EmbeddingProviderAdapter,
   EmbeddingProviderCreateOptions,
 } from "openclaw/plugin-sdk/embedding-providers";
-import type {
-  MemoryEmbeddingProvider,
-  MemoryEmbeddingProviderCreateOptions,
+import {
+  buildEmbeddingEndpointCacheIdentity,
+  type MemoryEmbeddingProvider,
+  type MemoryEmbeddingProviderCreateOptions,
 } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
 import {
   createDeepInfraEmbeddingProvider,
   DEFAULT_DEEPINFRA_EMBEDDING_MODEL,
 } from "./embedding-provider.js";
+import { DEEPINFRA_BASE_URL } from "./media-models.js";
 import type { DeepInfraSurfaceModel } from "./provider-models.js";
 
 function textFromEmbeddingInput(input: EmbeddingInput): string {
@@ -73,6 +75,11 @@ export function buildDeepInfraEmbeddingAdapter(options?: {
           id: "deepinfra",
           cacheKeyData: {
             provider: "deepinfra",
+            ...buildEmbeddingEndpointCacheIdentity({
+              baseUrl: client.baseUrl,
+              defaultBaseUrl: DEEPINFRA_BASE_URL,
+              headers: client.headers,
+            }),
             model: client.model,
           },
         },

--- a/extensions/deepinfra/embedding-provider.ts
+++ b/extensions/deepinfra/embedding-provider.ts
@@ -4,6 +4,7 @@ import {
   resolveRemoteEmbeddingClient,
   type MemoryEmbeddingProviderCreateOptions,
   type MemoryEmbeddingProviderCreateResult,
+  type RemoteEmbeddingClient,
 } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
 import {
   DEEPINFRA_BASE_URL,
@@ -15,7 +16,7 @@ export const DEFAULT_DEEPINFRA_EMBEDDING_MODEL = DEEPINFRA_EMBED_FALLBACK_MODELS
 
 export async function createDeepInfraEmbeddingProvider(
   options: MemoryEmbeddingProviderCreateOptions & { defaultModel?: string },
-): Promise<MemoryEmbeddingProviderCreateResult & { client: { model: string } }> {
+): Promise<MemoryEmbeddingProviderCreateResult & { client: RemoteEmbeddingClient }> {
   const defaultModel = options.defaultModel ?? DEFAULT_DEEPINFRA_EMBEDDING_MODEL;
   const client = await resolveRemoteEmbeddingClient({
     provider: "deepinfra",

--- a/extensions/mistral/embedding-provider.ts
+++ b/extensions/mistral/embedding-provider.ts
@@ -16,7 +16,7 @@ type MistralEmbeddingClient = {
 };
 
 export const DEFAULT_MISTRAL_EMBEDDING_MODEL = "mistral-embed";
-const DEFAULT_MISTRAL_BASE_URL = "https://api.mistral.ai/v1";
+export const DEFAULT_MISTRAL_BASE_URL = "https://api.mistral.ai/v1";
 
 function normalizeMistralModel(model: string): string {
   return normalizeEmbeddingModelWithPrefixes({

--- a/extensions/mistral/memory-embedding-adapter.test.ts
+++ b/extensions/mistral/memory-embedding-adapter.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./embedding-provider.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./embedding-provider.js")>();
+  return { ...actual, createMistralEmbeddingProvider: vi.fn() };
+});
+
+import { createMistralEmbeddingProvider, DEFAULT_MISTRAL_BASE_URL } from "./embedding-provider.js";
+import { mistralMemoryEmbeddingProviderAdapter } from "./memory-embedding-adapter.js";
+
+const mockCreate = vi.mocked(createMistralEmbeddingProvider);
+
+function stubClient(client: {
+  baseUrl: string;
+  headers: Record<string, string>;
+  model: string;
+}): void {
+  mockCreate.mockResolvedValue({
+    provider: {} as never,
+    client: { ssrfPolicy: undefined, ...client },
+  });
+}
+
+async function cacheKeyData(): Promise<Record<string, unknown>> {
+  const result = await mistralMemoryEmbeddingProviderAdapter.create({} as never);
+  return result.runtime.cacheKeyData as Record<string, unknown>;
+}
+
+describe("mistralMemoryEmbeddingProviderAdapter cache identity", () => {
+  beforeEach(() => mockCreate.mockReset());
+
+  it("keeps the shipped default identity (no baseUrl) for the default endpoint", async () => {
+    stubClient({
+      baseUrl: DEFAULT_MISTRAL_BASE_URL,
+      headers: { Authorization: "Bearer redacted" }, // pragma: allowlist secret
+      model: "mistral-embed",
+    });
+    expect(await cacheKeyData()).toEqual({ provider: "mistral", model: "mistral-embed" });
+  });
+
+  it("scopes cache identity by base URL when a custom endpoint is configured", async () => {
+    stubClient({
+      baseUrl: "https://mistral.proxy.internal/v1",
+      headers: { Authorization: "Bearer redacted" }, // pragma: allowlist secret
+      model: "mistral-embed",
+    });
+    expect(await cacheKeyData()).toEqual({
+      provider: "mistral",
+      baseUrl: "https://mistral.proxy.internal/v1",
+      model: "mistral-embed",
+    });
+  });
+
+  it("hashes custom header identity without leaking raw values", async () => {
+    stubClient({
+      baseUrl: DEFAULT_MISTRAL_BASE_URL,
+      headers: {
+        Authorization: "Bearer redacted", // pragma: allowlist secret
+        "X-Tenant": "tenant-a",
+      },
+      model: "mistral-embed",
+    });
+    const data = await cacheKeyData();
+    expect(data.headersHash).toMatch(/^[0-9a-f]{64}$/);
+    expect(JSON.stringify(data)).not.toContain("tenant-a");
+  });
+});

--- a/extensions/mistral/memory-embedding-adapter.test.ts
+++ b/extensions/mistral/memory-embedding-adapter.test.ts
@@ -5,10 +5,15 @@ vi.mock("./embedding-provider.js", async (importOriginal) => {
   return { ...actual, createMistralEmbeddingProvider: vi.fn() };
 });
 
-import { createMistralEmbeddingProvider, DEFAULT_MISTRAL_BASE_URL } from "./embedding-provider.js";
+import { createMistralEmbeddingProvider } from "./embedding-provider.js";
 import { mistralMemoryEmbeddingProviderAdapter } from "./memory-embedding-adapter.js";
 
 const mockCreate = vi.mocked(createMistralEmbeddingProvider);
+
+// Spelled out rather than imported from the module under test: the
+// default-endpoint case asserts that the shipped cache identity is unchanged, so
+// it has to mean the same thing with and without this patch applied.
+const SHIPPED_MISTRAL_BASE_URL = "https://api.mistral.ai/v1";
 
 function stubClient(client: {
   baseUrl: string;
@@ -23,6 +28,9 @@ function stubClient(client: {
 
 async function cacheKeyData(): Promise<Record<string, unknown>> {
   const result = await mistralMemoryEmbeddingProviderAdapter.create({} as never);
+  if (!result.runtime) {
+    throw new Error("expected the adapter to expose an embedding runtime");
+  }
   return result.runtime.cacheKeyData as Record<string, unknown>;
 }
 
@@ -31,7 +39,7 @@ describe("mistralMemoryEmbeddingProviderAdapter cache identity", () => {
 
   it("keeps the shipped default identity (no baseUrl) for the default endpoint", async () => {
     stubClient({
-      baseUrl: DEFAULT_MISTRAL_BASE_URL,
+      baseUrl: SHIPPED_MISTRAL_BASE_URL,
       headers: { Authorization: "Bearer redacted" }, // pragma: allowlist secret
       model: "mistral-embed",
     });
@@ -53,7 +61,7 @@ describe("mistralMemoryEmbeddingProviderAdapter cache identity", () => {
 
   it("hashes custom header identity without leaking raw values", async () => {
     stubClient({
-      baseUrl: DEFAULT_MISTRAL_BASE_URL,
+      baseUrl: SHIPPED_MISTRAL_BASE_URL,
       headers: {
         Authorization: "Bearer redacted", // pragma: allowlist secret
         "X-Tenant": "tenant-a",

--- a/extensions/mistral/memory-embedding-adapter.ts
+++ b/extensions/mistral/memory-embedding-adapter.ts
@@ -1,10 +1,12 @@
 // Mistral plugin module implements memory embedding adapter behavior.
 import {
+  buildEmbeddingEndpointCacheIdentity,
   isMissingEmbeddingApiKeyError,
   type MemoryEmbeddingProviderAdapter,
 } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
 import {
   createMistralEmbeddingProvider,
+  DEFAULT_MISTRAL_BASE_URL,
   DEFAULT_MISTRAL_EMBEDDING_MODEL,
 } from "./embedding-provider.js";
 
@@ -28,6 +30,11 @@ export const mistralMemoryEmbeddingProviderAdapter: MemoryEmbeddingProviderAdapt
         id: "mistral",
         cacheKeyData: {
           provider: "mistral",
+          ...buildEmbeddingEndpointCacheIdentity({
+            baseUrl: client.baseUrl,
+            defaultBaseUrl: DEFAULT_MISTRAL_BASE_URL,
+            headers: client.headers,
+          }),
           model: client.model,
         },
       },

--- a/packages/memory-host-sdk/src/engine-embeddings.ts
+++ b/packages/memory-host-sdk/src/engine-embeddings.ts
@@ -51,6 +51,7 @@ export {
 } from "./host/batch-utils.js";
 export { enforceEmbeddingMaxInputTokens } from "./host/embedding-chunk-limits.js";
 export {
+  buildEmbeddingEndpointCacheIdentity,
   isMissingEmbeddingApiKeyError,
   mapBatchEmbeddingsByIndex,
   sanitizeEmbeddingCacheHeaders,

--- a/packages/memory-host-sdk/src/host/embedding-provider-adapter-utils.test.ts
+++ b/packages/memory-host-sdk/src/host/embedding-provider-adapter-utils.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { sanitizeEmbeddingCacheHeaders } from "./embedding-provider-adapter-utils.js";
+import {
+  buildEmbeddingEndpointCacheIdentity,
+  sanitizeEmbeddingCacheHeaders,
+} from "./embedding-provider-adapter-utils.js";
 
 describe("sanitizeEmbeddingCacheHeaders", () => {
   it("removes only explicitly excluded header names", () => {
@@ -17,5 +20,55 @@ describe("sanitizeEmbeddingCacheHeaders", () => {
       ["X-Api-Key-Routing", "tenant-a"],
       ["X-Token-Bucket", "batch-a"],
     ]);
+  });
+});
+
+describe("buildEmbeddingEndpointCacheIdentity", () => {
+  const DEFAULT = "https://api.example.ai/v1";
+  const auth = { Authorization: "Bearer redacted" }; // pragma: allowlist secret
+
+  it("keeps the shipped default identity (no extra fields) so ordinary installs do not rebuild", () => {
+    expect(
+      buildEmbeddingEndpointCacheIdentity({
+        baseUrl: DEFAULT,
+        defaultBaseUrl: DEFAULT,
+        headers: auth,
+      }),
+    ).toEqual({});
+  });
+
+  it("scopes identity by base URL when a custom endpoint is configured", () => {
+    expect(
+      buildEmbeddingEndpointCacheIdentity({
+        baseUrl: "https://proxy.internal/v1",
+        defaultBaseUrl: DEFAULT,
+        headers: auth,
+      }),
+    ).toEqual({ baseUrl: "https://proxy.internal/v1" });
+  });
+
+  it("hashes custom header identity without retaining raw values, and forces base-url scoping", () => {
+    const identity = buildEmbeddingEndpointCacheIdentity({
+      baseUrl: DEFAULT,
+      defaultBaseUrl: DEFAULT,
+      headers: { ...auth, "X-Api-Key-Routing": "tenant-a" },
+    });
+    expect(identity.baseUrl).toBe(DEFAULT);
+    expect(identity.headersHash).toMatch(/^[0-9a-f]{64}$/);
+    expect(JSON.stringify(identity)).not.toContain("tenant-a");
+  });
+
+  it("gives distinct header hashes for distinct header identity", () => {
+    const a = buildEmbeddingEndpointCacheIdentity({
+      baseUrl: DEFAULT,
+      defaultBaseUrl: DEFAULT,
+      headers: { "X-Api-Key-Routing": "tenant-a" },
+    });
+    const b = buildEmbeddingEndpointCacheIdentity({
+      baseUrl: DEFAULT,
+      defaultBaseUrl: DEFAULT,
+      headers: { "X-Api-Key-Routing": "tenant-b" },
+    });
+    expect(a.headersHash).not.toBe(b.headersHash);
   });
 });

--- a/packages/memory-host-sdk/src/host/embedding-provider-adapter-utils.ts
+++ b/packages/memory-host-sdk/src/host/embedding-provider-adapter-utils.ts
@@ -1,7 +1,11 @@
 // Memory Host SDK helper module supports embedding provider adapter utils behavior.
+import { createHash } from "node:crypto";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 
 // Adapter helpers shared by remote embedding provider implementations.
+
+// Secret or invariant headers must never distinguish or leak into the cache identity.
+const EMBEDDING_CACHE_IDENTITY_EXCLUDED_HEADERS = ["authorization", "content-type", "x-api-key"];
 
 /** Detect missing API key errors from provider auth resolution. */
 export function isMissingEmbeddingApiKeyError(err: unknown): boolean {
@@ -20,6 +24,35 @@ export function sanitizeEmbeddingCacheHeaders(
     .filter(([key]) => !excluded.has(normalizeLowercaseStringOrEmpty(key)))
     .toSorted(([a], [b]) => a.localeCompare(b))
     .map(([key, value]) => [key, value]);
+}
+
+/**
+ * Endpoint-scoped extra cache-identity fields for a remote embedding provider.
+ * A custom base URL or custom header identity must not collide with the shipped
+ * default's cache entry, else a cached embedding computed against one endpoint is
+ * served for another (same provider+model). Returns fields to spread into
+ * `cacheKeyData`; empty for the shipped default so ordinary installs keep their
+ * existing cache identity and do not rebuild.
+ */
+export function buildEmbeddingEndpointCacheIdentity(params: {
+  baseUrl: string;
+  defaultBaseUrl: string;
+  headers: Record<string, string>;
+}): { baseUrl?: string; headersHash?: string } {
+  const identityHeaders = sanitizeEmbeddingCacheHeaders(
+    params.headers,
+    EMBEDDING_CACHE_IDENTITY_EXCLUDED_HEADERS,
+  );
+  const headersHash =
+    identityHeaders.length > 0
+      ? createHash("sha256").update(JSON.stringify(identityHeaders)).digest("hex")
+      : undefined;
+  const usesShippedDefaultIdentity =
+    params.baseUrl === params.defaultBaseUrl && headersHash === undefined;
+  return {
+    ...(usesShippedDefaultIdentity ? {} : { baseUrl: params.baseUrl }),
+    ...(headersHash ? { headersHash } : {}),
+  };
 }
 
 /** Convert custom-id keyed batch embeddings back to request-index order. */

--- a/src/plugin-sdk/memory-core-host-engine-embeddings.ts
+++ b/src/plugin-sdk/memory-core-host-engine-embeddings.ts
@@ -5,6 +5,7 @@ export {
   buildCaseInsensitiveExtensionGlob,
   buildEmbeddingBatchGroupOptions,
   buildRemoteBaseUrlPolicy,
+  buildEmbeddingEndpointCacheIdentity,
   classifyMemoryMultimodalPath,
   createLocalEmbeddingProvider,
   createRemoteEmbeddingProvider,


### PR DESCRIPTION
## What Problem This Solves

The Mistral and DeepInfra memory-embedding adapters build their cache key from
`{ provider, model }` only. Both resolve their client through
`resolveRemoteEmbeddingClient`, where the base URL and headers are
user-configurable (`memory.search.remote.baseUrl`, or a provider
`baseUrl` / `headers` override). So the same `provider + model` pointed at two
different base URLs shares one cache key, and a query against one endpoint can
return an embedding computed against the other. [#97059](https://github.com/openclaw/openclaw/pull/97059) fixed this for Ollama;
Mistral and DeepInfra were the adapters still missing endpoint scoping.

## Why This Change Was Made

Both adapters need the identical identity logic, so instead of inlining two
copies this adds one `buildEmbeddingEndpointCacheIdentity` helper next to the
existing `sanitizeEmbeddingCacheHeaders` in the shared embedding adapter utils.
It returns the extra `cacheKeyData` fields to spread:

- Shipped-default base URL with no custom headers → returns nothing, so the
  default-endpoint cache key stays compatible with today's `{ provider, model }`.
- Custom base URL → adds `baseUrl`.
- Custom headers → adds a sha256 `headersHash` of the effective custom headers,
  so a shared base URL that routes to a different backend or tenant via a routing or
  tenant header still gets a distinct cache identity. The stored identity holds
  the digest rather than the header values — which bounds what the cache key
  carries, though a low-entropy header value would still be guessable from it. `authorization` / `x-api-key` / `content-type` are excluded, matching
  the list [#97059](https://github.com/openclaw/openclaw/pull/97059) established for Ollama, so the three adapters agree on which
  headers are identity and which are authentication. That is a deliberate
  tradeoff rather than a claim that credentials never matter: hashing them would
  bust every cache on key rotation and fold secret material into a persisted
  identity. Its limit is a gateway that routes to a different backend or tenant
  *by credential alone*, with no distinguishing base URL or routing header — such
  a deployment would still share one identity, and scoping it would need the
  credential in the key. Out of scope here, and unchanged from Ollama's behavior.

DeepInfra's provider return type previously narrowed its client to `{ model }`,
hiding the `baseUrl`/`headers` it already returns at runtime; it now returns the
real `RemoteEmbeddingClient` type so the adapter can read them.

Two of the ten files are export plumbing only: `packages/memory-host-sdk/src/engine-embeddings.ts`
and `src/plugin-sdk/memory-core-host-engine-embeddings.ts` each add one line so
the new helper reaches the two plugins through the same SDK seam that already
carries `sanitizeEmbeddingCacheHeaders`. That does add a symbol package
consumers can see; what it does not add is any user-facing config, documented
API, or manifest surface.

DeepInfra's side lands in `extensions/deepinfra/embedding-adapter.ts` rather than
the `memory-embedding-adapter.ts` it originally targeted — [#114727](https://github.com/openclaw/openclaw/pull/114727) migrated that
adapter to the generic `EmbeddingProviderAdapter` contract while this PR was
open. The `cacheKeyData` seam is unchanged by that migration, so this is the same
one-line spread at a new location, with the focused cases folded into the
`embedding-adapter.test.ts` suite that migration added.

## User Impact

Users who point Mistral or DeepInfra embeddings at a custom base URL, or at custom
routing headers, for the same provider and model no longer risk a memory-search result
that reuses a different endpoint's cached embedding. Default-endpoint users are
unaffected: the cache key is unchanged, and the focused suite asserts that in both
legs of the before/after run rather than only after the fix.

## Evidence

Recaptured on the current merge head after rebasing; the earlier transcripts
predated this base.

```
head:  8282c124fcdbff1004b60deb7566901b615a689d
base:  e1e1c1879bf4924e070463b499f3f3b264092f4a   (merge base with upstream/main)
node:  v24.18.0
```

```
 extensions/deepinfra/embedding-adapter.test.ts     | 64 +++++++++++++++++-
 extensions/deepinfra/embedding-adapter.ts          | 13 +++-
 extensions/deepinfra/embedding-provider.ts         |  3 +-
 extensions/mistral/embedding-provider.ts           |  2 +-
 .../mistral/memory-embedding-adapter.test.ts       | 75 ++++++++++++++++++++++
 extensions/mistral/memory-embedding-adapter.ts     |  7 ++
 packages/memory-host-sdk/src/engine-embeddings.ts  |  1 +
 .../host/embedding-provider-adapter-utils.test.ts  | 55 +++++++++++++++-
 .../src/host/embedding-provider-adapter-utils.ts   | 33 ++++++++++
 .../memory-core-host-engine-embeddings.ts          |  1 +
 10 files changed, 247 insertions(+), 7 deletions(-)
```

### Runtime proof: switching endpoints on a real index

Two local OpenAI-compatible embeddings servers stand in for two different endpoints reachable at the same provider and model. Each logs every request it serves and returns a constant vector unique to itself. The production `openclaw memory index` command then runs against a real agent database, first pointed at endpoint A, then — with nothing else changed — repointed at endpoint B by editing `memory.search.remote.baseUrl`.

The fixture is one agent with a single `memory/notes.md`, an isolated `OPENCLAW_STATE_DIR`, and a config whose only edit between the two runs is `memory.search.remote.baseUrl`; `provider` (`deepinfra`), `model` and everything else stay fixed. Each run is `openclaw memory index --agent <id> --force`.

What is read afterwards is `memory_index_meta.providerKey` in the agent's SQLite database. That value is `hashText(JSON.stringify(cacheKeyData))` (`extensions/memory-core/src/memory/manager-reindex-state.ts`), so it is the memory identity this change is about, not a proxy for it.

**Before the fix**, with the production files reverted to `upstream/main` on this head and the build forced so the reverted code is what actually runs:

```
# indexed against endpoint A
providerKey          = 48a687b82fc96289291d41b0842360d1ef946cf7be1dd1f0d650b30075be79ca
indexed chunks       = 1
embedding cache rows = 1

# baseUrl switched to endpoint B, re-indexed
providerKey          = 48a687b82fc96289291d41b0842360d1ef946cf7be1dd1f0d650b30075be79ca
indexed chunks       = 1
embedding cache rows = 1
```

The identity did not move, and neither did the cache. The two servers say why:

```
endpoint-B listening on 127.0.0.1:18202
endpoint-A listening on 127.0.0.1:18201
endpoint-A SERVED /v1/embeddings inputs=1
```

Endpoint B was never contacted. Taken with the unchanged `providerKey` and the cache row count that stays at one, that is the defect: the index configured for endpoint B is the one endpoint A produced, and nothing in the run causes it to be recomputed. What the logs show directly is the absent request; the reuse is the inference from all three observations together.

**After the fix**, same two servers, same sequence:

```
# indexed against endpoint A
providerKey          = ac283b79945ac3bdaab44f439c1c4df286d2d33b8cb274b4f95735f373295c5b
indexed chunks       = 1
embedding cache rows = 1

# baseUrl switched to endpoint B, re-indexed
providerKey          = 43f78b1c2d870c0c3b91c2ef416bcbfe94998e2410e556a2dc809a19639f4bc9
indexed chunks       = 1
embedding cache rows = 2
```

```
endpoint-A SERVED /v1/embeddings inputs=1
endpoint-B SERVED /v1/embeddings inputs=1
```

The identity changed, endpoint B was asked for its own embedding, and the cache now holds both rows rather than one shared one. Note the before-run and after-run identities differ from each other too (`48a687b8` vs `ac283b79`): the default-endpoint key is unchanged by this PR, but these runs use a custom base URL on both sides, which is exactly the case the fix scopes.

`scripts/run-node.mjs` rebuilds from a source-mtime stamp and `dist` chunks are content-hash named without eviction, so each leg was taken after `rm -rf dist` and `OPENCLAW_FORCE_BUILD=1`, with the built output checked for `buildEmbeddingEndpointCacheIdentity` — required absent for the before leg, present for the after leg — before the run was trusted.

### Focused tests

Red before the change, with only the production files checked out from `upstream/main` on this head — the tests themselves are this PR's, run unchanged in both legs, so this isolates the production change rather than reproducing the pre-PR tree.

```
 ❯ packages/memory-host-sdk/src/host/embedding-provider-adapter-utils.test.ts (5 tests | 4 failed)
     × keeps the shipped default identity (no extra fields) so ordinary installs do not rebuild
     × scopes identity by base URL when a custom endpoint is configured
     × hashes custom header identity without retaining raw values, and forces base-url scoping
     × gives distinct header hashes for distinct header identity
       → TypeError: buildEmbeddingEndpointCacheIdentity is not a function

 ❯ extensions/mistral/memory-embedding-adapter.test.ts (3 tests | 2 failed)
     × scopes cache identity by base URL when a custom endpoint is configured
     × hashes custom header identity without leaking raw values

 ❯ extensions/deepinfra/embedding-adapter.test.ts (6 tests | 2 failed)
     × scopes cache identity by base URL when a custom endpoint is configured
     × hashes custom header identity without leaking raw values

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 8 ⎯⎯⎯⎯⎯⎯⎯
 Test Files  3 failed (3)
      Tests  8 failed | 6 passed (14)
```

What passes in that leg carries the compatibility claim. **Both adapters' default-endpoint cases pass before the change as well as after** — a shipped-endpoint install keeps `{ provider, model }` and does not rebuild. Only the custom-endpoint and custom-header cases move, which is the intended scope.

The four helper failures are the helper not existing yet: `buildEmbeddingEndpointCacheIdentity` is what this PR adds, so pre-fix there is nothing to call.

Green with the fix in place, same command:

```
 Test Files  3 passed (3)
      Tests  14 passed (14)
```

`pnpm check:changed` is green on this head, and oxlint, oxfmt, tsgo and `git diff --check` are clean.

### Sibling surfaces

Ollama already scopes by endpoint ([#97059](https://github.com/openclaw/openclaw/pull/97059)), and this change puts Mistral and DeepInfra on the same rule through one shared helper rather than a third inlined copy. The exclusion list matches the one that PR established, so the three adapters agree on which headers are identity and which are authentication.

### What was not covered

**DeepInfra** is the adapter exercised end to end at runtime here; Mistral shares the same helper and is covered by its own focused tests rather than by a second CLI run. (The earlier transcripts on this PR ran Mistral instead — the run was switched to DeepInfra because that is the adapter whose file [#114727](https://github.com/openclaw/openclaw/pull/114727) moved, so the endpoint scoping is proven at its new location.)

The two endpoints are local stand-ins, so nothing here says anything about the vectors either real provider returns — the point is which endpoint gets asked, and under which identity the answer is stored. No real DeepInfra or Mistral account is contacted in any of these runs.
