### PR TITLE
fix(security): audit live plugin collectors

### DIFF
--- a/src/security/audit-plugin-live-collectors.test.ts
+++ b/src/security/audit-plugin-live-collectors.test.ts
@@ -1,0 +1,93 @@
+// Verifies security audit collector discovery across live plugin registries.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createEmptyPluginRegistry } from "../plugins/registry.js";
+import {
+  pinActivePluginHttpRouteRegistry,
+  resetPluginRuntimeStateForTest,
+  setActivePluginRegistry,
+} from "../plugins/runtime.js";
+import { runSecurityAudit } from "./audit.js";
+
+describe("security audit live plugin collectors", () => {
+  afterEach(() => {
+    resetPluginRuntimeStateForTest();
+  });
+
+  it("runs collectors from pinned live registries while active duplicates win", async () => {
+    const activeDuplicateCollector = vi.fn(() => [
+      {
+        checkId: "plugins.duplicate.active",
+        severity: "warn" as const,
+        title: "Active duplicate collector ran",
+        detail: "active duplicate",
+      },
+    ]);
+    const pinnedDuplicateCollector = vi.fn(() => [
+      {
+        checkId: "plugins.duplicate.pinned",
+        severity: "warn" as const,
+        title: "Pinned duplicate collector ran",
+        detail: "pinned duplicate",
+      },
+    ]);
+    const pinnedOnlyCollector = vi.fn(() => [
+      {
+        checkId: "plugins.pinned_only.audit",
+        severity: "warn" as const,
+        title: "Pinned-only collector ran",
+        detail: "pinned only",
+      },
+    ]);
+
+    const startupRegistry = createEmptyPluginRegistry();
+    startupRegistry.securityAuditCollectors.push(
+      {
+        pluginId: "duplicate-plugin",
+        pluginName: "Duplicate plugin",
+        collector: pinnedDuplicateCollector,
+        source: "runtime",
+      },
+      {
+        pluginId: "pinned-only-plugin",
+        pluginName: "Pinned-only plugin",
+        collector: pinnedOnlyCollector,
+        source: "runtime",
+      },
+    );
+    const activeRegistry = createEmptyPluginRegistry();
+    activeRegistry.securityAuditCollectors.push({
+      pluginId: "duplicate-plugin",
+      pluginName: "Duplicate plugin",
+      collector: activeDuplicateCollector,
+      source: "runtime",
+    });
+
+    setActivePluginRegistry(startupRegistry);
+    pinActivePluginHttpRouteRegistry(startupRegistry);
+    setActivePluginRegistry(activeRegistry);
+
+    const report = await runSecurityAudit({
+      config: {},
+      sourceConfig: {},
+      env: {},
+      platform: process.platform,
+      includeFilesystem: false,
+      includeChannelSecurity: false,
+      deep: false,
+      stateDir: "/tmp/openclaw-test-state",
+      configPath: "/tmp/openclaw-test-config.json",
+      plugins: [],
+      loadPluginSecurityCollectors: true,
+      configSnapshot: null,
+    });
+
+    const pluginCheckIds = report.findings
+      .map((finding) => finding.checkId)
+      .filter((checkId) => checkId.startsWith("plugins."))
+      .toSorted();
+    expect(pluginCheckIds).toStrictEqual(["plugins.duplicate.active", "plugins.pinned_only.audit"]);
+    expect(activeDuplicateCollector).toHaveBeenCalledOnce();
+    expect(pinnedDuplicateCollector).not.toHaveBeenCalled();
+    expect(pinnedOnlyCollector).toHaveBeenCalledOnce();
+  });
+});

--- a/src/security/audit-plugin-readonly-scope.test.ts
+++ b/src/security/audit-plugin-readonly-scope.test.ts
@@ -2,8 +2,10 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
+import { createEmptyPluginRegistry } from "../plugins/registry.js";
 
 const applyPluginAutoEnableMock = vi.hoisted(() => vi.fn());
+const collectLivePluginRegistriesMock = vi.hoisted(() => vi.fn());
 const getActivePluginRegistryMock = vi.hoisted(() => vi.fn());
 const loadPluginMetadataRegistrySnapshotMock = vi.hoisted(() => vi.fn());
 const resolveConfiguredChannelPluginIdsMock = vi.hoisted(() => vi.fn());
@@ -21,6 +23,7 @@ vi.mock("../plugins/runtime.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../plugins/runtime.js")>();
   return {
     ...actual,
+    collectLivePluginRegistries: (...args: unknown[]) => collectLivePluginRegistriesMock(...args),
     getActivePluginRegistry: (...args: unknown[]) => getActivePluginRegistryMock(...args),
   };
 });
