### PR TITLE
fix(subagents): forward requested model to worker run

### DIFF
--- a/src/agents/subagent-spawn.model-session.test.ts
+++ b/src/agents/subagent-spawn.model-session.test.ts
@@ -95,5 +95,9 @@ describe("spawnSubagentDirect runtime model persistence", () => {
     expect(operations.indexOf("gateway:agent")).toBeGreaterThan(
       operations.lastIndexOf("store:update"),
     );
+    const agentCall = callGatewayMock.mock.calls.find(
+      ([request]) => (request as { method?: string }).method === "agent",
+    )?.[0] as { params?: Record<string, unknown> } | undefined;
+    expect(agentCall?.params?.model).toBe("openai-codex/gpt-5.4");
   });
 });

--- a/src/agents/subagent-spawn.test.ts
+++ b/src/agents/subagent-spawn.test.ts
@@ -249,6 +249,7 @@ describe("spawnSubagentDirect seam flow", () => {
         method: "agent",
         params: expect.objectContaining({
           sessionKey: childSessionKey,
+          model: "openai-codex/gpt-5.4",
           cleanupBundleMcpOnRunEnd: true,
         }),
       }),

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -1068,6 +1068,7 @@ export async function spawnSubagentDirect(
         lane: AGENT_LANE_SUBAGENT,
         cleanupBundleMcpOnRunEnd: spawnMode !== "session",
         extraSystemPrompt: childSystemPrompt,
+        model: resolvedModel,
         thinking: thinkingOverride,
         timeout: runTimeoutSeconds,
         label: label || undefined,

--- a/src/cron/isolated-agent/run.message-tool-policy.test.ts
+++ b/src/cron/isolated-agent/run.message-tool-policy.test.ts
@@ -690,7 +690,7 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
     );
   });
 
-  it("does not mark message tool delivery as matched when cron target resolution failed", async () => {
+  it("fails required announce delivery preflight before model execution when target resolution failed", async () => {
     mockRunCronFallbackPassthrough();
     resolveCronDeliveryPlanMock.mockReturnValue({
       requested: true,
@@ -706,31 +706,30 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
       mode: "implicit",
       error: new Error("sessionKey is required to resolve delivery.channel=last"),
     });
-    runEmbeddedPiAgentMock.mockResolvedValue(
-      makeMessageToolRunResult([{ tool: "message", provider: "messagechat", to: "123" }]),
-    );
 
     const result = await runCronIsolatedAgentTurn(makeParams());
 
-    expect(dispatchCronDeliveryMock).toHaveBeenCalledTimes(1);
-    expect(dispatchCronDeliveryMock.mock.calls[0]?.[0]).toEqual(
-      expect.objectContaining({
-        deliveryRequested: true,
-        skipMessagingToolDelivery: false,
-        unverifiedMessagingToolDelivery: true,
-      }),
-    );
+    expect(runEmbeddedPiAgentMock).not.toHaveBeenCalled();
+    expect(dispatchCronDeliveryMock).not.toHaveBeenCalled();
+    expect(result.status).toBe("error");
+    expect(result.errorKind).toBe("delivery-target");
+    expect(result.error).toBe("sessionKey is required to resolve delivery.channel=last");
+    expect(result.deliveryAttempted).toBe(false);
     expect(result.delivery).toEqual(
       expect.objectContaining({
         intended: { channel: "last", to: null, source: "last" },
+        fallbackUsed: false,
+        delivered: false,
         resolved: expect.objectContaining({
           ok: false,
           source: "last",
           error: "sessionKey is required to resolve delivery.channel=last",
         }),
-        messageToolSentTo: [{ channel: "messagechat", to: "123" }],
-        fallbackUsed: false,
-        delivered: false,
+      }),
+    );
+    expect(result.delivery).not.toEqual(
+      expect.objectContaining({
+        messageToolSentTo: expect.any(Array),
       }),
     );
   });
@@ -856,6 +855,38 @@ describe("runCronIsolatedAgentTurn delivery instruction", () => {
     expect(prompt).toContain("Use the message tool");
     expect(prompt).toContain("will be delivered automatically");
     expect(prompt).not.toContain("note who/where");
+  });
+
+  it("keeps generic explicit-target guidance when best-effort delivery resolution fails", async () => {
+    mockRunCronFallbackPassthrough();
+    resolveCronDeliveryPlanMock.mockReturnValue({
+      requested: true,
+      mode: "announce",
+      channel: "messagechat",
+      to: "missing",
+    });
+    resolveDeliveryTargetMock.mockResolvedValue({
+      ok: false,
+      channel: "messagechat",
+      to: undefined,
+      accountId: undefined,
+      error: new Error("target not found"),
+    });
+
+    await runCronIsolatedAgentTurn({
+      ...makeParams(),
+      job: makeMessageToolPolicyJob({
+        mode: "announce",
+        channel: "messagechat",
+        to: "missing",
+        bestEffort: true,
+      }),
+    });
+
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+    const prompt: string = runEmbeddedPiAgentMock.mock.calls[0]?.[0]?.prompt ?? "";
+    expect(prompt).toContain("with an explicit target");
+    expect(prompt).not.toContain('with channel="messagechat"');
   });
 
   it("does not prompt for the message tool when toolsAllow excludes it", async () => {

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -612,6 +612,29 @@ async function prepareCronRunContext(params: {
       job: input.job,
       agentId,
     });
+  if (deliveryRequested && !resolvedDelivery.ok && input.job.delivery?.bestEffort !== true) {
+    const error = resolvedDelivery.error.message;
+    const { matchesMessagingToolDeliveryTarget } = await loadCronDeliveryRuntime();
+    return {
+      ok: false,
+      result: withRunSession({
+        status: "error",
+        error,
+        errorKind: "delivery-target",
+        deliveryAttempted: false,
+        delivery: buildCronDeliveryTrace({
+          deliveryPlan,
+          resolvedDelivery,
+          messagingToolSentTargets: [],
+          matchesMessagingToolDeliveryTarget,
+          fallbackUsed: false,
+          delivered: false,
+        }),
+        provider,
+        model,
+      }),
+    };
+  }
 
   const { formattedTime, timeLine } = resolveCronStyleNow(input.cfg, now);
   const base = `[cron:${input.job.id} ${input.job.name}] ${input.message}`.trim();


### PR DESCRIPTION
## What
Forwards the resolved subagent model into the gateway `agent` call.

## Why
Subagent session persistence alone did not guarantee the requested model reached the worker runtime.

## Testing
- `corepack pnpm exec vitest run src/agents/subagent-spawn.test.ts src/agents/subagent-spawn.model-session.test.ts --reporter=dot`
- `git diff --check`

## Follow-up
Independent review must verify a spawned worker trajectory records the requested runtime provider/model before any activation.
