### PR TITLE
fix(security): recognize SecretRef objects as externalized in gateway_password_in_config audit

### DIFF
--- a/src/security/audit-secrets-in-config.test.ts
+++ b/src/security/audit-secrets-in-config.test.ts
@@ -1,0 +1,81 @@
+// Covers secrets-in-config security audit findings for SecretRef externalization.
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import type { SecretRef } from "../config/types.secrets.js";
+import { collectSecretsInConfigFindings } from "./audit-extra.sync.js";
+import { collectSecurityAuditFindings } from "./audit.test-support.js";
+
+const GATEWAY_PASSWORD_CHECK_ID = "config.secrets.gateway_password_in_config";
+const HOOKS_TOKEN_CHECK_ID = "config.secrets.hooks_token_in_config";
+
+describe("collectSecretsInConfigFindings", () => {
+  it("warns when the gateway password is a plaintext literal", () => {
+    const cfg = {
+      gateway: { auth: { password: "plaintext-gateway-password" } },
+    } satisfies OpenClawConfig;
+
+    const findings = collectSecretsInConfigFindings(cfg);
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.checkId).toBe(GATEWAY_PASSWORD_CHECK_ID);
+    expect(findings[0]?.severity).toBe("warn");
+  });
+
+  it("does not warn when the gateway password uses an env template string", () => {
+    const cfg = {
+      gateway: { auth: { password: "${OPENCLAW_GATEWAY_PASSWORD}" } },
+    } satisfies OpenClawConfig;
+
+    expect(collectSecretsInConfigFindings(cfg)).toEqual([]);
+  });
+
+  it("reports info when the enabled hooks token is a plaintext literal", () => {
+    const cfg = {
+      hooks: { enabled: true, token: "plaintext-hooks-token" },
+    } satisfies OpenClawConfig;
+
+    const findings = collectSecretsInConfigFindings(cfg);
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.checkId).toBe(HOOKS_TOKEN_CHECK_ID);
+    expect(findings[0]?.severity).toBe("info");
+  });
+
+  it("reports no findings when no credentials are configured", () => {
+    expect(collectSecretsInConfigFindings({})).toEqual([]);
+  });
+});
+
+describe("security audit secrets-in-config source classification", () => {
+  it("does not warn when the resolved config holds plaintext materialized from a SecretRef", async () => {
+    // The CLI resolves command secrets before auditing, so the runtime config carries
+    // the plaintext value while the source config keeps the externalized SecretRef.
+    const findings = await collectSecurityAuditFindings(
+      { gateway: { auth: { password: "resolved-plaintext-password" } } },
+      {
+        sourceConfig: {
+          gateway: {
+            auth: {
+              password: {
+                source: "file",
+                provider: "local",
+                id: "/gatewayPassword",
+              } satisfies SecretRef,
+            },
+          },
+        },
+      },
+    );
+
+    expect(findings.some((finding) => finding.checkId === GATEWAY_PASSWORD_CHECK_ID)).toBe(false);
+  });
+
+  it("still warns when the source config stores a plaintext gateway password", async () => {
+    const findings = await collectSecurityAuditFindings(
+      { gateway: { auth: { password: "plaintext-gateway-password" } } },
+      { sourceConfig: { gateway: { auth: { password: "plaintext-gateway-password" } } } },
+    );
+
+    expect(findings.some((finding) => finding.checkId === GATEWAY_PASSWORD_CHECK_ID)).toBe(true);
+  });
+});

--- a/src/security/audit.ts
+++ b/src/security/audit.ts
@@ -1378,7 +1378,10 @@ export async function runSecurityAudit(opts: SecurityAuditOptions): Promise<Secu
   findings.push(...auditNonDeep.collectNodeDenyCommandPatternFindings(cfg));
   findings.push(...auditNonDeep.collectNodeDangerousAllowCommandFindings(cfg));
   findings.push(...auditNonDeep.collectMinimalProfileOverrideFindings(cfg));
