### PR TITLE
feat(skills): install skills.sh catalog references

### DIFF
--- a/docs/clawhub/cli.md
+++ b/docs/clawhub/cli.md
@@ -22,6 +22,7 @@ Two command-line surfaces talk to ClawHub:
 openclaw skills search "calendar"
 openclaw skills install @owner/<slug>
 openclaw skills install @owner/<slug> --version <version> --global
+openclaw skills install skills-sh/<owner>/<repo>/<slug>
 openclaw skills update @owner/<slug>
 openclaw skills update --all --acknowledge-clawhub-risk
 openclaw skills verify @owner/<slug> --card
@@ -38,6 +39,10 @@ Skill installs target the active workspace `skills/` directory by default; add
 explicit `clawhub:` prefix to force ClawHub resolution over npm, git, or a
 local path. Full flag reference: [`openclaw skills`](/cli/skills) and
 [`openclaw plugins`](/cli/plugins).
+
+`skills-sh/` is a discovery reference only. OpenClaw sends it to ClawHub and
+installs the security-approved, commit-pinned GitHub source returned by
+ClawHub; it never downloads skill content from skills.sh directly.
 
 ### Release trust
 

--- a/docs/cli/skills.md
+++ b/docs/cli/skills.md
@@ -27,6 +27,7 @@ openclaw skills search "calendar"
 openclaw skills search --limit 20 --json
 openclaw skills install @owner/<slug>
 openclaw skills install @owner/<slug> --version <version>
+openclaw skills install skills-sh/<owner>/<repo>/<slug>
 openclaw skills install git:owner/repo
 openclaw skills install git:owner/repo@main
 openclaw skills install ./path/to/skill --as custom-name
