### PR TITLE
feat(tools): add productivity profile

### DIFF
--- a/docs/cli/policy.md
+++ b/docs/cli/policy.md
@@ -508,7 +508,7 @@ only reviewed exec approval posture for selected agents.
 
 | Policy field                    | Observed state                                              | Use when                                                                                                 |
 | ------------------------------- | ----------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
-| `tools.profiles.allow`          | `tools.profile` and `agents.entries.*.tools.profile`        | Allow only tool profile ids such as `minimal`, `messaging`, or `coding`.                                 |
+| `tools.profiles.allow`          | `tools.profile` and `agents.entries.*.tools.profile`        | Allow only tool profile ids such as `minimal`, `productivity`, `messaging`, or `coding`.                 |
 | `tools.fs.requireWorkspaceOnly` | `tools.fs.workspaceOnly` and per-agent `tools.fs` overrides | Set to `true` to require workspace-only filesystem tool posture.                                         |
 | `tools.exec.allowSecurity`      | `tools.exec.security` and per-agent exec security           | Allow only exec security modes such as `deny` or `allowlist`.                                            |
 | `tools.exec.requireAsk`         | `tools.exec.ask` and per-agent exec ask mode                | Require approval posture such as `always`.                                                               |

--- a/docs/gateway/config-tools.md
+++ b/docs/gateway/config-tools.md
@@ -20,14 +20,16 @@ sidebarTitle: "Tools and custom providers"
 Local onboarding defaults new local configs to `tools.profile: "coding"` when unset (existing explicit profiles are preserved).
 </Note>
 
-| Profile     | Includes                                                                                                                                                                                                                                                |
-| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `minimal`   | `session_status` only                                                                                                                                                                                                                                   |
-| `coding`    | `group:fs`, `group:runtime`, `group:web`, `group:sessions`, `group:memory`, `cron`, `get_goal`, `create_goal`, `update_goal`, `update_plan`, `ask_user`, `skill_workshop`, `image`, `image_generate`, `music_generate`, `video_generate`                |
-| `messaging` | `group:messaging`, `sessions`, `sessions_list`, `sessions_history`, `sessions_search`, `conversations_list`, `conversations_send`, `conversations_turn`, `sessions_send`, `sessions_spawn`, `sessions_yield`, `subagents`, `session_status`, `ask_user` |
-| `full`      | No restriction (same as unset)                                                                                                                                                                                                                          |
+| Profile        | Includes                                                                                                                                                                                                                                                |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `minimal`      | `session_status` only                                                                                                                                                                                                                                   |
+| `productivity` | File read/write/edit/patch, web search/fetch, memory search/read, session list/history/status, goals/plans, `cron`, and image understanding. Excludes command execution, messaging, delegation, browser/device control, and plugin/MCP tools.           |
+| `coding`       | `group:fs`, `group:runtime`, `group:web`, `group:sessions`, `group:memory`, `cron`, `get_goal`, `create_goal`, `update_goal`, `update_plan`, `ask_user`, `skill_workshop`, `image`, `image_generate`, `music_generate`, `video_generate`                |
+| `messaging`    | `group:messaging`, `sessions`, `sessions_list`, `sessions_history`, `sessions_search`, `conversations_list`, `conversations_send`, `conversations_turn`, `sessions_send`, `sessions_spawn`, `sessions_yield`, `subagents`, `session_status`, `ask_user` |
+| `full`         | No restriction (same as unset)                                                                                                                                                                                                                          |
 
 `coding` and `messaging` also implicitly allow `bundle-mcp` (configured MCP servers).
+`productivity` does not; add exact plugin or MCP tool IDs with `tools.alsoAllow` when needed. A tool profile selects capabilities; it does not confine file access. Pair write-capable profiles with `tools.fs.workspaceOnly: true` or sandboxing when files must stay inside the workspace.
 
 ### Tool groups
 

