### PR TITLE
feat: add poolside model provider

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -678,6 +678,11 @@
   - changed-files:
       - any-glob-to-any-file:
           - "extensions/perplexity/**"
+"extensions: poolside":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/poolside/**"
+          - "docs/providers/poolside.md"
 "extensions: sglang":
   - changed-files:
       - any-glob-to-any-file:

--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -1554,5 +1554,21 @@
   {
     "source": "Baseten (Inkling + Model APIs)",
     "target": "Baseten（Inkling + Model APIs）"
+  },
+  {
+    "source": "Poolside",
+    "target": "Poolside"
+  },
+  {
+    "source": "Poolside plugin",
+    "target": "Poolside 插件"
+  },
+  {
+    "source": "poolside",
+    "target": "poolside"
+  },
+  {
+    "source": "Poolside (Laguna models)",
+    "target": "Poolside（Laguna models）"
   }
 ]

--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -6938,6 +6938,15 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: Behavior
   - H2: Related docs
 
+## plugins/reference/poolside.md
+
+- Route: /plugins/reference/poolside
+- Headings:
+  - H1: Poolside plugin
+  - H2: Distribution
+  - H2: Surface
+  - H2: Related docs
+
 ## plugins/reference/qa-channel.md
 
 - Route: /plugins/reference/qa-channel
@@ -8290,6 +8299,17 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: Provider options
   - H2: Configuration
   - H2: Advanced configuration
+  - H2: Related
+
+## providers/poolside.md
+
+- Route: /providers/poolside
+- Headings:
+  - H2: Install plugin
+  - H2: Getting started
+  - H2: Models
+  - H2: Sampling
+  - H2: Manual config
   - H2: Related
 
 ## providers/qianfan.md

--- a/docs/plugins/plugin-inventory.md
+++ b/docs/plugins/plugin-inventory.md
@@ -191,7 +191,7 @@ Each entry lists the package, distribution route, and description.
 
 ## Official external packages
 
-72 plugins
+73 plugins
 
 - **[acpx](/plugins/reference/acpx)** (`@openclaw/acpx`) - npm; ClawHub. OpenClaw ACP runtime backend with plugin-owned session and transport management.
 
@@ -292,6 +292,8 @@ Each entry lists the package, distribution route, and description.
 - **[perplexity](/plugins/reference/perplexity)** (`@openclaw/perplexity-plugin`) - npm; ClawHub: `clawhub:@openclaw/perplexity-plugin`. Adds web search provider support.
 
 - **[pixverse](/plugins/reference/pixverse)** (`@openclaw/pixverse-provider`) - npm; ClawHub: `clawhub:@openclaw/pixverse-provider`. OpenClaw PixVerse video generation provider plugin.
+
+- **[poolside](/plugins/reference/poolside)** (`@openclaw/poolside-provider`) - npm; ClawHub: `clawhub:@openclaw/poolside-provider`. OpenClaw Poolside provider plugin.
 
 - **[qianfan](/plugins/reference/qianfan)** (`@openclaw/qianfan-provider`) - npm; ClawHub: `clawhub:@openclaw/qianfan-provider`. Adds Qianfan model provider support to OpenClaw.
 

--- a/docs/plugins/reference.md
+++ b/docs/plugins/reference.md
@@ -15,5 +15,5 @@ This page is generated from `extensions/*/package.json` and
 pnpm plugins:inventory:gen
 ```
 
-Use [Plugin inventory](/plugins/plugin-inventory) to browse all 141
+Use [Plugin inventory](/plugins/plugin-inventory) to browse all 142
 generated plugin reference pages by distribution, package, and description.

