### PR TITLE
fix(macos): prevent parallel Swift suite identity races

### DIFF
--- a/apps/macos/Sources/OpenClaw/GatewayConnection.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayConnection.swift
@@ -187,6 +187,7 @@ actor GatewayConnection {
     private let endpointProvider: EndpointProvider
     private let supportsSharedEndpointRecovery: Bool
     private let activationBindingKeyProvider: @Sendable () -> SymmetricKey?
+    private let includeDeviceIdentity: Bool
     private let sessionBox: WebSocketSessionBox?
     private let clientShutdown: @Sendable (GatewayChannelActor) async -> Void
     private let decoder = JSONDecoder()
@@ -233,6 +234,7 @@ actor GatewayConnection {
         self.endpointProvider = endpointProvider
         self.supportsSharedEndpointRecovery = supportsSharedEndpointRecovery
         self.activationBindingKeyProvider = activationBindingKeyProvider
+        self.includeDeviceIdentity = true
         self.sessionBox = sessionBox
         self.clientShutdown = clientShutdown
     }
@@ -255,6 +257,9 @@ actor GatewayConnection {
         }
         self.supportsSharedEndpointRecovery = false
         self.activationBindingKeyProvider = activationBindingKeyProvider
+        // Mock WebSocket routes do not exercise device authentication and must not
+        // depend on the process-global persisted identity store.
+        self.includeDeviceIdentity = false
         self.sessionBox = sessionBox
         self.clientShutdown = clientShutdown
     }
@@ -918,6 +923,7 @@ extension GatewayConnection {
                 clientId: "openclaw-macos",
                 clientMode: "ui",
                 clientDisplayName: InstanceIdentity.displayName,
+                includeDeviceIdentity: self.includeDeviceIdentity,
                 allowStoredDeviceAuth: deviceAuthGatewayID != nil,
                 deviceAuthGatewayID: deviceAuthGatewayID),
             disconnectHandler: { [weak self] _, socketGeneration in

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayChannelConfigureTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayChannelConfigureTests.swift
@@ -20,12 +20,17 @@ struct GatewayConnectionTests {
 
     private func makeSession(
         helloDelayMs: Int = 0,
-        serverCapabilities: [String] = []) -> GatewayTestWebSocketSession
+        serverCapabilities: [String] = [],
+        connectIncludesDeviceHandler: @escaping @Sendable (Bool) -> Void = { _ in })
+        -> GatewayTestWebSocketSession
     {
         GatewayTestWebSocketSession(
             taskFactory: {
                 GatewayTestWebSocketTask(
                     sendHook: { task, message, sendIndex in
+                        if let params = GatewayWebSocketTestSupport.connectRequestParams(from: message) {
+                            connectIncludesDeviceHandler(params["device"] != nil)
+                        }
                         guard sendIndex > 0 else { return }
                         guard let id = GatewayWebSocketTestSupport.requestID(from: message) else { return }
                         let response = GatewayWebSocketTestSupport.okResponseData(id: id)
@@ -86,6 +91,19 @@ struct GatewayConnectionTests {
         _ = try await conn.request(method: "status", params: nil)
         #expect(session.snapshotMakeCount() == 1)
         #expect(session.snapshotCancelCount() == 0)
+    }
+
+    @Test func `mock connection omits device identity`() async throws {
+        let connectIncludesDevice = OSAllocatedUnfairLock<Bool?>(initialState: nil)
+        let session = self.makeSession(connectIncludesDeviceHandler: { includesDevice in
+            connectIncludesDevice.withLock { $0 = includesDevice }
+        })
+        let (conn, _) = try self.makeConnection(session: session)
+
+        _ = try await conn.request(method: "status", params: nil)
+
+        #expect(connectIncludesDevice.withLock { $0 } == false)
+        await conn.shutdown()
     }
 
     @Test func `first connection admits hello capabilities before lease readiness`() async throws {

--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeRuntimeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeRuntimeTests.swift
@@ -80,7 +80,7 @@ struct MacNodeRuntimeTests {
 
     private func waitForCount(_ expected: Int, counter: LockedCounter) async -> Bool {
         let clock = ContinuousClock()
-        let deadline = clock.now.advanced(by: .seconds(1))
+        let deadline = clock.now.advanced(by: .seconds(10))
         while counter.value() < expected, clock.now < deadline {
             await Task.yield()
         }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the macOS Swift CI suite could fail nondeterministically under parallel load because mock Gateway connections accessed persisted device identity state, while a utility-priority catalog worker test required startup within one second.

The failure appeared across different tests on consecutive retries, including onboarding setup, memory import, and Claude catalog cancellation coverage.

## Why This Change Was Made

DEBUG-only `GatewayConnection(configProvider:)` instances now omit device identity from their mock WebSocket handshake, while production endpoint-based connections retain the existing identity behavior. A wire-level regression test verifies that boundary directly. The catalog cancellation test now allows the utility-priority worker ten seconds to begin under full-suite contention while preserving its cancellation result assertion.

## User Impact

There is no shipped runtime behavior change. Maintainers get stable macOS CI coverage without weakening production Gateway authentication or the catalog worker's cancellation contract.

## Evidence

- Exact failure: https://github.com/openclaw/openclaw/actions/runs/29894590588
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift build --package-path apps/macos --scratch-path /tmp/openclaw-macos-swift-proof --target OpenClaw` — passed after the change and after rebasing onto current `main`.
- `git diff --check` — passed.
- Codex autoreview (`--mode uncommitted`) — clean, no accepted/actionable findings.
- Exact-head CI for `5d1c5b2a0149a3c01d10389db8a378fa45ff704d`: https://github.com/openclaw/openclaw/actions/runs/29897605835
- Focused local test execution is blocked by an unrelated existing Swift 6.4 region-isolation compiler error in `GatewayChannelConnectTests.swift:204`; GitHub CI uses the repository's supported macOS toolchain and is the behavioral proof.

AI-assisted: implementation and review were performed with Claude Code and Codex autoreview; the change and evidence were manually verified.
