### PR TITLE
fix(android): Wear Talk works after exiting and reopening

### DIFF
--- a/apps/android/wear/src/main/java/ai/openclaw/wear/WearApplication.kt
+++ b/apps/android/wear/src/main/java/ai/openclaw/wear/WearApplication.kt
@@ -31,10 +31,6 @@ class WearApplication : Application() {
     WearGatewayRepository(proxyClient)
   }
 
-  internal val realtimeTalkClient: WearRealtimeTalkClient by lazy {
-    WearRealtimeTalkClient(this, gatewayRepository)
-  }
-
   private val visibleActivities = VisibleActivityTracker()
 
   internal fun onActivityStarted() = visibleActivities.onStarted()

--- a/apps/android/wear/src/main/java/ai/openclaw/wear/WearViewModel.kt
+++ b/apps/android/wear/src/main/java/ai/openclaw/wear/WearViewModel.kt
@@ -121,7 +121,7 @@ internal class WearViewModel(
 ) : AndroidViewModel(application) {
   private val app = application as WearApplication
   private val repository = app.gatewayRepository
-  private val realtimeTalkClient = app.realtimeTalkClient
+  private val realtimeTalkClient = WearRealtimeTalkClient(app, repository)
   private val mutableState = MutableStateFlow(WearUiState())
   private val eventSequenceTracker = WearEventSequenceTracker()
   private val eventSourceTracker = WearEventSourceTracker()

--- a/apps/android/wear/src/test/java/ai/openclaw/wear/WearViewModelLifecycleTest.kt
+++ b/apps/android/wear/src/test/java/ai/openclaw/wear/WearViewModelLifecycleTest.kt
@@ -1,0 +1,50 @@
+package ai.openclaw.wear
+
+import androidx.lifecycle.ViewModelStore
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = WearApplication::class, sdk = [35])
+class WearViewModelLifecycleTest {
+  @Test
+  fun recreatedViewModelGetsALiveTalkClientAfterThePreviousOneClears() {
+    val app = RuntimeEnvironment.getApplication() as WearApplication
+    val firstViewModel = WearViewModel(app)
+    val firstClient = firstViewModel.realtimeTalkClientForTest()
+    val firstStore = ViewModelStore().apply { put("wear", firstViewModel) }
+
+    firstStore.clear()
+
+    val reopenedViewModel = WearViewModel(app)
+    val reopenedClient = reopenedViewModel.realtimeTalkClientForTest()
+    val reopenedStore = ViewModelStore().apply { put("wear", reopenedViewModel) }
+    try {
+      assertFalse(firstClient.scopeForTest().coroutineContext[Job]?.isActive == true)
+      assertNotSame(firstClient, reopenedClient)
+      assertTrue(reopenedClient.scopeForTest().coroutineContext[Job]?.isActive == true)
+    } finally {
+      reopenedStore.clear()
+    }
+  }
+
+  private fun WearViewModel.realtimeTalkClientForTest(): WearRealtimeTalkClient =
+    javaClass.getDeclaredField("realtimeTalkClient").run {
+      isAccessible = true
+      get(this@realtimeTalkClientForTest) as WearRealtimeTalkClient
+    }
+
+  private fun WearRealtimeTalkClient.scopeForTest(): CoroutineScope =
+    javaClass.getDeclaredField("scope").run {
+      isAccessible = true
+      get(this@scopeForTest) as CoroutineScope
+    }
+}

--- a/apps/android/wear/src/test/java/ai/openclaw/wear/WearViewModelLifecycleTest.kt
+++ b/apps/android/wear/src/test/java/ai/openclaw/wear/WearViewModelLifecycleTest.kt
@@ -1,6 +1,8 @@
 package ai.openclaw.wear
 
