### PR TITLE
fix(ui): presence avatars show both photo and initials fallback

### DIFF
--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1936,7 +1936,9 @@ html.openclaw-native-macos
   height: 100%;
 }
 
-.viewer-avatar__fallback {
+/* Two classes on purpose: `.viewer-avatar > span` below sets display and
+   outranks a lone class, which showed image + initials side by side. */
+.viewer-avatar > .viewer-avatar__fallback {
   display: none;
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users with a profile picture would see two avatars side by side — the photo plus a colored initials bubble — in the who's-online presence roster, the footer facepile, and session facepiles.

## Why This Change Was Made

`openclaw-viewer-avatar` always renders the `<img>` together with a hidden initials fallback span so a failed image load can swap to initials without a re-render. The hiding rule used a lone class selector (`.viewer-avatar__fallback`, specificity 0-1-0), which the later generic sizing rule `.viewer-avatar > span { display: inline-flex }` (0-1-1) outranks — so the fallback was never actually hidden. Most visible in the roster popup, where the avatar wrapper uses `overflow: visible`. The fix bumps the hiding selector to `.viewer-avatar > .viewer-avatar__fallback` (0-2-0); the `.is-fallback` swap (0-3-0) still wins when the image errors. Regressed in #111421. The chat avatar siblings (`.chat-avatar-slot > .chat-avatar--sender-initials`, `.chat-author-avatar__fallback`) already use selectors that are not outranked, so they are unaffected.

## User Impact

Presence avatars show either the profile picture or the initials bubble, never both. Initials-only users and broken-image fallback behavior are unchanged.

## Evidence

- One-line CSS specificity fix; verified in a browser harness that inlines the real `ui/src/styles/layout.css` (before/after) with the exact markup `openclaw-viewer-avatar` renders, across four cases: image avatar in a roster row, image avatar in the footer facepile, initials-only avatar, and `is-fallback` (broken image). Before: photo + initials render side by side (matches the reported screenshot). After: image-only shows just the photo; initials-only and broken-image fallback still show initials.
- Codex autoreview (`gpt-5.6-sol`, xhigh): clean, "patch is correct (0.96)".