--- a/docs/plugins/reference/poolside.md
+++ b/docs/plugins/reference/poolside.md
@@ -1,0 +1,23 @@
+---
+summary: "OpenClaw Poolside provider plugin."
+read_when:
+  - You are installing, configuring, or auditing the poolside plugin
+title: "Poolside plugin"
+---
+
+# Poolside plugin
+
+OpenClaw Poolside provider plugin.
+
+## Distribution
+
+- Package: `@openclaw/poolside-provider`
+- Install route: npm; ClawHub: `clawhub:@openclaw/poolside-provider`
+
+## Surface
+
+providers: `poolside`
+
+## Related docs
+
+- [poolside](/providers/poolside)

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -67,6 +67,7 @@ Looking for chat channel docs (WhatsApp/Telegram/Discord/Slack/Mattermost (plugi
 - [OpenCode Go](/providers/opencode-go)
 - [OpenRouter](/providers/openrouter)
 - [Perplexity (web search)](/providers/perplexity-provider)
+- [Poolside (Laguna models)](/providers/poolside)
 - [Qianfan](/providers/qianfan)
 - [Qwen Cloud](/providers/qwen)
 - [Runway](/providers/runway)

--- a/docs/providers/models.md
+++ b/docs/providers/models.md
@@ -40,6 +40,7 @@ Pick a provider, authenticate, then set the default model as `provider/model`.
 - [OpenAI (API + Codex)](/providers/openai)
 - [OpenCode (Zen + Go)](/providers/opencode)
 - [OpenRouter](/providers/openrouter)
+- [Poolside (Laguna models)](/providers/poolside)
 - [Qianfan](/providers/qianfan)
 - [Qwen](/providers/qwen)
 - [Runway](/providers/runway)

--- a/docs/providers/poolside.md
+++ b/docs/providers/poolside.md
@@ -1,0 +1,157 @@
+---
+summary: "Poolside setup for the Laguna model family"
+title: "Poolside"
+read_when:
+  - You want to run Poolside's Laguna models in OpenClaw
+  - You want one OpenAI-compatible API for the Laguna model family
+---
+
+[Poolside](https://poolside.ai) serves its Laguna model family over a hosted, OpenAI-compatible API. The official external plugin ships a static catalog of the Laguna models, with tool calling and reasoning enabled.
+
+| Property        | Value                                                     |
+| --------------- | --------------------------------------------------------- |
+| Provider id     | `poolside`                                                |
+| Plugin          | official external package (`@openclaw/poolside-provider`) |
+| Auth env var    | `POOLSIDE_API_KEY`                                        |
+| Onboarding flag | `--auth-choice poolside-api-key`                          |
+| Direct CLI flag | `--poolside-api-key <key>`                                |
+| API             | OpenAI-compatible (`openai-completions`)                  |
+| Base URL        | `https://inference.poolside.ai/v1`                        |
+| Default model   | `poolside/laguna-s-2.1`                                   |
+
+## Install plugin
+
+```bash
+openclaw plugins install @openclaw/poolside-provider
+openclaw gateway restart
+```
+
+## Getting started
+
+<Steps>
+  <Step title="Get a Poolside API key">
+    Create an API key from your Poolside account and export it as `POOLSIDE_API_KEY`.
+  </Step>
+  <Step title="Run onboarding">
+    <CodeGroup>
+
+```bash Onboarding
+openclaw onboard --auth-choice poolside-api-key
+```
+
+```bash Direct flag
+openclaw onboard --non-interactive \
+  --auth-choice poolside-api-key \
+  --poolside-api-key "$POOLSIDE_API_KEY"
+```
+
+```bash Env only
+export POOLSIDE_API_KEY=...
+```
+
+    </CodeGroup>
+
+  </Step>
+  <Step title="Verify the catalog">
+    ```bash
+    openclaw models list --provider poolside
+    ```
+
+  </Step>
+</Steps>
+
+## Models
+
+Every Laguna model supports text input, tool calling, and reasoning, and returns up to 32k output tokens:
+
+| Model ref                     | Context | Max output |
+| ----------------------------- | ------: | ---------: |
+| `poolside/laguna-s-2.1`       |    262k |        32k |
+| `poolside/laguna-s-2.1:fast`  |  1.048M |        32k |
+| `poolside/laguna-xs-2.1`      |    262k |        32k |
+| `poolside/laguna-xs-2.1:fast` |    262k |        32k |
+| `poolside/laguna-m.1`         |    262k |        32k |
+| `poolside/laguna-m.1:fast`    |    262k |        32k |
+
+```json5
+{
+  agents: {
+    defaults: {
+      model: { primary: "poolside/laguna-s-2.1" },
+    },
+  },
+}
+```
+
+Use `/model poolside/laguna-s-2.1` to switch an existing chat.
+
+## Sampling
+
+Poolside's endpoints accept `temperature` only. They ignore `top_p`, `top_k`, `min_p`, and the presence/frequency penalties, and their no-parameter default (untruncated temperature 1.0) produces malformed output. The plugin therefore defaults `temperature` to `0.7` when a request sets none, and drops the unsupported sampling fields before they reach the wire. Set your own `temperature` in config to override the default; other sampling knobs have no effect.
+
+Laguna reasoning is always on and there is no `reasoning_effort` control, so OpenClaw streams `reasoning_content` without sending a reasoning-effort field.
+
+## Manual config
+
+Most setups only need the API key. To pin the provider explicitly:
+
+```json5
+{
+  env: { POOLSIDE_API_KEY: "..." },
+  agents: {
+    defaults: {
+      model: { primary: "poolside/laguna-s-2.1" },
+    },
+  },
+  models: {
+    mode: "merge",
+    providers: {
+      poolside: {
+        baseUrl: "https://inference.poolside.ai/v1",
+        apiKey: "${POOLSIDE_API_KEY}",
+        api: "openai-completions",
+        models: [
+          {
+            id: "laguna-s-2.1",
+            name: "Laguna S 2.1",
+            reasoning: true,
+            input: ["text"],
+            contextWindow: 262144,
+            maxTokens: 32768,
+            compat: {
+              supportsStore: false,
+              supportsDeveloperRole: false,
+              supportsUsageInStreaming: true,
+              supportsStrictMode: false,
+              supportsTools: true,
+              supportsReasoningEffort: false,
+              maxTokensField: "max_tokens",
+            },
+          },
+        ],
+      },
+    },
+  },
+}
+```
+
+<Note>
+If the Gateway runs as a daemon (launchd, systemd, Docker), make sure `POOLSIDE_API_KEY` is available to that process. A key exported only in an interactive shell is not visible to an already-running managed service.
+</Note>
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Model providers" href="/concepts/model-providers" icon="layers">
+    Choosing providers, model refs, and failover behavior.
+  </Card>
+  <Card title="Models CLI" href="/cli/models" icon="terminal">
+    List, inspect, and select models.
+  </Card>
+  <Card title="Models FAQ" href="/help/faq-models" icon="circle-question">
+    Auth profiles and model-selection troubleshooting.
+  </Card>
+  <Card title="Thinking modes" href="/tools/thinking" icon="brain">
+    How OpenClaw surfaces reasoning output.
+  </Card>
+</CardGroup>

--- a/extensions/poolside/README.md
+++ b/extensions/poolside/README.md
@@ -1,0 +1,13 @@
+# Poolside OpenClaw provider
+
+Official OpenClaw provider plugin for Poolside's Laguna model family.
+
+## Install
+
+```sh
+openclaw plugins install @openclaw/poolside-provider
+```
+
+## Docs
+
+See `docs/providers/poolside.md` in the OpenClaw repository, or the published docs at `https://docs.openclaw.ai/providers/poolside`.

--- a/extensions/poolside/api.ts
+++ b/extensions/poolside/api.ts
@@ -1,0 +1,19 @@
+/** Public Poolside provider plugin API exports. */
+export {
+  buildPoolsideModelDefinition,
+  buildStaticPoolsideModels,
+  isPoolsideCatalogModelId,
+  POOLSIDE_BASE_URL,
+  POOLSIDE_DEFAULT_MODEL_ID,
+  POOLSIDE_DEFAULT_MODEL_REF,
+  POOLSIDE_MODEL_CATALOG,
+  resolvePoolsideDynamicModel,
+} from "./models.js";
+export { applyPoolsideConfig } from "./onboard.js";
+export { buildPoolsideProvider } from "./provider-catalog.js";
+export {
+  applyPoolsideModelId,
+  createPoolsideSamplingWrapper,
+  POOLSIDE_DEFAULT_TEMPERATURE,
+  sanitizePoolsideSampling,
+} from "./stream.js";

--- a/extensions/poolside/index.test.ts
+++ b/extensions/poolside/index.test.ts
@@ -1,0 +1,172 @@
+import type { Model } from "openclaw/plugin-sdk/llm";
+import type { ProviderRuntimeModel } from "openclaw/plugin-sdk/plugin-entry";
+import {
+  registerSingleProviderPlugin,
+  resolveProviderPluginChoice,
+} from "openclaw/plugin-sdk/plugin-test-runtime";
+import { resolveAgentModelPrimaryValue } from "openclaw/plugin-sdk/provider-onboard";
+import { buildOpenAICompletionsParams } from "openclaw/plugin-sdk/provider-transport-runtime";
+import { describe, expect, it } from "vitest";
+import {
+  createProviderDynamicModelContext,
+  runSingleProviderCatalog,
+} from "../test-support/provider-model-test-helpers.js";
+import poolsidePlugin from "./index.js";
+import { applyPoolsideConfig } from "./onboard.js";
+
+const EXPECTED_MODEL_IDS = [
+  "laguna-s-2.1",
+  "laguna-s-2.1:fast",
+  "laguna-xs-2.1",
+  "laguna-xs-2.1:fast",
+  "laguna-m.1",
+  "laguna-m.1:fast",
+];
+
+type OpenAICompletionsModel = Model<"openai-completions">;
+
+function poolsideRuntimeModel(id: string): ProviderRuntimeModel {
+  return {
+    id,
+    name: id,
+    provider: "poolside",
+    api: "openai-completions",
+    baseUrl: "https://inference.poolside.ai/v1",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 262_144,
+    maxTokens: 32_768,
+  };
+}
+
+describe("poolside provider plugin", () => {
+  it("registers Poolside with api-key auth wizard metadata", async () => {
+    const provider = await registerSingleProviderPlugin(poolsidePlugin);
+    const resolved = resolveProviderPluginChoice({
+      providers: [provider],
+      choice: "poolside-api-key",
+    });
+
+    expect(provider).toMatchObject({
+      id: "poolside",
+      label: "Poolside",
+      docsPath: "/providers/poolside",
+      envVars: ["POOLSIDE_API_KEY"],
+      resolveDynamicModel: expect.any(Function),
+      wrapStreamFn: expect.any(Function),
+    });
+    expect(provider.auth).toHaveLength(1);
+    if (!resolved) {
+      throw new Error("expected Poolside api-key auth choice");
+    }
+    expect(resolved.provider.id).toBe("poolside");
+    expect(resolved.method.id).toBe("api-key");
+  });
+
+  it("builds the static Laguna catalog", async () => {
+    const provider = await registerSingleProviderPlugin(poolsidePlugin);
+    const catalog = await runSingleProviderCatalog(provider);
+
+    expect(catalog.api).toBe("openai-completions");
+    expect(catalog.baseUrl).toBe("https://inference.poolside.ai/v1");
+    const models = catalog.models;
+    if (!models) {
+      throw new Error("expected Poolside catalog models");
+    }
+    expect(models.map((model) => model.id)).toEqual(EXPECTED_MODEL_IDS);
+    for (const model of models) {
+      expect(model.reasoning).toBe(true);
+      expect(model.input).toEqual(["text"]);
+      expect(model.maxTokens).toBe(32_768);
+      expect(model.compat?.supportsTools).toBe(true);
+      expect(model.compat?.supportsReasoningEffort).toBe(false);
+      expect(model.compat?.maxTokensField).toBe("max_tokens");
+    }
+    const fast = models.find((model) => model.id === "laguna-s-2.1:fast");
+    expect(fast?.contextWindow).toBe(1_048_576);
+    const s21 = models.find((model) => model.id === "laguna-s-2.1");
+    expect(s21?.contextWindow).toBe(262_144);
+  });
+
+  it("onboards poolside/laguna-s-2.1 as the default model", () => {
+    expect(resolveAgentModelPrimaryValue(applyPoolsideConfig({}).agents?.defaults?.model)).toBe(
+      "poolside/laguna-s-2.1",
+    );
+  });
+
+  it("resolves forward-compat Laguna model ids as reasoning text models", async () => {
+    const provider = await registerSingleProviderPlugin(poolsidePlugin);
+    const resolved = provider.resolveDynamicModel?.(
+      createProviderDynamicModelContext({
+        provider: "poolside",
+        modelId: "laguna-s-2.2",
+        models: [poolsideRuntimeModel("laguna-s-2.1")],
+      }),
+    );
+
+    expect(resolved?.provider).toBe("poolside");
+    expect(resolved?.id).toBe("laguna-s-2.2");
+    expect(resolved?.api).toBe("openai-completions");
+    expect(resolved?.baseUrl).toBe("https://inference.poolside.ai/v1");
+    expect(resolved?.reasoning).toBe(true);
+    expect(resolved?.input).toEqual(["text"]);
+    expect(resolved?.compat?.supportsReasoningEffort).toBe(false);
+  });
+
+  it("defers bundled catalog ids to core static-catalog resolution", async () => {
+    const provider = await registerSingleProviderPlugin(poolsidePlugin);
+    for (const modelId of EXPECTED_MODEL_IDS) {
+      const resolved = provider.resolveDynamicModel?.(
+        createProviderDynamicModelContext({
+          provider: "poolside",
+          modelId,
+          models: [poolsideRuntimeModel(modelId)],
+        }),
+      );
+      expect(resolved).toBeUndefined();
+    }
+  });
+
+  it("never sends reasoning_effort for Laguna models", () => {
+    const model = {
+      id: "laguna-s-2.1",
+      name: "Laguna S 2.1",
+      provider: "poolside",
+      api: "openai-completions",
+      baseUrl: "https://inference.poolside.ai/v1",
+      reasoning: true,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 262_144,
+      maxTokens: 32_768,
+      compat: {
+        supportsReasoningEffort: false,
+        supportsTools: true,
+        maxTokensField: "max_tokens" as const,
+      },
+    } as OpenAICompletionsModel;
+
+    const payload = buildOpenAICompletionsParams(
+      model,
+      {
+        systemPrompt: "You are a helpful assistant.",
+        messages: [{ role: "user", content: "hello", timestamp: 1 }],
+      },
+      { reasoning: "high", maxTokens: 64 },
+    );
+
+    expect(payload.reasoning_effort).toBeUndefined();
+    expect(payload.max_tokens).toBe(64);
+  });
+
+  it("keeps reasoning replay history for Laguna models", async () => {
+    const provider = await registerSingleProviderPlugin(poolsidePlugin);
+    expect(
+      provider.buildReplayPolicy?.({
+        modelApi: "openai-completions",
+        modelId: "laguna-s-2.1",
+      } as never)?.dropReasoningFromHistory,
+    ).not.toBe(true);
+  });
+});

--- a/extensions/poolside/index.ts
+++ b/extensions/poolside/index.ts
@@ -1,0 +1,53 @@
+/** Poolside provider plugin entrypoint. */
+import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-entry";
+import { buildProviderReplayFamilyHooks } from "openclaw/plugin-sdk/provider-model-shared";
+import { POOLSIDE_DEFAULT_MODEL_REF, resolvePoolsideDynamicModel } from "./models.js";
+import { applyPoolsideConfig } from "./onboard.js";
+import { buildPoolsideProvider } from "./provider-catalog.js";
+import { createPoolsideSamplingWrapper } from "./stream.js";
+
+const PROVIDER_ID = "poolside";
+
+export default defineSingleProviderPluginEntry({
+  id: PROVIDER_ID,
+  name: "Poolside Provider",
+  description: "Official Poolside Laguna model provider plugin",
+  provider: {
+    label: "Poolside",
+    docsPath: "/providers/poolside",
+    auth: [
+      {
+        methodId: "api-key",
+        label: "Poolside API key",
+        hint: "Laguna model family",
+        optionKey: "poolsideApiKey",
+        flagName: "--poolside-api-key",
+        envVar: "POOLSIDE_API_KEY",
+        promptMessage: "Enter Poolside API key",
+        defaultModel: POOLSIDE_DEFAULT_MODEL_REF,
+        applyConfig: (cfg) => applyPoolsideConfig(cfg),
+        noteTitle: "Poolside",
+        noteMessage: [
+          "Poolside serves the Laguna model family behind one OpenAI-compatible API.",
+          "Learn more at: https://poolside.ai",
+        ].join("\n"),
+        wizard: {
+          groupLabel: "Poolside",
+          groupHint: "Laguna model family",
+        },
+      },
+    ],
+    catalog: {
+      buildProvider: buildPoolsideProvider,
+      buildStaticProvider: buildPoolsideProvider,
+      allowExplicitBaseUrl: true,
+    },
+    resolveDynamicModel: ({ modelId }) => resolvePoolsideDynamicModel(modelId),
+    ...buildProviderReplayFamilyHooks({
+      family: "openai-compatible",
+      dropReasoningFromHistory: false,
+    }),
+    wrapStreamFn: (ctx) => createPoolsideSamplingWrapper(ctx),
+    isModernModelRef: () => true,
+  },
+});

--- a/extensions/poolside/models.ts
+++ b/extensions/poolside/models.ts
@@ -1,0 +1,95 @@
+/**
+ * Poolside model catalog and compat metadata.
+ *
+ * Poolside serves the Laguna model family over an OpenAI-compatible API. The
+ * catalog is static: it lists only the Laguna models, not every model the
+ * Poolside endpoint proxies.
+ */
+import type { ProviderRuntimeModel } from "openclaw/plugin-sdk/plugin-entry";
+import { buildManifestModelProviderConfig } from "openclaw/plugin-sdk/provider-catalog-shared";
+import type {
+  ModelCompatConfig,
+  ModelDefinitionConfig,
+} from "openclaw/plugin-sdk/provider-model-shared";
+import manifest from "./openclaw.plugin.json" with { type: "json" };
+
+const POOLSIDE_MANIFEST_CATALOG = manifest.modelCatalog.providers.poolside;
+const DEFAULT_CONTEXT_WINDOW = 262_144;
+const DEFAULT_MAX_TOKENS = 32_768;
+
+/**
+ * Shared transport policy for every Laguna model.
+ *
+ * Laguna advertises `tools` and `reasoning` only: no `reasoning_effort`,
+ * `json_mode`, or `structured_outputs`. `supportsReasoningEffort` stays false
+ * so OpenClaw never sends a `reasoning_effort` field the endpoint rejects,
+ * while `reasoning: true` still streams `reasoning_content` deltas.
+ */
+const POOLSIDE_COMPAT: ModelCompatConfig = {
+  supportsStore: false,
+  supportsDeveloperRole: false,
+  supportsUsageInStreaming: true,
+  supportsStrictMode: false,
+  supportsTools: true,
+  supportsReasoningEffort: false,
+  maxTokensField: "max_tokens",
+};
+
+/** Base URL for Poolside's OpenAI-compatible inference API. */
+export const POOLSIDE_BASE_URL = POOLSIDE_MANIFEST_CATALOG.baseUrl;
+/** Default Poolside model id used for onboarding. */
+export const POOLSIDE_DEFAULT_MODEL_ID = "laguna-s-2.1";
+/** Default Poolside model ref used for onboarding. */
+export const POOLSIDE_DEFAULT_MODEL_REF = `poolside/${POOLSIDE_DEFAULT_MODEL_ID}`;
+/** Bundled Laguna catalog rows shipped with this release. */
+export const POOLSIDE_MODEL_CATALOG = POOLSIDE_MANIFEST_CATALOG.models;
+
+/** Builds one normalized Poolside model definition from a manifest entry. */
+export function buildPoolsideModelDefinition(
+  model: (typeof POOLSIDE_MODEL_CATALOG)[number],
+): ModelDefinitionConfig {
+  const provider = buildManifestModelProviderConfig({
+    providerId: "poolside",
+    catalog: { ...POOLSIDE_MANIFEST_CATALOG, models: [model] },
+  });
+  const normalized = provider.models[0];
+  if (!normalized) {
+    throw new Error(`Missing normalized Poolside model ${model.id}`);
+  }
+  return {
+    ...normalized,
+    compat: { ...POOLSIDE_COMPAT, ...normalized.compat },
+  };
+}
+
+/** Builds the full static Laguna catalog with shared compat applied. */
+export function buildStaticPoolsideModels(): ModelDefinitionConfig[] {
+  return POOLSIDE_MODEL_CATALOG.map(buildPoolsideModelDefinition);
+}
+
+/** Whether a model id is one of the bundled Laguna catalog rows. */
+export function isPoolsideCatalogModelId(modelId: string): boolean {
+  const id = modelId.trim();
+  return POOLSIDE_MODEL_CATALOG.some((model) => model.id === id);
+}
+
+/** Resolves a forward-compatible Laguna model id not yet in the bundled catalog. */
+export function resolvePoolsideDynamicModel(modelId: string): ProviderRuntimeModel | undefined {
+  const id = modelId.trim();
+  if (!id || isPoolsideCatalogModelId(id)) {
+    return undefined;
+  }
+  return {
+    id,
+    name: id,
+    provider: "poolside",
+    api: "openai-completions" as const,
+    baseUrl: POOLSIDE_BASE_URL,
+    reasoning: true,
+    input: ["text"] as Array<"text" | "image">,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: DEFAULT_CONTEXT_WINDOW,
+    maxTokens: DEFAULT_MAX_TOKENS,
+    compat: { ...POOLSIDE_COMPAT },
+  };
+}

--- a/extensions/poolside/npm-shrinkwrap.json
+++ b/extensions/poolside/npm-shrinkwrap.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/poolside-provider",
+  "version": "2026.7.2",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@openclaw/poolside-provider",
+      "version": "2026.7.2"
+    }
+  }
+}

