### PR TITLE
fix(model): report the model change before the thinking remap it triggers

### DIFF
--- a/src/auto-reply/reply/directive-handling.impl.ts
+++ b/src/auto-reply/reply/directive-handling.impl.ts
@@ -758,15 +758,6 @@ export async function handleDirectiveOnly(
   if (directives.hasExecDirective && directives.hasExecOptions && !allowInternalExecPersistence) {
     parts.push(formatDirectiveAck(formatInternalExecPersistenceDeniedText()));
   }
-  if (
-    !directives.hasThinkDirective &&
-    shouldRemapUnsupportedThinkLevel &&
-    remappedUnsupportedThinkLevel
-  ) {
-    parts.push(
-      `Thinking level set to ${remappedUnsupportedThinkLevel} (${nextThinkLevel} not supported for ${resolvedProvider}/${resolvedModel}).`,
-    );
-  }
   if (modelSelection && modelSelectionApplied) {
     const label = `${modelSelection.provider}/${modelSelection.model}`;
     const labelWithAlias = modelSelection.alias ? `${modelSelection.alias} (${label})` : label;
@@ -785,6 +776,17 @@ export async function handleDirectiveOnly(
     }
   } else if (modelSelection) {
     parts.push("Model change was not applied because the session changed. Retry.");
+  }
+  // Report the model change before the thinking remap it triggered: the remap is a
+  // consequence of the model switch, so the cause should be announced first.
+  if (
+    !directives.hasThinkDirective &&
+    shouldRemapUnsupportedThinkLevel &&
+    remappedUnsupportedThinkLevel
+  ) {
+    parts.push(
+      `Thinking level set to ${remappedUnsupportedThinkLevel} (${nextThinkLevel} not supported for ${resolvedProvider}/${resolvedModel}).`,
+    );
   }
   if (directives.hasQueueDirective && directives.queueMode) {
     parts.push(formatDirectiveAck(`Queue mode set to ${directives.queueMode}.`));

--- a/src/auto-reply/reply/directive-handling.model.test.ts
+++ b/src/auto-reply/reply/directive-handling.model.test.ts
@@ -1935,6 +1935,26 @@ describe("handleDirectiveOnly model persist behavior (fixes #1435)", () => {
     });
   });
 
