### PR TITLE
fix(matrix): exclude archived state roots from scans and selection

### DIFF
--- a/extensions/matrix/doctor-contract-api.account-state.test.ts
+++ b/extensions/matrix/doctor-contract-api.account-state.test.ts
@@ -183,7 +183,6 @@ describe("Matrix account state Doctor migration", () => {
     fs.writeFileSync(archivedDatabasePath, rawFixture);
 
     const beforeRepairRowsSha256 = matrixStateRowsSha256(databasePath);
-    const archivedRowsSha256 = matrixStateRowsSha256(archivedDatabasePath);
     const staleStore = new SqliteBackedMatrixSyncStore(storageRootDir);
     await expect(staleStore.getSavedSyncToken()).resolves.toBe("cursor-a");
     await staleStore.setSyncData(matrixSyncResponse("cursor-after-repair"));
@@ -214,14 +213,7 @@ describe("Matrix account state Doctor migration", () => {
       "Migrated shared state audit event ledger → versioned message lifecycle schema",
     );
     expect(matrixStateRowsSha256(databasePath)).toBe(beforeRepairRowsSha256);
-    const archived = new DatabaseSync(archivedDatabasePath, { readOnly: true });
-    try {
-      expect(archived.prepare("PRAGMA user_version").get()).toEqual({ user_version: 1 });
-      expect(archived.prepare("PRAGMA integrity_check").get()).toEqual({ integrity_check: "ok" });
-    } finally {
-      archived.close();
-    }
-    expect(matrixStateRowsSha256(archivedDatabasePath)).toBe(archivedRowsSha256);
+    expect(fs.readFileSync(archivedDatabasePath)).toEqual(rawFixture);
 
     const repairedStore = new SqliteBackedMatrixSyncStore(storageRootDir);
     await expect(repairedStore.getSavedSyncToken()).resolves.toBe("cursor-a");

--- a/extensions/matrix/doctor-contract-api.account-state.test.ts
+++ b/extensions/matrix/doctor-contract-api.account-state.test.ts
@@ -148,18 +148,28 @@ describe("Matrix account state Doctor migration", () => {
     resetPluginStateStoreForTests();
   });
 
-  it("repairs a 2026.7.1 account database before Matrix persists a new sync cursor", async () => {
+  it("repairs active account state without opening token-root archives", async () => {
     const stateDir = tempDirs.make("openclaw-matrix-doctor-");
     const storageRootDir = path.join(
       stateDir,
       "matrix",
       "accounts",
+      "sync-cache-backup",
+      "matrix.example.org__bot",
+      "0123456789abcdef",
+    );
+    const archivedStorageRootDir = path.join(
+      stateDir,
+      "matrix",
+      "accounts",
       "default",
       "matrix.example.org__bot",
-      "token-hash",
+      "sync-cache-backup",
     );
     const databasePath = path.join(storageRootDir, "state", "openclaw.sqlite");
+    const archivedDatabasePath = path.join(archivedStorageRootDir, "state", "openclaw.sqlite");
     fs.mkdirSync(path.dirname(databasePath), { recursive: true });
+    fs.mkdirSync(path.dirname(archivedDatabasePath), { recursive: true });
     const compressedFixture = Buffer.from(
       fs.readFileSync(MATRIX_V2026_7_1_FIXTURE_BASE64, "utf8").replaceAll(/\s/gu, ""),
       "base64",
@@ -170,8 +180,10 @@ describe("Matrix account state Doctor migration", () => {
     const rawFixture = gunzipSync(compressedFixture);
     expect(createHash("sha256").update(rawFixture).digest("hex")).toBe(MATRIX_V2026_7_1_RAW_SHA256);
     fs.writeFileSync(databasePath, rawFixture);
+    fs.writeFileSync(archivedDatabasePath, rawFixture);
 
     const beforeRepairRowsSha256 = matrixStateRowsSha256(databasePath);
+    const archivedRowsSha256 = matrixStateRowsSha256(archivedDatabasePath);
     const staleStore = new SqliteBackedMatrixSyncStore(storageRootDir);
     await expect(staleStore.getSavedSyncToken()).resolves.toBe("cursor-a");
     await staleStore.setSyncData(matrixSyncResponse("cursor-after-repair"));
@@ -197,10 +209,19 @@ describe("Matrix account state Doctor migration", () => {
     expect(doctor.signal, doctorOutput).toBeNull();
     expect(doctor.status, doctorOutput).toBe(0);
     expect(doctorOutput).toContain(`Matrix account SQLite ${storageRootDir}`);
+    expect(doctorOutput).not.toContain(`Matrix account SQLite ${archivedStorageRootDir}`);
     expect(doctorOutput).toContain(
       "Migrated shared state audit event ledger → versioned message lifecycle schema",
     );
     expect(matrixStateRowsSha256(databasePath)).toBe(beforeRepairRowsSha256);
+    const archived = new DatabaseSync(archivedDatabasePath, { readOnly: true });
+    try {
+      expect(archived.prepare("PRAGMA user_version").get()).toEqual({ user_version: 1 });
+      expect(archived.prepare("PRAGMA integrity_check").get()).toEqual({ integrity_check: "ok" });
+    } finally {
+      archived.close();
+    }
+    expect(matrixStateRowsSha256(archivedDatabasePath)).toBe(archivedRowsSha256);
 
     const repairedStore = new SqliteBackedMatrixSyncStore(storageRootDir);
     await expect(repairedStore.getSavedSyncToken()).resolves.toBe("cursor-a");

--- a/extensions/matrix/doctor-contract-api.archive-scan.test.ts
+++ b/extensions/matrix/doctor-contract-api.archive-scan.test.ts
@@ -1,0 +1,268 @@
+// Matrix tests cover bounded doctor state-root discovery.
+import fs from "node:fs";
+import fsPromises from "node:fs/promises";
+import path from "node:path";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import type {
+  OpenKeyedStoreOptions,
+  PluginStateKeyedStore,
+} from "openclaw/plugin-sdk/plugin-state-runtime";
+import {
+  createPluginStateKeyedStoreForTests,
+  getPluginStateCapacityForTests,
+  importPluginStateEntriesForDoctorForTests,
+  resetPluginStateStoreForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import type { PluginDoctorStateMigrationContext } from "openclaw/plugin-sdk/runtime-doctor";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { stateMigrations } from "./doctor-contract-api.js";
+import { installMatrixTestRuntime } from "./src/test-runtime.js";
+import { useAutoCleanupTempDirTracker } from "./test-support.js";
+
+function createMigrationParams(stateDir: string) {
+  const env = { OPENCLAW_STATE_DIR: stateDir };
+  const context: PluginDoctorStateMigrationContext = {
+    getPluginStateCapacity: () => getPluginStateCapacityForTests("matrix", env),
+    importPluginStateEntries: (options, entries) =>
+      importPluginStateEntriesForDoctorForTests("matrix", options, entries),
+    openPluginStateKeyedStore: <T>(options: OpenKeyedStoreOptions): PluginStateKeyedStore<T> =>
+      createPluginStateKeyedStoreForTests<T>("matrix", options),
+  };
+  return {
+    config: {} as OpenClawConfig,
+    env,
+    stateDir,
+    oauthDir: path.join(stateDir, "oauth"),
+    context,
+  };
+}
+
+function migrationById(id: string) {
+  const migration = stateMigrations.find((entry) => entry.id === id);
+  if (!migration) {
+    throw new Error(`missing migration ${id}`);
+  }
+  return migration;
+}
+
+function writeLegacySyncCache(storageRootDir: string, nextBatch: string): void {
+  fs.mkdirSync(storageRootDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(storageRootDir, "bot-storage.json"),
+    JSON.stringify({
+      version: 1,
+      savedSync: {
+        nextBatch,
+        accountData: [],
+        roomsData: { join: {}, invite: {}, leave: {}, knock: {} },
+      },
+      cleanShutdown: true,
+    }),
+  );
+}
+
+function expectRootNotVisited(visitedDirs: string[], storageRootDir: string): void {
+  const root = path.resolve(storageRootDir);
+  expect(
+    visitedDirs.some(
+      (visitedDir) => visitedDir === root || visitedDir.startsWith(`${root}${path.sep}`),
+    ),
+  ).toBe(false);
+}
+
+describe("matrix doctor archive scan boundaries", () => {
+  const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+  beforeEach(() => {
+    resetPluginStateStoreForTests();
+    installMatrixTestRuntime();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    resetPluginStateStoreForTests();
+  });
+
+  it("scans only active canonical and flat per-account Matrix storage roots", async () => {
+    const stateDir = tempDirs.make("openclaw-matrix-doctor-");
+    const matrixRoot = path.join(stateDir, "matrix");
+    const activeRoots = [
+      path.join(matrixRoot, "accounts", "legacy"),
+      path.join(matrixRoot, "accounts", "ops", "matrix.example.org__bot", "0123456789abcdef"),
+    ];
+    const excludedRoots = [
+      path.join(
+        matrixRoot,
+        "accounts",
+        "ops",
+        "matrix.example.org__bot",
+        "0123456789abcdef.apr24-cutover-20260424",
+      ),
+      path.join(
+        matrixRoot,
+        "accounts",
+        "ops",
+        "matrix.example.org__bot",
+        "fedcba9876543210.reset-20260720",
+      ),
+      path.join(
+        matrixRoot,
+        "accounts",
+        "ops",
+        "matrix.example.org__bot",
+        "sync-cache-backup-after-limit1-20260720",
+        "fedcba9876543210",
+      ),
+      path.join(
+        matrixRoot,
+        "crypto-backup-20260720",
+        "accounts",
+        "ops",
+        "matrix.example.org__bot",
+        "fedcba9876543210",
+      ),
+      path.join(
+        matrixRoot,
+        "accounts",
+        "ops",
+        "matrix.example.org__bot",
+        "fedcba9876543210.migrated",
+      ),
+      path.join(
+        matrixRoot,
+        "operator-copy",
+        "accounts",
+        "ops",
+        "matrix.example.org__bot",
+        "fedcba9876543210",
+      ),
+    ];
+    for (const [index, storageRootDir] of [...activeRoots, ...excludedRoots].entries()) {
+      writeLegacySyncCache(storageRootDir, `legacy-token-${index}`);
+    }
+
+    const visitedDirs: string[] = [];
+    const originalReaddir = fsPromises.readdir.bind(fsPromises);
+    vi.spyOn(fsPromises, "readdir").mockImplementation(async (...args) => {
+      visitedDirs.push(path.resolve(String(args[0])));
+      return originalReaddir(...args);
+    });
+
+    const migration = migrationById("matrix-sync-cache-json-to-plugin-state");
+    await expect(migration.detectLegacyState(createMigrationParams(stateDir))).resolves.toEqual({
+      preview: activeRoots.map(
+        (storageRootDir) => `Matrix sync cache JSON can migrate to SQLite: ${storageRootDir}`,
+      ),
+    });
+    const result = await migration.migrateLegacyState(createMigrationParams(stateDir));
+
+    expect(result.warnings).toEqual([]);
+    expect(result.changes).toHaveLength(activeRoots.length * 2);
+    for (const storageRootDir of activeRoots) {
+      expect(fs.existsSync(path.join(storageRootDir, "bot-storage.json"))).toBe(false);
+      expect(fs.existsSync(path.join(storageRootDir, "bot-storage.json.migrated"))).toBe(true);
+    }
+    for (const storageRootDir of excludedRoots) {
+      expect(fs.existsSync(path.join(storageRootDir, "bot-storage.json"))).toBe(true);
+      expectRootNotVisited(visitedDirs, storageRootDir);
+    }
+  });
+
+  it("never traverses or opens archived inbound dedupe roots", async () => {
+    const stateDir = tempDirs.make("openclaw-matrix-doctor-");
+    const matrixRoot = path.join(stateDir, "matrix");
+    const activeRoots = [
+      path.join(matrixRoot, "accounts", "home", "matrix.example.org__bot", "0123456789abcdef"),
+      path.join(matrixRoot, "accounts", "legacy"),
+    ];
+    const archivedRoots = [
+      path.join(
+        matrixRoot,
+        "accounts",
+        "home",
+        "matrix.example.org__bot",
+        "0123456789abcdef.pre-stable-token-20260716",
+      ),
+      path.join(
+        matrixRoot,
+        "accounts",
+        "home",
+        "matrix.example.org__bot",
+        "sync-cache-backup-after-limit1-20260720",
+        "fedcba9876543210",
+      ),
+      path.join(
+        matrixRoot,
+        ".apr24-cutover-20260424",
+        "accounts",
+        "home",
+        "matrix.example.org__bot",
+        "fedcba9876543210",
+      ),
+      path.join(
+        matrixRoot,
+        "accounts",
+        "home",
+        "matrix.example.org__bot",
+        "fedcba9876543210.migrated",
+      ),
+    ];
+    const now = Date.now();
+    for (const [index, storageRootDir] of activeRoots.entries()) {
+      fs.mkdirSync(storageRootDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(storageRootDir, "inbound-dedupe.json"),
+        JSON.stringify({
+          version: 1,
+          entries: [{ key: `!room:example.org|$active-${index}`, ts: now - 60_000 }],
+        }),
+      );
+      fs.writeFileSync(
+        path.join(storageRootDir, "storage-meta.json"),
+        JSON.stringify({ accountId: index === 0 ? "home" : "legacy" }),
+      );
+    }
+    for (const storageRootDir of archivedRoots) {
+      fs.mkdirSync(path.join(storageRootDir, "state"), { recursive: true });
+      fs.writeFileSync(
+        path.join(storageRootDir, "state", "openclaw.sqlite"),
+        "archived SQLite sentinel must not be opened",
+      );
+      fs.writeFileSync(
+        path.join(storageRootDir, "inbound-dedupe.json"),
+        JSON.stringify({
+          version: 1,
+          entries: [{ key: "!room:example.org|$archived", ts: now - 60_000 }],
+        }),
+      );
+    }
+
+    const visitedDirs: string[] = [];
+    const originalReaddir = fsPromises.readdir.bind(fsPromises);
+    vi.spyOn(fsPromises, "readdir").mockImplementation(async (...args) => {
+      visitedDirs.push(path.resolve(String(args[0])));
+      return originalReaddir(...args);
+    });
+
+    const result = await migrationById(
+      "matrix-inbound-dedupe-to-claimable-dedupe",
+    ).migrateLegacyState(createMigrationParams(stateDir));
+
+    expect(result.warnings).toEqual([]);
+    expect(result.changes).toEqual([
+      "Migrated Matrix inbound dedupe markers to the claimable dedupe store (2 of 2 entries)",
+      ...activeRoots.map(
+        (storageRootDir) =>
+          `Archived Matrix inbound dedupe legacy source -> ${path.join(storageRootDir, "inbound-dedupe.json")}.migrated`,
+      ),
+      "Recorded Matrix inbound dedupe migration completion (0 SQLite roots, 2 JSON roots scanned)",
+    ]);
+    for (const storageRootDir of archivedRoots) {
+      expect(fs.existsSync(path.join(storageRootDir, "inbound-dedupe.json"))).toBe(true);
+      expect(fs.readFileSync(path.join(storageRootDir, "state", "openclaw.sqlite"), "utf8")).toBe(
+        "archived SQLite sentinel must not be opened",
+      );
+      expectRootNotVisited(visitedDirs, storageRootDir);
+    }
+  });
+});

--- a/extensions/matrix/doctor-contract-api.archive-scan.test.ts
+++ b/extensions/matrix/doctor-contract-api.archive-scan.test.ts
@@ -1,0 +1,266 @@
+// Matrix tests cover bounded doctor state-root discovery.
+import fs from "node:fs";
+import fsPromises from "node:fs/promises";
+import path from "node:path";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import type {
+  OpenKeyedStoreOptions,
+  PluginStateKeyedStore,
+} from "openclaw/plugin-sdk/plugin-state-runtime";
+import {
+  createPluginStateKeyedStoreForTests,
+  getPluginStateCapacityForTests,
+  importPluginStateEntriesForDoctorForTests,
+  resetPluginStateStoreForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import type { PluginDoctorStateMigrationContext } from "openclaw/plugin-sdk/runtime-doctor-migrations";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { stateMigrations } from "./doctor-contract-api.js";
+import { installMatrixTestRuntime } from "./src/test-runtime.js";
+import { useAutoCleanupTempDirTracker } from "./test-support.js";
+
+function createMigrationParams(stateDir: string) {
+  const env = { OPENCLAW_STATE_DIR: stateDir };
+  const context: PluginDoctorStateMigrationContext = {
+    getPluginStateCapacity: () => getPluginStateCapacityForTests("matrix", env),
+    importPluginStateEntries: (options, entries) =>
+      importPluginStateEntriesForDoctorForTests("matrix", options, entries),
+    openPluginStateKeyedStore: <T>(options: OpenKeyedStoreOptions): PluginStateKeyedStore<T> =>
+      createPluginStateKeyedStoreForTests<T>("matrix", options),
+  };
+  return {
+    config: {} as OpenClawConfig,
+    env,
+    stateDir,
+    oauthDir: path.join(stateDir, "oauth"),
+    context,
+  };
+}
+
+function migrationById(id: string) {
+  const migration = stateMigrations.find((entry) => entry.id === id);
+  if (!migration) {
+    throw new Error(`missing migration ${id}`);
+  }
+  return migration;
+}
+
+function writeLegacySyncCache(storageRootDir: string, nextBatch: string): void {
+  fs.mkdirSync(storageRootDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(storageRootDir, "bot-storage.json"),
+    JSON.stringify({
+      version: 1,
+      savedSync: {
+        nextBatch,
+        accountData: [],
+        roomsData: { join: {}, invite: {}, leave: {}, knock: {} },
+      },
+      cleanShutdown: true,
+    }),
+  );
+}
+
+function expectRootNotVisited(visitedDirs: string[], storageRootDir: string): void {
+  const root = path.resolve(storageRootDir);
+  expect(
+    visitedDirs.some(
+      (visitedDir) => visitedDir === root || visitedDir.startsWith(`${root}${path.sep}`),
+    ),
+  ).toBe(false);
+}
+
+describe("matrix doctor archive scan boundaries", () => {
+  const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+  beforeEach(() => {
+    resetPluginStateStoreForTests();
+    installMatrixTestRuntime();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    resetPluginStateStoreForTests();
+  });
+
+  it("keeps archive-like account IDs active while excluding token-root archives", async () => {
+    const stateDir = tempDirs.make("openclaw-matrix-doctor-");
+    const matrixRoot = path.join(stateDir, "matrix");
+    const activeRoots = [
+      path.join(matrixRoot, "accounts", "legacy"),
+      path.join(
+        matrixRoot,
+        "accounts",
+        "sync-cache-backup",
+        "matrix.example.org__bot",
+        "0123456789abcdef",
+      ),
+    ];
+    const excludedRoots = [
+      path.join(
+        matrixRoot,
+        "accounts",
+        "ops",
+        "matrix.example.org__bot",
+        "0123456789abcdef.apr24-cutover-20260424",
+      ),
+      path.join(
+        matrixRoot,
+        "accounts",
+        "ops",
+        "matrix.example.org__bot",
+        "fedcba9876543210.reset-20260720",
+      ),
+      path.join(matrixRoot, "accounts", "ops", "matrix.example.org__bot", "sync-cache-backup"),
+      path.join(
+        matrixRoot,
+        "crypto-backup-20260720",
+        "accounts",
+        "ops",
+        "matrix.example.org__bot",
+        "fedcba9876543210",
+      ),
+      path.join(
+        matrixRoot,
+        "accounts",
+        "ops",
+        "matrix.example.org__bot",
+        "fedcba9876543210.migrated",
+      ),
+      path.join(
+        matrixRoot,
+        "operator-copy",
+        "accounts",
+        "ops",
+        "matrix.example.org__bot",
+        "fedcba9876543210",
+      ),
+    ];
+    for (const [index, storageRootDir] of [...activeRoots, ...excludedRoots].entries()) {
+      writeLegacySyncCache(storageRootDir, `legacy-token-${index}`);
+    }
+
+    const visitedDirs: string[] = [];
+    const originalReaddir = fsPromises.readdir.bind(fsPromises);
+    vi.spyOn(fsPromises, "readdir").mockImplementation(async (...args) => {
+      visitedDirs.push(path.resolve(String(args[0])));
+      return originalReaddir(...args);
+    });
+
+    const migration = migrationById("matrix-sync-cache-json-to-plugin-state");
+    await expect(migration.detectLegacyState(createMigrationParams(stateDir))).resolves.toEqual({
+      preview: activeRoots.map(
+        (storageRootDir) => `Matrix sync cache JSON can migrate to SQLite: ${storageRootDir}`,
+      ),
+    });
+    const result = await migration.migrateLegacyState(createMigrationParams(stateDir));
+
+    expect(result.warnings).toEqual([]);
+    expect(result.changes).toHaveLength(activeRoots.length * 2);
+    for (const storageRootDir of activeRoots) {
+      expect(fs.existsSync(path.join(storageRootDir, "bot-storage.json"))).toBe(false);
+      expect(fs.existsSync(path.join(storageRootDir, "bot-storage.json.migrated"))).toBe(true);
+    }
+    for (const storageRootDir of excludedRoots) {
+      expect(fs.existsSync(path.join(storageRootDir, "bot-storage.json"))).toBe(true);
+      expectRootNotVisited(visitedDirs, storageRootDir);
+    }
+  });
+
+  it("imports dedupe state for archive-like account IDs without opening token archives", async () => {
+    const stateDir = tempDirs.make("openclaw-matrix-doctor-");
+    const matrixRoot = path.join(stateDir, "matrix");
+    const activeRoots = [
+      path.join(matrixRoot, "accounts", "legacy"),
+      path.join(
+        matrixRoot,
+        "accounts",
+        "sync-cache-backup",
+        "matrix.example.org__bot",
+        "0123456789abcdef",
+      ),
+    ];
+    const archivedRoots = [
+      path.join(
+        matrixRoot,
+        "accounts",
+        "home",
+        "matrix.example.org__bot",
+        "0123456789abcdef.pre-stable-token-20260716",
+      ),
+      path.join(matrixRoot, "accounts", "home", "matrix.example.org__bot", "sync-cache-backup"),
+      path.join(
+        matrixRoot,
+        ".apr24-cutover-20260424",
+        "accounts",
+        "home",
+        "matrix.example.org__bot",
+        "fedcba9876543210",
+      ),
+      path.join(
+        matrixRoot,
+        "accounts",
+        "home",
+        "matrix.example.org__bot",
+        "fedcba9876543210.migrated",
+      ),
+    ];
+    const now = Date.now();
+    for (const [index, storageRootDir] of activeRoots.entries()) {
+      fs.mkdirSync(storageRootDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(storageRootDir, "inbound-dedupe.json"),
+        JSON.stringify({
+          version: 1,
+          entries: [{ key: `!room:example.org|$active-${index}`, ts: now - 60_000 }],
+        }),
+      );
+      fs.writeFileSync(
+        path.join(storageRootDir, "storage-meta.json"),
+        JSON.stringify({ accountId: index === 0 ? "sync-cache-backup" : "legacy" }),
+      );
+    }
+    for (const storageRootDir of archivedRoots) {
+      fs.mkdirSync(path.join(storageRootDir, "state"), { recursive: true });
+      fs.writeFileSync(
+        path.join(storageRootDir, "state", "openclaw.sqlite"),
+        "archived SQLite sentinel must not be opened",
+      );
+      fs.writeFileSync(
+        path.join(storageRootDir, "inbound-dedupe.json"),
+        JSON.stringify({
+          version: 1,
+          entries: [{ key: "!room:example.org|$archived", ts: now - 60_000 }],
+        }),
+      );
+    }
+
+    const visitedDirs: string[] = [];
+    const originalReaddir = fsPromises.readdir.bind(fsPromises);
+    vi.spyOn(fsPromises, "readdir").mockImplementation(async (...args) => {
+      visitedDirs.push(path.resolve(String(args[0])));
+      return originalReaddir(...args);
+    });
+
+    const result = await migrationById(
+      "matrix-inbound-dedupe-to-claimable-dedupe",
+    ).migrateLegacyState(createMigrationParams(stateDir));
+
+    expect(result.warnings).toEqual([]);
+    expect(result.changes).toEqual([
+      "Migrated Matrix inbound dedupe markers to the claimable dedupe store (2 of 2 entries)",
+      ...activeRoots.map(
+        (storageRootDir) =>
+          `Archived Matrix inbound dedupe legacy source -> ${path.join(storageRootDir, "inbound-dedupe.json")}.migrated`,
+      ),
+      "Recorded Matrix inbound dedupe migration completion (0 SQLite roots, 2 JSON roots scanned)",
+    ]);
+    for (const storageRootDir of archivedRoots) {
+      expect(fs.existsSync(path.join(storageRootDir, "inbound-dedupe.json"))).toBe(true);
+      expect(fs.readFileSync(path.join(storageRootDir, "state", "openclaw.sqlite"), "utf8")).toBe(
+        "archived SQLite sentinel must not be opened",
+      );
+      expectRootNotVisited(visitedDirs, storageRootDir);
+    }
+  });
+});

--- a/extensions/matrix/doctor-contract-api.archive-scan.test.ts
+++ b/extensions/matrix/doctor-contract-api.archive-scan.test.ts
@@ -16,6 +16,8 @@ import {
 import type { PluginDoctorStateMigrationContext } from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { stateMigrations } from "./doctor-contract-api.js";
+import { SqliteBackedMatrixSyncStore } from "./src/matrix/client/file-sync-store.js";
+import { createMatrixInboundEventDeduper } from "./src/matrix/monitor/inbound-dedupe.js";
 import { installMatrixTestRuntime } from "./src/test-runtime.js";
 import { useAutoCleanupTempDirTracker } from "./test-support.js";
 
@@ -61,6 +63,54 @@ function writeLegacySyncCache(storageRootDir: string, nextBatch: string): void {
   );
 }
 
+function createStateRoots(stateDir: string) {
+  const matrixRoot = path.join(stateDir, "matrix");
+  const tokenParent = path.join(matrixRoot, "accounts", "ops", "matrix.example.org__bot");
+  return {
+    activeRoots: [
+      path.join(matrixRoot, "accounts", "legacy"),
+      path.join(
+        matrixRoot,
+        "accounts",
+        "sync-cache-backup",
+        "matrix.example.org__bot",
+        "0123456789abcdef",
+      ),
+    ],
+    excludedRoots: [
+      "0123456789abcdef.apr24-cutover-20260424",
+      "fedcba9876543210.reset-20260720",
+      "0123456789abcdef.pre-stable-token-20260716",
+      "fedcba9876543210.migrated",
+      "sync-cache-backup",
+      "_archive",
+    ]
+      .map((name) => path.join(tokenParent, name))
+      .concat(
+        ["crypto-backup-20260720", ".apr24-cutover-20260424", "operator-copy"].map((name) =>
+          path.join(
+            matrixRoot,
+            name,
+            "accounts",
+            "ops",
+            "matrix.example.org__bot",
+            "fedcba9876543210",
+          ),
+        ),
+      ),
+  };
+}
+
+function trackVisitedDirectories(): string[] {
+  const visitedDirs: string[] = [];
+  const originalReaddir = fsPromises.readdir.bind(fsPromises);
+  vi.spyOn(fsPromises, "readdir").mockImplementation(async (...args) => {
+    visitedDirs.push(path.resolve(String(args[0])));
+    return originalReaddir(...args);
+  });
+  return visitedDirs;
+}
+
 function expectRootNotVisited(visitedDirs: string[], storageRootDir: string): void {
   const root = path.resolve(storageRootDir);
   expect(
@@ -85,67 +135,12 @@ describe("matrix doctor archive scan boundaries", () => {
 
   it("keeps archive-like account IDs active while excluding token-root archives", async () => {
     const stateDir = tempDirs.make("openclaw-matrix-doctor-");
-    const matrixRoot = path.join(stateDir, "matrix");
-    const activeRoots = [
-      path.join(matrixRoot, "accounts", "legacy"),
-      path.join(
-        matrixRoot,
-        "accounts",
-        "sync-cache-backup",
-        "matrix.example.org__bot",
-        "0123456789abcdef",
-      ),
-    ];
-    const excludedRoots = [
-      path.join(
-        matrixRoot,
-        "accounts",
-        "ops",
-        "matrix.example.org__bot",
-        "0123456789abcdef.apr24-cutover-20260424",
-      ),
-      path.join(
-        matrixRoot,
-        "accounts",
-        "ops",
-        "matrix.example.org__bot",
-        "fedcba9876543210.reset-20260720",
-      ),
-      path.join(matrixRoot, "accounts", "ops", "matrix.example.org__bot", "sync-cache-backup"),
-      path.join(
-        matrixRoot,
-        "crypto-backup-20260720",
-        "accounts",
-        "ops",
-        "matrix.example.org__bot",
-        "fedcba9876543210",
-      ),
-      path.join(
-        matrixRoot,
-        "accounts",
-        "ops",
-        "matrix.example.org__bot",
-        "fedcba9876543210.migrated",
-      ),
-      path.join(
-        matrixRoot,
-        "operator-copy",
-        "accounts",
-        "ops",
-        "matrix.example.org__bot",
-        "fedcba9876543210",
-      ),
-    ];
+    const { activeRoots, excludedRoots } = createStateRoots(stateDir);
     for (const [index, storageRootDir] of [...activeRoots, ...excludedRoots].entries()) {
       writeLegacySyncCache(storageRootDir, `legacy-token-${index}`);
     }
 
-    const visitedDirs: string[] = [];
-    const originalReaddir = fsPromises.readdir.bind(fsPromises);
-    vi.spyOn(fsPromises, "readdir").mockImplementation(async (...args) => {
-      visitedDirs.push(path.resolve(String(args[0])));
-      return originalReaddir(...args);
-    });
+    const visitedDirs = trackVisitedDirectories();
 
     const migration = migrationById("matrix-sync-cache-json-to-plugin-state");
     await expect(migration.detectLegacyState(createMigrationParams(stateDir))).resolves.toEqual({
@@ -157,7 +152,9 @@ describe("matrix doctor archive scan boundaries", () => {
 
     expect(result.warnings).toEqual([]);
     expect(result.changes).toHaveLength(activeRoots.length * 2);
-    for (const storageRootDir of activeRoots) {
+    for (const [index, storageRootDir] of activeRoots.entries()) {
+      const store = new SqliteBackedMatrixSyncStore(storageRootDir);
+      await expect(store.getSavedSyncToken()).resolves.toBe(`legacy-token-${index}`);
       expect(fs.existsSync(path.join(storageRootDir, "bot-storage.json"))).toBe(false);
       expect(fs.existsSync(path.join(storageRootDir, "bot-storage.json.migrated"))).toBe(true);
     }
@@ -169,42 +166,7 @@ describe("matrix doctor archive scan boundaries", () => {
 
   it("imports dedupe state for archive-like account IDs without opening token archives", async () => {
     const stateDir = tempDirs.make("openclaw-matrix-doctor-");
-    const matrixRoot = path.join(stateDir, "matrix");
-    const activeRoots = [
-      path.join(matrixRoot, "accounts", "legacy"),
-      path.join(
-        matrixRoot,
-        "accounts",
-        "sync-cache-backup",
-        "matrix.example.org__bot",
-        "0123456789abcdef",
-      ),
-    ];
-    const archivedRoots = [
-      path.join(
-        matrixRoot,
-        "accounts",
-        "home",
-        "matrix.example.org__bot",
-        "0123456789abcdef.pre-stable-token-20260716",
-      ),
-      path.join(matrixRoot, "accounts", "home", "matrix.example.org__bot", "sync-cache-backup"),
-      path.join(
-        matrixRoot,
-        ".apr24-cutover-20260424",
-        "accounts",
-        "home",
-        "matrix.example.org__bot",
-        "fedcba9876543210",
-      ),
-      path.join(
-        matrixRoot,
-        "accounts",
-        "home",
-        "matrix.example.org__bot",
-        "fedcba9876543210.migrated",
-      ),
-    ];
+    const { activeRoots, excludedRoots } = createStateRoots(stateDir);
     const now = Date.now();
     for (const [index, storageRootDir] of activeRoots.entries()) {
       fs.mkdirSync(storageRootDir, { recursive: true });
@@ -220,7 +182,7 @@ describe("matrix doctor archive scan boundaries", () => {
         JSON.stringify({ accountId: index === 0 ? "sync-cache-backup" : "legacy" }),
       );
     }
-    for (const storageRootDir of archivedRoots) {
+    for (const storageRootDir of excludedRoots) {
       fs.mkdirSync(path.join(storageRootDir, "state"), { recursive: true });
       fs.writeFileSync(
         path.join(storageRootDir, "state", "openclaw.sqlite"),
@@ -235,12 +197,7 @@ describe("matrix doctor archive scan boundaries", () => {
       );
     }
 
-    const visitedDirs: string[] = [];
-    const originalReaddir = fsPromises.readdir.bind(fsPromises);
-    vi.spyOn(fsPromises, "readdir").mockImplementation(async (...args) => {
-      visitedDirs.push(path.resolve(String(args[0])));
-      return originalReaddir(...args);
-    });
+    const visitedDirs = trackVisitedDirectories();
 
     const result = await migrationById(
       "matrix-inbound-dedupe-to-claimable-dedupe",
@@ -255,7 +212,16 @@ describe("matrix doctor archive scan boundaries", () => {
       ),
       "Recorded Matrix inbound dedupe migration completion (0 SQLite roots, 2 JSON roots scanned)",
     ]);
-    for (const storageRootDir of archivedRoots) {
+    for (const [index, accountId] of ["sync-cache-backup", "legacy"].entries()) {
+      const deduper = createMatrixInboundEventDeduper({
+        auth: { accountId },
+        env: { OPENCLAW_STATE_DIR: stateDir },
+      });
+      await expect(
+        deduper.claim({ roomId: "!room:example.org", eventId: `$active-${index}` }),
+      ).resolves.toEqual({ kind: "duplicate" });
+    }
+    for (const storageRootDir of excludedRoots) {
       expect(fs.existsSync(path.join(storageRootDir, "inbound-dedupe.json"))).toBe(true);
       expect(fs.readFileSync(path.join(storageRootDir, "state", "openclaw.sqlite"), "utf8")).toBe(
         "archived SQLite sentinel must not be opened",

--- a/extensions/matrix/doctor-contract-api.capacity.test.ts
+++ b/extensions/matrix/doctor-contract-api.capacity.test.ts
@@ -62,7 +62,7 @@ function writeLegacyDedupeSource(stateDir: string, now: number, withMetadata = f
     "accounts",
     "home",
     "matrix.example.org__bot",
-    "token-a",
+    "0123456789abcdef",
   );
   fs.mkdirSync(root, { recursive: true });
   const jsonPath = path.join(root, "inbound-dedupe.json");

--- a/extensions/matrix/doctor-contract-api.test.ts
+++ b/extensions/matrix/doctor-contract-api.test.ts
@@ -105,7 +105,7 @@ describe("matrix doctor contract state migrations", () => {
       "accounts",
       "default",
       "matrix.example.org__bot",
-      "token-hash",
+      "0123456789abcdef",
     );
     fs.mkdirSync(storageRootDir, { recursive: true });
     fs.writeFileSync(
@@ -198,7 +198,7 @@ describe("matrix doctor contract state migrations", () => {
       "accounts",
       "default",
       "matrix.example.org__bot",
-      "token-hash",
+      "0123456789abcdef",
     );
     fs.mkdirSync(storageRootDir, { recursive: true });
     fs.writeFileSync(
@@ -207,7 +207,7 @@ describe("matrix doctor contract state migrations", () => {
         homeserver: "https://matrix.example.org",
         userId: "@bot:example.org",
         accountId: "default",
-        accessTokenHash: "token-hash",
+        accessTokenHash: "0123456789abcdef",
         deviceId: "DEVICE",
         currentTokenStateClaimed: true,
       }),
@@ -267,7 +267,7 @@ describe("matrix doctor contract state migrations", () => {
       "accounts",
       "default",
       "matrix.example.org__bot",
-      "token-hash",
+      "0123456789abcdef",
     );
     fs.mkdirSync(storageRootDir, { recursive: true });
     fs.writeFileSync(
@@ -491,7 +491,7 @@ describe("matrix doctor contract state migrations", () => {
       "accounts",
       "ops",
       "matrix.example.org__bot",
-      "token-a",
+      "0123456789abcdef",
     );
     const jsonRoot = path.join(
       stateDir,
@@ -499,7 +499,7 @@ describe("matrix doctor contract state migrations", () => {
       "accounts",
       "home",
       "matrix.example.org__bot",
-      "token-b",
+      "fedcba9876543210",
     );
     fs.mkdirSync(sqliteRoot, { recursive: true });
     fs.mkdirSync(jsonRoot, { recursive: true });
@@ -701,7 +701,7 @@ describe("matrix doctor contract state migrations", () => {
       "accounts",
       "late",
       "matrix.example.org__bot",
-      "token-a",
+      "0123456789abcdef",
       "state",
       "openclaw.sqlite",
     );
@@ -717,7 +717,7 @@ describe("matrix doctor contract state migrations", () => {
   it("withholds completion after a directory read failure and imports the source on retry", async () => {
     const stateDir = tempDirs.make("openclaw-matrix-doctor-");
     const blockedDir = path.join(stateDir, "matrix", "accounts", "home");
-    const jsonRoot = path.join(blockedDir, "matrix.example.org__bot", "token-a");
+    const jsonRoot = path.join(blockedDir, "matrix.example.org__bot", "0123456789abcdef");
     const jsonPath = path.join(jsonRoot, "inbound-dedupe.json");
     const roomId = "!room:example.org";
     const eventId = "$found-on-retry";
@@ -803,7 +803,7 @@ describe("matrix doctor contract state migrations", () => {
       "accounts",
       "home",
       "matrix.example.org__bot",
-      "token-a",
+      "0123456789abcdef",
     );
     fs.mkdirSync(jsonRoot, { recursive: true });
     const jsonPath = path.join(jsonRoot, "inbound-dedupe.json");
@@ -834,7 +834,7 @@ describe("matrix doctor contract state migrations", () => {
       "accounts",
       "home",
       "matrix.example.org__bot",
-      "token-a",
+      "0123456789abcdef",
     );
     fs.mkdirSync(jsonRoot, { recursive: true });
     const jsonPath = path.join(jsonRoot, "inbound-dedupe.json");

--- a/extensions/matrix/doctor-contract-api.test.ts
+++ b/extensions/matrix/doctor-contract-api.test.ts
@@ -189,7 +189,7 @@ describe("matrix doctor contract state migrations", () => {
       "accounts",
       "default",
       "matrix.example.org__bot",
-      "token-hash",
+      "0123456789abcdef",
     );
     fs.mkdirSync(storageRootDir, { recursive: true });
     fs.writeFileSync(
@@ -282,7 +282,7 @@ describe("matrix doctor contract state migrations", () => {
       "accounts",
       "default",
       "matrix.example.org__bot",
-      "token-hash",
+      "0123456789abcdef",
     );
     fs.mkdirSync(storageRootDir, { recursive: true });
     fs.writeFileSync(
@@ -291,7 +291,7 @@ describe("matrix doctor contract state migrations", () => {
         homeserver: "https://matrix.example.org",
         userId: "@bot:example.org",
         accountId: "default",
-        accessTokenHash: "token-hash",
+        accessTokenHash: "0123456789abcdef",
         deviceId: "DEVICE",
         currentTokenStateClaimed: true,
       }),
@@ -351,7 +351,7 @@ describe("matrix doctor contract state migrations", () => {
       "accounts",
       "default",
       "matrix.example.org__bot",
-      "token-hash",
+      "0123456789abcdef",
     );
     fs.mkdirSync(storageRootDir, { recursive: true });
     fs.writeFileSync(
@@ -575,7 +575,7 @@ describe("matrix doctor contract state migrations", () => {
       "accounts",
       "ops",
       "matrix.example.org__bot",
-      "token-a",
+      "0123456789abcdef",
     );
     const jsonRoot = path.join(
       stateDir,
@@ -583,7 +583,7 @@ describe("matrix doctor contract state migrations", () => {
       "accounts",
       "home",
       "matrix.example.org__bot",
-      "token-b",
+      "fedcba9876543210",
     );
     fs.mkdirSync(sqliteRoot, { recursive: true });
     fs.mkdirSync(jsonRoot, { recursive: true });
@@ -785,7 +785,7 @@ describe("matrix doctor contract state migrations", () => {
       "accounts",
       "late",
       "matrix.example.org__bot",
-      "token-a",
+      "0123456789abcdef",
       "state",
       "openclaw.sqlite",
     );
@@ -801,7 +801,7 @@ describe("matrix doctor contract state migrations", () => {
   it("withholds completion after a directory read failure and imports the source on retry", async () => {
     const stateDir = tempDirs.make("openclaw-matrix-doctor-");
     const blockedDir = path.join(stateDir, "matrix", "accounts", "home");
-    const jsonRoot = path.join(blockedDir, "matrix.example.org__bot", "token-a");
+    const jsonRoot = path.join(blockedDir, "matrix.example.org__bot", "0123456789abcdef");
     const jsonPath = path.join(jsonRoot, "inbound-dedupe.json");
     const roomId = "!room:example.org";
     const eventId = "$found-on-retry";
@@ -887,7 +887,7 @@ describe("matrix doctor contract state migrations", () => {
       "accounts",
       "home",
       "matrix.example.org__bot",
-      "token-a",
+      "0123456789abcdef",
     );
     fs.mkdirSync(jsonRoot, { recursive: true });
     const jsonPath = path.join(jsonRoot, "inbound-dedupe.json");
@@ -918,7 +918,7 @@ describe("matrix doctor contract state migrations", () => {
       "accounts",
       "home",
       "matrix.example.org__bot",
-      "token-a",
+      "0123456789abcdef",
     );
     fs.mkdirSync(jsonRoot, { recursive: true });
     const jsonPath = path.join(jsonRoot, "inbound-dedupe.json");

--- a/extensions/matrix/doctor-contract-api.ts
+++ b/extensions/matrix/doctor-contract-api.ts
@@ -65,7 +65,10 @@ import {
   type MatrixInboundDedupeMigrationIo,
 } from "./src/matrix/monitor/inbound-dedupe-migration.js";
 import type { MatrixStoredRecoveryKey } from "./src/matrix/sdk/types.js";
-import { resolveMatrixCredentialsDir } from "./src/storage-paths.js";
+import {
+  resolveMatrixCredentialsDir,
+  resolveMatrixStateLayoutChildDepth,
+} from "./src/storage-paths.js";
 
 export { normalizeCompatibilityConfig, legacyConfigRules } from "./config-doctor-api.js";
 
@@ -140,7 +143,7 @@ async function collectLegacyMatrixStateRoots(
 ): Promise<string[]> {
   const matrixRoot = path.join(stateDir, "matrix");
   const roots: string[] = [];
-  async function visit(dir: string): Promise<void> {
+  async function visit(dir: string, depth: number): Promise<void> {
     let entries: Dirent[];
     try {
       entries = await fs.readdir(dir, { withFileTypes: true });
@@ -149,16 +152,23 @@ async function collectLegacyMatrixStateRoots(
     }
     for (const entry of entries) {
       const entryPath = path.join(dir, entry.name);
-      if (entry.isFile() && entry.name === filename) {
+      const isStorageRoot = depth === 0 || depth === 2 || depth === 4;
+      if (isStorageRoot && entry.isFile() && entry.name === filename) {
         roots.push(dir);
         continue;
       }
-      if (entry.isDirectory()) {
-        await visit(entryPath);
+      if (!entry.isDirectory()) {
+        continue;
+      }
+      // Only enter owned layout containers; archived and arbitrary descendants
+      // must never become migration roots just because they contain a known file.
+      const childDepth = resolveMatrixStateLayoutChildDepth(depth, entry.name);
+      if (childDepth !== null) {
+        await visit(entryPath, childDepth);
       }
     }
   }
-  await visit(matrixRoot);
+  await visit(matrixRoot, 0);
   return roots
     .filter((root) => options?.includeMatrixRoot || path.resolve(root) !== path.resolve(matrixRoot))
     .toSorted();

--- a/extensions/matrix/doctor-contract-api.ts
+++ b/extensions/matrix/doctor-contract-api.ts
@@ -65,12 +65,16 @@ import {
   type MatrixInboundDedupeMigrationIo,
 } from "./src/matrix/monitor/inbound-dedupe-migration.js";
 import type { MatrixStoredRecoveryKey } from "./src/matrix/sdk/types.js";
-import { resolveMatrixCredentialsDir } from "./src/storage-paths.js";
+import {
+  classifyMatrixStateRootDirectory,
+  resolveMatrixCredentialsDir,
+} from "./src/storage-paths.js";
 
 export { normalizeCompatibilityConfig, legacyConfigRules } from "./src/doctor-contract.js";
 
 const MATRIX_SYNC_CACHE_FILENAME = "bot-storage.json";
 const MATRIX_STORAGE_META_FILENAME = "storage-meta.json";
+const MATRIX_SERVER_USER_DIRECTORY_PATTERN = /^.+__.+$/u;
 
 type LegacyMatrixCredentialSource = {
   accountId: string | null;
@@ -140,7 +144,7 @@ async function collectLegacyMatrixStateRoots(
 ): Promise<string[]> {
   const matrixRoot = path.join(stateDir, "matrix");
   const roots: string[] = [];
-  async function visit(dir: string): Promise<void> {
+  async function visit(dir: string, depth: number): Promise<void> {
     let entries: Dirent[];
     try {
       entries = await fs.readdir(dir, { withFileTypes: true });
@@ -149,16 +153,32 @@ async function collectLegacyMatrixStateRoots(
     }
     for (const entry of entries) {
       const entryPath = path.join(dir, entry.name);
-      if (entry.isFile() && entry.name === filename) {
+      const isStorageRoot = depth === 0 || depth === 2 || depth === 4;
+      if (isStorageRoot && entry.isFile() && entry.name === filename) {
         roots.push(dir);
         continue;
       }
-      if (entry.isDirectory()) {
-        await visit(entryPath);
+      if (!entry.isDirectory()) {
+        continue;
+      }
+      const directoryKind = classifyMatrixStateRootDirectory(entry.name);
+      if (directoryKind === "archive") {
+        continue;
+      }
+      // Only enter owned layout containers; archived and arbitrary descendants
+      // must never become migration roots just because they contain a known file.
+      if (depth === 0 && entry.name === "accounts") {
+        await visit(entryPath, 1);
+      } else if (depth === 1) {
+        await visit(entryPath, 2);
+      } else if (depth === 2 && MATRIX_SERVER_USER_DIRECTORY_PATTERN.test(entry.name)) {
+        await visit(entryPath, 3);
+      } else if (depth === 3 && directoryKind === "active-token") {
+        await visit(entryPath, 4);
       }
     }
   }
-  await visit(matrixRoot);
+  await visit(matrixRoot, 0);
   return roots
     .filter((root) => options?.includeMatrixRoot || path.resolve(root) !== path.resolve(matrixRoot))
     .toSorted();

--- a/extensions/matrix/src/matrix/account-state-schema-doctor.ts
+++ b/extensions/matrix/src/matrix/account-state-schema-doctor.ts
@@ -4,15 +4,16 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import type { OpenClawStateDatabaseSchemaMigration } from "openclaw/plugin-sdk/doctor-repair-runtime";
 import type { PluginDoctorStateMigration } from "openclaw/plugin-sdk/runtime-doctor-migrations";
+import { resolveMatrixStateLayoutChildDepth } from "../storage-paths.js";
 import { resolveMatrixSqliteStateEnv } from "./sqlite-state.js";
 
 const STATE_DATABASE_FILENAME = "openclaw.sqlite";
 
 async function collectMatrixAccountStateRoots(stateDir: string): Promise<string[]> {
-  const accountsRoot = path.join(stateDir, "matrix", "accounts");
+  const matrixRoot = path.join(stateDir, "matrix");
   const roots = new Set<string>();
 
-  async function visit(dir: string, allowMissing = false): Promise<void> {
+  async function visit(dir: string, depth: number, allowMissing = false): Promise<void> {
     let entries: Dirent[];
     try {
       entries = await fs.readdir(dir, { withFileTypes: true });
@@ -30,19 +31,26 @@ async function collectMatrixAccountStateRoots(stateDir: string): Promise<string[
     }
     for (const entry of entries) {
       const entryPath = path.join(dir, entry.name);
-      if (
-        entry.isFile() &&
-        entry.name === STATE_DATABASE_FILENAME &&
-        path.basename(dir) === "state"
-      ) {
+      if (entry.isFile() && depth === 5 && entry.name === STATE_DATABASE_FILENAME) {
         roots.add(path.dirname(dir));
-      } else if (entry.isDirectory()) {
-        await visit(entryPath);
+        continue;
+      }
+      if (!entry.isDirectory()) {
+        continue;
+      }
+      const isStorageRoot = depth === 2 || depth === 4;
+      if (isStorageRoot && entry.name === "state") {
+        await visit(entryPath, 5);
+        continue;
+      }
+      const childDepth = resolveMatrixStateLayoutChildDepth(depth, entry.name);
+      if (childDepth !== null) {
+        await visit(entryPath, childDepth);
       }
     }
   }
 
-  await visit(accountsRoot, true);
+  await visit(matrixRoot, 0, true);
   return [...roots].toSorted();
 }
 

--- a/extensions/matrix/src/matrix/client/storage.test.ts
+++ b/extensions/matrix/src/matrix/client/storage.test.ts
@@ -480,6 +480,73 @@ describe("matrix client storage paths", () => {
     );
   });
 
+  it("selects the canonical active root without inspecting archived siblings", () => {
+    const logger = createTestLogger();
+    const stateDir = setupStateDir(undefined, logger);
+    const canonicalPaths = seedCanonicalStorageRoot({
+      stateDir,
+      accessToken: "secret-token-new",
+      storageMeta: {
+        homeserver: defaultStorageAuth.homeserver,
+        userId: defaultStorageAuth.userId,
+        accountId: "default",
+        accessTokenHash: resolveDefaultStoragePaths({ accessToken: "secret-token-new" }).tokenHash,
+        deviceId: "DEVICE123",
+      },
+    });
+    const previousPaths = seedCanonicalStorageRoot({
+      stateDir,
+      accessToken: "secret-token-old",
+      storageMeta: {
+        homeserver: defaultStorageAuth.homeserver,
+        userId: defaultStorageAuth.userId,
+        accountId: "default",
+        accessTokenHash: resolveDefaultStoragePaths({ accessToken: "secret-token-old" }).tokenHash,
+        deviceId: "DEVICE123",
+      },
+    });
+    fs.mkdirSync(path.join(previousPaths.rootDir, "crypto"), { recursive: true });
+    const archivedTokenRoot = `${previousPaths.rootDir}.apr24-cutover-20260424`;
+    fs.renameSync(previousPaths.rootDir, archivedTokenRoot);
+    const archivedBackupRoot = path.join(
+      path.dirname(canonicalPaths.rootDir),
+      "sync-cache-backup-after-limit1-20260720",
+    );
+    fs.mkdirSync(archivedBackupRoot, { recursive: true });
+    seedStorageMeta(archivedBackupRoot, {
+      homeserver: defaultStorageAuth.homeserver,
+      userId: defaultStorageAuth.userId,
+      accountId: "default",
+      accessTokenHash: "fedcba9876543210",
+      deviceId: "DEVICE123",
+    });
+    fs.mkdirSync(path.join(archivedBackupRoot, "crypto"), { recursive: true });
+    const archivedRoots = [archivedTokenRoot, archivedBackupRoot];
+    resetPluginStateStoreForTests();
+
+    const existsSync = vi.spyOn(fs, "existsSync");
+    const resolvedPaths = resolveDefaultStoragePaths({
+      accessToken: "secret-token-new",
+      deviceId: "DEVICE123",
+    });
+
+    expect(resolvedPaths.rootDir).toBe(canonicalPaths.rootDir);
+    expect(resolvedPaths.tokenHash).toBe(canonicalPaths.tokenHash);
+    const inspectedPaths = existsSync.mock.calls.map(([filePath]) =>
+      path.resolve(String(filePath)),
+    );
+    for (const storageRootDir of archivedRoots) {
+      expect(
+        inspectedPaths.some(
+          (inspectedPath) =>
+            inspectedPath === path.resolve(storageRootDir) ||
+            inspectedPath.startsWith(`${path.resolve(storageRootDir)}${path.sep}`),
+        ),
+      ).toBe(false);
+    }
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
   it("does not scan token-history roots when the canonical current-token state is claimed", () => {
     const logger = createTestLogger();
     const stateDir = setupStateDir(undefined, logger);

--- a/extensions/matrix/src/matrix/client/storage.ts
+++ b/extensions/matrix/src/matrix/client/storage.ts
@@ -6,7 +6,10 @@ import { normalizeAccountId } from "openclaw/plugin-sdk/account-id";
 import { loadJsonFile } from "openclaw/plugin-sdk/json-store";
 import type { PluginStateSyncKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
 import { getMatrixRuntime } from "../../runtime.js";
-import { resolveMatrixAccountStorageRoot } from "../../storage-paths.js";
+import {
+  isMatrixActiveTokenRootDirectory,
+  resolveMatrixAccountStorageRoot,
+} from "../../storage-paths.js";
 import {
   MATRIX_IDB_SNAPSHOT_FILENAME,
   MATRIX_LEGACY_CRYPTO_MIGRATION_FILENAME,
@@ -207,6 +210,11 @@ function resolvePreferredMatrixStorageRoot(params: {
       continue;
     }
     if (entry.name === params.canonicalTokenHash) {
+      continue;
+    }
+    // Sibling reuse is only defined for exact token-hash roots. Filtering here
+    // keeps archived SQLite state out of compatibility checks and scoring.
+    if (!isMatrixActiveTokenRootDirectory(entry.name)) {
       continue;
     }
     const candidateRootDir = path.join(parentDir, entry.name);

--- a/extensions/matrix/src/matrix/client/storage.ts
+++ b/extensions/matrix/src/matrix/client/storage.ts
@@ -10,7 +10,10 @@ import type {
 } from "openclaw/plugin-sdk/plugin-state-runtime";
 import { isRecord } from "../../record-shared.js";
 import { getMatrixRuntime } from "../../runtime.js";
-import { resolveMatrixAccountStorageRoot } from "../../storage-paths.js";
+import {
+  classifyMatrixStateRootDirectory,
+  resolveMatrixAccountStorageRoot,
+} from "../../storage-paths.js";
 import {
   MATRIX_IDB_SNAPSHOT_FILENAME,
   MATRIX_LEGACY_CRYPTO_MIGRATION_FILENAME,
@@ -270,6 +273,11 @@ function resolvePreferredMatrixStorageRoot(params: {
       continue;
     }
     if (entry.name === params.canonicalTokenHash) {
+      continue;
+    }
+    // Sibling reuse is only defined for exact token-hash roots. Filtering here
+    // keeps archived SQLite state out of compatibility checks and scoring.
+    if (classifyMatrixStateRootDirectory(entry.name) !== "active-token") {
       continue;
     }
     const candidateRootDir = path.join(parentDir, entry.name);

--- a/extensions/matrix/src/matrix/monitor/inbound-dedupe-migration.ts
+++ b/extensions/matrix/src/matrix/monitor/inbound-dedupe-migration.ts
@@ -20,6 +20,7 @@ import type { DatabaseSync } from "node:sqlite";
 import type { PersistentDedupeEntry } from "openclaw/plugin-sdk/persistent-dedupe";
 import type { PluginDoctorStateMigrationContext } from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { resolveMatrixStateLayoutChildDepth } from "../../storage-paths.js";
 import { normalizeMatrixStorageMetadata } from "../client/storage-metadata.js";
 
 const LEGACY_SQLITE_NAMESPACE = "inbound-dedupe";
@@ -126,7 +127,7 @@ export async function collectMatrixInboundDedupeSources(
   const sqliteRoots = new Set<string>();
   const jsonRoots = new Set<string>();
   const warnings: string[] = [];
-  async function visit(dir: string, allowMissing = false): Promise<void> {
+  async function visit(dir: string, depth: number, allowMissing = false): Promise<void> {
     let entries: Dirent[];
     try {
       entries = await fs.readdir(dir, { withFileTypes: true });
@@ -137,23 +138,33 @@ export async function collectMatrixInboundDedupeSources(
       warnings.push(`Failed scanning Matrix inbound dedupe sources under ${dir}: ${String(err)}`);
       return;
     }
+    const isStorageRoot = depth === 0 || depth === 2 || depth === 4;
     for (const entry of entries) {
       const entryPath = path.join(dir, entry.name);
       if (entry.isFile()) {
-        // Legacy per-root dedupe rows live in `<storageRoot>/state/openclaw.sqlite`.
-        if (entry.name === "openclaw.sqlite" && path.basename(dir) === "state") {
-          sqliteRoots.add(path.dirname(dir));
-        } else if (entry.name === MATRIX_LEGACY_INBOUND_DEDUPE_FILENAME) {
+        if (isStorageRoot && entry.name === MATRIX_LEGACY_INBOUND_DEDUPE_FILENAME) {
           jsonRoots.add(dir);
+        } else if (depth === 5 && entry.name === "openclaw.sqlite") {
+          sqliteRoots.add(path.dirname(dir));
         }
         continue;
       }
-      if (entry.isDirectory()) {
-        await visit(entryPath);
+      if (!entry.isDirectory()) {
+        continue;
+      }
+      if (isStorageRoot && entry.name === "state") {
+        await visit(entryPath, 5);
+        continue;
+      }
+      // The source census is deliberately bounded to current canonical roots
+      // and the two flat legacy levels that shipped migrations still consume.
+      const childDepth = resolveMatrixStateLayoutChildDepth(depth, entry.name);
+      if (childDepth !== null) {
+        await visit(entryPath, childDepth);
       }
     }
   }
-  await visit(matrixRoot, true);
+  await visit(matrixRoot, 0, true);
   const matrixRootResolved = path.resolve(matrixRoot);
   const isAccountRoot = (root: string) => path.resolve(root) !== matrixRootResolved;
   const roots = {

--- a/extensions/matrix/src/matrix/monitor/inbound-dedupe-migration.ts
+++ b/extensions/matrix/src/matrix/monitor/inbound-dedupe-migration.ts
@@ -25,6 +25,7 @@ import {
   runSqliteImmediateTransactionSync,
 } from "openclaw/plugin-sdk/sqlite-runtime";
 import { isRecord } from "../../record-shared.js";
+import { classifyMatrixStateRootDirectory } from "../../storage-paths.js";
 import { normalizeMatrixStorageMetadata } from "../client/storage.js";
 import {
   buildMatrixInboundDedupeEventKey,
@@ -38,6 +39,7 @@ const LEGACY_MARKERS_NAMESPACE = "inbound-dedupe-migrations";
 const LEGACY_JSON_VERSION = 1;
 const MATRIX_PLUGIN_ID = "matrix";
 const MIGRATION_COMPLETION_NAMESPACE = "inbound-dedupe-migration-state";
+const MATRIX_SERVER_USER_DIRECTORY_PATTERN = /^.+__.+$/u;
 const MIGRATION_COMPLETION_KEY = "sqlite-json-to-claimable-v1";
 const STATE_DATABASE_RELATIVE_PATH = path.join("state", "openclaw.sqlite");
 const STORAGE_META_FILENAME = "storage-meta.json";
@@ -137,7 +139,7 @@ export async function collectMatrixInboundDedupeSources(
   const sqliteRoots = new Set<string>();
   const jsonRoots = new Set<string>();
   const warnings: string[] = [];
-  async function visit(dir: string, allowMissing = false): Promise<void> {
+  async function visit(dir: string, depth: number, allowMissing = false): Promise<void> {
     let entries: Dirent[];
     try {
       entries = await fs.readdir(dir, { withFileTypes: true });
@@ -148,23 +150,42 @@ export async function collectMatrixInboundDedupeSources(
       warnings.push(`Failed scanning Matrix inbound dedupe sources under ${dir}: ${String(err)}`);
       return;
     }
+    const isStorageRoot = depth === 0 || depth === 2 || depth === 4;
     for (const entry of entries) {
       const entryPath = path.join(dir, entry.name);
       if (entry.isFile()) {
-        // Legacy per-root dedupe rows live in `<storageRoot>/state/openclaw.sqlite`.
-        if (entry.name === "openclaw.sqlite" && path.basename(dir) === "state") {
-          sqliteRoots.add(path.dirname(dir));
-        } else if (entry.name === MATRIX_LEGACY_INBOUND_DEDUPE_FILENAME) {
+        if (isStorageRoot && entry.name === MATRIX_LEGACY_INBOUND_DEDUPE_FILENAME) {
           jsonRoots.add(dir);
+        } else if (depth === 5 && entry.name === "openclaw.sqlite") {
+          sqliteRoots.add(path.dirname(dir));
         }
         continue;
       }
-      if (entry.isDirectory()) {
-        await visit(entryPath);
+      if (!entry.isDirectory()) {
+        continue;
+      }
+      const directoryKind = classifyMatrixStateRootDirectory(entry.name);
+      if (directoryKind === "archive") {
+        continue;
+      }
+      if (isStorageRoot && entry.name === "state") {
+        await visit(entryPath, 5);
+        continue;
+      }
+      // The source census is deliberately bounded to current canonical roots
+      // and the two flat legacy levels that shipped migrations still consume.
+      if (depth === 0 && entry.name === "accounts") {
+        await visit(entryPath, 1);
+      } else if (depth === 1) {
+        await visit(entryPath, 2);
+      } else if (depth === 2 && MATRIX_SERVER_USER_DIRECTORY_PATTERN.test(entry.name)) {
+        await visit(entryPath, 3);
+      } else if (depth === 3 && directoryKind === "active-token") {
+        await visit(entryPath, 4);
       }
     }
   }
-  await visit(matrixRoot, true);
+  await visit(matrixRoot, 0, true);
   const matrixRootResolved = path.resolve(matrixRoot);
   const isAccountRoot = (root: string) => path.resolve(root) !== matrixRootResolved;
   const roots = {

--- a/extensions/matrix/src/storage-paths.ts
+++ b/extensions/matrix/src/storage-paths.ts
@@ -4,6 +4,31 @@ import path from "node:path";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk/account-id";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 
+const MATRIX_TOKEN_HASH_DIRECTORY_PATTERN = /^[a-f0-9]{16}$/u;
+const MATRIX_SERVER_USER_DIRECTORY_PATTERN = /^.+__.+$/u;
+
+export function isMatrixActiveTokenRootDirectory(name: string): boolean {
+  return MATRIX_TOKEN_HASH_DIRECTORY_PATTERN.test(name);
+}
+
+// Layout position owns interpretation: account ids may resemble archives,
+// while only exact token hashes are active at the token-root depth.
+export function resolveMatrixStateLayoutChildDepth(depth: number, name: string): number | null {
+  if (depth === 0) {
+    return name === "accounts" ? 1 : null;
+  }
+  if (depth === 1) {
+    return 2;
+  }
+  if (depth === 2) {
+    return MATRIX_SERVER_USER_DIRECTORY_PATTERN.test(name) ? 3 : null;
+  }
+  if (depth === 3) {
+    return isMatrixActiveTokenRootDirectory(name) ? 4 : null;
+  }
+  return null;
+}
+
 export function sanitizeMatrixPathSegment(value: string): string {
   const cleaned = normalizeLowercaseStringOrEmpty(value)
     .replace(/[^a-z0-9._-]+/g, "_")

--- a/extensions/matrix/src/storage-paths.ts
+++ b/extensions/matrix/src/storage-paths.ts
@@ -4,6 +4,23 @@ import path from "node:path";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk/account-id";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 
+const MATRIX_TOKEN_HASH_DIRECTORY_PATTERN = /^[a-f0-9]{16}$/u;
+const MATRIX_TOKEN_HASH_ARCHIVE_PATTERN = /^[a-f0-9]{16}[._-].+$/u;
+const MATRIX_NAMED_ARCHIVE_PATTERN =
+  /^(?:(?:sync-cache-backup|crypto-backup)(?:[._-].*)?|.*\.migrated(?:[._-].*)?|\.(?:[^.]*-)?(?:cutover|backup|reset|pre-stable-token)(?:[._-].*)?)$/iu;
+
+export function classifyMatrixStateRootDirectory(
+  name: string,
+): "active-token" | "archive" | "other" {
+  if (MATRIX_TOKEN_HASH_DIRECTORY_PATTERN.test(name)) {
+    return "active-token";
+  }
+  if (MATRIX_TOKEN_HASH_ARCHIVE_PATTERN.test(name) || MATRIX_NAMED_ARCHIVE_PATTERN.test(name)) {
+    return "archive";
+  }
+  return "other";
+}
+
 export function sanitizeMatrixPathSegment(value: string): string {
   const cleaned = normalizeLowercaseStringOrEmpty(value)
     .replace(/[^a-z0-9._-]+/g, "_")


### PR DESCRIPTION
## What Problem This Solves

Matrix Doctor and startup root selection could descend into preserved backups, report migrations for archived files, and open archived SQLite stores. The work scaled with old state that operators deliberately moved aside, and an unclaimed current-token root could lose selection to an archived sibling.

## Why This Change Was Made

The Matrix storage-path owner now classifies directories by their position in the supported layout before a collector descends or root selection reads metadata. Account IDs remain unrestricted, including names resembling backups. Server/user containers retain the existing double-underscore shape, and active token roots match the 16 lowercase hexadecimal characters emitted by the existing access-token hash producer.

The three collectors keep their different error handling and legacy-root contracts. This avoids a name blacklist, configurable exclusions, or a generalized filesystem walker. No SQLite DDL, schema version, stored representation, migration format, configuration, or Matrix protocol changes are introduced.

## User Impact

Routine Doctor scans and token-root selection leave archived and arbitrary sibling trees untouched. Existing token rotation, same-device matching, claimed-current-root selection, flat per-account migrations, and the intentionally supported flat crypto/IndexedDB migration remain available.

Thanks to @shad0wca7 (Alexander Hill) for the fix. Maintainer follow-up consolidates duplicate archive fixtures, verifies migrated sync cursors through the runtime store class and imported dedupe markers through the runtime replay guard, and checks the entire archived released-database file remains byte-for-byte unchanged.

## Evidence

- Original production head: `2ff3384130ed8359fe3d6d5dc301f4526d8a8c41`; [exact-head CI passed](https://github.com/openclaw/openclaw/actions/runs/33970402173), including all 140 Matrix test files / 2,186 tests. The actual job log confirms the archive cases, token-root selection, and released-database Doctor CLI repair executed. The maintainer follow-up `9995a0cb978333d21f621ba97ae3a6a29ee88907` changes tests only; [updated exact-head CI passed](https://github.com/openclaw/openclaw/actions/runs/33983420044), including all 140 Matrix files / 2,186 tests and the strengthened Doctor CLI archive-byte preservation assertion.
- Maintainer-observed synthetic filesystem baseline on trusted main `ca70a3433a3d10b146ddf4717770699ebeb8d2d9`: one active root plus two archives produced **3 SQLite roots, 3 JSON roots, and 3 sync-migration previews**, instead of one active root. Compared with main `7755c7dc44e2432630c18844eedaf50d7845684e`, those collectors differ only in their metadata-module import; the traversal defect remains.
- Updated archive tests cover token suffixes, named backups, `.migrated`, the documented `_archive` directory, and arbitrary copied subtrees for both sync-cache and dedupe migration. They verify archives are never visited, active cursors reopen, and imported markers suppress replay under their metadata-owned account identities.
- The released `v2026.7.1` database fixture is repaired through the Doctor CLI and reopened for sync-cursor persistence, while its archived copy remains byte-for-byte unchanged. Existing suites cover token rotation, flat crypto/IndexedDB conversion, schema-v1 dedupe import/retirement, capacity, and read-failure retry semantics.
- Fresh automated review and an independent source challenge of the complete candidate, including test improvements: no actionable findings. Targeted formatting and `git diff --check` pass.

The contributor's isolated real-filesystem/SQLite proof on the unchanged production patch reported zero archived SQLite opens, the permission-trapped archive unchanged, canonical-root selection, both flat legacy crypto and IndexedDB stores migrated, and no Doctor warnings. This is synthetic filesystem/store proof, not authenticated Matrix-server proof; no live gateway or operator state was touched. Contributor code was not executed on the maintainer's credentialed Mac during this follow-up; updated tests passed in secretless fork CI.

### Compatibility review resolution

The [September 5 18:19 UTC ClawSweeper review](https://github.com/openclaw/openclaw/pull/112329#issuecomment-5127941553) covers the exact updated head, reports no findings and no remaining before-merge items, and accepts the upgrade evidence. The patch changes discovery boundaries only, with no data-model change. Current and `v2026.9.1` producers use the same accepted directory layout; the released-database repair/reopen test, flat migration tests, token-rotation tests, and unchanged-archive proof cover the concrete upgrade contracts.

Production LOC: +87/-25 (net +62). The growth establishes one shared layout boundary across collectors with different legacy and error semantics. Tests: +325/-13 (net +312), reduced by 42 lines while adding runtime-result and whole-file preservation assertions.
