### PR TITLE
fix(slack): preserve pasted table blocks in inbound messages

### DIFF
--- a/extensions/slack/src/actions.read.test.ts
+++ b/extensions/slack/src/actions.read.test.ts
@@ -121,6 +121,86 @@ describe("Slack read actions", () => {
     expect(result.messages.map((message) => message.ts)).toEqual(["1"]);
   });
 
+  it("renders attachment tables in channel reads without dropping raw payloads", async () => {
+    const client = createClient();
+    const blocks = [
+      {
+        type: "table",
+        rows: [
+          [
+            { type: "raw_text", text: "ID" },
+            { type: "raw_text", text: "Status" },
+          ],
+          [
+            { type: "raw_number", value: 12345, text: "12345" },
+            { type: "raw_text", text: "enabled" },
+          ],
+        ],
+      },
+    ];
+    const attachments = [{ fallback: "[no preview available]", blocks }];
+    client.conversations.history.mockResolvedValueOnce({
+      messages: [{ ts: "1", text: "  Please check these.  ", attachments }],
+      has_more: false,
+    });
+
+    const result = await readSlackMessages("C1", { client, token: "xoxb-test" });
+
+    expect(result.messages[0]?.text).toBe("  Please check these.  \nID\tStatus\n12345\tenabled");
+    expect(result.messages[0]?.attachments).toBe(attachments);
+    expect(result.messages[0]?.attachments?.[0]?.blocks).toBe(blocks);
+  });
+
+  it("leaves unrelated Slack message text byte-for-byte unchanged", async () => {
+    const client = createClient();
+    client.conversations.history.mockResolvedValueOnce({
+      messages: [
+        {
+          ts: "1",
+          text: "  keep me  ",
+          blocks: [{ type: "rich_text", elements: [] }],
+        },
+      ],
+      has_more: false,
+    });
+
+    const result = await readSlackMessages("C1", { client, token: "xoxb-test" });
+
+    expect(result.messages[0]?.text).toBe("  keep me  ");
+  });
+
+  it("renders attachment tables in thread reads without dropping raw payloads", async () => {
+    const client = createClient();
+    const attachments = [
+      {
+        fallback: "[no preview available]",
+        blocks: [
+          {
+            type: "table",
+            rows: [[{ type: "raw_text", text: "Name" }], [{ type: "raw_text", text: "Example A" }]],
+          },
+        ],
+      },
+    ];
+    client.conversations.replies.mockResolvedValueOnce({
+      messages: [
+        { ts: "1.000", text: "parent" },
+        { ts: "1.001", text: "Thread data", attachments },
+      ],
+      has_more: false,
+    });
+
+    const result = await readSlackMessages("C1", {
+      client,
+      threadId: "1.000",
+      token: "xoxb-test",
+    });
+
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0]?.text).toBe("Thread data\nName\nExample A");
+    expect(result.messages[0]?.attachments).toBe(attachments);
+  });
+
   it("filters a specific channel message by messageId", async () => {
     const client = createClient();
     client.conversations.history.mockResolvedValueOnce({

--- a/extensions/slack/src/actions.ts
+++ b/extensions/slack/src/actions.ts
@@ -11,6 +11,7 @@ import { validateSlackBlocksArray } from "./blocks-input.js";
 import { createSlackLookupClient, getSlackWriteClient } from "./client.js";
 import { buildSlackEditTextPayload } from "./edit-text.js";
 import { SLACK_EDIT_TEXT_LIMIT } from "./limits.js";
+import { hasSlackMessageTableBlock, resolveSlackMessageText } from "./monitor/block-text.js";
 import { resolveSlackMedia } from "./monitor/media.js";
 import type { SlackMediaResult } from "./monitor/media.js";
 import { escapeSlackMrkdwn } from "./monitor/mrkdwn.js";
@@ -24,6 +25,7 @@ import { buildSlackNativeDataDeliveryPlan } from "./native-data-fallback.js";
 import { sendMessageSlack } from "./send.js";
 import { resolveSlackBotToken } from "./token.js";
 import { truncateSlackText } from "./truncate.js";
+import type { SlackAttachment } from "./types.js";
 
 export type SlackActionClientOpts = {
   cfg?: OpenClawConfig;
@@ -37,6 +39,8 @@ export type SlackMessageSummary = {
   text?: string;
   user?: string;
   thread_ts?: string;
+  blocks?: unknown[];
+  attachments?: SlackAttachment[];
   reply_count?: number;
   reactions?: Array<{
     name?: string;
@@ -50,6 +54,14 @@ export type SlackMessageSummary = {
     mimetype?: string;
   }>;
 };
+
+function renderSlackReadMessageText(message: SlackMessageSummary): SlackMessageSummary {
+  if (!hasSlackMessageTableBlock(message)) {
+    return message;
+  }
+  const text = resolveSlackMessageText(message, { preserveMessageTextWhitespace: true });
+  return text && text !== message.text ? { ...message, text } : message;
+}
 
 export type SlackPin = {
   type?: string;
@@ -478,13 +490,15 @@ export async function readSlackMessages(
       limit: readLimit,
       ...exactBounds,
     });
-    const messages = ((result.messages ?? []) as SlackMessageSummary[]).filter((message) => {
-      if (exactMessageId) {
-        return message.ts === exactMessageId;
-      }
-      // conversations.replies includes the parent message; drop it for replies-only reads.
-      return message.ts !== opts.threadId;
-    });
+    const messages = ((result.messages ?? []) as SlackMessageSummary[])
+      .filter((message) => {
+        if (exactMessageId) {
+          return message.ts === exactMessageId;
+        }
+        // conversations.replies includes the parent message; drop it for replies-only reads.
+        return message.ts !== opts.threadId;
+      })
+      .map(renderSlackReadMessageText);
     return {
       messages,
       hasMore: exactMessageId ? false : Boolean(result.has_more),
@@ -496,9 +510,9 @@ export async function readSlackMessages(
     limit: readLimit,
     ...exactBounds,
   });
-  const messages = ((result.messages ?? []) as SlackMessageSummary[]).filter(
-    (message) => !exactMessageId || message.ts === exactMessageId,
-  );
+  const messages = ((result.messages ?? []) as SlackMessageSummary[])
+    .filter((message) => !exactMessageId || message.ts === exactMessageId)
+    .map(renderSlackReadMessageText);
   return {
     messages,
     hasMore: exactMessageId ? false : Boolean(result.has_more),

--- a/extensions/slack/src/blocks-fallback.ts
+++ b/extensions/slack/src/blocks-fallback.ts
@@ -2,6 +2,8 @@
 import {
   renderSlackDataTableFallbackText,
   renderSlackDataTableMrkdwnFallbackText,
+  renderSlackTableFallbackText,
+  renderSlackTableMrkdwnFallbackText,
 } from "./data-table.js";
 import {
   renderSlackDataVisualizationFallbackText,
@@ -266,6 +268,10 @@ export function renderSlackBlockFallbackText(
       return options.nativeDataFormat === "plain"
         ? renderSlackDataTableFallbackText(block)
         : renderSlackDataTableMrkdwnFallbackText(block);
+    case "table":
+      return options.nativeDataFormat === "plain"
+        ? renderSlackTableFallbackText(block)
+        : renderSlackTableMrkdwnFallbackText(block);
     default:
       return undefined;
   }

--- a/extensions/slack/src/blocks.test.ts
+++ b/extensions/slack/src/blocks.test.ts
@@ -60,6 +60,33 @@ describe("buildSlackBlocksFallbackText", () => {
     ).toBe("Pipeline report (table)\n- Account: Acme; ARR: 125000");
   });
 
+  it("renders basic table rows with plain or mrkdwn-safe cells", () => {
+    const table = {
+      type: "table",
+      rows: [
+        [
+          { type: "raw_text", text: "Owner\tname" },
+          {
+            type: "rich_text",
+            elements: [
+              {
+                type: "rich_text_section",
+                elements: [{ type: "text", text: "<!channel>\n*literal*" }],
+              },
+            ],
+          },
+        ],
+      ],
+    };
+
+    expect(renderSlackBlockFallbackText(table, { nativeDataFormat: "plain" })).toBe(
+      "Owner\\tname\t<!channel>\\n*literal*",
+    );
+    expect(renderSlackBlockFallbackText(table, { nativeDataFormat: "mrkdwn-safe" })).toBe(
+      "Owner\\tname\t&lt;!channel&gt;\\n\\*literal\\*",
+    );
+  });
+
   it("uses only visible action labels and select placeholders", () => {
     const fallback = buildSlackBlocksFallbackText([
       {

--- a/extensions/slack/src/data-table.ts
+++ b/extensions/slack/src/data-table.ts
@@ -1,4 +1,4 @@
-// Slack data_table Block Kit contract, projection, and text fallback.
+// Slack table Block Kit contracts, projection, and text fallback.
 import type { Block } from "@slack/web-api";
 import {
   renderMessagePresentationTableFallbackText,
@@ -57,6 +57,9 @@ function countCharacters(value: string): number {
 }
 
 function readRichTextLeaf(record: Record<string, unknown>): string {
+  if (record.type === "text" && typeof record.text === "string") {
+    return record.text;
+  }
   const text = readNonEmptyString(record.text);
   if (text) {
     return text;
@@ -91,7 +94,7 @@ function readRichTextLeaf(record: Record<string, unknown>): string {
   }
 }
 
-function readRichTextElements(value: unknown): string {
+function readRichTextElements(value: unknown, separator = ""): string {
   if (!Array.isArray(value)) {
     return "";
   }
@@ -102,7 +105,10 @@ function readRichTextElements(value: unknown): string {
       continue;
     }
     if (Array.isArray(element.elements)) {
-      const rendered = readRichTextElements(element.elements);
+      const rendered = readRichTextElements(
+        element.elements,
+        element.type === "rich_text_list" ? "\n" : "",
+      );
       if (rendered) {
         parts.push(rendered);
       }
@@ -113,7 +119,7 @@ function readRichTextElements(value: unknown): string {
       parts.push(rendered);
     }
   }
-  return parts.join("");
+  return parts.join(separator);
 }
 
 function readSlackDataTableCell(value: unknown, allowRichText: boolean): string | undefined {
@@ -133,6 +139,26 @@ function readSlackDataTableCell(value: unknown, allowRichText: boolean): string 
     return readNonEmptyString(readRichTextElements(cell.elements));
   }
   return undefined;
+}
+
+function readSlackTableCell(value: unknown): string {
+  const cell = asRecord(value);
+  if (!cell) {
+    return "";
+  }
+  if (cell.type === "raw_text") {
+    return typeof cell.text === "string" ? cell.text : "";
+  }
+  if (cell.type === "raw_number") {
+    if (typeof cell.value !== "number" || !Number.isFinite(cell.value)) {
+      return "";
+    }
+    return typeof cell.text === "string" && cell.text.length > 0 ? cell.text : String(cell.value);
+  }
+  if (cell.type === "rich_text") {
+    return readRichTextElements(cell.elements, "\n");
+  }
+  return "";
 }
 
 function parseSlackDataTable(
@@ -319,6 +345,40 @@ function escapeCompactFallbackCell(value: string): string {
     .replaceAll("\t", "\\t")
     .replaceAll("\r", "\\r")
     .replaceAll("\n", "\\n");
+}
+
+function escapeSlackTableFallbackCell(value: string, mrkdwnSafe: boolean): string {
+  const escaped = mrkdwnSafe ? escapeSlackMrkdwn(value) : value.replaceAll("\\", "\\\\");
+  return escaped.replaceAll("\t", "\\t").replaceAll("\r", "\\r").replaceAll("\n", "\\n");
+}
+
+function renderSlackTableRows(value: unknown, mrkdwnSafe: boolean): string | undefined {
+  const block = asRecord(value);
+  if (block?.type !== "table" || !Array.isArray(block.rows)) {
+    return undefined;
+  }
+  const rows: string[] = [];
+  for (const rawRow of block.rows) {
+    if (!Array.isArray(rawRow)) {
+      continue;
+    }
+    rows.push(
+      rawRow
+        .map((cell) => escapeSlackTableFallbackCell(readSlackTableCell(cell), mrkdwnSafe))
+        .join("\t"),
+    );
+  }
+  return rows.some((row) => row.length > 0) ? rows.join("\n") : undefined;
+}
+
+/** Render Slack's basic table block as ordered, delimiter-safe TSV. */
+export function renderSlackTableFallbackText(value: unknown): string | undefined {
+  return renderSlackTableRows(value, false);
+}
+
+/** Render Slack's basic table block as mrkdwn-safe ordered TSV. */
+export function renderSlackTableMrkdwnFallbackText(value: unknown): string | undefined {
+  return renderSlackTableRows(value, true);
 }
 
 /** Render each native table cell once for bounded, formatting-disabled delivery. */

--- a/extensions/slack/src/monitor/block-text.test.ts
+++ b/extensions/slack/src/monitor/block-text.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { chooseSlackPrimaryText, resolveSlackBlocksText } from "./block-text.js";
+import { resolveSlackBlocksText, resolveSlackMessageText } from "./block-text.js";
 
 describe("resolveSlackBlocksText data visualizations", () => {
   it("uses the shared visible-text parser for rich text, fields, and controls", () => {
@@ -113,8 +113,222 @@ describe("resolveSlackBlocksText data visualizations", () => {
     });
   });
 
+  it("renders basic table cells as ordered, delimiter-safe TSV", () => {
+    const table = {
+      type: "table",
+      rows: [
+        [
+          { type: "raw_text", text: "Name" },
+          { type: "raw_text", text: "Count" },
+          { type: "raw_text", text: "Owner" },
+          { type: "raw_text", text: "Note" },
+        ],
+        [
+          { type: "raw_text", text: "A\tB\nC\\D" },
+          { type: "raw_number", value: 12, text: "12 items" },
+          {
+            type: "rich_text",
+            elements: [
+              {
+                type: "rich_text_section",
+                elements: [
+                  { type: "text", text: "Ada" },
+                  { type: "text", text: " " },
+                  { type: "user", user_id: "U123" },
+                ],
+              },
+              {
+                type: "rich_text_section",
+                elements: [{ type: "text", text: "Team A" }],
+              },
+            ],
+          },
+          { type: "raw_text", text: "" },
+        ],
+        [
+          { type: "unknown", text: "ignored" },
+          { type: "raw_number", value: "not-a-number", text: "ignored" },
+          null,
+          { type: "raw_text", text: "tail" },
+        ],
+        "not-a-row",
+      ],
+    };
+
+    expect(resolveSlackBlocksText([table])).toEqual({
+      text: [
+        "Name\tCount\tOwner\tNote",
+        "A\\tB\\nC\\\\D\t12 items\tAda <@U123>\\nTeam A\t",
+        "\t\t\ttail",
+      ].join("\n"),
+      hasRichText: false,
+      hasNativeData: true,
+      hasBasicTable: true,
+    });
+  });
+
+  it("appends only attachment tables and deduplicates already-rendered rows", () => {
+    const table = {
+      type: "table",
+      rows: [
+        [
+          { type: "raw_text", text: "ID" },
+          { type: "raw_text", text: "Status" },
+        ],
+        [
+          { type: "raw_number", value: 12345, text: "12345" },
+          { type: "raw_text", text: "enabled" },
+        ],
+      ],
+    };
+    const rendered = "Please check these.\nID\tStatus\n12345\tenabled";
+
+    expect(
+      resolveSlackMessageText({
+        text: "Please check these.",
+        attachments: [
+          {
+            blocks: [{ type: "section", text: { type: "mrkdwn", text: "unfurl text" } }, table],
+          },
+        ],
+      }),
+    ).toBe(rendered);
+    expect(resolveSlackMessageText({ text: rendered, attachments: [{ blocks: [table] }] })).toBe(
+      rendered,
+    );
+
+    const secondTable = {
+      type: "table",
+      rows: [
+        [
+          { type: "raw_text", text: "Team" },
+          { type: "raw_text", text: "Owner" },
+        ],
+        [
+          { type: "raw_text", text: "Platform" },
+          { type: "raw_text", text: "Ada" },
+        ],
+      ],
+    };
+    expect(
+      resolveSlackMessageText({
+        text: rendered,
+        attachments: [{ blocks: [table, secondTable] }],
+      }),
+    ).toBe(`${rendered}\nTeam\tOwner\nPlatform\tAda`);
+    expect(
+      resolveSlackMessageText({
+        text: rendered,
+        blocks: [
+          { type: "section", text: { type: "plain_text", text: "Please check these." } },
+          table,
+          secondTable,
+        ],
+      }),
+    ).toBe(`${rendered}\nTeam\tOwner\nPlatform\tAda`);
+    expect(
+      resolveSlackMessageText({
+        text: "Please check these.",
+        blocks: [
+          { type: "section", text: { type: "plain_text", text: "Please check these." } },
+          table,
+          table,
+        ],
+      }),
+    ).toBe(rendered);
+  });
+
+  it("expands a message prefix only when blocks before the table represent it", () => {
+    const table = {
+      type: "table",
+      rows: [
+        [
+          { type: "raw_text", text: "Status" },
+          { type: "raw_text", text: "Value" },
+        ],
+      ],
+    };
+    const section = { type: "section", text: { type: "plain_text", text: "Instructions" } };
+
+    expect(resolveSlackMessageText({ text: "Status", blocks: [table, section] })).toBe(
+      "Status\nStatus\tValue\nInstructions",
+    );
+    expect(
+      resolveSlackMessageText({
+        text: "Instructions",
+        blocks: [{ type: "section", text: { type: "plain_text", text: "Instructions" } }, table],
+      }),
+    ).toBe("Instructions\nStatus\tValue");
+  });
+
+  it("does not deduplicate a short table found only inside surrounding words", () => {
+    expect(
+      resolveSlackMessageText({
+        text: "please look good",
+        attachments: [
+          {
+            blocks: [
+              {
+                type: "table",
+                rows: [
+                  [
+                    { type: "raw_text", text: "ok" },
+                    { type: "raw_text", text: "go" },
+                  ],
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+    ).toBe("please look good\nok\tgo");
+  });
+
+  it.each([
+    {
+      name: "space-separated sentence versus TSV row",
+      text: "A B",
+      cells: ["A", "B"],
+      expected: "A B\nA\tB",
+    },
+    {
+      name: "single cell inside a sentence",
+      text: "Please check enabled",
+      cells: ["enabled"],
+      expected: "Please check enabled\nenabled",
+    },
+    {
+      name: "cell extending the whole sentence",
+      text: "A",
+      cells: ["AB"],
+      expected: "A\nAB",
+    },
+    {
+      name: "sentence matching the first table cell",
+      text: "A",
+      cells: ["A", "B"],
+      expected: "A\nA\tB",
+    },
+  ])("preserves table structure for $name", ({ text, cells, expected }) => {
+    expect(
+      resolveSlackMessageText({
+        text,
+        attachments: [
+          {
+            blocks: [
+              {
+                type: "table",
+                rows: [cells.map((cell) => ({ type: "raw_text", text: cell }))],
+              },
+            ],
+          },
+        ],
+      }),
+    ).toBe(expected);
+  });
+
   it("keeps top-level message text alongside native chart details", () => {
-    const blocksText = resolveSlackBlocksText([
+    const blocks = [
       {
         type: "data_visualization",
         title: "Weekly latency",
@@ -132,12 +346,12 @@ describe("resolveSlackBlocksText data visualizations", () => {
           axis_config: { categories: ["Mon", "Tue"] },
         },
       },
-    ]);
+    ];
 
     expect(
-      chooseSlackPrimaryText({
-        messageText: "Here is the requested latency trend.",
-        blocksText,
+      resolveSlackMessageText({
+        text: "Here is the requested latency trend.",
+        blocks,
       }),
     ).toBe(
       [
@@ -148,8 +362,74 @@ describe("resolveSlackBlocksText data visualizations", () => {
     );
   });
 
+  it.each([
+    {
+      name: "data table",
+      text: "Pipeline report (table)",
+      block: {
+        type: "data_table",
+        caption: "Pipeline report",
+        rows: [[{ type: "raw_text", text: "Account" }], [{ type: "raw_text", text: "Acme" }]],
+      },
+      expected: "Pipeline report (table)\n- Account: Acme",
+      deduplicatedText: "Pipeline report (table) - Account: Acme",
+    },
+    {
+      name: "data visualization",
+      text: "Weekly latency (line chart)",
+      block: {
+        type: "data_visualization",
+        title: "Weekly latency",
+        chart: {
+          type: "line",
+          series: [{ name: "p95", data: [{ label: "Mon", value: 250 }] }],
+          axis_config: { categories: ["Mon"] },
+        },
+      },
+      expected: "Weekly latency (line chart)\n- p95: Mon: 250",
+      deduplicatedText: "Weekly latency (line chart) - p95: Mon: 250",
+    },
+  ])(
+    "preserves prefix expansion and whitespace-insensitive deduplication for a $name",
+    ({ text, block, expected, deduplicatedText }) => {
+      expect(resolveSlackMessageText({ text, blocks: [block] })).toBe(expected);
+      expect(resolveSlackMessageText({ text: deduplicatedText, blocks: [block] })).toBe(
+        deduplicatedText,
+      );
+    },
+  );
+
+  it("keeps legacy native-data comparison separate from an adjacent basic table", () => {
+    const messageText = "Weekly latency (line chart) - p95: Mon: 250";
+    expect(
+      resolveSlackMessageText({
+        text: messageText,
+        blocks: [
+          {
+            type: "data_visualization",
+            title: "Weekly latency",
+            chart: {
+              type: "line",
+              series: [{ name: "p95", data: [{ label: "Mon", value: 250 }] }],
+              axis_config: { categories: ["Mon"] },
+            },
+          },
+          {
+            type: "table",
+            rows: [
+              [
+                { type: "raw_text", text: "Status" },
+                { type: "raw_text", text: "Value" },
+              ],
+            ],
+          },
+        ],
+      }),
+    ).toBe(`${messageText}\nStatus\tValue`);
+  });
+
   it("does not duplicate top-level text already represented before a chart", () => {
-    const blocksText = resolveSlackBlocksText([
+    const blocks = [
       { type: "section", text: { type: "mrkdwn", text: "Latency report" } },
       {
         type: "data_visualization",
@@ -160,15 +440,15 @@ describe("resolveSlackBlocksText data visualizations", () => {
           axis_config: { categories: ["Mon"] },
         },
       },
-    ]);
+    ];
 
-    expect(chooseSlackPrimaryText({ messageText: "Latency report", blocksText })).toBe(
+    expect(resolveSlackMessageText({ text: "Latency report", blocks })).toBe(
       "Latency report\nWeekly latency (line chart)\n- p95: Mon: 250",
     );
   });
 
   it("does not duplicate chart data when top-level text uses paragraph spacing", () => {
-    const blocksText = resolveSlackBlocksText([
+    const blocks = [
       { type: "section", text: { type: "mrkdwn", text: "Latency report" } },
       {
         type: "data_visualization",
@@ -179,9 +459,9 @@ describe("resolveSlackBlocksText data visualizations", () => {
           axis_config: { categories: ["Mon"] },
         },
       },
-    ]);
+    ];
     const messageText = "Latency report\n\nWeekly latency (line chart)\n- p95: Mon: 250";
 
-    expect(chooseSlackPrimaryText({ messageText, blocksText })).toBe(messageText);
+    expect(resolveSlackMessageText({ text: messageText, blocks })).toBe(messageText);
   });
 });

--- a/extensions/slack/src/monitor/block-text.ts
+++ b/extensions/slack/src/monitor/block-text.ts
@@ -1,15 +1,42 @@
+import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { renderSlackBlockFallbackText } from "../blocks-fallback.js";
 
 type SlackBlocksText = {
   text: string;
   hasRichText: boolean;
   hasNativeData: boolean;
+  hasBasicTable?: boolean;
+};
+
+type SlackMessageTextSource = {
+  text?: string;
+  blocks?: unknown[];
+  attachments?: Array<{ blocks?: unknown[] }>;
+};
+
+type ResolveSlackMessageTextOptions = {
+  preserveMessageTextWhitespace?: boolean;
 };
 
 function readSlackBlockType(block: unknown): unknown {
   return block && typeof block === "object" && !Array.isArray(block)
     ? (block as { type?: unknown }).type
     : undefined;
+}
+
+function isSlackNativeDataBlockType(blockType: unknown): boolean {
+  return blockType === "data_visualization" || blockType === "data_table" || blockType === "table";
+}
+
+export function hasSlackTableBlock(blocks: unknown[] | undefined): boolean {
+  return blocks?.some((block) => readSlackBlockType(block) === "table") ?? false;
+}
+
+export function hasSlackMessageTableBlock(message: SlackMessageTextSource): boolean {
+  return (
+    hasSlackTableBlock(message.blocks) ||
+    message.attachments?.some((attachment) => hasSlackTableBlock(attachment.blocks)) === true
+  );
 }
 
 export function resolveSlackBlocksText(blocks: unknown[] | undefined): SlackBlocksText | undefined {
@@ -19,21 +46,30 @@ export function resolveSlackBlocksText(blocks: unknown[] | undefined): SlackBloc
   const parts: string[] = [];
   let hasRichText = false;
   let hasNativeData = false;
+  let hasBasicTable = false;
   for (const block of blocks) {
     const blockType = readSlackBlockType(block);
     hasRichText ||= blockType === "rich_text";
-    hasNativeData ||= blockType === "data_visualization" || blockType === "data_table";
+    hasNativeData ||= isSlackNativeDataBlockType(blockType);
     const text = renderSlackBlockFallbackText(block, { nativeDataFormat: "plain" });
     if (text) {
+      if (blockType === "table") {
+        hasBasicTable = true;
+      }
       parts.push(text);
     }
   }
-  return parts.length > 0 ? { text: parts.join("\n"), hasRichText, hasNativeData } : undefined;
+  if (parts.length === 0) {
+    return undefined;
+  }
+  const resolved = { text: parts.join("\n"), hasRichText, hasNativeData };
+  return hasBasicTable ? { ...resolved, hasBasicTable: true } : resolved;
 }
 
-export function chooseSlackPrimaryText(params: {
+function chooseSlackPrimaryText(params: {
   messageText: string | undefined;
   blocksText: SlackBlocksText | undefined;
+  allowMessagePrefixExpansion?: boolean;
 }): string | undefined {
   const { messageText, blocksText } = params;
   if (!blocksText) {
@@ -43,12 +79,23 @@ export function chooseSlackPrimaryText(params: {
     return blocksText.text;
   }
   if (blocksText.hasNativeData) {
-    const comparableMessageText = messageText.replace(/\s+/g, " ").trim();
-    const comparableBlocksText = blocksText.text.replace(/\s+/g, " ").trim();
-    if (comparableMessageText.includes(comparableBlocksText)) {
+    if (!blocksText.hasBasicTable) {
+      const comparableMessageText = normalizeLegacyNativeDataText(messageText);
+      const comparableBlocksText = normalizeLegacyNativeDataText(blocksText.text);
+      if (comparableMessageText.includes(comparableBlocksText)) {
+        return messageText;
+      }
+      return comparableBlocksText.startsWith(comparableMessageText)
+        ? blocksText.text
+        : `${messageText}\n${blocksText.text}`;
+    }
+    const comparableMessageText = normalizeComparableNativeDataText(messageText);
+    const comparableBlocksText = normalizeComparableNativeDataText(blocksText.text);
+    if (containsComparableNativeDataSegment(comparableMessageText, comparableBlocksText)) {
       return messageText;
     }
-    return comparableBlocksText.startsWith(comparableMessageText)
+    return params.allowMessagePrefixExpansion !== false &&
+      startsWithComparableText(comparableBlocksText, comparableMessageText)
       ? blocksText.text
       : `${messageText}\n${blocksText.text}`;
   }
@@ -58,4 +105,142 @@ export function chooseSlackPrimaryText(params: {
   return blocksText.text.length > messageText.length && blocksText.text.startsWith(messageText)
     ? blocksText.text
     : messageText;
+}
+
+function isComparableWordCharacter(value: string | undefined): boolean {
+  return value ? /[\p{L}\p{N}_]/u.test(value) : false;
+}
+
+function normalizeLegacyNativeDataText(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function normalizeComparableNativeDataText(value: string): string {
+  return value
+    .replace(/\r\n?/g, "\n")
+    .split("\n")
+    .filter((line) => !/^ *$/u.test(line))
+    .map((line) => line.replace(/^ +| +$/gu, ""))
+    .join("\n");
+}
+
+function containsComparableNativeDataSegment(haystack: string, needle: string): boolean {
+  if (!needle) {
+    return true;
+  }
+  return `\n${haystack}\n`.includes(`\n${needle}\n`);
+}
+
+function startsWithComparableText(value: string, prefix: string): boolean {
+  if (!prefix || !value.startsWith(prefix)) {
+    return false;
+  }
+  const next = value[prefix.length];
+  return (
+    next === undefined ||
+    !isComparableWordCharacter(prefix.at(-1)) ||
+    !isComparableWordCharacter(next)
+  );
+}
+
+function resolveSlackAttachmentTableTexts(
+  attachments: SlackMessageTextSource["attachments"],
+): SlackBlocksText[] {
+  const tableTexts: SlackBlocksText[] = [];
+  for (const attachment of attachments ?? []) {
+    for (const block of attachment.blocks ?? []) {
+      if (readSlackBlockType(block) === "table") {
+        const tableText = resolveSlackBlocksText([block]);
+        if (tableText) {
+          tableTexts.push(tableText);
+        }
+      }
+    }
+  }
+  return tableTexts;
+}
+
+function appendSlackFollowingBlocksText(
+  messageText: string | undefined,
+  blocksText: SlackBlocksText | undefined,
+): string | undefined {
+  if (!blocksText) {
+    return messageText;
+  }
+  if (!messageText) {
+    return blocksText.text;
+  }
+  if (blocksText.hasNativeData) {
+    return chooseSlackPrimaryText({ messageText, blocksText });
+  }
+  const comparableMessageText = normalizeComparableNativeDataText(messageText);
+  const comparableBlocksText = normalizeComparableNativeDataText(blocksText.text);
+  if (containsComparableNativeDataSegment(comparableMessageText, comparableBlocksText)) {
+    return messageText;
+  }
+  return startsWithComparableText(comparableBlocksText, comparableMessageText)
+    ? blocksText.text
+    : `${messageText}\n${blocksText.text}`;
+}
+
+function resolveSlackTopLevelMessageText(
+  messageText: string | undefined,
+  blocks: unknown[] | undefined,
+): string | undefined {
+  if (!hasSlackTableBlock(blocks)) {
+    return chooseSlackPrimaryText({ messageText, blocksText: resolveSlackBlocksText(blocks) });
+  }
+
+  let resolvedText = messageText;
+  let pendingBlocks: unknown[] = [];
+  let hasRenderedTable = false;
+  const flushPendingBlocks = () => {
+    const pendingText = resolveSlackBlocksText(pendingBlocks);
+    resolvedText = hasRenderedTable
+      ? appendSlackFollowingBlocksText(resolvedText, pendingText)
+      : chooseSlackPrimaryText({ messageText: resolvedText, blocksText: pendingText });
+    pendingBlocks = [];
+  };
+
+  for (const block of blocks ?? []) {
+    if (readSlackBlockType(block) !== "table") {
+      pendingBlocks.push(block);
+      continue;
+    }
+    const tableText = resolveSlackBlocksText([block]);
+    if (!tableText) {
+      continue;
+    }
+    flushPendingBlocks();
+    resolvedText = chooseSlackPrimaryText({
+      messageText: resolvedText,
+      blocksText: tableText,
+      allowMessagePrefixExpansion: false,
+    });
+    hasRenderedTable = true;
+  }
+  flushPendingBlocks();
+  return resolvedText;
+}
+
+/** Resolve agent-visible message text without admitting ordinary attachment unfurls. */
+export function resolveSlackMessageText(
+  message: SlackMessageTextSource,
+  options: ResolveSlackMessageTextOptions = {},
+): string | undefined {
+  const messageText = options.preserveMessageTextWhitespace
+    ? typeof message.text === "string" && message.text.trim().length > 0
+      ? message.text
+      : undefined
+    : normalizeOptionalString(message.text);
+  const primaryText = resolveSlackTopLevelMessageText(messageText, message.blocks);
+  return resolveSlackAttachmentTableTexts(message.attachments).reduce<string | undefined>(
+    (resolvedText, tableText) =>
+      chooseSlackPrimaryText({
+        messageText: resolvedText,
+        blocksText: tableText,
+        allowMessagePrefixExpansion: false,
+      }),
+    primaryText,
+  );
 }

--- a/extensions/slack/src/monitor/media.test.ts
+++ b/extensions/slack/src/monitor/media.test.ts
@@ -1163,6 +1163,92 @@ describe("resolveSlackThreadHistory", () => {
     ]);
   });
 
+  it("keeps attachment table rows with top-level text in thread history", async () => {
+    const replies = vi.fn().mockResolvedValueOnce({
+      messages: [
+        {
+          text: "Please check these.",
+          user: "U1",
+          ts: "1.000",
+          attachments: [
+            {
+              fallback: "[no preview available]",
+              blocks: [
+                {
+                  type: "table",
+                  rows: [
+                    [
+                      { type: "raw_text", text: "ID" },
+                      { type: "raw_text", text: "Status" },
+                    ],
+                    [
+                      { type: "raw_number", value: 12345, text: "12345" },
+                      { type: "raw_text", text: "enabled" },
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      response_metadata: { next_cursor: "" },
+    });
+    const client = {
+      conversations: { replies },
+    } as unknown as Parameters<typeof resolveSlackThreadHistory>[0]["client"];
+
+    const result = await resolveSlackThreadHistory({
+      channelId: "C1",
+      threadTs: "1.000",
+      client,
+      limit: 10,
+    });
+
+    expect(result[0]?.text).toBe("Please check these.\nID\tStatus\n12345\tenabled");
+  });
+
+  it("preserves empty outer table cells in thread history", async () => {
+    const replies = vi.fn().mockResolvedValueOnce({
+      messages: [
+        {
+          text: "",
+          ts: "1.000",
+          attachments: [
+            {
+              fallback: "[no preview available]",
+              blocks: [
+                {
+                  type: "table",
+                  rows: [
+                    [
+                      { type: "raw_text", text: "A" },
+                      { type: "raw_text", text: "" },
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      response_metadata: { next_cursor: "" },
+    });
+    const client = {
+      conversations: { replies },
+    } as unknown as Parameters<typeof resolveSlackThreadHistory>[0]["client"];
+
+    const result = await resolveSlackThreadHistory({
+      channelId: "C1",
+      threadTs: "1.000",
+      client,
+      limit: 10,
+    });
+
+    expect(result[0]?.text).toBe("A\t");
+    expect(result[0]?.text).not.toContain("[no preview available]");
+  });
+
   it("returns empty when limit is zero without calling Slack API", async () => {
     const replies = vi.fn();
     const client = {

--- a/extensions/slack/src/monitor/message-handler.test.ts
+++ b/extensions/slack/src/monitor/message-handler.test.ts
@@ -243,6 +243,48 @@ describe("createSlackMessageHandler", () => {
     expect(flushKeyMock).toHaveBeenCalledWith("slack:default:C111:1709000000.000100:U111");
   });
 
+  it("flushes buffered text before a table-bearing message", async () => {
+    const handler = createSlackMessageHandler({
+      ctx: createContext(),
+      account: { accountId: "default" } as Parameters<
+        typeof createSlackMessageHandler
+      >[0]["account"],
+    });
+
+    await handler(
+      {
+        type: "message",
+        channel: "C111",
+        user: "U111",
+        ts: "1709000000.000100",
+        text: "first buffered text",
+      } as never,
+      { source: "message" },
+    );
+    await handler(
+      {
+        type: "message",
+        channel: "C111",
+        user: "U111",
+        ts: "1709000000.000200",
+        text: "table follows",
+        attachments: [
+          {
+            blocks: [
+              {
+                type: "table",
+                rows: [[{ type: "raw_text", text: "kept" }]],
+              },
+            ],
+          },
+        ],
+      } as never,
+      { source: "message" },
+    );
+
+    expect(flushKeyMock).toHaveBeenCalledWith("slack:default:C111:1709000000.000100:U111");
+  });
+
   it("waits for debounced dispatch completion when requested by relay delivery", async () => {
     const { handler } = createHandlerWithTracker();
     const handled = handler(

--- a/extensions/slack/src/monitor/message-handler.ts
+++ b/extensions/slack/src/monitor/message-handler.ts
@@ -8,6 +8,7 @@ import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import type { ResolvedSlackAccount } from "../accounts.js";
 import type { SlackSendIdentity } from "../send.js";
 import type { SlackMessageEvent } from "../types.js";
+import { hasSlackMessageTableBlock } from "./block-text.js";
 import { stripSlackMentionsForCommandDetection } from "./commands.js";
 import type { SlackMonitorContext } from "./context.js";
 import type { SlackEventScope } from "./event-scope.js";
@@ -85,7 +86,8 @@ function shouldDebounceSlackMessage(message: SlackMessageEvent, cfg: SlackMonito
   return shouldDebounceTextInbound({
     text: textForCommandDetection,
     cfg,
-    hasMedia: Boolean(message.files && message.files.length > 0),
+    hasMedia:
+      Boolean(message.files && message.files.length > 0) || hasSlackMessageTableBlock(message),
   });
 }
 

--- a/extensions/slack/src/monitor/message-handler/prepare-content.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare-content.ts
@@ -6,7 +6,7 @@ import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { formatSlackFileReference } from "../../file-reference.js";
 import type { SlackFile, SlackMessageEvent } from "../../types.js";
-import { chooseSlackPrimaryText, resolveSlackBlocksText } from "../block-text.js";
+import { resolveSlackMessageText } from "../block-text.js";
 import { MAX_SLACK_MEDIA_FILES, type SlackMediaResult } from "../media-types.js";
 import type { SlackThreadStarter } from "../thread.js";
 
@@ -160,11 +160,7 @@ export async function resolveSlackMessageContent(params: {
       botAttachmentTextParts.length > 0 ? botAttachmentTextParts.join("\n") : undefined;
   }
 
-  const blocksText = resolveSlackBlocksText(params.message.blocks);
-  const primaryText = chooseSlackPrimaryText({
-    messageText: normalizeOptionalString(params.message.text),
-    blocksText,
-  });
+  const primaryText = resolveSlackMessageText(params.message);
   const textParts = [primaryText, attachmentContent?.text, botAttachmentText];
   const renderedMentions = new Map<string, string | null>();
   const resolveUserName = params.resolveUserName;

--- a/extensions/slack/src/monitor/message-handler/prepare.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test.ts
@@ -3820,8 +3820,8 @@ Second paragraph should still reach the agent after Slack's preview cutoff.`;
     let downloadedPath: string | undefined;
     let downloadedPaths: string[] = [];
     transcribeFirstAudioMock.mockImplementation(
-      async ({ ctx }: { ctx: { MediaPaths: string[] } }) => {
-        downloadedPath = ctx.MediaPaths[0];
+      async ({ ctx }: { ctx: { media: Array<{ path: string; contentType?: string }> } }) => {
+        downloadedPath = ctx.media.find((entry) => entry.contentType?.startsWith("audio/"))?.path;
         return "Bill /new please review this";
       },
     );
@@ -3945,8 +3945,8 @@ Second paragraph should still reach the agent after Slack's preview cutoff.`;
     slackCtx.historyLimit = 5;
     let downloadedPath: string | undefined;
     transcribeFirstAudioMock.mockImplementation(
-      async ({ ctx }: { ctx: { MediaPaths: string[] } }) => {
-        downloadedPath = ctx.MediaPaths[0];
+      async ({ ctx }: { ctx: { media: Array<{ path: string; contentType?: string }> } }) => {
+        downloadedPath = ctx.media.find((entry) => entry.contentType?.startsWith("audio/"))?.path;
         return "please review this";
       },
     );

--- a/extensions/slack/src/monitor/message-handler/prepare.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test.ts
@@ -1173,6 +1173,90 @@ Second paragraph should still reach the agent after Slack's preview cutoff.`;
     expect(prepared.ctxPayload.BodyForAgent).toContain(fullText);
   });
 
+  it("preserves a pasted table from a non-forwarded attachment", async () => {
+    const sentence = "<@U_BOT> please check whether these are wired up correctly";
+    const prepared = await prepareWithDefaultCtx(
+      createSlackMessage({
+        text: sentence,
+        blocks: [
+          {
+            type: "rich_text",
+            elements: [
+              {
+                type: "rich_text_section",
+                elements: [
+                  { type: "user", user_id: "U_BOT" },
+                  { type: "text", text: " please check whether these are wired up correctly" },
+                ],
+              },
+            ],
+          },
+        ],
+        attachments: [
+          {
+            fallback: "[no preview available]",
+            blocks: [
+              {
+                type: "table",
+                rows: [
+                  [
+                    {
+                      type: "rich_text",
+                      elements: [
+                        {
+                          type: "rich_text_section",
+                          elements: [{ type: "text", text: "ID" }],
+                        },
+                      ],
+                    },
+                    {
+                      type: "rich_text",
+                      elements: [
+                        {
+                          type: "rich_text_section",
+                          elements: [{ type: "text", text: "Name" }],
+                        },
+                      ],
+                    },
+                    {
+                      type: "rich_text",
+                      elements: [
+                        {
+                          type: "rich_text_section",
+                          elements: [{ type: "text", text: "Status" }],
+                        },
+                      ],
+                    },
+                  ],
+                  [
+                    { type: "raw_text", text: "12345" },
+                    { type: "raw_text", text: "Example A" },
+                    { type: "raw_text", text: "enabled" },
+                  ],
+                  [
+                    { type: "raw_text", text: "12346" },
+                    { type: "raw_text", text: "Example B" },
+                    { type: "raw_text", text: "enabled" },
+                  ],
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+    );
+
+    assertPrepared(prepared);
+    expect(prepared.ctxPayload.RawBody).toContain(
+      ["ID\tName\tStatus", "12345\tExample A\tenabled", "12346\tExample B\tenabled"].join("\n"),
+    );
+    expect(prepared.ctxPayload.RawBody).toContain(
+      "please check whether these are wired up correctly",
+    );
+    expect(prepared.ctxPayload.RawBody).not.toContain("[no preview available]");
+    expect(prepared.ctxPayload.BodyForAgent).toContain("12346\tExample B\tenabled");
+  });
+
   it("ignores non-forward attachments when no direct text/files are present", async () => {
     const prepared = await prepareWithDefaultCtx(
       createSlackMessage({

--- a/extensions/slack/src/monitor/thread.ts
+++ b/extensions/slack/src/monitor/thread.ts
@@ -9,7 +9,11 @@ import {
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { formatSlackFileReferenceList } from "../file-reference.js";
 import type { SlackAttachment, SlackFile } from "../types.js";
-import { chooseSlackPrimaryText, resolveSlackBlocksText } from "./block-text.js";
+import {
+  hasSlackTableBlock,
+  resolveSlackBlocksText,
+  resolveSlackMessageText as resolveSharedSlackMessageText,
+} from "./block-text.js";
 import { logVerbose } from "./thread.runtime.js";
 
 export type SlackThreadStarter = {
@@ -47,8 +51,16 @@ function formatSlackFilePlaceholder(files: SlackFile[] | undefined): string {
   return `[attached: ${formatSlackFileReferenceList(files)}]`;
 }
 
-function pushUniqueText(parts: string[], value: string | undefined): void {
-  const text = normalizeOptionalString(value);
+function pushUniqueText(
+  parts: string[],
+  value: string | undefined,
+  options: { preserveWhitespace?: boolean } = {},
+): void {
+  const text = options.preserveWhitespace
+    ? typeof value === "string" && value.trim().length > 0
+      ? value
+      : undefined
+    : normalizeOptionalString(value);
   if (text && !parts.includes(text)) {
     parts.push(text);
   }
@@ -70,13 +82,22 @@ function resolveSlackAttachmentFallbackText(
     pushUniqueText(parts, attachment.pretext);
     pushUniqueText(parts, attachment.title);
     pushUniqueText(parts, attachment.text);
-    pushUniqueText(parts, attachment.fallback);
+    const isTablePlaceholder =
+      hasSlackTableBlock(attachment.blocks) &&
+      normalizeOptionalString(attachment.fallback) === "[no preview available]";
+    if (!isTablePlaceholder) {
+      pushUniqueText(parts, attachment.fallback);
+    }
     for (const field of attachment.fields ?? []) {
       pushUniqueText(parts, field.title);
       pushUniqueText(parts, field.value);
     }
-    pushUniqueText(parts, resolveSlackBlocksFallbackText(attachment.blocks));
-    pushUniqueText(parts, resolveSlackBlocksFallbackText(attachment.message_blocks));
+    pushUniqueText(parts, resolveSlackBlocksFallbackText(attachment.blocks), {
+      preserveWhitespace: true,
+    });
+    pushUniqueText(parts, resolveSlackBlocksFallbackText(attachment.message_blocks), {
+      preserveWhitespace: true,
+    });
   }
   return parts.length > 0 ? parts.join("\n") : undefined;
 }
@@ -89,10 +110,13 @@ function resolveSlackMessageText(message: {
   const messageText =
     normalizeOptionalString(message.text) ??
     resolveSlackAttachmentFallbackText(message.attachments);
-  return chooseSlackPrimaryText({
-    messageText,
-    blocksText: resolveSlackBlocksText(message.blocks),
-  });
+  return resolveSharedSlackMessageText(
+    {
+      ...message,
+      text: messageText,
+    },
+    { preserveMessageTextWhitespace: true },
+  );
 }
 
 export async function resolveSlackThreadStarter(params: {


### PR DESCRIPTION
Closes #112229

## What Problem This Solves

Fixes an issue where users pasting a native table into Slack would have the surrounding sentence delivered to the agent while every table row was dropped. The same loss occurred in live inbound handling, thread context, and Slack channel/thread read results.

## Why This Change Was Made

Slack's [`table` block contract](https://docs.slack.dev/reference/block-kit/blocks/table-block/) permits tables in top-level blocks and attachments, with `raw_text`, `raw_number`, and `rich_text` cells. This change adds a deterministic TSV-style fallback for that contract and one shared message-text resolver that combines normal text, top-level blocks, and only native table blocks from attachments.

Table rows and columns retain their order; embedded delimiters are escaped; empty columns are preserved; malformed cells are ignored safely; and multiple tables are deduplicated independently. Live inbound preparation, thread history, and Slack read actions now reuse the resolver. Raw `blocks` and `attachments` remain available, forwarded-message behavior is unchanged, and ordinary non-forward link-unfurl attachments remain excluded.

## User Impact

Agents can now see and reason over tables pasted into Slack, including mixed text/number/rich-text cells, both when messages arrive live and when channel or thread history is read later. Existing Slack messages without native tables keep their previous text behavior.

## Evidence

- Production-shaped regression fixture mirrors the issue payload: non-empty sentence, non-`is_share` attachment, `[no preview available]` fallback, and nested `table` block. Result: `1 passed`, with the sentence and rendered rows present and the placeholder absent.
- Focused Slack regression suite covering block rendering, shared resolution, channel/thread reads, thread context, and debounce handling: `5 files passed`, `105 tests passed`.
- `scripts/check-changed.mjs` passed for all 13 changed Slack files; the final resolver files were rerun after the last review fix. This includes formatting, production/test typechecks, lint, plugin boundaries, database/media guards, and import-cycle checks.
- `git diff --check`: passed.
- Branch autoreview: TruffleHog clean; no accepted/actionable findings; patch rated correct.
- `pnpm test:changed`: `58 files passed`, `1224 tests passed`.
- Full `prepare.test.ts`: `123 tests passed`; CI also exposed two stale audio-preflight mocks in this already-changed test file, which now use the current `ctx.media` contract.
- No Slack credentials were available in the environment, so the production-shaped live-path fixture is included as the reproducible proof instead of a live workspace paste.

AI assistance was used to trace the inbound paths, implement the change, and draft tests; all changes were reviewed and validated locally.
