### PR TITLE
fix(openshell): mirror sandboxes can modify workspace skill files despite read-only policy

### DIFF
--- a/extensions/openshell/src/backend.ts
+++ b/extensions/openshell/src/backend.ts
@@ -46,6 +46,11 @@ type PendingExec = {
 };
 
 const MATERIALIZED_SKILLS_REMOTE_PARTS = [".openclaw", "sandbox-skills"] as const;
+const PROTECTED_SKILL_ROOT_PARTS: readonly (readonly string[])[] = [
+  MATERIALIZED_SKILLS_REMOTE_PARTS,
+  ["skills"],
+  [".agents", "skills"],
+];
 function buildOpenShellDirectoryUploadArgs(params: {
   sandboxName: string;
   localPath: string;
@@ -812,10 +817,17 @@ class OpenShellSandboxBackendImpl {
           throw new Error(result.stderr.trim() || "openshell sandbox download failed");
         }
         await removeMaterializedSkillsFromDownloadedWorkspace(tmpDir);
-        const preservedSandboxSkills = await moveMaterializedSkillsShadowAside({
-          workspaceDir: this.params.createParams.workspaceDir,
-          tmpDir,
-        });
+        const preservedSkillRoots: PreservedSkillRoot[] = [];
+        for (const parts of PROTECTED_SKILL_ROOT_PARTS) {
+          const preserved = await moveProtectedSkillRootAside({
+            workspaceDir: this.params.createParams.workspaceDir,
+            tmpDir,
+            parts,
+          });
+          if (preserved) {
+            preservedSkillRoots.push({ parts, preserved });
+          }
+        }
         try {
           await replaceDirectoryContents({
             sourceDir: tmpDir,
@@ -825,9 +837,9 @@ class OpenShellSandboxBackendImpl {
             excludeDirs: DEFAULT_OPEN_SHELL_MIRROR_EXCLUDE_DIRS,
           });
         } finally {
-          await restoreMaterializedSkillsShadow({
+          await restoreProtectedSkillRoots({
             workspaceDir: this.params.createParams.workspaceDir,
-            preserved: preservedSandboxSkills,
+            preservedSkillRoots,
           });
         }
       },
@@ -929,11 +941,35 @@ async function removeMaterializedSkillsFromDownloadedWorkspace(tmpDir: string): 
   }
 }
 
-async function moveMaterializedSkillsShadowAside(params: {
+type PreservedSkillRoot = {
+  parts: readonly string[];
+  preserved: { preservedPath: string; preserveRoot: string };
+};
+
+async function restoreProtectedSkillRoots(params: {
+  workspaceDir: string;
+  preservedSkillRoots: PreservedSkillRoot[];
+}): Promise<void> {
+  const restores = await Promise.allSettled(
+    params.preservedSkillRoots.map(
+      async ({ parts, preserved }) =>
+        await restoreProtectedSkillRoot({ workspaceDir: params.workspaceDir, preserved, parts }),
+    ),
+  );
+  const failedRestore = restores.find(
+    (entry): entry is PromiseRejectedResult => entry.status === "rejected",
+  );
+  if (failedRestore) {
+    throw failedRestore.reason;
+  }
+}
+
+async function moveProtectedSkillRootAside(params: {
   workspaceDir: string;
   tmpDir: string;
+  parts: readonly string[];
 }): Promise<{ preservedPath: string; preserveRoot: string } | undefined> {
-  const shadowPath = path.join(params.workspaceDir, ...MATERIALIZED_SKILLS_REMOTE_PARTS);
+  const shadowPath = path.join(params.workspaceDir, ...params.parts);
   const parentStats = await fs.lstat(path.dirname(shadowPath)).catch(() => null);
   if (!parentStats?.isDirectory() || parentStats.isSymbolicLink()) {
     return undefined;
@@ -945,25 +981,25 @@ async function moveMaterializedSkillsShadowAside(params: {
   const preserveRoot = await fs.mkdtemp(
     path.join(path.dirname(params.tmpDir), "openclaw-openshell-preserve-"),
   );
-  const preservedPath = path.join(preserveRoot, "sandbox-skills");
+  const preservedPath = path.join(preserveRoot, "preserved");
   await movePathWithCopyFallback({ from: shadowPath, to: preservedPath });
   return { preservedPath, preserveRoot };
 }
 
-async function restoreMaterializedSkillsShadow(params: {
+async function restoreProtectedSkillRoot(params: {
   workspaceDir: string;
-  preserved?: { preservedPath: string; preserveRoot: string };
+  preserved: { preservedPath: string; preserveRoot: string };
+  parts: readonly string[];
 }): Promise<void> {
-  if (!params.preserved) {
-    return;
-  }
   let restored = false;
   try {
-    const shadowPath = path.join(params.workspaceDir, ...MATERIALIZED_SKILLS_REMOTE_PARTS);
+    const shadowPath = path.join(params.workspaceDir, ...params.parts);
     const parentPath = path.dirname(shadowPath);
     const parentStats = await fs.lstat(parentPath).catch(() => null);
     if (parentStats?.isSymbolicLink()) {
-      throw new Error(`Refusing to restore sandbox skills through symlink parent: ${parentPath}`);
+      throw new Error(
+        `Refusing to restore protected skill root through symlink parent: ${parentPath}`,
+      );
     }
     if (parentStats && !parentStats.isDirectory()) {
       await fs.rm(parentPath, { recursive: true, force: true });

--- a/extensions/openshell/src/backend.ts
+++ b/extensions/openshell/src/backend.ts
@@ -975,7 +975,7 @@ async function moveProtectedSkillRootAside(params: {
     return undefined;
   }
   const shadowStats = await fs.lstat(shadowPath).catch(() => null);
-  if (!shadowStats || shadowStats.isSymbolicLink()) {
+  if (!shadowStats?.isDirectory() || shadowStats.isSymbolicLink()) {
     return undefined;
   }
   const preserveRoot = await fs.mkdtemp(

--- a/extensions/openshell/src/backend.ts
+++ b/extensions/openshell/src/backend.ts
@@ -29,7 +29,7 @@ import {
   type OpenShellExecContext,
 } from "./cli.js";
 import { resolveOpenShellPluginConfig, type ResolvedOpenShellPluginConfig } from "./config.js";
-import { createOpenShellFsBridge } from "./fs-bridge.js";
+import { createOpenShellFsBridge, WORKSPACE_SKILL_ROOT_PARTS } from "./fs-bridge.js";
 import {
   DEFAULT_OPEN_SHELL_MIRROR_EXCLUDE_DIRS,
   movePathWithCopyFallback,
@@ -48,8 +48,7 @@ type PendingExec = {
 const MATERIALIZED_SKILLS_REMOTE_PARTS = [".openclaw", "sandbox-skills"] as const;
 const PROTECTED_SKILL_ROOT_PARTS: readonly (readonly string[])[] = [
   MATERIALIZED_SKILLS_REMOTE_PARTS,
-  ["skills"],
-  [".agents", "skills"],
+  ...WORKSPACE_SKILL_ROOT_PARTS,
 ];
 function buildOpenShellDirectoryUploadArgs(params: {
   sandboxName: string;

--- a/extensions/openshell/src/fs-bridge.ts
+++ b/extensions/openshell/src/fs-bridge.ts
@@ -1,4 +1,5 @@
 // Openshell plugin module implements fs bridge behavior.
+import fsSync from "node:fs";
 import fsPromises from "node:fs/promises";
 import path from "node:path";
 import { root as fsRoot } from "openclaw/plugin-sdk/file-access-runtime";
@@ -21,6 +22,10 @@ type FsSafeRoot = Awaited<ReturnType<typeof fsRoot>>;
 type FsSafeStat = Awaited<ReturnType<FsSafeRoot["stat"]>>;
 
 const MATERIALIZED_SKILLS_CONTAINER_PARTS = [".openclaw", "sandbox-skills", "skills"] as const;
+const WORKSPACE_SKILL_ROOT_PARTS: readonly (readonly string[])[] = [
+  ["skills"],
+  [".agents", "skills"],
+];
 
 export function createOpenShellFsBridge(params: {
   sandbox: OpenShellFsBridgeContext;
@@ -269,7 +274,9 @@ class OpenShellFsBridge implements SandboxFsBridge {
           ? path.posix.join(workspaceContainerRoot, relative)
           : workspaceContainerRoot,
         mountHostRoot: workspaceRoot,
-        writable: this.sandbox.workspaceAccess === "rw",
+        writable:
+          this.sandbox.workspaceAccess === "rw" &&
+          !isProtectedWorkspaceSkillPath({ mountRoot: workspaceRoot, relative }),
         source: "workspace",
       };
     }
@@ -287,7 +294,9 @@ class OpenShellFsBridge implements SandboxFsBridge {
           ? path.posix.join(agentContainerRoot, relative)
           : agentContainerRoot,
         mountHostRoot: agentRoot,
-        writable: this.sandbox.workspaceAccess === "rw",
+        writable:
+          this.sandbox.workspaceAccess === "rw" &&
+          !isProtectedWorkspaceSkillPath({ mountRoot: agentRoot, relative }),
         source: "agent",
       };
     }
@@ -316,7 +325,9 @@ class OpenShellFsBridge implements SandboxFsBridge {
           ? path.posix.join(workspaceContainerRoot, relative)
           : workspaceContainerRoot,
         mountHostRoot: workspaceRoot,
-        writable: this.sandbox.workspaceAccess === "rw",
+        writable:
+          this.sandbox.workspaceAccess === "rw" &&
+          !isProtectedWorkspaceSkillPath({ mountRoot: workspaceRoot, relative }),
         source: "workspace",
       };
     }
@@ -346,7 +357,9 @@ class OpenShellFsBridge implements SandboxFsBridge {
           ? path.posix.join(agentContainerRoot, relative)
           : agentContainerRoot,
         mountHostRoot: agentRoot,
-        writable: this.sandbox.workspaceAccess === "rw",
+        writable:
+          this.sandbox.workspaceAccess === "rw" &&
+          !isProtectedWorkspaceSkillPath({ mountRoot: agentRoot, relative }),
         source: "agent",
       };
     }
@@ -509,6 +522,21 @@ function isNotFoundError(err: unknown): boolean {
       "code" in err &&
       (err as { code?: unknown }).code === "ENOENT")
   );
+}
+
+function isProtectedWorkspaceSkillPath(params: { mountRoot: string; relative: string }): boolean {
+  for (const parts of WORKSPACE_SKILL_ROOT_PARTS) {
+    const root = path.posix.join(...parts);
+    if (params.relative !== root && !params.relative.startsWith(`${root}/`)) {
+      continue;
+    }
+    try {
+      return fsSync.lstatSync(path.join(params.mountRoot, ...parts)).isDirectory();
+    } catch {
+      return false;
+    }
+  }
+  return false;
 }
 
 function resolveProtectedSkillTarget(params: {

--- a/extensions/openshell/src/fs-bridge.ts
+++ b/extensions/openshell/src/fs-bridge.ts
@@ -22,7 +22,7 @@ type FsSafeRoot = Awaited<ReturnType<typeof fsRoot>>;
 type FsSafeStat = Awaited<ReturnType<FsSafeRoot["stat"]>>;
 
 const MATERIALIZED_SKILLS_CONTAINER_PARTS = [".openclaw", "sandbox-skills", "skills"] as const;
-const WORKSPACE_SKILL_ROOT_PARTS: readonly (readonly string[])[] = [
+export const WORKSPACE_SKILL_ROOT_PARTS: readonly (readonly string[])[] = [
   ["skills"],
   [".agents", "skills"],
 ];

--- a/extensions/openshell/src/openshell-core.test.ts
+++ b/extensions/openshell/src/openshell-core.test.ts
@@ -538,6 +538,43 @@ describe("openshell backend manager", () => {
     );
   });
 
+  it("syncs a non-directory skills entry like ordinary workspace files", async () => {
+    const workspaceDir = await makeTempDir("openclaw-openshell-workspace-");
+    await fs.writeFile(path.join(workspaceDir, "skills"), "local file", "utf8");
+    cliMocks.runOpenShellCli.mockImplementation(async ({ args }: { args: string[] }) => {
+      if (args[0] === "sandbox" && args[1] === "download") {
+        const tmpDir = expectDefined(args[4], "OpenShell download destination");
+        await fs.writeFile(path.join(tmpDir, "skills"), "sandbox edit", "utf8");
+      }
+      return { code: 0, stdout: "", stderr: "" };
+    });
+
+    const factory = createOpenShellSandboxBackendFactory({
+      pluginConfig: resolveOpenShellPluginConfig({
+        command: "openshell",
+        mode: "mirror",
+      }),
+    });
+    const backend = await factory({
+      sessionKey: "agent:main:turn",
+      scopeKey: "agent:main",
+      workspaceDir,
+      agentWorkspaceDir: workspaceDir,
+      cfg: createOpenShellBackendSandboxConfig(),
+    });
+
+    await backend.finalizeExec?.({
+      status: "completed",
+      exitCode: 0,
+      timedOut: false,
+      token: undefined,
+    });
+
+    await expect(fs.readFile(path.join(workspaceDir, "skills"), "utf8")).resolves.toBe(
+      "sandbox edit",
+    );
+  });
+
   it("drops non-directory materialized sandbox skills from mirror downloads", async () => {
     const workspaceDir = await makeTempDir("openclaw-openshell-workspace-");
     cliMocks.runOpenShellCli.mockImplementation(async ({ args }: { args: string[] }) => {

--- a/extensions/openshell/src/openshell-core.test.ts
+++ b/extensions/openshell/src/openshell-core.test.ts
@@ -486,6 +486,58 @@ describe("openshell backend manager", () => {
     }
   });
 
+  it("preserves workspace skill roots when mirror sync downloads modified copies", async () => {
+    const workspaceDir = await makeTempDir("openclaw-openshell-workspace-");
+    const projectSkill = path.join(workspaceDir, "skills", "demo", "SKILL.md");
+    const agentsSkill = path.join(workspaceDir, ".agents", "skills", "demo", "SKILL.md");
+    await fs.mkdir(path.dirname(projectSkill), { recursive: true });
+    await fs.mkdir(path.dirname(agentsSkill), { recursive: true });
+    await fs.writeFile(projectSkill, "local skill", "utf8");
+    await fs.writeFile(agentsSkill, "local agent skill", "utf8");
+    cliMocks.runOpenShellCli.mockImplementation(async ({ args }: { args: string[] }) => {
+      if (args[0] === "sandbox" && args[1] === "download") {
+        const tmpDir = expectDefined(args[4], "OpenShell download destination");
+        await fs.writeFile(path.join(tmpDir, "from-remote.txt"), "remote", "utf8");
+        await fs.mkdir(path.join(tmpDir, "skills", "demo"), { recursive: true });
+        await fs.writeFile(path.join(tmpDir, "skills", "demo", "SKILL.md"), "tampered", "utf8");
+        await fs.mkdir(path.join(tmpDir, ".agents", "skills", "demo"), { recursive: true });
+        await fs.writeFile(
+          path.join(tmpDir, ".agents", "skills", "demo", "SKILL.md"),
+          "tampered",
+          "utf8",
+        );
+      }
+      return { code: 0, stdout: "", stderr: "" };
+    });
+
+    const factory = createOpenShellSandboxBackendFactory({
+      pluginConfig: resolveOpenShellPluginConfig({
+        command: "openshell",
+        mode: "mirror",
+      }),
+    });
+    const backend = await factory({
+      sessionKey: "agent:main:turn",
+      scopeKey: "agent:main",
+      workspaceDir,
+      agentWorkspaceDir: workspaceDir,
+      cfg: createOpenShellBackendSandboxConfig(),
+    });
+
+    await backend.finalizeExec?.({
+      status: "completed",
+      exitCode: 0,
+      timedOut: false,
+      token: undefined,
+    });
+
+    await expect(fs.readFile(projectSkill, "utf8")).resolves.toBe("local skill");
+    await expect(fs.readFile(agentsSkill, "utf8")).resolves.toBe("local agent skill");
+    await expect(fs.readFile(path.join(workspaceDir, "from-remote.txt"), "utf8")).resolves.toBe(
+      "remote",
+    );
+  });
+
   it("drops non-directory materialized sandbox skills from mirror downloads", async () => {
     const workspaceDir = await makeTempDir("openclaw-openshell-workspace-");
     cliMocks.runOpenShellCli.mockImplementation(async ({ args }: { args: string[] }) => {
@@ -1352,6 +1404,90 @@ describe("openshell fs bridges", () => {
     ).rejects.toThrow(/read-only/);
     expect(await fs.readFile(shadowFile, "utf8")).toContain("workspace shadow");
     expect(backend["syncLocalPathToRemote"]).not.toHaveBeenCalled();
+  });
+
+  it("rejects mutations of workspace skill roots through the mirror bridge", async () => {
+    const workspaceDir = await makeTempDir("openclaw-openshell-fs-");
+    const projectSkill = path.join(workspaceDir, "skills", "demo", "SKILL.md");
+    const agentsSkill = path.join(workspaceDir, ".agents", "skills", "demo", "SKILL.md");
+    await fs.mkdir(path.dirname(projectSkill), { recursive: true });
+    await fs.mkdir(path.dirname(agentsSkill), { recursive: true });
+    await fs.writeFile(projectSkill, "original", "utf8");
+    await fs.writeFile(agentsSkill, "original", "utf8");
+    await fs.writeFile(path.join(workspaceDir, "notes.txt"), "notes", "utf8");
+
+    const backend = createMirrorBackendMock();
+    const sandbox = createSandboxTestContext({
+      overrides: {
+        backendId: "openshell",
+        workspaceDir,
+        agentWorkspaceDir: workspaceDir,
+        workspaceAccess: "rw",
+        containerWorkdir: "/sandbox",
+      },
+    });
+
+    const { createOpenShellFsBridge } = await import("./fs-bridge.js");
+    const bridge = createOpenShellFsBridge({ sandbox, backend });
+
+    await expect(
+      bridge.writeFile({ filePath: "/sandbox/skills/demo/SKILL.md", data: "updated" }),
+    ).rejects.toThrow(/read-only/);
+    await expect(
+      bridge.writeFile({ filePath: ".agents/skills/demo/SKILL.md", data: "updated" }),
+    ).rejects.toThrow(/read-only/);
+    await expect(bridge.writeFile({ filePath: projectSkill, data: "updated" })).rejects.toThrow(
+      /read-only/,
+    );
+    await expect(
+      bridge.writeFile({ filePath: "/sandbox/skills/../skills/demo/SKILL.md", data: "updated" }),
+    ).rejects.toThrow(/read-only/);
+    await expect(bridge.mkdirp({ filePath: "skills/injected" })).rejects.toThrow(/read-only/);
+    await expect(
+      bridge.remove({ filePath: "/sandbox/.agents/skills/demo/SKILL.md" }),
+    ).rejects.toThrow(/read-only/);
+    await expect(bridge.rename({ from: "skills/demo/SKILL.md", to: "stolen.md" })).rejects.toThrow(
+      /read-only/,
+    );
+    await expect(
+      bridge.rename({ from: "notes.txt", to: "skills/demo/planted.md" }),
+    ).rejects.toThrow(/read-only/);
+
+    await expect(bridge.readFile({ filePath: "skills/demo/SKILL.md" })).resolves.toEqual(
+      Buffer.from("original"),
+    );
+    await bridge.writeFile({ filePath: "notes.txt", data: "updated" });
+
+    await expect(fs.readFile(projectSkill, "utf8")).resolves.toBe("original");
+    await expect(fs.readFile(agentsSkill, "utf8")).resolves.toBe("original");
+    await expect(fs.readFile(path.join(workspaceDir, "notes.txt"), "utf8")).resolves.toBe(
+      "updated",
+    );
+    await expectPathMissing(path.join(workspaceDir, "skills", "injected"));
+    expect(backend["syncLocalPathToRemote"]).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps missing workspace skill roots writable in the mirror bridge", async () => {
+    const workspaceDir = await makeTempDir("openclaw-openshell-fs-");
+    const backend = createMirrorBackendMock();
+    const sandbox = createSandboxTestContext({
+      overrides: {
+        backendId: "openshell",
+        workspaceDir,
+        agentWorkspaceDir: workspaceDir,
+        workspaceAccess: "rw",
+        containerWorkdir: "/sandbox",
+      },
+    });
+
+    const { createOpenShellFsBridge } = await import("./fs-bridge.js");
+    const bridge = createOpenShellFsBridge({ sandbox, backend });
+
+    await bridge.writeFile({ filePath: "skills/demo/SKILL.md", data: "created", mkdir: true });
+
+    await expect(
+      fs.readFile(path.join(workspaceDir, "skills", "demo", "SKILL.md"), "utf8"),
+    ).resolves.toBe("created");
   });
 
   it("rejects reads of a symlinked leaf", async () => {


### PR DESCRIPTION
Related: #17931

## What Problem This Solves

Fixes an issue where an OpenShell sandbox in its default mirror mode with `workspaceAccess: "rw"` could modify workspace skill instructions that every other sandbox backend treats as read-only.

Skill roots are supposed to stay owner-controlled inside writable sandboxes. Docker workspace mounts (`src/agents/sandbox/workspace-mounts.ts`) mount `skills/`, `.agents/skills/`, and `.openclaw/sandbox-skills/skills/` read-only, and the remote sandbox fs bridge (`src/agents/sandbox/remote-fs-bridge.ts`) rejects mutations under the same three roots. The OpenShell mirror backend enforced this policy only for the materialized `.openclaw/sandbox-skills/skills/` root. The other two skill roots fell through to the generic writable workspace mapping, on two surfaces:

1. Filesystem tools: `createOpenShellFsBridge` resolved `skills/...` and `.agents/skills/...` as writable, so write, mkdirp, remove, and rename mutated the host copies of `SKILL.md` files directly.
2. Shell execution plus mirror sync: a sandbox command could edit `/sandbox/skills/...` remotely, and `finalizeExec` mirror download copied the edited files back over the local workspace. Only `.openclaw/sandbox-skills` had preservation handling.

Since skill files are instructions consumed by later agent sessions, a writable mirror sandbox could persistently change future agent behavior on the host workspace.

## Why This Change Was Made

The OpenShell mirror backend kept a backend-specific protected-root list containing only the materialized skills root, instead of the full skill-root policy that #90798 established for Docker and the remote bridge. This change closes the gap at the same two seams the backend already uses for the materialized root, and both seams now read the same list.

`extensions/openshell/src/fs-bridge.ts` owns the policy list:

```ts
export const WORKSPACE_SKILL_ROOT_PARTS: readonly (readonly string[])[] = [
  ["skills"],
  [".agents", "skills"],
];
```

`resolveTarget` previously classified any workspace or agent mapping as writable:

```ts
writable: this.sandbox.workspaceAccess === "rw",
```

Now every workspace and agent mapping also checks the normalized relative path against that list, matching the exists-gated semantics of the sibling backends (a root is protected when it exists as a real directory on the host, exactly like Docker only mounts existing skill directories read-only and the remote bridge only rejects when the remote root exists):

```ts
writable:
  this.sandbox.workspaceAccess === "rw" &&
  !isProtectedWorkspaceSkillPath({ mountRoot: workspaceRoot, relative }),
```

The check runs on the already-normalized relative path from `path.relative`/`path.posix.relative`, so `.` and `..` segments are resolved before matching and sibling names such as `skills-backup/` never match. All mutation operations (`writeFile`, `mkdirp`, `remove`, both rename endpoints via the shared writable-rename resolver) route through this resolution, and reads are unaffected.

In `extensions/openshell/src/backend.ts`, `syncWorkspaceFromRemote` previously moved only `.openclaw/sandbox-skills` aside before replacing the workspace with the downloaded mirror. The existing move-aside and restore helpers are now parameterized over the protected root parts and applied to the materialized root plus the same shared list:

```ts
const PROTECTED_SKILL_ROOT_PARTS: readonly (readonly string[])[] = [
  MATERIALIZED_SKILLS_REMOTE_PARTS,
  ...WORKSPACE_SKILL_ROOT_PARTS,
];
```

So local skill roots survive the downloaded workspace replacement and sandbox-side edits of them are discarded. Preservation applies only when the local root is a real directory (per the Codex review finding on the first revision): a workspace with a regular file named `skills` or `.agents/skills` is not a skill root under any backend policy, so such files keep syncing like ordinary workspace files.

Both changes reuse the existing single-root mechanisms rather than adding a second policy path; the materialized-root handling stops being a special case, and there is one workspace skill-root list behind both OpenShell seams instead of two copies of the same literals.

## User Impact

- Operators running OpenShell mirror sandboxes with a writable workspace get the same guarantee as Docker and remote sandboxes: sandboxed agents and commands cannot change `skills/` or `.agents/skills/` on the host.
- Ordinary workspace files keep the configured `workspaceAccess` behavior, mirror sync for them is unchanged, and skill files remain readable inside the sandbox.
- Workspaces without a `skills/` or `.agents/skills/` directory behave exactly as before, matching the other backends.

## Evidence

### How the runtime was driven

The real sandbox stack was driven end to end through `resolveSandboxContext` (`src/agents/sandbox/context.ts`), the production entry that resolves the sandbox config for the agent, builds the `SandboxContext`, calls the registered sandbox backend factory, and wires the fs bridge. The OpenShell backend was registered exactly the way `extensions/openshell/index.ts` registers it (`createOpenShellSandboxBackendFactory` plus `createOpenShellSandboxBackendManager`), in mirror mode with `workspaceAccess: "rw"` on a real on-disk workspace. The only substituted component is the external `openshell` CLI executable itself, replaced at the `config.command` boundary by a real subprocess whose `sandbox download` writes sandbox-side edits into the download directory. The sandbox context resolution, backend, fs bridge, mirror sync, and on-disk workspace are production code.

The same driver ran on pristine main `f8cc39ce62139f689d474ea86c67bf9ad23ab30f` (the two changed production files reverted in place, everything else identical) and on this branch head `a28b2fec87f671aa5114dd1f79eca2c9a0f18eb0`, with identical inputs. The output is in the `Real behavior proof` block below.

On pristine main both skill paths resolve as writable, so the host `SKILL.md` files are already overwritten with `updated-via-fs-tool` by the time the bridge reaches its remote push leg. That leg then fails at the substituted CLI boundary, which is why the run still reports an error, but the host damage is done. With this change the same calls are rejected up front with `Sandbox path is read-only`, and the host files still read `original`. Mirror sync on pristine main replaces the host skill roots with the sandbox-side `tampered-by-sandbox-shell` copies; with this change both host skill roots survive the downloaded workspace replacement. The controls are unchanged between the runs: `/sandbox/notes.txt` is written on both sides, `from-remote.txt` syncs down on both sides, and a workspace entry that is a regular file named `skills` rather than a directory keeps syncing on both sides. Only the two protected skill root directories change behavior.

### Protected-root parity with the sibling backends

Source-level comparison against current `main` at `f8cc39ce62`, covering every write seam that can reach a host skill root in OpenShell mirror mode:

| Seam | Docker (`workspace-mounts.ts`) | Remote bridge (`remote-fs-bridge.ts`) | OpenShell mirror after this change |
| --- | --- | --- | --- |
| `skills/` | `-v host:container:ro` when the host path is an existing directory (`isExistingWorkspaceSkillMountSource`) | `getRemoteProtectedSkillRoots` plus `assertRemoteProtectedPathWritable`, gated on remote existence | `writable: false` for every workspace and agent mapping, gated on `lstat(...).isDirectory()`, plus mirror-download preservation |
| `.agents/skills/` | same | same | same |
| `.openclaw/sandbox-skills/skills/` | mounted read-only from the materialized skills workspace | listed as a protected root | already handled before this PR by `resolveProtectedSkillTarget` and `resolveProtectedSkillShadowTarget` (`writable: false`, `source: "protectedSkill"`), and preserved by mirror sync |

Path forms checked against the OpenShell resolver, since it matches on a relative path rather than on a mount table:

- Container-absolute (`/sandbox/skills/...`) and agent-container-absolute (`/agent/skills/...`): matched, because the relative path comes from `path.posix.relative` after the container-root prefix check.
- Host-absolute (`<workspaceDir>/skills/...`) and cwd-relative (`skills/...`): matched through the `isPathInside(workspaceRoot, hostPath)` branch, where the relative path comes from `path.relative` and is converted to posix separators.
- Traversal forms (`/sandbox/skills/../skills/demo/SKILL.md`, `/sandbox/foo/../skills/...`): normalized by `path.posix.relative`/`path.resolve` before the match, so they are rejected. Covered by a regression test.
- Sibling names (`skills-backup/`, `myskills/`): not matched, because the comparison is an exact root or a `root/` prefix.
- Symlinked ancestors (a writable `link -> skills` then `link/demo/SKILL.md`): rejected by the pre-existing `assertLocalPathSafety` walk, which fails any non-final symlink segment on every mutation, so no resolution-time bypass exists.
- Both rename endpoints: `createWritableRenameTargetResolver` (`src/agents/sandbox/fs-bridge-rename-targets.ts`) calls `ensureWritable` on the source and the destination, so neither renaming a skill file out nor planting one in is possible. Covered by regression tests.

Replacement paths on the mirror-sync seam:

- `syncWorkspaceFromRemote` is the only code path in the backend that writes host workspace content from remote content; every other remote mutation helper (`mkdirpRemotePath`, `removeRemotePath`, `renameRemotePath`, `syncLocalPathToRemote`) is host-to-remote or remote-only and is reached only after the fs bridge has already authorized the path.
- If the downloaded mirror contains a symlink or a regular file where a protected root belongs, `restoreProtectedSkillRoot` removes that entry (`fs.rm`, which unlinks a symlink rather than following it) before moving the preserved directory back, and refuses to restore through a symlinked parent.

The one deliberate difference from Docker: a skill root that does not exist when the sandbox starts stays writable under Docker for that container's lifetime, while OpenShell re-checks existence per operation, so OpenShell becomes protective as soon as the directory exists. That matches the remote bridge, which also re-checks per operation.

### Local validation at this head

- `node scripts/run-vitest.mjs extensions/openshell/src`: 4 files, 60 tests passed, including the regression tests added here (fs bridge mutations rejected across relative, absolute container, absolute host, and `..`-normalized paths for both roots plus rename in and out; mirror download preservation of both roots; missing skill roots stay writable; a regular file named `skills` keeps syncing).
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/openshell` clean, `oxfmt --check` clean on the three changed files, `tsgo -p tsconfig.extensions.json` and `tsgo -p test/tsconfig/tsconfig.extensions.test.json` clean.

### Review follow-ups

- Codex P2 (preserve only real skill directories): fixed on the second commit; mirror sync now moves a protected root aside only when the local root is a real directory, and a regression test pins that a regular file named `skills` keeps syncing.
- Review request to confirm parity across all protected-root write seams: done above, against current `main`, covering path forms, both rename endpoints, symlinked ancestors, and the mirror-download replacement path.
- Review question about whether an existing shared policy helper should own the invariant: there is no such helper reachable from a plugin. Core repeats the same skill-root literals in `workspace-mounts.ts`, `remote-fs-bridge-paths.ts`, and `remote-fs-bridge.ts`, and none of them is exported through `openclaw/plugin-sdk/*`. This PR therefore keeps one list per backend rather than two lists inside OpenShell, and both OpenShell seams now read `WORKSPACE_SKILL_ROOT_PARTS`. Promoting a single cross-backend policy API into the plugin SDK would touch three core sandbox modules and the Docker and remote bridges; that is a sandbox-owner refactor and is deliberately not bundled into this security fix.
- Automated note about a persistent data-model change in `extensions/openshell/src/openshell-core.test.ts`: that file is the extension test suite. This PR adds no persisted state, no schema, and no stored format, so there is nothing to migrate.
- The branch is rebased onto current `main` `f8cc39ce62` and the proof below is regenerated against this exact head.

## Real behavior proof
Behavior addressed: an OpenShell mirror sandbox with a writable workspace could overwrite host `skills/` and `.agents/skills/` instruction files, through filesystem tools and through mirror sync of sandbox-side edits, while Docker and remote sandboxes keep those roots read-only.
Real environment tested: production `resolveSandboxContext` resolving a mirror-mode OpenShell sandbox with `workspaceAccess: "rw"` on a real on-disk workspace, with the registered OpenShell backend, its fs bridge, and `finalizeExec` mirror sync, run on pristine main `f8cc39ce62139f689d474ea86c67bf9ad23ab30f` and on this branch head `a28b2fec87f671aa5114dd1f79eca2c9a0f18eb0` with identical inputs. Only the external `openshell` executable is substituted, at the `config.command` boundary, by a real subprocess.
Exact steps or command run after this patch: resolve the sandbox context for `agent:main:proof` against a workspace containing `skills/demo/SKILL.md`, `.agents/skills/demo/SKILL.md`, and `notes.txt`, call `fsBridge.writeFile` on `/sandbox/skills/demo/SKILL.md`, `/sandbox/.agents/skills/demo/SKILL.md`, and `/sandbox/notes.txt`, then call `backend.finalizeExec` so mirror sync downloads a sandbox copy whose skill files read `tampered-by-sandbox-shell`, and read the host files back.
Evidence after fix:
```
# BEFORE (pristine main f8cc39ce6213)
fs tool write /sandbox/skills/demo/SKILL.md
  host file content now: "updated-via-fs-tool"
  write error: Failed to parse SSH config output.
fs tool write /sandbox/.agents/skills/demo/SKILL.md
  host file content now: "updated-via-fs-tool"
  write error: Failed to parse SSH config output.
fs tool write /sandbox/notes.txt
  host file content now: "updated-via-fs-tool"
  write error: Failed to parse SSH config output.
host skills/demo/SKILL.md after mirror sync: tampered-by-sandbox-shell
host .agents/skills/demo/SKILL.md after mirror sync: tampered-by-sandbox-shell
host from-remote.txt after mirror sync: remote
host regular file named "skills" after mirror sync: sandbox edit

# AFTER (this patch, identical inputs, head a28b2fec87f6)
fs tool write /sandbox/skills/demo/SKILL.md
  host file content now: "original"
  write error: Sandbox path is read-only; cannot write files: /sandbox/skills/demo/SKILL.md
fs tool write /sandbox/.agents/skills/demo/SKILL.md
  host file content now: "original"
  write error: Sandbox path is read-only; cannot write files: /sandbox/.agents/skills/demo/SKILL.md
fs tool write /sandbox/notes.txt
  host file content now: "updated-via-fs-tool"
host skills/demo/SKILL.md after mirror sync: original
host .agents/skills/demo/SKILL.md after mirror sync: original
host from-remote.txt after mirror sync: remote
host regular file named "skills" after mirror sync: sandbox edit
```
Observed result after fix: both host skill roots keep their original instruction files against filesystem writes and against the downloaded mirror, the rejection message names the read-only boundary, and the three controls (an ordinary workspace file, a file synced down from the sandbox, and a workspace entry that is a regular file named `skills`) behave identically on both runs.
What was not tested: a live OpenShell service endpoint, since the external CLI executable was substituted at the `config.command` boundary, so the remote push leg of an allowed write is not exercised end to end; the OpenShell remote mode path, which already uses the core remote fs bridge protections and is unchanged here; and a full `pnpm build`, which this change cannot affect.
