### PR TITLE
fix(macos): avoid restarting healthy gateways for PATH advisories

### DIFF
--- a/apps/macos/Sources/OpenClaw/GatewayLaunchAgentManager.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayLaunchAgentManager.swift
@@ -73,7 +73,7 @@ enum GatewayLaunchAgentManager {
         }
         let runningPID = self.runningGatewayPID(from: service)
         let configAudit = service["configAudit"] as? [String: Any]
-        let reusablePID: Int32? = if configAudit?["ok"] as? Bool == true,
+        let reusablePID: Int32? = if self.configAuditAllowsReuse(configAudit),
                                      self.gatewayPort(from: service) == port
         {
             runningPID
@@ -81,6 +81,16 @@ enum GatewayLaunchAgentManager {
             nil
         }
         return LoadedGatewayState(runningPID: runningPID, reusablePID: reusablePID)
+    }
+
+    private static func configAuditAllowsReuse(_ audit: [String: Any]?) -> Bool {
+        if audit?["ok"] as? Bool == true {
+            return true
+        }
+        guard let issues = audit?["issues"] as? [[String: Any]], !issues.isEmpty else { return false }
+        // The installer may require an explicit Node bin directory. Its PATH hygiene advisory
+        // must not make a healthy Gateway restart into the same advisory on every app launch.
+        return issues.allSatisfy { $0["code"] as? String == "gateway-path-nonminimal" }
     }
 
     static func runningGatewayPID() async -> Int32? {

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayProcessManagerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayProcessManagerTests.swift
@@ -498,16 +498,6 @@ struct GatewayProcessManagerTests {
         try await self.withLocalGatewayConfig {
             GatewayLaunchAgentManager.setTestingDisableLaunchAgentMarkerURL(marker)
             GatewayLaunchAgentManager.setTestingInterceptDaemonCommands(true)
-            GatewayLaunchAgentManager.setTestingDaemonStatusPayload(
-                """
-                {"ok":true,"service":{
-                  "loaded":true,
-                  "runtime":{"status":"running","pid":4242},
-                  "command":{"programArguments":["openclaw","gateway","--port","\(port)"]},
-                  "configAudit":{"ok":true,"issues":[]}
-                }}
-                """)
-            GatewayLaunchAgentManager.clearTestingDaemonCommandCalls()
             defer {
                 GatewayLaunchAgentManager.setTestingDisableLaunchAgentMarkerURL(nil)
                 GatewayLaunchAgentManager.setTestingInterceptDaemonCommands(false)
@@ -516,13 +506,30 @@ struct GatewayProcessManagerTests {
                 GatewayProcessManager.shared._testClearLaunchAgentReadinessFailure()
             }
 
-            _ = await GatewayProcessManager.shared._testEnableLaunchAgentIfNeeded(
-                bundlePath: "/Applications/OpenClaw.app",
-                port: port)
+            let reusableAudits = [
+                #"{"ok":true,"issues":[]}"#,
+                #"{"ok":false,"issues":[{"code":"gateway-path-nonminimal","level":"recommended"}]}"#,
+            ]
+            for configAudit in reusableAudits {
+                GatewayLaunchAgentManager.setTestingDaemonStatusPayload(
+                    """
+                    {"ok":true,"service":{
+                      "loaded":true,
+                      "runtime":{"status":"running","pid":4242},
+                      "command":{"programArguments":["openclaw","gateway","--port","\(port)"]},
+                      "configAudit":\(configAudit)
+                    }}
+                    """)
+                GatewayLaunchAgentManager.clearTestingDaemonCommandCalls()
 
-            let calls = GatewayLaunchAgentManager.testingDaemonCommandCallsSnapshot()
-            #expect(calls.filter { $0.first == "status" }.count == 1)
-            #expect(calls.allSatisfy { $0.first != "install" })
+                _ = await GatewayProcessManager.shared._testEnableLaunchAgentIfNeeded(
+                    bundlePath: "/Applications/OpenClaw.app",
+                    port: port)
+
+                let calls = GatewayLaunchAgentManager.testingDaemonCommandCallsSnapshot()
+                #expect(calls.filter { $0.first == "status" }.count == 1)
+                #expect(calls.allSatisfy { $0.first != "install" })
+            }
         }
     }
 


### PR DESCRIPTION
Closes #112377

## What Problem This Solves

Fixes an issue where macOS app users with a healthy managed Gateway would have that Gateway force-reinstalled on app startup when its only configuration audit finding was the recommended nonminimal PATH advisory. The restart could briefly disconnect the app and native node without changing the advisory.

## Why This Change Was Made

The macOS app now treats a loaded Gateway as reusable when its audit is clean or when every reported issue is `gateway-path-nonminimal`. Running-process and port checks remain required, while missing, malformed, empty, mixed, or actionable audit results still trigger the existing repair path.

This change was developed with AI assistance and reviewed with the repository's autoreview workflow. No agent transcript is attached.

## User Impact

The macOS app reuses a healthy managed Gateway instead of restarting it solely for a PATH hygiene recommendation. Real service drift, wrong ports, stopped processes, and readiness failures continue to be repaired.

## Evidence

- Reproduced before the fix on macOS 26.5.1 with OpenClaw 2026.7.2: the loaded Gateway was running on the configured port, and its only audit issue was `gateway-path-nonminimal`, but the app selected the force-install path.
- `swift test --package-path apps/macos --filter 'keeps a reusable launch agent running'` passes on exact current `upstream/main` plus this commit; the test covers both a clean audit and the advisory-only audit.
- `swiftformat --lint apps/macos/Sources/OpenClaw/GatewayLaunchAgentManager.swift apps/macos/Tests/OpenClawIPCTests/GatewayProcessManagerTests.swift --config config/swiftformat` passes.
- SwiftLint reports zero violations for the changed production file.
- `git diff --check upstream/main...HEAD` passes.
- Fresh branch autoreview: no findings, patch correct, confidence 0.91.

Known proof gap: the broader local `GatewayProcessManagerTests` suite contains an existing failure in `startup install forces the recovered control channel refresh`; the same isolated failure reproduces with this production change removed. GitHub CI remains the broad hosted proof.
