### PR TITLE
fix(build): keep source checkout clean after builds

### DIFF
--- a/scripts/write-cli-startup-metadata.ts
+++ b/scripts/write-cli-startup-metadata.ts
@@ -1,8 +1,16 @@
 // Write Cli Startup Metadata script supports OpenClaw repository automation.
 import { spawn, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
-import { availableParallelism } from "node:os";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { availableParallelism, tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import pMap from "p-map";
@@ -318,8 +326,8 @@ function readBundledChannelCatalog(
 
 function createIsolatedRootHelpRenderContext(
   bundledPluginsDir: string = extensionsDir,
+  stateDir: string = path.join(rootDir, ".openclaw-build-root-help"),
 ): RootHelpRenderContext {
-  const stateDir = path.join(rootDir, ".openclaw-build-root-help");
   const workspaceDir = path.join(stateDir, "workspace");
   const homeDir = path.join(stateDir, "home");
   const env: NodeJS.ProcessEnv = {
@@ -751,9 +759,6 @@ export async function writeCliStartupMetadata(options?: {
   const nodesHelpSourceSignature = resolveNodesHelpSourceSignature(resolvedSourceRootDir);
   const subcommandHelpSourceSignature = resolveSubcommandHelpSourceSignature(resolvedSourceRootDir);
   const bundledPluginsDir = path.join(resolvedDistDir, "extensions");
-  const renderContext = createIsolatedRootHelpRenderContext(
-    existsSync(bundledPluginsDir) ? bundledPluginsDir : resolvedExtensionsDir,
-  );
   const channelOptions = dedupe([...CORE_CHANNEL_ORDER, ...channelCatalog.ids]);
 
   let existing: ExistingCliStartupMetadata | undefined;
@@ -821,6 +826,11 @@ export async function writeCliStartupMetadata(options?: {
     return;
   }
 
+  const renderStateDir = mkdtempSync(path.join(tmpdir(), "openclaw-build-root-help-"));
+  const renderContext = createIsolatedRootHelpRenderContext(
+    existsSync(bundledPluginsDir) ? bundledPluginsDir : resolvedExtensionsDir,
+    renderStateDir,
+  );
   const rootHelpTextPromise = reusableRootHelpText
     ? Promise.resolve(reusableRootHelpText)
     : (async () => {
@@ -862,21 +872,21 @@ export async function writeCliStartupMetadata(options?: {
     ? Promise.resolve(reusableBrowserHelpText)
     : commandHelpTextPromise
       ? commandHelpTextPromise.then((commandHelpText) => commandHelpText.browser)
-      : Promise.resolve(
+      : Promise.resolve().then(() =>
           (options?.renderSourceBrowserHelpText ?? renderSourceBrowserHelpText)(renderContext),
         );
   const secretsHelpTextPromise = reusableSecretsHelpText
     ? Promise.resolve(reusableSecretsHelpText)
     : commandHelpTextPromise
       ? commandHelpTextPromise.then((commandHelpText) => commandHelpText.secrets)
-      : Promise.resolve(
+      : Promise.resolve().then(() =>
           (options?.renderSourceSecretsHelpText ?? renderSourceSecretsHelpText)(renderContext),
         );
   const nodesHelpTextPromise = reusableNodesHelpText
     ? Promise.resolve(reusableNodesHelpText)
     : commandHelpTextPromise
       ? commandHelpTextPromise.then((commandHelpText) => commandHelpText.nodes)
-      : Promise.resolve(
+      : Promise.resolve().then(() =>
           (options?.renderSourceNodesHelpText ?? renderSourceNodesHelpText)(renderContext),
         );
   const subcommandHelpTextPromise = reusableSubcommandHelpText
@@ -891,19 +901,31 @@ export async function writeCliStartupMetadata(options?: {
               ]),
             ) as PrecomputedSubcommandHelpText,
         )
-      : Promise.resolve(
+      : Promise.resolve().then(() =>
           (options?.renderSourceSubcommandHelpTextRecord ?? renderSourceSubcommandHelpTextRecord)(
             renderContext,
           ),
         );
+  const helpTextPromises = [
+    rootHelpTextPromise,
+    browserHelpTextPromise,
+    secretsHelpTextPromise,
+    nodesHelpTextPromise,
+    subcommandHelpTextPromise,
+  ] as const;
+  let helpText: [string, string, string, string, PrecomputedSubcommandHelpText];
+  try {
+    try {
+      helpText = await Promise.all(helpTextPromises);
+    } catch (error) {
+      await Promise.allSettled(helpTextPromises);
+      throw error;
+    }
+  } finally {
+    rmSync(renderStateDir, { force: true, recursive: true });
+  }
   const [rootHelpText, browserHelpText, secretsHelpText, nodesHelpText, subcommandHelpText] =
-    await Promise.all([
-      rootHelpTextPromise,
-      browserHelpTextPromise,
-      secretsHelpTextPromise,
-      nodesHelpTextPromise,
-      subcommandHelpTextPromise,
-    ]);
+    helpText;
 
   mkdirSync(resolvedDistDir, { recursive: true });
   writeFileSync(

--- a/test/scripts/write-cli-startup-metadata.test.ts
+++ b/test/scripts/write-cli-startup-metadata.test.ts
@@ -1,7 +1,7 @@
 // Write Cli Startup Metadata tests cover write cli startup metadata script behavior.
 import { spawn, spawnSync } from "node:child_process";
 import { EventEmitter } from "node:events";
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { PassThrough } from "node:stream";
 import { pathToFileURL } from "node:url";
@@ -478,6 +478,71 @@ describe("write-cli-startup-metadata", () => {
     expect(written.subcommandHelpText.plugins).toContain("openclaw plugins");
     expect(written.subcommandHelpText.sessions).toContain("openclaw sessions");
     expect(written.subcommandHelpText.tasks).toContain("openclaw tasks");
+  });
+
+  it.each([
+    { label: "successful", renderError: undefined },
+    { label: "failed", renderError: new Error("browser help failed") },
+  ])("removes temporary render state after a $label render", async ({ renderError }) => {
+    const tempRoot = createTempDir("openclaw-startup-metadata-state-");
+    const distDir = path.join(tempRoot, "dist");
+    const extensionsDir = path.join(tempRoot, "extensions");
+    const outputPath = path.join(distDir, "cli-startup-metadata.json");
+    let renderStateDir = "";
+
+    writeStartupMetadataSourceSignatureFixture(tempRoot);
+    writeFixtureFile(distDir, "root-help-fixture.js", "export function outputRootHelp() {}\n");
+
+    const writeMetadata = writeCliStartupMetadata({
+      distDir,
+      outputPath,
+      extensionsDir,
+      sourceRootDir: tempRoot,
+      renderBundledRootHelpText: async () => "Usage: openclaw\n",
+      renderSourceBrowserHelpText: async (renderContext) => {
+        renderStateDir = renderContext.env?.OPENCLAW_STATE_DIR ?? "";
+        writeFixtureFile(renderStateDir, "state/openclaw.sqlite", "probe");
+        if (renderError) {
+          throw renderError;
+        }
+        return "Usage: openclaw browser\n";
+      },
+      renderSourceSecretsHelpText: async (renderContext) => {
+        if (renderError) {
+          await new Promise((resolve) => setTimeout(resolve, 25));
+          writeFixtureFile(
+            renderContext.env?.OPENCLAW_STATE_DIR ?? "",
+            "state/late-render",
+            "probe",
+          );
+        }
+        return "Usage: openclaw secrets\n";
+      },
+      renderSourceNodesHelpText: () => "Usage: openclaw nodes\n",
+      renderSourceSubcommandHelpTextRecord: () => ({
+        doctor: "Usage: openclaw doctor\n",
+        gateway: "Usage: openclaw gateway\n",
+        models: "Usage: openclaw models\n",
+        plugins: "Usage: openclaw plugins\n",
+        sessions: "Usage: openclaw sessions\n",
+        tasks: "Usage: openclaw tasks\n",
+      }),
+    });
+
+    try {
+      if (renderError) {
+        await expect(writeMetadata).rejects.toThrow(renderError.message);
+        await new Promise((resolve) => setTimeout(resolve, 50));
+      } else {
+        await expect(writeMetadata).resolves.toBeUndefined();
+      }
+      expect(renderStateDir).not.toBe("");
+      expect(existsSync(renderStateDir)).toBe(false);
+    } finally {
+      if (renderStateDir) {
+        rmSync(renderStateDir, { force: true, recursive: true });
+      }
+    }
   });
 
   it("renders independent startup help snapshots concurrently", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where maintainers running a full source build could be left with an untracked `.openclaw-build-root-help/` directory after CLI startup-help generation initialized SQLite state. Automated source-update jobs that require a clean checkout could then skip later updates.

## Why This Change Was Made

Startup-help renders now use a unique operating-system temporary directory and remove it after all render work settles, including failure paths. Generated CLI startup metadata and help output are unchanged.

## User Impact

Source builds no longer leave transient OpenClaw state in the repository, so clean-checkout automation can continue to run after a build.

## Evidence

- Reproduced the original behavior through the real `browser --help` render with `OPENCLAW_DISABLE_CLI_STARTUP_HELP_FAST_PATH=1`; it created `state/openclaw.sqlite`, `-shm`, and `-wal` beneath the configured repo-local render state directory.
- Added successful-render and failed-render lifecycle regressions. Before the fix both cases failed because the state directory remained; after the fix `test/scripts/write-cli-startup-metadata.test.ts` passes all 15 tests.
- Ran a real startup-metadata generation after the fix: temporary render-directory count remained `0 -> 0`, generated metadata was non-empty, and `.openclaw-build-root-help/` remained absent from the checkout.
- Passed scripts and root-test `tsgo` lanes, targeted `oxlint`, `oxfmt --check`, and `git diff --check`.

AI-assisted: implemented and validated with Codex; I reviewed the root cause, diff, and test evidence.
