### PR TITLE
feat(ui): unify agent pickers with avatars

### DIFF
--- a/ui/src/components/agent-scope-control.test.ts
+++ b/ui/src/components/agent-scope-control.test.ts
@@ -4,51 +4,58 @@ import { render } from "lit";
 import { describe, expect, it, vi } from "vitest";
 import type { AgentSelectionCapability } from "../app/agent-selection.ts";
 import { renderAgentScopeControl } from "./agent-scope-control.ts";
+import type { AgentSelectOption } from "./agent-select.ts";
+
+type AgentSelectElement = HTMLElement & {
+  options: AgentSelectOption[];
+  value: string;
+  onSelect: (value: string) => void;
+  updateComplete: Promise<boolean>;
+};
+
+function createSelection(setScope: (agentId: string | null) => void) {
+  return {
+    state: { selectedId: "main", scopeId: null },
+    set: vi.fn(),
+    setScope,
+    subscribe: vi.fn(),
+  } as unknown as AgentSelectionCapability;
+}
 
 describe("renderAgentScopeControl", () => {
-  it("includes historical agent ids that are absent from the configured roster", () => {
+  it("includes historical agent ids and maps All agents back to null", async () => {
     const container = document.createElement("div");
+    document.body.append(container);
     const setScope = vi.fn();
-    const selection = {
-      state: { selectedId: "main", scopeId: null },
-      set: vi.fn(),
-      setScope,
-      subscribe: vi.fn(),
-    } as unknown as AgentSelectionCapability;
 
     render(
       renderAgentScopeControl({
-        agents: [{ id: "main", name: "Main agent" }],
+        agents: [{ id: "main", name: "Main agent", identity: { emoji: "🦞" } }],
         additionalAgentIds: ["retired"],
-        selection,
+        selection: createSelection(setScope),
       }),
       container,
     );
 
-    const select = container.querySelector("select");
-    expect(Array.from(select?.options ?? []).map((option) => option.value)).toEqual([
-      "",
-      "main",
-      "retired",
-    ]);
+    const select = container.querySelector<AgentSelectElement>("openclaw-agent-select");
+    expect(select).not.toBeNull();
+    await select?.updateComplete;
+    expect(select?.options.map((option) => option.value)).toEqual(["", "main", "retired"]);
+    expect(select?.querySelector(".agent-select__avatar--text")?.getAttribute("data-avatar")).toBe(
+      "🦞",
+    );
 
-    if (!(select instanceof HTMLSelectElement)) {
-      throw new Error("expected agent scope select");
-    }
-    select.value = "retired";
-    select.dispatchEvent(new Event("change", { bubbles: true }));
-    expect(setScope).toHaveBeenCalledWith("retired");
+    select?.onSelect("retired");
+    select?.onSelect("");
+    expect(setScope).toHaveBeenNthCalledWith(1, "retired");
+    expect(setScope).toHaveBeenNthCalledWith(2, null);
+    container.remove();
   });
 
-  it("supports a concrete-agent selector without an all-agents option", () => {
+  it("supports a concrete-agent selector without an all-agents option", async () => {
     const container = document.createElement("div");
+    document.body.append(container);
     const setScope = vi.fn();
-    const selection = {
-      state: { selectedId: "main", scopeId: null },
-      set: vi.fn(),
-      setScope,
-      subscribe: vi.fn(),
-    } as unknown as AgentSelectionCapability;
 
     render(
       renderAgentScopeControl({
@@ -56,21 +63,18 @@ describe("renderAgentScopeControl", () => {
           { id: "main", name: "Main agent" },
           { id: "writer", name: "Writer" },
         ],
-        selection,
+        selection: createSelection(setScope),
         allowAll: false,
         selectedId: "writer",
       }),
       container,
     );
 
-    const select = container.querySelector("select");
+    const select = container.querySelector<AgentSelectElement>("openclaw-agent-select");
     expect(select?.value).toBe("writer");
-    expect(Array.from(select?.options ?? []).map((option) => option.value)).toEqual([
-      "main",
-      "writer",
-    ]);
-    select!.value = "main";
-    select!.dispatchEvent(new Event("change", { bubbles: true }));
+    expect(select?.options.map((option) => option.value)).toEqual(["main", "writer"]);
+    select?.onSelect("main");
     expect(setScope).toHaveBeenCalledWith("main");
+    container.remove();
   });
 });

--- a/ui/src/components/agent-scope-control.ts
+++ b/ui/src/components/agent-scope-control.ts
@@ -4,6 +4,9 @@ import type { AgentSelectionCapability } from "../app/agent-selection.ts";
 import { t } from "../i18n/index.ts";
 import { normalizeAgentLabel } from "../lib/agents/display.ts";
 import { normalizeAgentId } from "../lib/sessions/session-key.ts";
+import type { AgentSelectOption } from "./agent-select.ts";
+import "./agent-select-registration.ts";
+import { icons } from "./icons.ts";
 
 type AgentScopeControlParams = {
   agents: readonly GatewayAgentRow[];
@@ -31,38 +34,29 @@ export function renderAgentScopeControl(params: AgentScopeControlParams) {
       agentsById.set(agentId, { id: agentId });
     }
   }
+  if (selected && !agentsById.has(selected)) {
+    agentsById.set(selected, { id: selected });
+  }
   const agents = [...agentsById.values()].toSorted((left, right) =>
     normalizeAgentLabel(left).localeCompare(normalizeAgentLabel(right)),
   );
-  const selectedAgentMissing = selected && !agents.some((agent) => agent.id === selected);
+  const options: AgentSelectOption[] = [
+    ...(allowAll ? [{ value: "", label: t("agentScope.allAgents"), icon: icons.users }] : []),
+    ...agents.map((agent) => ({
+      value: agent.id,
+      label: normalizeAgentLabel(agent),
+      agent,
+    })),
+  ];
   return html`
     <label class="agent-scope-control">
       <span class="agent-scope-control__label">${t("agentScope.label")}</span>
-      <select
-        class="agent-scope-control__select"
-        aria-label=${t("agentScope.label")}
+      <openclaw-agent-select
+        .options=${options}
         .value=${selected}
-        @change=${(event: Event) => {
-          const value = (event.currentTarget as HTMLSelectElement).value;
-          params.selection.setScope(value || null);
-        }}
-      >
-        ${allowAll
-          ? html`<option value="" ?selected=${selected === ""}>
-              ${t("agentScope.allAgents")}
-            </option>`
-          : null}
-        ${selectedAgentMissing
-          ? html`<option value=${selected} selected>${selected}</option>`
-          : null}
-        ${agents.map(
-          (agent) => html`
-            <option value=${agent.id} ?selected=${agent.id === selected}>
-              ${normalizeAgentLabel(agent)}
-            </option>
-          `,
-        )}
-      </select>
+        .accessibleLabel=${t("agentScope.label")}
+        .onSelect=${(value: string) => params.selection.setScope(value || null)}
+      ></openclaw-agent-select>
     </label>
   `;
 }

--- a/ui/src/components/agent-select.test.ts
+++ b/ui/src/components/agent-select.test.ts
@@ -4,21 +4,21 @@ import { expect, it, vi } from "vitest";
 import type { AgentIdentityResult, GatewayAgentRow } from "../api/types.ts";
 import { i18n, t } from "../i18n/index.ts";
 import { waitForFast } from "../test-helpers/wait-for.ts";
-import { AgentSelect } from "./agent-select.ts";
+import { AgentSelect, type AgentSelectOption } from "./agent-select.ts";
 
 const AGENT_SELECT_TEST_TAG = `test-openclaw-agent-select-${crypto.randomUUID()}`;
 
 customElements.define(AGENT_SELECT_TEST_TAG, class extends AgentSelect {});
 
 type AgentSelectElement = HTMLElement & {
-  agents: GatewayAgentRow[];
-  selectedId: string | null;
-  defaultId: string | null;
+  options: AgentSelectOption[];
+  value: string;
+  accessibleLabel: string;
   identityById: Record<string, AgentIdentityResult>;
   authToken: string | null;
   disabled: boolean;
-  onSelect: (agentId: string) => void;
-  onCreateAgent: () => void;
+  onSelect: (value: string) => void;
+  onCreateAgent: (() => void) | null;
   updateComplete: Promise<boolean>;
 };
 
@@ -26,6 +26,11 @@ const agents: GatewayAgentRow[] = [
   { id: "alpha", name: "Alpha agent" },
   { id: "beta", name: "Beta agent" },
 ];
+const options: AgentSelectOption[] = agents.map((agent) => ({
+  value: agent.id,
+  label: agent.name ?? agent.id,
+  agent,
+}));
 
 function createIdentity(
   agentId: string,
@@ -43,8 +48,9 @@ async function createAgentSelect(
   overrides: Partial<Omit<AgentSelectElement, keyof HTMLElement>> = {},
 ): Promise<AgentSelectElement> {
   const element = document.createElement(AGENT_SELECT_TEST_TAG) as AgentSelectElement;
-  element.agents = agents;
-  element.selectedId = "alpha";
+  element.options = options;
+  element.value = "alpha";
+  element.onCreateAgent = vi.fn();
   Object.assign(element, overrides);
   document.body.append(element);
   await element.updateComplete;
@@ -67,13 +73,39 @@ it("renders the selected label and a data URL image avatar", async () => {
   }
 });
 
+it("prefers the roster-projected avatar URL over the raw local source", async () => {
+  const dataUrl = "data:image/png;base64,cm9zdGVy";
+  const element = await createAgentSelect({
+    options: [
+      {
+        value: "alpha",
+        label: "Alpha agent",
+        agent: {
+          id: "alpha",
+          identity: { avatar: "avatar.png", avatarUrl: dataUrl },
+        },
+      },
+    ],
+  });
+
+  try {
+    expect(element.querySelector<HTMLImageElement>("img.agent-select__avatar")?.src).toContain(
+      dataUrl,
+    );
+  } finally {
+    element.remove();
+  }
+});
+
 it("renders an emoji text avatar when no image URL is available", async () => {
   const element = await createAgentSelect({
     identityById: { alpha: createIdentity("alpha", { emoji: "🦉" }) },
   });
 
   try {
-    expect(element.querySelector(".agent-select__avatar--text")?.textContent?.trim()).toBe("🦉");
+    expect(element.querySelector(".agent-select__avatar--text")?.getAttribute("data-avatar")).toBe(
+      "🦉",
+    );
     expect(element.querySelector("img.agent-select__avatar")).toBeNull();
   } finally {
     element.remove();
@@ -84,7 +116,9 @@ it("falls back to the uppercase agent initial", async () => {
   const element = await createAgentSelect();
 
   try {
-    expect(element.querySelector(".agent-select__avatar--text")?.textContent?.trim()).toBe("A");
+    expect(element.querySelector(".agent-select__avatar--text")?.getAttribute("data-avatar")).toBe(
+      "A",
+    );
   } finally {
     element.remove();
   }
@@ -113,7 +147,9 @@ it("fetches local avatars with the bearer credential when token auth is active",
 
   try {
     // Text fallback renders while the authenticated fetch is in flight.
-    expect(element.querySelector(".agent-select__avatar--text")?.textContent?.trim()).toBe("A");
+    expect(element.querySelector(".agent-select__avatar--text")?.getAttribute("data-avatar")).toBe(
+      "A",
+    );
     expect(fetchMock).toHaveBeenCalledWith("/avatar/alpha", {
       headers: { Authorization: "Bearer tok" },
       signal: expect.any(AbortSignal),
@@ -267,7 +303,9 @@ it("aborts a stalled local avatar fetch after the request deadline", async () =>
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [, fetchInit] = fetchMock.mock.calls[0] ?? [];
     expect(fetchInit?.signal?.aborted).toBe(false);
-    expect(element.querySelector(".agent-select__avatar--text")?.textContent?.trim()).toBe("A");
+    expect(element.querySelector(".agent-select__avatar--text")?.getAttribute("data-avatar")).toBe(
+      "A",
+    );
 
     await vi.advanceTimersByTimeAsync(29_999);
     expect(fetchInit?.signal?.aborted).toBe(false);
@@ -276,7 +314,9 @@ it("aborts a stalled local avatar fetch after the request deadline", async () =>
 
     await waitForFast(() => {
       expect(element.querySelector("img.agent-select__avatar")).toBeNull();
-      expect(element.querySelector(".agent-select__avatar--text")?.textContent?.trim()).toBe("A");
+      expect(
+        element.querySelector(".agent-select__avatar--text")?.getAttribute("data-avatar"),
+      ).toBe("A");
     });
     expect(vi.getTimerCount()).toBe(0);
   } finally {
@@ -320,7 +360,9 @@ it("aborts a stalled local avatar body after the request deadline", async () => 
     expect(fetchInit?.signal?.aborted).toBe(true);
     await waitForFast(() => {
       expect(element.querySelector("img.agent-select__avatar")).toBeNull();
-      expect(element.querySelector(".agent-select__avatar--text")?.textContent?.trim()).toBe("A");
+      expect(
+        element.querySelector(".agent-select__avatar--text")?.getAttribute("data-avatar"),
+      ).toBe("A");
     });
     expect(vi.getTimerCount()).toBe(0);
   } finally {
@@ -346,23 +388,131 @@ it("renders a local avatar image when token auth is not active", async () => {
 });
 
 it("renders the agent picker as a Web Awesome dropdown", async () => {
-  const element = await createAgentSelect({ defaultId: "beta" });
+  const element = await createAgentSelect({
+    options: options.map((option) =>
+      option.value === "beta" ? { ...option, badge: "default" } : option,
+    ),
+  });
 
   try {
     const dropdown = element.querySelector<HTMLElement & { open: boolean }>("wa-dropdown");
-    const options = Array.from(
+    const items = Array.from(
       element.querySelectorAll<HTMLElement & { checked: boolean; value: string }>(
-        "wa-dropdown-item[data-agent-id]",
+        "wa-dropdown-item[data-agent-option]",
       ),
     );
     expect(dropdown).not.toBeNull();
-    expect(options).toHaveLength(2);
-    expect(options[0]?.checked).toBe(true);
-    expect(options[1]?.checked).toBe(false);
-    expect(options[0]?.value).toBe("alpha");
-    expect(options[1]?.value).toBe("beta");
-    expect(options[1]?.querySelector(".agent-select__badge")?.textContent?.trim()).toBe("default");
+    expect(items).toHaveLength(2);
+    expect(items[0]?.checked).toBe(true);
+    expect(items[1]?.checked).toBe(false);
+    expect(items[0]?.value).toBe("alpha");
+    expect(items[1]?.value).toBe("beta");
+    expect(items[1]?.querySelector(".agent-select__badge")?.textContent?.trim()).toBe("default");
     expect(dropdown?.shadowRoot?.querySelector('[role="menu"]')).not.toBeNull();
+  } finally {
+    element.remove();
+  }
+});
+
+it("keeps avatar text out of typeahead and announces option metadata", async () => {
+  const element = await createAgentSelect({
+    accessibleLabel: "Agent",
+    options: options.map((option) =>
+      option.value === "beta"
+        ? { ...option, description: "Handles research", badge: "Default" }
+        : option,
+    ),
+    value: "beta",
+  });
+
+  try {
+    const items = Array.from(
+      element.querySelectorAll<HTMLElement & { value: string }>("[data-agent-option]"),
+    );
+    expect(items.find((item) => item.value === "alpha")?.textContent?.trim()).toBe("Alpha agent");
+    expect(items.find((item) => item.value === "beta")?.getAttribute("aria-label")).toBe(
+      "Beta agent, Handles research, Default",
+    );
+    expect(element.querySelector(".agent-select__trigger")?.getAttribute("aria-label")).toBe(
+      "Agent: Beta agent, Default",
+    );
+  } finally {
+    element.remove();
+  }
+});
+
+it("shows an unmatched selected value instead of the first option", async () => {
+  const element = await createAgentSelect({ value: "system-monitor" });
+
+  try {
+    expect(element.querySelector(".agent-select__label")?.textContent?.trim()).toBe(
+      "system-monitor",
+    );
+    expect(element.querySelector(".agent-select__avatar--text")?.getAttribute("data-avatar")).toBe(
+      "S",
+    );
+    expect(
+      Array.from(
+        element.querySelectorAll<HTMLElement & { checked: boolean }>("[data-agent-option]"),
+      ).some((item) => item.checked),
+    ).toBe(false);
+  } finally {
+    element.remove();
+  }
+});
+
+it("focuses and scrolls the selected row into view when opened", async () => {
+  const element = await createAgentSelect({ value: "beta" });
+
+  try {
+    const beta = Array.from(
+      element.querySelectorAll<HTMLElement & { active: boolean; value: string }>(
+        "[data-agent-option]",
+      ),
+    ).find((item) => item.value === "beta");
+    if (!beta) {
+      throw new Error("expected beta option");
+    }
+    const scrollIntoView = vi.fn();
+    Object.defineProperty(beta, "scrollIntoView", { configurable: true, value: scrollIntoView });
+    element.querySelector("wa-dropdown")?.dispatchEvent(new CustomEvent("wa-after-show"));
+
+    expect(beta.active).toBe(true);
+    expect(document.activeElement).toBe(beta);
+    expect(scrollIntoView).toHaveBeenCalledWith({ block: "nearest" });
+  } finally {
+    element.remove();
+  }
+});
+
+it("closes and rejects selection when disabled while open", async () => {
+  const onSelect = vi.fn<(value: string) => void>();
+  const element = await createAgentSelect({ onSelect });
+
+  try {
+    const dropdown = element.querySelector<HTMLElement & { open: boolean }>("wa-dropdown");
+    const beta = Array.from(
+      element.querySelectorAll<HTMLElement & { disabled: boolean; value: string }>(
+        "[data-agent-option]",
+      ),
+    ).find((item) => item.value === "beta");
+    if (!dropdown || !beta) {
+      throw new Error("expected dropdown and beta option");
+    }
+    dropdown.open = true;
+    element.disabled = true;
+    await element.updateComplete;
+
+    expect(dropdown.open).toBe(false);
+    expect(beta.disabled).toBe(true);
+    const selection = new CustomEvent("wa-select", {
+      bubbles: true,
+      cancelable: true,
+      detail: { item: beta },
+    });
+    dropdown.dispatchEvent(selection);
+    expect(selection.defaultPrevented).toBe(true);
+    expect(onSelect).not.toHaveBeenCalled();
   } finally {
     element.remove();
   }
@@ -393,7 +543,16 @@ it("selects a different agent and ignores the already-selected agent", async () 
   const element = await createAgentSelect({ onSelect });
 
   try {
-    const beta = element.querySelector('[data-agent-id="beta"]');
+    const items = Array.from(
+      element.querySelectorAll<HTMLElement & { checked: boolean; value: string }>(
+        "[data-agent-option]",
+      ),
+    );
+    const beta = items.find((item) => item.value === "beta");
+    const alpha = items.find((item) => item.value === "alpha");
+    if (!beta || !alpha) {
+      throw new Error("expected alpha and beta options");
+    }
     const dropdown = element.querySelector("wa-dropdown");
     dropdown?.dispatchEvent(
       new CustomEvent("wa-select", { detail: { item: beta }, bubbles: true }),
@@ -402,7 +561,6 @@ it("selects a different agent and ignores the already-selected agent", async () 
     expect(onSelect).toHaveBeenCalledOnce();
     expect(onSelect).toHaveBeenCalledWith("beta");
 
-    const alpha = element.querySelector('[data-agent-id="alpha"]');
     const repeatedSelection = new CustomEvent("wa-select", {
       detail: { item: alpha },
       bubbles: true,
@@ -413,8 +571,48 @@ it("selects a different agent and ignores the already-selected agent", async () 
 
     expect(onSelect).toHaveBeenCalledOnce();
     expect(repeatedSelection.defaultPrevented).toBe(true);
-    expect((alpha as HTMLElement & { checked: boolean }).checked).toBe(true);
+    expect(alpha.checked).toBe(true);
     expect(document.activeElement).toBe(element.querySelector(".agent-select__trigger"));
+  } finally {
+    element.remove();
+  }
+});
+
+it("selects an empty-string special option and exposes radio semantics", async () => {
+  const onSelect = vi.fn<(value: string) => void>();
+  const element = await createAgentSelect({
+    options: [{ value: "", label: "All agents" }, ...options],
+    value: "alpha",
+    onSelect,
+  });
+
+  try {
+    const items = Array.from(
+      element.querySelectorAll<HTMLElement & { checked: boolean; value: string }>(
+        "[data-agent-option]",
+      ),
+    );
+    const allAgents = items.find((item) => item.value === "");
+    if (!allAgents) {
+      throw new Error("expected all-agents option");
+    }
+    await waitForFast(() => {
+      expect(items.find((item) => item.value === "alpha")?.getAttribute("role")).toBe(
+        "menuitemradio",
+      );
+      expect(items.find((item) => item.value === "alpha")?.getAttribute("aria-checked")).toBe(
+        "true",
+      );
+      expect(items.find((item) => item.value === "alpha")?.getAttribute("aria-label")).toBe(
+        "Alpha agent",
+      );
+    });
+
+    element
+      .querySelector("wa-dropdown")
+      ?.dispatchEvent(new CustomEvent("wa-select", { detail: { item: allAgents }, bubbles: true }));
+
+    expect(onSelect).toHaveBeenCalledWith("");
   } finally {
     element.remove();
   }
@@ -437,7 +635,7 @@ it("opens the new-agent flow from the footer item", async () => {
 });
 
 it("keeps the new-agent footer reachable with an empty roster", async () => {
-  const element = await createAgentSelect({ agents: [], selectedId: null });
+  const element = await createAgentSelect({ options: [], value: "" });
 
   try {
     const trigger = element.querySelector<HTMLButtonElement>(".agent-select__trigger");
@@ -448,9 +646,20 @@ it("keeps the new-agent footer reachable with an empty roster", async () => {
   }
 });
 
+it("disables an empty picker when no footer action is available", async () => {
+  const element = await createAgentSelect({ options: [], value: "", onCreateAgent: null });
+
+  try {
+    expect(element.querySelector<HTMLButtonElement>(".agent-select__trigger")?.disabled).toBe(true);
+    expect(element.querySelector("[data-create-agent]")).toBeNull();
+  } finally {
+    element.remove();
+  }
+});
+
 it("refreshes translated labels when the locale changes while mounted", async () => {
   await i18n.setLocale("en");
-  const element = await createAgentSelect({ agents: [], selectedId: null });
+  const element = await createAgentSelect({ options: [], value: "" });
 
   try {
     const label = element.querySelector(".agent-select__label");

--- a/ui/src/components/agent-select.ts
+++ b/ui/src/components/agent-select.ts
@@ -1,33 +1,82 @@
 import "@awesome.me/webawesome/dist/components/dropdown/dropdown.js";
 import "@awesome.me/webawesome/dist/components/dropdown-item/dropdown-item.js";
 import type { PropertyValues } from "lit";
-import { html, nothing } from "lit";
+import { html, nothing, type TemplateResult } from "lit";
 import { property } from "lit/decorators.js";
+import { ref } from "lit/directives/ref.js";
 import type { AgentIdentityResult, GatewayAgentRow } from "../api/types.ts";
 import { t } from "../i18n/index.ts";
-import {
-  agentBadgeText,
-  normalizeAgentLabel,
-  resolveAgentTextAvatar,
-} from "../lib/agents/display.ts";
+import { resolveAgentTextAvatar } from "../lib/agents/display.ts";
 import { resolveAgentAvatarUrl } from "../lib/avatar.ts";
 import { OpenClawLightDomElement } from "../lit/openclaw-element.ts";
 import { icons } from "./icons.ts";
+import { syncDropdownItemRadio } from "./web-awesome.ts";
+
+export type AgentSelectOption = {
+  value: string;
+  label: string;
+  agent?: GatewayAgentRow;
+  icon?: TemplateResult;
+  description?: string;
+  badge?: string;
+  disabled?: boolean;
+};
 
 type WebAwesomeSelectEvent = Event & { detail: { item: Element } };
 type AvatarFetch = { authToken: string; controller: AbortController };
 
 /** Bound local avatar fetches so a stalled Control UI media route cannot pin pending state forever. */
 const AGENT_SELECT_AVATAR_FETCH_TIMEOUT_MS = 30_000;
+
+export function renderAgentSelectAvatar(
+  option: AgentSelectOption,
+  identity: AgentIdentityResult | null = null,
+  imageUrl?: string | null,
+) {
+  const resolvedImageUrl =
+    imageUrl === undefined && option.agent
+      ? resolveAgentAvatarUrl(option.agent, identity)
+      : (imageUrl ?? null);
+  if (resolvedImageUrl) {
+    return html`<img class="agent-select__avatar" src=${resolvedImageUrl} alt="" loading="lazy" />`;
+  }
+  if (option.icon) {
+    return html`<span class="agent-select__avatar agent-select__avatar--icon" aria-hidden="true"
+      >${option.icon}</span
+    >`;
+  }
+  const text = option.agent ? resolveAgentTextAvatar(option.agent, identity) : null;
+  const fallback = (option.label[0] ?? "?").toUpperCase();
+  return html`
+    <span
+      class="agent-select__avatar agent-select__avatar--text"
+      data-avatar=${text ?? fallback}
+      aria-hidden="true"
+    ></span>
+  `;
+}
+
+export function renderAgentSelectCopy(option: AgentSelectOption) {
+  return html`
+    <span class="agent-select__option-copy">
+      <span class="agent-select__option-label">${option.label}</span>
+      ${option.description
+        ? html`<span class="agent-select__option-description">${option.description}</span>`
+        : nothing}
+    </span>
+  `;
+}
+
 export class AgentSelect extends OpenClawLightDomElement {
-  @property({ attribute: false }) agents: GatewayAgentRow[] = [];
-  @property({ attribute: false }) selectedId: string | null = null;
-  @property({ attribute: false }) defaultId: string | null = null;
+  @property({ attribute: false }) options: readonly AgentSelectOption[] = [];
+  @property({ attribute: false }) value = "";
+  @property({ attribute: false }) placeholder = "";
+  @property({ attribute: false }) accessibleLabel = "";
   @property({ attribute: false }) identityById: Record<string, AgentIdentityResult> = {};
   @property({ attribute: false }) authToken: string | null = null;
   @property({ attribute: false }) disabled = false;
-  @property({ attribute: false }) onSelect: (agentId: string) => void = () => {};
-  @property({ attribute: false }) onCreateAgent: () => void = () => {};
+  @property({ attribute: false }) onSelect: (value: string) => void = () => {};
+  @property({ attribute: false }) onCreateAgent: (() => void) | null = null;
 
   private readonly avatarBlobUrlByRoute = new Map<string, string>();
   private readonly avatarFetchByRoute = new Map<string, AvatarFetch>();
@@ -42,6 +91,12 @@ export class AgentSelect extends OpenClawLightDomElement {
     // a rotated token must refetch with the current authorization.
     if (changed.has("authToken")) {
       this.resetAvatarState();
+    }
+    if (changed.has("disabled") && this.disabled) {
+      const dropdown = this.querySelector<HTMLElement & { open: boolean }>("wa-dropdown");
+      if (dropdown) {
+        dropdown.open = false;
+      }
     }
   }
 
@@ -114,20 +169,14 @@ export class AgentSelect extends OpenClawLightDomElement {
     }
   }
 
-  private renderAvatar(agent: GatewayAgentRow) {
-    const identity = this.identityById[agent.id] ?? null;
-    const url = resolveAgentAvatarUrl(agent, identity);
+  private renderAvatar(option: AgentSelectOption) {
+    // agents.list projects local files into validated avatarUrl data URLs. Only
+    // Agents settings supplies identity.get /avatar routes together with authToken.
+    const agentId = option.agent?.id;
+    const identity = agentId ? (this.identityById[agentId] ?? null) : null;
+    const url = option.agent ? resolveAgentAvatarUrl(option.agent, identity) : null;
     const imageUrl = url ? this.resolveRenderableAvatarUrl(url) : null;
-    if (imageUrl) {
-      return html`<img class="agent-select__avatar" src=${imageUrl} alt="" loading="lazy" />`;
-    }
-    const text = resolveAgentTextAvatar(agent, identity);
-    const fallback = (normalizeAgentLabel(agent)[0] ?? "?").toUpperCase();
-    return html`
-      <span class="agent-select__avatar agent-select__avatar--text" aria-hidden="true"
-        >${text ?? fallback}</span
-      >
-    `;
+    return renderAgentSelectAvatar(option, identity, imageUrl);
   }
 
   private resolveRenderableAvatarUrl(url: string): string | null {
@@ -143,16 +192,20 @@ export class AgentSelect extends OpenClawLightDomElement {
   }
 
   private readonly handleSelect = (event: WebAwesomeSelectEvent) => {
+    if (this.disabled) {
+      event.preventDefault();
+      return;
+    }
     const item = event.detail.item as HTMLElement & { checked?: boolean; value?: string };
     if (item.hasAttribute("data-create-agent")) {
-      this.onCreateAgent();
+      this.onCreateAgent?.();
       return;
     }
-    const agentId = item.value ?? item.getAttribute("value");
-    if (!agentId) {
+    const value = item.value ?? item.getAttribute("value");
+    if (value === null || value === undefined) {
       return;
     }
-    if (agentId === this.selectedId) {
+    if (value === this.value) {
       event.preventDefault();
       item.checked = true;
       const dropdown = event.currentTarget as HTMLElement & { open: boolean };
@@ -160,55 +213,107 @@ export class AgentSelect extends OpenClawLightDomElement {
       dropdown.open = false;
       return;
     }
-    this.onSelect(agentId);
+    this.onSelect(value);
+  };
+
+  private readonly handleAfterShow = (event: Event) => {
+    const dropdown = event.currentTarget as HTMLElement;
+    const items = Array.from(
+      dropdown.querySelectorAll<HTMLElement & { active: boolean }>(
+        "wa-dropdown-item[data-agent-option]:not([disabled])",
+      ),
+    );
+    const selected = items.find((item) => item.hasAttribute("data-selected")) ?? items[0];
+    if (!selected) {
+      return;
+    }
+    for (const item of items) {
+      item.active = item === selected;
+    }
+    selected.focus({ preventScroll: true });
+    selected.scrollIntoView?.({ block: "nearest" });
   };
 
   override render() {
-    const selectedAgent =
-      this.agents.find((agent) => agent.id === this.selectedId) ??
-      this.agents.find((agent) => agent.id === this.defaultId) ??
-      this.agents[0];
-    const selectedBadge = selectedAgent ? agentBadgeText(selectedAgent.id, this.defaultId) : null;
-    const unavailable = this.disabled;
+    const selectedOption = this.options.find((option) => option.value === this.value);
+    const missingValueOption: AgentSelectOption | null =
+      !selectedOption && this.value
+        ? { value: this.value, label: this.value, agent: { id: this.value } }
+        : null;
+    const triggerOption = selectedOption ?? missingValueOption;
+    const unavailable = this.disabled || (this.options.length === 0 && !this.onCreateAgent);
+    const triggerLabel = triggerOption?.label ?? (this.placeholder || t("agents.noAgents"));
+    const selectedBadge = selectedOption?.badge;
+    const triggerAccessibleLabel = selectedBadge
+      ? `${triggerLabel}, ${selectedBadge}`
+      : triggerLabel;
 
     return html`
-      <wa-dropdown class="agent-select" placement="bottom-start" @wa-select=${this.handleSelect}>
-        <button slot="trigger" type="button" class="agent-select__trigger" ?disabled=${unavailable}>
-          ${selectedAgent
-            ? html`
-                ${this.renderAvatar(selectedAgent)}
-                <span class="agent-select__label">${normalizeAgentLabel(selectedAgent)}</span>
-                ${selectedBadge
-                  ? html`<span class="agent-select__badge">${selectedBadge}</span>`
-                  : nothing}
-              `
-            : html`<span class="agent-select__label">${t("agents.noAgents")}</span>`}
+      <wa-dropdown
+        class="agent-select"
+        placement="bottom-start"
+        aria-label=${this.accessibleLabel || triggerLabel}
+        @wa-select=${this.handleSelect}
+        @wa-after-show=${this.handleAfterShow}
+      >
+        <button
+          slot="trigger"
+          type="button"
+          class="agent-select__trigger"
+          aria-label=${this.accessibleLabel
+            ? `${this.accessibleLabel}: ${triggerAccessibleLabel}`
+            : triggerAccessibleLabel}
+          ?disabled=${unavailable}
+        >
+          ${triggerOption ? this.renderAvatar(triggerOption) : nothing}
+          <span class="agent-select__label">${triggerLabel}</span>
+          ${selectedBadge
+            ? html`<span class="agent-select__badge">${selectedBadge}</span>`
+            : nothing}
           <span class="agent-select__chevron" aria-hidden="true">${icons.chevronDown}</span>
         </button>
-        ${this.agents.map((agent) => {
-          const badge = agentBadgeText(agent.id, this.defaultId);
-          const selected = agent.id === this.selectedId;
+        ${this.options.map((option) => {
+          const selected = option.value === this.value;
+          const accessibleLabel = [option.label, option.description, option.badge]
+            .filter(Boolean)
+            .join(", ");
           return html`
             <wa-dropdown-item
               class="agent-select__option"
-              data-agent-id=${agent.id}
-              .value=${agent.id}
+              data-agent-option
+              ?data-selected=${selected}
+              aria-label=${accessibleLabel}
+              .value=${option.value}
               type="checkbox"
               .checked=${selected}
+              ?disabled=${this.disabled || option.disabled}
+              ${ref((element) => syncDropdownItemRadio(element, selected))}
             >
-              <span slot="icon">${this.renderAvatar(agent)}</span>
-              <span class="agent-select__option-label">${normalizeAgentLabel(agent)}</span>
-              ${badge
-                ? html`<span slot="details" class="agent-select__badge">${badge}</span>`
+              <span slot="icon">${this.renderAvatar(option)}</span>
+              ${renderAgentSelectCopy(option)}
+              ${option.badge
+                ? html`<span slot="details" class="agent-select__badge">${option.badge}</span>`
                 : nothing}
             </wa-dropdown-item>
           `;
         })}
-        <div class="agent-select__separator" role="separator"></div>
-        <wa-dropdown-item class="agent-select__option" data-create-agent>
-          <span slot="icon">${icons.users}</span>
-          <span class="agent-select__option-label">${t("custodian.newAgent")}</span>
-        </wa-dropdown-item>
+        ${this.onCreateAgent
+          ? html`
+              ${this.options.length > 0
+                ? html`<div class="agent-select__separator" role="separator"></div>`
+                : nothing}
+              <wa-dropdown-item
+                class="agent-select__option"
+                data-create-agent
+                ?disabled=${this.disabled}
+              >
+                <span slot="icon" class="agent-select__footer-icon" aria-hidden="true"
+                  >${icons.users}</span
+                >
+                <span class="agent-select__option-label">${t("custodian.newAgent")}</span>
+              </wa-dropdown-item>
+            `
+          : nothing}
       </wa-dropdown>
     `;
   }

--- a/ui/src/components/app-sidebar-agent-menu.ts
+++ b/ui/src/components/app-sidebar-agent-menu.ts
@@ -6,10 +6,11 @@ import { titleForRoute, type NavigationRouteId } from "../app-navigation.ts";
 import type { ApplicationNavigationOptions } from "../app/context.ts";
 import type { ThemeMode } from "../app/theme.ts";
 import { t } from "../i18n/index.ts";
-import { normalizeAgentLabel, resolveAgentTextAvatar } from "../lib/agents/display.ts";
+import { normalizeAgentLabel } from "../lib/agents/display.ts";
 import { buildExternalLinkRel, EXTERNAL_LINK_TARGET } from "../lib/external-link.ts";
 import { openExternalUrlSafe } from "../lib/open-external-url.ts";
 import { normalizeAgentId } from "../lib/sessions/session-key.ts";
+import { renderAgentSelectAvatar, renderAgentSelectCopy } from "./agent-select.ts";
 import { icons, type IconName } from "./icons.ts";
 import {
   consumeDropdownKeyboardDismissal,
@@ -40,7 +41,11 @@ const AGENT_VALUE_PREFIX = "agent:";
 const COMMAND_VALUE_PREFIX = "command:";
 const LINK_VALUE_PREFIX = "link:";
 
-type AgentMenuAgent = { id: string; name?: string; identity?: { name?: string; emoji?: string } };
+type AgentMenuAgent = {
+  id: string;
+  name?: string;
+  identity?: { name?: string; emoji?: string; avatar?: string; avatarUrl?: string };
+};
 
 type SidebarAgentMenuParams = {
   position: { x: number; bottom: number } | null;
@@ -129,18 +134,18 @@ function renderAgentRow(agent: AgentMenuAgent, params: SidebarAgentMenuParams) {
     approvals === 1 ? "execApproval.agentPendingOne" : "execApproval.agentPending",
     { count: String(approvals) },
   );
-  const initial = resolveAgentTextAvatar(agent) ?? (label || agent.id).slice(0, 1).toUpperCase();
+  const option = { value: agentId, label, agent };
   return html`
     <wa-dropdown-item
-      class="sidebar-customize-menu__item sidebar-agent-menu__agent-switch"
+      class="sidebar-customize-menu__item sidebar-agent-menu__agent-switch agent-select__option"
       value=${`${AGENT_VALUE_PREFIX}${encodeURIComponent(agentId)}`}
       type="checkbox"
       role="menuitemradio"
       aria-checked=${String(active)}
       ${ref((element) => syncDropdownItemRadio(element, active))}
     >
-      <span slot="icon" class="sidebar-agent-section__avatar" aria-hidden="true">${initial}</span>
-      <span class="sidebar-customize-menu__text">${label}</span>
+      <span slot="icon">${renderAgentSelectAvatar(option)}</span>
+      ${renderAgentSelectCopy(option)}
       ${approvals > 0
         ? html`<span
             slot="details"

--- a/ui/src/e2e/agent-page-scope.e2e.test.ts
+++ b/ui/src/e2e/agent-page-scope.e2e.test.ts
@@ -129,12 +129,21 @@ describeControlUiE2e("Control UI agent page scope", () => {
       await sidebar.getByRole("link", { name: "Usage" }).click();
       await expect.poll(() => new URL(page.url()).pathname).toBe("/usage");
       await waitForRequest(gateway, "sessions.usage", (params) => params.agentId === "writer");
-      const pageScope = page.locator(".agent-scope-control__select");
-      await expect.poll(() => pageScope.inputValue()).toBe("writer");
+      const pageScope = page.locator(".agent-scope-control openclaw-agent-select");
+      await expect
+        .poll(() =>
+          pageScope.evaluate((picker) => (picker as HTMLElement & { value: string }).value),
+        )
+        .toBe("writer");
       await screenshot(page, "01-writer-usage.png");
 
+      const scopeTrigger = pageScope.locator(".agent-select__trigger");
       const usageRequestsBeforeAll = (await gateway.getRequests("sessions.usage")).length;
-      await pageScope.selectOption("");
+      await scopeTrigger.click();
+      await pageScope
+        .locator("wa-dropdown-item[data-agent-option]")
+        .filter({ hasText: "All agents" })
+        .evaluate((item) => (item as HTMLElement).click());
       await expect
         .poll(async () => {
           const requests = await gateway.getRequests("sessions.usage");

--- a/ui/src/e2e/agent-select-avatar-timeout.e2e.test.ts
+++ b/ui/src/e2e/agent-select-avatar-timeout.e2e.test.ts
@@ -92,7 +92,9 @@ describeControlUiE2e("Control UI agent picker avatar timeout", () => {
       await expect.poll(() => avatarRequestCount).toBe(1);
       const picker = page.locator("openclaw-agent-select");
       await expect
-        .poll(() => picker.locator(".agent-select__avatar--text").first().textContent())
+        .poll(() =>
+          picker.locator(".agent-select__avatar--text").first().getAttribute("data-avatar"),
+        )
         .toBe("O");
       expect(avatarAuthorization).toBe("Bearer e2e-device-token");
       await screenshot(page, "01-request-stalled.png");
@@ -101,7 +103,9 @@ describeControlUiE2e("Control UI agent picker avatar timeout", () => {
       await expect.poll(() => failedAvatarRequests.length).toBe(1);
       await expect.poll(() => picker.locator("img.agent-select__avatar").count()).toBe(0);
       await expect
-        .poll(() => picker.locator(".agent-select__avatar--text").first().textContent())
+        .poll(() =>
+          picker.locator(".agent-select__avatar--text").first().getAttribute("data-avatar"),
+        )
         .toBe("O");
 
       // A later render must use the cached miss instead of launching another fetch.

--- a/ui/src/e2e/new-session-page.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.e2e.test.ts
@@ -346,6 +346,15 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
     });
     await installMockGateway(page, {
       methodResponses: {
+        "agents.list": {
+          defaultId: "main",
+          mainKey: "main",
+          scope: "agent",
+          agents: [
+            { id: "main", name: "Main" },
+            { id: "writer", name: "Writer" },
+          ],
+        },
         "sessions.create": { key: "agent:main:preview-cleanup", runStarted: true },
       },
     });
@@ -384,7 +393,26 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
 
       await pastePng(composer);
       await page.locator('.chat-attachment-thumb img[alt="Attachment preview"]').waitFor();
+      const agentDropdown = page.locator(".new-session-page__select--agent wa-dropdown");
+      await page.locator(".new-session-page__select--agent .agent-select__trigger").click();
+      await expect
+        .poll(() =>
+          agentDropdown.evaluate((dropdown) => (dropdown as HTMLElement & { open: boolean }).open),
+        )
+        .toBe(true);
       await navigate("new-session", "?agent=main&catalog=missing");
+      await expect
+        .poll(() =>
+          page.evaluate(
+            () =>
+              (
+                document.querySelector(".new-session-page__select--agent wa-dropdown") as
+                  | (HTMLElement & { open: boolean })
+                  | null
+              )?.open ?? false,
+          ),
+        )
+        .toBe(false);
       await expect.poll(() => page.locator(".chat-attachment-thumb").count()).toBe(0);
       await expect.poll(async () => (await proof()).revoked).toBe(2);
 

--- a/ui/src/e2e/new-session-page.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.e2e.test.ts
@@ -1413,10 +1413,11 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
         .toBe(true);
       await page.keyboard.press("Escape");
 
-      await page.locator("#new-session-agent-trigger").click();
-      await page
-        .locator("wa-popover.new-session-page__agent-popover")
-        .getByRole("button", { name: "Local" })
+      const agentPicker = page.locator(".new-session-page__select--agent openclaw-agent-select");
+      await agentPicker.locator(".agent-select__trigger").click();
+      await agentPicker
+        .locator("wa-dropdown-item[data-agent-option]")
+        .filter({ hasText: "Local" })
         .click();
       await page.getByRole("heading", { name: "Local" }).waitFor();
       await expect.poll(() => trigger.getAttribute("data-cloud-profile")).toBeNull();
@@ -2297,10 +2298,11 @@ describeControlUiE2e("Control UI new-session page mocked Gateway E2E", () => {
       await page.goto(`${server.baseUrl}new`);
       await page.getByRole("heading", { name: "Main" }).waitFor();
       await gateway.waitForRequest("worktrees.branches");
-      await page.locator("#new-session-agent-trigger").click();
-      await page
-        .locator("wa-popover.new-session-page__agent-popover")
-        .getByRole("button", { name: "Research" })
+      const agentPicker = page.locator(".new-session-page__select--agent openclaw-agent-select");
+      await agentPicker.locator(".agent-select__trigger").click();
+      await agentPicker
+        .locator("wa-dropdown-item[data-agent-option]")
+        .filter({ hasText: "Research" })
         .click();
       await page.getByRole("heading", { name: "Research" }).waitFor();
 

--- a/ui/src/e2e/usage-cost-analysis.e2e.test.ts
+++ b/ui/src/e2e/usage-cost-analysis.e2e.test.ts
@@ -298,7 +298,12 @@ describeControlUiE2e("Control UI usage cost analysis mocked Gateway E2E", () => 
     try {
       await page.goto(`${server.baseUrl}usage`);
       await page.locator(".daily-chart-compact").waitFor({ state: "visible", timeout: 10_000 });
-      await page.locator(".agent-scope-control__select").selectOption("");
+      const agentScope = page.locator(".agent-scope-control openclaw-agent-select");
+      await agentScope.locator(".agent-select__trigger").click();
+      await agentScope
+        .locator("wa-dropdown-item[data-agent-option]")
+        .filter({ hasText: "All agents" })
+        .click();
       await expect
         .poll(async () => (await gateway.getRequests("usage.cost")).at(-1)?.params)
         .toMatchObject({ agentScope: "all" });

--- a/ui/src/lib/agents/display.ts
+++ b/ui/src/lib/agents/display.ts
@@ -332,7 +332,7 @@ export function resolveAgentTextAvatar(
 }
 
 export function agentBadgeText(agentId: string, defaultId: string | null) {
-  return defaultId && agentId === defaultId ? "default" : null;
+  return defaultId && agentId === defaultId ? t("agents.default") : null;
 }
 
 export function formatBytes(bytes?: number) {

--- a/ui/src/pages/agents/view.test.ts
+++ b/ui/src/pages/agents/view.test.ts
@@ -194,14 +194,14 @@ describe("renderAgents", () => {
       render(renderAgents(createProps()), container);
       const select = container.querySelector("openclaw-agent-select") as
         | (HTMLElement & {
-            agents: Array<{ id: string }>;
+            options: Array<{ value: string }>;
             updateComplete: Promise<boolean>;
           })
         | null;
       expect(select).not.toBeNull();
       await select?.updateComplete;
 
-      expect(select?.agents).toHaveLength(2);
+      expect(select?.options.map((option) => option.value)).toEqual(["alpha", "beta"]);
       expect(select?.querySelector(".agent-select__label")?.textContent?.trim()).toBe("Beta");
     } finally {
       container.remove();

--- a/ui/src/pages/agents/view.ts
+++ b/ui/src/pages/agents/view.ts
@@ -20,7 +20,11 @@ import {
   renderSettingsSection,
 } from "../../components/settings-ui.ts";
 import { t } from "../../i18n/index.ts";
-import { buildAgentContext } from "../../lib/agents/display.ts";
+import {
+  agentBadgeText,
+  buildAgentContext,
+  normalizeAgentLabel,
+} from "../../lib/agents/display.ts";
 import type { AgentsPanel } from "../../lib/agents/index.ts";
 import { copyToClipboard } from "../../lib/clipboard.ts";
 import "../../styles/agents.css";
@@ -145,6 +149,12 @@ export function renderAgents(props: AgentsProps) {
   const selectedAgent = selectedId
     ? (agents.find((agent) => agent.id === selectedId) ?? null)
     : null;
+  const agentOptions = agents.map((agent) => ({
+    value: agent.id,
+    label: normalizeAgentLabel(agent),
+    agent,
+    badge: agentBadgeText(agent.id, defaultId) ?? undefined,
+  }));
   const selectedSkillCount =
     selectedId && props.agentSkills.agentId === selectedId
       ? (props.agentSkills.report?.skills?.length ?? null)
@@ -169,9 +179,9 @@ export function renderAgents(props: AgentsProps) {
         <div class="agents-toolbar-row">
           <div class="agents-control-select">
             <openclaw-agent-select
-              .agents=${agents}
-              .selectedId=${selectedId}
-              .defaultId=${defaultId}
+              .options=${agentOptions}
+              .value=${selectedId ?? ""}
+              .accessibleLabel=${t("usage.filters.agent")}
               .identityById=${props.agentIdentityById}
               .authToken=${props.authToken}
               .disabled=${props.loading}

--- a/ui/src/pages/memory-import/view.test.ts
+++ b/ui/src/pages/memory-import/view.test.ts
@@ -108,6 +108,41 @@ describe("renderMemoryImport", () => {
     expect(container.textContent).not.toContain("private memory body");
   });
 
+  it("renders the avatar agent picker and routes agent changes", async () => {
+    const onSelectAgent = vi.fn();
+    const container = document.createElement("div");
+    document.body.append(container);
+    render(
+      renderMemoryImport(
+        createProps({
+          agents: [
+            { id: "research", name: "Research", identity: { emoji: "🔎" } },
+            { id: "writer", name: "Writer" },
+          ],
+          onSelectAgent,
+        }),
+      ),
+      container,
+    );
+
+    const picker = container.querySelector<
+      HTMLElement & {
+        options: Array<{ value: string }>;
+        onSelect: (value: string) => void;
+        updateComplete: Promise<boolean>;
+      }
+    >('openclaw-agent-select[name="memory-import-agent"]');
+    await picker?.updateComplete;
+    expect(picker?.options.map((option) => option.value)).toEqual(["research", "writer"]);
+    expect(picker?.querySelector(".agent-select__avatar--text")?.getAttribute("data-avatar")).toBe(
+      "🔎",
+    );
+
+    picker?.onSelect("writer");
+    expect(onSelectAgent).toHaveBeenCalledWith("writer");
+    container.remove();
+  });
+
   it("passes the exact collection item ids when selection changes", () => {
     const onToggleCollection = vi.fn();
     const container = document.createElement("div");
@@ -186,6 +221,11 @@ describe("renderMemoryImport", () => {
       (button) => button.textContent?.trim() === "Refresh",
     );
     expect(refresh?.disabled).toBe(true);
+    expect(
+      container.querySelector<HTMLElement & { disabled: boolean }>(
+        'openclaw-agent-select[name="memory-import-agent"]',
+      )?.disabled,
+    ).toBe(true);
     expect(
       container.querySelector<HTMLButtonElement>("[data-test-id='memory-import-provider-button']")
         ?.disabled,

--- a/ui/src/pages/memory-import/view.ts
+++ b/ui/src/pages/memory-import/view.ts
@@ -6,6 +6,7 @@ import type {
   MigrationsMemoryPlanResult,
 } from "../../../../packages/gateway-protocol/src/schema/migrations.js";
 import type { GatewayAgentRow } from "../../../../src/shared/session-types.js";
+import "../../components/agent-select-registration.ts";
 import "../../components/modal-dialog.ts";
 import { icons } from "../../components/icons.ts";
 import { renderProviderBrandIcon } from "../../components/provider-icon.ts";
@@ -19,6 +20,7 @@ import {
   renderSettingsValue,
 } from "../../components/settings-ui.ts";
 import { t } from "../../i18n/index.ts";
+import { normalizeAgentLabel } from "../../lib/agents/display.ts";
 import "../../styles/memory-import.css";
 
 type MemoryCollection = {
@@ -383,22 +385,19 @@ function renderIntroSection(props: MemoryImportViewProps) {
       ${renderSettingsRow({
         title: t("memoryImport.agent"),
         control: html`
-          <select
-            class="settings-select"
+          <openclaw-agent-select
+            class="agent-select--settings"
             name="memory-import-agent"
+            .options=${props.agents.map((agent) => ({
+              value: agent.id,
+              label: normalizeAgentLabel(agent),
+              agent,
+            }))}
             .value=${props.selectedAgentId ?? ""}
-            ?disabled=${busy}
-            @change=${(event: Event) =>
-              props.onSelectAgent((event.currentTarget as HTMLSelectElement).value)}
-          >
-            ${props.agents.map(
-              (agent) => html`
-                <option value=${agent.id} ?selected=${agent.id === props.selectedAgentId}>
-                  ${agent.identity?.name ?? agent.name ?? agent.id}
-                </option>
-              `,
-            )}
-          </select>
+            .accessibleLabel=${t("memoryImport.agent")}
+            .disabled=${busy}
+            .onSelect=${props.onSelectAgent}
+          ></openclaw-agent-select>
         `,
       })}
       ${renderSettingsToggleRow({

--- a/ui/src/pages/new-session/new-session-page.ts
+++ b/ui/src/pages/new-session/new-session-page.ts
@@ -76,8 +76,6 @@ class NewSessionPage extends OpenClawLightDomElement {
   @state() private browserTarget: BrowserTarget | null = null;
   @state() private placePopoverOpen = false;
   @state() private placePopoverHiding = false;
-  @state() private agentPopoverOpen = false;
-  @state() private agentPopoverHiding = false;
   // Live head input; absolute paths stay applicable even without fs.listDir.
   @state() private browserPathDraft = "";
 
@@ -475,9 +473,7 @@ class NewSessionPage extends OpenClawLightDomElement {
     }
     this.error = null;
     this.placePopoverHiding = false;
-    this.agentPopoverHiding = false;
     this.closeBrowser();
-    this.closeAgentPopover();
     this.adoptAgentDefaults();
     void this.updateComplete.then(() => {
       this.querySelector<HTMLTextAreaElement>(".new-session-page__message")?.focus();
@@ -771,7 +767,6 @@ class NewSessionPage extends OpenClawLightDomElement {
     this.error = null;
     // Retire hidden pickers before their late requests can mutate this submitted draft.
     this.closeBrowser();
-    this.closeAgentPopover();
     for (const dropdown of this.querySelectorAll<HTMLElement & { open: boolean }>(
       "wa-dropdown[open]",
     )) {
@@ -1113,16 +1108,6 @@ class NewSessionPage extends OpenClawLightDomElement {
     }
   }
 
-  private closeAgentPopover() {
-    this.agentPopoverOpen = false;
-    const popover = this.querySelector<HTMLElement & { open: boolean }>(
-      ".new-session-page__agent-popover",
-    );
-    if (popover) {
-      popover.open = false;
-    }
-  }
-
   private guardPopoverTransition(event: Event, hiding: boolean) {
     if (!hiding) {
       return;
@@ -1233,17 +1218,6 @@ class NewSessionPage extends OpenClawLightDomElement {
       agents,
       agentId: this.agentId,
       disabled: this.submitting || Boolean(this.pendingCloud.sessionKey),
-      popoverOpen: this.agentPopoverOpen,
-      popoverHiding: this.agentPopoverHiding,
-      onGuardTransition: (event) => this.guardPopoverTransition(event, this.agentPopoverHiding),
-      onPopoverOpenChange: (open) => {
-        this.agentPopoverOpen = open;
-      },
-      onPopoverHidingChange: (hiding) => {
-        this.agentPopoverHiding = hiding;
-      },
-      onRestoreTrigger: () =>
-        this.restorePopoverTrigger("new-session-agent-trigger", ".new-session-page__agent-popover"),
       onSelect: (agentId) => this.selectAgentId(agentId),
     });
   }

--- a/ui/src/pages/new-session/new-session-page.ts
+++ b/ui/src/pages/new-session/new-session-page.ts
@@ -473,6 +473,7 @@ class NewSessionPage extends OpenClawLightDomElement {
     }
     this.error = null;
     this.placePopoverHiding = false;
+    this.closeAgentDropdown();
     this.closeBrowser();
     this.adoptAgentDefaults();
     void this.updateComplete.then(() => {
@@ -1090,6 +1091,15 @@ class NewSessionPage extends OpenClawLightDomElement {
 
   private browseAvailable(): boolean {
     return this.isAdmin();
+  }
+
+  private closeAgentDropdown() {
+    const dropdown = this.querySelector<HTMLElement & { open: boolean }>(
+      ".new-session-page__select--agent wa-dropdown",
+    );
+    if (dropdown) {
+      dropdown.open = false;
+    }
   }
 
   private closeBrowser() {

--- a/ui/src/pages/new-session/target-controls.ts
+++ b/ui/src/pages/new-session/target-controls.ts
@@ -1,83 +1,33 @@
 import { html } from "lit";
-import { icons } from "../../components/icons.ts";
+import type { GatewayAgentRow } from "../../api/types.ts";
+import "../../components/agent-select-registration.ts";
 import { t } from "../../i18n/index.ts";
+import { normalizeAgentLabel } from "../../lib/agents/display.ts";
 import { normalizeAgentId } from "../../lib/sessions/session-key.ts";
-import { renderSessionMenuItem } from "./cloud-target.ts";
 
-type DraftAgent = {
-  id: string;
-  name?: string;
-  identity?: { name?: string };
-};
-
-function agentDisplayName(agent: DraftAgent): string {
-  return agent.identity?.name ?? agent.name ?? agent.id;
-}
+type DraftAgent = GatewayAgentRow;
 
 export function renderAgentSelect(params: {
   agents: DraftAgent[];
   agentId: string;
   disabled: boolean;
-  popoverOpen: boolean;
-  popoverHiding: boolean;
-  onGuardTransition: (event: MouseEvent) => void;
-  onPopoverOpenChange: (open: boolean) => void;
-  onPopoverHidingChange: (hiding: boolean) => void;
-  onRestoreTrigger: () => void;
   onSelect: (agentId: string) => void;
 }) {
   const selectedId = normalizeAgentId(params.agentId);
-  const active = params.agents.find((agent) => normalizeAgentId(agent.id) === selectedId);
-  const activeLabel = active ? agentDisplayName(active) : params.agentId;
   return html`
-    <span class="new-session-page__select">
-      <button
-        id="new-session-agent-trigger"
-        type="button"
-        class="new-session-page__trigger ${params.popoverHiding
-          ? "new-session-page__trigger--hiding"
-          : ""}"
-        title=${t("newSession.agent")}
-        aria-label="${t("newSession.agent")}: ${activeLabel}"
-        aria-haspopup="dialog"
-        aria-expanded=${String(params.popoverOpen)}
-        ?disabled=${params.disabled}
-        @click=${params.onGuardTransition}
-      >
-        <span class="new-session-page__target-icon" aria-hidden="true">${icons.bot}</span>
-        <span class="new-session-page__trigger-label">${activeLabel}</span>
-        <span class="new-session-page__trigger-chevron" aria-hidden="true"
-          >${icons.chevronDown}</span
-        >
-      </button>
+    <span class="new-session-page__select new-session-page__select--agent">
+      <openclaw-agent-select
+        class="agent-select--compact"
+        .options=${params.agents.map((agent) => ({
+          value: normalizeAgentId(agent.id),
+          label: normalizeAgentLabel(agent),
+          agent,
+        }))}
+        .value=${selectedId}
+        .accessibleLabel=${t("newSession.agent")}
+        .disabled=${params.disabled}
+        .onSelect=${params.onSelect}
+      ></openclaw-agent-select>
     </span>
-    <wa-popover
-      class="new-session-page__select new-session-page__agent-popover"
-      for="new-session-agent-trigger"
-      placement="bottom-start"
-      without-arrow
-      @wa-show=${() => params.onPopoverOpenChange(true)}
-      @wa-hide=${() => {
-        params.onPopoverOpenChange(false);
-        params.onPopoverHidingChange(true);
-      }}
-      @wa-after-hide=${() => {
-        params.onPopoverHidingChange(false);
-        params.onRestoreTrigger();
-      }}
-    >
-      <div class="new-session-page__menu-title">${t("newSession.agent")}</div>
-      ${params.agents.map((option) =>
-        renderSessionMenuItem(
-          {
-            value: normalizeAgentId(option.id),
-            label: agentDisplayName(option),
-            checked: normalizeAgentId(option.id) === selectedId,
-            onSelect: () => params.onSelect(normalizeAgentId(option.id)),
-          },
-          params.disabled,
-        ),
-      )}
-    </wa-popover>
   `;
 }

--- a/ui/src/pages/nodes/view-exec-approvals.ts
+++ b/ui/src/pages/nodes/view-exec-approvals.ts
@@ -1,10 +1,11 @@
 // Control UI view renders nodes exec approvals screen content.
 import { html, nothing } from "lit";
+import "../../components/agent-select-registration.ts";
+import { icons } from "../../components/icons.ts";
 import {
   renderSettingsEmpty,
   renderSettingsRow,
   renderSettingsSection,
-  renderSettingsSegmented,
   renderSettingsToggle,
   renderSettingsValue,
 } from "../../components/settings-ui.ts";
@@ -349,20 +350,31 @@ function renderExecApprovalsTarget(state: ExecApprovalsState) {
 
 function renderExecApprovalsScope(state: ExecApprovalsState) {
   const options = [
-    { value: EXEC_APPROVALS_DEFAULT_SCOPE, label: t("nodes.execApprovals.defaults") },
+    {
+      value: EXEC_APPROVALS_DEFAULT_SCOPE,
+      label: t("nodes.execApprovals.defaults"),
+      icon: icons.settings,
+    },
     ...state.agents.map((agent) => ({
       value: agent.id,
       label: agent.name?.trim() ? `${agent.name} (${agent.id})` : agent.id,
+      agent: { id: agent.id, ...(agent.name ? { name: agent.name } : {}) },
+      badge: agent.isDefault ? t("agents.default") : undefined,
     })),
   ];
   return renderSettingsRow({
     title: t("nodes.execApprovals.scope"),
     stacked: true,
-    control: renderSettingsSegmented({
-      value: state.selectedScope,
-      options,
-      onChange: (value) => state.onSelectScope(value),
-    }),
+    control: html`
+      <openclaw-agent-select
+        class="agent-select--settings"
+        .options=${options}
+        .value=${state.selectedScope}
+        .accessibleLabel=${t("nodes.execApprovals.scope")}
+        .disabled=${state.disabled}
+        .onSelect=${state.onSelectScope}
+      ></openclaw-agent-select>
+    `,
   });
 }
 

--- a/ui/src/pages/nodes/view.devices.test.ts
+++ b/ui/src/pages/nodes/view.devices.test.ts
@@ -1,7 +1,7 @@
 /* @vitest-environment jsdom */
 import { expectDefined } from "@openclaw/normalization-core";
 import { render } from "lit";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { InventoryRemovalRequest } from "../../lib/nodes/index.ts";
 import { getRenderedModalDialog } from "../../test-helpers/modal-dialog.ts";
 import { renderNodes } from "./view.ts";
@@ -630,6 +630,46 @@ describe("nodes inventory rendering", () => {
 });
 
 describe("nodes exec approvals rendering", () => {
+  it("renders defaults, configured agents, and approval-only agents in the avatar picker", async () => {
+    const onExecApprovalsSelectAgent = vi.fn();
+    const container = renderNodesContainer({
+      configForm: {
+        agents: {
+          list: [
+            { id: "main", name: "Main", default: true },
+            { id: "research", name: "Research" },
+          ],
+        },
+      },
+      execApprovalsForm: {
+        version: 1,
+        defaults: { security: "deny" },
+        agents: { retired: { security: "full" } },
+      },
+      execApprovalsSelectedAgent: "research",
+      onExecApprovalsSelectAgent,
+    });
+    const section = getSection(container, "Exec approvals");
+    const picker = section.querySelector<
+      HTMLElement & {
+        options: Array<{ value: string; badge?: string }>;
+        onSelect: (value: string) => void;
+        updateComplete: Promise<boolean>;
+      }
+    >("openclaw-agent-select");
+    await picker?.updateComplete;
+
+    expect(picker?.options.map((option) => option.value)).toEqual([
+      "__defaults__",
+      "main",
+      "research",
+      "retired",
+    ]);
+    expect(picker?.options.find((option) => option.value === "main")?.badge).toBe("Default");
+    picker?.onSelect("retired");
+    expect(onExecApprovalsSelectAgent).toHaveBeenCalledWith("retired");
+  });
+
   it("renders host-native Windows policies as read-only", () => {
     const container = renderNodesContainer({
       nodes: [

--- a/ui/src/pages/skills/view.test.ts
+++ b/ui/src/pages/skills/view.test.ts
@@ -4,6 +4,7 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { render } from "lit";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AgentsListResult, SkillStatusEntry, SkillStatusReport } from "../../api/types.ts";
+import { i18n } from "../../i18n/index.ts";
 import { getRenderedModalDialog } from "../../test-helpers/modal-dialog.ts";
 import { renderSkills } from "./view.ts";
 
@@ -115,11 +116,12 @@ function createProps(overrides: Partial<SkillsProps> = {}): SkillsProps {
 }
 
 describe("renderSkills", () => {
-  afterEach(() => {
+  afterEach(async () => {
     vi.restoreAllMocks();
     while (dialogRestores.length > 0) {
       dialogRestores.pop()?.();
     }
+    await i18n.setLocale("en");
   });
 
   it("renders the agent selector and routes agent changes", async () => {
@@ -139,22 +141,55 @@ describe("renderSkills", () => {
     );
     await Promise.resolve();
 
-    const selector = container.querySelector<HTMLSelectElement>('select[name="skills-agent"]');
+    const selector = container.querySelector<
+      HTMLElement & {
+        options: Array<{ value: string; label: string; badge?: string }>;
+        value: string;
+        onSelect: (value: string) => void;
+        updateComplete: Promise<boolean>;
+      }
+    >('openclaw-agent-select[name="skills-agent"]');
     const filter = container.querySelector<HTMLInputElement>('input[name="skills-filter"]');
-    expect(selector).toBeInstanceOf(HTMLSelectElement);
+    expect(selector).toBeInstanceOf(HTMLElement);
     expect(filter).toBeInstanceOf(HTMLInputElement);
-    expect(normalizeText(selector!.closest("label")!)).toContain("Agent");
+    await selector?.updateComplete;
+    expect(normalizeText(selector!.closest(".plugins-field")!)).toContain("Agent");
     expect(normalizeText(filter!.closest("label")!)).toContain("Search");
     expect(selector?.value).toBe("research");
-    expect(Array.from(selector!.options).map((option) => option.textContent?.trim())).toEqual([
-      "Main (default)",
-      "Research",
+    expect(selector?.options.map((option) => [option.label, option.badge])).toEqual([
+      ["Main (default)", undefined],
+      ["Research", undefined],
     ]);
+    expect(
+      selector?.querySelector(".agent-select__avatar--text")?.getAttribute("data-avatar"),
+    ).toBe("R");
 
-    selector!.value = "main";
-    selector!.dispatchEvent(new Event("change", { bubbles: true }));
+    selector?.onSelect("main");
 
     expect(onAgentChange).toHaveBeenCalledWith("main");
+  });
+
+  it("localizes the default-agent label", async () => {
+    await i18n.setLocale("de");
+    const container = document.createElement("div");
+    document.body.append(container);
+    dialogRestores.push(() => container.remove());
+
+    render(renderSkills(createProps()), container);
+    const selector = container.querySelector<
+      HTMLElement & {
+        options: Array<{ value: string; label: string }>;
+        updateComplete: Promise<boolean>;
+      }
+    >('openclaw-agent-select[name="skills-agent"]');
+    await selector?.updateComplete;
+
+    expect(selector?.options.find((option) => option.value === "main")?.label).toBe(
+      "Main (Standard)",
+    );
+    expect(selector?.querySelector(".agent-select__trigger")?.getAttribute("aria-label")).toContain(
+      "Standard",
+    );
   });
 
   it("renders skill groups as open collapsible sections with heading summaries", async () => {
@@ -219,7 +254,9 @@ describe("renderSkills", () => {
     await Promise.resolve();
 
     expect(
-      container.querySelector<HTMLSelectElement>('select[name="skills-agent"]')?.disabled,
+      container.querySelector<HTMLElement & { disabled: boolean }>(
+        'openclaw-agent-select[name="skills-agent"]',
+      )?.disabled,
     ).toBe(true);
     const refresh = Array.from(container.querySelectorAll<HTMLButtonElement>("button")).find(
       (button) => button.textContent?.trim() === "Refresh",

--- a/ui/src/pages/skills/view.ts
+++ b/ui/src/pages/skills/view.ts
@@ -7,6 +7,7 @@ import { html, nothing, type TemplateResult } from "lit";
 import { repeat } from "lit/directives/repeat.js";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import type { AgentsListResult, SkillStatusEntry, SkillStatusReport } from "../../api/types.ts";
+import "../../components/agent-select-registration.ts";
 import { icons } from "../../components/icons.ts";
 import { toSanitizedMarkdownHtml } from "../../components/markdown.ts";
 import "../../components/modal-dialog.ts";
@@ -20,7 +21,7 @@ import {
   renderSettingsValue,
 } from "../../components/settings-ui.ts";
 import { t } from "../../i18n/index.ts";
-import { listSelectableAgents } from "../../lib/agents/display.ts";
+import { listSelectableAgents, normalizeAgentLabel } from "../../lib/agents/display.ts";
 import { clampText } from "../../lib/format.ts";
 import { resolveSafeExternalUrl } from "../../lib/open-external-url.ts";
 import { groupSkills, type SkillGroup } from "../../lib/skills-grouping.ts";
@@ -204,13 +205,6 @@ function verdictStatusKind(
   return status === "pending" || status === "not-run" ? "muted" : "warn";
 }
 
-type SkillsAgentOption = AgentsListResult["agents"][number];
-
-function agentOptionLabel(agent: SkillsAgentOption, defaultId: string | undefined): string {
-  const baseName = agent.identity?.name?.trim() || agent.name?.trim() || agent.id;
-  return agent.id === defaultId ? t("skillsPage.defaultAgent", { name: baseName }) : baseName;
-}
-
 function skillControlsLocked(props: SkillsProps): boolean {
   return props.loading || props.operation !== null;
 }
@@ -331,24 +325,28 @@ function renderSkillsToolbar(
       })}
       ${agents.length > 0
         ? html`
-            <label class="plugins-field skills-toolbar__agent">
+            <div class="plugins-field skills-toolbar__agent">
               <span>${t("usage.filters.agent")}</span>
-              <select
+              <openclaw-agent-select
+                class="agent-select--settings"
                 name="skills-agent"
-                class="settings-select"
+                .options=${agents.map((agent) => {
+                  const label = normalizeAgentLabel(agent);
+                  return {
+                    value: agent.id,
+                    label:
+                      agent.id === props.agentsList?.defaultId
+                        ? t("skillsPage.defaultAgent", { name: label })
+                        : label,
+                    agent,
+                  };
+                })}
                 .value=${selectedAgentId}
-                ?disabled=${skillControlsLocked(props) || !props.connected || agents.length < 2}
-                @change=${(e: Event) => props.onAgentChange((e.target as HTMLSelectElement).value)}
-              >
-                ${agents.map(
-                  (agent) => html`
-                    <option value=${agent.id} ?selected=${agent.id === selectedAgentId}>
-                      ${agentOptionLabel(agent, props.agentsList?.defaultId)}
-                    </option>
-                  `,
-                )}
-              </select>
-            </label>
+                .accessibleLabel=${t("usage.filters.agent")}
+                .disabled=${skillControlsLocked(props) || !props.connected || agents.length < 2}
+                .onSelect=${props.onAgentChange}
+              ></openclaw-agent-select>
+            </div>
           `
         : nothing}
       <label class="plugins-field skills-toolbar__search">

--- a/ui/src/pages/workboard/view.test.ts
+++ b/ui/src/pages/workboard/view.test.ts
@@ -55,6 +55,15 @@ function changeWorkboardSelect(select: Element | null | undefined, value: string
   control.dispatchEvent(new Event("change", { bubbles: true }));
 }
 
+function selectWorkboardAgent(select: Element | null | undefined, value: string) {
+  const control = select as
+    | (HTMLElement & { onSelect: (value: string) => void })
+    | null
+    | undefined;
+  expect(control).not.toBeNull();
+  control?.onSelect(value);
+}
+
 describe("renderWorkboard", () => {
   it("shows a card dashboard only for linked cards while the plugin is active", () => {
     const host = {};
@@ -1053,11 +1062,17 @@ describe("renderWorkboard", () => {
     );
 
     const toolbarFilters = container.querySelector(".workboard-toolbar__filters");
-    expect(toolbarFilters?.querySelectorAll(".workboard-select--toolbar")).toHaveLength(3);
+    expect(toolbarFilters?.querySelectorAll(".workboard-select--toolbar")).toHaveLength(2);
     expect(toolbarFilters?.querySelectorAll("select")).toHaveLength(0);
     expect(toolbarFilters?.textContent).toContain("All cards");
     expect(toolbarFilters?.textContent).toContain("All priorities");
-    expect(toolbarFilters?.textContent).toContain("All agents");
+    expect(
+      toolbarFilters
+        ?.querySelector<HTMLElement & { options: Array<{ label: string }> }>(
+          ".workboard-agent-select--toolbar",
+        )
+        ?.options.map((option) => option.label),
+    ).toContain("All agents");
     const priorityFilter = toolbarFilters?.querySelectorAll(".workboard-select--toolbar").item(1);
     expect(priorityFilter?.textContent).toContain("Low");
     expect(priorityFilter?.textContent).toContain("Normal");
@@ -1121,7 +1136,7 @@ describe("renderWorkboard", () => {
     expect(container.querySelectorAll(".workboard-select--toolbar")).toHaveLength(2);
   });
 
-  it("uses labelled Web Awesome selects for Workboard filters", () => {
+  it("uses labelled controls for Workboard filters", () => {
     const host = {};
     const state = getWorkboardState(host);
     state.loaded = true;
@@ -1145,13 +1160,17 @@ describe("renderWorkboard", () => {
         ".workboard-toolbar__filters > wa-select",
       ),
     ];
-    expect(selects).toHaveLength(3);
+    expect(selects).toHaveLength(2);
     expect(selects.map((select) => select.getAttribute("label"))).toEqual([
       "Workboard view",
       "All priorities",
-      "Filter by agent",
     ]);
-    expect(selects.map((select) => select.getAttribute("value"))).toEqual(["all", "all", "all"]);
+    expect(selects.map((select) => select.getAttribute("value"))).toEqual(["all", "all"]);
+    const agentSelect = container.querySelector<
+      HTMLElement & { accessibleLabel: string; value: string }
+    >(".workboard-agent-select--toolbar");
+    expect(agentSelect?.accessibleLabel).toBe("Filter by agent");
+    expect(agentSelect?.value).toBe("all");
     expect(container.querySelector(".workboard-select__trigger")).toBeNull();
   });
 
@@ -2841,12 +2860,18 @@ describe("renderWorkboard", () => {
       container,
     );
 
-    const agentFilter = container.querySelector(".workboard-select--toolbar-agent");
-    expect(agentFilter?.textContent).toContain("Main (default)");
-    expect(agentFilter?.textContent).toContain("Unassigned (uses Main)");
-    expect(agentFilter?.textContent).toContain("workboard-dispatcher (not configured)");
+    const agentFilter = container.querySelector<
+      HTMLElement & { options: Array<{ label: string }>; value: string }
+    >(".workboard-agent-select--toolbar");
+    expect(agentFilter?.options.map((option) => option.label)).toEqual([
+      "All agents",
+      "Unassigned (uses Main)",
+      "Main (default)",
+      "Ops",
+      "workboard-dispatcher (not configured)",
+    ]);
 
-    changeWorkboardSelect(agentFilter, "ops");
+    selectWorkboardAgent(agentFilter, "ops");
     render(
       renderWorkboard({
         host,
@@ -2870,12 +2895,13 @@ describe("renderWorkboard", () => {
 
     expect(container.textContent).not.toContain("Main work");
     expect(container.textContent).toContain("Ops work");
-    expect(container.querySelector(".workboard-select--toolbar-agent")?.textContent).toContain(
-      "Ops",
-    );
+    expect(
+      container.querySelector<HTMLElement & { value: string }>(".workboard-agent-select--toolbar")
+        ?.value,
+    ).toBe("ops");
 
-    changeWorkboardSelect(
-      container.querySelector(".workboard-select--toolbar-agent"),
+    selectWorkboardAgent(
+      container.querySelector(".workboard-agent-select--toolbar"),
       "workboard-dispatcher",
     );
     render(
@@ -2901,9 +2927,10 @@ describe("renderWorkboard", () => {
 
     expect(container.textContent).not.toContain("Ops work");
     expect(container.textContent).toContain("Dispatcher work");
-    expect(container.querySelector(".workboard-select--toolbar-agent")?.textContent).toContain(
-      "workboard-dispatcher (not configured)",
-    );
+    expect(
+      container.querySelector<HTMLElement & { value: string }>(".workboard-agent-select--toolbar")
+        ?.value,
+    ).toBe("workboard-dispatcher");
   });
 
   it("limits assignment choices to configured agents and preserves an unknown current assignee", () => {
@@ -2951,13 +2978,10 @@ describe("renderWorkboard", () => {
     );
 
     const draft = container.querySelector<HTMLElement>(".workboard-draft");
-    const agentSelect = [...(draft?.querySelectorAll<HTMLElement>(".workboard-select") ?? [])].at(
-      2,
+    const agentSelect = draft?.querySelector<HTMLElement & { options: Array<{ label: string }> }>(
+      ".workboard-agent-select",
     );
-    const optionLabels = [
-      ...(agentSelect?.querySelectorAll<HTMLButtonElement>(".workboard-select__option") ?? []),
-    ].map((option) => option.textContent?.trim());
-    expect(optionLabels).toEqual([
+    expect(agentSelect?.options.map((option) => option.label)).toEqual([
       "Unassigned (uses Main)",
       "Main (default)",
       "Ops",
@@ -3541,7 +3565,7 @@ describe("renderWorkboard", () => {
       ...(container
         .querySelector(".workboard-draft")
         ?.querySelectorAll<HTMLElement>(".workboard-select") ?? []),
-    ].at(3);
+    ].at(2);
     expect(sessionSelect?.getAttribute("value")).toBe("agent:main:archived-session");
     expect(
       sessionSelect?.querySelector('wa-option[value="agent:main:archived-session"]'),
@@ -3585,7 +3609,7 @@ describe("renderWorkboard", () => {
       ...(container
         .querySelector(".workboard-draft")
         ?.querySelectorAll<HTMLElement>(".workboard-select") ?? []),
-    ].at(3);
+    ].at(2);
     const labels = [...(sessionOptions?.querySelectorAll(".workboard-select__option") ?? [])].map(
       (option) => option.textContent?.trim(),
     );

--- a/ui/src/pages/workboard/view.ts
+++ b/ui/src/pages/workboard/view.ts
@@ -5,6 +5,7 @@ import { html, nothing, type TemplateResult } from "lit";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { AgentsListResult, GatewaySessionRow } from "../../api/types.ts";
 import { ensureCustomElementDefined } from "../../app/lazy-custom-element.ts";
+import "../../components/agent-select-registration.ts";
 import { icons } from "../../components/icons.ts";
 import "../../components/modal-dialog.ts";
 import "../../components/tooltip.ts";
@@ -830,9 +831,13 @@ function renderCardModal(props: WorkboardProps) {
   const priorityOptions: WorkboardSelectOption<WorkboardPriority>[] = WORKBOARD_PRIORITIES.map(
     (priority) => ({ value: priority, label: formatPriorityLabel(priority) }),
   );
-  const assignableAgentOptions: WorkboardSelectOption[] = agentOptions.map((agent) => ({
-    value: agent.id,
-    label: agent.label,
+  const assignableAgentOptions = agentOptions.map((option) => ({
+    value: option.id,
+    label: option.label,
+    agent: option.id
+      ? (props.agentsList?.agents.find((agent) => agent.id === option.id) ?? { id: option.id })
+      : undefined,
+    icon: option.id ? undefined : icons.bot,
   }));
   const sessionOptions: WorkboardSelectOption[] = [
     { value: "", label: t("workboard.noLinkedSession") },
@@ -996,16 +1001,20 @@ function renderCardModal(props: WorkboardProps) {
               requestUpdate: props.onRequestUpdate,
               disabled: draftActionsBusy,
             })}
-            ${renderWorkboardSelect({
-              value: state.draftAgentId,
-              options: assignableAgentOptions,
-              label: t("workboard.fieldAgent"),
-              onChange: (value) => {
-                state.draftAgentId = value;
-              },
-              requestUpdate: props.onRequestUpdate,
-              disabled: draftActionsBusy,
-            })}
+            <div class="workboard-field">
+              <span>${t("workboard.fieldAgent")}</span>
+              <openclaw-agent-select
+                class="workboard-agent-select"
+                .options=${assignableAgentOptions}
+                .value=${state.draftAgentId}
+                .accessibleLabel=${t("workboard.fieldAgent")}
+                .disabled=${draftActionsBusy}
+                .onSelect=${(value: string) => {
+                  state.draftAgentId = value;
+                  props.onRequestUpdate?.();
+                }}
+              ></openclaw-agent-select>
+            </div>
             ${renderWorkboardSelect({
               value: state.draftSessionKey,
               options: sessionOptions,
@@ -2097,16 +2106,16 @@ export function renderWorkboard(props: WorkboardProps) {
       label: formatPriorityLabel(priority),
     })),
   ];
-  const agentSelectOptions: WorkboardSelectOption[] = agentOptions.map((agent) => {
-    const option: WorkboardSelectOption = {
-      value: agent.id,
-      label: agent.label,
-    };
-    if (agent.description) {
-      option.description = agent.description;
-    }
-    return option;
-  });
+  const agentSelectOptions = agentOptions.map((option) => ({
+    value: option.id,
+    label: option.label,
+    description: option.description,
+    agent:
+      option.id === "all" || option.id === "default"
+        ? undefined
+        : (props.agentsList?.agents.find((agent) => agent.id === option.id) ?? { id: option.id }),
+    icon: option.id === "all" ? icons.users : option.id === "default" ? icons.bot : undefined,
+  }));
   const dialogOpen = state.draftOpen || Boolean(getVisibleDetailCard(state));
 
   return html`
@@ -2162,17 +2171,21 @@ export function renderWorkboard(props: WorkboardProps) {
                 })
               : nothing}
             ${props.showAgentFilter !== false
-              ? renderWorkboardSelect({
-                  value: state.agentFilter,
-                  options: agentSelectOptions,
-                  label: t("workboard.agentFilter"),
-                  onChange: (value) => {
-                    state.agentFilter = value;
-                  },
-                  requestUpdate: props.onRequestUpdate,
-                  className: "workboard-select--toolbar workboard-select--toolbar-agent",
-                  showLabel: false,
-                })
+              ? html`
+                  <openclaw-agent-select
+                    class="workboard-agent-select workboard-agent-select--toolbar"
+                    .options=${agentSelectOptions}
+                    .value=${state.agentFilter}
+                    .accessibleLabel=${t("workboard.agentFilter")}
+                    .onSelect=${(value: string) => {
+                      const option = agentOptions.find((candidate) => candidate.id === value);
+                      if (option) {
+                        state.agentFilter = option.id;
+                        props.onRequestUpdate?.();
+                      }
+                    }}
+                  ></openclaw-agent-select>
+                `
               : nothing}
             <button
               class="btn workboard-archive-toggle ${state.showArchived ? "active" : ""}"

--- a/ui/src/pages/workboard/workboard.e2e.test.ts
+++ b/ui/src/pages/workboard/workboard.e2e.test.ts
@@ -468,7 +468,10 @@ describeControlUiE2e("Control UI Workboard mocked Gateway E2E", () => {
           .evaluateAll(
             (inputs) => inputs.filter((input) => (input as HTMLInputElement).disabled).length,
           ),
-      ).toBe(4);
+      ).toBe(3);
+      expect(
+        await createForm.locator(".workboard-agent-select .agent-select__trigger").isDisabled(),
+      ).toBe(true);
       const pendingCancelButtons = createForm.getByRole("button", {
         name: "Cancel",
         exact: true,

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -3364,23 +3364,18 @@ td.data-table-key-col {
   white-space: nowrap;
 }
 
-.agent-scope-control__select {
+.agent-scope-control openclaw-agent-select {
   min-width: 150px;
   max-width: min(240px, 40vw);
-  height: 34px;
-  padding: 0 30px 0 12px;
-  border: 1px solid var(--border);
-  border-radius: 999px;
-  color: var(--text);
-  background: var(--bg-elevated);
-  font: inherit;
-  font-size: 12px;
-  font-weight: 600;
 }
 
-.agent-scope-control__select:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 2px;
+.agent-scope-control .agent-select__trigger {
+  min-height: 34px;
+  border-color: var(--border);
+  border-radius: var(--radius-full);
+  background: var(--bg-elevated);
+  font-size: 12px;
+  font-weight: 600;
 }
 
 @media (max-width: 640px) {
@@ -3388,7 +3383,7 @@ td.data-table-key-col {
     display: none;
   }
 
-  .agent-scope-control__select {
+  .agent-scope-control openclaw-agent-select {
     min-width: 128px;
     max-width: 44vw;
   }
@@ -3480,10 +3475,27 @@ td.data-table-key-col {
   object-fit: cover;
 }
 
-.agent-select__avatar--text {
+.agent-select__avatar--text,
+.agent-select__avatar--icon {
   background: var(--secondary);
+  color: var(--muted);
   font-size: 11px;
   font-weight: 600;
+}
+
+.agent-select__avatar--text::before {
+  content: attr(data-avatar);
+}
+
+.agent-select__avatar--icon svg,
+.agent-select__footer-icon svg {
+  width: 14px;
+  height: 14px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.7px;
+  stroke-linecap: round;
+  stroke-linejoin: round;
 }
 
 .agent-select__badge {
@@ -3510,12 +3522,35 @@ td.data-table-key-col {
   background: var(--border);
 }
 
-.agent-select__option-label {
+.agent-select__option-copy {
+  display: grid;
   flex: 1;
+  min-width: 0;
+  gap: 1px;
+}
+
+.agent-select__option-label {
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.agent-select__option-description {
+  overflow: hidden;
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 400;
+  line-height: 1.3;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agent-select__footer-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--muted);
 }
 
 .agent-select__option .agent-select__avatar {

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -3921,21 +3921,6 @@ wa-dropdown.sidebar-session-sort-menu::part(menu) {
   }
 }
 
-/* Kept for the agent-chip menu switcher rows (sessions list is single-agent now). */
-.sidebar-agent-section__avatar {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 20px;
-  height: 20px;
-  border-radius: 50%;
-  background: color-mix(in srgb, var(--accent-subtle) 80%, transparent);
-  color: var(--text-strong);
-  font-size: 11px;
-  font-weight: 600;
-  flex: none;
-}
-
 .sidebar-recent-session--draft {
   border: 1px dashed color-mix(in srgb, var(--accent) 55%, transparent);
   border-radius: 8px;

--- a/ui/src/styles/new-session.css
+++ b/ui/src/styles/new-session.css
@@ -73,6 +73,39 @@ openclaw-new-session-page {
   position: relative;
 }
 
+.new-session-page__select--agent openclaw-agent-select {
+  width: auto;
+  max-width: min(40vw, 260px);
+}
+
+.agent-select--compact .agent-select__trigger,
+:root[data-theme-mode="light"] .agent-select--compact .agent-select__trigger {
+  width: auto;
+  height: 26px;
+  padding: 0 10px;
+  border: 0;
+  border-radius: var(--radius-full);
+  background: transparent;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.agent-select--compact .agent-select__trigger:hover:not(:disabled),
+.agent-select--compact .agent-select__trigger[aria-expanded="true"] {
+  color: var(--text);
+  background: color-mix(in srgb, var(--bg-hover) 84%, transparent);
+}
+
+.agent-select--compact .agent-select__avatar {
+  width: 18px;
+  height: 18px;
+}
+
+.agent-select--compact .agent-select__label {
+  max-width: min(32vw, 220px);
+}
+
 .new-session-page__trigger {
   display: inline-flex;
   align-items: center;

--- a/ui/src/styles/workboard.css
+++ b/ui/src/styles/workboard.css
@@ -381,7 +381,7 @@
   max-width: 176px;
 }
 
-.workboard-select--toolbar-agent {
+.workboard-agent-select--toolbar {
   width: min(236px, 100%);
   max-width: 236px;
 }
@@ -391,6 +391,22 @@
   max-width: 224px;
 }
 
+.workboard-agent-select {
+  width: 100%;
+  min-width: 0;
+}
+
+.workboard-agent-select .agent-select__trigger {
+  min-height: var(--workboard-control-height);
+  border-color: var(--border);
+  border-radius: 7px;
+  background: var(--bg-elevated);
+  font-weight: 600;
+}
+
+.workboard-agent-select--toolbar .agent-select__trigger {
+  height: var(--workboard-control-height);
+}
 .workboard-select::part(form-control-label) {
   position: absolute;
   width: 1px;
@@ -1557,6 +1573,7 @@ openclaw-workboard-card-dashboard {
   .workboard-toolbar__filters .input[type="search"],
   .workboard-toolbar__filters .input,
   .workboard-select--toolbar,
+  .workboard-agent-select--toolbar,
   .workboard-draft__meta .input {
     width: 100%;
     max-width: none;

--- a/ui/src/test-helpers/app-sidebar-cases/agent-menu.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/agent-menu.ts
@@ -20,7 +20,16 @@ describe("AppSidebar agent chip", () => {
       gatewayHarness.gateway,
       createSessions("main", ["agent:main:main"]),
       "panel",
-      TWO_AGENTS,
+      {
+        ...TWO_AGENTS,
+        agents: [
+          { id: "main", identity: { name: "Molty", emoji: "🦞" } },
+          {
+            id: "research",
+            identity: { avatarUrl: "data:image/png;base64,eA==" },
+          },
+        ],
+      },
     );
     const onNavigate = vi.fn();
     sidebar.connected = true;
@@ -74,6 +83,12 @@ describe("AppSidebar agent chip", () => {
       ...(reopenedMenu?.querySelectorAll('wa-dropdown-item[type="checkbox"]') ?? []),
     ];
     expect(agentRows).toHaveLength(2);
+    expect(
+      reopenedMenu?.querySelector(".agent-select__avatar--text")?.getAttribute("data-avatar"),
+    ).toBe("🦞");
+    expect(
+      reopenedMenu?.querySelector<HTMLImageElement>("img.agent-select__avatar")?.src,
+    ).toContain("data:image/png;base64,eA==");
     expect(reopenedMenu?.querySelector(".sidebar-agent-menu__new")).toBeNull();
     const switchMenu = reopenedMenu;
     const researchRow = [
@@ -161,7 +176,7 @@ describe("AppSidebar agent chip", () => {
     const labels = () =>
       [
         ...sidebar.querySelectorAll(
-          ".sidebar-agent-menu wa-dropdown-item.sidebar-agent-menu__agent-switch .sidebar-customize-menu__text",
+          ".sidebar-agent-menu wa-dropdown-item.sidebar-agent-menu__agent-switch .agent-select__option-label",
         ),
       ].map((el) => el.textContent?.trim());
     expect(labels()).toEqual(["agent-7", "agent-12", "agent-1"]);


### PR DESCRIPTION
## What Problem This Solves

Agent selection was visually and behaviorally inconsistent across the Control UI. The Agents settings page already used a polished custom dropdown with avatars and names, while page scope, New Session, Skills, Memory Import, Workboard, and Exec Approvals still used native or one-off selectors.

## Why This Change Was Made

This introduces one reusable avatar-aware agent picker and migrates every closed Control UI agent-selection surface to it. Callers continue to own their domain values and side effects, including All agents, defaults, unassigned cards, and historical IDs. The sidebar keeps its larger switcher menu but reuses the same avatar and option presentation.

Cron's agent-ID field intentionally remains free-form because it supports arbitrary IDs rather than a closed roster.

The shared picker preserves authenticated avatar loading on Agents settings, uses safe roster avatar URLs elsewhere, keeps Web Awesome keyboard behavior, exposes radio semantics, restores focus on dismissal, supports localized default labels, handles missing historical values honestly, and prevents selection after a control becomes disabled.

## User Impact

Every closed web agent picker now shows a consistent avatar or icon beside the agent name. The menus retain their existing selection semantics while gaining consistent spacing, keyboard navigation, typeahead, accessibility labels, and disabled-state behavior.

## Evidence

- Focused Control UI unit coverage: 187 tests passed on Blacksmith Testbox.
- UI and core-test typecheck plus targeted UI lint passed on Blacksmith Testbox.
- New Session: 29 browser tests passed.
- Workboard: 3 browser tests passed.
- Usage cost analysis: browser test passed.
- Agent page scope and authenticated avatar timeout browser tests passed.
- Existing-Chrome live verification confirmed the custom menu renders avatar/icon + text rows and exposes menuitemradio semantics.
- Before/after screenshots are attached in the PR discussion.

Blacksmith evidence:
- https://github.com/openclaw/openclaw/actions/runs/29830690068
- https://github.com/openclaw/openclaw/actions/runs/29818008201
- https://github.com/openclaw/openclaw/actions/runs/29819258518
- https://github.com/openclaw/openclaw/actions/runs/29831407737

AI assistance: implementation and tests were produced with Claude Code, with mandatory Codex autoreview before commit.
