### PR TITLE
fix(voice-call): stop stale replies when caller resumes speaking

### DIFF
--- a/extensions/voice-call/src/manager.ts
+++ b/extensions/voice-call/src/manager.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { VoiceCallConfig, VoiceCallCoreSessionConfig } from "./config.js";
+import { CallerTurnState } from "./manager/caller-turn.js";
 import type { CallManagerContext, StreamSessionIssuer } from "./manager/context.js";
 import { processEvent as processManagerEvent, type ProcessEventResult } from "./manager/events.js";
 import { getCallByProviderCallId as getCallByProviderCallIdFromMaps } from "./manager/lookup.js";
@@ -68,6 +69,7 @@ function resolveDefaultStoreBase(config: VoiceCallConfig, storePath?: string): s
  */
 export class CallManager {
   private activeCalls = new Map<CallId, CallRecord>();
+  readonly callerTurns = new CallerTurnState((callId) => this.activeCalls.has(callId));
   private providerCallIdMap = new Map<string, CallId>();
   private processedEventIds = new Set<string>();
   private rejectedProviderCallIds = new Set<string>();
@@ -358,6 +360,7 @@ export class CallManager {
       storePath: this.storePath,
       webhookUrl: this.webhookUrl,
       activeTurnCalls: this.activeTurnCalls,
+      callerTurns: this.callerTurns,
       transcriptWaiters: this.transcriptWaiters,
       maxDurationTimers: this.maxDurationTimers,
       initialMessageInFlight: this.initialMessageInFlight,

--- a/extensions/voice-call/src/manager/caller-turn.test.ts
+++ b/extensions/voice-call/src/manager/caller-turn.test.ts
@@ -1,0 +1,49 @@
+// Voice Call tests cover caller speech and generated-response ordering.
+import { describe, expect, it } from "vitest";
+import { CallerTurnState } from "./caller-turn.js";
+
+describe("CallerTurnState", () => {
+  it("emits one speech start per utterance and invalidates an in-flight response", () => {
+    const activeCalls = new Set(["call-1"]);
+    const state = new CallerTurnState((callId) => activeCalls.has(callId));
+    const responseToken = state.beginResponse("call-1");
+
+    expect(state.isResponseCurrent("call-1", responseToken)).toBe(true);
+    expect(state.beginSpeech("call-1")).toBe(true);
+    expect(state.beginSpeech("call-1")).toBe(false);
+    expect(state.isSpeaking("call-1")).toBe(true);
+    expect(state.isResponseCurrent("call-1", responseToken)).toBe(false);
+
+    state.endSpeech("call-1");
+    expect(state.isSpeaking("call-1")).toBe(false);
+    expect(state.beginSpeech("call-1")).toBe(true);
+  });
+
+  it("keeps only the newest response token current", () => {
+    const state = new CallerTurnState((callId) => callId === "call-1");
+    const first = state.beginResponse("call-1");
+    const second = state.beginResponse("call-1");
+
+    expect(state.isResponseCurrent("call-1", first)).toBe(false);
+    expect(state.isResponseCurrent("call-1", second)).toBe(true);
+
+    state.finishResponse("call-1", first);
+    expect(state.isResponseCurrent("call-1", second)).toBe(true);
+
+    state.finishResponse("call-1", second);
+    expect(state.isResponseCurrent("call-1", second)).toBe(false);
+  });
+
+  it("rejects inactive calls and clears all turn state", () => {
+    const activeCalls = new Set(["call-1"]);
+    const state = new CallerTurnState((callId) => activeCalls.has(callId));
+
+    expect(state.beginSpeech("missing")).toBe(false);
+    const responseToken = state.beginResponse("call-1");
+    state.beginSpeech("call-1");
+    state.clear("call-1");
+
+    expect(state.isSpeaking("call-1")).toBe(false);
+    expect(state.isResponseCurrent("call-1", responseToken)).toBe(false);
+  });
+});

--- a/extensions/voice-call/src/manager/caller-turn.ts
+++ b/extensions/voice-call/src/manager/caller-turn.ts
@@ -1,0 +1,51 @@
+// Voice Call plugin module owns caller speech and generated-response ordering.
+import type { CallId } from "../types.js";
+
+export class CallerTurnState {
+  private readonly callerActiveCalls = new Set<CallId>();
+  private readonly responseGenerationTokens = new Map<CallId, symbol>();
+
+  constructor(private readonly isCallActive: (callId: CallId) => boolean) {}
+
+  beginSpeech(callId: CallId): boolean {
+    if (!this.isCallActive(callId) || this.callerActiveCalls.has(callId)) {
+      return false;
+    }
+    this.callerActiveCalls.add(callId);
+    this.responseGenerationTokens.delete(callId);
+    return true;
+  }
+
+  endSpeech(callId: CallId): void {
+    this.callerActiveCalls.delete(callId);
+  }
+
+  isSpeaking(callId: CallId): boolean {
+    return this.callerActiveCalls.has(callId);
+  }
+
+  beginResponse(callId: CallId): symbol {
+    const token = Symbol(callId);
+    this.responseGenerationTokens.set(callId, token);
+    return token;
+  }
+
+  isResponseCurrent(callId: CallId, token: symbol): boolean {
+    return (
+      this.isCallActive(callId) &&
+      !this.isSpeaking(callId) &&
+      this.responseGenerationTokens.get(callId) === token
+    );
+  }
+
+  finishResponse(callId: CallId, token: symbol): void {
+    if (this.responseGenerationTokens.get(callId) === token) {
+      this.responseGenerationTokens.delete(callId);
+    }
+  }
+
+  clear(callId: CallId): void {
+    this.callerActiveCalls.delete(callId);
+    this.responseGenerationTokens.delete(callId);
+  }
+}

--- a/extensions/voice-call/src/manager/context.ts
+++ b/extensions/voice-call/src/manager/context.ts
@@ -2,6 +2,7 @@
 import type { VoiceCallConfig, VoiceCallCoreSessionConfig } from "../config.js";
 import type { VoiceCallProvider } from "../providers/base.js";
 import type { CallId, CallRecord } from "../types.js";
+import type { CallerTurnState } from "./caller-turn.js";
 
 type TranscriptWaiter = {
   resolve: (text: string) => void;
@@ -28,6 +29,7 @@ type CallManagerRuntimeDeps = {
 
 type CallManagerTransientState = {
   activeTurnCalls: Set<CallId>;
+  callerTurns: CallerTurnState;
   transcriptWaiters: Map<CallId, TranscriptWaiter>;
   maxDurationTimers: Map<CallId, NodeJS.Timeout>;
   initialMessageInFlight: Set<CallId>;

--- a/extensions/voice-call/src/manager/events.test.ts
+++ b/extensions/voice-call/src/manager/events.test.ts
@@ -12,6 +12,7 @@ import { VoiceCallConfigSchema } from "../config.js";
 import type { VoiceCallProvider } from "../providers/base.js";
 import { setVoiceCallStateRuntime } from "../runtime-state.js";
 import type { AnswerCallInput, HangupCallInput, NormalizedEvent } from "../types.js";
+import { CallerTurnState } from "./caller-turn.js";
 import type { CallManagerContext } from "./context.js";
 import { processEvent } from "./events.js";
 import { speakInitialMessage } from "./outbound.js";
@@ -89,8 +90,9 @@ afterEach(async () => {
 
 function createContext(overrides: Partial<CallManagerContext> = {}): CallManagerContext {
   const storePath = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-voice-call-events-test-"));
+  const activeCalls: CallManagerContext["activeCalls"] = new Map();
   const ctx: CallManagerContext = {
-    activeCalls: new Map(),
+    activeCalls,
     providerCallIdMap: new Map(),
     processedEventIds: new Set(),
     rejectedProviderCallIds: new Set(),
@@ -103,6 +105,7 @@ function createContext(overrides: Partial<CallManagerContext> = {}): CallManager
     storePath,
     webhookUrl: null,
     activeTurnCalls: new Set(),
+    callerTurns: new CallerTurnState((callId) => activeCalls.has(callId)),
     transcriptWaiters: new Map(),
     maxDurationTimers: new Map(),
     initialMessageInFlight: new Set(),
@@ -579,6 +582,38 @@ describe("processEvent (functional)", () => {
 
     processEvent(ctx, event);
     expect(ctx.activeCalls.size).toBe(0);
+  });
+
+  it("clears caller-turn state when a call ends", () => {
+    const now = Date.now();
+    const ctx = createContext();
+    ctx.activeCalls.set("call-ended", {
+      callId: "call-ended",
+      providerCallId: "provider-ended",
+      provider: "twilio",
+      direction: "inbound",
+      state: "active",
+      from: "+15550000002",
+      to: "+15550000000",
+      startedAt: now,
+      transcript: [],
+      processedEventIds: [],
+      metadata: {},
+    });
+    ctx.providerCallIdMap.set("provider-ended", "call-ended");
+    expect(ctx.callerTurns.beginSpeech("call-ended")).toBe(true);
+
+    processEvent(ctx, {
+      id: "evt-ended",
+      type: "call.ended",
+      callId: "call-ended",
+      providerCallId: "provider-ended",
+      timestamp: now + 1,
+      reason: "completed",
+    });
+
+    expect(ctx.callerTurns.isSpeaking("call-ended")).toBe(false);
+    expect(ctx.activeCalls.has("call-ended")).toBe(false);
   });
 
   it("auto-registers externally-initiated outbound-api calls with correct direction", () => {

--- a/extensions/voice-call/src/manager/events.ts
+++ b/extensions/voice-call/src/manager/events.ts
@@ -30,6 +30,7 @@ type EventContext = Pick<
   | "provider"
   | "config"
   | "storePath"
+  | "callerTurns"
   | "transcriptWaiters"
   | "maxDurationTimers"
   | "onCallAnswered"

--- a/extensions/voice-call/src/manager/lifecycle.ts
+++ b/extensions/voice-call/src/manager/lifecycle.ts
@@ -11,7 +11,7 @@ type CallLifecycleContext = Pick<
   CallManagerContext,
   "activeCalls" | "providerCallIdMap" | "storePath"
 > &
-  Partial<Pick<CallManagerContext, "transcriptWaiters" | "maxDurationTimers">>;
+  Partial<Pick<CallManagerContext, "callerTurns" | "transcriptWaiters" | "maxDurationTimers">>;
 
 /** Remove a provider-call mapping only when it still points at this call. */
 function removeProviderCallMapping(
@@ -53,6 +53,7 @@ export function finalizeCall(params: {
     );
   }
 
+  ctx.callerTurns?.clear(call.callId);
   ctx.activeCalls.delete(call.callId);
   removeProviderCallMapping(ctx.providerCallIdMap, call);
 }

--- a/extensions/voice-call/src/manager/outbound.test.ts
+++ b/extensions/voice-call/src/manager/outbound.test.ts
@@ -60,7 +60,10 @@ vi.mock("./twiml.js", () => ({
   generateNotifyTwiml: generateNotifyTwimlMock,
 }));
 
+import { CallerTurnState } from "./caller-turn.js";
 import { endCall, initiateCall, sendDtmf, speak, speakInitialMessage } from "./outbound.js";
+
+const createCallerTurns = () => new CallerTurnState((callId) => callId === "call-1");
 
 function createActiveCallContext(params: { hangupCall?: ReturnType<typeof vi.fn> } = {}) {
   const call = { callId: "call-1", providerCallId: "provider-1", state: "active" };
@@ -72,6 +75,7 @@ function createActiveCallContext(params: { hangupCall?: ReturnType<typeof vi.fn>
     storePath: "/tmp/voice-call.json",
     transcriptWaiters: new Map(),
     maxDurationTimers: new Map(),
+    callerTurns: createCallerTurns(),
   };
 
   return { call, ctx, hangupCall };
@@ -352,6 +356,7 @@ describe("voice-call outbound helpers", () => {
       provider: { name: "twilio", playTts },
       config: { tts: { provider: "openai", providers: { openai: { voice: "alloy" } } } },
       storePath: "/tmp/voice-call.json",
+      callerTurns: createCallerTurns(),
     };
 
     await expect(
@@ -377,6 +382,28 @@ describe("voice-call outbound helpers", () => {
     expect(transitionStateMock).toHaveBeenLastCalledWith(call, "listening");
   });
 
+  it("does not start background playback while the caller is speaking", async () => {
+    const playTts = vi.fn(async () => {});
+    const callerTurns = createCallerTurns();
+    const ctx = {
+      activeCalls: new Map([
+        ["call-1", { callId: "call-1", providerCallId: "provider-1", state: "active" }],
+      ]),
+      providerCallIdMap: new Map(),
+      provider: { name: "twilio", playTts },
+      config: {},
+      storePath: "/tmp/voice-call.json",
+      callerTurns,
+    };
+    expect(callerTurns.beginSpeech("call-1")).toBe(true);
+
+    await expect(speak(ctx as never, "call-1", "stale background reply")).resolves.toEqual({
+      success: false,
+      error: "Caller is speaking",
+    });
+    expect(playTts).not.toHaveBeenCalled();
+  });
+
   it("passes configured voice ids through to Telnyx speak", async () => {
     const call = { callId: "call-1", providerCallId: "provider-1", state: "active" };
     const playTts = vi.fn(async () => {});
@@ -395,6 +422,7 @@ describe("voice-call outbound helpers", () => {
         },
       },
       storePath: "/tmp/voice-call.json",
+      callerTurns: createCallerTurns(),
     };
 
     await expect(speak(ctx as never, "call-1", "hello")).resolves.toEqual({ success: true });
@@ -429,6 +457,7 @@ describe("voice-call outbound helpers", () => {
         tts: { provider: "openai", providers: { openai: { voice: "alloy" } } },
       },
       storePath: "/tmp/voice-call.json",
+      callerTurns: createCallerTurns(),
     };
 
     try {
@@ -466,6 +495,7 @@ describe("voice-call outbound helpers", () => {
         },
       },
       storePath: "/tmp/voice-call.json",
+      callerTurns: createCallerTurns(),
     };
 
     await expect(speak(ctx as never, "call-1", "hello")).resolves.toEqual({ success: true });
@@ -500,6 +530,7 @@ describe("voice-call outbound helpers", () => {
         },
       },
       storePath: "/tmp/voice-call.json",
+      callerTurns: createCallerTurns(),
     };
 
     await expect(speak(ctx as never, "call-1", "hello")).resolves.toEqual({ success: true });

--- a/extensions/voice-call/src/manager/outbound.ts
+++ b/extensions/voice-call/src/manager/outbound.ts
@@ -49,6 +49,7 @@ type SpeakContext = Pick<
   | "provider"
   | "config"
   | "storePath"
+  | "callerTurns"
   | "transcriptWaiters"
   | "maxDurationTimers"
 >;
@@ -61,6 +62,7 @@ type ConversationContext = Pick<
   | "config"
   | "storePath"
   | "activeTurnCalls"
+  | "callerTurns"
   | "transcriptWaiters"
   | "maxDurationTimers"
   | "initialMessageInFlight"
@@ -74,7 +76,8 @@ type EndCallContext = Pick<
   | "storePath"
   | "transcriptWaiters"
   | "maxDurationTimers"
->;
+> &
+  Partial<Pick<CallManagerContext, "callerTurns">>;
 
 type ConnectedCallContext = Pick<CallManagerContext, "activeCalls" | "provider">;
 
@@ -284,6 +287,9 @@ export async function speak(
   const connected = requireConnectedCall(ctx, callId);
   if (!connected.ok) {
     return { success: false, error: connected.error };
+  }
+  if (ctx.callerTurns.isSpeaking(callId)) {
+    return { success: false, error: "Caller is speaking" };
   }
   const { call, providerCallId, provider } = connected;
 

--- a/extensions/voice-call/src/media-stream.caller-turn.test.ts
+++ b/extensions/voice-call/src/media-stream.caller-turn.test.ts
@@ -1,0 +1,77 @@
+// Voice Call tests cover caller-turn normalization for media streams.
+import type {
+  RealtimeTranscriptionSession,
+  RealtimeTranscriptionSessionCreateRequest,
+} from "openclaw/plugin-sdk/realtime-transcription";
+import { describe, expect, it, vi } from "vitest";
+import { MediaStreamHandler } from "./media-stream.js";
+import { connectWs, startUpgradeWsServer, waitForClose } from "./websocket-test-support.js";
+
+const createStubSession = (): RealtimeTranscriptionSession => ({
+  connect: async () => {},
+  sendAudio: () => {},
+  close: () => {},
+  isConnected: () => true,
+});
+
+const startWsServer = (handler: MediaStreamHandler) =>
+  startUpgradeWsServer({
+    urlPath: "/voice/stream",
+    onUpgrade: (request, socket, head) => {
+      handler.handleUpgrade(request, socket, head);
+    },
+  });
+
+describe("MediaStreamHandler caller turns", () => {
+  it("normalizes partial, native-start, and lone-final signals once per utterance", async () => {
+    let callbacks: RealtimeTranscriptionSessionCreateRequest | undefined;
+    const onSpeechStart = vi.fn();
+    const handler = new MediaStreamHandler({
+      transcriptionProvider: {
+        createSession: (request) => {
+          callbacks = request;
+          return createStubSession();
+        },
+        id: "elevenlabs",
+        label: "ElevenLabs",
+        isConfigured: () => true,
+      },
+      providerConfig: {},
+      shouldAcceptStream: () => true,
+      onSpeechStart,
+    });
+    const server = await startWsServer(handler);
+
+    try {
+      const ws = await connectWs(server.url);
+      ws.send(
+        JSON.stringify({
+          event: "start",
+          streamSid: "MZ-utterances",
+          start: { callSid: "CA-utterances" },
+        }),
+      );
+      await vi.waitFor(() => expect(callbacks).toBeDefined());
+
+      callbacks?.onPartial?.("hel");
+      callbacks?.onPartial?.("hello");
+      callbacks?.onSpeechStart?.();
+      expect(onSpeechStart).toHaveBeenCalledTimes(1);
+
+      callbacks?.onTranscript?.("hello there");
+      expect(onSpeechStart).toHaveBeenCalledTimes(1);
+
+      callbacks?.onTranscript?.("lone final");
+      expect(onSpeechStart).toHaveBeenCalledTimes(2);
+
+      callbacks?.onSpeechStart?.();
+      callbacks?.onPartial?.("next utterance");
+      expect(onSpeechStart).toHaveBeenCalledTimes(3);
+
+      ws.close();
+      await waitForClose(ws);
+    } finally {
+      await server.close();
+    }
+  });
+});

--- a/extensions/voice-call/src/media-stream.test.ts
+++ b/extensions/voice-call/src/media-stream.test.ts
@@ -369,6 +369,58 @@ describe("MediaStreamHandler security hardening", () => {
     }
   });
 
+  it("normalizes partial, native-start, and lone-final signals to one speech start per utterance", async () => {
+    let callbacks: RealtimeTranscriptionSessionCreateRequest | undefined;
+    const onSpeechStart = vi.fn();
+    const handler = new MediaStreamHandler({
+      transcriptionProvider: {
+        createSession: (request) => {
+          callbacks = request;
+          return createStubSession();
+        },
+        id: "elevenlabs",
+        label: "ElevenLabs",
+        isConfigured: () => true,
+      },
+      providerConfig: {},
+      shouldAcceptStream: () => true,
+      onSpeechStart,
+    });
+    const server = await startWsServer(handler);
+
+    try {
+      const ws = await connectWs(server.url);
+      ws.send(
+        JSON.stringify({
+          event: "start",
+          streamSid: "MZ-utterances",
+          start: { callSid: "CA-utterances" },
+        }),
+      );
+      await vi.waitFor(() => expect(callbacks).toBeDefined());
+
+      callbacks?.onPartial?.("hel");
+      callbacks?.onPartial?.("hello");
+      callbacks?.onSpeechStart?.();
+      expect(onSpeechStart).toHaveBeenCalledTimes(1);
+
+      callbacks?.onTranscript?.("hello there");
+      expect(onSpeechStart).toHaveBeenCalledTimes(1);
+
+      callbacks?.onTranscript?.("lone final");
+      expect(onSpeechStart).toHaveBeenCalledTimes(2);
+
+      callbacks?.onSpeechStart?.();
+      callbacks?.onPartial?.("next utterance");
+      expect(onSpeechStart).toHaveBeenCalledTimes(3);
+
+      ws.close();
+      await waitForClose(ws);
+    } finally {
+      await server.close();
+    }
+  });
+
   it("fails sends and closes stream when buffered bytes already exceed the cap", () => {
     const handler = new MediaStreamHandler({
       transcriptionProvider: createStubSttProvider(),

--- a/extensions/voice-call/src/media-stream.test.ts
+++ b/extensions/voice-call/src/media-stream.test.ts
@@ -369,58 +369,6 @@ describe("MediaStreamHandler security hardening", () => {
     }
   });
 
-  it("normalizes partial, native-start, and lone-final signals to one speech start per utterance", async () => {
-    let callbacks: RealtimeTranscriptionSessionCreateRequest | undefined;
-    const onSpeechStart = vi.fn();
-    const handler = new MediaStreamHandler({
-      transcriptionProvider: {
-        createSession: (request) => {
-          callbacks = request;
-          return createStubSession();
-        },
-        id: "elevenlabs",
-        label: "ElevenLabs",
-        isConfigured: () => true,
-      },
-      providerConfig: {},
-      shouldAcceptStream: () => true,
-      onSpeechStart,
-    });
-    const server = await startWsServer(handler);
-
-    try {
-      const ws = await connectWs(server.url);
-      ws.send(
-        JSON.stringify({
-          event: "start",
-          streamSid: "MZ-utterances",
-          start: { callSid: "CA-utterances" },
-        }),
-      );
-      await vi.waitFor(() => expect(callbacks).toBeDefined());
-
-      callbacks?.onPartial?.("hel");
-      callbacks?.onPartial?.("hello");
-      callbacks?.onSpeechStart?.();
-      expect(onSpeechStart).toHaveBeenCalledTimes(1);
-
-      callbacks?.onTranscript?.("hello there");
-      expect(onSpeechStart).toHaveBeenCalledTimes(1);
-
-      callbacks?.onTranscript?.("lone final");
-      expect(onSpeechStart).toHaveBeenCalledTimes(2);
-
-      callbacks?.onSpeechStart?.();
-      callbacks?.onPartial?.("next utterance");
-      expect(onSpeechStart).toHaveBeenCalledTimes(3);
-
-      ws.close();
-      await waitForClose(ws);
-    } finally {
-      await server.close();
-    }
-  });
-
   it("fails sends and closes stream when buffered bytes already exceed the cap", () => {
     const handler = new MediaStreamHandler({
       transcriptionProvider: createStubSttProvider(),

--- a/extensions/voice-call/src/media-stream.ts
+++ b/extensions/voice-call/src/media-stream.ts
@@ -73,6 +73,7 @@ interface StreamSession {
   ws: WebSocket;
   sttSession: RealtimeTranscriptionSession;
   talk: TalkSessionController;
+  callerSpeechActive: boolean;
 }
 
 type TtsQueueEntry = {
@@ -340,6 +341,7 @@ export class MediaStreamHandler {
       onPartial: (partial) => {
         const session = this.sessions.get(streamSid);
         if (session) {
+          this.beginCallerSpeech(session);
           this.emitTalkEvent(session, {
             type: "transcript.delta",
             turnId: this.ensureActiveTurn(session),
@@ -351,6 +353,8 @@ export class MediaStreamHandler {
       onTranscript: (transcript) => {
         const session = this.sessions.get(streamSid);
         if (session) {
+          this.beginCallerSpeech(session);
+          session.callerSpeechActive = false;
           const turnId = this.ensureActiveTurn(session);
           this.emitTalkEvent(session, {
             type: "input.audio.committed",
@@ -370,9 +374,8 @@ export class MediaStreamHandler {
       onSpeechStart: () => {
         const session = this.sessions.get(streamSid);
         if (session) {
-          this.ensureActiveTurn(session);
+          this.beginCallerSpeech(session);
         }
-        this.config.onSpeechStart?.(callSid);
       },
       onError: (error) => {
         console.warn("[MediaStream] Transcription session error:", error.message);
@@ -393,6 +396,7 @@ export class MediaStreamHandler {
       ws,
       sttSession,
       talk: this.createTalkEvents(callSid, streamSid),
+      callerSpeechActive: false,
     };
 
     this.sessions.set(streamSid, session);
@@ -796,6 +800,17 @@ export class MediaStreamHandler {
   private emitTalkEvent(session: StreamSession, input: TalkEventInput): void {
     const event = session.talk.emit(input);
     this.config.onTalkEvent?.(session.callId, session.streamSid, event);
+  }
+
+  private beginCallerSpeech(session: StreamSession): void {
+    this.ensureActiveTurn(session);
+    if (session.callerSpeechActive) {
+      return;
+    }
+    // Providers expose different VAD signals. Normalize the first partial, native
+    // speech-start, or lone final into one barge-in callback per utterance.
+    session.callerSpeechActive = true;
+    this.config.onSpeechStart?.(session.callId);
   }
 
   private ensureActiveTurn(session: StreamSession): string {

--- a/extensions/voice-call/src/webhook.test.ts
+++ b/extensions/voice-call/src/webhook.test.ts
@@ -4,6 +4,7 @@ import type { RealtimeTranscriptionProviderPlugin } from "openclaw/plugin-sdk/re
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { VoiceCallConfigSchema, resolveVoiceCallConfig, type VoiceCallConfig } from "./config.js";
 import type { CallManager } from "./manager.js";
+import { CallerTurnState } from "./manager/caller-turn.js";
 import type { VoiceCallProvider } from "./providers/base.js";
 import { PlivoProvider } from "./providers/plivo.js";
 import { TwilioProvider } from "./providers/twilio.js";
@@ -124,6 +125,20 @@ const createCall = (startedAt: number): CallRecord => ({
   processedEventIds: [],
 });
 
+const createCallerTurns = (...calls: CallRecord[]) =>
+  new CallerTurnState((callId) => calls.some((call) => call.callId === callId));
+
+function createDeferred<T>() {
+  let resolveValue: ((value: T) => void) | undefined;
+  const promise = new Promise<T>((resolve) => {
+    resolveValue = resolve;
+  });
+  if (!resolveValue) {
+    throw new Error("expected deferred resolver to be initialized");
+  }
+  return { promise, resolve: resolveValue };
+}
+
 const createManager = (calls: CallRecord[]) => {
   const endCall = vi.fn(async () => ({ success: true }));
   const processEvent = vi.fn<CallManager["processEvent"]>(() => ({ kind: "processed" }));
@@ -131,6 +146,7 @@ const createManager = (calls: CallRecord[]) => {
     getActiveCalls: () => calls,
     endCall,
     processEvent,
+    callerTurns: createCallerTurns(...calls),
   } as unknown as CallManager;
 
   return { manager, endCall, processEvent };
@@ -1740,6 +1756,7 @@ describe("VoiceCallWebhookServer classic response routing", () => {
     const manager = {
       getCall: (callId: string) => (callId === call.callId ? call : undefined),
       speak,
+      callerTurns: createCallerTurns(call),
     } as unknown as CallManager;
     const config = createConfig({
       agentId: "top",
@@ -1782,6 +1799,7 @@ describe("VoiceCallWebhookServer classic response routing", () => {
     const manager = {
       getCall: (callId: string) => (callId === call.callId ? call : undefined),
       speak,
+      callerTurns: createCallerTurns(call),
     } as unknown as CallManager;
     const server = new VoiceCallWebhookServer(
       createConfig({ agentId: "main" }),
@@ -1810,12 +1828,69 @@ describe("VoiceCallWebhookServer classic response routing", () => {
     ]);
   });
 
+  it("lets only the newest response speak after the caller resumes", async () => {
+    const call = createCall(Date.now());
+    const speak = vi.fn(async () => ({ success: true }));
+    const callerTurns = createCallerTurns(call);
+    const manager = {
+      getCall: (callId: string) => (callId === call.callId ? call : undefined),
+      speak,
+      callerTurns,
+    } as unknown as CallManager;
+    const server = new VoiceCallWebhookServer(
+      createConfig({ agentId: "main" }),
+      manager,
+      provider,
+      {} as never,
+      undefined,
+      {} as never,
+    );
+    const firstResponse = createDeferred<{ text: string; deliveredEarly: boolean }>();
+    const secondResponse = createDeferred<{ text: string; deliveredEarly: boolean }>();
+    let staleEarlyText: ((text: string) => Promise<boolean>) | undefined;
+    mocks.generateVoiceResponse
+      .mockReset()
+      .mockImplementationOnce(async (params) => {
+        staleEarlyText = params?.onEarlyText;
+        return firstResponse.promise;
+      })
+      .mockImplementationOnce(async () => secondResponse.promise);
+    const handleInboundResponse = (message: string) =>
+      (
+        server as unknown as {
+          handleInboundResponse: (callId: string, message: string) => Promise<void>;
+        }
+      ).handleInboundResponse(call.callId, message);
+
+    const firstRun = handleInboundResponse("first turn");
+    await vi.waitFor(() => expect(mocks.generateVoiceResponse).toHaveBeenCalledTimes(1));
+    expect(callerTurns.beginSpeech(call.callId)).toBe(true);
+    callerTurns.endSpeech(call.callId);
+
+    const secondRun = handleInboundResponse("replacement turn");
+    await vi.waitFor(() => expect(mocks.generateVoiceResponse).toHaveBeenCalledTimes(2));
+    if (!staleEarlyText) {
+      throw new Error("expected the first response to expose its early-text callback");
+    }
+    await expect(staleEarlyText("stale early reply")).resolves.toBe(false);
+
+    secondResponse.resolve({ text: "newest reply", deliveredEarly: false });
+    await secondRun;
+    firstResponse.resolve({ text: "stale final reply", deliveredEarly: false });
+    await firstRun;
+
+    expect(speak.mock.calls).toEqual([
+      [call.callId, "newest reply", { listenAfterPlayback: true }],
+    ]);
+  });
+
   it("logs only char counts for inbound user text, early AI text, and final AI text", async () => {
     const call = createCall(Date.now());
     const speak = vi.fn(async () => ({ success: true }));
     const manager = {
       getCall: (callId: string) => (callId === call.callId ? call : undefined),
       speak,
+      callerTurns: createCallerTurns(call),
     } as unknown as CallManager;
 
     const { logger, messages } = createCapturingLogger();
@@ -1956,6 +2031,7 @@ describe("VoiceCallWebhookServer stream disconnect grace", () => {
     const getCallByProviderCallId = vi.fn((providerCallId: string) =>
       providerCallId === "CA-stream-1" ? call : undefined,
     );
+    const callerTurns = createCallerTurns(call);
 
     const manager = {
       getActiveCalls: () => [call],
@@ -1963,6 +2039,7 @@ describe("VoiceCallWebhookServer stream disconnect grace", () => {
       endCall,
       speakInitialMessage,
       processEvent: vi.fn(),
+      callerTurns,
     } as unknown as CallManager;
 
     let currentStreamSid: string | null = "MZ-old";
@@ -2015,11 +2092,18 @@ describe("VoiceCallWebhookServer stream disconnect grace", () => {
     expect(endCall).not.toHaveBeenCalled();
     expect(speakInitialMessage).not.toHaveBeenCalled();
 
+    const replacementResponse = callerTurns.beginResponse(call.callId);
+    mediaHandler.config.onDisconnect?.("CA-stream-1", "MZ-old");
+    expect(callerTurns.isResponseCurrent(call.callId, replacementResponse)).toBe(true);
+    await vi.advanceTimersByTimeAsync(2_100);
+    expect(endCall).not.toHaveBeenCalled();
+
     mediaHandler.config.onTranscriptionReady?.("CA-stream-1", "MZ-new");
     expect(speakInitialMessage).toHaveBeenCalledTimes(1);
     expect(speakInitialMessage).toHaveBeenCalledWith("CA-stream-1");
 
     mediaHandler.config.onDisconnect?.("CA-stream-1", "MZ-new");
+    expect(callerTurns.isResponseCurrent(call.callId, replacementResponse)).toBe(false);
     await vi.advanceTimersByTimeAsync(2_100);
     expect(endCall).toHaveBeenCalledTimes(1);
     expect(endCall).toHaveBeenCalledWith(call.callId);
@@ -2052,6 +2136,7 @@ describe("VoiceCallWebhookServer barge-in suppression during initial message", (
       endCall: vi.fn(async () => ({ success: true })),
       speakInitialMessage: vi.fn(async () => {}),
       processEvent: vi.fn(),
+      callerTurns: createCallerTurns(),
     } as unknown as CallManager;
     const config = createConfig({
       provider: "twilio",
@@ -2129,6 +2214,7 @@ describe("VoiceCallWebhookServer barge-in suppression during initial message", (
       endCall: vi.fn(async () => ({ success: true })),
       speakInitialMessage: vi.fn(async () => {}),
       processEvent,
+      callerTurns: createCallerTurns(call),
     } as unknown as CallManager;
 
     const config = createConfig({
@@ -2173,7 +2259,7 @@ describe("VoiceCallWebhookServer barge-in suppression during initial message", (
 
       media.config.onSpeechStart?.("CA-barge");
       media.config.onTranscript?.("CA-barge", "hello after greeting");
-      expect(clearTtsQueue).toHaveBeenCalledTimes(2);
+      expect(clearTtsQueue).toHaveBeenCalledTimes(1);
       expect(handleInboundResponse).toHaveBeenCalledTimes(1);
       expect(processEvent).toHaveBeenCalledTimes(1);
       const [calledCallId, calledTranscript] = requireFirstMockCall(
@@ -2215,6 +2301,7 @@ describe("VoiceCallWebhookServer barge-in suppression during initial message", (
       endCall: vi.fn(async () => ({ success: true })),
       speakInitialMessage: vi.fn(async () => {}),
       processEvent,
+      callerTurns: createCallerTurns(call),
     } as unknown as CallManager;
 
     const config = createConfig({
@@ -2240,9 +2327,8 @@ describe("VoiceCallWebhookServer barge-in suppression during initial message", (
 
     try {
       const media = getMediaCallbacks(server);
-      media.config.onSpeechStart?.("CA-inbound");
       media.config.onTranscript?.("CA-inbound", "hello");
-      expect(clearTtsQueue).toHaveBeenCalledTimes(2);
+      expect(clearTtsQueue).toHaveBeenCalledTimes(1);
       expect(processEvent).toHaveBeenCalledTimes(1);
       const event = requireFirstMockCall(processEvent.mock.calls, "inbound processed event")[0] as
         | NormalizedEvent

--- a/extensions/voice-call/src/webhook.ts
+++ b/extensions/voice-call/src/webhook.ts
@@ -307,6 +307,17 @@ export class VoiceCallWebhookServer {
     return initialMessage.length > 0;
   }
 
+  private beginCallerSpeech(call: CallRecord, providerCallId: string): void {
+    if (
+      this.provider.name !== "twilio" ||
+      this.shouldSuppressBargeInForInitialMessage(call) ||
+      !this.manager.callerTurns.beginSpeech(call.callId)
+    ) {
+      return;
+    }
+    (this.provider as TwilioProvider).clearTtsQueue(providerCallId, "caller-speech");
+  }
+
   /**
    * Initialize media streaming with the selected realtime transcription provider.
    */
@@ -392,10 +403,8 @@ export class VoiceCallWebhookServer {
           return;
         }
 
-        // Clear TTS queue on barge-in (user started speaking, interrupt current playback)
-        if (this.provider.name === "twilio") {
-          (this.provider as TwilioProvider).clearTtsQueue(providerCallId);
-        }
+        this.beginCallerSpeech(call, providerCallId);
+        this.manager.callerTurns.endSpeech(call.callId);
 
         // Create a speech event and process it through the manager
         const event: NormalizedEvent = {
@@ -410,14 +419,10 @@ export class VoiceCallWebhookServer {
         this.processEventWithAutoResponse(event);
       },
       onSpeechStart: (providerCallId) => {
-        if (this.provider.name !== "twilio") {
-          return;
-        }
         const call = this.manager.getCallByProviderCallId(providerCallId);
-        if (this.shouldSuppressBargeInForInitialMessage(call)) {
-          return;
+        if (call) {
+          this.beginCallerSpeech(call, providerCallId);
         }
-        (this.provider as TwilioProvider).clearTtsQueue(providerCallId);
       },
       onPartialTranscript: (callId, partial) => {
         this.logger.info(`Partial transcript ${callId} chars=${partial.length}`);
@@ -444,8 +449,17 @@ export class VoiceCallWebhookServer {
       },
       onDisconnect: (callId, streamSid) => {
         this.logger.info(`Media stream disconnected: ${callId} (${streamSid})`);
+        let hasRegisteredStream = false;
         if (this.provider.name === "twilio") {
-          (this.provider as TwilioProvider).unregisterCallStream(callId, streamSid);
+          const twilio = this.provider as TwilioProvider;
+          twilio.unregisterCallStream(callId, streamSid);
+          hasRegisteredStream = twilio.hasRegisteredStream(callId);
+        }
+        const call = this.manager.getCallByProviderCallId(callId);
+        if (call && !hasRegisteredStream) {
+          // A late disconnect from an older stream must not invalidate the
+          // response or caller state belonging to its replacement stream.
+          this.manager.callerTurns.clear(call.callId);
         }
 
         this.clearPendingDisconnectHangup(callId);
@@ -999,6 +1013,7 @@ export class VoiceCallWebhookServer {
       return;
     }
 
+    const responseToken = this.manager.callerTurns.beginResponse(callId);
     try {
       const { generateVoiceResponse } = await loadResponseGeneratorModule();
       const numberRouteKey = resolveVoiceCallNumberRouteKeyForCall(call);
@@ -1015,6 +1030,10 @@ export class VoiceCallWebhookServer {
         transcript: call.transcript,
         userMessage,
         onEarlyText: async (text) => {
+          if (!this.manager.callerTurns.isResponseCurrent(callId, responseToken)) {
+            this.logger.info(`Dropping stale early AI response ${callId} chars=${text.length}`);
+            return false;
+          }
           this.logger.info(`Early AI response queued ${callId} chars=${text.length}`);
           const speakResult = await this.manager.speak(callId, text, { listenAfterPlayback: true });
           return speakResult.success;
@@ -1026,12 +1045,19 @@ export class VoiceCallWebhookServer {
         return;
       }
 
+      if (!this.manager.callerTurns.isResponseCurrent(callId, responseToken)) {
+        this.logger.info(`Dropping stale AI response ${callId}`);
+        return;
+      }
+
       if (result.text && !result.deliveredEarly) {
         this.logger.info(`AI response delivered ${callId} chars=${result.text.length}`);
         await this.manager.speak(callId, result.text, { listenAfterPlayback: true });
       }
     } catch (err) {
       this.logger.error(`Auto-response error: ${String(err)}`);
+    } finally {
+      this.manager.callerTurns.finishResponse(callId, responseToken);
     }
   }
 }


### PR DESCRIPTION
Closes #112360

AI-assisted: yes — this change was prepared with OpenAI Codex. I reviewed the event lifecycle, response-generation ownership, provider playback boundary, and the included regression coverage, and I understand the resulting behavior.

## What Problem This Solves

Fixes an issue where Voice Call users who resume speaking while a reply is being generated can hear the agent play an obsolete response over their new utterance.

## Why This Change Was Made

The Voice Call manager now owns per-call caller-turn state and gives each asynchronous response generation a unique ownership token. New caller speech invalidates the prior token, playback checks that the caller is not speaking and that the token is still current, and call finalization clears the transient state.

Speech event normalization covers provider event variants while keeping provider APIs and silence thresholds unchanged.

## User Impact

Callers can resume speaking without a response from the superseded turn starting afterward. Only the newest response for the active caller turn may reach TTS playback, and turn state is discarded when the call ends.

## Evidence

- `node scripts/run-vitest.mjs extensions/voice-call`: 53 test files passed, 541 tests passed.
- Regression coverage includes resumed-speech invalidation, newest-response ownership, no playback while the caller is speaking, speech-event normalization, inactive-call rejection, and call-end cleanup.
- `git diff --check` passes.
