### PR TITLE
fix(codex): label unnamed sessions from previews

### DIFF
--- a/extensions/codex/src/session-catalog-parsing.ts
+++ b/extensions/codex/src/session-catalog-parsing.ts
@@ -1,4 +1,5 @@
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { sanitizeTerminalText } from "openclaw/plugin-sdk/text-chunking";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { CodexThread, CodexThreadTurnsListResponse } from "./app-server/protocol.js";
 import {
@@ -29,6 +30,7 @@ const MAX_HOST_ID_LENGTH = 256;
 const MAX_CWD_LENGTH = 4096;
 export const MAX_SESSION_ID_LENGTH = 256;
 const MAX_SESSION_NAME_LENGTH = 500;
+const MAX_SESSION_PREVIEW_LENGTH = 500;
 const MAX_SESSION_KEY_LENGTH = 1024;
 const MAX_METADATA_LENGTH = 500;
 const MAX_ACTIVE_FLAGS = 16;
@@ -66,6 +68,14 @@ export function boundedCatalogString(
     return normalized;
   }
   return overflow === "truncate" ? truncateUtf16Safe(normalized, maxLength) : undefined;
+}
+
+function catalogPreview(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const singleLine = sanitizeTerminalText(value.replace(/\s+/g, " "));
+  return boundedCatalogString(singleLine, MAX_SESSION_PREVIEW_LENGTH, "truncate");
 }
 
 type CodexInteractiveThreadSource =
