### PR TITLE
fix: dashboard sessions lose subagent spawn rights after auto-parenting to main

### DIFF
--- a/src/agents/subagent-depth.test.ts
+++ b/src/agents/subagent-depth.test.ts
@@ -73,6 +73,23 @@ describe("getSubagentDepthFromSessionStore", () => {
     expect(depth).toBe(1);
   });
 
+  it("prefers stored spawnDepth 0 over parentSessionKey ancestry for operator dashboard sessions", () => {
+    // Operator-created dashboard sessions are auto-parented to main for UI
+    // threading; the explicit spawnDepth 0 keeps them spawn-capable roots.
+    const depth = getSubagentDepthFromSessionStore("agent:main:dashboard:operator", {
+      store: {
+        "agent:main:main": { sessionId: "root" },
+        "agent:main:dashboard:operator": {
+          sessionId: "operator",
+          spawnDepth: 0,
+          parentSessionKey: "agent:main:main",
+        },
+      },
+    });
+
+    expect(depth).toBe(0);
+  });
+
   it("resolves depth when caller is identified by sessionId", () => {
     const key1 = "agent:main:subagent:one";
     const key2 = "agent:main:subagent:two";

--- a/src/gateway/server.sessions.create.test.ts
+++ b/src/gateway/server.sessions.create.test.ts
@@ -741,12 +741,16 @@ test.each([undefined, "main"])(
 
     const created = await directSessionReq<{
       key?: string;
-      entry?: { parentSessionKey?: string };
+      entry?: { parentSessionKey?: string; spawnDepth?: number };
     }>("sessions.create", { agentId: "main" });
 
     expect(created.ok, JSON.stringify(created.error)).toBe(true);
     expect(created.payload?.key).toMatch(/^agent:main:dashboard:/);
     expect(created.payload?.entry?.parentSessionKey).toBe("agent:main:main");
+    // Auto-parented operator sessions must stay spawn-capable roots: without the
+    // explicit depth, spawn admission derives depth 1 from parentSessionKey and
+    // rejects all sessions_spawn calls at the default maxSpawnDepth of 1.
+    expect(created.payload?.entry?.spawnDepth).toBe(0);
   },
 );
 
@@ -761,7 +765,7 @@ test("sessions.create preserves an explicit parent under main dmScope", async ()
 
   const created = await directSessionReq<{
     key?: string;
-    entry?: { parentSessionKey?: string };
+    entry?: { parentSessionKey?: string; spawnDepth?: number };
   }>("sessions.create", {
     agentId: "main",
     parentSessionKey: "agent:main:explicit-parent",
@@ -769,6 +773,9 @@ test("sessions.create preserves an explicit parent under main dmScope", async ()
 
   expect(created.ok, JSON.stringify(created.error)).toBe(true);
   expect(created.payload?.entry?.parentSessionKey).toBe("agent:main:explicit-parent");
+  // Explicit parents include visible spawn children, whose depth is derived by
+  // walking parentSessionKey; a stored root depth here would let them over-spawn.
+  expect(created.payload?.entry?.spawnDepth).toBeUndefined();
 
   const reused = await directSessionReq<{
     entry?: { parentSessionKey?: string };

--- a/src/gateway/session-create-service.ts
+++ b/src/gateway/session-create-service.ts
@@ -790,10 +790,9 @@ export async function createGatewaySession(params: {
         };
         sessionEntries[target.canonicalKey] = initializedEntry;
         const initialized = { ...patched, entry: initializedEntry };
-        const storedParentSessionKey =
-          canonicalParentSessionKey ??
-          normalizeOptionalString(initializedEntry.parentSessionKey) ??
-          dashboardParentSessionKey;
+        const explicitParentSessionKey =
+          canonicalParentSessionKey ?? normalizeOptionalString(initializedEntry.parentSessionKey);
+        const storedParentSessionKey = explicitParentSessionKey ?? dashboardParentSessionKey;
         if (!storedParentSessionKey) {
           return initialized;
         }
@@ -805,6 +804,13 @@ export async function createGatewaySession(params: {
           ...initializedEntry,
           ...inheritedSelection,
           parentSessionKey: storedParentSessionKey,
+          // Auto-parenting to main is dashboard threading, not spawn lineage. Depth
+          // recovery walks parentSessionKey for visible spawn children, so record
+          // depth 0 explicitly or operator sessions classify as depth-1 subagents
+          // and lose spawn rights (maxSpawnDepth admission).
+          ...(!explicitParentSessionKey && initializedEntry.spawnDepth === undefined
+            ? { spawnDepth: 0 }
+            : {}),
         };
         if (params.fork !== true) {
           return { ...initialized, entry };


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users starting a swarm (or any `sessions_spawn` call) from a WebChat/dashboard session would see every spawn rejected with `sessions_spawn is not allowed at this depth (current depth: 1, max: 1)`, so swarm collectors never launched and the swarm dashboard visualization never appeared. The same task worked from a CLI session.

Since #110913, operator-created dashboard sessions are auto-parented to the agent main session (`parentSessionKey`) for sidebar threading. Subagent depth recovery (`getSubagentDepthFromSessionStore`) walks `parentSessionKey` as spawn lineage — required for visible spawn children, which live under dashboard keys and carry no explicit spawn fields. The collision makes every operator dashboard session resolve to spawn depth 1, which exhausts the default `maxSpawnDepth` of 1 and strips all spawn rights from the web UI.

## Why This Change Was Made

The creation site is the only place that knows whether a parent link is UI threading or spawn lineage, so the fact is recorded there: auto-parented dashboard creations now persist an explicit `spawnDepth: 0`, which depth recovery prefers over ancestry walking. Creations with an explicit `parentSessionKey` (visible spawn children, forks) are deliberately unchanged — they must keep deriving depth from lineage, otherwise visible children could over-spawn. The entry persists via `session_entries.entry_json`; no schema change.

Known gap, out of scope: dashboard sessions created since #110913 shipped already have the ambiguous store shape (`parentSessionKey` to main, no `spawnDepth`) and remain depth-1; that shape is byte-identical to a visible spawn child of main, so a doctor backfill needs a discriminating fact (e.g. the subagent run ledger) and a product decision. Starting a new chat resolves it. Operator UI forks share the same pre-existing depth-1 behavior.

## User Impact

Spawning subagents — including OpenClaw Swarm collectors — works again from web dashboard sessions, and the swarm visualization renders on the session that spawned the collectors. No behavior change for CLI sessions, visible spawn children, or forks.

## Evidence

- Focused tests on Blacksmith Testbox (lease `tbx_01ky43qhyps9krw6xs07pa5b46`): `src/gateway/server.sessions.create.test.ts` (52 passed) and `src/agents/subagent-depth.test.ts` (17 passed) — https://github.com/openclaw/openclaw/actions/runs/29893054475
- `check:changed` over the touched files on Testbox (lease `tbx_01ky43y06k3nc8csnfkcdhhfhe`), exit 0 — https://github.com/openclaw/openclaw/actions/runs/29893220238
- New regression tests: auto-parented dashboard creations store `spawnDepth: 0`; explicit-parent creations store none; depth walker prefers stored depth 0 over `parentSessionKey` ancestry.
- Codex autoreview (`gpt-5.6-sol`, xhigh): clean, no accepted findings.
