### PR TITLE
feat(agents): escalate unbroken identical tool-call runs (consecutive-repeat detector)

### DIFF
--- a/docs/tools/loop-detection.md
+++ b/docs/tools/loop-detection.md
@@ -25,6 +25,10 @@ Set `tools.loopDetection.enabled: false` to silence both guardrails.
 - Detect repetitive sequences that make no progress.
 - Detect high-frequency no-result loops (same tool, same inputs, repeated
   errors).
+- Block unbroken runs of byte-identical calls even when every result differs
+  (timestamps, fresh page dumps, rate-limited errors with new request ids) —
+  the no-progress tier never fires for those because the result hash changes
+  on every call. Known polling tools are exempt.
 - Detect specific repeated-call patterns for known polling tools.
 - Break context-overflow -> compaction -> same-loop cycles instead of letting
   them run indefinitely.

--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -373,6 +373,63 @@ describe("tool-loop-detection", () => {
       }
     });
 
+    it("blocks an unbroken run of identical calls even when every result differs", () => {
+      const state = createState();
+      const params = { command: "date +%S" };
+
+      for (let i = 0; i < CRITICAL_THRESHOLD; i += 1) {
+        recordSuccessfulCall(state, "exec", params, `second ${i}`, i);
+      }
+
+      const result = detectToolCallLoop(state, "exec", params, enabledLoopDetectionConfig);
+
+      expect(result.stuck).toBe(true);
+      if (result.stuck) {
+        expect(result.level).toBe("critical");
+        expect(result.detector).toBe("consecutive_repeat");
+        expect(result.count).toBe(CRITICAL_THRESHOLD);
+      }
+    });
+
+    it("does not escalate to consecutive critical when another call interrupts the run", () => {
+      const state = createState();
+      const params = { command: "date +%S" };
+
+      for (let i = 0; i < CRITICAL_THRESHOLD; i += 1) {
+        recordSuccessfulCall(state, "exec", params, `second ${i}`, i);
+        if (i === 10) {
+          recordSuccessfulCall(state, "read", { path: "/tmp/progress.txt" }, "ok", 1000 + i);
+        }
+      }
+
+      const result = detectToolCallLoop(state, "exec", params, enabledLoopDetectionConfig);
+
+      // The windowed generic tier may still warn, but the unbroken-run critical
+      // must not fire once the streak was interrupted.
+      expect(result.stuck).toBe(true);
+      if (result.stuck) {
+        expect(result.level).toBe("warning");
+        expect(result.detector).toBe("generic_repeat");
+      }
+    });
+
+    it("stays at warning level just below the consecutive threshold", () => {
+      const state = createState();
+      const params = { command: "date +%S" };
+
+      for (let i = 0; i < CRITICAL_THRESHOLD - 1; i += 1) {
+        recordSuccessfulCall(state, "exec", params, `second ${i}`, i);
+      }
+
+      const result = detectToolCallLoop(state, "exec", params, enabledLoopDetectionConfig);
+
+      expect(result.stuck).toBe(true);
+      if (result.stuck) {
+        expect(result.level).toBe("warning");
+        expect(result.detector).toBe("generic_repeat");
+      }
+    });
+
     it("keeps scoped and unscoped history isolated", () => {
       const state = createState();
       const params = { path: "/same.txt" };
@@ -585,8 +642,11 @@ describe("tool-loop-detection", () => {
       const loopResult = detectToolCallLoop(state, "exec", params, enabledLoopDetectionConfig);
       expect(loopResult.stuck).toBe(true);
       if (loopResult.stuck) {
-        expect(loopResult.level).toBe("warning");
-        expect(loopResult.detector).toBe("generic_repeat");
+        // Changing output must never trip the no-progress GLOBAL breaker; the
+        // unbroken run of identical calls is escalated by the consecutive
+        // detector instead (its message tells the model how to proceed).
+        expect(loopResult.level).toBe("critical");
+        expect(loopResult.detector).toBe("consecutive_repeat");
       }
     });
 
@@ -615,8 +675,10 @@ describe("tool-loop-detection", () => {
       const loopResult = detectToolCallLoop(state, "exec", params, enabledLoopDetectionConfig);
       expect(loopResult.stuck).toBe(true);
       if (loopResult.stuck) {
-        expect(loopResult.level).toBe("warning");
-        expect(loopResult.detector).toBe("generic_repeat");
+        // Same as above: not the global breaker — the consecutive detector
+        // handles the unbroken identical-args run.
+        expect(loopResult.level).toBe("critical");
+        expect(loopResult.detector).toBe("consecutive_repeat");
       }
     });
 

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -19,6 +19,7 @@ const log = createSubsystemLogger("agents/loop-detection");
 
 type LoopDetectorKind =
   | "generic_repeat"
+  | "consecutive_repeat"
   | "unknown_tool_repeat"
   | "known_poll_no_progress"
   | "global_circuit_breaker"
@@ -50,6 +51,7 @@ const DEFAULT_LOOP_DETECTION_CONFIG = {
   globalCircuitBreakerThreshold: GLOBAL_CIRCUIT_BREAKER_THRESHOLD,
   detectors: {
     genericRepeat: true,
+    consecutiveRepeat: true,
     knownPollNoProgress: true,
     pingPong: true,
   },
@@ -64,6 +66,7 @@ type ResolvedLoopDetectionConfig = {
   globalCircuitBreakerThreshold: number;
   detectors: {
     genericRepeat: boolean;
+    consecutiveRepeat: boolean;
     knownPollNoProgress: boolean;
     pingPong: boolean;
   };
@@ -72,6 +75,29 @@ type ResolvedLoopDetectionConfig = {
 type ToolLoopDetectionScope = {
   runId?: string;
 };
+
+/**
+ * Length of the unbroken tail of history entries matching the current call's
+ * (toolName, argsHash). Unlike the no-progress streak this deliberately ignores
+ * result hashes: an unbroken run of byte-identical calls is a stuck loop even
+ * when every result differs (timestamps, fresh page dumps, rate-limited errors
+ * with new request ids).
+ */
+function getConsecutiveRepeatStreak(
+  history: readonly ToolCallRecord[],
+  toolName: string,
+  currentHash: string,
+): number {
+  let streak = 0;
+  for (let i = history.length - 1; i >= 0; i -= 1) {
+    const entry = history[i];
+    if (!entry || entry.toolName !== toolName || entry.argsHash !== currentHash) {
+      break;
+    }
+    streak += 1;
+  }
+  return streak;
+}
 
 function selectHistoryForScope(
   history: readonly ToolCallRecord[],
@@ -655,6 +681,36 @@ export function detectToolCallLoop(
       count: noProgressStreak,
       message: `CRITICAL: Called ${toolName} with identical arguments and identical outcomes ${noProgressStreak} times. Session execution blocked to prevent runaway loops.`,
       warningKey: `generic:${toolName}:${currentHash}:${noProgress.latestResultHash ?? "none"}`,
+    };
+  }
+
+  // Consecutive-repeat detector: an unbroken run of byte-identical calls is a
+  // stuck loop even when every result differs, so the no-progress tier above
+  // never fires (its streak resets whenever the result hash changes). This is
+  // the "same tool called with the same arguments N times, escalate regardless
+  // of exact result" circuit breaker asked for in #78865. A blocked call
+  // surfaces the message below to the model as the tool result, which both
+  // breaks the streak and tells the model how to proceed. Known polling tools
+  // and messaging sends are exempt: polling legitimately repeats, and sends
+  // have their own volatility-strip escalation above that understands which
+  // result-side changes count as progress (#89090).
+  const consecutiveStreak = getConsecutiveRepeatStreak(history, toolName, currentHash);
+  if (
+    !knownPollTool &&
+    !isVolatileSendResult(toolName, params) &&
+    resolvedConfig.detectors.consecutiveRepeat &&
+    consecutiveStreak >= resolvedConfig.criticalThreshold
+  ) {
+    log.error(
+      `Critical consecutive loop detected: ${toolName} repeated ${consecutiveStreak} times in a row`,
+    );
+    return {
+      stuck: true,
+      level: "critical",
+      detector: "consecutive_repeat",
+      count: consecutiveStreak,
+      message: `CRITICAL: Called ${toolName} with identical arguments ${consecutiveStreak} times in a row. The results differ, but an unbroken run of identical calls indicates a stuck loop. This call was blocked — change the arguments or approach, or stop and report current progress to the user.`,
+      warningKey: `consecutive:${toolName}:${currentHash}`,
     };
   }
 

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -452,6 +452,7 @@ export type DiagnosticToolLoopEvent = DiagnosticBaseEvent & {
   action: "warn" | "block";
   detector:
     | "generic_repeat"
+    | "consecutive_repeat"
     | "unknown_tool_repeat"
     | "known_poll_no_progress"
     | "global_circuit_breaker"

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -1137,6 +1137,7 @@ export function logToolLoopAction(
     action: "warn" | "block";
     detector:
       | "generic_repeat"
+      | "consecutive_repeat"
       | "unknown_tool_repeat"
       | "known_poll_no_progress"
       | "global_circuit_breaker"


### PR DESCRIPTION
## What Problem This Solves

#78865 asks for a platform-level circuit breaker: *"If the same tool is called with similar arguments N times… block the next call"*, because *"AGENTS.md is a suggestion… the enforcement has to happen at the platform level, not the prompt level."*

Today the generic detector's critical tier requires **identical results** (`noProgressStreak` resets whenever the result hash changes). A model stuck re-issuing the same call whose output differs every time — timestamps, fresh page dumps, rate-limited errors with new request ids — only ever produces a **log-side warning the model never sees**, and runs until the token budget burns out.

Production incident that motivated this (OpenClaw 2026.7.1, mimo-v2.5): a model re-issued the identical `exec date +%S` call **62 times in an unbroken run** — every result differed (seconds changed), so nothing escalated past the log warning; the turn ended only by output-token exhaustion (`stopReason=length`, ~34K output tokens). A second incident the same week ran a browser-workflow marathon of 141 rounds for the same reason.

## Why This Change Was Made

Adds a `consecutive_repeat` detector: an **unbroken run of byte-identical (tool, args) calls** — nothing else interleaved — escalates to a critical veto at `criticalThreshold`, regardless of result hashes. The veto reason reaches the model as the tool result, which both breaks the streak and tells the model how to proceed.

Scope guards:
- **Known polling tools are exempt** (polling legitimately repeats; the existing "does not block known polling when output progresses" test passes unchanged).
- **Messaging sends are exempt** (they have their own volatility-strip escalation that understands which result-side changes count as progress, #89090; its tests pass unchanged).
- Mixed workflows are untouched: any interleaved different call resets the streak, so productive same-args repetition inside varied work (navigate → sleep → print per item) never trips it.

**Deliberate behavior change:** two exec tests that pinned changing-output runs at warning level now expect the consecutive critical instead. Their original concern — the global no-progress breaker must not fire on changing results — still holds and is still asserted (via the detector kind). If you'd prefer a separate, higher threshold for this tier instead of reusing `criticalThreshold`, happy to adjust.

## User Impact

Runaway identical-call loops stop after `criticalThreshold` consecutive calls with an actionable, model-visible message, instead of silently burning the run budget. No config surface changes (the detector rides the existing internal defaults; disabled together with `tools.loopDetection.enabled=false`).

## Evidence

- `pnpm test -- src/agents/tool-loop-detection.test.ts` — 56/56 pass (3 new tests: unbroken-run block with varying results; interrupted run does not escalate; below-threshold stays at warning).
- `pnpm run tsgo:prod` — clean.
- Same design validated in production on our deployment (implemented as a plugin hook while this PR is open): a 15×-identical-exec request executed 11 calls, refused the rest with the guard message, and the model recovered and summarized cleanly — the veto text is sufficient for models to break out.
- Cross-model replays of the incident contexts (mimo, deepseek-v4-flash, kimi-k2.6/k3, minimax-m2.5, gpt-5.6, gemini-3.5-flash) show mid-tier models continue such loops 2/2–3/3 once loop history is in context — platform-level enforcement is the only reliable layer, exactly as #78865 argues.

Closes #78865
