### PR TITLE
feat(ui): add text search/filter to model picker

### DIFF
--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -3956,6 +3956,9 @@ export const en: TranslationMap = {
       sessionOverride: "Thread override",
       usingDefault: "Using default from Settings",
       resetToDefault: "Reset to default ({model})",
+      searchModels: "Search models...",
+      clearSearch: "Clear search",
+      noModelsFound: "No models matching \"{query}\"",
     },
     sideChat: {
       title: "Side chat",

--- a/ui/src/pages/chat/components/chat-model-controls.ts
+++ b/ui/src/pages/chat/components/chat-model-controls.ts
@@ -29,6 +29,91 @@ import {
 import { areUiSessionKeysEquivalent } from "../../../lib/sessions/session-key.ts";
 import { selectChatModelProvider } from "./chat-model-provider-menu.ts";
 
+// Ephemeral search state persisted across re-renders, keyed by session key.
+const modelSearchQueries = new Map<string, string>();
+
+function getModelSearchQuery(sessionKey: string): string {
+  return modelSearchQueries.get(sessionKey) ?? "";
+}
+
+function setModelSearchQuery(sessionKey: string, query: string): void {
+  if (query) {
+    modelSearchQueries.set(sessionKey, query);
+  } else {
+    modelSearchQueries.delete(sessionKey);
+  }
+}
+
+type ChatModelFilterState = {
+  query: string;
+  filteredOptions: ChatModelProviderOption[];
+  activeProviderGroups: [string, ChatModelProviderOption[]][];
+};
+
+function normalizeModelFilterQuery(query: string): string {
+  return query.trim().toLowerCase();
+}
+
+function matchesModelFilter(
+  option: ChatModelProviderOption,
+  normalizedQuery: string,
+): boolean {
+  if (!normalizedQuery) {
+    return true;
+  }
+  const modelLabel = option.label.toLowerCase();
+  const modelValue = option.value.toLowerCase();
+  const providerLabel = providerDisplayLabel(option.provider).toLowerCase();
+  const rawProviderLabel = formatRawProviderLabel(option.provider).toLowerCase();
+  return (
+    modelLabel.includes(normalizedQuery) ||
+    modelValue.includes(normalizedQuery) ||
+    providerLabel.includes(normalizedQuery) ||
+    rawProviderLabel.includes(normalizedQuery)
+  );
+}
+
+function resolveModelFilterState(
+  modelOptions: ChatModelProviderOption[],
+  searchQuery: string,
+): ChatModelFilterState {
+  const normalizedQuery = normalizeModelFilterQuery(searchQuery);
+  if (!normalizedQuery) {
+    // No search — use normal provider-grouped view
+    const providerGroups = new Map<string, ChatModelProviderOption[]>();
+    for (const option of modelOptions) {
+      const existing = providerGroups.get(option.provider);
+      if (existing) {
+        existing.push(option);
+      } else {
+        providerGroups.set(option.provider, [option]);
+      }
+    }
+    return {
+      query: searchQuery,
+      filteredOptions: modelOptions,
+      activeProviderGroups: [...providerGroups],
+    };
+  }
+  // Search active — filter across all providers
+  const filtered = modelOptions.filter((option) => matchesModelFilter(option, normalizedQuery));
+  // Group filtered results by provider
+  const providerGroups = new Map<string, ChatModelProviderOption[]>();
+  for (const option of filtered) {
+    const existing = providerGroups.get(option.provider);
+    if (existing) {
+      existing.push(option);
+    } else {
+      providerGroups.set(option.provider, [option]);
+    }
+  }
+  return {
+    query: searchQuery,
+    filteredOptions: filtered,
+    activeProviderGroups: [...providerGroups],
+  };
+}
+
 export type ChatModelControlsProps = {
   activeRunId: string | null;
   agentDefaultModel?: string;
@@ -484,26 +569,22 @@ function renderChatModelReasoningSelect(params: {
   const effectiveThinkingValue = selectedThinkingValue || thinkingDefaultValue;
   const onlyStopSelected = onlyStop?.value === effectiveThinkingValue;
   const showReasoningPanel = showReasoning || showFastMode;
-  const providerGroups = new Map<string, ChatModelProviderOption[]>();
-  for (const option of modelOptions) {
-    const existing = providerGroups.get(option.provider);
-    if (existing) {
-      existing.push(option);
-    } else {
-      providerGroups.set(option.provider, [option]);
-    }
-  }
+  // Search/filter state (persisted per session across re-renders)
+  const modelSearchQuery = getModelSearchQuery(sessionKey);
+  const filterState = resolveModelFilterState(modelOptions, modelSearchQuery);
   const defaultModelOption = modelOptions.find((option) => option.isDefault);
-  const orderedProviderGroups = [...providerGroups];
-  const defaultProviderIndex = orderedProviderGroups.findIndex(
+  const orderedProviderGroups = filterState.activeProviderGroups;
+  // Sort: default provider first, then alphabetical
+  const defaultProviderIdx = orderedProviderGroups.findIndex(
     ([provider]) => provider === defaultModelOption?.provider,
   );
-  if (defaultProviderIndex > 0) {
-    const [defaultProviderGroup] = orderedProviderGroups.splice(defaultProviderIndex, 1);
-    if (defaultProviderGroup) {
-      orderedProviderGroups.unshift(defaultProviderGroup);
+  if (defaultProviderIdx > 0) {
+    const [defaultGroup] = orderedProviderGroups.splice(defaultProviderIdx, 1);
+    if (defaultGroup) {
+      orderedProviderGroups.unshift(defaultGroup);
     }
   }
+  const isSearching = modelSearchQuery.trim().length > 0;
   const selectedModelOption =
     (selectedModelValue === ""
       ? defaultModelOption
@@ -562,7 +643,18 @@ function renderChatModelReasoningSelect(params: {
     `;
   };
   return html`
-    <details class="chat-controls__session chat-controls__inline-select chat-controls__model">
+    <details class="chat-controls__session chat-controls__inline-select chat-controls__model" @toggle=${(event: Event) => {
+      const details = event.currentTarget as HTMLDetailsElement;
+      if (!details.open) {
+        setModelSearchQuery(sessionKey, "");
+      } else {
+        // Auto-focus search input when picker opens
+        requestAnimationFrame(() => {
+          const searchInput = details.querySelector<HTMLInputElement>(".chat-controls__model-search-input");
+          searchInput?.focus();
+        });
+      }
+    }}>
       <summary
         class="chat-controls__inline-select-trigger ${disabled
           ? "chat-controls__inline-select-trigger--disabled"
@@ -615,53 +707,136 @@ function renderChatModelReasoningSelect(params: {
                 onReset: () => commitModel(""),
               })}
               <div class="chat-controls__model-browser">
-                <div class="chat-controls__provider-list" aria-label=${t("sessionsView.provider")}>
-                  <div class="chat-controls__inline-select-section-label">
-                    ${t("sessionsView.provider")}
-                  </div>
-                  ${repeat(
-                    orderedProviderGroups,
-                    ([provider]) => provider,
-                    ([provider]) => {
-                      const active = provider === selectedProvider;
-                      return html`
+                <div class="chat-controls__model-search" role="search">
+                  <span class="chat-controls__model-search-icon" aria-hidden="true">
+                    ${icons.search}
+                  </span>
+                  <input
+                    class="chat-controls__model-search-input"
+                    type="text"
+                    placeholder=${t("chat.modelControls.searchModels")}
+                    aria-label=${t("chat.modelControls.searchModels")}
+                    .value=${modelSearchQuery}
+                    @input=${(event: Event) => {
+                      const input = event.currentTarget as HTMLInputElement;
+                      setModelSearchQuery(sessionKey, input.value);
+                      // Force re-render by triggering a state update
+                      onRequestUpdate?.();
+                    }}
+                    @keydown=${(event: KeyboardEvent) => {
+                      if (event.key === "Escape") {
+                        setModelSearchQuery(sessionKey, "");
+                        onRequestUpdate?.();
+                        event.stopPropagation();
+                      } else if (event.key === "Enter") {
+                        // Select first matching model
+                        const firstOption = filterState.filteredOptions[0];
+                        if (firstOption && !disabled && !modelSelectionLocked) {
+                          commitModel(firstOption.commitValue);
+                        }
+                        event.preventDefault();
+                      }
+                    }}
+                  />
+                  ${modelSearchQuery
+                    ? html`
                         <button
-                          class="chat-controls__provider-option"
-                          data-chat-model-provider=${provider}
+                          class="chat-controls__model-search-clear"
                           type="button"
-                          aria-pressed=${active ? "true" : "false"}
-                          @click=${(event: MouseEvent) => selectChatModelProvider(event, provider)}
+                          aria-label=${t("chat.modelControls.clearSearch")}
+                          @click=${() => {
+                            setModelSearchQuery(sessionKey, "");
+                            onRequestUpdate?.();
+                          }}
                         >
-                          ${renderChatModelProviderIcon(provider)}
-                          <span>${providerDisplayLabel(provider)}</span>
+                          ${icons.x}
                         </button>
-                      `;
-                    },
-                  )}
+                      `
+                    : ""}
                 </div>
+                ${!isSearching
+                  ? html`
+                      <div class="chat-controls__provider-list" aria-label=${t("sessionsView.provider")}>
+                        <div class="chat-controls__inline-select-section-label">
+                          ${t("sessionsView.provider")}
+                        </div>
+                        ${repeat(
+                          orderedProviderGroups,
+                          ([provider]) => provider,
+                          ([provider]) => {
+                            const active = provider === selectedProvider;
+                            return html`
+                              <button
+                                class="chat-controls__provider-option"
+                                data-chat-model-provider=${provider}
+                                type="button"
+                                aria-pressed=${active ? "true" : "false"}
+                                @click=${(event: MouseEvent) => selectChatModelProvider(event, provider)}
+                              >
+                                ${renderChatModelProviderIcon(provider)}
+                                <span>${providerDisplayLabel(provider)}</span>
+                              </button>
+                            `;
+                          },
+                        )}
+                      </div>
+                    `
+                  : ""}
                 <div
-                  class="chat-controls__provider-models"
+                  class="chat-controls__provider-models ${isSearching ? "chat-controls__provider-models--search-results" : ""}
                   role="listbox"
                   aria-label=${t("chat.selectors.model")}
                 >
-                  ${repeat(
-                    orderedProviderGroups,
-                    ([provider]) => provider,
-                    ([provider, options]) => html`
-                      <div
-                        class="chat-controls__provider-model-group"
-                        data-chat-model-provider-group=${provider}
-                        aria-label=${`${providerDisplayLabel(provider)} models`}
-                        ?hidden=${provider !== selectedProvider}
-                      >
-                        ${repeat(
-                          options,
-                          (entry) => entry.value,
-                          (entry) => renderModelOption(entry),
-                        )}
-                      </div>
-                    `,
-                  )}
+                  ${filterState.filteredOptions.length === 0 && isSearching
+                    ? html`
+                        <div class="chat-controls__model-search-empty">
+                          ${t("chat.modelControls.noModelsFound", { query: modelSearchQuery })}
+                        </div>
+                      `
+                    : isSearching
+                      ? html`
+                          ${repeat(
+                            orderedProviderGroups,
+                            ([provider]) => provider,
+                            ([provider, options]) => html`
+                              <div
+                                class="chat-controls__provider-model-group"
+                                data-chat-model-provider-group=${provider}
+                                aria-label=${`${providerDisplayLabel(provider)} models`}
+                              >
+                                <div class="chat-controls__model-search-group-label">
+                                  ${renderChatModelProviderIcon(provider)}
+                                  <span>${providerDisplayLabel(provider)}</span>
+                                </div>
+                                ${repeat(
+                                  options,
+                                  (entry) => entry.value,
+                                  (entry) => renderModelOption(entry),
+                                )}
+                              </div>
+                            `,
+                          )}
+                        `
+                      : html`
+                          ${repeat(
+                            orderedProviderGroups,
+                            ([provider]) => provider,
+                            ([provider, options]) => html`
+                              <div
+                                class="chat-controls__provider-model-group"
+                                data-chat-model-provider-group=${provider}
+                                aria-label=${`${providerDisplayLabel(provider)} models`}
+                                ?hidden=${provider !== selectedProvider}
+                              >
+                                ${repeat(
+                                  options,
+                                  (entry) => entry.value,
+                                  (entry) => renderModelOption(entry),
+                                )}
+                              </div>
+                            `,
+                          )}
+                        `}
                 </div>
               </div>
             `}

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -3699,10 +3699,20 @@ openclaw-chat-page {
 .chat-controls__model-browser {
   display: grid;
   grid-template-columns: 120px minmax(0, 1fr);
+  grid-template-rows: auto 1fr;
   min-height: 132px;
-  max-height: 220px;
-  flex: 1 1 220px;
+  max-height: 260px;
+  flex: 1 1 260px;
   overflow: hidden;
+}
+
+.chat-controls__model-browser .chat-controls__model-search {
+  grid-column: 1 / -1;
+}
+
+.chat-controls__model-browser .chat-controls__provider-list,
+.chat-controls__model-browser .chat-controls__provider-models--search-results {
+  grid-column: 1 / -1;
 }
 
 .chat-controls__locked-model {
@@ -3807,6 +3817,98 @@ openclaw-chat-page {
 
 .chat-controls__provider-model-group[hidden] {
   display: none;
+}
+
+/* Model search */
+.chat-controls__model-search {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 8px;
+  border-bottom: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
+  background: color-mix(in srgb, var(--card) 78%, transparent);
+}
+
+.chat-controls__model-search-icon {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  color: var(--muted);
+}
+
+.chat-controls__model-search-icon svg {
+  width: 14px;
+  height: 14px;
+}
+
+.chat-controls__model-search-input {
+  flex: 1 1 auto;
+  min-width: 0;
+  border: none;
+  background: transparent;
+  color: var(--text);
+  font: inherit;
+  font-size: 12px;
+  outline: none;
+  padding: 2px 0;
+}
+
+.chat-controls__model-search-input::placeholder {
+  color: var(--muted);
+}
+
+.chat-controls__model-search-clear {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  padding: 0;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+}
+
+.chat-controls__model-search-clear:hover {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+
+.chat-controls__model-search-clear svg {
+  width: 12px;
+  height: 12px;
+}
+
+.chat-controls__model-search-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 60px;
+  padding: 12px 16px;
+  color: var(--muted);
+  font-size: 12px;
+  text-align: center;
+}
+
+.chat-controls__model-search-group-label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 6px 2px;
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.chat-controls__model-search-group-label .chat-controls__provider-icon {
+  width: 14px;
+  height: 14px;
+  flex: 0 0 14px;
 }
 
 .chat-controls__inline-select-section-label {
@@ -4416,6 +4518,7 @@ openclaw-chat-page {
 
   .chat-controls__model-browser {
     grid-template-columns: 120px minmax(0, 1fr);
+    grid-template-rows: auto 1fr;
     min-height: 180px;
   }
 


### PR DESCRIPTION
## Summary

Adds a search input to the Control UI model picker that filters models by name, label, or provider in real-time.

Closes #47880 (Option 3: Search/Filter)

## What changed

- **Search input** at the top of the model browser with search icon, clear button, and keyboard shortcuts
- **Real-time filtering** across all providers as you type
- **Provider-aware matching** — searches model name, model value, and provider display name
- **Keyboard shortcuts**: Escape clears, Enter selects first match
- **Auto-focus** when picker opens, **auto-clear** when picker closes
- **Empty state** message when no models match the query
- **Search results layout** — when searching, provider sidebar hides and results span full width with provider group labels

## Files changed

- `ui/src/pages/chat/components/chat-model-controls.ts` — search state management, filter logic, search input UI
- `ui/src/styles/chat/layout.css` — search input, empty state, and search results styling
- `ui/src/i18n/locales/en.ts` — 3 new i18n strings

## How it works

1. Open the model picker in Control UI
2. Type in the search box — models filter in real-time across all providers
3. Press Enter to select first match, Escape to clear
4. Search auto-clears when picker closes