@@ -65,9 +68,11 @@ function requireFirstMockArg<T>(mock: { mock: { calls: T[][] } }, label: string)
 describe("security audit read-only plugin scope", () => {
   beforeEach(() => {
     applyPluginAutoEnableMock.mockReset();
+    collectLivePluginRegistriesMock.mockReset();
     getActivePluginRegistryMock.mockReset();
     loadPluginMetadataRegistrySnapshotMock.mockReset();
     resolveConfiguredChannelPluginIdsMock.mockReset();
+    collectLivePluginRegistriesMock.mockReturnValue([]);
     getActivePluginRegistryMock.mockReturnValue(null);
     applyPluginAutoEnableMock.mockImplementation((params: { config: unknown }) => ({
       config: params.config,
@@ -180,6 +185,75 @@ describe("security audit read-only plugin scope", () => {
     expect(loadPluginMetadataRegistrySnapshotMock).not.toHaveBeenCalled();
   });
 
+  it("keeps plugin security collectors from pinned live registries", async () => {
+    const activeDuplicateCollector = vi.fn(() => [
+      {
+        checkId: "plugins.duplicate.active",
+        severity: "warn" as const,
+        title: "Active duplicate collector ran",
+        detail: "active duplicate",
+      },
+    ]);
+    const pinnedDuplicateCollector = vi.fn(() => [
+      {
+        checkId: "plugins.duplicate.pinned",
+        severity: "warn" as const,
+        title: "Pinned duplicate collector ran",
+        detail: "pinned duplicate",
+      },
+    ]);
+    const pinnedOnlyCollector = vi.fn(() => [
+      {
+        checkId: "plugins.pinned_only.audit",
+        severity: "warn" as const,
+        title: "Pinned-only collector ran",
+        detail: "pinned only",
+      },
+    ]);
+
+    const activeRegistry = createEmptyPluginRegistry();
+    activeRegistry.securityAuditCollectors.push({
+      pluginId: "duplicate-plugin",
+      pluginName: "Duplicate plugin",
+      collector: activeDuplicateCollector,
+      source: "runtime",
+    });
+    const pinnedRegistry = createEmptyPluginRegistry();
+    pinnedRegistry.securityAuditCollectors.push(
+      {
+        pluginId: "duplicate-plugin",
+        pluginName: "Duplicate plugin",
+        collector: pinnedDuplicateCollector,
+        source: "runtime",
+      },
+      {
+        pluginId: "pinned-only-plugin",
+        pluginName: "Pinned-only plugin",
+        collector: pinnedOnlyCollector,
+        source: "runtime",
+      },
+    );
+    collectLivePluginRegistriesMock.mockReturnValue([activeRegistry, pinnedRegistry]);
+
+    const report = await runSecurityAudit(
+      createAuditOptions({
+        sourceConfig: {},
+        plugins: [],
+      }),
+    );
+
+    const pluginCheckIds = report.findings
+      .map((finding) => finding.checkId)
+      .filter((checkId) => checkId.startsWith("plugins."))
+      .toSorted();
+    expect(pluginCheckIds).toStrictEqual(["plugins.duplicate.active", "plugins.pinned_only.audit"]);
+    expect(activeDuplicateCollector).toHaveBeenCalledOnce();
+    expect(pinnedDuplicateCollector).not.toHaveBeenCalled();
+    expect(pinnedOnlyCollector).toHaveBeenCalledOnce();
+    expect(applyPluginAutoEnableMock).not.toHaveBeenCalled();
+    expect(loadPluginMetadataRegistrySnapshotMock).not.toHaveBeenCalled();
+  });
+
   it("keeps plain security audit off plugin collector runtime discovery by default", async () => {
     const sourceConfig = {
       plugins: {
@@ -198,6 +272,7 @@ describe("security audit read-only plugin scope", () => {
     });
 
     expect(getActivePluginRegistryMock).not.toHaveBeenCalled();
+    expect(collectLivePluginRegistriesMock).not.toHaveBeenCalled();
     expect(applyPluginAutoEnableMock).not.toHaveBeenCalled();
     expect(loadPluginMetadataRegistrySnapshotMock).not.toHaveBeenCalled();
   });

--- a/src/security/audit.ts
+++ b/src/security/audit.ts
@@ -39,6 +39,7 @@ import {
   resolveMergedSafeBinProfileFixtures,
 } from "../infra/exec-safe-bin-runtime-policy.js";
 import { listRiskyConfiguredSafeBins } from "../infra/exec-safe-bin-semantics.js";
+import type { PluginRegistry } from "../plugins/registry.js";
 import { DEFAULT_AGENT_ID } from "../routing/session-key.js";
 import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
 import { collectDeepCodeSafetyFindings } from "./audit-deep-code-safety.js";
@@ -86,6 +87,7 @@ type AgentSkillMcpBoundaryScope = {
   execSecurity: string;
   execAsk: string;
 };
+type PluginSecurityAuditCollectorRegistration = PluginRegistry["securityAuditCollectors"][number];
 
 export type { SecurityAuditReport } from "./audit.types.js";
 
@@ -488,8 +490,27 @@ async function collectPluginSecurityAuditFindings(
   if (!context.loadPluginSecurityCollectors) {
     return [];
   }
-  const { getActivePluginRegistry } = await loadPluginRuntimeModule();
-  let collectors = getActivePluginRegistry()?.securityAuditCollectors ?? [];
+  const { collectLivePluginRegistries } = await loadPluginRuntimeModule();
+  let collectors: PluginSecurityAuditCollectorRegistration[] = [];
+  const seenCollectorOwner = new Map<string, PluginRegistry>();
+  for (const registry of collectLivePluginRegistries()) {
+    for (const entry of registry.securityAuditCollectors) {
+      const pluginId = entry.pluginId.trim();
+      const source = entry.source.trim();
+      if (!pluginId || !source) {
+        continue;
+      }
+      const dedupeKey = `${pluginId}\0${source}`;
+      const owner = seenCollectorOwner.get(dedupeKey);
+      if (owner && owner !== registry) {
+        continue;
+      }
+      if (!owner) {
+        seenCollectorOwner.set(dedupeKey, registry);
+      }
+      collectors.push(entry);
+    }
+  }
   if (collectors.length === 0) {
     const { applyPluginAutoEnable } = await loadPluginAutoEnableModule();
     const autoEnabled = applyPluginAutoEnable({


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where plugin security audit collectors could be missed when a startup registry remained live for a pinned surface but the active runtime registry had already been replaced.

## Why This Change Was Made

Security audit discovery now reads collector registrations from all live plugin registries in runtime precedence order. Duplicate plugin/source registrations are skipped across registries so the active registry wins while pinned-only collectors still run.

## User Impact

Operators get plugin security audit findings from pinned live plugin surfaces instead of silently losing those checks after an active registry swap.

## Evidence

- `pnpm exec tsx proof-live.ts`: real `runSecurityAudit()` path with active + pinned live registries reported the active duplicate collector and the pinned-only collector.
- `node scripts/run-vitest.mjs src/security/audit-plugin-live-collectors.test.ts src/security/audit-plugin-readonly-scope.test.ts`: 2 files passed, 6 tests passed.

```text
$ pnpm exec tsx proof-live.ts
entrypoint: runSecurityAudit(loadPluginSecurityCollectors=true)
live-registries: active + pinned-http-route
plugin-findings: plugins.duplicate.active, plugins.pinned_only.audit
active-duplicate-calls: 1
pinned-duplicate-calls: 0
pinned-only-calls: 1
```

<details>
<summary>proof-live.ts</summary>

```ts
import { createEmptyPluginRegistry } from "./src/plugins/registry.js";
import {
  pinActivePluginHttpRouteRegistry,
  resetPluginRuntimeStateForTest,
  setActivePluginRegistry,
} from "./src/plugins/runtime.js";
import { runSecurityAudit } from "./src/security/audit.js";

function makeCollector(checkId: string, calls: { count: number }) {
  return () => {
    calls.count += 1;
    return [
      {
        checkId,
        severity: "warn" as const,
        title: checkId,
        detail: checkId,
      },
    ];
  };
}

const activeDuplicateCalls = { count: 0 };
const pinnedDuplicateCalls = { count: 0 };
const pinnedOnlyCalls = { count: 0 };

const startupRegistry = createEmptyPluginRegistry();
startupRegistry.securityAuditCollectors.push(
  {
    pluginId: "duplicate-plugin",
    pluginName: "Duplicate plugin",
    collector: makeCollector("plugins.duplicate.pinned", pinnedDuplicateCalls),
    source: "runtime",
  },
  {
    pluginId: "pinned-only-plugin",
    pluginName: "Pinned-only plugin",
    collector: makeCollector("plugins.pinned_only.audit", pinnedOnlyCalls),
    source: "runtime",
  },
);

const activeRegistry = createEmptyPluginRegistry();
activeRegistry.securityAuditCollectors.push({
  pluginId: "duplicate-plugin",
  pluginName: "Duplicate plugin",
  collector: makeCollector("plugins.duplicate.active", activeDuplicateCalls),
  source: "runtime",
});

setActivePluginRegistry(startupRegistry);
pinActivePluginHttpRouteRegistry(startupRegistry);
setActivePluginRegistry(activeRegistry);

try {
  const report = await runSecurityAudit({
    config: {},
    sourceConfig: {},
    env: {},
    platform: process.platform,
    includeFilesystem: false,
    includeChannelSecurity: false,
    deep: false,
    stateDir: "/tmp/openclaw-proof-state",
    configPath: "/tmp/openclaw-proof-config.json",
    plugins: [],
    loadPluginSecurityCollectors: true,
    configSnapshot: null,
  });
  const pluginFindings = report.findings
    .map((finding) => finding.checkId)
    .filter((checkId) => checkId.startsWith("plugins."))
    .toSorted();
  console.log("entrypoint: runSecurityAudit(loadPluginSecurityCollectors=true)");
  console.log("live-registries: active + pinned-http-route");
  console.log(`plugin-findings: ${pluginFindings.join(", ")}`);
  console.log(`active-duplicate-calls: ${activeDuplicateCalls.count}`);
  console.log(`pinned-duplicate-calls: ${pinnedDuplicateCalls.count}`);
  console.log(`pinned-only-calls: ${pinnedOnlyCalls.count}`);
} finally {
  resetPluginRuntimeStateForTest();
}
```

</details>

AI-assisted: built with Codex
