### PR TITLE
feat: resume requesters after deferred sessions_send replies

### DIFF
--- a/docs/concepts/session-tool.md
+++ b/docs/concepts/session-tool.md
@@ -85,6 +85,9 @@ In Code Mode, the conversation tools reuse their exact Gateway output contracts.
 
 - **Fire-and-forget:** set `timeoutSeconds: 0` to enqueue and return immediately.
 - **Wait for reply:** set a timeout and get the response inline.
+- **Resume the requester later:** set `wakeOnReply: true` to return after dispatch, then start one continuation in the exact requesting session and ingress route when that target run succeeds or fails.
+
+`wakeOnReply` is a durable, 24-hour, one-shot registration keyed to the target run. OpenClaw captures the requester session incarnation and normalized delivery context from trusted runtime state; the model cannot provide a return channel or target. The captured origin must identify its channel, destination, and account, so continuation delivery never substitutes a provider-default account. OpenClaw persists the terminal payload before settling the target and keeps an accepted dispatch open until the continuation user turn is durable. After restart, a matching restart-recovery claim plus transcript turn transfers ownership to main-session recovery; otherwise OpenClaw replays the dispatch with the same continuation id. The continuation fails closed if its durable ownership cannot be inspected or if the captured origin is missing, expired, replaced, or mismatched. This mode does not expose the target result to the initiating turn and replaces the legacy A2A reply-back and announce flow for that call. It cannot be combined with `watch: true` or a non-zero `timeoutSeconds`. Omitting it preserves existing `sessions_send` behavior.
 
 Thread-scoped chat sessions, such as keys ending in `:thread:<id>`, are not valid `sessions_send` targets. Use the parent channel session key for inter-agent coordination so tool-routed messages do not appear inside an active human-facing thread.
 

