### PR TITLE
fix(cron): honor script limits and permanent failures

### DIFF
--- a/src/agents/code-mode-headless.test.ts
+++ b/src/agents/code-mode-headless.test.ts
@@ -193,6 +193,27 @@ describe("headless Code Mode", () => {
     expect(tool.execute).toHaveBeenCalledOnce();
   });
 
+  it("honors cron payload tool budgets above the old headless cap", async () => {
+    const tool = fakeTool("budgeted", async () => jsonResult({ ok: true }));
+    const result = expectCompleted(
+      await runCodeModeScriptHeadless({
+        ctx: createHeadlessHarness([tool]),
+        code: `
+          for (let index = 0; index < 129; index += 1) {
+            await tools.call("openclaw:core:budgeted", {});
+          }
+          return true;
+        `,
+        maxToolCalls: 200,
+        wallClockMs: 120_000,
+      }),
+    );
+
+    expect(result.value).toBe(true);
+    expect(result.toolCallCount).toBe(129);
+    expect(tool.execute).toHaveBeenCalledTimes(129);
+  });
+
   it("enforces one wall-clock deadline across worker and tool legs", async () => {
     vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "Date"] });
     const toolStarted = createDeferred();
@@ -226,6 +247,39 @@ describe("headless Code Mode", () => {
     const result = expectFailed(await resultPromise);
 
     expect(result.code).toBe("timeout");
+    expect(result.toolCallCount).toBe(1);
+  });
+
+  it("honors cron payload wall-clock limits above the old headless cap", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "Date"] });
+    const toolStarted = createDeferred();
+    const slow = fakeTool("slow_leg", async () => {
+      toolStarted.resolve();
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 330_000);
+      });
+      return jsonResult({ ok: true });
+    });
+    const resultPromise = runCodeModeScriptHeadless({
+      ctx: createHeadlessHarness([slow]),
+      code: `
+        await tools.call("openclaw:core:slow_leg", {});
+        return true;
+      `,
+      wallClockMs: 360_000,
+    });
+
+    await toolStarted.promise;
+    let settled = false;
+    void resultPromise.finally(() => {
+      settled = true;
+    });
+    await vi.advanceTimersByTimeAsync(300_000);
+    expect(settled).toBe(false);
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    const result = expectCompleted(await resultPromise);
+    expect(result.value).toBe(true);
     expect(result.toolCallCount).toBe(1);
   });
 

--- a/src/agents/code-mode.ts
+++ b/src/agents/code-mode.ts
@@ -86,6 +86,12 @@ const MAX_ACTIVE_CODE_MODE_RUNS = 64;
 const MAX_AGENT_WAIT_SNAPSHOT_TTL_WINDOWS = 4;
 const MAX_CODE_MODE_CATALOG_INDEX_CHARS = 8_000;
 const CODE_MODE_WORKER_WATCHDOG_GRACE_MS = 2_000;
+const DEFAULT_HEADLESS_WALL_CLOCK_MS = 30_000;
+// Cron script payloads persist caps of 900 seconds and 200 tool calls.
+// The shared executor must not silently lower those accepted job limits.
+const MAX_HEADLESS_WALL_CLOCK_MS = 900_000;
+const DEFAULT_HEADLESS_TOOL_CALLS = 5;
+const MAX_HEADLESS_TOOL_CALLS = 200;
 
 type CodeModeLanguage = "javascript" | "typescript";
 
