### PR TITLE
fix(release): stabilize 2026.6.34 marketplace validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ Docs: https://docs.openclaw.ai
 
 ### Complete contribution record
 
-This audited record covers the complete v2026.6.33..496c84bf6159bd09ce2c2a261c354ea641757b19 history: 24 merged PRs. The generation manifest also supplies direct commits as editorial input; the grouped notes above prioritize user impact.
+This audited record covers the complete v2026.6.33..496c84bf6159bd09ce2c2a261c354ea641757b19 history plus release-validation backports: 25 merged PRs. The generation manifest also supplies direct commits as editorial input; the grouped notes above prioritize user impact.
 
 #### Pull requests
 
@@ -56,6 +56,7 @@ This audited record covers the complete v2026.6.33..496c84bf6159bd09ce2c2a261c35
 - **PR #103793** Thanks @yetval.
 - **PR #94016** Related #94008. Thanks @sheyanmin and @thomasthelen-kibeauftragter.
 - **PR #112406** Thanks @vincentkoc.
+- **PR #107938** Thanks @steipete.
 ## 2026.6.33
 
 ### Highlights

--- a/src/plugins/marketplace.test.ts
+++ b/src/plugins/marketplace.test.ts
@@ -751,7 +751,7 @@ describe("marketplace plugins", () => {
     });
   });
 
-  it("returns a structured error for invalid archive URLs", async () => {
+  it("redacts invalid archive URLs in structured errors", async () => {
     await withTempDir("openclaw-marketplace-test-", async (rootDir) => {
       const manifestPath = await writeMarketplaceManifest(rootDir, {
         plugins: [
@@ -769,7 +769,7 @@ describe("marketplace plugins", () => {
 
       expect(result).toEqual({
         ok: false,
-        error: "failed to download https://%/frontend-design.tgz: Invalid URL",
+        error: "failed to download ***: Invalid URL",
       });
       expect(installPluginFromPathMock).not.toHaveBeenCalled();
       expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the 2026.6.34 release validation fails on a malformed marketplace archive URL because GitHub Actions redacts the URL in command output while the release-branch test still expects the literal URL.

## Why This Change Was Made

Backports the focused assertion fix from #107938 and records that source PR in the unreleased 2026.6.34 contribution ledger. The production error already redacts the URL; only the stale test expectation changes.

## User Impact

No runtime behavior changes. Release operators can validate the 2026.6.34 candidate without this false-negative test failure.

## Evidence

- Exact upstream fix inspected: #107938 / `7748574c4b373eb3d29ff5113ce87c0c13260f5c`.
- `git diff --check` passed.
- Package changelog extraction for `2026.6.34` passed (4371 bytes).
- Focused Vitest could not run in this worktree because dependencies are absent; delegated Testbox authentication and brokered runner configuration are unavailable in this session. CI remains the execution gate.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` completed cleanly before commit.

AI-assisted; I reviewed and understand this change.