### PR TITLE
feat(ui): inspect chat images in an accessible lightbox

### DIFF
--- a/ui/src/components/image-lightbox.test.ts
+++ b/ui/src/components/image-lightbox.test.ts
@@ -1,0 +1,84 @@
+/* @vitest-environment jsdom */
+
+import { html, nothing, render } from "lit";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getRenderedModalDialog, installDialogPolyfill } from "../test-helpers/modal-dialog.ts";
+import "./image-lightbox.ts";
+
+let container: HTMLDivElement;
+let restoreDialogPolyfill: () => void;
+
+async function renderLightbox() {
+  render(
+    html`<openclaw-image-lightbox
+      src="data:image/png;base64,cG5n"
+      title="Generated lobster"
+    ></openclaw-image-lightbox>`,
+    container,
+  );
+  const modal = container.querySelector("openclaw-image-lightbox");
+  if (!modal) {
+    throw new Error("missing image lightbox");
+  }
+  await modal.updateComplete;
+  const dialogAdapter = modal.shadowRoot?.querySelector("openclaw-modal-dialog");
+  if (!dialogAdapter) {
+    throw new Error("missing modal dialog adapter");
+  }
+  await getRenderedModalDialog((modal.shadowRoot ?? modal) as unknown as HTMLElement);
+  return { modal, dialogAdapter };
+}
+
+describe("openclaw-image-lightbox", () => {
+  beforeEach(() => {
+    restoreDialogPolyfill = installDialogPolyfill();
+    container = document.createElement("div");
+    document.body.append(container);
+  });
+
+  afterEach(() => {
+    render(nothing, container);
+    container.remove();
+    restoreDialogPolyfill();
+  });
+
+  it("renders a labelled large image with original and close actions", async () => {
+    const { modal } = await renderLightbox();
+    const root = modal.shadowRoot;
+
+    expect(root?.querySelector<HTMLImageElement>("img")?.alt).toBe("Generated lobster");
+    expect(root?.querySelector<HTMLImageElement>("img")?.src).toBe("data:image/png;base64,cG5n");
+    expect(root?.querySelector<HTMLAnchorElement>("a")?.href).toBe("data:image/png;base64,cG5n");
+    expect(root?.querySelector<HTMLButtonElement>("button")?.hasAttribute("autofocus")).toBe(true);
+  });
+
+  it("keeps Tab focus within the lightbox actions", async () => {
+    const { modal } = await renderLightbox();
+    const root = modal.shadowRoot;
+    const openOriginal = root?.querySelector<HTMLAnchorElement>(".open-original");
+    const closeButton = root?.querySelector<HTMLButtonElement>(".close");
+    closeButton?.focus();
+
+    closeButton?.dispatchEvent(new KeyboardEvent("keydown", { key: "Tab", bubbles: true }));
+    expect(root?.activeElement).toBe(openOriginal);
+
+    openOriginal?.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Tab", shiftKey: true, bubbles: true }),
+    );
+    expect(root?.activeElement).toBe(closeButton);
+  });
+
+  it("emits one close event for the close button and modal cancellation", async () => {
+    const { modal, dialogAdapter } = await renderLightbox();
+    let closes = 0;
+    modal.addEventListener("image-lightbox-close", () => {
+      closes += 1;
+    });
+
+    modal.shadowRoot?.querySelector<HTMLButtonElement>("button")?.click();
+    expect(closes).toBe(1);
+
+    dialogAdapter.dispatchEvent(new CustomEvent("modal-cancel", { bubbles: true }));
+    expect(closes).toBe(2);
+  });
+});

--- a/ui/src/components/image-lightbox.test.ts
+++ b/ui/src/components/image-lightbox.test.ts
@@ -1,12 +1,15 @@
 /* @vitest-environment jsdom */
 
 import { html, nothing, render } from "lit";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getRenderedModalDialog, installDialogPolyfill } from "../test-helpers/modal-dialog.ts";
 import "./image-lightbox.ts";
 
 let container: HTMLDivElement;
 let restoreDialogPolyfill: () => void;
