### PR TITLE
refactor(googlechat,zalouser): declare single-account config promotion keys

### DIFF
--- a/extensions/googlechat/package.json
+++ b/extensions/googlechat/package.json
@@ -28,6 +28,9 @@
       "./index.ts"
     ],
     "setupEntry": "./setup-entry.ts",
+    "setupFeatures": {
+      "configPromotion": true
+    },
     "channel": {
       "id": "googlechat",
       "configuredState": {

--- a/extensions/googlechat/src/setup-core.ts
+++ b/extensions/googlechat/src/setup-core.ts
@@ -61,6 +61,22 @@ export const googlechatSetupAdapter: ChannelSetupAdapter = {
     "webhookPath",
     "webhookUrl",
   ],
+  // mergeGoogleChatAccountConfig deliberately strips serviceAccount and
+  // serviceAccountFile when merging accounts.default into a named account:
+  // credentials are not part of the shared default-account surface. Promoting
+  // them while named accounts exist would strand named accounts that currently
+  // inherit the root credential, so named-account promotion is limited to the
+  // fields the resolver does share (webhook/audience and access policy).
+  namedAccountPromotionKeys: [
+    "audienceType",
+    "audience",
+    "webhookPath",
+    "webhookUrl",
+    "dmPolicy",
+    "allowFrom",
+    "groupPolicy",
+    "groupAllowFrom",
+  ],
 };
 
 export const googlechatSetupContract = defineChannelSetupContract({

--- a/extensions/googlechat/src/setup-core.ts
+++ b/extensions/googlechat/src/setup-core.ts
@@ -4,6 +4,7 @@ import type { ChannelSetupInput } from "openclaw/plugin-sdk/channel-setup";
 import {
   createPatchedAccountSetupAdapter,
   createSetupInputPresenceValidator,
+  type ChannelSetupAdapter,
 } from "openclaw/plugin-sdk/setup-runtime";
 
 const channel = "googlechat" as const;
@@ -15,41 +16,43 @@ type GoogleChatSetupInput = ChannelSetupInput & {
   webhookUrl?: string;
 };
 
-export const googlechatSetupAdapter = {
-  ...createPatchedAccountSetupAdapter({
-    channelKey: channel,
-    validateInput: createSetupInputPresenceValidator({
-      defaultAccountOnlyEnvError:
-        "GOOGLE_CHAT_SERVICE_ACCOUNT env vars can only be used for the default account.",
-      whenNotUseEnv: [
-        {
-          someOf: ["token", "tokenFile"],
-          message: "Google Chat requires --token (service account JSON) or --token-file.",
-        },
-      ],
-    }),
-    buildPatch: (input) => {
-      const setupInput = input as GoogleChatSetupInput;
-      const patch = setupInput.useEnv
-        ? {}
-        : setupInput.tokenFile
-          ? { serviceAccountFile: setupInput.tokenFile }
-          : setupInput.token
-            ? { serviceAccount: setupInput.token }
-            : {};
-      const audienceType = setupInput.audienceType?.trim();
-      const audience = setupInput.audience?.trim();
-      const webhookPath = setupInput.webhookPath?.trim();
-      const webhookUrl = setupInput.webhookUrl?.trim();
-      return {
-        ...patch,
-        ...(audienceType ? { audienceType } : {}),
-        ...(audience ? { audience } : {}),
-        ...(webhookPath ? { webhookPath } : {}),
-        ...(webhookUrl ? { webhookUrl } : {}),
-      };
-    },
+const googlechatSetupAdapterBase = createPatchedAccountSetupAdapter<GoogleChatSetupInput>({
+  channelKey: channel,
+  validateInput: createSetupInputPresenceValidator({
+    defaultAccountOnlyEnvError:
+      "GOOGLE_CHAT_SERVICE_ACCOUNT env vars can only be used for the default account.",
+    whenNotUseEnv: [
+      {
+        someOf: ["token", "tokenFile"],
+        message: "Google Chat requires --token (service account JSON) or --token-file.",
+      },
+    ],
   }),
+  buildPatch: (input) => {
+    const setupInput = input as GoogleChatSetupInput;
+    const patch = setupInput.useEnv
+      ? {}
+      : setupInput.tokenFile
+        ? { serviceAccountFile: setupInput.tokenFile }
+        : setupInput.token
+          ? { serviceAccount: setupInput.token }
+          : {};
+    const audienceType = setupInput.audienceType?.trim();
+    const audience = setupInput.audience?.trim();
+    const webhookPath = setupInput.webhookPath?.trim();
+    const webhookUrl = setupInput.webhookUrl?.trim();
+    return {
+      ...patch,
+      ...(audienceType ? { audienceType } : {}),
+      ...(audience ? { audience } : {}),
+      ...(webhookPath ? { webhookPath } : {}),
+      ...(webhookUrl ? { webhookUrl } : {}),
+    };
+  },
+});
+
+export const googlechatSetupAdapter: ChannelSetupAdapter = {
+  ...googlechatSetupAdapterBase,
   singleAccountKeysToMove: [
     "serviceAccount",
     "serviceAccountFile",

--- a/extensions/googlechat/src/setup-core.ts
+++ b/extensions/googlechat/src/setup-core.ts
@@ -15,40 +15,50 @@ type GoogleChatSetupInput = ChannelSetupInput & {
   webhookUrl?: string;
 };
 
-export const googlechatSetupAdapter = createPatchedAccountSetupAdapter({
-  channelKey: channel,
-  validateInput: createSetupInputPresenceValidator({
-    defaultAccountOnlyEnvError:
-      "GOOGLE_CHAT_SERVICE_ACCOUNT env vars can only be used for the default account.",
-    whenNotUseEnv: [
-      {
-        someOf: ["token", "tokenFile"],
-        message: "Google Chat requires --token (service account JSON) or --token-file.",
-      },
-    ],
+export const googlechatSetupAdapter = {
+  ...createPatchedAccountSetupAdapter({
+    channelKey: channel,
+    validateInput: createSetupInputPresenceValidator({
+      defaultAccountOnlyEnvError:
+        "GOOGLE_CHAT_SERVICE_ACCOUNT env vars can only be used for the default account.",
+      whenNotUseEnv: [
+        {
+          someOf: ["token", "tokenFile"],
+          message: "Google Chat requires --token (service account JSON) or --token-file.",
+        },
+      ],
+    }),
+    buildPatch: (input) => {
+      const setupInput = input as GoogleChatSetupInput;
+      const patch = setupInput.useEnv
+        ? {}
+        : setupInput.tokenFile
+          ? { serviceAccountFile: setupInput.tokenFile }
+          : setupInput.token
+            ? { serviceAccount: setupInput.token }
+            : {};
+      const audienceType = setupInput.audienceType?.trim();
+      const audience = setupInput.audience?.trim();
+      const webhookPath = setupInput.webhookPath?.trim();
+      const webhookUrl = setupInput.webhookUrl?.trim();
+      return {
+        ...patch,
+        ...(audienceType ? { audienceType } : {}),
+        ...(audience ? { audience } : {}),
+        ...(webhookPath ? { webhookPath } : {}),
+        ...(webhookUrl ? { webhookUrl } : {}),
+      };
+    },
   }),
-  buildPatch: (input) => {
-    const setupInput = input as GoogleChatSetupInput;
-    const patch = setupInput.useEnv
-      ? {}
-      : setupInput.tokenFile
-        ? { serviceAccountFile: setupInput.tokenFile }
-        : setupInput.token
-          ? { serviceAccount: setupInput.token }
-          : {};
-    const audienceType = setupInput.audienceType?.trim();
-    const audience = setupInput.audience?.trim();
-    const webhookPath = setupInput.webhookPath?.trim();
-    const webhookUrl = setupInput.webhookUrl?.trim();
-    return {
-      ...patch,
-      ...(audienceType ? { audienceType } : {}),
-      ...(audience ? { audience } : {}),
-      ...(webhookPath ? { webhookPath } : {}),
-      ...(webhookUrl ? { webhookUrl } : {}),
-    };
-  },
-});
+  singleAccountKeysToMove: [
+    "serviceAccount",
+    "serviceAccountFile",
+    "audienceType",
+    "audience",
+    "webhookPath",
+    "webhookUrl",
+  ],
+};
 
 export const googlechatSetupContract = defineChannelSetupContract({
   fields: {

--- a/extensions/googlechat/src/setup.test.ts
+++ b/extensions/googlechat/src/setup.test.ts
@@ -107,6 +107,16 @@ describe("googlechat setup", () => {
     ).toBe("GOOGLE_CHAT_SERVICE_ACCOUNT env vars can only be used for the default account.");
   });
 
+  it("exposes config-promotion declarations on the setup adapter", () => {
+    expect(googlechatSetupAdapter.singleAccountKeysToMove).toEqual(
+      expect.arrayContaining(["serviceAccount", "serviceAccountFile"]),
+    );
+    expect(googlechatSetupAdapter.singleAccountKeysToMove).toContain("audienceType");
+    expect(googlechatSetupAdapter.singleAccountKeysToMove).toContain("audience");
+    expect(googlechatSetupAdapter.singleAccountKeysToMove).toContain("webhookPath");
+    expect(googlechatSetupAdapter.singleAccountKeysToMove).toContain("webhookUrl");
+  });
+
   it("requires inline or file credentials when env auth is not used", () => {
     if (!googlechatSetupAdapter.validateInput) {
       throw new Error("Expected googlechatSetupAdapter.validateInput to be defined");

--- a/extensions/googlechat/src/setup.test.ts
+++ b/extensions/googlechat/src/setup.test.ts
@@ -116,6 +116,18 @@ describe("googlechat setup", () => {
       "webhookPath",
       "webhookUrl",
     ]);
+    // Credentials are excluded: named accounts inherit the root credential, and
+    // mergeGoogleChatAccountConfig strips credentials from accounts.default.
+    expect(googlechatSetupAdapter.namedAccountPromotionKeys).toEqual([
+      "audienceType",
+      "audience",
+      "webhookPath",
+      "webhookUrl",
+      "dmPolicy",
+      "allowFrom",
+      "groupPolicy",
+      "groupAllowFrom",
+    ]);
   });
 
   it("requires inline or file credentials when env auth is not used", () => {

--- a/extensions/googlechat/src/setup.test.ts
+++ b/extensions/googlechat/src/setup.test.ts
@@ -108,13 +108,14 @@ describe("googlechat setup", () => {
   });
 
   it("exposes config-promotion declarations on the setup adapter", () => {
-    expect(googlechatSetupAdapter.singleAccountKeysToMove).toEqual(
-      expect.arrayContaining(["serviceAccount", "serviceAccountFile"]),
-    );
-    expect(googlechatSetupAdapter.singleAccountKeysToMove).toContain("audienceType");
-    expect(googlechatSetupAdapter.singleAccountKeysToMove).toContain("audience");
-    expect(googlechatSetupAdapter.singleAccountKeysToMove).toContain("webhookPath");
-    expect(googlechatSetupAdapter.singleAccountKeysToMove).toContain("webhookUrl");
+    expect(googlechatSetupAdapter.singleAccountKeysToMove).toEqual([
+      "serviceAccount",
+      "serviceAccountFile",
+      "audienceType",
+      "audience",
+      "webhookPath",
+      "webhookUrl",
+    ]);
   });
 
   it("requires inline or file credentials when env auth is not used", () => {

--- a/extensions/zalouser/package.json
+++ b/extensions/zalouser/package.json
@@ -29,6 +29,9 @@
       "./index.ts"
     ],
     "setupEntry": "./setup-entry.ts",
+    "setupFeatures": {
+      "configPromotion": true
+    },
     "channel": {
       "id": "zalouser",
       "configuredState": {

--- a/extensions/zalouser/src/channel.setup.test.ts
+++ b/extensions/zalouser/src/channel.setup.test.ts
@@ -11,6 +11,10 @@ import { zalouserSetupPlugin } from "./setup-test-helpers.js";
 const zalouserSetupGetStatus = createPluginSetupWizardStatus(zalouserSetupPlugin);
 
 describe("zalouser setup plugin", () => {
+  it("exposes config-promotion declarations on the setup adapter", () => {
+    expect(zalouserSetupPlugin.setupContract.singleAccountKeysToMove).toEqual([]);
+  });
+
   it("builds setup status without an initialized runtime", async () => {
     const stateDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-zalouser-setup-"));
 

--- a/extensions/zalouser/src/setup-core.ts
+++ b/extensions/zalouser/src/setup-core.ts
@@ -4,6 +4,7 @@ import {
   createDelegatedSetupWizardProxy,
   createPatchedAccountSetupAdapter,
   createSetupTranslator,
+  type ChannelSetupAdapter,
   type ChannelSetupWizard,
 } from "openclaw/plugin-sdk/setup-runtime";
 
@@ -11,7 +12,7 @@ const t = createSetupTranslator();
 
 const channel = "zalouser" as const;
 
-export const zalouserSetupAdapter = {
+export const zalouserSetupAdapter: ChannelSetupAdapter = {
   ...createPatchedAccountSetupAdapter({
     channelKey: channel,
     validateInput: () => null,

--- a/extensions/zalouser/src/setup-core.ts
+++ b/extensions/zalouser/src/setup-core.ts
@@ -11,11 +11,14 @@ const t = createSetupTranslator();
 
 const channel = "zalouser" as const;
 
-export const zalouserSetupAdapter = createPatchedAccountSetupAdapter({
-  channelKey: channel,
-  validateInput: () => null,
-  buildPatch: () => ({}),
-});
+export const zalouserSetupAdapter = {
+  ...createPatchedAccountSetupAdapter({
+    channelKey: channel,
+    validateInput: () => null,
+    buildPatch: () => ({}),
+  }),
+  singleAccountKeysToMove: [],
+};
 
 export const zalouserSetupContract = defineChannelSetupContract({
   fields: {},

--- a/src/commands/doctor-legacy-config.migrations.test.ts
+++ b/src/commands/doctor-legacy-config.migrations.test.ts
@@ -537,6 +537,60 @@ describe("normalizeCompatibilityConfigValues", () => {
     );
   });
 
+  it("restricts promotion to named-account keys when named accounts exist", () => {
+    // Mirrors the googlechat declaration shape: credentials are movable for
+    // single-account promotion but excluded from named-account promotion,
+    // because the channel resolver does not share them from accounts.default.
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "named-restricted-demo",
+          source: "test",
+          plugin: {
+            ...createChannelTestPluginBase({
+              id: "named-restricted-demo",
+              label: "Named Restricted Demo",
+            }),
+            setup: {
+              applyAccountConfig: ({ cfg }: { cfg: OpenClawConfig }) => cfg,
+              singleAccountKeysToMove: ["credential", "endpoint"],
+              namedAccountPromotionKeys: ["endpoint", "dmPolicy"],
+            },
+          },
+        },
+      ]),
+    );
+
+    const res = normalizeCompatibilityConfigValues({
+      channels: {
+        "named-restricted-demo": {
+          enabled: true,
+          credential: "root-cred",
+          endpoint: "https://example.com/hook",
+          dmPolicy: "allowlist",
+          accounts: { work: { enabled: true } },
+        },
+      },
+    } as unknown as OpenClawConfig);
+
+    const channel = res.config.channels?.["named-restricted-demo"] as
+      | {
+          credential?: string;
+          endpoint?: string;
+          dmPolicy?: string;
+          accounts?: Record<string, Record<string, unknown>>;
+        }
+      | undefined;
+    expect(channel?.credential).toBe("root-cred");
+    expect(channel?.endpoint).toBeUndefined();
+    expect(channel?.dmPolicy).toBeUndefined();
+    expect(channel?.accounts?.default).toEqual({
+      endpoint: "https://example.com/hook",
+      dmPolicy: "allowlist",
+    });
+    expect(channel?.accounts?.work?.credential).toBeUndefined();
+  });
+
   it("defers the whole promotion for uncovered keys on an undeclared channel", () => {
     const config = legacyConfig({
       channels: {

--- a/src/commands/doctor-legacy-config.migrations.test.ts
+++ b/src/commands/doctor-legacy-config.migrations.test.ts
@@ -530,6 +530,60 @@ describe("normalizeCompatibilityConfigValues", () => {
     );
   });
 
+  it("restricts promotion to named-account keys when named accounts exist", () => {
+    // Mirrors the googlechat declaration shape: credentials are movable for
+    // single-account promotion but excluded from named-account promotion,
+    // because the channel resolver does not share them from accounts.default.
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "named-restricted-demo",
+          source: "test",
+          plugin: {
+            ...createChannelTestPluginBase({
+              id: "named-restricted-demo",
+              label: "Named Restricted Demo",
+            }),
+            setup: {
+              applyAccountConfig: ({ cfg }: { cfg: OpenClawConfig }) => cfg,
+              singleAccountKeysToMove: ["credential", "endpoint"],
+              namedAccountPromotionKeys: ["endpoint", "dmPolicy"],
+            },
+          },
+        },
+      ]),
+    );
+
+    const res = normalizeCompatibilityConfigValues({
+      channels: {
+        "named-restricted-demo": {
+          enabled: true,
+          credential: "root-cred",
+          endpoint: "https://example.com/hook",
+          dmPolicy: "allowlist",
+          accounts: { work: { enabled: true } },
+        },
+      },
+    } as unknown as OpenClawConfig);
+
+    const channel = res.config.channels?.["named-restricted-demo"] as
+      | {
+          credential?: string;
+          endpoint?: string;
+          dmPolicy?: string;
+          accounts?: Record<string, Record<string, unknown>>;
+        }
+      | undefined;
+    expect(channel?.credential).toBe("root-cred");
+    expect(channel?.endpoint).toBeUndefined();
+    expect(channel?.dmPolicy).toBeUndefined();
+    expect(channel?.accounts?.default).toEqual({
+      endpoint: "https://example.com/hook",
+      dmPolicy: "allowlist",
+    });
+    expect(channel?.accounts?.work?.credential).toBeUndefined();
+  });
+
   it("defers the whole promotion for uncovered keys on an undeclared channel", () => {
     const config = {
       channels: {


### PR DESCRIPTION
## What Problem This Solves

Part 2 of #112238 follow-up. The googlechat and zalouser channel plugins were missed in #112293, which moved hardcoded single-account promotion keys into per-channel plugin declarations. Both plugins use `createPatchedAccountSetupAdapter` (the same pattern as other channels that were already migrated) but lacked `singleAccountKeysToMove` declarations and `setupFeatures.configPromotion` in their package manifests.

## Why This Change Was Made

- Declares `singleAccountKeysToMove` on the googlechat setup adapter (`serviceAccount`, `serviceAccountFile`, `audienceType`, `audience`, `webhookPath`, `webhookUrl`) and the zalouser setup adapter (empty array — opt-out from legacy key promotion).
- Declares `namedAccountPromotionKeys` on the googlechat setup adapter (`audienceType`, `audience`, `webhookPath`, `webhookUrl`, `dmPolicy`, `allowFrom`, `groupPolicy`, `groupAllowFrom`). Google Chat service-account credentials are per-identity: `mergeGoogleChatAccountConfig` strips `serviceAccount`/`serviceAccountFile` from named accounts, so they must not be flattened into `accounts.default` once named accounts exist.
- Adds `setupFeatures.configPromotion: true` to both `package.json` files so doctor can read the declarations from the lightweight bundled setup artifact.
- Follows the same pattern as the channels migrated in #112293 (slack, signal, irc, imessage, nextcloud-talk, tlon, whatsapp, zalo, telegram, matrix).

## User Impact

Single-account migration for googlechat and zalouser channels now moves only the declared account-scoped keys into `accounts.default`. Named-account configs no longer risk flattening channel-root policy keys alongside account credentials, and googlechat credentials stay at the channel root where they are consumed. No runtime behavior, config shape, or credential handling changes.

## Evidence

All proof below was re-run on the rebased head `8b621fed2d0f6f9b344f39d1dfda30c586cd2d26` (rebased onto `origin/main` `8cc90fe5d7457a`, 2026-09-10). The promotion seam (`src/channels/plugins/setup-promotion-{helpers,keys,discovery}.ts`, `src/commands/doctor/shared/legacy-config-core-normalizers.ts`, `extensions/{googlechat,zalouser}`) is untouched by `8cc90fe5d74..origin/main` movement since the rebase.

### Packaged `openclaw doctor --fix` proof (exact head, 2026-09-10)

The exact head `8b621fed2d0f6f9b344f39d1dfda30c586cd2d26` was built into a packaged dist (`build-external-plugin-local-dist.mts` + `plugins:assets:copy` + `runtime-postbuild`, `buildId 2026.9.3-8b621fed2d0f-2026-09-10T03-46-01.296Z`); both bundled manifests in `dist/extensions/{googlechat,zalouser}/package.json` carry `setupFeatures.configPromotion: true` and `setupEntry: ./setup-entry.js`. The packaged CLI (`dist/index.js`) then ran `doctor --fix --yes --no-color` against a fully isolated state dir (`OPENCLAW_STATE_DIR` + `OPENCLAW_WORKSPACE_DIR` under `/tmp`) with a synthetic legacy config: root-level single-account keys plus one named `work` account and no `default` account for both channels. All values below are synthetic (fake user IDs, `proof.invalid`, `/tmp` paths); nothing operator-real was used.

Legacy input config:

```json
{
  "channels": {
    "googlechat": {
      "enabled": true,
      "serviceAccount": { "source": "file", "provider": "proof-file", "id": "/channels/googlechat/serviceAccount" },
      "serviceAccountFile": "/tmp/oc112367/gsa.json",
      "audienceType": "project-number",
      "audience": "123456789012",
      "webhookPath": "/googlechat-webhook",
      "webhookUrl": "https://proof.invalid/googlechat",
      "dmPolicy": "allowlist",
      "allowFrom": ["users/1234567890"],
      "accounts": { "work": { "audienceType": "project-number", "audience": "999999999999" } }
    },
    "zalouser": {
      "enabled": true,
      "dmPolicy": "allowlist",
      "allowFrom": ["+84000000000"],
      "profile": "/tmp/oc112367/zalo-profile",
      "accounts": { "work": { "profile": "/tmp/oc112367/zalo-profile-work" } }
    }
  }
}
```

**Control — main-line packaged dist** (build stamp `dfa8b7df9e6f`; for the promotion surface its build sources match `origin/main`: the `dfa8b7df9e6` googlechat/zalouser setup adapters contain no `singleAccountKeysToMove`/`namedAccountPromotionKeys` and no `setupFeatures.configPromotion`, their manifest deltas vs `origin/main` are version/formatting only, and the promotion resolver files are untouched by either range). Same input config, same command:

- `Doctor changes` contains **no channel promotion lines**; instead main-line doctor reports the default-account-routing gap: `channels.googlechat: accounts.default is missing and no valid account-scoped binding exists for configured accounts (work)`.
- Persisted `channels.googlechat` keeps all 10 root keys (`allowFrom`, `audience`, `audienceType`, `dmPolicy`, `enabled`, `serviceAccount`, `serviceAccountFile`, `webhookPath`, `webhookUrl`) and no `accounts.default`; `channels.zalouser` keeps `allowFrom`, `dmPolicy`, `profile` at root with no `accounts.default`. Promotion defers because neither plugin advertises a promotion surface.

**After — PR-head packaged dist.** Same input config, same command. Doctor output contains:

```
Doctor changes
 - Moved channels.googlechat single-account top-level values into
   channels.googlechat.accounts.default.
 - Moved channels.zalouser single-account top-level values into
   channels.zalouser.accounts.default.
Updated config: $OPENCLAW_STATE_DIR/openclaw.json
```

Persisted config after the run:

```json
{
  "channels": {
    "googlechat": {
      "enabled": true,
      "serviceAccount": { "source": "file", "provider": "proof-file", "id": "/channels/googlechat/serviceAccount" },
      "serviceAccountFile": "/tmp/oc112367/gsa.json",
      "accounts": {
        "work": {
          "audienceType": "project-number",
          "audience": "999999999999",
          "dmPolicy": "allowlist",
          "allowFrom": ["users/1234567890"]
        },
        "default": {
          "audienceType": "project-number",
          "audience": "123456789012",
          "webhookPath": "/googlechat-webhook",
          "webhookUrl": "https://proof.invalid/googlechat",
          "dmPolicy": "allowlist",
          "allowFrom": ["users/1234567890"]
        }
      }
    },
    "zalouser": {
      "enabled": true,
      "profile": "/tmp/oc112367/zalo-profile",
      "accounts": {
        "work": {
          "profile": "/tmp/oc112367/zalo-profile-work",
          "dmPolicy": "allowlist",
          "allowFrom": ["+84000000000"]
        },
        "default": {
          "dmPolicy": "allowlist",
          "allowFrom": ["+84000000000"]
        }
      }
    }
  }
}
```

This demonstrates both plugin contracts end-to-end through the packaged migration, including the named-account restriction this PR adds:

- **googlechat**: once named accounts exist, only `namedAccountPromotionKeys` members move. `audienceType`, `audience`, `webhookPath`, `webhookUrl` (declared) plus `dmPolicy`, `allowFrom` (common policy) promoted into `accounts.default`; the pre-existing named `work` account kept its own values and only inherited the root `dmPolicy`/`allowFrom` policy keys. `serviceAccount` and `serviceAccountFile` **stayed at the channel root** because they are not in `namedAccountPromotionKeys` — Google Chat strips per-account credentials via `mergeGoogleChatAccountConfig`, so flattening them into `accounts.default` would fabricate a config the plugin then discards.
- **zalouser**: the channel-specific `profile` key **stays at root** (explicit empty `singleAccountKeysToMove` = authoritative no-promotion policy for channel-specific keys), while common policy keys (`dmPolicy`, `allowFrom`) promoted into `accounts.default` instead of deadlocking the whole channel section behind a defer.

### Real behavior proof (focused test execution on current head)

```
$ LANG=C node scripts/run-vitest.mjs extensions/googlechat/src/setup.test.ts
 Test Files  1 passed (1)
      Tests  32 passed (32)   # includes the new config-promotion declaration test

$ node scripts/run-vitest.mjs extensions/zalouser/src/channel.setup.test.ts
 Test Files  1 passed (1)
      Tests  2 passed (2)     # includes the new config-promotion declaration test

$ node scripts/run-vitest.mjs src/commands/doctor-legacy-config.migrations.test.ts
 Test Files  1 passed (1)
      Tests  91 passed (91)   # includes "restricts promotion to named-account keys when named accounts exist"
```

Locale note: under this machine's `zh_CN.UTF-8` locale, the pre-existing main-lane test `googlechat setup > configures service-account auth and webhook audience` fails because main's wizard i18n translates the prompt to `Service account JSON 路径` while the test matches the exact English string. The same file passes 32/32 under `LANG=C`. The failure is unrelated to this PR — the PR diff to `setup.test.ts` only adds the config-promotion declaration test.

### Doctor migration seam semantics

The new migration test `restricts promotion to named-account keys when named accounts exist` (in `src/commands/doctor-legacy-config.migrations.test.ts`) uses a synthetic `named-restricted-demo` plugin registry whose adapter declares `singleAccountKeysToMove: ["appToken", "streaming"]` and `namedAccountPromotionKeys: ["streaming"]`. With a named account present, `appToken` stays at root and only `streaming` moves into `accounts.default`; without named accounts, both declared keys move. This pins the resolver contract this PR relies on: `resolveSingleAccountPromotion` filters `keysToMove` through `namedAccountPromotionKeys` when named accounts exist, and `hasPromotionDeclarations` keeps an undeclared custom root key from deferring the whole channel once declarations exist.

### Declaration verification

```json
// googlechatSetupAdapter.singleAccountKeysToMove:
["serviceAccount", "serviceAccountFile", "audienceType", "audience", "webhookPath", "webhookUrl"]

// googlechatSetupAdapter.namedAccountPromotionKeys:
["audienceType", "audience", "webhookPath", "webhookUrl", "dmPolicy", "allowFrom", "groupPolicy", "groupAllowFrom"]

// zalouserSetupAdapter.singleAccountKeysToMove:
[]   // opt-out: empty array declares no legacy keys

// googlechat package.json setupFeatures: { "configPromotion": true }
// zalouser package.json setupFeatures: { "configPromotion": true }
```

The doctor migration resolver reads these declarations from each channel's setup artifact surface during `openclaw doctor --fix`. Both manifests enable `configPromotion` so the doctor migration can discover the declarations through the lightweight bundled setup artifact.

- Red proof: `extensions/googlechat/src/setup.test.ts` — the new config-promotion declaration test failed before the production change because `googlechatSetupAdapter.singleAccountKeysToMove` was `undefined`.
- Green proof: `extensions/googlechat/src/setup.test.ts` — 32 passed (31 existed before, 1 new) with the fix.
- Green proof: `extensions/zalouser/src/channel.setup.test.ts` — 2/2 passed including the new declaration test.
- Green proof: `src/commands/doctor-legacy-config.migrations.test.ts` — 91/91 passed including the named-account restriction test.
- `oxfmt --check` passed for all changed source files.

## Scope

- No config/schema/default changes.
- No runtime behavior, credential, or setup flow changes.
- No changelog change.
- googlechat and zalouser only — other channels were already covered by #112293.