--- a/src/agents/agent-command-reply.ts
+++ b/src/agents/agent-command-reply.ts
@@ -1,0 +1,27 @@
+/** Extracts user-visible assistant text from an agent-command result. */
+export function extractAgentCommandReply(result: unknown): string | undefined {
+  const candidate = result as { meta?: { error?: unknown }; payloads?: unknown } | null | undefined;
+  const error =
+    candidate?.meta?.error &&
+    typeof candidate.meta.error === "object" &&
+    !Array.isArray(candidate.meta.error)
+      ? (candidate.meta.error as { kind?: unknown; terminalPresentation?: unknown })
+      : undefined;
+  if (error?.kind === "incomplete_turn" && error.terminalPresentation !== true) {
+    return undefined;
+  }
+  const payloads = candidate?.payloads;
+  if (!Array.isArray(payloads)) {
+    return undefined;
+  }
+  const texts = payloads
+    .map((payload) =>
+      payload &&
+      typeof payload === "object" &&
+      typeof (payload as { text?: unknown }).text === "string"
+        ? (payload as { text: string }).text
+        : "",
+    )
+    .filter((text) => text.trim().length > 0);
+  return texts.length > 0 ? texts.join("\n\n") : undefined;
+}

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -649,7 +649,9 @@ export function createOpenClawTools(
           // is the gate in ensureConfiguredAgentMainSession).
           createSessionsSendTool({
             agentSessionKey: options?.agentSessionKey,
+            agentSessionId: options?.sessionId,
             agentChannel: options?.agentChannel,
+            deliveryContext,
             sandboxed: options?.sandboxed,
             config: resolvedConfig,
           }),

--- a/src/agents/sessions-send-deferred-store.ts
+++ b/src/agents/sessions-send-deferred-store.ts
@@ -1,0 +1,396 @@
+/** Durable one-shot registrations for origin-bound sessions_send completion. */
+import type { DatabaseSync } from "node:sqlite";
+import type { Selectable } from "kysely";
+import {
+  executeSqliteQuerySync,
+  executeSqliteQueryTakeFirstSync,
+  getNodeSqliteKysely,
+} from "../infra/kysely-sync.js";
+import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
+import {
+  openOpenClawStateDatabase,
+  runOpenClawStateWriteTransaction,
+  type OpenClawStateDatabaseOptions,
+} from "../state/openclaw-state-db.js";
+import {
+  type DeliveryContext,
+  normalizeDeliveryContext,
+} from "../utils/delivery-context.shared.js";
+
+type DeferredCompletionTable = OpenClawStateKyselyDatabase["sessions_send_deferred_completions"];
+type DeferredCompletionRow = Selectable<DeferredCompletionTable>;
+type DeferredCompletionDatabase = Pick<
+  OpenClawStateKyselyDatabase,
+  "sessions_send_deferred_completions"
+>;
+
+const ensuredDatabases = new WeakSet<DatabaseSync>();
+const SESSIONS_SEND_DEFERRED_SCHEMA_SQL = `
+CREATE TABLE IF NOT EXISTS sessions_send_deferred_completions (
+  target_run_id TEXT NOT NULL PRIMARY KEY,
+  target_session_key TEXT NOT NULL,
+  requester_session_key TEXT NOT NULL,
+  requester_session_id TEXT NOT NULL,
+  requester_origin_json TEXT NOT NULL,
+  request_message TEXT NOT NULL,
+  continuation_run_id TEXT NOT NULL UNIQUE,
+  state TEXT NOT NULL CHECK (state IN ('pending', 'dispatching', 'completed', 'cancelled', 'expired')),
+  created_at INTEGER NOT NULL,
+  expires_at INTEGER NOT NULL,
+  claimed_at INTEGER,
+  completed_at INTEGER,
+  terminal_outcome_json TEXT,
+  completion_text TEXT,
+  last_error TEXT
+) STRICT;
+
+CREATE INDEX IF NOT EXISTS idx_sessions_send_deferred_expiry
+  ON sessions_send_deferred_completions(state, expires_at, target_run_id);
+`;
+
+export type SessionsSendDeferredRegistration = {
+  targetRunId: string;
+  targetSessionKey: string;
+  requesterSessionKey: string;
+  requesterSessionId: string;
+  requesterOrigin: DeliveryContext;
+  requestMessage: string;
+  continuationRunId: string;
+  createdAt: number;
+  expiresAt: number;
+};
+
+export type PreparedSessionsSendDeferredRegistration = SessionsSendDeferredRegistration & {
+  completionText: string;
+};
+
+function getDeferredCompletionKysely(db: DatabaseSync) {
+  return getNodeSqliteKysely<DeferredCompletionDatabase>(db);
+}
+
+function ensureDeferredCompletionSchema(options: OpenClawStateDatabaseOptions = {}): void {
+  const database = openOpenClawStateDatabase(options);
+  if (ensuredDatabases.has(database.db)) {
+    return;
+  }
+  runOpenClawStateWriteTransaction(
+    ({ db }) => {
+      // sqlite-allow-raw -- feature-local additive schema DDL; rows use Kysely below.
+      db.exec(SESSIONS_SEND_DEFERRED_SCHEMA_SQL);
+    },
+    options,
+    { operationLabel: "sessions-send.deferred.schema.ensure" },
+  );
+  ensuredDatabases.add(database.db);
+}
+
+function openDeferredCompletionDatabase(options: OpenClawStateDatabaseOptions = {}) {
+  ensureDeferredCompletionSchema(options);
+  return openOpenClawStateDatabase(options);
+}
+
+function parseRegistrationRow(
+  row: DeferredCompletionRow | undefined,
+): SessionsSendDeferredRegistration | undefined {
+  if (!row) {
+    return undefined;
+  }
+  let requesterOrigin: DeliveryContext | undefined;
+  try {
+    requesterOrigin = normalizeDeliveryContext(
+      JSON.parse(row.requester_origin_json) as DeliveryContext,
+    );
+  } catch {
+    return undefined;
+  }
+  if (!requesterOrigin?.channel || !requesterOrigin.to || !requesterOrigin.accountId) {
+    return undefined;
+  }
+  return {
+    targetRunId: row.target_run_id,
+    targetSessionKey: row.target_session_key,
+    requesterSessionKey: row.requester_session_key,
+    requesterSessionId: row.requester_session_id,
+    requesterOrigin,
+    requestMessage: row.request_message,
+    continuationRunId: row.continuation_run_id,
+    createdAt: row.created_at,
+    expiresAt: row.expires_at,
+  };
+}
+
+function parsePreparedRegistrationRow(
+  row: DeferredCompletionRow | undefined,
+): PreparedSessionsSendDeferredRegistration | undefined {
+  const registration = parseRegistrationRow(row);
+  if (!registration || !row?.completion_text) {
+    return undefined;
+  }
+  return { ...registration, completionText: row.completion_text };
+}
+
+/** Persist a deferred completion registration before its target run is dispatched. */
+export function registerSessionsSendDeferredCompletion(
+  registration: SessionsSendDeferredRegistration,
+  options: OpenClawStateDatabaseOptions = {},
+): void {
+  ensureDeferredCompletionSchema(options);
+  runOpenClawStateWriteTransaction(
+    ({ db }) => {
+      const kysely = getDeferredCompletionKysely(db);
+      executeSqliteQuerySync(
+        db,
+        kysely
+          .deleteFrom("sessions_send_deferred_completions")
+          .where("expires_at", "<=", registration.createdAt),
+      );
+      executeSqliteQuerySync(
+        db,
+        kysely.insertInto("sessions_send_deferred_completions").values({
+          target_run_id: registration.targetRunId,
+          target_session_key: registration.targetSessionKey,
+          requester_session_key: registration.requesterSessionKey,
+          requester_session_id: registration.requesterSessionId,
+          requester_origin_json: JSON.stringify(registration.requesterOrigin),
+          request_message: registration.requestMessage,
+          continuation_run_id: registration.continuationRunId,
+          state: "pending",
+          created_at: registration.createdAt,
+          expires_at: registration.expiresAt,
+        }),
+      );
+    },
+    options,
+    { operationLabel: "sessions-send.deferred.register" },
+  );
+}
+
+/** Cancel an unclaimed registration when target dispatch does not start. */
+export function cancelSessionsSendDeferredCompletion(
+  params: { targetRunId: string; error?: string; now?: number },
+  options: OpenClawStateDatabaseOptions = {},
+): void {
+  const now = params.now ?? Date.now();
+  ensureDeferredCompletionSchema(options);
+  runOpenClawStateWriteTransaction(
+    ({ db }) => {
+      executeSqliteQuerySync(
+        db,
+        getDeferredCompletionKysely(db)
+          .updateTable("sessions_send_deferred_completions")
+          .set({ state: "cancelled", completed_at: now, last_error: params.error ?? null })
+          .where("target_run_id", "=", params.targetRunId)
+          .where("state", "=", "pending"),
+      );
+    },
+    options,
+    { operationLabel: "sessions-send.deferred.cancel" },
+  );
+}
+
+/** Persist target terminal data before the target run is allowed to settle. */
+export function prepareSessionsSendDeferredCompletion(
+  params: {
+    targetRunId: string;
+    targetSessionKey: string;
+    terminalOutcome: unknown;
+    completionText: string;
+    now?: number;
+  },
+  options: OpenClawStateDatabaseOptions = {},
+): boolean {
+  const now = params.now ?? Date.now();
+  ensureDeferredCompletionSchema(options);
+  return runOpenClawStateWriteTransaction(
+    ({ db }) => {
+      const kysely = getDeferredCompletionKysely(db);
+      executeSqliteQuerySync(
+        db,
+        kysely
+          .updateTable("sessions_send_deferred_completions")
+          .set({ state: "expired", completed_at: now })
+          .where("target_run_id", "=", params.targetRunId)
+          .where("state", "=", "pending")
+          .where("expires_at", "<=", now),
+      );
+      const prepared = executeSqliteQuerySync(
+        db,
+        kysely
+          .updateTable("sessions_send_deferred_completions")
+          .set({
+            terminal_outcome_json: JSON.stringify(params.terminalOutcome),
+            completion_text: params.completionText,
+          })
+          .where("target_run_id", "=", params.targetRunId)
+          .where("target_session_key", "=", params.targetSessionKey)
+          .where("state", "=", "pending")
+          .where("completion_text", "is", null)
+          .where("expires_at", ">", now),
+      );
+      return prepared.numAffectedRows === 1n;
+    },
+    options,
+    { operationLabel: "sessions-send.deferred.prepare" },
+  );
+}
+
+/** Claim prepared work or reopen an interrupted dispatch using its stable idempotency key. */
+export function claimSessionsSendDeferredCompletion(
+  params: { targetRunId: string; targetSessionKey?: string; now?: number },
+  options: OpenClawStateDatabaseOptions = {},
+): PreparedSessionsSendDeferredRegistration | undefined {
+  const now = params.now ?? Date.now();
+  ensureDeferredCompletionSchema(options);
+  return runOpenClawStateWriteTransaction(
+    ({ db }) => {
+      const kysely = getDeferredCompletionKysely(db);
+      executeSqliteQuerySync(
+        db,
+        kysely
+          .updateTable("sessions_send_deferred_completions")
+          .set({ state: "expired", completed_at: now })
+          .where("target_run_id", "=", params.targetRunId)
+          .where("state", "in", ["pending", "dispatching"])
+          .where("expires_at", "<=", now),
+      );
+      let claim = kysely
+        .updateTable("sessions_send_deferred_completions")
+        .set({ state: "dispatching", claimed_at: now })
+        .where("target_run_id", "=", params.targetRunId)
+        .where("state", "=", "pending")
+        .where("completion_text", "is not", null)
+        .where("expires_at", ">", now);
+      if (params.targetSessionKey) {
+        claim = claim.where("target_session_key", "=", params.targetSessionKey);
+      }
+      executeSqliteQuerySync(db, claim);
+
+      let select = kysely
+        .selectFrom("sessions_send_deferred_completions")
+        .selectAll()
+        .where("target_run_id", "=", params.targetRunId)
+        .where("state", "=", "dispatching")
+        .where("completion_text", "is not", null)
+        .where("expires_at", ">", now);
+      if (params.targetSessionKey) {
+        select = select.where("target_session_key", "=", params.targetSessionKey);
+      }
+      return parsePreparedRegistrationRow(executeSqliteQueryTakeFirstSync(db, select));
+    },
+    options,
+    { operationLabel: "sessions-send.deferred.claim" },
+  );
+}
+
+/** Record a continuation dispatch result; ambiguous failures remain restart-replayable. */
+export function finishSessionsSendDeferredCompletion(
+  params: { targetRunId: string; delivered: boolean; error?: string; now?: number },
+  options: OpenClawStateDatabaseOptions = {},
+): void {
+  const now = params.now ?? Date.now();
+  ensureDeferredCompletionSchema(options);
+  runOpenClawStateWriteTransaction(
+    ({ db }) => {
+      executeSqliteQuerySync(
+        db,
+        getDeferredCompletionKysely(db)
+          .updateTable("sessions_send_deferred_completions")
+          .set(
+            params.delivered
+              ? { state: "completed", completed_at: now, last_error: null }
+              : { last_error: params.error ?? "continuation dispatch failed" },
+          )
+          .where("target_run_id", "=", params.targetRunId)
+          .where("state", "=", "dispatching"),
+      );
+    },
+    options,
+    { operationLabel: "sessions-send.deferred.finish" },
+  );
+}
+
+/** Retire a dispatch after its continuation user turn becomes durable. */
+export function finishSessionsSendDeferredContinuation(
+  params: { continuationRunId: string; now?: number },
+  options: OpenClawStateDatabaseOptions = {},
+): string | undefined {
+  const now = params.now ?? Date.now();
+  ensureDeferredCompletionSchema(options);
+  return runOpenClawStateWriteTransaction(
+    ({ db }) => {
+      const kysely = getDeferredCompletionKysely(db);
+      const row = executeSqliteQueryTakeFirstSync(
+        db,
+        kysely
+          .selectFrom("sessions_send_deferred_completions")
+          .select("target_run_id")
+          .where("continuation_run_id", "=", params.continuationRunId)
+          .where("state", "=", "dispatching"),
+      );
+      if (!row) {
+        return undefined;
+      }
+      const finished = executeSqliteQuerySync(
+        db,
+        kysely
+          .updateTable("sessions_send_deferred_completions")
+          .set({ state: "completed", completed_at: now, last_error: null })
+          .where("target_run_id", "=", row.target_run_id)
+          .where("continuation_run_id", "=", params.continuationRunId)
+          .where("state", "=", "dispatching"),
+      );
+      return finished.numAffectedRows === 1n ? row.target_run_id : undefined;
+    },
+    options,
+    { operationLabel: "sessions-send.deferred.finish-continuation" },
+  );
+}
+
+/** List open rows so terminal observers avoid per-run database reads. */
+export function listOpenSessionsSendDeferredRunIds(
+  options: OpenClawStateDatabaseOptions & { now?: number } = {},
+): string[] {
+  const now = options.now ?? Date.now();
+  const { db } = openDeferredCompletionDatabase(options);
+  return executeSqliteQuerySync(
+    db,
+    getDeferredCompletionKysely(db)
+      .selectFrom("sessions_send_deferred_completions")
+      .select("target_run_id")
+      .where("state", "in", ["pending", "dispatching"])
+      .where("expires_at", ">", now),
+  ).rows.map((row) => row.target_run_id);
+}
+
+/** List open continuation ids for the hot transcript-persistence callback. */
+export function listOpenSessionsSendDeferredContinuationRunIds(
+  options: OpenClawStateDatabaseOptions & { now?: number } = {},
+): string[] {
+  const now = options.now ?? Date.now();
+  const { db } = openDeferredCompletionDatabase(options);
+  return executeSqliteQuerySync(
+    db,
+    getDeferredCompletionKysely(db)
+      .selectFrom("sessions_send_deferred_completions")
+      .select("continuation_run_id")
+      .where("state", "in", ["pending", "dispatching"])
+      .where("expires_at", ">", now),
+  ).rows.map((row) => row.continuation_run_id);
+}
+
+/** List prepared pending and interrupted dispatch rows for startup reconciliation. */
+export function listDispatchableSessionsSendDeferredRunIds(
+  options: OpenClawStateDatabaseOptions & { now?: number } = {},
+): string[] {
+  const now = options.now ?? Date.now();
+  const { db } = openDeferredCompletionDatabase(options);
+  return executeSqliteQuerySync(
+    db,
+    getDeferredCompletionKysely(db)
+      .selectFrom("sessions_send_deferred_completions")
+      .select("target_run_id")
+      .where("completion_text", "is not", null)
+      .where("state", "in", ["pending", "dispatching"])
+      .where("expires_at", ">", now),
+  ).rows.map((row) => row.target_run_id);
+}

--- a/src/agents/sessions-send-deferred.test.ts
+++ b/src/agents/sessions-send-deferred.test.ts
@@ -1,0 +1,496 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import {
+  appendTranscriptMessage,
+  upsertSessionEntry,
+} from "../config/sessions/session-accessor.js";
+import type { GatewayRecoveryRuntime } from "../gateway/server-instance-runtime.types.js";
+import { buildRunUserTurnIdempotencyKey } from "../sessions/user-turn-transcript.js";
+import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
+import {
+  closeOpenClawStateDatabase,
+  openOpenClawStateDatabase,
+} from "../state/openclaw-state-db.js";
+import {
+  markStartupOrphanedMainSessionsForRecovery,
+  recoverRestartAbortedMainSessions,
+} from "./main-session-restart-recovery.js";
+import { claimSessionsSendDeferredCompletion } from "./sessions-send-deferred-store.js";
+import {
+  armSessionsSendDeferredCompletion,
+  disarmSessionsSendDeferredCompletion,
+  finishSessionsSendDeferredContinuationAfterTranscript,
+  maybeCompleteSessionsSendDeferred,
+  prepareSessionsSendDeferredCompletion,
+  recoverSessionsSendDeferredCompletions,
+  testing,
+} from "./sessions-send-deferred.js";
+
+const targetRunId = "target-run-1";
+const targetSessionKey = "agent:research:main";
+const requesterSessionKey = "agent:main:telegram:dm:123";
+const requesterSessionId = "requester-session-1";
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+describe("sessions_send deferred completion", () => {
+  let stateDir: string;
+  let options: { env: NodeJS.ProcessEnv };
+
+  beforeEach(() => {
+    stateDir = tempDirs.make("openclaw-sessions-send-deferred-");
+    options = { env: { ...process.env, OPENCLAW_STATE_DIR: stateDir } };
+    testing.resetPendingRunIds();
+  });
+
+  afterEach(() => {
+    testing.resetPendingRunIds();
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabase();
+  });
+
+  function arm(overrides: Partial<Parameters<typeof armSessionsSendDeferredCompletion>[0]> = {}) {
+    return armSessionsSendDeferredCompletion(
+      {
+        targetRunId,
+        targetSessionKey,
+        requesterSessionKey,
+        requesterSessionId,
+        requesterOrigin: {
+          channel: "telegram",
+          to: "7504982318",
+          accountId: "primary",
+          threadId: "42",
+        },
+        requestMessage: "Find the deployment failure",
+        ...overrides,
+      },
+      options,
+    );
+  }
+
+  it("lazily creates its table in an existing current-schema database", () => {
+    const initial = openOpenClawStateDatabase(options);
+    initial.db.exec("DROP TABLE sessions_send_deferred_completions;");
+    closeOpenClawStateDatabase();
+
+    const reopened = openOpenClawStateDatabase(options);
+    expect(
+      reopened.db
+        .prepare(
+          "SELECT name FROM sqlite_schema WHERE type = 'table' AND name = 'sessions_send_deferred_completions';",
+        )
+        .get(),
+    ).toBeUndefined();
+
+    arm();
+    expect(
+      reopened.db
+        .prepare(
+          "SELECT name FROM sqlite_schema WHERE type = 'table' AND name = 'sessions_send_deferred_completions';",
+        )
+        .get(),
+    ).toEqual({ name: "sessions_send_deferred_completions" });
+  });
+
+  it("recovers a prepared completion after settlement and restart", async () => {
+    arm();
+    expect(
+      prepareSessionsSendDeferredCompletion(
+        {
+          targetRunId,
+          targetSessionKey,
+          terminalOutcome: { status: "ok", reason: "completed" },
+          result: { payloads: [{ text: "The deployment failed during migration." }] },
+        },
+        options,
+      ),
+    ).toBe(true);
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabase();
+    testing.resetPendingRunIds();
+    const dispatch = vi.fn(async (_params: Record<string, unknown>) => ({ status: "accepted" }));
+
+    await expect(recoverSessionsSendDeferredCompletions({ dispatch }, options)).resolves.toEqual({
+      recovered: 1,
+      failed: 0,
+    });
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey: requesterSessionKey,
+        expectedExistingSessionId: requesterSessionId,
+        channel: "telegram",
+        to: "7504982318",
+        accountId: "primary",
+        threadId: "42",
+        deliver: true,
+        bestEffortDeliver: false,
+        sourceReplyDeliveryMode: "automatic",
+      }),
+    );
+    expect(dispatch.mock.calls[0]?.[0]?.message).toContain(
+      "The deployment failed during migration.",
+    );
+    expect(
+      finishSessionsSendDeferredContinuationAfterTranscript(
+        String(dispatch.mock.calls[0]?.[0]?.idempotencyKey),
+        options,
+      ),
+    ).toBe(true);
+
+    await expect(recoverSessionsSendDeferredCompletions({ dispatch }, options)).resolves.toEqual({
+      recovered: 0,
+      failed: 0,
+    });
+    expect(dispatch).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not readmit a continuation whose user turn survived gateway restart", async () => {
+    arm();
+    const acceptedRuns: string[] = [];
+    const dispatch = vi.fn(async (params: Record<string, unknown>) => {
+      const continuationRunId = String(params.idempotencyKey);
+      acceptedRuns.push(continuationRunId);
+      await upsertSessionEntry(
+        {
+          agentId: "main",
+          env: options.env,
+          sessionKey: requesterSessionKey,
+        },
+        {
+          sessionId: requesterSessionId,
+          status: "running",
+          updatedAt: Date.now(),
+          restartRecoveryDeliveryRunId: continuationRunId,
+          restartRecoveryDeliveryContext: {
+            channel: "telegram",
+            to: "7504982318",
+            accountId: "primary",
+            threadId: "42",
+          },
+        },
+      );
+      await appendTranscriptMessage(
+        {
+          agentId: "main",
+          env: options.env,
+          sessionId: requesterSessionId,
+          sessionKey: requesterSessionKey,
+        },
+        {
+          message: {
+            role: "user",
+            content: String(params.message),
+            timestamp: Date.now(),
+            idempotencyKey: buildRunUserTurnIdempotencyKey(continuationRunId),
+          },
+          idempotencyLookup: "scan",
+        },
+      );
+      return { runId: continuationRunId, status: "accepted" };
+    });
+    await expect(
+      maybeCompleteSessionsSendDeferred(
+        {
+          targetRunId,
+          targetSessionKey,
+          terminalOutcome: { status: "ok", reason: "completed" },
+          result: { payloads: [{ text: "Durable result" }] },
+          dispatch,
+        },
+        options,
+      ),
+    ).resolves.toBe(true);
+    expect(acceptedRuns).toHaveLength(1);
+
+    // Simulate process death after Gateway acceptance and transcript commit,
+    // but before the transcript observer retires the deferred SQLite row.
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabase();
+    testing.resetPendingRunIds();
+    dispatch.mockClear();
+
+    await expect(recoverSessionsSendDeferredCompletions({ dispatch }, options)).resolves.toEqual({
+      recovered: 1,
+      failed: 0,
+    });
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(acceptedRuns).toHaveLength(1);
+    const postRestartAdmissions: Record<string, unknown>[] = [];
+    const gatewayRuntime: GatewayRecoveryRuntime = {
+      dispatchAgent: async <T>(params: Record<string, unknown>) => {
+        postRestartAdmissions.push(params);
+        return { runId: "restart-recovery-run" } as T;
+      },
+      waitForAgent: async <T>() => ({ status: "ok" }) as T,
+      sendRecoveryNotice: async <T>() => ({ ok: true }) as T,
+    };
+    await expect(
+      markStartupOrphanedMainSessionsForRecovery({
+        activeSessionIds: [],
+        activeSessionKeys: [],
+        cfg: {},
+        stateDir,
+        updatedBeforeMs: Date.now() + 1,
+      }),
+    ).resolves.toMatchObject({ marked: 1 });
+    await expect(
+      recoverRestartAbortedMainSessions({
+        activeSessionIds: [],
+        activeSessionKeys: [],
+        cfg: {},
+        gatewayRuntime,
+        stateDir,
+      }),
+    ).resolves.toMatchObject({ recovered: 1, failed: 0 });
+    expect(postRestartAdmissions).toHaveLength(1);
+    await expect(recoverSessionsSendDeferredCompletions({ dispatch }, options)).resolves.toEqual({
+      recovered: 0,
+      failed: 0,
+    });
+  });
+
+  it("replays a claimed dispatch after restart with the same idempotency key", async () => {
+    arm();
+    prepareSessionsSendDeferredCompletion(
+      {
+        targetRunId,
+        targetSessionKey,
+        terminalOutcome: { status: "ok", reason: "completed" },
+        result: { payloads: [{ text: "Recovered result" }] },
+      },
+      options,
+    );
+    const claimed = claimSessionsSendDeferredCompletion({ targetRunId, targetSessionKey }, options);
+    expect(claimed?.continuationRunId).toBeTruthy();
+    await upsertSessionEntry(
+      {
+        agentId: "main",
+        env: options.env,
+        sessionKey: requesterSessionKey,
+      },
+      {
+        sessionId: requesterSessionId,
+        status: "running",
+        updatedAt: Date.now(),
+        restartRecoveryDeliveryRunId: claimed?.continuationRunId,
+      },
+    );
+
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabase();
+    testing.resetPendingRunIds();
+    const dispatch = vi.fn(async (_params: Record<string, unknown>) => ({ status: "accepted" }));
+
+    await expect(recoverSessionsSendDeferredCompletions({ dispatch }, options)).resolves.toEqual({
+      recovered: 1,
+      failed: 0,
+    });
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ idempotencyKey: claimed?.continuationRunId }),
+    );
+  });
+
+  it("leaves an ambiguous dispatch failure replayable after restart", async () => {
+    arm();
+    const failedDispatch = vi.fn(async (_params: Record<string, unknown>) => {
+      throw new Error("connection closed before acceptance");
+    });
+    await expect(
+      maybeCompleteSessionsSendDeferred(
+        {
+          targetRunId,
+          targetSessionKey,
+          terminalOutcome: { status: "ok", reason: "completed" },
+          result: { payloads: [{ text: "Recovered result" }] },
+          dispatch: failedDispatch,
+        },
+        options,
+      ),
+    ).resolves.toBe(false);
+    const failedIdempotencyKey = failedDispatch.mock.calls[0]?.[0]?.idempotencyKey;
+
+    closeOpenClawStateDatabase();
+    testing.resetPendingRunIds();
+    const recoveredDispatch = vi.fn(async (_params: Record<string, unknown>) => ({
+      status: "accepted",
+    }));
+    await expect(
+      recoverSessionsSendDeferredCompletions({ dispatch: recoveredDispatch }, options),
+    ).resolves.toEqual({ recovered: 1, failed: 0 });
+    expect(recoveredDispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ idempotencyKey: failedIdempotencyKey }),
+    );
+  });
+
+  it("rejects a mismatched target session without consuming the registration", async () => {
+    arm();
+    const dispatch = vi.fn(async (_params: Record<string, unknown>) => ({ status: "accepted" }));
+
+    await expect(
+      maybeCompleteSessionsSendDeferred(
+        {
+          targetRunId,
+          targetSessionKey: "agent:forged:main",
+          terminalOutcome: { status: "ok", reason: "completed" },
+          dispatch,
+        },
+        options,
+      ),
+    ).resolves.toBe(false);
+    await expect(
+      maybeCompleteSessionsSendDeferred(
+        {
+          targetRunId,
+          targetSessionKey,
+          terminalOutcome: { status: "ok", reason: "completed" },
+          dispatch,
+        },
+        options,
+      ),
+    ).resolves.toBe(true);
+    expect(dispatch).toHaveBeenCalledTimes(1);
+  });
+
+  it("wakes the requester with terminal failure context", async () => {
+    arm();
+    const dispatch = vi.fn(async (_params: Record<string, unknown>) => ({ status: "accepted" }));
+
+    await maybeCompleteSessionsSendDeferred(
+      {
+        targetRunId,
+        targetSessionKey,
+        terminalOutcome: {
+          status: "error",
+          reason: "failed",
+          error: "provider authentication failed",
+        },
+        dispatch,
+      },
+      options,
+    );
+
+    expect(dispatch.mock.calls[0]?.[0]?.message).toContain("provider authentication failed");
+  });
+
+  it("keeps concurrent target completions bound to their respective origins", async () => {
+    arm({ targetRunId: "telegram-run" });
+    arm({
+      targetRunId: "slack-run",
+      targetSessionKey: "agent:operations:main",
+      requesterSessionKey: "agent:main:slack:channel:ops",
+      requesterSessionId: "requester-session-2",
+      requesterOrigin: {
+        channel: "slack",
+        to: "C01234567",
+        accountId: "workspace",
+        threadId: "1721592000.000100",
+      },
+    });
+    const dispatch = vi.fn(async (_params: Record<string, unknown>) => ({ status: "accepted" }));
+
+    await Promise.all([
+      maybeCompleteSessionsSendDeferred(
+        {
+          targetRunId: "slack-run",
+          targetSessionKey: "agent:operations:main",
+          terminalOutcome: { status: "ok", reason: "completed" },
+          result: { payloads: [{ text: "Slack result" }] },
+          dispatch,
+        },
+        options,
+      ),
+      maybeCompleteSessionsSendDeferred(
+        {
+          targetRunId: "telegram-run",
+          targetSessionKey,
+          terminalOutcome: { status: "ok", reason: "completed" },
+          result: { payloads: [{ text: "Telegram result" }] },
+          dispatch,
+        },
+        options,
+      ),
+    ]);
+
+    expect(dispatch).toHaveBeenCalledTimes(2);
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey: "agent:main:slack:channel:ops",
+        expectedExistingSessionId: "requester-session-2",
+        channel: "slack",
+        to: "C01234567",
+        accountId: "workspace",
+        threadId: "1721592000.000100",
+      }),
+    );
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey: requesterSessionKey,
+        expectedExistingSessionId: requesterSessionId,
+        channel: "telegram",
+        to: "7504982318",
+        accountId: "primary",
+        threadId: "42",
+      }),
+    );
+  });
+
+  it("does not dispatch explicitly cancelled or expired registrations", async () => {
+    const dispatch = vi.fn(async (_params: Record<string, unknown>) => ({ status: "accepted" }));
+    arm();
+    disarmSessionsSendDeferredCompletion({ targetRunId }, options);
+    await expect(
+      maybeCompleteSessionsSendDeferred(
+        {
+          targetRunId,
+          targetSessionKey,
+          terminalOutcome: { status: "ok", reason: "completed" },
+          dispatch,
+        },
+        options,
+      ),
+    ).resolves.toBe(false);
+
+    arm({ targetRunId: "expired-run", ttlMs: -1 });
+    testing.resetPendingRunIds();
+    await expect(
+      maybeCompleteSessionsSendDeferred(
+        {
+          targetRunId: "expired-run",
+          targetSessionKey,
+          terminalOutcome: { status: "ok", reason: "completed" },
+          dispatch,
+        },
+        options,
+      ),
+    ).resolves.toBe(false);
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when the requester origin is missing or internal", () => {
+    expect(() => arm({ requesterOrigin: { channel: "telegram" } })).toThrow(
+      "explicit external requester delivery context",
+    );
+    expect(() =>
+      arm({ requesterOrigin: { channel: "sessions_send", to: requesterSessionKey } }),
+    ).toThrow("explicit external requester delivery context");
+  });
+
+  it("never substitutes the provider default for an accountless multi-account origin", async () => {
+    const providerDefaultDispatch = vi.fn(async (_params: Record<string, unknown>) => ({
+      status: "accepted",
+    }));
+    expect(() =>
+      arm({
+        requesterOrigin: {
+          channel: "telegram",
+          to: "7504982318",
+        },
+      }),
+    ).toThrow("with accountId");
+    await expect(
+      recoverSessionsSendDeferredCompletions({ dispatch: providerDefaultDispatch }, options),
+    ).resolves.toEqual({ recovered: 0, failed: 0 });
+    expect(providerDefaultDispatch).not.toHaveBeenCalled();
+  });
+});

