### PR TITLE
refactor(line,mattermost): declare single-account config promotion keys

### DIFF
--- a/extensions/line/package.json
+++ b/extensions/line/package.json
@@ -28,6 +28,9 @@
       "./index.ts"
     ],
     "setupEntry": "./setup-entry.ts",
+    "setupFeatures": {
+      "configPromotion": true
+    },
     "channel": {
       "id": "line",
       "configuredState": {

--- a/extensions/line/src/setup-core.ts
+++ b/extensions/line/src/setup-core.ts
@@ -52,6 +52,7 @@ export function isLineConfigured(cfg: OpenClawConfig, accountId: string): boolea
 export { parseLineAllowFromId };
 
 export const lineSetupAdapter: ChannelSetupAdapter = {
+  singleAccountKeysToMove: ["channelAccessToken", "channelSecret", "tokenFile", "secretFile"],
   resolveAccountId: ({ accountId }) => normalizeAccountId(accountId),
   applyAccountName: ({ cfg, accountId, name }) =>
     patchLineAccountConfig({

--- a/extensions/line/src/setup-surface.test.ts
+++ b/extensions/line/src/setup-surface.test.ts
@@ -15,6 +15,7 @@ import { linePlugin } from "./channel.js";
 import { lineGatewayAdapter } from "./gateway.js";
 import { probeLineBot } from "./probe.js";
 import { setLineRuntime } from "./runtime.js";
+import { lineSetupAdapter } from "./setup-core.js";
 import { lineSetupWizard } from "./setup-surface.js";
 
 const { getBotInfoMock, MessagingApiClientMock } = vi.hoisted(() => {
@@ -40,6 +41,13 @@ afterAll(() => {
 const lineConfigure = createPluginSetupWizardConfigure(linePlugin);
 
 describe("line setup wizard", () => {
+  it("exposes config-promotion declarations on the setup adapter", () => {
+    expect(lineSetupAdapter.singleAccountKeysToMove).toContain("channelAccessToken");
+    expect(lineSetupAdapter.singleAccountKeysToMove).toContain("channelSecret");
+    expect(lineSetupAdapter.singleAccountKeysToMove).toContain("tokenFile");
+    expect(lineSetupAdapter.singleAccountKeysToMove).toContain("secretFile");
+  });
+
   it("configures token and secret for the default account", async () => {
     const prompter = createTestWizardPrompter({
       text: vi.fn(async ({ message }: { message: string }) => {

--- a/extensions/line/src/setup-surface.test.ts
+++ b/extensions/line/src/setup-surface.test.ts
@@ -18,14 +18,19 @@ import { setLineRuntime } from "./runtime.js";
 import { lineSetupAdapter } from "./setup-core.js";
 import { lineSetupWizard } from "./setup-surface.js";
 
-const { getBotInfoMock, MessagingApiClientMock } = vi.hoisted(() => {
+const { getBotInfoMock, MessagingApiClientMock, previousLocale } = vi.hoisted(() => {
   const getBotInfoMockLocal = vi.fn();
   const MessagingApiClientMockLocal = vi.fn(function () {
     return { getBotInfo: getBotInfoMockLocal };
   });
+  // Wizard copy is localized at module evaluation time; pin English before
+  // imports so prompt assertions do not depend on the developer machine's locale.
+  const previousLocaleLocal = process.env.OPENCLAW_LOCALE;
+  process.env.OPENCLAW_LOCALE = "en";
   return {
     getBotInfoMock: getBotInfoMockLocal,
     MessagingApiClientMock: MessagingApiClientMockLocal,
+    previousLocale: previousLocaleLocal,
   };
 });
 
@@ -36,6 +41,11 @@ vi.mock("@line/bot-sdk", () => ({
 afterAll(() => {
   vi.doUnmock("@line/bot-sdk");
   vi.resetModules();
+  if (previousLocale === undefined) {
+    delete process.env.OPENCLAW_LOCALE;
+  } else {
+    process.env.OPENCLAW_LOCALE = previousLocale;
+  }
 });
 
 const lineConfigure = createPluginSetupWizardConfigure(linePlugin);

--- a/extensions/mattermost/package.json
+++ b/extensions/mattermost/package.json
@@ -28,6 +28,9 @@
       "./index.ts"
     ],
     "setupEntry": "./setup-entry.ts",
+    "setupFeatures": {
+      "configPromotion": true
+    },
     "channel": {
       "id": "mattermost",
       "configuredState": {

--- a/extensions/mattermost/src/setup-core.ts
+++ b/extensions/mattermost/src/setup-core.ts
@@ -64,6 +64,7 @@ export function applyMattermostSetupConfigPatch(params: {
 }
 
 export const mattermostSetupAdapter: ChannelSetupAdapter = {
+  singleAccountKeysToMove: ["botToken", "baseUrl"],
   resolveAccountId: ({ accountId }) => normalizeAccountId(accountId),
   applyAccountName: ({ cfg, accountId, name }) =>
     applyAccountNameToChannelSection({

--- a/extensions/mattermost/src/setup.test.ts
+++ b/extensions/mattermost/src/setup.test.ts
@@ -131,6 +131,11 @@ describe("mattermost setup", () => {
     ).toBe(false);
   });
 
+  it("exposes config-promotion declarations on the setup adapter", () => {
+    expect(mattermostSetupAdapter.singleAccountKeysToMove).toContain("botToken");
+    expect(mattermostSetupAdapter.singleAccountKeysToMove).toContain("baseUrl");
+  });
+
   it("inspects accounts without resolving secret refs", () => {
     resolveMattermostAccount.mockReturnValue({ accountId: "default" });
 

--- a/extensions/mattermost/src/setup.test.ts
+++ b/extensions/mattermost/src/setup.test.ts
@@ -6,12 +6,19 @@ import {
   runSetupWizardConfigure,
 } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/setup";
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig, OpenClawPluginApi } from "../runtime-api.js";
 
 const resolveMattermostAccount = vi.hoisted(() => vi.fn());
 const normalizeMattermostBaseUrl = vi.hoisted(() => vi.fn((value: string | undefined) => value));
 const hasConfiguredSecretInput = vi.hoisted(() => vi.fn((value: unknown) => Boolean(value)));
+const previousLocale = vi.hoisted(() => {
+  // Wizard copy is localized at module evaluation time; pin English before
+  // imports so prompt assertions do not depend on the developer machine's locale.
+  const previousLocaleLocal = process.env.OPENCLAW_LOCALE;
+  process.env.OPENCLAW_LOCALE = "en";
+  return previousLocaleLocal;
+});
 
 vi.mock("./setup.accounts.runtime.js", () => {
   const resolveAccount = (params: Parameters<typeof resolveMattermostAccount>[0]) => {
@@ -103,6 +110,14 @@ describe("mattermost setup", () => {
     hasConfiguredSecretInput.mockReset();
     hasConfiguredSecretInput.mockImplementation((value: unknown) => Boolean(value));
     vi.unstubAllEnvs();
+  });
+
+  afterAll(() => {
+    if (previousLocale === undefined) {
+      delete process.env.OPENCLAW_LOCALE;
+    } else {
+      process.env.OPENCLAW_LOCALE = previousLocale;
+    }
   });
 
   it("reports configuration only when token and base url are both present", () => {

--- a/src/channels/plugins/setup-promotion-discovery.test.ts
+++ b/src/channels/plugins/setup-promotion-discovery.test.ts
@@ -1,0 +1,142 @@
+// Setup promotion discovery tests cover the doctor-only composed surface resolver.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+
+const resolveReadOnlyChannelPluginsForConfigMock = vi.hoisted(() => vi.fn());
+const resolveBundledChannelSetupPromotionSurfaceMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./read-only.js", () => ({
+  resolveReadOnlyChannelPluginsForConfig: resolveReadOnlyChannelPluginsForConfigMock,
+}));
+
+vi.mock("./setup-promotion-bundled.js", () => ({
+  resolveBundledChannelSetupPromotionSurface: resolveBundledChannelSetupPromotionSurfaceMock,
+}));
+
+import { createDiscoveredChannelSetupPromotionSurfaceResolver } from "./setup-promotion-discovery.js";
+
+const cfg = { channels: { mattermost: { enabled: true } } } as OpenClawConfig;
+
+describe("setup promotion discovery", () => {
+  beforeEach(() => {
+    resolveReadOnlyChannelPluginsForConfigMock.mockReset();
+    resolveReadOnlyChannelPluginsForConfigMock.mockReturnValue({ plugins: [] });
+    resolveBundledChannelSetupPromotionSurfaceMock.mockReset();
+    resolveBundledChannelSetupPromotionSurfaceMock.mockReturnValue(null);
+  });
+
+  it("resolves an external installed plugin promotion surface from its setup contract", () => {
+    resolveReadOnlyChannelPluginsForConfigMock.mockReturnValue({
+      plugins: [
+        {
+          id: "mattermost",
+          setupContract: { singleAccountKeysToMove: ["botToken", "baseUrl"] },
+        },
+      ],
+    });
+
+    const resolve = createDiscoveredChannelSetupPromotionSurfaceResolver(cfg);
+
+    expect(resolve("mattermost")).toEqual({
+      singleAccountKeysToMove: ["botToken", "baseUrl"],
+    });
+    expect(resolveBundledChannelSetupPromotionSurfaceMock).not.toHaveBeenCalled();
+  });
+
+  it("prefers the setup contract over the deprecated setup adapter", () => {
+    resolveReadOnlyChannelPluginsForConfigMock.mockReturnValue({
+      plugins: [
+        {
+          id: "mattermost",
+          setupContract: { singleAccountKeysToMove: ["botToken", "baseUrl"] },
+          setup: { singleAccountKeysToMove: ["legacyKey"] },
+        },
+      ],
+    });
+
+    const resolve = createDiscoveredChannelSetupPromotionSurfaceResolver(cfg);
+
+    expect(resolve("mattermost")).toEqual({
+      singleAccountKeysToMove: ["botToken", "baseUrl"],
+    });
+  });
+
+  it("falls back to the deprecated setup adapter when no setup contract exists", () => {
+    resolveReadOnlyChannelPluginsForConfigMock.mockReturnValue({
+      plugins: [
+        {
+          id: "mattermost",
+          setup: { singleAccountKeysToMove: ["botToken", "baseUrl"] },
+        },
+      ],
+    });
+
+    const resolve = createDiscoveredChannelSetupPromotionSurfaceResolver(cfg);
+
+    expect(resolve("mattermost")).toEqual({
+      singleAccountKeysToMove: ["botToken", "baseUrl"],
+    });
+  });
+
+  it("ignores plugins without a setup adapter surface", () => {
+    resolveReadOnlyChannelPluginsForConfigMock.mockReturnValue({
+      plugins: [{ id: "demo" }],
+    });
+
+    const resolve = createDiscoveredChannelSetupPromotionSurfaceResolver(cfg);
+
+    expect(resolve("demo")).toBeNull();
+    expect(resolveBundledChannelSetupPromotionSurfaceMock).toHaveBeenCalledWith("demo");
+  });
+
+  it("keeps an installed plugin surface authoritative when it declares no promotion keys", () => {
+    resolveReadOnlyChannelPluginsForConfigMock.mockReturnValue({
+      plugins: [{ id: "mattermost", setupContract: { resolveAccountId: () => "default" } }],
+    });
+    resolveBundledChannelSetupPromotionSurfaceMock.mockReturnValue({
+      singleAccountKeysToMove: ["bundledKey"],
+    });
+
+    const resolve = createDiscoveredChannelSetupPromotionSurfaceResolver(cfg);
+
+    expect(resolve("mattermost")).toEqual({ resolveAccountId: expect.any(Function) });
+    expect(resolveBundledChannelSetupPromotionSurfaceMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the bundled lookup when read-only discovery has no entry", () => {
+    resolveBundledChannelSetupPromotionSurfaceMock.mockReturnValue({
+      singleAccountKeysToMove: ["bundledKey"],
+    });
+
+    const resolve = createDiscoveredChannelSetupPromotionSurfaceResolver(cfg);
+
+    expect(resolve("signal")).toEqual({ singleAccountKeysToMove: ["bundledKey"] });
+  });
+
+  it("falls back to the bundled lookup when read-only discovery fails", () => {
+    resolveReadOnlyChannelPluginsForConfigMock.mockImplementation(() => {
+      throw new Error("snapshot unavailable");
+    });
+    resolveBundledChannelSetupPromotionSurfaceMock.mockReturnValue(null);
+
+    const resolve = createDiscoveredChannelSetupPromotionSurfaceResolver(cfg);
+
+    expect(resolve("mattermost")).toBeNull();
+    expect(resolveBundledChannelSetupPromotionSurfaceMock).toHaveBeenCalledWith("mattermost");
+  });
+
+  it("resolves read-only plugins lazily and only once", () => {
+    const resolve = createDiscoveredChannelSetupPromotionSurfaceResolver(cfg);
+
+    expect(resolveReadOnlyChannelPluginsForConfigMock).not.toHaveBeenCalled();
+
+    resolve("mattermost");
+    resolve("signal");
+
+    expect(resolveReadOnlyChannelPluginsForConfigMock).toHaveBeenCalledTimes(1);
+    expect(resolveReadOnlyChannelPluginsForConfigMock).toHaveBeenCalledWith(cfg, {
+      includePersistedAuthState: false,
+      includeSetupFallbackPlugins: true,
+    });
+  });
+});

--- a/src/channels/plugins/setup-promotion-discovery.ts
+++ b/src/channels/plugins/setup-promotion-discovery.ts
@@ -1,0 +1,61 @@
+/**
+ * Doctor-only setup promotion surface discovery.
+ *
+ * Doctor processes never load the runtime plugin registry, so promotion
+ * declarations must come from the same read-only manifest/setup-entry
+ * resolution the rest of doctor uses. That path covers external installed
+ * channel plugins; the bundled lookup stays as the fallback for channels
+ * without an installed setup entry.
+ *
+ * Kept separate so hot Plugin SDK setup helpers never import discovery.
+ */
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { resolveReadOnlyChannelPluginsForConfig } from "./read-only.js";
+import { resolveBundledChannelSetupPromotionSurface } from "./setup-promotion-bundled.js";
+import type { ChannelSetupPromotionSurface } from "./setup-promotion-helpers.js";
+
+function asPromotionSurface(value: unknown): ChannelSetupPromotionSurface | null {
+  return value && typeof value === "object" ? (value as ChannelSetupPromotionSurface) : null;
+}
+
+/**
+ * Compose read-only installed-plugin discovery with the bundled fallback into
+ * one lazily-resolved promotion surface resolver for doctor config migration.
+ */
+export function createDiscoveredChannelSetupPromotionSurfaceResolver(
+  cfg: OpenClawConfig,
+  options: { env?: NodeJS.ProcessEnv } = {},
+): (channelKey: string) => ChannelSetupPromotionSurface | null {
+  let surfacesByChannelId: Map<string, ChannelSetupPromotionSurface | null> | undefined;
+  const resolveSurfacesByChannelId = () => {
+    if (surfacesByChannelId) {
+      return surfacesByChannelId;
+    }
+    surfacesByChannelId = new Map();
+    try {
+      const { plugins } = resolveReadOnlyChannelPluginsForConfig(cfg, {
+        ...(options.env ? { env: options.env } : {}),
+        includePersistedAuthState: false,
+        includeSetupFallbackPlugins: true,
+      });
+      for (const plugin of plugins) {
+        // Mirror the channel contract precedence: the owned setup contract is
+        // the preferred surface; the legacy setup adapter is deprecated.
+        surfacesByChannelId.set(
+          plugin.id,
+          asPromotionSurface(plugin.setupContract ?? plugin.setup),
+        );
+      }
+    } catch {
+      // Discovery must never break doctor repair; the bundled fallback still applies.
+    }
+    return surfacesByChannelId;
+  };
+  return (channelKey) =>
+    // An installed plugin's setup surface is authoritative for its channel id:
+    // when it declares no promotion keys, promotion stays deferred rather than
+    // borrowing bundled declarations the installed plugin did not sanction.
+    // The bundled lookup only covers channels with no installed setup entry.
+    resolveSurfacesByChannelId().get(channelKey) ??
+    resolveBundledChannelSetupPromotionSurface(channelKey);
+}

--- a/src/channels/plugins/setup-promotion-helpers.test.ts
+++ b/src/channels/plugins/setup-promotion-helpers.test.ts
@@ -5,7 +5,7 @@ const getLoadedChannelPluginMock = vi.hoisted(() => vi.fn());
 const getBundledChannelPluginMock = vi.hoisted(() => vi.fn());
 const getBundledChannelSetupPluginMock = vi.hoisted(() => vi.fn());
 const hasBundledChannelPackageSetupFeatureMock = vi.hoisted(() => vi.fn());
-const resolveBundledSurfaceMock = vi.hoisted(() => vi.fn());
+const resolveFallbackSurfaceMock = vi.hoisted(() => vi.fn());
 
 vi.mock("./bundled.js", () => ({
   getBundledChannelPlugin: getBundledChannelPluginMock,
@@ -43,7 +43,7 @@ describe("setup promotion helpers", () => {
     getBundledChannelSetupPluginMock.mockReset();
     hasBundledChannelPackageSetupFeatureMock.mockReset();
     getLoadedChannelPluginMock.mockReset();
-    resolveBundledSurfaceMock.mockReset();
+    resolveFallbackSurfaceMock.mockReset();
   });
 
   it("resolves bundled promotion from the setup-only plugin", () => {
@@ -84,7 +84,7 @@ describe("setup promotion helpers", () => {
 
     expect(keys).toEqual(["dmPolicy", "allowFrom", "groupPolicy", "groupAllowFrom"]);
     expect(getLoadedChannelPluginMock).not.toHaveBeenCalled();
-    expect(resolveBundledSurfaceMock).not.toHaveBeenCalled();
+    expect(resolveFallbackSurfaceMock).not.toHaveBeenCalled();
   });
 
   it("retains the published-reader common tier when no declarations resolve", () => {
@@ -161,7 +161,7 @@ describe("setup promotion helpers", () => {
     getLoadedChannelPluginMock.mockReturnValue({
       setup: { singleAccountKeysToMove: ["loadedKey"] },
     });
-    resolveBundledSurfaceMock.mockReturnValue({ singleAccountKeysToMove: ["bundledKey"] });
+    resolveFallbackSurfaceMock.mockReturnValue({ singleAccountKeysToMove: ["bundledKey"] });
 
     const keys = resolveSingleAccountKeysToMove({
       channelKey: "scoped",
@@ -171,12 +171,12 @@ describe("setup promotion helpers", () => {
         bundledKey: true,
       },
       setupSurface: { singleAccountKeysToMove: ["callerKey"] },
-      resolveBundledSurface: resolveBundledSurfaceMock,
+      resolveFallbackSurface: resolveFallbackSurfaceMock,
     });
 
     expect(keys).toEqual(["callerKey"]);
     expect(getLoadedChannelPluginMock).not.toHaveBeenCalled();
-    expect(resolveBundledSurfaceMock).not.toHaveBeenCalled();
+    expect(resolveFallbackSurfaceMock).not.toHaveBeenCalled();
   });
 
   it("prefers loaded channel-owned promotion declarations over legacy setup", () => {
@@ -285,11 +285,11 @@ describe("setup promotion helpers", () => {
 
     expect(keys).toEqual(["dmPolicy", "allowFrom", "groupPolicy", "groupAllowFrom"]);
     expect(getLoadedChannelPluginMock).toHaveBeenCalledWith("demo");
-    expect(resolveBundledSurfaceMock).not.toHaveBeenCalled();
+    expect(resolveFallbackSurfaceMock).not.toHaveBeenCalled();
   });
 
   it("uses an injected bundled surface for non-static migration keys", () => {
-    resolveBundledSurfaceMock.mockReturnValue({ singleAccountKeysToMove: ["customAuth"] });
+    resolveFallbackSurfaceMock.mockReturnValue({ singleAccountKeysToMove: ["customAuth"] });
 
     expect(
       resolveSingleAccountKeysToMove({
@@ -297,10 +297,10 @@ describe("setup promotion helpers", () => {
         channel: {
           customAuth: "secret",
         },
-        resolveBundledSurface: resolveBundledSurfaceMock,
+        resolveFallbackSurface: resolveFallbackSurfaceMock,
       }),
     ).toEqual(["customAuth"]);
-    expect(resolveBundledSurfaceMock).toHaveBeenCalledWith("demo");
+    expect(resolveFallbackSurfaceMock).toHaveBeenCalledWith("demo");
   });
 
   it("honors loaded plugin named-account filters without bundled fallback", () => {
@@ -322,11 +322,11 @@ describe("setup promotion helpers", () => {
     });
 
     expect(keys).toEqual(["token"]);
-    expect(resolveBundledSurfaceMock).not.toHaveBeenCalled();
+    expect(resolveFallbackSurfaceMock).not.toHaveBeenCalled();
   });
 
   it("loads bundled setup for named-account filters before registry bootstrap", () => {
-    resolveBundledSurfaceMock.mockReturnValue({ namedAccountPromotionKeys: ["token"] });
+    resolveFallbackSurfaceMock.mockReturnValue({ namedAccountPromotionKeys: ["token"] });
 
     const keys = resolveSingleAccountKeysToMove({
       channelKey: "demo",
@@ -337,11 +337,11 @@ describe("setup promotion helpers", () => {
         token: "secret",
         dmPolicy: "allowlist",
       },
-      resolveBundledSurface: resolveBundledSurfaceMock,
+      resolveFallbackSurface: resolveFallbackSurfaceMock,
     });
 
     expect(keys).toEqual(["token"]);
     expect(getLoadedChannelPluginMock).toHaveBeenCalledWith("demo");
-    expect(resolveBundledSurfaceMock).toHaveBeenCalledWith("demo");
+    expect(resolveFallbackSurfaceMock).toHaveBeenCalledWith("demo");
   });
 });

--- a/src/channels/plugins/setup-promotion-helpers.ts
+++ b/src/channels/plugins/setup-promotion-helpers.ts
@@ -28,7 +28,8 @@ type SingleAccountPromotionParams = {
   channel: Record<string, unknown>;
   setupSurface?: ChannelSetupPromotionSurface;
   includeSetupKeys?: boolean;
-  resolveBundledSurface?: (channelKey: string) => ChannelSetupPromotionSurface | null;
+  /** Last-ditch surface discovery when the loaded plugin registry has no entry. */
+  resolveFallbackSurface?: (channelKey: string) => ChannelSetupPromotionSurface | null;
 };
 
 // Published undeclared adapters still depend on these keys: Chatu, GroupMe, OneBot,
@@ -89,7 +90,7 @@ export function resolveSingleAccountPromotion(params: SingleAccountPromotionPara
     if (discoveredSetupSurface === undefined) {
       discoveredSetupSurface =
         getLoadedChannelSetupPromotionSurface(params.channelKey) ??
-        params.resolveBundledSurface?.(params.channelKey) ??
+        params.resolveFallbackSurface?.(params.channelKey) ??
         null;
     }
     return discoveredSetupSurface;
@@ -99,6 +100,9 @@ export function resolveSingleAccountPromotion(params: SingleAccountPromotionPara
     : isCommonSingleAccountPromotionKey;
   const isLegacyPromotionKey = (key: string) =>
     isLegacyUndeclaredAdapterPromotionKey(key, params.includeSetupKeys === true);
+  // A surface that declares singleAccountKeysToMove (even as an empty list)
+  // marks the complete account-scoped key set; undeclared root keys under an
+  // explicit declaration are intentional root policy, not a defer trigger.
   const hasUncoveredRootKeys = entries.some(
     (key) => !isGenericPromotionKey(key) && !isLegacyPromotionKey(key),
   );

--- a/src/commands/doctor-legacy-config.migrations.test.ts
+++ b/src/commands/doctor-legacy-config.migrations.test.ts
@@ -78,6 +78,14 @@ vi.mock("./doctor/shared/channel-legacy-config-migrate.js", () => ({
   }),
 }));
 
+const resolveReadOnlyChannelPluginsForConfigMock = vi.hoisted(() =>
+  vi.fn(() => ({ plugins: [] as unknown[] })),
+);
+
+vi.mock("../channels/plugins/read-only.js", () => ({
+  resolveReadOnlyChannelPluginsForConfig: resolveReadOnlyChannelPluginsForConfigMock,
+}));
+
 vi.mock("../secrets/target-registry.js", async () => {
   const { asNullableRecord: readRecord } =
     await import("@openclaw/normalization-core/record-coerce");
@@ -170,6 +178,8 @@ describe("normalizeCompatibilityConfigValues", () => {
 
   beforeEach(() => {
     resetPluginRuntimeStateForTest();
+    resolveReadOnlyChannelPluginsForConfigMock.mockReset();
+    resolveReadOnlyChannelPluginsForConfigMock.mockReturnValue({ plugins: [] });
     fs.rmSync(tempOauthDir, { recursive: true, force: true });
     fs.mkdirSync(tempOauthDir, { recursive: true });
   });
@@ -537,6 +547,62 @@ describe("normalizeCompatibilityConfigValues", () => {
           dmPolicy: "allowlist",
           appToken: "covered-legacy-key",
           customAuth: "keep-at-root",
+          accounts: { work: { enabled: true } },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const res = normalizeCompatibilityConfigValues(config);
+
+    expect(res.config).toEqual(config);
+    expect(res.changes).toStrictEqual([]);
+  });
+
+  it("promotes declared keys for an external installed channel plugin", () => {
+    resolveReadOnlyChannelPluginsForConfigMock.mockReturnValue({
+      plugins: [
+        {
+          id: "mattermost",
+          setupContract: { singleAccountKeysToMove: ["botToken", "baseUrl"] },
+        },
+      ],
+    });
+
+    const res = normalizeCompatibilityConfigValues({
+      channels: {
+        mattermost: {
+          botToken: "root-bot-token",
+          baseUrl: "https://chat.example.com",
+          accounts: { work: { enabled: true } },
+        },
+      },
+    } as unknown as OpenClawConfig);
+
+    const channel = res.config.channels?.mattermost as
+      | { botToken?: string; baseUrl?: string; accounts?: Record<string, unknown> }
+      | undefined;
+    expect(channel?.botToken).toBeUndefined();
+    expect(channel?.baseUrl).toBeUndefined();
+    expect(channel?.accounts?.default).toEqual({
+      botToken: "root-bot-token",
+      baseUrl: "https://chat.example.com",
+    });
+    expect(channel?.accounts?.work).toEqual({ enabled: true });
+    expect(res.changes).toContain(
+      "Moved channels.mattermost single-account top-level values into channels.mattermost.accounts.default.",
+    );
+  });
+
+  it("still defers uncovered keys when the external plugin declares nothing", () => {
+    resolveReadOnlyChannelPluginsForConfigMock.mockReturnValue({
+      plugins: [{ id: "mattermost", setupContract: {} }],
+    });
+
+    const config = {
+      channels: {
+        mattermost: {
+          botToken: "root-bot-token",
+          baseUrl: "https://chat.example.com",
           accounts: { work: { enabled: true } },
         },
       },

--- a/src/commands/doctor/shared/legacy-config-core-normalizers.ts
+++ b/src/commands/doctor/shared/legacy-config-core-normalizers.ts
@@ -5,7 +5,7 @@ import {
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
 import { sanitizeForLog } from "../../../../packages/terminal-core/src/ansi.js";
-import { resolveBundledChannelSetupPromotionSurface } from "../../../channels/plugins/setup-promotion-bundled.js";
+import { createDiscoveredChannelSetupPromotionSurfaceResolver } from "../../../channels/plugins/setup-promotion-discovery.js";
 import { resolveSingleAccountPromotion } from "../../../channels/plugins/setup-promotion-helpers.js";
 import { resolveNormalizedProviderModelMaxTokens } from "../../../config/defaults.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
@@ -133,6 +133,9 @@ export function seedMissingDefaultAccountsFromSingleAccountBase(
 
   let channelsChanged = false;
   const nextChannels = { ...channels };
+  // Resolved lazily: read-only discovery only runs when a channel has root keys
+  // that generic + legacy coverage cannot promote on their own.
+  const resolveFallbackSurface = createDiscoveredChannelSetupPromotionSurfaceResolver(cfg);
   for (const [channelId, rawChannel] of Object.entries(channels)) {
     if (!isRecord(rawChannel)) {
       continue;
@@ -154,7 +157,7 @@ export function seedMissingDefaultAccountsFromSingleAccountBase(
     const promotion = resolveSingleAccountPromotion({
       channelKey: channelId,
       channel: rawChannel,
-      resolveBundledSurface: resolveBundledChannelSetupPromotionSurface,
+      resolveFallbackSurface,
     });
     // Defer only undeclared keys outside generic + legacy coverage. A partial
     // accounts.default would make later runs skip and permanently strand them at root.


### PR DESCRIPTION
## What Problem This Solves

Part 2 of #112238 follow-up. The line and mattermost channel plugins were missed in #112293, which moved hardcoded single-account promotion keys into per-channel plugin declarations. Both plugins have channel-specific config keys that need explicit declaration for single-account promotion but lacked `singleAccountKeysToMove` and `setupFeatures.configPromotion` in their package manifests.

## Why This Change Was Made

- Declares `singleAccountKeysToMove` on the line setup adapter (`channelAccessToken`, `channelSecret`, `tokenFile`, `secretFile`) and the mattermost setup adapter (`botToken`, `baseUrl`). `defineChannelSetupContract` forwards these declarations onto the published `setupContract`, so they stay visible after both channels moved from the legacy `setup` adapter to the owned setup contract.
- Adds `setupFeatures.configPromotion: true` to both `package.json` files so doctor can read the declarations from the lightweight bundled setup artifact.
- These channel-specific keys are not in the common promotion key set, so without explicit declaration they are invisible to the doctor migration path.
- Doctor side (new): `openclaw doctor` processes never load the runtime plugin registry, so declarations from externally installed channel plugins were invisible and single-account promotion deferred forever on packaged installs (Mattermost ships outside the npm `openclaw` package). The doctor promotion path now composes the same read-only installed-plugin discovery the rest of doctor uses, with the bundled lookup as last-ditch fallback. Discovery resolves the promotion surface with the same `setupContract ?? setup` precedence the channel contract, the runtime registry lookup (`setup-promotion-helpers.ts`), and the bundled lookup (`setup-promotion-bundled.ts`) already use — so current plugins that publish only `setupContract` (as line and mattermost do on main) are seen correctly, and legacy `setup`-only plugins keep working. An installed plugin's setup surface is authoritative for its channel id — when it declares no promotion keys, promotion stays deferred (fail-closed) rather than borrowing bundled declarations the installed plugin did not sanction.

Follows the same pattern as the channels migrated in #112293 (slack, signal, irc, imessage, nextcloud-talk, tlon, whatsapp, zalo, telegram, matrix) and the follow-up #112367 (googlechat, zalouser).

## User Impact

Single-account migration for line and mattermost channels now correctly identifies all account-scoped keys for promotion into `accounts.default`. Named-account configs won't risk flattening channel-root policy keys alongside account credentials. No runtime behavior, config shape, or credential handling changes.

## Evidence

PR branch rebased onto current `origin/main` (`d8a1ebbb492`); exact-head proof below was run after the rebase on head `d4652683b7e`.

### Packaged external-install Doctor proof (post-fix, packaged path, npm install semantics)

Built the npm tarball from this head (`scripts/package-openclaw-for-docker.mjs`; note `dist/extensions/mattermost/**` is excluded from the published package, so on real installs Mattermost only exists as an externally installed plugin), installed it into an isolated prefix with an isolated `$OPENCLAW_HOME`, built the Mattermost plugin npm runtime from this branch (`scripts/check-plugin-npm-runtime-builds.mts --package extensions/mattermost`) and installed it via `openclaw plugins install npm-pack:<tarball>` — real npm install semantics, so the plugin's runtime dependencies (`zod`, `ws`) resolve from its own package exactly like a registry install — then ran the packaged `openclaw doctor --fix` against a legacy config with leftover root keys plus an existing named account:

```json5
// $OPENCLAW_HOME/.openclaw/openclaw.json (before)
{
  channels: {
    mattermost: {
      enabled: true,
      botToken: "mm-<redacted>",
      baseUrl: "https://mattermost.example.com",
      dmPolicy: "pairing",
      accounts: {
        work: { botToken: "mm-<redacted>", baseUrl: "https://mattermost-work.example.com" },
      },
    },
  },
  plugins: { entries: { mattermost: { enabled: true } } },
}
```

Verified the installed plugin artifact actually carries the declaration before running doctor:

```
$ grep -rh 'singleAccountKeysToMove' $OPENCLAW_HOME/.openclaw/npm/projects/openclaw-mattermost-*/node_modules/@openclaw/mattermost/dist/*.js
	singleAccountKeysToMove: ["botToken", "baseUrl"],
```

```
$ openclaw doctor --fix
◇  Doctor changes ─────────────────────────────────────────────────╮
│                                                                  │
│  Moved channels.mattermost single-account top-level values into  │
│  channels.mattermost.accounts.default.                           │
│                                                                  │
├──────────────────────────────────────────────────────────────────╯
Updated config: $OPENCLAW_HOME/.openclaw/openclaw.json
```

```json
// $OPENCLAW_HOME/.openclaw/openclaw.json (after — channels.mattermost)
{
  "enabled": true,
  "accounts": {
    "work": { "botToken": "mm-<redacted>", "baseUrl": "https://mattermost-work.example.com" },
    "default": {
      "botToken": "mm-<redacted>",
      "baseUrl": "https://mattermost.example.com",
      "dmPolicy": "pairing"
    }
  }
}
```

Root `botToken`/`baseUrl`/`dmPolicy` moved into `accounts.default`, the existing `accounts.work` is preserved, and `enabled` stays at root. This run exercises the exact packaged path the earlier review flagged — declarations discovered from the externally installed plugin through its published `setupContract`, not from bundled artifacts and not from the legacy `setup` field — and supersedes the older bundled-layout transcript below.

### Real behavior proof (focused test execution on current head)

```
$ node scripts/run-vitest.mjs extensions/line/src/setup-surface.test.ts -t "config-promotion"
 ✓ |extension-line| line setup wizard > exposes config-promotion declarations on the setup adapter 702ms
 Test Files  1 passed (1)
      Tests  1 passed | 13 skipped (14)

$ node scripts/run-vitest.mjs extensions/mattermost/src/setup.test.ts -t "config-promotion"
 ✓ |extension-mattermost| mattermost setup > exposes config-promotion declarations on the setup adapter
 Test Files  1 passed (1)
      Tests  1 passed | 12 skipped (13)
```

### Discovery precedence regression coverage (new)

`src/channels/plugins/setup-promotion-discovery.test.ts` covers the installed-plugin contract surface directly: a plugin publishing only `setupContract` resolves its declared keys; `setupContract` wins when both surfaces exist; the deprecated `setup` adapter still resolves when no contract exists; an installed surface with no declarations stays authoritative (fail-closed deferral); bundled fallback still covers channels with no installed setup entry. `src/commands/doctor-legacy-config.migrations.test.ts` exercises the full normalizer path with an externally installed plugin whose declaration arrives via `setupContract` (promote) and with an empty contract (defer).

### Doctor migration proof (actual resolver with real setup adapters)

The PR's declarations are consumed by the real doctor single-account promotion resolver (`src/channels/plugins/setup-promotion-helpers.ts`). Running the resolver with representative legacy channel configs and the actual bundled setup adapters:

```
$ npx tsx proof-line-mattermost-promotion.ts

Line legacy root keys:
[
  "channelAccessToken",
  "channelSecret",
  "tokenFile",
  "secretFile",
  "enabled"
]

Line keys promoted to default account:
[
  "channelAccessToken",
  "channelSecret",
  "tokenFile",
  "secretFile"
]

Line shouldDeferPromotion:
false

Mattermost legacy root keys:
[
  "botToken",
  "baseUrl",
  "enabled"
]

Mattermost keys promoted to default account:
[
  "botToken",
  "baseUrl"
]

Mattermost shouldDeferPromotion:
false

---
Line promotion correct: true
Mattermost promotion correct: true
```

- Line: all 4 declared account-scoped keys are promoted to `accounts.default`; channel-root policy keys like `enabled` remain at root; migration is not deferred.
- Mattermost: both declared account-scoped keys are promoted to `accounts.default`; channel-root policy stays at root; migration is not deferred.

### End-to-end Doctor migration proof (`openclaw doctor --fix`)

Installed Node 24.18.0 and ran the packaged Doctor migration against a representative legacy config with named accounts plus leftover single-account root keys:

```json
// $OPENCLAW_HOME/.openclaw/openclaw.json (before)
{
  "agents": { "entries": { "main": { "default": true } } },
  "memory": { "search": { "enabled": false, "rememberAcrossConversations": false } },
  "channels": {
    "line": {
      "enabled": true,
      "channelAccessToken": "line-token",
      "channelSecret": "line-secret",
      "tokenFile": "/path/to/token",
      "secretFile": "/path/to/secret",
      "accounts": { "alerts": { "enabled": true } }
    },
    "mattermost": {
      "enabled": true,
      "botToken": "mm-token",
      "baseUrl": "https://mattermost.example.com",
      "accounts": { "alerts": { "enabled": true } }
    }
  }
}
```

```
$ openclaw doctor --fix --yes --non-interactive
...
◇  Doctor changes ──────────────────────────────────────────────────────╮
│                                                                       │
│  Moved channels.line single-account top-level values into             │
│  channels.line.accounts.default.                                      │
│  Moved channels.mattermost single-account top-level values into       │
│  channels.mattermost.accounts.default.                                │
│                                                                       │
├───────────────────────────────────────────────────────────────────────╯
...
└  Doctor complete.
```

```json
// $OPENCLAW_HOME/.openclaw/openclaw.json (after — channels only)
{
  "channels": {
    "line": {
      "enabled": true,
      "accounts": {
        "alerts": { "enabled": true },
        "default": {
          "channelAccessToken": "line-token",
          "channelSecret": "line-secret",
          "tokenFile": "/path/to/token",
          "secretFile": "/path/to/secret"
        }
      }
    },
    "mattermost": {
      "enabled": true,
      "accounts": {
        "alerts": { "enabled": true },
        "default": {
          "botToken": "mm-token",
          "baseUrl": "https://mattermost.example.com"
        }
      }
    }
  }
}
```

This confirms the full packaged Doctor path: artifact discovery, resolver key selection, and persisted config write all preserve channel-root policy while moving only the declared account-scoped keys into `accounts.default`.

### Declaration verification

```json
// lineSetupAdapter.singleAccountKeysToMove:
["channelAccessToken", "channelSecret", "tokenFile", "secretFile"]

// mattermostSetupAdapter.singleAccountKeysToMove:
["botToken", "baseUrl"]

// line package.json setupFeatures: { "configPromotion": true }
// mattermost package.json setupFeatures: { "configPromotion": true }
```

The doctor migration resolver reads `singleAccountKeysToMove` from each channel's setup artifact surface during `openclaw doctor --fix`. Line declares 4 account-scoped keys; Mattermost declares 2. Both manifests enable `configPromotion` so the doctor migration can discover these declarations through the lightweight bundled setup artifact. `defineChannelSetupContract` forwards the adapter declarations onto `lineSetupContract` / `mattermostSetupContract`, which is the only setup surface these plugins publish on current main.

- `extensions/mattermost/src/setup.test.ts` — declaration test passes (1 new, 14 passed).
- `extensions/line/src/setup-surface.test.ts` — declaration test passes (1 new, 13 passed; 1 pre-existing wizard timeout failure unchanged).
- `oxfmt --check` passed for all 4 changed source files.

## Scope

- No config/schema/default changes.
- No runtime behavior, credential, or setup flow changes.
- No changelog change.
- line and mattermost only — other channels were already covered by #112293 and #112367.
- Doctor-side addition: promotion-surface discovery for installed channel plugins (doctor repair path only; hot Plugin SDK setup helpers untouched), resolving `setupContract ?? setup` with the same precedence as the existing runtime and bundled lookups, plus focused unit/migration tests.
- Test-only: pinned `OPENCLAW_LOCALE=en` in the line/mattermost setup surface tests so wizard-copy assertions do not depend on the developer machine's locale.
