### PR TITLE
fix(infra): preserve large inode identity in session migrations

### DIFF
--- a/src/infra/file-identity.test.ts
+++ b/src/infra/file-identity.test.ts
@@ -66,6 +66,26 @@ describe("sameFileIdentity", () => {
       platform: "win32" as const,
       expected: true,
     },
+    {
+      // 72057594037932382n and 72057594037932383n both round to 72057594037932380
+      // when represented as a JS Number (> 2^53), so fs.statSync() without
+      // {bigint: true} incorrectly treats them as the same inode.  The fix in
+      // resolveSessionStorePathRelationship passes {bigint: true} so the full
+      // precision is preserved.  This test documents the correct behavior that
+      // the fix enables (#112341 — virtiofs/Kata inode precision).
+      name: "rejects adjacent inodes above 2^53 when both stats use BigInt (virtiofs/Kata, issue #112341)",
+      left: stat(2n, 72057594037932382n),
+      right: stat(2n, 72057594037932383n),
+      platform: "linux" as const,
+      expected: false,
+    },
+    {
+      name: "accepts same inode above 2^53 when both stats use BigInt",
+      left: stat(2n, 72057594037932382n),
+      right: stat(2n, 72057594037932382n),
+      platform: "linux" as const,
+      expected: true,
+    },
   ])("$name", ({ left, right, platform, expected }) => {
     expect(sameFileIdentity(left, right, platform)).toBe(expected);
   });

--- a/src/infra/file-identity.test.ts
+++ b/src/infra/file-identity.test.ts
@@ -66,26 +66,6 @@ describe("sameFileIdentity", () => {
       platform: "win32" as const,
       expected: true,
     },
-    {
-      // 72057594037932382n and 72057594037932383n both round to 72057594037932380
-      // when represented as a JS Number (> 2^53), so fs.statSync() without
-      // {bigint: true} incorrectly treats them as the same inode.  The fix in
-      // resolveSessionStorePathRelationship passes {bigint: true} so the full
-      // precision is preserved.  This test documents the correct behavior that
-      // the fix enables (#112341 — virtiofs/Kata inode precision).
-      name: "rejects adjacent inodes above 2^53 when both stats use BigInt (virtiofs/Kata, issue #112341)",
-      left: stat(2n, 72057594037932382n),
-      right: stat(2n, 72057594037932383n),
-      platform: "linux" as const,
-      expected: false,
-    },
-    {
-      name: "accepts same inode above 2^53 when both stats use BigInt",
-      left: stat(2n, 72057594037932382n),
-      right: stat(2n, 72057594037932382n),
-      platform: "linux" as const,
-      expected: true,
-    },
   ])("$name", ({ left, right, platform, expected }) => {
     expect(sameFileIdentity(left, right, platform)).toBe(expected);
   });

--- a/src/infra/state-migrations.orphan-keys.test.ts
+++ b/src/infra/state-migrations.orphan-keys.test.ts
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { withTempDir } from "../test-helpers/temp-dir.js";
 import { migrateOrphanedSessionKeys } from "./state-migrations.js";
+import { resolveSessionStoreOwnership } from "./state-migrations.session-store.js";
 
 const listPluginDoctorSessionStoreAgentIdsMock = vi.hoisted(() => vi.fn((): string[] => []));
 
