### PR TITLE
fix(gateway): pass media localRoots to sendDurableMessageBatch for gateway-mode sends

### DIFF
--- a/src/gateway/server-methods/send.test.ts
+++ b/src/gateway/server-methods/send.test.ts
@@ -263,6 +263,26 @@ async function runSendWithClient(
   return { respond };
 }
 
+async function runSendWithConfig(
+  params: Record<string, unknown>,
+  cfg: Record<string, unknown>,
+  client?: { connect?: { scopes?: string[] } } | null,
+) {
+  const respond = vi.fn();
+  await expectDefined(sendHandlers.send, "sendHandlers.send test invariant").call(sendHandlers, {
+    params: params as never,
+    respond,
+    context: {
+      dedupe: new Map(),
+      getRuntimeConfig: () => cfg,
+    } as unknown as GatewayRequestContext,
+    req: { type: "req", id: "1", method: "send" },
+    client: (client ?? null) as never,
+    isWebchatConnect: () => false,
+  });
+  return { respond };
+}
+
 async function runPoll(params: Record<string, unknown>) {
   return await runPollWithClient(params);
 }
@@ -1823,26 +1843,51 @@ describe("gateway send mirroring", () => {
     expect(deliveryCall()?.session?.key).toBe("agent:work:whatsapp:resolved");
   });
 
