### PR TITLE
fix(macos): prevent AppKit automatic termination in menu bar app

### DIFF
--- a/apps/macos/Sources/OpenClaw/MenuBar.swift
+++ b/apps/macos/Sources/OpenClaw/MenuBar.swift
@@ -541,6 +541,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Remote startup can spawn an SSH child. Admit tunnel work only after the
         // singleton check so a short-lived handoff process cannot orphan that child.
         GatewayEndpointStore.admitPrimaryAppLaunch()
+        // AppKit can terminate the process ~0.5s after launch in remote mode
+        // when no persistent window is open. Disable automatic termination so
+        // the menu bar app stays resident as long as the status item is active.
+        ProcessInfo.processInfo.disableAutomaticTermination()
         GatewayConnectivityCoordinator.shared.start()
         self.state = AppStateStore.shared
         if let state {


### PR DESCRIPTION
Fixes #89162

## What Problem This Solves

The macOS menu bar app auto-terminates ~0.5s after launch in remote mode. AppKit sees no persistent visible window and terminates the process, even though the menu bar status item is active and the app should remain resident.

## Why This Change Was Made

Added `ProcessInfo.processInfo.disableAutomaticTermination()` in `applicationDidFinishLaunching` to tell AppKit the app should stay resident regardless of window state.

## Evidence

- Single line addition in `apps/macos/Sources/OpenClaw/MenuBar.swift`
- `git diff --check` clean