### PR TITLE
refactor(channels): shrink ChannelSetupInput to a generic envelope with a deprecated compatibility tier

### DIFF
--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -7552,6 +7552,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: What changed
   - H3: Why
   - H2: Compatibility policy
+  - H3: Channel setup input field compatibility
   - H2: How to migrate
   - H2: Import path reference
   - H2: Removed compatibility surfaces
@@ -7622,6 +7623,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: ClawHub publishing
   - H2: Setup entry
   - H3: Narrow setup helper imports
+  - H3: Channel-owned setup input fields
   - H3: Channel-owned single-account promotion
   - H2: Config schema
   - H3: Building channel config schemas

--- a/docs/plugins/sdk-migration.md
+++ b/docs/plugins/sdk-migration.md
@@ -96,6 +96,10 @@ permanently. Channel-specific fields remain typed in a deprecated compatibility
 tier so existing external plugins still compile while plugin authors move those
 fields into plugin-local setup input types.
 
+The shared type has no index signature. Plugin-owned keys can still be present
+on runtime input objects; declare them in a plugin-local intersection or narrow
+them through the owning plugin's setup schema.
+
 | `code`                                  | `owner`   | `replacement`                                                                                    | `removeAfter`           | Removal condition                                                                                                                        |
 | --------------------------------------- | --------- | ------------------------------------------------------------------------------------------------ | ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
 | `plugin-sdk-channel-setup-input-fields` | `channel` | Intersect `ChannelSetupInput` with a plugin-local type that declares the owning channel's fields | `next-plugin-sdk-major` | Remove at the first Plugin SDK major after the bundled-plugin migration in [#112238](https://github.com/openclaw/openclaw/issues/112238) |

--- a/docs/plugins/sdk-migration.md
+++ b/docs/plugins/sdk-migration.md
@@ -89,6 +89,21 @@ If a manifest field is still accepted, keep using it until docs and
 diagnostics say otherwise. New code should prefer the documented replacement;
 existing plugins should not break during ordinary minor releases.
 
+### Channel setup input field compatibility
+
+`ChannelSetupInput` now keeps only the cross-channel setup envelope typed
+permanently. Channel-specific fields remain typed in a deprecated compatibility
+tier so existing external plugins still compile while plugin authors move those
+fields into plugin-local setup input types.
+
+| `code`                                  | `owner`   | `replacement`                                                                                    | `removeAfter`           | Removal condition                                                                                                                        |
+| --------------------------------------- | --------- | ------------------------------------------------------------------------------------------------ | ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `plugin-sdk-channel-setup-input-fields` | `channel` | Intersect `ChannelSetupInput` with a plugin-local type that declares the owning channel's fields | `next-plugin-sdk-major` | Remove at the first Plugin SDK major after the bundled-plugin migration in [#112238](https://github.com/openclaw/openclaw/issues/112238) |
+
+This is a source/type compatibility record only. It has no runtime adapter or
+compatibility-registry entry because runtime setup input objects and setup
+behavior are unchanged.
+
 Audit the current migration queue with `pnpm plugins:boundary-report`:
 
 | Flag                                                    | Effect                                                                         |

--- a/docs/plugins/sdk-setup.md
+++ b/docs/plugins/sdk-setup.md
@@ -350,6 +350,46 @@ Use `createSetupTranslator(...)` for fixed setup wizard copy. It uses the first 
 
 The setup patch adapters stay hot-path safe on import. Their bundled single-account promotion contract-surface lookup is lazy, so importing `plugin-sdk/setup-runtime` does not eagerly load bundled contract-surface discovery before the adapter is actually used.
 
