### PR TITLE
fix(gateway): resume interrupted turns after restarts instead of asking users to re-send

### DIFF
--- a/src/agents/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-restart-recovery.test.ts
@@ -4563,14 +4563,6 @@ describe("main-session-restart-recovery", () => {
       },
     ],
     [
-      "completed tool call",
-      {
-        role: "assistant",
-        content: [{ type: "toolCall", id: "call-1", name: "write", arguments: {} }],
-        stopReason: "toolUse",
-      },
-    ],
-    [
       "aborted tool call",
       {
         role: "assistant",
@@ -5324,8 +5316,8 @@ describe("main-session-restart-recovery", () => {
     {
       label: "provider abort artifact with partial output",
       content: [{ type: "text", text: "partial answer" }],
-      expected: { recovered: 0, failed: 1, skipped: 0 },
-      gatewayCalls: 0,
+      expected: { recovered: 1, failed: 0, skipped: 0 },
+      gatewayCalls: 1,
     },
   ])(
     "handles $label without discarding assistant output",
@@ -5379,8 +5371,150 @@ describe("main-session-restart-recovery", () => {
 
       expect(result).toEqual(expected);
       expect(callGateway).toHaveBeenCalledTimes(gatewayCalls);
+      expect(firstGatewayParams()).toMatchObject({ forceRestartSafeTools: true });
     },
   );
+
+  it("resumes a partial streamed answer interrupted by a restart", async () => {
+    const sessionsDir = await makeSessionsDir();
+    await writeStore(sessionsDir, {
+      "agent:main:main": {
+        sessionId: "main-session",
+        updatedAt: Date.now() - 10_000,
+        status: "running",
+        abortedLastRun: true,
+      },
+    });
+    await writeTranscript(sessionsDir, "main-session", [
+      { role: "user", content: "do the thing" },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Here is the first half of the answer" }],
+        stopReason: "aborted",
+        errorMessage: "This operation was aborted",
+      },
+    ]);
+
+    const result = await recoverRestartAbortedMainSessions({ stateDir: tmpDir });
+
+    expect(result).toEqual({ recovered: 1, failed: 0, skipped: 0 });
+    expect(callGateway).toHaveBeenCalledTimes(1);
+    expect(firstGatewayParams()).not.toMatchObject({ forceRestartSafeTools: true });
+  });
+
+  it("resumes an abort artifact persisted with the gateway restart reason", async () => {
+    const sessionsDir = await makeSessionsDir();
+    await writeStore(sessionsDir, {
+      "agent:main:main": {
+        sessionId: "main-session",
+        updatedAt: Date.now() - 10_000,
+        status: "running",
+        abortedLastRun: true,
+      },
+    });
+    await writeTranscript(sessionsDir, "main-session", [
+      { role: "user", content: "do the thing" },
+      {
+        role: "assistant",
+        content: [],
+        stopReason: "aborted",
+        errorMessage: "agent run aborted for restart",
+      },
+    ]);
+
+    const result = await recoverRestartAbortedMainSessions({ stateDir: tmpDir });
+
+    expect(result).toEqual({ recovered: 1, failed: 0, skipped: 0 });
+    expect(callGateway).toHaveBeenCalledTimes(1);
+  });
+
+  it("resumes a side-effecting tool call restricted to restart-safe tools", async () => {
+    const sessionsDir = await makeSessionsDir();
+    await writeStore(sessionsDir, {
+      "agent:main:main": {
+        sessionId: "main-session",
+        updatedAt: Date.now() - 10_000,
+        status: "running",
+        abortedLastRun: true,
+      },
+    });
+    await writeTranscript(sessionsDir, "main-session", [
+      { role: "user", content: "do the thing" },
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Running the check now." },
+          { type: "toolCall", id: "call-bash-1", name: "bash", arguments: { command: "true" } },
+        ],
+        stopReason: "toolUse",
+      },
+    ]);
+
+    const result = await recoverRestartAbortedMainSessions({ stateDir: tmpDir });
+
+    expect(result).toEqual({ recovered: 1, failed: 0, skipped: 0 });
+    expect(callGateway).toHaveBeenCalledTimes(1);
+    expect(firstGatewayParams()).toMatchObject({ forceRestartSafeTools: true });
+  });
+
+  it("keeps a dangling side-effecting call in an aborted tail restricted", async () => {
+    const sessionsDir = await makeSessionsDir();
+    await writeStore(sessionsDir, {
+      "agent:main:main": {
+        sessionId: "main-session",
+        updatedAt: Date.now() - 10_000,
+        status: "running",
+        abortedLastRun: true,
+      },
+    });
+    await writeTranscript(sessionsDir, "main-session", [
+      { role: "user", content: "do the thing" },
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Kicking that off." },
+          { type: "toolCall", id: "call-bash-1", name: "bash", arguments: { command: "true" } },
+        ],
+        stopReason: "aborted",
+        errorMessage: "This operation was aborted",
+      },
+    ]);
+
+    const result = await recoverRestartAbortedMainSessions({ stateDir: tmpDir });
+
+    expect(result).toEqual({ recovered: 1, failed: 0, skipped: 0 });
+    expect(callGateway).toHaveBeenCalledTimes(1);
+    expect(firstGatewayParams()).toMatchObject({ forceRestartSafeTools: true });
+  });
+
+  it("resumes an interrupted replay-safe tool call without restricting tools", async () => {
+    const sessionsDir = await makeSessionsDir();
+    await writeStore(sessionsDir, {
+      "agent:main:main": {
+        sessionId: "main-session",
+        updatedAt: Date.now() - 10_000,
+        status: "running",
+        abortedLastRun: true,
+      },
+    });
+    await writeTranscript(sessionsDir, "main-session", [
+      { role: "user", content: "do the thing" },
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Let me look that up." },
+          { type: "toolCall", id: "call-read-1", name: "read", arguments: { path: "README.md" } },
+        ],
+        stopReason: "toolUse",
+      },
+    ]);
+
+    const result = await recoverRestartAbortedMainSessions({ stateDir: tmpDir });
+
+    expect(result).toEqual({ recovered: 1, failed: 0, skipped: 0 });
+    expect(callGateway).toHaveBeenCalledTimes(1);
+    expect(firstGatewayParams()).not.toMatchObject({ forceRestartSafeTools: true });
+  });
 
   it("resumes through the shutdown error persisted for an interrupted Code Mode wait", async () => {
     const sessionsDir = await makeSessionsDir();

--- a/src/agents/main-session-restart-recovery.ts
+++ b/src/agents/main-session-restart-recovery.ts
@@ -69,6 +69,7 @@ import {
 import { tombstoneMainRestartRecoveryWithNotice } from "./main-session-restart-recovery-failure.js";
 import { resolveAgentSessionDirs } from "./session-dirs.js";
 import type { SessionLockInspection } from "./session-write-lock.js";
+import { isAgentToolReplaySafe } from "./tool-replay-safety.js";
 
 const log = createSubsystemLogger("main-session-restart-recovery");
 const DEFAULT_RECOVERY_DELAY_MS = 5_000;
@@ -818,6 +819,62 @@ function isPendingAssistantToolCall(message: unknown): boolean {
   return hasToolCall;
 }
 
+type DanglingToolCallClassification =
+  | { kind: "none" }
+  | { kind: "code-mode" }
+  | { kind: "resumable"; forceRestartSafeTools: boolean };
+
+// A dangling call may have committed before its result persisted, so anything
+// outside the audited replay-safe allowlist keeps the restart-safe tool
+// restriction: the continuation can inspect and report, but never silently
+// re-execute the ambiguous side effect. Name-only classification is enough
+// here because the concrete tool instance is gone with the old process.
+function classifyDanglingToolCalls(content: unknown): DanglingToolCallClassification | undefined {
+  if (!Array.isArray(content)) {
+    return undefined;
+  }
+  let allReplaySafe = true;
+  let hasToolCall = false;
+  for (const block of content) {
+    if (!block || typeof block !== "object") {
+      return undefined;
+    }
+    const type = normalizeOptionalString((block as { type?: unknown }).type);
+    if (type !== "toolCall" && type !== "toolUse" && type !== "tool_use") {
+      continue;
+    }
+    const name = normalizeOptionalString((block as { name?: unknown }).name);
+    if (name === CODE_MODE_EXEC_TOOL_NAME || name === CODE_MODE_WAIT_TOOL_NAME) {
+      return { kind: "code-mode" };
+    }
+    if (!isAgentToolReplaySafe({ name })) {
+      allReplaySafe = false;
+    }
+    hasToolCall = true;
+  }
+  return hasToolCall
+    ? { kind: "resumable", forceRestartSafeTools: !allReplaySafe }
+    : { kind: "none" };
+}
+
+// Unlike isPendingAssistantToolCall, visible text beside the call is fine —
+// the tail is not replayed, only continued past. Code Mode control calls are
+// excluded so their replay-safe checkpoint gating stays authoritative.
+function readResumablePendingToolCallTail(
+  message: unknown,
+): { forceRestartSafeTools: boolean } | undefined {
+  if (!message || typeof message !== "object" || getMessageRole(message) !== "assistant") {
+    return undefined;
+  }
+  if (normalizeOptionalString((message as { stopReason?: unknown }).stopReason) !== "toolUse") {
+    return undefined;
+  }
+  const classified = classifyDanglingToolCalls((message as { content?: unknown }).content);
+  return classified?.kind === "resumable"
+    ? { forceRestartSafeTools: classified.forceRestartSafeTools }
+    : undefined;
+}
+
 function readCodeModeCheckpoint(
   message: unknown,
 ): { replaySafe: boolean; runId?: string } | undefined {
@@ -874,7 +931,16 @@ function hasReplaySafeCodeModeCheckpointInCurrentTurn(messages: readonly unknown
   return false;
 }
 
-function isRestartAbortTailArtifact(message: unknown): boolean {
+// Generic fetch/undici abort strings plus the gateway's own restart abort
+// reason (run-termination.ts); which one lands depends on whether the provider
+// stream throws or surfaces the abort as an error event.
+const RESTART_ABORT_ERROR_MESSAGES = new Set([
+  "Request was aborted",
+  "This operation was aborted",
+  "agent run aborted for restart",
+]);
+
+function isRestartAbortAssistantMessage(message: unknown): boolean {
   if (!message || typeof message !== "object" || getMessageRole(message) !== "assistant") {
     return false;
   }
@@ -885,12 +951,15 @@ function isRestartAbortTailArtifact(message: unknown): boolean {
   const errorMessage = normalizeOptionalString(
     (message as { errorMessage?: unknown }).errorMessage,
   );
+  return errorMessage !== undefined && RESTART_ABORT_ERROR_MESSAGES.has(errorMessage);
+}
+
+function isRestartAbortTailArtifact(message: unknown): boolean {
+  if (!isRestartAbortAssistantMessage(message)) {
+    return false;
+  }
   const content = (message as { content?: unknown }).content;
-  return (
-    Array.isArray(content) &&
-    content.length === 0 &&
-    (errorMessage === "Request was aborted" || errorMessage === "This operation was aborted")
-  );
+  return Array.isArray(content) && content.length === 0;
 }
 
 function isRestartAbortedWaitFailure(message: unknown): boolean {
@@ -1001,8 +1070,21 @@ function resolveMainSessionResumePolicy(
   // `admitted` means no optional hook started. The dispatch boundary reloads
   // the current hook set before it permits this transcript to resume.
   const meaningfulMessages = messages.toReversed().filter(isMeaningfulTailMessage);
-  if (isRestartAbortTailArtifact(meaningfulMessages[0])) {
-    meaningfulMessages.shift();
+  // A restart abort tail without tool calls is lifecycle noise whether or not
+  // partial streamed text was persisted with it; the partial output stays in
+  // the transcript for the continuation, and the message beneath decides
+  // resume safety. Persisted dangling tool calls instead classify like a
+  // pending toolUse tail so ambiguous side effects stay restricted.
+  if (isRestartAbortAssistantMessage(meaningfulMessages[0])) {
+    const dangling = classifyDanglingToolCalls(
+      (meaningfulMessages[0] as { content?: unknown }).content,
+    );
+    if (dangling?.kind === "resumable") {
+      return { action: "resume", forceRestartSafeTools: dangling.forceRestartSafeTools };
+    }
+    if (dangling?.kind === "none") {
+      meaningfulMessages.shift();
+    }
   }
   if (isRestartAbortedWaitResultArtifact(meaningfulMessages[0], meaningfulMessages[1])) {
     meaningfulMessages.shift();
@@ -1033,6 +1115,14 @@ function resolveMainSessionResumePolicy(
     return tailCheckpoint.replaySafe
       ? { action: "resume", forceRestartSafeTools: true }
       : { action: "fail", reason: "Code Mode wait checkpoint is not replay-safe" };
+  }
+  // A tool call interrupted mid-execution resumes like the manual re-send the
+  // failure notice used to demand: the dangling call is dropped from the next
+  // provider payload and the continuation prompt lets the model re-decide.
+  // Code Mode control calls keep the stricter checkpoint gating above.
+  const pendingToolCallTail = readResumablePendingToolCallTail(lastMeaningful);
+  if (pendingToolCallTail) {
+    return { action: "resume", forceRestartSafeTools: pendingToolCallTail.forceRestartSafeTools };
   }
   if (!lastMeaningful || !isResumableTailMessage(lastMeaningful)) {
     return { action: "fail", reason: "transcript tail is not resumable" };


### PR DESCRIPTION
## What Problem This Solves

Every gateway restart — dev-watch rebuilds, auto-updates, `openclaw gateway restart` — that caught a main session mid-turn ended with the canned channel message:

> "I was interrupted by a gateway restart and couldn't safely resume the previous turn. Please send that last request again and I'll pick it up cleanly."

The Discord `#maintainers` archive shows this notice fired on Jul 11, 12, 15 (three times), and 16, and a maintainer asked the obvious question: if the agent can send that message, why can't it just resume?

Restart recovery (`resolveMainSessionResumePolicy`) already resumes cleanly when the transcript tail is a user turn, tool result, or an *empty* provider abort artifact. But the two most common real interruption shapes failed to `"transcript tail is not resumable"` and produced the notice:

1. **Partial streamed output** — when the provider surfaces the restart abort as an `error` stream event, the aborted assistant message persists with its accumulated partial blocks (`packages/agent-core/src/agent-loop.ts` `"done"/"error"` path). The empty-content-only artifact check rejected it.
2. **A tool call interrupted mid-execution** — the assistant `toolUse` message persisted, the tool result never did. This tail only resumed when the turn was already a restart-safe recovery turn.

There was also a latent recognition gap: the gateway's own restart abort reason (`"agent run aborted for restart"` from `createAgentRunRestartAbortError`) was not in the accepted abort-artifact strings, so even an empty abort tail could miss the strip depending on which abort path won.

## Why This Change Was Made

The notice demanded a manual re-send, and that manual re-send runs the *same* continuation on the same transcript with the same missing information — the human adds no safety, only latency. The recovery machinery for a safe automatic version already exists (recovery continuation prompt, dangling tool-call stripping before the provider payload, restart-safe tool catalog restriction, delivery receipts); the policy just never used it for these shapes.

Changes in `src/agents/main-session-restart-recovery.ts`:

- Restart abort tails are recognized by stop reason + the three known abort messages (now including `"agent run aborted for restart"`), regardless of partial content. A tail without tool calls is stripped as lifecycle noise (partial text stays in the transcript for the continuation) and the message beneath decides resume safety, exactly as before.
- Dangling tool calls — whether in an aborted tail or a pending `toolUse` tail — are classified against the audited replay-safe allowlist (`tool-replay-safety.ts`): all-replay-safe calls resume with full tools; anything side-effecting resumes under `forceRestartSafeTools`, so the recovery turn can inspect state and reply contextually but can never silently re-execute an ambiguous side effect. Code Mode control calls are excluded and keep their stricter replay-safe checkpoint gating.

Fail-closed behavior is unchanged for: unknown terminal delivery receipts (`terminal-pending`), `before_agent_reply` hook states, non-replay-safe Code Mode waits, stale approval-pending tails, completed-but-undelivered assistant output, and hook-safety dispatch gates. Truly unrecoverable sessions still get the notice.

## User Impact

Sessions interrupted by a gateway restart mid-answer or mid-tool-call now continue automatically instead of dead-ending with "please send that last request again". For interrupted side-effecting tools the agent replies with what it can verify instead of a canned notice, and asks before re-running anything ambiguous.

## Evidence

- Focused suite: `node scripts/run-vitest.mjs src/agents/main-session-restart-recovery.test.ts` → 132 passed (new coverage: partial streamed answer resumes; restart-reason abort artifact resumes; side-effecting dangling call resumes restricted, in both aborted and pending-toolUse tails; replay-safe dangling call resumes unrestricted; existing fail-closed suites unchanged).
- Sibling suites: `main-session-recovery-state.test.ts`, `main-session-recovery-store.test.ts` → 25 passed.
- `pnpm check:changed` (delegated Testbox) green: https://github.com/openclaw/openclaw/actions/runs/29896926646
- oxfmt/oxlint clean on touched files.
- Codex autoreview (gpt-5.6-sol, xhigh): two P1 findings raised and fixed across iterations (side-effect replay hazard → restart-safe restriction; aborted tails carrying tool calls → same classification), final pass clean: "patch is correct".
