### PR TITLE
fix(release): support frozen gateway stop commands

### DIFF
--- a/scripts/lib/cross-os-release-checks/installed.ts
+++ b/scripts/lib/cross-os-release-checks/installed.ts
@@ -376,6 +376,32 @@ export async function runInstalledCli(params: {
   });
 }
 
+export async function resolveInstalledGatewayStopArgs(params: {
+  cliPath: string;
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+  logPath: string;
+}) {
+  try {
+    const help = await runInstalledCli({
+      cliPath: params.cliPath,
+      args: ["gateway", "stop", "--help"],
+      cwd: params.cwd,
+      env: params.env,
+      logPath: params.logPath,
+      timeoutMs: 15_000,
+      check: false,
+    });
+    if (help.exitCode !== 0) {
+      throw new Error(`gateway stop --help exited ${help.exitCode}`);
+    }
+    return buildGatewayStopArgsFromHelpText(`${help.stdout}\n${help.stderr}`);
+  } catch (error) {
+    appendGatewayStopHelpProbeFallback(params.logPath, error);
+    return buildGatewayStopArgsFromHelpText("--force");
+  }
+}
+
 async function readInstalledUpdateStatus(params: {
   cliPath: string;
   cwd: string;
@@ -572,10 +598,24 @@ export function buildGatewayStatusArgsFromHelpText(
   return ["gateway", "status"];
 }
 
+export function buildGatewayStopArgsFromHelpText(helpText: string) {
+  if (helpText.includes("--force")) {
+    return ["gateway", "stop", "--force"];
+  }
+  return ["gateway", "stop"];
+}
+
 export function appendGatewayStatusHelpProbeFallback(logPath: string, error: unknown) {
   appendFileSync(
     logPath,
     `${new Date().toISOString()} gateway status help probe failed; assuming current --require-rpc support: ${formatError(error)}\n`,
+  );
+}
+
+function appendGatewayStopHelpProbeFallback(logPath: string, error: unknown) {
+  appendFileSync(
+    logPath,
+    `${new Date().toISOString()} gateway stop help probe failed; assuming current --force support: ${formatError(error)}\n`,
   );
 }
 

--- a/scripts/lib/cross-os-release-checks/installed.ts
+++ b/scripts/lib/cross-os-release-checks/installed.ts
@@ -382,24 +382,15 @@ export async function resolveInstalledGatewayStopArgs(params: {
   env: NodeJS.ProcessEnv;
   logPath: string;
 }) {
-  try {
-    const help = await runInstalledCli({
-      cliPath: params.cliPath,
-      args: ["gateway", "stop", "--help"],
-      cwd: params.cwd,
-      env: params.env,
-      logPath: params.logPath,
-      timeoutMs: 15_000,
-      check: false,
-    });
-    if (help.exitCode !== 0) {
-      throw new Error(`gateway stop --help exited ${help.exitCode}`);
-    }
-    return buildGatewayStopArgsFromHelpText(`${help.stdout}\n${help.stderr}`);
-  } catch (error) {
-    appendGatewayStopHelpProbeFallback(params.logPath, error);
-    return buildGatewayStopArgsFromHelpText("--force");
-  }
+  const help = await runInstalledCli({
+    cliPath: params.cliPath,
+    args: ["gateway", "stop", "--help"],
+    cwd: params.cwd,
+    env: params.env,
+    logPath: params.logPath,
+    timeoutMs: 15_000,
+  });
+  return buildGatewayStopArgsFromHelpText(`${help.stdout}\n${help.stderr}`);
 }
 
 async function readInstalledUpdateStatus(params: {
@@ -609,13 +600,6 @@ export function appendGatewayStatusHelpProbeFallback(logPath: string, error: unk
   appendFileSync(
     logPath,
     `${new Date().toISOString()} gateway status help probe failed; assuming current --require-rpc support: ${formatError(error)}\n`,
-  );
-}
-
-function appendGatewayStopHelpProbeFallback(logPath: string, error: unknown) {
-  appendFileSync(
-    logPath,
-    `${new Date().toISOString()} gateway stop help probe failed; assuming current --force support: ${formatError(error)}\n`,
   );
 }
 

--- a/scripts/lib/cross-os-release-checks/lanes.ts
+++ b/scripts/lib/cross-os-release-checks/lanes.ts
@@ -38,6 +38,7 @@ import {
   readInstalledVersion,
   resolveInstalledPrefixDirFromCliPath,
   resolvePublishedInstallerUrl,
+  resolveInstalledGatewayStopArgs,
   runBundledPluginPostinstall,
   runInstalledBrowserOverrideImportSmoke,
   shouldRunWindowsInstalledBrowserOverrideImportSmoke,
@@ -484,7 +485,12 @@ export async function runInstallerFreshSuite(
         logLanePhase(lane, "gateway-stop-managed");
         await runInstalledCli({
           cliPath: freshShell.cliPath,
-          args: ["gateway", "stop", "--force"],
+          args: await resolveInstalledGatewayStopArgs({
+            cliPath: freshShell.cliPath,
+            cwd: lane.homeDir,
+            env,
+            logPath: join(params.logsDir, "installer-fresh-gateway-stop-managed-help.log"),
+          }),
           env,
           cwd: lane.homeDir,
           logPath: join(params.logsDir, "installer-fresh-gateway-stop-managed.log"),

--- a/scripts/lib/cross-os-release-checks/lanes.ts
+++ b/scripts/lib/cross-os-release-checks/lanes.ts
@@ -38,7 +38,6 @@ import {
   readInstalledVersion,
   resolveInstalledPrefixDirFromCliPath,
   resolvePublishedInstallerUrl,
-  resolveInstalledGatewayStopArgs,
   runBundledPluginPostinstall,
   runInstalledBrowserOverrideImportSmoke,
   shouldRunWindowsInstalledBrowserOverrideImportSmoke,
@@ -47,6 +46,7 @@ import {
 import {
   ensureDevUpdateGitInstall,
   ensureManagedGatewayReady,
+  resolveInstalledGatewayStopArgs,
   resolveInstallerTargetVersion,
   runInstalledAgentTurn,
   runInstalledCli,

--- a/scripts/lib/cross-os-release-checks/runtime.ts
+++ b/scripts/lib/cross-os-release-checks/runtime.ts
@@ -32,6 +32,7 @@ import {
   buildGatewayStatusArgsFromHelpText,
   buildReleaseOnboardArgs,
   ensureManagedGatewayReady,
+  resolveInstalledGatewayStopArgs,
   runInstalledCli,
 } from "./installed.ts";
 import { readLogFileSize, readLogTextSince } from "./logs.ts";
@@ -108,7 +109,12 @@ export async function exerciseManagedGatewayLifecycle(
   logLanePhase(params.lane, "gateway-stop");
   await runInstalledCli({
     cliPath: params.cliPath,
-    args: ["gateway", "stop", "--force"],
+    args: await resolveInstalledGatewayStopArgs({
+      cliPath: params.cliPath,
+      cwd: params.lane.homeDir,
+      env: params.env,
+      logPath: `${params.logPrefix}-stop-help.log`,
+    }),
     env: params.env,
     cwd: params.lane.homeDir,
     logPath: `${params.logPrefix}-stop.log`,

--- a/test/scripts/openclaw-cross-os-release-checks.test.ts
+++ b/test/scripts/openclaw-cross-os-release-checks.test.ts
@@ -760,6 +760,10 @@ describe("scripts/openclaw-cross-os-release-checks", () => {
   });
 
   it("uses forced shutdown only when the installed gateway supports it", () => {
+    const installedSource = readFileSync(
+      "scripts/lib/cross-os-release-checks/installed.ts",
+      "utf8",
+    );
     const source = [
       "scripts/lib/cross-os-release-checks/lanes.ts",
       "scripts/lib/cross-os-release-checks/runtime.ts",
@@ -776,6 +780,8 @@ describe("scripts/openclaw-cross-os-release-checks", () => {
       "gateway",
       "stop",
     ]);
+    expect(installedSource).toContain('args: ["gateway", "stop", "--help"]');
+    expect(installedSource).not.toContain("appendGatewayStopHelpProbeFallback");
     expect(source.match(/resolveInstalledGatewayStopArgs\(/g)).toHaveLength(2);
   });
 

--- a/test/scripts/openclaw-cross-os-release-checks.test.ts
+++ b/test/scripts/openclaw-cross-os-release-checks.test.ts
@@ -31,6 +31,7 @@ import {
   buildInstalledBrowserOverrideImportProbeScript,
   buildNpmGlobalInstallArgs,
   appendLatestNpmDebugLogTail,
+  buildGatewayStopArgsFromHelpText,
   buildGatewayStatusArgsFromHelpText,
   buildInstallerSmokeScript,
   buildWindowsPathBootstrapScript,
@@ -758,7 +759,7 @@ describe("scripts/openclaw-cross-os-release-checks", () => {
     expect(args.at(-2)).toBe("--timeout");
   });
 
-  it("forces shutdown of the isolated managed gateways owned by release checks", () => {
+  it("uses forced shutdown only when the installed gateway supports it", () => {
     const source = [
       "scripts/lib/cross-os-release-checks/lanes.ts",
       "scripts/lib/cross-os-release-checks/runtime.ts",
@@ -766,8 +767,16 @@ describe("scripts/openclaw-cross-os-release-checks", () => {
       .map((filePath) => readFileSync(filePath, "utf8"))
       .join("\n");
 
-    expect(source.match(/args: \["gateway", "stop", "--force"\]/g)).toHaveLength(2);
-    expect(source).not.toContain('args: ["gateway", "stop"]');
+    expect(buildGatewayStopArgsFromHelpText("--force  Skip confirmation")).toEqual([
+      "gateway",
+      "stop",
+      "--force",
+    ]);
+    expect(buildGatewayStopArgsFromHelpText("--disable  Disable the service")).toEqual([
+      "gateway",
+      "stop",
+    ]);
+    expect(source.match(/resolveInstalledGatewayStopArgs\(/g)).toHaveLength(2);
   });
 
   it("keeps cross-OS live smoke agent turns on GPT-5-safe timeouts and minimal context", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Full Release Validation cannot test older, frozen release candidates on Windows because the trusted release harness always passes `gateway stop --force`, although that option was introduced after the candidate.

## Why This Change Was Made

The trusted cross-OS harness now reads the installed candidate CLI help and uses `--force` only when it is supported. The same capability check covers both managed-gateway shutdown paths, retaining the current non-interactive stop behavior without requiring a broad lifecycle backport into a release branch.

## User Impact

Release operators can validate older supported release heads with the current trusted harness. Current releases retain their forced, non-interactive managed-gateway shutdown.

## Evidence

- Failure reproduced from Full Release Validation #29895096406, child Release Checks #29895406949, Windows installer fresh job #88844687426: candidate rejected `gateway stop --force`.
- Candidate `2026.6.34` CLI inspected: `gateway stop` has no `--force`; current main acquired it in #110323.
- Added focused unit coverage for force-capability selection and both harness call sites.
- `git diff --check` passed.
- Focused Vitest is pending CI because this worktree has no dependencies and this session has neither Testbox authentication nor a configured brokered runner.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` completed cleanly before commit.

AI-assisted; I reviewed and understand this change.