### PR TITLE
fix(gateway): reject non-positive gateway.auth.rateLimit values

### DIFF
--- a/src/commands/doctor/shared/legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.test.ts
@@ -2933,6 +2933,91 @@ describe("gateway.port out-of-range repair migrate", () => {
   });
 });
 
+describe("gateway.auth.rateLimit out-of-range repair migrate", () => {
+  it("removes a zero maxAttempts and records a change", () => {
+    const res = migrateLegacyConfigForTest({
+      gateway: { auth: { rateLimit: { maxAttempts: 0 } } },
+    });
+
+    expect(res.changes).toStrictEqual([
+      "Removed invalid gateway.auth.rateLimit.maxAttempts (0). Must be a positive integer; the gateway will use the default 10.",
+    ]);
+    expect(res.config).not.toHaveProperty("gateway");
+  });
+
+  it("removes a zero windowMs and records a change", () => {
+    const res = migrateLegacyConfigForTest({
+      gateway: { auth: { rateLimit: { windowMs: 0 } } },
+    });
+
+    expect(res.changes).toStrictEqual([
+      "Removed invalid gateway.auth.rateLimit.windowMs (0). Must be a positive integer; the gateway will use the default 60000ms.",
+    ]);
+    expect(res.config).not.toHaveProperty("gateway");
+  });
+
+  it("removes a zero lockoutMs and records a change", () => {
+    const res = migrateLegacyConfigForTest({
+      gateway: { auth: { rateLimit: { lockoutMs: 0 } } },
+    });
+
+    expect(res.changes).toStrictEqual([
+      "Removed invalid gateway.auth.rateLimit.lockoutMs (0). Must be a positive integer; the gateway will use the default 300000ms.",
+    ]);
+    expect(res.config).not.toHaveProperty("gateway");
+  });
+
+  it("removes a negative or fractional value", () => {
+    const negative = migrateLegacyConfigForTest({
+      gateway: { auth: { rateLimit: { maxAttempts: -5 } } },
+    });
+    expect(negative.changes.length).toBe(1);
+
+    const fractional = migrateLegacyConfigForTest({
+      gateway: { auth: { rateLimit: { windowMs: 1.5 } } },
+    });
+    expect(fractional.changes.length).toBe(1);
+  });
+
+  it("preserves other rateLimit keys when removing one field", () => {
+    const res = migrateLegacyConfigForTest({
+      gateway: { auth: { rateLimit: { maxAttempts: 0, exemptLoopback: false } } },
+    });
+
+    expect(res.config?.gateway).toEqual({
+      auth: { rateLimit: { exemptLoopback: false } },
+    });
+  });
+
+  it("preserves other auth keys when removing the whole rateLimit block", () => {
+    const res = migrateLegacyConfigForTest({
+      gateway: { auth: { mode: "token", rateLimit: { maxAttempts: 0 } } },
+    });
+
+    expect(res.config?.gateway).toEqual({ auth: { mode: "token" } });
+  });
+
+  it("preserves valid rateLimit values", () => {
+    const res = migrateLegacyConfigForTest({
+      gateway: { auth: { rateLimit: { maxAttempts: 5, windowMs: 30_000, lockoutMs: 60_000 } } },
+    });
+
+    expect(res.config).toBeNull();
+    expect(res.changes).toEqual([]);
+  });
+
+  it("is idempotent for out-of-range values", () => {
+    const first = migrateLegacyConfigForTest({
+      gateway: { auth: { rateLimit: { maxAttempts: 0, windowMs: 0 } } },
+    });
+    expect(first.changes.length).toBe(2);
+    expect(first.config).not.toHaveProperty("gateway");
+
+    const second = migrateLegacyConfigForTest(first.config);
+    expect(second.changes).toStrictEqual([]);
+  });
+});
+
 describe("legacy model compat migrate", () => {
   it("upgrades the retired xAI quality image slug without pinning active aliases", () => {
     const raw = {

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.gateway.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.gateway.ts
@@ -13,12 +13,42 @@ import {
   type LegacyConfigRule,
 } from "../../../config/legacy.shared.js";
 import { DEFAULT_GATEWAY_PORT } from "../../../config/paths.js";
+import {
+  DEFAULT_LOCKOUT_MS,
+  DEFAULT_MAX_ATTEMPTS,
+  DEFAULT_WINDOW_MS,
+} from "../../../gateway/auth-rate-limit.js";
 
 const GATEWAY_PORT_OOB_RULE: LegacyConfigRule = {
   path: ["gateway", "port"],
   message:
     'gateway.port is outside the valid TCP range (1–65535) and will be removed to avoid startup failure. Run "openclaw doctor --fix".',
   match: (value) => typeof value === "number" && (value < 1 || value > 65_535),
+};
+
+function isNonPositiveIntegerConfigValue(value: unknown): boolean {
+  return typeof value === "number" && (!Number.isInteger(value) || value < 1);
+}
+
+const GATEWAY_RATE_LIMIT_MAX_ATTEMPTS_OOB_RULE: LegacyConfigRule = {
+  path: ["gateway", "auth", "rateLimit", "maxAttempts"],
+  message:
+    'gateway.auth.rateLimit.maxAttempts must be a positive integer and will be removed to avoid disabling auth throttling. Run "openclaw doctor --fix".',
+  match: isNonPositiveIntegerConfigValue,
+};
+
+const GATEWAY_RATE_LIMIT_WINDOW_MS_OOB_RULE: LegacyConfigRule = {
+  path: ["gateway", "auth", "rateLimit", "windowMs"],
+  message:
+    'gateway.auth.rateLimit.windowMs must be a positive integer and will be removed to avoid disabling auth throttling. Run "openclaw doctor --fix".',
+  match: isNonPositiveIntegerConfigValue,
+};
+
+const GATEWAY_RATE_LIMIT_LOCKOUT_MS_OOB_RULE: LegacyConfigRule = {
+  path: ["gateway", "auth", "rateLimit", "lockoutMs"],
+  message:
+    'gateway.auth.rateLimit.lockoutMs must be a positive integer and will be removed to avoid disabling auth throttling. Run "openclaw doctor --fix".',
+  match: isNonPositiveIntegerConfigValue,
 };
 
 const GATEWAY_BIND_RULE: LegacyConfigRule = {
@@ -118,6 +148,59 @@ export const LEGACY_CONFIG_MIGRATIONS_RUNTIME_GATEWAY: LegacyConfigMigrationSpec
         `Removed out-of-range gateway.port (${String(port)}). ` +
           `Valid TCP ports are 1–65535; the gateway will use the default port ${DEFAULT_GATEWAY_PORT}.`,
       );
+    },
+  }),
+  defineLegacyConfigMigration({
+    id: "gateway.auth.rateLimit-oob-repair",
+    describe:
+      "Remove invalid gateway.auth.rateLimit numeric fields that would silently disable auth throttling",
+    legacyRules: [
+      GATEWAY_RATE_LIMIT_MAX_ATTEMPTS_OOB_RULE,
+      GATEWAY_RATE_LIMIT_WINDOW_MS_OOB_RULE,
+      GATEWAY_RATE_LIMIT_LOCKOUT_MS_OOB_RULE,
+    ],
+    apply: (raw, changes) => {
+      const gateway = getRecord(raw.gateway);
+      const auth = getRecord(gateway?.auth);
+      const rateLimit = getRecord(auth?.rateLimit);
+      if (!gateway || !auth || !rateLimit) {
+        return;
+      }
+      const repairs: Array<{
+        key: "maxAttempts" | "windowMs" | "lockoutMs";
+        fallback: number;
+        unit: string;
+      }> = [
+        { key: "maxAttempts", fallback: DEFAULT_MAX_ATTEMPTS, unit: "" },
+        { key: "windowMs", fallback: DEFAULT_WINDOW_MS, unit: "ms" },
+        { key: "lockoutMs", fallback: DEFAULT_LOCKOUT_MS, unit: "ms" },
+      ];
+      for (const { key, fallback, unit } of repairs) {
+        const value = rateLimit[key];
+        if (!isNonPositiveIntegerConfigValue(value)) {
+          continue;
+        }
+        delete rateLimit[key];
+        changes.push(
+          `Removed invalid gateway.auth.rateLimit.${key} (${String(value)}). ` +
+            `Must be a positive integer; the gateway will use the default ${fallback}${unit}.`,
+        );
+      }
+      if (Object.keys(rateLimit).length > 0) {
+        auth.rateLimit = rateLimit;
+      } else {
+        delete auth.rateLimit;
+      }
+      if (Object.keys(auth).length > 0) {
+        gateway.auth = auth;
+      } else {
+        delete gateway.auth;
+      }
+      if (Object.keys(gateway).length > 0) {
+        raw.gateway = gateway;
+      } else {
+        delete raw.gateway;
+      }
     },
   }),
   defineLegacyConfigMigration({

--- a/src/config/validation.policy.test.ts
+++ b/src/config/validation.policy.test.ts
@@ -236,3 +236,26 @@ describe("config validation gateway.port policy", () => {
     expect(min.ok).toBe(true);
   });
 });
+
+describe("config validation gateway.auth.rateLimit policy", () => {
+  it("rejects non-positive-integer maxAttempts/windowMs/lockoutMs", () => {
+    for (const field of ["maxAttempts", "windowMs", "lockoutMs"] as const) {
+      // 0 previously slipped through and silently disabled auth throttling.
+      const zero = validateConfigObjectRaw({ gateway: { auth: { rateLimit: { [field]: 0 } } } });
+      expect(zero.ok).toBe(false);
+      if (!zero.ok) {
+        const issue = requireIssue(zero.issues, `gateway.auth.rateLimit.${field}`);
+        expect(issue.message).toContain("expected number to be >=1");
+      }
+
+      // NaN/fractional values previously bypassed the maxAttempts comparison entirely.
+      const fractional = validateConfigObjectRaw({
+        gateway: { auth: { rateLimit: { [field]: 1.5 } } },
+      });
+      expect(fractional.ok).toBe(false);
+
+      const valid = validateConfigObjectRaw({ gateway: { auth: { rateLimit: { [field]: 5 } } } });
+      expect(valid.ok).toBe(true);
+    }
+  });
+});

--- a/src/config/zod-schema.gateway.ts
+++ b/src/config/zod-schema.gateway.ts
@@ -72,9 +72,9 @@ export const GatewayConfigSchema = z
         allowTailscale: z.boolean().optional(),
         rateLimit: z
           .strictObject({
-            maxAttempts: z.number().optional(),
-            windowMs: z.number().optional(),
-            lockoutMs: z.number().optional(),
+            maxAttempts: z.number().int().min(1).optional(),
+            windowMs: z.number().int().min(1).optional(),
+            lockoutMs: z.number().int().min(1).optional(),
             exemptLoopback: z.boolean().optional(),
           })
           .optional(),

--- a/src/gateway/auth-rate-limit.test.ts
+++ b/src/gateway/auth-rate-limit.test.ts
@@ -8,6 +8,7 @@ import {
   AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET,
   buildRateLimitIdentityKey,
   createAuthRateLimiter,
+  DEFAULT_MAX_ATTEMPTS,
   type AuthRateLimiter,
 } from "./auth-rate-limit.js";
 
@@ -386,5 +387,53 @@ describe("auth rate limiter", () => {
     expect(limiter.size()).toBe(1);
     limiter.dispose();
     expect(limiter.size()).toBe(0);
+  });
+
+  // ---------- unvalidated config bypassing the config schema ----------
+  // These options are also bounded at the config schema layer, but the
+  // limiter clamps its own inputs so any caller that builds a config object
+  // directly (bypassing zod) cannot silently disable throttling.
+
+  it("does not disable lockout when maxAttempts is NaN", () => {
+    limiter = createAuthRateLimiter({
+      maxAttempts: Number.NaN,
+      windowMs: 60_000,
+      lockoutMs: 60_000,
+    });
+    for (let i = 0; i < DEFAULT_MAX_ATTEMPTS; i++) {
+      limiter.recordFailure("10.0.0.50");
+    }
+    expect(limiter.check("10.0.0.50").allowed).toBe(false);
+  });
+
+  it("treats a zero or negative maxAttempts as the minimum of 1 instead of an instant no-op", () => {
+    limiter = createAuthRateLimiter({ maxAttempts: 0, windowMs: 60_000, lockoutMs: 60_000 });
+    limiter.recordFailure("10.0.0.51");
+    expect(limiter.check("10.0.0.51").allowed).toBe(false);
+  });
+
+  it("does not disable the sliding window when windowMs is 0", () => {
+    vi.useFakeTimers();
+    try {
+      limiter = createAuthRateLimiter({ maxAttempts: 2, windowMs: 0, lockoutMs: 60_000 });
+      limiter.recordFailure("10.0.0.52");
+      limiter.recordFailure("10.0.0.52");
+      expect(limiter.check("10.0.0.52").allowed).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not disable the lockout duration when lockoutMs is 0", () => {
+    vi.useFakeTimers();
+    try {
+      limiter = createAuthRateLimiter({ maxAttempts: 1, windowMs: 60_000, lockoutMs: 0 });
+      limiter.recordFailure("10.0.0.53");
+      const result = limiter.check("10.0.0.53");
+      expect(result.allowed).toBe(false);
+      expect(result.retryAfterMs).toBeGreaterThan(0);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/gateway/auth-rate-limit.ts
+++ b/src/gateway/auth-rate-limit.ts
@@ -97,9 +97,9 @@ export interface AuthRateLimiter {
 // Defaults
 // ---------------------------------------------------------------------------
 
-const DEFAULT_MAX_ATTEMPTS = 10;
-const DEFAULT_WINDOW_MS = 60_000; // 1 minute
-const DEFAULT_LOCKOUT_MS = 300_000; // 5 minutes
+export const DEFAULT_MAX_ATTEMPTS = 10;
+export const DEFAULT_WINDOW_MS = 60_000; // 1 minute
+export const DEFAULT_LOCKOUT_MS = 300_000; // 5 minutes
 const PRUNE_INTERVAL_MS = 60_000; // prune stale entries every minute
 const DEFAULT_MAX_ENTRIES = 10_000;
 
@@ -138,9 +138,9 @@ function resolvePruneIntervalMs(value: number | undefined): number {
 }
 
 export function createAuthRateLimiter(config?: RateLimitConfig): AuthRateLimiter {
-  const maxAttempts = config?.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
-  const windowMs = resolveTimerTimeoutMs(config?.windowMs, DEFAULT_WINDOW_MS, 0);
-  const lockoutMs = resolveTimerTimeoutMs(config?.lockoutMs, DEFAULT_LOCKOUT_MS, 0);
+  const maxAttempts = resolveIntegerOption(config?.maxAttempts, DEFAULT_MAX_ATTEMPTS, { min: 1 });
+  const windowMs = resolveTimerTimeoutMs(config?.windowMs, DEFAULT_WINDOW_MS);
+  const lockoutMs = resolveTimerTimeoutMs(config?.lockoutMs, DEFAULT_LOCKOUT_MS);
   const exemptLoopback = config?.exemptLoopback ?? true;
   const pruneIntervalMs = resolvePruneIntervalMs(config?.pruneIntervalMs);
   const maxEntries = resolveIntegerOption(config?.maxEntries, DEFAULT_MAX_ENTRIES, { min: 1 });


### PR DESCRIPTION
## What Problem This Solves

`gateway.auth.rateLimit.maxAttempts`, `windowMs`, and `lockoutMs` accepted any number — including `0`, negative, `NaN`, or fractional values — with no validation at the config-schema layer or the runtime resolver. A `NaN` (or otherwise non-finite) `maxAttempts` makes the lockout comparison `entry.attempts.length >= maxAttempts` always evaluate `false`, so failed auth attempts are recorded but the account is never locked out. A `windowMs: 0` makes the sliding-window filter wipe every recorded attempt on the very next check (`cutoff = now - 0 = now`), so the window never accumulates attempts either. Both cases silently disable auth brute-force throttling instead of erroring — the sibling `maxEntries` option in the same file was already clamped this way, so this is an inconsistency, not an intended feature.

## Why This Change Was Made

Tightened `zod-schema.gateway.ts`'s `rateLimit` fields to `.int().min(1)`, matching the pattern of the recently-merged sibling fix for `gateway.port` (commit `ffff420f491`, #109875) in the same file. Clamped `maxAttempts` in `auth-rate-limit.ts` via the existing `resolveIntegerOption` helper (same helper `maxEntries` already uses), and removed the explicit `, 0` third argument passed to `resolveTimerTimeoutMs` for `windowMs`/`lockoutMs` so they fall through to that function's own default minimum of `1` instead of `0`. Added a doctor migration (`gateway.auth.rateLimit-oob-repair`) that strips out-of-range values from existing configs so a previously-loadable config with e.g. `windowMs: 0` doesn't fail startup after the schema tightens — mirroring the existing `gateway.port-oob-repair` migration in the same file.

## User Impact

Operators who (accidentally or via a malformed generated config) set one of these fields to a non-positive/non-integer value now get a clear validation error instead of a silently-disabled auth rate limiter. Existing on-disk configs with such values are auto-repaired by `openclaw doctor --fix` (falls back to the documented defaults: 10 attempts / 60s window / 5min lockout) instead of failing to start.

## Evidence

- Competing open PR scan: none — searched open PRs/issues for `maxAttempts`/`windowMs`/rate-limit-bypass; the only open PR touching `auth-rate-limit.ts` (#77492) is an unrelated pre-auth CPU-DoS fix.
- Red→green: stashed the fix, confirmed 3 of 4 new runtime tests fail on old code (`NaN` maxAttempts never locks, `windowMs:0` never locks, `lockoutMs:0` never locks) and all migration tests fail (0 changes recorded); restored the fix, all pass.
- `node scripts/run-vitest.mjs src/gateway/auth-rate-limit.test.ts src/config/validation.policy.test.ts src/commands/doctor/shared/legacy-config-migrate.test.ts` → 209/209 passed, post-rebase onto latest `origin/main`.
- `node --import tsx scripts/check-import-cycles.ts` → 0 cycles (new cross-import from doctor migrations into `gateway/auth-rate-limit.js`).
- `./node_modules/.bin/oxfmt --check` and `oxlint` on all 6 changed files → clean.
- `tsgo --noEmit -p tsconfig.core.json` → 4 pre-existing errors, none in touched files (confirmed unrelated to this change).
- What was not tested: full-repo `pnpm check:changed`/build — the remote Testbox delegation hit an unrelated npm-registry network timeout fetching `node-pty`'s prebuild; fell back to local narrow proof per repo policy instead of blocking. No live gateway/E2E run.

AI-assisted: Claude Code
