### PR TITLE
fix(pr): rebuild stale prep branches after head changes

### DIFF
--- a/scripts/pr-lib/gates.sh
+++ b/scripts/pr-lib/gates.sh
@@ -370,6 +370,7 @@ prepare_gates() {
   enter_worktree "$pr" false
 
   mark_pr_operation_side_effects_if_available
+  refresh_prep_branch_for_reviewed_head "$pr"
   checkout_prep_branch "$pr"
   require_artifact .local/pr-meta.env
   # shellcheck disable=SC1091

--- a/scripts/pr-lib/prepare-core.sh
+++ b/scripts/pr-lib/prepare-core.sh
@@ -9,6 +9,76 @@ checkout_prep_branch() {
   git checkout "$prep_branch"
 }
 
+refresh_prep_branch_for_reviewed_head() {
+  local pr="$1"
+  require_artifact .local/pr-meta.env
+  require_artifact .local/prep-context.env
+
+  # Capture the prepare context before review metadata overrides the same names.
+  # shellcheck disable=SC1091
+  source .local/prep-context.env
+  local prepared_head_ref="${PR_HEAD:-}"
+  local recorded_source_head="${PR_HEAD_SHA_BEFORE:-}"
+  local prep_branch="${PREP_BRANCH:-pr-$pr-prep}"
+
+  # shellcheck disable=SC1091
+  source .local/pr-meta.env
+  local reviewed_head_ref="${PR_HEAD:-}"
+  local reviewed_head_sha="${PR_HEAD_SHA:-}"
+
+  if [ -z "$recorded_source_head" ] || [ -z "$reviewed_head_sha" ]; then
+    echo "Prepare head refresh failed: missing recorded or reviewed PR head SHA. Re-run review-init and prepare-init."
+    exit 1
+  fi
+  if [ -n "$prepared_head_ref" ] && [ "$prepared_head_ref" != "$reviewed_head_ref" ]; then
+    echo "PR head branch changed from $prepared_head_ref to $reviewed_head_ref. Re-run review-init and prepare-init."
+    exit 1
+  fi
+  if [ "$recorded_source_head" = "$reviewed_head_sha" ]; then
+    return 0
+  fi
+
+  local reviewed_ref="refs/heads/pr-$pr"
+  local fetched_reviewed_head=""
+  if git show-ref --verify --quiet "$reviewed_ref"; then
+    fetched_reviewed_head=$(git rev-parse "$reviewed_ref")
+  fi
+  if [ "$fetched_reviewed_head" != "$reviewed_head_sha" ]; then
+    echo "Reviewed PR head $reviewed_head_sha is not available at $reviewed_ref (found ${fetched_reviewed_head:-missing})."
+    echo "Re-run scripts/pr review-init $pr before preparing."
+    exit 1
+  fi
+
+  local prior_prep_head
+  prior_prep_head=$(git rev-parse "refs/heads/$prep_branch")
+  echo "Prep source head changed from $recorded_source_head to reviewed head $reviewed_head_sha."
+  echo "Rebuilding $prep_branch from the reviewed PR head and invalidating stale prepare evidence."
+  git checkout -B "$prep_branch" "$reviewed_head_sha"
+  rm -f \
+    .local/gates.env \
+    .local/prep.env \
+    .local/prepare-push-result.env \
+    .local/prepare-sync-result.env
+
+  # Security: shell-escape values before sourcing this context later.
+  printf '%s=%q\n' \
+    PR_NUMBER "$pr" \
+    PR_HEAD "$reviewed_head_ref" \
+    PR_HEAD_SHA_BEFORE "$reviewed_head_sha" \
+    PREP_BRANCH "$prep_branch" \
+    PREP_STARTED_AT "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    > .local/prep-context.env
+
+  if [ ! -f .local/prep.md ]; then
+    printf '# PR %s prepare log\n\n' "$pr" > .local/prep.md
+  fi
+  cat >> .local/prep.md <<EOF_PREP
+- Rebuilt prep branch $prep_branch after reviewed PR head drifted from $recorded_source_head to $reviewed_head_sha.
+- Previous prep tip was $prior_prep_head; stale gate and prepare evidence was invalidated.
+EOF_PREP
+  PREP_BRANCH_REFRESHED=true
+}
+
 resolve_prep_branch_name() {
   local pr="$1"
   require_artifact .local/prep-context.env
@@ -59,8 +129,24 @@ prepare_init() {
     echo "WARNING: .local/review.json is missing; structured findings are expected."
   fi
 
+  local recorded_source_head=""
+  if [ -s .local/prep-context.env ]; then
+    recorded_source_head=$(
+      unset PR_HEAD_SHA_BEFORE
+      # shellcheck disable=SC1091
+      source .local/prep-context.env
+      printf '%s\n' "${PR_HEAD_SHA_BEFORE:-}"
+    )
+  fi
+
   # shellcheck disable=SC1091
   source .local/pr-meta.env
+  local reviewed_head="${PR_HEAD:-}"
+  local reviewed_head_sha="${PR_HEAD_SHA:-}"
+  if [ -z "$reviewed_head_sha" ]; then
+    echo "Prepare init failed: missing PR_HEAD_SHA in .local/pr-meta.env. Re-run review-init."
+    exit 1
+  fi
 
   local json
   json=$(pr_meta_json "$pr")
@@ -70,20 +156,30 @@ prepare_init() {
   local pr_head_sha_before
   pr_head_sha_before=$(printf '%s\n' "$json" | jq -r .headRefOid)
 
-  if [ -n "${PR_HEAD:-}" ] && [ "$head" != "$PR_HEAD" ]; then
-    echo "PR head branch changed from $PR_HEAD to $head. Re-run review-pr."
+  if [ -n "$reviewed_head" ] && [ "$head" != "$reviewed_head" ]; then
+    echo "PR head branch changed from $reviewed_head to $head. Re-run review-init."
+    exit 1
+  fi
+  if [ "$pr_head_sha_before" != "$reviewed_head_sha" ]; then
+    echo "PR head changed after review-init (reviewed $reviewed_head_sha, live $pr_head_sha_before). Re-run review-init."
     exit 1
   fi
 
   git fetch origin "pull/$pr/head:pr-$pr" --force
-  git checkout -B "pr-$pr-prep" "pr-$pr"
+  local fetched_head_sha
+  fetched_head_sha=$(git rev-parse "refs/heads/pr-$pr")
+  if [ "$fetched_head_sha" != "$reviewed_head_sha" ]; then
+    echo "PR head changed while prepare-init fetched it (reviewed $reviewed_head_sha, fetched $fetched_head_sha). Re-run review-init."
+    exit 1
+  fi
+  git checkout -B "pr-$pr-prep" "$reviewed_head_sha"
   git fetch origin main
 
   # Security: shell-escape values to prevent command injection via malicious branch names.
   printf '%s=%q\n' \
     PR_NUMBER "$pr" \
-    PR_HEAD "$head" \
-    PR_HEAD_SHA_BEFORE "$pr_head_sha_before" \
+    PR_HEAD "$reviewed_head" \
+    PR_HEAD_SHA_BEFORE "$reviewed_head_sha" \
     PREP_BRANCH "pr-$pr-prep" \
     PREP_STARTED_AT "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
     > .local/prep-context.env
@@ -93,6 +189,12 @@ prepare_init() {
 # PR $pr prepare log
 
 - Initialized prepare context from the PR head branch without rebasing on origin/main.
+EOF_PREP
+  fi
+  if [ -n "$recorded_source_head" ] && [ "$recorded_source_head" != "$reviewed_head_sha" ]; then
+    echo "Rebuilt pr-$pr-prep after reviewed PR head changed from $recorded_source_head to $reviewed_head_sha."
+    cat >> .local/prep.md <<EOF_PREP
+- Rebuilt prep branch pr-$pr-prep after reviewed PR head changed from $recorded_source_head to $reviewed_head_sha.
 EOF_PREP
   fi
 
@@ -135,10 +237,17 @@ prepare_push() {
 
   require_artifact .local/pr-meta.env
   require_artifact .local/prep-context.env
-  require_artifact .local/gates.env
 
   mark_pr_operation_side_effects_started
+  PREP_BRANCH_REFRESHED=false
+  refresh_prep_branch_for_reviewed_head "$pr"
   checkout_prep_branch "$pr"
+  if [ "$PREP_BRANCH_REFRESHED" = "true" ]; then
+    echo "Prep branch was refreshed for reviewed head drift; rerunning prepare gates before push."
+    prepare_gates "$pr"
+    checkout_prep_branch "$pr"
+  fi
+  require_artifact .local/gates.env
 
   # shellcheck disable=SC1091
   source .local/pr-meta.env

--- a/test/scripts/check-changelog-attributions.test.ts
+++ b/test/scripts/check-changelog-attributions.test.ts
@@ -238,6 +238,7 @@ source "$OPENCLAW_PR_GATES_SH"
 
 enter_worktree() { :; }
 checkout_prep_branch() { :; }
+refresh_prep_branch_for_reviewed_head() { :; }
 bootstrap_deps_if_needed() { :; }
 require_artifact() { [ -s "$1" ]; }
 normalize_pr_changelog_entries() { printf 'normalize\\n' >>"$OPENCLAW_TEST_CALLS"; }
@@ -289,6 +290,7 @@ source "$OPENCLAW_PR_GATES_SH"
 
 enter_worktree() { :; }
 checkout_prep_branch() { :; }
+refresh_prep_branch_for_reviewed_head() { :; }
 bootstrap_deps_if_needed() { :; }
 require_artifact() { [ -s "$1" ]; }
 normalize_pr_changelog_entries() { printf 'normalize\\n' >>"$OPENCLAW_TEST_CALLS"; }

--- a/test/scripts/pr-prepare-gates.test.ts
+++ b/test/scripts/pr-prepare-gates.test.ts
@@ -67,7 +67,7 @@ function runGatesBash(
         ...(options.sourcePush ? [`source '${repoRoot}/scripts/pr-lib/push.sh'`] : []),
         ...(options.sourcePrepareCore
           ? [`source '${repoRoot}/scripts/pr-lib/prepare-core.sh'`]
-          : []),
+          : ["refresh_prep_branch_for_reviewed_head() { :; }"]),
         script,
       ].join("\n"),
     ],
@@ -171,6 +171,69 @@ function makeSyncRepo(options: { needsRebase: boolean }): string {
   writeFileSync(join(repoDir, ".local", "prep-context.env"), "PR_HEAD=topic\nPREP_BRANCH=prep\n");
   writeFileSync(join(repoDir, ".local", "prep.md"), "# Prepare\n");
   return repoDir;
+}
+
+function makePreparePushHeadDriftRepo(): {
+  repoDir: string;
+  recordedHead: string;
+  reviewedHead: string;
+} {
+  const repoDir = join(makeTempDir("openclaw-pr-prepare-drift-"), "repo");
+  mkdirSync(repoDir);
+
+  const git = (...args: string[]) => {
+    const result = spawnSync("git", args, { cwd: repoDir, encoding: "utf8" });
+    expect(result.status, result.stderr).toBe(0);
+    return result.stdout.trim();
+  };
+  git("init", "-q", "-b", "main");
+  git("config", "user.name", "t");
+  git("config", "user.email", "t@example.com");
+  writeFileSync(join(repoDir, "base.txt"), "base\n");
+  git("add", "base.txt");
+  git("commit", "-qm", "base");
+  const recordedHead = git("rev-parse", "HEAD");
+  git("remote", "add", "origin", ".");
+  git("fetch", "-q", "origin", "main");
+
+  git("checkout", "-qb", "pr-4242");
+  writeFileSync(join(repoDir, "reviewed.txt"), "new reviewed head\n");
+  git("add", "reviewed.txt");
+  git("commit", "-qm", "reviewed head update");
+  const reviewedHead = git("rev-parse", "HEAD");
+
+  git("checkout", "-qb", "prep", recordedHead);
+  writeFileSync(join(repoDir, "stale-fixup.txt"), "belongs to stale prep head\n");
+  git("add", "stale-fixup.txt");
+  git("commit", "-qm", "stale prep fixup");
+
+  mkdirSync(join(repoDir, ".local"));
+  writeFileSync(
+    join(repoDir, ".local", "pr-meta.env"),
+    [
+      "PR_NUMBER=4242",
+      "PR_AUTHOR=steipete",
+      "PR_URL=https://example.test/pr/4242",
+      "PR_HEAD=topic",
+      `PR_HEAD_SHA=${reviewedHead}`,
+      "",
+    ].join("\n"),
+  );
+  writeFileSync(
+    join(repoDir, ".local", "prep-context.env"),
+    [
+      "PR_NUMBER=4242",
+      "PR_HEAD=topic",
+      `PR_HEAD_SHA_BEFORE=${recordedHead}`,
+      "PREP_BRANCH=prep",
+      "PREP_STARTED_AT=2026-07-19T00:00:00Z",
+      "",
+    ].join("\n"),
+  );
+  writeFileSync(join(repoDir, ".local", "gates.env"), "GATES_MODE=stale\n");
+  writeFileSync(join(repoDir, ".local", "prep.env"), "PREP_HEAD_SHA=stale\n");
+  writeFileSync(join(repoDir, ".local", "prep.md"), "# Prepare\n");
+  return { repoDir, recordedHead, reviewedHead };
 }
 
 function prepareSyncHeadStubs(): string[] {
@@ -505,6 +568,45 @@ describe("prepare sync-head transitions", () => {
     expect(result.status, result.stderr).toBe(0);
     expect(result.stdout).toContain("prepare-sync-head complete");
     expect(result.stdout).not.toContain("Rebase");
+  });
+});
+
+describe("prepare push head drift", () => {
+  it("rebuilds a stale prep branch and reruns gates before push", () => {
+    const { repoDir, recordedHead, reviewedHead } = makePreparePushHeadDriftRepo();
+    const result = runGatesBash(
+      [
+        "enter_worktree() { :; }",
+        `reviewed_head='${reviewedHead}'`,
+        'gh() { printf "%s\\n" "$reviewed_head"; }',
+        "verify_pr_head_branch_matches_expected() { :; }",
+        "prepare_gates() {",
+        "  touch .local/gates-reran",
+        "  printf 'DOCS_ONLY=false\\nGATES_MODE=fresh\\n' > .local/gates.env",
+        "}",
+        "push_prep_head_to_pr_branch() {",
+        '  local result_env="$7"',
+        '  printf \'PUSH_PREP_HEAD_SHA=%q\\nPUSH_LOCAL_PREP_HEAD_SHA=%q\\nPUSHED_FROM_SHA=%q\\nPR_HEAD_SHA_AFTER_PUSH=%q\\n\' "$3" "$3" "$reviewed_head" "$3" > "$result_env"',
+        "}",
+        "prepare_push 4242",
+        'test "$(git rev-parse HEAD)" = "$reviewed_head"',
+        "test -e .local/gates-reran",
+        "test ! -e stale-fixup.txt",
+        'test "$(. .local/prep-context.env; printf "%s" "$PR_HEAD_SHA_BEFORE")" = "$reviewed_head"',
+        `grep -F 'drifted from ${recordedHead} to ${reviewedHead}' .local/prep.md`,
+        "grep -F 'Gate mode: fresh' .local/prep.md",
+      ].join("\n"),
+      { cwd: repoDir, sourcePrepareCore: true },
+    );
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain(
+      `Prep source head changed from ${recordedHead} to reviewed head ${reviewedHead}.`,
+    );
+    expect(result.stdout).toContain(
+      "Prep branch was refreshed for reviewed head drift; rerunning prepare gates before push.",
+    );
+    expect(result.stdout).toContain("prepare-push complete");
   });
 });
 

--- a/ui/src/pages/chat/chat-view-state.ts
+++ b/ui/src/pages/chat/chat-view-state.ts
@@ -1,0 +1,7 @@
+import { resetChatComposerState } from "./components/chat-composer.ts";
+import { resetChatThreadPresentationState } from "./components/chat-thread.ts";
+
+export function resetChatViewState(paneId?: string, owner?: ParentNode) {
+  resetChatComposerState(paneId);
+  resetChatThreadPresentationState(paneId, owner);
+}

--- a/ui/src/pages/chat/chat-view.ts
+++ b/ui/src/pages/chat/chat-view.ts
@@ -39,11 +39,7 @@ import {
   renderBackgroundTasksRail,
   type BackgroundTasksProps,
 } from "./components/chat-background-tasks.ts";
-import {
-  isChatRunWorking,
-  renderChatComposer,
-  resetChatComposerState,
-} from "./components/chat-composer.ts";
+import { isChatRunWorking, renderChatComposer } from "./components/chat-composer.ts";
 import { renderChatPullRequests } from "./components/chat-pull-requests.ts";
 import {
   renderSessionWorkspaceRail,
@@ -63,7 +59,6 @@ import {
   renderChatPinnedMessages,
   renderChatSearchBar,
   renderChatThread,
-  resetChatThreadPresentationState,
   toggleChatThreadSearch,
 } from "./components/chat-thread.ts";
 import { renderWorkspaceConflictNotice } from "./components/chat-workspace-conflict.ts";
@@ -76,6 +71,8 @@ import type { ChatRunUiStatus } from "./run-lifecycle.ts";
 import type { CompactionStatus, FallbackStatus, PlanStatus } from "./tool-stream.ts";
 import type { WorkspaceResultConflict } from "./workspace-conflict.ts";
 import "../../components/resizable-divider.ts";
+
+export { resetChatViewState } from "./chat-view-state.ts";
 
 export type ChatProps = {
   transcript: ChatTranscriptController;
@@ -261,11 +258,6 @@ export type ChatProps = {
   onExpandPullRequests?: () => void;
   onDismissPullRequest?: (pullRequest: ControlUiSessionPullRequest) => void;
 };
-
-export function resetChatViewState(paneId?: string, owner?: ParentNode) {
-  resetChatComposerState(paneId);
-  resetChatThreadPresentationState(paneId, owner);
-}
 
 export function renderChatResizableDivider(props: {
   className?: string;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where maintainers rerunning `scripts/pr prepare-run` after new commits were pushed to a PR could retain a prep branch built from the prior head. Hosted-gate verification then looked for evidence on the stale SHA and failed with `Missing successful recent CI workflow for <old-sha>`, forcing operators to delete the prep branch manually and restart review initialization. This was observed during landings on July 19 and July 20, 2026.

## Why This Change Was Made

The prepare flow now binds its recorded source head to the exact head captured by `review-init`. When those SHAs diverge, it rebuilds the prep branch from the reviewed PR ref, invalidates stale gate and prepare stamps, records the refresh in the prepare log, and reruns gates before `prepare-push`. `prepare-init` also fails closed if the live or fetched head no longer matches the reviewed metadata.

The first exact-head CI run exposed one additional standalone gate fixture that sourced `gates.sh` without the prepare helper; that sibling fixture now models the dependency too. The same run also inherited an unrelated red-`main` max-lines failure in `chat-view.ts`. Per landing policy, this PR carries the smallest behavior-neutral repair: the existing seven-line reset helper moved into a focused state module and remains re-exported from the original API.

## User Impact

Maintainers can refresh review metadata and rerun prepare without manually deleting `pr-<n>-prep`. Head changes after review still fail closed until the new head has actually been reviewed.

## Evidence

- Regression: `corepack pnpm test test/scripts/pr-prepare-gates.test.ts` — 39/39 tests passed on Blacksmith Testbox ([run](https://github.com/openclaw/openclaw/actions/runs/29890776212)). The new fixture proves the stale prep tip is removed, the context is rewritten to the reviewed head, stale evidence is invalidated, and gates rerun before push.
- Changed-surface gate: `node scripts/check-changed.mjs` — formatting, script declarations, root test types, and script lint passed on Blacksmith Testbox ([run](https://github.com/openclaw/openclaw/actions/runs/29890913745)).
- Autoreview: Codex reported no accepted or actionable findings and rated the patch correct with 0.88 confidence.
- CI-repair regression: `corepack pnpm test test/scripts/pr-prepare-gates.test.ts test/scripts/check-changelog-attributions.test.ts ui/src/pages/chat/chat-view.test.ts` — 49 tooling tests and 194 UI tests passed on Blacksmith Testbox ([run](https://github.com/openclaw/openclaw/actions/runs/29891593670)).
- Expanded changed-surface gate: `node scripts/check-changed.mjs` — max-lines ratchet, formatting, i18n, UI/core/root typechecks, and UI/script lint passed on Blacksmith Testbox ([run](https://github.com/openclaw/openclaw/actions/runs/29891652648)).
- Final autoreview after the CI repairs: Codex reported no accepted or actionable findings and rated the patch correct with 0.94 confidence.

## ClawSweeper Rank-up Decision

Maintainer decision: accept the focused fixture and exact-head CI as sufficient pre-merge evidence. A true after-fix `scripts/pr prepare-push` run cannot safely execute until this change is on `main`: the canonical-wrapper trust boundary correctly rejects landing subcommands when the branch's `scripts/pr-lib` differs from `origin/main`, even with the advisory dev-wrapper opt-in. Bypassing that guard to manufacture live proof would weaken the very landing boundary this PR preserves. The regression fixture exercises the exact old-source/new-reviewed-head transition, and the first normal post-merge prepare operation can provide the live observation without bypassing policy.

- [x] AI-assisted; the author reviewed and understands the change.
