### PR TITLE
feat(plugin-sdk): add Gateway-managed realtime Talk sessions

### DIFF
--- a/docs/plugins/sdk-runtime.md
+++ b/docs/plugins/sdk-runtime.md
@@ -630,6 +630,30 @@ two-party event loops that do not go through the shared inbound reply runner.
     gateway.
 
   </Accordion>
+  <Accordion title="api.runtime.talk">
+    Open a plugin-owned voice conversation. OpenClaw handles realtime provider
+    setup, agent tool calls, workspace access, and turn coordination.
+
+    ```typescript
+    const session = await api.runtime.talk.openSession({
+      sessionKey: "agent:main:avatar",
+      onEvent(event) {
+        if (event.type === "audio") player.write(event.pcm);
+      },
+    });
+
+    session.sendAudio(microphonePcm);
+    session.cancelOutput();
+    session.close();
+    ```
+
+    `openSession` is available from Gateway-authenticated plugin routes that
+    declare `contracts.gatewayMethodDispatch`. Input and output are PCM16LE,
+    24 kHz mono audio. This is a trusted operator surface, not a plugin sandbox:
+    the caller may select an agent session and receive its raw Talk output. A
+    browser UI must obtain microphone permission before sending input audio.
+
+  </Accordion>
   <Accordion title="api.runtime.system">
     System-level utilities.
 

--- a/src/gateway/talk-managed-agent-consult.runtime.ts
+++ b/src/gateway/talk-managed-agent-consult.runtime.ts
@@ -1,0 +1,11 @@
+// Lazy runtime boundary for Gateway-owned realtime agent consultation.
+import { createRuntimeAgent } from "../plugins/runtime/runtime-agent.js";
+import { consultRealtimeVoiceAgent } from "../talk/agent-consult-runtime.js";
+
+const agentRuntime = createRuntimeAgent();
+
+export async function consultTalkManagedAgent(
+  params: Omit<Parameters<typeof consultRealtimeVoiceAgent>[0], "agentRuntime">,
+) {
+  return await consultRealtimeVoiceAgent({ ...params, agentRuntime });
+}

--- a/src/gateway/talk-plugin-session.test.ts
+++ b/src/gateway/talk-plugin-session.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  scope: vi.fn(),
+  ensureSession: vi.fn(),
+  resolveProvider: vi.fn(),
+  createRelay: vi.fn(),
+  sendAudio: vi.fn(),
+  cancelTurn: vi.fn(),
+  stopSession: vi.fn(),
+}));
+
+vi.mock("../plugins/runtime/gateway-request-scope.js", () => ({
+  getPluginRuntimeGatewayRequestScope: mocks.scope,
+}));
+vi.mock("../talk/client-voice-session.js", () => ({
+  ensureClientVoiceAgentSessionEntry: mocks.ensureSession,
+}));
+vi.mock("../talk/provider-resolver.js", () => ({
+  resolveConfiguredRealtimeVoiceProvider: mocks.resolveProvider,
+}));
+vi.mock("./talk-realtime-relay.js", () => ({
+  createTalkRealtimeRelaySession: mocks.createRelay,
+  sendTalkRealtimeRelayAudio: mocks.sendAudio,
+  cancelTalkRealtimeRelayTurn: mocks.cancelTurn,
+  stopTalkRealtimeRelaySession: mocks.stopSession,
+}));
+vi.mock("./server-methods/talk-shared.js", () => ({
+  buildTalkRealtimeConfig: () => ({ providers: {}, consultRouting: "force-agent-consult" }),
+  buildRealtimeVoiceLaunchOptions: ({ requested }: { requested: object }) => requested,
+  resolveTalkRealtimeProviderInstructions: async () => ({
+    agentId: "main",
+    instructions: "workspace context",
+  }),
+  buildRealtimeInstructions: (instructions: string) => instructions,
+  withRealtimeBrowserOverrides: (config: object) => config,
+}));
+
+import { openPluginTalkSession } from "./talk-plugin-session.js";
+
+describe("plugin Talk session", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.scope.mockReturnValue({
+      pluginId: "avatar",
+      gatewayMethodDispatchAllowed: true,
+      context: {
+        getRuntimeConfig: () => ({}),
+        logGateway: { warn: vi.fn(), info: vi.fn(), error: vi.fn(), debug: vi.fn() },
+      },
+    });
+    mocks.resolveProvider.mockReturnValue({ provider: { id: "openai" }, providerConfig: {} });
+    mocks.createRelay.mockReturnValue({ relaySessionId: "relay-1" });
+  });
+
+  it("opens one Gateway-owned consult session and returns a scoped media handle", async () => {
+    const events: unknown[] = [];
+    const session = await openPluginTalkSession({
+      sessionKey: "agent:main:avatar",
+      voice: "alloy",
+      onEvent: (event) => events.push(event),
+    });
+    const relayParams = mocks.createRelay.mock.calls[0]?.[0];
+
+    expect(relayParams).toMatchObject({
+      sessionKey: "agent:main:avatar",
+      manageAgentConsult: true,
+      forceAgentConsultOnFinalTranscript: true,
+      voice: "alloy",
+    });
+    expect(relayParams.connId).toMatch(/^plugin:avatar:/);
+    expect(mocks.ensureSession).toHaveBeenCalledWith({
+      agentId: "main",
+      sessionKey: "agent:main:avatar",
+    });
+
+    await relayParams.onOutputMediaEvent({
+      type: "audio",
+      generation: 1,
+      sequence: 0,
+      ptsMs: 0,
+      pcm: new Uint8Array([1, 0]),
+    });
+    session.sendAudio(new Uint8Array([2, 0]), { timestamp: 20 });
+    session.cancelOutput("barge-in");
+    session.close();
+
+    expect(events).toHaveLength(1);
+    expect(mocks.sendAudio).toHaveBeenCalledWith(
+      expect.objectContaining({ relaySessionId: "relay-1", audioBase64: "AgA=", timestamp: 20 }),
+    );
+    expect(mocks.cancelTurn).toHaveBeenCalledWith(
+      expect.objectContaining({ relaySessionId: "relay-1", reason: "barge-in" }),
+    );
+    expect(mocks.stopSession).toHaveBeenCalledWith(
+      expect.objectContaining({ relaySessionId: "relay-1" }),
+    );
+  });
+
+  it("requires an entitled Gateway route and an agent session", async () => {
+    mocks.scope.mockReturnValue(undefined);
+    await expect(
+      openPluginTalkSession({ sessionKey: "agent:main:avatar", onEvent: vi.fn() }),
+    ).rejects.toThrow("Gateway-authenticated plugin routes");
+
+    await expect(openPluginTalkSession({ sessionKey: " ", onEvent: vi.fn() })).rejects.toThrow(
+      "intended OpenClaw agent and workspace",
+    );
+  });
+});

--- a/src/gateway/talk-plugin-session.ts
+++ b/src/gateway/talk-plugin-session.ts
@@ -1,0 +1,147 @@
+import { randomUUID } from "node:crypto";
+import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
+import { getPluginRuntimeGatewayRequestScope } from "../plugins/runtime/gateway-request-scope.js";
+import { REALTIME_VOICE_AGENT_CONSULT_TOOL } from "../talk/agent-consult-tool.js";
+import { REALTIME_VOICE_AGENT_CONTROL_TOOL } from "../talk/agent-run-control-shared.js";
+import { ensureClientVoiceAgentSessionEntry } from "../talk/client-voice-session.js";
+import type { RealtimeVoiceOutputMediaEvent } from "../talk/output-media.js";
+import type {
+  OpenPluginTalkSessionParams,
+  PluginTalkSession,
+  PluginTalkSessionEvent,
+} from "../talk/plugin-session.js";
+import { PLUGIN_TALK_AUDIO_FORMAT } from "../talk/plugin-session.js";
+import { resolveConfiguredRealtimeVoiceProvider } from "../talk/provider-resolver.js";
+import {
+  buildRealtimeInstructions,
+  buildRealtimeVoiceLaunchOptions,
+  buildTalkRealtimeConfig,
+  resolveTalkRealtimeProviderInstructions,
+  withRealtimeBrowserOverrides,
+} from "./server-methods/talk-shared.js";
+import {
+  cancelTalkRealtimeRelayTurn,
+  createTalkRealtimeRelaySession,
+  sendTalkRealtimeRelayAudio,
+  stopTalkRealtimeRelaySession,
+} from "./talk-realtime-relay.js";
+
+function mapOutputEvent(event: RealtimeVoiceOutputMediaEvent): PluginTalkSessionEvent | undefined {
+  if (event.type === "session.start") {
+    return undefined;
+  }
+  if (event.type === "session.end") {
+    return { ...event, type: "closed" };
+  }
+  return event;
+}
+
+function requirePluginTalkScope() {
+  const scope = getPluginRuntimeGatewayRequestScope();
+  if (!scope?.context || !scope.pluginId || scope.gatewayMethodDispatchAllowed !== true) {
+    throw new Error(
+      "runtime.talk.openSession() is available from Gateway-authenticated plugin routes that declare contracts.gatewayMethodDispatch.",
+    );
+  }
+  return { context: scope.context, pluginId: scope.pluginId };
+}
+
+export async function openPluginTalkSession(
+  params: OpenPluginTalkSessionParams,
+): Promise<PluginTalkSession> {
+  const sessionKey = params.sessionKey.trim();
+  if (!sessionKey) {
+    throw new Error(
+      "runtime.talk.openSession() needs a sessionKey so the voice conversation uses the intended OpenClaw agent and workspace.",
+    );
+  }
+  const { context, pluginId } = requirePluginTalkScope();
+  const runtimeConfig = context.getRuntimeConfig();
+  const realtimeConfig = buildTalkRealtimeConfig(runtimeConfig, params.provider);
+  const resolution = resolveConfiguredRealtimeVoiceProvider({
+    configuredProviderId: realtimeConfig.provider,
+    providerConfigs: realtimeConfig.providers,
+    cfg: runtimeConfig,
+    cfgForResolve: runtimeConfig,
+    defaultModel: realtimeConfig.model,
+    noRegisteredProviderMessage: "No realtime voice provider registered",
+  });
+  const launchOptions = buildRealtimeVoiceLaunchOptions({
+    requested: params,
+    defaults: realtimeConfig,
+  });
+  const realtimeContext = await resolveTalkRealtimeProviderInstructions({
+    config: runtimeConfig,
+    configuredInstructions: realtimeConfig.instructions,
+    sessionKey,
+    requireSessionKeyForProfile: true,
+    warn: (message) => context.logGateway.warn(`talk plugin session: ${message}`),
+  });
+  await ensureClientVoiceAgentSessionEntry({
+    agentId: realtimeContext.agentId,
+    sessionKey,
+  });
+
+  const ownerId = `plugin:${pluginId}:${randomUUID()}`;
+  let closed = false;
+  const session = createTalkRealtimeRelaySession({
+    context,
+    connId: ownerId,
+    cfg: runtimeConfig,
+    provider: resolution.provider,
+    providerConfig: withRealtimeBrowserOverrides(resolution.providerConfig, launchOptions),
+    instructions: buildRealtimeInstructions(realtimeContext.instructions),
+    tools: [REALTIME_VOICE_AGENT_CONSULT_TOOL, REALTIME_VOICE_AGENT_CONTROL_TOOL],
+    model: launchOptions.model,
+    sessionKey,
+    voice: launchOptions.voice,
+    language: normalizeOptionalLowercaseString(params.language),
+    manageAgentConsult: true,
+    forceAgentConsultOnFinalTranscript: realtimeConfig.consultRouting === "force-agent-consult",
+    onOutputMediaEvent: async (event) => {
+      const mapped = mapOutputEvent(event);
+      if (!mapped) {
+        return;
+      }
+      if (mapped.type === "closed") {
+        closed = true;
+      }
+      await params.onEvent(mapped);
+    },
+  });
+
+  return {
+    audio: PLUGIN_TALK_AUDIO_FORMAT,
+    sendAudio(pcm, options) {
+      if (closed) {
+        throw new Error("Talk session is closed");
+      }
+      sendTalkRealtimeRelayAudio({
+        relaySessionId: session.relaySessionId,
+        connId: ownerId,
+        audioBase64: Buffer.from(pcm.buffer, pcm.byteOffset, pcm.byteLength).toString("base64"),
+        timestamp: options?.timestamp,
+      });
+    },
+    cancelOutput(reason) {
+      if (closed) {
+        return;
+      }
+      cancelTalkRealtimeRelayTurn({
+        relaySessionId: session.relaySessionId,
+        connId: ownerId,
+        reason: reason?.trim() || "plugin-cancelled",
+      });
+    },
+    close() {
+      if (closed) {
+        return;
+      }
+      closed = true;
+      stopTalkRealtimeRelaySession({
+        relaySessionId: session.relaySessionId,
+        connId: ownerId,
+      });
+    },
+  };
+}

