### PR TITLE
fix(ui): stopping Talk no longer leaks a pending gateway relay

### DIFF
--- a/ui/src/e2e/browser-talk-start-stop.e2e.test.ts
+++ b/ui/src/e2e/browser-talk-start-stop.e2e.test.ts
@@ -1,7 +1,5 @@
 // Control UI E2E tests cover browser Talk start and stop through a real page.
-import { mkdir } from "node:fs/promises";
-import path from "node:path";
-import { chromium, type Browser, type Page } from "playwright";
+import { chromium, type Browser } from "playwright";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
   canRunPlaywrightChromium,
@@ -10,6 +8,14 @@ import {
   startControlUiE2eServer,
   type ControlUiE2eServer,
 } from "../test-helpers/control-ui-e2e.ts";
+import {
+  captureComposerProof,
+  captureVideoTalkProof,
+  installBlockedMicrophoneFixture,
+  installBlockedVideoTalkFixture,
+  installTalkBrowserFixtures,
+  videoTalkCatalog,
+} from "./browser-talk-start-stop.fixtures.ts";
 
 const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
 const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
@@ -19,152 +25,6 @@ const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? descri
 let server: ControlUiE2eServer;
 // Browser contexts preserve test isolation; keep one process warm for this file.
 let browser: Browser;
