### PR TITLE
fix(google-meet): honor an explicit probe timeout for test-speech

### DIFF
--- a/docs/plugins/google-meet.md
+++ b/docs/plugins/google-meet.md
@@ -1099,7 +1099,7 @@ openclaw googlemeet doctor
 
 Use `mode: "agent"` for the STT -> OpenClaw agent -> TTS path, `mode: "bidi"` for the direct realtime voice fallback. `mode: "transcribe"` intentionally starts no talk-back bridge. For observe-only debugging, run `openclaw googlemeet status --json <session-id>` after participants speak and check `captioning`, `transcriptLines`, `lastCaptionText`. If `inCall` is true but `transcriptLines` stays `0`, Meet captions may be disabled, no one has spoken since the observer was installed, the Meet UI changed, or live captions are unavailable for the meeting language/account.
 
-`googlemeet test-speech` always checks the realtime path and reports whether bridge output bytes were observed for that invocation. If `speechOutputVerified` is false and `speechOutputTimedOut` is true, the realtime provider may have accepted the utterance but OpenClaw did not see new output bytes reach the Chrome audio bridge.
+`googlemeet test-speech` always checks the realtime path and reports whether bridge output bytes were observed for that invocation. If `speechOutputVerified` is false and `speechOutputTimedOut` is true, the realtime provider may have accepted the utterance but OpenClaw did not see new output bytes reach the Chrome audio bridge. That check waits up to five seconds by default; pass `--timeout-ms` (or `timeoutMs` on the `test_speech` tool action) to wait longer, up to the 120s probe ceiling, on a slow meeting.
 
 Also verify: a realtime provider key (`OPENAI_API_KEY` or `GEMINI_API_KEY`) is available on the Gateway host; `BlackHole 2ch` is visible on the Chrome host; `sox` exists there; Meet mic/speaker are routed through the virtual audio path (`doctor` should show `meet output routed: yes` for local Chrome realtime joins).
 