--- a/extensions/poolside/onboard.ts
+++ b/extensions/poolside/onboard.ts
@@ -1,0 +1,26 @@
+/** Poolside onboarding config helpers. */
+import {
+  createModelCatalogPresetAppliers,
+  type OpenClawConfig,
+} from "openclaw/plugin-sdk/provider-onboard";
+import {
+  buildStaticPoolsideModels,
+  POOLSIDE_BASE_URL,
+  POOLSIDE_DEFAULT_MODEL_REF,
+} from "./models.js";
+
+const poolsidePresetAppliers = createModelCatalogPresetAppliers({
+  primaryModelRef: POOLSIDE_DEFAULT_MODEL_REF,
+  resolveParams: (_cfg: OpenClawConfig) => ({
+    providerId: "poolside",
+    api: "openai-completions",
+    baseUrl: POOLSIDE_BASE_URL,
+    catalogModels: buildStaticPoolsideModels(),
+    aliases: [{ modelRef: POOLSIDE_DEFAULT_MODEL_REF, alias: "Laguna S 2.1" }],
+  }),
+});
+
+/** Applies Poolside's provider catalog, alias, and default model. */
+export function applyPoolsideConfig(cfg: OpenClawConfig): OpenClawConfig {
+  return poolsidePresetAppliers.applyConfig(cfg);
+}

