### PR TITLE
fix(config): add compaction.enabled to agent defaults schema

### DIFF
--- a/src/config/schema.help.agents.ts
+++ b/src/config/schema.help.agents.ts
@@ -122,6 +122,8 @@ export const AGENT_FIELD_HELP: Record<string, string> = {
   "agents.defaults.cliBackends": "Optional CLI backends for text-only fallback (claude-cli, etc.).",
   "agents.defaults.compaction":
     "Compaction behavior for when context nears token limits, including strategy and pre-compaction memory flush behavior. Use this when long-running sessions need stable continuity under tight context windows.",
+  "agents.defaults.compaction.enabled":
+    "Enable or disable auto-compaction for this agent. When disabled, the agent will not automatically compact the transcript even when it approaches the context window limit. Default: true.",
   "agents.defaults.compaction.mode":
     'Compaction strategy mode: "default" uses baseline behavior, while "safeguard" applies stricter guardrails to preserve recent context. Keep "default" unless you observe aggressive history loss near limit boundaries.',
   "agents.defaults.compaction.provider":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -681,6 +681,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "agents.defaults.humanDelay.maxMs": "Human Delay Max (ms)",
   "agents.defaults.cliBackends": "CLI Backends",
   "agents.defaults.compaction": "Compaction",
+  "agents.defaults.compaction.enabled": "Auto-Compaction",
   "agents.defaults.compaction.mode": "Compaction Mode",
   "agents.defaults.compaction.provider": "Compaction Provider",
   "agents.defaults.compaction.thinkingLevel": "Compaction Thinking Level",

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -488,6 +488,8 @@ export type AgentCompactionMidTurnPrecheckConfig = {
 };
 
 export type AgentCompactionConfig = {
+  /** Enable or disable auto-compaction for this agent. Default: true. */
+  enabled?: boolean;
   /** Compaction summarization mode. */
   mode?: AgentCompactionMode;
   /** Override the session thinking level for embedded OpenClaw compaction summaries. */

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -159,6 +159,7 @@ export const AgentDefaultsSchema = z
       .optional(),
     compaction: z
       .object({
+        enabled: z.boolean().optional(),
         mode: z.union([z.literal("default"), z.literal("safeguard")]).optional(),
         provider: z.string().optional(),
         thinkingLevel: AgentThinkingLevelSchema.optional(),


### PR DESCRIPTION
Fixes #110065

## What Problem This Solves

Setting `compaction.enabled: false` in `openclaw.json` causes config validation to reject the entire config file because the zod schema and TypeScript type for `AgentCompactionConfig` lack the `enabled` field, even though the runtime reads it via `settingsManager.getCompactionEnabled()`.

## Why This Change Was Made

Added `enabled?: boolean` to:
- `AgentCompactionConfig` type (`src/config/types.agent-defaults.ts`)
- Zod schema (`src/config/zod-schema.agent-defaults.ts`)
- Help text (`src/config/schema.help.agents.ts`)
- Labels (`src/config/schema.labels.ts`)

## Evidence

- `git diff --check` clean
- `git diff --stat` shows 4 files, 6 lines added