### PR TITLE
fix(memory-wiki): stop doctor errors for keyed agents

### DIFF
--- a/extensions/memory-wiki/index.test.ts
+++ b/extensions/memory-wiki/index.test.ts
@@ -109,10 +109,10 @@ describe("memory-wiki plugin", () => {
     });
   });
 
-  it("resolves every tool factory from the invocation agent", async () => {
+  it("resolves every tool factory from keyed agent entries", async () => {
     const rootDir = await createTempDir("memory-wiki-index-agents-");
     const appConfig = {
-      agents: { list: [{ id: "support", default: true }, { id: "marketing" }] },
+      agents: { entries: { support: { default: true }, marketing: {} } },
     } as OpenClawConfig;
     const { api, registerTool } = createPluginApi();
     api.config = appConfig;

--- a/extensions/memory-wiki/src/config.ts
+++ b/extensions/memory-wiki/src/config.ts
@@ -296,9 +296,11 @@ export function resolveMemoryWikiConfig(
 export function resolveMemoryWikiConfiguredAgentIds(
   appConfig: OpenClawConfig | undefined,
 ): string[] {
-  const configured = appConfig?.agents?.list ?? [];
-  const ids = configured.flatMap((entry) => {
-    const rawId = entry?.id?.trim();
+  const configuredIds = appConfig?.agents?.entries
+    ? Object.keys(appConfig.agents.entries)
+    : (appConfig?.agents?.list ?? []).map((entry) => entry.id);
+  const ids = configuredIds.flatMap((entryId) => {
+    const rawId = entryId.trim();
     if (!rawId) {
       return [];
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators using an agent-scoped Memory Wiki vault with canonical keyed `agents.entries` would see repeated `Unknown memory-wiki agentId` plugin-tool errors on stderr during `openclaw doctor --lint --severity-min warning --json`, even though the JSON findings and direct wiki commands were otherwise healthy.

## Why This Change Was Made

Memory Wiki now enumerates canonical keyed agent entries before falling back to the validated runtime's internal `agents.list` projection. The fix stays in the plugin-owned vault resolver rather than suppressing errors in doctor or the generic plugin-tool loader, so genuine unknown-agent validation remains intact.

## User Impact

Doctor lint no longer emits spurious Memory Wiki tool-factory errors for valid configured agents. Agent-scoped `openclaw wiki --agent <id>` commands continue to resolve the correct vault, and unknown agent IDs are still rejected.

## Evidence

- Focused regression: `pnpm test extensions/memory-wiki/index.test.ts` — 1 file, 4 tests passed on Blacksmith Testbox.
- Changed-scope validation: targeted `pnpm format:check` plus `pnpm check:changed -- extensions/memory-wiki/src/config.ts extensions/memory-wiki/index.test.ts` — formatting, extension production/test typechecks, lint, plugin boundaries, and import cycles passed.
- Black-box CLI validation with an isolated four-agent keyed config:
  - `openclaw doctor --lint --severity-min warning --json` returned valid JSON and emitted zero `plugin tool failed (memory-wiki)` errors on stderr.
  - Known-agent `wiki status --json` and `wiki doctor --json` both exited 0; doctor reported `healthy: true` with zero warnings.
  - Unknown-agent `wiki status --json` exited 1 with `Unknown memory-wiki agentId`.
- Codex autoreview (`gpt-5.6-sol`, high reasoning): clean, no accepted/actionable findings.

AI-assisted change; implementation and proof were reviewed before submission.
