### PR TITLE
fix(plugins): deep-clone registry elements in transaction snapshot

### DIFF
--- a/src/plugins/plugin-registration-transaction.test.ts
+++ b/src/plugins/plugin-registration-transaction.test.ts
@@ -113,4 +113,52 @@ describe("plugin registration transaction", () => {
 
     expect(getSessionDiscussionProvider()).toBe(activeProvider);
   });
+
+  it("rollback restores original array element values after in-place mutation", () => {
+    const registry = createEmptyPluginRegistry();
+    registry.plugins.push({
+      id: "test-plugin",
+      name: "Test Plugin",
+      enabled: true,
+      status: "loaded" as const,
+      source: "test",
+      origin: "external" as const,
+      toolNames: [],
+      hookNames: [],
+      channelIds: [],
+      cliBackendIds: [],
+      providerIds: [],
+      embeddingProviderIds: [],
+      speechProviderIds: [],
+      realtimeTranscriptionProviderIds: [],
+      realtimeVoiceProviderIds: [],
+      mediaUnderstandingProviderIds: [],
+      transcriptSourceProviderIds: [],
+      imageGenerationProviderIds: [],
+      videoGenerationProviderIds: [],
+      musicGenerationProviderIds: [],
+      webFetchProviderIds: [],
+      webSearchProviderIds: [],
+      migrationProviderIds: [],
+      memoryEmbeddingProviderIds: [],
+      agentHarnessIds: [],
+      cliCommands: [],
+      services: [],
+      gatewayDiscoveryServiceIds: [],
+      commands: [],
+      httpRoutes: 0,
+      hookCount: 0,
+      configSchema: false,
+    });
+
+    const transaction = createPluginRegistrationTransaction({ registry });
+
+    registry.plugins[0].enabled = false;
+    registry.plugins[0].status = "disabled";
+
+    transaction.rollback();
+
+    expect(registry.plugins[0].enabled).toBe(true);
+    expect(registry.plugins[0].status).toBe("loaded");
+  });
 });

--- a/src/plugins/plugin-registration-transaction.ts
+++ b/src/plugins/plugin-registration-transaction.ts
@@ -90,13 +90,22 @@ function snapshotPluginRegistry(registry: PluginRegistry): PluginRegistry {
   return Object.fromEntries(
     Object.entries(registry).map(([key, value]) => {
       if (Array.isArray(value)) {
-        return [key, [...value]];
+        return [key, value.map((item) => structuredClone(item))];
       }
       if (value instanceof Map) {
-        return [key, new Map(value as ReadonlyMap<unknown, unknown>)];
+        return [
+          key,
+          new Map(
+            [...(value as ReadonlyMap<unknown, unknown>)].map(([k, v]) => [k, structuredClone(v)]),
+          ),
+        ];
       }
       if (value && typeof value === "object") {
-        return [key, { ...value }];
+        try {
+          return [key, structuredClone(value)];
+        } catch {
+          return [key, { ...value }];
+        }
       }
       return [key, value];
     }),


### PR DESCRIPTION
Fixes #106647

## What Problem This Solves

`snapshotPluginRegistry` used shallow copies for arrays, Maps, and plain objects. When plugins are registered, in-place mutations on objects within arrays leak through to the snapshot, violating transactional integrity on rollback.

## Why This Change Was Made

Replaced shallow copies with `structuredClone`:
- Arrays: deep-clone each element
- Maps: deep-clone each value
- Objects: deep-clone, with fallback to shallow copy for non-cloneable values

New test verifies rollback restores original PluginRecord properties after in-place mutation.

## Evidence

- 5 tests pass (2 existing + 1 new + 2 unmodified)