### PR TITLE
fix: onboarding app-scan spinner floods the terminal when its label wraps

### DIFF
--- a/src/wizard/clack-prompter.test.ts
+++ b/src/wizard/clack-prompter.test.ts
@@ -150,7 +150,7 @@ describe("tokenizedOptionFilter", () => {
 });
 
 describe("createClackPrompter", () => {
-  it("clamps long progress labels by display width without splitting UTF-16 pairs", () => {
+  it("clamps long progress labels by display width without splitting grapheme clusters", () => {
     stubStdoutColumns(20);
     const prompter = createClackPrompter();
 
@@ -167,6 +167,35 @@ describe("createClackPrompter", () => {
       expect.objectContaining({ label: "12345678😀ABC" }),
     );
     expect(osc.setLabel).toHaveBeenCalledWith("正在扫描已安装应用…");
+  });
+
+  it("preserves emoji joined by zero-width joiners when truncating", () => {
+    stubStdoutColumns(14);
+    const prompter = createClackPrompter();
+
+    prompter.progress("👨‍👩‍👧‍👦ABCDEFGH");
+
+    const spin = clackMocks.spinner.mock.results[0]!.value;
+    expect(spin.start).toHaveBeenCalledWith(theme.accent("👨‍👩‍👧‍👦A…"));
+  });
+
+  it("shrinks active progress labels without expanding past the initial width", () => {
+    stubStdoutColumns(20);
+    const initialResizeListeners = process.stdout.listenerCount("resize");
+    const prompter = createClackPrompter();
+
+    const progress = prompter.progress("123456789ABC");
+    stubStdoutColumns(14);
+    process.stdout.emit("resize");
+    stubStdoutColumns(30);
+    process.stdout.emit("resize");
+    progress.update("ABCDEFGHIJK");
+    progress.stop();
+
+    const spin = clackMocks.spinner.mock.results[0]!.value;
+    expect(spin.message).toHaveBeenNthCalledWith(1, theme.accent("123…"));
+    expect(spin.message).toHaveBeenNthCalledWith(2, theme.accent("ABC…"));
+    expect(process.stdout.listenerCount("resize")).toBe(initialResizeListeners);
   });
 
   it("leaves progress labels untouched when terminal columns are unavailable", () => {

--- a/src/wizard/clack-prompter.test.ts
+++ b/src/wizard/clack-prompter.test.ts
@@ -7,10 +7,22 @@ const themeMocks = vi.hoisted(() => ({
 }));
 
 const stdoutIsTTYDescriptor = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+const stdoutColumnsDescriptor = Object.getOwnPropertyDescriptor(process.stdout, "columns");
 
 function stubStdoutIsTTY(value: boolean): void {
   Object.defineProperty(process.stdout, "isTTY", { configurable: true, value });
 }
+
+function stubStdoutColumns(value: number | undefined): void {
+  Object.defineProperty(process.stdout, "columns", { configurable: true, value });
+}
+
+const cliProgressMocks = vi.hoisted(() => ({
+  createCliProgress: vi.fn(() => ({
+    done: vi.fn(),
+    setLabel: vi.fn(),
+  })),
+}));
 
 const clackMocks = vi.hoisted(() => ({
   autocomplete: vi.fn(),
@@ -67,6 +79,10 @@ vi.mock("@clack/prompts", () => ({
   text: clackMocks.text,
 }));
 
+vi.mock("../cli/progress.js", () => ({
+  createCliProgress: cliProgressMocks.createCliProgress,
+}));
+
 vi.mock("./clack-navigation-prompts.js", () => ({
   autocompleteMultiselectWithNavigationFooter:
     navigationPromptMocks.autocompleteMultiselectWithNavigationFooter,
@@ -90,6 +106,11 @@ afterEach(() => {
     Object.defineProperty(process.stdout, "isTTY", stdoutIsTTYDescriptor);
   } else {
     Reflect.deleteProperty(process.stdout, "isTTY");
+  }
+  if (stdoutColumnsDescriptor) {
+    Object.defineProperty(process.stdout, "columns", stdoutColumnsDescriptor);
+  } else {
+    Reflect.deleteProperty(process.stdout, "columns");
   }
   themeMocks.isRich.mockReturnValue(false);
   clackMocks.settings.actions = new Set(["left", "right"]);
@@ -129,6 +150,55 @@ describe("tokenizedOptionFilter", () => {
 });
 
 describe("createClackPrompter", () => {
+  it("clamps long progress labels by display width without splitting UTF-16 pairs", () => {
+    stubStdoutColumns(20);
+    const prompter = createClackPrompter();
+
+    const progress = prompter.progress("12345678😀ABC");
+    progress.update("正在扫描已安装应用…");
+    progress.stop("1234567890ABC");
+
+    const spin = clackMocks.spinner.mock.results[0]!.value;
+    const osc = cliProgressMocks.createCliProgress.mock.results[0]!.value;
+    expect(spin.start).toHaveBeenCalledWith(theme.accent("12345678…"));
+    expect(spin.message).toHaveBeenCalledWith(theme.accent("正在扫描…"));
+    expect(spin.stop).toHaveBeenCalledWith("1234567890ABC");
+    expect(cliProgressMocks.createCliProgress).toHaveBeenCalledWith(
+      expect.objectContaining({ label: "12345678😀ABC" }),
+    );
+    expect(osc.setLabel).toHaveBeenCalledWith("正在扫描已安装应用…");
+  });
+
+  it("leaves progress labels untouched when terminal columns are unavailable", () => {
+    stubStdoutColumns(undefined);
+    const prompter = createClackPrompter();
+
+    prompter.progress("1234567890ABC");
+
+    const spin = clackMocks.spinner.mock.results[0]!.value;
+    expect(spin.start).toHaveBeenCalledWith(theme.accent("1234567890ABC"));
+  });
+
+  it("leaves short progress labels untouched", () => {
+    stubStdoutColumns(20);
+    const prompter = createClackPrompter();
+
+    prompter.progress("Loading");
+
+    const spin = clackMocks.spinner.mock.results[0]!.value;
+    expect(spin.start).toHaveBeenCalledWith(theme.accent("Loading"));
+  });
+
+  it("uses an empty progress label when decoration consumes the terminal width", () => {
+    stubStdoutColumns(10);
+    const prompter = createClackPrompter();
+
+    prompter.progress("Loading");
+
+    const spin = clackMocks.spinner.mock.results[0]!.value;
+    expect(spin.start).toHaveBeenCalledWith(theme.accent(""));
+  });
+
   it("uses the claw spinner on rich interactive terminals", () => {
     stubStdoutIsTTY(true);
     vi.stubEnv("CI", "");

--- a/src/wizard/clack-prompter.ts
+++ b/src/wizard/clack-prompter.ts
@@ -16,7 +16,12 @@ import {
   text,
 } from "@clack/prompts";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
-import { stripAnsi } from "../../packages/terminal-core/src/ansi.js";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import {
+  stripAnsi,
+  truncateToVisibleWidth,
+  visibleWidth,
+} from "../../packages/terminal-core/src/ansi.js";
 import { note as emitNote } from "../../packages/terminal-core/src/note.js";
 import { styleSelectParams } from "../../packages/terminal-core/src/prompt-select-styled-params.js";
 import {
@@ -40,6 +45,23 @@ import { WizardCancelledError, WizardNavigationError } from "./prompts.js";
 // Same species as the pixel-mascot banner, compressed into a four-column
 // spinner for long-running wizard steps.
 const CLAW_SPINNER_FRAMES = ["(\\/)", "(||)", "(--)", "(||)"];
+const SPINNER_DECORATION_COLUMNS = 10;
+
+function clampProgressLabel(label: string): string {
+  const columns = process.stdout.columns;
+  if (typeof columns !== "number" || !Number.isFinite(columns) || columns <= 0) {
+    return label;
+  }
+  const maxLabelWidth = columns - SPINNER_DECORATION_COLUMNS;
+  if (maxLabelWidth <= 0) {
+    return "";
+  }
+  if (visibleWidth(label) <= maxLabelWidth) {
+    return label;
+  }
+  const utf16Cut = truncateUtf16Safe(label, maxLabelWidth - 1);
+  return `${truncateToVisibleWidth(utf16Cut, maxLabelWidth - 1)}…`;
+}
 
 // Clack-backed WizardPrompter implementation for interactive CLI setup. It
 // converts the generic wizard prompt contract into styled Clack prompts.
@@ -334,7 +356,9 @@ export function createClackPrompter(): WizardPrompter {
             styleFrame: theme.accent,
           })
         : spinner();
-      spin.start(theme.accent(label));
+      // Clack erases using bare-message wrapping but writes the frame and dots too.
+      // Keeping animated labels to one row prevents long scans from leaking a line each tick.
+      spin.start(theme.accent(clampProgressLabel(label)));
       const osc = createCliProgress({
         label,
         indeterminate: true,
@@ -345,7 +369,7 @@ export function createClackPrompter(): WizardPrompter {
       // display command progress outside the prompt line.
       return {
         update: (message) => {
-          spin.message(theme.accent(message));
+          spin.message(theme.accent(clampProgressLabel(message)));
           osc.setLabel(message);
         },
         stop: (message) => {

--- a/src/wizard/clack-prompter.ts
+++ b/src/wizard/clack-prompter.ts
@@ -16,7 +16,6 @@ import {
   text,
 } from "@clack/prompts";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
-import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import {
   stripAnsi,
   truncateToVisibleWidth,
@@ -47,9 +46,16 @@ import { WizardCancelledError, WizardNavigationError } from "./prompts.js";
 const CLAW_SPINNER_FRAMES = ["(\\/)", "(||)", "(--)", "(||)"];
 const SPINNER_DECORATION_COLUMNS = 10;
 
-function clampProgressLabel(label: string): string {
+function readProgressColumns(): number | undefined {
   const columns = process.stdout.columns;
   if (typeof columns !== "number" || !Number.isFinite(columns) || columns <= 0) {
+    return undefined;
+  }
+  return columns;
+}
+
+function clampProgressLabel(label: string, columns: number | undefined): string {
+  if (columns === undefined) {
     return label;
   }
   const maxLabelWidth = columns - SPINNER_DECORATION_COLUMNS;
@@ -59,8 +65,7 @@ function clampProgressLabel(label: string): string {
   if (visibleWidth(label) <= maxLabelWidth) {
     return label;
   }
-  const utf16Cut = truncateUtf16Safe(label, maxLabelWidth - 1);
-  return `${truncateToVisibleWidth(utf16Cut, maxLabelWidth - 1)}…`;
+  return `${truncateToVisibleWidth(label, maxLabelWidth - 1)}…`;
 }
 
 // Clack-backed WizardPrompter implementation for interactive CLI setup. It
@@ -356,9 +361,25 @@ export function createClackPrompter(): WizardPrompter {
             styleFrame: theme.accent,
           })
         : spinner();
+      let currentLabel = label;
+      let maxColumns = readProgressColumns();
+      const renderLabel = () => theme.accent(clampProgressLabel(currentLabel, maxColumns));
+      const handleResize = () => {
+        const columns = readProgressColumns();
+        if (maxColumns === undefined || columns === undefined || columns >= maxColumns) {
+          return;
+        }
+        // Clack snapshots its erase width when the spinner is created. Only
+        // tighten our label budget so later terminal growth cannot exceed it.
+        maxColumns = columns;
+        spin.message(renderLabel());
+      };
+      if (maxColumns !== undefined) {
+        process.stdout.on("resize", handleResize);
+      }
       // Clack erases using bare-message wrapping but writes the frame and dots too.
       // Keeping animated labels to one row prevents long scans from leaking a line each tick.
-      spin.start(theme.accent(clampProgressLabel(label)));
+      spin.start(renderLabel());
       const osc = createCliProgress({
         label,
         indeterminate: true,
@@ -369,10 +390,12 @@ export function createClackPrompter(): WizardPrompter {
       // display command progress outside the prompt line.
       return {
         update: (message) => {
-          spin.message(theme.accent(clampProgressLabel(message)));
+          currentLabel = message;
+          spin.message(renderLabel());
           osc.setLabel(message);
         },
         stop: (message) => {
+          process.stdout.off("resize", handleResize);
           osc.done();
           if (message === undefined) {
             spin.clear();

--- a/src/wizard/i18n/locales/en.ts
+++ b/src/wizard/i18n/locales/en.ts
@@ -162,8 +162,9 @@ export const en = {
       option: "{name} — {reason} (detected: {app})",
       optionThirdParty:
         "{name} — {reason} (detected: {app}) — third-party ClawHub skill; installs its publisher's code",
-      scanning:
-        "Scanning installed apps — names are matched with your configured model and ClawHub search (disable via wizard.appRecommendations)…",
+      scanDisclosure:
+        "App names are matched with your configured model and ClawHub search (disable via wizard.appRecommendations).",
+      scanning: "Scanning installed apps…",
       select: "Install recommended plugins and skills",
       skillTrust: "Trust and install the ClawHub skill {name}?",
       skipped: "App recommendations skipped: {reason}",

--- a/src/wizard/i18n/locales/zh-CN.ts
+++ b/src/wizard/i18n/locales/zh-CN.ts
@@ -161,8 +161,9 @@ export const zh_CN = {
       option: "{name} — {reason}（检测到：{app}）",
       optionThirdParty:
         "{name} — {reason}（检测到：{app}）— 第三方 ClawHub 技能；将安装其发布者的代码",
-      scanning:
-        "正在扫描已安装应用 — 应用名称将通过你配置的模型与 ClawHub 搜索进行匹配（可通过 wizard.appRecommendations 关闭）…",
+      scanDisclosure:
+        "应用名称将使用你配置的模型和 ClawHub 搜索进行匹配（可通过 wizard.appRecommendations 关闭）。",
+      scanning: "正在扫描已安装应用…",
       select: "安装推荐的插件和技能",
       skillTrust: "信任并安装 ClawHub 技能 {name}？",
       skipped: "已跳过应用推荐：{reason}",

--- a/src/wizard/i18n/locales/zh-TW.ts
+++ b/src/wizard/i18n/locales/zh-TW.ts
@@ -161,8 +161,9 @@ export const zh_TW = {
       option: "{name} — {reason}（偵測到：{app}）",
       optionThirdParty:
         "{name} — {reason}（偵測到：{app}）— 第三方 ClawHub 技能；將安裝其發佈者的程式碼",
-      scanning:
-        "正在掃描已安裝的應用程式 — 應用程式名稱會透過你設定的模型與 ClawHub 搜尋進行比對（可透過 wizard.appRecommendations 停用）…",
+      scanDisclosure:
+        "應用程式名稱會使用你設定的模型和 ClawHub 搜尋進行比對（可透過 wizard.appRecommendations 停用）。",
+      scanning: "正在掃描已安裝的應用程式…",
       select: "安裝推薦的插件和技能",
       skillTrust: "信任並安裝 ClawHub 技能 {name}？",
       skipped: "已略過應用程式推薦：{reason}",

--- a/src/wizard/setup.app-recommendations.test.ts
+++ b/src/wizard/setup.app-recommendations.test.ts
@@ -197,12 +197,13 @@ describe("setupAppRecommendations", () => {
       return true;
     });
     const recommend = vi.fn(async () => recommendationResult());
+    const log = vi.fn();
 
     refreshOnboardRecommendationsCommand(runtime, { clear });
     await setupAppRecommendations({
       config: {},
       prompter: createPrompter(),
-      runtime,
+      runtime: { ...runtime, log },
       workspaceDir: "/tmp/workspace",
       modelRouteVerified: true,
       platform: "darwin",
@@ -216,10 +217,15 @@ describe("setupAppRecommendations", () => {
 
     expect(clear).toHaveBeenCalledOnce();
     expect(recommend).toHaveBeenCalledOnce();
+    expect(log).toHaveBeenCalledWith(
+      "App names are matched with your configured model and ClawHub search (disable via wizard.appRecommendations).",
+    );
+    expect(log.mock.invocationCallOrder[0]).toBeLessThan(recommend.mock.invocationCallOrder[0]!);
   });
 
   it("reuses a pending stored offer without rescanning and acknowledges the answer", async () => {
     const recommend = vi.fn(async () => recommendationResult());
+    const log = vi.fn();
     const prompter = createPrompter(["recommendation:0"]);
     const pending: OnboardingRecommendationsRecord = {
       inventoryHash: "hash",
@@ -238,7 +244,7 @@ describe("setupAppRecommendations", () => {
     await setupAppRecommendations({
       config: {},
       prompter,
-      runtime,
+      runtime: { ...runtime, log },
       workspaceDir: "/tmp/workspace",
       modelRouteVerified: true,
       platform: "darwin",
@@ -256,6 +262,9 @@ describe("setupAppRecommendations", () => {
     });
 
     expect(recommend).not.toHaveBeenCalled();
+    expect(log).not.toHaveBeenCalledWith(
+      "App names are matched with your configured model and ClawHub search (disable via wizard.appRecommendations).",
+    );
     expect(prompter.progress).not.toHaveBeenCalled();
     expect(prompter.multiselect).toHaveBeenCalledOnce();
     expect(store.acknowledgeStored).toHaveBeenCalledOnce();

--- a/src/wizard/setup.app-recommendations.test.ts
+++ b/src/wizard/setup.app-recommendations.test.ts
@@ -198,11 +198,12 @@ describe("setupAppRecommendations", () => {
     });
     const recommend = vi.fn(async () => recommendationResult());
     const log = vi.fn();
+    const prompter = createPrompter();
 
     refreshOnboardRecommendationsCommand(runtime, { clear });
     await setupAppRecommendations({
       config: {},
-      prompter: createPrompter(),
+      prompter,
       runtime: { ...runtime, log },
       workspaceDir: "/tmp/workspace",
       modelRouteVerified: true,
@@ -217,6 +218,36 @@ describe("setupAppRecommendations", () => {
 
     expect(clear).toHaveBeenCalledOnce();
     expect(recommend).toHaveBeenCalledOnce();
+    expect(prompter.plain).toHaveBeenCalledWith(
+      "App names are matched with your configured model and ClawHub search (disable via wizard.appRecommendations).",
+    );
+    expect(vi.mocked(prompter.plain!).mock.invocationCallOrder[0]).toBeLessThan(
+      recommend.mock.invocationCallOrder[0]!,
+    );
+    expect(log).not.toHaveBeenCalledWith(
+      "App names are matched with your configured model and ClawHub search (disable via wizard.appRecommendations).",
+    );
+  });
+
+  it("logs the scan disclosure when the prompter has no plain-output surface", async () => {
+    const recommend = vi.fn(async () => recommendationResult());
+    const log = vi.fn();
+    const prompter = createPrompter();
+    delete prompter.plain;
+
+    await setupAppRecommendations({
+      config: {},
+      prompter,
+      runtime: { ...runtime, log },
+      workspaceDir: "/tmp/workspace",
+      modelRouteVerified: true,
+      platform: "darwin",
+      deps: {
+        recommend,
+        ...storeDeps(),
+      },
+    });
+
     expect(log).toHaveBeenCalledWith(
       "App names are matched with your configured model and ClawHub search (disable via wizard.appRecommendations).",
     );
@@ -265,6 +296,7 @@ describe("setupAppRecommendations", () => {
     expect(log).not.toHaveBeenCalledWith(
       "App names are matched with your configured model and ClawHub search (disable via wizard.appRecommendations).",
     );
+    expect(prompter.plain).not.toHaveBeenCalled();
     expect(prompter.progress).not.toHaveBeenCalled();
     expect(prompter.multiselect).toHaveBeenCalledOnce();
     expect(store.acknowledgeStored).toHaveBeenCalledOnce();

--- a/src/wizard/setup.app-recommendations.ts
+++ b/src/wizard/setup.app-recommendations.ts
@@ -189,7 +189,14 @@ export async function setupAppRecommendations(params: {
     appLabels = [...new Set(stored.matches.map((match) => match.appLabel))];
     recordResult = commitStoredResult;
   } else {
-    params.runtime.log(t("wizard.appRecommendations.scanDisclosure"));
+    const scanDisclosure = t("wizard.appRecommendations.scanDisclosure");
+    // Gateway wizards must show the disclosure on the client before app names
+    // leave the machine; CLI plain output preserves the same ordering locally.
+    if (params.prompter.plain) {
+      await params.prompter.plain(scanDisclosure);
+    } else {
+      params.runtime.log(scanDisclosure);
+    }
     const progress = params.prompter.progress(t("wizard.appRecommendations.scanning"));
     let result: SetupAppRecommendationsResult;
     try {

--- a/src/wizard/setup.app-recommendations.ts
+++ b/src/wizard/setup.app-recommendations.ts
@@ -126,8 +126,8 @@ export async function setupAppRecommendations(params: {
   const platform = params.platform ?? process.platform;
   // Product decision: default-on "magical" scan with a kill switch, not
   // consent-first. App labels/bundle ids go to the user's configured model and
-  // ClawHub search; the scanning progress line and the results note disclose
-  // this, and wizard.appRecommendations=false disables the step entirely.
+  // ClawHub search; a static disclosure stays in scrollback before app names
+  // leave the machine, while results repeat it. The config flag disables the step.
   if (
     params.config.wizard?.appRecommendations === false ||
     platform !== "darwin" ||
@@ -189,6 +189,7 @@ export async function setupAppRecommendations(params: {
     appLabels = [...new Set(stored.matches.map((match) => match.appLabel))];
     recordResult = commitStoredResult;
   } else {
+    params.runtime.log(t("wizard.appRecommendations.scanDisclosure"));
     const progress = params.prompter.progress(t("wizard.appRecommendations.scanning"));
     let result: SetupAppRecommendationsResult;
     try {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running `openclaw onboard` would see the "Scanning installed apps…" progress line duplicated hundreds of times, flooding the screen, whenever their terminal width fell in the range where the spinner's decorated line wrapped (roughly 130–139 columns for the shipped label). Affected surface: the onboarding wizard's app-recommendations step, which keeps its spinner up for a 20–40 second scan.

## Why This Change Was Made

The upstream `@clack/prompts` spinner erases each redraw using the wrapped line count of the bare message, but writes the frame prefix and animated dots as well — so any label that wraps leaks one stale line per 120 ms tick (bombshell-dev/clack#132, open since 2023; fix PRs #478/#584 declined pending a spinner rework). Instead of patching the dependency, the wizard now (1) prints the model/ClawHub privacy disclosure as a static log line before the scan starts — so it is on screen before app names leave the machine and survives in scrollback — leaving the spinner with a short "Scanning installed apps…" label, and (2) defensively clamps every wizard progress label to one terminal row, display-width aware, so no future label can retrigger the clack bug at any width. Non-goal: fixing or patching clack itself.

## User Impact

Onboarding shows a single scanning line that animates in place at any terminal width. The disclosure that app names are matched with the configured model and ClawHub search (and how to disable it) is now persistently visible in scrollback, rather than vanishing when the spinner clears.

## Evidence

- Manually verified on macOS `openclaw onboard` at a previously-affected terminal width: static disclosure line, single in-place spinner line, no duplication.
- Focused tests: `node scripts/run-vitest.mjs src/wizard/setup.app-recommendations.test.ts src/wizard/clack-prompter.test.ts` → 32/32 pass. Coverage includes clamp width edges (CJK width, emoji surrogate pairs, missing/degenerate columns), disclosure logged before the scan, stored-offer path skipping the disclosure, and stop/OSC labels staying unclamped.
- `check-changed` core lanes green (Blacksmith Testbox API timed out twice; trusted-source local fallback per repo policy); autoreview clean.
- Root cause confirmed by direct inspection of the installed `@clack/prompts@1.6.0` dist and current upstream `main` (`_prevMessage` excludes frame/dots while the write includes them).
