### PR TITLE
fix(config): allow provider overlay revalidation

### DIFF
--- a/src/config/config-misc.test.ts
+++ b/src/config/config-misc.test.ts
@@ -148,6 +148,28 @@ describe("model provider localService config", () => {
     }
   });
 
+  it("revalidates materialized bundled provider overlays", () => {
+    const first = validateConfigObjectRaw({
+      models: {
+        providers: {
+          google: {
+            timeoutSeconds: 600,
+          },
+        },
+      },
+    });
+
+    expect(first.ok).toBe(true);
+    if (!first.ok) {
+      throw new Error("expected bundled provider overlay to pass initial validation");
+    }
+    expect(first.config.models?.providers?.google?.baseUrl).toBe("");
+    expect(first.config.models?.providers?.google?.models).toEqual([]);
+
+    const second = validateConfigObjectRaw(first.config);
+    expect(second.ok).toBe(true);
+  });
+
   it("rejects standalone timeout overlays for unknown model providers", () => {
     const result = OpenClawSchema.safeParse({
       models: {

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -502,7 +502,9 @@ export function isBuiltInModelProviderOverlayId(providerId: string): boolean {
 
 const ModelProviderSchema = z
   .object({
-    baseUrl: z.string().min(1).optional(),
+    // Bundled provider overlays are materialized with an empty-string sentinel.
+    // ModelProvidersSchema below still rejects empty baseUrl values for custom providers.
+    baseUrl: z.string().optional(),
     apiKey: SecretInputSchema.optional().register(sensitive),
     auth: z
       .union([z.literal("api-key"), z.literal("aws-sdk"), z.literal("oauth"), z.literal("token")])


### PR DESCRIPTION
## Summary

- Make raw config validation idempotent for bundled model-provider overlays.
- Preserve strict `baseUrl` validation for custom providers.
- Add a regression test that validates the materialized Google overlay twice.

## What Problem This Solves

OpenClaw can accept a bundled provider overlay, materialize it into its canonical internal shape, and then reject that same shape on a later validation pass. This blocks config migration and repair flows such as `openclaw doctor --fix --non-interactive`.

## Root Cause

On `main` at `46632e9e3f7`, a real update/doctor run accepted a bundled `models.providers.google` overlay, then stopped during a later validation pass with:

```text
models.providers.google.baseUrl: Too small: expected string to have >=1 characters
```

The inspected code shows why:

- `validateConfigObjectRaw` calls `materializeBundledModelProviderOverlays` after its initial schema parse.
- That materializer intentionally fills omitted bundled-provider fields with `baseUrl: ""` and `models: []`.
- `ModelProviderSchema` required every present `baseUrl` string to contain at least one character.
- Revalidating the already-materialized config therefore failed before `ModelProvidersSchema.superRefine` could apply the intended bundled-versus-custom provider distinction.

The regression came from the mismatch between the bundled overlay materialization contract and the provider field schema. Existing tests already assert that the canonical bundled overlay contains the empty-string sentinel.

## Why This Change Was Made

The field schema now accepts the canonical empty-string sentinel. The enclosing provider-map refinement remains the ownership boundary for provider-kind validation and still rejects missing or empty `baseUrl` values for custom providers.

## User Impact

Doctor, migration, and config-write paths can safely revalidate materialized bundled provider overlays instead of failing on OpenClaw's own canonical output. Custom provider declarations remain required to supply a non-empty `baseUrl` and a `models` array.

## Evidence

### Real behavior proof

Before the patch, the real update path reached `openclaw doctor --fix --non-interactive` and stopped on the Google overlay error shown above.

After the patch, the regression test performs these exact steps:

1. Validate a bundled Google provider overlay.
2. Confirm OpenClaw materializes `baseUrl: ""` and `models: []`.
3. Pass that returned config back through `validateConfigObjectRaw`.
4. Confirm the second validation succeeds.

Exact focused command and result:

```text
OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs src/config/config-misc.test.ts src/config/zod-schema.models.test.ts
[test] passed 1 Vitest shard in 3.67s
```

Broader config schema/write proof:

```text
OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs src/config/schema.test.ts src/config/io.write-config.test.ts
[test] passed 1 Vitest shard in 11.01s
```

The patch was then overlaid onto a real source-checkout update of an existing OpenClaw installation. The updater completed a fresh state snapshot before its checkout reset, applied this PR, ran doctor/finalization, reinstalled the managed service, and verified the replacement Gateway.

Exact live command:

```text
OPENCLAW_UPDATE_INCLUDE_PRS=112334 oc-update
```

Sanitized copied updater result (the local snapshot path and runtime identifiers are omitted):

```text
OpenClaw state backup completed: <snapshot-path-redacted>
==> Enforcing OpenClaw state backup safety gate
==> Discarding local tracked changes
applied: #112334 fix(config): allow provider overlay revalidation
└  Doctor complete.
Update finalization completed.
Replacement Gateway verified: pid=<redacted> instance=<redacted> entrypoint=<sha256> runtime=<sha256>.
Gateway restart log audit: 30 gateway entries, 1 ready marker(s), no error/fatal entries.
```

The original `models.providers.google.baseUrl` validation error did not recur. Doctor completed, config validation remained successful, the replacement CLI and Gateway both reported `2026.7.2`, RPC was available, and verbose health returned:

```json
{
  "ok": true,
  "pluginErrors": 0,
  "channelsRunningWithoutErrors": true
}
```

## Verification

- `pnpm test src/config/config-misc.test.ts` — 95 tests passed.
- `pnpm test src/config/zod-schema.models.test.ts` — 23 tests passed.
- `pnpm exec oxfmt --check src/config/zod-schema.core.ts src/config/config-misc.test.ts` — clean.
- `git diff --check` — clean.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --stream-engine-output` — TruffleHog clean; `autoreview clean: no accepted/actionable findings reported`; patch judged correct at 0.96 confidence.
- `codex review --uncommitted` — no actionable findings; the review also reran the focused and broader config tests successfully.

## What was not tested

- Unrelated channel/provider integrations were not exercised.
- An unrelated installed-plugin compatibility repair encountered later in the update was outside this PR's scope.
