### PR TITLE
fix(media): keep an unquoted MEDIA path with spaces as one media item

### DIFF
--- a/src/media/parse.test.ts
+++ b/src/media/parse.test.ts
@@ -49,12 +49,33 @@ describe("splitMediaFromOutput", () => {
   it.each([
     ["/Users/pete/My File.png", "MEDIA:/Users/pete/My File.png"],
     ["/Users/pete/My File.png", 'MEDIA:"/Users/pete/My File.png"'],
+    [
+      "/Users/pete/My Files/Project Assets/render final.png",
+      "MEDIA:/Users/pete/My Files/Project Assets/render final.png",
+    ],
+    [
+      "/Users/pete/My Files/Project Assets/render final.png",
+      'MEDIA:"/Users/pete/My Files/Project Assets/render final.png"',
+    ],
+    ["/tmp/album.v1/photo.png copy.png", "MEDIA:/tmp/album.v1/photo.png copy.png"],
     ["./screenshots/image.png", "MEDIA:./screenshots/image.png"],
     ["media/inbound/image.png", "MEDIA:media/inbound/image.png"],
     ["./screenshot.png", "  MEDIA:./screenshot.png"],
     ["~/Pictures/My File.png", "MEDIA:~/Pictures/My File.png"],
     ["~/.openclaw/media/browser/snap.png", "MEDIA:~/.openclaw/media/browser/snap.png"],
     ["C:\\Users\\pete\\Pictures\\snap.png", "MEDIA:C:\\Users\\pete\\Pictures\\snap.png"],
+    [
+      "C:\\Users\\First Last\\workspace\\shot.png",
+      "MEDIA:C:\\Users\\First Last\\workspace\\shot.png",
+    ],
+    [
+      "C:\\Users\\First  Last\\workspace\\shot.png",
+      "MEDIA:C:\\Users\\First  Last\\workspace\\shot.png",
+    ],
+    [
+      "\\\\server\\My Files\\Project Assets\\render final.png",
+      "MEDIA:\\\\server\\My Files\\Project Assets\\render final.png",
+    ],
     ["/tmp/tts-fAJy8C/voice-1770246885083.opus", "MEDIA:/tmp/tts-fAJy8C/voice-1770246885083.opus"],
     ["image.png", "MEDIA:image.png"],
     [
@@ -75,13 +96,53 @@ describe("splitMediaFromOutput", () => {
   });
 
   it.each([
+    ["MEDIA:/tmp/a.png /tmp/b.png", ["/tmp/a.png", "/tmp/b.png"]],
+    ["MEDIA:media/a.png media/b.png", ["media/a.png", "media/b.png"]],
+    ["MEDIA:/tmp/a.png media/b.png", ["/tmp/a.png", "media/b.png"]],
+    ["MEDIA:./a.png ./b.png", ["./a.png", "./b.png"]],
+    ["MEDIA:/tmp/a.png https://example.com/b.png", ["/tmp/a.png", "https://example.com/b.png"]],
+    [
+      "MEDIA:C:\\Users\\First Last\\workspace\\shot.png D:\\Other User\\second.png",
+      ["C:\\Users\\First Last\\workspace\\shot.png", "D:\\Other User\\second.png"],
+    ],
+    [
+      "MEDIA:C:\\Users\\First Last\\workspace\\shot.png media/second.png",
+      ["C:\\Users\\First Last\\workspace\\shot.png", "media/second.png"],
+    ],
+    [
+      "MEDIA:/tmp/project screenshots/shot.png media\\second.png",
+      ["/tmp/project screenshots/shot.png", "media\\second.png"],
+    ],
+    [
+      "MEDIA:/tmp/project screenshots/shot.png file:///tmp/second.png",
+      ["/tmp/project screenshots/shot.png", "/tmp/second.png"],
+    ],
+    ["MEDIA:C:\\Users\\First Last\\..\\secret.png D:\\safe\\second.png", ["D:\\safe\\second.png"]],
+    ["MEDIA:/tmp/project screenshots/../../.env /tmp/safe/second.png", ["/tmp/safe/second.png"]],
+  ] as const)("keeps separate media items on one directive line: %s", (input, mediaUrls) => {
+    expectParsedMediaOutputCase(input, { mediaUrls: [...mediaUrls] });
+  });
+
+  it.each([
     "MEDIA:../../../etc/passwd",
     "MEDIA:../../.env",
     "MEDIA:~user/Pictures/My File.png",
     "MEDIA:~/Pictures/../../.ssh/id_rsa",
     "MEDIA:./foo/../../../etc/shadow",
+    "MEDIA:C:\\Users\\First Last\\..\\secret.png",
+    "MEDIA:/tmp/project screenshots/../../.env",
   ] as const)("rejects traversal and unsupported home-dir path: %s", (input) => {
     expectRejectedMediaPathCase(input);
+  });
+
+  it("does not absorb an unsafe remote URL into a spaced local media path", () => {
+    expectParsedMediaOutputCase(
+      "MEDIA:C:\\Users\\First Last\\workspace\\shot.png https://127.0.0.1/secret.png",
+      {
+        mediaUrls: ["C:\\Users\\First Last\\workspace\\shot.png"],
+        text: "https://127.0.0.1/secret.png",
+      },
+    );
   });
 
   it.each([

--- a/src/media/parse.ts
+++ b/src/media/parse.ts
@@ -50,6 +50,7 @@ function cleanCandidate(raw: string) {
 }
 
 const WINDOWS_DRIVE_RE = /^[a-zA-Z]:[\\/]/;
+const MEDIA_SOURCE_ROOT_RE = /^(?:[a-z]:[\\/]|[/~]|\.{1,2}[\\/]|\\\\)/i;
 const SCHEME_RE = /^[a-zA-Z][a-zA-Z0-9+.-]*:/;
 const HAS_FILE_EXT = /\.\w{1,10}$/;
 
@@ -196,6 +197,33 @@ function isValidMedia(
   }
 
   return false;
+}
+
+function beginsIndependentMediaSource(raw: string): boolean {
+  const candidate = normalizeMediaSource(cleanCandidate(raw));
+  return MEDIA_SOURCE_ROOT_RE.test(candidate) || SCHEME_RE.test(candidate);
+}
+
+function splitUnquotedMediaDirectiveParts(payload: string): string[] {
+  const parts: string[] = [];
+  let previousEnd = 0;
+  for (const match of payload.matchAll(/\S+/g)) {
+    const candidate = normalizeMediaSource(cleanCandidate(match[0]));
+    const previous = parts.at(-1);
+    const previousCandidate = previous ? normalizeMediaSource(cleanCandidate(previous)) : "";
+    if (
+      MEDIA_SOURCE_ROOT_RE.test(previousCandidate) &&
+      !beginsIndependentMediaSource(candidate) &&
+      (!HAS_FILE_EXT.test(previousCandidate) || !isValidMedia(candidate))
+    ) {
+      // Preserve real filename whitespace while keeping independently valid attachments separate.
+      parts[parts.length - 1] = `${previous}${payload.slice(previousEnd, match.index)}${match[0]}`;
+    } else {
+      parts.push(match[0]);
+    }
+    previousEnd = match.index + match[0].length;
+  }
+  return parts;
 }
 
 function unwrapQuoted(value: string): string | undefined {
@@ -583,19 +611,21 @@ export function splitMediaFromOutput(
       const payload = expectDefined(match[1], "parse regex capture 1");
       const unwrapped = unwrapQuoted(payload);
       const payloadValue = unwrapped ?? payload;
-      const parts = unwrapped ? [unwrapped] : payload.split(/\s+/).filter(Boolean);
+      const parts = unwrapped ? [unwrapped] : splitUnquotedMediaDirectiveParts(payload);
       const mediaStartIndex = media.length;
       let validCount = 0;
       const invalidParts: string[] = [];
       let hasValidMedia = false;
       for (const part of parts) {
         const candidate = normalizeMediaSource(cleanCandidate(part));
-        if (isValidMedia(candidate, unwrapped ? { allowSpaces: true } : undefined)) {
+        if (
+          isValidMedia(candidate, unwrapped || /\s/.test(part) ? { allowSpaces: true } : undefined)
+        ) {
           media.push(candidate);
           hasValidMedia = true;
           foundMediaToken = true;
           validCount += 1;
-        } else {
+        } else if (!/\s/.test(part) || !hasTraversalOrUnsupportedHomeDirPrefix(candidate)) {
           invalidParts.push(part);
         }
       }
@@ -607,6 +637,7 @@ export function splitMediaFromOutput(
         !unwrapped &&
         validCount === 1 &&
         invalidParts.length > 0 &&
+        !parts.slice(1).some(beginsIndependentMediaSource) &&
         /\s/.test(payloadValue) &&
         looksLikeLocalPath
       ) {


### PR DESCRIPTION
Fixes #112421

Original contributor: @MatthewSynthia. Original issue reporter: @Ali-Al1. The contributor's original human Git author, email, first authored timestamp, and PR are preserved.

## What Problem This Solves

Legacy final assistant replies with an unquoted `MEDIA:` attachment whose actual local pathname contains spaces silently split that one image into nonexistent/unsafe fragments. The fragments then reach reply normalization, outbound payload planning, and the real local media loader, so the user loses the generated image. Two spaced attachments on the same directive can both be lost. Windows profile names and UNC paths are affected as well.

## Why This Change Was Made

Group whitespace-separated fragments at the canonical `src/media/parse.ts` directive parser only while they still belong to the same rooted local source. Preserve original whitespace; stop at an independent drive, absolute/home/relative root, URL/file scheme, or independently valid completed attachment. Validate grouped paths with the existing security owner, and never absorb traversal or a rejected loopback URL into an approved attachment.

Refresh the contributor's implementation onto current main and remove the unrelated bundled relay file. The exact branch now changes only `src/media/parse.ts` and its colocated owner test. Production delta is +31 lines; there is no dependency, config, public API, or channel-specific behavior change.

## User Impact

One or multiple real image files in directories or filenames containing spaces now survive the entire parser -> reply normalization -> outbound payload -> real local file loading path. Quoted inputs remain unchanged, independent attachments remain separate, Windows drives/UNC paths retain their full spelling, and traversal/SSRF rejection remains enforced.

## Evidence

The exact same real proof creates two real 68-byte PNGs in separate spaced directories, invokes production `splitMediaFromOutput`, `normalizeReplyPayloadDirectives`, `createOutboundPayloadPlan`, and `loadWebMedia` with the real allowlisted directory, and compares every loaded byte.

Before, current main:

```json
[
  {
    "scenario": "single-png",
    "caption": "Image ready\nfinal.png",
    "parsed": [
      "<temp-root>/My",
      "Files/Project",
      "Assets/render"
    ],
    "reply": [
      "<temp-root>/My",
      "Files/Project",
      "Assets/render"
    ],
    "outbound": [
      [
        "<temp-root>/My",
        "Files/Project",
        "Assets/render"
      ]
    ],
    "loaded": [
      {
        "path": "<temp-root>/My",
        "error": "not-found"
      },
      {
        "path": "Files/Project",
        "error": "path-not-allowed"
      },
      {
        "path": "Assets/render",
        "error": "path-not-allowed"
      }
    ]
  },
  {
    "scenario": "two-png",
    "caption": "Images ready\nfinal.png photo.png",
    "parsed": [
      "<temp-root>/My",
      "Files/Project",
      "Assets/render",
      "<temp-root>/Second",
      "Album/another"
    ],
    "reply": [
      "<temp-root>/My",
      "Files/Project",
      "Assets/render",
      "<temp-root>/Second",
      "Album/another"
    ],
    "outbound": [
      [
        "<temp-root>/My",
        "Files/Project",
        "Assets/render",
        "<temp-root>/Second",
        "Album/another"
      ]
    ],
    "loaded": [
      {
        "path": "<temp-root>/My",
        "error": "not-found"
      },
      {
        "path": "Files/Project",
        "error": "path-not-allowed"
      },
      {
        "path": "Assets/render",
        "error": "path-not-allowed"
      },
      {
        "path": "<temp-root>/Second",
        "error": "not-found"
      },
      {
        "path": "Album/another",
        "error": "path-not-allowed"
      }
    ]
  },
  {
    "scenario": "windows-traversal",
    "text": "Last\\..\\secret.png",
    "parsed": [
      "C:\\Users\\First"
    ]
  },
  {
    "scenario": "posix-traversal",
    "text": "screenshots/../../.env",
    "parsed": [
      "/tmp/project"
    ]
  },
  {
    "scenario": "blocked-ssrf",
    "text": "https://127.0.0.1/secret.png",
    "parsed": [
      "C:\\Users\\First",
      "Last\\workspace\\shot.png"
    ]
  }
]
```

After, exact contributor head `bdc22d78c1cde863e7ee3b2863bdbf777f8766c8`:

```json
[
  {
    "scenario": "single-png",
    "caption": "Image ready",
    "parsed": [
      "<temp-root>/My Files/Project Assets/render final.png"
    ],
    "reply": [
      "<temp-root>/My Files/Project Assets/render final.png"
    ],
    "outbound": [
      [
        "<temp-root>/My Files/Project Assets/render final.png"
      ]
    ],
    "loaded": [
      {
        "path": "<temp-root>/My Files/Project Assets/render final.png",
        "kind": "image",
        "bytes": 68,
        "exactBytes": true
      }
    ]
  },
  {
    "scenario": "two-png",
    "caption": "Images ready",
    "parsed": [
      "<temp-root>/My Files/Project Assets/render final.png",
      "<temp-root>/Second Album/another photo.png"
    ],
    "reply": [
      "<temp-root>/My Files/Project Assets/render final.png",
      "<temp-root>/Second Album/another photo.png"
    ],
    "outbound": [
      [
        "<temp-root>/My Files/Project Assets/render final.png",
        "<temp-root>/Second Album/another photo.png"
      ]
    ],
    "loaded": [
      {
        "path": "<temp-root>/My Files/Project Assets/render final.png",
        "kind": "image",
        "bytes": 68,
        "exactBytes": true
      },
      {
        "path": "<temp-root>/Second Album/another photo.png",
        "kind": "image",
        "bytes": 68,
        "exactBytes": true
      }
    ]
  },
  {
    "scenario": "quoted-png",
    "caption": "Quoted image",
    "parsed": [
      "<temp-root>/My Files/Project Assets/render final.png"
    ],
    "reply": [
      "<temp-root>/My Files/Project Assets/render final.png"
    ],
    "outbound": [
      [
        "<temp-root>/My Files/Project Assets/render final.png"
      ]
    ],
    "loaded": [
      {
        "path": "<temp-root>/My Files/Project Assets/render final.png",
        "kind": "image",
        "bytes": 68,
        "exactBytes": true
      }
    ]
  },
  {
    "scenario": "windows-two",
    "text": "",
    "parsed": [
      "C:\\Users\\First Last\\workspace\\shot.png",
      "D:\\Other User\\second.png"
    ]
  },
  {
    "scenario": "windows-relative",
    "text": "",
    "parsed": [
      "C:\\Users\\First Last\\workspace\\shot.png",
      "media/second.png"
    ]
  },
  {
    "scenario": "unc",
    "text": "",
    "parsed": [
      "\\\\server\\My Files\\Project Assets\\render final.png"
    ]
  },
  {
    "scenario": "windows-traversal",
    "text": "",
    "parsed": []
  },
  {
    "scenario": "posix-traversal",
    "text": "",
    "parsed": []
  },
  {
    "scenario": "traversal-plus-safe",
    "text": "",
    "parsed": [
      "/tmp/safe/second.png"
    ]
  },
  {
    "scenario": "blocked-ssrf",
    "text": "https://127.0.0.1/secret.png",
    "parsed": [
      "C:\\Users\\First Last\\workspace\\shot.png"
    ]
  }
]
```

```bash
OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/private/tmp/openclaw-vitest-s02-112464-media node scripts/run-vitest.mjs src/media/parse.test.ts src/auto-reply/reply/reply-delivery.test.ts src/infra/outbound/payloads.test.ts
.agents/skills/autoreview/scripts/autoreview --mode uncommitted --engine codex --thinking xhigh
```

All three owner/caller suites pass: 158 tests across two Vitest shards. Targeted oxfmt and `git diff --check` pass. Fresh Codex Sol xhigh structured autoreview is clean. Both latest ClawSweeper rank-up moves are satisfied: current-main refresh plus focused parser proof, and complete removal of the unrelated relay change.