-
-function videoTalkCatalog(activeProvider: "google" | "openai") {
-  return {
-    realtime: {
-      activeProvider,
-      providers: [{ id: activeProvider, label: activeProvider, supportsVideoFrames: true }],
-    },
-  };
-}
-
-async function installTalkBrowserFixtures(page: Page) {
-  await page.addInitScript(() => {
-    type InputProcessor = {
-      onaudioprocess:
-        | ((event: { inputBuffer: { getChannelData: () => Float32Array } }) => void)
-        | null;
-    };
-    const state = {
-      audioContextsClosed: 0,
-      tracksStopped: 0,
-      constraints: [] as unknown[],
-      inputProcessor: null as InputProcessor | null,
-      meterLevel: 0,
-    };
-    const track = { stop: () => (state.tracksStopped += 1) };
-    Object.defineProperty(navigator, "mediaDevices", {
-      configurable: true,
-      value: {
-        enumerateDevices: async () => [
-          { kind: "audioinput", deviceId: "built-in", label: "Built-in Microphone" },
-          { kind: "audioinput", deviceId: "usb", label: "USB Audio Interface" },
-          { kind: "videoinput", deviceId: "camera", label: "Camera" },
-        ],
-        getUserMedia: async (constraints: unknown) => {
-          state.constraints.push(constraints);
-          return { getTracks: () => [track] };
-        },
-      },
-    });
-
-    class MockAudioContext {
-      readonly currentTime = 0;
-      readonly destination = {};
-      readonly sampleRate: number;
-
-      constructor(options?: { sampleRate?: number }) {
-        this.sampleRate = options?.sampleRate ?? 24_000;
-      }
-
-      createMediaStreamSource() {
-        return { connect() {}, disconnect() {} };
-      }
-
-      createGain() {
-        return { connect() {}, disconnect() {}, gain: { value: 1 } };
-      }
-
-      createScriptProcessor() {
-        const processor = { connect() {}, disconnect() {}, onaudioprocess: null };
-        state.inputProcessor = processor;
-        return processor;
-      }
-
-      createAnalyser() {
-        return {
-          fftSize: 0,
-          smoothingTimeConstant: 0,
-          disconnect() {},
-          getFloatTimeDomainData(samples: Float32Array) {
-            samples.fill(state.meterLevel);
-          },
-        };
-      }
-
-      async close() {
-        state.audioContextsClosed += 1;
-      }
-    }
-
-    Object.defineProperty(window, "AudioContext", {
-      configurable: true,
-      value: MockAudioContext,
-    });
-    Object.defineProperty(window, "openclawTalkE2eState", {
-      configurable: true,
-      value: state,
-    });
-  });
-}
-
-async function captureComposerProof(page: Page, fileName: string) {
-  const artifactDir = path.join(process.cwd(), ".artifacts", "control-ui-e2e", "voice-controls");
-  await mkdir(artifactDir, { recursive: true });
-  await page
-    .locator(".agent-chat__composer-shell")
-    .screenshot({ path: path.join(artifactDir, fileName) });
-}
-
-async function captureVideoTalkProof(page: Page, fileName: string) {
-  const artifactDir = path.join(process.cwd(), ".artifacts", "control-ui-e2e", "video-talk");
-  await mkdir(artifactDir, { recursive: true });
-  await page
-    .locator(".agent-chat__composer-shell")
-    .screenshot({ path: path.join(artifactDir, fileName) });
-}
-
-async function installBlockedMicrophoneFixture(page: Page) {
-  await page.addInitScript(() => {
-    Object.defineProperty(navigator, "mediaDevices", {
-      configurable: true,
-      value: {
-        enumerateDevices: async () => [],
-        getUserMedia: async () => {
-          throw new DOMException("Permission denied", "NotAllowedError");
-        },
-      },
-    });
-  });
-}
-
-async function installBlockedVideoTalkFixture(page: Page) {
-  await page.addInitScript(() => {
-    const getUserMedia = navigator.mediaDevices.getUserMedia.bind(navigator.mediaDevices);
-    Object.defineProperty(navigator, "mediaDevices", {
-      configurable: true,
-      value: {
-        getUserMedia: async (constraints: MediaStreamConstraints) => {
-          if (constraints.video) {
-            throw new DOMException("Permission denied", "NotAllowedError");
-          }
-          return getUserMedia(constraints);
-        },
-      },
-    });
-    class FakePeerConnection extends EventTarget {
-      connectionState = "new";
-      close() {
-        this.connectionState = "closed";
-      }
-    }
-    Object.defineProperty(window, "RTCPeerConnection", {
-      configurable: true,
-      value: FakePeerConnection,
-    });
-  });
-}
 
 describeControlUiE2e("Control UI browser Talk", () => {
   beforeAll(async () => {
@@ -999,6 +859,123 @@ describeControlUiE2e("Control UI browser Talk", () => {
       // A collapsed turn renders one character per line (tall, sliver-wide box).
       expect(turnBounds?.width ?? 0).toBeGreaterThanOrEqual(500);
       expect(turnBounds?.height ?? Number.POSITIVE_INFINITY).toBeLessThanOrEqual(120);
+    } finally {
+      await context.close();
+    }
+  });
+
+  it("closes a stale relay when stop and restart race its create response", async () => {
+    const context = await browser.newContext({ locale: "en-US", permissions: ["microphone"] });
+    const page = await context.newPage();
+    const currentRelaySessionId = "relay-current-e2e";
+    const staleRelaySessionId = "relay-stale-e2e";
+    const gateway = await installMockGateway(page, {
+      methodResponses: {
+        "talk.client.create": {
+          provider: "openai",
+          transport: "gateway-relay",
+          relaySessionId: currentRelaySessionId,
+          audio: {
+            inputEncoding: "pcm16",
+            inputSampleRateHz: 16_000,
+            outputEncoding: "pcm16",
+            outputSampleRateHz: 24_000,
+          },
+        },
+        "talk.session.appendAudio": {},
+        "talk.session.close": {},
+      },
+    });
+    await installTalkBrowserFixtures(page);
+
+    try {
+      await page.goto(`${server.baseUrl}chat`);
+      await gateway.deferNext("talk.client.create");
+
+      await page.getByRole("button", { name: "Start voice input" }).click();
+      await expect
+        .poll(() => gateway.getRequests("talk.client.create").then((requests) => requests.length))
+        .toBe(1);
+      await page.getByRole("button", { name: "Stop voice input" }).click();
+      await page.getByRole("button", { name: "Start voice input" }).click();
+      await expect
+        .poll(() => gateway.getRequests("talk.client.create").then((requests) => requests.length))
+        .toBe(2);
+
+      await expect
+        .poll(() =>
+          page.evaluate(
+            () =>
+              (
+                window as Window & {
+                  openclawTalkE2eState?: { constraints: unknown[] };
+                }
+              ).openclawTalkE2eState?.constraints.length,
+          ),
+        )
+        .toBe(1);
+      await gateway.emitGatewayEvent("talk.event", {
+        relaySessionId: currentRelaySessionId,
+        type: "ready",
+      });
+      await expect
+        .poll(() => page.locator('.agent-chat__voice-activity[data-status="listening"]').count())
+        .toBe(1);
+
+      await gateway.resolveDeferred("talk.client.create", {
+        provider: "openai",
+        transport: "gateway-relay",
+        relaySessionId: staleRelaySessionId,
+        audio: {
+          inputEncoding: "pcm16",
+          inputSampleRateHz: 16_000,
+          outputEncoding: "pcm16",
+          outputSampleRateHz: 24_000,
+        },
+      });
+      await expect
+        .poll(() => gateway.getRequests("talk.session.close"))
+        .toEqual([
+          expect.objectContaining({
+            params: { sessionId: staleRelaySessionId },
+          }),
+        ]);
+
+      await page.evaluate(() => {
+        const state = (
+          window as Window & {
+            openclawTalkE2eState?: {
+              inputProcessor?: {
+                onaudioprocess?: (event: {
+                  inputBuffer: { getChannelData: () => Float32Array };
+                }) => void;
+              };
+            };
+          }
+        ).openclawTalkE2eState;
+        state?.inputProcessor?.onaudioprocess?.({
+          inputBuffer: { getChannelData: () => new Float32Array(4096).fill(0.1) },
+        });
+      });
+      await expect
+        .poll(() => gateway.getRequests("talk.session.appendAudio"))
+        .toEqual([
+          expect.objectContaining({
+            params: expect.objectContaining({ sessionId: currentRelaySessionId }),
+          }),
+        ]);
+      await expect
+        .poll(() => page.getByRole("button", { name: "Stop voice input" }).isVisible())
+        .toBe(true);
+
+      await page.getByRole("button", { name: "Stop voice input" }).click();
+      await expect
+        .poll(() =>
+          gateway
+            .getRequests("talk.session.close")
+            .then((requests) => requests.map((request) => request.params)),
+        )
+        .toEqual([{ sessionId: staleRelaySessionId }, { sessionId: currentRelaySessionId }]);
     } finally {
       await context.close();
     }

--- a/ui/src/e2e/browser-talk-start-stop.fixtures.ts
+++ b/ui/src/e2e/browser-talk-start-stop.fixtures.ts
@@ -1,0 +1,149 @@
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import type { Page } from "playwright";
+
+export function videoTalkCatalog(activeProvider: "google" | "openai") {
+  return {
+    realtime: {
+      activeProvider,
+      providers: [{ id: activeProvider, label: activeProvider, supportsVideoFrames: true }],
+    },
+  };
+}
+
+export async function installTalkBrowserFixtures(page: Page) {
+  await page.addInitScript(() => {
+    type InputProcessor = {
+      onaudioprocess:
+        | ((event: { inputBuffer: { getChannelData: () => Float32Array } }) => void)
+        | null;
+    };
+    const state = {
+      audioContextsClosed: 0,
+      tracksStopped: 0,
+      constraints: [] as unknown[],
+      inputProcessor: null as InputProcessor | null,
+      meterLevel: 0,
+    };
+    const track = { stop: () => (state.tracksStopped += 1) };
+    Object.defineProperty(navigator, "mediaDevices", {
+      configurable: true,
+      value: {
+        enumerateDevices: async () => [
+          { kind: "audioinput", deviceId: "built-in", label: "Built-in Microphone" },
+          { kind: "audioinput", deviceId: "usb", label: "USB Audio Interface" },
+          { kind: "videoinput", deviceId: "camera", label: "Camera" },
+        ],
+        getUserMedia: async (constraints: unknown) => {
+          state.constraints.push(constraints);
+          return { getTracks: () => [track] };
+        },
+      },
+    });
+
+    class MockAudioContext {
+      readonly currentTime = 0;
+      readonly destination = {};
+      readonly sampleRate: number;
+
+      constructor(options?: { sampleRate?: number }) {
+        this.sampleRate = options?.sampleRate ?? 24_000;
+      }
+
+      createMediaStreamSource() {
+        return { connect() {}, disconnect() {} };
+      }
+
+      createGain() {
+        return { connect() {}, disconnect() {}, gain: { value: 1 } };
+      }
+
+      createScriptProcessor() {
+        const processor = { connect() {}, disconnect() {}, onaudioprocess: null };
+        state.inputProcessor = processor;
+        return processor;
+      }
+
+      createAnalyser() {
+        return {
+          fftSize: 0,
+          smoothingTimeConstant: 0,
+          disconnect() {},
+          getFloatTimeDomainData(samples: Float32Array) {
+            samples.fill(state.meterLevel);
+          },
+        };
+      }
+
+      async close() {
+        state.audioContextsClosed += 1;
+      }
+    }
+
+    Object.defineProperty(window, "AudioContext", {
+      configurable: true,
+      value: MockAudioContext,
+    });
+    Object.defineProperty(window, "openclawTalkE2eState", {
+      configurable: true,
+      value: state,
+    });
+  });
+}
+
+export async function captureComposerProof(page: Page, fileName: string) {
+  const artifactDir = path.join(process.cwd(), ".artifacts", "control-ui-e2e", "voice-controls");
+  await mkdir(artifactDir, { recursive: true });
+  await page
+    .locator(".agent-chat__composer-shell")
+    .screenshot({ path: path.join(artifactDir, fileName) });
+}
+
+export async function captureVideoTalkProof(page: Page, fileName: string) {
+  const artifactDir = path.join(process.cwd(), ".artifacts", "control-ui-e2e", "video-talk");
+  await mkdir(artifactDir, { recursive: true });
+  await page
+    .locator(".agent-chat__composer-shell")
+    .screenshot({ path: path.join(artifactDir, fileName) });
+}
+
+export async function installBlockedMicrophoneFixture(page: Page) {
+  await page.addInitScript(() => {
+    Object.defineProperty(navigator, "mediaDevices", {
+      configurable: true,
+      value: {
+        enumerateDevices: async () => [],
+        getUserMedia: async () => {
+          throw new DOMException("Permission denied", "NotAllowedError");
+        },
+      },
+    });
+  });
+}
+
+export async function installBlockedVideoTalkFixture(page: Page) {
+  await page.addInitScript(() => {
+    const getUserMedia = navigator.mediaDevices.getUserMedia.bind(navigator.mediaDevices);
+    Object.defineProperty(navigator, "mediaDevices", {
+      configurable: true,
+      value: {
+        getUserMedia: async (constraints: MediaStreamConstraints) => {
+          if (constraints.video) {
+            throw new DOMException("Permission denied", "NotAllowedError");
+          }
+          return getUserMedia(constraints);
+        },
+      },
+    });
+    class FakePeerConnection extends EventTarget {
+      connectionState = "new";
+      close() {
+        this.connectionState = "closed";
+      }
+    }
+    Object.defineProperty(window, "RTCPeerConnection", {
+      configurable: true,
+      value: FakePeerConnection,
+    });
+  });
+}

--- a/ui/src/pages/chat/realtime-talk.test.ts
+++ b/ui/src/pages/chat/realtime-talk.test.ts
@@ -47,6 +47,14 @@ function transportContext(transport: object | undefined): RealtimeTalkTransportC
   return (transport as { ctx: RealtimeTalkTransportContext }).ctx;
 }
 
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
 describe("RealtimeTalkSession", () => {
   beforeEach(() => {
     googleStart.mockClear();
@@ -207,6 +215,97 @@ describe("RealtimeTalkSession", () => {
     expect(relayStop).toHaveBeenCalledTimes(1);
     expect(googleInstances).toHaveLength(0);
     expect(webRtcInstances).toHaveLength(0);
+  });
+
+  it("closes a Gateway relay allocated after the session stops", async () => {
+    const create = createDeferred<{
+      provider: string;
+      transport: "gateway-relay";
+      relaySessionId: string;
+      audio: {
+        inputEncoding: "pcm16";
+        inputSampleRateHz: number;
+        outputEncoding: "pcm16";
+        outputSampleRateHz: number;
+      };
+    }>();
+    const request = vi.fn((method: string) => {
+      if (method === "talk.client.create") {
+        return create.promise;
+      }
+      if (method === "talk.session.close") {
+        return Promise.resolve({ ok: true });
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const session = new RealtimeTalkSession({ request } as never, "main");
+
+    const starting = session.start();
+    await vi.waitFor(() =>
+      expect(request).toHaveBeenCalledWith("talk.client.create", expect.anything()),
+    );
+    session.stop();
+    create.resolve({
+      provider: "openai",
+      transport: "gateway-relay",
+      relaySessionId: "relay-stale",
+      audio: {
+        inputEncoding: "pcm16",
+        inputSampleRateHz: 24_000,
+        outputEncoding: "pcm16",
+        outputSampleRateHz: 24_000,
+      },
+    });
+    await starting;
+
+    expect(request).toHaveBeenCalledWith("talk.session.close", { sessionId: "relay-stale" });
+    expect(relayInstances).toHaveLength(0);
+  });
+
+  it("closes a superseded client-owned allocation without replacing the active call", async () => {
+    const creates: Array<ReturnType<typeof createDeferred<unknown>>> = [];
+    const request = vi.fn((method: string) => {
+      if (method === "talk.client.create") {
+        const create = createDeferred<unknown>();
+        creates.push(create);
+        return create.promise;
+      }
+      if (method === "talk.client.close") {
+        return Promise.resolve({ ok: true });
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const session = new RealtimeTalkSession({ request } as never, "main");
+
+    const firstStart = session.start();
+    await vi.waitFor(() => expect(creates).toHaveLength(1));
+    session.stop();
+    const secondStart = session.start();
+    await vi.waitFor(() => expect(creates).toHaveLength(2));
+    creates[1]!.resolve({
+      provider: "openai",
+      transport: "webrtc",
+      voiceSessionId: "voice-current",
+      clientSecret: "secret",
+    });
+    await secondStart;
+    creates[0]!.resolve({
+      provider: "openai",
+      transport: "webrtc",
+      voiceSessionId: "voice-stale",
+      clientSecret: "secret",
+    });
+    await firstStart;
+
+    await vi.waitFor(() =>
+      expect(request).toHaveBeenCalledWith("talk.client.close", {
+        sessionKey: "main",
+        voiceSessionId: "voice-stale",
+      }),
+    );
+    expect(webRtcInstances).toHaveLength(1);
+    expect(webRtcStart).toHaveBeenCalledTimes(1);
+    session.stop();
   });
 
   it("falls back to talk.session.create when gateway-relay is rejected by talk.client.create", async () => {

--- a/ui/src/pages/chat/realtime-talk.ts
+++ b/ui/src/pages/chat/realtime-talk.ts
@@ -61,7 +61,7 @@ type RealtimeTalkLaunchTransport = NonNullable<RealtimeTalkLaunchOptions["transp
 type DetachedVoiceSession = {
   voiceSessionId: string;
   serverOwned: boolean;
-  generation: number;
+  generation?: number;
   transcriptWrites: Promise<void>;
 };
 
@@ -137,6 +137,7 @@ function compactLaunchParams(
 export class RealtimeTalkSession {
   private transport: RealtimeTalkTransport | null = null;
   private closed = false;
+  private lifecycleGeneration = 0;
   private videoEnabled = false;
   private videoOperation = 0;
   private voiceSessionId: string | undefined;
@@ -155,10 +156,11 @@ export class RealtimeTalkSession {
   ) {}
 
   async start(): Promise<void> {
+    const lifecycleGeneration = ++this.lifecycleGeneration;
     this.closed = false;
     this.callbacks.onStatus?.("connecting");
     const providerVideoCapable = await this.resolveVideoCapability();
-    if (this.closed) {
+    if (this.closed || lifecycleGeneration !== this.lifecycleGeneration) {
       return;
     }
     // Declaring voice-transcript arms the server-side spoken-confirmation gate;
@@ -182,16 +184,13 @@ export class RealtimeTalkSession {
     if (!voiceSessionId) {
       throw new Error("Realtime Talk session did not return a voice session id");
     }
+    if (this.closed || lifecycleGeneration !== this.lifecycleGeneration) {
+      this.closeUnadoptedVoiceSession(voiceSessionId, transport);
+      return;
+    }
     this.voiceSessionId = voiceSessionId;
     this.acceptingTranscripts = true;
     this.serverOwnedVoiceSession = transport === "gateway-relay";
-    if (this.closed) {
-      const detached = this.detachVoiceSession();
-      if (detached) {
-        this.closeLogicalVoiceSession(detached);
-      }
-      return;
-    }
     this.transportGeneration += 1;
     const callbacks =
       transport === "gateway-relay"
@@ -300,6 +299,7 @@ export class RealtimeTalkSession {
   }
 
   stop(): void {
+    this.lifecycleGeneration += 1;
     this.closed = true;
     this.videoOperation += 1;
     this.videoEnabled = false;
@@ -311,6 +311,22 @@ export class RealtimeTalkSession {
     if (detached) {
       this.closeLogicalVoiceSession(detached);
     }
+  }
+
+  private closeUnadoptedVoiceSession(voiceSessionId: string, transport: string): void {
+    // A stopped or superseded create still owns the allocation returned to it.
+    // Close at the provider boundary without installing a stale transport.
+    if (transport === "gateway-relay") {
+      void this.client
+        .request("talk.session.close", { sessionId: voiceSessionId })
+        .catch(() => undefined);
+      return;
+    }
+    this.closeLogicalVoiceSession({
+      voiceSessionId,
+      serverOwned: false,
+      transcriptWrites: Promise.resolve(),
+    });
   }
 
   private clientOwnedTranscriptCallbacks(


### PR DESCRIPTION
Related: #110302, #111725

## What Problem This Solves

Stopping or restarting Talk while a session allocation is still pending can
discard the local start before the allocation ID returns. On current `main`,
the late gateway relay or client-owned voice session is then left open, and an
older start can race with the replacement session.

## Why This Change

`RealtimeTalkSession` now owns a small lifecycle generation:

- stop invalidates every pending start
- a newer start supersedes an older pending start
- late gateway relays close through `talk.session.close`
- late client-owned sessions close through the existing retrying
  `talk.client.close` path
- only the current allocation may replace the active transport

This stays inside the existing Talk session owner. It adds no provider, config,
protocol, or environment-variable surface.

## Consolidation And Credit

This is the canonical fix for the overlap with #110302. The rewritten history
keeps NianJiuZst credited on the lifecycle fix and carries #110302's stronger
browser start/stop regression in a separate commit co-authored by shaoohh. The
existing Talk browser fixtures moved to one shared test helper so the stronger
coverage does not grow the already-large E2E file past the repository line cap.

## Evidence

Frozen relevant base: `12297b79471177f08a1959855d2998146c29537f`

- Blacksmith Testbox
  [run](https://github.com/openclaw/openclaw/actions/runs/30617812266):
  `pnpm test ui/src/pages/chat/realtime-talk.test.ts` passed 28/28 tests
- The same Testbox run: the focused
  `browser-talk-start-stop.e2e.test.ts` race passed 1/1; it proves stop/restart,
  reverse create completion, exactly one stale relay close, working replacement
  audio, and final replacement close
- The same Testbox run: path-scoped
  `node scripts/check-changed.mjs -- ui/src/pages/chat/realtime-talk.ts
  ui/src/pages/chat/realtime-talk.test.ts
  ui/src/e2e/browser-talk-start-stop.e2e.test.ts
  ui/src/e2e/browser-talk-start-stop.fixtures.ts` passed, including max-lines,
  both TypeScript lanes, and lint
- OAuth-backed canonical realtime live smoke: OpenAI backend bridge connected;
  PCM audio roundtrip sent 199,200 input bytes and received 48,000 output bytes,
  transcribed `Glacier` on both sides, completed the response, and received zero
  late audio bytes; browser WebRTC connected; the Gateway relay adapter passed
  append-audio, tool call/result, close, listening/thinking, and transcript
  checks. Google was not run because no Google key was available.
- `git diff --check` and targeted `oxfmt --check` passed
- `git range-diff` confirmed the two commits were unchanged by the rebase
- Codex autoreview found no issues (0.88 confidence)

### Redacted Terminal Proof

```text
ui/src/pages/chat/realtime-talk.test.ts (28 tests)
Test Files  1 passed (1)
Tests       28 passed (28)

ui/src/e2e/browser-talk-start-stop.e2e.test.ts
✓ closes a stale relay when stop and restart race its create response
Test Files  1 passed (1)
Tests       1 passed | 7 skipped (8)

openai-backend-bridge: ok
  model: gpt-realtime-2.1
  connected: true

openai-backend-audio-roundtrip: ok
  inputAudioBytes: 199200
  chunksSent: 208
  outputAudioBytes: 48000
  userTranscript: Please reply with the single word Glacier.
  assistantTranscript: glacier
  responseDone: true
  lateAudioBytes: 0

openai-webrtc-browser: ok
  answerHasAudio: true
  remoteDescriptionApplied: true
  connectionState: connected

gateway-relay-browser-adapter: ok
  methods: talk.client.toolCall, talk.session.appendAudio,
           talk.session.close, talk.session.submitToolResult
  statuses: listening, thinking
  transcripts: relay assistant, relay user
```

## Real Behavior Proof

- Behavior addressed: stopping and immediately restarting Talk while the first
  relay allocation is delayed must close only the stale relay and leave the
  replacement relay usable.
- Real environment tested: Blacksmith Testbox Chromium against the real Control
  UI page and Talk implementation, with a controlled Gateway for deterministic
  reverse completion; separate OAuth-backed OpenAI realtime backend, PCM audio,
  WebRTC, and relay-adapter live smoke on the same head.
- Exact steps after the patch: defer the first `talk.client.create`, Start,
  Stop, Start, allow the replacement relay to become ready, resolve the stale
  allocation, send microphone audio through the replacement, then Stop.
- Evidence after fix:
  https://github.com/openclaw/openclaw/actions/runs/30617812266 and the verdict
  below.
- Observed result after fix: exactly one stale close occurred before the final
  stop; replacement audio was appended only to the current relay; the final
  stop closed the current relay.
- What was not tested: Google Live, because no Google API key was available.

```json
{
  "scenario": "control-ui-talk-delayed-allocation-stop-restart",
  "head": "85b4a4a612632add0b0a88ba344047051346d61e",
  "result": "pass",
  "environment": {
    "runner": "blacksmith-testbox",
    "browser": "chromium",
    "surface": "real Control UI page",
    "gateway": "controlled deterministic Gateway"
  },
  "observed": {
    "createRequests": 2,
    "staleRelayCloseCountBeforeFinalStop": 1,
    "staleRelayClosed": "relay-stale-e2e",
    "replacementRelayReady": "relay-current-e2e",
    "replacementAudioAppendedOnlyToCurrentRelay": true,
    "finalCloseOrder": ["relay-stale-e2e", "relay-current-e2e"]
  },
  "liveProviderCorroboration": {
    "openAIBackendConnected": true,
    "openAIAudioRoundtripCompleted": true,
    "openAIWebRtcConnected": true,
    "gatewayRelayAdapterPassed": true,
    "lateAudioBytes": 0
  }
}
```

The browser regression uses the controlled mock Gateway because the race
requires deterministic reverse completion order. It is not presented as a
live-provider race test. No screenshot is included because there is no visual
UI change.
