### PR TITLE
feat(scripts): reference update script for source-checkout gateway servers

### DIFF
--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -4815,6 +4815,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
 - Headings:
   - H2: Recommended: openclaw update
   - H2: Switch between npm and git installs
+  - H2: Source-checkout servers (reference script)
   - H2: Alternative: re-run the installer
   - H2: Alternative: manual npm, pnpm, or bun
   - H3: Advanced npm install topics

--- a/docs/install/updating.md
+++ b/docs/install/updating.md
@@ -99,6 +99,29 @@ from a different install, the updater prints both roots and the managed
 service's Node path, and checks that Node version against the target release's
 `engines.node` requirement before replacing the package.
 
+## Source-checkout servers (reference script)
+
+Teams running a gateway directly from a git checkout on a server can update it
+with `scripts/update-gateway.sh` from inside that checkout. It is the reference
+for an efficient source-server update: it restores tracked build outputs that
+`pnpm build` rewrites, fails closed on any other local changes, fast-forwards
+`main` (or rebases a local server branch onto `origin/main`), installs
+dependencies, builds clean, and restarts the gateway.
+
+```bash
+ssh you@server 'cd /path/to/openclaw && scripts/update-gateway.sh'
+```
+
+Override the restart for custom service units, or skip it entirely:
+
+```bash
+OPENCLAW_UPDATE_RESTART_CMD='systemctl --user restart openclaw-gateway.service' scripts/update-gateway.sh
+OPENCLAW_UPDATE_RESTART_CMD='' scripts/update-gateway.sh
+```
+
+For a plain single-user source install, prefer `openclaw update --channel dev`
+instead — it manages the checkout, build, and gateway restart for you.
+
 ## Alternative: re-run the installer
 
 ```bash

--- a/scripts/update-gateway.sh
+++ b/scripts/update-gateway.sh
@@ -47,25 +47,21 @@ fi
 # uncommitted work in this checkout, and an update must never eat it.
 if ! git diff --quiet || ! git diff --cached --quiet; then
   log "working tree has local changes; commit, stash, or restore them first:"
-  git status --short | head -20
+  status_lines="$(git status --short)"
+  head -20 <<<"$status_lines"
   exit 1
 fi
 
-# Untracked files outside the build dirs cannot change what the updated commit
-# builds, so they only warn (servers accumulate harmless scratch files). Inside
-# the dirs the clean build deletes, untracked work would be silently destroyed,
-# so those fail closed. Accepted tradeoff: a build that globs untracked inputs
-# keeps them, same as before the update.
+# dist, dist-runtime, and .artifacts/tsgo-cache are wholly disposable build
+# outputs: every update deletes and regenerates them, tracked or not — never
+# store anything there. Untracked files elsewhere are kept and only warned
+# about (servers accumulate harmless scratch files). Accepted tradeoff: an
+# untracked file a build tool happens to read stays in effect, same as before
+# the update; operators own what they leave in the checkout.
 untracked="$(git ls-files --others --exclude-standard)"
 if [ -n "$untracked" ]; then
-  doomed="$(printf '%s\n' "$untracked" | grep -E '^(dist|dist-runtime|\.artifacts/tsgo-cache)(/|$)' || true)"
-  if [ -n "$doomed" ]; then
-    log "untracked files inside build dirs would be deleted by the clean build; move them first:"
-    printf '%s\n' "$doomed" | head -10
-    exit 1
-  fi
   log "note: untracked files present (kept, not deployed):"
-  printf '%s\n' "$untracked" | head -10
+  head -10 <<<"$untracked"
 fi
 
 log "fetching ${remote}/main"
@@ -92,6 +88,8 @@ pnpm install --frozen-lockfile
 # Incremental builds have left stale hashed chunks and config validators from
 # the previous revision in dist; a clean build is the reliable path.
 log "clean building"
+# No trailing slashes: if a path is a symlink, rm removes the link itself and
+# never traverses into the target.
 rm -rf dist dist-runtime .artifacts/tsgo-cache
 pnpm build
 

--- a/scripts/update-gateway.sh
+++ b/scripts/update-gateway.sh
@@ -73,9 +73,11 @@ if [ "$branch" = "main" ]; then
   git merge --ff-only "${remote}/main"
 else
   # A server may carry a local branch (e.g. an agent's in-progress fix) on top
-  # of main. Rebase preserves that work while still deploying latest main.
+  # of main. Rebase preserves that work while still deploying latest main;
+  # --rebase-merges keeps merge commits (and their conflict resolutions)
+  # instead of silently flattening them away.
   log "rebasing local branch '$branch' onto ${remote}/main"
-  if ! git rebase "${remote}/main"; then
+  if ! git rebase --rebase-merges "${remote}/main"; then
     git rebase --abort
     log "rebase of '$branch' conflicts with ${remote}/main; resolve manually"
     exit 1

--- a/scripts/update-gateway.sh
+++ b/scripts/update-gateway.sh
@@ -34,12 +34,38 @@ remote="${OPENCLAW_UPDATE_REMOTE:-origin}"
 # regenerates it from source every run.
 git checkout -- extensions/browser/chrome-extension/modules/copilot-runtime.js 2>/dev/null || true
 
+# Never update over an in-progress git operation: aborting or rebasing on top
+# of an operator's paused rebase/merge would discard their progress.
+git_dir="$(git rev-parse --git-dir)"
+if [ -d "$git_dir/rebase-merge" ] || [ -d "$git_dir/rebase-apply" ] || \
+  [ -f "$git_dir/MERGE_HEAD" ] || [ -f "$git_dir/CHERRY_PICK_HEAD" ]; then
+  log "a git rebase/merge/cherry-pick is in progress; finish or abort it first"
+  exit 1
+fi
+
 # Fail closed on any other local changes: an agent or operator may have
 # uncommitted work in this checkout, and an update must never eat it.
 if ! git diff --quiet || ! git diff --cached --quiet; then
   log "working tree has local changes; commit, stash, or restore them first:"
   git status --short | head -20
   exit 1
+fi
+
+# Untracked files outside the build dirs cannot change what the updated commit
+# builds, so they only warn (servers accumulate harmless scratch files). Inside
+# the dirs the clean build deletes, untracked work would be silently destroyed,
+# so those fail closed. Accepted tradeoff: a build that globs untracked inputs
+# keeps them, same as before the update.
+untracked="$(git ls-files --others --exclude-standard)"
+if [ -n "$untracked" ]; then
+  doomed="$(printf '%s\n' "$untracked" | grep -E '^(dist|dist-runtime|\.artifacts/tsgo-cache)(/|$)' || true)"
+  if [ -n "$doomed" ]; then
+    log "untracked files inside build dirs would be deleted by the clean build; move them first:"
+    printf '%s\n' "$doomed" | head -10
+    exit 1
+  fi
+  log "note: untracked files present (kept, not deployed):"
+  printf '%s\n' "$untracked" | head -10
 fi
 
 log "fetching ${remote}/main"

--- a/scripts/update-gateway.sh
+++ b/scripts/update-gateway.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Updates a self-hosted OpenClaw gateway that runs from this source checkout.
+#
+# Reference workflow for team-operated servers (see docs/install/updating.md).
+# Simple installs should prefer `openclaw update` / `openclaw update --channel
+# dev`; this script exists for checkouts that additionally need to:
+#   - preserve a local branch by rebasing it onto origin/main,
+#   - tolerate tracked build outputs that `pnpm build` rewrites,
+#   - build clean (incremental builds have shipped stale hashed chunks),
+#   - restart a custom service unit.
+#
+# Environment:
+#   OPENCLAW_UPDATE_RESTART_CMD  restart command (default: openclaw gateway restart)
+#                                set to "" to skip the restart step
+#   OPENCLAW_UPDATE_REMOTE       git remote to update from (default: origin)
+set -euo pipefail
+
+log() { echo "[update-gateway] $*"; }
+on_exit() {
+  local code=$?
+  if [ "$code" -ne 0 ]; then
+    echo "[update-gateway] FAILED (exit $code)" >&2
+  fi
+}
+trap on_exit EXIT
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+remote="${OPENCLAW_UPDATE_REMOTE:-origin}"
+
+# `pnpm build` rewrites this tracked bundle, which would make the tree look
+# dirty and block the rebase below. Restoring it loses nothing: the build
+# regenerates it from source every run.
+git checkout -- extensions/browser/chrome-extension/modules/copilot-runtime.js 2>/dev/null || true
+
+# Fail closed on any other local changes: an agent or operator may have
+# uncommitted work in this checkout, and an update must never eat it.
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  log "working tree has local changes; commit, stash, or restore them first:"
+  git status --short | head -20
+  exit 1
+fi
+
+log "fetching ${remote}/main"
+git fetch "$remote" main
+
+branch="$(git rev-parse --abbrev-ref HEAD)"
+if [ "$branch" = "main" ]; then
+  log "fast-forwarding main"
+  git merge --ff-only "${remote}/main"
+else
+  # A server may carry a local branch (e.g. an agent's in-progress fix) on top
+  # of main. Rebase preserves that work while still deploying latest main.
+  log "rebasing local branch '$branch' onto ${remote}/main"
+  if ! git rebase "${remote}/main"; then
+    git rebase --abort
+    log "rebase of '$branch' conflicts with ${remote}/main; resolve manually"
+    exit 1
+  fi
+fi
+
+log "installing dependencies"
+pnpm install --frozen-lockfile
+
+# Incremental builds have left stale hashed chunks and config validators from
+# the previous revision in dist; a clean build is the reliable path.
+log "clean building"
+rm -rf dist dist-runtime .artifacts/tsgo-cache
+pnpm build
+
+restart_cmd="${OPENCLAW_UPDATE_RESTART_CMD-openclaw gateway restart}"
+if [ -n "$restart_cmd" ]; then
+  log "restarting gateway: $restart_cmd"
+  bash -c "$restart_cmd"
+else
+  log "restart skipped (OPENCLAW_UPDATE_RESTART_CMD is empty)"
+fi
+
+log "OK $(git rev-parse --short HEAD) ($branch)"

