### PR TITLE
fix: allow unknown long flags as boolean in safeBin validator

### DIFF
--- a/src/infra/exec-safe-bin-policy-validator.ts
+++ b/src/infra/exec-safe-bin-policy-validator.ts
@@ -77,6 +77,21 @@ function consumeLongOptionToken(params: {
     longFlagPrefixMap: params.longFlagPrefixMap,
   });
   if (!canonicalFlag) {
+    // Allow unknown long flags as boolean when not explicitly denied.
+    // This lets tools without builtin profiles (git, gh, etc.) use --flags
+    // without needing every flag declared in safeBinProfiles.
+    if (
+      params.flag.startsWith("--") &&
+      params.flag.length > 2 &&
+      !params.deniedFlags.has(params.flag)
+    ) {
+      // Unknown flag with inline value: reject because we can't verify value safety.
+      if (params.inlineValue !== undefined) {
+        return -1;
+      }
+      // Unknown flag without value: treat as boolean.
+      return params.index + 1;
+    }
     return -1;
   }
   if (params.deniedFlags.has(canonicalFlag)) {
@@ -109,6 +124,7 @@ function consumeShortOptionClusterToken(params: {
       return -1;
     }
     if (!params.allowedValueFlags.has(flag)) {
+      // Unknown short flag: treat as boolean (not a value flag).
       continue;
     }
     const inlineValue = params.cluster.slice(j + 1);
@@ -117,7 +133,8 @@ function consumeShortOptionClusterToken(params: {
     }
     return isInvalidValueToken(params.args[params.index + 1]) ? -1 : params.index + 2;
   }
-  return -1;
+  // All flags processed successfully (all booleans or value flags consumed).
+  return params.index + 1;
 }
 
 function consumePositionalToken(token: string, positional: string[]): boolean {


### PR DESCRIPTION
## Problem

The safeBin allowlist validator rejected any `--flag` not explicitly declared in the profile's `knownLongFlagsSet`. This made `allowlist` mode non-functional for tools without builtin profiles (git, gh, etc.) because every flag (`--force`, `--no-edit`, `--amend`, etc.) was rejected.

## Root Cause

In `consumeLongOptionToken`, when `resolveCanonicalLongFlag` couldn't find the flag in the profile's known set, it returned -1 (reject). There was no fallback to treat unknown `--` flags as booleans.

Additionally, `consumeShortOptionClusterToken` had a bug where a cluster of only boolean short flags (e.g. `-abc`) was rejected because the loop continued past all flags without ever returning success — it fell through to `return -1`.

## Fix

Two changes in `src/infra/exec-safe-bin-policy-validator.ts`:

### 1. `consumeLongOptionToken` — allow unknown `--` flags as boolean

When a `--flag` isn't in the profile's known set:
- If the flag starts with `--` and has length > 2
- And it's not in `deniedFlags`
- And it doesn't have an inline value (`--flag=value`)

Then treat it as a boolean flag (return `index + 1`).

Unknown flags with inline values are still rejected because we can't verify the value is safe without a profile declaring the flag expects a value.

### 2. `consumeShortOptionClusterToken` — fix all-boolean cluster rejection

Changed the final `return -1` to `return params.index + 1`. After the loop completes, all flags were either consumed as value flags or continued as booleans — this is success, not failure.

## Security Model Preserved

- Denied flags are still rejected (both long and short)
- Unknown flags with inline values (`--flag=value`) are rejected (can't verify value safety)
- Shell metacharacters and globs are still caught by `isSafeLiteralToken`
- Path-like tokens are still caught
- Only exact `--long-flags` without values are allowed as booleans

## Impact

This unblocks agents using `tools.exec.mode: "allowlist"` with tools like `git` and `gh` that have many flags. Previously, users had to either:
1. Declare every flag in `safeBinProfiles` (tedious, brittle)
2. Use `security: "full"` (bypasses the allowlist entirely)

With this fix, unknown `--long-flags` are accepted as booleans, so agents can use `git commit --force`, `gh pr create --draft`, etc. without profile declarations.