### PR TITLE
fix(ui): keep Model Providers select chevrons on the right

### DIFF
--- a/ui/src/components/form-controls.browser.test.ts
+++ b/ui/src/components/form-controls.browser.test.ts
@@ -38,6 +38,7 @@ function controlsHtml() {
       <label class="field"><input type="text" value="field input" /></label>
       <label class="field"><textarea>field textarea</textarea></label>
       <label class="field"><select><option>field select</option></select></label>
+      <label class="field"><select class="settings-select"><option>field settings select</option></select></label>
       <label class="field checkbox"><input type="checkbox" /><span>field checkbox</span></label>
       <label class="field checkbox"><input type="radio" /><span>field radio</span></label>
       <input class="settings-sidebar__search-input" value="settings search" />
@@ -221,16 +222,17 @@ describeBrowserLayout("touch-primary form controls", () => {
     }
   });
 
-  it("keeps native select affordances visible in light mode", async () => {
+  it("keeps settings select affordances visible in light mode", async () => {
     const fixture = await openMobileFixture();
     const { page } = fixture;
     try {
-      const selects = await page.locator(".field select").evaluateAll((nodes) =>
+      const selects = await page.locator(".field select.settings-select").evaluateAll((nodes) =>
         nodes.map((node) => {
           const style = getComputedStyle(node as HTMLElement);
           return {
             image: style.backgroundImage,
             paddingRight: Number.parseFloat(style.paddingRight),
+            positionX: style.backgroundPositionX,
             repeat: style.backgroundRepeat,
           };
         }),
@@ -240,6 +242,7 @@ describeBrowserLayout("touch-primary form controls", () => {
       for (const select of selects) {
         expect(select.image).not.toBe("none");
         expect(select.paddingRight).toBeGreaterThanOrEqual(32);
+        expect(select.positionX).toBe("calc(100% - 10px)");
         expect(select.repeat).toContain("no-repeat");
       }
     } finally {

--- a/ui/src/styles/settings.css
+++ b/ui/src/styles/settings.css
@@ -443,6 +443,12 @@ select.settings-select {
   transition: border-color var(--duration-fast) var(--ease-out);
 }
 
+select.settings-select {
+  background-position: right 10px center;
+  background-repeat: no-repeat;
+  padding-right: 36px;
+}
+
 .settings-row:not(.settings-row--stacked) .settings-row__control > .settings-select {
   width: auto;
   min-width: min(220px, 100%);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening **Model Providers** would see the native select chevron repeated across the field, or positioned at the left edge, in light mode. Long selected model names could also run into the chevron.

## Why This Change Was Made

The settings select style now explicitly restores the generic field select’s background position, non-repeating behavior, and trailing space after its background shorthand resets those values.

## User Impact

Model Provider selectors now show one chevron at the right edge, with enough space for long model names.

## Evidence

- Focused real-Chromium Control UI test passed: `node scripts/test-projects.mjs ui/src/components/form-controls.browser.test.ts -- --reporter=verbose` (6/6).
- Deterministic mocked Model Providers page confirmed each of the three selectors has `background-position-x: calc(100% - 10px)`, `background-repeat: no-repeat`, and `padding-right: 36px`.
- Source-aware autoreview passed clean

Before:

<img width="1718" height="673" alt="Screenshot 2026-07-21 at 1 23 38 PM" src="https://github.com/user-attachments/assets/30773b2f-1922-4d48-bdee-b582f694d797" />

After:

<img width="919" height="371" alt="Screenshot 2026-07-21 at 3 39 25 PM" src="https://github.com/user-attachments/assets/9ffd41ca-aa18-4558-9cc5-aa07f12848f1" />


AI-assisted: yes.