+### Channel-owned setup input fields
+
+`ChannelSetupInput` is a generic envelope shared by setup callers and channel
+plugins. Its permanently typed fields are `name`, `token`, `tokenFile`,
+`useEnv`, `allowFrom`, and `defaultTo`. It also accepts plugin-owned keys as
+`unknown`, so each plugin must declare and narrow its own setup fields at the
+adapter boundary:
+
+```typescript
+import type { ChannelSetupAdapter, ChannelSetupInput } from "openclaw/plugin-sdk/channel-setup";
+
+type AcmeSetupInput = ChannelSetupInput & {
+  workspaceId?: string;
+  webhookUrl?: string;
+};
+
+export const acmeSetupAdapter: ChannelSetupAdapter = {
+  applyAccountConfig: ({ cfg, input }) => {
+    const setupInput = input as AcmeSetupInput;
+    return {
+      ...cfg,
+      channels: {
+        ...cfg.channels,
+        acme: {
+          token: setupInput.token,
+          workspaceId: setupInput.workspaceId,
+          webhookUrl: setupInput.webhookUrl,
+        },
+      },
+    };
+  },
+};
+```
+
+Channel-specific fields that were previously declared directly on
+`ChannelSetupInput` remain temporarily typed for external source compatibility.
+They are deprecated and will be removed at the next Plugin SDK major after
+[#112238](https://github.com/openclaw/openclaw/issues/112238). New and bundled
+plugins must not rely on that tier; declare the fields they own locally.
+
 ### Channel-owned single-account promotion
 
 When a channel upgrades from a single-account top-level config to `channels.<id>.accounts.*`, the default shared behavior moves promoted account-scoped values into `accounts.default`.

--- a/docs/plugins/sdk-setup.md
+++ b/docs/plugins/sdk-setup.md
@@ -354,9 +354,10 @@ The setup patch adapters stay hot-path safe on import. Their bundled single-acco
 
 `ChannelSetupInput` is a generic envelope shared by setup callers and channel
 plugins. Its permanently typed fields are `name`, `token`, `tokenFile`,
-`useEnv`, `allowFrom`, and `defaultTo`. It also accepts plugin-owned keys as
-`unknown`, so each plugin must declare and narrow its own setup fields at the
-adapter boundary:
+`useEnv`, `allowFrom`, and `defaultTo`. Additional plugin-owned keys can still
+be present on the runtime input object, but the shared type does not declare an
+index signature. Each plugin must declare and narrow its own setup fields or
+validate them with a plugin-owned schema at the adapter boundary:
 
 ```typescript
 import type { ChannelSetupAdapter, ChannelSetupInput } from "openclaw/plugin-sdk/channel-setup";

--- a/extensions/clickclack/src/setup-core.ts
+++ b/extensions/clickclack/src/setup-core.ts
@@ -1,6 +1,6 @@
 // ClickClack plugin module implements non-interactive setup behavior.
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk/account-id";
-import type { ChannelSetupAdapter } from "openclaw/plugin-sdk/channel-setup";
+import type { ChannelSetupAdapter, ChannelSetupInput } from "openclaw/plugin-sdk/channel-setup";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import {
@@ -26,6 +26,13 @@ const REQUIRED_INPUT_ERROR =
 const INVALID_BASE_URL_ERROR = "ClickClack base URL must be a valid http(s) URL.";
 const SETUP_CODE_CONFLICT_ERROR =
   "ClickClack --code cannot be combined with --token, --token-file, or --use-env.";
+
+type ClickClackSetupInput = ChannelSetupInput & {
+  baseUrl?: string;
+  code?: string;
+  workspace?: string;
+  agentActivity?: boolean;
+};
 
 export function normalizeClickClackBaseUrl(value: string | undefined): string | undefined {
   const trimmed = value?.trim();
@@ -263,15 +270,16 @@ export function applyClickClackCredentialConfig(params: {
 export const clickClackSetupAdapter: ChannelSetupAdapter = {
   resolveAccountId: ({ accountId }) => normalizeAccountId(accountId),
   prepareAccountConfigInput: async ({ cfg, accountId, input }) => {
-    if (!input.code?.trim()) {
-      return input;
+    const setupInput = input as ClickClackSetupInput;
+    if (!setupInput.code?.trim()) {
+      return setupInput;
     }
-    if (input.token?.trim() || input.tokenFile?.trim() || input.useEnv) {
+    if (setupInput.token?.trim() || setupInput.tokenFile?.trim() || setupInput.useEnv) {
       throw new Error(SETUP_CODE_CONFLICT_ERROR);
     }
     let setup = parseClickClackSetupCodeInput({
-      code: input.code,
-      baseUrl: input.baseUrl,
+      code: setupInput.code,
+      baseUrl: setupInput.baseUrl,
     });
     const existing = resolveClickClackAccountConfig(cfg as CoreConfig, accountId);
     const privateApiBaseUrl = normalizeClickClackBaseUrl(existing.apiBaseUrl);
@@ -291,7 +299,7 @@ export const clickClackSetupAdapter: ChannelSetupAdapter = {
       throw formatClickClackSetupCodeClaimError(error);
     }
     setup = { ...setup, baseUrl: claim.api_base_url ?? setup.baseUrl };
-    const { code: _code, tokenFile: _tokenFile, useEnv: _useEnv, ...remainingInput } = input;
+    const { code: _code, tokenFile: _tokenFile, useEnv: _useEnv, ...remainingInput } = setupInput;
     return {
       ...remainingInput,
       baseUrl: setup.baseUrl,
@@ -321,11 +329,12 @@ export const clickClackSetupAdapter: ChannelSetupAdapter = {
       { someOf: ["workspace"], message: REQUIRED_INPUT_ERROR },
     ],
     validate: ({ cfg, accountId, input }) => {
-      const baseUrl = normalizeClickClackBaseUrl(input.baseUrl);
-      if (input.baseUrl && !baseUrl) {
+      const setupInput = input as ClickClackSetupInput;
+      const baseUrl = normalizeClickClackBaseUrl(setupInput.baseUrl);
+      if (setupInput.baseUrl && !baseUrl) {
         return INVALID_BASE_URL_ERROR;
       }
-      if (!input.useEnv) {
+      if (!setupInput.useEnv) {
         return null;
       }
       const existing = resolveClickClackAccountConfig(cfg as CoreConfig, accountId);
@@ -336,30 +345,33 @@ export const clickClackSetupAdapter: ChannelSetupAdapter = {
       if (!baseUrl && !existingBaseUrl) {
         return REQUIRED_INPUT_ERROR;
       }
-      if (!input.workspace?.trim() && !existing.workspace?.trim()) {
+      if (!setupInput.workspace?.trim() && !existing.workspace?.trim()) {
         return REQUIRED_INPUT_ERROR;
       }
       return null;
     },
   }),
   applyAccountConfig: ({ cfg, accountId, input }) => {
-    const existing = input.useEnv
+    const setupInput = input as ClickClackSetupInput;
+    const existing = setupInput.useEnv
       ? resolveClickClackAccountConfig(cfg as CoreConfig, accountId)
       : undefined;
-    const baseUrl = normalizeClickClackBaseUrl(input.baseUrl ?? existing?.baseUrl);
-    const workspace = input.workspace?.trim() || existing?.workspace?.trim();
-    const tokenFile = input.tokenFile?.trim();
-    const token = input.token?.trim();
+    const baseUrl = normalizeClickClackBaseUrl(setupInput.baseUrl ?? existing?.baseUrl);
+    const workspace = setupInput.workspace?.trim() || existing?.workspace?.trim();
+    const tokenFile = setupInput.tokenFile?.trim();
+    const token = setupInput.token?.trim();
     const next = applyClickClackSetupConfigPatch({
       cfg,
       accountId,
-      name: input.name,
+      name: setupInput.name,
       patch: {
         ...(baseUrl ? { baseUrl } : {}),
         ...(workspace ? { workspace } : {}),
-        ...(input.defaultTo?.trim() ? { defaultTo: input.defaultTo.trim() } : {}),
-        ...(input.allowFrom ? { allowFrom: [...input.allowFrom] } : {}),
-        ...(input.agentActivity !== undefined ? { agentActivity: input.agentActivity } : {}),
+        ...(setupInput.defaultTo?.trim() ? { defaultTo: setupInput.defaultTo.trim() } : {}),
+        ...(setupInput.allowFrom ? { allowFrom: [...setupInput.allowFrom] } : {}),
+        ...(setupInput.agentActivity !== undefined
+          ? { agentActivity: setupInput.agentActivity }
+          : {}),
       },
     });
     return applyClickClackCredentialConfig({
@@ -367,7 +379,7 @@ export const clickClackSetupAdapter: ChannelSetupAdapter = {
       accountId,
       token,
       tokenFile,
-      useEnv: input.useEnv,
+      useEnv: setupInput.useEnv,
     });
   },
   afterAccountConfigWritten: async ({ cfg, accountId, runtime }) => {

--- a/extensions/googlechat/src/setup-core.ts
+++ b/extensions/googlechat/src/setup-core.ts
@@ -1,10 +1,18 @@
 // Googlechat plugin module implements setup core behavior.
+import type { ChannelSetupInput } from "openclaw/plugin-sdk/channel-setup";
 import {
   createPatchedAccountSetupAdapter,
   createSetupInputPresenceValidator,
 } from "openclaw/plugin-sdk/setup-runtime";
 
 const channel = "googlechat" as const;
+
+type GoogleChatSetupInput = ChannelSetupInput & {
+  audienceType?: string;
+  audience?: string;
+  webhookPath?: string;
+  webhookUrl?: string;
+};
 
 export const googlechatSetupAdapter = createPatchedAccountSetupAdapter({
   channelKey: channel,
@@ -19,17 +27,18 @@ export const googlechatSetupAdapter = createPatchedAccountSetupAdapter({
     ],
   }),
   buildPatch: (input) => {
-    const patch = input.useEnv
+    const setupInput = input as GoogleChatSetupInput;
+    const patch = setupInput.useEnv
       ? {}
-      : input.tokenFile
-        ? { serviceAccountFile: input.tokenFile }
-        : input.token
-          ? { serviceAccount: input.token }
+      : setupInput.tokenFile
+        ? { serviceAccountFile: setupInput.tokenFile }
+        : setupInput.token
+          ? { serviceAccount: setupInput.token }
           : {};
-    const audienceType = input.audienceType?.trim();
-    const audience = input.audience?.trim();
-    const webhookPath = input.webhookPath?.trim();
-    const webhookUrl = input.webhookUrl?.trim();
+    const audienceType = setupInput.audienceType?.trim();
+    const audience = setupInput.audience?.trim();
+    const webhookPath = setupInput.webhookPath?.trim();
+    const webhookUrl = setupInput.webhookUrl?.trim();
     return {
       ...patch,
       ...(audienceType ? { audienceType } : {}),

--- a/extensions/imessage/src/setup-core.ts
+++ b/extensions/imessage/src/setup-core.ts
@@ -1,3 +1,4 @@
+import type { ChannelSetupInput } from "openclaw/plugin-sdk/channel-setup";
 // Imessage plugin module implements setup core behavior.
 import type {
   ChannelSetupAdapter,
@@ -63,6 +64,13 @@ const CHAT_TARGET_ALLOWFROM_PREFIXES = [
 ];
 const SERVICE_ALLOWFROM_PREFIXES = ["imessage:", "sms:", "auto:"];
 
+type IMessageSetupInput = ChannelSetupInput & {
+  cliPath?: string;
+  dbPath?: string;
+  service?: "imessage" | "sms" | "auto";
+  region?: string;
+};
+
 function normalizeAllowFromEntryForPrefixCheck(entry: string): string {
   let lower = normalizeLowercaseStringOrEmpty(entry);
   let stripped = true;
@@ -91,12 +99,7 @@ export function parseIMessageAllowFromEntries(raw: string): { entries: string[];
   });
 }
 
-function buildIMessageSetupPatch(input: {
-  cliPath?: string;
-  dbPath?: string;
-  service?: "imessage" | "sms" | "auto";
-  region?: string;
-}) {
+function buildIMessageSetupPatch(input: IMessageSetupInput) {
   return {
     ...(input.cliPath ? { cliPath: input.cliPath } : {}),
     ...(input.dbPath ? { dbPath: input.dbPath } : {}),
@@ -227,7 +230,7 @@ export const imessageCompletionNote = {
 export const imessageSetupAdapter: ChannelSetupAdapter = {
   ...createPatchedAccountSetupAdapter({
     channelKey: channel,
-    buildPatch: (input) => buildIMessageSetupPatch(input),
+    buildPatch: (input) => buildIMessageSetupPatch(input as IMessageSetupInput),
   }),
   singleAccountKeysToMove: ["cliPath", "dbPath", "service", "region"],
 };

--- a/extensions/line/src/setup-core.ts
+++ b/extensions/line/src/setup-core.ts
@@ -1,5 +1,9 @@
 // Line plugin module implements setup core behavior.
-import type { ChannelSetupAdapter, OpenClawConfig } from "openclaw/plugin-sdk/setup";
+import type {
+  ChannelSetupAdapter,
+  ChannelSetupInput,
+  OpenClawConfig,
+} from "openclaw/plugin-sdk/setup";
 import { createSetupInputPresenceValidator } from "openclaw/plugin-sdk/setup";
 import { hasLineCredentials, parseLineAllowFromId } from "./account-helpers.js";
 import {
@@ -9,6 +13,12 @@ import {
   resolveLineAccount,
   type LineConfig,
 } from "./setup-runtime-api.js";
+
+type LineSetupInput = ChannelSetupInput & {
+  channelAccessToken?: string;
+  channelSecret?: string;
+  secretFile?: string;
+};
 
 export function patchLineAccountConfig(params: {
   cfg: OpenClawConfig;
@@ -95,13 +105,7 @@ export const lineSetupAdapter: ChannelSetupAdapter = {
     ],
   }),
   applyAccountConfig: ({ cfg, accountId, input }) => {
-    const typedInput = input as {
-      useEnv?: boolean;
-      channelAccessToken?: string;
-      channelSecret?: string;
-      tokenFile?: string;
-      secretFile?: string;
-    };
+    const typedInput = input as LineSetupInput;
     const normalizedAccountId = normalizeAccountId(accountId);
     if (normalizedAccountId === DEFAULT_ACCOUNT_ID) {
       return patchLineAccountConfig({

--- a/extensions/matrix/src/cli.ts
+++ b/extensions/matrix/src/cli.ts
@@ -4,7 +4,6 @@ import { normalizeAccountId } from "openclaw/plugin-sdk/account-id";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { parseStrictInteger, timestampMsToIsoString } from "openclaw/plugin-sdk/number-runtime";
 import { readByteStreamWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
-import type { ChannelSetupInput } from "openclaw/plugin-sdk/setup";
 import { resolveMatrixAccount, resolveMatrixAccountConfig } from "./matrix/accounts.js";
 import { listMatrixOwnDevices, pruneMatrixStaleGatewayDevices } from "./matrix/actions/devices.js";
 import { updateMatrixOwnProfile } from "./matrix/actions/profile.js";
@@ -35,6 +34,7 @@ import { formatMatrixErrorMessage } from "./matrix/errors.js";
 import { applyMatrixProfileUpdate, type MatrixProfileUpdateResult } from "./profile-update.js";
 import { formatZonedTimestamp } from "./runtime-api.js";
 import { getMatrixRuntime } from "./runtime.js";
+import type { MatrixSetupInput } from "./setup-config.js";
 import { matrixSetupAdapter } from "./setup-core.js";
 import type { CoreConfig } from "./types.js";
 
@@ -301,7 +301,7 @@ async function addMatrixAccount(params: {
     throw new Error("Matrix account setup is unavailable.");
   }
 
-  const input: ChannelSetupInput = {
+  const input: MatrixSetupInput = {
     name: params.name,
     avatarUrl: params.avatarUrl,
     homeserver: params.homeserver,

--- a/extensions/matrix/src/setup-config.ts
+++ b/extensions/matrix/src/setup-config.ts
@@ -43,6 +43,19 @@ const COMMON_SINGLE_ACCOUNT_KEYS_TO_MOVE = new Set([
 const MATRIX_SINGLE_ACCOUNT_KEYS_TO_MOVE = new Set<string>(matrixSingleAccountKeysToMove);
 const MATRIX_NAMED_ACCOUNT_PROMOTION_KEYS = new Set<string>(matrixNamedAccountPromotionKeys);
 
+export type MatrixSetupInput = ChannelSetupInput & {
+  homeserver?: string;
+  dangerouslyAllowPrivateNetwork?: boolean;
+  allowPrivateNetwork?: boolean;
+  proxy?: string;
+  userId?: string;
+  accessToken?: string;
+  password?: string;
+  deviceName?: string;
+  avatarUrl?: string;
+  initialSyncLimit?: number;
+};
+
 function cloneIfObject<T>(value: T): T {
   if (value && typeof value === "object") {
     return structuredClone(value);
@@ -50,7 +63,7 @@ function cloneIfObject<T>(value: T): T {
   return value;
 }
 
-function resolveSetupAvatarUrl(input: ChannelSetupInput): string | undefined {
+function resolveSetupAvatarUrl(input: MatrixSetupInput): string | undefined {
   const avatarUrl = input.avatarUrl;
   if (typeof avatarUrl !== "string") {
     return undefined;
@@ -139,20 +152,21 @@ export function validateMatrixSetupInput(params: {
   accountId: string;
   input: ChannelSetupInput;
 }): string | null {
-  const avatarUrl = resolveSetupAvatarUrl(params.input);
+  const input = params.input as MatrixSetupInput;
+  const avatarUrl = resolveSetupAvatarUrl(input);
   if (avatarUrl && !isSupportedMatrixAvatarSource(avatarUrl)) {
     return "Matrix avatar URL must be an mxc:// URI or an http(s) URL.";
   }
-  if (params.input.useEnv) {
+  if (input.useEnv) {
     const envReadiness = resolveMatrixEnvAuthReadiness(params.accountId, process.env);
     return envReadiness.ready ? null : envReadiness.missingMessage;
   }
-  if (!params.input.homeserver?.trim()) {
+  if (!input.homeserver?.trim()) {
     return "Matrix requires --homeserver";
   }
-  const accessToken = params.input.accessToken?.trim();
-  const password = normalizeSecretInputString(params.input.password);
-  const userId = params.input.userId?.trim();
+  const accessToken = input.accessToken?.trim();
+  const password = normalizeSecretInputString(input.password);
+  const userId = input.userId?.trim();
   if (!accessToken && !password) {
     return "Matrix requires --access-token or --password";
   }
@@ -172,6 +186,7 @@ export function applyMatrixSetupAccountConfig(params: {
   accountId: string;
   input: ChannelSetupInput;
 }): CoreConfig {
+  const input = params.input as MatrixSetupInput;
   const normalizedAccountId = normalizeAccountId(params.accountId);
   const migratedCfg =
     normalizedAccountId !== DEFAULT_ACCOUNT_ID
@@ -181,11 +196,11 @@ export function applyMatrixSetupAccountConfig(params: {
     cfg: migratedCfg,
     channelKey: channel,
     accountId: normalizedAccountId,
-    name: params.input.name,
+    name: input.name,
   }) as CoreConfig;
-  const avatarUrl = resolveSetupAvatarUrl(params.input);
+  const avatarUrl = resolveSetupAvatarUrl(input);
 
-  if (params.input.useEnv) {
+  if (input.useEnv) {
     return updateMatrixAccountConfig(next, normalizedAccountId, {
       enabled: true,
       homeserver: null,
@@ -200,24 +215,24 @@ export function applyMatrixSetupAccountConfig(params: {
     });
   }
 
-  const accessToken = params.input.accessToken?.trim();
-  const password = normalizeSecretInputString(params.input.password);
-  const userId = params.input.userId?.trim();
+  const accessToken = input.accessToken?.trim();
+  const password = normalizeSecretInputString(input.password);
+  const userId = input.userId?.trim();
   return updateMatrixAccountConfig(next, normalizedAccountId, {
     enabled: true,
-    homeserver: params.input.homeserver?.trim(),
+    homeserver: input.homeserver?.trim(),
     allowPrivateNetwork:
-      typeof params.input.dangerouslyAllowPrivateNetwork === "boolean"
-        ? params.input.dangerouslyAllowPrivateNetwork
-        : typeof params.input.allowPrivateNetwork === "boolean"
-          ? params.input.allowPrivateNetwork
+      typeof input.dangerouslyAllowPrivateNetwork === "boolean"
+        ? input.dangerouslyAllowPrivateNetwork
+        : typeof input.allowPrivateNetwork === "boolean"
+          ? input.allowPrivateNetwork
           : undefined,
-    proxy: normalizeOptionalString(params.input.proxy),
+    proxy: normalizeOptionalString(input.proxy),
     userId: password && !userId ? null : userId,
     accessToken: accessToken || (password ? null : undefined),
     password: password || (accessToken ? null : undefined),
-    deviceName: params.input.deviceName?.trim(),
+    deviceName: input.deviceName?.trim(),
     avatarUrl,
-    initialSyncLimit: params.input.initialSyncLimit,
+    initialSyncLimit: input.initialSyncLimit,
   });
 }

--- a/extensions/mattermost/src/setup-core.ts
+++ b/extensions/mattermost/src/setup-core.ts
@@ -1,6 +1,6 @@
 // Mattermost plugin module implements setup core behavior.
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk/account-id";
-import type { ChannelSetupAdapter } from "openclaw/plugin-sdk/channel-setup";
+import type { ChannelSetupAdapter, ChannelSetupInput } from "openclaw/plugin-sdk/channel-setup";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
   applyAccountNameToChannelSection,
@@ -16,6 +16,11 @@ import { normalizeMattermostBaseUrl } from "./setup.client.runtime.js";
 import { hasConfiguredSecretInput } from "./setup.secret-input.runtime.js";
 
 const channel = "mattermost" as const;
+
+type MattermostSetupInput = ChannelSetupInput & {
+  botToken?: string;
+  httpUrl?: string;
+};
 
 export function isMattermostConfigured(account: ResolvedMattermostAccount): boolean {
   const tokenConfigured =
@@ -80,25 +85,27 @@ export const mattermostSetupAdapter: ChannelSetupAdapter = {
       },
     ],
     validate: ({ input }) => {
-      const token = input.botToken ?? input.token;
-      const baseUrl = normalizeMattermostBaseUrl(input.httpUrl);
-      if (!input.useEnv && (!token || !baseUrl)) {
+      const setupInput = input as MattermostSetupInput;
+      const token = setupInput.botToken ?? setupInput.token;
+      const baseUrl = normalizeMattermostBaseUrl(setupInput.httpUrl);
+      if (!setupInput.useEnv && (!token || !baseUrl)) {
         return "Mattermost requires --bot-token and --http-url (or --use-env).";
       }
-      if (input.httpUrl && !baseUrl) {
+      if (setupInput.httpUrl && !baseUrl) {
         return "Mattermost --http-url must include a valid base URL.";
       }
       return null;
     },
   }),
   applyAccountConfig: ({ cfg, accountId, input }) => {
-    const token = input.botToken ?? input.token;
-    const baseUrl = normalizeMattermostBaseUrl(input.httpUrl);
+    const setupInput = input as MattermostSetupInput;
+    const token = setupInput.botToken ?? setupInput.token;
+    const baseUrl = normalizeMattermostBaseUrl(setupInput.httpUrl);
     return applyMattermostSetupConfigPatch({
       cfg,
       accountId,
-      name: input.name,
-      patch: input.useEnv
+      name: setupInput.name,
+      patch: setupInput.useEnv
         ? {}
         : {
             ...(token ? { botToken: token } : {}),

--- a/extensions/nextcloud-talk/src/setup-core.ts
+++ b/extensions/nextcloud-talk/src/setup-core.ts
@@ -28,6 +28,8 @@ type NextcloudSetupInput = ChannelSetupInput & {
   baseUrl?: string;
   secret?: string;
   secretFile?: string;
+  url?: string;
+  password?: string;
 };
 type NextcloudTalkSection = NonNullable<CoreConfig["channels"]>["nextcloud-talk"];
 
@@ -209,12 +211,18 @@ export const nextcloudTalkDmPolicy: ChannelSetupDmPolicy = {
 export const nextcloudTalkSetupAdapter: ChannelSetupAdapter = {
   singleAccountKeysToMove: ["rooms"],
   resolveAccountId: ({ accountId }) => normalizeAccountId(accountId),
-  prepareAccountConfigInput: ({ input }) => ({
-    ...input,
-    baseUrl: input.baseUrl ?? readOptionalString(input.url),
-    secret: input.secret ?? readOptionalString(input.token) ?? readOptionalString(input.password),
-    secretFile: input.secretFile ?? readOptionalString(input.tokenFile),
-  }),
+  prepareAccountConfigInput: ({ input }) => {
+    const setupInput = input as NextcloudSetupInput;
+    return {
+      ...setupInput,
+      baseUrl: setupInput.baseUrl ?? readOptionalString(setupInput.url),
+      secret:
+        setupInput.secret ??
+        readOptionalString(setupInput.token) ??
+        readOptionalString(setupInput.password),
+      secretFile: setupInput.secretFile ?? readOptionalString(setupInput.tokenFile),
+    };
+  },
   applyAccountName: ({ cfg, accountId, name }) =>
     applyAccountNameToChannelSection({
       cfg,

--- a/extensions/nostr/src/setup-adapter.ts
+++ b/extensions/nostr/src/setup-adapter.ts
@@ -1,11 +1,16 @@
 // Nostr plugin module implements setup adapter behavior.
-import type { ChannelSetupAdapter } from "openclaw/plugin-sdk/channel-setup";
+import type { ChannelSetupAdapter, ChannelSetupInput } from "openclaw/plugin-sdk/channel-setup";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/routing";
 import { patchTopLevelChannelConfigSection, splitSetupEntries } from "openclaw/plugin-sdk/setup";
 import { uniqueStrings } from "openclaw/plugin-sdk/string-coerce-runtime";
 
 const channel = "nostr" as const;
+
+type NostrSetupInput = ChannelSetupInput & {
+  privateKey?: string;
+  relayUrls?: string;
+};
 
 export function buildNostrSetupPatch(accountId: string, patch: Record<string, unknown>) {
   return {
@@ -43,11 +48,7 @@ export function createNostrSetupAdapter(params: {
         patch: buildNostrSetupPatch(accountId, name?.trim() ? { name: name.trim() } : {}),
       }),
     validateInput: ({ input }) => {
-      const typedInput = input as {
-        useEnv?: boolean;
-        privateKey?: string;
-        relayUrls?: string;
-      };
+      const typedInput = input as NostrSetupInput;
       if (!typedInput.useEnv) {
         const privateKey = typedInput.privateKey?.trim();
         if (!privateKey) {
@@ -63,11 +64,7 @@ export function createNostrSetupAdapter(params: {
       return null;
     },
     applyAccountConfig: ({ cfg, accountId, input }) => {
-      const typedInput = input as {
-        useEnv?: boolean;
-        privateKey?: string;
-        relayUrls?: string;
-      };
+      const typedInput = input as NostrSetupInput;
       const relayResult = typedInput.relayUrls?.trim()
         ? parseRelayUrls(typedInput.relayUrls)
         : { relays: [] };

--- a/extensions/qa-channel/src/channel-base.ts
+++ b/extensions/qa-channel/src/channel-base.ts
@@ -7,7 +7,7 @@ import {
 } from "./accounts.js";
 import { qaChannelPluginConfigSchema } from "./config-schema.js";
 import type { ChannelPlugin } from "./runtime-api.js";
-import { applyQaSetup } from "./setup.js";
+import { applyQaSetup, type QaChannelSetupInput } from "./setup.js";
 import type { CoreConfig } from "./types.js";
 
 export const QA_CHANNEL_ID = "qa-channel" as const;
@@ -44,7 +44,7 @@ export function createQaChannelPluginBase(
         applyQaSetup({
           cfg,
           accountId,
-          input: input as Record<string, unknown>,
+          input: input as QaChannelSetupInput,
         }),
     },
     config: {

--- a/extensions/qa-channel/src/setup.ts
+++ b/extensions/qa-channel/src/setup.ts
@@ -1,12 +1,19 @@
 // Qa Channel setup module handles plugin onboarding behavior.
+import type { ChannelSetupInput } from "openclaw/plugin-sdk/channel-setup";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { DEFAULT_ACCOUNT_ID } from "./accounts.js";
 import type { CoreConfig } from "./types.js";
 
+export type QaChannelSetupInput = ChannelSetupInput & {
+  baseUrl?: string;
+  botUserId?: string;
+  botDisplayName?: string;
+};
+
 export function applyQaSetup(params: {
   cfg: OpenClawConfig;
   accountId: string;
-  input: Record<string, unknown>;
+  input: QaChannelSetupInput;
 }): OpenClawConfig {
   const nextCfg = structuredClone(params.cfg) as CoreConfig;
   const section = nextCfg.channels?.["qa-channel"] ?? {};

--- a/extensions/raft/src/setup.ts
+++ b/extensions/raft/src/setup.ts
@@ -1,6 +1,9 @@
 import type { ChannelPlugin } from "openclaw/plugin-sdk/core";
 // Raft plugin setup owns only the Raft CLI profile, never Raft credentials.
-import { createPatchedAccountSetupAdapter } from "openclaw/plugin-sdk/setup";
+import {
+  createPatchedAccountSetupAdapter,
+  type ChannelSetupInput,
+} from "openclaw/plugin-sdk/setup";
 import {
   createDetectedBinaryStatus,
   formatDocsLink,
@@ -16,14 +19,22 @@ import {
   type ResolvedRaftAccount,
 } from "./accounts.js";
 
+type RaftSetupInput = ChannelSetupInput & {
+  profile?: string;
+};
+
 const raftSetupAdapter = createPatchedAccountSetupAdapter({
   channelKey: RAFT_CHANNEL_ID,
   buildPatch: (input) => {
-    const profile = normalizeOptionalString(input.profile);
+    const profile = normalizeOptionalString((input as RaftSetupInput).profile);
     return profile ? { profile } : {};
   },
   validateInput: ({ cfg, accountId, input }) => {
-    if (normalizeOptionalString(input.profile) ?? resolveRaftAccount({ cfg, accountId }).profile) {
+    const setupInput = input as RaftSetupInput;
+    if (
+      normalizeOptionalString(setupInput.profile) ??
+      resolveRaftAccount({ cfg, accountId }).profile
+    ) {
       return null;
     }
     return "Raft requires a CLI profile.";

--- a/extensions/signal/src/setup-core.ts
+++ b/extensions/signal/src/setup-core.ts
@@ -1,4 +1,5 @@
 // Signal plugin module implements setup core behavior.
+import type { ChannelSetupInput } from "openclaw/plugin-sdk/channel-setup";
 import {
   createCliPathTextInput,
   createDelegatedSetupWizardProxy,
@@ -35,6 +36,14 @@ const MAX_E164_DIGITS = 15;
 const DIGITS_ONLY = /^\d+$/;
 const INVALID_SIGNAL_ACCOUNT_ERROR =
   "Invalid E.164 phone number (must start with + and country code, e.g. +15555550123)";
+
+type SignalSetupInput = ChannelSetupInput & {
+  signalNumber?: string;
+  cliPath?: string;
+  httpUrl?: string;
+  httpHost?: string;
+  httpPort?: string;
+};
 
 export function normalizeSignalAccountInput(value: string | null | undefined): string | null {
   const trimmed = normalizeOptionalString(value);
@@ -82,13 +91,7 @@ function parseSignalAllowFromEntries(raw: string): { entries: string[]; error?: 
   });
 }
 
-export function buildSignalSetupPatch(input: {
-  signalNumber?: string;
-  cliPath?: string;
-  httpUrl?: string;
-  httpHost?: string;
-  httpPort?: string;
-}) {
+export function buildSignalSetupPatch(input: SignalSetupInput) {
   const rawHttpHost = input.httpHost || "127.0.0.1";
   const httpHost =
     rawHttpHost.includes(":") && !rawHttpHost.startsWith("[") ? `[${rawHttpHost}]` : rawHttpHost;
@@ -240,19 +243,20 @@ export const signalSetupAdapter: ChannelSetupAdapter = {
     channelKey: channel,
     validateInput: createSetupInputPresenceValidator({
       validate: ({ input }) => {
+        const setupInput = input as SignalSetupInput;
         if (
-          !input.signalNumber &&
-          !input.httpUrl &&
-          !input.httpHost &&
-          !input.httpPort &&
-          !input.cliPath
+          !setupInput.signalNumber &&
+          !setupInput.httpUrl &&
+          !setupInput.httpHost &&
+          !setupInput.httpPort &&
+          !setupInput.cliPath
         ) {
           return "Signal requires --signal-number or --http-url/--http-host/--http-port/--cli-path.";
         }
         return null;
       },
     }),
-    buildPatch: (input) => buildSignalSetupPatch(input),
+    buildPatch: (input) => buildSignalSetupPatch(input as SignalSetupInput),
   }),
   singleAccountKeysToMove: [
     "signalNumber",

--- a/extensions/slack/src/setup-core.ts
+++ b/extensions/slack/src/setup-core.ts
@@ -35,6 +35,15 @@ import {
 
 const t = createSetupTranslator();
 
+type SlackSetupInput = ChannelSetupInput & {
+  botToken?: string;
+  appToken?: string;
+  userToken?: string;
+  signingSecret?: string;
+  identity?: "bot" | "user";
+  mode?: "socket" | "http" | "relay";
+};
+
 function enableSlackAccount(cfg: OpenClawConfig, accountId: string): OpenClawConfig {
   return patchChannelConfigForAccount({
     cfg,
@@ -199,7 +208,7 @@ function createSlackTokenCredential(params: {
 }
 
 function hasSlackSetupCredentials(params: {
-  input: ChannelSetupInput;
+  input: SlackSetupInput;
   identity: "bot" | "user";
   mode: "socket" | "http" | "relay";
 }): boolean {
@@ -216,21 +225,22 @@ function hasSlackSetupCredentials(params: {
 const slackSetupAdapterBase = createPatchedAccountSetupAdapter({
   channelKey: channel,
   validateInput: ({ cfg, accountId, input }) => {
-    if (input.useEnv && accountId !== DEFAULT_ACCOUNT_ID) {
+    const setupInput = input as SlackSetupInput;
+    if (setupInput.useEnv && accountId !== DEFAULT_ACCOUNT_ID) {
       return "Slack env tokens can only be used for the default account.";
     }
     const account = inspectSlackAccount({ cfg, accountId });
-    const identity = input.identity ?? account.config.postAs ?? "bot";
-    const mode = input.mode ?? account.config.mode ?? "socket";
+    const identity = setupInput.identity ?? account.config.postAs ?? "bot";
+    const mode = setupInput.mode ?? account.config.mode ?? "socket";
     if (identity === "user" && mode === "relay") {
       return 'Slack user identity setup supports mode "socket" or "http", not "relay".';
     }
-    if (input.useEnv) {
+    if (setupInput.useEnv) {
       return identity === "user"
         ? "Slack user identity setup does not support --use-env; configure userToken and the transport credential explicitly."
         : null;
     }
-    if (hasSlackSetupCredentials({ input, identity, mode })) {
+    if (hasSlackSetupCredentials({ input: setupInput, identity, mode })) {
       return null;
     }
     if (identity === "user") {
@@ -240,25 +250,29 @@ const slackSetupAdapterBase = createPatchedAccountSetupAdapter({
     }
     return "Slack requires --bot-token and --app-token (or --use-env).";
   },
-  buildPatch: (input) => ({
-    ...(input.identity ? { postAs: input.identity } : {}),
-    ...(input.identity === "user" && input.mode ? { mode: input.mode } : {}),
-    ...(input.botToken ? { botToken: input.botToken } : {}),
-    ...(input.appToken ? { appToken: input.appToken } : {}),
-    ...(input.userToken ? { userToken: input.userToken } : {}),
-    ...(input.signingSecret ? { signingSecret: input.signingSecret } : {}),
-  }),
+  buildPatch: (input) => {
+    const setupInput = input as SlackSetupInput;
+    return {
+      ...(setupInput.identity ? { postAs: setupInput.identity } : {}),
+      ...(setupInput.identity === "user" && setupInput.mode ? { mode: setupInput.mode } : {}),
+      ...(setupInput.botToken ? { botToken: setupInput.botToken } : {}),
+      ...(setupInput.appToken ? { appToken: setupInput.appToken } : {}),
+      ...(setupInput.userToken ? { userToken: setupInput.userToken } : {}),
+      ...(setupInput.signingSecret ? { signingSecret: setupInput.signingSecret } : {}),
+    };
+  },
 });
 
 export const slackSetupAdapter: ChannelSetupAdapter = {
   ...slackSetupAdapterBase,
   singleAccountKeysToMove: ["appToken"],
   applyAccountConfig: ({ cfg, accountId, input }) => {
-    const identity = input.identity ?? inspectSlackAccount({ cfg, accountId }).config.postAs;
+    const setupInput = input as SlackSetupInput;
+    const identity = setupInput.identity ?? inspectSlackAccount({ cfg, accountId }).config.postAs;
     return slackSetupAdapterBase.applyAccountConfig({
       cfg,
       accountId,
-      input: identity === "user" ? { ...input, identity } : input,
+      input: identity === "user" ? { ...setupInput, identity } : setupInput,
     });
   },
 };

--- a/extensions/sms/src/channel.ts
+++ b/extensions/sms/src/channel.ts
@@ -108,7 +108,7 @@ function smsSetupPatch(input: SmsSetupInput): Record<string, unknown> {
     "publicWebhookUrl",
     "dmPolicy",
     "allowFrom",
-  ]) {
+  ] as const) {
     if (input[key] !== undefined) {
       patch[key] = input[key];
     }

--- a/extensions/sms/src/channel.ts
+++ b/extensions/sms/src/channel.ts
@@ -16,6 +16,7 @@ import {
   defineChannelMessageAdapter,
 } from "openclaw/plugin-sdk/channel-outbound";
 import { createConditionalWarningCollector } from "openclaw/plugin-sdk/channel-policy";
+import type { ChannelSetupInput } from "openclaw/plugin-sdk/channel-setup";
 import { createEmptyChannelDirectoryAdapter } from "openclaw/plugin-sdk/directory-runtime";
 import { normalizeStringEntries } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { chunkTextForOutbound } from "openclaw/plugin-sdk/text-chunking";
@@ -40,6 +41,16 @@ import { formatSmsProbeLines, probeSmsAccount, type SmsProbe } from "./status.js
 import type { ResolvedSmsAccount } from "./types.js";
 
 const CHANNEL_ID = "sms";
+
+type SmsSetupInput = ChannelSetupInput & {
+  accountSid?: string;
+  authToken?: string;
+  fromNumber?: string;
+  messagingServiceSid?: string;
+  webhookPath?: string;
+  publicWebhookUrl?: string;
+  dmPolicy?: string;
+};
 
 const smsConfigAdapter = createHybridChannelConfigAdapter<ResolvedSmsAccount>({
   sectionKey: CHANNEL_ID,
@@ -85,7 +96,7 @@ const collectSmsSecurityWarnings = createConditionalWarningCollector<ResolvedSms
     '- SMS: dmPolicy="open" allows any phone number to message the bot.',
 );
 
-function smsSetupPatch(input: Record<string, unknown>): Record<string, unknown> {
+function smsSetupPatch(input: SmsSetupInput): Record<string, unknown> {
   const patch: Record<string, unknown> = {};
   for (const key of [
     "accountSid",
@@ -108,7 +119,7 @@ function smsSetupPatch(input: Record<string, unknown>): Record<string, unknown> 
 function applySmsAccountConfig(params: {
   cfg: OpenClawConfig;
   accountId: string;
-  input: Record<string, unknown>;
+  input: SmsSetupInput;
 }): OpenClawConfig {
   const patch = smsSetupPatch(params.input);
   const channels = { ...params.cfg.channels };
@@ -240,7 +251,8 @@ export const smsPlugin: ChannelPlugin<ResolvedSmsAccount, SmsProbe> = createChat
     reload: { configPrefixes: [`channels.${CHANNEL_ID}`] },
     configSchema: SmsChannelConfigSchema,
     setup: {
-      applyAccountConfig: applySmsAccountConfig,
+      applyAccountConfig: ({ cfg, accountId, input }) =>
+        applySmsAccountConfig({ cfg, accountId, input: input as SmsSetupInput }),
     },
     config: {
       ...smsConfigAdapter,

--- a/extensions/synology-chat/src/setup-surface.ts
+++ b/extensions/synology-chat/src/setup-surface.ts
@@ -11,6 +11,7 @@ import {
   setSetupChannelEnabled,
   splitSetupEntries,
   type ChannelSetupAdapter,
+  type ChannelSetupInput,
   type ChannelSetupWizard,
   type OpenClawConfig,
 } from "openclaw/plugin-sdk/setup";
@@ -25,6 +26,11 @@ const t = createSetupTranslator();
 
 const channel = "synology-chat" as const;
 const DEFAULT_WEBHOOK_PATH = "/webhook/synology";
+
+type SynologyChatSetupInput = ChannelSetupInput & {
+  url?: string;
+  webhookPath?: string;
+};
 
 const SYNOLOGY_SETUP_HELP_LINES = [
   t("wizard.synologyChat.helpIncomingWebhook"),
@@ -158,36 +164,39 @@ function resolveExistingAllowedUserIds(cfg: OpenClawConfig, accountId: string): 
 export const synologyChatSetupAdapter: ChannelSetupAdapter = {
   resolveAccountId: ({ accountId }) => normalizeAccountId(accountId) ?? DEFAULT_ACCOUNT_ID,
   validateInput: ({ accountId, input }) => {
-    if (input.useEnv && accountId !== DEFAULT_ACCOUNT_ID) {
+    const setupInput = input as SynologyChatSetupInput;
+    if (setupInput.useEnv && accountId !== DEFAULT_ACCOUNT_ID) {
       return "Synology Chat env credentials only support the default account.";
     }
-    if (!input.useEnv && !input.token?.trim()) {
+    if (!setupInput.useEnv && !setupInput.token?.trim()) {
       return "Synology Chat requires --token or --use-env.";
     }
-    if (!input.url?.trim()) {
+    if (!setupInput.url?.trim()) {
       return "Synology Chat requires --url for the incoming webhook.";
     }
-    const urlError = validateWebhookUrl(input.url.trim());
+    const urlError = validateWebhookUrl(setupInput.url.trim());
     if (urlError) {
       return urlError;
     }
-    if (input.webhookPath?.trim()) {
-      return validateWebhookPath(input.webhookPath.trim()) ?? null;
+    if (setupInput.webhookPath?.trim()) {
+      return validateWebhookPath(setupInput.webhookPath.trim()) ?? null;
     }
     return null;
   },
-  applyAccountConfig: ({ cfg, accountId, input }) =>
-    patchSynologyChatAccountConfig({
+  applyAccountConfig: ({ cfg, accountId, input }) => {
+    const setupInput = input as SynologyChatSetupInput;
+    return patchSynologyChatAccountConfig({
       cfg,
       accountId,
       enabled: true,
-      clearFields: input.useEnv ? ["token"] : undefined,
+      clearFields: setupInput.useEnv ? ["token"] : undefined,
       patch: {
-        ...(input.useEnv ? {} : { token: input.token?.trim() }),
-        incomingUrl: input.url?.trim(),
-        ...(input.webhookPath?.trim() ? { webhookPath: input.webhookPath.trim() } : {}),
+        ...(setupInput.useEnv ? {} : { token: setupInput.token?.trim() }),
+        incomingUrl: setupInput.url?.trim(),
+        ...(setupInput.webhookPath?.trim() ? { webhookPath: setupInput.webhookPath.trim() } : {}),
       },
-    }),
+    });
+  },
 };
 
 export const synologyChatSetupWizard: ChannelSetupWizard = {

--- a/extensions/tlon/src/setup-core.ts
+++ b/extensions/tlon/src/setup-core.ts
@@ -200,12 +200,13 @@ export const tlonSetupAdapter: ChannelSetupAdapter = {
   singleAccountKeysToMove: ["url", "code"],
   resolveAccountId: ({ accountId }) => normalizeAccountId(accountId),
   prepareAccountConfigInput: ({ input }) => {
-    const url = normalizeOptionalString(input.url);
+    const setupInput = input as TlonSetupInput;
+    const url = normalizeOptionalString(setupInput.url);
     if (!url) {
-      return input;
+      return setupInput;
     }
     const validatedUrl = validateUrbitBaseUrl(url);
-    return validatedUrl.ok ? { ...input, url: validatedUrl.baseUrl } : input;
+    return validatedUrl.ok ? { ...setupInput, url: validatedUrl.baseUrl } : setupInput;
   },
   applyAccountName: ({ cfg, accountId, name }) =>
     prepareScopedSetupConfig({
@@ -216,10 +217,11 @@ export const tlonSetupAdapter: ChannelSetupAdapter = {
     }),
   validateInput: createSetupInputPresenceValidator({
     validate: ({ cfg, accountId, input }) => {
+      const setupInput = input as TlonSetupInput;
       const resolved = resolveTlonAccount(cfg, accountId ?? undefined);
-      const ship = normalizeOptionalString(input.ship ?? resolved.ship);
-      const url = normalizeOptionalString(input.url ?? resolved.url);
-      const code = normalizeOptionalString(input.code ?? resolved.code);
+      const ship = normalizeOptionalString(setupInput.ship ?? resolved.ship);
+      const url = normalizeOptionalString(setupInput.url ?? resolved.url);
+      const code = normalizeOptionalString(setupInput.code ?? resolved.code);
       if (!ship) {
         return "Tlon requires --ship.";
       }

--- a/extensions/whatsapp/src/setup-core.ts
+++ b/extensions/whatsapp/src/setup-core.ts
@@ -2,11 +2,16 @@
 import {
   applyAccountNameToChannelSection,
   type ChannelSetupAdapter,
+  type ChannelSetupInput,
   migrateBaseNameToDefaultAccount,
   normalizeAccountId,
 } from "openclaw/plugin-sdk/setup";
 
 const channel = "whatsapp" as const;
+
+type WhatsAppSetupInput = ChannelSetupInput & {
+  authDir?: string;
+};
 
 export const whatsappSetupAdapter: ChannelSetupAdapter = {
   singleAccountKeysToMove: ["authDir"],
@@ -20,11 +25,12 @@ export const whatsappSetupAdapter: ChannelSetupAdapter = {
       alwaysUseAccounts: true,
     }),
   applyAccountConfig: ({ cfg, accountId, input }) => {
+    const setupInput = input as WhatsAppSetupInput;
     const namedConfig = applyAccountNameToChannelSection({
       cfg,
       channelKey: channel,
       accountId,
-      name: input.name,
+      name: setupInput.name,
       alwaysUseAccounts: true,
     });
     const next = migrateBaseNameToDefaultAccount({
@@ -34,7 +40,7 @@ export const whatsappSetupAdapter: ChannelSetupAdapter = {
     });
     const entry = {
       ...next.channels?.whatsapp?.accounts?.[accountId],
-      ...(input.authDir ? { authDir: input.authDir } : {}),
+      ...(setupInput.authDir ? { authDir: setupInput.authDir } : {}),
       enabled: true,
     };
     return {

--- a/src/channels/plugins/types.core.ts
+++ b/src/channels/plugins/types.core.ts
@@ -197,9 +197,7 @@ type DeprecatedChannelSetupFields = {
 };
 
 /** Generic setup envelope used by CLI, onboarding, and channel-owned setup adapters. */
-export type ChannelSetupInput = ChannelSetupEnvelope &
-  DeprecatedChannelSetupFields &
-  Record<string, unknown>;
+export type ChannelSetupInput = ChannelSetupEnvelope & DeprecatedChannelSetupFields;
 
 export type ChannelStatusIssue = {
   channel: ChannelId;

--- a/src/channels/plugins/types.core.ts
+++ b/src/channels/plugins/types.core.ts
@@ -95,59 +95,111 @@ export type ChannelMessageToolDiscovery = {
   mediaSourceParams?: ChannelMessageToolMediaSourceParams | null;
 };
 
-/** Shared setup input bag used by CLI, onboarding, and setup adapters. */
-export type ChannelSetupInput = {
+type ChannelSetupEnvelope = {
   name?: string;
   token?: string;
-  privateKey?: string;
   tokenFile?: string;
-  secret?: string;
-  secretFile?: string;
-  botToken?: string;
-  appToken?: string;
-  userToken?: string;
-  signingSecret?: string;
-  identity?: "bot" | "user";
-  mode?: "socket" | "http" | "relay";
-  signalNumber?: string;
-  cliPath?: string;
-  dbPath?: string;
-  service?: "imessage" | "sms" | "auto";
-  region?: string;
-  authDir?: string;
-  httpUrl?: string;
-  httpHost?: string;
-  httpPort?: string;
-  webhookPath?: string;
-  webhookUrl?: string;
-  audienceType?: string;
-  audience?: string;
   useEnv?: boolean;
-  homeserver?: string;
-  dangerouslyAllowPrivateNetwork?: boolean;
-  /** @deprecated Compatibility alias; prefer dangerouslyAllowPrivateNetwork. */
-  allowPrivateNetwork?: boolean;
-  proxy?: string;
-  userId?: string;
-  accessToken?: string;
-  password?: string;
-  deviceName?: string;
-  avatarUrl?: string;
-  initialSyncLimit?: number;
-  profile?: string;
-  ship?: string;
-  url?: string;
-  baseUrl?: string;
-  relayUrls?: string;
-  code?: string;
-  groupChannels?: string[];
-  dmAllowlist?: string[];
-  autoDiscoverChannels?: boolean;
-  workspace?: string;
   defaultTo?: string;
   allowFrom?: string[];
+};
+
+type DeprecatedChannelSetupFields = {
+  /** @deprecated Channel-owned setup field; declare it in the owning plugin's setup input type. Removed at the next Plugin SDK major (#112238). */
+  privateKey?: string;
+  /** @deprecated Channel-owned setup field; declare it in the owning plugin's setup input type. Removed at the next Plugin SDK major (#112238). */
+  secret?: string;
+  /** @deprecated Channel-owned setup field; declare it in the owning plugin's setup input type. Removed at the next Plugin SDK major (#112238). */
+  secretFile?: string;
+  /** @deprecated Channel-owned setup field; declare it in the owning plugin's setup input type. Removed at the next Plugin SDK major (#112238). */
+  botToken?: string;
+  /** @deprecated Channel-owned setup field; declare it in the owning plugin's setup input type. Removed at the next Plugin SDK major (#112238). */
+  appToken?: string;
+  /** @deprecated Channel-owned setup field; declare it in the owning plugin's setup input type. Removed at the next Plugin SDK major (#112238). */
+  userToken?: string;
+  /** @deprecated Channel-owned setup field; declare it in the owning plugin's setup input type. Removed at the next Plugin SDK major (#112238). */
+  signingSecret?: string;
+  /** @deprecated Channel-owned setup field; declare it in the owning plugin's setup input type. Removed at the next Plugin SDK major (#112238). */
+  identity?: "bot" | "user";
+  /** @deprecated Channel-owned setup field; declare it in the owning plugin's setup input type. Removed at the next Plugin SDK major (#112238). */
+  mode?: "socket" | "http" | "relay";
+  /** @deprecated Channel-owned setup field; declare it in the owning plugin's setup input type. Removed at the next Plugin SDK major (#112238). */
+  signalNumber?: string;
+  /** @deprecated Channel-owned setup field; declare it in the owning plugin's setup input type. Removed at the next Plugin SDK major (#112238). */
+  cliPath?: string;
+  /** @deprecated Channel-owned setup field; declare it in the owning plugin's setup input type. Removed at the next Plugin SDK major (#112238). */
+  dbPath?: string;
+  /** @deprecated Channel-owned setup field; declare it in the owning plugin's setup input type. Removed at the next Plugin SDK major (#112238). */
+  service?: "imessage" | "sms" | "auto";
+  /** @deprecated Channel-owned setup field; declare it in the owning plugin's setup input type. Removed at the next Plugin SDK major (#112238). */
+  region?: string;
+  /** @deprecated Channel-owned setup field; declare it in the owning plugin's setup input type. Removed at the next Plugin SDK major (#112238). */
+  authDir?: string;
+  /** @deprecated Channel-owned setup field; declare it in the owning plugin's setup input type. Removed at the next Plugin SDK major (#112238). */
+  httpUrl?: string;
+  /** @deprecated Channel-owned setup field; declare it in the owning plugin's setup input type. Removed at the next Plugin SDK major (#112238). */
+  httpHost?: string;
+  /** @deprecated Channel-owned setup field; declare it in the owning plugin's setup input type. Removed at the next Plugin SDK major (#112238). */
+  httpPort?: string;
+  /** @deprecated Channel-owned setup field; declare it in the owning plugin's setup input type. Removed at the next Plugin SDK major (#112238). */
+  webhookPath?: string;
+  /** @deprecated Channel-owned setup field; declare it in the owning plugin's setup input type. Removed at the next Plugin SDK major (#112238). */
+  webhookUrl?: string;
+  /** @deprecated Channel-owned setup field; declare it in the owning plugin's setup input type. Removed at the next Plugin SDK major (#112238). */
+  audienceType?: string;
+  /** @deprecated Channel-owned setup field; declare it in the owning plugin's setup input type. Removed at the next Plugin SDK major (#112238). */
+  audience?: string;
+  /** @deprecated Channel-owned setup field; declare it in the owning plugin's setup input type. Removed at the next Plugin SDK major (#112238). */
+  homeserver?: string;
+  /** @deprecated Channel-owned setup field; declare it in the owning plugin's setup input type. Removed at the next Plugin SDK major (#112238). */
+  dangerouslyAllowPrivateNetwork?: boolean;
+  /**
+   * Compatibility alias for `dangerouslyAllowPrivateNetwork`.
+   * @deprecated Channel-owned setup field; declare it in the owning plugin's setup input type. Removed at the next Plugin SDK major (#112238).
+   */
+  allowPrivateNetwork?: boolean;
+  /** @deprecated Channel-owned setup field; declare it in the owning plugin's setup input type. Removed at the next Plugin SDK major (#112238). */
+  proxy?: string;
+  /** @deprecated Channel-owned setup field; declare it in the owning plugin's setup input type. Removed at the next Plugin SDK major (#112238). */
+  userId?: string;
+  /** @deprecated Channel-owned setup field; declare it in the owning plugin's setup input type. Removed at the next Plugin SDK major (#112238). */
+  accessToken?: string;
+  /** @deprecated Channel-owned setup field; declare it in the owning plugin's setup input type. Removed at the next Plugin SDK major (#112238). */
+  password?: string;
+  /** @deprecated Channel-owned setup field; declare it in the owning plugin's setup input type. Removed at the next Plugin SDK major (#112238). */
+  deviceName?: string;
+  /** @deprecated Channel-owned setup field; declare it in the owning plugin's setup input type. Removed at the next Plugin SDK major (#112238). */
+  avatarUrl?: string;
+  /** @deprecated Channel-owned setup field; declare it in the owning plugin's setup input type. Removed at the next Plugin SDK major (#112238). */
+  initialSyncLimit?: number;
+  /** @deprecated Channel-owned setup field; declare it in the owning plugin's setup input type. Removed at the next Plugin SDK major (#112238). */
+  profile?: string;
+  /** @deprecated Channel-owned setup field; declare it in the owning plugin's setup input type. Removed at the next Plugin SDK major (#112238). */
+  ship?: string;
+  /** @deprecated Channel-owned setup field; declare it in the owning plugin's setup input type. Removed at the next Plugin SDK major (#112238). */
+  url?: string;
+  /** @deprecated Channel-owned setup field; declare it in the owning plugin's setup input type. Removed at the next Plugin SDK major (#112238). */
+  baseUrl?: string;
+  /** @deprecated Channel-owned setup field; declare it in the owning plugin's setup input type. Removed at the next Plugin SDK major (#112238). */
+  relayUrls?: string;
+  /** @deprecated Channel-owned setup field; declare it in the owning plugin's setup input type. Removed at the next Plugin SDK major (#112238). */
+  code?: string;
+  /** @deprecated Channel-owned setup field; declare it in the owning plugin's setup input type. Removed at the next Plugin SDK major (#112238). */
+  groupChannels?: string[];
+  /** @deprecated Channel-owned setup field; declare it in the owning plugin's setup input type. Removed at the next Plugin SDK major (#112238). */
+  dmAllowlist?: string[];
+  /** @deprecated Channel-owned setup field; declare it in the owning plugin's setup input type. Removed at the next Plugin SDK major (#112238). */
+  autoDiscoverChannels?: boolean;
+  /** @deprecated Channel-owned setup field; declare it in the owning plugin's setup input type. Removed at the next Plugin SDK major (#112238). */
+  workspace?: string;
+  /** @deprecated Channel-owned setup field; declare it in the owning plugin's setup input type. Removed at the next Plugin SDK major (#112238). */
   agentActivity?: boolean;
 };
+
+/** Generic setup envelope used by CLI, onboarding, and channel-owned setup adapters. */
+export type ChannelSetupInput = ChannelSetupEnvelope &
+  DeprecatedChannelSetupFields &
+  Record<string, unknown>;
 
 export type ChannelStatusIssue = {
   channel: ChannelId;

--- a/src/plugin-sdk/channel-setup.test.ts
+++ b/src/plugin-sdk/channel-setup.test.ts
@@ -1,7 +1,31 @@
 // Channel setup tests cover setup wizard finalize behavior and config write contracts.
 import { runSetupWizardFinalize } from "openclaw/plugin-sdk/plugin-test-runtime";
-import { describe, expect, it } from "vitest";
+import { describe, expect, expectTypeOf, it } from "vitest";
+import type { ChannelSetupInput } from "./channel-setup.js";
 import { createOptionalChannelSetupSurface } from "./channel-setup.js";
+
+describe("ChannelSetupInput", () => {
+  it("keeps the generic envelope and deprecated compatibility tier typed", () => {
+    expectTypeOf<ChannelSetupInput["name"]>().toEqualTypeOf<string | undefined>();
+    expectTypeOf<ChannelSetupInput["token"]>().toEqualTypeOf<string | undefined>();
+    expectTypeOf<ChannelSetupInput["tokenFile"]>().toEqualTypeOf<string | undefined>();
+    expectTypeOf<ChannelSetupInput["useEnv"]>().toEqualTypeOf<boolean | undefined>();
+    expectTypeOf<ChannelSetupInput["allowFrom"]>().toEqualTypeOf<string[] | undefined>();
+    expectTypeOf<ChannelSetupInput["defaultTo"]>().toEqualTypeOf<string | undefined>();
+
+    expectTypeOf<ChannelSetupInput["botToken"]>().toEqualTypeOf<string | undefined>();
+    expectTypeOf<ChannelSetupInput["appToken"]>().toEqualTypeOf<string | undefined>();
+    expectTypeOf<ChannelSetupInput["signalNumber"]>().toEqualTypeOf<string | undefined>();
+    expectTypeOf<ChannelSetupInput["homeserver"]>().toEqualTypeOf<string | undefined>();
+    expectTypeOf<ChannelSetupInput["mode"]>().toEqualTypeOf<
+      "socket" | "http" | "relay" | undefined
+    >();
+    expectTypeOf<ChannelSetupInput["identity"]>().toEqualTypeOf<"bot" | "user" | undefined>();
+
+    const input: ChannelSetupInput = { pluginOwned: { enabled: true } };
+    expectTypeOf(input.pluginOwned).toEqualTypeOf<unknown>();
+  });
+});
 
 describe("createOptionalChannelSetupSurface", () => {
   it("returns a matched adapter and wizard for optional plugins", async () => {

--- a/src/plugin-sdk/channel-setup.test.ts
+++ b/src/plugin-sdk/channel-setup.test.ts
@@ -4,6 +4,11 @@ import { describe, expect, expectTypeOf, it } from "vitest";
 import type { ChannelSetupInput } from "./channel-setup.js";
 import { createOptionalChannelSetupSurface } from "./channel-setup.js";
 
+interface ThirdPartySetupInput {
+  name?: string;
+  botToken?: string;
+}
+
 describe("ChannelSetupInput", () => {
   it("keeps the generic envelope and deprecated compatibility tier typed", () => {
     expectTypeOf<ChannelSetupInput["name"]>().toEqualTypeOf<string | undefined>();
@@ -22,8 +27,8 @@ describe("ChannelSetupInput", () => {
     >();
     expectTypeOf<ChannelSetupInput["identity"]>().toEqualTypeOf<"bot" | "user" | undefined>();
 
-    const input: ChannelSetupInput = { pluginOwned: { enabled: true } };
-    expectTypeOf(input.pluginOwned).toEqualTypeOf<unknown>();
+    const assignable: ChannelSetupInput = {} as ThirdPartySetupInput;
+    expectTypeOf(assignable).toEqualTypeOf<ChannelSetupInput>();
   });
 });
 


### PR DESCRIPTION
## What Problem This Solves

Part 3 (final) of #112238 — the type Jesse's original observation was about. `ChannelSetupInput` in core was a ~50-field union of every channel's setup vocabulary (`botToken`, `signalNumber`, `homeserver`, `ship`, `cliPath`, ...), exported as public SDK surface. Core declared every channel's fields; plugins read their own off the shared bag.

## Why This Change Was Made

Per the SDK migration policy (new contract → deprecation window → removal at major):

- `ChannelSetupInput` is now `ChannelSetupEnvelope & DeprecatedChannelSetupFields`. The envelope keeps the genuinely cross-channel fields (`name`, `token`, `tokenFile`, `useEnv`, `allowFrom`, `defaultTo`); all 43 channel-owned fields move to a clearly-bounded deprecated tier with identical value types and per-field `@deprecated` JSDoc pointing at the plugin-local pattern and the removal milestone (next Plugin SDK major).
- Every in-repo plugin now declares its own setup-input type locally (`SlackSetupInput`, `MatrixSetupInput`, ...); a compatibility-off compile proof (deprecated tier temporarily disconnected, full core+extensions typecheck lanes green) shows in-repo code no longer touches the tier — it exists purely for third parties.
- No index signature: the type stays structurally assignable exactly as before, so interface-typed third-party inputs keep compiling. Unknown plugin keys remain a runtime fact that plugin-local types/schemas narrow at the adapter boundary (an earlier draft intersected `Record<string, unknown>`; review showed that breaks interface assignability and was never needed — withdrawn).
- A type fixture (`expectTypeOf` + interface-assignability guard) locks the contract, deliberately covering the API-baseline blind spot: the baseline renders re-exported type aliases by name and produced byte-identical hashes across this change, so the fixture is the field-level guard.
- `docs/plugins/sdk-migration.md` records the deprecation and removal window; `docs/plugins/sdk-setup.md` documents the envelope + plugin-local pattern.

Third-party impact verified by tarball inspection of all four published out-of-tree plugins (WeCom, Yuanbao, Weixin, Zalo ClawBot): zero runtime impact (compiled dist), zero rebuild break (deprecated tier + preserved assignability).

## User Impact

None at runtime. Plugin authors get deprecation guidance in their IDE and a documented migration pattern; the actual field removal is reserved for the next SDK major.

## Evidence

- Compatibility-off compile proof: `tsgo:core` + `tsgo:extensions` green with the deprecated tier disconnected (Blacksmith run 29837400152), tier restored after; final full type lanes green (core, core:test, extensions, extensions:test — rerun locally after the assignability correction during a Blacksmith outage, noted as the sanctioned fallback).
- Type fixture + SDK surface/api checks green; API baseline byte-identical (blind spot confirmed, fixture guards).
- Focused setup suites green (slack, matrix, nextcloud-talk, tlon + fixture, 60 tests in the final round).
- Structured review (Codex gpt-5.6-sol): one P1 accepted and fixed (index-signature intersection broke interface assignability — removed); final run clean, 0.97.
