### PR TITLE
fix(process): prevent gateway crash after Claude CLI auth-profile turns

### DIFF
--- a/src/process/spawn-secret-input.test.ts
+++ b/src/process/spawn-secret-input.test.ts
@@ -1,0 +1,61 @@
+import type { ChildProcess } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { describe, expect, it } from "vitest";
+import { writeSecretInputToChild } from "./spawn-secret-input.js";
+
+class ControlledSecretStream extends EventEmitter {
+  private endCallback: ((error?: Error | null) => void) | undefined;
+
+  end(_data: Buffer, callback?: (error?: Error | null) => void): this {
+    this.endCallback = callback;
+    return this;
+  }
+
+  finishWrite(error?: Error): void {
+    if (!this.endCallback) {
+      throw new Error("secret write callback was not registered");
+    }
+    this.endCallback(error);
+  }
+}
+
+function childWithSecretStream(stream: ControlledSecretStream): ChildProcess {
+  return { stdio: [null, null, null, stream] } as unknown as ChildProcess;
+}
+
+function writeSecret(stream: ControlledSecretStream): Promise<void> {
+  return writeSecretInputToChild(childWithSecretStream(stream), {
+    fd: 3,
+    createData: () => Buffer.from("selected-secret"),
+  });
+}
+
+describe("writeSecretInputToChild", () => {
+  it("consumes pipe errors after delivery until the stream closes", async () => {
+    const stream = new ControlledSecretStream();
+    const write = writeSecret(stream);
+
+    stream.finishWrite();
+    await expect(write).resolves.toBeUndefined();
+
+    const reset = Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" });
+    expect(() => stream.emit("error", reset)).not.toThrow();
+    expect(stream.listenerCount("error")).toBe(1);
+
+    stream.emit("close");
+    expect(stream.listenerCount("error")).toBe(0);
+  });
+
+  it("rejects delivery errors before consuming their later stream event", async () => {
+    const stream = new ControlledSecretStream();
+    const write = writeSecret(stream);
+    const deliveryError = new Error("secret delivery failed");
+
+    stream.finishWrite(deliveryError);
+    await expect(write).rejects.toBe(deliveryError);
+    expect(() => stream.emit("error", deliveryError)).not.toThrow();
+
+    stream.emit("close");
+    expect(stream.listenerCount("error")).toBe(0);
+  });
+});

--- a/src/process/spawn-secret-input.ts
+++ b/src/process/spawn-secret-input.ts
@@ -37,15 +37,28 @@ export async function writeSecretInputToChild(
     // End the parent pipe immediately after delivery so descendants cannot
     // inherit a still-readable credential stream.
     await new Promise<void>((resolve, reject) => {
-      const onError = (error: Error) => {
-        stream.off("error", onError);
-        reject(error);
+      let settled = false;
+      const settle = (error?: Error | null) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        if (error) {
+          reject(error);
+        } else {
+          resolve();
+        }
       };
-      stream.once("error", onError);
-      stream.end(data, () => {
+      const onError = (error: Error) => {
+        settle(error);
+      };
+      // A child-process pipe can emit its terminal error after end's callback.
+      // Keep it handled until close while only the first outcome settles delivery.
+      stream.on("error", onError);
+      stream.once("close", () => {
         stream.off("error", onError);
-        resolve();
       });
+      stream.end(data, settle);
     });
   } finally {
     data?.fill(0);


### PR DESCRIPTION
Closes #112549

## What Problem This Solves

Fixes an issue where users running Claude CLI turns with a selected auth profile could have the Gateway exit after the turn completed when the fd 3 credential pipe reported a late connection reset.

## Why This Change Was Made

The shared secret-input writer now keeps the pipe error listener attached through `close` while settling credential delivery only once. This consumes terminal errors that arrive after the write callback, but still rejects errors reported before delivery; both the supervisor and node-host Claude paths inherit the same lifecycle fix without provider-specific handling.

## User Impact

Claude CLI auth-profile turns can complete without taking down the Gateway when the child closes its credential pipe. Genuine credential-delivery failures still fail the child launch instead of being hidden.

## Evidence

- Linux Blacksmith Testbox `tbx_01ky47k5yjtnjgfw0xceyb18jv`, [Actions run 29896343501](https://github.com/openclaw/openclaw/actions/runs/29896343501): the new regression test failed before the fix on both lifecycle assertions (late `ECONNRESET` was unhandled; callback delivery error resolved as success), then passed after the fix.
- Focused Linux proof: `pnpm test src/process/spawn-secret-input.test.ts src/process/supervisor/adapters/child.test.ts src/node-host/invoke-agent-cli-claude.test.ts` — 53 tests passed across 3 Vitest shards.
- Changed gate: `pnpm check:changed` — formatting, core/core-test typecheck, lint, and boundary/runtime guards passed.
- `git diff --check` passed.
- Fresh `autoreview --mode uncommitted --stream-engine-output` completed with no accepted/actionable findings (0.96 confidence).
- Redacted production observation: two consecutive selected-profile turns crashed with the reported signature before a temporary compiled mitigation retained the listener through close; the mitigation then completed the exact Gateway marker path with zero restarts. This PR neither depends on nor modifies that temporary artifact.

AI-assisted; I reviewed the stream lifecycle, both shared callers, Node 24.15 writable/destroy ordering, and the resulting patch.
