### PR TITLE
refactor(channels): remove retired ack cleanup branches

### DIFF
--- a/docs/channels/signal.md
+++ b/docs/channels/signal.md
@@ -305,7 +305,7 @@ Set `messages.statusReactions.enabled: true` to let Signal show the shared queue
 
 Status reactions also require an ack reaction and a matching `messages.ackReactionScope` (`direct`, `group-all`, `group-mentions`, or `all`). Set `channels.signal.reactionLevel: "off"` to disable Signal status reactions.
 
-`messages.removeAckAfterReply: true` clears the final status reaction after the configured hold time. Otherwise Signal restores the initial ack reaction after the final done/error state.
+Signal restores the initial ack reaction after the final done/error state.
 
 ## Reactions (message tool)
 

--- a/docs/channels/whatsapp.md
+++ b/docs/channels/whatsapp.md
@@ -132,7 +132,6 @@ A separate WhatsApp number is recommended (setup and metadata are optimized for 
 - Direct chats use DM session rules (`session.dmScope`; default `main` collapses DMs into the agent main session). Group sessions are isolated per JID (`agent:<agentId>:whatsapp:group:<jid>`).
 - WhatsApp Channels/Newsletters can be explicit outbound targets via their native `@newsletter` JID, using channel session metadata (`agent:<agentId>:whatsapp:channel:<jid>`) rather than DM semantics.
 - WhatsApp Web transport honors standard proxy environment variables on the gateway host (`HTTPS_PROXY`, `HTTP_PROXY`, `NO_PROXY`, lowercase variants). Prefer host-level proxy config over per-channel settings.
-- With `messages.removeAckAfterReply` enabled, OpenClaw clears the ack reaction once a visible reply is delivered.
 
 ## Call the current requester with MeowCaller (experimental)
 
@@ -482,17 +481,12 @@ Set `messages.statusReactions.enabled: true` to let WhatsApp replace the ack rea
   messages: {
     statusReactions: {
       enabled: true,
-      emojis: {
-        deploy: "🛫",
-        build: "🏗️",
-        concierge: "💁",
-      },
     },
   },
 }
 ```
 
-Notes: `channels.whatsapp.ackReaction` still controls eligibility for direct messages and groups; the queued state uses the same effective emoji as plain ack reactions; WhatsApp has one bot reaction slot per message, so lifecycle updates replace the current reaction in place; `messages.removeAckAfterReply: true` clears the final status reaction after the configured done/error hold; tool emoji categories include `tool`, `coding`, `web`, `deploy`, `build`, and `concierge`.
+Notes: `channels.whatsapp.ackReaction` still controls eligibility for direct messages and groups; the queued state uses the same effective emoji as plain ack reactions; WhatsApp has one bot reaction slot per message, so lifecycle updates replace the current reaction in place and restore the ack after the final done/error state.
 
 ## Multi-account and credentials
 

--- a/docs/gateway/config-agents.md
+++ b/docs/gateway/config-agents.md
@@ -1274,7 +1274,6 @@ See [Multi-Agent Sandbox & Tools](/tools/multi-agent-sandbox-tools) for preceden
     responsePrefix: "🦞", // or "auto"
     ackReaction: "👀",
     ackReactionScope: "group-mentions", // group-mentions | group-all | direct | all | off | none
-    removeAckAfterReply: false,
     queue: {
       mode: "steer", // steer (default) | followup | collect | interrupt
       debounceMs: 500,
@@ -1320,16 +1319,10 @@ Variables are case-insensitive. `{think}` is an alias for `{thinkingLevel}`.
 - Per-channel overrides: `channels.<channel>.ackReaction`, `channels.<channel>.accounts.<id>.ackReaction`.
 - Resolution order: account → channel → `messages.ackReaction` → identity fallback.
 - Scope: `group-mentions` (default), `group-all`, `direct`, `all`, or `off`/`none` (disables ack reactions entirely).
-- `removeAckAfterReply`: removes ack after reply on reaction-capable channels such as Slack, Discord, Signal, Telegram, WhatsApp, and iMessage.
 - `messages.statusReactions.enabled`: enables lifecycle status reactions on Slack, Discord, Signal, Telegram, and WhatsApp.
   On Discord, unset keeps status reactions enabled when ack reactions are active.
   On Slack, Signal, Telegram, and WhatsApp, set it explicitly to `true` to enable lifecycle status reactions.
   Slack uses its native assistant thread status and rotating loading messages for progress by default, while keeping the configured ack reaction static.
-- `messages.statusReactions.emojis`: overrides lifecycle emoji keys:
-  `queued`, `thinking`, `compacting`, `tool`, `coding`, `web`, `deploy`, `build`,
-  `concierge`, `done`, `error`, `stallSoft`, and `stallHard`.
-  Telegram only allows a fixed reaction set, so unsupported configured emoji fall back
-  to the nearest supported status variant for that chat.
 
 ### Queue
 

--- a/extensions/discord/src/monitor/message-handler.process-reactions.ts
+++ b/extensions/discord/src/monitor/message-handler.process-reactions.ts
@@ -7,9 +7,8 @@ import {
   shouldAckReaction as shouldAckReactionGate,
   type StatusReactionController,
 } from "openclaw/plugin-sdk/channel-feedback";
-import { logVerbose, sleep } from "openclaw/plugin-sdk/runtime-env";
+import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { createDiscordRestClient } from "../client.js";
-import { removeReactionDiscord } from "../send.js";
 import { resolveDiscordTargetChannelId } from "../send.shared.js";
 import { resolveDiscordChannelId } from "../targets.js";
 import {
@@ -60,7 +59,6 @@ export function createDiscordMessageReactionRuntime(params: {
     channel: "discord",
     accountId,
   });
-  const removeAckAfterReply = false;
   const shouldSendAckReaction = Boolean(
     ackReaction &&
     shouldAckReactionGate({
@@ -226,11 +224,7 @@ export function createDiscordMessageReactionRuntime(params: {
   }) => {
     if (statusReactionsActive) {
       if (result.dispatchAborted) {
-        if (removeAckAfterReply) {
-          void statusReactions.clear();
-        } else {
-          void statusReactions.restoreInitial();
-        }
+        void statusReactions.restoreInitial();
         return;
       }
       if (result.dispatchError || result.finalDeliveryFailed) {
@@ -238,34 +232,7 @@ export function createDiscordMessageReactionRuntime(params: {
       } else {
         await statusReactions.setDone();
       }
-      if (removeAckAfterReply) {
-        void (async () => {
-          await sleep(
-            result.dispatchError || result.finalDeliveryFailed
-              ? statusReactionTiming.errorHoldMs
-              : statusReactionTiming.doneHoldMs,
-          );
-          await statusReactions.clear();
-        })();
-      } else {
-        void statusReactions.restoreInitial();
-      }
-      return;
-    }
-    if (shouldSendAckReaction && ackReaction && removeAckAfterReply) {
-      void removeReactionDiscord(
-        messageChannelId,
-        message.id,
-        ackReaction,
-        ackReactionContext,
-      ).catch((err: unknown) => {
-        logAckFailure({
-          log: logVerbose,
-          channel: "discord",
-          target: `${messageChannelId}/${message.id}`,
-          error: err,
-        });
-      });
+      void statusReactions.restoreInitial();
     }
   };
 

--- a/extensions/discord/src/monitor/message-handler.process.test-helpers.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test-helpers.ts
@@ -55,7 +55,6 @@ function expectAckReactionRuntimeOptions(
   params?: {
     accountId?: string;
     ackReaction?: string;
-    removeAckAfterReply?: boolean;
   },
 ) {
   const optionRecord = requireRecord(options, "reaction runtime options");
@@ -66,9 +65,6 @@ function expectAckReactionRuntimeOptions(
   const messages: Record<string, unknown> = {};
   if (params?.ackReaction) {
     messages.ackReaction = params.ackReaction;
-  }
-  if (params?.removeAckAfterReply !== undefined) {
-    messages.removeAckAfterReply = params.removeAckAfterReply;
   }
   if (Object.keys(messages).length > 0) {
     const cfg = requireRecord(optionRecord.cfg, "reaction config");
@@ -94,7 +90,6 @@ function expectReactionCallAt(
   params?: {
     accountId?: string;
     ackReaction?: string;
-    removeAckAfterReply?: boolean;
     channelId?: string;
     messageId?: string;
   },
@@ -125,7 +120,6 @@ export function expectReactAckCallAt(
     messageId?: string;
     accountId?: string;
     ackReaction?: string;
-    removeAckAfterReply?: boolean;
   },
 ) {
   expectReactionCallAt(sendMocks.reactMessageDiscord, index, emoji, params);

--- a/extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.config.ts
+++ b/extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.config.ts
@@ -175,10 +175,6 @@ export function buildWhatsAppQaConfig(
     ? buildNonMatchingWhatsAppQaAllowFrom(params.allowFrom)
     : undefined;
   const groupHistoryLimit = params.overrides?.groupHistoryLimit;
-  const statusReactionOverride =
-    typeof params.overrides?.statusReactions === "object"
-      ? params.overrides.statusReactions
-      : undefined;
   const statusReactionsEnabled = Boolean(params.overrides?.statusReactions);
   const whatsappHistoryLimit =
     typeof groupHistoryLimit === "number" && groupHistoryLimit > 0
@@ -355,11 +351,6 @@ export function buildWhatsAppQaConfig(
               : {}),
             ...(statusReactionsEnabled
               ? {
-                  ...(statusReactionOverride?.removeAckAfterReply !== undefined
-                    ? {
-                        removeAckAfterReply: statusReactionOverride.removeAckAfterReply,
-                      }
-                    : {}),
                   statusReactions: {
                     ...baseCfg.messages?.statusReactions,
                     enabled: true,

--- a/extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.contracts.ts
+++ b/extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.contracts.ts
@@ -260,11 +260,7 @@ export type WhatsAppQaConfigOverrides = {
   groupPolicy?: "allowlist" | "disabled" | "open";
   inboundDebounceMs?: number;
   replyToMode?: "all" | "batched" | "first" | "off";
-  statusReactions?:
-    | boolean
-    | {
-        removeAckAfterReply?: boolean;
-      };
+  statusReactions?: boolean;
 };
 
 export type WhatsAppQaScenarioDefinition = {

--- a/extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/whatsapp/whatsapp-live.runtime.test.ts
@@ -2177,9 +2177,7 @@ describe("WhatsApp QA live runtime", () => {
       overrides: {
         inboundDebounceMs: 250,
         replyToMode: "all",
-        statusReactions: {
-          removeAckAfterReply: true,
-        },
+        statusReactions: true,
       },
     });
 
@@ -2189,7 +2187,6 @@ describe("WhatsApp QA live runtime", () => {
       direct: true,
       emoji: "👀",
     });
-    expect(cfg.messages?.removeAckAfterReply).toBe(true);
     expect(cfg.messages?.statusReactions?.enabled).toBe(true);
   });
 

--- a/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
+++ b/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
@@ -35,7 +35,6 @@ const {
   sendTypingMock,
   sendReadReceiptMock,
   sendReactionSignalMock,
-  removeReactionSignalMock,
   dispatchInboundMessageMock,
   enqueueSystemEventMock,
   recordInboundSessionMock,
@@ -46,7 +45,6 @@ const {
     sendTypingMock: vi.fn(),
     sendReadReceiptMock: vi.fn(),
     sendReactionSignalMock: vi.fn(async () => ({ ok: true })),
-    removeReactionSignalMock: vi.fn(async () => ({ ok: true })),
     enqueueSystemEventMock: vi.fn(),
     recordInboundSessionMock: vi.fn(),
     dispatchInboundMessageMock: vi.fn(async (params: DispatchInboundMessageMockParams) => {
@@ -70,7 +68,6 @@ vi.mock("../send.js", () => ({
 
 vi.mock("../send-reactions.js", () => ({
   sendReactionSignal: sendReactionSignalMock,
-  removeReactionSignal: removeReactionSignalMock,
 }));
 
 vi.mock("openclaw/plugin-sdk/reply-runtime", async () => {
@@ -223,7 +220,6 @@ describe("signal createSignalEventHandler inbound context", () => {
     sendTypingMock.mockReset().mockResolvedValue(true);
     sendReadReceiptMock.mockReset().mockResolvedValue(true);
     sendReactionSignalMock.mockReset().mockResolvedValue({ ok: true });
-    removeReactionSignalMock.mockReset().mockResolvedValue({ ok: true });
     enqueueSystemEventMock.mockReset();
     recordInboundSessionMock.mockReset().mockResolvedValue(undefined);
     dispatchInboundMessageMock.mockClear();
@@ -589,7 +585,6 @@ describe("signal createSignalEventHandler inbound context", () => {
     ).map((call) => call[2]);
     expect(sentEmojis).toEqual(expect.arrayContaining(["👀", "🧠", "🛠️", "🗜️", "✅"]));
     expect(sentEmojis.at(-1)).toBe("👀");
-    expect(removeReactionSignalMock).not.toHaveBeenCalled();
     expect(dispatchInboundMessageMock.mock.calls[0]?.[0].replyOptions).toEqual(
       expect.objectContaining({
         allowProgressCallbacksWhenSourceDeliverySuppressed: true,
@@ -685,7 +680,7 @@ describe("signal createSignalEventHandler inbound context", () => {
     }
   });
 
-  it("honors configured Signal hard-stall status reaction emoji overrides", async () => {
+  it("uses the curated Signal soft-stall emoji for hard stalls", async () => {
     vi.useFakeTimers();
     let releaseDispatch!: () => void;
     try {
@@ -707,10 +702,6 @@ describe("signal createSignalEventHandler inbound context", () => {
               inbound: { debounceMs: 0 },
               statusReactions: {
                 enabled: true,
-                emojis: {
-                  stallSoft: "⌛",
-                  stallHard: "⚠️",
-                },
                 timing: {
                   debounceMs: 0,
                   doneHoldMs: 0,
@@ -750,8 +741,8 @@ describe("signal createSignalEventHandler inbound context", () => {
       let sentEmojis = (
         sendReactionSignalMock.mock.calls as unknown as SendReactionSignalMockCall[]
       ).map((call) => call[2]);
-      expect(sentEmojis).toContain("⌛");
-      expect(sentEmojis).toContain("⚠️");
+      expect(sentEmojis).toContain("⏳");
+      expect(sentEmojis).not.toContain("⚠️");
 
       releaseDispatch();
       await handled;
@@ -767,7 +758,7 @@ describe("signal createSignalEventHandler inbound context", () => {
     }
   });
 
-  it("clears the latest Signal status reaction after reply when removeAckAfterReply is enabled", async () => {
+  it("restores the initial Signal ack reaction after a successful reply", async () => {
     dispatchInboundMessageMock.mockImplementationOnce(
       async (params: DispatchInboundMessageMockParams) => {
         capture.ctx = params.ctx;
@@ -780,7 +771,6 @@ describe("signal createSignalEventHandler inbound context", () => {
           messages: {
             ackReaction: "👀",
             ackReactionScope: "direct",
-            removeAckAfterReply: true,
             inbound: { debounceMs: 0 },
             statusReactions: {
               enabled: true,
@@ -818,18 +808,10 @@ describe("signal createSignalEventHandler inbound context", () => {
       sendReactionSignalMock.mock.calls as unknown as SendReactionSignalMockCall[]
     ).map((call) => call[2]);
     expect(sentEmojis).toContain("✅");
-    expect(removeReactionSignalMock).toHaveBeenCalledWith(
-      "+15550002222",
-      1700000000001,
-      "✅",
-      expect.objectContaining({
-        accountId: "default",
-        baseUrl: "http://localhost",
-      }),
-    );
+    expect(sentEmojis.at(-1)).toBe("👀");
   });
 
-  it("clears failed Signal status reactions after partial reply delivery", async () => {
+  it("restores the initial Signal ack reaction after partial reply delivery fails", async () => {
     dispatchInboundMessageMock.mockImplementationOnce(
       async (params: DispatchInboundMessageMockParams) => {
         capture.ctx = params.ctx;
@@ -846,7 +828,6 @@ describe("signal createSignalEventHandler inbound context", () => {
           messages: {
             ackReaction: "👀",
             ackReactionScope: "direct",
-            removeAckAfterReply: true,
             inbound: { debounceMs: 0 },
             statusReactions: {
               enabled: true,
@@ -885,15 +866,7 @@ describe("signal createSignalEventHandler inbound context", () => {
     ).map((call) => call[2]);
     expect(sentEmojis).toContain("❌");
     expect(sentEmojis).not.toContain("✅");
-    expect(removeReactionSignalMock).toHaveBeenCalledWith(
-      "+15550002222",
-      1700000000001,
-      "❌",
-      expect.objectContaining({
-        accountId: "default",
-        baseUrl: "http://localhost",
-      }),
-    );
+    expect(sentEmojis.at(-1)).toBe("👀");
   });
 
   it("uses dataMessage timestamp fallback for Signal status reactions", async () => {
@@ -988,7 +961,6 @@ describe("signal createSignalEventHandler inbound context", () => {
 
     expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
     expect(sendReactionSignalMock).not.toHaveBeenCalled();
-    expect(removeReactionSignalMock).not.toHaveBeenCalled();
   });
 
   it("does not send Signal status reactions for non-positive inbound timestamps", async () => {
@@ -1022,7 +994,6 @@ describe("signal createSignalEventHandler inbound context", () => {
 
     expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
     expect(sendReactionSignalMock).not.toHaveBeenCalled();
-    expect(removeReactionSignalMock).not.toHaveBeenCalled();
   });
 
   it("does not send Signal status reactions unless explicitly enabled", async () => {
@@ -1051,7 +1022,6 @@ describe("signal createSignalEventHandler inbound context", () => {
 
     expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
     expect(sendReactionSignalMock).not.toHaveBeenCalled();
-    expect(removeReactionSignalMock).not.toHaveBeenCalled();
   });
 
   it("does not send Signal status reactions when reactionLevel is off", async () => {
@@ -1504,62 +1474,6 @@ describe("signal createSignalEventHandler inbound context", () => {
     expect(capture.ctx?.To).toBe("+15550002222");
   });
 
-  it("keeps dispatch running when Signal status reaction removal fails", async () => {
-    removeReactionSignalMock.mockRejectedValueOnce(new Error("reaction removal rejected"));
-    dispatchInboundMessageMock.mockImplementationOnce(
-      async (params: DispatchInboundMessageMockParams) => {
-        capture.ctx = params.ctx;
-        return {
-          queuedFinal: false,
-          counts: { tool: 0, block: 0, final: 1 },
-        };
-      },
-    );
-    const handler = createSignalEventHandler(
-      createBaseSignalEventHandlerDeps({
-        cfg: {
-          messages: {
-            ackReaction: "👀",
-            ackReactionScope: "direct",
-            removeAckAfterReply: true,
-            inbound: { debounceMs: 0 },
-            statusReactions: {
-              enabled: true,
-              timing: {
-                debounceMs: 0,
-                doneHoldMs: 0,
-                errorHoldMs: 0,
-                stallSoftMs: 60_000,
-                stallHardMs: 120_000,
-              },
-            },
-          },
-          channels: { signal: { dmPolicy: "open", allowFrom: ["*"] } },
-        } as OpenClawConfig,
-        historyLimit: 0,
-      }),
-    );
-
-    await handler(
-      createSignalReceiveEvent({
-        sourceNumber: "+15550002222",
-        sourceName: "Bob",
-        timestamp: 1700000000001,
-        dataMessage: {
-          message: "ship it",
-          attachments: [],
-        },
-      }),
-    );
-    for (let i = 0; i < 5; i += 1) {
-      await nextTimerTick();
-    }
-
-    expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
-    expect(capture.ctx?.To).toBe("+15550002222");
-    expect(removeReactionSignalMock).toHaveBeenCalled();
-  });
-
   it("finalizes Signal status reactions as error when session recording fails", async () => {
     recordInboundSessionMock.mockRejectedValueOnce(new Error("record boom"));
     const handler = createSignalEventHandler(
@@ -1606,7 +1520,6 @@ describe("signal createSignalEventHandler inbound context", () => {
       sendReactionSignalMock.mock.calls as unknown as SendReactionSignalMockCall[]
     ).map((call) => call[2]);
     expect(sentEmojis).toEqual(["👀", "❌", "👀"]);
-    expect(removeReactionSignalMock).not.toHaveBeenCalled();
   });
 
   it("keeps pending group history structured while current text stays command-clean", async () => {

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -51,12 +51,7 @@ import { kindFromMime } from "openclaw/plugin-sdk/media-runtime";
 import { createChannelHistoryWindow } from "openclaw/plugin-sdk/reply-history";
 import { resolveBatchedReplyThreadingPolicy } from "openclaw/plugin-sdk/reply-reference";
 import { resolveAgentRoute, resolveInboundLastRouteSessionKey } from "openclaw/plugin-sdk/routing";
-import {
-  danger,
-  logVerbose,
-  shouldLogVerbose,
-  sleep as delay,
-} from "openclaw/plugin-sdk/runtime-env";
+import { danger, logVerbose, shouldLogVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { resolvePinnedMainDmOwnerFromAllowlist } from "openclaw/plugin-sdk/security-runtime";
 import { readSessionUpdatedAt, resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -82,11 +77,7 @@ import { normalizeSignalMessagingTarget } from "../normalize.js";
 import { maybeResolveSignalQuestionReaction } from "../question-reactions.js";
 import { resolveSignalReactionLevel } from "../reaction-level.js";
 import { registerSignalReplyContext } from "../reply-authors.js";
-import {
-  removeReactionSignal,
-  sendReactionSignal,
-  type SignalReactionOpts,
-} from "../send-reactions.js";
+import { sendReactionSignal, type SignalReactionOpts } from "../send-reactions.js";
 import { sendMessageSignal, sendReadReceiptSignal, sendTypingSignal } from "../send.js";
 import type { SignalIngressLifecycle } from "../signal-ingress.js";
 import { handleSignalDirectMessageAccess, resolveSignalAccessState } from "./access-policy.js";
@@ -172,33 +163,11 @@ function resolveSignalStatusReactionEmojis(
 async function finalizeSignalStatusReaction(params: {
   controller: StatusReactionController;
   outcome: "done" | "error";
-  hasFinalResponse: boolean;
-  removeAckAfterReply: boolean;
-  timing: typeof DEFAULT_TIMING;
 }): Promise<void> {
   if (params.outcome === "done") {
     await params.controller.setDone();
-    if (params.removeAckAfterReply) {
-      await delay(params.timing.doneHoldMs);
-      await params.controller.clear();
-    } else {
-      await params.controller.restoreInitial();
-    }
-    return;
-  }
-
-  await params.controller.setError();
-  if (params.hasFinalResponse) {
-    if (params.removeAckAfterReply) {
-      await delay(params.timing.errorHoldMs);
-      await params.controller.clear();
-    } else {
-      await params.controller.restoreInitial();
-    }
-    return;
-  }
-  if (params.removeAckAfterReply) {
-    await delay(params.timing.errorHoldMs);
+  } else {
+    await params.controller.setError();
   }
   await params.controller.restoreInitial();
 }
@@ -390,7 +359,6 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
         : {}),
     };
     const statusReactionRecipient = entry.isGroup ? "" : entry.senderRecipient;
-    let currentStatusReactionEmoji = ackReaction;
     const statusReactionController =
       statusReactionsConfig?.enabled === true &&
       signalReactionLevel.level !== "off" &&
@@ -406,19 +374,6 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
                   emoji,
                   signalReactionOpts,
                 );
-                currentStatusReactionEmoji = emoji;
-              },
-              clearReaction: async () => {
-                if (!currentStatusReactionEmoji) {
-                  return;
-                }
-                await removeReactionSignal(
-                  statusReactionRecipient,
-                  statusReactionTimestamp,
-                  currentStatusReactionEmoji,
-                  signalReactionOpts,
-                );
-                currentStatusReactionEmoji = "";
               },
             },
             initialEmoji: ackReaction,
@@ -613,9 +568,6 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
           void finalizeSignalStatusReaction({
             controller: statusReactionController,
             outcome: hasFinalResponse && !hasDeliveryFailure ? "done" : "error",
-            hasFinalResponse,
-            removeAckAfterReply: false,
-            timing: statusReactionTiming,
           }).catch((err: unknown) => {
             logVerbose(`signal: status reaction finalize failed: ${String(err)}`);
           });

--- a/extensions/slack/src/delivery-trace.test.ts
+++ b/extensions/slack/src/delivery-trace.test.ts
@@ -453,7 +453,6 @@ function createPreparedTraceMessage(scenario: SlackTraceScenarioName): PreparedS
       botId: "BBOT",
       textLimit: 4000,
       typingReaction: "",
-      removeAckAfterReply: false,
       allowFrom: [],
       // Mirrors the monitor's setSlackThreadStatus wiring
       // (extensions/slack/src/monitor/context.ts): typing travels over

--- a/extensions/slack/src/monitor.tool-result.test.ts
+++ b/extensions/slack/src/monitor.tool-result.test.ts
@@ -265,7 +265,6 @@ describe("monitorSlackProvider tool results", () => {
         ackReaction: "👀",
         ackReactionScope: "group-mentions",
         groupChat: { visibleReplies: "automatic" },
-        removeAckAfterReply: true,
         statusReactions: statusReactionsEnabled
           ? { enabled: true, timing: { debounceMs: 0, doneHoldMs: 0, errorHoldMs: 0 } }
           : { enabled: false },

--- a/extensions/slack/src/monitor/context.test.ts
+++ b/extensions/slack/src/monitor/context.test.ts
@@ -54,7 +54,6 @@ function createTestContext(params?: {
     typingReaction: "",
     ackReactionScope: "group-mentions",
     mediaMaxBytes: 20 * 1024 * 1024,
-    removeAckAfterReply: false,
   });
 }
 

--- a/extensions/slack/src/monitor/context.ts
+++ b/extensions/slack/src/monitor/context.ts
@@ -153,7 +153,6 @@ export type SlackMonitorContext = {
   ackReactionScope: string;
   typingReaction: string;
   mediaMaxBytes: number;
-  removeAckAfterReply: boolean;
 
   logger: ReturnType<typeof getChildLogger>;
   shouldDropMismatchedSlackEvent: (body: unknown) => boolean;
@@ -249,7 +248,6 @@ export function createSlackMonitorContext(params: {
   ackReactionScope: string;
   typingReaction: string;
   mediaMaxBytes: number;
-  removeAckAfterReply: boolean;
 }): SlackMonitorContext {
   const channelHistories = new Map<string, HistoryEntry[]>();
   const logger = getChildLogger({ module: "slack-auto-reply" });
@@ -717,7 +715,6 @@ export function createSlackMonitorContext(params: {
     ackReactionScope: params.ackReactionScope,
     typingReaction: params.typingReaction,
     mediaMaxBytes: params.mediaMaxBytes,
-    removeAckAfterReply: params.removeAckAfterReply,
     logger,
     shouldDropMismatchedSlackEvent,
     resolveSlackSystemEventSessionKey,

--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -420,7 +420,6 @@ function createPreparedSlackMessage(params?: {
       botId: "B_OPENCLAW",
       textLimit: 4000,
       typingReaction: params?.typingReaction ?? "",
-      removeAckAfterReply: false,
       historyLimit: 0,
       channelHistories: new Map(),
       allowFrom: [],

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -5,7 +5,6 @@ import {
   DEFAULT_TIMING,
   logAckFailure,
   logTypingFailure,
-  removeAckReactionAfterReply,
   type StatusReactionAdapter,
 } from "openclaw/plugin-sdk/channel-feedback";
 import {
@@ -53,7 +52,7 @@ import {
 } from "openclaw/plugin-sdk/reply-payload";
 import type { ReplyDispatchKind, ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { resolveInboundLastRouteSessionKey } from "openclaw/plugin-sdk/routing";
-import { danger, logVerbose, shouldLogVerbose, sleep } from "openclaw/plugin-sdk/runtime-env";
+import { danger, logVerbose, shouldLogVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { resolvePinnedMainDmOwnerFromAllowlist } from "openclaw/plugin-sdk/security-runtime";
 import { normalizeOptionalLowercaseString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { reactSlackMessage, removeSlackReaction } from "../../actions.js";
@@ -482,7 +481,6 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       });
     },
   };
-  const statusReactionTiming = DEFAULT_TIMING;
   const statusReactions = createStatusReactionController({
     enabled: statusReactionsEnabled,
     adapter: slackStatusAdapter,
@@ -2345,24 +2343,9 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
   if (statusReactionsEnabled) {
     if (dispatchError) {
       await statusReactions.setError();
-      if (ctx.removeAckAfterReply) {
-        void (async () => {
-          await sleep(statusReactionTiming.errorHoldMs);
-          if (anyReplyDelivered) {
-            await statusReactions.clear();
-          }
-        })();
-      }
     } else if (anyReplyDelivered) {
       await statusReactions.setDone();
-      if (ctx.removeAckAfterReply) {
-        void (async () => {
-          await sleep(statusReactionTiming.doneHoldMs);
-          await statusReactions.clear();
-        })();
-      } else {
-        void statusReactions.restoreInitial();
-      }
+      void statusReactions.restoreInitial();
     } else {
       // Silent success should preserve queued state and clear any stall timers
       // instead of transitioning to terminal/stall reactions after return.
@@ -2393,32 +2376,6 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     logVerbose(
       `slack: delivered ${finalCount} reply${finalCount === 1 ? "" : "ies"} to ${prepared.replyTarget}`,
     );
-  }
-
-  if (!statusReactionsEnabled) {
-    removeAckReactionAfterReply({
-      removeAfterReply: ctx.removeAckAfterReply && anyReplyDelivered,
-      ackReactionPromise: prepared.ackReactionPromise,
-      ackReactionValue: prepared.ackReactionValue,
-      remove: () =>
-        removeSlackReaction(
-          message.channel,
-          prepared.ackReactionMessageTs ?? "",
-          prepared.ackReactionValue,
-          {
-            token: ctx.botToken,
-            client: slackClient,
-          },
-        ),
-      onError: (err) => {
-        logAckFailure({
-          log: logVerbose,
-          channel: "slack",
-          target: `${message.channel}/${message.ts}`,
-          error: err,
-        });
-      },
-    });
   }
 }
 

--- a/extensions/slack/src/monitor/message-handler/prepare.test-helpers.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test-helpers.ts
@@ -62,7 +62,6 @@ export function createInboundSlackTestContext(params: {
     ackReactionScope: "group-mentions",
     typingReaction: "",
     mediaMaxBytes: 1024,
-    removeAckAfterReply: false,
   });
 }
 

--- a/extensions/slack/src/monitor/message-handler/prepare.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test.ts
@@ -4514,7 +4514,6 @@ describe("prepareSlackMessage sender prefix", () => {
       textLimit: 2000,
       ackReactionScope: "off",
       mediaMaxBytes: 1000,
-      removeAckAfterReply: false,
       logger: { info: vi.fn(), warn: vi.fn() },
       shouldDropMismatchedSlackEvent: () => false,
       resolveSlackSystemEventSessionKey: () => "agent:main:slack:channel:c1",

--- a/extensions/slack/src/monitor/monitor.test.ts
+++ b/extensions/slack/src/monitor/monitor.test.ts
@@ -226,7 +226,6 @@ const baseParams = () => ({
   mediaMaxBytes: 1,
   threadHistoryScope: "thread" as const,
   threadInheritParent: false,
-  removeAckAfterReply: false,
 });
 
 function createListedChannelsContext(groupPolicy: "open" | "allowlist") {

--- a/extensions/slack/src/monitor/provider.ts
+++ b/extensions/slack/src/monitor/provider.ts
@@ -341,7 +341,6 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
   const ackReactionScope = cfg.messages?.ackReactionScope ?? "group-mentions";
   const typingReaction = slackCfg.typingReaction?.trim() ?? "";
   const mediaMaxBytes = (opts.mediaMaxMb ?? slackCfg.mediaMaxMb ?? 20) * 1024 * 1024;
-  const removeAckAfterReply = false;
   const clientOptions = resolveSlackWebClientOptions();
   const durableIngress = createSlackDurableIngress({
     accountId: account.accountId,
@@ -506,7 +505,6 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
     ackReactionScope,
     typingReaction,
     mediaMaxBytes,
-    removeAckAfterReply,
   });
 
   // Slack's socket-mode client keeps ping/pong health private and closes on

--- a/extensions/telegram/src/bot-message-context.ts
+++ b/extensions/telegram/src/bot-message-context.ts
@@ -111,7 +111,6 @@ export type TelegramMessageContext = {
   initialTypingCueSent?: boolean;
   ackReactionPromise: Promise<boolean> | null;
   reactionApi: TelegramReactionApi | null;
-  removeAckAfterReply: boolean;
   statusReactionController: TelegramStatusReactionController | null;
   accountId: string;
 };
@@ -538,7 +537,6 @@ export const buildTelegramMessageContext = async ({
   });
   const ackReactionEmoji =
     ackReaction && isTelegramSupportedReactionEmoji(ackReaction) ? ackReaction : undefined;
-  const removeAckAfterReply = false;
   const shouldSendAckReaction = Boolean(
     ackReaction &&
     shouldAckReactionGate({
@@ -662,7 +660,6 @@ export const buildTelegramMessageContext = async ({
     initialTypingCueSent,
     ackReactionPromise,
     reactionApi,
-    removeAckAfterReply,
     statusReactionController,
     accountId: account.accountId,
   };

--- a/extensions/telegram/src/bot-message-dispatch-status.ts
+++ b/extensions/telegram/src/bot-message-dispatch-status.ts
@@ -1,91 +1,28 @@
 // Telegram plugin module owns dispatch status-reaction finalization.
-import {
-  DEFAULT_TIMING,
-  logAckFailure,
-  removeAckReactionAfterReply,
-} from "openclaw/plugin-sdk/channel-feedback";
-import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { logVerbose, sleepWithAbort } from "openclaw/plugin-sdk/runtime-env";
+import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import type { TelegramMessageContext } from "./bot-message-context.js";
 
-export function createTelegramDispatchStatus(params: {
-  cfg: OpenClawConfig;
-  context: TelegramMessageContext;
-}) {
+export function createTelegramDispatchStatus(params: { context: TelegramMessageContext }) {
   const { context } = params;
   const controller =
     context.ctxPayload.InboundEventKind === "room_event" ? null : context.statusReactionController;
-  const timing = DEFAULT_TIMING;
-
-  const clear = async () => {
-    if (!context.msg.message_id || !context.reactionApi) {
-      return;
-    }
-    await context.reactionApi(context.chatId, context.msg.message_id, []);
-  };
-
-  const finalize = async (final: { outcome: "done" | "error"; hasFinalResponse: boolean }) => {
+  const finalize = async (final: { outcome: "done" | "error" }) => {
     if (!controller) {
       return;
     }
     if (final.outcome === "done") {
       await controller.setDone();
-      if (context.removeAckAfterReply) {
-        await sleepWithAbort(timing.doneHoldMs);
-        await clear();
-      } else {
-        await controller.restoreInitial();
-      }
-      return;
-    }
-    await controller.setError();
-    if (final.hasFinalResponse) {
-      if (context.removeAckAfterReply) {
-        await sleepWithAbort(timing.errorHoldMs);
-        await clear();
-      } else {
-        await controller.restoreInitial();
-      }
-      return;
-    }
-    if (context.removeAckAfterReply) {
-      await sleepWithAbort(timing.errorHoldMs);
+    } else {
+      await controller.setError();
     }
     await controller.restoreInitial();
   };
 
-  const removeAck = () => {
-    removeAckReactionAfterReply({
-      removeAfterReply: context.removeAckAfterReply,
-      ackReactionPromise: context.ackReactionPromise,
-      ackReactionValue: context.ackReactionPromise ? "ack" : null,
-      remove: () =>
-        (
-          context.reactionApi?.(context.chatId, context.msg.message_id ?? 0, []) ??
-          Promise.resolve()
-        ).then(() => {}),
-      onError: (err) => {
-        if (!context.msg.message_id) {
-          return;
-        }
-        logAckFailure({
-          log: logVerbose,
-          channel: "telegram",
-          target: `${context.chatId}/${context.msg.message_id}`,
-          error: err,
-        });
-      },
-    });
-  };
-
-  const finalizeInBackground = (
-    final: { outcome: "done" | "error"; hasFinalResponse: boolean },
-    label: string,
-  ) => {
+  const finalizeInBackground = (final: { outcome: "done" | "error" }, label: string) => {
     void finalize(final).catch((err: unknown) => {
       logVerbose(`telegram: status reaction ${label} failed: ${String(err)}`);
     });
   };
 
-  return { controller, finalizeInBackground, removeAck };
+  return { controller, finalizeInBackground };
 }

--- a/extensions/telegram/src/bot-message-dispatch.pipeline-init.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.pipeline-init.test.ts
@@ -1,4 +1,3 @@
-import { DEFAULT_TIMING } from "openclaw/plugin-sdk/channel-feedback";
 import { expect, it, vi } from "vitest";
 import {
   createChannelMessageReplyPipeline,
@@ -13,7 +12,6 @@ import { notifyTelegramInboundEventOutboundSuccess } from "./inbound-event-deliv
 
 describeTelegramDispatch("dispatchTelegramMessage pipeline-init", () => {
   it("cleans delivery correlation when reply-pipeline initialization fails", async () => {
-    vi.useFakeTimers();
     const sessionKey = "agent:main:telegram:direct:pipeline-init-failure";
     const statusReactionController = createStatusReactionController();
     const reactionApi = vi.fn(async () => undefined);
@@ -37,14 +35,14 @@ describeTelegramDispatch("dispatchTelegramMessage pipeline-init", () => {
         } as TelegramMessageContext["ctxPayload"],
         statusReactionController: statusReactionController as never,
         reactionApi,
-        removeAckAfterReply: true,
       }),
       runtime,
       suppressFailureFallback: true,
     });
 
-    await vi.advanceTimersByTimeAsync(DEFAULT_TIMING.errorHoldMs);
-    expect(statusReactionController.restoreInitial).toHaveBeenCalled();
+    await vi.waitFor(() => {
+      expect(statusReactionController.restoreInitial).toHaveBeenCalled();
+    });
     expect(reactionApi).not.toHaveBeenCalled();
   });
 });

--- a/extensions/telegram/src/bot-message-dispatch.status-reactions.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.status-reactions.test.ts
@@ -104,7 +104,7 @@ describeTelegramDispatch("dispatchTelegramMessage status-reactions", () => {
     );
   });
 
-  it("restores the initial Telegram status reaction after reply when removeAckAfterReply is disabled", async () => {
+  it("restores the initial Telegram status reaction after reply", async () => {
     const reactionApi = vi.fn(async () => true);
     const statusReactionController = createStatusReactionController();
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
@@ -116,7 +116,6 @@ describeTelegramDispatch("dispatchTelegramMessage status-reactions", () => {
     await dispatchWithContext({
       context: createContext({
         reactionApi: reactionApi as never,
-        removeAckAfterReply: false,
         statusReactionController: statusReactionController as never,
       }),
       streamMode: "off",
@@ -131,35 +130,27 @@ describeTelegramDispatch("dispatchTelegramMessage status-reactions", () => {
   });
 
   it("restores the initial Telegram status reaction after an error when no final reply is sent", async () => {
-    vi.useFakeTimers();
     const reactionApi = vi.fn(async () => true);
     const statusReactionController = createStatusReactionController();
     dispatchReplyWithBufferedBlockDispatcher.mockRejectedValue(new Error("dispatcher exploded"));
     deliverReplies.mockResolvedValue({ delivered: false });
 
-    try {
-      await dispatchWithContext({
-        context: createContext({
-          reactionApi: reactionApi as never,
-          removeAckAfterReply: true,
-          statusReactionController: statusReactionController as never,
-        }),
-        streamMode: "off",
-      });
+    await dispatchWithContext({
+      context: createContext({
+        reactionApi: reactionApi as never,
+        statusReactionController: statusReactionController as never,
+      }),
+      streamMode: "off",
+    });
 
+    await vi.waitFor(() => {
       expect(statusReactionController.setError).toHaveBeenCalledTimes(1);
-      expect(statusReactionController.restoreInitial).not.toHaveBeenCalled();
-      expect(reactionApi).not.toHaveBeenCalledWith(123, 456, []);
-
-      await vi.runAllTimersAsync();
       expect(statusReactionController.restoreInitial).toHaveBeenCalledTimes(1);
-      expect(reactionApi).not.toHaveBeenCalledWith(123, 456, []);
-    } finally {
-      vi.useRealTimers();
-    }
+    });
+    expect(reactionApi).not.toHaveBeenCalledWith(123, 456, []);
   });
 
-  it("restores the initial Telegram status reaction after an error fallback when removeAckAfterReply is disabled", async () => {
+  it("restores the initial Telegram status reaction after an error fallback", async () => {
     const reactionApi = vi.fn(async () => true);
     const statusReactionController = createStatusReactionController();
     dispatchReplyWithBufferedBlockDispatcher.mockRejectedValue(new Error("dispatcher exploded"));
@@ -168,7 +159,6 @@ describeTelegramDispatch("dispatchTelegramMessage status-reactions", () => {
     await dispatchWithContext({
       context: createContext({
         reactionApi: reactionApi as never,
-        removeAckAfterReply: false,
         statusReactionController: statusReactionController as never,
       }),
       streamMode: "off",

--- a/extensions/telegram/src/bot-message-dispatch.test-harness.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test-harness.ts
@@ -573,7 +573,6 @@ export function createContext(overrides?: Partial<TelegramMessageContext>): Tele
     sendChatActionHandler: { sendChatAction: vi.fn(async () => undefined) },
     ackReactionPromise: null,
     reactionApi: null,
-    removeAckAfterReply: false,
   } as unknown as TelegramMessageContext;
   base.turn = {
     storePath: "/tmp/openclaw/telegram-sessions.json",

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -292,7 +292,7 @@ export const dispatchTelegramMessage = async ({
     injectedTelegramDeps ?? (await import("./bot-deps.js")).defaultTelegramBotDeps;
   const loadFreshSessionEntry = createFreshTelegramSessionEntryLoader({ cfg, telegramDeps });
   const isRoomEvent = dispatchContext.ctxPayload.InboundEventKind === "room_event";
-  const status = createTelegramDispatchStatus({ cfg, context: dispatchContext });
+  const status = createTelegramDispatchStatus({ context: dispatchContext });
   const tableMode = resolveMarkdownTableMode({
     cfg,
     channel: "telegram",
@@ -462,9 +462,7 @@ export const dispatchTelegramMessage = async ({
   }
   if (dispatchWasSuperseded) {
     if (status.controller) {
-      status.finalizeInBackground({ outcome: "done", hasFinalResponse: true }, "finalize");
-    } else {
-      status.removeAck();
+      status.finalizeInBackground({ outcome: "done" }, "finalize");
     }
     return { kind: "completed" };
   }
@@ -543,7 +541,7 @@ export const dispatchTelegramMessage = async ({
       : null);
 
   if (status.controller && !hasVisibleResponse) {
-    status.finalizeInBackground({ outcome: "error", hasFinalResponse: false }, "error finalize");
+    status.finalizeInBackground({ outcome: "error" }, "error finalize");
   }
   const shouldReturnRetryableDispatchFailure =
     retryDispatchErrors &&
@@ -570,12 +568,9 @@ export const dispatchTelegramMessage = async ({
           !progress.finalAnswerDelivered() && (state.dispatchError != null || sentFallback)
             ? "error"
             : "done",
-        hasFinalResponse: true,
       },
       "finalize",
     );
-  } else {
-    status.removeAck();
   }
   return { kind: "completed" };
 };

--- a/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts
@@ -1,8 +1,5 @@
 // Whatsapp plugin module implements inbound dispatch behavior.
-import {
-  DEFAULT_TIMING,
-  type StatusReactionController,
-} from "openclaw/plugin-sdk/channel-feedback";
+import type { StatusReactionController } from "openclaw/plugin-sdk/channel-feedback";
 import {
   buildChannelInboundEventContext,
   type CommandFacts,
@@ -545,8 +542,6 @@ export function createWhatsAppReplyPlan(params: {
   const conversationId = admission.conversation.id;
   const conversationKind = admission.conversation.kind;
   const statusReactionController = params.statusReactionController ?? null;
-  const statusReactionTiming = DEFAULT_TIMING;
-  const removeAckAfterReply = false;
   const textLimit = params.maxMediaTextChunkLimit ?? resolveTextChunkLimit(params.cfg, "whatsapp");
   const chunkMode = resolveChunkMode(params.cfg, "whatsapp", params.route.accountId);
   const tableMode = resolveMarkdownTableMode({
@@ -794,9 +789,6 @@ export function createWhatsAppReplyPlan(params: {
           void finalizeWhatsAppStatusReaction({
             controller: statusReactionController,
             outcome: "error",
-            hasFinalResponse: false,
-            removeAckAfterReply,
-            timing: statusReactionTiming,
           });
         }
         if (params.shouldClearGroupHistory) {
@@ -810,9 +802,6 @@ export function createWhatsAppReplyPlan(params: {
         void finalizeWhatsAppStatusReaction({
           controller: statusReactionController,
           outcome: didDeliverVisibleReply ? "done" : "error",
-          hasFinalResponse: didDeliverVisibleReply,
-          removeAckAfterReply,
-          timing: statusReactionTiming,
         });
       }
       if (params.shouldClearGroupHistory) {
@@ -826,38 +815,11 @@ export function createWhatsAppReplyPlan(params: {
 async function finalizeWhatsAppStatusReaction(params: {
   controller: StatusReactionController;
   outcome: "done" | "error";
-  hasFinalResponse: boolean;
-  removeAckAfterReply: boolean;
-  timing: typeof DEFAULT_TIMING;
 }): Promise<void> {
   if (params.outcome === "done") {
     await params.controller.setDone();
-    if (params.removeAckAfterReply) {
-      await new Promise<void>((resolve) => {
-        setTimeout(resolve, params.timing.doneHoldMs);
-      });
-      await params.controller.clear();
-    } else {
-      await params.controller.restoreInitial();
-    }
-    return;
-  }
-  await params.controller.setError();
-  if (params.hasFinalResponse) {
-    if (params.removeAckAfterReply) {
-      await new Promise<void>((resolve) => {
-        setTimeout(resolve, params.timing.errorHoldMs);
-      });
-      await params.controller.clear();
-    } else {
-      await params.controller.restoreInitial();
-    }
-    return;
-  }
-  if (params.removeAckAfterReply) {
-    await new Promise<void>((resolve) => {
-      setTimeout(resolve, params.timing.errorHoldMs);
-    });
+  } else {
+    await params.controller.setError();
   }
   await params.controller.restoreInitial();
 }


### PR DESCRIPTION
Related: #111527

## What Problem This Solves

The config-surface retirement in #111527 made acknowledgement removal permanently disabled, but five channel handlers still carried branches, parameters, and tests for clearing acknowledgements after a reply. Signal also retained an unreachable reaction-removal adapter, and the focused Signal monitor test on current `main` was red because it still expected the retired configuration to work.

## Why This Change Was Made

This deletes the impossible acknowledgement-removal paths across Signal, Telegram, Slack, Discord, and WhatsApp while preserving each channel's current retained-reaction behavior. It also removes the dead Signal `clearReaction` wiring, trims the obsolete context plumbing and QA override, and aligns the stale docs/tests with the Doctor-owned migration contract. Doctor's legacy input type and migration remain intact so old config files are still repaired.

## User Impact

There is no user-visible behavior change. Acknowledgements remain retained after replies, and lifecycle status reactions continue to restore or retain their current terminal state exactly as they did after #111527.

## Evidence

- Pre-change Blacksmith Testbox proof reproduced four failures in `extensions/signal/src/monitor/event-handler.inbound-context.test.ts`, including the impossible acknowledgement-removal assertions.
- Final focused Testbox proof passed 310 tests across six Vitest shards: Signal 46, Telegram 6, Slack 118, Discord 29, WhatsApp 57, and WhatsApp QA 54.
- `pnpm check:changed` passed on Blacksmith Testbox, including extension production/test typechecks, extension lint, formatting, plugin boundaries, and repository guards.
- `git diff --check` passed.
- Fresh branch-mode Codex autoreview reported no findings after being given the current Doctor/dead-key contract evidence.
- Testbox: `blacksmith-testbox`, `tbx_01ky4n4an67gw0rcnzs9vah6vt`; [Actions run](https://github.com/openclaw/openclaw/actions/runs/29911172930).

AI-assisted. I reviewed the affected channel finalization paths, sibling implementations, current config/Doctor contracts, and the resulting diff.

Release note: none; this is a behavior-neutral dead-code and stale-contract cleanup.
