### PR TITLE
fix(ui): collapse discussion panel chrome to a single header

### DIFF
--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -4289,7 +4289,6 @@ export const en: TranslationMap = {
       loading: "Loading discussion…",
       opening: "Opening discussion…",
       requiresWriteAccess: "Operator write access is required to open this discussion.",
-      opened: "Session discussion",
       openExternal: "Open discussion in a new tab",
       frameTitle: "Session discussion",
       unavailable: "This discussion cannot be embedded.",

--- a/ui/src/pages/chat/chat-pane.session-discussion.test.ts
+++ b/ui/src/pages/chat/chat-pane.session-discussion.test.ts
@@ -6,6 +6,7 @@ import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { SessionCapability } from "../../lib/sessions/index.ts";
 import { createTestChatPane, type TestChatPane } from "./chat-pane.test-support.ts";
 import type { SidebarContent } from "./components/chat-sidebar.ts";
+import "./components/chat-sidebar.ts";
 
 type DiscussionTestPane = TestChatPane & {
   probeSessionDiscussion: (sessionKey: string) => Promise<void>;
@@ -51,6 +52,42 @@ describe("chat pane session discussion auto-show", () => {
     const content = handleOpenSidebar.mock.calls[0]?.[0];
     expect(content?.kind).toBe("session-discussion");
     expect(content && "sessionKey" in content ? content.sessionKey : null).toBe(SESSION_KEY);
+  });
+
+  it("shows the reported external URL in the outer sidebar header", async () => {
+    const openUrl = "https://clack.example/channels/c1";
+    const { pane, state, handleOpenSidebar } = createDiscussionPane({
+      info: {
+        state: "open",
+        embedUrl: "https://clack.example/embed/c1",
+        openUrl,
+      },
+    });
+
+    await pane.probeSessionDiscussion(SESSION_KEY);
+
+    const content = handleOpenSidebar.mock.calls[0]?.[0];
+    if (!content || content.kind !== "session-discussion") {
+      throw new Error("expected a session discussion sidebar");
+    }
+    content.onStateChange(SESSION_KEY, "open", openUrl);
+
+    const panel = document.createElement("openclaw-chat-detail-panel") as HTMLElement & {
+      content: SidebarContent;
+      onClose: () => void;
+      updateComplete: Promise<unknown>;
+    };
+    panel.content = state.sidebarContent as SidebarContent;
+    panel.onClose = vi.fn();
+    document.body.append(panel);
+    await panel.updateComplete;
+
+    const external = panel.querySelector<HTMLAnchorElement>(".sidebar-header a");
+    expect(external?.href).toBe(openUrl);
+    expect(external?.target).toBe("_blank");
+    expect(external?.rel).toBe("noopener");
+    expect(panel.querySelector(".session-discussion__header")).toBeNull();
+    panel.remove();
   });
 
   it("does not auto-show for a merely available discussion", async () => {

--- a/ui/src/pages/chat/chat-pane.ts
+++ b/ui/src/pages/chat/chat-pane.ts
@@ -470,6 +470,7 @@ class ChatPane extends OpenClawLightDomElement {
   private swarmBoardSnapshotBase: BoardSnapshot | null = null;
   private swarmBoardSnapshotRequest = 0;
   private readonly sessionDiscussionStates = new Map<string, SessionDiscussionState>();
+  private readonly sessionDiscussionOpenUrls = new Map<string, string | null>();
   private readonly sessionDiscussionProbes = new Set<string>();
   private headerRenameInitialLabel: string | null = null;
   private headerRenameInitialValue = "";
@@ -923,6 +924,7 @@ class ChatPane extends OpenClawLightDomElement {
     // Close old-session portals and listener-owning popovers before the next
     // render detaches their DOM and makes owner-scoped cleanup impossible.
     resetChatThreadPresentationState(this.paneId, this);
+    this.sessionDiscussionOpenUrls.clear();
     const previousSessionKey = state.sessionKey;
     // An in-progress title edit belongs to the previous session; committing
     // it against the newly routed row would rename the wrong session.
@@ -2562,6 +2564,7 @@ class ChatPane extends OpenClawLightDomElement {
       this.taskSuggestionBusyIds.clear();
       this.taskSuggestionOperations.clear();
       this.sessionDiscussionStates.clear();
+      this.sessionDiscussionOpenUrls.clear();
       this.resetSessionPullRequests();
       this.resetOlderMessagesViewport();
       state.chatLoading = false;
@@ -2992,6 +2995,7 @@ class ChatPane extends OpenClawLightDomElement {
       kind: "session-discussion",
       sessionKey,
       canOpen,
+      openUrl: this.sessionDiscussionOpenUrls.get(sessionKey) ?? null,
       loadInfo: async (key) => {
         if (!state.connected || !state.client) {
           throw new Error(t("chat.sessionDiscussion.disconnected"));
@@ -3008,13 +3012,20 @@ class ChatPane extends OpenClawLightDomElement {
           sessionKey: key,
         });
       },
-      onStateChange: (key, discussionState) => {
+      onStateChange: (key, discussionState, openUrl) => {
         // Panels created under a previous connection may report late; their
         // state belongs to the old provider and must not touch the new cache.
         if (contentGeneration !== this.connectionGeneration) {
           return;
         }
         this.sessionDiscussionStates.set(key, discussionState);
+        const isCurrentSession = state.sessionKey.trim() === key;
+        if (isCurrentSession) {
+          this.sessionDiscussionOpenUrls.set(key, openUrl);
+        }
+        if (discussionState === "none") {
+          this.sessionDiscussionOpenUrls.delete(key);
+        }
         const current = state.sidebarContent;
         if (
           discussionState === "none" &&
@@ -3023,6 +3034,13 @@ class ChatPane extends OpenClawLightDomElement {
         ) {
           state.handleCloseSidebar();
           return;
+        }
+        if (
+          isCurrentSession &&
+          current?.kind === "session-discussion" &&
+          current.sessionKey === key
+        ) {
+          state.sidebarContent = { ...current, openUrl };
         }
         state.requestUpdate();
       },
@@ -3607,7 +3625,13 @@ class ChatPane extends OpenClawLightDomElement {
       canvasPluginSurfaceUrl: state.hello?.pluginSurfaceUrls?.canvas ?? null,
       boardProvider: board.provider,
       onOpenSidebar: state.handleOpenSidebar,
-      onCloseSidebar: state.handleCloseSidebar,
+      onCloseSidebar: () => {
+        const content = state.sidebarContent;
+        if (content?.kind === "session-discussion") {
+          this.sessionDiscussionOpenUrls.delete(content.sessionKey);
+        }
+        state.handleCloseSidebar();
+      },
       onSplitRatioChange: state.handleSplitRatioChange,
       assistantName: state.assistantName,
       assistantAvatar: state.assistantAvatar,

--- a/ui/src/pages/chat/components/chat-sidebar.ts
+++ b/ui/src/pages/chat/components/chat-sidebar.ts
@@ -91,6 +91,7 @@ type SessionDiscussionSidebarContent = {
   kind: "session-discussion";
   sessionKey: string;
   canOpen: boolean;
+  openUrl?: string | null;
   loadInfo: SessionDiscussionInfoLoader;
   openDiscussion: SessionDiscussionOpener;
   onStateChange: SessionDiscussionStateListener;
@@ -523,6 +524,8 @@ function renderMarkdownSidebar(props: MarkdownSidebarProps) {
           props.allowExternalEmbedUrls ?? false,
         )
       : null;
+  const discussionOpenUrl =
+    content?.kind === "session-discussion" ? (content.openUrl ?? null) : null;
   const title =
     content?.kind === "canvas"
       ? content.title?.trim() || "Render Preview"
@@ -541,16 +544,33 @@ function renderMarkdownSidebar(props: MarkdownSidebarProps) {
     <div class="sidebar-panel">
       <div class="sidebar-header">
         <div class="sidebar-title">${title}</div>
-        <openclaw-tooltip .content=${t("chat.detailPanel.close")}>
-          <button
-            @click=${props.onClose}
-            class="btn"
-            type="button"
-            aria-label=${t("chat.detailPanel.close")}
-          >
-            ${icons.x}
-          </button>
-        </openclaw-tooltip>
+        <div class="sidebar-header__actions">
+          ${discussionOpenUrl
+            ? html`
+                <openclaw-tooltip .content=${t("chat.sessionDiscussion.openExternal")}>
+                  <a
+                    class="btn btn--ghost btn--icon"
+                    href=${discussionOpenUrl}
+                    target="_blank"
+                    rel="noopener"
+                    aria-label=${t("chat.sessionDiscussion.openExternal")}
+                  >
+                    ${icons.externalLink}
+                  </a>
+                </openclaw-tooltip>
+              `
+            : nothing}
+          <openclaw-tooltip .content=${t("chat.detailPanel.close")}>
+            <button
+              @click=${props.onClose}
+              class="btn"
+              type="button"
+              aria-label=${t("chat.detailPanel.close")}
+            >
+              ${icons.x}
+            </button>
+          </openclaw-tooltip>
+        </div>
       </div>
       <div
         class="sidebar-content ${content?.kind === "session-discussion"

--- a/ui/src/pages/chat/components/session-discussion-panel.test.ts
+++ b/ui/src/pages/chat/components/session-discussion-panel.test.ts
@@ -41,7 +41,7 @@ function mount(params: {
 }
 
 describe("session discussion panel", () => {
-  it("automatically opens an available discussion and renders both URLs", async () => {
+  it("automatically opens an available discussion without a redundant header", async () => {
     const loadInfo = vi.fn<SessionDiscussionInfoLoader>().mockResolvedValue({
       state: "available",
     });
@@ -50,7 +50,8 @@ describe("session discussion panel", () => {
       embedUrl: "https://discussion.example/embed/thread",
       openUrl: "https://discussion.example/thread",
     });
-    const panel = mount({ loadInfo, openDiscussion });
+    const onStateChange = vi.fn<SessionDiscussionStateListener>();
+    const panel = mount({ loadInfo, openDiscussion, onStateChange });
 
     await vi.waitFor(() => {
       expect(panel.querySelector("iframe")?.getAttribute("src")).toBe(
@@ -60,11 +61,36 @@ describe("session discussion panel", () => {
         "allow-forms allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts",
       );
     });
-    const external = panel.querySelector<HTMLAnchorElement>("a");
     expect(loadInfo).toHaveBeenCalledTimes(1);
     expect(openDiscussion).toHaveBeenCalledTimes(1);
     expect(openDiscussion).toHaveBeenCalledWith("agent:main:first");
-    expect(external?.href).toBe("https://discussion.example/thread");
+    expect(onStateChange).toHaveBeenLastCalledWith(
+      "agent:main:first",
+      "open",
+      "https://discussion.example/thread",
+    );
+    expect(panel.querySelector(".session-discussion__header")).toBeNull();
+    expect(panel.querySelector("a")).toBeNull();
+  });
+
+  it("offers the valid open URL when a same-origin embed is rejected", async () => {
+    const openUrl = "https://discussion.example/thread";
+    const panel = mount({
+      loadInfo: vi.fn().mockResolvedValue({
+        state: "open",
+        embedUrl: new URL("/embed/thread", window.location.origin).href,
+        openUrl,
+      }),
+      openDiscussion: vi.fn(),
+    });
+
+    await vi.waitFor(() => {
+      expect(panel.textContent).toContain("This discussion cannot be embedded");
+    });
+    const external = panel.querySelector<HTMLAnchorElement>("a");
+    expect(panel.querySelector("iframe")).toBeNull();
+    expect(external?.textContent).toContain("Open discussion in a new tab");
+    expect(external?.href).toBe(openUrl);
     expect(external?.target).toBe("_blank");
     expect(external?.rel).toBe("noopener");
   });
@@ -133,7 +159,7 @@ describe("session discussion panel", () => {
 
     await vi.waitFor(() => {
       expect(loadInfo).toHaveBeenNthCalledWith(2, "agent:main:second");
-      expect(onStateChange).toHaveBeenLastCalledWith("agent:main:second", "none");
+      expect(onStateChange).toHaveBeenLastCalledWith("agent:main:second", "none", null);
     });
     expect(panel.querySelector("button")).toBeNull();
     expect(panel.querySelector("iframe")).toBeNull();

--- a/ui/src/pages/chat/components/session-discussion-panel.ts
+++ b/ui/src/pages/chat/components/session-discussion-panel.ts
@@ -4,8 +4,6 @@ import type {
   SessionDiscussionInfo,
   SessionDiscussionState,
 } from "../../../../../packages/gateway-protocol/src/index.js";
-import { icons } from "../../../components/icons.ts";
-import "../../../components/tooltip.ts";
 import { t } from "../../../i18n/index.ts";
 import { OpenClawLightDomElement } from "../../../lit/openclaw-element.ts";
 
@@ -14,6 +12,7 @@ export type SessionDiscussionOpener = (sessionKey: string) => Promise<SessionDis
 export type SessionDiscussionStateListener = (
   sessionKey: string,
   discussionState: SessionDiscussionState,
+  openUrl: string | null,
 ) => void;
 
 function resolveDiscussionUrl(value: string | undefined): string | null {
@@ -79,7 +78,7 @@ class SessionDiscussionPanel extends OpenClawLightDomElement {
       return;
     }
     this.info = info;
-    this.onStateChange?.(requestKey, info.state);
+    this.onStateChange?.(requestKey, info.state, resolveDiscussionUrl(info.openUrl));
   }
 
   private async refresh(): Promise<void> {
@@ -145,24 +144,6 @@ class SessionDiscussionPanel extends OpenClawLightDomElement {
     const openUrl = resolveDiscussionUrl(info.openUrl);
     return html`
       <div class="session-discussion__open">
-        <div class="session-discussion__header">
-          <span>${t("chat.sessionDiscussion.opened")}</span>
-          ${openUrl
-            ? html`
-                <openclaw-tooltip .content=${t("chat.sessionDiscussion.openExternal")}>
-                  <a
-                    class="btn btn--ghost btn--icon session-discussion__external"
-                    href=${openUrl}
-                    target="_blank"
-                    rel="noopener"
-                    aria-label=${t("chat.sessionDiscussion.openExternal")}
-                  >
-                    ${icons.externalLink}
-                  </a>
-                </openclaw-tooltip>
-              `
-            : nothing}
-        </div>
         ${embedUrl
           ? html`
               <iframe
@@ -173,7 +154,12 @@ class SessionDiscussionPanel extends OpenClawLightDomElement {
               ></iframe>
             `
           : html`<div class="session-discussion__empty">
-              ${t("chat.sessionDiscussion.unavailable")}
+              <span>${t("chat.sessionDiscussion.unavailable")}</span>
+              ${openUrl
+                ? html`<a class="session-link" href=${openUrl} target="_blank" rel="noopener">
+                    ${t("chat.sessionDiscussion.openExternal")}
+                  </a>`
+                : nothing}
             </div>`}
       </div>
     `;

--- a/ui/src/styles/chat/sidebar.css
+++ b/ui/src/styles/chat/sidebar.css
@@ -1014,6 +1014,12 @@
   line-height: 1;
 }
 
+.sidebar-header__actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
 .sidebar-title {
   font-weight: 600;
   font-size: var(--control-ui-text-md);
@@ -1049,8 +1055,10 @@ openclaw-session-discussion {
 .session-discussion__empty {
   display: flex;
   flex: 1;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
+  gap: 12px;
   padding: 24px;
   color: var(--muted);
 }
@@ -1061,27 +1069,6 @@ openclaw-session-discussion {
   flex-direction: column;
   min-width: 0;
   min-height: 0;
-}
-
-.session-discussion__header {
-  display: flex;
-  flex-shrink: 0;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px;
-  min-height: 36px;
-  padding: 4px 8px 4px 12px;
-  border-bottom: 1px solid var(--border);
-  color: var(--muted);
-  font-size: var(--control-ui-text-sm);
-}
-
-.session-discussion__external {
-  width: 28px;
-  min-width: 28px;
-  height: 28px;
-  min-height: 28px;
-  padding: 5px;
 }
 
 .session-discussion__frame {


### PR DESCRIPTION
## What Problem This Solves

The session Discussion side panel stacks three title bars before the first message: the panel header ("Discussion" + close), an OpenClaw subheader ("Session discussion" + external-link icon), and the embedded ClickClack channel header ("# s-…" + "Open in ClickClack"). Each draws its own bottom border, so the panel opens with three stacked titles and three separator lines, and the middle bar duplicates both the title above it and the external-link affordance the embed provides below it. The embed composer also sits visibly lower than the main chat composer because the extra chrome pushes the iframe down while the embed hugs its bottom edge.

## Why This Change Was Made

The middle layer carries no information — "Session discussion" restates "Discussion" — so it is deleted. The panel now shows exactly two title bars and two borders: the OpenClaw panel header and the embed's own channel header. The external-open affordance moves into the existing panel header (icon next to the close button, no new bar): the panel component now reports its validated `openUrl` through the state-change listener, the pane caches it per session (cleared on session switch, close, and disconnect), and the sidebar header renders the link whenever a URL is known. This keeps an escape hatch for the case where a valid `embedUrl` still cannot render (frame-ancestors misconfiguration, auth redirect) — previously covered by the subheader link. When the embed URL is rejected locally (e.g. same-origin), the unavailable state now also renders an "Open discussion in a new tab" link instead of a dead end.

Companion ClickClack change: openclaw/clickclack#110 compacts the embed header and aligns the embed composer dock with the Control UI main composer spacing.

## User Impact

- Discussion panel shows one OpenClaw header + the channel's own header; the redundant middle bar and its separator are gone, and the discussion gains ~36px of vertical space.
- The embed composer aligns with the main composer level (with the ClickClack-side change).
- Opening the discussion externally stays one click away in the panel header, and embed failures now offer a working external link instead of only "cannot be embedded".

## Evidence

- `node scripts/run-vitest.mjs ui/src/pages/chat/components/session-discussion-panel.test.ts ui/src/pages/chat/chat-pane.session-discussion.test.ts` — 14/14 green, including new assertions: open state renders no `.session-discussion__header`; the listener reports the validated `openUrl` (and `null` when absent); the sidebar header renders the external anchor (`target=_blank rel=noopener`); same-origin-rejected embeds render the fallback anchor.
- Unused i18n key `chat.sessionDiscussion.opened` removed; `pnpm ui:i18n:baseline` clean, no baseline drift. Repo-wide greps show no remaining `session-discussion__header` / `session-discussion__external` references outside the negative test assertion.
- Screenshot hosting (artifacts.openclaw.ai) is currently unavailable locally (crabbox artifact broker down, no R2-scoped token); the layout contract is encoded in the test assertions above, and the companion ClickClack PR carries 320px-viewport e2e bounds checks for the embedded side.

## Follow-up idea: native session-discussion rendering (no iframe)

Today the panel is a cross-origin iframe of ClickClack's `/embed/channel/...` route. That forces duplicated chrome, a second composer implementation, cookie-based auth coupling (fragile under Safari ITP), and the sandbox/same-origin security dance in `session-discussion-panel.ts`. ClickClack already exposes everything needed to render the discussion natively: REST (`GET/POST /api/channels/{id}/messages` with cursor pagination and nonce-idempotent posting), realtime WS (`/api/realtime/ws` with bearer via `Sec-WebSocket-Protocol`), scoped bot tokens, and a generated TS SDK (`packages/sdk-ts`).

Proposed shape, reusing the existing session-discussion seam: extend `SessionDiscussionInfo` (additive) with a `feed` capability; the gateway proxies history/post/stream over the existing JSON-RPC socket (`session.discussion.history` / `session.discussion.post` / push events) so the browser never holds a ClickClack credential; the clickclack extension (which already owns the session⇄channel binding store and a server-side client) serves those methods; the Control UI renders messages with existing chat list primitives and reuses the main composer component — making composer parity structural instead of pixel-matched across an iframe. The iframe path stays as the capability-gated fallback for discussion servers without the feed capability.