--- a/docs/gateway/config-tools.md
+++ b/docs/gateway/config-tools.md
@@ -20,16 +20,18 @@ sidebarTitle: "Tools and custom providers"
 Local onboarding defaults new local configs to `tools.profile: "coding"` when unset (existing explicit profiles are preserved).
 </Note>
 
-| Profile        | Includes                                                                                                                                                                                                                                                |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `minimal`      | `session_status` only                                                                                                                                                                                                                                   |
-| `productivity` | File read/write/edit/patch, web search/fetch, memory search/read, session list/history/status, goals/plans, `cron`, and image understanding. Excludes command execution, messaging, delegation, browser/device control, and plugin/MCP tools.           |
-| `coding`       | `group:fs`, `group:runtime`, `group:web`, `group:sessions`, `group:memory`, `cron`, `get_goal`, `create_goal`, `update_goal`, `update_plan`, `ask_user`, `skill_workshop`, `image`, `image_generate`, `music_generate`, `video_generate`                |
-| `messaging`    | `group:messaging`, `sessions`, `sessions_list`, `sessions_history`, `sessions_search`, `conversations_list`, `conversations_send`, `conversations_turn`, `sessions_send`, `sessions_spawn`, `sessions_yield`, `subagents`, `session_status`, `ask_user` |
-| `full`         | No restriction (same as unset)                                                                                                                                                                                                                          |
+| Profile        | Includes                                                                                                                                                                                                                                                                                       |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `minimal`      | `session_status` only                                                                                                                                                                                                                                                                          |
+| `productivity` | File read/write/edit/patch, web search/fetch, X search, memory search/read, session list/history/status, goals/plans, interactive questions, `cron`, and image understanding. Excludes command execution, general-purpose messaging, delegation, browser/device control, and plugin/MCP tools. |
+| `coding`       | `group:fs`, `group:runtime`, `group:web`, `group:sessions`, `group:memory`, `cron`, `get_goal`, `create_goal`, `update_goal`, `update_plan`, `ask_user`, `skill_workshop`, `image`, `image_generate`, `music_generate`, `video_generate`                                                       |
+| `messaging`    | `group:messaging`, `sessions`, `sessions_list`, `sessions_history`, `sessions_search`, `conversations_list`, `conversations_send`, `conversations_turn`, `sessions_send`, `sessions_spawn`, `sessions_yield`, `subagents`, `session_status`, `ask_user`                                        |
+| `full`         | No restriction (same as unset)                                                                                                                                                                                                                                                                 |
 
 `coding` and `messaging` also implicitly allow `bundle-mcp` (configured MCP servers).
-`productivity` does not; add exact plugin or MCP tool IDs with `tools.alsoAllow` when needed. A tool profile selects capabilities; it does not confine file access. Pair write-capable profiles with `tools.fs.workspaceOnly: true` or sandboxing when files must stay inside the workspace.
+`productivity` does not; add exact plugin or MCP tool IDs with `tools.alsoAllow` when needed.
+Its `cron` access can schedule isolated jobs whose configured delivery announces to a chat or posts to a webhook; scheduled runs retain the creator's effective tool allowlist.
+A tool profile selects capabilities; it does not confine file access. Pair write-capable profiles with `tools.fs.workspaceOnly: true` or sandboxing when files must stay inside the workspace.
 
 ### Tool groups
 

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -51,6 +51,7 @@ openclaw doctor
 Common causes:
 
 - `tools.profile: "minimal"` allows only `session_status`.
+- `tools.profile: "productivity"` allows file, web, memory, session-inspection, planning, cron, and image-understanding tools without command execution, messaging, delegation, or plugin/MCP tools.
 - `tools.profile: "messaging"` is narrow, for chat-only agents.
 - `tools.profile: "coding"` is the default for new local configs (repo, file,
   shell, and runtime work).

