### PR TITLE
feat(android): port the zen, drummer, and peekaboo claw stances

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -13171,7 +13171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 345,
+      "line": 384,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "${days}d",
       "surface": "android",
@@ -13179,7 +13179,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 349,
+      "line": 388,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "${hours}h",
       "surface": "android",
@@ -13187,7 +13187,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 353,
+      "line": 392,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "${minutes}m",
       "surface": "android",
@@ -13195,7 +13195,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 357,
+      "line": 396,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "${seconds}s",
       "surface": "android",
@@ -13203,7 +13203,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 392,
+      "line": 431,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "Shelling",
       "surface": "android",
@@ -13211,7 +13211,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 393,
+      "line": 432,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "Scuttling",
       "surface": "android",
@@ -13219,7 +13219,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 394,
+      "line": 433,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "Clawing",
       "surface": "android",
@@ -13227,7 +13227,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 395,
+      "line": 434,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "Pinching",
       "surface": "android",
@@ -13235,7 +13235,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 396,
+      "line": 435,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "Molting",
       "surface": "android",
@@ -13243,7 +13243,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 397,
+      "line": 436,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "Bubbling",
       "surface": "android",
@@ -13251,7 +13251,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 398,
+      "line": 437,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "Tiding",
       "surface": "android",
@@ -13259,7 +13259,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 399,
+      "line": 438,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "Reefing",
       "surface": "android",
@@ -13267,7 +13267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 400,
+      "line": 439,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "Cracking",
       "surface": "android",
@@ -13275,7 +13275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 401,
+      "line": 440,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "Sifting",
       "surface": "android",
@@ -13283,7 +13283,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 402,
+      "line": 441,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "Brining",
       "surface": "android",
@@ -13291,7 +13291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 403,
+      "line": 442,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "Nautiling",
       "surface": "android",
@@ -13299,7 +13299,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 404,
+      "line": 443,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "Krilling",
       "surface": "android",
@@ -13307,7 +13307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 405,
+      "line": 444,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "Barnacling",
       "surface": "android",
@@ -13315,7 +13315,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 406,
+      "line": 445,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "Lobstering",
       "surface": "android",
@@ -13323,7 +13323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 407,
+      "line": 446,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "Tidepooling",
       "surface": "android",
@@ -13331,7 +13331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 408,
+      "line": 447,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "Pearling",
       "surface": "android",
@@ -13339,7 +13339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 409,
+      "line": 448,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "Snapping",
       "surface": "android",
@@ -13347,7 +13347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 410,
+      "line": 449,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt",
       "source": "Surfacing",
       "surface": "android",

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatWorkingIndicator.kt
@@ -38,8 +38,10 @@ import kotlin.math.roundToLong
 import kotlin.random.Random
 
 private const val DEFAULT_CLAW_CYCLE_MS = 2_400L
+private const val DRUMMER_CLAW_CYCLE_MS = 1_200L
 private const val FLURRY_CLAW_CYCLE_MS = 1_300L
 private const val SPIN_CLAW_CYCLE_MS = 3_600L
+private const val ZEN_CLAW_CYCLE_MS = 6_000L
 internal const val WORKING_PHRASE_SHOW_AFTER_MS = 30_000L
 internal const val WORKING_PHRASE_ROTATE_EVERY_MS = 45_000L
 
@@ -67,16 +69,22 @@ internal enum class WorkingClawStance {
   Spin,
   Shadowbox,
   Backflip,
+  Zen,
+  Drummer,
+  Peekaboo,
 }
 
 private val stanceWeights =
   listOf(
-    WorkingClawStance.Default to 66,
-    WorkingClawStance.Southpaw to 20,
+    WorkingClawStance.Default to 63,
+    WorkingClawStance.Southpaw to 19,
     WorkingClawStance.Flurry to 5,
     WorkingClawStance.Spin to 4,
     WorkingClawStance.Shadowbox to 3,
     WorkingClawStance.Backflip to 2,
+    WorkingClawStance.Zen to 2,
+    WorkingClawStance.Drummer to 1,
+    WorkingClawStance.Peekaboo to 1,
   )
 private val processStanceSalt = Random.nextInt()
 
