### PR TITLE
feat(snapshot): compose RFC 0013 recovery points

### DIFF
--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -381,6 +381,9 @@ const config = {
     // Declaration companions describe executable JavaScript modules; they are not standalone roots.
     "scripts/**/*.d.{mts,ts}",
     "**/live-*.ts",
+    // PR 112385 proves this private RFC slice before its hidden production
+    // caller lands in the next stacked PR.
+    "src/snapshot/recovery-point.ts",
     "src/shared/text/assistant-visible-text.ts",
     bundledPluginFile("telegram", "src/bot/reply-threading.ts"),
     bundledPluginFile("telegram", "src/draft-chunking.ts"),

--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -436,9 +436,6 @@ const config = {
     // asserted by the focused Beam mirror tests; production wires only the service.
     "extensions/beam/src/mirror.ts": ["exports", "types"],
     "src/infra/heartbeat-wake.ts": ["exports"],
-    // Private RFC 0013 recovery helpers are direct unit-test contracts until
-    // their hidden host-facing caller lands in the next stacked slice.
-    "src/snapshot/recovery-point.ts": ["exports"],
   },
   workspaces: {
     ".": {

--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -433,6 +433,9 @@ const config = {
     // asserted by the focused Beam mirror tests; production wires only the service.
     "extensions/beam/src/mirror.ts": ["exports", "types"],
     "src/infra/heartbeat-wake.ts": ["exports"],
+    // Private RFC 0013 recovery helpers are direct unit-test contracts until
+    // their hidden host-facing caller lands in the next stacked slice.
+    "src/snapshot/recovery-point.ts": ["exports"],
   },
   workspaces: {
     ".": {

--- a/src/snapshot/recovery-point.test.ts
+++ b/src/snapshot/recovery-point.test.ts
@@ -9,6 +9,8 @@ import {
   createRecoveryPointManifest,
   verifyRecoveryPoint,
   verifyRecoveryPointManifest,
+  type RecoveryPointAcceptance,
+  type RecoveryPointManifest,
   type RecoveryPointSqliteSnapshot,
 } from "./recovery-point.js";
 import type { SnapshotManifest, SnapshotRef, SqliteSnapshotProvider } from "./snapshot-provider.js";
@@ -50,7 +52,7 @@ describe("recovery point composition", () => {
       ],
     } as const;
 
-    const first = await createRecoveryPointManifest({
+    const first: RecoveryPointManifest = await createRecoveryPointManifest({
       snapshots: [agent.snapshot, global.snapshot],
       expectedAgentIds: ["main"],
       obligations,
@@ -76,7 +78,8 @@ describe("recovery point composition", () => {
     ]);
     expect(first.obligations.external).toEqual(obligations.external);
     expect(first.components.every((component) => component.ownerManifestSizeBytes > 0)).toBe(true);
-    expect(createRecoveryPointAcceptance(first)).toEqual(createRecoveryPointAcceptance(second));
+    const firstAcceptance: RecoveryPointAcceptance = createRecoveryPointAcceptance(first);
+    expect(firstAcceptance).toEqual(createRecoveryPointAcceptance(second));
     expect(global.verify).toHaveBeenCalledTimes(4);
     expect(agent.verify).toHaveBeenCalledTimes(4);
   });

--- a/src/snapshot/recovery-point.test.ts
+++ b/src/snapshot/recovery-point.test.ts
@@ -1,0 +1,263 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, type Mock, vi } from "vitest";
+import { stableStringify } from "../agents/stable-stringify.js";
+import {
+  createRecoveryPointManifest,
+  verifyRecoveryPoint,
+  verifyRecoveryPointManifest,
+  type RecoveryPointSqliteSnapshot,
+} from "./recovery-point.js";
+import type { SnapshotManifest, SnapshotRef, SqliteSnapshotProvider } from "./snapshot-provider.js";
+
+const tempRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((entry) => fs.rm(entry, { force: true, recursive: true })),
+  );
+});
+
+describe("recovery point composition", () => {
+  it("composes verified global and agent snapshots into one deterministic identity", async () => {
+    const global = await createSnapshotFixture({ role: "global", userVersion: 7, byte: "a" });
+    const agent = await createSnapshotFixture({
+      role: "agent",
+      agentId: "main",
+      userVersion: 11,
+      byte: "b",
+    });
+    const now = () => new Date("2026-07-21T16:00:00.000Z");
+    const obligations = {
+      external: [{ id: "secret/provider-api-key", owner: "secrets", readinessRequired: true }],
+      reconstructed: [{ id: "plugin/optional-source", owner: "plugins", readinessRequired: false }],
+    } as const;
+
+    const first = await createRecoveryPointManifest({
+      snapshots: [agent.snapshot, global.snapshot],
+      obligations,
+      now,
+    });
+    const second = await createRecoveryPointManifest({
+      snapshots: [global.snapshot, agent.snapshot],
+      obligations,
+      now,
+    });
+
+    expect(first).toEqual(second);
+    expect(first.recoveryPointId).toMatch(/^[a-f0-9]{64}$/u);
+    expect(first.components.map((component) => component.id)).toEqual([
+      "sqlite/global",
+      "sqlite/agent/main",
+    ]);
+    expect(first.obligations.external).toEqual(obligations.external);
+    expect(global.verify).toHaveBeenCalledTimes(4);
+    expect(agent.verify).toHaveBeenCalledTimes(4);
+  });
+
+  it("re-verifies every owner snapshot against the aggregate manifest", async () => {
+    const global = await createSnapshotFixture({ role: "global", userVersion: 7, byte: "a" });
+    const agent = await createSnapshotFixture({
+      role: "agent",
+      agentId: "main",
+      userVersion: 11,
+      byte: "b",
+    });
+    const manifest = await createRecoveryPointManifest({
+      snapshots: [global.snapshot, agent.snapshot],
+      now: () => new Date("2026-07-21T16:00:00.000Z"),
+    });
+
+    await expect(
+      verifyRecoveryPoint({ manifest, snapshots: [agent.snapshot, global.snapshot] }),
+    ).resolves.toEqual(manifest);
+
+    const mismatched = structuredClone(manifest);
+    mismatched.components[1]!.artifactSha256 = "c".repeat(64);
+    mismatched.recoveryPointId = recomputeIdentity(mismatched);
+    await expect(
+      verifyRecoveryPoint({ manifest: mismatched, snapshots: [global.snapshot, agent.snapshot] }),
+    ).rejects.toThrow("do not match the verified owner snapshots");
+  });
+
+  it("rejects reordered, duplicate, unknown, and secret-shaped metadata", async () => {
+    const global = await createSnapshotFixture({ role: "global", userVersion: 7, byte: "a" });
+    const agent = await createSnapshotFixture({
+      role: "agent",
+      agentId: "main",
+      userVersion: 11,
+      byte: "b",
+    });
+    const manifest = await createRecoveryPointManifest({
+      snapshots: [global.snapshot, agent.snapshot],
+      obligations: {
+        external: [
+          { id: "secret/z", owner: "secrets", readinessRequired: true },
+          { id: "secret/a", owner: "secrets", readinessRequired: true },
+        ],
+      },
+      now: () => new Date("2026-07-21T16:00:00.000Z"),
+    });
+
+    const reordered = structuredClone(manifest);
+    reordered.components.reverse();
+    reordered.recoveryPointId = recomputeIdentity(reordered);
+    expect(() => verifyRecoveryPointManifest(reordered)).toThrow("canonical order");
+
+    const reorderedObligations = structuredClone(manifest);
+    reorderedObligations.obligations.external.reverse();
+    reorderedObligations.recoveryPointId = recomputeIdentity(reorderedObligations);
+    expect(() => verifyRecoveryPointManifest(reorderedObligations)).toThrow(
+      "obligations are not in canonical order",
+    );
+
+    const invalidAgent = structuredClone(manifest);
+    const agentComponent = invalidAgent.components[1];
+    if (agentComponent?.kind !== "sqlite-agent") {
+      throw new Error("expected agent component fixture");
+    }
+    agentComponent.agentId = "foo/bar";
+    agentComponent.id = "sqlite/agent/foo/bar";
+    invalidAgent.recoveryPointId = recomputeIdentity(invalidAgent);
+    expect(() => verifyRecoveryPointManifest(invalidAgent)).toThrow("agent id is invalid");
+
+    const duplicate = structuredClone(manifest);
+    duplicate.components.push(structuredClone(duplicate.components[1]!));
+    duplicate.recoveryPointId = recomputeIdentity(duplicate);
+    expect(() => verifyRecoveryPointManifest(duplicate)).toThrow("duplicate component id");
+
+    const unknown = structuredClone(manifest) as unknown as {
+      components: Array<Record<string, unknown>>;
+    };
+    unknown.components[0]!.kind = "workspace";
+    expect(() => verifyRecoveryPointManifest(unknown)).toThrow("manifest is invalid");
+
+    const secretShaped = structuredClone(manifest) as unknown as {
+      obligations: { external: Array<Record<string, unknown>> };
+    };
+    secretShaped.obligations.external.push({
+      id: "secret/provider-api-key",
+      owner: "secrets",
+      readinessRequired: true,
+      value: "must-not-appear",
+    });
+    expect(() => verifyRecoveryPointManifest(secretShaped)).toThrow("manifest is invalid");
+  });
+
+  it("rejects owner manifest byte rewrites during composition", async () => {
+    const global = await createSnapshotFixture({ role: "global", userVersion: 7, byte: "a" });
+    const agent = await createSnapshotFixture({
+      role: "agent",
+      agentId: "main",
+      userVersion: 11,
+      byte: "b",
+    });
+    global.verify.mockImplementationOnce(async () => ({
+      ok: true as const,
+      manifest: global.manifest,
+    }));
+    global.verify.mockImplementationOnce(async () => {
+      await fs.writeFile(
+        path.join(global.snapshot.ref.path, "manifest.json"),
+        JSON.stringify(global.manifest),
+        { mode: 0o600 },
+      );
+      return { ok: true as const, manifest: global.manifest };
+    });
+
+    await expect(
+      createRecoveryPointManifest({ snapshots: [global.snapshot, agent.snapshot] }),
+    ).rejects.toThrow("changed during recovery-point composition");
+  });
+
+  it("rejects generic snapshots and incomplete SQLite inventories", async () => {
+    const generic = await createSnapshotFixture({
+      role: "generic",
+      id: "custom",
+      userVersion: 1,
+      byte: "a",
+    });
+    await expect(createRecoveryPointManifest({ snapshots: [generic.snapshot] })).rejects.toThrow(
+      "Generic SQLite snapshots are not eligible",
+    );
+
+    const global = await createSnapshotFixture({ role: "global", userVersion: 7, byte: "b" });
+    await expect(createRecoveryPointManifest({ snapshots: [global.snapshot] })).rejects.toThrow(
+      "at least one agent",
+    );
+  });
+});
+
+type SnapshotFixtureOptions =
+  | { role: "global"; userVersion: number; byte: string }
+  | { role: "agent"; agentId: string; userVersion: number; byte: string }
+  | { role: "generic"; id: string; userVersion: number; byte: string };
+
+async function createSnapshotFixture(options: SnapshotFixtureOptions): Promise<{
+  snapshot: RecoveryPointSqliteSnapshot;
+  manifest: SnapshotManifest;
+  verify: Mock<SqliteSnapshotProvider["verify"]>;
+}> {
+  const rootPath = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-recovery-point-"));
+  tempRoots.push(rootPath);
+  const snapshotPath = path.join(rootPath, "snapshot-1");
+  await fs.mkdir(snapshotPath, { mode: 0o700 });
+  const database =
+    options.role === "global"
+      ? { role: "global" as const, basename: "state.sqlite", userVersion: options.userVersion }
+      : options.role === "agent"
+        ? {
+            role: "agent" as const,
+            agentId: options.agentId,
+            basename: "agent.sqlite",
+            userVersion: options.userVersion,
+          }
+        : {
+            role: "generic" as const,
+            id: options.id,
+            basename: "custom.sqlite",
+            userVersion: options.userVersion,
+          };
+  const manifest: SnapshotManifest = {
+    schemaVersion: 1,
+    snapshotId: "snapshot-1",
+    createdAt: "2026-07-21T15:00:00.000Z",
+    database,
+    artifact: {
+      path: "database.sqlite",
+      sha256: options.byte.repeat(64),
+      sizeBytes: 1024,
+    },
+  };
+  await fs.writeFile(
+    path.join(snapshotPath, "manifest.json"),
+    `${JSON.stringify(manifest, null, 2)}\n`,
+    {
+      mode: 0o600,
+    },
+  );
+  const verify = vi.fn<SqliteSnapshotProvider["verify"]>(async () => ({
+    ok: true as const,
+    manifest,
+  }));
+  const unsupported = async (): Promise<never> => {
+    throw new Error("unsupported in recovery-point fixture");
+  };
+  const provider: SqliteSnapshotProvider = {
+    create: unsupported,
+    list: async () => [],
+    restoreFresh: unsupported,
+    verify,
+  };
+  const ref: SnapshotRef = { path: snapshotPath };
+  return { snapshot: { provider, ref }, manifest, verify };
+}
+
+function recomputeIdentity(
+  manifest: { recoveryPointId: string } & Record<string, unknown>,
+): string {
+  const { recoveryPointId: _recoveryPointId, ...withoutId } = manifest;
+  return createHash("sha256").update(stableStringify(withoutId)).digest("hex");
+}

--- a/src/snapshot/recovery-point.test.ts
+++ b/src/snapshot/recovery-point.test.ts
@@ -268,6 +268,33 @@ describe("recovery point composition", () => {
     ).rejects.toThrow("does not match the state owner's expected agents");
   });
 
+  it("rejects non-canonical dependency ordering", async () => {
+    const global = await createSnapshotFixture({ role: "global", userVersion: 7, byte: "a" });
+    const main = await createSnapshotFixture({
+      role: "agent",
+      agentId: "main",
+      userVersion: 11,
+      byte: "b",
+    });
+    const research = await createSnapshotFixture({
+      role: "agent",
+      agentId: "research",
+      userVersion: 12,
+      byte: "c",
+    });
+    const manifest = await createRecoveryPointManifest({
+      snapshots: [global.snapshot, main.snapshot, research.snapshot],
+      expectedAgentIds: ["main", "research"],
+      now: () => new Date("2026-07-21T16:00:00.000Z"),
+    });
+    manifest.components[2]!.dependsOn = ["sqlite/global", "sqlite/agent/main"];
+    manifest.recoveryPointId = recomputeIdentity(manifest);
+
+    expect(() => verifyRecoveryPointManifest(manifest)).toThrow(
+      "dependencies are not in canonical order",
+    );
+  });
+
   it("rejects unsupported obligation treatment, kind, and owner combinations", async () => {
     const global = await createSnapshotFixture({ role: "global", userVersion: 7, byte: "a" });
     const agent = await createSnapshotFixture({

--- a/src/snapshot/recovery-point.test.ts
+++ b/src/snapshot/recovery-point.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it, type Mock, vi } from "vitest";
 import { stableStringify } from "../agents/stable-stringify.js";
 import {
+  createRecoveryPointAcceptance,
   createRecoveryPointManifest,
   verifyRecoveryPoint,
   verifyRecoveryPointManifest,
@@ -31,28 +32,51 @@ describe("recovery point composition", () => {
     });
     const now = () => new Date("2026-07-21T16:00:00.000Z");
     const obligations = {
-      external: [{ id: "secret/provider-api-key", owner: "secrets", readinessRequired: true }],
-      reconstructed: [{ id: "plugin/optional-source", owner: "plugins", readinessRequired: false }],
+      external: [
+        {
+          id: "secret/provider-api-key",
+          kind: "secret-ref",
+          owner: "secrets",
+          readinessRequired: true,
+        },
+      ],
+      reconstructed: [
+        {
+          id: "plugin/optional-source",
+          kind: "plugin-dependency",
+          owner: "plugins",
+          readinessRequired: false,
+        },
+      ],
     } as const;
 
     const first = await createRecoveryPointManifest({
       snapshots: [agent.snapshot, global.snapshot],
+      expectedAgentIds: ["main"],
       obligations,
       now,
     });
     const second = await createRecoveryPointManifest({
       snapshots: [global.snapshot, agent.snapshot],
+      expectedAgentIds: ["main"],
       obligations,
       now,
     });
 
     expect(first).toEqual(second);
     expect(first.recoveryPointId).toMatch(/^[a-f0-9]{64}$/u);
+    expect(first.inventory).toEqual({
+      version: "openclaw-runtime-sqlite-inventory/v1",
+      requiredComponentIds: ["sqlite/global", "sqlite/agent/main"],
+    });
+    expect(first.protection).toEqual({ mode: "host-protected" });
     expect(first.components.map((component) => component.id)).toEqual([
       "sqlite/global",
       "sqlite/agent/main",
     ]);
     expect(first.obligations.external).toEqual(obligations.external);
+    expect(first.components.every((component) => component.ownerManifestSizeBytes > 0)).toBe(true);
+    expect(createRecoveryPointAcceptance(first)).toEqual(createRecoveryPointAcceptance(second));
     expect(global.verify).toHaveBeenCalledTimes(4);
     expect(agent.verify).toHaveBeenCalledTimes(4);
   });
@@ -67,18 +91,27 @@ describe("recovery point composition", () => {
     });
     const manifest = await createRecoveryPointManifest({
       snapshots: [global.snapshot, agent.snapshot],
+      expectedAgentIds: ["main"],
       now: () => new Date("2026-07-21T16:00:00.000Z"),
     });
 
     await expect(
-      verifyRecoveryPoint({ manifest, snapshots: [agent.snapshot, global.snapshot] }),
-    ).resolves.toEqual(manifest);
+      verifyRecoveryPoint({
+        manifest,
+        snapshots: [agent.snapshot, global.snapshot],
+        expectedAgentIds: ["main"],
+      }),
+    ).resolves.toEqual({ manifest, acceptance: createRecoveryPointAcceptance(manifest) });
 
     const mismatched = structuredClone(manifest);
     mismatched.components[1]!.artifactSha256 = "c".repeat(64);
     mismatched.recoveryPointId = recomputeIdentity(mismatched);
     await expect(
-      verifyRecoveryPoint({ manifest: mismatched, snapshots: [global.snapshot, agent.snapshot] }),
+      verifyRecoveryPoint({
+        manifest: mismatched,
+        snapshots: [global.snapshot, agent.snapshot],
+        expectedAgentIds: ["main"],
+      }),
     ).rejects.toThrow("do not match the verified owner snapshots");
   });
 
@@ -92,10 +125,11 @@ describe("recovery point composition", () => {
     });
     const manifest = await createRecoveryPointManifest({
       snapshots: [global.snapshot, agent.snapshot],
+      expectedAgentIds: ["main"],
       obligations: {
         external: [
-          { id: "secret/z", owner: "secrets", readinessRequired: true },
-          { id: "secret/a", owner: "secrets", readinessRequired: true },
+          { id: "secret/z", kind: "secret-ref", owner: "secrets", readinessRequired: true },
+          { id: "secret/a", kind: "secret-ref", owner: "secrets", readinessRequired: true },
         ],
       },
       now: () => new Date("2026-07-21T16:00:00.000Z"),
@@ -139,6 +173,7 @@ describe("recovery point composition", () => {
     };
     secretShaped.obligations.external.push({
       id: "secret/provider-api-key",
+      kind: "secret-ref",
       owner: "secrets",
       readinessRequired: true,
       value: "must-not-appear",
@@ -168,7 +203,10 @@ describe("recovery point composition", () => {
     });
 
     await expect(
-      createRecoveryPointManifest({ snapshots: [global.snapshot, agent.snapshot] }),
+      createRecoveryPointManifest({
+        snapshots: [global.snapshot, agent.snapshot],
+        expectedAgentIds: ["main"],
+      }),
     ).rejects.toThrow("changed during recovery-point composition");
   });
 
@@ -179,14 +217,81 @@ describe("recovery point composition", () => {
       userVersion: 1,
       byte: "a",
     });
-    await expect(createRecoveryPointManifest({ snapshots: [generic.snapshot] })).rejects.toThrow(
-      "Generic SQLite snapshots are not eligible",
-    );
+    await expect(
+      createRecoveryPointManifest({ snapshots: [generic.snapshot], expectedAgentIds: ["main"] }),
+    ).rejects.toThrow("Generic SQLite snapshots are not eligible");
 
     const global = await createSnapshotFixture({ role: "global", userVersion: 7, byte: "b" });
-    await expect(createRecoveryPointManifest({ snapshots: [global.snapshot] })).rejects.toThrow(
-      "at least one agent",
-    );
+    await expect(
+      createRecoveryPointManifest({ snapshots: [global.snapshot], expectedAgentIds: ["main"] }),
+    ).rejects.toThrow("do not match the required inventory");
+  });
+
+  it("rejects incomplete, extra, and self-consistent but owner-mismatched inventories", async () => {
+    const global = await createSnapshotFixture({ role: "global", userVersion: 7, byte: "a" });
+    const main = await createSnapshotFixture({
+      role: "agent",
+      agentId: "main",
+      userVersion: 11,
+      byte: "b",
+    });
+    const research = await createSnapshotFixture({
+      role: "agent",
+      agentId: "research",
+      userVersion: 12,
+      byte: "c",
+    });
+
+    await expect(
+      createRecoveryPointManifest({
+        snapshots: [global.snapshot, main.snapshot],
+        expectedAgentIds: ["main", "research"],
+      }),
+    ).rejects.toThrow("do not match the required inventory");
+    await expect(
+      createRecoveryPointManifest({
+        snapshots: [global.snapshot, main.snapshot, research.snapshot],
+        expectedAgentIds: ["main"],
+      }),
+    ).rejects.toThrow("do not match the required inventory");
+
+    const manifest = await createRecoveryPointManifest({
+      snapshots: [global.snapshot, main.snapshot],
+      expectedAgentIds: ["main"],
+    });
+    await expect(
+      verifyRecoveryPoint({
+        manifest,
+        snapshots: [global.snapshot, main.snapshot],
+        expectedAgentIds: ["main", "research"],
+      }),
+    ).rejects.toThrow("does not match the state owner's expected agents");
+  });
+
+  it("rejects unsupported obligation treatment, kind, and owner combinations", async () => {
+    const global = await createSnapshotFixture({ role: "global", userVersion: 7, byte: "a" });
+    const agent = await createSnapshotFixture({
+      role: "agent",
+      agentId: "main",
+      userVersion: 11,
+      byte: "b",
+    });
+    await expect(
+      createRecoveryPointManifest({
+        snapshots: [global.snapshot, agent.snapshot],
+        expectedAgentIds: ["main"],
+        obligations: {
+          reconstructed: [
+            {
+              id: "secret/provider-api-key",
+              kind: "secret-ref",
+              owner: "secrets",
+              readinessRequired: true,
+            },
+          ],
+        },
+      }),
+    ).rejects.toThrow("unsupported treatment, kind, or owner");
   });
 });
 

