### PR TITLE
test(ui): isolate chat pane lifecycle jsdom context

### DIFF
--- a/ui/src/pages/chat/chat-pane-lifecycle.test.ts
+++ b/ui/src/pages/chat/chat-pane-lifecycle.test.ts
@@ -1,5 +1,12 @@
 /* @vitest-environment jsdom */
+/* @vitest-environment-options {"url":"http://chat-pane-lifecycle.test/"} */
 
+// customElements is shared by every file in one jsdom context, but module
+// instances are not. A sibling file that registers openclaw-chat-pane and a
+// later vi.resetModules() leave this file creating panes from a stale module
+// graph, whose dismisser WeakMap and chat-thread bindings differ from the ones
+// imported here. The dedicated context keeps tag registration and imports on
+// one graph.
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { SessionCapability } from "../../lib/sessions/index.ts";


### PR DESCRIPTION
## What Problem This Solves

Two tests in `ui/src/pages/chat/chat-pane-lifecycle.test.ts` failed intermittently in CI and passed on rerun of the identical SHA, blocking unrelated PRs:

- `dismisses only confirmations owned by the disconnected pane` — `expected "removeEventListener" to be called with arguments: [ 'click', ... ]; Number of calls: 0`
- `dismisses the previous session confirmation before switching in place` — expected a thrown `Error`, got `TypeError: Cannot read properties of undefined (reading 'agent:main:current^@agent:main')`

Seen most recently on #112536 (https://github.com/openclaw/openclaw/actions/runs/29894898428), whose diff was wizard i18n copy plus README and could not reach this code path.

## Why This Change Was Made

`customElements` is shared by every test file in one jsdom context, but module instances are not. When a sibling file registers `openclaw-chat-pane` and a later `vi.resetModules()` clears the module registry, this file ends up creating panes from a stale module graph while its own imports resolve to a fresh one. That single divergence produces both failures:

1. The pane's `dismissDeleteConfirm` consults the `deleteConfirmDismissers` WeakMap in *its* `chat-message` instance (`ui/src/pages/chat/components/chat-message.ts:1268`). Against a stale graph the lookup misses, so it falls back to a bare `element.remove()` — the popover disappears without any `removeEventListener` call, which is exactly the observed assertion failure.
2. `vi.spyOn(chatThread, "resetChatThreadPresentationState")` patches a namespace object the stale pane never reads, so the real `switchPaneSession` runs on to `ui/src/pages/chat/chat-pane.ts:939`, where `state.chatComposerFallbackByScope[previousComposerScopeKey]` is undefined on the test's fake state — the observed `TypeError`.

Instrumented proof of the mechanism: after `disconnectedCallback` the pane's popover was gone with **0** `removeEventListener` calls, while dismissing the sibling popover through the test file's own module instance produced **2** calls. Same element type, same code path, different module instance.

The fix follows the precedent set in #102869 (`test(ui): isolate chat pane custom-element registration`): a distinct `@vitest-environment-options` URL gives the file its own jsdom context, so tag registration and imports stay on one graph. No production code changes — module duplication is a test-harness artifact and cannot occur in a browser, where modules load once.

## User Impact

None. Test-only change; no runtime, config, or API surface is touched. CI stops failing intermittently on this file.

## Evidence

A/B on one Blacksmith Testbox lease (`tbx_01ky47wp0d1qtpn71whq2m8w7k`), using `OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test ui/src/pages`, which raises the hit rate considerably versus sharded CI:

- **Baseline (without fix): 2 of 3 runs failed** — run1 and run3 reproduced both original assertion failures verbatim; run2 passed.
- **With fix: 10 of 10 runs passed** (runs 1-10). If the change were inert, ten clean runs at the observed failure rate would occur well under 1% of the time.

Also run: autoreview (Codex `gpt-5.6-sol`, xhigh) — clean, no accepted/actionable findings, TruffleHog clean.

Note for follow-up, out of scope here: other UI files are independently order/timing sensitive. Across these runs `ui/src/components/board/board-view.test.ts` failed on timing assertions (`expected "vi.fn()" to be called 2 times, but got 1`), and full-suite failure counts varied run to run. That is a separate flake from this one.
