### PR TITLE
fix(channels): preserve concurrent draft updates when sendOrEditStreamMessage returns false

### DIFF
--- a/src/channels/draft-stream-loop.test.ts
+++ b/src/channels/draft-stream-loop.test.ts
@@ -291,4 +291,73 @@ describe("createDraftStreamLoop", () => {
       [{ text: "latest", blocks: ["latest-blocks"] }],
     ]);
   });
+
+  it("preserves concurrent update text when sendOrEditStreamMessage returns false", async () => {
+    let deliver!: (() => void) | undefined;
+    const deliverPromise = new Promise<void>((resolve) => {
+      deliver = resolve;
+    });
+    const capturedArgs: string[] = [];
+
+    const sendOrEditStreamMessage = vi
+      .fn<(text: string) => Promise<boolean>>()
+      .mockImplementationOnce(async (text: string) => {
+        capturedArgs.push(text);
+        await deliverPromise;
+        return false;
+      })
+      .mockImplementationOnce(async (text: string) => {
+        capturedArgs.push(text);
+        return true;
+      });
+
+    const loop = createDraftStreamLoop({
+      throttleMs: 0,
+      isStopped: () => false,
+      sendOrEditStreamMessage,
+    });
+
+    loop.update("initial");
+    await flushMicrotasks();
+
+    loop.update("concurrent");
+    deliver!();
+    await loop.flush();
+
+    expect(capturedArgs[1]).toBe("concurrent");
+  });
+
+  it("preserves generic pending updates when consecutive sends return false", async () => {
+    type Update = { text: string; blocks: string[] };
+    const initial = { text: "initial", blocks: ["initial-blocks"] };
+    const latest = { text: "latest", blocks: ["latest-blocks"] };
+    let releaseFirst: (() => void) | undefined;
+    const firstSend = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const sendOrEditStreamMessage = vi
+      .fn<(update: Update) => Promise<boolean>>()
+      .mockImplementationOnce(async () => {
+        await firstSend;
+        return false;
+      })
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+    const loop = createDraftStreamLoop<Update>({
+      throttleMs: 0,
+      isStopped: () => false,
+      emptyValue: { text: "", blocks: [] },
+      isEmpty: (update) => !update.text,
+      sendOrEditStreamMessage,
+    });
+
+    loop.update(initial);
+    await flushMicrotasks();
+    loop.update(latest);
+    releaseFirst?.();
+    await loop.flush();
+    await loop.flush();
+
+    expect(sendOrEditStreamMessage.mock.calls).toEqual([[initial], [latest], [latest]]);
+  });
 });

--- a/src/channels/draft-stream-loop.test.ts
+++ b/src/channels/draft-stream-loop.test.ts
@@ -260,38 +260,6 @@ describe("createDraftStreamLoop", () => {
     expect(sendOrEditStreamMessage).toHaveBeenNthCalledWith(2, "hello");
   });
 
