### PR TITLE
feat(dashboard): workboard:mini aggregates all boards when boardId is unset

### DIFF
--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -7772,6 +7772,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: CLI and slash command
   - H2: Session lifecycle sync
   - H2: Dashboard workflow
+  - H3: Session-board widgets
   - H2: Diagnostics
   - H2: Permissions
   - H2: Storage

--- a/docs/plugins/workboard.md
+++ b/docs/plugins/workboard.md
@@ -349,6 +349,20 @@ the template id is stored as card metadata.
 6. Let lifecycle sync move running work into `review`/`blocked`, then manually
    move the card to `done` when accepted.
 
+### Session-board widgets
+
+Workboard ships two native widgets for session dashboards (see
+[Dashboards](/web/dashboards)). The agent pins them with its `dashboard` tool
+using `content: { kind: "plugin", pluginKind, props }`, and they render as
+first-party UI with live data — no sandbox frame or capability grant:
+
+- `workboard:card` with `props: { cardId }` shows one card with its status
+  control, priority, and assigned agent.
+- `workboard:mini` with optional `props: { boardId, limit }` shows per-status
+  counts plus the top ready/running cards, and links to the full board page.
+  Without `boardId` it aggregates every board; with `boardId` it scopes to that
+  board (cards created without an explicit board id live on `default`).
+
 ## Diagnostics
 
 Diagnostics are computed from local card metadata. Built-in checks flag:

--- a/ui/src/lib/board/widgets/workboard-mini.ts
+++ b/ui/src/lib/board/widgets/workboard-mini.ts
@@ -23,9 +23,11 @@ class OpenClawWorkboardMiniWidget extends WorkboardWidgetElement {
         </button>
       </div>`;
     }
-    const boardId = this.readStringProp("boardId") ?? "default";
+    // No boardId prop means every board: silently scoping to "default" hides
+    // cards created with an explicit board id and renders an all-zero widget.
+    const boardId = this.readStringProp("boardId");
     const limit = Math.min(10, this.readPositiveIntegerProp("limit", 5));
-    const cards = this.cards.filter((card) => cardBoardId(card) === boardId);
+    const cards = boardId ? this.cards.filter((card) => cardBoardId(card) === boardId) : this.cards;
     const topCards = cards
       .filter((card) => card.status === "ready" || card.status === "running")
       .toSorted(
@@ -35,11 +37,14 @@ class OpenClawWorkboardMiniWidget extends WorkboardWidgetElement {
           left.title.localeCompare(right.title),
       )
       .slice(0, limit);
-    const workboardPath = `${pathForRoute("workboard", this.context?.basePath ?? "")}?board=${encodeURIComponent(boardId)}`;
+    const workboardBase = pathForRoute("workboard", this.context?.basePath ?? "");
+    const workboardPath = boardId
+      ? `${workboardBase}?board=${encodeURIComponent(boardId)}`
+      : workboardBase;
     return html`
       <section class="workboard-widget-mini" data-test-id="workboard-mini-widget">
         <header>
-          <strong>${boardId}</strong>
+          <strong>${boardId ?? t("workboard.allBoards")}</strong>
           <a href=${workboardPath}>${t("workboard.widget.openBoard")}</a>
         </header>
         <div class="workboard-widget-mini__counts" aria-label=${t("workboard.widget.statusCounts")}>

--- a/ui/src/lib/board/widgets/workboard.test.ts
+++ b/ui/src/lib/board/widgets/workboard.test.ts
@@ -164,6 +164,38 @@ describe("Workboard plugin widgets", () => {
     expect(element.querySelector("a")?.getAttribute("href")).toBe("/control/workboard?board=ops");
   });
 
+  it("aggregates every board when no boardId prop is set", async () => {
+    const mixedCards = [
+      ...cards,
+      {
+        id: "card-unscoped",
+        title: "Unscoped card",
+        status: "running",
+        priority: "normal",
+        labels: [],
+        position: 3,
+        createdAt: 1,
+        updatedAt: 1,
+      },
+    ];
+    const request = vi.fn(async () => ({
+      cards: mixedCards,
+      statuses: ["ready", "running", "done"],
+    }));
+    const element = document.createElement("openclaw-workboard-mini-widget");
+    element.widget = pluginWidget("workboard:mini", {});
+    element.sessionKey = "agent:main:test";
+    await mount(element, createContext(request), request);
+
+    const counts = [...element.querySelectorAll(".workboard-widget-mini__counts span")].map(
+      (entry) => entry.textContent?.replace(/\s+/g, " ").trim(),
+    );
+    expect(counts).toContain("2 Running");
+    expect(element.querySelector("header strong")?.textContent).toBe("All boards");
+    expect(element.textContent).toContain("Unscoped card");
+    expect(element.querySelector("a")?.getAttribute("href")).toBe("/control/workboard");
+  });
+
   it("retries a transient initial list failure without reconnecting", async () => {
     const request = vi
       .fn()


### PR DESCRIPTION
## What Problem This Solves

Follow-up from #112434 live proof: `workboard:mini` hardcoded its default board scope to `"default"`. Cards created with an explicit board id (`openclaw workboard create --board ops ...`, stored as `metadata.automation.boardId`) silently disappear from a widget pinned without a `boardId` prop — the widget renders all-zero counts and "No ready or running cards" even though cards exist. This exact trap hit the post-merge proof session for #112434.

## Why This Change Was Made

An omitted prop should mean "everything", not a silent filter to one implicit board. With no `boardId`, the mini widget now aggregates cards across all boards, titles itself with the existing `workboard.allBoards` string ("All boards"), and links to `/workboard` unscoped — mirroring the Workboard page's own **All boards** filter semantics. An explicit `boardId` keeps the current scoped behavior unchanged.

Also documents the two native widget kinds (`workboard:card`, `workboard:mini`) in `docs/plugins/workboard.md` — #112434 landed without user-doc coverage.

## User Impact

Agents can pin a board-overview widget without knowing board topology, and the widget shows real data instead of an empty shell when cards live on named boards.

## Evidence

- New test: cards across `ops` + unscoped → no-prop widget counts all of them, headers "All boards", link is `/control/workboard`. `node scripts/run-vitest.mjs ui/src/lib/board/widgets`: 13/13.
- Explicit-`boardId` tests unchanged and green.
- Codex autoreview clean (0.94, no findings).
