### PR TITLE
fix(ui): use catalog display names in the agent model picker

### DIFF
--- a/ui/src/lib/agents/display.test.ts
+++ b/ui/src/lib/agents/display.test.ts
@@ -12,6 +12,7 @@ import {
   buildAgentContext,
   formatBytes,
   listSelectableAgents,
+  resolveConfiguredModels,
   resolveEffectiveModelFallbacks,
 } from "./display.ts";
 
@@ -25,6 +26,36 @@ describe("listSelectableAgents", () => {
 
     expect(listSelectableAgents(agents)).toEqual([agents[0], agents[2]]);
     expect(agents).toHaveLength(3);
+  });
+});
+
+describe("resolveConfiguredModels (model picker labels)", () => {
+  const catalog = [
+    { id: "claude-opus-4-8", provider: "anthropic", name: "Opus 4.8" },
+  ] as unknown as ModelCatalogEntry[];
+
+  it("labels an aliased configured model with its catalog display name, not the alias (regression #111884)", () => {
+    const configForm = {
+      agents: { defaults: { models: { "anthropic/claude-opus-4-8": { alias: "opus" } } } },
+    };
+    const [option] = resolveConfiguredModels(configForm, catalog);
+    expect(option?.label).toBe("Opus 4.8");
+  });
+
+  it("preserves an intentional custom alias the catalog name does not convey", () => {
+    const configForm = {
+      agents: { defaults: { models: { "anthropic/claude-opus-4-8": { alias: "smart" } } } },
+    };
+    const [option] = resolveConfiguredModels(configForm, catalog);
+    expect(option?.label).toBe("smart (Opus 4.8)");
+  });
+
+  it("falls back to the raw id when the model is not in the catalog", () => {
+    const configForm = {
+      agents: { defaults: { models: { "openai/mystery-model": {} } } },
+    };
+    const [option] = resolveConfiguredModels(configForm, catalog);
+    expect(option?.label).toBe("openai/mystery-model");
   });
 });
 

--- a/ui/src/lib/agents/display.ts
+++ b/ui/src/lib/agents/display.ts
@@ -16,7 +16,11 @@ import type {
 } from "../../api/types.ts";
 import { t } from "../../i18n/index.ts";
 import { resolveAgentAvatarUrl, resolveAssistantTextAvatar } from "../avatar.ts";
