### PR TITLE
fix(scripts): bound release metadata git lookups

### DIFF
--- a/scripts/check-release-metadata-only.mjs
+++ b/scripts/check-release-metadata-only.mjs
@@ -5,6 +5,10 @@ import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { RELEASE_METADATA_PATHS } from "./changed-lanes.mjs";
 
+const DEFAULT_GIT_TIMEOUT_MS = 60_000;
+const MAX_GIT_TIMEOUT_MS = 10 * 60_000;
+const GIT_TIMEOUT_ENV = "OPENCLAW_RELEASE_METADATA_GIT_TIMEOUT_MS";
+
 const VERSION_ONLY_TEXT_PATHS = new Set([
   "apps/android/Config/Version.properties",
   "apps/android/version.json",
@@ -24,6 +28,18 @@ function readRefOptionValue(argv, index, optionName) {
     throw new Error(`Expected ${optionName} <ref>.`);
   }
   return value;
+}
+
+function resolveGitTimeoutMs(env = process.env) {
+  const raw = env[GIT_TIMEOUT_ENV]?.trim();
+  if (!raw) {
+    return DEFAULT_GIT_TIMEOUT_MS;
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return DEFAULT_GIT_TIMEOUT_MS;
+  }
+  return Math.min(Math.trunc(parsed), MAX_GIT_TIMEOUT_MS);
 }
 
 export function parseArgs(argv) {
@@ -52,12 +68,28 @@ export function parseArgs(argv) {
   return args;
 }
 
+function formatGitArgs(args) {
+  return args.join(" ");
+}
+
 function git(args) {
-  return execFileSync("git", args, {
-    stdio: ["ignore", "pipe", "pipe"],
-    encoding: "utf8",
-    maxBuffer: 16 * 1024 * 1024,
-  });
+  const timeout = resolveGitTimeoutMs();
+  try {
+    return execFileSync("git", args, {
+      stdio: ["ignore", "pipe", "pipe"],
+      encoding: "utf8",
+      maxBuffer: 16 * 1024 * 1024,
+      timeout,
+    });
+  } catch (error) {
+    if (error?.signal === "SIGTERM" || error?.code === "ETIMEDOUT") {
+      throw new Error(
+        `release metadata guard: git ${formatGitArgs(args)} timed out after ${timeout}ms.`,
+        { cause: error },
+      );
+    }
+    throw error;
+  }
 }
 
 function listChangedPaths(args) {

--- a/scripts/check-release-metadata-only.mjs
+++ b/scripts/check-release-metadata-only.mjs
@@ -39,7 +39,7 @@ function resolveGitTimeoutMs(env = process.env) {
   if (!Number.isFinite(parsed) || parsed <= 0) {
     return DEFAULT_GIT_TIMEOUT_MS;
   }
-  return Math.min(Math.trunc(parsed), MAX_GIT_TIMEOUT_MS);
+  return Math.max(1, Math.min(Math.trunc(parsed), MAX_GIT_TIMEOUT_MS));
 }
 
 export function parseArgs(argv) {

--- a/test/scripts/check-release-metadata-only.test.ts
+++ b/test/scripts/check-release-metadata-only.test.ts
@@ -1,5 +1,15 @@
-import { describe, expect, it } from "vitest";
+import { spawnSync } from "node:child_process";
+import { chmodSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
 import { parseArgs } from "../../scripts/check-release-metadata-only.mjs";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
+
+const scriptPath = path.resolve(
+  import.meta.dirname,
+  "../../scripts/check-release-metadata-only.mjs",
+);
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 describe("check-release-metadata-only", () => {
   it("parses refs and explicit paths", () => {
@@ -39,5 +49,38 @@ describe("check-release-metadata-only", () => {
       head: "HEAD",
       paths: ["--head"],
     });
+  });
+
+  it("fails with an actionable timeout when git diff hangs", () => {
+    const tempDir = tempDirs.make("openclaw-release-metadata-git-");
+    const gitPath = path.join(tempDir, "git");
+    writeFileSync(
+      gitPath,
+      `#!/usr/bin/env node
+if (process.argv.includes("diff")) {
+  setInterval(() => {}, 1000);
+} else {
+  process.exit(0);
+}
+`,
+      "utf8",
+    );
+    chmodSync(gitPath, 0o755);
+
+    const result = spawnSync(process.execPath, [scriptPath], {
+      cwd: path.resolve(import.meta.dirname, "../.."),
+      env: {
+        ...process.env,
+        OPENCLAW_RELEASE_METADATA_GIT_TIMEOUT_MS: "500",
+        PATH: `${tempDir}${path.delimiter}${process.env.PATH ?? ""}`,
+      },
+      encoding: "utf8",
+      timeout: 5_000,
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      "release metadata guard: git diff --name-only --diff-filter=ACMR origin/main...HEAD timed out after 500ms.",
+    );
   });
 });

--- a/test/scripts/check-release-metadata-only.test.ts
+++ b/test/scripts/check-release-metadata-only.test.ts
@@ -10,6 +10,7 @@ const scriptPath = path.resolve(
   "../../scripts/check-release-metadata-only.mjs",
 );
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const itUnix = process.platform === "win32" ? it.skip : it;
 
 describe("check-release-metadata-only", () => {
   it("parses refs and explicit paths", () => {
@@ -51,7 +52,7 @@ describe("check-release-metadata-only", () => {
     });
   });
 
-  it("fails with an actionable timeout when git diff hangs", () => {
+  itUnix("fails with an actionable timeout when git diff hangs", () => {
     const tempDir = tempDirs.make("openclaw-release-metadata-git-");
     const gitPath = path.join(tempDir, "git");
     writeFileSync(

--- a/test/scripts/check-release-metadata-only.test.ts
+++ b/test/scripts/check-release-metadata-only.test.ts
@@ -82,5 +82,19 @@ if (process.argv.includes("diff")) {
     expect(result.stderr).toContain(
       "release metadata guard: git diff --name-only --diff-filter=ACMR origin/main...HEAD timed out after 500ms.",
     );
+
+    const fractionalResult = spawnSync(process.execPath, [scriptPath], {
+      cwd: path.resolve(import.meta.dirname, "../.."),
+      env: {
+        ...process.env,
+        OPENCLAW_RELEASE_METADATA_GIT_TIMEOUT_MS: "0.5",
+        PATH: `${tempDir}${path.delimiter}${process.env.PATH ?? ""}`,
+      },
+      encoding: "utf8",
+      timeout: 5_000,
+    });
+
+    expect(fractionalResult.status).toBe(1);
+    expect(fractionalResult.stderr).toContain("timed out after 1ms.");
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where release metadata-only checks could hang indefinitely when a `git diff` or `git show` subprocess stopped responding.

## Why This Change Was Made

The release metadata guard now applies a bounded timeout to every git lookup, with a capped environment override for tests and slow hosts. Timeout failures report the exact git operation instead of leaving CI without an actionable error.

## User Impact

Maintainers and contributors get a deterministic failure from the release metadata gate when git stalls, while normal fast git lookups continue to pass unchanged.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/check-release-metadata-only.test.ts`: 5 passed.
- `git diff --check origin/main...HEAD`: passed.
- Real CLI proof: `node scripts/check-release-metadata-only.mjs` was run with a fake git on `PATH`; the valid empty diff succeeds, and the hanging `git diff` case exits with the new timeout diagnostic.

```text
$ PATH=<fake-git-returns-empty-diff> node scripts/check-release-metadata-only.mjs
valid-status: 0
valid-stderr: [release-metadata] ok (0 files)

$ OPENCLAW_RELEASE_METADATA_GIT_TIMEOUT_MS=500 PATH=<fake-git-hangs-on-diff> node scripts/check-release-metadata-only.mjs
timeout-status: 1
timeout-stderr: release metadata guard: git diff --name-only --diff-filter=ACMR origin/main...HEAD timed out after 500ms.
```

<details>
<summary>proof harness</summary>

```js
const { spawnSync } = require("node:child_process");
const fs = require("node:fs");
const os = require("node:os");
const path = require("node:path");

function withFakeGit(source, env = {}) {
  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-release-metadata-proof-"));
  try {
    const gitPath = path.join(tmp, "git");
    fs.writeFileSync(gitPath, source, "utf8");
    fs.chmodSync(gitPath, 0o755);
    return spawnSync(process.execPath, ["scripts/check-release-metadata-only.mjs"], {
      env: { ...process.env, ...env, PATH: `${tmp}${path.delimiter}${process.env.PATH ?? ""}` },
      encoding: "utf8",
      timeout: 5_000,
    });
  } finally {
    fs.rmSync(tmp, { recursive: true, force: true });
  }
}

withFakeGit(`#!/usr/bin/env node
if (process.argv.includes("diff")) {
  process.stdout.write("");
  process.exit(0);
}
process.exit(0);
`);

withFakeGit(`#!/usr/bin/env node
if (process.argv.includes("diff")) {
  setInterval(() => {}, 1000);
} else {
  process.exit(0);
}
`, { OPENCLAW_RELEASE_METADATA_GIT_TIMEOUT_MS: "500" });
```

</details>

AI-assisted: built with Codex