--- a/src/gateway/talk-realtime-relay.test.ts
+++ b/src/gateway/talk-realtime-relay.test.ts
@@ -15,6 +15,7 @@ import type { RealtimeVoiceProviderPlugin } from "../plugins/types.js";
 import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { clientVoiceSessionTesting } from "../talk/client-voice-session.test-support.js";
+import type { RealtimeVoiceOutputMediaEvent } from "../talk/output-media.js";
 import type {
   RealtimeVoiceBridge,
   RealtimeVoiceBridgeCreateRequest,
@@ -373,6 +374,69 @@ describe("talk realtime gateway relay", () => {
         tools: [],
       }),
     ).toThrow("Realtime relay session expiry is outside the supported Date range");
+  });
+
+  it("keeps conversation direct while Gateway owns agent consultation", async () => {
+    let bridgeRequest: RealtimeVoiceBridgeCreateRequest | undefined;
+    const provider: RealtimeVoiceProviderPlugin = {
+      id: "relay-test",
+      label: "Relay Test",
+      isConfigured: () => true,
+      createBridge: (request) => {
+        bridgeRequest = request;
+        return {
+          connect: vi.fn(async () => undefined),
+          sendAudio: vi.fn(),
+          setMediaTimestamp: vi.fn(),
+          sendUserMessage: vi.fn(),
+          handleBargeIn: vi.fn(),
+          submitToolResult: vi.fn(),
+          acknowledgeMark: vi.fn(),
+          close: vi.fn(),
+          isConnected: vi.fn(() => true),
+        };
+      },
+    };
+    createTalkRealtimeRelaySession({
+      context: {
+        broadcastToConnIds: vi.fn(),
+        logGateway: { info: vi.fn(), warn: vi.fn() },
+      } as never,
+      connId: "conn-1",
+      cfg: {},
+      provider,
+      providerConfig: {},
+      instructions: "transcribe and wait",
+      tools: [
+        {
+          type: "function",
+          name: "browser-tool",
+          description: "browser tool",
+          parameters: { type: "object", properties: {} },
+        },
+      ],
+      sessionKey: "agent:main:main",
+      manageAgentConsult: true,
+    });
+    await Promise.resolve();
+
+    expect(bridgeRequest?.autoRespondToAudio).toBe(true);
+    expect(bridgeRequest?.interruptResponseOnInputAudio).toBe(true);
+    expect(bridgeRequest?.tools).toEqual([expect.objectContaining({ name: "browser-tool" })]);
+  });
+
+  it("requires a session key for gateway-owned agent consultation", () => {
+    expect(() =>
+      createTalkRealtimeRelaySession({
+        context: {} as never,
+        connId: "conn-1",
+        provider: createIdleRelayProvider(),
+        providerConfig: {},
+        instructions: "brief",
+        tools: [],
+        manageAgentConsult: true,
+      }),
+    ).toThrow("requires a session key");
   });
 
   function createAbortableRelayRunFixture(provider = createIdleRelayProvider()) {
@@ -1786,6 +1850,119 @@ describe("talk realtime gateway relay", () => {
           entry.payload.talkEvent.turnId === "turn-1",
       ),
     ).toBe(true);
+  });
+
+  it("sends exact output PCM and lifecycle to the session owner without changing relay delivery", async () => {
+    let bridgeRequest: RealtimeVoiceBridgeCreateRequest | undefined;
+    const provider: RealtimeVoiceProviderPlugin = {
+      id: "relay-test",
+      label: "Relay Test",
+      isConfigured: () => true,
+      createBridge: (request) => {
+        bridgeRequest = request;
+        return {
+          connect: vi.fn(async () => undefined),
+          sendAudio: vi.fn(),
+          setMediaTimestamp: vi.fn(),
+          handleBargeIn: vi.fn(() => request.onClearAudio("barge-in")),
+          submitToolResult: vi.fn(),
+          acknowledgeMark: vi.fn(),
+          close: vi.fn(),
+          isConnected: vi.fn(() => true),
+        };
+      },
+    };
+    const broadcastToConnIds = vi.fn();
+    const mediaEvents: RealtimeVoiceOutputMediaEvent[] = [];
+    const session = createTalkRealtimeRelaySession({
+      context: { broadcastToConnIds } as never,
+      connId: "conn-1",
+      provider,
+      providerConfig: {},
+      instructions: "brief",
+      tools: [],
+      sessionKey: "agent:main:main",
+      onOutputMediaEvent: (event) => {
+        mediaEvents.push(event);
+      },
+    });
+
+    bridgeRequest?.onReady?.();
+    bridgeRequest?.onAudio(Buffer.from([1, 2, 3, 4]));
+    await vi.waitFor(() =>
+      expect(mediaEvents.some((event) => event.type === "audio" && event.generation === 1)).toBe(
+        true,
+      ),
+    );
+    const listeningStatesBefore = mediaEvents.filter(
+      (event) => event.type === "state" && event.state === "listening",
+    ).length;
+    bridgeRequest?.onError?.(new Error("recoverable provider stream warning"));
+    await vi.waitFor(() =>
+      expect(
+        mediaEvents.filter((event) => event.type === "state" && event.state === "listening").length,
+      ).toBe(listeningStatesBefore + 1),
+    );
+    expect(mediaEvents.some((event) => event.type === "state" && event.state === "error")).toBe(
+      false,
+    );
+    cancelTalkRealtimeRelayTurn({
+      relaySessionId: session.relaySessionId,
+      connId: "conn-1",
+      reason: "barge-in",
+    });
+    await vi.waitFor(() =>
+      expect(mediaEvents.filter((event) => event.type === "clear")).toHaveLength(1),
+    );
+    bridgeRequest?.onAudio(Buffer.from([5, 6]));
+    await vi.waitFor(() =>
+      expect(mediaEvents.some((event) => event.type === "audio" && event.generation === 2)).toBe(
+        true,
+      ),
+    );
+    stopTalkRealtimeRelaySession({ relaySessionId: session.relaySessionId, connId: "conn-1" });
+
+    await vi.waitFor(() =>
+      expect(mediaEvents.some((event) => event.type === "session.end")).toBe(true),
+    );
+    expect(mediaEvents.map((event) => event.type)).toEqual([
+      "session.start",
+      "state",
+      "state",
+      "state",
+      "audio",
+      "state",
+      "clear",
+      "state",
+      "audio",
+      "clear",
+      "state",
+      "session.end",
+    ]);
+    const audioEvents = mediaEvents.filter(
+      (event): event is Extract<RealtimeVoiceOutputMediaEvent, { type: "audio" }> =>
+        event.type === "audio",
+    );
+    expect(
+      audioEvents.map((event) => ({
+        generation: event.generation,
+        sequence: event.sequence,
+        ptsMs: event.ptsMs,
+        pcm: [...event.pcm],
+      })),
+    ).toEqual([
+      { generation: 1, sequence: 0, ptsMs: 0, pcm: [1, 2, 3, 4] },
+      { generation: 2, sequence: 0, ptsMs: 0, pcm: [5, 6] },
+    ]);
+    expect(
+      broadcastToConnIds.mock.calls
+        .map((call) => call[1] as { type?: string; audioBase64?: string })
+        .filter((event) => event.type === "audio")
+        .map((event) => event.audioBase64),
+    ).toEqual([
+      Buffer.from([1, 2, 3, 4]).toString("base64"),
+      Buffer.from([5, 6]).toString("base64"),
+    ]);
   });
 
   it("aborts linked agent consult runs when the relay turn is cancelled", () => {

--- a/src/gateway/talk-realtime-relay.ts
+++ b/src/gateway/talk-realtime-relay.ts
@@ -5,10 +5,12 @@ import { resolveExpiresAtMsFromDurationMs } from "@openclaw/normalization-core/n
 import type { OpenClawConfig } from "../config/types.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import type { RealtimeVoiceProviderPlugin } from "../plugins/types.js";
+import { runOutsideGatewayRootWorkAdmission } from "../process/gateway-work-admission.js";
 import { resolveAgentIdFromSessionKey } from "../routing/session-key.js";
 import {
   REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME,
   buildRealtimeVoiceAgentConsultWorkingResponse,
+  parseRealtimeVoiceAgentConsultArgs,
 } from "../talk/agent-consult-tool.js";
 import { buildRealtimeVoiceAgentCancelProviderResult } from "../talk/agent-run-control-shared.js";
 import {
@@ -26,18 +28,27 @@ import {
 import { readSpeakableRealtimeVoiceToolResult } from "../talk/consult-question.js";
 import type { RealtimeVoiceForcedConsultHandle } from "../talk/forced-consult-coordinator.js";
 import {
+  createRealtimeVoiceOutputMediaSession,
+  type RealtimeVoiceOutputMediaEvent,
+  type RealtimeVoiceOutputMediaSession,
+} from "../talk/output-media.js";
+import {
   REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ,
   type RealtimeVoiceBrowserAudioContract,
   type RealtimeVoiceAudioClearReason,
   type RealtimeVoiceProviderConfig,
   type RealtimeVoiceTool,
+  type RealtimeVoiceToolCallEvent,
   type RealtimeVoiceToolResultOptions,
 } from "../talk/provider-types.js";
 import {
   createRealtimeVoiceSessionHarness,
   type RealtimeVoiceSessionHarness,
 } from "../talk/realtime-session-harness.js";
-import type { RealtimeVoiceBridgeSession } from "../talk/session-runtime.js";
+import type {
+  RealtimeVoiceBridgeSession,
+  RealtimeVoiceBridgeSessionParams,
+} from "../talk/session-runtime.js";
 import type { TalkEvent, TalkEventInput } from "../talk/talk-session-controller.js";
 import { abortChatRunById } from "./chat-abort.js";
 import type { GatewayRequestContext } from "./server-methods/shared-types.js";
@@ -122,7 +133,8 @@ type RelaySession = {
   connId: string;
   context: GatewayRequestContext;
   bridge: RealtimeVoiceBridgeSession;
-  harness: RealtimeVoiceSessionHarness;
+  harness: RealtimeVoiceSessionHarness<unknown, ManagedAgentConsultMetadata>;
+  outputMedia?: RealtimeVoiceOutputMediaSession;
   sessionKey?: string;
   expiresAtMs: number;
   cleanupTimer: ReturnType<typeof setTimeout>;
@@ -151,6 +163,12 @@ type RelaySession = {
   voiceTranscriptSeq: number;
   voiceTranscriptWrites: Promise<void>;
   pendingVoiceTranscripts: Array<{ role: "user" | "assistant"; text: string }>;
+  managedConsultResults: Map<string, string>;
+};
+
+type ManagedAgentConsultMetadata = {
+  handle: RealtimeVoiceForcedConsultHandle;
+  args?: RealtimeVoiceToolCallEvent["args"];
 };
 
 type CreateTalkRealtimeRelaySessionParams = {
@@ -165,7 +183,9 @@ type CreateTalkRealtimeRelaySessionParams = {
   sessionKey?: string;
   voice?: string;
   language?: string;
+  manageAgentConsult?: boolean;
   forceAgentConsultOnFinalTranscript?: boolean;
+  onOutputMediaEvent?: (event: RealtimeVoiceOutputMediaEvent) => void | Promise<void>;
 };
 
 type TalkRealtimeRelaySessionResult = {
@@ -300,6 +320,15 @@ export function ensureTalkRealtimeRelayVoiceSession(params: {
   for (const entry of buffered) {
     enqueueRelayVoiceTranscript(session, entry.role, entry.text);
   }
+}
+
+let gatewayAgentConsultRuntimePromise:
+  | Promise<typeof import("./talk-managed-agent-consult.runtime.js")>
+  | undefined;
+
+function resolveGatewayAgentConsultRuntime() {
+  gatewayAgentConsultRuntimePromise ??= import("./talk-managed-agent-consult.runtime.js");
+  return gatewayAgentConsultRuntimePromise;
 }
 
 function isWorkingToolResult(result: unknown): boolean {
@@ -653,6 +682,7 @@ function closeRelaySession(session: RelaySession, reason: "completed" | "error")
   abortRelayAgentRuns(session, reason === "error" ? "relay-error" : "relay-closed");
   session.bridge.close();
   closeRelayVoiceSession(session);
+  session.outputMedia?.end(reason);
   broadcastToOwner(session.context, session.connId, {
     relaySessionId: session.id,
     type: "close",
@@ -698,13 +728,22 @@ export function createTalkRealtimeRelaySession(
   params: CreateTalkRealtimeRelaySessionParams,
 ): TalkRealtimeRelaySessionResult {
   enforceRelaySessionLimits(params.connId);
+  const manageAgentConsult = params.manageAgentConsult === true;
+  if (manageAgentConsult && !params.sessionKey?.trim()) {
+    throw new Error("Gateway-owned realtime agent consult requires a session key");
+  }
   const forceAgentConsultOnFinalTranscript = params.forceAgentConsultOnFinalTranscript === true;
   const relaySessionId = randomUUID();
   const expiresAtMs = resolveExpiresAtMsFromDurationMs(RELAY_SESSION_TTL_MS);
   if (expiresAtMs === undefined) {
     throw new Error("Realtime relay session expiry is outside the supported Date range");
   }
-  const harness = createRealtimeVoiceSessionHarness({
+  const relayRef: { current?: RelaySession } = {};
+  const requesterSessionKey = params.sessionKey?.trim() ?? "";
+  const managedAgentId = manageAgentConsult
+    ? resolveAgentIdFromSessionKey(requesterSessionKey)
+    : undefined;
+  const harness = createRealtimeVoiceSessionHarness<unknown, ManagedAgentConsultMetadata>({
     talk: {
       sessionId: relaySessionId,
       mode: "realtime",
@@ -722,7 +761,100 @@ export function createTalkRealtimeRelaySession(
     },
     transcriptLookbackMs: RELAY_TRANSCRIPT_ECHO_LOOKBACK_MS,
     captureBridgeEvents: false,
+    ...(manageAgentConsult && managedAgentId
+      ? {
+          talkback: {
+            debounceMs: 120,
+            logger: params.context.logGateway,
+            logPrefix: `[talk:${relaySessionId}] gateway agent`,
+            responseStyle: "Brief, natural spoken answer for a live voice conversation.",
+            fallbackText: "I hit an error while checking that. Please try again.",
+            consult: async ({ question, responseStyle, metadata }) => {
+              const relay = relayRef.current;
+              if (!relay) {
+                throw new Error("Realtime Talk session closed before the agent consult started");
+              }
+              const runtime = await resolveGatewayAgentConsultRuntime();
+              const toolArgs = metadata?.args ?? { question, responseStyle };
+              return await runtime.consultTalkManagedAgent({
+                cfg: params.cfg ?? params.context.getRuntimeConfig(),
+                logger: params.context.logGateway,
+                agentId: managedAgentId,
+                sessionKey: requesterSessionKey,
+                messageProvider: "talk",
+                lane: "talk",
+                runIdPrefix: `talk:${relaySessionId}`,
+                onRunStarted: (runId) =>
+                  registerTalkRealtimeRelayAgentRun({
+                    relaySessionId,
+                    connId: params.connId,
+                    sessionKey: requesterSessionKey,
+                    runId,
+                  }),
+                args: toolArgs,
+                transcript: relay.harness.transcript,
+                surface: "OpenClaw realtime Talk",
+                userLabel: "person",
+                assistantLabel: "voice assistant",
+                questionSourceLabel: "live microphone",
+                extraSystemPrompt:
+                  "You are the configured OpenClaw agent receiving a request from a realtime Talk session. Use the OpenClaw workspace and available tools when appropriate, complete the requested work, and return a concise result suitable for speech.",
+              });
+            },
+            deliver: (text, metadata) => {
+              const relay = relayRef.current;
+              if (!relay || relaySessions.get(relaySessionId) !== relay) {
+                return;
+              }
+              const handle = metadata?.handle;
+              const callIds = handle ? relay.harness.forcedConsults.nativeCallIds(handle) : [];
+              if (handle) {
+                relay.managedConsultResults.set(handle.id, text);
+                while (relay.managedConsultResults.size > 12) {
+                  const oldest = relay.managedConsultResults.keys().next().value;
+                  if (!oldest) {
+                    break;
+                  }
+                  relay.managedConsultResults.delete(oldest);
+                }
+              }
+              if (callIds.length === 0) {
+                relay.bridge.sendUserMessage(buildForcedConsultSpeechPrompt(text));
+                if (handle) {
+                  relay.harness.forcedConsults.markDelivered(handle);
+                }
+                return;
+              }
+              void Promise.all(
+                callIds.map((callId) =>
+                  Promise.resolve(
+                    submitTalkRealtimeRelayToolResult({
+                      relaySessionId,
+                      connId: params.connId,
+                      callId,
+                      result: { text },
+                    }),
+                  ),
+                ),
+              )
+                .then(() => {
+                  if (handle) {
+                    relay.harness.forcedConsults.markDelivered(handle);
+                  }
+                })
+                .catch((error: unknown) => {
+                  params.context.logGateway.warn(
+                    `[talk:${relaySessionId}] managed consult result failed: ${formatErrorMessage(error)}`,
+                  );
+                });
+            },
+          },
+        }
+      : {}),
   });
+  const outputMedia = params.onOutputMediaEvent
+    ? createRealtimeVoiceOutputMediaSession({ onEvent: params.onOutputMediaEvent })
+    : undefined;
   const emit = (event: TalkRealtimeRelayEventPayload, talkEvent?: TalkEventInput) =>
     broadcastToOwner(
       params.context,
@@ -737,8 +869,7 @@ export function createTalkRealtimeRelaySession(
   let currentOutputResponseId: string | undefined;
   let ready = false;
   let failureEmitted = false;
-  const relayRef: { current?: RelaySession } = {};
-  const bridge = harness.createBridge({
+  const bridgeParams: RealtimeVoiceBridgeSessionParams = {
     provider: params.provider,
     cfg: params.cfg,
     providerConfig: params.providerConfig,
@@ -746,7 +877,7 @@ export function createTalkRealtimeRelaySession(
     instructions: params.instructions,
     language: params.language,
     autoRespondToAudio: !forceAgentConsultOnFinalTranscript,
-    interruptResponseOnInputAudio: !forceAgentConsultOnFinalTranscript,
+    interruptResponseOnInputAudio: manageAgentConsult || !forceAgentConsultOnFinalTranscript,
     tools: params.tools,
     markStrategy: "transport",
     audioSink: {
@@ -767,6 +898,7 @@ export function createTalkRealtimeRelaySession(
             payload: { byteLength: audio.length },
           },
         );
+        outputMedia?.sendAudio(audio);
       },
       clearAudio: (reason) => {
         const turnId = relayRef.current ? ensureRelayTurn(relayRef.current) : undefined;
@@ -779,6 +911,8 @@ export function createTalkRealtimeRelaySession(
             final: true,
           },
         );
+        outputMedia?.clear(reason ?? "cancel");
+        outputMedia?.setState("listening");
       },
       sendMark: (markName) => {
         const turnId = relayRef.current ? ensureRelayTurn(relayRef.current) : undefined;
@@ -797,6 +931,15 @@ export function createTalkRealtimeRelaySession(
       if (event.direction !== "server") {
         return;
       }
+      if (event.type === "input_audio_buffer.speech_started") {
+        outputMedia?.setState("listening");
+      } else if (
+        event.type === "input_audio_buffer.speech_stopped" ||
+        event.type === "input_audio_buffer.committed" ||
+        event.type === "response.created"
+      ) {
+        outputMedia?.setState("thinking");
+      }
       if (
         event.type === "conversation.output_audio.delta" ||
         event.type === "response.audio.delta" ||
@@ -813,6 +956,7 @@ export function createTalkRealtimeRelaySession(
         event.type === "response.done" ||
         event.type === "response.cancelled"
       ) {
+        outputMedia?.setState("listening");
         emit({
           relaySessionId,
           type: "audioDone",
@@ -885,13 +1029,76 @@ export function createTalkRealtimeRelaySession(
             });
           return;
         }
-        if (forceAgentConsultOnFinalTranscript) {
+        if (manageAgentConsult && forceAgentConsultOnFinalTranscript) {
+          if (!relay) {
+            return;
+          }
+          if (relay.harness.forcedConsults.hasRecent(question)) {
+            return;
+          }
+          relay.harness.forcedConsults.clearPending();
+          const handle = relay.harness.forcedConsults.prepare(question);
+          if (handle) {
+            relay.harness.forcedConsults.schedule(handle, FORCED_CONSULT_FALLBACK_DELAY_MS, () => {
+              relay.harness.forcedConsults.markStarted(handle);
+              runOutsideGatewayRootWorkAdmission(() =>
+                relay.harness.talkback?.enqueue(question, { handle }),
+              );
+            });
+          }
+        } else if (forceAgentConsultOnFinalTranscript) {
           scheduleForcedAgentConsult(relay, question);
         }
       }
     },
     onToolCall: (toolCall) => {
       const relay = relayRef.current;
+      if (relay && manageAgentConsult && toolCall.name === REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME) {
+        const parsed = parseRealtimeVoiceAgentConsultArgs(toolCall.args);
+        let match = relay.harness.forcedConsults.recordNativeConsult(
+          toolCall.args,
+          toolCall.callId,
+        );
+        let handle = match.kind === "none" ? undefined : match.handle;
+        if (!handle) {
+          handle = relay.harness.forcedConsults.prepare(parsed.question);
+          if (handle) {
+            match = relay.harness.forcedConsults.recordNativeConsult(
+              toolCall.args,
+              toolCall.callId,
+            );
+          }
+        }
+        const working = submitRealtimeAgentConsultWorkingResponse(
+          relay,
+          toolCall.callId,
+          ensureRelayTurn(relay),
+        );
+        if (!handle) {
+          return working;
+        }
+        if (match.kind === "already_delivered") {
+          const text = relay.managedConsultResults.get(handle.id);
+          if (text) {
+            void Promise.resolve(working).then(() =>
+              submitTalkRealtimeRelayToolResult({
+                relaySessionId,
+                connId: params.connId,
+                callId: toolCall.callId,
+                result: { text },
+              }),
+            );
+          }
+          return working;
+        }
+        if (match.kind !== "in_flight") {
+          relay.harness.forcedConsults.markStarted(handle);
+          runOutsideGatewayRootWorkAdmission(() =>
+            relay.harness.talkback?.enqueue(parsed.question, { handle, args: toolCall.args }),
+          );
+        }
+        return working;
+      }
       let shouldSubmitWorkingResult = false;
       if (relay && toolCall.name === REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME) {
         const forcedConsult = relay.harness.forcedConsults.recordNativeConsult(
@@ -944,6 +1151,7 @@ export function createTalkRealtimeRelaySession(
     onReady: () => {
       ready = true;
       emit({ relaySessionId, type: "ready" }, { type: "session.ready", payload: null });
+      outputMedia?.setState("listening");
     },
     onError: (error) => {
       const issue = realtimeRelayIssue({
@@ -958,6 +1166,7 @@ export function createTalkRealtimeRelaySession(
         payload: issue,
         final: true,
       });
+      outputMedia?.setState(ready ? "listening" : "error");
     },
     onClose: (reason) => {
       const active = relaySessions.get(relaySessionId);
@@ -970,6 +1179,7 @@ export function createTalkRealtimeRelaySession(
       clearTimeout(active.cleanupTimer);
       abortRelayAgentRuns(active, "relay-closed");
       closeRelayVoiceSession(active);
+      active.outputMedia?.end(reason);
       if (!ready && !failureEmitted) {
         const issue = realtimeRelayIssue({
           message: "Realtime provider closed before the session became ready.",
@@ -988,13 +1198,22 @@ export function createTalkRealtimeRelaySession(
         { type: "session.closed", payload: { reason }, final: true },
       );
     },
-  });
+  };
+  let bridge: RealtimeVoiceBridgeSession;
+  try {
+    bridge = harness.createBridge(bridgeParams);
+  } catch (error) {
+    harness.close();
+    outputMedia?.end("error");
+    throw error;
+  }
   const relay: RelaySession = {
     id: relaySessionId,
     connId: params.connId,
     context: params.context,
     bridge,
     harness,
+    ...(outputMedia ? { outputMedia } : {}),
     sessionKey: params.sessionKey?.trim() || undefined,
     expiresAtMs,
     cleanupTimer: setTimeout(() => {
@@ -1019,6 +1238,7 @@ export function createTalkRealtimeRelaySession(
     voiceTranscriptSeq: 0,
     voiceTranscriptWrites: Promise.resolve(),
     pendingVoiceTranscripts: [],
+    managedConsultResults: new Map(),
   };
   relayRef.current = relay;
   relay.cleanupTimer.unref?.();
@@ -1579,7 +1799,12 @@ export function cancelTalkRealtimeRelayTurn(params: {
       }
     }
   }
+  const outputGeneration = session.outputMedia?.generation;
   session.harness.handleBargeIn({ audioPlaybackActive: true });
+  if (session.outputMedia && session.outputMedia.generation === outputGeneration) {
+    session.outputMedia.clear(reason === "barge-in" ? "barge-in" : "cancel");
+  }
+  session.outputMedia?.setState("listening");
   abortRelayAgentRuns(session, reason);
   const cancelled = session.harness.talk.cancelTurn({
     turnId,

--- a/src/gateway/talk-realtime-relay.ts
+++ b/src/gateway/talk-realtime-relay.ts
@@ -24,12 +24,7 @@ import {
   registerClientVoiceConsultRun,
 } from "../talk/client-voice-session.js";
 import { readSpeakableRealtimeVoiceToolResult } from "../talk/consult-question.js";
-import {
-  createRealtimeVoiceForcedConsultCoordinator,
-  type RealtimeVoiceForcedConsultCoordinator,
-  type RealtimeVoiceForcedConsultHandle,
-} from "../talk/forced-consult-coordinator.js";
-import { recordTalkObservabilityEvent } from "../talk/observability.js";
+import type { RealtimeVoiceForcedConsultHandle } from "../talk/forced-consult-coordinator.js";
 import {
   REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ,
   type RealtimeVoiceBrowserAudioContract,
@@ -39,20 +34,11 @@ import {
   type RealtimeVoiceToolResultOptions,
 } from "../talk/provider-types.js";
 import {
-  isLikelyRealtimeVoiceAssistantEchoTranscript,
-  recordRealtimeVoiceTranscript,
-  type RealtimeVoiceTranscriptEntry,
-} from "../talk/session-log-runtime.js";
-import {
-  createRealtimeVoiceBridgeSession,
-  type RealtimeVoiceBridgeSession,
-} from "../talk/session-runtime.js";
-import {
-  type TalkEvent,
-  type TalkEventInput,
-  type TalkSessionController,
-  createTalkSessionController,
-} from "../talk/talk-session-controller.js";
+  createRealtimeVoiceSessionHarness,
+  type RealtimeVoiceSessionHarness,
+} from "../talk/realtime-session-harness.js";
+import type { RealtimeVoiceBridgeSession } from "../talk/session-runtime.js";
+import type { TalkEvent, TalkEventInput } from "../talk/talk-session-controller.js";
 import { abortChatRunById } from "./chat-abort.js";
 import type { GatewayRequestContext } from "./server-methods/shared-types.js";
 import {
@@ -136,7 +122,7 @@ type RelaySession = {
   connId: string;
   context: GatewayRequestContext;
   bridge: RealtimeVoiceBridgeSession;
-  talk: TalkSessionController;
+  harness: RealtimeVoiceSessionHarness;
   sessionKey?: string;
   expiresAtMs: number;
   cleanupTimer: ReturnType<typeof setTimeout>;
@@ -160,8 +146,6 @@ type RelaySession = {
   forcedTerminalProviderResults: Map<string, ForcedTerminalProviderResult>;
   // Turn cancellation invalidates async acceptance callbacks from the prior turn.
   toolResultEpoch: number;
-  forcedConsults: RealtimeVoiceForcedConsultCoordinator;
-  transcript: RealtimeVoiceTranscriptEntry[];
   voiceConfig?: OpenClawConfig;
   voiceSessionCreated: boolean;
   voiceTranscriptSeq: number;
@@ -328,14 +312,7 @@ function isWorkingToolResult(result: unknown): boolean {
 }
 
 function isRelayAssistantEchoTranscript(session: RelaySession | undefined, text: string): boolean {
-  if (!session) {
-    return false;
-  }
-  return isLikelyRealtimeVoiceAssistantEchoTranscript({
-    transcript: session.transcript,
-    text,
-    lookbackMs: RELAY_TRANSCRIPT_ECHO_LOOKBACK_MS,
-  });
+  return session?.harness.isLikelyAssistantEchoTranscript(text) ?? false;
 }
 function buildForcedConsultCheckingPrompt(): string {
   return [
@@ -369,8 +346,8 @@ function suppressedToolResultOptions(
 }
 
 function cancelForcedConsults(session: RelaySession): void {
-  for (const handle of session.forcedConsults.handles()) {
-    session.forcedConsults.markCancelled(handle);
+  for (const handle of session.harness.forcedConsults.handles()) {
+    session.harness.forcedConsults.markCancelled(handle);
   }
 }
 
@@ -437,7 +414,7 @@ function broadcastToolResultToOwner(
     relaySessionId: session.id,
     type: "toolResult",
     callId: params.callId,
-    talkEvent: session.talk.emit({
+    talkEvent: session.harness.talk.emit({
       type: "tool.result",
       callId: params.callId,
       turnId: params.turnId,
@@ -608,7 +585,7 @@ function submitRelayAgentControlProviderResults(
       return;
     }
     if (forcedConsult) {
-      session.forcedConsults.markCancelled(forcedConsult);
+      session.harness.forcedConsults.markCancelled(forcedConsult);
     }
     broadcastToolResultToOwner(session, {
       callId,
@@ -620,9 +597,11 @@ function submitRelayAgentControlProviderResults(
     session.completedAgentToolCalls.add(callId);
   };
   for (const callId of activeCallIds) {
-    const forcedConsult = session.forcedConsults.handles().find((handle) => handle.id === callId);
+    const forcedConsult = session.harness.forcedConsults
+      .handles()
+      .find((handle) => handle.id === callId);
     if (forcedConsult) {
-      const nativeCallIds = session.forcedConsults.nativeCallIds(forcedConsult);
+      const nativeCallIds = session.harness.forcedConsults.nativeCallIds(forcedConsult);
       providerResponseStarted ||= toolResultOptions === undefined && nativeCallIds.length > 0;
       const terminal: ForcedTerminalProviderResult = {
         result: providerResult,
@@ -667,7 +646,7 @@ function submitRelayAgentControlProviderResults(
 }
 
 function closeRelaySession(session: RelaySession, reason: "completed" | "error"): void {
-  session.forcedConsults.clear();
+  session.harness.close();
   relaySessions.delete(session.id);
   forgetUnifiedTalkSession(session.id);
   clearTimeout(session.cleanupTimer);
@@ -678,7 +657,7 @@ function closeRelaySession(session: RelaySession, reason: "completed" | "error")
     relaySessionId: session.id,
     type: "close",
     reason,
-    talkEvent: session.talk.emit({
+    talkEvent: session.harness.talk.emit({
       type: "session.closed",
       payload: { reason },
       final: true,
@@ -725,23 +704,32 @@ export function createTalkRealtimeRelaySession(
   if (expiresAtMs === undefined) {
     throw new Error("Realtime relay session expiry is outside the supported Date range");
   }
-  const talk = createTalkSessionController(
-    {
+  const harness = createRealtimeVoiceSessionHarness({
+    talk: {
       sessionId: relaySessionId,
       mode: "realtime",
       transport: "gateway-relay",
       brain: "agent-consult",
       provider: params.provider.id,
     },
-    { onEvent: recordTalkObservabilityEvent },
-  );
+    talkPayloads: {
+      turnStarted: () => ({}),
+      turnEnded: (reason) => ({ reason }),
+      inputAudioDelta: (audio) => ({ byteLength: audio.byteLength }),
+      outputAudioStarted: () => ({}),
+      outputAudioDelta: (audio) => ({ byteLength: audio.byteLength }),
+      outputAudioDone: (reason) => ({ reason }),
+    },
+    transcriptLookbackMs: RELAY_TRANSCRIPT_ECHO_LOOKBACK_MS,
+    captureBridgeEvents: false,
+  });
   const emit = (event: TalkRealtimeRelayEventPayload, talkEvent?: TalkEventInput) =>
     broadcastToOwner(
       params.context,
       params.connId,
       {
         ...event,
-        ...(talkEvent ? { talkEvent: talk.emit(talkEvent) } : {}),
+        ...(talkEvent ? { talkEvent: harness.emit(talkEvent) } : {}),
       },
       relayEventDeliveryOptions(event),
     );
@@ -750,7 +738,7 @@ export function createTalkRealtimeRelaySession(
   let ready = false;
   let failureEmitted = false;
   const relayRef: { current?: RelaySession } = {};
-  const bridge = createRealtimeVoiceBridgeSession({
+  const bridge = harness.createBridge({
     provider: params.provider,
     cfg: params.cfg,
     providerConfig: params.providerConfig,
@@ -843,7 +831,6 @@ export function createTalkRealtimeRelaySession(
       const relay = relayRef.current;
       const turnId = relay ? ensureRelayTurn(relay) : undefined;
       if (final && relay) {
-        recordRealtimeVoiceTranscript(relay.transcript, role, text);
         enqueueRelayVoiceTranscript(relay, role, text);
       }
       const eventType =
@@ -907,13 +894,13 @@ export function createTalkRealtimeRelaySession(
       const relay = relayRef.current;
       let shouldSubmitWorkingResult = false;
       if (relay && toolCall.name === REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME) {
-        const forcedConsult = relay.forcedConsults.recordNativeConsult(
+        const forcedConsult = relay.harness.forcedConsults.recordNativeConsult(
           toolCall.args,
           toolCall.callId,
         );
         if (forcedConsult.kind === "in_flight" || forcedConsult.kind === "already_delivered") {
           if (forcedConsult.kind === "already_delivered") {
-            const result = relay.forcedConsults.isCancelled(forcedConsult.handle)
+            const result = relay.harness.forcedConsults.isCancelled(forcedConsult.handle)
               ? buildRealtimeVoiceAgentCancelProviderResult(
                   "OpenClaw cancelled this consult before completion. Do not restart it.",
                 )
@@ -977,7 +964,7 @@ export function createTalkRealtimeRelaySession(
       if (!active) {
         return;
       }
-      active.forcedConsults.clear();
+      active.harness.close();
       relaySessions.delete(relaySessionId);
       forgetUnifiedTalkSession(relaySessionId);
       clearTimeout(active.cleanupTimer);
@@ -1007,7 +994,7 @@ export function createTalkRealtimeRelaySession(
     connId: params.connId,
     context: params.context,
     bridge,
-    talk,
+    harness,
     sessionKey: params.sessionKey?.trim() || undefined,
     expiresAtMs,
     cleanupTimer: setTimeout(() => {
@@ -1027,8 +1014,6 @@ export function createTalkRealtimeRelaySession(
     pendingWorkingToolResults: new Map(),
     forcedTerminalProviderResults: new Map(),
     toolResultEpoch: 0,
-    forcedConsults: createRealtimeVoiceForcedConsultCoordinator(),
-    transcript: [],
     ...(params.cfg ? { voiceConfig: params.cfg } : {}),
     voiceSessionCreated: false,
     voiceTranscriptSeq: 0,
@@ -1077,23 +1062,23 @@ function scheduleForcedAgentConsult(session: RelaySession | undefined, question:
   if (!session || !question.trim()) {
     return;
   }
-  if (session.forcedConsults.hasRecentNativeConsult(question)) {
+  if (session.harness.forcedConsults.hasRecentNativeConsult(question)) {
     return;
   }
-  session.forcedConsults.clearPending();
-  const handle = session.forcedConsults.prepare(question);
+  session.harness.forcedConsults.clearPending();
+  const handle = session.harness.forcedConsults.prepare(question);
   if (!handle) {
     return;
   }
-  session.forcedConsults.schedule(handle, FORCED_CONSULT_FALLBACK_DELAY_MS, () => {
+  session.harness.forcedConsults.schedule(handle, FORCED_CONSULT_FALLBACK_DELAY_MS, () => {
     if (!relaySessions.has(session.id)) {
       return;
     }
     const turnId = ensureRelayTurn(session);
     const callId = handle.id;
     const itemId = `forced-consult-item-${randomUUID()}`;
-    session.forcedConsults.markStarted(handle);
-    session.bridge.handleBargeIn({ audioPlaybackActive: true, force: true });
+    session.harness.forcedConsults.markStarted(handle);
+    session.harness.handleBargeIn({ audioPlaybackActive: true, force: true });
     broadcastToOwner(session.context, session.connId, {
       relaySessionId: session.id,
       type: "toolCall",
@@ -1107,7 +1092,7 @@ function scheduleForcedAgentConsult(session: RelaySession | undefined, question:
           "The realtime provider produced a final user transcript without invoking openclaw_agent_consult, so OpenClaw is forcing the consult for realtime Talk.",
         responseStyle: "Reply in a concise spoken tone.",
       },
-      talkEvent: session.talk.emit({
+      talkEvent: session.harness.talk.emit({
         type: "tool.call",
         itemId,
         callId,
@@ -1144,7 +1129,7 @@ function drainForcedTerminalProviderResults(
   if (session.forcedTerminalProviderResults.get(handle.id) !== terminal) {
     return;
   }
-  const submissions = session.forcedConsults
+  const submissions = session.harness.forcedConsults
     .nativeCallIds(handle)
     .map((callId) =>
       submitForcedConsultProviderResult(session, callId, terminal.result, terminal.options),
@@ -1157,7 +1142,7 @@ function drainForcedTerminalProviderResults(
       drainForcedTerminalProviderResults(session, handle, terminal),
     );
   }
-  const hasUnsubmittedCall = session.forcedConsults
+  const hasUnsubmittedCall = session.harness.forcedConsults
     .nativeCallIds(handle)
     .some((callId) => !session.completedProviderToolResults.has(callId));
   if (hasUnsubmittedCall) {
@@ -1170,7 +1155,7 @@ function drainForcedTerminalProviderResultsAfterPending(
   handle: RealtimeVoiceForcedConsultHandle,
   terminal: ForcedTerminalProviderResult,
 ): void | Promise<void> {
-  const pending = session.forcedConsults
+  const pending = session.harness.forcedConsults
     .nativeCallIds(handle)
     .map((callId) => session.pendingProviderToolResults.get(callId))
     .filter((submission): submission is Promise<void> => submission !== undefined);
@@ -1204,7 +1189,7 @@ function submitRealtimeAgentConsultWorkingResponse(
       relaySessionId: session.id,
       type: "toolResult",
       callId,
-      talkEvent: session.talk.emit({
+      talkEvent: session.harness.talk.emit({
         type: "tool.progress",
         callId,
         turnId,
@@ -1216,7 +1201,7 @@ function submitRealtimeAgentConsultWorkingResponse(
 }
 
 function ensureRelayTurn(session: RelaySession): string {
-  const turn = session.talk.ensureTurn();
+  const turn = session.harness.talk.ensureTurn();
   if (turn.event) {
     broadcastToOwner(session.context, session.connId, {
       relaySessionId: session.id,
@@ -1256,7 +1241,7 @@ export function sendTalkRealtimeRelayAudio(params: {
     relaySessionId: session.id,
     type: "inputAudio",
     byteLength: audio.byteLength,
-    talkEvent: session.talk.emit({
+    talkEvent: session.harness.talk.emit({
       type: "input.audio.delta",
       turnId,
       payload: { byteLength: audio.byteLength },
@@ -1294,13 +1279,13 @@ export function submitTalkRealtimeRelayToolResult(params: {
   if (pendingFinal && !cancelledAgentCall) {
     return pendingFinal;
   }
-  const forcedConsult = session.forcedConsults
+  const forcedConsult = session.harness.forcedConsults
     .handles()
     .find((handle) => handle.id === params.callId);
   if (forcedConsult) {
-    const cancelled = session.forcedConsults.isCancelled(forcedConsult);
+    const cancelled = session.harness.forcedConsults.isCancelled(forcedConsult);
     const turnId = cancelled
-      ? (session.cancelledAgentToolCalls.get(params.callId) ?? session.talk.activeTurnId)
+      ? (session.cancelledAgentToolCalls.get(params.callId) ?? session.harness.talk.activeTurnId)
       : ensureRelayTurn(session);
     if (!turnId) {
       throw new Error("Cancelled realtime consult is missing its original turn");
@@ -1331,7 +1316,7 @@ export function submitTalkRealtimeRelayToolResult(params: {
         if (session.toolResultEpoch !== terminal.epoch) {
           return;
         }
-        session.forcedConsults.markCancelled(forcedConsult);
+        session.harness.forcedConsults.markCancelled(forcedConsult);
         clearRelayAgentToolCall(session, params.callId);
         session.cancelledAgentToolCalls.delete(params.callId);
         session.completedAgentToolCalls.add(params.callId);
@@ -1382,10 +1367,10 @@ export function submitTalkRealtimeRelayToolResult(params: {
       if (session.toolResultEpoch !== terminal.epoch) {
         return;
       }
-      session.forcedConsults.markDelivered(forcedConsult);
+      session.harness.forcedConsults.markDelivered(forcedConsult);
       clearRelayAgentToolCall(session, params.callId);
       session.completedAgentToolCalls.add(params.callId);
-      const hasNativeCalls = session.forcedConsults.nativeCallIds(forcedConsult).length > 0;
+      const hasNativeCalls = session.harness.forcedConsults.nativeCallIds(forcedConsult).length > 0;
       if (text && (!hasNativeCalls || providerOptions)) {
         session.bridge.sendUserMessage(buildForcedConsultSpeechPrompt(text));
       }
@@ -1537,7 +1522,7 @@ export async function steerTalkRealtimeRelayAgentRun(params: {
     sessionKey,
     text: params.text,
     mode: params.mode,
-    recentEvents: session.talk.recentEvents,
+    recentEvents: session.harness.talk.recentEvents,
   });
   if (relaySessions.get(session.id) !== session) {
     throw new Error("Realtime relay session closed while steering the agent run");
@@ -1557,7 +1542,7 @@ export async function steerTalkRealtimeRelayAgentRun(params: {
     relaySessionId: session.id,
     type: "toolProgress",
     result: finalResult,
-    talkEvent: session.talk.emit({
+    talkEvent: session.harness.talk.emit({
       type: "tool.progress",
       turnId,
       payload: {
@@ -1586,17 +1571,17 @@ export function cancelTalkRealtimeRelayTurn(params: {
   for (const callId of session.activeAgentToolCalls.keys()) {
     session.cancelledAgentToolCalls.set(callId, turnId);
   }
-  for (const forcedConsult of session.forcedConsults.handles()) {
-    if (session.forcedConsults.isCancelled(forcedConsult)) {
+  for (const forcedConsult of session.harness.forcedConsults.handles()) {
+    if (session.harness.forcedConsults.isCancelled(forcedConsult)) {
       session.cancelledAgentToolCalls.set(forcedConsult.id, turnId);
-      for (const nativeCallId of session.forcedConsults.nativeCallIds(forcedConsult)) {
+      for (const nativeCallId of session.harness.forcedConsults.nativeCallIds(forcedConsult)) {
         session.cancelledAgentToolCalls.set(nativeCallId, turnId);
       }
     }
   }
-  session.bridge.handleBargeIn({ audioPlaybackActive: true });
+  session.harness.handleBargeIn({ audioPlaybackActive: true });
   abortRelayAgentRuns(session, reason);
-  const cancelled = session.talk.cancelTurn({
+  const cancelled = session.harness.talk.cancelTurn({
     turnId,
     payload: { reason },
   });

--- a/src/plugin-sdk/test-helpers/plugin-runtime-mock.test.ts
+++ b/src/plugin-sdk/test-helpers/plugin-runtime-mock.test.ts
@@ -5,6 +5,11 @@ import { createPluginRuntimeMock } from "openclaw/plugin-sdk/plugin-test-runtime
 import { describe, expect, it, vi } from "vitest";
 
 describe("createPluginRuntimeMock", () => {
+  it("includes the interactive Talk session opener", () => {
+    const runtime = createPluginRuntimeMock();
+
+    expect(vi.isMockFunction(runtime.talk.openSession)).toBe(true);
+  });
   it("clones the initializer callback input and applies its final extension patch", async () => {
     const runtime = createPluginRuntimeMock();
     const pluginExtensions = { codex: { marker: "original" } };

--- a/src/plugin-sdk/test-helpers/plugin-runtime-mock.ts
+++ b/src/plugin-sdk/test-helpers/plugin-runtime-mock.ts
@@ -606,6 +606,9 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
         () => "",
       ) as unknown as PluginRuntime["system"]["formatNativeDependencyHint"],
     },
+    talk: {
+      openSession: vi.fn(),
+    },
     media: {
       loadWebMedia: vi.fn() as unknown as PluginRuntime["media"]["loadWebMedia"],
       detectMime: vi.fn() as unknown as PluginRuntime["media"]["detectMime"],

--- a/src/plugins/runtime/index.test.ts
+++ b/src/plugins/runtime/index.test.ts
@@ -163,6 +163,12 @@ describe("plugin runtime command execution", () => {
       expected: onSessionTranscriptUpdate,
     },
     {
+      name: "exposes runtime.talk.openSession",
+      readValue: (runtime: ReturnType<typeof createPluginRuntime>) =>
+        typeof runtime.talk.openSession,
+      expected: "function",
+    },
+    {
       name: "exposes runtime.system.requestHeartbeat",
       readValue: (runtime: ReturnType<typeof createPluginRuntime>) =>
         runtime.system.requestHeartbeat,

--- a/src/plugins/runtime/index.ts
+++ b/src/plugins/runtime/index.ts
@@ -32,6 +32,7 @@ import { createRuntimeEvents } from "./runtime-events.js";
 import { createRuntimeLogging } from "./runtime-logging.js";
 import { createRuntimeMedia } from "./runtime-media.js";
 import { createRuntimeSystem } from "./runtime-system.js";
+import { createRuntimeTalk } from "./runtime-talk.js";
 import { createRuntimeTaskFlow } from "./runtime-taskflow.js";
 import { createRuntimeTasks } from "./runtime-tasks.js";
 import type { CreatePluginRuntimeOptions, PluginRuntime } from "./types.js";
@@ -325,6 +326,7 @@ export function createPluginRuntime(_options: CreatePluginRuntimeOptions = {}): 
     sandbox: createRuntimeSandbox(agent),
     worktrees: createRuntimeWorktrees(),
     system: createRuntimeSystem(),
+    talk: createRuntimeTalk(),
     media: createRuntimeMedia(),
     webSearch: {
       listProviders: listWebSearchProviders,

--- a/src/plugins/runtime/runtime-talk.ts
+++ b/src/plugins/runtime/runtime-talk.ts
@@ -1,0 +1,10 @@
+import type { PluginRuntime } from "./types.js";
+
+export function createRuntimeTalk(): PluginRuntime["talk"] {
+  return {
+    openSession: async (params) => {
+      const runtime = await import("../../gateway/talk-plugin-session.js");
+      return await runtime.openPluginTalkSession(params);
+    },
+  };
+}

--- a/src/plugins/runtime/types-core.ts
+++ b/src/plugins/runtime/types-core.ts
@@ -336,6 +336,11 @@ export type PluginRuntimeCore = {
     runCommandWithTimeout: typeof import("../../process/exec.js").runCommandWithTimeout;
     formatNativeDependencyHint: typeof import("./native-deps.js").formatNativeDependencyHint;
   };
+  talk: {
+    openSession: (
+      params: import("../../talk/plugin-session.js").OpenPluginTalkSessionParams,
+    ) => Promise<import("../../talk/plugin-session.js").PluginTalkSession>;
+  };
   media: {
     loadWebMedia: typeof import("../../media/web-media.js").loadWebMedia;
     detectMime: typeof import("@openclaw/media-core/mime").detectMime;

--- a/src/talk/agent-consult-runtime.test.ts
+++ b/src/talk/agent-consult-runtime.test.ts
@@ -212,6 +212,7 @@ describe("realtime voice agent consult runtime", () => {
 
   it("runs an embedded agent using the shared session and prompt contract", async () => {
     const { runtime, runEmbeddedAgent, sessionStore } = createAgentRuntime();
+    const onRunStarted = vi.fn();
 
     const result = await consultRealtimeVoiceAgent({
       cfg: { agents: { list: [{ id: "operator", default: true }] } } as never,
@@ -221,6 +222,7 @@ describe("realtime voice agent consult runtime", () => {
       messageProvider: "voice",
       lane: "voice",
       runIdPrefix: "voice-realtime-consult:call-1",
+      onRunStarted,
       args: { question: "What should I say?", context: "Caller asked about PR #123." },
       transcript: [{ role: "user", text: "Can you check this?" }],
       surface: "a live phone call",
@@ -249,6 +251,7 @@ describe("realtime voice agent consult runtime", () => {
     expect(call.agentId).toBe("operator");
     expect(call.messageProvider).toBe("voice");
     expect(call.lane).toBe("voice");
+    expect(onRunStarted).toHaveBeenCalledWith(call.runId);
     expect(call.toolsAllow).toStrictEqual(["read"]);
     expect(call.provider).toBe("openai");
     expect(call.model).toBe("gpt-5.4");

--- a/src/talk/agent-consult-runtime.ts
+++ b/src/talk/agent-consult-runtime.ts
@@ -241,6 +241,7 @@ export async function consultRealtimeVoiceAgent(params: {
   messageProvider: string;
   lane: string;
   runIdPrefix: string;
+  onRunStarted?: (runId: string) => void;
   args: unknown;
   transcript: RealtimeVoiceAgentConsultTranscriptEntry[];
   surface: string;
@@ -337,6 +338,8 @@ export async function consultRealtimeVoiceAgent(params: {
 
       // Voice consults suppress verbose/reasoning output because the bridge needs a short,
       // speakable answer, not agent-run diagnostics or hidden reasoning artifacts.
+      const runId = `${params.runIdPrefix}:${Date.now()}`;
+      params.onRunStarted?.(runId);
       const result = await params.agentRuntime.runEmbeddedAgent({
         sessionId,
         sessionKey: params.sessionKey,
@@ -378,7 +381,7 @@ export async function consultRealtimeVoiceAgent(params: {
         toolsAllow: params.toolsAllow,
         timeoutMs:
           params.timeoutMs ?? params.agentRuntime.resolveAgentTimeoutMs({ cfg: params.cfg }),
-        runId: `${params.runIdPrefix}:${Date.now()}`,
+        runId,
         lane: params.lane,
         extraSystemPrompt:
           params.extraSystemPrompt ??

--- a/src/talk/agent-talkback-runtime.test.ts
+++ b/src/talk/agent-talkback-runtime.test.ts
@@ -159,8 +159,8 @@ describe("realtime voice agent talkback queue", () => {
       question: "guest",
       responseStyle: "brief",
     });
-    expect(deliver).toHaveBeenCalledWith("owner-answer");
-    expect(deliver).toHaveBeenCalledWith("guest-answer");
+    expect(deliver).toHaveBeenCalledWith("owner-answer", { senderIsOwner: true });
+    expect(deliver).toHaveBeenCalledWith("guest-answer", { senderIsOwner: false });
   });
 
   it("delivers fallback text when consult fails", async () => {

--- a/src/talk/agent-talkback-runtime.ts
+++ b/src/talk/agent-talkback-runtime.ts
@@ -13,13 +13,13 @@ export type RealtimeVoiceAgentTalkbackResult = {
 };
 
 /** Minimal queue API owned by a realtime voice session. */
-export type RealtimeVoiceAgentTalkbackQueue = {
+export type RealtimeVoiceAgentTalkbackQueue<TMetadata = unknown> = {
   close(): void;
-  enqueue(question: string, metadata?: unknown): void;
+  enqueue(question: string, metadata?: TMetadata): void;
 };
 
 /** Runtime dependencies and policy knobs for the talkback queue. */
-export type RealtimeVoiceAgentTalkbackQueueParams = {
+export type RealtimeVoiceAgentTalkbackQueueParams<TMetadata = unknown> = {
   /** Delay used to merge nearby transcript fragments into one consult. */
   debounceMs: number;
   isStopped: () => boolean;
@@ -30,25 +30,25 @@ export type RealtimeVoiceAgentTalkbackQueueParams = {
   /** Delegates a batched question to OpenClaw and respects the abort signal. */
   consult: (args: {
     question: string;
-    metadata?: unknown;
+    metadata?: TMetadata;
     responseStyle: string;
     signal: AbortSignal;
   }) => Promise<RealtimeVoiceAgentTalkbackResult>;
   /** Delivers final speakable text back to the realtime provider/session. */
-  deliver: (text: string) => void;
+  deliver: (text: string, metadata?: TMetadata) => void;
 };
 
-type PendingQuestion = {
+type PendingQuestion<TMetadata> = {
   question: string;
-  metadata?: unknown;
+  metadata?: TMetadata;
 };
 
 /** Create a serial consult queue for realtime transcript talkback. */
-export function createRealtimeVoiceAgentTalkbackQueue(
-  params: RealtimeVoiceAgentTalkbackQueueParams,
-): RealtimeVoiceAgentTalkbackQueue {
+export function createRealtimeVoiceAgentTalkbackQueue<TMetadata = unknown>(
+  params: RealtimeVoiceAgentTalkbackQueueParams<TMetadata>,
+): RealtimeVoiceAgentTalkbackQueue<TMetadata> {
   let active = false;
-  let pendingQuestions: PendingQuestion[] = [];
+  let pendingQuestions: PendingQuestion<TMetadata>[] = [];
   let debounceTimer: ReturnType<typeof setTimeout> | undefined;
   let activeAbortController: AbortController | undefined;
 
@@ -60,7 +60,15 @@ export function createRealtimeVoiceAgentTalkbackQueue(
     debounceTimer = undefined;
   };
 
-  const run = async (pending: PendingQuestion): Promise<void> => {
+  const deliver = (text: string, metadata: TMetadata | undefined) => {
+    if (metadata === undefined) {
+      params.deliver(text);
+    } else {
+      params.deliver(text, metadata);
+    }
+  };
+
+  const run = async (pending: PendingQuestion<TMetadata>): Promise<void> => {
     const trimmed = pending.question.trim();
     if (!trimmed || params.isStopped()) {
       return;
@@ -76,7 +84,7 @@ export function createRealtimeVoiceAgentTalkbackQueue(
     }
 
     active = true;
-    let nextQuestion: PendingQuestion | undefined = {
+    let nextQuestion: PendingQuestion<TMetadata> | undefined = {
       question: trimmed,
       metadata: pending.metadata,
     };
@@ -104,7 +112,7 @@ export function createRealtimeVoiceAgentTalkbackQueue(
           `${params.logPrefix} consult done: elapsedMs=${Date.now() - consultStartedAt} answerChars=${text.length} queued=${pendingQuestions.length}`,
         );
         if (!params.isStopped() && text) {
-          params.deliver(text);
+          deliver(text, currentQuestion.metadata);
         }
         nextQuestion = pendingQuestions.shift();
       }
@@ -117,7 +125,7 @@ export function createRealtimeVoiceAgentTalkbackQueue(
       const elapsedDetail =
         consultStartedAt === undefined ? "" : ` elapsedMs=${Date.now() - consultStartedAt}`;
       params.logger.warn(`${params.logPrefix} consult failed:${elapsedDetail} ${message}`);
-      params.deliver(params.fallbackText);
+      deliver(params.fallbackText, nextQuestion?.metadata);
     } finally {
       active = false;
       const queuedQuestion = pendingQuestions.shift();
@@ -164,7 +172,10 @@ export function createRealtimeVoiceAgentTalkbackQueue(
   };
 }
 
-function appendPendingQuestion(queue: PendingQuestion[], next: PendingQuestion): void {
+function appendPendingQuestion<TMetadata>(
+  queue: PendingQuestion<TMetadata>[],
+  next: PendingQuestion<TMetadata>,
+): void {
   const current = queue.at(-1);
   if (current && Object.is(current.metadata, next.metadata)) {
     // Metadata identity represents the caller/context lane; merge only when the

--- a/src/talk/output-media.test.ts
+++ b/src/talk/output-media.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createRealtimeVoiceOutputMediaSession,
+  type RealtimeVoiceOutputMediaEvent,
+} from "./output-media.js";
+
+describe("realtime voice output media", () => {
+  it("does no delivery work when the session has no owner listener", () => {
+    const session = createRealtimeVoiceOutputMediaSession();
+
+    expect(session.sendAudio(new Uint8Array([1, 0]))).toBe(true);
+    expect(session.clear("barge-in")).toBe(2);
+    expect(() => session.end("completed")).not.toThrow();
+  });
+
+  it("delivers ordered, copied media only to the owning session listener", async () => {
+    const events: RealtimeVoiceOutputMediaEvent[] = [];
+    const session = createRealtimeVoiceOutputMediaSession({
+      onEvent: (event) => events.push(event),
+    });
+    const pcm = new Uint8Array([1, 0, 2, 0]);
+
+    session.setState("listening");
+    session.sendAudio(pcm);
+    pcm.fill(9);
+    await vi.waitFor(() => expect(events.some((event) => event.type === "audio")).toBe(true));
+    session.clear("barge-in");
+    session.end("completed");
+
+    await vi.waitFor(() => expect(events.at(-1)?.type).toBe("session.end"));
+    expect(events.map((event) => event.type)).toEqual([
+      "session.start",
+      "state",
+      "state",
+      "state",
+      "audio",
+      "clear",
+      "clear",
+      "state",
+      "session.end",
+    ]);
+    const audio = events.find(
+      (event): event is Extract<RealtimeVoiceOutputMediaEvent, { type: "audio" }> =>
+        event.type === "audio",
+    );
+    expect(audio?.pcm).toEqual(new Uint8Array([1, 0, 2, 0]));
+    expect(audio).toMatchObject({ generation: 1, sequence: 0, ptsMs: 0 });
+    expect(events.at(-1)).toMatchObject({ generation: 3, reason: "completed" });
+  });
+
+  it("isolates listener failures from playback", async () => {
+    const onEvent = vi.fn(async () => {
+      throw new Error("owner failed");
+    });
+    const session = createRealtimeVoiceOutputMediaSession({ onEvent });
+
+    expect(session.sendAudio(new Uint8Array([1, 0]))).toBe(true);
+    await vi.waitFor(() => expect(onEvent).toHaveBeenCalled());
+    expect(session.sendAudio(new Uint8Array([2, 0]))).toBe(true);
+  });
+});

--- a/src/talk/output-media.ts
+++ b/src/talk/output-media.ts
@@ -1,0 +1,221 @@
+const OUTPUT_AUDIO_FORMAT = {
+  encoding: "pcm16le",
+  sampleRateHz: 24_000,
+  channels: 1,
+} as const;
+const PCM_BYTES_PER_SAMPLE = 2;
+const PCM_BYTES_PER_MILLISECOND =
+  (OUTPUT_AUDIO_FORMAT.sampleRateHz * OUTPUT_AUDIO_FORMAT.channels * PCM_BYTES_PER_SAMPLE) / 1000;
+const MAX_PENDING_EVENTS = 256;
+const MAX_PENDING_AUDIO_BYTES = 1024 * 1024;
+
+export type RealtimeVoiceOutputMediaState =
+  | "idle"
+  | "listening"
+  | "thinking"
+  | "speaking"
+  | "error";
+
+export type RealtimeVoiceOutputMediaClearReason =
+  | "barge-in"
+  | "cancel"
+  | "replace"
+  | "hangup"
+  | "error";
+
+export type RealtimeVoiceOutputMediaEvent =
+  | { type: "session.start"; generation: number; audio: typeof OUTPUT_AUDIO_FORMAT }
+  | { type: "state"; generation: number; ptsMs: number; state: RealtimeVoiceOutputMediaState }
+  | { type: "audio"; generation: number; sequence: number; ptsMs: number; pcm: Uint8Array }
+  | { type: "clear"; generation: number; reason: RealtimeVoiceOutputMediaClearReason }
+  | {
+      type: "session.end";
+      generation: number;
+      reason: "completed" | "error" | "replaced";
+    };
+
+export type RealtimeVoiceOutputMediaSession = {
+  readonly generation: number;
+  clear(reason: RealtimeVoiceOutputMediaClearReason): number;
+  end(reason: "completed" | "error" | "replaced"): void;
+  sendAudio(pcm: Uint8Array, generation?: number): boolean;
+  setState(state: RealtimeVoiceOutputMediaState, generation?: number): boolean;
+};
+
+type OutputListener = (event: RealtimeVoiceOutputMediaEvent) => void | Promise<void>;
+
+class OutputMediaSession implements RealtimeVoiceOutputMediaSession {
+  private active = true;
+  private currentGeneration = 1;
+  private stateGeneration = 1;
+  private sequence = 0;
+  private audioBytes = 0;
+  private state: RealtimeVoiceOutputMediaState = "idle";
+  private queue: RealtimeVoiceOutputMediaEvent[] = [];
+  private queuedAudioBytes = 0;
+  private draining = false;
+
+  constructor(private readonly listener?: OutputListener) {
+    this.publish({
+      type: "session.start",
+      generation: this.currentGeneration,
+      audio: OUTPUT_AUDIO_FORMAT,
+    });
+    this.publish(this.stateEvent());
+  }
+
+  get generation(): number {
+    return this.currentGeneration;
+  }
+
+  private ptsMs(): number {
+    return this.audioBytes / PCM_BYTES_PER_MILLISECOND;
+  }
+
+  private stateEvent(): Extract<RealtimeVoiceOutputMediaEvent, { type: "state" }> {
+    return {
+      type: "state",
+      generation: this.currentGeneration,
+      ptsMs: this.ptsMs(),
+      state: this.state,
+    };
+  }
+
+  private publish(event: RealtimeVoiceOutputMediaEvent): void {
+    if (!this.listener) {
+      return;
+    }
+    if (event.type === "audio") {
+      if (
+        this.queue.length >= MAX_PENDING_EVENTS ||
+        this.queuedAudioBytes + event.pcm.byteLength > MAX_PENDING_AUDIO_BYTES
+      ) {
+        return;
+      }
+      const copy = { ...event, pcm: Uint8Array.from(event.pcm) };
+      this.queue.push(copy);
+      this.queuedAudioBytes += copy.pcm.byteLength;
+    } else {
+      while (this.queue.length >= MAX_PENDING_EVENTS) {
+        const audioIndex = this.queue.findIndex((queued) => queued.type === "audio");
+        if (audioIndex < 0) {
+          this.queue.shift();
+          break;
+        }
+        const [removed] = this.queue.splice(audioIndex, 1);
+        if (removed?.type === "audio") {
+          this.queuedAudioBytes -= removed.pcm.byteLength;
+        }
+      }
+      this.queue.push(event);
+    }
+    this.scheduleDrain();
+  }
+
+  private scheduleDrain(): void {
+    if (this.draining) {
+      return;
+    }
+    this.draining = true;
+    queueMicrotask(() => void this.drain());
+  }
+
+  private async drain(): Promise<void> {
+    try {
+      while (this.listener) {
+        const event = this.queue.shift();
+        if (!event) {
+          return;
+        }
+        if (event.type === "audio") {
+          this.queuedAudioBytes -= event.pcm.byteLength;
+        }
+        try {
+          await this.listener(event);
+        } catch {
+          // The session owner cannot interrupt provider playback.
+        }
+      }
+    } finally {
+      this.draining = false;
+      if (this.queue.length > 0) {
+        this.scheduleDrain();
+      }
+    }
+  }
+
+  setState(state: RealtimeVoiceOutputMediaState, generation = this.currentGeneration): boolean {
+    if (!this.active || generation !== this.currentGeneration) {
+      return false;
+    }
+    if (state === this.state && this.stateGeneration === this.currentGeneration) {
+      return true;
+    }
+    this.state = state;
+    this.stateGeneration = this.currentGeneration;
+    this.publish(this.stateEvent());
+    return true;
+  }
+
+  sendAudio(pcm: Uint8Array, generation = this.currentGeneration): boolean {
+    if (!this.active || generation !== this.currentGeneration || pcm.byteLength === 0) {
+      return false;
+    }
+    this.setState("speaking", generation);
+    const event = {
+      type: "audio" as const,
+      generation: this.currentGeneration,
+      sequence: this.sequence,
+      ptsMs: this.ptsMs(),
+      pcm,
+    };
+    this.sequence += 1;
+    this.audioBytes += pcm.byteLength;
+    this.publish(event);
+    return true;
+  }
+
+  clear(reason: RealtimeVoiceOutputMediaClearReason): number {
+    if (!this.active) {
+      return this.currentGeneration;
+    }
+    this.currentGeneration += 1;
+    this.stateGeneration = this.currentGeneration;
+    this.sequence = 0;
+    this.audioBytes = 0;
+    for (let index = this.queue.length - 1; index >= 0; index -= 1) {
+      const queued = this.queue[index];
+      if (
+        queued &&
+        queued.generation < this.currentGeneration &&
+        (queued.type === "audio" || queued.type === "state")
+      ) {
+        this.queue.splice(index, 1);
+        if (queued.type === "audio") {
+          this.queuedAudioBytes -= queued.pcm.byteLength;
+        }
+      }
+    }
+    this.publish({ type: "clear", generation: this.currentGeneration, reason });
+    return this.currentGeneration;
+  }
+
+  end(reason: "completed" | "error" | "replaced"): void {
+    if (!this.active) {
+      return;
+    }
+    const clearReason = reason === "error" ? "error" : reason === "replaced" ? "replace" : "hangup";
+    this.clear(clearReason);
+    this.setState(reason === "error" ? "error" : "idle");
+    this.active = false;
+    this.publish({ type: "session.end", generation: this.currentGeneration, reason });
+  }
+}
+
+export function createRealtimeVoiceOutputMediaSession(
+  params: {
+    onEvent?: OutputListener;
+  } = {},
+): RealtimeVoiceOutputMediaSession {
+  return new OutputMediaSession(params.onEvent);
+}

--- a/src/talk/plugin-session.ts
+++ b/src/talk/plugin-session.ts
@@ -1,0 +1,46 @@
+export const PLUGIN_TALK_AUDIO_FORMAT = {
+  encoding: "pcm16le",
+  sampleRateHz: 24_000,
+  channels: 1,
+} as const;
+
+export type PluginTalkSessionEvent =
+  | {
+      type: "state";
+      generation: number;
+      ptsMs: number;
+      state: "idle" | "listening" | "thinking" | "speaking" | "error";
+    }
+  | {
+      type: "audio";
+      generation: number;
+      sequence: number;
+      ptsMs: number;
+      pcm: Uint8Array;
+    }
+  | {
+      type: "clear";
+      generation: number;
+      reason: "barge-in" | "cancel" | "replace" | "hangup" | "error";
+    }
+  | {
+      type: "closed";
+      generation: number;
+      reason: "completed" | "error" | "replaced";
+    };
+
+export type OpenPluginTalkSessionParams = {
+  sessionKey: string;
+  provider?: string;
+  model?: string;
+  voice?: string;
+  language?: string;
+  onEvent: (event: PluginTalkSessionEvent) => void | Promise<void>;
+};
+
+export type PluginTalkSession = {
+  readonly audio: typeof PLUGIN_TALK_AUDIO_FORMAT;
+  sendAudio(pcm: Uint8Array, options?: { timestamp?: number }): void;
+  cancelOutput(reason?: string): void;
+  close(): void;
+};

--- a/src/talk/realtime-session-harness.test.ts
+++ b/src/talk/realtime-session-harness.test.ts
@@ -120,6 +120,15 @@ describe("realtime voice session harness", () => {
     expect(deliver).toHaveBeenCalledWith("answer:first\nsecond");
   });
 
+  it("detects assistant transcript echo without enabling audio suppression", () => {
+    const harness = createHarness({ transcriptLookbackMs: 12_000 });
+
+    harness.recordTranscript("assistant", "I found the shopping list");
+
+    expect(harness.isLikelyAssistantEchoTranscript("I found the shopping list")).toBe(true);
+    expect(harness.recordInputAudio(Buffer.from([1, 2]))).toBe(true);
+  });
+
   it("flushes transport output when provider barge-in does not clear it", () => {
     const handleBargeIn = vi.fn();
     const provider: RealtimeVoiceProviderPlugin = {

--- a/src/talk/realtime-session-harness.ts
+++ b/src/talk/realtime-session-harness.ts
@@ -92,7 +92,7 @@ export type RealtimeVoiceSessionHarness<TForcedConsultContext = unknown> = {
     providerConnected: boolean;
     realtimeReady: boolean;
   }): RealtimeVoiceSessionHarnessHealth;
-  handleBargeIn(options: RealtimeVoiceBargeInOptions, flushOutput: () => void): void;
+  handleBargeIn(options: RealtimeVoiceBargeInOptions, flushOutput?: () => void): void;
   isLikelyAssistantEchoTranscript(text: string): boolean;
   isOutputPlaybackWindowActive(): boolean;
   recordInputAudio(audio: Buffer): boolean;
@@ -107,6 +107,8 @@ export function createRealtimeVoiceSessionHarness<TForcedConsultContext = unknow
   talkback?: Omit<RealtimeVoiceAgentTalkbackQueueParams, "isStopped">;
   forcedConsults?: RealtimeVoiceForcedConsultCoordinatorOptions;
   echoSuppression?: RealtimeVoiceSessionHarnessEchoSuppression;
+  transcriptLookbackMs?: number;
+  captureBridgeEvents?: boolean;
 }): RealtimeVoiceSessionHarness<TForcedConsultContext> {
   let closed = false;
   let bridge: RealtimeVoiceBridgeSession | undefined;
@@ -121,6 +123,8 @@ export function createRealtimeVoiceSessionHarness<TForcedConsultContext = unknow
   const transcript: RealtimeVoiceTranscriptEntry[] = [];
   const bridgeEvents: RealtimeVoiceBridgeEventLogEntry[] = [];
   const outputActivity = createRealtimeVoiceOutputActivityTracker();
+  const transcriptLookbackMs =
+    params.transcriptLookbackMs ?? params.echoSuppression?.transcriptLookbackMs;
   const forcedConsults = createRealtimeVoiceForcedConsultCoordinator<TForcedConsultContext>(
     params.forcedConsults,
   );
@@ -173,7 +177,9 @@ export function createRealtimeVoiceSessionHarness<TForcedConsultContext = unknow
           bridgeParams.onTranscript?.(role, text, isFinal);
         },
         onEvent: (event) => {
-          recordRealtimeVoiceBridgeEvent(bridgeEvents, event);
+          if (params.captureBridgeEvents !== false) {
+            recordRealtimeVoiceBridgeEvent(bridgeEvents, event);
+          }
           bridgeParams.onEvent?.(event);
         },
       });
@@ -218,18 +224,18 @@ export function createRealtimeVoiceSessionHarness<TForcedConsultContext = unknow
       suppressInputUntilMs = 0;
       const flushGeneration = outputFlushGeneration;
       bridge?.handleBargeIn(options);
-      if (flushGeneration === outputFlushGeneration) {
+      if (fallbackFlush && flushGeneration === outputFlushGeneration) {
         flushOutput(fallbackFlush);
       }
     },
     isLikelyAssistantEchoTranscript(text) {
-      return params.echoSuppression
-        ? isLikelyRealtimeVoiceAssistantEchoTranscript({
+      return transcriptLookbackMs === undefined
+        ? false
+        : isLikelyRealtimeVoiceAssistantEchoTranscript({
             transcript,
             text,
-            lookbackMs: params.echoSuppression.transcriptLookbackMs,
-          })
-        : false;
+            lookbackMs: transcriptLookbackMs,
+          });
     },
     isOutputPlaybackWindowActive() {
       return Date.now() <= Math.max(lastOutputPlayableUntilMs, suppressInputUntilMs);

--- a/src/talk/realtime-session-harness.ts
+++ b/src/talk/realtime-session-harness.ts
@@ -75,11 +75,14 @@ type RealtimeVoiceSessionHarnessHealth = ReturnType<typeof getRealtimeVoiceTrans
     }>;
   };
 
-export type RealtimeVoiceSessionHarness<TForcedConsultContext = unknown> = {
+export type RealtimeVoiceSessionHarness<
+  TForcedConsultContext = unknown,
+  TTalkbackMetadata = unknown,
+> = {
   readonly forcedConsults: RealtimeVoiceForcedConsultCoordinator<TForcedConsultContext>;
   readonly outputActivity: RealtimeVoiceOutputActivityTracker;
   readonly talk: TalkSessionController;
-  readonly talkback: RealtimeVoiceAgentTalkbackQueue | undefined;
+  readonly talkback: RealtimeVoiceAgentTalkbackQueue<TTalkbackMetadata> | undefined;
   readonly transcript: RealtimeVoiceTranscriptEntry[];
   close(): void;
   createBridge(params: RealtimeVoiceBridgeSessionParams): RealtimeVoiceBridgeSession;
@@ -100,16 +103,19 @@ export type RealtimeVoiceSessionHarness<TForcedConsultContext = unknown> = {
   recordTranscript(role: RealtimeVoiceRole, text: string): RealtimeVoiceTranscriptEntry;
 };
 
-export function createRealtimeVoiceSessionHarness<TForcedConsultContext = unknown>(params: {
+export function createRealtimeVoiceSessionHarness<
+  TForcedConsultContext = unknown,
+  TTalkbackMetadata = unknown,
+>(params: {
   talk: TalkSessionControllerParams;
   talkPayloads: RealtimeVoiceSessionHarnessTalkPayloads;
   onTalkEvent?: (event: TalkEvent) => void;
-  talkback?: Omit<RealtimeVoiceAgentTalkbackQueueParams, "isStopped">;
+  talkback?: Omit<RealtimeVoiceAgentTalkbackQueueParams<TTalkbackMetadata>, "isStopped">;
   forcedConsults?: RealtimeVoiceForcedConsultCoordinatorOptions;
   echoSuppression?: RealtimeVoiceSessionHarnessEchoSuppression;
   transcriptLookbackMs?: number;
   captureBridgeEvents?: boolean;
-}): RealtimeVoiceSessionHarness<TForcedConsultContext> {
+}): RealtimeVoiceSessionHarness<TForcedConsultContext, TTalkbackMetadata> {
   let closed = false;
   let bridge: RealtimeVoiceBridgeSession | undefined;
   let lastInputAt: string | undefined;
@@ -153,7 +159,7 @@ export function createRealtimeVoiceSessionHarness<TForcedConsultContext = unknow
     flush();
   };
 
-  const harness: RealtimeVoiceSessionHarness<TForcedConsultContext> = {
+  const harness: RealtimeVoiceSessionHarness<TForcedConsultContext, TTalkbackMetadata> = {
     forcedConsults,
     outputActivity,
     talk,


### PR DESCRIPTION
## Problem

Plugin pages can capture microphone audio, but they should not own provider credentials or reproduce OpenClaw's realtime tool-call, agent-run, cancellation, transcript, and turn orchestration. The existing low-level relay leaves those responsibilities with native clients, so a simple browser plugin cannot start a fully capable conversation with the configured OpenClaw agent and workspace.

## Change

Add one public Plugin SDK method: `runtime.talk.openSession(...)`.

```ts
const session = await api.runtime.talk.openSession({
  sessionKey: "agent:main:avatar",
  onEvent(event) {
    if (event.type === "audio") player.write(event.pcm);
  },
});

session.sendAudio(microphonePcm);
session.cancelOutput();
session.close();
```

The returned session handle exposes its PCM16LE 24 kHz mono format plus three operations: `sendAudio`, `cancelOutput`, and `close`. Its owner callback receives conversational state, exact output PCM, playback clears, and closure.

The Gateway resolves the configured realtime provider and agent session, keeps provider credentials server-side, executes agent tools against the intended workspace, and returns the result to the same voice conversation. Barge-in cancels current output and agent work without changing existing native-client coordination.

The implementation builds on the shared realtime session harness from #112590. The harness owns the bridge, transcript, forced-consult coordinator, talkback queue, barge-in dispatch, and cleanup; this PR adds only Gateway-managed consult policy, owner-scoped output delivery, and the Plugin SDK handle.

## Ownership and cost

Raw audio is available only through the handle that opened the session. `openSession` is restricted to Gateway-authenticated plugin routes that declare `contracts.gatewayMethodDispatch`.

This deliberately follows the existing documented trust model: Gateway-dispatch plugins are tightly reviewed, trusted in-process/operator surfaces rather than sandboxed code. The caller may select an agent session and receive its Talk PCM; browser plugin UIs remain responsible for obtaining microphone permission before sending input.

Output-media buffering is created only when a caller supplies an output callback. Existing Talk relay sessions do not copy or queue PCM for this surface.

## Stack

The feature commit is directly based on #112590 (`21a8dfd22e4`). GitHub displays `main` as this PR's base because an upstream PR cannot select a fork-owned branch, but the commit ancestry is:

`main` → #112590 → this PR

This PR is independent of #110902's anonymous `watchActivity` observer.

Companion plugin: https://github.com/RomneyDa/openclaw-avatar-plugin

## Validation

- `pnpm check`
- 106 focused Talk, Gateway, Plugin SDK, and plugin runtime tests
- Plugin SDK surface check
- Focused oxlint and oxfmt checks
