### PR TITLE
refactor(sessions): migrate pure readers to read-only session accessors

### DIFF
--- a/extensions/active-memory/session.ts
+++ b/extensions/active-memory/session.ts
@@ -27,6 +27,7 @@ function resolveCanonicalSessionKeyFromSessionId(params: {
       | undefined;
     for (const { sessionKey, entry } of params.api.runtime.agent.session.listSessionEntries({
       agentId: params.agentId,
+      readOnly: true,
     })) {
       if (!entry || typeof entry !== "object") {
         continue;

--- a/extensions/anthropic/session-catalog-runtime.ts
+++ b/extensions/anthropic/session-catalog-runtime.ts
@@ -60,7 +60,7 @@ export function listBoundClaudeSessions(api: OpenClawPluginApi): Map<string, str
   ];
   const bound = new Map<string, string>();
   for (const { sessionKey, entry } of agentIds.flatMap((agentId) =>
-    api.runtime.agent.session.listSessionEntries({ agentId }),
+    api.runtime.agent.session.listSessionEntries({ agentId, readOnly: true }),
   )) {
     const source = boundClaudeSource(api.id, entry);
     if (source) {

--- a/extensions/codex/src/app-server/session-history.ts
+++ b/extensions/codex/src/app-server/session-history.ts
@@ -109,6 +109,7 @@ function resolveSqliteMarkerSessionKey(
   }
   const entries = listSessionEntries({
     agentId: marker.agentId,
+    readOnly: true,
     storePath: marker.storePath,
   });
   const exactEntry = entries.find(({ entry }) => {

--- a/extensions/codex/src/session-catalog-node-adoption.ts
+++ b/extensions/codex/src/session-catalog-node-adoption.ts
@@ -142,6 +142,7 @@ export function listNodeAdoptedSessionEntries(params: {
   for (const agentId of listSupervisionAgentIds(params.config ?? {})) {
     for (const { entry, sessionKey } of params.runtime.agent.session.listSessionEntries({
       agentId,
+      readOnly: true,
     })) {
       const marker = readNodeSessionMarker(entry);
       const sessionId = entry.sessionId?.trim();

--- a/extensions/codex/src/session-catalog.ts
+++ b/extensions/codex/src/session-catalog.ts
@@ -673,6 +673,7 @@ async function listAdoptedSessionEntries(params: {
   for (const agentId of listSupervisionAgentIds(params.config ?? {})) {
     for (const { entry, sessionKey } of params.runtime.agent.session.listSessionEntries({
       agentId,
+      readOnly: true,
     })) {
       const sessionKeyRest = adoptionSessionKeyRest(sessionKey);
       if (
@@ -1104,7 +1105,9 @@ async function assertNoPendingSupervisionBranch(params: {
   threadId: string;
 }): Promise<void> {
   const adoptedEntries = listSupervisionAgentIds(params.config)
-    .flatMap((agentId) => params.runtime.agent.session.listSessionEntries({ agentId }))
+    .flatMap((agentId) =>
+      params.runtime.agent.session.listSessionEntries({ agentId, readOnly: true }),
+    )
     .filter((candidate) => isAdoptionSessionKeyForThread(candidate.sessionKey, params.threadId));
   for (const adopted of adoptedEntries) {
     if (adopted.entry.initializationPending === true) {

--- a/extensions/qa-lab/src/runtime-parity.ts
+++ b/extensions/qa-lab/src/runtime-parity.ts
@@ -985,6 +985,7 @@ function readRuntimeParitySessionEntries(params: {
     const entries = listSessionEntries({
       agentId: params.agentId,
       env: runtimeParitySessionEnv(params.stateDir),
+      readOnly: true,
     })
       .filter(({ entry }) => readNonEmptyString(entry.sessionId))
       .map(({ entry, sessionKey }) => ({

--- a/extensions/qa-lab/src/scenario-catalog.test-utils.ts
+++ b/extensions/qa-lab/src/scenario-catalog.test-utils.ts
@@ -1,0 +1,47 @@
+import fs from "node:fs";
+import { expect } from "vitest";
+import { readQaScenarioPack } from "./scenario-catalog.js";
+
+type CatalogScenario = ReturnType<typeof readQaScenarioPack>["scenarios"][number];
+type FlowCatalogScenario = CatalogScenario & {
+  execution: Extract<CatalogScenario["execution"], { kind: "flow" }>;
+};
+
+export function listScenarioMarkdownPaths(dir = "qa/scenarios"): string[] {
+  return fs
+    .readdirSync(dir, { withFileTypes: true })
+    .flatMap((entry) => {
+      const entryPath = `${dir}/${entry.name}`;
+      if (entry.isDirectory()) {
+        return listScenarioMarkdownPaths(entryPath);
+      }
+      return entry.isFile() && entry.name.endsWith(".md") ? [entryPath] : [];
+    })
+    .toSorted();
+}
+
+export function isFlowScenario(scenario: CatalogScenario): scenario is FlowCatalogScenario {
+  return scenario.execution.kind === "flow";
+}
+
+export function requireFlowScenario(scenario: CatalogScenario): FlowCatalogScenario {
+  expect(scenario.execution.kind).toBe("flow");
+  if (!isFlowScenario(scenario)) {
+    throw new Error(`expected ${scenario.id} to be a flow scenario`);
+  }
+  return scenario;
+}
+
+export function flowContainsCall(value: unknown, callName: string): boolean {
+  if (Array.isArray(value)) {
+    return value.some((entry) => flowContainsCall(entry, callName));
+  }
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  return (
+    record.call === callName ||
+    Object.values(record).some((entry) => flowContainsCall(entry, callName))
+  );
+}

--- a/extensions/qa-lab/src/scenario-catalog.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.test.ts
@@ -12,51 +12,13 @@ import {
   readQaScenarioPack,
   validateQaScenarioExecutionConfig,
 } from "./scenario-catalog.js";
+import {
+  flowContainsCall,
+  isFlowScenario,
+  listScenarioMarkdownPaths,
+  requireFlowScenario,
+} from "./scenario-catalog.test-utils.js";
 import { runQaTestFileScenarios } from "./test-file-scenario-runner.js";
-
-type CatalogScenario = ReturnType<typeof readQaScenarioPack>["scenarios"][number];
-type FlowCatalogScenario = CatalogScenario & {
-  execution: Extract<CatalogScenario["execution"], { kind: "flow" }>;
-};
-
-function listScenarioMarkdownPaths(dir = "qa/scenarios"): string[] {
-  return fs
-    .readdirSync(dir, { withFileTypes: true })
-    .flatMap((entry) => {
-      const entryPath = `${dir}/${entry.name}`;
-      if (entry.isDirectory()) {
-        return listScenarioMarkdownPaths(entryPath);
-      }
-      return entry.isFile() && entry.name.endsWith(".md") ? [entryPath] : [];
-    })
-    .toSorted();
-}
-
-function isFlowScenario(scenario: CatalogScenario): scenario is FlowCatalogScenario {
-  return scenario.execution.kind === "flow";
-}
-
-function requireFlowScenario(scenario: CatalogScenario): FlowCatalogScenario {
-  expect(scenario.execution.kind).toBe("flow");
-  if (!isFlowScenario(scenario)) {
-    throw new Error(`expected ${scenario.id} to be a flow scenario`);
-  }
-  return scenario;
-}
-
-function flowContainsCall(value: unknown, callName: string): boolean {
-  if (Array.isArray(value)) {
-    return value.some((entry) => flowContainsCall(entry, callName));
-  }
-  if (!value || typeof value !== "object") {
-    return false;
-  }
-  const record = value as Record<string, unknown>;
-  return (
-    record.call === callName ||
-    Object.values(record).some((entry) => flowContainsCall(entry, callName))
-  );
-}
 
 describe("qa scenario catalog", () => {
   const dottedCoverageIdPattern = /^[a-z0-9][a-z0-9-]*(?:\.[a-z0-9][a-z0-9-]*)+$/;

--- a/extensions/telegram/src/bot-handlers.message-session.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.message-session.runtime.ts
@@ -81,7 +81,7 @@ export function createTelegramMessageSessionRuntime({
     });
     const entry = (telegramDeps.getSessionEntry ?? getSessionEntry)({ storePath, sessionKey });
     const store = Object.fromEntries(
-      (telegramDeps.listSessionEntries ?? listSessionEntries)({ storePath }).map(
+      (telegramDeps.listSessionEntries ?? listSessionEntries)({ storePath, readOnly: true }).map(
         ({ sessionKey: key, entry: value }) => [key, value],
       ),
     );

--- a/scripts/check-session-accessor-boundary.d.mts
+++ b/scripts/check-session-accessor-boundary.d.mts
@@ -14,6 +14,10 @@ export function findSessionAccessorBoundaryViolations(
   content: unknown,
   fileName?: string,
 ): unknown[];
+export function findReadOnlySessionAccessorViolations(
+  content: unknown,
+  fileName?: string,
+): unknown[];
 export function findEmbeddedAgentSessionTargetViolations(
   content: unknown,
   fileName?: string,
@@ -71,3 +75,4 @@ export const migratedTranscriptWriterFiles: Set<string>;
 export const migratedSessionCompactManualTrimFiles: Set<string>;
 export const migratedSessionLifecycleCleanupFiles: Set<string>;
 export const migratedMemoryHostSessionCorpusFiles: Set<string>;
+export const readOnlyGatewaySessionAccessorFiles: Set<string>;

--- a/scripts/check-session-accessor-boundary.mjs
+++ b/scripts/check-session-accessor-boundary.mjs
@@ -65,6 +65,7 @@ const sessionStoreRuntimeFileBackedCompatNames = new Set([
   "updateSessionStore",
 ]);
 const embeddedAgentSessionFileRuntimeNames = new Set(["resolveSessionFilePath"]);
+const materializingSessionEntryAccessorNames = new Set(["listSessionEntries", "loadSessionEntry"]);
 
 // Shipped beta.5 official plugins import these deprecated helpers during
 // doctor migrations. Remove this ratchet with the compatibility bridge once
@@ -244,6 +245,25 @@ export const migratedSessionLifecycleCleanupFiles = new Set([
   "src/config/sessions/cleanup-service.ts",
   "src/cron/session-reaper.ts",
   "src/infra/heartbeat-runner.ts",
+]);
+
+export const readOnlyGatewaySessionAccessorFiles = new Set([
+  "src/gateway/approval-session-audience.ts",
+  "src/gateway/control-ui-session-prs.ts",
+  "src/gateway/managed-image-attachments.ts",
+  "src/gateway/mcp-app-reconstruction.ts",
+  "src/gateway/server-chat.ts",
+  "src/gateway/server-methods/artifacts.ts",
+  "src/gateway/server-methods/chat-history-handler.ts",
+  "src/gateway/server-methods/chat-message-get-handler.ts",
+  "src/gateway/server-methods/sessions-diff.ts",
+  "src/gateway/server-methods/sessions-files.ts",
+  "src/gateway/server-methods/sessions-read.ts",
+  "src/gateway/server-methods/sessions-subscriptions.ts",
+  "src/gateway/server-methods/task-suggestions.ts",
+  "src/gateway/server-methods/tools-effective.ts",
+  "src/gateway/server-methods/usage.ts",
+  "src/gateway/server-session-events.ts",
 ]);
 
 export const migratedMemoryHostSessionCorpusFiles = new Set([
@@ -460,6 +480,15 @@ export function findSessionAccessorBoundaryViolations(content, fileName = "sourc
   const legacyNames = legacyNamesForFile(fileName);
   const legacyKind = legacyNames === legacyWholeStoreAccessNames ? "access" : "reader";
   return findNamedSessionStoreViolations(content, fileName, legacyNames, legacyKind);
+}
+
+export function findReadOnlySessionAccessorViolations(content, fileName = "source.ts") {
+  return findNamedBoundaryViolations(
+    content,
+    fileName,
+    materializingSessionEntryAccessorNames,
+    "materializing session entry accessor",
+  );
 }
 
 export function findEmbeddedAgentSessionTargetViolations(content, fileName = "source.ts") {
@@ -921,6 +950,15 @@ export async function main() {
       ),
     findViolations: findEmbeddedAgentSessionTargetViolations,
   });
+  const readOnlyGatewaySessionAccessorViolations = await collectFileViolations({
+    repoRoot,
+    sourceRoots: resolveSourceRoots(repoRoot, ["src/gateway"]),
+    skipFile: (filePath) =>
+      !readOnlyGatewaySessionAccessorFiles.has(
+        normalizeRelativePath(path.relative(repoRoot, filePath)),
+      ),
+    findViolations: findReadOnlySessionAccessorViolations,
+  });
   const sessionStoreRuntimePath = path.join(repoRoot, "src/plugin-sdk/session-store-runtime.ts");
   const sessionStoreRuntimeCompatViolations =
     findSessionStoreRuntimeFileBackedCompatExportViolations(
@@ -938,6 +976,7 @@ export async function main() {
     ...lifecycleCleanupViolations,
     ...memoryHostSessionCorpusViolations,
     ...embeddedAgentSessionTargetViolations,
+    ...readOnlyGatewaySessionAccessorViolations,
     ...sessionStoreRuntimeCompatViolations,
   ];
 

--- a/src/acp/runtime/session-meta.ts
+++ b/src/acp/runtime/session-meta.ts
@@ -7,7 +7,7 @@ import type { Insertable, Selectable } from "kysely";
 import { getRuntimeConfig } from "../../config/config.js";
 import { resolveStorePath } from "../../config/sessions/paths.js";
 import {
-  listSessionEntries,
+  listSessionEntriesReadOnly,
   patchSessionEntryWithKey,
   type SessionEntrySummary,
 } from "../../config/sessions/session-accessor.js";
@@ -366,7 +366,7 @@ function readSessionEntryFromStore(params: {
     env: params.env,
   });
   try {
-    const entries = listSessionEntries({
+    const entries = listSessionEntriesReadOnly({
       ...(agentId ? { agentId } : {}),
       storePath,
       ...(params.clone === false ? { clone: false } : {}),
@@ -438,7 +438,7 @@ export async function listAcpSessionEntries(params: {
     });
     let sessionEntries: SessionEntrySummary[];
     try {
-      sessionEntries = listSessionEntries({
+      sessionEntries = listSessionEntriesReadOnly({
         ...(agentId ? { agentId } : {}),
         storePath,
         ...(params.clone === false ? { clone: false } : {}),

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -93,21 +93,24 @@ const hoisted = vi.hoisted(() => {
       >;
       return store[scope.sessionKey];
     };
+    const listMockEntries = (
+      scope: {
+        agentId?: string;
+        env?: NodeJS.ProcessEnv;
+        storePath?: string;
+      } = {},
+    ) => {
+      const store = loadSessionStoreMock(resolveMockStorePath(scope)) as Record<
+        string,
+        SessionEntry
+      >;
+      return Object.entries(store).map(([sessionKey, entry]) => ({ sessionKey, entry }));
+    };
     return {
-      listSessionEntries: (
-        scope: {
-          agentId?: string;
-          env?: NodeJS.ProcessEnv;
-          storePath?: string;
-        } = {},
-      ) => {
-        const store = loadSessionStoreMock(resolveMockStorePath(scope)) as Record<
-          string,
-          SessionEntry
-        >;
-        return Object.entries(store).map(([sessionKey, entry]) => ({ sessionKey, entry }));
-      },
+      listSessionEntries: listMockEntries,
+      listSessionEntriesReadOnly: listMockEntries,
       loadSessionEntry: loadMockEntry,
+      loadSessionEntryReadOnly: loadMockEntry,
       resolveSessionTranscriptRuntimeTarget: async (scope: {
         agentId: string;
         sessionId: string;

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -34,8 +34,9 @@ import { parseDurationMs } from "../cli/parse-duration.js";
 import { getRuntimeConfig } from "../config/config.js";
 import { resolveStorePath } from "../config/sessions/paths.js";
 import {
-  listSessionEntries,
+  listSessionEntriesReadOnly,
   loadSessionEntry,
+  loadSessionEntryReadOnly,
   resolveSessionTranscriptRuntimeTarget,
 } from "../config/sessions/session-accessor.js";
 import type { SessionAcpMeta, SessionEntry } from "../config/sessions/types.js";
@@ -417,7 +418,7 @@ function hasSessionLocalHeartbeatRelayRoute(params: {
   const storePath = resolveStorePath(params.cfg.session?.store, {
     agentId: params.requesterAgentId,
   });
-  const parentEntry = loadSessionEntry({
+  const parentEntry = loadSessionEntryReadOnly({
     storePath,
     sessionKey: params.parentSessionKey,
     clone: false,
@@ -586,7 +587,7 @@ async function persistAcpSpawnSessionFileBestEffort(params: {
       threadId: params.threadId,
     });
     return (
-      loadSessionEntry({
+      loadSessionEntryReadOnly({
         storePath: params.storePath,
         sessionKey: resolvedSessionFile.sessionKey,
         clone: false,
@@ -724,7 +725,7 @@ function validateAcpResumeSessionOwnership(params: {
   }
 
   const storePath = resolveStorePath(params.cfg.session?.store, { agentId: params.targetAgentId });
-  for (const { sessionKey, entry } of listSessionEntries({ storePath, clone: false })) {
+  for (const { sessionKey, entry } of listSessionEntriesReadOnly({ storePath, clone: false })) {
     const acp = readAcpSessionMeta({ sessionKey, cfg: params.cfg });
     if (!sessionEntryMatchesAcpResumeSessionId(acp, resumeSessionId)) {
       continue;
@@ -1249,7 +1250,7 @@ export async function spawnAcpDirect(
   const parentDeliveryCtx =
     effectiveStreamToParent && parentSessionKey
       ? deliveryContextFromSession(
-          loadSessionEntry({
+          loadSessionEntryReadOnly({
             sessionKey: parentSessionKey,
             ...(parentAgentId ? { agentId: parentAgentId } : {}),
             clone: false,

--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -172,6 +172,7 @@ vi.mock("./command/run-context.js", () => ({
 
 vi.mock("./command/session-store.runtime.js", () => ({
   loadSessionEntry: (...args: unknown[]) => state.loadSessionEntryMock(...args),
+  loadSessionEntryReadOnly: (...args: unknown[]) => state.loadSessionEntryMock(...args),
   updateSessionStoreAfterAgentRun: (...args: unknown[]) =>
     state.updateSessionStoreAfterAgentRunMock(...args),
 }));

--- a/src/agents/bash-tools.exec-approval-followup.ts
+++ b/src/agents/bash-tools.exec-approval-followup.ts
@@ -8,7 +8,7 @@ import {
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
 import { resolveStorePath } from "../config/sessions/paths.js";
-import { loadSessionEntry } from "../config/sessions/session-accessor.js";
+import { loadSessionEntryReadOnly } from "../config/sessions/session-accessor.js";
 import { emitDiagnosticEvent } from "../infra/diagnostic-events.js";
 import {
   resolveExternalBestEffortDeliveryTarget,
@@ -130,7 +130,7 @@ function isExecApprovalFollowupDirectDeliveryStale(params: {
       agentId: resolveAgentIdFromSessionKey(sessionKey),
     });
     const resolvedSessionId = normalizeOptionalString(
-      loadSessionEntry({
+      loadSessionEntryReadOnly({
         storePath,
         sessionKey,
         clone: false,

--- a/src/agents/command/post-run.ts
+++ b/src/agents/command/post-run.ts
@@ -272,8 +272,8 @@ export async function finalizeEmbeddedAgentCommand(params: {
     const resolveFreshSessionEntryForDelivery =
       sessionStore && sessionKey && !params.suppressVisibleSessionEffects
         ? async (): Promise<SessionEntry | undefined> => {
-            const { loadSessionEntry } = await loadSessionStoreRuntime();
-            const freshEntry = loadSessionEntry({
+            const { loadSessionEntryReadOnly } = await loadSessionStoreRuntime();
+            const freshEntry = loadSessionEntryReadOnly({
               storePath,
               sessionKey,
               readConsistency: "latest",

--- a/src/agents/command/session-store.runtime.ts
+++ b/src/agents/command/session-store.runtime.ts
@@ -1,4 +1,7 @@
 // Runtime barrel for session-store writes; keeps command modules from importing
 // config/session persistence until an agent run needs to save state.
 export { updateSessionStoreAfterAgentRun } from "./session-store.js";
-export { loadSessionEntry } from "../../config/sessions/session-accessor.js";
+export {
+  loadSessionEntry,
+  loadSessionEntryReadOnly,
+} from "../../config/sessions/session-accessor.js";

--- a/src/agents/embedded-agent-runner/run/attempt-history-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-history-prepare.ts
@@ -5,7 +5,7 @@ import { buildHierarchyReinforcementMessage } from "../../../auto-reply/handoff-
 import { filterHeartbeatTranscriptArtifacts } from "../../../auto-reply/heartbeat-filter.js";
 import { resolveStorePath } from "../../../config/sessions/paths.js";
 import {
-  listSessionEntries,
+  listSessionEntriesReadOnly,
   updateSessionEntry,
 } from "../../../config/sessions/session-accessor.js";
 import { OPENCLAW_EMBEDDED_CONTEXT_ENGINE_HOST } from "../../../context-engine/host-compat.js";
@@ -119,7 +119,7 @@ export async function prepareEmbeddedAttemptHistory(input: {
       });
       const suspension = sessionEntry?.quotaSuspension;
       if (sessionEntry && suspension?.state === "resuming") {
-        const subagents = listSessionEntries({ storePath, clone: false })
+        const subagents = listSessionEntriesReadOnly({ storePath, clone: false })
           .map(({ entry }) => entry)
           .filter((entry) => entry.spawnedBy === sessionEntry.sessionId)
           .map((entry) => ({

--- a/src/agents/live-model-switch.test.ts
+++ b/src/agents/live-model-switch.test.ts
@@ -27,13 +27,17 @@ vi.mock("./model-selection.js", async () => {
   };
 });
 
-vi.mock("../config/sessions/session-accessor.js", () => ({
-  loadSessionEntry: (scope: { sessionKey: string }) => {
+vi.mock("../config/sessions/session-accessor.js", () => {
+  const loadSessionEntry = (scope: { sessionKey: string }) => {
     const store = state.loadSessionStoreMock(scope) as Record<string, unknown> | undefined;
     return store?.[scope.sessionKey];
-  },
-  patchSessionEntry: (...args: unknown[]) => state.updateSessionStoreMock(...args),
-}));
+  };
+  return {
+    loadSessionEntry,
+    loadSessionEntryReadOnly: loadSessionEntry,
+    patchSessionEntry: (...args: unknown[]) => state.updateSessionStoreMock(...args),
+  };
+});
 
 vi.mock("../config/sessions/paths.js", () => ({
   resolveStorePath: (...args: unknown[]) => state.resolveStorePathMock(...args),

--- a/src/agents/live-model-switch.ts
+++ b/src/agents/live-model-switch.ts
@@ -4,7 +4,11 @@
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { resolveStorePath } from "../config/sessions/paths.js";
-import { loadSessionEntry, patchSessionEntry } from "../config/sessions/session-accessor.js";
+import {
+  loadSessionEntry,
+  loadSessionEntryReadOnly,
+  patchSessionEntry,
+} from "../config/sessions/session-accessor.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveSessionAgentId } from "./agent-scope.js";
@@ -43,7 +47,7 @@ function resolveLiveSessionModelSelection(params: {
   const storePath = resolveStorePath(cfg.session?.store, {
     agentId,
   });
-  const entry = loadSessionEntry({
+  const entry = loadSessionEntryReadOnly({
     storePath,
     sessionKey,
     hydrateSkillPromptRefs: false,

--- a/src/agents/subagent-announce-delivery.runtime.ts
+++ b/src/agents/subagent-announce-delivery.runtime.ts
@@ -6,7 +6,7 @@
  */
 export { getRuntimeConfig } from "../config/config.js";
 export { resolveAgentIdFromSessionKey, resolveStorePath } from "../config/sessions.js";
-export { loadSessionEntry } from "../config/sessions/session-accessor.js";
+export { loadSessionEntryReadOnly as loadSessionEntry } from "../config/sessions/session-accessor.js";
 export { callGateway } from "../gateway/call.js";
 export { dispatchGatewayMethodInProcess } from "../gateway/server-plugins.js";
 export { resolveQueueSettings } from "../auto-reply/reply/queue.js";

--- a/src/agents/subagent-capabilities.ts
+++ b/src/agents/subagent-capabilities.ts
@@ -13,7 +13,7 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import { DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH } from "../config/agent-limits.js";
 import { resolveStorePath } from "../config/sessions.js";
-import { listSessionEntries } from "../config/sessions/session-accessor.js";
+import { listSessionEntriesReadOnly } from "../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   isAcpSessionKey,
@@ -105,10 +105,9 @@ function readSessionStore(
 ): Record<string, SessionCapabilityEntry> {
   try {
     return Object.fromEntries(
-      listSessionEntries({ agentId, storePath, clone: false }).map(({ sessionKey, entry }) => [
-        sessionKey,
-        entry,
-      ]),
+      listSessionEntriesReadOnly({ agentId, storePath, clone: false }).map(
+        ({ sessionKey, entry }) => [sessionKey, entry],
+      ),
     );
   } catch {
     return {};

--- a/src/agents/subagent-depth.ts
+++ b/src/agents/subagent-depth.ts
@@ -5,7 +5,7 @@
  */
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { resolveStorePath } from "../config/sessions/paths.js";
-import { listSessionEntries } from "../config/sessions/session-accessor.js";
+import { listSessionEntriesReadOnly } from "../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { parseStrictNonNegativeInteger } from "../infra/parse-finite-number.js";
 import { getSubagentDepth, parseAgentSessionKey } from "../sessions/session-key-utils.js";
@@ -31,10 +31,9 @@ function normalizeSpawnDepth(value: unknown): number | undefined {
 function readSessionStore(storePath: string, agentId: string): Record<string, SessionDepthEntry> {
   try {
     return Object.fromEntries(
-      listSessionEntries({ agentId, storePath, clone: false }).map(({ sessionKey, entry }) => [
-        sessionKey,
-        entry,
-      ]),
+      listSessionEntriesReadOnly({ agentId, storePath, clone: false }).map(
+        ({ sessionKey, entry }) => [sessionKey, entry],
+      ),
     );
   } catch {
     // ignore missing/unavailable stores

--- a/src/agents/subagent-list.ts
+++ b/src/agents/subagent-list.ts
@@ -6,7 +6,7 @@
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { resolveSubagentLabel, sortSubagentRuns } from "../auto-reply/reply/subagents-utils.js";
 import { resolveStorePath } from "../config/sessions/paths.js";
-import { listSessionEntries } from "../config/sessions/session-accessor.js";
+import { listSessionEntriesReadOnly } from "../config/sessions/session-accessor.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { parseAgentSessionKey, type ParsedAgentSessionKey } from "../routing/session-key.js";
@@ -83,7 +83,7 @@ export function resolveSessionEntryForKey(params: {
   let store = params.cache.get(storePath);
   if (!store) {
     store = Object.fromEntries(
-      listSessionEntries({ storePath, clone: false }).map(({ sessionKey, entry }) => [
+      listSessionEntriesReadOnly({ storePath, clone: false }).map(({ sessionKey, entry }) => [
         sessionKey,
         entry,
       ]),

--- a/src/agents/subagent-registry.announce-loop-guard.test.ts
+++ b/src/agents/subagent-registry.announce-loop-guard.test.ts
@@ -41,13 +41,19 @@ vi.mock("../config/sessions.js", () => ({
   updateSessionStore: mocks.updateSessionStore,
 }));
 
-vi.mock("../config/sessions/session-accessor.js", () => ({
-  listSessionEntries: () =>
-    Object.entries(sessionStore).map(([sessionKey, entry]) => ({ sessionKey, entry })),
-  loadSessionEntry: (scope: { sessionKey: keyof typeof sessionStore }) =>
-    sessionStore[scope.sessionKey],
-  patchSessionEntry: async () => null,
-}));
+vi.mock("../config/sessions/session-accessor.js", () => {
+  const listSessionEntries = () =>
+    Object.entries(sessionStore).map(([sessionKey, entry]) => ({ sessionKey, entry }));
+  const loadSessionEntry = (scope: { sessionKey: keyof typeof sessionStore }) =>
+    sessionStore[scope.sessionKey];
+  return {
+    listSessionEntries,
+    listSessionEntriesReadOnly: listSessionEntries,
+    loadSessionEntry,
+    loadSessionEntryReadOnly: loadSessionEntry,
+    patchSessionEntry: async () => null,
+  };
+});
 
 vi.mock("../gateway/call.js", () => ({
   callGateway: mocks.callGateway,

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -239,7 +239,9 @@ vi.mock("../config/sessions.js", () => ({
 
 vi.mock("../config/sessions/session-accessor.js", () => ({
   listSessionEntries: mocks.listSessionEntries,
+  listSessionEntriesReadOnly: mocks.listSessionEntries,
   loadSessionEntry: mocks.loadSessionEntry,
+  loadSessionEntryReadOnly: mocks.loadSessionEntry,
   patchSessionEntry: mocks.patchSessionEntry,
 }));
 

--- a/src/agents/subagent-session-reconciliation.ts
+++ b/src/agents/subagent-session-reconciliation.ts
@@ -10,7 +10,10 @@ import {
   resolveStorePath,
   type SessionEntry,
 } from "../config/sessions.js";
-import { listSessionEntries, loadSessionEntry } from "../config/sessions/session-accessor.js";
+import {
+  listSessionEntriesReadOnly,
+  loadSessionEntryReadOnly,
+} from "../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { SubagentRunOutcome } from "./subagent-announce-output.js";
 import {
@@ -96,7 +99,7 @@ export function loadSubagentSessionEntry(params: {
   let store = params.storeCache?.get(storePath);
   if (!store) {
     store = Object.fromEntries(
-      listSessionEntries({ storePath, clone: false }).map(({ sessionKey, entry }) => [
+      listSessionEntriesReadOnly({ storePath, clone: false }).map(({ sessionKey, entry }) => [
         sessionKey,
         entry,
       ]),
@@ -118,7 +121,7 @@ function loadSubagentSessionEntryForAccessor(params: {
   const agentId = resolveAgentIdFromSessionKey(key);
   const cfg = params.cfg ?? getRuntimeConfig();
   const storePath = resolveStorePath(cfg.session?.store, { agentId });
-  return loadSessionEntry({
+  return loadSessionEntryReadOnly({
     storePath,
     sessionKey: key,
     clone: false,

--- a/src/agents/subagent-spawn.runtime.ts
+++ b/src/agents/subagent-spawn.runtime.ts
@@ -4,7 +4,10 @@
  * entire gateway/channel stack.
  */
 export { getRuntimeConfig } from "../config/config.js";
-export { loadSessionEntry, upsertSessionEntry } from "../config/sessions/session-accessor.js";
+export {
+  loadSessionEntryReadOnly as loadSessionEntry,
+  upsertSessionEntry,
+} from "../config/sessions/session-accessor.js";
 export { forkSessionEntryFromParent } from "../auto-reply/reply/session-fork.js";
 export { ensureContextEnginesInitialized } from "../context-engine/init.js";
 export { resolveContextEngine } from "../context-engine/registry.js";

--- a/src/agents/tools/embedded-gateway-stub.runtime.ts
+++ b/src/agents/tools/embedded-gateway-stub.runtime.ts
@@ -34,7 +34,7 @@ export {
 export {
   listSessionsFromStoreAsync,
   loadCombinedSessionStoreForGateway,
-  loadSessionEntry,
+  loadSessionEntryReadOnly as loadSessionEntry,
   resolveSessionModelRef,
 } from "../../gateway/session-utils.js";
 export { resolveSessionKeyFromResolveParams } from "../../gateway/sessions-resolve.js";

--- a/src/agents/tools/image-generate-tool.test.ts
+++ b/src/agents/tools/image-generate-tool.test.ts
@@ -21,11 +21,17 @@ const taskRuntimeMocks = vi.hoisted(() => ({
   completeTaskRunByRunId: vi.fn(),
   failTaskRunByRunId: vi.fn(),
 }));
+const sessionAccessorMocks = vi.hoisted(() => ({
+  loadSessionEntryReadOnly: vi.fn(),
+}));
 
 vi.mock("../../tasks/runtime-internal.js", () => taskRuntimeInternalMocks);
 vi.mock("../../tasks/detached-task-runtime.js", () => taskRuntimeMocks);
+vi.mock("../../config/sessions/session-accessor.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../config/sessions/session-accessor.js")>()),
+  loadSessionEntryReadOnly: sessionAccessorMocks.loadSessionEntryReadOnly,
+}));
 
-let sessionAccessor: typeof import("../../config/sessions/session-accessor.js");
 let imageGenerationRuntime: typeof import("../../image-generation/runtime.js");
 let imageOps: typeof import("../../media/media-services.js");
 let splitMediaFromOutput: typeof import("../../media/parse.js").splitMediaFromOutput;
@@ -346,7 +352,6 @@ describe("createImageGenerateTool", () => {
     });
     imageGenerationRuntime = await import("../../image-generation/runtime.js");
     imageOps = await import("../../media/media-services.js");
-    sessionAccessor = await import("../../config/sessions/session-accessor.js");
     ({ splitMediaFromOutput } = await import("../../media/parse.js"));
     mediaStore = await import("../../media/store.js");
     webMedia = await import("../../media/web-media.js");
@@ -366,6 +371,7 @@ describe("createImageGenerateTool", () => {
     taskRuntimeMocks.recordTaskRunProgressByRunId.mockReset();
     taskRuntimeMocks.completeTaskRunByRunId.mockReset();
     taskRuntimeMocks.failTaskRunByRunId.mockReset();
+    sessionAccessorMocks.loadSessionEntryReadOnly.mockReset();
     taskRuntimeInternalMocks.listTasksForOwnerKey.mockReset();
     taskRuntimeInternalMocks.listTasksForOwnerKey.mockReturnValue([]);
     taskRuntimeInternalMocks.listFreshTasksForOwnerKey.mockReset();
@@ -912,7 +918,7 @@ describe("createImageGenerateTool", () => {
   it("starts run-scoped cron image generation as a tracked async task", async () => {
     stubImageGenerationProviders();
     vi.stubEnv("OPENAI_API_KEY", "openai-test");
-    vi.spyOn(sessionAccessor, "loadSessionEntry").mockReturnValue({
+    sessionAccessorMocks.loadSessionEntryReadOnly.mockReturnValue({
       sessionId: "run-123",
       updatedAt: 1,
       cronRunContinuation: {

--- a/src/agents/tools/media-generate-background-shared.test.ts
+++ b/src/agents/tools/media-generate-background-shared.test.ts
@@ -33,6 +33,7 @@ vi.mock("../../config/sessions/session-accessor.js", async () => ({
     "../../config/sessions/session-accessor.js",
   )),
   loadSessionEntry: sessionMocks.loadSessionEntry,
+  loadSessionEntryReadOnly: sessionMocks.loadSessionEntry,
 }));
 vi.mock("../../tasks/detached-task-runtime.js", () => detachedTaskRuntimeMocks);
 vi.mock("../../tasks/task-registry-delivery-runtime.js", () => taskRegistryDeliveryRuntimeMocks);

--- a/src/agents/tools/media-generate-background-shared.ts
+++ b/src/agents/tools/media-generate-background-shared.ts
@@ -5,7 +5,7 @@
  */
 import crypto from "node:crypto";
 import { getCliSessionBinding } from "../../config/sessions/cli-session-binding.js";
-import { loadSessionEntry } from "../../config/sessions/session-accessor.js";
+import { loadSessionEntryReadOnly } from "../../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { clearAgentRunContext, registerAgentRunContext } from "../../infra/agent-events.js";
 import { formatErrorMessage } from "../../infra/errors.js";
@@ -70,7 +70,7 @@ export function shouldDetachMediaGenerationTask(sessionKey: string | undefined):
     return true;
   }
   try {
-    const entry = loadSessionEntry({
+    const entry = loadSessionEntryReadOnly({
       sessionKey: normalizedSessionKey,
       clone: false,
       hydrateSkillPromptRefs: false,

--- a/src/auto-reply/reply/agent-runner-helpers.test.ts
+++ b/src/auto-reply/reply/agent-runner-helpers.test.ts
@@ -15,6 +15,7 @@ vi.mock("../../config/sessions/session-accessor.js", async () => {
   return {
     ...actual,
     loadSessionEntry: (...args: unknown[]) => hoisted.loadSessionEntryMock(...args),
+    loadSessionEntryReadOnly: (...args: unknown[]) => hoisted.loadSessionEntryMock(...args),
   };
 });
 

--- a/src/auto-reply/reply/agent-runner-helpers.ts
+++ b/src/auto-reply/reply/agent-runner-helpers.ts
@@ -4,7 +4,7 @@ import {
   hasOutboundReplyContent,
   resolveSendableOutboundReplyParts,
 } from "openclaw/plugin-sdk/reply-payload";
-import { loadSessionEntry } from "../../config/sessions/session-accessor.js";
+import { loadSessionEntryReadOnly } from "../../config/sessions/session-accessor.js";
 import { normalizeVerboseLevel, type VerboseLevel } from "../thinking.js";
 import type { ReplyPayload } from "../types.js";
 import type { TypingSignaler } from "./typing-mode.js";
@@ -29,7 +29,7 @@ function readCurrentVerboseLevel(params: VerboseGateParams): VerboseLevel | unde
     return undefined;
   }
   try {
-    const entry = loadSessionEntry({
+    const entry = loadSessionEntryReadOnly({
       storePath: params.storePath,
       sessionKey: params.sessionKey,
       clone: false,

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -36,7 +36,11 @@ import {
   type SessionEntry,
 } from "../../config/sessions.js";
 import { hasRestartRecoverySourceClaim } from "../../config/sessions/restart-recovery-state.js";
-import { loadSessionEntry, updateSessionEntry } from "../../config/sessions/session-accessor.js";
+import {
+  loadSessionEntry,
+  loadSessionEntryReadOnly,
+  updateSessionEntry,
+} from "../../config/sessions/session-accessor.js";
 import {
   formatSqliteSessionFileMarker,
   sqliteSessionFileMarkerMatchesSession,
@@ -1127,7 +1131,7 @@ function refreshSessionEntryFromStore(params: {
     return fallbackEntry;
   }
   try {
-    const latestEntry = loadSessionEntry({
+    const latestEntry = loadSessionEntryReadOnly({
       storePath,
       sessionKey,
     });

--- a/src/auto-reply/reply/commands-export-common.ts
+++ b/src/auto-reply/reply/commands-export-common.ts
@@ -4,7 +4,7 @@ import {
   resolveSessionFilePath,
   resolveSessionFilePathOptions,
 } from "../../config/sessions/paths.js";
-import { loadSessionEntry } from "../../config/sessions/session-accessor.js";
+import { loadSessionEntryReadOnly } from "../../config/sessions/session-accessor.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
@@ -56,7 +56,7 @@ export function resolveExportCommandSessionTarget(
     return { text: `❌ Failed to resolve agent for session: ${params.sessionKey}` };
   }
   const storePath = params.storePath ?? resolveDefaultSessionStorePath(targetAgentId);
-  const entry = loadSessionEntry({
+  const entry = loadSessionEntryReadOnly({
     storePath,
     sessionKey: params.sessionKey,
     clone: false,

--- a/src/auto-reply/reply/commands-export-session.test.ts
+++ b/src/auto-reply/reply/commands-export-session.test.ts
@@ -54,11 +54,15 @@ vi.mock("../../config/sessions/store.js", () => ({
   loadSessionStore: hoisted.loadSessionStoreMock,
 }));
 
-vi.mock("../../config/sessions/session-accessor.js", () => ({
-  loadSessionEntry: (scope: { storePath?: string; sessionKey: string }) =>
-    (hoisted.loadSessionStoreMock(scope.storePath) as Record<string, unknown>)[scope.sessionKey],
-  loadTranscriptEvents: hoisted.loadTranscriptEventsMock,
-}));
+vi.mock("../../config/sessions/session-accessor.js", () => {
+  const loadSessionEntry = (scope: { storePath?: string; sessionKey: string }) =>
+    (hoisted.loadSessionStoreMock(scope.storePath) as Record<string, unknown>)[scope.sessionKey];
+  return {
+    loadSessionEntry,
+    loadSessionEntryReadOnly: loadSessionEntry,
+    loadTranscriptEvents: hoisted.loadTranscriptEventsMock,
+  };
+});
 
 vi.mock("./commands-system-prompt.js", () => ({
   resolveCommandsSystemPromptBundle: hoisted.resolveCommandsSystemPromptBundleMock,

--- a/src/auto-reply/reply/commands-name.ts
+++ b/src/auto-reply/reply/commands-name.ts
@@ -4,7 +4,7 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import {
   applySessionPatchProjection,
-  loadSessionEntry,
+  loadSessionEntryReadOnly,
 } from "../../config/sessions/session-accessor.js";
 import { normalizeStoreSessionKey } from "../../config/sessions/store-entry.js";
 import { deriveSessionTitle } from "../../gateway/session-utils.js";
@@ -38,7 +38,10 @@ function syncNameSessionEntry(params: HandleCommandsParams): void {
   if (!params.sessionStore || !params.sessionKey || !params.storePath) {
     return;
   }
-  const entry = loadSessionEntry({ sessionKey: params.sessionKey, storePath: params.storePath });
+  const entry = loadSessionEntryReadOnly({
+    sessionKey: params.sessionKey,
+    storePath: params.storePath,
+  });
   if (!entry) {
     return;
   }
@@ -69,7 +72,7 @@ export const handleNameCommand: CommandHandler = async (params, allowTextCommand
   // derived locally (no LLM, no mutation). Apply it with `/name <title>`.
   if (!title) {
     const entry =
-      loadSessionEntry({ sessionKey: params.sessionKey, storePath: params.storePath }) ??
+      loadSessionEntryReadOnly({ sessionKey: params.sessionKey, storePath: params.storePath }) ??
       params.sessionEntry;
     const current = normalizeOptionalString(entry?.label);
     const suggestionEntry = entry ? { ...entry, label: undefined } : undefined;

--- a/src/auto-reply/reply/commands-subagents/action-info.ts
+++ b/src/auto-reply/reply/commands-subagents/action-info.ts
@@ -4,7 +4,7 @@ import { subagentRuns } from "../../../agents/subagent-registry-memory.js";
 import { countPendingDescendantRunsFromRuns } from "../../../agents/subagent-registry-queries.js";
 import { getSubagentRunsSnapshotForRead } from "../../../agents/subagent-registry-state.js";
 import { resolveStorePath } from "../../../config/sessions/paths.js";
-import { loadSessionEntry } from "../../../config/sessions/session-accessor.js";
+import { loadSessionEntryReadOnly } from "../../../config/sessions/session-accessor.js";
 import { formatTimeAgo } from "../../../infra/format-time/format-relative.ts";
 import { parseAgentSessionKey } from "../../../routing/session-key.js";
 import { formatDurationCompact } from "../../../shared/subagents-format.js";
@@ -48,7 +48,7 @@ function loadSubagentSessionEntry(params: SubagentsCommandContext["params"], chi
     agentId: parsed?.agentId,
   });
   return {
-    entry: loadSessionEntry({
+    entry: loadSessionEntryReadOnly({
       storePath,
       sessionKey: childKey,
       clone: false,

--- a/src/auto-reply/reply/conversation-turn-capture.ts
+++ b/src/auto-reply/reply/conversation-turn-capture.ts
@@ -11,7 +11,7 @@ import { conversationIdentityFromMsgContext } from "../../config/sessions/conver
 import { resolveStorePath } from "../../config/sessions/paths.js";
 import {
   appendTranscriptEventSync,
-  loadSessionEntry,
+  loadSessionEntryReadOnly,
 } from "../../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { logVerbose } from "../../globals.js";
@@ -95,7 +95,7 @@ async function capturePendingConversationTurnReplyUnsafe(params: {
   const agentId =
     normalizeOptionalString(params.ctx.AgentId) ?? resolveAgentIdFromSessionKey(sessionKey);
   const storePath = resolveStorePath(params.cfg.session?.store, { agentId });
-  const sessionEntry = loadSessionEntry({
+  const sessionEntry = loadSessionEntryReadOnly({
     agentId,
     sessionKey,
     storePath,

--- a/src/auto-reply/reply/dispatch-acp-transcript.runtime.ts
+++ b/src/auto-reply/reply/dispatch-acp-transcript.runtime.ts
@@ -3,7 +3,7 @@ import { resolveAcpSessionCwd } from "@openclaw/acp-core/runtime/session-identif
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { persistAcpTurnTranscript } from "../../agents/command/attempt-execution.js";
 import { resolveStorePath } from "../../config/sessions.js";
-import { loadSessionEntry } from "../../config/sessions/session-accessor.js";
+import { loadSessionEntryReadOnly } from "../../config/sessions/session-accessor.js";
 import type { SessionAcpMeta } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 
@@ -28,7 +28,7 @@ export async function persistAcpDispatchTranscript(params: {
   const storePath = resolveStorePath(params.cfg.session?.store, {
     agentId: sessionAgentId,
   });
-  const sessionEntry = loadSessionEntry({
+  const sessionEntry = loadSessionEntryReadOnly({
     agentId: sessionAgentId,
     sessionKey: params.sessionKey,
     storePath,

--- a/src/auto-reply/reply/dispatch-from-config.pending-final.ts
+++ b/src/auto-reply/reply/dispatch-from-config.pending-final.ts
@@ -1,5 +1,8 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import { loadSessionEntry, updateSessionEntry } from "../../config/sessions/session-accessor.js";
+import {
+  loadSessionEntryReadOnly,
+  updateSessionEntry,
+} from "../../config/sessions/session-accessor.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import type { ReplyPayload } from "../reply-payload.js";
 import { getReplyPayloadMetadata } from "../reply-payload.js";
@@ -114,7 +117,7 @@ export function capturePendingFinalDeliveryIdentity(params: {
     return undefined;
   }
   try {
-    const entry = loadSessionEntry({
+    const entry = loadSessionEntryReadOnly({
       storePath: params.storePath,
       sessionKey: params.sessionKey,
       hydrateSkillPromptRefs: false,

--- a/src/auto-reply/reply/dispatch-from-config.runtime.ts
+++ b/src/auto-reply/reply/dispatch-from-config.runtime.ts
@@ -1,6 +1,6 @@
 /** Runtime-only dispatch dependencies shared by config-driven reply delivery. */
 /** Runtime-only dispatch dependencies shared by config-driven reply delivery. */
-import { loadSessionEntry } from "../../config/sessions/session-accessor.js";
+import { loadSessionEntryReadOnly } from "../../config/sessions/session-accessor.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 
 export { resolveStorePath } from "../../config/sessions/paths.js";
@@ -13,5 +13,5 @@ export function loadSessionStoreEntry(params: {
   readConsistency?: "latest";
   clone?: boolean;
 }): SessionEntry | undefined {
-  return loadSessionEntry(params);
+  return loadSessionEntryReadOnly(params);
 }

--- a/src/auto-reply/reply/dispatch-from-config.shared.test-harness.ts
+++ b/src/auto-reply/reply/dispatch-from-config.shared.test-harness.ts
@@ -491,6 +491,7 @@ vi.mock("../../config/sessions/session-accessor.js", async (importOriginal) => {
   return {
     ...actual,
     loadSessionEntry: (...args: unknown[]) => sessionStoreMocks.loadSessionEntry(...args),
+    loadSessionEntryReadOnly: (...args: unknown[]) => sessionStoreMocks.loadSessionEntry(...args),
     updateSessionEntry: (...args: Parameters<typeof sessionStoreMocks.updateSessionEntry>) =>
       sessionStoreMocks.updateSessionEntry(...args),
   };

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -35,7 +35,11 @@ import { resolveSessionRuntimeOverrideForProvider } from "../../agents/session-r
 import { resolveCandidateThinkingLevel } from "../../agents/thinking-runtime.js";
 import { normalizeAgentPlanSteps } from "../../channels/streaming.js";
 import type { SessionEntry } from "../../config/sessions.js";
-import { loadSessionEntry, updateSessionEntry } from "../../config/sessions/session-accessor.js";
+import {
+  loadSessionEntry,
+  loadSessionEntryReadOnly,
+  updateSessionEntry,
+} from "../../config/sessions/session-accessor.js";
 import type { TypingMode } from "../../config/types.js";
 import { logVerbose } from "../../globals.js";
 import {
@@ -592,7 +596,7 @@ export function createFollowupRunner(params: {
       const resolveCurrentVerboseLevel = () => {
         if (replySessionKey && storePath) {
           try {
-            const level = loadSessionEntry({
+            const level = loadSessionEntryReadOnly({
               storePath,
               sessionKey: replySessionKey,
             })?.verboseLevel;

--- a/src/auto-reply/reply/queue/drain.ts
+++ b/src/auto-reply/reply/queue/drain.ts
@@ -5,7 +5,7 @@ import { runAgentHarnessBeforeMessageWriteHook } from "../../../agents/harness/h
 import { stableStringify } from "../../../agents/stable-stringify.js";
 import { normalizeChatType } from "../../../channels/chat-type.js";
 import { resolveStorePath } from "../../../config/sessions.js";
-import { loadSessionEntry } from "../../../config/sessions/session-accessor.js";
+import { loadSessionEntryReadOnly } from "../../../config/sessions/session-accessor.js";
 // Drains queued follow-up runs while preserving route and session identity.
 import {
   channelRouteCompactKey,
@@ -343,7 +343,7 @@ function resolveFollowupTranscriptTarget(source: FollowupRun) {
   const storePath = resolveStorePath(source.run.config.session?.store, {
     agentId: source.run.agentId,
   });
-  const sessionEntry = loadSessionEntry({
+  const sessionEntry = loadSessionEntryReadOnly({
     storePath,
     sessionKey,
     clone: false,

--- a/src/channels/feedback-reflection.test.ts
+++ b/src/channels/feedback-reflection.test.ts
@@ -12,6 +12,7 @@ vi.mock("../config/sessions/paths.js", () => ({ resolveStorePath }));
 vi.mock("../config/sessions/session-accessor.js", () => ({
   appendTranscriptEvent,
   loadSessionEntry,
+  loadSessionEntryReadOnly: loadSessionEntry,
   readSessionUpdatedAt,
 }));
 vi.mock("./turn/kernel.js", () => ({ dispatchChannelInboundTurn }));

--- a/src/channels/feedback-reflection.ts
+++ b/src/channels/feedback-reflection.ts
@@ -1,6 +1,9 @@
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { resolveStorePath } from "../config/sessions/paths.js";
-import { appendTranscriptEvent, loadSessionEntry } from "../config/sessions/session-accessor.js";
+import {
+  appendTranscriptEvent,
+  loadSessionEntryReadOnly,
+} from "../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { buildChannelInboundEventContext } from "./inbound-event/context.js";
 import { createChannelInboundEnvelopeBuilder } from "./inbound-event/envelope.js";
@@ -18,7 +21,7 @@ export async function recordChannelFeedbackEvent(params: {
   event: Parameters<typeof appendTranscriptEvent>[1];
 }): Promise<boolean> {
   const storePath = resolveStorePath(params.cfg.session?.store, { agentId: params.agentId });
-  const entry = loadSessionEntry({
+  const entry = loadSessionEntryReadOnly({
     agentId: params.agentId,
     sessionKey: params.sessionKey,
     storePath,

--- a/src/commands/sessions-tail.ts
+++ b/src/commands/sessions-tail.ts
@@ -11,7 +11,7 @@ import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { readAcpSessionMeta } from "../acp/runtime/session-meta.js";
 import { getRuntimeConfig } from "../config/config.js";
 import { resolveSessionFilePath } from "../config/sessions/paths.js";
-import { listSessionEntries } from "../config/sessions/session-accessor.js";
+import { listSessionEntriesReadOnly } from "../config/sessions/session-accessor.js";
 import { parseSqliteSessionFileMarker } from "../config/sessions/sqlite-marker.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import { resolveStoredSessionKeyForAgentStore } from "../gateway/session-store-key.js";
@@ -681,7 +681,7 @@ export async function sessionsTailCommand(
 
   const selections: TailSelection[] = [];
   for (const target of targets) {
-    for (const { sessionKey, entry } of listSessionEntries({
+    for (const { sessionKey, entry } of listSessionEntriesReadOnly({
       agentId: target.agentId,
       storePath: target.storePath,
     })) {

--- a/src/commands/sessions.default-agent-store.test.ts
+++ b/src/commands/sessions.default-agent-store.test.ts
@@ -45,6 +45,7 @@ vi.mock("../infra/state-migrations.js", async () => ({
 
 vi.mock("../config/sessions/session-accessor.js", () => ({
   listSessionEntries: listSessionEntriesMock,
+  listSessionEntriesReadOnly: listSessionEntriesMock,
 }));
 
 import { sessionsCommand } from "./sessions.js";

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -16,7 +16,7 @@ import { resolveRuntimePolicySessionKey } from "../auto-reply/reply/runtime-poli
 import { normalizeChatType } from "../channels/chat-type.js";
 import { getRuntimeConfig } from "../config/config.js";
 import { resolveSessionTotalTokens } from "../config/sessions.js";
-import { listSessionEntries } from "../config/sessions/session-accessor.js";
+import { listSessionEntriesReadOnly } from "../config/sessions/session-accessor.js";
 import { resolveSqliteTargetFromSessionStorePath } from "../config/sessions/session-sqlite-target.js";
 import {
   formatSqliteSessionFileMarker,
@@ -381,7 +381,7 @@ export async function sessionsCommand(
   }
 
   const allRows = targets.flatMap((target) => {
-    return listSessionEntries({ agentId: target.agentId, storePath: target.storePath })
+    return listSessionEntriesReadOnly({ agentId: target.agentId, storePath: target.storePath })
       .filter(({ entry }) => {
         if (activeMinutes === undefined) {
           return true;

--- a/src/commands/status.agent-local.ts
+++ b/src/commands/status.agent-local.ts
@@ -4,7 +4,7 @@
 import path from "node:path";
 import { resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
 import { resolveStorePath } from "../config/sessions/paths.js";
-import { listSessionEntries } from "../config/sessions/session-accessor.js";
+import { listSessionEntriesReadOnly } from "../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../config/types.js";
 import { listGatewayAgentsBasic } from "../gateway/agent-list.js";
 import { pathExists } from "../infra/fs-safe.js";
@@ -50,7 +50,7 @@ export async function getAgentLocalStatuses(
     const bootstrapPending = bootstrapPath != null ? await pathExists(bootstrapPath) : null;
 
     const sessionsPath = resolveStorePath(cfg.session?.store, { agentId });
-    const sessions = listSessionEntries({ agentId, storePath: sessionsPath })
+    const sessions = listSessionEntriesReadOnly({ agentId, storePath: sessionsPath })
       // Global/unknown buckets are aggregate compatibility entries, not agent activity.
       .filter(({ sessionKey }) => sessionKey !== "global" && sessionKey !== "unknown")
       .map(({ entry }) => entry);

--- a/src/commands/status.summary.test.ts
+++ b/src/commands/status.summary.test.ts
@@ -137,6 +137,7 @@ vi.mock("../config/sessions/paths.js", () => ({
 
 vi.mock("../config/sessions/session-accessor.js", () => ({
   listSessionEntries: statusSummaryMocks.listSessionEntries,
+  listSessionEntriesReadOnly: statusSummaryMocks.listSessionEntries,
 }));
 
 vi.mock("../gateway/agent-list.js", () => ({

--- a/src/commands/status.summary.ts
+++ b/src/commands/status.summary.ts
@@ -10,7 +10,7 @@ import {
   hasSessionAutoModelFallbackProvenance,
 } from "../config/sessions/model-override-provenance.js";
 import { resolveStorePath } from "../config/sessions/paths.js";
-import { listSessionEntries } from "../config/sessions/session-accessor.js";
+import { listSessionEntriesReadOnly } from "../config/sessions/session-accessor.js";
 import { resolveSessionTotalTokens, type SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.js";
 import { listGatewayAgentsBasic } from "../gateway/agent-list.js";
@@ -213,7 +213,7 @@ function selectRecentSessionCandidates(
 
 function listSessionCandidates(storePath: string, agentId?: string) {
   return (
-    listSessionEntries({
+    listSessionEntriesReadOnly({
       ...(agentId ? { agentId } : {}),
       storePath,
     })

--- a/src/config/sessions/combined-store-gateway.ts
+++ b/src/config/sessions/combined-store-gateway.ts
@@ -10,7 +10,7 @@ import {
 import { normalizeAgentId } from "../../routing/session-key.js";
 import type { OpenClawConfig } from "../types.openclaw.js";
 import { resolveStorePath } from "./paths.js";
-import { listSessionEntries } from "./session-accessor.js";
+import { listSessionEntriesReadOnly } from "./session-accessor.js";
 import {
   resolveAgentSessionStoreTargetsSync,
   resolveAllAgentSessionStoreTargetsSync,
@@ -28,7 +28,7 @@ function loadGatewayStoreEntries(params: {
   storePath: string;
 }): Record<string, SessionEntry> {
   return Object.fromEntries(
-    listSessionEntries({
+    listSessionEntriesReadOnly({
       agentId: params.agentId,
       clone: false,
       storePath: params.storePath,

--- a/src/config/sessions/entry-freshness.ts
+++ b/src/config/sessions/entry-freshness.ts
@@ -12,7 +12,7 @@ import {
   type SessionResetPolicy,
   type SessionResetType,
 } from "./reset.js";
-import { loadSessionEntry, type SessionAccessScope } from "./session-accessor.js";
+import { loadSessionEntryReadOnly, type SessionAccessScope } from "./session-accessor.js";
 import type { SessionEntry } from "./types.js";
 
 type ResolveSessionEntryResetFreshnessParams = SessionAccessScope & {
@@ -62,7 +62,7 @@ export function resolveSessionEntryResetFreshness(
       agentId,
       env: params.env,
     });
-  const entry = loadSessionEntry({
+  const entry = loadSessionEntryReadOnly({
     ...params,
     agentId,
     storePath,

--- a/src/config/sessions/goals.ts
+++ b/src/config/sessions/goals.ts
@@ -5,7 +5,7 @@ import {
   type SessionStateActorType,
 } from "../../sessions/session-state-events.js";
 import { formatTokenCount } from "../../utils/token-format.js";
-import { loadSessionEntry, patchSessionEntry } from "./session-accessor.js";
+import { loadSessionEntryReadOnly, patchSessionEntry } from "./session-accessor.js";
 import { resolveFreshSessionTotalTokens } from "./types.js";
 import type { SessionEntry, SessionGoal, SessionGoalStatus } from "./types.js";
 
@@ -182,7 +182,7 @@ export async function getSessionGoal(
   if (options.persist === false) {
     // Status rendering should not write incidental budget/baseline adoption unless callers opt in.
     const entry =
-      loadSessionEntry({ sessionKey: options.sessionKey, storePath: options.storePath }) ??
+      loadSessionEntryReadOnly({ sessionKey: options.sessionKey, storePath: options.storePath }) ??
       options.fallbackEntry;
     const projected = entry
       ? resolveSessionGoalDisplayState(entry, now, { adoptFreshBaseline: false })

--- a/src/config/sessions/session-accessor.entry.ts
+++ b/src/config/sessions/session-accessor.entry.ts
@@ -163,10 +163,9 @@ export function resolveSessionEntryCandidateTarget(
     env: scope.env,
   });
   const store = Object.fromEntries(
-    listSessionEntries({ agentId: scope.agentId, storePath }).map(({ sessionKey, entry }) => [
-      sessionKey,
-      entry,
-    ]),
+    listSessionEntriesReadOnly({ agentId: scope.agentId, storePath }).map(
+      ({ sessionKey, entry }) => [sessionKey, entry],
+    ),
   );
   for (const candidateKey of uniqueStrings(scope.candidateKeys.map((key) => key.trim()))) {
     if (!candidateKey) {

--- a/src/config/sessions/session-accessor.reset.ts
+++ b/src/config/sessions/session-accessor.reset.ts
@@ -8,6 +8,7 @@ import {
 } from "./session-accessor.entry-mutation.js";
 import {
   listSessionEntries,
+  listSessionEntriesReadOnly,
   replaceSessionEntry,
   resolveSessionEntryFromStore,
 } from "./session-accessor.entry.js";
@@ -162,7 +163,7 @@ export function loadReplySessionInitializationSnapshot(params: {
   sessionKey: string;
 }): ReplySessionInitializationSnapshot {
   const store = Object.fromEntries(
-    listSessionEntries({ storePath: params.storePath }).map(({ sessionKey, entry }) => [
+    listSessionEntriesReadOnly({ storePath: params.storePath }).map(({ sessionKey, entry }) => [
       sessionKey,
       entry,
     ]),

--- a/src/config/sessions/session-accessor.transcript-target.ts
+++ b/src/config/sessions/session-accessor.transcript-target.ts
@@ -8,6 +8,7 @@ import {
 import {
   loadSessionEntry,
   listSessionEntries,
+  listSessionEntriesReadOnly,
   resolveSessionEntryFromStore,
 } from "./session-accessor.entry.js";
 import type {
@@ -195,7 +196,7 @@ export function resolveSessionTranscriptReadTarget(
       : storePath
         ? resolveSessionEntryFromStore({
             store: Object.fromEntries(
-              listSessionEntries({ agentId, storePath }).map(({ sessionKey, entry }) => [
+              listSessionEntriesReadOnly({ agentId, storePath }).map(({ sessionKey, entry }) => [
                 sessionKey,
                 entry,
               ]),

--- a/src/config/sessions/skill-suggestions.ts
+++ b/src/config/sessions/skill-suggestions.ts
@@ -1,6 +1,6 @@
 // Session skill suggestions are one-shot hints consumed by the next interactive turn.
 import {
-  loadSessionEntry,
+  loadSessionEntryReadOnly,
   patchSessionEntry,
   type SessionAccessScope,
 } from "./session-accessor.js";
@@ -45,7 +45,7 @@ function appendSignalHashes(entry: SessionEntry, signalHashes: readonly string[]
 export function readSessionSkillCaptureSignalHashes(
   options: SessionSkillSuggestionScope,
 ): string[] | undefined {
-  const entry = loadSessionEntry({ ...options, readConsistency: "latest" });
+  const entry = loadSessionEntryReadOnly({ ...options, readConsistency: "latest" });
   return entry ? [...(entry.skillCaptureSignalHashes ?? [])] : undefined;
 }
 

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -18,7 +18,7 @@ import type { OpenClawConfig } from "../types.openclaw.js";
 import { resolveDefaultSessionStorePath, resolveStorePath } from "./paths.js";
 import {
   listSessionEntries,
-  loadSessionEntry,
+  loadSessionEntryReadOnly,
   loadTranscriptEvents,
   isSessionTranscriptProjectionUnavailableError,
   persistSessionTranscriptTurn,
@@ -269,7 +269,7 @@ function resolveSessionConversationTranscriptTarget(params: {
   }
   const agentId = params.agentId ?? resolveAgentIdFromSessionKey(sessionKey) ?? "main";
   const storePath = params.storePath ?? resolveDefaultSessionStorePath(agentId);
-  const entry = loadSessionEntry({ agentId, sessionKey, storePath });
+  const entry = loadSessionEntryReadOnly({ agentId, sessionKey, storePath });
   if (!entry?.sessionId) {
     return {};
   }

--- a/src/cron/isolated-agent/delivery-target.issue-91613.test.ts
+++ b/src/cron/isolated-agent/delivery-target.issue-91613.test.ts
@@ -31,9 +31,13 @@ vi.mock("../../config/sessions/paths.js", () => ({
   resolveStorePath: vi.fn().mockReturnValue("/tmp/test-store.json"),
 }));
 
-vi.mock("../../config/sessions/session-accessor.js", () => ({
-  loadSessionEntry: vi.fn(),
-}));
+vi.mock("../../config/sessions/session-accessor.js", () => {
+  const loadSessionEntry = vi.fn();
+  return {
+    loadSessionEntry,
+    loadSessionEntryReadOnly: loadSessionEntry,
+  };
+});
 
 vi.mock("../../infra/outbound/channel-selection.runtime.js", () => ({
   resolveMessageChannelSelection: vi

--- a/src/cron/isolated-agent/delivery-target.test.ts
+++ b/src/cron/isolated-agent/delivery-target.test.ts
@@ -32,9 +32,13 @@ vi.mock("../../config/sessions/paths.js", () => ({
   resolveStorePath: vi.fn().mockReturnValue("/tmp/test-store.json"),
 }));
 
-vi.mock("../../config/sessions/session-accessor.js", () => ({
-  loadSessionEntry: vi.fn(),
-}));
+vi.mock("../../config/sessions/session-accessor.js", () => {
+  const loadSessionEntry = vi.fn();
+  return {
+    loadSessionEntry,
+    loadSessionEntryReadOnly: loadSessionEntry,
+  };
+});
 
 vi.mock("../../infra/outbound/channel-selection.runtime.js", () => ({
   resolveMessageChannelSelection: vi

--- a/src/cron/isolated-agent/delivery-target.ts
+++ b/src/cron/isolated-agent/delivery-target.ts
@@ -5,7 +5,7 @@ import { resolveExplicitDeliveryTargetCompat } from "../../channels/plugins/targ
 import type { ChannelId } from "../../channels/plugins/types.public.js";
 import { resolveAgentMainSessionKey } from "../../config/sessions/main-session.js";
 import { resolveStorePath } from "../../config/sessions/paths.js";
-import { loadSessionEntry } from "../../config/sessions/session-accessor.js";
+import { loadSessionEntryReadOnly } from "../../config/sessions/session-accessor.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { formatErrorMessage } from "../../infra/errors.js";
@@ -178,9 +178,9 @@ export async function resolveDeliveryTarget(
       } satisfies SessionEntry)
     : undefined;
   const threadEntry = threadSessionKey
-    ? loadSessionEntry({ agentId, sessionKey: threadSessionKey, storePath })
+    ? loadSessionEntryReadOnly({ agentId, sessionKey: threadSessionKey, storePath })
     : undefined;
-  const mainEntry = loadSessionEntry({ agentId, sessionKey: mainSessionKey, storePath });
+  const mainEntry = loadSessionEntryReadOnly({ agentId, sessionKey: mainSessionKey, storePath });
   const main = storedDeliveryEntry ?? threadEntry ?? mainEntry;
   // True when the cron has no delivery identity of its own (no per-job target, no own
   // sessionKey, no stored/creation delivery context) and therefore fell back to the SHARED

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -1,7 +1,7 @@
 /** Cron timer loop, execution, catch-up, and run-result state transitions. */
 import pMap, { pMapSkip } from "p-map";
 import { resolveCronTriggerMinIntervalMs } from "../../config/cron-limits.js";
-import { loadSessionEntry } from "../../config/sessions/session-accessor.js";
+import { loadSessionEntryReadOnly } from "../../config/sessions/session-accessor.js";
 import type { CronConfig } from "../../config/types.cron.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import type { HeartbeatRunResult } from "../../infra/heartbeat-wake.js";
@@ -491,7 +491,7 @@ function resolveMainSessionCronDeliveryContext(
     return undefined;
   }
   try {
-    const sessionEntry = loadSessionEntry({
+    const sessionEntry = loadSessionEntryReadOnly({
       agentId,
       sessionKey: targetSessionKey,
       storePath,

--- a/src/gateway/approval-session-audience.test.ts
+++ b/src/gateway/approval-session-audience.test.ts
@@ -33,6 +33,7 @@ vi.mock("../agents/subagent-registry-read.js", () => ({
 }));
 vi.mock("../config/sessions/session-accessor.js", () => ({
   loadSessionEntry: (scope: { sessionKey: string }) => loadSessionEntryMock(scope),
+  loadSessionEntryReadOnly: (scope: { sessionKey: string }) => loadSessionEntryMock(scope),
 }));
 
 beforeEach(() => {

--- a/src/gateway/approval-session-audience.ts
+++ b/src/gateway/approval-session-audience.ts
@@ -1,7 +1,7 @@
 import { resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { buildLatestSubagentRunReadIndex } from "../agents/subagent-registry-read.js";
 import { getRuntimeConfig } from "../config/io.js";
-import { loadSessionEntry } from "../config/sessions/session-accessor.js";
+import { loadSessionEntryReadOnly } from "../config/sessions/session-accessor.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizeAgentId, parseAgentSessionKey } from "../routing/session-key.js";
@@ -129,7 +129,7 @@ function createRuntimeApprovalSessionAudienceSources(
     getLatestSubagentLineage: (sessionKey) => subagentRuns.getLatestSubagentRun(sessionKey),
     getStoredSessionLineage: (sessionKey) => {
       const target = resolveStorageTarget(sessionKey);
-      return loadSessionEntry({
+      return loadSessionEntryReadOnly({
         agentId: target.agentId,
         clone: false,
         hydrateSkillPromptRefs: false,

--- a/src/gateway/control-ui-session-prs.ts
+++ b/src/gateway/control-ui-session-prs.ts
@@ -21,7 +21,7 @@ import {
   optionalString,
 } from "./control-ui-github-api.js";
 import { parseGitHubRemoteUrl } from "./github-remote.js";
-import { loadSessionEntry } from "./session-utils.js";
+import { loadSessionEntryReadOnly } from "./session-utils.js";
 
 const SUCCESS_CACHE_MS = 60_000;
 // Back off refetches while GitHub reports quota exhaustion; the UI keeps
@@ -106,7 +106,7 @@ async function gitOutput(cwd: string, args: string[]): Promise<string | null> {
 async function resolveSessionPullRequestGitContext(
   params: ControlUiSessionPullRequestsParams,
 ): Promise<SessionPullRequestGitContext | null> {
-  const { cfg, entry, storePath, canonicalKey } = loadSessionEntry(params.sessionKey, {
+  const { cfg, entry, storePath, canonicalKey } = loadSessionEntryReadOnly(params.sessionKey, {
     agentId: params.agentId,
   });
   // Same session/agent scoping as sessions.files.*: a missing entry means an

--- a/src/gateway/managed-image-attachments.test.ts
+++ b/src/gateway/managed-image-attachments.test.ts
@@ -41,6 +41,7 @@ vi.mock("./http-utils.js", () => ({
 
 vi.mock("./session-utils.js", () => ({
   loadSessionEntry: loadSessionEntryMock,
+  loadSessionEntryReadOnly: loadSessionEntryMock,
   resolveSessionHistoryTranscriptPathAsync: resolveSessionHistoryTranscriptPathMock,
 }));
 

--- a/src/gateway/managed-image-attachments.ts
+++ b/src/gateway/managed-image-attachments.ts
@@ -37,7 +37,10 @@ import {
 } from "./managed-image-record-store.js";
 import { authorizeOperatorScopesForMethod } from "./method-scopes.js";
 import { readSessionMessagesWithSourceAsync } from "./session-transcript-readers.js";
-import { loadSessionEntry, resolveSessionHistoryTranscriptPathAsync } from "./session-utils.js";
+import {
+  loadSessionEntryReadOnly,
+  resolveSessionHistoryTranscriptPathAsync,
+} from "./session-utils.js";
 
 const OUTGOING_IMAGE_ROUTE_PREFIX = "/api/chat/media/outgoing";
 const DEFAULT_TRANSIENT_OUTGOING_IMAGE_TTL_MS = 15 * 60 * 1000;
@@ -669,7 +672,7 @@ async function getSessionManagedOutgoingAttachmentIndex(
   if (cache?.has(cacheKey)) {
     return cache.get(cacheKey) ?? null;
   }
-  const { storePath, entry } = loadSessionEntry(
+  const { storePath, entry } = loadSessionEntryReadOnly(
     sessionKey,
     sessionKey === "global" && agentId ? { agentId } : undefined,
   );

--- a/src/gateway/mcp-app-reconstruction.test.ts
+++ b/src/gateway/mcp-app-reconstruction.test.ts
@@ -30,6 +30,7 @@ vi.mock("./session-transcript-readers.js", () => ({
 }));
 vi.mock("./session-utils.js", () => ({
   loadSessionEntry: mocks.loadSessionEntry,
+  loadSessionEntryReadOnly: mocks.loadSessionEntry,
 }));
 
 import { mintMcpAppViewFromTranscript, restoreMcpAppView } from "./mcp-app-reconstruction.js";

--- a/src/gateway/mcp-app-reconstruction.ts
+++ b/src/gateway/mcp-app-reconstruction.ts
@@ -11,7 +11,7 @@ import {
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveAgentIdFromSessionKey } from "../routing/session-key.js";
 import { visitSessionMessagesAsync } from "./session-transcript-readers.js";
-import { loadSessionEntry } from "./session-utils.js";
+import { loadSessionEntryReadOnly } from "./session-utils.js";
 
 const MCP_APP_RESTORE_IN_FLIGHT_KEY = Symbol.for("openclaw.mcpAppRestoreInFlight");
 
@@ -254,7 +254,7 @@ async function reconstructMcpAppView(params: {
   viewId?: string;
 }): Promise<ReconstructionResult | undefined> {
   const agentId = resolveAgentIdFromSessionKey(params.sessionKey);
-  const loaded = loadSessionEntry(params.sessionKey, { agentId });
+  const loaded = loadSessionEntryReadOnly(params.sessionKey, { agentId });
   const sessionId = loaded.entry?.sessionId;
   if (!sessionId) {
     return undefined;

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -45,8 +45,8 @@ vi.mock("./server-chat.load-gateway-session-row.runtime.js", () => ({
   loadGatewaySessionRow: vi.fn(),
 }));
 
-vi.mock("./session-utils.js", () => ({
-  loadSessionEntry: vi.fn(() => ({
+vi.mock("./session-utils.js", () => {
+  const loadSessionEntry = vi.fn(() => ({
     cfg: {},
     storePath: "/tmp/sessions.json",
     store: {},
@@ -54,8 +54,12 @@ vi.mock("./session-utils.js", () => ({
     canonicalKey: "session-1",
     storeKeys: ["session-1"],
     legacyKey: undefined,
-  })),
-}));
+  }));
+  return {
+    loadSessionEntry,
+    loadSessionEntryReadOnly: loadSessionEntry,
+  };
+});
 
 import { getRuntimeConfig } from "../config/io.js";
 import { resolveHeartbeatVisibility } from "../infra/heartbeat-visibility.js";

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -56,7 +56,7 @@ import {
   isRestartRecoveryLifecycleEvent,
   isStaleLifecycleEventForSession,
 } from "./session-lifecycle-state.js";
-import { loadSessionEntry } from "./session-utils.js";
+import { loadSessionEntryReadOnly } from "./session-utils.js";
 import { formatForLog } from "./ws-log.js";
 
 export {
@@ -443,7 +443,7 @@ export function createAgentEventHandler({
     event: AgentEventPayload,
   ): { suppress: boolean } => {
     try {
-      const { entry } = loadSessionEntry(sessionKey, {
+      const { entry } = loadSessionEntryReadOnly(sessionKey, {
         ...(agentId ? { agentId } : {}),
         clone: false,
       });
@@ -1275,7 +1275,7 @@ export function createAgentEventHandler({
       return runVerbose ?? "off";
     }
     try {
-      const { cfg, entry } = loadSessionEntry(sessionKey);
+      const { cfg, entry } = loadSessionEntryReadOnly(sessionKey);
       const sessionVerbose = normalizeVerboseLevel(entry?.verboseLevel);
       const sessionUpdatedAt = typeof entry?.updatedAt === "number" ? entry.updatedAt : undefined;
       const sessionChangedAfterRunStarted =

--- a/src/gateway/server-methods/agent-session-patch.ts
+++ b/src/gateway/server-methods/agent-session-patch.ts
@@ -17,7 +17,7 @@ import {
   normalizeSessionDeliveryFields,
   type DeliveryContext,
 } from "../../utils/delivery-context.shared.js";
-import { canonicalizeSpawnedByForAgent, loadSessionEntry } from "../session-utils.js";
+import { canonicalizeSpawnedByForAgent, loadSessionEntryReadOnly } from "../session-utils.js";
 import {
   normalizeTrustedGroupMetadata,
   requestGroupMatchesTrusted,
@@ -73,7 +73,7 @@ export function buildAgentSessionPatch(params: {
     (!storedGroup.groupId || !storedGroup.groupChannel || !storedGroup.groupSpace)
   ) {
     try {
-      const parentEntry = loadSessionEntry(freshSpawnedBy)?.entry;
+      const parentEntry = loadSessionEntryReadOnly(freshSpawnedBy)?.entry;
       inheritedGroup = normalizeTrustedGroupMetadata({
         groupId: parentEntry?.groupId,
         groupChannel: parentEntry?.groupChannel,

--- a/src/gateway/server-methods/artifacts.test.ts
+++ b/src/gateway/server-methods/artifacts.test.ts
@@ -20,6 +20,7 @@ vi.mock("../session-utils.js", async () => {
   return {
     ...actual,
     loadSessionEntry: hoisted.loadSessionEntry,
+    loadSessionEntryReadOnly: hoisted.loadSessionEntry,
   };
 });
 

--- a/src/gateway/server-methods/artifacts.ts
+++ b/src/gateway/server-methods/artifacts.ts
@@ -29,7 +29,7 @@ import {
   resolveStoredSessionKeyForAgentStore,
 } from "../session-store-key.js";
 import { visitSessionMessagesAsync } from "../session-transcript-readers.js";
-import { loadSessionEntry } from "../session-utils.js";
+import { loadSessionEntryReadOnly } from "../session-utils.js";
 import type { GatewayRequestHandlers, RespondFn } from "./types.js";
 import { assertValidParams } from "./validation.js";
 
@@ -512,8 +512,8 @@ async function loadArtifacts(
   const scopedGlobalAgentId =
     cfg?.session?.scope === "global" && sessionKey === "global" ? resolved.agentId : undefined;
   const { storePath, entry } = scopedGlobalAgentId
-    ? loadSessionEntry(sessionKey, { agentId: scopedGlobalAgentId })
-    : loadSessionEntry(sessionKey);
+    ? loadSessionEntryReadOnly(sessionKey, { agentId: scopedGlobalAgentId })
+    : loadSessionEntryReadOnly(sessionKey);
   const sessionId = entry?.sessionId;
   if (!sessionId || !storePath) {
     return { sessionKey, artifacts: [] };

--- a/src/gateway/server-methods/chat-history-handler.ts
+++ b/src/gateway/server-methods/chat-history-handler.ts
@@ -37,7 +37,7 @@ import { capArrayByJsonBytes } from "../session-transcript-readers.js";
 import {
   buildGatewaySessionInfo,
   getSessionDefaults,
-  loadSessionEntry,
+  loadSessionEntryReadOnly,
   listAgentsForGateway,
   resolveSessionModelRef,
   resolveSessionStoreKey,
@@ -186,7 +186,7 @@ async function buildChatStartupModelCatalogProjection(params: {
   cfg: OpenClawConfig;
   snapshot: ModelCatalogSnapshot;
   sessionAgentId: string;
-  sessionEntry: ReturnType<typeof loadSessionEntry>["entry"];
+  sessionEntry: ReturnType<typeof loadSessionEntryReadOnly>["entry"];
   defaultAgentId: string;
   includeAgentsList: boolean;
 }) {
@@ -352,7 +352,7 @@ async function handleChatHistoryRequest({
     agentId: agentIdOverride,
   });
   const sessionLoadOptions = requestedAgentId ? { agentId: requestedAgentId } : undefined;
-  const { cfg, storePath, store, entry, canonicalKey } = loadSessionEntry(
+  const { cfg, storePath, store, entry, canonicalKey } = loadSessionEntryReadOnly(
     sessionKey,
     sessionLoadOptions,
   );

--- a/src/gateway/server-methods/chat-message-get-handler.ts
+++ b/src/gateway/server-methods/chat-message-get-handler.ts
@@ -17,7 +17,7 @@ import {
   readSessionMessageByIdAsync,
   readSessionMessagesAsync,
 } from "../session-transcript-readers.js";
-import { loadSessionEntry } from "../session-utils.js";
+import { loadSessionEntryReadOnly } from "../session-utils.js";
 import { readChatHistoryMessageId } from "./chat-history-pages.js";
 import { resolveRequestedChatAgentId, validateChatSelectedAgent } from "./chat-origin-routing.js";
 import { normalizeOptionalChatText as normalizeOptionalText } from "./chat-text-normalization.js";
@@ -81,7 +81,7 @@ export const chatMessageGetHandlers: GatewayRequestHandlers = {
       agentId: agentIdOverride,
     });
     const sessionLoadOptions = requestedAgentId ? { agentId: requestedAgentId } : undefined;
-    const { cfg, storePath, entry } = loadSessionEntry(sessionKey, sessionLoadOptions);
+    const { cfg, storePath, entry } = loadSessionEntryReadOnly(sessionKey, sessionLoadOptions);
     const selectedAgent = validateChatSelectedAgent({
       cfg,
       requestedSessionKey: sessionKey,

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -169,36 +169,38 @@ const TINY_PNG_BASE64 =
 vi.mock("../session-utils.js", async () => {
   const original =
     await vi.importActual<typeof import("../session-utils.js")>("../session-utils.js");
+  const loadSessionEntry = (rawKey: string, opts?: { agentId?: string }) => {
+    mockState.loadSessionEntryCalls.push({ rawKey, opts });
+    const canonicalKey =
+      typeof mockState.sessionEntry.canonicalKey === "string"
+        ? mockState.sessionEntry.canonicalKey
+        : rawKey || "main";
+    const entry = mockState.sessionMissing
+      ? undefined
+      : {
+          sessionId: mockState.sessionId,
+          sessionFile: mockState.transcriptPath,
+          ...mockState.sessionEntry,
+        };
+    return {
+      ...(typeof mockState.sessionEntry.canonicalKey === "string" ? { canonicalKey } : {}),
+      cfg: {
+        ...mockState.config,
+        session: {
+          ...(mockState.config.session as Record<string, unknown> | undefined),
+          mainKey: mockState.mainSessionKey,
+        },
+      },
+      storePath: path.join(path.dirname(mockState.transcriptPath), "sessions.json"),
+      store: entry ? { [canonicalKey]: entry } : {},
+      entry,
+      canonicalKey,
+    };
+  };
   return {
     ...original,
-    loadSessionEntry: (rawKey: string, opts?: { agentId?: string }) => {
-      mockState.loadSessionEntryCalls.push({ rawKey, opts });
-      const canonicalKey =
-        typeof mockState.sessionEntry.canonicalKey === "string"
-          ? mockState.sessionEntry.canonicalKey
-          : rawKey || "main";
-      const entry = mockState.sessionMissing
-        ? undefined
-        : {
-            sessionId: mockState.sessionId,
-            sessionFile: mockState.transcriptPath,
-            ...mockState.sessionEntry,
-          };
-      return {
-        ...(typeof mockState.sessionEntry.canonicalKey === "string" ? { canonicalKey } : {}),
-        cfg: {
-          ...mockState.config,
-          session: {
-            ...(mockState.config.session as Record<string, unknown> | undefined),
-            mainKey: mockState.mainSessionKey,
-          },
-        },
-        storePath: path.join(path.dirname(mockState.transcriptPath), "sessions.json"),
-        store: entry ? { [canonicalKey]: entry } : {},
-        entry,
-        canonicalKey,
-      };
-    },
+    loadSessionEntry,
+    loadSessionEntryReadOnly: loadSessionEntry,
   };
 });
 

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -14,7 +14,11 @@ import {
   projectChatDisplayMessage,
   resolveEffectiveChatHistoryMaxChars,
 } from "../chat-display-projection.js";
-import { loadSessionEntry, resolveSessionModelRef } from "../session-utils.js";
+import {
+  loadSessionEntry,
+  loadSessionEntryReadOnly,
+  resolveSessionModelRef,
+} from "../session-utils.js";
 import { formatForLog } from "../ws-log.js";
 import { handleChatAbortRequest } from "./chat-abort-handler.js";
 import { sendGlobalAwareNodeChatPayload } from "./chat-broadcast.js";
@@ -88,7 +92,7 @@ export const chatHandlers: GatewayRequestHandlers = {
       // Session entry carries per-session model overrides; utility routing must
       // derive its small-model default from the provider this session actually
       // uses, not the agent's configured default.
-      const { cfg: sessionCfg, entry } = loadSessionEntry(
+      const { cfg: sessionCfg, entry } = loadSessionEntryReadOnly(
         params.sessionKey,
         selectedAgent.agentId ? { agentId: selectedAgent.agentId } : undefined,
       );

--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -48,7 +48,7 @@ import {
 } from "../../sessions/agent-harness-session-key.js";
 import { parseAgentSessionKey } from "../../sessions/session-key-utils.js";
 import { getGatewayProcessInstanceId } from "../process-instance.js";
-import { loadSessionEntry } from "../session-utils.js";
+import { loadSessionEntryReadOnly } from "../session-utils.js";
 import {
   applyCronCreateCallerScopeDefault,
   cronCreateMatchesCallerScope,
@@ -254,7 +254,7 @@ function assertCronDoesNotTargetAgentHarness(input: {
     return;
   }
 
-  const loaded = loadSessionEntry(
+  const loaded = loadSessionEntryReadOnly(
     targetSessionKey,
     input.agentId?.trim() ? { agentId: input.agentId.trim() } : {},
   );
@@ -324,7 +324,7 @@ export const cronHandlers: GatewayRequestHandlers = {
     const sessionKey = p.sessionKey?.trim() || undefined;
     const agentId = p.agentId?.trim() || undefined;
     if (sessionKey && isAgentHarnessSessionKey(sessionKey)) {
-      const loaded = loadSessionEntry(sessionKey, agentId ? { agentId } : {});
+      const loaded = loadSessionEntryReadOnly(sessionKey, agentId ? { agentId } : {});
       const harnessSessionError = loaded.entry
         ? resolveAgentHarnessSessionStoreEntryError(loaded.canonicalKey, loaded.entry)
         : AGENT_HARNESS_SESSION_KEY_RESERVED_MESSAGE;

--- a/src/gateway/server-methods/cron.validation.test.ts
+++ b/src/gateway/server-methods/cron.validation.test.ts
@@ -43,6 +43,7 @@ vi.mock("../../config/config.js", async () => {
 
 vi.mock("../session-utils.js", () => ({
   loadSessionEntry: loadGatewaySessionEntry,
+  loadSessionEntryReadOnly: loadGatewaySessionEntry,
 }));
 
 import { cronHandlers } from "./cron.js";

--- a/src/gateway/server-methods/sessions-create.ts
+++ b/src/gateway/server-methods/sessions-create.ts
@@ -26,7 +26,7 @@ import {
 } from "../session-create-service.js";
 import { resolveSessionStoreAgentId } from "../session-store-key.js";
 import { readSessionMessageCountAsync } from "../session-transcript-readers.js";
-import { loadSessionEntry, resolveGatewaySessionStoreTarget } from "../session-utils.js";
+import { loadSessionEntryReadOnly, resolveGatewaySessionStoreTarget } from "../session-utils.js";
 import { chatHandlers } from "./chat.js";
 import { resolveSessionCatalogCreateTarget } from "./session-catalog.js";
 import { emitSessionsChanged } from "./session-change-event.js";
@@ -211,7 +211,7 @@ export const sessionCreateHandlers: GatewayRequestHandlers = {
         !hasInitialTurn &&
         cfg.session?.dmScope === "main"
       ) {
-        const parent = loadSessionEntry(
+        const parent = loadSessionEntryReadOnly(
           parentSessionKey,
           requestedAgent.agentId ? { agentId: requestedAgent.agentId } : undefined,
         );

--- a/src/gateway/server-methods/sessions-diff.test.ts
+++ b/src/gateway/server-methods/sessions-diff.test.ts
@@ -21,6 +21,7 @@ const hoisted = vi.hoisted(() => ({
 
 vi.mock("../session-utils.js", () => ({
   loadSessionEntry: hoisted.loadSessionEntry,
+  loadSessionEntryReadOnly: hoisted.loadSessionEntry,
 }));
 
 vi.mock("../../agents/agent-scope.js", () => ({

--- a/src/gateway/server-methods/sessions-diff.ts
+++ b/src/gateway/server-methods/sessions-diff.ts
@@ -14,7 +14,7 @@ import {
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import { runGit } from "../../agents/worktrees/git.js";
 import { normalizeAgentId, parseAgentSessionKey } from "../../routing/session-key.js";
-import { loadSessionEntry } from "../session-utils.js";
+import { loadSessionEntryReadOnly } from "../session-utils.js";
 import type { GatewayRequestHandlers } from "./types.js";
 import { assertValidParams } from "./validation.js";
 
@@ -422,7 +422,7 @@ export async function loadSessionDiff(params: SessionsDiffParams): Promise<Sessi
     deletions: 0,
     ...(unavailableReason ? { unavailableReason } : {}),
   });
-  const { cfg, entry, storePath, canonicalKey } = loadSessionEntry(params.sessionKey, {
+  const { cfg, entry, storePath, canonicalKey } = loadSessionEntryReadOnly(params.sessionKey, {
     agentId: params.agentId,
   });
   // Same session scoping as sessions.files.*: an unknown session must not fall

--- a/src/gateway/server-methods/sessions-files.test.ts
+++ b/src/gateway/server-methods/sessions-files.test.ts
@@ -32,6 +32,7 @@ vi.mock("../session-utils.js", async () => {
   return {
     ...actual,
     loadSessionEntry: hoisted.loadSessionEntry,
+    loadSessionEntryReadOnly: hoisted.loadSessionEntry,
   };
 });
 

--- a/src/gateway/server-methods/sessions-files.ts
+++ b/src/gateway/server-methods/sessions-files.ts
@@ -22,7 +22,7 @@ import { resolveToCwd as resolveSessionToolPathToCwd } from "../../agents/sessio
 import { FsSafeError } from "../../infra/fs-safe.js";
 import { normalizeAgentId, parseAgentSessionKey } from "../../routing/session-key.js";
 import { visitSessionMessagesAsync } from "../session-transcript-readers.js";
-import { loadSessionEntry } from "../session-utils.js";
+import { loadSessionEntryReadOnly } from "../session-utils.js";
 import {
   execOpenPath,
   formatOpenPathError,
@@ -348,7 +348,7 @@ async function toSessionFileEntry(
 }
 
 function loadSessionFileRoot(params: { sessionKey: string; agentId?: string }) {
-  const loaded = loadSessionEntry(params.sessionKey, { agentId: params.agentId });
+  const loaded = loadSessionEntryReadOnly(params.sessionKey, { agentId: params.agentId });
   if (!loaded.entry?.sessionId) {
     return { ...loaded, agentId: undefined, root: undefined, fileRoot: undefined };
   }

--- a/src/gateway/server-methods/sessions-messaging.ts
+++ b/src/gateway/server-methods/sessions-messaging.ts
@@ -19,7 +19,11 @@ import { parseAgentSessionKey } from "../../routing/session-key.js";
 import { resolveRequestedSessionAgentId as resolveRequestedGlobalAgentId } from "../session-create-service.js";
 import { reactivateCompletedSubagentSession } from "../session-subagent-reactivation.js";
 import { readSessionMessageCountAsync } from "../session-transcript-readers.js";
-import { loadSessionEntry, resolveDeletedAgentIdFromSessionKey } from "../session-utils.js";
+import {
+  loadSessionEntry,
+  loadSessionEntryReadOnly,
+  resolveDeletedAgentIdFromSessionKey,
+} from "../session-utils.js";
 import { asWorkerInferenceControl } from "../worker-environments/inference-control.js";
 import { chatHandlers } from "./chat.js";
 import { hasTrackedActiveSessionRun } from "./session-active-runs.js";
@@ -98,7 +102,7 @@ async function createAgentMainSessionForSend(params: {
   }
 
   const createdKey = normalizeOptionalString(createResult.payload?.key) ?? params.canonicalKey;
-  const loaded = loadSessionEntry(createdKey);
+  const loaded = loadSessionEntryReadOnly(createdKey);
   if (!loaded.entry?.sessionId) {
     return {
       ok: false,

--- a/src/gateway/server-methods/sessions-read.ts
+++ b/src/gateway/server-methods/sessions-read.ts
@@ -19,7 +19,7 @@ import {
   serializeSessionCleanupResult,
   type SessionEntry,
 } from "../../config/sessions.js";
-import { listSessionEntries } from "../../config/sessions/session-accessor.js";
+import { listSessionEntriesReadOnly } from "../../config/sessions/session-accessor.js";
 import { searchSessionTranscripts } from "../../config/sessions/session-transcript-search.js";
 import {
   measureDiagnosticsTimelineSpan,
@@ -132,7 +132,7 @@ export const sessionReadHandlers: GatewayRequestHandlers = {
         const targetSessionKeys =
           scopedSessionKeys ??
           (target && !isPerAgentSessionStoreConfig(cfg.session?.store)
-            ? listSessionEntries({ agentId: target.agentId, storePath: target.storePath })
+            ? listSessionEntriesReadOnly({ agentId: target.agentId, storePath: target.storePath })
                 .map((entry) => entry.sessionKey)
                 .filter((sessionKey) => {
                   const parsed = parseAgentSessionKey(sessionKey);

--- a/src/gateway/server-methods/sessions-search.test.ts
+++ b/src/gateway/server-methods/sessions-search.test.ts
@@ -14,6 +14,7 @@ vi.mock("../../config/sessions/session-transcript-search.js", () => ({
 vi.mock("../../config/sessions/session-accessor.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../../config/sessions/session-accessor.js")>()),
   listSessionEntries: (...args: unknown[]) => listSessionEntriesMock(...args),
+  listSessionEntriesReadOnly: (...args: unknown[]) => listSessionEntriesMock(...args),
 }));
 vi.mock("../../config/sessions.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../../config/sessions.js")>()),

--- a/src/gateway/server-methods/sessions-subscriptions.ts
+++ b/src/gateway/server-methods/sessions-subscriptions.ts
@@ -10,7 +10,7 @@ import { normalizeAgentId } from "../../routing/session-key.js";
 import { canReviewOperatorApproval } from "../operator-approval-authorization.js";
 import { APPROVALS_SCOPE } from "../operator-scopes.js";
 import { resolveRequestedSessionAgentId as resolveRequestedGlobalAgentId } from "../session-create-service.js";
-import { loadSessionEntry } from "../session-utils.js";
+import { loadSessionEntryReadOnly } from "../session-utils.js";
 import { requireSessionKey } from "./sessions-shared.js";
 import type { GatewayRequestHandlers } from "./types.js";
 import { assertValidParams } from "./validation.js";
@@ -81,7 +81,7 @@ export const sessionSubscriptionHandlers: GatewayRequestHandlers = {
       return;
     }
     const requestedAgentId = requestedAgent.agentId;
-    const { canonicalKey } = loadSessionEntry(key, { agentId: requestedAgentId });
+    const { canonicalKey } = loadSessionEntryReadOnly(key, { agentId: requestedAgentId });
     const subscriptionKey = resolveSessionMessageSubscriptionKey({
       canonicalKey,
       agentId: requestedAgentId,
@@ -163,7 +163,7 @@ export const sessionSubscriptionHandlers: GatewayRequestHandlers = {
       return;
     }
     const requestedAgentId = requestedAgent.agentId;
-    const { canonicalKey } = loadSessionEntry(key, { agentId: requestedAgentId });
+    const { canonicalKey } = loadSessionEntryReadOnly(key, { agentId: requestedAgentId });
     const subscriptionKey = resolveSessionMessageSubscriptionKey({
       canonicalKey,
       agentId: requestedAgentId,

--- a/src/gateway/server-methods/sessions.abort-agent-scope.test.ts
+++ b/src/gateway/server-methods/sessions.abort-agent-scope.test.ts
@@ -41,6 +41,8 @@ vi.mock("../session-utils.js", async () => {
       loadCombinedSessionStoreForGatewayMock(...args),
     loadSessionEntry: (...args: unknown[]) =>
       loadSessionEntryMock(...(args as [string, { agentId?: string }?])),
+    loadSessionEntryReadOnly: (...args: unknown[]) =>
+      loadSessionEntryMock(...(args as [string, { agentId?: string }?])),
   };
 });
 

--- a/src/gateway/server-methods/sessions.messages-subscribe-approvals.test.ts
+++ b/src/gateway/server-methods/sessions.messages-subscribe-approvals.test.ts
@@ -17,6 +17,8 @@ vi.mock("../session-utils.js", async () => {
     ...actual,
     loadSessionEntry: (...args: unknown[]) =>
       loadSessionEntryMock(...(args as [string, { agentId?: string }?])),
+    loadSessionEntryReadOnly: (...args: unknown[]) =>
+      loadSessionEntryMock(...(args as [string, { agentId?: string }?])),
   };
 });
 

--- a/src/gateway/server-methods/task-suggestions.ts
+++ b/src/gateway/server-methods/task-suggestions.ts
@@ -16,7 +16,7 @@ import { managedWorktrees } from "../../agents/worktrees/service.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { normalizeAgentId, parseAgentSessionKey } from "../../routing/session-key.js";
 import { buildDashboardSessionKey } from "../session-create-service.js";
-import { loadSessionEntry } from "../session-utils.js";
+import { loadSessionEntryReadOnly } from "../session-utils.js";
 import {
   abandonTaskSuggestionAcceptance,
   beginTaskSuggestionAcceptance,
@@ -71,7 +71,10 @@ async function rollbackSuggestedTaskSession(params: {
     // and its worktree were fully removed despite a handler-level failure.
   }
   try {
-    if (!deletionConfirmed && loadSessionEntry(params.key, { agentId: params.agentId }).entry) {
+    if (
+      !deletionConfirmed &&
+      loadSessionEntryReadOnly(params.key, { agentId: params.agentId }).entry
+    ) {
       return false;
     }
   } catch {

--- a/src/gateway/server-methods/tools-effective.runtime.ts
+++ b/src/gateway/server-methods/tools-effective.runtime.ts
@@ -24,4 +24,4 @@ export {
   getActivePluginRegistryVersion,
 } from "../../plugins/runtime.js";
 export { deliveryContextFromSession } from "../../utils/delivery-context.shared.js";
-export { loadSessionEntry, resolveSessionModelRef } from "../session-utils.js";
+export { loadSessionEntryReadOnly, resolveSessionModelRef } from "../session-utils.js";

--- a/src/gateway/server-methods/tools-effective.test.ts
+++ b/src/gateway/server-methods/tools-effective.test.ts
@@ -68,7 +68,10 @@ const runtimeMocks = vi.hoisted(() => ({
   })),
 }));
 
-vi.mock("./tools-effective.runtime.js", () => runtimeMocks);
+vi.mock("./tools-effective.runtime.js", () => ({
+  ...runtimeMocks,
+  loadSessionEntryReadOnly: runtimeMocks.loadSessionEntry,
+}));
 
 const nodePluginToolSnapshotMocks = vi.hoisted(() => ({
   version: 1,

--- a/src/gateway/server-methods/tools-effective.ts
+++ b/src/gateway/server-methods/tools-effective.ts
@@ -26,7 +26,7 @@ import {
   getActivePluginChannelRegistryVersion,
   getActivePluginRegistryVersion,
   listAgentIds,
-  loadSessionEntry,
+  loadSessionEntryReadOnly,
   peekSessionMcpRuntime,
   resolveAgentDir,
   resolveAgentWorkspaceDir,
@@ -466,7 +466,7 @@ function resolveTrustedToolsEffectiveContext(params: {
 }) {
   // The effective tools request is read-only but security-sensitive. Derive
   // routing/account/model context from the persisted session, not client params.
-  const loaded = loadSessionEntry(
+  const loaded = loadSessionEntryReadOnly(
     params.sessionKey,
     params.requestedAgentId ? { agentId: params.requestedAgentId } : undefined,
   );

--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -63,7 +63,7 @@ import {
   resolveSessionStoreAgentId,
   resolveStoredSessionKeyForAgentStore,
 } from "../session-store-key.js";
-import { loadCombinedSessionStoreForGateway, loadSessionEntry } from "../session-utils.js";
+import { loadCombinedSessionStoreForGateway, loadSessionEntryReadOnly } from "../session-utils.js";
 import type { GatewayRequestHandlers, RespondFn } from "./types.js";
 
 const COST_USAGE_CACHE_TTL_MS = 30_000;
@@ -144,7 +144,7 @@ function resolveSessionUsageFileOrRespond(
   sessionId: string;
   sessionFile: string;
 } | null {
-  const { entry, storePath } = loadSessionEntry(key);
+  const { entry, storePath } = loadSessionEntryReadOnly(key);
 
   // For discovered sessions (not in store), try using key as sessionId directly
   const parsed = parseAgentSessionKey(key);

--- a/src/gateway/server-session-events.ts
+++ b/src/gateway/server-session-events.ts
@@ -5,7 +5,7 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import { resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { getRuntimeConfig } from "../config/io.js";
 import {
-  loadSessionEntry as loadAccessorSessionEntry,
+  loadSessionEntryReadOnly as loadAccessorSessionEntry,
   resolveTranscriptSessionKeyBySessionId,
 } from "../config/sessions/session-accessor.js";
 import { parseSqliteSessionFileMarker } from "../config/sessions/sqlite-marker.js";
@@ -31,7 +31,7 @@ import {
 } from "./session-transcript-readers.js";
 import {
   loadGatewaySessionRow,
-  loadSessionEntry,
+  loadSessionEntryReadOnly,
   type GatewaySessionRow,
 } from "./session-utils.js";
 
@@ -198,7 +198,7 @@ async function handleTranscriptUpdateBroadcast(
       : undefined;
     const fallbackTarget = markerEntry
       ? undefined
-      : loadSessionEntry(sessionKey, { agentId: visibleAgentId });
+      : loadSessionEntryReadOnly(sessionKey, { agentId: visibleAgentId });
     const entry = markerEntry ?? fallbackTarget?.entry;
     const storePath = sqliteMarker?.storePath ?? fallbackTarget?.storePath;
     messageSeq = entry?.sessionId

--- a/src/gateway/session-create-service.ts
+++ b/src/gateway/session-create-service.ts
@@ -62,7 +62,7 @@ import { ADMIN_SCOPE } from "./operator-scopes.js";
 import { buildForkedGatewaySessionEntry } from "./session-create-fork-entry.js";
 import { shouldPreserveSessionAuthProfileOverride } from "./session-model-patch-origin.js";
 import { resolveSessionStoreAgentId, resolveSessionStoreKey } from "./session-store-key.js";
-import { loadSessionEntry, resolveGatewaySessionStoreTarget } from "./session-utils.js";
+import { loadSessionEntryReadOnly, resolveGatewaySessionStoreTarget } from "./session-utils.js";
 import { applySessionsPatchToStore, resolveSessionPatchModelSelection } from "./sessions-patch.js";
 
 type TrustedCatalogSessionTarget = {
@@ -443,7 +443,7 @@ export async function createGatewaySession(params: {
       }
       parentSelectedAgentId = parentRequestedAgent.agentId;
     }
-    const parent = loadSessionEntry(
+    const parent = loadSessionEntryReadOnly(
       parentSessionKey,
       parentSelectedAgentId ? { agentId: parentSelectedAgentId } : undefined,
     );
@@ -544,7 +544,7 @@ export async function createGatewaySession(params: {
       parentSessionTarget &&
       (params.emitCommandHooks === true || params.fork === true)
     ) {
-      const currentParent = loadSessionEntry(
+      const currentParent = loadSessionEntryReadOnly(
         canonicalParentSessionKey,
         parentSelectedAgentId ? { agentId: parentSelectedAgentId } : undefined,
       );

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -30,6 +30,7 @@ import {
   listSessionsFromStore,
   listSessionsFromStoreAsync,
   loadSessionEntry,
+  loadSessionEntryReadOnly,
   migrateAndPruneGatewaySessionStoreKey,
   resolveDeletedAgentIdFromSessionKey,
   resolveGatewayModelSupportsImages,
@@ -1860,6 +1861,29 @@ describe("gateway session utils", () => {
         const loaded = loadSessionEntry("agent:main:main", { clone: false });
 
         expect(loaded.entry).toEqual({ sessionId: "sess-main", updatedAt: 7 });
+      });
+    } finally {
+      resetConfigRuntimeState();
+    }
+  });
+
+  test("loadSessionEntryReadOnly does not materialize a missing configured agent", async () => {
+    resetConfigRuntimeState();
+    try {
+      await withStateDirEnv("session-utils-load-entry-read-only-", async ({ stateDir }) => {
+        const cfg = {
+          session: {
+            mainKey: "main",
+            store: path.join(stateDir, "agents", "{agentId}", "sessions", "sessions.json"),
+          },
+          agents: { list: [{ id: "main", default: true }, { id: "missing" }] },
+        } as OpenClawConfig;
+        setRuntimeConfigSnapshot(cfg, cfg);
+
+        const loaded = loadSessionEntryReadOnly("agent:missing:main");
+
+        expect(loaded.entry).toBeUndefined();
+        expect(fs.existsSync(path.join(stateDir, "agents", "missing"))).toBe(false);
       });
     } finally {
       resetConfigRuntimeState();

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -91,7 +91,10 @@ import {
   type SessionStoreTarget,
   type SessionScope,
 } from "../config/sessions.js";
-import { listSessionEntries as listAccessorSessionEntries } from "../config/sessions/session-accessor.js";
+import {
+  listSessionEntries as listAccessorSessionEntries,
+  listSessionEntriesReadOnly as listAccessorSessionEntriesReadOnly,
+} from "../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { projectPluginSessionExtensionsSync } from "../plugins/host-hook-state.js";
 import { withPinnedActivePluginRegistryWorkspaceDir } from "../plugins/runtime-workspace-state.js";
@@ -971,7 +974,11 @@ export function resolveDeletedAgentIdFromSessionKey(
   return agentId;
 }
 
-export function loadSessionEntry(sessionKey: string, opts?: { agentId?: string; clone?: boolean }) {
+function loadSessionEntryWithMode(
+  sessionKey: string,
+  opts: { agentId?: string; clone?: boolean } | undefined,
+  readOnly: boolean,
+) {
   const cfg = getRuntimeConfig();
   const key = normalizeOptionalString(sessionKey) ?? "";
   const target = resolveGatewaySessionStoreTargetWithStore({
@@ -979,6 +986,7 @@ export function loadSessionEntry(sessionKey: string, opts?: { agentId?: string; 
     key,
     ...(opts?.clone === false ? { clone: false } : {}),
     ...(opts?.agentId ? { agentId: opts.agentId } : {}),
+    ...(readOnly ? { readOnly: true } : {}),
   });
   const storePath = target.storePath;
   const store = target.store;
@@ -993,6 +1001,17 @@ export function loadSessionEntry(sessionKey: string, opts?: { agentId?: string; 
     storeKeys: target.storeKeys,
     legacyKey,
   };
+}
+
+export function loadSessionEntry(sessionKey: string, opts?: { agentId?: string; clone?: boolean }) {
+  return loadSessionEntryWithMode(sessionKey, opts, false);
+}
+
+export function loadSessionEntryReadOnly(
+  sessionKey: string,
+  opts?: { agentId?: string; clone?: boolean },
+) {
+  return loadSessionEntryWithMode(sessionKey, opts, true);
 }
 
 function resolveFreshestSessionStoreMatchFromStoreKeys(
@@ -1329,7 +1348,7 @@ function loadGatewaySessionLookupStore(
   storePath: string,
   clone: boolean | undefined,
   agentId?: string,
-  options: { allowLegacyFallback?: boolean } = {},
+  options: { allowLegacyFallback?: boolean; readOnly?: boolean } = {},
 ): Record<string, SessionEntry> {
   try {
     if (options.allowLegacyFallback) {
@@ -1338,8 +1357,11 @@ function loadGatewaySessionLookupStore(
         return legacyStore;
       }
     }
+    const listEntries = options.readOnly
+      ? listAccessorSessionEntriesReadOnly
+      : listAccessorSessionEntries;
     return Object.fromEntries(
-      listAccessorSessionEntries({
+      listEntries({
         ...(agentId ? { agentId } : {}),
         ...(clone === false ? { clone: false } : {}),
         storePath,
@@ -1357,6 +1379,7 @@ function resolveGatewaySessionStoreLookup(params: {
   agentId: string;
   clone?: boolean;
   initialStore?: Record<string, SessionEntry>;
+  readOnly?: boolean;
 }): {
   storePath: string;
   store: Record<string, SessionEntry>;
@@ -1380,6 +1403,7 @@ function resolveGatewaySessionStoreLookup(params: {
   const loadStore = (target: SessionStoreTarget) =>
     loadGatewaySessionLookupStore(target.storePath, params.clone, target.agentId, {
       allowLegacyFallback: !configured,
+      readOnly: params.readOnly,
     });
   const firstCandidate = candidates[0] ?? fallback;
   let selectedStorePath = firstCandidate.storePath;
@@ -1426,6 +1450,7 @@ function resolveExplicitDeletedLegacyMainStoreTarget(params: {
   cfg: OpenClawConfig;
   key: string;
   clone?: boolean;
+  readOnly?: boolean;
 }): GatewaySessionStoreTargetWithStore | null {
   const parsed = parseAgentSessionKey(params.key);
   const legacyAgentId = normalizeAgentId(parsed?.agentId);
@@ -1460,7 +1485,9 @@ function resolveExplicitDeletedLegacyMainStoreTarget(params: {
     if (target.agentId !== legacyAgentId) {
       continue;
     }
-    const store = loadGatewaySessionLookupStore(target.storePath, params.clone, target.agentId);
+    const store = loadGatewaySessionLookupStore(target.storePath, params.clone, target.agentId, {
+      readOnly: params.readOnly,
+    });
     const match = findFreshestStoreMatch(store, ...lookupSeeds);
     if (!match) {
       continue;
@@ -1495,6 +1522,7 @@ export function resolveGatewaySessionStoreTargetWithStore(params: {
   key: string;
   agentId?: string;
   clone?: boolean;
+  readOnly?: boolean;
   store?: Record<string, SessionEntry>;
 }): GatewaySessionStoreTargetWithStore {
   const key = normalizeOptionalString(params.key) ?? "";
@@ -1502,6 +1530,7 @@ export function resolveGatewaySessionStoreTargetWithStore(params: {
     cfg: params.cfg,
     key,
     clone: params.clone,
+    readOnly: params.readOnly,
   });
   if (explicitDeletedMainTarget) {
     return explicitDeletedMainTarget;
@@ -1524,6 +1553,7 @@ export function resolveGatewaySessionStoreTargetWithStore(params: {
     canonicalKey,
     agentId,
     clone: params.clone,
+    readOnly: params.readOnly,
     initialStore: params.store,
   });
 
@@ -2435,7 +2465,7 @@ export function loadGatewaySessionRow(
   },
 ): GatewaySessionRow | null {
   const now = options?.now ?? Date.now();
-  const { cfg, storePath, store, entry, canonicalKey } = loadSessionEntry(sessionKey, {
+  const { cfg, storePath, store, entry, canonicalKey } = loadSessionEntryReadOnly(sessionKey, {
     clone: false,
     ...(options?.agentId ? { agentId: options.agentId } : {}),
   });

--- a/src/infra/approval-request-account-binding.ts
+++ b/src/infra/approval-request-account-binding.ts
@@ -1,7 +1,7 @@
 // Matches approval requests against channel account and session bindings.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { resolveStorePath } from "../config/sessions/paths.js";
-import { loadSessionEntry } from "../config/sessions/session-accessor.js";
+import { loadSessionEntryReadOnly } from "../config/sessions/session-accessor.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizeOptionalAccountId } from "../routing/account-id.js";
@@ -38,7 +38,7 @@ export function resolvePersistedApprovalRequestSessionEntry(params: {
   const parsed = parseAgentSessionKey(sessionKey);
   const agentId = parsed?.agentId ?? params.request.request.agentId ?? "main";
   const storePath = resolveStorePath(params.cfg.session?.store, { agentId });
-  const entry = loadSessionEntry({
+  const entry = loadSessionEntryReadOnly({
     storePath,
     sessionKey,
     clone: false,

--- a/src/infra/outbound/message-action-tts.ts
+++ b/src/infra/outbound/message-action-tts.ts
@@ -2,7 +2,7 @@
 // to send payloads without loading TTS providers for ordinary sends.
 import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
 import { resolveStorePath } from "../../config/sessions.js";
-import { loadSessionEntry } from "../../config/sessions/session-accessor.js";
+import { loadSessionEntryReadOnly } from "../../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { TtsAutoMode } from "../../config/types.tts.js";
 import { createLazyRuntimeModule } from "../../shared/lazy-runtime.js";
@@ -25,7 +25,7 @@ function resolveMessageActionSessionTtsAuto(params: {
   }
   try {
     const storePath = resolveStorePath(params.cfg.session?.store, { agentId: params.agentId });
-    return loadSessionEntry({
+    return loadSessionEntryReadOnly({
       agentId: params.agentId,
       sessionKey,
       storePath,

--- a/src/plugin-sdk/command-status.runtime.test.ts
+++ b/src/plugin-sdk/command-status.runtime.test.ts
@@ -17,7 +17,7 @@ vi.mock("../auto-reply/reply/commands-status.js", () => ({
 }));
 
 vi.mock("../gateway/session-utils.js", () => ({
-  loadSessionEntry,
+  loadSessionEntryReadOnly: loadSessionEntry,
 }));
 
 vi.mock("../agents/agent-scope.js", () => ({

--- a/src/plugin-sdk/command-status.runtime.ts
+++ b/src/plugin-sdk/command-status.runtime.ts
@@ -8,7 +8,7 @@ import { resolveCurrentDirectiveLevels } from "../auto-reply/reply/directive-han
 import { createModelSelectionState } from "../auto-reply/reply/model-selection.js";
 import type { ReplyPayload } from "../auto-reply/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { loadSessionEntry } from "../gateway/session-utils.js";
+import { loadSessionEntryReadOnly } from "../gateway/session-utils.js";
 
 /** Inputs for rendering direct-session status replies outside the active channel turn. */
 export type ResolveDirectStatusReplyForSessionParams = {
@@ -43,7 +43,7 @@ export async function resolveDirectStatusReplyForSession(
     return undefined;
   }
 
-  const statusLoaded = loadSessionEntry(requestedSessionKey);
+  const statusLoaded = loadSessionEntryReadOnly(requestedSessionKey);
   const statusCfg = statusLoaded.cfg ?? params.cfg;
   const statusSessionKey = statusLoaded.canonicalKey;
   const statusEntry = statusLoaded.entry;

--- a/src/plugin-sdk/session-store-runtime.ts
+++ b/src/plugin-sdk/session-store-runtime.ts
@@ -17,7 +17,7 @@ import {
   loadTranscriptEventsSync as loadAccessorTranscriptEventsSync,
   listSessionEntries as listAccessorSessionEntries,
   listSessionEntriesReadOnly as listAccessorSessionEntriesReadOnly,
-  loadSessionEntry,
+  loadSessionEntryReadOnly,
   patchSessionEntry as patchAccessorSessionEntry,
   readSessionUpdatedAt as readAccessorSessionUpdatedAt,
   readTranscriptStatsSync as readAccessorTranscriptStatsSync,
@@ -357,7 +357,7 @@ export function resolveSessionStoreEntry(params: {
 
 /** Loads one session entry by agent/session identity. */
 export function getSessionEntry(params: SessionStoreReadParams): SessionEntry | undefined {
-  const entry = loadSessionEntry(toSessionAccessScope(params));
+  const entry = loadSessionEntryReadOnly(toSessionAccessScope(params));
   return entry ? projectPluginSessionEntry(entry) : undefined;
 }
 

--- a/src/plugins/registry-runtime.ts
+++ b/src/plugins/registry-runtime.ts
@@ -307,6 +307,7 @@ export function createPluginRuntimeResolver(state: PluginRegistryState) {
       const entries = registryParams.runtime.agent.session.listSessionEntries({
         ...(agentId ? { agentId } : {}),
         ...(storePath ? { storePath } : {}),
+        readOnly: true,
       });
       for (const { sessionKey, entry } of entries) {
         if (

--- a/src/plugins/runtime/runtime-agent.ts
+++ b/src/plugins/runtime/runtime-agent.ts
@@ -21,7 +21,8 @@ import { resolveStorePath } from "../../config/sessions/paths.js";
 import {
   deleteSessionEntryLifecycle,
   listSessionEntries as listAccessorSessionEntries,
-  loadSessionEntry,
+  listSessionEntriesReadOnly as listAccessorSessionEntriesReadOnly,
+  loadSessionEntryReadOnly,
   patchSessionEntry as patchAccessorSessionEntry,
   replaceSessionEntry,
   rollbackAgentHarnessSessionEntryLifecycle,
@@ -51,7 +52,9 @@ type RuntimeSessionStoreReadParams = {
   storePath?: string;
 };
 
-type RuntimeSessionStoreListParams = Partial<Omit<RuntimeSessionStoreReadParams, "sessionKey">>;
+type RuntimeSessionStoreListParams = Partial<Omit<RuntimeSessionStoreReadParams, "sessionKey">> & {
+  readOnly?: boolean;
+};
 
 type RuntimeSessionStoreEntrySummary = {
   sessionKey: string;
@@ -104,13 +107,16 @@ function toSessionAccessScope(params: RuntimeSessionStoreReadParams): SessionAcc
 }
 
 function getSessionEntry(params: RuntimeSessionStoreReadParams): SessionEntry | undefined {
-  return loadSessionEntry(toSessionAccessScope(params));
+  return loadSessionEntryReadOnly(toSessionAccessScope(params));
 }
 
 function listSessionEntries(
   params: RuntimeSessionStoreListParams = {},
 ): RuntimeSessionStoreEntrySummary[] {
-  return listAccessorSessionEntries({
+  const listEntries = params.readOnly
+    ? listAccessorSessionEntriesReadOnly
+    : listAccessorSessionEntries;
+  return listEntries({
     ...(params.agentId !== undefined ? { agentId: params.agentId } : {}),
     ...(params.env !== undefined ? { env: params.env } : {}),
     ...(params.hydrateSkillPromptRefs !== undefined

--- a/src/plugins/runtime/types-core.ts
+++ b/src/plugins/runtime/types-core.ts
@@ -73,7 +73,9 @@ type RuntimeSessionStoreReadParams = {
   readConsistency?: "latest";
   storePath?: string;
 };
-type RuntimeSessionStoreListParams = Partial<Omit<RuntimeSessionStoreReadParams, "sessionKey">>;
+type RuntimeSessionStoreListParams = Partial<Omit<RuntimeSessionStoreReadParams, "sessionKey">> & {
+  readOnly?: boolean;
+};
 type RuntimeSessionStoreEntrySummary = {
   sessionKey: string;
   entry: RuntimeSessionEntry;

--- a/src/sessions/session-state-events.ts
+++ b/src/sessions/session-state-events.ts
@@ -1,7 +1,7 @@
 /** Best-effort durable signal log for session state changes. */
 import type { DatabaseSync } from "node:sqlite";
 import type { Insertable, Selectable } from "kysely";
-import { loadSessionEntry } from "../config/sessions/session-accessor.js";
+import { loadSessionEntryReadOnly } from "../config/sessions/session-accessor.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import type { DmScope } from "../config/types.base.js";
 import {
@@ -623,7 +623,7 @@ export function handleSessionStateSessionDeleted(
 
 function sessionExists(sessionKey: string, env?: NodeJS.ProcessEnv): boolean {
   try {
-    return Boolean(loadSessionEntry({ sessionKey, clone: false, env }));
+    return Boolean(loadSessionEntryReadOnly({ sessionKey, clone: false, env }));
   } catch {
     return false;
   }

--- a/src/sessions/session-upstream-monitor.ts
+++ b/src/sessions/session-upstream-monitor.ts
@@ -1,7 +1,7 @@
 /** Polls watched adopted sessions for direct upstream human activity. */
 import { createHash } from "node:crypto";
 import { isEmbeddedAgentRunActive } from "../agents/embedded-agent.js";
-import { loadSessionEntry } from "../config/sessions/session-accessor.js";
+import { loadSessionEntryReadOnly } from "../config/sessions/session-accessor.js";
 import { resolveSessionStorePathForScope } from "../config/sessions/session-store-path.js";
 import { readRecentUserAssistantTextForSession } from "../config/sessions/transcript.js";
 import type { SessionEntry } from "../config/sessions/types.js";
@@ -30,7 +30,7 @@ const log = createSubsystemLogger("sessions/upstream-monitor");
 type SessionUpstreamMonitorOptions = OpenClawStateDatabaseOptions & {
   providers?: readonly SessionCatalogProvider[];
   now?: () => number;
-  loadEntry?: typeof loadSessionEntry;
+  loadEntry?: typeof loadSessionEntryReadOnly;
   isRunActive?: typeof isEmbeddedAgentRunActive;
   loadOwnRecentUserTexts?: (params: {
     entry: SessionEntry;
@@ -115,7 +115,7 @@ async function probeProvenanceUnchanged(
   probe: SessionUpstreamProbe,
   options: SessionUpstreamMonitorOptions,
 ): Promise<boolean> {
-  const entry = (options.loadEntry ?? loadSessionEntry)({
+  const entry = (options.loadEntry ?? loadSessionEntryReadOnly)({
     sessionKey: probe.sessionKey,
     agentId: probe.agentId,
     clone: false,
@@ -166,7 +166,7 @@ async function runSessionUpstreamMonitorTick(
       } satisfies Omit<SessionUpstreamProbe, "ownRecentUserTexts">;
       // One corrupt session store must not reject the whole tick; skip that link only.
       try {
-        const entry = (options.loadEntry ?? loadSessionEntry)({
+        const entry = (options.loadEntry ?? loadSessionEntryReadOnly)({
           sessionKey: probe.sessionKey,
           agentId: probe.agentId,
           clone: false,

--- a/src/talk/client-voice-session.ts
+++ b/src/talk/client-voice-session.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import {
   appendTranscriptMessage,
   loadSessionEntry,
+  loadSessionEntryReadOnly,
   upsertSessionEntry,
 } from "../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -401,7 +402,7 @@ async function appendVoiceTranscript(params: {
     if (record.origin !== params.origin) {
       throw new Error("voice session origin does not allow this transcript source");
     }
-    const sessionEntry = loadSessionEntry({
+    const sessionEntry = loadSessionEntryReadOnly({
       agentId: params.agentId,
       sessionKey: params.sessionKey,
     });
@@ -531,7 +532,10 @@ async function deliverMutationDigestOnce(
   if (!text) {
     return;
   }
-  const entry = loadSessionEntry({ agentId: record.agentId, sessionKey: record.sessionKey });
+  const entry = loadSessionEntryReadOnly({
+    agentId: record.agentId,
+    sessionKey: record.sessionKey,
+  });
   const target = resolveSessionDeliveryTarget({ entry, requestedChannel: "last" });
   if (!target.channel || target.channel === "webchat" || !target.to) {
     return;

--- a/src/tasks/task-registry.maintenance.ts
+++ b/src/tasks/task-registry.maintenance.ts
@@ -15,7 +15,7 @@ import {
 import { resolveStorePath } from "../config/sessions.js";
 import type { SessionEntry } from "../config/sessions.js";
 import {
-  listSessionEntries,
+  listSessionEntriesReadOnly,
   type SessionEntrySummary,
 } from "../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -100,7 +100,7 @@ type TaskRegistryMaintenanceRuntime = {
   }) => Promise<void>;
   listSessionBindingsBySession?: ReturnType<typeof getSessionBindingService>["listBySession"];
   unbindSessionBindings?: ReturnType<typeof getSessionBindingService>["unbind"];
-  listSessionEntries: typeof listSessionEntries;
+  listSessionEntries: typeof listSessionEntriesReadOnly;
   resolveStorePath: typeof resolveStorePath;
   deriveSessionChatTypeFromKey?: typeof deriveSessionChatTypeFromKey;
   isCronJobActive: typeof isCronJobActive;
@@ -139,7 +139,7 @@ const defaultTaskRegistryMaintenanceRuntime: TaskRegistryMaintenanceRuntime = {
   listSessionBindingsBySession: (sessionKey) =>
     getSessionBindingService().listBySession(sessionKey),
   unbindSessionBindings: (input) => getSessionBindingService().unbind(input),
-  listSessionEntries,
+  listSessionEntries: listSessionEntriesReadOnly,
   resolveStorePath,
   deriveSessionChatTypeFromKey,
   isCronJobActive,

--- a/src/tui/embedded-backend.test.ts
+++ b/src/tui/embedded-backend.test.ts
@@ -209,6 +209,8 @@ vi.mock("../gateway/session-utils.js", () => ({
     loadCombinedSessionStoreForGatewayMock(...args),
   loadSessionEntry: (sessionKey: string, opts?: { agentId?: string }) =>
     loadSessionEntryMock(sessionKey, opts),
+  loadSessionEntryReadOnly: (sessionKey: string, opts?: { agentId?: string }) =>
+    loadSessionEntryMock(sessionKey, opts),
   migrateAndPruneGatewaySessionStoreKey: ({ key }: { key: string }) => ({
     primaryKey: key,
     target: { storeKeys: [key] },

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -76,6 +76,7 @@ import {
   listSessionsFromStoreAsync,
   loadCombinedSessionStoreForGateway,
   loadSessionEntry,
+  loadSessionEntryReadOnly,
   migrateAndPruneGatewaySessionStoreKey,
   resolveGatewaySessionStoreTarget,
   resolveSessionModelRef,
@@ -599,7 +600,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
   async loadHistory(opts: { sessionKey: string; agentId?: string; limit?: number }) {
     await this.ready;
     const loadOptions = opts.agentId ? { agentId: opts.agentId } : undefined;
-    const { cfg, storePath, store, entry, canonicalKey } = loadSessionEntry(
+    const { cfg, storePath, store, entry, canonicalKey } = loadSessionEntryReadOnly(
       opts.sessionKey,
       loadOptions,
     );

--- a/test/scripts/check-session-accessor-boundary.test.ts
+++ b/test/scripts/check-session-accessor-boundary.test.ts
@@ -6,6 +6,7 @@ import {
   findGatewaySessionCreateLifecycleViolations,
   findEmbeddedAgentSessionTargetViolations,
   findMemoryHostSessionCorpusBoundaryViolations,
+  findReadOnlySessionAccessorViolations,
   findSessionAccessorBoundaryViolations,
   findSessionCompactManualTrimBoundaryViolations,
   findSessionAccessorWriteBoundaryViolations,
@@ -21,9 +22,35 @@ import {
   migratedSessionAccessorFiles,
   migratedSessionAccessorWriteFiles,
   migratedTranscriptWriterFiles,
+  readOnlyGatewaySessionAccessorFiles,
 } from "../../scripts/check-session-accessor-boundary.mjs";
 
 describe("session accessor boundary guard", () => {
+  it("keeps Gateway read paths on non-materializing accessors", () => {
+    expect(
+      readOnlyGatewaySessionAccessorFiles.has("src/gateway/server-methods/sessions-read.ts"),
+    ).toBe(true);
+    expect(
+      findReadOnlySessionAccessorViolations(`
+        import { listSessionEntries, loadSessionEntry } from "../config/sessions/session-accessor.js";
+        listSessionEntries({ storePath });
+        sessionUtils.loadSessionEntry(sessionKey);
+      `),
+    ).toEqual([
+      { line: 2, reason: 'imports materializing session entry accessor "listSessionEntries"' },
+      { line: 2, reason: 'imports materializing session entry accessor "loadSessionEntry"' },
+      { line: 3, reason: 'calls materializing session entry accessor "listSessionEntries"' },
+      { line: 4, reason: 'references materializing session entry accessor "loadSessionEntry"' },
+    ]);
+    expect(
+      findReadOnlySessionAccessorViolations(`
+        import { listSessionEntriesReadOnly, loadSessionEntryReadOnly } from "../config/sessions/session-accessor.js";
+        listSessionEntriesReadOnly({ storePath });
+        sessionUtils.loadSessionEntryReadOnly(sessionKey);
+      `),
+    ).toEqual([]);
+  });
+
   it("ratchets only the files migrated by the session accessor slices", () => {
     expect(migratedSessionAccessorFiles).toEqual(
       new Set([


### PR DESCRIPTION
## What Problem This Solves

`loadSessionEntry` joins the agent database writable lifecycle on every read — opening and registering the per-agent SQLite database, and materializing `agents/<id>/` state for agents that do not exist. Reads that mutate. The observer program hit this concretely (merely watching a session could create phantom agent state; fixed narrowly in #112216), and `listSessionEntriesReadOnly`'s own comment records the same disease on health ticks churning fleet-wide agent handles.

## Why This Change Was Made

A full audit of all 217 production call sites (164 loads, 53 lists) across 144 files, classifying each as pure-read or write-adjacent. Every provable pure reader now uses the non-materializing accessor; write-adjacent and ambiguous sites are retained with per-site reasons recorded in the review artifact's audit table. A narrow guard now covers 16 gateway read-path files so projections and status paths cannot regress to the materializing accessor.

Deliberately NOT in this PR: flipping the default. The end state — after these migrations prove out — is `loadSessionEntry` itself becoming the pure read (the name telling the truth) and the `ReadOnly` suffix retiring; that flip is a follow-up once no legitimate materializing reader remains.

## User Impact

Behavior-neutral by contract: no user-visible change. Structurally, status surfaces, projections, exports, and doctor inspections can no longer create agent state or churn database handles as a side effect of reading.

## Evidence

- 106 files changed (84 production, 21 tests, 1 checker), +429/−209.
- Conformance suite plus migrated-cluster focused tests green (60 tests in the ship run); new boundary and missing-agent regression tests included.
- Structured autoreview (gpt-5.6-sol, high) on the full branch diff: clean, no findings.
- The complete audit table (every call site, classification, migration decision, retention reason) ships in the PR review artifacts.
