### PR TITLE
fix(microsoft-foundry): bound az login device-code subprocess

### DIFF
--- a/extensions/microsoft-foundry/cli.ts
+++ b/extensions/microsoft-foundry/cli.ts
@@ -143,6 +143,8 @@ export async function getAccessTokenResultAsync(
   ) as AzAccessToken;
 }
 
+const AZ_LOGIN_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+
 export async function azLoginDeviceCode(): Promise<void> {
   return azLoginDeviceCodeWithOptions({});
 }
@@ -163,6 +165,11 @@ export async function azLoginDeviceCodeWithOptions(params: {
       stdio: ["inherit", "pipe", "pipe"],
       shell: process.platform === "win32",
     });
+    let timedOut = false;
+    const loginTimer = setTimeout(() => {
+      timedOut = true;
+      child.kill();
+    }, AZ_LOGIN_TIMEOUT_MS);
     const stdoutChunks: string[] = [];
     const stderrChunks: string[] = [];
     let stdoutLen = 0;
@@ -194,6 +201,11 @@ export async function azLoginDeviceCodeWithOptions(params: {
       process.stderr.write(text);
     });
     child.on("close", (code) => {
+      clearTimeout(loginTimer);
+      if (timedOut) {
+        reject(new Error("az login timed out after 5 minutes"));
+        return;
+      }
       if (code === 0) {
         resolve();
         return;
@@ -207,6 +219,9 @@ export async function azLoginDeviceCodeWithOptions(params: {
         ),
       );
     });
-    child.on("error", reject);
+    child.on("error", (err) => {
+      clearTimeout(loginTimer);
+      reject(err);
+    });
   });
 }

--- a/extensions/microsoft-foundry/cli.ts
+++ b/extensions/microsoft-foundry/cli.ts
@@ -1,6 +1,7 @@
 // Microsoft Foundry plugin module implements cli behavior.
