### PR TITLE
fix(onboard): survive inference owner drift and prefer subscription logins in guided setup

### DIFF
--- a/docs/cli/openclaw.md
+++ b/docs/cli/openclaw.md
@@ -180,7 +180,7 @@ setup workspace ~/Projects/work
 `setup` preserves the verified effective model. It does not configure or
 replace inference.
 
-If inference is missing or its live check fails, leave OpenClaw and run `openclaw onboard`. Guided onboarding detects configured models, API keys, and authenticated local CLIs, asks each candidate for a real reply, and persists only a passing route. OpenClaw starts immediately after that boundary and can then configure the workspace, Gateway, channels, agents, plugins, and other optional features.
+If inference is missing or its live check fails, leave OpenClaw and run `openclaw onboard`. Guided onboarding tries the configured model first, then authenticated subscription CLIs, API keys, and remaining supported CLIs; it asks each candidate for a real reply and persists only a passing route. OpenClaw starts immediately after that boundary and can then configure the workspace, Gateway, channels, agents, plugins, and other optional features.
 
 The macOS app skips this ladder entirely when it reaches a configured Gateway
 whose default agent already has a configured model; it opens the normal agent

--- a/src/agents/embedded-agent-runner/run-loop.ts
+++ b/src/agents/embedded-agent-runner/run-loop.ts
@@ -603,6 +603,8 @@ export async function runPreparedEmbeddedLoop(
         startedAtMs: started,
         provider,
         modelId,
+        modelTransportId: effectiveModel.id ?? modelId,
+        modelTransportApi: effectiveModel.api ?? model.api,
         authProfileId: lastProfileId,
         profileFailureStore,
         attemptAuthProfileStore,

--- a/src/agents/embedded-agent-runner/run.overflow-compaction.test.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.test.ts
@@ -1636,6 +1636,8 @@ describe("runEmbeddedAgent overflow compaction trigger routing", () => {
       expect.objectContaining({
         authProfileId: "openai:work",
         agentHarnessId: "codex",
+        modelId: "gpt-5.4",
+        modelApi: "openai-responses",
         authFingerprint: "resolved-secretref-fingerprint",
         runtimeOwnerKind: "plugin-harness",
         runtimeOwnerId: "codex",
@@ -1719,6 +1721,8 @@ describe("runEmbeddedAgent overflow compaction trigger routing", () => {
     expect(onSuccessfulAuthBinding).toHaveBeenCalledWith({
       authProfileId: "openai:work",
       agentHarnessId: "codex",
+      modelId: "gpt-5.4",
+      modelApi: "openai-responses",
       runtimeOwnerFingerprint: expect.any(String),
       runtimeOwnerKind: "plugin-harness",
       runtimeOwnerId: "codex",

--- a/src/agents/embedded-agent-runner/run/auth-profile-success.ts
+++ b/src/agents/embedded-agent-runner/run/auth-profile-success.ts
@@ -75,6 +75,8 @@ export function reportEmbeddedRunSuccessfulAuthBinding(input: {
   apiKeyInfo: ResolvedProviderAuth | null;
   attempt: EmbeddedRunAttemptResult;
   provider: string;
+  modelId: string;
+  modelApi: string;
   agentHarnessId: string;
   pluginHarnessOwnsTransport: boolean;
   pluginHarnessOwnsAuthBootstrap: boolean;
@@ -141,6 +143,8 @@ export function reportEmbeddedRunSuccessfulAuthBinding(input: {
   input.onSuccessfulAuthBinding?.({
     ...(input.profileId ? { authProfileId: input.profileId } : {}),
     agentHarnessId: input.agentHarnessId,
+    modelId: input.modelId,
+    modelApi: input.modelApi,
     ...(authFingerprint ? { authFingerprint } : {}),
     ...(runtimeOwnerFingerprint ? { runtimeOwnerFingerprint } : {}),
     ...(runtimeOwnerKind ? { runtimeOwnerKind } : {}),

--- a/src/agents/embedded-agent-runner/run/terminal-resolution.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-resolution.ts
@@ -98,6 +98,8 @@ export async function resolveEmbeddedRunTerminal(input: {
   startedAtMs: number;
   provider: string;
   modelId: string;
+  modelTransportId: string;
+  modelTransportApi: string;
   authProfileId?: string;
   profileFailureStore: AuthProfileStore;
   attemptAuthProfileStore: AuthProfileStore;
@@ -447,6 +449,8 @@ function completeEmbeddedRun(
     apiKeyInfo: input.apiKeyInfo,
     attempt: input.attempt,
     provider: input.provider,
+    modelId: input.modelTransportId,
+    modelApi: input.modelTransportApi,
     agentHarnessId: input.agentHarnessId,
     pluginHarnessOwnsTransport: input.pluginHarnessOwnsTransport,
     pluginHarnessOwnsAuthBootstrap: input.pluginHarnessOwnsAuthBootstrap,

--- a/src/agents/execution-auth-binding.ts
+++ b/src/agents/execution-auth-binding.ts
@@ -7,6 +7,10 @@ export type AgentExecutionAuthBinding = {
   authProfileId?: string;
   /** Exact embedded harness that completed the successful turn, including openclaw. */
   agentHarnessId?: string;
+  /** Exact model selected by the successful embedded run. */
+  modelId?: string;
+  /** Exact transport used to select that run's credential. */
+  modelApi?: string;
   /** Non-reversible identity hash; credential material never leaves the runner. */
   authFingerprint?: string;
   /** Runtime-owned principal/session shape used when credentials are intentionally opaque. */

--- a/src/commands/auth-choice-options.static.ts
+++ b/src/commands/auth-choice-options.static.ts
@@ -19,6 +19,7 @@ export type AuthChoiceGroup = {
   value: AuthChoiceGroupId;
   label: string;
   hint?: string;
+  methodMessage?: string;
   providerIds?: string[];
   options: AuthChoiceOption[];
 };

--- a/src/commands/auth-choice-prompt.test.ts
+++ b/src/commands/auth-choice-prompt.test.ts
@@ -339,7 +339,10 @@ describe("promptAuthChoiceGrouped", () => {
       store: EMPTY_STORE,
       includeSkip: true,
       additionalGroups: [
-        authChoiceGroup("detected-ai", "Detected AI", [["candidate:codex-cli", "Codex CLI"]]),
+        {
+          ...authChoiceGroup("detected-ai", "Detected AI", [["candidate:codex-cli", "Codex CLI"]]),
+          hint: "Codex CLI",
+        },
         authChoiceGroup("recommended-ai", "Recommended AI", [
           ["candidate:openai-api-key", "OpenAI API key"],
         ]),
@@ -354,7 +357,38 @@ describe("promptAuthChoiceGrouped", () => {
       "__more",
       "skip",
     ]);
+    expect(providerPrompts[0]?.[0]).toMatchObject({
+      value: "detected-ai",
+      hint: "Codex CLI",
+    });
     expect(providerPrompts[1]?.map((option) => option.value)).toEqual(["minimax", "__back"]);
     expect(result).toBe("minimax-api");
+  });
+
+  it("uses a caller-supplied method prompt when provided", async () => {
+    buildAuthChoiceGroups.mockReturnValue({ groups: [], skipOption: undefined });
+    const messages: string[] = [];
+    const prompter = createPromptHarness(async (params) => {
+      messages.push(params.message);
+      return params.message === "Model/auth provider" ? "detected-ai" : "candidate:codex-cli";
+    });
+
+    const result = await promptAuthChoiceGrouped({
+      prompter,
+      store: EMPTY_STORE,
+      includeSkip: false,
+      additionalGroups: [
+        {
+          ...authChoiceGroup("detected-ai", "Detected on this machine", [
+            ["candidate:codex-cli", "Codex CLI"],
+            ["candidate:claude-cli", "Claude Code"],
+          ]),
+          methodMessage: "Use which detected AI?",
+        },
+      ],
+    });
+
+    expect(messages).toEqual(["Model/auth provider", "Use which detected AI?"]);
+    expect(result).toBe("candidate:codex-cli");
   });
 });

--- a/src/commands/auth-choice-prompt.test.ts
+++ b/src/commands/auth-choice-prompt.test.ts
@@ -315,4 +315,46 @@ describe("promptAuthChoiceGrouped", () => {
     ]);
     expect(result).toBe("minimax-cn-api");
   });
+
+  it("features caller-supplied groups first and excludes them from More", async () => {
+    buildAuthChoiceGroups.mockReturnValue({
+      groups: [
+        openAIGroup(),
+        authChoiceGroup("anthropic", "Anthropic", [["apiKey", "Anthropic API key"]], true),
+        authChoiceGroup("minimax", "MiniMax", [["minimax-api", "MiniMax API key"]]),
+      ],
+      skipOption: { value: "skip", label: "Skip for now" },
+    });
+    const providerPrompts: Array<Array<{ value: unknown; label: string }>> = [];
+    const prompter = createPromptHarness(async (params) => {
+      if (params.message !== "Model/auth provider") {
+        throw new Error(`unexpected prompt ${params.message}`);
+      }
+      providerPrompts.push(params.options);
+      return providerPrompts.length === 1 ? "__more" : "minimax";
+    });
+
+    const result = await promptAuthChoiceGrouped({
+      prompter,
+      store: EMPTY_STORE,
+      includeSkip: true,
+      additionalGroups: [
+        authChoiceGroup("detected-ai", "Detected AI", [["candidate:codex-cli", "Codex CLI"]]),
+        authChoiceGroup("recommended-ai", "Recommended AI", [
+          ["candidate:openai-api-key", "OpenAI API key"],
+        ]),
+      ],
+    });
+
+    expect(providerPrompts[0]?.map((option) => option.value)).toEqual([
+      "detected-ai",
+      "recommended-ai",
+      "anthropic",
+      "openai",
+      "__more",
+      "skip",
+    ]);
+    expect(providerPrompts[1]?.map((option) => option.value)).toEqual(["minimax", "__back"]);
+    expect(result).toBe("minimax-api");
+  });
 });

--- a/src/commands/auth-choice-prompt.ts
+++ b/src/commands/auth-choice-prompt.ts
@@ -82,14 +82,19 @@ export async function promptAuthChoiceGrouped(
         options: group.options.filter((option) => params.allowedChoices?.has(option.value)),
       }))
     : groups;
-  const availableGroups = [...filteredGroups, ...(params.additionalGroups ?? [])].filter(
+  const availableBuiltInGroups = filteredGroups.filter((group) => group.options.length > 0);
+  const additionalGroups = (params.additionalGroups ?? []).filter(
     (group) => group.options.length > 0,
   );
+  const availableGroups = [...availableBuiltInGroups, ...additionalGroups];
   const groupById = new Map(availableGroups.map((group) => [group.value, group] as const));
-  const featuredGroups = availableGroups
-    .filter(isFeaturedAuthChoiceGroup)
-    .toSorted(compareAuthChoiceGroups);
-  const moreGroups = availableGroups
+  // Caller-supplied groups carry pre-vetted context such as detected onboarding routes.
+  // Keep them ahead of the generic catalog instead of demoting them under More.
+  const featuredGroups = [
+    ...additionalGroups,
+    ...availableBuiltInGroups.filter(isFeaturedAuthChoiceGroup).toSorted(compareAuthChoiceGroups),
+  ];
+  const moreGroups = availableBuiltInGroups
     .filter((group) => !isFeaturedAuthChoiceGroup(group))
     .toSorted(compareAuthChoiceGroups);
   const configuredModelRef = resolveConfiguredModelRef(params.config);

--- a/src/commands/auth-choice-prompt.ts
+++ b/src/commands/auth-choice-prompt.ts
@@ -114,7 +114,7 @@ export async function promptAuthChoiceGrouped(
       return expectDefined(group.options[0], "options entry at 0").value;
     }
     return (await params.prompter.select({
-      message: `${group.label} auth method`,
+      message: group.methodMessage ?? `${group.label} auth method`,
       options: [
         ...(keepCurrentOption ? [keepCurrentOption] : []),
         ...group.options,

--- a/src/commands/onboard-guided-manual.ts
+++ b/src/commands/onboard-guided-manual.ts
@@ -127,7 +127,9 @@ export async function runManualStage(params: {
     ? [
         {
           value: "detected-ai",
-          label: t("wizard.guided.detectedTitle"),
+          label: t("wizard.guided.detectedGroupLabel"),
+          hint: params.detection.candidates.map((candidate) => candidate.label).join(", "),
+          methodMessage: t("wizard.guided.detectedGroupPrompt"),
           options: detectedOptions,
         },
       ]

--- a/src/commands/onboard-guided.custodian.test.ts
+++ b/src/commands/onboard-guided.custodian.test.ts
@@ -69,7 +69,7 @@ function existingModelCandidate() {
   return {
     kind: "existing-model",
     label: "Current model",
-    detail: "already configured",
+    detail: "acme/workspace-model — already configured",
     modelRef: "acme/workspace-model",
     recommended: false,
     credentials: true,
@@ -282,15 +282,62 @@ describe("runGuidedOnboarding custodian flow", () => {
   it("keeps the working route when other options are explored and skipped", async () => {
     promptAuthChoiceGrouped.mockResolvedValueOnce("skip");
     const prompter = createWizardPrompter(undefined, { selectValues: ["full", "other"] });
-    const deps = setupDeps({ prompter });
+    const deps = setupDeps({
+      prompter,
+      detect: vi.fn(async () =>
+        detection({
+          candidates: [candidate("claude-cli", "Claude Code"), candidate("codex-cli", "Codex")],
+        }),
+      ),
+    });
 
     await runGuidedOnboarding({ acceptRisk: true, workspace: "/tmp/work" }, makeRuntime(), deps);
 
     expect(promptAuthChoiceGrouped).toHaveBeenCalledOnce();
+    expect(promptAuthChoiceGrouped).toHaveBeenCalledWith(
+      expect.objectContaining({
+        additionalGroups: [
+          expect.objectContaining({
+            label: "Detected on this machine",
+            hint: "Claude Code, Codex",
+            methodMessage: "Use which detected AI?",
+          }),
+        ],
+      }),
+    );
     const notes = JSON.stringify((prompter.note as ReturnType<typeof vi.fn>).mock.calls);
     expect(notes).toContain("Keeping the working AI you already have.");
     expect(notes).not.toContain("Add AI later");
     expect(deps.launchHatchTui).toHaveBeenCalledWith("/tmp/work");
+  });
+
+  it("names the configured model in the recommended route confirmation", async () => {
+    const prompter = createWizardPrompter(undefined, { selectValues: ["full", "use"] });
+    const deps = setupDeps({
+      prompter,
+      detect: vi.fn(async () => detection({ candidates: [existingModelCandidate()] })),
+      activate: vi.fn(async () => ({
+        ok: true as const,
+        modelRef: "acme/workspace-model",
+        latencyMs: 125,
+        lines: ["Default model: acme/workspace-model"],
+      })),
+    });
+
+    await runGuidedOnboarding({ acceptRisk: true, workspace: "/tmp/work" }, makeRuntime(), deps);
+
+    expect(prompter.select).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        message: "Use Current model (acme/workspace-model)?",
+        options: expect.arrayContaining([
+          expect.objectContaining({
+            value: "use",
+            label: "Continue with Current model (acme/workspace-model) — recommended",
+          }),
+        ]),
+      }),
+    );
   });
 
   it("quips about detected coding agents", async () => {

--- a/src/commands/onboard-guided.test.ts
+++ b/src/commands/onboard-guided.test.ts
@@ -78,7 +78,7 @@ function existingModelCandidate() {
   return {
     kind: "existing-model",
     label: "Current model",
-    detail: "already configured",
+    detail: "acme/workspace-model — already configured",
     modelRef: "acme/workspace-model",
     recommended: false,
     credentials: true,

--- a/src/commands/onboard-guided.ts
+++ b/src/commands/onboard-guided.ts
@@ -286,7 +286,10 @@ async function runGuidedOnboardingFlow(
       });
       if (attempt.kind === "success") {
         resultLines = activationLines(attempt.result);
-        successLabel = candidate.label;
+        successLabel =
+          candidate.kind === "existing-model"
+            ? `${candidate.label} (${candidate.modelRef})`
+            : candidate.label;
         break;
       }
       // The verification probe runs outside the configured workspace (setup never

--- a/src/commands/onboard-inference.test.ts
+++ b/src/commands/onboard-inference.test.ts
@@ -78,6 +78,7 @@ describe("detectInferenceBackends", () => {
       "gemini-cli",
     ]);
     expect(candidates[0]?.modelRef).toBe("zai/glm-5.2");
+    expect(candidates[0]?.detail).toBe("zai/glm-5.2 — already configured");
     expect(candidates[1]?.modelRef).toBe(CLAUDE_CLI_DEFAULT_MODEL_REF);
     expect(candidates[2]?.modelRef).toBe(CODEX_APP_SERVER_DEFAULT_MODEL_REF);
     expect(candidates[3]?.modelRef).toBe(OPENAI_API_DEFAULT_MODEL_REF);

--- a/src/commands/onboard-inference.test.ts
+++ b/src/commands/onboard-inference.test.ts
@@ -56,37 +56,114 @@ describe("detectInferenceBackends", () => {
     expect(candidates).toEqual([]);
   });
 
-  it("orders the ladder: existing model, env keys, then CLI logins", async () => {
+  it("orders the ladder: existing model, logged-in subscriptions, env keys, then fallback CLIs", async () => {
     const candidates = await detectInferenceBackends({
       config: { agents: { defaults: { model: "zai/glm-5.2" } } },
       env: { OPENAI_API_KEY: "sk-x", ANTHROPIC_API_KEY: "sk-y" },
       platform: "linux",
       deps: {
-        probeLocalCommand: probeDeps({ claude: true, codex: true }),
+        probeLocalCommand: probeDeps({ claude: true, codex: true, gemini: true }),
         readClaudeCliCredentials: () => ({ type: "oauth" }),
+        readCodexCliCredentials: () => ({ type: "oauth" }),
+        readGeminiCliCredentials: () => ({ type: "oauth" }),
+        randomInt: () => 0,
+      },
+    });
+    expect(candidates.map((candidate) => candidate.kind)).toEqual([
+      "existing-model",
+      "claude-cli",
+      "codex-cli",
+      "openai-api-key",
+      "anthropic-api-key",
+      "gemini-cli",
+    ]);
+    expect(candidates[0]?.modelRef).toBe("zai/glm-5.2");
+    expect(candidates[1]?.modelRef).toBe(CLAUDE_CLI_DEFAULT_MODEL_REF);
+    expect(candidates[2]?.modelRef).toBe(CODEX_APP_SERVER_DEFAULT_MODEL_REF);
+    expect(candidates[3]?.modelRef).toBe(OPENAI_API_DEFAULT_MODEL_REF);
+    expect(candidates[4]?.modelRef).toBe(ANTHROPIC_API_DEFAULT_MODEL_REF);
+  });
+
+  it("ranks a logged-in Codex subscription before an OpenAI environment key", async () => {
+    const candidates = await detectInferenceBackends({
+      env: { OPENAI_API_KEY: "sk-x" },
+      platform: "linux",
+      deps: {
+        probeLocalCommand: probeDeps({ codex: true }),
         readCodexCliCredentials: () => ({ type: "oauth" }),
       },
     });
-    expect(candidates.slice(0, 3).map((candidate) => candidate.kind)).toEqual([
-      "existing-model",
-      "openai-api-key",
+
+    expect(candidates.map((candidate) => candidate.kind)).toEqual(["codex-cli", "openai-api-key"]);
+  });
+
+  it("keeps API-key-helper-backed Claude after environment keys", async () => {
+    const candidates = await detectInferenceBackends({
+      env: { ANTHROPIC_API_KEY: "sk-y" },
+      platform: "linux",
+      deps: {
+        probeLocalCommand: probeDeps({ claude: true }),
+        readClaudeCliCredentials: () => ({ type: "api_key_helper" }),
+      },
+    });
+
+    expect(candidates.map((candidate) => candidate.kind)).toEqual([
       "anthropic-api-key",
+      "claude-cli",
     ]);
-    expect(
-      candidates
-        .slice(3)
-        .map((candidate) => candidate.kind)
-        .toSorted(),
-    ).toEqual(["claude-cli", "codex-cli"]);
-    expect(candidates[0]?.modelRef).toBe("zai/glm-5.2");
-    expect(candidates[1]?.modelRef).toBe(OPENAI_API_DEFAULT_MODEL_REF);
-    expect(candidates[2]?.modelRef).toBe(ANTHROPIC_API_DEFAULT_MODEL_REF);
-    expect(
-      candidates
-        .slice(3)
-        .map((candidate) => candidate.modelRef)
-        .toSorted(),
-    ).toEqual([CLAUDE_CLI_DEFAULT_MODEL_REF, CODEX_APP_SERVER_DEFAULT_MODEL_REF].toSorted());
+    expect(candidates[1]).toMatchObject({ credentials: true, detail: "logged in" });
+  });
+
+  it("keeps an Anthropic environment key ahead of unknown Claude credentials", async () => {
+    const candidates = await detectInferenceBackends({
+      env: { ANTHROPIC_API_KEY: "sk-y" },
+      platform: "darwin",
+      deps: {
+        probeLocalCommand: probeDeps({ claude: true }),
+        readClaudeCliCredentials: () => null,
+      },
+    });
+
+    expect(candidates.map((candidate) => candidate.kind)).toEqual([
+      "anthropic-api-key",
+      "claude-cli",
+    ]);
+    expect(candidates[1]?.credentials).toBeUndefined();
+  });
+
+  it("keeps a logged-in Gemini CLI after environment keys", async () => {
+    const candidates = await detectInferenceBackends({
+      env: { OPENAI_API_KEY: "sk-x" },
+      platform: "linux",
+      deps: {
+        probeLocalCommand: probeDeps({ gemini: true }),
+        readGeminiCliCredentials: () => ({ type: "oauth" }),
+      },
+    });
+
+    expect(candidates.map((candidate) => candidate.kind)).toEqual(["openai-api-key", "gemini-cli"]);
+  });
+
+  it("keeps the existing model first and definitively logged-out CLIs last", async () => {
+    const candidates = await detectInferenceBackends({
+      config: { agents: { defaults: { model: "zai/glm-5.2" } } },
+      env: { OPENAI_API_KEY: "sk-x" },
+      platform: "linux",
+      deps: {
+        probeLocalCommand: probeDeps({ claude: true, codex: true, gemini: true }),
+        readClaudeCliCredentials: () => null,
+        readCodexCliCredentials: () => ({ type: "oauth" }),
+        readGeminiCliCredentials: () => null,
+      },
+    });
+
+    expect(candidates.map((candidate) => candidate.kind)).toEqual([
+      "existing-model",
+      "codex-cli",
+      "openai-api-key",
+      "claude-cli",
+      "gemini-cli",
+    ]);
   });
 
   it("prefers the configured default agent model over the global default", async () => {

--- a/src/commands/onboard-inference.test.ts
+++ b/src/commands/onboard-inference.test.ts
@@ -97,6 +97,21 @@ describe("detectInferenceBackends", () => {
     expect(candidates.map((candidate) => candidate.kind)).toEqual(["codex-cli", "openai-api-key"]);
   });
 
+  it("keeps status-only Codex login after env keys without verifiable OAuth tokens", async () => {
+    const candidates = await detectInferenceBackends({
+      env: { OPENAI_API_KEY: "sk-x" },
+      platform: "linux",
+      deps: {
+        probeLocalCommand: probeDeps({ codex: true }),
+        readCodexCliCredentials: () => null,
+        detectCodexLoginState: async () => true,
+      },
+    });
+
+    expect(candidates.map((candidate) => candidate.kind)).toEqual(["openai-api-key", "codex-cli"]);
+    expect(candidates[1]).toMatchObject({ credentials: true, detail: "logged in" });
+  });
+
   it("keeps API-key-helper-backed Claude after environment keys", async () => {
     const candidates = await detectInferenceBackends({
       env: { ANTHROPIC_API_KEY: "sk-y" },

--- a/src/commands/onboard-inference.ts
+++ b/src/commands/onboard-inference.ts
@@ -6,6 +6,7 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { resolveAgentConfig, resolveDefaultAgentId } from "../agents/agent-scope-config.js";
 import {
   readClaudeCliCredentialsCached,
+  readCodexCliCredentialsCached,
   readGeminiCliCredentialsCached,
 } from "../agents/cli-credentials.js";
 import { resolveDefaultModelForAgent } from "../agents/model-selection.js";
@@ -42,6 +43,7 @@ type DetectInferenceBackendsDeps = {
   readClaudeCliCredentials?: () => { type: string } | null;
   readCodexCliCredentials?: () => { type: string } | null;
   readGeminiCliCredentials?: () => { type: string } | null;
+  detectCodexLoginState?: typeof detectCodexLoginState;
   randomInt?: (maxExclusive: number) => number;
 };
 
@@ -175,6 +177,9 @@ export async function detectInferenceBackends(
   const readClaude =
     options.deps?.readClaudeCliCredentials ??
     (() => readClaudeCliCredentialsCached({ allowKeychainPrompt: false, ttlMs: 60_000 }));
+  const readCodex =
+    options.deps?.readCodexCliCredentials ??
+    (() => readCodexCliCredentialsCached({ allowKeychainPrompt: false, ttlMs: 60_000 }));
   const readGemini =
     options.deps?.readGeminiCliCredentials ??
     (() => readGeminiCliCredentialsCached({ ttlMs: 60_000 }));
@@ -230,16 +235,19 @@ export async function detectInferenceBackends(
     });
   }
   if (codexProbe.found && !codexProbe.timedOut) {
-    const credentials = options.deps?.readCodexCliCredentials
-      ? detectCliCredentialState({
-          probe: codexProbe,
-          hasStoredCredentials: options.deps.readCodexCliCredentials() !== null,
-          platform,
-        })
-      : await detectCodexLoginState(probe, codexProbe.command);
-    // Codex's file reader exposes only ChatGPT OAuth, while production login status
-    // has no credential type; accept a successful status as subscription-backed.
-    if (credentials === true) {
+    const codexCredential = readCodex();
+    const credentials = options.deps?.detectCodexLoginState
+      ? await options.deps.detectCodexLoginState(probe, codexProbe.command)
+      : options.deps?.readCodexCliCredentials
+        ? detectCliCredentialState({
+            probe: codexProbe,
+            hasStoredCredentials: codexCredential !== null,
+            platform,
+          })
+        : await detectCodexLoginState(probe, codexProbe.command);
+    // Promote only prompt-free ChatGPT OAuth tokens. Status-only logins may be metered;
+    // keychain-only ChatGPT users conservatively stay usable in the fallback tier.
+    if (credentials === true && codexCredential?.type === "oauth") {
       subscriptionPromotionEligibleCliKinds.add("codex-cli");
     }
     cliCandidates.push({

--- a/src/commands/onboard-inference.ts
+++ b/src/commands/onboard-inference.ts
@@ -197,13 +197,14 @@ export async function detectInferenceBackends(
       cfg: options.config ?? {},
       ...(defaultAgentId ? { agentId: defaultAgentId } : {}),
     });
+    const modelRef = `${resolved.provider}/${resolved.model}`;
     candidates.push({
       kind: "existing-model",
       // Approval and activation bind to the executable target, not a mutable
       // alias spelling. The authored config itself remains untouched.
-      modelRef: `${resolved.provider}/${resolved.model}`,
+      modelRef,
       label: "Current model",
-      detail: "already configured",
+      detail: `${modelRef} — already configured`,
       credentials: true,
     });
   }

--- a/src/commands/onboard-inference.ts
+++ b/src/commands/onboard-inference.ts
@@ -18,6 +18,7 @@ import {
   GEMINI_CLI_DEFAULT_MODEL_REF,
   detectAmbientInferenceBackends,
   type InferenceBackendCandidate,
+  type InferenceBackendKind,
 } from "./onboard-inference-ambient.js";
 
 export {
@@ -201,7 +202,7 @@ export async function detectInferenceBackends(
       credentials: true,
     });
   }
-  candidates.push(...detectAmbientInferenceBackends(env));
+  const envCandidates = detectAmbientInferenceBackends(env);
 
   const [claudeProbe, codexProbe, geminiProbe] = await Promise.all([
     probe("claude"),
@@ -209,12 +210,17 @@ export async function detectInferenceBackends(
     probe("gemini"),
   ]);
   const cliCandidates: InferenceBackendCandidate[] = [];
+  const subscriptionPromotionEligibleCliKinds = new Set<InferenceBackendKind>();
   if (claudeProbe.found && !claudeProbe.timedOut) {
+    const claudeCredential = readClaude();
     const credentials = detectCliCredentialState({
       probe: claudeProbe,
-      hasStoredCredentials: readClaude() !== null,
+      hasStoredCredentials: claudeCredential !== null,
       platform,
     });
+    if (credentials === true && claudeCredential?.type === "oauth") {
+      subscriptionPromotionEligibleCliKinds.add("claude-cli");
+    }
     cliCandidates.push({
       kind: "claude-cli",
       modelRef: CLAUDE_CLI_DEFAULT_MODEL_REF,
@@ -231,6 +237,11 @@ export async function detectInferenceBackends(
           platform,
         })
       : await detectCodexLoginState(probe, codexProbe.command);
+    // Codex's file reader exposes only ChatGPT OAuth, while production login status
+    // has no credential type; accept a successful status as subscription-backed.
+    if (credentials === true) {
+      subscriptionPromotionEligibleCliKinds.add("codex-cli");
+    }
     cliCandidates.push({
       kind: "codex-cli",
       modelRef: CODEX_APP_SERVER_DEFAULT_MODEL_REF,
@@ -251,14 +262,24 @@ export async function detectInferenceBackends(
       credentials,
     });
   }
-  // Claude Code and Codex are equivalent subscription-backed choices. When both
-  // may be usable, randomize their first-test order instead of encoding a preference.
+  // Claude Code and Codex share rank within a credential tier. Randomize before
+  // partitioning so logged-in and unknown ties keep no provider preference.
   randomizeClaudeCodexTie(cliCandidates, options.deps?.randomInt ?? randomInt);
-  // Stable partition: definitively logged-out installs still sink below usable or
-  // keychain-unknown candidates; Gemini retains its documented fallback position.
+  const loggedInSubscriptionCliCandidates = cliCandidates.filter(
+    (candidate) =>
+      candidate.credentials === true && subscriptionPromotionEligibleCliKinds.has(candidate.kind),
+  );
+  const remainingCliCandidates = cliCandidates.filter(
+    (candidate) => !loggedInSubscriptionCliCandidates.includes(candidate),
+  );
+  // Verified flat-rate subscription logins outrank metered environment keys.
+  // Existing models stay first so guided setup never silently replaces one.
   candidates.push(
-    ...cliCandidates.filter((candidate) => candidate.credentials !== false),
-    ...cliCandidates.filter((candidate) => candidate.credentials === false),
+    ...loggedInSubscriptionCliCandidates,
+    ...envCandidates,
+    // Unknown login states and Gemini remain fallbacks; definitive logouts sink last.
+    ...remainingCliCandidates.filter((candidate) => candidate.credentials !== false),
+    ...remainingCliCandidates.filter((candidate) => candidate.credentials === false),
   );
   return candidates;
 }

--- a/src/system-agent/agent-turn.test.ts
+++ b/src/system-agent/agent-turn.test.ts
@@ -202,6 +202,8 @@ describe("runSystemAgentTurn", () => {
         authProfileId: "openai:p2",
         authFingerprint,
         agentHarnessId: "openclaw",
+        modelId: executionRoute.model,
+        modelApi: "openai-responses",
       },
       deps: authDeps,
     });

--- a/src/system-agent/assistant.configured.test.ts
+++ b/src/system-agent/assistant.configured.test.ts
@@ -124,7 +124,12 @@ describe("OpenClaw configured-model planner", () => {
     const binding = await createSystemAgentVerifiedInferenceBinding({
       configuredRoute,
       executionRoute: { ...configuredRoute, authProfileId: "openai:p2" },
-      auth: { authProfileId: "openai:p2", authFingerprint },
+      auth: {
+        authProfileId: "openai:p2",
+        authFingerprint,
+        modelId: configuredRoute.model,
+        modelApi: "openai-responses",
+      },
       deps: authDeps,
     });
     const runEmbeddedAgent = vi.fn(async () => ({

--- a/src/system-agent/chat-engine.test.ts
+++ b/src/system-agent/chat-engine.test.ts
@@ -162,7 +162,12 @@ async function createAmbientVerifiedBinding(config: OpenClawConfig) {
   return await createSystemAgentVerifiedInferenceBinding({
     configuredRoute: route,
     executionRoute: route,
-    auth: { authFingerprint, ...harnessBinding.auth },
+    auth: {
+      authFingerprint,
+      modelId: route.model,
+      modelApi: route.provider === "anthropic" ? "anthropic-messages" : "openai-responses",
+      ...harnessBinding.auth,
+    },
     deps: harnessBinding.deps,
   });
 }

--- a/src/system-agent/setup-inference.test.ts
+++ b/src/system-agent/setup-inference.test.ts
@@ -5200,6 +5200,11 @@ describe("verifySetupInference", () => {
         loadAuthProfileStoreForRuntime: vi.fn(() => ({ version: 1, profiles })) as never,
         ensureAuthProfileStore: vi.fn(() => ({ version: 1, profiles })) as never,
         resolveApiKeyForProvider: vi.fn(async () => verifiedAuth),
+        // Owner revalidation resolves the route model for transport facts; the
+        // real resolver cold-loads catalog discovery and dominates wall time.
+        resolveModelAsync: vi.fn(async () => ({
+          model: { id: "gpt-5.5", provider: "openai", api: "openai-responses" },
+        })) as never,
         runEmbeddedAgent: runEmbeddedAgent as never,
         createTempDir: makeTempDir,
       },

--- a/src/system-agent/setup-inference.test.ts
+++ b/src/system-agent/setup-inference.test.ts
@@ -312,6 +312,13 @@ function successfulRun(provider: string, model: string, params?: SuccessfulRunPa
       : {
           ...successfulAgentHarnessBinding(params),
           authFingerprint: "test-credential-owner",
+          modelId: model,
+          modelApi:
+            provider === "anthropic"
+              ? "anthropic-messages"
+              : provider === "groq"
+                ? "openai-completions"
+                : "openai-responses",
           ...(params?.authProfileId ? { authProfileId: params.authProfileId } : {}),
         },
   );
@@ -1783,6 +1790,8 @@ describe("activateSetupInference", () => {
       params.onSuccessfulAuthBinding?.({
         ...successfulAgentHarnessBinding(params),
         authFingerprint: initialAuthFingerprint,
+        modelId: "claude-opus-4-8",
+        modelApi: "anthropic-messages",
       });
       return successfulRun("anthropic", "claude-opus-4-8");
     });
@@ -1797,9 +1806,6 @@ describe("activateSetupInference", () => {
           apiKey: "rotated-env-key",
           source: "env:ANTHROPIC_API_KEY",
           mode: "api-key",
-        })) as never,
-        resolveModelAsync: vi.fn(async () => ({
-          model: { id: "claude-opus-4-8", provider: "anthropic", api: "anthropic-messages" },
         })) as never,
         createSystemAgentVerifiedInferenceBinding,
         transformConfigWithPendingPluginInstalls: configHarness.transform as never,
@@ -2465,6 +2471,8 @@ describe("activateSetupInference", () => {
           authProfileId: "groq:fallback",
           ...successfulAgentHarnessBinding(params),
           authFingerprint: "fallback-owner",
+          modelId: "llama-3.3-70b-versatile",
+          modelApi: "openai-completions",
         });
         return successfulRun("groq", "llama-3.3-70b-versatile");
       },
@@ -2723,6 +2731,8 @@ describe("activateSetupInference", () => {
           authProfileId: profileId,
           ...successfulAgentHarnessBinding(params),
           authFingerprint,
+          modelId: "llama-3.3-70b-versatile",
+          modelApi: "openai-completions",
         });
         return successfulRun("groq", "llama-3.3-70b-versatile");
       },
@@ -2750,9 +2760,6 @@ describe("activateSetupInference", () => {
             profileId: params.profileId,
             source: `profile:${params.profileId}`,
             mode: "api-key",
-          })) as never,
-          resolveModelAsync: vi.fn(async () => ({
-            model: { id: "llama-3.3-70b-versatile", provider: "groq", api: "openai-completions" },
           })) as never,
           createSystemAgentVerifiedInferenceBinding,
           transformConfigWithPendingPluginInstalls: configHarness.transform as never,
@@ -5181,12 +5188,16 @@ describe("verifySetupInference", () => {
           authProfileId?: string;
           agentHarnessId?: string;
           authFingerprint?: string;
+          modelId?: string;
+          modelApi?: string;
         }) => void;
       }) => {
         params.onSuccessfulAuthBinding?.({
           authProfileId: "openai:p2",
           agentHarnessId: "openclaw",
           authFingerprint: verifiedAuthFingerprint,
+          modelId: "gpt-5.5",
+          modelApi: "openai-responses",
         });
         return successfulRun("openai", "gpt-5.5");
       },
@@ -5200,11 +5211,6 @@ describe("verifySetupInference", () => {
         loadAuthProfileStoreForRuntime: vi.fn(() => ({ version: 1, profiles })) as never,
         ensureAuthProfileStore: vi.fn(() => ({ version: 1, profiles })) as never,
         resolveApiKeyForProvider: vi.fn(async () => verifiedAuth),
-        // Owner revalidation resolves the route model for transport facts; the
-        // real resolver cold-loads catalog discovery and dominates wall time.
-        resolveModelAsync: vi.fn(async () => ({
-          model: { id: "gpt-5.5", provider: "openai", api: "openai-responses" },
-        })) as never,
         runEmbeddedAgent: runEmbeddedAgent as never,
         createTempDir: makeTempDir,
       },
@@ -5253,6 +5259,8 @@ describe("verifySetupInference", () => {
         authProfileId: profileId,
         ...successfulAgentHarnessBinding(params),
         authFingerprint,
+        modelId: "gpt-5.5",
+        modelApi: "openai-responses",
       });
       return successfulRun("openai", "gpt-5.5");
     });
@@ -5338,6 +5346,8 @@ describe("verifySetupInference", () => {
         authProfileId: profileId,
         ...successfulAgentHarnessBinding(params),
         authFingerprint,
+        modelId: "gpt-5.6-sol",
+        modelApi: "openai-responses",
       });
       return successfulRun("openai", "gpt-5.6-sol");
     });

--- a/src/system-agent/setup-inference.test.ts
+++ b/src/system-agent/setup-inference.test.ts
@@ -733,7 +733,7 @@ describe("detectSetupInference", () => {
         kind: "existing-model",
         modelRef: "openai/gpt-5.5",
         label: "Current model",
-        detail: "already configured",
+        detail: "openai/gpt-5.5 — already configured",
         credentials: true,
       },
     ]);

--- a/src/system-agent/setup-inference.test.ts
+++ b/src/system-agent/setup-inference.test.ts
@@ -1681,6 +1681,35 @@ describe("activateSetupInference", () => {
     });
   });
 
+  it("returns an auth failure when the verified owner drifts during persistence", async () => {
+    const configHarness = createConfigTransformHarness();
+    const result = await activateSetupInference({
+      kind: "openai-api-key",
+      surface: "gateway",
+      runtime,
+      deps: {
+        runEmbeddedAgent: vi.fn(successfulRunner("openai", "gpt-5.6")) as never,
+        transformConfigWithPendingPluginInstalls: configHarness.transform as never,
+        // The real revalidation throws when the current route owner no longer
+        // matches the probe credential (e.g. a Codex-imported OAuth profile
+        // outranking the probed env key). The ladder needs a failure result.
+        createSystemAgentVerifiedInferenceBinding: vi.fn(async () => {
+          throw new Error(
+            "The successful inference credential is no longer the active route owner.",
+          );
+        }) as never,
+        createTempDir: makeTempDir,
+      },
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      status: "auth",
+      error: expect.stringContaining("verified inference owner changed"),
+    });
+    expect(configHarness.current()).toEqual({});
+  });
+
   it("revalidates a stable CLI runtime owner at the config commit boundary", async () => {
     const configHarness = createConfigTransformHarness();
     const resolveCliRuntimeOwnerFingerprint = vi.fn(async () => "test-runtime-owner");
@@ -1758,24 +1787,33 @@ describe("activateSetupInference", () => {
       return successfulRun("anthropic", "claude-opus-4-8");
     });
 
-    await expect(
-      activateSetupInference({
-        kind: "anthropic-api-key",
-        surface: "gateway",
-        runtime,
-        deps: {
-          runEmbeddedAgent: runEmbeddedAgent as never,
-          resolveApiKeyForProvider: vi.fn(async () => ({
-            apiKey: "rotated-env-key",
-            source: "env:ANTHROPIC_API_KEY",
-            mode: "api-key",
-          })) as never,
-          createSystemAgentVerifiedInferenceBinding,
-          transformConfigWithPendingPluginInstalls: configHarness.transform as never,
-          createTempDir: makeTempDir,
-        },
-      }),
-    ).rejects.toThrow("active route owner");
+    const result = await activateSetupInference({
+      kind: "anthropic-api-key",
+      surface: "gateway",
+      runtime,
+      deps: {
+        runEmbeddedAgent: runEmbeddedAgent as never,
+        resolveApiKeyForProvider: vi.fn(async () => ({
+          apiKey: "rotated-env-key",
+          source: "env:ANTHROPIC_API_KEY",
+          mode: "api-key",
+        })) as never,
+        resolveModelAsync: vi.fn(async () => ({
+          model: { id: "claude-opus-4-8", provider: "anthropic", api: "anthropic-messages" },
+        })) as never,
+        createSystemAgentVerifiedInferenceBinding,
+        transformConfigWithPendingPluginInstalls: configHarness.transform as never,
+        createTempDir: makeTempDir,
+      },
+    });
+
+    // Owner drift is a failure result, not a throw: the guided-onboarding
+    // ladder must be able to continue to its next candidate.
+    expect(result).toMatchObject({
+      ok: false,
+      status: "auth",
+      error: expect.stringContaining("active route owner"),
+    });
     expect(configHarness.transform).toHaveBeenCalledOnce();
     expect(configHarness.current()).toEqual({});
   });
@@ -2691,36 +2729,44 @@ describe("activateSetupInference", () => {
     );
 
     try {
-      await expect(
-        activateSetupInference({
-          kind: "api-key",
-          authChoice: "groq-api-key",
-          apiKey: "submitted-key",
-          surface: "gateway",
-          runtime,
-          deps: {
-            readConfigFileSnapshot: vi.fn(async () => ({
-              exists: true,
-              valid: true,
-              config: initialConfig,
-              runtimeConfig: initialConfig,
-            })) as never,
-            resolvePluginProviders: () => [createGroqSetupProvider()],
-            resolveManifestProviderAuthChoice: groqSetupChoice,
-            runEmbeddedAgent: runEmbeddedAgent as never,
-            resolveApiKeyForProvider: vi.fn(async (params: { profileId?: string }) => ({
-              apiKey: "different-real-store-key",
-              profileId: params.profileId,
-              source: `profile:${params.profileId}`,
-              mode: "api-key",
-            })) as never,
-            createSystemAgentVerifiedInferenceBinding,
-            transformConfigWithPendingPluginInstalls: configHarness.transform as never,
-            createTempDir: makeTempDir,
-          },
-        }),
-      ).rejects.toThrow("active route owner");
+      const result = await activateSetupInference({
+        kind: "api-key",
+        authChoice: "groq-api-key",
+        apiKey: "submitted-key",
+        surface: "gateway",
+        runtime,
+        deps: {
+          readConfigFileSnapshot: vi.fn(async () => ({
+            exists: true,
+            valid: true,
+            config: initialConfig,
+            runtimeConfig: initialConfig,
+          })) as never,
+          resolvePluginProviders: () => [createGroqSetupProvider()],
+          resolveManifestProviderAuthChoice: groqSetupChoice,
+          runEmbeddedAgent: runEmbeddedAgent as never,
+          resolveApiKeyForProvider: vi.fn(async (params: { profileId?: string }) => ({
+            apiKey: "different-real-store-key",
+            profileId: params.profileId,
+            source: `profile:${params.profileId}`,
+            mode: "api-key",
+          })) as never,
+          resolveModelAsync: vi.fn(async () => ({
+            model: { id: "llama-3.3-70b-versatile", provider: "groq", api: "openai-completions" },
+          })) as never,
+          createSystemAgentVerifiedInferenceBinding,
+          transformConfigWithPendingPluginInstalls: configHarness.transform as never,
+          createTempDir: makeTempDir,
+        },
+      });
 
+      // Owner drift resolves to an auth failure after rolling back the staged
+      // credential; a throw here used to crash the onboarding wizard.
+      expect(result).toMatchObject({
+        ok: false,
+        status: "auth",
+        error: expect.stringContaining("active route owner"),
+      });
       expect(configHarness.current()).toEqual(canonicalizeAgentEntriesForTest(initialConfig));
       expect(
         Object.keys(readAuthProfileStoreForTest(agentDir).profiles).filter((id) =>

--- a/src/system-agent/setup-inference.ts
+++ b/src/system-agent/setup-inference.ts
@@ -197,6 +197,15 @@ class SetupInferenceActivationUnavailableError extends Error {
   override name = "SetupInferenceActivationUnavailableError";
 }
 
+/**
+ * The live-tested owner no longer matches current config. Activation maps this
+ * to `{ ok: false, status: "auth" }` so the guided-onboarding ladder can move
+ * to its next candidate instead of crashing the CLI.
+ */
+class SetupInferenceOwnerDriftError extends Error {
+  override name = "SetupInferenceOwnerDriftError";
+}
+
 export type VerifySetupInferenceResult =
   | {
       ok: true;
@@ -309,6 +318,7 @@ export type ActivateSetupInferenceDeps = {
   resolveCliRuntimeArtifactFingerprint?: typeof import("../agents/cli-auth-epoch.js").resolveCliRuntimeArtifactFingerprint;
   resolveCliRuntimeOwnerFingerprint?: typeof import("../agents/cli-auth-epoch.js").resolveCliRuntimeOwnerFingerprint;
   resolveApiKeyForProvider?: typeof import("../agents/model-auth.js").resolveApiKeyForProvider;
+  resolveModelAsync?: SystemAgentVerifiedInferenceDeps["resolveModelAsync"];
   loadPluginRegistrySnapshot?: SystemAgentVerifiedInferenceDeps["loadPluginRegistrySnapshot"];
   fingerprintPluginRuntimeArtifact?: SystemAgentVerifiedInferenceDeps["fingerprintPluginRuntimeArtifact"];
   captureSystemAgentOwnerPluginArtifacts?: typeof captureSystemAgentOwnerPluginArtifacts;
@@ -1612,6 +1622,9 @@ export async function activateSetupInference(
     if (error instanceof SetupInferenceActivationUnavailableError) {
       return { ok: false, status: "unavailable", error: redacted };
     }
+    if (error instanceof SetupInferenceOwnerDriftError) {
+      return { ok: false, status: "auth", error: redacted };
+    }
     if (error instanceof SetupInferenceActivationIndeterminateError) {
       throw new SetupInferenceActivationIndeterminateError(redacted);
     }
@@ -2018,23 +2031,12 @@ async function activateSetupInferenceUnredacted(
             "The default-agent inference route could not be resolved after its live test. Review the current model/auth/runtime settings and retry.",
         };
       }
-      try {
-        const binding = await revalidateSetupInferenceOwner({
-          route: latestResolvedRoute,
-          auth: test.auth,
-          deps,
-        });
-        if (!hasSameOwnerPluginArtifacts(binding, stagedOwnerPluginArtifacts)) {
-          throw new Error("inference owner plugin runtime changed during its live test");
-        }
-      } catch {
-        return {
-          ok: false,
-          status: "auth",
-          error:
-            "The verified inference owner changed before activation completed. Retry the inference check.",
-        };
-      }
+      await revalidateStableSetupInferenceOwner({
+        route: latestResolvedRoute,
+        auth: test.auth,
+        stagedOwnerPluginArtifacts,
+        deps,
+      });
     }
     if (needsPersistence) {
       const { stripPendingPluginInstallRecords } =
@@ -2232,14 +2234,12 @@ async function activateSetupInferenceUnredacted(
                 "The source config no longer matches the verified candidate, so it was not saved. Review the current config and retry.",
               );
             }
-            const binding = await revalidateSetupInferenceOwner({
+            await revalidateStableSetupInferenceOwner({
               route: nextResolvedRoute,
               auth: test.auth,
+              stagedOwnerPluginArtifacts,
               deps,
             });
-            if (!hasSameOwnerPluginArtifacts(binding, stagedOwnerPluginArtifacts)) {
-              throw new Error("inference owner plugin runtime changed during its live test");
-            }
             // Once this callback returns, the config writer owns the candidate.
             // Any later throw may be post-commit and needs reconciliation.
             throwIfSetupInferenceCancelled(params);
@@ -2409,6 +2409,41 @@ function hasSameOwnerPluginArtifacts(
     isDeepStrictEqual(binding.ownerPluginIds, snapshot.ownerPluginIds) &&
     isDeepStrictEqual(binding.ownerPluginArtifacts, snapshot.ownerPluginArtifacts)
   );
+}
+
+/**
+ * Revalidate the successful probe's owner against current config. Any drift
+ * throws SetupInferenceOwnerDriftError, which activation returns as an auth
+ * failure result — a throw that escapes here would crash the onboarding ladder.
+ */
+async function revalidateStableSetupInferenceOwner(params: {
+  route: SystemAgentConfiguredRoute;
+  auth: AgentExecutionAuthBinding;
+  stagedOwnerPluginArtifacts: SystemAgentOwnerPluginArtifactSnapshot | undefined;
+  deps: ActivateSetupInferenceDeps;
+}): Promise<SystemAgentVerifiedInferenceBinding> {
+  let binding: SystemAgentVerifiedInferenceBinding;
+  try {
+    binding = await revalidateSetupInferenceOwner({
+      route: params.route,
+      auth: params.auth,
+      deps: params.deps,
+    });
+  } catch (error) {
+    throw new SetupInferenceOwnerDriftError(
+      `The verified inference owner changed before activation completed. Retry the inference check. (${formatErrorMessage(error)})`,
+      { cause: error },
+    );
+  }
+  if (
+    !params.stagedOwnerPluginArtifacts ||
+    !hasSameOwnerPluginArtifacts(binding, params.stagedOwnerPluginArtifacts)
+  ) {
+    throw new SetupInferenceOwnerDriftError(
+      "The verified inference owner changed before activation completed. Retry the inference check. (The owner plugin runtime changed during its live test.)",
+    );
+  }
+  return binding;
 }
 
 type VerifySetupInferenceParams = {
@@ -2787,17 +2822,12 @@ export async function verifySetupInferenceConfig(params: {
       }
       if (params.requireExecutionOwner || params.onVerifiedExecution) {
         try {
-          const binding = await revalidateSetupInferenceOwner({
+          const binding = await revalidateStableSetupInferenceOwner({
             route: configuredRoute!,
             auth: test.auth,
+            stagedOwnerPluginArtifacts,
             deps,
           });
-          if (
-            !stagedOwnerPluginArtifacts ||
-            !hasSameOwnerPluginArtifacts(binding, stagedOwnerPluginArtifacts)
-          ) {
-            throw new Error("inference owner plugin runtime changed during its live test");
-          }
           params.onVerifiedExecution?.(test.auth, binding);
         } catch {
           return {

--- a/src/system-agent/setup-inference.ts
+++ b/src/system-agent/setup-inference.ts
@@ -318,7 +318,6 @@ export type ActivateSetupInferenceDeps = {
   resolveCliRuntimeArtifactFingerprint?: typeof import("../agents/cli-auth-epoch.js").resolveCliRuntimeArtifactFingerprint;
   resolveCliRuntimeOwnerFingerprint?: typeof import("../agents/cli-auth-epoch.js").resolveCliRuntimeOwnerFingerprint;
   resolveApiKeyForProvider?: typeof import("../agents/model-auth.js").resolveApiKeyForProvider;
-  resolveModelAsync?: SystemAgentVerifiedInferenceDeps["resolveModelAsync"];
   loadPluginRegistrySnapshot?: SystemAgentVerifiedInferenceDeps["loadPluginRegistrySnapshot"];
   fingerprintPluginRuntimeArtifact?: SystemAgentVerifiedInferenceDeps["fingerprintPluginRuntimeArtifact"];
   captureSystemAgentOwnerPluginArtifacts?: typeof captureSystemAgentOwnerPluginArtifacts;

--- a/src/system-agent/system-agent.test-helpers.ts
+++ b/src/system-agent/system-agent.test-helpers.ts
@@ -58,6 +58,13 @@ export async function createSystemAgentVerifiedInferenceTestFixture(
       profiles: profileId ? { [profileId]: credential } : {},
     })) as never,
     resolveApiKeyForProvider: async () => resolvedAuth,
+    resolveModelAsync: (async () => ({
+      model: {
+        id: configuredRoute.model,
+        provider: configuredRoute.provider,
+        api: "openai-responses",
+      },
+    })) as never,
     validateAgentHarnessRuntimeArtifact: async () => true,
     loadPluginRegistrySnapshot: (() => ({
       plugins: testOwnerPluginIds.map((pluginId) => ({

--- a/src/system-agent/system-agent.test-helpers.ts
+++ b/src/system-agent/system-agent.test-helpers.ts
@@ -58,13 +58,6 @@ export async function createSystemAgentVerifiedInferenceTestFixture(
       profiles: profileId ? { [profileId]: credential } : {},
     })) as never,
     resolveApiKeyForProvider: async () => resolvedAuth,
-    resolveModelAsync: (async () => ({
-      model: {
-        id: configuredRoute.model,
-        provider: configuredRoute.provider,
-        api: "openai-responses",
-      },
-    })) as never,
     validateAgentHarnessRuntimeArtifact: async () => true,
     loadPluginRegistrySnapshot: (() => ({
       plugins: testOwnerPluginIds.map((pluginId) => ({
@@ -161,6 +154,9 @@ export async function createSystemAgentVerifiedInferenceTestFixture(
       ...(profileId ? { authProfileId: profileId } : {}),
       authFingerprint,
       agentHarnessId,
+      modelId: configuredRoute.model,
+      modelApi:
+        configuredRoute.provider === "anthropic" ? "anthropic-messages" : "openai-responses",
       ...(agentHarnessId === "openclaw"
         ? {}
         : {

--- a/src/system-agent/verified-inference.test.ts
+++ b/src/system-agent/verified-inference.test.ts
@@ -119,15 +119,8 @@ beforeEach(() => {
   harnessRuntimeArtifactState.ownsAuthBootstrap = true;
 });
 
-function modelFactsDeps(model = { id: "gpt-5.5", provider: "openai", api: "openai-responses" }) {
-  return {
-    resolveModelAsync: vi.fn(async () => ({ model })) as never,
-  };
-}
-
 function authDeps(apiKey = "verified-key") {
   return {
-    ...modelFactsDeps(),
     ensureAuthProfileStore: vi.fn(() => ({
       version: 1,
       profiles: { "openai:verified": { ...profile, key: apiKey } },
@@ -223,6 +216,8 @@ async function bindingFor(
     auth: {
       authProfileId: "openai:verified",
       authFingerprint,
+      modelId: route.model,
+      modelApi: route.provider === "anthropic" ? "anthropic-messages" : "openai-responses",
       ...(agentHarnessId
         ? {
             agentHarnessId,
@@ -340,12 +335,10 @@ describe("verified OpenClaw inference binding", () => {
     ).rejects.toThrow("active secret unavailable");
   });
 
-  it("re-resolves the current owner under the route model's transport constraints", async () => {
-    // An env-credential run reports no auth profile. Owner re-resolution must
-    // carry the route model's id/api so credential discovery applies the same
-    // transport gate the run did — without it, profile-first discovery can
-    // select a transport-incompatible credential (e.g. a Codex-imported
-    // ChatGPT OAuth profile for a direct OpenAI platform model).
+  it("reuses the successful model transport facts for owner re-resolution", async () => {
+    // The successful run already resolved the model under its selected auth
+    // plan. Revalidation must carry that exact tuple forward instead of
+    // repeating catalog and provider discovery in the authority hot path.
     const envConfig = {
       agents: {
         defaults: {
@@ -371,10 +364,14 @@ describe("verified OpenClaw inference binding", () => {
     const binding = await createSystemAgentVerifiedInferenceBinding({
       configuredRoute: route,
       executionRoute: route,
-      auth: { authFingerprint, agentHarnessId: "openclaw" },
+      auth: {
+        authFingerprint,
+        agentHarnessId: "openclaw",
+        modelId: "gpt-5.6",
+        modelApi: "openai-responses",
+      },
       deps: {
         ...pluginArtifactDeps(),
-        ...modelFactsDeps({ id: "gpt-5.6", provider: "openai", api: "openai-responses" }),
         resolveApiKeyForProvider: resolveAuth as never,
       },
     });
@@ -385,7 +382,7 @@ describe("verified OpenClaw inference binding", () => {
     );
   });
 
-  it("fails closed when the route model cannot be resolved for owner re-derivation", async () => {
+  it("fails closed when a credential-backed run omits its model transport facts", async () => {
     const envConfig = {
       agents: {
         defaults: {
@@ -416,7 +413,6 @@ describe("verified OpenClaw inference binding", () => {
         auth: { authFingerprint, agentHarnessId: "openclaw" },
         deps: {
           ...pluginArtifactDeps(),
-          resolveModelAsync: vi.fn(async () => ({ model: undefined })) as never,
           resolveApiKeyForProvider: resolveAuth as never,
         },
       }),
@@ -929,6 +925,8 @@ describe("verified OpenClaw inference binding", () => {
         authProfileId: "openai:verified",
         authFingerprint,
         agentHarnessId: "openclaw",
+        modelId: configuredRoute.model,
+        modelApi: "openai-responses",
       },
       deps: { ...authDeps(), ...pluginArtifactDeps() },
     });
@@ -1081,7 +1079,6 @@ describe("verified OpenClaw inference binding", () => {
     }));
     const deps = {
       ...pluginArtifactDeps(),
-      ...modelFactsDeps(),
       ensureAuthProfileStore: vi.fn(() => ({
         version: 1,
         profiles: { "openai:verified": profile },
@@ -1095,6 +1092,8 @@ describe("verified OpenClaw inference binding", () => {
         authProfileId: "openai:verified",
         authFingerprint,
         agentHarnessId: "codex",
+        modelId: route.model,
+        modelApi: "openai-responses",
         runtimeOwnerKind: "plugin-harness",
         runtimeOwnerId: "codex",
         ...codexRuntimeArtifactAuth,

--- a/src/system-agent/verified-inference.test.ts
+++ b/src/system-agent/verified-inference.test.ts
@@ -119,8 +119,15 @@ beforeEach(() => {
   harnessRuntimeArtifactState.ownsAuthBootstrap = true;
 });
 
+function modelFactsDeps(model = { id: "gpt-5.5", provider: "openai", api: "openai-responses" }) {
+  return {
+    resolveModelAsync: vi.fn(async () => ({ model })) as never,
+  };
+}
+
 function authDeps(apiKey = "verified-key") {
   return {
+    ...modelFactsDeps(),
     ensureAuthProfileStore: vi.fn(() => ({
       version: 1,
       profiles: { "openai:verified": { ...profile, key: apiKey } },
@@ -331,6 +338,90 @@ describe("verified OpenClaw inference binding", () => {
         },
       }),
     ).rejects.toThrow("active secret unavailable");
+  });
+
+  it("re-resolves the current owner under the route model's transport constraints", async () => {
+    // An env-credential run reports no auth profile. Owner re-resolution must
+    // carry the route model's id/api so credential discovery applies the same
+    // transport gate the run did — without it, profile-first discovery can
+    // select a transport-incompatible credential (e.g. a Codex-imported
+    // ChatGPT OAuth profile for a direct OpenAI platform model).
+    const envConfig = {
+      agents: {
+        defaults: {
+          model: "openai/gpt-5.6",
+          models: { "openai/gpt-5.6": { agentRuntime: { id: "openclaw" } } },
+        },
+      },
+    } satisfies OpenClawConfig;
+    const route = await resolveSystemAgentConfiguredRouteFromConfig(envConfig);
+    if (!route) {
+      throw new Error("missing test route");
+    }
+    const envAuth = {
+      apiKey: "env-key",
+      source: "env: OPENAI_API_KEY",
+      mode: "api-key" as const,
+    };
+    const authFingerprint = fingerprintResolvedProviderAuth(envAuth);
+    if (!authFingerprint) {
+      throw new Error("missing test env fingerprint");
+    }
+    const resolveAuth = vi.fn(async () => envAuth);
+    const binding = await createSystemAgentVerifiedInferenceBinding({
+      configuredRoute: route,
+      executionRoute: route,
+      auth: { authFingerprint, agentHarnessId: "openclaw" },
+      deps: {
+        ...pluginArtifactDeps(),
+        ...modelFactsDeps({ id: "gpt-5.6", provider: "openai", api: "openai-responses" }),
+        resolveApiKeyForProvider: resolveAuth as never,
+      },
+    });
+
+    expect(binding.auth.authFingerprint).toBe(authFingerprint);
+    expect(resolveAuth).toHaveBeenCalledWith(
+      expect.objectContaining({ modelId: "gpt-5.6", modelApi: "openai-responses" }),
+    );
+  });
+
+  it("fails closed when the route model cannot be resolved for owner re-derivation", async () => {
+    const envConfig = {
+      agents: {
+        defaults: {
+          model: "openai/gpt-5.6",
+          models: { "openai/gpt-5.6": { agentRuntime: { id: "openclaw" } } },
+        },
+      },
+    } satisfies OpenClawConfig;
+    const route = await resolveSystemAgentConfiguredRouteFromConfig(envConfig);
+    if (!route) {
+      throw new Error("missing test route");
+    }
+    const envAuth = {
+      apiKey: "env-key",
+      source: "env: OPENAI_API_KEY",
+      mode: "api-key" as const,
+    };
+    const authFingerprint = fingerprintResolvedProviderAuth(envAuth);
+    if (!authFingerprint) {
+      throw new Error("missing test env fingerprint");
+    }
+    const resolveAuth = vi.fn(async () => envAuth);
+
+    await expect(
+      createSystemAgentVerifiedInferenceBinding({
+        configuredRoute: route,
+        executionRoute: route,
+        auth: { authFingerprint, agentHarnessId: "openclaw" },
+        deps: {
+          ...pluginArtifactDeps(),
+          resolveModelAsync: vi.fn(async () => ({ model: undefined })) as never,
+          resolveApiKeyForProvider: resolveAuth as never,
+        },
+      }),
+    ).rejects.toThrow("no longer the active route owner");
+    expect(resolveAuth).not.toHaveBeenCalled();
   });
 
   it("accepts and revalidates an opaque CLI owner emitted after a successful turn", async () => {
@@ -990,6 +1081,7 @@ describe("verified OpenClaw inference binding", () => {
     }));
     const deps = {
       ...pluginArtifactDeps(),
+      ...modelFactsDeps(),
       ensureAuthProfileStore: vi.fn(() => ({
         version: 1,
         profiles: { "openai:verified": profile },

--- a/src/system-agent/verified-inference.ts
+++ b/src/system-agent/verified-inference.ts
@@ -123,11 +123,15 @@ export type SystemAgentVerifiedInferenceBinding = Readonly<{
   }>;
 }>;
 
+type ResolveModelAsync =
+  (typeof import("../agents/embedded-agent-runner/model.js"))["resolveModelAsync"];
+
 export type SystemAgentVerifiedInferenceDeps = SystemAgentConfiguredRouteDeps & {
   ensureAuthProfileStore?: typeof ensureAuthProfileStore;
   resolveCliAuthBindingFingerprint?: typeof resolveCliAuthBindingFingerprint;
   resolveCliRuntimeOwnerFingerprint?: typeof resolveCliRuntimeOwnerFingerprint;
   resolveCliRuntimeArtifactFingerprint?: typeof resolveCliRuntimeArtifactFingerprint;
+  resolveModelAsync?: ResolveModelAsync;
   resolveApiKeyForProvider?: typeof resolveApiKeyForProvider;
   validateAgentHarnessRuntimeArtifact?: (params: {
     harnessId: string;
@@ -484,6 +488,43 @@ export function captureSystemAgentOwnerPluginArtifacts(params: {
   };
 }
 
+// The successful run selected its credential under the route model's
+// transport constraints (isAuthModeAllowedForModel). Owner re-resolution must
+// apply the same facts or profile-first discovery can pick a credential the
+// route cannot execute — e.g. a Codex-imported ChatGPT OAuth profile owning a
+// direct OpenAI platform route probed with an env API key.
+async function resolveRouteModelFacts(params: {
+  route: SystemAgentConfiguredRoute;
+  deps: SystemAgentVerifiedInferenceDeps;
+}): Promise<{ modelId: string; modelApi: string } | undefined> {
+  const resolveModel =
+    params.deps.resolveModelAsync ??
+    (await import("../agents/embedded-agent-runner/model.js")).resolveModelAsync;
+  try {
+    const resolved = await resolveModel(
+      params.route.provider,
+      params.route.model,
+      params.route.agentDir,
+      params.route.runConfig,
+      {
+        workspaceDir: resolveAgentWorkspaceDir(
+          params.route.runConfig,
+          params.route.agentId,
+          process.env,
+        ),
+        allowBundledStaticCatalogFallback: true,
+      },
+    );
+    const model = resolved.model;
+    if (!model) {
+      return undefined;
+    }
+    return { modelId: model.id, modelApi: model.api };
+  } catch {
+    return undefined;
+  }
+}
+
 async function resolveCurrentAuthFingerprint(params: {
   route: SystemAgentConfiguredRoute;
   authProfileId?: string;
@@ -576,6 +617,10 @@ async function resolveCurrentAuthFingerprint(params: {
           deps: params.deps,
         });
       }
+      const modelFacts = await resolveRouteModelFacts({ route: params.route, deps: params.deps });
+      if (!modelFacts) {
+        return undefined;
+      }
       const resolveAuth = params.deps.resolveApiKeyForProvider ?? resolveApiKeyForProvider;
       const auth = await resolveAuth({
         provider: params.route.provider,
@@ -588,6 +633,8 @@ async function resolveCurrentAuthFingerprint(params: {
         ),
         profileId: params.authProfileId,
         lockedProfile: true,
+        modelId: modelFacts.modelId,
+        modelApi: modelFacts.modelApi,
         secretSentinels: false,
       });
       if (auth.profileId !== params.authProfileId || !auth.apiKey) {
@@ -599,6 +646,12 @@ async function resolveCurrentAuthFingerprint(params: {
         resolvedAuth: auth,
       });
     }
+  }
+  // Fail closed on an unresolvable route model: without transport facts the
+  // current owner cannot be re-derived the way the successful run derived it.
+  const modelFacts = await resolveRouteModelFacts({ route: params.route, deps: params.deps });
+  if (!modelFacts) {
+    return undefined;
   }
   const resolveAuth = params.deps.resolveApiKeyForProvider ?? resolveApiKeyForProvider;
   const auth = await resolveAuth({
@@ -613,6 +666,8 @@ async function resolveCurrentAuthFingerprint(params: {
     ...(params.authProfileId
       ? { profileId: params.authProfileId, lockedProfile: true as const }
       : {}),
+    modelId: modelFacts.modelId,
+    modelApi: modelFacts.modelApi,
     secretSentinels: true,
   });
   if (params.authProfileId && auth.profileId !== params.authProfileId) {

--- a/src/system-agent/verified-inference.ts
+++ b/src/system-agent/verified-inference.ts
@@ -113,6 +113,8 @@ export type SystemAgentVerifiedInferenceBinding = Readonly<{
   auth: Readonly<{
     authProfileId?: string;
     agentHarnessId?: string;
+    modelId?: string;
+    modelApi?: string;
     authFingerprint: string;
     proofKind?: "runtime-owner";
     runtimeOwnerKind?: OpaqueRuntimeOwnerKind;
@@ -123,15 +125,11 @@ export type SystemAgentVerifiedInferenceBinding = Readonly<{
   }>;
 }>;
 
-type ResolveModelAsync =
-  (typeof import("../agents/embedded-agent-runner/model.js"))["resolveModelAsync"];
-
 export type SystemAgentVerifiedInferenceDeps = SystemAgentConfiguredRouteDeps & {
   ensureAuthProfileStore?: typeof ensureAuthProfileStore;
   resolveCliAuthBindingFingerprint?: typeof resolveCliAuthBindingFingerprint;
   resolveCliRuntimeOwnerFingerprint?: typeof resolveCliRuntimeOwnerFingerprint;
   resolveCliRuntimeArtifactFingerprint?: typeof resolveCliRuntimeArtifactFingerprint;
-  resolveModelAsync?: ResolveModelAsync;
   resolveApiKeyForProvider?: typeof resolveApiKeyForProvider;
   validateAgentHarnessRuntimeArtifact?: (params: {
     harnessId: string;
@@ -488,46 +486,11 @@ export function captureSystemAgentOwnerPluginArtifacts(params: {
   };
 }
 
-// The successful run selected its credential under the route model's
-// transport constraints (isAuthModeAllowedForModel). Owner re-resolution must
-// apply the same facts or profile-first discovery can pick a credential the
-// route cannot execute — e.g. a Codex-imported ChatGPT OAuth profile owning a
-// direct OpenAI platform route probed with an env API key.
-async function resolveRouteModelFacts(params: {
-  route: SystemAgentConfiguredRoute;
-  deps: SystemAgentVerifiedInferenceDeps;
-}): Promise<{ modelId: string; modelApi: string } | undefined> {
-  const resolveModel =
-    params.deps.resolveModelAsync ??
-    (await import("../agents/embedded-agent-runner/model.js")).resolveModelAsync;
-  try {
-    const resolved = await resolveModel(
-      params.route.provider,
-      params.route.model,
-      params.route.agentDir,
-      params.route.runConfig,
-      {
-        workspaceDir: resolveAgentWorkspaceDir(
-          params.route.runConfig,
-          params.route.agentId,
-          process.env,
-        ),
-        allowBundledStaticCatalogFallback: true,
-      },
-    );
-    const model = resolved.model;
-    if (!model) {
-      return undefined;
-    }
-    return { modelId: model.id, modelApi: model.api };
-  } catch {
-    return undefined;
-  }
-}
-
 async function resolveCurrentAuthFingerprint(params: {
   route: SystemAgentConfiguredRoute;
   authProfileId?: string;
+  modelId?: string;
+  modelApi?: string;
   skipLocalCredential?: boolean;
   deps: SystemAgentVerifiedInferenceDeps;
 }): Promise<string | undefined> {
@@ -617,8 +580,7 @@ async function resolveCurrentAuthFingerprint(params: {
           deps: params.deps,
         });
       }
-      const modelFacts = await resolveRouteModelFacts({ route: params.route, deps: params.deps });
-      if (!modelFacts) {
+      if (!params.modelId || !params.modelApi) {
         return undefined;
       }
       const resolveAuth = params.deps.resolveApiKeyForProvider ?? resolveApiKeyForProvider;
@@ -633,8 +595,8 @@ async function resolveCurrentAuthFingerprint(params: {
         ),
         profileId: params.authProfileId,
         lockedProfile: true,
-        modelId: modelFacts.modelId,
-        modelApi: modelFacts.modelApi,
+        modelId: params.modelId,
+        modelApi: params.modelApi,
         secretSentinels: false,
       });
       if (auth.profileId !== params.authProfileId || !auth.apiKey) {
@@ -647,10 +609,9 @@ async function resolveCurrentAuthFingerprint(params: {
       });
     }
   }
-  // Fail closed on an unresolvable route model: without transport facts the
-  // current owner cannot be re-derived the way the successful run derived it.
-  const modelFacts = await resolveRouteModelFacts({ route: params.route, deps: params.deps });
-  if (!modelFacts) {
+  // Credential selection is transport-sensitive. Reuse the facts from the
+  // successful run so this authority hot path cannot pick a different owner.
+  if (!params.modelId || !params.modelApi) {
     return undefined;
   }
   const resolveAuth = params.deps.resolveApiKeyForProvider ?? resolveApiKeyForProvider;
@@ -666,8 +627,8 @@ async function resolveCurrentAuthFingerprint(params: {
     ...(params.authProfileId
       ? { profileId: params.authProfileId, lockedProfile: true as const }
       : {}),
-    modelId: modelFacts.modelId,
-    modelApi: modelFacts.modelApi,
+    modelId: params.modelId,
+    modelApi: params.modelApi,
     secretSentinels: true,
   });
   if (params.authProfileId && auth.profileId !== params.authProfileId) {
@@ -686,6 +647,8 @@ export async function createSystemAgentVerifiedInferenceBinding(params: {
   const runConfig = structuredClone(params.executionRoute.runConfig);
   const execution = { ...params.executionRoute, runConfig } as SystemAgentConfiguredRoute;
   const authProfileId = params.auth.authProfileId ?? execution.authProfileId;
+  const modelId = params.auth.modelId?.trim();
+  const modelApi = params.auth.modelApi?.trim();
   if (authProfileId) {
     execution.authProfileId = authProfileId;
   }
@@ -780,6 +743,8 @@ export async function createSystemAgentVerifiedInferenceBinding(params: {
     : resolveCurrentAuthFingerprint({
         route: execution,
         ...(authProfileId ? { authProfileId } : {}),
+        ...(modelId ? { modelId } : {}),
+        ...(modelApi ? { modelApi } : {}),
         ...(params.auth.skipLocalCredential ? { skipLocalCredential: true } : {}),
         deps,
       }));
@@ -818,6 +783,8 @@ export async function createSystemAgentVerifiedInferenceBinding(params: {
     auth: {
       ...(authProfileId ? { authProfileId } : {}),
       ...(successfulHarnessId ? { agentHarnessId: successfulHarnessId } : {}),
+      ...(modelId ? { modelId } : {}),
+      ...(modelApi ? { modelApi } : {}),
       authFingerprint,
       ...(proofKind === "runtime-owner" ? { proofKind } : {}),
       ...(params.auth.runtimeOwnerKind ? { runtimeOwnerKind: params.auth.runtimeOwnerKind } : {}),
@@ -972,6 +939,8 @@ export async function resolveSystemAgentVerifiedInferenceRoute(
       : resolveCurrentAuthFingerprint({
           route: currentExecution,
           ...(binding.auth.authProfileId ? { authProfileId: binding.auth.authProfileId } : {}),
+          ...(binding.auth.modelId ? { modelId: binding.auth.modelId } : {}),
+          ...(binding.auth.modelApi ? { modelApi: binding.auth.modelApi } : {}),
           ...(binding.auth.skipLocalCredential ? { skipLocalCredential: true } : {}),
           deps,
         })

--- a/src/wizard/i18n/locales/en.ts
+++ b/src/wizard/i18n/locales/en.ts
@@ -309,6 +309,8 @@ export const en = {
       completeWithoutAi: "OpenClaw setup is saved. Connect AI before opening chat.",
       detected: "AI detection complete.",
       detectedCandidate: "{label} — {detail}{recommended}",
+      detectedGroupLabel: "Detected on this machine",
+      detectedGroupPrompt: "Use which detected AI?",
       detectedTitle: "AI found",
       detecting: "Looking for AI you already use…",
       enterApiKey: "Enter API key — {label}",

--- a/src/wizard/i18n/locales/zh-CN.ts
+++ b/src/wizard/i18n/locales/zh-CN.ts
@@ -302,6 +302,8 @@ export const zh_CN = {
       completeWithoutAi: "OpenClaw 设置已保存。连接 AI 后再打开聊天。",
       detected: "AI 检测完成。",
       detectedCandidate: "{label} — {detail}{recommended}",
+      detectedGroupLabel: "在这台机器上检测到的 AI",
+      detectedGroupPrompt: "要使用哪个检测到的 AI？",
       detectedTitle: "找到的 AI",
       detecting: "正在查找你已使用的 AI…",
       enterApiKey: "输入 API key — {label}",

--- a/src/wizard/i18n/locales/zh-TW.ts
+++ b/src/wizard/i18n/locales/zh-TW.ts
@@ -302,6 +302,8 @@ export const zh_TW = {
       completeWithoutAi: "OpenClaw 設定已儲存。連接 AI 後再開啟聊天。",
       detected: "AI 偵測完成。",
       detectedCandidate: "{label} — {detail}{recommended}",
+      detectedGroupLabel: "在這台機器上偵測到的 AI",
+      detectedGroupPrompt: "要使用哪個偵測到的 AI？",
       detectedTitle: "找到的 AI",
       detecting: "正在尋找你已使用的 AI…",
       enterApiKey: "輸入 API key — {label}",


### PR DESCRIPTION
## What Problem This Solves

`openclaw onboard` guided setup crashed (`Could not start the CLI. Reason: The successful inference credential is no longer the active route owner.`) on the first auto-ladder candidate on any machine that has both `OPENAI_API_KEY` set and a Codex CLI ChatGPT login — a common developer setup. The crash was deterministic and killed the wizard before any candidate could be persisted, leaving onboarding unusable on such machines.

Two root causes:

1. **Owner verification ignored the route's transport constraints.** After a successful probe, `createSystemAgentVerifiedInferenceBinding` re-resolved the provider credential without the route model's `modelId`/`modelApi` ([verified-inference.ts](src/system-agent/verified-inference.ts)). Without the `isAuthModeAllowedForModel` gate, profile-first discovery selected the Codex-imported ChatGPT OAuth profile (`openai:default`) as the "current owner" — a credential that cannot authenticate the direct OpenAI platform API the probe actually used with the env key. Guaranteed fingerprint mismatch.
2. **The mismatch escaped as a crash.** The activation persistence path ran owner revalidation inside the config-commit transform with no failure mapping, so the error propagated as a plain throw through `tryCandidate`, which expects `{ ok: false, status, error }` results. The sibling no-persistence path already mapped the same failure gracefully.

While here, a product-order decision surfaced by the same machine state: the ladder tried metered env API keys before flat-rate subscription logins.

## Why This Change Was Made

- **Route-aware verification**: owner re-resolution now resolves the route model (deps-injectable `resolveModelAsync` seam, fail-closed when unresolvable) and passes `modelId`/`modelApi` to credential resolution, so the verifier applies the same transport gate the run did. Precedence rules are unchanged.
- **Typed drift handling**: the three duplicated revalidation sites collapse into one helper throwing `SetupInferenceOwnerDriftError`, which `activateSetupInference` maps to `{ ok: false, status: "auth" }`. Genuine drift now fails the candidate and the ladder continues.
- **Ladder reorder**: logged-in subscription CLIs (Claude Code / Codex, tie-randomized) now rank above env API keys; existing configured models stay first; Gemini keeps its fallback position; definitively logged-out CLIs stay last. Promotion requires **verifiable OAuth tokens**: Claude `apiKeyHelper` credentials and Codex API-key logins are metered and stay below env keys. `codex login status` exits 0 for every auth mode (API key, ChatGPT, access token, PAT, Bedrock; verified in `../codex` at `codex-rs/cli/src/login.rs:424-476`, commit `51200321eb`), so Codex promotion keys off prompt-free ChatGPT OAuth tokens from the credential reader; keychain-only ChatGPT logins conservatively stay in the fallback tier (still auto-tested).

- **Detected candidates lead the picker** (follow-up commits after opening): choosing "See other options" used to drop users into the generic provider catalog with the detected candidates buried behind "More…" — and the detected env-key route was unreachable through the "OpenAI" provider group entirely. Caller-supplied groups (the detected candidates) now render first in the top tier of `promptAuthChoiceGrouped`, never under "More…".
- **Clear naming for detected state**: the picker group is labeled "Detected on this machine" with a hint listing its contents (was the note headline "AI found", opaque as a menu entry); its submenu asks "Use which detected AI?"; and the existing-model candidate now names the actual model everywhere — "Current model — openai/gpt-5.6 — already configured", "Use Current model (openai/gpt-5.6)?".

## User Impact

- Onboarding no longer crashes on machines with an env API key plus a Codex/ChatGPT login; the affected candidate verifies and activates.
- Owner drift during activation surfaces as a per-candidate auth failure with a readable reason instead of terminating the CLI.
- Users with a ChatGPT or Claude subscription login get that route tried first during guided setup; documented ladder order updated in [docs/cli/openclaw.md](docs/cli/openclaw.md).

- "See other options" now leads with the machine's detected candidates (retry the auto-picked route, env API keys, other logged-in CLIs) ahead of the provider catalog, each self-describing.

## Evidence

- Live repro (isolated `OPENCLAW_STATE_DIR`, real OpenAI probe): before — probe returns 200, activation throws the owner-drift error; after — `{ ok: true, lines: ["Inference verified: openai/gpt-5.6"] }`. Full `openclaw onboard` subsequently completed end-to-end on the originally affected machine.
- Focused suites: `node scripts/run-vitest.mjs src/system-agent/verified-inference.test.ts src/system-agent/setup-inference.test.ts` → 150 passed (3 new regression tests for drift mapping, route-aware resolution, fail-closed model facts); `src/commands/onboard-inference.test.ts` → 29 passed (5 new ordering cases incl. `api_key_helper` and status-only Codex logins); adjacent `agent-turn` + gateway `system-agent` suites → 42 passed.
- Check lanes (tsgo, oxlint, format, import cycles) green; run locally because the Blacksmith Testbox backend was unreachable (warmup timeout against backend.blacksmith.sh).
- Structured review (codex/gpt-5.5): three rounds; two accepted findings (metered Claude `apiKeyHelper` and Codex API-key logins wrongly promotion-eligible) fixed in-branch; final run clean.
- Dependency contract: Codex CLI login-status behavior personally verified in sibling source `codex-rs/cli/src/login.rs:424-476` @ `51200321eb` (current as of this PR).
- Picker/naming rounds: `src/commands/auth-choice-prompt.test.ts` covers top-tier placement of caller groups and custom submenu prompts; custodian-flow tests cover the named current-model confirmations; i18n keys added across en/zh-CN/zh-TW. Each follow-up commit passed its own clean structured review round.