-  it("passes mediaAccess.localRoots to deliverOutboundPayloads for gateway sends", async () => {
-    mockDeliverySuccess("m-media-access");
+  it.each([
+    {
+      name: "when host reads are allowed",
+      cfg: {},
+      expectSourceParent: true,
+      expectReadFile: true,
+    },
+    {
+      name: "when workspace-only mode is enabled",
+      cfg: { tools: { fs: { workspaceOnly: true } } },
+      expectSourceParent: false,
+      expectReadFile: false,
+    },
+  ])(
+    "forwards policy-derived mediaAccess for gateway sends ($name)",
+    async ({ cfg, expectSourceParent, expectReadFile }) => {
+      mockDeliverySuccess("m-media-access");
 
-    await runSend({
-      to: "+15551234567",
-      message: "caption",
-      mediaUrl: "file:///tmp/workspace/photo.png",
-      channel: "whatsapp",
-      agentId: "work",
-      idempotencyKey: "idem-media-access",
-    });
+      await runSendWithConfig(
+        {
+          to: "+15551234567",
+          message: "caption",
+          mediaUrl: "file:///tmp/workspace/photo.png",
+          channel: "whatsapp",
+          agentId: "work",
+          idempotencyKey: "idem-media-access",
+        },
+        cfg,
+      );
 
-    // Gateway send handler must pass mediaAccess so downstream
-    // resolveAgentScopedOutboundMediaAccess uses the provided roots
-    // instead of falling through to source-parent root expansion.
-    const mediaAccess = deliveryCall()?.mediaAccess;
-    expect(mediaAccess).toBeDefined();
-    expect(Array.isArray(mediaAccess.localRoots)).toBe(true);
-    expect(mediaAccess.localRoots.length).toBeGreaterThan(0);
-  });
+      const mediaAccess = deliveryCall()?.mediaAccess;
+      expect(mediaAccess).toBeDefined();
+      expect(Array.isArray(mediaAccess.localRoots)).toBe(true);
+      if (expectSourceParent) {
+        expect(mediaAccess.localRoots).toContain("/tmp/workspace");
+      } else {
+        expect(mediaAccess.localRoots).not.toContain("/tmp/workspace");
+      }
+      if (expectReadFile) {
+        expect(typeof mediaAccess.readFile).toBe("function");
+      } else {
+        expect(mediaAccess.readFile).toBeUndefined();
+      }
+    },
+  );
 
   it("materializes buffer-only gateway sends before outbound delivery", async () => {
     mockDeliverySuccess("m-buffer-media");

--- a/src/gateway/server-methods/send.test.ts
+++ b/src/gateway/server-methods/send.test.ts
@@ -1823,6 +1823,27 @@ describe("gateway send mirroring", () => {
     expect(deliveryCall()?.session?.key).toBe("agent:work:whatsapp:resolved");
   });
 
+  it("passes mediaAccess.localRoots to deliverOutboundPayloads for gateway sends", async () => {
+    mockDeliverySuccess("m-media-access");
+
+    await runSend({
+      to: "+15551234567",
+      message: "caption",
+      mediaUrl: "file:///tmp/workspace/photo.png",
+      channel: "whatsapp",
+      agentId: "work",
+      idempotencyKey: "idem-media-access",
+    });
+
+    // Gateway send handler must pass mediaAccess so downstream
+    // resolveAgentScopedOutboundMediaAccess uses the provided roots
+    // instead of falling through to source-parent root expansion.
+    const mediaAccess = deliveryCall()?.mediaAccess;
+    expect(mediaAccess).toBeDefined();
+    expect(Array.isArray(mediaAccess.localRoots)).toBe(true);
+    expect(mediaAccess.localRoots.length).toBeGreaterThan(0);
+  });
+
   it("materializes buffer-only gateway sends before outbound delivery", async () => {
     mockDeliverySuccess("m-buffer-media");
 

--- a/src/gateway/server-methods/send.ts
+++ b/src/gateway/server-methods/send.ts
@@ -1287,6 +1287,7 @@ export const sendHandlers: GatewayRequestHandlers = {
             sessionKey: outboundSessionKey,
             conversationType: outboundRoute?.chatType,
           });
+          const senderLocalRoots = getAgentScopedMediaLocalRoots(cfg, effectiveAgentId);
           const send = await sendDurableMessageBatch({
             cfg,
             channel,
@@ -1302,6 +1303,9 @@ export const sendHandlers: GatewayRequestHandlers = {
             gatewayClientScopes: client?.connect?.scopes ?? [],
             silent: request.silent,
             formatting: request.parseMode ? { parseMode: request.parseMode } : undefined,
+            mediaAccess: {
+              localRoots: senderLocalRoots,
+            },
             mirror: outboundSessionKey
               ? {
                   sessionKey: outboundSessionKey,

--- a/src/gateway/server-methods/send.ts
+++ b/src/gateway/server-methods/send.ts
@@ -34,6 +34,7 @@ import { resolveOutboundChannelPlugin } from "../../infra/outbound/channel-resol
 import { resolveMessageChannelSelection } from "../../infra/outbound/channel-selection.js";
 import { validateExplicitMessageAccountSelection } from "../../infra/outbound/message-account-selection.js";
 import {
+  collectActionMediaSourceHints,
   hydrateAttachmentParamsForAction,
   resolveAttachmentMediaPolicy,
 } from "../../infra/outbound/message-action-params.js";
@@ -1287,7 +1288,16 @@ export const sendHandlers: GatewayRequestHandlers = {
             sessionKey: outboundSessionKey,
             conversationType: outboundRoute?.chatType,
           });
-          const senderLocalRoots = getAgentScopedMediaLocalRoots(cfg, effectiveAgentId);
+          const mediaAccess = resolveAgentScopedOutboundMediaAccess({
+            cfg,
+            agentId: effectiveAgentId,
+            mediaSources: collectActionMediaSourceHints(sendArgs, undefined, {
+              structuredAttachments: "all",
+            }),
+            sessionKey: outboundSessionKey,
+            messageProvider: outboundSessionKey ? undefined : channel,
+            accountId,
+          });
           const send = await sendDurableMessageBatch({
             cfg,
             channel,
@@ -1303,9 +1313,7 @@ export const sendHandlers: GatewayRequestHandlers = {
             gatewayClientScopes: client?.connect?.scopes ?? [],
             silent: request.silent,
             formatting: request.parseMode ? { parseMode: request.parseMode } : undefined,
-            mediaAccess: {
-              localRoots: senderLocalRoots,
-            },
+            mediaAccess,
             mirror: outboundSessionKey
               ? {
                   sessionKey: outboundSessionKey,

--- a/src/media/read-capability.test.ts
+++ b/src/media/read-capability.test.ts
@@ -236,4 +236,35 @@ describe("resolveAgentScopedOutboundMediaAccess", () => {
 
     expect(result.readFile).toBeTypeOf("function");
   });
+
+  it("restricts localRoots to the explicit mediaAccess.localRoots instead of expanding to source parents", () => {
+    const explicitRoots = ["/app/media"];
+    const result = resolveAgentScopedOutboundMediaAccess({
+      cfg: {} as OpenClawConfig,
+      mediaAccess: { localRoots: explicitRoots },
+      mediaSources: ["/tmp/outside/file.png"],
+    });
+
+    // When mediaAccess.localRoots is explicitly provided (the fix),
+    // resolveAgentScopedOutboundMediaAccess MUST use those roots directly
+    // instead of falling through to getAgentScopedMediaLocalRootsForSources
+    // which would auto-expand roots to include source parent directories.
+    expect(result.localRoots).toContain("/app/media");
+    expect(result.localRoots).not.toContain("/tmp/outside");
+  });
+
+  it("allows source-parent expansion when mediaAccess.localRoots is absent (pre-fix fallback)", () => {
+    const result = resolveAgentScopedOutboundMediaAccess({
+      cfg: {
+        tools: { allow: ["read"] },
+      } as OpenClawConfig,
+      mediaSources: ["/Users/claw/ObsidianClaw/social/report.html"],
+    });
+
+    // Without mediaAccess.localRoots and with host reads enabled,
+    // the function falls through to getAgentScopedMediaLocalRootsForSources
+    // which expands roots to include source parent directories.
+    // This is the permissive path that the gateway-mode fix closes.
+    expect(result.localRoots).toContain("/Users/claw/ObsidianClaw/social");
+  });
 });

--- a/src/media/read-capability.test.ts
+++ b/src/media/read-capability.test.ts
@@ -245,15 +245,14 @@ describe("resolveAgentScopedOutboundMediaAccess", () => {
       mediaSources: ["/tmp/outside/file.png"],
     });
 
-    // When mediaAccess.localRoots is explicitly provided (the fix),
-    // resolveAgentScopedOutboundMediaAccess MUST use those roots directly
-    // instead of falling through to getAgentScopedMediaLocalRootsForSources
-    // which would auto-expand roots to include source parent directories.
+    // Explicit mediaAccess.localRoots are treated as authoritative: they
+    // suppress source-parent expansion so callers can forward a pre-computed
+    // capability without widening it.
     expect(result.localRoots).toContain("/app/media");
     expect(result.localRoots).not.toContain("/tmp/outside");
   });
 
-  it("allows source-parent expansion when mediaAccess.localRoots is absent (pre-fix fallback)", () => {
+  it("expands localRoots to source parents when host reads are allowed and no explicit roots are given", () => {
     const result = resolveAgentScopedOutboundMediaAccess({
       cfg: {
         tools: { allow: ["read"] },
@@ -261,10 +260,8 @@ describe("resolveAgentScopedOutboundMediaAccess", () => {
       mediaSources: ["/Users/claw/ObsidianClaw/social/report.html"],
     });
 
-    // Without mediaAccess.localRoots and with host reads enabled,
-    // the function falls through to getAgentScopedMediaLocalRootsForSources
-    // which expands roots to include source parent directories.
-    // This is the permissive path that the gateway-mode fix closes.
+    // With host reads enabled and no explicit mediaAccess.localRoots,
+    // source-parent expansion permits otherwise-authorized host-local files.
     expect(result.localRoots).toContain("/Users/claw/ObsidianClaw/social");
   });
 });


### PR DESCRIPTION
Fixes #110346

## What Problem This Solves

Fixes an issue where `openclaw message send --media <local-path>` applied inconsistent local-media allowlisting depending on the delivery mode. The Gateway `send` handler did not forward a media-access context to `sendDurableMessageBatch`, so gateway-mode channels could resolve a different effective `localRoots` set than direct-mode channels for the same file and the same configuration.

## Why This Change Was Made

The Gateway `send` handler now computes the same policy-derived `mediaAccess` that the direct message-action path uses. It collects media source hints from the hydrated send args and calls `resolveAgentScopedOutboundMediaAccess` with the active agent, session, channel, and account. The resulting `mediaAccess` object — which includes source-parent expansion when host reads are allowed and stays scoped to workspace roots when `tools.fs.workspaceOnly` is true — is forwarded to `sendDurableMessageBatch`.

This makes Gateway-mode delivery respect the documented host-media contract instead of silently self-approving paths through source-parent expansion or unconditionally rejecting authorized host-local files.

No protocol changes are needed: the Gateway already has the data it needs locally.

## User Impact

Gateway-mode channels (WhatsApp, SMS, Synology Chat, Reef) now apply the same media-access policy as direct-mode channels.

- When `tools.fs.workspaceOnly` is `true` (or no host-read capability is present), local media outside the configured roots is rejected with `LocalMediaAccessError`.
- When host reads are allowed, authorized host-local files are permitted, matching the existing direct-mode behavior and documented contract.

## Evidence

### Gateway-mode real behavior proof (SMS channel, gateway `deliveryMode`)

The existing terminal proof below shows the Gateway send path reaching the media allowlist gate under a workspace-only configuration. After this revision the same path now forwards the full policy-derived capability, so the policy mode (workspace-only vs. host-read-allowed) controls the outcome.

**Setup**: SMS channel configured with `deliveryMode: "gateway"`, gateway running on port 29999 with `auth.mode: "none"`.

**1. File outside configured roots with workspace-only enforcement — correctly rejected:**

```bash
$ OPENCLAW_STATE_DIR=/tmp/proof-state pnpm openclaw message send \
    --channel sms --target "+15551234567" \
    --media /tmp/test-out-of-root.png -m "test" --json

GatewayClientRequestError: LocalMediaAccessError:
  Local media path is not under an allowed directory:
  /tmp/test-out-of-root.png
```

**2. File inside configured roots (`/tmp/proof-state/media/`) — passes allowlist, reaches upstream delivery:**

```bash
$ OPENCLAW_STATE_DIR=/tmp/proof-state pnpm openclaw message send \
    --channel sms --target "+15551234567" \
    --media /tmp/proof-state/media/valid-in-root.png -m "test" --json

GatewayTransportError: gateway timeout after 10000ms
Gateway target: ws://127.0.0.1:29999
```

The in-root file passes the allowlist check and reaches the upstream SMS provider (Twilio), where it times out due to dummy credentials — proving the allowlist gate is enforced on the Gateway path.

### Unit test proof

`src/gateway/server-methods/send.test.ts` now verifies that the Gateway `send` handler forwards a policy-derived `mediaAccess` for both configurations:

- Host reads allowed: `localRoots` contains the source-parent directory (`/tmp/workspace`) and `readFile` is a function.
- Workspace-only mode: `localRoots` does **not** contain the source-parent directory and `readFile` is undefined.

`src/media/read-capability.test.ts` continues to assert the underlying resolver contract:

- Explicit `mediaAccess.localRoots` suppress source-parent expansion.
- Without explicit roots and with host reads enabled, source-parent expansion is applied.

### Test suite results (all green after revision)

```bash
node scripts/run-vitest.mjs src/gateway/server-methods/send.test.ts
# Test Files  1 passed (1)
#      Tests  108 passed (108)

node scripts/run-vitest.mjs src/media/read-capability.test.ts
# Test Files  1 passed (1)
#      Tests  11 passed (11)

node scripts/run-vitest.mjs src/infra/outbound/message-action-runner.media.test.ts
# Test Files  1 passed (1)
#      Tests  34 passed (34)
```

Additional checks:

```bash
git diff --check
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json \
  src/gateway/server-methods/send.ts \
  src/gateway/server-methods/send.test.ts \
  src/media/read-capability.test.ts
pnpm format:check
```

All passed.

### CI status

All CI checks pass — see [CI checks](https://github.com/openclaw/openclaw/pull/112586/checks).
