### PR TITLE
fix(model): yield to event loop in stream iterator to prevent starvation

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.ts
@@ -725,6 +725,9 @@ async function* observeModelCallIterator<T>(
       observeResponseChunk(state, startedAt, next.value);
       maybeEmitModelCallStreamProgress(eventBase, state);
       yield next.value;
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
     }
     emitModelCallCompleted(eventBase, startedAt, state);
   } catch (err) {


### PR DESCRIPTION
## Problem

The `observeModelCallIterator` in `attempt.model-diagnostic-events.ts` processes model streaming chunks in a tight `for(;;)` loop. Each `await iterator.next()` yields only at the microtask level, but the synchronous work inside the loop (diagnostic event emission, content capture) combined with high-frequency token streaming causes sustained macrotask starvation.

This manifests as cascading Gateway failures:

- `monitorEventLoopDelay` reports P99 >8000ms
- `sessions.list` takes >30s  
- `models.list` takes >150s
- WebSocket handshakes time out with `invalid connect params`
- Chat runs hit timeout because `fetch` timer callbacks never get scheduled
- Liveness warning: `event_loop_delay,cpu eventLoopDelayP99Ms=8090.8 interval=33s`

The framework already detects this in `fetch-timeout.ts` (timer delayed N ms, "likely event-loop starvation") but the root cause is at the iterator level.

## Fix

Inject `await new Promise<void>((resolve) => { setImmediate(resolve) })` after each `yield` in `observeModelCallIterator`. This yields to the event loop's check phase, allowing pending I/O, timers, and WebSocket operations to be processed between stream chunks.

The `setImmediate` pattern is already used in the project (tests, `yieldToEventLoop` in `task-registry.maintenance.ts`).

## Overhead

`setImmediate` adds ~0.01ms per token. At 100 tokens/second, that's 1ms overhead per second — negligible for streaming LLM responses.

## Verification

Reproduced on Windows + Electron with embedded Gateway. After applying this fix to the vendored dist file, event loop delays drop from P99 8000ms to <50ms, and all downstream timeouts (sessions.list, models.list, WS handshakes) resolve immediately.
