### PR TITLE
fix(ai): honor provider reasoning effort maps

### DIFF
--- a/packages/ai/src/providers/openai-completions.test.ts
+++ b/packages/ai/src/providers/openai-completions.test.ts
@@ -228,6 +228,34 @@ describe("OpenAI-compatible completions params", () => {
     expect(mockOpenAIOptionsRef.payloads[0]).not.toHaveProperty("reasoning_effort");
   });
 
+  it.each([
+    { name: "model compat mapping", reasoningEffort: "low", expected: "high" },
+    { name: "thinkingLevelMap fallback", reasoningEffort: "medium", expected: "xhigh" },
+    { name: "requested effort fallback", reasoningEffort: "high", expected: "high" },
+  ] as const)(
+    "uses $name in the emitted reasoning_effort payload",
+    async ({ reasoningEffort, expected }) => {
+      mockChunksRef.chunks = [makeTextChunk("ok"), makeFinishChunk("stop")];
+      const compatibleModel = {
+        ...reasoningModel,
+        provider: "custom-openai-compatible",
+        baseUrl: "https://third-party.test/v1",
+        thinkingLevelMap: { low: "medium", medium: "xhigh" },
+        compat: {
+          supportsReasoningEffort: true,
+          reasoningEffortMap: { low: "high" },
+        },
+      } as unknown as Model<"openai-completions">;
+
+      await streamOpenAICompletions(compatibleModel, context, {
+        apiKey: "sk-test",
+        reasoningEffort,
+      }).result();
+
+      expect(mockOpenAIOptionsRef.payloads[0]).toMatchObject({ reasoning_effort: expected });
+    },
+  );
+
   it("configures the OpenAI SDK client with the host-built model fetch", async () => {
     mockOpenAIOptionsRef.options = [];
     mockChunksRef.chunks = [makeTextChunk("ok"), makeFinishChunk("stop")];

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -18,6 +18,7 @@ import {
   calculateCost,
   clampThinkingLevel,
 } from "../model-utils.js";
+import { resolveOpenAIReasoningEffortMap } from "../transports/openai-reasoning-compat.js";
 import type {
   AssistantMessage,
   CacheRetention,
@@ -814,51 +815,57 @@ function buildParams(
     }
   }
 
+  // Provider compat is authoritative; keep model-level and literal values as fallbacks
+  // for catalogs that have not adopted reasoningEffortMap.
+  const reasoningEffortMap = resolveOpenAIReasoningEffortMap(model);
+  const reasoningEffort =
+    options?.reasoningEffort === undefined
+      ? undefined
+      : (reasoningEffortMap[options.reasoningEffort] ??
+        model.thinkingLevelMap?.[options.reasoningEffort] ??
+        options.reasoningEffort);
+  const reasoningEnabled = reasoningEffort !== undefined;
+  const offReasoningEffort = reasoningEffortMap.off ?? model.thinkingLevelMap?.off;
+
   if (compat.thinkingFormat === "zai" && model.reasoning) {
-    params.thinking = options?.reasoningEffort
+    params.thinking = reasoningEnabled
       ? { type: "enabled", clear_thinking: false }
       : { type: "disabled" };
   } else if (compat.thinkingFormat === "qwen" && model.reasoning) {
-    params.enable_thinking = Boolean(options?.reasoningEffort);
+    params.enable_thinking = reasoningEnabled;
   } else if (compat.thinkingFormat === "qwen-chat-template" && model.reasoning) {
     params.chat_template_kwargs = {
-      enable_thinking: Boolean(options?.reasoningEffort),
+      enable_thinking: reasoningEnabled,
       preserve_thinking: true,
     };
   } else if (compat.thinkingFormat === "deepseek" && model.reasoning) {
-    params.thinking = { type: options?.reasoningEffort ? "enabled" : "disabled" };
-    if (options?.reasoningEffort && compat.supportsReasoningEffort) {
-      params.reasoning_effort =
-        model.thinkingLevelMap?.[options.reasoningEffort] ?? options.reasoningEffort;
+    params.thinking = { type: reasoningEnabled ? "enabled" : "disabled" };
+    if (reasoningEnabled && compat.supportsReasoningEffort) {
+      params.reasoning_effort = reasoningEffort;
     }
   } else if (compat.thinkingFormat === "openrouter" && model.reasoning) {
     // OpenRouter normalizes reasoning across providers via a nested reasoning object.
     const openRouterParams = params as typeof params & { reasoning?: { effort?: string } };
-    if (options?.reasoningEffort) {
-      openRouterParams.reasoning = {
-        effort: model.thinkingLevelMap?.[options.reasoningEffort] ?? options.reasoningEffort,
-      };
-    } else if (model.thinkingLevelMap?.off !== null) {
-      openRouterParams.reasoning = { effort: model.thinkingLevelMap?.off ?? "none" };
+    if (reasoningEnabled) {
+      openRouterParams.reasoning = { effort: reasoningEffort };
+    } else if (offReasoningEffort !== null) {
+      openRouterParams.reasoning = { effort: offReasoningEffort ?? "none" };
     }
   } else if (compat.thinkingFormat === "together" && model.reasoning) {
     const togetherParams = params as Omit<typeof params, "reasoning_effort"> & {
       reasoning?: { enabled: boolean };
       reasoning_effort?: string;
     };
-    togetherParams.reasoning = { enabled: Boolean(options?.reasoningEffort) };
-    if (options?.reasoningEffort && compat.supportsReasoningEffort) {
-      togetherParams.reasoning_effort =
-        model.thinkingLevelMap?.[options.reasoningEffort] ?? options.reasoningEffort;
+    togetherParams.reasoning = { enabled: reasoningEnabled };
+    if (reasoningEnabled && compat.supportsReasoningEffort) {
+      togetherParams.reasoning_effort = reasoningEffort;
     }
-  } else if (options?.reasoningEffort && model.reasoning && compat.supportsReasoningEffort) {
+  } else if (reasoningEnabled && model.reasoning && compat.supportsReasoningEffort) {
     // OpenAI-style reasoning_effort
-    params.reasoning_effort =
-      model.thinkingLevelMap?.[options.reasoningEffort] ?? options.reasoningEffort;
-  } else if (!options?.reasoningEffort && model.reasoning && compat.supportsReasoningEffort) {
-    const offValue = model.thinkingLevelMap?.off;
-    if (typeof offValue === "string") {
-      params.reasoning_effort = offValue;
+    params.reasoning_effort = reasoningEffort;
+  } else if (model.reasoning && compat.supportsReasoningEffort) {
+    if (typeof offReasoningEffort === "string") {
+      params.reasoning_effort = offReasoningEffort;
     }
   }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users selecting reasoning-capable OpenAI-compatible providers could get immediate inference failures when OpenClaw sent the caller's canonical reasoning level instead of the provider-declared wire value.

This was reproduced with two independent providers:

- `cohere/command-a-plus-05-2026` returned HTTP 422 because `reasoning_effort: "low"` is unsupported and must be `"high"`.
- `mistral/mistral-small-latest` returned HTTP 400 for the same reason.

Direct requests with the same credentials, models, streaming shape, and `reasoning_effort: "high"` returned HTTP 200, isolating the failure to OpenClaw's request construction.

## Why This Change Was Made

The shared Chat Completions provider path now resolves `model.compat.reasoningEffortMap` before the existing model-level `thinkingLevelMap` and literal-value fallbacks. This keeps provider-native effort naming at the generic compatibility boundary, with no provider IDs, new configuration, or duplicate maps.

The same resolved value is reused across the existing OpenAI, OpenRouter, DeepSeek, Together, Qwen, and Z.AI payload shapes so their precedence cannot drift.

## User Impact

Cohere, Mistral, and other OpenAI-compatible providers that declare reasoning-effort mappings now receive supported wire values. Existing providers without compat maps keep their prior model-level or literal fallback behavior. No config, auth, onboarding, or migration action is required.

## Evidence

Before, using the real OpenClaw live-model path with valid provider credentials:

```text
cohere/command-a-plus-05-2026: HTTP 422
mistral/mistral-small-latest: HTTP 400
```

Redacted upstream responses identified the unsupported literal `low` value and required `high`. Direct provider controls with the same keys and models returned HTTP 200.

After, the same OpenClaw command completed both providers:

```text
cohere/command-a-plus-05-2026: done
mistral/mistral-small-latest: done
Test Files  1 passed (1)
Tests       37 passed (37)
```

Focused regression proof after the final rebase:

```text
node scripts/run-vitest.mjs \
  packages/ai/src/providers/openai-completions.test.ts \
  packages/ai/src/providers/openai-reasoning-effort.test.ts \
  extensions/cohere/index.test.ts \
  extensions/mistral/api.test.ts

Test Files  4 passed across 3 shards
Tests       95 passed
```

Additional gates:

- `node scripts/check-changed.mjs -- packages/ai/src/providers/openai-completions.ts packages/ai/src/providers/openai-completions.test.ts`
  - Blacksmith Testbox `tbx_01ky4k9zrmc2v1ngbs5zvymng3`
  - https://github.com/openclaw/openclaw/actions/runs/29909067966
- `pnpm build`
  - Blacksmith Testbox `tbx_01ky4krsepa3k8f0rpa8wjwwxd`
  - https://github.com/openclaw/openclaw/actions/runs/29909605131
- Codex autoreview: clean, no accepted/actionable findings.
- Source-blind behavior validation: all four contract clauses passed using real provider APIs and an isolated OpenClaw config.
