### PR TITLE
feat(tasks): add trusted TaskFlow review orchestration

### DIFF
--- a/src/agents/subagent-control.test.ts
+++ b/src/agents/subagent-control.test.ts
@@ -971,6 +971,64 @@ describe("killSubagentRunAdmin", () => {
     expect(abortedLastRunWrites).toEqual([true, false]);
   });
 
+  it("does not let a descendant kill mask a live target whose abort was rejected", async () => {
+    const childSessionKey = "agent:main:subagent:live-target";
+    const descendantSessionKey = `${childSessionKey}:subagent:descendant`;
+    const storePath = await writeSessionStoreFixture("admin-kill-live-target", {
+      [childSessionKey]: {
+        sessionId: "sess-live-target",
+        updatedAt: Date.now(),
+      },
+      [descendantSessionKey]: {
+        sessionId: "sess-live-descendant",
+        updatedAt: Date.now(),
+      },
+    });
+
+    addSubagentRunForTests({
+      runId: "run-live-target",
+      childSessionKey,
+      controllerSessionKey: "agent:main:controller",
+      requesterSessionKey: "agent:main:requester",
+      requesterDisplayKey: "requester",
+      task: "live target",
+      cleanup: "keep",
+      createdAt: Date.now() - 5_000,
+      startedAt: Date.now() - 4_000,
+    });
+    addSubagentRunForTests({
+      runId: "run-live-descendant",
+      childSessionKey: descendantSessionKey,
+      controllerSessionKey: childSessionKey,
+      requesterSessionKey: childSessionKey,
+      requesterDisplayKey: "parent",
+      task: "live descendant",
+      cleanup: "keep",
+      createdAt: Date.now() - 3_000,
+      startedAt: Date.now() - 2_000,
+    });
+    setSubagentControlDepsForTest({
+      isEmbeddedAgentRunActive: () => true,
+      abortEmbeddedAgentRun: (sessionId) => sessionId === "sess-live-descendant",
+    });
+
+    const result = await killSubagentRunAdmin({
+      cfg: cfgWithSessionStore(storePath),
+      sessionKey: childSessionKey,
+    });
+
+    expect(result).toMatchObject({
+      found: true,
+      killed: false,
+      runId: "run-live-target",
+      sessionKey: childSessionKey,
+      cascadeKilled: 1,
+      cascadeLabels: ["live descendant"],
+    });
+    expect(getSubagentRunByChildSessionKey(childSessionKey)?.endedAt).toBeUndefined();
+    expect(getSubagentRunByChildSessionKey(descendantSessionKey)?.endedAt).toBeTypeOf("number");
+  });
+
   it("kills a run that yields while the kill path awaits persistence", async () => {
     const childSessionKey = "agent:main:subagent:yield-race";
     const storePath = await writeSessionStoreFixture("admin-kill-yield-race", {

--- a/src/agents/subagent-control.ts
+++ b/src/agents/subagent-control.ts
@@ -605,7 +605,7 @@ export async function killSubagentRunAdmin(params: { cfg: OpenClawConfig; sessio
 
   return {
     found: true as const,
-    killed: stopResult.killed || cascade.killed > 0,
+    killed: stopResult.killed,
     ...(targetState ? { targetState } : {}),
     runId: entry.runId,
     sessionKey: entry.childSessionKey,

--- a/src/agents/subagent-registry-lifecycle.ts
+++ b/src/agents/subagent-registry-lifecycle.ts
@@ -483,6 +483,9 @@ export function createSubagentRegistryLifecycleController(params: {
     deliveryStatus: "delivered" | "failed";
     deliveryError?: string;
   }) => {
+    if (args.entry.externalTaskLifecycle) {
+      return;
+    }
     const target = resolveSubagentTaskTarget(args.entry);
     try {
       setDetachedTaskDeliveryStatusByRunId({
@@ -507,6 +510,9 @@ export function createSubagentRegistryLifecycleController(params: {
     outcome: SubagentRunOutcome;
     taskResolution?: DetachedTaskFindResult;
   }): ReturnType<typeof completeTaskRunByRunId> => {
+    if (args.entry.externalTaskLifecycle) {
+      return [];
+    }
     const terminal = resolveFinalizedSubagentTaskState(args.entry);
     if (!terminal) {
       return [];
@@ -549,6 +555,9 @@ export function createSubagentRegistryLifecycleController(params: {
     entry: SubagentRunRecord;
     reason?: string;
   }) => {
+    if (args.entry.externalTaskLifecycle) {
+      return;
+    }
     if (args.entry.expectsCompletionMessage !== true || args.entry.outcome?.status !== "ok") {
       return;
     }

--- a/src/agents/subagent-registry-run-manager.ts
+++ b/src/agents/subagent-registry-run-manager.ts
@@ -876,18 +876,11 @@ export function createSubagentRunManager(params: {
     }
     try {
       if (registerParams.externalTaskLifecycle) {
-        const updated = startTaskRunByRunId({
-          runId: entry.taskRunId ?? runId,
-          runtime: "subagent",
-          childSessionKey,
-          startedAt: now,
-          lastEventAt: now,
-          progressSummary: "Reviewer child launched.",
-          eventSummary: "Reviewer child launched.",
-        });
-        if (updated.length === 0) {
-          throw new Error("external task binding was not found");
-        }
+        // The external lifecycle owner must bind its child only after validating
+        // the exact claim that originated this launch. Registration happens
+        // before spawn returns, so mutating the task here would let a late,
+        // non-owning launch overwrite the canonical child session before that
+        // claim CAS can reject it.
         params.ensureListener();
         params.persist();
         params.startSweeper();

--- a/src/agents/subagent-registry-run-manager.ts
+++ b/src/agents/subagent-registry-run-manager.ts
@@ -204,6 +204,8 @@ export function markSubagentRunPausedAfterYield(params: {
 
 export type RegisterSubagentRunParams = {
   runId: string;
+  taskRunId?: string;
+  externalTaskLifecycle?: boolean;
   requesterTurnRunId?: string;
   childSessionKey: string;
   controllerSessionKey?: string;
@@ -598,7 +600,7 @@ export function createSubagentRunManager(params: {
               error: "Subagent restart failed after the prior run was interrupted.",
             }
           : resolveFinalizedSubagentTaskState(entry);
-      if (terminal) {
+      if (terminal && !entry.externalTaskLifecycle) {
         const targetRunId = task?.runId ?? entry.taskRunId ?? entry.runId;
         const targetSessionKey = task?.childSessionKey ?? entry.childSessionKey;
         try {
@@ -803,7 +805,8 @@ export function createSubagentRunManager(params: {
     const queued = registerParams.queued === true;
     const entry: SubagentRunRecord = normalizeSubagentRunState({
       runId,
-      taskRunId: runId,
+      taskRunId: registerParams.taskRunId ?? runId,
+      externalTaskLifecycle: registerParams.externalTaskLifecycle,
       ...(requesterTurnRunId && registerParams.expectsCompletionMessage === true
         ? { requesterTurnRunId }
         : {}),
@@ -872,6 +875,25 @@ export function createSubagentRunManager(params: {
       throw error;
     }
     try {
+      if (registerParams.externalTaskLifecycle) {
+        const updated = startTaskRunByRunId({
+          runId: entry.taskRunId ?? runId,
+          runtime: "subagent",
+          childSessionKey,
+          startedAt: now,
+          lastEventAt: now,
+          progressSummary: "Reviewer child launched.",
+          eventSummary: "Reviewer child launched.",
+        });
+        if (updated.length === 0) {
+          throw new Error("external task binding was not found");
+        }
+        params.ensureListener();
+        params.persist();
+        params.startSweeper();
+        void waitForSubagentCompletion(runId, waitTimeoutMs, entry);
+        return;
+      }
       const taskParams = {
         runtime: "subagent",
         sourceId: runId,
@@ -1030,6 +1052,9 @@ export function createSubagentRunManager(params: {
       throw persistError;
     }
     try {
+      if (entry.externalTaskLifecycle) {
+        return true;
+      }
       finalizeTaskRunByRunId({
         runId: entry.taskRunId ?? entry.runId,
         runtime: "subagent",
@@ -1145,6 +1170,9 @@ export function createSubagentRunManager(params: {
     const entrySnapshots = new Map<SubagentRunRecord, SubagentRunRecord>();
     const pendingTaskFinalizations: Array<{ entry: SubagentRunRecord; endedAt: number }> = [];
     const finalizeKilledTask = (entry: SubagentRunRecord, endedAt: number) => {
+      if (entry.externalTaskLifecycle) {
+        return;
+      }
       const taskResolution = params.resolveSubagentTask(entry);
       const task = taskResolution.lookup === "available" ? taskResolution.task : undefined;
       const targetRunId = task?.runId ?? entry.taskRunId ?? entry.runId;

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -26,6 +26,16 @@ import {
   finalizeTaskRunByRunId,
   getDetachedTaskLifecycleRuntime,
 } from "../tasks/detached-task-runtime.js";
+import { reloadTaskRuntimeStateFromStore } from "../tasks/runtime-internal.js";
+import { createManagedTaskFlow } from "../tasks/task-flow-registry.js";
+import { listTasksForFlowId } from "../tasks/task-registry.js";
+import {
+  dispatchTaskReview,
+  parseTaskReviewDetail,
+  reconcileTaskReviewRuntime,
+  type TaskReviewRequest,
+  type TaskReviewerRuntime,
+} from "../tasks/task-review-lifecycle.js";
 import {
   resetDetachedTaskLifecycleRuntimeForTests,
   resetTaskFlowRegistryForTests,
@@ -33,6 +43,7 @@ import {
   setDetachedTaskLifecycleRuntime,
 } from "../tasks/task-runtime.test-helpers.js";
 import { findTaskByRunIdForStatus } from "../tasks/task-status-access.js";
+import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
 import {
   SUBAGENT_ENDED_REASON_COMPLETE,
   SUBAGENT_ENDED_REASON_ERROR,
@@ -542,7 +553,7 @@ describe("subagent registry seam flow", () => {
     });
   });
 
-  it("binds an externally owned task without duplicate creation or generic terminalization", async () => {
+  it("registers an externally owned run without preempting its lifecycle authority", async () => {
     const taskRunId = "task-review:external-owner";
     expect(
       createQueuedTaskRun({
@@ -567,13 +578,182 @@ describe("subagent registry seam flow", () => {
     });
 
     expect(findTaskByRunIdForStatus(taskRunId)).toMatchObject({
-      status: "running",
-      childSessionKey: "agent:reviewer:subagent:external-owner",
+      status: "queued",
+      childSessionKey: undefined,
     });
     await waitForFast(() =>
       expect(mod.getSubagentRunByRunId("reviewer-run-external-owner")?.endedAt).toBeDefined(),
     );
-    expect(findTaskByRunIdForStatus(taskRunId)?.status).toBe("running");
+    expect(findTaskByRunIdForStatus(taskRunId)?.status).toBe("queued");
+  });
+
+  it("preserves the owning reviewer binding when a stale external launch registers late", async () => {
+    await withStateDirEnv("openclaw-review-registry-race-", async () => {
+      resetTaskRegistryForTests({ persist: false });
+      resetTaskFlowRegistryForTests({ persist: false });
+      mod.resetSubagentRegistryForTests({ persist: false });
+
+      const ownerKey = "agent:main:main";
+      const request = {
+        reviewerAgentId: "reviewer",
+        staleAfterMs: 1_000,
+        maxRecoveryAttempts: 2,
+        proofBundle: {
+          commit: "1".repeat(40),
+          baseCommit: "2".repeat(40),
+          diff: {
+            sha256: "3".repeat(64),
+            summary: "Verify the production registry binding race.",
+            files: ["src/agents/subagent-registry-run-manager.ts"],
+          },
+          tests: [
+            {
+              name: "registry race",
+              command: "vitest subagent-registry.test.ts",
+              status: "passed" as const,
+              evidence: "Owning binding survives a late registration and reload.",
+            },
+          ],
+          screenshots: [],
+          criteria: [
+            {
+              id: "registry-binding-authority",
+              description: "Only the exact originating claim binds the reviewer child.",
+            },
+          ],
+        },
+      } satisfies TaskReviewRequest;
+      const flow = createManagedTaskFlow({
+        ownerKey,
+        controllerId: "tests/registry-review-race",
+        goal: "Preserve exact reviewer binding",
+        stateJson: { reviewRequest: request },
+      });
+      expect(flow).toBeTruthy();
+      if (!flow) {
+        return;
+      }
+
+      let releaseInitial: (() => void) | undefined;
+      let releaseAttemptOne: (() => void) | undefined;
+      const launches: number[] = [];
+      const settledNonOwners = new Set<string>();
+      const registerAcceptedLaunch = (params: {
+        taskRunId: string;
+        reviewerRunId: string;
+        childSessionKey: string;
+      }) => {
+        mod.registerSubagentRun({
+          runId: params.reviewerRunId,
+          taskRunId: params.taskRunId,
+          externalTaskLifecycle: true,
+          childSessionKey: params.childSessionKey,
+          requesterSessionKey: ownerKey,
+          requesterDisplayKey: "main",
+          task: "Review exact proof",
+          cleanup: "keep",
+          expectsCompletionMessage: false,
+        });
+        return {
+          ok: true as const,
+          reviewerRunId: params.reviewerRunId,
+          childSessionKey: params.childSessionKey,
+        };
+      };
+      const runtime: TaskReviewerRuntime = {
+        async launch({ task, recoveryAttempt }) {
+          launches.push(recoveryAttempt);
+          if (!task.runId) {
+            return { ok: false, reason: "missing stable task run id" };
+          }
+          if (launches.length === 1) {
+            return await new Promise((resolve) => {
+              releaseInitial = () =>
+                resolve(
+                  registerAcceptedLaunch({
+                    taskRunId: task.runId!,
+                    reviewerRunId: "late-run-0",
+                    childSessionKey: "agent:reviewer:subagent:late-attempt-0",
+                  }),
+                );
+            });
+          }
+          if (launches.length === 2) {
+            return { ok: false, reason: "attempt zero was not found during recovery" };
+          }
+          return await new Promise((resolve) => {
+            releaseAttemptOne = () =>
+              resolve(
+                registerAcceptedLaunch({
+                  taskRunId: task.runId!,
+                  reviewerRunId: "run-1",
+                  childSessionKey: "agent:reviewer:subagent:attempt-1",
+                }),
+              );
+          });
+        },
+        async inspect() {
+          return { state: "live" };
+        },
+        async settleNonOwningLaunch({ reviewerRunId, childSessionKey }) {
+          expect(mod.getSubagentRunByRunId(reviewerRunId)).toMatchObject({ childSessionKey });
+          await mod.finalizeInterruptedSubagentRun({
+            runId: reviewerRunId,
+            error: "non-owning reviewer launch",
+            endedAt: Date.now(),
+          });
+          settledNonOwners.add(childSessionKey);
+        },
+      };
+
+      const dispatching = dispatchTaskReview({
+        flowId: flow.flowId,
+        callerOwnerKey: ownerKey,
+        request,
+        continuity: { ownerKey, sessionKey: ownerKey },
+        now: 10_000,
+        runtime,
+      });
+      await waitForFast(() => expect(launches).toEqual([0]));
+      const claimed = listTasksForFlowId(flow.flowId)[0]!;
+      const recovering = reconcileTaskReviewRuntime({
+        taskId: claimed.taskId,
+        runtime,
+        now: 11_001,
+      });
+      await waitForFast(() => expect(launches).toEqual([0, 0, 1]));
+
+      releaseAttemptOne?.();
+      const recovered = await recovering;
+      expect(recovered.state).toBe("recovered");
+      expect(recovered.task.childSessionKey).toBe("agent:reviewer:subagent:attempt-1");
+      expect(parseTaskReviewDetail(recovered.task)?.launch).toMatchObject({
+        phase: "bound",
+        attempt: 1,
+        reviewerRunId: "run-1",
+        childSessionKey: "agent:reviewer:subagent:attempt-1",
+      });
+
+      releaseInitial?.();
+      const stale = await dispatching;
+      expect(stale.ok).toBe(true);
+      if (stale.ok) {
+        expect(stale.task.childSessionKey).toBe("agent:reviewer:subagent:attempt-1");
+      }
+      expect(settledNonOwners).toEqual(new Set(["agent:reviewer:subagent:late-attempt-0"]));
+      expect(mod.getSubagentRunByRunId("late-run-0")?.endedAt).toBeTypeOf("number");
+
+      resetTaskRegistryForTests({ persist: false });
+      resetTaskFlowRegistryForTests({ persist: false });
+      reloadTaskRuntimeStateFromStore();
+      const reloaded = listTasksForFlowId(flow.flowId)[0]!;
+      expect(reloaded.childSessionKey).toBe("agent:reviewer:subagent:attempt-1");
+      expect(parseTaskReviewDetail(reloaded)?.launch).toMatchObject({
+        phase: "bound",
+        attempt: 1,
+        childSessionKey: "agent:reviewer:subagent:attempt-1",
+      });
+    });
   });
 
   it("tracks missing-entry lifecycle result refresh until capture and persistence settle", async () => {

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -20,6 +20,7 @@ import {
 } from "../process/gateway-work-admission.js";
 import { SUBAGENT_KILL_TASK_ERROR } from "../tasks/detached-task-runtime-contract.js";
 import {
+  createQueuedTaskRun,
   createRunningTaskRun,
   findDetachedTaskRun,
   finalizeTaskRunByRunId,
@@ -539,6 +540,40 @@ describe("subagent registry seam flow", () => {
     expect(mod.getSubagentRunByRunId("run-collector-descendant")).toMatchObject({
       swarmWaitOwnerSessionKeys: [parentSessionKey, "agent:main:main"],
     });
+  });
+
+  it("binds an externally owned task without duplicate creation or generic terminalization", async () => {
+    const taskRunId = "task-review:external-owner";
+    expect(
+      createQueuedTaskRun({
+        runtime: "subagent",
+        requesterSessionKey: "agent:main:main",
+        ownerKey: "agent:main:main",
+        runId: taskRunId,
+        task: "review exact proof",
+      }),
+    ).toBeTruthy();
+
+    mod.registerSubagentRun({
+      runId: "reviewer-run-external-owner",
+      taskRunId,
+      externalTaskLifecycle: true,
+      childSessionKey: "agent:reviewer:subagent:external-owner",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "review exact proof",
+      cleanup: "keep",
+      expectsCompletionMessage: false,
+    });
+
+    expect(findTaskByRunIdForStatus(taskRunId)).toMatchObject({
+      status: "running",
+      childSessionKey: "agent:reviewer:subagent:external-owner",
+    });
+    await waitForFast(() =>
+      expect(mod.getSubagentRunByRunId("reviewer-run-external-owner")?.endedAt).toBeDefined(),
+    );
+    expect(findTaskByRunIdForStatus(taskRunId)?.status).toBe("running");
   });
 
   it("tracks missing-entry lifecycle result refresh until capture and persistence settle", async () => {

--- a/src/agents/subagent-registry.types.ts
+++ b/src/agents/subagent-registry.types.ts
@@ -151,6 +151,8 @@ export type SubagentRunRecord = {
   runId: string;
   /** Detached task owner; steer/restart changes runId but continues the same task. */
   taskRunId?: string;
+  /** True when another durable controller owns task terminalization. */
+  externalTaskLifecycle?: boolean;
   /** Requester attempt that must settle before this completion row can retire. */
   requesterTurnRunId?: string;
   /** Durable proof that this requester attempt invoked sessions_yield. */

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -167,6 +167,8 @@ type SpawnSubagentParams = {
   groupId?: string;
   /** Host bridge identity used to recover a replay-safe collector launch. */
   swarmLaunchReplayKey?: string;
+  /** Internal replay key for a durable external task launcher. */
+  externalLaunchReplayKey?: string;
   /** Canonical request hash checked before reusing a host-reserved collector. */
   swarmLaunchRequestFingerprint?: string;
   cwd?: string;
@@ -185,6 +187,9 @@ type SpawnSubagentParams = {
     mimeType?: string;
   }>;
   attachMountPath?: string;
+  /** Existing durable task row owned by an external lifecycle controller. */
+  taskRunId?: string;
+  externalTaskLifecycle?: boolean;
 };
 
 type SpawnSubagentContext = {
@@ -1176,11 +1181,13 @@ export async function spawnSubagentDirect(
   const childDepth = admission.childSessionPatch?.spawnDepth ?? 1;
   const maxSpawnDepth = admission.maxSpawnDepth ?? childDepth;
   const swarmLaunchReplayKey = normalizeOptionalString(params.swarmLaunchReplayKey);
+  const externalLaunchReplayKey = normalizeOptionalString(params.externalLaunchReplayKey);
+  const launchReplayKey = swarmLaunchReplayKey ?? externalLaunchReplayKey;
   // Registry and Gateway identities are global, while host replay keys are requester-scoped.
-  const childIdem = swarmLaunchReplayKey
+  const childIdem = launchReplayKey
     ? `swarm_${crypto
         .createHash("sha256")
-        .update(JSON.stringify([requesterInternalKey, swarmLaunchReplayKey]))
+        .update(JSON.stringify([requesterInternalKey, launchReplayKey]))
         .digest("hex")
         .slice(0, 32)}`
     : crypto.randomUUID();
@@ -1237,7 +1244,9 @@ export async function spawnSubagentDirect(
       requesterGroupSpace: ctx.agentGroupSpace,
       requesterMemberRoleIds: ctx.agentMemberRoleIds,
     });
-    const childSessionKey = mintSpawnSessionKey({ targetAgentId, backend: "subagent" });
+    const childSessionKey = externalLaunchReplayKey
+      ? `agent:${targetAgentId}:subagent:${childIdem}`
+      : mintSpawnSessionKey({ targetAgentId, backend: "subagent" });
     const requesterRuntime = resolveSandboxRuntimeStatus({
       cfg,
       sessionKey: requesterInternalKey,
@@ -1737,6 +1746,8 @@ export async function spawnSubagentDirect(
         }
         return {
           runId,
+          taskRunId: params.taskRunId,
+          externalTaskLifecycle: params.externalTaskLifecycle,
           requesterTurnRunId: ctx.requesterTurnRunId,
           childSessionKey,
           controllerSessionKey: ownership.controllerSessionKey,

--- a/src/auto-reply/commands-registry.shared.ts
+++ b/src/auto-reply/commands-registry.shared.ts
@@ -810,6 +810,21 @@ export function buildBuiltinChatCommands(
       ],
     }),
     defineChatCommand({
+      key: "wrap",
+      nativeName: "wrap",
+      description: "Hand off a managed TaskFlow for durable review.",
+      textAlias: "/wrap",
+      category: "session",
+      tier: "essential",
+      args: [
+        {
+          name: "flow",
+          description: "Managed TaskFlow id (omit to use the latest active flow)",
+          type: "string",
+        },
+      ],
+    }),
+    defineChatCommand({
       key: "compact",
       nativeName: "compact",
       description: "Compact the session context.",

--- a/src/auto-reply/commands-registry.test.ts
+++ b/src/auto-reply/commands-registry.test.ts
@@ -221,6 +221,7 @@ describe("commands registry", () => {
       "learn",
       "tasks",
       "whoami",
+      "wrap",
       "compact",
     ]);
   });
@@ -274,6 +275,8 @@ describe("commands registry", () => {
     expect(resolveTextCommand("/COMPACT Keep CaseSensitivePath")?.args).toBe(
       "Keep CaseSensitivePath",
     );
+    expect(resolveTextCommand("/WRAP flow-1")?.command.key).toBe("wrap");
+    expect(resolveTextCommand("/WRAP flow-1")?.args).toBe("flow-1");
   });
 
   it("preserves multiline payloads for skill slash commands", () => {
@@ -526,6 +529,7 @@ describe("commands registry", () => {
     expect(detection.exact.has("/skill")).toBe(true);
     expect(detection.exact.has("/learn")).toBe(true);
     expect(detection.exact.has("/compact")).toBe(true);
+    expect(detection.exact.has("/wrap")).toBe(true);
     expect(detection.exact.has("/whoami")).toBe(true);
     expect(detection.exact.has("/id")).toBe(true);
     for (const command of listChatCommands()) {

--- a/src/auto-reply/reply/commands-handlers.order.ts
+++ b/src/auto-reply/reply/commands-handlers.order.ts
@@ -41,6 +41,7 @@ export const commandHandlerOrder = [
   "debug",
   "models",
   "stop",
+  "wrap",
   "compact",
   "abort-trigger",
 ] as const;

--- a/src/auto-reply/reply/commands-handlers.registration.test.ts
+++ b/src/auto-reply/reply/commands-handlers.registration.test.ts
@@ -5,6 +5,7 @@ describe("command handler registration", () => {
   it("registers built-in handlers in the runtime handler list", () => {
     expect(commandHandlerOrder).toContain("name");
     expect(commandHandlerOrder).toContain("login");
+    expect(commandHandlerOrder).toContain("wrap");
     expect(new Set(commandHandlerOrder).size).toBe(commandHandlerOrder.length);
   });
 

--- a/src/auto-reply/reply/commands-handlers.runtime.ts
+++ b/src/auto-reply/reply/commands-handlers.runtime.ts
@@ -44,6 +44,7 @@ import { handleTasksCommand } from "./commands-tasks.js";
 import { handleTtsCommands } from "./commands-tts.js";
 import type { CommandHandler } from "./commands-types.js";
 import { handleWhoamiCommand } from "./commands-whoami.js";
+import { handleWrapCommand } from "./commands-wrap.js";
 
 const commandHandlersById = {
   acp: handleAcpCommand,
@@ -86,6 +87,7 @@ const commandHandlersById = {
   tts: handleTtsCommands,
   usage: handleUsageCommand,
   whoami: handleWhoamiCommand,
+  wrap: handleWrapCommand,
 } satisfies Record<CommandHandlerId, CommandHandler>;
 
 export function loadCommandHandlers(): CommandHandler[] {

--- a/src/auto-reply/reply/commands-wrap.runtime.ts
+++ b/src/auto-reply/reply/commands-wrap.runtime.ts
@@ -5,3 +5,4 @@ export {
   parseTaskReviewRequest,
   resolveWrapReviewFlow,
 } from "../../tasks/task-review-lifecycle.js";
+export { taskReviewerRuntime } from "../../tasks/task-reviewer-runtime.js";

--- a/src/auto-reply/reply/commands-wrap.runtime.ts
+++ b/src/auto-reply/reply/commands-wrap.runtime.ts
@@ -1,0 +1,7 @@
+/** Runtime facade for managed review handoff dependencies. */
+export {
+  dispatchTaskReview,
+  findReviewSourceTask,
+  parseTaskReviewRequest,
+  resolveWrapReviewFlow,
+} from "../../tasks/task-review-lifecycle.js";

--- a/src/auto-reply/reply/commands-wrap.test.ts
+++ b/src/auto-reply/reply/commands-wrap.test.ts
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   findReviewSourceTask: vi.fn(),
   parseTaskReviewRequest: vi.fn(),
   resolveWrapReviewFlow: vi.fn(),
+  taskReviewerRuntime: { launch: vi.fn(), inspect: vi.fn() },
 }));
 
 vi.mock("./commands-wrap.runtime.js", () => mocks);
@@ -16,6 +17,7 @@ const { handleWrapCommand } = await import("./commands-wrap.js");
 const request = {
   reviewerAgentId: "reviewer",
   staleAfterMs: 60_000,
+  maxRecoveryAttempts: 2,
   proofBundle: {
     commit: "1".repeat(40),
     baseCommit: "2".repeat(40),
@@ -95,6 +97,7 @@ describe("handleWrapCommand", () => {
         sourceTaskId: "source-task",
       },
       parentTaskId: "source-task",
+      runtime: mocks.taskReviewerRuntime,
     });
     expect(result?.reply?.text).toContain("Review dispatched.");
     expect(result?.reply?.text).toContain(`Commit: ${request.proofBundle.commit}.`);

--- a/src/auto-reply/reply/commands-wrap.test.ts
+++ b/src/auto-reply/reply/commands-wrap.test.ts
@@ -1,0 +1,132 @@
+// Verifies /wrap authorization, flow selection, continuity, and idempotent status replies.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { HandleCommandsParams } from "./commands-types.js";
+
+const mocks = vi.hoisted(() => ({
+  dispatchTaskReview: vi.fn(),
+  findReviewSourceTask: vi.fn(),
+  parseTaskReviewRequest: vi.fn(),
+  resolveWrapReviewFlow: vi.fn(),
+}));
+
+vi.mock("./commands-wrap.runtime.js", () => mocks);
+
+const { handleWrapCommand } = await import("./commands-wrap.js");
+
+const request = {
+  reviewerAgentId: "reviewer",
+  staleAfterMs: 60_000,
+  proofBundle: {
+    commit: "1".repeat(40),
+    baseCommit: "2".repeat(40),
+    diff: { sha256: "3".repeat(64), summary: "review", files: ["src/review.ts"] },
+    tests: [],
+    screenshots: [],
+    criteria: [{ id: "criterion-1", description: "durable" }],
+  },
+};
+
+function buildParams(commandBodyNormalized = "/wrap"): HandleCommandsParams {
+  return {
+    cfg: {},
+    ctx: { CommandBody: commandBodyNormalized },
+    command: {
+      commandBodyNormalized,
+      isAuthorizedSender: true,
+      senderIsOwner: true,
+      channel: "whatsapp",
+      ownerList: [],
+    },
+    sessionKey: "agent:main:main",
+    sessionEntry: {
+      sessionId: "session-after-compact",
+      compactionCount: 4,
+      updatedAt: 1,
+    },
+  } as unknown as HandleCommandsParams;
+}
+
+describe("handleWrapCommand", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.resolveWrapReviewFlow.mockReturnValue({
+      flowId: "flow-1",
+      ownerKey: "agent:main:main",
+      syncMode: "managed",
+    });
+    mocks.parseTaskReviewRequest.mockReturnValue(request);
+    mocks.findReviewSourceTask.mockReturnValue({ taskId: "source-task" });
+    mocks.dispatchTaskReview.mockReturnValue({
+      ok: true,
+      created: true,
+      task: { taskId: "review-task" },
+      detail: {
+        state: "review_pending",
+        reviewerAgentId: "reviewer",
+        proofBundle: request.proofBundle,
+      },
+    });
+  });
+
+  it("ignores unrelated and unauthorized commands", async () => {
+    expect(await handleWrapCommand(buildParams("/status"), true)).toBeNull();
+    const unauthorized = buildParams();
+    unauthorized.command.isAuthorizedSender = false;
+    expect(await handleWrapCommand(unauthorized, true)).toEqual({ shouldContinue: false });
+    expect(mocks.dispatchTaskReview).not.toHaveBeenCalled();
+  });
+
+  it("dispatches the configured reviewer with flow, source-task, and compacted session continuity", async () => {
+    const result = await handleWrapCommand(buildParams("/wrap flow-1"), true);
+
+    expect(mocks.resolveWrapReviewFlow).toHaveBeenCalledWith({
+      ownerKey: "agent:main:main",
+      flowId: "flow-1",
+    });
+    expect(mocks.dispatchTaskReview).toHaveBeenCalledWith({
+      flowId: "flow-1",
+      callerOwnerKey: "agent:main:main",
+      request,
+      continuity: {
+        ownerKey: "agent:main:main",
+        sessionKey: "agent:main:main",
+        sessionId: "session-after-compact",
+        compactionCount: 4,
+        sourceTaskId: "source-task",
+      },
+      parentTaskId: "source-task",
+    });
+    expect(result?.reply?.text).toContain("Review dispatched.");
+    expect(result?.reply?.text).toContain(`Commit: ${request.proofBundle.commit}.`);
+  });
+
+  it("reports the durable state when a duplicate /wrap reuses the same handoff", async () => {
+    mocks.dispatchTaskReview.mockReturnValueOnce({
+      ok: true,
+      created: false,
+      task: { taskId: "review-task" },
+      detail: {
+        state: "recovery_pending",
+        reviewerAgentId: "reviewer",
+        proofBundle: request.proofBundle,
+      },
+    });
+
+    const result = await handleWrapCommand(buildParams(), true);
+
+    expect(result?.reply?.text).toContain("reusing durable handoff");
+    expect(result?.reply?.text).toContain("State: recovery_pending.");
+  });
+
+  it("fails closed for missing managed flows and invalid review configuration", async () => {
+    mocks.resolveWrapReviewFlow.mockReturnValueOnce(undefined);
+    const missing = await handleWrapCommand(buildParams(), true);
+    expect(missing?.reply?.text).toContain("no active managed TaskFlow");
+
+    mocks.parseTaskReviewRequest.mockImplementationOnce(() => {
+      throw new Error("reviewerAgentId is required.");
+    });
+    const invalid = await handleWrapCommand(buildParams(), true);
+    expect(invalid?.reply?.text).toContain("reviewerAgentId is required");
+  });
+});

--- a/src/auto-reply/reply/commands-wrap.ts
+++ b/src/auto-reply/reply/commands-wrap.ts
@@ -1,0 +1,83 @@
+// Implements durable managed-flow review handoff without losing session continuity.
+import { logVerbose } from "../../globals.js";
+import { createLazyImportLoader } from "../../shared/lazy-promise.js";
+import type { CommandHandler } from "./commands-types.js";
+
+const wrapRuntimeLoader = createLazyImportLoader(() => import("./commands-wrap.runtime.js"));
+
+function loadWrapRuntime(): Promise<typeof import("./commands-wrap.runtime.js")> {
+  return wrapRuntimeLoader.load();
+}
+
+function statusReply(text: string) {
+  return {
+    shouldContinue: false as const,
+    reply: { text, isStatusNotice: true },
+  };
+}
+
+export const handleWrapCommand: CommandHandler = async (params) => {
+  const body = params.command.commandBodyNormalized;
+  if (body !== "/wrap" && !body.startsWith("/wrap ")) {
+    return null;
+  }
+  if (!params.command.isAuthorizedSender) {
+    logVerbose(
+      `Ignoring /wrap from unauthorized sender: ${params.command.senderId || "<unknown>"}`,
+    );
+    return { shouldContinue: false };
+  }
+
+  const runtime = await loadWrapRuntime();
+  const requestedFlowId = body.slice("/wrap".length).trim() || undefined;
+  const flow = runtime.resolveWrapReviewFlow({
+    ownerKey: params.sessionKey,
+    flowId: requestedFlowId,
+  });
+  if (!flow || flow.syncMode !== "managed") {
+    return statusReply(
+      requestedFlowId
+        ? `⚙️ Review handoff unavailable: managed TaskFlow ${requestedFlowId} was not found.`
+        : "⚙️ Review handoff unavailable: no active managed TaskFlow was found for this session.",
+    );
+  }
+
+  let request;
+  try {
+    request = runtime.parseTaskReviewRequest(flow);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return statusReply(`⚙️ Review handoff unavailable: ${message}`);
+  }
+
+  const sourceTask = runtime.findReviewSourceTask(flow.flowId);
+  const targetSessionEntry = params.sessionStore?.[params.sessionKey] ?? params.sessionEntry;
+  const result = runtime.dispatchTaskReview({
+    flowId: flow.flowId,
+    callerOwnerKey: params.sessionKey,
+    request,
+    continuity: {
+      ownerKey: flow.ownerKey,
+      sessionKey: params.sessionKey,
+      ...(targetSessionEntry?.sessionId ? { sessionId: targetSessionEntry.sessionId } : {}),
+      ...(targetSessionEntry?.compactionCount !== undefined
+        ? { compactionCount: targetSessionEntry.compactionCount }
+        : {}),
+      ...(sourceTask ? { sourceTaskId: sourceTask.taskId } : {}),
+    },
+    ...(sourceTask ? { parentTaskId: sourceTask.taskId } : {}),
+  });
+  if (!result.ok) {
+    return statusReply(`⚙️ Review handoff unavailable: ${result.reason}`);
+  }
+
+  return statusReply(
+    [
+      result.created ? "Review dispatched." : "Review already dispatched; reusing durable handoff.",
+      `State: ${result.detail.state}.`,
+      `Commit: ${result.detail.proofBundle.commit}.`,
+      `Reviewer: ${result.detail.reviewerAgentId}.`,
+      `Task: ${result.task.taskId}.`,
+    ].join(" "),
+  );
+};

--- a/src/auto-reply/reply/commands-wrap.ts
+++ b/src/auto-reply/reply/commands-wrap.ts
@@ -52,7 +52,7 @@ export const handleWrapCommand: CommandHandler = async (params) => {
 
   const sourceTask = runtime.findReviewSourceTask(flow.flowId);
   const targetSessionEntry = params.sessionStore?.[params.sessionKey] ?? params.sessionEntry;
-  const result = runtime.dispatchTaskReview({
+  const result = await runtime.dispatchTaskReview({
     flowId: flow.flowId,
     callerOwnerKey: params.sessionKey,
     request,
@@ -66,6 +66,7 @@ export const handleWrapCommand: CommandHandler = async (params) => {
       ...(sourceTask ? { sourceTaskId: sourceTask.taskId } : {}),
     },
     ...(sourceTask ? { parentTaskId: sourceTask.taskId } : {}),
+    runtime: runtime.taskReviewerRuntime,
   });
   if (!result.ok) {
     return statusReply(`⚙️ Review handoff unavailable: ${result.reason}`);

--- a/src/plugins/runtime/task-domain-types.ts
+++ b/src/plugins/runtime/task-domain-types.ts
@@ -51,8 +51,10 @@ export type TaskRunView = {
   terminalOutcome?: TaskTerminalOutcome;
 };
 
-/** Detailed task run view; currently equal to the summary view. */
-export type TaskRunDetail = TaskRunView;
+/** Detailed task run view, including durable runtime-specific continuity state. */
+export type TaskRunDetail = TaskRunView & {
+  detail?: JsonValue;
+};
 
 /** Result returned when cancelling a task run. */
 export type TaskRunCancelResult = {

--- a/src/tasks/detached-task-runtime-contract.ts
+++ b/src/tasks/detached-task-runtime-contract.ts
@@ -48,6 +48,7 @@ type DetachedTaskStartParams = {
   runId: string;
   runtime?: TaskRuntime;
   sessionKey?: string;
+  childSessionKey?: string;
   startedAt?: number;
   lastEventAt?: number;
   progressSummary?: string | null;

--- a/src/tasks/task-domain-views.test.ts
+++ b/src/tasks/task-domain-views.test.ts
@@ -141,6 +141,21 @@ describe("task domain view mappers", () => {
     expect(mapTaskRunDetail(task)).toEqual(mapTaskRunView(task));
   });
 
+  it("includes durable runtime detail only on the task detail surface", () => {
+    const task = makeTask({
+      taskId: "task-review",
+      detail: { kind: "managed-review", state: "recovery_pending" },
+    });
+
+    expect(mapTaskRunView(task)).not.toHaveProperty("detail");
+    const detail = mapTaskRunDetail(task);
+    expect(detail).toEqual({
+      ...mapTaskRunView(task),
+      detail: { kind: "managed-review", state: "recovery_pending" },
+    });
+    expect(detail.detail).not.toBe(task.detail);
+  });
+
   it("maps task flow records to public flow views without sharing requester origins", () => {
     const requesterOrigin = {
       channel: "telegram",

--- a/src/tasks/task-domain-views.ts
+++ b/src/tasks/task-domain-views.ts
@@ -53,7 +53,10 @@ export function mapTaskRunView(task: TaskRecord): TaskRunView {
 }
 
 export function mapTaskRunDetail(task: TaskRecord): TaskRunDetail {
-  return mapTaskRunView(task);
+  return {
+    ...mapTaskRunView(task),
+    ...(task.detail !== undefined ? { detail: structuredClone(task.detail) } : {}),
+  };
 }
 
 export function mapTaskFlowView(flow: TaskFlowRecord): TaskFlowView {

--- a/src/tasks/task-executor.ts
+++ b/src/tasks/task-executor.ts
@@ -41,6 +41,7 @@ import {
 } from "./task-flow-runtime-internal.js";
 import { summarizeTaskRecords } from "./task-registry.summary.js";
 import type {
+  JsonValue,
   TaskDeliveryState,
   TaskDeliveryStatus,
   TaskNotifyPolicy,
@@ -143,6 +144,7 @@ export function listTaskRecordsUnsorted(): TaskRecord[] {
 type RunTaskInFlowParams = {
   flowId: string;
   runtime: TaskRuntime;
+  taskKind?: string;
   sourceId?: string;
   childSessionKey?: string;
   parentTaskId?: string;
@@ -157,6 +159,7 @@ type RunTaskInFlowParams = {
   startedAt?: number;
   lastEventAt?: number;
   progressSummary?: string | null;
+  detail?: JsonValue;
 };
 
 export function startTaskRunByRunId(params: {
@@ -178,6 +181,7 @@ export function recordTaskRunProgressByRunId(params: {
   lastEventAt?: number;
   progressSummary?: string | null;
   eventSummary?: string | null;
+  detail?: JsonValue;
 }) {
   return recordTaskProgressByRunId(params);
 }
@@ -370,6 +374,7 @@ function runTaskInFlow(params: RunTaskInFlowParams): RunTaskInFlowResult {
 
   const common = {
     runtime: params.runtime,
+    taskKind: params.taskKind,
     sourceId: params.sourceId,
     ownerKey: flow.ownerKey,
     scopeKind: "session" as const,
@@ -384,6 +389,7 @@ function runTaskInFlow(params: RunTaskInFlowParams): RunTaskInFlowResult {
     preferMetadata: params.preferMetadata,
     notifyPolicy: params.notifyPolicy,
     deliveryStatus: params.deliveryStatus ?? "pending",
+    detail: params.detail,
   };
   let task: TaskRecord | null;
   try {
@@ -445,6 +451,7 @@ export function runTaskInFlowForOwner(
   return runTaskInFlow({
     flowId: flow.flowId,
     runtime: params.runtime,
+    taskKind: params.taskKind,
     sourceId: params.sourceId,
     childSessionKey: params.childSessionKey,
     parentTaskId: params.parentTaskId,
@@ -459,6 +466,7 @@ export function runTaskInFlowForOwner(
     startedAt: params.startedAt,
     lastEventAt: params.lastEventAt,
     progressSummary: params.progressSummary,
+    detail: params.detail,
   });
 }
 

--- a/src/tasks/task-executor.ts
+++ b/src/tasks/task-executor.ts
@@ -166,6 +166,7 @@ export function startTaskRunByRunId(params: {
   runId: string;
   runtime?: TaskRuntime;
   sessionKey?: string;
+  childSessionKey?: string;
   startedAt?: number;
   lastEventAt?: number;
   progressSummary?: string | null;

--- a/src/tasks/task-registry.maintenance.ts
+++ b/src/tasks/task-registry.maintenance.ts
@@ -76,7 +76,6 @@ import {
   listStaleTaskReviewIds,
   parseTaskReviewDetail,
   reconcileTaskReviewRuntime,
-  reconcileStaleTaskReviews,
   type TaskReviewerRuntime,
 } from "./task-review-lifecycle.js";
 import { taskReviewerRuntime } from "./task-reviewer-runtime.js";
@@ -1033,7 +1032,11 @@ export async function runTaskRegistryMaintenance(): Promise<TaskRegistryMaintena
   let cleanupStamped = 0;
   let pruned = 0;
   const tasks = taskRegistryMaintenanceRuntime.listTaskRecords();
-  const reviewReconciliation = reconcileStaleTaskReviews({ tasks, now });
+  const staleReviewTaskIds = listStaleTaskReviewIds({ tasks, now });
+  const reviewReconciliation = {
+    escalated: staleReviewTaskIds.length,
+    taskIds: staleReviewTaskIds,
+  };
   const reconciledReviewTaskIds = new Set(reviewReconciliation.taskIds);
   reconciled += reviewReconciliation.escalated;
   for (const snapshot of tasks) {

--- a/src/tasks/task-registry.maintenance.ts
+++ b/src/tasks/task-registry.maintenance.ts
@@ -75,8 +75,11 @@ import { resolveEffectiveTaskCleanupAfter, resolveTaskCleanupAfter } from "./tas
 import {
   listStaleTaskReviewIds,
   parseTaskReviewDetail,
+  reconcileTaskReviewRuntime,
   reconcileStaleTaskReviews,
+  type TaskReviewerRuntime,
 } from "./task-review-lifecycle.js";
+import { taskReviewerRuntime } from "./task-reviewer-runtime.js";
 
 const log = createSubsystemLogger("tasks/task-registry-maintenance");
 const TASK_RECONCILE_GRACE_MS = 5 * 60_000;
@@ -125,6 +128,7 @@ type TaskRegistryMaintenanceRuntime = {
   setTaskCleanupAfterById: typeof setTaskCleanupAfterById;
   isRuntimeAuthoritative: () => boolean;
   listTaskRegistryRecordsByRuntimeSourceIdFromSqlite: typeof listTaskRegistryRecordsByRuntimeSourceIdFromSqlite;
+  reviewerRuntime?: TaskReviewerRuntime;
 };
 
 const defaultTaskRegistryMaintenanceRuntime: TaskRegistryMaintenanceRuntime = {
@@ -164,6 +168,7 @@ const defaultTaskRegistryMaintenanceRuntime: TaskRegistryMaintenanceRuntime = {
   setTaskCleanupAfterById,
   isRuntimeAuthoritative: () => configuredRuntimeAuthoritative,
   listTaskRegistryRecordsByRuntimeSourceIdFromSqlite,
+  reviewerRuntime: taskReviewerRuntime,
 };
 
 let taskRegistryMaintenanceRuntime: TaskRegistryMaintenanceRuntime =
@@ -1031,6 +1036,34 @@ export async function runTaskRegistryMaintenance(): Promise<TaskRegistryMaintena
   const reviewReconciliation = reconcileStaleTaskReviews({ tasks, now });
   const reconciledReviewTaskIds = new Set(reviewReconciliation.taskIds);
   reconciled += reviewReconciliation.escalated;
+  for (const snapshot of tasks) {
+    const current = taskRegistryMaintenanceRuntime.getTaskById(snapshot.taskId);
+    const detail = current ? parseTaskReviewDetail(current) : undefined;
+    if (
+      !current ||
+      !detail ||
+      (detail.state !== "review_pending" &&
+        detail.state !== "recovery_pending" &&
+        detail.state !== "recovering" &&
+        detail.state !== "reverify_pending")
+    ) {
+      continue;
+    }
+    try {
+      const result = await reconcileTaskReviewRuntime({
+        taskId: current.taskId,
+        runtime: taskRegistryMaintenanceRuntime.reviewerRuntime ?? taskReviewerRuntime,
+        now,
+      });
+      reconciledReviewTaskIds.add(current.taskId);
+      if (result.state === "recovered") {
+        recovered += 1;
+      }
+    } catch (error) {
+      log.warn("Failed to reconcile managed review task", { taskId: current.taskId, error });
+      reconciledReviewTaskIds.add(current.taskId);
+    }
+  }
   const cronHistoryOverflowTaskIds = collectCronHistoryOverflowTaskIds(tasks);
   const cronRecoveryContext = createCronRecoveryContext();
   const backingSessionContext = createBackingSessionLookupContext();
@@ -1184,6 +1217,12 @@ export function setTaskRegistryMaintenanceRuntimeForTests(
 export function resetTaskRegistryMaintenanceRuntimeForTests(): void {
   taskRegistryMaintenanceRuntime = defaultTaskRegistryMaintenanceRuntime;
   configuredRuntimeAuthoritative = false;
+}
+
+export function setTaskRegistryMaintenanceReviewerRuntimeForTests(
+  reviewerRuntime: TaskReviewerRuntime,
+): void {
+  taskRegistryMaintenanceRuntime = { ...taskRegistryMaintenanceRuntime, reviewerRuntime };
 }
 
 export function configureTaskRegistryMaintenance(options?: {

--- a/src/tasks/task-registry.maintenance.ts
+++ b/src/tasks/task-registry.maintenance.ts
@@ -72,6 +72,11 @@ import { summarizeTaskRecords } from "./task-registry.summary.js";
 import type { TaskRecord, TaskRegistrySummary, TaskStatus } from "./task-registry.types.js";
 import type { ActiveTaskRestartBlocker } from "./task-restart-blocker.js";
 import { resolveEffectiveTaskCleanupAfter, resolveTaskCleanupAfter } from "./task-retention.js";
+import {
+  listStaleTaskReviewIds,
+  parseTaskReviewDetail,
+  reconcileStaleTaskReviews,
+} from "./task-review-lifecycle.js";
 
 const log = createSubsystemLogger("tasks/task-registry-maintenance");
 const TASK_RECONCILE_GRACE_MS = 5 * 60_000;
@@ -896,8 +901,13 @@ export function previewTaskRegistryMaintenance(): TaskRegistryMaintenanceSummary
   const cronRecoveryContext = createCronRecoveryContext();
   const backingSessionContext = createBackingSessionLookupContext();
   const tasks = taskRegistryMaintenanceRuntime.listTaskRecords();
+  const staleReviewTaskIds = new Set(listStaleTaskReviewIds({ tasks, now }));
+  reconciled += staleReviewTaskIds.size;
   const cronHistoryOverflowTaskIds = collectCronHistoryOverflowTaskIds(tasks);
   for (const task of tasks) {
+    if (staleReviewTaskIds.has(task.taskId)) {
+      continue;
+    }
     if (resolveDurableCronTaskRecovery(task, cronRecoveryContext)) {
       recovered += 1;
       continue;
@@ -1018,6 +1028,9 @@ export async function runTaskRegistryMaintenance(): Promise<TaskRegistryMaintena
   let cleanupStamped = 0;
   let pruned = 0;
   const tasks = taskRegistryMaintenanceRuntime.listTaskRecords();
+  const reviewReconciliation = reconcileStaleTaskReviews({ tasks, now });
+  const reconciledReviewTaskIds = new Set(reviewReconciliation.taskIds);
+  reconciled += reviewReconciliation.escalated;
   const cronHistoryOverflowTaskIds = collectCronHistoryOverflowTaskIds(tasks);
   const cronRecoveryContext = createCronRecoveryContext();
   const backingSessionContext = createBackingSessionLookupContext();
@@ -1026,6 +1039,12 @@ export async function runTaskRegistryMaintenance(): Promise<TaskRegistryMaintena
   for (const task of tasks) {
     const current = taskRegistryMaintenanceRuntime.getTaskById(task.taskId);
     if (!current) {
+      continue;
+    }
+    if (
+      reconciledReviewTaskIds.has(current.taskId) ||
+      parseTaskReviewDetail(current)?.state === "recovery_pending"
+    ) {
       continue;
     }
     const cronRecovery = resolveDurableCronTaskRecovery(current, cronRecoveryContext);

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -2185,6 +2185,7 @@ export function markTaskRunningByRunId(params: {
   runId: string;
   runtime?: TaskRuntime;
   sessionKey?: string;
+  childSessionKey?: string;
   startedAt?: number;
   lastEventAt?: number;
   progressSummary?: string | null;
@@ -2194,6 +2195,7 @@ export function markTaskRunningByRunId(params: {
     runId: params.runId,
     runtime: params.runtime,
     sessionKey: params.sessionKey,
+    childSessionKey: params.childSessionKey,
     status: "running",
     startedAt: params.startedAt,
     lastEventAt: params.lastEventAt,

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -2209,6 +2209,7 @@ export function recordTaskProgressByRunId(params: {
   lastEventAt?: number;
   progressSummary?: string | null;
   eventSummary?: string | null;
+  detail?: JsonValue;
 }) {
   return updateTaskStateByRunId({
     runId: params.runId,
@@ -2217,6 +2218,7 @@ export function recordTaskProgressByRunId(params: {
     lastEventAt: params.lastEventAt,
     progressSummary: params.progressSummary,
     eventSummary: params.eventSummary,
+    detail: params.detail,
   });
 }
 

--- a/src/tasks/task-review-lifecycle.test.ts
+++ b/src/tasks/task-review-lifecycle.test.ts
@@ -1,27 +1,33 @@
 // Verifies durable, idempotent managed review handoff and closed lifecycle transitions.
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { setHeartbeatWakeHandler } from "../infra/heartbeat-wake.js";
 import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
 import { captureEnv } from "../test-utils/env.js";
 import { reloadTaskRuntimeStateFromStore } from "./runtime-internal.js";
 import { recordTaskRunProgressByRunId } from "./task-executor.js";
-import { createManagedTaskFlow } from "./task-flow-registry.js";
+import { createManagedTaskFlow, getTaskFlowById } from "./task-flow-registry.js";
 import { listTasksForFlowId } from "./task-registry.js";
 import {
   previewTaskRegistryMaintenance,
   resetTaskRegistryMaintenanceRuntimeForTests,
   runTaskRegistryMaintenance,
+  setTaskRegistryMaintenanceReviewerRuntimeForTests,
   stopTaskRegistryMaintenance,
 } from "./task-registry.maintenance.js";
+import type { TaskRecord } from "./task-registry.types.js";
 import {
   applyTaskReviewDecision,
   beginTaskReviewRecovery,
   dispatchTaskReview,
   markTaskReviewReverifyPending,
   parseTaskReviewDetail,
+  reconcileTaskReviewRuntime,
   reconcileStaleTaskReviews,
   resumeTaskReviewVerification,
   type TaskReviewRequest,
+  type TaskReviewerRuntime,
 } from "./task-review-lifecycle.js";
+import { createReviewDispatchAtomically } from "./task-review-store.js";
 import {
   resetTaskFlowRegistryForTests,
   resetTaskRegistryForTests,
@@ -30,11 +36,24 @@ import {
 const ORIGINAL_ENV = captureEnv(["OPENCLAW_STATE_DIR"]);
 const OWNER_KEY = "agent:main:main";
 const COMMIT = "1".repeat(40);
+const reviewerRuntime: TaskReviewerRuntime = {
+  async launch({ detail, recoveryAttempt }) {
+    return {
+      ok: true,
+      reviewerRunId: `reviewer-${detail.dispatchKey}-${recoveryAttempt}`,
+      childSessionKey: `agent:reviewer:subagent:${detail.dispatchKey}-${recoveryAttempt}`,
+    };
+  },
+  async inspect() {
+    return { state: "live" };
+  },
+};
 
 function buildRequest(overrides: Partial<TaskReviewRequest> = {}): TaskReviewRequest {
   return {
     reviewerAgentId: "reviewer",
     staleAfterMs: 1_000,
+    maxRecoveryAttempts: 2,
     proofBundle: {
       commit: COMMIT,
       baseCommit: "2".repeat(40),
@@ -95,6 +114,7 @@ function dispatch(flowId: string, request = buildRequest(), now = 10_000) {
     },
     parentTaskId: "source-task",
     now,
+    runtime: reviewerRuntime,
   });
 }
 
@@ -106,9 +126,9 @@ describe("task review lifecycle", () => {
   });
 
   it("atomically persists one reviewer, linkage, continuity, and exact proof across reload", async () => {
-    await withReviewState(() => {
+    await withReviewState(async () => {
       const flow = createReviewFlow();
-      const first = dispatch(flow.flowId);
+      const first = await dispatch(flow.flowId);
       expect(first.ok).toBe(true);
       if (!first.ok) {
         return;
@@ -124,7 +144,7 @@ describe("task review lifecycle", () => {
       resetTaskFlowRegistryForTests({ persist: false });
       reloadTaskRuntimeStateFromStore();
 
-      const replay = dispatch(flow.flowId);
+      const replay = await dispatch(flow.flowId);
       expect(replay.ok).toBe(true);
       if (!replay.ok) {
         return;
@@ -133,13 +153,88 @@ describe("task review lifecycle", () => {
       expect(replay.task.taskId).toBe(first.task.taskId);
       expect(listTasksForFlowId(flow.flowId)).toHaveLength(1);
       expect(parseTaskReviewDetail(replay.task)).toEqual(first.detail);
+
+      const successor = await dispatchTaskReview({
+        flowId: flow.flowId,
+        callerOwnerKey: OWNER_KEY,
+        request: buildRequest(),
+        continuity: {
+          ownerKey: OWNER_KEY,
+          sessionKey: OWNER_KEY,
+          sessionId: "session-after-compact",
+          compactionCount: 4,
+          sourceTaskId: "source-task",
+        },
+        parentTaskId: "source-task",
+        now: 12_000,
+        runtime: reviewerRuntime,
+      });
+      expect(successor.ok).toBe(true);
+      if (successor.ok) {
+        expect(successor.created).toBe(false);
+        expect(successor.detail.continuity).toMatchObject({
+          sessionId: "session-after-compact",
+          compactionCount: 4,
+        });
+      }
+    });
+  });
+
+  it("admits one launch under concurrent duplicate dispatch", async () => {
+    await withReviewState(async () => {
+      const flow = createReviewFlow();
+      const launch = vi.fn((params) => reviewerRuntime.launch(params));
+      const runtime = { ...reviewerRuntime, launch };
+      const dispatchOnce = () =>
+        dispatchTaskReview({
+          flowId: flow.flowId,
+          callerOwnerKey: OWNER_KEY,
+          request: buildRequest(),
+          continuity: { ownerKey: OWNER_KEY, sessionKey: OWNER_KEY },
+          runtime,
+        });
+      const results = await Promise.all([dispatchOnce(), dispatchOnce()]);
+      expect(results.every((result) => result.ok)).toBe(true);
+      expect(results.filter((result) => result.ok && result.created)).toHaveLength(1);
+      expect(launch).toHaveBeenCalledTimes(1);
+      expect(listTasksForFlowId(flow.flowId)).toHaveLength(1);
+    });
+  });
+
+  it("rolls back the flow CAS and task insert when the coupled delivery insert fails", async () => {
+    await withReviewState(() => {
+      const flow = createReviewFlow();
+      const task: TaskRecord = {
+        taskId: null as unknown as string,
+        runtime: "subagent",
+        requesterSessionKey: OWNER_KEY,
+        ownerKey: OWNER_KEY,
+        scopeKind: "session",
+        task: "rollback fixture",
+        status: "queued",
+        notifyPolicy: "state_changes",
+        deliveryStatus: "pending",
+        createdAt: 20_000,
+      };
+      expect(() =>
+        createReviewDispatchAtomically({
+          flow,
+          expectedRevision: flow.revision,
+          nextStateJson: { review: { state: "review_pending" } },
+          task,
+        }),
+      ).toThrow();
+      reloadTaskRuntimeStateFromStore();
+      expect(listTasksForFlowId(flow.flowId)).toHaveLength(0);
+      expect(getTaskFlowById(flow.flowId)?.revision).toBe(flow.revision);
+      expect(getTaskFlowById(flow.flowId)?.status).toBe(flow.status);
     });
   });
 
   it("accepts merge_ready only for the exact commit with passing proof and criteria", async () => {
-    await withReviewState(() => {
+    await withReviewState(async () => {
       const flow = createReviewFlow();
-      const result = dispatch(flow.flowId);
+      const result = await dispatch(flow.flowId);
       if (!result.ok) {
         throw new Error(result.reason);
       }
@@ -172,9 +267,9 @@ describe("task review lifecycle", () => {
   });
 
   it("persists actionable changes_requested and genuine awaiting_owner outcomes", async () => {
-    await withReviewState(() => {
+    await withReviewState(async () => {
       const changesFlow = createReviewFlow();
-      const changes = dispatch(changesFlow.flowId);
+      const changes = await dispatch(changesFlow.flowId);
       if (!changes.ok) {
         throw new Error(changes.reason);
       }
@@ -202,7 +297,7 @@ describe("task review lifecycle", () => {
       expect(changed.terminalOutcome).toBe("blocked");
 
       const ownerFlow = createReviewFlow({ ...buildRequest(), reviewerAgentId: "owner-reviewer" });
-      const owner = dispatch(ownerFlow.flowId, {
+      const owner = await dispatch(ownerFlow.flowId, {
         ...buildRequest(),
         reviewerAgentId: "owner-reviewer",
       });
@@ -237,9 +332,9 @@ describe("task review lifecycle", () => {
   });
 
   it("escalates stale unclaimed reviews and records recovery and reverify states", async () => {
-    await withReviewState(() => {
+    await withReviewState(async () => {
       const flow = createReviewFlow();
-      const result = dispatch(flow.flowId, buildRequest(), 1_000);
+      const result = await dispatch(flow.flowId, buildRequest(), 1_000);
       if (!result.ok) {
         throw new Error(result.reason);
       }
@@ -274,7 +369,7 @@ describe("task review lifecycle", () => {
   it("escalates an unclaimed reviewer through the registry maintenance pass", async () => {
     await withReviewState(async () => {
       const flow = createReviewFlow();
-      const result = dispatch(flow.flowId);
+      const result = await dispatch(flow.flowId);
       if (!result.ok || !result.task.runId) {
         throw new Error(result.ok ? "Expected stable review run id." : result.reason);
       }
@@ -283,11 +378,123 @@ describe("task review lifecycle", () => {
         lastEventAt: Date.now() - 2_000,
       });
 
+      const replacementRuntime: TaskReviewerRuntime = {
+        ...reviewerRuntime,
+        inspect: async () => ({ state: "missing" }),
+      };
+      setTaskRegistryMaintenanceReviewerRuntimeForTests(replacementRuntime);
+
       expect(previewTaskRegistryMaintenance().reconciled).toBe(1);
       expect((await runTaskRegistryMaintenance()).reconciled).toBe(1);
       expect(parseTaskReviewDetail(listTasksForFlowId(flow.flowId)[0]!)?.state).toBe(
-        "recovery_pending",
+        "review_pending",
       );
+      expect(parseTaskReviewDetail(listTasksForFlowId(flow.flowId)[0]!)?.recoveryAttempt).toBe(1);
+    });
+  });
+
+  it("adopts one live child or creates one bounded deterministic replacement", async () => {
+    await withReviewState(async () => {
+      const flow = createReviewFlow();
+      const result = await dispatch(flow.flowId);
+      if (!result.ok) {
+        throw new Error(result.reason);
+      }
+      const launch = vi.fn((params) => reviewerRuntime.launch(params));
+      const adopted = await reconcileTaskReviewRuntime({
+        taskId: result.task.taskId,
+        runtime: { ...reviewerRuntime, launch },
+        now: 11_000,
+      });
+      expect(adopted.state).toBe("adopted");
+      expect(launch).not.toHaveBeenCalled();
+
+      const replaced = await reconcileTaskReviewRuntime({
+        taskId: result.task.taskId,
+        runtime: { ...reviewerRuntime, launch, inspect: async () => ({ state: "missing" }) },
+        now: 12_000,
+      });
+      expect(replaced.state).toBe("recovered");
+      expect(launch).toHaveBeenCalledTimes(1);
+      expect(parseTaskReviewDetail(replaced.task)).toMatchObject({
+        state: "review_pending",
+        recoveryAttempt: 1,
+      });
+    });
+  });
+
+  it("fails closed after the configured replacement limit", async () => {
+    await withReviewState(async () => {
+      const request = buildRequest({ maxRecoveryAttempts: 1 });
+      const flow = createReviewFlow(request);
+      const result = await dispatch(flow.flowId, request);
+      if (!result.ok) {
+        throw new Error(result.reason);
+      }
+      const exhausted = await reconcileTaskReviewRuntime({
+        taskId: result.task.taskId,
+        runtime: {
+          inspect: async () => ({ state: "missing" }),
+          launch: async () => ({ ok: false, reason: "reviewer unavailable" }),
+        },
+        now: 12_000,
+      });
+      expect(exhausted.state).toBe("failed");
+      expect(exhausted.task.status).toBe("failed");
+      expect(parseTaskReviewDetail(exhausted.task)).toMatchObject({
+        state: "recovery_failed",
+        recoveryAttempt: 1,
+        maxRecoveryAttempts: 1,
+      });
+      expect(getTaskFlowById(flow.flowId)).toMatchObject({
+        status: "failed",
+        currentStep: "recovery_failed",
+      });
+    });
+  });
+
+  it("ingests a typed reviewer decision and projects truthful task and flow status", async () => {
+    await withReviewState(async () => {
+      const wakes: Array<{ source: string; sessionKey?: string }> = [];
+      const clearWake = setHeartbeatWakeHandler(async (request) => {
+        wakes.push(request);
+        return { status: "ran", durationMs: 0 };
+      });
+      const flow = createReviewFlow();
+      const result = await dispatch(flow.flowId);
+      if (!result.ok) {
+        throw new Error(result.reason);
+      }
+      const completed = await reconcileTaskReviewRuntime({
+        taskId: result.task.taskId,
+        runtime: {
+          ...reviewerRuntime,
+          inspect: async () => ({
+            state: "completed",
+            decision: {
+              outcome: "changes_requested",
+              reviewedCommit: COMMIT,
+              criteria: [{ id: "criterion-1", status: "failed", evidence: "fixture" }],
+              findings: ["Fix the fixture."],
+            },
+          }),
+        },
+        now: 13_000,
+      });
+      expect(completed.state).toBe("completed");
+      expect(completed.task).toMatchObject({ status: "succeeded", terminalOutcome: "blocked" });
+      expect(parseTaskReviewDetail(completed.task)?.state).toBe("changes_requested");
+      expect(getTaskFlowById(flow.flowId)).toMatchObject({
+        status: "blocked",
+        currentStep: "changes_requested",
+        blockedTaskId: result.task.taskId,
+      });
+      await vi.waitFor(() => {
+        expect(wakes).toContainEqual(
+          expect.objectContaining({ source: "background-task", sessionKey: OWNER_KEY }),
+        );
+      });
+      clearWake();
     });
   });
 });

--- a/src/tasks/task-review-lifecycle.test.ts
+++ b/src/tasks/task-review-lifecycle.test.ts
@@ -1,11 +1,19 @@
 // Verifies durable, idempotent managed review handoff and closed lifecycle transitions.
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { handleTasksCommand } from "../auto-reply/reply/commands-tasks.js";
+import type { HandleCommandsParams } from "../auto-reply/reply/commands-types.js";
 import { setHeartbeatWakeHandler } from "../infra/heartbeat-wake.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
 import { captureEnv } from "../test-utils/env.js";
 import { reloadTaskRuntimeStateFromStore } from "./runtime-internal.js";
+import { mapTaskFlowDetail } from "./task-domain-views.js";
 import { recordTaskRunProgressByRunId } from "./task-executor.js";
-import { createManagedTaskFlow, getTaskFlowById } from "./task-flow-registry.js";
+import {
+  createManagedTaskFlow,
+  getTaskFlowById,
+  updateFlowRecordByIdExpectedRevision,
+} from "./task-flow-registry.js";
 import { listTasksForFlowId } from "./task-registry.js";
 import {
   previewTaskRegistryMaintenance,
@@ -27,11 +35,15 @@ import {
   type TaskReviewRequest,
   type TaskReviewerRuntime,
 } from "./task-review-lifecycle.js";
-import { createReviewDispatchAtomically } from "./task-review-store.js";
+import {
+  commitReviewTaskAndFlowAtomically,
+  createReviewDispatchAtomically,
+} from "./task-review-store.js";
 import {
   resetTaskFlowRegistryForTests,
   resetTaskRegistryForTests,
 } from "./task-runtime.test-helpers.js";
+import { formatTaskStatusDetail } from "./task-status.js";
 
 const ORIGINAL_ENV = captureEnv(["OPENCLAW_STATE_DIR"]);
 const OWNER_KEY = "agent:main:main";
@@ -75,6 +87,63 @@ function buildRequest(overrides: Partial<TaskReviewRequest> = {}): TaskReviewReq
     },
     ...overrides,
   };
+}
+
+function buildRequestForCommit(digit: string, overrides: Partial<TaskReviewRequest> = {}) {
+  const base = buildRequest();
+  return {
+    ...base,
+    proofBundle: {
+      ...base.proofBundle,
+      commit: digit.repeat(40),
+      diff: { ...base.proofBundle.diff, sha256: digit.repeat(64) },
+    },
+    ...overrides,
+  } satisfies TaskReviewRequest;
+}
+
+function replaceReviewRequest(flowId: string, request: TaskReviewRequest): void {
+  const flow = getTaskFlowById(flowId);
+  if (!flow) {
+    throw new Error("Expected review flow.");
+  }
+  const state =
+    flow.stateJson && typeof flow.stateJson === "object" && !Array.isArray(flow.stateJson)
+      ? flow.stateJson
+      : {};
+  const updated = updateFlowRecordByIdExpectedRevision({
+    flowId,
+    expectedRevision: flow.revision,
+    patch: { stateJson: { ...state, reviewRequest: request } },
+  });
+  if (!updated.applied) {
+    throw new Error("Expected review request update.");
+  }
+}
+
+function reopenReviewState(): void {
+  resetTaskRegistryForTests({ persist: false });
+  resetTaskFlowRegistryForTests({ persist: false });
+  closeOpenClawStateDatabaseForTest();
+  reloadTaskRuntimeStateFromStore();
+}
+
+async function renderTasksCommand(): Promise<string> {
+  const result = await handleTasksCommand(
+    {
+      cfg: {},
+      command: {
+        commandBodyNormalized: "/tasks",
+        isAuthorizedSender: true,
+        senderIsOwner: true,
+        channel: "whatsapp",
+        ownerList: [],
+      },
+      sessionKey: OWNER_KEY,
+    } as unknown as HandleCommandsParams,
+    true,
+  );
+  return result?.reply?.text ?? "";
 }
 
 async function withReviewState(run: () => Promise<void> | void): Promise<void> {
@@ -201,6 +270,178 @@ describe("task review lifecycle", () => {
     });
   });
 
+  it("does not recover a fresh initial launch claim while launch is held", async () => {
+    await withReviewState(async () => {
+      const flow = createReviewFlow();
+      let releaseLaunch:
+        | ((value: Awaited<ReturnType<TaskReviewerRuntime["launch"]>>) => void)
+        | undefined;
+      const launch = vi.fn(
+        async () =>
+          await new Promise<Awaited<ReturnType<TaskReviewerRuntime["launch"]>>>((resolve) => {
+            releaseLaunch = resolve;
+          }),
+      );
+      const runtime: TaskReviewerRuntime = { ...reviewerRuntime, launch };
+      const dispatching = dispatchTaskReview({
+        flowId: flow.flowId,
+        callerOwnerKey: OWNER_KEY,
+        request: buildRequest(),
+        continuity: { ownerKey: OWNER_KEY, sessionKey: OWNER_KEY },
+        now: 10_000,
+        runtime,
+      });
+      await vi.waitFor(() => expect(launch).toHaveBeenCalledTimes(1));
+      const claimed = listTasksForFlowId(flow.flowId)[0]!;
+      expect(parseTaskReviewDetail(claimed)?.launch).toMatchObject({
+        phase: "claimed",
+        attempt: 0,
+      });
+
+      const maintained = await reconcileTaskReviewRuntime({
+        taskId: claimed.taskId,
+        runtime,
+        now: 10_500,
+      });
+      expect(maintained.state).toBe("adopted");
+      expect(launch).toHaveBeenCalledTimes(1);
+
+      releaseLaunch?.({
+        ok: true,
+        reviewerRunId: "run-0",
+        childSessionKey: "agent:reviewer:subagent:attempt-0",
+      });
+      const dispatched = await dispatching;
+      expect(dispatched.ok).toBe(true);
+      if (dispatched.ok) {
+        expect(dispatched.detail.launch).toMatchObject({ phase: "bound", attempt: 0 });
+      }
+    });
+  });
+
+  it("replays an accepted-but-unbound claim after reopen using the same attempt and child", async () => {
+    await withReviewState(async () => {
+      const flow = createReviewFlow();
+      const launches: number[] = [];
+      let holdInitial = true;
+      const runtime: TaskReviewerRuntime = {
+        ...reviewerRuntime,
+        async launch({ recoveryAttempt }) {
+          launches.push(recoveryAttempt);
+          if (holdInitial) {
+            holdInitial = false;
+            return await new Promise(() => {
+              // Simulate process loss after external acceptance but before durable binding.
+            });
+          }
+          return {
+            ok: true,
+            reviewerRunId: "accepted-run-0",
+            childSessionKey: "agent:reviewer:subagent:accepted-attempt-0",
+          };
+        },
+      };
+      void dispatchTaskReview({
+        flowId: flow.flowId,
+        callerOwnerKey: OWNER_KEY,
+        request: buildRequest(),
+        continuity: { ownerKey: OWNER_KEY, sessionKey: OWNER_KEY },
+        now: 10_000,
+        runtime,
+      });
+      await vi.waitFor(() => expect(launches).toEqual([0]));
+
+      resetTaskRegistryForTests({ persist: false });
+      resetTaskFlowRegistryForTests({ persist: false });
+      reloadTaskRuntimeStateFromStore();
+      const claimed = listTasksForFlowId(flow.flowId)[0]!;
+      const replayed = await reconcileTaskReviewRuntime({
+        taskId: claimed.taskId,
+        runtime,
+        now: 11_001,
+      });
+      expect(replayed.state).toBe("recovered");
+      expect(launches).toEqual([0, 0]);
+      expect(parseTaskReviewDetail(replayed.task)).toMatchObject({
+        recoveryAttempt: 0,
+        launch: {
+          phase: "bound",
+          attempt: 0,
+          reviewerRunId: "accepted-run-0",
+          childSessionKey: "agent:reviewer:subagent:accepted-attempt-0",
+        },
+      });
+      expect(listTasksForFlowId(flow.flowId)).toHaveLength(1);
+    });
+  });
+
+  it("rejects a late initial binding after a newer recovery attempt is bound", async () => {
+    await withReviewState(async () => {
+      const flow = createReviewFlow();
+      let releaseInitial:
+        | ((value: Awaited<ReturnType<TaskReviewerRuntime["launch"]>>) => void)
+        | undefined;
+      const launches: number[] = [];
+      const runtime: TaskReviewerRuntime = {
+        ...reviewerRuntime,
+        async launch({ recoveryAttempt }) {
+          launches.push(recoveryAttempt);
+          if (launches.length === 1) {
+            return await new Promise((resolve) => {
+              releaseInitial = resolve;
+            });
+          }
+          if (launches.length === 2) {
+            return { ok: false, reason: "attempt zero was not found" };
+          }
+          return {
+            ok: true,
+            reviewerRunId: "run-1",
+            childSessionKey: "agent:reviewer:subagent:attempt-1",
+          };
+        },
+      };
+      const dispatching = dispatchTaskReview({
+        flowId: flow.flowId,
+        callerOwnerKey: OWNER_KEY,
+        request: buildRequest(),
+        continuity: { ownerKey: OWNER_KEY, sessionKey: OWNER_KEY },
+        now: 10_000,
+        runtime,
+      });
+      await vi.waitFor(() => expect(launches).toEqual([0]));
+      const task = listTasksForFlowId(flow.flowId)[0]!;
+      const recovered = await reconcileTaskReviewRuntime({
+        taskId: task.taskId,
+        runtime,
+        now: 11_001,
+      });
+      expect(recovered.state).toBe("recovered");
+      expect(launches).toEqual([0, 0, 1]);
+      expect(parseTaskReviewDetail(recovered.task)?.launch).toMatchObject({
+        phase: "bound",
+        attempt: 1,
+        reviewerRunId: "run-1",
+      });
+
+      releaseInitial?.({
+        ok: true,
+        reviewerRunId: "late-run-0",
+        childSessionKey: "agent:reviewer:subagent:late-attempt-0",
+      });
+      const settled = await dispatching;
+      expect(settled.ok).toBe(true);
+      if (settled.ok) {
+        expect(settled.detail.launch).toMatchObject({
+          phase: "bound",
+          attempt: 1,
+          reviewerRunId: "run-1",
+        });
+        expect(settled.task.childSessionKey).toBe("agent:reviewer:subagent:attempt-1");
+      }
+    });
+  });
+
   it("rolls back the flow CAS and task insert when the coupled delivery insert fails", async () => {
     await withReviewState(() => {
       const flow = createReviewFlow();
@@ -228,6 +469,40 @@ describe("task review lifecycle", () => {
       expect(listTasksForFlowId(flow.flowId)).toHaveLength(0);
       expect(getTaskFlowById(flow.flowId)?.revision).toBe(flow.revision);
       expect(getTaskFlowById(flow.flowId)?.status).toBe(flow.status);
+    });
+  });
+
+  it("rolls back a terminal flow projection when the task detail CAS loses", async () => {
+    await withReviewState(async () => {
+      const flow = createReviewFlow();
+      const dispatched = await dispatch(flow.flowId);
+      if (!dispatched.ok) {
+        throw new Error(dispatched.reason);
+      }
+      const beforeFlow = getTaskFlowById(flow.flowId)!;
+      const beforeTask = listTasksForFlowId(flow.flowId)[0]!;
+      const result = commitReviewTaskAndFlowAtomically({
+        task: beforeTask,
+        expectedDetail: { wrong: "detail" },
+        nextTask: {
+          ...beforeTask,
+          status: "succeeded",
+          endedAt: 30_000,
+          terminalSummary: "must roll back",
+        },
+        reviewProjection: { state: "merge_ready", taskId: beforeTask.taskId },
+        flowStatus: "waiting",
+        currentStep: "merge_ready",
+        now: 30_000,
+      });
+      expect(result).toEqual({ status: "task_conflict" });
+      reopenReviewState();
+      expect(getTaskFlowById(flow.flowId)?.revision).toBe(beforeFlow.revision);
+      expect(getTaskFlowById(flow.flowId)?.currentStep).toBe(beforeFlow.currentStep);
+      expect(listTasksForFlowId(flow.flowId)[0]).toMatchObject({
+        status: beforeTask.status,
+        childSessionKey: beforeTask.childSessionKey,
+      });
     });
   });
 
@@ -384,8 +659,8 @@ describe("task review lifecycle", () => {
       };
       setTaskRegistryMaintenanceReviewerRuntimeForTests(replacementRuntime);
 
-      expect(previewTaskRegistryMaintenance().reconciled).toBe(1);
-      expect((await runTaskRegistryMaintenance()).reconciled).toBe(1);
+      expect(previewTaskRegistryMaintenance().reconciled).toBe(0);
+      expect((await runTaskRegistryMaintenance()).reconciled).toBe(0);
       expect(parseTaskReviewDetail(listTasksForFlowId(flow.flowId)[0]!)?.state).toBe(
         "review_pending",
       );
@@ -449,6 +724,142 @@ describe("task review lifecycle", () => {
       expect(getTaskFlowById(flow.flowId)).toMatchObject({
         status: "failed",
         currentStep: "recovery_failed",
+      });
+    });
+  });
+
+  it("reopens changes_requested into a clean new review and merge_ready projection", async () => {
+    await withReviewState(async () => {
+      const firstRequest = buildRequestForCommit("1");
+      const flow = createReviewFlow(firstRequest);
+      const first = await dispatch(flow.flowId, firstRequest);
+      if (!first.ok) {
+        throw new Error(first.reason);
+      }
+      applyTaskReviewDecision({
+        taskId: first.task.taskId,
+        now: 20_000,
+        decision: {
+          outcome: "changes_requested",
+          reviewedCommit: firstRequest.proofBundle.commit,
+          criteria: [{ id: "criterion-1", status: "failed", evidence: "old blocker" }],
+          findings: ["Fix the old blocker."],
+        },
+      });
+      const secondRequest = buildRequestForCommit("4");
+      replaceReviewRequest(flow.flowId, secondRequest);
+      const beforeNewReview = getTaskFlowById(flow.flowId)!;
+      expect(
+        updateFlowRecordByIdExpectedRevision({
+          flowId: flow.flowId,
+          expectedRevision: beforeNewReview.revision,
+          patch: { waitJson: { kind: "old-wait" } },
+        }).applied,
+      ).toBe(true);
+
+      const second = await dispatch(flow.flowId, secondRequest, 21_000);
+      if (!second.ok) {
+        throw new Error(second.reason);
+      }
+      reopenReviewState();
+      expect(getTaskFlowById(flow.flowId)).toMatchObject({
+        status: "waiting",
+        currentStep: "review_pending",
+      });
+      expect(getTaskFlowById(flow.flowId)?.blockedTaskId).toBeUndefined();
+      expect(getTaskFlowById(flow.flowId)?.blockedSummary).toBeUndefined();
+      expect(getTaskFlowById(flow.flowId)?.endedAt).toBeUndefined();
+      expect(getTaskFlowById(flow.flowId)?.waitJson).toBeUndefined();
+
+      const currentSecond = listTasksForFlowId(flow.flowId).find(
+        (task) => parseTaskReviewDetail(task)?.dispatchKey === second.detail.dispatchKey,
+      )!;
+      const merged = applyTaskReviewDecision({
+        taskId: currentSecond.taskId,
+        now: 22_000,
+        decision: {
+          outcome: "merge_ready",
+          reviewedCommit: secondRequest.proofBundle.commit,
+          criteria: [{ id: "criterion-1", status: "passed", evidence: "new proof verified" }],
+          findings: [],
+        },
+      });
+      reopenReviewState();
+      const reopenedFlow = getTaskFlowById(flow.flowId)!;
+      const reopenedTasks = listTasksForFlowId(flow.flowId);
+      const reopenedMerged = reopenedTasks.find((task) => task.taskId === merged.taskId)!;
+      expect(reopenedFlow).toMatchObject({ status: "waiting", currentStep: "merge_ready" });
+      expect(reopenedFlow.blockedTaskId).toBeUndefined();
+      expect(reopenedFlow.blockedSummary).toBeUndefined();
+      expect(reopenedFlow.endedAt).toBeUndefined();
+      expect(reopenedMerged).toMatchObject({
+        status: "succeeded",
+        terminalOutcome: "succeeded",
+      });
+      expect(formatTaskStatusDetail(reopenedMerged)).toContain("Merge ready");
+      const tasksText = await renderTasksCommand();
+      expect(tasksText).toContain("Merge ready");
+      expect(mapTaskFlowDetail({ flow: reopenedFlow, tasks: reopenedTasks })).toMatchObject({
+        status: "waiting",
+        currentStep: "merge_ready",
+        tasks: expect.arrayContaining([
+          expect.objectContaining({
+            id: reopenedMerged.taskId,
+            status: "succeeded",
+            terminalOutcome: "succeeded",
+          }),
+        ]),
+        state: { review: { state: "merge_ready", taskId: reopenedMerged.taskId } },
+      });
+    });
+  });
+
+  it("reopens recovery_failed into a clean active review", async () => {
+    await withReviewState(async () => {
+      const firstRequest = buildRequestForCommit("1", { maxRecoveryAttempts: 1 });
+      const flow = createReviewFlow(firstRequest);
+      const first = await dispatch(flow.flowId, firstRequest);
+      if (!first.ok) {
+        throw new Error(first.reason);
+      }
+      await reconcileTaskReviewRuntime({
+        taskId: first.task.taskId,
+        runtime: {
+          inspect: async () => ({ state: "missing" }),
+          launch: async () => ({ ok: false, reason: "reviewer unavailable" }),
+        },
+        now: 20_000,
+      });
+      reopenReviewState();
+      expect(getTaskFlowById(flow.flowId)).toMatchObject({
+        status: "failed",
+        currentStep: "recovery_failed",
+        endedAt: 20_000,
+      });
+
+      const secondRequest = buildRequestForCommit("5");
+      replaceReviewRequest(flow.flowId, secondRequest);
+      const second = await dispatch(flow.flowId, secondRequest, 21_000);
+      if (!second.ok) {
+        throw new Error(second.reason);
+      }
+      reopenReviewState();
+      const reopenedFlow = getTaskFlowById(flow.flowId)!;
+      const reopenedTask = listTasksForFlowId(flow.flowId).find(
+        (task) => task.taskId === second.task.taskId,
+      )!;
+      expect(reopenedFlow).toMatchObject({ status: "waiting", currentStep: "review_pending" });
+      expect(reopenedFlow.endedAt).toBeUndefined();
+      expect(reopenedFlow.blockedTaskId).toBeUndefined();
+      expect(reopenedFlow.blockedSummary).toBeUndefined();
+      expect(reopenedTask.status).toBe("running");
+      expect(parseTaskReviewDetail(reopenedTask)?.state).toBe("review_pending");
+      expect(await renderTasksCommand()).toContain("Reviewer child is running");
+      expect(mapTaskFlowDetail({ flow: reopenedFlow, tasks: [reopenedTask] })).toMatchObject({
+        status: "waiting",
+        currentStep: "review_pending",
+        tasks: [expect.objectContaining({ id: reopenedTask.taskId, status: "running" })],
+        state: { review: { state: "review_pending", taskId: reopenedTask.taskId } },
       });
     });
   });

--- a/src/tasks/task-review-lifecycle.test.ts
+++ b/src/tasks/task-review-lifecycle.test.ts
@@ -1,0 +1,293 @@
+// Verifies durable, idempotent managed review handoff and closed lifecycle transitions.
+import { afterEach, describe, expect, it } from "vitest";
+import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
+import { captureEnv } from "../test-utils/env.js";
+import { reloadTaskRuntimeStateFromStore } from "./runtime-internal.js";
+import { recordTaskRunProgressByRunId } from "./task-executor.js";
+import { createManagedTaskFlow } from "./task-flow-registry.js";
+import { listTasksForFlowId } from "./task-registry.js";
+import {
+  previewTaskRegistryMaintenance,
+  resetTaskRegistryMaintenanceRuntimeForTests,
+  runTaskRegistryMaintenance,
+  stopTaskRegistryMaintenance,
+} from "./task-registry.maintenance.js";
+import {
+  applyTaskReviewDecision,
+  beginTaskReviewRecovery,
+  dispatchTaskReview,
+  markTaskReviewReverifyPending,
+  parseTaskReviewDetail,
+  reconcileStaleTaskReviews,
+  resumeTaskReviewVerification,
+  type TaskReviewRequest,
+} from "./task-review-lifecycle.js";
+import {
+  resetTaskFlowRegistryForTests,
+  resetTaskRegistryForTests,
+} from "./task-runtime.test-helpers.js";
+
+const ORIGINAL_ENV = captureEnv(["OPENCLAW_STATE_DIR"]);
+const OWNER_KEY = "agent:main:main";
+const COMMIT = "1".repeat(40);
+
+function buildRequest(overrides: Partial<TaskReviewRequest> = {}): TaskReviewRequest {
+  return {
+    reviewerAgentId: "reviewer",
+    staleAfterMs: 1_000,
+    proofBundle: {
+      commit: COMMIT,
+      baseCommit: "2".repeat(40),
+      diff: {
+        sha256: "3".repeat(64),
+        summary: "Add durable review handoff.",
+        files: ["src/review.ts"],
+      },
+      tests: [
+        {
+          name: "focused",
+          command: "vitest review",
+          status: "passed",
+          evidence: "12 tests passed",
+        },
+      ],
+      screenshots: [],
+      criteria: [{ id: "criterion-1", description: "Review remains durable." }],
+    },
+    ...overrides,
+  };
+}
+
+async function withReviewState(run: () => Promise<void> | void): Promise<void> {
+  await withStateDirEnv("openclaw-task-review-", async () => {
+    resetTaskRegistryForTests({ persist: false });
+    resetTaskFlowRegistryForTests({ persist: false });
+    stopTaskRegistryMaintenance();
+    resetTaskRegistryMaintenanceRuntimeForTests();
+    await run();
+  });
+}
+
+function createReviewFlow(request = buildRequest()) {
+  const flow = createManagedTaskFlow({
+    ownerKey: OWNER_KEY,
+    controllerId: "tests/review",
+    goal: "Review exact proof",
+    stateJson: { reviewRequest: request },
+  });
+  if (!flow) {
+    throw new Error("Expected managed flow creation to succeed.");
+  }
+  return flow;
+}
+
+function dispatch(flowId: string, request = buildRequest(), now = 10_000) {
+  return dispatchTaskReview({
+    flowId,
+    callerOwnerKey: OWNER_KEY,
+    request,
+    continuity: {
+      ownerKey: OWNER_KEY,
+      sessionKey: OWNER_KEY,
+      sessionId: "session-before-compact",
+      compactionCount: 3,
+      sourceTaskId: "source-task",
+    },
+    parentTaskId: "source-task",
+    now,
+  });
+}
+
+describe("task review lifecycle", () => {
+  afterEach(() => {
+    ORIGINAL_ENV.restore();
+    resetTaskRegistryForTests({ persist: false });
+    resetTaskFlowRegistryForTests({ persist: false });
+  });
+
+  it("atomically persists one reviewer, linkage, continuity, and exact proof across reload", async () => {
+    await withReviewState(() => {
+      const flow = createReviewFlow();
+      const first = dispatch(flow.flowId);
+      expect(first.ok).toBe(true);
+      if (!first.ok) {
+        return;
+      }
+      expect(first.created).toBe(true);
+      expect(first.task.parentFlowId).toBe(flow.flowId);
+      expect(first.task.parentTaskId).toBe("source-task");
+      expect(first.task.agentId).toBe("reviewer");
+      expect(first.detail.proofBundle.commit).toBe(COMMIT);
+      expect(first.detail.continuity.compactionCount).toBe(3);
+
+      resetTaskRegistryForTests({ persist: false });
+      resetTaskFlowRegistryForTests({ persist: false });
+      reloadTaskRuntimeStateFromStore();
+
+      const replay = dispatch(flow.flowId);
+      expect(replay.ok).toBe(true);
+      if (!replay.ok) {
+        return;
+      }
+      expect(replay.created).toBe(false);
+      expect(replay.task.taskId).toBe(first.task.taskId);
+      expect(listTasksForFlowId(flow.flowId)).toHaveLength(1);
+      expect(parseTaskReviewDetail(replay.task)).toEqual(first.detail);
+    });
+  });
+
+  it("accepts merge_ready only for the exact commit with passing proof and criteria", async () => {
+    await withReviewState(() => {
+      const flow = createReviewFlow();
+      const result = dispatch(flow.flowId);
+      if (!result.ok) {
+        throw new Error(result.reason);
+      }
+      expect(() =>
+        applyTaskReviewDecision({
+          taskId: result.task.taskId,
+          decision: {
+            outcome: "merge_ready",
+            reviewedCommit: "4".repeat(40),
+            criteria: [{ id: "criterion-1", status: "passed", evidence: "verified" }],
+            findings: [],
+          },
+        }),
+      ).toThrow(/commit does not match/u);
+
+      const updated = applyTaskReviewDecision({
+        taskId: result.task.taskId,
+        now: 11_000,
+        decision: {
+          outcome: "merge_ready",
+          reviewedCommit: COMMIT,
+          criteria: [{ id: "criterion-1", status: "passed", evidence: "verified" }],
+          findings: [],
+        },
+      });
+      expect(updated.status).toBe("succeeded");
+      expect(updated.terminalOutcome).toBe("succeeded");
+      expect(parseTaskReviewDetail(updated)?.state).toBe("merge_ready");
+    });
+  });
+
+  it("persists actionable changes_requested and genuine awaiting_owner outcomes", async () => {
+    await withReviewState(() => {
+      const changesFlow = createReviewFlow();
+      const changes = dispatch(changesFlow.flowId);
+      if (!changes.ok) {
+        throw new Error(changes.reason);
+      }
+      expect(() =>
+        applyTaskReviewDecision({
+          taskId: changes.task.taskId,
+          decision: {
+            outcome: "changes_requested",
+            reviewedCommit: COMMIT,
+            criteria: [{ id: "criterion-1", status: "failed", evidence: "missing" }],
+            findings: [],
+          },
+        }),
+      ).toThrow(/actionable finding/u);
+      const changed = applyTaskReviewDecision({
+        taskId: changes.task.taskId,
+        decision: {
+          outcome: "changes_requested",
+          reviewedCommit: COMMIT,
+          criteria: [{ id: "criterion-1", status: "failed", evidence: "missing" }],
+          findings: ["Persist the recovery marker."],
+        },
+      });
+      expect(parseTaskReviewDetail(changed)?.state).toBe("changes_requested");
+      expect(changed.terminalOutcome).toBe("blocked");
+
+      const ownerFlow = createReviewFlow({ ...buildRequest(), reviewerAgentId: "owner-reviewer" });
+      const owner = dispatch(ownerFlow.flowId, {
+        ...buildRequest(),
+        reviewerAgentId: "owner-reviewer",
+      });
+      if (!owner.ok) {
+        throw new Error(owner.reason);
+      }
+      expect(() =>
+        applyTaskReviewDecision({
+          taskId: owner.task.taskId,
+          decision: {
+            outcome: "awaiting_owner",
+            reviewedCommit: COMMIT,
+            criteria: [{ id: "criterion-1", status: "passed", evidence: "verified" }],
+            ownerQuestion: "",
+            whyAutomationCannotDecide: "Product policy choice.",
+          },
+        }),
+      ).toThrow(/ownerQuestion/u);
+      const awaitingOwner = applyTaskReviewDecision({
+        taskId: owner.task.taskId,
+        decision: {
+          outcome: "awaiting_owner",
+          reviewedCommit: COMMIT,
+          criteria: [{ id: "criterion-1", status: "passed", evidence: "verified" }],
+          ownerQuestion: "Should this policy exception be accepted?",
+          whyAutomationCannotDecide: "The product owner must choose the policy tradeoff.",
+        },
+      });
+      expect(parseTaskReviewDetail(awaitingOwner)?.state).toBe("awaiting_owner");
+      expect(awaitingOwner.terminalOutcome).toBe("blocked");
+    });
+  });
+
+  it("escalates stale unclaimed reviews and records recovery and reverify states", async () => {
+    await withReviewState(() => {
+      const flow = createReviewFlow();
+      const result = dispatch(flow.flowId, buildRequest(), 1_000);
+      if (!result.ok) {
+        throw new Error(result.reason);
+      }
+      if (result.task.lastEventAt === undefined) {
+        throw new Error("Expected review task activity timestamp.");
+      }
+      const stale = reconcileStaleTaskReviews({
+        tasks: listTasksForFlowId(flow.flowId),
+        now: result.task.lastEventAt + 1_001,
+      });
+      expect(stale).toEqual({ escalated: 1, taskIds: [result.task.taskId] });
+      expect(parseTaskReviewDetail(listTasksForFlowId(flow.flowId)[0]!)?.state).toBe(
+        "recovery_pending",
+      );
+      expect(
+        parseTaskReviewDetail(beginTaskReviewRecovery({ taskId: result.task.taskId, now: 3_000 }))
+          ?.state,
+      ).toBe("recovering");
+      expect(
+        parseTaskReviewDetail(
+          markTaskReviewReverifyPending({ taskId: result.task.taskId, now: 4_000 }),
+        )?.state,
+      ).toBe("reverify_pending");
+      expect(
+        parseTaskReviewDetail(
+          resumeTaskReviewVerification({ taskId: result.task.taskId, now: 5_000 }),
+        )?.state,
+      ).toBe("review_pending");
+    });
+  });
+
+  it("escalates an unclaimed reviewer through the registry maintenance pass", async () => {
+    await withReviewState(async () => {
+      const flow = createReviewFlow();
+      const result = dispatch(flow.flowId);
+      if (!result.ok || !result.task.runId) {
+        throw new Error(result.ok ? "Expected stable review run id." : result.reason);
+      }
+      recordTaskRunProgressByRunId({
+        runId: result.task.runId,
+        lastEventAt: Date.now() - 2_000,
+      });
+
+      expect(previewTaskRegistryMaintenance().reconciled).toBe(1);
+      expect((await runTaskRegistryMaintenance()).reconciled).toBe(1);
+      expect(parseTaskReviewDetail(listTasksForFlowId(flow.flowId)[0]!)?.state).toBe(
+        "recovery_pending",
+      );
+    });
+  });
+});

--- a/src/tasks/task-review-lifecycle.test.ts
+++ b/src/tasks/task-review-lifecycle.test.ts
@@ -8,10 +8,11 @@ import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
 import { captureEnv } from "../test-utils/env.js";
 import { reloadTaskRuntimeStateFromStore } from "./runtime-internal.js";
 import { mapTaskFlowDetail } from "./task-domain-views.js";
-import { recordTaskRunProgressByRunId } from "./task-executor.js";
+import { finalizeTaskRunByRunId, recordTaskRunProgressByRunId } from "./task-executor.js";
 import {
   createManagedTaskFlow,
   getTaskFlowById,
+  requestFlowCancel,
   updateFlowRecordByIdExpectedRevision,
 } from "./task-flow-registry.js";
 import { listTasksForFlowId } from "./task-registry.js";
@@ -929,6 +930,76 @@ describe("task review lifecycle", () => {
         );
       });
       clearWake();
+    });
+  });
+
+  it("does not let late review reconciliation revive cancelled work", async () => {
+    await withReviewState(async () => {
+      const flow = createReviewFlow();
+      const result = await dispatch(flow.flowId);
+      if (!result.ok || !result.task.runId) {
+        throw new Error(result.ok ? "Expected stable review run id." : result.reason);
+      }
+
+      let releaseInspection: (() => void) | undefined;
+      const inspectionHeld = new Promise<void>((resolve) => {
+        releaseInspection = resolve;
+      });
+      const reconciling = reconcileTaskReviewRuntime({
+        taskId: result.task.taskId,
+        runtime: {
+          ...reviewerRuntime,
+          inspect: async () => {
+            await inspectionHeld;
+            return {
+              state: "completed",
+              decision: {
+                outcome: "merge_ready",
+                reviewedCommit: COMMIT,
+                criteria: [{ id: "criterion-1", status: "passed", evidence: "verified" }],
+                findings: [],
+              },
+            };
+          },
+        },
+        now: 13_000,
+      });
+      await vi.waitFor(() => expect(releaseInspection).toBeTypeOf("function"));
+
+      const currentFlow = getTaskFlowById(flow.flowId)!;
+      expect(
+        requestFlowCancel({
+          flowId: flow.flowId,
+          expectedRevision: currentFlow.revision,
+          cancelRequestedAt: 12_000,
+          updatedAt: 12_000,
+        }).applied,
+      ).toBe(true);
+      expect(
+        finalizeTaskRunByRunId({
+          runId: result.task.runId,
+          runtime: "subagent",
+          status: "cancelled",
+          endedAt: 12_500,
+          lastEventAt: 12_500,
+          error: "Cancelled by operator.",
+        }),
+      ).toHaveLength(1);
+
+      releaseInspection?.();
+      const reconciled = await reconciling;
+
+      expect(reconciled.state).toBe("adopted");
+      expect(reconciled.task).toMatchObject({
+        status: "cancelled",
+        endedAt: expect.any(Number),
+        error: "Cancelled by operator.",
+      });
+      expect(getTaskFlowById(flow.flowId)).toMatchObject({
+        status: "cancelled",
+        cancelRequestedAt: 12_000,
+        endedAt: expect.any(Number),
+      });
     });
   });
 });

--- a/src/tasks/task-review-lifecycle.test.ts
+++ b/src/tasks/task-review-lifecycle.test.ts
@@ -375,13 +375,18 @@ describe("task review lifecycle", () => {
     });
   });
 
-  it("rejects a late initial binding after a newer recovery attempt is bound", async () => {
+  it("rejects attempt zero while attempt one is still claimed and accounts for both children", async () => {
     await withReviewState(async () => {
       const flow = createReviewFlow();
       let releaseInitial:
         | ((value: Awaited<ReturnType<TaskReviewerRuntime["launch"]>>) => void)
         | undefined;
+      let releaseAttemptOne:
+        | ((value: Awaited<ReturnType<TaskReviewerRuntime["launch"]>>) => void)
+        | undefined;
       const launches: number[] = [];
+      const acceptedChildren = new Set<string>();
+      const settledNonOwners = new Set<string>();
       const runtime: TaskReviewerRuntime = {
         ...reviewerRuntime,
         async launch({ recoveryAttempt }) {
@@ -394,11 +399,12 @@ describe("task review lifecycle", () => {
           if (launches.length === 2) {
             return { ok: false, reason: "attempt zero was not found" };
           }
-          return {
-            ok: true,
-            reviewerRunId: "run-1",
-            childSessionKey: "agent:reviewer:subagent:attempt-1",
-          };
+          return await new Promise((resolve) => {
+            releaseAttemptOne = resolve;
+          });
+        },
+        async settleNonOwningLaunch({ childSessionKey }) {
+          settledNonOwners.add(childSessionKey);
         },
       };
       const dispatching = dispatchTaskReview({
@@ -411,19 +417,18 @@ describe("task review lifecycle", () => {
       });
       await vi.waitFor(() => expect(launches).toEqual([0]));
       const task = listTasksForFlowId(flow.flowId)[0]!;
-      const recovered = await reconcileTaskReviewRuntime({
+      const recovering = reconcileTaskReviewRuntime({
         taskId: task.taskId,
         runtime,
         now: 11_001,
       });
-      expect(recovered.state).toBe("recovered");
-      expect(launches).toEqual([0, 0, 1]);
-      expect(parseTaskReviewDetail(recovered.task)?.launch).toMatchObject({
-        phase: "bound",
+      await vi.waitFor(() => expect(launches).toEqual([0, 0, 1]));
+      expect(parseTaskReviewDetail(listTasksForFlowId(flow.flowId)[0]!)?.launch).toMatchObject({
+        phase: "claimed",
         attempt: 1,
-        reviewerRunId: "run-1",
       });
 
+      acceptedChildren.add("agent:reviewer:subagent:late-attempt-0");
       releaseInitial?.({
         ok: true,
         reviewerRunId: "late-run-0",
@@ -433,12 +438,30 @@ describe("task review lifecycle", () => {
       expect(settled.ok).toBe(true);
       if (settled.ok) {
         expect(settled.detail.launch).toMatchObject({
-          phase: "bound",
+          phase: "claimed",
           attempt: 1,
-          reviewerRunId: "run-1",
         });
-        expect(settled.task.childSessionKey).toBe("agent:reviewer:subagent:attempt-1");
+        expect(settled.task.childSessionKey).toBeUndefined();
       }
+      expect(settledNonOwners).toEqual(new Set(["agent:reviewer:subagent:late-attempt-0"]));
+
+      acceptedChildren.add("agent:reviewer:subagent:attempt-1");
+      releaseAttemptOne?.({
+        ok: true,
+        reviewerRunId: "run-1",
+        childSessionKey: "agent:reviewer:subagent:attempt-1",
+      });
+      const recovered = await recovering;
+      expect(recovered.state).toBe("recovered");
+      expect(parseTaskReviewDetail(recovered.task)?.launch).toMatchObject({
+        phase: "bound",
+        attempt: 1,
+        reviewerRunId: "run-1",
+        childSessionKey: "agent:reviewer:subagent:attempt-1",
+      });
+      expect(recovered.task.childSessionKey).toBe("agent:reviewer:subagent:attempt-1");
+      const accountedChildren = new Set([...settledNonOwners, recovered.task.childSessionKey!]);
+      expect(accountedChildren).toEqual(acceptedChildren);
     });
   });
 

--- a/src/tasks/task-review-lifecycle.ts
+++ b/src/tasks/task-review-lifecycle.ts
@@ -1,18 +1,23 @@
 // Owns deterministic managed-flow review dispatch, outcomes, and recovery state.
+/* oxlint-disable max-lines -- Review dispatch and recovery remain one state-machine authority. */
 import crypto from "node:crypto";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { reloadTaskRuntimeStateFromStore } from "./runtime-internal.js";
 import {
   completeTaskRunByRunId,
+  failTaskRunByRunId,
   recordTaskRunProgressByRunId,
-  runTaskInFlowForOwner,
 } from "./task-executor.js";
 import { getTaskFlowByIdForOwner, listTaskFlowsForOwner } from "./task-flow-owner-access.js";
+import { updateFlowRecordByIdExpectedRevision } from "./task-flow-registry.js";
 import type { TaskFlowRecord } from "./task-flow-registry.types.js";
 import { getTaskById, listTasksForFlowId } from "./task-registry.js";
-import type { JsonValue, TaskRecord } from "./task-registry.types.js";
+import type { JsonValue, TaskDeliveryState, TaskRecord } from "./task-registry.types.js";
+import { createReviewDispatchAtomically } from "./task-review-store.js";
 
 export const TASK_REVIEW_KIND = "managed-review";
 export const DEFAULT_TASK_REVIEW_STALE_MS = 30 * 60_000;
+export const DEFAULT_TASK_REVIEW_MAX_RECOVERY_ATTEMPTS = 2;
 
 export type TaskReviewState =
   | "review_pending"
@@ -21,7 +26,8 @@ export type TaskReviewState =
   | "awaiting_owner"
   | "recovery_pending"
   | "recovering"
-  | "reverify_pending";
+  | "reverify_pending"
+  | "recovery_failed";
 
 export type TaskReviewProofBundle = {
   commit: string;
@@ -52,6 +58,7 @@ export type TaskReviewRequest = {
   reviewerAgentId: string;
   proofBundle: TaskReviewProofBundle;
   staleAfterMs: number;
+  maxRecoveryAttempts: number;
 };
 
 export type TaskReviewContinuity = {
@@ -79,6 +86,9 @@ export type TaskReviewDetail = {
   staleAfterMs: number;
   stateChangedAt: number;
   recoveryAttempt: number;
+  maxRecoveryAttempts: number;
+  reviewerRunId?: string;
+  childSessionKey?: string;
   history: TaskReviewHistoryEntry[];
   decision?: TaskReviewDecision;
 };
@@ -114,6 +124,28 @@ export type DispatchTaskReviewResult =
   | { ok: true; created: boolean; task: TaskRecord; detail: TaskReviewDetail }
   | { ok: false; reason: string };
 
+export type TaskReviewerLaunchResult =
+  | { ok: true; reviewerRunId: string; childSessionKey: string }
+  | { ok: false; reason: string };
+
+export type TaskReviewerInspection =
+  | { state: "live" }
+  | { state: "missing" }
+  | { state: "failed"; reason: string }
+  | { state: "completed"; decision: unknown };
+
+export type TaskReviewerRuntime = {
+  launch(params: {
+    task: TaskRecord;
+    detail: TaskReviewDetail;
+    recoveryAttempt: number;
+  }): Promise<TaskReviewerLaunchResult>;
+  inspect(params: {
+    reviewerRunId: string;
+    childSessionKey: string;
+  }): Promise<TaskReviewerInspection>;
+};
+
 const REVIEW_STATES = new Set<TaskReviewState>([
   "review_pending",
   "changes_requested",
@@ -122,6 +154,7 @@ const REVIEW_STATES = new Set<TaskReviewState>([
   "recovery_pending",
   "recovering",
   "reverify_pending",
+  "recovery_failed",
 ]);
 
 const ALLOWED_TRANSITIONS: Record<TaskReviewState, ReadonlySet<TaskReviewState>> = {
@@ -131,12 +164,13 @@ const ALLOWED_TRANSITIONS: Record<TaskReviewState, ReadonlySet<TaskReviewState>>
     "awaiting_owner",
     "recovery_pending",
   ]),
-  changes_requested: new Set(["reverify_pending"]),
+  changes_requested: new Set(),
   merge_ready: new Set(),
-  awaiting_owner: new Set(["reverify_pending"]),
-  recovery_pending: new Set(["recovering"]),
-  recovering: new Set(["reverify_pending"]),
-  reverify_pending: new Set(["review_pending"]),
+  awaiting_owner: new Set(),
+  recovery_pending: new Set(["recovering", "recovery_failed"]),
+  recovering: new Set(["reverify_pending", "recovery_failed"]),
+  reverify_pending: new Set(["review_pending", "recovery_pending", "recovery_failed"]),
+  recovery_failed: new Set(),
 };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -248,6 +282,7 @@ export function parseTaskReviewRequest(flow: TaskFlowRecord): TaskReviewRequest 
   const state = requireObject(flow.stateJson, "TaskFlow state");
   const request = requireObject(state.reviewRequest, "TaskFlow state.reviewRequest");
   const staleAfterMsRaw = request.staleAfterMs;
+  const maxRecoveryAttemptsRaw = request.maxRecoveryAttempts;
   const staleAfterMs =
     typeof staleAfterMsRaw === "number" &&
     Number.isFinite(staleAfterMsRaw) &&
@@ -261,6 +296,13 @@ export function parseTaskReviewRequest(flow: TaskFlowRecord): TaskReviewRequest 
     ),
     proofBundle: parseProofBundle(request.proofBundle),
     staleAfterMs,
+    maxRecoveryAttempts:
+      typeof maxRecoveryAttemptsRaw === "number" &&
+      Number.isSafeInteger(maxRecoveryAttemptsRaw) &&
+      maxRecoveryAttemptsRaw >= 1 &&
+      maxRecoveryAttemptsRaw <= 5
+        ? maxRecoveryAttemptsRaw
+        : DEFAULT_TASK_REVIEW_MAX_RECOVERY_ATTEMPTS,
   };
 }
 
@@ -287,12 +329,62 @@ function buildReviewPrompt(detail: TaskReviewDetail): string {
     "Verify the supplied diff, tests, screenshots, and every acceptance criterion.",
     "Return exactly one outcome: changes_requested, merge_ready, or awaiting_owner.",
     "Use awaiting_owner only for a genuine decision that cannot be resolved from code or proof.",
+    "Return only JSON with reviewedCommit, outcome, criteria, and the outcome-specific fields.",
+    "Each criteria item must contain id, status (passed or failed), and evidence.",
+    "changes_requested also requires non-empty findings; merge_ready requires findings: []; awaiting_owner requires ownerQuestion and whyAutomationCannotDecide.",
     `Proof bundle: ${JSON.stringify(detail.proofBundle)}`,
   ].join("\n");
 }
 
 function detailToJson(detail: TaskReviewDetail): JsonValue {
   return structuredClone(detail) as unknown as JsonValue;
+}
+
+function syncReviewFlowProjection(task: TaskRecord, detail: TaskReviewDetail, now: number): void {
+  if (!task.parentFlowId) {
+    return;
+  }
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    const flow = getTaskFlowByIdForOwner({
+      flowId: task.parentFlowId,
+      callerOwnerKey: task.ownerKey,
+    });
+    if (!flow) {
+      return;
+    }
+    const state = isRecord(flow.stateJson) ? flow.stateJson : {};
+    const currentReview = isRecord(state.review) ? state.review : {};
+    const blocked = detail.state === "changes_requested" || detail.state === "awaiting_owner";
+    const failed = detail.state === "recovery_failed";
+    const result = updateFlowRecordByIdExpectedRevision({
+      flowId: flow.flowId,
+      expectedRevision: flow.revision,
+      patch: {
+        status: failed ? "failed" : blocked ? "blocked" : "waiting",
+        currentStep: detail.state,
+        updatedAt: now,
+        ...(failed ? { endedAt: now } : {}),
+        blockedTaskId: blocked ? task.taskId : undefined,
+        blockedSummary: blocked ? (task.terminalSummary ?? task.progressSummary) : undefined,
+        stateJson: {
+          ...state,
+          review: {
+            ...currentReview,
+            state: detail.state,
+            taskId: task.taskId,
+            dispatchKey: detail.dispatchKey,
+            commit: detail.proofBundle.commit,
+            reviewerAgentId: detail.reviewerAgentId,
+            recoveryAttempt: detail.recoveryAttempt,
+            ...(detail.decision ? { decision: detail.decision } : {}),
+          },
+        },
+      },
+    });
+    if (result.applied) {
+      return;
+    }
+  }
 }
 
 export function parseTaskReviewDetail(
@@ -319,14 +411,15 @@ function findReviewTask(flowId: string, dispatchKey: string): TaskRecord | undef
   );
 }
 
-export function dispatchTaskReview(params: {
+export async function dispatchTaskReview(params: {
   flowId: string;
   callerOwnerKey: string;
   request: TaskReviewRequest;
   continuity: TaskReviewContinuity;
   parentTaskId?: string;
   now?: number;
-}): DispatchTaskReviewResult {
+  runtime: TaskReviewerRuntime;
+}): Promise<DispatchTaskReviewResult> {
   const flow = getTaskFlowByIdForOwner({
     flowId: params.flowId,
     callerOwnerKey: params.callerOwnerKey,
@@ -343,8 +436,12 @@ export function dispatchTaskReview(params: {
   const existing = findReviewTask(flow.flowId, dispatchKey);
   if (existing) {
     const detail = parseTaskReviewDetail(existing);
-    return detail
-      ? { ok: true, created: false, task: existing, detail }
+    const refreshed = detail
+      ? refreshTaskReviewContinuity({ taskId: existing.taskId, continuity: params.continuity, now })
+      : undefined;
+    const refreshedDetail = refreshed ? parseTaskReviewDetail(refreshed) : undefined;
+    return refreshed && refreshedDetail
+      ? { ok: true, created: false, task: refreshed, detail: refreshedDetail }
       : { ok: false, reason: "Existing review task detail is invalid." };
   }
   const detail: TaskReviewDetail = {
@@ -358,29 +455,166 @@ export function dispatchTaskReview(params: {
     staleAfterMs: params.request.staleAfterMs,
     stateChangedAt: now,
     recoveryAttempt: 0,
+    maxRecoveryAttempts: params.request.maxRecoveryAttempts,
     history: [{ state: "review_pending", at: now, summary: "Review dispatched." }],
   };
-  const result = runTaskInFlowForOwner({
-    flowId: flow.flowId,
-    callerOwnerKey: params.callerOwnerKey,
+  const runId = `task-review:${dispatchKey}`;
+  const task: TaskRecord = {
+    taskId: `review-${dispatchKey}`,
     runtime: "subagent",
     taskKind: TASK_REVIEW_KIND,
-    sourceId: `task-review:${dispatchKey}`,
-    runId: `task-review:${dispatchKey}`,
-    parentTaskId: params.parentTaskId,
+    sourceId: runId,
+    requesterSessionKey: flow.ownerKey,
+    ownerKey: flow.ownerKey,
+    scopeKind: "session",
+    parentFlowId: flow.flowId,
+    ...(params.parentTaskId ? { parentTaskId: params.parentTaskId } : {}),
     agentId: params.request.reviewerAgentId,
     label: `Review ${params.request.proofBundle.commit.slice(0, 12)}`,
     task: buildReviewPrompt(detail),
-    status: "queued",
+    runId,
+    status: "queued" as const,
     notifyPolicy: "state_changes",
     deliveryStatus: "pending",
+    createdAt: now,
+    lastEventAt: now,
     progressSummary: `Review pending for ${params.request.proofBundle.commit.slice(0, 12)}.`,
     detail: detailToJson(detail),
+  };
+  const flowState = isRecord(flow.stateJson) ? flow.stateJson : {};
+  const atomic = createReviewDispatchAtomically({
+    flow,
+    expectedRevision: flow.revision,
+    nextStateJson: {
+      ...flowState,
+      review: {
+        state: "review_pending",
+        taskId: task.taskId,
+        dispatchKey,
+        commit: detail.proofBundle.commit,
+        reviewerAgentId: detail.reviewerAgentId,
+      },
+    },
+    task,
+    ...(flow.requesterOrigin
+      ? {
+          deliveryState: {
+            taskId: task.taskId,
+            requesterOrigin: flow.requesterOrigin,
+          } satisfies TaskDeliveryState,
+        }
+      : {}),
   });
-  if (!result.created || !result.task) {
-    return { ok: false, reason: result.reason ?? "Review task persistence failed." };
+  reloadTaskRuntimeStateFromStore();
+  const stored = getTaskById(task.taskId);
+  const storedDetail = stored ? parseTaskReviewDetail(stored) : undefined;
+  if (atomic.status === "flow_conflict" || !stored || !storedDetail) {
+    return { ok: false, reason: "Review dispatch lost its TaskFlow revision race." };
   }
-  return { ok: true, created: true, task: result.task, detail };
+  if (atomic.status === "existing") {
+    return { ok: true, created: false, task: stored, detail: storedDetail };
+  }
+
+  const launched = await params.runtime.launch({
+    task: stored,
+    detail: storedDetail,
+    recoveryAttempt: 0,
+  });
+  if (!launched.ok) {
+    markTaskReviewRecoveryPending({
+      taskId: stored.taskId,
+      reason: `reviewer launch failed: ${launched.reason}`,
+      now: Date.now(),
+    });
+    return {
+      ok: false,
+      reason: `Reviewer launch failed; durable recovery is pending: ${launched.reason}`,
+    };
+  }
+  const bound = bindTaskReviewLaunch({ taskId: stored.taskId, launched, now: Date.now() });
+  return {
+    ok: true,
+    created: true,
+    task: bound,
+    detail: parseTaskReviewDetail(bound) ?? storedDetail,
+  };
+}
+
+function bindTaskReviewLaunch(params: {
+  taskId: string;
+  launched: Extract<TaskReviewerLaunchResult, { ok: true }>;
+  now: number;
+}): TaskRecord {
+  const task = getTaskById(params.taskId);
+  const detail = task ? parseTaskReviewDetail(task) : undefined;
+  if (!task || !detail || !task.runId) {
+    throw new Error("Managed review task disappeared while binding its reviewer child.");
+  }
+  if (
+    detail.reviewerRunId === params.launched.reviewerRunId &&
+    detail.childSessionKey === params.launched.childSessionKey
+  ) {
+    return task;
+  }
+  const nextDetail: TaskReviewDetail = {
+    ...detail,
+    reviewerRunId: params.launched.reviewerRunId,
+    childSessionKey: params.launched.childSessionKey,
+    stateChangedAt: params.now,
+    history: [
+      ...detail.history,
+      { state: detail.state, at: params.now, summary: "Reviewer child bound." },
+    ],
+  };
+  recordTaskRunProgressByRunId({
+    runId: task.runId,
+    runtime: task.runtime,
+    lastEventAt: params.now,
+    progressSummary: `Reviewer ${detail.reviewerAgentId} is running.`,
+    eventSummary: "Reviewer child bound.",
+    detail: detailToJson(nextDetail),
+  });
+  const updated = getTaskById(task.taskId);
+  if (!updated) {
+    throw new Error("Reviewer child binding did not persist.");
+  }
+  return updated;
+}
+
+export function refreshTaskReviewContinuity(params: {
+  taskId: string;
+  continuity: TaskReviewContinuity;
+  now?: number;
+}): TaskRecord {
+  const task = getTaskById(params.taskId);
+  const detail = task ? parseTaskReviewDetail(task) : undefined;
+  if (!task || !detail || !task.runId) {
+    throw new Error("Managed review task not found.");
+  }
+  if (JSON.stringify(detail.continuity) === JSON.stringify(params.continuity)) {
+    return task;
+  }
+  const now = params.now ?? Date.now();
+  const nextDetail: TaskReviewDetail = {
+    ...detail,
+    continuity: structuredClone(params.continuity),
+    history: [
+      ...detail.history,
+      { state: detail.state, at: now, summary: "Continuity refreshed." },
+    ],
+  };
+  recordTaskRunProgressByRunId({
+    runId: task.runId,
+    runtime: task.runtime,
+    lastEventAt: now,
+    eventSummary: "Review continuity refreshed.",
+    detail: detailToJson(nextDetail),
+  });
+  const updated = getTaskById(task.taskId);
+  if (!updated) {
+    throw new Error("Review continuity refresh did not persist.");
+  }
+  return updated;
 }
 
 function validateCriterionDecisions(
@@ -428,6 +662,52 @@ function validateDecision(detail: TaskReviewDetail, decision: TaskReviewDecision
   }
 }
 
+export function parseTaskReviewDecision(value: unknown): TaskReviewDecision {
+  const decision = requireObject(value, "Reviewer decision");
+  const outcome = decision.outcome;
+  if (
+    outcome !== "changes_requested" &&
+    outcome !== "merge_ready" &&
+    outcome !== "awaiting_owner"
+  ) {
+    throw new Error("Reviewer decision outcome is invalid.");
+  }
+  const criteria = requireArray(decision.criteria, "decision.criteria").map((entry, index) => {
+    const criterion = requireObject(entry, `decision.criteria[${index}]`);
+    if (criterion.status !== "passed" && criterion.status !== "failed") {
+      throw new Error(`decision.criteria[${index}].status is invalid.`);
+    }
+    const status: "passed" | "failed" = criterion.status;
+    return {
+      id: requireString(criterion.id, `decision.criteria[${index}].id`),
+      status,
+      evidence: requireString(criterion.evidence, `decision.criteria[${index}].evidence`),
+    };
+  });
+  const reviewedCommit = requireString(decision.reviewedCommit, "decision.reviewedCommit");
+  if (outcome === "awaiting_owner") {
+    return {
+      outcome,
+      reviewedCommit,
+      criteria,
+      ownerQuestion: requireString(decision.ownerQuestion, "decision.ownerQuestion"),
+      whyAutomationCannotDecide: requireString(
+        decision.whyAutomationCannotDecide,
+        "decision.whyAutomationCannotDecide",
+      ),
+    };
+  }
+  const findings = requireArray(decision.findings, "decision.findings").map((entry, index) =>
+    requireString(entry, `decision.findings[${index}]`),
+  );
+  if (outcome === "merge_ready" && findings.length > 0) {
+    throw new Error("merge_ready cannot include findings.");
+  }
+  return outcome === "merge_ready"
+    ? { outcome, reviewedCommit, criteria, findings: [] }
+    : { outcome, reviewedCommit, criteria, findings };
+}
+
 function appendState(
   detail: TaskReviewDetail,
   state: TaskReviewState,
@@ -469,6 +749,7 @@ function transitionTaskReview(params: {
   if (!updated) {
     throw new Error("Task review transition did not persist.");
   }
+  syncReviewFlowProjection(updated, nextDetail, params.now);
   return updated;
 }
 
@@ -510,6 +791,7 @@ export function applyTaskReviewDecision(params: {
   if (!updated) {
     throw new Error("Task review decision did not persist.");
   }
+  syncReviewFlowProjection(updated, nextDetail, now);
   return updated;
 }
 
@@ -572,6 +854,137 @@ export function resumeTaskReviewVerification(params: { taskId: string; now?: num
     now: params.now ?? Date.now(),
     summary: `Review resumed for ${detail?.proofBundle.commit.slice(0, 12) ?? "exact proof"}.`,
   });
+}
+
+function failTaskReviewRecovery(params: {
+  task: TaskRecord;
+  detail: TaskReviewDetail;
+  reason: string;
+  now: number;
+}): TaskRecord {
+  if (!params.task.runId) {
+    throw new Error("Managed review task has no stable run id.");
+  }
+  const nextDetail = appendState(
+    params.detail,
+    "recovery_failed",
+    params.now,
+    `Review recovery exhausted: ${params.reason}`,
+  );
+  failTaskRunByRunId({
+    runId: params.task.runId,
+    runtime: params.task.runtime,
+    endedAt: params.now,
+    lastEventAt: params.now,
+    terminalSummary: `Review recovery exhausted: ${params.reason}`,
+    error: params.reason,
+    detail: detailToJson(nextDetail),
+  });
+  const updated = getTaskById(params.task.taskId);
+  if (!updated) {
+    throw new Error("Review recovery failure did not persist.");
+  }
+  syncReviewFlowProjection(updated, nextDetail, params.now);
+  return updated;
+}
+
+export async function reconcileTaskReviewRuntime(params: {
+  taskId: string;
+  runtime: TaskReviewerRuntime;
+  now?: number;
+}): Promise<{ state: "adopted" | "completed" | "recovered" | "failed"; task: TaskRecord }> {
+  const now = params.now ?? Date.now();
+  let task = getTaskById(params.taskId);
+  let detail = task ? parseTaskReviewDetail(task) : undefined;
+  if (!task || !detail) {
+    throw new Error("Managed review task not found.");
+  }
+
+  if (detail.state === "review_pending" && detail.reviewerRunId && detail.childSessionKey) {
+    const inspected = await params.runtime.inspect({
+      reviewerRunId: detail.reviewerRunId,
+      childSessionKey: detail.childSessionKey,
+    });
+    if (inspected.state === "live") {
+      return { state: "adopted", task };
+    }
+    if (inspected.state === "completed") {
+      try {
+        const completed = applyTaskReviewDecision({
+          taskId: task.taskId,
+          decision: parseTaskReviewDecision(inspected.decision),
+          now,
+        });
+        return { state: "completed", task: completed };
+      } catch (error) {
+        task = markTaskReviewRecoveryPending({
+          taskId: task.taskId,
+          reason: `invalid reviewer decision: ${error instanceof Error ? error.message : String(error)}`,
+          now,
+        });
+      }
+    } else {
+      task = markTaskReviewRecoveryPending({
+        taskId: task.taskId,
+        reason: inspected.state === "failed" ? inspected.reason : "reviewer child is missing",
+        now,
+      });
+    }
+    detail = parseTaskReviewDetail(task);
+  } else if (detail.state === "review_pending") {
+    task = markTaskReviewRecoveryPending({
+      taskId: task.taskId,
+      reason: "reviewer child binding is missing",
+      now,
+    });
+    detail = parseTaskReviewDetail(task);
+  }
+
+  if (!detail) {
+    throw new Error("Managed review detail disappeared during recovery.");
+  }
+  if (detail.state === "recovery_pending") {
+    if (detail.recoveryAttempt >= detail.maxRecoveryAttempts) {
+      return {
+        state: "failed",
+        task: failTaskReviewRecovery({ task, detail, reason: "retry limit reached", now }),
+      };
+    }
+    task = beginTaskReviewRecovery({ taskId: task.taskId, now });
+    detail = parseTaskReviewDetail(task)!;
+  }
+  if (detail.state === "recovering") {
+    task = markTaskReviewReverifyPending({ taskId: task.taskId, now });
+    detail = parseTaskReviewDetail(task)!;
+  }
+  if (detail.state !== "reverify_pending") {
+    return { state: "adopted", task };
+  }
+
+  const launched = await params.runtime.launch({
+    task,
+    detail,
+    recoveryAttempt: detail.recoveryAttempt,
+  });
+  if (!launched.ok) {
+    task = transitionTaskReview({
+      task,
+      state: "recovery_pending",
+      now,
+      summary: `Review replacement launch failed: ${launched.reason}`,
+    });
+    const failedDetail = parseTaskReviewDetail(task)!;
+    if (failedDetail.recoveryAttempt >= failedDetail.maxRecoveryAttempts) {
+      return {
+        state: "failed",
+        task: failTaskReviewRecovery({ task, detail: failedDetail, reason: launched.reason, now }),
+      };
+    }
+    return { state: "failed", task };
+  }
+  task = bindTaskReviewLaunch({ taskId: task.taskId, launched, now });
+  task = resumeTaskReviewVerification({ taskId: task.taskId, now });
+  return { state: "recovered", task };
 }
 
 export function reconcileStaleTaskReviews(params?: { tasks?: TaskRecord[]; now?: number }): {

--- a/src/tasks/task-review-lifecycle.ts
+++ b/src/tasks/task-review-lifecycle.ts
@@ -3,17 +3,20 @@
 import crypto from "node:crypto";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { reloadTaskRuntimeStateFromStore } from "./runtime-internal.js";
-import {
-  completeTaskRunByRunId,
-  failTaskRunByRunId,
-  recordTaskRunProgressByRunId,
-} from "./task-executor.js";
+import { recordTaskRunProgressByRunId } from "./task-executor.js";
 import { getTaskFlowByIdForOwner, listTaskFlowsForOwner } from "./task-flow-owner-access.js";
-import { updateFlowRecordByIdExpectedRevision } from "./task-flow-registry.js";
 import type { TaskFlowRecord } from "./task-flow-registry.types.js";
-import { getTaskById, listTasksForFlowId } from "./task-registry.js";
+import {
+  getTaskById,
+  listTasksForFlowId,
+  maybeDeliverTaskTerminalUpdate,
+} from "./task-registry.js";
 import type { JsonValue, TaskDeliveryState, TaskRecord } from "./task-registry.types.js";
-import { createReviewDispatchAtomically } from "./task-review-store.js";
+import {
+  bindReviewLaunchAtomically,
+  commitReviewTaskAndFlowAtomically,
+  createReviewDispatchAtomically,
+} from "./task-review-store.js";
 
 export const TASK_REVIEW_KIND = "managed-review";
 export const DEFAULT_TASK_REVIEW_STALE_MS = 30 * 60_000;
@@ -87,6 +90,13 @@ export type TaskReviewDetail = {
   stateChangedAt: number;
   recoveryAttempt: number;
   maxRecoveryAttempts: number;
+  launch: {
+    phase: "claimed" | "bound";
+    attempt: number;
+    claimedAt: number;
+    reviewerRunId?: string;
+    childSessionKey?: string;
+  };
   reviewerRunId?: string;
   childSessionKey?: string;
   history: TaskReviewHistoryEntry[];
@@ -340,53 +350,6 @@ function detailToJson(detail: TaskReviewDetail): JsonValue {
   return structuredClone(detail) as unknown as JsonValue;
 }
 
-function syncReviewFlowProjection(task: TaskRecord, detail: TaskReviewDetail, now: number): void {
-  if (!task.parentFlowId) {
-    return;
-  }
-  for (let attempt = 0; attempt < 3; attempt += 1) {
-    const flow = getTaskFlowByIdForOwner({
-      flowId: task.parentFlowId,
-      callerOwnerKey: task.ownerKey,
-    });
-    if (!flow) {
-      return;
-    }
-    const state = isRecord(flow.stateJson) ? flow.stateJson : {};
-    const currentReview = isRecord(state.review) ? state.review : {};
-    const blocked = detail.state === "changes_requested" || detail.state === "awaiting_owner";
-    const failed = detail.state === "recovery_failed";
-    const result = updateFlowRecordByIdExpectedRevision({
-      flowId: flow.flowId,
-      expectedRevision: flow.revision,
-      patch: {
-        status: failed ? "failed" : blocked ? "blocked" : "waiting",
-        currentStep: detail.state,
-        updatedAt: now,
-        ...(failed ? { endedAt: now } : {}),
-        blockedTaskId: blocked ? task.taskId : undefined,
-        blockedSummary: blocked ? (task.terminalSummary ?? task.progressSummary) : undefined,
-        stateJson: {
-          ...state,
-          review: {
-            ...currentReview,
-            state: detail.state,
-            taskId: task.taskId,
-            dispatchKey: detail.dispatchKey,
-            commit: detail.proofBundle.commit,
-            reviewerAgentId: detail.reviewerAgentId,
-            recoveryAttempt: detail.recoveryAttempt,
-            ...(detail.decision ? { decision: detail.decision } : {}),
-          },
-        },
-      },
-    });
-    if (result.applied) {
-      return;
-    }
-  }
-}
-
 export function parseTaskReviewDetail(
   task: Pick<TaskRecord, "taskKind" | "detail">,
 ): TaskReviewDetail | undefined {
@@ -402,7 +365,24 @@ export function parseTaskReviewDetail(
   ) {
     return undefined;
   }
-  return structuredClone(detail) as unknown as TaskReviewDetail;
+  const parsed = structuredClone(detail) as unknown as TaskReviewDetail;
+  if (!isRecord(parsed.launch)) {
+    parsed.launch =
+      parsed.reviewerRunId && parsed.childSessionKey
+        ? {
+            phase: "bound",
+            attempt: parsed.recoveryAttempt,
+            claimedAt: parsed.stateChangedAt,
+            reviewerRunId: parsed.reviewerRunId,
+            childSessionKey: parsed.childSessionKey,
+          }
+        : {
+            phase: "claimed",
+            attempt: parsed.recoveryAttempt,
+            claimedAt: parsed.stateChangedAt,
+          };
+  }
+  return parsed;
 }
 
 function findReviewTask(flowId: string, dispatchKey: string): TaskRecord | undefined {
@@ -456,6 +436,7 @@ export async function dispatchTaskReview(params: {
     stateChangedAt: now,
     recoveryAttempt: 0,
     maxRecoveryAttempts: params.request.maxRecoveryAttempts,
+    launch: { phase: "claimed", attempt: 0, claimedAt: now },
     history: [{ state: "review_pending", at: now, summary: "Review dispatched." }],
   };
   const runId = `task-review:${dispatchKey}`;
@@ -521,11 +502,16 @@ export async function dispatchTaskReview(params: {
     recoveryAttempt: 0,
   });
   if (!launched.ok) {
-    markTaskReviewRecoveryPending({
+    const pending = markClaimFailureIfCurrent({
       taskId: stored.taskId,
+      expected: storedDetail.launch,
       reason: `reviewer launch failed: ${launched.reason}`,
       now: Date.now(),
     });
+    const pendingDetail = parseTaskReviewDetail(pending);
+    if (pendingDetail?.launch.phase === "bound") {
+      return { ok: true, created: true, task: pending, detail: pendingDetail };
+    }
     return {
       ok: false,
       reason: `Reviewer launch failed; durable recovery is pending: ${launched.reason}`,
@@ -540,6 +526,31 @@ export async function dispatchTaskReview(params: {
   };
 }
 
+function markClaimFailureIfCurrent(params: {
+  taskId: string;
+  expected: TaskReviewDetail["launch"];
+  reason: string;
+  now: number;
+}): TaskRecord {
+  const current = getTaskById(params.taskId);
+  const detail = current ? parseTaskReviewDetail(current) : undefined;
+  if (!current || !detail) {
+    throw new Error("Managed review task not found while settling launch claim.");
+  }
+  if (
+    detail.launch.phase !== "claimed" ||
+    detail.launch.attempt !== params.expected.attempt ||
+    detail.launch.claimedAt !== params.expected.claimedAt
+  ) {
+    return current;
+  }
+  return markTaskReviewRecoveryPending({
+    taskId: current.taskId,
+    reason: params.reason,
+    now: params.now,
+  });
+}
+
 function bindTaskReviewLaunch(params: {
   taskId: string;
   launched: Extract<TaskReviewerLaunchResult, { ok: true }>;
@@ -551,32 +562,45 @@ function bindTaskReviewLaunch(params: {
     throw new Error("Managed review task disappeared while binding its reviewer child.");
   }
   if (
-    detail.reviewerRunId === params.launched.reviewerRunId &&
-    detail.childSessionKey === params.launched.childSessionKey
+    detail.launch.phase === "bound" &&
+    detail.launch.reviewerRunId === params.launched.reviewerRunId &&
+    detail.launch.childSessionKey === params.launched.childSessionKey
   ) {
+    return task;
+  }
+  if (detail.launch.phase !== "claimed") {
     return task;
   }
   const nextDetail: TaskReviewDetail = {
     ...detail,
     reviewerRunId: params.launched.reviewerRunId,
     childSessionKey: params.launched.childSessionKey,
+    launch: {
+      ...detail.launch,
+      phase: "bound",
+      reviewerRunId: params.launched.reviewerRunId,
+      childSessionKey: params.launched.childSessionKey,
+    },
     stateChangedAt: params.now,
     history: [
       ...detail.history,
       { state: detail.state, at: params.now, summary: "Reviewer child bound." },
     ],
   };
-  recordTaskRunProgressByRunId({
-    runId: task.runId,
-    runtime: task.runtime,
-    lastEventAt: params.now,
-    progressSummary: `Reviewer ${detail.reviewerAgentId} is running.`,
-    eventSummary: "Reviewer child bound.",
-    detail: detailToJson(nextDetail),
+  const bound = bindReviewLaunchAtomically({
+    task,
+    expectedDetail: task.detail ?? detailToJson(detail),
+    nextDetail: detailToJson(nextDetail),
+    childSessionKey: params.launched.childSessionKey,
+    now: params.now,
   });
+  reloadTaskRuntimeStateFromStore();
   const updated = getTaskById(task.taskId);
   if (!updated) {
     throw new Error("Reviewer child binding did not persist.");
+  }
+  if (bound.status === "task_conflict") {
+    return updated;
   }
   return updated;
 }
@@ -726,6 +750,68 @@ function appendState(
   };
 }
 
+function buildReviewProjection(task: TaskRecord, detail: TaskReviewDetail): JsonValue {
+  return {
+    state: detail.state,
+    taskId: task.taskId,
+    dispatchKey: detail.dispatchKey,
+    commit: detail.proofBundle.commit,
+    reviewerAgentId: detail.reviewerAgentId,
+    recoveryAttempt: detail.recoveryAttempt,
+    launchPhase: detail.launch.phase,
+    launchAttempt: detail.launch.attempt,
+    ...(detail.decision ? { decision: detail.decision } : {}),
+  } as JsonValue;
+}
+
+class TaskReviewMutationConflict extends Error {
+  constructor(
+    readonly task: TaskRecord,
+    status: string,
+  ) {
+    super(`Managed review atomic projection failed: ${status}.`);
+  }
+}
+
+function persistTaskReviewMutation(params: {
+  task: TaskRecord;
+  expectedDetail: TaskReviewDetail;
+  nextDetail: TaskReviewDetail;
+  nextTask: TaskRecord;
+  now: number;
+}): TaskRecord {
+  const blocked =
+    params.nextDetail.state === "changes_requested" || params.nextDetail.state === "awaiting_owner";
+  const failed = params.nextDetail.state === "recovery_failed";
+  const result = commitReviewTaskAndFlowAtomically({
+    task: params.task,
+    expectedDetail: params.task.detail ?? detailToJson(params.expectedDetail),
+    nextTask: params.nextTask,
+    reviewProjection: buildReviewProjection(params.task, params.nextDetail),
+    flowStatus: failed ? "failed" : blocked ? "blocked" : "waiting",
+    currentStep: params.nextDetail.state,
+    ...(blocked
+      ? {
+          blockedSummary:
+            params.nextTask.terminalSummary ??
+            params.nextTask.progressSummary ??
+            `Review ${params.nextDetail.state}.`,
+        }
+      : {}),
+    ...(failed ? { flowEndedAt: params.now } : {}),
+    now: params.now,
+  });
+  reloadTaskRuntimeStateFromStore();
+  const updated = getTaskById(params.task.taskId);
+  if (!updated) {
+    throw new Error("Managed review task disappeared during atomic projection.");
+  }
+  if (result.status !== "applied") {
+    throw new TaskReviewMutationConflict(updated, result.status);
+  }
+  return updated;
+}
+
 function transitionTaskReview(params: {
   task: TaskRecord;
   state: TaskReviewState;
@@ -737,20 +823,18 @@ function transitionTaskReview(params: {
     throw new Error("Task is not a managed review task with a stable run id.");
   }
   const nextDetail = appendState(detail, params.state, params.now, params.summary);
-  recordTaskRunProgressByRunId({
-    runId: params.task.runId,
-    runtime: params.task.runtime,
-    lastEventAt: params.now,
-    progressSummary: params.summary,
-    eventSummary: params.summary,
-    detail: detailToJson(nextDetail),
+  return persistTaskReviewMutation({
+    task: params.task,
+    expectedDetail: detail,
+    nextDetail,
+    nextTask: {
+      ...params.task,
+      lastEventAt: params.now,
+      progressSummary: params.summary,
+      detail: detailToJson(nextDetail),
+    },
+    now: params.now,
   });
-  const updated = getTaskById(params.task.taskId);
-  if (!updated) {
-    throw new Error("Task review transition did not persist.");
-  }
-  syncReviewFlowProjection(updated, nextDetail, params.now);
-  return updated;
 }
 
 export function applyTaskReviewDecision(params: {
@@ -778,20 +862,23 @@ export function applyTaskReviewDecision(params: {
     ...appendState(detail, params.decision.outcome, now, summary),
     decision: params.decision,
   };
-  completeTaskRunByRunId({
-    runId: task.runId,
-    runtime: task.runtime,
-    endedAt: now,
-    lastEventAt: now,
-    terminalSummary: summary,
-    terminalOutcome: params.decision.outcome === "merge_ready" ? "succeeded" : "blocked",
-    detail: detailToJson(nextDetail),
+  const updated = persistTaskReviewMutation({
+    task,
+    expectedDetail: detail,
+    nextDetail,
+    nextTask: {
+      ...task,
+      status: "succeeded",
+      endedAt: now,
+      lastEventAt: now,
+      progressSummary: summary,
+      terminalSummary: summary,
+      terminalOutcome: params.decision.outcome === "merge_ready" ? "succeeded" : "blocked",
+      detail: detailToJson(nextDetail),
+    },
+    now,
   });
-  const updated = getTaskById(task.taskId);
-  if (!updated) {
-    throw new Error("Task review decision did not persist.");
-  }
-  syncReviewFlowProjection(updated, nextDetail, now);
+  void maybeDeliverTaskTerminalUpdate(updated.taskId);
   return updated;
 }
 
@@ -815,14 +902,34 @@ export function markTaskReviewRecoveryPending(params: {
 
 export function beginTaskReviewRecovery(params: { taskId: string; now?: number }): TaskRecord {
   const task = getTaskById(params.taskId);
-  if (!task) {
+  const detail = task ? parseTaskReviewDetail(task) : undefined;
+  if (!task || !detail) {
     throw new Error("Managed review task not found.");
   }
-  return transitionTaskReview({
+  const now = params.now ?? Date.now();
+  const summary = "Review recovery claimed.";
+  const nextDetail: TaskReviewDetail = {
+    ...appendState(detail, "recovering", now, summary),
+    reviewerRunId: undefined,
+    childSessionKey: undefined,
+    launch: {
+      phase: "claimed",
+      attempt: detail.recoveryAttempt + 1,
+      claimedAt: now,
+    },
+  };
+  return persistTaskReviewMutation({
     task,
-    state: "recovering",
-    now: params.now ?? Date.now(),
-    summary: "Review recovery claimed.",
+    expectedDetail: detail,
+    nextDetail,
+    nextTask: {
+      ...task,
+      childSessionKey: undefined,
+      lastEventAt: now,
+      progressSummary: summary,
+      detail: detailToJson(nextDetail),
+    },
+    now,
   });
 }
 
@@ -871,20 +978,25 @@ function failTaskReviewRecovery(params: {
     params.now,
     `Review recovery exhausted: ${params.reason}`,
   );
-  failTaskRunByRunId({
-    runId: params.task.runId,
-    runtime: params.task.runtime,
-    endedAt: params.now,
-    lastEventAt: params.now,
-    terminalSummary: `Review recovery exhausted: ${params.reason}`,
-    error: params.reason,
-    detail: detailToJson(nextDetail),
+  const summary = `Review recovery exhausted: ${params.reason}`;
+  const updated = persistTaskReviewMutation({
+    task: params.task,
+    expectedDetail: params.detail,
+    nextDetail,
+    nextTask: {
+      ...params.task,
+      status: "failed",
+      endedAt: params.now,
+      lastEventAt: params.now,
+      error: params.reason,
+      progressSummary: summary,
+      terminalSummary: summary,
+      terminalOutcome: undefined,
+      detail: detailToJson(nextDetail),
+    },
+    now: params.now,
   });
-  const updated = getTaskById(params.task.taskId);
-  if (!updated) {
-    throw new Error("Review recovery failure did not persist.");
-  }
-  syncReviewFlowProjection(updated, nextDetail, params.now);
+  void maybeDeliverTaskTerminalUpdate(updated.taskId);
   return updated;
 }
 
@@ -900,10 +1012,36 @@ export async function reconcileTaskReviewRuntime(params: {
     throw new Error("Managed review task not found.");
   }
 
-  if (detail.state === "review_pending" && detail.reviewerRunId && detail.childSessionKey) {
+  if (detail.state === "review_pending" && detail.launch.phase === "claimed") {
+    if (now - detail.launch.claimedAt < detail.staleAfterMs) {
+      return { state: "adopted", task };
+    }
+    const expectedLaunch = detail.launch;
+    const launched = await params.runtime.launch({
+      task,
+      detail,
+      recoveryAttempt: detail.launch.attempt,
+    });
+    if (launched.ok) {
+      const rebound = bindTaskReviewLaunch({ taskId: task.taskId, launched, now });
+      return { state: "recovered", task: rebound };
+    }
+    task = markClaimFailureIfCurrent({
+      taskId: task.taskId,
+      expected: expectedLaunch,
+      reason: `claimed reviewer launch failed: ${launched.reason}`,
+      now,
+    });
+    detail = parseTaskReviewDetail(task);
+  } else if (
+    detail.state === "review_pending" &&
+    detail.launch.phase === "bound" &&
+    detail.launch.reviewerRunId &&
+    detail.launch.childSessionKey
+  ) {
     const inspected = await params.runtime.inspect({
-      reviewerRunId: detail.reviewerRunId,
-      childSessionKey: detail.childSessionKey,
+      reviewerRunId: detail.launch.reviewerRunId,
+      childSessionKey: detail.launch.childSessionKey,
     });
     if (inspected.state === "live") {
       return { state: "adopted", task };
@@ -917,6 +1055,9 @@ export async function reconcileTaskReviewRuntime(params: {
         });
         return { state: "completed", task: completed };
       } catch (error) {
+        if (error instanceof TaskReviewMutationConflict) {
+          return { state: "adopted", task: error.task };
+        }
         task = markTaskReviewRecoveryPending({
           taskId: task.taskId,
           reason: `invalid reviewer decision: ${error instanceof Error ? error.message : String(error)}`,
@@ -943,6 +1084,7 @@ export async function reconcileTaskReviewRuntime(params: {
   if (!detail) {
     throw new Error("Managed review detail disappeared during recovery.");
   }
+  let ownsClaim = false;
   if (detail.state === "recovery_pending") {
     if (detail.recoveryAttempt >= detail.maxRecoveryAttempts) {
       return {
@@ -952,28 +1094,44 @@ export async function reconcileTaskReviewRuntime(params: {
     }
     task = beginTaskReviewRecovery({ taskId: task.taskId, now });
     detail = parseTaskReviewDetail(task)!;
+    ownsClaim = true;
   }
   if (detail.state === "recovering") {
     task = markTaskReviewReverifyPending({ taskId: task.taskId, now });
     detail = parseTaskReviewDetail(task)!;
+    ownsClaim = true;
   }
   if (detail.state !== "reverify_pending") {
     return { state: "adopted", task };
   }
+  if (
+    detail.launch.phase !== "claimed" ||
+    (!ownsClaim && now - detail.launch.claimedAt < detail.staleAfterMs)
+  ) {
+    return { state: "adopted", task };
+  }
 
+  const expectedLaunch = detail.launch;
   const launched = await params.runtime.launch({
     task,
     detail,
-    recoveryAttempt: detail.recoveryAttempt,
+    recoveryAttempt: detail.launch.attempt,
   });
   if (!launched.ok) {
-    task = transitionTaskReview({
-      task,
-      state: "recovery_pending",
+    task = markClaimFailureIfCurrent({
+      taskId: task.taskId,
+      expected: expectedLaunch,
+      reason: `replacement launch failed: ${launched.reason}`,
       now,
-      summary: `Review replacement launch failed: ${launched.reason}`,
     });
     const failedDetail = parseTaskReviewDetail(task)!;
+    if (failedDetail.launch.phase === "bound") {
+      task = resumeTaskReviewVerification({ taskId: task.taskId, now });
+      return { state: "recovered", task };
+    }
+    if (failedDetail.state !== "recovery_pending") {
+      return { state: "adopted", task };
+    }
     if (failedDetail.recoveryAttempt >= failedDetail.maxRecoveryAttempts) {
       return {
         state: "failed",
@@ -1018,6 +1176,7 @@ export function listStaleTaskReviewIds(params: { tasks: TaskRecord[]; now: numbe
     if (
       !detail ||
       detail.state !== "review_pending" ||
+      detail.launch.phase === "claimed" ||
       (current.status !== "queued" && current.status !== "running")
     ) {
       continue;

--- a/src/tasks/task-review-lifecycle.ts
+++ b/src/tasks/task-review-lifecycle.ts
@@ -154,6 +154,13 @@ export type TaskReviewerRuntime = {
     reviewerRunId: string;
     childSessionKey: string;
   }): Promise<TaskReviewerInspection>;
+  settleNonOwningLaunch?(params: { reviewerRunId: string; childSessionKey: string }): Promise<void>;
+};
+
+type TaskReviewLaunchClaimSnapshot = {
+  rawExpectedDetail: JsonValue;
+  attempt: number;
+  claimedAt: number;
 };
 
 const REVIEW_STATES = new Set<TaskReviewState>([
@@ -496,6 +503,7 @@ export async function dispatchTaskReview(params: {
     return { ok: true, created: false, task: stored, detail: storedDetail };
   }
 
+  const launchClaim = captureLaunchClaim(stored, storedDetail);
   const launched = await params.runtime.launch({
     task: stored,
     detail: storedDetail,
@@ -517,12 +525,33 @@ export async function dispatchTaskReview(params: {
       reason: `Reviewer launch failed; durable recovery is pending: ${launched.reason}`,
     };
   }
-  const bound = bindTaskReviewLaunch({ taskId: stored.taskId, launched, now: Date.now() });
+  const binding = await settleTaskReviewLaunch({
+    taskId: stored.taskId,
+    launched,
+    claim: launchClaim,
+    runtime: params.runtime,
+    now: Date.now(),
+  });
+  const bound = binding.task;
   return {
     ok: true,
     created: true,
     task: bound,
     detail: parseTaskReviewDetail(bound) ?? storedDetail,
+  };
+}
+
+function captureLaunchClaim(
+  task: TaskRecord,
+  detail: TaskReviewDetail,
+): TaskReviewLaunchClaimSnapshot {
+  if (detail.launch.phase !== "claimed") {
+    throw new Error("Managed review launch does not own a claimed phase.");
+  }
+  return {
+    rawExpectedDetail: structuredClone(task.detail ?? detailToJson(detail)),
+    attempt: detail.launch.attempt,
+    claimedAt: detail.launch.claimedAt,
   };
 }
 
@@ -554,8 +583,9 @@ function markClaimFailureIfCurrent(params: {
 function bindTaskReviewLaunch(params: {
   taskId: string;
   launched: Extract<TaskReviewerLaunchResult, { ok: true }>;
+  claim: TaskReviewLaunchClaimSnapshot;
   now: number;
-}): TaskRecord {
+}): { task: TaskRecord; owned: boolean } {
   const task = getTaskById(params.taskId);
   const detail = task ? parseTaskReviewDetail(task) : undefined;
   if (!task || !detail || !task.runId) {
@@ -566,10 +596,14 @@ function bindTaskReviewLaunch(params: {
     detail.launch.reviewerRunId === params.launched.reviewerRunId &&
     detail.launch.childSessionKey === params.launched.childSessionKey
   ) {
-    return task;
+    return { task, owned: true };
   }
-  if (detail.launch.phase !== "claimed") {
-    return task;
+  if (
+    detail.launch.phase !== "claimed" ||
+    detail.launch.attempt !== params.claim.attempt ||
+    detail.launch.claimedAt !== params.claim.claimedAt
+  ) {
+    return { task, owned: false };
   }
   const nextDetail: TaskReviewDetail = {
     ...detail,
@@ -589,7 +623,9 @@ function bindTaskReviewLaunch(params: {
   };
   const bound = bindReviewLaunchAtomically({
     task,
-    expectedDetail: task.detail ?? detailToJson(detail),
+    expectedDetail: params.claim.rawExpectedDetail,
+    expectedAttempt: params.claim.attempt,
+    expectedClaimedAt: params.claim.claimedAt,
     nextDetail: detailToJson(nextDetail),
     childSessionKey: params.launched.childSessionKey,
     now: params.now,
@@ -600,9 +636,26 @@ function bindTaskReviewLaunch(params: {
     throw new Error("Reviewer child binding did not persist.");
   }
   if (bound.status === "task_conflict") {
-    return updated;
+    return { task: updated, owned: false };
   }
-  return updated;
+  return { task: updated, owned: true };
+}
+
+async function settleTaskReviewLaunch(params: {
+  taskId: string;
+  launched: Extract<TaskReviewerLaunchResult, { ok: true }>;
+  claim: TaskReviewLaunchClaimSnapshot;
+  runtime: TaskReviewerRuntime;
+  now: number;
+}): Promise<{ task: TaskRecord; owned: boolean }> {
+  const bound = bindTaskReviewLaunch(params);
+  if (!bound.owned) {
+    await params.runtime.settleNonOwningLaunch?.({
+      reviewerRunId: params.launched.reviewerRunId,
+      childSessionKey: params.launched.childSessionKey,
+    });
+  }
+  return bound;
 }
 
 export function refreshTaskReviewContinuity(params: {
@@ -1017,14 +1070,21 @@ export async function reconcileTaskReviewRuntime(params: {
       return { state: "adopted", task };
     }
     const expectedLaunch = detail.launch;
+    const launchClaim = captureLaunchClaim(task, detail);
     const launched = await params.runtime.launch({
       task,
       detail,
       recoveryAttempt: detail.launch.attempt,
     });
     if (launched.ok) {
-      const rebound = bindTaskReviewLaunch({ taskId: task.taskId, launched, now });
-      return { state: "recovered", task: rebound };
+      const rebound = await settleTaskReviewLaunch({
+        taskId: task.taskId,
+        launched,
+        claim: launchClaim,
+        runtime: params.runtime,
+        now,
+      });
+      return { state: rebound.owned ? "recovered" : "adopted", task: rebound.task };
     }
     task = markClaimFailureIfCurrent({
       taskId: task.taskId,
@@ -1112,6 +1172,7 @@ export async function reconcileTaskReviewRuntime(params: {
   }
 
   const expectedLaunch = detail.launch;
+  const launchClaim = captureLaunchClaim(task, detail);
   const launched = await params.runtime.launch({
     task,
     detail,
@@ -1140,7 +1201,17 @@ export async function reconcileTaskReviewRuntime(params: {
     }
     return { state: "failed", task };
   }
-  task = bindTaskReviewLaunch({ taskId: task.taskId, launched, now });
+  const binding = await settleTaskReviewLaunch({
+    taskId: task.taskId,
+    launched,
+    claim: launchClaim,
+    runtime: params.runtime,
+    now,
+  });
+  task = binding.task;
+  if (!binding.owned) {
+    return { state: "adopted", task };
+  }
   task = resumeTaskReviewVerification({ taskId: task.taskId, now });
   return { state: "recovered", task };
 }

--- a/src/tasks/task-review-lifecycle.ts
+++ b/src/tasks/task-review-lifecycle.ts
@@ -1,0 +1,649 @@
+// Owns deterministic managed-flow review dispatch, outcomes, and recovery state.
+import crypto from "node:crypto";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import {
+  completeTaskRunByRunId,
+  recordTaskRunProgressByRunId,
+  runTaskInFlowForOwner,
+} from "./task-executor.js";
+import { getTaskFlowByIdForOwner, listTaskFlowsForOwner } from "./task-flow-owner-access.js";
+import type { TaskFlowRecord } from "./task-flow-registry.types.js";
+import { getTaskById, listTasksForFlowId } from "./task-registry.js";
+import type { JsonValue, TaskRecord } from "./task-registry.types.js";
+
+export const TASK_REVIEW_KIND = "managed-review";
+export const DEFAULT_TASK_REVIEW_STALE_MS = 30 * 60_000;
+
+export type TaskReviewState =
+  | "review_pending"
+  | "changes_requested"
+  | "merge_ready"
+  | "awaiting_owner"
+  | "recovery_pending"
+  | "recovering"
+  | "reverify_pending";
+
+export type TaskReviewProofBundle = {
+  commit: string;
+  baseCommit: string;
+  diff: {
+    sha256: string;
+    summary: string;
+    files: string[];
+  };
+  tests: Array<{
+    name: string;
+    command: string;
+    status: "passed" | "failed";
+    evidence: string;
+  }>;
+  screenshots: Array<{
+    name: string;
+    path: string;
+    sha256: string;
+  }>;
+  criteria: Array<{
+    id: string;
+    description: string;
+  }>;
+};
+
+export type TaskReviewRequest = {
+  reviewerAgentId: string;
+  proofBundle: TaskReviewProofBundle;
+  staleAfterMs: number;
+};
+
+export type TaskReviewContinuity = {
+  ownerKey: string;
+  sessionKey: string;
+  sessionId?: string;
+  compactionCount?: number;
+  sourceTaskId?: string;
+};
+
+type TaskReviewHistoryEntry = {
+  state: TaskReviewState;
+  at: number;
+  summary: string;
+};
+
+export type TaskReviewDetail = {
+  kind: typeof TASK_REVIEW_KIND;
+  version: 1;
+  state: TaskReviewState;
+  dispatchKey: string;
+  reviewerAgentId: string;
+  proofBundle: TaskReviewProofBundle;
+  continuity: TaskReviewContinuity;
+  staleAfterMs: number;
+  stateChangedAt: number;
+  recoveryAttempt: number;
+  history: TaskReviewHistoryEntry[];
+  decision?: TaskReviewDecision;
+};
+
+type ReviewCriterionDecision = {
+  id: string;
+  status: "passed" | "failed";
+  evidence: string;
+};
+
+export type TaskReviewDecision =
+  | {
+      outcome: "changes_requested";
+      reviewedCommit: string;
+      criteria: ReviewCriterionDecision[];
+      findings: string[];
+    }
+  | {
+      outcome: "merge_ready";
+      reviewedCommit: string;
+      criteria: ReviewCriterionDecision[];
+      findings: [];
+    }
+  | {
+      outcome: "awaiting_owner";
+      reviewedCommit: string;
+      criteria: ReviewCriterionDecision[];
+      ownerQuestion: string;
+      whyAutomationCannotDecide: string;
+    };
+
+export type DispatchTaskReviewResult =
+  | { ok: true; created: boolean; task: TaskRecord; detail: TaskReviewDetail }
+  | { ok: false; reason: string };
+
+const REVIEW_STATES = new Set<TaskReviewState>([
+  "review_pending",
+  "changes_requested",
+  "merge_ready",
+  "awaiting_owner",
+  "recovery_pending",
+  "recovering",
+  "reverify_pending",
+]);
+
+const ALLOWED_TRANSITIONS: Record<TaskReviewState, ReadonlySet<TaskReviewState>> = {
+  review_pending: new Set([
+    "changes_requested",
+    "merge_ready",
+    "awaiting_owner",
+    "recovery_pending",
+  ]),
+  changes_requested: new Set(["reverify_pending"]),
+  merge_ready: new Set(),
+  awaiting_owner: new Set(["reverify_pending"]),
+  recovery_pending: new Set(["recovering"]),
+  recovering: new Set(["reverify_pending"]),
+  reverify_pending: new Set(["review_pending"]),
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function requireString(value: unknown, label: string): string {
+  const normalized = normalizeOptionalString(value);
+  if (!normalized) {
+    throw new Error(`${label} is required.`);
+  }
+  return normalized;
+}
+
+function requireHex(value: unknown, length: number, label: string): string {
+  const normalized = requireString(value, label).toLowerCase();
+  if (!new RegExp(`^[0-9a-f]{${length}}$`, "u").test(normalized)) {
+    throw new Error(`${label} must be a ${length}-character hexadecimal value.`);
+  }
+  return normalized;
+}
+
+function requireObject(value: unknown, label: string): Record<string, unknown> {
+  if (!isRecord(value)) {
+    throw new Error(`${label} must be an object.`);
+  }
+  return value;
+}
+
+function requireArray(value: unknown, label: string): unknown[] {
+  if (!Array.isArray(value)) {
+    throw new Error(`${label} must be an array.`);
+  }
+  return value;
+}
+
+function parseProofBundle(value: unknown): TaskReviewProofBundle {
+  const proof = requireObject(value, "reviewRequest.proofBundle");
+  const diff = requireObject(proof.diff, "reviewRequest.proofBundle.diff");
+  const files = requireArray(diff.files, "reviewRequest.proofBundle.diff.files")
+    .map((entry, index) => requireString(entry, `reviewRequest.proofBundle.diff.files[${index}]`))
+    .toSorted();
+  const tests = requireArray(proof.tests, "reviewRequest.proofBundle.tests").map((entry, index) => {
+    const test = requireObject(entry, `reviewRequest.proofBundle.tests[${index}]`);
+    if (test.status !== "passed" && test.status !== "failed") {
+      throw new Error(`reviewRequest.proofBundle.tests[${index}].status is invalid.`);
+    }
+    const status: "passed" | "failed" = test.status;
+    return {
+      name: requireString(test.name, `reviewRequest.proofBundle.tests[${index}].name`),
+      command: requireString(test.command, `reviewRequest.proofBundle.tests[${index}].command`),
+      status,
+      evidence: requireString(test.evidence, `reviewRequest.proofBundle.tests[${index}].evidence`),
+    };
+  });
+  const screenshots = requireArray(proof.screenshots, "reviewRequest.proofBundle.screenshots").map(
+    (entry, index) => {
+      const screenshot = requireObject(entry, `reviewRequest.proofBundle.screenshots[${index}]`);
+      return {
+        name: requireString(
+          screenshot.name,
+          `reviewRequest.proofBundle.screenshots[${index}].name`,
+        ),
+        path: requireString(
+          screenshot.path,
+          `reviewRequest.proofBundle.screenshots[${index}].path`,
+        ),
+        sha256: requireHex(
+          screenshot.sha256,
+          64,
+          `reviewRequest.proofBundle.screenshots[${index}].sha256`,
+        ),
+      };
+    },
+  );
+  const criteria = requireArray(proof.criteria, "reviewRequest.proofBundle.criteria").map(
+    (entry, index) => {
+      const criterion = requireObject(entry, `reviewRequest.proofBundle.criteria[${index}]`);
+      return {
+        id: requireString(criterion.id, `reviewRequest.proofBundle.criteria[${index}].id`),
+        description: requireString(
+          criterion.description,
+          `reviewRequest.proofBundle.criteria[${index}].description`,
+        ),
+      };
+    },
+  );
+  if (criteria.length === 0) {
+    throw new Error("reviewRequest.proofBundle.criteria must not be empty.");
+  }
+  if (new Set(criteria.map((criterion) => criterion.id)).size !== criteria.length) {
+    throw new Error("reviewRequest.proofBundle.criteria ids must be unique.");
+  }
+  return {
+    commit: requireHex(proof.commit, 40, "reviewRequest.proofBundle.commit"),
+    baseCommit: requireHex(proof.baseCommit, 40, "reviewRequest.proofBundle.baseCommit"),
+    diff: {
+      sha256: requireHex(diff.sha256, 64, "reviewRequest.proofBundle.diff.sha256"),
+      summary: requireString(diff.summary, "reviewRequest.proofBundle.diff.summary"),
+      files,
+    },
+    tests,
+    screenshots,
+    criteria,
+  };
+}
+
+export function parseTaskReviewRequest(flow: TaskFlowRecord): TaskReviewRequest {
+  const state = requireObject(flow.stateJson, "TaskFlow state");
+  const request = requireObject(state.reviewRequest, "TaskFlow state.reviewRequest");
+  const staleAfterMsRaw = request.staleAfterMs;
+  const staleAfterMs =
+    typeof staleAfterMsRaw === "number" &&
+    Number.isFinite(staleAfterMsRaw) &&
+    staleAfterMsRaw >= 1_000
+      ? Math.floor(staleAfterMsRaw)
+      : DEFAULT_TASK_REVIEW_STALE_MS;
+  return {
+    reviewerAgentId: requireString(
+      request.reviewerAgentId,
+      "TaskFlow state.reviewRequest.reviewerAgentId",
+    ),
+    proofBundle: parseProofBundle(request.proofBundle),
+    staleAfterMs,
+  };
+}
+
+function buildDispatchKey(params: {
+  flowId: string;
+  reviewerAgentId: string;
+  proofBundle: TaskReviewProofBundle;
+}): string {
+  return crypto
+    .createHash("sha256")
+    .update(
+      JSON.stringify({
+        flowId: params.flowId,
+        reviewerAgentId: params.reviewerAgentId,
+        proofBundle: params.proofBundle,
+      }),
+    )
+    .digest("hex");
+}
+
+function buildReviewPrompt(detail: TaskReviewDetail): string {
+  return [
+    `Review exact commit ${detail.proofBundle.commit} over base ${detail.proofBundle.baseCommit}.`,
+    "Verify the supplied diff, tests, screenshots, and every acceptance criterion.",
+    "Return exactly one outcome: changes_requested, merge_ready, or awaiting_owner.",
+    "Use awaiting_owner only for a genuine decision that cannot be resolved from code or proof.",
+    `Proof bundle: ${JSON.stringify(detail.proofBundle)}`,
+  ].join("\n");
+}
+
+function detailToJson(detail: TaskReviewDetail): JsonValue {
+  return structuredClone(detail) as unknown as JsonValue;
+}
+
+export function parseTaskReviewDetail(
+  task: Pick<TaskRecord, "taskKind" | "detail">,
+): TaskReviewDetail | undefined {
+  if (task.taskKind !== TASK_REVIEW_KIND || !isRecord(task.detail)) {
+    return undefined;
+  }
+  const detail = task.detail;
+  if (
+    detail.kind !== TASK_REVIEW_KIND ||
+    detail.version !== 1 ||
+    typeof detail.state !== "string" ||
+    !REVIEW_STATES.has(detail.state as TaskReviewState)
+  ) {
+    return undefined;
+  }
+  return structuredClone(detail) as unknown as TaskReviewDetail;
+}
+
+function findReviewTask(flowId: string, dispatchKey: string): TaskRecord | undefined {
+  return listTasksForFlowId(flowId).find(
+    (task) => parseTaskReviewDetail(task)?.dispatchKey === dispatchKey,
+  );
+}
+
+export function dispatchTaskReview(params: {
+  flowId: string;
+  callerOwnerKey: string;
+  request: TaskReviewRequest;
+  continuity: TaskReviewContinuity;
+  parentTaskId?: string;
+  now?: number;
+}): DispatchTaskReviewResult {
+  const flow = getTaskFlowByIdForOwner({
+    flowId: params.flowId,
+    callerOwnerKey: params.callerOwnerKey,
+  });
+  if (!flow || flow.syncMode !== "managed") {
+    return { ok: false, reason: "Managed TaskFlow not found." };
+  }
+  const now = params.now ?? Date.now();
+  const dispatchKey = buildDispatchKey({
+    flowId: flow.flowId,
+    reviewerAgentId: params.request.reviewerAgentId,
+    proofBundle: params.request.proofBundle,
+  });
+  const existing = findReviewTask(flow.flowId, dispatchKey);
+  if (existing) {
+    const detail = parseTaskReviewDetail(existing);
+    return detail
+      ? { ok: true, created: false, task: existing, detail }
+      : { ok: false, reason: "Existing review task detail is invalid." };
+  }
+  const detail: TaskReviewDetail = {
+    kind: TASK_REVIEW_KIND,
+    version: 1,
+    state: "review_pending",
+    dispatchKey,
+    reviewerAgentId: params.request.reviewerAgentId,
+    proofBundle: params.request.proofBundle,
+    continuity: params.continuity,
+    staleAfterMs: params.request.staleAfterMs,
+    stateChangedAt: now,
+    recoveryAttempt: 0,
+    history: [{ state: "review_pending", at: now, summary: "Review dispatched." }],
+  };
+  const result = runTaskInFlowForOwner({
+    flowId: flow.flowId,
+    callerOwnerKey: params.callerOwnerKey,
+    runtime: "subagent",
+    taskKind: TASK_REVIEW_KIND,
+    sourceId: `task-review:${dispatchKey}`,
+    runId: `task-review:${dispatchKey}`,
+    parentTaskId: params.parentTaskId,
+    agentId: params.request.reviewerAgentId,
+    label: `Review ${params.request.proofBundle.commit.slice(0, 12)}`,
+    task: buildReviewPrompt(detail),
+    status: "queued",
+    notifyPolicy: "state_changes",
+    deliveryStatus: "pending",
+    progressSummary: `Review pending for ${params.request.proofBundle.commit.slice(0, 12)}.`,
+    detail: detailToJson(detail),
+  });
+  if (!result.created || !result.task) {
+    return { ok: false, reason: result.reason ?? "Review task persistence failed." };
+  }
+  return { ok: true, created: true, task: result.task, detail };
+}
+
+function validateCriterionDecisions(
+  proofBundle: TaskReviewProofBundle,
+  decisions: ReviewCriterionDecision[],
+): void {
+  const expectedIds = proofBundle.criteria.map((criterion) => criterion.id).toSorted();
+  const actualIds = decisions.map((criterion) => criterion.id).toSorted();
+  if (
+    new Set(actualIds).size !== actualIds.length ||
+    expectedIds.join("\n") !== actualIds.join("\n")
+  ) {
+    throw new Error("Reviewer decision must cover every acceptance criterion exactly once.");
+  }
+  for (const [index, decision] of decisions.entries()) {
+    requireString(decision.evidence, `decision.criteria[${index}].evidence`);
+    if (decision.status !== "passed" && decision.status !== "failed") {
+      throw new Error(`decision.criteria[${index}].status is invalid.`);
+    }
+  }
+}
+
+function validateDecision(detail: TaskReviewDetail, decision: TaskReviewDecision): void {
+  if (decision.reviewedCommit !== detail.proofBundle.commit) {
+    throw new Error("Reviewer decision commit does not match the dispatched proof bundle.");
+  }
+  validateCriterionDecisions(detail.proofBundle, decision.criteria);
+  if (decision.outcome === "changes_requested" && decision.findings.length === 0) {
+    throw new Error("changes_requested requires at least one actionable finding.");
+  }
+  if (decision.outcome === "merge_ready") {
+    if (decision.findings.length !== 0) {
+      throw new Error("merge_ready cannot include findings.");
+    }
+    if (detail.proofBundle.tests.some((test) => test.status !== "passed")) {
+      throw new Error("merge_ready requires every supplied test to pass.");
+    }
+    if (decision.criteria.some((criterion) => criterion.status !== "passed")) {
+      throw new Error("merge_ready requires every acceptance criterion to pass.");
+    }
+  }
+  if (decision.outcome === "awaiting_owner") {
+    requireString(decision.ownerQuestion, "awaiting_owner.ownerQuestion");
+    requireString(decision.whyAutomationCannotDecide, "awaiting_owner.whyAutomationCannotDecide");
+  }
+}
+
+function appendState(
+  detail: TaskReviewDetail,
+  state: TaskReviewState,
+  at: number,
+  summary: string,
+): TaskReviewDetail {
+  if (!ALLOWED_TRANSITIONS[detail.state].has(state)) {
+    throw new Error(`Invalid task review transition: ${detail.state} -> ${state}.`);
+  }
+  return {
+    ...detail,
+    state,
+    stateChangedAt: at,
+    recoveryAttempt: state === "recovering" ? detail.recoveryAttempt + 1 : detail.recoveryAttempt,
+    history: [...detail.history, { state, at, summary }],
+  };
+}
+
+function transitionTaskReview(params: {
+  task: TaskRecord;
+  state: TaskReviewState;
+  now: number;
+  summary: string;
+}): TaskRecord {
+  const detail = parseTaskReviewDetail(params.task);
+  if (!detail || !params.task.runId) {
+    throw new Error("Task is not a managed review task with a stable run id.");
+  }
+  const nextDetail = appendState(detail, params.state, params.now, params.summary);
+  recordTaskRunProgressByRunId({
+    runId: params.task.runId,
+    runtime: params.task.runtime,
+    lastEventAt: params.now,
+    progressSummary: params.summary,
+    eventSummary: params.summary,
+    detail: detailToJson(nextDetail),
+  });
+  const updated = getTaskById(params.task.taskId);
+  if (!updated) {
+    throw new Error("Task review transition did not persist.");
+  }
+  return updated;
+}
+
+export function applyTaskReviewDecision(params: {
+  taskId: string;
+  decision: TaskReviewDecision;
+  now?: number;
+}): TaskRecord {
+  const task = getTaskById(params.taskId);
+  const detail = task ? parseTaskReviewDetail(task) : undefined;
+  if (!task || !detail || !task.runId) {
+    throw new Error("Managed review task not found.");
+  }
+  if (detail.state !== "review_pending") {
+    throw new Error(`Review decision is not allowed from ${detail.state}.`);
+  }
+  validateDecision(detail, params.decision);
+  const now = params.now ?? Date.now();
+  const summary =
+    params.decision.outcome === "changes_requested"
+      ? `Changes requested for ${detail.proofBundle.commit.slice(0, 12)}.`
+      : params.decision.outcome === "merge_ready"
+        ? `Merge ready for ${detail.proofBundle.commit.slice(0, 12)}.`
+        : `Owner decision required for ${detail.proofBundle.commit.slice(0, 12)}.`;
+  const nextDetail = {
+    ...appendState(detail, params.decision.outcome, now, summary),
+    decision: params.decision,
+  };
+  completeTaskRunByRunId({
+    runId: task.runId,
+    runtime: task.runtime,
+    endedAt: now,
+    lastEventAt: now,
+    terminalSummary: summary,
+    terminalOutcome: params.decision.outcome === "merge_ready" ? "succeeded" : "blocked",
+    detail: detailToJson(nextDetail),
+  });
+  const updated = getTaskById(task.taskId);
+  if (!updated) {
+    throw new Error("Task review decision did not persist.");
+  }
+  return updated;
+}
+
+export function markTaskReviewRecoveryPending(params: {
+  taskId: string;
+  reason: string;
+  now?: number;
+}): TaskRecord {
+  const task = getTaskById(params.taskId);
+  if (!task) {
+    throw new Error("Managed review task not found.");
+  }
+  const reason = requireString(params.reason, "Recovery reason");
+  return transitionTaskReview({
+    task,
+    state: "recovery_pending",
+    now: params.now ?? Date.now(),
+    summary: `Review recovery pending: ${reason}`,
+  });
+}
+
+export function beginTaskReviewRecovery(params: { taskId: string; now?: number }): TaskRecord {
+  const task = getTaskById(params.taskId);
+  if (!task) {
+    throw new Error("Managed review task not found.");
+  }
+  return transitionTaskReview({
+    task,
+    state: "recovering",
+    now: params.now ?? Date.now(),
+    summary: "Review recovery claimed.",
+  });
+}
+
+export function markTaskReviewReverifyPending(params: {
+  taskId: string;
+  now?: number;
+}): TaskRecord {
+  const task = getTaskById(params.taskId);
+  if (!task) {
+    throw new Error("Managed review task not found.");
+  }
+  return transitionTaskReview({
+    task,
+    state: "reverify_pending",
+    now: params.now ?? Date.now(),
+    summary: "Review proof must be reverified before merge readiness.",
+  });
+}
+
+export function resumeTaskReviewVerification(params: { taskId: string; now?: number }): TaskRecord {
+  const task = getTaskById(params.taskId);
+  if (!task) {
+    throw new Error("Managed review task not found.");
+  }
+  const detail = parseTaskReviewDetail(task);
+  return transitionTaskReview({
+    task,
+    state: "review_pending",
+    now: params.now ?? Date.now(),
+    summary: `Review resumed for ${detail?.proofBundle.commit.slice(0, 12) ?? "exact proof"}.`,
+  });
+}
+
+export function reconcileStaleTaskReviews(params?: { tasks?: TaskRecord[]; now?: number }): {
+  escalated: number;
+  taskIds: string[];
+} {
+  const now = params?.now ?? Date.now();
+  const tasks = params?.tasks ?? [];
+  const candidates = listStaleTaskReviewIds({ tasks, now });
+  const taskIds: string[] = [];
+  for (const taskId of candidates) {
+    const current = getTaskById(taskId);
+    if (!current) {
+      continue;
+    }
+    const reason =
+      current.status === "queued" && !current.childSessionKey
+        ? "reviewer child remained unclaimed"
+        : "reviewer child stopped reporting progress";
+    markTaskReviewRecoveryPending({ taskId, reason, now });
+    taskIds.push(taskId);
+  }
+  return { escalated: taskIds.length, taskIds };
+}
+
+export function listStaleTaskReviewIds(params: { tasks: TaskRecord[]; now: number }): string[] {
+  const taskIds: string[] = [];
+  for (const snapshot of params.tasks) {
+    const current = getTaskById(snapshot.taskId) ?? snapshot;
+    const detail = parseTaskReviewDetail(current);
+    if (
+      !detail ||
+      detail.state !== "review_pending" ||
+      (current.status !== "queued" && current.status !== "running")
+    ) {
+      continue;
+    }
+    const referenceAt = current.lastEventAt ?? current.startedAt ?? current.createdAt;
+    if (params.now - referenceAt < detail.staleAfterMs) {
+      continue;
+    }
+    taskIds.push(current.taskId);
+  }
+  return taskIds;
+}
+
+export function resolveWrapReviewFlow(params: {
+  ownerKey: string;
+  flowId?: string;
+}): TaskFlowRecord | undefined {
+  if (params.flowId) {
+    return getTaskFlowByIdForOwner({
+      flowId: params.flowId,
+      callerOwnerKey: params.ownerKey,
+    });
+  }
+  const ownerKey = params.ownerKey;
+  // Avoid selecting a terminal or mirrored flow merely because it was updated most recently.
+  return listTaskFlowsForOwner({ callerOwnerKey: ownerKey })
+    .filter(
+      (flow) =>
+        flow.syncMode === "managed" &&
+        (flow.status === "queued" ||
+          flow.status === "running" ||
+          flow.status === "waiting" ||
+          flow.status === "blocked"),
+    )
+    .toSorted((left, right) => right.updatedAt - left.updatedAt)[0];
+}
+
+export function findReviewSourceTask(flowId: string): TaskRecord | undefined {
+  return listTasksForFlowId(flowId)
+    .filter((task) => task.taskKind !== TASK_REVIEW_KIND)
+    .toSorted((left, right) => right.createdAt - left.createdAt)[0];
+}

--- a/src/tasks/task-review-store.ts
+++ b/src/tasks/task-review-store.ts
@@ -140,10 +140,32 @@ function parseStateJson(value: string | null): Record<string, unknown> {
 export function bindReviewLaunchAtomically(params: {
   task: TaskRecord;
   expectedDetail: JsonValue;
+  expectedAttempt: number;
+  expectedClaimedAt: number;
   nextDetail: JsonValue;
   childSessionKey: string;
   now: number;
 }): AtomicReviewMutationResult {
+  const expected = JSON.stringify(params.expectedDetail);
+  const expectedRecord =
+    params.expectedDetail &&
+    typeof params.expectedDetail === "object" &&
+    !Array.isArray(params.expectedDetail)
+      ? params.expectedDetail
+      : undefined;
+  const launch =
+    expectedRecord?.launch &&
+    typeof expectedRecord.launch === "object" &&
+    !Array.isArray(expectedRecord.launch)
+      ? expectedRecord.launch
+      : undefined;
+  if (
+    launch?.phase !== "claimed" ||
+    launch.attempt !== params.expectedAttempt ||
+    launch.claimedAt !== params.expectedClaimedAt
+  ) {
+    throw new Error("Launch binding claim metadata does not match its raw detail snapshot.");
+  }
   const { db } = openOpenClawStateDatabase();
   const store = getNodeSqliteKysely<ReviewStoreDatabase>(db);
   const updated = executeSqliteQuerySync(
@@ -160,7 +182,7 @@ export function bindReviewLaunchAtomically(params: {
       })
       .where("task_id", "=", params.task.taskId)
       .where("runtime", "=", params.task.runtime)
-      .where("detail_json", "=", JSON.stringify(params.expectedDetail)),
+      .where("detail_json", "=", expected),
   );
   return updated.numAffectedRows === 1n ? { status: "applied" } : { status: "task_conflict" };
 }

--- a/src/tasks/task-review-store.ts
+++ b/src/tasks/task-review-store.ts
@@ -118,6 +118,7 @@ export function createReviewDispatchAtomically(params: {
 export type AtomicReviewMutationResult =
   | { status: "applied" }
   | { status: "task_conflict" }
+  | { status: "flow_conflict" }
   | { status: "flow_missing" };
 
 class ReviewMutationConflict extends Error {

--- a/src/tasks/task-review-store.ts
+++ b/src/tasks/task-review-store.ts
@@ -7,7 +7,7 @@ import {
   runOpenClawStateWriteTransaction,
 } from "../state/openclaw-state-db.js";
 import type { TaskFlowRecord } from "./task-flow-registry.types.js";
-import type { TaskDeliveryState, TaskRecord } from "./task-registry.types.js";
+import type { JsonValue, TaskDeliveryState, TaskRecord } from "./task-registry.types.js";
 
 type ReviewStoreDatabase = Pick<
   OpenClawStateDatabase,
@@ -80,6 +80,11 @@ export function createReviewDispatchAtomically(params: {
           revision: params.expectedRevision + 1,
           status: "waiting",
           current_step: "review_pending",
+          blocked_task_id: null,
+          blocked_summary: null,
+          ended_at: null,
+          wait_json: null,
+          cancel_requested_at: null,
           state_json:
             params.nextStateJson === undefined ? null : JSON.stringify(params.nextStateJson),
           updated_at: params.task.createdAt,
@@ -108,4 +113,141 @@ export function createReviewDispatchAtomically(params: {
     }
     return { status: "created" } as const;
   });
+}
+
+export type AtomicReviewMutationResult =
+  | { status: "applied" }
+  | { status: "task_conflict" }
+  | { status: "flow_missing" };
+
+class ReviewMutationConflict extends Error {
+  constructor(readonly result: Exclude<AtomicReviewMutationResult, { status: "applied" }>) {
+    super(result.status);
+  }
+}
+
+function parseStateJson(value: string | null): Record<string, unknown> {
+  if (!value) {
+    return {};
+  }
+  const parsed = JSON.parse(value) as unknown;
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("Managed review flow state must be an object.");
+  }
+  return parsed as Record<string, unknown>;
+}
+
+export function bindReviewLaunchAtomically(params: {
+  task: TaskRecord;
+  expectedDetail: JsonValue;
+  nextDetail: JsonValue;
+  childSessionKey: string;
+  now: number;
+}): AtomicReviewMutationResult {
+  const { db } = openOpenClawStateDatabase();
+  const store = getNodeSqliteKysely<ReviewStoreDatabase>(db);
+  const updated = executeSqliteQuerySync(
+    db,
+    store
+      .updateTable("task_runs")
+      .set({
+        child_session_key: params.childSessionKey,
+        status: "running",
+        started_at: params.task.startedAt ?? params.now,
+        last_event_at: params.now,
+        progress_summary: "Reviewer child is running.",
+        detail_json: JSON.stringify(params.nextDetail),
+      })
+      .where("task_id", "=", params.task.taskId)
+      .where("runtime", "=", params.task.runtime)
+      .where("detail_json", "=", JSON.stringify(params.expectedDetail)),
+  );
+  return updated.numAffectedRows === 1n ? { status: "applied" } : { status: "task_conflict" };
+}
+
+export function commitReviewTaskAndFlowAtomically(params: {
+  task: TaskRecord;
+  expectedDetail: JsonValue;
+  nextTask: TaskRecord;
+  reviewProjection: JsonValue;
+  flowStatus: TaskFlowRecord["status"];
+  currentStep: string;
+  blockedSummary?: string;
+  flowEndedAt?: number;
+  now: number;
+}): AtomicReviewMutationResult {
+  if (!params.task.parentFlowId) {
+    return { status: "flow_missing" };
+  }
+  const { db } = openOpenClawStateDatabase();
+  const store = getNodeSqliteKysely<ReviewStoreDatabase>(db);
+  try {
+    return runOpenClawStateWriteTransaction(() => {
+      const flow = executeSqliteQuerySync(
+        db,
+        store
+          .selectFrom("flow_runs")
+          .select(["revision", "state_json"])
+          .where("flow_id", "=", params.task.parentFlowId!)
+          .where("owner_key", "=", params.task.ownerKey)
+          .where("sync_mode", "=", "managed"),
+      ).rows[0];
+      if (!flow) {
+        throw new ReviewMutationConflict({ status: "flow_missing" });
+      }
+      const state = parseStateJson(flow.state_json);
+      const taskUpdate = executeSqliteQuerySync(
+        db,
+        store
+          .updateTable("task_runs")
+          .set({
+            child_session_key: params.nextTask.childSessionKey ?? null,
+            status: params.nextTask.status,
+            started_at: params.nextTask.startedAt ?? null,
+            ended_at: params.nextTask.endedAt ?? null,
+            last_event_at: params.nextTask.lastEventAt ?? null,
+            error: params.nextTask.error ?? null,
+            progress_summary: params.nextTask.progressSummary ?? null,
+            terminal_summary: params.nextTask.terminalSummary ?? null,
+            terminal_outcome: params.nextTask.terminalOutcome ?? null,
+            detail_json:
+              params.nextTask.detail === undefined ? null : JSON.stringify(params.nextTask.detail),
+          })
+          .where("task_id", "=", params.task.taskId)
+          .where("runtime", "=", params.task.runtime)
+          .where("detail_json", "=", JSON.stringify(params.expectedDetail)),
+      );
+      if (taskUpdate.numAffectedRows !== 1n) {
+        throw new ReviewMutationConflict({ status: "task_conflict" });
+      }
+      const flowUpdate = executeSqliteQuerySync(
+        db,
+        store
+          .updateTable("flow_runs")
+          .set({
+            revision: flow.revision + 1,
+            status: params.flowStatus,
+            current_step: params.currentStep,
+            blocked_task_id: params.blockedSummary ? params.task.taskId : null,
+            blocked_summary: params.blockedSummary ?? null,
+            ended_at: params.flowEndedAt ?? null,
+            wait_json: null,
+            cancel_requested_at: null,
+            state_json: JSON.stringify({ ...state, review: params.reviewProjection }),
+            updated_at: params.now,
+          })
+          .where("flow_id", "=", params.task.parentFlowId!)
+          .where("revision", "=", flow.revision),
+      );
+      if (flowUpdate.numAffectedRows !== 1n) {
+        throw new Error("Managed review flow revision changed inside its write transaction.");
+      }
+      return { status: "applied" } as const;
+    });
+  } catch (error) {
+    if (error instanceof ReviewMutationConflict) {
+      return error.result;
+    }
+    throw error;
+  }
 }

--- a/src/tasks/task-review-store.ts
+++ b/src/tasks/task-review-store.ts
@@ -1,0 +1,111 @@
+// Atomically couples managed-flow review state with its canonical reviewer task.
+import type { Insertable } from "kysely";
+import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
+import type { DB as OpenClawStateDatabase } from "../state/openclaw-state-db.generated.js";
+import {
+  openOpenClawStateDatabase,
+  runOpenClawStateWriteTransaction,
+} from "../state/openclaw-state-db.js";
+import type { TaskFlowRecord } from "./task-flow-registry.types.js";
+import type { TaskDeliveryState, TaskRecord } from "./task-registry.types.js";
+
+type ReviewStoreDatabase = Pick<
+  OpenClawStateDatabase,
+  "flow_runs" | "task_delivery_state" | "task_runs"
+>;
+
+function bindTask(task: TaskRecord): Insertable<OpenClawStateDatabase["task_runs"]> {
+  return {
+    task_id: task.taskId,
+    runtime: task.runtime,
+    task_kind: task.taskKind ?? null,
+    source_id: task.sourceId ?? null,
+    requester_session_key: task.requesterSessionKey,
+    owner_key: task.ownerKey,
+    scope_kind: task.scopeKind,
+    child_session_key: task.childSessionKey ?? null,
+    parent_flow_id: task.parentFlowId ?? null,
+    parent_task_id: task.parentTaskId ?? null,
+    agent_id: task.agentId ?? null,
+    requester_agent_id: task.requesterAgentId ?? null,
+    run_id: task.runId ?? null,
+    label: task.label ?? null,
+    task: task.task,
+    status: task.status,
+    delivery_status: task.deliveryStatus,
+    notify_policy: task.notifyPolicy,
+    created_at: task.createdAt,
+    started_at: task.startedAt ?? null,
+    ended_at: task.endedAt ?? null,
+    last_event_at: task.lastEventAt ?? null,
+    cleanup_after: task.cleanupAfter ?? null,
+    tool_use_count: task.toolUseCount ?? null,
+    last_tool_name: task.lastToolName ?? null,
+    error: task.error ?? null,
+    progress_summary: task.progressSummary ?? null,
+    terminal_summary: task.terminalSummary ?? null,
+    terminal_outcome: task.terminalOutcome ?? null,
+    detail_json: task.detail === undefined ? null : JSON.stringify(task.detail),
+  };
+}
+
+export type AtomicReviewDispatchResult =
+  | { status: "created" }
+  | { status: "existing" }
+  | { status: "flow_conflict" };
+
+export function createReviewDispatchAtomically(params: {
+  flow: TaskFlowRecord;
+  expectedRevision: number;
+  nextStateJson: TaskFlowRecord["stateJson"];
+  task: TaskRecord;
+  deliveryState?: TaskDeliveryState;
+}): AtomicReviewDispatchResult {
+  const { db } = openOpenClawStateDatabase();
+  const store = getNodeSqliteKysely<ReviewStoreDatabase>(db);
+  return runOpenClawStateWriteTransaction(() => {
+    const existing = executeSqliteQuerySync(
+      db,
+      store.selectFrom("task_runs").select(["task_id"]).where("task_id", "=", params.task.taskId),
+    ).rows[0];
+    if (existing) {
+      return { status: "existing" } as const;
+    }
+
+    const flowUpdate = executeSqliteQuerySync(
+      db,
+      store
+        .updateTable("flow_runs")
+        .set({
+          revision: params.expectedRevision + 1,
+          status: "waiting",
+          current_step: "review_pending",
+          state_json:
+            params.nextStateJson === undefined ? null : JSON.stringify(params.nextStateJson),
+          updated_at: params.task.createdAt,
+        })
+        .where("flow_id", "=", params.flow.flowId)
+        .where("owner_key", "=", params.flow.ownerKey)
+        .where("sync_mode", "=", "managed")
+        .where("revision", "=", params.expectedRevision),
+    );
+    if (flowUpdate.numAffectedRows !== 1n) {
+      return { status: "flow_conflict" } as const;
+    }
+
+    executeSqliteQuerySync(db, store.insertInto("task_runs").values(bindTask(params.task)));
+    if (params.deliveryState) {
+      executeSqliteQuerySync(
+        db,
+        store.insertInto("task_delivery_state").values({
+          task_id: params.task.taskId,
+          requester_origin_json: params.deliveryState.requesterOrigin
+            ? JSON.stringify(params.deliveryState.requesterOrigin)
+            : null,
+          last_notified_event_at: params.deliveryState.lastNotifiedEventAt ?? null,
+        }),
+      );
+    }
+    return { status: "created" } as const;
+  });
+}

--- a/src/tasks/task-review-store.ts
+++ b/src/tasks/task-review-store.ts
@@ -209,13 +209,18 @@ export function commitReviewTaskAndFlowAtomically(params: {
         db,
         store
           .selectFrom("flow_runs")
-          .select(["revision", "state_json"])
+          .select(["revision", "state_json", "cancel_requested_at"])
           .where("flow_id", "=", params.task.parentFlowId!)
           .where("owner_key", "=", params.task.ownerKey)
           .where("sync_mode", "=", "managed"),
       ).rows[0];
       if (!flow) {
         throw new ReviewMutationConflict({ status: "flow_missing" });
+      }
+      // A late reviewer result must not clear an owner's cancellation or revive
+      // its task after cancellation wins while inspection is in flight.
+      if (flow.cancel_requested_at !== null) {
+        throw new ReviewMutationConflict({ status: "flow_conflict" });
       }
       const state = parseStateJson(flow.state_json);
       const taskUpdate = executeSqliteQuerySync(

--- a/src/tasks/task-reviewer-runtime.test.ts
+++ b/src/tasks/task-reviewer-runtime.test.ts
@@ -4,7 +4,9 @@ import type { TaskRecord } from "./task-registry.types.js";
 import type { TaskReviewDetail } from "./task-review-lifecycle.js";
 
 const mocks = vi.hoisted(() => ({
+  getRuntimeConfig: vi.fn(() => ({})),
   getSubagentRunByRunId: vi.fn(),
+  killSubagentRunAdmin: vi.fn(),
   spawnSubagentDirect: vi.fn(),
 }));
 
@@ -13,6 +15,12 @@ vi.mock("../agents/subagent-registry.js", () => ({
 }));
 vi.mock("../agents/subagent-spawn.js", () => ({
   spawnSubagentDirect: mocks.spawnSubagentDirect,
+}));
+vi.mock("../agents/subagent-control.js", () => ({
+  killSubagentRunAdmin: mocks.killSubagentRunAdmin,
+}));
+vi.mock("../config/config.js", () => ({
+  getRuntimeConfig: mocks.getRuntimeConfig,
 }));
 
 const { taskReviewerRuntime } = await import("./task-reviewer-runtime.js");
@@ -118,5 +126,19 @@ describe("task reviewer runtime", () => {
         childSessionKey: "agent:reviewer:subagent:child",
       }),
     ).resolves.toEqual({ state: "completed", decision });
+  });
+
+  it("terminates a live accepted launch that no longer owns its durable claim", async () => {
+    mocks.getSubagentRunByRunId.mockReturnValue({
+      childSessionKey: "agent:reviewer:subagent:stale-child",
+    });
+    await taskReviewerRuntime.settleNonOwningLaunch?.({
+      reviewerRunId: "stale-run",
+      childSessionKey: "agent:reviewer:subagent:stale-child",
+    });
+    expect(mocks.killSubagentRunAdmin).toHaveBeenCalledWith({
+      cfg: {},
+      sessionKey: "agent:reviewer:subagent:stale-child",
+    });
   });
 });

--- a/src/tasks/task-reviewer-runtime.test.ts
+++ b/src/tasks/task-reviewer-runtime.test.ts
@@ -55,6 +55,7 @@ const detail = {
   stateChangedAt: 1,
   recoveryAttempt: 1,
   maxRecoveryAttempts: 2,
+  launch: { phase: "claimed", attempt: 1, claimedAt: 1 },
   history: [],
 } satisfies TaskReviewDetail;
 
@@ -75,6 +76,14 @@ describe("task reviewer runtime", () => {
         childSessionKey: "agent:reviewer:subagent:child",
       },
     );
+    await expect(taskReviewerRuntime.launch({ task, detail, recoveryAttempt: 1 })).resolves.toEqual(
+      {
+        ok: true,
+        reviewerRunId: "reviewer-run",
+        childSessionKey: "agent:reviewer:subagent:child",
+      },
+    );
+    expect(mocks.spawnSubagentDirect).toHaveBeenCalledTimes(2);
     expect(mocks.spawnSubagentDirect).toHaveBeenCalledWith(
       expect.objectContaining({
         agentId: "reviewer",

--- a/src/tasks/task-reviewer-runtime.test.ts
+++ b/src/tasks/task-reviewer-runtime.test.ts
@@ -132,6 +132,13 @@ describe("task reviewer runtime", () => {
     mocks.getSubagentRunByRunId.mockReturnValue({
       childSessionKey: "agent:reviewer:subagent:stale-child",
     });
+    mocks.killSubagentRunAdmin.mockResolvedValue({
+      found: true,
+      killed: true,
+      runId: "stale-run",
+      sessionKey: "agent:reviewer:subagent:stale-child",
+      cascadeKilled: 0,
+    });
     await taskReviewerRuntime.settleNonOwningLaunch?.({
       reviewerRunId: "stale-run",
       childSessionKey: "agent:reviewer:subagent:stale-child",
@@ -140,5 +147,27 @@ describe("task reviewer runtime", () => {
       cfg: {},
       sessionKey: "agent:reviewer:subagent:stale-child",
     });
+  });
+
+  it("fails settlement when rejected kills leave a non-owning reviewer live", async () => {
+    mocks.getSubagentRunByRunId.mockReturnValue({
+      childSessionKey: "agent:reviewer:subagent:stale-child",
+    });
+    mocks.killSubagentRunAdmin.mockResolvedValue({
+      found: true,
+      killed: false,
+      runId: "stale-run",
+      sessionKey: "agent:reviewer:subagent:stale-child",
+      cascadeKilled: 0,
+    });
+
+    await expect(
+      taskReviewerRuntime.settleNonOwningLaunch?.({
+        reviewerRunId: "stale-run",
+        childSessionKey: "agent:reviewer:subagent:stale-child",
+      }),
+    ).rejects.toThrow("Non-owning reviewer stale-run remained live after cancellation.");
+
+    expect(mocks.killSubagentRunAdmin).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/tasks/task-reviewer-runtime.test.ts
+++ b/src/tasks/task-reviewer-runtime.test.ts
@@ -1,0 +1,113 @@
+// Verifies the production reviewer adapter launches and inspects durable subagent runs.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { TaskRecord } from "./task-registry.types.js";
+import type { TaskReviewDetail } from "./task-review-lifecycle.js";
+
+const mocks = vi.hoisted(() => ({
+  getSubagentRunByRunId: vi.fn(),
+  spawnSubagentDirect: vi.fn(),
+}));
+
+vi.mock("../agents/subagent-registry.js", () => ({
+  getSubagentRunByRunId: mocks.getSubagentRunByRunId,
+}));
+vi.mock("../agents/subagent-spawn.js", () => ({
+  spawnSubagentDirect: mocks.spawnSubagentDirect,
+}));
+
+const { taskReviewerRuntime } = await import("./task-reviewer-runtime.js");
+
+const task = {
+  taskId: "review-task",
+  runtime: "subagent",
+  requesterSessionKey: "agent:main:main",
+  ownerKey: "agent:main:main",
+  scopeKind: "session",
+  task: "Review exact proof",
+  runId: "task-review:dispatch",
+  status: "queued",
+  notifyPolicy: "state_changes",
+  deliveryStatus: "pending",
+  createdAt: 1,
+} satisfies TaskRecord;
+
+const detail = {
+  kind: "managed-review",
+  version: 1,
+  state: "review_pending",
+  dispatchKey: "dispatch",
+  reviewerAgentId: "reviewer",
+  proofBundle: {
+    commit: "1".repeat(40),
+    baseCommit: "2".repeat(40),
+    diff: { sha256: "3".repeat(64), summary: "fixture", files: [] },
+    tests: [],
+    screenshots: [],
+    criteria: [{ id: "criterion-1", description: "durable" }],
+  },
+  continuity: {
+    ownerKey: "agent:main:main",
+    sessionKey: "agent:main:main",
+    sessionId: "successor-session",
+    compactionCount: 4,
+  },
+  staleAfterMs: 60_000,
+  stateChangedAt: 1,
+  recoveryAttempt: 1,
+  maxRecoveryAttempts: 2,
+  history: [],
+} satisfies TaskReviewDetail;
+
+describe("task reviewer runtime", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("passes the canonical task binding, continuity, and stable replay key to the real launcher seam", async () => {
+    mocks.spawnSubagentDirect.mockResolvedValue({
+      status: "accepted",
+      runId: "reviewer-run",
+      childSessionKey: "agent:reviewer:subagent:child",
+    });
+
+    await expect(taskReviewerRuntime.launch({ task, detail, recoveryAttempt: 1 })).resolves.toEqual(
+      {
+        ok: true,
+        reviewerRunId: "reviewer-run",
+        childSessionKey: "agent:reviewer:subagent:child",
+      },
+    );
+    expect(mocks.spawnSubagentDirect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: "reviewer",
+        taskRunId: "task-review:dispatch",
+        externalTaskLifecycle: true,
+        externalLaunchReplayKey: "dispatch:1",
+      }),
+      expect.objectContaining({
+        agentSessionKey: "agent:main:main",
+        completionOwnerKey: "agent:main:main",
+        requesterRunId: "dispatch:1",
+      }),
+    );
+  });
+
+  it("converts a persisted successful completion into a typed decision payload", async () => {
+    const decision = {
+      outcome: "merge_ready",
+      reviewedCommit: "1".repeat(40),
+      criteria: [{ id: "criterion-1", status: "passed", evidence: "verified" }],
+      findings: [],
+    };
+    mocks.getSubagentRunByRunId.mockReturnValue({
+      childSessionKey: "agent:reviewer:subagent:child",
+      endedAt: 2,
+      outcome: { status: "ok" },
+      completion: { resultText: JSON.stringify(decision) },
+    });
+    await expect(
+      taskReviewerRuntime.inspect({
+        reviewerRunId: "reviewer-run",
+        childSessionKey: "agent:reviewer:subagent:child",
+      }),
+    ).resolves.toEqual({ state: "completed", decision });
+  });
+});

--- a/src/tasks/task-reviewer-runtime.ts
+++ b/src/tasks/task-reviewer-runtime.ts
@@ -64,4 +64,16 @@ export const taskReviewerRuntime: TaskReviewerRuntime = {
       return { state: "failed", reason: "Reviewer decision payload was not valid JSON." };
     }
   },
+
+  async settleNonOwningLaunch({ reviewerRunId, childSessionKey }) {
+    const run = getSubagentRunByRunId(reviewerRunId);
+    if (!run || run.childSessionKey !== childSessionKey || typeof run.endedAt === "number") {
+      return;
+    }
+    const [{ getRuntimeConfig }, { killSubagentRunAdmin }] = await Promise.all([
+      import("../config/config.js"),
+      import("../agents/subagent-control.js"),
+    ]);
+    await killSubagentRunAdmin({ cfg: getRuntimeConfig(), sessionKey: childSessionKey });
+  },
 };

--- a/src/tasks/task-reviewer-runtime.ts
+++ b/src/tasks/task-reviewer-runtime.ts
@@ -74,6 +74,13 @@ export const taskReviewerRuntime: TaskReviewerRuntime = {
       import("../config/config.js"),
       import("../agents/subagent-control.js"),
     ]);
-    await killSubagentRunAdmin({ cfg: getRuntimeConfig(), sessionKey: childSessionKey });
+    const cfg = getRuntimeConfig();
+    let result = await killSubagentRunAdmin({ cfg, sessionKey: childSessionKey });
+    if (result.found && !result.killed && !result.targetState) {
+      result = await killSubagentRunAdmin({ cfg, sessionKey: childSessionKey });
+    }
+    if (result.found && !result.killed && !result.targetState) {
+      throw new Error(`Non-owning reviewer ${reviewerRunId} remained live after cancellation.`);
+    }
   },
 };

--- a/src/tasks/task-reviewer-runtime.ts
+++ b/src/tasks/task-reviewer-runtime.ts
@@ -1,0 +1,67 @@
+// Bridges durable review tasks to the production subagent launcher and completion registry.
+import { getSubagentRunByRunId } from "../agents/subagent-registry.js";
+import { spawnSubagentDirect } from "../agents/subagent-spawn.js";
+import type { TaskReviewerRuntime } from "./task-review-lifecycle.js";
+
+export const taskReviewerRuntime: TaskReviewerRuntime = {
+  async launch({ task, detail, recoveryAttempt }) {
+    if (!task.runId) {
+      return { ok: false, reason: "Review task has no stable run id." };
+    }
+    const result = await spawnSubagentDirect(
+      {
+        task: task.task,
+        taskName: `review-${detail.dispatchKey.slice(0, 12)}`,
+        label: task.label,
+        agentId: detail.reviewerAgentId,
+        mode: "run",
+        cleanup: "keep",
+        expectsCompletionMessage: false,
+        taskRunId: task.runId,
+        externalTaskLifecycle: true,
+        externalLaunchReplayKey: `${detail.dispatchKey}:${recoveryAttempt}`,
+      },
+      {
+        agentSessionKey: detail.continuity.sessionKey,
+        completionOwnerKey: detail.continuity.ownerKey,
+        requesterRunId: `${detail.dispatchKey}:${recoveryAttempt}`,
+      },
+    );
+    if (result.status !== "accepted" || !result.runId || !result.childSessionKey) {
+      return { ok: false, reason: result.error ?? "Reviewer launch was not accepted." };
+    }
+    return {
+      ok: true,
+      reviewerRunId: result.runId,
+      childSessionKey: result.childSessionKey,
+    };
+  },
+
+  async inspect({ reviewerRunId, childSessionKey }) {
+    const run = getSubagentRunByRunId(reviewerRunId);
+    if (!run || run.childSessionKey !== childSessionKey) {
+      return { state: "missing" };
+    }
+    if (typeof run.endedAt !== "number") {
+      return { state: "live" };
+    }
+    if (run.outcome?.status !== "ok") {
+      return {
+        state: "failed",
+        reason:
+          run.outcome?.status === "error"
+            ? (run.outcome.error ?? "Reviewer failed.")
+            : `Reviewer ended with ${run.outcome?.status ?? "unknown"}.`,
+      };
+    }
+    const text = run.completion?.resultText?.trim();
+    if (!text) {
+      return { state: "failed", reason: "Reviewer returned no decision payload." };
+    }
+    try {
+      return { state: "completed", decision: JSON.parse(text) as unknown };
+    } catch {
+      return { state: "failed", reason: "Reviewer decision payload was not valid JSON." };
+    }
+  },
+};


### PR DESCRIPTION
## Summary

- add durable TaskFlow review handoff, launch ownership, recovery, and projection repair
- preserve cancellation monotonicity across late review reconciliation and restart
- distinguish target reviewer kill truth from descendant cascade cleanup
- close the `AtomicReviewMutationResult` contract for `flow_conflict`

## Validation

- accepted correction: `054e5f7104..0c1249d0a3`
- independent adversarial review: `no_blocker`
- accepted broad gate: 20 files, 836/836 tests; type, lint, format, import-cycle, storage, runtime-sidecar, diff, commit, and secret-scan guards passed
- rebased onto frozen upstream `7a0ae5070a`; all 7 stable patch IDs match the accepted series exactly
- post-integration focused gate: 3 files, 58/58 tests
- integrated source build: passed
- isolated gateway canary: `a235922`, loopback port 19737, temporary state, `/health` returned HTTP 200 with `{"ok":true,"status":"live"}`, no fatal/error, clean deliberate shutdown

## Release boundary

This PR does not activate the change in the operator's live gateway. The canary used isolated state and a dedicated loopback port only.