@@ -107,6 +115,7 @@ private data class ClawKeyframe(
 )
 
 private val easeOut = CubicBezierEasing(0f, 0f, 0.58f, 1f)
+private val easeInOut = CubicBezierEasing(0.42f, 0f, 0.58f, 1f)
 private val flexFrames =
   frames(0f to 0f, 0.06f to 0f, 0.10f to -4f, 0.16f to 3f, 0.22f to -4f, 0.26f to -4f, 0.32f to 3f, 0.42f to 0f, 1f to 0f)
 private val snipFrames =
@@ -122,12 +131,20 @@ private val backflipRotationFrames =
 private val backflipYFrames = frames(0f to 0f, 0.55f to 0f, 0.62f to -3f, 0.70f to -3f, 0.78f to 0f, 1f to 0f)
 private val powAlphaFrames = frames(0f to 0f, 0.46f to 0f, 0.52f to 1f, 0.58f to 0f, 1f to 0f)
 private val powScaleFrames = frames(0f to 0.4f, 0.46f to 0.4f, 0.52f to 1.2f, 0.58f to 1.5f, 1f to 1.5f)
+private val zenScaleFrames = frames(0f to 1f, 0.30f to 1.08f, 0.55f to 1f, 1f to 1f)
+private val zenJawFrames = frames(0f to -10f, 0.60f to -10f, 0.70f to -24f, 0.76f to 2f, 0.86f to -10f, 1f to -10f)
+private val drummerRotationFrames = frames(0f to 0f, 0.15f to -8f, 0.30f to 0f, 0.55f to 8f, 0.70f to 0f, 1f to 0f)
+private val drummerJawFrames = frames(0f to -10f, 0.10f to -20f, 0.15f to 2f, 0.25f to -10f, 0.50f to -20f, 0.55f to 2f, 0.65f to -10f, 1f to -10f)
+private val peekabooScaleFrames = frames(0f to 1f, 0.55f to 1f, 0.62f to 0.72f, 0.72f to 0.72f, 0.78f to 1.06f, 0.84f to 1f, 1f to 1f)
+private val peekabooYFrames = frames(0f to 0f, 0.55f to 0f, 0.62f to 5f, 0.72f to 5f, 0.78f to -1.5f, 0.84f to 0f, 1f to 0f)
+private val peekabooJawFrames = frames(0f to -10f, 0.55f to -10f, 0.62f to -2f, 0.72f to -2f, 0.78f to -28f, 0.86f to -10f, 1f to -10f)
 
 private fun frames(vararg values: Pair<Float, Float>): List<ClawKeyframe> = values.map { (phase, value) -> ClawKeyframe(phase, value) }
 
 private fun sampleFrames(
   keyframes: List<ClawKeyframe>,
   phase: Float,
+  easing: CubicBezierEasing = easeOut,
 ): Float {
   val bounded = phase.coerceIn(0f, 1f)
   val nextIndex = keyframes.indexOfFirst { it.phase >= bounded }.takeIf { it >= 0 } ?: keyframes.lastIndex
@@ -135,21 +152,22 @@ private fun sampleFrames(
   val previous = keyframes[nextIndex - 1]
   val next = keyframes[nextIndex]
   if (next.phase == previous.phase) return next.value
-  val progress = easeOut.transform((bounded - previous.phase) / (next.phase - previous.phase))
+  val progress = easing.transform((bounded - previous.phase) / (next.phase - previous.phase))
   return previous.value + (next.value - previous.value) * progress
 }
 
-private data class WorkingClawPose(
+internal data class WorkingClawPose(
   val rotationZ: Float = 0f,
   val rotationY: Float = 0f,
   val translationXDp: Float = 0f,
   val translationYDp: Float = 0f,
+  val scale: Float = 1f,
   val jawRotation: Float = -10f,
   val powAlpha: Float = 0f,
   val powScale: Float = 0.4f,
 )
 
-private fun workingClawPose(
+internal fun workingClawPose(
   stance: WorkingClawStance,
   phase: Float,
 ): WorkingClawPose =
@@ -173,6 +191,22 @@ private fun workingClawPose(
         translationYDp = sampleFrames(backflipYFrames, phase),
         jawRotation = sampleFrames(snipFrames, phase),
       )
+    WorkingClawStance.Zen ->
+      WorkingClawPose(
+        scale = sampleFrames(zenScaleFrames, phase, easeInOut),
+        jawRotation = sampleFrames(zenJawFrames, phase),
+      )
+    WorkingClawStance.Drummer ->
+      WorkingClawPose(
+        rotationZ = sampleFrames(drummerRotationFrames, phase),
+        jawRotation = sampleFrames(drummerJawFrames, phase),
+      )
+    WorkingClawStance.Peekaboo ->
+      WorkingClawPose(
+        translationYDp = sampleFrames(peekabooYFrames, phase),
+        scale = sampleFrames(peekabooScaleFrames, phase),
+        jawRotation = sampleFrames(peekabooJawFrames, phase),
+      )
     WorkingClawStance.Default,
     WorkingClawStance.Southpaw,
     WorkingClawStance.Flurry,
@@ -181,6 +215,15 @@ private fun workingClawPose(
         rotationZ = sampleFrames(flexFrames, phase),
         jawRotation = sampleFrames(snipFrames, phase),
       )
+  }
+
+internal fun workingClawCycleMs(stance: WorkingClawStance): Long =
+  when (stance) {
+    WorkingClawStance.Drummer -> DRUMMER_CLAW_CYCLE_MS
+    WorkingClawStance.Flurry -> FLURRY_CLAW_CYCLE_MS
+    WorkingClawStance.Spin -> SPIN_CLAW_CYCLE_MS
+    WorkingClawStance.Zen -> ZEN_CLAW_CYCLE_MS
+    else -> DEFAULT_CLAW_CYCLE_MS
   }
 
 @Composable
@@ -193,12 +236,7 @@ internal fun WorkingClawIcon(
   val stance = remember(runKey, parked) { if (parked) WorkingClawStance.Default else pickWorkingClawStance(runKey) }
   val density = LocalDensity.current
   val animationsEnabled = rememberSystemAnimationsEnabled() && !parked
-  val cycleMs =
-    when (stance) {
-      WorkingClawStance.Flurry -> FLURRY_CLAW_CYCLE_MS
-      WorkingClawStance.Spin -> SPIN_CLAW_CYCLE_MS
-      else -> DEFAULT_CLAW_CYCLE_MS
-    }
+  val cycleMs = workingClawCycleMs(stance)
   var phase by remember(runKey) { mutableFloatStateOf(0f) }
   LaunchedEffect(animationsEnabled, runKey, cycleMs) {
     if (!animationsEnabled) {
@@ -231,7 +269,8 @@ internal fun WorkingClawIcon(
             rotationY = pose.rotationY
             translationX = with(density) { pose.translationXDp.dp.toPx() }
             translationY = with(density) { pose.translationYDp.dp.toPx() }
-            scaleX = if (stance == WorkingClawStance.Southpaw) -1f else 1f
+            scaleX = pose.scale * if (stance == WorkingClawStance.Southpaw) -1f else 1f
+            scaleY = pose.scale
             cameraDistance = with(density) { 60.dp.toPx() }
           },
     ) {

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatWorkingIndicatorTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatWorkingIndicatorTest.kt
@@ -27,12 +27,64 @@ class ChatWorkingIndicatorTest {
       counts[stance] = counts.getOrDefault(stance, 0) + 1
     }
 
-    assertEquals(660, counts[WorkingClawStance.Default])
-    assertEquals(200, counts[WorkingClawStance.Southpaw])
+    assertEquals(1_000, counts.values.sum())
+    assertEquals(WorkingClawStance.entries.toSet(), counts.keys)
+    assertEquals(630, counts[WorkingClawStance.Default])
+    assertEquals(190, counts[WorkingClawStance.Southpaw])
     assertEquals(50, counts[WorkingClawStance.Flurry])
     assertEquals(40, counts[WorkingClawStance.Spin])
     assertEquals(30, counts[WorkingClawStance.Shadowbox])
     assertEquals(20, counts[WorkingClawStance.Backflip])
+    assertEquals(20, counts[WorkingClawStance.Zen])
+    assertEquals(10, counts[WorkingClawStance.Drummer])
+    assertEquals(10, counts[WorkingClawStance.Peekaboo])
+  }
+
+  @Test
+  fun newStancesUseSpecifiedCyclesAndKeyframePoses() {
+    assertEquals(6_000L, workingClawCycleMs(WorkingClawStance.Zen))
+    assertPose(
+      workingClawPose(WorkingClawStance.Zen, 0.30f),
+      scale = 1.08f,
+      jawRotation = -10f,
+    )
+    assertPose(
+      workingClawPose(WorkingClawStance.Zen, 0.70f),
+      jawRotation = -24f,
+    )
+    assertPose(
+      workingClawPose(WorkingClawStance.Zen, 0.76f),
+      scale = 1f,
+      jawRotation = 2f,
+    )
+
+    assertEquals(1_200L, workingClawCycleMs(WorkingClawStance.Drummer))
+    assertEquals(-20f, workingClawPose(WorkingClawStance.Drummer, 0.10f).jawRotation, 0.001f)
+    assertPose(
+      workingClawPose(WorkingClawStance.Drummer, 0.15f),
+      rotationZ = -8f,
+      jawRotation = 2f,
+    )
+    assertEquals(-20f, workingClawPose(WorkingClawStance.Drummer, 0.50f).jawRotation, 0.001f)
+    assertPose(
+      workingClawPose(WorkingClawStance.Drummer, 0.55f),
+      rotationZ = 8f,
+      jawRotation = 2f,
+    )
+
+    assertEquals(2_400L, workingClawCycleMs(WorkingClawStance.Peekaboo))
+    assertPose(
+      workingClawPose(WorkingClawStance.Peekaboo, 0.62f),
+      translationYDp = 5f,
+      scale = 0.72f,
+      jawRotation = -2f,
+    )
+    assertPose(
+      workingClawPose(WorkingClawStance.Peekaboo, 0.78f),
+      translationYDp = -1.5f,
+      scale = 1.06f,
+      jawRotation = -28f,
+    )
   }
 
   @Test
@@ -124,5 +176,21 @@ class ChatWorkingIndicatorTest {
     assertEquals("run-2", replacement.key)
     assertEquals(9_000L, replacement.observedAtElapsedMs)
     assertEquals(2_000L, replacement.authoritativeStartedAtMs)
+  }
+
+  private fun assertPose(
+    pose: WorkingClawPose,
+    rotationZ: Float = 0f,
+    translationXDp: Float = 0f,
+    translationYDp: Float = 0f,
+    scale: Float = 1f,
+    jawRotation: Float = -10f,
+  ) {
+    assertEquals(rotationZ, pose.rotationZ, 0.001f)
+    assertEquals(0f, pose.rotationY, 0.001f)
+    assertEquals(translationXDp, pose.translationXDp, 0.001f)
+    assertEquals(translationYDp, pose.translationYDp, 0.001f)
+    assertEquals(scale, pose.scale, 0.001f)
+    assertEquals(jawRotation, pose.jawRotation, 0.001f)
   }
 }


### PR DESCRIPTION
## What Problem This Solves

The web working claw just learned three new rare stances (#112552); the Android claw (landed in #112221) needs parity.

## Why This Change Was Made

Ports zen (2%, 6s scale-breath with one deliberate late snip), drummer (1%, 1.2s two-beat ±8° rock with jaw hits on the tilts), and peekaboo (1%, duck to 0.72× with tucked jaw, then pop to 1.06× wide open) into `ChatWorkingIndicator.kt`'s stance system: weighted selection, cycle timing, and keyframes. Weights rebalance from the calm stances only (default 63, southpaw 19); all motion is scale/rotate/vertical, matching the web keyframes exactly. The animation-disabled path keeps the static claw.

## User Impact

Same three rare surprises in the Android chat working indicator as on web and Apple.

## Evidence

- `:app:ktlintCheck`, `:app:lintPlayDebug`, `:app:testPlayDebugUnitTest` green (1,862 tests across 167 suites; 8 indicator tests including deterministic pose sampling of the breath, drum-hit, duck, and "boo" landmark poses).
- Structured Codex autoreview: clean first pass ("weights still total 100, animation-disabled behavior intact").
- Behavior reference (web spec of record + GIF): https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/2026-07-claw-more-tricks/claw-tricks.gif
