### PR TITLE
fix(deps): bump fast-uri override to 3.1.4

### DIFF
--- a/extensions/acpx/npm-shrinkwrap.json
+++ b/extensions/acpx/npm-shrinkwrap.json
@@ -1514,9 +1514,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",

--- a/extensions/lobster/npm-shrinkwrap.json
+++ b/extensions/lobster/npm-shrinkwrap.json
@@ -53,9 +53,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1477,9 +1477,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,7 +14,7 @@ overrides:
   hono: 4.12.25
   '@hono/node-server': 1.19.14
   axios: 1.18.0
-  fast-uri: 3.1.3
+  fast-uri: 3.1.4
   follow-redirects: 1.16.0
   defu: 6.1.5
   fast-xml-parser: 5.7.0
@@ -5831,8 +5831,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.3:
-    resolution: {integrity: sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==}
+  fast-uri@3.1.4:
+    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -11428,7 +11428,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.3
+      fast-uri: 3.1.4
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -12220,7 +12220,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.3: {}
+  fast-uri@3.1.4: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -106,7 +106,7 @@ overrides:
   hono: 4.12.25
   "@hono/node-server": 1.19.14
   axios: 1.18.0
-  fast-uri: 3.1.3
+  fast-uri: 3.1.4
   follow-redirects: 1.16.0
   defu: 6.1.5
   fast-xml-parser: 5.7.0


### PR DESCRIPTION
## What Problem This Solves

The `security-fast` CI job's "Audit production dependencies" step fails repo-wide — including on `main` — since 2026-07-21 22:08 UTC, when GHSA-v2hh-gcrm-f6hx published (fast-uri host confusion via literal backslash authority delimiter, HIGH, vulnerable `>=3.0.0 <=3.1.3`, first patched 3.1.4). The pnpm override pins `fast-uri: 3.1.3` — the fix for the earlier advisory cleared by #112406 — which the new advisory also covers, so `openclaw/ci-gate` is red on every PR regardless of content.

## Why This Change Was Made

`scripts/pre-commit/pnpm-audit-prod.mjs --audit-level=high` fails closed on HIGH advisories in production dependencies. fast-uri is a transitive production dependency via `ajv@8.20.0`. Bumping the override to the first patched version (3.1.4, exact pin per repo override policy) clears the advisory and unblocks CI. Same shape as the previous bump in #112406: override in `pnpm-workspace.yaml`, regenerated `pnpm-lock.yaml`, regenerated npm shrinkwraps.

## User Impact

No product behavior change. Restores green `security-fast`/`openclaw/ci-gate` for all PRs and `main`. Resolved dependency trees ship fast-uri 3.1.4, which fixes the URI host-confusion parsing flaw.

## Evidence

- `node scripts/pre-commit/pnpm-audit-prod.mjs --audit-level=high` → `No high or higher advisories found for production dependencies.`
- `node scripts/generate-npm-shrinkwrap.mjs --all --check` → all 82 shrinkwrap files current
- `node scripts/run-vitest.mjs test/scripts/root-package-overrides.test.ts test/package-manager-config.test.ts` → 2 files, 16 tests passed
- `git diff --check` → clean
- fast-uri@3.1.4 `integrity` in the lockfile/shrinkwraps matches the npm registry `dist.integrity` for that version
- Advisory: https://github.com/advisories/GHSA-v2hh-gcrm-f6hx (published 2026-07-21T22:08:28Z; vulnerable `>=3.0.0 <=3.1.3`; patched 3.1.4)
