### PR TITLE
docs(wizard): attribute OpenClaw to the OpenClaw Foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg?style=for-the-badge" alt="MIT License"></a>
 </p>
 
-**OpenClaw** is a _personal AI assistant_ you run on your own devices.
+**OpenClaw** is a _personal AI assistant_ that learns and grows with you, running on your own devices — developed in the open by the OpenClaw Foundation (a non-profit).
 It answers you on the channels you already use. It can speak and listen on macOS/iOS/Android, and can render a live Canvas you control. The Gateway is just the control plane — the product is the assistant.
 
 If you want a personal, single-user assistant that feels local, fast, and always-on, this is it.

--- a/src/wizard/i18n/locales/en.ts
+++ b/src/wizard/i18n/locales/en.ts
@@ -425,6 +425,8 @@ export const en = {
     security: {
       askForHelp:
         "Ask someone experienced to help before enabling tools or exposing it to the internet.",
+      attribution:
+        "OpenClaw is an open-source assistant that learns and grows with you, by the OpenClaw Foundation (a non-profit).",
       baselineDmSessions:
         "Shared inboxes: isolate DM sessions (session.dmScope: per-channel-peer) and keep tool access minimal.",
       baselinePairing: "Pairing/allowlists + mention gating.",
@@ -434,7 +436,6 @@ export const en = {
         "Multi-user/shared inbox: split trust boundaries (separate gateway/credentials, ideally separate OS users/hosts).",
       baselineStrongModel:
         "Use the strongest available model for any bot with tools or untrusted inboxes.",
-      beta: "OpenClaw is a hobby project and still in beta. Expect sharp edges.",
       confirm:
         "I understand this is personal-by-default and shared/multi-user use requires lock-down. Continue?",
       hardeningRequired:

--- a/src/wizard/i18n/locales/zh-CN.ts
+++ b/src/wizard/i18n/locales/zh-CN.ts
@@ -417,6 +417,8 @@ export const zh_CN = {
     },
     security: {
       askForHelp: "启用工具或暴露到互联网之前，请找有经验的人协助。",
+      attribution:
+        "OpenClaw 是由 OpenClaw 基金会（非营利组织）开发的开源助手，会与你一同学习成长。",
       baselineDmSessions:
         "共享收件箱：隔离 DM 会话（session.dmScope: per-channel-peer），并尽量减少工具访问权限。",
       baselinePairing: "配对/允许列表 + @ 提及门控。",
@@ -425,7 +427,6 @@ export const zh_CN = {
       baselineSharedInbox:
         "多用户/共享收件箱：拆分信任边界（分离 gateway/凭据，最好使用独立 OS 用户/主机）。",
       baselineStrongModel: "对启用工具或面对不可信收件箱的 bot，使用可用的最强模型。",
-      beta: "OpenClaw 是一个爱好项目，仍处于 beta 阶段。请预期会有边缘问题。",
       confirm: "我理解 OpenClaw 默认面向个人使用；共享/多用户使用需要加固。继续？",
       hardeningRequired: "如果你不熟悉安全加固和访问控制，请不要运行 OpenClaw。",
       learnMore: "了解更多",

--- a/src/wizard/i18n/locales/zh-TW.ts
+++ b/src/wizard/i18n/locales/zh-TW.ts
@@ -417,6 +417,8 @@ export const zh_TW = {
     },
     security: {
       askForHelp: "啟用工具或暴露到網際網路之前，請找有經驗的人協助。",
+      attribution:
+        "OpenClaw 是由 OpenClaw 基金會（非營利組織）開發的開源助手，會與你一同學習成長。",
       baselineDmSessions:
         "共享收件箱：隔離 DM 工作階段（session.dmScope: per-channel-peer），並盡量減少工具存取權限。",
       baselinePairing: "配對/允許清單 + @ 提及門控。",
@@ -425,7 +427,6 @@ export const zh_TW = {
       baselineSharedInbox:
         "多使用者/共享收件箱：拆分信任邊界（分離 gateway/憑證，最好使用獨立 OS 使用者/主機）。",
       baselineStrongModel: "對啟用工具或面對不可信收件箱的 bot，使用可用的最強模型。",
-      beta: "OpenClaw 是一個興趣專案，仍處於 beta 階段。請預期會有邊緣問題。",
       confirm: "我理解 OpenClaw 預設面向個人使用；共享/多使用者使用需要加固。繼續？",
       hardeningRequired: "如果你不熟悉安全加固和存取控制，請不要執行 OpenClaw。",
       learnMore: "了解更多",

--- a/src/wizard/setup.security-note.ts
+++ b/src/wizard/setup.security-note.ts
@@ -15,7 +15,7 @@ export function getSecurityConfirmMessage(): string {
 
 export function getSecurityNoteMessage(): string {
   return [
-    t("wizard.security.beta"),
+    t("wizard.security.attribution"),
     t("wizard.security.personalAgent"),
     t("wizard.security.toolAccess"),
     t("wizard.security.promptRisk"),


### PR DESCRIPTION
## What Problem This Solves

The onboarding security disclaimer opened with "OpenClaw is a hobby project and still in beta. Expect sharp edges." Both halves are now wrong and needlessly scary:

- OpenClaw is developed by the OpenClaw Foundation, a non-profit — already the copyright holder in `LICENSE` ("Copyright (c) 2026 OpenClaw Foundation"), but nowhere in user-facing copy.
- The project is no longer in beta.

This is the first thing every new user reads during `openclaw onboard`, so it sets the tone for the whole product.

## Why This Change Was Made

Maintainer feedback: "hobby project" undersells where the project is, and the disclaimer should carry the Foundation attribution in friendlier language.

The i18n key was literally named `wizard.security.beta`, so leaving it in place while removing the beta claim would have left the key lying about its contents. It is renamed to `wizard.security.attribution` along with its single consumer in `src/wizard/setup.security-note.ts`. This is internal wizard copy, not a public contract, so the old key is deleted rather than aliased.

The rest of the disclaimer — the personal-agent trust boundary, prompt-injection warning, and multi-tenant guidance — is deliberately untouched. Only the opening line changed.

## User Impact

The onboarding security disclaimer's first line changes from:

> OpenClaw is a hobby project and still in beta. Expect sharp edges.

to:

> OpenClaw is an open-source assistant that learns and grows with you, by the OpenClaw Foundation (a non-profit).

Translations updated for `zh-CN` and `zh-TW`. The README intro gains the same attribution plus "that learns and grows with you". No behavior, config, or API surface changes.

## Evidence

- `node scripts/check-changed.mjs` (delegated Blacksmith Testbox, lanes `core, coreTests, docs`): `exitCode: 0, runStatus: "succeeded"` — https://github.com/openclaw/openclaw/actions/runs/29894110577
- Autoreview (Codex `gpt-5.6-sol`, xhigh): clean, no accepted/actionable findings; TruffleHog clean.
- Verified no remaining "hobby project" / "still in beta" product claim: the surviving `beta` mentions in README are the release-channel docs (`--channel stable|beta|dev`), which are unrelated.
- Attribution cross-checked against `LICENSE`.