--- a/scripts/update-gateway.sh
+++ b/scripts/update-gateway.sh
@@ -29,11 +29,6 @@ cd "$repo_root"
 
 remote="${OPENCLAW_UPDATE_REMOTE:-origin}"
 
-# `pnpm build` rewrites this tracked bundle, which would make the tree look
-# dirty and block the rebase below. Restoring it loses nothing: the build
-# regenerates it from source every run.
-git checkout -- extensions/browser/chrome-extension/modules/copilot-runtime.js 2>/dev/null || true
-
 # Never update over an in-progress git operation: aborting or rebasing on top
 # of an operator's paused rebase/merge would discard their progress.
 git_dir="$(git rev-parse --git-dir)"
@@ -42,6 +37,11 @@ if [ -d "$git_dir/rebase-merge" ] || [ -d "$git_dir/rebase-apply" ] || \
   log "a git rebase/merge/cherry-pick is in progress; finish or abort it first"
   exit 1
 fi
+
+# `pnpm build` rewrites this tracked bundle, which would make the tree look
+# dirty and block the rebase below. Restoring it loses nothing: the build
+# regenerates it from source every run.
+git checkout -- extensions/browser/chrome-extension/modules/copilot-runtime.js 2>/dev/null || true
 
 # Fail closed on any other local changes: an agent or operator may have
 # uncommitted work in this checkout, and an update must never eat it.
