### PR TITLE
feat(ui): teach the working claw three new rare tricks

### DIFF
--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -1674,6 +1674,9 @@ describe("grouped chat rendering", () => {
         "chat-reading-indicator--spin",
         "chat-reading-indicator--shadowbox",
         "chat-reading-indicator--backflip",
+        "chat-reading-indicator--zen",
+        "chat-reading-indicator--drummer",
+        "chat-reading-indicator--peekaboo",
       ]).toContain(cls);
     }
   });

--- a/ui/src/pages/chat/components/chat-working-indicator.ts
+++ b/ui/src/pages/chat/components/chat-working-indicator.ts
@@ -12,12 +12,15 @@ import type { ChatRunStartupPhase } from "../chat-run-startup.ts";
 // The default stance just claws in place; the busier stances stay rare on purpose.
 const STANCE_SALT = Math.trunc(Math.random() * 0xffffffff);
 const STANCES: Array<[stance: string, weight: number]> = [
-  ["", 66],
-  ["chat-reading-indicator--southpaw", 20],
+  ["", 63],
+  ["chat-reading-indicator--southpaw", 19],
   ["chat-reading-indicator--flurry", 5],
   ["chat-reading-indicator--spin", 4],
   ["chat-reading-indicator--shadowbox", 3],
   ["chat-reading-indicator--backflip", 2],
+  ["chat-reading-indicator--zen", 2],
+  ["chat-reading-indicator--drummer", 1],
+  ["chat-reading-indicator--peekaboo", 1],
 ];
 const STARTUP_STATUS_LABEL_KEYS = {
   preparing_workspace: "chat.startupStatus.preparingWorkspace",

--- a/ui/src/styles/chat/tool-cards.css
+++ b/ui/src/styles/chat/tool-cards.css
@@ -1371,8 +1371,10 @@
 /* Seeded stance variants (see stanceClass in chat-working-indicator.ts): the
    southpaw claws mirrored, the flurry snips double-time, the spin does a
    fake-3D turntable revolve while snipping, the shadowbox brings back the
-   full jab-jab-cross combo with the pow star, and the rarest backflip throws
-   a single in-place somersault per cycle. */
+   full jab-jab-cross combo with the pow star, the backflip throws a single
+   in-place somersault, the zen breathes through one long meditative snip,
+   the drummer rocks a two-beat rhythm, and the rarest peekaboo ducks away
+   and pops back wide open. */
 .chat-reading-indicator--southpaw {
   transform: scaleX(-1);
 }
@@ -1402,6 +1404,39 @@
 
 .chat-reading-indicator--backflip svg {
   animation-name: chatWorkingClawBackflip;
+}
+
+.chat-reading-indicator--zen {
+  --claw-cycle: 6s;
+}
+
+.chat-reading-indicator--zen svg {
+  animation-name: chatWorkingClawZenBreath;
+  animation-timing-function: ease-in-out;
+}
+
+.chat-reading-indicator--zen svg .claw-icon__jaw {
+  animation-name: chatWorkingClawZenSnip;
+}
+
+.chat-reading-indicator--drummer {
+  --claw-cycle: 1.2s;
+}
+
+.chat-reading-indicator--drummer svg {
+  animation-name: chatWorkingClawDrumRock;
+}
+
+.chat-reading-indicator--drummer svg .claw-icon__jaw {
+  animation-name: chatWorkingClawDrumHit;
+}
+
+.chat-reading-indicator--peekaboo svg {
+  animation-name: chatWorkingClawPeekaboo;
+}
+
+.chat-reading-indicator--peekaboo svg .claw-icon__jaw {
+  animation-name: chatWorkingClawPeekabooJaw;
 }
 
 @keyframes chatWorkingClawSpin {
@@ -1434,6 +1469,143 @@
   78%,
   100% {
     transform: translateY(0) rotate(-360deg);
+  }
+}
+
+/* Zen: one long meditative cycle — a slow scale breath, then a single
+   deliberate snip on the exhale. Scale keeps it perfectly in place. */
+@keyframes chatWorkingClawZenBreath {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+
+  30% {
+    transform: scale(1.08);
+  }
+
+  55% {
+    transform: scale(1);
+  }
+}
+
+@keyframes chatWorkingClawZenSnip {
+  0%,
+  60% {
+    transform: rotate(-10deg);
+  }
+
+  70% {
+    transform: rotate(-24deg);
+  }
+
+  76% {
+    transform: rotate(2deg);
+  }
+
+  86%,
+  100% {
+    transform: rotate(-10deg);
+  }
+}
+
+/* Drummer: two-beat rock — the body tilts left then right and the jaw hits
+   on each tilt peak. Rotation only, no travel. */
+@keyframes chatWorkingClawDrumRock {
+  0%,
+  100% {
+    transform: rotate(0deg);
+  }
+
+  15% {
+    transform: rotate(-8deg);
+  }
+
+  30% {
+    transform: rotate(0deg);
+  }
+
+  55% {
+    transform: rotate(8deg);
+  }
+
+  70% {
+    transform: rotate(0deg);
+  }
+}
+
+@keyframes chatWorkingClawDrumHit {
+  0%,
+  100% {
+    transform: rotate(-10deg);
+  }
+
+  10% {
+    transform: rotate(-20deg);
+  }
+
+  15% {
+    transform: rotate(2deg);
+  }
+
+  25% {
+    transform: rotate(-10deg);
+  }
+
+  50% {
+    transform: rotate(-20deg);
+  }
+
+  55% {
+    transform: rotate(2deg);
+  }
+
+  65% {
+    transform: rotate(-10deg);
+  }
+}
+
+/* Peekaboo: long rest, duck down small with the jaw tucked, hold a beat,
+   then pop back up wide open. Vertical dip only — no lateral travel. */
+@keyframes chatWorkingClawPeekaboo {
+  0%,
+  55% {
+    transform: translateY(0) scale(1);
+  }
+
+  62%,
+  72% {
+    transform: translateY(5px) scale(0.72);
+  }
+
+  78% {
+    transform: translateY(-1.5px) scale(1.06);
+  }
+
+  84%,
+  100% {
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes chatWorkingClawPeekabooJaw {
+  0%,
+  55% {
+    transform: rotate(-10deg);
+  }
+
+  62%,
+  72% {
+    transform: rotate(-2deg);
+  }
+
+  78% {
+    transform: rotate(-28deg);
+  }
+
+  86%,
+  100% {
+    transform: rotate(-10deg);
   }
 }
 


### PR DESCRIPTION
## What Problem This Solves

The working claw's rare-stance roster (#112060) had three parked ideas — the maintainer asked for more tricks.

## Why This Change Was Made

Three new seeded stances, all strictly in place (scale/rotate/vertical only, no lateral travel):

- **zen (2%)** — a 6s meditative cycle: slow scale breath (1.0 → 1.08 → 1.0), then one deliberate snip on the exhale.
- **drummer (1%)** — a 1.2s two-beat rhythm: body rocks ±8° with a jaw hit on each tilt peak.
- **peekaboo (1%)** — rests, ducks down small (0.72×, tucked jaw), holds a beat, then pops back up wide open (-28° jaw, 1.06×).

Weights rebalance from the calm stances only: default 66→63, southpaw 20→19; the existing rare stances are untouched. Reduced motion continues to disable all stance animations via the existing base-selector media block.

## User Impact

Three more rare surprises while the model works, in the Control UI chat. Native ports (shared SwiftUI + Compose) follow in companion PRs.

## Evidence

- `chat-message.test.ts` green on Blacksmith Testbox (stance allowlist extended; seeding invariants unchanged).
- Structured Codex autoreview: clean first pass ("weights remain normalized to 100 … each added class has matching animation definitions").
- Motion verified programmatically in the browser harness: zen is a pure scale matrix (1.08 breath, jaw -24° at the 70% snip), drummer ±8° rotation with +2° jaw snaps on the beats, peekaboo translateY +5/scale 0.72 duck → -1.5/1.06 pop with the jaw at -28° — zero translateX in every sampled frame.

## Pictures

![all nine stances plus status rows](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/2026-07-claw-more-tricks/claw-tricks.gif)

<details><summary>Still frame</summary>

![still](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/2026-07-claw-more-tricks/claw-tricks-still.png)

</details>