-  findings.push(...auditNonDeep.collectSecretsInConfigFindings(cfg));
+  // "Secret stored in config" must inspect the on-disk source config: the resolved
+  // config materializes SecretRefs into plaintext, which would false-positive every
+  // externalized credential.
+  findings.push(...auditNonDeep.collectSecretsInConfigFindings(context.sourceConfig));
   findings.push(...auditNonDeep.collectModelHygieneFindings(cfg));
   findings.push(...auditNonDeep.collectSmallModelRiskFindings({ cfg, env }));
   findings.push(...auditNonDeep.collectExposureMatrixFindings(cfg));


### PR DESCRIPTION
## What Problem This Solves

`openclaw security audit` emitted `config.secrets.gateway_password_in_config` ("Gateway password is stored in config", severity `warn`) even when `gateway.auth.password` was a file/exec/env SecretRef rather than a plaintext literal. With a SecretRef, the secret is not in the config — only a reference is — so this was a false positive that steered operators away from the durable file/exec provider forms.

Fixes #111468

## Root Cause

The audit CLI resolves command secrets (`resolveCommandSecretRefsViaGateway`) before running the audit, so the runtime config passed to `runSecurityAudit` holds the **plaintext materialized from the SecretRef**. `collectSecretsInConfigFindings` — which reports whether a credential is *persisted in config* — was classifying against that resolved config, false-positiving every externalized credential. It now classifies against the on-disk **source config** (`context.sourceConfig`), matching the existing `collectGatewayConfigFindings(cfg, context.sourceConfig, ...)` source/resolved split.

## Evidence

Environment: macOS, OpenClaw 2026.7.2 built from this branch (`node openclaw.mjs`), isolated `OPENCLAW_STATE_DIR`. Verbatim terminal output below; only the sandbox path is redacted.

Setup (exact repro from the issue):

```text
$ openclaw config set secrets.providers.local \
  --provider-source file --provider-path ~/.openclaw-demo/secrets/service-secrets.json --provider-mode json
Updated secrets.providers.local. No gateway restart needed.
$ openclaw config set gateway.auth.password \
  --ref-provider local --ref-source file --ref-id /gatewayPassword
Updated gateway.auth.password. Restart the gateway to apply.
$ openclaw config validate
Config valid: ~/.openclaw-demo/state/openclaw.json
$ cat ~/.openclaw-demo/state/openclaw.json
# config holds a SecretRef, not a literal:
#   "gateway": { "auth": { "password": { "source": "file", "provider": "local", "id": "/gatewayPassword" } } }
```

**Before** (main behavior — `config.secrets.gateway_password_in_config` is raised, note `Summary: ... 2 warn`):

```text
$ openclaw security audit
OpenClaw security audit
Summary: 0 critical · 2 warn · 1 info
Run deeper: openclaw security audit --deep
[secrets] security audit: gateway secrets.resolve unavailable (gateway closed (1006 abnormal closure (no close frame)): no close reason
Gateway target: ws://127.0.0.1:18789
Source: local loopback
Config: ~/.openclaw-demo/state/openclaw.json
Bind: loopback

Possible causes:
- Connection dropped without a close frame (retry; check network and gateway load)
- Gateway not yet ready to accept connections (retry after a moment)
- TLS mismatch (connecting with ws:// to a wss:// gateway, or vice versa)
- Gateway process stopped or became unreachable (confirm it is still running)
Run `openclaw doctor` for diagnostics.); resolved command secrets locally.

WARN
gateway.trusted_proxies_missing Reverse proxy headers are not trusted
  gateway.bind is loopback and gateway.trustedProxies is empty. If you expose the Control UI through a reverse proxy, configure trusted proxies so local-client checks cannot be spoofed.
  Fix: Set gateway.trustedProxies to your proxy IPs or keep the Control UI local-only.
config.secrets.gateway_password_in_config Gateway password is stored in config
  gateway.auth.password is set in the config file; prefer environment variables for secrets when possible.
  Fix: Prefer OPENCLAW_GATEWAY_PASSWORD (env) and remove gateway.auth.password from disk.

INFO
summary.attack_surface Attack surface summary
  groups: open=0, allowlist=0
tools.elevated: enabled
hooks.webhooks: disabled
hooks.internal: disabled
browser control: enabled
trust model: personal assistant (one trusted operator boundary), not hostile multi-tenant on one shared gateway. For multiple users or organizations, run one isolated Gateway cell per tenant: https://docs.openclaw.ai/gateway/multi-tenant-hosting
```

