### PR TITLE
fix(macos): keep permissions reachable on short screens

### DIFF
--- a/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
@@ -715,6 +715,7 @@ extension OnboardingView {
     func permissionsPage() -> some View {
         onboardingPage {
             VStack(spacing: 12) {
+                // Keep intro and rows in one document so short windows can reveal every permission.
                 HStack(spacing: 8) {
                     Text("Grant permissions")
                         .font(.largeTitle.weight(.semibold))
@@ -745,6 +746,7 @@ extension OnboardingView {
                 }
             }
         }
+        // The root onboarding layout keeps navigation outside this scrollable document.
     }
 
     func cliPage() -> some View {

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Pages.swift
@@ -19,7 +19,7 @@ extension OnboardingView {
         case 4:
             self.memoryImportPage(contentHeight: contentHeight)
         case 5:
-            self.permissionsPage(contentHeight: contentHeight)
+            self.permissionsPage()
         case 9:
             self.readyPage()
         default:
@@ -712,41 +712,39 @@ extension OnboardingView {
         .buttonStyle(.plain)
     }
 
-    func permissionsPage(contentHeight: CGFloat) -> some View {
-        // Fixed layout (no ScrollView): sorted by importance and sized so all
-        // permissions stay visible at once — no scrollbars during onboarding.
-        VStack(spacing: 12) {
-            HStack(spacing: 8) {
-                Text("Grant permissions")
-                    .font(.largeTitle.weight(.semibold))
-                if self.isRequesting {
-                    ProgressView()
-                        .controlSize(.small)
+    func permissionsPage() -> some View {
+        onboardingPage {
+            VStack(spacing: 12) {
+                HStack(spacing: 8) {
+                    Text("Grant permissions")
+                        .font(.largeTitle.weight(.semibold))
+                    if self.isRequesting {
+                        ProgressView()
+                            .controlSize(.small)
+                    }
                 }
-            }
-            Text(
-                "These macOS permissions let OpenClaw automate apps and capture context on this Mac. " +
-                    "Status updates automatically.")
-                .font(.body)
-                .foregroundStyle(.secondary)
-                .multilineTextAlignment(.center)
-                .frame(maxWidth: 520)
-                .fixedSize(horizontal: false, vertical: true)
+                Text(
+                    "These macOS permissions let OpenClaw automate apps and capture context on this Mac. " +
+                        "Status updates automatically.")
+                    .font(.body)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: 520)
+                    .fixedSize(horizontal: false, vertical: true)
 
-            self.onboardingCard(spacing: 4, padding: 12) {
-                ForEach(Capability.importanceOrdered, id: \.self) { cap in
-                    PermissionRow(
-                        capability: cap,
-                        status: self.permissionMonitor.status[cap] ?? .notGranted,
-                        compact: true)
-                    {
-                        Task { await self.request(cap) }
+                self.onboardingCard(spacing: 4, padding: 12) {
+                    ForEach(Capability.importanceOrdered, id: \.self) { cap in
+                        PermissionRow(
+                            capability: cap,
+                            status: self.permissionMonitor.status[cap] ?? .notGranted,
+                            compact: true)
+                        {
+                            Task { await self.request(cap) }
+                        }
                     }
                 }
             }
         }
-        .padding(.horizontal, 28)
-        .frame(width: self.pageWidth, height: contentHeight, alignment: .top)
     }
 
     func cliPage() -> some View {

--- a/apps/macos/Sources/OpenClaw/OnboardingView+Testing.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Testing.swift
@@ -40,7 +40,7 @@ extension OnboardingView {
         _ = view.connectionPage()
         _ = view.aiSetupPage(contentHeight: contentHeight)
         _ = view.memoryImportPage(contentHeight: contentHeight)
-        _ = view.permissionsPage(contentHeight: contentHeight)
+        _ = view.permissionsPage()
         _ = view.cliPage()
         _ = view.readyPage()
 

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingViewSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingViewSmokeTests.swift
@@ -73,6 +73,25 @@ struct OnboardingViewSmokeTests {
         #expect(short < preferred)
     }
 
+    @Test func `permissions page scrolls when the onboarding window is short`() throws {
+        let state = AppState(preview: true)
+        let view = OnboardingView(state: state)
+        let hosting = NSHostingView(rootView: view.permissionsPage())
+        let contentHeight = OnboardingView.contentHeight(
+            for: OnboardingView.minimumWindowHeight,
+            usesCompactHero: false)
+        hosting.frame = NSRect(
+            x: 0,
+            y: 0,
+            width: OnboardingView.windowWidth,
+            height: contentHeight)
+        hosting.layoutSubtreeIfNeeded()
+
+        let scrollView = try #require(Self.firstDescendant(of: NSScrollView.self, in: hosting))
+        #expect(contentHeight == 303)
+        #expect(scrollView.documentView != nil)
+    }
+
     @Test func `local page order includes memory import only while eligible`() {
         let configuredOrder = OnboardingView.pageOrder(
             for: .local,
@@ -588,5 +607,13 @@ struct OnboardingViewSmokeTests {
         #expect(Array(Capability.importanceOrdered.prefix(3))
             == [.appleScript, .accessibility, .screenRecording])
         #expect(Capability.importanceOrdered.last == Capability.location)
+    }
+
+    private static func firstDescendant<T: NSView>(of type: T.Type, in view: NSView) -> T? {
+        if let match = view as? T { return match }
+        for child in view.subviews {
+            if let match = self.firstDescendant(of: type, in: child) { return match }
+        }
+        return nil
     }
 }


### PR DESCRIPTION
Closes #98674

## What Problem This Solves

Fixes an issue where the macOS onboarding permissions page clipped the lower permission rows on short screens. At the minimum supported onboarding window height, only five of eight permissions were visible, and the page could not scroll, so users could not reach Speech Recognition, Camera, or Location controls.

The earlier window-sizing fix kept the navigation bar reachable, but this one page still opted out of the scrollable onboarding container used by other content-heavy pages.

## Why This Change Was Made

The permissions page now uses the existing `onboardingPage` container instead of maintaining a separate fixed-height layout. This keeps the current permission ordering, compact rows, status presentation, grant actions, mascot, and fixed navigation bar while allowing the permission content itself to scroll when the available height is too small.

A native AppKit-hosted regression verifies that the permissions page renders a document-backed `NSScrollView` at the 303-point minimum content height.

## User Impact

Users on short displays can reach and grant every macOS permission during onboarding without enlarging or moving the window. The **Finish** button remains fixed and reachable while the permission list scrolls independently.

## Evidence

Exact head: `7d12f3d5a7e1eaa4c49298148ec9d80c4bf73976`

### Signed-app before and after

Both captures use the same Developer ID signed app path, isolated HOME/state, and 630×552 minimum window frame.

**Before:** only five of eight permission rows are visible; wheel scrolling does not move the fixed page.

![Before: clipped permissions page](https://artifacts.openclaw.ai/issue-98674-permissions-scroll-20260722/before.png)

**After, top:** the same page exposes a scroll indicator while keeping **Finish** reachable.

![After: scrollable permissions page at top](https://artifacts.openclaw.ai/issue-98674-permissions-scroll-20260722/after-top.png)

**After, scrolled:** a real foreground wheel scroll reveals Speech Recognition, Camera, and Location while **Finish** remains reachable.

![After: lower permissions visible after scrolling](https://artifacts.openclaw.ai/issue-98674-permissions-scroll-20260722/after-scrolled.png)

Artifact manifest: https://artifacts.openclaw.ai/issue-98674-permissions-scroll-20260722/artifact-manifest.json

### Automated proof

- Xcode 26.6 / Swift 6.3.3: `swift test --package-path apps/macos --filter OnboardingViewSmokeTests` — 27/27 passed.
- Xcode 26.6: `swift build --package-path apps/macos --product OpenClaw` — passed.
- Pinned SwiftFormat — 0/3 touched Swift files require formatting.
- `git diff --check` — passed.
- Native app i18n inventory verification — clean; no generated baseline edit required.
- Codex autoreview over the final branch — clean, no accepted/actionable findings; patch correct, confidence 0.91.
- TruffleHog review scan — clean.

AI-assisted: Claude and Codex were used for source tracing, implementation review, native proof orchestration, and final closeout. No agent transcript is included.