### PR TITLE
fix(plugins): expose inbound identity before dispatch

### DIFF
--- a/docs/plugins/hooks.md
+++ b/docs/plugins/hooks.md
@@ -768,6 +768,9 @@ has visibility-filtered quoted message data: `replyToId`, `replyToIdFull`,
 `replyToBody`, `replyToSender`, and `replyToIsQuote`. Prefer these
 first-class fields before reading legacy metadata.
 
+`before_dispatch` receives the canonical inbound `messageId` in both its event
+and context.
+
 Prefer typed `threadId` and `replyToId` fields before using channel-specific
 metadata.
 

--- a/src/auto-reply/reply/dispatch-from-config.choose-route.ts
+++ b/src/auto-reply/reply/dispatch-from-config.choose-route.ts
@@ -466,6 +466,7 @@ export async function chooseDispatchRoute(state: PrepareDispatchOperationReadySt
             () =>
               hookRunner.runBeforeDispatch(
                 {
+                  messageId: state.hookContext.messageId,
                   content: state.hookContext.content,
                   body: state.hookContext.bodyForAgent ?? state.hookContext.body,
                   channel: state.hookContext.channelId,
@@ -480,6 +481,7 @@ export async function chooseDispatchRoute(state: PrepareDispatchOperationReadySt
                   timestamp: state.hookContext.timestamp,
                 },
                 {
+                  messageId: state.hookContext.messageId,
                   channelId: state.hookContext.channelId,
                   accountId: state.hookContext.accountId,
                   conversationId: state.inboundClaimContext.conversationId,

--- a/src/auto-reply/reply/dispatch-from-config.hooks-and-send-policy.test-utils.ts
+++ b/src/auto-reply/reply/dispatch-from-config.hooks-and-send-policy.test-utils.ts
@@ -148,6 +148,8 @@ describe("before_dispatch hook", () => {
     hookMocks.runner.runBeforeDispatch.mockResolvedValue({ handled: true });
     const dispatcher = createDispatcher();
     const ctx = createHookCtx({
+      MessageSid: "discord-message-456",
+      MessageSidFull: "  ",
       ReplyToId: "discord-reply-123",
       ReplyToIdFull: "discord:channel-1:discord-reply-123",
       ReplyToBody: "the quoted parent message",
@@ -163,6 +165,7 @@ describe("before_dispatch hook", () => {
     ) as
       | [
           {
+            messageId?: unknown;
             replyToId?: unknown;
             replyToIdFull?: unknown;
             replyToBody?: unknown;
@@ -170,6 +173,7 @@ describe("before_dispatch hook", () => {
             replyToIsQuote?: unknown;
           },
           {
+            messageId?: unknown;
             replyToId?: unknown;
             replyToIdFull?: unknown;
             replyToBody?: unknown;
@@ -179,6 +183,7 @@ describe("before_dispatch hook", () => {
         ]
       | undefined;
     expect(beforeDispatchCall?.[0]).toMatchObject({
+      messageId: "discord-message-456",
       replyToId: "discord-reply-123",
       replyToIdFull: "discord:channel-1:discord-reply-123",
       replyToBody: "the quoted parent message",
@@ -186,6 +191,7 @@ describe("before_dispatch hook", () => {
       replyToIsQuote: true,
     });
     expect(beforeDispatchCall?.[1]).toMatchObject({
+      messageId: "discord-message-456",
       replyToId: "discord-reply-123",
       replyToIdFull: "discord:channel-1:discord-reply-123",
       replyToBody: "the quoted parent message",

--- a/src/hooks/message-hook-mappers.test.ts
+++ b/src/hooks/message-hook-mappers.test.ts
@@ -132,6 +132,19 @@ describe("message hook mappers", () => {
     expect(canonical.guildId).toBe("guild-1");
   });
 
+  it("normalizes canonical inbound message id precedence", () => {
+    expect(
+      deriveInboundMessageHookContext(
+        makeInboundCtx({ MessageSidFull: "full-message-id", MessageSid: "short-message-id" }),
+      ).messageId,
+    ).toBe("full-message-id");
+    expect(
+      deriveInboundMessageHookContext(
+        makeInboundCtx({ MessageSidFull: "  ", MessageSid: "short-message-id" }),
+      ).messageId,
+    ).toBe("short-message-id");
+  });
+
   it("uses the session key as the Control UI conversation id", () => {
     const canonical = deriveInboundMessageHookContext(
       makeInboundCtx({

--- a/src/hooks/message-hook-mappers.ts
+++ b/src/hooks/message-hook-mappers.ts
@@ -188,11 +188,11 @@ export function deriveInboundMessageHookContext(
     sessionKey: ctx.SessionKey,
     agentId: ctx.AgentId,
     messageId:
-      overrides?.messageId ??
-      ctx.MessageSidFull ??
-      ctx.MessageSid ??
-      ctx.MessageSidFirst ??
-      ctx.MessageSidLast,
+      normalizeOptionalString(overrides?.messageId) ??
+      normalizeOptionalString(ctx.MessageSidFull) ??
+      normalizeOptionalString(ctx.MessageSid) ??
+      normalizeOptionalString(ctx.MessageSidFirst) ??
+      normalizeOptionalString(ctx.MessageSidLast),
     senderId: ctx.SenderId,
     senderName: ctx.SenderName,
     senderUsername: ctx.SenderUsername,

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -511,6 +511,7 @@ export type PluginHookInboundClaimResult = {
 };
 
 export type PluginHookBeforeDispatchEvent = {
+  messageId?: string;
   content: string;
   body?: string;
   channel?: string;
@@ -526,6 +527,7 @@ export type PluginHookBeforeDispatchEvent = {
 };
 
 export type PluginHookBeforeDispatchContext = {
+  messageId?: string;
   channelId?: string;
   accountId?: string;
   conversationId?: string;


### PR DESCRIPTION
## What Problem This Solves

External policy plugins cannot reliably deduplicate or classify inbound turns
in `before_dispatch`: the host already derives a canonical inbound message ID,
but the hook drops it.

## Why This Change Was Made

Forward the existing canonical `messageId` to both `before_dispatch` arguments
and normalize blank provider IDs before applying the existing
Full -> Sid -> First -> Last precedence.

This intentionally keeps the generic hook contract portable. Provider-native
message classifications remain owned by their channel integrations rather than
adding a one-sided LINE field to the shared plugin API.

## User Impact

Plugins can make durable, account-scoped decisions using the real inbound event
identity. Existing plugins that ignore the optional field keep their current
behavior.

## Evidence

- `node scripts/run-vitest.mjs src/hooks/message-hook-mappers.test.ts src/auto-reply/reply/dispatch-from-config.test.ts` - 304 tests passed.
- Targeted `oxfmt` and `oxlint` checks passed.
- `git diff --check origin/main...HEAD` - passed.
- Exact-head hosted CI passed for `54087fc3a2931129c1c09b8ec830cd4bea83afc1`, including `openclaw/ci-gate`.
- Packaged-runtime proof used CI run `30484969396`, artifact `dist-runtime-build` (`8737297731`), built from synthetic merge `dd61b8e41fab31b14ebeecceea5da533bd2d661d` with the exact PR head as its second parent.
- The packaged Gateway accepted a real `chat.send` request with idempotency key `pr112359-proof-1`. The loaded `before_dispatch` plugin observed:

```json
{
  "eventMessageId": "pr112359-proof-1",
  "contextMessageId": "pr112359-proof-1",
  "content": "proof",
  "channelId": "webchat",
  "conversationId": "agent:main:main"
}
```

The hook returned `{ handled: true }`, so the proof exercised the real Gateway
dispatch path without invoking a model.

## Release Notes

Release-note context is included here; the root changelog is release-owned.
