### PR TITLE
fix(matrix): migrate dedupe from legacy state databases

### DIFF
--- a/extensions/matrix/doctor-contract-api.test.ts
+++ b/extensions/matrix/doctor-contract-api.test.ts
@@ -1,6 +1,7 @@
 // Matrix tests cover doctor contract state migrations.
 import { createHash } from "node:crypto";
 import fs from "node:fs";
+import fsPromises from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
@@ -14,7 +15,7 @@ import {
   resetPluginStateStoreForTests,
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import type { PluginDoctorStateMigrationContext } from "openclaw/plugin-sdk/runtime-doctor";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { stateMigrations } from "./doctor-contract-api.js";
 import { SqliteBackedMatrixSyncStore } from "./src/matrix/client/file-sync-store.js";
 import { openMatrixStorageMetaStoreOptions } from "./src/matrix/client/storage.js";
@@ -73,6 +74,7 @@ describe("matrix doctor contract state migrations", () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     resetPluginStateStoreForTests();
     for (const dir of tempDirs.splice(0)) {
       fs.rmSync(dir, { recursive: true, force: true });
@@ -690,6 +692,64 @@ describe("matrix doctor contract state migrations", () => {
       changes: [],
       warnings: [],
     });
+  });
+
+  it("withholds completion after a directory read failure and imports the source on retry", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-matrix-doctor-"));
+    tempDirs.push(stateDir);
+    const blockedDir = path.join(stateDir, "matrix", "accounts", "home");
+    const jsonRoot = path.join(blockedDir, "matrix.example.org__bot", "token-a");
+    const jsonPath = path.join(jsonRoot, "inbound-dedupe.json");
+    const roomId = "!room:example.org";
+    const eventId = "$found-on-retry";
+    fs.mkdirSync(jsonRoot, { recursive: true });
+    fs.writeFileSync(
+      jsonPath,
+      JSON.stringify({
+        version: 1,
+        entries: [{ key: `${roomId}|${eventId}`, ts: Date.now() - 60_000 }],
+      }),
+    );
+    fs.writeFileSync(
+      path.join(jsonRoot, "storage-meta.json"),
+      JSON.stringify({ accountId: "home", userId: "@home:example.org" }),
+    );
+
+    const originalReaddir = fsPromises.readdir.bind(fsPromises);
+    const readdirSpy = vi.spyOn(fsPromises, "readdir").mockImplementation(async (...args) => {
+      if (path.resolve(String(args[0])) === path.resolve(blockedDir)) {
+        throw Object.assign(new Error("injected directory read failure"), { code: "EACCES" });
+      }
+      return originalReaddir(...args);
+    });
+    const migration = migrationById("matrix-inbound-dedupe-to-claimable-dedupe");
+    const params = createMigrationParams(stateDir);
+
+    await expect(migration.migrateLegacyState(params)).resolves.toEqual({
+      changes: [],
+      warnings: [
+        `Failed scanning Matrix inbound dedupe sources under ${blockedDir}: Error: injected directory read failure`,
+      ],
+    });
+    await expect(migration.detectLegacyState(params)).resolves.toEqual({
+      preview: ["Matrix inbound dedupe legacy sources need a one-time migration scan"],
+    });
+
+    readdirSpy.mockRestore();
+    await expect(migration.migrateLegacyState(params)).resolves.toEqual({
+      changes: [
+        "Migrated Matrix inbound dedupe markers to the claimable dedupe store (1 of 1 entries)",
+        `Archived Matrix inbound dedupe legacy source -> ${jsonPath}.migrated`,
+        "Recorded Matrix inbound dedupe migration completion (0 SQLite roots, 1 JSON roots scanned)",
+      ],
+      warnings: [],
+    });
+    const deduper = createMatrixInboundEventDeduper({
+      auth: { accountId: "home" },
+      env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+    });
+    await expect(deduper.claim({ roomId, eventId })).resolves.toEqual({ kind: "duplicate" });
+    await expect(migration.detectLegacyState(params)).resolves.toBeNull();
   });
 
   it("ignores an invalid legacy-scan completion receipt", async () => {

--- a/extensions/matrix/doctor-contract-api.test.ts
+++ b/extensions/matrix/doctor-contract-api.test.ts
@@ -901,4 +901,45 @@ describe("matrix doctor contract state migrations", () => {
       ].toSorted(),
     );
   });
+
+  it("preserves a legacy inbound dedupe marker's remaining TTL", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-matrix-doctor-"));
+    tempDirs.push(stateDir);
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const io = { context: createContext(), env };
+    const now = 2_000_000_000_000;
+    const remainingTtlMs = 1_000;
+    const roomId = "!room:example.org";
+    const eventId = "$near-expiry";
+    const key = `ops\0${roomId}\0${eventId}`;
+    const markerTs = now - MATRIX_INBOUND_DEDUPE_TTL_MS + remainingTtlMs;
+    const storedEntry = createPersistentDedupeImportEntry({ key, seenAt: markerTs });
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(now);
+
+    await expect(
+      importNewestInboundDedupeMarkers({
+        io,
+        now,
+        markers: [
+          {
+            accountId: "ops",
+            roomId,
+            eventId,
+            ts: markerTs,
+          },
+        ],
+      }),
+    ).resolves.toEqual({ imported: 1, total: 1 });
+
+    const store = createPluginStateKeyedStoreForTests<PersistentDedupeEntry>("matrix", {
+      namespace: resolveMatrixInboundDedupeStateNamespace(),
+      maxEntries: 20_000,
+      defaultTtlMs: MATRIX_INBOUND_DEDUPE_TTL_MS,
+      env,
+    });
+    nowSpy.mockReturnValue(now + remainingTtlMs - 1);
+    await expect(store.lookup(storedEntry.key)).resolves.toEqual(storedEntry.value);
+    nowSpy.mockReturnValue(now + remainingTtlMs + 1);
+    await expect(store.lookup(storedEntry.key)).resolves.toBeUndefined();
+  });
 });

