### PR TITLE
refactor(media): staging and understanding consume media facts positionally

### DIFF
--- a/src/auto-reply/reply.stage-sandbox-media.scp-remote-path.test.ts
+++ b/src/auto-reply/reply.stage-sandbox-media.scp-remote-path.test.ts
@@ -1,6 +1,7 @@
 /** Tests sandbox media staging for SCP remote-path inputs. */
 import fs from "node:fs/promises";
 import { basename, join } from "node:path";
+import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { slugifySessionKey } from "../agents/sandbox/shared.js";
 import { CONFIG_DIR } from "../utils.js";
@@ -144,7 +145,9 @@ describe("stageSandboxMedia scp remote paths", () => {
       const remotePath = "/Users/demo/Library/Messages/Attachments/ab/cd/photo.jpg";
       const { ctx, sessionCtx } = createRemoteContexts(remotePath);
       ctx.MediaPaths = [remotePath];
+      ctx.MediaUrl = pathToFileURL(remotePath).href;
       sessionCtx.MediaPaths = [remotePath];
+      sessionCtx.MediaUrl = pathToFileURL(remotePath).href;
       processExecMocks.runCommandWithTimeout.mockImplementation(async (argvUnknown) => {
         const argv = argvUnknown as string[];
         const localPath = argv.at(-1);
@@ -170,13 +173,17 @@ describe("stageSandboxMedia scp remote paths", () => {
         slugifySessionKey(sessionKey),
         basename(remotePath),
       );
-      expect(result.staged.get(remotePath)).toBe(stagedPath);
+      expect(result.staged.get(0)).toBe(stagedPath);
       expect(ctx.MediaPath).toBe(stagedPath);
       expect(ctx.MediaPaths).toEqual([stagedPath]);
       expect(ctx.MediaUrl).toBe(stagedPath);
       expect(sessionCtx.MediaPath).toBe(stagedPath);
       expect(sessionCtx.MediaPaths).toEqual([stagedPath]);
       expect(sessionCtx.MediaUrl).toBe(stagedPath);
+      expect(ctx.media?.[0]).toMatchObject({
+        path: stagedPath,
+        workspaceDir: join(CONFIG_DIR, "media", "remote-cache", slugifySessionKey(sessionKey)),
+      });
       expect(await fs.readFile(stagedPath, "utf8")).toBe("staged-image-bytes");
       await fs.rm(join(CONFIG_DIR, "media", "remote-cache", slugifySessionKey(sessionKey)), {
         recursive: true,
@@ -223,9 +230,13 @@ describe("stageSandboxMedia scp remote paths", () => {
         slugifySessionKey(sessionKey),
         basename(remotePath),
       );
-      expect(result.staged.get(remotePath)).toBe(stagedPath);
+      expect(result.staged.get(0)).toBe(stagedPath);
       expect(ctx.MediaPath).toBe(stagedPath);
       expect(ctx.MediaPaths).toEqual([stagedPath]);
+      expect(ctx.media?.[0]).toMatchObject({
+        path: stagedPath,
+        workspaceDir: join(CONFIG_DIR, "media", "remote-cache", slugifySessionKey(sessionKey)),
+      });
       await expectPathMissing(join(sandboxWorkspace, "media", "inbound", basename(remotePath)));
       expect(await fs.readFile(stagedPath, "utf8")).toBe("staged-image-bytes");
       await fs.rm(join(CONFIG_DIR, "media", "remote-cache", slugifySessionKey(sessionKey)), {

--- a/src/auto-reply/reply.triggers.trigger-handling.stages-inbound-media-into-sandbox-workspace.test.ts
+++ b/src/auto-reply/reply.triggers.trigger-handling.stages-inbound-media-into-sandbox-workspace.test.ts
@@ -1,6 +1,7 @@
 /** Tests trigger handling for staging inbound media into sandbox workspaces. */
 import fs from "node:fs/promises";
 import path, { basename, dirname, join } from "node:path";
+import { pathToFileURL } from "node:url";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MEDIA_MAX_BYTES } from "../media/store.js";
 import { stageSandboxMedia } from "./reply/stage-sandbox-media.js";
@@ -172,7 +173,7 @@ describe("stageSandboxMedia", () => {
     await withSandboxMediaTempHome("openclaw-triggers-", async (home) => {
       const { cfg, workspaceDir, sandboxDir } = await setupSandboxWorkspace(home);
       const fileName = "report.pdf";
-      const mediaPath = await writeInboundMedia(home, fileName, "pdf-bytes");
+      await writeInboundMedia(home, fileName, "pdf-bytes");
       const mediaUri = `media://inbound/${fileName}`;
       const { ctx, sessionCtx } = createSandboxMediaContexts(mediaUri);
       ctx.MediaType = "application/pdf";
@@ -187,12 +188,13 @@ describe("stageSandboxMedia", () => {
       });
 
       const stagedPath = `media/inbound/${fileName}`;
-      expect(result.staged.get(mediaUri)).toBe(stagedPath);
-      expect(result.staged.get(await fs.realpath(mediaPath))).toBe(stagedPath);
+      expect(result.staged.get(0)).toBe(stagedPath);
       expect(ctx.MediaPath).toBe(stagedPath);
       expect(sessionCtx.MediaPath).toBe(stagedPath);
       expect(ctx.MediaUrl).toBe(stagedPath);
       expect(sessionCtx.MediaUrl).toBe(stagedPath);
+      expect(ctx.media?.[0]).toMatchObject({ path: stagedPath, workspaceDir: sandboxDir });
+      expect(sessionCtx.media?.[0]).toMatchObject({ path: stagedPath, workspaceDir: sandboxDir });
       await expect(fs.readFile(join(sandboxDir, stagedPath), "utf8")).resolves.toBe("pdf-bytes");
     });
   });
@@ -225,12 +227,58 @@ describe("stageSandboxMedia", () => {
       expect(stagedRelativePath).toMatch(
         new RegExp(`^media/inbound/openclaw-staged-[0-9a-f-]+/${fileName}$`),
       );
-      expect(result.staged.get(mediaUri)).toBe(stagedPath);
+      expect(result.staged.get(0)).toBe(stagedPath);
       expect(sessionCtx.MediaPath).toBe(stagedPath);
       expect(ctx.MediaWorkspaceDir).toBe(dirname(stagedPath));
       expect(sessionCtx.MediaWorkspaceDir).toBeUndefined();
+      expect(ctx.media?.[0]).toMatchObject({ path: stagedPath, workspaceDir });
+      expect(sessionCtx.media?.[0]).toMatchObject({ path: stagedPath, workspaceDir });
       await expect(fs.readFile(stagedPath, "utf8")).resolves.toBe("host-image-bytes");
       await expect(fs.readFile(existingProjectFile, "utf8")).resolves.toBe("project-file");
+
+      const blockedPath = join(home, "blocked-host.png");
+      await fs.writeFile(blockedPath, "blocked");
+      const { ctx: blockedCtx, sessionCtx: blockedSessionCtx } =
+        createSandboxMediaContexts(blockedPath);
+      blockedCtx.MediaWorkspaceDir = workspaceDir;
+      blockedSessionCtx.MediaWorkspaceDir = workspaceDir;
+      const blockedResult = await stageSandboxMedia({
+        ctx: blockedCtx,
+        sessionCtx: blockedSessionCtx,
+        cfg,
+        sessionKey: "agent:main:main",
+        workspaceDir,
+      });
+      expect(blockedResult.staged).toEqual(new Map());
+      expect(blockedCtx.MediaWorkspaceDir).toBe(workspaceDir);
+      expect(blockedSessionCtx.MediaWorkspaceDir).toBe(workspaceDir);
+
+      const partialCtx = {
+        media: [
+          { path: mediaUri, contentType: "image/png" },
+          { path: blockedPath, contentType: "image/png" },
+        ],
+      };
+      const partialSessionCtx = {
+        media: [
+          { path: mediaUri, contentType: "image/png" },
+          { path: blockedPath, contentType: "image/png" },
+        ],
+      };
+      const partialResult = await stageSandboxMedia({
+        ctx: partialCtx,
+        sessionCtx: partialSessionCtx,
+        cfg,
+        sessionKey: "agent:main:main",
+        workspaceDir,
+      });
+      expect([...partialResult.staged.keys()]).toEqual([0]);
+      expect(partialResult.staged.get(0)).toBe(partialCtx.media[0]?.path);
+      expect(partialCtx).not.toHaveProperty("MediaWorkspaceDir");
+      expect(partialCtx.media[0]).toMatchObject({ workspaceDir });
+      expect(partialCtx.media[1]).toMatchObject({ path: blockedPath, contentType: "image/png" });
+      expect(partialCtx.media[1]).not.toHaveProperty("workspaceDir");
+      expect(partialSessionCtx.media).toEqual(partialCtx.media);
     });
   });
 
@@ -306,6 +354,123 @@ describe("stageSandboxMedia", () => {
       }
     });
   });
+
+  it.each([
+    { name: "failed slot before staged slot", allowedIndex: 1, blockedIndex: 0 },
+    { name: "staged slot before failed slot", allowedIndex: 0, blockedIndex: 1 },
+  ])("updates facts positionally: $name", async ({ allowedIndex, blockedIndex }) => {
+    await withSandboxMediaTempHome("openclaw-staging-slots-", async (home) => {
+      const { cfg, workspaceDir, sandboxDir } = await setupSandboxWorkspace(home);
+      const allowedPath = await writeInboundMedia(home, "allowed.jpg", "allowed");
+      const blockedPath = join(home, "blocked.jpg");
+      await fs.writeFile(blockedPath, "blocked");
+      const allowedUrl = "https://cdn.example/allowed.jpg";
+      const media = [allowedPath, blockedPath].map((pathValue, index) => ({
+        path: pathValue,
+        url: index === 0 ? allowedUrl : undefined,
+        contentType: "image/jpeg",
+      }));
+      if (allowedIndex === 1) {
+        media.reverse();
+      }
+      const ctx = { media };
+      const sessionCtx = {
+        media: media.map((fact) => ({
+          path: fact.path,
+          url: fact.url,
+          contentType: fact.contentType,
+        })),
+      };
+
+      const result = await stageSandboxMedia({
+        ctx,
+        sessionCtx,
+        cfg,
+        sessionKey: "agent:main:main",
+        workspaceDir,
+      });
+
+      const stagedPath = "media/inbound/allowed.jpg";
+      expect(result.staged).toEqual(new Map([[allowedIndex, stagedPath]]));
+      expect(ctx.media[allowedIndex]).toMatchObject({ path: stagedPath, workspaceDir: sandboxDir });
+      expect(ctx.media[allowedIndex]?.url).toBe(allowedUrl);
+      expect(ctx).toHaveProperty(`MediaUrls.${allowedIndex}`, allowedUrl);
+      expect(ctx.media[blockedIndex]).toMatchObject({ path: blockedPath });
+      expect(ctx.media[blockedIndex]).not.toHaveProperty("workspaceDir");
+      expect(sessionCtx.media).toEqual(ctx.media);
+    });
+  });
+
+  it.each([
+    {
+      name: "media URI path and physical-path URL",
+      source: "media-uri",
+      url: "physical-path",
+      rewritesUrl: true,
+    },
+    {
+      name: "physical path and media-URI URL",
+      source: "physical-path",
+      url: "media-uri",
+      rewritesUrl: true,
+    },
+    {
+      name: "physical path and file-URL URL",
+      source: "physical-path",
+      url: "file-url",
+      rewritesUrl: true,
+    },
+    {
+      name: "physical path and distinct remote URL",
+      source: "physical-path",
+      url: "remote-url",
+      rewritesUrl: false,
+    },
+  ] as const)(
+    "rewrites resolved local URL aliases: $name",
+    async ({ source, url, rewritesUrl }) => {
+      await withSandboxMediaTempHome("openclaw-staging-url-alias-", async (home) => {
+        const { cfg, workspaceDir, sandboxDir } = await setupSandboxWorkspace(home);
+        const fileName = "alias.jpg";
+        const mediaPath = await writeInboundMedia(home, fileName, "alias-bytes");
+        const mediaUri = `media://inbound/${fileName}`;
+        const sourcePath = source === "media-uri" ? mediaUri : mediaPath;
+        const mediaUrl =
+          url === "media-uri"
+            ? mediaUri
+            : url === "file-url"
+              ? pathToFileURL(mediaPath).href
+              : url === "remote-url"
+                ? "https://cdn.example/alias.jpg"
+                : mediaPath;
+        const ctx = {
+          media: [{ path: sourcePath, url: mediaUrl, contentType: "image/jpeg" }],
+        };
+        const sessionCtx = {
+          media: [{ path: sourcePath, url: mediaUrl, contentType: "image/jpeg" }],
+        };
+
+        const result = await stageSandboxMedia({
+          ctx,
+          sessionCtx,
+          cfg,
+          sessionKey: "agent:main:main",
+          workspaceDir,
+        });
+
+        const stagedPath = `media/inbound/${fileName}`;
+        const expectedUrl = rewritesUrl ? stagedPath : mediaUrl;
+        expect(result.staged).toEqual(new Map([[0, stagedPath]]));
+        expect(ctx.media[0]).toMatchObject({
+          path: stagedPath,
+          url: expectedUrl,
+          workspaceDir: sandboxDir,
+        });
+        expect(ctx).toHaveProperty("MediaUrl", expectedUrl);
+        expect(sessionCtx.media).toEqual(ctx.media);
+      });
+    },
+  );
 
   it("blocks destination symlink escapes when staging into sandbox workspace", async () => {
     await withSandboxMediaTempHome("openclaw-triggers-", async (home) => {

--- a/src/auto-reply/reply/current-turn-images.test.ts
+++ b/src/auto-reply/reply/current-turn-images.test.ts
@@ -67,14 +67,14 @@ describe("resolveCurrentTurnImages", () => {
       await fs.writeFile(imagePath, imageBytes);
       const sharedContext = {
         Body: "caption",
-        MediaPath: imagePath,
-        MediaPaths: [imagePath],
-        MediaType: "image/png",
-        MediaTypes: ["image/png"],
+        media: [{ path: imagePath, contentType: "image/png" }],
       } satisfies MsgContext;
 
       const prepared = await resolveCurrentTurnImages({
-        ctx: { ...sharedContext, MediaWorkspaceDir: stagingRoot },
+        ctx: {
+          ...sharedContext,
+          media: [{ path: imagePath, contentType: "image/png", workspaceDir: stagingRoot }],
+        },
         cfg: {} as OpenClawConfig,
       });
       const runner = await resolveCurrentTurnImages({
@@ -100,11 +100,7 @@ describe("resolveCurrentTurnImages", () => {
       const result = await resolveCurrentTurnImages({
         ctx: {
           Body: "caption",
-          MediaPath: rejectedPath,
-          MediaPaths: [rejectedPath],
-          MediaType: "image/png",
-          MediaTypes: ["image/png"],
-          MediaWorkspaceDir: stagingRoot,
+          media: [{ path: rejectedPath, contentType: "image/png", workspaceDir: stagingRoot }],
         } satisfies MsgContext,
         cfg: {} as OpenClawConfig,
       });

--- a/src/auto-reply/reply/current-turn-images.ts
+++ b/src/auto-reply/reply/current-turn-images.ts
@@ -10,6 +10,7 @@ import {
   stripExtractedFileImageMetadata,
   type ExtractedFileImage,
 } from "../../media-understanding/extracted-file-images.js";
+import { projectMediaFacts } from "../../media/media-facts.js";
 import type { PromptImageOrderEntry } from "../../media/prompt-image-order.js";
 import type { MsgContext } from "../templating.js";
 import { resolveAgentTurnAttachments } from "./agent-turn-attachments.js";
@@ -18,6 +19,7 @@ type CurrentImageAttachment = {
   index: number;
   path: string;
   mediaType: string;
+  workspaceDir?: string;
 };
 
 type OrderedTurnImage = {
@@ -57,7 +59,14 @@ function collectCurrentImageAttachments(ctx: MsgContext): CurrentImageAttachment
     const mediaPath = normalizeOptionalString(attachment.path);
     const mediaType = resolveCurrentImageMediaType(attachment.path, attachment.mime);
     if (mediaPath && mediaType) {
-      return [{ index: attachment.index, path: mediaPath, mediaType }];
+      return [
+        {
+          index: attachment.index,
+          path: mediaPath,
+          mediaType,
+          workspaceDir: attachment.workspaceDir,
+        },
+      ];
     }
     return [];
   });
@@ -75,19 +84,15 @@ function createUndescribedImageContext(
   ctx: MsgContext,
   undescribedAttachments: CurrentImageAttachment[],
 ): MsgContext {
-  const first = undescribedAttachments[0];
+  const media = undescribedAttachments.map((attachment) => ({
+    path: attachment.path,
+    contentType: attachment.mediaType,
+    workspaceDir: attachment.workspaceDir,
+  }));
   return {
     ...ctx,
-    media: undescribedAttachments.map((attachment) => ({
-      path: attachment.path,
-      contentType: attachment.mediaType,
-    })),
-    MediaPath: first?.path,
-    MediaUrl: first?.path,
-    MediaType: first?.mediaType,
-    MediaPaths: undescribedAttachments.map((attachment) => attachment.path),
-    MediaUrls: undescribedAttachments.map((attachment) => attachment.path),
-    MediaTypes: undescribedAttachments.map((attachment) => attachment.mediaType),
+    media,
+    ...projectMediaFacts(media),
   };
 }
 

--- a/src/auto-reply/reply/get-reply.message-hooks.test.ts
+++ b/src/auto-reply/reply/get-reply.message-hooks.test.ts
@@ -608,7 +608,10 @@ describe("getReplyFromConfig message hooks", () => {
       params.sessionCtx.MediaPaths = [stagedPath];
       params.sessionCtx.MediaUrl = stagedPath;
       params.sessionCtx.MediaUrls = [stagedPath];
-      return { staged: new Map([[remotePath, stagedPath]]) };
+      const stagedFact = { path: stagedPath, contentType: "image/jpeg", workspaceDir: "/tmp" };
+      params.ctx.media = [stagedFact];
+      params.sessionCtx.media = [stagedFact];
+      return { staged: new Map([[0, stagedPath]]) };
     });
     mocks.applyMediaUnderstanding.mockImplementationOnce(async (...args: unknown[]) => {
       order.push("understand");

--- a/src/auto-reply/reply/inbound-context.ts
+++ b/src/auto-reply/reply/inbound-context.ts
@@ -2,7 +2,7 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { normalizeChatType } from "../../channels/chat-type.js";
 import { resolveConversationLabel } from "../../channels/conversation-label.js";
-import { resolveMediaFacts } from "../../media/media-facts.js";
+import { projectMediaFacts, resolveMediaFacts } from "../../media/media-facts.js";
 import { resolveCommandTurnContext } from "../command-turn-context.js";
 import type { FinalizedMsgContext, MsgContext } from "../templating.js";
 import { normalizeInboundTextNewlines, sanitizeInboundSystemTags } from "./inbound-text.js";
@@ -13,8 +13,6 @@ export type FinalizeInboundContextOptions = {
   forceChatType?: boolean;
   forceConversationLabel?: boolean;
 };
-
-const DEFAULT_MEDIA_TYPE = "application/octet-stream";
 
 function normalizeTextField(value: unknown): string | undefined {
   if (typeof value !== "string") {
@@ -28,21 +26,6 @@ function normalizeTrustedTextField(value: unknown): string | undefined {
     return undefined;
   }
   return normalizeInboundTextNewlines(value);
-}
-
-function normalizeMediaType(value: unknown): string | undefined {
-  if (typeof value !== "string") {
-    return undefined;
-  }
-  const trimmed = value.trim();
-  return trimmed.length > 0 ? trimmed : undefined;
-}
-
-function countMediaEntries(ctx: MsgContext): number {
-  const pathCount = Array.isArray(ctx.MediaPaths) ? ctx.MediaPaths.length : 0;
-  const urlCount = Array.isArray(ctx.MediaUrls) ? ctx.MediaUrls.length : 0;
-  const single = ctx.MediaPath || ctx.MediaUrl ? 1 : 0;
-  return Math.max(pathCount, urlCount, single);
 }
 
 function applySupplementalContext(ctx: MsgContext): void {
@@ -143,39 +126,14 @@ export function finalizeInboundContext<T extends Record<string, unknown>>(
     normalized.CommandSource = undefined;
   }
 
-  // MediaType/MediaTypes alignment:
-  // - No media: do not inject defaults.
-  // - Media present: ensure MediaType is always set, and MediaTypes is padded to match
-  //   MediaPaths/MediaUrls length when possible.
-  const mediaCount = countMediaEntries(normalized);
-  if (mediaCount > 0) {
-    const mediaType = normalizeMediaType(normalized.MediaType);
-    const rawMediaTypes = Array.isArray(normalized.MediaTypes) ? normalized.MediaTypes : undefined;
-    const normalizedMediaTypes = rawMediaTypes?.map((entry) => normalizeMediaType(entry));
-
-    let mediaTypesFinal: string[] | undefined;
-    if (normalizedMediaTypes && normalizedMediaTypes.length > 0) {
-      const filled = normalizedMediaTypes.slice();
-      while (filled.length < mediaCount) {
-        filled.push(undefined);
-      }
-      mediaTypesFinal = filled.map((entry) => entry ?? DEFAULT_MEDIA_TYPE);
-    } else if (mediaType) {
-      mediaTypesFinal = [mediaType];
-      while (mediaTypesFinal.length < mediaCount) {
-        mediaTypesFinal.push(DEFAULT_MEDIA_TYPE);
-      }
-    } else {
-      mediaTypesFinal = Array.from({ length: mediaCount }, () => DEFAULT_MEDIA_TYPE);
-    }
-
-    normalized.MediaTypes = mediaTypesFinal;
-    normalized.MediaType = mediaType ?? mediaTypesFinal[0] ?? DEFAULT_MEDIA_TYPE;
-  }
-
-  const media = resolveMediaFacts(normalized);
+  const media = resolveMediaFacts(normalized).map((fact) =>
+    (fact.path || fact.url) && !fact.contentType && !fact.kind
+      ? Object.assign(fact, { contentType: "application/octet-stream" })
+      : fact,
+  );
   if (media.length > 0) {
     normalized.media = media;
+    Object.assign(normalized, projectMediaFacts(media));
   }
 
   return normalized as T & FinalizedMsgContext;

--- a/src/auto-reply/reply/stage-sandbox-media.ts
+++ b/src/auto-reply/reply/stage-sandbox-media.ts
@@ -15,6 +15,7 @@ import { root as fsRoot, FsSafeError } from "../../infra/fs-safe.js";
 import { normalizeScpRemoteHost, normalizeScpRemotePath } from "../../infra/scp-host.js";
 import { resolvePreferredOpenClawTmpDir } from "../../infra/tmp-openclaw-dir.js";
 import { resolveChannelRemoteInboundAttachmentRoots } from "../../media/channel-inbound-roots.js";
+import { projectMediaFacts, resolveMediaFacts, type MediaFact } from "../../media/media-facts.js";
 import { resolveInboundMediaReference } from "../../media/media-reference.js";
 import { getMediaDir, MEDIA_MAX_BYTES } from "../../media/store.js";
 import { runCommandWithTimeout } from "../../process/exec.js";
@@ -24,21 +25,15 @@ import type { MsgContext, TemplateContext } from "../templating.js";
 const STAGED_MEDIA_MAX_BYTES = MEDIA_MAX_BYTES;
 const SCP_STDERR_TAIL_CHARS = 16_384;
 
-// `staged` maps every absolute source path that was copied into the sandbox
-// (or remote cache) to its rewritten ctx path. Callers like chat.send's
-// prestage use this to detect partial failures: unstaged sources keep their
-// original absolute path in ctx.MediaPaths, so a length check against the
-// input cannot distinguish "everything staged" from "silently skipped some"
-// (e.g. the 5MB cap in STAGED_MEDIA_MAX_BYTES rejecting files that the
-// chat.send RPC already admitted under its 20MB cap).
+// Attachment indexes are the staging identity. Callers use this map to detect
+// partial failures without matching rewritten strings back to source paths.
 export type StageSandboxMediaResult = {
-  staged: ReadonlyMap<string, string>;
+  staged: ReadonlyMap<number, string>;
 };
 
 const EMPTY_STAGE_RESULT: StageSandboxMediaResult = { staged: new Map() };
 
 type StageableMediaSource = {
-  lookupKey: string;
   pathForFileName: string;
   physicalPath: string;
 };
@@ -52,9 +47,12 @@ export async function stageSandboxMedia(params: {
   remoteMediaMode?: "sandbox-or-cache" | "cache";
 }): Promise<StageSandboxMediaResult> {
   const { ctx, sessionCtx, cfg, sessionKey, workspaceDir } = params;
-  const hasPathsArray = Array.isArray(ctx.MediaPaths) && ctx.MediaPaths.length > 0;
-  const rawPaths = resolveRawPaths(ctx);
-  if (rawPaths.length === 0 || !sessionKey) {
+  const media = resolveMediaFacts(ctx);
+  const pathEntries = media.flatMap((fact, index) => {
+    const mediaPath = normalizeOptionalString(fact.path);
+    return mediaPath ? [{ index, path: mediaPath }] : [];
+  });
+  if (pathEntries.length === 0 || !sessionKey) {
     return EMPTY_STAGE_RESULT;
   }
 
@@ -84,15 +82,16 @@ export async function stageSandboxMedia(params: {
     : [];
 
   const usedNames = new Set<string>();
-  const staged = new Map<string, string>(); // original/resolved source -> runner-visible path
+  const staged = new Map<number, string>();
+  const stagedUrlAliases = new Set<number>();
   const hostWorkspaceStagingDir =
     !sandbox && !ctx.MediaRemoteHost
       ? path.join("media", "inbound", `openclaw-staged-${crypto.randomUUID()}`)
       : undefined;
 
-  for (const raw of rawPaths) {
-    const source = await resolveStageableMediaSource(raw);
-    if (!source || staged.has(source.lookupKey) || staged.has(source.physicalPath)) {
+  for (const entry of pathEntries) {
+    const source = await resolveStageableMediaSource(entry.path);
+    if (!source) {
       continue;
     }
     const allowed = await isAllowedSourcePath({
@@ -145,25 +144,101 @@ export async function stageSandboxMedia(params: {
 
     // For sandbox use relative path, for remote cache use absolute path
     const stagedPath = stageIntoSandboxMediaDir ? toPosixRelativePath(relativeDest) : dest;
-    staged.set(source.lookupKey, stagedPath);
-    if (source.physicalPath !== source.lookupKey) {
-      staged.set(source.physicalPath, stagedPath);
+    staged.set(entry.index, stagedPath);
+    if (
+      await isUrlAliasForStagedSource({
+        url: media[entry.index]?.url,
+        sourcePath: entry.path,
+        source,
+        mediaRemoteHost: ctx.MediaRemoteHost,
+      })
+    ) {
+      stagedUrlAliases.add(entry.index);
     }
   }
 
-  if (staged.size > 0 && hostWorkspaceStagingDir) {
-    ctx.MediaWorkspaceDir = path.join(effectiveWorkspaceDir, hostWorkspaceStagingDir);
+  if (staged.size === 0) {
+    return { staged };
   }
 
-  rewriteStagedMediaPaths({
-    ctx,
-    sessionCtx,
-    rawPaths,
-    staged,
-    hasPathsArray,
-  });
+  const nextMedia = [...media];
+  for (const [index, stagedPath] of staged) {
+    const fact = nextMedia[index];
+    if (fact) {
+      nextMedia[index] = {
+        ...fact,
+        path: stagedPath,
+        ...(stagedUrlAliases.has(index) ? { url: stagedPath } : {}),
+        workspaceDir: effectiveWorkspaceDir,
+      };
+    }
+  }
+  const legacyWorkspaceDir =
+    hostWorkspaceStagingDir && staged.size === pathEntries.length
+      ? path.join(effectiveWorkspaceDir, hostWorkspaceStagingDir)
+      : undefined;
+  applyStagedMediaContext(ctx, nextMedia, legacyWorkspaceDir);
+  if (sessionCtx !== ctx) {
+    applyStagedMediaContext(sessionCtx, nextMedia, undefined);
+  }
 
   return { staged };
+}
+
+async function isUrlAliasForStagedSource(params: {
+  url?: string;
+  sourcePath: string;
+  source: StageableMediaSource;
+  mediaRemoteHost?: string;
+}): Promise<boolean> {
+  const url = normalizeOptionalString(params.url);
+  if (!url) {
+    return false;
+  }
+  if (url === params.sourcePath) {
+    return true;
+  }
+  const sourceAbsolutePath = resolveAbsolutePath(params.sourcePath);
+  const urlAbsolutePath = resolveAbsolutePath(url);
+  if (
+    sourceAbsolutePath &&
+    urlAbsolutePath &&
+    path.normalize(sourceAbsolutePath) === path.normalize(urlAbsolutePath)
+  ) {
+    return true;
+  }
+  // Non-identical remote references belong to the remote host; resolving them
+  // against local storage could rewrite an unrelated local file by accident.
+  if (params.mediaRemoteHost) {
+    return false;
+  }
+  const urlSource = await resolveStageableMediaSource(url);
+  if (!urlSource) {
+    return false;
+  }
+  const [sourceIdentity, urlIdentity] = await Promise.all([
+    resolveLocalSourceIdentity(params.source.physicalPath),
+    resolveLocalSourceIdentity(urlSource.physicalPath),
+  ]);
+  return sourceIdentity === urlIdentity;
+}
+
+async function resolveLocalSourceIdentity(sourcePath: string): Promise<string> {
+  return await fs.realpath(sourcePath).catch(() => path.resolve(sourcePath));
+}
+
+function applyStagedMediaContext(
+  ctx: MsgContext,
+  media: MediaFact[],
+  legacyWorkspaceDir: string | undefined,
+): void {
+  ctx.media = media;
+  Object.assign(ctx, projectMediaFacts(media));
+  if (legacyWorkspaceDir) {
+    ctx.MediaWorkspaceDir = legacyWorkspaceDir;
+  } else {
+    delete ctx.MediaWorkspaceDir;
+  }
 }
 
 function toPosixRelativePath(filePath: string): string {
@@ -178,7 +253,6 @@ async function resolveStageableMediaSource(value: string): Promise<StageableMedi
   const inboundReference = await resolveInboundMediaReference(raw).catch(() => null);
   if (inboundReference) {
     return {
-      lookupKey: raw,
       pathForFileName: inboundReference.physicalPath,
       physicalPath: inboundReference.physicalPath,
     };
@@ -186,7 +260,6 @@ async function resolveStageableMediaSource(value: string): Promise<StageableMedi
   const source = resolveAbsolutePath(raw);
   return source
     ? {
-        lookupKey: source,
         pathForFileName: source,
         physicalPath: source,
       }
@@ -227,15 +300,6 @@ async function stageRemoteFileIntoRoot(params: {
   } finally {
     await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
   }
-}
-
-function resolveRawPaths(ctx: MsgContext): string[] {
-  const pathsFromArray = Array.isArray(ctx.MediaPaths) ? ctx.MediaPaths : undefined;
-  return pathsFromArray && pathsFromArray.length > 0
-    ? pathsFromArray
-    : normalizeOptionalString(ctx.MediaPath)
-      ? [normalizeOptionalString(ctx.MediaPath)!]
-      : [];
 }
 
 function resolveAbsolutePath(value: string): string | null {
@@ -316,51 +380,6 @@ function allocateStagedFileName(source: string, usedNames: Set<string>): string 
   }
   usedNames.add(fileName);
   return fileName;
-}
-
-function rewriteStagedMediaPaths(params: {
-  ctx: MsgContext;
-  sessionCtx: TemplateContext;
-  rawPaths: string[];
-  staged: Map<string, string>;
-  hasPathsArray: boolean;
-}): void {
-  const rewriteIfStaged = (value: string | undefined): string | undefined => {
-    const raw = normalizeOptionalString(value);
-    if (!raw) {
-      return value;
-    }
-    const abs = resolveAbsolutePath(raw);
-    const mapped = params.staged.get(raw) ?? (abs ? params.staged.get(abs) : undefined);
-    return mapped ?? value;
-  };
-
-  const nextMediaPaths = params.hasPathsArray
-    ? params.rawPaths.map((p) => rewriteIfStaged(p) ?? p)
-    : undefined;
-  if (nextMediaPaths) {
-    params.ctx.MediaPaths = nextMediaPaths;
-    params.sessionCtx.MediaPaths = nextMediaPaths;
-    params.ctx.MediaPath = nextMediaPaths[0];
-    params.sessionCtx.MediaPath = nextMediaPaths[0];
-  } else {
-    const rewritten = rewriteIfStaged(params.ctx.MediaPath);
-    if (rewritten && rewritten !== params.ctx.MediaPath) {
-      params.ctx.MediaPath = rewritten;
-      params.sessionCtx.MediaPath = rewritten;
-    }
-  }
-
-  if (Array.isArray(params.ctx.MediaUrls) && params.ctx.MediaUrls.length > 0) {
-    const nextUrls = params.ctx.MediaUrls.map((u) => rewriteIfStaged(u) ?? u);
-    params.ctx.MediaUrls = nextUrls;
-    params.sessionCtx.MediaUrls = nextUrls;
-  }
-  const rewrittenUrl = rewriteIfStaged(params.ctx.MediaUrl);
-  if (rewrittenUrl && rewrittenUrl !== params.ctx.MediaUrl) {
-    params.ctx.MediaUrl = rewrittenUrl;
-    params.sessionCtx.MediaUrl = rewrittenUrl;
-  }
 }
 
 async function scpFile(remoteHost: string, remotePath: string, localPath: string): Promise<void> {

--- a/src/channels/inbound-event/media.test.ts
+++ b/src/channels/inbound-event/media.test.ts
@@ -62,11 +62,13 @@ function buildCanonicalMedia(
     {
       path: "/canonical/voice.ogg",
       url: "https://canonical.test/voice.ogg",
+      workspaceDir: "/canonical/workspace-a",
       ...typeFields[0],
     },
     {
       path: "/canonical/photo.jpg",
       url: "https://canonical.test/photo.jpg",
+      workspaceDir: "/canonical/workspace-b",
       ...typeFields[1],
     },
   ];
@@ -273,6 +275,23 @@ describe("channel inbound media facts", () => {
     ]);
   });
 
+  it("normalizes blank workspace and MIME values before fallbacks apply", () => {
+    expect(
+      resolveMediaFacts({
+        media: [{ path: "rel/staged.png", workspaceDir: "  " }],
+        MediaWorkspaceDir: "/tmp/stage-root",
+      }),
+    ).toEqual([
+      expect.objectContaining({ path: "rel/staged.png", workspaceDir: "/tmp/stage-root" }),
+    ]);
+    expect(resolveMediaFacts({ MediaPath: "/tmp/blob", MediaType: "   " })).toEqual([
+      expect.objectContaining({ path: "/tmp/blob", contentType: undefined }),
+    ]);
+    expect(resolveMediaFacts({ MediaPath: "/tmp/a.png", MediaType: "  image/png  " })).toEqual([
+      expect.objectContaining({ contentType: "image/png", kind: "image" }),
+    ]);
+  });
+
   it.each(mediaMergeMatrix)("merges $name", ({ canonicalMode, legacyMode, typeMode }) => {
     const canonical = buildCanonicalMedia(canonicalMode, typeMode);
     const legacy = buildLegacyMedia(legacyMode, typeMode);
@@ -310,12 +329,17 @@ describe("channel inbound media facts", () => {
           (expectedCount === 1 ? legacy.MediaType : undefined),
       );
       const expectedKind = canonicalFact?.kind ?? kindFromMime(expectedContentType);
+      const expectedWorkspaceDir = canonicalFact?.workspaceDir ?? legacy.MediaWorkspaceDir;
       expect(facts[index]).toMatchObject({
         path: expectedPath,
         url: expectedUrl,
         contentType: expectedContentType,
         kind: expectedKind,
+        ...(expectedWorkspaceDir ? { workspaceDir: expectedWorkspaceDir } : {}),
       });
+      if (!expectedWorkspaceDir) {
+        expect(facts[index]).not.toHaveProperty("workspaceDir");
+      }
     }
   });
 

--- a/src/gateway/server-methods/chat-send-attachments.ts
+++ b/src/gateway/server-methods/chat-send-attachments.ts
@@ -1,6 +1,5 @@
 import path from "node:path";
 import { performance } from "node:perf_hooks";
-import { expectDefined } from "@openclaw/normalization-core";
 import { ErrorCodes, errorShape } from "../../../packages/gateway-protocol/src/index.js";
 import { resolveAgentWorkspaceDir } from "../../agents/agent-scope.js";
 import { ensureSandboxWorkspaceForSession } from "../../agents/sandbox/context.js";
@@ -155,10 +154,7 @@ async function prestageMediaPathOffloads(params: {
     }
 
     const stagingCtx: MsgContext = {
-      MediaPath: expectDefined(refsToStage[0], "refs to stage entry at 0").path,
-      MediaPaths: refsToStage.map((ref) => ref.path),
-      MediaType: expectDefined(refsToStage[0], "refs to stage entry at 0").mimeType,
-      MediaTypes: refsToStage.map((ref) => ref.mimeType),
+      media: refsToStage.map((ref) => ({ path: ref.path, contentType: ref.mimeType })),
     };
     let stageResult: StageSandboxMediaResult;
     try {
@@ -181,22 +177,21 @@ async function prestageMediaPathOffloads(params: {
     // stageSandboxMedia preserves an absolute source path when no copy lands;
     // the staged map is the authoritative success signal.
     const stagedSources = stageResult.staged;
-    const missing = refsToStage.filter((ref) => !stagedSources.has(ref.path));
+    const missing = refsToStage.filter((_ref, index) => !stagedSources.has(index));
     const unstageable = missing.filter((ref) => !isManagedInboundPdfOffloadRef(ref));
     if (unstageable.length > 0) {
       throw new Error(
         `attachment staging incomplete: ${stagedSources.size}/${refsToStage.length} paths staged into sandbox workspace (missing: ${unstageable.map((ref) => ref.path).join(", ")})`,
       );
     }
-    const stagedPaths = stagingCtx.MediaPaths ?? [];
-    const stagedTypes = stagingCtx.MediaTypes ?? refsToStage.map((ref) => ref.mimeType);
+    const stagedMedia = stagingCtx.media ?? [];
     // Preserve request order while mixing sandbox-relative paths with managed
     // host paths used by pass-through or fallback PDFs.
     const resolvedByRef = new Map<OffloadedRef, { path: string; mimeType: string }>();
     refsToStage.forEach((ref, index) => {
       resolvedByRef.set(ref, {
-        path: stagedPaths[index] ?? ref.path,
-        mimeType: stagedTypes[index] ?? ref.mimeType,
+        path: stagedMedia[index]?.path ?? ref.path,
+        mimeType: stagedMedia[index]?.contentType ?? ref.mimeType,
       });
     });
     for (const ref of passThroughRefs) {

--- a/src/gateway/server-methods/chat-send-user-turn.ts
+++ b/src/gateway/server-methods/chat-send-user-turn.ts
@@ -1,5 +1,6 @@
 import type { GatewayClientInfo } from "../../../packages/gateway-protocol/src/client-info.js";
 import type { MsgContext } from "../../auto-reply/templating.js";
+import { projectMediaFacts } from "../../media/media-facts.js";
 import type { PromptImageOrderEntry } from "../../media/prompt-image-order.js";
 import type { SavedMedia } from "../../media/store.js";
 import type { InputProvenance } from "../../sessions/input-provenance.js";
@@ -181,10 +182,12 @@ function buildChatSendMessageContext(params: {
   if (params.mediaPathOffloadPaths.length > 0) {
     // Pre-staged offloads must use the channel media fields and marker so the
     // dispatch path renders their prompt note without staging them a second time.
-    ctx.MediaPath = params.mediaPathOffloadPaths[0];
-    ctx.MediaPaths = params.mediaPathOffloadPaths;
-    ctx.MediaType = params.mediaPathOffloadTypes[0];
-    ctx.MediaTypes = params.mediaPathOffloadTypes;
+    ctx.media = params.mediaPathOffloadPaths.map((pathValue, index) => ({
+      path: pathValue,
+      contentType: params.mediaPathOffloadTypes[index],
+      workspaceDir: params.mediaPathOffloadWorkspaceDir,
+    }));
+    Object.assign(ctx, projectMediaFacts(ctx.media));
     ctx.MediaWorkspaceDir = params.mediaPathOffloadWorkspaceDir;
     ctx.MediaStaged = true;
   }

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -404,27 +404,35 @@ vi.mock("../../agents/sandbox/context.js", async () => {
 
 vi.mock("../../auto-reply/reply/stage-sandbox-media.js", () => ({
   stageSandboxMedia: vi.fn(
-    async (params: { ctx: { MediaPaths?: string[]; MediaPath?: string } }) => {
+    async (params: {
+      ctx: { media?: Array<{ path?: string; contentType?: string; workspaceDir?: string }> };
+    }) => {
       if (mockState.stageSandboxMediaError) {
         throw mockState.stageSandboxMediaError;
       }
-      const staged = new Map<string, string>();
-      const originalPaths = params.ctx.MediaPaths ?? [];
+      const staged = new Map<number, string>();
+      const originalPaths = params.ctx.media?.map((fact) => fact.path) ?? [];
       if (mockState.stagedRelativePaths) {
         const mapping = mockState.stagedRelativePaths;
-        params.ctx.MediaPaths = [...mapping];
-        params.ctx.MediaPath = mapping[0];
+        params.ctx.media = (params.ctx.media ?? []).map((fact, index) => ({
+          path: mapping[index] ?? fact.path,
+          contentType: fact.contentType,
+          workspaceDir: mockState.sandboxWorkspace?.workspaceDir,
+        }));
         for (let i = 0; i < mapping.length; i += 1) {
           const source = originalPaths[i];
           const dest = mapping[i];
           if (source && dest) {
-            staged.set(source, dest);
+            staged.set(i, dest);
           }
         }
       }
       if (mockState.unstagedSources) {
         for (const source of mockState.unstagedSources) {
-          staged.delete(source);
+          const index = originalPaths.indexOf(source);
+          if (index >= 0) {
+            staged.delete(index);
+          }
         }
       }
       return { staged };

--- a/src/media-understanding/apply.test.ts
+++ b/src/media-understanding/apply.test.ts
@@ -1170,10 +1170,10 @@ describe("applyMediaUnderstanding", () => {
     expect(ctx.Body).toBe("[Image]\nDescription:\nshared description");
   });
 
-  it("uses media workspace for staged files and agent workspace for provider resolution", async () => {
-    const mediaWorkspaceDir = await createTempMediaDir();
+  it("uses the agent workspace as a fallback for relative media paths", async () => {
+    const workspaceDir = await createTempMediaDir();
     const relativeImagePath = path.join("media", "inbound", "workspace.jpg");
-    const imagePath = path.join(mediaWorkspaceDir, relativeImagePath);
+    const imagePath = path.join(workspaceDir, relativeImagePath);
     await fs.mkdir(path.dirname(imagePath), { recursive: true });
     await fs.writeFile(imagePath, "image-bytes");
     const describeImage = vi.fn(async () => ({ text: "workspace image" }));
@@ -1181,7 +1181,6 @@ describe("applyMediaUnderstanding", () => {
       Body: "",
       MediaPath: relativeImagePath,
       MediaType: "image/jpeg",
-      MediaWorkspaceDir: mediaWorkspaceDir,
     };
     const cfg: OpenClawConfig = {
       tools: {
@@ -1198,7 +1197,7 @@ describe("applyMediaUnderstanding", () => {
       ctx,
       cfg,
       agentDir: "/tmp/openclaw-agent",
-      workspaceDir: "/tmp/openclaw-workspace",
+      workspaceDir,
       providers: {
         openai: {
           id: "openai",
@@ -1212,7 +1211,7 @@ describe("applyMediaUnderstanding", () => {
     expect(describeImage).toHaveBeenCalledWith(
       expect.objectContaining({
         agentDir: "/tmp/openclaw-agent",
-        workspaceDir: "/tmp/openclaw-workspace",
+        workspaceDir,
         fileName: "workspace.jpg",
         provider: "openai",
         model: "gpt-5.4",
@@ -1312,9 +1311,7 @@ describe("applyMediaUnderstanding", () => {
     const ctx: MsgContext = {
       Body: "preflight transcript",
       Transcript: "preflight transcript",
-      MediaPath: audioPath,
-      MediaType: "audio/ogg",
-      MediaTranscribedIndexes: [0],
+      media: [{ path: audioPath, contentType: "audio/ogg", transcribed: true }],
     };
     const cfg: OpenClawConfig = {
       tools: {

--- a/src/media-understanding/apply.ts
+++ b/src/media-understanding/apply.ts
@@ -542,7 +542,6 @@ export async function applyMediaUnderstanding(params: {
   processingMode?: "audio-only";
 }): Promise<ApplyMediaUnderstandingResult> {
   const { ctx, cfg } = params;
-  const mediaWorkspaceDir = ctx.MediaWorkspaceDir ?? params.workspaceDir;
   const commandCandidates = [ctx.CommandBody, ctx.RawBody, ctx.Body];
   const originalUserText =
     commandCandidates
@@ -558,7 +557,7 @@ export async function applyMediaUnderstanding(params: {
       workspaceDir: params.workspaceDir,
     }),
     ssrfPolicy: cfg.tools?.web?.fetch?.ssrfPolicy,
-    workspaceDir: mediaWorkspaceDir,
+    workspaceDir: params.workspaceDir,
   });
 
   try {

--- a/src/media-understanding/attachments.cache.ts
+++ b/src/media-understanding/attachments.cache.ts
@@ -121,7 +121,7 @@ export class MediaAttachmentCache {
   private readonly attachments: MediaAttachment[];
   private readonly localPathRoots: readonly string[];
   private readonly ssrfPolicy: SsrFPolicy | undefined;
-  private readonly workspaceDir?: string;
+  private readonly fallbackWorkspaceDir?: string;
   private canonicalLocalPathRoots?: Promise<readonly string[]>;
 
   constructor(attachments: MediaAttachment[], options?: MediaAttachmentCacheOptions) {
@@ -131,7 +131,7 @@ export class MediaAttachmentCache {
       options?.includeDefaultLocalPathRoots === false
         ? mergeInboundPathRoots(options.localPathRoots)
         : mergeInboundPathRoots(options?.localPathRoots, getDefaultLocalPathRoots());
-    this.workspaceDir = options?.workspaceDir ? path.resolve(options.workspaceDir) : undefined;
+    this.fallbackWorkspaceDir = options?.workspaceDir;
     for (const attachment of attachments) {
       this.entries.set(attachment.index, { attachment });
     }
@@ -351,8 +351,9 @@ export class MediaAttachmentCache {
     if (inboundReference) {
       return inboundReference.physicalPath;
     }
-    if (this.workspaceDir) {
-      return path.resolve(this.workspaceDir, rawPath);
+    const workspaceDir = attachment.workspaceDir ?? this.fallbackWorkspaceDir;
+    if (workspaceDir) {
+      return path.resolve(workspaceDir, rawPath);
     }
     if (!path.isAbsolute(rawPath)) {
       const cwdCandidate = path.resolve(rawPath);

--- a/src/media-understanding/attachments.normalize.ts
+++ b/src/media-understanding/attachments.normalize.ts
@@ -37,6 +37,7 @@ export function normalizeAttachments(ctx: MsgContext): MediaAttachment[] {
       path: normalizeOptionalString(fact.path),
       url: normalizeOptionalString(fact.url),
       mime: normalizeOptionalString(fact.contentType) ?? fact.kind,
+      workspaceDir: normalizeOptionalString(fact.workspaceDir),
       index,
       alreadyTranscribed: fact.transcribed === true,
     }))

--- a/src/media-understanding/audio-preflight.test.ts
+++ b/src/media-understanding/audio-preflight.test.ts
@@ -1,6 +1,7 @@
 // Audio preflight tests cover auto mode, explicit disable, and transcript echo
 // delivery settings.
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { MsgContext } from "../auto-reply/templating.js";
 import { transcribeFirstAudio } from "./audio-preflight.js";
 
 const runAudioTranscriptionMock = vi.hoisted(() => vi.fn());
@@ -27,26 +28,27 @@ describe("transcribeFirstAudio", () => {
       attachments: [],
     });
 
-    const transcript = await transcribeFirstAudio({
-      ctx: {
-        Body: "<media:audio>",
-        MediaPath: "/tmp/voice.ogg",
-        MediaType: "audio/ogg",
-      },
-      cfg: {},
-    });
+    const ctx: MsgContext = {
+      Body: "<media:audio>",
+      media: [
+        { path: "/tmp/photo.jpg", contentType: "image/jpeg" },
+        { path: "/tmp/voice.ogg", contentType: "audio/ogg" },
+      ],
+    };
+    const transcript = await transcribeFirstAudio({ ctx, cfg: {} });
 
     expect(transcript).toBe("voice note transcript");
     expect(runAudioTranscriptionMock).toHaveBeenCalledTimes(1);
     expect(sendTranscriptEchoMock).not.toHaveBeenCalled();
+    expect(ctx.media?.[0]?.transcribed).not.toBe(true);
+    expect(ctx.media?.[1]?.transcribed).toBe(true);
   });
 
   it("skips audio preflight when audio config is explicitly disabled", async () => {
     const transcript = await transcribeFirstAudio({
       ctx: {
         Body: "<media:audio>",
-        MediaPath: "/tmp/voice.ogg",
-        MediaType: "audio/ogg",
+        media: [{ path: "/tmp/voice.ogg", contentType: "audio/ogg" }],
       },
       cfg: {
         tools: {
@@ -75,8 +77,7 @@ describe("transcribeFirstAudio", () => {
       Provider: "telegram",
       OriginatingTo: "telegram:42",
       AccountId: "default",
-      MediaPath: "/tmp/voice.ogg",
-      MediaType: "audio/ogg",
+      media: [{ path: "/tmp/voice.ogg", contentType: "audio/ogg" }],
     };
     const cfg = {
       tools: {

--- a/src/media-understanding/audio-preflight.ts
+++ b/src/media-understanding/audio-preflight.ts
@@ -4,6 +4,7 @@ import type { ActiveMediaModel } from "../../packages/media-understanding-common
 import type { MsgContext } from "../auto-reply/templating.js";
 import type { OpenClawConfig } from "../config/types.js";
 import { logVerbose, shouldLogVerbose } from "../globals.js";
+import { projectMediaFacts, resolveMediaFacts } from "../media/media-facts.js";
 import { isAudioAttachment } from "./attachments.js";
 import { runAudioTranscription } from "./audio-transcription-runner.js";
 import { DEFAULT_ECHO_TRANSCRIPT_FORMAT, sendTranscriptEcho } from "./echo-transcript.js";
@@ -69,8 +70,15 @@ export async function transcribeFirstAudio(params: {
       });
     }
 
-    // Mark this attachment as transcribed so the main media pass does not duplicate STT output.
-    firstAudio.alreadyTranscribed = true;
+    // Persist transcription state on the matching fact so later normalization
+    // cannot shift or lose it through a parallel index list.
+    const media = resolveMediaFacts(ctx);
+    const transcribedFact = media[firstAudio.index];
+    if (transcribedFact) {
+      media[firstAudio.index] = { ...transcribedFact, transcribed: true };
+      ctx.media = media;
+      ctx.MediaTranscribedIndexes = projectMediaFacts(media).MediaTranscribedIndexes;
+    }
 
     if (shouldLogVerbose()) {
       logVerbose(

--- a/src/media-understanding/media-understanding-misc.test.ts
+++ b/src/media-understanding/media-understanding-misc.test.ts
@@ -153,13 +153,44 @@ describe("media understanding attachments SSRF", () => {
       await fs.mkdir(path.dirname(attachmentPath), { recursive: true });
       await fs.writeFile(attachmentPath, "ok");
 
-      const cache = new MediaAttachmentCache([{ index: 0, path: "media/inbound/report.pdf" }], {
-        localPathRoots: [workspaceDir],
-        workspaceDir,
-      });
+      const cache = new MediaAttachmentCache(
+        [{ index: 0, path: "media/inbound/report.pdf", workspaceDir }],
+        { localPathRoots: [workspaceDir] },
+      );
 
       const result = await cache.getBuffer({ attachmentIndex: 0, maxBytes: 1024, timeoutMs: 1000 });
       expect(result.buffer.toString()).toBe("ok");
+    });
+  });
+
+  it("resolves each relative attachment against its own workspace", async () => {
+    await withTempDir({ prefix: "openclaw-media-cache-workspaces-" }, async (base) => {
+      const workspaces = ["first", "second"].map((name) => path.join(base, name));
+      await Promise.all(
+        workspaces.map(async (workspaceDir, index) => {
+          await fs.mkdir(workspaceDir, { recursive: true });
+          await fs.writeFile(path.join(workspaceDir, "attachment.txt"), `slot-${index}`);
+        }),
+      );
+      const cache = new MediaAttachmentCache(
+        workspaces.map((workspaceDir, index) => ({
+          index,
+          path: "attachment.txt",
+          workspaceDir,
+        })),
+        { localPathRoots: workspaces },
+      );
+
+      await expect(
+        Promise.all(
+          workspaces.map((_workspaceDir, attachmentIndex) =>
+            cache.getBuffer({ attachmentIndex, maxBytes: 1024, timeoutMs: 1000 }),
+          ),
+        ),
+      ).resolves.toEqual([
+        expect.objectContaining({ buffer: Buffer.from("slot-0") }),
+        expect.objectContaining({ buffer: Buffer.from("slot-1") }),
+      ]);
     });
   });
 

--- a/src/media-understanding/runner.ts
+++ b/src/media-understanding/runner.ts
@@ -40,6 +40,7 @@ import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 import { logWarn } from "../logger.js";
 import { resolveChannelInboundAttachmentRoots } from "../media/channel-inbound-roots.js";
 import { getDefaultMediaLocalRoots } from "../media/local-roots.js";
+import { resolveMediaFacts } from "../media/media-facts.js";
 import { runExec } from "../process/exec.js";
 import { getOrCreatePromise } from "../shared/lazy-promise.js";
 import { createLazyRuntimeModule, createLazyRuntimeNamedExport } from "../shared/lazy-runtime.js";
@@ -344,15 +345,13 @@ export function resolveMediaAttachmentLocalRoots(params: {
   ctx: MsgContext;
   workspaceDir?: string;
 }): readonly string[] {
-  // ctx.MediaWorkspaceDir is set by chat.send's prestageNonImageOffloads when
-  // inbound attachments were staged into a sandbox workspace. The paths in
-  // ctx.MediaPaths are kept sandbox-relative (so the agent inside the
-  // container can read them), and the workspace dir is carried separately so
-  // host-side media-understanding can still resolve them via this root list.
-  const workspaceDir = params.ctx.MediaWorkspaceDir ?? params.workspaceDir;
+  const workspaceDirs = resolveMediaFacts(params.ctx).flatMap((fact) =>
+    fact.workspaceDir ? [path.resolve(fact.workspaceDir)] : [],
+  );
   return mergeInboundPathRoots(
     getDefaultMediaLocalRoots(),
-    workspaceDir ? [path.resolve(workspaceDir)] : undefined,
+    workspaceDirs,
+    params.workspaceDir ? [path.resolve(params.workspaceDir)] : undefined,
     resolveChannelInboundAttachmentRoots(params),
   );
 }

--- a/src/media-understanding/types.ts
+++ b/src/media-understanding/types.ts
@@ -27,6 +27,7 @@ export type MediaAttachment = {
   path?: string;
   url?: string;
   mime?: string;
+  workspaceDir?: string;
   index: number;
   alreadyTranscribed?: boolean;
 };

--- a/src/media/media-facts.ts
+++ b/src/media/media-facts.ts
@@ -115,11 +115,13 @@ export function resolveMediaFacts(source: MediaFactSource): MediaFact[] {
         contentType:
           fact?.contentType ??
           normalizeOptionalString(types[index]) ??
-          (count === 1 ? source.MediaType : undefined),
+          (index === 0 ? source.MediaType : undefined),
         kind: fact?.kind,
         transcribed: fact?.transcribed === true || transcribed.has(index),
         messageId: fact?.messageId,
-        workspaceDir: fact?.workspaceDir,
+        workspaceDir:
+          normalizeOptionalString(fact?.workspaceDir) ??
+          normalizeOptionalString(source.MediaWorkspaceDir),
       },
       index,
     );


### PR DESCRIPTION
## What Problem This Solves

PR 3 of the audit-frozen media-facts program (PR 1 #112197, PR 2 #112276). Sandbox staging, the media-understanding cache, current-turn images, transcription state, and workspace roots still worked over the parallel `Media*` arrays with string-matching rewrites and alignment/padding helpers.

## Why This Change Was Made

- All five surfaces now consume and update ordered `MediaFact[]` positionally — staging rewrites update the fact's path/workspaceDir in its own slot rather than re-deriving membership by string comparison; the alignment helpers whose consumers migrated are deleted per the audit's kill list.
- Review-hardened, one accepted finding per class: per-fact `workspaceDir` normalizes before the legacy `MediaWorkspaceDir` fallback (whitespace values no longer suppress a valid staging root; fixed maintainer-side); staging keeps resolved-identity URL-alias matching (`media://inbound/<id>`, `file://`, and physical-path forms rewrite together on a successful stage, distinct remote URLs untouched — restoring the old `rewriteIfStaged` semantics the first draft lost). A third finding (MIME normalization regression) was disproven with executable matrix cells: the merge path already trims/voids whitespace MIME, so the finalization default applies correctly; the cells are kept as regression coverage.
- The PR-2 merge matrix remains the single contract and gained cells rather than parallel ad-hoc tests.

## User Impact

None intended — behavior-preserving migration; the workspace-normalization fix removes a latent path where a blank per-fact workspace could misroot relative staged attachments.

## Evidence

- 546 focused tests green via `node scripts/run-vitest.mjs`, including the extended merge matrix (66/66) and staging alias-form regressions.
- Local gates green: format wrapper, oxlint (type-aware incl. boundary dts), tsgo lanes, SDK manifest/export/surface, knip, `git diff --check`. Blacksmith warmups timed out during the final proof window (three bounded attempts) — authorized local fallback per repo policy; exact-head hosted CI still gates the merge. An earlier full remote `check:changed` on this PR's pre-fix content was green (run 29836761422).
- Autoreview: three cycles — workspace fallback (fixed), MIME claim (rejected with executable proof), staging alias regression (fixed) — final pass clean, "patch is correct (0.87)".
- Net −27 production LOC before tests.
