### PR TITLE
fix(sessions): add non-string guard to validateSessionId

### DIFF
--- a/src/config/sessions/paths.ts
+++ b/src/config/sessions/paths.ts
@@ -64,6 +64,9 @@ export function resolveSessionFilePathOptions(params: {
 const SAFE_SESSION_ID_RE = /^[a-z0-9][a-z0-9._-]{0,127}$/i;
 
 export function validateSessionId(sessionId: string): string {
+  if (typeof sessionId !== "string") {
+    throw new Error(`Invalid session ID: ${String(sessionId)}`);
+  }
   const trimmed = sessionId.trim();
   if (
     !SAFE_SESSION_ID_RE.test(trimmed) ||

--- a/src/config/sessions/sessions.test.ts
+++ b/src/config/sessions/sessions.test.ts
@@ -69,6 +69,12 @@ describe("session path safety", () => {
     }
   });
 
+  it("throws a controlled error for non-string sessionId", () => {
+    for (const bad of [undefined, null, 123]) {
+      expect(() => validateSessionId(bad as unknown as string)).toThrow(/Invalid session ID/);
+    }
+  });
+
   it("resolves transcript path inside an explicit sessions dir", () => {
     const sessionsDir = "/tmp/openclaw/agents/main/sessions";
     const resolved = resolveSessionTranscriptPathInDir("sess-1", sessionsDir, "topic/a+b");


### PR DESCRIPTION
## What Problem This Solves

`openclaw sessions tail <key>` crashes with an uncaught `TypeError: Cannot read properties of undefined (reading 'trim')` when any entry in the session store lacks a `sessionId` (e.g. from an aborted init or gateway store-rewrite). The crash occurs because `validateSessionId` calls `sessionId.trim()` without a type guard, so `undefined` inputs throw a TypeError instead of the expected controlled `Error("Invalid session ID: ...")`.

Closes #112355

## Evidence

The fix adds a `typeof sessionId !== 'string'` check at the top of `validateSessionId` that throws the same "Invalid session ID" error pattern already used by the regex check below it. This converts an unhandled TypeError into a catchable, descriptive Error.

## Changes

- `src/config/sessions/paths.ts`: Add type guard before `.trim()` call
- `src/config/sessions/sessions.test.ts`: Add test verifying `undefined`, `null`, and numeric inputs throw controlled errors

## Real behavior proof

**Behavior or issue addressed**: validateSessionId crashes with TypeError on non-string input
**Real environment tested**: Linux x64, Node v24.18.0, vitest 4.1.9
**Exact steps or command run after this patch**: npx vitest run src/config/sessions/sessions.test.ts
**Evidence after fix**: 47 tests pass including new non-string guard test
**Observed result after fix**: undefined/null/numeric inputs now throw "Invalid session ID" Error instead of TypeError
**What was not tested**: Full sessions tail CLI flow with corrupted store (unit test covers the root cause function)