--- a/src/agents/sessions-send-deferred.ts
+++ b/src/agents/sessions-send-deferred.ts
@@ -1,0 +1,362 @@
+/** Origin-bound deferred completion for opt-in sessions_send calls. */
+import crypto from "node:crypto";
+import {
+  findTranscriptEvent,
+  loadSessionEntry,
+  type TranscriptEvent,
+} from "../config/sessions/session-accessor.js";
+import { resolveAgentIdFromSessionKey } from "../routing/session-key.js";
+import { buildRunUserTurnIdempotencyKey } from "../sessions/user-turn-transcript.js";
+import type { OpenClawStateDatabaseOptions } from "../state/openclaw-state-db.js";
+import {
+  type DeliveryContext,
+  normalizeDeliveryContext,
+} from "../utils/delivery-context.shared.js";
+import {
+  INTERNAL_MESSAGE_CHANNEL,
+  isInternalNonDeliveryChannel,
+} from "../utils/message-channel.js";
+import { extractAgentCommandReply } from "./agent-command-reply.js";
+import type { AgentRunTerminalOutcome } from "./agent-run-terminal-outcome.js";
+import { resolveNestedAgentLaneForSession } from "./lanes.js";
+import {
+  cancelSessionsSendDeferredCompletion,
+  claimSessionsSendDeferredCompletion,
+  finishSessionsSendDeferredCompletion,
+  finishSessionsSendDeferredContinuation,
+  listDispatchableSessionsSendDeferredRunIds,
+  listOpenSessionsSendDeferredContinuationRunIds,
+  listOpenSessionsSendDeferredRunIds,
+  prepareSessionsSendDeferredCompletion as prepareSessionsSendDeferredCompletionStore,
+  registerSessionsSendDeferredCompletion,
+  type PreparedSessionsSendDeferredRegistration,
+  type SessionsSendDeferredRegistration,
+} from "./sessions-send-deferred-store.js";
+
+export const SESSIONS_SEND_DEFERRED_TTL_MS = 24 * 60 * 60_000;
+
+const openRunIds = new Set<string>();
+const openContinuationRunIds = new Set<string>();
+let openRunIdsLoaded = false;
+
+type DeferredCompletionDispatch = (params: Record<string, unknown>) => Promise<unknown>;
+
+async function dispatchContinuation(params: Record<string, unknown>): Promise<unknown> {
+  const { callGateway } = await import("../gateway/call.js");
+  return await callGateway({ method: "agent", params, timeoutMs: 10_000 });
+}
+
+function resolveExplicitOrigin(origin?: DeliveryContext): DeliveryContext | undefined {
+  const normalized = normalizeDeliveryContext(origin);
+  if (
+    !normalized?.channel ||
+    !normalized.to ||
+    !normalized.accountId ||
+    isInternalNonDeliveryChannel(normalized.channel)
+  ) {
+    return undefined;
+  }
+  return normalized;
+}
+
+/** Persist and index a one-shot deferred completion before target dispatch. */
+export function armSessionsSendDeferredCompletion(
+  params: {
+    targetRunId: string;
+    targetSessionKey: string;
+    requesterSessionKey: string;
+    requesterSessionId: string;
+    requesterOrigin: DeliveryContext;
+    requestMessage: string;
+    now?: number;
+    ttlMs?: number;
+  },
+  options: OpenClawStateDatabaseOptions = {},
+): { expiresAt: number } {
+  const requesterOrigin = resolveExplicitOrigin(params.requesterOrigin);
+  if (!requesterOrigin) {
+    throw new Error(
+      "wakeOnReply requires an explicit external requester delivery context with accountId",
+    );
+  }
+  const createdAt = params.now ?? Date.now();
+  const expiresAt = createdAt + (params.ttlMs ?? SESSIONS_SEND_DEFERRED_TTL_MS);
+  const registration: SessionsSendDeferredRegistration = {
+    targetRunId: params.targetRunId,
+    targetSessionKey: params.targetSessionKey,
+    requesterSessionKey: params.requesterSessionKey,
+    requesterSessionId: params.requesterSessionId,
+    requesterOrigin,
+    requestMessage: params.requestMessage,
+    continuationRunId: crypto.randomUUID(),
+    createdAt,
+    expiresAt,
+  };
+  registerSessionsSendDeferredCompletion(registration, options);
+  openRunIds.add(params.targetRunId);
+  openContinuationRunIds.add(registration.continuationRunId);
+  return { expiresAt };
+}
+
+/** Cancel a registration when its target run was not accepted. */
+export function disarmSessionsSendDeferredCompletion(
+  params: { targetRunId: string; error?: string },
+  options: OpenClawStateDatabaseOptions = {},
+): void {
+  openRunIds.delete(params.targetRunId);
+  cancelSessionsSendDeferredCompletion(params, options);
+}
+
+function buildTargetCompletionText(params: {
+  terminalOutcome: AgentRunTerminalOutcome;
+  result?: unknown;
+}): string {
+  const reply = extractAgentCommandReply(params.result);
+  const outcome =
+    params.terminalOutcome.status === "ok"
+      ? reply || "(The target run completed without final assistant text.)"
+      : [
+          `The target run ended with ${params.terminalOutcome.reason}.`,
+          params.terminalOutcome.error,
+        ]
+          .filter(Boolean)
+          .join(" ");
+  return outcome;
+}
+
+function buildDeferredCompletionPrompt(params: {
+  registration: SessionsSendDeferredRegistration & { completionText: string };
+}): string {
+  return [
+    "[Deferred sessions_send completion]",
+    `Target session: ${params.registration.targetSessionKey}`,
+    `Target run: ${params.registration.targetRunId}`,
+    `Original request: ${params.registration.requestMessage}`,
+    "",
+    "The user is waiting in this conversation for the result. Continue this conversation now and give the user the result or failure status.",
+    "",
+    "Target result:",
+    params.registration.completionText,
+  ].join("\n");
+}
+
+function buildContinuationParams(params: {
+  registration: SessionsSendDeferredRegistration & { completionText: string };
+}): Record<string, unknown> {
+  const { registration } = params;
+  const origin = registration.requesterOrigin;
+  return {
+    message: buildDeferredCompletionPrompt(params),
+    sessionKey: registration.requesterSessionKey,
+    expectedExistingSessionId: registration.requesterSessionId,
+    idempotencyKey: registration.continuationRunId,
+    deliver: true,
+    bestEffortDeliver: false,
+    sourceReplyDeliveryMode: "automatic",
+    channel: origin.channel,
+    to: origin.to,
+    accountId: origin.accountId,
+    ...(origin.threadId != null ? { threadId: String(origin.threadId) } : {}),
+    lane: resolveNestedAgentLaneForSession(registration.requesterSessionKey),
+    inputProvenance: {
+      kind: "inter_session",
+      sourceSessionKey: registration.targetSessionKey,
+      sourceChannel: INTERNAL_MESSAGE_CHANNEL,
+      sourceTool: "sessions_send",
+    },
+  };
+}
+
+function ensureOpenRunIdsLoaded(options: OpenClawStateDatabaseOptions): void {
+  if (openRunIdsLoaded) {
+    return;
+  }
+  for (const runId of listOpenSessionsSendDeferredRunIds(options)) {
+    openRunIds.add(runId);
+  }
+  for (const runId of listOpenSessionsSendDeferredContinuationRunIds(options)) {
+    openContinuationRunIds.add(runId);
+  }
+  openRunIdsLoaded = true;
+}
+
+function readTranscriptMessageIdempotencyKey(event: TranscriptEvent): string | undefined {
+  if (!event || typeof event !== "object" || Array.isArray(event)) {
+    return undefined;
+  }
+  const message = (event as { message?: unknown }).message;
+  if (!message || typeof message !== "object" || Array.isArray(message)) {
+    return undefined;
+  }
+  const idempotencyKey = (message as { idempotencyKey?: unknown }).idempotencyKey;
+  return typeof idempotencyKey === "string" ? idempotencyKey : undefined;
+}
+
+async function hasDurableContinuationTurn(
+  registration: PreparedSessionsSendDeferredRegistration,
+  options: OpenClawStateDatabaseOptions,
+): Promise<boolean> {
+  const entry = loadSessionEntry({
+    agentId: resolveAgentIdFromSessionKey(registration.requesterSessionKey),
+    env: options.env,
+    sessionKey: registration.requesterSessionKey,
+  });
+  const ownsContinuation =
+    entry?.sessionId === registration.requesterSessionId &&
+    (entry.restartRecoveryDeliveryRunId === registration.continuationRunId ||
+      entry.restartRecoveryTerminalRunIds?.includes(registration.continuationRunId) === true);
+  if (!ownsContinuation) {
+    return false;
+  }
+  const idempotencyKeys = new Set([
+    buildRunUserTurnIdempotencyKey(registration.continuationRunId),
+    `hook-block:before_agent_run:user:${registration.continuationRunId}`,
+  ]);
+  const match = await findTranscriptEvent(
+    {
+      agentId: resolveAgentIdFromSessionKey(registration.requesterSessionKey),
+      env: options.env,
+      sessionId: registration.requesterSessionId,
+      sessionKey: registration.requesterSessionKey,
+    },
+    (event) => idempotencyKeys.has(readTranscriptMessageIdempotencyKey(event) ?? ""),
+  );
+  return match !== undefined;
+}
+
+/** Retire a deferred row only after its continuation user turn is durable. */
+export function finishSessionsSendDeferredContinuationAfterTranscript(
+  continuationRunId: string,
+  options: OpenClawStateDatabaseOptions = {},
+): boolean {
+  ensureOpenRunIdsLoaded(options);
+  if (!openContinuationRunIds.has(continuationRunId)) {
+    return false;
+  }
+  const targetRunId = finishSessionsSendDeferredContinuation({ continuationRunId }, options);
+  if (!targetRunId) {
+    return false;
+  }
+  openContinuationRunIds.delete(continuationRunId);
+  openRunIds.delete(targetRunId);
+  return true;
+}
+
+/** Persist the target result before its run is allowed to settle. */
+export function prepareSessionsSendDeferredCompletion(
+  params: {
+    targetRunId: string;
+    targetSessionKey: string;
+    terminalOutcome: AgentRunTerminalOutcome;
+    result?: unknown;
+  },
+  options: OpenClawStateDatabaseOptions = {},
+): boolean {
+  ensureOpenRunIdsLoaded(options);
+  if (!openRunIds.has(params.targetRunId)) {
+    return false;
+  }
+  return prepareSessionsSendDeferredCompletionStore(
+    {
+      targetRunId: params.targetRunId,
+      targetSessionKey: params.targetSessionKey,
+      terminalOutcome: params.terminalOutcome,
+      completionText: buildTargetCompletionText(params),
+    },
+    options,
+  );
+}
+
+/** Dispatch prepared work using the registration's stable idempotency key. */
+export async function dispatchPreparedSessionsSendDeferredCompletion(
+  params: {
+    targetRunId: string;
+    targetSessionKey?: string;
+    dispatch?: DeferredCompletionDispatch;
+  },
+  options: OpenClawStateDatabaseOptions = {},
+): Promise<boolean> {
+  ensureOpenRunIdsLoaded(options);
+  if (!openRunIds.has(params.targetRunId)) {
+    return false;
+  }
+  const registration = claimSessionsSendDeferredCompletion(
+    {
+      targetRunId: params.targetRunId,
+      targetSessionKey: params.targetSessionKey,
+    },
+    options,
+  );
+  if (!registration) {
+    return false;
+  }
+  openRunIds.delete(params.targetRunId);
+  try {
+    if (await hasDurableContinuationTurn(registration, options)) {
+      finishSessionsSendDeferredContinuationAfterTranscript(
+        registration.continuationRunId,
+        options,
+      );
+      return true;
+    }
+    await (params.dispatch ?? dispatchContinuation)(buildContinuationParams({ registration }));
+    return true;
+  } catch (error) {
+    finishSessionsSendDeferredCompletion(
+      {
+        targetRunId: params.targetRunId,
+        delivered: false,
+        error: error instanceof Error ? error.message : String(error),
+      },
+      options,
+    );
+    return false;
+  }
+}
+
+/** Persist and dispatch a correlated target result in the normal terminal path. */
+export async function maybeCompleteSessionsSendDeferred(
+  params: {
+    targetRunId: string;
+    targetSessionKey: string;
+    terminalOutcome: AgentRunTerminalOutcome;
+    result?: unknown;
+    dispatch?: DeferredCompletionDispatch;
+  },
+  options: OpenClawStateDatabaseOptions = {},
+): Promise<boolean> {
+  if (!prepareSessionsSendDeferredCompletion(params, options)) {
+    return false;
+  }
+  return await dispatchPreparedSessionsSendDeferredCompletion(params, options);
+}
+
+/** Replay prepared or interrupted continuation dispatches after gateway restart. */
+export async function recoverSessionsSendDeferredCompletions(
+  params: { dispatch?: DeferredCompletionDispatch } = {},
+  options: OpenClawStateDatabaseOptions = {},
+): Promise<{ recovered: number; failed: number }> {
+  ensureOpenRunIdsLoaded(options);
+  let recovered = 0;
+  let failed = 0;
+  for (const targetRunId of listDispatchableSessionsSendDeferredRunIds(options)) {
+    const delivered = await dispatchPreparedSessionsSendDeferredCompletion(
+      { targetRunId, dispatch: params.dispatch },
+      options,
+    );
+    if (delivered) {
+      recovered += 1;
+    } else {
+      failed += 1;
+    }
+  }
+  return { recovered, failed };
+}
+
+export const testing = {
+  resetPendingRunIds() {
+    openRunIds.clear();
+    openContinuationRunIds.clear();
+    openRunIdsLoaded = false;
+  },
+};

