### PR TITLE
fix(media): preserve paths containing spaces

### DIFF
--- a/src/media/parse.test.ts
+++ b/src/media/parse.test.ts
@@ -1,10 +1,24 @@
 // Media parse tests cover media reference parsing from text and payloads.
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { splitMediaFromOutput } from "./parse.js";
+
+const mocks = vi.hoisted(() => ({
+  statSync: vi.fn(() => {
+    throw new Error("ENOENT");
+  }),
+}));
+
+vi.mock("node:fs", () => ({ statSync: mocks.statSync }));
 
 type SplitMediaFromOutputOptions = NonNullable<Parameters<typeof splitMediaFromOutput>[1]>;
 
 describe("splitMediaFromOutput", () => {
+  afterEach(() => {
+    mocks.statSync.mockReset().mockImplementation(() => {
+      throw new Error("ENOENT");
+    });
+  });
+
   function expectParsedMediaOutputCase(
     input: string,
     expected: {
@@ -72,6 +86,21 @@ describe("splitMediaFromOutput", () => {
     ["/Users/pete/My File.png", "MEDIA:file:///Users/pete/My File.png"],
   ] as const)("accepts supported media path variant: %s", (expectedPath, input) => {
     expectAcceptedMediaPathCase(expectedPath, input);
+  });
+
+  it("keeps an existing unquoted Windows path containing spaces as one attachment", () => {
+    const path = String.raw`C:\Users\Asus X13\workspace\shot.png`;
+    mocks.statSync.mockReturnValue({ isFile: () => true } as never);
+
+    expectAcceptedMediaPathCase(path, `MEDIA:${path}`);
+    expect(mocks.statSync).toHaveBeenCalledWith(path);
+  });
+
+  it("keeps multiple local paths separate when their combined payload is not a file", () => {
+    expectParsedMediaOutputCase("MEDIA:/one.png /two.png", {
+      mediaUrls: ["/one.png", "/two.png"],
+    });
+    expect(mocks.statSync).toHaveBeenCalledWith("/one.png /two.png");
   });
 
   it.each([

--- a/src/media/parse.ts
+++ b/src/media/parse.ts
@@ -1,4 +1,5 @@
 // Media parse helpers normalize media references from user and channel input.
+import { statSync } from "node:fs";
 import {
   extractEmbeddedIpv4FromIpv6,
   isBlockedSpecialUseIpv4Address,
@@ -97,6 +98,14 @@ function isLikelyLocalPath(candidate: string): boolean {
     candidate.startsWith("\\\\") ||
     (!SCHEME_RE.test(candidate) && (candidate.includes("/") || candidate.includes("\\")))
   );
+}
+
+function isExistingRegularFile(candidate: string): boolean {
+  try {
+    return statSync(candidate).isFile();
+  } catch {
+    return false;
+  }
 }
 
 function normalizeRemoteMediaHostname(value: string): string {
@@ -618,6 +627,17 @@ export function splitMediaFromOutput(
           media.splice(mediaStartIndex, media.length - mediaStartIndex, fallback);
           hasValidMedia = true;
           foundMediaToken = true;
+          validCount = 1;
+          invalidParts.length = 0;
+        }
+      }
+
+      if (!unwrapped && validCount > 1 && /\s/.test(payloadValue) && looksLikeLocalPath) {
+        // Multiple valid fragments can still be one local path whose components contain spaces.
+        // Prefer the full path only when the filesystem resolves that ambiguity.
+        const fallback = normalizeMediaSource(cleanCandidate(payloadValue));
+        if (isValidMedia(fallback, { allowSpaces: true }) && isExistingRegularFile(fallback)) {
+          media.splice(mediaStartIndex, media.length - mediaStartIndex, fallback);
           validCount = 1;
           invalidParts.length = 0;
         }


### PR DESCRIPTION
Closes #112421

## What Problem This Solves

Fixes an issue where users sending an unquoted `MEDIA:` directive would get broken attachments when an absolute local file path contained spaces, such as a Windows profile path under `C:\Users\Asus X13`.

## Why This Change Was Made

When whitespace splitting produces multiple otherwise valid local-path fragments, the parser now prefers the complete payload only if it resolves to an existing regular file. This preserves legacy multi-attachment lines while avoiding filesystem-dependent guesses for missing or inaccessible paths.

## User Impact

Users can send existing local media files from absolute paths containing spaces without adding quotes or backticks. Multiple paths on one `MEDIA:` line continue to parse separately when their combined payload is not a file.

## Evidence

- Added a regression test for an existing unquoted Windows path containing spaces.
- Added a compatibility test confirming `MEDIA:/one.png /two.png` remains two attachments.
- Focused media parser suite: 68 tests passed.
- Core TypeScript check passed: `pnpm tsgo:core`.
- Changed-file formatting and lint passed.
- `git diff --check` passed.
- `pnpm check:changed` could not start its delegated Blacksmith Testbox runner because the local `crabbox` binary failed its version/help sanity check; this was an infrastructure startup failure, not a code/test failure.

## AI Assistance

AI-assisted. The change was reproduced, regression-tested, reviewed for ambiguous multi-item behavior, and independently validated before submission. I understand the implementation and its filesystem-probe tradeoff.
