### PR TITLE
fix(ollama): preserve cloud model context windows

### DIFF
--- a/extensions/ollama/src/provider-models.test.ts
+++ b/extensions/ollama/src/provider-models.test.ts
@@ -7,6 +7,7 @@ import {
   buildOllamaModelDefinition,
   capLocalOllamaProviderContext,
   enrichOllamaModelsWithContext,
+  isOllamaCloudModel,
   fetchOllamaModels,
   queryOllamaModelShowInfo,
   resolveOllamaApiBase,
@@ -31,6 +32,8 @@ describe("ollama provider models", () => {
         buildOllamaModelDefinition("qwen3.5:4b", 262_144),
         buildOllamaModelDefinition("small", 16_384),
         buildOllamaModelDefinition("glm-5.2:cloud", 1_000_000),
+        buildOllamaModelDefinition("gpt-oss:120b-cloud", 131_072),
+        buildOllamaModelDefinition("local-cloud", 65_536),
       ],
     });
 
@@ -38,8 +41,23 @@ describe("ollama provider models", () => {
       expect.objectContaining({ contextWindow: 262_144, contextTokens: 32_768 }),
       expect.objectContaining({ contextWindow: 16_384, contextTokens: 16_384 }),
       expect.objectContaining({ id: "glm-5.2:cloud", contextWindow: 1_000_000 }),
+      expect.objectContaining({ id: "gpt-oss:120b-cloud", contextWindow: 131_072 }),
+      expect.objectContaining({ id: "local-cloud", contextTokens: 32_768 }),
     ]);
     expect(provider.models?.[2]).not.toHaveProperty("contextTokens");
