### PR TITLE
fix: bound compaction planning worker payloads

### DIFF
--- a/src/agents/compaction-planning-projection.ts
+++ b/src/agents/compaction-planning-projection.ts
@@ -1,0 +1,319 @@
+/** Builds bounded transcript projections for compaction worker planning. */
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import type { AgentMessage } from "./runtime/index.js";
+
+const TEXT_TRUNCATE_THRESHOLD_CHARS = 32_768;
+const TEXT_SAMPLE_CHARS = 8_192;
+const PLANNING_MAX_CHARS = 256 * 1024;
+const MAX_ARGUMENT_ESTIMATE_CHARS = 1_000_000;
+const UNMEASURABLE_ARGUMENT_OMITTED_CHARS = Number.MAX_SAFE_INTEGER;
+const OMITTED_CHARS_FIELD = "__openclawCompactionPlanningOmittedChars";
+
+type ProjectionBudget = {
+  remainingChars: number;
+};
+
+export function readCompactionPlanningOmittedChars(message: AgentMessage): number {
+  const value = (message as unknown as Record<string, unknown>)[OMITTED_CHARS_FIELD];
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? Math.floor(value) : 0;
+}
+
+function projectText(
+  text: string,
+  budget: ProjectionBudget,
+): { text: string; omittedChars: number } | null {
+  if (text.length <= TEXT_TRUNCATE_THRESHOLD_CHARS && text.length <= budget.remainingChars) {
+    budget.remainingChars -= text.length;
+    return null;
+  }
+  const sample = truncateUtf16Safe(text, Math.min(TEXT_SAMPLE_CHARS, budget.remainingChars));
+  budget.remainingChars -= sample.length;
+  return {
+    text: sample,
+    omittedChars: text.length - sample.length,
+  };
+}
+
+function jsonStringLengthWithin(text: string, maxChars: number): number | undefined {
+  let length = 2;
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index] ?? "";
+    const code = text.charCodeAt(index);
+    const nextCode = text.charCodeAt(index + 1);
+    const pairedSurrogate =
+      code >= 0xd800 && code <= 0xdbff && nextCode >= 0xdc00 && nextCode <= 0xdfff;
+    length += pairedSurrogate
+      ? 2
+      : code >= 0xd800 && code <= 0xdfff
+        ? 6
+        : char === '"' ||
+            char === "\\" ||
+            code === 8 ||
+            code === 9 ||
+            code === 10 ||
+            code === 12 ||
+            code === 13
+          ? 2
+          : code < 32
+            ? 6
+            : 1;
+    if (pairedSurrogate) {
+      index += 1;
+    }
+    if (length > maxChars) {
+      return undefined;
+    }
+  }
+  return length;
+}
+
+function jsonLengthWithin(
+  value: unknown,
+  maxChars: number,
+  seen = new Set<object>(),
+): number | undefined {
+  if (typeof value === "string") {
+    return jsonStringLengthWithin(value, maxChars);
+  }
+  if (value === null) {
+    return 4;
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    const length = String(value).length;
+    return length <= maxChars ? length : undefined;
+  }
+  if (!value || typeof value !== "object" || seen.has(value)) {
+    return undefined;
+  }
+
+  seen.add(value);
+  let length = 2;
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      const separatorLength = length === 2 ? 0 : 1;
+      const entryLength = jsonLengthWithin(entry, maxChars - length - separatorLength, seen);
+      if (entryLength === undefined) {
+        return undefined;
+      }
+      length += separatorLength + entryLength;
+      if (length > maxChars) {
+        return undefined;
+      }
+    }
+  } else {
+    const record = value as Record<string, unknown>;
+    for (const key in record) {
+      if (!Object.hasOwn(record, key)) {
+        continue;
+      }
+      const separatorLength = length === 2 ? 0 : 1;
+      const keyLength = jsonStringLengthWithin(key, maxChars - length - separatorLength);
+      const entryLength = jsonLengthWithin(
+        record[key],
+        maxChars - length - separatorLength - (keyLength ?? 0) - 1,
+        seen,
+      );
+      if (keyLength === undefined || entryLength === undefined) {
+        return undefined;
+      }
+      length += separatorLength + keyLength + entryLength + 1;
+      if (length > maxChars) {
+        return undefined;
+      }
+    }
+  }
+  seen.delete(value);
+  return length;
+}
+
+function projectToolArguments(
+  value: unknown,
+  budget: ProjectionBudget,
+): { value: Record<string, never>; omittedChars: number; changed: boolean } {
+  const length = jsonLengthWithin(value, budget.remainingChars);
+  if (length !== undefined) {
+    budget.remainingChars -= length;
+    return { value: {}, omittedChars: 0, changed: false };
+  }
+  budget.remainingChars = 0;
+  return {
+    value: {},
+    // Unmeasurable arguments must force an oversized plan, never understate token pressure.
+    omittedChars:
+      jsonLengthWithin(value, MAX_ARGUMENT_ESTIMATE_CHARS) ?? UNMEASURABLE_ARGUMENT_OMITTED_CHARS,
+    changed: true,
+  };
+}
+
+function projectContentBlock(
+  block: unknown,
+  projectTextContent: boolean,
+  budget: ProjectionBudget,
+): { block: unknown; omittedChars: number; changed: boolean } {
+  if (!block || typeof block !== "object") {
+    return { block, omittedChars: 0, changed: false };
+  }
+  const record = block as Record<string, unknown>;
+  const type = typeof record.type === "string" ? record.type : "";
+  if (type === "image" && typeof record.data === "string" && record.data.length > 0) {
+    return {
+      block: { ...record, data: "" },
+      omittedChars: 0,
+      changed: true,
+    };
+  }
+  if (!projectTextContent) {
+    return { block, omittedChars: 0, changed: false };
+  }
+  const hasText = typeof record.text === "string" && record.text.length > 0;
+  const textIsModelVisible =
+    type === "text" || ((type === "toolResult" || type === "tool_result") && hasText);
+  const contentIsModelVisible =
+    (type === "toolResult" || type === "tool_result") &&
+    !hasText &&
+    typeof record.content === "string";
+  const projectedText = typeof record.text === "string" ? projectText(record.text, budget) : null;
+  const projectedContent =
+    typeof record.content === "string" ? projectText(record.content, budget) : null;
+  const projectedThinking =
+    type === "thinking" && typeof record.thinking === "string"
+      ? projectText(record.thinking, budget)
+      : null;
+  const projectedArguments =
+    type === "toolCall" ? projectToolArguments(record.arguments, budget) : undefined;
+  // Tool-call IDs are provider-generated and bounded in practice. Planning never uses them as
+  // durable keys, so malformed giant IDs do not justify an ID-remapping protocol here.
+  const hasPlanningIrrelevantSignature =
+    "textSignature" in record || "thinkingSignature" in record || "thoughtSignature" in record;
+  if (
+    !projectedText &&
+    !projectedContent &&
+    !projectedThinking &&
+    !projectedArguments?.changed &&
+    !hasPlanningIrrelevantSignature
+  ) {
+    return { block, omittedChars: 0, changed: false };
+  }
+  const next = { ...record };
+  let omittedChars = 0;
+  if (projectedText) {
+    next.text = projectedText.text;
+    omittedChars += textIsModelVisible ? projectedText.omittedChars : 0;
+  }
+  if (projectedContent) {
+    next.content = projectedContent.text;
+    omittedChars += contentIsModelVisible ? projectedContent.omittedChars : 0;
+  }
+  if (projectedThinking) {
+    next.thinking = projectedThinking.text;
+    omittedChars += projectedThinking.omittedChars;
+  }
+  if (projectedArguments?.changed) {
+    next.arguments = projectedArguments.value;
+    omittedChars += projectedArguments.omittedChars;
+  }
+  delete next.textSignature;
+  delete next.thinkingSignature;
+  delete next.thoughtSignature;
+  return { block: next, omittedChars, changed: true };
+}
+
+function projectStringFields(
+  message: AgentMessage,
+  fields: readonly string[],
+  budget: ProjectionBudget,
+): AgentMessage {
+  const record = message as unknown as Record<string, unknown>;
+  let omittedChars = readCompactionPlanningOmittedChars(message);
+  let next: Record<string, unknown> | undefined;
+  for (const field of fields) {
+    const value = record[field];
+    if (typeof value !== "string") {
+      continue;
+    }
+    const projected = projectText(value, budget);
+    if (!projected) {
+      continue;
+    }
+    next ??= { ...record };
+    next[field] = projected.text;
+    omittedChars += projected.omittedChars;
+  }
+  return next
+    ? ({ ...next, [OMITTED_CHARS_FIELD]: omittedChars } as unknown as AgentMessage)
+    : message;
+}
+
+function projectMessage(message: AgentMessage, budget: ProjectionBudget): AgentMessage {
+  const source = (() => {
+    switch (message.role) {
+      case "assistant":
+        return {
+          role: message.role,
+          content: message.content,
+          stopReason: message.stopReason,
+          timestamp: message.timestamp,
+        } as AgentMessage;
+      case "bashExecution": {
+        const { fullOutputPath: _, ...rest } = message;
+        return rest as AgentMessage;
+      }
+      case "compactionSummary": {
+        const { details: _, ...rest } = message;
+        return rest as AgentMessage;
+      }
+      case "custom": {
+        const { details: _, ...rest } = message;
+        return rest as AgentMessage;
+      }
+      default:
+        return message;
+    }
+  })();
+  const currentOmittedChars = readCompactionPlanningOmittedChars(source);
+  const content = (source as { content?: unknown }).content;
+  if (typeof content === "string") {
+    const projected = projectText(content, budget);
+    if (!projected) {
+      return source;
+    }
+    return {
+      ...(source as unknown as Record<string, unknown>),
+      content: projected.text,
+      [OMITTED_CHARS_FIELD]: currentOmittedChars + projected.omittedChars,
+    } as unknown as AgentMessage;
+  }
+  if (!Array.isArray(content)) {
+    switch (source.role) {
+      case "bashExecution":
+        return projectStringFields(source, ["command", "output"], budget);
+      case "branchSummary":
+      case "compactionSummary":
+        return projectStringFields(source, ["summary"], budget);
+      default:
+        return source;
+    }
+  }
+
+  let omittedChars = 0;
+  let changed = false;
+  const projectedContent = content.map((block) => {
+    const projected = projectContentBlock(block, true, budget);
+    omittedChars += projected.omittedChars;
+    changed ||= projected.changed;
+    return projected.block;
+  });
+  if (!changed) {
+    return source;
+  }
+  return {
+    ...(source as unknown as Record<string, unknown>),
+    content: projectedContent,
+    [OMITTED_CHARS_FIELD]: currentOmittedChars + omittedChars,
+  } as unknown as AgentMessage;
+}
+
+export function projectCompactionPlanningMessages(messages: AgentMessage[]): AgentMessage[] {
+  const budget = { remainingChars: PLANNING_MAX_CHARS };
+  return messages.map((message) => projectMessage(message, budget));
+}