+  it("announces the model change before the thinking remap in the ack", async () => {
+    const sessionEntry = createSessionEntry({ thinkingLevel: "adaptive" });
+
+    const result = await handleDirectiveOnly(
+      createHandleParams({
+        directives: parseInlineDirectives("/model openai/gpt-4o"),
+        allowedModelKeys: new Set(["anthropic/claude-opus-4-6", "openai/gpt-4o"]),
+        sessionEntry,
+      }),
+    );
+
+    const text = result?.text ?? "";
+    expect(text).toContain("Model set to openai/gpt-4o for this session.");
+    expect(text).toContain(
+      "Thinking level set to medium (adaptive not supported for openai/gpt-4o).",
+    );
+    // The model change (cause) must be reported before the thinking remap (effect).
+    expect(text.indexOf("Model set to")).toBeLessThan(text.indexOf("Thinking level set to"));
+  });
+
   it("fires session:patch when /model changes the persisted session model", async () => {
     const events: InternalHookEvent[] = [];
     registerInternalHook("session:patch", async (event) => {

--- a/src/auto-reply/reply/get-reply-directives-apply.ts
+++ b/src/auto-reply/reply/get-reply-directives-apply.ts
@@ -366,13 +366,15 @@ export async function applyInlineDirectiveOverrides(params: {
         }
         const label = `${modelSelection.provider}/${modelSelection.model}`;
         const labelWithAlias = modelSelection.alias ? `${modelSelection.alias} (${label})` : label;
+        // Model change first, then the thinking remap it triggered: the remap is a
+        // consequence of the model switch, so the cause is announced before the effect.
         const parts = [
-          persisted.thinkingRemap
-            ? `Thinking level set to ${persisted.thinkingRemap.to} (${persisted.thinkingRemap.from} not supported for ${persisted.thinkingRemap.provider}/${persisted.thinkingRemap.model}).`
-            : undefined,
           modelSelection.isDefault
             ? `Model reset to default (${labelWithAlias}).`
             : `Model set to ${labelWithAlias} for this session.`,
+          persisted.thinkingRemap
+            ? `Thinking level set to ${persisted.thinkingRemap.to} (${persisted.thinkingRemap.from} not supported for ${persisted.thinkingRemap.provider}/${persisted.thinkingRemap.model}).`
+            : undefined,
           persisted.runtimeChange?.kind === "clear"
             ? "Runtime reset to configured policy."
             : persisted.runtimeChange?.kind === "set"


### PR DESCRIPTION
# fix(model): report the model change before the thinking remap it triggers

## What Problem This Solves

When a user runs a bare `/model <ref>` switch to a model that does not support the session's currently stored thinking level, OpenClaw automatically remaps the thinking level and appends a notice to the acknowledgement string. The acknowledgement listed the thinking-remap notice **before** the model-change line, so it announced the *consequence* before its *cause*:

> Thinking level set to medium (adaptive not supported for openai/gpt-4o). Model set to openai/gpt-4o for this session.

This reads backwards to users. The remap only happens *because* the model changed, so the model line should come first:

> Model set to openai/gpt-4o for this session. Thinking level set to medium (adaptive not supported for openai/gpt-4o).

## How to Reproduce

1. Start a session with `thinkingLevel: adaptive` (or any level not supported by the target model).
2. Run `/model openai/gpt-4o` (gpt-4o does not support `adaptive`).
3. Observe the ack: the thinking-remap line appears before the model-change line.

The same reversed ordering appears in the inline directive-override path (`applyInlineDirectiveOverrides`) that assembles the ack from persisted directive results.

## Why This Change Was Made

The model switch is the trigger; the thinking remap is the side effect. Announcing the side effect before the action that caused it is confusing UX. This reorders the two ack parts so the model-change line precedes the thinking-remap line in both builders that assemble this acknowledgement:

- `src/auto-reply/reply/directive-handling.impl.ts` (`handleDirectiveOnly`) -- move the remap `parts.push(...)` to after the model block.
- `src/auto-reply/reply/get-reply-directives-apply.ts` (`applyInlineDirectiveOverrides`) -- swap the first two entries of the `parts` array literal.

Both are pure string-assembly reorders: no control flow, variable scope, or side effects change. Runtime, auth-profile, and queue lines keep their existing relative positions after both.

## User Impact

Users see a logically ordered acknowledgement when a model switch triggers an automatic thinking-level remap. No behavioral change beyond the ack string ordering. Normal conversation flow, model switching, and thinking-level selection are unaffected.

## Non-goals / Scope

The **explicit** `/model X /think Y` case (a user-supplied `/think`, not an auto-remap) is left as-is. That is a deliberate, separate user directive acked in directive order; the remap handled here is an automatic side-effect of the model switch, which is why it now sits with the model line. Left intentionally to keep the change minimal; happy to follow up if maintainers prefer full symmetry.

## Tests

- Added a regression test in `directive-handling.model.test.ts` (`announces the model change before the thinking remap in the ack`) that drives the real `handleDirectiveOnly` builder and asserts `indexOf("Model set to") < indexOf("Thinking level set to")`. It fails on the pre-fix ordering and passes after.
- Existing ack tests use order-independent `.toContain(...)`, so nothing else needed updating.
- Local: the affected suites (`directive-handling.model`, `get-reply-directives-apply`, `get-reply-directives.target-session`) pass -- 101 tests green.

## Evidence

Scenario: session stored `thinkingLevel: adaptive`; user sends `/model openai/gpt-4o` (gpt-4o does not support `adaptive`, so it auto-remaps to `medium`). Rendered ack string from the **real `handleDirectiveOnly` production builder**, captured via the test harness (same harness for both):

- **Before** (`origin/main`):
  `Thinking level set to medium (adaptive not supported for openai/gpt-4o). Model set to openai/gpt-4o for this session.`
- **After** (this branch):
  `Model set to openai/gpt-4o for this session. Thinking level set to medium (adaptive not supported for openai/gpt-4o).`

Invocation layer: the production builder function driven through the unit harness, not a full end-to-end channel send. The ack is plain text (no HTML/Markdown/placeholders), so the channel-rendered output is byte-identical to the strings above.

## Notes

- Small correctness/UX fix (CONTRIBUTING category 1), no new surface or config.
- No redactions needed; the proof uses only synthetic `openai/gpt-4o` + `adaptive` inputs.
- Rebased onto current `main`; CI re-triggered on the updated head.

AI-assisted: yes. The implementation and evidence were produced with Codex and reviewed with the repository's autoreview workflow. No agent transcript is included.