+    expect(provider.models?.[3]).not.toHaveProperty("contextTokens");
+  });
+
+  it.each([
+    ["glm-5.2:cloud", true],
+    ["gpt-oss:120b-cloud", true],
+    ["local-cloud", false],
+    ["invalid:cloud-cloud", false],
+    ["invalid:local:cloud", false],
+    ["invalid:local-cloud", false],
+    ["invalid:cloud:local", false],
+  ])("classifies Ollama model source %s", (modelId, expected) => {
+    expect(isOllamaCloudModel(modelId)).toBe(expected);
   });
 
   it("sets discovered models with context windows from /api/show", async () => {

--- a/extensions/ollama/src/provider-models.test.ts
+++ b/extensions/ollama/src/provider-models.test.ts
@@ -30,13 +30,16 @@ describe("ollama provider models", () => {
       models: [
         buildOllamaModelDefinition("qwen3.5:4b", 262_144),
         buildOllamaModelDefinition("small", 16_384),
+        buildOllamaModelDefinition("glm-5.2:cloud", 1_000_000),
       ],
     });
 
     expect(provider.models).toEqual([
       expect.objectContaining({ contextWindow: 262_144, contextTokens: 32_768 }),
       expect.objectContaining({ contextWindow: 16_384, contextTokens: 16_384 }),
+      expect.objectContaining({ id: "glm-5.2:cloud", contextWindow: 1_000_000 }),
     ]);
+    expect(provider.models?.[2]).not.toHaveProperty("contextTokens");
   });
 
   it("sets discovered models with context windows from /api/show", async () => {

--- a/extensions/ollama/src/provider-models.ts
+++ b/extensions/ollama/src/provider-models.ts
@@ -256,6 +256,37 @@ export async function enrichOllamaModelsWithContext(
   return enriched;
 }
 
+type OllamaModelSource = "cloud" | "local";
+
+function parseOllamaModelSourceSuffix(
+  modelName: string,
+): { base: string; source: OllamaModelSource } | undefined {
+  const sourceSeparator = modelName.lastIndexOf(":");
+  if (sourceSeparator < 0) {
+    return undefined;
+  }
+  const source = modelName.slice(sourceSeparator + 1);
+  if (source === "cloud" || source === "local") {
+    return { base: modelName.slice(0, sourceSeparator), source };
+  }
+  if (!source.includes("/") && source.endsWith("-cloud")) {
+    return {
+      base: modelName.slice(0, sourceSeparator + 1) + source.slice(0, -"-cloud".length),
+      source: "cloud",
+    };
+  }
+  return undefined;
+}
+
+export function isOllamaCloudModel(modelName: string | undefined): boolean {
+  const normalized = modelName?.trim().toLowerCase();
+  if (!normalized) {
+    return false;
+  }
+  const parsed = parseOllamaModelSourceSuffix(normalized);
+  return parsed?.source === "cloud" && parseOllamaModelSourceSuffix(parsed.base) === undefined;
+}
+
 export function isReasoningModelHeuristic(modelId: string): boolean {
   return /r1|reasoning|think|reason/i.test(modelId);
 }
@@ -304,7 +335,7 @@ export function buildOllamaModelDefinition(
 }
 
 export function capLocalOllamaModelContext(model: ModelDefinitionConfig): ModelDefinitionConfig {
-  if (model.id.trim().toLowerCase().endsWith(":cloud") || typeof model.contextWindow !== "number") {
+  if (isOllamaCloudModel(model.id) || typeof model.contextWindow !== "number") {
     return model;
   }
   return {

--- a/extensions/ollama/src/provider-models.ts
+++ b/extensions/ollama/src/provider-models.ts
@@ -304,7 +304,7 @@ export function buildOllamaModelDefinition(
 }
 
 export function capLocalOllamaModelContext(model: ModelDefinitionConfig): ModelDefinitionConfig {
-  if (typeof model.contextWindow !== "number") {
+  if (model.id.trim().toLowerCase().endsWith(":cloud") || typeof model.contextWindow !== "number") {
     return model;
   }
   return {

--- a/extensions/ollama/src/setup.test.ts
+++ b/extensions/ollama/src/setup.test.ts
@@ -986,26 +986,27 @@ describe("ollama setup", () => {
     expect(runtime.log).toHaveBeenCalledWith("Default Ollama model: gemma4:latest");
   });
 
-  it("accepts cloud models in non-interactive mode without pulling", async () => {
-    const fetchMock = createOllamaFetchMock({ tags: [] });
-    vi.stubGlobal("fetch", fetchMock);
-    const runtime = createRuntime();
+  it.each(["kimi-k2.5:cloud", "gpt-oss:120b-cloud"])(
+    "accepts cloud model %s in non-interactive mode without pulling",
+    async (modelId) => {
+      const fetchMock = createOllamaFetchMock({ tags: [] });
+      vi.stubGlobal("fetch", fetchMock);
+      const runtime = createRuntime();
 
-    const result = await configureOllamaNonInteractive({
-      nextConfig: {},
-      opts: {
-        customBaseUrl: "http://127.0.0.1:11434",
-        customModelId: "kimi-k2.5:cloud",
-      },
-      runtime,
-    });
+      const result = await configureOllamaNonInteractive({
+        nextConfig: {},
+        opts: {
+          customBaseUrl: "http://127.0.0.1:11434",
+          customModelId: modelId,
+        },
+        runtime,
+      });
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(result.models?.providers?.ollama?.models?.map((model) => model.id)).toContain(
-      "kimi-k2.5:cloud",
-    );
-    expect(result.agents?.defaults?.model).toEqual({ primary: "ollama/kimi-k2.5:cloud" });
-  });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(result.models?.providers?.ollama?.models?.map((model) => model.id)).toContain(modelId);
+      expect(result.agents?.defaults?.model).toEqual({ primary: `ollama/${modelId}` });
+    },
+  );
 
   it("exits when Ollama is unreachable", async () => {
     const fetchMock = createOllamaFetchMock({

--- a/extensions/ollama/src/setup.ts
+++ b/extensions/ollama/src/setup.ts
@@ -19,10 +19,7 @@ import { applyAgentDefaultModelPrimary } from "openclaw/plugin-sdk/provider-onbo
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime";
 import { WizardCancelledError, type WizardPrompter } from "openclaw/plugin-sdk/setup";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
-import {
-  normalizeLowercaseStringOrEmpty,
-  normalizeOptionalLowercaseString,
-} from "openclaw/plugin-sdk/string-coerce-runtime";
+import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   OLLAMA_CLOUD_BASE_URL,
   OLLAMA_CLOUD_DEFAULT_MODELS,
@@ -37,6 +34,7 @@ import {
   buildOllamaModelDefinition,
   enrichOllamaModelsWithContext,
   fetchOllamaModels,
+  isOllamaCloudModel,
   resolveOllamaApiBase,
   type OllamaModelWithContext,
 } from "./provider-models.js";
@@ -119,10 +117,6 @@ function normalizeOllamaModelName(value: string | undefined): string | undefined
     return normalized || undefined;
   }
   return trimmed;
-}
-
-function isOllamaCloudModel(modelName: string | undefined): boolean {
-  return normalizeOptionalLowercaseString(modelName)?.endsWith(":cloud") === true;
 }
 
 function formatOllamaPullStatus(status: string): { text: string; hidePercent: boolean } {


### PR DESCRIPTION
[AI-assisted]
## What Problem This Solves

Ollama Cloud + Local routes advertise the native context windows of :cloud models, but the local-provider discovery path currently adds a 32,768-token runtime cap to every discovered model. Hosted models routed through a signed-in local Ollama host therefore compact early and forward an unnecessarily small context budget.

## Why This Change Was Made

The existing Ollama cap owner now leaves :cloud model definitions unchanged while retaining the safety cap for genuinely local models. The fix stays in provider model resolution, where contextTokens is introduced, rather than adding configuration workarounds downstream.

## User Impact

Cloud models used through an Ollama Cloud + Local setup retain their advertised context window. Local Ollama models continue to receive the existing 32k runtime cap.

## Evidence

### Provenance

- **Base:** `98742bc2c7f222a05d9c3a7d1622c49e21dec56f`
- **Proof head:** `d70a2b0083f1e55214b90c2e55fb9abbeb836828`
- **Revalidated:** after merging current upstream `main`

### Direct behavior

- `pnpm exec vitest run extensions/ollama/src/provider-models.test.ts --reporter=dot` — 21/21 tests passed with 0 failures and 0 skips. Proves the cap owner leaves a 1,000,000-token :cloud model without contextTokens while local large and small models retain their 32,768- and 16,384-token effective caps. Preserves native contextWindow metadata and existing local-model runtime safeguards.

### Automated verification

- `pnpm exec oxfmt --check extensions/ollama/src/provider-models.ts extensions/ollama/src/provider-models.test.ts` — both changed files matched the repository format. Proves the scoped source and regression test conform to the formatter. Preserves the repository formatting contract.
- `pnpm exec oxlint extensions/ollama/src/provider-models.ts extensions/ollama/src/provider-models.test.ts` — 0 warnings and 0 errors across both changed files. Proves the scoped TypeScript change satisfies the affected lint rules. Preserves the existing static-analysis boundary.
- `git diff --check` — completed with no whitespace errors. Proves the final two-file patch is whitespace-clean. Preserves the locked provider-model and regression-test scope.

### Preserved boundaries

- Local Ollama models with native windows above 32,768 tokens remain capped at 32,768 contextTokens.
- Models with native windows below 32,768 tokens remain capped at their smaller native window.
- Advertised contextWindow metadata remains unchanged for both local and cloud models.

### Proof gap

A credentialed live Cloud + Local request was not run because the focused code profile does not require external Ollama Cloud access. The cap-owner regression directly exercises the resolved model definitions; no end-to-end hosted inference response is claimed.

### Artifacts

- None attached.
