### PR TITLE
fix(media): keep hosted plugin media pinned

### DIFF
--- a/src/media/web-media.test.ts
+++ b/src/media/web-media.test.ts
@@ -10,7 +10,12 @@ import { createSolidPngBuffer } from "../../test/helpers/image-fixtures.js";
 import { resolveStateDir } from "../config/paths.js";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
-import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
+import {
+  pinActivePluginHttpRouteRegistry,
+  releasePinnedPluginHttpRouteRegistry,
+  resetPluginRuntimeStateForTest,
+  setActivePluginRegistry,
+} from "../plugins/runtime.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import { resizeToJpeg } from "./media-services.js";
 import { encodePngRgba, fillPixel } from "./png-encode.js";
@@ -343,6 +348,32 @@ describe("loadWebMedia", () => {
 
     expect(result.kind).toBe("image");
     expect(result.buffer.length).toBeGreaterThan(0);
+  });
+
+  it("loads hosted plugin media from the pinned HTTP-route registry", async () => {
+    const httpRegistry = createEmptyPluginRegistry();
+    httpRegistry.hostedMediaResolvers = [
+      {
+        pluginId: "hosted-media",
+        resolver: (mediaUrl) =>
+          mediaUrl === "/__test__/hosted/pinned-tiny.png" ? canvasPngFile : null,
+        source: "test",
+      },
+    ];
+
+    try {
+      pinActivePluginHttpRouteRegistry(httpRegistry);
+      setActivePluginRegistry(createEmptyPluginRegistry());
+
+      const result = await loadWebMedia("/__test__/hosted/pinned-tiny.png", {
+        maxBytes: 1024 * 1024,
+      });
+
+      expect(result.kind).toBe("image");
+      expect(result.buffer.length).toBeGreaterThan(0);
+    } finally {
+      releasePinnedPluginHttpRouteRegistry(httpRegistry);
+    }
   });
 
   it("surfaces Rastermill decode failures when image optimization cannot produce a JPEG", async () => {

--- a/src/media/web-media.ts
+++ b/src/media/web-media.ts
@@ -27,7 +27,7 @@ import { assertNoWindowsNetworkPath, safeFileURLToPath } from "../infra/local-fi
 import type { PinnedDispatcherPolicy, SsrFPolicy } from "../infra/net/ssrf.js";
 import { isNotFoundPathError } from "../infra/path-guards.js";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
-import { getActivePluginRegistry } from "../plugins/runtime.js";
+import { getActivePluginHttpRouteRegistry } from "../plugins/runtime.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import {
   openOpenClawStateDatabase,
@@ -118,7 +118,7 @@ async function resolveMediaStoreUriToPath(mediaUrl: string): Promise<string | nu
 }
 
 async function resolveHostedPluginMediaUrl(mediaUrl: string): Promise<string | null> {
-  const registry = getActivePluginRegistry();
+  const registry = getActivePluginHttpRouteRegistry();
   for (const entry of registry?.hostedMediaResolvers ?? []) {
     try {
       const resolved = await entry.resolver(mediaUrl);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where plugin-hosted media could disappear when the active plugin registry changed while the Gateway HTTP-route registry was still pinned. A hosted media resolver registered with the pinned Gateway surface could be skipped, causing `loadWebMedia()` to treat the plugin URL as an ordinary local path instead of resolving it through the plugin.

## Why This Change Was Made

Hosted media resolvers are registered alongside plugin network/HTTP route contributions, so the media loader now reads them from the active HTTP-route registry rather than the request-local active registry. The regression test pins an HTTP registry, swaps the active registry to empty, and verifies the hosted media path still loads.

## User Impact

Plugin-hosted images and attachments remain available across request-local registry swaps and Gateway plugin surface pinning.

## Evidence

- `node scripts/run-vitest.mjs src/media/web-media.test.ts` — 76/76 tests passed.
- `npx tsx proof-live.ts` imports the real `loadWebMedia()` production module and shows pinned HTTP registry resolution works while the active registry has zero hosted media resolvers.

```text
$ npx tsx proof-live.ts
entrypoint: loadWebMedia
active-registry-hosted-media-resolvers: 0
pinned-http-registry-hosted-media-resolvers: 1
valid: ok=true kind=image bytes=70
negative-control: hosted path is unavailable after releasing pinned registry
```

<details>
<summary>proof-live.ts</summary>

```ts
import fs from "node:fs/promises";
import os from "node:os";
import path from "node:path";
import { loadWebMedia } from "./src/media/web-media.js";
import { createEmptyPluginRegistry } from "./src/plugins/registry-empty.js";
import {
  pinActivePluginHttpRouteRegistry,
  releasePinnedPluginHttpRouteRegistry,
  resetPluginRuntimeStateForTest,
  setActivePluginRegistry,
} from "./src/plugins/runtime.js";

const tinyPngBase64 =
  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAFgwJ/lO3J8gAAAABJRU5ErkJggg==";
const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-hosted-media-proof-"));
const tinyPngPath = path.join(tmpDir, "tiny.png");
const hostedPath = "/__proof__/hosted/tiny.png";

await fs.writeFile(tinyPngPath, Buffer.from(tinyPngBase64, "base64"));

const httpRegistry = createEmptyPluginRegistry();
httpRegistry.hostedMediaResolvers = [
  {
    pluginId: "proof-hosted-media",
    resolver: (mediaUrl) => (mediaUrl === hostedPath ? tinyPngPath : null),
    source: "proof",
  },
];

try {
  resetPluginRuntimeStateForTest();
  pinActivePluginHttpRouteRegistry(httpRegistry);
  setActivePluginRegistry(createEmptyPluginRegistry());

  const result = await loadWebMedia(hostedPath, { maxBytes: 1024 * 1024, localRoots: [tmpDir] });
  console.log("entrypoint: loadWebMedia");
  console.log("active-registry-hosted-media-resolvers: 0");
  console.log(`pinned-http-registry-hosted-media-resolvers: ${httpRegistry.hostedMediaResolvers.length}`);
  console.log(`valid: ok=${result.kind === "image"} kind=${result.kind} bytes=${result.buffer.length}`);

  releasePinnedPluginHttpRouteRegistry(httpRegistry);
  setActivePluginRegistry(createEmptyPluginRegistry());
  try {
    await loadWebMedia(hostedPath, { maxBytes: 1024 * 1024, localRoots: [tmpDir] });
    console.log("negative-control: unexpected success after releasing pinned registry");
    process.exitCode = 1;
  } catch {
    console.log("negative-control: hosted path is unavailable after releasing pinned registry");
  }
} finally {
  resetPluginRuntimeStateForTest();
  await fs.rm(tmpDir, { recursive: true, force: true });
}
```

</details>

AI-assisted: built with Codex
