### PR TITLE
fix(mcp): keep resource-only servers that report tools/list as Unknown method [AI-assisted]

### DIFF
--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -65,6 +65,8 @@ async function writeListToolsMcpServer(params: {
   notifyListChangedAfterFirstList?: boolean;
   exitOnListCall?: number;
   listToolsMethodNotFound?: boolean;
+  listToolsErrorCode?: number;
+  listToolsErrorMessage?: string;
   callToolIsError?: boolean;
   callToolJsonRpcError?: boolean;
   resourceListJsonRpcError?: boolean;
@@ -86,6 +88,8 @@ const notifyListChangedOnInitialized = ${params.notifyListChangedOnInitialized =
 const notifyListChangedAfterFirstList = ${params.notifyListChangedAfterFirstList === true};
 const exitOnListCall = ${params.exitOnListCall ?? 0};
 const listToolsMethodNotFound = ${params.listToolsMethodNotFound === true};
+const listToolsErrorCode = ${params.listToolsErrorCode ?? -32601};
+const listToolsErrorMessage = ${JSON.stringify(params.listToolsErrorMessage ?? "Method not found")};
 const tools = ${JSON.stringify(
       params.tools ?? [
         {
@@ -159,7 +163,7 @@ function handle(message) {
       send({
         jsonrpc: "2.0",
         id: message.id,
-        error: { code: -32601, message: "Method not found" },
+        error: { code: listToolsErrorCode, message: listToolsErrorMessage },
       });
       return;
     }
@@ -1530,6 +1534,99 @@ process.on("SIGINT", shutdown);`,
         resources: { listChanged: true },
       });
       await waitForFileText(logPath, "recv initialize", LIST_TOOLS_SERVER_LOG_TIMEOUT_MS);
+    } finally {
+      await runtime.dispose();
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps resource-only MCP servers available on Unknown method tools/list errors", async () => {
+    // Some resource-only servers/proxies report an unsupported optional
+    // tools/list request with JSON-RPC code -32000 and message "Unknown method"
+    // instead of the standard -32601 / "Method not found". The catalog must
+    // treat that as an unsupported optional method and keep the server.
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "bundle-mcp-resource-only-unknown-"));
+    const serverPath = path.join(tempDir, "resource-only-unknown.mjs");
+    const logPath = path.join(tempDir, "server.log");
+    await writeListToolsMcpServer({
+      filePath: serverPath,
+      logPath,
+      capabilities: { resources: { listChanged: true } },
+      listToolsMethodNotFound: true,
+      listToolsErrorCode: -32000,
+      listToolsErrorMessage: "Unknown method",
+    });
+
+    const runtime = await getOrCreateSessionMcpRuntime({
+      sessionId: "session-resource-only-unknown",
+      sessionKey: "agent:test:session-resource-only-unknown",
+      workspaceDir: "/workspace",
+      cfg: {
+        mcp: {
+          servers: {
+            notes: {
+              command: process.execPath,
+              args: [serverPath],
+            },
+          },
+        },
+      },
+    });
+
+    try {
+      const catalog = await runtime.getCatalog();
+
+      expect(catalog.tools).toEqual([]);
+      expect(catalog.servers.notes).toMatchObject({
+        serverName: "notes",
+        toolCount: 0,
+        resources: { listChanged: true },
+      });
+      await waitForFileText(logPath, "recv initialize", LIST_TOOLS_SERVER_LOG_TIMEOUT_MS);
+    } finally {
+      await runtime.dispose();
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not keep resource-only MCP servers when tools/list fails with a non-method error", async () => {
+    // Scope guard for the unsupported-method matcher: broadening it to accept
+    // "Unknown method" must not swallow a genuine server error. A tools/list
+    // failure that is not an unsupported-method response must still drop the
+    // server so the failure is not hidden.
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "bundle-mcp-resource-only-internal-"));
+    const serverPath = path.join(tempDir, "resource-only-internal.mjs");
+    const logPath = path.join(tempDir, "server.log");
+    await writeListToolsMcpServer({
+      filePath: serverPath,
+      logPath,
+      capabilities: { resources: { listChanged: true } },
+      listToolsMethodNotFound: true,
+      listToolsErrorCode: -32603,
+      listToolsErrorMessage: "Internal error",
+    });
+
+    const runtime = await getOrCreateSessionMcpRuntime({
+      sessionId: "session-resource-only-internal",
+      sessionKey: "agent:test:session-resource-only-internal",
+      workspaceDir: "/workspace",
+      cfg: {
+        mcp: {
+          servers: {
+            notes: {
+              command: process.execPath,
+              args: [serverPath],
+            },
+          },
+        },
+      },
+    });
+
+    try {
+      const catalog = await runtime.getCatalog();
+
+      expect(catalog.tools).toEqual([]);
+      expect(catalog.servers.notes).toBeUndefined();
     } finally {
       await runtime.dispose();
       await fs.rm(tempDir, { recursive: true, force: true });

--- a/src/agents/agent-bundle-mcp-runtime.ts
+++ b/src/agents/agent-bundle-mcp-runtime.ts
@@ -179,7 +179,13 @@ function isMcpMethodNotFoundError(error: unknown): boolean {
     return true;
   }
   const message = String(error);
-  return message.includes("-32601") || /method not found/i.test(message);
+  // Some resource-only servers and proxies report an unsupported optional
+  // tools/list request as code -32000 / "Unknown method" instead of the
+  // standard -32601 / "Method not found". Treat that wording as an unsupported
+  // method too. This matcher is only consulted on the optional best-effort
+  // tools/list discovery path (see listAllToolsBestEffort); genuine tool
+  // request failures never reach it and continue to propagate.
+  return message.includes("-32601") || /method not found|unknown method/i.test(message);
 }
 
 async function listAllToolsBestEffort(params: {


### PR DESCRIPTION
Closes #111940

> [AI-assisted] This PR was generated using Claude Code.

## What Problem This Solves

Fixes an issue where operators using a **resource-only** (or prompt-only) MCP server could not initialize it when the server/proxy reports an unsupported optional `tools/list` request with the nonstandard JSON-RPC response `code: -32000` / `message: "Unknown method"` instead of the standard `-32601` / `"Method not found"`.

Even though the server's resources/prompts were otherwise healthy, catalog initialization rejected the whole server, so its non-tool capabilities were unavailable to the agent.

## Why This Change Was Made

`isMcpMethodNotFoundError` already treats `-32601` / `"Method not found"` as an unsupported *optional* `tools/list` method (keeping the server with an empty tool catalog). This extends the message-based branch of that matcher to also recognize the `"Unknown method"` wording.

The matcher is consulted **only** on the optional best-effort tool discovery path (`listAllToolsBestEffort`, gated by `suppressUnsupported` — true only for servers that advertise resources/prompts but not tools). Genuine MCP tool **request** failures never reach it and continue to propagate unchanged. A scope-safety regression test (a `tools/list` failure that is *not* an unsupported-method response still drops the server) guards against over-acceptance.

## User Impact

Operators of resource-only or prompt-only MCP servers whose implementation/proxy answers `tools/list` with `-32000` / `"Unknown method"` can now use the server's resources and prompts. Servers using the standard `-32601` / `"Method not found"` (or servers that actually implement tools) are unaffected.

## Evidence

Real catalog-init path (`getOrCreateSessionMcpRuntime` -> `getCatalog`) driven against a local resource-only stdio MCP server that advertises `resources` and answers `tools/list` with `-32000` / `"Unknown method"`. A second server answers with `-32603` / `"Internal error"` as a non-method control.

Run via `pnpm exec tsx scripts/proof/mcp-unknown-method.proof.mjs` (proof script kept local/untracked; the spawned server is `scripts/proof/mcp-resource-only-server.mjs`).

**Before (current main) — resource-only server dropped despite being healthy:**
```
#111940 real-behavior proof — resource-only MCP catalog init
[bundle-mcp] failed to start server "notes" (<node> scripts/proof/mcp-resource-only-server.mjs unknown-method): McpError: MCP error -32000: Unknown method
{"mode":"unknown-method","outcome":"server-dropped","serverPresent":false,"resources":null}
[bundle-mcp] failed to start server "notes" (<node> scripts/proof/mcp-resource-only-server.mjs internal-error): McpError: MCP error -32603: Internal error
{"mode":"internal-error","outcome":"server-dropped","serverPresent":false,"resources":null}
summary: {"unknownMethodKeptAvailable":false,"internalErrorStillAborts":true}
```

**After (this branch) — server kept with its resources; non-method control still aborts:**
```
#111940 real-behavior proof — resource-only MCP catalog init
{"mode":"unknown-method","outcome":"server-available-with-resources","serverPresent":true,"serverToolCount":0,"resources":{"listChanged":true}}
[bundle-mcp] failed to start server "notes" (<node> scripts/proof/mcp-resource-only-server.mjs internal-error): McpError: MCP error -32603: Internal error
{"mode":"internal-error","outcome":"server-dropped","serverPresent":false,"resources":null}
summary: {"unknownMethodKeptAvailable":true,"internalErrorStillAborts":true}
```

Regression tests added to `src/agents/agent-bundle-mcp-runtime.test.ts`:
- `keeps resource-only MCP servers available on Unknown method tools/list errors` — fails on current main (server dropped), passes after the fix.
- `does not keep resource-only MCP servers when tools/list fails with a non-method error` — scope guard: a `-32603` / `"Internal error"` failure still drops the server (passes before and after).

```
$ node scripts/run-vitest.mjs src/agents/agent-bundle-mcp-runtime.test.ts -t "resource-only"
 Test Files  2 passed (2)
      Tests  6 passed | 146 skipped (152)
```

Verification: `pnpm format:check`, `pnpm tsgo`, and `oxlint --type-aware` on the changed files all pass.
