### PR TITLE
fix(onboard): reset sessions for every agent

### DIFF
--- a/src/commands/onboard-helpers.test.ts
+++ b/src/commands/onboard-helpers.test.ts
@@ -152,11 +152,13 @@ describe("handleReset", () => {
     const profileConfigPath = path.join(profileStateDir, "openclaw.json");
     const profileCredentialsDir = path.join(profileStateDir, "credentials");
     const profileSessionsDir = path.join(profileStateDir, "agents", "main", "sessions");
+    const secondarySessionsDir = path.join(profileStateDir, "agents", "ops", "sessions");
     const workspaceDir = path.join(profileStateDir, "workspace");
     const defaultCredentialsDir = path.join(defaultStateDir, "credentials");
 
     fs.mkdirSync(profileCredentialsDir, { recursive: true });
     fs.mkdirSync(profileSessionsDir, { recursive: true });
+    fs.mkdirSync(secondarySessionsDir, { recursive: true });
     fs.mkdirSync(workspaceDir, { recursive: true });
     fs.mkdirSync(defaultCredentialsDir, { recursive: true });
     fs.writeFileSync(profileConfigPath, "{}\n");
@@ -166,6 +168,7 @@ describe("handleReset", () => {
       profileConfigPath,
       profileCredentialsDir,
       profileSessionsDir,
+      secondarySessionsDir,
       workspaceDir,
     ].map(expectedTrashSourcePath);
     const expectedDefaultCredentialsDir = expectedTrashSourcePath(defaultCredentialsDir);

--- a/src/commands/onboard-helpers.ts
+++ b/src/commands/onboard-helpers.ts
@@ -24,7 +24,7 @@ import {
 import { DEFAULT_AGENT_WORKSPACE_DIR, ensureAgentWorkspace } from "../agents/workspace.js";
 import { printClawBanner } from "../cli/claw-banner.js";
 import { resolveAgentModelPrimaryValue } from "../config/model-input.js";
-import { resolveConfigPath } from "../config/paths.js";
+import { resolveConfigPath, resolveStateDir } from "../config/paths.js";
 import { resolveSessionTranscriptsDirForAgent } from "../config/sessions/paths.js";
 import type { OptionalBootstrapFileName } from "../config/types.agent-defaults.js";
 import type { GatewayAuthMode } from "../config/types.gateway.js";
@@ -46,6 +46,7 @@ import { movePathToTrash } from "../infra/fs-safe.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { resolveConfigDir, shortenHomeInString, shortenHomePath, sleep } from "../utils.js";
 import { VERSION } from "../version.js";
+import { listAgentSessionDirs } from "./cleanup-utils.js";
 import type { OnboardMode, ResetScope } from "./onboard-types.js";
 export { randomToken } from "./random-token.js";
 
@@ -314,7 +315,10 @@ export async function handleReset(scope: ResetScope, workspaceDir: string, runti
     return;
   }
   await moveToTrash(path.join(resolveConfigDir(), "credentials"), runtime);
-  await moveToTrash(resolveSessionTranscriptsDirForAgent(), runtime);
+  const sessionDirs = await listAgentSessionDirs(resolveStateDir());
+  for (const sessionDir of sessionDirs) {
+    await moveToTrash(sessionDir, runtime);
+  }
   if (scope === "full") {
     const legacyPlan = prepareLegacyWorkspaceStateReset(workspaceDir);
     const statePlan = prepareWorkspaceStateDeletion(workspaceDir);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `openclaw onboard --reset --reset-scope config+creds+sessions` removed only the `main` agent's session directory. Session history for custom, removed, or non-default agents remained under `state/agents/*/sessions` even though the selected reset scope explicitly includes sessions.

## Why This Change Was Made

Onboarding reset now reuses the same disk-based per-agent session enumeration as the standalone `openclaw reset` command. Disk ownership is the correct boundary because reset must also remove sessions for agents that are no longer present in config.

## User Impact

Operators can rely on onboarding's `config+creds+sessions` and `full` reset scopes to clear session history for every agent, not only `main`.

## Evidence

- Hosted current-main reproduction before the fix: `main` session marker removed, `ops` marker and directory remained.
- Hosted user-path proof after the fix: both `main` and `ops` markers were removed; the command logged both session directories moving to Trash.
- Blacksmith Testbox `tbx_01ky4eh2dt1wwq3wprqtbzpyrc`: `pnpm test src/commands/onboard-helpers.test.ts src/commands/reset.test.ts` passed 51/51 tests.
- Blacksmith Testbox `tbx_01ky4eh2dt1wwq3wprqtbzpyrc`: `pnpm check:changed` passed formatting, core and test typechecks, lint, storage guards, and import-cycle checks.
- Codex autoreview (`gpt-5.6-sol`, xhigh) reported no accepted or actionable findings.

AI-assisted: yes. The implementation and evidence were reviewed before submission.
