### PR TITLE
feat(media): thread ordered media facts through the prompt path

### DIFF
--- a/extensions/tlon/src/monitor/index.ts
+++ b/extensions/tlon/src/monitor/index.ts
@@ -1,7 +1,7 @@
 import { resolveHumanDelayConfig } from "openclaw/plugin-sdk/agent-runtime";
 import { createChannelInboundEnvelopeBuilder } from "openclaw/plugin-sdk/channel-inbound";
 import { bindIngressLifecycleToReplyOptions } from "openclaw/plugin-sdk/channel-outbound";
-import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
+import type { GetReplyOptions, ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime";
 import { sleepWithAbort } from "openclaw/plugin-sdk/runtime-env";
 import { asFiniteNumber } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -29,7 +29,7 @@ import { createTlonCitationResolver } from "./cites.js";
 import { fetchAllChannels, fetchInitData } from "./discovery.js";
 import { cacheMessage, fetchThreadHistory, getChannelHistory } from "./history.js";
 import { createTlonIngressMonitor, type TlonIngressLifecycle } from "./ingress.js";
-import { downloadMessageImages } from "./media.js";
+import { buildTlonInboundMediaPrompt, downloadMessageImages } from "./media.js";
 import {
   applyTlonSettingsOverrides,
   buildTlonSettingsMigrations,
@@ -495,19 +495,13 @@ export async function monitorTlonProvider(opts: MonitorTlonOpts = {}): Promise<v
       }
     }
 
-    let bodyWithAttachments = messageText;
-    if (attachments.length > 0) {
-      const mediaLines = attachments
-        .map((a) => `[media attached: ${a.path} (${a.contentType}) | ${a.path}]`)
-        .join("\n");
-      bodyWithAttachments = mediaLines + "\n" + messageText;
-    }
+    const promptMedia = buildTlonInboundMediaPrompt(messageText, attachments);
 
     const body = createChannelInboundEnvelopeBuilder({ cfg, route })({
       channel: "Tlon",
       from: fromLabel,
       timestamp,
-      body: bodyWithAttachments,
+      body: promptMedia.body,
     });
 
     const commandBody = isGroup ? stripBotMention(messageText, botShipName) : messageText;
@@ -595,6 +589,10 @@ export async function monitorTlonProvider(opts: MonitorTlonOpts = {}): Promise<v
       runtime.log?.(`[tlon] Now tracking thread for future replies: ${parentId}`);
     };
 
