### PR TITLE
fix(ui): move footer title tooltips onto the shared tooltip component

### DIFF
--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -311,19 +311,20 @@ class AppSidebar extends AppSidebarSessionListElement {
           <openclaw-lobster-logo-standin .visit=${this.logoVisit}></openclaw-lobster-logo-standin>
         </span>
         ${selfUser && selfLabel
-          ? html`<button
-              type="button"
-              class="sidebar-footer-bar__identity"
-              title=${selfLabel}
-              aria-label=${t("profilePage.identity.openSettings", { name: selfLabel })}
-              @click=${() => this.onNavigate?.("profile", { hash: "#settings-profile-identity" })}
-            >
-              <openclaw-viewer-avatar
-                .user=${{ ...selfUser, watchedSessions: [] }}
-                variant="footer"
-              ></openclaw-viewer-avatar>
-              <span class="sidebar-footer-bar__identity-name">${selfLabel}</span>
-            </button>`
+          ? html`<openclaw-tooltip .content=${selfLabel}>
+              <button
+                type="button"
+                class="sidebar-footer-bar__identity"
+                aria-label=${t("profilePage.identity.openSettings", { name: selfLabel })}
+                @click=${() => this.onNavigate?.("profile", { hash: "#settings-profile-identity" })}
+              >
+                <openclaw-viewer-avatar
+                  .user=${{ ...selfUser, watchedSessions: [] }}
+                  variant="footer"
+                ></openclaw-viewer-avatar>
+                <span class="sidebar-footer-bar__identity-name">${selfLabel}</span>
+              </button>
+            </openclaw-tooltip>`
           : nothing}
         <openclaw-viewer-facepile
           .presencePayload=${this.presencePayload}
@@ -339,18 +340,21 @@ class AppSidebar extends AppSidebarSessionListElement {
           .onNavigate=${(routeId: "about") => this.onNavigate?.(routeId)}
         ></openclaw-sidebar-build-chip>
         ${this.offline
-          ? html`<button
-              type="button"
-              class="sidebar-footer-bar__status"
-              aria-live="polite"
-              aria-label=${`${t("common.offline")} — ${t("connection.retryNow")}`}
-              title=${this.lastError ? redactLoginFailureError(this.lastError) : reconnecting}
-              @click=${() => this.onRetryConnect?.()}
+          ? html`<openclaw-tooltip
+              .content=${this.lastError ? redactLoginFailureError(this.lastError) : reconnecting}
             >
-              <span class="sidebar-footer-bar__status-dot" aria-hidden="true"></span>${t(
-                "common.offline",
-              )}<span class="sidebar-footer-bar__status-detail">${reconnecting}</span>
-            </button>`
+              <button
+                type="button"
+                class="sidebar-footer-bar__status"
+                aria-live="polite"
+                aria-label=${`${t("common.offline")} — ${t("connection.retryNow")}`}
+                @click=${() => this.onRetryConnect?.()}
+              >
+                <span class="sidebar-footer-bar__status-dot" aria-hidden="true"></span>${t(
+                  "common.offline",
+                )}<span class="sidebar-footer-bar__status-detail">${reconnecting}</span>
+              </button>
+            </openclaw-tooltip>`
           : nothing}
         <openclaw-tooltip .content=${t("nav.settings")}>
           <button
@@ -509,12 +513,14 @@ class AppSidebar extends AppSidebarSessionListElement {
               .gatewayVersion=${this.gatewayVersion}
             ></openclaw-lobster-pet>
             ${this.devGitBranch
-              ? html`<div class="sidebar-footer-branch" title=${this.devGitBranch}>
-                  <span class="sidebar-footer-branch__icon" aria-hidden="true"
-                    >${icons.gitBranch}</span
-                  >
-                  <span class="sidebar-footer-branch__name">${this.devGitBranch}</span>
-                </div>`
+              ? html`<openclaw-tooltip .content=${this.devGitBranch}>
+                  <div class="sidebar-footer-branch">
+                    <span class="sidebar-footer-branch__icon" aria-hidden="true"
+                      >${icons.gitBranch}</span
+                    >
+                    <span class="sidebar-footer-branch__name">${this.devGitBranch}</span>
+                  </div>
+                </openclaw-tooltip>`
               : nothing}
             ${this.renderFooterBar()}
           </div>

--- a/ui/src/e2e/sidebar-dev-branch.e2e.test.ts
+++ b/ui/src/e2e/sidebar-dev-branch.e2e.test.ts
@@ -55,7 +55,16 @@ describeControlUiE2e("Control UI sidebar dev branch badge E2E", () => {
       await expect
         .poll(() => badge.locator(".sidebar-footer-branch__name").textContent())
         .toBe(DEV_BRANCH);
-      await expect.poll(() => badge.getAttribute("title")).toBe(DEV_BRANCH);
+      // The branch name surfaces via the shared tooltip's accessible
+      // description instead of a native title attribute.
+      await expect
+        .poll(() =>
+          badge.evaluate((element) => {
+            const id = element.getAttribute("aria-describedby");
+            return id ? (document.getElementById(id)?.textContent ?? null) : null;
+          }),
+        )
+        .toBe(DEV_BRANCH);
 
       const colors = await badge.evaluate((element) => {
         // Compare resolved colors: getComputedStyle().color returns rgb() while

--- a/ui/src/test-helpers/app-sidebar-cases/basics.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/basics.ts
@@ -371,7 +371,13 @@ describe("AppSidebar agent chip", () => {
     expect(button?.textContent).toContain("Reconnecting…");
     expect(button?.getAttribute("aria-label")).toBe("Offline — Retry now");
     expect(button?.getAttribute("aria-live")).toBe("polite");
-    expect(button?.title).toBe("gateway unavailable?[redacted-credential]");
+    // The redacted error detail moved from a native title to the shared
+    // tooltip's accessible description.
+    expect(button?.hasAttribute("title")).toBe(false);
+    const descriptionId = button?.getAttribute("aria-describedby") ?? "";
+    expect(document.getElementById(descriptionId)?.textContent).toBe(
+      "gateway unavailable?[redacted-credential]",
+    );
     expect(button?.querySelector(".sidebar-footer-bar__status-dot")).not.toBeNull();
     expect(sidebar.querySelector(".sidebar-agent-card__subtitle")?.textContent).not.toContain(
       "Offline",


### PR DESCRIPTION
Related: #112602

## What Problem This Solves

Resolves a problem where three sidebar footer surfaces still used native browser `title` tooltips after #112602 unified everything else on the shared styled tooltip: the identity chip, the offline/retry status button, and the dev-branch badge. Native titles look nothing like the app's tooltips (unstyled OS bubble, no theming, long hover delay) and were the last inconsistent hover surfaces in the footer.

## Why This Change Was Made

Each `title` attribute became an `openclaw-tooltip` wrapper: the identity chip shows the full display name (the shared component's redundancy check suppresses it when the name isn't truncated), the offline retry button surfaces its redacted connection error / reconnecting detail, and the dev-branch badge shows the full branch name. The accessible description moves from the native title to the tooltip's `aria-describedby` wiring; the offline button's recently landed retry semantics (aria-label, click-to-retry) are preserved unchanged.

## User Impact

All footer hovers now share one styled, theme-aware tooltip with the same arrow — no more stock OS tooltips in the footer. Truncated names and branch names are readable on hover in both themes, and screen readers keep an equivalent description.

## Evidence

Focused suites pass: `node scripts/run-vitest.mjs ui/src/components/app-sidebar.test.ts` (152 tests, including the updated offline-retry and dev-branch assertions) and `ui/src/e2e/sidebar-dev-branch.e2e.test.ts` (Playwright, asserts the branch name via the tooltip's accessible description). Codex autoreview clean on the commit.

Screenshots (mock gateway e2e harness, dark, DPR2):
- Identity chip tooltip (truncated name): https://artifacts.openclaw.ai/pr-footer-title-tooltips-202607/full-identity.png
- Dev-branch badge tooltip (truncated branch): https://artifacts.openclaw.ai/pr-footer-title-tooltips-202607/full-branch.png
- Manifest: https://artifacts.openclaw.ai/pr-footer-title-tooltips-202607/artifact-manifest.json

Note on "before" imagery: the prior behavior was the OS-native title tooltip, which headless capture cannot render, so only after-shots are included.
