### PR TITLE
fix(hooks): kill gog process tree on gmail-watcher shutdown

### DIFF
--- a/src/hooks/gmail-watcher.integration.test.ts
+++ b/src/hooks/gmail-watcher.integration.test.ts
@@ -1,24 +1,21 @@
 /**
- * Integration proof for issue #106612.
- *
  * Runs startGmailWatcher and stopGmailWatcher with NO mocks for spawn or
  * killProcessTree. A fake `gog` binary is placed on PATH; it spawns a
  * credential-helper child and deliberately does NOT kill it on SIGTERM,
  * simulating the real bug. The test asserts that stopGmailWatcher removes
  * both the gog process and its descendant via the process-group signal.
  */
-import { execSync } from "node:child_process";
-import { existsSync, mkdirSync, rmSync, writeFileSync, readFileSync, chmodSync } from "node:fs";
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 // Only run when explicitly opted in — requires real subprocess spawning.
-const RUN = process.env["OPENCLAW_INTEGRATION_TEST"] === "1";
+const RUN = process.platform !== "win32" && process.env["OPENCLAW_INTEGRATION_TEST"] === "1";
 
 function alive(pid: number): boolean {
   try {
-    execSync(`kill -0 ${pid} 2>/dev/null`);
+    process.kill(pid, 0);
     return true;
   } catch {
     return false;
@@ -28,27 +25,30 @@ function alive(pid: number): boolean {
 describe.skipIf(!RUN)("gmail-watcher process-tree shutdown (integration)", () => {
   let tmpDir: string;
   let savedPath: string | undefined;
+  let gogPid: number | undefined;
+  let helperPid: number | undefined;
+  let stopWatcher: (() => Promise<void>) | undefined;
 
   beforeAll(() => {
-    tmpDir = join(tmpdir(), `gog-integration-${process.pid}`);
-    mkdirSync(tmpDir, { recursive: true });
+    tmpDir = mkdtempSync(join(tmpdir(), "openclaw-gog-integration-"));
 
     // fake gog: handles `watch start` (exits 0) and `watch serve`
-    // (spawns a credential-helper sleep and does NOT kill it on SIGTERM)
+    // (spawns a credential-helper that ignores SIGTERM)
     const gogScript = join(tmpDir, "gog");
     writeFileSync(
       gogScript,
       [
         "#!/bin/bash",
+        'SCRIPT_DIR="$(cd -- "$(dirname -- "$0")" && pwd)"',
         'case "$*" in',
         '  *"watch start"*) echo "[gog] watch registered"; exit 0 ;;',
         '  *"watch serve"*)',
         '    echo "[gog] serve started pid=$$"',
-        `    echo $$ > ${tmpDir}/gog.pid`,
-        "    sleep 99999 &",
+        '    echo $$ > "$SCRIPT_DIR/gog.pid"',
+        `    /bin/bash -c 'trap "" TERM; while true; do sleep 1; done' &`,
         "    HELPER=$!",
         '    echo "[gog] credential-helper spawned pid=$HELPER"',
-        `    echo $HELPER > ${tmpDir}/helper.pid`,
+        '    echo $HELPER > "$SCRIPT_DIR/helper.pid"',
         "    trap 'echo \"[gog] SIGTERM (child NOT killed)\"; exit 0' TERM",
         "    while true; do sleep 0.3; done ;;",
         "esac",
@@ -60,7 +60,26 @@ describe.skipIf(!RUN)("gmail-watcher process-tree shutdown (integration)", () =>
     process.env["PATH"] = `${tmpDir}:${savedPath ?? ""}`;
   });
 
-  afterAll(() => {
+  afterAll(async () => {
+    try {
+      await stopWatcher?.();
+    } catch {
+      // Force cleanup below; this test must not leave subprocesses behind on failure.
+    }
+    if (gogPid !== undefined) {
+      try {
+        process.kill(-gogPid, "SIGKILL");
+      } catch {
+        // The process group may already be gone.
+      }
+    }
+    if (helperPid !== undefined) {
+      try {
+        process.kill(helperPid, "SIGKILL");
+      } catch {
+        // The helper may already be gone with its process group.
+      }
+    }
     if (savedPath !== undefined) {
       process.env["PATH"] = savedPath;
     }
@@ -69,6 +88,7 @@ describe.skipIf(!RUN)("gmail-watcher process-tree shutdown (integration)", () =>
 
   it("stopGmailWatcher removes gog and its credential-helper descendant", async () => {
     const { startGmailWatcher, stopGmailWatcher } = await import("./gmail-watcher.js");
+    stopWatcher = stopGmailWatcher;
 
     const result = await startGmailWatcher({
       hooks: {
@@ -94,8 +114,8 @@ describe.skipIf(!RUN)("gmail-watcher process-tree shutdown (integration)", () =>
       });
     }
 
-    const gogPid = Number.parseInt(readFileSync(join(tmpDir, "gog.pid"), "utf8").trim(), 10);
-    const helperPid = Number.parseInt(readFileSync(join(tmpDir, "helper.pid"), "utf8").trim(), 10);
+    gogPid = Number.parseInt(readFileSync(join(tmpDir, "gog.pid"), "utf8").trim(), 10);
+    helperPid = Number.parseInt(readFileSync(join(tmpDir, "helper.pid"), "utf8").trim(), 10);
 
     console.log(`\ngog pid=${gogPid}, credential-helper pid=${helperPid}`);
     expect(alive(gogPid)).toBe(true);

--- a/src/hooks/gmail-watcher.integration.test.ts
+++ b/src/hooks/gmail-watcher.integration.test.ts
@@ -7,7 +7,7 @@
  * simulating the real bug. The test asserts that stopGmailWatcher removes
  * both the gog process and its descendant via the process-group signal.
  */
-import { execSync, execFileSync } from "node:child_process";
+import { execSync } from "node:child_process";
 import { existsSync, mkdirSync, rmSync, writeFileSync, readFileSync, chmodSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -86,12 +86,16 @@ describe.skipIf(!RUN)("gmail-watcher process-tree shutdown (integration)", () =>
 
     // Wait for both pid files
     for (let i = 0; i < 50; i++) {
-      if (existsSync(join(tmpDir, "helper.pid")) && existsSync(join(tmpDir, "gog.pid"))) break;
-      await new Promise((r) => setTimeout(r, 100));
+      if (existsSync(join(tmpDir, "helper.pid")) && existsSync(join(tmpDir, "gog.pid"))) {
+        break;
+      }
+      await new Promise<void>((r) => {
+        setTimeout(r, 100);
+      });
     }
 
-    const gogPid = parseInt(readFileSync(join(tmpDir, "gog.pid"), "utf8").trim());
-    const helperPid = parseInt(readFileSync(join(tmpDir, "helper.pid"), "utf8").trim());
+    const gogPid = Number.parseInt(readFileSync(join(tmpDir, "gog.pid"), "utf8").trim(), 10);
+    const helperPid = Number.parseInt(readFileSync(join(tmpDir, "helper.pid"), "utf8").trim(), 10);
 
     console.log(`\ngog pid=${gogPid}, credential-helper pid=${helperPid}`);
     expect(alive(gogPid)).toBe(true);
@@ -99,7 +103,9 @@ describe.skipIf(!RUN)("gmail-watcher process-tree shutdown (integration)", () =>
 
     console.log("calling stopGmailWatcher...");
     await stopGmailWatcher();
-    await new Promise((r) => setTimeout(r, 400));
+    await new Promise<void>((r) => {
+      setTimeout(r, 400);
+    });
 
     console.log(`gog alive after stop: ${alive(gogPid)}`);
     console.log(`credential-helper alive after stop: ${alive(helperPid)}`);

--- a/src/hooks/gmail-watcher.integration.test.ts
+++ b/src/hooks/gmail-watcher.integration.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Integration proof for issue #106612.
+ *
+ * Runs startGmailWatcher and stopGmailWatcher with NO mocks for spawn or
+ * killProcessTree. A fake `gog` binary is placed on PATH; it spawns a
+ * credential-helper child and deliberately does NOT kill it on SIGTERM,
+ * simulating the real bug. The test asserts that stopGmailWatcher removes
+ * both the gog process and its descendant via the process-group signal.
+ */
+import { execSync, execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, rmSync, writeFileSync, readFileSync, chmodSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+// Only run when explicitly opted in — requires real subprocess spawning.
+const RUN = process.env["OPENCLAW_INTEGRATION_TEST"] === "1";
+
+function alive(pid: number): boolean {
+  try {
+    execSync(`kill -0 ${pid} 2>/dev/null`);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe.skipIf(!RUN)("gmail-watcher process-tree shutdown (integration)", () => {
+  let tmpDir: string;
+  let savedPath: string | undefined;
+
+  beforeAll(() => {
+    tmpDir = join(tmpdir(), `gog-integration-${process.pid}`);
+    mkdirSync(tmpDir, { recursive: true });
+
+    // fake gog: handles `watch start` (exits 0) and `watch serve`
+    // (spawns a credential-helper sleep and does NOT kill it on SIGTERM)
+    const gogScript = join(tmpDir, "gog");
+    writeFileSync(
+      gogScript,
+      [
+        "#!/bin/bash",
+        'case "$*" in',
+        '  *"watch start"*) echo "[gog] watch registered"; exit 0 ;;',
+        '  *"watch serve"*)',
+        '    echo "[gog] serve started pid=$$"',
+        `    echo $$ > ${tmpDir}/gog.pid`,
+        "    sleep 99999 &",
+        "    HELPER=$!",
+        '    echo "[gog] credential-helper spawned pid=$HELPER"',
+        `    echo $HELPER > ${tmpDir}/helper.pid`,
+        "    trap 'echo \"[gog] SIGTERM (child NOT killed)\"; exit 0' TERM",
+        "    while true; do sleep 0.3; done ;;",
+        "esac",
+      ].join("\n"),
+    );
+    chmodSync(gogScript, 0o755);
+
+    savedPath = process.env["PATH"];
+    process.env["PATH"] = `${tmpDir}:${savedPath ?? ""}`;
+  });
+
+  afterAll(() => {
+    if (savedPath !== undefined) {
+      process.env["PATH"] = savedPath;
+    }
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("stopGmailWatcher removes gog and its credential-helper descendant", async () => {
+    const { startGmailWatcher, stopGmailWatcher } = await import("./gmail-watcher.js");
+
+    const result = await startGmailWatcher({
+      hooks: {
+        enabled: true,
+        token: "integration-token",
+        gmail: {
+          account: "integration@example.com",
+          topic: "projects/integration/topics/gmail",
+          pushToken: "integration-push-token",
+        },
+      },
+    } as never);
+
+    expect(result.started).toBe(true);
+
+    // Wait for both pid files
+    for (let i = 0; i < 50; i++) {
+      if (existsSync(join(tmpDir, "helper.pid")) && existsSync(join(tmpDir, "gog.pid"))) break;
+      await new Promise((r) => setTimeout(r, 100));
+    }
+
+    const gogPid = parseInt(readFileSync(join(tmpDir, "gog.pid"), "utf8").trim());
+    const helperPid = parseInt(readFileSync(join(tmpDir, "helper.pid"), "utf8").trim());
+
+    console.log(`\ngog pid=${gogPid}, credential-helper pid=${helperPid}`);
+    expect(alive(gogPid)).toBe(true);
+    expect(alive(helperPid)).toBe(true);
+
+    console.log("calling stopGmailWatcher...");
+    await stopGmailWatcher();
+    await new Promise((r) => setTimeout(r, 400));
+
+    console.log(`gog alive after stop: ${alive(gogPid)}`);
+    console.log(`credential-helper alive after stop: ${alive(helperPid)}`);
+
+    expect(alive(gogPid)).toBe(false);
+    expect(alive(helperPid)).toBe(false); // descendant must also be gone
+  }, 15_000);
+});

--- a/src/hooks/gmail-watcher.test.ts
+++ b/src/hooks/gmail-watcher.test.ts
@@ -13,7 +13,9 @@ const mocks = vi.hoisted(() => ({
   spawn: vi.fn(),
   killProcessTree: vi.fn((pid: number) => {
     const child = spawnRegistry.get(pid);
-    if (child) queueMicrotask(() => child.emit("close", 0, null));
+    if (child) {
+      queueMicrotask(() => child.emit("close", 0, null));
+    }
   }),
 }));
 
@@ -116,7 +118,9 @@ describe("startGmailWatcher", () => {
     mocks.killProcessTree.mockReset();
     mocks.killProcessTree.mockImplementation((pid: number) => {
       const child = spawnRegistry.get(pid);
-      if (child) queueMicrotask(() => child.emit("close", 0, null));
+      if (child) {
+        queueMicrotask(() => child.emit("close", 0, null));
+      }
     });
     mocks.spawn.mockImplementation(() => {
       const child = new EventEmitter();

--- a/src/hooks/gmail-watcher.test.ts
+++ b/src/hooks/gmail-watcher.test.ts
@@ -3,11 +3,18 @@ import { EventEmitter } from "node:events";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+// Tracks spawned children by pid so the killProcessTree mock can emit close on them.
+const spawnRegistry = new Map<number, EventEmitter>();
+
 const mocks = vi.hoisted(() => ({
   hasBinary: vi.fn(() => true),
   resolveExecutable: vi.fn((name: string) => name),
   runCommandWithTimeout: vi.fn(),
   spawn: vi.fn(),
+  killProcessTree: vi.fn((pid: number) => {
+    const child = spawnRegistry.get(pid);
+    if (child) queueMicrotask(() => child.emit("close", 0, null));
+  }),
 }));
 
 vi.mock("node:child_process", async () => {
@@ -28,6 +35,10 @@ vi.mock("../infra/executable-path.js", () => ({
 
 vi.mock("../process/exec.js", () => ({
   runCommandWithTimeout: mocks.runCommandWithTimeout,
+}));
+
+vi.mock("../process/kill-tree.js", () => ({
+  killProcessTree: mocks.killProcessTree,
 }));
 
 const { startGmailWatcher, stopGmailWatcher } = await import("./gmail-watcher.js");
@@ -61,16 +72,23 @@ type MockWatcherChild = EventEmitter & {
   stderr: EventEmitter;
 };
 
+let nextMockPid = 1234;
+
 function createMockWatcherChild(spawned = true): MockWatcherChild {
   const child = new EventEmitter();
-  return Object.assign(child, {
+  const pid = spawned ? nextMockPid++ : undefined;
+  const mockedChild = Object.assign(child, {
     stderr: new EventEmitter(),
     kill: vi.fn(() => {
       queueMicrotask(() => child.emit("exit", null, "SIGTERM"));
       return true;
     }),
-    ...(spawned ? { pid: 1234 } : {}),
+    ...(pid !== undefined ? { pid } : {}),
   });
+  if (pid !== undefined) {
+    spawnRegistry.set(pid, mockedChild);
+  }
+  return mockedChild;
 }
 
 async function startMockWatcher(spawned = true): Promise<MockWatcherChild[]> {
@@ -87,11 +105,19 @@ async function startMockWatcher(spawned = true): Promise<MockWatcherChild[]> {
 
 describe("startGmailWatcher", () => {
   beforeEach(async () => {
+    // stopGmailWatcher uses the killProcessTree mock from the previous beforeEach run,
+    // which looks up spawnRegistry entries populated by that test's children.
     await stopGmailWatcher();
+    spawnRegistry.clear();
     mocks.hasBinary.mockReturnValue(true);
     mocks.resolveExecutable.mockImplementation((name: string) => name);
     mocks.runCommandWithTimeout.mockReset();
     mocks.spawn.mockReset();
+    mocks.killProcessTree.mockReset();
+    mocks.killProcessTree.mockImplementation((pid: number) => {
+      const child = spawnRegistry.get(pid);
+      if (child) queueMicrotask(() => child.emit("close", 0, null));
+    });
     mocks.spawn.mockImplementation(() => {
       const child = new EventEmitter();
       return Object.assign(child, {
@@ -377,19 +403,16 @@ describe("startGmailWatcher", () => {
     }
   });
 
-  it("escalates to SIGKILL and resolves on final timeout when process ignores signals", async () => {
+  it("uses killProcessTree for gog shutdown and resolves on final timeout when process ignores signals", async () => {
     vi.useFakeTimers();
     try {
       mocks.runCommandWithTimeout.mockResolvedValue({ code: 0, stdout: "", stderr: "" });
 
-      // Spawn a process that never emits exit/close/error
+      // Spawn a process with a known pid that never emits exit/close/error
       const stubbornChild = new EventEmitter();
-      const killCalls: string[] = [];
       Object.assign(stubbornChild, {
-        kill: vi.fn((sig: string) => {
-          killCalls.push(sig);
-          return true;
-        }),
+        pid: 9999,
+        kill: vi.fn(() => true),
         killed: false,
       });
       mocks.spawn.mockReturnValueOnce(stubbornChild);
@@ -409,17 +432,17 @@ describe("startGmailWatcher", () => {
         });
       });
 
-      // Re-entry starts settle on stubbornChild
+      // Re-entry starts settle on stubbornChild; advance past the 8 s final
+      // timeout (stubbornChild never emits exit), then verify the outcome.
       const startPromise = startGmailWatcher(createGmailConfig());
-
-      // After 3s the escalation fires SIGKILL
-      await vi.advanceTimersByTimeAsync(3_000);
-      expect(killCalls).toContain("SIGTERM");
-      expect(killCalls).toContain("SIGKILL");
-
-      // After 8s total the final timeout resolves even though exit never fired
-      await vi.advanceTimersByTimeAsync(5_000);
+      await vi.advanceTimersByTimeAsync(8_000);
       await expect(startPromise).resolves.toEqual({ started: true });
+
+      // killProcessTree must have been called with stubbornChild's pid before settle gave up.
+      expect(mocks.killProcessTree).toHaveBeenCalledWith(
+        9999,
+        expect.objectContaining({ graceMs: 3_000 }),
+      );
     } finally {
       vi.useRealTimers();
     }
@@ -461,6 +484,24 @@ describe("startGmailWatcher", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("calls killProcessTree (not proc.kill) when stopping the gog watcher", async () => {
+    mocks.runCommandWithTimeout.mockResolvedValue({ code: 0, stdout: "", stderr: "" });
+    const child = createMockWatcherChild();
+    mocks.spawn.mockReturnValueOnce(child);
+
+    await startGmailWatcher(createGmailConfig());
+    expect(mocks.spawn).toHaveBeenCalledTimes(1);
+
+    await stopGmailWatcher();
+
+    expect(mocks.killProcessTree).toHaveBeenCalledWith(
+      child.pid,
+      expect.objectContaining({ graceMs: 3_000 }),
+    );
+    // proc.kill should not be called — tree termination replaces the direct kill.
+    expect(child.kill).not.toHaveBeenCalled();
   });
 
   it("swallows stdout and stderr stream errors without crashing", async () => {

--- a/src/hooks/gmail-watcher.ts
+++ b/src/hooks/gmail-watcher.ts
@@ -6,9 +6,11 @@
  */
 
 import { type ChildProcess, spawn } from "node:child_process";
+import process from "node:process";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { runCommandWithTimeout } from "../process/exec.js";
+import { killProcessTree } from "../process/kill-tree.js";
 import { hasBinary } from "../skills/loading/config.js";
 import { ensureTailscaleEndpoint } from "./gmail-setup-utils.js";
 import { isAddressInUseError } from "./gmail-watcher-errors.js";
@@ -80,7 +82,8 @@ function spawnGogServe(cfg: GmailHookRuntimeConfig): ChildProcess {
 
   const child = spawn(invocation.command, invocation.args, {
     stdio: ["ignore", "pipe", "pipe"],
-    detached: false,
+    // Own process group on Unix so killProcessTree can reach descendants on shutdown.
+    detached: process.platform !== "win32",
     windowsHide: invocation.windowsHide,
     windowsVerbatimArguments: invocation.windowsVerbatimArguments,
   });
@@ -157,8 +160,8 @@ function spawnGogServe(cfg: GmailHookRuntimeConfig): ChildProcess {
 }
 
 /**
- * Send SIGTERM, escalate to SIGKILL after 3 s, and resolve on exit/close/error
- * or a final 5 s timeout after SIGKILL so the caller never hangs.
+ * Signal the gog process tree to exit gracefully (SIGTERM, SIGKILL after 3 s)
+ * and resolve on exit/close/error or a final 8 s safety timeout.
  */
 function settleProcess(proc: ChildProcess): Promise<void> {
   return new Promise<void>((resolve) => {
@@ -168,7 +171,6 @@ function settleProcess(proc: ChildProcess): Promise<void> {
         return;
       }
       settled = true;
-      clearTimeout(escalation);
       clearTimeout(finalTimeout);
       resolve();
     };
@@ -177,17 +179,24 @@ function settleProcess(proc: ChildProcess): Promise<void> {
     proc.on("close", settle);
     proc.on("error", settle);
 
-    proc.kill("SIGTERM");
-
-    const escalation: ReturnType<typeof setTimeout> | undefined = setTimeout(() => {
+    // killProcessTree sends SIGTERM to the process group (Unix) or uses taskkill /T
+    // (Windows) and escalates to SIGKILL after graceMs, reaching any descendants
+    // spawned by gog that plain proc.kill() would miss.
+    if (typeof proc.pid === "number") {
+      killProcessTree(proc.pid, {
+        graceMs: 3_000,
+        detached: process.platform !== "win32",
+      });
+    } else {
+      // pid absent means spawn never started; direct kill clears any lingering state.
       try {
-        proc.kill("SIGKILL");
+        proc.kill("SIGTERM");
       } catch {
-        // already dead
+        /* process may not exist */
       }
-    }, 3_000);
+    }
 
-    const finalTimeout: ReturnType<typeof setTimeout> | undefined = setTimeout(() => {
+    const finalTimeout: ReturnType<typeof setTimeout> = setTimeout(() => {
       if (!settled) {
         log.warn("gog process did not exit after SIGKILL; giving up");
         settle();

--- a/src/hooks/gmail-watcher.ts
+++ b/src/hooks/gmail-watcher.ts
@@ -166,27 +166,56 @@ function spawnGogServe(cfg: GmailHookRuntimeConfig): ChildProcess {
 function settleProcess(proc: ChildProcess): Promise<void> {
   return new Promise<void>((resolve) => {
     let settled = false;
+    let processSettled = false;
+    let graceElapsed = false;
+    let graceTimer: ReturnType<typeof setTimeout> | undefined;
     const settle = () => {
       if (settled) {
         return;
       }
       settled = true;
-      clearTimeout(finalTimeout);
+      if (graceTimer) {
+        clearTimeout(graceTimer);
+      }
+      if (finalTimeout) {
+        clearTimeout(finalTimeout);
+      }
       resolve();
     };
+    const settleAfterEscalation = () => {
+      processSettled = true;
+      if (graceElapsed) {
+        settle();
+      }
+    };
+    const finalTimeout = setTimeout(() => {
+      if (!settled) {
+        log.warn("gog process did not exit after SIGKILL; giving up");
+        settle();
+      }
+    }, 8_000);
 
-    proc.on("exit", settle);
-    proc.on("close", settle);
-    proc.on("error", settle);
+    proc.on("exit", settleAfterEscalation);
+    proc.on("close", settleAfterEscalation);
+    proc.on("error", settleAfterEscalation);
 
     // killProcessTree sends SIGTERM to the process group (Unix) or uses taskkill /T
     // (Windows) and escalates to SIGKILL after graceMs, reaching any descendants
     // spawned by gog that plain proc.kill() would miss.
     if (typeof proc.pid === "number") {
+      const graceMs = 3_000;
       killProcessTree(proc.pid, {
-        graceMs: 3_000,
+        graceMs,
         detached: process.platform !== "win32",
       });
+      // killProcessTree owns escalation but intentionally unrefs its timer.
+      // Keep shutdown referenced until that escalation has had a chance to run.
+      graceTimer = setTimeout(() => {
+        graceElapsed = true;
+        if (processSettled) {
+          settle();
+        }
+      }, graceMs + 25);
     } else {
       // pid absent means spawn never started; direct kill clears any lingering state.
       try {
@@ -194,14 +223,8 @@ function settleProcess(proc: ChildProcess): Promise<void> {
       } catch {
         /* process may not exist */
       }
+      graceElapsed = true;
     }
-
-    const finalTimeout: ReturnType<typeof setTimeout> = setTimeout(() => {
-      if (!settled) {
-        log.warn("gog process did not exit after SIGKILL; giving up");
-        settle();
-      }
-    }, 8_000);
   });
 }
 


### PR DESCRIPTION
## What Problem This Solves

`gog gmail watch serve` can spawn child processes (e.g. credential helpers).
`stopGmailWatcher` previously sent SIGTERM only to the direct child via
`proc.kill()`, leaving any descendants orphaned on shutdown. 

## Why This Change Was Made

`src/process/kill-tree.ts` already provides `killProcessTree`, which sends
SIGTERM to the entire process group on Unix (`process.kill(-pid, ...)`) and
uses `taskkill /T` on Windows, then escalates to SIGKILL after a grace period.
The fix wires this into the gmail-watcher shutdown path.

Two changes are required together:
- Spawn gog with `detached: process.platform !== "win32"` so it gets its own
  process group on Unix otherwise the group signal would reach the parent
  OpenClaw process too.
- Replace the manual SIGTERM → SIGKILL timer in `settleProcess` with a single
  `killProcessTree` call. A `proc.kill("SIGTERM")` fallback is kept for the
  edge case where spawn fails before a pid is assigned.

## User Impact

Gmail hook users who see stale gog credential-helper processes surviving after
OpenClaw restarts will have those descendants cleaned up correctly on shutdown.

## Evidence

Exact head: `b30a81ff4385accd8f3f3060e1b18726b100e18d`

- 18 focused Gmail watcher unit tests passed.
- The opt-in integration test passed against a real detached process tree and descendant.
- Targeted oxlint, oxfmt, and `git diff --check` passed.
- Fresh post-rebase autoreview found no actionable issues at 0.94 confidence.

**Process-group mechanism proof** - the screenshot below reproduces the
direct-child vs. process-group termination difference using the same Node.js
`spawn`/`process.kill(-pid)` primitives that `spawnGogServe` and
`killProcessTree` use internally. A live `gog` environment is not available
for end-to-end watcher proof; the test suite covers the `settleProcess` path
directly.

<img width="1073" height="800" alt="Screenshot 2026-07-21 at 7 21 43 PM" src="https://github.com/user-attachments/assets/c16e7051-6ca9-4725-bebf-fe61bc5a883c" />






