### PR TITLE
fix(gateway,cli-runner): SIGKILL teardown fallback + token-silence watchdog

### DIFF
--- a/src/agents/cli-runner/claude-live-session.ts
+++ b/src/agents/cli-runner/claude-live-session.ts
@@ -1174,7 +1174,11 @@ function handleClaudeLiveLine(session: ClaudeLiveSession, line: string): void {
 
 function handleClaudeStdout(session: ClaudeLiveSession, chunk: string) {
   session.currentTurn?.onCliOutput?.(chunk, "stdout");
-  resetNoOutputTimer(session);
+  // NOTE: the no-output watchdog is intentionally NOT reset here. Resetting on
+  // every stdout chunk (stream progress, tool events, heartbeats) let a turn
+  // that emitted noise but never real assistant text run forever. The timer is
+  // now re-armed only on genuine assistant-token / thinking progress via the
+  // parser's onAssistantDelta / onThinkingDelta hooks (see createTurn).
   session.stdoutBuffer += chunk;
   const maxPendingLineChars =
     session.currentTurn?.outputLimits.maxPendingLineChars ??
@@ -1337,7 +1341,10 @@ async function createClaudeLiveSession(params: {
             );
             return;
           }
-          resetNoOutputTimer(session);
+          // Intentionally do NOT reset the no-output watchdog on stderr bytes:
+          // stderr is progress/diagnostic noise, not assistant-token progress.
+          // The watchdog re-arms only on real assistant/thinking deltas (see
+          // createTurn).
         }
       },
     });
