### PR TITLE
fix(gateway): resolve canonical media params on message.action dispatch

### DIFF
--- a/docs/channels/feishu.md
+++ b/docs/channels/feishu.md
@@ -712,6 +712,10 @@ resource payload.
 - ✅ Interactive cards (including streaming updates)
 - ⚠️ Rich text (post-style formatting; doesn't support full Feishu/Lark authoring capabilities)
 
+Feishu delivers one media item per message. A send declaring more than one
+attachment is rejected rather than silently delivering only the first, and
+`thread-reply` rejects media outright because it delivers text only.
+
 Native Feishu/Lark audio bubbles use the Feishu `audio` message type and require
 Ogg/Opus upload media (`file_type: "opus"`). Existing `.opus` and `.ogg` media
 is sent directly as native audio. MP3/WAV/M4A and other likely audio formats are

--- a/extensions/feishu/src/channel.test.ts
+++ b/extensions/feishu/src/channel.test.ts
@@ -960,7 +960,7 @@ describe("feishuPlugin actions", () => {
     ]);
   });
 
-  it("sends media through the outbound adapter", async () => {
+  it("sends core-normalized media through the outbound adapter", async () => {
     feishuOutboundSendMediaMock.mockResolvedValueOnce({
       channel: "feishu",
       messageId: "om_media",
@@ -973,6 +973,9 @@ describe("feishuPlugin actions", () => {
         to: "chat:oc_group_1",
         message: "test",
         media: "/tmp/image.png",
+        mediaUrl: "/tmp/image.png",
+        mediaUrls: ["/tmp/image.png"],
+        attachments: [{ media: "/tmp/image.png" }],
       },
       cfg,
       accountId: undefined,
@@ -990,6 +993,159 @@ describe("feishuPlugin actions", () => {
       replyToId: undefined,
     });
     expect(resultDetails(result).messageId).toBe("om_media");
+  });
+
+  it.each([
+    ["attachment", { path: "/tmp/script.py" }],
+    ["file", "/tmp/script.py"],
+  ] as const)("rejects unsupported Feishu attachment param %s", async (key, value) => {
+    await expect(
+      feishuPlugin.actions?.handleAction?.({
+        action: "send",
+        params: {
+          to: "chat:oc_group_1",
+          message: "see attached",
+          [key]: value,
+        },
+        cfg,
+        accountId: undefined,
+        toolContext: {},
+        mediaLocalRoots: ["/tmp"],
+      } as never),
+    ).rejects.toThrow(
+      `Feishu send supports media attachments through the media parameter; ${key} is not supported.`,
+    );
+
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+    expect(sendCardFeishuMock).not.toHaveBeenCalled();
+    expect(feishuOutboundSendMediaMock).not.toHaveBeenCalled();
+  });
+
+  // Core resolves its own alias chain into `media` before dispatch, so Feishu must not
+  // reject the aliases themselves; doing so regressed previously working sends.
+  it.each([
+    ["path", "/tmp/script.py"],
+    ["filePath", "/tmp/script.py"],
+    ["fileUrl", "file:///tmp/script.py"],
+    ["image", "/tmp/script.py"],
+    ["mediaUrl", "/tmp/script.py"],
+  ] as const)(
+    "accepts core-canonical media alias %s alongside normalized media",
+    async (key, value) => {
+      feishuOutboundSendMediaMock.mockResolvedValueOnce({
+        channel: "feishu",
+        messageId: "om_media",
+        chatId: "oc_group_1",
+      });
+
+      await feishuPlugin.actions?.handleAction?.({
+        action: "send",
+        params: {
+          to: "chat:oc_group_1",
+          message: "see attached",
+          media: "/tmp/script.py",
+          [key]: value,
+        },
+        cfg,
+        accountId: undefined,
+        toolContext: {},
+        mediaLocalRoots: ["/tmp"],
+      } as never);
+
+      expect(feishuOutboundSendMediaMock).toHaveBeenCalledOnce();
+      expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it("rejects multiple media attachments rather than dropping all but the first", async () => {
+    await expect(
+      feishuPlugin.actions?.handleAction?.({
+        action: "send",
+        params: {
+          to: "chat:oc_group_1",
+          message: "see attached",
+          media: "/tmp/first.py",
+          mediaUrls: ["/tmp/first.py", "/tmp/second.py"],
+        },
+        cfg,
+        accountId: undefined,
+        toolContext: {},
+        mediaLocalRoots: ["/tmp"],
+      } as never),
+    ).rejects.toThrow("Feishu send supports a single media attachment.");
+
+    expect(feishuOutboundSendMediaMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects media on thread replies instead of delivering text only", async () => {
+    await expect(
+      feishuPlugin.actions?.handleAction?.({
+        action: "thread-reply",
+        params: {
+          to: "chat:oc_group_1",
+          messageId: "om_parent",
+          message: "see attached",
+          attachments: [{ media: "/tmp/script.py" }],
+        },
+        cfg,
+        accountId: undefined,
+        toolContext: {},
+        mediaLocalRoots: ["/tmp"],
+      } as never),
+    ).rejects.toThrow(
+      "Feishu thread-reply does not support media attachments; attachments is not supported.",
+    );
+
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+    expect(feishuOutboundSendMediaMock).not.toHaveBeenCalled();
+  });
+
+  it("ignores empty optional attachment defaults", async () => {
+    sendMessageFeishuMock.mockResolvedValueOnce({ messageId: "om_sent", chatId: "oc_group_1" });
+
+    await feishuPlugin.actions?.handleAction?.({
+      action: "send",
+      params: {
+        to: "chat:oc_group_1",
+        message: "hello",
+        attachment: {},
+        attachments: [],
+        buffer: "",
+        file: null,
+        filename: "",
+        mediaUrls: [],
+      },
+      cfg,
+      accountId: undefined,
+      toolContext: {},
+    } as never);
+
+    expect(sendMessageFeishuMock).toHaveBeenCalledOnce();
+    expect(feishuOutboundSendMediaMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["blank string", "   "],
+    ["object", { path: "/tmp/script.py" }],
+  ] as const)("rejects invalid Feishu media param %s", async (_name, media) => {
+    await expect(
+      feishuPlugin.actions?.handleAction?.({
+        action: "send",
+        params: {
+          to: "chat:oc_group_1",
+          message: "see attached",
+          media,
+        },
+        cfg,
+        accountId: undefined,
+        toolContext: {},
+        mediaLocalRoots: ["/tmp"],
+      } as never),
+    ).rejects.toThrow("Feishu send media must be a non-empty string.");
+
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+    expect(sendCardFeishuMock).not.toHaveBeenCalled();
+    expect(feishuOutboundSendMediaMock).not.toHaveBeenCalled();
   });
 
   it("passes asVoice through media sends", async () => {

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -112,12 +112,92 @@ import { feishuSetupWizard, runFeishuLogin } from "./setup-surface.js";
 import { looksLikeFeishuId, normalizeFeishuTarget } from "./targets.js";
 import type { FeishuConfig, FeishuProbeResult, ResolvedFeishuAccount } from "./types.js";
 
-function readFeishuMediaParam(params: Record<string, unknown>): string | undefined {
-  const media = params.media;
-  if (typeof media !== "string") {
+/**
+ * Media sources core never resolves into `media`. Core folds its own aliases (`media`,
+ * `path`, `filePath`, `mediaUrl`, `fileUrl`, `image`, `mediaUrls`, `attachments[]`, and the
+ * snake_case spelling of each) into `media` before dispatch, so those arrive here already
+ * resolved. These two have no such handling and would be dropped without telling the caller.
+ */
+const FEISHU_UNRECOGNIZED_MEDIA_SOURCE_PARAM_NAMES = ["attachment", "file"] as const;
+
+/**
+ * Every spelling a caller can use to declare media. Core resolves the recognized ones into
+ * `media` for `send`, but no dispatch path does so for `thread-reply`, so a thread reply
+ * carrying any of these would deliver text only.
+ */
+const FEISHU_MEDIA_SOURCE_PARAM_NAMES = [
+  ...FEISHU_UNRECOGNIZED_MEDIA_SOURCE_PARAM_NAMES,
+  "attachments",
+  "file_path",
+  "file_url",
+  "filePath",
+  "fileUrl",
+  "image",
+  "media",
+  "media_url",
+  "media_urls",
+  "mediaUrl",
+  "mediaUrls",
+  "path",
+] as const;
+
+function hasFeishuAttachmentIntent(
+  params: Readonly<Record<string, unknown>>,
+  key: string,
+): boolean {
+  if (!Object.hasOwn(params, key)) {
+    return false;
+  }
+  const value = params[key];
+  if (typeof value === "string") {
+    return Boolean(value.trim());
+  }
+  if (Array.isArray(value)) {
+    return value.length > 0;
+  }
+  if (value && typeof value === "object") {
+    return Object.keys(value).length > 0;
+  }
+  return Boolean(value);
+}
+
+function readFeishuMediaParam(
+  params: Readonly<Record<string, unknown>>,
+  action: "send" | "thread-reply",
+): string | undefined {
+  if (action === "thread-reply") {
+    const declaredMedia = FEISHU_MEDIA_SOURCE_PARAM_NAMES.find((key) =>
+      hasFeishuAttachmentIntent(params, key),
+    );
+    if (declaredMedia) {
+      throw new Error(
+        `Feishu thread-reply does not support media attachments; ${declaredMedia} is not supported.`,
+      );
+    }
     return undefined;
   }
-  return media.trim() ? media : undefined;
+  const unsupportedParam = FEISHU_UNRECOGNIZED_MEDIA_SOURCE_PARAM_NAMES.find((key) =>
+    hasFeishuAttachmentIntent(params, key),
+  );
+  if (unsupportedParam) {
+    throw new Error(
+      `Feishu send supports media attachments through the media parameter; ${unsupportedParam} is not supported.`,
+    );
+  }
+  const media = params.media;
+  const normalizedMedia = typeof media === "string" && media.trim() ? media : undefined;
+  // Feishu delivers a single media item per message; a second one would be dropped silently.
+  const mediaUrls = params.mediaUrls;
+  if (Array.isArray(mediaUrls) && mediaUrls.length > 1) {
+    throw new Error("Feishu send supports a single media attachment.");
+  }
+  if (media !== undefined) {
+    if (normalizedMedia) {
+      return normalizedMedia;
+    }
+    throw new Error("Feishu send media must be a non-empty string.");
+  }
+  return undefined;
 }
 
 function readBooleanParam(params: Record<string, unknown>, keys: string[]): boolean | undefined {
@@ -1084,7 +1164,7 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
             const presentation =
               normalizeMessagePresentation(ctx.params.presentation) ??
               (interactive ? legacyInteractiveReplyToPresentation(interactive) : undefined);
-            const mediaUrl = readFeishuMediaParam(ctx.params);
+            const mediaUrl = readFeishuMediaParam(ctx.params, ctx.action);
             const audioAsVoice = readBooleanParam(ctx.params, ["asVoice", "audioAsVoice"]);
             if (textCard && !presentation) {
               assertFeishuCardWithinEnvelope(textCard, "Feishu native card");

--- a/src/gateway/server-methods/send.test.ts
+++ b/src/gateway/server-methods/send.test.ts
@@ -2005,6 +2005,60 @@ describe("gateway send mirroring", () => {
     );
   });
 
+  // Gateway dispatch does not run the outbound runner's send payload build, so without an
+  // explicit resolve step a canonical attachment reaches the adapter with no `media` set and
+  // is silently dropped as a text-only send. Regression guard for that resolve call.
+  it("resolves canonical attachments into media before dispatching message action sends", async () => {
+    const sendPlugin: ChannelPlugin = {
+      id: "whatsapp",
+      meta: {
+        id: "whatsapp",
+        label: "WhatsApp",
+        selectionLabel: "WhatsApp",
+        docsPath: "/channels/whatsapp",
+        blurb: "WhatsApp send dispatch test plugin.",
+      },
+      capabilities: { chatTypes: ["direct"], media: true },
+      config: {
+        listAccountIds: () => ["default"],
+        resolveAccount: () => ({ enabled: true }),
+        isConfigured: () => true,
+      },
+      actions: {
+        describeMessageTool: () => ({ actions: ["send"] }),
+        supportsAction: ({ action }) => action === "send",
+        handleAction: async () => jsonResult({ ok: true }),
+      },
+    };
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "whatsapp", source: "test", plugin: sendPlugin }]),
+      "send-test-attachment-resolve",
+    );
+
+    await runMessageActionRequest({
+      channel: "whatsapp",
+      action: "send",
+      idempotencyKey: "message-action-attachment-resolve",
+      params: {
+        target: "user:15551234567",
+        message: "see attached",
+        attachments: [{ media: "/tmp/script.py" }],
+      },
+      requesterAccountId: "default",
+      sessionKey: "agent:main:whatsapp:direct:15551234567",
+      agentId: "main",
+    });
+
+    expect(mocks.dispatchChannelMessageAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: expect.objectContaining({
+          media: "/tmp/script.py",
+          mediaUrls: ["/tmp/script.py"],
+        }),
+      }),
+    );
+  });
+
   it("strips current-turn context from unauthenticated message action callers", async () => {
     mocks.getChannelPlugin.mockReturnValue({
       actions: {

--- a/src/gateway/server-methods/send.ts
+++ b/src/gateway/server-methods/send.ts
@@ -40,6 +40,7 @@ import {
   createOutboundPayloadPlan,
   projectOutboundPayloadPlanForMirror,
 } from "../../infra/outbound/payloads.js";
+import { normalizeSendMediaParams } from "../../infra/outbound/send-media-sources.js";
 import { buildOutboundSessionContext } from "../../infra/outbound/session-context.js";
 import {
   beginTerminalSourceReplyDelivery,
@@ -552,6 +553,9 @@ export const sendHandlers: GatewayRequestHandlers = {
               mediaLocalRoots: getAgentScopedMediaLocalRoots(cfg, agentId),
             }),
           });
+          // Gateway dispatch does not run the outbound runner's send payload build, so
+          // resolve the canonical media alias chain here or channels never see the media.
+          normalizeSendMediaParams(request.params);
         }
         const sourceReplyMirror = {
           action: request.action,

--- a/src/infra/outbound/message-action-params.test.ts
+++ b/src/infra/outbound/message-action-params.test.ts
@@ -23,6 +23,7 @@ import {
   resolveExtraActionMediaSourceParamKeys,
   resolveAttachmentMediaPolicy,
 } from "./message-action-params.js";
+import { normalizeSendMediaParams } from "./send-media-sources.js";
 
 const cfg = {} as OpenClawConfig;
 const maybeIt = process.platform === "win32" ? it.skip : it;
@@ -498,6 +499,57 @@ describe("message action media helpers", () => {
       mediaPolicy: { mode: "host" },
     });
     expect(fileArgs.filename).toBe("report.pdf");
+  });
+
+  // Gateway `message.action` sends never reach the outbound runner's send payload build, so
+  // this is the only place canonical media sources become the `media` param adapters read.
+  // Without it the attachment reaches the adapter unresolved and is silently dropped.
+  it.each([
+    ["canonical attachments", { attachments: [{ media: "/tmp/script.py" }] }],
+    ["filePath alias", { filePath: "/tmp/script.py" }],
+    ["path alias", { path: "/tmp/script.py" }],
+    ["image alias", { image: "/tmp/script.py" }],
+    ["mediaUrls list", { mediaUrls: ["/tmp/script.py"] }],
+  ] as const)("resolves %s into the media param", (_label, source) => {
+    const args: Record<string, unknown> = { message: "hello", ...source };
+
+    normalizeSendMediaParams(args);
+
+    expect(args.media).toBe("/tmp/script.py");
+    expect(args.mediaUrls).toEqual(["/tmp/script.py"]);
+  });
+
+  it("keeps an explicit media param ahead of other canonical sources", () => {
+    const args: Record<string, unknown> = {
+      message: "hello",
+      media: "/tmp/explicit.py",
+      attachments: [{ media: "/tmp/attachment.py" }],
+    };
+
+    normalizeSendMediaParams(args);
+
+    expect(args.media).toBe("/tmp/explicit.py");
+  });
+
+  it("resolves every attachment so single-media channels can reject the extras", () => {
+    const args: Record<string, unknown> = {
+      message: "hello",
+      attachments: [{ media: "/tmp/first.py" }, { media: "/tmp/second.py" }],
+    };
+
+    normalizeSendMediaParams(args);
+
+    expect(args.media).toBe("/tmp/first.py");
+    expect(args.mediaUrls).toEqual(["/tmp/first.py", "/tmp/second.py"]);
+  });
+
+  it("leaves params untouched when no media source is present", () => {
+    const args: Record<string, unknown> = { message: "hello" };
+
+    normalizeSendMediaParams(args);
+
+    expect(args.media).toBeUndefined();
+    expect(args.mediaUrls).toBeUndefined();
   });
 
   it("uses only the leaf filename from Windows-style attachment hints", async () => {

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -111,6 +111,7 @@ import {
   materializeMessagePresentationFallback,
 } from "./outbound-send-service.js";
 import { ensureOutboundSessionEntry, resolveOutboundSessionRoute } from "./outbound-session.js";
+import { collectSendMediaSources } from "./send-media-sources.js";
 import {
   beginTerminalSourceReplyDelivery,
   cancelTerminalSourceReplyDelivery,
@@ -717,35 +718,6 @@ function applySendPayloadPartsToActionParams(
   applySendLocationToActionParams(actionParams, parts.payload.location);
 }
 
-function collectMessageAttachmentMediaHints(value: unknown): string[] {
-  if (!Array.isArray(value)) {
-    return [];
-  }
-  const mediaUrls: string[] = [];
-  const seen = new Set<string>();
-  const pushMedia = (entry: unknown) => {
-    const normalized = normalizeOptionalString(entry);
-    if (!normalized || seen.has(normalized)) {
-      return;
-    }
-    seen.add(normalized);
-    mediaUrls.push(normalized);
-  };
-  for (const attachment of value) {
-    if (!attachment || typeof attachment !== "object" || Array.isArray(attachment)) {
-      continue;
-    }
-    const record = attachment as Record<string, unknown>;
-    pushMedia(record.media);
-    pushMedia(record.mediaUrl);
-    pushMedia(record.path);
-    pushMedia(record.filePath);
-    pushMedia(record.fileUrl);
-    pushMedia(record.url);
-  }
-  return mediaUrls;
-}
-
 function hasExplicitSingularTargetParam(params: Record<string, unknown>): boolean {
   return readTrimmedStringAlias(params, ["target", "to", "channelId"]) !== undefined;
 }
@@ -1186,17 +1158,8 @@ async function buildSendPayloadParts(params: {
       }
     }
   }
-  const mediaHint =
-    readStringParam(actionParams, "media", { trim: false }) ??
-    readStringParam(actionParams, "mediaUrl", { trim: false }) ??
-    readStringParam(actionParams, "path", { trim: false }) ??
-    readStringParam(actionParams, "filePath", { trim: false }) ??
-    readStringParam(actionParams, "fileUrl", { trim: false }) ??
-    readStringParam(actionParams, "image", { trim: false });
-  const mediaUrlHints = readStringArrayParam(actionParams, "mediaUrls") ?? [];
-  const attachmentMediaHints = collectMessageAttachmentMediaHints(actionParams.attachments);
-  const hasMediaHint =
-    Boolean(mediaHint) || mediaUrlHints.length > 0 || attachmentMediaHints.length > 0;
+  const declaredMediaSources = collectSendMediaSources(actionParams);
+  const hasMediaHint = declaredMediaSources.length > 0;
   const hasPresentation = hasMessagePresentationBlocks(actionParams.presentation);
   const hasInteractive = hasLegacyInteractiveReplyBlocks(actionParams.interactive);
   const rawLocation = actionParams.location;
@@ -1224,23 +1187,7 @@ async function buildSendPayloadParts(params: {
     stripAudioTag: true,
     stripReplyTags: true,
   });
-  const mergedMediaUrls: string[] = [];
-  const seenMedia = new Set<string>();
-  const pushMedia = (value?: string | null) => {
-    const trimmed = normalizeOptionalString(value);
-    if (!trimmed || seenMedia.has(trimmed)) {
-      return;
-    }
-    seenMedia.add(trimmed);
-    mergedMediaUrls.push(trimmed);
-  };
-  pushMedia(mediaHint);
-  for (const mediaUrlHint of mediaUrlHints) {
-    pushMedia(mediaUrlHint);
-  }
-  for (const attachmentMediaHint of attachmentMediaHints) {
-    pushMedia(attachmentMediaHint);
-  }
+  const mergedMediaUrls: string[] = [...declaredMediaSources];
 
   const normalizedMediaUrls = await normalizeSandboxMediaList({
     values: mergedMediaUrls,

--- a/src/infra/outbound/send-media-sources.ts
+++ b/src/infra/outbound/send-media-sources.ts
@@ -1,0 +1,80 @@
+// Shared resolution of the media sources a send action declares, so the outbound runner
+// and gateway message.action dispatch cannot drift on which attachment gets delivered.
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { readStringArrayParam, readStringParam } from "../../agents/tools/common.js";
+
+const SEND_MEDIA_ALIAS_PARAM_KEYS = [
+  "media",
+  "mediaUrl",
+  "path",
+  "filePath",
+  "fileUrl",
+  "image",
+] as const;
+
+const STRUCTURED_ATTACHMENT_MEDIA_HINT_KEYS = [
+  "media",
+  "mediaUrl",
+  "path",
+  "filePath",
+  "fileUrl",
+  "url",
+] as const;
+
+/**
+ * Collect every media source a send action declares, in delivery order.
+ *
+ * The first alias wins for the primary media, then explicit `mediaUrls`, then each
+ * `attachments[]` entry. Callers own what they do with the result: the outbound runner
+ * sandbox-normalizes the list before assigning it, while gateway dispatch assigns directly.
+ */
+export function collectSendMediaSources(args: Record<string, unknown>): string[] {
+  const values: string[] = [];
+  const seen = new Set<string>();
+  const push = (value: unknown) => {
+    const normalized = normalizeOptionalString(value);
+    if (!normalized || seen.has(normalized)) {
+      return;
+    }
+    seen.add(normalized);
+    values.push(normalized);
+  };
+  for (const key of SEND_MEDIA_ALIAS_PARAM_KEYS) {
+    const alias = readStringParam(args, key, { trim: false });
+    if (alias) {
+      push(alias);
+      break;
+    }
+  }
+  readStringArrayParam(args, "mediaUrls")?.forEach(push);
+  const attachments = args.attachments;
+  if (Array.isArray(attachments)) {
+    for (const attachment of attachments) {
+      if (!isRecord(attachment)) {
+        continue;
+      }
+      for (const key of STRUCTURED_ATTACHMENT_MEDIA_HINT_KEYS) {
+        push(attachment[key]);
+      }
+    }
+  }
+  return values;
+}
+
+/**
+ * Resolve declared media sources into the top-level `media`/`mediaUrls` params.
+ *
+ * The outbound runner does this itself in `buildSendPayloadParts`, after sandbox
+ * normalization. Gateway `message.action` sends never reach that code, so without this a
+ * caller-supplied alias or attachment arrives at the channel adapter with no `media` set and
+ * is silently dropped. Gateway dispatch calls this to reach the same result.
+ */
+export function normalizeSendMediaParams(args: Record<string, unknown>): void {
+  const values = collectSendMediaSources(args);
+  if (values.length === 0) {
+    return;
+  }
+  args.media = values[0];
+  args.mediaUrls = [...values];
+}


### PR DESCRIPTION
## What Problem This Solves

Closes #112244.

A gateway `message.action` send carrying a canonical attachment was silently dropped and reported success:

```json
{"action":"send","channel":"feishu","message":"hello","attachments":[{"media":"/tmp/script.py"}]}
→ {"ok":true,"channel":"feishu","action":"send"}   // attachment never sent
```

The root cause is **not** channel-specific. There are two dispatch paths:

- **Outbound runner** — `buildSendPayloadParts` resolves the canonical media alias chain (`media` → `mediaUrl`/`path`/`filePath`/`fileUrl`/`image` → `mediaUrls` → `attachments[]`) into the `media` param adapters read.
- **Gateway `message.action`** — never reaches that code. `hydrateAttachmentParamsForAction` handles only `buffer` for `send` and returns early, then dispatch goes straight to the plugin.

So on the gateway path the adapter received `attachments` with no `media`, found nothing to send, and fell through to a text-only send. Feishu surfaced it first because it is the channel with a single-`media`-string transport, but any channel reading `media` has the same hole.

## Why This Change Was Made

Resolve the same chain on the gateway path, and give both paths **one** collector so their precedence cannot drift. `buildSendPayloadParts` now consumes `collectSendMediaSources`, and its duplicate `collectMessageAttachmentMediaHints` is deleted (runner is −57 lines).

Before unification the two paths genuinely disagreed: for `{path: A, mediaUrl: B}` the runner picked `B` and a naive gateway resolver picked `A`. One collector makes that class of bug unrepresentable.

Feishu additionally fails fast on what it cannot deliver, rather than dropping it:

- `file` and `attachment` — the only two media spellings core never resolves.
- More than one media item — Feishu delivers one per message; the second was dropped silently.
- Media on `thread-reply` — no dispatch path resolves media for that action, so it always delivered text only.

Deliberately **not** rejected: `path`, `filePath`, `mediaUrl`, `fileUrl`, `image`, `mediaUrls`, `attachments`, and their snake_case spellings. Core resolves all of these (`readStringParam` → `resolveSnakeCaseParamKey`), and blocking them would regress working sends. There is a regression test pinning `file_path`.

## User Impact

- Canonical attachments now deliver on gateway `message.action` sends instead of silently vanishing behind `ok:true`.
- Feishu returns an actionable error for unsupported/multi/thread-reply media instead of a false success.
- No change to the outbound runner's delivered output; it is byte-identical, now sourced from the shared collector.
- Fail-closed note: `attachment`/`file`, multi-media, and `thread-reply` media on Feishu now error where they previously returned `ok:true` without sending. That is the reported bug, but it is a behavior change worth calling out.

## Evidence

Red-green on the call site — `send.test.ts` fails with the resolve call removed, passes with it restored:

```
# with normalizeSendMediaParams(request.params) removed from send.ts
× resolves canonical attachments into media before dispatching message action sends
  Tests  1 failed | 78 passed (79)

# restored
  Tests  79 passed (79)
```

Full suites (Node 22.22.3):

```
node scripts/run-vitest.mjs run \
  src/gateway/server-methods/send.test.ts \
  extensions/feishu/src/channel.test.ts \
  src/infra/outbound/message-action-params.test.ts \
  src/infra/outbound/message-action-runner.media.test.ts \
  src/infra/outbound/message-action-runner.plugin-dispatch.test.ts

Tests  79 passed (79)    # gateway
Tests  123 passed (123)  # outbound params + runner media + plugin dispatch
Tests  112 passed (112)  # feishu
```

Lint/format: `oxfmt --check` clean on all changed files; `check-max-lines-ratchet` OK. `message-action-params.ts` still trips raw `oxlint` `max-lines`, but it was already over at baseline (753 lines) and is grandfathered — this change does not move it past the enforced gate.

`pnpm check:changed` delegates to Blacksmith Testbox, which is unavailable in my environment (`executable file not found`), so I ran the underlying linters and the affected suites directly.

Sibling-surface note: `outbound-send-service.ts` also calls `dispatchChannelMessageAction`, but it is reached from the runner *after* `buildSendPayloadParts`, so it was already covered and is unaffected.

## Known follow-ups (not in this PR, to keep it focused)

On the gateway path these remain unresolved and are pre-existing:

- `attachments: [{ buffer, filename }]` — no collector reads a per-attachment buffer.
- `caption` without `message` — the runner folds it into `message`; the gateway does not.
- `extraParamKeys` — plugin-declared media params are resolved on the runner path only.
- `assertMediaNotDataUrl` is not applied to newly resolved values (a caller could already pass `media: "data:…"` directly on this path).

Happy to take any of these in a follow-up, or fold one in here if you'd prefer.

## Duplicate-work check

```
gh issue view 112244 --repo openclaw/openclaw --comments        # open, unassigned, no claim
gh pr list --repo openclaw/openclaw --state open --search "112244 in:body"   # []
gh pr list --repo openclaw/openclaw --state open --search "feishu attachment media"
```

No open PR references #112244. The nearby Feishu PRs are different concerns: #102397 (text/media ordering), #108588 (inbound durable attachment), #102650 (card image embed). None touches send-param resolution or gateway media dispatch.

## AI assistance disclosure

This change was developed with AI assistance (Claude). I reviewed every changed line, ran the tests above myself, and can defend the design end-to-end. Attribution is in the commit trailer (`Co-authored-by: Claude`).

Notably, AI review caught two defects in earlier iterations of this patch that I had to correct before submitting: an over-broad denylist that would have rejected core-resolved snake_case aliases, and a media promotion that ran before sandbox normalization and produced un-normalized paths. Both are covered by tests here.
