### PR TITLE
fix(ci): stabilize Swift and Android coordination tests

### DIFF
--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerBranchCoordinationTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerBranchCoordinationTest.kt
@@ -3,6 +3,7 @@ package ai.openclaw.app.chat
 import ai.openclaw.app.gateway.GatewayRequestOutcomeUnknown
 import androidx.room.Room
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -10,6 +11,8 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
@@ -45,8 +48,11 @@ class ChatControllerBranchCoordinationTest {
     database.close()
   }
 
-  private fun controller(gateway: ScriptedGateway): ChatController {
-    val controllerScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+  private fun controller(
+    gateway: ScriptedGateway,
+    dispatcher: CoroutineDispatcher = Dispatchers.Default,
+  ): ChatController {
+    val controllerScope = CoroutineScope(SupervisorJob() + dispatcher)
     controllerScopes += controllerScope
     return ChatController(
       scope = controllerScope,
@@ -166,14 +172,15 @@ class ChatControllerBranchCoordinationTest {
         """{"branches":[{"leafEntryId":"leaf-rewound","headline":"Rewound","messageCount":1,"active":true}]}""",
       )
       gateway.respondChatSend("started")
-      val controller = controller(gateway)
+      val controller = controller(gateway, StandardTestDispatcher(testScheduler))
+      runCurrent()
       controller.awaitOutboxRestore()
       controller.handleGatewayEvent("health", null)
-      withContext(Dispatchers.Default.limitedParallelism(1)) {
-        withTimeout(5_000) { controller.healthOk.first { it } }
-      }
+      runCurrent()
+      assertTrue(controller.healthOk.value)
 
       assertNull(controller.rewindSessionAtEntryResult("main", "entry-a"))
+      advanceUntilIdle()
       retryHistoryStarted.await()
       assertTrue(controller.sendMessageAwaitAcceptance("queued after rewind", "off", emptyList()))
 
@@ -186,7 +193,10 @@ class ChatControllerBranchCoordinationTest {
       releaseRetryHistory.complete(Unit)
       withContext(Dispatchers.Default.limitedParallelism(1)) {
         withTimeout(5_000) {
-          while (gateway.callCount("chat.send") == 0) kotlinx.coroutines.delay(10)
+          while (gateway.callCount("chat.send") == 0) {
+            runCurrent()
+            kotlinx.coroutines.delay(10)
+          }
         }
       }
 

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelOutboxTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelOutboxTests.swift
@@ -2684,21 +2684,24 @@ extension ChatViewModelOutboxTests {
             await MainActor.run { queuedStateCount(observer) == 1 }
         }
 
-        let sendGate = DeleteGate()
-        await transport.state.setHeldSendGate(sendGate)
-        await transport.goOnline()
-        try await waitUntil("first view model claims row") {
-            await store.loadCommands().map(\.status) == [.sending]
-        }
         let messageID = try #require(await MainActor.run {
             observer.messages.first { observer.outboxState(for: $0.id) == .queued }?.id
         })
+        let sendGate = DeleteGate()
+        await transport.state.setHeldSendGate(sendGate)
+        // This fake exposes one shared event stream, unlike native transports that
+        // broadcast reconnects. Select the intended owner instead of racing the observer.
+        await MainActor.run { sender.applyTransportHealth(true) }
+        try await waitUntil("first view model claims row") {
+            await store.loadCommands().map(\.status) == [.sending]
+        }
         await MainActor.run { observer.deleteOutboxMessage(messageID) }
         try await waitUntil("observer adopts sending status") {
             await MainActor.run { observer.outboxState(for: messageID) == .sending }
         }
         #expect(await store.loadCommands().map(\.status) == [.sending])
 
+        await transport.state.setHealthy(true)
         await sendGate.open()
         try await waitUntil("claimed send confirms") {
             await store.loadCommands().isEmpty


### PR DESCRIPTION
## What Problem This Solves

Fixes two nondeterministic test failures that made `main` CI red under parallel runner load:

- The OpenClawKit outbox test could let a stale observer consume the fake transport's single reconnect event, violating the test's intended sender/observer roles.
- The Android branch-reconciliation test put retry work on real `Dispatchers.Default` while waiting unboundedly from `runTest`, allowing the coroutine-test watchdog to expire.

Failing run: https://github.com/openclaw/openclaw/actions/runs/29905762458

## Why This Change Was Made

The Swift test now invokes the intended sender's normal transport-health path directly and captures the observer's queued message before the sender claims it. The Android test injects a `StandardTestDispatcher` into the controller, explicitly advances the delayed retry, and uses a bounded scheduler pump while Room callbacks complete on their real dispatcher.

Production outbox, transport, and branch-reconciliation behavior is unchanged.

## User Impact

There is no shipped runtime behavior change. Maintainers get stable Swift and Android CI coverage without weakening the concurrency, stale-observer, or reconciliation invariants those tests protect.

## Evidence

- Swift outbox test: 10 consecutive focused passes.
- Android branch-reconciliation test: 5 consecutive focused passes.
- Full `ChatViewModelOutboxTests` suite: 51 tests passed.
- Full OpenClawKit package with `swift test --parallel`: passed.
- Full Android `ChatControllerBranchCoordinationTest` class: passed.
- Android `:app:ktlintCheck`: passed.
- Repository Swift lint and formatting wrappers: passed with full Xcode.
- Rebased patch identity verified with `git patch-id --stable`; both exact tests passed again after rebasing onto current `main`.
- Codex autoreview (`--mode uncommitted`): clean, no accepted/actionable findings.

AI-assisted: Claude Code investigated and implemented the fixes with independent Codex autoreview. The code paths, test contracts, and proof results were manually verified.
