### PR TITLE
fix(agents): keep heartbeat on configured provider when aliases collide

### DIFF
--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -829,6 +829,25 @@ describe("runWithModelFallback", () => {
         expected: ["anthropic", "claude-sonnet-4-6"],
       },
       {
+        name: "resolves cross-provider bare alias from the default provider",
+        cfg: makeCfg({
+          agents: {
+            defaults: {
+              model: {
+                primary: "openai/gpt-5.4",
+                fallbacks: [],
+              },
+              models: {
+                "anthropic/claude-sonnet-4-6": { alias: "sonnet" },
+              },
+            },
+          },
+        }),
+        provider: "openai",
+        model: "sonnet",
+        expected: ["anthropic", "claude-sonnet-4-6"],
+      },
+      {
         name: "resolves slash-form alias before provider parsing",
         cfg: makeCfg({
           agents: {
@@ -866,6 +885,60 @@ describe("runWithModelFallback", () => {
         provider: "opencode-go",
         model: "deepseek-v4-pro",
         expected: ["opencode-go", "deepseek-v4-pro"],
+      },
+      {
+        name: "keeps explicit default provider when another provider aliases the bare model id",
+        cfg: makeCfg({
+          models: {
+            providers: {
+              "cloudflare-ai-gateway": {
+                baseUrl: "https://gateway.example.test",
+                models: [
+                  {
+                    id: "gemini-2.5-flash-lite",
+                    name: "Gemini 2.5 Flash Lite via gateway",
+                    reasoning: false,
+                    input: ["text"],
+                    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                    contextWindow: 1_000_000,
+                    maxTokens: 8192,
+                  },
+                ],
+              },
+              google: {
+                baseUrl: "https://google.example.test",
+                models: [
+                  {
+                    id: "gemini-2.5-flash-lite",
+                    name: "Gemini 2.5 Flash Lite",
+                    reasoning: false,
+                    input: ["text"],
+                    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                    contextWindow: 1_000_000,
+                    maxTokens: 8192,
+                  },
+                ],
+              },
+            },
+          },
+          agents: {
+            defaults: {
+              model: {
+                primary: "cloudflare-ai-gateway/gemini-3.1-flash-lite",
+                fallbacks: [],
+              },
+              models: {
+                "cloudflare-ai-gateway/gemini-2.5-flash-lite": {
+                  alias: "cf-gemini-2.5-flash-lite",
+                },
+                "google/gemini-2.5-flash-lite": { alias: "gemini-2.5-flash-lite" },
+              },
+            },
+          },
+        }),
+        provider: "cloudflare-ai-gateway",
+        model: "gemini-2.5-flash-lite",
+        expected: ["cloudflare-ai-gateway", "gemini-2.5-flash-lite"],
       },
     ] satisfies Array<{
       name: string;

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -1070,10 +1070,17 @@ function resolveFallbackCandidatesUncached(
     }),
     manifestPlugins: params.manifestPlugins,
   });
+  // A configured provider/model pair remains explicit even when that provider is
+  // the default; a same-named alias from another provider must not rewrite it.
+  const exactProviderModelConfigured = hasExactConfiguredProviderModel({
+    cfg: params.cfg,
+    provider: normalizedPrimary.provider,
+    model: normalizedPrimary.model,
+  });
   const resolvedBareModelAlias =
     resolvedModelAlias?.alias &&
     (resolvedModelAlias.ref.provider === normalizedPrimary.provider ||
-      normalizedPrimary.provider === defaultProvider)
+      (normalizedPrimary.provider === defaultProvider && !exactProviderModelConfigured))
       ? resolvedModelAlias.ref
       : null;
   const resolvedPrimary =


### PR DESCRIPTION
Closes #112289

## What Problem This Solves

Fixes an issue where heartbeat requests could be silently routed through a different provider when the configured provider was also the agent default and another provider used the bare model ID as an alias.

## Why This Change Was Made

An exact configured provider/model pair now takes precedence over a same-named bare alias owned by another provider. Cross-provider bare aliases still resolve normally when no exact model exists on the selected provider.

## User Impact

Heartbeat and other explicitly resolved model overrides keep the configured provider route, preserving gateway routing, analytics, rate limits, and provider-specific policy even when model aliases collide.

## Evidence

- Base: `3a1351a3035b71a09c8bbd481a959a462616ab4b`
- Head: `65dc6b39d3`
- Before the fix, the focused production-resolver regression failed with:
  - expected provider: `cloudflare-ai-gateway`
  - received provider: `google`
- After the fix, the focused alias-resolution regression passes in both agent test projects.
- `node scripts/run-vitest.mjs src/agents/model-fallback.test.ts`: 128/128 passed.
- Core test TypeScript check passed with `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --pretty false`.
- Scoped formatting, oxlint, `git diff --check`, and TruffleHog passed.
- Required uncommitted autoreview completed with no accepted or actionable findings.
- The linked issue provides live instrumentation from the affected heartbeat route; the regression reproduces the same provider substitution through the production fallback resolver without external credentials.