--- a/src/snapshot/recovery-point.test.ts
+++ b/src/snapshot/recovery-point.test.ts
@@ -9,6 +9,7 @@ import {
   createRecoveryPointManifest,
   verifyRecoveryPoint,
   verifyRecoveryPointManifest,
+  verifyRecoveryPointOwnerInventory,
   type RecoveryPointAcceptance,
   type RecoveryPointManifest,
   type RecoveryPointOwnerInventory,
@@ -256,6 +257,13 @@ describe("recovery point composition", () => {
         } as unknown as RecoveryPointOwnerInventory,
       }),
     ).rejects.toThrow();
+
+    expect(() =>
+      verifyRecoveryPointOwnerInventory(stateOwnerInventory(["research", "main"])),
+    ).toThrow("canonical order");
+    expect(() => verifyRecoveryPointOwnerInventory(stateOwnerInventory(["../../outside"]))).toThrow(
+      "expected agent id is invalid",
+    );
   });
 
   it("rejects incomplete, extra, and self-consistent but owner-mismatched inventories", async () => {

--- a/src/snapshot/recovery-point.test.ts
+++ b/src/snapshot/recovery-point.test.ts
@@ -11,6 +11,7 @@ import {
   verifyRecoveryPointManifest,
   type RecoveryPointAcceptance,
   type RecoveryPointManifest,
+  type RecoveryPointOwnerInventory,
   type RecoveryPointSqliteSnapshot,
 } from "./recovery-point.js";
 import type { SnapshotManifest, SnapshotRef, SqliteSnapshotProvider } from "./snapshot-provider.js";
@@ -54,21 +55,32 @@ describe("recovery point composition", () => {
 
     const first: RecoveryPointManifest = await createRecoveryPointManifest({
       snapshots: [agent.snapshot, global.snapshot],
-      expectedAgentIds: ["main"],
+      ownerInventory: stateOwnerInventory(["main"]),
       obligations,
       now,
     });
     const second = await createRecoveryPointManifest({
       snapshots: [global.snapshot, agent.snapshot],
-      expectedAgentIds: ["main"],
+      ownerInventory: stateOwnerInventory(["main"]),
+      obligations,
+      now,
+    });
+
+    const revised = await createRecoveryPointManifest({
+      snapshots: [global.snapshot, agent.snapshot],
+      ownerInventory: stateOwnerInventory(["main"], { revision: "inventory-revision-2" }),
       obligations,
       now,
     });
 
     expect(first).toEqual(second);
+    expect(revised.recoveryPointId).not.toBe(first.recoveryPointId);
     expect(first.recoveryPointId).toMatch(/^[a-f0-9]{64}$/u);
     expect(first.inventory).toEqual({
       version: "openclaw-runtime-sqlite-inventory/v1",
+      owner: "openclaw-state",
+      sourceRuntimeGeneration: "runtime-generation-1",
+      revision: "inventory-revision-1",
       requiredComponentIds: ["sqlite/global", "sqlite/agent/main"],
     });
     expect(first.protection).toEqual({ mode: "host-protected" });
@@ -80,8 +92,8 @@ describe("recovery point composition", () => {
     expect(first.components.every((component) => component.ownerManifestSizeBytes > 0)).toBe(true);
     const firstAcceptance: RecoveryPointAcceptance = createRecoveryPointAcceptance(first);
     expect(firstAcceptance).toEqual(createRecoveryPointAcceptance(second));
-    expect(global.verify).toHaveBeenCalledTimes(4);
-    expect(agent.verify).toHaveBeenCalledTimes(4);
+    expect(global.verify).toHaveBeenCalledTimes(6);
+    expect(agent.verify).toHaveBeenCalledTimes(6);
   });
 
   it("re-verifies every owner snapshot against the aggregate manifest", async () => {
@@ -94,7 +106,7 @@ describe("recovery point composition", () => {
     });
     const manifest = await createRecoveryPointManifest({
       snapshots: [global.snapshot, agent.snapshot],
-      expectedAgentIds: ["main"],
+      ownerInventory: stateOwnerInventory(["main"]),
       now: () => new Date("2026-07-21T16:00:00.000Z"),
     });
 
@@ -102,7 +114,7 @@ describe("recovery point composition", () => {
       verifyRecoveryPoint({
         manifest,
         snapshots: [agent.snapshot, global.snapshot],
-        expectedAgentIds: ["main"],
+        ownerInventory: stateOwnerInventory(["main"]),
       }),
     ).resolves.toEqual({ manifest, acceptance: createRecoveryPointAcceptance(manifest) });
 
@@ -113,7 +125,7 @@ describe("recovery point composition", () => {
       verifyRecoveryPoint({
         manifest: mismatched,
         snapshots: [global.snapshot, agent.snapshot],
-        expectedAgentIds: ["main"],
+        ownerInventory: stateOwnerInventory(["main"]),
       }),
     ).rejects.toThrow("do not match the verified owner snapshots");
   });
@@ -128,7 +140,7 @@ describe("recovery point composition", () => {
     });
     const manifest = await createRecoveryPointManifest({
       snapshots: [global.snapshot, agent.snapshot],
-      expectedAgentIds: ["main"],
+      ownerInventory: stateOwnerInventory(["main"]),
       obligations: {
         external: [
           { id: "secret/z", kind: "secret-ref", owner: "secrets", readinessRequired: true },
@@ -208,7 +220,7 @@ describe("recovery point composition", () => {
     await expect(
       createRecoveryPointManifest({
         snapshots: [global.snapshot, agent.snapshot],
-        expectedAgentIds: ["main"],
+        ownerInventory: stateOwnerInventory(["main"]),
       }),
     ).rejects.toThrow("changed during recovery-point composition");
   });
@@ -221,13 +233,29 @@ describe("recovery point composition", () => {
       byte: "a",
     });
     await expect(
-      createRecoveryPointManifest({ snapshots: [generic.snapshot], expectedAgentIds: ["main"] }),
+      createRecoveryPointManifest({
+        snapshots: [generic.snapshot],
+        ownerInventory: stateOwnerInventory(["main"]),
+      }),
     ).rejects.toThrow("Generic SQLite snapshots are not eligible");
 
     const global = await createSnapshotFixture({ role: "global", userVersion: 7, byte: "b" });
     await expect(
-      createRecoveryPointManifest({ snapshots: [global.snapshot], expectedAgentIds: ["main"] }),
+      createRecoveryPointManifest({
+        snapshots: [global.snapshot],
+        ownerInventory: stateOwnerInventory(["main"]),
+      }),
     ).rejects.toThrow("do not match the required inventory");
+
+    await expect(
+      createRecoveryPointManifest({
+        snapshots: [global.snapshot],
+        ownerInventory: {
+          ...stateOwnerInventory(["main"]),
+          owner: "host",
+        } as unknown as RecoveryPointOwnerInventory,
+      }),
+    ).rejects.toThrow();
   });
 
   it("rejects incomplete, extra, and self-consistent but owner-mismatched inventories", async () => {
@@ -248,27 +276,35 @@ describe("recovery point composition", () => {
     await expect(
       createRecoveryPointManifest({
         snapshots: [global.snapshot, main.snapshot],
-        expectedAgentIds: ["main", "research"],
+        ownerInventory: stateOwnerInventory(["main", "research"]),
       }),
     ).rejects.toThrow("do not match the required inventory");
     await expect(
       createRecoveryPointManifest({
         snapshots: [global.snapshot, main.snapshot, research.snapshot],
-        expectedAgentIds: ["main"],
+        ownerInventory: stateOwnerInventory(["main"]),
       }),
     ).rejects.toThrow("do not match the required inventory");
 
     const manifest = await createRecoveryPointManifest({
       snapshots: [global.snapshot, main.snapshot],
-      expectedAgentIds: ["main"],
+      ownerInventory: stateOwnerInventory(["main"]),
     });
     await expect(
       verifyRecoveryPoint({
         manifest,
         snapshots: [global.snapshot, main.snapshot],
-        expectedAgentIds: ["main", "research"],
+        ownerInventory: stateOwnerInventory(["main", "research"]),
       }),
-    ).rejects.toThrow("does not match the state owner's expected agents");
+    ).rejects.toThrow("does not match the state owner's inventory receipt");
+
+    await expect(
+      verifyRecoveryPoint({
+        manifest,
+        snapshots: [global.snapshot, main.snapshot],
+        ownerInventory: stateOwnerInventory(["main"], { revision: "inventory-revision-2" }),
+      }),
+    ).rejects.toThrow("does not match the state owner's inventory receipt");
   });
 
   it("rejects non-canonical dependency ordering", async () => {
@@ -287,7 +323,7 @@ describe("recovery point composition", () => {
     });
     const manifest = await createRecoveryPointManifest({
       snapshots: [global.snapshot, main.snapshot, research.snapshot],
-      expectedAgentIds: ["main", "research"],
+      ownerInventory: stateOwnerInventory(["main", "research"]),
       now: () => new Date("2026-07-21T16:00:00.000Z"),
     });
     manifest.components[2]!.dependsOn = ["sqlite/global", "sqlite/agent/main"];
@@ -309,7 +345,7 @@ describe("recovery point composition", () => {
     await expect(
       createRecoveryPointManifest({
         snapshots: [global.snapshot, agent.snapshot],
-        expectedAgentIds: ["main"],
+        ownerInventory: stateOwnerInventory(["main"]),
         obligations: {
           reconstructed: [
             {
@@ -324,6 +360,19 @@ describe("recovery point composition", () => {
     ).rejects.toThrow("unsupported treatment, kind, or owner");
   });
 });
+
+function stateOwnerInventory(
+  agentIds: string[],
+  overrides: { sourceRuntimeGeneration?: string; revision?: string } = {},
+): RecoveryPointOwnerInventory {
+  return {
+    version: "openclaw-runtime-sqlite-inventory/v1",
+    owner: "openclaw-state",
+    sourceRuntimeGeneration: overrides.sourceRuntimeGeneration ?? "runtime-generation-1",
+    revision: overrides.revision ?? "inventory-revision-1",
+    agentIds,
+  };
+}
 
 type SnapshotFixtureOptions =
   | { role: "global"; userVersion: number; byte: string }

--- a/src/snapshot/recovery-point.test.ts
+++ b/src/snapshot/recovery-point.test.ts
@@ -2,8 +2,8 @@ import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { stableStringify } from "@openclaw/normalization-core/stable-stringify";
 import { afterEach, describe, expect, it, type Mock, vi } from "vitest";
-import { stableStringify } from "../agents/stable-stringify.js";
 import {
   createRecoveryPointAcceptance,
   createRecoveryPointManifest,
@@ -12,12 +12,15 @@ import {
   verifyRecoveryPointOwnerInventory,
   type RecoveryPointAcceptance,
   type RecoveryPointManifest,
-  type RecoveryPointOwnerInventory,
   type RecoveryPointSqliteSnapshot,
 } from "./recovery-point.js";
 import type { SnapshotManifest, SnapshotRef, SqliteSnapshotProvider } from "./snapshot-provider.js";
 
 const tempRoots: string[] = [];
+
+type RecoveryPointOwnerInventory = Parameters<
+  typeof createRecoveryPointManifest
+>[0]["ownerInventory"];
 
 afterEach(async () => {
   await Promise.all(

--- a/src/snapshot/recovery-point.test.ts
+++ b/src/snapshot/recovery-point.test.ts
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { stableStringify } from "@openclaw/normalization-core/stable-stringify";
+import { stableStringify } from "@openclaw/normalization-core";
 import { afterEach, describe, expect, it, type Mock, vi } from "vitest";
 import {
   createRecoveryPointAcceptance,

--- a/src/snapshot/recovery-point.ts
+++ b/src/snapshot/recovery-point.ts
@@ -396,6 +396,11 @@ function assertCanonicalComponentOrder(components: readonly RecoveryPointCompone
 function assertDependencies(components: readonly RecoveryPointComponent[]): void {
   const byId = new Map(components.map((component) => [component.id, component]));
   for (const component of components) {
+    if (!isDeepStrictEqual(component.dependsOn, component.dependsOn.toSorted(compareCodeUnits))) {
+      throw new Error(
+        `Recovery point component ${component.id} dependencies are not in canonical order.`,
+      );
+    }
     const dependencies = new Set<string>();
     for (const dependency of component.dependsOn) {
       if (!byId.has(dependency)) {

--- a/src/snapshot/recovery-point.ts
+++ b/src/snapshot/recovery-point.ts
@@ -243,6 +243,7 @@ async function buildVerifiedComponent(
   if (
     !isDeepStrictEqual(firstVerification.manifest, secondVerification.manifest) ||
     !isDeepStrictEqual(firstManifestRead.parsed, secondVerification.manifest) ||
+    !isDeepStrictEqual(secondManifestRead.parsed, secondVerification.manifest) ||
     firstManifestRead.sha256 !== secondManifestRead.sha256
   ) {
     throw new Error(

--- a/src/snapshot/recovery-point.ts
+++ b/src/snapshot/recovery-point.ts
@@ -11,8 +11,8 @@ import {
   type SqliteSnapshotProvider,
 } from "./snapshot-provider.js";
 
-export const RECOVERY_POINT_VERSION = "openclaw-recovery-point/v1";
-export const RECOVERY_POINT_ACCEPTANCE_VERSION = "openclaw-recovery-point-acceptance/v1";
+const RECOVERY_POINT_VERSION = "openclaw-recovery-point/v1";
+const RECOVERY_POINT_ACCEPTANCE_VERSION = "openclaw-recovery-point-acceptance/v1";
 
 const RECOVERY_POINT_INVENTORY_VERSION = "openclaw-runtime-sqlite-inventory/v1";
 
@@ -104,8 +104,8 @@ const recoveryPointAcceptanceSchema = z
   })
   .strict();
 
-export type RecoveryPointObligation = z.infer<typeof obligationSchema>;
-export type RecoveryPointComponent = z.infer<typeof recoveryPointComponentSchema>;
+type RecoveryPointObligation = z.infer<typeof obligationSchema>;
+type RecoveryPointComponent = z.infer<typeof recoveryPointComponentSchema>;
 export type RecoveryPointManifest = z.infer<typeof recoveryPointManifestSchema>;
 export type RecoveryPointAcceptance = z.infer<typeof recoveryPointAcceptanceSchema>;
 
@@ -114,7 +114,7 @@ export type RecoveryPointSqliteSnapshot = {
   readonly ref: SnapshotRef;
 };
 
-export type RecoveryPointObligations = {
+type RecoveryPointObligations = {
   readonly external?: readonly RecoveryPointObligation[];
   readonly reconstructed?: readonly RecoveryPointObligation[];
   readonly ephemeral?: readonly RecoveryPointObligation[];

--- a/src/snapshot/recovery-point.ts
+++ b/src/snapshot/recovery-point.ts
@@ -1,0 +1,368 @@
+import { isDeepStrictEqual } from "node:util";
+import { z } from "zod";
+import { stableStringify } from "../agents/stable-stringify.js";
+import { sha256Hex } from "../infra/crypto-digest.js";
+import { root } from "../infra/fs-safe.js";
+import { isValidAgentId, normalizeAgentId } from "../routing/session-key.js";
+import {
+  SNAPSHOT_MANIFEST_FILENAME,
+  type SnapshotManifest,
+  type SnapshotRef,
+  type SqliteSnapshotProvider,
+} from "./snapshot-provider.js";
+
+export const RECOVERY_POINT_VERSION = "openclaw-recovery-point/v1";
+
+const MAX_OWNER_MANIFEST_BYTES = 1024 * 1024;
+const SHA256_PATTERN = /^[a-f0-9]{64}$/u;
+const SAFE_ID_PATTERN = /^[a-z0-9][a-z0-9._/-]{0,254}$/u;
+
+const obligationSchema = z
+  .object({
+    id: z.string().regex(SAFE_ID_PATTERN),
+    owner: z.string().regex(SAFE_ID_PATTERN),
+    readinessRequired: z.boolean(),
+  })
+  .strict();
+
+const componentBaseSchema = {
+  id: z.string().regex(SAFE_ID_PATTERN),
+  artifactSha256: z.string().regex(SHA256_PATTERN),
+  artifactSizeBytes: z.number().int().positive().max(Number.MAX_SAFE_INTEGER),
+  ownerManifestSha256: z.string().regex(SHA256_PATTERN),
+  compatibility: z.string().regex(SAFE_ID_PATTERN),
+  dependsOn: z.array(z.string().regex(SAFE_ID_PATTERN)),
+  capturedAt: z.string(),
+  required: z.boolean(),
+};
+
+const recoveryPointComponentSchema = z.discriminatedUnion("kind", [
+  z
+    .object({
+      ...componentBaseSchema,
+      id: z.literal("sqlite/global"),
+      kind: z.literal("sqlite-global"),
+      owner: z.literal("openclaw-state"),
+    })
+    .strict(),
+  z
+    .object({
+      ...componentBaseSchema,
+      kind: z.literal("sqlite-agent"),
+      owner: z.literal("openclaw-agent-state"),
+      agentId: z.string().min(1).max(64),
+    })
+    .strict(),
+]);
+
+const recoveryPointManifestSchema = z
+  .object({
+    version: z.literal(RECOVERY_POINT_VERSION),
+    recoveryPointId: z.string().regex(SHA256_PATTERN),
+    createdAt: z.string(),
+    components: z.array(recoveryPointComponentSchema).min(1),
+    obligations: z
+      .object({
+        external: z.array(obligationSchema),
+        reconstructed: z.array(obligationSchema),
+        ephemeral: z.array(obligationSchema),
+      })
+      .strict(),
+  })
+  .strict();
+
+export type RecoveryPointObligation = z.infer<typeof obligationSchema>;
+export type RecoveryPointComponent = z.infer<typeof recoveryPointComponentSchema>;
+export type RecoveryPointManifest = z.infer<typeof recoveryPointManifestSchema>;
+
+export type RecoveryPointSqliteSnapshot = {
+  readonly provider: SqliteSnapshotProvider;
+  readonly ref: SnapshotRef;
+};
+
+export type RecoveryPointObligations = {
+  readonly external?: readonly RecoveryPointObligation[];
+  readonly reconstructed?: readonly RecoveryPointObligation[];
+  readonly ephemeral?: readonly RecoveryPointObligation[];
+};
+
+export async function createRecoveryPointManifest(params: {
+  snapshots: readonly RecoveryPointSqliteSnapshot[];
+  obligations?: RecoveryPointObligations;
+  now?: () => Date;
+}): Promise<RecoveryPointManifest> {
+  const now = (params.now ?? (() => new Date()))();
+  if (!Number.isFinite(now.getTime())) {
+    throw new Error("Recovery point timestamp is invalid.");
+  }
+
+  const components = await Promise.all(params.snapshots.map(buildVerifiedComponent));
+  components.sort(compareComponents);
+  assertRequiredSqliteInventory(components);
+
+  const manifestWithoutId = {
+    version: RECOVERY_POINT_VERSION,
+    createdAt: now.toISOString(),
+    components,
+    obligations: normalizeObligations(params.obligations),
+  };
+  return verifyRecoveryPointManifest({
+    ...manifestWithoutId,
+    recoveryPointId: digestRecoveryPoint(manifestWithoutId),
+  });
+}
+
+export function verifyRecoveryPointManifest(value: unknown): RecoveryPointManifest {
+  const parsed = recoveryPointManifestSchema.safeParse(value);
+  if (!parsed.success) {
+    throw new Error(`Recovery point manifest is invalid: ${parsed.error.message}`);
+  }
+  const manifest = parsed.data;
+  assertCanonicalTimestamp(manifest.createdAt, "createdAt");
+  for (const component of manifest.components) {
+    assertCanonicalTimestamp(component.capturedAt, `${component.id}.capturedAt`);
+    if (component.kind === "sqlite-agent") {
+      if (
+        !isValidAgentId(component.agentId) ||
+        normalizeAgentId(component.agentId) !== component.agentId
+      ) {
+        throw new Error(`Recovery point component agent id is invalid: ${component.agentId}.`);
+      }
+      if (component.id !== `sqlite/agent/${component.agentId}`) {
+        throw new Error(`Recovery point component id does not match agent ${component.agentId}.`);
+      }
+    }
+  }
+  assertCanonicalComponentOrder(manifest.components);
+  assertRequiredSqliteInventory(manifest.components);
+  assertDependencies(manifest.components);
+  assertCanonicalObligationOrder(manifest.obligations);
+  assertObligationIds(manifest.obligations);
+
+  const { recoveryPointId: _recoveryPointId, ...manifestWithoutId } = manifest;
+  const expectedId = digestRecoveryPoint(manifestWithoutId);
+  if (manifest.recoveryPointId !== expectedId) {
+    throw new Error(
+      `Recovery point identity mismatch: expected ${expectedId}, got ${manifest.recoveryPointId}.`,
+    );
+  }
+  return manifest;
+}
+
+export async function verifyRecoveryPoint(params: {
+  manifest: unknown;
+  snapshots: readonly RecoveryPointSqliteSnapshot[];
+}): Promise<RecoveryPointManifest> {
+  const manifest = verifyRecoveryPointManifest(params.manifest);
+  const actualComponents = await Promise.all(params.snapshots.map(buildVerifiedComponent));
+  actualComponents.sort(compareComponents);
+  if (!isDeepStrictEqual(actualComponents, manifest.components)) {
+    throw new Error("Recovery point SQLite components do not match the verified owner snapshots.");
+  }
+  return manifest;
+}
+
+async function buildVerifiedComponent(
+  snapshot: RecoveryPointSqliteSnapshot,
+): Promise<RecoveryPointComponent> {
+  const firstVerification = await snapshot.provider.verify(snapshot.ref);
+  const firstManifestRead = await readOwnerManifest(snapshot.ref);
+  const secondVerification = await snapshot.provider.verify(snapshot.ref);
+  const secondManifestRead = await readOwnerManifest(snapshot.ref);
+  if (
+    !isDeepStrictEqual(firstVerification.manifest, secondVerification.manifest) ||
+    !isDeepStrictEqual(firstManifestRead.parsed, secondVerification.manifest) ||
+    firstManifestRead.sha256 !== secondManifestRead.sha256
+  ) {
+    throw new Error(
+      `SQLite owner manifest changed during recovery-point composition: ${snapshot.ref.path}`,
+    );
+  }
+  return componentFromSnapshotManifest(secondVerification.manifest, secondManifestRead.sha256);
+}
+
+async function readOwnerManifest(ref: SnapshotRef): Promise<{ parsed: unknown; sha256: string }> {
+  const snapshotRoot = await root(ref.path);
+  const manifestRead = await snapshotRoot.read(SNAPSHOT_MANIFEST_FILENAME, {
+    hardlinks: "reject",
+    maxBytes: MAX_OWNER_MANIFEST_BYTES,
+    symlinks: "reject",
+  });
+  try {
+    return {
+      parsed: JSON.parse(manifestRead.buffer.toString("utf8")) as unknown,
+      sha256: sha256Hex(manifestRead.buffer),
+    };
+  } catch (error) {
+    throw new Error(`Verified SQLite owner manifest is not valid JSON: ${ref.path}`, {
+      cause: error,
+    });
+  }
+}
+
+function componentFromSnapshotManifest(
+  manifest: SnapshotManifest,
+  ownerManifestSha256: string,
+): RecoveryPointComponent {
+  const common = {
+    artifactSha256: manifest.artifact.sha256,
+    artifactSizeBytes: manifest.artifact.sizeBytes,
+    ownerManifestSha256,
+    dependsOn: [],
+    capturedAt: manifest.createdAt,
+    required: true,
+  };
+  if (manifest.database.role === "global") {
+    return recoveryPointComponentSchema.parse({
+      ...common,
+      id: "sqlite/global",
+      kind: "sqlite-global",
+      owner: "openclaw-state",
+      compatibility: `openclaw-state-schema/${manifest.database.userVersion}`,
+    });
+  }
+  if (manifest.database.role === "agent") {
+    return recoveryPointComponentSchema.parse({
+      ...common,
+      id: `sqlite/agent/${manifest.database.agentId}`,
+      kind: "sqlite-agent",
+      owner: "openclaw-agent-state",
+      agentId: manifest.database.agentId,
+      compatibility: `openclaw-agent-schema/${manifest.database.userVersion}`,
+    });
+  }
+  throw new Error("Generic SQLite snapshots are not eligible recovery-point components.");
+}
+
+function normalizeObligations(obligations: RecoveryPointObligations | undefined) {
+  const normalized = {
+    external: (obligations?.external ?? []).toSorted(compareObligations),
+    reconstructed: (obligations?.reconstructed ?? []).toSorted(compareObligations),
+    ephemeral: (obligations?.ephemeral ?? []).toSorted(compareObligations),
+  };
+  assertObligationIds(normalized);
+  return normalized;
+}
+
+function assertRequiredSqliteInventory(components: readonly RecoveryPointComponent[]): void {
+  const globalCount = components.filter((component) => component.kind === "sqlite-global").length;
+  const agentCount = components.filter((component) => component.kind === "sqlite-agent").length;
+  if (globalCount !== 1 || agentCount < 1) {
+    throw new Error(
+      "Recovery point V1 requires exactly one global and at least one agent SQLite component.",
+    );
+  }
+  const ids = new Set<string>();
+  for (const component of components) {
+    if (ids.has(component.id)) {
+      throw new Error(`Recovery point contains duplicate component id: ${component.id}.`);
+    }
+    ids.add(component.id);
+  }
+}
+
+function assertCanonicalComponentOrder(components: readonly RecoveryPointComponent[]): void {
+  const sorted = components.toSorted(compareComponents);
+  if (!components.every((component, index) => component.id === sorted[index]?.id)) {
+    throw new Error("Recovery point components are not in canonical order.");
+  }
+}
+
+function assertDependencies(components: readonly RecoveryPointComponent[]): void {
+  const byId = new Map(components.map((component) => [component.id, component]));
+  for (const component of components) {
+    const dependencies = new Set<string>();
+    for (const dependency of component.dependsOn) {
+      if (!byId.has(dependency)) {
+        throw new Error(
+          `Recovery point component ${component.id} has missing dependency ${dependency}.`,
+        );
+      }
+      if (dependency === component.id || dependencies.has(dependency)) {
+        throw new Error(
+          `Recovery point component ${component.id} has invalid dependency ${dependency}.`,
+        );
+      }
+      dependencies.add(dependency);
+    }
+  }
+
+  const visiting = new Set<string>();
+  const visited = new Set<string>();
+  const visit = (id: string): void => {
+    if (visiting.has(id)) {
+      throw new Error(`Recovery point component dependency cycle includes ${id}.`);
+    }
+    if (visited.has(id)) {
+      return;
+    }
+    visiting.add(id);
+    for (const dependency of byId.get(id)?.dependsOn ?? []) {
+      visit(dependency);
+    }
+    visiting.delete(id);
+    visited.add(id);
+  };
+  for (const component of components) {
+    visit(component.id);
+  }
+}
+
+function assertCanonicalObligationOrder(obligations: {
+  external: readonly RecoveryPointObligation[];
+  reconstructed: readonly RecoveryPointObligation[];
+  ephemeral: readonly RecoveryPointObligation[];
+}): void {
+  for (const entries of [obligations.external, obligations.reconstructed, obligations.ephemeral]) {
+    const sorted = entries.toSorted(compareObligations);
+    if (
+      !entries.every(
+        (entry, index) => entry.id === sorted[index]?.id && entry.owner === sorted[index]?.owner,
+      )
+    ) {
+      throw new Error("Recovery point obligations are not in canonical order.");
+    }
+  }
+}
+
+function assertObligationIds(obligations: {
+  external: readonly RecoveryPointObligation[];
+  reconstructed: readonly RecoveryPointObligation[];
+  ephemeral: readonly RecoveryPointObligation[];
+}): void {
+  const ids = new Set<string>();
+  for (const entries of [obligations.external, obligations.reconstructed, obligations.ephemeral]) {
+    for (const obligation of entries) {
+      if (ids.has(obligation.id)) {
+        throw new Error(`Recovery point contains duplicate obligation id: ${obligation.id}.`);
+      }
+      ids.add(obligation.id);
+    }
+  }
+}
+
+function assertCanonicalTimestamp(value: string, label: string): void {
+  const parsed = new Date(value);
+  if (!Number.isFinite(parsed.getTime()) || parsed.toISOString() !== value) {
+    throw new Error(`Recovery point ${label} is not a canonical timestamp.`);
+  }
+}
+
+function digestRecoveryPoint(manifestWithoutId: object): string {
+  return sha256Hex(stableStringify(manifestWithoutId));
+}
+
+function compareComponents(left: RecoveryPointComponent, right: RecoveryPointComponent): number {
+  if (left.kind !== right.kind) {
+    return left.kind === "sqlite-global" ? -1 : 1;
+  }
+  return compareCodeUnits(left.id, right.id);
+}
+
+function compareObligations(left: RecoveryPointObligation, right: RecoveryPointObligation): number {
+  return compareCodeUnits(left.id, right.id) || compareCodeUnits(left.owner, right.owner);
+}
+
+function compareCodeUnits(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}

--- a/src/snapshot/recovery-point.ts
+++ b/src/snapshot/recovery-point.ts
@@ -12,6 +12,9 @@ import {
 } from "./snapshot-provider.js";
 
 export const RECOVERY_POINT_VERSION = "openclaw-recovery-point/v1";
+export const RECOVERY_POINT_ACCEPTANCE_VERSION = "openclaw-recovery-point-acceptance/v1";
+
+const RECOVERY_POINT_INVENTORY_VERSION = "openclaw-runtime-sqlite-inventory/v1";
 
 const MAX_OWNER_MANIFEST_BYTES = 1024 * 1024;
 const SHA256_PATTERN = /^[a-f0-9]{64}$/u;
@@ -20,6 +23,7 @@ const SAFE_ID_PATTERN = /^[a-z0-9][a-z0-9._/-]{0,254}$/u;
 const obligationSchema = z
   .object({
     id: z.string().regex(SAFE_ID_PATTERN),
+    kind: z.enum(["secret-ref", "plugin-dependency", "runtime-cache"]),
     owner: z.string().regex(SAFE_ID_PATTERN),
     readinessRequired: z.boolean(),
   })
@@ -30,6 +34,7 @@ const componentBaseSchema = {
   artifactSha256: z.string().regex(SHA256_PATTERN),
   artifactSizeBytes: z.number().int().positive().max(Number.MAX_SAFE_INTEGER),
   ownerManifestSha256: z.string().regex(SHA256_PATTERN),
+  ownerManifestSizeBytes: z.number().int().positive().max(Number.MAX_SAFE_INTEGER),
   compatibility: z.string().regex(SAFE_ID_PATTERN),
   dependsOn: z.array(z.string().regex(SAFE_ID_PATTERN)),
   capturedAt: z.string(),
@@ -60,6 +65,13 @@ const recoveryPointManifestSchema = z
     version: z.literal(RECOVERY_POINT_VERSION),
     recoveryPointId: z.string().regex(SHA256_PATTERN),
     createdAt: z.string(),
+    inventory: z
+      .object({
+        version: z.literal(RECOVERY_POINT_INVENTORY_VERSION),
+        requiredComponentIds: z.array(z.string().regex(SAFE_ID_PATTERN)).min(2),
+      })
+      .strict(),
+    protection: z.object({ mode: z.literal("host-protected") }).strict(),
     components: z.array(recoveryPointComponentSchema).min(1),
     obligations: z
       .object({
@@ -71,9 +83,31 @@ const recoveryPointManifestSchema = z
   })
   .strict();
 
+const recoveryPointAcceptanceSchema = z
+  .object({
+    version: z.literal(RECOVERY_POINT_ACCEPTANCE_VERSION),
+    acceptanceSetId: z.string().regex(SHA256_PATTERN),
+    recoveryPointId: z.string().regex(SHA256_PATTERN),
+    aggregateManifestSha256: z.string().regex(SHA256_PATTERN),
+    aggregateManifestSizeBytes: z.number().int().positive().max(Number.MAX_SAFE_INTEGER),
+    components: z.array(
+      z
+        .object({
+          componentId: z.string().regex(SAFE_ID_PATTERN),
+          ownerManifestSha256: z.string().regex(SHA256_PATTERN),
+          ownerManifestSizeBytes: z.number().int().positive().max(Number.MAX_SAFE_INTEGER),
+          artifactSha256: z.string().regex(SHA256_PATTERN),
+          artifactSizeBytes: z.number().int().positive().max(Number.MAX_SAFE_INTEGER),
+        })
+        .strict(),
+    ),
+  })
+  .strict();
+
 export type RecoveryPointObligation = z.infer<typeof obligationSchema>;
 export type RecoveryPointComponent = z.infer<typeof recoveryPointComponentSchema>;
 export type RecoveryPointManifest = z.infer<typeof recoveryPointManifestSchema>;
+export type RecoveryPointAcceptance = z.infer<typeof recoveryPointAcceptanceSchema>;
 
 export type RecoveryPointSqliteSnapshot = {
   readonly provider: SqliteSnapshotProvider;
@@ -88,6 +122,7 @@ export type RecoveryPointObligations = {
 
 export async function createRecoveryPointManifest(params: {
   snapshots: readonly RecoveryPointSqliteSnapshot[];
+  expectedAgentIds: readonly string[];
   obligations?: RecoveryPointObligations;
   now?: () => Date;
 }): Promise<RecoveryPointManifest> {
@@ -98,11 +133,17 @@ export async function createRecoveryPointManifest(params: {
 
   const components = await Promise.all(params.snapshots.map(buildVerifiedComponent));
   components.sort(compareComponents);
-  assertRequiredSqliteInventory(components);
+  const requiredComponentIds = normalizeRequiredComponentIds(params.expectedAgentIds);
+  assertRequiredSqliteInventory(components, requiredComponentIds);
 
   const manifestWithoutId = {
     version: RECOVERY_POINT_VERSION,
     createdAt: now.toISOString(),
+    inventory: {
+      version: RECOVERY_POINT_INVENTORY_VERSION,
+      requiredComponentIds,
+    },
+    protection: { mode: "host-protected" },
     components,
     obligations: normalizeObligations(params.obligations),
   };
@@ -134,10 +175,12 @@ export function verifyRecoveryPointManifest(value: unknown): RecoveryPointManife
     }
   }
   assertCanonicalComponentOrder(manifest.components);
-  assertRequiredSqliteInventory(manifest.components);
+  assertCanonicalRequiredInventory(manifest.inventory.requiredComponentIds);
+  assertRequiredSqliteInventory(manifest.components, manifest.inventory.requiredComponentIds);
   assertDependencies(manifest.components);
   assertCanonicalObligationOrder(manifest.obligations);
   assertObligationIds(manifest.obligations);
+  assertSupportedObligations(manifest.obligations);
 
   const { recoveryPointId: _recoveryPointId, ...manifestWithoutId } = manifest;
   const expectedId = digestRecoveryPoint(manifestWithoutId);
@@ -152,14 +195,42 @@ export function verifyRecoveryPointManifest(value: unknown): RecoveryPointManife
 export async function verifyRecoveryPoint(params: {
   manifest: unknown;
   snapshots: readonly RecoveryPointSqliteSnapshot[];
-}): Promise<RecoveryPointManifest> {
+  expectedAgentIds: readonly string[];
+}): Promise<{ manifest: RecoveryPointManifest; acceptance: RecoveryPointAcceptance }> {
   const manifest = verifyRecoveryPointManifest(params.manifest);
+  const requiredComponentIds = normalizeRequiredComponentIds(params.expectedAgentIds);
+  if (!isDeepStrictEqual(manifest.inventory.requiredComponentIds, requiredComponentIds)) {
+    throw new Error("Recovery point inventory does not match the state owner's expected agents.");
+  }
   const actualComponents = await Promise.all(params.snapshots.map(buildVerifiedComponent));
   actualComponents.sort(compareComponents);
+  assertRequiredSqliteInventory(actualComponents, requiredComponentIds);
   if (!isDeepStrictEqual(actualComponents, manifest.components)) {
     throw new Error("Recovery point SQLite components do not match the verified owner snapshots.");
   }
-  return manifest;
+  return { manifest, acceptance: createRecoveryPointAcceptance(manifest) };
+}
+
+export function createRecoveryPointAcceptance(value: unknown): RecoveryPointAcceptance {
+  const manifest = verifyRecoveryPointManifest(value);
+  const manifestBytes = Buffer.from(stableStringify(manifest), "utf8");
+  const acceptanceWithoutId = {
+    version: RECOVERY_POINT_ACCEPTANCE_VERSION,
+    recoveryPointId: manifest.recoveryPointId,
+    aggregateManifestSha256: sha256Hex(manifestBytes),
+    aggregateManifestSizeBytes: manifestBytes.byteLength,
+    components: manifest.components.map((component) => ({
+      componentId: component.id,
+      ownerManifestSha256: component.ownerManifestSha256,
+      ownerManifestSizeBytes: component.ownerManifestSizeBytes,
+      artifactSha256: component.artifactSha256,
+      artifactSizeBytes: component.artifactSizeBytes,
+    })),
+  };
+  return recoveryPointAcceptanceSchema.parse({
+    ...acceptanceWithoutId,
+    acceptanceSetId: sha256Hex(stableStringify(acceptanceWithoutId)),
+  });
 }
 
 async function buildVerifiedComponent(
@@ -178,10 +249,16 @@ async function buildVerifiedComponent(
       `SQLite owner manifest changed during recovery-point composition: ${snapshot.ref.path}`,
     );
   }
-  return componentFromSnapshotManifest(secondVerification.manifest, secondManifestRead.sha256);
+  return componentFromSnapshotManifest(
+    secondVerification.manifest,
+    secondManifestRead.sha256,
+    secondManifestRead.sizeBytes,
+  );
 }
 
-async function readOwnerManifest(ref: SnapshotRef): Promise<{ parsed: unknown; sha256: string }> {
+async function readOwnerManifest(
+  ref: SnapshotRef,
+): Promise<{ parsed: unknown; sha256: string; sizeBytes: number }> {
   const snapshotRoot = await root(ref.path);
   const manifestRead = await snapshotRoot.read(SNAPSHOT_MANIFEST_FILENAME, {
     hardlinks: "reject",
@@ -192,6 +269,7 @@ async function readOwnerManifest(ref: SnapshotRef): Promise<{ parsed: unknown; s
     return {
       parsed: JSON.parse(manifestRead.buffer.toString("utf8")) as unknown,
       sha256: sha256Hex(manifestRead.buffer),
+      sizeBytes: manifestRead.buffer.byteLength,
     };
   } catch (error) {
     throw new Error(`Verified SQLite owner manifest is not valid JSON: ${ref.path}`, {
@@ -203,11 +281,13 @@ async function readOwnerManifest(ref: SnapshotRef): Promise<{ parsed: unknown; s
 function componentFromSnapshotManifest(
   manifest: SnapshotManifest,
   ownerManifestSha256: string,
+  ownerManifestSizeBytes: number,
 ): RecoveryPointComponent {
   const common = {
     artifactSha256: manifest.artifact.sha256,
     artifactSizeBytes: manifest.artifact.sizeBytes,
     ownerManifestSha256,
+    ownerManifestSizeBytes,
     dependsOn: [],
     capturedAt: manifest.createdAt,
     required: true,
@@ -241,23 +321,67 @@ function normalizeObligations(obligations: RecoveryPointObligations | undefined)
     ephemeral: (obligations?.ephemeral ?? []).toSorted(compareObligations),
   };
   assertObligationIds(normalized);
+  assertSupportedObligations(normalized);
   return normalized;
 }
 
-function assertRequiredSqliteInventory(components: readonly RecoveryPointComponent[]): void {
-  const globalCount = components.filter((component) => component.kind === "sqlite-global").length;
-  const agentCount = components.filter((component) => component.kind === "sqlite-agent").length;
-  if (globalCount !== 1 || agentCount < 1) {
-    throw new Error(
-      "Recovery point V1 requires exactly one global and at least one agent SQLite component.",
-    );
+function normalizeRequiredComponentIds(expectedAgentIds: readonly string[]): string[] {
+  if (expectedAgentIds.length === 0) {
+    throw new Error("Recovery point V1 requires at least one expected agent.");
   }
+  const normalizedAgentIds = expectedAgentIds.map((agentId) => normalizeAgentId(agentId));
+  for (let index = 0; index < expectedAgentIds.length; index += 1) {
+    if (
+      !isValidAgentId(expectedAgentIds[index] ?? "") ||
+      normalizedAgentIds[index] !== expectedAgentIds[index]
+    ) {
+      throw new Error(`Recovery point expected agent id is invalid: ${expectedAgentIds[index]}.`);
+    }
+  }
+  const uniqueAgentIds = new Set(normalizedAgentIds);
+  if (uniqueAgentIds.size !== normalizedAgentIds.length) {
+    throw new Error("Recovery point expected agent inventory contains duplicates.");
+  }
+  return [
+    "sqlite/global",
+    ...normalizedAgentIds.toSorted(compareCodeUnits).map((agentId) => `sqlite/agent/${agentId}`),
+  ];
+}
+
+function assertCanonicalRequiredInventory(requiredComponentIds: readonly string[]): void {
+  const agentIds = requiredComponentIds.map((componentId, index) => {
+    if (index === 0 && componentId === "sqlite/global") {
+      return undefined;
+    }
+    return componentId.startsWith("sqlite/agent/")
+      ? componentId.slice("sqlite/agent/".length)
+      : null;
+  });
+  if (agentIds.some((agentId) => agentId === null)) {
+    throw new Error("Recovery point required-component inventory is invalid.");
+  }
+  const expected = normalizeRequiredComponentIds(
+    agentIds.filter((agentId): agentId is string => agentId !== undefined),
+  );
+  if (!isDeepStrictEqual(requiredComponentIds, expected)) {
+    throw new Error("Recovery point required-component inventory is not canonical.");
+  }
+}
+
+function assertRequiredSqliteInventory(
+  components: readonly RecoveryPointComponent[],
+  requiredComponentIds: readonly string[],
+): void {
   const ids = new Set<string>();
   for (const component of components) {
     if (ids.has(component.id)) {
       throw new Error(`Recovery point contains duplicate component id: ${component.id}.`);
     }
     ids.add(component.id);
+  }
+  const componentIds = components.map((component) => component.id);
+  if (!isDeepStrictEqual(componentIds, requiredComponentIds)) {
+    throw new Error("Recovery point SQLite components do not match the required inventory.");
   }
 }
 
@@ -337,6 +461,33 @@ function assertObligationIds(obligations: {
         throw new Error(`Recovery point contains duplicate obligation id: ${obligation.id}.`);
       }
       ids.add(obligation.id);
+    }
+  }
+}
+
+function assertSupportedObligations(obligations: {
+  external: readonly RecoveryPointObligation[];
+  reconstructed: readonly RecoveryPointObligation[];
+  ephemeral: readonly RecoveryPointObligation[];
+}): void {
+  const supported = new Set([
+    "external:secret-ref:secrets",
+    "external:plugin-dependency:plugins",
+    "reconstructed:plugin-dependency:plugins",
+    "ephemeral:runtime-cache:openclaw-runtime",
+  ]);
+  const treatments = [
+    ["external", obligations.external],
+    ["reconstructed", obligations.reconstructed],
+    ["ephemeral", obligations.ephemeral],
+  ] as const;
+  for (const [treatment, entries] of treatments) {
+    for (const obligation of entries) {
+      if (!supported.has(`${treatment}:${obligation.kind}:${obligation.owner}`)) {
+        throw new Error(
+          `Recovery point obligation ${obligation.id} has unsupported treatment, kind, or owner.`,
+        );
+      }
     }
   }
 }

--- a/src/snapshot/recovery-point.ts
+++ b/src/snapshot/recovery-point.ts
@@ -20,7 +20,7 @@ const MAX_OWNER_MANIFEST_BYTES = 1024 * 1024;
 const SHA256_PATTERN = /^[a-f0-9]{64}$/u;
 const SAFE_ID_PATTERN = /^[a-z0-9][a-z0-9._/-]{0,254}$/u;
 
-const stateOwnerInventorySchema = z
+export const recoveryPointOwnerInventorySchema = z
   .object({
     version: z.literal(RECOVERY_POINT_INVENTORY_VERSION),
     owner: z.literal("openclaw-state"),
@@ -121,7 +121,7 @@ type RecoveryPointObligation = z.infer<typeof obligationSchema>;
 type RecoveryPointComponent = z.infer<typeof recoveryPointComponentSchema>;
 export type RecoveryPointManifest = z.infer<typeof recoveryPointManifestSchema>;
 export type RecoveryPointAcceptance = z.infer<typeof recoveryPointAcceptanceSchema>;
-export type RecoveryPointOwnerInventory = z.input<typeof stateOwnerInventorySchema>;
+export type RecoveryPointOwnerInventory = z.input<typeof recoveryPointOwnerInventorySchema>;
 
 export type RecoveryPointSqliteSnapshot = {
   readonly provider: SqliteSnapshotProvider;
@@ -361,7 +361,7 @@ function normalizeRequiredComponentIds(expectedAgentIds: readonly string[]): str
 }
 
 function normalizeOwnerInventory(value: RecoveryPointOwnerInventory) {
-  const inventory = stateOwnerInventorySchema.parse(value);
+  const inventory = recoveryPointOwnerInventorySchema.parse(value);
   return {
     version: inventory.version,
     owner: inventory.owner,

--- a/src/snapshot/recovery-point.ts
+++ b/src/snapshot/recovery-point.ts
@@ -20,6 +20,16 @@ const MAX_OWNER_MANIFEST_BYTES = 1024 * 1024;
 const SHA256_PATTERN = /^[a-f0-9]{64}$/u;
 const SAFE_ID_PATTERN = /^[a-z0-9][a-z0-9._/-]{0,254}$/u;
 
+const stateOwnerInventorySchema = z
+  .object({
+    version: z.literal(RECOVERY_POINT_INVENTORY_VERSION),
+    owner: z.literal("openclaw-state"),
+    sourceRuntimeGeneration: z.string().regex(SAFE_ID_PATTERN),
+    revision: z.string().regex(SAFE_ID_PATTERN),
+    agentIds: z.array(z.string().min(1).max(64)).min(1),
+  })
+  .strict();
+
 const obligationSchema = z
   .object({
     id: z.string().regex(SAFE_ID_PATTERN),
@@ -68,6 +78,9 @@ const recoveryPointManifestSchema = z
     inventory: z
       .object({
         version: z.literal(RECOVERY_POINT_INVENTORY_VERSION),
+        owner: z.literal("openclaw-state"),
+        sourceRuntimeGeneration: z.string().regex(SAFE_ID_PATTERN),
+        revision: z.string().regex(SAFE_ID_PATTERN),
         requiredComponentIds: z.array(z.string().regex(SAFE_ID_PATTERN)).min(2),
       })
       .strict(),
@@ -108,6 +121,7 @@ type RecoveryPointObligation = z.infer<typeof obligationSchema>;
 type RecoveryPointComponent = z.infer<typeof recoveryPointComponentSchema>;
 export type RecoveryPointManifest = z.infer<typeof recoveryPointManifestSchema>;
 export type RecoveryPointAcceptance = z.infer<typeof recoveryPointAcceptanceSchema>;
+export type RecoveryPointOwnerInventory = z.input<typeof stateOwnerInventorySchema>;
 
 export type RecoveryPointSqliteSnapshot = {
   readonly provider: SqliteSnapshotProvider;
@@ -122,7 +136,7 @@ type RecoveryPointObligations = {
 
 export async function createRecoveryPointManifest(params: {
   snapshots: readonly RecoveryPointSqliteSnapshot[];
-  expectedAgentIds: readonly string[];
+  ownerInventory: RecoveryPointOwnerInventory;
   obligations?: RecoveryPointObligations;
   now?: () => Date;
 }): Promise<RecoveryPointManifest> {
@@ -133,16 +147,13 @@ export async function createRecoveryPointManifest(params: {
 
   const components = await Promise.all(params.snapshots.map(buildVerifiedComponent));
   components.sort(compareComponents);
-  const requiredComponentIds = normalizeRequiredComponentIds(params.expectedAgentIds);
-  assertRequiredSqliteInventory(components, requiredComponentIds);
+  const inventory = normalizeOwnerInventory(params.ownerInventory);
+  assertRequiredSqliteInventory(components, inventory.requiredComponentIds);
 
   const manifestWithoutId = {
     version: RECOVERY_POINT_VERSION,
     createdAt: now.toISOString(),
-    inventory: {
-      version: RECOVERY_POINT_INVENTORY_VERSION,
-      requiredComponentIds,
-    },
+    inventory,
     protection: { mode: "host-protected" },
     components,
     obligations: normalizeObligations(params.obligations),
@@ -195,16 +206,16 @@ export function verifyRecoveryPointManifest(value: unknown): RecoveryPointManife
 export async function verifyRecoveryPoint(params: {
   manifest: unknown;
   snapshots: readonly RecoveryPointSqliteSnapshot[];
-  expectedAgentIds: readonly string[];
+  ownerInventory: RecoveryPointOwnerInventory;
 }): Promise<{ manifest: RecoveryPointManifest; acceptance: RecoveryPointAcceptance }> {
   const manifest = verifyRecoveryPointManifest(params.manifest);
-  const requiredComponentIds = normalizeRequiredComponentIds(params.expectedAgentIds);
-  if (!isDeepStrictEqual(manifest.inventory.requiredComponentIds, requiredComponentIds)) {
-    throw new Error("Recovery point inventory does not match the state owner's expected agents.");
+  const ownerInventory = normalizeOwnerInventory(params.ownerInventory);
+  if (!isDeepStrictEqual(manifest.inventory, ownerInventory)) {
+    throw new Error("Recovery point inventory does not match the state owner's inventory receipt.");
   }
   const actualComponents = await Promise.all(params.snapshots.map(buildVerifiedComponent));
   actualComponents.sort(compareComponents);
-  assertRequiredSqliteInventory(actualComponents, requiredComponentIds);
+  assertRequiredSqliteInventory(actualComponents, ownerInventory.requiredComponentIds);
   if (!isDeepStrictEqual(actualComponents, manifest.components)) {
     throw new Error("Recovery point SQLite components do not match the verified owner snapshots.");
   }
@@ -347,6 +358,17 @@ function normalizeRequiredComponentIds(expectedAgentIds: readonly string[]): str
     "sqlite/global",
     ...normalizedAgentIds.toSorted(compareCodeUnits).map((agentId) => `sqlite/agent/${agentId}`),
   ];
+}
+
+function normalizeOwnerInventory(value: RecoveryPointOwnerInventory) {
+  const inventory = stateOwnerInventorySchema.parse(value);
+  return {
+    version: inventory.version,
+    owner: inventory.owner,
+    sourceRuntimeGeneration: inventory.sourceRuntimeGeneration,
+    revision: inventory.revision,
+    requiredComponentIds: normalizeRequiredComponentIds(inventory.agentIds),
+  };
 }
 
 function assertCanonicalRequiredInventory(requiredComponentIds: readonly string[]): void {

--- a/src/snapshot/recovery-point.ts
+++ b/src/snapshot/recovery-point.ts
@@ -360,8 +360,19 @@ function normalizeRequiredComponentIds(expectedAgentIds: readonly string[]): str
   ];
 }
 
-function normalizeOwnerInventory(value: RecoveryPointOwnerInventory) {
+export function verifyRecoveryPointOwnerInventory(value: unknown): RecoveryPointOwnerInventory {
   const inventory = recoveryPointOwnerInventorySchema.parse(value);
+  const canonicalAgentIds = normalizeRequiredComponentIds(inventory.agentIds)
+    .slice(1)
+    .map((componentId) => componentId.slice("sqlite/agent/".length));
+  if (!isDeepStrictEqual(inventory.agentIds, canonicalAgentIds)) {
+    throw new Error("Recovery point owner inventory agent ids are not in canonical order.");
+  }
+  return inventory;
+}
+
+function normalizeOwnerInventory(value: RecoveryPointOwnerInventory) {
+  const inventory = verifyRecoveryPointOwnerInventory(value);
   return {
     version: inventory.version,
     owner: inventory.owner,

--- a/src/snapshot/recovery-point.ts
+++ b/src/snapshot/recovery-point.ts
@@ -1,5 +1,5 @@
 import { isDeepStrictEqual } from "node:util";
-import { stableStringify } from "@openclaw/normalization-core/stable-stringify";
+import { stableStringify } from "@openclaw/normalization-core";
 import { z } from "zod";
 import { sha256Hex } from "../infra/crypto-digest.js";
 import { root } from "../infra/fs-safe.js";

--- a/src/snapshot/recovery-point.ts
+++ b/src/snapshot/recovery-point.ts
@@ -20,7 +20,7 @@ const MAX_OWNER_MANIFEST_BYTES = 1024 * 1024;
 const SHA256_PATTERN = /^[a-f0-9]{64}$/u;
 const SAFE_ID_PATTERN = /^[a-z0-9][a-z0-9._/-]{0,254}$/u;
 
-export const recoveryPointOwnerInventorySchema = z
+const recoveryPointOwnerInventorySchema = z
   .object({
     version: z.literal(RECOVERY_POINT_INVENTORY_VERSION),
     owner: z.literal("openclaw-state"),
@@ -121,7 +121,7 @@ type RecoveryPointObligation = z.infer<typeof obligationSchema>;
 type RecoveryPointComponent = z.infer<typeof recoveryPointComponentSchema>;
 export type RecoveryPointManifest = z.infer<typeof recoveryPointManifestSchema>;
 export type RecoveryPointAcceptance = z.infer<typeof recoveryPointAcceptanceSchema>;
-export type RecoveryPointOwnerInventory = z.input<typeof recoveryPointOwnerInventorySchema>;
+type RecoveryPointOwnerInventory = z.input<typeof recoveryPointOwnerInventorySchema>;
 
 export type RecoveryPointSqliteSnapshot = {
   readonly provider: SqliteSnapshotProvider;

--- a/src/snapshot/recovery-point.ts
+++ b/src/snapshot/recovery-point.ts
@@ -1,6 +1,6 @@
 import { isDeepStrictEqual } from "node:util";
+import { stableStringify } from "@openclaw/normalization-core/stable-stringify";
 import { z } from "zod";
-import { stableStringify } from "../agents/stable-stringify.js";
 import { sha256Hex } from "../infra/crypto-digest.js";
 import { root } from "../infra/fs-safe.js";
 import { isValidAgentId, normalizeAgentId } from "../routing/session-key.js";


### PR DESCRIPTION
Related RFC: https://github.com/openclaw/rfcs/pull/46

Umbrella outcome: https://github.com/openclaw/openclaw/issues/114145

Stacked follow-up: https://github.com/openclaw/openclaw/pull/112865

Exact current head: `32809a14fc6b9feca7faecc377fa394c5260fd31`

## What problem this solves

A verified RFC 0013 SQLite snapshot represents one owner database, not one
complete OpenClaw recovery point. Recovery orchestration needs one exact
identity spanning the owner-selected global and per-agent inventory without
inventing a second snapshot implementation or host lifecycle framework.

This PR adds a private aggregate recovery-point slice above the existing
`SqliteSnapshotProvider`. It:

- re-verifies every owner snapshot and manifest;
- binds a canonical state-owner inventory, source generation, and revision;
- rejects missing, extra, duplicate, traversal-shaped, and non-canonical owner
  entries;
- binds exact artifact and owner-manifest digests and sizes;
- validates a closed, value-free obligation vocabulary; and
- derives deterministic recovery-point and acceptance-set identities.

The result remains `host-protected`. This PR adds no CLI, plugin API, storage
provider, suspension, wake, restore, or destruction authority.

## Latest restack

The branch was rebuilt on OpenClaw `main` at
`c43847313da1160852499618fb140779288f8faa` and remained mergeable after `main`
advanced again. The complete three-branch ancestry is linear:

`32809a14fc6` (#112385) -> `77e09a8f5c9` (#112865) ->
`247457d3544` (#112896).

GitHub cannot target a cross-fork PR at another fork-only branch, so the child
PRs continue to target `main` and display cumulative diffs.

## Real behavior proof

- `src/snapshot/recovery-point.test.ts`: eight composition, verification,
  inventory, ordering, obligation, and rewrite-race tests passed in the
  integrated restack.
- `pnpm tsgo:core` and the core test typecheck passed on the complete stack.
- The protocol registry check and the restored-admission integration suite also
  passed on the complete stack.

## Review gate

This remains owner-review evidence. Before merge, maintainers must accept the
authoritative activation-pinned inventory source and decide whether the
scale-to-zero lifecycle contract stays under RFC 0013 or moves to a standalone
draft RFC. Credential-free portability, durable host acceptance, retained
ingress, wake, placement, and restored admission are outside this PR.
