### PR TITLE
test(ui): isolate chat-pane lifecycle tests to fix core-runtime-media-ui flake

### DIFF
--- a/scripts/lib/ci-node-test-plan.mjs
+++ b/scripts/lib/ci-node-test-plan.mjs
@@ -1129,6 +1129,7 @@ const SPLIT_NODE_SHARDS = new Map([
           "test/vitest/vitest.media-understanding.config.ts",
           "test/vitest/vitest.tui.config.ts",
           "test/vitest/vitest.ui.config.ts",
+          "test/vitest/vitest.ui-isolated.config.ts",
           "test/vitest/vitest.wizard.config.ts",
         ],
         requiresDist: false,

--- a/test/scripts/ci-node-test-plan.test.ts
+++ b/test/scripts/ci-node-test-plan.test.ts
@@ -664,6 +664,7 @@ describe("scripts/lib/ci-node-test-plan.mjs", () => {
           "test/vitest/vitest.media-understanding.config.ts",
           "test/vitest/vitest.tui.config.ts",
           "test/vitest/vitest.ui.config.ts",
+          "test/vitest/vitest.ui-isolated.config.ts",
           "test/vitest/vitest.wizard.config.ts",
         ],
         requiresDist: false,

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -4731,6 +4731,7 @@ describe("scripts/test-projects full-suite sharding", () => {
       "test/vitest/vitest.tui.config.ts",
       "test/vitest/vitest.tui-pty.config.ts",
       "test/vitest/vitest.ui.config.ts",
+      "test/vitest/vitest.ui-isolated.config.ts",
       "test/vitest/vitest.utils.config.ts",
       "test/vitest/vitest.wizard.config.ts",
       "test/vitest/vitest.gateway-core.config.ts",

--- a/test/vitest/vitest.test-shards.mjs
+++ b/test/vitest/vitest.test-shards.mjs
@@ -84,6 +84,7 @@ export const fullSuiteVitestShards = [
       "test/vitest/vitest.tui.config.ts",
       "test/vitest/vitest.tui-pty.config.ts",
       "test/vitest/vitest.ui.config.ts",
+      "test/vitest/vitest.ui-isolated.config.ts",
       "test/vitest/vitest.utils.config.ts",
       "test/vitest/vitest.wizard.config.ts",
     ],

--- a/test/vitest/vitest.ui-isolated.config.ts
+++ b/test/vitest/vitest.ui-isolated.config.ts
@@ -1,0 +1,23 @@
+// Vitest ui-isolated config runs jsdom ui tests that need a fresh module graph.
+// The shared ui shard runs non-isolated for speed, but tests that spy on module
+// internals and assert the component uses that spy must not share a module cache
+// with stateful predecessor files (see UI_ISOLATED_TEST_FILES).
+import { createScopedVitestConfig } from "./vitest.scoped-config.ts";
+import { jsdomOptimizedDeps } from "./vitest.shared.config.ts";
+import { UI_ISOLATED_TEST_FILES } from "./vitest.ui.config.ts";
+
+export function createUiIsolatedVitestConfig(env?: Record<string, string | undefined>) {
+  return createScopedVitestConfig(UI_ISOLATED_TEST_FILES, {
+    deps: jsdomOptimizedDeps,
+    environment: "jsdom",
+    env,
+    excludeUnitFastTests: false,
+    includeOpenClawRuntimeSetup: false,
+    isolate: true,
+    name: "ui-isolated",
+    setupFiles: ["ui/src/test-helpers/lit-warnings.setup.ts"],
+    useNonIsolatedRunner: false,
+  });
+}
+
+export default createUiIsolatedVitestConfig();

--- a/test/vitest/vitest.ui.config.ts
+++ b/test/vitest/vitest.ui.config.ts
@@ -2,12 +2,32 @@
 import { createScopedVitestConfig } from "./vitest.scoped-config.ts";
 import { jsdomOptimizedDeps } from "./vitest.shared.config.ts";
 
+// Full chat-pane lifecycle tests instantiate the pane component, which relies on
+// chat-thread/chat-message module-level singletons (thread state maps, module-scoped
+// document context-menu listeners) and spies on those modules. Under the non-isolated
+// ui runner a stateful predecessor file can leave those modules duplicated across the
+// shared graph, so the pane binds to a different instance than the test's spy/registry
+// — surfacing as flaky teardown assertions or 120s session-lifecycle hangs, depending
+// on file order. These tests run in the isolated ui lane for a fresh module graph;
+// keep this list in sync with vitest.ui-isolated.config.ts's include.
+export const UI_ISOLATED_TEST_FILES = [
+  "ui/src/pages/chat/chat-pane-history.test.ts",
+  "ui/src/pages/chat/chat-pane-lifecycle.test.ts",
+  "ui/src/pages/chat/chat-pane-pull-requests.test.ts",
+  "ui/src/pages/chat/chat-pane.message-cut.test.ts",
+  "ui/src/pages/chat/chat-pane.read-marker.test.ts",
+  "ui/src/pages/chat/chat-pane.session-discussion.test.ts",
+  "ui/src/pages/chat/chat-pane.test.ts",
+];
+
 export function createUiVitestConfig(
   env?: Record<string, string | undefined>,
   options?: { includePatterns?: string[]; name?: string },
 ) {
   const includePatterns = options?.includePatterns ?? ["ui/src/**/*.test.ts"];
-  const exclude = options?.includePatterns ? [] : ["ui/src/**/*.e2e.test.ts"];
+  const exclude = options?.includePatterns
+    ? []
+    : ["ui/src/**/*.e2e.test.ts", ...UI_ISOLATED_TEST_FILES];
   return createScopedVitestConfig(includePatterns, {
     deps: jsdomOptimizedDeps,
     environment: "jsdom",


### PR DESCRIPTION
## What Problem This Solves

The `core-runtime-media-ui` CI shard (`checks-node-compact-large-3`) intermittently fails on `ui/src/pages/chat/chat-pane-*.test.ts` — flaky teardown assertions (`removeEventListener` not called) or 120s session-lifecycle hangs — blocking merges across multiple PRs. It reproduces only on Linux Node 24 and only under certain file orderings, so it is invisible locally on macOS.

## Root Cause

The media-ui shard runs its configs (`media`, `media-understanding`, `tui`, `ui`, `wizard`) **non-isolated** for speed (shared module graph across files, reset between files by `test/non-isolated-runner.ts`). The full chat-pane lifecycle tests instantiate the pane component, which depends on `chat-thread`/`chat-message` **module-level singletons** — the `threadStates` map, the confirmation-dismisser `WeakMap`, and module-scoped `document` context-menu listeners. After enough churn a stateful predecessor file leaves those modules duplicated across the shared graph, so the pane binds to a **different module instance** than the test's `vi.spyOn`/registry. The result is order-dependent: the spy never fires (assertion fails) or a session-creation promise never resolves (120s timeout).

Confirmed by bisection: reproduced deterministically on a Linux Testbox with `OPENCLAW_VITEST_MAX_WORKERS=1`; isolating a single file merely shifted the failure to a sibling pane test, proving the whole full-pane family shares the fragility.

## Why This Change Was Made

These lifecycle tests legitimately require a fresh module graph (same reason `vitest.unit-fast-isolated.config.ts` exists: "Forced stateful tests can mock modules imported by later files, so each gets a fresh graph."). Rather than slow the entire ui shard by isolating everything (46s → 3m18s), only the 7 full-pane test files run isolated; the other ~370 ui tests stay fast and non-isolated.

## User Impact

None — test-infrastructure only. No product code changes.

## Design

- New `test/vitest/vitest.ui-isolated.config.ts` (jsdom, `isolate: true`) runs the 7 pane-lifecycle test files (`UI_ISOLATED_TEST_FILES`, exported from `vitest.ui.config.ts` and shared by both configs).
- `vitest.ui.config.ts` excludes those files from the non-isolated ui lane.
- Registered in both shard registries — `scripts/lib/ci-node-test-plan.mjs` (CI plan) and `test/vitest/vitest.test-shards.mjs` (full-suite / `test-projects` config recognition) — added to the `core-runtime-media-ui` shard.

## Evidence

- **Reproduced then fixed on a Linux Node 24 Blacksmith Testbox** (the CI environment): the deterministic single-worker media-ui shard went from `1 failed` (then, after a one-file experiment, `3 failed` hangs) to **5182 passed, 0 failed** with all 7 pane files green in the `ui-isolated` lane.
- `test/scripts/ci-node-test-plan.test.ts` and `test/scripts/test-projects.test.ts` updated for the new shard config and pass (241 tests).
- oxfmt clean.
