### PR TITLE
fix(ui): show session name in browser title

### DIFF
--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -687,6 +687,7 @@ class OpenClawShell extends OpenClawLightDomElement {
     this.agentsListSource = null;
     this.sessionKeyClient = null;
     this.activeSessionTitleRow = null;
+    syncControlUiDocumentTitle({ sessionKey: null });
     this.runtimeConfigClient = null;
     this.runtimeConfigSource = null;
     if (this.agentRosterRefreshTimer !== null) {

--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -8,7 +8,7 @@ import {
   hasStoredGatewayAuth,
   type GatewayBrowserClient,
 } from "../api/gateway.ts";
-import type { GatewayAgentRow } from "../api/types.ts";
+import type { GatewayAgentRow, GatewaySessionRow } from "../api/types.ts";
 import "../components/app-sidebar.ts";
 import "../components/app-topbar.ts";
 import "../components/connection-banner.ts";
@@ -44,9 +44,11 @@ import { renderSettingsSidebar } from "../components/settings-sidebar.ts";
 import type { ThemeModeChangeDetail } from "../components/theme-mode-toggle.ts";
 import { i18n, isSupportedLocale, t } from "../i18n/index.ts";
 import { copyToClipboard } from "../lib/clipboard.ts";
+import { syncControlUiDocumentTitle } from "../lib/document-title.ts";
 import { isGatewayMethodAdvertised } from "../lib/gateway-methods.ts";
 import { isWorkboardEnabledInConfigSnapshot } from "../lib/plugin-activation.ts";
 import { searchForSession } from "../lib/sessions/index.ts";
+import { areUiSessionKeysEquivalent } from "../lib/sessions/session-key.ts";
 import { isTerminalAvailable } from "../lib/terminal-availability.ts";
 import "../lib/toast.ts";
 import { OpenClawLightDomElement } from "../lit/openclaw-element.ts";
@@ -492,6 +494,7 @@ class OpenClawShell extends OpenClawLightDomElement {
   private agentsListClient: GatewayBrowserClient | null = null;
   private agentsListSource: ApplicationContext["agents"] | null = null;
   private sessionKeyClient: GatewayBrowserClient | null = null;
+  private activeSessionTitleRow: GatewaySessionRow | null = null;
   private runtimeConfigClient: GatewayBrowserClient | null = null;
   private runtimeConfigSource: ApplicationContext["runtimeConfig"] | null = null;
   private agentRosterRefreshTimer: ReturnType<typeof globalThis.setTimeout> | null = null;
@@ -534,6 +537,10 @@ class OpenClawShell extends OpenClawLightDomElement {
         () => this.context?.gateway,
         (gateway, notify) => gateway.subscribe(notify),
         (gateway) => this.synchronizeGateway(gateway.snapshot),
+      )
+      .watch(
+        () => this.context?.sessions,
+        (sessions, notify) => sessions.subscribe(notify),
       )
       .effect(
         () => this.context?.gateway,
@@ -679,6 +686,7 @@ class OpenClawShell extends OpenClawLightDomElement {
     this.agentsListClient = null;
     this.agentsListSource = null;
     this.sessionKeyClient = null;
+    this.activeSessionTitleRow = null;
     this.runtimeConfigClient = null;
     this.runtimeConfigSource = null;
     if (this.agentRosterRefreshTimer !== null) {
@@ -1205,6 +1213,7 @@ class OpenClawShell extends OpenClawLightDomElement {
   }
 
   override updated() {
+    this.syncDocumentTitle();
     const context = this.context;
     if (!context) {
       return;
@@ -1240,6 +1249,30 @@ class OpenClawShell extends OpenClawLightDomElement {
     this.updateGatewaySessionKey(snapshot);
     this.ensureAgentsList(snapshot);
     this.ensureRuntimeConfig(snapshot);
+  }
+
+  private syncDocumentTitle(): void {
+    const sessionsResult = this.context?.sessions.state.result ?? null;
+    const activeSessionRow = this.findActiveSessionTitleRow(sessionsResult?.sessions);
+    if (activeSessionRow) {
+      this.activeSessionTitleRow = activeSessionRow;
+    }
+    syncControlUiDocumentTitle({
+      sessionKey: this.activeSessionKey,
+      sessionsResult,
+      activeSessionTitleRow: this.activeSessionTitleRow,
+    });
+  }
+
+  private findActiveSessionTitleRow(
+    rows: GatewaySessionRow[] | undefined,
+  ): GatewaySessionRow | null {
+    const sessionKey = this.activeSessionKey;
+    return (
+      rows?.find((row) => row.key === sessionKey) ??
+      rows?.find((row) => areUiSessionKeysEquivalent(row.key, sessionKey)) ??
+      null
+    );
   }
 
   private ensureRuntimeConfig(

--- a/ui/src/lib/document-title.test.ts
+++ b/ui/src/lib/document-title.test.ts
@@ -99,6 +99,36 @@ describe("resolveControlUiDocumentTitle", () => {
       }),
     ).toBe(CONTROL_UI_DOCUMENT_TITLE);
   });
+
+  it("falls back to the derived title when label and display name are absent", () => {
+    expect(
+      resolveControlUiDocumentTitle({
+        sessionKey: "agent:main:dashboard:uuid",
+        sessionsResult: sessionsResult([
+          sessionRow({
+            key: "agent:main:dashboard:uuid",
+            kind: "global",
+            derivedTitle: "Quarterly launch plan",
+          }),
+        ]),
+      }),
+    ).toBe("Quarterly launch plan - OpenClaw Control");
+  });
+
+  it("ignores a derived title that is the raw session key", () => {
+    expect(
+      resolveControlUiDocumentTitle({
+        sessionKey: "agent:main:dashboard:uuid",
+        sessionsResult: sessionsResult([
+          sessionRow({
+            key: "agent:main:dashboard:uuid",
+            kind: "global",
+            derivedTitle: "agent:main:dashboard:uuid",
+          }),
+        ]),
+      }),
+    ).toBe(CONTROL_UI_DOCUMENT_TITLE);
+  });
 });
 
 describe("syncControlUiDocumentTitle", () => {

--- a/ui/src/lib/document-title.test.ts
+++ b/ui/src/lib/document-title.test.ts
@@ -1,0 +1,132 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { GatewaySessionRow, SessionsListResult } from "../api/types.ts";
+import {
+  CONTROL_UI_DOCUMENT_TITLE,
+  resolveControlUiDocumentTitle,
+  syncControlUiDocumentTitle,
+} from "./document-title.ts";
+
+function sessionsResult(sessions: GatewaySessionRow[]): SessionsListResult {
+  return {
+    ts: 1,
+    path: "/api/sessions",
+    count: sessions.length,
+    defaults: {
+      modelProvider: null,
+      model: null,
+      contextTokens: null,
+    },
+    sessions,
+  };
+}
+
+function sessionRow(row: Partial<GatewaySessionRow> & { key: string }): GatewaySessionRow {
+  return {
+    kind: "unknown",
+    updatedAt: 1,
+    ...row,
+  };
+}
+
+describe("resolveControlUiDocumentTitle", () => {
+  it("keeps the base title when no session is selected", () => {
+    expect(resolveControlUiDocumentTitle({ sessionKey: "" })).toBe(CONTROL_UI_DOCUMENT_TITLE);
+  });
+
+  it("includes the active session label before the app title", () => {
+    expect(
+      resolveControlUiDocumentTitle({
+        sessionKey: "agent:main:session-1",
+        sessionsResult: sessionsResult([
+          sessionRow({ key: "agent:main:session-1", label: "Release triage" }),
+        ]),
+      }),
+    ).toBe("Release triage - OpenClaw Control");
+  });
+
+  it("uses preserved active session metadata when the refreshed list omits the session", () => {
+    expect(
+      resolveControlUiDocumentTitle({
+        sessionKey: "agent:main:searched",
+        sessionsResult: sessionsResult([
+          sessionRow({ key: "agent:main:other", label: "Other session" }),
+        ]),
+        activeSessionTitleRow: sessionRow({
+          key: "agent:main:searched",
+          label: "Searched archive",
+        }),
+      }),
+    ).toBe("Searched archive - OpenClaw Control");
+  });
+
+  it("falls back to a non-generated display name", () => {
+    expect(
+      resolveControlUiDocumentTitle({
+        sessionKey: "agent:main:subagent:abc-123",
+        sessionsResult: sessionsResult([
+          sessionRow({ key: "agent:main:subagent:abc-123", displayName: "Task Runner" }),
+        ]),
+      }),
+    ).toBe("Subagent: Task Runner - OpenClaw Control");
+  });
+
+  it("keeps the base title when label metadata is the raw session key", () => {
+    expect(
+      resolveControlUiDocumentTitle({
+        sessionKey: "agent:main:imessage:direct:+49123456789",
+        sessionsResult: sessionsResult([
+          sessionRow({
+            key: "agent:main:imessage:direct:+49123456789",
+            label: "agent:main:imessage:direct:+49123456789",
+          }),
+        ]),
+      }),
+    ).toBe(CONTROL_UI_DOCUMENT_TITLE);
+  });
+
+  it("does not use generated direct conversation display names as titles", () => {
+    expect(
+      resolveControlUiDocumentTitle({
+        sessionKey: "agent:main:telegram:direct:42",
+        sessionsResult: sessionsResult([
+          sessionRow({
+            key: "agent:main:telegram:direct:42",
+            kind: "direct",
+            displayName: "Telegram Contact",
+          }),
+        ]),
+      }),
+    ).toBe(CONTROL_UI_DOCUMENT_TITLE);
+  });
+});
+
+describe("syncControlUiDocumentTitle", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("does nothing outside the browser", () => {
+    expect(() =>
+      syncControlUiDocumentTitle({
+        sessionKey: "agent:main:session-1",
+        sessionsResult: sessionsResult([
+          sessionRow({ key: "agent:main:session-1", label: "Release triage" }),
+        ]),
+      }),
+    ).not.toThrow();
+  });
+
+  it("updates document.title when it changes", () => {
+    vi.stubGlobal("document", { title: CONTROL_UI_DOCUMENT_TITLE });
+
+    syncControlUiDocumentTitle({
+      sessionKey: "agent:main:session-1",
+      sessionsResult: sessionsResult([
+        sessionRow({ key: "agent:main:session-1", label: "Release triage" }),
+      ]),
+    });
+
+    expect(document.title).toBe("Release triage - OpenClaw Control");
+  });
+});

--- a/ui/src/lib/document-title.ts
+++ b/ui/src/lib/document-title.ts
@@ -1,0 +1,104 @@
+import type { GatewaySessionRow, SessionsListResult } from "../api/types.ts";
+import { areUiSessionKeysEquivalent } from "./sessions/session-key.ts";
+import { normalizeOptionalString } from "./string-coerce.ts";
+
+export const CONTROL_UI_DOCUMENT_TITLE = "OpenClaw Control";
+
+type DocumentTitleState = {
+  sessionKey?: string | null;
+  activeSessionTitleRow?: GatewaySessionRow | null;
+  sessionsResult?: SessionsListResult | null;
+};
+
+function findExactSessionTitleRow(rows: GatewaySessionRow[] | undefined, sessionKey: string) {
+  return rows?.find((entry) => entry.key === sessionKey);
+}
+
+function findEquivalentSessionTitleRow(rows: GatewaySessionRow[] | undefined, sessionKey: string) {
+  return rows?.find((entry) => areUiSessionKeysEquivalent(entry.key, sessionKey));
+}
+
+function findSessionTitleRow(state: DocumentTitleState, sessionKey: string) {
+  const activeSessionTitleRow = state.activeSessionTitleRow;
+  return (
+    findExactSessionTitleRow(state.sessionsResult?.sessions, sessionKey) ??
+    findEquivalentSessionTitleRow(state.sessionsResult?.sessions, sessionKey) ??
+    (activeSessionTitleRow && areUiSessionKeysEquivalent(activeSessionTitleRow.key, sessionKey)
+      ? activeSessionTitleRow
+      : undefined)
+  );
+}
+
+function isRawSessionKeyTitle(value: string, rowKey: string, sessionKey: string): boolean {
+  return (
+    value === rowKey ||
+    value === sessionKey ||
+    areUiSessionKeysEquivalent(value, rowKey) ||
+    areUiSessionKeysEquivalent(value, sessionKey)
+  );
+}
+
+function isGeneratedConversationDisplayNameRow(row: GatewaySessionRow): boolean {
+  return (
+    row.kind === "direct" ||
+    row.kind === "group" ||
+    row.key.includes(":direct:") ||
+    row.key.includes(":group:") ||
+    row.key.includes(":channel:") ||
+    /^(?:direct|group|channel):/.test(row.key)
+  );
+}
+
+function applyTypedSessionPrefix(rowKey: string, title: string): string {
+  const prefix = rowKey.includes(":subagent:")
+    ? "Subagent:"
+    : rowKey.toLowerCase().startsWith("cron:") || rowKey.includes(":cron:")
+      ? "Cron:"
+      : "";
+  if (!prefix || title.toLowerCase().startsWith(prefix.toLowerCase())) {
+    return title;
+  }
+  return `${prefix} ${title}`;
+}
+
+function resolveSafeSessionTitle(row: GatewaySessionRow, sessionKey: string): string | null {
+  const label = normalizeOptionalString(row.label);
+  if (label && !isRawSessionKeyTitle(label, row.key, sessionKey)) {
+    return applyTypedSessionPrefix(row.key, label);
+  }
+  const displayName = normalizeOptionalString(row.displayName);
+  if (
+    !displayName ||
+    isRawSessionKeyTitle(displayName, row.key, sessionKey) ||
+    isGeneratedConversationDisplayNameRow(row)
+  ) {
+    return null;
+  }
+  return applyTypedSessionPrefix(row.key, displayName);
+}
+
+export function resolveControlUiDocumentTitle(state: DocumentTitleState): string {
+  const sessionKey = normalizeOptionalString(state.sessionKey);
+  if (!sessionKey) {
+    return CONTROL_UI_DOCUMENT_TITLE;
+  }
+  const row = findSessionTitleRow(state, sessionKey);
+  if (!row) {
+    return CONTROL_UI_DOCUMENT_TITLE;
+  }
+  const sessionName = resolveSafeSessionTitle(row, sessionKey);
+  if (!sessionName || sessionName === CONTROL_UI_DOCUMENT_TITLE) {
+    return CONTROL_UI_DOCUMENT_TITLE;
+  }
+  return `${sessionName} - ${CONTROL_UI_DOCUMENT_TITLE}`;
+}
+
+export function syncControlUiDocumentTitle(state: DocumentTitleState): void {
+  if (typeof document === "undefined") {
+    return;
+  }
+  const nextTitle = resolveControlUiDocumentTitle(state);
+  if (document.title !== nextTitle) {
+    document.title = nextTitle;
+  }
+}

--- a/ui/src/lib/document-title.ts
+++ b/ui/src/lib/document-title.ts
@@ -68,13 +68,17 @@ function resolveSafeSessionTitle(row: GatewaySessionRow, sessionKey: string): st
   }
   const displayName = normalizeOptionalString(row.displayName);
   if (
-    !displayName ||
-    isRawSessionKeyTitle(displayName, row.key, sessionKey) ||
-    isGeneratedConversationDisplayNameRow(row)
+    displayName &&
+    !isRawSessionKeyTitle(displayName, row.key, sessionKey) &&
+    !isGeneratedConversationDisplayNameRow(row)
   ) {
-    return null;
+    return applyTypedSessionPrefix(row.key, displayName);
   }
-  return applyTypedSessionPrefix(row.key, displayName);
+  const derivedTitle = normalizeOptionalString(row.derivedTitle);
+  if (derivedTitle && !isRawSessionKeyTitle(derivedTitle, row.key, sessionKey)) {
+    return applyTypedSessionPrefix(row.key, derivedTitle);
+  }
+  return null;
 }
 
 export function resolveControlUiDocumentTitle(state: DocumentTitleState): string {


### PR DESCRIPTION
Reviving #90577, which was closed while review feedback had already been addressed. Branch content unchanged (head 7749eef8).

---

## Summary
- Updates the Control UI browser tab title to include the active session name, for example `Release triage - OpenClaw Control`.
- Keeps the static `OpenClaw Control` title when no session is selected.
- Syncs the title when the active session changes or when refreshed session metadata updates labels/display names.

## Linked context
Which issue does this close?
Closes #

Which issues, PRs, or discussions are related?
None.

Was this requested by a maintainer or owner?
No. This came from user feedback while working with multiple parallel OpenClaw sessions where every tab showed the same `OpenClaw Control` title.

## Real behavior proof (required for external PRs)
- Behavior or issue addressed: Browser tabs for different Control UI sessions were indistinguishable because every tab used the static `OpenClaw Control` document title.
- Real environment tested: Control UI unit/runtime helpers in the OpenClaw repo on Windows, using the UI Vitest project and production UI build.
- Exact steps or command run after this patch:
  ```text
  node scripts\\run-vitest.mjs run ui\\src\\ui\\document-title.node.test.ts ui\\src\\ui\\app-lifecycle.node.test.ts
  cd ui && npm run build
  ```
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):
  ```text
  ui/src/ui/document-title.node.test.ts (6 tests) passed
  ui/src/ui/app-lifecycle.node.test.ts (8 tests) passed
  Tests 14 passed (14)
  vite build: 919 modules transformed, built successfully
  ```
- Observed result after fix: The title resolver produces session-specific titles like `Release triage - OpenClaw Control`, and lifecycle sync updates `document.title` when `sessionKey` or `sessionsResult` changes.
- What was not tested: A manual browser screenshot was not captured.
- Proof limitations or environment constraints: This is a UI behavior change validated with targeted UI tests and production build rather than a live browser recording.
- Before evidence (optional but encouraged): The static HTML title remains `<title>OpenClaw Control</title>`, and runtime code previously did not update `document.title` for the active session.

## Tests and validation

Which commands did you run?

```text
node scripts\\run-vitest.mjs run ui\\src\\ui\\document-title.node.test.ts ui\\src\\ui\\app-lifecycle.node.test.ts
cd ui && npm run build
```

What regression coverage was added or updated?

Added `document-title.node.test.ts` coverage for label, display name, fallback, and `document.title` sync behavior. Existing lifecycle tests were run to cover the integration point.

What failed before this fix, if known?

Parallel Control UI tabs all kept the static browser title `OpenClaw Control`, making sessions hard to distinguish.

If no test was added, why not?

A regression test was added.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)
Yes. Browser tab titles now include the active session name.

Did config, environment, or migration behavior change? (`Yes/No`)
No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)
No.

What is the highest-risk area?

The highest-risk area is ensuring the document title stays in sync with session metadata without affecting chat state persistence.

How is that risk mitigated?

The change is isolated to a document-title helper and lifecycle sync on `sessionKey`/`sessionsResult` changes, with targeted tests plus an unchanged passing production build.

## Current review state

What is the next action?

Maintainer review and CI.

What is still waiting on author, maintainer, CI, or external proof?

Waiting on maintainer review and CI.

Which bot or reviewer comments were addressed?

None yet.
