### PR TITLE
fix(google): image generation works with empty base URL

### DIFF
--- a/extensions/google/api.ts
+++ b/extensions/google/api.ts
@@ -50,9 +50,9 @@ type GoogleGenerativeAiRequestOverrides = ProviderRequestTransportOverrides & {
 };
 
 function resolveTrustedGoogleGenerativeAiBaseUrl(baseUrl?: string): string {
-  const normalized =
-    normalizeGoogleGenerativeAiBaseUrl(baseUrl ?? DEFAULT_GOOGLE_API_BASE_URL) ??
-    DEFAULT_GOOGLE_API_BASE_URL;
+  // Config validation can materialize an absent provider URL as an empty string.
+  // Native Google HTTP callers must still use the canonical Gemini endpoint.
+  const normalized = normalizeGoogleGenerativeAiBaseUrl(baseUrl) || DEFAULT_GOOGLE_API_BASE_URL;
   let url: URL;
   try {
     url = new URL(normalized);

--- a/extensions/google/api.ts
+++ b/extensions/google/api.ts
@@ -80,8 +80,9 @@ export function resolveGoogleGenerativeAiHttpRequestConfig(params: {
   capability: "image" | "audio" | "video";
   transport: "http" | "media-understanding";
 }) {
+  const baseUrl = resolveTrustedGoogleGenerativeAiBaseUrl(params.baseUrl);
   return resolveProviderHttpRequestConfig({
-    baseUrl: resolveTrustedGoogleGenerativeAiBaseUrl(params.baseUrl),
+    baseUrl,
     defaultBaseUrl: DEFAULT_GOOGLE_API_BASE_URL,
     allowPrivateNetwork: params.request?.allowPrivateNetwork,
     headers: params.headers,
@@ -89,7 +90,7 @@ export function resolveGoogleGenerativeAiHttpRequestConfig(params: {
     defaultHeaders: {
       ...parseGeminiAuth(params.apiKey).headers,
       ...resolveGoogleApiClientHeaders({
-        baseUrl: params.baseUrl,
+        baseUrl,
         api: "google-generative-ai",
         capability: params.capability,
         transport: params.transport,

--- a/extensions/google/image-generation-provider.test.ts
+++ b/extensions/google/image-generation-provider.test.ts
@@ -168,6 +168,38 @@ describe("Google image-generation provider", () => {
     });
   });
 
+  it.each([
+    ["empty", ""],
+    ["whitespace-only", "   "],
+  ])(
+    "uses the default Gemini API root when the configured base URL is %s",
+    async (_label, baseUrl) => {
+      mockGoogleApiKeyAuth();
+      const fetchMock = installGoogleFetchMock();
+
+      const provider = buildGoogleImageGenerationProvider();
+      await provider.generateImage({
+        provider: "google",
+        model: "gemini-3.1-flash-image",
+        prompt: "draw a cat",
+        cfg: {
+          models: {
+            providers: {
+              google: {
+                baseUrl,
+                models: [],
+              },
+            },
+          },
+        },
+      });
+
+      expect(fetchRequest(fetchMock).url).toBe(
+        "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-image:generateContent",
+      );
+    },
+  );
+
   it("passes request SSRF policy to the provider HTTP helper", async () => {
     mockGoogleApiKeyAuth();
     const postJsonRequest = vi.spyOn(providerHttp, "postJsonRequest").mockResolvedValue({

--- a/extensions/google/image-generation-provider.test.ts
+++ b/extensions/google/image-generation-provider.test.ts
@@ -194,9 +194,11 @@ describe("Google image-generation provider", () => {
         },
       });
 
-      expect(fetchRequest(fetchMock).url).toBe(
+      const request = fetchRequest(fetchMock);
+      expect(request.url).toBe(
         "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-image:generateContent",
       );
+      expect(new Headers(request.headers).get("x-goog-api-client")).toMatch(/^openclaw\//u);
     },
   );
 


### PR DESCRIPTION
Closes #111550

AI-assisted: Codex. I reviewed and understand the change.

## What Problem This Solves

Fixes an issue where users generating images with Google would receive a base URL validation error when an omitted provider URL was materialized as an empty string.

## Why This Change Was Made

Treat blank provider base URLs as absent at the trusted Google HTTP resolver, so native Gemini requests retain the canonical endpoint fallback while explicit invalid hosts remain rejected. The resolved trusted URL is reused for both the outgoing request and Google client-header selection. Regression coverage exercises empty and whitespace-only configured values and asserts the native attribution header.

## User Impact

Google image generation now uses the canonical Gemini API endpoint when the provider base URL is omitted or blank instead of failing before the request is sent.

## Evidence

- Before the fix, the focused regression failed in `resolveTrustedGoogleGenerativeAiBaseUrl` with `Google Generative AI baseUrl must be a valid https URL on generativelanguage.googleapis.com`.
- The review follow-up at `43a726d845fc` resolves the trusted base URL once, uses it for both the request and `x-goog-api-client` classification, and asserts that header for empty and whitespace-only configured values.
- Exact-head secretless CI passed, including `checks-node-changed` and `openclaw/ci-gate`: https://github.com/openclaw/openclaw/actions/runs/30166044865
- `git diff --check` passed.
- Fresh isolated autoreview completed with a clean TruffleHog scan and no actionable findings (correctness confidence 0.94).
- Live Google attempt on 2026-07-25: a single POST to the canonical `gemini-3.1-flash-image:generateContent` endpoint used a redacted transient API key and included `x-goog-api-client`. Google returned HTTP 429 `RESOURCE_EXHAUSTED` because the key had no available quota. No image was generated, so this is not successful real behavior proof and that proof gap remains.
- Sanitized AWS test allocation was unavailable because the Crabbox host had no AWS credential path. No contributor branch code received the Google credential.