--- a/src/agents/tool-description-presets.ts
+++ b/src/agents/tool-description-presets.ts
@@ -76,6 +76,7 @@ export function describeSessionsSendTool(): string {
     "For an exact external destination, use `conversations_list` plus `conversations_send`/`conversations_turn`, or `message` with an explicit channel and target.",
     "Thread chats rejected: target parent channel. Missing configured-agent main created. Waits for reply when available.",
     "watch:true: notice arrives when others later change target session.",
+    "wakeOnReply:true: return after dispatch, then resume this exact requester session and ingress route once that target run succeeds or fails; cannot combine with watch or a non-zero timeoutSeconds.",
   ].join(" ");
 }
 

--- a/src/agents/tools/agent-step.ts
+++ b/src/agents/tools/agent-step.ts
@@ -8,6 +8,7 @@ import { callGateway } from "../../gateway/call.js";
 import { annotateInterSessionPromptText } from "../../sessions/input-provenance.js";
 import { INTERNAL_MESSAGE_CHANNEL } from "../../utils/message-channel.js";
 import { retireSessionMcpRuntimeForSessionKey } from "../agent-bundle-mcp-tools.js";
+import { extractAgentCommandReply } from "../agent-command-reply.js";
 import { resolveNestedAgentLaneForSession } from "../lanes.js";
 import { waitForAgentRunAndReadUpdatedAssistantReply } from "../run-wait.js";
 
