### PR TITLE
test: restore shared environment mutations

### DIFF
--- a/src/agents/models.profiles.live.test.ts
+++ b/src/agents/models.profiles.live.test.ts
@@ -1752,10 +1752,7 @@ describeLive("live models (profile keys)", () => {
         ? []
         : collectProviderApiKeys("anthropic");
       if (anthropicKeys.length > 0) {
-        vi.stubEnv(
-          "ANTHROPIC_API_KEY",
-          expectDefined(anthropicKeys[0], "Anthropic API key 1"),
-        );
+        vi.stubEnv("ANTHROPIC_API_KEY", expectDefined(anthropicKeys[0], "Anthropic API key 1"));
         logProgress(`[live-models] anthropic keys loaded: ${anthropicKeys.length}`);
       }
 

--- a/src/agents/models.profiles.live.test.ts
+++ b/src/agents/models.profiles.live.test.ts
@@ -1752,7 +1752,10 @@ describeLive("live models (profile keys)", () => {
         ? []
         : collectProviderApiKeys("anthropic");
       if (anthropicKeys.length > 0) {
-        process.env.ANTHROPIC_API_KEY = anthropicKeys[0];
+        vi.stubEnv(
+          "ANTHROPIC_API_KEY",
+          expectDefined(anthropicKeys[0], "Anthropic API key 1"),
+        );
         logProgress(`[live-models] anthropic keys loaded: ${anthropicKeys.length}`);
       }
 
@@ -1952,9 +1955,6 @@ describeLive("live models (profile keys)", () => {
             model.provider === "anthropic" && anthropicKeys.length > 0
               ? expectDefined(anthropicKeys[attempt], `Anthropic API key ${attempt + 1}`)
               : undefined;
-          if (anthropicApiKey) {
-            process.env.ANTHROPIC_API_KEY = anthropicApiKey;
-          }
           const apiKey = anthropicApiKey ?? requireApiKey(apiKeyInfo, model.provider);
           try {
             // Special regression: OpenAI requires replayed `reasoning` items for tool-only turns.

--- a/src/agents/tools/image-tool.ollama.live.test.ts
+++ b/src/agents/tools/image-tool.ollama.live.test.ts
@@ -2,7 +2,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { createImageTool } from "./image-tool.js";
 
@@ -43,7 +43,9 @@ async function withLiveImageWorkspace<T>(
 
 describe.skipIf(!LIVE)("image tool Ollama live", () => {
   it("describes a local image through a providerless configured Ollama image model", async () => {
-    process.env.OLLAMA_API_KEY ||= "ollama-local";
+    if (!process.env.OLLAMA_API_KEY) {
+      vi.stubEnv("OLLAMA_API_KEY", "ollama-local");
+    }
     await withLiveImageWorkspace(async ({ agentDir, workspaceDir, imagePath }) => {
       const cfg: OpenClawConfig = {
         agents: {

--- a/src/commands/channels/capabilities.test.ts
+++ b/src/commands/channels/capabilities.test.ts
@@ -1,6 +1,4 @@
 // Channels capabilities tests cover capability reporting, account selection, probes, and installable plugins.
-process.env.NO_COLOR = "1";
-
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getChannelPlugin, listChannelPlugins } from "../../channels/plugins/index.js";
 import type { ChannelPlugin } from "../../channels/plugins/types.public.js";
@@ -129,6 +127,7 @@ function buildPlugin(params: {
 
 describe("channelsCapabilitiesCommand", () => {
   beforeEach(() => {
+    vi.stubEnv("NO_COLOR", "1");
     resetOutput();
     vi.clearAllMocks();
     mocks.readConfigFileSnapshot.mockResolvedValue({ hash: "config-1" });

--- a/src/commands/onboard-channels.e2e.test.ts
+++ b/src/commands/onboard-channels.e2e.test.ts
@@ -627,7 +627,7 @@ describe("setupChannels", () => {
     // Simulate missing registry entries (the scenario reported in #25545).
     setActivePluginRegistry(createEmptyPluginRegistry());
     // Avoid accidental env-token configuration changing the prompt path.
-    process.env.TELEGRAM_BOT_TOKEN = "";
+    vi.stubEnv("TELEGRAM_BOT_TOKEN", "");
 
     const note = vi.fn(async (_message?: string, _title?: string) => {});
     const select = vi.fn(async ({ message }: { message: string }) => {


### PR DESCRIPTION
## What Problem This Solves

Several tests mutate `process.env` directly. Vitest restores variables changed through `vi.stubEnv`, but direct assignments can survive later tests in the same shared worker and make outcomes order-dependent.

## Why This Change Was Made

Replace the actual leaking mutations with Vitest-managed environment stubs. The live Anthropic sweep now sets the first discovery key through `vi.stubEnv` and stops rewriting the process-global key inside concurrent model tasks because every completion already receives its rotated `apiKey` explicitly.

The Matrix onboarding suite was reviewed but intentionally not changed: its harness already snapshots and restores every Matrix environment key after each test.

## User Impact

Developers get more deterministic shared-worker tests. Production behavior is unchanged, and credentialed live tests retain their existing key-selection semantics.

## Evidence

- `node scripts/run-vitest.mjs src/commands/channels/capabilities.test.ts src/commands/onboard-channels.e2e.test.ts src/agents/tools/image-tool.ollama.live.test.ts src/agents/models.profiles.live.test.ts`
  - ordinary command/E2E shards: 25 tests passed
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.live.config.ts src/agents/models.profiles.live.test.ts src/agents/tools/image-tool.ollama.live.test.ts`
  - 36 noncredentialed tests passed
  - 2 credentialed live cases skipped as expected
- `git diff --check`: passed
- Formal Codex autoreview: clean, no accepted/actionable findings

AI-assisted: yes.