--- a/extensions/poolside/openclaw.plugin.json
+++ b/extensions/poolside/openclaw.plugin.json
@@ -1,0 +1,146 @@
+{
+  "id": "poolside",
+  "name": "Poolside",
+  "description": "OpenClaw Poolside provider plugin.",
+  "activation": {
+    "onStartup": false
+  },
+  "enabledByDefault": true,
+  "providers": ["poolside"],
+  "providerRequest": {
+    "providers": {
+      "poolside": {
+        "family": "poolside",
+        "openAICompletions": {
+          "supportsStreamingUsage": true
+        }
+      }
+    }
+  },
+  "modelCatalog": {
+    "providers": {
+      "poolside": {
+        "baseUrl": "https://inference.poolside.ai/v1",
+        "api": "openai-completions",
+        "models": [
+          {
+            "id": "laguna-s-2.1",
+            "name": "Laguna S 2.1",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 262144,
+            "maxTokens": 32768,
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "laguna-s-2.1:fast",
+            "name": "Laguna S 2.1 Fast",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 1048576,
+            "maxTokens": 32768,
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "laguna-xs-2.1",
+            "name": "Laguna XS 2.1",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 262144,
+            "maxTokens": 32768,
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "laguna-xs-2.1:fast",
+            "name": "Laguna XS 2.1 Fast",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 262144,
+            "maxTokens": 32768,
+            "cost": {
+              "input": 0.1,
+              "output": 0.2,
+              "cacheRead": 0.05,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "laguna-m.1",
+            "name": "Laguna M.1",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 262144,
+            "maxTokens": 32768,
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "laguna-m.1:fast",
+            "name": "Laguna M.1 Fast",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 262144,
+            "maxTokens": 32768,
+            "cost": {
+              "input": 0.2,
+              "output": 0.4,
+              "cacheRead": 0.1,
+              "cacheWrite": 0
+            }
+          }
+        ]
+      }
+    },
+    "discovery": {
+      "poolside": "static"
+    }
+  },
+  "setup": {
+    "providers": [
+      {
+        "id": "poolside",
+        "envVars": ["POOLSIDE_API_KEY"]
+      }
+    ]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "poolside",
+      "method": "api-key",
+      "choiceId": "poolside-api-key",
+      "appGuidedSecret": true,
+      "choiceLabel": "Poolside API key",
+      "groupId": "poolside",
+      "groupLabel": "Poolside",
+      "groupHint": "Laguna model family",
+      "optionKey": "poolsideApiKey",
+      "cliFlag": "--poolside-api-key",
+      "cliOption": "--poolside-api-key <key>",
+      "cliDescription": "Poolside API key"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/poolside/package.json
+++ b/extensions/poolside/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@openclaw/poolside-provider",
+  "version": "2026.7.2",
+  "description": "OpenClaw Poolside provider plugin.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/openclaw/openclaw"
+  },
+  "type": "module",
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ],
+    "install": {
+      "clawhubSpec": "clawhub:@openclaw/poolside-provider",
+      "npmSpec": "@openclaw/poolside-provider",
+      "defaultChoice": "npm",
+      "minHostVersion": ">=2026.7.2"
+    },
+    "compat": {
+      "pluginApi": ">=2026.7.2"
+    },
+    "build": {
+      "openclawVersion": "2026.7.2",
+      "bundledDist": false
+    },
+    "release": {
+      "publishToClawHub": true,
+      "publishToNpm": true
+    }
+  }
+}

