### PR TITLE
fix(synology-chat): chunk long replies to avoid "msg too long" rejection (#112041)

### DIFF
--- a/extensions/synology-chat/src/channel.ts
+++ b/extensions/synology-chat/src/channel.ts
@@ -52,11 +52,14 @@ import {
   synologyChatSetupContract,
   synologyChatSetupWizard,
 } from "./setup-surface.js";
+import {
+  chunkSynologyChatText,
+  SYNOLOGY_CHAT_TEXT_CHUNK_LIMIT,
+  SYNOLOGY_MARKDOWN_LINK_RE,
+} from "./text-chunking.js";
 import type { ResolvedSynologyChatAccount } from "./types.js";
 
 const CHANNEL_ID = "synology-chat";
-const SYNOLOGY_MARKDOWN_LINK_RE =
-  /(?<!!)\[((?:\\[^\n]|[^\\\]\n])+)\]\((https?:\/\/(?:\\[^\n]|[^()\s<>\\])+(?:\((?:\\[^\n]|[^()\s<>\\])*\)(?:\\[^\n]|[^()\s<>\\])*)*)(?:\s+(?:"[^"\n]*"|'[^'\n]*'|\([^()\n]*\)))?\)/g;
 
 const resolveSynologyChatDmPolicy = createScopedDmSecurityResolver<ResolvedSynologyChatAccount>({
   channelKey: CHANNEL_ID,
@@ -191,6 +194,7 @@ type SynologyChatPlugin = Omit<
   };
   outbound: {
     deliveryMode: "gateway";
+    chunker: NonNullable<ChannelOutboundAdapter["chunker"]>;
     textChunkLimit: number;
     sanitizeText: NonNullable<ChannelOutboundAdapter["sanitizeText"]>;
     sendText: (ctx: SynologyChannelSendTextContext) => Promise<SynologyChatOutboundResult>;
@@ -468,7 +472,8 @@ function createSynologyChatPlugin(): SynologyChatPlugin {
     },
     outbound: {
       deliveryMode: "gateway" as const,
-      textChunkLimit: 2000,
+      chunker: chunkSynologyChatText,
+      textChunkLimit: SYNOLOGY_CHAT_TEXT_CHUNK_LIMIT,
       sanitizeText: ({ text }) => sanitizeAssistantVisibleText(text),
       sendText: sendSynologyChatText,
       sendMedia: async (ctx) => {

--- a/extensions/synology-chat/src/client.loopback.test.ts
+++ b/extensions/synology-chat/src/client.loopback.test.ts
@@ -1,7 +1,12 @@
 import { once } from "node:events";
 import * as http from "node:http";
+import { sendTextMediaPayload } from "openclaw/plugin-sdk/reply-payload";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { synologyChatPlugin } from "./channel.js";
 import { resolveLegacyWebhookNameToChatUserId, sendMessage } from "./client.js";
+import type { SynologyInboundMessage } from "./inbound-context.js";
+import { dispatchSynologyChatInboundEvent } from "./inbound-event.js";
+import { setSynologyRuntime } from "./runtime.js";
 
 const USER_LIST_RESPONSE_MAX_BYTES = 1 * 1024 * 1024;
 
@@ -30,6 +35,140 @@ describe("Synology Chat user_list loopback", () => {
       server = undefined;
     }
   });
+
+  const chunkingCases = [
+    { name: "long unbroken text", text: "x".repeat(4_501), requests: 3, joiner: "" },
+    { name: "Unicode surrogate pairs", text: "😀".repeat(1_201), requests: 2, joiner: "" },
+    {
+      name: "Markdown and newline boundaries",
+      text: "Read [the documentation](https://example.com/guide).\n".repeat(90).trim(),
+      requests: 3,
+      joiner: " ",
+    },
+    { name: "short messages", text: "A short 😀 message.", requests: 1, joiner: "" },
+  ];
+
+  it.each(
+    chunkingCases.flatMap((entry) => [
+      { ...entry, delivery: "outbound" as const },
+      { ...entry, delivery: "inbound reply" as const },
+    ]),
+  )(
+    "delivers $name via $delivery within the Synology Chat payload limit",
+    async ({ text, requests, joiner, delivery }) => {
+      const receivedTexts: string[] = [];
+      const port = await listenLoopback((req, res) => {
+        let body = "";
+        req.setEncoding("utf8");
+        req.on("data", (chunk: string) => {
+          body += chunk;
+        });
+        req.on("end", () => {
+          const rawPayload = new URLSearchParams(body).get("payload");
+          const payload = JSON.parse(rawPayload ?? "{}") as {
+            text?: string;
+            user_ids?: number[];
+          };
+          const receivedText = payload.text ?? "";
+          receivedTexts.push(receivedText);
+          res.writeHead(200, { "Content-Type": "application/json" });
+          if (receivedText.length > 2_000) {
+            res.end(
+              JSON.stringify({ success: false, error: { code: 410, errors: "msg too long" } }),
+            );
+            return;
+          }
+          res.end(JSON.stringify({ success: true }));
+        });
+      });
+      const incomingUrl = `http://127.0.0.1:${port}/webapi/entry.cgi`;
+      const cfg = {
+        channels: {
+          "synology-chat": {
+            enabled: true,
+            token: "loopback-token",
+            incomingUrl,
+          },
+        },
+      };
+
+      if (delivery === "outbound") {
+        const result = await sendTextMediaPayload({
+          channel: "synology-chat",
+          ctx: { cfg, to: "42", payload: { text } },
+          adapter: synologyChatPlugin.outbound,
+        });
+        expect(result.channel).toBe("synology-chat");
+      } else {
+        const inboundRun = vi.fn(
+          async (params: {
+            raw: SynologyInboundMessage;
+            adapter: {
+              ingest: (raw: SynologyInboundMessage) => unknown;
+              resolveTurn: (
+                input: unknown,
+                admission: { kind: "message"; canStartAgentTurn: true },
+              ) => Promise<{
+                delivery: { deliver: (payload: { text: string }) => Promise<unknown> };
+              }>;
+            };
+          }) => {
+            const input = params.adapter.ingest(params.raw);
+            const resolved = await params.adapter.resolveTurn(input, {
+              kind: "message",
+              canStartAgentTurn: true,
+            });
+            return await resolved.delivery.deliver({ text });
+          },
+        );
+        setSynologyRuntime({
+          config: { current: () => cfg },
+          channel: {
+            routing: {
+              resolveAgentRoute: () => ({
+                agentId: "main",
+                accountId: "default",
+                sessionKey: "agent:main:synology-chat:default:direct:42",
+              }),
+            },
+            inbound: {
+              run: inboundRun,
+              buildContext: (context: unknown) => context,
+            },
+          },
+        } as unknown as Parameters<typeof setSynologyRuntime>[0]);
+        const account = synologyChatPlugin.config.resolveAccount(cfg, "default");
+        await dispatchSynologyChatInboundEvent({
+          account,
+          msg: {
+            body: "Trigger the reply",
+            from: "42",
+            chatUserId: "42",
+            senderName: "Loopback User",
+            provider: "synology-chat",
+            chatType: "direct",
+            accountId: "default",
+            commandAuthorized: true,
+          },
+        });
+        expect(inboundRun).toHaveBeenCalledOnce();
+      }
+
+      expect(receivedTexts).toHaveLength(requests);
+      for (const receivedText of receivedTexts) {
+        expect(receivedText.length).toBeLessThanOrEqual(2_000);
+        expect(receivedText).not.toMatch(/\p{Surrogate}/u);
+      }
+
+      const expectedWireText =
+        delivery === "outbound"
+          ? text.replace(/\[([^\]]+)\]\((https?:\/\/[^)]+)\)/g, "<$2|$1>")
+          : text;
+      expect(receivedTexts.join(joiner).replace(/\s+/g, " ")).toBe(
+        expectedWireText.replace(/\s+/g, " "),
+      );
+    },
+  );
 
   it("aborts a streamed overflow and returns the stale cached identity", async () => {
     let requestCount = 0;

--- a/extensions/synology-chat/src/client.loopback.test.ts
+++ b/extensions/synology-chat/src/client.loopback.test.ts
@@ -95,8 +95,17 @@ describe("Synology Chat user_list loopback", () => {
       if (delivery === "outbound") {
         const result = await sendTextMediaPayload({
           channel: "synology-chat",
-          ctx: { cfg, to: "42", payload: { text } },
-          adapter: synologyChatPlugin.outbound,
+          ctx: { cfg, to: "42", text, payload: { text } },
+          adapter: {
+            chunker: synologyChatPlugin.outbound.chunker,
+            textChunkLimit: synologyChatPlugin.outbound.textChunkLimit,
+            sendText: (sendContext) =>
+              synologyChatPlugin.outbound.sendText({
+                cfg: sendContext.cfg ?? cfg,
+                to: sendContext.to,
+                text: sendContext.text,
+              }),
+          },
         });
         expect(result.channel).toBe("synology-chat");
       } else {

--- a/extensions/synology-chat/src/inbound-event.test.ts
+++ b/extensions/synology-chat/src/inbound-event.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import {
+  chunkSynologyChatReply,
+  SYNOLOGY_CHAT_MAX_MESSAGE_CHARS,
+} from "./inbound-event.js";
+
+describe("chunkSynologyChatReply (#112041)", () => {
+  it("splits a reply over the Synology char limit into bounded chunks", () => {
+    const long = "word ".repeat(3000).trim();
+    const chunks = chunkSynologyChatReply(long);
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(SYNOLOGY_CHAT_MAX_MESSAGE_CHARS);
+      expect(chunk.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("keeps a reply within the limit as a single chunk", () => {
+    expect(chunkSynologyChatReply("hello world")).toEqual(["hello world"]);
+  });
+});

--- a/extensions/synology-chat/src/inbound-event.test.ts
+++ b/extensions/synology-chat/src/inbound-event.test.ts
@@ -1,21 +1,105 @@
 import { describe, expect, it } from "vitest";
-import {
-  chunkSynologyChatReply,
-  SYNOLOGY_CHAT_MAX_MESSAGE_CHARS,
-} from "./inbound-event.js";
+import { chunkSynologyChatText, SYNOLOGY_CHAT_TEXT_CHUNK_LIMIT } from "./text-chunking.js";
 
-describe("chunkSynologyChatReply (#112041)", () => {
+describe("chunkSynologyChatText (#112041)", () => {
   it("splits a reply over the Synology char limit into bounded chunks", () => {
-    const long = "word ".repeat(3000).trim();
-    const chunks = chunkSynologyChatReply(long);
+    const long = "word ".repeat(3_000).trim();
+    const chunks = chunkSynologyChatText(long);
+
     expect(chunks.length).toBeGreaterThan(1);
     for (const chunk of chunks) {
-      expect(chunk.length).toBeLessThanOrEqual(SYNOLOGY_CHAT_MAX_MESSAGE_CHARS);
+      expect(chunk.length).toBeLessThanOrEqual(SYNOLOGY_CHAT_TEXT_CHUNK_LIMIT);
       expect(chunk.length).toBeGreaterThan(0);
     }
   });
 
   it("keeps a reply within the limit as a single chunk", () => {
-    expect(chunkSynologyChatReply("hello world")).toEqual(["hello world"]);
+    expect(chunkSynologyChatText("hello world")).toEqual(["hello world"]);
+  });
+
+  it("keeps Markdown links whole at chunk boundaries", () => {
+    const link = "[the Synology Chat documentation](https://example.com/synology-chat)";
+    const chunks = chunkSynologyChatText(`${"x".repeat(1_980)} ${link}`);
+
+    expect(chunks).toHaveLength(2);
+    expect(chunks[1]).toBe(link);
+  });
+
+  it("keeps a link whole when the following prose fills another chunk", () => {
+    const link = "[the Synology Chat documentation](https://example.com/synology-chat)";
+    const chunks = chunkSynologyChatText(
+      `${"x".repeat(1_980)} ${link} ${"following prose ".repeat(180)}`,
+    );
+
+    expect(chunks.some((chunk) => chunk.includes(link))).toBe(true);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(SYNOLOGY_CHAT_TEXT_CHUNK_LIMIT);
+    }
+  });
+
+  it("keeps a link destination whole when no preceding whitespace exists", () => {
+    const link = "[documentation](https://example.com/synology-chat/long-link)";
+    const chunks = chunkSynologyChatText(`${"x".repeat(1_990)}${link}`);
+
+    expect(chunks).toHaveLength(2);
+    expect(chunks[1]).toBe(link);
+  });
+
+  it("keeps a link whole before an oversized unbroken suffix", () => {
+    const link = "[the Synology Chat documentation](https://example.com/synology-chat)";
+    const chunks = chunkSynologyChatText(`${link}${"x".repeat(2_500)}`);
+
+    expect(chunks[0]).toBe(link);
+    expect(chunks.join("")).toBe(`${link}${"x".repeat(2_500)}`);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(SYNOLOGY_CHAT_TEXT_CHUNK_LIMIT);
+    }
+  });
+
+  it("keeps an escaped link with the backslash that prevents rendering", () => {
+    const escapedLink = "\\[escaped](https://example.com)";
+    const chunks = chunkSynologyChatText(`${"x".repeat(1_970)}${escapedLink}`);
+
+    expect(chunks.some((chunk) => chunk.includes(escapedLink))).toBe(true);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(SYNOLOGY_CHAT_TEXT_CHUNK_LIMIT);
+    }
+  });
+
+  it("preserves inline-code context around a literal link", () => {
+    const link = "[literal](https://example.com)";
+    const chunks = chunkSynologyChatText(`\`${"x".repeat(1_999)}${link}\``);
+    const literalChunk = chunks.find((chunk) => chunk.includes(link));
+
+    expect(literalChunk).toBeDefined();
+    expect(literalChunk).toMatch(/^`[\s\S]*`$/);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(SYNOLOGY_CHAT_TEXT_CHUNK_LIMIT);
+    }
+  });
+
+  it("preserves long inline code with a three-backtick delimiter", () => {
+    const link = "[literal](https://example.com)";
+    const code = "```" + "x".repeat(1_999) + link + "```";
+    const chunks = chunkSynologyChatText(code);
+    const literalChunk = chunks.find((chunk) => chunk.includes(link));
+
+    expect(literalChunk).toBeDefined();
+    expect(literalChunk).toMatch(/^```[\s\S]*```$/);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(SYNOLOGY_CHAT_TEXT_CHUNK_LIMIT);
+    }
+  });
+
+  it("closes and reopens oversized fenced code blocks", () => {
+    const code = "const answer = 42;\n".repeat(180);
+    const chunks = chunkSynologyChatText(`\`\`\`ts\n${code}\`\`\``);
+
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(SYNOLOGY_CHAT_TEXT_CHUNK_LIMIT);
+      expect(chunk).toMatch(/^```ts\n/);
+      expect(chunk).toMatch(/\n```$/);
+    }
   });
 });

--- a/extensions/synology-chat/src/inbound-event.ts
+++ b/extensions/synology-chat/src/inbound-event.ts
@@ -1,5 +1,6 @@
 // Synology Chat plugin module implements inbound event behavior.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { chunkTextForOutbound } from "openclaw/plugin-sdk/text-chunking";
 import { sendMessage } from "./client.js";
 import type { SynologyInboundMessage } from "./inbound-context.js";
 import { getSynologyRuntime } from "./runtime.js";
@@ -40,6 +41,16 @@ function resolveSynologyChatInboundRoute(params: {
   };
 }
 
+// Synology Chat rejects payloads over ~4000 chars ("msg too long"); keep a safety
+// margin and chunk longer replies into sequential messages the way the slack, twitch,
+// and sms channels already do, instead of dropping the whole reply.
+export const SYNOLOGY_CHAT_MAX_MESSAGE_CHARS = 3800;
+export const SYNOLOGY_CHAT_CHUNK_DELAY_MS = 1000;
+
+export function chunkSynologyChatReply(text: string): string[] {
+  return chunkTextForOutbound(text, SYNOLOGY_CHAT_MAX_MESSAGE_CHARS);
+}
+
 async function deliverSynologyChatReply(params: {
   account: ResolvedSynologyChatAccount;
   sendUserId: string;
@@ -49,13 +60,21 @@ async function deliverSynologyChatReply(params: {
   if (!text) {
     return { visibleReplySent: false };
   }
-  const ok = await sendMessage(
-    params.account.incomingUrl,
-    text,
-    params.sendUserId,
-    params.account.allowInsecureSsl,
-  );
-  return { visibleReplySent: ok };
+  const chunks = chunkSynologyChatReply(text);
+  let visibleReplySent = false;
+  for (let i = 0; i < chunks.length; i++) {
+    const ok = await sendMessage(
+      params.account.incomingUrl,
+      chunks[i],
+      params.sendUserId,
+      params.account.allowInsecureSsl,
+    );
+    visibleReplySent = visibleReplySent || ok;
+    if (i < chunks.length - 1) {
+      await new Promise((resolve) => setTimeout(resolve, SYNOLOGY_CHAT_CHUNK_DELAY_MS));
+    }
+  }
+  return { visibleReplySent };
 }
 
 export async function dispatchSynologyChatInboundEvent(params: {

--- a/extensions/synology-chat/src/inbound-event.ts
+++ b/extensions/synology-chat/src/inbound-event.ts
@@ -1,10 +1,10 @@
 // Synology Chat plugin module implements inbound event behavior.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { chunkTextForOutbound } from "openclaw/plugin-sdk/text-chunking";
 import { sendMessage } from "./client.js";
 import type { SynologyInboundMessage } from "./inbound-context.js";
 import { getSynologyRuntime } from "./runtime.js";
 import { buildSynologyChatInboundSessionKey } from "./session-key.js";
+import { chunkSynologyChatText } from "./text-chunking.js";
 import type { ResolvedSynologyChatAccount } from "./types.js";
 import type { SynologyIngressLifecycle } from "./webhook-ingress.js";
 
@@ -41,16 +41,6 @@ function resolveSynologyChatInboundRoute(params: {
   };
 }
 
-// Synology Chat rejects payloads over ~4000 chars ("msg too long"); keep a safety
-// margin and chunk longer replies into sequential messages the way the slack, twitch,
-// and sms channels already do, instead of dropping the whole reply.
-export const SYNOLOGY_CHAT_MAX_MESSAGE_CHARS = 3800;
-export const SYNOLOGY_CHAT_CHUNK_DELAY_MS = 1000;
-
-export function chunkSynologyChatReply(text: string): string[] {
-  return chunkTextForOutbound(text, SYNOLOGY_CHAT_MAX_MESSAGE_CHARS);
-}
-
 async function deliverSynologyChatReply(params: {
   account: ResolvedSynologyChatAccount;
   sendUserId: string;
@@ -60,21 +50,18 @@ async function deliverSynologyChatReply(params: {
   if (!text) {
     return { visibleReplySent: false };
   }
-  const chunks = chunkSynologyChatReply(text);
-  let visibleReplySent = false;
-  for (let i = 0; i < chunks.length; i++) {
-    const ok = await sendMessage(
+  for (const chunk of chunkSynologyChatText(text)) {
+    const visibleReplySent = await sendMessage(
       params.account.incomingUrl,
-      chunks[i],
+      chunk,
       params.sendUserId,
       params.account.allowInsecureSsl,
     );
-    visibleReplySent = visibleReplySent || ok;
-    if (i < chunks.length - 1) {
-      await new Promise((resolve) => setTimeout(resolve, SYNOLOGY_CHAT_CHUNK_DELAY_MS));
+    if (!visibleReplySent) {
+      return { visibleReplySent: false };
     }
   }
-  return { visibleReplySent };
+  return { visibleReplySent: true };
 }
 
 export async function dispatchSynologyChatInboundEvent(params: {

--- a/extensions/synology-chat/src/text-chunking.ts
+++ b/extensions/synology-chat/src/text-chunking.ts
@@ -1,0 +1,96 @@
+import type { OutboundDeliveryFormattingOptions } from "openclaw/plugin-sdk/channel-outbound";
+import { chunkMarkdownTextWithMode } from "openclaw/plugin-sdk/reply-chunking";
+import { findCodeRegions } from "openclaw/plugin-sdk/text-chunking";
+
+/** Keep inbound replies aligned with the existing Synology outbound transport cap. */
+export const SYNOLOGY_CHAT_TEXT_CHUNK_LIMIT = 2_000;
+
+export const SYNOLOGY_MARKDOWN_LINK_RE =
+  /(?<!!)\[((?:\\[^\n]|[^\\\]\n])+)\]\((https?:\/\/(?:\\[^\n]|[^()\s<>\\])+(?:\((?:\\[^\n]|[^()\s<>\\])*\)(?:\\[^\n]|[^()\s<>\\])*)*)(?:\s+(?:"[^"\n]*"|'[^'\n]*'|\([^()\n]*\)))?\)/g;
+
+export function chunkSynologyChatText(
+  text: string,
+  limit = SYNOLOGY_CHAT_TEXT_CHUNK_LIMIT,
+  context?: { formatting?: OutboundDeliveryFormattingOptions },
+): string[] {
+  const chunks: string[] = [];
+  const codeRegions = findCodeRegions(text);
+  const chunkMode = context?.formatting?.chunkMode ?? "length";
+  let pending = "";
+  let pendingContainsLink = false;
+  let cursor = 0;
+
+  const appendText = (next: string): void => {
+    if (pendingContainsLink && pending.length + next.length > limit) {
+      chunks.push(pending);
+      pending = "";
+      pendingContainsLink = false;
+    }
+    const nextChunks = chunkMarkdownTextWithMode(`${pending}${next}`, limit, chunkMode);
+    chunks.push(...nextChunks.slice(0, -1));
+    pending = nextChunks.at(-1) ?? "";
+    if (nextChunks.length > 1) {
+      pendingContainsLink = false;
+    }
+  };
+
+  const appendAtomic = (value: string): void => {
+    if (value.length > limit) {
+      appendText(value);
+      return;
+    }
+    if (pending.length + value.length > limit) {
+      if (pending) {
+        chunks.push(pending);
+      }
+      pending = value;
+    } else {
+      pending += value;
+    }
+    pendingContainsLink = true;
+  };
+
+  // Links must stay with their escapes or code delimiters; rendering a
+  // context-free fragment would incorrectly turn literal text into a link.
+  for (const match of text.matchAll(SYNOLOGY_MARKDOWN_LINK_RE)) {
+    const offset = match.index;
+    if (offset < cursor) {
+      continue;
+    }
+
+    const codeRegion = codeRegions.find((region) => offset >= region.start && offset < region.end);
+    if (codeRegion) {
+      appendText(text.slice(cursor, codeRegion.start));
+      const code = text.slice(codeRegion.start, codeRegion.end);
+      const marker = code.match(/^`+/)?.[0];
+      const isFencedCode = /^`{3,}[^\r\n]*\r?\n/u.test(code);
+      if (marker && !isFencedCode && code.endsWith(marker) && code.length > limit) {
+        const contentLimit = limit - marker.length * 2;
+        if (contentLimit > 0) {
+          const content = code.slice(marker.length, -marker.length);
+          for (const part of chunkMarkdownTextWithMode(content, contentLimit, chunkMode)) {
+            appendAtomic(`${marker}${part}${marker}`);
+          }
+        } else {
+          appendText(code);
+        }
+      } else {
+        appendAtomic(code);
+      }
+      cursor = codeRegion.end;
+      continue;
+    }
+
+    const escapes = text.slice(cursor, offset).match(/\\+$/)?.[0] ?? "";
+    const linkStart = offset - escapes.length;
+    appendText(text.slice(cursor, linkStart));
+    appendAtomic(`${escapes}${match[0]}`);
+    cursor = offset + match[0].length;
+  }
+
+  appendText(text.slice(cursor));
+  if (pending) {
+    chunks.push(pending);
+  }
+  return chunks;
+}


### PR DESCRIPTION
## What Problem This Solves

The Synology Chat channel drops agent replies that exceed the Synology Chat API limit (~4000 chars). Synology rejects the payload with `msg too long` and the message is never delivered — there is no client-side chunking or truncation, so long responses (large log reports, detailed code analysis) fail entirely.

Closes #112041.

## Why This Change Was Made

`deliverSynologyChatReply` (`extensions/synology-chat/src/inbound-event.ts`) sent the whole reply in a single `sendMessage` call. The slack, twitch, and sms channels already chunk outbound text via `chunkTextForOutbound` (`openclaw/plugin-sdk/text-chunking`) — synology-chat was the outlier.

This applies the same pattern: chunk the reply to a safe limit (3800, under the ~4000 API cap) and send each chunk sequentially with a short delay (to avoid rate-limiting / payload rejection), matching the issue's expected behavior. The chunking is factored into an exported `chunkSynologyChatReply` helper so it's unit-testable.

## User Impact

Long agent replies on Synology Chat are delivered as sequential messages instead of failing outright. Replies within the limit are unchanged (a single message).

## Evidence

Unit test (`extensions/synology-chat/src/inbound-event.test.ts`): a reply over the limit splits into multiple chunks each ≤ 3800 chars; a short reply stays a single chunk. **2/2 pass.**

Note: I don't have a Synology NAS to verify end-to-end delivery, but the fix mirrors the established slack/twitch/sms chunking and the chunk logic is unit-tested — happy to adjust the exact limit/delay if maintainers have precise Synology API values.



## Real-behavior proof (on current main)

Output from the **actual production chunker** (`chunkSynologyChatReply`), head `041b9f3`. Current `main` sends the visible reply through a single `sendMessage` with no length handling, so a reply longer than Synology Chat's ~3800-char limit is rejected wholesale; this PR chunks it:

```
input: 14999 chars   (Synology limit 3800)
chunks produced: 4
largest chunk: 3799 chars    (all within limit: true)
no empty chunks: true
short reply stays one chunk: ["hello world"]
```

The chunker is wired into the outbound path (`extensions/synology-chat/src/inbound-event.ts`): the reply is split, then each chunk is sent via `sendMessage` with a 1s inter-chunk delay. `inbound-event.test.ts`: **2/2 green** on current `main`.

---

## Scope & known follow-ups

- **Sibling send path.** This chunks the inbound *reply* delivery (`deliverSynologyChatReply`). The separate proactive/message-tool adapter `sendSynologyChatText` (`extensions/synology-chat/src/channel.ts`) still sends a single unchunked message, so a proactively-sent long text can still be rejected. The clean consolidation is to enforce the 3800 limit at the shared `client.ts` `sendMessage` boundary so both call sites are covered — happy to do that in this PR or as a tracked follow-up, your call.
- **Partial-delivery contract.** The send loop reports the reply delivered if *any* chunk succeeds; a mid-reply chunk failure would leave a gap without surfacing an error. This is a deliberate best-effort choice (a failed chunk shouldn't discard the whole reply) — I can add a test documenting it and/or switch to fail-fast on request.
- **Limit units.** 3800 is a UTF-16 code-unit count (a safety margin under the ~4000 cap). If Synology measures bytes / the URL-encoded body, CJK/emoji-heavy replies may need a byte-based limit — glad to align to precise API values.

