### PR TITLE
fix(gateway): read control-UI descriptors from the pinned session-extension registry

### DIFF
--- a/src/gateway/control-ui-plugin-tabs.test.ts
+++ b/src/gateway/control-ui-plugin-tabs.test.ts
@@ -1,7 +1,11 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, describe, expect, it } from "vitest";
 import type { PluginControlUiDescriptor } from "../plugins/host-hooks.js";
-import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
+import {
+  pinActivePluginSessionExtensionRegistry,
+  resetPluginRuntimeStateForTest,
+  setActivePluginRegistry,
+} from "../plugins/runtime.js";
 import { createTestRegistry } from "../test-utils/channel-plugins.js";
 import {
   listControlUiPluginTabAuthGrants,
@@ -122,6 +126,33 @@ describe("listControlUiPluginTabs", () => {
       { pluginId: "workboard", kind: "workboard:card", label: "Workboard card" },
       { pluginId: "workboard", kind: "workboard:mini", label: "Workboard summary" },
     ]);
+  });
+
+  it("survives agent-turn active-registry swaps via the pinned session-extension registry", () => {
+    const gatewayRegistry = createTestRegistry([]);
+    gatewayRegistry.controlUiDescriptors = [
+      {
+        pluginId: "workboard",
+        descriptor: tabDescriptor({
+          id: "card",
+          surface: "widget",
+          label: "Workboard card",
+          requiredScopes: ["operator.read"],
+        }),
+        source: "test:workboard",
+      },
+      { pluginId: "logbook", descriptor: tabDescriptor(), source: "test:logbook" },
+    ];
+    // Gateway startup pins its fully wired registry on the session-extension surface.
+    pinActivePluginSessionExtensionRegistry(gatewayRegistry);
+
+    // Agent-turn standalone loads install a registry without control-UI descriptors.
+    setActivePluginRegistry(createTestRegistry([]));
+
+    expect(listControlUiPluginWidgetKinds(["operator.read"]).map((kind) => kind.kind)).toEqual([
+      "workboard:card",
+    ]);
+    expect(listControlUiPluginTabs(["operator.admin"]).map((tab) => tab.id)).toEqual(["logbook"]);
   });
 
   it("grants only same-plugin gateway routes with least-privilege scopes", () => {

--- a/src/gateway/control-ui-plugin-tabs.ts
+++ b/src/gateway/control-ui-plugin-tabs.ts
@@ -1,8 +1,12 @@
 // Projects plugin "tab" Control UI descriptors into the hello payload so the
 // dashboard renders plugin tabs without hardcoding plugin ids in core.
+// Read the session-extension registry (gateway-pinned at startup), not the
+// mutable active registry: agent-turn standalone loads swap the active registry
+// for one without control-UI descriptors, which would empty hello for every
+// connection made after the first agent run.
 import type { PluginControlUiDescriptor } from "../plugins/host-hooks.js";
 import type { PluginRegistry } from "../plugins/registry.js";
-import { getActivePluginRegistry } from "../plugins/runtime.js";
+import { getActivePluginSessionExtensionRegistry } from "../plugins/runtime.js";
 import { resolveControlUiPluginTabPathname } from "./control-ui-contract.js";
 import {
   authorizeOperatorScopesForRequiredScope,
@@ -105,7 +109,7 @@ export function listControlUiPluginTabs(
   scopes: readonly string[],
   opts: { requireGatewayAuthGrant?: boolean } = {},
 ): ControlUiPluginTab[] {
-  const registry = getActivePluginRegistry();
+  const registry = getActivePluginSessionExtensionRegistry();
   return projectControlUiPluginTabs(registry?.controlUiDescriptors ?? [], scopes).flatMap((tab) => {
     const route = registry ? findControlUiTabGatewayRoute(registry, tab) : undefined;
     if (route === null) {
@@ -123,7 +127,7 @@ export function listControlUiPluginTabs(
 export function listControlUiPluginWidgetKinds(
   scopes: readonly string[],
 ): ControlUiPluginWidgetKind[] {
-  const entries = getActivePluginRegistry()?.controlUiDescriptors ?? [];
+  const entries = getActivePluginSessionExtensionRegistry()?.controlUiDescriptors ?? [];
   return entries
     .flatMap((entry) => {
       const descriptor = entry.descriptor;
@@ -152,7 +156,7 @@ export function listControlUiPluginWidgetKinds(
 export function listControlUiPluginTabAuthGrants(
   callerScopes: readonly string[],
 ): ControlUiPluginTabAuthGrant[] {
-  const registry = getActivePluginRegistry();
+  const registry = getActivePluginSessionExtensionRegistry();
   if (!registry || !authorizeOperatorScopesForRequiredScope(READ_SCOPE, callerScopes).allowed) {
     return [];
   }


### PR DESCRIPTION
## What Problem This Solves

Plugin widget kinds (and plugin tabs/tab auth grants) vanish from the control-UI hello payload after the first agent turn. Repro on a fresh gateway with the Workboard plugin enabled:

1. Cold-load the control UI → board plugin widgets (`workboard:card`, `workboard:mini`) render natively. ✅
2. Run any agent turn (even a one-word reply).
3. Cold-load a new page → the same widgets render as **"Widget from disabled plugin workboard"** with a Remove button. ❌ Already-open tabs keep working because they cached the earlier hello.

## Why This Change Was Made

`control-ui-plugin-tabs.ts` read `getActivePluginRegistry()`, but the active registry is process-mutable: agent-turn standalone plugin loads (`ensureStandaloneRuntimePluginRegistryLoaded` → `setActivePluginRegistry`) install a registry without control-UI descriptors. The gateway already pins its fully wired registry on the session-extension surface at startup (`server-plugin-bootstrap.ts`, `server-runtime-state.ts`) precisely so gateway-owned reads survive agent-scoped swaps — `session-catalog.ts` and `getActivePluginGatewayNodePolicyRegistry` already follow this pattern ("Agent-scoped registry swaps must not add commands or shadow the pinned startup policy").

This switches the three descriptor reads to `getActivePluginSessionExtensionRegistry()` (pinned ?? active, so standalone/test contexts keep working) and adds the invariant comment.

## User Impact

Dashboard plugin widgets, plugin tabs, and tab auth grants stay available to every new browser connection for the gateway's lifetime instead of degrading after the first agent run. This also affected pre-existing plugin tabs, not just the new widget kinds from #112434.

## Evidence

- New regression test: pin descriptor-bearing registry → swap active registry to a bare one (simulating the agent-turn install) → kinds and tabs still list. `src/gateway/control-ui-plugin-tabs.test.ts` 14/14.
- `node scripts/run-vitest.mjs src/gateway/server/ws-connection` (hello consumer): 33 files, 390/390 passed.
- Live proof on a scratch gateway (build at the fix): restart → agent turn → cold page load renders `workboard:card` + `workboard:mini` natively; same sequence on `main` (0f066eec811) renders the "disabled plugin" fallback.