--- a/src/agents/compaction-planning-worker.test.ts
+++ b/src/agents/compaction-planning-worker.test.ts
@@ -1,7 +1,12 @@
 // Covers the compaction planning worker boundary and timeout behavior.
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
+import { serializeConversation } from "openclaw/plugin-sdk/agent-core";
 import { beforeAll, describe, expect, it, vi } from "vitest";
-import { compactionPlanningWorkerTesting } from "./compaction-planning-worker.test-support.js";
+import {
+  buildSummaryChunksWithWorker,
+  compactionPlanningWorkerTesting,
+} from "./compaction-planning-worker.js";
+import { estimateMessagesTokens } from "./compaction-planning.js";
 import { runCompactionPlanningWorkerInput } from "./compaction-planning.worker.js";
 import type { AgentMessage } from "./runtime/index.js";
 
@@ -62,10 +67,82 @@ describe("compaction planning worker", () => {
     if (packagedSummaryChunks.kind !== "summaryChunks") {
       return;
     }
-    expect(packagedSummaryChunks.chunks.flat().map((message) => message.timestamp)).toEqual([
-      1, 2, 3,
+    expect(packagedSummaryChunks.chunkIndexes.flat()).toEqual([0, 1, 2]);
+    expect(packagedSummaryChunks.chunkIndexes.length).toBeGreaterThan(1);
+  }, 45_000);
+
+  it("bounds image data in worker planning without changing returned summary input", async () => {
+    const imageData = "a".repeat(1_000_000);
+    const imageMessage = {
+      role: "toolResult",
+      toolCallId: "call_image",
+      toolName: "browser",
+      isError: false,
+      content: [{ type: "image", data: imageData, mimeType: "image/png" }],
+      timestamp: 1,
+    } satisfies AgentMessage;
+    const messages = [
+      {
+        role: "user" as const,
+        content: [{ type: "image" as const, data: imageData, mimeType: "image/png" }],
+        timestamp: 0,
+      },
+      imageMessage,
+      ...Array.from({ length: 62 }, (_, index) => makeMessage(index + 2)),
+    ];
+
+    const chunks = await buildSummaryChunksWithWorker({ messages, maxChunkTokens: 8_000 });
+    const plannedMessages = chunks.flat();
+    const plannedImageMessage = plannedMessages.find(
+      (message) => message.role === "toolResult" && message.toolCallId === "call_image",
+    );
+    const plannedUserImageMessage = plannedMessages.find(
+      (message) => message.role === "user" && message.timestamp === 0,
+    );
+    expect(plannedImageMessage?.role).toBe("toolResult");
+    if (!plannedImageMessage || plannedImageMessage.role !== "toolResult") {
+      throw new Error("expected planned tool result");
+    }
+
+    expect(plannedImageMessage.content[0]).toEqual({
+      type: "image",
+      data: imageData,
+      mimeType: "image/png",
+    });
+    expect(plannedUserImageMessage?.role).toBe("user");
+    if (!plannedUserImageMessage || plannedUserImageMessage.role !== "user") {
+      throw new Error("expected planned user message");
+    }
+    expect(plannedUserImageMessage.content).toEqual([
+      { type: "image", data: imageData, mimeType: "image/png" },
     ]);
-    expect(packagedSummaryChunks.chunks.length).toBeGreaterThan(1);
+    expect(estimateMessagesTokens([plannedImageMessage])).toBe(
+      estimateMessagesTokens([imageMessage]),
+    );
+    expect(serializeConversation([plannedImageMessage])).toBe(
+      serializeConversation([imageMessage]),
+    );
+  }, 45_000);
+
+  it("preserves oversized tool-result text in returned summary input", async () => {
+    const hugeText = "x".repeat(120_000);
+    const messages: AgentMessage[] = [
+      {
+        role: "toolResult",
+        toolCallId: "call_large",
+        toolName: "browser",
+        isError: false,
+        content: [{ type: "text", text: hugeText }],
+        timestamp: 1,
+      },
+      ...Array.from({ length: 63 }, (_, index) => makeMessage(index + 2)),
+    ];
+
+    const chunks = await buildSummaryChunksWithWorker({ messages, maxChunkTokens: 8_000 });
+    const returnedMessages = chunks.flat();
+
+    expect(JSON.stringify(returnedMessages)).toBe(JSON.stringify(messages));
+    expect(JSON.stringify(returnedMessages)).toContain(hugeText);
   }, 45_000);
 
   it("plans summary chunks for worker input", () => {
@@ -84,8 +161,8 @@ describe("compaction planning worker", () => {
     if (value.kind !== "summaryChunks") {
       return;
     }
-    expect(value.chunks.flat().map((message) => message.timestamp)).toEqual([1, 2, 3]);
-    expect(value.chunks.length).toBeGreaterThan(1);
+    expect(value.chunkIndexes.flat()).toEqual([0, 1, 2]);
+    expect(value.chunkIndexes.length).toBeGreaterThan(1);
   });
 
   it("clamps oversized worker timeouts before scheduling", async () => {

--- a/src/agents/compaction-planning-worker.test.ts
+++ b/src/agents/compaction-planning-worker.test.ts
@@ -2,10 +2,8 @@
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { serializeConversation } from "openclaw/plugin-sdk/agent-core";
 import { beforeAll, describe, expect, it, vi } from "vitest";
-import {
-  buildSummaryChunksWithWorker,
-  compactionPlanningWorkerTesting,
-} from "./compaction-planning-worker.js";
+import { buildSummaryChunksWithWorker } from "./compaction-planning-worker.js";
+import { compactionPlanningWorkerTesting } from "./compaction-planning-worker.test-support.js";
 import { estimateMessagesTokens } from "./compaction-planning.js";
 import { runCompactionPlanningWorkerInput } from "./compaction-planning.worker.js";
 import type { AgentMessage } from "./runtime/index.js";

--- a/src/agents/compaction-planning-worker.ts
+++ b/src/agents/compaction-planning-worker.ts
@@ -13,6 +13,7 @@ import {
   buildStageSplitPlan,
   buildSummaryChunks,
   computeAdaptiveChunkRatio,
+  projectCompactionMessagesForPlanning,
   sanitizeCompactionMessages,
   type HistoryPrunePlan,
   type OversizedFallbackPlan,
@@ -170,6 +171,67 @@ function shouldUsePlanningWorker(messageCount: number): boolean {
   return messageCount >= COMPACTION_PLANNING_WORKER_MIN_MESSAGES;
 }
 
+function indexSelectedMessages(
+  indexByMessage: ReadonlyMap<AgentMessage, number>,
+  selected: AgentMessage[],
+): number[] {
+  return selected.map((message) => {
+    const index = indexByMessage.get(message);
+    if (index === undefined) {
+      throw new CompactionPlanningWorkerError(
+        "compaction planning result contains an unknown message",
+        "failed",
+      );
+    }
+    return index;
+  });
+}
+
+function indexMessageChunks(source: AgentMessage[], chunks: AgentMessage[][]): number[][] {
+  const indexByMessage = new Map(source.map((message, index) => [message, index]));
+  return chunks.map((chunk) => indexSelectedMessages(indexByMessage, chunk));
+}
+
+function indexOversizedFallbackPlan(
+  source: AgentMessage[],
+  plan: OversizedFallbackPlan,
+): Extract<CompactionPlanningWorkerValue, { kind: "oversizedFallback" }> {
+  return {
+    kind: "oversizedFallback",
+    smallMessageIndexes: indexSelectedMessages(
+      new Map(source.map((message, index) => [message, index])),
+      plan.smallMessages,
+    ),
+    oversizedNotes: plan.oversizedNotes,
+  };
+}
+
+function indexStageSplitPlan(
+  source: AgentMessage[],
+  plan: StageSplitPlan,
+): Extract<CompactionPlanningWorkerValue, { kind: "stageSplit" }> {
+  return plan.mode === "split"
+    ? {
+        kind: "stageSplit",
+        mode: "split",
+        chunkIndexes: indexMessageChunks(source, plan.chunks),
+      }
+    : { kind: "stageSplit", mode: "single" };
+}
+
+function restoreIndexedMessages(source: AgentMessage[], indexes: number[]): AgentMessage[] {
+  return indexes.map((index) => {
+    const message = source.at(index);
+    if (!Number.isInteger(index) || index < 0 || !message) {
+      throw new CompactionPlanningWorkerError(
+        "compaction planning result contains an invalid message index",
+        "failed",
+      );
+    }
+    return message;
+  });
+}
+
 async function runWithUnavailableFallback<T extends CompactionPlanningWorkerValue>(params: {
   input: CompactionPlanningWorkerInput;
   signal?: AbortSignal;
@@ -206,23 +268,27 @@ export async function buildSummaryChunksWithWorker(params: {
   if (!shouldUsePlanningWorker(messages.length)) {
     return buildSummaryChunks(params);
   }
+  const planningMessages = projectCompactionMessagesForPlanning(messages);
   const value = await runWithUnavailableFallback({
     input: {
       kind: "summaryChunks",
-      messages,
+      messages: planningMessages,
       maxChunkTokens: params.maxChunkTokens,
     },
     signal: params.signal,
     fallback: () => ({
       kind: "summaryChunks" as const,
-      chunks: buildSummaryChunks(params),
+      chunkIndexes: indexMessageChunks(
+        messages,
+        buildSummaryChunks({ messages, maxChunkTokens: params.maxChunkTokens }),
+      ),
     }),
     isExpected: (
       valueCandidate,
     ): valueCandidate is Extract<CompactionPlanningWorkerValue, { kind: "summaryChunks" }> =>
       valueCandidate.kind === "summaryChunks",
   });
-  return value.chunks;
+  return value.chunkIndexes.map((indexes) => restoreIndexedMessages(messages, indexes));
 }
 
 /** Builds an oversized-message fallback plan, using the worker when worthwhile. */
@@ -235,24 +301,26 @@ export async function buildOversizedFallbackPlanWithWorker(params: {
   if (!shouldUsePlanningWorker(messages.length)) {
     return buildOversizedFallbackPlan(params);
   }
+  const planningMessages = projectCompactionMessagesForPlanning(messages);
   const value = await runWithUnavailableFallback({
     input: {
       kind: "oversizedFallback",
-      messages,
+      messages: planningMessages,
       contextWindow: params.contextWindow,
     },
     signal: params.signal,
-    fallback: () => ({
-      kind: "oversizedFallback" as const,
-      ...buildOversizedFallbackPlan(params),
-    }),
+    fallback: () =>
+      indexOversizedFallbackPlan(
+        messages,
+        buildOversizedFallbackPlan({ messages, contextWindow: params.contextWindow }),
+      ),
     isExpected: (
       valueEntry,
     ): valueEntry is Extract<CompactionPlanningWorkerValue, { kind: "oversizedFallback" }> =>
       valueEntry.kind === "oversizedFallback",
   });
   return {
-    smallMessages: value.smallMessages,
+    smallMessages: restoreIndexedMessages(messages, value.smallMessageIndexes),
     oversizedNotes: value.oversizedNotes,
   };
 }
@@ -269,28 +337,45 @@ export async function buildStageSplitPlanWithWorker(params: {
   if (!shouldUsePlanningWorker(messages.length)) {
     return buildStageSplitPlan(params);
   }
+  const planningMessages = projectCompactionMessagesForPlanning(messages);
   const value = await runWithUnavailableFallback({
     input: {
       kind: "stageSplit",
-      messages,
+      messages: planningMessages,
       maxChunkTokens: params.maxChunkTokens,
       parts: params.parts,
       minMessagesForSplit: params.minMessagesForSplit,
     },
     signal: params.signal,
-    fallback: () => ({
-      kind: "stageSplit" as const,
-      ...buildStageSplitPlan(params),
-    }),
+    fallback: () =>
+      indexStageSplitPlan(
+        messages,
+        buildStageSplitPlan({
+          messages,
+          maxChunkTokens: params.maxChunkTokens,
+          parts: params.parts,
+          minMessagesForSplit: params.minMessagesForSplit,
+        }),
+      ),
     isExpected: (
       valueResult,
     ): valueResult is Extract<CompactionPlanningWorkerValue, { kind: "stageSplit" }> =>
       valueResult.kind === "stageSplit",
   });
-  return value.mode === "split" ? { mode: "split", chunks: value.chunks } : { mode: "single" };
+  return value.mode === "split"
+    ? {
+        mode: "split",
+        chunks: value.chunkIndexes.map((indexes) => restoreIndexedMessages(messages, indexes)),
+      }
+    : { mode: "single" };
 }
 
-/** Builds a history-pruning plan with worker fallback for large transcripts. */
+/**
+ * Builds a history-pruning plan on the owner thread.
+ *
+ * Pruning repairs tool-result pairs and returns exact retained/dropped messages,
+ * so a bounded selection projection cannot reconstruct every result faithfully.
+ */
 export async function buildHistoryPrunePlanWithWorker(params: {
   messagesToSummarize: AgentMessage[];
   turnPrefixMessages: AgentMessage[];
@@ -300,37 +385,7 @@ export async function buildHistoryPrunePlanWithWorker(params: {
   parts?: number;
   signal?: AbortSignal;
 }): Promise<HistoryPrunePlan> {
-  const messagesToSummarize = sanitizeCompactionMessages(params.messagesToSummarize);
-  const turnPrefixMessages = sanitizeCompactionMessages(params.turnPrefixMessages);
-  if (!shouldUsePlanningWorker(messagesToSummarize.length + turnPrefixMessages.length)) {
-    return buildHistoryPrunePlan(params);
-  }
-  const value = await runWithUnavailableFallback({
-    input: {
-      kind: "historyPrune",
-      messagesToSummarize,
-      turnPrefixMessages,
-      tokensBefore: params.tokensBefore,
-      contextWindowTokens: params.contextWindowTokens,
-      maxHistoryShare: params.maxHistoryShare,
-      parts: params.parts,
-    },
-    signal: params.signal,
-    fallback: () => ({
-      kind: "historyPrune" as const,
-      ...buildHistoryPrunePlan(params),
-    }),
-    isExpected: (
-      valueValue,
-    ): valueValue is Extract<CompactionPlanningWorkerValue, { kind: "historyPrune" }> =>
-      valueValue.kind === "historyPrune",
-  });
-  return {
-    summarizableTokens: value.summarizableTokens,
-    newContentTokens: value.newContentTokens,
-    maxHistoryTokens: value.maxHistoryTokens,
-    pruned: value.pruned,
-  };
+  return buildHistoryPrunePlan(params);
 }
 
 /** Computes the adaptive compaction chunk ratio with worker fallback. */
@@ -343,10 +398,11 @@ export async function computeAdaptiveChunkRatioWithWorker(params: {
   if (!shouldUsePlanningWorker(messages.length)) {
     return computeAdaptiveChunkRatio(params.messages, params.contextWindow);
   }
+  const planningMessages = projectCompactionMessagesForPlanning(messages);
   const value = await runWithUnavailableFallback({
     input: {
       kind: "adaptiveChunkRatio",
-      messages,
+      messages: planningMessages,
       contextWindow: params.contextWindow,
     },
     signal: params.signal,
@@ -363,13 +419,8 @@ export async function computeAdaptiveChunkRatioWithWorker(params: {
 }
 
 /** Test-only worker internals for URL resolution and error-path coverage. */
-const compactionPlanningWorkerTesting = {
+export const compactionPlanningWorkerTesting = {
   resolveCompactionPlanningWorkerUrl,
   runCompactionPlanningWorker,
+  CompactionPlanningWorkerError,
 };
-
-if (process.env.VITEST || process.env.NODE_ENV === "test") {
-  (globalThis as Record<PropertyKey, unknown>)[
-    Symbol.for("openclaw.compactionPlanningWorkerTestApi")
-  ] = compactionPlanningWorkerTesting;
-}

--- a/src/agents/compaction-planning-worker.ts
+++ b/src/agents/compaction-planning-worker.ts
@@ -418,9 +418,14 @@ export async function computeAdaptiveChunkRatioWithWorker(params: {
   return value.ratio;
 }
 
-/** Test-only worker internals for URL resolution and error-path coverage. */
-export const compactionPlanningWorkerTesting = {
+const compactionPlanningWorkerTesting = {
   resolveCompactionPlanningWorkerUrl,
   runCompactionPlanningWorker,
   CompactionPlanningWorkerError,
 };
+
+if (process.env.VITEST || process.env.NODE_ENV === "test") {
+  (globalThis as Record<PropertyKey, unknown>)[
+    Symbol.for("openclaw.compactionPlanningWorkerTestApi")
+  ] = compactionPlanningWorkerTesting;
+}

--- a/src/agents/compaction-planning.ts
+++ b/src/agents/compaction-planning.ts
@@ -3,6 +3,10 @@
  * token usage, chooses chunking strategy, and preserves active tool-use pairs
  * while splitting history for summaries.
  */
+import {
+  projectCompactionPlanningMessages,
+  readCompactionPlanningOmittedChars,
+} from "./compaction-planning-projection.js";
 import { stripRuntimeContextCustomMessages } from "./internal-runtime-context.js";
 import type { AgentMessage } from "./runtime/index.js";
 import { repairToolUseResultPairing, stripToolResultDetails } from "./session-transcript-repair.js";
@@ -51,7 +55,7 @@ export type HistoryPrunePlan = {
 export function estimateMessagesTokens(messages: AgentMessage[]): number {
   // SECURITY: toolResult.details and runtime-context transcript entries must never enter LLM-facing compaction.
   const safe = sanitizeCompactionMessages(messages);
-  return safe.reduce((sum, message) => sum + estimateTokens(message), 0);
+  return safe.reduce((sum, message) => sum + estimateCompactionPlanningTokens(message), 0);
 }
 
 /**
@@ -65,7 +69,9 @@ function estimatePerMessageTokens(messages: AgentMessage[]): number[] {
   const detailStripped = stripToolResultDetails(messages);
   // stripRuntimeContextCustomMessages filters by reference, so kept entries keep their identity.
   const modelVisible = new Set(stripRuntimeContextCustomMessages(detailStripped));
-  return detailStripped.map((message) => (modelVisible.has(message) ? estimateTokens(message) : 0));
+  return detailStripped.map((message) =>
+    modelVisible.has(message) ? estimateCompactionPlanningTokens(message) : 0,
+  );
 }
 
 /** Removes runtime-only context and tool-result details before token estimates or summaries. */
@@ -76,6 +82,20 @@ export function sanitizeCompactionMessages(messages: AgentMessage[]): AgentMessa
 /** Estimates one message using the same sanitization path as multi-message planning. */
 function estimateCompactionMessageTokens(message: AgentMessage): number {
   return estimateMessagesTokens([message]);
+}
+
+function estimateCompactionPlanningTokens(message: AgentMessage): number {
+  const omittedChars = readCompactionPlanningOmittedChars(message);
+  if (omittedChars === 0) {
+    return estimateTokens(message);
+  }
+  return estimateTokens(message) + Math.ceil(omittedChars / 4);
+}
+
+/** Builds a bounded planning projection that preserves token pressure accounting. */
+export function projectCompactionMessagesForPlanning(messages: AgentMessage[]): AgentMessage[] {
+  const safe = sanitizeCompactionMessages(messages);
+  return projectCompactionPlanningMessages(safe);
 }
 
 /** Clamps requested split parts to a usable count for the available messages. */

--- a/src/agents/compaction-planning.worker.ts
+++ b/src/agents/compaction-planning.worker.ts
@@ -9,8 +9,6 @@ import {
   buildSummaryChunks,
   computeAdaptiveChunkRatio,
   type HistoryPrunePlan,
-  type OversizedFallbackPlan,
-  type StageSplitPlan,
 } from "./compaction-planning.js";
 import type { AgentMessage } from "./runtime/index.js";
 
@@ -52,14 +50,22 @@ export type CompactionPlanningWorkerInput =
 export type CompactionPlanningWorkerValue =
   | {
       kind: "summaryChunks";
-      chunks: AgentMessage[][];
+      chunkIndexes: number[][];
     }
-  | ({
+  | {
       kind: "oversizedFallback";
-    } & OversizedFallbackPlan)
-  | ({
+      smallMessageIndexes: number[];
+      oversizedNotes: string[];
+    }
+  | {
       kind: "stageSplit";
-    } & StageSplitPlan)
+      mode: "single";
+    }
+  | {
+      kind: "stageSplit";
+      mode: "split";
+      chunkIndexes: number[][];
+    }
   | ({
       kind: "historyPrune";
     } & HistoryPrunePlan)
@@ -114,6 +120,24 @@ function isWorkerInput(value: unknown): value is CompactionPlanningWorkerInput {
   }
 }
 
+function indexSelectedMessages(
+  indexByMessage: ReadonlyMap<AgentMessage, number>,
+  selected: AgentMessage[],
+): number[] {
+  return selected.map((message) => {
+    const index = indexByMessage.get(message);
+    if (index === undefined) {
+      throw new Error("Compaction planning result contains an unknown message");
+    }
+    return index;
+  });
+}
+
+function indexMessageChunks(source: AgentMessage[], chunks: AgentMessage[][]): number[][] {
+  const indexByMessage = new Map(source.map((message, index) => [message, index]));
+  return chunks.map((chunk) => indexSelectedMessages(indexByMessage, chunk));
+}
+
 /** Run one compaction planning request and return a serializable result. */
 export function runCompactionPlanningWorkerInput(input: unknown): CompactionPlanningWorkerResult {
   if (!isWorkerInput(input)) {
@@ -125,30 +149,42 @@ export function runCompactionPlanningWorkerInput(input: unknown): CompactionPlan
 
   try {
     switch (input.kind) {
-      case "summaryChunks":
+      case "summaryChunks": {
+        const chunks = buildSummaryChunks(input);
         return {
           status: "ok",
           value: {
             kind: "summaryChunks",
-            chunks: buildSummaryChunks(input),
+            chunkIndexes: indexMessageChunks(input.messages, chunks),
           },
         };
-      case "oversizedFallback":
+      }
+      case "oversizedFallback": {
+        const plan = buildOversizedFallbackPlan(input);
+        const indexByMessage = new Map(input.messages.map((message, index) => [message, index]));
         return {
           status: "ok",
           value: {
             kind: "oversizedFallback",
-            ...buildOversizedFallbackPlan(input),
+            smallMessageIndexes: indexSelectedMessages(indexByMessage, plan.smallMessages),
+            oversizedNotes: plan.oversizedNotes,
           },
         };
-      case "stageSplit":
+      }
+      case "stageSplit": {
+        const plan = buildStageSplitPlan(input);
         return {
           status: "ok",
-          value: {
-            kind: "stageSplit",
-            ...buildStageSplitPlan(input),
-          },
+          value:
+            plan.mode === "split"
+              ? {
+                  kind: "stageSplit",
+                  mode: "split",
+                  chunkIndexes: indexMessageChunks(input.messages, plan.chunks),
+                }
+              : { kind: "stageSplit", mode: "single" },
         };
+      }
       case "historyPrune":
         return {
           status: "ok",

--- a/src/agents/compaction.token-sanitize.test.ts
+++ b/src/agents/compaction.token-sanitize.test.ts
@@ -1,5 +1,5 @@
 // Verifies compaction token planning strips private/non-model fields first.
-import type { AgentMessage } from "openclaw/plugin-sdk/agent-core";
+import { serializeConversation, type AgentMessage } from "openclaw/plugin-sdk/agent-core";
 import { describe, expect, it, vi } from "vitest";
 
 const agentSessionMocks = vi.hoisted(() => ({
@@ -21,6 +21,8 @@ vi.mock("openclaw/plugin-sdk/agent-sessions", async () => {
 import {
   buildStageSplitPlan,
   buildSummaryChunks,
+  estimateMessagesTokens,
+  projectCompactionMessagesForPlanning,
   sanitizeCompactionMessages,
 } from "./compaction-planning.js";
 
@@ -87,5 +89,203 @@ describe("compaction token accounting sanitization", () => {
     expect(sanitized).toHaveLength(2);
     expect(sanitized[0]).not.toHaveProperty("details");
     expect(sanitized.map((message) => message.role)).toEqual(["toolResult", "user"]);
+  });
+
+  it("bounds oversized tool-result text before worker cloning while preserving token pressure", () => {
+    const hugeText = "x".repeat(120_000);
+    const messages: AgentMessage[] = [
+      {
+        role: "toolResult",
+        toolCallId: "call_1",
+        toolName: "browser",
+        isError: false,
+        content: [{ type: "text", text: hugeText }],
+        timestamp: 1,
+      } satisfies AgentMessage,
+    ];
+
+    const projected = projectCompactionMessagesForPlanning(messages);
+    const originalJson = JSON.stringify(messages);
+    const projectedJson = JSON.stringify(projected);
+
+    expect(projectedJson.length).toBeLessThan(originalJson.length / 4);
+    expect(projectedJson).not.toContain(hugeText);
+    expect(estimateMessagesTokens(projected)).toBeGreaterThanOrEqual(
+      estimateMessagesTokens(messages),
+    );
+  });
+
+  it("bounds thinking and nested tool-call arguments before worker cloning", () => {
+    const hugeText = "\n".repeat(120_000);
+    const unmeasurableArgument = "\ud800".repeat(200_000);
+    const messages: AgentMessage[] = [
+      {
+        role: "assistant",
+        api: "openai-completions",
+        provider: "openai",
+        model: "gpt-5.6-luna",
+        content: [
+          { type: "thinking", thinking: hugeText, thinkingSignature: hugeText },
+          {
+            type: "toolCall",
+            id: "call_large",
+            name: "write",
+            thoughtSignature: hugeText,
+            arguments: {
+              content: hugeText,
+              unmeasurableArgument,
+              nested: { note: hugeText },
+              values: Array.from({ length: 50_000 }, (_, index) => index),
+            },
+          },
+        ],
+        usage: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 0,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+        stopReason: "toolUse",
+        timestamp: 1,
+      },
+    ];
+
+    const projected = projectCompactionMessagesForPlanning(messages);
+    const projectedJson = JSON.stringify(projected);
+    const projectedAssistant = projected[0];
+
+    expect(projectedJson.length).toBeLessThan(JSON.stringify(messages).length / 4);
+    expect(projectedJson).not.toContain(hugeText);
+    expect(projectedAssistant?.role).toBe("assistant");
+    if (!projectedAssistant || projectedAssistant.role !== "assistant") {
+      throw new Error("expected projected assistant");
+    }
+    const projectedToolCall = projectedAssistant.content.find((block) => block.type === "toolCall");
+    if (!projectedToolCall || projectedToolCall.type !== "toolCall") {
+      throw new Error("expected projected tool call");
+    }
+    expect(projectedToolCall.arguments).toEqual({});
+    expect(estimateMessagesTokens(projected)).toBeGreaterThan(Number.MAX_SAFE_INTEGER / 8);
+  });
+
+  it("bounds aggregate planning payloads and custom message variants", () => {
+    const hugeText = "x".repeat(32_768);
+    const customMessage = {
+      role: "custom" as const,
+      customType: "test",
+      content: "visible",
+      display: false,
+      details: { raw: hugeText },
+      timestamp: 0,
+    } satisfies AgentMessage;
+    const messages: AgentMessage[] = [
+      customMessage,
+      {
+        role: "bashExecution",
+        command: hugeText,
+        output: hugeText,
+        exitCode: 0,
+        cancelled: false,
+        truncated: false,
+        timestamp: 1,
+      },
+      { role: "branchSummary", summary: hugeText, fromId: "branch", timestamp: 2 },
+      { role: "compactionSummary", summary: hugeText, tokensBefore: 1, timestamp: 3 },
+      ...Array.from({ length: 64 }, (_, index) => ({
+        role: "user" as const,
+        content: hugeText,
+        timestamp: index + 4,
+      })),
+    ];
+
+    const projected = projectCompactionMessagesForPlanning(messages);
+    const projectedJson = JSON.stringify(projected);
+    const projectedCustom = projected[0];
+
+    expect(projectedJson.length).toBeLessThan(JSON.stringify(messages).length / 4);
+    expect(projectedCustom).not.toHaveProperty("details");
+    expect(estimateMessagesTokens(projected)).toBeGreaterThanOrEqual(
+      estimateMessagesTokens(messages),
+    );
+  });
+
+  it("keeps later small tool calls within a realistic token estimate", () => {
+    const messages: AgentMessage[] = [
+      ...Array.from({ length: 8 }, (_, index) => ({
+        role: "user" as const,
+        content: "x".repeat(32_768),
+        timestamp: index,
+      })),
+      {
+        role: "assistant",
+        api: "openai-completions",
+        provider: "openai",
+        model: "gpt-5.6-luna",
+        content: [{ type: "toolCall", id: "call_late", name: "read", arguments: { path: "x" } }],
+        usage: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 0,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+        stopReason: "toolUse",
+        timestamp: 9,
+      } satisfies AgentMessage,
+    ];
+
+    const projected = projectCompactionMessagesForPlanning(messages);
+    const last = projected.at(-1);
+
+    expect(last?.role).toBe("assistant");
+    expect(estimateMessagesTokens(last ? [last] : [])).toBeLessThan(100);
+  });
+
+  it("removes tool-result image bytes while preserving image pressure and summary semantics", () => {
+    const imageData = "a".repeat(1_000_000);
+    const userImageMessage = {
+      role: "user",
+      content: [
+        { type: "text", text: "describe this image" },
+        { type: "image", data: imageData, mimeType: "image/png" },
+      ],
+      timestamp: 0,
+    } satisfies AgentMessage;
+    const imageMessage = {
+      role: "toolResult",
+      toolCallId: "call_image",
+      toolName: "browser",
+      isError: false,
+      content: [{ type: "image", data: imageData, mimeType: "image/png" }],
+      timestamp: 1,
+    } satisfies AgentMessage;
+    const messages: AgentMessage[] = [userImageMessage, imageMessage];
+
+    const projected = projectCompactionMessagesForPlanning(messages);
+    const projectedUserMessage = projected[0];
+    expect(projectedUserMessage?.role).toBe("user");
+    if (!projectedUserMessage || projectedUserMessage.role !== "user") {
+      throw new Error("expected projected user message");
+    }
+    const projectedUserImage = Array.isArray(projectedUserMessage.content)
+      ? projectedUserMessage.content[1]
+      : undefined;
+    const projectedMessage = projected[1];
+    expect(projectedMessage?.role).toBe("toolResult");
+    if (!projectedMessage || projectedMessage.role !== "toolResult") {
+      throw new Error("expected projected tool result");
+    }
+    const projectedImage = projectedMessage.content[0];
+
+    expect(projectedUserImage).toMatchObject({ type: "image", data: "", mimeType: "image/png" });
+    expect(projectedImage).toMatchObject({ type: "image", data: "", mimeType: "image/png" });
+    expect(JSON.stringify(projected)).not.toContain(imageData);
+    expect(estimateMessagesTokens(projected)).toBe(estimateMessagesTokens(messages));
+    expect(serializeConversation([projectedUserMessage, projectedMessage])).toBe(
+      serializeConversation([userImageMessage, imageMessage]),
+    );
   });
 });


### PR DESCRIPTION
Closes #100635
Related: #103153

## What Problem This Solves

Fixes an issue where compaction planning could structured-clone very large transcript payloads into its worker before planning had a chance to reduce them. Large tool output, image bytes, reasoning data, and deeply nested tool arguments could stall the event loop or exhaust memory while a compaction plan was being selected.

## Why This Change Was Made

Selection-only planning now receives a bounded projection and returns indexes, letting the owner restore the exact sanitized source messages only after planning. Token pressure remains conservative, including a saturation path for arguments that cannot be measured safely. History-prune planning remains on the owner thread because it repairs tool/result pairs and needs exact message fidelity.

Tool-call identifiers deliberately have no remapping protocol. They are provider-generated and bounded in practice; pathological arbitrarily large identifiers are outside the product input contract. The code records that named tradeoff at the projection boundary.

## User Impact

Large and multimodal conversations should avoid unnecessary worker-clone memory pressure while producing the same sanitized messages for downstream compaction summaries. Users keep the existing tool/result repair behavior in history pruning.

## Evidence

- `node scripts/run-vitest.mjs src/agents/compaction-planning-worker.test.ts src/agents/compaction.token-sanitize.test.ts` — 16 tests passed after the final rebase.
- Blacksmith changed-surface gate — core production/test typechecks, formatting, lint, import-cycle, database/state, dependency, and Plugin SDK guards passed. Run: https://github.com/openclaw/openclaw/actions/runs/29898800606
- The first hosted CI run exposed an unused production export for a test hook; the hook is now test-only again and the focused tests pass on the repaired head.
- Codex autoreview (`gpt-5.6-sol`, xhigh) — clean, no accepted/actionable findings, 0.91 confidence.
- `git diff --check` — passed.
- `git diff --numstat origin/main...HEAD` — six files, +783/-80; no config, dependency, migration, or protocol surface.

AI-assisted: yes. The previous candidate in #103153 is credited as prior art; this branch was independently reviewed, rebased, and validated.

Co-authored-by: Ho Lim <subhoya@gmail.com>