@@ -121,6 +131,7 @@ export function toCatalogSession(
   const gitInfo = isRecord(record.gitInfo) ? record.gitInfo : undefined;
   const sessionId = boundedCatalogString(thread.sessionId, MAX_SESSION_ID_LENGTH);
   const name = boundedCatalogString(thread.name, MAX_SESSION_NAME_LENGTH, "truncate");
+  const fallbackName = name ? undefined : catalogPreview(thread.preview);
   const cwd = boundedCatalogString(thread.cwd, MAX_CWD_LENGTH);
   const modelProvider = boundedCatalogString(record.modelProvider, MAX_METADATA_LENGTH, "truncate");
   const cliVersion = boundedCatalogString(record.cliVersion, MAX_METADATA_LENGTH, "truncate");
@@ -131,6 +142,7 @@ export function toCatalogSession(
     archived,
     ...(sessionId ? { sessionId } : {}),
     ...(thread.name === null ? { name: null } : name ? { name } : {}),
+    ...(fallbackName ? { fallbackName } : {}),
     ...(cwd ? { cwd } : {}),
     ...(activeFlags?.length ? { activeFlags } : {}),
     ...(typeof thread.createdAt === "number" && Number.isFinite(thread.createdAt)
@@ -352,6 +364,11 @@ function parseCatalogSession(
     value.name === null
       ? null
       : parseOptionalCatalogString(value.name, "session name", MAX_SESSION_NAME_LENGTH);
+  const fallbackName = parseOptionalCatalogString(
+    value.fallbackName,
+    "session fallback name",
+    MAX_SESSION_PREVIEW_LENGTH,
+  );
   const cwd = parseOptionalCatalogString(value.cwd, "cwd", MAX_CWD_LENGTH);
   const source = parseOptionalCatalogString(value.source, "source", MAX_METADATA_LENGTH);
   const modelProvider = parseOptionalCatalogString(
@@ -377,6 +394,7 @@ function parseCatalogSession(
     archived: value.archived,
     ...(sessionId !== undefined ? { sessionId } : {}),
     ...(name !== undefined ? { name } : {}),
+    ...(fallbackName !== undefined ? { fallbackName } : {}),
     ...(cwd !== undefined ? { cwd } : {}),
     ...(activeFlags && activeFlags.length > 0 ? { activeFlags } : {}),
     ...(createdAt !== undefined ? { createdAt } : {}),

--- a/extensions/codex/src/session-catalog-types.ts
+++ b/extensions/codex/src/session-catalog-types.ts
@@ -13,6 +13,8 @@ export type CodexSessionCatalogSession = {
   threadId: string;
   sessionId?: string;
   name?: string | null;
+  /** Display-only fallback kept separate so title search never scans prompt previews. */
+  fallbackName?: string;
   cwd?: string;
   status: string;
   activeFlags?: string[];

--- a/extensions/codex/src/session-catalog.test.ts
+++ b/extensions/codex/src/session-catalog.test.ts
@@ -18,7 +18,7 @@ import {
   type CodexAppServerThreadBinding,
 } from "./app-server/session-binding.test-helpers.js";
 import { listPairedNode } from "./session-catalog-node-continue.js";
-import { catalogError } from "./session-catalog-parsing.js";
+import { catalogError, parseCatalogPage } from "./session-catalog-parsing.js";
 import { CODEX_TERMINAL_RESUME_COMMAND } from "./session-catalog-terminal.js";
 import {
   CODEX_LOCAL_SESSION_HOST_ID,
@@ -392,6 +392,30 @@ afterEach(async () => {
 });
 
 describe("Codex session catalog errors", () => {
+  it("preserves fallback names returned by paired nodes", () => {
+    expect(
+      parseCatalogPage({
+        sessions: [
+          {
+            threadId: "thread-1",
+            fallbackName: "Readable fallback",
+            status: "idle",
+            archived: false,
+          },
+        ],
+      }),
+    ).toEqual({
+      sessions: [
+        {
+          threadId: "thread-1",
+          fallbackName: "Readable fallback",
+          status: "idle",
+          archived: false,
+        },
+      ],
+    });
+  });
+
   it("keeps the underlying paired-node list failure", () => {
     expect(catalogError("NODE_LIST_FAILED", new Error("paired store is unreadable"))).toEqual({
       code: "NODE_LIST_FAILED",
@@ -408,14 +432,13 @@ describe("Codex supervision catalog", () => {
         {
           id: "thread-title",
           name: "Match title",
-          preview: "private transcript preview",
+          preview: "private\ntranscript preview",
           cwd: "/workspace/one",
           status: { type: "idle" },
           source: "vscode",
         },
         {
           id: "thread-preview",
-          name: "Other title",
           preview: "Match appears only in private preview text",
           status: { type: "idle" },
           source: "cli",
@@ -465,6 +488,50 @@ describe("Codex supervision catalog", () => {
     expect(commandRpcMocks.codexControlRequest.mock.calls.map((call) => call[1])).not.toContain(
       "thread/resume",
     );
+  });
+
+  it("uses a sanitized preview only when Codex has no thread name", async () => {
+    const pluginConfig = { supervision: { enabled: true } };
+    commandRpcMocks.codexControlRequest.mockResolvedValue({
+      data: [
+        {
+          id: "thread-named",
+          name: "Explicit title",
+          preview: "must stay private",
+          status: { type: "idle" },
+          source: "cli",
+        },
+        {
+          id: "thread-fallback",
+          preview: "Investigate\nfailed Rosita run",
+          status: { type: "idle" },
+          source: "cli",
+        },
+      ],
+    });
+    const control = createCodexSessionCatalogControl({
+      getPluginConfig: () => pluginConfig,
+      getRuntimeConfig: () => config,
+    });
+
+    await expect(control.listPage({ limit: 25 })).resolves.toEqual({
+      sessions: [
+        {
+          threadId: "thread-named",
+          name: "Explicit title",
+          status: "idle",
+          source: "cli",
+          archived: false,
+        },
+        {
+          threadId: "thread-fallback",
+          fallbackName: "Investigate failed Rosita run",
+          status: "idle",
+          source: "cli",
+          archived: false,
+        },
+      ],
+    });
   });
 
   it("scans bounded native pages for complete title-only search results", async () => {
@@ -3427,6 +3494,7 @@ describe("Codex supervision actions", () => {
           sessions: [
             {
               threadId: "thread-1",
+              fallbackName: "Readable fallback",
               status: "notLoaded",
               source: "cli",
               archived: false,
@@ -3440,7 +3508,14 @@ describe("Codex supervision actions", () => {
     await expect(getProvider()?.list({})).resolves.toMatchObject([
       {
         hostId: CODEX_LOCAL_SESSION_HOST_ID,
-        sessions: [{ threadId: "thread-1", canContinue: true, canArchive: true }],
+        sessions: [
+          {
+            threadId: "thread-1",
+            name: "Readable fallback",
+            canContinue: true,
+            canArchive: true,
+          },
+        ],
       },
     ]);
   });

--- a/extensions/codex/src/session-catalog.ts
+++ b/extensions/codex/src/session-catalog.ts
@@ -1218,9 +1218,10 @@ function toGenericCatalogHost(
       const canOpenTerminal =
         isInteractiveThreadSource(session.source) &&
         (local ? localTerminalAvailable : host.canOpenTerminalCodex === true);
+      const name = session.name ?? session.fallbackName;
       return {
         threadId: session.threadId,
-        ...(session.name != null ? { name: session.name } : {}),
+        ...(name ? { name } : {}),
         ...(session.cwd ? { cwd: session.cwd } : {}),
         status: session.status,
         ...(session.createdAt != null ? { createdAt: session.createdAt } : {}),


### PR DESCRIPTION
## Summary
- derive a bounded, sanitized display fallback from Codex thread previews when no explicit thread name exists
- keep the fallback separate from `name` during catalog search so prompt previews remain outside title-only matching
- map the fallback into the generic catalog name only at the presentation boundary, replacing UUID-only sidebar rows

## Release note
Codex sessions without generated names now show a readable prompt preview in the Control UI sidebar instead of a UUID.

## Testing
- `pnpm test extensions/codex/src/session-catalog.test.ts` (89 passed)
- `pnpm tsgo:extensions`
- `pnpm lint:extensions`
- autoreview: clean, no accepted/actionable findings
- `pnpm check:changed` reached the unrelated repo-wide shrinkwrap gate; the Codex shrinkwrap was current, while existing stale root and sibling package shrinkwraps failed

## Screenshots / Visual evidence
Not included; focused catalog tests cover the UUID-to-preview fallback path.

## Related issues / PRs
None.

## Pre-merge checklist
- [x] Scope is focused and avoids unrelated changes.
- [x] Tests cover the fallback, sanitization, search isolation, and paired-node transport.
- [x] No changelog edit required; release-note context is included above.
