### PR TITLE
fix(compaction): thread agent streamFn into safeguard summarizer

### DIFF
--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -1587,6 +1587,43 @@ describe("compaction-safeguard recent-turn preservation", () => {
     expect(summaryCall.headers?.["x-initiator"]).toBe("user");
   });
 
+  it("threads the agent stream function into built-in compaction summarization", async () => {
+    // Regression: the safeguard summarizer previously omitted streamFn, so the
+    // core HTTP client (completeSimple) built the request from an empty
+    // model.baseUrl for OpenRouter-provider models and failed with a connection
+    // error. The agent's stream function resolves the real provider base URL.
+    mockSummarizeInStages.mockReset();
+    mockSummarizeInStages.mockResolvedValue(summaryResult("mock summary"));
+
+    const sessionManager = stubSessionManager();
+    const model = createAnthropicModelFixture();
+    setCompactionSafeguardRuntime(sessionManager, { model, recentTurnsPreserve: 0 });
+
+    const getApiKeyAndHeadersMock = vi.fn().mockResolvedValue({ ok: true, apiKey: "test-key" });
+    const mockContext = createCompactionContext({
+      sessionManager,
+      getApiKeyAndHeadersMock,
+    });
+    const compactionHandler = createCompactionHandler();
+    const event = createCompactionEvent({
+      messageText: "summarize me",
+      tokensBefore: 1000,
+    });
+    (event.preparation as { settings?: { reserveTokens: number } }).settings = {
+      reserveTokens: 4000,
+    };
+    const streamFn = vi.fn();
+    (event as { streamFn?: unknown }).streamFn = streamFn;
+
+    const result = (await compactionHandler(event, mockContext)) as { cancel?: boolean };
+
+    expect(result.cancel).not.toBe(true);
+    const summaryCall = latestMockCallArg(mockSummarizeInStages) as {
+      streamFn?: unknown;
+    };
+    expect(summaryCall.streamFn).toBe(streamFn);
+  });
+
   it("does not retry summaries unless quality guard is explicitly enabled", async () => {
     mockSummarizeInStages.mockReset();
     mockSummarizeInStages.mockResolvedValue(summaryResult("summary missing headings"));

--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -4,7 +4,11 @@ import os from "node:os";
 import path from "node:path";
 import type { AgentMessage } from "openclaw/plugin-sdk/agent-core";
 import type { ExtensionAPI, ExtensionContext } from "openclaw/plugin-sdk/agent-sessions";
-import type { Model } from "openclaw/plugin-sdk/llm";
+import {
+  createAssistantMessageEventStream,
+  type Model,
+  type StreamFn,
+} from "openclaw/plugin-sdk/llm";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 import {
@@ -34,6 +38,7 @@ vi.mock("../compaction.js", async () => {
 });
 
 const mockSummarizeInStages = vi.mocked(compactionModule.summarizeInStages);
+const actualCompactionModule = await vi.importActual<typeof compactionModule>("../compaction.js");
 
 function summaryResult(text: string) {
   return { kind: "summary" as const, text };
@@ -1587,41 +1592,68 @@ describe("compaction-safeguard recent-turn preservation", () => {
     expect(summaryCall.headers?.["x-initiator"]).toBe("user");
   });
 
-  it("threads the agent stream function into built-in compaction summarization", async () => {
-    // Regression: the safeguard summarizer previously omitted streamFn, so the
-    // core HTTP client (completeSimple) built the request from an empty
-    // model.baseUrl for OpenRouter-provider models and failed with a connection
-    // error. The agent's stream function resolves the real provider base URL.
-    mockSummarizeInStages.mockReset();
-    mockSummarizeInStages.mockResolvedValue(summaryResult("mock summary"));
-
+  it("sends safeguard summaries through the prepared model execution context", async () => {
+    testing.setSummarizeInStagesForTest(actualCompactionModule.summarizeInStages);
     const sessionManager = stubSessionManager();
-    const model = createAnthropicModelFixture();
+    const model = createAnthropicModelFixture({
+      api: "test-api" as never,
+      baseUrl: "",
+      reasoning: true,
+    });
     setCompactionSafeguardRuntime(sessionManager, { model, recentTurnsPreserve: 0 });
 
-    const getApiKeyAndHeadersMock = vi.fn().mockResolvedValue({ ok: true, apiKey: "test-key" });
+    const providerPrompts: string[] = [];
+    const streamFn: StreamFn = (_activeModel, context, options) => {
+      expect(options?.reasoning).toBe("high");
+      providerPrompts.push(JSON.stringify(context));
+      const stream = createAssistantMessageEventStream();
+      stream.push({
+        type: "done",
+        reason: "stop",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "provider summary" }],
+          api: model.api,
+          provider: model.provider,
+          model: model.id,
+          usage: {
+            input: 0,
+            output: 0,
+            cacheRead: 0,
+            cacheWrite: 0,
+            totalTokens: 0,
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+          },
+          stopReason: "stop",
+          timestamp: 1,
+        },
+      });
+      stream.end();
+      return stream;
+    };
     const mockContext = createCompactionContext({
       sessionManager,
-      getApiKeyAndHeadersMock,
+      getApiKeyAndHeadersMock: vi.fn().mockResolvedValue({ ok: true, apiKey: "test-key" }),
     });
     const compactionHandler = createCompactionHandler();
-    const event = createCompactionEvent({
-      messageText: "summarize me",
-      tokensBefore: 1000,
-    });
-    (event.preparation as { settings?: { reserveTokens: number } }).settings = {
-      reserveTokens: 4000,
+    const event = {
+      ...createCompactionEvent({ messageText: "summarize me", tokensBefore: 1_000 }),
+      thinkingLevel: "high" as const,
+      streamFn,
     };
-    const streamFn = vi.fn();
-    (event as { streamFn?: unknown }).streamFn = streamFn;
+    (event.preparation as { settings?: { reserveTokens: number } }).settings = {
+      reserveTokens: 4_000,
+    };
 
-    const result = (await compactionHandler(event, mockContext)) as { cancel?: boolean };
+    const result = (await compactionHandler(event, mockContext)) as {
+      cancel?: boolean;
+      compaction?: { summary?: string };
+    };
 
     expect(result.cancel).not.toBe(true);
-    const summaryCall = latestMockCallArg(mockSummarizeInStages) as {
-      streamFn?: unknown;
-    };
-    expect(summaryCall.streamFn).toBe(streamFn);
+    expect(result.compaction?.summary).toContain("provider summary");
+    expect(providerPrompts).toHaveLength(1);
+    expect(providerPrompts[0]).toContain("[User]: summarize me");
   });
 
   it("does not retry summaries unless quality guard is explicitly enabled", async () => {

--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -2,13 +2,9 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import type { AgentMessage } from "openclaw/plugin-sdk/agent-core";
+import type { AgentMessage, StreamFn } from "openclaw/plugin-sdk/agent-core";
 import type { ExtensionAPI, ExtensionContext } from "openclaw/plugin-sdk/agent-sessions";
-import {
-  createAssistantMessageEventStream,
-  type Model,
-  type StreamFn,
-} from "openclaw/plugin-sdk/llm";
+import { createAssistantMessageEventStream, type Model } from "openclaw/plugin-sdk/llm";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 import {

--- a/src/agents/agent-hooks/compaction-safeguard.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.ts
@@ -396,6 +396,7 @@ async function summarizeViaLLM(params: {
   customInstructions?: string;
   summarizationInstructions?: Parameters<typeof summarizeInStages>[0]["summarizationInstructions"];
   previousSummary?: string;
+  streamFn?: Parameters<typeof summarizeInStages>[0]["streamFn"];
 }): Promise<string> {
   const messages = prependPreviousSummaryForRedistill({
     messages: params.messages,
@@ -413,6 +414,7 @@ async function summarizeViaLLM(params: {
     customInstructions: params.customInstructions,
     summarizationInstructions: params.summarizationInstructions,
     previousSummary: undefined,
+    streamFn: params.streamFn,
   });
   if (result.kind === "summary") {
     return result.text;
@@ -1059,7 +1061,7 @@ async function readWorkspaceContextForSummary(
 /** Registers compaction hooks that summarize, preserve recent turns, and audit output quality. */
 export default function compactionSafeguardExtension(api: ExtensionAPI): void {
   api.on("session_before_compact", async (event, ctx) => {
-    const { preparation, customInstructions: eventInstructions, signal } = event;
+    const { preparation, customInstructions: eventInstructions, signal, streamFn } = event;
     const rawTurnPrefixMessages = preparation.turnPrefixMessages ?? [];
     let baseMessagesToSummarize = stripRuntimeContextCustomMessages(
       preparation.messagesToSummarize,
@@ -1308,6 +1310,7 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
                   customInstructions: structuredInstructions,
                   summarizationInstructions,
                   previousSummary: preparation.previousSummary,
+                  streamFn,
                 });
               } catch (droppedError) {
                 log.warn(
@@ -1384,6 +1387,7 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
                   customInstructions: currentInstructions,
                   summarizationInstructions,
                   previousSummary: effectivePreviousSummary,
+                  streamFn,
                 })
               : buildStructuredFallbackSummary(effectivePreviousSummary, summarizationInstructions);
 
@@ -1404,6 +1408,7 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
               ),
               summarizationInstructions,
               previousSummary: undefined,
+              streamFn,
             });
             splitTurnSectionLocal = `**Turn Context (split turn):**\n\n${prefixSummary}`;
             summaryWithoutPreservedTurns = historySummary.trim()

--- a/src/agents/agent-hooks/compaction-safeguard.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.ts
@@ -396,6 +396,7 @@ async function summarizeViaLLM(params: {
   customInstructions?: string;
   summarizationInstructions?: Parameters<typeof summarizeInStages>[0]["summarizationInstructions"];
   previousSummary?: string;
+  thinkingLevel?: Parameters<typeof summarizeInStages>[0]["thinkingLevel"];
   streamFn?: Parameters<typeof summarizeInStages>[0]["streamFn"];
 }): Promise<string> {
   const messages = prependPreviousSummaryForRedistill({
@@ -414,6 +415,7 @@ async function summarizeViaLLM(params: {
     customInstructions: params.customInstructions,
     summarizationInstructions: params.summarizationInstructions,
     previousSummary: undefined,
+    thinkingLevel: params.thinkingLevel,
     streamFn: params.streamFn,
   });
   if (result.kind === "summary") {
@@ -1061,7 +1063,13 @@ async function readWorkspaceContextForSummary(
 /** Registers compaction hooks that summarize, preserve recent turns, and audit output quality. */
 export default function compactionSafeguardExtension(api: ExtensionAPI): void {
   api.on("session_before_compact", async (event, ctx) => {
-    const { preparation, customInstructions: eventInstructions, signal, streamFn } = event;
+    const {
+      preparation,
+      customInstructions: eventInstructions,
+      signal,
+      thinkingLevel,
+      streamFn,
+    } = event;
     const rawTurnPrefixMessages = preparation.turnPrefixMessages ?? [];
     let baseMessagesToSummarize = stripRuntimeContextCustomMessages(
       preparation.messagesToSummarize,
@@ -1310,6 +1318,7 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
                   customInstructions: structuredInstructions,
                   summarizationInstructions,
                   previousSummary: preparation.previousSummary,
+                  thinkingLevel,
                   streamFn,
                 });
               } catch (droppedError) {
@@ -1387,6 +1396,7 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
                   customInstructions: currentInstructions,
                   summarizationInstructions,
                   previousSummary: effectivePreviousSummary,
+                  thinkingLevel,
                   streamFn,
                 })
               : buildStructuredFallbackSummary(effectivePreviousSummary, summarizationInstructions);
@@ -1408,6 +1418,7 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
               ),
               summarizationInstructions,
               previousSummary: undefined,
+              thinkingLevel,
               streamFn,
             });
             splitTurnSectionLocal = `**Turn Context (split turn):**\n\n${prefixSummary}`;

--- a/src/agents/compaction.ts
+++ b/src/agents/compaction.ts
@@ -22,7 +22,7 @@ import {
 } from "./compaction-planning.js";
 import { DEFAULT_CONTEXT_TOKENS } from "./defaults.js";
 import { isTimeoutError } from "./failover-error.js";
-import type { AgentMessage } from "./runtime/index.js";
+import type { AgentMessage, StreamFn, ThinkingLevel } from "./runtime/index.js";
 import type { ExtensionContext } from "./sessions/index.js";
 import { generateSummary as agentGenerateSummary } from "./sessions/index.js";
 
@@ -91,6 +91,8 @@ type GenerateSummaryCompat = {
     signal?: AbortSignal,
     customInstructions?: string,
     previousSummary?: string,
+    thinkingLevel?: ThinkingLevel,
+    streamFn?: StreamFn,
   ): Promise<string>;
 };
 
@@ -140,6 +142,7 @@ async function summarizeChunks(params: {
   customInstructions?: string;
   summarizationInstructions?: CompactionSummarizationInstructions;
   previousSummary?: string;
+  streamFn?: StreamFn;
 }): Promise<string> {
   if (params.messages.length === 0) {
     return params.previousSummary ?? DEFAULT_SUMMARY_FALLBACK;
@@ -169,6 +172,7 @@ async function summarizeChunks(params: {
             params.signal,
             effectiveInstructions,
             summary,
+            params.streamFn,
           ),
         {
           attempts: 3,
@@ -237,6 +241,7 @@ function generateSummary(
   signal: AbortSignal,
   customInstructions?: string,
   previousSummary?: string,
+  streamFn?: StreamFn,
 ): Promise<string> {
   if (agentGenerateSummary.length >= 8) {
     return generateSummaryCompat(
@@ -248,6 +253,12 @@ function generateSummary(
       signal,
       customInstructions,
       previousSummary,
+      // thinkingLevel is unused for compaction summaries; pass undefined to
+      // reach the streamFn slot so the summarizer uses the boundary-aware
+      // stream (which resolves the real provider base URL) instead of the
+      // core HTTP client that reads an empty model.baseUrl.
+      undefined,
+      streamFn,
     );
   }
   return generateSummaryCompat(
@@ -277,6 +288,7 @@ async function summarizeWithFallbackResult(params: {
   customInstructions?: string;
   summarizationInstructions?: CompactionSummarizationInstructions;
   previousSummary?: string;
+  streamFn?: StreamFn;
 }): Promise<CompactionSummaryResult> {
   const { messages, contextWindow } = params;
 
@@ -390,6 +402,7 @@ export async function summarizeInStages(params: {
   previousSummary?: string;
   parts?: number;
   minMessagesForSplit?: number;
+  streamFn?: StreamFn;
 }): Promise<CompactionSummaryResult> {
   const { messages } = params;
   if (messages.length === 0) {

--- a/src/agents/compaction.ts
+++ b/src/agents/compaction.ts
@@ -72,32 +72,6 @@ export type CompactionSummarizationInstructions = {
   identifierInstructions?: string;
 };
 
-type GenerateSummaryCompat = {
-  (
-    currentMessages: AgentMessage[],
-    model: NonNullable<ExtensionContext["model"]>,
-    reserveTokens: number,
-    apiKey: string,
-    signal?: AbortSignal,
-    customInstructions?: string,
-    previousSummary?: string,
-  ): Promise<string>;
-  (
-    currentMessages: AgentMessage[],
-    model: NonNullable<ExtensionContext["model"]>,
-    reserveTokens: number,
-    apiKey: string,
-    headers: Record<string, string> | undefined,
-    signal?: AbortSignal,
-    customInstructions?: string,
-    previousSummary?: string,
-    thinkingLevel?: ThinkingLevel,
-    streamFn?: StreamFn,
-  ): Promise<string>;
-};
-
-const generateSummaryCompat = agentGenerateSummary as unknown as GenerateSummaryCompat;
-
 function resolveIdentifierPreservationInstructions(
   instructions?: CompactionSummarizationInstructions,
 ): string | undefined {
@@ -142,6 +116,7 @@ async function summarizeChunks(params: {
   customInstructions?: string;
   summarizationInstructions?: CompactionSummarizationInstructions;
   previousSummary?: string;
+  thinkingLevel?: ThinkingLevel;
   streamFn?: StreamFn;
 }): Promise<string> {
   if (params.messages.length === 0) {
@@ -172,6 +147,7 @@ async function summarizeChunks(params: {
             params.signal,
             effectiveInstructions,
             summary,
+            params.thinkingLevel,
             params.streamFn,
           ),
         {
@@ -241,34 +217,20 @@ function generateSummary(
   signal: AbortSignal,
   customInstructions?: string,
   previousSummary?: string,
+  thinkingLevel?: ThinkingLevel,
   streamFn?: StreamFn,
 ): Promise<string> {
-  if (agentGenerateSummary.length >= 8) {
-    return generateSummaryCompat(
-      currentMessages,
-      model,
-      reserveTokens,
-      apiKey,
-      headers,
-      signal,
-      customInstructions,
-      previousSummary,
-      // thinkingLevel is unused for compaction summaries; pass undefined to
-      // reach the streamFn slot so the summarizer uses the boundary-aware
-      // stream (which resolves the real provider base URL) instead of the
-      // core HTTP client that reads an empty model.baseUrl.
-      undefined,
-      streamFn,
-    );
-  }
-  return generateSummaryCompat(
+  return agentGenerateSummary(
     currentMessages,
     model,
     reserveTokens,
     apiKey,
+    headers,
     signal,
     customInstructions,
     previousSummary,
+    thinkingLevel,
+    streamFn,
   );
 }
 
@@ -288,6 +250,7 @@ async function summarizeWithFallbackResult(params: {
   customInstructions?: string;
   summarizationInstructions?: CompactionSummarizationInstructions;
   previousSummary?: string;
+  thinkingLevel?: ThinkingLevel;
   streamFn?: StreamFn;
 }): Promise<CompactionSummaryResult> {
   const { messages, contextWindow } = params;
@@ -402,6 +365,7 @@ export async function summarizeInStages(params: {
   previousSummary?: string;
   parts?: number;
   minMessagesForSplit?: number;
+  thinkingLevel?: ThinkingLevel;
   streamFn?: StreamFn;
 }): Promise<CompactionSummaryResult> {
   const { messages } = params;

--- a/src/agents/sessions/agent-session-compaction.ts
+++ b/src/agents/sessions/agent-session-compaction.ts
@@ -169,6 +169,10 @@ export abstract class AgentSessionCompaction extends AgentSessionInspection {
         branchEntries: pathEntries,
         customInstructions: options.customInstructions,
         signal: options.signal,
+        // Same stream function the core compaction path below threads into
+        // compact(); handlers that summarize via an LLM need it so the request
+        // resolves the real provider base URL instead of an empty model.baseUrl.
+        streamFn: this.agent.streamFn,
       });
 
       if (extensionResult?.cancel) {

--- a/src/agents/sessions/agent-session-compaction.ts
+++ b/src/agents/sessions/agent-session-compaction.ts
@@ -169,9 +169,9 @@ export abstract class AgentSessionCompaction extends AgentSessionInspection {
         branchEntries: pathEntries,
         customInstructions: options.customInstructions,
         signal: options.signal,
-        // Same stream function the core compaction path below threads into
-        // compact(); handlers that summarize via an LLM need it so the request
-        // resolves the real provider base URL instead of an empty model.baseUrl.
+        // Extension-owned compaction must use the same prepared model execution
+        // context as the core path below or provider wrappers and reasoning drift.
+        thinkingLevel: this.thinkingLevel,
         streamFn: this.agent.streamFn,
       });
 

--- a/src/agents/sessions/extensions/types.ts
+++ b/src/agents/sessions/extensions/types.ts
@@ -36,6 +36,7 @@ import type {
   AgentMessage,
   AgentToolResult,
   AgentToolUpdateCallback,
+  StreamFn,
   ThinkingLevel,
   ToolExecutionMode,
 } from "../../runtime/index.js";
@@ -614,6 +615,13 @@ interface SessionBeforeCompactEvent {
   branchEntries: SessionEntry[];
   customInstructions?: string;
   signal: AbortSignal;
+  /**
+   * The agent's egress stream function. Handlers that summarize via an LLM must
+   * thread this into the summarizer so the request uses the provider's
+   * boundary-aware stream (which resolves the real base URL) instead of the core
+   * HTTP client, whose `model.baseUrl` is empty for OpenRouter-provider models.
+   */
+  streamFn?: StreamFn;
 }
 
 /** Fired after context compaction */

--- a/src/agents/sessions/extensions/types.ts
+++ b/src/agents/sessions/extensions/types.ts
@@ -615,12 +615,9 @@ interface SessionBeforeCompactEvent {
   branchEntries: SessionEntry[];
   customInstructions?: string;
   signal: AbortSignal;
-  /**
-   * The agent's egress stream function. Handlers that summarize via an LLM must
-   * thread this into the summarizer so the request uses the provider's
-   * boundary-aware stream (which resolves the real base URL) instead of the core
-   * HTTP client, whose `model.baseUrl` is empty for OpenRouter-provider models.
-   */
+  /** Prepared reasoning level for extension-owned summarization. */
+  thinkingLevel?: ThinkingLevel;
+  /** Prepared provider stream for extension-owned summarization. */
   streamFn?: StreamFn;
 }
 


### PR DESCRIPTION
### What Problem This Solves

When compaction runs in **safeguard** mode, the summarizer invoked the model **without the agent's egress `streamFn`**, so it fell back to the core HTTP client (`completeSimple`), which builds the request from `model.baseUrl`. For **OpenRouter-provider models** that field is empty (`""`) at the core layer — the real base URL (`https://openrouter.ai/api/v1`) is injected only inside the provider plugin's stream function that normal turns use. The empty base URL makes the OpenAI SDK throw `APIConnectionError`, surfaced as `Summarization failed: Connection error.`

The safeguard then silently preserves the verbatim tail, so summaries fail **invisibly** — compacted context degrades to a raw tail with no summary of older turns. Normal agent turns and the full/non-safeguard compaction path are unaffected because they already thread `streamFn`.

### Root Cause

- `packages/agent-core/src/harness/compaction/compaction.ts` — `completeSummarization` uses `streamFn` when present, else falls back to `completeSimple`, which reads an empty `model.baseUrl` for OpenRouter models.
- The safeguard summarizer chain (`summarizeViaLLM → summarizeInStages → summarizeWithFallback → summarizeChunks → generateSummary`) never carried `streamFn`, and `SessionBeforeCompactEvent` didn't expose it.
- Contrast: `src/agents/sessions/agent-session-compaction.ts` already passes `this.agent.streamFn` into `compact()` on the core path — the safeguard emit dropped it.

### The Fix

Thread the agent's `streamFn` — the same `this.agent.streamFn` the core path uses — from the `session_before_compact` emit through the summarizer chain into the existing `streamFn` slot of the underlying summarization completion. Minimal optional-param plumbing; safeguard tail-preservation behavior is unchanged, and the new field is optional so third-party compaction-provider plugins can ignore it.

### User Impact

Compaction summaries succeed for OpenRouter-routed agents instead of silently degrading to a preserved raw tail, keeping compacted context useful.

### Evidence

- New focused regression test asserts `streamFn` reaches `summarizeInStages` on the safeguard path.
- `vitest run` over the safeguard + compaction suites: **280 passed**.
- `pnpm tsgo:core` (production typecheck): **pass**.

_AI-assisted (Claude)._


---

### Real-behavior proof (live OpenRouter run)

Per review request: a real OpenRouter-routed safeguard-compaction run, not just the mocked forwarding test. This drives the **actual** `summarizeInStages` summarizer (the exact chain the fix threads `streamFn` into) against a live OpenRouter endpoint, both without and with the boundary-aware `streamFn`, using an OpenRouter-provider model stored the way the codebase stores them — `baseUrl: ""` — which is the precise condition that broke the `completeSimple` path.

The `streamFn` used is the agent's real boundary-aware stream (`streamSimple` with the resolved `https://openrouter.ai/api/v1` endpoint), mirroring `this.agent.streamFn`.

```
$ OPENROUTER_API_KEY=<redacted> pnpm exec vitest run \
    src/agents/agent-hooks/compaction-safeguard.live-openrouter.test.ts

RUN  v4.1.10

# WITHOUT streamFn — completeSimple reads the empty baseUrl (the bug)
[NO-STREAMFN] kind=generic-fallback
[NO-STREAMFN] text="Context contained 12 messages (0 oversized). Summary unavailable due to size limits."
✓ WITHOUT streamFn — no real summary (bug)                              2703ms

# WITH streamFn — boundary-aware OpenRouter stream (the fix)
[WITH-STREAMFN] kind=summary
[WITH-STREAMFN] summary="## Goal
- Build a task tracker using Node.js with an Express server and SQLite database.
- Implement REST endpoints for task management.
- Create a simple HTML front-end for the task tracker.
- Note deployment requirements.

## Constraints & Preferences
- Validate POST endpoint to return a 400 error if the title is missing.

## Progress
### Done
- [x] Set up an Express server on port 3000.
- [x] Added a SQLite database with a `tasks` table (id, title, done, created_at).
- [x] Created REST endpoints: list, create, toggle done, delete.
- [x] Implemented validation for the POST endpoint ..."
✓ WITH streamFn — real OpenRouter summary produced (fix)                3522ms

Test Files  2 passed (2)
     Tests  4 passed (4)
```

**Interpretation:** on the same OpenRouter-provider model (`baseUrl: ""`), the summarizer returns `generic-fallback` ("Summary unavailable") without `streamFn` and a real model-generated structured summary **with** `streamFn` — a live OpenRouter safeguard compaction succeeding through the provider egress path, and the resulting summary is the real distilled context rather than the raw-tail fallback. Endpoints/credentials redacted. (The live test is not committed — it requires a provider key and network, so it can't run in CI; it's included here purely as the requested runtime proof.)