@@ -60,7 +60,7 @@ fi
 # the update; operators own what they leave in the checkout.
 untracked="$(git ls-files --others --exclude-standard)"
 if [ -n "$untracked" ]; then
-  log "note: untracked files present (kept, not deployed):"
+  log "warning: untracked files present; they are kept and a build tool that reads them can affect the deployed output:"
   head -10 <<<"$untracked"
 fi
 
@@ -88,8 +88,14 @@ pnpm install --frozen-lockfile
 # Incremental builds have left stale hashed chunks and config validators from
 # the previous revision in dist; a clean build is the reliable path.
 log "clean building"
-# No trailing slashes: if a path is a symlink, rm removes the link itself and
-# never traverses into the target.
+# These deletes must stay inside the checkout: a symlinked build dir would
+# redirect the recursion into its target, so refuse symlinks outright.
+for build_path in dist dist-runtime .artifacts; do
+  if [ -L "$build_path" ]; then
+    log "$build_path is a symlink; refusing to clean through it"
+    exit 1
+  fi
+done
 rm -rf dist dist-runtime .artifacts/tsgo-cache
 pnpm build
 


### PR DESCRIPTION
## What Problem This Solves

Teams running a gateway from a git source checkout (like the shared team server) update it with a hand-rolled SSH ritual that keeps getting re-derived: restore the tracked bundle `pnpm build` rewrites, avoid eating local changes, fast-forward or rebase, reinstall deps, build clean, restart the service. Every operator/agent rediscovers the same gotchas (dirty-artifact rebase blocks, stale hashed chunks from incremental builds, stale `node_modules` after dep-adding merges).

## Why This Change Was Made

`scripts/update-gateway.sh` encodes that runbook once, as a documented reference:

- restores the tracked build output (`copilot-runtime.js`) that `pnpm build` rewrites, then **fails closed** on any other local changes — an update must never eat operator or agent work;
- `main` fast-forwards; a local server branch (e.g. an agent's in-progress fix) rebases onto `origin/main`, aborting cleanly on conflict;
- `pnpm install --frozen-lockfile` + clean build (`rm -rf dist dist-runtime .artifacts/tsgo-cache`) — incremental builds have shipped stale hashed chunks;
- restart via `OPENCLAW_UPDATE_RESTART_CMD` (default `openclaw gateway restart`; empty skips), custom units supported;
- follows the fail-loud wrapper rule: nonzero exits end with `[update-gateway] FAILED (exit N)`.

`docs/install/updating.md` gains a "Source-checkout servers" section positioning it against `openclaw update --channel dev` (which stays the recommendation for plain single-user source installs).

## User Impact

Self-hosters running from source get a supported, documented update path. No runtime behavior changes.

## Evidence

- Live proof on the team gateway server: full run — restore, fetch, fast-forward, `pnpm install`, clean `pnpm build`, systemd user-unit restart — ending `[update-gateway] OK b8ccb5df (main)`; gateway `active`, `/chat` → 200 afterwards.
- `bash -n` and `shellcheck` clean.
