### PR TITLE
refactor: declare subagent spawn lineage explicitly so forks and dashboard chats stay spawn-capable

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -6330,6 +6330,7 @@ public struct SessionsCreateParams: Codable, Sendable {
     public let thinkinglevel: String?
     public let catalogid: String?
     public let parentsessionkey: String?
+    public let spawndepth: Int?
     public let fork: Bool?
     public let emitcommandhooks: Bool?
     public let succeedsparent: Bool?
@@ -6350,6 +6351,7 @@ public struct SessionsCreateParams: Codable, Sendable {
         thinkinglevel: String? = nil,
         catalogid: String? = nil,
         parentsessionkey: String? = nil,
+        spawndepth: Int? = nil,
         fork: Bool? = nil,
         emitcommandhooks: Bool? = nil,
         succeedsparent: Bool? = nil,
@@ -6369,6 +6371,7 @@ public struct SessionsCreateParams: Codable, Sendable {
         self.thinkinglevel = thinkinglevel
         self.catalogid = catalogid
         self.parentsessionkey = parentsessionkey
+        self.spawndepth = spawndepth
         self.fork = fork
         self.emitcommandhooks = emitcommandhooks
         self.succeedsparent = succeedsparent
@@ -6390,6 +6393,7 @@ public struct SessionsCreateParams: Codable, Sendable {
         case thinkinglevel = "thinkingLevel"
         case catalogid = "catalogId"
         case parentsessionkey = "parentSessionKey"
+        case spawndepth = "spawnDepth"
         case fork
         case emitcommandhooks = "emitCommandHooks"
         case succeedsparent = "succeedsParent"

--- a/packages/gateway-protocol/src/schema/sessions-create.ts
+++ b/packages/gateway-protocol/src/schema/sessions-create.ts
@@ -12,6 +12,13 @@ export const SessionsCreateParamsSchema = closedObject({
   thinkingLevel: Type.Optional(NonEmptyString),
   catalogId: Type.Optional(NonEmptyString),
   parentSessionKey: Type.Optional(NonEmptyString),
+  spawnDepth: Type.Optional(
+    Type.Integer({
+      minimum: 1,
+      description:
+        "Spawn-lineage depth for spawn-owned creations (visible subagent sessions); requires parentSessionKey. Omitted creations persist as root sessions (depth 0).",
+    }),
+  ),
   fork: Type.Optional(
     Type.Boolean({ description: "Fork the parent transcript; requires parentSessionKey." }),
   ),

--- a/src/agents/subagent-depth.test.ts
+++ b/src/agents/subagent-depth.test.ts
@@ -59,35 +59,23 @@ describe("getSubagentDepthFromSessionStore", () => {
     expect(depth).toBe(3);
   });
 
-  it("derives visible dashboard depth from parentSessionKey", () => {
-    const depth = getSubagentDepthFromSessionStore("agent:main:dashboard:child", {
-      store: {
-        "agent:main:main": { sessionId: "root" },
-        "agent:main:dashboard:child": {
-          sessionId: "child",
-          parentSessionKey: "agent:main:main",
-        },
+  it("ignores parentSessionKey threading when resolving spawn depth", () => {
+    // parentSessionKey is UI threading (dashboard auto-parenting, forks); only
+    // stored spawnDepth and spawnedBy lineage may contribute depth.
+    const store = {
+      "agent:main:main": { sessionId: "root" },
+      "agent:main:dashboard:operator": {
+        sessionId: "operator",
+        spawnDepth: 0,
+        parentSessionKey: "agent:main:main",
       },
-    });
-
-    expect(depth).toBe(1);
-  });
-
-  it("prefers stored spawnDepth 0 over parentSessionKey ancestry for operator dashboard sessions", () => {
-    // Operator-created dashboard sessions are auto-parented to main for UI
-    // threading; the explicit spawnDepth 0 keeps them spawn-capable roots.
-    const depth = getSubagentDepthFromSessionStore("agent:main:dashboard:operator", {
-      store: {
-        "agent:main:main": { sessionId: "root" },
-        "agent:main:dashboard:operator": {
-          sessionId: "operator",
-          spawnDepth: 0,
-          parentSessionKey: "agent:main:main",
-        },
+      "agent:main:dashboard:legacy": {
+        sessionId: "legacy",
+        parentSessionKey: "agent:main:main",
       },
-    });
-
-    expect(depth).toBe(0);
+    };
+    expect(getSubagentDepthFromSessionStore("agent:main:dashboard:operator", { store })).toBe(0);
+    expect(getSubagentDepthFromSessionStore("agent:main:dashboard:legacy", { store })).toBe(0);
   });
 
   it("resolves depth when caller is identified by sessionId", () => {
@@ -155,7 +143,7 @@ describe("getSubagentDepthFromSessionStore", () => {
         store: {
           "agent:work:dashboard:child": {
             sessionId: "child",
-            parentSessionKey: parentKey,
+            spawnedBy: parentKey,
           },
         },
       });

--- a/src/agents/subagent-depth.ts
+++ b/src/agents/subagent-depth.ts
@@ -15,7 +15,6 @@ type SessionDepthEntry = {
   sessionId?: unknown;
   spawnDepth?: unknown;
   spawnedBy?: unknown;
-  parentSessionKey?: unknown;
 };
 
 function normalizeSpawnDepth(value: unknown): number | undefined {
@@ -157,8 +156,14 @@ export function getSubagentDepthFromSessionStore(
       return storedDepth;
     }
 
-    const parentKey =
-      normalizeOptionalString(entry?.spawnedBy) ?? normalizeOptionalString(entry?.parentSessionKey);
+    // Only spawnedBy is spawn lineage. parentSessionKey is UI threading
+    // (dashboard auto-parenting, forks, checkpoints) and must never add depth;
+    // sessions.create persists explicit spawnDepth for every fresh entry.
+    // Accepted tradeoff: pre-upgrade visible children carried lineage only via
+    // parentSessionKey and now resolve as roots; that transient population may
+    // spawn one extra generation (still capped by maxChildrenPerAgent), which
+    // beats permanently misclassifying operator sessions as depth-1 leaves.
+    const parentKey = normalizeOptionalString(entry?.spawnedBy);
     if (!parentKey) {
       return undefined;
     }

--- a/src/agents/tools/sessions-spawn-tool.test.ts
+++ b/src/agents/tools/sessions-spawn-tool.test.ts
@@ -458,6 +458,7 @@ describe("sessions_spawn tool", () => {
         model: "anthropic/claude-sonnet-4-6",
         task: "inspect issue",
         parentSessionKey: "agent:main:main",
+        spawnDepth: 1,
         fork: true,
         cwd: dir,
         worktree: true,
@@ -527,6 +528,7 @@ describe("sessions_spawn tool", () => {
         agentId: "reviewer",
         model: "anthropic/claude-sonnet-4-6",
         parentSessionKey: "agent:main:main",
+        spawnDepth: 1,
       }),
     );
     expect(mockCallArg(callGateway, 0, 1, "sessions.create")).not.toHaveProperty("fork");
@@ -974,7 +976,9 @@ describe("sessions_spawn tool", () => {
       );
       await upsertSessionEntry(
         { agentId: "main", sessionKey: childKey, storePath },
-        { sessionId: "child", updatedAt: 1, parentSessionKey: "agent:main:main" },
+        // Canonical spawn-child shape: sessions.create persists explicit
+        // spawnDepth; parentSessionKey alone is UI threading and adds no depth.
+        { sessionId: "child", updatedAt: 1, spawnDepth: 1, parentSessionKey: "agent:main:main" },
       );
       const callGateway = vi.fn();
       const tool = createSessionsSpawnTool({

--- a/src/agents/tools/sessions-spawn-visible.ts
+++ b/src/agents/tools/sessions-spawn-visible.ts
@@ -285,6 +285,9 @@ export async function maybeSpawnVisibleSession(params: {
       model: resolvedModel,
       task: params.task,
       parentSessionKey: requesterKey,
+      // Declared spawn lineage: without it the child persists as a depth-0 root
+      // and could spawn past maxSpawnDepth.
+      spawnDepth: callerDepth + 1,
       ...(params.raw.context === "fork" ? { fork: true } : {}),
       ...(spawnedCwd ? { cwd: spawnedCwd } : {}),
       ...(worktree ? { worktree: true } : {}),

--- a/src/gateway/server-methods/sessions-create.ts
+++ b/src/gateway/server-methods/sessions-create.ts
@@ -335,6 +335,7 @@ export const sessionCreateHandlers: GatewayRequestHandlers = {
       thinkingLevel: p.thinkingLevel,
       allowExistingModelSelection,
       parentSessionKey: p.parentSessionKey,
+      spawnDepth: p.spawnDepth,
       spawnedCwd: sessionCwd,
       worktree: sessionWorktree
         ? {

--- a/src/gateway/server.sessions.create.test.ts
+++ b/src/gateway/server.sessions.create.test.ts
@@ -790,9 +790,9 @@ test("sessions.create preserves an explicit parent under main dmScope", async ()
 
   expect(created.ok, JSON.stringify(created.error)).toBe(true);
   expect(created.payload?.entry?.parentSessionKey).toBe("agent:main:explicit-parent");
-  // Explicit parents include visible spawn children, whose depth is derived by
-  // walking parentSessionKey; a stored root depth here would let them over-spawn.
-  expect(created.payload?.entry?.spawnDepth).toBeUndefined();
+  // Operator creations with a parent (UI forks/threads) are still roots: only a
+  // declared spawnDepth marks spawn lineage.
+  expect(created.payload?.entry?.spawnDepth).toBe(0);
 
   const reused = await directSessionReq<{
     entry?: { parentSessionKey?: string };
@@ -803,6 +803,42 @@ test("sessions.create preserves an explicit parent under main dmScope", async ()
 
   expect(reused.ok, JSON.stringify(reused.error)).toBe(true);
   expect(reused.payload?.entry?.parentSessionKey).toBe("agent:main:explicit-parent");
+});
+
+test("sessions.create persists declared spawn lineage for spawn-owned creations", async () => {
+  await createSessionStoreDir();
+  testState.sessionConfig = { dmScope: "main" };
+  await writeSessionStore({
+    entries: {
+      "agent:main:main": sessionStoreEntry("sess-spawn-parent"),
+    },
+  });
+
+  const created = await directSessionReq<{
+    entry?: { parentSessionKey?: string; spawnDepth?: number };
+  }>("sessions.create", {
+    agentId: "main",
+    parentSessionKey: "agent:main:main",
+    spawnDepth: 2,
+  });
+
+  expect(created.ok, JSON.stringify(created.error)).toBe(true);
+  expect(created.payload?.entry?.parentSessionKey).toBe("agent:main:main");
+  expect(created.payload?.entry?.spawnDepth).toBe(2);
+});
+
+test("sessions.create rejects spawnDepth without parentSessionKey", async () => {
+  await createSessionStoreDir();
+
+  const created = await directSessionReq("sessions.create", {
+    agentId: "main",
+    spawnDepth: 1,
+  });
+
+  expect(created.ok).toBe(false);
+  expect(created.error).toMatchObject({
+    message: "spawnDepth requires parentSessionKey",
+  });
 });
 
 test("sessions.create leaves dashboard sessions unparented under per-channel-peer dmScope", async () => {

--- a/src/gateway/session-create-service.ts
+++ b/src/gateway/session-create-service.ts
@@ -261,6 +261,12 @@ export async function createGatewaySession(params: {
   /** Trusted catalog-owned model/runtime pair, persisted and locked together. */
   catalogTarget?: TrustedCatalogSessionTarget;
   parentSessionKey?: string;
+  /**
+   * Spawn-lineage depth declared by spawn-owned creations (visible subagent
+   * sessions). Requires parentSessionKey. Omitted creations persist depth 0 so
+   * operator sessions and forks stay spawn-capable roots.
+   */
+  spawnDepth?: number;
   spawnedCwd?: string;
   /** Managed worktree bound to the new session; persisted alongside spawnedCwd. */
   worktree?: { id: string; branch: string; repoRoot: string };
@@ -410,6 +416,20 @@ export async function createGatewaySession(params: {
       ok: false,
       error: errorShape(ErrorCodes.INVALID_REQUEST, "fork requires parentSessionKey"),
     };
+  }
+  if (params.spawnDepth !== undefined) {
+    if (!Number.isInteger(params.spawnDepth) || params.spawnDepth < 1) {
+      return {
+        ok: false,
+        error: errorShape(ErrorCodes.INVALID_REQUEST, "spawnDepth must be an integer >= 1"),
+      };
+    }
+    if (!parentSessionKey) {
+      return {
+        ok: false,
+        error: errorShape(ErrorCodes.INVALID_REQUEST, "spawnDepth requires parentSessionKey"),
+      };
+    }
   }
   const targetSessionKey = explicitTargetKey ?? buildDashboardSessionKey(agentId);
   const agentMainSessionKey = resolveAgentMainSessionKey({ cfg: params.cfg, agentId });
@@ -787,6 +807,11 @@ export async function createGatewaySession(params: {
           ...(params.initialEntry?.pluginExtensions !== undefined
             ? { pluginExtensions: structuredClone(params.initialEntry.pluginExtensions) }
             : {}),
+          // Spawn lineage is declared, never inferred: spawn-owned creations pass
+          // spawnDepth explicitly; everything else (operator chats, forks, harness
+          // and plugin sessions) persists as a depth-0 root. Reused entries keep
+          // their stored depth.
+          ...(existingEntry === undefined ? { spawnDepth: params.spawnDepth ?? 0 } : {}),
         };
         sessionEntries[target.canonicalKey] = initializedEntry;
         const initialized = { ...patched, entry: initializedEntry };
@@ -804,13 +829,6 @@ export async function createGatewaySession(params: {
           ...initializedEntry,
           ...inheritedSelection,
           parentSessionKey: storedParentSessionKey,
-          // Auto-parenting to main is dashboard threading, not spawn lineage. Depth
-          // recovery walks parentSessionKey for visible spawn children, so record
-          // depth 0 explicitly or operator sessions classify as depth-1 subagents
-          // and lose spawn rights (maxSpawnDepth admission).
-          ...(!explicitParentSessionKey && initializedEntry.spawnDepth === undefined
-            ? { spawnDepth: 0 }
-            : {}),
         };
         if (params.fork !== true) {
           return { ...initialized, entry };


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #112527. Two related problems remained after that targeted fix:

1. Operator UI forks ("fork from here") carry an explicit `parentSessionKey`, so subagent depth recovery still classified them as depth-1 children — a forked chat could not spawn subagents (including swarm collectors) at the default `maxSpawnDepth` of 1.
2. Spawn depth was inferred by walking `parentSessionKey`, a field that means UI threading in every other context (dashboard auto-parenting, forks, checkpoints). That heuristic is what made #110913 break the web dashboard in the first place, and it left forks and spawn children indistinguishable at the store level.

## Why This Change Was Made

Spawn lineage becomes a declared fact instead of an inference. `sessions.create` gains an additive optional `spawnDepth` param (integer >= 1, requires `parentSessionKey`) that spawn-owned creations pass — the visible spawn tool declares `callerDepth + 1`. Every other fresh session persists an explicit `spawnDepth: 0`, so operator chats, UI forks, harness and plugin sessions are all spawn-capable roots by construction. With every fresh entry carrying explicit depth, the `parentSessionKey` fallback in `getSubagentDepthFromSessionStore` is deleted; only `spawnedBy` ancestry remains as legacy lineage. The internal caller (sessions_spawn visible path) migrates in the same change.

Accepted tradeoff (per maintainer decision to not migrate old sessions, documented inline at the walker): pre-upgrade visible spawn children whose only lineage was `parentSessionKey` now resolve as roots, so that transient population can spawn one extra generation until those sessions end; `maxChildrenPerAgent` still bounds concurrent children. The alternative — keeping the fallback — would permanently misclassify existing operator sessions as depth-1 leaves, which is the user-facing bug this series fixes.

Trust note: `sessions.create` is an operator-scoped gateway method; agents reach it only through the sessions_spawn tool, which enforces depth admission before calling it, so the new param does not let a leaf agent bypass depth limits.

## User Impact

Forked chats regain subagent spawn rights (swarm works from a forked dashboard session). Spawn-depth enforcement for new spawn children is now based on explicit persisted state rather than a heuristic that misfired on UI threading.

## Evidence

- Focused suites on Blacksmith Testbox (lease `tbx_01ky453qj59ke06hy9dn7ks3qj`): `subagent-depth`, `server.sessions.create`, `sessions-spawn-tool`, `subagent-spawn.depth-limits`, `spawn-plan.admission` — 171 tests passed across 3 shards, exit 0.
- `check:changed` (lanes core, coreTests) on the same lease: exit 0, deprecated-API / native-schema / database-first guards passed.
- New tests: declared `spawnDepth` persists; `spawnDepth` without `parentSessionKey` rejected; explicit-parent operator creations persist depth 0; `parentSessionKey` threading adds no depth (stored-depth and legacy shapes); visible-child depth-limit test updated to the canonical explicit-depth shape.
- Codex autoreview (`gpt-5.6-sol`, xhigh): one P1 raised — pre-upgrade visible children losing depth inference — consciously rejected as the explicitly deprioritized old-session class, with the tradeoff documented inline and above.
