### PR TITLE
docs: attribute published packages and docs home to the OpenClaw Foundation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,8 @@ title: "OpenClaw"
 
 <p align="center">
   <strong>Any OS gateway for AI agents across Discord, Google Chat, iMessage, Matrix, Microsoft Teams, Signal, Slack, Telegram, WhatsApp, Zalo, and more.</strong><br />
-  Send a message, get an agent response from your pocket. Run one Gateway across channel plugins, WebChat, and mobile nodes.
+  Send a message, get an agent response from your pocket. Run one Gateway across channel plugins, WebChat, and mobile nodes.<br />
+  Developed in the open by the <a href="https://openclaw.org">OpenClaw Foundation</a>, a non-profit.
 </p>
 
 <Columns>

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/openclaw/openclaw/issues"
   },
   "license": "MIT",
-  "author": "",
+  "author": "OpenClaw Foundation (https://openclaw.org)",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/openclaw/openclaw.git"

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -16,6 +16,7 @@
     "url": "https://github.com/openclaw/openclaw/issues"
   },
   "license": "MIT",
+  "author": "OpenClaw Foundation (https://openclaw.org)",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/openclaw/openclaw.git",

--- a/packages/gateway-client/package.json
+++ b/packages/gateway-client/package.json
@@ -13,6 +13,7 @@
     "url": "https://github.com/openclaw/openclaw/issues"
   },
   "license": "MIT",
+  "author": "OpenClaw Foundation (https://openclaw.org)",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/openclaw/openclaw.git",

--- a/packages/gateway-protocol/package.json
+++ b/packages/gateway-protocol/package.json
@@ -14,6 +14,7 @@
     "url": "https://github.com/openclaw/openclaw/issues"
   },
   "license": "MIT",
+  "author": "OpenClaw Foundation (https://openclaw.org)",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/openclaw/openclaw.git",


### PR DESCRIPTION
## What Problem This Solves

Several surfaces credited nobody for OpenClaw:

- The root `package.json` shipped `"author": ""` — literally an empty string — so the published `openclaw` package shows no author on npmjs.com.
- The three published workspace packages (`@openclaw/ai`, `@openclaw/gateway-client`, `@openclaw/gateway-protocol`) had no `author` field at all.
- `docs/index.md`, the docs homepage, never said who develops OpenClaw, even though the README and the openclaw.ai footer both do.

## Why This Change Was Made

Follow-up to #112536, which added Foundation attribution to the onboarding security disclaimer and the README intro. This closes the remaining gaps found in a survey of the attribution surfaces.

"OpenClaw Foundation" is the correct entity, confirmed against `LICENSE` ("Copyright (c) 2026 OpenClaw Foundation"), `CONTRIBUTING.md` ("the current OpenClaw Foundation team"), `docs/reference/credits.md` ("MIT, copyright OpenClaw Foundation"), and the openclaw.ai footer ("An OpenClaw Foundation project", "© 2026 OpenClaw Foundation"). So this aligns package metadata with what the repo already records rather than asserting anything new.

**Shape choice.** There was no existing convention — the empty root field was the only `author` anywhere in the repo. This uses npm's people-string shorthand (`"Name (url)"`), which npm parses into the same structured name/url as the object form, keeps the field on one line like the neighbouring `license`/`homepage` entries, and avoids four lines of JSON per package. The only tooling that reads the field is `scripts/plugin-publication-artifact.mjs:810`, which passes it through with `?? null` and imposes no shape; it also only covers plugin packages, which are untouched here.

**Scope.** Only published packages get the field. Private workspace packages never reach npm, so adding it there would be churn with no user-visible effect.

**Deliberately unchanged.** Personal credits are authorship history, not org attribution standing in for the Foundation, and replacing them would erase real project history:

- `docs/reference/credits.md` — "**Peter Steinberger** ([@steipete]) - Creator, lobster whisperer" (that file's license line already names the Foundation)
- `docs/start/lore.md` — storytelling references
- openclaw.ai `SiteFooter.astro` — "Built by Molty 🦞 … by Peter Steinberger & community", which already sits directly above the Foundation and copyright lines

## User Impact

npmjs.com will show "OpenClaw Foundation" as the author for `openclaw`, `@openclaw/ai`, `@openclaw/gateway-client`, and `@openclaw/gateway-protocol` on their next publish. The docs homepage gains one line naming the Foundation. No runtime, config, CLI, or API behavior changes.

## Evidence

- `node scripts/check-changed.mjs` (delegated Blacksmith Testbox): `exitCode: 0, runStatus: "succeeded"` — https://github.com/openclaw/openclaw/actions/runs/29912101328. Ran the heavier package-touching lanes including the dependency pin guard, package patch guard, runtime import cycles, and the docs lane.
- Autoreview (Codex `gpt-5.6-sol`, xhigh): clean, no accepted/actionable findings; TruffleHog clean. It independently confirmed the edited JSON stays syntactically valid and the docs markup is well formed.
- All four manifests re-parsed via `require()` after editing; each reports the expected `name` and `author`.
- Docs markup: raw `<a href>` inside a `<p>` block is an established pattern in this docs setup (`docs/maturity/taxonomy.md:12`, `docs/maturity/scorecard.md:12`), so the link renders rather than appearing as literal text.