-import { buildQualifiedChatModelValue } from "../chat/model-ref.ts";
+import {
+  buildCatalogDisplayLookup,
+  buildQualifiedChatModelValue,
+  formatCatalogEntryDisplay,
+} from "../chat/model-ref.ts";
 import { normalizeLowercaseStringOrEmpty, normalizeOptionalString } from "../string-coerce.ts";
 
 type AgentRosterEntry = {
@@ -508,13 +512,44 @@ type ConfiguredModelOption = {
   label: string;
 };
 
-function resolveConfiguredModels(
+function buildQualifiedModelValue(entry: ModelCatalogEntry): string {
+  return buildQualifiedChatModelValue(entry.id, entry.provider);
+}
+
+function isAliasCoveredByCatalogLabel(
+  alias: string,
+  value: string,
+  entry: ModelCatalogEntry,
+  catalogLabel: string,
+) {
+  const normalizedAlias = normalizeLowercaseStringOrEmpty(alias);
+  if (!normalizedAlias) {
+    return true;
+  }
+  if (
+    normalizedAlias === normalizeLowercaseStringOrEmpty(value) ||
+    normalizedAlias === normalizeLowercaseStringOrEmpty(entry.id) ||
+    normalizedAlias === normalizeLowercaseStringOrEmpty(entry.alias ?? "")
+  ) {
+    return true;
+  }
+  const labelWords = new Set(catalogLabel.toLowerCase().split(/[^a-z0-9.]+/));
+  return labelWords.has(normalizedAlias);
+}
+
+export function resolveConfiguredModels(
   configForm: Record<string, unknown> | null,
+  catalog?: ModelCatalogEntry[],
 ): ConfiguredModelOption[] {
   const cfg = configForm as ConfigSnapshot | null;
   const models = cfg?.agents?.defaults?.models;
   if (!models || typeof models !== "object") {
     return [];
+  }
+  const displayLookup = buildCatalogDisplayLookup(catalog ?? []);
+  const catalogByValue = new Map<string, ModelCatalogEntry>();
+  for (const entry of catalog ?? []) {
+    catalogByValue.set(normalizeLowercaseStringOrEmpty(buildQualifiedModelValue(entry)), entry);
   }
   const options: ConfiguredModelOption[] = [];
   for (const [modelId, modelRaw] of Object.entries(models)) {
@@ -528,7 +563,17 @@ function resolveConfiguredModels(
           ? (modelRaw as { alias?: string }).alias?.trim()
           : undefined
         : undefined;
-    const label = alias && alias !== trimmed ? `${alias} (${trimmed})` : trimmed;
+    const catalogEntry = catalogByValue.get(normalizeLowercaseStringOrEmpty(trimmed));
+    let label = alias && alias !== trimmed ? `${alias} (${trimmed})` : trimmed;
+    if (catalogEntry) {
+      const catalogLabel = formatCatalogEntryDisplay(catalogEntry, displayLookup);
+      label =
+        alias &&
+        alias !== trimmed &&
+        !isAliasCoveredByCatalogLabel(alias, trimmed, catalogEntry, catalogLabel)
+          ? `${alias} (${catalogLabel})`
+          : catalogLabel;
+    }
     options.push({ value: trimmed, label });
   }
   return options;
@@ -552,16 +597,14 @@ export function buildModelOptions(
     options.push({ value, label });
   };
 
-  for (const opt of resolveConfiguredModels(configForm)) {
+  for (const opt of resolveConfiguredModels(configForm, catalog)) {
     addOption(opt.value, opt.label);
   }
 
   if (catalog) {
+    const displayLookup = buildCatalogDisplayLookup(catalog);
     for (const entry of catalog) {
-      const provider = entry.provider?.trim();
-      const value = buildQualifiedChatModelValue(entry.id, provider);
-      const label = provider ? `${entry.id} · ${provider}` : entry.id;
-      addOption(value, label);
+      addOption(buildQualifiedModelValue(entry), formatCatalogEntryDisplay(entry, displayLookup));
     }
   }
 

--- a/ui/src/lib/chat/model-ref.ts
+++ b/ui/src/lib/chat/model-ref.ts
@@ -260,7 +260,7 @@ export function buildCatalogDisplayLookup(catalog: ModelCatalogEntry[]): Map<str
   return displayLookup;
 }
 
-function formatCatalogEntryDisplay(
+export function formatCatalogEntryDisplay(
   entry: ModelCatalogEntry,
   displayLookup: ChatModelDisplayLookup,
 ): string {


### PR DESCRIPTION
## What Problem This Solves

The Control UI agent **model picker** labels a configured model by its family **alias/id** instead of its **catalog display name**. A model configured as `anthropic/claude-opus-4-8` with `alias: opus` renders as **"Opus"** in the dropdown — `resolveConfiguredModels` produces the label `opus (anthropic/claude-opus-4-8)` — instead of its versioned display name **"Opus 4.8"**. The version is dropped from the visible label, so users can't distinguish Opus 4.8 from an older Opus (same for Sonnet 5 → "Sonnet").

This is a regression of #67988: that issue was fixed in #75157 for the then-aliased models, but the bug moved to whichever models currently hold the family alias (`claude-opus-4-8` → `alias:opus`, `claude-sonnet-5` → `alias:sonnet`).

Closes #111884.

## Why This Change Was Made

The #75157 fix lived in `ui/src/ui/views/agents-utils.ts::resolveConfiguredModels`. That module is **no longer imported anywhere** — the label logic was refactored into `ui/src/lib/agents/display.ts` (used by the live picker at `pages/agents/panels-overview.ts`), and the refactor reintroduced the pre-fix label (`` `${alias} (${id})` ``), dropping the catalog-display-name resolution. Both the configured-model path and the catalog-entry path ignored the catalog `name`.

This ports the reviewed #75157 logic to `display.ts`:
- `resolveConfiguredModels` now takes the catalog, prefers the catalog display name, and preserves an intentional custom alias only when the catalog label doesn't already convey it (`isAliasCoveredByCatalogLabel`, identical to #75157).
- `buildModelOptions` threads the catalog through and labels catalog entries with `formatCatalogEntryDisplay` instead of `` `${id} · ${provider}` ``.
- `formatCatalogEntryDisplay` is exported from `lib/chat/model-ref.ts` (already used internally by `buildChatModelOptionFromLookup`).

No behavior change when no catalog is available (unchanged fallback to the raw id/alias).

## User Impact

The picker again shows the full versioned display name ("Opus 4.8", "Sonnet 5"), matching the configured name and `openclaw models` output, so aliased flagship models are distinguishable. Custom user aliases that add information are preserved (e.g. `smart (Opus 4.8)`).

## Evidence

Focused unit tests added to `ui/src/lib/agents/display.test.ts`; the full file passes **20/20**. The regression tests **fail on the pre-fix code and pass after** — verified by reverting only the label fix:

Before (label fix reverted):
```
AssertionError: expected 'opus (anthropic/claude-opus-4-8)' to be 'Opus 4.8'
AssertionError: expected 'smart (anthropic/claude-opus-4-8)' to be 'smart (Opus 4.8)'
```
After (fix applied):
```
Test Files  1 passed (1)
     Tests  20 passed (20)
```

Tests cover: aliased configured model → catalog display name; intentional custom alias preserved; non-catalog model falls back to its raw id.
