### PR TITLE
fix: prevent announce restart recovery cascades

### DIFF
--- a/extensions/codex/src/app-server/dynamic-tool-build.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.test.ts
@@ -1526,6 +1526,15 @@ describe("Codex app-server dynamic tool build", () => {
     expect(shouldEnableCodexAppServerNativeToolSurface(params)).toBe(false);
   });
 
+  it("disables Codex native tool surfaces when all tools are disabled", () => {
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);
+    params.disableTools = true;
+    params.toolsAllow = undefined;
+
+    expect(shouldEnableCodexAppServerNativeToolSurface(params)).toBe(false);
+  });
+
   it("keeps Codex native tool surfaces when the effective exec target is node", () => {
     const workspaceDir = path.join(tempDir, "workspace");
     const sessionParams = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);

--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -508,6 +508,9 @@ export function shouldEnableCodexAppServerNativeToolSurface(
   if (isCodexMemoryFlushRun(params)) {
     return false;
   }
+  if (params.disableTools) {
+    return false;
+  }
   const toolsAllow = includeForcedCodexDynamicToolAllow(params.toolsAllow, params);
   if (toolsAllow === undefined) {
     return canCodexAppServerNativeToolSurfaceHonorSandbox(sandbox, options);

--- a/qa/scenarios/agents/subagent-completion-direct-fallback.yaml
+++ b/qa/scenarios/agents/subagent-completion-direct-fallback.yaml
@@ -74,7 +74,7 @@ flow:
             catch:
               - set: fallbackDebugRequests
                 value:
-                  expr: "env.mock ? [...(await fetchJson(`${env.mock.baseUrl}/debug/requests`))].slice(-20).map((request) => ({ plannedToolName: request.plannedToolName ?? null, plannedToolArgs: request.plannedToolArgs ?? null, prompt: String(request.prompt ?? '').slice(0, 280), allInputText: String(request.allInputText ?? '').slice(0, 280), toolOutput: request.toolOutput ? String(request.toolOutput).slice(0, 280) : null })) : []"
+                  expr: "env.mock ? await (async () => { const cursor = Number((await fetchJson(`${env.mock.baseUrl}/debug/request-cursor`)).cursor ?? 0); return [...(await fetchJson(`${env.mock.baseUrl}/debug/requests?after=${Math.max(0, cursor - 20)}`))].map((request) => ({ plannedToolName: request.plannedToolName ?? null, plannedToolArgs: request.plannedToolArgs ?? null, prompt: String(request.prompt ?? '').slice(0, 280), allInputText: String(request.allInputText ?? '').slice(0, 280), toolOutput: request.toolOutput ? String(request.toolOutput).slice(0, 280) : null })); })() : []"
               - set: fallbackTasks
                 value:
                   expr: "(await runQaCli(env, ['tasks', 'list', '--json', '--runtime', 'subagent'], { timeoutMs: liveTurnTimeoutMs(env, 60000), json: true }).catch((error) => ({ error: String(error?.message ?? error) })))"

--- a/src/agents/announce-idempotency.ts
+++ b/src/agents/announce-idempotency.ts
@@ -7,6 +7,8 @@ type AnnounceIdFromChildRunParams = {
   childRunId: string;
 };
 
+const ANNOUNCE_IDEMPOTENCY_KEY_PREFIX = "announce:";
+
 /** Build the persisted announce id for a child session/run pair. */
 export function buildAnnounceIdFromChildRun(params: AnnounceIdFromChildRunParams): string {
   return `v1:${params.childSessionKey}:${params.childRunId}`;
@@ -14,5 +16,10 @@ export function buildAnnounceIdFromChildRun(params: AnnounceIdFromChildRunParams
 
 /** Build the idempotency key used by announce delivery storage. */
 export function buildAnnounceIdempotencyKey(announceId: string): string {
-  return `announce:${announceId}`;
+  return `${ANNOUNCE_IDEMPOTENCY_KEY_PREFIX}${announceId}`;
+}
+
+/** True when a gateway run id belongs to an announce delivery turn. */
+export function isAnnounceRunId(runId: string | null | undefined): boolean {
+  return typeof runId === "string" && runId.startsWith(ANNOUNCE_IDEMPOTENCY_KEY_PREFIX);
 }

--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -2198,6 +2198,73 @@ describe("CLI attempt execution", () => {
     });
   });
 
+  it("disables CLI tools for a subagent completion announce handoff", async () => {
+    const sessionKey = "agent:main:direct:claude-announce";
+    const sessionEntry: SessionEntry = {
+      sessionId: "openclaw-session-cli-announce",
+      updatedAt: Date.now(),
+    };
+    const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
+    await writeSessionStoreSeed(sessionStore);
+    runCliAgentMock.mockResolvedValueOnce(makeCliResult("tool-free announce"));
+
+    await runAgentAttempt({
+      providerOverride: "claude-cli",
+      originalProvider: "claude-cli",
+      modelOverride: "opus",
+      cfg: {} as OpenClawConfig,
+      sessionEntry,
+      sessionId: sessionEntry.sessionId,
+      sessionKey,
+      sessionAgentId: "main",
+      sessionFile: path.join(tmpDir, "session.jsonl"),
+      workspaceDir: tmpDir,
+      body: "A background task finished. Process the completion update now.",
+      isFallbackRetry: false,
+      resolvedThinkLevel: "medium",
+      timeoutMs: 1_000,
+      runId: "run-cli-announce",
+      opts: {
+        inputProvenance: {
+          kind: "inter_session",
+          sourceSessionKey: "agent:openclaw:subagent:child",
+          sourceChannel: "internal",
+          sourceTool: "subagent_announce",
+        },
+        internalEvents: [
+          {
+            type: "task_completion",
+            source: "subagent",
+            childSessionKey: "agent:openclaw:subagent:child",
+            announceType: "subagent task",
+            taskLabel: "review",
+            status: "ok",
+            statusLabel: "completed",
+            result: "child output",
+            replyInstruction: "Relay this completion.",
+          },
+        ],
+      } as Parameters<typeof runAgentAttempt>[0]["opts"],
+      runContext: {} as Parameters<typeof runAgentAttempt>[0]["runContext"],
+      spawnedBy: undefined,
+      messageChannel: "telegram",
+      skillsSnapshot: undefined,
+      resolvedVerboseLevel: undefined,
+      agentDir: tmpDir,
+      onAgentEvent: vi.fn(),
+      authProfileProvider: "claude-cli",
+      sessionStore,
+      storePath,
+      sessionHasHistory: false,
+    });
+
+    expectMockArgFields(runCliAgentMock, {
+      provider: "claude-cli",
+      disableTools: true,
+    });
+    expect(runEmbeddedAgentMock).not.toHaveBeenCalled();
+  });
+
   it("stamps CLI prompts with current timestamp context", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2024-06-05T15:30:00Z"));

--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -2261,6 +2261,7 @@ describe("CLI attempt execution", () => {
     expectMockArgFields(runCliAgentMock, {
       provider: "claude-cli",
       disableTools: true,
+      allowEmptyAssistantReplyAsSilent: true,
     });
     expect(runEmbeddedAgentMock).not.toHaveBeenCalled();
   });

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -74,6 +74,7 @@ import { buildAgentRuntimeAuthPlan } from "../runtime-plan/auth.js";
 import type { AgentMessage } from "../runtime/index.js";
 import { withLocalSessionPlacementTurnAdmission } from "../session-placement-admission.js";
 import { buildUsageWithNoCost } from "../stream-message-shared.js";
+import { isSubagentAnnounceCompletionHandoff } from "../subagent-announce-handoff.js";
 import {
   buildClaudeCliFallbackContextPrelude,
   claudeCliSessionTranscriptHasContent,
@@ -514,6 +515,14 @@ export function runAgentAttempt(params: {
           ? { id: sessionAuthProfileId, source: sessionAuthProfileSource }
           : undefined;
   const isRawModelRun = params.opts.modelRun === true || params.opts.promptMode === "none";
+  // A completion handoff relays frozen child output; letting it act with the
+  // requester's tools would turn child text into a new privileged instruction.
+  const disableTools =
+    params.opts.modelRun === true ||
+    isSubagentAnnounceCompletionHandoff({
+      inputProvenance: params.opts.inputProvenance,
+      internalEvents: params.opts.internalEvents,
+    });
   const claudeCliFallbackPrelude =
     !isRawModelRun &&
     params.isFallbackRetry &&
@@ -827,6 +836,7 @@ export function runAgentAttempt(params: {
             oneShotCliRun: params.opts.oneShotCliRun,
             userTurnTranscriptRecorder: params.userTurnTranscriptRecorder,
             suppressNextUserMessagePersistence: params.suppressPromptPersistenceOnRetry === true,
+            disableTools,
             ...(mutableCliSessionStore && !forkCliSessionOnResume
               ? {
                   onBeforeFreshCliSessionRetry: async (retry) => {
@@ -964,7 +974,7 @@ export function runAgentAttempt(params: {
     oneShotCliRun: params.opts.oneShotCliRun,
     modelRun: params.opts.modelRun,
     promptMode: params.opts.promptMode,
-    disableTools: params.opts.modelRun === true,
+    disableTools,
     onAgentEvent: params.onAgentEvent,
     deferTerminalLifecycle: params.deferTerminalLifecycle,
     suppressNextUserMessagePersistence: params.suppressPromptPersistenceOnRetry === true,

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -517,12 +517,11 @@ export function runAgentAttempt(params: {
   const isRawModelRun = params.opts.modelRun === true || params.opts.promptMode === "none";
   // A completion handoff relays frozen child output; letting it act with the
   // requester's tools would turn child text into a new privileged instruction.
-  const disableTools =
-    params.opts.modelRun === true ||
-    isSubagentAnnounceCompletionHandoff({
-      inputProvenance: params.opts.inputProvenance,
-      internalEvents: params.opts.internalEvents,
-    });
+  const isSubagentAnnounceHandoff = isSubagentAnnounceCompletionHandoff({
+    inputProvenance: params.opts.inputProvenance,
+    internalEvents: params.opts.internalEvents,
+  });
+  const disableTools = params.opts.modelRun === true || isSubagentAnnounceHandoff;
   const claudeCliFallbackPrelude =
     !isRawModelRun &&
     params.isFallbackRetry &&
@@ -837,6 +836,7 @@ export function runAgentAttempt(params: {
             userTurnTranscriptRecorder: params.userTurnTranscriptRecorder,
             suppressNextUserMessagePersistence: params.suppressPromptPersistenceOnRetry === true,
             disableTools,
+            allowEmptyAssistantReplyAsSilent: isSubagentAnnounceHandoff,
             ...(mutableCliSessionStore && !forkCliSessionOnResume
               ? {
                   onBeforeFreshCliSessionRetry: async (retry) => {
@@ -975,6 +975,7 @@ export function runAgentAttempt(params: {
     modelRun: params.opts.modelRun,
     promptMode: params.opts.promptMode,
     disableTools,
+    allowEmptyAssistantReplyAsSilent: isSubagentAnnounceHandoff,
     onAgentEvent: params.onAgentEvent,
     deferTerminalLifecycle: params.deferTerminalLifecycle,
     suppressNextUserMessagePersistence: params.suppressPromptPersistenceOnRetry === true,

--- a/src/agents/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-restart-recovery.test.ts
@@ -894,55 +894,25 @@ describe("main-session-restart-recovery", () => {
     expect(store["agent:main:main"]?.abortedLastRun).toBe(false);
   });
 
-  it("reconciles an interrupted announce run after same-process lifecycle rotation", async () => {
-    const sessionsDir = await makeSessionsDir();
-    const storePath = path.join(sessionsDir, "sessions.json");
-    const sessionKey = "agent:main:telegram:group:-100:topic:2";
-    await writeStore(sessionsDir, {
-      [sessionKey]: {
-        sessionId: "topic-2-session",
-        updatedAt: Date.now() - 10_000,
-        status: "running",
-        abortedLastRun: true,
-        restartRecoveryRuns: [
-          {
-            runId: "announce:v1:agent:main:subagent:child:run-1",
-            lifecycleGeneration: "generation-old",
-          },
-        ],
-      },
-    });
-    await writeTranscript(sessionsDir, "topic-2-session", [
-      { role: "user", content: "earlier human request" },
-      { role: "assistant", content: [{ type: "toolCall", id: "call-1", name: "exec" }] },
-      { role: "toolResult", content: "child completion" },
-    ]);
-
-    const result = await recoverRestartAbortedMainSessions({ stateDir: tmpDir });
-
-    expect(result).toEqual({ recovered: 0, failed: 0, skipped: 1 });
-    expect(callGateway).not.toHaveBeenCalled();
-    expect(loadSessionEntry({ sessionKey, storePath })).toMatchObject({
-      status: "killed",
-      abortedLastRun: false,
-    });
-    expect(readStore(storePath)[sessionKey]).not.toHaveProperty("restartRecoveryRuns");
-  });
-
-  it("reconciles an interrupted completion report after a full restart", async () => {
-    const sessionsDir = await makeSessionsDir();
-    const storePath = path.join(sessionsDir, "sessions.json");
-    const sessionKey = "agent:main:telegram:group:-100:topic:8893";
-    await writeStore(sessionsDir, {
-      [sessionKey]: {
-        sessionId: "topic-8893-session",
-        updatedAt: Date.now() - 10_000,
-        status: "running",
-        abortedLastRun: true,
-      },
-    });
-    await writeTranscript(sessionsDir, "topic-8893-session", [
-      {
+  it.each([
+    {
+      label: "same-process lifecycle rotation",
+      sessionKey: "agent:main:telegram:group:-100:topic:2",
+      sessionId: "topic-2-session",
+      restartRecoveryRuns: [
+        {
+          runId: "announce:v1:agent:main:subagent:child:run-1",
+          lifecycleGeneration: "generation-old",
+        },
+      ],
+      userMessage: { role: "user", content: "earlier human request" },
+    },
+    {
+      label: "full restart",
+      sessionKey: "agent:main:telegram:group:-100:topic:8893",
+      sessionId: "topic-8893-session",
+      restartRecoveryRuns: undefined,
+      userMessage: {
         role: "user",
         content: "A background task finished.",
         provenance: {
@@ -952,46 +922,39 @@ describe("main-session-restart-recovery", () => {
           sourceTool: "subagent_announce",
         },
       },
-      { role: "assistant", content: [{ type: "toolCall", id: "call-1", name: "exec" }] },
-      { role: "toolResult", content: "done" },
-    ]);
-
-    const result = await recoverRestartAbortedMainSessions({ stateDir: tmpDir });
-
-    expect(result).toEqual({ recovered: 0, failed: 0, skipped: 1 });
-    expect(callGateway).not.toHaveBeenCalled();
-    expect(loadSessionEntry({ sessionKey, storePath })).toMatchObject({
-      status: "killed",
-      abortedLastRun: false,
-    });
-  });
-
-  it("still resumes an interrupted human turn", async () => {
+    },
+  ])("reconciles an interrupted completion after $label", async (fixture) => {
     const sessionsDir = await makeSessionsDir();
-    const sessionKey = "agent:main:telegram:group:-100:topic:41817";
+    const storePath = path.join(sessionsDir, "sessions.json");
     await writeStore(sessionsDir, {
-      [sessionKey]: {
-        sessionId: "topic-41817-session",
+      [fixture.sessionKey]: {
+        sessionId: fixture.sessionId,
         updatedAt: Date.now() - 10_000,
         status: "running",
         abortedLastRun: true,
-        restartRecoveryRuns: [{ runId: "human-run-1", lifecycleGeneration: "generation-old" }],
+        restartRecoveryRuns: fixture.restartRecoveryRuns,
       },
     });
-    await writeTranscript(sessionsDir, "topic-41817-session", [
-      { role: "user", content: "real human request" },
+    await writeTranscript(sessionsDir, fixture.sessionId, [
+      fixture.userMessage,
       { role: "assistant", content: [{ type: "toolCall", id: "call-1", name: "exec" }] },
       { role: "toolResult", content: "done" },
     ]);
 
-    const result = await recoverRestartAbortedMainSessions({ stateDir: tmpDir });
-
-    expect(result).toEqual({ recovered: 1, failed: 0, skipped: 0 });
-    expect(callGateway).toHaveBeenCalledOnce();
-    expect(firstGatewayParams().sessionKey).toBe(sessionKey);
+    await expect(recoverRestartAbortedMainSessions({ stateDir: tmpDir })).resolves.toEqual({
+      recovered: 0,
+      failed: 0,
+      skipped: 1,
+    });
+    expect(callGateway).not.toHaveBeenCalled();
+    expect(loadSessionEntry({ sessionKey: fixture.sessionKey, storePath })).toMatchObject({
+      status: "killed",
+      abortedLastRun: false,
+    });
+    expect(readStore(storePath)[fixture.sessionKey]).not.toHaveProperty("restartRecoveryRuns");
   });
 
-  it("prefers an explicit human recovery run over stale completion provenance", async () => {
+  it("resumes an explicit human run despite stale completion provenance", async () => {
     const sessionsDir = await makeSessionsDir();
     const sessionKey = "agent:main:telegram:group:-100:topic:41818";
     await writeStore(sessionsDir, {

--- a/src/agents/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-restart-recovery.test.ts
@@ -894,6 +894,103 @@ describe("main-session-restart-recovery", () => {
     expect(store["agent:main:main"]?.abortedLastRun).toBe(false);
   });
 
+  it("reconciles an interrupted announce run after same-process lifecycle rotation", async () => {
+    const sessionsDir = await makeSessionsDir();
+    const storePath = path.join(sessionsDir, "sessions.json");
+    const sessionKey = "agent:main:telegram:group:-100:topic:2";
+    await writeStore(sessionsDir, {
+      [sessionKey]: {
+        sessionId: "topic-2-session",
+        updatedAt: Date.now() - 10_000,
+        status: "running",
+        abortedLastRun: true,
+        restartRecoveryRuns: [
+          {
+            runId: "announce:v1:agent:main:subagent:child:run-1",
+            lifecycleGeneration: "generation-old",
+          },
+        ],
+      },
+    });
+    await writeTranscript(sessionsDir, "topic-2-session", [
+      { role: "user", content: "earlier human request" },
+      { role: "assistant", content: [{ type: "toolCall", id: "call-1", name: "exec" }] },
+      { role: "toolResult", content: "child completion" },
+    ]);
+
+    const result = await recoverRestartAbortedMainSessions({ stateDir: tmpDir });
+
+    expect(result).toEqual({ recovered: 0, failed: 0, skipped: 1 });
+    expect(callGateway).not.toHaveBeenCalled();
+    expect(loadSessionEntry({ sessionKey, storePath })).toMatchObject({
+      status: "killed",
+      abortedLastRun: false,
+    });
+    expect(readStore(storePath)[sessionKey]).not.toHaveProperty("restartRecoveryRuns");
+  });
+
+  it("reconciles an interrupted completion report after a full restart", async () => {
+    const sessionsDir = await makeSessionsDir();
+    const storePath = path.join(sessionsDir, "sessions.json");
+    const sessionKey = "agent:main:telegram:group:-100:topic:8893";
+    await writeStore(sessionsDir, {
+      [sessionKey]: {
+        sessionId: "topic-8893-session",
+        updatedAt: Date.now() - 10_000,
+        status: "running",
+        abortedLastRun: true,
+      },
+    });
+    await writeTranscript(sessionsDir, "topic-8893-session", [
+      {
+        role: "user",
+        content: "A background task finished.",
+        provenance: {
+          kind: "inter_session",
+          sourceSessionKey: "agent:main:subagent:child",
+          sourceChannel: "internal",
+          sourceTool: "subagent_announce",
+        },
+      },
+      { role: "assistant", content: [{ type: "toolCall", id: "call-1", name: "exec" }] },
+      { role: "toolResult", content: "done" },
+    ]);
+
+    const result = await recoverRestartAbortedMainSessions({ stateDir: tmpDir });
+
+    expect(result).toEqual({ recovered: 0, failed: 0, skipped: 1 });
+    expect(callGateway).not.toHaveBeenCalled();
+    expect(loadSessionEntry({ sessionKey, storePath })).toMatchObject({
+      status: "killed",
+      abortedLastRun: false,
+    });
+  });
+
+  it("still resumes an interrupted human turn", async () => {
+    const sessionsDir = await makeSessionsDir();
+    const sessionKey = "agent:main:telegram:group:-100:topic:41817";
+    await writeStore(sessionsDir, {
+      [sessionKey]: {
+        sessionId: "topic-41817-session",
+        updatedAt: Date.now() - 10_000,
+        status: "running",
+        abortedLastRun: true,
+        restartRecoveryRuns: [{ runId: "human-run-1", lifecycleGeneration: "generation-old" }],
+      },
+    });
+    await writeTranscript(sessionsDir, "topic-41817-session", [
+      { role: "user", content: "real human request" },
+      { role: "assistant", content: [{ type: "toolCall", id: "call-1", name: "exec" }] },
+      { role: "toolResult", content: "done" },
+    ]);
+
+    const result = await recoverRestartAbortedMainSessions({ stateDir: tmpDir });
+
+    expect(result).toEqual({ recovered: 1, failed: 0, skipped: 0 });
+    expect(callGateway).toHaveBeenCalledOnce();
+    expect(firstGatewayParams().sessionKey).toBe(sessionKey);
+  });
+
   it("delivers resumed marked sessions through the current run recovery context", async () => {
     const sessionsDir = await makeSessionsDir();
     await writeStore(sessionsDir, {

--- a/src/agents/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-restart-recovery.test.ts
@@ -991,6 +991,40 @@ describe("main-session-restart-recovery", () => {
     expect(firstGatewayParams().sessionKey).toBe(sessionKey);
   });
 
+  it("prefers an explicit human recovery run over stale completion provenance", async () => {
+    const sessionsDir = await makeSessionsDir();
+    const sessionKey = "agent:main:telegram:group:-100:topic:41818";
+    await writeStore(sessionsDir, {
+      [sessionKey]: {
+        sessionId: "topic-41818-session",
+        updatedAt: Date.now() - 10_000,
+        status: "running",
+        abortedLastRun: true,
+        restartRecoveryRuns: [{ runId: "human-run-2", lifecycleGeneration: "generation-old" }],
+      },
+    });
+    await writeTranscript(sessionsDir, "topic-41818-session", [
+      {
+        role: "user",
+        content: "A background task finished.",
+        provenance: {
+          kind: "inter_session",
+          sourceSessionKey: "agent:main:subagent:child",
+          sourceChannel: "internal",
+          sourceTool: "subagent_announce",
+        },
+      },
+      { role: "assistant", content: [{ type: "toolCall", id: "call-1", name: "exec" }] },
+      { role: "toolResult", content: "done" },
+    ]);
+
+    const result = await recoverRestartAbortedMainSessions({ stateDir: tmpDir });
+
+    expect(result).toEqual({ recovered: 1, failed: 0, skipped: 0 });
+    expect(callGateway).toHaveBeenCalledOnce();
+    expect(firstGatewayParams().sessionKey).toBe(sessionKey);
+  });
+
   it("delivers resumed marked sessions through the current run recovery context", async () => {
     const sessionsDir = await makeSessionsDir();
     await writeStore(sessionsDir, {

--- a/src/agents/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-restart-recovery.test.ts
@@ -1025,6 +1025,67 @@ describe("main-session-restart-recovery", () => {
     expect(firstGatewayParams().sessionKey).toBe(sessionKey);
   });
 
+  it("retries when a human recovery run appears during announce reconciliation", async () => {
+    const sessionsDir = await makeSessionsDir();
+    const storePath = path.join(sessionsDir, "sessions.json");
+    const sessionKey = "agent:main:telegram:group:-100:topic:41819";
+    const announceRun = {
+      runId: "announce:v1:agent:main:subagent:child:run-race",
+      lifecycleGeneration: "generation-old",
+    };
+    const humanRun = { runId: "human-run-race", lifecycleGeneration: "generation-old" };
+    await writeStore(sessionsDir, {
+      [sessionKey]: {
+        sessionId: "topic-41819-session",
+        updatedAt: Date.now() - 10_000,
+        status: "running",
+        abortedLastRun: true,
+        restartRecoveryRuns: [announceRun],
+      },
+    });
+    await writeTranscript(sessionsDir, "topic-41819-session", [
+      { role: "user", content: "earlier human request" },
+      { role: "assistant", content: [{ type: "toolCall", id: "call-1", name: "exec" }] },
+      { role: "toolResult", content: "done" },
+    ]);
+    const updateSessionEntry = sessionAccessor.updateSessionEntry;
+    let injectedHumanRun = false;
+    const updateSpy = vi
+      .spyOn(sessionAccessor, "updateSessionEntry")
+      .mockImplementation(async (scope, update, options) => {
+        if (!injectedHumanRun) {
+          injectedHumanRun = true;
+          await updateSessionEntry(scope, (entry) => ({
+            restartRecoveryRuns: [...(entry.restartRecoveryRuns ?? []), humanRun],
+          }));
+        }
+        return await updateSessionEntry(scope, update, options);
+      });
+
+    try {
+      await expect(recoverRestartAbortedMainSessions({ stateDir: tmpDir })).resolves.toEqual({
+        recovered: 0,
+        failed: 1,
+        skipped: 0,
+      });
+    } finally {
+      updateSpy.mockRestore();
+    }
+
+    expect(callGateway).not.toHaveBeenCalled();
+    expect(loadSessionEntry({ sessionKey, storePath })).toMatchObject({
+      status: "running",
+      abortedLastRun: true,
+      restartRecoveryRuns: [announceRun, humanRun],
+    });
+    await expect(recoverRestartAbortedMainSessions({ stateDir: tmpDir })).resolves.toEqual({
+      recovered: 1,
+      failed: 0,
+      skipped: 0,
+    });
+    expect(callGateway).toHaveBeenCalledOnce();
+  });
+
   it("delivers resumed marked sessions through the current run recovery context", async () => {
     const sessionsDir = await makeSessionsDir();
     await writeStore(sessionsDir, {

--- a/src/agents/main-session-restart-recovery.ts
+++ b/src/agents/main-session-restart-recovery.ts
@@ -24,6 +24,7 @@ import {
   persistSessionTranscriptTurn,
   type SessionTranscriptTurnExpectedState,
   type SessionTranscriptTurnLifecyclePatch,
+  updateSessionEntry,
 } from "../config/sessions/session-accessor.js";
 import { appendAssistantMessageToSessionTranscript } from "../config/sessions/transcript.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -38,16 +39,22 @@ import { createSubsystemLogger } from "../logging/subsystem.js";
 import { runWithGatewayIndependentRootWorkAdmission } from "../process/gateway-work-admission.js";
 import { resolveAgentIdFromSessionKey } from "../routing/session-key.js";
 import {
+  hasInterSessionUserProvenance,
+  isCompletionReportInputProvenance,
+} from "../sessions/input-provenance.js";
+import {
   beginSessionWorkAdmission,
   cancelSessionWorkAdmissionHandoff,
 } from "../sessions/session-lifecycle-admission.js";
 import { buildRunUserTurnIdempotencyKey } from "../sessions/user-turn-transcript.js";
 import type { DeliveryContext } from "../utils/delivery-context.shared.js";
+import { isAnnounceRunId } from "./announce-idempotency.js";
 import { CODE_MODE_EXEC_TOOL_NAME, CODE_MODE_WAIT_TOOL_NAME } from "./code-mode-control-tools.js";
 import {
   listActiveEmbeddedRunSessionIds,
   listActiveEmbeddedRunSessionKeys,
 } from "./embedded-agent-runner/run-state.js";
+import { buildMainSessionRecoveryClearPatch } from "./main-session-recovery-clear.js";
 import {
   isMainRestartRecoveryCandidate,
   transitionMainSessionRecovery,
@@ -432,6 +439,59 @@ function getMessageRole(message: unknown): string | undefined {
   }
   const role = (message as { role?: unknown }).role;
   return typeof role === "string" ? role : undefined;
+}
+
+function hasOnlyAnnounceRecoveryRuns(entry: SessionEntry): boolean {
+  const runs = entry.restartRecoveryRuns;
+  return Boolean(runs?.length && runs.every((run) => isAnnounceRunId(run.runId)));
+}
+
+function hasCompletionReportUserTail(messages: readonly unknown[]): boolean {
+  const message = messages.findLast((candidate) => getMessageRole(candidate) === "user");
+  if (!message || typeof message !== "object") {
+    return false;
+  }
+  const userMessage = message as { role?: unknown; provenance?: unknown };
+  return (
+    hasInterSessionUserProvenance(userMessage) &&
+    isCompletionReportInputProvenance(userMessage.provenance)
+  );
+}
+
+async function reconcileInterruptedCompletionReport(params: {
+  entry: SessionEntry;
+  storePath: string;
+  sessionKey: string;
+}): Promise<boolean> {
+  const reconciled = await updateSessionEntry(
+    { sessionKey: params.sessionKey, storePath: params.storePath },
+    (entry) => {
+      if (
+        entry.sessionId !== params.entry.sessionId ||
+        entry.status !== "running" ||
+        entry.abortedLastRun !== true
+      ) {
+        return null;
+      }
+      const endedAt = Date.now();
+      return {
+        ...buildRestartRecoveryClaimCleanupPatch({ entry, recordTerminalSource: false }),
+        ...buildMainSessionRecoveryClearPatch(entry),
+        status: "killed",
+        abortedLastRun: false,
+        endedAt,
+        lastRunError: undefined,
+        runtimeMs:
+          typeof entry.startedAt === "number" ? Math.max(0, endedAt - entry.startedAt) : undefined,
+        updatedAt: endedAt,
+      };
+    },
+    { requireWriteSuccess: true },
+  );
+  if (reconciled) {
+    log.info(`reconciled interrupted completion report to non-running: ${params.sessionKey}`);
+  }
+  return Boolean(reconciled);
 }
 
 function findSourceTurnRange(params: {
@@ -1799,6 +1859,23 @@ async function recoverStore(params: {
         gatewayRuntime: params.gatewayRuntime,
       });
       recordResumeResult(resumed);
+      continue;
+    }
+
+    // Completion reports are delivery turns, not human work. Same-process
+    // rotation retains their announce run ids; a full restart can recover the
+    // same fact from the already-persisted user-message provenance.
+    if (hasOnlyAnnounceRecoveryRuns(entry) || hasCompletionReportUserTail(messages)) {
+      if (
+        await reconcileInterruptedCompletionReport({
+          entry,
+          storePath: params.storePath,
+          sessionKey,
+        })
+      ) {
+        params.resumedSessionKeys.add(resumeDedupeKey);
+      }
+      result.skipped++;
       continue;
     }
 

--- a/src/agents/main-session-restart-recovery.ts
+++ b/src/agents/main-session-restart-recovery.ts
@@ -460,19 +460,26 @@ function hasCompletionReportUserTail(messages: readonly unknown[]): boolean {
 
 async function reconcileInterruptedCompletionReport(params: {
   entry: SessionEntry;
+  source: "announce_runs" | "transcript";
   storePath: string;
   sessionKey: string;
-}): Promise<boolean> {
-  const reconciled = await updateSessionEntry(
+}): Promise<{ outcome: "reconciled" } | { outcome: "changed"; entry: SessionEntry | null }> {
+  let didReconcile = false;
+  const current = await updateSessionEntry(
     { sessionKey: params.sessionKey, storePath: params.storePath },
     (entry) => {
+      const hasRecoveryRuns = Boolean(entry.restartRecoveryRuns?.length);
+      const stillMatchesSource =
+        params.source === "announce_runs" ? hasOnlyAnnounceRecoveryRuns(entry) : !hasRecoveryRuns;
       if (
         entry.sessionId !== params.entry.sessionId ||
         entry.status !== "running" ||
-        entry.abortedLastRun !== true
+        entry.abortedLastRun !== true ||
+        !stillMatchesSource
       ) {
         return null;
       }
+      didReconcile = true;
       const endedAt = Date.now();
       return {
         ...buildRestartRecoveryClaimCleanupPatch({ entry, recordTerminalSource: false }),
@@ -488,10 +495,11 @@ async function reconcileInterruptedCompletionReport(params: {
     },
     { requireWriteSuccess: true },
   );
-  if (reconciled) {
+  if (didReconcile) {
     log.info(`reconciled interrupted completion report to non-running: ${params.sessionKey}`);
+    return { outcome: "reconciled" };
   }
-  return Boolean(reconciled);
+  return { outcome: "changed", entry: current };
 }
 
 function findSourceTurnRange(params: {
@@ -1866,20 +1874,29 @@ async function recoverStore(params: {
     // rotation retains their announce run ids; a full restart can recover the
     // same fact from the already-persisted user-message provenance.
     const hasRecoveryRuns = Boolean(entry.restartRecoveryRuns?.length);
-    if (
-      hasOnlyAnnounceRecoveryRuns(entry) ||
-      (!hasRecoveryRuns && hasCompletionReportUserTail(messages))
-    ) {
-      if (
-        await reconcileInterruptedCompletionReport({
-          entry,
-          storePath: params.storePath,
-          sessionKey,
-        })
-      ) {
+    const completionSource = hasOnlyAnnounceRecoveryRuns(entry)
+      ? "announce_runs"
+      : !hasRecoveryRuns && hasCompletionReportUserTail(messages)
+        ? "transcript"
+        : undefined;
+    if (completionSource) {
+      const reconciliation = await reconcileInterruptedCompletionReport({
+        entry,
+        source: completionSource,
+        storePath: params.storePath,
+        sessionKey,
+      });
+      if (reconciliation.outcome === "reconciled") {
         params.resumedSessionKeys.add(resumeDedupeKey);
+        result.skipped++;
+      } else if (
+        reconciliation.entry?.status === "running" &&
+        reconciliation.entry.abortedLastRun === true
+      ) {
+        result.failed++;
+      } else {
+        result.skipped++;
       }
-      result.skipped++;
       continue;
     }
 

--- a/src/agents/main-session-restart-recovery.ts
+++ b/src/agents/main-session-restart-recovery.ts
@@ -1865,7 +1865,11 @@ async function recoverStore(params: {
     // Completion reports are delivery turns, not human work. Same-process
     // rotation retains their announce run ids; a full restart can recover the
     // same fact from the already-persisted user-message provenance.
-    if (hasOnlyAnnounceRecoveryRuns(entry) || hasCompletionReportUserTail(messages)) {
+    const hasRecoveryRuns = Boolean(entry.restartRecoveryRuns?.length);
+    if (
+      hasOnlyAnnounceRecoveryRuns(entry) ||
+      (!hasRecoveryRuns && hasCompletionReportUserTail(messages))
+    ) {
       if (
         await reconcileInterruptedCompletionReport({
           entry,

--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -1381,6 +1381,41 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     );
   });
 
+  it("directly delivers direct-message subagent text when the announce agent replies NO_REPLY", async () => {
+    const callGateway = createGatewayMock({
+      result: {
+        payloads: [{ text: "NO_REPLY" }],
+      },
+    });
+    const sendMessage = createSendMessageMock();
+
+    const result = await deliverDiscordDirectMessageCompletion({
+      callGateway,
+      sendMessage,
+      internalEvents: [
+        {
+          type: "task_completion",
+          source: "subagent",
+          childSessionKey: "agent:worker:subagent:child",
+          announceType: "subagent task",
+          taskLabel: "direct completion smoke",
+          status: "ok",
+          statusLabel: "completed successfully",
+          result: "child completion output",
+          replyInstruction: "Summarize the result.",
+        },
+      ],
+    });
+
+    expectRecordFields(result, { delivered: true, path: "direct" });
+    expect(sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: "child completion output",
+        idempotencyKey: "announce-dm-fallback-empty:text-direct",
+      }),
+    );
+  });
+
   it("directly delivers direct-message subagent text when the announce agent omits the result", async () => {
     const callGateway = createGatewayMock({
       result: {

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -2053,8 +2053,7 @@ async function sendSubagentAnnounceDirectly(params: {
       shouldDeliverAgentFinal &&
       isSubagentCompletion &&
       !hasVisibleGatewayAgentPayload(directAnnounceResponse) &&
-      !hasGatewayAgentMessagingToolDeliveryEvidence(directAnnounceResponse) &&
-      !hasIntentionalSilentGatewayAgentPayload(directAnnounceResponse)
+      !hasGatewayAgentMessagingToolDeliveryEvidence(directAnnounceResponse)
     ) {
       const textDelivery = await deliverTextCompletionDirect({
         cfg,
@@ -2079,7 +2078,8 @@ async function sendSubagentAnnounceDirectly(params: {
       params.expectsCompletionMessage &&
       requiresMessageToolDelivery &&
       !hasGatewayAgentMessagingToolDeliveryEvidence(directAnnounceResponse) &&
-      !hasIntentionalSilentGatewayAgentPayload(directAnnounceResponse)
+      (!hasIntentionalSilentGatewayAgentPayload(directAnnounceResponse) ||
+        subagentDirectMessageCompletionRequiresMessageTool)
     ) {
       if (hasFailedSubagentNoOutputCompletion(params.internalEvents)) {
         return {

--- a/src/agents/subagent-announce-handoff.test.ts
+++ b/src/agents/subagent-announce-handoff.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { AGENT_INTERNAL_EVENT_TYPE_TASK_COMPLETION } from "./internal-event-contract.js";
+import type { AgentInternalEvent } from "./internal-events.js";
+import { isSubagentAnnounceCompletionHandoff } from "./subagent-announce-handoff.js";
+
+const announceProvenance = {
+  kind: "inter_session",
+  sourceSessionKey: "agent:openclaw:subagent:child",
+  sourceChannel: "internal",
+  sourceTool: "subagent_announce",
+} as const;
+
+const subagentCompletionEvent: AgentInternalEvent = {
+  type: AGENT_INTERNAL_EVENT_TYPE_TASK_COMPLETION,
+  source: "subagent",
+  childSessionKey: "agent:openclaw:subagent:child",
+  announceType: "subagent task",
+  taskLabel: "review",
+  status: "ok",
+  statusLabel: "completed",
+  result: "child finished",
+  replyInstruction: "Relay this completion.",
+};
+
+describe("isSubagentAnnounceCompletionHandoff", () => {
+  it("matches an inter-session subagent completion announce", () => {
+    expect(
+      isSubagentAnnounceCompletionHandoff({
+        inputProvenance: announceProvenance,
+        internalEvents: [subagentCompletionEvent],
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects human and non-completion inter-session turns", () => {
+    expect(isSubagentAnnounceCompletionHandoff({ internalEvents: [subagentCompletionEvent] })).toBe(
+      false,
+    );
+    expect(
+      isSubagentAnnounceCompletionHandoff({
+        inputProvenance: { ...announceProvenance, sourceTool: "sessions_send" },
+        internalEvents: [subagentCompletionEvent],
+      }),
+    ).toBe(false);
+    expect(
+      isSubagentAnnounceCompletionHandoff({
+        inputProvenance: announceProvenance,
+        internalEvents: [],
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/agents/subagent-announce-handoff.ts
+++ b/src/agents/subagent-announce-handoff.ts
@@ -1,0 +1,22 @@
+import type { InputProvenance } from "../sessions/input-provenance.js";
+import { AGENT_INTERNAL_EVENT_TYPE_TASK_COMPLETION } from "./internal-event-contract.js";
+import type { AgentInternalEvent } from "./internal-events.js";
+
+/** Identifies the delivery-only turn that hands a completed subagent result to its requester. */
+export function isSubagentAnnounceCompletionHandoff(params: {
+  inputProvenance?: InputProvenance;
+  internalEvents?: AgentInternalEvent[];
+}): boolean {
+  if (
+    params.inputProvenance?.kind !== "inter_session" ||
+    params.inputProvenance.sourceTool !== "subagent_announce"
+  ) {
+    return false;
+  }
+  return (
+    params.internalEvents?.some(
+      (event) =>
+        event.type === AGENT_INTERNAL_EVENT_TYPE_TASK_COMPLETION && event.source === "subagent",
+    ) === true
+  );
+}


### PR DESCRIPTION
Related: #97932

## What Problem This Solves

Fixes an issue where a gateway restart during a subagent completion announce could revive the parent topic as a human "previous turn interrupted" recovery task. That misclassified delivery turn could repeat work and cascade across Telegram topics.

## Why This Change Was Made

The fix keeps announce completion handoffs tool-free across CLI, embedded, and Codex runtimes, then recognizes interrupted completion turns from facts OpenClaw already has: `announce:*` recovery run ids during same-process lifecycle rotation and persisted inter-session completion provenance after a full restart. It intentionally adds no session schema field, lifecycle marker, migration, config, or prompt-persistence coupling.

This rebuild uses #97932 by @moeedahmed as prior art while replacing its persisted `announceLastRun` design with stateless transcript recovery.

## User Impact

Interrupted subagent completion delivery no longer becomes a new human recovery task after restart. Genuine interrupted human turns continue to resume normally, and completion text cannot invoke the parent session's tools while it is being handed off.

## Evidence

- Focused Vitest: the announce classifier/attempt/recovery/Codex command passed 3 shards and 251 tests; final recovery proof passed 132 tests; final announce delivery/CLI proof passed 197 tests.
- Changed gate on Blacksmith Testbox `tbx_01ky44faffff386hjjw3bjcw05`: core + extension production/test typechecks, full core + extension lint, formatting, import-cycle, database/state, dependency, Plugin SDK, and guard lanes passed. Run: https://github.com/openclaw/openclaw/actions/runs/29893656658
- Final recovery-only changed gate on Blacksmith Testbox `tbx_01ky473w7492rspxmpsdbttn40`: formatting, core production/test typechecks, changed-file lint, import cycles, database/state, dependency, and Plugin SDK guards passed. Run: https://github.com/openclaw/openclaw/actions/runs/29895903440
- Exact QA repro: `subagent-completion-direct-fallback` failed deterministically because a tool-free empty announce response entered empty-response retries; after the fix it passed on Testbox `tbx_01ky48mta1gyth24dfnbj15843`. Run: https://github.com/openclaw/openclaw/actions/runs/29897309519
- Final all-lanes changed gate on Testbox `tbx_01ky48vvr2cm64jh2yb2jkn6ke`: full TypeScript project build, core/extensions/scripts lint, formatting, import cycles, database/state, dependency, and Plugin SDK guards passed. Run: https://github.com/openclaw/openclaw/actions/runs/29897515122
- Codex autoreview (`gpt-5.6-sol`, xhigh): two accepted recovery-ownership findings and the QA blocker were fixed with regressions; final reviews clean with no accepted/actionable findings (0.95 recovery, 0.90 silent-fallback confidence).
- `git diff --check` — passed.
- `git diff --numstat origin/main...HEAD` — 12 files, +466/-6; no persisted session schema, lifecycle marker, slot-key, or migration surface.

AI-assisted: implementation and validation were performed with Codex under maintainer direction. I reviewed the full recovery/tool paths and the corresponding `codex-rs` app-server/runtime contracts.

Co-authored-by: Moeed Ahmed <moeedahmed@users.noreply.github.com>
