### PR TITLE
fix(onboard): remove stale password when switching remote auth

### DIFF
--- a/src/commands/onboard-non-interactive/remote.test.ts
+++ b/src/commands/onboard-non-interactive/remote.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { createThrowingRuntime } from "../onboard-non-interactive.test-helpers.js";
+
+const commitNonInteractiveOnboardConfigMock = vi.hoisted(() =>
+  vi.fn(async (_params: { nextConfig: OpenClawConfig }) => undefined),
+);
+
+vi.mock("./config-write.js", () => ({
+  commitNonInteractiveOnboardConfig: commitNonInteractiveOnboardConfigMock,
+}));
+vi.mock("../../config/logging.js", () => ({ logConfigUpdated: vi.fn() }));
+
+const { runNonInteractiveRemoteSetup } = await import("./remote.js");
+
+describe("runNonInteractiveRemoteSetup", () => {
+  const runtime = createThrowingRuntime();
+  const remoteUrl = "wss://gateway.example.test";
+
+  beforeEach(() => {
+    commitNonInteractiveOnboardConfigMock.mockClear();
+  });
+
+  it("clears a stale password when a token replaces auth for the same endpoint", async () => {
+    await runNonInteractiveRemoteSetup({
+      opts: {
+        nonInteractive: true,
+        mode: "remote",
+        remoteUrl,
+        remoteToken: "replacement-token",
+        skipHooks: true,
+      },
+      runtime,
+      baseConfig: {
+        gateway: {
+          mode: "remote",
+          remote: {
+            url: remoteUrl,
+            password: "old-password",
+            tlsFingerprint: "sha256:test-fingerprint",
+          },
+        },
+      },
+    });
+
+    const commit = commitNonInteractiveOnboardConfigMock.mock.calls[0]?.[0];
+    expect(commit?.nextConfig.gateway?.remote).toEqual({
+      url: remoteUrl,
+      token: "replacement-token",
+      tlsFingerprint: "sha256:test-fingerprint",
+    });
+  });
+
+  it("preserves existing auth when no replacement token is provided", async () => {
+    const remote = {
+      url: remoteUrl,
+      token: "existing-token",
+      password: "existing-password",
+    };
+
+    await runNonInteractiveRemoteSetup({
+      opts: { nonInteractive: true, mode: "remote", remoteUrl, skipHooks: true },
+      runtime,
+      baseConfig: { gateway: { mode: "remote", remote } },
+    });
+
+    const commit = commitNonInteractiveOnboardConfigMock.mock.calls[0]?.[0];
+    expect(commit?.nextConfig.gateway?.remote).toEqual(remote);
+  });
+});

--- a/src/commands/onboard-non-interactive/remote.test.ts
+++ b/src/commands/onboard-non-interactive/remote.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { createThrowingRuntime } from "../onboard-non-interactive.test-helpers.js";
+import type { RuntimeEnv } from "../../runtime.js";
 
 const commitNonInteractiveOnboardConfigMock = vi.hoisted(() =>
   vi.fn(async (_params: { nextConfig: OpenClawConfig }) => undefined),
@@ -14,7 +14,13 @@ vi.mock("../../config/logging.js", () => ({ logConfigUpdated: vi.fn() }));
 const { runNonInteractiveRemoteSetup } = await import("./remote.js");
 
 describe("runNonInteractiveRemoteSetup", () => {
-  const runtime = createThrowingRuntime();
+  const runtime: RuntimeEnv = {
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: (code) => {
+      throw new Error(`unexpected exit ${code}`);
+    },
+  };
   const remoteUrl = "wss://gateway.example.test";
 
   beforeEach(() => {

--- a/src/commands/onboard-non-interactive/remote.ts
+++ b/src/commands/onboard-non-interactive/remote.ts
@@ -45,7 +45,10 @@ export async function runNonInteractiveRemoteSetup(params: {
   const remoteUrlChanged = normalizeOptionalString(existingRemote?.url) !== remoteUrl;
   // A remote block belongs to one endpoint. Reusing it for a different URL can
   // send old credentials or keep routing through the old SSH target.
-  const preservedRemote = remoteUrlChanged ? {} : existingRemote;
+  const preservedRemote = remoteUrlChanged ? {} : { ...existingRemote };
+  if (remoteToken) {
+    delete preservedRemote.password;
+  }
 
   let nextConfig: OpenClawConfig = {
     ...baseConfig,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users rerunning non-interactive remote onboarding with `--remote-token` for the same Gateway URL would retain the previously configured remote password. The resulting config contained both authentication methods even though token auth was selected.

## Why This Change Was Made

When an explicit replacement token is supplied, onboarding now removes the stale alternate password while preserving unrelated settings that still belong to the same endpoint, such as its TLS fingerprint. Reruns without a replacement token continue to preserve existing remote authentication unchanged.

## User Impact

Operators can switch an existing remote Gateway from password auth to token auth without leaving obsolete secret material in `openclaw.json`.

## Evidence

- Hosted current-main reproduction before the fix persisted remote keys `password`, `token`, and `url` after a same-endpoint password-to-token switch.
- The same user-path probe after the fix persisted only `token` and `url`.
- Blacksmith Testbox `tbx_01ky466hvnex55yhsx082psvq8`: `pnpm test src/commands/onboard-non-interactive/remote.test.ts src/commands/onboard-non-interactive.gateway.test.ts` passed 19/19 tests.
- Blacksmith Testbox `tbx_01ky466hvnex55yhsx082psvq8`: `pnpm check:changed` passed formatting, core and test typechecks, lint, database/storage guards, and import-cycle checks.
- Codex autoreview (`gpt-5.6-sol`, xhigh) reported no accepted or actionable findings.

AI-assisted: yes. The implementation and evidence were reviewed before submission.