--- a/extensions/poolside/poolside.live.test.ts
+++ b/extensions/poolside/poolside.live.test.ts
@@ -1,0 +1,153 @@
+import {
+  streamSimple,
+  type AssistantMessage,
+  type Context,
+  type Model,
+  type Tool,
+} from "openclaw/plugin-sdk/llm";
+import { registerSingleProviderPlugin } from "openclaw/plugin-sdk/plugin-test-runtime";
+import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import { isLiveTestEnabled } from "openclaw/plugin-sdk/test-live";
+import { Type } from "typebox";
+import { describe, expect, it } from "vitest";
+import { runSingleProviderCatalog } from "../test-support/provider-model-test-helpers.js";
+import poolsidePlugin from "./index.js";
+import { POOLSIDE_BASE_URL, POOLSIDE_DEFAULT_MODEL_ID, POOLSIDE_MODEL_CATALOG } from "./models.js";
+import { POOLSIDE_DEFAULT_TEMPERATURE } from "./stream.js";
+
+const LIVE_VALUE = process.env.POOLSIDE_API_KEY?.trim() ?? "";
+const LIVE = isLiveTestEnabled(["POOLSIDE_LIVE_TEST"]) && LIVE_VALUE.length > 0;
+const describeLive = LIVE ? describe : describe.skip;
+
+function asLiveModel(model: ModelDefinitionConfig) {
+  return {
+    ...model,
+    provider: "poolside",
+    baseUrl: POOLSIDE_BASE_URL,
+    api: "openai-completions",
+  } as Model<"openai-completions">;
+}
+
+function liveProbeTool(): Tool {
+  return {
+    name: "live_probe",
+    description: "Return the supplied value.",
+    parameters: Type.Object({ value: Type.String() }, { additionalProperties: false }),
+  };
+}
+
+function requireToolCall(message: AssistantMessage) {
+  const toolCall = message.content.find((block) => block.type === "toolCall");
+  if (toolCall?.type !== "toolCall") {
+    throw new Error(`Laguna did not call the live probe: ${message.stopReason}`);
+  }
+  return toolCall;
+}
+
+describeLive("Poolside plugin live", () => {
+  it(
+    "completes through every bundled Laguna model with the temperature-only contract",
+    async () => {
+      const provider = await registerSingleProviderPlugin(poolsidePlugin);
+      const catalog = await runSingleProviderCatalog(provider);
+      const models = catalog.models;
+      const ids = new Set(models.map((model) => model.id));
+      for (const staticModel of POOLSIDE_MODEL_CATALOG) {
+        expect(ids.has(staticModel.id), `missing model ${staticModel.id}`).toBe(true);
+      }
+
+      console.info(`[poolside:live] exercising ${models.length} models`);
+      const failures: string[] = [];
+      for (const model of models) {
+        try {
+          const wrappedStream = provider.wrapStreamFn?.({
+            provider: "poolside",
+            modelId: model.id,
+            streamFn: streamSimple,
+          } as never);
+          if (!wrappedStream) {
+            throw new Error("Poolside provider did not register a stream wrapper");
+          }
+          const context: Context = {
+            messages: [{ role: "user", content: "Say hello in one word.", timestamp: Date.now() }],
+          };
+          let payload: Record<string, unknown> | undefined;
+          const stream = await wrappedStream(asLiveModel(model), context, {
+            apiKey: LIVE_VALUE,
+            maxTokens: 512,
+            onPayload: (value) => {
+              payload = value as Record<string, unknown>;
+            },
+          });
+          const response = await stream.result();
+          if (response.stopReason === "error" || response.content.length === 0) {
+            throw new Error(response.errorMessage || `empty ${response.stopReason} response`);
+          }
+          // Temperature-only contract: default temperature is applied and no
+          // unsupported sampling field reaches the wire. The wire model id is
+          // restored to the poolside/-prefixed form the endpoint expects.
+          expect(payload?.temperature, model.id).toBe(POOLSIDE_DEFAULT_TEMPERATURE);
+          expect(payload?.top_p, model.id).toBeUndefined();
+          expect(payload?.reasoning_effort, model.id).toBeUndefined();
+          expect(payload?.model, model.id).toBe(`poolside/${model.id}`);
+          console.info(`[poolside:live] ${model.id}: ok`);
+        } catch (error) {
+          failures.push(`${model.id}: ${error instanceof Error ? error.message : String(error)}`);
+        }
+      }
+      expect(failures).toEqual([]);
+    },
+    20 * 60_000,
+  );
+
+  it("runs a Laguna tool call through OpenClaw's completions transport", async () => {
+    const provider = await registerSingleProviderPlugin(poolsidePlugin);
+    const catalog = await runSingleProviderCatalog(provider);
+    const laguna = catalog.models.find((model) => model.id === POOLSIDE_DEFAULT_MODEL_ID);
+    if (!laguna) {
+      throw new Error("Poolside catalog did not include the default Laguna model");
+    }
+
+    const wrappedStream = provider.wrapStreamFn?.({
+      provider: "poolside",
+      modelId: laguna.id,
+      streamFn: streamSimple,
+    } as never);
+    if (!wrappedStream) {
+      throw new Error("Poolside provider did not register a stream wrapper");
+    }
+    let payload: Record<string, unknown> | undefined;
+    const stream = await wrappedStream(
+      asLiveModel(laguna),
+      {
+        systemPrompt: "Call the requested function exactly once.",
+        messages: [
+          {
+            role: "user",
+            content: "Call live_probe with value exactly laguna.",
+            timestamp: Date.now(),
+          },
+        ],
+        tools: [liveProbeTool()],
+      },
+      {
+        apiKey: LIVE_VALUE,
+        maxTokens: 512,
+        onPayload: (value) => {
+          payload = {
+            ...(value as Record<string, unknown>),
+            tool_choice: { type: "function", function: { name: "live_probe" } },
+          };
+          return payload;
+        },
+      },
+    );
+    const response = await stream.result();
+    if (response.stopReason === "error") {
+      throw new Error(response.errorMessage || "Laguna live tool call failed");
+    }
+    expect(payload?.temperature).toBe(POOLSIDE_DEFAULT_TEMPERATURE);
+    const toolCall = requireToolCall(response);
+    expect(toolCall).toMatchObject({ name: "live_probe", arguments: { value: "laguna" } });
+  }, 120_000);
+});

