### PR TITLE
fix: refresh vulnerable production dependencies

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   '@anthropic-ai/sdk': 0.109.1
   '@opentelemetry/core': 2.9.0
+  '@opentelemetry/propagator-jaeger': 2.9.0
   '@aws-sdk/core': 3.974.27
   '@aws-sdk/credential-provider-node': 3.972.61
   '@aws-sdk/xml-builder': 3.972.33

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -99,6 +99,7 @@ blockExoticSubdeps: true
 overrides:
   "@anthropic-ai/sdk": 0.109.1
   "@opentelemetry/core": 2.9.0
+  "@opentelemetry/propagator-jaeger": 2.9.0
   "@aws-sdk/core": 3.974.27
   "@aws-sdk/credential-provider-node": 3.972.61
   "@aws-sdk/xml-builder": 3.972.33


### PR DESCRIPTION
## Summary
- override `fast-uri` to 3.1.3 to clear GHSA-4c8g-83qw-93j6
- override `@opentelemetry/propagator-jaeger` to 2.9.0 to clear GHSA-45rx-2jwx-cxfr
- regenerate affected npm shrinkwrap files

## What Problem This Solves
Production dependency audit started failing on upstream `main` for two high-severity advisories that are unrelated to the SQLite WAL guard PR. This refreshes the vulnerable production dependency resolutions so `security-fast` can pass again and dependent validation can resume.

## Evidence
- `git diff --check`
- `node scripts/pre-commit/pnpm-audit-prod.mjs --audit-level=high` -> `No high or higher advisories found for production dependencies.`
- `node scripts/generate-npm-shrinkwrap.mjs --all --check`
- `node node_modules/vitest/vitest.mjs run test/scripts/root-package-overrides.test.ts test/package-manager-config.test.ts`
- Hosted PR check `security-fast` is passing on this branch.

GitLab tracker: https://gitlab.com/xrow-public/helm-openclaw/-/work_items/45