### PR TITLE
fix(android): make branch counts locale-neutral

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -12845,17 +12845,9 @@
       "kind": "ui-call",
       "line": 2261,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "$count messages",
+      "source": "Messages: $count",
       "surface": "android",
-      "id": "native.android.72ad7c7cb98ed70d"
-    },
-    {
-      "kind": "ui-call",
-      "line": 2261,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
-      "source": "1 message",
-      "surface": "android",
-      "id": "native.android.a19751c49ae4a6f9"
+      "id": "native.android.d79a4188788ccf49"
     },
     {
       "kind": "ui-call",

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
@@ -2258,7 +2258,7 @@ private fun BranchSwitcherSheet(
   }
 }
 
-internal fun branchMessageCountText(count: Int): String = if (count == 1) nativeString("1 message") else nativeString("\$count messages", count)
+internal fun branchMessageCountText(count: Int): String = nativeString("Messages: \$count", count)
 
 internal fun branchMetadataText(branch: SessionBranch): String {
   val count = branchMessageCountText(branch.messageCount)

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatScreenTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatScreenTest.kt
@@ -13,11 +13,11 @@ import org.junit.Test
 
 class ChatScreenTest {
   @Test
-  fun branchMessageCountUsesSingularAndPluralCopy() {
-    assertEquals("1 message", branchMessageCountText(1))
-    assertEquals("2 messages", branchMessageCountText(2))
+  fun branchMessageCountUsesCountNeutralCopy() {
+    assertEquals("Messages: 1", branchMessageCountText(1))
+    assertEquals("Messages: 2", branchMessageCountText(2))
     assertEquals(
-      "2 messages",
+      "Messages: 2",
       branchMetadataText(SessionBranch("leaf", "", 2, updatedAt = null, active = false)),
     )
   }


### PR DESCRIPTION
## What Problem This Solves

Android's new session-branch metadata used English-style singular and plural strings. Languages with more than two plural forms could therefore render common message counts with the wrong inflection.

## Why This Change Was Made

Use one count-neutral localized label, `Messages: N`, rather than pretending the native string pipeline supports Android quantity resources. Refresh the canonical native source inventory in the same stack.

## User Impact

Session branch message counts remain concise while translating correctly across plural-sensitive locales.

## Evidence

- Focused Testbox Android unit test: `:app:testPlayDebugUnitTest --tests ai.openclaw.app.ui.chat.ChatScreenTest`
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/29871701162
- `pnpm check:changed` passed on the same Testbox
- Fresh branch autoreview: clean, no actionable findings
- `git diff --check`