@@ -1317,8 +1323,16 @@ export async function runCodeModeScriptHeadless(params: {
   signal?: AbortSignal;
 }): Promise<CodeModeHeadlessResult> {
   const config = resolveCodeModeHeadlessConfig(params.ctx, params.overrides);
-  const wallClockMs = clampNumber(readPositiveInteger(params.wallClockMs, 30_000), 1, 300_000);
-  const maxToolCalls = clampNumber(readPositiveInteger(params.maxToolCalls, 5), 1, 128);
+  const wallClockMs = clampNumber(
+    readPositiveInteger(params.wallClockMs, DEFAULT_HEADLESS_WALL_CLOCK_MS),
+    1,
+    MAX_HEADLESS_WALL_CLOCK_MS,
+  );
+  const maxToolCalls = clampNumber(
+    readPositiveInteger(params.maxToolCalls, DEFAULT_HEADLESS_TOOL_CALLS),
+    1,
+    MAX_HEADLESS_TOOL_CALLS,
+  );
   const deadline = Date.now() + wallClockMs;
   const abortScope = createHeadlessAbortScope(params.signal, wallClockMs);
   const output: unknown[] = [];

--- a/src/cron/run-error-reason.test.ts
+++ b/src/cron/run-error-reason.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { resolveCronRunErrorReason } from "./run-error-reason.js";
+
+describe("resolveCronRunErrorReason", () => {
+  it("keeps permanent local script errors out of provider timeout classification", () => {
+    expect(
+      resolveCronRunErrorReason("cron script failed: request timed out", undefined, {
+        kind: "permanent",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("preserves genuine script timeout classification", () => {
+    expect(
+      resolveCronRunErrorReason("cron script failed", undefined, {
+        kind: "reason",
+        reason: "timeout",
+      }),
+    ).toBe("timeout");
+  });
+
+  it("preserves provider error classification for other cron failures", () => {
+    expect(resolveCronRunErrorReason("internal_error from provider")).toBe("timeout");
+  });
+});

--- a/src/cron/run-error-reason.ts
+++ b/src/cron/run-error-reason.ts
@@ -1,0 +1,18 @@
+import type { FailoverReason } from "../agents/embedded-agent-helpers/types.js";
+import { resolveFailoverReasonFromError } from "../agents/failover-error.js";
+import type { CronRunErrorClassification } from "./types.js";
+
+/** Resolve one cron-owned classification before falling back to provider error inference. */
+export function resolveCronRunErrorReason(
+  error: unknown,
+  provider?: string,
+  classification?: CronRunErrorClassification,
+): FailoverReason | undefined {
+  if (classification?.kind === "permanent") {
+    return undefined;
+  }
+  if (classification?.kind === "reason") {
+    return classification.reason;
+  }
+  return resolveFailoverReasonFromError(error, provider) ?? undefined;
+}

--- a/src/cron/service.failure-alert.test.ts
+++ b/src/cron/service.failure-alert.test.ts
@@ -504,6 +504,49 @@ describe("CronService failure alerts", () => {
     await store.cleanup();
   });
 
+  it("does not reclassify permanent local script errors in failure alerts", async () => {
+    const store = await makeStorePath();
+    const sendCronFailureAlert = vi.fn(async () => undefined);
+    const runIsolatedAgentJob = vi.fn(async () => ({
+      status: "error" as const,
+      error: "cron script failed after a tool side effect: request timed out",
+      errorClassification: { kind: "permanent" as const },
+    }));
+
+    const cron = createFailureAlertCron({
+      storePath: store.storePath,
+      cronConfig: {
+        failureAlert: {
+          enabled: true,
+          after: 1,
+        },
+      },
+      runIsolatedAgentJob,
+      sendCronFailureAlert,
+    });
+
+    await cron.start();
+    const job = await cron.add({
+      name: "permanent script alert",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "ping" },
+      delivery: { mode: "announce", channel: "telegram", to: "19098680" },
+    });
+
+    await cron.run(job.id, "force");
+    expect(sendCronFailureAlert).toHaveBeenCalledTimes(1);
+    expect(alertCallArg(sendCronFailureAlert).text).toBe(
+      'Cron job "permanent script alert" failed 1 times\n' +
+        "Last error: cron script failed after a tool side effect: request timed out",
+    );
+
+    cron.stop();
+    await store.cleanup();
+  });
+
   it("keeps skipped alert text unchanged when the skip reason looks classifiable", async () => {
     const store = await makeStorePath();
     const sendCronFailureAlert = vi.fn(async () => undefined);

--- a/src/cron/service/failure-alerts.ts
+++ b/src/cron/service/failure-alerts.ts
@@ -1,7 +1,7 @@
 /** Resolves and emits cron failure-alert notifications. */
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
-import { resolveFailoverReasonFromError } from "../../agents/failover-error.js";
+import type { FailoverReason } from "../../agents/embedded-agent-helpers/types.js";
 import type { CronFailureNotificationDelivery, CronJob, CronMessageChannel } from "../types.js";
 import type { CronServiceState } from "./state.js";
 
@@ -104,21 +104,18 @@ function emitFailureAlert(
   params: {
     job: CronJob;
     error?: string;
+    errorReason?: FailoverReason;
     consecutiveErrors: number;
     channel: CronMessageChannel;
     to?: string;
     mode?: "announce" | "webhook";
     accountId?: string;
     status: "error" | "skipped";
-    provider?: string;
   },
 ) {
   const safeJobName = params.job.name || params.job.id;
   const truncatedError = truncateUtf16Safe(params.error?.trim() || "unknown reason", 200);
-  const errorReason =
-    params.status === "error" && typeof params.error === "string"
-      ? (resolveFailoverReasonFromError(params.error, params.provider) ?? undefined)
-      : undefined;
+  const errorReason = params.status === "error" ? params.errorReason : undefined;
   // Keep alert bodies compact because they may route through chat channels
   // with notification previews and provider-specific message limits.
   const statusVerb = params.status === "skipped" ? "skipped" : "failed";
@@ -166,7 +163,7 @@ export function maybeEmitFailureAlert(
     alertConfig: ResolvedFailureAlert | null;
     status: "error" | "skipped";
     error?: string;
-    provider?: string;
+    errorReason?: FailoverReason;
     consecutiveCount: number;
     delivery?: "emit" | "record-only";
     occurredAtMs?: number;
@@ -192,13 +189,13 @@ export function maybeEmitFailureAlert(
     emitFailureAlert(state, {
       job: params.job,
       error: params.error,
+      errorReason: params.errorReason,
       consecutiveErrors: params.consecutiveCount,
       channel: params.alertConfig.channel,
       to: params.alertConfig.to,
       mode: params.alertConfig.mode,
       accountId: params.alertConfig.accountId,
       status: params.status,
-      provider: params.provider,
     });
   }
   params.job.state.lastFailureAlertAtMs = now;

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -25,7 +25,13 @@ import { createCronRunDiagnosticsFromError } from "../run-diagnostics.js";
 import { cronSchedulingInputsEqual } from "../schedule-identity.js";
 import { createCronStreamSourceIdentity, cronStreamScheduleKey } from "../stream-schedule.js";
 import { normalizeCronTaskRunJobId } from "../task-run-history.js";
-import type { CronJob, CronJobCreate, CronJobPatch, CronPayload } from "../types.js";
+import type {
+  CronJob,
+  CronJobCreate,
+  CronJobPatch,
+  CronPayload,
+  CronRunErrorClassification,
+} from "../types.js";
 import { normalizeCronRunErrorText } from "./execution-errors.js";
 import { failureNotificationDeliveryFromJobState } from "./failure-alerts.js";
 import {
@@ -1021,15 +1027,19 @@ function emitCronRunFinished(
   evt: CronEvent & { action: "finished" },
   tracker?: ManualRunTerminalTracker,
   taskRunId?: string,
-  triggerEval?: CronTriggerEvalOutcome,
-  scriptResult?: { scriptStateChanged?: boolean; scriptState?: unknown },
+  details?: {
+    triggerEval?: CronTriggerEvalOutcome;
+    scriptResult?: { scriptStateChanged?: boolean; scriptState?: unknown };
+    errorClassification?: CronRunErrorClassification;
+  },
 ): void {
   tryFinishCronTaskRun(state, {
     taskRunId,
     job: evt.job,
     event: evt,
-    ...(scriptResult ? { scriptResult } : {}),
-    ...(triggerEval ? { triggerEval } : {}),
+    errorClassification: details?.errorClassification,
+    ...(details?.scriptResult ? { scriptResult: details.scriptResult } : {}),
+    ...(details?.triggerEval ? { triggerEval: details.triggerEval } : {}),
   });
   emit(state, evt);
   if (tracker) {
@@ -1602,6 +1612,9 @@ async function finishPreparedManualRun(
         },
         tracker,
         taskRunId,
+        {
+          errorClassification: triggerSkipped ? undefined : coreResult.errorClassification,
+        },
       );
     };
     if (!triggerSkipped) {
@@ -1701,8 +1714,11 @@ async function finishPreparedManualRun(
           },
           prepared.terminalTracker,
           taskRunId,
-          coreResult.triggerEval,
-          coreResult,
+          {
+            triggerEval: coreResult.triggerEval,
+            scriptResult: coreResult,
+            errorClassification: coreResult.errorClassification,
+          },
         );
       }
 

--- a/src/cron/service/task-runs.ts
+++ b/src/cron/service/task-runs.ts
@@ -28,7 +28,7 @@ import {
   resolveCronTaskRecordTimestamp,
 } from "../task-run-detail.js";
 import { cronRunLogEntryFromEvent } from "../task-run-event-codec.js";
-import type { CronJob, CronRunStatus } from "../types.js";
+import type { CronJob, CronRunErrorClassification, CronRunStatus } from "../types.js";
 import { normalizeCronRunErrorText, timeoutErrorMessage } from "./execution-errors.js";
 import type { CronEvent, CronServiceState } from "./state.js";
 import { CRON_TASK_RUNNING_PROGRESS_SUMMARY } from "./task-ledger.js";
@@ -293,11 +293,16 @@ export function tryFinishCronTaskRun(
     taskRunId?: string;
     job?: CronJob;
     event: CronEvent & { action: "finished" };
+    errorClassification?: CronRunErrorClassification;
     scriptResult?: { scriptStateChanged?: boolean; scriptState?: unknown };
     triggerEval?: { fired: boolean; stateChanged: boolean; state?: unknown };
   },
 ): void {
-  const entry = cronRunLogEntryFromEvent(result.event, state.deps.nowMs());
+  const entry = cronRunLogEntryFromEvent(
+    result.event,
+    state.deps.nowMs(),
+    result.errorClassification,
+  );
   const startedAt = entry.runAtMs ?? entry.ts;
   const candidateRunId =
     result.taskRunId ?? createCronTaskRunId(entry.jobId, startedAt, entry.runId);

--- a/src/cron/service/timer.regression.test.ts
+++ b/src/cron/service/timer.regression.test.ts
@@ -3679,6 +3679,70 @@ describe("cron service timer regressions", () => {
     }
   });
 
+  it("does not retry permanent script failures with timeout-looking text", () => {
+    const startedAt = Date.parse("2026-07-21T12:00:00.000Z");
+    const endedAt = startedAt + 500;
+    const job = createIsolatedRegressionJob({
+      id: "permanent-script-failure",
+      name: "permanent-script-failure",
+      scheduledAt: startedAt,
+      schedule: { kind: "at", at: new Date(startedAt).toISOString() },
+      payload: { kind: "script", script: "throw new Error('request timed out')" },
+      state: { runningAtMs: startedAt },
+    });
+    const state = createRunningCronServiceState({
+      storePath: "/tmp/cron-permanent-script-failure.json",
+      log: noopLogger,
+      nowMs: () => endedAt,
+      jobs: [job],
+    });
+
+    applyJobResult(state, job, {
+      status: "error",
+      error: "cron script failed after a tool side effect: request timed out",
+      errorClassification: { kind: "permanent" },
+      executionStarted: true,
+      startedAt,
+      endedAt,
+    });
+
+    expect(job.state.lastErrorReason).toBeUndefined();
+    expect(job.state.nextRunAtMs).toBeUndefined();
+    expect(job.enabled).toBe(false);
+  });
+
+  it("retries explicitly classified script timeouts", () => {
+    const startedAt = Date.parse("2026-07-21T12:00:00.000Z");
+    const endedAt = startedAt + 500;
+    const job = createIsolatedRegressionJob({
+      id: "transient-script-timeout",
+      name: "transient-script-timeout",
+      scheduledAt: startedAt,
+      schedule: { kind: "at", at: new Date(startedAt).toISOString() },
+      payload: { kind: "script", script: "while (true) {}" },
+      state: { runningAtMs: startedAt },
+    });
+    const state = createRunningCronServiceState({
+      storePath: "/tmp/cron-transient-script-timeout.json",
+      log: noopLogger,
+      nowMs: () => endedAt,
+      jobs: [job],
+    });
+
+    applyJobResult(state, job, {
+      status: "error",
+      error: "cron script payload failed (timeout): wall-clock timeout exceeded",
+      errorClassification: { kind: "reason", reason: "timeout" },
+      executionStarted: true,
+      startedAt,
+      endedAt,
+    });
+
+    expect(job.state.lastErrorReason).toBe("timeout");
+    expect(job.state.nextRunAtMs).toBe(endedAt + 30_000);
+    expect(job.enabled).toBe(true);
+  });
+
   it("force run preserves 'every' anchor while recording manual lastRunAtMs", () => {
     const nowMs = Date.now();
     const everyMs = 24 * 60 * 60 * 1_000;

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -1,6 +1,5 @@
 /** Cron timer loop, execution, catch-up, and run-result state transitions. */
 import pMap, { pMapSkip } from "p-map";
-import { resolveFailoverReasonFromError } from "../../agents/failover-error.js";
 import { resolveCronTriggerMinIntervalMs } from "../../config/cron-limits.js";
 import { loadSessionEntry } from "../../config/sessions/session-accessor.js";
 import type { CronConfig } from "../../config/types.cron.js";
@@ -35,6 +34,7 @@ import {
   normalizeCronRunDiagnostics,
   summarizeCronRunDiagnostics,
 } from "../run-diagnostics.js";
+import { resolveCronRunErrorReason } from "../run-error-reason.js";
 import { computeNextRunAtMs } from "../schedule.js";
 import { sweepCronRunSessions } from "../session-reaper.js";
 import {
@@ -50,6 +50,7 @@ import type {
   CronFailureNotificationDelivery,
   CronJob,
   CronNextCheckProposal,
+  CronRunErrorClassification,
   CronRunOutcome,
   CronRunStatus,
   CronRunTelemetry,
@@ -556,15 +557,26 @@ function resolveRetryConfig() {
 function resolveTransientCronRetryDecision(params: {
   cronConfig?: CronConfig;
   error: string | undefined;
+  errorClassification?: CronRunErrorClassification;
   lastErrorReason?: string;
   executionStarted?: boolean;
   consecutiveErrors: number | undefined;
 }): TransientCronRetryDecision {
   const retryConfig = resolveRetryConfig();
+  if (params.errorClassification?.kind === "permanent") {
+    return {
+      retryable: false,
+      consecutiveErrors: params.consecutiveErrors ?? 0,
+      reason: "permanent error",
+    };
+  }
   const retryHint = resolveCronExecutionRetryHint({
     error: params.error,
     retryOn: retryConfig.retryOn,
-    classifiedReason: params.lastErrorReason,
+    classifiedReason:
+      params.errorClassification?.kind === "reason"
+        ? params.errorClassification.reason
+        : params.lastErrorReason,
     executionStarted: params.executionStarted,
   });
   const consecutiveErrors = params.consecutiveErrors ?? 0;
@@ -792,7 +804,7 @@ export function applyJobResult(
   job.state.lastDiagnosticSummary = summarizeCronRunDiagnostics(job.state.lastDiagnostics);
   job.state.lastErrorReason =
     result.status === "error" && typeof result.error === "string"
-      ? (resolveFailoverReasonFromError(result.error, result.provider) ?? undefined)
+      ? resolveCronRunErrorReason(result.error, result.provider, result.errorClassification)
       : undefined;
   if (result.status === "error") {
     state.deps.log.warn(
@@ -839,7 +851,7 @@ export function applyJobResult(
       alertConfig,
       status: "error",
       error: result.error,
-      provider: result.provider,
+      errorReason: job.state.lastErrorReason,
       consecutiveCount: job.state.consecutiveErrors,
       ...(opts?.replayFailureAlertAtMs !== undefined
         ? { delivery: "record-only" as const, occurredAtMs: opts.replayFailureAlertAtMs }
@@ -854,7 +866,6 @@ export function applyJobResult(
         alertConfig,
         status: "skipped",
         error: result.error,
-        provider: result.provider,
         consecutiveCount: job.state.consecutiveSkipped,
         ...(opts?.replayFailureAlertAtMs !== undefined
           ? { delivery: "record-only" as const, occurredAtMs: opts.replayFailureAlertAtMs }
@@ -916,6 +927,7 @@ export function applyJobResult(
         const retryDecision = resolveTransientCronRetryDecision({
           cronConfig: state.deps.cronConfig,
           error: result.error,
+          errorClassification: result.errorClassification,
           lastErrorReason: job.state.lastErrorReason,
           executionStarted: result.executionStarted,
           consecutiveErrors: job.state.consecutiveErrors,
@@ -964,6 +976,7 @@ export function applyJobResult(
       const retryDecision = resolveTransientCronRetryDecision({
         cronConfig: state.deps.cronConfig,
         error: result.error,
+        errorClassification: result.errorClassification,
         lastErrorReason: job.state.lastErrorReason,
         executionStarted: result.executionStarted,
         consecutiveErrors: job.state.consecutiveErrors,
@@ -2850,6 +2863,7 @@ async function executeDetachedCronJob(
   return {
     status: res.status,
     error: res.error,
+    errorClassification: res.errorClassification,
     executionStarted: res.executionStarted,
     // Forward the post-run delivery failure recorded on an otherwise
     // successful run so the service can persist it as `lastDeliveryError` and
@@ -2972,6 +2986,7 @@ function emitJobFinished(
     taskRunId: result.taskRunId,
     job,
     event,
+    errorClassification: result.errorClassification,
     ...(result.scriptStateChanged === true ? { scriptResult: result } : {}),
     ...(result.triggerEval ? { triggerEval: result.triggerEval } : {}),
   });

--- a/src/cron/task-run-event-codec.test.ts
+++ b/src/cron/task-run-event-codec.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { cronRunLogEntryFromEvent } from "./task-run-event-codec.js";
+
+describe("cronRunLogEntryFromEvent", () => {
+  it("keeps permanent script failures out of run-history timeout classification", () => {
+    const entry = cronRunLogEntryFromEvent(
+      {
+        jobId: "script-job",
+        action: "finished",
+        status: "error",
+        error: "cron script failed after a tool side effect: request timed out",
+      },
+      1,
+      { kind: "permanent" },
+    );
+
+    expect(entry.errorReason).toBeUndefined();
+  });
+
+  it("preserves explicit script timeout classification in run history", () => {
+    const entry = cronRunLogEntryFromEvent(
+      {
+        jobId: "script-job",
+        action: "finished",
+        status: "error",
+        error: "cron script failed",
+      },
+      1,
+      { kind: "reason", reason: "timeout" },
+    );
+
+    expect(entry.errorReason).toBe("timeout");
+  });
+});

--- a/src/cron/task-run-event-codec.ts
+++ b/src/cron/task-run-event-codec.ts
@@ -1,9 +1,10 @@
 /** Write-side cron codec: converts a finished service event into a run-history entry.
  * Kept separate from task-run-detail.ts so the read/history codec stays free of the
  * agents failover tree (which transitively pulls the sandbox module graph). */
-import { resolveFailoverReasonFromError } from "../agents/failover-error.js";
+import { resolveCronRunErrorReason } from "./run-error-reason.js";
 import type { CronRunLogEntry } from "./run-log-types.js";
 import type { CronEvent } from "./service/state.js";
+import type { CronRunErrorClassification } from "./types.js";
 
 type CronFinishedEvent = CronEvent & { action: "finished" };
 
@@ -24,8 +25,9 @@ function resolveCronRunEndedAt(event: CronFinishedEvent, fallbackTs: number): nu
 export function cronRunLogEntryFromEvent(
   event: CronFinishedEvent,
   fallbackTs: number,
+  errorClassification?: CronRunErrorClassification,
 ): CronRunLogEntry {
-  const errorReason = resolveFailoverReasonFromError(event.error, event.provider) ?? undefined;
+  const errorReason = resolveCronRunErrorReason(event.error, event.provider, errorClassification);
   return {
     ts: resolveCronRunEndedAt(event, fallbackTs),
     jobId: event.jobId,

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -196,6 +196,11 @@ export type CronRunDiagnostics = {
   entries: CronRunDiagnostic[];
 };
 
+/** Explicit execution-error disposition used consistently by retry, history, and alerts. */
+export type CronRunErrorClassification =
+  | { kind: "reason"; reason: FailoverReason }
+  | { kind: "permanent" };
+
 /** Execution result persisted on cron state, run logs, and isolated turn results. */
 export type CronRunOutcome = {
   status: CronRunStatus;
@@ -204,6 +209,7 @@ export type CronRunOutcome = {
   executionStarted?: boolean;
   /** Optional classifier for execution errors to guide fallback behavior. */
   errorKind?: "delivery-target";
+  errorClassification?: CronRunErrorClassification;
   summary?: string;
   sessionId?: string;
   sessionKey?: string;

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -35,7 +35,12 @@ import {
 import { resolveCronJobsStorePath } from "../cron/store.js";
 import { cronStreamScheduleKey } from "../cron/stream-schedule.js";
 import { createCronScriptRuntime } from "../cron/trigger-script.js";
-import type { CronJob, CronPayload } from "../cron/types.js";
+import type {
+  CronJob,
+  CronPayload,
+  CronRunErrorClassification,
+  CronTriggerFailureCode,
+} from "../cron/types.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { resolveMainScopedEventSessionKey } from "../infra/event-session-routing.js";
 import { runHeartbeatOnce } from "../infra/heartbeat-runner.js";
@@ -90,6 +95,16 @@ export type GatewayCronState = {
   reconcileStreamWatchers?: () => Promise<void>;
   stopStreamWatchers?: () => Promise<void>;
 };
+
+function classifyCronScriptFailure(code: CronTriggerFailureCode): CronRunErrorClassification {
+  if (code === "timeout") {
+    return { kind: "reason", reason: "timeout" };
+  }
+  if (code === "runtime_unavailable") {
+    return { kind: "reason", reason: "server_error" };
+  }
+  return { kind: "permanent" };
+}
 
 function formatOnExitRunSummary(exit: CronExitResult): string {
   const lines = [
@@ -810,6 +825,7 @@ export function buildGatewayCronService(params: {
         return {
           status: "error",
           error: `cron script payload failed (${execution.code}): ${execution.error}`,
+          errorClassification: classifyCronScriptFailure(execution.code),
         };
       }
       if (execution.nextCheck && !job.pacing) {

--- a/src/tui/tui-pty-local.e2e.test.ts
+++ b/src/tui/tui-pty-local.e2e.test.ts
@@ -735,12 +735,12 @@ async function requireSharedGatewayFixture(): Promise<SharedGatewayFixture> {
 }
 
 async function cleanupSharedGatewayFixture(
-  startup: Promise<SharedGatewayFixture> | undefined,
+  startup: Promise<Pick<SharedGatewayFixture, "cleanup">> | undefined,
 ): Promise<void> {
   if (!startup) {
     return;
   }
-  let fixture: SharedGatewayFixture;
+  let fixture: Pick<SharedGatewayFixture, "cleanup">;
   try {
     fixture = await startup;
   } catch {
@@ -814,7 +814,7 @@ describe("TUI PTY real backends", () => {
       cleanup: async () => {
         throw cleanupError;
       },
-    } as SharedGatewayFixture;
+    };
     await expect(cleanupSharedGatewayFixture(Promise.resolve(fixture))).rejects.toBe(cleanupError);
   });
 

--- a/src/tui/tui-pty-local.e2e.test.ts
+++ b/src/tui/tui-pty-local.e2e.test.ts
@@ -591,12 +591,7 @@ type SharedGatewayFixture = {
   cleanup: () => Promise<void>;
 };
 
-type SharedGatewayFixtureStartup = {
-  promise: Promise<SharedGatewayFixture>;
-  failureReported: boolean;
-};
-
-let sharedGatewayFixtureStartup: SharedGatewayFixtureStartup | undefined;
+let sharedGatewayFixtureStartup: Promise<SharedGatewayFixture> | undefined;
 let gatewaySessionSequence = 0;
 
 function buildGatewayModeConfig(params: { tempDir: string; providerBaseUrl: string }) {
@@ -733,16 +728,26 @@ async function startSharedGatewayFixture(): Promise<SharedGatewayFixture> {
 }
 
 async function requireSharedGatewayFixture(): Promise<SharedGatewayFixture> {
-  const startup = sharedGatewayFixtureStartup;
-  if (!startup) {
+  if (!sharedGatewayFixtureStartup) {
     throw new Error("shared Gateway fixture startup was not initialized");
   }
-  try {
-    return await startup.promise;
-  } catch (error) {
-    startup.failureReported = true;
-    throw error;
+  return await sharedGatewayFixtureStartup;
+}
+
+async function cleanupSharedGatewayFixture(
+  startup: Promise<SharedGatewayFixture> | undefined,
+): Promise<void> {
+  if (!startup) {
+    return;
   }
+  let fixture: SharedGatewayFixture;
+  try {
+    fixture = await startup;
+  } catch {
+    // The setup hook already reports startup failures. Teardown only owns cleanup.
+    return;
+  }
+  await fixture.cleanup();
 }
 
 async function startGatewayModeTui(
@@ -799,36 +804,19 @@ async function startGatewayModeTui(
 // Gateway cases share one real server but keep isolated PTYs, models, and sessions.
 // Keep them serial so constrained release runners avoid host contention.
 describe("TUI PTY real backends", () => {
-  beforeAll(() => {
-    const promise = startSharedGatewayFixture();
-    sharedGatewayFixtureStartup = { promise, failureReported: false };
-    // Local cases run while startup continues. Mark an early rejection handled;
-    // the Gateway setup hook awaits the original promise and reports the failure.
-    void promise.catch(() => undefined);
-  });
+  it("owns late fixture startup without swallowing cleanup failures", async () => {
+    await expect(
+      cleanupSharedGatewayFixture(Promise.reject(new Error("setup failed"))),
+    ).resolves.toBe(undefined);
 
-  afterAll(async () => {
-    const startup = sharedGatewayFixtureStartup;
-    try {
-      if (!startup) {
-        return;
-      }
-      let fixture: SharedGatewayFixture;
-      try {
-        fixture = await startup.promise;
-      } catch (error) {
-        // A filtered local-only run has no Gateway hook to surface startup failure.
-        // Preserve the old beforeAll contract without duplicating an existing failure.
-        if (!startup.failureReported) {
-          throw error;
-        }
-        return;
-      }
-      await fixture.cleanup();
-    } finally {
-      sharedGatewayFixtureStartup = undefined;
-    }
-  }, LOCAL_TEST_TIMEOUT_MS);
+    const cleanupError = new Error("cleanup failed");
+    const fixture = {
+      cleanup: async () => {
+        throw cleanupError;
+      },
+    } as SharedGatewayFixture;
+    await expect(cleanupSharedGatewayFixture(Promise.resolve(fixture))).rejects.toBe(cleanupError);
+  });
 
   it(
     "drives the real local backend with a mocked model endpoint",
@@ -1364,10 +1352,16 @@ describe("TUI PTY real backends", () => {
   );
 
   describe("with shared Gateway fixture", () => {
-    // Preserve the fixture's original setup budget: overlap startup with local
-    // cases, then join it in a hook before any Gateway PTY starts.
     beforeAll(async () => {
-      await requireSharedGatewayFixture();
+      const startup = startSharedGatewayFixture();
+      sharedGatewayFixtureStartup = startup;
+      await startup;
+    }, LOCAL_TEST_TIMEOUT_MS);
+
+    afterAll(async () => {
+      const startup = sharedGatewayFixtureStartup;
+      sharedGatewayFixtureStartup = undefined;
+      await cleanupSharedGatewayFixture(startup);
     }, LOCAL_TEST_TIMEOUT_MS);
 
     for (const register of gatewayTestRegistrations) {


### PR DESCRIPTION
## What Problem This Solves

Fixes two issues in cron script/code-mode jobs:

1. Jobs accepted with `--script-timeout-seconds` above 300 seconds or `--script-tool-budget` above 128 were silently constrained by lower executor caps, despite the documented and persisted limits being 900 seconds and 200 calls.
2. Permanent local script failures could be mislabeled as provider timeouts and transiently retried when their error text contained timeout-like wording, risking repeated side effects and misleading failure alerts/history.

## Why This Change Was Made

The shared headless Code Mode executor now honors the existing cron script contract of 900 seconds and 200 tool calls while preserving smaller limits passed by trigger scripts and other callers.

Script failures also carry a typed cron-owned classification from the Gateway execution boundary through retry decisions, job state, task history, and failure alerts. Genuine timeouts remain transient; runtime-unavailable failures remain retryable as server errors; syntax, invalid-result, tool-budget, unknown-tool, and other local script failures are permanent without downstream string reclassification.

This PR is AI-assisted. An independent exhaustive review found two classification gaps in the initial implementation; both were fixed, re-reviewed, and the final diff is clean.

The PR also fixes the unrelated red-main TUI PTY gate encountered during landing. Local embedded TUI cases no longer overlap startup with the expensive shared Gateway fixture; Gateway-only cases still share one fixture, and teardown retains late startup ownership without swallowing cleanup failures.

## User Impact

Long-running and tool-heavy cron scripts now receive the limits users configured. Permanent script defects stop after one-shot failure instead of being presented and retried as provider timeouts, while real timeouts retain normal cron retry behavior.

## Evidence

### Live isolated Gateway proof

- A script configured with tool budget 200 previously failed on call 129 with `tool_budget_exceeded (128)`; after the fix, all 129 calls completed successfully in about 31 seconds.
- A script configured with a 360-second timeout previously failed after about 305 seconds; after the fix, the same job completed successfully after about 313 seconds.
- A script that performed a tool side effect and then threw `request timed out after side effect` recorded no timeout cause, was disabled as a permanent one-shot error, and was not retried.
- A genuine one-second script timeout retained `errorReason: timeout` and transient retry scheduling.
- Real OpenAI chat and terminal TUI each created exact script-payload jobs through the native cron tool; the stored script, empty tool allowlist, delivery mode, and natural execution were independently verified through the CLI.
- Additional live coverage passed for persisted script state, silent success, invalid return values, syntax errors, 16 KiB state enforcement, pacing, main-session notify/wake, isolated sessions, natural schedules, on-exit, allowlist denial, nested cron/exec tools, nine simultaneous script jobs at the eight-run admission cap, and hard-crash recovery.

### Automated proof

- Direct AWS Crabbox `run_b5200dbbc975` (`cbx_b3d59a5585be`): focused tests, scoped `check:changed`, typechecks, lint, import-cycle and repository guards, and full `pnpm build` passed.
- Direct AWS Crabbox `run_b5cf731622c7` (`cbx_93de6f1a90d1`): initial focused tests, scoped checks, and production build passed after the lint correction.
- Full cron shard passed locally after the final classification changes: 140 files / 1562 tests.
- Exact-head focused suite after rebase: 99 tests passed across cron and agent shards.
- TUI PTY gate fix: the filtered local case passed five consecutive repetitions, a filtered real-Gateway case passed, and the complete dedicated PTY suite passed 33/33 tests. Lifecycle review verified late-startup cleanup ownership and cleanup-error propagation.
- Final independent reviews: no actionable findings.

Blacksmith Testbox was attempted first but remained queued while its status API timed out; its unused lease was cancelled, and trusted-source heavy proof was completed on direct AWS Crabbox instead.
