### PR TITLE
chore(scripts): end failing oxlint runs with a stable status line

### DIFF
--- a/scripts/run-oxlint.d.mts
+++ b/scripts/run-oxlint.d.mts
@@ -29,3 +29,11 @@ export function filterSparseMissingOxlintTargets(
  * Applies wrapper policy and runs oxlint with the final argument list.
  */
 export function main(argv?: string[], runtimeEnv?: NodeJS.ProcessEnv): Promise<void>;
+/**
+ * CLI entry: converts wrapper crashes into exit 1 and ends every failing run
+ * with a stable `[oxlint] FAILED (exit N)` final line.
+ */
+export function runOxlintCliEntry(
+  run?: () => Promise<void>,
+  log?: (message: unknown) => void,
+): Promise<void>;

--- a/scripts/run-oxlint.mjs
+++ b/scripts/run-oxlint.mjs
@@ -281,6 +281,24 @@ export async function main(argv = process.argv.slice(2), runtimeEnv = process.en
   }
 }
 
+/**
+ * CLI entry: converts wrapper crashes into a nonzero exit and ends every
+ * failing run with one stable final line. That line must survive output
+ * truncation (`… | tail -N`): without it, a crash or lint failure whose
+ * diagnostics scrolled away reads as success when only the tail is inspected.
+ */
+export async function runOxlintCliEntry(run = main, log = console.error) {
+  try {
+    await run();
+  } catch (error) {
+    log(error);
+    process.exitCode = 1;
+  }
+  if (typeof process.exitCode === "number" && process.exitCode !== 0) {
+    log(`[oxlint] FAILED (exit ${process.exitCode})`);
+  }
+}
+
 if (import.meta.main) {
-  await main();
+  await runOxlintCliEntry();
 }

--- a/test/scripts/run-oxlint.test.ts
+++ b/test/scripts/run-oxlint.test.ts
@@ -20,6 +20,7 @@ import {
 } from "../../scripts/run-oxlint-shards.mjs";
 import {
   filterSparseMissingOxlintTargets,
+  runOxlintCliEntry,
   shouldPrepareExtensionPackageBoundaryArtifacts,
 } from "../../scripts/run-oxlint.mjs";
 import { createScriptTestHarness } from "./test-helpers.js";
@@ -49,6 +50,60 @@ function isProcessAlive(pid: number): boolean {
 }
 
 describe("run-oxlint", () => {
+  it("ends a failing run with a stable final status line", async () => {
+    const priorExitCode = process.exitCode;
+    const lines: unknown[] = [];
+    try {
+      process.exitCode = 0;
+      await runOxlintCliEntry(
+        async () => {
+          process.exitCode = 2;
+        },
+        (line) => lines.push(line),
+      );
+      expect(lines).toEqual(["[oxlint] FAILED (exit 2)"]);
+    } finally {
+      process.exitCode = priorExitCode;
+    }
+  });
+
+  it("converts a wrapper crash into a nonzero exit with the status line last", async () => {
+    // The original incident: a crashed wrapper printed only a stack trace, and
+    // truncated output read as success. The marker must be the final line.
+    const priorExitCode = process.exitCode;
+    const lines: unknown[] = [];
+    try {
+      process.exitCode = 0;
+      await runOxlintCliEntry(
+        async () => {
+          throw new Error("artifact prep failed");
+        },
+        (line) => lines.push(line),
+      );
+      expect(process.exitCode).toBe(1);
+      expect(lines).toHaveLength(2);
+      expect(lines[0]).toBeInstanceOf(Error);
+      expect(lines[1]).toBe("[oxlint] FAILED (exit 1)");
+    } finally {
+      process.exitCode = priorExitCode;
+    }
+  });
+
+  it("stays silent on a clean run", async () => {
+    const priorExitCode = process.exitCode;
+    const lines: unknown[] = [];
+    try {
+      process.exitCode = 0;
+      await runOxlintCliEntry(
+        async () => {},
+        (line) => lines.push(line),
+      );
+      expect(lines).toEqual([]);
+    } finally {
+      process.exitCode = priorExitCode;
+    }
+  });
+
   it("prepares extension package boundary artifacts for normal lint runs", () => {
     expect(shouldPrepareExtensionPackageBoundaryArtifacts([])).toBe(true);
     expect(shouldPrepareExtensionPackageBoundaryArtifacts(["src/index.ts"])).toBe(true);

--- a/test/scripts/run-oxlint.test.ts
+++ b/test/scripts/run-oxlint.test.ts
@@ -59,7 +59,7 @@ describe("run-oxlint", () => {
         async () => {
           process.exitCode = 2;
         },
-        (line) => lines.push(line),
+        (line: unknown) => lines.push(line),
       );
       expect(lines).toEqual(["[oxlint] FAILED (exit 2)"]);
     } finally {
@@ -78,7 +78,7 @@ describe("run-oxlint", () => {
         async () => {
           throw new Error("artifact prep failed");
         },
-        (line) => lines.push(line),
+        (line: unknown) => lines.push(line),
       );
       expect(process.exitCode).toBe(1);
       expect(lines).toHaveLength(2);
@@ -96,7 +96,7 @@ describe("run-oxlint", () => {
       process.exitCode = 0;
       await runOxlintCliEntry(
         async () => {},
-        (line) => lines.push(line),
+        (line: unknown) => lines.push(line),
       );
       expect(lines).toEqual([]);
     } finally {


### PR DESCRIPTION
## What Problem This Solves

A failing `scripts/run-oxlint.mjs` run has no stable final marker. Two consequences observed in practice:

- When the wrapper itself **crashes** (e.g. artifact prep hitting stale `node_modules` right after a dependency-adding merge — reproduced with `Cannot find module 'libphonenumber-js/min'` after #112400), the only output is a Node stack trace, and the crash's exit code is easy to lose behind a pipeline (`cmd | tail -N; echo $?` reports `tail`'s status).
- When lint **fails** but the diagnostics scroll out of a truncated view, the tail of the output looks identical to a clean run.

Both let a red lint read as green during agent-driven and scripted workflows.

## Why This Change Was Made

Route the CLI entry through a small exported wrapper (`runOxlintCliEntry`) that converts wrapper crashes into `exit 1` and ends **every** failing run with one stable final line:

```
[oxlint] FAILED (exit N)
```

Clean runs stay silent (oxlint's own summary is unchanged). The marker is deliberately the last line so any `tail -N` still shows it.

## User Impact

None at runtime — developer/CI tooling only. Sharded CI lint output gains the same trailing marker on failure.

## Evidence

- Live smoke in this checkout: clean file → exit 0, no marker; file violating `no-promise-executor-return` → exit 1 with `[oxlint] FAILED (exit 1)` as the final line; wrapper crash (stale deps) → exit 1 with the marker last after the stack trace.
- `test/scripts/run-oxlint.test.ts`: three new unit tests (failing run marker, crash → exit 1 + marker last, clean run silent); file green (33 tests).
- `pnpm deadcode:dependencies` green (new export consumed cross-module by the test).
