### PR TITLE
refactor(media): persistence and template boundaries ride media facts

### DIFF
--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -41,6 +41,7 @@ import { logVerbose } from "../../globals.js";
 import { measureDiagnosticsTimelineSpan } from "../../infra/diagnostics-timeline.js";
 import { resolveHeartbeatRunScope } from "../../infra/heartbeat-run-scope.js";
 import type { ExtractedFileImage } from "../../media-understanding/extracted-file-images.js";
+import { resolveMediaFacts } from "../../media/media-facts.js";
 import { clearCommandLane, getQueueSize } from "../../process/command-queue.js";
 import {
   isAcpSessionKey,
@@ -49,7 +50,6 @@ import {
 } from "../../routing/session-key.js";
 import { MEDIA_ONLY_USER_TEXT } from "../../sessions/user-turn-media.js";
 import {
-  buildPersistedUserTurnMediaInputsFromFields,
   createUserTurnTranscriptRecorder,
   resolvePersistedUserTurnText,
 } from "../../sessions/user-turn-transcript.js";
@@ -1461,7 +1461,7 @@ export async function runPreparedReply(
       : undefined);
   setChannelSourceTurnId(sessionCtx, sourceTurnId);
   const persistGroupSender = replyRoute.chatType === "group" || replyRoute.chatType === "channel";
-  const userTurnMediaForPersistence = buildPersistedUserTurnMediaInputsFromFields(ctx);
+  const userTurnMediaForPersistence = resolveMediaFacts(ctx);
   const inputProvenance = ctx.InputProvenance ?? sessionCtx.InputProvenance;
   const userTurnTimestamp = normalizeMessageTimestampMs(ctx.Timestamp);
   // prompt-prelude substitutes MEDIA_ONLY_USER_TEXT as transcriptBody for

--- a/src/config/legacy.shared.test.ts
+++ b/src/config/legacy.shared.test.ts
@@ -1,6 +1,20 @@
 // Covers shared legacy config rule detection helpers.
 import { afterEach, describe, expect, it } from "vitest";
-import { mergeMissing } from "./legacy.shared.js";
+import { mapLegacyAudioTranscription, mergeMissing } from "./legacy.shared.js";
+
+describe("legacy audio transcription migration", () => {
+  it("migrates deprecated input placeholders to the documented singular media path", () => {
+    expect(
+      mapLegacyAudioTranscription({
+        command: ["whisper", "--file", "{input}", "--label={input}"],
+      }),
+    ).toEqual({
+      type: "cli",
+      command: "whisper",
+      args: ["--file", "{{MediaPath}}", "--label={{MediaPath}}"],
+    });
+  });
+});
 
 describe("mergeMissing prototype pollution guard", () => {
   afterEach(() => {

--- a/src/media-understanding/attachments.normalize.test.ts
+++ b/src/media-understanding/attachments.normalize.test.ts
@@ -28,6 +28,18 @@ describe("normalizeAttachmentPath", () => {
 });
 
 describe("normalizeAttachments", () => {
+  it("preserves original fact indexes when empty slots are not materializable", () => {
+    expect(
+      normalizeAttachments({
+        media: [
+          {},
+          { path: "/tmp/voice.ogg", contentType: "audio/ogg" },
+          { url: "https://example.test/photo.jpg", contentType: "image/jpeg" },
+        ],
+      }).map((attachment) => attachment.index),
+    ).toEqual([1, 2]);
+  });
+
   it("prefers ordered facts over conflicting legacy projections", () => {
     expect(
       normalizeAttachments({

--- a/src/media-understanding/runner.cli-audio.test.ts
+++ b/src/media-understanding/runner.cli-audio.test.ts
@@ -4,9 +4,12 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.js";
+import { withTempDir } from "../test-helpers/temp-dir.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import { CLI_OUTPUT_MAX_BUFFER } from "./defaults.constants.js";
-import { withAudioFixture } from "./runner.test-utils.js";
+import { createMediaAttachmentCache, normalizeMediaAttachments } from "./runner.attachments.js";
+import { createSafeAudioFixtureBuffer, withAudioFixture } from "./runner.test-utils.js";
+import type { MediaAttachment } from "./types.js";
 
 const runExecMock = vi.hoisted(() => vi.fn());
 
@@ -83,18 +86,26 @@ function requireFirstRunExecCall(): unknown[] {
   return call;
 }
 
+function requireFirstAttachment(media: MediaAttachment[]): MediaAttachment {
+  const attachment = media[0];
+  if (!attachment) {
+    throw new Error("expected media attachment");
+  }
+  return attachment;
+}
+
 async function runAudioEntry(params: {
   command: string;
   args: string[];
 }): Promise<Awaited<ReturnType<typeof runCliEntry>>> {
   let result: Awaited<ReturnType<typeof runCliEntry>> = null;
-  await withAudioFixture(`openclaw-cli-${params.command}`, async ({ ctx, cache }) => {
+  await withAudioFixture(`openclaw-cli-${params.command}`, async ({ ctx, media, cache }) => {
     result = await runCliEntry({
       capability: "audio",
       entry: { type: "cli", command: params.command, args: params.args },
       cfg: { tools: { media: { audio: {} } } } as OpenClawConfig,
       ctx,
-      attachmentIndex: 0,
+      attachment: requireFirstAttachment(media),
       cache,
       config: {} as never,
     });
@@ -118,7 +129,7 @@ describe("media-understanding CLI audio entry", () => {
   it("applies per-request prompt and language overrides to CLI transcription templating", async () => {
     let mediaPath = "";
 
-    await withAudioFixture("openclaw-cli-audio", async ({ ctx, cache }) => {
+    await withAudioFixture("openclaw-cli-audio", async ({ ctx, media, cache }) => {
       mediaPath = await fs.realpath(ctx.MediaPath);
 
       await runCliEntry({
@@ -143,7 +154,7 @@ describe("media-understanding CLI audio entry", () => {
           },
         } as OpenClawConfig,
         ctx,
-        attachmentIndex: 0,
+        attachment: requireFirstAttachment(media),
         cache,
         config: {
           prompt: "configured prompt",
@@ -161,6 +172,77 @@ describe("media-understanding CLI audio entry", () => {
     expect(options).toEqual({
       timeoutMs: 60_000,
       maxBuffer: CLI_OUTPUT_MAX_BUFFER,
+    });
+  });
+
+  it.each([
+    { name: "one attachment", count: 1, leadingEmpty: false },
+    { name: "many attachments after an empty slot", count: 2, leadingEmpty: true },
+  ])("projects singular template variables for $name", async ({ count, leadingEmpty }) => {
+    await withTempDir({ prefix: "openclaw-cli-media-template-" }, async (base) => {
+      const media = await Promise.all(
+        Array.from({ length: count }, async (_, index) => {
+          const mediaPath = path.join(base, `audio-${index}.wav`);
+          await fs.writeFile(mediaPath, createSafeAudioFixtureBuffer());
+          return {
+            path: mediaPath,
+            url: `media://inbound/audio-${index}.wav`,
+            contentType: index === 0 ? "audio/wav" : "audio/x-wav",
+          };
+        }),
+      );
+      const alignedMedia: Array<Partial<(typeof media)[number]>> = leadingEmpty
+        ? [{}, ...media]
+        : media;
+      const ctx = {
+        media: alignedMedia,
+        MediaPath: "/tmp/stale-first.wav",
+        MediaUrl: "media://inbound/stale-first.wav",
+        MediaType: "application/octet-stream",
+        MediaPaths: alignedMedia.map((entry) => entry.path ?? ""),
+        MediaUrls: alignedMedia.map((entry) => entry.url ?? ""),
+        MediaTypes: alignedMedia.map((entry) => entry.contentType ?? ""),
+      };
+      const attachments = normalizeMediaAttachments(ctx);
+      expect(attachments.map((attachment) => attachment.index)).toEqual(
+        leadingEmpty ? [1, 2] : [0],
+      );
+      const cache = createMediaAttachmentCache(attachments, {
+        localPathRoots: [base],
+        includeDefaultLocalPathRoots: false,
+      });
+      try {
+        for (const [callIndex, attachment] of attachments.entries()) {
+          await runCliEntry({
+            capability: "audio",
+            entry: {
+              type: "cli",
+              command: "mock-transcriber",
+              args: [
+                "{{MediaPath}}",
+                "{{MediaUrl}}",
+                "{{MediaType}}",
+                "{{MediaDir}}",
+                "{{MediaPaths}}",
+              ],
+            },
+            cfg: { tools: { media: { audio: {} } } } as OpenClawConfig,
+            ctx,
+            attachment,
+            cache,
+            config: {} as never,
+          });
+          expect(runExecMock.mock.calls[callIndex]?.[1]).toEqual([
+            media[callIndex]?.path,
+            media[callIndex]?.url,
+            media[callIndex]?.contentType,
+            base,
+            "",
+          ]);
+        }
+      } finally {
+        await cache.cleanup();
+      }
     });
   });
 
@@ -287,7 +369,7 @@ describe("media-understanding CLI audio entry", () => {
       stderr: "",
     });
 
-    await withAudioFixture("openclaw-cli-audio-empty-sherpa", async ({ ctx, cache }) => {
+    await withAudioFixture("openclaw-cli-audio-empty-sherpa", async ({ ctx, media, cache }) => {
       const result = await runCliEntry({
         capability: "audio",
         entry: {
@@ -297,7 +379,7 @@ describe("media-understanding CLI audio entry", () => {
         },
         cfg: { tools: { media: { audio: {} } } } as OpenClawConfig,
         ctx,
-        attachmentIndex: 0,
+        attachment: requireFirstAttachment(media),
         cache,
         config: {} as never,
       });
@@ -312,7 +394,7 @@ describe("media-understanding CLI audio entry", () => {
       stderr: "",
     });
 
-    await withAudioFixture("openclaw-cli-audio-sherpa-json", async ({ ctx, cache }) => {
+    await withAudioFixture("openclaw-cli-audio-sherpa-json", async ({ ctx, media, cache }) => {
       const result = await runCliEntry({
         capability: "audio",
         entry: {
@@ -322,7 +404,7 @@ describe("media-understanding CLI audio entry", () => {
         },
         cfg: { tools: { media: { audio: {} } } } as OpenClawConfig,
         ctx,
-        attachmentIndex: 0,
+        attachment: requireFirstAttachment(media),
         cache,
         config: {} as never,
       });

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -66,6 +66,7 @@ import { normalizeMediaExecutionProviderId } from "./provider-id.js";
 import { getMediaUnderstandingProvider, normalizeMediaProviderId } from "./provider-registry.js";
 import { resolveMaxBytes, resolveMaxChars, resolvePrompt, resolveTimeoutMs } from "./resolve.js";
 import type {
+  MediaAttachment,
   MediaUnderstandingCapability,
   MediaUnderstandingDecision,
   MediaUnderstandingModelDecision,
@@ -1011,11 +1012,12 @@ export async function runCliEntry(params: {
   entry: MediaUnderstandingModelConfig;
   cfg: OpenClawConfig;
   ctx: MsgContext;
-  attachmentIndex: number;
+  attachment: MediaAttachment;
   cache: MediaAttachmentCache;
   config?: MediaUnderstandingConfig;
 }): Promise<MediaUnderstandingOutput | null> {
   const { entry, capability, cfg, ctx } = params;
+  const attachmentIndex = params.attachment.index;
   const command = entry.command?.trim();
   const args = entry.args ?? [];
   if (!command) {
@@ -1029,13 +1031,13 @@ export async function runCliEntry(params: {
     config: params.config,
   });
   const pathResult = await params.cache.getPath({
-    attachmentIndex: params.attachmentIndex,
+    attachmentIndex,
     maxBytes,
     timeoutMs,
   });
   if (capability === "audio") {
     const stat = await fs.stat(pathResult.path);
-    assertMinAudioSize({ size: stat.size, attachmentIndex: params.attachmentIndex });
+    assertMinAudioSize({ size: stat.size, attachmentIndex });
   }
   const outputDir = await fs.mkdtemp(
     path.join(resolvePreferredOpenClawTmpDir(), "openclaw-media-cli-"),
@@ -1051,7 +1053,15 @@ export async function runCliEntry(params: {
   const templCtx: MsgContext = {
     ...ctx,
     MediaPath: mediaPath,
+    MediaUrl: params.attachment.url ?? params.attachment.path ?? mediaPath,
+    MediaType: params.attachment.mime,
     MediaDir: path.dirname(mediaPath),
+    MediaPaths: undefined,
+    MediaUrls: undefined,
+    MediaTypes: undefined,
+    MediaWorkspaceDir: undefined,
+    MediaTranscribedIndexes: undefined,
+    MediaStaged: undefined,
     OutputDir: outputDir,
     OutputBase: outputBase,
     Prompt: requestOverrides.prompt ?? prompt,
@@ -1101,7 +1111,7 @@ export async function runCliEntry(params: {
     }
     return {
       kind: capability === "audio" ? "audio.transcription" : `${capability}.description`,
-      attachmentIndex: params.attachmentIndex,
+      attachmentIndex,
       text,
       provider: capability === "audio" ? commandBase(command) : "cli",
       model: command,

--- a/src/media-understanding/runner.ts
+++ b/src/media-understanding/runner.ts
@@ -893,7 +893,7 @@ async function runAttachmentEntries(params: {
   capability: MediaUnderstandingCapability;
   cfg: OpenClawConfig;
   ctx: MsgContext;
-  attachmentIndex: number;
+  attachment: MediaAttachment;
   agentId?: string;
   agentDir?: string;
   workspaceDir?: string;
@@ -906,6 +906,7 @@ async function runAttachmentEntries(params: {
   attempts: MediaUnderstandingModelDecision[];
 }> {
   const { entries, capability } = params;
+  const attachmentIndex = params.attachment.index;
   const attempts: MediaUnderstandingModelDecision[] = [];
   for (const candidate of entries) {
     const { entry } = candidate;
@@ -918,7 +919,7 @@ async function runAttachmentEntries(params: {
               entry,
               cfg: params.cfg,
               ctx: params.ctx,
-              attachmentIndex: params.attachmentIndex,
+              attachment: params.attachment,
               cache: params.cache,
               config: params.config,
             })
@@ -927,7 +928,7 @@ async function runAttachmentEntries(params: {
               entry,
               cfg: params.cfg,
               ctx: params.ctx,
-              attachmentIndex: params.attachmentIndex,
+              attachmentIndex,
               cache: params.cache,
               agentId: params.agentId,
               agentDir: params.agentDir,
@@ -1130,7 +1131,7 @@ export async function runCapability(params: {
       capability,
       cfg,
       ctx,
-      attachmentIndex: attachment.index,
+      attachment,
       agentId: params.agentId,
       agentDir: params.agentDir,
       workspaceDir: params.workspaceDir,

--- a/src/sessions/user-turn-transcript.media.test.ts
+++ b/src/sessions/user-turn-transcript.media.test.ts
@@ -1,0 +1,178 @@
+// User-turn media persistence tests cover fact normalization and legacy row projection.
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  buildPersistedUserTurnMediaInputsFromFields,
+  buildPersistedUserTurnMessage,
+} from "./user-turn-transcript.js";
+
+describe("buildPersistedUserTurnMediaInputsFromFields", () => {
+  it("builds media facts from persisted parallel fields", () => {
+    expect(
+      buildPersistedUserTurnMediaInputsFromFields({
+        MediaPath: "/tmp/a.png",
+        MediaPaths: ["/tmp/a.png", "/tmp/b.jpg"],
+        MediaType: "image/png",
+        MediaTypes: ["image/png", "image/jpeg"],
+      }),
+    ).toEqual([
+      { path: "/tmp/a.png", contentType: "image/png" },
+      { path: "/tmp/b.jpg", contentType: "image/jpeg" },
+    ]);
+  });
+
+  it("uses url-backed media fields when no local path is present", () => {
+    expect(
+      buildPersistedUserTurnMediaInputsFromFields({
+        MediaUrl: "media://inbound/a.png",
+        MediaType: "image/png",
+      }),
+    ).toEqual([{ url: "media://inbound/a.png", contentType: "image/png" }]);
+  });
+
+  it("infers transcript media type from media path when explicit type is absent", () => {
+    expect(
+      buildPersistedUserTurnMediaInputsFromFields({
+        MediaPaths: ["/tmp/a.png", "https://example.test/report.pdf"],
+      }),
+    ).toEqual([
+      { path: "/tmp/a.png", contentType: "image/png" },
+      { path: "https://example.test/report.pdf", contentType: "application/pdf" },
+    ]);
+  });
+
+  it("does not reuse singular media type for later media paths", () => {
+    expect(
+      buildPersistedUserTurnMediaInputsFromFields({
+        MediaPath: "/tmp/a.png",
+        MediaPaths: ["/tmp/a.png", "/tmp/report.pdf"],
+        MediaType: "image/png",
+      }),
+    ).toEqual([
+      { path: "/tmp/a.png", contentType: "image/png" },
+      { path: "/tmp/report.pdf", contentType: "application/pdf" },
+    ]);
+  });
+
+  it("resolves staged legacy paths against the media workspace", () => {
+    const workspaceDir = "/tmp/openclaw-user-turn-workspace";
+    expect(
+      buildPersistedUserTurnMediaInputsFromFields({
+        MediaPaths: ["media/inbound/a.png", "media/inbound/b.jpg"],
+        MediaTypes: ["image/png", "image/jpeg"],
+        MediaWorkspaceDir: workspaceDir,
+      }),
+    ).toEqual([
+      { path: path.join(workspaceDir, "media/inbound/a.png"), contentType: "image/png" },
+      { path: path.join(workspaceDir, "media/inbound/b.jpg"), contentType: "image/jpeg" },
+    ]);
+  });
+
+  it("does not rewrite absolute or URL-like media paths", () => {
+    const workspaceDir = "/tmp/openclaw-user-turn-workspace";
+    const absolutePath = path.join(workspaceDir, "media/inbound/a.png");
+    expect(
+      buildPersistedUserTurnMediaInputsFromFields({
+        MediaPaths: [absolutePath, "media://inbound/b.jpg", "https://example.test/c.png"],
+        MediaTypes: ["image/png", "image/jpeg", "image/png"],
+        MediaWorkspaceDir: workspaceDir,
+      }),
+    ).toEqual([
+      { path: absolutePath, contentType: "image/png" },
+      { path: "media://inbound/b.jpg", contentType: "image/jpeg" },
+      { path: "https://example.test/c.png", contentType: "image/png" },
+    ]);
+  });
+
+  it("does not infer media from absent structured fields", () => {
+    expect(buildPersistedUserTurnMediaInputsFromFields(undefined)).toEqual([]);
+    expect(buildPersistedUserTurnMediaInputsFromFields({})).toEqual([]);
+    expect(buildPersistedUserTurnMediaInputsFromFields({ MediaTypes: ["image/png"] })).toEqual([]);
+  });
+
+  it("preserves aligned content-type holes while normalizing the row", () => {
+    const result = buildPersistedUserTurnMediaInputsFromFields({
+      MediaPaths: ["/media/a.bin", "/media/b.png"],
+      MediaTypes: ["", "image/png"],
+    });
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject({ path: "/media/a.bin" });
+    expect(result[0]?.contentType).not.toBe("image/png");
+    expect(result[1]).toEqual({ path: "/media/b.png", contentType: "image/png" });
+  });
+
+  it("preserves aligned path and URL holes while normalizing the row", () => {
+    expect(
+      buildPersistedUserTurnMediaInputsFromFields({
+        MediaPaths: ["/media/local.bin", ""],
+        MediaUrls: ["", "https://example.test/remote.png"],
+        MediaTypes: ["application/octet-stream", "image/png"],
+      }),
+    ).toEqual([
+      { path: "/media/local.bin", contentType: "application/octet-stream" },
+      { url: "https://example.test/remote.png", contentType: "image/png" },
+    ]);
+  });
+
+  it("keeps empty attachment slots aligned for a later writer", () => {
+    expect(
+      buildPersistedUserTurnMediaInputsFromFields({
+        MediaPaths: ["", "/media/b.png"],
+        MediaTypes: ["", "image/png"],
+      }),
+    ).toEqual([{}, { path: "/media/b.png", contentType: "image/png" }]);
+  });
+});
+
+describe("buildPersistedUserTurnMessage media projection", () => {
+  it.each([
+    {
+      name: "one attachment",
+      media: [{ path: "/tmp/a.png", contentType: "image/png" }],
+      expected: {
+        role: "user",
+        content: "inspect",
+        timestamp: 123,
+        MediaPath: "/tmp/a.png",
+        MediaPaths: ["/tmp/a.png"],
+        MediaType: "image/png",
+        MediaTypes: ["image/png"],
+      },
+    },
+    {
+      name: "many attachments",
+      media: [
+        { path: " /tmp/a.png ", contentType: " image/png " },
+        { url: " https://example.test/report.pdf ", contentType: " application/pdf " },
+      ],
+      expected: {
+        role: "user",
+        content: "inspect",
+        timestamp: 123,
+        MediaPath: "/tmp/a.png",
+        MediaPaths: ["/tmp/a.png", "https://example.test/report.pdf"],
+        MediaType: "image/png",
+        MediaTypes: ["image/png", "application/pdf"],
+      },
+    },
+  ])("keeps $name row bytes stable", ({ media, expected }) => {
+    const message = buildPersistedUserTurnMessage({ text: "inspect", timestamp: 123, media });
+    expect(message).toEqual(expected);
+    expect(JSON.stringify(message)).toBe(JSON.stringify(expected));
+  });
+
+  it("uses the aligned storage projection when an earlier fact has no path", () => {
+    const message = buildPersistedUserTurnMessage({
+      text: "inspect",
+      timestamp: 123,
+      media: [{ kind: "image" }, { path: "/tmp/b.png", contentType: "image/png" }],
+    });
+    expect(message).toEqual({
+      role: "user",
+      content: "inspect",
+      timestamp: 123,
+      MediaPaths: ["", "/tmp/b.png"],
+      MediaTypes: ["", "image/png"],
+    });
+  });
+});

--- a/src/sessions/user-turn-transcript.persistence.test.ts
+++ b/src/sessions/user-turn-transcript.persistence.test.ts
@@ -96,21 +96,55 @@ describe("persistUserTurnTranscript", () => {
       updateMode: "none",
     });
 
-    expect(appended?.message).toMatchObject({
+    const expected = {
       role: "user",
       content: "What is in this image?",
+      timestamp: 123,
       MediaPath: "/tmp/image.png",
+      MediaPaths: ["/tmp/image.png"],
+      MediaType: "image/png",
+      MediaTypes: ["image/png"],
+      __openclaw: { senderIsOwner: true },
+      provenance,
+    };
+    expect(appended?.message).toEqual(expected);
+    expect(JSON.stringify(appended?.message)).toBe(JSON.stringify(expected));
+    const messages = await readTranscriptMessages(target);
+    expect(messages).toEqual([expected]);
+    expect(JSON.stringify(messages[0])).toBe(JSON.stringify(expected));
+  });
+
+  it("round-trips a multi-attachment SQLite row byte-identically", async () => {
+    const dir = createTempDir("openclaw-user-turn-append-media-");
+    const target = createSqliteTranscriptTarget({ dir });
+    const expected = {
+      role: "user",
+      content: "Inspect both",
+      timestamp: 456,
+      MediaPath: "/tmp/image.png",
+      MediaPaths: ["/tmp/image.png", "https://example.test/report.pdf"],
+      MediaType: "image/png",
+      MediaTypes: ["image/png", "application/pdf"],
+    };
+
+    const appended = await persistUserTurnTranscript({
+      ...target,
+      input: {
+        text: "Inspect both",
+        timestamp: 456,
+        media: [
+          { path: "/tmp/image.png", contentType: "image/png" },
+          { url: "https://example.test/report.pdf", contentType: "application/pdf" },
+        ],
+      },
+      updateMode: "none",
     });
-    await expect(readTranscriptMessages(target)).resolves.toEqual([
-      expect.objectContaining({
-        role: "user",
-        content: "What is in this image?",
-        MediaPath: "/tmp/image.png",
-        __openclaw: { senderIsOwner: true },
-        provenance,
-        MediaType: "image/png",
-      }),
-    ]);
+
+    expect(appended?.message).toEqual(expected);
+    expect(JSON.stringify(appended?.message)).toBe(JSON.stringify(expected));
+    const messages = await readTranscriptMessages(target);
+    expect(messages).toEqual([expected]);
+    expect(JSON.stringify(messages[0])).toBe(JSON.stringify(expected));
   });
 
   it("persists sender metadata as __openclaw envelope", async () => {

--- a/src/sessions/user-turn-transcript.test.ts
+++ b/src/sessions/user-turn-transcript.test.ts
@@ -7,7 +7,6 @@ import { afterEach, describe, expect, it } from "vitest";
 import { loadTranscriptEvents } from "../config/sessions/session-accessor.js";
 import { formatSqliteSessionFileMarker } from "../config/sessions/sqlite-marker.js";
 import {
-  buildPersistedUserTurnMediaInputsFromFields,
   createUserTurnTranscriptRecorder,
   mergePreparedUserTurnMessageForRuntime,
   resolvePersistedUserTurnText,
@@ -81,129 +80,6 @@ describe("user turn transcript persistence", () => {
           typeof message === "object" && message !== null,
       );
   }
-
-  describe("buildPersistedUserTurnMediaInputsFromFields", () => {
-    it("builds media inputs from structured context media fields", () => {
-      expect(
-        buildPersistedUserTurnMediaInputsFromFields({
-          MediaPath: "/tmp/a.png",
-          MediaPaths: ["/tmp/a.png", "/tmp/b.jpg"],
-          MediaType: "image/png",
-          MediaTypes: ["image/png", "image/jpeg"],
-        }),
-      ).toEqual([
-        { path: "/tmp/a.png", contentType: "image/png" },
-        { path: "/tmp/b.jpg", contentType: "image/jpeg" },
-      ]);
-    });
-
-    it("uses url-backed media fields when no local path is present", () => {
-      expect(
-        buildPersistedUserTurnMediaInputsFromFields({
-          MediaUrl: "media://inbound/a.png",
-          MediaType: "image/png",
-        }),
-      ).toEqual([{ url: "media://inbound/a.png", contentType: "image/png" }]);
-    });
-
-    it("infers transcript media type from media path when explicit type is absent", () => {
-      expect(
-        buildPersistedUserTurnMediaInputsFromFields({
-          MediaPaths: ["/tmp/a.png", "https://example.test/report.pdf"],
-        }),
-      ).toEqual([
-        { path: "/tmp/a.png", contentType: "image/png" },
-        { path: "https://example.test/report.pdf", contentType: "application/pdf" },
-      ]);
-    });
-
-    it("does not reuse singular media type for later media paths", () => {
-      expect(
-        buildPersistedUserTurnMediaInputsFromFields({
-          MediaPath: "/tmp/a.png",
-          MediaPaths: ["/tmp/a.png", "/tmp/report.pdf"],
-          MediaType: "image/png",
-        }),
-      ).toEqual([
-        { path: "/tmp/a.png", contentType: "image/png" },
-        { path: "/tmp/report.pdf", contentType: "application/pdf" },
-      ]);
-    });
-
-    it("resolves staged relative media paths against the media workspace", () => {
-      const workspaceDir = createTempDir("openclaw-user-turn-media-");
-
-      expect(
-        buildPersistedUserTurnMediaInputsFromFields({
-          MediaPath: "media/inbound/a.png",
-          MediaPaths: ["media/inbound/a.png", "media/inbound/b.jpg"],
-          MediaType: "image/png",
-          MediaTypes: ["image/png", "image/jpeg"],
-          MediaWorkspaceDir: workspaceDir,
-        }),
-      ).toEqual([
-        { path: path.join(workspaceDir, "media/inbound/a.png"), contentType: "image/png" },
-        { path: path.join(workspaceDir, "media/inbound/b.jpg"), contentType: "image/jpeg" },
-      ]);
-    });
-
-    it("does not rewrite absolute or URL-like media paths", () => {
-      const workspaceDir = createTempDir("openclaw-user-turn-media-");
-      const absolutePath = path.join(workspaceDir, "media/inbound/a.png");
-
-      expect(
-        buildPersistedUserTurnMediaInputsFromFields({
-          MediaPaths: [absolutePath, "media://inbound/b.jpg", "https://example.test/c.png"],
-          MediaTypes: ["image/png", "image/jpeg", "image/png"],
-          MediaWorkspaceDir: workspaceDir,
-        }),
-      ).toEqual([
-        { path: absolutePath, contentType: "image/png" },
-        { path: "media://inbound/b.jpg", contentType: "image/jpeg" },
-        { path: "https://example.test/c.png", contentType: "image/png" },
-      ]);
-    });
-
-    it("does not infer media from absent structured fields", () => {
-      expect(buildPersistedUserTurnMediaInputsFromFields(undefined)).toEqual([]);
-      expect(buildPersistedUserTurnMediaInputsFromFields({})).toEqual([]);
-    });
-
-    it("preserves index alignment when an earlier attachment lacks a content type", () => {
-      // Writer pads missing types with "" to keep MediaPaths/MediaTypes index-aligned.
-      // The reader must NOT compact those "" holes away before indexing or a later
-      // attachment's type lands on the wrong attachment.
-      const result = buildPersistedUserTurnMediaInputsFromFields({
-        MediaPaths: ["/media/a.bin", "/media/b.png"],
-        MediaTypes: ["", "image/png"],
-      });
-      expect(result).toHaveLength(2);
-      const [first, second] = result;
-      // a.bin has no explicit type in the "" hole. Its contentType must NOT be
-      // "image/png" — that belongs to b.png at index 1.
-      expect(first).toMatchObject({ path: "/media/a.bin" });
-      expect(first?.contentType).not.toBe("image/png");
-      // b.png at index 1 must keep its own type correctly aligned.
-      expect(second).toEqual({ path: "/media/b.png", contentType: "image/png" });
-    });
-
-    it("preserves index alignment when an earlier attachment lacks a url", () => {
-      // Same misalignment risk for MediaUrls: a "" hole for a path-only attachment
-      // must not shift a later attachment's URL to the wrong index.
-      expect(
-        buildPersistedUserTurnMediaInputsFromFields({
-          MediaPaths: ["/media/local.bin", ""],
-          MediaUrls: ["", "https://example.test/remote.png"],
-          MediaTypes: ["application/octet-stream", "image/png"],
-        }),
-      ).toEqual([
-        // local.bin has a path but no url (the "" was a placeholder, not a real url).
-        { path: "/media/local.bin", contentType: "application/octet-stream" },
-        // remote.png has no path (the "" was a placeholder) but does have a url.
-        { url: "https://example.test/remote.png", contentType: "image/png" },
-      ]);
-    });
-  });
 
   describe("mergePreparedUserTurnMessageForRuntime", () => {
     it("adds prepared transcript metadata to runtime user messages", () => {

--- a/src/sessions/user-turn-transcript.ts
+++ b/src/sessions/user-turn-transcript.ts
@@ -6,6 +6,7 @@ import {
   persistSessionTranscriptTurn,
   type SessionTranscriptTurnPersistOptions,
 } from "../config/sessions/session-accessor.js";
+import { projectMediaFacts, resolveMediaFacts, type MediaFactInput } from "../media/media-facts.js";
 import { applyInputProvenanceToUserMessage, normalizeInputProvenance } from "./input-provenance.js";
 import type {
   CreateUserTurnTranscriptRecorderParams,
@@ -66,38 +67,24 @@ export function resolvePersistedUserTurnText(value: string | null | undefined): 
   return normalized;
 }
 
-function mediaTypeForTranscript(media: PersistedUserTurnMediaInput): string {
+function mediaTypeForTranscript(media: PersistedUserTurnMediaInput, mediaPath?: string): string {
   return (
     normalizeOptionalText(media.contentType) ??
     normalizeOptionalText(media.kind) ??
+    mimeTypeFromFilePath(mediaPath) ??
     "application/octet-stream"
   );
 }
 
-function normalizeMediaEntryForTranscript(media: PersistedUserTurnMediaInput):
-  | {
-      path: string;
-      type: string;
-    }
-  | undefined {
-  const pathLocal = normalizeOptionalText(media.path) ?? normalizeOptionalText(media.url);
-  if (!pathLocal) {
-    return undefined;
+function normalizeMediaEntryForTranscript(media: PersistedUserTurnMediaInput): MediaFactInput {
+  const rawPath = normalizeOptionalText(media.path) ?? normalizeOptionalText(media.url);
+  if (!rawPath) {
+    return {};
   }
   return {
-    path: pathLocal,
-    type: mediaTypeForTranscript(media),
+    path: resolveTranscriptMediaPath(rawPath, normalizeOptionalText(media.workspaceDir)),
+    contentType: mediaTypeForTranscript(media, rawPath),
   };
-}
-
-function normalizeOptionalTextArray(
-  values: readonly (string | null | undefined)[] | null | undefined,
-): (string | undefined)[] {
-  // Map each entry to a normalized string or undefined — do NOT compact with
-  // .filter(Boolean). The writer pads holes with "" to keep parallel Media*
-  // arrays (MediaPaths / MediaUrls / MediaTypes) index-aligned, so compaction
-  // here would shift later entries onto the wrong attachment.
-  return values?.map(normalizeOptionalText) ?? [];
 }
 
 const URL_LIKE_MEDIA_PATH_PATTERN = /^[a-z][a-z0-9+.-]*:/i;
@@ -126,36 +113,34 @@ export function buildPersistedUserTurnMediaInputsFromFields(
     return [];
   }
 
-  const mediaFields = fields as PersistedUserTurnMediaFieldSource;
-  const paths = normalizeOptionalTextArray(mediaFields.MediaPaths);
-  const urls = normalizeOptionalTextArray(mediaFields.MediaUrls);
-  const types = normalizeOptionalTextArray(mediaFields.MediaTypes);
-  const singlePath = normalizeOptionalText(mediaFields.MediaPath);
-  const singleUrl = normalizeOptionalText(mediaFields.MediaUrl);
-  const singleType = normalizeOptionalText(mediaFields.MediaType);
-  const workspaceDir = normalizeOptionalText(mediaFields.MediaWorkspaceDir);
-  const mediaCount = Math.max(paths.length, urls.length, singlePath || singleUrl ? 1 : 0);
-  const media: PersistedUserTurnMediaInput[] = [];
-
-  for (let index = 0; index < mediaCount; index += 1) {
-    const rawPath = paths[index] ?? (index === 0 ? singlePath : undefined);
-    const mediaPath = rawPath ? resolveTranscriptMediaPath(rawPath, workspaceDir) : undefined;
-    const url = urls[index] ?? (index === 0 ? singleUrl : undefined);
+  const facts = resolveMediaFacts(fields as unknown as Parameters<typeof resolveMediaFacts>[0]);
+  const normalizedMedia = facts.map((fact) => {
+    const rawPath = normalizeOptionalText(fact.path);
+    const mediaPath = rawPath
+      ? resolveTranscriptMediaPath(rawPath, normalizeOptionalText(fact.workspaceDir))
+      : undefined;
+    const url = normalizeOptionalText(fact.url);
     if (!mediaPath && !url) {
-      continue;
+      return {};
     }
-    media.push({
-      ...(mediaPath ? { path: mediaPath } : {}),
-      ...(url ? { url } : {}),
-      contentType: resolveTranscriptMediaType({
-        explicitType: types[index] ?? (index === 0 ? singleType : undefined),
-        mediaPath,
-        mediaUrl: url,
-      }),
+    const contentType = resolveTranscriptMediaType({
+      explicitType: normalizeOptionalText(fact.contentType),
+      mediaPath,
+      mediaUrl: url,
     });
-  }
-
-  return media;
+    const media: PersistedUserTurnMediaInput = { contentType };
+    if (mediaPath) {
+      media.path = mediaPath;
+    }
+    if (url) {
+      media.url = url;
+    }
+    if (!contentType && fact.kind) {
+      media.kind = fact.kind;
+    }
+    return media;
+  });
+  return normalizedMedia.some((entry) => entry.path || entry.url) ? normalizedMedia : [];
 }
 
 export function buildLateMediaAttachedText(message: AgentMessage): string | undefined {
@@ -164,7 +149,10 @@ export function buildLateMediaAttachedText(message: AgentMessage): string | unde
       ? buildPersistedUserTurnMediaInputsFromFields(message as PersistedUserTurnMediaFieldSource)
       : []
   )
-    .map((entry) => `[media attached: ${entry.path ?? entry.url}]`)
+    .flatMap((entry) => {
+      const mediaRef = entry.path ?? entry.url;
+      return mediaRef ? [`[media attached: ${mediaRef}]`] : [];
+    })
     .join("\n");
   return text || undefined;
 }
@@ -172,20 +160,16 @@ export function buildLateMediaAttachedText(message: AgentMessage): string | unde
 function buildPersistedUserTurnMediaFields(
   media: readonly PersistedUserTurnMediaInput[] | null | undefined,
 ): PersistedUserTurnMediaFields {
-  const entries = Array.isArray(media) ? media : [];
-  const normalized = entries
-    .map(normalizeMediaEntryForTranscript)
-    .filter((entry): entry is { path: string; type: string } => entry !== undefined);
-  const paths = normalized.map((entry) => entry.path);
-  if (paths.length === 0) {
+  const normalized = (Array.isArray(media) ? media : []).map(normalizeMediaEntryForTranscript);
+  const projected = projectMediaFacts(normalized, "aligned");
+  if (!projected.MediaPaths?.some(Boolean)) {
     return {};
   }
-  const types = normalized.map((entry) => entry.type);
   return {
-    MediaPath: paths[0],
-    MediaPaths: paths,
-    MediaType: types[0],
-    MediaTypes: types,
+    ...(projected.MediaPath ? { MediaPath: projected.MediaPath } : {}),
+    MediaPaths: projected.MediaPaths,
+    ...(projected.MediaType ? { MediaType: projected.MediaType } : {}),
+    MediaTypes: projected.MediaTypes ?? [],
   };
 }
 

--- a/src/sessions/user-turn-transcript.types.ts
+++ b/src/sessions/user-turn-transcript.types.ts
@@ -16,6 +16,7 @@ type UserTurnSessionEntry = {
 
 export type PersistedUserTurnMediaInput = Pick<MediaFactInput, "contentType" | "path" | "url"> & {
   kind?: string | null;
+  workspaceDir?: string | null;
 };
 
 export type PersistedUserTurnMessage = Extract<AgentMessage, { role: "user" }>;


### PR DESCRIPTION
## What Problem This Solves

PR 4 of the audit-frozen media-facts program (#112197, #112276, #112335). Persistence and CLI templating still consumed the parallel `Media*` fields directly, and the transcript writer was not yet the single owner of the legacy projection.

## Why This Change Was Made

- Legacy `Media*` fields are now emitted only by the user-turn transcript writer; persisted rows stay byte-identical (fixture and SQLite round-trip proven — no migration, no schema bump). Reads normalize into ordered facts via the PR-1/2 owner.
- Documented singular template variables project per attachment, with per-attachment CLI execution tested for one and many attachments; the `{input}` doctor migration is preserved.
- Review fix (accepted P2): normalized attachments carry their original fact index, so sparse aligned slots (`[{}, B, C]`) can no longer shift CLI url/type projections onto the wrong attachment — the alignment-vs-presence rule applied at this boundary, with sibling consumers of the same normalization audited in the same pass.

## User Impact

None intended — storage bytes, template contracts, and prompt bytes unchanged.

## Evidence

- 388 focused tests green across 14 files (new transcript-media suite; legacy projection, multi-attachment persistence, sparse-slot regressions).
- Delegated `check:changed` green on Blacksmith Testbox (run 29895037407); local format/oxlint/tsgo/SDK/knip/diff gates green.
- Autoreview: one accepted P2 (sparse-index projection) fixed with regression tests; final pass clean, "patch is correct (0.84)".
- Net −4 production LOC.