+import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStore
+import androidx.lifecycle.ViewModelStoreOwner
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import org.junit.Assert.assertFalse
@@ -18,22 +20,27 @@ class WearViewModelLifecycleTest {
   @Test
   fun recreatedViewModelGetsALiveTalkClientAfterThePreviousOneClears() {
     val app = RuntimeEnvironment.getApplication() as WearApplication
-    val firstViewModel = WearViewModel(app)
+    val factory = ViewModelProvider.AndroidViewModelFactory.getInstance(app)
+    val firstOwner = TestViewModelStoreOwner()
+    val firstViewModel = ViewModelProvider(firstOwner, factory)[WearViewModel::class.java]
     val firstClient = firstViewModel.realtimeTalkClientForTest()
-    val firstStore = ViewModelStore().apply { put("wear", firstViewModel) }
 
-    firstStore.clear()
+    firstOwner.viewModelStore.clear()
 
-    val reopenedViewModel = WearViewModel(app)
+    val reopenedOwner = TestViewModelStoreOwner()
+    val reopenedViewModel = ViewModelProvider(reopenedOwner, factory)[WearViewModel::class.java]
     val reopenedClient = reopenedViewModel.realtimeTalkClientForTest()
-    val reopenedStore = ViewModelStore().apply { put("wear", reopenedViewModel) }
     try {
       assertFalse(firstClient.scopeForTest().coroutineContext[Job]?.isActive == true)
       assertNotSame(firstClient, reopenedClient)
       assertTrue(reopenedClient.scopeForTest().coroutineContext[Job]?.isActive == true)
     } finally {
-      reopenedStore.clear()
+      reopenedOwner.viewModelStore.clear()
     }
+  }
+
+  private class TestViewModelStoreOwner : ViewModelStoreOwner {
+    override val viewModelStore = ViewModelStore()
   }
 
   private fun WearViewModel.realtimeTalkClientForTest(): WearRealtimeTalkClient =


### PR DESCRIPTION
AI-assisted: Implemented and reviewed with Codex.

## What Problem This Solves

Fixes an issue where users who exited the Wear Activity after using Talk could reopen it with Talk permanently unable to start again for the rest of the app process.

## Why This Change Was Made

The realtime Talk client is now owned by the `WearViewModel` instead of the process-wide `WearApplication`. AndroidX Lifecycle 2.11.0 retains a ViewModel across configuration changes and clears it when its owner is permanently destroyed, which matches the lifetime of the client's microphone, playback, coroutine, and Data Layer resources. Clearing one Activity's ViewModel shuts down only that client, while a reopened Activity receives a new client with an active coroutine scope.

The regression test uses AndroidX's real `AndroidViewModelFactory` and separate `ViewModelStoreOwner` instances, so it exercises the same construction and clear/recreate ownership contract as the Activity rather than manually constructing ViewModels.

## User Impact

Wear Talk can recover after exiting and reopening the Activity without requiring the user to kill or restart the app process.

## Evidence

- Blacksmith Testbox `tbx_01kykadbr995rs35czwdpt2cvh`: Wear ktlint, `WearViewModelLifecycleTest`, and `:wear:assembleDebug` all passed.
- Wear API 36 emulator: the exact APK launched, exited, and reopened twice while retaining PID 2631 and restoring the interactive surface each time.
- Exact-head CI run 30325227153: both phone flavors, Wear unit tests, Wear/phone builds, Android ktlint, native i18n, security, and `openclaw/ci-gate` passed at `0566d90fa2d5adf3c1e1ea49b22181750172a69d`.
- Final mandatory P1 autoreview: clean, patch correct (0.98 confidence).
- `git diff --check upstream/main...HEAD`: passed.

## Remaining Proof Limitation

The isolated Wear emulator reported `Phone not reachable`, so it could not complete a paired Talk audio start after reopen. This is not being represented as paired-device proof. The confidence instead comes from the AndroidX lifecycle contract, the real factory/store regression, the same-process Activity exercise, focused Testbox proof, and exact-head Android CI. A paired phone/Gateway run remains useful follow-up proof but is not required to validate the ownership correction itself.

No screenshot is included because this changes lifecycle ownership and has no visual UI change.
