### PR TITLE
fix(mcp): coerce string numeric tool args to numbers per inputSchema (#107648)

### DIFF
--- a/src/agents/agent-bundle-mcp-materialize.ts
+++ b/src/agents/agent-bundle-mcp-materialize.ts
@@ -7,6 +7,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { logWarn } from "../logger.js";
 import { getPluginToolMeta, setPluginToolMeta, type PluginToolMcpMeta } from "../plugins/tools.js";
 import { matchesMcpToolFilterPattern } from "./agent-bundle-mcp-filter.js";
+import { coerceMcpToolInputToSchema } from "./mcp-tool-input-coercion.js";
 import {
   buildSafeToolName,
   normalizeReservedToolNames,
@@ -428,7 +429,10 @@ export async function materializeBundleMcpToolsForRun(params: {
     reservedToolNames,
     createExecute: (tool) => async (toolCallId: string, input: unknown) => {
       params.runtime.markUsed();
-      const result = await params.runtime.callTool(tool.serverName, tool.toolName, input);
+      // Rescue model backends that emit numeric args as strings (#107648): coerce
+      // string -> number only where this tool's inputSchema says number/integer.
+      const coercedInput = coerceMcpToolInputToSchema(input, tool.inputSchema);
+      const result = await params.runtime.callTool(tool.serverName, tool.toolName, coercedInput);
       const agentResult = toAgentToolResult({
         serverName: tool.serverName,
         toolName: tool.toolName,
@@ -446,7 +450,7 @@ export async function materializeBundleMcpToolsForRun(params: {
           toolName: tool.toolName,
           uiResourceUri: tool.uiResourceUri,
           toolCallId,
-          toolInput: input,
+          toolInput: coercedInput,
           toolResult: result,
           ...(allowedAppToolNames ? { allowedAppToolNames } : {}),
         });

--- a/src/agents/mcp-tool-input-coercion.test.ts
+++ b/src/agents/mcp-tool-input-coercion.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { coerceMcpToolInputToSchema } from "./mcp-tool-input-coercion.js";
+
+const notionish = {
+  type: "object",
+  properties: {
+    count: { type: "integer" },
+    price: { type: "number" },
+    title: { type: "string" },
+  },
+} as const;
+
+describe("coerceMcpToolInputToSchema (#107648)", () => {
+  it("coerces a string integer where the schema says integer", () => {
+    expect(coerceMcpToolInputToSchema({ count: "10" }, notionish)).toEqual({ count: 10 });
+  });
+
+  it("coerces a string decimal where the schema says number", () => {
+    expect(coerceMcpToolInputToSchema({ price: "10.5" }, notionish)).toEqual({ price: 10.5 });
+  });
+
+  it("coerces negative and zero", () => {
+    expect(coerceMcpToolInputToSchema({ count: "-3" }, notionish)).toEqual({ count: -3 });
+    expect(coerceMcpToolInputToSchema({ count: "0" }, notionish)).toEqual({ count: 0 });
+  });
+
+  it("is a no-op for already-numeric values", () => {
+    expect(coerceMcpToolInputToSchema({ count: 10, price: 2.5 }, notionish)).toEqual({
+      count: 10,
+      price: 2.5,
+    });
+  });
+
+  it("never coerces a string field", () => {
+    expect(coerceMcpToolInputToSchema({ title: "42" }, notionish)).toEqual({ title: "42" });
+  });
+
+  it("leaves non-numeric-looking strings untouched", () => {
+    for (const bad of ["0x10", "1,000", "1e3", "10abc", " 1 2 ", "", "  ", "NaN"]) {
+      expect(coerceMcpToolInputToSchema({ count: bad }, notionish)).toEqual({ count: bad });
+    }
+  });
+
+  it("does not coerce a non-integer string for an integer field", () => {
+    expect(coerceMcpToolInputToSchema({ count: "10.5" }, notionish)).toEqual({ count: "10.5" });
+  });
+
+  it("recurses into nested objects", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        page: { type: "object", properties: { size: { type: "integer" } } },
+      },
+    };
+    expect(coerceMcpToolInputToSchema({ page: { size: "25" } }, schema)).toEqual({
+      page: { size: 25 },
+    });
+  });
+
+  it("recurses into arrays of numbers", () => {
+    const schema = { type: "object", properties: { rows: { type: "array", items: { type: "number" } } } };
+    expect(coerceMcpToolInputToSchema({ rows: ["1", "2.5", "x"] }, schema)).toEqual({
+      rows: [1, 2.5, "x"],
+    });
+  });
+
+  it("leaves fields absent from the schema untouched", () => {
+    expect(coerceMcpToolInputToSchema({ extra: "10" }, notionish)).toEqual({ extra: "10" });
+  });
+
+  it("tolerates missing/!object schema and non-object input", () => {
+    expect(coerceMcpToolInputToSchema({ count: "10" }, undefined)).toEqual({ count: "10" });
+    expect(coerceMcpToolInputToSchema("10", { type: "string" })).toEqual("10");
+    expect(coerceMcpToolInputToSchema(null, notionish)).toEqual(null);
+  });
+});

--- a/src/agents/mcp-tool-input-coercion.ts
+++ b/src/agents/mcp-tool-input-coercion.ts
@@ -1,0 +1,87 @@
+/**
+ * Some model backends emit numeric MCP tool arguments as JSON strings (e.g. the
+ * literal "10" instead of 10) even when the tool's own inputSchema types the
+ * field as `number`/`integer`. OpenClaw forwards model-supplied arguments to the
+ * MCP server verbatim, so the string reaches the wire and strict servers reject
+ * the call -- Notion's data source API, for one, answers "Number values must be
+ * JavaScript numbers" (#107648).
+ *
+ * `coerceMcpToolInputToSchema` narrows that gap conservatively: it converts a
+ * string argument to a number ONLY when the tool's inputSchema declares the field
+ * `number`/`integer` and the string is a faithful, finite representation of that
+ * number (round-tripping through `String(...)`, and an exact integer where the
+ * schema says `integer`). It never throws, never touches a non-numeric schema
+ * type, and leaves already-correct arguments untouched -- so well-typed calls are
+ * unaffected and only the exact reported failure mode is rescued.
+ */
+
+interface JsonSchemaLike {
+  type?: unknown;
+  properties?: unknown;
+  items?: unknown;
+}
+
+function schemaTypeIncludes(type: unknown, wanted: string): boolean {
+  if (type === wanted) return true;
+  if (Array.isArray(type)) return type.includes(wanted);
+  return false;
+}
+
+function coerceNumericString(value: string, integer: boolean): number | undefined {
+  const trimmed = value.trim();
+  if (trimmed === "") return undefined;
+  const n = Number(trimmed);
+  if (!Number.isFinite(n)) return undefined;
+  if (integer && !Number.isInteger(n)) return undefined;
+  // Only coerce when the string is a faithful representation of the parsed
+  // number, so values like "0x10", "1,000", "1e3", "10abc", or " 1 2 " are left
+  // as-is rather than silently rewritten.
+  if (String(n) !== trimmed) return undefined;
+  return n;
+}
+
+function coerceValue(value: unknown, schema: unknown): unknown {
+  if (!schema || typeof schema !== "object") return value;
+  const s = schema as JsonSchemaLike;
+
+  if (typeof value === "string") {
+    if (schemaTypeIncludes(s.type, "integer")) {
+      const n = coerceNumericString(value, true);
+      return n ?? value;
+    }
+    if (schemaTypeIncludes(s.type, "number")) {
+      const n = coerceNumericString(value, false);
+      return n ?? value;
+    }
+    return value;
+  }
+
+  if (Array.isArray(value) && s.items && typeof s.items === "object") {
+    return value.map((item) => coerceValue(item, s.items));
+  }
+
+  if (
+    value &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    s.properties &&
+    typeof s.properties === "object"
+  ) {
+    const props = s.properties as Record<string, unknown>;
+    const out: Record<string, unknown> = { ...(value as Record<string, unknown>) };
+    for (const [key, propSchema] of Object.entries(props)) {
+      if (key in out) out[key] = coerceValue(out[key], propSchema);
+    }
+    return out;
+  }
+
+  return value;
+}
+
+export function coerceMcpToolInputToSchema(input: unknown, inputSchema: unknown): unknown {
+  try {
+    return coerceValue(input, inputSchema);
+  } catch {
+    return input;
+  }
+}


### PR DESCRIPTION
## What Problem This Solves

When a model backend emits a numeric MCP tool argument as a JSON **string** (e.g. the literal `"10"` instead of `10`) — even though the tool's own `inputSchema` types the field as `number`/`integer` — OpenClaw forwards it to the MCP server **verbatim**, so the string reaches the wire. Strict servers then reject the call. Notion's data source API is the reported case: `Number values must be JavaScript numbers`.

Closes #107648.

## Why This Change Was Made

The MCP tool dispatch seam (`src/agents/agent-bundle-mcp-materialize.ts`, the `createExecute` closure) passes the model-supplied `input` straight into `runtime.callTool(serverName, toolName, input)` — there is no coercion between the model and the server. Different backends serialize numeric arguments differently; the ones that emit string-numbers are the ones that trip strict servers.

This adds a single, **ultra-conservative** coercion at that seam. `coerceMcpToolInputToSchema(input, tool.inputSchema)` converts a string argument to a number **only** when *all* of these hold:

- the tool's own `inputSchema` declares that field `number` or `integer`, and
- the string is a **faithful, finite** representation of the number — it round-trips through `String(...)` (so `"0x10"`, `"1,000"`, `"1e3"`, `"10abc"`, `" 1 2 "`, `""` are left untouched), and
- for an `integer` field, the value is an exact integer (`"10.5"` stays a string).

It recurses through nested objects and array `items`, never throws (any error → original input), and is a **no-op** for already-numeric values and every non-numeric schema type. Well-typed calls — including everything a strict-schema backend already sends — are byte-for-byte unaffected.

## User Impact

MCP tools that take numeric parameters (Notion number properties, pagination `page_size`, etc.) work across model backends that emit string-numbers, instead of failing with a server-side type error. Backends that already send proper numbers are unchanged.

## Evidence

- New unit suite `src/agents/mcp-tool-input-coercion.test.ts` — **11 tests** (× 2 project configs = 22) covering: string→int/number coercion, negatives/zero, no-op on real numbers, never coercing `string`-typed fields, rejecting non-numeric-looking strings, integer-field decimals staying strings, nested-object + array recursion, unknown fields untouched, and null/undefined-schema tolerance.
- Regression: `agent-bundle-mcp-tools.materialize.test.ts` + `agent-bundle-mcp-runtime.test.ts` — **165 tests pass** unchanged.

**Note for maintainers:** the fix is deliberately narrow — it rescues the exact reported failure mode (schema-typed numeric field, faithfully-numeric string) without rewriting anything ambiguous, so it can't silently change a correct call. If you'd rather gate it behind a config flag or apply it only for specific transports, I'm glad to adjust — hence draft. I could not reproduce against a live Notion workspace, so the server-side half is reasoned from the reported error text, not observed here.