**After** (this branch, same SecretRef config — the finding is gone, `Summary: ... 1 warn`):

```text
$ openclaw security audit
OpenClaw security audit
Summary: 0 critical · 1 warn · 1 info
Run deeper: openclaw security audit --deep
[secrets] security audit: gateway secrets.resolve unavailable (gateway closed (1006 abnormal closure (no close frame)): no close reason
Gateway target: ws://127.0.0.1:18789
Source: local loopback
Config: ~/.openclaw-demo/state/openclaw.json
Bind: loopback

Possible causes:
- Connection dropped without a close frame (retry; check network and gateway load)
- Gateway not yet ready to accept connections (retry after a moment)
- TLS mismatch (connecting with ws:// to a wss:// gateway, or vice versa)
- Gateway process stopped or became unreachable (confirm it is still running)
Run `openclaw doctor` for diagnostics.); resolved command secrets locally.

WARN
gateway.trusted_proxies_missing Reverse proxy headers are not trusted
  gateway.bind is loopback and gateway.trustedProxies is empty. If you expose the Control UI through a reverse proxy, configure trusted proxies so local-client checks cannot be spoofed.
  Fix: Set gateway.trustedProxies to your proxy IPs or keep the Control UI local-only.

INFO
summary.attack_surface Attack surface summary
  groups: open=0, allowlist=0
tools.elevated: enabled
hooks.webhooks: disabled
hooks.internal: disabled
browser control: enabled
trust model: personal assistant (one trusted operator boundary), not hostile multi-tenant on one shared gateway. For multiple users or organizations, run one isolated Gateway cell per tenant: https://docs.openclaw.ai/gateway/multi-tenant-hosting
```

**Control — plaintext literal still warns after the fix** (back to `2 warn`):

```text
$ openclaw config set gateway.auth.password "sandbox-dummy-plaintext-not-real"
Updated gateway.auth.password. Restart the gateway to apply.
$ openclaw security audit
OpenClaw security audit
Summary: 0 critical · 2 warn · 1 info
Run deeper: openclaw security audit --deep

WARN
gateway.trusted_proxies_missing Reverse proxy headers are not trusted
  gateway.bind is loopback and gateway.trustedProxies is empty. If you expose the Control UI through a reverse proxy, configure trusted proxies so local-client checks cannot be spoofed.
  Fix: Set gateway.trustedProxies to your proxy IPs or keep the Control UI local-only.
config.secrets.gateway_password_in_config Gateway password is stored in config
  gateway.auth.password is set in the config file; prefer environment variables for secrets when possible.
  Fix: Prefer OPENCLAW_GATEWAY_PASSWORD (env) and remove gateway.auth.password from disk.

INFO
summary.attack_surface Attack surface summary
  groups: open=0, allowlist=0
tools.elevated: enabled
hooks.webhooks: disabled
hooks.internal: disabled
browser control: enabled
trust model: personal assistant (one trusted operator boundary), not hostile multi-tenant on one shared gateway. For multiple users or organizations, run one isolated Gateway cell per tenant: https://docs.openclaw.ai/gateway/multi-tenant-hosting
```

**Tests** (6 cases; the audit-level resolved-config-with-SecretRef-source case fails on unpatched main):

```text
$ node scripts/run-vitest.mjs src/security/audit-secrets-in-config.test.ts
 ✓ |unit| src/security/audit-secrets-in-config.test.ts (6 tests) 143ms
 Test Files  1 passed (1)
      Tests  6 passed (6)
```

Also verified: `pnpm tsgo:core`, `pnpm tsgo:core:test`, oxfmt/oxlint clean, `git diff --check` clean, neighboring audit suites (`audit-config-basics`, `audit-hooks-routing`, `audit-gateway-http-auth`) pass.

## Modified Files

- `src/security/audit.ts` — classify secrets-in-config against the source config, not the resolved config
- `src/security/audit-secrets-in-config.test.ts` — new regression coverage (6 cases)

## User Impact

- File/exec/env SecretRefs for `gateway.auth.password` and `hooks.token` no longer raise "stored in config" findings
- Plaintext literals still warn, so real secret-in-config exposure is not masked
- No breaking changes — backward compatible
