### PR TITLE
feat(ui): show live output tokens while agents run

### DIFF
--- a/src/agents/embedded-agent-runner/run/progress-controller.ts
+++ b/src/agents/embedded-agent-runner/run/progress-controller.ts
@@ -2,7 +2,7 @@ import {
   FAST_MODE_AUTO_PROGRESS_KIND,
   type ReplyPayload,
 } from "../../../auto-reply/reply-payload.js";
-import { emitAgentItemEvent } from "../../../infra/agent-events.js";
+import { emitAgentItemEvent } from "../../../infra/agent-activity-events.js";
 import { formatErrorMessage } from "../../../infra/errors.js";
 import { resolveFastModeModelAutoOnSeconds } from "../../../shared/fast-mode.js";
 import {

--- a/src/agents/embedded-agent-subscribe.handlers.tools.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.ts
@@ -19,18 +19,17 @@ import {
 import { type AgentPlanStep, normalizeAgentPlanSteps } from "../channels/streaming.js";
 import { parseSessionThreadInfoFast } from "../config/sessions/thread-info.js";
 import type {
-  AgentApprovalEventData,
   AgentCommandOutputEventData,
   AgentItemEventData,
   AgentPatchSummaryEventData,
-} from "../infra/agent-events.js";
+} from "../infra/agent-activity-events.js";
 import {
   emitAgentApprovalEvent,
   emitAgentCommandOutputEvent,
-  emitAgentEvent,
   emitAgentItemEvent,
   emitAgentPatchSummaryEvent,
-} from "../infra/agent-events.js";
+} from "../infra/agent-activity-events.js";
+import { emitAgentEvent, type AgentApprovalEventData } from "../infra/agent-events.js";
 import { consumeRootOptionToken } from "../infra/cli-root-options.js";
 import type { ExecApprovalDecision } from "../infra/exec-approvals.js";
 import {

--- a/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts
+++ b/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts
@@ -262,6 +262,31 @@ describe("subscribeEmbeddedAgentSession", () => {
     });
   });
 