@@ -1431,8 +1438,25 @@ function createTurn(params: {
     streamingParser: createCliJsonlStreamingParser({
       backend: params.context.preparedBackend.backend,
       providerId: params.context.backendResolved.id,
-      onAssistantDelta: params.onAssistantDelta,
-      onThinkingDelta: params.onThinkingDelta,
+      // Re-arm the no-output watchdog only on real assistant-token progress
+      // (a parsed content_block_delta / assistant-text delta), NOT on every
+      // stdout/stderr byte. A hung-but-chatty turn that streams tool/heartbeat
+      // noise but never produces assistant text or a result must be allowed to
+      // trip the watchdog; the previous byte-level reset in handleClaudeStdout
+      // / the stderr handler kept re-arming it forever, so such a turn hung
+      // indefinitely with no abort emitted and the model-downgrade failover
+      // never fired.
+      onAssistantDelta: (delta) => {
+        resetNoOutputTimer(params.session);
+        params.onAssistantDelta(delta);
+      },
+      // Thinking deltas are genuine model progress too: a turn actively
+      // emitting reasoning tokens is alive and must not be killed by the
+      // token-silence watchdog.
+      onThinkingDelta: (delta) => {
+        resetNoOutputTimer(params.session);
+        params.onThinkingDelta?.(delta);
+      },
       onThinkingProgress: params.onThinkingProgress,
       onToolUseStart: (delta) => {
         markClaudeLiveToolStarted(turn, delta);

--- a/src/agents/cli-watchdog-defaults.ts
+++ b/src/agents/cli-watchdog-defaults.ts
@@ -1,9 +1,15 @@
 // Default watchdog timing bounds for CLI-backed agent sessions.
 export const CLI_WATCHDOG_MIN_TIMEOUT_MS = 1_000;
 
+// minMs is the floor for assistant-token silence on a fresh turn. Now that the
+// no-output watchdog re-arms only on real assistant-token / thinking progress
+// (not on every byte), 180s was needlessly slack: a genuine slow first token
+// after a large-prompt compaction lands in single-digit seconds, so a 90s floor
+// still never trips a live turn yet catches a hung turn an order of magnitude
+// sooner.
 export const CLI_FRESH_WATCHDOG_DEFAULTS = {
   noOutputTimeoutRatio: 0.8,
-  minMs: 180_000,
+  minMs: 90_000,
   maxMs: 600_000,
 } as const;
 

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -21,6 +21,26 @@ import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import { formatActiveTaskRestartBlocker } from "../../tasks/task-restart-blocker.js";
 const gatewayLog = createSubsystemLogger("gateway");
 const LAUNCHD_SUPERVISED_RESTART_EXIT_DELAY_MS = 1500;
+// Hard self-SIGKILL fallback after a launchd-supervised exitProcess(0). If the
+// graceful teardown hangs (e.g. a stuck async flush inside process.exit), the
+// process becomes a live-but-dead zombie: cleanupSignals() has already removed
+// our handlers and launchd KeepAlive only relaunches on a real EXIT, so nothing
+// recovers it. This timer guarantees a real EXIT within N ms so KeepAlive
+// relaunches. N=5000 sits well above the 1500ms handoff wait and an observed
+// ~118ms clean drain, so it is dead code on every healthy restart and never
+// truncates a legitimate flush, while capping the worst-case dark window at
+// ~6.5s instead of hours. MUST be .unref()'d so the fallback timer itself never
+// keeps the event loop alive and blocks the very clean exit it is guarding.
+const GATEWAY_TEARDOWN_SIGKILL_FALLBACK_MS = 5000;
+function armGatewayTeardownSigkillFallback(): void {
+  setTimeout(() => {
+    try {
+      process.kill(process.pid, "SIGKILL");
+    } catch {
+      // Best-effort: if the process is already gone this throws; nothing to do.
+    }
+  }, GATEWAY_TEARDOWN_SIGKILL_FALLBACK_MS).unref();
+}
 const DEFAULT_RESTART_DRAIN_TIMEOUT_MS = 300_000;
 const RESTART_DRAIN_STILL_PENDING_WARN_MS = 30_000;
 const RESTART_CLOSE_REPLY_DRAIN_SHUTDOWN_RESERVE_MS = 10_000;
@@ -283,6 +303,8 @@ export async function runGatewayLoop(params: {
           await new Promise((resolve) => {
             setTimeout(resolve, LAUNCHD_SUPERVISED_RESTART_EXIT_DELAY_MS);
           });
+          // Guard against a hung teardown becoming a launchd-invisible zombie.
+          armGatewayTeardownSigkillFallback();
         }
         exitProcess(0);
         return;
@@ -357,6 +379,8 @@ export async function runGatewayLoop(params: {
         await new Promise((resolve) => {
           setTimeout(resolve, LAUNCHD_SUPERVISED_RESTART_EXIT_DELAY_MS);
         });
+        // Guard against a hung teardown becoming a launchd-invisible zombie.
+        armGatewayTeardownSigkillFallback();
       }
       exitProcess(0);
       return;


### PR DESCRIPTION
> **Draft.** Two of three intended fixes are complete and surgical (3 files,
> ~59 lines); the third (same-model retry wiring) is deferred with a documented,
> unverified source mapping rather than guessed at. The full monorepo
> test/typecheck could not be run in the authoring environment (heap OOM on
> `tsc -p tsconfig.json`); per-file transpile is clean. Requesting review on fix
> shape + the deferred-wiring question before marking ready.

## Intent

Two OpenClaw "wedge"/hang failure modes reduce to the same anti-pattern — a
blocking await with no self-timeout to break it — at two different layers. Both
were root-caused from real outages:

1. **Gateway teardown zombie (~16h dark).** On a launchd-supervised restart the
   gateway calls `process.exit(0)` after a 1500ms handoff wait. When that
   teardown hangs, the process becomes live-but-dead: `cleanupSignals()` has
   already removed our signal handlers and launchd `KeepAlive` relaunches only on
   a real EXIT, so nothing recovers it.
2. **Token-silent CLI turn (~50 min hang).** The per-turn no-output watchdog
   reset on *every* stdout/stderr byte, so a hung-but-chatty turn (streams
   tool/heartbeat noise but never assistant text or a `result`) re-armed the
   timer forever and never tripped — no `abort` emitted, so the model-downgrade
   failover never fired.

## Changes (3 files)

**Fix A — SIGKILL teardown self-fallback** (`src/cli/gateway-cli/run-loop.ts`)
Immediately before each launchd-supervised `exitProcess(0)` in
`handleRestartAfterServerClose` (the full-process handoff and the twin
update-process handoff), arm a `.unref()`'d
`setTimeout(() => process.kill(process.pid, "SIGKILL"), 5000)`.
- `.unref()` is mandatory: without it the fallback timer would itself keep the
  event loop alive and block the very clean exit it guards.
- `N=5000` sits well above the 1500ms handoff wait and an observed ~118ms clean
  drain, so it is dead code on every healthy restart and never truncates a
  legitimate flush, while capping the worst-case dark window at ~6.5s.

**Fix B1 — token-silence watchdog re-scope** (`src/agents/cli-runner/claude-live-session.ts`)
Re-arm the no-output watchdog only on real model progress via the streaming
parser's `onAssistantDelta` and `onThinkingDelta` hooks (a parsed
`content_block_delta` / assistant-text or thinking delta). Remove the
unconditional byte-level resets in `handleClaudeStdout` and the stderr callback.

**Fix B2 — fresh floor 180s → 90s** (`src/agents/cli-watchdog-defaults.ts`)
With the reset now token-scoped, 180s was needlessly slack. 90s still never
trips a live turn (a slow first token after compaction lands in single-digit
seconds) yet catches a hung turn an order of magnitude sooner.

## Deferred (not in this PR): same-model retry wiring

The intended third element — route the `cli_no_output_timeout` abort through one
`same_model_idle_timeout` retry before the model-downgrade chain — is **not**
included because the source mapping is non-trivial and I did not want to guess:

- The retry hook exists: `sameModelIdleTimeoutRetry()`
  (`src/agents/embedded-agent-runner/run/assistant-failover.ts`,
  `retryKind: "same_model_idle_timeout"`).
- But `idleTimedOut = true` is set only by `idleTimeoutTrigger`
  (`src/agents/embedded-agent-runner/run/attempt.ts`), wired via
  `streamWithIdleTimeout(activeSession.agent.streamFn, …)` — the **direct-LLM
  stream path**, not the claude-cli live-session path.
- The live-session token-silence abort emits `FailoverError{reason:"timeout"}`
  (`createTimeoutError`), which classifies as `timedOut` but **not**
  `idleTimedOut`, so today it routes to the model-downgrade failover, not the
  same-model retry.

Wiring this means routing the live-session `cli_no_output_timeout` abort into
`idleTimeoutTrigger` (or an equivalent that sets `idleTimedOut` for the CLI
path), which crosses a module boundary into the attempt-loop classifier.
Deferred to a follow-up. **B1+B2 already deliver the load-bearing behaviour
change** (the watchdog now *trips* on a token-silent hang instead of hanging
forever); B3 only refines *recovery* (one same-model retry ahead of the
downgrade). Guidance welcome on whether upstream prefers the abort re-classified
as `idleTimedOut` for the CLI path vs a dedicated CLI retry hook.

## Acceptance Criteria (testable)

- **Fix A (induced-kill):** with a deliberately-hung supervised `process.exit(0)`
  (or SIGSTOP between the 1500ms wait and exit), the process is hard-killed
  within ~5s; `launchctl list | grep ai.openclaw.gateway` run-count increments
  and a fresh PID binds `127.0.0.1:18789`. Negative control: a normal supervised
  restart still exits in ~118ms with the fallback never firing.
- **Fix B1+B2:** a fake claude-cli that streams `stream_event`/tool JSONL but
  never a `content_block_delta` assistant-text line or a `result` aborts at ~90s
  (vs hanging forever under the old byte-level reset). Negative control: a stream
  emitting assistant-text/thinking deltas every <90s does not trip.

## Notes for reviewers

- Fix sites were root-caused in a shipped bundle and authored directly against
  current `main`; the diff is exactly these 3 files.
- Tracking issue: Digital Indies DIG-34.