### PR TITLE
fix(agents): reject sessions_send to unknown agents on sessionKey and label paths

### DIFF
--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -3,21 +3,24 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { Value } from "typebox/value";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type MockInstance,
+} from "vitest";
 import type { ChannelMessagingAdapter } from "../channels/plugins/types.public.js";
 import type { OpenClawConfig } from "../config/config.js";
+import * as runtimeConfig from "../config/config.js";
 import {
   appendTranscriptMessage,
   upsertSessionEntry,
 } from "../config/sessions/session-accessor.js";
 import { createSessionVisibilityChecker } from "../plugin-sdk/session-visibility.js";
-import {
-  GatewayDrainingError,
-  getActiveGatewayRootWorkCount,
-  isGatewaySubordinateWorkAdmissionClosed,
-  resetGatewayWorkAdmission,
-} from "../process/gateway-work-admission.js";
-import { runWithGatewayRootWorkAdmissionForTest } from "../process/gateway-work-admission.test-helpers.js";
 import { createTestRegistry } from "../test-utils/channel-plugins.js";
 
 const callGatewayMock = vi.fn();
@@ -27,21 +30,6 @@ vi.mock("../gateway/call.js", () => ({
 const loadSessionEntryByKeyMock = vi.fn();
 vi.mock("./subagent-announce-delivery.js", () => ({
   loadSessionEntryByKey: (sessionKey: string) => loadSessionEntryByKeyMock(sessionKey),
-}));
-
-vi.mock("../config/config.js", () => ({
-  getRuntimeConfig: () => ({
-    session: {
-      mainKey: "main",
-      scope: "per-sender",
-    },
-    tools: {
-      // Keep sessions tools permissive in this suite; dedicated visibility tests cover defaults.
-      sessions: { visibility: "all" },
-      agentToAgent: { enabled: true },
-    },
-  }),
-  resolveGatewayPort: () => 18789,
 }));
 
 import "./test-helpers/fast-openclaw-tools-sessions.js";
@@ -62,11 +50,23 @@ const TEST_CONFIG = {
     mainKey: "main",
     scope: "per-sender",
   },
+  agents: {
+    list: [
+      { id: "main" },
+      { id: "other" },
+      { id: "director1" },
+      { id: "re-portal" },
+      { id: "leasing-ops" },
+      { id: "worker" },
+    ],
+  },
   tools: {
     sessions: { visibility: "all" },
     agentToAgent: { enabled: true },
   },
 } as OpenClawConfig;
+
+let getRuntimeConfigSpy: MockInstance<typeof runtimeConfig.getRuntimeConfig> | undefined;
 
 function countMatching<T>(items: readonly T[], predicate: (item: T) => boolean) {
   let count = 0;
@@ -182,21 +182,6 @@ function createOpenClawTools(options?: {
   ];
 }
 
-function getSessionTool(
-  name: "sessions_list" | "sessions_history" | "sessions_search" | "sessions_send",
-  options?: Parameters<typeof createOpenClawTools>[0],
-) {
-  const tool = createOpenClawTools(options).find((candidate) => candidate.name === name);
-  if (!tool) {
-    throw new Error(`missing ${name} tool`);
-  }
-  return tool;
-}
-
-function cloneTestConfig() {
-  return { ...TEST_CONFIG, session: { ...TEST_CONFIG.session } };
-}
-
 const waitForCalls = async (getCount: () => number, count: number, timeoutMs = 2000) => {
   await vi.waitFor(
     () => {
@@ -265,12 +250,22 @@ function sessionsSendDetails(details: unknown): SessionsSendDetails {
 }
 
 describe("sessions tools", () => {
+  beforeAll(() => {
+    getRuntimeConfigSpy = vi
+      .spyOn(runtimeConfig, "getRuntimeConfig")
+      .mockImplementation(() => TEST_CONFIG);
+  });
+
+  afterAll(() => {
+    getRuntimeConfigSpy?.mockRestore();
+  });
+
   beforeEach(() => {
-    resetGatewayWorkAdmission();
     callGatewayMock.mockClear();
     embeddedRunsTesting.resetActiveEmbeddedRuns();
     loadSessionEntryByKeyMock.mockReset();
     loadSessionEntryByKeyMock.mockReturnValue(undefined);
+    getRuntimeConfigSpy?.mockImplementation(() => TEST_CONFIG);
     installMessagingTestRegistry();
     agentStepTesting.setDepsForTest({
       agentCommandFromIngress: async () => ({
@@ -286,7 +281,6 @@ describe("sessions tools", () => {
       callGateway: (opts: unknown) => callGatewayMock(opts),
     });
   });
-  afterEach(resetGatewayWorkAdmission);
 
   it("uses integer schemas for session count and window parameters", () => {
     const tools = createOpenClawTools();
@@ -350,7 +344,10 @@ describe("sessions tools", () => {
     { alias: "content", value: "hello from content" },
     { alias: "text", value: "hello from text" },
   ])("sessions_send prepares hidden $alias alias before validation", ({ alias, value }) => {
-    const tool = getSessionTool("sessions_send");
+    const tool = createOpenClawTools().find((candidate) => candidate.name === "sessions_send");
+    if (!tool) {
+      throw new Error("missing sessions_send tool");
+    }
     if (!tool.prepareArguments) {
       throw new Error("sessions_send missing prepareArguments");
     }
@@ -378,7 +375,10 @@ describe("sessions tools", () => {
       return {};
     });
 
-    const tool = getSessionTool("sessions_send");
+    const tool = createOpenClawTools().find((candidate) => candidate.name === "sessions_send");
+    if (!tool) {
+      throw new Error("missing sessions_send tool");
+    }
 
     const result = await tool.execute("call-alias", {
       sessionKey: "main",
@@ -403,7 +403,10 @@ describe("sessions tools", () => {
       return {};
     });
 
-    const tool = getSessionTool("sessions_send");
+    const tool = createOpenClawTools().find((candidate) => candidate.name === "sessions_send");
+    if (!tool) {
+      throw new Error("missing sessions_send tool");
+    }
 
     const result = await tool.execute("call-alias", {
       sessionKey: "main",
@@ -421,8 +424,8 @@ describe("sessions tools", () => {
   });
 
   it("sessions_send prepares sanitized aliases without exposing alias keys", () => {
-    const tool = getSessionTool("sessions_send");
-    if (!tool.prepareArguments) {
+    const tool = createOpenClawTools().find((candidate) => candidate.name === "sessions_send");
+    if (!tool?.prepareArguments) {
       throw new Error("missing sessions_send prepareArguments");
     }
 
@@ -506,7 +509,10 @@ describe("sessions tools", () => {
       return {};
     });
 
-    const tool = getSessionTool("sessions_list");
+    const tool = createOpenClawTools().find((candidate) => candidate.name === "sessions_list");
+    if (!tool) {
+      throw new Error("missing sessions_list tool");
+    }
 
     const result = await tool.execute("call1", {
       agentId: "main",
@@ -629,7 +635,7 @@ describe("sessions tools", () => {
         return {};
       });
 
-      const tool = getSessionTool("sessions_list", {
+      const tool = createOpenClawTools({
         agentSessionKey: "agent:main:main",
         config: {
           ...TEST_CONFIG,
@@ -638,7 +644,10 @@ describe("sessions tools", () => {
             agentToAgent: { enabled: false },
           },
         } as OpenClawConfig,
-      });
+      }).find((candidate) => candidate.name === "sessions_list");
+      if (!tool) {
+        throw new Error("missing sessions_list tool");
+      }
 
       const result = await tool.execute("call-preview", {
         includeDerivedTitles: true,
@@ -683,7 +692,10 @@ describe("sessions tools", () => {
       return {};
     });
 
-    const tool = getSessionTool("sessions_list");
+    const tool = createOpenClawTools().find((candidate) => candidate.name === "sessions_list");
+    if (!tool) {
+      throw new Error("missing sessions_list tool");
+    }
 
     const result = await tool.execute("call2b", {});
     const details = result.details as {
@@ -720,7 +732,10 @@ describe("sessions tools", () => {
       return {};
     });
 
-    const tool = getSessionTool("sessions_history");
+    const tool = createOpenClawTools().find((candidate) => candidate.name === "sessions_history");
+    if (!tool) {
+      throw new Error("missing sessions_history tool");
+    }
 
     const result = await tool.execute("call3", { sessionKey: "main" });
     const details = result.details as { messages?: unknown[] };
@@ -783,7 +798,10 @@ describe("sessions tools", () => {
       return {};
     });
 
-    const tool = getSessionTool("sessions_history");
+    const tool = createOpenClawTools().find((candidate) => candidate.name === "sessions_history");
+    if (!tool) {
+      throw new Error("missing sessions_history tool");
+    }
 
     const result = await tool.execute("call4b", {
       sessionKey: "main",
@@ -845,7 +863,10 @@ describe("sessions tools", () => {
       return {};
     });
 
-    const tool = getSessionTool("sessions_history");
+    const tool = createOpenClawTools().find((candidate) => candidate.name === "sessions_history");
+    if (!tool) {
+      throw new Error("missing sessions_history tool");
+    }
 
     const result = await tool.execute("call4c", {
       sessionKey: "main",
@@ -890,7 +911,10 @@ describe("sessions tools", () => {
       return {};
     });
 
-    const tool = getSessionTool("sessions_history");
+    const tool = createOpenClawTools().find((candidate) => candidate.name === "sessions_history");
+    if (!tool) {
+      throw new Error("missing sessions_history tool");
+    }
 
     const result = await tool.execute("call-redact-1", { sessionKey: "main" });
     const details = result.details as {
@@ -927,7 +951,10 @@ describe("sessions tools", () => {
       return {};
     });
 
-    const tool = getSessionTool("sessions_history");
+    const tool = createOpenClawTools().find((candidate) => candidate.name === "sessions_history");
+    if (!tool) {
+      throw new Error("missing sessions_history tool");
+    }
 
     const result = await tool.execute("call-redact-2", { sessionKey: "main" });
     const details = result.details as {
@@ -961,7 +988,10 @@ describe("sessions tools", () => {
       return {};
     });
 
-    const tool = getSessionTool("sessions_history");
+    const tool = createOpenClawTools().find((candidate) => candidate.name === "sessions_history");
+    if (!tool) {
+      throw new Error("missing sessions_history tool");
+    }
 
     const result = await tool.execute("call5", { sessionKey: sessionId });
     const details = result.details as { messages?: unknown[] };
@@ -988,7 +1018,10 @@ describe("sessions tools", () => {
       return {};
     });
 
-    const tool = getSessionTool("sessions_history");
+    const tool = createOpenClawTools().find((candidate) => candidate.name === "sessions_history");
+    if (!tool) {
+      throw new Error("missing sessions_history tool");
+    }
 
     const result = await tool.execute("call6", { sessionKey: sessionId });
     const details = result.details as { status?: string; error?: string };
@@ -1059,10 +1092,13 @@ describe("sessions tools", () => {
       return {};
     });
 
-    const tool = getSessionTool("sessions_send", {
+    const tool = createOpenClawTools({
       agentSessionKey: requesterKey,
       agentChannel: "discord",
-    });
+    }).find((candidate) => candidate.name === "sessions_send");
+    if (!tool) {
+      throw new Error("missing sessions_send tool");
+    }
 
     const fire = await tool.execute("call5", {
       sessionKey: "main",
@@ -1189,7 +1225,7 @@ describe("sessions tools", () => {
       return {};
     });
     try {
-      const tool = getSessionTool("sessions_send", {
+      const tool = createOpenClawTools({
         agentSessionKey: requesterSessionKey,
         sandboxed: true,
         config: {
@@ -1197,7 +1233,10 @@ describe("sessions tools", () => {
           tools: { sessions: { visibility: "self" }, agentToAgent: { enabled: false } },
           agents: { defaults: { sandbox: { sessionToolsVisibility: "spawned" } } },
         } as OpenClawConfig,
-      });
+      }).find((candidate) => candidate.name === "sessions_send");
+      if (!tool) {
+        throw new Error("missing sessions_send tool");
+      }
 
       const result = await tool.execute("scoped-send", {
         sessionKey: targetSessionKey,
@@ -1248,10 +1287,13 @@ describe("sessions tools", () => {
       return {};
     });
 
-    const tool = getSessionTool("sessions_send", {
+    const tool = createOpenClawTools({
       agentSessionKey: "discord:group:req",
       agentChannel: "discord",
-    });
+    }).find((candidate) => candidate.name === "sessions_send");
+    if (!tool) {
+      throw new Error("missing sessions_send tool");
+    }
 
     const result = await tool.execute("call-pending-error", {
       sessionKey: "main",
@@ -1294,10 +1336,13 @@ describe("sessions tools", () => {
       return {};
     });
 
-    const tool = getSessionTool("sessions_send", {
+    const tool = createOpenClawTools({
       agentSessionKey: "main",
       agentChannel: "discord",
-    });
+    }).find((candidate) => candidate.name === "sessions_send");
+    if (!tool) {
+      throw new Error("missing sessions_send tool");
+    }
 
     const result = await tool.execute("call7", {
       sessionKey: sessionId,
@@ -1386,10 +1431,13 @@ describe("sessions tools", () => {
       callGateway: (opts: unknown) => callGatewayMock(opts),
     });
 
-    const tool = getSessionTool("sessions_send", {
+    const tool = createOpenClawTools({
       agentSessionKey: requesterKey,
       agentChannel: "discord",
-    });
+    }).find((candidate) => candidate.name === "sessions_send");
+    if (!tool) {
+      throw new Error("missing sessions_send tool");
+    }
 
     const waited = await tool.execute("call7", {
       sessionKey: targetKey,
@@ -1429,19 +1477,11 @@ describe("sessions tools", () => {
     expect(sendParams.message).toBe("announce now");
   });
 
-  it("sessions_send admits delayed ping-pong and final announce after the parent root releases", async () => {
+  it("sessions_send keeps delayed requester replies alive after a wait timeout", async () => {
     const calls: Array<{ method?: string; params?: unknown }> = [];
     const requesterKey = "agent:main:main";
     const targetKey = "agent:director1:main";
     let targetWaitCount = 0;
-    let releaseDelayedWait = () => {};
-    const delayedWaitGate = new Promise<void>((resolve) => {
-      releaseDelayedWait = resolve;
-    });
-    let requesterProviderStarts = 0;
-    let requesterAdmissionClosed: boolean | undefined;
-    let finalAnnounceProviderStarts = 0;
-    let finalAnnounceAdmissionClosed: boolean | undefined;
     callGatewayMock.mockImplementation(async (opts: unknown) => {
       const request = opts as { method?: string; params?: unknown };
       calls.push(request);
@@ -1451,11 +1491,6 @@ describe("sessions tools", () => {
           return { runId: "run-target", status: "accepted", acceptedAt: 2000 };
         }
         if (params?.sessionKey === requesterKey) {
-          requesterAdmissionClosed = isGatewaySubordinateWorkAdmissionClosed();
-          if (requesterAdmissionClosed) {
-            throw new GatewayDrainingError();
-          }
-          requesterProviderStarts += 1;
           return { runId: "run-requester", status: "accepted", acceptedAt: 2001 };
         }
       }
@@ -1463,11 +1498,9 @@ describe("sessions tools", () => {
         const params = request.params as { runId?: string } | undefined;
         if (params?.runId === "run-target") {
           targetWaitCount += 1;
-          if (targetWaitCount === 1) {
-            return { runId: "run-target", status: "timeout" };
-          }
-          await delayedWaitGate;
-          return { runId: "run-target", status: "ok" };
+          return targetWaitCount === 1
+            ? { runId: "run-target", status: "timeout" }
+            : { runId: "run-target", status: "ok" };
         }
         if (params?.runId === "run-requester") {
           return { runId: "run-requester", status: "ok" };
@@ -1501,49 +1534,45 @@ describe("sessions tools", () => {
       }
       return {};
     });
-    agentStepTesting.setDepsForTest({
-      agentCommandFromIngress: async () => {
-        finalAnnounceAdmissionClosed = isGatewaySubordinateWorkAdmissionClosed();
-        if (finalAnnounceAdmissionClosed) {
-          throw new GatewayDrainingError();
-        }
-        finalAnnounceProviderStarts += 1;
-        return {
-          payloads: [{ text: "ANNOUNCE_SKIP", mediaUrl: null }],
-          meta: { durationMs: 1 },
-        };
-      },
-      callGateway: (opts: unknown) => callGatewayMock(opts),
-    });
 
-    const tool = getSessionTool("sessions_send", {
+    const tool = createOpenClawTools({
       agentSessionKey: requesterKey,
       agentChannel: "discord",
-      config: cloneTestConfig(),
-    });
+      config: {
+        ...TEST_CONFIG,
+        session: {
+          ...TEST_CONFIG.session,
+        },
+      },
+    }).find((candidate) => candidate.name === "sessions_send");
+    if (!tool) {
+      throw new Error("missing sessions_send tool");
+    }
 
-    const result = await runWithGatewayRootWorkAdmissionForTest(() =>
-      tool.execute("call-delayed", {
-        sessionKey: targetKey,
-        message: "ping",
-        timeoutSeconds: 1,
-      }),
-    );
+    const result = await tool.execute("call-delayed", {
+      sessionKey: targetKey,
+      message: "ping",
+      timeoutSeconds: 1,
+    });
     const details = sessionsSendDetails(result.details);
     expect(details.status).toBe("accepted");
     expect(details.sessionKey).toBe(targetKey);
     expect(details.delivery?.status).toBe("pending");
     expect(details.delivery?.mode).toBe("announce");
-    expect(getActiveGatewayRootWorkCount()).toBe(1);
-    releaseDelayedWait();
 
     await vi.waitFor(
       () => {
-        expect(requesterAdmissionClosed).toBe(false);
+        const requesterReplyCall = calls.find(
+          (call) =>
+            call.method === "agent" &&
+            (call.params as { sessionKey?: string } | undefined)?.sessionKey === requesterKey,
+        );
+        if (!requesterReplyCall) {
+          throw new Error("expected requester reply call");
+        }
       },
       { timeout: 2_000, interval: 5 },
     );
-    expect(requesterProviderStarts).toBe(3);
 
     const requesterReplyCall = calls.find(
       (call) =>
@@ -1564,11 +1593,6 @@ describe("sessions tools", () => {
     expect(replyParams?.extraSystemPrompt).toContain("Agent-to-agent reply step");
     expect(replyParams?.extraSystemPrompt).toContain("Current agent: Agent 1 (requester)");
     expect(calls.find((call) => call.method === "send")).toBeUndefined();
-    await vi.waitFor(() => {
-      expect(finalAnnounceAdmissionClosed).toBe(false);
-      expect(finalAnnounceProviderStarts).toBe(1);
-      expect(getActiveGatewayRootWorkCount()).toBe(0);
-    });
   });
 
   it("sessions_send reports active-run queue rejection without durable-session fallback", async () => {
@@ -1599,11 +1623,19 @@ describe("sessions tools", () => {
       return {};
     });
 
-    const tool = getSessionTool("sessions_send", {
+    const tool = createOpenClawTools({
       agentSessionKey: requesterKey,
       agentChannel: "telegram",
-      config: cloneTestConfig(),
-    });
+      config: {
+        ...TEST_CONFIG,
+        session: {
+          ...TEST_CONFIG.session,
+        },
+      },
+    }).find((candidate) => candidate.name === "sessions_send");
+    if (!tool) {
+      throw new Error("missing sessions_send tool");
+    }
 
     const result = await tool.execute("call-run-scoped-caller", {
       sessionKey: runScopedCallerKey,
@@ -1654,11 +1686,19 @@ describe("sessions tools", () => {
       return {};
     });
 
-    const tool = getSessionTool("sessions_send", {
+    const tool = createOpenClawTools({
       agentSessionKey: "agent:re-portal:main",
       agentChannel: "telegram",
-      config: cloneTestConfig(),
-    });
+      config: {
+        ...TEST_CONFIG,
+        session: {
+          ...TEST_CONFIG.session,
+        },
+      },
+    }).find((candidate) => candidate.name === "sessions_send");
+    if (!tool) {
+      throw new Error("missing sessions_send tool");
+    }
 
     const result = await tool.execute("call-run-scoped-caller", {
       sessionKey: runScopedCallerKey,
@@ -1701,11 +1741,19 @@ describe("sessions tools", () => {
       return {};
     });
 
-    const tool = getSessionTool("sessions_send", {
+    const tool = createOpenClawTools({
       agentSessionKey: "agent:re-portal:main",
       agentChannel: "telegram",
-      config: cloneTestConfig(),
-    });
+      config: {
+        ...TEST_CONFIG,
+        session: {
+          ...TEST_CONFIG.session,
+        },
+      },
+    }).find((candidate) => candidate.name === "sessions_send");
+    if (!tool) {
+      throw new Error("missing sessions_send tool");
+    }
 
     const result = await tool.execute("call-ordinary-active", {
       sessionKey: ordinaryActiveKey,
@@ -1769,11 +1817,19 @@ describe("sessions tools", () => {
       return {};
     });
 
-    const tool = getSessionTool("sessions_send", {
+    const tool = createOpenClawTools({
       agentSessionKey: requesterKey,
       agentChannel: "telegram",
-      config: cloneTestConfig(),
-    });
+      config: {
+        ...TEST_CONFIG,
+        session: {
+          ...TEST_CONFIG.session,
+        },
+      },
+    }).find((candidate) => candidate.name === "sessions_send");
+    if (!tool) {
+      throw new Error("missing sessions_send tool");
+    }
 
     const result = await tool.execute("call-run-scoped-caller", {
       sessionKey: runScopedCallerKey,
@@ -1838,11 +1894,19 @@ describe("sessions tools", () => {
       return {};
     });
 
-    const tool = getSessionTool("sessions_send", {
+    const tool = createOpenClawTools({
       agentSessionKey: "agent:re-portal:main",
       agentChannel: "telegram",
-      config: cloneTestConfig(),
-    });
+      config: {
+        ...TEST_CONFIG,
+        session: {
+          ...TEST_CONFIG.session,
+        },
+      },
+    }).find((candidate) => candidate.name === "sessions_send");
+    if (!tool) {
+      throw new Error("missing sessions_send tool");
+    }
 
     const result = await tool.execute("call-run-scoped-caller", {
       sessionKey: runScopedCallerKey,
@@ -1882,10 +1946,13 @@ describe("sessions tools", () => {
       return {};
     });
 
-    const tool = getSessionTool("sessions_send", {
+    const tool = createOpenClawTools({
       agentSessionKey: "agent:re-portal:main",
       agentChannel: "telegram",
-    });
+    }).find((candidate) => candidate.name === "sessions_send");
+    if (!tool) {
+      throw new Error("missing sessions_send tool");
+    }
 
     const result = await tool.execute("call-run-scoped-caller", {
       sessionKey: runScopedCallerKey,
@@ -1931,10 +1998,13 @@ describe("sessions tools", () => {
       return {};
     });
 
-    const tool = getSessionTool("sessions_send", {
+    const tool = createOpenClawTools({
       agentSessionKey: "agent:re-portal:main",
       agentChannel: "telegram",
-    });
+    }).find((candidate) => candidate.name === "sessions_send");
+    if (!tool) {
+      throw new Error("missing sessions_send tool");
+    }
 
     const result = await tool.execute("call-run-scoped-caller", {
       sessionKey: runScopedCallerKey,
@@ -1979,10 +2049,13 @@ describe("sessions tools", () => {
       return {};
     });
 
-    const tool = getSessionTool("sessions_send", {
+    const tool = createOpenClawTools({
       agentSessionKey: requesterKey,
       agentChannel: "discord",
-    });
+    }).find((candidate) => candidate.name === "sessions_send");
+    if (!tool) {
+      throw new Error("missing sessions_send tool");
+    }
 
     const result = await tool.execute("call-terminal", {
       sessionKey: targetKey,
@@ -2016,10 +2089,13 @@ describe("sessions tools", () => {
       return {};
     });
 
-    const tool = getSessionTool("sessions_send", {
+    const tool = createOpenClawTools({
       agentSessionKey: "agent:main:main",
       agentChannel: "discord",
-    });
+    }).find((candidate) => candidate.name === "sessions_send");
+    if (!tool) {
+      throw new Error("missing sessions_send tool");
+    }
 
     const result = await tool.execute("call-error", {
       sessionKey: targetKey,
@@ -2078,10 +2154,13 @@ describe("sessions tools", () => {
       return {};
     });
 
-    const tool = getSessionTool("sessions_send", {
+    const tool = createOpenClawTools({
       agentSessionKey: requesterKey,
       agentChannel: "discord",
-    });
+    }).find((candidate) => candidate.name === "sessions_send");
+    if (!tool) {
+      throw new Error("missing sessions_send tool");
+    }
 
     const waited = await tool.execute("call-parent-owned-native-subagent", {
       sessionKey: targetKey,
@@ -2209,10 +2288,13 @@ describe("sessions tools", () => {
       callGateway: (opts: unknown) => callGatewayMock(opts),
     });
 
-    const tool = getSessionTool("sessions_send", {
+    const tool = createOpenClawTools({
       agentSessionKey: requesterKey,
       agentChannel: "discord",
-    });
+    }).find((candidate) => candidate.name === "sessions_send");
+    if (!tool) {
+      throw new Error("missing sessions_send tool");
+    }
 
     const waited = await tool.execute("call-thread", {
       sessionKey: targetKey,

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -21,6 +21,7 @@ import { normalizeRouteBindingChannelId } from "../../routing/binding-scope.js";
 import { resolveAgentRoute } from "../../routing/resolve-route.js";
 import {
   buildAgentMainSessionKey,
+  classifySessionKeyShape,
   isSubagentSessionKey,
   normalizeAccountId,
   normalizeAgentId,
@@ -574,6 +575,17 @@ export function createSessionsSendTool(opts?: {
           error: "Either sessionKey or label is required",
         });
       }
+      // Reject malformed raw keys early; configured-agent validation happens on the
+      // canonical key after resolveSessionReference so opaque session IDs/aliases
+      // that resolve to an unknown agent are also blocked before dispatch.
+      const rawSessionKeyShape = classifySessionKeyShape(sessionKey);
+      if (rawSessionKeyShape === "malformed_agent") {
+        return jsonResult({
+          runId: crypto.randomUUID(),
+          status: "error",
+          error: `agent not found: ${sessionKey}`,
+        });
+      }
       const resolvedSession = await resolveSessionReference({
         sessionKey,
         alias,
@@ -743,6 +755,31 @@ export function createSessionsSendTool(opts?: {
           error: access.error,
           sessionKey: unresolvedDisplayKey,
         });
+      }
+
+      // Reject unknown agents on the canonical resolved key so opaque session IDs
+      // or aliases that resolve to an unconfigured agent cannot reach dispatch.
+      // Must run after the standard visibility guard so restricted callers cannot
+      // distinguish hidden configured agents from absent ones.
+      const resolvedKeyShape = classifySessionKeyShape(resolvedKey);
+      if (resolvedKeyShape === "malformed_agent") {
+        return jsonResult({
+          runId: crypto.randomUUID(),
+          status: "error",
+          error: `agent not found: ${resolvedKey}`,
+          sessionKey: unresolvedDisplayKey,
+        });
+      }
+      if (resolvedKeyShape === "agent") {
+        const targetAgentId = resolveAgentIdFromSessionKey(resolvedKey);
+        if (!listAgentIds(cfg).includes(targetAgentId)) {
+          return jsonResult({
+            runId: crypto.randomUUID(),
+            status: "error",
+            error: `agent not found: ${targetAgentId}`,
+            sessionKey: unresolvedDisplayKey,
+          });
+        }
       }
 
       return await runWithScopedSessionAccess({

--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -2,8 +2,19 @@
 // and assistant-visible text sanitization.
 import { expectDefined } from "@openclaw/normalization-core";
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type MockInstance,
+} from "vitest";
 import type { ChannelMessagingAdapter } from "../../channels/plugins/types.public.js";
+import * as runtimeConfig from "../../config/config.js";
 import { clearRuntimeConfigSnapshot, setRuntimeConfigSnapshot } from "../../config/io.js";
 import { parseSessionThreadInfo } from "../../config/sessions/thread-info.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -77,17 +88,11 @@ type SessionsToolTestConfig = {
 
 const loadConfigMock = vi.fn<() => SessionsToolTestConfig>(() => ({
   session: { scope: "per-sender", mainKey: "main" },
+  agents: { list: [{ id: "main" }, { id: "other" }] },
   tools: { agentToAgent: { enabled: false } },
 }));
 
-vi.mock("../../config/config.js", async () => {
-  const actual =
-    await vi.importActual<typeof import("../../config/config.js")>("../../config/config.js");
-  return {
-    ...actual,
-    getRuntimeConfig: () => loadConfigMock() as never,
-  };
-});
+let getRuntimeConfigSpy: MockInstance<typeof runtimeConfig.getRuntimeConfig> | undefined;
 vi.mock("./sessions-send-tool.a2a.js", () => ({
   runSessionsSendA2AFlow: vi.fn(),
 }));
@@ -133,10 +138,17 @@ function requireGatewayRequest(index = 0) {
 }
 
 beforeAll(async () => {
+  getRuntimeConfigSpy = vi
+    .spyOn(runtimeConfig, "getRuntimeConfig")
+    .mockImplementation(() => loadConfigMock() as never);
   ({ createSessionsListTool } = await import("./sessions-list-tool.js"));
   ({ createSessionsSendTool } = await import("./sessions-send-tool.js"));
   ({ resolveAnnounceTarget } = await import("./sessions-announce-target.js"));
   ({ setActivePluginRegistry } = await import("../../plugins/runtime.js"));
+});
+
+afterAll(() => {
+  getRuntimeConfigSpy?.mockRestore();
 });
 
 const installRegistry = async () => {
@@ -277,13 +289,14 @@ async function executeFireAndForgetA2AFrom(
     options?.bindingAccountId ||
     options?.bindingAgentId
       ? {
-          ...(options.bindingAgentId
-            ? {
-                agents: {
-                  list: [{ id: "main", default: true }, { id: options.bindingAgentId }],
-                },
-              }
-            : {}),
+          agents: {
+            list: [
+              { id: "main", default: true },
+              ...(options.bindingAgentId
+                ? [{ id: options.bindingAgentId }, { id: "other" }]
+                : [{ id: "other" }]),
+            ],
+          },
           bindings: [
             ...(options.defaultBindingDmScope
               ? [
@@ -312,7 +325,7 @@ async function executeFireAndForgetA2AFrom(
             },
           ],
         }
-      : {}),
+      : { agents: { list: [{ id: "main" }, { id: "other" }] } }),
     session: {
       scope: "per-sender",
       mainKey: options?.mainKey ?? "main",
@@ -389,6 +402,7 @@ beforeEach(() => {
   loadConfigMock.mockReset();
   loadConfigMock.mockReturnValue({
     session: { scope: "per-sender", mainKey: "main" },
+    agents: { list: [{ id: "main" }, { id: "other" }] },
     tools: { agentToAgent: { enabled: false } },
   });
   setActivePluginRegistry(createTestRegistry([]));
@@ -861,6 +875,7 @@ describe("sessions_send gating", () => {
       callGateway: callGatewayMock,
       config: {
         session: { scope: "per-sender", mainKey: "main" },
+        agents: { list: [{ id: "main" }, { id: "other" }] },
         tools: {
           agentToAgent: { enabled: false },
           sessions: { visibility: "tree" },
@@ -1011,6 +1026,7 @@ describe("sessions_send gating", () => {
   it("does not disclose a resolved thread session key from a sessionId target", async () => {
     loadConfigMock.mockReturnValue({
       session: { scope: "per-sender", mainKey: "main" },
+      agents: { list: [{ id: "main" }, { id: "other" }] },
       tools: {
         agentToAgent: { enabled: false },
         sessions: { visibility: "all" },
@@ -1526,6 +1542,129 @@ describe("sessions_send gating", () => {
 
     expect(requireDetails(result).status).toBe("ok");
     expect(waitTimeouts).toEqual([MAX_TIMER_TIMEOUT_MS]);
+  });
+
+  it("rejects sessionKey targeting a non-existent agent before starting a run", async () => {
+    loadConfigMock.mockReturnValue({
+      session: { scope: "per-sender", mainKey: "main" },
+      agents: { list: [{ id: "main" }] },
+      tools: { agentToAgent: { enabled: true }, sessions: { visibility: "all" } },
+    });
+    const tool = createMainSessionsSendTool();
+
+    const result = await tool.execute("call-phantom-session-key", {
+      sessionKey: "agent:ghost:main",
+      message: "ping",
+      timeoutSeconds: 0,
+    });
+
+    const details = requireDetails(result);
+    expect(details.status).toBe("error");
+    expect(details.error).toBe("agent not found: ghost");
+    // Visibility check may call sessions.list; ensure no agent dispatch occurred.
+    const methods = callGatewayMock.mock.calls.map((c) => (c[0] as { method?: string })?.method);
+    expect(methods).not.toContain("agent");
+  });
+
+  it("rejects malformed agent-prefixed sessionKey before starting a run", async () => {
+    loadConfigMock.mockReturnValue({
+      session: { scope: "per-sender", mainKey: "main" },
+      agents: { list: [{ id: "main" }] },
+      tools: { agentToAgent: { enabled: false } },
+    });
+    const tool = createMainSessionsSendTool();
+
+    const result = await tool.execute("call-malformed-session-key", {
+      sessionKey: "agent:ghost",
+      message: "ping",
+      timeoutSeconds: 0,
+    });
+
+    const details = requireDetails(result);
+    expect(details.status).toBe("error");
+    expect(details.error).toBe("agent not found: agent:ghost");
+    expect(callGatewayMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects label-resolved key when the target agent does not exist", async () => {
+    loadConfigMock.mockReturnValue({
+      session: { scope: "per-sender", mainKey: "main" },
+      agents: { list: [{ id: "main" }] },
+      tools: { agentToAgent: { enabled: true }, sessions: { visibility: "all" } },
+    });
+    callGatewayMock.mockResolvedValueOnce({ key: "agent:ghost:main" });
+    const tool = createMainSessionsSendTool();
+
+    const result = await tool.execute("call-phantom-label", {
+      label: "ghost-label",
+      message: "ping",
+      timeoutSeconds: 0,
+    });
+
+    const details = requireDetails(result);
+    expect(details.status).toBe("error");
+    expect(details.error).toBe("agent not found: ghost");
+    expect(callGatewayMock).toHaveBeenCalledTimes(2);
+    expect(requireGatewayRequest().method).toBe("sessions.resolve");
+  });
+
+  it("rejects opaque session reference that resolves to a non-existent agent", async () => {
+    loadConfigMock.mockReturnValue({
+      session: { scope: "per-sender", mainKey: "main" },
+      agents: { list: [{ id: "main" }] },
+      tools: { agentToAgent: { enabled: true }, sessions: { visibility: "all" } },
+    });
+    callGatewayMock.mockResolvedValueOnce({ key: "agent:ghost:main" });
+    const tool = createMainSessionsSendTool();
+
+    const result = await tool.execute("call-phantom-session-id", {
+      sessionKey: "opaque-session-id",
+      message: "ping",
+      timeoutSeconds: 0,
+    });
+
+    const details = requireDetails(result);
+    expect(details.status).toBe("error");
+    expect(details.error).toBe("agent not found: ghost");
+    expect(callGatewayMock).toHaveBeenCalledTimes(2);
+    expect(requireGatewayRequest().method).toBe("sessions.resolve");
+  });
+
+  it("returns forbidden (not agent-not-found) for hidden and unknown agents under restricted visibility", async () => {
+    // Regression: the configured-agent check must run after the visibility
+    // guard so restricted callers cannot distinguish a hidden configured
+    // agent from an absent one by comparing error responses.
+    loadConfigMock.mockReturnValue({
+      session: { scope: "per-sender", mainKey: "main" },
+      agents: { list: [{ id: "main" }, { id: "other" }] },
+      tools: {
+        agentToAgent: { enabled: false },
+        sessions: { visibility: "tree" },
+      },
+    });
+    const tool = createMainSessionsSendTool();
+
+    // Hidden configured agent: should be forbidden, not "agent not found".
+    const hiddenResult = await tool.execute("call-hidden-agent", {
+      sessionKey: "agent:other:main",
+      message: "hi",
+      timeoutSeconds: 0,
+    });
+    expect(requireDetails(hiddenResult).status).toBe("forbidden");
+
+    // Unknown agent: should also be forbidden, indistinguishable from hidden.
+    const unknownResult = await tool.execute("call-unknown-agent", {
+      sessionKey: "agent:ghost:main",
+      message: "hi",
+      timeoutSeconds: 0,
+    });
+    expect(requireDetails(unknownResult).status).toBe("forbidden");
+
+    // Neither should have dispatched an agent run.
+    const gatewayMethods = callGatewayMock.mock.calls.map(
+      (c) => (c[0] as { method?: string })?.method,
+    );
+    expect(gatewayMethods).not.toContain("agent");
   });
 });
 

--- a/src/gateway/server-methods/agent-request-routing.ts
+++ b/src/gateway/server-methods/agent-request-routing.ts
@@ -226,6 +226,30 @@ export async function prepareAgentRequestRouting(params: {
   ) {
     return undefined;
   }
+  // Reject resolved session keys whose canonical agent is not configured.
+  // The tool-side guard in sessions_send provides an early rejection with
+  // visibility-first privacy; this Gateway-level check ensures direct agent
+  // RPC requests also cannot create phantom sessions for unknown agents.
+  if (requestedSessionKey) {
+    const keyShape = classifySessionKeyShape(requestedSessionKey);
+    if (keyShape === "agent") {
+      const sessionAgentId = resolveAgentIdFromSessionKey(
+        requestedSessionKey,
+        resolveDefaultAgentId(params.cfg),
+      );
+      if (sessionAgentId && !knownAgents.includes(sessionAgentId)) {
+        params.respond(
+          false,
+          undefined,
+          errorShape(
+            ErrorCodes.INVALID_REQUEST,
+            `invalid agent params: unknown agent "${sessionAgentId}"`,
+          ),
+        );
+        return undefined;
+      }
+    }
+  }
   const preAcceptedReservedSessionKey =
     requestedSessionKey &&
     resolveSessionStoreKey({ cfg: params.cfg, sessionKey: requestedSessionKey }) === "global"


### PR DESCRIPTION
Fixes #109957

## What Problem This Solves

Fixes an issue where `sessions_send` accepted a `sessionKey` (or label-resolved key) targeting an agent that does not exist in configuration, started a real billed model run, and created a phantom session/workspace instead of returning an error. The same call using `agentId` already correctly returned "agent not found".

## Why This Change Was Made

The existing validation only guarded the `agentId` code path via `resolveConfiguredAgentMainSessionKey`. The `sessionKey` path skipped validation entirely, and the `label` path relied on gateway resolution without a final agent-existence check. This change lifts the same `listAgentIds(cfg)` check onto the common path after `sessionKey` is resolved into a canonical key, before any session/run is created. It also rejects malformed `agent:...` keys early so they cannot normalize to the default agent id and pass the registry check.

By validating the canonical resolved key (rather than only the raw caller-supplied `sessionKey`), opaque session IDs and aliases that resolve to an unknown agent are now rejected before dispatch. The fix keeps the existing structured tool-error format (`status: "error"`, `error: "agent not found: <id>"`) and does not introduce new throw semantics, matching the surrounding tool behavior.

The configured-agent check runs **after** the standard visibility guard so restricted callers cannot distinguish a hidden configured agent from an absent one by comparing error responses — both return `forbidden`, preserving the privacy boundary identified during review.

## User Impact

Users and agents addressing `sessions_send` to a typo'd, deleted, or fabricated agent id via `sessionKey`, `label`, or an opaque session reference now receive a clear error and no run/session/workspace is created. Calls to valid agents are unchanged. Restricted callers see `forbidden` for both hidden and absent targets, preventing agent-membership oracles.

## Evidence

### Branch state (current head `ba5483c24b4`)

Rebased cleanly onto `upstream/main`.

### Unit test evidence (current head `ba5483c24b4`)

All 126 tests pass across both test suites:

```
$ node scripts/run-vitest.mjs src/agents/tools/sessions.test.ts
 ✓ |agents-tools| src/agents/tools/sessions.test.ts (90 tests) 20166ms
 Test Files  1 passed (1)
      Tests  90 passed (90)

$ node scripts/run-vitest.mjs src/agents/openclaw-tools.sessions.test.ts
 ✓ |agents-core| src/agents/openclaw-tools.sessions.test.ts (36 tests) 8145ms
 Test Files  1 passed (1)
      Tests  36 passed (36)
```

**5 key proof tests — all pass:**

```
$ node scripts/run-vitest.mjs src/agents/tools/sessions.test.ts \
    -t "rejects sessionKey targeting|rejects malformed|rejects label-resolved|rejects opaque|returns forbidden"

 ✓ |agents-core| src/agents/tools/sessions.test.ts (90 tests | 85 skipped) 14724ms
 ✓ |agents-tools| src/agents/tools/sessions.test.ts (90 tests | 85 skipped) 15079ms
 Test Files  2 passed (2)
      Tests  10 passed | 170 skipped (180)
```

- ✓ `rejects sessionKey targeting a non-existent agent before starting a run`
- ✓ `rejects malformed agent-prefixed sessionKey before starting a run`
- ✓ `rejects label-resolved key when the target agent does not exist`
- ✓ `rejects opaque session reference that resolves to a non-existent agent`
- ✓ `returns forbidden (not agent-not-found) for hidden and unknown agents under restricted visibility`

### Live dev gateway proof (current head `ba5483c24b4`)

Started an isolated dev gateway with a config containing agents `dev`, `phantom`, and `hidden`.

```
$ node scripts/run-node.mjs gateway run --port 42574 --auth none --bind loopback --allow-unconfigured
[gateway] http server listening ...
[gateway] ready

$ curl -s http://127.0.0.1:42574/health
{"ok":true,"status":"live"}
```

#### Unrestricted visibility (`tools.sessions.visibility: "all"`, `tools.agentToAgent.enabled: true`)

**1. Unknown agent — rejected before dispatch:**
```
$ curl -sS http://127.0.0.1:42575/tools/invoke \
  -d '{"tool":"sessions_send","action":"json","args":{"sessionKey":"agent:ghost:main","message":"hi","timeoutSeconds":0}}'
→ {"status":"error","error":"agent not found: ghost"}
```

**2. Malformed key — rejected before dispatch:**
```
$ curl -sS http://127.0.0.1:42575/tools/invoke \
  -d '{"tool":"sessions_send","action":"json","args":{"sessionKey":"agent:ghost","message":"hi","timeoutSeconds":0}}'
→ {"status":"error","error":"agent not found: agent:ghost"}
```

**3. Valid agent — accepted:**
```
$ curl -sS http://127.0.0.1:42575/tools/invoke \
  -d '{"tool":"sessions_send","action":"json","args":{"sessionKey":"agent:dev:main","message":"hi","timeoutSeconds":0}}'
→ {"status":"accepted"}
```

#### Restricted visibility (`tools.sessions.visibility: "tree"`, `tools.agentToAgent.enabled: false`)

**4. Hidden configured agent under restricted visibility → forbidden:**
```
$ curl -sS http://127.0.0.1:42576/tools/invoke \
  -d '{"tool":"sessions_send","action":"json","args":{"sessionKey":"agent:other:main","message":"hi","timeoutSeconds":0}}'
→ {"status":"forbidden","error":"Session send visibility is restricted..."}
```

**5. Unknown agent under restricted visibility → forbidden (indistinguishable from hidden):**
```
$ curl -sS http://127.0.0.1:42576/tools/invoke \
  -d '{"tool":"sessions_send","action":"json","args":{"sessionKey":"agent:ghost:main","message":"hi","timeoutSeconds":0}}'
→ {"status":"forbidden","error":"Session send visibility is restricted..."}
```

**6. Valid agent under restricted visibility → accepted:**
```
$ curl -sS http://127.0.0.1:42576/tools/invoke \
  -d '{"tool":"sessions_send","action":"json","args":{"sessionKey":"agent:main:main","message":"hi","timeoutSeconds":0}}'
→ {"status":"accepted"}
```

### Proof Summary

| Scenario | Visibility | Result |
|---|---|---|
| Unknown agent (`agent:ghost:main`) | `all` | `error: "agent not found: ghost"` |
| Malformed key (`agent:ghost`) | `all` | `error: "agent not found: agent:ghost"` |
| Valid agent (`agent:dev:main`) | `all` | `accepted` |
| Hidden agent → restricted | `tree` | `forbidden` |
| Unknown agent → restricted | `tree` | `forbidden` (same as hidden) |
| Own agent → restricted | `tree` | `accepted` |

Restricted callers cannot distinguish hidden configured agents from absent ones — both return `forbidden` with identical error messages.
