### PR TITLE
fix(channels): hide internal tool text in Reef and Zalo Personal

### DIFF
--- a/extensions/reef/src/outbound.test.ts
+++ b/extensions/reef/src/outbound.test.ts
@@ -18,6 +18,23 @@ describe("reefOutboundAdapter", () => {
     expect(reefOutboundAdapter.deliveryMode).toBe("gateway");
   });
 
+  it("removes internal tool text while preserving user-visible examples", () => {
+    const sanitizeText = reefOutboundAdapter.sanitizeText;
+    if (!sanitizeText) {
+      throw new Error("expected Reef outbound sanitizeText hook");
+    }
+    const sanitize = (text: string) => sanitizeText({ text, payload: { text } });
+    const fenced = ["```xml", '<tool_call>{"name":"exec"}</tool_call>', "```"].join("\n");
+
+    expect(sanitize("Done.\n⚠️ 🛠️ `search repos (agent)` failed")).toBe("Done.");
+    expect(sanitize('<tool_call>{"name":"exec"}</tool_call>Message sent.')).toBe("Message sent.");
+    expect(sanitize("The encrypted message was delivered.")).toBe(
+      "The encrypted message was delivered.",
+    );
+    expect(sanitize(fenced)).toBe(fenced);
+    expect(sanitize("⚠️ 🛠️ `search repos (agent)` failed")).toBe("");
+  });
+
   it("normalizes the SDK target and delegates only message content/context to the guarded flow", async () => {
     const order: string[] = [];
     const send = vi.fn(

--- a/extensions/reef/src/outbound.ts
+++ b/extensions/reef/src/outbound.ts
@@ -7,6 +7,7 @@ import type {
   OutboundDeliveryResult,
 } from "openclaw/plugin-sdk/channel-send-result";
 import { PlatformMessageNotDispatchedError } from "openclaw/plugin-sdk/error-runtime";
+import { sanitizeAssistantVisibleText } from "openclaw/plugin-sdk/text-chunking";
 import { canonicalBytes, REEF_MAX_PLAINTEXT_BYTES } from "../protocol/index.js";
 import { normalizeReefTarget } from "./config-schema.js";
 import { isPermanentReefOutboundRejection, prepareReefMessageId } from "./flow.js";
@@ -141,6 +142,7 @@ export const reefOutboundAdapter: ChannelOutboundAdapter = {
   deliveryMode: "gateway",
   textChunkLimit: REEF_MAX_PLAINTEXT_BYTES,
   chunker: chunkReefText,
+  sanitizeText: ({ text }) => sanitizeAssistantVisibleText(text),
   prepareConversationTurnMessageId: ({ text, threadId }) => {
     // Runs in Gateway correlation setup before the operation and queue row exist.
     assertAtomicReefMessageFits({ text, threadId });

--- a/extensions/zalouser/src/channel.adapters.ts
+++ b/extensions/zalouser/src/channel.adapters.ts
@@ -18,6 +18,7 @@ import { createStaticReplyToModeResolver } from "openclaw/plugin-sdk/conversatio
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { sanitizeAssistantVisibleText } from "openclaw/plugin-sdk/text-chunking";
 import {
   checkZcaAuthenticated,
   listZalouserAccountIds,
@@ -469,7 +470,8 @@ export const zalouserOutboundAdapter = {
       emptyResult: createEmptyChannelResult("zalouser"),
     }),
   ...zalouserRawSendResultAdapter,
-};
+  sanitizeText: ({ text }) => sanitizeAssistantVisibleText(text),
+} satisfies ChannelOutboundAdapter;
 
 export const zalouserMessagingAdapter = {
   targetPrefixes: ["zalouser", "zlu"],

--- a/extensions/zalouser/src/channel.test.ts
+++ b/extensions/zalouser/src/channel.test.ts
@@ -98,6 +98,23 @@ describe("zalouser outbound", () => {
     } as never);
   });
 
+  it("removes internal tool text while preserving user-visible examples", () => {
+    const sanitizeText = zalouserOutboundAdapter.sanitizeText;
+    if (!sanitizeText) {
+      throw new Error("expected Zalo Personal outbound sanitizeText hook");
+    }
+    const sanitize = (text: string) => sanitizeText({ text, payload: { text } });
+    const fenced = ["```xml", '<tool_call>{"name":"exec"}</tool_call>', "```"].join("\n");
+
+    expect(sanitize("Done.\n⚠️ 🛠️ `search repos (agent)` failed")).toBe("Done.");
+    expect(sanitize('<tool_call>{"name":"exec"}</tool_call>Message sent.')).toBe("Message sent.");
+    expect(sanitize("The personal message was delivered.")).toBe(
+      "The personal message was delivered.",
+    );
+    expect(sanitize(fenced)).toBe(fenced);
+    expect(sanitize("⚠️ 🛠️ `search repos (agent)` failed")).toBe("");
+  });
+
   it("passes markdown chunk settings through sendText", async () => {
     const sendText = requireZalouserSendText();
 


### PR DESCRIPTION
## What Problem This Solves

Reef and Zalo Personal could deliver internal assistant tool-failure banners or tool-call XML to recipients because their outbound adapters did not provide the shared `sanitizeText` hook. The canonical delivery pipeline therefore skipped `sanitizeAssistantVisibleText()` for these two channels.

Related: #90684. The overlapping Nostr and Microsoft Teams slices remain in #103361 and #95867; this PR does not duplicate them.

## Why This Change Was Made

Both channel-owned outbound adapters now opt into the existing Plugin SDK assistant-visible-text sanitizer. This keeps policy at the established adapter boundary, reuses the canonical parser instead of adding channel-specific regexes, and avoids changing the optional outbound contract for external plugins.

The Zalo Personal adapter also uses `satisfies ChannelOutboundAdapter`, so the hook and existing spread-based send implementation are checked against the complete adapter contract without widening its inferred return surface.

## User Impact

Reef and Zalo Personal recipients receive intended assistant prose without internal `⚠️ 🛠️ … failed` traces or raw tool-call scaffolding. Ordinary prose and literal XML examples inside fenced code remain unchanged. Replies containing only internal trace text sanitize to empty rather than exposing the trace.

No config, authentication, protocol, dependency, or channel transport behavior changes.

## Evidence

Exact head: `3ae07c652c2f9cd084bf03ace1ed8dad3d630777`

Environment: Linux, Node `24.18.0`, pnpm `11.2.2`.

### Before / after behavior

Current `main` negative control:

```text
git grep -n 'sanitizeText' origin/main -- \
  extensions/reef/src/outbound.ts \
  extensions/zalouser/src/channel.adapters.ts
# no matches
```

The same input was executed through both exact-head adapter hooks:

```text
Visible answer.
⚠️ 🛠️ `search repos (agent)` failed
<tool_call>{"name":"exec"}</tool_call>
```

Observed output:

```json
{"channel":"reef","output":"Visible answer."}
{"channel":"zalouser","output":"Visible answer."}
```

The adjacent regressions additionally prove ordinary prose and fenced XML examples are preserved, while trace-only input becomes empty.

### Automated validation

- `node scripts/run-vitest.mjs extensions/reef/src/outbound.test.ts extensions/zalouser/src/channel.test.ts src/shared/text/assistant-visible-text.test.ts src/infra/outbound/deliver.test.ts` — 4 Vitest shards passed; 301 tests passed.
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 node scripts/check-changed.mjs -- extensions/reef/src/outbound.ts extensions/reef/src/outbound.test.ts extensions/zalouser/src/channel.adapters.ts extensions/zalouser/src/channel.test.ts` — passed on Node 24.18.0, including extension production/test typechecks, targeted lint, formatting, Plugin SDK API/boundary checks, import cycles, and repository guards.
- `git diff --check` — passed.

No live Reef or Zalo Personal credentials were used. This is a nonvisual text-shaping change, so exact adapter output and canonical delivery tests are stronger evidence than a screenshot of mocked text.

Fresh autoreview secret preflight passed, but the Codex reviewer transport could not produce a verdict because the environment proxy repeatedly returned HTTP 403 for Responses WebSocket connections. The requester explicitly authorized proceeding with focused proof, CI, and exact-head ClawSweeper review; this is not represented as an autoreview-clean result.

Disclosure: AI-assisted.