--- a/extensions/poolside/provider-catalog.ts
+++ b/extensions/poolside/provider-catalog.ts
@@ -1,0 +1,12 @@
+/** Poolside static provider catalog builders. */
+import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import { buildStaticPoolsideModels, POOLSIDE_BASE_URL } from "./models.js";
+
+/** Builds Poolside's static Laguna provider catalog. */
+export function buildPoolsideProvider(): ModelProviderConfig {
+  return {
+    baseUrl: POOLSIDE_BASE_URL,
+    api: "openai-completions",
+    models: buildStaticPoolsideModels(),
+  };
+}

--- a/extensions/poolside/stream.test.ts
+++ b/extensions/poolside/stream.test.ts
@@ -1,0 +1,149 @@
+import type { Model } from "openclaw/plugin-sdk/llm";
+import { createAssistantMessageEventStream } from "openclaw/plugin-sdk/llm";
+import type { ProviderWrapStreamFnContext } from "openclaw/plugin-sdk/plugin-entry";
+import { describe, expect, it } from "vitest";
+import {
+  applyPoolsideModelId,
+  createPoolsideSamplingWrapper,
+  POOLSIDE_DEFAULT_TEMPERATURE,
+  sanitizePoolsideSampling,
+} from "./stream.js";
+
+type OpenAICompletionsModel = Model<"openai-completions">;
+
+function poolsideModel(id: string): OpenAICompletionsModel {
+  return {
+    id,
+    name: id,
+    provider: "poolside",
+    api: "openai-completions",
+    baseUrl: "https://inference.poolside.ai/v1",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 262_144,
+    maxTokens: 32_768,
+  };
+}
+
+function capturePayload(params: {
+  model: OpenAICompletionsModel;
+  initialPayload: Record<string, unknown>;
+}): Record<string, unknown> {
+  let captured: Record<string, unknown> = {};
+  const streamFn: NonNullable<ProviderWrapStreamFnContext["streamFn"]> = (
+    model,
+    _context,
+    options,
+  ) => {
+    const payload = { ...params.initialPayload };
+    options?.onPayload?.(payload, model);
+    captured = payload;
+    const stream = createAssistantMessageEventStream();
+    queueMicrotask(() => stream.end());
+    return stream;
+  };
+  const wrapped = createPoolsideSamplingWrapper({
+    provider: params.model.provider,
+    modelId: params.model.id,
+    streamFn,
+  } as ProviderWrapStreamFnContext);
+  if (!wrapped) {
+    throw new Error("expected Poolside sampling wrapper");
+  }
+  void wrapped(params.model, { messages: [] }, {});
+  return captured;
+}
+
+describe("sanitizePoolsideSampling", () => {
+  it("defaults temperature to 0.7 when the caller sets none", () => {
+    const payload: Record<string, unknown> = { model: "laguna-s-2.1" };
+    sanitizePoolsideSampling(payload);
+    expect(payload.temperature).toBe(POOLSIDE_DEFAULT_TEMPERATURE);
+  });
+
+  it("preserves an explicit caller temperature", () => {
+    const payload: Record<string, unknown> = { temperature: 0.2 };
+    sanitizePoolsideSampling(payload);
+    expect(payload.temperature).toBe(0.2);
+  });
+
+  it("preserves an explicit temperature of 0", () => {
+    const payload: Record<string, unknown> = { temperature: 0 };
+    sanitizePoolsideSampling(payload);
+    expect(payload.temperature).toBe(0);
+  });
+
+  it("strips every unsupported sampling field", () => {
+    const payload: Record<string, unknown> = {
+      temperature: 0.5,
+      top_p: 0.9,
+      top_k: 40,
+      min_p: 0.05,
+      presence_penalty: 0.5,
+      frequency_penalty: 0.5,
+      n: 2,
+    };
+    sanitizePoolsideSampling(payload);
+    expect(payload).toEqual({ temperature: 0.5 });
+  });
+});
+
+describe("applyPoolsideModelId", () => {
+  it("prefixes a bare Laguna model id with poolside/", () => {
+    const payload: Record<string, unknown> = { model: "laguna-s-2.1" };
+    applyPoolsideModelId(payload);
+    expect(payload.model).toBe("poolside/laguna-s-2.1");
+  });
+
+  it("prefixes the fast variant", () => {
+    const fast: Record<string, unknown> = { model: "laguna-s-2.1:fast" };
+    applyPoolsideModelId(fast);
+    expect(fast.model).toBe("poolside/laguna-s-2.1:fast");
+  });
+
+  it("leaves an already-prefixed model id untouched", () => {
+    const payload: Record<string, unknown> = { model: "poolside/laguna-m.1" };
+    applyPoolsideModelId(payload);
+    expect(payload.model).toBe("poolside/laguna-m.1");
+  });
+
+  it("does nothing when there is no model field", () => {
+    const payload: Record<string, unknown> = { temperature: 0.7 };
+    applyPoolsideModelId(payload);
+    expect(payload).toEqual({ temperature: 0.7 });
+  });
+});
+
+describe("createPoolsideSamplingWrapper", () => {
+  it("injects the default temperature, strips unsupported fields, and prefixes the model", () => {
+    expect(
+      capturePayload({
+        model: poolsideModel("laguna-s-2.1"),
+        initialPayload: { model: "laguna-s-2.1", top_p: 0.95, frequency_penalty: 0.1 },
+      }),
+    ).toEqual({ model: "poolside/laguna-s-2.1", temperature: POOLSIDE_DEFAULT_TEMPERATURE });
+  });
+
+  it("keeps a caller-provided temperature while dropping unsupported fields", () => {
+    expect(
+      capturePayload({
+        model: poolsideModel("laguna-m.1"),
+        initialPayload: { model: "laguna-m.1", temperature: 0.3, top_p: 0.95 },
+      }),
+    ).toEqual({ model: "poolside/laguna-m.1", temperature: 0.3 });
+  });
+
+  it("leaves non-Poolside models untouched", () => {
+    const foreignModel = {
+      ...poolsideModel("laguna-s-2.1"),
+      provider: "openai",
+    } as OpenAICompletionsModel;
+    expect(
+      capturePayload({
+        model: foreignModel,
+        initialPayload: { model: "laguna-s-2.1", top_p: 0.95 },
+      }),
+    ).toEqual({ model: "laguna-s-2.1", top_p: 0.95 });
+  });
+});