--- a/extensions/google-meet/index.ts
+++ b/extensions/google-meet/index.ts
@@ -380,6 +380,7 @@ export default definePluginEntry({
             message: normalizeOptionalString(trustedParams.message),
             requesterSessionKey: normalizeOptionalString(trustedParams.requesterSessionKey),
             agentId: normalizeOptionalString(trustedParams.agentId),
+            timeoutMs: readPositiveIntegerParam(trustedParams, "timeoutMs"),
           });
           respond(true, result);
         } catch (err) {

--- a/extensions/google-meet/src/cli-runtime-commands.ts
+++ b/extensions/google-meet/src/cli-runtime-commands.ts
@@ -15,6 +15,21 @@ import {
 import { resolveGoogleMeetProbeGatewayTimeoutMs } from "./config.js";
 import type { GoogleMeetRuntime } from "./runtime.js";
 
+// The Gateway handler and the tool schema both take timeoutMs as a positive
+// integer, so parse it that way here instead of letting a fractional value reach
+// the RPC and fail there. Mirrors Zoom's probe option parser. `test-listen`
+// still uses the looser parsePositiveNumber and is left as a follow-up.
+function parseProbeTimeoutOption(value: string | undefined): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const parsed = parseStrictNonNegativeInteger(value);
+  if (parsed === undefined || parsed === 0) {
+    throw new Error("timeout-ms must be a positive integer");
+  }
+  return parsed;
+}
+
 export function registerGoogleMeetProbeCommands(context: GoogleMeetCliCommandContext): void {
   const params = context;
   const { root, callGateway, operationTimeoutMs, resolveMeetingInput } = context;
@@ -71,7 +86,7 @@ export function registerGoogleMeetProbeCommands(context: GoogleMeetCliCommandCon
         transport: options.transport,
         mode: options.mode,
         message: options.message,
-        timeoutMs: parsePositiveNumber(options.timeoutMs, "timeout-ms"),
+        timeoutMs: parseProbeTimeoutOption(options.timeoutMs),
       };
       const delegated = await callGoogleMeetGateway({
         callGateway,

--- a/extensions/google-meet/src/cli-runtime-commands.ts
+++ b/extensions/google-meet/src/cli-runtime-commands.ts
@@ -12,6 +12,7 @@ import {
   writeStdoutJson,
   writeStdoutLine,
 } from "./cli-shared.js";
+import { resolveGoogleMeetProbeGatewayTimeoutMs } from "./config.js";
 import type { GoogleMeetRuntime } from "./runtime.js";
 
 export function registerGoogleMeetProbeCommands(context: GoogleMeetCliCommandContext): void {
@@ -63,18 +64,22 @@ export function registerGoogleMeetProbeCommands(context: GoogleMeetCliCommandCon
       "Realtime speech to trigger",
       "Say exactly: Google Meet speech test complete.",
     )
+    .option("--timeout-ms <ms>", "How long to wait for the spoken audio to reach the meeting")
     .action(async (url: string | undefined, options: JoinOptions) => {
       const payload = {
         url: resolveMeetingInput(params.config, url),
         transport: options.transport,
         mode: options.mode,
         message: options.message,
+        timeoutMs: parsePositiveNumber(options.timeoutMs, "timeout-ms"),
       };
       const delegated = await callGoogleMeetGateway({
         callGateway,
         method: "googlemeet.testSpeech",
+        // The probe waits inside the Gateway, so the client deadline has to cover
+        // the requested wait; the plain operation budget would abort first.
+        timeoutMs: resolveGoogleMeetProbeGatewayTimeoutMs(params.config, payload.timeoutMs),
         payload,
-        timeoutMs: operationTimeoutMs,
       });
       if (delegated.ok) {
         writeStdoutJson(delegated.payload);

--- a/extensions/google-meet/src/cli-runtime.test.ts
+++ b/extensions/google-meet/src/cli-runtime.test.ts
@@ -396,17 +396,26 @@ describe("google-meet CLI", () => {
     expect(ensureRuntime).not.toHaveBeenCalled();
   });
 
-  it("rejects a non-positive test-speech --timeout-ms before the gateway call", async () => {
-    const callGatewayFromCli = vi.fn(async () => ({}));
+  it.each(["0", "1.5"])(
+    "rejects a test-speech --timeout-ms of %s before the gateway call",
+    async (value) => {
+      const callGatewayFromCli = vi.fn(async () => ({}));
 
-    await expect(
-      setupCli({ callGatewayFromCli }).parseAsync(
-        ["googlemeet", "test-speech", "https://meet.google.com/abc-defg-hij", "--timeout-ms", "0"],
-        { from: "user" },
-      ),
-    ).rejects.toThrow("timeout-ms must be a positive number");
-    expect(callGatewayFromCli).not.toHaveBeenCalled();
-  });
+      await expect(
+        setupCli({ callGatewayFromCli }).parseAsync(
+          [
+            "googlemeet",
+            "test-speech",
+            "https://meet.google.com/abc-defg-hij",
+            "--timeout-ms",
+            value,
+          ],
+          { from: "user" },
+        ),
+      ).rejects.toThrow("timeout-ms must be a positive integer");
+      expect(callGatewayFromCli).not.toHaveBeenCalled();
+    },
+  );
 
   it("runs a listen-first health probe", async () => {
     const testListen = vi.fn(async () => ({

--- a/extensions/google-meet/src/cli-runtime.test.ts
+++ b/extensions/google-meet/src/cli-runtime.test.ts
@@ -359,6 +359,55 @@ describe("google-meet CLI", () => {
     }
   });
 
+  it("extends the test-speech gateway deadline to cover an explicit --timeout-ms", async () => {
+    const callGatewayFromCli = vi.fn(async () => ({
+      createdSession: true,
+      speechOutputTimedOut: false,
+    }));
+    const ensureRuntime = vi.fn();
+
+    const stdout = captureStdout();
+    try {
+      await setupCli({
+        callGatewayFromCli,
+        ensureRuntime: ensureRuntime as unknown as () => Promise<GoogleMeetRuntime>,
+      }).parseAsync(
+        [
+          "googlemeet",
+          "test-speech",
+          "https://meet.google.com/abc-defg-hij",
+          "--timeout-ms",
+          "30000",
+        ],
+        { from: "user" },
+      );
+    } finally {
+      stdout.restore();
+    }
+
+    // 60s operation budget plus the requested 30s wait; the plain budget would
+    // abort the call before the probe could finish waiting.
+    expect(callGatewayFromCli).toHaveBeenCalledWith(
+      "googlemeet.testSpeech",
+      { json: true, timeout: "90000" },
+      expect.objectContaining({ timeoutMs: 30_000 }),
+      { progress: false },
+    );
+    expect(ensureRuntime).not.toHaveBeenCalled();
+  });
+
+  it("rejects a non-positive test-speech --timeout-ms before the gateway call", async () => {
+    const callGatewayFromCli = vi.fn(async () => ({}));
+
+    await expect(
+      setupCli({ callGatewayFromCli }).parseAsync(
+        ["googlemeet", "test-speech", "https://meet.google.com/abc-defg-hij", "--timeout-ms", "0"],
+        { from: "user" },
+      ),
+    ).rejects.toThrow("timeout-ms must be a positive number");
+    expect(callGatewayFromCli).not.toHaveBeenCalled();
+  });
+
   it("runs a listen-first health probe", async () => {
     const testListen = vi.fn(async () => ({
       createdSession: true,

--- a/extensions/google-meet/src/config.test.ts
+++ b/extensions/google-meet/src/config.test.ts
@@ -1,7 +1,11 @@
 // Google Meet tests cover config plugin behavior.
 import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { describe, expect, it } from "vitest";
-import { resolveGoogleMeetConfig, resolveGoogleMeetGatewayOperationTimeoutMs } from "./config.js";
+import {
+  resolveGoogleMeetConfig,
+  resolveGoogleMeetGatewayOperationTimeoutMs,
+  resolveGoogleMeetProbeGatewayTimeoutMs,
+} from "./config.js";
 
 describe("google meet gateway operation timeout", () => {
   it("caps timer config fields before runtime polling uses them", () => {
@@ -53,5 +57,33 @@ describe("google meet gateway operation timeout", () => {
         }),
       ),
     ).toBe(MAX_TIMER_TIMEOUT_MS);
+  });
+});
+
+describe("google meet probe gateway timeout", () => {
+  it("keeps the operation budget when no probe wait is requested", () => {
+    const config = resolveGoogleMeetConfig({});
+
+    expect(resolveGoogleMeetProbeGatewayTimeoutMs(config, undefined)).toBe(
+      resolveGoogleMeetGatewayOperationTimeoutMs(config),
+    );
+  });
+
+  it("covers the requested probe wait on top of the operation budget", () => {
+    const config = resolveGoogleMeetConfig({});
+
+    // Without this the caller aborts at the 60s budget and an explicit 90s probe
+    // wait can never be observed.
+    expect(resolveGoogleMeetProbeGatewayTimeoutMs(config, 30_000)).toBe(
+      resolveGoogleMeetGatewayOperationTimeoutMs(config) + 30_000,
+    );
+  });
+
+  it("covers only the capped probe wait", () => {
+    const config = resolveGoogleMeetConfig({});
+
+    expect(resolveGoogleMeetProbeGatewayTimeoutMs(config, 600_000)).toBe(
+      resolveGoogleMeetGatewayOperationTimeoutMs(config) + 120_000,
+    );
   });
 });

--- a/extensions/google-meet/src/config.ts
+++ b/extensions/google-meet/src/config.ts
@@ -15,6 +15,7 @@ import {
   normalizeOptionalString,
   normalizeOptionalTrimmedStringList,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { resolveGoogleMeetProbeTimeoutMs } from "./probe-timeout.js";
 
 export type GoogleMeetTransport = "chrome" | "chrome-node" | "twilio";
 export type GoogleMeetMode = "agent" | "bidi" | "transcribe";
@@ -102,6 +103,27 @@ export function resolveGoogleMeetGatewayOperationTimeoutMs(config: GoogleMeetCon
     60_000,
     addTimerTimeoutGraceMs(config.chrome.joinTimeoutMs, 30_000) ?? 1,
     addTimerTimeoutGraceMs(config.voiceCall.requestTimeoutMs, 10_000) ?? 1,
+  );
+}
+
+/**
+ * Client deadline for a probe call: the operation budget plus the wait the caller
+ * asked the probe to perform. Without the requested wait folded in, an explicit
+ * timeout above the budget is cut off by the caller instead of the probe.
+ */
+export function resolveGoogleMeetProbeGatewayTimeoutMs(
+  config: GoogleMeetConfig,
+  requestedTimeoutMs: number | undefined,
+): number {
+  const operationTimeoutMs = resolveGoogleMeetGatewayOperationTimeoutMs(config);
+  if (requestedTimeoutMs === undefined) {
+    return operationTimeoutMs;
+  }
+  return (
+    addTimerTimeoutGraceMs(
+      operationTimeoutMs,
+      resolveGoogleMeetProbeTimeoutMs(requestedTimeoutMs, config.chrome.joinTimeoutMs),
+    ) ?? operationTimeoutMs
   );
 }
 

--- a/extensions/google-meet/src/plugin-helpers.ts
+++ b/extensions/google-meet/src/plugin-helpers.ts
@@ -1,4 +1,4 @@
-import { readPositiveIntegerParam } from "openclaw/plugin-sdk/channel-actions";
+import { readNumberParam, readPositiveIntegerParam } from "openclaw/plugin-sdk/channel-actions";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import {
   callGatewayFromCli,
@@ -17,6 +17,7 @@ import {
 } from "./calendar.js";
 import {
   resolveGoogleMeetGatewayOperationTimeoutMs,
+  resolveGoogleMeetProbeGatewayTimeoutMs,
   type GoogleMeetConfig,
   type GoogleMeetMode,
   type GoogleMeetTransport,
@@ -158,13 +159,23 @@ export async function callGoogleMeetGatewayFromTool(params: {
   raw: Record<string, unknown>;
   runtime?: OpenClawPluginApi["runtime"];
 }): Promise<unknown> {
+  // test_speech waits inside the Gateway, so its client deadline has to cover the
+  // requested wait. Read the request the same way the handler does so both
+  // spellings of the parameter produce the same deadline.
+  const gatewayTimeoutMs =
+    params.action === "test_speech"
+      ? resolveGoogleMeetProbeGatewayTimeoutMs(
+          params.config,
+          readNumberParam(params.raw, "timeoutMs", { positiveInteger: true, strict: true }),
+        )
+      : resolveGoogleMeetGatewayOperationTimeoutMs(params.config);
   try {
     if (params.runtime) {
       return await params.runtime.gateway.request(
         googleMeetGatewayMethodForToolAction(params.action),
         params.raw,
         {
-          timeoutMs: resolveGoogleMeetGatewayOperationTimeoutMs(params.config),
+          timeoutMs: gatewayTimeoutMs,
           scopes: ["operator.admin"],
         },
       );
@@ -175,7 +186,7 @@ export async function callGoogleMeetGatewayFromTool(params: {
       googleMeetGatewayMethodForToolAction(params.action),
       {
         json: true,
-        timeout: String(resolveGoogleMeetGatewayOperationTimeoutMs(params.config)),
+        timeout: String(gatewayTimeoutMs),
       },
       params.raw,
       { progress: false, scopes: ["operator.admin"] },

--- a/extensions/google-meet/src/probe-timeout.ts
+++ b/extensions/google-meet/src/probe-timeout.ts
@@ -1,4 +1,4 @@
-export const GOOGLE_MEET_MAX_PROBE_TIMEOUT_MS = 120_000;
+const GOOGLE_MEET_MAX_PROBE_TIMEOUT_MS = 120_000;
 
 export function resolveGoogleMeetProbeTimeoutMs(
   input: number | undefined,

--- a/extensions/google-meet/src/probe-timeout.ts
+++ b/extensions/google-meet/src/probe-timeout.ts
@@ -1,0 +1,14 @@
+export const GOOGLE_MEET_MAX_PROBE_TIMEOUT_MS = 120_000;
+
+export function resolveGoogleMeetProbeTimeoutMs(
+  input: number | undefined,
+  fallback: number,
+): number {
+  if (input === undefined) {
+    return Math.min(Math.max(fallback, 1), GOOGLE_MEET_MAX_PROBE_TIMEOUT_MS);
+  }
+  if (!Number.isFinite(input) || input <= 0) {
+    throw new Error("timeoutMs must be a positive number");
+  }
+  return Math.min(Math.trunc(input), GOOGLE_MEET_MAX_PROBE_TIMEOUT_MS);
+}

--- a/extensions/google-meet/src/runtime-probes.test.ts
+++ b/extensions/google-meet/src/runtime-probes.test.ts
@@ -1,0 +1,100 @@
+// Google Meet tests cover the speech probe deadline the platform adapter delegates back.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolveGoogleMeetConfig } from "./config.js";
+import { testGoogleMeetSpeech, type GoogleMeetRuntimeProbeContext } from "./runtime-probes.js";
+import type { GoogleMeetSession } from "./transports/types.js";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+function neverVerifyingContext(): GoogleMeetRuntimeProbeContext {
+  const session = {
+    id: "meet_probe",
+    url: "https://meet.google.com/abc-defg-hij",
+    transport: "chrome",
+    mode: "agent",
+    agentId: "main",
+    chrome: {
+      launched: true,
+      // Output never advances, so the probe always runs to its deadline.
+      health: { inCall: true, lastOutputBytes: 0, outputGeneration: 0 },
+    },
+  } as unknown as GoogleMeetSession;
+  return {
+    config: resolveGoogleMeetConfig({}),
+    resolveAgentId: () => "main",
+    list: () => [],
+    join: async () => ({ session, spoken: true }),
+    isReusable: () => false,
+    hasHealthHandle: () => true,
+    refreshHealth: () => {},
+    refreshCaptionHealth: async () => {},
+  };
+}
+
+async function settleAt(
+  request: { url: string; timeoutMs?: number },
+  checkpoints: number[],
+): Promise<{ settledAfterMs: number[]; result: Awaited<ReturnType<typeof testGoogleMeetSpeech>> }> {
+  vi.useFakeTimers();
+  let settled = false;
+  const pending = testGoogleMeetSpeech(neverVerifyingContext(), request).then((value) => {
+    settled = true;
+    return value;
+  });
+  const settledAfterMs: number[] = [];
+  let elapsed = 0;
+  for (const checkpoint of checkpoints) {
+    await vi.advanceTimersByTimeAsync(checkpoint - elapsed);
+    elapsed = checkpoint;
+    if (settled) {
+      settledAfterMs.push(checkpoint);
+    }
+  }
+  await vi.advanceTimersByTimeAsync(200_000);
+  return { settledAfterMs, result: await pending };
+}
+
+describe("google-meet test_speech probe deadline", () => {
+  it("keeps the five-second observe-mode default when no timeout is requested", async () => {
+    const { settledAfterMs, result } = await settleAt(
+      { url: "https://meet.google.com/abc-defg-hij" },
+      [4_900, 5_500],
+    );
+
+    expect(settledAfterMs).toEqual([5_500]);
+    expect(result.speechOutputTimedOut).toBe(true);
+    expect(result.speechOutputVerified).toBe(false);
+  });
+
+  it("honors an explicit probe timeout instead of the five-second default", async () => {
+    const { settledAfterMs, result } = await settleAt(
+      { url: "https://meet.google.com/abc-defg-hij", timeoutMs: 30_000 },
+      [5_500, 29_900, 30_500],
+    );
+
+    // Still waiting well past the default deadline is the whole point: before the
+    // request was read, this probe gave up at five seconds.
+    expect(settledAfterMs).toEqual([30_500]);
+    expect(result.speechOutputTimedOut).toBe(true);
+  });
+
+  it("caps an explicit probe timeout at the shared probe ceiling", async () => {
+    const { settledAfterMs } = await settleAt(
+      { url: "https://meet.google.com/abc-defg-hij", timeoutMs: 600_000 },
+      [119_900, 120_500],
+    );
+
+    expect(settledAfterMs).toEqual([120_500]);
+  });
+
+  it("rejects a non-positive explicit probe timeout", async () => {
+    await expect(
+      testGoogleMeetSpeech(neverVerifyingContext(), {
+        url: "https://meet.google.com/abc-defg-hij",
+        timeoutMs: -1,
+      }),
+    ).rejects.toThrow("timeoutMs must be a positive number");
+  });
+});

--- a/extensions/google-meet/src/runtime-probes.ts
+++ b/extensions/google-meet/src/runtime-probes.ts
@@ -1,6 +1,7 @@
 import { MeetingPlatformAdapter } from "openclaw/plugin-sdk/meeting-runtime";
 import type { GoogleMeetConfig, GoogleMeetMode, GoogleMeetTransport } from "./config.js";
 import { normalizeMeetUrl } from "./meet-url.js";
+import { resolveGoogleMeetProbeTimeoutMs } from "./probe-timeout.js";
 import type {
   GoogleMeetChromeHealth,
   GoogleMeetJoinRequest,
@@ -27,16 +28,6 @@ export type GoogleMeetRuntimeProbeContext = {
   refreshCaptionHealth(session: GoogleMeetSession): Promise<void>;
 };
 
-function resolveProbeTimeoutMs(input: number | undefined, fallback: number): number {
-  if (input === undefined) {
-    return Math.min(Math.max(fallback, 1), 120_000);
-  }
-  if (!Number.isFinite(input) || input <= 0) {
-    throw new Error("timeoutMs must be a positive number");
-  }
-  return Math.min(Math.trunc(input), 120_000);
-}
-
 const probes = MeetingPlatformAdapter.createRuntimeProbes<
   GoogleMeetConfig,
   GoogleMeetMode,
@@ -47,7 +38,7 @@ const probes = MeetingPlatformAdapter.createRuntimeProbes<
 >({
   defaultSpeechMessage: "Say exactly: Google Meet speech test complete.",
   invalidRequest: (message) => new Error(message),
-  resolveTimeoutMs: resolveProbeTimeoutMs,
+  resolveTimeoutMs: resolveGoogleMeetProbeTimeoutMs,
   shouldWaitForListening: (session) =>
     Boolean(
       (session.transport === "chrome" || session.transport === "chrome-node") &&
@@ -62,7 +53,14 @@ const probes = MeetingPlatformAdapter.createRuntimeProbes<
       throw new Error("test_listen supports chrome or chrome-node transports");
     }
   },
-  resolveSpeechTimeoutMs: (_request, config) => Math.min(config.chrome.joinTimeoutMs, 5_000),
+  // Unlike Zoom and Teams, Meet keeps a short observe-mode default so unattended
+  // speech checks stay fast (#73256). An explicit caller timeout still wins, capped
+  // like every other probe; dropping the request here is what made timeoutMs
+  // unreachable for test_speech.
+  resolveSpeechTimeoutMs: (request, config) =>
+    request.timeoutMs === undefined
+      ? Math.min(config.chrome.joinTimeoutMs, 5_000)
+      : resolveGoogleMeetProbeTimeoutMs(request.timeoutMs, config.chrome.joinTimeoutMs),
   refreshCaptionHealth: async (context, session) => await context.refreshCaptionHealth(session),
   speechModeError:
     "test_speech requires mode: agent or bidi; use join mode: transcribe for observe-only sessions.",


### PR DESCRIPTION
## What Problem This Solves

The shared meeting probe already treats a per-request `timeoutMs` as part of the
`test_speech` contract. `createMeetingRuntimeProbes` computes the speech deadline from
`resolveTimeoutMs(request.timeoutMs, …)`, and the shared plugin entry passes
`{ allowTimeout: true }` for `testSpeech` and `testListen` while rejecting the parameter
everywhere else with `"timeoutMs is supported only by testSpeech or testListen"`
(`src/meeting-bot/plugin-entry.ts:166`). Zoom and Teams inherit that end to end. Those files
are current `main` for context; this PR changes only Google Meet.

Google Meet is the one meeting plugin that drops it at every layer it owns:

- its CLI registers `--timeout-ms` on `test-listen` but not on `test-speech`
- its hand-written `googlemeet.testSpeech` handler forwards every field except `timeoutMs`
- its `resolveSpeechTimeoutMs` override discards the request:
  `(_request, config) => Math.min(config.chrome.joinTimeoutMs, 5_000)`

So the wait for spoken audio is pinned at five seconds with no way to extend it. On a slow
or congested meeting the probe reports `speechOutputTimedOut` even though more time would
have let the audio verify, and raising `chrome.joinTimeoutMs` does not help because the
expression clamps to 5s.

## Why This Change Was Made

Wire the parameter through the three Google Meet layers so it behaves like the sibling
platforms, without changing what an unattended check does:

- **CLI** (`cli-runtime-commands.ts`): register `--timeout-ms` on `test-speech` and put it in
  the payload, parsed as a positive integer so it matches what the handler and the tool
  schema accept — a fractional value would otherwise reach the RPC and fail there.
  `test-listen` still uses the looser `parsePositiveNumber` and is left as a follow-up.
- **Gateway handler** (`index.ts`): forward `timeoutMs` with the same
  `readPositiveIntegerParam(trustedParams, "timeoutMs")` the adjacent `testListen` handler
  uses. The `google_meet` tool already carries `timeoutMs` in its schema, so the tool path
  is covered by the same change.
- **Runtime** (`runtime-probes.ts`): honor the request when one is supplied, capped at the
  shared 120s probe ceiling. When it is omitted the deadline stays
  `Math.min(chrome.joinTimeoutMs, 5_000)` — the observe-mode default introduced by
  `fix(google-meet): harden observe mode speech health` (#73256), computed by the same
  expression as before. No config key or default value changes.

A caller also sends its own RPC deadline, so `resolveGoogleMeetProbeGatewayTimeoutMs` folds
the requested wait into the client deadline on the CLI and agent-tool paths. Without it an
explicit timeout above the operation budget is cut off by the caller before the probe can
report, so the option would have no observable effect. This mirrors
`resolveZoomMeetingsCliGatewayTimeoutMs`, which already does the same for Zoom's probes.
`test-listen` shares that RPC-budget limitation and is left as a follow-up.

`resolveGoogleMeetProbeTimeoutMs` moves into its own module so the CLI can compute the same
capped value without importing the adapter, matching Zoom's `probe-timeout.ts` layout.

## User Impact

`googlemeet test-speech … --timeout-ms <ms>` and the `google_meet` `test_speech` tool action
now wait as long as the caller asked, up to the 120s ceiling, instead of giving up at five
seconds on a slow meeting. With no `--timeout-ms`, behavior is unchanged.

## Evidence

Rebased onto `upstream/main` @ `1695854877`. Diff: 10 files, +274/-18. No default or
config-surface change.

The added tests fail on `upstream/main`: with only the production files reverted, 8 of them
go red, including `expected [ 5500, 29900, 30500 ] to deeply equal [ 30500 ]` — the
probe settling at ~5s when asked for 30s. The "keeps the five-second observe-mode default"
case passes on both sides; it is the control for the unchanged path.

Local: `extensions/google-meet/` suites `23 files / 318 tests` pass. `tsgo -p
tsconfig.extensions.json` and `-p test/tsconfig/tsconfig.extensions.test.json` report zero
Google Meet errors, and the extensions project reports the same error count with the patch
reverted. `oxlint` and `oxfmt --check` clean on the changed files.

## Real behavior proof

Behavior addressed: Google Meet's `test_speech` ignores a caller-supplied probe timeout and
always gives up at five seconds, while the same shared probe honors it for Zoom.

Scope of this proof, up front: the CLI option and the RPC round trip are exercised against a
real Gateway; the deadline itself is measured at the probe seam, not in a live meeting. No
browser or Meet session is reachable on a non-macOS host (see the last section).

Real environment tested: Linux. A real `openclaw gateway run` process with the Google Meet
plugin loaded from source (isolated state dir and port), plus a standalone Node process
driving the real shipped probe exports of both meeting plugins. Nothing in the code under
test is stubbed; the meeting session handed to it is synthetic.

Exact steps or command run after this patch: at head `c6c441db24`,
`openclaw googlemeet test-speech <meet-url> --timeout-ms 30000` against the running Gateway,
and `./node_modules/.bin/tsx probe-parity-harness.ts` for the deadline measurement. The
before runs are the same two commands with the Google Meet files at `upstream/main`
@ `1695854877`.

Evidence after fix: the captures below — the option present on the shipped command and the
request crossing the real RPC, and a probe-seam measurement showing a 12059ms wait where the
same probe previously stopped at 5021ms.

Observed result after fix: Google Meet's speech probe honors a caller's `timeoutMs`
(12059ms for a 12000ms request) instead of ignoring it (5021ms before), so it now agrees
with Zoom, which reaches the same shared wait loop without a `resolveSpeechTimeoutMs`
override. Google Meet keeps its override, now to preserve the 5s default rather than to
discard the request; the no-timeout path still stops at ~5s.

What was not tested: no live Meet session, Chrome profile, or virtual audio device — see
"What this proof does not cover" below for why that is unreachable on this host and what a
live run would require.

### The option surface, on a real Gateway

A real `openclaw gateway run` on Linux with this branch's Google Meet plugin loaded from
source (`OPENCLAW_BUNDLED_PLUGINS_DIR`, so no stale `dist/` is involved), an isolated state
dir, and its own port — not the operator's Gateway.

At `upstream/main` the option does not exist on the shipped command, so the request cannot
be made at all:

```
$ openclaw googlemeet test-speech https://meet.google.com/abc-defg-hij --timeout-ms 30000
OpenClaw does not recognize option "--timeout-ms".
Try: openclaw googlemeet test-speech --help
```

With the branch applied the option is on the shipped command and the request is dispatched
over the real RPC, reaching the plugin and running until this host's platform gate stops it:

```
$ openclaw googlemeet test-speech https://meet.google.com/abc-defg-hij --timeout-ms 30000
[openclaw] Reason: Chrome Meet transport with blackhole-2ch audio is currently macOS-only

gateway: ⇄ res ✗ googlemeet.testSpeech 27ms errorCode=UNAVAILABLE
         errorMessage=Chrome Meet transport with blackhole-2ch audio is currently macOS-only
```

That is as far as a Linux host gets: the refusal is the browser-transport gate described
below, and it lands before the wait this PR changes. So this pair evidences the CLI surface
and the RPC round trip only; the deadline itself is measured in the next section.

### The probe deadline, measured at the probe seam

Both meeting plugins call the same shared probe. This runs the real, unmodified
`testGoogleMeetSpeech` and `testZoomMeetingSpeech` exports side by side in one Node process
— real `resolveGoogleMeetConfig({})` / `resolveZoomMeetingsConfig({})` defaults, real
timers, real wall clock — and measures how long each one actually waits when asked for
12000ms. The only thing supplied is the meeting-session boundary a Chrome/BlackHole host
would provide: a joined session whose output health never advances, so each probe runs to
whatever deadline it computes. Standalone script, no test runner:

`./node_modules/.bin/tsx probe-parity-harness.ts`

Before (`upstream/main` @ `1695854877`, Google Meet files at that revision):

```
requested timeoutMs = 12000 (both plugins ship joinTimeoutMs 30000)

zoom-meetings  test_speech         waited  12045ms  timedOut=true  honored_request=true
google-meet    test_speech         waited   5021ms  timedOut=true  honored_request=false
google-meet    test_speech (no timeoutMs) waited   5019ms  timedOut=true  honored_request=false
```

After (this branch @ `c6c441db24`):

```
requested timeoutMs = 12000 (both plugins ship joinTimeoutMs 30000)

zoom-meetings  test_speech         waited  12058ms  timedOut=true  honored_request=true
google-meet    test_speech         waited  12059ms  timedOut=true  honored_request=true
google-meet    test_speech (no timeoutMs) waited   5024ms  timedOut=true  honored_request=false
```

Observed result: Google Meet went from ignoring a 12s request (5021ms, same as its default)
to honoring it (12059ms), which is what Zoom already got from the shared wait loop.
The no-timeout row is the control and is unchanged at ~5s on both sides.

### What this proof does not cover

It does not run a real Meet session. The changed wait only executes after a successful
browser join, and every browser transport refuses before that on any non-macOS host:
`assertBlackHole2chAvailable` throws `"Chrome Meet transport with blackhole-2ch audio is
currently macOS-only"` when `process.platform !== "darwin"`
(`extensions/google-meet/src/transports/chrome.ts:63`), and the node-host path applies the
same gate before it will act as a Chrome host (`src/node-host.ts:17`). Entering the wait
also requires a Chrome health handle that only that transport creates. A live run would
need a macOS host with BlackHole 2ch and `sox`, a signed-in Chrome profile, a realtime
provider key, and a meeting with someone speaking; I do not have that setup, so the probe
deadline is proven at the probe seam and the meeting-side signals it reads come from the
harness rather than from Meet.

<details>
<summary>probe-parity-harness.ts (the script run above)</summary>

```ts
/*
 * Standalone probe-parity harness (no vitest, no mocks of the code under test).
 *
 * It calls the real, unmodified speech probes that ship with each meeting plugin
 * — extensions/google-meet/src/runtime-probes.ts and
 * extensions/zoom-meetings/src/runtime-probes.ts — which both delegate to the
 * shared src/meeting-bot/runtime-probes.ts adapter. Configs come from each
 * plugin's real resolve*Config({}) defaults. Real timers, real wall clock.
 *
 * The only thing supplied by the harness is the meeting session boundary that a
 * Chrome/BlackHole host would otherwise provide: a joined session whose output
 * health never advances, so each probe runs to whatever deadline it computes.
 * The measured number is that deadline.
 *
 * Run from the repo root:  ./node_modules/.bin/tsx probe-parity-harness.ts
 */
import { resolveGoogleMeetConfig } from "./extensions/google-meet/src/config.js";
import { testGoogleMeetSpeech } from "./extensions/google-meet/src/runtime-probes.js";
import { resolveZoomMeetingsConfig } from "./extensions/zoom-meetings/src/config.js";
import { testZoomMeetingSpeech } from "./extensions/zoom-meetings/src/runtime-probes.js";

const REQUESTED_TIMEOUT_MS = 12_000;

function joinedSessionNeverVerifying(id: string) {
  return {
    id,
    url: "https://meet.google.com/abc-defg-hij",
    transport: "chrome",
    mode: "agent",
    agentId: "main",
    chrome: {
      launched: true,
      health: { inCall: true, lastOutputBytes: 0, outputGeneration: 0 },
    },
  };
}

function contextFor(config: unknown, id: string) {
  const session = joinedSessionNeverVerifying(id);
  return {
    config,
    resolveAgentId: () => "main",
    list: () => [],
    join: async () => ({ session, spoken: true }),
    isReusable: () => false,
    hasHealthHandle: () => true,
    refreshHealth: () => {},
    refreshCaptionHealth: async () => {},
  } as unknown as Parameters<typeof testGoogleMeetSpeech>[0];
}

async function measure(
  label: string,
  run: () => Promise<{ speechOutputTimedOut?: boolean }>,
): Promise<void> {
  const startedAt = Date.now();
  const result = await run();
  const elapsedMs = Date.now() - startedAt;
  const honored = elapsedMs >= REQUESTED_TIMEOUT_MS - 500;
  process.stdout.write(
    `${label.padEnd(34)} waited ${String(elapsedMs).padStart(6)}ms  ` +
      `timedOut=${result.speechOutputTimedOut}  honored_request=${honored}\n`,
  );
}

async function main(): Promise<void> {
  process.stdout.write(
    `requested timeoutMs = ${REQUESTED_TIMEOUT_MS} (both plugins ship joinTimeoutMs 30000)\n\n`,
  );

  await measure("zoom-meetings  test_speech", () =>
    testZoomMeetingSpeech(contextFor(resolveZoomMeetingsConfig({}), "zoom_probe"), {
      url: "https://zoom.us/j/1234567890",
      timeoutMs: REQUESTED_TIMEOUT_MS,
    } as Parameters<typeof testZoomMeetingSpeech>[1]),
  );

  await measure("google-meet    test_speech", () =>
    testGoogleMeetSpeech(contextFor(resolveGoogleMeetConfig({}), "meet_probe"), {
      url: "https://meet.google.com/abc-defg-hij",
      timeoutMs: REQUESTED_TIMEOUT_MS,
    } as Parameters<typeof testGoogleMeetSpeech>[1]),
  );

  await measure("google-meet    test_speech (no timeoutMs)", () =>
    testGoogleMeetSpeech(contextFor(resolveGoogleMeetConfig({}), "meet_default"), {
      url: "https://meet.google.com/abc-defg-hij",
    } as Parameters<typeof testGoogleMeetSpeech>[1]),
  );
}

await main();
```

</details>