--- a/docs/help/troubleshooting.md
+++ b/docs/help/troubleshooting.md
@@ -51,7 +51,7 @@ openclaw doctor
 Common causes:
 
 - `tools.profile: "minimal"` allows only `session_status`.
-- `tools.profile: "productivity"` allows file, web, memory, session-inspection, planning, cron, and image-understanding tools without command execution, messaging, delegation, or plugin/MCP tools.
+- `tools.profile: "productivity"` allows file, web/X research, memory, session inspection, planning, interactive questions, cron, and image-understanding tools without command execution, general-purpose messaging, delegation, or plugin/MCP tools. Cron jobs may still use their configured chat or webhook delivery.
 - `tools.profile: "messaging"` is narrow, for chat-only agents.
 - `tools.profile: "coding"` is the default for new local configs (repo, file,
   shell, and runtime work).

--- a/extensions/policy/src/doctor/metadata.ts
+++ b/extensions/policy/src/doctor/metadata.ts
@@ -250,7 +250,7 @@ export const POLICY_RULE_METADATA = [
     valueType: "string-list",
     checkIds: [CHECK_IDS.policyToolsProfileUnapproved],
     emptyList: "disabled",
-    allowedValues: ["minimal", "coding", "messaging", "full"],
+    allowedValues: ["minimal", "productivity", "coding", "messaging", "full"],
     scopeSelectors: ["agentIds"],
   },
   {

--- a/extensions/policy/src/doctor/policy-constants.ts
+++ b/extensions/policy/src/doctor/policy-constants.ts
@@ -63,7 +63,13 @@ export const SUPPORTED_AGENT_WORKSPACE_DENY_TOOLS = [
   "apply_patch",
 ] as const;
 
-export const SUPPORTED_TOOL_PROFILES = ["minimal", "coding", "messaging", "full"] as const;
+export const SUPPORTED_TOOL_PROFILES = [
+  "minimal",
+  "productivity",
+  "coding",
+  "messaging",
+  "full",
+] as const;
 
 export const SUPPORTED_TOOL_EXEC_SECURITY = ["deny", "allowlist", "full"] as const;
 

--- a/packages/gateway-protocol/src/schema/agents-models-skills.ts
+++ b/packages/gateway-protocol/src/schema/agents-models-skills.ts
@@ -807,6 +807,7 @@ export const ToolsInvokeParamsSchema = closedObject({
 export const ToolCatalogProfileSchema = closedObject({
   id: Type.Union([
     Type.Literal("minimal"),
+    Type.Literal("productivity"),
     Type.Literal("coding"),
     Type.Literal("messaging"),
     Type.Literal("full"),
@@ -829,6 +830,7 @@ export const ToolCatalogEntrySchema = closedObject({
   defaultProfiles: Type.Array(
     Type.Union([
       Type.Literal("minimal"),
+      Type.Literal("productivity"),
       Type.Literal("coding"),
       Type.Literal("messaging"),
       Type.Literal("full"),

--- a/src/agents/tool-catalog.test.ts
+++ b/src/agents/tool-catalog.test.ts
@@ -100,6 +100,28 @@ describe("tool-catalog", () => {
     expect(requirePolicyAllow("minimal")).toEqual(["session_status"]);
   });
 
+  it("provides a productivity profile without runtime, messaging, delegation, or plugin tools", () => {
+    expect(requirePolicyAllow("productivity")).toEqual([
+      "read",
+      "write",
+      "edit",
+      "apply_patch",
+      "web_search",
+      "web_fetch",
+      "memory_search",
+      "memory_get",
+      "sessions_list",
+      "sessions_history",
+      "session_status",
+      "cron",
+      "get_goal",
+      "create_goal",
+      "update_goal",
+      "update_plan",
+      "image",
+    ]);
+  });
+
   it("full profile uses wildcard to grant all tools (#76507)", () => {
     const policy = requireCoreToolProfilePolicy("full");
     expect(policy.allow).toEqual(["*"]);

--- a/src/agents/tool-catalog.test.ts
+++ b/src/agents/tool-catalog.test.ts
@@ -108,6 +108,7 @@ describe("tool-catalog", () => {
       "apply_patch",
       "web_search",
       "web_fetch",
+      "x_search",
       "memory_search",
       "memory_get",
       "sessions_list",
@@ -118,6 +119,7 @@ describe("tool-catalog", () => {
       "create_goal",
       "update_goal",
       "update_plan",
+      "ask_user",
       "image",
     ]);
   });

--- a/src/agents/tool-catalog.ts
+++ b/src/agents/tool-catalog.ts
@@ -25,7 +25,7 @@ import {
 } from "./tool-description-presets.js";
 
 /** Built-in tool profile ids exposed in config and UI. */
-export type ToolProfileId = "minimal" | "coding" | "messaging" | "full";
+export type ToolProfileId = "minimal" | "productivity" | "coding" | "messaging" | "full";
 
 /** Allow/deny policy generated from a built-in tool profile. */
 type ToolProfilePolicy = {
@@ -72,28 +72,28 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
     label: "read",
     description: "Read file contents",
     sectionId: "fs",
-    profiles: ["coding"],
+    profiles: ["productivity", "coding"],
   },
   {
     id: "write",
     label: "write",
     description: "Create or overwrite files",
     sectionId: "fs",
-    profiles: ["coding"],
+    profiles: ["productivity", "coding"],
   },
   {
     id: "edit",
     label: "edit",
     description: "Make precise edits",
     sectionId: "fs",
-    profiles: ["coding"],
+    profiles: ["productivity", "coding"],
   },
   {
     id: "apply_patch",
     label: "apply_patch",
     description: "Patch files",
     sectionId: "fs",
-    profiles: ["coding"],
+    profiles: ["productivity", "coding"],
   },
   {
     id: "exec",
@@ -122,7 +122,7 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
     label: "web_search",
     description: "Search the web",
     sectionId: "web",
-    profiles: ["coding"],
+    profiles: ["productivity", "coding"],
     includeInOpenClawGroup: true,
   },
   {
@@ -130,7 +130,7 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
     label: "web_fetch",
     description: "Fetch web content",
     sectionId: "web",
-    profiles: ["coding"],
+    profiles: ["productivity", "coding"],
     includeInOpenClawGroup: true,
   },
   {
@@ -146,7 +146,7 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
     label: "memory_search",
     description: "Semantic search",
     sectionId: "memory",
-    profiles: ["coding"],
+    profiles: ["productivity", "coding"],
     includeInOpenClawGroup: true,
   },
   {
@@ -154,7 +154,7 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
     label: "memory_get",
     description: "Read memory files",
     sectionId: "memory",
-    profiles: ["coding"],
+    profiles: ["productivity", "coding"],
     includeInOpenClawGroup: true,
   },
   {
@@ -170,7 +170,7 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
     label: "sessions_list",
     description: SESSIONS_LIST_TOOL_DISPLAY_SUMMARY,
     sectionId: "sessions",
-    profiles: ["coding", "messaging"],
+    profiles: ["productivity", "coding", "messaging"],
     includeInOpenClawGroup: true,
   },
   {
@@ -178,7 +178,7 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
     label: "sessions_history",
     description: SESSIONS_HISTORY_TOOL_DISPLAY_SUMMARY,
     sectionId: "sessions",
-    profiles: ["coding", "messaging"],
+    profiles: ["productivity", "coding", "messaging"],
     includeInOpenClawGroup: true,
   },
   {
@@ -258,7 +258,7 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
     label: "session_status",
     description: SESSION_STATUS_TOOL_DISPLAY_SUMMARY,
     sectionId: "sessions",
-    profiles: ["minimal", "coding", "messaging"],
+    profiles: ["minimal", "productivity", "coding", "messaging"],
     includeInOpenClawGroup: true,
   },
   {
@@ -345,7 +345,7 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
     label: "cron",
     description: CRON_TOOL_DISPLAY_SUMMARY,
     sectionId: "automation",
-    profiles: ["coding"],
+    profiles: ["productivity", "coding"],
     includeInOpenClawGroup: true,
   },
   {
@@ -393,7 +393,7 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
     label: "get_goal",
     description: "Get current thread goal",
     sectionId: "agents",
-    profiles: ["coding"],
+    profiles: ["productivity", "coding"],
     includeInOpenClawGroup: true,
   },
   {
@@ -401,7 +401,7 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
     label: "create_goal",
     description: "Create a thread goal",
     sectionId: "agents",
-    profiles: ["coding"],
+    profiles: ["productivity", "coding"],
     includeInOpenClawGroup: true,
   },
   {
@@ -409,7 +409,7 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
     label: "update_goal",
     description: "Complete or block a thread goal",
     sectionId: "agents",
-    profiles: ["coding"],
+    profiles: ["productivity", "coding"],
     includeInOpenClawGroup: true,
   },
   {
@@ -417,7 +417,7 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
     label: "update_plan",
     description: UPDATE_PLAN_TOOL_DISPLAY_SUMMARY,
     sectionId: "agents",
-    profiles: ["coding"],
+    profiles: ["productivity", "coding"],
     includeInOpenClawGroup: true,
   },
   {
@@ -442,7 +442,7 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
     label: "image",
     description: "Image understanding",
     sectionId: "media",
-    profiles: ["coding"],
+    profiles: ["productivity", "coding"],
     includeInOpenClawGroup: true,
   },
   {
@@ -493,6 +493,9 @@ const CORE_TOOL_PROFILES: Record<ToolProfileId, ToolProfilePolicy> = {
   minimal: {
     allow: listCoreToolIdsForProfile("minimal"),
   },
+  productivity: {
+    allow: listCoreToolIdsForProfile("productivity"),
+  },
   coding: {
     allow: [...listCoreToolIdsForProfile("coding"), "bundle-mcp"],
   },
@@ -527,6 +530,7 @@ export const CORE_TOOL_GROUPS = buildCoreToolGroupMap();
 /** Profile options shown in model/tool configuration UIs. */
 export const PROFILE_OPTIONS = [
   { id: "minimal", label: "Minimal" },
+  { id: "productivity", label: "Productivity" },
   { id: "coding", label: "Coding" },
   { id: "messaging", label: "Messaging" },
   { id: "full", label: "Full" },

--- a/src/agents/tool-catalog.ts
+++ b/src/agents/tool-catalog.ts
@@ -138,7 +138,7 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
     label: "x_search",
     description: "Search X posts",
     sectionId: "web",
-    profiles: ["coding"],
+    profiles: ["productivity", "coding"],
     includeInOpenClawGroup: true,
   },
   {
@@ -425,7 +425,7 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
     label: "ask_user",
     description: ASK_USER_TOOL_DISPLAY_SUMMARY,
     sectionId: "agents",
-    profiles: ["coding", "messaging"],
+    profiles: ["productivity", "coding", "messaging"],
     includeInOpenClawGroup: true,
   },
   {

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -1412,8 +1412,9 @@ describe("config cli", () => {
             {
               path: "agents.list.3.tools.profile",
               pathSegments: ["agents", "list", 3, "tools", "profile"],
-              message: 'Invalid input (allowed: "minimal", "coding", "messaging", "full")',
-              allowedValues: ["minimal", "coding", "messaging", "full"],
+              message:
+                'Invalid input (allowed: "minimal", "productivity", "coding", "messaging", "full")',
+              allowedValues: ["minimal", "productivity", "coding", "messaging", "full"],
             },
           ],
         }),
@@ -1422,7 +1423,7 @@ describe("config cli", () => {
       await expect(runConfigCommand(["config", "validate"])).rejects.toThrow(ExitError);
 
       expectErrorIncludes(
-        'openclaw.json:7 — agents.list[3].tools.profile: Invalid input (allowed: "minimal", "coding", "messaging", "full"), got: "none"',
+        'openclaw.json:7 — agents.list[3].tools.profile: Invalid input (allowed: "minimal", "productivity", "coding", "messaging", "full"), got: "none"',
       );
     });
 

--- a/src/config/config.tools-alsoAllow.test.ts
+++ b/src/config/config.tools-alsoAllow.test.ts
@@ -42,7 +42,7 @@ describe("config: tools.alsoAllow", () => {
   it("allows profile + alsoAllow", () => {
     const res = validateConfigObject({
       tools: {
-        profile: "coding",
+        profile: "productivity",
         alsoAllow: ["lobster"],
       },
     });

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -155,7 +155,7 @@ export type MediaToolsConfig = {
   video?: MediaUnderstandingCapabilityConfig;
 };
 
-export type ToolProfileId = "minimal" | "coding" | "messaging" | "full";
+export type ToolProfileId = "minimal" | "productivity" | "coding" | "messaging" | "full";
 
 export type ToolLoopDetectionConfig = {
   /** Enable tool-loop protection (default: false). */

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -449,7 +449,13 @@ const ToolsWebSchema = z
   .optional();
 
 const ToolProfileSchema = z
-  .union([z.literal("minimal"), z.literal("coding"), z.literal("messaging"), z.literal("full")])
+  .union([
+    z.literal("minimal"),
+    z.literal("productivity"),
+    z.literal("coding"),
+    z.literal("messaging"),
+    z.literal("full"),
+  ])
   .optional();
 
 type AllowlistPolicy = {

--- a/src/gateway/server-methods/tools-catalog.test.ts
+++ b/src/gateway/server-methods/tools-catalog.test.ts
@@ -71,6 +71,7 @@ type CatalogGroup = {
 };
 type CatalogPayload = {
   agentId?: string;
+  profiles?: Array<{ id?: string; label?: string }>;
   groups: CatalogGroup[];
 };
 
@@ -148,6 +149,13 @@ describe("tools.catalog handler", () => {
     await invoke();
     const payload = expectCatalogPayload(respond);
     expect(payload.agentId).toBe("main");
+    expect(payload.profiles).toEqual([
+      { id: "minimal", label: "Minimal" },
+      { id: "productivity", label: "Productivity" },
+      { id: "coding", label: "Coding" },
+      { id: "messaging", label: "Messaging" },
+      { id: "full", label: "Full" },
+    ]);
     const groups = payload.groups ?? [];
     expect(groups.some((group) => group.source === "plugin")).toBe(false);
     const media = groups.find((group) => group.id === "media");

--- a/src/gateway/server-methods/tools-catalog.ts
+++ b/src/gateway/server-methods/tools-catalog.ts
@@ -38,7 +38,7 @@ type ToolCatalogEntry = {
   optional?: boolean;
   risk?: "low" | "medium" | "high";
   tags?: string[];
-  defaultProfiles: Array<"minimal" | "coding" | "messaging" | "full">;
+  defaultProfiles: Array<"minimal" | "productivity" | "coding" | "messaging" | "full">;
 };
 
 type ToolCatalogGroup = {

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -880,6 +880,7 @@ export const en: TranslationMap = {
       },
       profiles: {
         minimal: "Minimal",
+        productivity: "Productivity",
         coding: "Coding",
         messaging: "Messaging",
         full: "Full",

--- a/ui/src/lib/agents/display.ts
+++ b/ui/src/lib/agents/display.ts
@@ -220,6 +220,7 @@ const FALLBACK_TOOL_SECTIONS: FallbackToolSection[] = [
 // labels stay translated and consistent.
 export const PROFILE_OPTIONS = [
   { id: "minimal", labelKey: "agents.toolCatalog.profiles.minimal" },
+  { id: "productivity", labelKey: "agents.toolCatalog.profiles.productivity" },
   { id: "coding", labelKey: "agents.toolCatalog.profiles.coding" },
   { id: "messaging", labelKey: "agents.toolCatalog.profiles.messaging" },
   { id: "full", labelKey: "agents.toolCatalog.profiles.full" },


### PR DESCRIPTION
## Summary

Adds a built-in `productivity` tool profile for bounded personal-assistant workflows: workspace files, web/X research, memory lookup, session inspection, goals/plans, structured questions, scheduled work, and image understanding.

The exact allowlist is:

`read`, `write`, `edit`, `apply_patch`, `web_search`, `web_fetch`, `x_search`, `memory_search`, `memory_get`, `sessions_list`, `sessions_history`, `session_status`, `cron`, `get_goal`, `create_goal`, `update_goal`, `update_plan`, `ask_user`, and `image`.

It intentionally excludes shell/runtime tools, general-purpose messaging, delegation/session mutation, browser/device/UI control, generative media, `skill_workshop`, and arbitrary plugin/MCP tools. Users can add specifically trusted tools with the existing `tools.alsoAllow` setting.

This is additive: it does not change onboarding or any existing default profile. `cron` jobs remain capped to the creator's effective tool surface, although scheduled jobs can still use cron delivery (chat announcement or webhook). As with every tool profile, this is an allowlist rather than a filesystem sandbox; `workspaceOnly` and sandbox settings remain the containment controls.

## Public contract

Yes. This adds one new value to the public `tools.profile` config enum and the additive Gateway protocol/tool-catalog profile list. Policy metadata, config validation, Control UI option/translation, and developer documentation are updated in the same change.

## Validation

- Exact-head focused tests: 498 passed across tool catalog, `tools.alsoAllow`, config CLI, Gateway catalog, policy doctor/register, and Control UI display/security coverage.
- `pnpm docs:check-mdx`: passed (758 files).
- `pnpm docs:check-links`: passed (6,274 internal links; 0 broken).
- `pnpm docs:check-i18n-glossary -- --base origin/main`: passed.
- `git diff --check origin/main...HEAD`: passed.
- Exact committed branch autoreview against `origin/main`: no actionable regressions.
- Remote `pnpm check:changed` was attempted but did not reach test execution: Blacksmith Testbox leases `tbx_01kymt8373z3tkra5m30gvtdr6` and `tbx_01kymtr90n8waxbvvbt2yq4h96` failed during delegated file sync; brokered AWS lease `cbx_a04f2050b953` was quota-fallbacked to `t3.small` and OOM-killed during hydration (`exit 137`). GitHub CI is the remaining broad gate.

## Real behavior proof

Behavior or issue addressed:
Users can select the built-in `productivity` tool profile through the normal configuration CLI, persist it, read it back, and validate the resulting configuration.

Real environment tested:
Ubuntu under WSL, source checkout at `3858833c38fded70713e18de4703c382cbbc3bbb`, using the repository CLI and an isolated temporary `OPENCLAW_STATE_DIR`.

Exact steps or command run after this patch:

1. `pnpm openclaw config set tools.profile '"productivity"' --strict-json`
2. `pnpm openclaw config get tools.profile`
3. `pnpm openclaw config validate`

Evidence after fix:

```text
Updated tools.profile. No gateway restart needed.
productivity
Config valid: /tmp/openclaw-pr112473.IxE4GW/openclaw.json
```

Observed result after fix:
The profile value was accepted, persisted, returned as `productivity`, and the complete generated config passed validation.

What was not tested:
A live model turn and interactive Control UI click-through were not exercised. The config/catalog/UI behavior is covered by focused tests; broad remote `check:changed` was blocked during runner sync/hydration as documented above.
