### PR TITLE
fix(linux): hide Quick Chat before widget cleanup

### DIFF
--- a/apps/linux/src-tauri/src/quickchat_widgets.rs
+++ b/apps/linux/src-tauri/src/quickchat_widgets.rs
@@ -218,7 +218,15 @@ impl QuickChatWidgetState {
             }
         }
         let labels = self.view_labels()?;
-        let (retained, cleanup_error) = Self::close_views(app, &labels, false);
+        if !labels.is_empty() {
+            app.get_webview_window(QUICKCHAT_LABEL)
+                .ok_or_else(|| "Quick Chat window is unavailable.".to_string())?
+                .hide()
+                .map_err(|error| {
+                    format!("Could not hide Quick Chat before renderer cleanup: {error}")
+                })?;
+        }
+        let (retained, cleanup_error) = Self::close_views(app, &labels, true);
         self.store_view_labels(retained)?;
         if let Some(error) = cleanup_error {
             return Err(error);


### PR DESCRIPTION
Related: #112261

## What Problem This Solves

Closes one fail-open renderer-replacement edge found by the post-land review of Linux Quick Chat widget lifecycle hardening. If stale child WebViews exist and a child cannot be hidden, session startup must not leave the visible parent window exposing stale content.

## Why This Change Was Made

Renderer-session replacement now hides the parent Quick Chat window before attempting retained child cleanup. Cleanup errors still propagate and retained labels remain tracked, but stale child content is masked by the hidden parent throughout the failure path.

## User Impact

A rare native child-WebView cleanup failure can no longer leave an old widget visible while a replacement renderer session is rejected.

## Evidence

- Focused autoreview: clean, no accepted/actionable findings.
- `node scripts/run-vitest.mjs test/linux-quickchat-stream.test.ts` — 19/19 passed.
- Rust formatting and diff checks passed.
- Parent follow-up PR #112261 had green exact-head CI, Linux App, Rust tests/build, and `pnpm check:changed`; this patch changes only the renderer-replacement cleanup ordering.

AI-assisted: yes. No agent transcript is attached.
