### PR TITLE
fix(compaction): rotate transcript after compaction by default (#112476)

### DIFF
--- a/src/agents/embedded-agent-runner/compaction-successor-transcript.test.ts
+++ b/src/agents/embedded-agent-runner/compaction-successor-transcript.test.ts
@@ -559,8 +559,18 @@ describe("rotateTranscriptAfterCompaction", () => {
 });
 
 describe("shouldRotateCompactionTranscript", () => {
-  it("keeps transcript rotation opt-in behind the existing config key", () => {
-    expect(shouldRotateCompactionTranscript()).toBe(false);
+  it("rotates by default, opting out only on an explicit false (#112476)", () => {
+    // Unset must rotate: otherwise a long-lived session grows past the context window
+    // into an unrecoverable every-turn-compaction spiral.
+    expect(shouldRotateCompactionTranscript()).toBe(true);
+    expect(
+      shouldRotateCompactionTranscript({ agents: { defaults: { compaction: {} } } }),
+    ).toBe(true);
+    expect(
+      shouldRotateCompactionTranscript({
+        agents: { defaults: { compaction: { truncateAfterCompaction: false } } },
+      }),
+    ).toBe(false);
     expect(
       shouldRotateCompactionTranscript({
         agents: { defaults: { compaction: { truncateAfterCompaction: true } } },

--- a/src/agents/embedded-agent-runner/compaction-successor-transcript.ts
+++ b/src/agents/embedded-agent-runner/compaction-successor-transcript.ts
@@ -31,7 +31,10 @@ export type CompactionTranscriptRotation = {
 };
 
 export function shouldRotateCompactionTranscript(config?: OpenClawConfig): boolean {
-  return config?.agents?.defaults?.compaction?.truncateAfterCompaction === true;
+  // Default to rotating after compaction so a long-lived session cannot grow past the
+  // context window into an unrecoverable every-turn-compaction spiral (#112476). Only an
+  // explicit `truncateAfterCompaction: false` opts out of the successor-transcript rotation.
+  return config?.agents?.defaults?.compaction?.truncateAfterCompaction !== false;
 }
 
 export async function rotateTranscriptAfterCompaction(params: {


### PR DESCRIPTION
## What Problem This Solves

`agents.defaults.compaction.truncateAfterCompaction` is unset/`false` by default, so a long-running session's active transcript is **never shrunk after compaction**. It grows past the model's context window, after which compaction fires **every turn** and hangs at the compaction-preparation safeguard until the 120s transport timeout — leaving the lane **permanently unusable** (an unrecoverable death spiral). Long-lived, frequently-driven lanes (e.g. heartbeat sessions) hit this fastest.

Reporter verified it present in 2026.7.1, 2026.7.1-2, and 2026.7.2-beta.3.

Closes #112476.

## Why This Change Was Made

`shouldRotateCompactionTranscript` (`src/agents/embedded-agent-runner/compaction-successor-transcript.ts`) gates rotation to a smaller successor transcript on `truncateAfterCompaction === true`, so the **default (unset) never rotates** and the transcript grows unbounded. The expected behavior is that compaction keeps the active working set bounded (summary + unsummarized tail).

This makes successor-transcript rotation the **default**: `shouldRotateCompactionTranscript` now returns `true` unless `truncateAfterCompaction` is **explicitly `false`** — the opt-out is preserved. A successful compaction then always rotates to a smaller successor, so the working set stays bounded and the session remains usable indefinitely. Scope is the one guard function; the rotation machinery is unchanged.

## User Impact

Long-running sessions no longer death-spiral under the default config. Anyone who intentionally wants the old behavior can still set `truncateAfterCompaction: false`.

## Evidence

- Updated `shouldRotateCompactionTranscript` unit test: unset → rotates; `compaction: {}` → rotates; explicit `false` → does not; explicit `true` → does.
- **Rotation safety confirmed** — the existing rotation regression tests pass unchanged with rotation now default-on, so this does not reintroduce the duplicate/lost-prompt issues they guard:
  - `compaction-successor-transcript.test.ts`: **12/12**
  - `compaction-successor-transcript.duplicate-prompt-loss.test.ts`: **1/1**

**Note for maintainers:** this changes a default behavior. It's aligned with the issue's expected behavior and de-risked by the passing rotation regression suite, but if you'd prefer a narrower safety-valve (force rotation only once the active transcript exceeds the context window, leaving the default otherwise), I'm glad to switch approach — hence draft.



## Real-behavior proof (on current main)

Output from the **actual production predicate** (`shouldRotateCompactionTranscript`), head `7ab1820`. This flips the post-compaction transcript-rotation default from opt-in to opt-out:

| config | `main` (before) | this PR (after) |
|---|---|---|
| default (unset) | `rotate=false` | `rotate=true` |
| `truncateAfterCompaction: false` | `rotate=false` | `rotate=false` |
| `truncateAfterCompaction: true` | `rotate=true` | `rotate=true` |

`src/agents/embedded-agent-runner/compaction-successor-transcript.test.ts`: **12/12 green** on current `main`.

> **Note for maintainers:** this changes a **default behavior** (#112476). It is non-breaking — an explicit `agents.defaults.compaction.truncateAfterCompaction: false` still opts out — but the default flip is a product call worth a maintainer's sign-off.
>
> _Follow-up on your nod:_ the user-facing docs and the `truncateAfterCompaction` JSDoc still describe the prior `Default: false`; I scoped this PR to the behavior change and will update those docs (and can reconcile the sibling `maxActiveTranscriptBytes` default semantics) in the same PR once the default direction is confirmed.

