### PR TITLE
fix(ui): stop chat pane lifecycle test pollution

### DIFF
--- a/ui/src/pages/chat/chat-pane-lifecycle.test.ts
+++ b/ui/src/pages/chat/chat-pane-lifecycle.test.ts
@@ -1,5 +1,8 @@
 /* @vitest-environment jsdom */
+/* @vitest-environment-options {"url":"http://chat-pane-lifecycle.test/"} */
 
+// The non-isolated runner resets modules between files but preserves customElements.
+// A dedicated jsdom context keeps the registered pane class on this file's module graph.
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { SessionCapability } from "../../lib/sessions/index.ts";
@@ -10,9 +13,30 @@ import {
 } from "./components/chat-message.ts";
 import * as chatThread from "./components/chat-thread.ts";
 
+const SKIP_REWIND_CONFIRM_PREFERENCE = "openclaw:skip-rewind-confirm";
+const confirmationOwners = new Set<HTMLElement>();
+
+function createConfirmationOwner() {
+  const owner = document.createElement("span");
+  owner.className = "chat-delete-wrap";
+  const trigger = document.createElement("button");
+  owner.appendChild(trigger);
+  document.body.appendChild(owner);
+  confirmationOwners.add(owner);
+  openChatRewindConfirmation(trigger, vi.fn());
+  return owner;
+}
+
 afterEach(() => {
-  vi.unstubAllGlobals();
   vi.restoreAllMocks();
+  for (const owner of confirmationOwners) {
+    dismissConfirmedActionPopovers(owner);
+    owner.remove();
+  }
+  confirmationOwners.clear();
+  chatThread.resetChatThreadPresentationState();
+  window.localStorage.removeItem(SKIP_REWIND_CONFIRM_PREFERENCE);
+  vi.unstubAllGlobals();
 });
 
 describe("chat pane presentation teardown", () => {
@@ -33,61 +57,41 @@ describe("chat pane presentation teardown", () => {
       client: {} as GatewayBrowserClient,
       sessions: {} as SessionCapability,
     });
-    const createConfirmationOwner = () => {
-      const owner = document.createElement("span");
-      owner.className = "chat-delete-wrap";
-      const trigger = document.createElement("button");
-      owner.appendChild(trigger);
-      document.body.appendChild(owner);
-      openChatRewindConfirmation(trigger, vi.fn());
-      return { owner, trigger };
-    };
-    window.localStorage.removeItem("openclaw:skip-rewind-confirm");
+    window.localStorage.removeItem(SKIP_REWIND_CONFIRM_PREFERENCE);
     const paneConfirmation = createConfirmationOwner();
     const siblingConfirmation = createConfirmationOwner();
 
-    try {
-      for (const callback of frameCallbacks.splice(0)) {
-        callback(0);
-      }
-      const captureClickListeners = addDocumentListener.mock.calls.flatMap(
-        ([type, listener, options]) =>
-          type === "click" && options === true && listener ? [listener] : [],
-      );
-      const captureKeydownListeners = addWindowListener.mock.calls.flatMap(
-        ([type, listener, options]) =>
-          type === "keydown" && options === true && listener ? [listener] : [],
-      );
-      expect(captureClickListeners).toHaveLength(2);
-      expect(captureKeydownListeners).toHaveLength(2);
-
-      pane.appendChild(paneConfirmation.owner);
-      pane.disconnectedCallback();
-
-      expect(pane.querySelector(".chat-delete-confirm")).toBeNull();
-      expect(siblingConfirmation.owner.querySelector(".chat-delete-confirm")).not.toBeNull();
-      expect(removeDocumentListener).toHaveBeenCalledWith("click", captureClickListeners[0], true);
-      expect(removeDocumentListener).not.toHaveBeenCalledWith(
-        "click",
-        captureClickListeners[1],
-        true,
-      );
-      expect(removeWindowListener).toHaveBeenCalledWith(
-        "keydown",
-        captureKeydownListeners[0],
-        true,
-      );
-      expect(removeWindowListener).not.toHaveBeenCalledWith(
-        "keydown",
-        captureKeydownListeners[1],
-        true,
-      );
-    } finally {
-      dismissConfirmedActionPopovers(paneConfirmation.owner);
-      dismissConfirmedActionPopovers(siblingConfirmation.owner);
-      paneConfirmation.owner.remove();
-      siblingConfirmation.owner.remove();
+    for (const callback of frameCallbacks.splice(0)) {
+      callback(0);
     }
+    const captureClickListeners = addDocumentListener.mock.calls.flatMap(
+      ([type, listener, options]) =>
+        type === "click" && options === true && listener ? [listener] : [],
+    );
+    const captureKeydownListeners = addWindowListener.mock.calls.flatMap(
+      ([type, listener, options]) =>
+        type === "keydown" && options === true && listener ? [listener] : [],
+    );
+    expect(captureClickListeners).toHaveLength(2);
+    expect(captureKeydownListeners).toHaveLength(2);
+
+    pane.appendChild(paneConfirmation);
+    pane.disconnectedCallback();
+
+    expect(pane.querySelector(".chat-delete-confirm")).toBeNull();
+    expect(siblingConfirmation.querySelector(".chat-delete-confirm")).not.toBeNull();
+    expect(removeDocumentListener).toHaveBeenCalledWith("click", captureClickListeners[0], true);
+    expect(removeDocumentListener).not.toHaveBeenCalledWith(
+      "click",
+      captureClickListeners[1],
+      true,
+    );
+    expect(removeWindowListener).toHaveBeenCalledWith("keydown", captureKeydownListeners[0], true);
+    expect(removeWindowListener).not.toHaveBeenCalledWith(
+      "keydown",
+      captureKeydownListeners[1],
+      true,
+    );
   });
 
   it("dismisses the previous session confirmation before switching in place", () => {
@@ -107,44 +111,34 @@ describe("chat pane presentation teardown", () => {
       client: {} as GatewayBrowserClient,
       sessions: {} as SessionCapability,
     });
-    const owner = document.createElement("span");
-    owner.className = "chat-delete-wrap";
-    const trigger = document.createElement("button");
-    owner.appendChild(trigger);
-    document.body.appendChild(owner);
-    window.localStorage.removeItem("openclaw:skip-rewind-confirm");
-    openChatRewindConfirmation(trigger, vi.fn());
+    window.localStorage.removeItem(SKIP_REWIND_CONFIRM_PREFERENCE);
+    const owner = createConfirmationOwner();
 
-    try {
-      for (const callback of frameCallbacks.splice(0)) {
-        callback(0);
-      }
-      const captureClickListener = addDocumentListener.mock.calls.find(
-        ([type, listener, options]) => type === "click" && options === true && listener,
-      )?.[1];
-      const captureKeydownListener = addWindowListener.mock.calls.find(
-        ([type, listener, options]) => type === "keydown" && options === true && listener,
-      )?.[1];
-      expect(captureClickListener).toBeDefined();
-      expect(captureKeydownListener).toBeDefined();
-      pane.appendChild(owner);
-
-      const resetPresentation = chatThread.resetChatThreadPresentationState;
-      const stopAfterReset = new Error("stop after thread presentation reset");
-      vi.spyOn(chatThread, "resetChatThreadPresentationState").mockImplementation(
-        (paneId, presentationOwner) => {
-          resetPresentation(paneId, presentationOwner);
-          throw stopAfterReset;
-        },
-      );
-
-      expect(() => pane.switchPaneSession("agent:main:next")).toThrow(stopAfterReset);
-      expect(owner.querySelector(".chat-delete-confirm")).toBeNull();
-      expect(removeDocumentListener).toHaveBeenCalledWith("click", captureClickListener, true);
-      expect(removeWindowListener).toHaveBeenCalledWith("keydown", captureKeydownListener, true);
-    } finally {
-      dismissConfirmedActionPopovers(owner);
-      owner.remove();
+    for (const callback of frameCallbacks.splice(0)) {
+      callback(0);
     }
+    const captureClickListener = addDocumentListener.mock.calls.find(
+      ([type, listener, options]) => type === "click" && options === true && listener,
+    )?.[1];
+    const captureKeydownListener = addWindowListener.mock.calls.find(
+      ([type, listener, options]) => type === "keydown" && options === true && listener,
+    )?.[1];
+    expect(captureClickListener).toBeDefined();
+    expect(captureKeydownListener).toBeDefined();
+    pane.appendChild(owner);
+
+    const resetPresentation = chatThread.resetChatThreadPresentationState;
+    const stopAfterReset = new Error("stop after thread presentation reset");
+    vi.spyOn(chatThread, "resetChatThreadPresentationState").mockImplementation(
+      (paneId, presentationOwner) => {
+        resetPresentation(paneId, presentationOwner);
+        throw stopAfterReset;
+      },
+    );
+
+    expect(() => pane.switchPaneSession("agent:main:next")).toThrow(stopAfterReset);
+    expect(owner.querySelector(".chat-delete-confirm")).toBeNull();
+    expect(removeDocumentListener).toHaveBeenCalledWith("click", captureClickListener, true);
+    expect(removeWindowListener).toHaveBeenCalledWith("keydown", captureKeydownListener, true);
   });
 });


