### PR TITLE
refactor(agents): share eligibility-aware node resolution across tools

### DIFF
--- a/src/agents/tools/computer-tool.ts
+++ b/src/agents/tools/computer-tool.ts
@@ -36,7 +36,12 @@ import {
 } from "./common.js";
 import { gatewayCallOptionSchemaProperties } from "./gateway-schema.js";
 import { callGatewayTool, type GatewayCallOptions, readGatewayCallOptions } from "./gateway.js";
-import { listNodes, type NodeListNode, resolveNodeIdFromList } from "./nodes-utils.js";
+import {
+  type EligibleNodeMessages,
+  listNodes,
+  type NodeListNode,
+  resolveEligibleNodeFromList,
+} from "./nodes-utils.js";
 
 const COMPUTER_ACT_COMMAND = "computer.act";
 const SCREEN_SNAPSHOT_COMMAND = "screen.snapshot";
@@ -325,14 +330,19 @@ function isEligibleComputerNode(node: NodeListNode): boolean {
 const NOT_COMPUTER_CAPABLE_HINT =
   "enable Computer Control in the OpenClaw app and approve the pairing update";
 
-function formatEligibleComputerNodeIds(nodes: NodeListNode[]): string {
-  return nodes.length > 0
-    ? nodes
-        .map((node) => node.nodeId)
-        .toSorted()
-        .join(", ")
-    : "none";
-}
+const COMPUTER_NODE_MESSAGES: EligibleNodeMessages = {
+  ineligibleExact: (query, eligibleIds) =>
+    `node "${query}" is not computer-capable (needs a connected node advertising ${COMPUTER_ACT_COMMAND} and ${SCREEN_SNAPSHOT_COMMAND}; ${NOT_COMPUTER_CAPABLE_HINT}; ` +
+    `eligible node ids: ${eligibleIds})`,
+  nameResolveFailed: (reason, eligibleIds) =>
+    `${reason} (eligible computer-capable node ids: ${eligibleIds})`,
+  noneEligible: () =>
+    `no connected computer-capable node (a node must advertise ${COMPUTER_ACT_COMMAND} and ${SCREEN_SNAPSHOT_COMMAND}; ${NOT_COMPUTER_CAPABLE_HINT})`,
+  multipleEligible: (eligible) =>
+    `multiple computer-capable nodes connected; pass node explicitly: ${eligible
+      .map((node) => node.nodeId)
+      .join(", ")}`,
+};
 
 async function resolveComputerNode(
   gatewayOpts: GatewayCallOptions,
@@ -340,58 +350,7 @@ async function resolveComputerNode(
   signal?: AbortSignal,
 ): Promise<NodeListNode> {
   const nodes = await listNodes(gatewayOpts, signal);
-  const eligible = nodes.filter(isEligibleComputerNode);
-  const trimmed = query?.trim();
-  if (trimmed) {
-    // Stable ids outrank human-facing names across the full machine set, and the
-    // precedence check matches case-insensitively because display-name resolution
-    // below is case-insensitive: an ineligible id that differs only by case must
-    // never fall through to another eligible machine's name. Exact case wins first.
-    const lowerTrimmed = trimmed.toLowerCase();
-    const exactNode =
-      nodes.find((node) => node.nodeId === trimmed) ??
-      nodes.find((node) => node.nodeId.toLowerCase() === lowerTrimmed);
-    if (exactNode) {
-      if (!isEligibleComputerNode(exactNode)) {
-        throw new Error(
-          `node "${trimmed}" is not computer-capable (needs a connected node advertising ${COMPUTER_ACT_COMMAND} and ${SCREEN_SNAPSHOT_COMMAND}; ${NOT_COMPUTER_CAPABLE_HINT}; ` +
-            `eligible node ids: ${formatEligibleComputerNodeIds(eligible)})`,
-        );
-      }
-      return exactNode;
-    }
-    // Shared resolver: rejects ambiguous display-name collisions, so control
-    // never lands on the wrong machine.
-    try {
-      const nodeId = resolveNodeIdFromList(eligible, trimmed, false);
-      const match = eligible.find((node) => node.nodeId === nodeId);
-      if (match) {
-        return match;
-      }
-    } catch (err) {
-      throw new Error(
-        `${formatErrorMessage(err)} (eligible computer-capable node ids: ${formatEligibleComputerNodeIds(eligible)})`,
-        { cause: err },
-      );
-    }
-    throw new Error(`node not found: ${trimmed}`);
-  }
-  if (eligible.length === 1) {
-    const node = eligible.at(0);
-    if (node) {
-      return node;
-    }
-  }
-  if (eligible.length === 0) {
-    throw new Error(
-      `no connected computer-capable node (a node must advertise ${COMPUTER_ACT_COMMAND} and ${SCREEN_SNAPSHOT_COMMAND}; ${NOT_COMPUTER_CAPABLE_HINT})`,
-    );
-  }
-  throw new Error(
-    `multiple computer-capable nodes connected; pass node explicitly: ${eligible
-      .map((node) => node.nodeId)
-      .join(", ")}`,
-  );
+  return resolveEligibleNodeFromList(nodes, query, isEligibleComputerNode, COMPUTER_NODE_MESSAGES);
 }
 
 type ScreenshotCapture = {

--- a/src/agents/tools/mobile-ui-tool.ts
+++ b/src/agents/tools/mobile-ui-tool.ts
@@ -14,7 +14,12 @@ import { stringEnum } from "../schema/typebox.js";
 import { type AnyAgentTool, jsonResult, readStringParam, ToolInputError } from "./common.js";
 import { gatewayCallOptionSchemaProperties } from "./gateway-schema.js";
 import { callGatewayTool, type GatewayCallOptions, readGatewayCallOptions } from "./gateway.js";
-import { listNodes, type NodeListNode, resolveNodeIdFromList } from "./nodes-utils.js";
+import {
+  type EligibleNodeMessages,
+  listNodes,
+  type NodeListNode,
+  resolveEligibleNodeFromList,
+} from "./nodes-utils.js";
 
 const MOBILE_UI_OBSERVE_COMMAND = "mobile.ui.observe";
 const MOBILE_UI_ACT_COMMAND = "mobile.ui.act";
@@ -219,14 +224,19 @@ function isEligibleMobileUiNode(node: NodeListNode): boolean {
 const MOBILE_UI_NODE_HINT =
   "pair an Android device, enable its Accessibility service, and arm mobile UI control";
 
-function formatEligibleMobileUiNodeIds(nodes: NodeListNode[]): string {
-  return nodes.length > 0
-    ? nodes
-        .map((node) => node.nodeId)
-        .toSorted()
-        .join(", ")
-    : "none";
-}
+const MOBILE_UI_NODE_MESSAGES: EligibleNodeMessages = {
+  ineligibleExact: (query, eligibleIds) =>
+    `node "${query}" is not a mobile-UI-capable device (${MOBILE_UI_NODE_HINT}; ` +
+    `eligible device ids: ${eligibleIds})`,
+  nameResolveFailed: (reason, eligibleIds) =>
+    `${reason} (eligible mobile-UI device ids: ${eligibleIds})`,
+  noneEligible: () =>
+    `no mobile-UI-capable device paired / not armed (${MOBILE_UI_NODE_HINT}; requires Android capability ${MOBILE_UI_CAPABILITY})`,
+  multipleEligible: (eligible) =>
+    `multiple mobile-UI-capable devices connected; pass node explicitly: ${eligible
+      .map((node) => node.nodeId)
+      .join(", ")}`,
+};
 
 async function resolveMobileUiNode(
   gatewayOpts: GatewayCallOptions,
@@ -234,53 +244,7 @@ async function resolveMobileUiNode(
   signal?: AbortSignal,
 ): Promise<NodeListNode> {
   const nodes = await listNodes(gatewayOpts, signal);
-  const eligible = nodes.filter(isEligibleMobileUiNode);
-  const trimmed = query?.trim();
-  if (trimmed) {
-    // Stable ids outrank human-facing names across the full device set, and the
-    // precedence check matches case-insensitively because display-name resolution
-    // below is case-insensitive: an ineligible id that differs only by case must
-    // never fall through to another eligible device's name. Exact case wins first.
-    const lowerTrimmed = trimmed.toLowerCase();
-    const exactNode =
-      nodes.find((node) => node.nodeId === trimmed) ??
-      nodes.find((node) => node.nodeId.toLowerCase() === lowerTrimmed);
-    if (exactNode) {
-      if (!isEligibleMobileUiNode(exactNode)) {
-        throw new Error(
-          `node "${trimmed}" is not a mobile-UI-capable device (${MOBILE_UI_NODE_HINT}; ` +
-            `eligible device ids: ${formatEligibleMobileUiNodeIds(eligible)})`,
-        );
-      }
-      return exactNode;
-    }
-    try {
-      const nodeId = resolveNodeIdFromList(eligible, trimmed, false);
-      const match = eligible.find((node) => node.nodeId === nodeId);
-      if (match) {
-        return match;
-      }
-    } catch (error) {
-      throw new Error(
-        `${formatErrorMessage(error)} (eligible mobile-UI device ids: ${formatEligibleMobileUiNodeIds(eligible)})`,
-        { cause: error },
-      );
-    }
-    throw new Error(`node not found: ${trimmed}`);
-  }
-  if (eligible.length === 1) {
-    return eligible[0] as NodeListNode;
-  }
-  if (eligible.length === 0) {
-    throw new Error(
-      `no mobile-UI-capable device paired / not armed (${MOBILE_UI_NODE_HINT}; requires Android capability ${MOBILE_UI_CAPABILITY})`,
-    );
-  }
-  throw new Error(
-    `multiple mobile-UI-capable devices connected; pass node explicitly: ${eligible
-      .map((node) => node.nodeId)
-      .join(", ")}`,
-  );
+  return resolveEligibleNodeFromList(nodes, query, isEligibleMobileUiNode, MOBILE_UI_NODE_MESSAGES);
 }
 
 async function invokeNodeCommand(params: {

--- a/src/agents/tools/nodes-utils.ts
+++ b/src/agents/tools/nodes-utils.ts
@@ -4,6 +4,7 @@
  * Loads paired nodes from Gateway and resolves requested/default nodes with legacy pair-list fallback.
  */
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
+import { formatErrorMessage } from "../../infra/errors.js";
 import { parseNodeList, parsePairingList } from "../../shared/node-list-parse.js";
 import type { NodeListNode } from "../../shared/node-list-types.js";
 import { resolveNodeFromNodeList, resolveNodeIdFromNodeList } from "../../shared/node-resolve.js";
@@ -161,6 +162,79 @@ export function resolveNodeIdFromList(
     allowCompactDisplayName: options.allowCompactDisplayName,
     pickDefaultNode,
   });
+}
+
+/** Tool-supplied error wording for {@link resolveEligibleNodeFromList}. */
+export type EligibleNodeMessages = {
+  /** Explicit exact-id match that is not eligible; `eligibleIds` is the sorted list (or "none"). */
+  ineligibleExact: (query: string, eligibleIds: string) => string;
+  /** Display-name/query resolution among eligible nodes failed (unknown/ambiguous). */
+  nameResolveFailed: (reason: string, eligibleIds: string) => string;
+  /** No eligible node exists. */
+  noneEligible: () => string;
+  /** Several eligible nodes and no query to disambiguate. */
+  multipleEligible: (eligible: NodeListNode[]) => string;
+};
+
+function formatNodeIdList(nodes: NodeListNode[]): string {
+  return nodes.length > 0
+    ? nodes
+        .map((node) => node.nodeId)
+        .toSorted()
+        .join(", ")
+    : "none";
+}
+
+/**
+ * Resolves a capability-gated node from the FULL node list, keeping control off
+ * the wrong device. An exact node-id match (case-sensitive, then -insensitive to
+ * mirror display-name matching) is checked against every node first, so an
+ * ineligible id can never fall through to an eligible node that merely shares its
+ * display name. Display-name/query resolution runs only among eligible nodes and
+ * rejects ambiguity. Any tool that filters nodes by capability must resolve
+ * through here rather than handing a pre-filtered list to {@link resolveNodeIdFromList}.
+ */
+export function resolveEligibleNodeFromList(
+  nodes: NodeListNode[],
+  query: string | undefined,
+  isEligible: (node: NodeListNode) => boolean,
+  messages: EligibleNodeMessages,
+): NodeListNode {
+  const eligible = nodes.filter(isEligible);
+  const trimmed = query?.trim();
+  if (trimmed) {
+    const eligibleIds = formatNodeIdList(eligible);
+    const lowerTrimmed = trimmed.toLowerCase();
+    const exactNode =
+      nodes.find((node) => node.nodeId === trimmed) ??
+      nodes.find((node) => node.nodeId.toLowerCase() === lowerTrimmed);
+    if (exactNode) {
+      if (!isEligible(exactNode)) {
+        throw new Error(messages.ineligibleExact(trimmed, eligibleIds));
+      }
+      return exactNode;
+    }
+    try {
+      const nodeId = resolveNodeIdFromList(eligible, trimmed, false);
+      const match = eligible.find((node) => node.nodeId === nodeId);
+      if (match) {
+        return match;
+      }
+    } catch (err) {
+      throw new Error(messages.nameResolveFailed(formatErrorMessage(err), eligibleIds), {
+        cause: err,
+      });
+    }
+    throw new Error(`node not found: ${trimmed}`);
+  }
+  const only = eligible.length === 1 ? eligible.at(0) : undefined;
+  if (only) {
+    return only;
+  }
+  if (eligible.length === 0) {
+    throw new Error(messages.noneEligible());
+  }
+  throw new Error(messages.multipleEligible(eligible));
 }
 
 /** Loads nodes from the Gateway and resolves the requested or default node id. */


### PR DESCRIPTION
## What Problem This Solves

The `computer` and `mobile_ui` agent tools each hand-rolled the identical node-resolution guard that keeps control off the wrong paired device. Duplicated safety logic is a latent hazard: a future capability-gated node tool (or a well-meaning edit to one copy) can silently reintroduce the wrong-device fall-through that #112503 fixed — where an explicit exact node id belonging to an ineligible device gets redirected to a *different* eligible device that merely shares its display name.

## Why This Change Was Made

Follow-up to #112255 (mobile_ui) landing, which put a second copy of that guard on `main`. This extracts the shared contract — exact node-id match against the FULL node list first → reject an ineligible exact match (listing eligible ids) → resolve by display-name/query only among eligible nodes, rejecting ambiguity → auto-select only when exactly one eligible node exists — into `resolveEligibleNodeFromList` in `nodes-utils.ts`, the node-resolution owner boundary. Any capability-gated tool now resolves through it instead of handing a pre-filtered list to `resolveNodeIdFromList` (the misuse that caused the original footgun). Each tool keeps its own eligibility predicate and error wording via a small `EligibleNodeMessages` config, so error strings are byte-identical and both tools' existing node-resolution tests pass unchanged. `bash-tools.exec-host-node-phases.ts` already resolves against the full list then validates capability, so it is left untouched.

## User Impact

No behavior change. Error messages, resolution order, and auto-select rules are identical. The change is structural: it removes two duplicate copies of the wrong-device guard and centralizes it so the safe order can't be re-broken per-tool. Net non-test LOC: −3.

## Evidence

- `node scripts/run-vitest.mjs` on `computer-tool.node-resolution.test.ts`, `computer-tool.test.ts`, `mobile-ui-tool.test.ts`, `nodes-utils.test.ts` → **108 passed** (all preserved, unchanged strings).
- `tsgo -p tsconfig.core.json`: the only project error is a pre-existing stale-install (`libphonenumber-js/min` in `packages/normalization-core`, unrelated — merged `main` added the dep and no local checkout has re-`pnpm install`ed); my three changed files produce **zero** type errors. Hosted CI runs tsgo on a fresh install.
- `oxfmt --check` (0.58.0) clean; `oxlint` (1.73.0) on all three files → exit 0.
- `git diff --numstat` (non-test): +114 / −117 = **−3**.
- Autoreview (Codex `gpt-5.6-sol`, xhigh): clean, 0.98, no accepted findings — "preserves the existing capability filtering, exact-ID precedence, case-insensitive fallback, display-name ambiguity handling, eligible-ID formatting, and no-query behavior for both."