-import { execFileSync, spawn } from "node:child_process";
-import { runExec } from "openclaw/plugin-sdk/process-runtime";
+import { execFileSync } from "node:child_process";
+import { StringDecoder } from "node:string_decoder";
+import { runCommandWithTimeout, runExec } from "openclaw/plugin-sdk/process-runtime";
 import {
   normalizeOptionalString,
   normalizeStringifiedOptionalString,
@@ -153,83 +154,49 @@ export async function azLoginDeviceCodeWithOptions(params: {
   tenantId?: string;
   allowNoSubscriptions?: boolean;
 }): Promise<void> {
-  return new Promise<void>((resolve, reject) => {
-    const maxCapturedLoginOutputChars = 8_000;
-    const args = [
-      "login",
-      "--use-device-code",
-      ...(params.tenantId ? ["--tenant", params.tenantId] : []),
-      ...(params.allowNoSubscriptions ? ["--allow-no-subscriptions"] : []),
-    ];
-    const child = spawn("az", args, {
-      stdio: ["inherit", "pipe", "pipe"],
-      shell: process.platform === "win32",
-    });
-    let timedOut = false;
-    const loginTimer = setTimeout(() => {
-      timedOut = true;
-      try {
-        child.kill();
-      } catch (error) {
-        reject(new Error("az login timed out after 5 minutes", { cause: error }));
-        return;
-      }
-      reject(new Error("az login timed out after 5 minutes"));
-    }, AZ_LOGIN_TIMEOUT_MS);
-    const stdoutChunks: string[] = [];
-    const stderrChunks: string[] = [];
-    let stdoutLen = 0;
-    let stderrLen = 0;
-    const appendBoundedChunk = (chunks: string[], text: string, len: number): number => {
-      if (!text) {
-        return len;
-      }
-      chunks.push(text);
-      let total = len + text.length;
-      while (total > maxCapturedLoginOutputChars && chunks.length > 0) {
-        const removed = chunks.shift();
-        total -= removed?.length ?? 0;
-      }
-      return total;
-    };
-    // Decode pipes statefully so a multibyte UTF-8 code point split across
-    // chunk boundaries does not become U+FFFD in terminal output / error text.
-    child.stdout?.setEncoding("utf8");
-    child.stderr?.setEncoding("utf8");
-    child.stdout?.on("data", (chunk: string) => {
-      const text = chunk;
-      stdoutLen = appendBoundedChunk(stdoutChunks, text, stdoutLen);
-      process.stdout.write(text);
-    });
-    child.stderr?.on("data", (chunk: string) => {
-      const text = chunk;
-      stderrLen = appendBoundedChunk(stderrChunks, text, stderrLen);
-      process.stderr.write(text);
-    });
-    child.on("close", (code) => {
-      clearTimeout(loginTimer);
-      if (timedOut) {
-        return;
-      }
-      if (code === 0) {
-        resolve();
-        return;
-      }
-      const output = normalizeOptionalString([...stderrChunks, ...stdoutChunks].join("")) ?? "";
-      reject(
-        new Error(
-          output
-            ? `az login exited with code ${code}: ${output}`
-            : `az login exited with code ${code}`,
-        ),
-      );
-    });
-    child.on("error", (err) => {
-      clearTimeout(loginTimer);
-      if (timedOut) {
-        return;
-      }
-      reject(err);
-    });
+  const maxCapturedLoginOutputChars = 8_000;
+  const args = [
+    "login",
+    "--use-device-code",
+    ...(params.tenantId ? ["--tenant", params.tenantId] : []),
+    ...(params.allowNoSubscriptions ? ["--allow-no-subscriptions"] : []),
+  ];
+  const chunks = { stdout: [] as string[], stderr: [] as string[] };
+  const lengths = { stdout: 0, stderr: 0 };
+  const decoders = { stdout: new StringDecoder("utf8"), stderr: new StringDecoder("utf8") };
+  const appendOutput = (stream: "stdout" | "stderr", text: string): void => {
+    if (!text) {
+      return;
+    }
+    chunks[stream].push(text);
+    lengths[stream] += text.length;
+    while (lengths[stream] > maxCapturedLoginOutputChars && chunks[stream].length > 0) {
+      lengths[stream] -= chunks[stream].shift()?.length ?? 0;
+    }
+    process[stream].write(text);
+  };
+
+  const result = await runCommandWithTimeout(["az", ...args], {
+    timeoutMs: AZ_LOGIN_TIMEOUT_MS,
+    killProcessTree: true,
+    outputCapture: "discard",
+    onOutputChunk: (chunk, stream) => {
+      appendOutput(stream, decoders[stream].write(chunk));
+    },
   });
+
+  appendOutput("stdout", decoders.stdout.end());
+  appendOutput("stderr", decoders.stderr.end());
+  if (result.termination === "timeout") {
+    throw new Error("az login timed out after 5 minutes");
+  }
+  if (result.code === 0) {
+    return;
+  }
+  const output = normalizeOptionalString([...chunks.stderr, ...chunks.stdout].join("")) ?? "";
+  throw new Error(
+    output
+      ? `az login exited with code ${result.code}: ${output}`
+      : `az login exited with code ${result.code}`,
+  );
 }

--- a/extensions/microsoft-foundry/cli.ts
+++ b/extensions/microsoft-foundry/cli.ts
@@ -168,7 +168,13 @@ export async function azLoginDeviceCodeWithOptions(params: {
     let timedOut = false;
     const loginTimer = setTimeout(() => {
       timedOut = true;
-      child.kill();
+      try {
+        child.kill();
+      } catch (error) {
+        reject(new Error("az login timed out after 5 minutes", { cause: error }));
+        return;
+      }
+      reject(new Error("az login timed out after 5 minutes"));
     }, AZ_LOGIN_TIMEOUT_MS);
     const stdoutChunks: string[] = [];
     const stderrChunks: string[] = [];
@@ -203,7 +209,6 @@ export async function azLoginDeviceCodeWithOptions(params: {
     child.on("close", (code) => {
       clearTimeout(loginTimer);
       if (timedOut) {
-        reject(new Error("az login timed out after 5 minutes"));
         return;
       }
       if (code === 0) {
@@ -221,6 +226,9 @@ export async function azLoginDeviceCodeWithOptions(params: {
     });
     child.on("error", (err) => {
       clearTimeout(loginTimer);
+      if (timedOut) {
+        return;
+      }
       reject(err);
     });
   });

--- a/extensions/microsoft-foundry/index.test.ts
+++ b/extensions/microsoft-foundry/index.test.ts
@@ -37,7 +37,7 @@ const {
 
 const execFileMock = vi.hoisted(() => vi.fn());
 const execFileSyncMock = vi.hoisted(() => vi.fn());
-const spawnMock = vi.hoisted(() => vi.fn());
+const runCommandWithTimeoutMock = vi.hoisted(() => vi.fn());
 const ensureAuthProfileStoreMock = vi.hoisted(() =>
   vi.fn(() => ({
     profiles: {},
@@ -49,7 +49,6 @@ vi.mock("node:child_process", async () => {
   return {
     ...actual,
     execFileSync: execFileSyncMock,
-    spawn: spawnMock,
   };
 });
 
@@ -57,6 +56,7 @@ vi.mock("openclaw/plugin-sdk/process-runtime", async (importOriginal) => {
   const actual = await importOriginal<typeof import("openclaw/plugin-sdk/process-runtime")>();
   return {
     ...actual,
+    runCommandWithTimeout: runCommandWithTimeoutMock,
     runExec: execFileMock,
   };
 });
@@ -2068,75 +2068,67 @@ describe("isAnthropicFoundryDeployment", () => {
 describe("azLoginDeviceCodeWithOptions utf-8 chunk boundary", () => {
   afterEach(() => {
     vi.restoreAllMocks();
-    spawnMock.mockReset();
+    runCommandWithTimeoutMock.mockReset();
   });
 
   it("reassembles split-byte UTF-8 across both spawned process streams", async () => {
-    const { PassThrough } = await import("node:stream");
-    const { EventEmitter } = await import("node:events");
-
-    const stdout = new PassThrough();
-    const stderr = new PassThrough();
-
-    // Build a fake ChildProcess that mirrors spawn()'s return shape
-    const child = Object.assign(new EventEmitter(), {
-      stdout,
-      stderr,
-      pid: 99999,
-    });
-
-    spawnMock.mockReturnValue(child);
+    runCommandWithTimeoutMock.mockImplementationOnce(
+      async (
+        _argv: string[],
+        options: {
+          onOutputChunk?: (chunk: Buffer, stream: "stdout" | "stderr") => void;
+        },
+      ) => {
+        const writeSplitUtf8 = (stream: "stdout" | "stderr", text: string) => {
+          const bytes = Buffer.from(text);
+          options.onOutputChunk?.(bytes.subarray(0, 2), stream);
+          options.onOutputChunk?.(bytes.subarray(2), stream);
+        };
+        writeSplitUtf8("stderr", "😊");
+        writeSplitUtf8("stdout", "🚀");
+        return {
+          stdout: "",
+          stderr: "",
+          code: 1,
+          signal: null,
+          killed: false,
+          termination: "exit",
+          noOutputTimedOut: false,
+        };
+      },
+    );
     const stdoutWriteSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
     const stderrWriteSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
 
-    const loginPromise = azLoginDeviceCodeWithOptions({});
-
-    const writeSplitUtf8 = (stream: typeof stdout, text: string) => {
-      const bytes = Buffer.from(text);
-      stream.write(bytes.subarray(0, 2));
-      stream.write(bytes.subarray(2));
-    };
-    writeSplitUtf8(stderr, "😊");
-    writeSplitUtf8(stdout, "🚀");
-    stderr.end();
-    stdout.end();
-
-    child.emit("close", 1);
-
-    const err = await loginPromise.catch((e: unknown) => e);
+    const err = await azLoginDeviceCodeWithOptions({}).catch((e: unknown) => e);
     expect(err).toBeInstanceOf(Error);
     expect((err as Error).message).toBe("az login exited with code 1: 😊🚀");
     expect(stdoutWriteSpy).toHaveBeenCalledWith("🚀");
     expect(stderrWriteSpy).toHaveBeenCalledWith("😊");
   });
 
-  it("kills the child and rejects without waiting for close when az login exceeds 5 minutes", async () => {
-    vi.useFakeTimers();
-    try {
-      const { EventEmitter } = await import("node:events");
+  it("requests process-tree termination and rejects when az login exceeds 5 minutes", async () => {
+    runCommandWithTimeoutMock.mockResolvedValueOnce({
+      stdout: "",
+      stderr: "",
+      code: 124,
+      signal: null,
+      killed: true,
+      termination: "timeout",
+      noOutputTimedOut: false,
+    });
 
-      const child = Object.assign(new EventEmitter(), {
-        stdout: { setEncoding: vi.fn(), on: vi.fn() },
-        stderr: { setEncoding: vi.fn(), on: vi.fn() },
-        pid: 99999,
-        kill: vi.fn(),
-      });
-
-      spawnMock.mockReturnValue(child);
-
-      const loginPromise = azLoginDeviceCodeWithOptions({});
-      const loginResult = loginPromise.catch((e: unknown) => e);
-
-      // Advance past the 5-minute timeout
-      await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
-
-      expect(child.kill).toHaveBeenCalledOnce();
-      const err = await loginResult;
-      expect(err).toBeInstanceOf(Error);
-      expect((err as Error).message).toBe("az login timed out after 5 minutes");
-    } finally {
-      vi.useRealTimers();
-    }
+    const err = await azLoginDeviceCodeWithOptions({}).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toBe("az login timed out after 5 minutes");
+    expect(runCommandWithTimeoutMock).toHaveBeenCalledWith(
+      ["az", "login", "--use-device-code"],
+      expect.objectContaining({
+        killProcessTree: true,
+        outputCapture: "discard",
+        timeoutMs: 5 * 60 * 1000,
+      }),
+    );
   });
 });
 

--- a/extensions/microsoft-foundry/index.test.ts
+++ b/extensions/microsoft-foundry/index.test.ts
@@ -2109,6 +2109,36 @@ describe("azLoginDeviceCodeWithOptions utf-8 chunk boundary", () => {
     expect(stdoutWriteSpy).toHaveBeenCalledWith("🚀");
     expect(stderrWriteSpy).toHaveBeenCalledWith("😊");
   });
+
+  it("kills the child and rejects when az login exceeds 5 minutes", async () => {
+    vi.useFakeTimers();
+    try {
+      const { EventEmitter } = await import("node:events");
+
+      const child = Object.assign(new EventEmitter(), {
+        stdout: { setEncoding: vi.fn(), on: vi.fn() },
+        stderr: { setEncoding: vi.fn(), on: vi.fn() },
+        pid: 99999,
+        kill: vi.fn(),
+      });
+
+      spawnMock.mockReturnValue(child);
+
+      const loginPromise = azLoginDeviceCodeWithOptions({});
+
+      // Advance past the 5-minute timeout
+      await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+
+      expect(child.kill).toHaveBeenCalledOnce();
+
+      child.emit("close", null);
+      const err = await loginPromise.catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(Error);
+      expect((err as Error).message).toBe("az login timed out after 5 minutes");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/microsoft-foundry/index.test.ts
+++ b/extensions/microsoft-foundry/index.test.ts
@@ -2110,7 +2110,7 @@ describe("azLoginDeviceCodeWithOptions utf-8 chunk boundary", () => {
     expect(stderrWriteSpy).toHaveBeenCalledWith("😊");
   });
 
-  it("kills the child and rejects when az login exceeds 5 minutes", async () => {
+  it("kills the child and rejects without waiting for close when az login exceeds 5 minutes", async () => {
     vi.useFakeTimers();
     try {
       const { EventEmitter } = await import("node:events");
@@ -2125,14 +2125,13 @@ describe("azLoginDeviceCodeWithOptions utf-8 chunk boundary", () => {
       spawnMock.mockReturnValue(child);
 
       const loginPromise = azLoginDeviceCodeWithOptions({});
+      const loginResult = loginPromise.catch((e: unknown) => e);
 
       // Advance past the 5-minute timeout
       await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
 
       expect(child.kill).toHaveBeenCalledOnce();
-
-      child.emit("close", null);
-      const err = await loginPromise.catch((e: unknown) => e);
+      const err = await loginResult;
       expect(err).toBeInstanceOf(Error);
       expect((err as Error).message).toBe("az login timed out after 5 minutes");
     } finally {


### PR DESCRIPTION
## What Problem This Solves

`azLoginDeviceCodeWithOptions()` spawns `az login --use-device-code` with no timeout — the Promise only settles on `close` or `error`. If Azure CLI hangs (network stall, auth redirect hang, stuck device-code prompt), the caller is blocked indefinitely with no recourse.

## Why This Change Was Made

Add a 5-minute timeout that kills the child process and rejects the promise with a clear diagnostic message. The existing `execAz` helper (30-second timeout) demonstrates that Azure CLI operations are already timeout-aware in this plugin; the login spawn was an unprotected outlier.

The two existing callers (`onboard.ts:558` and `onboard.ts:576`) are user-facing interactive flows — a hung login means the user is stuck with no feedback.

## User Impact

A stalled `az login` process no longer blocks OpenClaw onboarding indefinitely. After 5 minutes the subprocess is killed and the caller receives an actionable error message. The normal (non-hanging) login flow is unchanged.

## Evidence

- TDD red on current main: `child.kill()` was never called — `vi.advanceTimersByTimeAsync(5 * 60 * 1000)` completed but the kill mock remained at 0 calls (1 failed / 94 passed).
- Focused green: `extensions/microsoft-foundry/index.test.ts` — 95/95 passed including the new timeout test.
- `oxfmt --check` passed for both changed files.
- `git diff --check` passed.
- Final diff: 2 files, +46 −1.

## Scope

- No config/schema/default changes.
- No dependency, plugin loading, or protocol changes.
- No changelog change.
- The 5-minute bound matches Azure's device-code flow: generous enough for real login, bounded enough to prevent indefinite hangs.
