### PR TITLE
feat(agents): emit sanitized authType on successful model calls

### DIFF
--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -1619,6 +1619,10 @@ async function compactEmbeddedAgentSessionDirectOnce(
               api: effectiveModel.api,
               transport: session.agent.transport,
               contextTokenBudget,
+              ...(apiKeyInfo?.mode ? { selectedAuthMode: apiKeyInfo.mode } : {}),
+              ...(resolvedRuntimeAuthPlan?.selectedAuthMode && !apiKeyInfo?.mode
+                ? { selectedAuthMode: resolvedRuntimeAuthPlan.selectedAuthMode }
+                : {}),
               trace: compactionModelCallTrace,
               contentCapture: resolveDiagnosticModelContentCapturePolicy(params.config),
               nextCallId: () =>

--- a/src/agents/embedded-agent-runner/run/attempt-stream.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream.ts
@@ -317,6 +317,9 @@ export function installEmbeddedAttemptStreamGuards(input: {
     };
   }
   let diagnosticModelCallSeq = 0;
+  // Only the actual selected credential mode from the resolved runtime plan.
+  // Never invent auth from defaults, oauth meters, or configured primary alone.
+  const selectedAuthMode = attempt.runtimePlan?.auth?.selectedAuthMode;
   session.agent.streamFn = wrapStreamFnWithDiagnosticModelCallEvents(session.agent.streamFn, {
     runId: attempt.runId,
     ...(attempt.sessionKey && { sessionKey: attempt.sessionKey }),
@@ -334,6 +337,7 @@ export function installEmbeddedAttemptStreamGuards(input: {
     ...(attempt.contextWindowInfo?.referenceTokens
       ? { contextWindowReferenceTokens: attempt.contextWindowInfo.referenceTokens }
       : {}),
+    ...(selectedAuthMode ? { selectedAuthMode } : {}),
     trace: input.runTrace,
     contentCapture: resolveDiagnosticModelContentCapturePolicy(attempt.config),
     nextCallId: () => `${attempt.runId}:model:${(diagnosticModelCallSeq += 1)}`,

--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.test.ts
@@ -25,7 +25,10 @@ import {
 } from "../../../plugins/hook-runner-global.js";
 import { createHookRunnerWithRegistry } from "../../../plugins/hooks.test-fixtures.js";
 import { withEnvAsync } from "../../../test-utils/env.js";
-import { wrapStreamFnWithDiagnosticModelCallEvents } from "./attempt.model-diagnostic-events.js";
+import {
+  sanitizeSuccessfulAttemptAuthType,
+  wrapStreamFnWithDiagnosticModelCallEvents,
+} from "./attempt.model-diagnostic-events.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
@@ -136,6 +139,28 @@ async function collectProviderTimelineEvents(run: () => Promise<void>) {
     .map((line) => requireRecord(JSON.parse(line), "provider timeline event"))
     .filter((event) => event.type === "provider.request");
 }
+
+describe("sanitizeSuccessfulAttemptAuthType", () => {
+  it("maps selected credential modes to sanitized oauth|api only", () => {
+    expect(sanitizeSuccessfulAttemptAuthType("oauth")).toBe("oauth");
+    expect(sanitizeSuccessfulAttemptAuthType("OAuth")).toBe("oauth");
+    expect(sanitizeSuccessfulAttemptAuthType("api")).toBe("api");
+    expect(sanitizeSuccessfulAttemptAuthType("api-key")).toBe("api");
+    expect(sanitizeSuccessfulAttemptAuthType("api_key")).toBe("api");
+    expect(sanitizeSuccessfulAttemptAuthType("token")).toBe("api");
+    expect(sanitizeSuccessfulAttemptAuthType(" TOKEN ")).toBe("api");
+  });
+
+  it("omits unknown, empty, and non-string modes instead of inventing auth", () => {
+    expect(sanitizeSuccessfulAttemptAuthType(undefined)).toBeUndefined();
+    expect(sanitizeSuccessfulAttemptAuthType(null)).toBeUndefined();
+    expect(sanitizeSuccessfulAttemptAuthType("")).toBeUndefined();
+    expect(sanitizeSuccessfulAttemptAuthType("   ")).toBeUndefined();
+    expect(sanitizeSuccessfulAttemptAuthType("aws-sdk")).toBeUndefined();
+    expect(sanitizeSuccessfulAttemptAuthType("bearer")).toBeUndefined();
+    expect(sanitizeSuccessfulAttemptAuthType("usage-meter")).toBeUndefined();
+  });
+});
 
 describe("wrapStreamFnWithDiagnosticModelCallEvents", () => {
   beforeEach(() => {
@@ -1217,6 +1242,215 @@ describe("wrapStreamFnWithDiagnosticModelCallEvents", () => {
     expect(Object.isFrozen(startedCtx)).toBe(true);
     expect(Object.isFrozen(startedCtx.trace)).toBe(true);
     expect(JSON.stringify([started.mock.calls, ended.mock.calls])).not.toContain(secretChunk);
+  });
+
+  it("emits sanitized authType only on successful model_call_ended hooks", async () => {
+    const ended = vi.fn();
+    const { registry } = createHookRunnerWithRegistry([
+      { hookName: "model_call_ended", handler: ended },
+    ]);
+    initializeGlobalHookRunner(registry);
+
+    async function* stream() {
+      yield { type: "text", text: "ok" };
+    }
+    const wrapped = wrapStreamFnWithDiagnosticModelCallEvents(
+      (() => stream()) as unknown as StreamFn,
+      {
+        runId: "run-auth-success",
+        provider: "openai",
+        model: "gpt-5.4",
+        selectedAuthMode: "api_key",
+        trace: createDiagnosticTraceContext(),
+        nextCallId: () => "call-auth-success",
+      },
+    );
+
+    await collectModelCallEvents(async () => {
+      await drain(wrapped({} as never, {} as never, {} as never) as AsyncIterable<unknown>);
+    });
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+
+    const endedEvent = requireMockRecordArg(ended, 0, 0, "ended hook event");
+    expect(endedEvent.outcome).toBe("completed");
+    expect(endedEvent.authType).toBe("api");
+    expect(endedEvent).not.toHaveProperty("selectedAuthMode");
+    expect(JSON.stringify(endedEvent)).not.toMatch(/api[_-]key|token|profile/i);
+  });
+
+  it("omits authType on failed model_call_ended so consumers can preserve last success", async () => {
+    const ended = vi.fn();
+    const { registry } = createHookRunnerWithRegistry([
+      { hookName: "model_call_ended", handler: ended },
+    ]);
+    initializeGlobalHookRunner(registry);
+
+    const wrapped = wrapStreamFnWithDiagnosticModelCallEvents(
+      (() => {
+        throw new Error("provider failed");
+      }) as unknown as StreamFn,
+      {
+        runId: "run-auth-fail",
+        provider: "openai",
+        model: "gpt-5.4",
+        selectedAuthMode: "oauth",
+        trace: createDiagnosticTraceContext(),
+        nextCallId: () => "call-auth-fail",
+      },
+    );
+
+    await collectModelCallEvents(async () => {
+      expect(() => wrapped({} as never, {} as never, {} as never)).toThrow("provider failed");
+    });
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+
+    const endedEvent = requireMockRecordArg(ended, 0, 0, "ended hook event");
+    expect(endedEvent.outcome).toBe("error");
+    expect(endedEvent).not.toHaveProperty("authType");
+  });
+
+  it("emits only the fallback-winning successful authType across ordered attempts", async () => {
+    const ended = vi.fn();
+    const { registry } = createHookRunnerWithRegistry([
+      { hookName: "model_call_ended", handler: ended },
+    ]);
+    initializeGlobalHookRunner(registry);
+
+    let callSeq = 0;
+    const nextCallId = () => `call-fallback-${(callSeq += 1)}`;
+
+    // First attempt fails on oauth; second succeeds on api-key fallback.
+    const failing = wrapStreamFnWithDiagnosticModelCallEvents(
+      (() => {
+        throw new Error("oauth exhausted");
+      }) as unknown as StreamFn,
+      {
+        runId: "run-fallback",
+        provider: "openai",
+        model: "gpt-5.4",
+        selectedAuthMode: "oauth",
+        trace: createDiagnosticTraceContext(),
+        nextCallId,
+      },
+    );
+    async function* successStream() {
+      yield { type: "text", text: "fallback-ok" };
+    }
+    const succeeding = wrapStreamFnWithDiagnosticModelCallEvents(
+      (() => successStream()) as unknown as StreamFn,
+      {
+        runId: "run-fallback",
+        provider: "openai",
+        model: "gpt-5.4",
+        selectedAuthMode: "api-key",
+        trace: createDiagnosticTraceContext(),
+        nextCallId,
+      },
+    );
+
+    await collectModelCallEvents(async () => {
+      expect(() => failing({} as never, {} as never, {} as never)).toThrow("oauth exhausted");
+      await drain(succeeding({} as never, {} as never, {} as never) as AsyncIterable<unknown>);
+    });
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+
+    expect(ended).toHaveBeenCalledTimes(2);
+    const failedEvent = requireMockRecordArg(ended, 0, 0, "failed ended hook");
+    const successEvent = requireMockRecordArg(ended, 1, 0, "success ended hook");
+    expect(failedEvent.outcome).toBe("error");
+    expect(failedEvent).not.toHaveProperty("authType");
+    expect(successEvent.outcome).toBe("completed");
+    expect(successEvent.authType).toBe("api");
+
+    // Consumer preserve-last-success: only completed events with authType update the cache.
+    let lastSuccessfulAuthType: "oauth" | "api" | undefined;
+    for (const call of ended.mock.calls) {
+      const event = requireRecord(call[0], "ended hook event");
+      if (
+        event.outcome === "completed" &&
+        (event.authType === "oauth" || event.authType === "api")
+      ) {
+        lastSuccessfulAuthType = event.authType;
+      }
+    }
+    expect(lastSuccessfulAuthType).toBe("api");
+  });
+
+  it("preserves prior successful authType when a later attempt fails", async () => {
+    const ended = vi.fn();
+    const { registry } = createHookRunnerWithRegistry([
+      { hookName: "model_call_ended", handler: ended },
+    ]);
+    initializeGlobalHookRunner(registry);
+
+    let callSeq = 0;
+    const nextCallId = () => `call-preserve-${(callSeq += 1)}`;
+
+    async function* successStream() {
+      yield { type: "text", text: "first-ok" };
+    }
+    const succeeding = wrapStreamFnWithDiagnosticModelCallEvents(
+      (() => successStream()) as unknown as StreamFn,
+      {
+        runId: "run-preserve",
+        provider: "xai",
+        model: "grok-4",
+        selectedAuthMode: "oauth",
+        trace: createDiagnosticTraceContext(),
+        nextCallId,
+      },
+    );
+    const failing = wrapStreamFnWithDiagnosticModelCallEvents(
+      (() => {
+        throw new Error("later failure");
+      }) as unknown as StreamFn,
+      {
+        runId: "run-preserve",
+        provider: "xai",
+        model: "grok-4",
+        selectedAuthMode: "api-key",
+        trace: createDiagnosticTraceContext(),
+        nextCallId,
+      },
+    );
+
+    await collectModelCallEvents(async () => {
+      await drain(succeeding({} as never, {} as never, {} as never) as AsyncIterable<unknown>);
+      expect(() => failing({} as never, {} as never, {} as never)).toThrow("later failure");
+    });
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+
+    expect(ended).toHaveBeenCalledTimes(2);
+    const successEvent = requireMockRecordArg(ended, 0, 0, "success ended hook");
+    const failedEvent = requireMockRecordArg(ended, 1, 0, "failed ended hook");
+    expect(successEvent.outcome).toBe("completed");
+    expect(successEvent.authType).toBe("oauth");
+    expect(failedEvent.outcome).toBe("error");
+    expect(failedEvent).not.toHaveProperty("authType");
+
+    let lastSuccessfulAuthType: "oauth" | "api" | undefined = "api"; // stale prior value
+    for (const call of ended.mock.calls) {
+      const event = requireRecord(call[0], "ended hook event");
+      if (
+        event.outcome === "completed" &&
+        (event.authType === "oauth" || event.authType === "api")
+      ) {
+        lastSuccessfulAuthType = event.authType;
+      }
+      // Failures must not clear or overwrite last success.
+      if (event.outcome === "error") {
+        expect(event.authType).toBeUndefined();
+      }
+    }
+    expect(lastSuccessfulAuthType).toBe("oauth");
   });
 
   it("emits completed events when stream consumption stops early", async () => {

--- a/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.ts
@@ -50,6 +50,11 @@ type ModelCallDiagnosticContext = {
   contextTokenBudget?: number;
   contextWindowSource?: PluginHookContextWindowSource;
   contextWindowReferenceTokens?: number;
+  /**
+   * Selected credential class for this attempt (`oauth` | `api-key` | `token` | ...).
+   * Only sanitized successful-call values are emitted on model_call_ended.
+   */
+  selectedAuthMode?: string | null;
   trace: DiagnosticTraceContext;
   contentCapture?: DiagnosticModelContentCapturePolicy;
   nextCallId: () => string;
@@ -74,7 +79,33 @@ type ModelCallEndedHookFields = Pick<
   | "timeToFirstByteMs"
   | "failureKind"
   | "upstreamRequestIdHash"
+  | "authType"
 >;
+
+/**
+ * Sanitize selected credential class for successful model_call_ended events.
+ * Emits only `oauth` | `api`. Never invents auth from usage meters or defaults.
+ */
+export function sanitizeSuccessfulAttemptAuthType(
+  selectedAuthMode: string | null | undefined,
+): PluginHookModelCallEndedEvent["authType"] | undefined {
+  if (typeof selectedAuthMode !== "string") {
+    return undefined;
+  }
+  const normalized = selectedAuthMode.trim().toLowerCase().replaceAll("_", "-");
+  if (!normalized) {
+    return undefined;
+  }
+  if (normalized === "oauth") {
+    return "oauth";
+  }
+  // api-key and token both surface as API credential class on Agent Cards.
+  if (normalized === "api" || normalized === "api-key" || normalized === "token") {
+    return "api";
+  }
+  return undefined;
+}
+
 type ModelCallSizeTimingFields = Pick<
   Extract<DiagnosticEventInput, { type: "model.call.completed" }>,
   "requestPayloadBytes" | "responseStreamBytes" | "timeToFirstByteMs"
@@ -95,6 +126,8 @@ type ModelCallObservationState = {
   contentCapture?: DiagnosticModelContentCapturePolicy;
   lastStreamProgressAt?: number;
   terminalEventEmitted?: boolean;
+  /** Sanitized successful-attempt auth class only; never set on failed attempts. */
+  successfulAuthType?: PluginHookModelCallEndedEvent["authType"];
 };
 
 const MODEL_CALL_STREAM_PROGRESS_INTERVAL_MS = 30_000;
@@ -588,6 +621,7 @@ function emitModelCallCompleted(
     durationMs,
     outcome: "completed",
     ...sizeTimingFields,
+    ...(state.successfulAuthType ? { authType: state.successfulAuthType } : {}),
   });
 }
 
@@ -866,10 +900,12 @@ export function wrapStreamFnWithDiagnosticModelCallEvents(
     emitModelCallStarted(eventBase, modelContent);
     ctx.onStarted?.();
     const startedAt = Date.now();
+    const successfulAuthType = sanitizeSuccessfulAttemptAuthType(ctx.selectedAuthMode);
     const state: ModelCallObservationState = {
       responseStreamBytes: 0,
       modelContent,
       contentCapture: ctx.contentCapture,
+      ...(successfulAuthType ? { successfulAuthType } : {}),
     };
     // Provider wrappers consume this same call id for transport correlation,
     // keeping external request evidence joined to the emitted diagnostics.

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -339,6 +339,13 @@ export type PluginHookModelCallEndedEvent = PluginHookModelCallBaseEvent & {
   responseStreamBytes?: number;
   timeToFirstByteMs?: number;
   upstreamRequestIdHash?: string;
+  /**
+   * Sanitized credential class actually used for a successful model call.
+   * Derived only from the selected credential after success (`oauth` | `api`).
+   * Never includes profile IDs, secrets, defaults, or usage-derived guesses.
+   * Omitted on failed attempts so consumers can preserve last-successful evidence.
+   */
+  authType?: "oauth" | "api";
 };
 
 export type PluginHookLlmOutputEvent = {


### PR DESCRIPTION
## Summary
- carry the resolved credential mode through model-call diagnostics
- emit only sanitized `oauth` or `api` auth types on successful `model_call_ended` hooks
- omit failed attempt auth types so consumers retain the last successful route

## Validation
- `pnpm exec vitest run src/agents/embedded-agent-runner/run/attempt.model-diagnostic-events.test.ts` — 2 files, 54 tests passed
- `git diff --check origin/main...HEAD`