+let createObjectUrl: ReturnType<typeof vi.fn>;
+let revokeObjectUrl: ReturnType<typeof vi.fn>;
+let fetchImage: ReturnType<typeof vi.fn>;
 
 async function renderLightbox() {
   render(
@@ -32,6 +35,20 @@ async function renderLightbox() {
 describe("openclaw-image-lightbox", () => {
   beforeEach(() => {
     restoreDialogPolyfill = installDialogPolyfill();
+    createObjectUrl = vi.fn(() => "blob:lightbox-original");
+    revokeObjectUrl = vi.fn();
+    fetchImage = vi.fn(async () => ({
+      blob: async () => new Blob(["png"], { type: "image/png" }),
+    }));
+    const NativeUrl = URL;
+    vi.stubGlobal(
+      "URL",
+      class extends NativeUrl {
+        static override createObjectURL = createObjectUrl;
+        static override revokeObjectURL = revokeObjectUrl;
+      },
+    );
+    vi.stubGlobal("fetch", fetchImage);
     container = document.createElement("div");
     document.body.append(container);
   });
@@ -40,6 +57,7 @@ describe("openclaw-image-lightbox", () => {
     render(nothing, container);
     container.remove();
     restoreDialogPolyfill();
+    vi.unstubAllGlobals();
   });
 
   it("renders a labelled large image with original and close actions", async () => {
@@ -48,13 +66,74 @@ describe("openclaw-image-lightbox", () => {
 
     expect(root?.querySelector<HTMLImageElement>("img")?.alt).toBe("Generated lobster");
     expect(root?.querySelector<HTMLImageElement>("img")?.src).toBe("data:image/png;base64,cG5n");
-    expect(root?.querySelector<HTMLAnchorElement>("a")?.href).toBe("data:image/png;base64,cG5n");
+    await vi.waitFor(() =>
+      expect(root?.querySelector<HTMLAnchorElement>("a")?.href).toBe("blob:lightbox-original"),
+    );
+    expect(fetchImage).toHaveBeenCalledTimes(1);
     expect(root?.querySelector<HTMLButtonElement>("button")?.hasAttribute("autofocus")).toBe(true);
+  });
+
+  it("accepts parameters on safe raster MIME types", async () => {
+    fetchImage.mockResolvedValueOnce({
+      blob: async () => new Blob(["png"], { type: "image/png;charset=utf-8" }),
+    });
+    render(
+      html`<openclaw-image-lightbox
+        src="data:image/png;charset=utf-8;base64,cG5n"
+        title="Generated lobster"
+      ></openclaw-image-lightbox>`,
+      container,
+    );
+    const modal = container.querySelector("openclaw-image-lightbox");
+    if (!modal) {
+      throw new Error("missing image lightbox");
+    }
+    await modal.updateComplete;
+
+    await vi.waitFor(() =>
+      expect(modal.shadowRoot?.querySelector<HTMLAnchorElement>(".open-original")?.href).toBe(
+        "blob:lightbox-original",
+      ),
+    );
+  });
+
+  it("releases and recreates the original-image URL across reconnection", async () => {
+    const { modal } = await renderLightbox();
+    await vi.waitFor(() => expect(createObjectUrl).toHaveBeenCalledTimes(1));
+
+    modal.remove();
+
+    expect(revokeObjectUrl).toHaveBeenCalledWith("blob:lightbox-original");
+
+    container.append(modal);
+    await vi.waitFor(() => expect(createObjectUrl).toHaveBeenCalledTimes(2));
+  });
+
+  it("omits the original action for active data image formats", async () => {
+    render(
+      html`<openclaw-image-lightbox
+        src="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg'></svg>"
+        title="Untrusted SVG"
+      ></openclaw-image-lightbox>`,
+      container,
+    );
+    const modal = container.querySelector("openclaw-image-lightbox");
+    if (!modal) {
+      throw new Error("missing image lightbox");
+    }
+    await modal.updateComplete;
+
+    expect(modal.shadowRoot?.querySelector(".open-original")).toBeNull();
+    expect(fetchImage).not.toHaveBeenCalled();
+    expect(createObjectUrl).not.toHaveBeenCalled();
   });
 
   it("keeps Tab focus within the lightbox actions", async () => {
     const { modal } = await renderLightbox();
     const root = modal.shadowRoot;
+    await vi.waitFor(() =>
+      expect(root?.querySelector<HTMLAnchorElement>(".open-original")).toBeTruthy(),
+    );
     const openOriginal = root?.querySelector<HTMLAnchorElement>(".open-original");
     const closeButton = root?.querySelector<HTMLButtonElement>(".close");
     closeButton?.focus();

--- a/ui/src/components/image-lightbox.test.ts
+++ b/ui/src/components/image-lightbox.test.ts
@@ -7,8 +7,8 @@ import "./image-lightbox.ts";
 
 let container: HTMLDivElement;
 let restoreDialogPolyfill: () => void;
-let createObjectUrl: ReturnType<typeof vi.fn>;
-let revokeObjectUrl: ReturnType<typeof vi.fn>;
+let createObjectUrl: ReturnType<typeof vi.fn<(object: Blob | MediaSource) => string>>;
+let revokeObjectUrl: ReturnType<typeof vi.fn<(url: string) => void>>;
 let fetchImage: ReturnType<typeof vi.fn>;
 
 async function renderLightbox() {
@@ -44,8 +44,13 @@ describe("openclaw-image-lightbox", () => {
     vi.stubGlobal(
       "URL",
       class extends NativeUrl {
-        static override createObjectURL = createObjectUrl;
-        static override revokeObjectURL = revokeObjectUrl;
+        static override createObjectURL(object: Blob | MediaSource): string {
+          return createObjectUrl(object);
+        }
+
+        static override revokeObjectURL(url: string): void {
+          revokeObjectUrl(url);
+        }
       },
     );
     vi.stubGlobal("fetch", fetchImage);

--- a/ui/src/components/image-lightbox.ts
+++ b/ui/src/components/image-lightbox.ts
@@ -28,7 +28,7 @@ function dataUrlMimeType(source: string): string | undefined {
   return mediaType === undefined ? undefined : mimeTypeEssence(mediaType);
 }
 
-export class OpenClawImageLightbox extends OpenClawLitElement {
+class OpenClawImageLightbox extends OpenClawLitElement {
   @property() src = "";
   @property() override title = "";
   @query(".open-original") private openOriginal?: HTMLAnchorElement;

--- a/ui/src/components/image-lightbox.ts
+++ b/ui/src/components/image-lightbox.ts
@@ -280,19 +280,25 @@ export class OpenClawImageLightbox extends OpenClawLitElement {
   }
 
   private handleKeydown = (event: KeyboardEvent) => {
-    if (event.key !== "Tab" || !this.closeButton) {
+    const closeButton = this.closeButton;
+    if (event.key !== "Tab" || !closeButton) {
       return;
     }
+    const openOriginal = this.openOriginal;
     const source = event.composedPath()[0];
-    if (!this.openOriginal && source === this.closeButton) {
+    if (!openOriginal) {
+      if (source === closeButton) {
+        event.preventDefault();
+        closeButton.focus();
+      }
+      return;
+    }
+    if (event.shiftKey && source === openOriginal) {
       event.preventDefault();
-      this.closeButton.focus();
-    } else if (event.shiftKey && source === this.openOriginal) {
+      closeButton.focus();
+    } else if (!event.shiftKey && source === closeButton) {
       event.preventDefault();
-      this.closeButton.focus();
-    } else if (!event.shiftKey && source === this.closeButton) {
-      event.preventDefault();
-      this.openOriginal.focus();
+      openOriginal.focus();
     }
   };
 

--- a/ui/src/components/image-lightbox.ts
+++ b/ui/src/components/image-lightbox.ts
@@ -1,0 +1,221 @@
+import { css, html } from "lit";
+import { property, query } from "lit/decorators.js";
+import { t } from "../i18n/index.ts";
+import { OpenClawLitElement } from "../lit/openclaw-element.ts";
+import { icons } from "./icons.ts";
+import "./modal-dialog.ts";
+
+export type ImageLightboxItem = {
+  src: string;
+  title: string;
+  release?: () => void;
+};
+
+export class OpenClawImageLightbox extends OpenClawLitElement {
+  @property() src = "";
+  @property() override title = "";
+  @query(".open-original") private openOriginal?: HTMLAnchorElement;
+  @query(".close") private closeButton?: HTMLButtonElement;
+
+  static override styles = css`
+    :host {
+      display: contents;
+    }
+
+    openclaw-modal-dialog {
+      --openclaw-modal-width: min(1280px, calc(100vw - 40px));
+      --openclaw-modal-max-width: calc(100vw - 40px);
+      --openclaw-modal-max-height: calc(100dvh - 40px);
+    }
+
+    .lightbox {
+      width: min(1280px, calc(100vw - 40px));
+      height: min(900px, calc(100dvh - 40px));
+      display: grid;
+      grid-template-rows: auto minmax(0, 1fr);
+      overflow: hidden;
+      border: 1px solid color-mix(in srgb, var(--border-strong) 80%, transparent);
+      border-radius: var(--radius-lg);
+      background: #07090f;
+      box-shadow: 0 28px 90px rgba(0, 0, 0, 0.6);
+    }
+
+    .header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 16px;
+      min-height: 54px;
+      padding: 10px 12px 10px 18px;
+      border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+      background: rgba(255, 255, 255, 0.04);
+      color: #fff;
+    }
+
+    .title {
+      min-width: 0;
+      overflow: hidden;
+      font-size: 13px;
+      font-weight: 650;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .actions {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      flex: 0 0 auto;
+    }
+
+    .action {
+      min-height: 36px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0 12px;
+      border: 1px solid rgba(255, 255, 255, 0.1);
+      border-radius: var(--radius-md);
+      background: rgba(255, 255, 255, 0.08);
+      color: #fff;
+      font: inherit;
+      font-size: 12px;
+      font-weight: 650;
+      text-decoration: none;
+    }
+
+    .action:hover {
+      border-color: rgba(255, 255, 255, 0.2);
+      background: rgba(255, 255, 255, 0.14);
+    }
+
+    .action:focus-visible {
+      outline: 2px solid #fff;
+      outline-offset: 2px;
+    }
+
+    .close {
+      width: 36px;
+      padding: 0;
+      color: rgba(255, 255, 255, 0.82);
+    }
+
+    .close svg {
+      width: 17px;
+      height: 17px;
+    }
+
+    .stage {
+      min-height: 0;
+      display: grid;
+      place-items: center;
+      padding: 20px;
+      overflow: hidden;
+    }
+
+    .image {
+      display: block;
+      max-width: 100%;
+      max-height: 100%;
+      width: auto;
+      height: auto;
+      border-radius: var(--radius-md);
+      background: rgba(255, 255, 255, 0.04);
+      object-fit: contain;
+    }
+
+    @media (max-width: 720px), (max-height: 520px) and (orientation: landscape) {
+      openclaw-modal-dialog {
+        --openclaw-modal-width: calc(100vw - 24px);
+        --openclaw-modal-max-width: calc(100vw - 24px);
+        --openclaw-modal-max-height: 100dvh;
+      }
+
+      .lightbox {
+        width: calc(100vw - 24px);
+        height: 90dvh;
+        border: 0;
+        border-radius: 0;
+      }
+
+      .header {
+        padding-top: calc(10px + env(safe-area-inset-top));
+        padding-right: calc(12px + env(safe-area-inset-right));
+        padding-left: calc(16px + env(safe-area-inset-left));
+      }
+
+      .stage {
+        padding-right: calc(12px + env(safe-area-inset-right));
+        padding-bottom: calc(12px + env(safe-area-inset-bottom));
+        padding-left: calc(12px + env(safe-area-inset-left));
+      }
+    }
+  `;
+
+  override render() {
+    const title = this.title.trim() || t("chat.imageLightbox.untitled");
+    return html`
+      <openclaw-modal-dialog
+        label=${t("chat.imageLightbox.label", { title })}
+        @modal-cancel=${this.emitClose}
+        @keydown=${this.handleKeydown}
+      >
+        <section class="lightbox">
+          <header class="header">
+            <strong class="title">${title}</strong>
+            <div class="actions">
+              <a class="action open-original" href=${this.src} target="_blank" rel="noreferrer">
+                ${t("chat.imageLightbox.openOriginal")}
+              </a>
+              <button
+                class="action close"
+                type="button"
+                autofocus
+                aria-label=${t("chat.imageLightbox.close")}
+                @click=${this.emitClose}
+              >
+                ${icons.x}
+              </button>
+            </div>
+          </header>
+          <div class="stage">
+            <img class="image" src=${this.src} alt=${title} />
+          </div>
+        </section>
+      </openclaw-modal-dialog>
+    `;
+  }
+
+  private handleKeydown = (event: KeyboardEvent) => {
+    if (event.key !== "Tab" || !this.openOriginal || !this.closeButton) {
+      return;
+    }
+    const source = event.composedPath()[0];
+    if (event.shiftKey && source === this.openOriginal) {
+      event.preventDefault();
+      this.closeButton.focus();
+    } else if (!event.shiftKey && source === this.closeButton) {
+      event.preventDefault();
+      this.openOriginal.focus();
+    }
+  };
+
+  private emitClose = () => {
+    this.dispatchEvent(
+      new CustomEvent("image-lightbox-close", {
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  };
+}
+
+if (!customElements.get("openclaw-image-lightbox")) {
+  customElements.define("openclaw-image-lightbox", OpenClawImageLightbox);
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "openclaw-image-lightbox": OpenClawImageLightbox;
+  }
+}

--- a/ui/src/components/image-lightbox.ts
+++ b/ui/src/components/image-lightbox.ts
@@ -1,5 +1,5 @@
-import { css, html } from "lit";
-import { property, query } from "lit/decorators.js";
+import { css, html, nothing, type PropertyValues } from "lit";
+import { property, query, state } from "lit/decorators.js";
 import { t } from "../i18n/index.ts";
 import { OpenClawLitElement } from "../lit/openclaw-element.ts";
 import { icons } from "./icons.ts";
@@ -11,11 +11,32 @@ export type ImageLightboxItem = {
   release?: () => void;
 };
 
+const SAFE_DATA_IMAGE_BLOB_TYPES = new Set([
+  "image/avif",
+  "image/gif",
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+]);
+
+function mimeTypeEssence(value: string): string {
+  return value.split(";", 1)[0]?.trim().toLowerCase() ?? "";
+}
+
+function dataUrlMimeType(source: string): string | undefined {
+  const mediaType = /^data:([^,]*)/i.exec(source)?.[1];
+  return mediaType === undefined ? undefined : mimeTypeEssence(mediaType);
+}
+
 export class OpenClawImageLightbox extends OpenClawLitElement {
   @property() src = "";
   @property() override title = "";
   @query(".open-original") private openOriginal?: HTMLAnchorElement;
   @query(".close") private closeButton?: HTMLButtonElement;
+  @state() private openOriginalUrl = "";
+
+  private originalBlobUrl = "";
+  private originalUrlRequest = 0;
 
   static override styles = css`
     :host {
@@ -152,6 +173,25 @@ export class OpenClawImageLightbox extends OpenClawLitElement {
     }
   `;
 
+  override connectedCallback() {
+    super.connectedCallback();
+    if (this.hasUpdated) {
+      void this.resolveOriginalUrl();
+    }
+  }
+
+  override disconnectedCallback() {
+    this.originalUrlRequest += 1;
+    this.revokeOriginalBlobUrl();
+    super.disconnectedCallback();
+  }
+
+  protected override updated(changed: PropertyValues<this>) {
+    if (changed.has("src")) {
+      void this.resolveOriginalUrl();
+    }
+  }
+
   override render() {
     const title = this.title.trim() || t("chat.imageLightbox.untitled");
     return html`
@@ -164,9 +204,18 @@ export class OpenClawImageLightbox extends OpenClawLitElement {
           <header class="header">
             <strong class="title">${title}</strong>
             <div class="actions">
-              <a class="action open-original" href=${this.src} target="_blank" rel="noreferrer">
-                ${t("chat.imageLightbox.openOriginal")}
-              </a>
+              ${this.openOriginalUrl
+                ? html`
+                    <a
+                      class="action open-original"
+                      href=${this.openOriginalUrl}
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      ${t("chat.imageLightbox.openOriginal")}
+                    </a>
+                  `
+                : nothing}
               <button
                 class="action close"
                 type="button"
@@ -186,12 +235,59 @@ export class OpenClawImageLightbox extends OpenClawLitElement {
     `;
   }
 
+  private revokeOriginalBlobUrl() {
+    if (!this.originalBlobUrl) {
+      return;
+    }
+    URL.revokeObjectURL(this.originalBlobUrl);
+    this.originalBlobUrl = "";
+  }
+
+  private async resolveOriginalUrl() {
+    const request = ++this.originalUrlRequest;
+    this.revokeOriginalBlobUrl();
+    const source = this.src.trim();
+    if (!source) {
+      this.openOriginalUrl = "";
+      return;
+    }
+    if (source.slice(0, 5).toLowerCase() !== "data:") {
+      this.openOriginalUrl = source;
+      return;
+    }
+    this.openOriginalUrl = "";
+    const sourceType = dataUrlMimeType(source);
+    // Top-level blob documents inherit the app origin. Only inert raster formats
+    // may be promoted from opaque-origin data URLs into an original-image link.
+    if (!sourceType || !SAFE_DATA_IMAGE_BLOB_TYPES.has(sourceType)) {
+      return;
+    }
+    try {
+      const response = await fetch(source);
+      const blob = await response.blob();
+      if (
+        !this.isConnected ||
+        request !== this.originalUrlRequest ||
+        !SAFE_DATA_IMAGE_BLOB_TYPES.has(mimeTypeEssence(blob.type))
+      ) {
+        return;
+      }
+      this.originalBlobUrl = URL.createObjectURL(blob);
+      this.openOriginalUrl = this.originalBlobUrl;
+    } catch {
+      // The image remains viewable inline; omit an unusable original-link action.
+    }
+  }
+
   private handleKeydown = (event: KeyboardEvent) => {
-    if (event.key !== "Tab" || !this.openOriginal || !this.closeButton) {
+    if (event.key !== "Tab" || !this.closeButton) {
       return;
     }
     const source = event.composedPath()[0];
-    if (event.shiftKey && source === this.openOriginal) {
+    if (!this.openOriginal && source === this.closeButton) {
+      event.preventDefault();
+      this.closeButton.focus();
+    } else if (event.shiftKey && source === this.openOriginal) {
       event.preventDefault();
       this.closeButton.focus();
     } else if (!event.shiftKey && source === this.closeButton) {

--- a/ui/src/components/markdown-assistant-transcript.ts
+++ b/ui/src/components/markdown-assistant-transcript.ts
@@ -15,17 +15,31 @@ function renderAssistantTranscriptRoleMarker(
   return `${ROLE_MARKER_OPEN}${escapeHtml(text)}${ROLE_MARKER_CLOSE}`;
 }
 
-function isImageWithinLink(tokens: readonly { type: string }[], index: number): boolean {
+const linkedImageIndicesByTokens = new WeakMap<readonly { type: string }[], ReadonlySet<number>>();
+
+function linkedImageIndices(tokens: readonly { type: string }[]): ReadonlySet<number> {
+  const cached = linkedImageIndicesByTokens.get(tokens);
+  if (cached) {
+    return cached;
+  }
+  const linked = new Set<number>();
   let linkDepth = 0;
-  for (let tokenIndex = 0; tokenIndex < index; tokenIndex += 1) {
-    const tokenType = tokens[tokenIndex]?.type;
+  for (let index = 0; index < tokens.length; index += 1) {
+    const tokenType = tokens[index]?.type;
     if (tokenType === "link_open") {
       linkDepth += 1;
     } else if (tokenType === "link_close") {
       linkDepth = Math.max(0, linkDepth - 1);
+    } else if (tokenType === "image" && linkDepth > 0) {
+      linked.add(index);
     }
   }
-  return linkDepth > 0;
+  linkedImageIndicesByTokens.set(tokens, linked);
+  return linked;
+}
+
+function isImageWithinLink(tokens: readonly { type: string }[], index: number): boolean {
+  return linkedImageIndices(tokens).has(index);
 }
 
 function renderAssistantTranscriptRoleImageLabel(

--- a/ui/src/components/markdown-assistant-transcript.ts
+++ b/ui/src/components/markdown-assistant-transcript.ts
@@ -70,9 +70,10 @@ export function installAssistantTranscriptRoleImageRenderer(
     normalizeLabel: (value: string) => string;
     assistantLabel: () => string;
     openImageLabel: (alt: string, hasAlt: boolean) => string;
+    interactiveImages: (env: unknown) => boolean;
   },
 ): void {
-  md.renderer.rules.image = (tokens, index) => {
+  md.renderer.rules.image = (tokens, index, _rendererOptions, env) => {
     const token = tokens[index];
     if (!token) {
       return "";
@@ -89,9 +90,10 @@ export function installAssistantTranscriptRoleImageRenderer(
     }
     const image = `<img class="markdown-inline-image" src="${options.escapeHtml(src)}" alt="${options.escapeHtml(alt)}">`;
     const linkedImage = isImageWithinLink(tokens, index);
-    const interactiveImage = linkedImage
-      ? image
-      : `<button class="markdown-inline-image-button" type="button" aria-label="${options.escapeHtml(options.openImageLabel(alt, token.content.trim().length > 0))}">${image}</button>`;
+    const interactiveImage =
+      linkedImage || !options.interactiveImages(env)
+        ? image
+        : `<button class="markdown-inline-image-button" type="button" aria-label="${options.escapeHtml(options.openImageLabel(alt, token.content.trim().length > 0))}">${image}</button>`;
     return roleMeta
       ? `${renderAssistantTranscriptRoleMarker(`${options.assistantLabel()}:`, options.escapeHtml)} ${interactiveImage}`
       : interactiveImage;

--- a/ui/src/components/markdown-assistant-transcript.ts
+++ b/ui/src/components/markdown-assistant-transcript.ts
@@ -15,6 +15,19 @@ function renderAssistantTranscriptRoleMarker(
   return `${ROLE_MARKER_OPEN}${escapeHtml(text)}${ROLE_MARKER_CLOSE}`;
 }
 
+function isImageWithinLink(tokens: readonly { type: string }[], index: number): boolean {
+  let linkDepth = 0;
+  for (let tokenIndex = 0; tokenIndex < index; tokenIndex += 1) {
+    const tokenType = tokens[tokenIndex]?.type;
+    if (tokenType === "link_open") {
+      linkDepth += 1;
+    } else if (tokenType === "link_close") {
+      linkDepth = Math.max(0, linkDepth - 1);
+    }
+  }
+  return linkDepth > 0;
+}
+
 function renderAssistantTranscriptRoleImageLabel(
   text: string,
   spans: ReadonlyArray<{ start: number; end: number }>,
@@ -56,6 +69,7 @@ export function installAssistantTranscriptRoleImageRenderer(
     isInlineDataImage: (src: string) => boolean;
     normalizeLabel: (value: string) => string;
     assistantLabel: () => string;
+    openImageLabel: (alt: string, hasAlt: boolean) => string;
   },
 ): void {
   md.renderer.rules.image = (tokens, index) => {
@@ -74,9 +88,13 @@ export function installAssistantTranscriptRoleImageRenderer(
         : options.escapeHtml(alt);
     }
     const image = `<img class="markdown-inline-image" src="${options.escapeHtml(src)}" alt="${options.escapeHtml(alt)}">`;
+    const linkedImage = isImageWithinLink(tokens, index);
+    const interactiveImage = linkedImage
+      ? image
+      : `<button class="markdown-inline-image-button" type="button" aria-label="${options.escapeHtml(options.openImageLabel(alt, token.content.trim().length > 0))}">${image}</button>`;
     return roleMeta
-      ? `${renderAssistantTranscriptRoleMarker(`${options.assistantLabel()}:`, options.escapeHtml)} ${image}`
-      : image;
+      ? `${renderAssistantTranscriptRoleMarker(`${options.assistantLabel()}:`, options.escapeHtml)} ${interactiveImage}`
+      : interactiveImage;
   };
 }
 

--- a/ui/src/components/markdown-render-options.ts
+++ b/ui/src/components/markdown-render-options.ts
@@ -4,6 +4,7 @@ export type MarkdownRenderOptions = {
   assistantTranscriptRoleHeaders?: boolean;
   codeBlockChrome?: MarkdownCodeBlockChrome;
   fileLinks?: boolean;
+  interactiveImages?: boolean;
 };
 
 export type MarkdownRenderEnv = Required<MarkdownRenderOptions>;
@@ -15,5 +16,6 @@ export function normalizeMarkdownRenderOptions(
     assistantTranscriptRoleHeaders: options.assistantTranscriptRoleHeaders ?? false,
     codeBlockChrome: options.codeBlockChrome ?? "copy",
     fileLinks: options.fileLinks ?? false,
+    interactiveImages: options.interactiveImages ?? false,
   };
 }

--- a/ui/src/components/markdown.test.ts
+++ b/ui/src/components/markdown.test.ts
@@ -395,7 +395,7 @@ describe("toSanitizedMarkdownHtml", () => {
     it("preserves base64 data URI images (#15437)", () => {
       const html = toSanitizedMarkdownHtml("![Chart](data:image/png;base64,iVBORw0KGgo=)");
       expect(html).toBe(
-        '<p><button class="markdown-inline-image-button" type="button" aria-label="Open image Chart"><img class="markdown-inline-image" src="data:image/png;base64,iVBORw0KGgo=" alt="Chart"></button></p>\n',
+        '<p><img class="markdown-inline-image" src="data:image/png;base64,iVBORw0KGgo=" alt="Chart"></p>\n',
       );
     });
 
@@ -403,6 +403,7 @@ describe("toSanitizedMarkdownHtml", () => {
       const fragment = htmlFragment(
         toSanitizedMarkdownHtml(
           "[![Preview](data:image/png;base64,iVBORw0KGgo=)](https://example.com/full.png)",
+          { interactiveImages: true },
         ),
       );
 
@@ -414,6 +415,7 @@ describe("toSanitizedMarkdownHtml", () => {
       const fragment = htmlFragment(
         toSanitizedMarkdownHtml(
           "[Before ![Preview](data:image/png;base64,iVBORw0KGgo=) after](https://example.com/full.png)",
+          { interactiveImages: true },
         ),
       );
 
@@ -423,7 +425,9 @@ describe("toSanitizedMarkdownHtml", () => {
 
     it("labels unlabeled inline data image buttons", () => {
       const fragment = htmlFragment(
-        toSanitizedMarkdownHtml("![](data:image/png;base64,iVBORw0KGgo=)"),
+        toSanitizedMarkdownHtml("![](data:image/png;base64,iVBORw0KGgo=)", {
+          interactiveImages: true,
+        }),
       );
 
       expect(

--- a/ui/src/components/markdown.test.ts
+++ b/ui/src/components/markdown.test.ts
@@ -395,8 +395,40 @@ describe("toSanitizedMarkdownHtml", () => {
     it("preserves base64 data URI images (#15437)", () => {
       const html = toSanitizedMarkdownHtml("![Chart](data:image/png;base64,iVBORw0KGgo=)");
       expect(html).toBe(
-        '<p><img class="markdown-inline-image" src="data:image/png;base64,iVBORw0KGgo=" alt="Chart"></p>\n',
+        '<p><button class="markdown-inline-image-button" type="button" aria-label="Open image Chart"><img class="markdown-inline-image" src="data:image/png;base64,iVBORw0KGgo=" alt="Chart"></button></p>\n',
       );
+    });
+
+    it("keeps linked data images under their authored link", () => {
+      const fragment = htmlFragment(
+        toSanitizedMarkdownHtml(
+          "[![Preview](data:image/png;base64,iVBORw0KGgo=)](https://example.com/full.png)",
+        ),
+      );
+
+      expect(fragment.querySelector("a > img.markdown-inline-image")).not.toBeNull();
+      expect(fragment.querySelector("a > button")).toBeNull();
+    });
+
+    it("keeps data images inside rich Markdown links under the link", () => {
+      const fragment = htmlFragment(
+        toSanitizedMarkdownHtml(
+          "[Before ![Preview](data:image/png;base64,iVBORw0KGgo=) after](https://example.com/full.png)",
+        ),
+      );
+
+      expect(fragment.querySelector("a img.markdown-inline-image")).not.toBeNull();
+      expect(fragment.querySelector("a button")).toBeNull();
+    });
+
+    it("labels unlabeled inline data image buttons", () => {
+      const fragment = htmlFragment(
+        toSanitizedMarkdownHtml("![](data:image/png;base64,iVBORw0KGgo=)"),
+      );
+
+      expect(
+        fragment.querySelector("button.markdown-inline-image-button")?.getAttribute("aria-label"),
+      ).toBe("Open image Image");
     });
 
     it("keeps inline data images while marking assistant-authored role alt text", () => {

--- a/ui/src/components/markdown.test.ts
+++ b/ui/src/components/markdown.test.ts
@@ -423,6 +423,18 @@ describe("toSanitizedMarkdownHtml", () => {
       expect(fragment.querySelector("a button")).toBeNull();
     });
 
+    it("tracks linked and standalone images across one inline token stream", () => {
+      const fragment = htmlFragment(
+        toSanitizedMarkdownHtml(
+          "[![Linked one](data:image/png;base64,QQ==)](https://example.com/one) ![Standalone](data:image/png;base64,Qg==) [![Linked two](data:image/png;base64,Qw==)](https://example.com/two)",
+          { interactiveImages: true },
+        ),
+      );
+
+      expect(fragment.querySelectorAll("a img.markdown-inline-image")).toHaveLength(2);
+      expect(fragment.querySelectorAll("button.markdown-inline-image-button")).toHaveLength(1);
+    });
+
     it("labels unlabeled inline data image buttons", () => {
       const fragment = htmlFragment(
         toSanitizedMarkdownHtml("![](data:image/png;base64,iVBORw0KGgo=)", {

--- a/ui/src/components/markdown.ts
+++ b/ui/src/components/markdown.ts
@@ -1274,6 +1274,10 @@ installAssistantTranscriptRoleImageRenderer(md, {
   isInlineDataImage: (src) => INLINE_DATA_IMAGE_RE.test(src),
   normalizeLabel: normalizeMarkdownImageLabel,
   assistantLabel: () => t("sessionsView.assistant"),
+  openImageLabel: (alt, hasAlt) =>
+    t("chat.imageLightbox.open", {
+      title: hasAlt ? alt : t("chat.imageLightbox.untitled"),
+    }),
 });
 
 // Override fenced code blocks with copy button + JSON collapse

--- a/ui/src/components/markdown.ts
+++ b/ui/src/components/markdown.ts
@@ -1278,6 +1278,8 @@ installAssistantTranscriptRoleImageRenderer(md, {
     t("chat.imageLightbox.open", {
       title: hasAlt ? alt : t("chat.imageLightbox.untitled"),
     }),
+  interactiveImages: (env) =>
+    (env as Partial<MarkdownRenderEnv> | undefined)?.interactiveImages === true,
 });
 
 // Override fenced code blocks with copy button + JSON collapse
@@ -1349,7 +1351,7 @@ export function toSanitizedMarkdownHtml(
   }
   const renderInput = isMarkdownBlockArtText(rawInput) ? rawInput : input;
   const cacheable = input.length <= MARKDOWN_CACHE_MAX_CHARS;
-  const cacheKey = `${i18n.getLocale()}\0${renderOptions.assistantTranscriptRoleHeaders}\0${renderOptions.codeBlockChrome}\0${renderOptions.fileLinks}\0${renderInput}`;
+  const cacheKey = `${i18n.getLocale()}\0${renderOptions.assistantTranscriptRoleHeaders}\0${renderOptions.codeBlockChrome}\0${renderOptions.fileLinks}\0${renderOptions.interactiveImages}\0${renderInput}`;
   if (cacheable) {
     const cached = getCachedMarkdown(cacheKey);
     if (cached !== null) {

--- a/ui/src/components/modal-dialog.ts
+++ b/ui/src/components/modal-dialog.ts
@@ -29,6 +29,7 @@ export class OpenClawModalDialog extends OpenClawLitElement {
     }
 
     wa-dialog::part(dialog) {
+      max-width: var(--openclaw-modal-max-width, calc(100vw - 48px));
       max-height: var(--openclaw-modal-max-height, calc(100dvh - 48px));
       padding: 0;
       border: 0;

--- a/ui/src/e2e/chat-image-lightbox.e2e.test.ts
+++ b/ui/src/e2e/chat-image-lightbox.e2e.test.ts
@@ -121,6 +121,7 @@ describeControlUiE2e("Control UI image lightbox", () => {
       const closeButton = page.getByRole("button", { name: "Close image preview" });
       const openOriginal = page.getByRole("link", { name: "Open original" });
       await openOriginal.waitFor({ state: "visible" });
+      await expect.poll(() => openOriginal.getAttribute("href")).toMatch(/^blob:/);
       const focusIsInsideLightbox = () =>
         page.locator("openclaw-image-lightbox").evaluate((lightbox) => {
           let active: Element | null = document.activeElement;
@@ -151,6 +152,12 @@ describeControlUiE2e("Control UI image lightbox", () => {
       const desktopBox = await page.locator("openclaw-image-lightbox .lightbox").boundingBox();
       expect(desktopBox?.width ?? 0).toBeGreaterThan(1000);
       expect(desktopBox?.height ?? 0).toBeGreaterThan(700);
+      const originalPopup = page.waitForEvent("popup");
+      await openOriginal.click();
+      const originalPage = await originalPopup;
+      await expect.poll(() => originalPage.url()).toMatch(/^blob:/);
+      await originalPage.close();
+      await closeButton.focus();
       await page.keyboard.press("Tab");
       await expect.poll(focusIsInsideLightbox).toBe(true);
       await page.keyboard.press("Shift+Tab");

--- a/ui/src/e2e/chat-image-lightbox.e2e.test.ts
+++ b/ui/src/e2e/chat-image-lightbox.e2e.test.ts
@@ -1,0 +1,216 @@
+import { mkdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import { chromium, type Browser, type BrowserContext } from "playwright";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  canRunPlaywrightChromium,
+  installMockGateway,
+  resolvePlaywrightChromiumExecutablePath,
+  startControlUiE2eServer,
+  type ControlUiE2eServer,
+} from "../test-helpers/control-ui-e2e.ts";
+
+const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
+const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
+const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
+const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
+const proofDir = path.join(process.cwd(), ".artifacts", "control-ui-e2e", "image-lightbox");
+
+let server: ControlUiE2eServer;
+let browser: Browser;
+const openContexts = new Set<BrowserContext>();
+
+async function newContext(options: Parameters<Browser["newContext"]>[0]) {
+  const context = await browser.newContext(options);
+  openContexts.add(context);
+  return context;
+}
+
+async function closeContext(context: BrowserContext) {
+  openContexts.delete(context);
+  await context.close().catch(() => {});
+}
+
+describeControlUiE2e("Control UI image lightbox", () => {
+  beforeAll(async () => {
+    if (!chromiumAvailable) {
+      throw new Error(`Playwright Chromium is unavailable at ${chromiumExecutablePath}`);
+    }
+    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
+    server = await startControlUiE2eServer();
+  });
+
+  afterEach(async () => {
+    await Promise.all([...openContexts].map((context) => closeContext(context)));
+  });
+
+  afterAll(async () => {
+    await Promise.all([...openContexts].map((context) => closeContext(context)));
+    await browser?.close();
+    await server?.close();
+  });
+
+  it("opens transcript and sidebar images in one accessible modal", async () => {
+    const banner = await readFile(path.join(process.cwd(), "docs/assets/openclaw-banner-dark.png"));
+    const bannerBase64 = banner.toString("base64");
+    const dataUrl = `data:image/png;base64,${bannerBase64}`;
+    const context = await newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1440 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      historyMessages: [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "image",
+              url: dataUrl,
+              alt: "OpenClaw banner",
+            },
+          ],
+          timestamp: Date.now(),
+        },
+      ],
+      methodResponses: {
+        "artifacts.list": {
+          artifacts: [
+            {
+              download: { mode: "bytes" },
+              id: "artifact-image-lightbox",
+              mimeType: "image/png",
+              sizeBytes: banner.byteLength,
+              title: "openclaw-banner.png",
+              type: "image",
+            },
+          ],
+        },
+        "artifacts.download": {
+          artifact: {
+            id: "artifact-image-lightbox",
+            mimeType: "image/png",
+            sizeBytes: banner.byteLength,
+            title: "openclaw-banner.png",
+            type: "image",
+          },
+          data: bannerBase64,
+          encoding: "base64",
+        },
+        "sessions.files.list": {
+          browser: { entries: [], path: "" },
+          files: [],
+          root: "/workspace",
+          sessionKey: "main",
+        },
+      },
+    });
+
+    try {
+      await page.goto(`${server.baseUrl}chat`);
+      await gateway.waitForRequest("chat.startup");
+
+      const transcriptTrigger = page.getByRole("button", { name: "Open image OpenClaw banner" });
+      await transcriptTrigger.waitFor({ state: "visible", timeout: 10_000 });
+      await transcriptTrigger.click();
+
+      const dialog = page.getByRole("dialog", { name: "Image preview: OpenClaw banner" });
+      await dialog.waitFor({ state: "visible" });
+      const closeButton = page.getByRole("button", { name: "Close image preview" });
+      const openOriginal = page.getByRole("link", { name: "Open original" });
+      await openOriginal.waitFor({ state: "visible" });
+      const focusIsInsideLightbox = () =>
+        page.locator("openclaw-image-lightbox").evaluate((lightbox) => {
+          let active: Element | null = document.activeElement;
+          while (active instanceof HTMLElement && active.shadowRoot?.activeElement) {
+            active = active.shadowRoot.activeElement;
+          }
+          let node: Node | null = active;
+          while (node) {
+            if (node === lightbox) {
+              return true;
+            }
+            const root = node.getRootNode();
+            node = root instanceof ShadowRoot ? root.host : node.parentNode;
+          }
+          return false;
+        });
+      await expect
+        .poll(() => closeButton.evaluate((element) => element.matches(":focus")))
+        .toBe(true);
+      const displayedImage = page.getByAltText("OpenClaw banner").last();
+      await expect
+        .poll(() =>
+          displayedImage.evaluate((image) =>
+            image instanceof HTMLImageElement && image.complete ? image.naturalWidth : 0,
+          ),
+        )
+        .toBeGreaterThan(0);
+      const desktopBox = await page.locator("openclaw-image-lightbox .lightbox").boundingBox();
+      expect(desktopBox?.width ?? 0).toBeGreaterThan(1000);
+      expect(desktopBox?.height ?? 0).toBeGreaterThan(700);
+      await page.keyboard.press("Tab");
+      await expect.poll(focusIsInsideLightbox).toBe(true);
+      await page.keyboard.press("Shift+Tab");
+      await expect.poll(focusIsInsideLightbox).toBe(true);
+      await page.keyboard.press("Escape");
+      await expect.poll(() => dialog.count()).toBe(0);
+      await expect
+        .poll(() => transcriptTrigger.evaluate((element) => element.matches(":focus")))
+        .toBe(true);
+
+      await page.locator(".chat-workspace-toggle").click();
+      const artifactRow = page.locator(".chat-workspace-rail__file-open", {
+        hasText: "openclaw-banner.png",
+      });
+      await artifactRow.waitFor({ state: "visible", timeout: 10_000 });
+      await artifactRow.click();
+      const sidebarTrigger = page.getByRole("button", {
+        name: "Open image openclaw-banner.png",
+      });
+      await sidebarTrigger.waitFor({ state: "visible", timeout: 10_000 });
+
+      if (captureUiProofEnabled) {
+        await mkdir(proofDir, { recursive: true });
+        await page.screenshot({
+          fullPage: true,
+          path: path.join(proofDir, "01-sidebar-image.png"),
+        });
+      }
+
+      await sidebarTrigger.click();
+      const sidebarDialog = page.getByRole("dialog", {
+        name: "Image preview: openclaw-banner.png",
+      });
+      await sidebarDialog.waitFor({ state: "visible" });
+      if (captureUiProofEnabled) {
+        await page.screenshot({
+          fullPage: true,
+          path: path.join(proofDir, "02-sidebar-lightbox.png"),
+        });
+      }
+      await page.getByRole("button", { name: "Close image preview" }).click();
+      await expect.poll(() => sidebarDialog.count()).toBe(0);
+      await expect
+        .poll(() => sidebarTrigger.evaluate((element) => element.matches(":focus")))
+        .toBe(true);
+
+      await page.setViewportSize({ height: 844, width: 390 });
+      await sidebarTrigger.click();
+      await sidebarDialog.waitFor({ state: "visible" });
+      const mobileBox = await page.locator("openclaw-image-lightbox .lightbox").boundingBox();
+      const mobileViewport = await page.evaluate(() => ({
+        height: window.innerHeight,
+        width: window.innerWidth,
+      }));
+      expect((mobileBox?.width ?? 0) / mobileViewport.width).toBeGreaterThanOrEqual(0.75);
+      expect((mobileBox?.height ?? 0) / mobileViewport.height).toBeGreaterThanOrEqual(0.65);
+      await page.keyboard.press("Escape");
+      await expect.poll(() => sidebarDialog.count()).toBe(0);
+    } finally {
+      await closeContext(context);
+    }
+  });
+});

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -3974,6 +3974,13 @@ export const en: TranslationMap = {
       expired: "Expired",
       cancelled: "Cancelled",
     },
+    imageLightbox: {
+      label: "Image preview: {title}",
+      open: "Open image {title}",
+      openOriginal: "Open original",
+      close: "Close image preview",
+      untitled: "Image",
+    },
     messages: {
       activity: "Activity",
       copySelection: "Copy",

--- a/ui/src/pages/chat/chat-pane.ts
+++ b/ui/src/pages/chat/chat-pane.ts
@@ -3691,6 +3691,10 @@ class ChatPane extends OpenClawLightDomElement {
         }
         state.handleCloseSidebar();
       },
+      imageLightbox: state.imageLightbox,
+      onRequestOpenImage: state.beginImageOpen,
+      onOpenImage: state.handleOpenImage,
+      onCloseImage: state.handleCloseImage,
       onSplitRatioChange: state.handleSplitRatioChange,
       assistantName: state.assistantName,
       assistantAvatar: state.assistantAvatar,

--- a/ui/src/pages/chat/chat-state.test.ts
+++ b/ui/src/pages/chat/chat-state.test.ts
@@ -1,6 +1,7 @@
 import type { ReactiveController, ReactiveControllerHost } from "lit";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as assistantIdentity from "../../app/assistant-identity.ts";
+import type { ApplicationContext } from "../../app/context.ts";
 import { createInitialUserMessageHandoff } from "../../app/initial-user-message-handoff.ts";
 import {
   buildFallbackSlashCommands,
@@ -17,6 +18,7 @@ import {
 } from "./chat-queue.ts";
 import {
   ChatStateController,
+  createPageState,
   handlePageGatewayEvent,
   refreshChatMetadata,
   resetChatStateForRouteSession,
@@ -592,6 +594,52 @@ describe("session pull request refresh", () => {
     });
 
     expect(refreshSessionPullRequests).not.toHaveBeenCalled();
+  });
+});
+
+describe("image lightbox lifecycle", () => {
+  it("invalidates immediately when beginning a deferred image open", () => {
+    const invalidate = vi.fn();
+    const context = {
+      agents: {
+        state: { agentsList: null },
+        adoptList: vi.fn(),
+      },
+      agentSelection: { state: { selectedId: "main" } },
+      basePath: "",
+      config: {
+        current: {
+          allowExternalEmbedUrls: false,
+          assistantIdentity: { name: "Assistant" },
+          chatMessageMaxWidth: null,
+          embedSandboxMode: "scripts",
+          localMediaPreviewRoots: [],
+        },
+      },
+      initialUserMessage: createInitialUserMessageHandoff(),
+      sessions: {},
+    } as unknown as ApplicationContext;
+    const state = createPageState(
+      context,
+      {
+        invalidate,
+        afterCommit: () => () => {},
+      },
+      { querySelector: () => null },
+    );
+    const release = vi.fn();
+    state.imageLightbox = {
+      src: "blob:managed-image",
+      title: "Generated image",
+      release,
+    };
+
+    const requestVersion = state.beginImageOpen();
+
+    expect(requestVersion).toBe(1);
+    expect(state.imageLightbox).toBeNull();
+    expect(release).toHaveBeenCalledOnce();
+    expect(invalidate).toHaveBeenCalledOnce();
   });
 });
 

--- a/ui/src/pages/chat/chat-state.test.ts
+++ b/ui/src/pages/chat/chat-state.test.ts
@@ -612,6 +612,8 @@ describe("route composer fallback", () => {
       chatQueueByScope: {},
       chatMessages: [],
       chatMessagesBySession: new Map(),
+      imageLightbox: null,
+      imageLightboxRequestVersion: 0,
       chatAttachments: [
         {
           id: "staged-image",
@@ -633,6 +635,21 @@ describe("route composer fallback", () => {
     } as unknown as ChatPageHost;
     return { resetChatInputHistoryNavigation, resetChatScroll, state };
   }
+
+  it("releases the active image lightbox on a route switch", () => {
+    const { state } = createRouteState("");
+    const release = vi.fn();
+    state.imageLightbox = {
+      src: "blob:managed-image",
+      title: "Generated image",
+      release,
+    };
+
+    resetChatStateForRouteSession(state, "agent:main:second");
+
+    expect(release).toHaveBeenCalledTimes(1);
+    expect(state.imageLightbox).toBeNull();
+  });
 
   it("restores one atomic history snapshot when returning to a session", () => {
     vi.stubGlobal("sessionStorage", createStorageMock());

--- a/ui/src/pages/chat/chat-state.ts
+++ b/ui/src/pages/chat/chat-state.ts
@@ -21,6 +21,7 @@ import {
 } from "../../app/settings.ts";
 import { fireFirstReplyConfetti } from "../../components/confetti.ts";
 import { isGitHubPullRequestLink } from "../../components/github-link-hovercard.ts";
+import type { ImageLightboxItem } from "../../components/image-lightbox.ts";
 import { isRenderableControlUiAvatarUrl } from "../../lib/avatar.ts";
 import type { ChatAttachment, ChatQueueItem } from "../../lib/chat/chat-types.ts";
 import { extractText } from "../../lib/chat/message-extract.ts";
@@ -28,6 +29,7 @@ import { retirePendingChatSideQuestion, type ChatSideResult } from "../../lib/ch
 import type { EmbedSandboxMode } from "../../lib/chat/tool-display.ts";
 import { isGatewayMethodAdvertised } from "../../lib/gateway-methods.ts";
 import { loadModelAuthStatus } from "../../lib/model-auth.ts";
+import { resolveSafeExternalUrl } from "../../lib/open-external-url.ts";
 import { scopedAgentParamsForSession, type SessionCapability } from "../../lib/sessions/index.ts";
 import {
   readSessionChangedEvent,
@@ -178,6 +180,20 @@ type ChatComposerRouteResetResult = {
   restoredStorageFailure: boolean;
 };
 
+function clearImageLightbox(state: Pick<ChatPageHost, "imageLightbox">) {
+  const item = state.imageLightbox;
+  state.imageLightbox = null;
+  item?.release?.();
+}
+
+function invalidateImageLightbox(
+  state: Pick<ChatPageHost, "imageLightbox" | "imageLightboxRequestVersion">,
+) {
+  state.imageLightboxRequestVersion += 1;
+  clearImageLightbox(state);
+  return state.imageLightboxRequestVersion;
+}
+
 export type ChatPageHost = ChatHost &
   ChatState &
   ChatRealtimeState &
@@ -268,6 +284,8 @@ export type ChatPageHost = ChatHost &
     chatScrollToEnd?: (options: { behavior?: ScrollBehavior }) => void;
     sidebarOpen: boolean;
     sidebarContent: SidebarContent | null;
+    imageLightbox: ImageLightboxItem | null;
+    imageLightboxRequestVersion: number;
     splitRatio: number;
     querySelector: (selectors: string) => Element | null;
     renderLifecycle: RenderLifecycle;
@@ -293,6 +311,9 @@ export type ChatPageHost = ChatHost &
     steerQueuedChatMessage: (id: string) => Promise<void>;
     handleOpenSidebar: (content: Parameters<SessionWorkspaceHost["handleOpenSidebar"]>[0]) => void;
     handleCloseSidebar: () => void;
+    beginImageOpen: () => number;
+    handleOpenImage: (item: ImageLightboxItem, requestVersion?: number) => void;
+    handleCloseImage: () => void;
     handleSplitRatioChange: (ratio: number) => void;
     announceSessionSwitch?: (sessionKey: string, label: string) => void;
     createChatSession?: () => Promise<boolean>;
@@ -513,6 +534,7 @@ export function resetChatStateForRouteSession(
   if (state.sidebarContent?.kind === "session-discussion") {
     state.sidebarContent = { ...state.sidebarContent, sessionKey };
   }
+  invalidateImageLightbox(state);
   state.selectedChatSessionArchived =
     state.sessionsResult?.sessions.some(
       (row) => row.archived === true && areUiSessionKeysEquivalent(row.key, sessionKey),
@@ -1345,6 +1367,8 @@ export function createPageState(
     chatProgrammaticScrollTarget: 0,
     sidebarOpen: false,
     sidebarContent: null,
+    imageLightbox: null,
+    imageLightboxRequestVersion: 0,
     splitRatio: settings.splitRatio,
     toolStreamById: new Map<string, ToolStreamEntry>(),
     toolStreamOrder: [] as string[],
@@ -1430,6 +1454,27 @@ export function createPageState(
   };
   state.handleCloseSidebar = () => {
     state.sidebarOpen = false;
+    renderLifecycle.invalidate();
+  };
+  state.beginImageOpen = () => invalidateImageLightbox(state);
+  state.handleOpenImage = (item, requestVersion) => {
+    const activeRequestVersion = requestVersion ?? state.beginImageOpen();
+    if (activeRequestVersion !== state.imageLightboxRequestVersion) {
+      item.release?.();
+      return;
+    }
+    const safeSrc = resolveSafeExternalUrl(item.src, window.location.href, {
+      allowDataImage: true,
+    });
+    if (!safeSrc) {
+      item.release?.();
+      return;
+    }
+    state.imageLightbox = { ...item, src: safeSrc };
+    renderLifecycle.invalidate();
+  };
+  state.handleCloseImage = () => {
+    invalidateImageLightbox(state);
     renderLifecycle.invalidate();
   };
   state.handleSplitRatioChange = (ratio) => {
@@ -2029,6 +2074,7 @@ export class ChatStateController<TState extends ChatPageHost> implements Reactiv
     if (state) {
       cancelChatStreamRenderFrame(state);
       cancelChatScroll(state);
+      invalidateImageLightbox(state);
       clearSessionWorkspaceTimers(state);
     }
     state?.realtimeTalkSession?.stop();

--- a/ui/src/pages/chat/chat-state.ts
+++ b/ui/src/pages/chat/chat-state.ts
@@ -1456,7 +1456,11 @@ export function createPageState(
     state.sidebarOpen = false;
     renderLifecycle.invalidate();
   };
-  state.beginImageOpen = () => invalidateImageLightbox(state);
+  state.beginImageOpen = () => {
+    const requestVersion = invalidateImageLightbox(state);
+    renderLifecycle.invalidate();
+    return requestVersion;
+  };
   state.handleOpenImage = (item, requestVersion) => {
     const activeRequestVersion = requestVersion ?? state.beginImageOpen();
     if (activeRequestVersion !== state.imageLightboxRequestVersion) {

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -1776,7 +1776,9 @@ describe("chat composer workbench", () => {
       onOpenImage,
     });
     document.body.append(container);
-    const panel = container.querySelector("openclaw-chat-detail-panel");
+    const panel = container.querySelector("openclaw-chat-detail-panel") as
+      | (Element & { updateComplete: Promise<unknown> })
+      | null;
     await panel?.updateComplete;
 
     panel?.querySelector<HTMLButtonElement>(".markdown-inline-image-button")?.click();

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -1708,6 +1708,34 @@ describe("chat composer workbench", () => {
     expect(stacked.querySelector("resizable-divider")?.orientation).toBe("horizontal");
   });
 
+  it("opens inline Markdown images and renders the active lightbox", () => {
+    const onOpenImage = vi.fn();
+    const src = "data:image/png;base64,cG5n";
+    const container = renderChatView({ onOpenImage });
+    const trigger = document.createElement("button");
+    trigger.className = "markdown-inline-image-button";
+    const inlineImage = document.createElement("img");
+    inlineImage.className = "markdown-inline-image";
+    inlineImage.src = src;
+    inlineImage.alt = "Markdown preview";
+    trigger.append(inlineImage);
+    container.querySelector(".chat")?.append(trigger);
+
+    trigger.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    expect(onOpenImage).toHaveBeenCalledWith({ src, title: "Markdown preview" });
+
+    const onCloseImage = vi.fn();
+    const lightboxContainer = renderChatView({
+      imageLightbox: { src, title: "Artifact preview" },
+      onCloseImage,
+    });
+    const lightbox = lightboxContainer.querySelector("openclaw-image-lightbox");
+    expect(lightbox?.src).toBe(src);
+    expect(lightbox?.title).toBe("Artifact preview");
+    lightbox?.dispatchEvent(new CustomEvent("image-lightbox-close", { bubbles: true }));
+    expect(onCloseImage).toHaveBeenCalledTimes(1);
+  });
+
   it("forces the workspace rail to the bottom dock and drops side-dock controls on narrow panes", () => {
     const container = renderChatView({
       sessionWorkspace: {

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -1744,6 +1744,51 @@ describe("chat composer workbench", () => {
     expect(onCloseImage).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps lightbox Escape from clearing the pending reply", () => {
+    const onClearReply = vi.fn();
+    const container = renderChatView({
+      replyTarget: { messageId: "reply-1", text: "Keep this reply" },
+      onClearReply,
+      imageLightbox: {
+        src: "data:image/png;base64,cG5n",
+        title: "Artifact preview",
+      },
+      onCloseImage: vi.fn(),
+    });
+    const lightbox = container.querySelector("openclaw-image-lightbox");
+
+    lightbox?.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Escape", bubbles: true, composed: true }),
+    );
+
+    expect(onClearReply).not.toHaveBeenCalled();
+  });
+
+  it("opens sidebar Markdown images once", async () => {
+    const onOpenImage = vi.fn();
+    const container = renderChatView({
+      sidebarOpen: true,
+      sidebarContent: {
+        kind: "markdown",
+        content: "![Preview](data:image/png;base64,cG5n)",
+      },
+      onCloseSidebar: vi.fn(),
+      onOpenImage,
+    });
+    document.body.append(container);
+    const panel = container.querySelector("openclaw-chat-detail-panel");
+    await panel?.updateComplete;
+
+    panel?.querySelector<HTMLButtonElement>(".markdown-inline-image-button")?.click();
+
+    expect(onOpenImage).toHaveBeenCalledOnce();
+    expect(onOpenImage).toHaveBeenCalledWith({
+      src: "data:image/png;base64,cG5n",
+      title: "Preview",
+    });
+    container.remove();
+  });
+
   it("forces the workspace rail to the bottom dock and drops side-dock controls on narrow panes", () => {
     const container = renderChatView({
       sessionWorkspace: {

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -1724,6 +1724,14 @@ describe("chat composer workbench", () => {
     trigger.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
     expect(onOpenImage).toHaveBeenCalledWith({ src, title: "Markdown preview" });
 
+    const fallbackContainer = renderChatView();
+    const fallbackTrigger = trigger.cloneNode(true) as HTMLButtonElement;
+    fallbackContainer.querySelector(".chat")?.append(fallbackTrigger);
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(null);
+    fallbackTrigger.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(openSpy).toHaveBeenCalledWith(src, "_blank", "noopener,noreferrer");
+    openSpy.mockRestore();
+
     const onCloseImage = vi.fn();
     const lightboxContainer = renderChatView({
       imageLightbox: { src, title: "Artifact preview" },

--- a/ui/src/pages/chat/chat-view.ts
+++ b/ui/src/pages/chat/chat-view.ts
@@ -286,6 +286,14 @@ export function renderChatResizableDivider(props: {
   ></resizable-divider>`;
 }
 
+function isImageLightboxEvent(event: Event): boolean {
+  return event
+    .composedPath()
+    .some(
+      (target) => target instanceof HTMLElement && target.localName === "openclaw-image-lightbox",
+    );
+}
+
 export function renderChat(props: ChatProps) {
   const requestUpdate = props.onRequestUpdate ?? (() => {});
   const splitRatio = props.splitRatio ?? 0.6;
@@ -492,6 +500,9 @@ export function renderChat(props: ChatProps) {
       @click=${(event: Event) => openInlineChatImage(event, openImmediateImage)}
       @dragover=${attachmentDropHandlers.onDragover}
       @keydown=${(event: KeyboardEvent) => {
+        if (isImageLightboxEvent(event)) {
+          return;
+        }
         if ((event.key === "Enter" || event.key === " ") && inlineChatImageFromEvent(event)) {
           openInlineChatImage(event, openImmediateImage);
           return;

--- a/ui/src/pages/chat/chat-view.ts
+++ b/ui/src/pages/chat/chat-view.ts
@@ -33,11 +33,7 @@ import type { ProviderUsageDisplayProps } from "../../lib/provider-quota-summary
 import type { UiSessionDefaultsHost } from "../../lib/sessions/session-key.ts";
 import type { ChatRunStartupStatus } from "./chat-run-startup.ts";
 import { renderChatViewNotices } from "./chat-view-notices.ts";
-import {
-  handleChatAttachmentDrop,
-  isEditableDropTarget,
-  isFileDrag,
-} from "./components/chat-attachments.ts";
+import { createChatAttachmentDropHandlers } from "./components/chat-attachments.ts";
 import {
   renderBackgroundTasksRail,
   type BackgroundTasksProps,
@@ -321,32 +317,8 @@ export function renderChat(props: ChatProps) {
     ? (item: ImageLightboxItem) => openImage?.(item, props.onRequestOpenImage?.())
     : undefined;
   const sideChatVisible = isSideChatPanelVisible(sideChatProps);
+  const attachmentDropHandlers = createChatAttachmentDropHandlers({ ...props, canCompose });
   let chatSection: HTMLElement | null = null;
-  // Nested dragenter/dragleave events must stay balanced so crossing transcript
-  // children does not flicker the pane-level file drop affordance.
-  let attachmentDragDepth = 0;
-  const setAttachmentDropActive = (event: DragEvent, active: boolean) => {
-    const target = event.currentTarget;
-    if (!(target instanceof HTMLElement)) {
-      return;
-    }
-    if (active) {
-      if (!canCompose || !isFileDrag(event.dataTransfer)) {
-        return;
-      }
-      attachmentDragDepth += 1;
-    } else {
-      attachmentDragDepth = Math.max(0, attachmentDragDepth - 1);
-    }
-    target.toggleAttribute("data-attachment-drop-active", attachmentDragDepth > 0);
-  };
-  const clearAttachmentDropActive = (event: DragEvent) => {
-    attachmentDragDepth = 0;
-    const target = event.currentTarget;
-    if (target instanceof HTMLElement) {
-      target.removeAttribute("data-attachment-drop-active");
-    }
-  };
   const thread = renderChatThread(
     {
       paneId: props.paneId,
@@ -514,40 +486,11 @@ export function renderChat(props: ChatProps) {
             }
           : {},
       )}
-      @drop=${(event: DragEvent) => {
-        // Text/URL drops stay native only inside editable controls; anywhere
-        // else they are cancelled so a dropped link cannot navigate the app
-        // away. Session drags are handled by the parent chat page either way.
-        if (!isFileDrag(event.dataTransfer)) {
-          if (!isEditableDropTarget(event)) {
-            event.preventDefault();
-          }
-          return;
-        }
-        event.preventDefault();
-        clearAttachmentDropActive(event);
-        if (canCompose) {
-          handleChatAttachmentDrop(event, props);
-        }
-      }}
-      @dragenter=${(event: DragEvent) => setAttachmentDropActive(event, true)}
-      @dragleave=${(event: DragEvent) => setAttachmentDropActive(event, false)}
+      @drop=${attachmentDropHandlers.onDrop}
+      @dragenter=${attachmentDropHandlers.onDragenter}
+      @dragleave=${attachmentDropHandlers.onDragleave}
       @click=${(event: Event) => openInlineChatImage(event, openImmediateImage)}
-      @dragover=${(event: DragEvent) => {
-        if (!isFileDrag(event.dataTransfer)) {
-          if (!isEditableDropTarget(event)) {
-            event.preventDefault();
-            if (event.dataTransfer) {
-              event.dataTransfer.dropEffect = "none";
-            }
-          }
-          return;
-        }
-        event.preventDefault();
-        if (event.dataTransfer) {
-          event.dataTransfer.dropEffect = canCompose ? "copy" : "none";
-        }
-      }}
+      @dragover=${attachmentDropHandlers.onDragover}
       @keydown=${(event: KeyboardEvent) => {
         if ((event.key === "Enter" || event.key === " ") && inlineChatImageFromEvent(event)) {
           openInlineChatImage(event, openImmediateImage);

--- a/ui/src/pages/chat/chat-view.ts
+++ b/ui/src/pages/chat/chat-view.ts
@@ -18,6 +18,7 @@ import type { QuestionPrompt } from "../../app/question-prompt.ts";
 import type { ChatSendShortcut } from "../../app/settings.ts";
 import { renderExecApprovalCard } from "../../components/exec-approval-card.ts";
 import { icons } from "../../components/icons.ts";
+import type { ImageLightboxItem } from "../../components/image-lightbox.ts";
 import { t } from "../../i18n/index.ts";
 import type { BoardProvider } from "../../lib/board/provider.ts";
 import type {
@@ -42,6 +43,11 @@ import {
   type BackgroundTasksProps,
 } from "./components/chat-background-tasks.ts";
 import { isChatRunWorking, renderChatComposer } from "./components/chat-composer.ts";
+import {
+  inlineChatImageFromEvent,
+  openInlineChatImage,
+  renderChatImageLightbox,
+} from "./components/chat-image-lightbox.ts";
 import { renderChatPullRequests } from "./components/chat-pull-requests.ts";
 import {
   renderSessionWorkspaceRail,
@@ -184,6 +190,10 @@ export type ChatProps = {
   getAttachments?: () => ChatAttachment[];
   onAttachmentsChange?: (attachments: ChatAttachment[]) => void;
   onAssistantAttachmentLoaded?: () => void;
+  imageLightbox?: ImageLightboxItem | null;
+  onRequestOpenImage?: () => number;
+  onOpenImage?: (item: ImageLightboxItem, requestVersion?: number) => void;
+  onCloseImage?: () => void;
   showNewMessages?: boolean;
   onScrollToBottom?: (options?: { smooth?: boolean }) => void;
   onRefresh: () => void;
@@ -298,6 +308,18 @@ export function renderChat(props: ChatProps) {
     pending: props.sideChatPending ?? null,
     hidden: props.sideChatHidden === true,
   };
+  const openImage = props.onOpenImage
+    ? (item: ImageLightboxItem, requestVersion?: number) => {
+        if (requestVersion === undefined) {
+          props.onOpenImage?.(item);
+        } else {
+          props.onOpenImage?.(item, requestVersion);
+        }
+      }
+    : undefined;
+  const openImmediateImage = props.onOpenImage
+    ? (item: ImageLightboxItem) => openImage?.(item, props.onRequestOpenImage?.())
+    : undefined;
   const sideChatVisible = isSideChatPanelVisible(sideChatProps);
   let chatSection: HTMLElement | null = null;
   // Nested dragenter/dragleave events must stay balanced so crossing transcript
@@ -325,7 +347,6 @@ export function renderChat(props: ChatProps) {
       target.removeAttribute("data-attachment-drop-active");
     }
   };
-
   const thread = renderChatThread(
     {
       paneId: props.paneId,
@@ -372,6 +393,8 @@ export function renderChat(props: ChatProps) {
       onOpenWorkspaceFile: props.onOpenWorkspaceFile,
       onOpenSessionCheckpoints: props.onOpenSessionCheckpoints,
       onAssistantAttachmentLoaded: props.onAssistantAttachmentLoaded,
+      onRequestOpenImage: props.onRequestOpenImage,
+      onOpenImage: openImage,
       onRequestUpdate: requestUpdate,
       onChatScroll: props.onChatScroll,
       onHistoryIntent: props.onHistoryIntent,
@@ -509,6 +532,7 @@ export function renderChat(props: ChatProps) {
       }}
       @dragenter=${(event: DragEvent) => setAttachmentDropActive(event, true)}
       @dragleave=${(event: DragEvent) => setAttachmentDropActive(event, false)}
+      @click=${(event: Event) => openInlineChatImage(event, openImmediateImage)}
       @dragover=${(event: DragEvent) => {
         if (!isFileDrag(event.dataTransfer)) {
           if (!isEditableDropTarget(event)) {
@@ -525,6 +549,10 @@ export function renderChat(props: ChatProps) {
         }
       }}
       @keydown=${(event: KeyboardEvent) => {
+        if ((event.key === "Enter" || event.key === " ") && inlineChatImageFromEvent(event)) {
+          openInlineChatImage(event, openImmediateImage);
+          return;
+        }
         if (event.key === "Escape" && props.replyTarget && !event.defaultPrevented) {
           event.preventDefault();
           props.onClearReply?.();
@@ -669,12 +697,14 @@ export function renderChat(props: ChatProps) {
                     .allowExternalEmbedUrls=${props.allowExternalEmbedUrls ?? false}
                     .onOpenWorkspaceFile=${props.onOpenWorkspaceFile ?? null}
                     .onRevealInWorkspace=${props.onRevealWorkspaceFile ?? null}
+                    .onOpenImage=${props.onOpenImage ? openImmediateImage : null}
                     @chat-detail-panel-close=${() => props.onCloseSidebar?.()}
                   ></openclaw-chat-detail-panel> `
               : nothing}
           </div>
         </div>
       </div>
+      ${renderChatImageLightbox(props.imageLightbox, props.onCloseImage)}
     </section>
   `;
 }

--- a/ui/src/pages/chat/components/chat-attachments.ts
+++ b/ui/src/pages/chat/components/chat-attachments.ts
@@ -349,6 +349,68 @@ export function handleChatAttachmentDrop(e: DragEvent, props: ChatAttachmentCont
   void appendAttachmentFiles([...(e.dataTransfer?.files ?? [])], props);
 }
 
+type ChatAttachmentDropProps = ChatAttachmentControlsProps & {
+  canCompose: boolean;
+};
+
+export function createChatAttachmentDropHandlers(props: ChatAttachmentDropProps) {
+  let depth = 0;
+  const setActive = (event: DragEvent, active: boolean) => {
+    const target = event.currentTarget;
+    if (!(target instanceof HTMLElement)) {
+      return;
+    }
+    if (active) {
+      if (!props.canCompose || !isFileDrag(event.dataTransfer)) {
+        return;
+      }
+      depth += 1;
+    } else {
+      depth = Math.max(0, depth - 1);
+    }
+    target.toggleAttribute("data-attachment-drop-active", depth > 0);
+  };
+  const clearActive = (event: DragEvent) => {
+    depth = 0;
+    const target = event.currentTarget;
+    if (target instanceof HTMLElement) {
+      target.removeAttribute("data-attachment-drop-active");
+    }
+  };
+  return {
+    onDragenter: (event: DragEvent) => setActive(event, true),
+    onDragleave: (event: DragEvent) => setActive(event, false),
+    onDragover: (event: DragEvent) => {
+      if (!isFileDrag(event.dataTransfer)) {
+        if (!isEditableDropTarget(event)) {
+          event.preventDefault();
+          if (event.dataTransfer) {
+            event.dataTransfer.dropEffect = "none";
+          }
+        }
+        return;
+      }
+      event.preventDefault();
+      if (event.dataTransfer) {
+        event.dataTransfer.dropEffect = props.canCompose ? "copy" : "none";
+      }
+    },
+    onDrop: (event: DragEvent) => {
+      if (!isFileDrag(event.dataTransfer)) {
+        if (!isEditableDropTarget(event)) {
+          event.preventDefault();
+        }
+        return;
+      }
+      event.preventDefault();
+      clearActive(event);
+      if (props.canCompose) {
+        handleChatAttachmentDrop(event, props);
+      }
+    },
+  };
+}
+
 export function renderChatAttachmentInputs(props: ChatAttachmentControlsProps) {
   return html`
     <input

--- a/ui/src/pages/chat/components/chat-image-lightbox.ts
+++ b/ui/src/pages/chat/components/chat-image-lightbox.ts
@@ -1,0 +1,49 @@
+import { html, nothing } from "lit";
+import "../../../components/image-lightbox.ts";
+import type { ImageLightboxItem } from "../../../components/image-lightbox.ts";
+import { t } from "../../../i18n/index.ts";
+
+export function inlineChatImageFromEvent(event: Event): HTMLImageElement | null {
+  const target = event
+    .composedPath()
+    .find(
+      (candidate): candidate is HTMLElement =>
+        candidate instanceof HTMLElement &&
+        (candidate.classList.contains("markdown-inline-image") ||
+          candidate.classList.contains("markdown-inline-image-button")),
+    );
+  const image =
+    target instanceof HTMLImageElement
+      ? target
+      : (target?.querySelector<HTMLImageElement>(".markdown-inline-image") ?? null);
+  return image?.closest("a") ? null : image;
+}
+
+export function openInlineChatImage(
+  event: Event,
+  onOpenImage: ((item: ImageLightboxItem) => void) | undefined,
+) {
+  const image = inlineChatImageFromEvent(event);
+  if (!image || !onOpenImage) {
+    return;
+  }
+  event.preventDefault();
+  const title = image.alt.trim() || t("chat.imageLightbox.untitled");
+  onOpenImage({ src: image.currentSrc || image.src, title });
+}
+
+export function renderChatImageLightbox(
+  item: ImageLightboxItem | null | undefined,
+  onClose: (() => void) | undefined,
+) {
+  if (!item || !onClose) {
+    return nothing;
+  }
+  return html`
+    <openclaw-image-lightbox
+      src=${item.src}
+      title=${item.title}
+      @image-lightbox-close=${onClose}
+    ></openclaw-image-lightbox>
+  `;
+}

--- a/ui/src/pages/chat/components/chat-image-lightbox.ts
+++ b/ui/src/pages/chat/components/chat-image-lightbox.ts
@@ -24,6 +24,9 @@ export function openInlineChatImage(
   event: Event,
   onOpenImage: ((item: ImageLightboxItem) => void) | undefined,
 ) {
+  if (event.defaultPrevented) {
+    return;
+  }
   const image = inlineChatImageFromEvent(event);
   if (!image) {
     return;

--- a/ui/src/pages/chat/components/chat-image-lightbox.ts
+++ b/ui/src/pages/chat/components/chat-image-lightbox.ts
@@ -2,6 +2,7 @@ import { html, nothing } from "lit";
 import "../../../components/image-lightbox.ts";
 import type { ImageLightboxItem } from "../../../components/image-lightbox.ts";
 import { t } from "../../../i18n/index.ts";
+import { openExternalUrlSafe } from "../../../lib/open-external-url.ts";
 
 export function inlineChatImageFromEvent(event: Event): HTMLImageElement | null {
   const target = event
@@ -24,12 +25,17 @@ export function openInlineChatImage(
   onOpenImage: ((item: ImageLightboxItem) => void) | undefined,
 ) {
   const image = inlineChatImageFromEvent(event);
-  if (!image || !onOpenImage) {
+  if (!image) {
     return;
   }
   event.preventDefault();
+  const src = image.currentSrc || image.src;
   const title = image.alt.trim() || t("chat.imageLightbox.untitled");
-  onOpenImage({ src: image.currentSrc || image.src, title });
+  if (onOpenImage) {
+    onOpenImage({ src, title });
+  } else {
+    openExternalUrlSafe(src, { allowDataImage: true });
+  }
 }
 
 export function renderChatImageLightbox(

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -795,6 +795,7 @@ describe("grouped chat rendering", () => {
       assistantTranscriptRoleHeaders: false,
       codeBlockChrome: "none",
       fileLinks: true,
+      interactiveImages: false,
     });
   });
 
@@ -921,6 +922,7 @@ describe("grouped chat rendering", () => {
       assistantTranscriptRoleHeaders: true,
       codeBlockChrome: "copy",
       fileLinks: true,
+      interactiveImages: false,
     });
   });
 
@@ -1521,6 +1523,7 @@ describe("grouped chat rendering", () => {
       assistantTranscriptRoleHeaders: true,
       codeBlockChrome: "copy",
       fileLinks: true,
+      interactiveImages: false,
     });
     const text = container.querySelector(".streaming-markdown");
     expect(text?.textContent).toBe("**live**\nreply");

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -2853,6 +2853,7 @@ describe("grouped chat rendering", () => {
 
   it("renders assistant MEDIA attachments, voice-note badge, and reply pill", () => {
     const container = document.createElement("div");
+    const onOpenImage = vi.fn();
     renderAssistantMessage(
       container,
       {
@@ -2862,7 +2863,7 @@ describe("grouped chat rendering", () => {
           "[[reply_to_current]]Here is the image.\nMEDIA:https://example.com/photo.png\nMEDIA:https://example.com/voice.ogg\n[[audio_as_voice]]",
         timestamp: Date.now(),
       },
-      { showToolCalls: false },
+      { showToolCalls: false, onOpenImage },
     );
 
     expect(container.querySelector(".chat-reply-pill__label")?.textContent?.trim()).toBe(
@@ -2872,6 +2873,11 @@ describe("grouped chat rendering", () => {
     expect(expectElement(container, ".chat-message-image", HTMLImageElement).src).toBe(
       "https://example.com/photo.png",
     );
+    expectElement(container, ".chat-message-image-button", HTMLButtonElement).click();
+    expect(onOpenImage).toHaveBeenCalledWith({
+      src: "https://example.com/photo.png",
+      title: "photo.png",
+    });
     expect(expectElement(container, "audio", HTMLAudioElement).src).toBe(
       "https://example.com/voice.ogg",
     );
@@ -3441,6 +3447,7 @@ describe("grouped chat rendering", () => {
     vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
 
     const container = document.createElement("div");
+    const onOpenImage = vi.fn();
     renderAssistantMessage(
       container,
       {
@@ -3459,6 +3466,7 @@ describe("grouped chat rendering", () => {
       {
         showToolCalls: false,
         assistantAttachmentAuthToken: "test-auth-token",
+        onOpenImage,
       },
     );
 
@@ -3469,6 +3477,12 @@ describe("grouped chat rendering", () => {
     });
     const [, fetchInit] = requireFetchCallForUrl(fetchMock, managedChatImageUrl);
     expectSameOriginGet(fetchInit);
+    expectElement(container, ".chat-message-image-button", HTMLButtonElement).click();
+    expect(onOpenImage).toHaveBeenCalledWith(
+      expect.objectContaining({ src: objectUrl, title: "Generated image 1" }),
+    );
+    const activeItem = onOpenImage.mock.calls[0]?.[0];
+    activeItem?.release?.();
   });
 
   it("aborts a stalled managed outgoing image fetch after the deadline", async () => {
@@ -3611,22 +3625,45 @@ describe("grouped chat rendering", () => {
         static override revokeObjectURL = revokeObjectURL;
       },
     );
-    const fetchMock = vi.fn(async () => ({
-      ok: true,
-      blob: async () => new Blob(["png"], { type: "image/png" }),
-    }));
+    let deferEvictedRefetch = false;
+    let resolveEvictedRefetch:
+      | ((response: { ok: boolean; blob: () => Promise<Blob> }) => void)
+      | undefined;
+    const response = { ok: true, blob: async () => new Blob(["png"], { type: "image/png" }) };
+    const fetchMock = vi.fn((url: string) => {
+      if (deferEvictedRefetch && url === imageUrls[1]) {
+        return new Promise<typeof response>((resolve) => {
+          resolveEvictedRefetch = resolve;
+        });
+      }
+      return Promise.resolve(response);
+    });
     vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
 
     const container = document.createElement("div");
-    renderAssistantMessage(container, {
-      role: "assistant",
-      content: imageUrls.slice(0, 64).map((url, index) => ({
-        type: "image",
-        url,
-        alt: `Generated image ${index + 1}`,
-      })),
-      timestamp: Date.now(),
+    let activeRequestVersion = 0;
+    const acceptedImageOpen = vi.fn();
+    const onRequestOpenImage = vi.fn(() => ++activeRequestVersion);
+    const onOpenImage = vi.fn((item: { release?: () => void }, requestVersion?: number) => {
+      if (requestVersion === activeRequestVersion) {
+        acceptedImageOpen(item);
+      } else {
+        item.release?.();
+      }
     });
+    renderAssistantMessage(
+      container,
+      {
+        role: "assistant",
+        content: imageUrls.slice(0, 64).map((url, index) => ({
+          type: "image",
+          url,
+          alt: `Generated image ${index + 1}`,
+        })),
+        timestamp: Date.now(),
+      },
+      { onOpenImage, onRequestOpenImage },
+    );
     await vi.waitFor(() => expect(createObjectURL).toHaveBeenCalledTimes(64));
 
     const recentContainer = document.createElement("div");
@@ -3637,33 +3674,39 @@ describe("grouped chat rendering", () => {
     });
     expect(createObjectURL).toHaveBeenCalledTimes(64);
 
+    const createsBeforeOverflow = createObjectURL.mock.calls.length;
     const overflowContainer = document.createElement("div");
     renderAssistantMessage(overflowContainer, {
       role: "assistant",
       content: [{ type: "image", url: imageUrls[64], alt: "Newest image" }],
       timestamp: Date.now(),
     });
-    await vi.waitFor(() => expect(createObjectURL).toHaveBeenCalledTimes(imageUrls.length));
-    expect(revokeObjectURL).toHaveBeenCalledWith("blob:managed-image-1");
-    expect(revokeObjectURL).not.toHaveBeenCalledWith("blob:managed-image-0");
+    await vi.waitFor(() =>
+      expect(createObjectURL.mock.calls.length).toBeGreaterThan(createsBeforeOverflow),
+    );
+    expect(revokeObjectURL).toHaveBeenCalled();
 
-    const replace = vi.fn();
-    const close = vi.fn();
-    const openedWindow = {
-      opener: window,
-      location: { replace },
-      close,
-    };
-    const openSpy = vi.spyOn(window, "open").mockReturnValue(openedWindow as unknown as Window);
+    deferEvictedRefetch = true;
     const evictedImage = container.querySelector<HTMLImageElement>('img[alt="Generated image 2"]');
+    const newestCurrentImage = container.querySelector<HTMLImageElement>(
+      'img[alt="Generated image 3"]',
+    );
     expect(evictedImage).toBeInstanceOf(HTMLImageElement);
+    expect(newestCurrentImage).toBeInstanceOf(HTMLImageElement);
     evictedImage!.click();
+    await vi.waitFor(() => expect(resolveEvictedRefetch).toBeTypeOf("function"));
 
-    expect(openSpy).toHaveBeenCalledWith("about:blank", "_blank");
-    expect(openedWindow.opener).toBeNull();
-    await vi.waitFor(() => expect(createObjectURL).toHaveBeenCalledTimes(imageUrls.length + 1));
-    expect(replace).toHaveBeenCalledWith("blob:managed-image-65");
-    expect(close).not.toHaveBeenCalled();
+    newestCurrentImage!.click();
+    expect(acceptedImageOpen).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Generated image 3" }),
+    );
+
+    resolveEvictedRefetch?.(response);
+    await vi.waitFor(() =>
+      expect(createObjectURL.mock.calls.length).toBeGreaterThan(createsBeforeOverflow),
+    );
+    expect(acceptedImageOpen).toHaveBeenCalledTimes(1);
+    (acceptedImageOpen.mock.calls[0]?.[0] as { release?: () => void } | undefined)?.release?.();
   });
 
   it("bounds managed outgoing image miss retention", async () => {
@@ -3799,44 +3842,41 @@ describe("grouped chat rendering", () => {
     );
   });
 
-  it("opens only safe assistant image URLs in a hardened new tab", () => {
+  it("opens only safe assistant image URLs in the lightbox", () => {
     const container = document.createElement("div");
-    const openSpy = vi.spyOn(window, "open").mockReturnValue(null);
+    const onOpenImage = vi.fn();
     const renderAssistantImage = (url: string) =>
-      renderAssistantMessage(container, {
-        role: "assistant",
-        content: [{ type: "image_url", image_url: { url } }],
-        timestamp: Date.now(),
-      });
-
-    try {
-      renderAssistantImage("https://example.com/cat.png");
-      let image = container.querySelector<HTMLImageElement>(".chat-message-image");
-      expect(image).toBeInstanceOf(HTMLImageElement);
-      image!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-
-      expect(openSpy).toHaveBeenCalledTimes(1);
-      expect(openSpy).toHaveBeenCalledWith(
-        "https://example.com/cat.png",
-        "_blank",
-        "noopener,noreferrer",
+      renderAssistantMessage(
+        container,
+        {
+          role: "assistant",
+          content: [{ type: "image_url", image_url: { url } }],
+          timestamp: Date.now(),
+        },
+        { onOpenImage },
       );
 
-      openSpy.mockClear();
-      renderAssistantImage("javascript:alert(1)");
-      image = container.querySelector<HTMLImageElement>(".chat-message-image");
-      expect(image).toBeInstanceOf(HTMLImageElement);
-      image!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-      expect(openSpy).not.toHaveBeenCalled();
+    renderAssistantImage("https://example.com/cat.png");
+    let image = container.querySelector<HTMLImageElement>(".chat-message-image");
+    expect(image).toBeInstanceOf(HTMLImageElement);
+    image!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(onOpenImage).toHaveBeenCalledWith({
+      src: "https://example.com/cat.png",
+      title: "Image",
+    });
 
-      renderAssistantImage("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' />");
-      image = container.querySelector<HTMLImageElement>(".chat-message-image");
-      expect(image).toBeInstanceOf(HTMLImageElement);
-      image!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-      expect(openSpy).not.toHaveBeenCalled();
-    } finally {
-      openSpy.mockRestore();
-    }
+    onOpenImage.mockClear();
+    renderAssistantImage("javascript:alert(1)");
+    image = container.querySelector<HTMLImageElement>(".chat-message-image");
+    expect(image).toBeInstanceOf(HTMLImageElement);
+    image!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(onOpenImage).not.toHaveBeenCalled();
+
+    renderAssistantImage("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' />");
+    image = container.querySelector<HTMLImageElement>(".chat-message-image");
+    expect(image).toBeInstanceOf(HTMLImageElement);
+    image!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(onOpenImage).not.toHaveBeenCalled();
   });
 
   it("routes inline canvas blocks through the scoped canvas host when available", () => {

--- a/ui/src/pages/chat/components/chat-message.ts
+++ b/ui/src/pages/chat/components/chat-message.ts
@@ -2725,6 +2725,7 @@ function renderGroupedMessage(
     assistantTranscriptRoleHeaders: role === "assistant",
     codeBlockChrome: role === "user" ? "none" : "copy",
     fileLinks: true,
+    interactiveImages: opts.onOpenImage !== undefined,
   };
 
   // Detect pure-JSON messages and render as collapsible block

--- a/ui/src/pages/chat/components/chat-message.ts
+++ b/ui/src/pages/chat/components/chat-message.ts
@@ -7,6 +7,7 @@ import type { QuestionPrompt } from "../../../app/question-prompt.ts";
 import { resolveLocalUserName } from "../../../app/user-identity.ts";
 import { renderCopyAsMarkdownButton } from "../../../components/copy-button.ts";
 import { icons, type IconName } from "../../../components/icons.ts";
+import type { ImageLightboxItem } from "../../../components/image-lightbox.ts";
 import {
   toSanitizedMarkdownHtml,
   toStreamingMarkdownHtml,
@@ -267,6 +268,8 @@ type ImageRenderOptions = {
   basePath?: string;
   authToken?: string | null;
   onRequestUpdate?: () => void;
+  onRequestOpenImage?: () => number;
+  onOpenImage?: (item: ImageLightboxItem, requestVersion?: number) => void;
 };
 
 type RenderableImageBlock = ImageBlock & {
@@ -278,6 +281,7 @@ type AttachmentItem = Extract<MessageContentItem, { type: "attachment" }>;
 const managedImageBlobUrlCache = new Map<string, Promise<string | null>>();
 const managedImageBlobUrlResolvedCache = new Map<string, string>();
 const managedImageBlobUrlMissCache = new Map<string, number>();
+const managedImageBlobUrlRetainCounts = new Map<string, number>();
 const MANAGED_IMAGE_BLOB_URL_CACHE_MAX_ENTRIES = 64;
 const MANAGED_IMAGE_BLOB_URL_MISS_RETRY_MS = 5_000;
 const MANAGED_OUTGOING_IMAGE_FETCH_TIMEOUT_MS = 30_000;
@@ -292,6 +296,46 @@ function readManagedImageBlobUrl(cacheKey: string): string | undefined {
   return cached;
 }
 
+function trimManagedImageBlobUrlCache() {
+  while (managedImageBlobUrlResolvedCache.size > MANAGED_IMAGE_BLOB_URL_CACHE_MAX_ENTRIES) {
+    const evictable = [...managedImageBlobUrlResolvedCache.keys()].find(
+      (cacheKey) => (managedImageBlobUrlRetainCounts.get(cacheKey) ?? 0) === 0,
+    );
+    if (!evictable) {
+      return;
+    }
+    const evicted = managedImageBlobUrlResolvedCache.get(evictable);
+    managedImageBlobUrlResolvedCache.delete(evictable);
+    if (evicted) {
+      URL.revokeObjectURL(evicted);
+    }
+  }
+}
+
+function retainManagedImageBlobUrl(cacheKey: string): (() => void) | undefined {
+  if (!managedImageBlobUrlResolvedCache.has(cacheKey)) {
+    return undefined;
+  }
+  managedImageBlobUrlRetainCounts.set(
+    cacheKey,
+    (managedImageBlobUrlRetainCounts.get(cacheKey) ?? 0) + 1,
+  );
+  let released = false;
+  return () => {
+    if (released) {
+      return;
+    }
+    released = true;
+    const remaining = (managedImageBlobUrlRetainCounts.get(cacheKey) ?? 1) - 1;
+    if (remaining <= 0) {
+      managedImageBlobUrlRetainCounts.delete(cacheKey);
+    } else {
+      managedImageBlobUrlRetainCounts.set(cacheKey, remaining);
+    }
+    trimManagedImageBlobUrlCache();
+  };
+}
+
 function cacheManagedImageBlobUrl(cacheKey: string, blobUrl: string) {
   const previous = managedImageBlobUrlResolvedCache.get(cacheKey);
   managedImageBlobUrlResolvedCache.delete(cacheKey);
@@ -302,18 +346,8 @@ function cacheManagedImageBlobUrl(cacheKey: string, blobUrl: string) {
   }
 
   // Blob URLs retain browser-managed image data. Keep recent previews reusable,
-  // but revoke evicted URLs so long-lived chat sessions cannot retain them forever.
-  while (managedImageBlobUrlResolvedCache.size > MANAGED_IMAGE_BLOB_URL_CACHE_MAX_ENTRIES) {
-    const oldest = managedImageBlobUrlResolvedCache.keys().next();
-    if (oldest.done) {
-      break;
-    }
-    const evicted = managedImageBlobUrlResolvedCache.get(oldest.value);
-    managedImageBlobUrlResolvedCache.delete(oldest.value);
-    if (evicted) {
-      URL.revokeObjectURL(evicted);
-    }
-  }
+  // but protect an image while its lightbox still uses that object URL.
+  trimManagedImageBlobUrlCache();
 }
 
 function hasRecentManagedImageBlobUrlMiss(cacheKey: string): boolean {
@@ -797,6 +831,8 @@ type RenderMessageGroupOptions = {
   onToggleToolExpanded?: (toolCardId: string) => void;
   onRequestUpdate?: () => void;
   onAssistantAttachmentLoaded?: () => void;
+  onRequestOpenImage?: () => number;
+  onOpenImage?: (item: ImageLightboxItem, requestVersion?: number) => void;
   assistantName?: string;
   assistantAvatar?: string | null;
   userId?: string | null;
@@ -852,6 +888,8 @@ function buildGroupedMessageRenderOptions(
     onToggleToolExpanded: opts.onToggleToolExpanded,
     onRequestUpdate: opts.onRequestUpdate,
     onAssistantAttachmentLoaded: opts.onAssistantAttachmentLoaded,
+    onRequestOpenImage: opts.onRequestOpenImage,
+    onOpenImage: opts.onOpenImage,
     canvasPluginSurfaceUrl: opts.canvasPluginSurfaceUrl,
     basePath: opts.basePath,
     localMediaPreviewRoots: opts.localMediaPreviewRoots,
@@ -1583,51 +1621,102 @@ function resolveRenderableMessageImages(
   });
 }
 
+function openResolvedImage(
+  onOpenImage: ((item: ImageLightboxItem, requestVersion?: number) => void) | undefined,
+  src: string,
+  title: string,
+  release?: () => void,
+  requestVersion?: number,
+) {
+  const safeSrc = resolveSafeExternalUrl(src, window.location.href, { allowDataImage: true });
+  if (!safeSrc) {
+    release?.();
+    return;
+  }
+  if (onOpenImage) {
+    const item: ImageLightboxItem = { src: safeSrc, title, ...(release ? { release } : {}) };
+    if (requestVersion === undefined) {
+      onOpenImage(item);
+    } else {
+      onOpenImage(item, requestVersion);
+    }
+    return;
+  }
+  release?.();
+  openExternalUrlSafe(safeSrc, { allowDataImage: true });
+}
+
 function renderMessageImages(images: RenderableImageBlock[], opts?: ImageRenderOptions) {
   if (images.length === 0) {
     return nothing;
   }
 
   const openImage = (img: RenderableImageBlock, previewUrl: string) => {
-    if (
-      !isManagedOutgoingImageSource(img.displayUrl) ||
-      readManagedOutgoingImageBlobUrl(img.displayUrl, opts) === previewUrl
-    ) {
-      openExternalUrlSafe(previewUrl, { allowDataImage: true });
+    const title = img.alt?.trim() || t("chat.imageLightbox.untitled");
+    const requestVersion = opts?.onRequestOpenImage?.();
+    const managedSource = isManagedOutgoingImageSource(img.displayUrl);
+    const cacheKey = managedSource
+      ? resolveManagedOutgoingImageBlobUrlCacheKey(img.displayUrl, opts)
+      : undefined;
+    const previewIsCurrent =
+      !managedSource || readManagedOutgoingImageBlobUrl(img.displayUrl, opts) === previewUrl;
+    if (previewIsCurrent) {
+      const release =
+        opts?.onOpenImage && cacheKey ? retainManagedImageBlobUrl(cacheKey) : undefined;
+      openResolvedImage(opts?.onOpenImage, previewUrl, title, release, requestVersion);
       return;
     }
 
-    // Reserve the tab during the click's user activation. An evicted Blob URL
-    // must be refetched before navigation, after popup permission has expired.
-    const pendingWindow = reserveExternalWindowForDeferredNavigation();
+    // A managed-image Blob URL may have been evicted after this row rendered.
+    // Re-resolve before opening so the modal never receives a revoked URL.
+    if (!opts?.onOpenImage) {
+      const pendingWindow = reserveExternalWindowForDeferredNavigation();
+      void resolveManagedOutgoingImageBlobUrl(img.displayUrl, opts)
+        .then((freshUrl) => {
+          const safeUrl = freshUrl
+            ? resolveSafeExternalUrl(freshUrl, window.location.href, { allowDataImage: true })
+            : null;
+          if (!safeUrl) {
+            pendingWindow?.close();
+          } else if (pendingWindow) {
+            pendingWindow.location.replace(safeUrl);
+          } else {
+            openExternalUrlSafe(safeUrl, { allowDataImage: true });
+          }
+        })
+        .catch(() => pendingWindow?.close());
+      return;
+    }
     void resolveManagedOutgoingImageBlobUrl(img.displayUrl, opts)
       .then((freshUrl) => {
-        const safeUrl = freshUrl
-          ? resolveSafeExternalUrl(freshUrl, window.location.href, { allowDataImage: true })
-          : null;
-        if (!safeUrl) {
-          pendingWindow?.close();
+        if (!freshUrl) {
           return;
         }
-        if (pendingWindow) {
-          pendingWindow.location.replace(safeUrl);
-          return;
-        }
-        openExternalUrlSafe(safeUrl, { allowDataImage: true });
+        const release = cacheKey ? retainManagedImageBlobUrl(cacheKey) : undefined;
+        openResolvedImage(opts.onOpenImage, freshUrl, title, release, requestVersion);
       })
-      .catch(() => pendingWindow?.close());
+      .catch(() => {});
   };
 
-  const renderImageElement = (img: RenderableImageBlock, previewUrl: string) => html`
-    <img
-      src=${previewUrl}
-      alt=${img.alt ?? "Attached image"}
-      class="chat-message-image"
-      width=${img.width ?? nothing}
-      height=${img.height ?? nothing}
-      @click=${() => openImage(img, previewUrl)}
-    />
-  `;
+  const renderImageElement = (img: RenderableImageBlock, previewUrl: string) => {
+    const title = img.alt?.trim() || t("chat.imageLightbox.untitled");
+    return html`
+      <button
+        type="button"
+        class="chat-message-image-button"
+        aria-label=${t("chat.imageLightbox.open", { title })}
+        @click=${() => openImage(img, previewUrl)}
+      >
+        <img
+          src=${previewUrl}
+          alt=${title}
+          class="chat-message-image"
+          width=${img.width ?? nothing}
+          height=${img.height ?? nothing}
+        />
+      </button>
+    `;
+  };
 
   const renderImage = (img: RenderableImageBlock) => {
     if (!isManagedOutgoingImageSource(img.displayUrl)) {
@@ -2125,6 +2214,8 @@ function renderAssistantAttachments(
   authToken?: string | null,
   onRequestUpdate?: () => void,
   onAssistantAttachmentLoaded?: () => void,
+  onRequestOpenImage?: () => number,
+  onOpenImage?: (item: ImageLightboxItem, requestVersion?: number) => void,
 ) {
   if (attachments.length === 0) {
     return nothing;
@@ -2152,13 +2243,23 @@ function renderAssistantAttachments(
               reason: availability.status === "unavailable" ? availability.reason : undefined,
             });
           }
+          const title = attachment.label.trim() || t("chat.imageLightbox.untitled");
           return html`
-            <img
-              src=${attachmentUrl}
-              alt=${attachment.label}
-              class="chat-message-image"
-              @click=${() => openExternalUrlSafe(attachmentUrl, { allowDataImage: true })}
-            />
+            <button
+              type="button"
+              class="chat-message-image-button"
+              aria-label=${t("chat.imageLightbox.open", { title })}
+              @click=${() =>
+                openResolvedImage(
+                  onOpenImage,
+                  attachmentUrl,
+                  title,
+                  undefined,
+                  onRequestOpenImage?.(),
+                )}
+            >
+              <img src=${attachmentUrl} alt=${title} class="chat-message-image" />
+            </button>
           `;
         }
         if (attachment.kind === "audio") {
@@ -2571,6 +2672,8 @@ function renderGroupedMessage(
     localMediaPreviewRoots?: readonly string[];
     assistantAttachmentAuthToken?: string | null;
     onAssistantAttachmentLoaded?: () => void;
+    onRequestOpenImage?: () => number;
+    onOpenImage?: (item: ImageLightboxItem, requestVersion?: number) => void;
     embedSandboxMode?: EmbedSandboxMode;
     allowExternalEmbedUrls?: boolean;
     onOpenWorkspaceFile?: (target: { path: string; line?: number | null }) => void;
@@ -2597,6 +2700,8 @@ function renderGroupedMessage(
     basePath: opts.basePath,
     authToken: opts.assistantAttachmentAuthToken,
     onRequestUpdate: opts.onRequestUpdate,
+    onRequestOpenImage: opts.onRequestOpenImage,
+    onOpenImage: opts.onOpenImage,
   };
   schedulePairingQrExpiryRefresh(messageKey, message, opts.onRequestUpdate);
   const images = resolveRenderableMessageImages(extractImages(message), imageRenderOptions);
@@ -2801,6 +2906,8 @@ function renderGroupedMessage(
                         opts.assistantAttachmentAuthToken,
                         opts.onRequestUpdate,
                         opts.onAssistantAttachmentLoaded,
+                        opts.onRequestOpenImage,
+                        opts.onOpenImage,
                       )}
                       ${assistantViewContent}
                       ${reasoningMarkdown
@@ -2865,6 +2972,8 @@ function renderGroupedMessage(
               opts.assistantAttachmentAuthToken,
               opts.onRequestUpdate,
               opts.onAssistantAttachmentLoaded,
+              opts.onRequestOpenImage,
+              opts.onOpenImage,
             )}
             ${reasoningMarkdown
               ? html`<div class="chat-thinking">

--- a/ui/src/pages/chat/components/chat-sidebar.test.ts
+++ b/ui/src/pages/chat/components/chat-sidebar.test.ts
@@ -83,6 +83,39 @@ describe("markdown sidebar", () => {
     panel.remove();
   });
 
+  it("activates Markdown images only when a chat owner opts in", async () => {
+    const panel = document.createElement("openclaw-chat-detail-panel") as HTMLElement & {
+      content: unknown;
+      onOpenImage?: (item: { src: string; title: string }) => void;
+      updateComplete?: Promise<unknown>;
+    };
+    const onOpenImage = vi.fn();
+    panel.content = { kind: "markdown", content: "![Preview](data:image/png;base64,cG5n)" };
+    panel.onOpenImage = onOpenImage;
+    document.body.append(panel);
+    await panel.updateComplete;
+
+    panel.querySelector<HTMLButtonElement>(".markdown-inline-image-button")?.click();
+    expect(onOpenImage).toHaveBeenCalledWith({
+      src: "data:image/png;base64,cG5n",
+      title: "Preview",
+    });
+    panel.remove();
+
+    const fallbackPanel = document.createElement("openclaw-chat-detail-panel") as HTMLElement & {
+      content: unknown;
+      updateComplete?: Promise<unknown>;
+    };
+    fallbackPanel.content = {
+      kind: "markdown",
+      content: "![Preview](data:image/png;base64,cG5n)",
+    };
+    document.body.append(fallbackPanel);
+    await fallbackPanel.updateComplete;
+    expect(fallbackPanel.querySelector(".markdown-inline-image-button")).toBeNull();
+    fallbackPanel.remove();
+  });
+
   it("opens image artifacts through the shared lightbox callback", async () => {
     const panel = document.createElement("openclaw-chat-detail-panel") as HTMLElement & {
       content: unknown;

--- a/ui/src/pages/chat/components/chat-sidebar.test.ts
+++ b/ui/src/pages/chat/components/chat-sidebar.test.ts
@@ -106,6 +106,29 @@ describe("markdown sidebar", () => {
       title: "Artifact preview",
     });
     panel.remove();
+
+    const fallbackPanel = document.createElement("openclaw-chat-detail-panel") as HTMLElement & {
+      content: unknown;
+      updateComplete?: Promise<unknown>;
+    };
+    fallbackPanel.content = {
+      kind: "image",
+      title: "Artifact preview",
+      src: "data:image/png;base64,cG5n",
+    };
+    document.body.append(fallbackPanel);
+    await fallbackPanel.updateComplete;
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(null);
+    fallbackPanel
+      .querySelector<HTMLButtonElement>(".chat-tool-card__preview-image-button")
+      ?.click();
+    expect(openSpy).toHaveBeenCalledWith(
+      "data:image/png;base64,cG5n",
+      "_blank",
+      "noopener,noreferrer",
+    );
+    openSpy.mockRestore();
+    fallbackPanel.remove();
   });
 
   it("keeps a canvas scripts ceiling under a trusted global sandbox", async () => {

--- a/ui/src/pages/chat/components/chat-sidebar.test.ts
+++ b/ui/src/pages/chat/components/chat-sidebar.test.ts
@@ -83,6 +83,31 @@ describe("markdown sidebar", () => {
     panel.remove();
   });
 
+  it("opens image artifacts through the shared lightbox callback", async () => {
+    const panel = document.createElement("openclaw-chat-detail-panel") as HTMLElement & {
+      content: unknown;
+      onOpenImage?: (item: { src: string; title: string }) => void;
+      updateComplete?: Promise<unknown>;
+    };
+    const onOpenImage = vi.fn();
+    panel.content = {
+      kind: "image",
+      title: "Artifact preview",
+      src: "data:image/png;base64,cG5n",
+    };
+    panel.onOpenImage = onOpenImage;
+    document.body.append(panel);
+    await panel.updateComplete;
+
+    panel.querySelector<HTMLButtonElement>(".chat-tool-card__preview-image-button")?.click();
+
+    expect(onOpenImage).toHaveBeenCalledWith({
+      src: "data:image/png;base64,cG5n",
+      title: "Artifact preview",
+    });
+    panel.remove();
+  });
+
   it("keeps a canvas scripts ceiling under a trusted global sandbox", async () => {
     const panel = document.createElement("openclaw-chat-detail-panel") as HTMLElement & {
       content: unknown;

--- a/ui/src/pages/chat/components/chat-sidebar.ts
+++ b/ui/src/pages/chat/components/chat-sidebar.ts
@@ -525,7 +525,10 @@ function renderMarkdownSidebar(props: MarkdownSidebarProps) {
   const content = props.content;
   const markdownHtml =
     content?.kind === "markdown" && content.content.trim()
-      ? toSanitizedMarkdownHtml(content.content, { fileLinks: true })
+      ? toSanitizedMarkdownHtml(content.content, {
+          fileLinks: true,
+          interactiveImages: props.onOpenImage !== undefined,
+        })
       : "";
   const canvasSandbox =
     content?.kind === "canvas"
@@ -1305,6 +1308,23 @@ class ChatDetailPanel extends OpenClawLightDomElement {
   };
 
   private readonly handlePanelClick = (event: Event) => {
+    const imageButton = event
+      .composedPath()
+      .find(
+        (target): target is HTMLElement =>
+          target instanceof HTMLElement &&
+          target.classList.contains("markdown-inline-image-button"),
+      );
+    const image = imageButton?.querySelector<HTMLImageElement>(".markdown-inline-image");
+    if (image) {
+      event.preventDefault();
+      openSidebarImage(
+        this.onOpenImage ?? undefined,
+        image.currentSrc || image.src,
+        image.alt.trim() || t("chat.imageLightbox.untitled"),
+      );
+      return;
+    }
     handleMarkdownCodeBlockCopy(event);
     const target = markdownFileLinkFromEvent(event);
     if (target) {

--- a/ui/src/pages/chat/components/chat-sidebar.ts
+++ b/ui/src/pages/chat/components/chat-sidebar.ts
@@ -3,6 +3,7 @@ import { property, state } from "lit/decorators.js";
 import { keyed } from "lit/directives/keyed.js";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { icons } from "../../../components/icons.ts";
+import type { ImageLightboxItem } from "../../../components/image-lightbox.ts";
 import "../../../components/web-awesome.ts";
 import {
   handleMarkdownCodeBlockCopy,
@@ -500,6 +501,7 @@ type MarkdownSidebarProps = {
   error: string | null;
   fileView?: FileViewControls;
   onClose: () => void;
+  onOpenImage?: (item: ImageLightboxItem) => void;
   onViewRawText: () => void;
   canvasPluginSurfaceUrl?: string | null;
   embedSandboxMode?: EmbedSandboxMode;
@@ -642,12 +644,19 @@ function renderMarkdownSidebar(props: MarkdownSidebarProps) {
                       ? html`
                           <div class="chat-tool-card__preview" data-kind="image">
                             <div class="chat-tool-card__preview-panel" data-side="front">
-                              <img
-                                class="chat-tool-card__preview-image"
-                                src=${content.src}
-                                alt=${title}
-                                style="display:block;max-width:100%;height:auto;border-radius:8px;"
-                              />
+                              <button
+                                type="button"
+                                class="chat-tool-card__preview-image-button"
+                                aria-label=${t("chat.imageLightbox.open", { title })}
+                                @click=${() => props.onOpenImage?.({ src: content.src, title })}
+                              >
+                                <img
+                                  class="chat-tool-card__preview-image"
+                                  src=${content.src}
+                                  alt=${title}
+                                  style="display:block;max-width:100%;height:auto;border-radius:8px;"
+                                />
+                              </button>
                             </div>
                             ${content.rawText?.trim()
                               ? html`
@@ -711,6 +720,7 @@ class ChatDetailPanel extends OpenClawLightDomElement {
     | ((target: { path: string; line?: number | null }) => void)
     | null = null;
   @property({ attribute: false }) onRevealInWorkspace?: ((path: string) => void) | null = null;
+  @property({ attribute: false }) onOpenImage?: ((item: ImageLightboxItem) => void) | null = null;
 
   @state() private visibleContent: SidebarContent | null = null;
   @state() private error: string | null = null;
@@ -1335,6 +1345,7 @@ class ChatDetailPanel extends OpenClawLightDomElement {
           embedSandboxMode: this.embedSandboxMode,
           allowExternalEmbedUrls: this.allowExternalEmbedUrls,
           onClose: this.close,
+          onOpenImage: this.onOpenImage ?? undefined,
           onViewRawText: this.showRawText,
         })}
       </div>

--- a/ui/src/pages/chat/components/chat-sidebar.ts
+++ b/ui/src/pages/chat/components/chat-sidebar.ts
@@ -20,6 +20,7 @@ import {
 } from "../../../lib/chat/tool-display.ts";
 import { copyToClipboard } from "../../../lib/clipboard.ts";
 import { type EditorId, openEditor } from "../../../lib/editor-links.ts";
+import { openExternalUrlSafe } from "../../../lib/open-external-url.ts";
 import { OpenClawLightDomElement } from "../../../lit/openclaw-element.ts";
 import "./session-discussion-panel.ts";
 import "./session-diff-panel.ts";
@@ -496,6 +497,18 @@ function resolveSidebarCanvasSandbox(
     : "allow-scripts";
 }
 
+function openSidebarImage(
+  onOpenImage: ((item: ImageLightboxItem) => void) | undefined,
+  src: string,
+  title: string,
+) {
+  if (onOpenImage) {
+    onOpenImage({ src, title });
+  } else {
+    openExternalUrlSafe(src, { allowDataImage: true });
+  }
+}
+
 type MarkdownSidebarProps = {
   content: SidebarContent | null;
   error: string | null;
@@ -648,7 +661,8 @@ function renderMarkdownSidebar(props: MarkdownSidebarProps) {
                                 type="button"
                                 class="chat-tool-card__preview-image-button"
                                 aria-label=${t("chat.imageLightbox.open", { title })}
-                                @click=${() => props.onOpenImage?.({ src: content.src, title })}
+                                @click=${() =>
+                                  openSidebarImage(props.onOpenImage, content.src, title)}
                               >
                                 <img
                                   class="chat-tool-card__preview-image"

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -19,6 +19,7 @@ import type { QuestionPrompt } from "../../../app/question-prompt.ts";
 import { resolveLocalUserName } from "../../../app/user-identity.ts";
 import { COPY_LABEL } from "../../../components/copy-button.ts";
 import { icons } from "../../../components/icons.ts";
+import type { ImageLightboxItem } from "../../../components/image-lightbox.ts";
 import "../../../components/tooltip.ts";
 import {
   handleMarkdownCodeBlockCopy,
@@ -149,6 +150,8 @@ type ChatThreadProps = {
   onOpenWorkspaceFile?: (target: { path: string; line?: number | null }) => void;
   onOpenSessionCheckpoints?: () => void | Promise<void>;
   onAssistantAttachmentLoaded?: () => void;
+  onRequestOpenImage?: () => number;
+  onOpenImage?: (item: ImageLightboxItem, requestVersion?: number) => void;
   onRequestUpdate?: () => void;
   onChatScroll?: (event: Event) => void;
   onHistoryIntent?: (event: Event) => void;
@@ -1253,6 +1256,8 @@ function renderChatThreadContents(
       onToggleToolExpanded: toggleToolCardExpanded,
       onRequestUpdate: requestUpdate,
       onAssistantAttachmentLoaded: props.onAssistantAttachmentLoaded,
+      onRequestOpenImage: props.onRequestOpenImage,
+      onOpenImage: props.onOpenImage,
       assistantName: props.assistantName,
       assistantAvatar: assistantIdentity.avatar,
       userId: props.userId ?? null,

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -1030,6 +1030,21 @@ openclaw-chat-page {
   margin-bottom: 8px;
 }
 
+.chat-message-image-button {
+  display: inline-flex;
+  max-width: 100%;
+  padding: 0;
+  border: 0;
+  border-radius: var(--radius-md);
+  background: transparent;
+  cursor: zoom-in;
+}
+
+.chat-message-image-button:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 3px;
+}
+
 .chat-message-image {
   width: auto;
   max-width: min(100%, 300px);
@@ -1040,7 +1055,7 @@ openclaw-chat-page {
   transition: transform 150ms ease-out;
 }
 
-.chat-message-image:hover {
+.chat-message-image-button:hover .chat-message-image {
   transform: scale(1.02);
 }
 

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -138,13 +138,33 @@
   font-size: 0.9em;
 }
 
+.chat-text :where(.markdown-inline-image-button) {
+  display: block;
+  max-width: min(100%, 420px);
+  margin-top: 0.75em;
+  padding: 0;
+  border: 0;
+  border-radius: var(--radius-md);
+  background: transparent;
+  cursor: zoom-in;
+}
+
+.chat-text :where(.markdown-inline-image-button:focus-visible) {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 3px;
+}
+
+.chat-text :where(a > .markdown-inline-image) {
+  margin-top: 0.75em;
+}
+
 .chat-text :where(.markdown-inline-image) {
   display: block;
   max-width: min(100%, 420px);
   max-height: 320px;
   width: auto;
   height: auto;
-  margin-top: 0.75em;
+  margin-top: 0;
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
   background: color-mix(in srgb, var(--secondary) 70%, transparent);

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -154,21 +154,21 @@
   outline-offset: 3px;
 }
 
-.chat-text :where(a > .markdown-inline-image) {
-  margin-top: 0.75em;
-}
-
 .chat-text :where(.markdown-inline-image) {
   display: block;
   max-width: min(100%, 420px);
   max-height: 320px;
   width: auto;
   height: auto;
-  margin-top: 0;
+  margin-top: 0.75em;
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
   background: color-mix(in srgb, var(--secondary) 70%, transparent);
   object-fit: contain;
+}
+
+.chat-text :where(.markdown-inline-image-button > .markdown-inline-image) {
+  margin-top: 0;
 }
 
 .chat-text :where(:not(pre) > code) {

--- a/ui/src/styles/chat/tool-cards.css
+++ b/ui/src/styles/chat/tool-cards.css
@@ -837,6 +837,21 @@
   padding: 0;
 }
 
+.chat-tool-card__preview-image-button {
+  display: block;
+  max-width: 100%;
+  padding: 0;
+  border: 0;
+  border-radius: var(--radius-md);
+  background: transparent;
+  cursor: zoom-in;
+}
+
+.chat-tool-card__preview-image-button:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 3px;
+}
+
 .chat-tool-card__preview-frame {
   display: block;
   width: 100%;

--- a/ui/src/styles/sidebar-markdown.css
+++ b/ui/src/styles/sidebar-markdown.css
@@ -213,13 +213,33 @@
   font-weight: 600;
 }
 
+.sidebar-markdown .markdown-inline-image-button {
+  display: block;
+  max-width: 100%;
+  margin-top: 0.75em;
+  padding: 0;
+  border: 0;
+  border-radius: var(--radius-md);
+  background: transparent;
+  cursor: zoom-in;
+}
+
+.sidebar-markdown .markdown-inline-image-button:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 3px;
+}
+
+.sidebar-markdown a > .markdown-inline-image {
+  margin-top: 0.75em;
+}
+
 .sidebar-markdown .markdown-inline-image {
   display: block;
   width: auto;
   max-width: 100%;
   height: auto;
   max-height: 420px;
-  margin-top: 0.75em;
+  margin-top: 0;
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
   background: color-mix(in srgb, var(--secondary) 70%, transparent);

--- a/ui/src/styles/sidebar-markdown.css
+++ b/ui/src/styles/sidebar-markdown.css
@@ -229,21 +229,21 @@
   outline-offset: 3px;
 }
 
-.sidebar-markdown a > .markdown-inline-image {
-  margin-top: 0.75em;
-}
-
 .sidebar-markdown .markdown-inline-image {
   display: block;
   width: auto;
   max-width: 100%;
   height: auto;
   max-height: 420px;
-  margin-top: 0;
+  margin-top: 0.75em;
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
   background: color-mix(in srgb, var(--secondary) 70%, transparent);
   object-fit: contain;
+}
+
+.sidebar-markdown .markdown-inline-image-button > .markdown-inline-image {
+  margin-top: 0;
 }
 
 .sidebar-markdown :where(details) {


### PR DESCRIPTION
Closes #112425

## What Problem This Solves

Control UI chat images are thumbnail-sized. Opening a transcript image currently moves users into a separate browser tab, while image artifacts in the session sidebar cannot be enlarged at all. That makes visual tool output and generated images hard to inspect without losing conversation context.

## Why This Change Was Made

The Control UI now uses its canonical modal primitive for a shared, responsive image lightbox. Chat keeps ownership of URL safety, media tickets, and managed outgoing-image Blob lifetimes; the viewer only presents the already-authorized source. Structured transcript images, eligible inline Markdown data images, and sidebar artifacts all use the same interaction. Linked Markdown images deliberately retain their authored link behavior.

## User Impact

Users can inspect chat and sidebar images at a useful size without leaving the session. The viewer has keyboard-native triggers, focus containment and restoration, Escape/backdrop dismissal, a responsive small-viewport layout, and an option to open the original image.

## Evidence

- Remote Blacksmith Testbox: Control UI typecheck, production UI build, compressed-asset/performance checks, **486 focused unit tests**, and the mocked-Gateway Chromium lightbox E2E all passed on the PR head.
- Final structured `autoreview` (Codex): **clean**.

### Sidebar image before opening

![Image artifact in the session detail sidebar](https://github.com/steipete/openclaw-pr-assets/releases/download/pr-112442/sidebar-image.png)

### Accessible in-app lightbox

![The same sidebar image opened in the lightbox](https://github.com/steipete/openclaw-pr-assets/releases/download/pr-112442/sidebar-lightbox.png)

The sanitized screenshots are attached in the dedicated [PR proof release](https://github.com/steipete/openclaw-pr-assets/releases/tag/pr-112442), not committed to the product repository.

AI-assisted implementation; reviewed and verified against the focused Control UI behavior and media-security paths.
