### PR TITLE
fix: keep replies working after config reload

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.delivery-and-tts.test-utils.ts
+++ b/src/auto-reply/reply/dispatch-from-config.delivery-and-tts.test-utils.ts
@@ -1,6 +1,10 @@
 // Imported by dispatch-from-config.test.ts to keep its mocked suite in one Vitest module graph.
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import type { OpenClawConfig } from "../../config/config.js";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearRuntimeConfigSnapshot,
+  setRuntimeConfigSnapshot,
+  type OpenClawConfig,
+} from "../../config/config.js";
 import {
   createDiagnosticTraceContext,
   getActiveDiagnosticTraceContext,
@@ -37,7 +41,11 @@ import { buildTestCtx } from "./test-ctx.js";
 beforeAll(globalBeforeAll0);
 
 describe("dispatchReplyFromConfig", () => {
-  beforeEach(describe0BeforeEach0);
+  beforeEach(() => {
+    clearRuntimeConfigSnapshot();
+    describe0BeforeEach0();
+  });
+  afterEach(clearRuntimeConfigSnapshot);
 
   it("keeps unauthorized plugin-owned binding slash replies suppressed while routed to the bound plugin", async () => {
     setNoAbort();
@@ -973,11 +981,15 @@ describe("dispatchReplyFromConfig", () => {
     expect(replyResolver).toHaveBeenCalledTimes(1);
   });
 
-  it("passes the loaded config plus configOverride patch to replyResolver when provided", async () => {
+  it("applies configOverride as a patch over the runtime config for replyResolver", async () => {
     setNoAbort();
     const cfg = emptyConfig;
     const dispatcher = createDispatcher();
     const ctx = buildTestCtx({ Provider: "msteams", Surface: "msteams" });
+    setRuntimeConfigSnapshot({
+      agents: { defaults: { userTimezone: "UTC" } },
+      messages: { suppressToolErrors: true },
+    });
 
     const overrideCfg = {
       agents: { defaults: { userTimezone: "America/New_York" } },
@@ -1003,14 +1015,37 @@ describe("dispatchReplyFromConfig", () => {
 
     expect(receivedCfg).not.toBe(cfg);
     expect(receivedCfg).not.toBe(overrideCfg);
-    expect(receivedCfg).toEqual(overrideCfg);
+    expect(receivedCfg).toMatchObject({
+      agents: { defaults: { userTimezone: "America/New_York" } },
+      messages: { suppressToolErrors: true },
+    });
   });
 
-  it("passes the already loaded config to replyResolver when configOverride is not provided", async () => {
+  it("drops a removed Firecrawl SecretRef from Discord replies after config reload", async () => {
     setNoAbort();
-    const cfg = { agents: { defaults: { userTimezone: "UTC" } } } as OpenClawConfig;
+    const cfg = {
+      plugins: {
+        entries: {
+          firecrawl: {
+            config: {
+              webFetch: {
+                apiKey: {
+                  source: "file",
+                  provider: "default",
+                  id: "/firecrawl/api-key",
+                },
+              },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const runtimeCfg = {
+      agents: { defaults: { userTimezone: "America/Edmonton" } },
+    } as OpenClawConfig;
+    setRuntimeConfigSnapshot(runtimeCfg);
     const dispatcher = createDispatcher();
-    const ctx = buildTestCtx({ Provider: "telegram", Surface: "telegram" });
+    const ctx = buildTestCtx({ Provider: "discord", Surface: "discord" });
 
     let receivedCfg: OpenClawConfig | undefined;
     const replyResolver = async (
@@ -1019,12 +1054,17 @@ describe("dispatchReplyFromConfig", () => {
       cfgArg?: OpenClawConfig,
     ) => {
       receivedCfg = cfgArg;
+      if (cfgArg?.plugins?.entries?.firecrawl) {
+        throw new Error("stale Firecrawl SecretRef reached reply resolution");
+      }
       return { text: "hi" } satisfies ReplyPayload;
     };
 
     await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
 
-    expect(receivedCfg).toBe(cfg);
+    expect(receivedCfg).toBe(runtimeCfg);
+    expect(receivedCfg?.plugins?.entries?.firecrawl).toBeUndefined();
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "hi" });
   });
 
   it("suppresses isReasoning payloads from final replies (WhatsApp channel)", async () => {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -42,6 +42,7 @@ import {
   formatPlanChecklistLines,
   normalizeAgentPlanSteps,
 } from "../../channels/streaming.js";
+import { getRuntimeConfigSnapshot } from "../../config/config.js";
 import { applyMergePatch } from "../../config/merge-patch.js";
 import { normalizeExplicitSessionKey } from "../../config/sessions/explicit-session-key-normalization.js";
 import { resolveGroupSessionKey } from "../../config/sessions/group.js";
@@ -2276,8 +2277,13 @@ async function dispatchReplyFromConfigInner(
       params.replyResolver ??
       (await traceReplyPhase("reply.load_reply_resolver", () => loadGetReplyFromConfigRuntime()))
         .getReplyFromConfig;
+    // Channel runtimes can outlive a config reload. Resolve one live snapshot
+    // per turn so reply setup and dispatch callbacks share the same authority.
+    const runtimeReplyConfig = getRuntimeConfigSnapshot() ?? cfg;
     const replyConfig = withFullRuntimeReplyConfig(
-      params.configOverride ? (applyMergePatch(cfg, params.configOverride) as OpenClawConfig) : cfg,
+      params.configOverride
+        ? (applyMergePatch(runtimeReplyConfig, params.configOverride) as OpenClawConfig)
+        : runtimeReplyConfig,
     );
     recordAgentDispatchStarted();
     const replyResult = await runWithDispatchLifecycleAdmission(

--- a/src/auto-reply/reply/dispatch-from-config.types.ts
+++ b/src/auto-reply/reply/dispatch-from-config.types.ts
@@ -21,6 +21,7 @@ export type DispatchFromConfigResult = {
 
 export type DispatchFromConfigParams = {
   ctx: FinalizedMsgContext;
+  /** Full runtime config captured by the channel; reply resolution refreshes it per turn. */
   cfg: OpenClawConfig;
   dispatcher: ReplyDispatcher;
   replyOptions?: Omit<InternalGetReplyOptions, "onBlockReply">;
@@ -28,7 +29,7 @@ export type DispatchFromConfigParams = {
   onSessionMetadataChanges?: (changes: CommandSessionMetadataChange[]) => void;
   fastAbortResolver?: TryFastAbortFromMessage;
   formatAbortReplyTextResolver?: FormatAbortReplyText;
-  /** Optional patch applied to the already loaded config before reply resolution. */
+  /** Optional patch applied to the current runtime config before reply resolution. */
   configOverride?: OpenClawConfig;
 };
 


### PR DESCRIPTION
Related: #103324

## What Problem This Solves

Fixes an issue where Discord users could have later replies fail after a successful config or secret reload when the channel runtime still retained its startup config. A removed SecretRef, such as a Firecrawl API key reference, could remain in that stale config and abort reply resolution.

## Why This Change Was Made

Reply resolution now takes the active runtime config snapshot at the start of each turn and applies any explicit per-dispatch override on top of it. The channel's startup config remains the fallback when no runtime snapshot is available, preserving the existing dispatch lifecycle while preventing stale configuration from reaching the reply resolver.

This is a focused adaptation of `c091f0e731754961fd6e896e1e002dbb93190c9e` from `fix/model-pin-fallback`; the unrelated model-pin and OAuth commits on that historical branch are intentionally excluded.

## User Impact

Discord replies continue working after live config or secret reloads, and removed SecretRefs no longer remain authoritative for later turns. Explicit per-turn config overrides still apply over the refreshed runtime config.

## Evidence

- Added a regression test that starts with a Firecrawl file SecretRef, installs a reloaded runtime snapshot without Firecrawl, and verifies the Discord reply resolver receives only the live snapshot and delivers the reply.
- Blacksmith Testbox `tbx_01ky3nxnywh5m0k2vh16dq5s5h` (`crimson-lobster`): `corepack pnpm test src/auto-reply/reply/dispatch-from-config.test.ts` — 275/275 tests passed.
- Same Testbox: `pnpm check:changed` for the three touched files — formatting, core/core-test typechecks, lint, dependency/plugin guards, and runtime guards passed (`exitCode: 0`).
- Fresh mandatory autoreview: clean, no accepted or actionable findings.
- `git diff --check` passed.

AI-assisted: implementation, regression coverage, and review were prepared with Codex.