--- a/extensions/poolside/stream.ts
+++ b/extensions/poolside/stream.ts
@@ -1,0 +1,66 @@
+/**
+ * Poolside request sampling and model-id policy.
+ *
+ * Poolside's Laguna endpoints accept only `temperature`. They ignore `top_p`,
+ * `top_k`, `min_p`, and the penalties, and their no-parameter default
+ * (temperature 1.0, untruncated) leaks control tokens and repeats. This wrapper
+ * forces a safe default temperature when the caller sets none, and drops the
+ * unsupported sampling fields so nothing surprising reaches the wire.
+ *
+ * The endpoint also expects the `poolside/`-prefixed model id on the wire (for
+ * example `poolside/laguna-s-2.1`), while OpenClaw model refs stay
+ * `poolside/laguna-s-2.1` with the bare `laguna-s-2.1` catalog id. The wrapper
+ * restores the prefix so the model ref reads cleanly without a double prefix.
+ */
+import type { ProviderWrapStreamFnContext } from "openclaw/plugin-sdk/plugin-entry";
+import { createPayloadPatchStreamWrapper } from "openclaw/plugin-sdk/provider-stream-shared";
+
+const POOLSIDE_PROVIDER_ID = "poolside";
+const POOLSIDE_MODEL_ID_PREFIX = "poolside/";
+
+/** Safe default temperature for Laguna models when the caller sets none. */
+export const POOLSIDE_DEFAULT_TEMPERATURE = 0.7;
+
+/** Sampling fields Poolside ignores; stripped so they never reach the wire. */
+const POOLSIDE_UNSUPPORTED_SAMPLING_FIELDS = [
+  "top_p",
+  "top_k",
+  "min_p",
+  "presence_penalty",
+  "frequency_penalty",
+  "n",
+] as const;
+
+/** Applies Poolside's temperature-only sampling contract to a request payload. */
+export function sanitizePoolsideSampling(payload: Record<string, unknown>): void {
+  for (const field of POOLSIDE_UNSUPPORTED_SAMPLING_FIELDS) {
+    delete payload[field];
+  }
+  if (typeof payload.temperature !== "number") {
+    payload.temperature = POOLSIDE_DEFAULT_TEMPERATURE;
+  }
+}
+
+/** Restores the `poolside/` prefix the endpoint expects on the wire model id. */
+export function applyPoolsideModelId(payload: Record<string, unknown>): void {
+  if (
+    typeof payload.model === "string" &&
+    payload.model.length > 0 &&
+    !payload.model.startsWith(POOLSIDE_MODEL_ID_PREFIX)
+  ) {
+    payload.model = `${POOLSIDE_MODEL_ID_PREFIX}${payload.model}`;
+  }
+}
+
+/** Wraps the stream fn to enforce Poolside's sampling and model-id contract. */
+export function createPoolsideSamplingWrapper(
+  ctx: ProviderWrapStreamFnContext,
+): ProviderWrapStreamFnContext["streamFn"] {
+  return createPayloadPatchStreamWrapper(ctx.streamFn, ({ payload, model }) => {
+    if (model.provider !== POOLSIDE_PROVIDER_ID || model.api !== "openai-completions") {
+      return;
+    }
+    sanitizePoolsideSampling(payload);
+    applyPoolsideModelId(payload);
+  });
+}