+  it("emits cumulative run output usage once per completed assistant message", () => {
+    const { emit, onAgentEvent } = createAgentEventHarness({ runId: "usage-event-run" });
+    const emitAssistantUsage = (output: number) => {
+      const usage = { input: 100, output, totalTokens: 100 + output };
+      emit({ type: "message_start", message: { role: "assistant" } });
+      emit({
+        type: "message_update",
+        message: { role: "assistant" },
+        assistantMessageEvent: { type: "done", usage },
+      });
+      emit({ type: "message_end", message: { role: "assistant", usage } });
+    };
+
+    emitAssistantUsage(12);
+    emitAssistantUsage(8);
+
+    const usageEvents = onAgentEvent.mock.calls
+      .map(([event]) => event)
+      .filter((event) => event.stream === "usage");
+    expect(usageEvents).toEqual([
+      { stream: "usage", data: { outputTokens: 12 } },
+      { stream: "usage", data: { outputTokens: 20 } },
+    ]);
+  });
+
   it.each([
     ["telegram", "gateway/channels/telegram"],
     [undefined, "agent/embedded"],

--- a/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts
+++ b/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts
@@ -30,13 +30,18 @@ describe("subscribeEmbeddedAgentSession", () => {
     await Promise.resolve();
   }
 
-  function createAgentEventHarness(options?: { runId?: string; sessionKey?: string }) {
+  function createAgentEventHarness(options?: {
+    runId?: string;
+    sessionKey?: string;
+    lifecycleGeneration?: string;
+  }) {
     const { session, emit } = createStubSessionHarness();
     const onAgentEvent = vi.fn();
 
     subscribeEmbeddedAgentSession({
       session,
       runId: options?.runId ?? "run",
+      lifecycleGeneration: options?.lifecycleGeneration,
       onAgentEvent,
       sessionKey: options?.sessionKey,
     });
@@ -263,7 +268,10 @@ describe("subscribeEmbeddedAgentSession", () => {
   });
 
   it("emits cumulative run output usage once per completed assistant message", () => {
-    const { emit, onAgentEvent } = createAgentEventHarness({ runId: "usage-event-run" });
+    const { emit, onAgentEvent } = createAgentEventHarness({
+      runId: "usage-event-run",
+      lifecycleGeneration: agentEvents.getAgentEventLifecycleGeneration(),
+    });
     const emitAssistantUsage = (output: number) => {
       const usage = { input: 100, output, totalTokens: 100 + output };
       emit({ type: "message_start", message: { role: "assistant" } });

--- a/src/agents/embedded-agent-subscribe.ts
+++ b/src/agents/embedded-agent-subscribe.ts
@@ -13,7 +13,7 @@ import { getReplyPayloadMetadata, setReplyPayloadMetadata } from "../auto-reply/
 import { createStreamingDirectiveAccumulator } from "../auto-reply/reply/streaming-directives.js";
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import { formatToolAggregate } from "../auto-reply/tool-meta.js";
-import { emitAgentEvent } from "../infra/agent-events.js";
+import { emitAgentEvent, emitAgentEventIfCurrent } from "../infra/agent-events.js";
 import { recordAgentRunOutputTokens } from "../infra/agent-run-usage.js";
 import type { AssistantMessage } from "../llm/types.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -636,7 +636,13 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
       runId: params.runId,
       lifecycleGeneration: params.lifecycleGeneration,
       outputTokens,
-      emit: (usage) => emitAgentEvent({ runId: params.runId, stream: "usage", data: usage }),
+      emit: (usage) =>
+        emitAgentEventIfCurrent({
+          runId: params.runId,
+          lifecycleGeneration: params.lifecycleGeneration,
+          stream: "usage",
+          data: usage,
+        }),
     });
     if (!data || !params.onAgentEvent) {
       return;

--- a/src/agents/embedded-agent-subscribe.ts
+++ b/src/agents/embedded-agent-subscribe.ts
@@ -14,6 +14,7 @@ import { createStreamingDirectiveAccumulator } from "../auto-reply/reply/streami
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import { formatToolAggregate } from "../auto-reply/tool-meta.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
+import { recordAgentRunOutputTokens } from "../infra/agent-run-usage.js";
 import type { AssistantMessage } from "../llm/types.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { findFinalTagMatches } from "../shared/text/final-tags.js";
@@ -630,6 +631,22 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     }
     return undefined;
   };
+  const emitRunUsage = (outputTokens: number) => {
+    const data = recordAgentRunOutputTokens({
+      runId: params.runId,
+      lifecycleGeneration: params.lifecycleGeneration,
+      outputTokens,
+      emit: (usage) => emitAgentEvent({ runId: params.runId, stream: "usage", data: usage }),
+    });
+    if (!data || !params.onAgentEvent) {
+      return;
+    }
+    runBestEffortCallback({
+      label: "usage agent event",
+      log,
+      callback: () => params.onAgentEvent?.({ stream: "usage", data }),
+    });
+  };
   const commitAssistantUsage = () => {
     if (state.assistantUsageCommitted || !state.pendingAssistantUsage) {
       return;
@@ -648,6 +665,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     // Retain the latest committed nonzero call so context accounting stays exact.
     lastAssistantUsage = { ...usage };
     state.assistantUsageCommitted = true;
+    emitRunUsage(usage.output ?? 0);
   };
   const recordAssistantUsage = (usageLike: unknown) => {
     if (state.assistantUsageCommitted) {

--- a/src/agents/embedded-agent-subscribe.ts
+++ b/src/agents/embedded-agent-subscribe.ts
@@ -632,14 +632,18 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     return undefined;
   };
   const emitRunUsage = (outputTokens: number) => {
+    const lifecycleGeneration = params.lifecycleGeneration;
+    if (!lifecycleGeneration) {
+      return;
+    }
     const data = recordAgentRunOutputTokens({
       runId: params.runId,
-      lifecycleGeneration: params.lifecycleGeneration,
+      lifecycleGeneration,
       outputTokens,
       emit: (usage) =>
         emitAgentEventIfCurrent({
           runId: params.runId,
-          lifecycleGeneration: params.lifecycleGeneration,
+          lifecycleGeneration,
           stream: "usage",
           data: usage,
         }),

--- a/src/infra/agent-activity-events.ts
+++ b/src/infra/agent-activity-events.ts
@@ -1,0 +1,114 @@
+import { emitAgentEvent, type AgentApprovalEventData } from "./agent-events.js";
+
+/** Lifecycle phase for a visible item in the agent activity feed. */
+type AgentItemEventPhase = "start" | "update" | "end";
+/** Status rendered for an item-level agent activity event. */
+type AgentItemEventStatus = "running" | "completed" | "failed" | "blocked";
+/** Item category used by channels and Control UI to choose progress presentation. */
+type AgentItemEventKind = "tool" | "command" | "patch" | "search" | "analysis" | (string & {});
+
+/** Payload for a single item shown in the agent activity stream. */
+export type AgentItemEventData = {
+  itemId: string;
+  phase: AgentItemEventPhase;
+  kind: AgentItemEventKind;
+  title: string;
+  status: AgentItemEventStatus;
+  name?: string;
+  meta?: string;
+  toolCallId?: string;
+  startedAt?: number;
+  endedAt?: number;
+  error?: string;
+  summary?: string;
+  progressText?: string;
+  /** Preserve item telemetry while letting channel progress render a sibling tool event instead. */
+  suppressChannelProgress?: boolean;
+  /** Preserve activity telemetry without rendering this internal item in channel progress. */
+  hideFromChannelProgress?: boolean;
+  approvalId?: string;
+  approvalSlug?: string;
+};
+
+/** Incremental command output payload associated with an item/tool call. */
+export type AgentCommandOutputEventData = {
+  itemId: string;
+  phase: "delta" | "end";
+  title: string;
+  toolCallId: string;
+  name?: string;
+  output?: string;
+  status?: AgentItemEventStatus | "running";
+  exitCode?: number | null;
+  durationMs?: number;
+  cwd?: string;
+};
+
+/** Patch summary payload emitted after an agent applies file changes. */
+export type AgentPatchSummaryEventData = {
+  itemId: string;
+  phase: "end";
+  title: string;
+  toolCallId: string;
+  name?: string;
+  added: string[];
+  modified: string[];
+  deleted: string[];
+  summary: string;
+};
+
+/** Emits an item activity event on the shared agent event bus. */
+export function emitAgentItemEvent(params: {
+  runId: string;
+  data: AgentItemEventData;
+  sessionKey?: string;
+}) {
+  emitAgentEvent({
+    runId: params.runId,
+    stream: "item",
+    data: params.data as unknown as Record<string, unknown>,
+    ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
+  });
+}
+
+/** Emits an approval event on the shared agent event bus. */
+export function emitAgentApprovalEvent(params: {
+  runId: string;
+  data: AgentApprovalEventData;
+  sessionKey?: string;
+}) {
+  emitAgentEvent({
+    runId: params.runId,
+    stream: "approval",
+    data: params.data as unknown as Record<string, unknown>,
+    ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
+  });
+}
+
+/** Emits command output for a running or completed item/tool call. */
+export function emitAgentCommandOutputEvent(params: {
+  runId: string;
+  data: AgentCommandOutputEventData;
+  sessionKey?: string;
+}) {
+  emitAgentEvent({
+    runId: params.runId,
+    stream: "command_output",
+    data: params.data as unknown as Record<string, unknown>,
+    ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
+  });
+}
+
+/** Emits a patch summary for a completed file-editing item/tool call. */
+export function emitAgentPatchSummaryEvent(params: {
+  runId: string;
+  data: AgentPatchSummaryEventData;
+  sessionKey?: string;
+}) {
+  emitAgentEvent({
+    runId: params.runId,
+    stream: "patch",
+    data: params.data as unknown as Record<string, unknown>,
+    ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
+  });
+}

--- a/src/infra/agent-events.test.ts
+++ b/src/infra/agent-events.test.ts
@@ -89,6 +89,7 @@ describe("agent-events sequencing", () => {
     const emitUsage = (outputTokens: number) => {
       recordAgentRunOutputTokens({
         runId: "usage-run",
+        lifecycleGeneration,
         outputTokens,
         emit: (data) => emitAgentEvent({ runId: "usage-run", stream: "usage", data }),
       });

--- a/src/infra/agent-events.test.ts
+++ b/src/infra/agent-events.test.ts
@@ -22,6 +22,7 @@ import {
   withAgentRunLifecycleGeneration,
 } from "./agent-events.js";
 import { emitAgentRunStatusEvent } from "./agent-run-status-events.js";
+import { recordAgentRunOutputTokens } from "./agent-run-usage.js";
 
 type AgentEventsModule = typeof import("./agent-events.js");
 
@@ -74,6 +75,34 @@ describe("agent-events sequencing", () => {
 
     clearAgentRunContext("shared-run", "post-restart");
     expect(getAgentRunContext("shared-run")).toBeUndefined();
+  });
+
+  test("accumulates output usage across attempts and resets with run context", () => {
+    const lifecycleGeneration = getAgentEventLifecycleGeneration();
+    registerAgentRunContext("usage-run", { sessionKey: "main", lifecycleGeneration });
+    const seen: number[] = [];
+    const stop = onAgentEvent((event) => {
+      if (event.runId === "usage-run" && event.stream === "usage") {
+        seen.push(event.data.outputTokens as number);
+      }
+    });
+    const emitUsage = (outputTokens: number) => {
+      recordAgentRunOutputTokens({
+        runId: "usage-run",
+        outputTokens,
+        emit: (data) => emitAgentEvent({ runId: "usage-run", stream: "usage", data }),
+      });
+    };
+
+    emitUsage(12);
+    registerAgentRunContext("usage-run", { sessionKey: "main", lifecycleGeneration });
+    emitUsage(8);
+    clearAgentRunContext("usage-run", lifecycleGeneration);
+    registerAgentRunContext("usage-run", { sessionKey: "main", lifecycleGeneration });
+    emitUsage(3);
+    stop();
+
+    expect(seen).toEqual([12, 20, 3]);
   });
 
   test("clears sequence state when guarded cleanup finds no run context", () => {

--- a/src/infra/agent-events.test.ts
+++ b/src/infra/agent-events.test.ts
@@ -8,6 +8,7 @@ import {
   emitAgentAuditEvent,
   emitAgentEvent,
   emitAgentEventForOwner,
+  emitAgentEventIfCurrent,
   getAgentEventLifecycleGeneration,
   getAgentRunContext,
   listAgentRunsForSession,
@@ -91,7 +92,13 @@ describe("agent-events sequencing", () => {
         runId: "usage-run",
         lifecycleGeneration,
         outputTokens,
-        emit: (data) => emitAgentEvent({ runId: "usage-run", stream: "usage", data }),
+        emit: (data) =>
+          emitAgentEventIfCurrent({
+            runId: "usage-run",
+            lifecycleGeneration,
+            stream: "usage",
+            data,
+          }),
       });
     };
 
@@ -340,18 +347,22 @@ describe("agent-events sequencing", () => {
     const seen: AgentEventPayload[] = [];
     const stop = onAgentEvent((event) => seen.push(event));
 
-    emitAgentEvent({
-      runId: "shared-run",
-      lifecycleGeneration: "pre-restart",
-      stream: "lifecycle",
-      data: { phase: "end" },
-    });
-    emitAgentEvent({
-      runId: "shared-run",
-      lifecycleGeneration: activeGeneration,
-      stream: "lifecycle",
-      data: { phase: "start", startedAt: 1_000 },
-    });
+    expect(
+      emitAgentEventIfCurrent({
+        runId: "shared-run",
+        lifecycleGeneration: "pre-restart",
+        stream: "lifecycle",
+        data: { phase: "end" },
+      }),
+    ).toBe(false);
+    expect(
+      emitAgentEventIfCurrent({
+        runId: "shared-run",
+        lifecycleGeneration: activeGeneration,
+        stream: "lifecycle",
+        data: { phase: "start", startedAt: 1_000 },
+      }),
+    ).toBe(true);
     stop();
 
     expect(seen).toHaveLength(1);

--- a/src/infra/agent-events.ts
+++ b/src/infra/agent-events.ts
@@ -656,12 +656,19 @@ function enrichAgentEvent(
   return enriched;
 }
 
+/** Emits an event only when its run ownership is still current. */
+export function emitAgentEventIfCurrent(event: Omit<AgentEventPayload, "seq" | "ts">): boolean {
+  const enriched = enrichAgentEvent(event);
+  if (!enriched) {
+    return false;
+  }
+  notifyListeners(getAgentEventState().listeners, enriched);
+  return true;
+}
+
 /** Emits an agent event after assigning per-run sequence, timestamp, and context metadata. */
 export function emitAgentEvent(event: Omit<AgentEventPayload, "seq" | "ts">) {
-  const enriched = enrichAgentEvent(event);
-  if (enriched) {
-    notifyListeners(getAgentEventState().listeners, enriched);
-  }
+  emitAgentEventIfCurrent(event);
 }
 
 export function emitAgentEventForOwner(

--- a/src/infra/agent-events.ts
+++ b/src/infra/agent-events.ts
@@ -507,7 +507,7 @@ export function clearAgentRunContext(
   }
   state.runContextById.delete(runId);
   state.seqByRun.delete(runId);
-  clearAgentRunUsage(runId);
+  clearAgentRunUsage(runId, lifecycleGeneration ?? existing?.lifecycleGeneration);
 }
 
 /** Releases one tracked owner and clears its context after the final owner exits. */
@@ -550,7 +550,7 @@ export function sweepStaleRunContexts(maxAgeMs = 30 * 60 * 1000): number {
     if (age > maxAgeMs) {
       state.runContextById.delete(runId);
       state.seqByRun.delete(runId);
-      clearAgentRunUsage(runId);
+      clearAgentRunUsage(runId, ctx.lifecycleGeneration);
       getAgentRunContextOwners(state).delete(runId);
       swept++;
     }

--- a/src/infra/agent-events.ts
+++ b/src/infra/agent-events.ts
@@ -6,51 +6,7 @@ import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 import { notifyListeners, registerListener } from "../shared/listeners.js";
 import { createAbortError } from "./abort-signal.js";
 import { hasInvalidLifecycleStartTimestamp } from "./agent-event-lifecycle.js";
-
-/** Stream name for agent events delivered to gateway listeners and plugin host hooks. */
-export type AgentEventStream =
-  | "lifecycle"
-  | "tool"
-  | "assistant"
-  | "error"
-  | "item"
-  | "plan"
-  | "approval"
-  | "command_output"
-  | "patch"
-  | "compaction"
-  | "thinking"
-  | (string & {});
-
-/** Lifecycle phase for a visible item in the agent activity feed. */
-type AgentItemEventPhase = "start" | "update" | "end";
-/** Status rendered for an item-level agent activity event. */
-type AgentItemEventStatus = "running" | "completed" | "failed" | "blocked";
-/** Item category used by channels and Control UI to choose progress presentation. */
-type AgentItemEventKind = "tool" | "command" | "patch" | "search" | "analysis" | (string & {});
-
-/** Payload for a single item shown in the agent activity stream. */
-export type AgentItemEventData = {
-  itemId: string;
-  phase: AgentItemEventPhase;
-  kind: AgentItemEventKind;
-  title: string;
-  status: AgentItemEventStatus;
-  name?: string;
-  meta?: string;
-  toolCallId?: string;
-  startedAt?: number;
-  endedAt?: number;
-  error?: string;
-  summary?: string;
-  progressText?: string;
-  /** Preserve item telemetry while letting channel progress render a sibling tool event instead. */
-  suppressChannelProgress?: boolean;
-  /** Preserve activity telemetry without rendering this internal item in channel progress. */
-  hideFromChannelProgress?: boolean;
-  approvalId?: string;
-  approvalSlug?: string;
-};
+import { clearAgentRunUsage, resetAgentRunUsageForTest } from "./agent-run-usage.js";
 
 /** Approval event phase for request/resolution transitions. */
 type AgentApprovalEventPhase = "requested" | "resolved";
@@ -76,32 +32,21 @@ export type AgentApprovalEventData = {
   message?: string;
 };
 
-/** Incremental command output payload associated with an item/tool call. */
-export type AgentCommandOutputEventData = {
-  itemId: string;
-  phase: "delta" | "end";
-  title: string;
-  toolCallId: string;
-  name?: string;
-  output?: string;
-  status?: AgentItemEventStatus | "running";
-  exitCode?: number | null;
-  durationMs?: number;
-  cwd?: string;
-};
-
-/** Patch summary payload emitted after an agent applies file changes. */
-export type AgentPatchSummaryEventData = {
-  itemId: string;
-  phase: "end";
-  title: string;
-  toolCallId: string;
-  name?: string;
-  added: string[];
-  modified: string[];
-  deleted: string[];
-  summary: string;
-};
+/** Stream name for agent events delivered to gateway listeners and plugin host hooks. */
+export type AgentEventStream =
+  | "lifecycle"
+  | "tool"
+  | "assistant"
+  | "usage"
+  | "error"
+  | "item"
+  | "plan"
+  | "approval"
+  | "command_output"
+  | "patch"
+  | "compaction"
+  | "thinking"
+  | (string & {});
 
 /** Enriched event delivered to subscribers after sequencing and context stamping. */
 export type AgentEventPayload = {
@@ -431,6 +376,7 @@ export function claimAgentRunContext(
     registeredAt: context.registeredAt ?? Date.now(),
   });
   state.seqByRun.delete(runId);
+  clearAgentRunUsage(runId);
   return claimId;
 }
 
@@ -561,6 +507,7 @@ export function clearAgentRunContext(
   }
   state.runContextById.delete(runId);
   state.seqByRun.delete(runId);
+  clearAgentRunUsage(runId);
 }
 
 /** Releases one tracked owner and clears its context after the final owner exits. */
@@ -603,6 +550,7 @@ export function sweepStaleRunContexts(maxAgeMs = 30 * 60 * 1000): number {
     if (age > maxAgeMs) {
       state.runContextById.delete(runId);
       state.seqByRun.delete(runId);
+      clearAgentRunUsage(runId);
       getAgentRunContextOwners(state).delete(runId);
       swept++;
     }
@@ -741,62 +689,6 @@ export function emitAgentAuditEvent(event: Omit<AgentEventPayload, "seq" | "ts">
   }
 }
 
-/** Emits an item activity event on the shared agent event bus. */
-export function emitAgentItemEvent(params: {
-  runId: string;
-  data: AgentItemEventData;
-  sessionKey?: string;
-}) {
-  emitAgentEvent({
-    runId: params.runId,
-    stream: "item",
-    data: params.data as unknown as Record<string, unknown>,
-    ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
-  });
-}
-
-/** Emits an approval event on the shared agent event bus. */
-export function emitAgentApprovalEvent(params: {
-  runId: string;
-  data: AgentApprovalEventData;
-  sessionKey?: string;
-}) {
-  emitAgentEvent({
-    runId: params.runId,
-    stream: "approval",
-    data: params.data as unknown as Record<string, unknown>,
-    ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
-  });
-}
-
-/** Emits command output for a running or completed item/tool call. */
-export function emitAgentCommandOutputEvent(params: {
-  runId: string;
-  data: AgentCommandOutputEventData;
-  sessionKey?: string;
-}) {
-  emitAgentEvent({
-    runId: params.runId,
-    stream: "command_output",
-    data: params.data as unknown as Record<string, unknown>,
-    ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
-  });
-}
-
-/** Emits a patch summary for a completed file-editing item/tool call. */
-export function emitAgentPatchSummaryEvent(params: {
-  runId: string;
-  data: AgentPatchSummaryEventData;
-  sessionKey?: string;
-}) {
-  emitAgentEvent({
-    runId: params.runId,
-    stream: "patch",
-    data: params.data as unknown as Record<string, unknown>,
-    ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
-  });
-}
-
 /** Subscribes to sequenced agent events; returns an unsubscribe callback. */
 export function onAgentEvent(listener: (evt: AgentEventPayload) => void) {
   const state = getAgentEventState();
@@ -817,6 +709,7 @@ export function onAgentAuditEvent(listener: (evt: AgentEventPayload) => void) {
 export function resetAgentEventsForTest(options?: { preserveListeners?: boolean }) {
   const state = getAgentEventState();
   state.seqByRun.clear();
+  resetAgentRunUsageForTest();
   if (!options?.preserveListeners) {
     state.listeners.clear();
     state.auditListeners.clear();

--- a/src/infra/agent-run-usage.test.ts
+++ b/src/infra/agent-run-usage.test.ts
@@ -8,13 +8,31 @@ import {
 describe("agent run usage", () => {
   beforeEach(() => resetAgentRunUsageForTest());
 
+  it("does not commit usage when run ownership rejects the event", () => {
+    const rejected = recordAgentRunOutputTokens({
+      runId: "stale-run",
+      lifecycleGeneration: "old-generation",
+      outputTokens: 12,
+      emit: () => false,
+    });
+    const accepted = recordAgentRunOutputTokens({
+      runId: "stale-run",
+      lifecycleGeneration: "old-generation",
+      outputTokens: 3,
+      emit: () => true,
+    });
+
+    expect(rejected).toBeUndefined();
+    expect(accepted?.outputTokens).toBe(3);
+  });
+
   it("clears only the targeted lifecycle generation", () => {
     const record = (lifecycleGeneration: string, outputTokens: number) =>
       recordAgentRunOutputTokens({
         runId: "shared-run",
         lifecycleGeneration,
         outputTokens,
-        emit: () => undefined,
+        emit: () => true,
       });
 
     expect(record("old-generation", 12)?.outputTokens).toBe(12);

--- a/src/infra/agent-run-usage.test.ts
+++ b/src/infra/agent-run-usage.test.ts
@@ -1,0 +1,28 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  clearAgentRunUsage,
+  recordAgentRunOutputTokens,
+  resetAgentRunUsageForTest,
+} from "./agent-run-usage.js";
+
+describe("agent run usage", () => {
+  beforeEach(() => resetAgentRunUsageForTest());
+
+  it("clears only the targeted lifecycle generation", () => {
+    const record = (lifecycleGeneration: string, outputTokens: number) =>
+      recordAgentRunOutputTokens({
+        runId: "shared-run",
+        lifecycleGeneration,
+        outputTokens,
+        emit: () => undefined,
+      });
+
+    expect(record("old-generation", 12)?.outputTokens).toBe(12);
+    expect(record("new-generation", 7)?.outputTokens).toBe(7);
+
+    clearAgentRunUsage("shared-run", "old-generation");
+
+    expect(record("new-generation", 3)?.outputTokens).toBe(10);
+    expect(record("old-generation", 2)?.outputTokens).toBe(2);
+  });
+});

--- a/src/infra/agent-run-usage.ts
+++ b/src/infra/agent-run-usage.ts
@@ -1,5 +1,5 @@
 /** Cumulative output-token usage for one active agent run. */
-export type AgentRunUsage = {
+type AgentRunUsage = {
   outputTokens: number;
 };
 

--- a/src/infra/agent-run-usage.ts
+++ b/src/infra/agent-run-usage.ts
@@ -1,0 +1,41 @@
+/** Cumulative output-token usage for one active agent run. */
+export type AgentRunUsage = {
+  outputTokens: number;
+};
+
+type RecordAgentRunOutputTokensParams = {
+  runId: string;
+  lifecycleGeneration?: string;
+  outputTokens: number;
+  emit: (usage: AgentRunUsage) => void;
+};
+
+const usageByRun = new Map<string, Map<string, AgentRunUsage>>();
+
+/** Adds one completed model call and commits the new total only when delivery succeeds. */
+export function recordAgentRunOutputTokens(
+  params: RecordAgentRunOutputTokensParams,
+): AgentRunUsage | undefined {
+  const outputTokens = Math.floor(params.outputTokens);
+  if (!Number.isFinite(outputTokens) || outputTokens <= 0) {
+    return undefined;
+  }
+  const lifecycleGeneration = params.lifecycleGeneration ?? "";
+  const usageByGeneration = usageByRun.get(params.runId) ?? new Map<string, AgentRunUsage>();
+  const previous = usageByGeneration.get(lifecycleGeneration);
+  const usage = {
+    outputTokens: (previous?.outputTokens ?? 0) + outputTokens,
+  };
+  params.emit(usage);
+  usageByGeneration.set(lifecycleGeneration, usage);
+  usageByRun.set(params.runId, usageByGeneration);
+  return usage;
+}
+
+export function clearAgentRunUsage(runId: string): void {
+  usageByRun.delete(runId);
+}
+
+export function resetAgentRunUsageForTest(): void {
+  usageByRun.clear();
+}

--- a/src/infra/agent-run-usage.ts
+++ b/src/infra/agent-run-usage.ts
@@ -5,7 +5,7 @@ type AgentRunUsage = {
 
 type RecordAgentRunOutputTokensParams = {
   runId: string;
-  lifecycleGeneration?: string;
+  lifecycleGeneration: string;
   outputTokens: number;
   emit: (usage: AgentRunUsage) => boolean;
 };
@@ -20,16 +20,15 @@ export function recordAgentRunOutputTokens(
   if (!Number.isFinite(outputTokens) || outputTokens <= 0) {
     return undefined;
   }
-  const lifecycleGeneration = params.lifecycleGeneration ?? "";
   const usageByGeneration = usageByRun.get(params.runId) ?? new Map<string, AgentRunUsage>();
-  const previous = usageByGeneration.get(lifecycleGeneration);
+  const previous = usageByGeneration.get(params.lifecycleGeneration);
   const usage = {
     outputTokens: (previous?.outputTokens ?? 0) + outputTokens,
   };
   if (!params.emit(usage)) {
     return undefined;
   }
-  usageByGeneration.set(lifecycleGeneration, usage);
+  usageByGeneration.set(params.lifecycleGeneration, usage);
   usageByRun.set(params.runId, usageByGeneration);
   return usage;
 }

--- a/src/infra/agent-run-usage.ts
+++ b/src/infra/agent-run-usage.ts
@@ -7,7 +7,7 @@ type RecordAgentRunOutputTokensParams = {
   runId: string;
   lifecycleGeneration?: string;
   outputTokens: number;
-  emit: (usage: AgentRunUsage) => void;
+  emit: (usage: AgentRunUsage) => boolean;
 };
 
 const usageByRun = new Map<string, Map<string, AgentRunUsage>>();
@@ -26,7 +26,9 @@ export function recordAgentRunOutputTokens(
   const usage = {
     outputTokens: (previous?.outputTokens ?? 0) + outputTokens,
   };
-  params.emit(usage);
+  if (!params.emit(usage)) {
+    return undefined;
+  }
   usageByGeneration.set(lifecycleGeneration, usage);
   usageByRun.set(params.runId, usageByGeneration);
   return usage;

--- a/src/infra/agent-run-usage.ts
+++ b/src/infra/agent-run-usage.ts
@@ -12,7 +12,7 @@ type RecordAgentRunOutputTokensParams = {
 
 const usageByRun = new Map<string, Map<string, AgentRunUsage>>();
 
-/** Adds one completed model call and commits the new total only when delivery succeeds. */
+/** Adds one completed model call and emits the new generation-scoped total. */
 export function recordAgentRunOutputTokens(
   params: RecordAgentRunOutputTokensParams,
 ): AgentRunUsage | undefined {
@@ -32,8 +32,16 @@ export function recordAgentRunOutputTokens(
   return usage;
 }
 
-export function clearAgentRunUsage(runId: string): void {
-  usageByRun.delete(runId);
+export function clearAgentRunUsage(runId: string, lifecycleGeneration?: string): void {
+  if (lifecycleGeneration === undefined) {
+    usageByRun.delete(runId);
+    return;
+  }
+  const usageByGeneration = usageByRun.get(runId);
+  usageByGeneration?.delete(lifecycleGeneration);
+  if (usageByGeneration?.size === 0) {
+    usageByRun.delete(runId);
+  }
 }
 
 export function resetAgentRunUsageForTest(): void {

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -3684,6 +3684,7 @@ export const en: TranslationMap = {
       preparingContext: "Preparing context…",
       startingModel: "Starting model…",
     },
+    outputTokens: "{count} output tokens",
     archivedSessionDisabled: "Restore this thread to send messages.",
     loadOlder: "Load older",
     sessionHeader: {

--- a/ui/src/pages/chat/chat-history.ts
+++ b/ui/src/pages/chat/chat-history.ts
@@ -342,6 +342,7 @@ export type ChatState = {
   chatAttachments: ChatAttachment[];
   chatQueue: ChatQueueItem[];
   chatRunId: string | null;
+  chatRunUsageById?: Map<string, number>;
   chatStream: string | null;
   chatStreamStartedAt: number | null;
   chatRunStartup?: ChatRunStartupState | null;

--- a/ui/src/pages/chat/chat-pane.ts
+++ b/ui/src/pages/chat/chat-pane.ts
@@ -246,7 +246,10 @@ import {
   readChatSessionSnapshot,
   type ChatMessageCache,
 } from "./session-message-cache.ts";
-import { reconcileWaitingApprovalsFromSnapshot } from "./tool-stream.ts";
+import {
+  reconcileWaitingApprovalsFromSnapshot,
+  resolveActiveRunOutputTokens,
+} from "./tool-stream.ts";
 import { configureToolTitleFetcher } from "./tool-titles.ts";
 import { workspaceResultConflictFromPlacement } from "./workspace-conflict.ts";
 
@@ -3293,10 +3296,11 @@ class ChatPane extends OpenClawLightDomElement {
       presenceEntries: readPresenceEntries(gatewaySnapshot.hello?.snapshot),
       presenceInstanceId: gatewaySnapshot.client?.instanceId,
     });
-    const displayRunId = state.chatRunId ?? selectedSession?.activeRunIds?.[0];
-    const runOutputTokens = displayRunId
-      ? (state.chatRunUsageById?.get(displayRunId) ?? null)
-      : null;
+    const runOutputTokens = resolveActiveRunOutputTokens({
+      localRunId: state.chatRunId,
+      activeRunIds: selectedSession?.activeRunIds,
+      usageByRun: state.chatRunUsageById,
+    });
     const props: ChatProps = {
       transcript: this.transcript,
       paneId: this.paneId,

--- a/ui/src/pages/chat/chat-pane.ts
+++ b/ui/src/pages/chat/chat-pane.ts
@@ -3293,6 +3293,10 @@ class ChatPane extends OpenClawLightDomElement {
       presenceEntries: readPresenceEntries(gatewaySnapshot.hello?.snapshot),
       presenceInstanceId: gatewaySnapshot.client?.instanceId,
     });
+    const displayRunId = state.chatRunId ?? selectedSession?.activeRunIds?.[0];
+    const runOutputTokens = displayRunId
+      ? (state.chatRunUsageById?.get(displayRunId) ?? null)
+      : null;
     const props: ChatProps = {
       transcript: this.transcript,
       paneId: this.paneId,
@@ -3343,6 +3347,7 @@ class ChatPane extends OpenClawLightDomElement {
       streamSegments: catalogKey ? [] : state.chatStreamSegments,
       stream: catalogKey ? null : state.chatStream,
       streamStartedAt: catalogKey ? null : state.chatStreamStartedAt,
+      runOutputTokens: catalogKey ? null : runOutputTokens,
       assistantAvatarUrl: resolveChatAvatarUrl(state),
       sendShortcut: state.settings.chatSendShortcut,
       followUpMode: state.chatFollowUpMode,

--- a/ui/src/pages/chat/chat-send.ts
+++ b/ui/src/pages/chat/chat-send.ts
@@ -129,6 +129,7 @@ export type ChatHost = ChatInputHistoryState &
     chatQueueByScope?: Record<string, ChatQueueItem[]>;
     chatRunId: string | null;
     chatRunStartup?: ChatRunStartupState | null;
+    chatRunUsageById?: Map<string, number>;
     chatSending: boolean;
     chatSendingScopeKey?: string | null;
     chatRunError?: { summary: string } | null;

--- a/ui/src/pages/chat/chat-state.ts
+++ b/ui/src/pages/chat/chat-state.ts
@@ -536,6 +536,7 @@ export function resetChatStateForRouteSession(
   state.chatEffectiveQueueMode = undefined;
   state.chatStream = null;
   state.observerDigest = null;
+  state.chatRunUsageById = new Map();
   state.chatSending = false;
   state.chatSendingScopeKey = null;
   state.chatSideChatTurns = [];
@@ -1269,6 +1270,7 @@ export function createPageState(
     chatEffectiveQueueMode: undefined,
     chatAttachments: [] as ChatAttachment[],
     chatRunId: null,
+    chatRunUsageById: new Map<string, number>(),
     chatStream: null,
     chatStreamStartedAt: null,
     chatRunStartup: null,

--- a/ui/src/pages/chat/chat-view.ts
+++ b/ui/src/pages/chat/chat-view.ts
@@ -105,9 +105,7 @@ export type ChatProps = {
   onGatewayQuestionSubmit?: (id: string, answers: Record<string, string[]>) => void | Promise<void>;
   onGatewayQuestionSkip?: (id: string) => void | Promise<void>;
   messages: unknown[];
-  historyPagination?: {
-    loading: boolean;
-  };
+  historyPagination?: { loading: boolean };
   sideChatTurns?: ChatSideResult[];
   sideChatPending?: ChatSideResultPending | null;
   sideChatHidden?: boolean;

--- a/ui/src/pages/chat/chat-view.ts
+++ b/ui/src/pages/chat/chat-view.ts
@@ -75,6 +75,13 @@ import "../../components/resizable-divider.ts";
 
 export { resetChatViewState } from "./chat-view-state.ts";
 
+type ChatReplyTarget = {
+  messageId: string;
+  text: string;
+  senderLabel?: string | null;
+  sourceMessageId?: string | null;
+};
+
 export type ChatProps = {
   transcript: ChatTranscriptController;
   paneId: string;
@@ -229,19 +236,9 @@ export type ChatProps = {
   basePath?: string;
   gatewayUrl?: string;
   composerControls?: TemplateResult | typeof nothing;
-  replyTarget?: {
-    messageId: string;
-    text: string;
-    senderLabel?: string | null;
-    sourceMessageId?: string | null;
-  } | null;
+  replyTarget?: ChatReplyTarget | null;
   onClearReply?: () => void;
-  onSetReply?: (target: {
-    messageId: string;
-    text: string;
-    senderLabel?: string | null;
-    sourceMessageId?: string | null;
-  }) => void;
+  onSetReply?: (target: ChatReplyTarget) => void;
   onRewindMessage?: (entryId: string) => Promise<boolean> | boolean;
   onForkMessage?: (entryId: string) => Promise<void> | void;
   sessionWorkspace?: SessionWorkspaceProps;

--- a/ui/src/pages/chat/chat-view.ts
+++ b/ui/src/pages/chat/chat-view.ts
@@ -115,6 +115,7 @@ export type ChatProps = {
   streamSegments: ChatStreamSegment[];
   stream: string | null;
   streamStartedAt: number | null;
+  runOutputTokens?: number | null;
   assistantAvatarUrl?: string | null;
   draft: string;
   queue: ChatQueueItem[];
@@ -341,6 +342,7 @@ export function renderChat(props: ChatProps) {
       streamSegments: props.streamSegments,
       stream: props.stream,
       streamStartedAt: props.streamStartedAt,
+      runOutputTokens: props.runOutputTokens,
       queue: props.queue,
       showThinking: props.showThinking,
       showToolCalls: props.showToolCalls,

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -1572,6 +1572,22 @@ describe("grouped chat rendering", () => {
     ).toBeNull();
   });
 
+  it("shows live output usage beside elapsed time", () => {
+    const container = document.createElement("div");
+
+    render(
+      renderStreamGroup([{ kind: "reading-indicator", key: "reading", startedAt: 1_000 }], {
+        runOutputTokens: 5_500,
+      }),
+      container,
+    );
+
+    expect(container.querySelector(".chat-working-indicator__elapsed")).not.toBeNull();
+    expect(container.querySelector(".chat-working-indicator__tokens")?.textContent?.trim()).toBe(
+      "5.5k output tokens",
+    );
+  });
+
   it("relabels the working indicator while the run waits for approval", () => {
     const container = document.createElement("div");
 
@@ -1579,6 +1595,7 @@ describe("grouped chat rendering", () => {
       renderStreamGroup([{ kind: "reading-indicator", key: "reading", startedAt: 1_000 }], {
         startupPhase: "starting_model",
         waitingApproval: true,
+        runOutputTokens: 5_500,
       }),
       container,
     );
@@ -1587,6 +1604,7 @@ describe("grouped chat rendering", () => {
       "Waiting for approval…",
     );
     expect(container.querySelector(".chat-working-indicator__elapsed")).toBeNull();
+    expect(container.querySelector(".chat-working-indicator__tokens")).toBeNull();
   });
 
   it("renders the active plan card inside the working stream group", () => {

--- a/ui/src/pages/chat/components/chat-message.ts
+++ b/ui/src/pages/chat/components/chat-message.ts
@@ -654,6 +654,7 @@ type StreamGroupOptions = {
   planActive?: boolean;
   startupPhase?: ChatRunStartupPhase;
   waitingApproval?: boolean;
+  runOutputTokens?: number | null;
   questionPrompts?: ReadonlyMap<string, QuestionPrompt>;
 };
 
@@ -690,7 +691,12 @@ export function renderStreamGroup(parts: StreamGroupPart[], opts: StreamGroupOpt
       <div class="chat-group-messages">
         ${parts.map((part) =>
           part.kind === "reading-indicator"
-            ? renderChatWorkingIndicator(part, opts.waitingApproval === true, opts.startupPhase)
+            ? renderChatWorkingIndicator(
+                part,
+                opts.waitingApproval === true,
+                opts.startupPhase,
+                opts.runOutputTokens,
+              )
             : part.kind === "question"
               ? renderQuestionStreamPart(part, opts)
               : part.kind === "plan"

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -110,6 +110,7 @@ type ChatThreadProps = {
   streamSegments: ChatStreamSegment[];
   stream: string | null;
   streamStartedAt: number | null;
+  runOutputTokens?: number | null;
   queue: ChatQueueItem[];
   showThinking: boolean;
   showToolCalls: boolean;
@@ -1294,6 +1295,7 @@ function renderChatThreadContents(
         planActive: Boolean(props.runActive),
         startupPhase: props.startupStatus?.phase,
         waitingApproval: props.waitingApproval,
+        runOutputTokens: props.runOutputTokens,
         onOpenSidebar: props.onOpenSidebar,
         assistant: assistantIdentity,
         basePath: props.basePath,

--- a/ui/src/pages/chat/components/chat-working-indicator.ts
+++ b/ui/src/pages/chat/components/chat-working-indicator.ts
@@ -30,6 +30,18 @@ function startupStatusLabel(phase: ChatRunStartupPhase): string {
   return t(STARTUP_STATUS_LABEL_KEYS[phase]);
 }
 
+function renderLiveOutputTokens(outputTokens: number | null | undefined) {
+  if (outputTokens === null || outputTokens === undefined) {
+    return nothing;
+  }
+  return html`
+    <span aria-hidden="true">·</span>
+    <span class="chat-working-indicator__tokens">
+      ${t("chat.outputTokens", { count: formatCompactTokenCount(outputTokens) })}
+    </span>
+  `;
+}
+
 function stanceClass(key: string): string {
   let hash = 0x811c9dc5;
   for (let i = 0; i < key.length; i++) {
@@ -51,6 +63,7 @@ export function renderChatWorkingIndicator(
   part: Extract<ChatItem, { kind: "reading-indicator" }>,
   waitingApproval = false,
   startupPhase?: ChatRunStartupPhase,
+  outputTokens?: number | null,
 ) {
   // The animated claw stays decorative; the text status exposes progress without
   // announcing every elapsed-time tick to screen readers.
@@ -69,6 +82,7 @@ export function renderChatWorkingIndicator(
                   class="chat-working-indicator__elapsed"
                   .startMs=${part.startedAt}
                 ></openclaw-elapsed-time>
+                ${renderLiveOutputTokens(outputTokens)}
               `
             : html`
                 <span class="agent-chat__sr-only">${t("common.working")}</span>
@@ -81,6 +95,7 @@ export function renderChatWorkingIndicator(
                   .startMs=${part.startedAt}
                   .seed=${part.key}
                 ></openclaw-working-phrase>
+                ${renderLiveOutputTokens(outputTokens)}
               `}
       </span>
     </div>

--- a/ui/src/pages/chat/tool-stream.node.test.ts
+++ b/ui/src/pages/chat/tool-stream.node.test.ts
@@ -108,6 +108,36 @@ function useToolStreamFakeTimers(): void {
   vi.setSystemTime(TOOL_STREAM_TEST_NOW);
 }
 
+describe("app-tool-stream run usage", () => {
+  it("tracks monotonic output usage for the active run", () => {
+    const host = createHost({ chatRunId: "run-1" });
+
+    handleAgentEvent(host, agentEvent("run-1", 1, "usage", { outputTokens: 12 }));
+    handleAgentEvent(host, agentEvent("run-1", 2, "usage", { outputTokens: 8 }));
+    handleAgentEvent(host, agentEvent("run-2", 1, "usage", { outputTokens: 30 }));
+
+    expect(host.chatRunUsageById?.get("run-1")).toBe(12);
+    expect(host.chatRunUsageById?.has("run-2")).toBe(false);
+
+    handleAgentEvent(host, agentEvent("run-1", 3, "lifecycle", { phase: "start" }));
+    handleAgentEvent(host, agentEvent("run-1", 4, "usage", { outputTokens: 3 }));
+
+    expect(host.chatRunUsageById?.get("run-1")).toBe(3);
+  });
+
+  it("keeps session-scoped usage separate for concurrent active runs", () => {
+    const host = createHost();
+
+    handleAgentEvent(host, agentEvent("run-a", 1, "usage", { outputTokens: 100 }));
+    handleAgentEvent(host, agentEvent("run-b", 1, "usage", { outputTokens: 10 }));
+
+    expect(Array.from(host.chatRunUsageById?.entries() ?? [])).toEqual([
+      ["run-a", 100],
+      ["run-b", 10],
+    ]);
+  });
+});
+
 describe("app-tool-stream plan snapshots", () => {
   it("stores a normalized snapshot and drops malformed entries", () => {
     const requestUpdate = vi.fn();

--- a/ui/src/pages/chat/tool-stream.node.test.ts
+++ b/ui/src/pages/chat/tool-stream.node.test.ts
@@ -5,6 +5,7 @@ import {
   handleSessionOperationEvent,
   reconcileWaitingApprovalsFromSnapshot,
   resetToolStream,
+  resolveActiveRunOutputTokens,
   type FallbackStatus,
   type PlanStatus,
   type ToolStreamEntry,
@@ -109,20 +110,18 @@ function useToolStreamFakeTimers(): void {
 }
 
 describe("app-tool-stream run usage", () => {
-  it("tracks monotonic output usage for the active run", () => {
-    const host = createHost({ chatRunId: "run-1" });
+  it("tracks monotonic output usage for a session-owned engine run", () => {
+    const host = createHost({ chatRunId: "client-run" });
 
-    handleAgentEvent(host, agentEvent("run-1", 1, "usage", { outputTokens: 12 }));
-    handleAgentEvent(host, agentEvent("run-1", 2, "usage", { outputTokens: 8 }));
-    handleAgentEvent(host, agentEvent("run-2", 1, "usage", { outputTokens: 30 }));
+    handleAgentEvent(host, agentEvent("engine-run", 1, "usage", { outputTokens: 12 }));
+    handleAgentEvent(host, agentEvent("engine-run", 2, "usage", { outputTokens: 8 }));
 
-    expect(host.chatRunUsageById?.get("run-1")).toBe(12);
-    expect(host.chatRunUsageById?.has("run-2")).toBe(false);
+    expect(host.chatRunUsageById?.get("engine-run")).toBe(12);
 
-    handleAgentEvent(host, agentEvent("run-1", 3, "lifecycle", { phase: "start" }));
-    handleAgentEvent(host, agentEvent("run-1", 4, "usage", { outputTokens: 3 }));
+    handleAgentEvent(host, agentEvent("engine-run", 3, "lifecycle", { phase: "start" }));
+    handleAgentEvent(host, agentEvent("engine-run", 4, "usage", { outputTokens: 3 }));
 
-    expect(host.chatRunUsageById?.get("run-1")).toBe(3);
+    expect(host.chatRunUsageById?.get("engine-run")).toBe(3);
   });
 
   it("keeps session-scoped usage separate for concurrent active runs", () => {
@@ -135,6 +134,30 @@ describe("app-tool-stream run usage", () => {
       ["run-a", 100],
       ["run-b", 10],
     ]);
+  });
+});
+
+describe("active run output usage selection", () => {
+  it("prefers local client-run usage and falls back to a server active run", () => {
+    const usageByRun = new Map([
+      ["client-run", 12],
+      ["engine-run", 30],
+    ]);
+
+    expect(
+      resolveActiveRunOutputTokens({
+        localRunId: "client-run",
+        activeRunIds: ["engine-run"],
+        usageByRun,
+      }),
+    ).toBe(12);
+    expect(
+      resolveActiveRunOutputTokens({
+        localRunId: "missing-client-run",
+        activeRunIds: ["missing-engine-run", "engine-run"],
+        usageByRun,
+      }),
+    ).toBe(30);
   });
 });
 

--- a/ui/src/pages/chat/tool-stream.node.test.ts
+++ b/ui/src/pages/chat/tool-stream.node.test.ts
@@ -5,7 +5,6 @@ import {
   handleSessionOperationEvent,
   reconcileWaitingApprovalsFromSnapshot,
   resetToolStream,
-  resolveActiveRunOutputTokens,
   type FallbackStatus,
   type PlanStatus,
   type ToolStreamEntry,
@@ -108,58 +107,6 @@ function useToolStreamFakeTimers(): void {
   vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
   vi.setSystemTime(TOOL_STREAM_TEST_NOW);
 }
-
-describe("app-tool-stream run usage", () => {
-  it("tracks monotonic output usage for a session-owned engine run", () => {
-    const host = createHost({ chatRunId: "client-run" });
-
-    handleAgentEvent(host, agentEvent("engine-run", 1, "usage", { outputTokens: 12 }));
-    handleAgentEvent(host, agentEvent("engine-run", 2, "usage", { outputTokens: 8 }));
-
-    expect(host.chatRunUsageById?.get("engine-run")).toBe(12);
-
-    handleAgentEvent(host, agentEvent("engine-run", 3, "lifecycle", { phase: "start" }));
-    handleAgentEvent(host, agentEvent("engine-run", 4, "usage", { outputTokens: 3 }));
-
-    expect(host.chatRunUsageById?.get("engine-run")).toBe(3);
-  });
-
-  it("keeps session-scoped usage separate for concurrent active runs", () => {
-    const host = createHost();
-
-    handleAgentEvent(host, agentEvent("run-a", 1, "usage", { outputTokens: 100 }));
-    handleAgentEvent(host, agentEvent("run-b", 1, "usage", { outputTokens: 10 }));
-
-    expect(Array.from(host.chatRunUsageById?.entries() ?? [])).toEqual([
-      ["run-a", 100],
-      ["run-b", 10],
-    ]);
-  });
-});
-
-describe("active run output usage selection", () => {
-  it("prefers local client-run usage and falls back to a server active run", () => {
-    const usageByRun = new Map([
-      ["client-run", 12],
-      ["engine-run", 30],
-    ]);
-
-    expect(
-      resolveActiveRunOutputTokens({
-        localRunId: "client-run",
-        activeRunIds: ["engine-run"],
-        usageByRun,
-      }),
-    ).toBe(12);
-    expect(
-      resolveActiveRunOutputTokens({
-        localRunId: "missing-client-run",
-        activeRunIds: ["missing-engine-run", "engine-run"],
-        usageByRun,
-      }),
-    ).toBe(30);
-  });
-});
 
 describe("app-tool-stream plan snapshots", () => {
   it("stores a normalized snapshot and drops malformed entries", () => {

--- a/ui/src/pages/chat/tool-stream.ts
+++ b/ui/src/pages/chat/tool-stream.ts
@@ -56,6 +56,7 @@ type ToolStreamHost = {
   agentsList?: { defaultId?: string | null } | null;
   hello?: { snapshot?: unknown } | null;
   chatRunId: string | null;
+  chatRunUsageById?: Map<string, number>;
   chatStream: string | null;
   chatStreamStartedAt: number | null;
   chatRunStartup?: ChatRunStartupState | null;
@@ -618,6 +619,29 @@ function resolveAcceptedSession(
   return { accepted: true, sessionKey };
 }
 
+function handleUsageEvent(host: ToolStreamHost, payload: AgentEventPayload): boolean {
+  if (payload.stream !== "usage") {
+    return false;
+  }
+  if (!resolveAcceptedSession(host, payload, { allowSessionScopedWhenIdle: true }).accepted) {
+    return true;
+  }
+  const rawOutputTokens = payload.data?.outputTokens;
+  if (typeof rawOutputTokens !== "number" || !Number.isFinite(rawOutputTokens)) {
+    return true;
+  }
+  const outputTokens = Math.floor(rawOutputTokens);
+  if (outputTokens < 0) {
+    return true;
+  }
+  const current = host.chatRunUsageById?.get(payload.runId);
+  if (current !== undefined && outputTokens <= current) {
+    return true;
+  }
+  host.chatRunUsageById = new Map(host.chatRunUsageById).set(payload.runId, outputTokens);
+  return true;
+}
+
 function handleLifecycleFallbackEvent(host: CompactionHost, payload: AgentEventPayload) {
   const data = payload.data ?? {};
   const phase = payload.stream === "fallback" ? "fallback" : toTrimmedString(data.phase);
@@ -860,6 +884,10 @@ export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPaylo
     }
   }
 
+  if (handleUsageEvent(host, payload)) {
+    return;
+  }
+
   // Handle compaction events
   if (payload.stream === "compaction") {
     handleCompactionEvent(host as CompactionHost, payload);
@@ -867,6 +895,15 @@ export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPaylo
   }
 
   if (payload.stream === "lifecycle") {
+    const phase = payload.data?.phase;
+    if (
+      (phase === "start" || phase === "end" || phase === "error") &&
+      host.chatRunUsageById?.has(payload.runId)
+    ) {
+      const usageByRun = new Map(host.chatRunUsageById);
+      usageByRun.delete(payload.runId);
+      host.chatRunUsageById = usageByRun;
+    }
     if (handleLifecycleApprovalEvent(host, payload)) {
       return;
     }

--- a/ui/src/pages/chat/tool-stream.ts
+++ b/ui/src/pages/chat/tool-stream.ts
@@ -366,6 +366,24 @@ export type WaitingApprovalStatus = {
   runId: string;
 };
 
+export function resolveActiveRunOutputTokens(params: {
+  localRunId?: string | null;
+  activeRunIds?: readonly string[];
+  usageByRun?: ReadonlyMap<string, number>;
+}): number | null {
+  const localUsage = params.localRunId ? params.usageByRun?.get(params.localRunId) : undefined;
+  if (localUsage !== undefined) {
+    return localUsage;
+  }
+  for (const runId of params.activeRunIds ?? []) {
+    const usage = params.usageByRun?.get(runId);
+    if (usage !== undefined) {
+      return usage;
+    }
+  }
+  return null;
+}
+
 type WaitingApprovalSnapshotHost = Pick<
   ToolStreamHost,
   | "sessionKey"
@@ -623,7 +641,12 @@ function handleUsageEvent(host: ToolStreamHost, payload: AgentEventPayload): boo
   if (payload.stream !== "usage") {
     return false;
   }
-  if (!resolveAcceptedSession(host, payload, { allowSessionScopedWhenIdle: true }).accepted) {
+  const sessionKey = toTrimmedString(payload.sessionKey);
+  if (sessionKey) {
+    if (!uiSessionEventMatches(host, sessionKey, toTrimmedString(payload.agentId))) {
+      return true;
+    }
+  } else if (!host.chatRunId || payload.runId !== host.chatRunId) {
     return true;
   }
   const rawOutputTokens = payload.data?.outputTokens;

--- a/ui/src/pages/chat/tool-stream.usage.node.test.ts
+++ b/ui/src/pages/chat/tool-stream.usage.node.test.ts
@@ -1,0 +1,104 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+import {
+  handleAgentEvent,
+  resolveActiveRunOutputTokens,
+  type ToolStreamEntry,
+} from "./tool-stream.ts";
+
+type ToolStreamHost = Parameters<typeof handleAgentEvent>[0];
+type AgentEvent = NonNullable<Parameters<typeof handleAgentEvent>[1]>;
+
+function createHost(overrides?: Partial<ToolStreamHost>): ToolStreamHost {
+  return {
+    sessionKey: "main",
+    chatRunId: null,
+    chatStream: null,
+    chatStreamStartedAt: null,
+    chatStreamSegments: [],
+    toolStreamById: new Map<string, ToolStreamEntry>(),
+    toolStreamOrder: [],
+    chatToolMessages: [],
+    toolStreamSyncTimer: null,
+    sessions: { setModelOverride: () => undefined },
+    ...overrides,
+  };
+}
+
+function agentEvent(
+  runId: string,
+  seq: number,
+  stream: AgentEvent["stream"],
+  data: AgentEvent["data"],
+  sessionKey?: string,
+): AgentEvent {
+  return {
+    runId,
+    seq,
+    stream,
+    ts: Date.now(),
+    ...(sessionKey ? { sessionKey } : {}),
+    data,
+  };
+}
+
+describe("app-tool-stream run usage", () => {
+  it("tracks monotonic output usage for a session-owned engine run", () => {
+    const host = createHost({ chatRunId: "client-run" });
+
+    handleAgentEvent(host, agentEvent("engine-run", 1, "usage", { outputTokens: 12 }, "main"));
+    handleAgentEvent(host, agentEvent("engine-run", 2, "usage", { outputTokens: 8 }, "main"));
+
+    expect(host.chatRunUsageById?.get("engine-run")).toBe(12);
+
+    handleAgentEvent(host, agentEvent("engine-run", 3, "lifecycle", { phase: "start" }, "main"));
+    handleAgentEvent(host, agentEvent("engine-run", 4, "usage", { outputTokens: 3 }, "main"));
+
+    expect(host.chatRunUsageById?.get("engine-run")).toBe(3);
+  });
+
+  it("keeps session-scoped usage separate for concurrent active runs", () => {
+    const host = createHost();
+
+    handleAgentEvent(host, agentEvent("run-a", 1, "usage", { outputTokens: 100 }, "main"));
+    handleAgentEvent(host, agentEvent("run-b", 1, "usage", { outputTokens: 10 }, "main"));
+
+    expect(Array.from(host.chatRunUsageById?.entries() ?? [])).toEqual([
+      ["run-a", 100],
+      ["run-b", 10],
+    ]);
+  });
+
+  it("requires the local run id when an event has no session identity", () => {
+    const host = createHost({ chatRunId: "client-run" });
+
+    handleAgentEvent(host, agentEvent("engine-run", 1, "usage", { outputTokens: 20 }));
+    handleAgentEvent(host, agentEvent("client-run", 2, "usage", { outputTokens: 7 }));
+
+    expect(Array.from(host.chatRunUsageById?.entries() ?? [])).toEqual([["client-run", 7]]);
+  });
+});
+
+describe("active run output usage selection", () => {
+  it("prefers local client-run usage and falls back to a server active run", () => {
+    const usageByRun = new Map([
+      ["client-run", 12],
+      ["engine-run", 30],
+    ]);
+
+    expect(
+      resolveActiveRunOutputTokens({
+        localRunId: "client-run",
+        activeRunIds: ["engine-run"],
+        usageByRun,
+      }),
+    ).toBe(12);
+    expect(
+      resolveActiveRunOutputTokens({
+        localRunId: "missing-client-run",
+        activeRunIds: ["missing-engine-run", "engine-run"],
+        usageByRun,
+      }),
+    ).toBe(30);
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Control UI users could see how long an agent had been working but could not see live output-token usage until the run finished.

## Why This Change Was Made

The agent runtime now publishes additive, cumulative per-run output-token usage events after completed model responses. Usage remains isolated by lifecycle generation, follows the existing session-scoped agent event path, and is kept separate from persisted post-run session totals. The Control UI tracks concurrent runs independently and shows the active run's count beside elapsed time without adding token-delta traffic.

## User Impact

During an active chat run, the working indicator now shows a compact output-token count next to elapsed time. The count updates after each completed model response and remains correct across retries, fallback attempts, reconnect attachment, concurrent runs, and run-ID differences between chat requests and engine execution.

### Before

![Working indicator with elapsed time only](https://artifacts.openclaw.ai/pr-live-run-token-usage-20260721/before.png)

### After

![Working indicator with elapsed time and live output tokens](https://artifacts.openclaw.ai/pr-live-run-token-usage-20260721/after.png)

## Evidence

- Focused latest-main tests: 40 infra, 65 agents, and 126 UI tests passed on Node 24.
- Blacksmith Testbox `tbx_01ky4421rje1ran675bxtn1y3a` ([run](https://github.com/openclaw/openclaw/actions/runs/29893326240)): repository-wide lint, both Knip deadcode scans, and all focused tests passed in 4m46s.
- Final autoreview: Codex `gpt-5.6-sol`, high reasoning, clean with no accepted/actionable findings.
- Visual proof used the isolated Control UI mock gateway; the operator gateway and live state were not touched.
- Artifact manifest: https://artifacts.openclaw.ai/pr-live-run-token-usage-20260721/artifact-manifest.json

AI-assisted: yes. I reviewed the implementation and validation results.
