### PR TITLE
fix: keep Control UI setup responsive when discovery stalls

### DIFF
--- a/extensions/zoom-meetings/src/runtime-node.test.ts
+++ b/extensions/zoom-meetings/src/runtime-node.test.ts
@@ -149,7 +149,7 @@ describe("Zoom meetings node realtime recovery", () => {
     expect(realtimeMocks.startAgent).toHaveBeenCalledWith(
       expect.objectContaining({
         config: expect.objectContaining({
-          realtime: expect.objectContaining({ agentId: "consult" }),
+          realtime: expect.objectContaining({ agentId: "support" }),
         }),
         requesterSessionKey: "agent:support:session:caller",
       }),

--- a/src/agents/embedded-agent-runner/run-orchestrator.ts
+++ b/src/agents/embedded-agent-runner/run-orchestrator.ts
@@ -27,7 +27,10 @@ import {
   resolveAgentWorkspaceDir,
   resolveDefaultAgentDir,
 } from "../agent-scope.js";
-import { acquireAgentRunPreparedModelRuntime } from "../prepared-model-runtime.js";
+import {
+  acquireAgentRunPreparedModelRuntime,
+  acquireReadOnlyPreparedModelRuntime,
+} from "../prepared-model-runtime.js";
 import {
   applyAgentRunSessionTargetIdentity,
   resolveAgentRunSessionTarget,
@@ -206,9 +209,10 @@ async function runEmbeddedAgentInternal(
       };
       // Configless direct hosts reuse one bounded idle generation. Gateway and explicitly
       // configured runs release dynamic workspaces so one-off paths cannot accumulate owners.
-      const preparedModelRuntimeLease = await acquireAgentRunPreparedModelRuntime(preparedInput, {
-        retainIdleRunOwner,
-      });
+      const preparedModelRuntimeLease =
+        params.preparedModelRuntimeMode === "isolated-read-only"
+          ? await acquireReadOnlyPreparedModelRuntime(preparedInput)
+          : await acquireAgentRunPreparedModelRuntime(preparedInput, { retainIdleRunOwner });
       const preparedModelRuntime = preparedModelRuntimeLease.snapshot;
       try {
         // A reload may complete while admission waits. The committed generation owns config,

--- a/src/agents/embedded-agent-runner/run/internal-params.ts
+++ b/src/agents/embedded-agent-runner/run/internal-params.ts
@@ -5,6 +5,8 @@ import type { RunEmbeddedAgentParams } from "./params.js";
 export type RunEmbeddedAgentInternalParams = RunEmbeddedAgentParams & {
   onSuccessfulAuthBinding?: (binding: AgentExecutionAuthBinding) => void;
   authProfileStateMode?: "read-write" | "read-only";
+  /** Keep staged setup config and credentials outside configured Gateway ownership. */
+  preparedModelRuntimeMode?: "isolated-read-only";
   /** Ring-zero tool override, supplied only by the OpenClaw orchestrator. */
   systemAgentTool?: SystemAgentToolOptions;
 };

--- a/src/agents/prepared-model-runtime.test.ts
+++ b/src/agents/prepared-model-runtime.test.ts
@@ -84,6 +84,7 @@ vi.mock("../logging/subsystem.js", () => ({
 }));
 
 import {
+  acquireAgentRunPreparedModelRuntime,
   acquireReadOnlyPreparedModelRuntime,
   activateStandalonePreparedModelRuntime,
   getPreparedModelRuntimeSnapshot,
@@ -114,6 +115,59 @@ describe("prepared model runtime snapshots", () => {
     mocks.loadStaticCatalog.mockClear();
     mocks.modelRegistry.fork.mockClear();
     mocks.configuredAgentIds = [];
+  });
+
+  it("keeps an isolated setup probe outside configured gateway ownership", async () => {
+    mocks.configuredAgentIds = ["default"];
+    const config = {};
+    const input = {
+      agentId: "openclaw",
+      config,
+      agentDir: "/tmp/setup-probe-agent",
+      inheritedAuthDir: "/tmp/setup-probe-agent",
+      workspaceDir: "/tmp/setup-probe-workspace",
+    };
+    await refreshPreparedModelRuntimeSnapshots(config, { gatewayLifecycle: true });
+
+    await expect(acquireAgentRunPreparedModelRuntime(input)).rejects.toThrow(
+      "prepared model runtime owner was not committed",
+    );
+    const lease = await acquireReadOnlyPreparedModelRuntime(input);
+    expect(lease.snapshot).toMatchObject(input);
+    lease.release();
+    await expect(prepareModelRuntimeSnapshot({ ...input, readOnly: true })).rejects.toThrow(
+      "prepared model runtime owner was not published",
+    );
+  });
+
+  it("keeps an isolated setup probe exact after a gateway replacement", async () => {
+    mocks.configuredAgentIds = ["default"];
+    const stagedConfig = { agents: { defaults: { model: "openai/gpt-5.6" } } };
+    await refreshPreparedModelRuntimeSnapshots({}, { gatewayLifecycle: true });
+    markPreparedModelRuntimeSnapshotsStale("test isolated probe replacement", {
+      waitForReplacement: true,
+    });
+    const leasePending = acquireReadOnlyPreparedModelRuntime({
+      agentId: "openclaw",
+      config: stagedConfig,
+      agentDir: "/tmp/setup-probe-agent",
+      inheritedAuthDir: "/tmp/setup-probe-agent",
+      workspaceDir: "/tmp/setup-probe-workspace",
+    });
+    await Promise.resolve();
+    expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(1);
+
+    await refreshPreparedModelRuntimeSnapshots({
+      agents: { defaults: { model: "openai/gpt-5.5" } },
+    });
+    const lease = await leasePending;
+    expect(lease.snapshot).toMatchObject({
+      agentId: "openclaw",
+      config: stagedConfig,
+      agentDir: "/tmp/setup-probe-agent",
+      workspaceDir: "/tmp/setup-probe-workspace",
+    });
+    lease.release();
   });
 
   it("reactivates a standalone read-only owner after a publication boundary", async () => {

--- a/src/agents/prepared-model-runtime.test.ts
+++ b/src/agents/prepared-model-runtime.test.ts
@@ -84,7 +84,6 @@ vi.mock("../logging/subsystem.js", () => ({
 }));
 
 import {
-  acquireAgentRunPreparedModelRuntime,
   acquireReadOnlyPreparedModelRuntime,
   activateStandalonePreparedModelRuntime,
   getPreparedModelRuntimeSnapshot,
@@ -115,29 +114,6 @@ describe("prepared model runtime snapshots", () => {
     mocks.loadStaticCatalog.mockClear();
     mocks.modelRegistry.fork.mockClear();
     mocks.configuredAgentIds = [];
-  });
-
-  it("keeps an isolated setup probe outside configured gateway ownership", async () => {
-    mocks.configuredAgentIds = ["default"];
-    const config = {};
-    const input = {
-      agentId: "openclaw",
-      config,
-      agentDir: "/tmp/setup-probe-agent",
-      inheritedAuthDir: "/tmp/setup-probe-agent",
-      workspaceDir: "/tmp/setup-probe-workspace",
-    };
-    await refreshPreparedModelRuntimeSnapshots(config, { gatewayLifecycle: true });
-
-    await expect(acquireAgentRunPreparedModelRuntime(input)).rejects.toThrow(
-      "prepared model runtime owner was not committed",
-    );
-    const lease = await acquireReadOnlyPreparedModelRuntime(input);
-    expect(lease.snapshot).toMatchObject(input);
-    lease.release();
-    await expect(prepareModelRuntimeSnapshot({ ...input, readOnly: true })).rejects.toThrow(
-      "prepared model runtime owner was not published",
-    );
   });
 
   it("keeps an isolated setup probe exact after a gateway replacement", async () => {

--- a/src/agents/prepared-model-runtime.ts
+++ b/src/agents/prepared-model-runtime.ts
@@ -272,8 +272,10 @@ async function acquirePreparedModelRuntimeLease(
       if (pendingModelRuntimeReplacement) {
         continue;
       }
-      input = rebindInputToCommittedConfiguredOwner(owners, input);
-      key = ownerKey(input);
+      if (provenance === "run") {
+        input = rebindInputToCommittedConfiguredOwner(owners, input);
+        key = ownerKey(input);
+      }
       continue;
     }
     let existing = owners.get(key);
@@ -387,7 +389,7 @@ export async function acquireAgentRunPreparedModelRuntime(
   return await acquirePreparedModelRuntimeLease(rawInput, "run", options);
 }
 
-/** Acquires a one-read metadata generation without retaining a dynamic workspace owner. */
+/** Acquires an exact read-only generation scoped to the returned lease. */
 export async function acquireReadOnlyPreparedModelRuntime(
   rawInput: PreparedModelRuntimeInput,
 ): Promise<PreparedModelRuntimeLease> {

--- a/src/commands/onboard-inference-ambient.ts
+++ b/src/commands/onboard-inference-ambient.ts
@@ -1,0 +1,52 @@
+export const OPENAI_API_DEFAULT_MODEL_REF = "openai/gpt-5.6";
+export const ANTHROPIC_API_DEFAULT_MODEL_REF = "anthropic/claude-opus-4-8";
+export const CLAUDE_CLI_DEFAULT_MODEL_REF = "claude-cli/claude-opus-4-8";
+export const CODEX_APP_SERVER_DEFAULT_MODEL_REF = "openai/gpt-5.6-sol";
+export const GEMINI_CLI_DEFAULT_MODEL_REF = "google-gemini-cli/gemini-3.1-pro-preview";
+
+export type InferenceBackendKind =
+  | "existing-model"
+  | "openai-api-key"
+  | "anthropic-api-key"
+  | "claude-cli"
+  | "codex-cli"
+  | "gemini-cli";
+
+export type InferenceBackendCandidate = {
+  kind: InferenceBackendKind;
+  modelRef: string;
+  /** Short human label, e.g. "Claude Code CLI". */
+  label: string;
+  /** One-line provenance, e.g. "logged in", "ANTHROPIC_API_KEY set". */
+  detail: string;
+  /**
+   * true: credentials verified; false: definitively logged out; undefined:
+   * unknown (e.g. macOS keychain-backed logins we must not prompt for here).
+   */
+  credentials?: boolean;
+};
+
+export function detectAmbientInferenceBackends(
+  env: NodeJS.ProcessEnv = process.env,
+): InferenceBackendCandidate[] {
+  const candidates: InferenceBackendCandidate[] = [];
+  if (env.OPENAI_API_KEY?.trim()) {
+    candidates.push({
+      kind: "openai-api-key",
+      modelRef: OPENAI_API_DEFAULT_MODEL_REF,
+      label: "OpenAI API key",
+      detail: "OPENAI_API_KEY set",
+      credentials: true,
+    });
+  }
+  if (env.ANTHROPIC_API_KEY?.trim()) {
+    candidates.push({
+      kind: "anthropic-api-key",
+      modelRef: ANTHROPIC_API_DEFAULT_MODEL_REF,
+      label: "Anthropic API key",
+      detail: "ANTHROPIC_API_KEY set",
+      credentials: true,
+    });
+  }
+  return candidates;
+}

--- a/src/commands/onboard-inference.ts
+++ b/src/commands/onboard-inference.ts
@@ -12,6 +12,22 @@ import { resolveDefaultModelForAgent } from "../agents/model-selection.js";
 import { resolveAgentModelPrimaryValue } from "../config/model-input.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { probeLocalCommand, type LocalCommandProbe } from "../system-agent/probes.js";
+import {
+  CLAUDE_CLI_DEFAULT_MODEL_REF,
+  CODEX_APP_SERVER_DEFAULT_MODEL_REF,
+  GEMINI_CLI_DEFAULT_MODEL_REF,
+  detectAmbientInferenceBackends,
+  type InferenceBackendCandidate,
+} from "./onboard-inference-ambient.js";
+
+export {
+  ANTHROPIC_API_DEFAULT_MODEL_REF,
+  CLAUDE_CLI_DEFAULT_MODEL_REF,
+  CODEX_APP_SERVER_DEFAULT_MODEL_REF,
+  GEMINI_CLI_DEFAULT_MODEL_REF,
+  OPENAI_API_DEFAULT_MODEL_REF,
+  type InferenceBackendKind,
+} from "./onboard-inference-ambient.js";
 
 /**
  * Onboarding treats inference as the one required step: reuse whatever the
@@ -19,33 +35,6 @@ import { probeLocalCommand, type LocalCommandProbe } from "../system-agent/probe
  * asking the user anything. The ladder order is a documented contract
  * (docs/cli/setup.md "Setup bootstrap") — change docs when changing it.
  */
-export const OPENAI_API_DEFAULT_MODEL_REF = "openai/gpt-5.6";
-export const ANTHROPIC_API_DEFAULT_MODEL_REF = "anthropic/claude-opus-4-8";
-export const CLAUDE_CLI_DEFAULT_MODEL_REF = "claude-cli/claude-opus-4-8";
-export const CODEX_APP_SERVER_DEFAULT_MODEL_REF = "openai/gpt-5.6-sol";
-export const GEMINI_CLI_DEFAULT_MODEL_REF = "google-gemini-cli/gemini-3.1-pro-preview";
-
-export type InferenceBackendKind =
-  | "existing-model"
-  | "openai-api-key"
-  | "anthropic-api-key"
-  | "claude-cli"
-  | "codex-cli"
-  | "gemini-cli";
-
-type InferenceBackendCandidate = {
-  kind: InferenceBackendKind;
-  modelRef: string;
-  /** Short human label, e.g. "Claude Code CLI". */
-  label: string;
-  /** One-line provenance, e.g. "logged in", "ANTHROPIC_API_KEY set". */
-  detail: string;
-  /**
-   * true: credentials verified; false: definitively logged out; undefined:
-   * unknown (e.g. macOS keychain-backed logins we must not prompt for here).
-   */
-  credentials?: boolean;
-};
 
 type DetectInferenceBackendsDeps = {
   probeLocalCommand?: typeof probeLocalCommand;
@@ -212,24 +201,7 @@ export async function detectInferenceBackends(
       credentials: true,
     });
   }
-  if (env.OPENAI_API_KEY?.trim()) {
-    candidates.push({
-      kind: "openai-api-key",
-      modelRef: OPENAI_API_DEFAULT_MODEL_REF,
-      label: "OpenAI API key",
-      detail: "OPENAI_API_KEY set",
-      credentials: true,
-    });
-  }
-  if (env.ANTHROPIC_API_KEY?.trim()) {
-    candidates.push({
-      kind: "anthropic-api-key",
-      modelRef: ANTHROPIC_API_DEFAULT_MODEL_REF,
-      label: "Anthropic API key",
-      detail: "ANTHROPIC_API_KEY set",
-      credentials: true,
-    });
-  }
+  candidates.push(...detectAmbientInferenceBackends(env));
 
   const [claudeProbe, codexProbe, geminiProbe] = await Promise.all([
     probe("claude"),

--- a/src/gateway/system-ca-warmup.test.ts
+++ b/src/gateway/system-ca-warmup.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { warmMacOSSystemCaOffMainThread } from "./system-ca-warmup.js";
 
 class FakeWorker extends EventEmitter {
+  terminate = vi.fn(async () => 0);
   unref = vi.fn();
 }
 
@@ -28,6 +29,7 @@ describe("warmMacOSSystemCaOffMainThread", () => {
     expect(workerSource).toContain('getCACertificates("default")');
     expect(workerSource).not.toContain('getCACertificates("system")');
     expect(worker.unref).toHaveBeenCalledOnce();
+    expect(worker.terminate).not.toHaveBeenCalled();
   });
 
   it("skips the warmup outside macOS", async () => {
@@ -38,14 +40,14 @@ describe("warmMacOSSystemCaOffMainThread", () => {
     expect(createWorker).not.toHaveBeenCalled();
   });
 
-  it("waits for the worker while leaving the main event loop available", async () => {
+  it("bounds a stalled trust lookup and continues startup", async () => {
     vi.useFakeTimers();
     const worker = new FakeWorker();
     const log = { warn: vi.fn() };
     const warmup = warmMacOSSystemCaOffMainThread({
       platform: "darwin",
       env: {},
-      warningMs: 10,
+      timeoutMs: 10,
       log,
       createWorker: vi.fn(() => worker),
     });
@@ -55,15 +57,18 @@ describe("warmMacOSSystemCaOffMainThread", () => {
       mainTurnRan = true;
     });
     await vi.advanceTimersByTimeAsync(10);
+    await warmup;
 
     expect(mainTurnRan).toBe(true);
     expect(log.warn).toHaveBeenCalledWith(
-      "macOS CA warmup is still waiting for default trust settings; gateway post-attach startup remains deferred",
+      "macOS CA warmup timed out after 10ms; gateway startup will continue and trust settings will load lazily",
     );
     expect(worker.unref).toHaveBeenCalledOnce();
+    expect(worker.terminate).toHaveBeenCalledOnce();
 
     worker.emit("message", { ok: true, certificateCount: 42 });
-    await warmup;
+    worker.emit("exit", 0);
+    expect(log.warn).toHaveBeenCalledOnce();
   });
 
   it("falls back to lazy CA loading when Node denies worker-thread permission", async () => {
@@ -86,16 +91,39 @@ describe("warmMacOSSystemCaOffMainThread", () => {
     );
   });
 
-  it("fails closed when the worker cannot populate the cache", async () => {
+  it("continues startup when the worker cannot populate the cache", async () => {
     const worker = new FakeWorker();
+    const log = { warn: vi.fn() };
     const warmup = warmMacOSSystemCaOffMainThread({
       platform: "darwin",
       env: {},
+      log,
       createWorker: vi.fn(() => worker),
     });
 
     worker.emit("message", { ok: false, error: "trust store unavailable" });
+    await warmup;
 
-    await expect(warmup).rejects.toThrow("trust store unavailable");
+    expect(log.warn).toHaveBeenCalledWith(
+      "macOS CA warmup failed: trust store unavailable; gateway startup will continue and trust settings will load lazily",
+    );
+    expect(worker.terminate).toHaveBeenCalledOnce();
+  });
+
+  it("continues startup when worker creation fails", async () => {
+    const log = { warn: vi.fn() };
+
+    await warmMacOSSystemCaOffMainThread({
+      platform: "darwin",
+      env: {},
+      log,
+      createWorker: vi.fn(() => {
+        throw new Error("worker unavailable");
+      }),
+    });
+
+    expect(log.warn).toHaveBeenCalledWith(
+      "macOS CA warmup skipped because worker creation failed: worker unavailable; trust settings will load lazily",
+    );
   });
 });

--- a/src/gateway/system-ca-warmup.ts
+++ b/src/gateway/system-ca-warmup.ts
@@ -2,7 +2,7 @@ import type { EventEmitter } from "node:events";
 import { Worker, type WorkerOptions } from "node:worker_threads";
 import { isVitestRuntimeEnv } from "../infra/env.js";
 
-const SYSTEM_CA_WARMUP_WARNING_MS = 10_000;
+const SYSTEM_CA_WARMUP_TIMEOUT_MS = 10_000;
 const SYSTEM_CA_WORKER_SOURCE = String.raw`
   const { getCACertificates } = require("node:tls");
   const { parentPort } = require("node:worker_threads");
@@ -21,6 +21,7 @@ const SYSTEM_CA_WORKER_SOURCE = String.raw`
 `;
 
 type SystemCaWarmupWorker = Pick<EventEmitter, "once" | "removeAllListeners"> & {
+  terminate: () => Promise<number>;
   unref: () => void;
 };
 
@@ -28,7 +29,7 @@ type SystemCaWarmupOptions = {
   env?: NodeJS.ProcessEnv;
   platform?: NodeJS.Platform;
   log?: { warn: (message: string) => void };
-  warningMs?: number;
+  timeoutMs?: number;
   createWorker?: (source: string, options: WorkerOptions) => SystemCaWarmupWorker;
 };
 
@@ -53,6 +54,10 @@ function isWorkerPermissionDenied(error: unknown): boolean {
   );
 }
 
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 /** Warm Node's effective default CA set without blocking the gateway event loop on macOS. */
 export async function warmMacOSSystemCaOffMainThread(
   options: SystemCaWarmupOptions = {},
@@ -72,55 +77,71 @@ export async function warmMacOSSystemCaOffMainThread(
       options.createWorker ?? ((source, workerOptions) => new Worker(source, workerOptions))
     )(SYSTEM_CA_WORKER_SOURCE, { eval: true });
   } catch (error) {
-    // Node's permission model can deny Worker construction. Fall back to Node's lazy CA
-    // loading instead of turning an optional event-loop warmup into a startup requirement.
-    if (!isWorkerPermissionDenied(error)) {
-      throw error;
-    }
-    options.log?.warn(
-      "macOS CA warmup skipped because Node denied worker-thread permission; trust settings will load lazily",
-    );
+    // CA prewarming is an optimization. Node can still load trust settings lazily.
+    const reason = isWorkerPermissionDenied(error)
+      ? "Node denied worker-thread permission"
+      : `worker creation failed: ${describeError(error)}`;
+    options.log?.warn(`macOS CA warmup skipped because ${reason}; trust settings will load lazily`);
     return;
   }
 
-  await new Promise<void>((resolve, reject) => {
+  await new Promise<void>((resolve) => {
     let settled = false;
-    const warningTimer = setTimeout(() => {
-      options.log?.warn(
-        "macOS CA warmup is still waiting for default trust settings; gateway post-attach startup remains deferred",
-      );
-    }, options.warningMs ?? SYSTEM_CA_WARMUP_WARNING_MS);
-    warningTimer.unref?.();
+    const timeoutMs = options.timeoutMs ?? SYSTEM_CA_WARMUP_TIMEOUT_MS;
 
-    const settle = (finish: () => void) => {
+    const settle = (warning?: string, terminate = false) => {
       if (settled) {
         return;
       }
       settled = true;
-      clearTimeout(warningTimer);
+      clearTimeout(timeout);
       worker.removeAllListeners();
-      finish();
+      // A terminating worker can still report one final error after listener cleanup.
+      worker.once("error", () => {});
+      if (terminate) {
+        void worker.terminate().catch(() => {});
+      }
+      if (warning) {
+        options.log?.warn(warning);
+      }
+      resolve();
     };
 
     worker.once("message", (value: unknown) => {
-      settle(() => {
-        if (!isSystemCaWarmupMessage(value)) {
-          reject(new Error("macOS system CA warmup worker returned an invalid result"));
-          return;
-        }
-        if (!value.ok) {
-          reject(new Error(value.error));
-          return;
-        }
-        resolve();
-      });
+      if (!isSystemCaWarmupMessage(value)) {
+        settle(
+          "macOS CA warmup returned an invalid result; gateway startup will continue and trust settings will load lazily",
+          true,
+        );
+        return;
+      }
+      if (!value.ok) {
+        settle(
+          `macOS CA warmup failed: ${value.error}; gateway startup will continue and trust settings will load lazily`,
+          true,
+        );
+        return;
+      }
+      settle();
     });
-    worker.once("error", (error: Error) => settle(() => reject(error)));
-    worker.once("exit", (code: number) => {
-      settle(() =>
-        reject(new Error(`macOS system CA warmup worker exited before replying (code ${code})`)),
+    worker.once("error", (error: Error) => {
+      settle(
+        `macOS CA warmup worker failed: ${error.message}; gateway startup will continue and trust settings will load lazily`,
       );
     });
+    worker.once("exit", (code: number) => {
+      settle(
+        `macOS CA warmup worker exited before replying (code ${code}); gateway startup will continue and trust settings will load lazily`,
+      );
+    });
+
+    const timeout = setTimeout(() => {
+      settle(
+        `macOS CA warmup timed out after ${timeoutMs}ms; gateway startup will continue and trust settings will load lazily`,
+        true,
+      );
+    }, timeoutMs);
+    timeout.unref?.();
 
     // A wedged trustd lookup must not keep an otherwise stopped gateway process alive.
     worker.unref();

--- a/src/system-agent/setup-inference-detection.test.ts
+++ b/src/system-agent/setup-inference-detection.test.ts
@@ -99,6 +99,43 @@ describe("isolated setup inference detection", () => {
     expect(performance.now() - pendingStartedAt).toBeLessThan(1_000);
   });
 
+  it("preserves ambient API keys when detection times out", async () => {
+    const { detectSetupInferenceIsolated } = await loadDetectionModule();
+
+    const detection = await detectSetupInferenceIsolated({
+      workerUrl: blockingWorkerUrl,
+      workerData: {
+        blockMs: 10_000,
+        detection: emptyDetection(),
+        partialDetection: emptyDetection(),
+      },
+      timeoutMs: 50,
+      fallbackEnv: {
+        OPENAI_API_KEY: "test-openai-key",
+        ANTHROPIC_API_KEY: "test-anthropic-key",
+      },
+    });
+
+    expect(detection.candidates).toEqual([
+      {
+        kind: "openai-api-key",
+        modelRef: "openai/gpt-5.6",
+        label: "OpenAI API key",
+        detail: "OPENAI_API_KEY set",
+        credentials: true,
+        recommended: false,
+      },
+      {
+        kind: "anthropic-api-key",
+        modelRef: "anthropic/claude-opus-4-8",
+        label: "Anthropic API key",
+        detail: "ANTHROPIC_API_KEY set",
+        credentials: true,
+        recommended: false,
+      },
+    ]);
+  });
+
   it("coalesces concurrent detections behind one bounded worker", async () => {
     const { detectSetupInferenceIsolated } = await loadDetectionModule();
     const fallback = vi.fn(async () => emptyDetection());

--- a/src/system-agent/setup-inference-detection.ts
+++ b/src/system-agent/setup-inference-detection.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { Worker, type WorkerOptions } from "node:worker_threads";
 import { DEFAULT_AGENT_WORKSPACE_DIR } from "../agents/workspace-default.js";
+import { detectAmbientInferenceBackends } from "../commands/onboard-inference-ambient.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { listRecommendedToolInstalls } from "../plugins/recommended-tool-installs.js";
 import type { SetupInferenceDetection } from "./setup-inference.js";
@@ -20,6 +21,7 @@ type DetectionWorkerOptions = {
   workerUrl?: URL;
   workerData?: WorkerOptions["workerData"];
   fallback?: () => Promise<SetupInferenceDetection>;
+  fallbackEnv?: NodeJS.ProcessEnv;
 };
 
 let inFlightDetection: Promise<SetupInferenceDetection> | undefined;
@@ -75,18 +77,37 @@ function parseDetectionWorkerMessage(value: unknown): DetectionWorkerMessage | u
   return undefined;
 }
 
-function createUndetectedFallback(): SetupInferenceDetection {
+function withAmbientCandidates(
+  detection: SetupInferenceDetection,
+  env: NodeJS.ProcessEnv,
+): SetupInferenceDetection {
+  const existing = new Set(
+    detection.candidates.map((candidate) => `${candidate.kind}\0${candidate.modelRef}`),
+  );
+  const ambient = detectAmbientInferenceBackends(env)
+    .filter((candidate) => !existing.has(`${candidate.kind}\0${candidate.modelRef}`))
+    .map((candidate) => Object.assign(candidate, { recommended: false as const }));
+  if (ambient.length === 0) {
+    return detection;
+  }
+  return { ...detection, candidates: [...detection.candidates, ...ambient] };
+}
+
+function createUndetectedFallback(env: NodeJS.ProcessEnv = process.env): SetupInferenceDetection {
   // This fallback must stay independent of the detection/plugin graph. The worker
   // supplies richer partial data when that graph loads before the deadline.
-  return {
-    candidates: [],
-    unavailableCandidates: [],
-    manualProviders: [],
-    authOptions: [],
-    recommendedInstalls: listRecommendedToolInstalls(),
-    workspace: DEFAULT_AGENT_WORKSPACE_DIR,
-    setupComplete: false,
-  };
+  return withAmbientCandidates(
+    {
+      candidates: [],
+      unavailableCandidates: [],
+      manualProviders: [],
+      authOptions: [],
+      recommendedInstalls: listRecommendedToolInstalls(),
+      workspace: DEFAULT_AGENT_WORKSPACE_DIR,
+      setupComplete: false,
+    },
+    env,
+  );
 }
 
 async function runDetectionWorker(
@@ -155,7 +176,11 @@ async function runDetectionWorker(
           void options.fallback().then(resolve, reject);
           return;
         }
-        const detection = partialDetection ?? createUndetectedFallback();
+        const env = options.fallbackEnv ?? process.env;
+        const detection = withAmbientCandidates(
+          partialDetection ?? createUndetectedFallback(env),
+          env,
+        );
         workerShutdownResult = detection;
         resolve(detection);
       });

--- a/src/system-agent/setup-inference.test.ts
+++ b/src/system-agent/setup-inference.test.ts
@@ -2317,6 +2317,7 @@ describe("activateSetupInference", () => {
             authProfileId: activatedProfileId,
             agentDir: expect.stringContaining("setup-inference-test-"),
             authProfileStateMode: "read-only",
+            preparedModelRuntimeMode: "isolated-read-only",
           }),
         );
         expect(configHarness.current()).toMatchObject({
@@ -5650,6 +5651,7 @@ describe("verifySetupInference", () => {
         model: "gpt-5.5",
         agentHarnessRuntimeOverride: "codex",
         authProfileStateMode: "read-only",
+        preparedModelRuntimeMode: "isolated-read-only",
       }),
     );
   });

--- a/src/system-agent/setup-inference.ts
+++ b/src/system-agent/setup-inference.ts
@@ -281,6 +281,7 @@ type SetupInferenceRunEmbeddedAgent = (
   params: Parameters<typeof import("../agents/embedded-agent.js").runEmbeddedAgent>[0] & {
     onSuccessfulAuthBinding?: (binding: AgentExecutionAuthBinding) => void;
     authProfileStateMode?: "read-write" | "read-only";
+    preparedModelRuntimeMode?: "isolated-read-only";
   },
 ) => ReturnType<typeof import("../agents/embedded-agent.js").runEmbeddedAgent>;
 
@@ -3411,6 +3412,7 @@ async function runSetupInferenceTest(params: {
           ? { authProfileId: plan.authProfileId, authProfileIdSource: "user" as const }
           : {}),
         authProfileStateMode,
+        preparedModelRuntimeMode: "isolated-read-only",
         ...(plan.cleanupBundleMcpOnRunEnd ? { cleanupBundleMcpOnRunEnd: true } : {}),
         ...(plan.agentHarnessRuntimeOverride
           ? { agentHarnessRuntimeOverride: plan.agentHarnessRuntimeOverride }


### PR DESCRIPTION
Closes #112336

## What Problem This Solves

Fixes an issue where users completing first-run Control UI setup could lose the available ambient OpenAI API-key route when rich inference discovery exceeded its timeout. On macOS, an unrelated stalled default trust-store lookup could also keep Gateway startup waiting indefinitely, so setup and chat remained unavailable despite valid AI access.

## Why This Change Was Made

The Gateway now treats macOS CA prewarming as a bounded, non-fatal optimization and terminates a stalled worker after 10 seconds. Setup detection keeps a tiny dependency-free ambient credential path so timeout fallback still exposes OpenAI and Anthropic API-key candidates. Live setup probes acquire an isolated read-only prepared runtime, preserving the exact staged candidate across concurrent Gateway runtime replacement instead of rebinding it to configured ownership.

Landing also corrects a pre-existing stale Zoom Meetings test expectation exposed by the required full-suite gate: production intentionally routes the realtime engine through the joined session owner (`support`), while the test still expected the configured fallback (`consult`). No production Zoom behavior changes.

This PR is AI-assisted. The final diff was reviewed with the repository `autoreview` workflow and no actionable findings remained.

## User Impact

Control UI onboarding remains responsive on slow or wedged macOS trust-store hosts, and a valid ambient API key continues to appear after discovery timeout. Users can verify and activate that route instead of being left without a setup candidate or waiting indefinitely for startup.

## Evidence

- Focused local proof after the final rebase:
  - `node scripts/run-vitest.mjs src/agents/prepared-model-runtime.test.ts src/gateway/system-ca-warmup.test.ts src/system-agent/setup-inference-detection.test.ts src/system-agent/setup-inference.test.ts`
  - 150 tests passed across unit, Gateway, and agents shards, including the startup event-loop regression.
  - Changed-file formatting and targeted oxlint passed.
  - `node scripts/run-vitest.mjs extensions/google-meet/index.test.ts extensions/zoom-meetings/src/runtime-node.test.ts` — 161 tests passed after correcting the stale Zoom expectation.
- Full changed gate on trusted source via AWS Crabbox:
  - Provider: `aws`
  - Lease: `cbx_e4a106046c3d` (`crimson-prawn`, stopped automatically)
  - Run: https://crabbox.openclaw.ai/portal/runs/run_17f945cd02c8
  - Command: `CI=1 NODE_OPTIONS=--max-old-space-size=4096 OPENCLAW_TEST_PROJECTS_PARALLEL=6 OPENCLAW_VITEST_MAX_WORKERS=1 pnpm check:changed`
  - Result: passed `core, coreTests`, including typecheck, core/core-test lint, import-cycle and architecture guards.
- Final branch autoreview against current `origin/main`: clean, no accepted/actionable findings; TruffleHog clean.
- Live isolated Gateway proof with a real OpenAI key:
  - Timeout detection still returned the `openai-api-key` candidate.
  - Four session variants completed real OpenAI turns: named managed worktree, auto-named managed worktree, direct repository session, and `openai/gpt-5.6-luna` override.
  - Concurrent worktree/session creation succeeded for distinct names; same-name contention was rejected with the owning session identified.
  - Session worktree reuse succeeded; contradictory worktree name, relative `cwd`, and base-ref-without-worktree inputs were rejected.
  - Control UI PR projection reported local tracked/untracked diff statistics without inventing a PR/create URL.
  - Snapshot remove/restore preserved tracked and untracked working state exactly.
  - All test sessions, worktrees, branches, snapshot refs, isolated state, and the credential-bearing Gateway process were removed afterward.
- Rendered browser interaction gap: the existing-profile Chrome DevTools bridge was unavailable after its single approved restart/retry, so this PR does not claim screenshot-level UI proof. No visual UI code changed; the exercised RPCs are the exact Control UI session/worktree/Git surfaces.