@@ -26,34 +27,6 @@ let agentStepDeps: {
   agentCommandFromIngress: AgentCommandRunner;
   callGateway: GatewayCaller;
 } = defaultAgentStepDeps;
-
-function extractAgentCommandReply(result: unknown): string | undefined {
-  const candidate = result as { meta?: { error?: unknown }; payloads?: unknown } | null | undefined;
-  const error =
-    candidate?.meta?.error &&
-    typeof candidate.meta.error === "object" &&
-    !Array.isArray(candidate.meta.error)
-      ? (candidate.meta.error as { kind?: unknown; terminalPresentation?: unknown })
-      : undefined;
-  // Plain incomplete-turn output is a control failure; trusted terminal tool presentations remain deliverable.
-  if (error?.kind === "incomplete_turn" && error.terminalPresentation !== true) {
-    return undefined;
-  }
-  const payloads = candidate?.payloads;
-  if (!Array.isArray(payloads)) {
-    return undefined;
-  }
-  const texts = payloads
-    .map((payload) =>
-      payload &&
-      typeof payload === "object" &&
-      typeof (payload as { text?: unknown }).text === "string"
-        ? (payload as { text: string }).text
-        : "",
-    )
-    .filter((text) => text.trim().length > 0);
-  return texts.length > 0 ? texts.join("\n\n") : undefined;
-}
 
 /** Sends one annotated message to a target session and returns the resulting assistant text. */
 export async function runAgentStep(params: {

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -37,6 +37,7 @@ import {
 import { SESSION_LABEL_MAX_LENGTH } from "../../sessions/session-label.js";
 import { registerSessionStateWatch } from "../../sessions/session-state-events.js";
 import { stripFormattedReasoningMessage } from "../../shared/text/formatted-reasoning-message.js";
+import type { DeliveryContext } from "../../utils/delivery-context.shared.js";
 import {
   type GatewayMessageChannel,
   INTERNAL_MESSAGE_CHANNEL,
@@ -56,6 +57,10 @@ import {
   readLatestAssistantReplySnapshot,
   waitForAgentRunAndReadUpdatedAssistantReply,
 } from "../run-wait.js";
+import {
+  armSessionsSendDeferredCompletion,
+  disarmSessionsSendDeferredCompletion,
+} from "../sessions-send-deferred.js";
 import { loadSessionEntryByKey } from "../subagent-announce-delivery.js";
 import {
   describeSessionsSendTool,
@@ -86,17 +91,28 @@ const SessionsSendToolSchema = Type.Object({
   message: Type.String(),
   timeoutSeconds: Type.Optional(Type.Integer({ minimum: 0 })),
   watch: Type.Optional(Type.Boolean()),
+  wakeOnReply: Type.Optional(Type.Boolean()),
 });
 
 const log = createSubsystemLogger("agents/sessions-send");
 
-const SessionsSendDeliverySchema = Type.Object(
-  {
-    status: Type.Union([Type.Literal("pending"), Type.Literal("skipped")]),
-    mode: Type.Literal("announce"),
-  },
-  { additionalProperties: false },
-);
+const SessionsSendDeliverySchema = Type.Union([
+  Type.Object(
+    {
+      status: Type.Union([Type.Literal("pending"), Type.Literal("skipped")]),
+      mode: Type.Literal("announce"),
+    },
+    { additionalProperties: false },
+  ),
+  Type.Object(
+    {
+      status: Type.Literal("armed"),
+      mode: Type.Literal("wake_on_reply"),
+      expiresAt: Type.Integer(),
+    },
+    { additionalProperties: false },
+  ),
+]);
 
 const SessionsSendOutputSchema = Type.Union([
   Type.Object(
@@ -439,7 +455,9 @@ async function startAgentRun(params: {
 
 export function createSessionsSendTool(opts?: {
   agentSessionKey?: string;
+  agentSessionId?: string;
   agentChannel?: GatewayMessageChannel;
+  deliveryContext?: DeliveryContext;
   sandboxed?: boolean;
   config?: OpenClawConfig;
   callGateway?: GatewayCaller;
@@ -456,7 +474,23 @@ export function createSessionsSendTool(opts?: {
       const params = normalizeSessionsSendArguments(args);
       const gatewayCall = opts?.callGateway ?? callGateway;
       const message = readStringParam(params, "message", { required: true });
-      const timeoutSeconds = readNonNegativeIntegerParam(params, "timeoutSeconds") ?? 30;
+      const requestedTimeoutSeconds = readNonNegativeIntegerParam(params, "timeoutSeconds");
+      const wakeOnReply = params.wakeOnReply === true;
+      if (wakeOnReply && requestedTimeoutSeconds !== undefined && requestedTimeoutSeconds !== 0) {
+        return jsonResult({
+          runId: crypto.randomUUID(),
+          status: "error",
+          error: "wakeOnReply cannot be combined with a non-zero timeoutSeconds",
+        });
+      }
+      if (wakeOnReply && params.watch === true) {
+        return jsonResult({
+          runId: crypto.randomUUID(),
+          status: "error",
+          error: "wakeOnReply cannot be combined with watch",
+        });
+      }
+      const timeoutSeconds = wakeOnReply ? 0 : (requestedTimeoutSeconds ?? 30);
       const { cfg, mainKey, alias, effectiveRequesterKey, restrictToSpawned } =
         resolveSessionToolContext(opts);
 
@@ -711,7 +745,7 @@ export function createSessionsSendTool(opts?: {
       let runId: string = idempotencyKey;
       // Fire-and-forget self-send remains a channel-delivery path. A synchronous
       // self-send would wait behind its own active session lane until timeout.
-      if (timeoutSeconds !== 0 && requesterSessionKey === resolvedKey) {
+      if ((timeoutSeconds !== 0 || wakeOnReply) && requesterSessionKey === resolvedKey) {
         return jsonResult({
           runId,
           status: "error",
@@ -792,6 +826,80 @@ export function createSessionsSendTool(opts?: {
               ? resolveCronRunScopedFallbackSessionKey(displayKey)
               : undefined;
 
+          const agentMessageContext = buildAgentToAgentMessageContext({
+            requesterSessionKey: replyRequesterSessionKey,
+            requesterChannel,
+            targetSessionKey: displayKey,
+          });
+          const inputProvenance = {
+            kind: "inter_session" as const,
+            sourceSessionKey: replyRequesterSessionKey,
+            sourceChannel: requesterChannel,
+            sourceTool: "sessions_send",
+          };
+          const sendParams = {
+            message: annotateInterSessionPromptText(message, inputProvenance),
+            sessionKey: resolvedKey,
+            idempotencyKey,
+            deliver: false,
+            sourceReplyDeliveryMode: "message_tool_only" as const,
+            channel: INTERNAL_MESSAGE_CHANNEL,
+            lane: resolveNestedAgentLaneForSession(resolvedKey),
+            extraSystemPrompt: agentMessageContext,
+            inputProvenance,
+          };
+
+          if (wakeOnReply) {
+            if (!requesterSessionKey || !opts?.agentSessionId || !opts.deliveryContext) {
+              return jsonResult({
+                runId,
+                status: "error",
+                error:
+                  "wakeOnReply requires a trusted requester session incarnation and delivery context",
+                sessionKey: displayKey,
+              });
+            }
+            let expiresAt: number;
+            try {
+              ({ expiresAt } = armSessionsSendDeferredCompletion({
+                targetRunId: runId,
+                targetSessionKey: resolvedKey,
+                requesterSessionKey,
+                requesterSessionId: opts.agentSessionId,
+                requesterOrigin: opts.deliveryContext,
+                requestMessage: message,
+              }));
+            } catch (error) {
+              return jsonResult({
+                runId,
+                status: "error",
+                error: formatErrorMessage(error),
+                sessionKey: displayKey,
+              });
+            }
+            const start = await startAgentRun({
+              callGateway: gatewayCall,
+              runId,
+              sendParams,
+              sessionKey: displayKey,
+              deliveryTimeoutMs: announceTimeoutMs,
+            });
+            if (!start.ok) {
+              disarmSessionsSendDeferredCompletion({
+                targetRunId: runId,
+                error: "target run was not accepted",
+              });
+              return start.result;
+            }
+            runId = start.runId;
+            return jsonResult({
+              runId,
+              status: "accepted",
+              sessionKey: displayKey,
+              delivery: { status: "armed", mode: "wake_on_reply", expiresAt },
+            });
+          }
+
           // Capture the pre-run assistant snapshot before starting the nested run.
           // Fast in-process test doubles and short-circuit agent paths can finish
           // before we reach the post-run read, which would otherwise make the new
@@ -824,28 +932,6 @@ export function createSessionsSendTool(opts?: {
                 }).catch(() => undefined)
               : undefined;
 
-          const agentMessageContext = buildAgentToAgentMessageContext({
-            requesterSessionKey: replyRequesterSessionKey,
-            requesterChannel,
-            targetSessionKey: displayKey,
-          });
-          const inputProvenance = {
-            kind: "inter_session" as const,
-            sourceSessionKey: replyRequesterSessionKey,
-            sourceChannel: requesterChannel,
-            sourceTool: "sessions_send",
-          };
-          const sendParams = {
-            message: annotateInterSessionPromptText(message, inputProvenance),
-            sessionKey: resolvedKey,
-            idempotencyKey,
-            deliver: false,
-            sourceReplyDeliveryMode: "message_tool_only" as const,
-            channel: INTERNAL_MESSAGE_CHANNEL,
-            lane: resolveNestedAgentLaneForSession(resolvedKey),
-            extraSystemPrompt: agentMessageContext,
-            inputProvenance,
-          };
           const maxPingPongTurns = resolvePingPongTurns();
 
           // Skip the A2A ping-pong + announce flow when the current caller is the

--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -17,6 +17,10 @@ const inProcessCreationMock = vi.fn(
 // Default false mirrors running outside a gateway process; the trusted-creation
 // regression test flips it on and restores it.
 let inProcessGatewayContextAvailable = false;
+const deferredCompletionMocks = vi.hoisted(() => ({
+  arm: vi.fn(() => ({ expiresAt: 1_800_000_000_000 })),
+  disarm: vi.fn(),
+}));
 const facadeRuntimeMock = vi.hoisted(() => ({
   sessionKeyResolvers: new Map<
     string,
@@ -36,6 +40,10 @@ vi.mock("./in-process-gateway.js", () => ({
   callInProcessGatewayToolWithCreation: (method: unknown, params: unknown, creation: unknown) =>
     inProcessCreationMock(method, params, creation),
   hasInProcessGatewayToolContext: () => inProcessGatewayContextAvailable,
+}));
+vi.mock("../sessions-send-deferred.js", () => ({
+  armSessionsSendDeferredCompletion: deferredCompletionMocks.arm,
+  disarmSessionsSendDeferredCompletion: deferredCompletionMocks.disarm,
 }));
 vi.mock("../../plugin-sdk/facade-runtime.js", async () => {
   const actual = await vi.importActual<typeof import("../../plugin-sdk/facade-runtime.js")>(
@@ -777,6 +785,96 @@ describe("sessions_list channel derivation", () => {
 describe("sessions_send gating", () => {
   beforeEach(() => {
     callGatewayMock.mockReset();
+    deferredCompletionMocks.arm.mockClear();
+    deferredCompletionMocks.disarm.mockClear();
+  });
+
+  it("arms origin-bound completion and skips waiting and legacy announce", async () => {
+    const { runSessionsSendA2AFlow } = await import("./sessions-send-tool.a2a.js");
+    const targetSessionKey = "agent:main:research";
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string; params?: Record<string, unknown> };
+      if (request.method === "sessions.list") {
+        return { path: "/tmp/sessions.json", sessions: [{ key: targetSessionKey }] };
+      }
+      if (request.method === "agent") {
+        return { runId: request.params?.idempotencyKey };
+      }
+      return {};
+    });
+    const tool = createSessionsSendTool({
+      agentSessionKey: MAIN_AGENT_SESSION_KEY,
+      agentSessionId: "requester-session-id",
+      agentChannel: "telegram",
+      deliveryContext: {
+        channel: "telegram",
+        to: "7504982318",
+        accountId: "primary",
+        threadId: "42",
+      },
+      callGateway: callGatewayMock,
+      config: {
+        session: { scope: "per-sender", mainKey: "main" },
+        tools: {
+          agentToAgent: { enabled: false },
+          sessions: { visibility: "all" },
+        },
+      } as never,
+    });
+
+    const result = await tool.execute("call-deferred", {
+      sessionKey: targetSessionKey,
+      message: "Investigate the failure",
+      wakeOnReply: true,
+    });
+
+    expect(requireDetails(result)).toMatchObject({
+      status: "accepted",
+      sessionKey: targetSessionKey,
+      delivery: {
+        status: "armed",
+        mode: "wake_on_reply",
+        expiresAt: 1_800_000_000_000,
+      },
+    });
+    expect(deferredCompletionMocks.arm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        targetSessionKey,
+        requesterSessionKey: MAIN_AGENT_SESSION_KEY,
+        requesterSessionId: "requester-session-id",
+        requesterOrigin: {
+          channel: "telegram",
+          to: "7504982318",
+          accountId: "primary",
+          threadId: "42",
+        },
+      }),
+    );
+    expect(callGatewayMock.mock.calls.some(([call]) => call.method === "agent.wait")).toBe(false);
+    expect(callGatewayMock.mock.calls.some(([call]) => call.method === "chat.history")).toBe(false);
+    expect(runSessionsSendA2AFlow).not.toHaveBeenCalled();
+  });
+
+  it("rejects conflicting deferred completion options before dispatch", async () => {
+    const tool = createMainSessionsSendTool();
+
+    const waited = await tool.execute("call-deferred-wait", {
+      sessionKey: "agent:main:research",
+      message: "Investigate",
+      wakeOnReply: true,
+      timeoutSeconds: 5,
+    });
+    const watched = await tool.execute("call-deferred-watch", {
+      sessionKey: "agent:main:research",
+      message: "Investigate",
+      wakeOnReply: true,
+      watch: true,
+    });
+
+    expect(requireDetails(waited).error).toContain("non-zero timeoutSeconds");
+    expect(requireDetails(watched).error).toContain("cannot be combined with watch");
+    expect(callGatewayMock).not.toHaveBeenCalled();
+    expect(deferredCompletionMocks.arm).not.toHaveBeenCalled();
   });
 
   it("returns an error when neither sessionKey nor label is provided", async () => {

--- a/src/gateway/server-methods/agent-run-dispatch.ts
+++ b/src/gateway/server-methods/agent-run-dispatch.ts
@@ -116,6 +116,14 @@ export function dispatchAgentRunFromGateway(params: {
     terminalOutcome: AgentRunTerminalOutcome;
     onRecovered?: () => void;
   }) => Promise<boolean> | boolean;
+  onBeforeTerminalSettlement?: (outcome: {
+    terminalOutcome: AgentRunTerminalOutcome;
+    result?: unknown;
+  }) => Promise<void> | void;
+  onTerminal?: (outcome: {
+    terminalOutcome: AgentRunTerminalOutcome;
+    result?: unknown;
+  }) => Promise<void> | void;
 }) {
   const shouldTrackTask = params.taskTrackingMode === "cli";
   let taskTracked = false;
@@ -160,6 +168,38 @@ export function dispatchAgentRunFromGateway(params: {
       );
       return false;
     }
+  };
+  const notifyTerminal = async (outcome: {
+    terminalOutcome: AgentRunTerminalOutcome;
+    result?: unknown;
+  }): Promise<void> => {
+    try {
+      await params.onTerminal?.(outcome);
+    } catch (error) {
+      params.context.logGateway.warn(
+        `failed to process agent terminal observer ${params.runId}: ${formatForLog(error)}`,
+      );
+    }
+  };
+  const prepareTerminalSettlement = async (outcome: {
+    terminalOutcome: AgentRunTerminalOutcome;
+    result?: unknown;
+  }): Promise<boolean> => {
+    try {
+      await params.onBeforeTerminalSettlement?.(outcome);
+      return true;
+    } catch (error) {
+      params.context.logGateway.warn(
+        `failed to persist pre-settlement agent terminal state ${params.runId}: ${formatForLog(error)}`,
+      );
+      return false;
+    }
+  };
+  const respondTerminalPreparationFailure = () => {
+    const summary = "failed to persist pre-settlement agent terminal state";
+    const error = errorShape(ErrorCodes.UNAVAILABLE, summary);
+    const payload = { runId: params.runId, status: "error" as const, summary };
+    params.respond(false, payload, error, { runId: params.runId, error: summary });
   };
   void agentCommandFromGatewayIngress(params.ingressOpts, defaultRuntime, params.context.deps, {
     restoreAdmittedRecovery: params.restoreAdmittedRecovery,
@@ -237,7 +277,12 @@ export function dispatchAgentRunFromGateway(params: {
           },
         });
       };
+      if (!(await prepareTerminalSettlement({ terminalOutcome, result }))) {
+        respondTerminalPreparationFailure();
+        return;
+      }
       const settled = await settle({ terminalOutcome, onRecovered: persistTerminalDedupe });
+      await notifyTerminal({ terminalOutcome, result });
       if (!settled) {
         const summary = "failed to persist cron continuation settlement";
         const error = errorShape(ErrorCodes.UNAVAILABLE, summary);
@@ -305,10 +350,15 @@ export function dispatchAgentRunFromGateway(params: {
           },
         });
       };
+      if (!(await prepareTerminalSettlement({ terminalOutcome }))) {
+        respondTerminalPreparationFailure();
+        return;
+      }
       const settled = await settle({
         terminalOutcome,
         onRecovered: () => persistTerminalDedupe(true),
       });
+      await notifyTerminal({ terminalOutcome });
       persistTerminalDedupe(settled);
       params.respond(aborted && settled, payload, aborted && settled ? undefined : error, {
         runId: params.runId,

--- a/src/gateway/server-methods/agent-run-execution-phase.ts
+++ b/src/gateway/server-methods/agent-run-execution-phase.ts
@@ -20,6 +20,11 @@ import {
   type MainSessionRecoveryOwnerLease,
 } from "../../agents/main-session-recovery-store.js";
 import { resolveScheduledToolPolicyContext } from "../../agents/scheduled-tool-policy.js";
+import {
+  dispatchPreparedSessionsSendDeferredCompletion,
+  finishSessionsSendDeferredContinuationAfterTranscript,
+  prepareSessionsSendDeferredCompletion,
+} from "../../agents/sessions-send-deferred.js";
 import { resolveIngressWorkspaceOverrideForSessionRun } from "../../agents/spawned-context.js";
 import {
   setChannelSourceTurnId,
@@ -306,6 +311,9 @@ export function startAgentRunExecution(params: {
                   `gateway agent user transcript persistence failed: ${formatForLog(error)}`,
                 );
               },
+              onMessagePersisted: () => {
+                finishSessionsSendDeferredContinuationAfterTranscript(params.runId);
+              },
             })
           : undefined;
 
@@ -352,6 +360,7 @@ export function startAgentRunExecution(params: {
         restartRecoveryChannelContext?.sameChannelThreadRequired,
       );
 
+      const deferredCompletionSessionKey = params.resolvedSessionKey;
       dispatchAgentRunFromGateway({
         ingressOpts: {
           message,
@@ -477,6 +486,24 @@ export function startAgentRunExecution(params: {
                 { terminalOutcome },
                 onRecovered,
               )
+          : undefined,
+        onBeforeTerminalSettlement: deferredCompletionSessionKey
+          ? async ({ terminalOutcome, result }) => {
+              prepareSessionsSendDeferredCompletion({
+                targetRunId: params.runId,
+                targetSessionKey: deferredCompletionSessionKey,
+                terminalOutcome,
+                result,
+              });
+            }
+          : undefined,
+        onTerminal: deferredCompletionSessionKey
+          ? async () => {
+              await dispatchPreparedSessionsSendDeferredCompletion({
+                targetRunId: params.runId,
+                targetSessionKey: deferredCompletionSessionKey,
+              });
+            }
           : undefined,
         respond: params.respond,
         context: params.context,

--- a/src/gateway/server-methods/agent.base.test-utils.ts
+++ b/src/gateway/server-methods/agent.base.test-utils.ts
@@ -4,12 +4,20 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ErrorCodes } from "../../../packages/gateway-protocol/src/index.js";
 import { isAgentRunRestartAbortReason } from "../../agents/run-termination.js";
+import { claimSessionsSendDeferredCompletion } from "../../agents/sessions-send-deferred-store.js";
+import {
+  armSessionsSendDeferredCompletion,
+  prepareSessionsSendDeferredCompletion,
+  testing as deferredCompletionTesting,
+} from "../../agents/sessions-send-deferred.js";
 import {
   beginSessionWorkAdmission,
   cancelSessionWorkAdmissionHandoff,
   interruptSessionWorkAdmissions,
   runExclusiveSessionLifecycleMutation,
 } from "../../sessions/session-lifecycle-admission.js";
+import type { UserTurnTranscriptRecorder } from "../../sessions/user-turn-transcript.js";
+import { closeOpenClawStateDatabase } from "../../state/openclaw-state-db.js";
 import { withTempDir } from "../../test-helpers/temp-dir.js";
 import { normalizeSessionDeliveryState } from "../../utils/delivery-context.shared.js";
 import {
@@ -44,7 +52,11 @@ import type { GatewayRequestContext } from "./types.js";
 const mocks = getAgentTestMocks();
 
 describe("gateway agent handler", () => {
-  afterEach(describe0AfterEach0);
+  afterEach(() => {
+    deferredCompletionTesting.resetPendingRunIds();
+    closeOpenClawStateDatabase();
+    describe0AfterEach0();
+  });
 
   it("passes resolved maintenance config to the gateway admission store write", async () => {
     primeMainAgentRun({
@@ -67,6 +79,71 @@ describe("gateway agent handler", () => {
         mode: "enforce",
         maxEntries: 42,
       },
+    });
+  });
+
+  it("retires a deferred dispatch when the accepted gateway turn becomes durable", async () => {
+    await withTempDir({ prefix: "openclaw-agent-deferred-admission-" }, async (root) => {
+      useTestStateDir(root);
+      closeOpenClawStateDatabase();
+      deferredCompletionTesting.resetPendingRunIds();
+      const targetRunId = "deferred-target-run";
+      const targetSessionKey = "agent:research:main";
+      armSessionsSendDeferredCompletion({
+        targetRunId,
+        targetSessionKey,
+        requesterSessionKey: "agent:main:main",
+        requesterSessionId: "existing-session-id",
+        requesterOrigin: { channel: "telegram", to: "123", accountId: "primary" },
+        requestMessage: "Research this",
+      });
+      prepareSessionsSendDeferredCompletion({
+        targetRunId,
+        targetSessionKey,
+        terminalOutcome: { status: "ok", reason: "completed" },
+        result: { payloads: [{ text: "Done" }] },
+      });
+      const claimed = claimSessionsSendDeferredCompletion({ targetRunId, targetSessionKey });
+      const continuationRunId = requireValue(
+        claimed?.continuationRunId,
+        "continuation run id missing",
+      );
+
+      primeMainAgentRun();
+      await invokeAgent(
+        {
+          message: "[Deferred sessions_send completion]",
+          agentId: "main",
+          sessionKey: "agent:main:main",
+          expectedExistingSessionId: "existing-session-id",
+          channel: "telegram",
+          to: "123",
+          accountId: "primary",
+          deliver: true,
+          idempotencyKey: continuationRunId,
+        },
+        { client: backendGatewayClient() },
+      );
+      const call = await waitForAgentCommandCall<
+        AgentCommandCall & { userTurnTranscriptRecorder?: UserTurnTranscriptRecorder }
+      >();
+      expect(claimSessionsSendDeferredCompletion({ targetRunId, targetSessionKey })).toBeDefined();
+
+      const recorder = requireValue(
+        call.userTurnTranscriptRecorder,
+        "gateway user turn recorder missing",
+      );
+      recorder.markRuntimePersisted({
+        role: "user",
+        content: "[Deferred sessions_send completion]",
+        timestamp: Date.now(),
+      });
+
+      expect(
+        claimSessionsSendDeferredCompletion({ targetRunId, targetSessionKey }),
+      ).toBeUndefined();
+      deferredCompletionTesting.resetPendingRunIds();
+      closeOpenClawStateDatabase();
     });
   });
 

--- a/src/gateway/server-methods/agent.sessions-and-models.test-utils.ts
+++ b/src/gateway/server-methods/agent.sessions-and-models.test-utils.ts
@@ -1207,6 +1207,98 @@ describe("gateway agent handler", () => {
     });
   });
 
+  it("prepares terminal state before settlement and dispatches after settlement", async () => {
+    const result = { payloads: [{ text: "target result" }], meta: { durationMs: 10 } };
+    mocks.agentCommand.mockResolvedValueOnce(result);
+    const context = makeContext();
+    const events: string[] = [];
+    const onBeforeTerminalSettlement = vi.fn(async () => {
+      events.push("prepare");
+    });
+    const onSettled = vi.fn(async () => {
+      events.push("settle");
+      return true;
+    });
+    const onTerminal = vi.fn(async () => {
+      events.push("dispatch");
+    });
+    const respond = vi.fn(() => {
+      events.push("respond");
+    });
+
+    dispatchAgentRunFromGateway({
+      ingressOpts: {
+        message: "deferred target task",
+        sessionKey: "agent:research:main",
+        allowModelOverride: false,
+      },
+      runId: "agent-run-terminal-observer",
+      dedupeKeys: ["agent:agent-run-terminal-observer"],
+      abortController: new AbortController(),
+      cleanupAbortController: vi.fn(),
+      respond,
+      context,
+      taskTrackingMode: "none",
+      onBeforeTerminalSettlement,
+      onSettled,
+      onTerminal,
+    });
+
+    await waitForAssertion(() => {
+      expect(onBeforeTerminalSettlement).toHaveBeenCalledWith({
+        terminalOutcome: { reason: "completed", status: "ok" },
+        result,
+      });
+      expect(onTerminal).toHaveBeenCalledWith({
+        terminalOutcome: { reason: "completed", status: "ok" },
+        result,
+      });
+      expect(respond).toHaveBeenCalled();
+      expect(events).toEqual(["prepare", "settle", "dispatch", "respond"]);
+    });
+  });
+
+  it("does not settle when pre-settlement terminal persistence fails", async () => {
+    mocks.agentCommand.mockResolvedValueOnce({ payloads: [{ text: "target result" }] });
+    const context = makeContext();
+    const onSettled = vi.fn();
+    const onTerminal = vi.fn();
+    const respond = vi.fn();
+
+    dispatchAgentRunFromGateway({
+      ingressOpts: {
+        message: "deferred target task",
+        sessionKey: "agent:research:main",
+        allowModelOverride: false,
+      },
+      runId: "agent-run-terminal-prepare-failure",
+      dedupeKeys: ["agent:agent-run-terminal-prepare-failure"],
+      abortController: new AbortController(),
+      cleanupAbortController: vi.fn(),
+      respond,
+      context,
+      taskTrackingMode: "none",
+      onBeforeTerminalSettlement: async () => {
+        throw new Error("state database unavailable");
+      },
+      onSettled,
+      onTerminal,
+    });
+
+    await waitForAssertion(() => {
+      expect(respond).toHaveBeenCalledWith(
+        false,
+        expect.objectContaining({
+          summary: "failed to persist pre-settlement agent terminal state",
+        }),
+        expect.anything(),
+        expect.anything(),
+      );
+    });
+    expect(onSettled).not.toHaveBeenCalled();
+    expect(onTerminal).not.toHaveBeenCalled();
+  });
+
   it("does not overwrite operator-cancelled async gateway agent tasks after late completion", async () => {
     await withTempDir({ prefix: "openclaw-gateway-agent-task-cancelled-" }, async (root) => {
       useTestStateDir(root);

--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -39,6 +39,10 @@ const hoisted = vi.hoisted(() => {
     skipped: 0,
   }));
   const scheduleRestartAbortedMainSessionRecovery = vi.fn();
+  const recoverSessionsSendDeferredCompletions = vi.fn(async () => ({
+    recovered: 0,
+    failed: 0,
+  }));
   const scheduleRestartSentinelWake =
     vi.fn<typeof import("./server-restart-sentinel.js").scheduleRestartSentinelWake>();
   const refreshLatestUpdateRestartSentinel = vi.fn<
@@ -95,6 +99,7 @@ const hoisted = vi.hoisted(() => {
     scheduleSubagentRegistrySweep,
     markStartupOrphanedMainSessionsForRecovery,
     scheduleRestartAbortedMainSessionRecovery,
+    recoverSessionsSendDeferredCompletions,
     scheduleRestartSentinelWake,
     refreshLatestUpdateRestartSentinel,
     getAcpRuntimeBackend,
@@ -131,6 +136,10 @@ vi.mock("../agents/main-session-restart-recovery-marking.js", () => ({
 
 vi.mock("../agents/main-session-restart-recovery.js", () => ({
   scheduleRestartAbortedMainSessionRecovery: hoisted.scheduleRestartAbortedMainSessionRecovery,
+}));
+
+vi.mock("../agents/sessions-send-deferred.js", () => ({
+  recoverSessionsSendDeferredCompletions: hoisted.recoverSessionsSendDeferredCompletions,
 }));
 
 vi.mock("../config/paths.js", async () => {
@@ -344,6 +353,8 @@ describe("startGatewayPostAttachRuntime", () => {
       skipped: 0,
     });
     hoisted.scheduleRestartAbortedMainSessionRecovery.mockClear();
+    hoisted.recoverSessionsSendDeferredCompletions.mockReset();
+    hoisted.recoverSessionsSendDeferredCompletions.mockResolvedValue({ recovered: 0, failed: 0 });
     hoisted.scheduleRestartSentinelWake.mockClear();
     hoisted.refreshLatestUpdateRestartSentinel.mockReset();
     hoisted.refreshLatestUpdateRestartSentinel.mockResolvedValue(null);
@@ -392,12 +403,17 @@ describe("startGatewayPostAttachRuntime", () => {
     const unavailableGatewayMethods = new Set<string>(["chat.history", "models.list"]);
     const methodsAtRecoveryRegistration: string[][] = [];
     const currentConfig = { agents: { list: [{ id: "main" }, { id: "work" }] } };
+    const methodsAtDeferredRecovery: string[][] = [];
     hoisted.scheduleRestartAbortedMainSessionRecovery.mockImplementationOnce(
       (params: { getConfig: () => unknown }) => {
         methodsAtRecoveryRegistration.push([...unavailableGatewayMethods]);
         expect(params.getConfig()).toBe(currentConfig);
       },
     );
+    hoisted.recoverSessionsSendDeferredCompletions.mockImplementationOnce(async () => {
+      methodsAtDeferredRecovery.push([...unavailableGatewayMethods]);
+      return { recovered: 0, failed: 0 };
+    });
     const onSidecarsReady = vi.fn();
     const log = { info: vi.fn(), warn: vi.fn() };
 
@@ -411,6 +427,7 @@ describe("startGatewayPostAttachRuntime", () => {
 
     await waitForGatewayTestState(() => {
       expect(onSidecarsReady).toHaveBeenCalledTimes(1);
+      expect(hoisted.recoverSessionsSendDeferredCompletions).toHaveBeenCalledTimes(1);
     });
     expect([...unavailableGatewayMethods]).toStrictEqual([]);
     expect(hoisted.startPluginServices).toHaveBeenCalledTimes(1);
@@ -433,6 +450,7 @@ describe("startGatewayPostAttachRuntime", () => {
     });
     expect(hoisted.scheduleSubagentRegistrySweep).toHaveBeenCalledWith();
     expect(methodsAtRecoveryRegistration).toStrictEqual([["chat.history", "models.list"]]);
+    expect(methodsAtDeferredRecovery).toStrictEqual([[]]);
     expect(hoisted.startGatewayMemoryBackend).not.toHaveBeenCalled();
   });
 

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -66,6 +66,10 @@ const loadMainSessionRestartRecoveryMarkingModule = createLazyRuntimeModule(
   () => import("../agents/main-session-restart-recovery-marking.js"),
 );
 
+const loadSessionsSendDeferredModule = createLazyRuntimeModule(
+  () => import("../agents/sessions-send-deferred.js"),
+);
+
 const loadAgentDefaultsModule = createLazyRuntimeModule(() => import("../agents/defaults.js"));
 
 const loadAgentModelSelectionModule = createLazyRuntimeModule(
@@ -1313,6 +1317,18 @@ export async function startGatewayPostAttachRuntime(
         for (const method of STARTUP_UNAVAILABLE_GATEWAY_METHODS) {
           params.unavailableGatewayMethods.delete(method);
         }
+        void loadSessionsSendDeferredModule()
+          .then(async ({ recoverSessionsSendDeferredCompletions }) => {
+            const recoveryResult = await recoverSessionsSendDeferredCompletions();
+            if (recoveryResult.failed > 0) {
+              params.log.warn(
+                `sessions_send deferred recovery left ${recoveryResult.failed} continuation(s) pending`,
+              );
+            }
+          })
+          .catch((err: unknown) => {
+            params.log.warn(`sessions_send deferred recovery failed: ${String(err)}`);
+          });
         if (!pluginServicesReported) {
           reportPluginServices(result.pluginServices);
         }

--- a/src/state/openclaw-state-db-contract.ts
+++ b/src/state/openclaw-state-db-contract.ts
@@ -9,6 +9,7 @@ export const OPENCLAW_STATE_STRICT_SCHEMA_VERSION = 3;
 // lazy ensures run; fold them into the next natural schema-version bump.
 export const LAZY_ADDITIVE_STATE_TABLES = [
   "model_catalog_remote",
+  "sessions_send_deferred_completions",
   "sidebar_sections",
   "skill_workshop_proposal_events",
   "skill_workshop_proposal_origin_runs",

--- a/src/state/openclaw-state-db.generated.d.ts
+++ b/src/state/openclaw-state-db.generated.d.ts
@@ -1081,6 +1081,24 @@ export interface SessionWatchCursors {
   watcher_session_key: string;
 }
 
+export interface SessionsSendDeferredCompletions {
+  claimed_at: number | null;
+  completed_at: number | null;
+  completion_text: string | null;
+  continuation_run_id: string;
+  created_at: number;
+  expires_at: number;
+  last_error: string | null;
+  request_message: string;
+  requester_origin_json: string;
+  requester_session_id: string;
+  requester_session_key: string;
+  state: string;
+  target_run_id: string;
+  target_session_key: string;
+  terminal_outcome_json: string | null;
+}
+
 export interface SidebarSections {
   position: number;
   section_id: string;
@@ -1622,6 +1640,7 @@ export interface DB {
   session_state_heads: SessionStateHeads;
   session_upstream_links: SessionUpstreamLinks;
   session_watch_cursors: SessionWatchCursors;
+  sessions_send_deferred_completions: SessionsSendDeferredCompletions;
   sidebar_sections: SidebarSections;
   skill_curator_state: SkillCuratorState;
   skill_lifecycle: SkillLifecycle;

--- a/src/state/openclaw-state-schema.sql
+++ b/src/state/openclaw-state-schema.sql
@@ -1064,6 +1064,24 @@ CREATE INDEX IF NOT EXISTS idx_plugin_state_expiry
 CREATE INDEX IF NOT EXISTS idx_plugin_state_listing
   ON plugin_state_entries(plugin_id, namespace, created_at, entry_key);
 
+CREATE TABLE IF NOT EXISTS sessions_send_deferred_completions (
+  target_run_id TEXT NOT NULL PRIMARY KEY,
+  target_session_key TEXT NOT NULL,
+  requester_session_key TEXT NOT NULL,
+  requester_session_id TEXT NOT NULL,
+  requester_origin_json TEXT NOT NULL,
+  request_message TEXT NOT NULL,
+  continuation_run_id TEXT NOT NULL UNIQUE,
+  state TEXT NOT NULL CHECK (state IN ('pending', 'dispatching', 'completed', 'cancelled', 'expired')),
+  created_at INTEGER NOT NULL,
+  expires_at INTEGER NOT NULL,
+  claimed_at INTEGER,
+  completed_at INTEGER,
+  terminal_outcome_json TEXT,
+  completion_text TEXT,
+  last_error TEXT
+) STRICT;
+
 CREATE TABLE IF NOT EXISTS channel_ingress_events (
   queue_name TEXT NOT NULL,
   event_id TEXT NOT NULL,


### PR DESCRIPTION
Closes #112372

## What Problem This Solves

Adds opt-in `wakeOnReply: true` behavior to `sessions_send`. The tool returns after target dispatch, then resumes the exact requesting session incarnation and captured ingress route when that target run succeeds or fails.

## Why

An agent can currently delegate work and return from the tool call, but it cannot durably express “my user is waiting for this particular result.” Legacy A2A announce behavior is not correlated to one target run or pinned to the exact requester route, so the user may not hear the result until another inbound turn wakes the requester.

## Changes

- Add opt-in `wakeOnReply` tool contract
- Register completion before target dispatch
- Persist terminal payload before target settlement
- Replay prepared and interrupted dispatches at startup
- Reuse one stable continuation idempotency key
- Retire dispatch only after transcript persistence
- Hand accepted restarts to session recovery
- Pin session incarnation and complete delivery context
- Require explicit captured channel account
- Lazily add deferred state on existing databases
- Suppress legacy A2A flow for opted-in calls
- Preserve all omitted-option behavior

## Safety And Recovery

The model cannot provide a return destination. OpenClaw captures the requester session ID and normalized `DeliveryContext` from trusted runtime state. Registration fails if the external origin does not contain an explicit `channel`, `to`, and `accountId`; continuation dispatch therefore cannot substitute a provider-default account.

The target terminal payload is written while the registration remains `pending`, before the target is allowed to settle. After settlement, dispatch changes the row to `dispatching`. Gateway acceptance does not complete that row. The row is retired only after the continuation's user turn is durably written to the exact requester transcript.

Gateway startup reconciles both prepared `pending` rows and interrupted `dispatching` rows. If the exact requester session incarnation owns the continuation run ID and its transcript contains that run's user turn, deferred recovery retires its row without another gateway call and leaves the existing main-session recovery system as the sole post-restart continuation owner. If no transcript turn exists, deferred recovery replays the dispatch with the same continuation ID. Durable-ownership inspection failure suppresses dispatch and leaves the row available for a later recovery attempt.

Persistence failure before target settlement prevents settlement. Ambiguous continuation dispatch failure remains durable and restart-replayable. Completed, expired, explicitly cancelled, or mismatched state produces no new continuation. Required delivery and `expectedExistingSessionId` prevent route or incarnation fallback.

This is not a general durable outbound outbox. It provides durable target-result correlation and coordinates accepted continuation ownership with OpenClaw's existing main-session restart recovery for this opt-in `sessions_send` path.

## Evidence

Current head `16ccee3e2f2b`, rebased onto `openclaw/main` at `9faf34d3bcb`:

- `pnpm test src/agents/sessions-send-deferred.test.ts src/agents/tools/sessions.test.ts src/gateway/server-startup-post-attach.test.ts`
  - Passed 168 tests across three repository-routed Vitest shards in an isolated Node 24 container.
- `pnpm tsgo:core`
  - Passed the production source typecheck.
- Focused test typecheck for the three changed test files
  - Passed against the repository test tsconfig and ambient declarations.
- `pnpm format:check <changed files>` and `node scripts/run-oxlint.mjs <changed files>`
  - Passed with zero formatting errors, lint errors, or warnings.
- `node scripts/generate-kysely-types.mjs --verify` and `git diff --check`
  - Passed after the rebase.

The previous head also passed `check:changed`, the build, the full test type graph, and 363 focused agent/gateway tests. Those broader results predate the current-main rebase; current CI is the broad validation source for this head.

Regression coverage includes:

- prepared completion recovery after restart
- claimed dispatch recovery after restart
- accepted-before-retirement handoff to session recovery
- exactly one post-restart model continuation admission
- claim without transcript remains replayable
- gateway transcript persistence retires the dispatch
- stable idempotency after ambiguous dispatch failure
- pre-settlement persistence failure blocking settlement
- startup replay after gateway methods become available
- lazy table creation on an existing current-schema database
- explicit account preservation and no default substitution
- exact requester session ID and route capture
- target success and terminal failure
- duplicate, mismatched, cancelled, and expired state
- concurrent requester origins
- incompatible tool options
- omitted-option compatibility
- legacy A2A suppression for opted-in calls

Not yet run: a live two-agent channel round trip using `wakeOnReply`. This remains a draft for external design review before live proof.

<details>
<summary>Redacted AI-assisted decision transcript</summary>

This PR is AI-assisted. The author reviewed the implementation and validation and can explain the code.

**User need:** “We do not want to destroy wake in the channel you asked. We want a setting for ‘my user is expecting me to come back with an answer.’”

**Agreed contract:** make the behavior opt-in on `sessions_send`; return after the target run is accepted; do not expose the target result to the initiating turn; resume the exact requester session incarnation and ingress route on target success or terminal failure; suppress legacy A2A ping-pong/announce only for that call; never use a fallback destination.

**Review corrections:** persist the completion payload before target settlement; reconcile both prepared and interrupted dispatches after restart; reject external origins without a canonical account so ordinary delivery cannot choose a provider default; and keep an accepted dispatch durable until transcript persistence transfers restart ownership to the existing main-session recovery system.

The optional `autoreview` skill was not run. Direct diff review and the repository gates listed above were run instead.

</details>

## Review Focus

- Whether pre-settlement persistence plus startup reconciliation is the correct durability boundary.
- Whether transcript persistence plus the exact restart-recovery claim is the correct ownership-transfer boundary after gateway acceptance.
- Whether the feature-local lazy table lifecycle is the correct additive upgrade path.
- Whether requiring an explicit captured account is appropriate for every external ingress adapter.