--- a/extensions/matrix/doctor-contract-api.test.ts
+++ b/extensions/matrix/doctor-contract-api.test.ts
@@ -3,6 +3,7 @@ import { createHash } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type {
   OpenKeyedStoreOptions,
@@ -458,7 +459,7 @@ describe("matrix doctor contract state migrations", () => {
     expect(fs.existsSync(path.join(storageRootDir, "legacy-crypto-migration.json"))).toBe(false);
   });
 
-  it("migrates legacy inbound dedupe markers into the claimable dedupe store", async () => {
+  it("detects, imports, and retires schema-v1 inbound dedupe rows without upgrading the source", async () => {
     const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-matrix-doctor-"));
     tempDirs.push(stateDir);
     const sqliteRoot = path.join(
@@ -490,35 +491,70 @@ describe("matrix doctor contract state migrations", () => {
         .update(eventId)
         .digest("hex")}`;
 
-    // >=2026.6 shape: per-storage-root SQLite rows plus JSON-import markers.
-    const legacyStore = createPluginStateKeyedStoreForTests<{
-      roomId: string;
-      eventId: string;
-      ts: number;
-    }>("matrix", {
-      namespace: "inbound-dedupe",
-      maxEntries: 20_000,
-      env: { OPENCLAW_STATE_DIR: sqliteRoot },
-    });
-    await legacyStore.register(legacyKey("ops", "$committed"), {
-      roomId,
-      eventId: "$committed",
-      ts: now - 60_000,
-    });
-    await legacyStore.register(legacyKey("ops", "$expired"), {
-      roomId,
-      eventId: "$expired",
-      ts: now - 31 * 24 * 60 * 60 * 1000,
-    });
-    const legacyMarkersStore = createPluginStateKeyedStoreForTests<{ importedAt: number }>(
-      "matrix",
-      {
-        namespace: "inbound-dedupe-migrations",
-        maxEntries: 1_000,
-        env: { OPENCLAW_STATE_DIR: sqliteRoot },
-      },
-    );
-    await legacyMarkersStore.register("ops:legacy-json-marker", { importedAt: now });
+    // >=2026.6 shape in a historical schema-v1 database. It intentionally has
+    // none of the current schema's migration/audit tables.
+    const legacyDatabasePath = path.join(sqliteRoot, "state", "openclaw.sqlite");
+    fs.mkdirSync(path.dirname(legacyDatabasePath), { recursive: true });
+    const legacyDb = new DatabaseSync(legacyDatabasePath);
+    try {
+      legacyDb.exec(`
+        CREATE TABLE plugin_state_entries (
+          plugin_id TEXT NOT NULL,
+          namespace TEXT NOT NULL,
+          entry_key TEXT NOT NULL,
+          value_json TEXT NOT NULL,
+          created_at INTEGER NOT NULL,
+          expires_at INTEGER,
+          PRIMARY KEY (plugin_id, namespace, entry_key)
+        ) STRICT;
+        PRAGMA user_version = 1;
+      `);
+      const insert = legacyDb.prepare(`
+        INSERT INTO plugin_state_entries (
+          plugin_id, namespace, entry_key, value_json, created_at, expires_at
+        ) VALUES (?, ?, ?, ?, ?, ?)
+      `);
+      insert.run(
+        "matrix",
+        "inbound-dedupe",
+        legacyKey("ops", "$committed"),
+        JSON.stringify({ roomId, eventId: "$committed", ts: now - 60_000 }),
+        1,
+        now + 60_000,
+      );
+      insert.run(
+        "matrix",
+        "inbound-dedupe",
+        legacyKey("ops", "$stale"),
+        JSON.stringify({
+          roomId,
+          eventId: "$stale",
+          ts: now - 31 * 24 * 60 * 60 * 1000,
+        }),
+        2,
+        null,
+      );
+      insert.run(
+        "matrix",
+        "inbound-dedupe",
+        legacyKey("ops", "$expired-corrupt"),
+        "not-json",
+        3,
+        now - 1,
+      );
+      insert.run(
+        "matrix",
+        "inbound-dedupe-migrations",
+        "ops:legacy-json-marker",
+        JSON.stringify({ importedAt: now }),
+        4,
+        now + 60_000,
+      );
+      insert.run("matrix", "credentials", "keep-matrix", '{"keep":true}', 5, null);
+      insert.run("other-plugin", "inbound-dedupe", "keep-other", '{"keep":true}', 6, null);
+    } finally {
+      legacyDb.close();
+    }
 
     // <=2026.5 shape: raw inbound-dedupe.json plus storage-meta.json identity.
     fs.writeFileSync(
@@ -534,12 +570,29 @@ describe("matrix doctor contract state migrations", () => {
     );
 
     const migration = migrationById("matrix-inbound-dedupe-to-claimable-dedupe");
-    await expect(migration.detectLegacyState(createMigrationParams(stateDir))).resolves.toEqual({
+    const detectParams = createMigrationParams(stateDir);
+    detectParams.context = {
+      openPluginStateKeyedStore() {
+        throw new Error("detection must not open the current plugin-state runtime");
+      },
+    };
+    await expect(migration.detectLegacyState(detectParams)).resolves.toEqual({
       preview: [
         `Matrix inbound dedupe rows can migrate to the claimable dedupe store: ${sqliteRoot}`,
         `Matrix inbound dedupe JSON can migrate to the claimable dedupe store: ${path.join(jsonRoot, "inbound-dedupe.json")}`,
       ],
     });
+    const detectedDb = new DatabaseSync(legacyDatabasePath, { readOnly: true });
+    try {
+      expect(detectedDb.prepare("PRAGMA user_version").get()).toEqual({ user_version: 1 });
+      expect(
+        detectedDb
+          .prepare("SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name")
+          .all(),
+      ).toEqual([{ name: "plugin_state_entries" }]);
+    } finally {
+      detectedDb.close();
+    }
 
     await expect(migration.migrateLegacyState(createMigrationParams(stateDir))).resolves.toEqual({
       changes: [
@@ -559,10 +612,10 @@ describe("matrix doctor contract state migrations", () => {
     await expect(opsDeduper.claim({ roomId, eventId: "$committed" })).resolves.toEqual({
       kind: "duplicate",
     });
-    const expiredClaim = await opsDeduper.claim({ roomId, eventId: "$expired" });
-    expect(expiredClaim.kind).toBe("claimed");
-    if (expiredClaim.kind === "claimed") {
-      expiredClaim.handle.release();
+    const staleClaim = await opsDeduper.claim({ roomId, eventId: "$stale" });
+    expect(staleClaim.kind).toBe("claimed");
+    if (staleClaim.kind === "claimed") {
+      staleClaim.handle.release();
     }
     const homeDeduper = createMatrixInboundEventDeduper({
       auth: { accountId: "home" },
@@ -572,9 +625,41 @@ describe("matrix doctor contract state migrations", () => {
       kind: "duplicate",
     });
 
-    // Legacy sources are retired and the migration is idempotent.
-    await expect(legacyStore.entries()).resolves.toEqual([]);
-    await expect(legacyMarkersStore.entries()).resolves.toEqual([]);
+    // Only the two retired Matrix namespaces are deleted. The source remains
+    // schema v1, with unrelated Matrix and other-plugin state untouched.
+    const retiredDb = new DatabaseSync(legacyDatabasePath, { readOnly: true });
+    try {
+      expect(retiredDb.prepare("PRAGMA user_version").get()).toEqual({ user_version: 1 });
+      expect(
+        retiredDb
+          .prepare("SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name")
+          .all(),
+      ).toEqual([{ name: "plugin_state_entries" }]);
+      expect(
+        retiredDb
+          .prepare(
+            `SELECT plugin_id, namespace, entry_key, value_json
+             FROM plugin_state_entries
+             ORDER BY plugin_id ASC, namespace ASC, entry_key ASC`,
+          )
+          .all(),
+      ).toEqual([
+        {
+          plugin_id: "matrix",
+          namespace: "credentials",
+          entry_key: "keep-matrix",
+          value_json: '{"keep":true}',
+        },
+        {
+          plugin_id: "other-plugin",
+          namespace: "inbound-dedupe",
+          entry_key: "keep-other",
+          value_json: '{"keep":true}',
+        },
+      ]);
+    } finally {
+      retiredDb.close();
+    }
     expect(fs.existsSync(path.join(jsonRoot, "inbound-dedupe.json"))).toBe(false);
     expect(fs.existsSync(path.join(jsonRoot, "inbound-dedupe.json.migrated"))).toBe(true);
     await expect(migration.detectLegacyState(createMigrationParams(stateDir))).resolves.toBeNull();

--- a/extensions/matrix/doctor-contract-api.test.ts
+++ b/extensions/matrix/doctor-contract-api.test.ts
@@ -571,16 +571,8 @@ describe("matrix doctor contract state migrations", () => {
 
     const migration = migrationById("matrix-inbound-dedupe-to-claimable-dedupe");
     const detectParams = createMigrationParams(stateDir);
-    detectParams.context = {
-      openPluginStateKeyedStore() {
-        throw new Error("detection must not open the current plugin-state runtime");
-      },
-    };
     await expect(migration.detectLegacyState(detectParams)).resolves.toEqual({
-      preview: [
-        `Matrix inbound dedupe rows can migrate to the claimable dedupe store: ${sqliteRoot}`,
-        `Matrix inbound dedupe JSON can migrate to the claimable dedupe store: ${path.join(jsonRoot, "inbound-dedupe.json")}`,
-      ],
+      preview: ["Matrix inbound dedupe legacy sources need a one-time migration scan"],
     });
     const detectedDb = new DatabaseSync(legacyDatabasePath, { readOnly: true });
     try {
@@ -599,6 +591,7 @@ describe("matrix doctor contract state migrations", () => {
         "Migrated Matrix inbound dedupe markers to the claimable dedupe store (2 of 3 entries)",
         `Retired Matrix inbound dedupe rows for ${sqliteRoot}`,
         `Archived Matrix inbound dedupe legacy source -> ${path.join(jsonRoot, "inbound-dedupe.json")}.migrated`,
+        "Recorded Matrix inbound dedupe migration completion (1 SQLite roots, 1 JSON roots scanned)",
       ],
       warnings: [],
     });
@@ -665,6 +658,65 @@ describe("matrix doctor contract state migrations", () => {
     await expect(migration.detectLegacyState(createMigrationParams(stateDir))).resolves.toBeNull();
   });
 
+  it("records an empty legacy scan and then skips historical databases", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-matrix-doctor-"));
+    tempDirs.push(stateDir);
+    const migration = migrationById("matrix-inbound-dedupe-to-claimable-dedupe");
+    const params = createMigrationParams(stateDir);
+
+    await expect(migration.detectLegacyState(params)).resolves.toEqual({
+      preview: ["Matrix inbound dedupe legacy sources need a one-time migration scan"],
+    });
+    await expect(migration.migrateLegacyState(params)).resolves.toEqual({
+      changes: [
+        "Recorded Matrix inbound dedupe migration completion (0 SQLite roots, 0 JSON roots scanned)",
+      ],
+      warnings: [],
+    });
+    const lateDatabasePath = path.join(
+      stateDir,
+      "matrix",
+      "accounts",
+      "late",
+      "matrix.example.org__bot",
+      "token-a",
+      "state",
+      "openclaw.sqlite",
+    );
+    fs.mkdirSync(path.dirname(lateDatabasePath), { recursive: true });
+    fs.writeFileSync(lateDatabasePath, "the completed migration must not open this database");
+    await expect(migration.detectLegacyState(params)).resolves.toBeNull();
+    await expect(migration.migrateLegacyState(params)).resolves.toEqual({
+      changes: [],
+      warnings: [],
+    });
+  });
+
+  it("ignores an invalid legacy-scan completion receipt", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-matrix-doctor-"));
+    tempDirs.push(stateDir);
+    const params = createMigrationParams(stateDir);
+    const receiptStore = params.context.openPluginStateKeyedStore<{
+      version: number;
+      completedAt: number;
+    }>({
+      namespace: "inbound-dedupe-migration-state",
+      maxEntries: 4,
+      overflowPolicy: "reject-new",
+      env: params.env,
+    });
+    await receiptStore.register("sqlite-json-to-claimable-v1", {
+      version: 1,
+      completedAt: -1,
+    });
+
+    await expect(
+      migrationById("matrix-inbound-dedupe-to-claimable-dedupe").detectLegacyState(params),
+    ).resolves.toEqual({
+      preview: ["Matrix inbound dedupe legacy sources need a one-time migration scan"],
+    });
+  });
+
   it("archives malformed inbound dedupe JSON without importing it", async () => {
     const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-matrix-doctor-"));
     tempDirs.push(stateDir);
@@ -692,6 +744,9 @@ describe("matrix doctor contract state migrations", () => {
     });
     expect(fs.existsSync(jsonPath)).toBe(false);
     expect(fs.existsSync(`${jsonPath}.migrated`)).toBe(true);
+    await expect(migration.detectLegacyState(createMigrationParams(stateDir))).resolves.toEqual({
+      preview: ["Matrix inbound dedupe legacy sources need a one-time migration scan"],
+    });
   });
 
   it("keeps newer runtime dedupe rows when legacy imports hit capacity", async () => {

--- a/extensions/matrix/doctor-contract-api.test.ts
+++ b/extensions/matrix/doctor-contract-api.test.ts
@@ -6,12 +6,17 @@ import os from "node:os";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import {
+  createPersistentDedupeImportEntry,
+  type PersistentDedupeEntry,
+} from "openclaw/plugin-sdk/persistent-dedupe";
 import type {
   OpenKeyedStoreOptions,
   PluginStateKeyedStore,
 } from "openclaw/plugin-sdk/plugin-state-runtime";
 import {
   createPluginStateKeyedStoreForTests,
+  importPluginStateEntriesForDoctorForTests,
   resetPluginStateStoreForTests,
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import type { PluginDoctorStateMigrationContext } from "openclaw/plugin-sdk/runtime-doctor";
@@ -42,6 +47,9 @@ import { installMatrixTestRuntime } from "./src/test-runtime.js";
 
 function createContext(): PluginDoctorStateMigrationContext {
   return {
+    importPluginStateEntries(options, entries) {
+      importPluginStateEntriesForDoctorForTests("matrix", options, entries);
+    },
     openPluginStateKeyedStore: <T>(options: OpenKeyedStoreOptions): PluginStateKeyedStore<T> =>
       createPluginStateKeyedStoreForTests<T>("matrix", options),
   };
@@ -809,42 +817,88 @@ describe("matrix doctor contract state migrations", () => {
     });
   });
 
+  it("keeps inbound dedupe sources when retention-aware import is unavailable", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-matrix-doctor-"));
+    tempDirs.push(stateDir);
+    const jsonRoot = path.join(
+      stateDir,
+      "matrix",
+      "accounts",
+      "home",
+      "matrix.example.org__bot",
+      "token-a",
+    );
+    fs.mkdirSync(jsonRoot, { recursive: true });
+    const jsonPath = path.join(jsonRoot, "inbound-dedupe.json");
+    fs.writeFileSync(
+      jsonPath,
+      JSON.stringify({
+        version: 1,
+        entries: [{ key: "!room:example.org|$legacy", ts: Date.now() - 60_000 }],
+      }),
+    );
+    const params = createMigrationParams(stateDir);
+    delete params.context.importPluginStateEntries;
+    const migration = migrationById("matrix-inbound-dedupe-to-claimable-dedupe");
+
+    await expect(migration.migrateLegacyState(params)).resolves.toEqual({
+      changes: [],
+      warnings: [
+        "Failed importing Matrix inbound dedupe markers: Error: retention-aware Matrix inbound dedupe import is unavailable; left legacy sources in place",
+      ],
+    });
+    expect(fs.existsSync(jsonPath)).toBe(true);
+    expect(fs.existsSync(`${jsonPath}.migrated`)).toBe(false);
+    await expect(migration.detectLegacyState(params)).resolves.toEqual({
+      preview: ["Matrix inbound dedupe legacy sources need a one-time migration scan"],
+    });
+  });
+
   it("keeps newer runtime dedupe rows when legacy imports hit capacity", async () => {
     const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-matrix-doctor-"));
     tempDirs.push(stateDir);
     const io = { context: createContext(), env: { OPENCLAW_STATE_DIR: stateDir } };
     const roomId = "!room:example.org";
     const now = Date.now();
-    // Simulate the row the upgraded runtime already committed post-upgrade.
-    await expect(
-      importNewestInboundDedupeMarkers({
-        io,
-        now,
-        stateMaxEntries: 2,
-        markers: [{ accountId: "ops", roomId, eventId: "$runtime", ts: now - 1_000 }],
-      }),
-    ).resolves.toEqual({ imported: 1, total: 1 });
+    const store = createPluginStateKeyedStoreForTests<PersistentDedupeEntry>("matrix", {
+      namespace: resolveMatrixInboundDedupeStateNamespace(),
+      maxEntries: 3,
+      defaultTtlMs: MATRIX_INBOUND_DEDUPE_TTL_MS,
+      env: io.env,
+    });
+    const runtimeEntry = createPersistentDedupeImportEntry({
+      key: `ops\0${roomId}\0$runtime`,
+      seenAt: now,
+    });
+    await store.register(runtimeEntry.key, runtimeEntry.value);
 
-    // Only one slot remains: the newest legacy marker wins, the runtime row survives.
+    // Both legacy rows fit, but retain their source age below the runtime row.
     await expect(
       importNewestInboundDedupeMarkers({
         io,
         now,
-        stateMaxEntries: 2,
+        stateMaxEntries: 3,
         markers: [
           { accountId: "ops", roomId, eventId: "$old", ts: now - 60_000 },
           { accountId: "ops", roomId, eventId: "$newer", ts: now - 30_000 },
         ],
       }),
-    ).resolves.toEqual({ imported: 1, total: 2 });
+    ).resolves.toEqual({ imported: 2, total: 2 });
 
-    const store = createPluginStateKeyedStoreForTests<{ key: string }>("matrix", {
-      namespace: resolveMatrixInboundDedupeStateNamespace(),
-      maxEntries: 2,
-      defaultTtlMs: MATRIX_INBOUND_DEDUPE_TTL_MS,
-      env: io.env,
+    // The next runtime-equivalent insert evicts the oldest legacy row, not the
+    // newer legacy marker or the row committed after upgrade.
+    const nextRuntimeEntry = createPersistentDedupeImportEntry({
+      key: `ops\0${roomId}\0$next-runtime`,
+      seenAt: now + 1,
     });
+    await store.register(nextRuntimeEntry.key, nextRuntimeEntry.value);
     const keys = (await store.entries()).map((entry) => entry.value.key).toSorted();
-    expect(keys).toEqual([`ops\0${roomId}\0$runtime`, `ops\0${roomId}\0$newer`].toSorted());
+    expect(keys).toEqual(
+      [
+        `ops\0${roomId}\0$newer`,
+        `ops\0${roomId}\0$runtime`,
+        `ops\0${roomId}\0$next-runtime`,
+      ].toSorted(),
+    );
   });
 });

--- a/extensions/matrix/doctor-contract-api.ts
+++ b/extensions/matrix/doctor-contract-api.ts
@@ -322,6 +322,9 @@ export const stateMigrations: PluginDoctorStateMigration[] = [
         return { changes, warnings };
       }
       const sources = await collectMatrixInboundDedupeSources(params.stateDir);
+      if (sources.status === "incomplete") {
+        warnings.push(...sources.warnings);
+      }
 
       const recordCompletionIfClean = async (verifyRetirement = false) => {
         if (warnings.length > 0) {

--- a/extensions/matrix/doctor-contract-api.ts
+++ b/extensions/matrix/doctor-contract-api.ts
@@ -55,11 +55,14 @@ import {
 } from "./src/matrix/crypto-state-store.js";
 import {
   collectMatrixInboundDedupeSources,
+  hasCompletedMatrixInboundDedupeMigration,
   importNewestInboundDedupeMarkers,
   MATRIX_LEGACY_INBOUND_DEDUPE_FILENAME,
   readLegacyInboundDedupeJsonSource,
   readLegacyInboundDedupeSqliteSource,
+  recordMatrixInboundDedupeMigrationCompletion,
   retireLegacyInboundDedupeSqliteRows,
+  verifyMatrixInboundDedupeSourcesRetired,
   type LegacyInboundDedupeMarker,
   type MatrixInboundDedupeMigrationIo,
 } from "./src/matrix/monitor/inbound-dedupe-migration.js";
@@ -307,32 +310,40 @@ export const stateMigrations: PluginDoctorStateMigration[] = [
     id: "matrix-inbound-dedupe-to-claimable-dedupe",
     label: "Matrix inbound dedupe markers",
     async detectLegacyState(params) {
-      const preview: string[] = [];
-      const sources = await collectMatrixInboundDedupeSources(params.stateDir);
-      for (const storageRootDir of sources.sqliteRoots) {
-        try {
-          if ((await readLegacyInboundDedupeSqliteSource(storageRootDir)).legacyRowCount === 0) {
-            continue;
-          }
-        } catch {
-          continue;
-        }
-        preview.push(
-          `Matrix inbound dedupe rows can migrate to the claimable dedupe store: ${storageRootDir}`,
-        );
-      }
-      for (const storageRootDir of sources.jsonRoots) {
-        preview.push(
-          `Matrix inbound dedupe JSON can migrate to the claimable dedupe store: ${path.join(storageRootDir, MATRIX_LEGACY_INBOUND_DEDUPE_FILENAME)}`,
-        );
-      }
-      return preview.length > 0 ? { preview } : null;
+      return (await hasCompletedMatrixInboundDedupeMigration(params.context, params.env))
+        ? null
+        : { preview: ["Matrix inbound dedupe legacy sources need a one-time migration scan"] };
     },
     async migrateLegacyState(params) {
       const io: MatrixInboundDedupeMigrationIo = { context: params.context, env: params.env };
       const changes: string[] = [];
       const warnings: string[] = [];
+      if (await hasCompletedMatrixInboundDedupeMigration(params.context, params.env)) {
+        return { changes, warnings };
+      }
       const sources = await collectMatrixInboundDedupeSources(params.stateDir);
+
+      const recordCompletionIfClean = async (verifyRetirement = false) => {
+        if (warnings.length > 0) {
+          return;
+        }
+        if (verifyRetirement) {
+          warnings.push(...(await verifyMatrixInboundDedupeSourcesRetired(params.stateDir)));
+          if (warnings.length > 0) {
+            return;
+          }
+        }
+        try {
+          await recordMatrixInboundDedupeMigrationCompletion(params.context, params.env);
+          changes.push(
+            `Recorded Matrix inbound dedupe migration completion (${sources.sqliteRoots.length} SQLite roots, ${sources.jsonRoots.length} JSON roots scanned)`,
+          );
+        } catch (err) {
+          warnings.push(
+            `Failed recording Matrix inbound dedupe migration completion: ${String(err)}`,
+          );
+        }
+      };
 
       // Gather every marker first so the capacity-aware import keeps the
       // globally newest ones instead of whichever storage root imports last.
@@ -373,6 +384,7 @@ export const stateMigrations: PluginDoctorStateMigration[] = [
         }
       }
       if (sqliteRootsToRetire.length + jsonRootsToRetire.length === 0) {
+        await recordCompletionIfClean();
         return { changes, warnings };
       }
 
@@ -409,6 +421,7 @@ export const stateMigrations: PluginDoctorStateMigration[] = [
           warnings,
         });
       }
+      await recordCompletionIfClean(true);
       return { changes, warnings };
     },
   },

--- a/extensions/matrix/doctor-contract-api.ts
+++ b/extensions/matrix/doctor-contract-api.ts
@@ -307,14 +307,11 @@ export const stateMigrations: PluginDoctorStateMigration[] = [
     id: "matrix-inbound-dedupe-to-claimable-dedupe",
     label: "Matrix inbound dedupe markers",
     async detectLegacyState(params) {
-      const io: MatrixInboundDedupeMigrationIo = { context: params.context, env: params.env };
       const preview: string[] = [];
       const sources = await collectMatrixInboundDedupeSources(params.stateDir);
       for (const storageRootDir of sources.sqliteRoots) {
         try {
-          if (
-            (await readLegacyInboundDedupeSqliteSource(io, storageRootDir)).legacyRowCount === 0
-          ) {
+          if ((await readLegacyInboundDedupeSqliteSource(storageRootDir)).legacyRowCount === 0) {
             continue;
           }
         } catch {
@@ -343,7 +340,7 @@ export const stateMigrations: PluginDoctorStateMigration[] = [
       const sqliteRootsToRetire: string[] = [];
       for (const storageRootDir of sources.sqliteRoots) {
         try {
-          const source = await readLegacyInboundDedupeSqliteSource(io, storageRootDir);
+          const source = await readLegacyInboundDedupeSqliteSource(storageRootDir);
           if (source.legacyRowCount === 0) {
             continue;
           }
@@ -395,7 +392,7 @@ export const stateMigrations: PluginDoctorStateMigration[] = [
       // run keeps them for the next doctor attempt.
       for (const storageRootDir of sqliteRootsToRetire) {
         try {
-          await retireLegacyInboundDedupeSqliteRows(io, storageRootDir);
+          await retireLegacyInboundDedupeSqliteRows(storageRootDir);
           changes.push(`Retired Matrix inbound dedupe rows for ${storageRootDir}`);
         } catch (err) {
           warnings.push(

--- a/extensions/matrix/src/matrix/monitor/inbound-dedupe-migration.ts
+++ b/extensions/matrix/src/matrix/monitor/inbound-dedupe-migration.ts
@@ -54,6 +54,15 @@ export type LegacyInboundDedupeMarker = {
   ts: number;
 };
 
+type MatrixInboundDedupeSourceRoots = {
+  sqliteRoots: string[];
+  jsonRoots: string[];
+};
+
+export type MatrixInboundDedupeSourceCensus =
+  | ({ status: "complete" } & MatrixInboundDedupeSourceRoots)
+  | ({ status: "incomplete"; warnings: string[] } & MatrixInboundDedupeSourceRoots);
+
 type LegacySqliteRow = {
   namespace: string;
   entry_key: string;
@@ -109,18 +118,22 @@ function loadNodeSqlite(): typeof import("node:sqlite") {
   return req("node:sqlite") as typeof import("node:sqlite");
 }
 
-export async function collectMatrixInboundDedupeSources(stateDir: string): Promise<{
-  sqliteRoots: string[];
-  jsonRoots: string[];
-}> {
+export async function collectMatrixInboundDedupeSources(
+  stateDir: string,
+): Promise<MatrixInboundDedupeSourceCensus> {
   const matrixRoot = path.join(stateDir, "matrix");
   const sqliteRoots = new Set<string>();
   const jsonRoots = new Set<string>();
-  async function visit(dir: string): Promise<void> {
+  const warnings: string[] = [];
+  async function visit(dir: string, allowMissing = false): Promise<void> {
     let entries: Dirent[];
     try {
       entries = await fs.readdir(dir, { withFileTypes: true });
-    } catch {
+    } catch (err) {
+      if (allowMissing && (err as NodeJS.ErrnoException).code === "ENOENT") {
+        return;
+      }
+      warnings.push(`Failed scanning Matrix inbound dedupe sources under ${dir}: ${String(err)}`);
       return;
     }
     for (const entry of entries) {
@@ -139,13 +152,16 @@ export async function collectMatrixInboundDedupeSources(stateDir: string): Promi
       }
     }
   }
-  await visit(matrixRoot);
+  await visit(matrixRoot, true);
   const matrixRootResolved = path.resolve(matrixRoot);
   const isAccountRoot = (root: string) => path.resolve(root) !== matrixRootResolved;
-  return {
+  const roots = {
     sqliteRoots: [...sqliteRoots].filter(isAccountRoot).toSorted(),
     jsonRoots: [...jsonRoots].filter(isAccountRoot).toSorted(),
   };
+  return warnings.length === 0
+    ? { status: "complete", ...roots }
+    : { status: "incomplete", ...roots, warnings };
 }
 
 function selectLegacySqliteRows(db: DatabaseSync): LegacySqliteRow[] {
@@ -282,6 +298,9 @@ export async function retireLegacyInboundDedupeSqliteRows(storageRootDir: string
 export async function verifyMatrixInboundDedupeSourcesRetired(stateDir: string): Promise<string[]> {
   const warnings: string[] = [];
   const remaining = await collectMatrixInboundDedupeSources(stateDir);
+  if (remaining.status === "incomplete") {
+    warnings.push(...remaining.warnings);
+  }
   for (const storageRootDir of remaining.sqliteRoots) {
     try {
       if ((await readLegacyInboundDedupeSqliteSource(storageRootDir)).legacyRowCount > 0) {

--- a/extensions/matrix/src/matrix/monitor/inbound-dedupe-migration.ts
+++ b/extensions/matrix/src/matrix/monitor/inbound-dedupe-migration.ts
@@ -35,6 +35,8 @@ const LEGACY_SQLITE_NAMESPACE = "inbound-dedupe";
 const LEGACY_MARKERS_NAMESPACE = "inbound-dedupe-migrations";
 const LEGACY_JSON_VERSION = 1;
 const MATRIX_PLUGIN_ID = "matrix";
+const MIGRATION_COMPLETION_NAMESPACE = "inbound-dedupe-migration-state";
+const MIGRATION_COMPLETION_KEY = "sqlite-json-to-claimable-v1";
 const STATE_DATABASE_RELATIVE_PATH = path.join("state", "openclaw.sqlite");
 const STORAGE_META_FILENAME = "storage-meta.json";
 
@@ -58,6 +60,49 @@ type LegacySqliteRow = {
   value_json: string;
   expires_at: number | bigint | null;
 };
+
+type MatrixInboundDedupeMigrationCompletion = {
+  version: 1;
+  completedAt: number;
+};
+
+function openMatrixInboundDedupeMigrationCompletionStore(
+  context: PluginDoctorStateMigrationContext,
+  env: NodeJS.ProcessEnv,
+) {
+  return context.openPluginStateKeyedStore<MatrixInboundDedupeMigrationCompletion>({
+    namespace: MIGRATION_COMPLETION_NAMESPACE,
+    maxEntries: 4,
+    overflowPolicy: "reject-new",
+    env,
+  });
+}
+
+export async function hasCompletedMatrixInboundDedupeMigration(
+  context: PluginDoctorStateMigrationContext,
+  env: NodeJS.ProcessEnv,
+): Promise<boolean> {
+  const marker = await openMatrixInboundDedupeMigrationCompletionStore(context, env).lookup(
+    MIGRATION_COMPLETION_KEY,
+  );
+  return (
+    isRecord(marker) &&
+    marker.version === 1 &&
+    typeof marker.completedAt === "number" &&
+    Number.isFinite(marker.completedAt) &&
+    marker.completedAt >= 0
+  );
+}
+
+export async function recordMatrixInboundDedupeMigrationCompletion(
+  context: PluginDoctorStateMigrationContext,
+  env: NodeJS.ProcessEnv,
+): Promise<void> {
+  await openMatrixInboundDedupeMigrationCompletionStore(context, env).register(
+    MIGRATION_COMPLETION_KEY,
+    { version: 1, completedAt: Date.now() },
+  );
+}
 
 function loadNodeSqlite(): typeof import("node:sqlite") {
   const req = createRequire(import.meta.url);
@@ -232,6 +277,26 @@ export async function retireLegacyInboundDedupeSqliteRows(storageRootDir: string
   } finally {
     db.close();
   }
+}
+
+export async function verifyMatrixInboundDedupeSourcesRetired(stateDir: string): Promise<string[]> {
+  const warnings: string[] = [];
+  const remaining = await collectMatrixInboundDedupeSources(stateDir);
+  for (const storageRootDir of remaining.sqliteRoots) {
+    try {
+      if ((await readLegacyInboundDedupeSqliteSource(storageRootDir)).legacyRowCount > 0) {
+        warnings.push(`Matrix inbound dedupe rows remain after retirement for ${storageRootDir}`);
+      }
+    } catch (err) {
+      warnings.push(
+        `Failed verifying retired Matrix inbound dedupe rows for ${storageRootDir}: ${String(err)}`,
+      );
+    }
+  }
+  for (const storageRootDir of remaining.jsonRoots) {
+    warnings.push(`Matrix inbound dedupe JSON remains after retirement for ${storageRootDir}`);
+  }
+  return warnings;
 }
 
 async function resolveJsonRootAccountId(storageRootDir: string): Promise<string> {

--- a/extensions/matrix/src/matrix/monitor/inbound-dedupe-migration.ts
+++ b/extensions/matrix/src/matrix/monitor/inbound-dedupe-migration.ts
@@ -385,10 +385,10 @@ export async function readLegacyInboundDedupeJsonSource(
 
 /**
  * Imports the globally newest legacy markers into the claimable-dedupe store.
- * Never exceeds capacity: eviction is by row creation time, so letting fresh
- * imports overflow the namespace would evict the newer rows the runtime
- * committed since the upgrade. Throws on store errors so the caller keeps the
- * legacy sources for the next doctor attempt.
+ * Never exceeds capacity, never replaces a post-upgrade destination row, and
+ * preserves source timestamps because eviction is ordered by row creation
+ * time. Throws on import or verification errors so the caller keeps the legacy
+ * sources for the next doctor attempt.
  */
 export async function importNewestInboundDedupeMarkers(params: {
   io: MatrixInboundDedupeMigrationIo;
@@ -417,30 +417,45 @@ export async function importNewestInboundDedupeMarkers(params: {
     defaultTtlMs: MATRIX_INBOUND_DEDUPE_TTL_MS,
     env: params.io.env,
   });
-  let capacity = Math.max(0, stateMaxEntries - (await store.entries()).length);
-  let imported = 0;
-  for (const marker of markers) {
-    if (capacity <= 0) {
-      break;
-    }
+  const existingEntries = await store.entries();
+  const existingKeys = new Set(existingEntries.map((entry) => entry.key));
+  const missingEntries = markers.flatMap((marker) => {
     const remainingTtlMs = MATRIX_INBOUND_DEDUPE_TTL_MS - (now - marker.ts);
     if (remainingTtlMs <= 0) {
-      continue;
+      return [];
     }
     const entry = createPersistentDedupeImportEntry({
       key: marker.key,
       seenAt: marker.ts,
       ttlMs: Math.max(1, Math.floor(remainingTtlMs)),
     });
-    // Rows committed after the upgrade are newer than any legacy marker, so
-    // registerIfAbsent keeps them and only fills the missing keys.
-    const registered = await store.registerIfAbsent(entry.key, entry.value, {
-      ttlMs: entry.ttlMs ?? MATRIX_INBOUND_DEDUPE_TTL_MS,
-    });
-    if (registered) {
-      imported += 1;
-      capacity -= 1;
+    return existingKeys.has(entry.key) ? [] : [{ marker, entry }];
+  });
+  const capacity = Math.max(0, stateMaxEntries - existingEntries.length);
+  const selectedEntries = missingEntries.slice(0, capacity);
+  if (selectedEntries.length > 0) {
+    const importEntries = params.io.context.importPluginStateEntries;
+    if (!importEntries) {
+      throw new Error("retention-aware Matrix inbound dedupe import is unavailable");
+    }
+    importEntries(
+      {
+        namespace: resolveMatrixInboundDedupeStateNamespace(),
+        maxEntries: stateMaxEntries,
+        defaultTtlMs: MATRIX_INBOUND_DEDUPE_TTL_MS,
+        env: params.io.env,
+      },
+      selectedEntries.map(({ marker, entry }) => ({
+        key: entry.key,
+        value: entry.value,
+        createdAt: marker.ts,
+      })),
+    );
+    const importedKeys = new Set((await store.entries()).map((entry) => entry.key));
+    const missingKey = selectedEntries.find(({ entry }) => !importedKeys.has(entry.key))?.entry.key;
+    if (missingKey) {
+      throw new Error(`retention-aware Matrix inbound dedupe import did not persist ${missingKey}`);
     }
   }
-  return { imported, total: markers.length };
+  return { imported: selectedEntries.length, total: markers.length };
 }

--- a/extensions/matrix/src/matrix/monitor/inbound-dedupe-migration.ts
+++ b/extensions/matrix/src/matrix/monitor/inbound-dedupe-migration.ts
@@ -59,7 +59,7 @@ type MatrixInboundDedupeSourceRoots = {
   jsonRoots: string[];
 };
 
-export type MatrixInboundDedupeSourceCensus =
+type MatrixInboundDedupeSourceCensus =
   | ({ status: "complete" } & MatrixInboundDedupeSourceRoots)
   | ({ status: "incomplete"; warnings: string[] } & MatrixInboundDedupeSourceRoots);
 

--- a/extensions/matrix/src/matrix/monitor/inbound-dedupe-migration.ts
+++ b/extensions/matrix/src/matrix/monitor/inbound-dedupe-migration.ts
@@ -449,6 +449,7 @@ export async function importNewestInboundDedupeMarkers(params: {
         key: entry.key,
         value: entry.value,
         createdAt: marker.ts,
+        ...(entry.ttlMs != null ? { ttlMs: entry.ttlMs } : {}),
       })),
     );
     const importedKeys = new Set((await store.entries()).map((entry) => entry.key));

--- a/extensions/matrix/src/matrix/monitor/inbound-dedupe-migration.ts
+++ b/extensions/matrix/src/matrix/monitor/inbound-dedupe-migration.ts
@@ -13,12 +13,15 @@
 import { createHash } from "node:crypto";
 import type { Dirent } from "node:fs";
 import fs from "node:fs/promises";
+import { createRequire } from "node:module";
 import path from "node:path";
+import type { DatabaseSync } from "node:sqlite";
 import {
   createPersistentDedupeImportEntry,
   type PersistentDedupeEntry,
 } from "openclaw/plugin-sdk/persistent-dedupe";
 import type { PluginDoctorStateMigrationContext } from "openclaw/plugin-sdk/runtime-doctor";
+import { runSqliteImmediateTransactionSync } from "openclaw/plugin-sdk/sqlite-runtime";
 import { isRecord } from "../../record-shared.js";
 import { normalizeMatrixStorageMetadata } from "../client/storage.js";
 import {
@@ -29,10 +32,10 @@ import {
 } from "./inbound-dedupe.js";
 
 const LEGACY_SQLITE_NAMESPACE = "inbound-dedupe";
-const LEGACY_SQLITE_MAX_ENTRIES = 20_000;
 const LEGACY_MARKERS_NAMESPACE = "inbound-dedupe-migrations";
-const LEGACY_MARKERS_MAX_ENTRIES = 1_000;
 const LEGACY_JSON_VERSION = 1;
+const MATRIX_PLUGIN_ID = "matrix";
+const STATE_DATABASE_RELATIVE_PATH = path.join("state", "openclaw.sqlite");
 const STORAGE_META_FILENAME = "storage-meta.json";
 
 export const MATRIX_LEGACY_INBOUND_DEDUPE_FILENAME = "inbound-dedupe.json";
@@ -48,6 +51,18 @@ export type LegacyInboundDedupeMarker = {
   eventId: string;
   ts: number;
 };
+
+type LegacySqliteRow = {
+  namespace: string;
+  entry_key: string;
+  value_json: string;
+  expires_at: number | bigint | null;
+};
+
+function loadNodeSqlite(): typeof import("node:sqlite") {
+  const req = createRequire(import.meta.url);
+  return req("node:sqlite") as typeof import("node:sqlite");
+}
 
 export async function collectMatrixInboundDedupeSources(stateDir: string): Promise<{
   sqliteRoots: string[];
@@ -88,20 +103,32 @@ export async function collectMatrixInboundDedupeSources(stateDir: string): Promi
   };
 }
 
-function openLegacySqliteStore(io: MatrixInboundDedupeMigrationIo, storageRootDir: string) {
-  return io.context.openPluginStateKeyedStore<unknown>({
-    namespace: LEGACY_SQLITE_NAMESPACE,
-    maxEntries: LEGACY_SQLITE_MAX_ENTRIES,
-    env: { ...io.env, OPENCLAW_STATE_DIR: storageRootDir },
-  });
+function selectLegacySqliteRows(db: DatabaseSync): LegacySqliteRow[] {
+  const table = db
+    .prepare(
+      `SELECT 1 AS present
+       FROM sqlite_master
+       WHERE type = 'table' AND name = 'plugin_state_entries'`,
+    )
+    .get();
+  if (!table) {
+    return [];
+  }
+  return db
+    .prepare(
+      `SELECT namespace, entry_key, value_json, expires_at
+       FROM plugin_state_entries
+       WHERE plugin_id = ? AND namespace IN (?, ?)
+       ORDER BY namespace ASC, created_at ASC, entry_key ASC`,
+    )
+    .all(MATRIX_PLUGIN_ID, LEGACY_SQLITE_NAMESPACE, LEGACY_MARKERS_NAMESPACE) as LegacySqliteRow[];
 }
 
-function openLegacyMarkersStore(io: MatrixInboundDedupeMigrationIo, storageRootDir: string) {
-  return io.context.openPluginStateKeyedStore<unknown>({
-    namespace: LEGACY_MARKERS_NAMESPACE,
-    maxEntries: LEGACY_MARKERS_MAX_ENTRIES,
-    env: { ...io.env, OPENCLAW_STATE_DIR: storageRootDir },
-  });
+function isLegacySqliteRowExpired(row: LegacySqliteRow, now: number): boolean {
+  if (typeof row.expires_at === "bigint") {
+    return row.expires_at <= BigInt(now);
+  }
+  return row.expires_at !== null && row.expires_at <= now;
 }
 
 function normalizeLegacyTimestamp(raw: unknown): number | null {
@@ -140,30 +167,71 @@ function parseLegacySqliteRow(row: {
   return { accountId, roomId, eventId, ts };
 }
 
-/** Reads one storage root's legacy SQLite dedupe rows; throws on store errors. */
+/**
+ * Reads one storage root's legacy SQLite dedupe rows without opening it through
+ * the current state runtime. Historical per-account databases can predate the
+ * current core schema, and detection must not upgrade them merely to inspect
+ * these retired plugin-state namespaces.
+ */
 export async function readLegacyInboundDedupeSqliteSource(
-  io: MatrixInboundDedupeMigrationIo,
   storageRootDir: string,
 ): Promise<{ markers: LegacyInboundDedupeMarker[]; legacyRowCount: number }> {
-  const rows = await openLegacySqliteStore(io, storageRootDir).entries();
-  const markerRows = await openLegacyMarkersStore(io, storageRootDir).entries();
-  const markers: LegacyInboundDedupeMarker[] = [];
-  for (const row of rows) {
-    const marker = parseLegacySqliteRow(row);
-    if (marker) {
-      markers.push(marker);
+  const { DatabaseSync: SqliteDatabase } = loadNodeSqlite();
+  const databasePath = path.join(storageRootDir, STATE_DATABASE_RELATIVE_PATH);
+  const db = new SqliteDatabase(databasePath, { readOnly: true });
+  try {
+    const rows = selectLegacySqliteRows(db);
+    const markers: LegacyInboundDedupeMarker[] = [];
+    const now = Date.now();
+    for (const row of rows) {
+      // The keyed-store reader filtered expired rows before decoding them. We
+      // still count that residue so doctor can retire it, but it has no replay
+      // value and malformed expired JSON must not block the whole root.
+      if (isLegacySqliteRowExpired(row, now)) {
+        continue;
+      }
+      // The keyed-store reader parsed every value, including import-marker
+      // values. Keep that fail-closed behavior so corrupt sources are not
+      // retired unread.
+      const value = JSON.parse(row.value_json) as unknown;
+      if (row.namespace !== LEGACY_SQLITE_NAMESPACE) {
+        continue;
+      }
+      const marker = parseLegacySqliteRow({ key: row.entry_key, value });
+      if (marker) {
+        markers.push(marker);
+      }
     }
+    return { markers, legacyRowCount: rows.length };
+  } finally {
+    db.close();
   }
-  return { markers, legacyRowCount: rows.length + markerRows.length };
 }
 
-/** Clears one storage root's retired legacy dedupe namespaces after import. */
-export async function retireLegacyInboundDedupeSqliteRows(
-  io: MatrixInboundDedupeMigrationIo,
-  storageRootDir: string,
-): Promise<void> {
-  await openLegacySqliteStore(io, storageRootDir).clear();
-  await openLegacyMarkersStore(io, storageRootDir).clear();
+/** Deletes only the two retired Matrix namespaces after a successful import. */
+export async function retireLegacyInboundDedupeSqliteRows(storageRootDir: string): Promise<void> {
+  const { DatabaseSync: SqliteDatabase } = loadNodeSqlite();
+  const databasePath = path.join(storageRootDir, STATE_DATABASE_RELATIVE_PATH);
+  const db = new SqliteDatabase(databasePath);
+  try {
+    // Plan outside the write transaction, then re-read after BEGIN IMMEDIATE
+    // before deleting. The predicates intentionally cannot touch other Matrix
+    // namespaces or another plugin's rows.
+    if (selectLegacySqliteRows(db).length === 0) {
+      return;
+    }
+    runSqliteImmediateTransactionSync(db, () => {
+      if (selectLegacySqliteRows(db).length === 0) {
+        return;
+      }
+      db.prepare(
+        `DELETE FROM plugin_state_entries
+         WHERE plugin_id = ? AND namespace IN (?, ?)`,
+      ).run(MATRIX_PLUGIN_ID, LEGACY_SQLITE_NAMESPACE, LEGACY_MARKERS_NAMESPACE);
+    });
+  } finally {
+    db.close();
+  }
 }
 
 async function resolveJsonRootAccountId(storageRootDir: string): Promise<string> {

--- a/src/infra/state-migrations.doctor.ts
+++ b/src/infra/state-migrations.doctor.ts
@@ -265,7 +265,7 @@ function createPluginDoctorStateMigrationContext(
     },
     importPluginStateEntries(
       options: OpenKeyedStoreOptions,
-      entries: readonly { key: string; value: unknown; createdAt: number }[],
+      entries: readonly { key: string; value: unknown; createdAt: number; ttlMs?: number }[],
     ) {
       importPluginStateEntriesForDoctor(pluginId, { ...options, env: options.env ?? env }, entries);
     },

--- a/src/plugin-state/plugin-state-store.ts
+++ b/src/plugin-state/plugin-state-store.ts
@@ -69,6 +69,7 @@ type PluginStateImportEntry = {
   key: string;
   value: unknown;
   createdAt: number;
+  ttlMs?: number;
 };
 
 const namespaceOptionSignatures = new Map<string, StoreOptionSignature>();
@@ -555,7 +556,7 @@ export function registerPluginStateSyncSequencedJournalEntry(params: {
   });
 }
 
-/** Doctor-only import that preserves source age for retention ordering. */
+/** Doctor-only import that preserves source age and remaining retention. */
 export function importPluginStateEntriesForDoctor(
   pluginId: string,
   options: OpenKeyedStoreOptions,
@@ -575,7 +576,12 @@ export function importPluginStateEntriesForDoctor(
     if (!Number.isSafeInteger(entry.createdAt)) {
       throw invalidInput("plugin state import createdAt must be a safe integer", "register");
     }
-    const prepared = prepareRegisterParams(entry.key, entry.value, defaultTtlMs);
+    const prepared = prepareRegisterParams(
+      entry.key,
+      entry.value,
+      defaultTtlMs,
+      entry.ttlMs != null ? { ttlMs: entry.ttlMs } : undefined,
+    );
     pluginStateRegister({
       pluginId,
       namespace,

--- a/src/plugins/doctor-contract-registry.ts
+++ b/src/plugins/doctor-contract-registry.ts
@@ -59,10 +59,10 @@ export type PluginDoctorStateMigrationDetection = {
 
 export type PluginDoctorStateMigrationContext = {
   openPluginStateKeyedStore: <T>(options: OpenKeyedStoreOptions) => PluginStateKeyedStore<T>;
-  /** Doctor-only batch import preserving source age for retention ordering. */
+  /** Doctor-only batch import preserving source age and remaining retention. */
   importPluginStateEntries?: (
     options: OpenKeyedStoreOptions,
-    entries: readonly { key: string; value: unknown; createdAt: number }[],
+    entries: readonly { key: string; value: unknown; createdAt: number; ttlMs?: number }[],
   ) => void;
   /** Plugin-wide live-row capacity for import preflight. Older test hosts may omit it. */
   getPluginStateCapacity?: () => { liveEntries: number; maxEntries: number };


### PR DESCRIPTION
Closes #112450

## What Problem This Solves

Fixes an issue where Matrix users upgrading with historical token-root databases would wait through a full integrity check for every schema-v1 root, while the intended inbound-dedupe migration silently skipped the legacy rows in those databases.

## Why This Change Was Made

The Matrix doctor migration now reads only its two retired namespaces directly from each historical `plugin_state_entries` table through a read-only SQLite connection, without opening or upgrading the database through the current shared-state runtime. After the claimable-dedupe import succeeds, retirement runs in an immediate transaction and deletes only `matrix/inbound-dedupe` and `matrix/inbound-dedupe-migrations`; other namespaces, plugins, tables, and the historical schema version are preserved.

After a clean migration (or a clean validation-only recovery pass), it records a small, versioned, non-expiring completion receipt in the current Matrix store. Later process starts validate that receipt and skip the historical-root census in O(1). A warning, unreadable source, failed import, failed retirement, malformed receipt, or failed final validation cannot produce a completion receipt.

## User Impact

Upgrades with accumulated Matrix token history can import the replay-protection markers that those roots actually contain without schema-migrating every historical database. This removes the integrity-check storm from this doctor path and avoids replaying already-handled events whose valid markers were previously left behind.

## Evidence

All installation evidence below is redacted; no account, user, server, room, event, token, device, token-hash, or local-path identifiers are included.

### Observed before the fix

- Six current Matrix account roots and 1,351 historical schema-v1 roots were present.
- The normal doctor detector emitted 1,351 `state database schema migration pending; verifying integrity first` lines.
- A bounded read-only census found 11,306 retired inbound-dedupe rows across seven schema-v1 roots; the current runtime-backed detector did not discover them.
- The no-checkpoint boot needed approximately 82.2 seconds to reach gateway readiness, versus approximately 16.3 seconds for the subsequent checkpointed boot.

### Observed after the fix

- The corrected migration imported 10,330 of 10,401 eligible/current dedupe markers. A concurrent second runner imported zero additional markers, demonstrating idempotence.
- It retired all 11,306 targeted rows: 11,300 `matrix/inbound-dedupe` rows and six `matrix/inbound-dedupe-migrations` rows.
- The database census remained exactly 1,357 roots. Schema versions remained exactly 1,351 v1 and six v4; the migration did not upgrade a historical database.
- Total per-root plugin-state rows changed from 29,728 to 18,422. All 18,422 unrelated rows were preserved.
- All 1,357 databases returned `PRAGMA quick_check = ok`; zero databases were corrupt or unreadable.
- The one-time clean completion pass scanned all 1,357 roots in 16.50 seconds and wrote a valid receipt. Subsequent migration detection resolves from that receipt without reopening historical roots.
- On the corrected installed artifact, the next gateway boot produced zero schema-migration warnings, Matrix membership errors, trust errors, SQLite lock errors, or other errors. It reached HTTP listening in approximately 8.5 seconds and reported ready.

### Regression proof

- Exact head `f86167fd0e0c1e5b730d4b092e5fc369226c548e`: `node scripts/run-vitest.mjs extensions/matrix/doctor-contract-api.test.ts` — 16/16 tests passed.
- The schema-v1 fixtures prove detection does not call the current plugin-state runtime, `PRAGMA user_version` remains `1`, table inventory is unchanged, valid live markers import, expired/corrupt residue does not block cleanup, only the two retired Matrix namespaces are deleted, unrelated Matrix and other-plugin rows survive, and reruns are idempotent.
- Receipt coverage proves a valid completion receipt short-circuits without opening a late or corrupt historical database; malformed/wrong-version receipts are ignored; warning paths do not record completion; and a clean-but-unreceipted recovery pass validates before recording completion.
- Exact-head local `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 pnpm check:changed` passed every changed-file lane, including production/test TypeScript, type-aware lint, database-first guard, and dependency-cycle checks.
- Exact-head focused Oxlint and oxfmt checks passed; `git diff --check origin/main...HEAD` is clean.
- Fresh independent review found no remaining correctness, security, transaction, or data-retention issue after the expired-row decoding edge case was fixed.

### Exact-head historical-runtime proof

- The checksum-verified historical `2026.7.1-beta.1022643` plugin-state runtime created a real schema-v1 WAL fixture; the source was not assembled with handwritten SQL.
- Exact head `f86167fd0e0c1e5b730d4b092e5fc369226c548e` imported two markers, including a near-expiry marker, while retaining original creation and expiry times to within the 2 ms execution interval.
- The historical source remained schema v1 with an identical schema digest. Only the two retired Matrix namespaces were removed; unrelated Matrix and other-plugin rows remained.
- A successful second Doctor pass produced no migration output and left every inspected field/invariant unchanged.
- The fully redacted transcript and isolation checks are in [this PR comment](https://github.com/openclaw/openclaw/pull/112575#issuecomment-5053432247).

## AI Assistance

AI-assisted: yes, with Codex. The implementation, schema-v1 fixture, direct SQLite invariants, focused tests, changed-file gates, and redaction were reviewed directly.