@@ -170,6 +171,74 @@ describe("migrateOrphanedSessionKeys", () => {
       expect(store["voice:15550001111"]).toBeUndefined();
       expect(result.changes).toHaveLength(1);
       expect(result.warnings).toHaveLength(0);
+    });
+  });
+
+  it("distinguishes large adjacent inodes before planning store aliases", async () => {
+    await withStateFixture(async ({ tmpDir, stateDir }) => {
+      const configuredStorePath = path.join(tmpDir, "configured-sessions.json");
+      const targetStorePath = path.join(stateDir, "agents", "voice", "sessions", "sessions.json");
+      writeStore(configuredStorePath, {});
+      writeStore(targetStorePath, {});
+      const cfg = {
+        session: { store: configuredStorePath },
+        agents: { list: [{ id: "ops", default: true }] },
+      } as OpenClawConfig;
+      const realStatSync = fs.statSync.bind(fs);
+      const largeInodes = new Map([
+        [configuredStorePath, 72057594037932382n],
+        [targetStorePath, 72057594037932383n],
+      ]);
+      const statSpy = vi.spyOn(fs, "statSync").mockImplementation(((
+        candidate: Parameters<typeof fs.statSync>[0],
+        options?: { bigint?: boolean },
+      ) => {
+        const resolvedPath = path.resolve(candidate.toString());
+        const inode = largeInodes.get(resolvedPath);
+        const useBigInt = options?.bigint === true;
+        const stat = useBigInt
+          ? realStatSync(candidate, { bigint: true })
+          : realStatSync(candidate);
+        if (inode === undefined) {
+          return stat;
+        }
+        return new Proxy(stat, {
+          get(target, property, receiver) {
+            if (property === "dev") {
+              return useBigInt ? 2n : 2;
+            }
+            if (property === "ino") {
+              return useBigInt ? inode : Number(inode);
+            }
+            return Reflect.get(target, property, receiver);
+          },
+        });
+      }) as typeof fs.statSync);
+
+      let ownership: ReturnType<typeof resolveSessionStoreOwnership>;
+      try {
+        ownership = resolveSessionStoreOwnership({
+          cfg,
+          env: { OPENCLAW_STATE_DIR: stateDir },
+          stateDir,
+          targetAgentId: "voice",
+          pluginSessionStoreAgentIds: ["voice"],
+        });
+        expect(statSpy).toHaveBeenCalledWith(configuredStorePath, { bigint: true });
+        expect(statSpy).toHaveBeenCalledWith(targetStorePath, { bigint: true });
+      } finally {
+        statSpy.mockRestore();
+      }
+
+      expect(ownership).toEqual({
+        preserveAmbiguousKeys: false,
+        preserveForeignMainAliases: false,
+        targetStoreAliases: {
+          hasDistinctAliases: false,
+          hasFinalSymlink: false,
+          hasUnresolvedIdentity: false,
+        },
+      });
     });
   });
 

--- a/src/infra/state-migrations.session-store.ts
+++ b/src/infra/state-migrations.session-store.ts
@@ -1214,7 +1214,12 @@ function resolveSessionStorePathRelationship(
     return "same";
   }
   try {
-    return sameFileIdentity(fs.statSync(left), fs.statSync(right)) ? "same" : "different";
+    return sameFileIdentity(
+      fs.statSync(left, { bigint: true }),
+      fs.statSync(right, { bigint: true }),
+    )
+      ? "same"
+      : "different";
   } catch (err) {
     const code = (err as NodeJS.ErrnoException).code;
     if (code !== "ENOENT" && code !== "ENOTDIR") {


### PR DESCRIPTION
Closes #112341

## What Problem This Solves

Fixes gateway startup failure on virtiofs/Kata and other filesystems whose inode values exceed JavaScript's safe-integer range. Distinct session-store paths could be reported as one filesystem object, causing the session-to-SQLite migration to emit a false `aliased store` deferral and refuse gateway readiness.

The issue's direct reproduction observed adjacent inodes `72057594037932382` and `72057594037932383` collapse to the same Number value, while `fs.statSync(path, { bigint: true })` preserved them as distinct.

## Why This Change Was Made

`resolveSessionStorePathRelationship` now reads filesystem identity with `fs.statSync(..., { bigint: true })` before calling the existing `sameFileIdentity` helper. The helper already accepts BigInt values; precision had been lost before the comparison.

The regression is placed at the session-store ownership boundary rather than the lower-level comparator. It simulates two distinct adjacent large inodes, verifies both identity probes request `{ bigint: true }`, and proves the ownership/alias plan remains unambiguous.

## User Impact

OpenClaw can complete startup migrations on large-inode filesystems instead of reporting a nonexistent alias and refusing to start. Real hard links, symlinks, inaccessible paths, and actual shared-store aliases retain their existing fail-closed behavior.

## Evidence

Reporter reproduction from #112341:

```text
Number same-ino? true
BigInt same-ino? false
```

Focused proof after the final rebase:

```text
Blacksmith Testbox: tbx_01ky8204nca58qtyyyc8n539bg
Test Files  2 passed (2)
Tests       45 passed (45)
```

https://github.com/openclaw/openclaw/actions/runs/30031627514

Additional proof:

- Earlier Testbox `tbx_01ky81tscxr8cq9rpa7nkp5krt` passed the same 45 tests after coverage was moved to the production ownership seam.
- Fresh Codex autoreview against `origin/main`: clean, no accepted/actionable findings.
- Node 24.18.0 confirms `fs.statSync(path, { bigint: true }).ino` is a BigInt.
- Exact-head CI: https://github.com/openclaw/openclaw/actions/runs/30031878836

AI-assisted: contributor fix repaired and verified by maintainers.