@@ -69,8 +70,13 @@ openclaw skills workshop quarantine <proposal-id> --reason "Needs security revie
 ```
 
 `search`, `update`, and `verify` use ClawHub directly. `install @owner/<slug>`
-installs a ClawHub skill, `install git:owner/repo[@ref]` clones a Git skill,
-and `install ./path` copies a local skill directory. By default, `install`,
+installs a ClawHub skill. `install skills-sh/<owner>/<repo>/<slug>` asks
+ClawHub to resolve that discovery reference to a security-approved,
+commit-pinned GitHub source; OpenClaw does not download from skills.sh.
+Normal search results include approved skills.sh entries alongside native
+ClawHub skills and show their `skills-sh/` install references.
+`install git:owner/repo[@ref]` clones a Git skill, and `install ./path` copies
+a local skill directory. By default, `install`,
 `update`, and `verify` target the active workspace `skills/` directory; with
 `--global`, they target the shared managed skills directory. `list`/`info`/`check`
 still inspect the local skills visible to the current workspace and config.
@@ -97,7 +103,7 @@ Notes:
 | `install git:owner/repo[@ref]`   | Installs a Git skill. Branch refs may contain slashes, such as `git:owner/repo@feature/foo`.                                                                                                                                                                                      |
 | `install ./path/to/skill`        | Installs a local directory whose root contains `SKILL.md`.                                                                                                                                                                                                                        |
 | `install --as <slug>`            | Overrides the inferred slug for Git and local directory installs.                                                                                                                                                                                                                 |
-| `install --version <version>`    | Applies only to ClawHub skill refs.                                                                                                                                                                                                                                               |
+| `install --version <version>`    | Applies to native ClawHub skill refs, not `skills-sh/` refs; ClawHub selects the approved GitHub commit for those references.                                                                                                                                                     |
 | `install --force`                | Overwrites an existing workspace skill folder for the same slug.                                                                                                                                                                                                                  |
 | `install/update --force-install` | Installs a pending GitHub-backed ClawHub skill before ClawHub's scan completes.                                                                                                                                                                                                   |
 | `--global`                       | Targets the shared managed skills directory; cannot combine with `--agent <id>`.                                                                                                                                                                                                  |

--- a/docs/tools/skills.md
+++ b/docs/tools/skills.md
@@ -164,6 +164,7 @@ publish and sync.
 | Action                             | Command                                                |
 | ---------------------------------- | ------------------------------------------------------ |
 | Install a skill into the workspace | `openclaw skills install @owner/<slug>`                |
+| Install a skills.sh discovery ref  | `openclaw skills install skills-sh/owner/repo/slug`    |
 | Install from a Git repository      | `openclaw skills install git:owner/repo@ref`           |
 | Install a local skill directory    | `openclaw skills install ./path/to/skill --as my-tool` |
 | Install for all local agents       | `openclaw skills install @owner/<slug> --global`       |

--- a/src/cli/skills-cli.commands.test.ts
+++ b/src/cli/skills-cli.commands.test.ts
@@ -394,6 +394,25 @@ describe("skills cli commands", () => {
     expect(runtimeLogs).toEqual(["legacy-calendar  Legacy Calendar"]);
   });
 
+  it("shows skills.sh entries in normal ClawHub search results", async () => {
+    searchSkillsFromClawHubMock.mockResolvedValue([
+      {
+        slug: "weather",
+        installRef: "skills-sh/openclaw/skills/weather",
+        displayName: "Weather",
+        summary: "Forecast helpers",
+      },
+    ]);
+
+    await runCommand(["skills", "search", "weather"]);
+
+    expect(searchSkillsFromClawHubMock).toHaveBeenCalledWith({
+      query: "weather",
+      limit: undefined,
+    });
+    expect(runtimeLogs).toEqual(["skills-sh/openclaw/skills/weather  Weather  Forecast helpers"]);
+  });
+
   it("keeps multiline ClawHub search metadata on one terminal line", async () => {
     searchSkillsFromClawHubMock.mockResolvedValue([
       {
@@ -486,6 +505,43 @@ describe("skills cli commands", () => {
         line.includes("Installed calendar@1.2.3 -> /tmp/workspace/skills/calendar"),
       ),
     ).toBe(true);
+  });
+
+  it("routes skills-sh refs through ClawHub without translating them", async () => {
+    const reference = "skills-sh/openclaw/skills/weather";
+    installSkillFromClawHubMock.mockResolvedValue({
+      ok: true,
+      slug: "weather",
+      version: "a".repeat(40),
+      targetDir: "/tmp/workspace/skills/weather",
+    });
+
+    await runCommand(["skills", "install", reference]);
+
+    expect(mockFirstObjectArg(installSkillFromClawHubMock).slug).toBe(reference);
+    expect(installSkillFromSourceMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects --version for skills-sh refs", async () => {
+    await expect(
+      runCommand(["skills", "install", "skills-sh/openclaw/skills/weather", "--version", "1.2.3"]),
+    ).rejects.toThrow("__exit__:1");
+
+    expect(runtimeErrors).toContain("--version is not supported for skills-sh references.");
+    expect(installSkillFromClawHubMock).not.toHaveBeenCalled();
+    expect(installSkillFromSourceMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects the reverted skills-sh colon syntax", async () => {
+    await expect(
+      runCommand(["skills", "install", "skills-sh:openclaw/skills/weather"]),
+    ).rejects.toThrow("__exit__:1");
+
+    expect(runtimeErrors).toContain(
+      "Invalid skills.sh skill reference: skills-sh:openclaw/skills/weather",
+    );
+    expect(installSkillFromClawHubMock).not.toHaveBeenCalled();
+    expect(installSkillFromSourceMock).not.toHaveBeenCalled();
   });
 
   it("documents owner-qualified ClawHub install refs in command help", () => {

--- a/src/cli/skills-cli.ts
+++ b/src/cli/skills-cli.ts
@@ -435,9 +435,14 @@ export function registerSkillsCli(program: Command) {
           return;
         }
         for (const entry of results) {
+          const installRef = normalizeOptionalString(entry.installRef);
           const ownerHandle = normalizeOptionalString(entry.ownerHandle);
           const slug = formatClawHubSearchText(entry.slug);
-          const skillRef = ownerHandle ? `@${formatClawHubSearchText(ownerHandle)}/${slug}` : slug;
+          const skillRef = installRef?.startsWith("skills-sh/")
+            ? formatClawHubSearchText(installRef)
+            : ownerHandle
+              ? `@${formatClawHubSearchText(ownerHandle)}/${slug}`
+              : slug;
           const version = entry.version ? ` v${formatClawHubSearchText(entry.version)}` : "";
           const summary = entry.summary ? `  ${formatClawHubSearchText(entry.summary)}` : "";
           const displayName = formatClawHubSearchText(entry.displayName);
@@ -454,7 +459,7 @@ export function registerSkillsCli(program: Command) {
     .description("Install a skill from ClawHub, git, or a local directory")
     .argument(
       "<skill-ref>",
-      "ClawHub skill ref (@owner/slug), git:<repo>, or local skill directory",
+      "ClawHub skill ref (@owner/slug or skills-sh/owner/repo/slug), git:<repo>, or local skill directory",
     )
     .option("--version <version>", "Install a specific version")
     .option("--force", "Overwrite an existing workspace skill", false)
@@ -471,7 +476,10 @@ export function registerSkillsCli(program: Command) {
     .option("--global", "Install into the shared managed skills directory", false)
     .option("--agent <id>", "Target agent workspace (defaults to cwd-inferred, then default agent)")
     .option("--as <slug>", "Install a git/local skill under this slug")
-    .addHelpText("after", "\nExamples:\n  openclaw skills install @owner/weather\n")
+    .addHelpText(
+      "after",
+      "\nExamples:\n  openclaw skills install @owner/weather\n  openclaw skills install skills-sh/owner/repo/weather\n",
+    )
     .action(
       async (
         slug: string,
@@ -490,6 +498,11 @@ export function registerSkillsCli(program: Command) {
         try {
           const workspaceDir = resolveClawHubTargetWorkspaceDir(command, opts);
           if (!workspaceDir) {
+            return;
+          }
+          if (slug.trim().startsWith("skills-sh:")) {
+            defaultRuntime.error(`Invalid skills.sh skill reference: ${slug}`);
+            defaultRuntime.exit(1);
             return;
           }
           if (isSkillSourceInstallSpec(slug)) {
@@ -522,6 +535,11 @@ export function registerSkillsCli(program: Command) {
             defaultRuntime.error(
               "--as is only supported for git and local directory skill installs.",
             );
+            defaultRuntime.exit(1);
+            return;
+          }
+          if (slug.trim().startsWith("skills-sh/") && opts.version) {
+            defaultRuntime.error("--version is not supported for skills-sh references.");
             defaultRuntime.exit(1);
             return;
           }
@@ -685,6 +703,9 @@ export function registerSkillsCli(program: Command) {
             const verification = await fetchClawHubSkillVerification({
               slug: target.slug,
               ...(target.ownerHandle ? { ownerHandle: target.ownerHandle } : {}),
+              ...(target.requestedReference
+                ? { requestedReference: target.requestedReference }
+                : {}),
               version: target.version,
               tag: target.tag,
               baseUrl: target.baseUrl,

--- a/src/cli/skills-cli.verify.test.ts
+++ b/src/cli/skills-cli.verify.test.ts
@@ -156,6 +156,100 @@ describe("skills verify CLI", () => {
     );
   }
 
+  async function writeInstalledSkillsShSkill() {
+    const requestedReference = "skills-sh/patrick-erichsen/skills/html";
+    const installedVersion = "a".repeat(40);
+    const skillDir = path.join(workspaceDir, "skills", "html");
+    await fs.mkdir(path.join(skillDir, ".clawhub"), { recursive: true });
+    await fs.writeFile(path.join(skillDir, "SKILL.md"), "# HTML\n", "utf8");
+    await fs.writeFile(
+      path.join(skillDir, ".clawhub", "origin.json"),
+      `${JSON.stringify(
+        {
+          version: 1,
+          registry: "https://private.example.com/clawhub",
+          slug: "html",
+          requestedReference,
+          installedVersion,
+          installedAt: 123,
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+    await fs.mkdir(path.join(workspaceDir, ".clawhub"), { recursive: true });
+    await fs.writeFile(
+      path.join(workspaceDir, ".clawhub", "lock.json"),
+      `${JSON.stringify(
+        {
+          version: 1,
+          skills: {
+            html: {
+              version: installedVersion,
+              installedAt: 123,
+              registry: "https://private.example.com/clawhub",
+              requestedReference,
+            },
+          },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+    return { requestedReference };
+  }
+
+  function mockPassingSkillsShVerification() {
+    mocks.fetchClawHubSkillVerificationMock.mockResolvedValueOnce({
+      schema: "clawhub.skill.verify.v1",
+      ok: true,
+      decision: "pass",
+      reasons: [],
+      skill: { slug: "html" },
+      publisher: { handle: "patrick-erichsen" },
+      version: { version: "a".repeat(40) },
+      card: { available: true },
+      artifact: { sourceFingerprint: "source-fp" },
+      provenance: null,
+      security: { status: "clean" },
+      signature: { status: "unsigned" },
+    });
+  }
+
+  it("verifies an installed skills.sh skill by its exact reference without a version selector", async () => {
+    const { requestedReference } = await writeInstalledSkillsShSkill();
+    mockPassingSkillsShVerification();
+
+    await runCommand(["skills", "verify", requestedReference]);
+
+    expect(mocks.fetchClawHubSkillVerificationMock).toHaveBeenCalledWith({
+      slug: "html",
+      requestedReference,
+      version: undefined,
+      tag: undefined,
+      baseUrl: "https://private.example.com/clawhub",
+    });
+    expect(mocks.defaultRuntime.exit).not.toHaveBeenCalled();
+  });
+
+  it("verifies an installed skills.sh skill by slug without a version selector", async () => {
+    const { requestedReference } = await writeInstalledSkillsShSkill();
+    mockPassingSkillsShVerification();
+
+    await runCommand(["skills", "verify", "html"]);
+
+    expect(mocks.fetchClawHubSkillVerificationMock).toHaveBeenCalledWith({
+      slug: "html",
+      requestedReference,
+      version: undefined,
+      tag: undefined,
+      baseUrl: "https://private.example.com/clawhub",
+    });
+    expect(mocks.defaultRuntime.exit).not.toHaveBeenCalled();
+  });
+
   it("does not reject an installed bundle just because ClawHub generated skill-card.md", async () => {
     await writeInstalledGeneratedCardSkill();
     mocks.fetchClawHubSkillVerificationMock.mockResolvedValueOnce({

--- a/src/infra/clawhub.test.ts
+++ b/src/infra/clawhub.test.ts
@@ -433,6 +433,29 @@ describe("clawhub helpers", () => {
     expect(fetchImpl).not.toHaveBeenCalled();
   });
 
+  it("preserves skills-sh references in install telemetry", async () => {
+    let body: unknown;
+
+    await reportClawHubSkillInstallTelemetry({
+      token: "token-123",
+      slug: "weather",
+      version: "a".repeat(40),
+      requestedReference: "skills-sh/openclaw/skills/weather",
+      fetchImpl: async (_input, init) => {
+        expect(typeof init?.body).toBe("string");
+        body = JSON.parse(init?.body as string);
+        return new Response(null, { status: 200 });
+      },
+    });
+
+    expect(body).toMatchObject({
+      event: "install",
+      slug: "weather",
+      version: "a".repeat(40),
+      reference: "skills-sh/openclaw/skills/weather",
+    });
+  });
+
   it("preserves the configured ClawHub base URL path prefix", async () => {
     process.env.OPENCLAW_CLAWHUB_URL = "https://internal.example.com/clawhub";
     let requestedUrl = "";
@@ -541,6 +564,38 @@ describe("clawhub helpers", () => {
     const url = new URL(requestedUrl);
     expect(url.pathname).toBe("/api/v1/skills/weather/install");
     expect(url.searchParams.get("ownerHandle")).toBe("demo-owner");
+  });
+
+  it("sends skills-sh references to the ClawHub install resolver", async () => {
+    let requestedUrl = "";
+    const reference = "skills-sh/openclaw/skills/weather";
+
+    await fetchClawHubSkillInstallResolution({
+      slug: "weather",
+      requestedReference: reference,
+      fetchImpl: async (input) => {
+        requestedUrl = input instanceof Request ? input.url : String(input);
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            slug: "weather",
+            installKind: "github",
+            github: {
+              repo: "openclaw/skills",
+              path: "skills/weather",
+              commit: "a".repeat(40),
+              contentHash: "sha256:approved",
+              sourceUrl: "https://github.com/openclaw/skills",
+            },
+          }),
+          { headers: { "content-type": "application/json" } },
+        );
+      },
+    });
+
+    const url = new URL(requestedUrl);
+    expect(url.pathname).toBe("/api/v1/skills/weather/install");
+    expect(url.searchParams.get("reference")).toBe(reference);
   });
 
   it("fetches skill verification reports and lets version take precedence over tag", async () => {

--- a/src/infra/clawhub.ts
+++ b/src/infra/clawhub.ts
@@ -270,6 +270,7 @@ export type ClawHubPackageSearchResult = {
 export type ClawHubSkillSearchResult = {
   score: number;
   slug: string;
+  installRef?: string;
   // Search may return the same slug for multiple publishers; exact install refs need this handle.
   ownerHandle?: string | null;
   displayName: string;
@@ -1234,6 +1235,7 @@ export async function fetchClawHubSkillDetail(params: {
 export async function fetchClawHubSkillInstallResolution(params: {
   slug: string;
   ownerHandle?: string;
+  requestedReference?: string;
   baseUrl?: string;
   token?: string;
   timeoutMs?: number;
@@ -1248,6 +1250,7 @@ export async function fetchClawHubSkillInstallResolution(params: {
     fetchImpl: params.fetchImpl,
     search: {
       ownerHandle: params.ownerHandle,
+      reference: params.requestedReference,
       forceInstall: params.forceInstall ? "1" : undefined,
     },
   });
@@ -1265,6 +1268,7 @@ export async function fetchClawHubSkillInstallResolution(params: {
 export async function fetchClawHubSkillVerification(params: {
   slug: string;
   ownerHandle?: string;
+  requestedReference?: string;
   version?: string;
   tag?: string;
   baseUrl?: string;
@@ -1278,7 +1282,10 @@ export async function fetchClawHubSkillVerification(params: {
     token: params.token,
     timeoutMs: params.timeoutMs,
     fetchImpl: params.fetchImpl,
-    search: buildVersionOrTagSearch(params),
+    search: {
+      ...buildVersionOrTagSearch(params),
+      ...(params.requestedReference ? { reference: params.requestedReference } : {}),
+    },
   });
 }
 
@@ -1599,6 +1606,7 @@ export async function reportClawHubSkillInstallTelemetry(params: {
   token?: string;
   slug: string;
   ownerHandle?: string;
+  requestedReference?: string;
   version?: string | null;
   timeoutMs?: number;
   fetchImpl?: FetchLike;
@@ -1623,6 +1631,7 @@ export async function reportClawHubSkillInstallTelemetry(params: {
       event: "install",
       slug,
       ...(params.ownerHandle ? { ownerHandle: params.ownerHandle } : {}),
+      ...(params.requestedReference ? { reference: params.requestedReference } : {}),
       version: params.version ?? undefined,
     },
   });

--- a/src/skills/lifecycle/clawhub.test.ts
+++ b/src/skills/lifecycle/clawhub.test.ts
@@ -129,6 +129,7 @@ async function writeClawHubOriginFixture(params: {
   slug: string;
   originSlug?: string;
   ownerHandle?: string;
+  requestedReference?: string;
   registry?: string;
   installedVersion?: string;
   installedAt?: number;
@@ -147,6 +148,7 @@ async function writeClawHubOriginFixture(params: {
         registry,
         slug: params.originSlug ?? params.slug,
         ...(params.ownerHandle ? { ownerHandle: params.ownerHandle } : {}),
+        ...(params.requestedReference ? { requestedReference: params.requestedReference } : {}),
         installedVersion,
         installedAt,
       },
@@ -168,6 +170,9 @@ async function writeClawHubOriginFixture(params: {
               installedAt,
               registry,
               ...(params.ownerHandle ? { ownerHandle: params.ownerHandle } : {}),
+              ...(params.requestedReference
+                ? { requestedReference: params.requestedReference }
+                : {}),
             },
           },
         },
@@ -329,6 +334,133 @@ describe("skills-clawhub", () => {
       slug: "agentreceipt",
       version: "1.0.0",
     });
+  });
+
+  it("installs skills-sh references via a ClawHub-approved pinned GitHub commit", async () => {
+    const commit = "a".repeat(40);
+    const reference = "skills-sh/openclaw/skills/weather";
+    fetchClawHubSkillInstallResolutionMock.mockResolvedValueOnce({
+      ok: true,
+      slug: "weather",
+      installKind: "github",
+      github: {
+        repo: "openclaw/skills",
+        path: "skills/weather",
+        commit,
+        contentHash: "sha256:approved",
+        sourceUrl: `https://github.com/openclaw/skills/tree/${commit}/skills/weather`,
+      },
+    });
+    withExtractedArchiveRootMock.mockImplementationOnce(async (params) => {
+      expect(params.rootMarkers).toBeUndefined();
+      return await params.onExtracted("/tmp/extracted-github-repo");
+    });
+    installPackageDirMock.mockResolvedValueOnce({
+      ok: true,
+      targetDir: "/tmp/workspace/skills/weather",
+    });
+
+    const result = await installSkillFromClawHub({
+      workspaceDir: "/tmp/workspace",
+      slug: reference,
+    });
+
+    expect(fetchClawHubSkillInstallResolutionMock).toHaveBeenCalledWith({
+      slug: "weather",
+      baseUrl: undefined,
+      requestedReference: reference,
+    });
+    expect(downloadClawHubGitHubSkillArchiveMock).toHaveBeenCalledWith({
+      repo: "openclaw/skills",
+      commit,
+    });
+    expect(fetchClawHubSkillVerificationMock).toHaveBeenCalledWith({
+      slug: "weather",
+      requestedReference: reference,
+      version: undefined,
+      baseUrl: undefined,
+    });
+    expect(installPolicyInput()).toMatchObject({
+      requestedSpecifier: reference,
+      origin: {
+        slug: "weather",
+        version: commit,
+        repo: "openclaw/skills",
+        path: "skills/weather",
+        commit,
+      },
+    });
+    expectInstalledSkill(result, {
+      slug: "weather",
+      version: commit,
+      targetDir: "/tmp/workspace/skills/weather",
+    });
+    expect(reportClawHubSkillInstallTelemetryMock).toHaveBeenCalledWith({
+      baseUrl: undefined,
+      slug: "weather",
+      version: commit,
+      requestedReference: reference,
+    });
+  });
+
+  it.each([
+    "skills-sh/",
+    "skills-sh:owner/repo/slug",
+    "skills-sh/owner/repo",
+    "skills-sh/owner/repo/slug/extra",
+    "skills-sh/-owner/repo/slug",
+    "skills-sh/owner/../slug",
+  ])("rejects invalid skills-sh reference %s before network access", async (reference) => {
+    const result = await installSkillFromClawHub({
+      workspaceDir: "/tmp/workspace",
+      slug: reference,
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: expect.stringContaining("Invalid skills.sh skill reference"),
+    });
+    expect(fetchClawHubSkillInstallResolutionMock).not.toHaveBeenCalled();
+    expect(downloadClawHubGitHubSkillArchiveMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects versions for skills-sh references before network access", async () => {
+    const result = await installSkillFromClawHub({
+      workspaceDir: "/tmp/workspace",
+      slug: "skills-sh/openclaw/skills/weather",
+      version: "1.2.3",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: "--version is not supported for skills-sh references.",
+    });
+    expect(fetchClawHubSkillInstallResolutionMock).not.toHaveBeenCalled();
+    expect(downloadClawHubSkillArchiveMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-GitHub resolutions for skills-sh references", async () => {
+    fetchClawHubSkillInstallResolutionMock.mockResolvedValueOnce({
+      ok: true,
+      slug: "weather",
+      installKind: "archive",
+      archive: {
+        version: "1.0.0",
+        downloadUrl: "https://clawhub.ai/api/v1/download?slug=weather&version=1.0.0",
+      },
+    });
+
+    const result = await installSkillFromClawHub({
+      workspaceDir: "/tmp/workspace",
+      slug: "skills-sh/openclaw/skills/weather",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: 'Skill "weather" did not resolve to a commit-pinned GitHub source.',
+    });
+    expect(downloadClawHubSkillArchiveMock).not.toHaveBeenCalled();
+    expect(downloadClawHubGitHubSkillArchiveMock).not.toHaveBeenCalled();
   });
 
   it("resolves an exact skill artifact without mutating the workspace", async () => {
@@ -1598,24 +1730,30 @@ describe("skills-clawhub", () => {
     },
   );
 
-  it("updates owner-qualified ClawHub skills with the stored owner namespace", async () => {
+  it("updates skills.sh installs with the stored reference", async () => {
     const workspaceDir = await tempDirs.make("openclaw-owner-update-");
+    const commit = "b".repeat(40);
     await writeClawHubOriginFixture({
       workspaceDir,
       slug: "weather",
-      ownerHandle: "demo-owner",
+      requestedReference: "skills-sh/openclaw/skills/weather",
       registry: "https://private.example.com/clawhub",
       installedVersion: "0.9.0",
     });
     fetchClawHubSkillInstallResolutionMock.mockResolvedValueOnce({
       ok: true,
       slug: "weather",
-      installKind: "archive",
-      archive: {
-        version: "1.0.0",
-        downloadUrl:
-          "https://private.example.com/clawhub/api/v1/download?slug=weather&ownerHandle=demo-owner&version=1.0.0",
+      installKind: "github",
+      github: {
+        repo: "openclaw/skills",
+        path: "skills/weather",
+        commit,
+        contentHash: "sha256:approved",
+        sourceUrl: `https://github.com/openclaw/skills/tree/${commit}/skills/weather`,
       },
+    });
+    withExtractedArchiveRootMock.mockImplementationOnce(async (params) => {
+      return await params.onExtracted("/tmp/extracted-github-repo");
     });
     installPackageDirMock.mockImplementationOnce(async (params: { targetDir: string }) => {
       await fs.mkdir(params.targetDir, { recursive: true });
@@ -1625,18 +1763,18 @@ describe("skills-clawhub", () => {
 
     const results = await updateSkillsFromClawHub({
       workspaceDir,
-      slug: "weather",
+      slug: "skills-sh/openclaw/skills/weather",
     });
 
     expect(fetchClawHubSkillInstallResolutionMock).toHaveBeenCalledWith({
       slug: "weather",
-      ownerHandle: "demo-owner",
+      requestedReference: "skills-sh/openclaw/skills/weather",
       baseUrl: "https://private.example.com/clawhub",
     });
     expect(fetchClawHubSkillVerificationMock).toHaveBeenCalledWith({
       slug: "weather",
-      ownerHandle: "demo-owner",
-      version: "1.0.0",
+      requestedReference: "skills-sh/openclaw/skills/weather",
+      version: undefined,
       baseUrl: "https://private.example.com/clawhub",
     });
     expect(results).toEqual([
@@ -1644,7 +1782,7 @@ describe("skills-clawhub", () => {
         ok: true,
         slug: "weather",
         previousVersion: "0.9.0",
-        version: "1.0.0",
+        version: commit,
         changed: true,
         targetDir: path.join(workspaceDir, "skills", "weather"),
       },
@@ -1652,7 +1790,7 @@ describe("skills-clawhub", () => {
     const lock = JSON.parse(
       await fs.readFile(path.join(workspaceDir, ".clawhub", "lock.json"), "utf8"),
     ) as { skills: Record<string, Record<string, unknown>> };
-    expect(lock.skills.weather?.ownerHandle).toBe("demo-owner");
+    expect(lock.skills.weather?.requestedReference).toBe("skills-sh/openclaw/skills/weather");
   });
 
   it("updates official publisher ClawHub skills without fetching security verdicts", async () => {
@@ -2119,12 +2257,13 @@ describe("skills-clawhub", () => {
   });
 
   describe("verification target resolution", () => {
-    it("uses installed origin registry and installed version by default", async () => {
+    it("preserves installed skills.sh references for verification", async () => {
       const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-skill-verify-"));
       try {
         const skillDir = await writeClawHubOriginFixture({
           workspaceDir,
           slug: "agentreceipt",
+          requestedReference: "skills-sh/openclaw/skills/agentreceipt",
           registry: "https://private.example.com/clawhub/",
           installedVersion: "2.0.0",
         });
@@ -2132,11 +2271,12 @@ describe("skills-clawhub", () => {
         await expect(
           resolveClawHubSkillVerificationTarget({
             workspaceDir,
-            slug: "agentreceipt",
+            slug: "skills-sh/openclaw/skills/agentreceipt",
           }),
         ).resolves.toEqual({
           ok: true,
           slug: "agentreceipt",
+          requestedReference: "skills-sh/openclaw/skills/agentreceipt",
           baseUrl: "https://private.example.com/clawhub",
           version: "2.0.0",
           tag: undefined,

--- a/src/skills/lifecycle/clawhub.test.ts
+++ b/src/skills/lifecycle/clawhub.test.ts
@@ -2278,7 +2278,7 @@ describe("skills-clawhub", () => {
           slug: "agentreceipt",
           requestedReference: "skills-sh/openclaw/skills/agentreceipt",
           baseUrl: "https://private.example.com/clawhub",
-          version: "2.0.0",
+          version: undefined,
           tag: undefined,
           resolution: {
             source: "installed",
@@ -2292,6 +2292,54 @@ describe("skills-clawhub", () => {
         await fs.rm(workspaceDir, { recursive: true, force: true });
       }
     });
+
+    it.each([
+      { version: "2.0.0", tag: undefined },
+      { version: undefined, tag: "latest" },
+    ])(
+      "rejects selectors for exact skills.sh verification references",
+      async ({ version, tag }) => {
+        await expect(
+          resolveClawHubSkillVerificationTarget({
+            workspaceDir: "/tmp/workspace",
+            slug: "skills-sh/openclaw/skills/agentreceipt",
+            version,
+            tag,
+          }),
+        ).resolves.toEqual({
+          ok: false,
+          error: "--version and --tag are not supported for skills-sh references.",
+        });
+      },
+    );
+
+    it.each([
+      { version: "2.0.0", tag: undefined },
+      { version: undefined, tag: "latest" },
+    ])(
+      "rejects selectors when an installed skill is tracked from skills.sh",
+      async ({ version, tag }) => {
+        const workspaceDir = await tempDirs.make("openclaw-skill-verify-");
+        await writeClawHubOriginFixture({
+          workspaceDir,
+          slug: "agentreceipt",
+          requestedReference: "skills-sh/openclaw/skills/agentreceipt",
+          installedVersion: "a".repeat(40),
+        });
+
+        await expect(
+          resolveClawHubSkillVerificationTarget({
+            workspaceDir,
+            slug: "agentreceipt",
+            version,
+            tag,
+          }),
+        ).resolves.toEqual({
+          ok: false,
+          error: "--version and --tag are not supported for skills-sh references.",
+        });
+      },
+    );
 
     it("uses installed owner namespace when resolving owner-qualified verification targets", async () => {
       const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-skill-verify-"));

--- a/src/skills/lifecycle/clawhub.ts
+++ b/src/skills/lifecycle/clawhub.ts
@@ -1118,6 +1118,12 @@ export async function resolveClawHubSkillVerificationTarget(params: {
     }
 
     const requestedRef = parseRequestedClawHubSkillRef(params.slug);
+    if (requestedRef.requestedReference && (version || tag)) {
+      return {
+        ok: false,
+        error: "--version and --tag are not supported for skills-sh references.",
+      };
+    }
     const trackedSlug = requestedRef.slug;
     const skillDir = resolveWorkspaceSkillInstallDir(params.workspaceDir, trackedSlug);
     const originRead = await readClawHubSkillOriginStrict(skillDir);
@@ -1161,6 +1167,12 @@ export async function resolveClawHubSkillVerificationTarget(params: {
           error: `Skill "${trackedSlug}" ClawHub origin metadata does not match the workspace ClawHub lockfile. Reinstall it from ClawHub before verifying it as an installed ClawHub skill.`,
         };
       }
+      if (lockedRequestedReference && (version || tag)) {
+        return {
+          ok: false,
+          error: "--version and --tag are not supported for skills-sh references.",
+        };
+      }
       if (requestedRef.ownerHandle && lockedOwnerHandle !== requestedRef.ownerHandle) {
         const trackedRef = lockedOwnerHandle ? `@${lockedOwnerHandle}/${trackedSlug}` : trackedSlug;
         return {
@@ -1173,14 +1185,17 @@ export async function resolveClawHubSkillVerificationTarget(params: {
         : tag
           ? "tag"
           : "installed-version";
+      // The stored skills.sh reference already identifies the approved commit.
+      // Adding a version or tag makes the ClawHub verification request invalid.
+      const usesExactReference = Boolean(lockedRequestedReference);
       return {
         ok: true,
         slug: trackedSlug,
         ...(lockedOwnerHandle ? { ownerHandle: lockedOwnerHandle } : {}),
         ...(lockedRequestedReference ? { requestedReference: lockedRequestedReference } : {}),
         baseUrl: lockedRegistry,
-        version: version ?? (tag ? undefined : locked.version),
-        tag,
+        version: usesExactReference ? undefined : (version ?? (tag ? undefined : locked.version)),
+        tag: usesExactReference ? undefined : tag,
         resolution: {
           source: "installed",
           selector,

--- a/src/skills/lifecycle/clawhub.ts
+++ b/src/skills/lifecycle/clawhub.ts
@@ -76,6 +76,7 @@ type ClawHubSkillLockEntry = {
   installedAt: number;
   registry?: string;
   ownerHandle?: string;
+  requestedReference?: string;
   sourceUrl?: string;
   artifact?: ClawHubSkillDownloadedArtifactLock;
   skillFile?: ClawHubSkillFileLock;
@@ -88,6 +89,7 @@ type ClawHubSkillOrigin = {
   registry: string;
   slug: string;
   ownerHandle?: string;
+  requestedReference?: string;
   installedVersion: string;
   installedAt: number;
   sourceUrl?: string;
@@ -113,6 +115,7 @@ export type ClawHubSkillStatusLink =
       registry: string;
       slug: string;
       ownerHandle?: string;
+      requestedReference?: string;
       installedVersion: string;
       installedAt: number;
       originPath: string;
@@ -176,9 +179,12 @@ type Logger = {
 type ClawHubSkillRef = {
   slug: string;
   ownerHandle?: string;
+  requestedReference?: string;
 };
 
 const CLAWHUB_OWNER_HANDLE_PATTERN = /^[a-z0-9](?:[a-z0-9._-]{0,38}[a-z0-9])?$/;
+const GITHUB_OWNER_PATTERN = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/;
+const GITHUB_REPO_PATTERN = /^[A-Za-z0-9._-]{1,100}$/;
 
 function normalizeClawHubOwnerHandle(raw: string): string {
   const ownerHandle = raw.trim().toLowerCase();
@@ -190,6 +196,31 @@ function normalizeClawHubOwnerHandle(raw: string): string {
 
 function parseRequestedClawHubSkillRef(raw: string): ClawHubSkillRef {
   const value = raw.trim();
+  if (value.startsWith("skills-sh:")) {
+    throw new Error(`Invalid skills.sh skill reference: ${raw}`);
+  }
+  if (value.startsWith("skills-sh/")) {
+    const parts = value.slice("skills-sh/".length).split("/");
+    if (parts.length !== 3) {
+      throw new Error(`Invalid skills.sh skill reference: ${raw}`);
+    }
+    const [owner, repo, slug] = parts;
+    if (
+      !owner ||
+      !repo ||
+      !slug ||
+      !GITHUB_OWNER_PATTERN.test(owner) ||
+      !GITHUB_REPO_PATTERN.test(repo) ||
+      repo === "." ||
+      repo === ".."
+    ) {
+      throw new Error(`Invalid skills.sh skill reference: ${raw}`);
+    }
+    return {
+      slug: validateRequestedSkillSlug(slug),
+      requestedReference: value,
+    };
+  }
   if (!value.startsWith("@")) {
     return { slug: validateRequestedSkillSlug(value) };
   }
@@ -217,9 +248,10 @@ async function resolveRequestedUpdateSlug(params: {
   lock: ClawHubSkillsLockfile;
 }): Promise<string> {
   const requested = params.requestedSlug.trim();
-  const requestedRef = requested.startsWith("@")
-    ? parseRequestedClawHubSkillRef(requested)
-    : { slug: normalizeTrackedSkillSlug(requested) };
+  const requestedRef =
+    requested.startsWith("@") || requested.startsWith("skills-sh/")
+      ? parseRequestedClawHubSkillRef(requested)
+      : { slug: normalizeTrackedSkillSlug(requested) };
   const trackedSlug = requestedRef.slug;
   const trackedTargetDir = resolveWorkspaceSkillInstallDir(params.workspaceDir, trackedSlug);
   const trackedOrigin = await readClawHubSkillOrigin(trackedTargetDir);
@@ -232,6 +264,16 @@ async function resolveRequestedUpdateSlug(params: {
         `Skill "${trackedSlug}" is tracked as ${trackedRef}, not @${requestedRef.ownerHandle}/${trackedSlug}.`,
       );
     }
+    const trackedRequestedReference =
+      trackedOrigin?.requestedReference ?? trackedLockEntry?.requestedReference;
+    if (
+      requestedRef.requestedReference &&
+      trackedRequestedReference !== requestedRef.requestedReference
+    ) {
+      throw new Error(
+        `Skill "${trackedSlug}" is not tracked from ${requestedRef.requestedReference}.`,
+      );
+    }
     return trackedSlug;
   }
   return validateRequestedSkillSlug(requestedRef.slug);
@@ -241,6 +283,7 @@ type ClawHubInstallParams = {
   workspaceDir: string;
   slug: string;
   ownerHandle?: string;
+  requestedReference?: string;
   version?: string;
   expectedIntegrity?: string;
   baseUrl?: string;
@@ -337,6 +380,7 @@ type TrackedUpdateTarget =
       ok: true;
       slug: string;
       ownerHandle?: string;
+      requestedReference?: string;
       baseUrl?: string;
       previousVersion: string | null;
     }
@@ -354,6 +398,7 @@ type ClawHubSkillVerificationTargetResult =
       ok: true;
       slug: string;
       ownerHandle?: string;
+      requestedReference?: string;
       baseUrl: string;
       version: string | undefined;
       tag: string | undefined;
@@ -524,6 +569,7 @@ function snapshotClawHubSkillVerification(
 async function fetchInstallVerificationLock(params: {
   slug: string;
   ownerHandle?: string;
+  requestedReference?: string;
   version?: string;
   baseUrl?: string;
   logger?: Logger;
@@ -532,6 +578,7 @@ async function fetchInstallVerificationLock(params: {
     const verification = await fetchClawHubSkillVerification({
       slug: params.slug,
       ...(params.ownerHandle ? { ownerHandle: params.ownerHandle } : {}),
+      ...(params.requestedReference ? { requestedReference: params.requestedReference } : {}),
       version: params.version,
       baseUrl: params.baseUrl,
     });
@@ -669,6 +716,21 @@ function normalizeClawHubSkillOrigin(
         return null;
       }
     }
+    const requestedReferenceRaw = normalizeOptionalStringValue(
+      (raw as { requestedReference?: unknown }).requestedReference,
+    );
+    let requestedReference: string | undefined;
+    if (requestedReferenceRaw) {
+      try {
+        const parsed = parseRequestedClawHubSkillRef(requestedReferenceRaw);
+        if (!parsed.requestedReference || parsed.slug !== raw.slug) {
+          return null;
+        }
+        requestedReference = parsed.requestedReference;
+      } catch {
+        return null;
+      }
+    }
     const artifact = normalizeDownloadedArtifactLock((raw as { artifact?: unknown }).artifact);
     const skillFile = normalizeSkillFileLock((raw as { skillFile?: unknown }).skillFile);
     const fileTreeSha256 = normalizeOptionalStringValue(
@@ -679,6 +741,7 @@ function normalizeClawHubSkillOrigin(
       registry: normalizeStoredRegistry(raw.registry),
       slug: raw.slug,
       ...(ownerHandle ? { ownerHandle } : {}),
+      ...(requestedReference ? { requestedReference } : {}),
       installedVersion: raw.installedVersion,
       installedAt: raw.installedAt,
       ...(sourceUrl ? { sourceUrl } : {}),
@@ -898,11 +961,13 @@ export function resolveClawHubSkillStatusLinkSync(params: {
     locked.registry === undefined ? originRegistry : normalizeStoredRegistry(locked.registry);
   const lockedSourceUrl = normalizeOptionalStringValue(locked.sourceUrl);
   const lockedOwnerHandle = normalizeOptionalStringValue(locked.ownerHandle);
+  const lockedRequestedReference = normalizeOptionalStringValue(locked.requestedReference);
   const lockedArtifact = normalizeDownloadedArtifactLock(locked.artifact);
   const lockedSkillFile = normalizeSkillFileLock(locked.skillFile);
   const lockedFileTreeSha256 = normalizeOptionalStringValue(locked.fileTreeSha256);
   const provenanceMatches =
     originRead.origin.ownerHandle === lockedOwnerHandle &&
+    originRead.origin.requestedReference === lockedRequestedReference &&
     originRead.origin.sourceUrl === lockedSourceUrl &&
     originRead.origin.artifact?.kind === lockedArtifact?.kind &&
     originRead.origin.artifact?.sha256 === lockedArtifact?.sha256 &&
@@ -936,6 +1001,7 @@ export function resolveClawHubSkillStatusLinkSync(params: {
     registry: lockedRegistry,
     slug: trackedSlug,
     ...(lockedOwnerHandle ? { ownerHandle: lockedOwnerHandle } : {}),
+    ...(lockedRequestedReference ? { requestedReference: lockedRequestedReference } : {}),
     installedVersion: locked.version,
     installedAt: locked.installedAt,
     originPath: originRead.path,
@@ -1082,11 +1148,13 @@ export async function resolveClawHubSkillVerificationTarget(params: {
       const lockedRegistry =
         locked.registry === undefined ? originRegistry : normalizeStoredRegistry(locked.registry);
       const lockedOwnerHandle = normalizeOptionalStringValue(locked.ownerHandle);
+      const lockedRequestedReference = normalizeOptionalStringValue(locked.requestedReference);
       if (
         locked.version !== originRead.origin.installedVersion ||
         locked.installedAt !== originRead.origin.installedAt ||
         lockedRegistry !== originRegistry ||
-        originRead.origin.ownerHandle !== lockedOwnerHandle
+        originRead.origin.ownerHandle !== lockedOwnerHandle ||
+        originRead.origin.requestedReference !== lockedRequestedReference
       ) {
         return {
           ok: false,
@@ -1109,6 +1177,7 @@ export async function resolveClawHubSkillVerificationTarget(params: {
         ok: true,
         slug: trackedSlug,
         ...(lockedOwnerHandle ? { ownerHandle: lockedOwnerHandle } : {}),
+        ...(lockedRequestedReference ? { requestedReference: lockedRequestedReference } : {}),
         baseUrl: lockedRegistry,
         version: version ?? (tag ? undefined : locked.version),
         tag,
@@ -1142,6 +1211,9 @@ export async function resolveClawHubSkillVerificationTarget(params: {
       ok: true,
       slug: requestedRef.slug,
       ...(requestedRef.ownerHandle ? { ownerHandle: requestedRef.ownerHandle } : {}),
+      ...(requestedRef.requestedReference
+        ? { requestedReference: requestedRef.requestedReference }
+        : {}),
       baseUrl: registry,
       version,
       tag,
@@ -1252,6 +1324,7 @@ async function installGitHubResolution(params: {
   authority: "official" | "third-party";
   repo: string;
   commit: string;
+  requestedReference?: string;
   force?: boolean;
   logger?: Logger;
   config?: OpenClawConfig;
@@ -1286,7 +1359,9 @@ async function installGitHubResolution(params: {
             mutable: false,
             network: true,
           },
-          requestedSpecifier: `clawhub:${formatClawHubSkillRef(params)}@${params.commit}`,
+          requestedSpecifier:
+            params.requestedReference ??
+            `clawhub:${formatClawHubSkillRef(params)}@${params.commit}`,
         },
         rootMarkers: CLAWHUB_SKILL_ARCHIVE_ROOT_MARKERS,
       }),
@@ -1409,10 +1484,14 @@ async function performClawHubSkillInstall(
         await fetchClawHubSkillInstallResolution({
           slug: params.slug,
           ...(params.ownerHandle ? { ownerHandle: params.ownerHandle } : {}),
+          ...(params.requestedReference ? { requestedReference: params.requestedReference } : {}),
           baseUrl: params.baseUrl,
           ...(params.forceInstall ? { forceInstall: true } : {}),
         }),
       );
+      if (params.requestedReference && latestResolution.installKind !== "github") {
+        throw new Error(`Skill "${params.slug}" did not resolve to a commit-pinned GitHub source.`);
+      }
       const resolutionOfficialClawHubSkill = isDefaultOfficialClawHubSkillSource({
         baseUrl: params.baseUrl,
         resolution: latestResolution,
@@ -1479,6 +1558,7 @@ async function performClawHubSkillInstall(
                 authority: officialClawHubSkill ? "official" : "third-party",
                 repo: latestResolution.github.repo,
                 commit: latestResolution.github.commit,
+                requestedReference: params.requestedReference,
                 force: params.force,
                 logger: params.logger,
                 config: params.config,
@@ -1523,6 +1603,7 @@ async function performClawHubSkillInstall(
         fetchInstallVerificationLock({
           slug: params.slug,
           ...(params.ownerHandle ? { ownerHandle: params.ownerHandle } : {}),
+          ...(params.requestedReference ? { requestedReference: params.requestedReference } : {}),
           version: verificationVersion,
           baseUrl: params.baseUrl,
           logger: params.logger,
@@ -1536,6 +1617,7 @@ async function performClawHubSkillInstall(
         registry: resolveClawHubBaseUrl(params.baseUrl),
         slug: params.slug,
         ...(params.ownerHandle ? { ownerHandle: params.ownerHandle } : {}),
+        ...(params.requestedReference ? { requestedReference: params.requestedReference } : {}),
         installedVersion: version,
         installedAt,
         ...(sourceUrl ? { sourceUrl } : {}),
@@ -1549,6 +1631,7 @@ async function performClawHubSkillInstall(
         installedAt,
         registry: resolveClawHubBaseUrl(params.baseUrl),
         ...(params.ownerHandle ? { ownerHandle: params.ownerHandle } : {}),
+        ...(params.requestedReference ? { requestedReference: params.requestedReference } : {}),
         ...(sourceUrl ? { sourceUrl } : {}),
         artifact,
         ...(skillFile ? { skillFile } : {}),
@@ -1570,6 +1653,7 @@ async function performClawHubSkillInstall(
         slug: params.slug,
         ...(params.ownerHandle ? { ownerHandle: params.ownerHandle } : {}),
         version,
+        ...(params.requestedReference ? { requestedReference: params.requestedReference } : {}),
       }).catch(() => undefined);
 
       return {
@@ -1596,10 +1680,14 @@ async function installRequestedSkillFromClawHub(
 ): Promise<InstallClawHubSkillResult> {
   try {
     const ref = parseRequestedClawHubSkillRef(params.slug);
+    if (ref.requestedReference && params.version) {
+      throw new Error("--version is not supported for skills-sh references.");
+    }
     return await performClawHubSkillInstall({
       ...params,
       slug: ref.slug,
       ...(ref.ownerHandle ? { ownerHandle: ref.ownerHandle } : {}),
+      ...(ref.requestedReference ? { requestedReference: ref.requestedReference } : {}),
     });
   } catch (err) {
     return {
@@ -1768,10 +1856,12 @@ async function resolveTrackedUpdateTarget(params: {
   }
   const lockEntry = params.lock.skills[params.slug];
   const ownerHandle = origin?.ownerHandle ?? lockEntry?.ownerHandle;
+  const requestedReference = origin?.requestedReference ?? lockEntry?.requestedReference;
   return {
     ok: true,
     slug: params.slug,
     ...(ownerHandle ? { ownerHandle } : {}),
+    ...(requestedReference ? { requestedReference } : {}),
     baseUrl: origin?.registry ?? params.baseUrl,
     previousVersion: origin?.installedVersion ?? lockEntry?.version ?? null,
   };
@@ -1853,6 +1943,7 @@ export async function updateSkillsFromClawHub(params: {
           workspaceDir: params.workspaceDir,
           slug: tracked.slug,
           ...(tracked.ownerHandle ? { ownerHandle: tracked.ownerHandle } : {}),
+          ...(tracked.requestedReference ? { requestedReference: tracked.requestedReference } : {}),
           baseUrl: tracked.baseUrl,
           force: true,
           forceInstall: params.forceInstall,


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where users could discover approved skills.sh catalog entries through ClawHub but could not install them with a distinct managed CLI reference after the previous colon syntax was reverted.

## Why This Change Was Made

Adds `skills-sh/owner/repo/slug` as the only skills.sh install syntax, resolves it through ClawHub to a security-approved commit-pinned GitHub descriptor, and preserves the original reference through install, update, verification, lock state, and telemetry. The reverted `skills-sh:owner/repo/slug` syntax is explicitly rejected; direct unmanaged GitHub installs remain under `git:`.

Verification treats the persisted skills.sh reference as the exact approved artifact identity. It omits redundant version/tag selectors from ClawHub verification requests and rejects explicit selectors for skills.sh references, preventing an otherwise valid direct or installed-skill verification from returning HTTP 400.

Normal skill search results also render ClawHub-provided skills.sh install references alongside native ClawHub skills. OpenClaw never fetches content from skills.sh directly.

## User Impact

Users can install approved skills.sh catalog entries with:

```text
openclaw skills install skills-sh/owner/repo/slug
```

Native ClawHub references remain `@owner/slug`, while `git:` continues to mean a direct unmanaged GitHub install.

## Evidence

- `node scripts/run-vitest.mjs src/skills/lifecycle/clawhub.test.ts` - 90 passed
- `node scripts/run-vitest.mjs src/cli/skills-cli.verify.test.ts` - 7 passed
- `node scripts/run-vitest.mjs src/infra/clawhub.test.ts` - 88 passed
- `node scripts/run-vitest.mjs src/cli/skills-cli.commands.test.ts` - 68 passed
- `pnpm docs:list` - passed
- `node scripts/check-changed.mjs` - passed on Blacksmith Testbox, including formatting, core/core-test typecheck, lint, import-cycle, and state guards
- `autoreview --mode uncommitted` - clean, no accepted/actionable findings
- Exact-head CI run `29907149519` - green, including `openclaw/ci-gate`, dependency guard, and security-sensitive guard
- Permanent Test proof on exact head `f2d9247653e1e76434728e85128bafc38f47f672`: isolated install, direct `skills-sh/patrick-erichsen/skills/html` verification, and installed bare-slug `html` verification all passed against the approved commit-pinned artifact
- Explicit negative tests cover the reverted `skills-sh:` syntax and prevent network access

AI-assisted: Codex implementation and review; author has inspected the resulting code and tests.