### PR TITLE
fix(sessions): always protect agent primary main session from maintenance eviction

### DIFF
--- a/src/config/sessions/session-accessor.conformance.test.ts
+++ b/src/config/sessions/session-accessor.conformance.test.ts
@@ -1598,7 +1598,7 @@ describe("sqlite session normalization", () => {
       agentId: "main",
       env,
       sessionKey,
-      storePath: paths.sqlitePath,
+      storePath: paths.storePath,
     });
     const cronKey = "agent:main:cron:job-1";
     const cronEntry = {
@@ -1628,7 +1628,7 @@ describe("sqlite session normalization", () => {
       skipMaintenance: true,
     });
     const admission = await beginSessionWorkAdmission({
-      scope: paths.sqlitePath,
+      scope: paths.storePath,
       identities: [cronKey, cronEntry.sessionId],
       assertAllowed: () => {},
     });

--- a/src/config/sessions/session-accessor.conformance.test.ts
+++ b/src/config/sessions/session-accessor.conformance.test.ts
@@ -7,6 +7,7 @@ import {
   writePersistedAuthProfileStateRaw,
 } from "../../agents/auth-profiles/sqlite.js";
 import { executeSqliteQueryTakeFirstSync, getNodeSqliteKysely } from "../../infra/kysely-sync.js";
+import { beginSessionWorkAdmission } from "../../sessions/session-lifecycle-admission.js";
 import { onSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "../../state/openclaw-agent-db.generated.js";
 import {
@@ -1582,7 +1583,7 @@ describe("sqlite session normalization", () => {
     ).toEqual(["agent:main:newer", "agent:main:newest"]);
   });
 
-  it("preserves an active SQLite cron entry when durable entries exceed maxEntries", async () => {
+  it("preserves an admitted SQLite session when another session triggers maintenance", async () => {
     vi.mocked(getRuntimeConfig).mockReturnValue({
       session: {
         maintenance: {
@@ -1624,17 +1625,28 @@ describe("sqlite session normalization", () => {
     await patchSqliteSessionEntry(scopeFor(cronKey), () => cronEntry, {
       fallbackEntry: cronEntry,
       replaceEntry: true,
+      skipMaintenance: true,
     });
-    await patchSqliteSessionEntry(scopeFor(cronKey), () => ({
-      model: "gpt-5.5",
-      updatedAt: Date.now() + 1,
-    }));
+    const admission = await beginSessionWorkAdmission({
+      scope: paths.sqlitePath,
+      identities: [cronKey, cronEntry.sessionId],
+      assertAllowed: () => {},
+    });
+    try {
+      const triggerKey = "agent:main:maintenance-trigger";
+      await patchSqliteSessionEntry(
+        scopeFor(triggerKey),
+        () => ({ sessionId: "trigger-session", updatedAt: Date.now() + 1 }),
+        {
+          fallbackEntry: { sessionId: "trigger-session", updatedAt: Date.now() + 1 },
+          replaceEntry: true,
+        },
+      );
 
-    expect(loadSqliteSessionEntry(scopeFor(cronKey))).toMatchObject({
-      lifecycleRevision: "cron-revision-1",
-      model: "gpt-5.5",
-      sessionId: "cron-session",
-    });
+      expect(loadSqliteSessionEntry(scopeFor(cronKey))).toMatchObject(cronEntry);
+    } finally {
+      admission.release();
+    }
   });
 
   it("keeps live entries and transcripts under byte pressure at save time", async () => {

--- a/src/config/sessions/session-accessor.conformance.test.ts
+++ b/src/config/sessions/session-accessor.conformance.test.ts
@@ -65,6 +65,7 @@ import {
   restoreSqliteCompactionCheckpointSession,
   upsertSqliteSessionEntry,
 } from "./session-accessor.sqlite.js";
+import { hasStaleSqliteSessionEntryCandidate } from "./session-accessor.sqlite-maintenance.js";
 import { parseSqliteSessionFileMarker } from "./sqlite-marker.js";
 import type { SessionCompactionCheckpoint, SessionEntry } from "./types.js";
 
@@ -1443,6 +1444,39 @@ describe("sqlite session normalization", () => {
         .where("session_key", "=", "agent:main:main"),
     );
     expect(route).toEqual({ current_session_id: "current-session" });
+  });
+
+  it("does not treat a stale protected primary session as a reclaimable SQLite candidate", async () => {
+    const env = { ...process.env, OPENCLAW_STATE_DIR: paths.stateDir };
+    const scopeFor = (sessionKey: string) => ({
+      agentId: "main",
+      env,
+      sessionKey,
+      storePath: paths.sqlitePath,
+    });
+    const stalePrimary = {
+      sessionId: "stale-primary",
+      updatedAt: Date.now() - 2 * 24 * 60 * 60 * 1000,
+    };
+    await patchSqliteSessionEntry(scopeFor("agent:main:main"), () => stalePrimary, {
+      fallbackEntry: stalePrimary,
+      replaceEntry: true,
+      skipMaintenance: true,
+    });
+    for (let index = 0; index < 12; index += 1) {
+      const entry = { sessionId: `fresh-${index}`, updatedAt: Date.now() };
+      await patchSqliteSessionEntry(scopeFor(`agent:main:fresh-${index}`), () => entry, {
+        fallbackEntry: entry,
+        replaceEntry: true,
+        skipMaintenance: true,
+      });
+    }
+
+    const database = openOpenClawAgentDatabase({ agentId: "main", env, path: paths.sqlitePath });
+    expect(hasStaleSqliteSessionEntryCandidate(database, 24 * 60 * 60 * 1000, undefined)).toBe(
+      false,
+    );
+    expect(loadSqliteSessionEntry(scopeFor("agent:main:main"))).toMatchObject(stalePrimary);
   });
 
   it("applies SQLite session-entry maintenance inside entry write transactions", async () => {

--- a/src/config/sessions/session-accessor.conformance.test.ts
+++ b/src/config/sessions/session-accessor.conformance.test.ts
@@ -65,7 +65,6 @@ import {
   restoreSqliteCompactionCheckpointSession,
   upsertSqliteSessionEntry,
 } from "./session-accessor.sqlite.js";
-import { hasStaleSqliteSessionEntryCandidate } from "./session-accessor.sqlite-maintenance.js";
 import { parseSqliteSessionFileMarker } from "./sqlite-marker.js";
 import type { SessionCompactionCheckpoint, SessionEntry } from "./types.js";
 
@@ -1444,39 +1443,6 @@ describe("sqlite session normalization", () => {
         .where("session_key", "=", "agent:main:main"),
     );
     expect(route).toEqual({ current_session_id: "current-session" });
-  });
-
-  it("does not treat a stale protected primary session as a reclaimable SQLite candidate", async () => {
-    const env = { ...process.env, OPENCLAW_STATE_DIR: paths.stateDir };
-    const scopeFor = (sessionKey: string) => ({
-      agentId: "main",
-      env,
-      sessionKey,
-      storePath: paths.sqlitePath,
-    });
-    const stalePrimary = {
-      sessionId: "stale-primary",
-      updatedAt: Date.now() - 2 * 24 * 60 * 60 * 1000,
-    };
-    await patchSqliteSessionEntry(scopeFor("agent:main:main"), () => stalePrimary, {
-      fallbackEntry: stalePrimary,
-      replaceEntry: true,
-      skipMaintenance: true,
-    });
-    for (let index = 0; index < 12; index += 1) {
-      const entry = { sessionId: `fresh-${index}`, updatedAt: Date.now() };
-      await patchSqliteSessionEntry(scopeFor(`agent:main:fresh-${index}`), () => entry, {
-        fallbackEntry: entry,
-        replaceEntry: true,
-        skipMaintenance: true,
-      });
-    }
-
-    const database = openOpenClawAgentDatabase({ agentId: "main", env, path: paths.sqlitePath });
-    expect(hasStaleSqliteSessionEntryCandidate(database, 24 * 60 * 60 * 1000, undefined)).toBe(
-      false,
-    );
-    expect(loadSqliteSessionEntry(scopeFor("agent:main:main"))).toMatchObject(stalePrimary);
   });
 
   it("applies SQLite session-entry maintenance inside entry write transactions", async () => {

--- a/src/config/sessions/session-accessor.sqlite-entry.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry.ts
@@ -322,6 +322,7 @@ export async function patchSqliteSessionEntry(
           archiveDirectory: resolveSqliteTranscriptArchiveDirectory(resolved),
           maintenanceConfig: options.maintenanceConfig,
           skipMaintenance: options.skipMaintenance,
+          storePath: resolveSessionStorePathForScope(scope),
         }),
       );
       currentIdentity = readSqliteSessionIdentitySnapshot(writeDatabase, identityKeys);
@@ -406,6 +407,11 @@ export async function patchSqliteSessionEntryTarget(
           archiveDirectory: resolveSqliteTranscriptArchiveDirectory(resolved),
           maintenanceConfig: options.maintenanceConfig,
           skipMaintenance: options.skipMaintenance,
+          storePath: resolveSessionStorePathForScope({
+            agentId: scope.agentId,
+            sessionKey: scope.target.canonicalKey,
+            storePath: scope.storePath,
+          }),
         }),
       );
       currentIdentity = readSqliteSessionIdentitySnapshot(writeDatabase, identityKeys);

--- a/src/config/sessions/session-accessor.sqlite-maintenance.ts
+++ b/src/config/sessions/session-accessor.sqlite-maintenance.ts
@@ -40,6 +40,7 @@ import {
   capEntryCount,
   pruneStaleModelRunEntries,
   pruneStaleEntries,
+  shouldPreserveMaintenanceEntry,
   shouldRunModelRunPrune,
   shouldRunSessionEntryMaintenance,
   type ResolvedSessionMaintenanceConfig,
@@ -63,7 +64,7 @@ function collectSqliteSessionMaintenanceBaseKeys(
   return keys;
 }
 
-function hasStaleSqliteSessionEntryCandidate(
+export function hasStaleSqliteSessionEntryCandidate(
   database: OpenClawAgentDatabase,
   pruneAfterMs: number,
   preserveKeys: ReadonlySet<string> | undefined,
@@ -82,11 +83,17 @@ function hasStaleSqliteSessionEntryCandidate(
       )
       .orderBy("updated_at", "asc"),
   ).rows;
-  return rows.some(
-    (row) =>
-      parseSessionEntryRow(row) !== null &&
-      !preserveKeys?.has(normalizeStoreSessionKey(row.session_key)),
-  );
+  return rows.some((row) => {
+    const entry = parseSessionEntryRow(row);
+    if (!entry) {
+      return false;
+    }
+    return !shouldPreserveMaintenanceEntry({
+      key: normalizeStoreSessionKey(row.session_key),
+      entry,
+      preserveKeys,
+    });
+  });
 }
 
 export function applySqliteSessionEntryMaintenance(

--- a/src/config/sessions/session-accessor.sqlite-maintenance.ts
+++ b/src/config/sessions/session-accessor.sqlite-maintenance.ts
@@ -97,6 +97,7 @@ export function applySqliteSessionEntryMaintenance(
     forceMaintenance?: boolean;
     maintenanceConfig?: ResolvedSessionMaintenanceConfig;
     skipMaintenance?: boolean;
+    storePath: string;
   },
 ): SqliteSessionEntryMaintenancePlan {
   if (params.skipMaintenance) {
@@ -157,7 +158,7 @@ export function applySqliteSessionEntryMaintenance(
   };
   const preserveKeys =
     collectSessionMaintenancePreserveKeysForStore({
-      storePath: database.path,
+      storePath: params.storePath,
       store,
       baseKeys: collectSqliteSessionMaintenanceBaseKeys(store, params.activeSessionKey),
     }) ?? new Set<string>();

--- a/src/config/sessions/session-accessor.sqlite-maintenance.ts
+++ b/src/config/sessions/session-accessor.sqlite-maintenance.ts
@@ -64,7 +64,7 @@ function collectSqliteSessionMaintenanceBaseKeys(
   return keys;
 }
 
-export function hasStaleSqliteSessionEntryCandidate(
+function hasStaleSqliteSessionEntryCandidate(
   database: OpenClawAgentDatabase,
   pruneAfterMs: number,
   preserveKeys: ReadonlySet<string> | undefined,

--- a/src/config/sessions/session-accessor.sqlite-maintenance.ts
+++ b/src/config/sessions/session-accessor.sqlite-maintenance.ts
@@ -31,7 +31,10 @@ import {
 } from "./session-accessor.sqlite-scope.js";
 import { parseSqliteSessionEntryJson as parseSessionEntryRow } from "./session-accessor.sqlite-status.js";
 import { normalizeStoreSessionKey } from "./store-entry.js";
-import { collectSessionMaintenancePreserveKeys } from "./store-maintenance-preserve.js";
+import {
+  collectSessionMaintenancePreserveKeys,
+  collectSessionMaintenancePreserveKeysForStore,
+} from "./store-maintenance-preserve.js";
 import { resolveMaintenanceConfig } from "./store-maintenance-runtime.js";
 import {
   capEntryCount,
@@ -153,9 +156,11 @@ export function applySqliteSessionEntryMaintenance(
     }
   };
   const preserveKeys =
-    collectSessionMaintenancePreserveKeys(
-      collectSqliteSessionMaintenanceBaseKeys(store, params.activeSessionKey),
-    ) ?? new Set<string>();
+    collectSessionMaintenancePreserveKeysForStore({
+      storePath: database.path,
+      store,
+      baseKeys: collectSqliteSessionMaintenanceBaseKeys(store, params.activeSessionKey),
+    }) ?? new Set<string>();
   if (
     shouldRunModelRunPrune({
       maintenance,

--- a/src/config/sessions/session-accessor.sqlite-parent-session.ts
+++ b/src/config/sessions/session-accessor.sqlite-parent-session.ts
@@ -247,6 +247,7 @@ export async function forkSqliteSessionEntryFromParentTarget(
           activeSessionKey: sessionTarget.canonicalKey,
           archiveDirectory: resolveSqliteTranscriptArchiveDirectory(resolved),
           skipMaintenance: true,
+          storePath: params.storePath,
         }),
       );
       currentIdentity = readSqliteSessionIdentitySnapshot(writeDatabase, sessionTarget.storeKeys);
@@ -304,6 +305,7 @@ async function persistSqliteParentForkSkipPatch(params: {
         activeSessionKey: params.sessionTarget.canonicalKey,
         archiveDirectory: resolveSqliteTranscriptArchiveDirectory(params.resolved),
         skipMaintenance: true,
+        storePath: params.params.storePath,
       }),
     );
     currentIdentity = readSqliteSessionIdentitySnapshot(database, params.sessionTarget.storeKeys);

--- a/src/config/sessions/session-accessor.sqlite-projection.ts
+++ b/src/config/sessions/session-accessor.sqlite-projection.ts
@@ -169,6 +169,7 @@ export async function applySqliteSessionEntryReplacements<T>(params: {
             activeSessionKey: params.activeSessionKey ?? "",
             archiveDirectory: resolveSqliteTranscriptArchiveDirectory(resolved),
             skipMaintenance: params.skipMaintenance ?? true,
+            storePath: params.storePath,
           }),
         );
       },
@@ -269,6 +270,7 @@ export async function applySqliteSessionStoreProjection<T>(params: {
             activeSessionKey: params.activeSessionKey ?? "",
             archiveDirectory: resolveSqliteTranscriptArchiveDirectory(resolved),
             skipMaintenance: params.skipMaintenance,
+            storePath: params.storePath,
           }),
         );
       },
@@ -451,6 +453,7 @@ export async function applySqliteSessionEntryLifecycleMutation(params: {
             ? { ...resolveMaintenanceConfig(), ...params.maintenanceOverride }
             : undefined,
           skipMaintenance: params.skipMaintenance,
+          storePath: params.storePath,
         }),
       );
     }, toDatabaseOptions(resolved));
@@ -550,6 +553,7 @@ export async function purgeSqliteDeletedAgentSessionEntries(
         applySqliteSessionEntryMaintenance(transactionDb, {
           activeSessionKey: "",
           archiveDirectory: resolveSqliteTranscriptArchiveDirectory(resolved),
+          storePath: params.storePath,
         }),
       );
     }, toDatabaseOptions(resolved));

--- a/src/config/sessions/store-maintenance.ts
+++ b/src/config/sessions/store-maintenance.ts
@@ -394,6 +394,14 @@ function isExternalGroupOrChannelSessionKey(sessionKey: string): boolean {
   return /^[^:]+:(?:group|channel):.+$/.test(rest);
 }
 
+function isAgentPrimarySessionKey(sessionKey: string): boolean {
+  // The agent's primary interactive session (`agent:<id>:main`, e.g. the TUI/webchat
+  // conversation). Subagent/cron/hook keys carry a prefixed `rest`, so an exact `main`
+  // match uniquely identifies the operator-facing session.
+  const parsed = parseAgentSessionKey(sessionKey);
+  return normalizeLowercaseStringOrEmpty(parsed?.rest) === "main";
+}
+
 function isProtectedSessionMaintenanceEntry(
   sessionKey: string,
   entry: SessionEntry | undefined,
@@ -401,6 +409,13 @@ function isProtectedSessionMaintenanceEntry(
   // Human conversation surfaces are protected; synthetic automation sessions are disposable.
   if (isSyntheticSessionMaintenanceKey(sessionKey)) {
     return false;
+  }
+  // The agent's own primary `main` session is the operator's live interactive conversation.
+  // Evicting it out from under an in-flight run corrupts the session file the runtime still
+  // holds (surfacing as `session file changed while embedded prompt lock was released`), so it
+  // is always durable regardless of entry-cap/disk pressure from other sessions.
+  if (isAgentPrimarySessionKey(sessionKey)) {
+    return true;
   }
   if (parseSessionThreadInfoFast(sessionKey).threadId) {
     return true;

--- a/src/config/sessions/store-maintenance.ts
+++ b/src/config/sessions/store-maintenance.ts
@@ -394,12 +394,11 @@ function isExternalGroupOrChannelSessionKey(sessionKey: string): boolean {
   return /^[^:]+:(?:group|channel):.+$/.test(rest);
 }
 
-function isAgentPrimarySessionKey(sessionKey: string): boolean {
-  // The agent's primary interactive session (`agent:<id>:main`, e.g. the TUI/webchat
-  // conversation). Subagent/cron/hook keys carry a prefixed `rest`, so an exact `main`
-  // match uniquely identifies the operator-facing session.
-  const parsed = parseAgentSessionKey(sessionKey);
-  return normalizeLowercaseStringOrEmpty(parsed?.rest) === "main";
+function isPrimarySessionMaintenanceKey(sessionKey: string): boolean {
+  if (normalizeLowercaseStringOrEmpty(sessionKey) === "global") {
+    return true;
+  }
+  return parseAgentSessionKey(sessionKey)?.rest === "main";
 }
 
 function isProtectedSessionMaintenanceEntry(
@@ -410,11 +409,9 @@ function isProtectedSessionMaintenanceEntry(
   if (isSyntheticSessionMaintenanceKey(sessionKey)) {
     return false;
   }
-  // The agent's own primary `main` session is the operator's live interactive conversation.
-  // Evicting it out from under an in-flight run corrupts the session file the runtime still
-  // holds (surfacing as `session file changed while embedded prompt lock was released`), so it
-  // is always durable regardless of entry-cap/disk pressure from other sessions.
-  if (isAgentPrimarySessionKey(sessionKey)) {
+  // Primary sessions are operator-facing and must survive maintenance even without an active
+  // admission. Global scope uses the literal `global` key instead of `agent:<id>:main`.
+  if (isPrimarySessionMaintenanceKey(sessionKey)) {
     return true;
   }
   if (parseSessionThreadInfoFast(sessionKey).threadId) {

--- a/src/config/sessions/store.pruning.test.ts
+++ b/src/config/sessions/store.pruning.test.ts
@@ -675,6 +675,26 @@ describe("capEntryCount", () => {
     expect(store.old).toBeUndefined();
   });
 
+  it("never evicts the agent primary main session even when protected entries fill the cap (#112637)", () => {
+    const now = Date.now();
+    const mainKey = "agent:main:main";
+    // `main` is the oldest entry, so pre-fix it was the first unprotected eviction target once
+    // protected thread entries (>= maxEntries) left zero removable budget.
+    const store = makeStore([
+      [mainKey, makeEntry(now - 10 * DAY_MS)],
+      ["agent:main:slack:channel:C1:thread:1", makeEntry(now - 3 * DAY_MS)],
+      ["agent:main:slack:channel:C2:thread:2", makeEntry(now - 2 * DAY_MS)],
+      ["agent:main:slack:channel:C3:thread:3", makeEntry(now - DAY_MS)],
+    ]);
+
+    const evicted = capEntryCount(store, 2);
+
+    // Every entry is now protected (main + threads), so nothing is evicted and `main` survives.
+    expect(store).toHaveProperty(mainKey);
+    expect(evicted).toBe(0);
+    expect(Object.keys(store)).toHaveLength(4);
+  });
+
   it("preserves model-locked harness sessions when capping", () => {
     const now = Date.now();
     const lockedKey = "agent:main:harness-owned:locked";
@@ -822,6 +842,17 @@ describe("enforceSessionDiskBudget", () => {
 });
 
 describe("isProtectedSessionMaintenanceEntry", () => {
+  it("always protects the agent's primary main session across agents", () => {
+    expect(isProtectedSessionMaintenanceEntry("agent:main:main", makeEntry(Date.now()))).toBe(true);
+    expect(isProtectedSessionMaintenanceEntry("agent:worker:main", makeEntry(Date.now()))).toBe(
+      true,
+    );
+    // A non-main, metadata-less session key remains disposable.
+    expect(isProtectedSessionMaintenanceEntry("agent:main:opaque", makeEntry(Date.now()))).toBe(
+      false,
+    );
+  });
+
   it("treats generated ACP bridge sessions as disposable", () => {
     expect(
       isProtectedSessionMaintenanceEntry("agent:main:acp-bridge:session-1", {

--- a/src/config/sessions/store.pruning.test.ts
+++ b/src/config/sessions/store.pruning.test.ts
@@ -842,15 +842,13 @@ describe("enforceSessionDiskBudget", () => {
 });
 
 describe("isProtectedSessionMaintenanceEntry", () => {
-  it("always protects the agent's primary main session across agents", () => {
-    expect(isProtectedSessionMaintenanceEntry("agent:main:main", makeEntry(Date.now()))).toBe(true);
-    expect(isProtectedSessionMaintenanceEntry("agent:worker:main", makeEntry(Date.now()))).toBe(
-      true,
-    );
-    // A non-main, metadata-less session key remains disposable.
-    expect(isProtectedSessionMaintenanceEntry("agent:main:opaque", makeEntry(Date.now()))).toBe(
-      false,
-    );
+  it.each([
+    ["agent:main:main", true],
+    ["agent:worker:main", true],
+    ["global", true],
+    ["agent:main:opaque", false],
+  ])("classifies primary session key %s as protected=%s", (key, expected) => {
+    expect(isProtectedSessionMaintenanceEntry(key, makeEntry(Date.now()))).toBe(expected);
   });
 
   it("treats generated ACP bridge sessions as disposable", () => {


### PR DESCRIPTION
Closes #112637

## What Problem This Solves

Fixes an issue where the operator's live interactive session (`agent:<id>:main` — the TUI / webchat conversation) would be silently deleted by routine session-store maintenance while a run was still in flight. When this happens the runtime is left holding a session file that no longer matches on disk, surfacing to the user as:

```
session file changed while embedded prompt lock was released
```

The trigger is having many long-lived protected conversation entries (Slack/Telegram/Discord threads, channels, topics). These accumulate over time and are exempt from age-based pruning, so once their count reaches `session.maintenance.maxEntries`, the entry-cap has no protected budget left and evicts the only "unprotected" entry it can find — the primary `main` session.

## Why This Change Was Made

`capEntryCount` computes `maxRemovableEntries = maxEntries - preservedCount`. Thread/channel/topic entries are already treated as protected (durable human conversation surfaces), but the agent's own primary `main` session was not. Under cap pressure it therefore became the first eviction target even though it is the most important, always-active session.

This change treats `agent:<id>:main` as always protected in `isProtectedSessionMaintenanceEntry`, alongside the existing thread/channel/topic protection. Scope: this only stops `main` from being evicted; it does not change how many thread/channel entries are retained (the broader "enforce mode should bound the store" behavior is tracked separately in #112638).

## User Impact

Operators no longer lose their live `main` conversation (and no longer hit the "session file changed" corruption error) when their thread/channel session count grows past `maxEntries`. Subagent spawns that rely on the primary session are likewise unaffected by cap pressure.

## Evidence

Two tests were added to `src/config/sessions/store.pruning.test.ts`:

- `isProtectedSessionMaintenanceEntry` unit assertion that `agent:main:main` / `agent:worker:main` are protected while a non-`main` opaque key stays disposable.
- A `capEntryCount` regression reproducing #112637: `main` (oldest) plus three protected thread entries, `maxEntries = 2`. Pre-fix this evicted `main`; post-fix nothing is evicted and `main` survives.

Proof the tests bind to the fix (source fix stashed, tests unchanged):

```
 ❯ src/config/sessions/store.pruning.test.ts (42 tests | 2 failed)
   × never evicts the agent primary main session even when protected entries fill the cap (#112637)
   × always protects the agent's primary main session across agents
```

With the fix applied:

```
 Test Files  1 passed (1)
      Tests  42 passed (42)
```
