### PR TITLE
refactor(line,mattermost): declare single-account config promotion keys

### DIFF
--- a/extensions/line/package.json
+++ b/extensions/line/package.json
@@ -28,6 +28,9 @@
       "./index.ts"
     ],
     "setupEntry": "./setup-entry.ts",
+    "setupFeatures": {
+      "configPromotion": true
+    },
     "channel": {
       "id": "line",
       "configuredState": {

--- a/extensions/line/src/setup-core.ts
+++ b/extensions/line/src/setup-core.ts
@@ -73,6 +73,7 @@ export function isLineConfigured(cfg: OpenClawConfig, accountId: string): boolea
 export { parseLineAllowFromId };
 
 export const lineSetupAdapter: ChannelSetupAdapter = {
+  singleAccountKeysToMove: ["channelAccessToken", "channelSecret", "tokenFile", "secretFile"],
   resolveAccountId: ({ accountId }) => normalizeAccountId(accountId),
   applyAccountName: ({ cfg, accountId, name }) =>
     patchLineAccountConfig({

--- a/extensions/line/src/setup-surface.test.ts
+++ b/extensions/line/src/setup-surface.test.ts
@@ -16,6 +16,7 @@ import { linePlugin } from "./channel.js";
 import { lineGatewayAdapter } from "./gateway.js";
 import { probeLineBot } from "./probe.js";
 import { setLineRuntime } from "./runtime.js";
+import { lineSetupAdapter } from "./setup-core.js";
 import { lineSetupWizard } from "./setup-surface.js";
 
 const { getBotInfoMock, MessagingApiClientMock } = vi.hoisted(() => {
@@ -160,6 +161,13 @@ function collectRuntimeApiPreExports(runtimeApiPath: string): string[] {
 }
 
 describe("line setup wizard", () => {
+  it("exposes config-promotion declarations on the setup adapter", () => {
+    expect(lineSetupAdapter.singleAccountKeysToMove).toContain("channelAccessToken");
+    expect(lineSetupAdapter.singleAccountKeysToMove).toContain("channelSecret");
+    expect(lineSetupAdapter.singleAccountKeysToMove).toContain("tokenFile");
+    expect(lineSetupAdapter.singleAccountKeysToMove).toContain("secretFile");
+  });
+
   it("configures token and secret for the default account", async () => {
     const prompter = createTestWizardPrompter({
       text: vi.fn(async ({ message }: { message: string }) => {

--- a/extensions/mattermost/package.json
+++ b/extensions/mattermost/package.json
@@ -28,6 +28,9 @@
       "./index.ts"
     ],
     "setupEntry": "./setup-entry.ts",
+    "setupFeatures": {
+      "configPromotion": true
+    },
     "channel": {
       "id": "mattermost",
       "configuredState": {

--- a/extensions/mattermost/src/setup-core.ts
+++ b/extensions/mattermost/src/setup-core.ts
@@ -59,6 +59,7 @@ export function applyMattermostSetupConfigPatch(params: {
 }
 
 export const mattermostSetupAdapter: ChannelSetupAdapter = {
+  singleAccountKeysToMove: ["botToken", "baseUrl"],
   resolveAccountId: ({ accountId }) => normalizeAccountId(accountId),
   applyAccountName: ({ cfg, accountId, name }) =>
     applyAccountNameToChannelSection({

--- a/extensions/mattermost/src/setup.test.ts
+++ b/extensions/mattermost/src/setup.test.ts
@@ -125,6 +125,11 @@ describe("mattermost setup", () => {
     ).toBe(false);
   });
 
+  it("exposes config-promotion declarations on the setup adapter", () => {
+    expect(mattermostSetupAdapter.singleAccountKeysToMove).toContain("botToken");
+    expect(mattermostSetupAdapter.singleAccountKeysToMove).toContain("baseUrl");
+  });
+
   it("resolves accounts with unresolved secret refs allowed", () => {
     resolveMattermostAccount.mockReturnValue({ accountId: "default" });
 


### PR DESCRIPTION
## What Problem This Solves

Part 2 of #112238 follow-up. The line and mattermost channel plugins were missed in #112293, which moved hardcoded single-account promotion keys into per-channel plugin declarations. Both plugins have channel-specific config keys that need explicit declaration for single-account promotion but lacked `singleAccountKeysToMove` and `setupFeatures.configPromotion` in their package manifests.

## Why This Change Was Made

- Declares `singleAccountKeysToMove` on the line setup adapter (`channelAccessToken`, `channelSecret`, `tokenFile`, `secretFile`) and the mattermost setup adapter (`botToken`, `baseUrl`).
- Adds `setupFeatures.configPromotion: true` to both `package.json` files so doctor can read the declarations from the lightweight bundled setup artifact.
- These channel-specific keys are not in the common promotion key set, so without explicit declaration they are invisible to the doctor migration path.

Follows the same pattern as the channels migrated in #112293 (slack, signal, irc, imessage, nextcloud-talk, tlon, whatsapp, zalo, telegram, matrix) and the follow-up #112367 (googlechat, zalouser).

## User Impact

Single-account migration for line and mattermost channels now correctly identifies all account-scoped keys for promotion into `accounts.default`. Named-account configs won't risk flattening channel-root policy keys alongside account credentials. No runtime behavior, config shape, or credential handling changes.

## Evidence

- `extensions/mattermost/src/setup.test.ts` — declaration test passes (1 new, 14 passed).
- `extensions/line/src/setup-surface.test.ts` — declaration test passes (1 new, 13 passed; 1 pre-existing wizard timeout failure unchanged).
- `oxfmt --check` passed for all 4 changed source files.

## Scope

- No config/schema/default changes.
- No runtime behavior, credential, or setup flow changes.
- No changelog change.
- line and mattermost only — other channels were already covered by #112293 and #112367.