+    const replyOptions: GetReplyOptions = {
+      ...(turnAdoptionLifecycle ? bindIngressLifecycleToReplyOptions(turnAdoptionLifecycle) : {}),
+      ...(promptMedia.media.length > 0 ? { media: promptMedia.media } : {}),
+    };
     await core.channel.inbound.dispatch({
       channel: "tlon",
       accountId: route.accountId,
@@ -654,9 +652,7 @@ export async function monitorTlonProvider(opts: MonitorTlonOpts = {}): Promise<v
         responsePrefix,
         humanDelay,
       },
-      ...(turnAdoptionLifecycle
-        ? { replyOptions: bindIngressLifecycleToReplyOptions(turnAdoptionLifecycle) }
-        : {}),
+      ...(turnAdoptionLifecycle || promptMedia.media.length > 0 ? { replyOptions } : {}),
       record: {
         onRecordError: (err) => {
           runtime.error?.(`[tlon] failed updating session meta: ${String(err)}`);

--- a/extensions/tlon/src/monitor/media.test.ts
+++ b/extensions/tlon/src/monitor/media.test.ts
@@ -5,7 +5,7 @@ import {
   saveRemoteMedia,
 } from "openclaw/plugin-sdk/media-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { downloadMessageImages } from "./media.js";
+import { buildTlonInboundMediaPrompt, downloadMessageImages } from "./media.js";
 
 vi.mock("openclaw/plugin-sdk/media-runtime", () => ({
   MAX_IMAGE_BYTES: 6 * 1024 * 1024,
@@ -44,6 +44,25 @@ describe("tlon monitor media", () => {
     expect(saveRemoteMediaMock.mock.calls.map(([options]) => options.url)).toEqual(
       Array.from({ length: 8 }, (_, index) => `https://example.com/${index}.png`),
     );
+  });
+
+  it("keeps the duplicated path projection byte-stable beside ordered facts", () => {
+    expect(
+      buildTlonInboundMediaPrompt("caption", [
+        { path: "/tmp/a.png", contentType: "image/png" },
+        { path: "/tmp/b.jpg", contentType: "image/jpeg" },
+      ]),
+    ).toEqual({
+      body: [
+        "[media attached: /tmp/a.png (image/png) | /tmp/a.png]",
+        "[media attached: /tmp/b.jpg (image/jpeg) | /tmp/b.jpg]",
+        "caption",
+      ].join("\n"),
+      media: [
+        { path: "/tmp/a.png", contentType: "image/png" },
+        { path: "/tmp/b.jpg", contentType: "image/jpeg" },
+      ],
+    });
   });
 
   it("stores fetched media through the shared inbound media store with the image cap", async () => {

--- a/extensions/tlon/src/monitor/media.ts
+++ b/extensions/tlon/src/monitor/media.ts
@@ -25,6 +25,26 @@ interface DownloadedMedia {
   originalUrl: string;
 }
 
+type TlonInboundMedia = { path: string; contentType: string };
+
+/** Keeps Tlon's shipped path-duplicating prompt bytes paired with ordered facts. */
+export function buildTlonInboundMediaPrompt(
+  messageText: string,
+  attachments: readonly TlonInboundMedia[],
+): { body: string; media: TlonInboundMedia[] } {
+  const media = attachments.map((attachment) => ({ ...attachment }));
+  if (media.length === 0) {
+    return { body: messageText, media };
+  }
+  const mediaLines = media
+    .map(
+      (attachment) =>
+        `[media attached: ${attachment.path} (${attachment.contentType}) | ${attachment.path}]`,
+    )
+    .join("\n");
+  return { body: `${mediaLines}\n${messageText}`, media };
+}
+
 /**
  * Extract image blocks from Tlon message content.
  * Returns array of image URLs found in the message.

--- a/src/agents/cli-runner/types.ts
+++ b/src/agents/cli-runner/types.ts
@@ -16,6 +16,7 @@ import type { CliBackendConfig } from "../../config/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { ContextEngine } from "../../context-engine/types.js";
 import type { ImageContent } from "../../llm/types.js";
+import type { MediaFact } from "../../media/media-facts.js";
 import type { PromptImageOrderEntry } from "../../media/prompt-image-order.js";
 import type { CliBackendExecutionMode } from "../../plugins/cli-backend.types.js";
 import type { PluginHookChannelContext } from "../../plugins/hook-types.js";
@@ -148,6 +149,8 @@ export type RunCliAgentParams = {
   bootstrapContextRunKind?: BootstrapContextRunKind;
   images?: ImageContent[];
   imageOrder?: PromptImageOrderEntry[];
+  /** Ordered facts represented by attachment text in the current prompt. */
+  media?: MediaFact[];
   skillsSnapshot?: SkillSnapshot;
   messageChannel?: string;
   messageProvider?: string;

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -800,6 +800,7 @@ export function runAgentAttempt(params: {
             // accompany every CLI process. Native dedupe requires a runtime receipt.
             images: params.opts.images,
             imageOrder: params.opts.imageOrder,
+            media: params.opts.media,
             skillsSnapshot: params.skillsSnapshot,
             messageChannel: params.messageChannel,
             streamParams: params.opts.streamParams,
@@ -922,6 +923,7 @@ export function runAgentAttempt(params: {
     // removes the persisted CLI turn before the embedded prompt is submitted.
     images: shouldForwardImagesToEmbedded ? params.opts.images : undefined,
     imageOrder: shouldForwardImagesToEmbedded ? params.opts.imageOrder : undefined,
+    media: params.opts.media,
     clientTools: params.opts.clientTools,
     provider: embeddedAgentProvider,
     model: params.modelOverride,

--- a/src/agents/command/types.ts
+++ b/src/agents/command/types.ts
@@ -7,6 +7,7 @@ import type { SpawnedRunMetadata } from "../../agents/spawned-context.js";
 import type { PromptMode } from "../../agents/system-prompt.types.js";
 import type { SourceReplyDeliveryMode } from "../../auto-reply/get-reply-options.types.js";
 import type { ChannelOutboundTargetMode } from "../../channels/plugins/types.public.js";
+import type { MediaFact } from "../../media/media-facts.js";
 import type { PromptImageOrderEntry } from "../../media/prompt-image-order.js";
 import type { PluginHookChannelContext } from "../../plugins/hook-types.js";
 import type { RuntimePluginToolGrant } from "../../plugins/runtime/tool-grant.js";
@@ -61,6 +62,8 @@ export type AgentCommandOpts = {
   images?: ImageContent[];
   /** Original inline/offloaded attachment order for inbound images. */
   imageOrder?: PromptImageOrderEntry[];
+  /** Ordered facts represented by attachment text in this prompt. */
+  media?: MediaFact[];
   /** Optional client-provided tools (OpenResponses hosted tools). */
   clientTools?: ClientToolDefinition[];
   /** Agent id override (must exist in config). */

--- a/src/agents/embedded-agent-runner/cli-backend-dispatch.test.ts
+++ b/src/agents/embedded-agent-runner/cli-backend-dispatch.test.ts
@@ -383,6 +383,17 @@ describe("runEmbeddedAgentViaCliBackendIfEligible execution", () => {
     expect(onExecutionStarted).toHaveBeenCalledWith({ lifecycleGeneration: "gen-1" });
   });
 
+  it("retains prompt media facts through the embedded-to-CLI bridge", async () => {
+    const media = [{ path: "/tmp/recall.png", contentType: "image/png" }];
+
+    await runEmbeddedAgentViaCliBackendIfEligible(baseRunParams({ media }));
+
+    expect(runCliAgent.mock.calls[0]?.[0]).toMatchObject({
+      prompt: "recall prompt",
+      media,
+    });
+  });
+
   it("forwards execution phases from the CLI backend", async () => {
     const onExecutionPhase = vi.fn();
     runCliAgent.mockImplementation(

--- a/src/agents/embedded-agent-runner/cli-backend-dispatch.ts
+++ b/src/agents/embedded-agent-runner/cli-backend-dispatch.ts
@@ -193,6 +193,7 @@ async function runEmbeddedAgentViaCliBackend(
       agentDir: params.agentDir,
       config: params.config,
       prompt: params.prompt,
+      media: params.media,
       provider: dispatch.provider,
       model: params.model,
       thinkLevel: params.thinkLevel,

--- a/src/agents/embedded-agent-runner/run/attempt-before-agent-run.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-before-agent-run.test.ts
@@ -86,12 +86,13 @@ describe("runEmbeddedAttemptBeforeAgentRun", () => {
     const { input, lock, state } = createInput([
       { pluginId: "policy", hookName: "before_agent_run", handler, source: "test" },
     ]);
+    input.modelPrompt = "[media attached: /tmp/a.png (image/png)]\ninspect this";
 
     await expect(runEmbeddedAttemptBeforeAgentRun(input)).resolves.toBeUndefined();
 
     expect(handler).toHaveBeenCalledWith(
       expect.objectContaining({
-        prompt: "model prompt",
+        prompt: "[media attached: /tmp/a.png (image/png)]\ninspect this",
         systemPrompt: "system prompt",
         channelId: undefined,
         accountId: "account-1",

--- a/src/agents/embedded-agent-runner/run/attempt.llm-boundary.cache-stability.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.llm-boundary.cache-stability.test.ts
@@ -27,6 +27,7 @@ import { loadTranscriptEvents } from "../../../config/sessions/session-accessor.
 import { buildTimestampPrefix } from "../../../gateway/server-methods/agent-timestamp.js";
 import type { Context, Model } from "../../../llm/types.js";
 import {
+  buildLateMediaAttachedProjection,
   createUserTurnTranscriptRecorder,
   mergePreparedUserTurnMessageForRuntime,
   type UserTurnInput,
@@ -437,6 +438,15 @@ describe("append-only late media (issue #99495)", () => {
       expect(lateProvider?.content).toBe(
         `${EXPECTED_PREFIX_TURN1}[media attached: ${path.join(dir, "image.png")}]`,
       );
+      const lateProjection = buildLateMediaAttachedProjection(latePersisted as AgentMsg);
+      expect(lateProjection.text).toBe(`[media attached: ${path.join(dir, "image.png")}]`);
+      expect(lateProjection.media).toEqual([
+        expect.objectContaining({
+          path: path.join(dir, "image.png"),
+          contentType: "image/png",
+          kind: "image",
+        }),
+      ]);
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }

--- a/src/agents/embedded-agent-runner/run/attempt.llm-boundary.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.llm-boundary.ts
@@ -5,7 +5,7 @@ import { stripInboundMetadata } from "../../../auto-reply/reply/strip-inbound-me
 import { buildTimestampPrefix } from "../../../gateway/server-methods/agent-timestamp.js";
 import { INTER_SESSION_PROMPT_PREFIX_BASE } from "../../../sessions/input-provenance.js";
 import { hasPersistedMedia, MEDIA_ONLY_USER_TEXT } from "../../../sessions/user-turn-media.js";
-import { buildLateMediaAttachedText } from "../../../sessions/user-turn-transcript.js";
+import { buildLateMediaAttachedProjection } from "../../../sessions/user-turn-transcript.js";
 import { stripHistoricalRuntimeContextCustomMessages } from "../../internal-runtime-context.js";
 import type { AgentMessage } from "../../runtime/index.js";
 import { stripToolResultDetails } from "../../session-transcript-repair.js";
@@ -470,7 +470,7 @@ function stripHistoricalInboundMetadataFromUserMessages(
     const content = (message as { content?: unknown }).content;
     const injectMediaText = hasPersistedMedia(message) && !hasNonBlankUserText(content);
     // #111204: restore marked path lines here, never in UI-visible transcript storage.
-    const mediaOnlyText = buildLateMediaAttachedText(message) ?? MEDIA_ONLY_USER_TEXT;
+    const mediaOnlyText = buildLateMediaAttachedProjection(message).text ?? MEDIA_ONLY_USER_TEXT;
     const isActive = index === activeUserMessageIndex;
     const override = options?.currentUserTimestampOverride;
     const runtimeTimestamp = (message as { timestamp?: unknown }).timestamp;

--- a/src/agents/embedded-agent-runner/run/attempt.queue-message.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.queue-message.test.ts
@@ -54,6 +54,22 @@ describe("embedded OpenClaw queued steering cancellation", () => {
     expect(steer).toHaveBeenCalledWith("compare these", images);
   });
 
+  it("forwards ordered prompt facts with a queued steering message", async () => {
+    const steer = vi.fn(async () => undefined);
+    const media = [
+      { path: "/tmp/a.png", contentType: "image/png" },
+      { path: "/tmp/b.pdf", contentType: "application/pdf" },
+    ];
+    const activeSession: EmbeddedAgentActiveSessionSteerTarget = {
+      steer,
+      subscribe: () => () => {},
+    };
+
+    await steerActiveSessionWithOptionalDeliveryWait(activeSession, "inspect both", { media });
+
+    expect(steer).toHaveBeenCalledWith("inspect both", undefined, undefined, media);
+  });
+
   it("waits for the queued user message_end transcript boundary", async () => {
     // A queued steer is only durable once the user message_end event lands in
     // the active transcript.

--- a/src/agents/embedded-agent-runner/run/attempt.queue-message.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.queue-message.ts
@@ -3,6 +3,7 @@
  */
 import { toErrorObject } from "../../../infra/errors.js";
 import type { ImageContent } from "../../../llm/types.js";
+import type { MediaFact } from "../../../media/media-facts.js";
 import type { UserTurnTranscriptRecorder } from "../../../sessions/user-turn-transcript.types.js";
 import {
   cancelPendingAgentQuestionForSession,
@@ -22,12 +23,28 @@ type EmbeddedAgentActiveSessionSteerTarget = {
     text: string,
     images?: ImageContent[],
     userTurnTranscriptRecorder?: UserTurnTranscriptRecorder,
+    media?: MediaFact[],
   ): Promise<void>;
   subscribe(listener: (event: unknown) => void): () => void;
 };
 
 /** Default wait for a steered user message to appear in the active transcript. */
 const DEFAULT_QUEUE_TRANSCRIPT_COMMIT_TIMEOUT_MS = 120_000;
+
+function steerActiveSession(
+  activeSession: EmbeddedAgentActiveSessionSteerTarget,
+  text: string,
+  images?: ImageContent[],
+  userTurnTranscriptRecorder?: UserTurnTranscriptRecorder,
+  media?: MediaFact[],
+): Promise<void> {
+  if (media?.length) {
+    return activeSession.steer(text, images, userTurnTranscriptRecorder, media);
+  }
+  return userTurnTranscriptRecorder
+    ? activeSession.steer(text, images, userTurnTranscriptRecorder)
+    : activeSession.steer(text, images);
+}
 
 function extractQueuedUserMessageText(message: unknown): string | undefined {
   if (!message || typeof message !== "object") {
@@ -139,6 +156,7 @@ async function steerAndWaitForTranscriptCommit(
   timeoutMs: number,
   userTurnTranscriptRecorder?: UserTurnTranscriptRecorder,
   images?: ImageContent[],
+  media?: MediaFact[],
 ): Promise<void> {
   await new Promise<void>((resolve, reject) => {
     let settled = false;
@@ -219,9 +237,13 @@ async function steerAndWaitForTranscriptCommit(
         scheduleTerminalCancellation();
       }
     });
-    const steer = userTurnTranscriptRecorder
-      ? activeSession.steer(text, images, userTurnTranscriptRecorder)
-      : activeSession.steer(text, images);
+    const steer = steerActiveSession(
+      activeSession,
+      text,
+      images,
+      userTurnTranscriptRecorder,
+      media,
+    );
     steer.catch((err: unknown) => {
       finish(err);
     });
@@ -263,11 +285,13 @@ export async function steerActiveSessionWithOptionalDeliveryWait(
     return;
   }
   if (options?.waitForTranscriptCommit !== true) {
-    if (options?.userTurnTranscriptRecorder) {
-      await activeSession.steer(text, options.images, options.userTurnTranscriptRecorder);
-    } else {
-      await activeSession.steer(text, options?.images);
-    }
+    await steerActiveSession(
+      activeSession,
+      text,
+      options?.images,
+      options?.userTurnTranscriptRecorder,
+      options?.media,
+    );
     return;
   }
   await steerAndWaitForTranscriptCommit(
@@ -276,5 +300,6 @@ export async function steerActiveSessionWithOptionalDeliveryWait(
     options.deliveryTimeoutMs ?? DEFAULT_QUEUE_TRANSCRIPT_COMMIT_TIMEOUT_MS,
     options.userTurnTranscriptRecorder,
     options.images,
+    options.media,
   );
 }

--- a/src/agents/embedded-agent-runner/run/history-image-prune.ts
+++ b/src/agents/embedded-agent-runner/run/history-image-prune.ts
@@ -1,7 +1,7 @@
 /**
  * Prunes already-processed image payloads from replayed prompt history.
  */
-import { buildLateMediaAttachedText } from "../../../sessions/user-turn-transcript.js";
+import { buildLateMediaAttachedProjection } from "../../../sessions/user-turn-transcript.js";
 import type { AgentMessage } from "../../runtime/index.js";
 import { hasNonBlankUserText } from "./attempt.user-message-boundary.js";
 
@@ -97,7 +97,7 @@ export function pruneProcessedHistoryImages(messages: AgentMessage[]): AgentMess
     // Materialize blank marked turns here so this earlier boundary still prunes stale paths.
     const lateMediaText =
       message.role === "user" && !hasNonBlankUserText(message.content)
-        ? buildLateMediaAttachedText(message)
+        ? buildLateMediaAttachedProjection(message).text
         : undefined;
     const content = lateMediaText
       ? Array.isArray(message.content)

--- a/src/agents/embedded-agent-runner/run/params.ts
+++ b/src/agents/embedded-agent-runner/run/params.ts
@@ -15,6 +15,7 @@ import type { ChatType } from "../../../channels/chat-type.js";
 import type { InboundEventKind } from "../../../channels/inbound-event/kind.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import type { ImageContent } from "../../../llm/types.js";
+import type { MediaFact } from "../../../media/media-facts.js";
 import type { PromptImageOrderEntry } from "../../../media/prompt-image-order.js";
 import type { PluginHookChannelContext } from "../../../plugins/hook-types.js";
 import type { RuntimePluginToolGrant } from "../../../plugins/runtime/tool-grant.js";
@@ -189,6 +190,8 @@ export type RunEmbeddedAgentParams = {
   currentInboundContext?: CurrentInboundPromptContext;
   images?: ImageContent[];
   imageOrder?: PromptImageOrderEntry[];
+  /** Ordered facts represented by attachment text in the current prompt. */
+  media?: MediaFact[];
   /** Optional client-provided tools (OpenResponses hosted tools). */
   clientTools?: ClientToolDefinition[];
   /** Disable built-in tools for this run (LLM-only mode). */

--- a/src/agents/embedded-agent-runner/run/runtime-context-prompt.test.ts
+++ b/src/agents/embedded-agent-runner/run/runtime-context-prompt.test.ts
@@ -38,8 +38,9 @@ describe("runtime context prompt submission", () => {
   it("moves hidden runtime context out of the visible prompt", () => {
     // Hidden context is provider input, not user-authored transcript text; it
     // must be split before persistence and display.
+    const visiblePrompt = "[media attached: /tmp/a.png (image/png)]\nvisible ask";
     const effectivePrompt = [
-      "visible ask",
+      visiblePrompt,
       "",
       "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>",
       "secret runtime context",
@@ -49,10 +50,10 @@ describe("runtime context prompt submission", () => {
     expect(
       resolveRuntimeContextPromptParts({
         effectivePrompt,
-        transcriptPrompt: "visible ask",
+        transcriptPrompt: visiblePrompt,
       }),
     ).toEqual({
-      prompt: "visible ask",
+      prompt: visiblePrompt,
       runtimeContext:
         "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>\nsecret runtime context\n<<<END_OPENCLAW_INTERNAL_CONTEXT>>>",
     });

--- a/src/agents/sessions/agent-session-prompting.ts
+++ b/src/agents/sessions/agent-session-prompting.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from "node:fs";
 import type { ImageContent, TextContent } from "../../llm/types.js";
+import { attachRuntimePromptMediaFacts, type MediaFact } from "../../media/media-facts.js";
 import { attachRuntimeUserTurnTranscriptContext } from "../../sessions/user-turn-transcript-runtime-context.js";
 import type {
   PersistedUserTurnMessage,
@@ -320,6 +321,7 @@ export abstract class AgentSessionPrompting extends AgentSessionBase {
     text: string,
     images?: ImageContent[],
     userTurnTranscriptRecorder?: UserTurnTranscriptRecorder,
+    media?: MediaFact[],
   ): Promise<void> {
     // Check for extension commands (cannot be queued)
     if (text.startsWith("/")) {
@@ -337,6 +339,7 @@ export abstract class AgentSessionPrompting extends AgentSessionBase {
       preparedMessage && userTurnTranscriptRecorder
         ? { message: preparedMessage, recorder: userTurnTranscriptRecorder }
         : undefined,
+      media,
     );
   }
 
@@ -370,6 +373,7 @@ export abstract class AgentSessionPrompting extends AgentSessionBase {
       message: PersistedUserTurnMessage;
       recorder: UserTurnTranscriptRecorder;
     },
+    media?: MediaFact[],
   ): Promise<void> {
     this.steeringMessages.push(text);
     this.emitQueueUpdate();
@@ -378,10 +382,13 @@ export abstract class AgentSessionPrompting extends AgentSessionBase {
       content: this.createUserContent(text, images),
       timestamp: Date.now(),
     } satisfies PersistedUserTurnMessage;
+    const promptMessage = media?.length
+      ? attachRuntimePromptMediaFacts(runtimeMessage, media)
+      : runtimeMessage;
     this.agent.steer(
       transcriptContext
-        ? attachRuntimeUserTurnTranscriptContext(runtimeMessage, transcriptContext)
-        : runtimeMessage,
+        ? attachRuntimeUserTurnTranscriptContext(promptMessage, transcriptContext)
+        : promptMessage,
     );
   }
 

--- a/src/agents/sessions/sdk.test.ts
+++ b/src/agents/sessions/sdk.test.ts
@@ -290,6 +290,28 @@ describe("AgentSession queued user turns", () => {
       recorder,
     });
   });
+
+  it("carries prompt facts non-enumerably on the exact steered message", async () => {
+    const session = await createSessionFromManager(SessionManager.inMemory());
+    const steer = vi.spyOn(session.agent, "steer").mockImplementation(() => undefined);
+    const media = [{ path: "/tmp/a.png", contentType: "image/png" }];
+
+    await session.steer("[media attached: /tmp/a.png (image/png)]", undefined, undefined, media);
+
+    const runtimeMessage = steer.mock.calls[0]?.[0];
+    expect(runtimeMessage).toBeDefined();
+    const mediaSymbol = Object.getOwnPropertySymbols(runtimeMessage ?? {}).find(
+      (symbol) => Symbol.keyFor(symbol) === "openclaw.runtimePromptMediaFacts",
+    );
+    expect(mediaSymbol).toBeDefined();
+    if (!mediaSymbol) {
+      throw new Error("expected runtime prompt media symbol");
+    }
+    expect((runtimeMessage as unknown as Record<PropertyKey, unknown>)[mediaSymbol]).toEqual([
+      expect.objectContaining({ path: "/tmp/a.png", contentType: "image/png", kind: "image" }),
+    ]);
+    expect(JSON.stringify(runtimeMessage)).not.toContain("runtimePromptMediaFacts");
+  });
 });
 
 describe("createAgentSession attribution headers", () => {

--- a/src/auto-reply/get-reply-options.types.ts
+++ b/src/auto-reply/get-reply-options.types.ts
@@ -2,6 +2,7 @@ import type { FastMode } from "@openclaw/normalization-core/string-coerce";
 /** Public option types for reply generation callbacks, streaming, and delivery policy. */
 import type { AgentPlanStep } from "../channels/streaming.js";
 import type { ImageContent } from "../llm/types.js";
+import type { MediaFact } from "../media/media-facts.js";
 import type { PromptImageOrderEntry } from "../media/prompt-image-order.js";
 import type { UserTurnTranscriptRecorder } from "../sessions/user-turn-transcript.types.js";
 import type { ReplyPayload } from "./reply-payload.js";
@@ -109,6 +110,8 @@ export type GetReplyOptions = {
   images?: ImageContent[];
   /** Original inline/offloaded attachment order for inbound images. */
   imageOrder?: PromptImageOrderEntry[];
+  /** Ordered media facts whose model-facing text projection is already present in the prompt. */
+  media?: MediaFact[];
   /** Notifies when an agent run actually starts (useful for webchat command handling). */
   onAgentRunStart?: (runId: string) => void;
   /**

--- a/src/auto-reply/media-note.test.ts
+++ b/src/auto-reply/media-note.test.ts
@@ -2,11 +2,15 @@
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { getMediaDir } from "../media/store.js";
-import { buildInboundMediaNote } from "./media-note.js";
+import { buildInboundMediaNoteProjection } from "./media-note.js";
 import {
   createSuccessfulAudioMediaDecision,
   createSuccessfulImageMediaDecision,
 } from "./media-understanding.test-fixtures.js";
+
+const buildInboundMediaNote = (
+  ctx: Parameters<typeof buildInboundMediaNoteProjection>[0],
+): string | undefined => buildInboundMediaNoteProjection(ctx).text;
 
 describe("buildInboundMediaNote", () => {
   it("formats single MediaPath as a media note (collapses redundant duplicate URL, #47587)", () => {
@@ -373,5 +377,60 @@ describe("buildInboundMediaNote", () => {
       MediaUrl: "/tmp/a.png   ",
     });
     expect(note).toBe("[media attached: /tmp/a.png (image/png)]");
+  });
+
+  it("pairs byte-stable single and multi notes with their ordered facts", () => {
+    const single = buildInboundMediaNoteProjection({
+      media: [
+        {
+          path: "/tmp/a.png",
+          url: "https://example.com/a.png",
+          contentType: "image/png",
+          kind: "image",
+        },
+      ],
+      MediaPath: "/tmp/a.png",
+      MediaUrl: "https://example.com/a.png",
+      MediaType: "image/png",
+    });
+    expect(single).toEqual({
+      text: "[media attached: /tmp/a.png (image/png) | https://example.com/a.png]",
+      media: [
+        {
+          path: "/tmp/a.png",
+          url: "https://example.com/a.png",
+          contentType: "image/png",
+          kind: "image",
+          transcribed: false,
+          messageId: undefined,
+        },
+      ],
+    });
+
+    const multi = buildInboundMediaNoteProjection({
+      media: [
+        { path: "/tmp/a.png", contentType: "image/png" },
+        { path: "/tmp/b.pdf", contentType: "application/pdf" },
+      ],
+      MediaPaths: ["/tmp/a.png", "/tmp/b.pdf"],
+      MediaTypes: ["image/png", "application/pdf"],
+    });
+    expect(multi.text).toBe(
+      [
+        "[media attached: 2 files]",
+        "[media attached 1/2: /tmp/a.png (image/png)]",
+        "[media attached 2/2: /tmp/b.pdf (application/pdf)]",
+      ].join("\n"),
+    );
+    expect(
+      multi.media.map(({ path: pathValue, contentType, kind }) => ({
+        path: pathValue,
+        contentType,
+        kind,
+      })),
+    ).toEqual([
+      { path: "/tmp/a.png", contentType: "image/png", kind: "image" },
+      { path: "/tmp/b.pdf", contentType: "application/pdf", kind: "document" },
+    ]);
   });
 });

--- a/src/auto-reply/media-note.ts
+++ b/src/auto-reply/media-note.ts
@@ -1,6 +1,7 @@
 /** Builds compact prompt notes for inbound media attachments. */
 import path from "node:path";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import { normalizeMediaFacts, resolveMediaFacts, type MediaFact } from "../media/media-facts.js";
 import { getMediaDir } from "../media/store.js";
 import type { MsgContext } from "./templating.js";
 
@@ -130,8 +131,13 @@ function collectTranscribedAudioAttachmentIndices(
   return transcribedAudioIndices;
 }
 
-/** Formats a prompt-visible media attachment note, omitting audio already represented by transcript. */
-export function buildInboundMediaNote(ctx: MsgContext): string | undefined {
+type InboundMediaNoteProjection = {
+  text?: string;
+  media: MediaFact[];
+};
+
+/** Formats prompt-visible attachment text and retains the facts represented by it. */
+export function buildInboundMediaNoteProjection(ctx: MsgContext): InboundMediaNoteProjection {
   // Attachment indices follow MediaPaths/MediaUrls ordering as supplied by the channel.
   const pathsFromArray = Array.isArray(ctx.MediaPaths) ? ctx.MediaPaths : undefined;
   const paths =
@@ -141,7 +147,7 @@ export function buildInboundMediaNote(ctx: MsgContext): string | undefined {
         ? [ctx.MediaPath.trim()]
         : [];
   if (paths.length === 0) {
-    return undefined;
+    return { media: [] };
   }
 
   const transcribedAudioIndices = collectTranscribedAudioAttachmentIndices(ctx, paths.length);
@@ -187,14 +193,26 @@ export function buildInboundMediaNote(ctx: MsgContext): string | undefined {
       return true;
     });
   if (entries.length === 0) {
-    return undefined;
+    return { media: [] };
   }
+  const facts = resolveMediaFacts(ctx);
+  const media = normalizeMediaFacts(
+    entries.map((entry) => ({
+      ...facts[entry.index],
+      path: entry.path,
+      url: entry.url,
+      contentType: entry.type,
+    })),
+  );
   if (entries.length === 1) {
-    return formatMediaAttachedLine({
-      path: entries[0]?.path ?? "",
-      type: entries[0]?.type,
-      url: entries[0]?.url,
-    });
+    return {
+      text: formatMediaAttachedLine({
+        path: entries[0]?.path ?? "",
+        type: entries[0]?.type,
+        url: entries[0]?.url,
+      }),
+      media,
+    };
   }
 
   const count = entries.length;
@@ -210,5 +228,5 @@ export function buildInboundMediaNote(ctx: MsgContext): string | undefined {
       }),
     );
   }
-  return lines.join("\n");
+  return { text: lines.join("\n"), media };
 }

--- a/src/auto-reply/reply.media-note.test.ts
+++ b/src/auto-reply/reply.media-note.test.ts
@@ -13,7 +13,7 @@ describe("getReplyFromConfig media note plumbing", () => {
       MediaPaths: ["/tmp/a.png", "/tmp/b.png"],
       MediaUrls: ["/tmp/a.png", "/tmp/b.png"],
     });
-    const prompt = buildReplyPromptEnvelope({
+    const envelope = buildReplyPromptEnvelope({
       ctx: sessionCtx,
       sessionCtx,
       baseBody: sessionCtx.BodyForAgent,
@@ -22,9 +22,20 @@ describe("getReplyFromConfig media note plumbing", () => {
       isBareSessionReset: false,
       startupAction: "new",
       prefixedBody: sessionCtx.BodyForAgent,
-    }).prefixedCommandBody;
+    });
+    const prompt = envelope.prefixedCommandBody;
 
-    expect(prompt).toContain("[media attached: 2 files]");
+    const mediaNote = [
+      "[media attached: 2 files]",
+      "[media attached 1/2: /tmp/a.png (application/octet-stream)]",
+      "[media attached 2/2: /tmp/b.png (application/octet-stream)]",
+    ].join("\n");
+    const replyHint =
+      "To send an image back, use the message tool with structured media fields such as media, mediaUrl, path, or filePath. Keep caption in the text body.";
+    expect(prompt).toBe(`${mediaNote}\n${replyHint}\nhello`);
+    expect(envelope.queuedBody).toBe(`${mediaNote}\n${replyHint}\nhello`);
+    expect(envelope.transcriptCommandBody).toBe(`${mediaNote}\nhello`);
+    expect(envelope.media?.map(({ path }) => path)).toEqual(["/tmp/a.png", "/tmp/b.png"]);
     const idxA = prompt.indexOf("[media attached 1/2: /tmp/a.png");
     const idxB = prompt.indexOf("[media attached 2/2: /tmp/b.png");
     expect(idxA).toBeGreaterThanOrEqual(0);

--- a/src/auto-reply/reply/agent-runner-cli-candidate.ts
+++ b/src/auto-reply/reply/agent-runner-cli-candidate.ts
@@ -241,6 +241,7 @@ export async function runCliFallbackCandidate(params: {
             config: params.runtimeConfig,
             prompt: turn.commandBody,
             transcriptPrompt: turn.transcriptCommandBody,
+            media: turn.followupRun.media,
             suppressNextUserMessagePersistence: params.suppressQueuedUserPersistenceForCandidate,
             userTurnTranscriptRecorder: params.userTurnTranscriptRecorder,
             onUserMessagePersisted: params.notifyUserMessagePersisted,

--- a/src/auto-reply/reply/agent-runner-embedded-candidate.ts
+++ b/src/auto-reply/reply/agent-runner-embedded-candidate.ts
@@ -210,6 +210,7 @@ export async function runEmbeddedFallbackCandidate(params: {
         sandboxSessionKey: turn.runtimePolicySessionKey,
         prompt: turn.commandBody,
         transcriptPrompt: turn.transcriptCommandBody,
+        media: turn.followupRun.media,
         userTurnTranscriptRecorder: params.userTurnTranscriptRecorder,
         currentInboundEventKind: turn.followupRun.currentInboundEventKind,
         currentInboundContext: turn.followupRun.currentInboundContext,

--- a/src/auto-reply/reply/agent-runner-execution-lifecycle.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-lifecycle.test.ts
@@ -86,6 +86,8 @@ describe("runAgentTurnWithFallback: run lifecycle and ownership", () => {
 
   it("freezes abort ownership only after model fallback settles", async () => {
     const { replyOperation, freezeAbortMock } = createMockReplyOperation();
+    const followupRun = createFollowupRun();
+    followupRun.media = [{ path: "/tmp/retry.png", contentType: "image/png" }];
     state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => {
       expect(freezeAbortMock).not.toHaveBeenCalled();
       await params.run("anthropic", "claude").catch(() => undefined);
@@ -108,11 +110,15 @@ describe("runAgentTurnWithFallback: run lifecycle and ownership", () => {
 
     const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
     await runAgentTurnWithFallback({
-      ...createMinimalRunAgentTurnParams(),
+      ...createMinimalRunAgentTurnParams({ followupRun }),
       replyOperation,
     });
 
     expect(state.runEmbeddedAgentMock).toHaveBeenCalledTimes(2);
+    expect(state.runEmbeddedAgentMock.mock.calls.map((call) => call[0]?.media)).toEqual([
+      followupRun.media,
+      followupRun.media,
+    ]);
     expect(freezeAbortMock).toHaveBeenCalledTimes(1);
   });
 
@@ -436,6 +442,7 @@ describe("runAgentTurnWithFallback: run lifecycle and ownership", () => {
     followupRun.run.provider = "codex-cli";
     followupRun.run.model = "gpt-5.4";
     followupRun.run.clientCaps = ["tool-events", "inline-widgets"];
+    followupRun.media = [{ path: "/tmp/cli.png", contentType: "image/png" }];
     const typingSignals = createMockTypingSignaler();
 
     const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
@@ -452,6 +459,7 @@ describe("runAgentTurnWithFallback: run lifecycle and ownership", () => {
       provider: "codex-cli",
       model: "gpt-5.4",
       clientCaps: ["tool-events", "inline-widgets"],
+      media: followupRun.media,
     });
   });
 

--- a/src/auto-reply/reply/agent-runner.media-paths.test.ts
+++ b/src/auto-reply/reply/agent-runner.media-paths.test.ts
@@ -463,6 +463,10 @@ describe("runReplyAgent media path normalization", () => {
     ];
     const followupRun = createMockFollowupRun({ prompt: "compare these" });
     followupRun.images = images;
+    followupRun.media = [
+      { path: "/tmp/first.jpg", contentType: "image/jpeg" },
+      { path: "/tmp/second.png", contentType: "image/png" },
+    ];
 
     await runReplyAgent(
       makeRunReplyAgentParams({
@@ -481,6 +485,7 @@ describe("runReplyAgent media path normalization", () => {
         steeringMode: "all",
         isInboundUserMessage: true,
         images,
+        media: followupRun.media,
         taskSuggestionDeliveryMode: undefined,
       },
     );

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1415,6 +1415,7 @@ export async function runReplyAgent(params: {
         steeringMode: "all",
         isInboundUserMessage: true,
         ...(followupRun.images?.length ? { images: followupRun.images } : {}),
+        ...(followupRun.media?.length ? { media: followupRun.media } : {}),
         ...(turnAdoptionLifecycle ? { waitForTranscriptCommit: true } : {}),
         ...(resolvedQueue.debounceMs !== undefined ? { debounceMs: resolvedQueue.debounceMs } : {}),
         ...(followupRun.run.sourceReplyDeliveryMode

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -560,6 +560,7 @@ export function createFollowupRunner(params: {
       .filter((end): end is () => void => typeof end === "function");
     const queuedImages = queued.images ?? opts?.images;
     const queuedImageOrder = queued.imageOrder ?? opts?.imageOrder;
+    const queuedMedia = queued.media ?? opts?.media;
     let replyOperation: ReplyOperation | undefined;
     let deferred = false;
     let failed = false;
@@ -1297,6 +1298,7 @@ export function createFollowupRunner(params: {
                           ],
                         images: queuedImages,
                         imageOrder: queuedImageOrder,
+                        media: queuedMedia,
                         skillsSnapshot: run.skillsSnapshot,
                         messageChannel: queued.originatingChannel ?? undefined,
                         messageProvider: resolveOriginMessageProvider({
@@ -1449,6 +1451,7 @@ export function createFollowupRunner(params: {
                 },
                 images: queuedImages,
                 imageOrder: queuedImageOrder,
+                media: queuedMedia,
                 allowTransientCooldownProbe: runOptions?.allowTransientCooldownProbe,
                 blockReplyBreak: run.blockReplyBreak,
                 bootstrapPromptWarningSignaturesSeen,

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -43,7 +43,7 @@ import { measureDiagnosticsTimelineSpan } from "../../infra/diagnostics-timeline
 import { isFastTestRuntimeEnv } from "../../infra/env.js";
 import { resolveHeartbeatRunScope } from "../../infra/heartbeat-run-scope.js";
 import type { ExtractedFileImage } from "../../media-understanding/extracted-file-images.js";
-import { resolveMediaFacts } from "../../media/media-facts.js";
+import { resolveMediaFacts, type MediaFact } from "../../media/media-facts.js";
 import { clearCommandLane, getQueueSize } from "../../process/command-queue.js";
 import {
   isAcpSessionKey,
@@ -932,6 +932,7 @@ export async function runPreparedReply(
     queuedBody: string;
     transcriptBody: string;
     transcriptCommandBody: string;
+    media?: MediaFact[];
     currentInboundContext?: typeof promptEnvelopeBase.currentInboundContext;
   }> => {
     if (!useFastReplyRuntime && heartbeatRunScope !== "commitment-only") {
@@ -964,6 +965,7 @@ export async function runPreparedReply(
       sourceReplyDeliveryMode,
       threadContextNote,
       systemEventBlocks: drainedSystemEventBlocks,
+      media: opts?.media,
     });
   };
   const skillResult = isFastTestRuntimeEnv()
@@ -998,6 +1000,7 @@ export async function runPreparedReply(
     queuedBody,
     transcriptBody,
     transcriptCommandBody,
+    media: promptMedia,
     currentInboundContext,
   } = await traceRunPhase("reply.build_prompt_bodies", () => rebuildPromptBodies());
   const isRoomEvent = inboundEventKind === "room_event";
@@ -1376,6 +1379,7 @@ export async function runPreparedReply(
           queuedBody,
           transcriptBody,
           transcriptCommandBody,
+          media: promptMedia,
           currentInboundContext,
         } = await traceRunPhase("reply.build_prompt_bodies", () => rebuildPromptBodies()));
       },
@@ -1462,7 +1466,7 @@ export async function runPreparedReply(
       : undefined);
   setChannelSourceTurnId(sessionCtx, sourceTurnId);
   const persistGroupSender = replyRoute.chatType === "group" || replyRoute.chatType === "channel";
-  const userTurnMediaForPersistence = resolveMediaFacts(ctx);
+  const userTurnMediaForPersistence = [...resolveMediaFacts(ctx), ...(opts?.media ?? [])];
   const inputProvenance = ctx.InputProvenance ?? sessionCtx.InputProvenance;
   const userTurnTimestamp = normalizeMessageTimestampMs(ctx.Timestamp);
   // prompt-prelude substitutes MEDIA_ONLY_USER_TEXT as transcriptBody for
@@ -1577,6 +1581,7 @@ export async function runPreparedReply(
     enqueuedAt: Date.now(),
     images: currentTurnImages.images,
     imageOrder: currentTurnImages.imageOrder,
+    media: promptMedia,
     // Originating channel for reply routing.
     originatingChannel: replyRoute.channel,
     originatingTo: replyRoute.to,

--- a/src/auto-reply/reply/prompt-prelude.test.ts
+++ b/src/auto-reply/reply/prompt-prelude.test.ts
@@ -291,6 +291,42 @@ describe("buildReplyPromptEnvelope", () => {
     expect(envelope.transcriptCommandBody).toContain("https://example.com/photo.jpg");
   });
 
+  it("carries preprojected media without duplicating its model-facing bytes", () => {
+    const body = "[media attached: /tmp/tlon.png (image/png) | /tmp/tlon.png]\ninspect this";
+    const sessionCtx = finalizeInboundContext({
+      Body: body,
+      BodyForAgent: body,
+      Provider: "tlon",
+      ChatType: "direct",
+    });
+    const media = [{ path: "/tmp/tlon.png", contentType: "image/png", kind: "image" as const }];
+
+    const envelope = buildReplyPromptEnvelope({
+      ctx: sessionCtx,
+      sessionCtx,
+      baseBody: body,
+      hasUserBody: true,
+      inboundUserContext: "",
+      isBareSessionReset: false,
+      startupAction: "new",
+      media,
+    });
+
+    expect(envelope.prefixedCommandBody).toBe(body);
+    expect(envelope.queuedBody).toBe(body);
+    expect(envelope.transcriptCommandBody).toBe(body);
+    expect(envelope.media).toEqual([
+      {
+        path: "/tmp/tlon.png",
+        url: undefined,
+        contentType: "image/png",
+        kind: "image",
+        transcribed: false,
+        messageId: undefined,
+      },
+    ]);
+  });
+
   it("keeps soft reset user notes visible without leaking startup context into transcripts", () => {
     const sessionCtx = finalizeInboundContext({
       Body: "",

--- a/src/auto-reply/reply/prompt-prelude.ts
+++ b/src/auto-reply/reply/prompt-prelude.ts
@@ -2,12 +2,13 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { CurrentInboundPromptContext } from "../../agents/embedded-agent-runner/run/params.js";
 import type { InboundEventKind } from "../../channels/inbound-event/kind.js";
+import { normalizeMediaFacts, type MediaFact } from "../../media/media-facts.js";
 import { MESSAGE_TOOL_ONLY_DELIVERY_HINT } from "../../plugin-sdk/message-tool-delivery-hints.js";
 import { annotateInterSessionPromptText } from "../../sessions/input-provenance.js";
 import { MEDIA_ONLY_USER_TEXT } from "../../sessions/user-turn-media.js";
 import type { SourceReplyDeliveryMode } from "../get-reply-options.types.js";
 import { HEARTBEAT_TRANSCRIPT_PROMPT } from "../heartbeat.js";
-import { buildInboundMediaNote } from "../media-note.js";
+import { buildInboundMediaNoteProjection } from "../media-note.js";
 import type { MsgContext, TemplateContext } from "../templating.js";
 import { appendUntrustedContext } from "./untrusted-context.js";
 
@@ -29,9 +30,12 @@ function buildReplyPromptBodies(params: {
   threadContextNote?: string;
   systemEventBlocks?: string[];
   inboundEventKind?: InboundEventKind;
+  /** Facts whose text projection is already present in a body variant. */
+  media?: readonly MediaFact[];
 }): {
   mediaNote?: string;
   mediaReplyHint?: string;
+  media?: MediaFact[];
   prefixedCommandBody: string;
   queuedBody: string;
   transcriptCommandBody: string;
@@ -49,7 +53,9 @@ function buildReplyPromptBodies(params: {
     .filter(Boolean)
     .join("\n\n");
   const queueBodyBase = [params.threadContextNote, bodyWithEvents].filter(Boolean).join("\n\n");
-  const mediaNote = buildInboundMediaNote(params.ctx);
+  const generatedMedia = buildInboundMediaNoteProjection(params.ctx);
+  const mediaNote = generatedMedia.text;
+  const media = [...generatedMedia.media, ...normalizeMediaFacts(params.media)];
   const mediaReplyHint = mediaNote ? REPLY_MEDIA_HINT : undefined;
   const queuedBodyRaw = mediaNote
     ? [mediaNote, mediaReplyHint, queueBodyBase].filter(Boolean).join("\n").trim()
@@ -69,6 +75,7 @@ function buildReplyPromptBodies(params: {
   return {
     mediaNote,
     mediaReplyHint,
+    ...(media.length > 0 ? { media } : {}),
     prefixedCommandBody: annotateInterSessionPromptText(
       prefixedCommandBodyRaw,
       params.sessionCtx.InputProvenance,
@@ -262,6 +269,8 @@ export function buildReplyPromptEnvelope(
     prefixedBody?: string;
     threadContextNote?: string;
     systemEventBlocks?: string[];
+    /** Facts whose model-facing projection is already present in the supplied body. */
+    media?: readonly MediaFact[];
   },
 ): ReplyPromptEnvelope {
   const base = buildReplyPromptEnvelopeBase(params);
@@ -275,6 +284,7 @@ export function buildReplyPromptEnvelope(
     threadContextNote: params.threadContextNote,
     systemEventBlocks: params.systemEventBlocks,
     inboundEventKind: params.inboundEventKind,
+    media: params.media,
   });
 
   return {

--- a/src/auto-reply/reply/queue.media-carrier.test.ts
+++ b/src/auto-reply/reply/queue.media-carrier.test.ts
@@ -1,0 +1,74 @@
+// Prompt media carrier tests cover collect batching, deferral, and retry identity.
+import { afterEach, describe, expect, it } from "vitest";
+import type { FollowupRun, QueueSettings } from "./queue.js";
+import { enqueueFollowupRun, FollowupRunDeferredError, scheduleFollowupDrain } from "./queue.js";
+import { createDeferred, createQueueTestRun } from "./queue.test-helpers.js";
+import { createOverflowSummaryRetrySource } from "./queue/drain.js";
+import { clearFollowupQueue } from "./queue/state.js";
+
+const queueKeys = new Set<string>();
+
+afterEach(() => {
+  for (const key of queueKeys) {
+    clearFollowupQueue(key);
+  }
+  queueKeys.clear();
+});
+
+describe("followup prompt media carrier", () => {
+  it("keeps collected prompt bytes and ordered facts stable across deferred admission", async () => {
+    const key = `prompt-media-collect-${Date.now()}`;
+    queueKeys.add(key);
+    const settings: QueueSettings = { mode: "collect", debounceMs: 0 };
+    const done = createDeferred<void>();
+    const calls: FollowupRun[] = [];
+
+    for (const [prompt, path, contentType] of [
+      ["[media attached: /tmp/a.png (image/png)]\nfirst", "/tmp/a.png", "image/png"],
+      ["[media attached: /tmp/b.pdf (application/pdf)]\nsecond", "/tmp/b.pdf", "application/pdf"],
+    ] as const) {
+      const run = createQueueTestRun({ prompt });
+      run.media = [{ path, contentType }];
+      enqueueFollowupRun(key, run, settings);
+    }
+
+    scheduleFollowupDrain(key, async (run) => {
+      calls.push(run);
+      if (calls.length === 1) {
+        throw new FollowupRunDeferredError();
+      }
+      done.resolve();
+    });
+    await done.promise;
+
+    const expectedPrompt = [
+      "[Queued messages while agent was busy]",
+      "---\nQueued #1\n[media attached: /tmp/a.png (image/png)]\nfirst",
+      "---\nQueued #2\n[media attached: /tmp/b.pdf (application/pdf)]\nsecond",
+    ].join("\n\n");
+    expect(calls).toHaveLength(2);
+    expect(calls.map((run) => run.prompt)).toEqual([expectedPrompt, expectedPrompt]);
+    expect(calls.map((run) => run.media)).toEqual([
+      [
+        { path: "/tmp/a.png", contentType: "image/png" },
+        { path: "/tmp/b.pdf", contentType: "application/pdf" },
+      ],
+      [
+        { path: "/tmp/a.png", contentType: "image/png" },
+        { path: "/tmp/b.pdf", contentType: "application/pdf" },
+      ],
+    ]);
+  });
+
+  it("preserves facts when an overflow source is rebuilt for retry", () => {
+    const source = createQueueTestRun({
+      prompt: "[media attached: /tmp/retry.png (image/png)]\nretry me",
+    });
+    source.media = [{ path: "/tmp/retry.png", contentType: "image/png" }];
+
+    const retry = createOverflowSummaryRetrySource(source);
+
+    expect(retry.prompt).toBe(source.prompt);
+    expect(retry.media).toEqual(source.media);
+  });
+});

--- a/src/auto-reply/reply/queue/drain.ts
+++ b/src/auto-reply/reply/queue/drain.ts
@@ -288,9 +288,12 @@ function renderCollectItemPrompt(item: FollowupRun, idx: number, prompt: string)
   return `---\nQueued #${idx + 1}${senderSuffix}\n${prompt}`.trim();
 }
 
-function collectQueuedImages(items: FollowupRun[]): Pick<FollowupRun, "images" | "imageOrder"> {
+function collectQueuedPromptMedia(
+  items: FollowupRun[],
+): Pick<FollowupRun, "images" | "imageOrder" | "media"> {
   const images: NonNullable<FollowupRun["images"]> = [];
   const imageOrder: NonNullable<FollowupRun["imageOrder"]> = [];
+  const media: NonNullable<FollowupRun["media"]> = [];
   for (const item of items) {
     if (item.images) {
       images.push(...item.images);
@@ -298,10 +301,14 @@ function collectQueuedImages(items: FollowupRun[]): Pick<FollowupRun, "images" |
     if (item.imageOrder) {
       imageOrder.push(...item.imageOrder);
     }
+    if (item.media) {
+      media.push(...item.media);
+    }
   }
   return {
     ...(images.length > 0 ? { images } : {}),
     ...(imageOrder.length > 0 ? { imageOrder } : {}),
+    ...(media.length > 0 ? { media } : {}),
   };
 }
 
@@ -883,6 +890,7 @@ export function createOverflowSummaryRetrySource(source: FollowupRun): FollowupR
     prompt: source.prompt,
     queueAbortSignal: source.queueAbortSignal,
     transcriptPrompt: source.transcriptPrompt,
+    media: source.media,
     messageId: source.messageId,
     summaryLine: source.summaryLine,
     enqueuedAt: source.enqueuedAt,
@@ -1291,7 +1299,7 @@ export function scheduleFollowupDrain(
                       },
                     }
                   : {}),
-                ...collectQueuedImages(activeGroupItems),
+                ...collectQueuedPromptMedia(activeGroupItems),
               });
             };
             try {

--- a/src/auto-reply/reply/queue/types.ts
+++ b/src/auto-reply/reply/queue/types.ts
@@ -10,6 +10,7 @@ import type { InboundEventKind } from "../../../channels/inbound-event/kind.js";
 import type { SessionEntry } from "../../../config/sessions.js";
 import type { ReplyToMode } from "../../../config/types.base.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import type { MediaFact } from "../../../media/media-facts.js";
 import type { PromptImageOrderEntry } from "../../../media/prompt-image-order.js";
 import type { PluginHookChannelContext } from "../../../plugins/hook-types.js";
 import type { InputProvenance } from "../../../sessions/input-provenance.js";
@@ -97,6 +98,8 @@ export type FollowupRun = {
   enqueuedAt: number;
   images?: Array<{ type: "image"; data: string; mimeType: string }>;
   imageOrder?: PromptImageOrderEntry[];
+  /** Ordered facts represented by attachment text in this prompt. */
+  media?: MediaFact[];
   /**
    * Originating channel for reply routing.
    * When set, replies should be routed back to this provider

--- a/src/auto-reply/reply/reply-run-registry.ts
+++ b/src/auto-reply/reply/reply-run-registry.ts
@@ -17,6 +17,7 @@ import {
   resolveRunStaleThresholdMs,
 } from "../../logging/diagnostic-run-activity.js";
 import { diagnosticLogger as diag } from "../../logging/diagnostic-runtime.js";
+import type { MediaFact } from "../../media/media-facts.js";
 import type { UserTurnTranscriptRecorder } from "../../sessions/user-turn-transcript.types.js";
 import { resolveGlobalSingleton } from "../../shared/global-singleton.js";
 import { resolveTimerTimeoutMs } from "../../shared/number-coercion.js";
@@ -40,6 +41,8 @@ export type ReplyBackendQueueMessageOptions = {
   debounceMs?: number;
   /** Ordered current-turn images to inject with the steering text. */
   images?: ImageContent[];
+  /** Ordered facts represented by attachment text in this steering prompt. */
+  media?: MediaFact[];
   deliveryTimeoutMs?: number;
   waitForTranscriptCommit?: boolean;
   sourceReplyDeliveryMode?: SourceReplyDeliveryMode;

--- a/src/gateway/chat-attachments.test.ts
+++ b/src/gateway/chat-attachments.test.ts
@@ -492,8 +492,16 @@ describe("parseMessageWithAttachments validation errors", () => {
       expect(parsed.images).toHaveLength(0);
       expect(parsed.imageOrder).toEqual(["offloaded"]);
       expect(parsed.offloadedRefs).toHaveLength(1);
-      expect(parsed.offloadedRefs[0]?.mimeType).toBe("image/png");
-      expect(parsed.message).toMatch(/^see this\n\[media attached: media:\/\/inbound\//);
+      const offloaded = expectDefined(parsed.offloadedRefs[0], "offloaded image ref");
+      expect(offloaded.mimeType).toBe("image/png");
+      expect(parsed.message).toBe(`see this\n[media attached: ${offloaded.mediaRef}]`);
+      expect(parsed.media).toEqual([
+        {
+          path: offloaded.path,
+          url: offloaded.mediaRef,
+          contentType: "image/png",
+        },
+      ]);
       expect(infos[0]).toMatch(/Offloaded image for text-only model/i);
       expect(logs).toHaveLength(0);
     } finally {

--- a/src/gateway/chat-attachments.ts
+++ b/src/gateway/chat-attachments.ts
@@ -7,6 +7,7 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { formatErrorMessage } from "../infra/errors.js";
+import type { MediaFact } from "../media/media-facts.js";
 import type { PromptImageOrderEntry } from "../media/prompt-image-order.js";
 import { sniffMimeFromBase64 } from "../media/sniff-mime-from-base64.js";
 import { deleteMediaBuffer, saveMediaBuffer, type SavedMedia } from "../media/store.js";
@@ -37,6 +38,7 @@ type ParsedMessageWithImages = {
   message: string;
   images: ChatImageContent[];
   imageOrder: PromptImageOrderEntry[];
+  media: MediaFact[];
   offloadedRefs: OffloadedRef[];
 };
 
@@ -320,7 +322,7 @@ export async function parseMessageWithAttachments(
   const acceptNonImage = opts?.acceptNonImage !== false;
 
   if (!attachments || attachments.length === 0) {
-    return { message, images: [], imageOrder: [], offloadedRefs: [] };
+    return { message, images: [], imageOrder: [], media: [], offloadedRefs: [] };
   }
 
   const images: ChatImageContent[] = [];
@@ -491,6 +493,11 @@ export async function parseMessageWithAttachments(
     message: updatedMessage !== message ? updatedMessage.trimEnd() : message,
     images,
     imageOrder,
+    media: offloadedRefs.map((ref) => ({
+      path: ref.path,
+      url: ref.mediaRef,
+      contentType: ref.mimeType,
+    })),
     offloadedRefs,
   };
 }

--- a/src/gateway/server-methods/agent-content-phase.ts
+++ b/src/gateway/server-methods/agent-content-phase.ts
@@ -14,6 +14,7 @@ import {
   loadVoiceWakeRoutingConfig,
   resolveVoiceWakeRouteByTrigger,
 } from "../../infra/voicewake-routing.js";
+import type { MediaFact } from "../../media/media-facts.js";
 import type { PromptImageOrderEntry } from "../../media/prompt-image-order.js";
 import {
   classifySessionKeyShape,
@@ -57,6 +58,7 @@ type AgentContentPhaseResult = {
   message: string;
   images: Array<{ type: "image"; data: string; mimeType: string }>;
   imageOrder: PromptImageOrderEntry[];
+  media: MediaFact[];
   replyTo: string;
   recipientChannel?: string;
   recipientAccountId?: string;
@@ -110,6 +112,7 @@ export async function prepareAgentContentPhase(params: {
     : annotateInterSessionPromptText(transcriptInputText, params.inputProvenance);
   let images: AgentContentPhaseResult["images"] = [];
   let imageOrder: PromptImageOrderEntry[] = [];
+  let media: MediaFact[] = [];
   let agentId = params.agentId;
   let requestedSessionKey = params.requestedSessionKey;
 
@@ -150,6 +153,7 @@ export async function prepareAgentContentPhase(params: {
       message = parsed.message.trim();
       images = parsed.images;
       imageOrder = parsed.imageOrder;
+      media = parsed.media;
     } catch (err) {
       logAttachmentFailure(params.context.logGateway, "agent attachment parse failed", err);
       params.respond(
@@ -255,6 +259,7 @@ export async function prepareAgentContentPhase(params: {
     message,
     images,
     imageOrder,
+    media,
     replyTo,
     recipientChannel,
     recipientAccountId,

--- a/src/gateway/server-methods/agent-run-execution-phase.ts
+++ b/src/gateway/server-methods/agent-run-execution-phase.ts
@@ -20,6 +20,7 @@ import {
 import type { SessionEntry } from "../../config/sessions.js";
 import { resolveAgentIdFromSessionKey } from "../../config/sessions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { MediaFact } from "../../media/media-facts.js";
 import type { PromptImageOrderEntry } from "../../media/prompt-image-order.js";
 import { retainGatewayRootWorkAdmissionContinuation } from "../../process/gateway-work-admission.js";
 import {
@@ -76,6 +77,7 @@ export function startAgentRunExecution(params: {
   message: string;
   images: Array<{ type: "image"; data: string; mimeType: string }>;
   imageOrder: PromptImageOrderEntry[];
+  media: MediaFact[];
   effectiveTranscriptInputText: string;
   inputProvenance?: InputProvenance;
   runId: string;
@@ -313,6 +315,7 @@ export function startAgentRunExecution(params: {
           message,
           images: params.images,
           imageOrder: params.imageOrder,
+          media: params.media,
           agentId: ingressAgentId,
           provider: prepared.effectiveProviderOverride,
           model: prepared.effectiveModelOverride,

--- a/src/gateway/server-methods/agent-run-handler.ts
+++ b/src/gateway/server-methods/agent-run-handler.ts
@@ -152,6 +152,7 @@ export const agentRunHandler: GatewayRequestHandlers["agent"] = async ({
     const {
       images,
       imageOrder,
+      media,
       replyTo,
       recipientChannel,
       recipientAccountId,
@@ -480,6 +481,7 @@ export const agentRunHandler: GatewayRequestHandlers["agent"] = async ({
       message,
       images,
       imageOrder,
+      media,
       effectiveTranscriptInputText,
       inputProvenance,
       runId,

--- a/src/gateway/server-methods/chat-send-handler.ts
+++ b/src/gateway/server-methods/chat-send-handler.ts
@@ -305,6 +305,7 @@ export const handleChatSend: GatewayRequestHandlers["chat.send"] = async ({
       pluginBoundMediaFieldsPromise,
       queuedFollowupOwnerKey,
       replyOptionImages,
+      replyOptionMedia,
     } = prepareChatSendUserTurn({
       request: normalizedRequest.value,
       session: preparedSession.value,
@@ -473,6 +474,7 @@ export const handleChatSend: GatewayRequestHandlers["chat.send"] = async ({
                 },
                 images: replyOptionImages,
                 imageOrder: imageOrder.length > 0 ? imageOrder : undefined,
+                media: replyOptionMedia,
                 thinkingLevelOverride: p.thinking,
                 fastModeOverride: p.fastMode,
                 queueModeOverride: p.queueMode,

--- a/src/gateway/server-methods/chat-send-user-turn.test.ts
+++ b/src/gateway/server-methods/chat-send-user-turn.test.ts
@@ -42,6 +42,15 @@ function createAttachments(
     mediaPathOffloadPaths: string[];
     mediaPathOffloadTypes: string[];
     mediaPathOffloadWorkspaceDir: string | undefined;
+    imageOrder: Array<"inline" | "offloaded">;
+    offloadedRefs: Array<{
+      mediaRef: string;
+      id: string;
+      path: string;
+      mimeType: string;
+      label: string;
+      sizeBytes: number;
+    }>;
     parsedMessage: string;
   }> = {},
 ) {
@@ -185,6 +194,57 @@ describe("prepareChatSendUserTurn", () => {
     expect(prepared.ctx).not.toHaveProperty("SenderId");
     expect(prepared.queuedFollowupOwnerKey).toBe("device:device-1");
     await expect(readInput()).resolves.toEqual(controller.baseInput);
+  });
+
+  it("carries retained image claim-check facts without changing the trailing prompt line", () => {
+    const { controller } = createUserTurnInputController();
+    const mediaRef = "media://inbound/image-1.png";
+    const prepared = prepareChatSendUserTurn({
+      request: {
+        clientInfo: createClientInfo(),
+        normalizedAttachments: [{}],
+        suppressCommandInterpretation: false,
+        systemInputProvenance: undefined,
+        systemProvenanceReceipt: undefined,
+      },
+      session: {
+        agentId: "main",
+        clientRunId: "run-1",
+        sessionKey: "agent:main:main",
+      },
+      admission: {
+        originatingRoute: {
+          originatingChannel: "webchat",
+          explicitDeliverRoute: false,
+        },
+      },
+      attachments: createAttachments({
+        imageOrder: ["offloaded"],
+        offloadedRefs: [
+          {
+            mediaRef,
+            id: "image-1.png",
+            path: "/media/inbound/image-1.png",
+            mimeType: "image/png",
+            label: "image.png",
+            sizeBytes: 10,
+          },
+        ],
+        parsedMessage: `inspect\n[media attached: ${mediaRef}]`,
+      }),
+      client: null,
+      logGateway: { warn: vi.fn() } as never,
+      userTurn: controller,
+    });
+
+    expect(prepared.ctx.Body).toBe(`inspect\n[media attached: ${mediaRef}]`);
+    expect(prepared.replyOptionMedia).toEqual([
+      {
+        path: "/media/inbound/image-1.png",
+        url: mediaRef,
+        contentType: "image/png",
+      },
+    ]);
   });
 });
 

--- a/src/gateway/server-methods/chat-send-user-turn.ts
+++ b/src/gateway/server-methods/chat-send-user-turn.ts
@@ -1,6 +1,6 @@
 import type { GatewayClientInfo } from "../../../packages/gateway-protocol/src/client-info.js";
 import type { MsgContext } from "../../auto-reply/templating.js";
-import { projectMediaFacts } from "../../media/media-facts.js";
+import { projectMediaFacts, type MediaFact } from "../../media/media-facts.js";
 import type { PromptImageOrderEntry } from "../../media/prompt-image-order.js";
 import type { SavedMedia } from "../../media/store.js";
 import type { InputProvenance } from "../../sessions/input-provenance.js";
@@ -97,6 +97,18 @@ function buildChatSendUserTurnMedia(savedMedia: SavedMedia[]): NonNullable<UserT
     path: entry.path,
     contentType: entry.contentType,
   }));
+}
+
+function buildChatSendPromptMedia(
+  attachments: PreparedChatSendAttachments,
+): MediaFact[] | undefined {
+  if (!attachments.imageOrder.includes("offloaded")) {
+    return undefined;
+  }
+  const media = attachments.offloadedRefs
+    .filter((ref) => ref.mimeType.startsWith("image/"))
+    .map((ref) => ({ path: ref.path, url: ref.mediaRef, contentType: ref.mimeType }));
+  return media.length > 0 ? media : undefined;
 }
 
 function buildChatSendMessageContext(params: {
@@ -273,5 +285,6 @@ export function prepareChatSendUserTurn(params: {
       : attachments.parsedImages.length > 0
         ? attachments.parsedImages
         : undefined,
+    replyOptionMedia: buildChatSendPromptMedia(attachments),
   };
 }

--- a/src/gateway/server.agent.gateway-server-agent-a.test.ts
+++ b/src/gateway/server.agent.gateway-server-agent-a.test.ts
@@ -116,11 +116,20 @@ const baseImageAttachment = () => ({
   content: BASE_IMAGE_PNG,
 });
 
+const offloadedImageAttachment = () => ({
+  ...baseImageAttachment(),
+  fileName: "large.png",
+  content: Buffer.concat([Buffer.from(BASE_IMAGE_PNG, "base64"), Buffer.alloc(2_000_001)]).toString(
+    "base64",
+  ),
+});
+
 async function runAgentImageRequest(params: {
   idempotencyKey: string;
   sessionId: string;
   sessionKey?: string;
   agentId?: string;
+  attachment?: ReturnType<typeof baseImageAttachment>;
   failureMessage: string;
 }) {
   await setTestSessionStore({
@@ -137,7 +146,7 @@ async function runAgentImageRequest(params: {
     message: "what is in the image?",
     ...(params.agentId ? { agentId: params.agentId } : {}),
     sessionKey: params.sessionKey ?? "main",
-    attachments: [baseImageAttachment()],
+    attachments: [params.attachment ?? baseImageAttachment()],
     idempotencyKey: params.idempotencyKey,
   });
   expect(res.ok, `${params.failureMessage}: ${JSON.stringify(res)}`).toBe(true);
@@ -514,6 +523,27 @@ describe("gateway server agent", () => {
     expect(typeof call.message).toBe("string");
     expect(call.message).toContain("what is in the image?");
     expectBaseImageForwarded(call.images);
+  });
+
+  test("agent retains image offload facts beside the claim-check line", async () => {
+    testState.agentConfig = { model: { primary: "ollama-cloud/gemma4:31b" } };
+    await setGatewayModelCatalogForTest([TEXT_ONLY_AGENT_MODEL, VISION_AGENT_MODEL]);
+    const call = await runAgentImageRequest({
+      idempotencyKey: "idem-agent-offloaded-media",
+      sessionId: "sess-main-offloaded-media",
+      attachment: offloadedImageAttachment(),
+      failureMessage: "agent RPC failed before forwarding offloaded media facts",
+    });
+
+    const media = call.media as
+      | Array<{ path?: string; url?: string; contentType?: string }>
+      | undefined;
+    expect(call.images).toEqual([]);
+    expect(media).toHaveLength(1);
+    expect(media?.[0]).toMatchObject({ contentType: "image/png" });
+    expect(media?.[0]?.path).toMatch(/\/media\/inbound\//);
+    expect(media?.[0]?.url).toMatch(/^media:\/\/inbound\//);
+    expect(call.message).toBe(`what is in the image?\n[media attached: ${media?.[0]?.url}]`);
   });
 
   test("agent validates first image attachment against per-agent model for fresh sessions", async () => {

--- a/src/media/media-facts.ts
+++ b/src/media/media-facts.ts
@@ -17,6 +17,20 @@ export type MediaFactInput = {
   [Key in keyof MediaFact]?: MediaFact[Key] | null;
 };
 
+const RUNTIME_PROMPT_MEDIA_FACTS = Symbol.for("openclaw.runtimePromptMediaFacts");
+
+/** Attaches facts to a runtime prompt message without changing serialized/model-visible bytes. */
+export function attachRuntimePromptMediaFacts<T extends object>(
+  message: T,
+  media: readonly MediaFact[],
+): T {
+  Object.defineProperty(message, RUNTIME_PROMPT_MEDIA_FACTS, {
+    configurable: true,
+    value: normalizeMediaFacts(media),
+  });
+  return message;
+}
+
 type MediaFactDefaults<TInput extends MediaFactInput = MediaFactInput> = {
   kind?: MediaKind;
   messageId?: string;

--- a/src/sessions/user-turn-transcript.test.ts
+++ b/src/sessions/user-turn-transcript.test.ts
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { loadTranscriptEvents } from "../config/sessions/session-accessor.js";
 import { formatSqliteSessionFileMarker } from "../config/sessions/sqlite-marker.js";
 import {
+  buildLateMediaAttachedProjection,
   createUserTurnTranscriptRecorder,
   mergePreparedUserTurnMessageForRuntime,
   resolvePersistedUserTurnText,
@@ -435,7 +436,8 @@ describe("user turn transcript persistence", () => {
 
       await persistence;
 
-      await expect(readTranscriptMessages(target)).resolves.toEqual([
+      const messages = await readTranscriptMessages(target);
+      expect(messages).toEqual([
         expect.objectContaining({
           content: "describe this",
           idempotencyKey: "chat-run-late:user",
@@ -448,6 +450,15 @@ describe("user turn transcript persistence", () => {
           MediaType: "image/png",
           MediaTypes: ["image/png"],
           __openclaw: { hookOwned: true, lateMedia: true },
+        }),
+      ]);
+      const lateProjection = buildLateMediaAttachedProjection(castAgentMessage(messages[1]));
+      expect(lateProjection.text).toBe(`[media attached: ${path.join(dir, "image.png")}]`);
+      expect(lateProjection.media).toEqual([
+        expect.objectContaining({
+          path: path.join(dir, "image.png"),
+          contentType: "image/png",
+          kind: "image",
         }),
       ]);
     });

--- a/src/sessions/user-turn-transcript.ts
+++ b/src/sessions/user-turn-transcript.ts
@@ -6,7 +6,12 @@ import {
   persistSessionTranscriptTurn,
   type SessionTranscriptTurnPersistOptions,
 } from "../config/sessions/session-accessor.js";
-import { projectMediaFacts, resolveMediaFacts, type MediaFactInput } from "../media/media-facts.js";
+import {
+  projectMediaFacts,
+  resolveMediaFacts,
+  type MediaFact,
+  type MediaFactInput,
+} from "../media/media-facts.js";
 import { applyInputProvenanceToUserMessage, normalizeInputProvenance } from "./input-provenance.js";
 import type {
   CreateUserTurnTranscriptRecorderParams,
@@ -143,18 +148,26 @@ export function buildPersistedUserTurnMediaInputsFromFields(
   return normalizedMedia.some((entry) => entry.path || entry.url) ? normalizedMedia : [];
 }
 
-export function buildLateMediaAttachedText(message: AgentMessage): string | undefined {
-  const text = (
-    readOpenClawMessageMeta(message)?.lateMedia === true
-      ? buildPersistedUserTurnMediaInputsFromFields(message as PersistedUserTurnMediaFieldSource)
-      : []
-  )
+export function buildLateMediaAttachedProjection(message: AgentMessage): {
+  text?: string;
+  media: MediaFact[];
+} {
+  const isLateMedia = readOpenClawMessageMeta(message)?.lateMedia === true;
+  const entries = isLateMedia
+    ? buildPersistedUserTurnMediaInputsFromFields(message as PersistedUserTurnMediaFieldSource)
+    : [];
+  const text = entries
     .flatMap((entry) => {
       const mediaRef = entry.path ?? entry.url;
       return mediaRef ? [`[media attached: ${mediaRef}]`] : [];
     })
     .join("\n");
-  return text || undefined;
+  const media = isLateMedia
+    ? resolveMediaFacts(message as unknown as Parameters<typeof resolveMediaFacts>[0]).filter(
+        (entry) => entry.path || entry.url,
+      )
+    : [];
+  return { ...(text ? { text } : {}), media };
 }
 
 function buildPersistedUserTurnMediaFields(


### PR DESCRIPTION
## What Problem This Solves

PR 5 of the audit-frozen media-facts program (#112197, #112276, #112335, #112545) — the one intentionally additive PR. The 818-line `[media attached:]`/claim-check parsing DSL exists because prompt text is the only carrier of media identity through the prompt path; before the parsers can be deleted (PR 6), the facts must travel end to end.

## Why This Change Was Made

- Ordered `MediaFact[]` now travels alongside the exact prompt text through prompt prelude, `GetReplyOptions`, `FollowupRun`, queue collect/defer/retry, active steering, embedded/CLI run params, Gateway offloads (`offloadedRefs` is no longer discarded; `AgentContentPhaseResult` carries `media` per the audit's producer table), Tlon, and late-media projection.
- Prompt bytes are golden-equal everywhere, enforced by new golden tests over the audit risk table's full list: single/multi media notes, Tlon's duplicated `path | path` form, gateway trailing claim-check lines, media reply hint placement, queued/collect prompts, transcript prompt, hook prompt, runtime-context split, and late-media projection. These goldens are PR 6's safety net.
- Facts follow the same adoption/idempotency/late-append lifecycle as prompt text — deferred collect, sent-to-provider late media, retry, and cache-stable replay each tested. Runtime prompt messages carry facts via a non-serialized side channel so model-visible bytes cannot drift.

## User Impact

None — behavior-neutral by construction; every byte the model sees is unchanged.

## Evidence

- 559 focused tests green across 21 files (new queue media-carrier suite; golden byte-equality suites) via `node scripts/run-vitest.mjs`.
- Delegated `check:changed` green on Blacksmith Testbox (run 29900470892), pinned to the declared base after unrelated max-lines shrinkage landed on main mid-run.
- Local format/type-aware-oxlint/tsgo/SDK/knip gates green; autoreview clean first pass, "patch is correct (0.87)".
- Intentionally +175 production LOC — the audit's planned bridge cost, consumed by the deletion PRs that follow.