--- a/extensions/poolside/tsconfig.json
+++ b/extensions/poolside/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../tsconfig.package-boundary.base.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["./*.ts", "./src/**/*.ts"],
+  "exclude": [
+    "./**/*.test.ts",
+    "./dist/**",
+    "./node_modules/**",
+    "./src/test-support/**",
+    "./src/**/*test-helpers.ts",
+    "./src/**/*test-harness.ts",
+    "./src/**/*test-support.ts"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
     "!dist/extensions/nostr/**",
     "!dist/extensions/parallel/**",
     "!dist/extensions/perplexity/**",
+    "!dist/extensions/poolside/**",
     "!dist/extensions/qianfan/**",
     "!dist/extensions/qqbot/**",
     "!dist/extensions/raft/**",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1479,6 +1479,12 @@ importers:
         specifier: workspace:*
         version: link:../..
 
+  extensions/poolside:
+    devDependencies:
+      '@openclaw/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../packages/plugin-sdk
+
   extensions/qa-channel:
     dependencies:
       typebox:

--- a/scripts/lib/official-external-provider-catalog.json
+++ b/scripts/lib/official-external-provider-catalog.json
@@ -946,6 +946,55 @@
       }
     },
     {
+      "name": "@openclaw/poolside-provider",
+      "description": "OpenClaw Poolside provider plugin.",
+      "source": "official",
+      "kind": "provider",
+      "openclaw": {
+        "plugin": {
+          "id": "poolside",
+          "label": "Poolside"
+        },
+        "providers": [
+          {
+            "id": "poolside",
+            "name": "Poolside",
+            "docs": "/providers/poolside",
+            "categories": [
+              "cloud",
+              "llm"
+            ],
+            "envVars": [
+              "POOLSIDE_API_KEY"
+            ],
+            "authChoices": [
+              {
+                "method": "api-key",
+                "choiceId": "poolside-api-key",
+                "choiceLabel": "Poolside API key",
+                "groupId": "poolside",
+                "groupLabel": "Poolside",
+                "groupHint": "Laguna model family",
+                "optionKey": "poolsideApiKey",
+                "cliFlag": "--poolside-api-key",
+                "cliOption": "--poolside-api-key <key>",
+                "cliDescription": "Poolside API key",
+                "onboardingScopes": [
+                  "text-inference"
+                ]
+              }
+            ]
+          }
+        ],
+        "install": {
+          "clawhubSpec": "clawhub:@openclaw/poolside-provider",
+          "npmSpec": "@openclaw/poolside-provider",
+          "defaultChoice": "npm",
+          "minHostVersion": ">=2026.7.2"
+        }
+      }
+    },
+    {
       "name": "@openclaw/qianfan-provider",
       "description": "OpenClaw Qianfan provider plugin.",
       "source": "official",


### PR DESCRIPTION
## What Problem This Solves

OpenClaw users have no way to route models through poolside. Anyone with a
poolside API key had to fall back to a generic OpenAI-compatible custom
provider, which mishandles poolside's sampling contract and model naming, so
`poolside/laguna-*` models did not work out of the box.

## Why This Change Was Made

Adds a self-contained bundled provider plugin (`extensions/poolside/`,
mirroring the baseten provider layout) using the `openai-completions`
transport against `https://inference.poolside.ai/v1`. Provider-specific
policy is kept in one place (`stream.ts`): the endpoint's temperature-only
sampling contract (defaults to 0.7, strips top_p/top_k/min_p/penalties/n)
and the `poolside/` wire prefix the endpoint requires. No changes outside
the plugin and its catalog/docs/labeler wiring.

## User Impact

Users can select 6 Laguna models (`laguna-s-2.1`, `laguna-xs-2.1`,
`laguna-m.1`, and their `:fast` variants) with tool calling and streamed
reasoning content, after setting `POOLSIDE_API_KEY`. All models have 256K
context, except `laguna-s-2.1:fast` which serves 1M.

## Evidence

AI-assisted.

- `pnpm test:extension poolside`: 18/18 pass
- Live e2e vs the real endpoint (`POOLSIDE_LIVE_TEST=1`): 2/2 pass, all 6
  models return "ok" under the temperature-only contract, including a tool
  call round trip
- `oxlint`, `oxfmt --check`, `tsgo --noEmit`, `docs:map:check`, and
  `docs:check-i18n-glossary` all clean on the touched surface
- `check:changed` delegates to Blacksmith Testbox (no org access from this
  machine); relying on CI for that lane