-  it("keeps generic payload fields atomic while newer updates queue", async () => {
-    type Update = { text: string; blocks: string[] };
-    let releaseFirst: (() => void) | undefined;
-    const firstSend = new Promise<void>((resolve) => {
-      releaseFirst = resolve;
-    });
-    const sendOrEditStreamMessage = vi.fn(async (update: Update) => {
-      if (update.text === "first") {
-        await firstSend;
-      }
-      return true;
-    });
-    const loop = createDraftStreamLoop<Update>({
-      throttleMs: 0,
-      isStopped: () => false,
-      emptyValue: { text: "", blocks: [] },
-      isEmpty: (update) => !update.text,
-      sendOrEditStreamMessage,
-    });
-
-    loop.update({ text: "first", blocks: ["first-blocks"] });
-    await flushMicrotasks();
-    loop.update({ text: "latest", blocks: ["latest-blocks"] });
-    releaseFirst?.();
-    await loop.flush();
-
-    expect(sendOrEditStreamMessage.mock.calls).toEqual([
-      [{ text: "first", blocks: ["first-blocks"] }],
-      [{ text: "latest", blocks: ["latest-blocks"] }],
-    ]);
-  });
-
   it("preserves concurrent update text when sendOrEditStreamMessage returns false", async () => {
     let deliver!: (() => void) | undefined;
     const deliverPromise = new Promise<void>((resolve) => {
@@ -359,5 +327,37 @@ describe("createDraftStreamLoop", () => {
     await loop.flush();
 
     expect(sendOrEditStreamMessage.mock.calls).toEqual([[initial], [latest], [latest]]);
+  });
+
+  it("keeps generic payload fields atomic while newer updates queue", async () => {
+    type Update = { text: string; blocks: string[] };
+    let releaseFirst: (() => void) | undefined;
+    const firstSend = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const sendOrEditStreamMessage = vi.fn(async (update: Update) => {
+      if (update.text === "first") {
+        await firstSend;
+      }
+      return true;
+    });
+    const loop = createDraftStreamLoop<Update>({
+      throttleMs: 0,
+      isStopped: () => false,
+      emptyValue: { text: "", blocks: [] },
+      isEmpty: (update) => !update.text,
+      sendOrEditStreamMessage,
+    });
+
+    loop.update({ text: "first", blocks: ["first-blocks"] });
+    await flushMicrotasks();
+    loop.update({ text: "latest", blocks: ["latest-blocks"] });
+    releaseFirst?.();
+    await loop.flush();
+
+    expect(sendOrEditStreamMessage.mock.calls).toEqual([
+      [{ text: "first", blocks: ["first-blocks"] }],
+      [{ text: "latest", blocks: ["latest-blocks"] }],
+    ]);
   });
 });

--- a/src/channels/draft-stream-loop.ts
+++ b/src/channels/draft-stream-loop.ts
@@ -84,7 +84,9 @@ export function createDraftStreamLoop<T = string>(params: {
         throw err;
       }
       if (sent === false) {
-        pendingValue = value;
+        if (!hasPendingValue(pendingValue)) {
+          pendingValue = value;
+        }
         return;
       }
       lastSentAt = Date.now();


### PR DESCRIPTION
## What Problem This Solves

A channel preview can visibly revert to stale content when a draft send returns `false` after a newer update arrived during the in-flight send. The shared draft-stream loop restored the older failed value unconditionally, overwriting the newer pending value before its next retry.

Telegram can exercise this through a real Bot API HTTP 429 response: its draft transport suspends briefly, returns `false`, and retries. The documented default Telegram `progress` mode uses one editable status/tool draft, so preserving the latest pending preview is normal operator-visible behavior.

## Why This Change Was Made

At the canonical `createDraftStreamLoop` owner, restore the failed value only when `hasPendingValue` says no newer value arrived. Preserve an existing pending value unchanged otherwise. This is intentionally a generic presence check, not the old string-only `pendingText ||= ...` workaround: structured draft values such as Slack `{ text, blocks }` are truthy even when their empty sentinel is represented by an object.

The contributor's original string race regression remains, and a second generic structured-value regression proves both that the newest text/blocks stay together and that the same object is retried when no replacement arrives.

Original issue identification, fix, and string regression: @yangxiansheng (Qiong). Maintainer rebasing adapted the original patch to the current generic draft-stream owner and added the structured-value regression.

## User Impact

Default Telegram progress/status previews and other retrying draft streams preserve the latest model or tool progress after a transient Telegram rate limit. Shared generic draft values remain atomic. Slack's documented default preview replacement and its structured `{ text, blocks }` representation remain compatible; this does not claim the current Slack transport itself exercises the `false`-retry path.

## Evidence

Focused real owner and sibling suites:

```sh
OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-pr112370-s06 node scripts/run-vitest.mjs src/channels/draft-stream-loop.test.ts extensions/telegram/src/draft-stream.test.ts extensions/slack/src/draft-stream.test.ts
```

Result: **3 files passed; 113 tests passed**: shared draft loop 10, Telegram 90, Slack 13.

End-to-end before/after proof imported the actual production Telegram draft-stream owner and used the real installed grammY `Api` against an ephemeral localhost HTTP Bot API server. The first real `sendMessage` response was HTTP 429 with `retry_after: 0.02`; a newer draft arrived during the failed request; the next response was HTTP 200.

Before, using only an in-memory reversion of the owner fix:

```json
{"mode":"red","inMemoryBaselineRevert":true,"requests":[{"method":"sendMessage","text":"older draft","status":429},{"method":"sendMessage","text":"older draft","status":200}],"newestVisibleDraftDelivered":false,"pass":true}
```

After, using the committed production owner unchanged:

```json
{"mode":"green","inMemoryBaselineRevert":false,"requests":[{"method":"sendMessage","text":"older draft","status":429},{"method":"sendMessage","text":"newest draft","status":200}],"newestVisibleDraftDelivered":true,"pass":true}
```

The generic structured regression additionally observes `initial → latest → latest`, preserving the entire `{ text, blocks }` payload while covering both concurrent replacement and retry without replacement. No external Telegram service, live account, or real credential was used.