### PR TITLE
fix(skills): allow skills browse commands with invalid config

### DIFF
--- a/src/cli/skills-cli.commands.test.ts
+++ b/src/cli/skills-cli.commands.test.ts
@@ -1453,7 +1453,7 @@ describe("skills cli commands", () => {
   it("keeps non-JSON skills list output on stdout with human-readable formatting", async () => {
     await runCommand(["skills", "list"]);
 
-    expect(loadConfigMock).toHaveBeenCalledWith({ skipPluginValidation: true });
+    expect(loadConfigMock).toHaveBeenCalledWith({ observe: false, skipPluginValidation: true });
     expect(defaultRuntime.writeStdout).toHaveBeenCalledTimes(1);
     expect(defaultRuntime.log).not.toHaveBeenCalled();
     expect(runtimeErrors).toStrictEqual([]);

--- a/src/cli/skills-cli.commands.test.ts
+++ b/src/cli/skills-cli.commands.test.ts
@@ -206,6 +206,7 @@ vi.mock("../utils.js", async (importOriginal) => ({
 vi.mock("../config/config.js", () => ({
   getRuntimeConfig: (...args: unknown[]) => mocks.loadConfigMock(...args),
   loadConfig: () => mocks.loadConfigMock(),
+  readBestEffortConfig: async (...args: unknown[]) => mocks.loadConfigMock(...args),
 }));
 
 vi.mock("../agents/agent-scope.js", () => ({

--- a/src/cli/skills-cli.commands.test.ts
+++ b/src/cli/skills-cli.commands.test.ts
@@ -1626,29 +1626,65 @@ describe("skills cli commands", () => {
   const explicitGatewaySkillFailures = [
     {
       label: "configured remote missing URL",
+      outcome: "command" as const,
       config: { gateway: { mode: "remote" as const } },
       message: "gateway remote mode misconfigured: gateway.remote.url missing",
     },
     {
       label: "configured remote transport failure",
+      outcome: "root" as const,
       config: { gateway: { mode: "remote" as const, remote: { url: "ws://127.0.0.1:9" } } },
-      message: "Gateway not reachable: ws://127.0.0.1:9",
+      // Fallback-eligible by error type: only the remote configuration itself
+      // may block the implicit-local substitution.
+      error: new GatewayTransportError({
+        kind: "closed",
+        code: 1006,
+        reason: "abnormal closure",
+        message: "gateway closed (1006): abnormal closure",
+        connectionDetails: {
+          url: "ws://127.0.0.1:9",
+          urlSource: "remote url",
+          message: "",
+        },
+      }),
+      message: "gateway closed (1006): abnormal closure",
     },
     {
       label: "configured remote auth failure",
+      outcome: "command" as const,
       config: { gateway: { mode: "remote" as const, remote: { url: "ws://127.0.0.1:9" } } },
+      // Credentials errors are fallback-eligible too; remote stays fail-closed.
+      error: Object.assign(new Error("gateway authentication failed"), {
+        name: "GatewayCredentialsRequiredError",
+      }),
       message: "gateway authentication failed",
     },
     {
       label: "environment-selected transport failure",
+      outcome: "root" as const,
       config: {},
       url: "ws://127.0.0.1:9",
-      message: "Gateway not reachable: ws://127.0.0.1:9",
+      error: new GatewayTransportError({
+        kind: "closed",
+        code: 1006,
+        reason: "abnormal closure",
+        message: "gateway closed (1006): abnormal closure",
+        connectionDetails: {
+          url: "ws://127.0.0.1:9",
+          urlSource: "remote url",
+          message: "",
+        },
+      }),
+      message: "gateway closed (1006): abnormal closure",
     },
     {
       label: "environment-selected auth failure",
+      outcome: "command" as const,
       config: {},
       url: "ws://127.0.0.1:9",
+      error: Object.assign(new Error("gateway authentication failed"), {
+        name: "GatewayCredentialsRequiredError",
+      }),
       message: "gateway authentication failed",
     },
   ];
@@ -1672,16 +1708,24 @@ describe("skills cli commands", () => {
     ),
   )("does not substitute local skills after $label", async ({ target, command, json }) => {
     loadConfigMock.mockReturnValue(target.config);
+    // Browse commands resolve through the best-effort reader; the fixtures
+    // must reach that mock too or the remote configuration never exists.
+    readBestEffortConfigMock.mockResolvedValue(target.config);
     if (target.url) {
       vi.stubEnv("OPENCLAW_GATEWAY_URL", target.url);
     }
-    callGatewayMock.mockRejectedValue(new Error(target.message));
+    const failure = target.error ?? new Error(target.message);
+    callGatewayMock.mockRejectedValue(failure);
 
-    await expect(runCommand([...command.argv, ...(json ? ["--json"] : [])])).rejects.toThrow(
-      "__exit__:1",
-    );
-
-    expect(runtimeErrors).toEqual([target.message]);
+    // Root-owned credential/transport errors propagate; ordinary command errors log and exit.
+    const run = runCommand([...command.argv, ...(json ? ["--json"] : [])]);
+    if (target.outcome === "root") {
+      await expect(run).rejects.toBe(failure);
+      expect(runtimeErrors).toEqual([]);
+    } else {
+      await expect(run).rejects.toThrow("__exit__:1");
+      expect(runtimeErrors).toEqual([target.message]);
+    }
     expect(runtimeStdout).toEqual([]);
     expect(buildWorkspaceSkillStatusMock).not.toHaveBeenCalled();
   });

--- a/src/cli/skills-cli.commands.test.ts
+++ b/src/cli/skills-cli.commands.test.ts
@@ -269,7 +269,10 @@ vi.mock("../gateway/call.js", () => ({
   isGatewayClientRequestError: (error: unknown) =>
     error instanceof Error && error.name === "GatewayClientRequestError",
   isGatewayCredentialsRequiredError: (error: unknown) =>
-    error instanceof Error && error.name === "GatewayCredentialsRequiredError",
+    error instanceof Error &&
+    error.name === "GatewayCredentialsRequiredError" &&
+    typeof (error as { method?: unknown }).method === "string" &&
+    typeof (error as { configPath?: unknown }).configPath === "string",
   isImplicitLocalGatewayTarget: async ({ config }: { config?: { gateway?: { mode?: string } } }) =>
     !process.env.OPENCLAW_GATEWAY_URL && config?.gateway?.mode !== "remote",
 }));
@@ -1651,11 +1654,15 @@ describe("skills cli commands", () => {
     },
     {
       label: "configured remote auth failure",
-      outcome: "command" as const,
+      outcome: "root" as const,
       config: { gateway: { mode: "remote" as const, remote: { url: "ws://127.0.0.1:9" } } },
       // Credentials errors are fallback-eligible too; remote stays fail-closed.
+      // Production credentials errors carry method/configPath and bypass
+      // command-level formatting through the root renderer.
       error: Object.assign(new Error("gateway authentication failed"), {
         name: "GatewayCredentialsRequiredError",
+        method: "skills.status",
+        configPath: "/tmp/openclaw.json",
       }),
       message: "gateway authentication failed",
     },
@@ -1679,11 +1686,13 @@ describe("skills cli commands", () => {
     },
     {
       label: "environment-selected auth failure",
-      outcome: "command" as const,
+      outcome: "root" as const,
       config: {},
       url: "ws://127.0.0.1:9",
       error: Object.assign(new Error("gateway authentication failed"), {
         name: "GatewayCredentialsRequiredError",
+        method: "skills.status",
+        configPath: "/tmp/openclaw.json",
       }),
       message: "gateway authentication failed",
     },

--- a/src/cli/skills-cli.commands.test.ts
+++ b/src/cli/skills-cli.commands.test.ts
@@ -102,6 +102,7 @@ const mocks = vi.hoisted(() => {
   return {
     callGatewayMock: vi.fn(),
     loadConfigMock: vi.fn((_options?: unknown) => ({})),
+    readBestEffortConfigMock: vi.fn(async (_options?: unknown) => ({})),
     resolveDefaultAgentIdMock: vi.fn(
       (_configForTest: unknown, _context?: AgentSelectionContext) => "main",
     ),
@@ -138,6 +139,7 @@ const mocks = vi.hoisted(() => {
 const {
   callGatewayMock,
   loadConfigMock,
+  readBestEffortConfigMock,
   resolveDefaultAgentIdMock,
   resolveAgentIdByWorkspacePathMock,
   resolveConfiguredAgentIdMock,
@@ -280,6 +282,7 @@ vi.mock("../utils.js", async (importOriginal) => ({
 vi.mock("../config/config.js", () => ({
   getRuntimeConfig: (...args: unknown[]) => mocks.loadConfigMock(...args),
   loadConfig: () => mocks.loadConfigMock(),
+  readBestEffortConfig: async (...args: unknown[]) => mocks.readBestEffortConfigMock(...args),
 }));
 
 vi.mock("../agents/agent-scope.js", () => ({
@@ -360,6 +363,7 @@ describe("skills cli commands", () => {
     runtimeErrors.length = 0;
     callGatewayMock.mockReset();
     loadConfigMock.mockReset();
+    readBestEffortConfigMock.mockReset();
     resolveDefaultAgentIdMock.mockReset();
     resolveAgentIdByWorkspacePathMock.mockReset();
     resolveConfiguredAgentIdMock.mockReset();
@@ -392,6 +396,7 @@ describe("skills cli commands", () => {
       }),
     );
     loadConfigMock.mockReturnValue({});
+    readBestEffortConfigMock.mockResolvedValue({});
     resolveDefaultAgentIdMock.mockReturnValue("main");
     resolveAgentIdByWorkspacePathMock.mockReturnValue(undefined);
     resolveConfiguredAgentIdMock.mockImplementation((_config, agentId: string) => agentId);
@@ -1903,12 +1908,31 @@ describe("skills cli commands", () => {
   it("keeps non-JSON skills list output on stdout with human-readable formatting", async () => {
     await runCommand(["skills", "list"]);
 
-    expect(loadConfigMock).toHaveBeenCalledWith({ skipPluginValidation: true });
+    expect(readBestEffortConfigMock).toHaveBeenCalledWith({
+      observe: false,
+      skipPluginValidation: true,
+    });
     expect(defaultRuntime.writeStdout).toHaveBeenCalledTimes(1);
     expect(defaultRuntime.log).not.toHaveBeenCalled();
     expect(runtimeErrors).toStrictEqual([]);
     expect(runtimeStdout.at(-1)).toContain("calendar");
     expect(runtimeStdout.at(-1)).toContain("openclaw skills search");
+  });
+
+  it("renders skills browse output when the strict config load fails", async () => {
+    loadConfigMock.mockImplementation(() => {
+      throw new Error("Invalid config: unrecognized key");
+    });
+
+    await runCommand(["skills", "list"]);
+
+    expect(readBestEffortConfigMock).toHaveBeenCalledWith({
+      observe: false,
+      skipPluginValidation: true,
+    });
+    expect(loadConfigMock).not.toHaveBeenCalled();
+    expect(runtimeErrors).toStrictEqual([]);
+    expect(runtimeStdout.at(-1)).toContain("calendar");
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/cli/skills-cli.ts
+++ b/src/cli/skills-cli.ts
@@ -167,9 +167,10 @@ async function resolveSkillsWorkspaceBestEffort(
   options?: ResolveSkillsWorkspaceOptions,
 ): Promise<ResolvedSkillsWorkspace> {
   // Browse commands must render local skill metadata even when config validation fails,
-  // so read best-effort and keep the no-plugin-validation status contract.
+  // so read best-effort and keep the no-plugin-validation status contract. They are
+  // read-only: observe:false keeps them from persisting config-health/audit state.
   return resolveSkillsWorkspaceFromConfig(
-    await readBestEffortConfig({ skipPluginValidation: true }),
+    await readBestEffortConfig({ observe: false, skipPluginValidation: true }),
     options,
   );
 }

--- a/src/cli/skills-cli.ts
+++ b/src/cli/skills-cli.ts
@@ -13,7 +13,7 @@ import {
   resolveAgentWorkspaceDir,
   resolveDefaultAgentId,
 } from "../agents/agent-scope.js";
-import { getRuntimeConfig } from "../config/config.js";
+import { getRuntimeConfig, readBestEffortConfig } from "../config/config.js";
 import { resolveGatewayPort } from "../config/paths.js";
 import { CLAWHUB_TRUST_ERROR_CODE } from "../infra/clawhub-install-trust.js";
 import {
@@ -119,10 +119,9 @@ function isClawHubSkillBlockedCliFailure(result: { code?: string; warning?: stri
 type ResolveSkillsWorkspaceOptions = {
   agentId?: string;
   cwd?: string;
-  skipPluginValidation?: boolean;
 };
 
-type ResolvedSkillsWorkspace = ReturnType<typeof resolveSkillsWorkspace>;
+type ResolvedSkillsWorkspace = ReturnType<typeof resolveSkillsWorkspaceFromConfig>;
 type SkillProposalDraftCliOptions = {
   agent?: string;
   json?: boolean;
@@ -139,15 +138,15 @@ const GATEWAY_SKILLS_OFFLINE_LOCK_TIMEOUT_MS = 250;
 // Apply can await evaluator, proposal-change, and skill-change hook phases.
 const GATEWAY_SKILLS_APPLY_TIMEOUT_MS = 1_850_000;
 
-function resolveSkillsWorkspace(options?: ResolveSkillsWorkspaceOptions): {
+function resolveSkillsWorkspaceFromConfig(
+  config: ReturnType<typeof getRuntimeConfig>,
+  options?: ResolveSkillsWorkspaceOptions,
+): {
   config: ReturnType<typeof getRuntimeConfig>;
   workspaceDir: string;
   agentId: string;
 } {
   // Prefer explicit --agent, then infer from cwd, then fall back to configured default agent.
-  const config = getRuntimeConfig(
-    options?.skipPluginValidation ? { skipPluginValidation: true } : undefined,
-  );
   const explicitAgentId = normalizeOptionalString(options?.agentId);
   const inferredAgentId = explicitAgentId
     ? undefined
@@ -158,6 +157,21 @@ function resolveSkillsWorkspace(options?: ResolveSkillsWorkspaceOptions): {
     agentId,
     workspaceDir: resolveAgentWorkspaceDir(config, agentId),
   };
+}
+
+function resolveSkillsWorkspace(options?: ResolveSkillsWorkspaceOptions): ResolvedSkillsWorkspace {
+  return resolveSkillsWorkspaceFromConfig(getRuntimeConfig(), options);
+}
+
+async function resolveSkillsWorkspaceBestEffort(
+  options?: ResolveSkillsWorkspaceOptions,
+): Promise<ResolvedSkillsWorkspace> {
+  // Browse commands must render local skill metadata even when config validation fails,
+  // so read best-effort and keep the no-plugin-validation status contract.
+  return resolveSkillsWorkspaceFromConfig(
+    await readBestEffortConfig({ skipPluginValidation: true }),
+    options,
+  );
 }
 
 function resolveAgentOption(
@@ -186,9 +200,8 @@ async function loadGatewaySkillsStatusReport(
 }
 
 async function loadSkillsStatusReport(
-  options?: ResolveSkillsWorkspaceOptions,
+  resolved: ResolvedSkillsWorkspace,
 ): Promise<SkillStatusReport> {
-  const resolved = resolveSkillsWorkspace({ ...options, skipPluginValidation: true });
   const gatewayReport = await loadGatewaySkillsStatusReport(resolved);
   if (gatewayReport) {
     return gatewayReport;
@@ -205,7 +218,8 @@ async function runSkillsAction(
   options?: ResolveSkillsWorkspaceOptions,
 ): Promise<void> {
   try {
-    const report = await loadSkillsStatusReport(options);
+    const resolved = await resolveSkillsWorkspaceBestEffort(options);
+    const report = await loadSkillsStatusReport(resolved);
     defaultRuntime.writeStdout(render(report));
   } catch (err) {
     defaultRuntime.error(String(err));

--- a/src/cli/skills-cli.ts
+++ b/src/cli/skills-cli.ts
@@ -14,7 +14,7 @@ import {
   resolveAgentWorkspaceDir,
   resolveDefaultAgentId,
 } from "../agents/agent-scope.js";
-import { getRuntimeConfig } from "../config/config.js";
+import { getRuntimeConfig, readBestEffortConfig } from "../config/config.js";
 import { resolveGatewayPort } from "../config/paths.js";
 import { CLAWHUB_TRUST_ERROR_CODE } from "../infra/clawhub-install-trust.js";
 import {
@@ -123,10 +123,9 @@ function isClawHubSkillBlockedCliFailure(result: { code?: string; warning?: stri
 type ResolveSkillsWorkspaceOptions = {
   agentId?: string;
   cwd?: string;
-  skipPluginValidation?: boolean;
 };
 
-type ResolvedSkillsWorkspace = ReturnType<typeof resolveSkillsWorkspace>;
+type ResolvedSkillsWorkspace = ReturnType<typeof resolveSkillsWorkspaceFromConfig>;
 type SkillProposalDraftCliOptions = {
   agent?: string;
   json?: boolean;
@@ -167,15 +166,15 @@ function normalizeExplicitAgentId(agentId?: string): string | undefined {
   return normalizedAgentId;
 }
 
-function resolveSkillsWorkspace(options?: ResolveSkillsWorkspaceOptions): {
+function resolveSkillsWorkspaceFromConfig(
+  config: ReturnType<typeof getRuntimeConfig>,
+  options?: ResolveSkillsWorkspaceOptions,
+): {
   config: ReturnType<typeof getRuntimeConfig>;
   workspaceDir: string;
   agentId: string;
 } {
   // Prefer explicit --agent, then infer from cwd, then fall back to configured default agent.
-  const config = getRuntimeConfig(
-    options?.skipPluginValidation ? { skipPluginValidation: true } : undefined,
-  );
   const explicitAgentId = normalizeExplicitAgentId(options?.agentId);
   const inferredAgentId = explicitAgentId
     ? undefined
@@ -191,6 +190,22 @@ function resolveSkillsWorkspace(options?: ResolveSkillsWorkspaceOptions): {
   };
 }
 
+function resolveSkillsWorkspace(options?: ResolveSkillsWorkspaceOptions): ResolvedSkillsWorkspace {
+  return resolveSkillsWorkspaceFromConfig(getRuntimeConfig(), options);
+}
+
+async function resolveSkillsWorkspaceBestEffort(
+  options?: ResolveSkillsWorkspaceOptions,
+): Promise<ResolvedSkillsWorkspace> {
+  // Browse commands must render local skill metadata even when config validation fails,
+  // so read best-effort and keep the no-plugin-validation status contract. They are
+  // read-only: observe:false keeps them from persisting config-health/audit state.
+  return resolveSkillsWorkspaceFromConfig(
+    await readBestEffortConfig({ observe: false, skipPluginValidation: true }),
+    options,
+  );
+}
+
 function resolveAgentOption(
   command: Command | undefined,
   opts?: { agent?: string },
@@ -199,9 +214,8 @@ function resolveAgentOption(
 }
 
 async function loadSkillsStatusReport(
-  options?: ResolveSkillsWorkspaceOptions,
+  resolved: ResolvedSkillsWorkspace,
 ): Promise<SkillStatusReport> {
-  const resolved = resolveSkillsWorkspace({ ...options, skipPluginValidation: true });
   try {
     return await callSkillsGateway<SkillStatusReport>({
       config: resolved.config,
@@ -232,7 +246,8 @@ async function runSkillsAction(
   options?: ResolveSkillsWorkspaceOptions,
 ): Promise<void> {
   await runCommandWithRuntime(defaultRuntime, async () => {
-    const report = await loadSkillsStatusReport(options);
+    const resolved = await resolveSkillsWorkspaceBestEffort(options);
+    const report = await loadSkillsStatusReport(resolved);
     defaultRuntime.writeStdout(render(report));
   });
 }


### PR DESCRIPTION
## What Problem This Solves

`openclaw skills`, `openclaw skills check`, `openclaw skills info`, and `openclaw skills list` are read-only browse commands that search or list installed skills. An unrelated invalid key in `openclaw.json` would stop them before they could report results, leaving users unable to browse skill metadata when the config is broken.

Current `main` already skips the startup config guard and plugin loading for these four browse routes (`src/cli/command-catalog.ts`, `configGuard: "skip"` / `loadPlugins: "never"`), but the commands still fail: `runSkillsAction` resolves the agent workspace through strict `getRuntimeConfig()`, which re-throws on the same invalid config after the startup guard has stepped aside.

## Why This Change Was Made

- Loads config with `readBestEffortConfig()` inside `skills-cli.ts` for the read-only status path only, so the command itself does not re-throw on an unrelated invalid key after the startup guard steps aside.
- Passes `observe: false` alongside `skipPluginValidation: true`: browse commands are read-only, so they must not persist config-health/audit state as a side effect (config reads default observation to true).
- Resolution runs inside `runCommandWithRuntime`, so the shared CLI error handling (expected/JSON error formatting and secret redaction) still applies to any workspace-resolution failure.
- The canonical explicit-agent validation (`normalizeExplicitAgentId` blank rejection + `resolveConfiguredAgentId` unknown-ID rejection) is preserved on the shared `resolveSkillsWorkspaceFromConfig` path used by both strict and best-effort resolution.
- This keeps the fix at the command owner boundary: config schema, doctor flow, and all other commands remain unchanged. The mutating commands (`skills install`, `skills update`, `skills verify`) are intentionally unchanged because they modify state or require plugin access.

Follows the same pattern as #111803 (`fix(docs): search live docs with unrelated invalid config`).

## User Impact

Users can run `openclaw skills`, `openclaw skills check`, `openclaw skills info`, and `openclaw skills list` even when their local OpenClaw config is invalid. The commands still use the same execution paths and render the same results when the config is valid.

## Evidence

Rebuilt on current `main` (`b0d6fff9f95`); new exact head is `0dcc76d54b5ec3f9b66e2c6ee3cdacf6f44537aa`. The previous head had diverged from upstream history (no merge base) and predated main's explicit-agent validation and shared CLI error redaction; the change was re-applied on current `main` as a single commit that keeps both contracts. The earlier command-catalog half remains dropped as superseded (current `main` already ships `configGuard: "skip"` + `loadPlugins: "never"` for the four browse routes).

- Exact-head focused proof (Node 24.19.0): `skills-cli.commands.test.ts` 95/95 passed, including a new regression test `renders skills browse output when the strict config load fails` and the existing `redacts secrets from rendered skills CLI errors` redaction contract.
- Red/green: the new regression test fails on pre-fix code (strict `getRuntimeConfig` throw propagates, browse command exits 1) and passes with the fix.
- `tsgo` core test-shard typecheck passed; `oxlint`/`oxfmt` clean; `git diff --check` passed.
- The final diff is 2 files, +49 −10 (src only +23 −10).

### Call-graph audit: best-effort config is reachable only from the four browse routes

Verifiable with `git grep` on head `0dcc76d54b`; every claim is one command away:

- `readBestEffortConfig` is imported once (`src/cli/skills-cli.ts:17`) and consumed exactly once, with `{ observe: false, skipPluginValidation: true }`: inside `resolveSkillsWorkspaceBestEffort` (`src/cli/skills-cli.ts:181-191`).
- `resolveSkillsWorkspaceBestEffort` has exactly one caller in the repo: `runSkillsAction` (`src/cli/skills-cli.ts:232`, call at `:237`), inside the `runCommandWithRuntime` wrapper.
- `runSkillsAction` has exactly four call sites, all browse commands: `src/cli/skills-cli.ts:1316` (`skills list`), `:1337` (`skills info`), `:1360` (`skills check`), `:1374` (bare `skills`) — precisely the four routes carrying `configGuard: "skip"` in the catalog.
- Every mutating command (`install`, `update`, `verify`) resolves config strictly through `resolveSkillsWorkspace` -> `getRuntimeConfig()`, reached via `resolveSkillsWorkspaceForCommand` (`:243`) and `resolveClawHubTargetWorkspace` (`:250`). None of them call `runSkillsAction` or `resolveSkillsWorkspaceBestEffort`.
- Repo-wide: `git grep -n "resolveSkillsWorkspaceBestEffort" -- "src/"` returns only the definition and the single `runSkillsAction` call site; `git grep -n "runSkillsAction" -- "src/"` returns only the definition and the four browse call sites above. No strict skills action can receive best-effort (partial) configuration.

### Real behavior proof (exact-head CLI with invalid config)

Ran the exact-head built CLI (`0dcc76d54b`, Node 24.19.0) against a deliberately invalid `openclaw.json` in an isolated `HOME`:

```json
// $HOME/.openclaw/openclaw.json
{
  "agents": { "defaults": { "workspace": "$HOME/.openclaw/workspace" } },
  "definitelyNotARealKey": true
}
```

The config is genuinely invalid — strict reads reject it on this head:

```
$ openclaw config get agents.defaults.workspace
OpenClaw config is invalid: ~/.openclaw/openclaw.json
- <root>: Unrecognized key: "definitelyNotARealKey"
Run `openclaw doctor --fix` to repair, then retry.
```

#### Browse commands work anyway (exit 0)

```
$ openclaw skills
Skills (21/57 ready)
┌───────────────┬──────────────────────────┬──────────────────────────────────────────────────────┬────────────────────┐
│ Status        │ Skill                    │ Description                                          │ Source             │
...

$ openclaw skills list
Skills (21/57 ready)
...

$ openclaw skills check
Skills Status Check
Agent: main

Total: 57
✓ Eligible: 21
✓ Visible to model: 21
✓ Available as command: 20
Disabled: 0

$ openclaw skills info 1password
🔐 1password △ Needs setup

Set up and use 1Password CLI for sign-in, desktop integration, and reading or injecting secrets.
...
```

Exit codes measured on the exact head:

```
openclaw skills                  -> exit=0
openclaw skills list             -> exit=0
openclaw skills check            -> exit=0
openclaw skills info 1password   -> exit=0
```

The mutating commands (`skills install`, `skills update`, `skills verify`) are untouched by this diff and keep the strict config path; the previous head's transcript showed all three blocked by the config guard with "OpenClaw config is invalid". (This build environment could not re-run them: the mutating routes load plugins, and this worktree's shared `node_modules` predates current `main`, so plugin loading fails with an unrelated stale-dependency error before the guard message is reached.)

This confirms the full CLI path:
- The four read-only browse commands (`skills`, `skills check`, `skills info`, `skills list`) produce normal output despite the invalid config.
- The state-changing/mutating commands (`skills install`, `skills update`, `skills verify`) remain on the strict config path, unchanged.

## Scope

- No config/schema/default changes; no command-catalog changes (current `main` already ships the skip policy for the browse routes).
- No plugin loading, network proxy, migration, or doctor behavior changes.
- `skills install`, `skills update`, and `skills verify` remain unchanged — they modify state or require plugin access.
- No changelog change.



Fixes #130569


## Exact-head proof (2026-08-27, head `82da54d5f06`)

Supersedes the earlier transcript (which predated the rebase). Built CLI (`node scripts/run-node.mjs`, Node v24.19.0) with `OPENCLAW_CONFIG_PATH=/tmp/skills-proof/invalid.json` containing `gateway.port: "not-a-number"` and an isolated `OPENCLAW_STATE_DIR`:

```
$ openclaw skills list
Skills (21/57 ready)
| Status        | Skill      | Description ... | Source |
| needs setup   | 1password  | Set up and use 1Password CLI ... | openclaw-bundled |
| ready         | add-model-provider | Add and live-prove a model provider ... | openclaw-custodian |
... (full 57-row table rendered, exit 0)

$ openclaw skills            # same table rendered
$ openclaw skills info weather
weather Ready — Current weather and forecasts with web_fetch ... Source: openclaw-bundled

$ openclaw skills check
Skills Status Check — Agent: main — Total: 57, Eligible: 21, Visible to model: 21

$ openclaw config get agents.defaults.workspace   # strict path must still fail
OpenClaw config is invalid: /tmp/skills-proof/invalid.json
- invalid.json:3 — gateway.port: Invalid input: expected number, received string
Run `openclaw doctor --fix` to repair, then retry.
```

All four browse commands render local skill metadata under the invalid config; the strict config path still reports the validation error.

Test-wiring fix in `82da54d5f06` (P2 finding): the configured-remote no-local-fallback table now feeds `readBestEffortConfigMock`, and the transport/credentials rows are fallback-eligible by error type, so fail-closed is proven for the right reason — with the wiring removed, the configured-remote transport rows fall back locally and fail (verified locally), with it all 147 tests pass.
