### PR TITLE
fix(uninstall): remove the OpenClaw shell-completion block on uninstall (#112625)

### DIFF
--- a/src/cli/completion-runtime.remove.test.ts
+++ b/src/cli/completion-runtime.remove.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { removeCompletionBlockFromProfile } from "./completion-runtime.js";
+
+const CACHE = "/home/kng/.openclaw/completions/openclaw.bash";
+
+describe("removeCompletionBlockFromProfile (#112625)", () => {
+  it("removes the header + source line block, preserving surrounding user content", () => {
+    const content = [
+      "# my prompt",
+      'export PS1="$ "',
+      "",
+      "# OpenClaw Completion",
+      `[ -f "${CACHE}" ] && source "${CACHE}"`,
+      "",
+      "alias ll='ls -la'",
+    ].join("\n");
+    const { next, changed } = removeCompletionBlockFromProfile(content, "openclaw", CACHE);
+    expect(changed).toBe(true);
+    expect(next).not.toContain("# OpenClaw Completion");
+    expect(next).not.toContain(CACHE);
+    expect(next).toContain("# my prompt");
+    expect(next).toContain("alias ll='ls -la'");
+  });
+
+  it("removes a stray completion source line even without the header", () => {
+    const content = ["# user", `source "${CACHE}"`, "# more"].join("\n");
+    const { next, changed } = removeCompletionBlockFromProfile(content, "openclaw", CACHE);
+    expect(changed).toBe(true);
+    expect(next).not.toContain(CACHE);
+    expect(next).toContain("# user");
+    expect(next).toContain("# more");
+  });
+
+  it("removes a dynamic `openclaw completion` source line", () => {
+    const content = ["setup", 'source <(openclaw completion bash)', "done"].join("\n");
+    const { next, changed } = removeCompletionBlockFromProfile(content, "openclaw", null);
+    expect(changed).toBe(true);
+    expect(next).not.toContain("openclaw completion");
+    expect(next).toContain("setup");
+    expect(next).toContain("done");
+  });
+
+  it("is a no-op when there is no OpenClaw block", () => {
+    const content = ["# just a user file", 'export PATH="$HOME/bin:$PATH"'].join("\n");
+    const { next, changed } = removeCompletionBlockFromProfile(content, "openclaw", CACHE);
+    expect(changed).toBe(false);
+    expect(next).toBe(content);
+  });
+
+  it("does not touch a user comment that merely mentions openclaw", () => {
+    const content = ["# reminder: install openclaw later", "echo hi"].join("\n");
+    const { next, changed } = removeCompletionBlockFromProfile(content, "openclaw", CACHE);
+    expect(changed).toBe(false);
+    expect(next).toBe(content);
+  });
+
+  it("empties a profile that held only the completion block", () => {
+    const content = ["# OpenClaw Completion", `[ -f "${CACHE}" ] && source "${CACHE}"`, ""].join(
+      "\n",
+    );
+    const { next } = removeCompletionBlockFromProfile(content, "openclaw", CACHE);
+    expect(next).toBe("");
+  });
+
+  it("is idempotent", () => {
+    const content = ["a", "# OpenClaw Completion", `source "${CACHE}"`, "b"].join("\n");
+    const once = removeCompletionBlockFromProfile(content, "openclaw", CACHE).next;
+    const twice = removeCompletionBlockFromProfile(once, "openclaw", CACHE);
+    expect(twice.changed).toBe(false);
+    expect(twice.next).toBe(once);
+  });
+});

--- a/src/cli/completion-runtime.remove.test.ts
+++ b/src/cli/completion-runtime.remove.test.ts
@@ -34,13 +34,13 @@ describe("removeCompletionBlockFromProfile (#112625)", () => {
     expect(next).toContain("# more");
   });
 
-  it("removes a dynamic `openclaw completion` source line", () => {
+  it("preserves a user-managed standalone dynamic completion line (#112631 review)", () => {
+    // A bare `source <(openclaw completion bash)` with no OpenClaw header and no cache-file
+    // reference may be user-managed; uninstall must not delete it.
     const content = ["setup", "source <(openclaw completion bash)", "done"].join("\n");
     const { next, changed } = removeCompletionBlockFromProfile(content, "openclaw", null);
-    expect(changed).toBe(true);
-    expect(next).not.toContain("openclaw completion");
-    expect(next).toContain("setup");
-    expect(next).toContain("done");
+    expect(changed).toBe(false);
+    expect(next).toBe(content);
   });
 
   it("is a no-op when there is no OpenClaw block", () => {

--- a/src/cli/completion-runtime.remove.test.ts
+++ b/src/cli/completion-runtime.remove.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { removeCompletionBlockFromProfile } from "./completion-runtime.js";
+import {
+  completionProfileCandidates,
+  removeCompletionBlockFromProfile,
+} from "./completion-runtime.js";
 
 const CACHE = "/home/kng/.openclaw/completions/openclaw.bash";
 
@@ -32,7 +35,7 @@ describe("removeCompletionBlockFromProfile (#112625)", () => {
   });
 
   it("removes a dynamic `openclaw completion` source line", () => {
-    const content = ["setup", 'source <(openclaw completion bash)', "done"].join("\n");
+    const content = ["setup", "source <(openclaw completion bash)", "done"].join("\n");
     const { next, changed } = removeCompletionBlockFromProfile(content, "openclaw", null);
     expect(changed).toBe(true);
     expect(next).not.toContain("openclaw completion");
@@ -60,6 +63,27 @@ describe("removeCompletionBlockFromProfile (#112625)", () => {
     );
     const { next } = removeCompletionBlockFromProfile(content, "openclaw", CACHE);
     expect(next).toBe("");
+  });
+
+  it("preserves unrelated trailing bytes after the removed block (#112631 review)", () => {
+    const content = [
+      "export EDITOR=vim",
+      "# OpenClaw Completion",
+      `[ -f "${CACHE}" ] && source "${CACHE}"`,
+      "",
+      "",
+    ].join("\n");
+    const { next, changed } = removeCompletionBlockFromProfile(content, "openclaw", CACHE);
+    expect(changed).toBe(true);
+    expect(next).not.toContain("# OpenClaw Completion");
+    expect(next).toBe("export EDITOR=vim\n\n");
+  });
+
+  it("targets both bash profiles so a .bash_profile install is cleaned (#112631 review)", () => {
+    expect(completionProfileCandidates("bash", { env: { HOME: "/home/kng" } })).toEqual([
+      "/home/kng/.bashrc",
+      "/home/kng/.bash_profile",
+    ]);
   });
 
   it("is idempotent", () => {

--- a/src/cli/completion-runtime.ts
+++ b/src/cli/completion-runtime.ts
@@ -173,6 +173,11 @@ export function removeCompletionBlockFromProfile(
     const line = lines[i] ?? "";
     if (isCompletionProfileHeader(line)) {
       removed = true;
+      // Drop the single blank separator the installer writes before the block;
+      // leave all other user whitespace untouched.
+      if (filtered[filtered.length - 1] === "") {
+        filtered.pop();
+      }
       i += 1; // drop the source line that follows the header too
       continue;
     }
@@ -187,31 +192,55 @@ export function removeCompletionBlockFromProfile(
   if (!removed) {
     return { next: content, changed: false };
   }
-  const trimmed = filtered.join("\n").trimEnd();
-  const next = trimmed ? `${trimmed}\n` : "";
+  // Rejoin without normalizing the tail so user bytes after the block survive.
+  const next = filtered.join("\n");
   return { next, changed: next !== content };
 }
 
 /**
- * Strips the OpenClaw completion block from a shell's startup profile on disk.
- * A no-op when the profile is absent or holds no OpenClaw lines.
+ * Every startup profile the installer may have written the completion block to.
+ * `installCompletion` falls back to `~/.bash_profile` when `~/.bashrc` is absent, so
+ * uninstall must check both bash profiles to avoid leaving a stale source line.
+ */
+export function completionProfileCandidates(
+  shell: CompletionShell,
+  options: { env?: NodeJS.ProcessEnv; homeDir?: () => string; platform?: NodeJS.Platform } = {},
+): string[] {
+  const primary = resolveCompletionProfilePath(shell, options);
+  if (shell === "bash") {
+    const env = options.env ?? process.env;
+    const home = env.HOME || (options.homeDir ?? os.homedir)();
+    return [primary, path.join(home, ".bash_profile")];
+  }
+  return [primary];
+}
+
+/**
+ * Strips the OpenClaw completion block from a shell's startup profile(s) on disk.
+ * A no-op when a profile is absent or holds no OpenClaw lines.
  */
 export async function removeCompletionInstall(
   shell: CompletionShell,
   binName = "openclaw",
 ): Promise<{ profilePath: string; changed: boolean }> {
-  const profilePath = resolveCompletionProfilePath(shell);
-  if (!(await pathExists(profilePath))) {
-    return { profilePath, changed: false };
-  }
   const cachePathCandidate = resolveCompletionCachePath(shell, binName);
   const cachedPath = (await pathExists(cachePathCandidate)) ? cachePathCandidate : null;
-  const content = await fs.readFile(profilePath, "utf-8");
-  const { next, changed } = removeCompletionBlockFromProfile(content, binName, cachedPath);
-  if (changed) {
-    await fs.writeFile(profilePath, next, "utf-8");
+  const candidates = completionProfileCandidates(shell);
+  let changedPath = candidates[0] ?? resolveCompletionProfilePath(shell);
+  let changed = false;
+  for (const profilePath of candidates) {
+    if (!(await pathExists(profilePath))) {
+      continue;
+    }
+    const content = await fs.readFile(profilePath, "utf-8");
+    const result = removeCompletionBlockFromProfile(content, binName, cachedPath);
+    if (result.changed) {
+      await fs.writeFile(profilePath, result.next, "utf-8");
+      changed = true;
+      changedPath = profilePath;
+    }
   }
-  return { profilePath, changed };
+  return { profilePath: changedPath, changed };
 }
 
 /** Resolves the shell startup profile path that should contain the OpenClaw completion block. */

--- a/src/cli/completion-runtime.ts
+++ b/src/cli/completion-runtime.ts
@@ -229,12 +229,12 @@ export function completionProfileCandidates(
 export async function removeCompletionInstall(
   shell: CompletionShell,
   binName = "openclaw",
-): Promise<{ profilePath: string; changed: boolean }> {
+  options: { dryRun?: boolean } = {},
+): Promise<{ profilePath: string; changed: boolean; changedPaths: string[] }> {
   const cachePathCandidate = resolveCompletionCachePath(shell, binName);
   const cachedPath = (await pathExists(cachePathCandidate)) ? cachePathCandidate : null;
   const candidates = completionProfileCandidates(shell);
-  let changedPath = candidates[0] ?? resolveCompletionProfilePath(shell);
-  let changed = false;
+  const changedPaths: string[] = [];
   for (const profilePath of candidates) {
     if (!(await pathExists(profilePath))) {
       continue;
@@ -242,12 +242,20 @@ export async function removeCompletionInstall(
     const content = await fs.readFile(profilePath, "utf-8");
     const result = removeCompletionBlockFromProfile(content, binName, cachedPath);
     if (result.changed) {
-      await fs.writeFile(profilePath, result.next, "utf-8");
-      changed = true;
-      changedPath = profilePath;
+      // Dry-run computes exactly what WOULD change without touching the file, so the
+      // uninstall preview lists the same removable entries the real removal reports.
+      if (!options.dryRun) {
+        await fs.writeFile(profilePath, result.next, "utf-8");
+      }
+      changedPaths.push(profilePath);
     }
   }
-  return { profilePath: changedPath, changed };
+  return {
+    profilePath:
+      changedPaths[changedPaths.length - 1] ?? candidates[0] ?? resolveCompletionProfilePath(shell),
+    changed: changedPaths.length > 0,
+    changedPaths,
+  };
 }
 
 /** Resolves the shell startup profile path that should contain the OpenClaw completion block. */

--- a/src/cli/completion-runtime.ts
+++ b/src/cli/completion-runtime.ts
@@ -210,7 +210,10 @@ export function completionProfileCandidates(
   if (shell === "bash") {
     const env = options.env ?? process.env;
     const home = env.HOME || (options.homeDir ?? os.homedir)();
-    return [primary, path.join(home, ".bash_profile")];
+    // Scrub BOTH standard bash profiles regardless of which exists now: install writes to
+    // whichever bash profile is present (resolveCompletionProfilePath picks the existing
+    // one), so uninstall must clean both, plus any custom primary. Dedupe, .bashrc first.
+    return [...new Set([path.join(home, ".bashrc"), path.join(home, ".bash_profile"), primary])];
   }
   return [primary];
 }

--- a/src/cli/completion-runtime.ts
+++ b/src/cli/completion-runtime.ts
@@ -181,7 +181,11 @@ export function removeCompletionBlockFromProfile(
       i += 1; // drop the source line that follows the header too
       continue;
     }
-    if (isCompletionProfileLine(line, binName, cachePath)) {
+    // Only remove a STANDALONE line that points at OpenClaw's own completion cache file
+    // (unambiguously installer-written). A bare `source <(openclaw completion ...)` with no
+    // header and no cache reference may be user-managed, so uninstall must preserve it.
+    // (#112631 review: preserve user-managed dynamic completion commands)
+    if (cachePath !== null && line.includes(cachePath)) {
       removed = true;
       continue;
     }

--- a/src/cli/completion-runtime.ts
+++ b/src/cli/completion-runtime.ts
@@ -154,6 +154,66 @@ function updateCompletionProfile(
   return { next, changed: next !== content, hadExisting };
 }
 
+/**
+ * Removes the OpenClaw completion block -- the `# OpenClaw Completion` header plus
+ * the source line that follows it -- and any stray OpenClaw completion source lines
+ * from a shell profile's raw content. Only OpenClaw-owned lines are touched; all
+ * user content is preserved. This mirrors the removal half of
+ * updateCompletionProfile so install and uninstall stay symmetric.
+ */
+export function removeCompletionBlockFromProfile(
+  content: string,
+  binName: string,
+  cachePath: string | null,
+): { next: string; changed: boolean } {
+  const lines = content.split("\n");
+  const filtered: string[] = [];
+  let removed = false;
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i] ?? "";
+    if (isCompletionProfileHeader(line)) {
+      removed = true;
+      i += 1; // drop the source line that follows the header too
+      continue;
+    }
+    if (isCompletionProfileLine(line, binName, cachePath)) {
+      removed = true;
+      continue;
+    }
+    filtered.push(line);
+  }
+  // Preserve the profile byte-for-byte when it holds no OpenClaw lines, so an
+  // uninstall never rewrites (or adds a trailing newline to) an untouched file.
+  if (!removed) {
+    return { next: content, changed: false };
+  }
+  const trimmed = filtered.join("\n").trimEnd();
+  const next = trimmed ? `${trimmed}\n` : "";
+  return { next, changed: next !== content };
+}
+
+/**
+ * Strips the OpenClaw completion block from a shell's startup profile on disk.
+ * A no-op when the profile is absent or holds no OpenClaw lines.
+ */
+export async function removeCompletionInstall(
+  shell: CompletionShell,
+  binName = "openclaw",
+): Promise<{ profilePath: string; changed: boolean }> {
+  const profilePath = resolveCompletionProfilePath(shell);
+  if (!(await pathExists(profilePath))) {
+    return { profilePath, changed: false };
+  }
+  const cachePathCandidate = resolveCompletionCachePath(shell, binName);
+  const cachedPath = (await pathExists(cachePathCandidate)) ? cachePathCandidate : null;
+  const content = await fs.readFile(profilePath, "utf-8");
+  const { next, changed } = removeCompletionBlockFromProfile(content, binName, cachedPath);
+  if (changed) {
+    await fs.writeFile(profilePath, next, "utf-8");
+  }
+  return { profilePath, changed };
+}
+
 /** Resolves the shell startup profile path that should contain the OpenClaw completion block. */
 export function resolveCompletionProfilePath(
   shell: CompletionShell,

--- a/src/commands/uninstall.ts
+++ b/src/commands/uninstall.ts
@@ -20,6 +20,12 @@ import type { RuntimeEnv } from "../runtime.js";
 import { resolveHomeDir, shortenHomeInString } from "../utils.js";
 import { resolveCleanupPlanFromDisk } from "./cleanup-plan.js";
 import { removePath, removeStateAndLinkedPaths, removeWorkspaceDirs } from "./cleanup-utils.js";
+import {
+  COMPLETION_SHELLS,
+  isCompletionInstalled,
+  removeCompletionInstall,
+  resolveCompletionProfilePath,
+} from "../cli/completion-runtime.js";
 
 type UninstallScope = "service" | "state" | "workspace" | "app";
 
@@ -113,6 +119,29 @@ function logBackupRecommendation(runtime: RuntimeEnv) {
 }
 
 /** Runs the uninstall flow for selected service/state/workspace/app scopes. */
+// Removes the OpenClaw completion block from every shell profile that carries it,
+// so uninstall stops leaving a source line for a now-deleted completions file.
+async function removeShellCompletion(runtime: RuntimeEnv, dryRun?: boolean) {
+  for (const shell of COMPLETION_SHELLS) {
+    try {
+      if (dryRun) {
+        if (await isCompletionInstalled(shell)) {
+          runtime.log(
+            `[dry-run] remove shell completion from ${shortenHomeInString(resolveCompletionProfilePath(shell))}`,
+          );
+        }
+        continue;
+      }
+      const { profilePath, changed } = await removeCompletionInstall(shell);
+      if (changed) {
+        runtime.log(`Removed shell completion from ${shortenHomeInString(profilePath)}`);
+      }
+    } catch {
+      // Best-effort: never fail an uninstall because one profile could not be rewritten.
+    }
+  }
+}
+
 export async function uninstallCommand(runtime: RuntimeEnv, opts: UninstallOptions) {
   const { scopes, hadExplicit } = buildScopeSelection(opts);
   const interactive = !opts.nonInteractive;
@@ -214,6 +243,7 @@ export async function uninstallCommand(runtime: RuntimeEnv, opts: UninstallOptio
       runtime,
       { dryRun, preservePaths: scopes.has("workspace") ? [] : workspaceDirs },
     );
+    await removeShellCompletion(runtime, dryRun);
   }
 
   if (scopes.has("workspace")) {

--- a/src/commands/uninstall.ts
+++ b/src/commands/uninstall.ts
@@ -13,6 +13,7 @@ import {
   removeLegacyWorkspaceStateForReset,
 } from "../agents/workspace-legacy-state.js";
 import { formatCliCommand } from "../cli/command-format.js";
+import { COMPLETION_SHELLS, removeCompletionInstall } from "../cli/completion-runtime.js";
 import { isNixMode } from "../config/config.js";
 import { resolveGatewayService } from "../daemon/service.js";
 import { formatErrorMessage } from "../infra/errors.js";
@@ -20,12 +21,6 @@ import type { RuntimeEnv } from "../runtime.js";
 import { resolveHomeDir, shortenHomeInString } from "../utils.js";
 import { resolveCleanupPlanFromDisk } from "./cleanup-plan.js";
 import { removePath, removeStateAndLinkedPaths, removeWorkspaceDirs } from "./cleanup-utils.js";
-import {
-  COMPLETION_SHELLS,
-  isCompletionInstalled,
-  removeCompletionInstall,
-  resolveCompletionProfilePath,
-} from "../cli/completion-runtime.js";
 
 type UninstallScope = "service" | "state" | "workspace" | "app";
 
@@ -124,17 +119,16 @@ function logBackupRecommendation(runtime: RuntimeEnv) {
 async function removeShellCompletion(runtime: RuntimeEnv, dryRun?: boolean) {
   for (const shell of COMPLETION_SHELLS) {
     try {
-      if (dryRun) {
-        if (await isCompletionInstalled(shell)) {
-          runtime.log(
-            `[dry-run] remove shell completion from ${shortenHomeInString(resolveCompletionProfilePath(shell))}`,
-          );
-        }
-        continue;
-      }
-      const { profilePath, changed } = await removeCompletionInstall(shell);
-      if (changed) {
-        runtime.log(`Removed shell completion from ${shortenHomeInString(profilePath)}`);
+      // Base the dry-run preview on the SAME entries the real removal would touch, so it
+      // lists exactly the profiles that carry a removable OpenClaw block (both bash profiles
+      // included) and never a profile with nothing to remove.
+      const { changedPaths } = await removeCompletionInstall(shell, "openclaw", { dryRun });
+      for (const profilePath of changedPaths) {
+        runtime.log(
+          dryRun
+            ? `[dry-run] remove shell completion from ${shortenHomeInString(profilePath)}`
+            : `Removed shell completion from ${shortenHomeInString(profilePath)}`,
+        );
       }
     } catch {
       // Best-effort: never fail an uninstall because one profile could not be rewritten.


### PR DESCRIPTION
## What Problem This Solves

`openclaw uninstall` removes the gateway service, state, workspaces, and the macOS app — but it **never removes the `# OpenClaw Completion` block it added to the user's shell profile** (`.bashrc`/`.zshrc`/fish/PowerShell). After uninstalling (including `openclaw uninstall --all --yes`), every new shell keeps sourcing a completions file that state-removal just deleted:

```
bash: /home/<user>/.openclaw/completions/openclaw.bash: No such file or directory
```

Closes #112625.

## Why This Change Was Made

Install writes a completion block via `updateCompletionProfile` (`src/cli/completion-runtime.ts`), but there was **no inverse** — `uninstall.ts` had no path that touches the shell profile, so the block (and any stray source line) was orphaned. Uninstall even prints "CLI still installed", but the dangling *completion* line is OpenClaw-owned config that uninstall should clean up.

This adds symmetric removal:

- **`removeCompletionBlockFromProfile(content, binName, cachePath)`** — a pure function that strips the `# OpenClaw Completion` header plus the source line that follows it, and any stray OpenClaw completion source lines (cached or dynamic `source <(openclaw completion …)`). It mirrors the *removal half* of `updateCompletionProfile` exactly, so install and uninstall use the same marker logic. It touches **only OpenClaw-owned lines** and returns the profile **byte-for-byte unchanged** when there is nothing to remove (never rewrites or adds a trailing newline to an untouched file).
- **`removeCompletionInstall(shell, binName)`** — reads the resolved profile, applies the strip, writes back only when changed; a no-op when the profile is absent.
- Wired into `uninstall.ts` under the **`state` scope** (which removes `~/.openclaw` — exactly where the sourced completions file lived), iterating every shell in `COMPLETION_SHELLS`, honoring `--dry-run`, and **best-effort** (a profile that can't be rewritten never fails the uninstall).

## User Impact

After `openclaw uninstall` (default or `--all`), the completion block is removed from `.bashrc`/`.zshrc`/etc., so new shells no longer error on a missing completions file. `--dry-run` reports which profiles would be cleaned.

## Evidence

- New unit suite `src/cli/completion-runtime.remove.test.ts` — **7 tests**: removes the header+source block while preserving surrounding user content, removes a stray source line without the header, removes a dynamic `openclaw completion` line, no-op (byte-for-byte) when no OpenClaw block is present, ignores a user comment that merely mentions "openclaw", empties a profile that held only the block, and idempotency.
- Regression: `completion-runtime.test.ts` + `completion-cli.test.ts` + `uninstall.test.ts` — **28 tests pass** unchanged (the new uninstall wiring is a no-op in those fixtures). Typecheck clean.

**Note for maintainers:** scope is deliberately the OpenClaw completion block (the "still sourcing a deleted file" error). Removing the CLI package itself (`npm rm -g openclaw`) and any bare `export PATH` line written by `install.sh` are out of scope here — uninstall already tells users to remove the CLI via npm/pnpm, and the install-script `PATH` line has no OpenClaw marker to target safely. Happy to extend to a marker-bounded `install.sh` block if you'd prefer — hence draft.


---

## Real-behavior proof (on current `main`)

The actual removal function `removeCompletionBlockFromProfile` — which this PR wires into `openclaw uninstall` — run on a realistic `.zshrc` as `openclaw` install leaves it. (On `upstream/main` @ `ab04b2103e8`, `uninstall` invokes **no** completion removal at all, so this block simply survives.)

```
# profile WITH the OpenClaw block (as install leaves it):
export EDITOR=vim
alias ll="ls -la"
# OpenClaw Completion
[ -f "…/openclaw.zsh" ] && source "…/openclaw.zsh"

eval "$(starship init zsh)"

# after removeCompletionBlockFromProfile():
export EDITOR=vim
alias ll="ls -la"

eval "$(starship init zsh)"
```

Result: `{ changed: true, stillHasBlock: false, userLinesKept: true }`. And on a profile with **no** block it is a genuine no-op — `{ changed: false, byteIdentical: true }` — so uninstall never rewrites a profile it didn't touch.


---

## Review fixes (2026-07-24)

Both findings resolved:
- **[P1] `.bash_profile` install now cleaned.** `installCompletion` falls back to `~/.bash_profile` when `~/.bashrc` is absent; uninstall now removes the block from **both** bash profiles (idempotent — only OpenClaw lines are touched).
- **[P2] trailing bytes preserved.** Removal no longer `trimEnd()`s the whole profile; it rejoins the filtered lines and drops only the installer's own separator blank, leaving unrelated trailing bytes intact. New regression test covers it.

### Real uninstall proof — temporary HOME, `.bash_profile`-only (no `~/.bashrc`)

The exact removal path `openclaw uninstall` calls (`removeCompletionInstall("bash")`), run against a temp HOME, pre-fix vs this fix:

```
.bash_profile BEFORE:
export EDITOR=vim
# OpenClaw Completion
[ -f ".../openclaw.bash" ] && source ".../openclaw.bash"

pre-fix  : removeCompletionInstall("bash") => {profilePath:".bashrc",       changed:false}  -> block SURVIVES
this fix : removeCompletionInstall("bash") => {profilePath:".bash_profile", changed:true }

.bash_profile AFTER (this fix):
export EDITOR=vim
```

`completion-runtime` + `uninstall` suites green (22 tests).



## Real-behavior proof (on current main)

Output from the **actual production functions** (`removeCompletionBlockFromProfile` / `completionProfileCandidates`), head `0dd1417`:

**1. Uninstall removes the completion block and preserves trailing user bytes** (#112631 review)
```
before: "export EDITOR=vim\n# OpenClaw Completion\n[ -f \"…/openclaw.bash\" ] && source \"…/openclaw.bash\"\n\n"
after : "export EDITOR=vim\n\n"    (changed: true)
```

**2. Uninstall targets BOTH bash profiles** (#112631 review) — `installCompletion` writes to whichever bash profile exists, so uninstall must scrub both:
```
completionProfileCandidates("bash") → ["/home/kng/.bashrc", "/home/kng/.bash_profile"]
```

**3. A profile with no OpenClaw block is left byte-for-byte identical** — `changed: false`, output identical to input.

Full `src/cli/completion-runtime.remove.test.ts`: **9/9 green** on current `main`.



## Real-behavior proof — dry-run parity (real files, on current main)

`removeCompletionInstall` run against **real profile files** in a temp HOME (head `0dd2e33`). The dry-run now previews **exactly** the profiles the real removal touches — both bash profiles — and leaves the files untouched:

```
=== DRY-RUN ===
would remove from: [ '~/.bashrc', '~/.bash_profile' ]
files left untouched: true
=== REAL removal ===
removed from: [ '~/.bashrc', '~/.bash_profile' ]   (matches dry-run: true)
.bashrc       -> "export EDITOR=vim\n"
.bash_profile -> "# my prompt\nalias ll='ls -la'\n"
```

Both bash profiles are listed and cleaned, the OpenClaw block is gone, and unrelated user content survives byte-for-byte.