### PR DESCRIPTION
Related: #103320

AI-assisted by Claude Code.

## What Problem This Solves

Resolves a problem where unrelated changes could intermittently fail both chat pane lifecycle tests in the `core-runtime-media-ui` shard, then pass when the identical SHA was rerun. The failures blocked otherwise unrelated PRs and made the shard order-dependent.

## Why This Change Was Made

The non-isolated UI runner resets modules between files while jsdom retains its custom-element registry. When another chat-pane test ran first, `openclaw-chat-pane` kept the previous file's constructor and module graph, so the lifecycle test's confirmation helpers and spies no longer matched the pane instance.

Give this file a dedicated jsdom context, matching the isolation pattern from #102869, and centralize teardown so every test dismisses tracked confirmation popovers, removes their DOM owners, clears chat-thread presentation state and the rewind preference, and restores globals. There is no production-code change.

## User Impact

No runtime behavior changes. Maintainers get deterministic Control UI lifecycle coverage instead of unrelated PRs failing based on worker file order.

## Evidence

- Original unrelated-PR failure: https://github.com/openclaw/openclaw/actions/runs/29894898428/attempts/1
- The identical SHA passed when the failed job was rerun: https://github.com/openclaw/openclaw/actions/runs/29894898428
- Deterministic pre-fix two-file reproduction: 8 of 10 shuffled seeds failed when `chat-pane-history.test.ts` ran before `chat-pane-lifecycle.test.ts`; the failures matched CI exactly.
- Post-fix ordering proof: all 10 shuffled seeds passed.
- Focused repetition: `node scripts/run-vitest.mjs ui/src/pages/chat/chat-pane-lifecycle.test.ts` passed 20 consecutive bounded runs.
- Post-rebase failing-order proof: the two-file seed-1 run passed 17/17 tests.
- Targeted oxfmt check, oxlint, and `git diff --check`: clean.
- Fresh Codex autoreview (`gpt-5.6-sol`, high reasoning): no accepted/actionable findings; correctness confidence 0.97.
- Blacksmith Testbox warmup was unavailable with a workflow-dispatch HTTP 500, so exact-head hosted CI remains the heavy shard proof.
