### PR TITLE
fix(cron): condition-watcher QA fails after interval retirement

### DIFF
--- a/qa/scenarios/scheduling/cron-condition-watcher.yaml
+++ b/qa/scenarios/scheduling/cron-condition-watcher.yaml
@@ -24,11 +24,11 @@ scenario:
     cron:
       triggers:
         enabled: true
-        minIntervalMs: 250
   execution:
     kind: flow
     summary: Poll a stateful headless condition, prove quiet ticks stay artifact-free, then observe one natural fired command payload and once disarm.
     channel: qa-channel
+    timeoutMs: 180000
 
 flow:
   steps:
@@ -50,9 +50,9 @@ flow:
               enabled: true
               schedule:
                 kind: every
-                everyMs: 250
+                everyMs: 30000
               trigger:
-                script: "const count = (trigger.state?.count ?? 0) + 1; return { fire: count >= 6, state: { count } };"
+                script: "const count = (trigger.state?.count ?? 0) + 1; return { fire: count >= 3, state: { count } };"
                 once: true
               sessionTarget: isolated
               wakeMode: now
@@ -76,11 +76,11 @@ flow:
           args:
             - lambda:
                 async: true
-                expr: "(async () => { const job = await env.gateway.call('cron.get', { id: jobId }, { timeoutMs: 30000 }); const runs = await env.gateway.call('cron.runs', { id: jobId, limit: 10 }, { timeoutMs: 30000 }); return job.state?.triggerEvalCount >= 2 && runs.entries.length === 0 ? { job, runs } : undefined; })()"
-            - 15000
-            - 100
+                expr: "(async () => { const job = await env.gateway.call('cron.get', { id: jobId }, { timeoutMs: 30000 }); const runs = await env.gateway.call('cron.runs', { id: jobId, limit: 10 }, { timeoutMs: 30000 }); return job.state?.triggerEvalCount === 2 && job.state?.triggerState?.count === 2 && runs.entries.length === 0 ? { job, runs } : undefined; })()"
+            - 90000
+            - 250
         - assert:
-            expr: "quiet.job.state.triggerState?.count >= 2 && quiet.runs.entries.length === 0"
+            expr: "quiet.job.state.triggerEvalCount === 2 && quiet.job.state.triggerState?.count === 2 && quiet.runs.entries.length === 0"
             message:
               expr: "`expected quiet state with no runs, got ${JSON.stringify(quiet)}`"
       detailsExpr: "`job=${jobId} quietEvals=${quiet.job.state.triggerEvalCount} runRows=${quiet.runs.entries.length}`"
@@ -96,7 +96,7 @@ flow:
                 ref: jobId
               afterTs:
                 ref: startedAt
-              timeoutMs: 30000
+              timeoutMs: 60000
         - call: env.gateway.call
           saveAs: finalJob
           args:
@@ -117,7 +117,7 @@ flow:
             message:
               expr: "`expected fired command run, got ${JSON.stringify(completedRun)}`"
         - assert:
-            expr: "finalJob.enabled === false && finalJob.state?.triggerEvalCount >= 6 && finalJob.state?.triggerState?.count >= 6"
+            expr: "finalJob.enabled === false && finalJob.state?.triggerEvalCount === 3 && finalJob.state?.triggerState?.count === 3"
             message:
               expr: "`expected once disarm with persisted state, got ${JSON.stringify(finalJob)}`"
         - assert:


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the repo-backed cron condition-watcher QA scenario could not start against the current config contract. The scenario still set the retired `cron.triggers.minIntervalMs` key and requested a 250 ms trigger schedule even though trigger schedules now use a built-in 30-second minimum.

## Why This Change Was Made

The minimum-interval field remains retired, matching the canonical schema, doctor migration, runtime, and docs. The scenario now uses the real 30-second cadence, observes exactly two quiet evaluations without run history, then requires the third evaluation to fire and disable the once trigger after the payload succeeds. Timeouts were expanded to cover the real scheduler interval.

This change was AI-assisted and manually reviewed against the config and cron runtime contracts.

## User Impact

There is no production runtime behavior change. Maintainers can run the condition-watcher QA scenario against current `main`, and the scenario now validates the supported built-in interval rather than relying on a retired tuning knob.

## Evidence

- `node scripts/run-vitest.mjs extensions/qa-lab/src/scenario-catalog.test.ts src/config/dead-config-keys.test.ts src/config/zod-schema.cron-triggers.test.ts src/cron/service.jobs.test.ts` — 262 assertions passed.
- Blacksmith Testbox `tbx_01ky3xc0xerz1nk0wfb3k4ttrr` ran the exact final patch: `pnpm openclaw qa suite --scenario cron-condition-watcher --provider-mode mock-openai --channel-driver qa-channel --output-dir .artifacts/qa-e2e/cron-condition-watcher-contract-final --concurrency 1` — 1/1 scenario passed: https://github.com/openclaw/openclaw/actions/runs/29888156343
- Final Codex autoreview (`gpt-5.6-sol`, xhigh) reported no accepted or actionable findings.
- `git diff --check` passed.
