### PR TITLE
Support plugin subagent approval handoff

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -26675,7 +26675,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 276,
+      "line": 294,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Overview",
       "surface": "apple",
@@ -26683,7 +26683,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 304,
+      "line": 322,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Agents",
       "surface": "apple",
@@ -26691,7 +26691,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 311,
+      "line": 329,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Instances",
       "surface": "apple",
@@ -26699,7 +26699,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 322,
+      "line": 340,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Files",
       "surface": "apple",
@@ -26707,7 +26707,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 329,
+      "line": 347,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Dreaming",
       "surface": "apple",
@@ -26715,7 +26715,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 336,
+      "line": 354,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Usage",
       "surface": "apple",
@@ -26723,7 +26723,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 343,
+      "line": 361,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Automations",
       "surface": "apple",
@@ -26731,7 +26731,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 433,
+      "line": 451,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Hide Sidebar",
       "surface": "apple",
@@ -26739,7 +26739,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 439,
+      "line": 457,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Show Sidebar",
       "surface": "apple",
@@ -26747,7 +26747,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 566,
+      "line": 584,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Close canvas",
       "surface": "apple",
@@ -26755,7 +26755,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 829,
+      "line": 847,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Gateway needs attention",
       "surface": "apple",
@@ -26763,7 +26763,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 829,
+      "line": 847,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "OpenClaw iOS",
       "surface": "apple",
@@ -26771,7 +26771,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 865,
+      "line": 883,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Available",
       "surface": "apple",
@@ -26779,7 +26779,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 865,
+      "line": 883,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Gateway default",
       "surface": "apple",
@@ -26787,7 +26787,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 865,
+      "line": 883,
       "path": "apps/ios/Sources/RootTabs.swift",
       "source": "Routed on this phone",
       "surface": "apple",

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -2537,6 +2537,9 @@ public struct AgentParams: Codable, Sendable {
     public let replyto: String?
     public let sessionid: String?
     public let sessionkey: String?
+    public let requestersessionkey: String?
+    public let expectscompletionmessage: Bool?
+    public let approvalgrant: AnyCodable?
     public let expectedexistingsessionid: String?
     public let thinking: String?
     public let deliver: Bool?
@@ -2584,6 +2587,9 @@ public struct AgentParams: Codable, Sendable {
         replyto: String? = nil,
         sessionid: String? = nil,
         sessionkey: String? = nil,
+        requestersessionkey: String? = nil,
+        expectscompletionmessage: Bool? = nil,
+        approvalgrant: AnyCodable? = nil,
         expectedexistingsessionid: String? = nil,
         thinking: String? = nil,
         deliver: Bool? = nil,
@@ -2630,6 +2636,9 @@ public struct AgentParams: Codable, Sendable {
         self.replyto = replyto
         self.sessionid = sessionid
         self.sessionkey = sessionkey
+        self.requestersessionkey = requestersessionkey
+        self.expectscompletionmessage = expectscompletionmessage
+        self.approvalgrant = approvalgrant
         self.expectedexistingsessionid = expectedexistingsessionid
         self.thinking = thinking
         self.deliver = deliver
@@ -2678,6 +2687,9 @@ public struct AgentParams: Codable, Sendable {
         case replyto = "replyTo"
         case sessionid = "sessionId"
         case sessionkey = "sessionKey"
+        case requestersessionkey = "requesterSessionKey"
+        case expectscompletionmessage = "expectsCompletionMessage"
+        case approvalgrant = "approvalGrant"
         case expectedexistingsessionid = "expectedExistingSessionId"
         case thinking
         case deliver

--- a/docs/plugins/sdk-runtime.md
+++ b/docs/plugins/sdk-runtime.md
@@ -338,6 +338,8 @@ two-party event loops that do not go through the shared inbound reply runner.
 
     `toolsAlsoAllow` adds exact, uniquely owned tools registered by the calling plugin to the worker's normal tool surface. The runtime rejects core tools and names shared with another plugin. Profiles and operator tool policies still apply, including explicit allowlists and denies.
 
+    `requesterSessionKey`, `expectsCompletionMessage`, and `approvalGrant` are reserved for bundled or trusted official plugins. Untrusted plugins can run subagents, but cannot bind completion delivery or approval capabilities to arbitrary requester sessions.
+
     `deleteSession(...)` can delete sessions created by the same plugin through `api.runtime.subagent.run(...)`. Deleting arbitrary user or operator sessions still requires an admin-scoped Gateway request.
 
   </Accordion>

--- a/packages/gateway-protocol/src/schema/agent.test.ts
+++ b/packages/gateway-protocol/src/schema/agent.test.ts
@@ -79,6 +79,24 @@ describe("AgentParamsSchema", () => {
     ).toBe(true);
   });
 
+  it("accepts trusted plugin subagent routing and approval params", () => {
+    expect(
+      Value.Check(AgentParamsSchema, {
+        message: "handoff",
+        sessionKey: "agent:main:subagent:loop-guard",
+        requesterSessionKey: "agent:main:feishu:direct:user",
+        expectsCompletionMessage: true,
+        approvalGrant: {
+          kind: "loop_guard_inherited_approval",
+          approvalPolicy: "never",
+          sandbox: "danger-full-access",
+          expiresAt: Date.now() + 30_000,
+        },
+        idempotencyKey: "plugin-subagent-approval-1",
+      }),
+    ).toBe(true);
+  });
+
   it("rejects host-owned delivery media constraints from public requests", () => {
     expect(
       Value.Check(AgentParamsSchema, {

--- a/packages/gateway-protocol/src/schema/agent.ts
+++ b/packages/gateway-protocol/src/schema/agent.ts
@@ -283,6 +283,11 @@ export const AgentParamsSchema = closedObject({
   replyTo: Type.Optional(Type.String()),
   sessionId: Type.Optional(Type.String()),
   sessionKey: Type.Optional(Type.String()),
+  // Trusted plugin-subagent routing/approval parameters. Public callers may send
+  // them, but gateway handlers only consume them for authenticated plugin subagent runs.
+  requesterSessionKey: Type.Optional(Type.String()),
+  expectsCompletionMessage: Type.Optional(Type.Boolean()),
+  approvalGrant: Type.Optional(Type.Unknown()),
   // Backend-owned continuations can bind work to an already-admitted transcript.
   expectedExistingSessionId: Type.Optional(NonEmptyString),
   thinking: Type.Optional(Type.String()),

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -960,6 +960,7 @@ export function runAgentAttempt(params: {
     bootstrapContextRunKind: params.opts.bootstrapContextRunKind,
     toolsAllow: params.opts.toolsAllow,
     runtimePluginToolGrant: params.opts.runtimePluginToolGrant,
+    approvalGrant: params.opts.approvalGrant,
     trustedInternalHandoff: params.opts.trustedInternalHandoff,
     internalEvents: params.opts.internalEvents,
     inputProvenance: params.opts.inputProvenance,

--- a/src/agents/command/types.ts
+++ b/src/agents/command/types.ts
@@ -111,6 +111,8 @@ export type AgentCommandOpts = {
   toolsAllow?: string[];
   /** Trusted owner-scoped plugin tool grant; normal policy and deny rules still apply. */
   runtimePluginToolGrant?: RuntimePluginToolGrant;
+  /** Trusted plugin-subagent, run-scoped approval capability for native harnesses. */
+  approvalGrant?: unknown;
   /** Trusted in-process subagent-completion handoff; never accepted from public RPC params. */
   trustedInternalHandoff?: boolean;
   /** Internal marker for an auto-applied cap that CLI runtimes must omit. */

--- a/src/agents/embedded-agent-runner/run/params.ts
+++ b/src/agents/embedded-agent-runner/run/params.ts
@@ -234,6 +234,8 @@ export type RunEmbeddedAgentParams = {
   toolsAllow?: string[];
   /** Owner-scoped plugin tool grant; normal policy and deny rules still apply. */
   runtimePluginToolGrant?: RuntimePluginToolGrant;
+  /** Trusted plugin-subagent, run-scoped approval capability for native harnesses. */
+  approvalGrant?: unknown;
   /** Trusted in-process subagent-completion handoff; never derived from public input. */
   trustedInternalHandoff?: boolean;
   /** Seen bootstrap truncation warning signatures for this session (once mode dedupe). */

--- a/src/agents/embedded-agent-runner/run/run-attempt-dispatch.ts
+++ b/src/agents/embedded-agent-runner/run/run-attempt-dispatch.ts
@@ -349,6 +349,7 @@ export async function dispatchEmbeddedRunAttempt(input: {
     bootstrapContextRunKind: params.bootstrapContextRunKind,
     jobId: params.jobId,
     toolsAllow: params.toolsAllow,
+    approvalGrant: params.approvalGrant,
     ...(params.systemAgentTool ? { systemAgentTool: params.systemAgentTool } : {}),
     cleanupBundleMcpOnRunEnd: params.cleanupBundleMcpOnRunEnd,
     disableMessageTool: params.disableMessageTool,

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -1822,9 +1822,7 @@ async function sendSubagentAnnounceDirectly(params: {
       }
       activeRequesterWakeFailed = true;
       const logPrefix =
-        wakeOutcome.queued === false && wakeOutcome.reason === "no_active_run"
-          ? "[subagent]"
-          : "[warn]";
+        !wakeOutcome.queued && wakeOutcome.reason === "no_active_run" ? "[subagent]" : "[warn]";
       defaultRuntime.log(
         `${logPrefix} Active requester session could not be woken for subagent completion; falling back to requester-agent handoff: ${formatQueueWakeFailureError(
           "active requester session could not be woken",

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -1821,8 +1821,12 @@ async function sendSubagentAnnounceDirectly(params: {
         };
       }
       activeRequesterWakeFailed = true;
+      const logPrefix =
+        wakeOutcome.queued === false && wakeOutcome.reason === "no_active_run"
+          ? "[subagent]"
+          : "[warn]";
       defaultRuntime.log(
-        `[warn] Active requester session could not be woken for subagent completion; falling back to requester-agent handoff: ${formatQueueWakeFailureError(
+        `${logPrefix} Active requester session could not be woken for subagent completion; falling back to requester-agent handoff: ${formatQueueWakeFailureError(
           "active requester session could not be woken",
           wakeOutcome,
         )}`,

--- a/src/agents/subagent-announce.test.ts
+++ b/src/agents/subagent-announce.test.ts
@@ -336,6 +336,33 @@ describe("subagent announce seam flow", () => {
     });
   });
 
+  it("adds a stable child suffix to plugin completion labels", async () => {
+    await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:loop-guard-worker",
+      childRunId: "run-plugin-label",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "do thing",
+      label: "plugin:loop-guard",
+      timeoutMs: 10,
+      cleanup: "keep",
+      waitForCompletion: false,
+      startedAt: 10,
+      endedAt: 20,
+      outcome: { status: "ok" },
+      roundOneReply: "completed",
+    });
+
+    expect(callGatewayMock).toHaveBeenCalledWith({
+      method: "sessions.patch",
+      params: {
+        key: "agent:main:subagent:loop-guard-worker",
+        label: "plugin:loop-guard:loop-guard-worker",
+      },
+      timeoutMs: 10_000,
+    });
+  });
+
   it("skips delete cleanup when the lifecycle owner invalidates the attempt", async () => {
     const didAnnounce = await runSubagentAnnounceFlow({
       childSessionKey: "agent:main:subagent:test",

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -79,6 +79,27 @@ function loadSubagentRegistryRuntime() {
   return subagentRegistryRuntimeLoader.load();
 }
 
+function resolveSubagentCompletionLabel(params: {
+  label: string;
+  childSessionKey: string;
+}): string {
+  const label = params.label.trim();
+  if (!label.startsWith("plugin:")) {
+    return label;
+  }
+  const suffix =
+    params.childSessionKey
+      .trim()
+      .split(":")
+      .filter(Boolean)
+      .at(-1)
+      ?.replace(/[^a-zA-Z0-9._-]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .slice(0, 24) || "subagent";
+  const maxBaseLength = Math.max(1, 512 - suffix.length - 1);
+  return `${label.slice(0, maxBaseLength)}:${suffix}`;
+}
+
 export { buildSubagentSystemPrompt } from "./subagent-system-prompt.js";
 export { captureSubagentCompletionReply } from "./subagent-announce-output.js";
 export type { SubagentRunOutcome } from "./subagent-announce-output.js";
@@ -613,7 +634,13 @@ export async function runSubagentAnnounceFlow(params: {
       try {
         await subagentAnnounceDeps.callGateway({
           method: "sessions.patch",
-          params: { key: params.childSessionKey, label: params.label },
+          params: {
+            key: params.childSessionKey,
+            label: resolveSubagentCompletionLabel({
+              label: params.label,
+              childSessionKey: params.childSessionKey,
+            }),
+          },
           timeoutMs: 10_000,
         });
       } catch {

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -91,8 +91,7 @@ function resolveSubagentCompletionLabel(params: {
     params.childSessionKey
       .trim()
       .split(":")
-      .filter(Boolean)
-      .at(-1)
+      .findLast(Boolean)
       ?.replace(/[^a-zA-Z0-9._-]+/g, "-")
       .replace(/^-+|-+$/g, "")
       .slice(0, 24) || "subagent";

--- a/src/gateway/server-methods/agent-request-types.ts
+++ b/src/gateway/server-methods/agent-request-types.ts
@@ -10,6 +10,9 @@ export type AgentRunRequest = {
   replyTo?: string;
   sessionId?: string;
   sessionKey?: string;
+  requesterSessionKey?: string;
+  expectsCompletionMessage?: boolean;
+  approvalGrant?: unknown;
   expectedExistingSessionId?: string;
   thinking?: string;
   deliver?: boolean;

--- a/src/gateway/server-methods/agent-run-admission-phase.ts
+++ b/src/gateway/server-methods/agent-run-admission-phase.ts
@@ -293,6 +293,7 @@ export async function prepareAgentRunDispatch(params: {
         runId: params.runId,
         childSessionKey: params.resolvedSessionKey,
         task: params.request.message.trim(),
+        requesterSessionKey: normalizeOptionalString(params.request.requesterSessionKey),
         requesterOrigin: normalizeDeliveryContext({
           channel: params.delivery.resolvedChannel,
           to: params.delivery.resolvedTo,
@@ -300,6 +301,7 @@ export async function prepareAgentRunDispatch(params: {
           threadId: resolvedThreadId,
         }),
         pluginId: normalizeOptionalString(params.client?.internal?.pluginRuntimeOwnerId),
+        expectsCompletionMessage: params.request.expectsCompletionMessage === true,
       });
     } catch (err) {
       params.context.logGateway.warn(

--- a/src/gateway/server-methods/agent-run-execution-phase.ts
+++ b/src/gateway/server-methods/agent-run-execution-phase.ts
@@ -278,6 +278,11 @@ export function startAgentRunExecution(params: {
           params.client.internal.runtimePluginToolGrant?.pluginId
           ? params.client.internal.runtimePluginToolGrant
           : undefined;
+      const approvalGrant =
+        params.client?.internal?.agentRunTracking === "plugin_subagent" &&
+        params.client.internal.pluginRuntimeOwnerId
+          ? params.request.approvalGrant
+          : undefined;
       const trustedInternalHandoff =
         params.client?.internal?.delegatedToolPolicyHandoff === true &&
         params.inputProvenance?.kind === "inter_session" &&
@@ -348,6 +353,7 @@ export function startAgentRunExecution(params: {
           bootstrapContextRunKind: params.effectiveBootstrapContextRunKind,
           toolsAllow: params.restoredCronContinuation?.toolsAllow,
           runtimePluginToolGrant,
+          approvalGrant,
           trustedInternalHandoff,
           toolsAllowIsDefault: params.restoredCronContinuation?.toolsAllowIsDefault,
           requireExplicitMessageTarget:

--- a/src/gateway/server-methods/agent-task-tracking.ts
+++ b/src/gateway/server-methods/agent-task-tracking.ts
@@ -158,8 +158,10 @@ export async function registerPluginSubagentRunFromGateway(params: {
   runId: string;
   childSessionKey: string;
   task: string;
+  requesterSessionKey?: string;
   requesterOrigin?: DeliveryContext;
   pluginId?: string;
+  expectsCompletionMessage?: boolean;
 }): Promise<void> {
   const childSessionKey = params.childSessionKey.trim();
   if (!childSessionKey) {
@@ -169,18 +171,19 @@ export async function registerPluginSubagentRunFromGateway(params: {
     cfg: params.cfg,
     agentId: resolveAgentIdFromSessionKey(childSessionKey),
   });
+  const requesterSessionKey = params.requesterSessionKey?.trim() || ownerSessionKey;
   const { registerSubagentRun } = await import("../../agents/subagent-registry.js");
   registerSubagentRun({
     runId: params.runId,
     childSessionKey,
     controllerSessionKey: ownerSessionKey,
-    requesterSessionKey: ownerSessionKey,
+    requesterSessionKey,
     requesterOrigin: params.requesterOrigin,
-    requesterDisplayKey: "main",
+    requesterDisplayKey: requesterSessionKey === ownerSessionKey ? "main" : requesterSessionKey,
     task: params.task,
     cleanup: "keep",
     ...(params.pluginId ? { label: `plugin:${params.pluginId}` } : {}),
-    expectsCompletionMessage: false,
+    expectsCompletionMessage: params.expectsCompletionMessage === true,
     spawnMode: "run",
   });
 }

--- a/src/gateway/server-plugins-subagent-runtime.ts
+++ b/src/gateway/server-plugins-subagent-runtime.ts
@@ -1,0 +1,216 @@
+import { randomUUID } from "node:crypto";
+import type { PluginOrigin } from "../plugins/plugin-origin.types.js";
+import type { RuntimePluginToolGrant } from "../plugins/runtime/tool-grant.js";
+import type { PluginRuntime } from "../plugins/runtime/types.js";
+import type { GatewayRequestOptions } from "./server-methods/types.js";
+
+type PluginRuntimeGatewayRequestScope = {
+  client?: GatewayRequestOptions["client"];
+  pluginId?: string;
+  pluginOrigin?: PluginOrigin;
+  pluginTrustedOfficialInstall?: boolean;
+};
+
+type ServerPluginsSubagentRuntimeDeps = {
+  adminScope: string;
+  canClientUseModelOverride: (client: GatewayRequestOptions["client"]) => boolean;
+  canTrustedOfficialPluginRequestScopes: (params: {
+    pluginId?: string;
+    pluginOrigin?: PluginOrigin;
+    pluginTrustedOfficialInstall?: boolean;
+  }) => boolean;
+  authorizeFallbackModelOverride: (params: {
+    pluginId?: string;
+    provider?: string;
+    model?: string;
+  }) => { allowed: true } | { allowed: false; reason: string };
+  dispatchGatewayMethod: <T>(
+    method: string,
+    params: unknown,
+    options?: {
+      allowSyntheticModelOverride?: boolean;
+      agentRunTracking?: "plugin_subagent";
+      expectFinal?: boolean;
+      forceSyntheticClient?: boolean;
+      pluginRuntimeOwnerId?: string;
+      runtimePluginToolGrant?: RuntimePluginToolGrant;
+      syntheticScopes?: string[];
+    },
+  ) => Promise<T>;
+  getPluginRuntimeGatewayRequestScope: () => PluginRuntimeGatewayRequestScope | undefined;
+  hasAdminScope: (client: GatewayRequestOptions["client"] | undefined) => boolean;
+  resolvePluginSubagentToolsAlsoAllow: (params: {
+    pluginId?: string;
+    toolsAlsoAllow?: string[];
+  }) => RuntimePluginToolGrant | undefined;
+};
+
+const PLUGIN_SUBAGENT_SESSION_MESSAGES_MAX_LIMIT = 1_000;
+
+function normalizeSubagentRunRuntime(
+  value: unknown,
+): Awaited<ReturnType<PluginRuntime["subagent"]["run"]>>["runtime"] {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  const record = value as Record<string, unknown>;
+  const harness = typeof record.harness === "string" ? record.harness.trim() : "";
+  const provider = typeof record.provider === "string" ? record.provider.trim() : "";
+  const model = typeof record.model === "string" ? record.model.trim() : "";
+  return harness && provider && model ? { harness, provider, model } : undefined;
+}
+
+export function createGatewaySubagentRuntimeImpl(
+  deps: ServerPluginsSubagentRuntimeDeps,
+): PluginRuntime["subagent"] {
+  const getSessionMessages: PluginRuntime["subagent"]["getSessionMessages"] = async (params) => {
+    const limit =
+      params.limit == null || !Number.isFinite(params.limit)
+        ? undefined
+        : Math.min(
+            PLUGIN_SUBAGENT_SESSION_MESSAGES_MAX_LIMIT,
+            Math.max(1, Math.floor(params.limit)),
+          );
+    const payload = await deps.dispatchGatewayMethod<{ messages?: unknown[] }>("sessions.get", {
+      key: params.sessionKey,
+      ...(limit != null && { limit }),
+    });
+    return { messages: Array.isArray(payload?.messages) ? payload.messages : [] };
+  };
+
+  return {
+    async run(params) {
+      const scope = deps.getPluginRuntimeGatewayRequestScope();
+      const pluginId =
+        typeof scope?.pluginId === "string" && scope.pluginId.trim()
+          ? scope.pluginId.trim()
+          : undefined;
+      const runtimePluginToolGrant = deps.resolvePluginSubagentToolsAlsoAllow({
+        pluginId,
+        toolsAlsoAllow: params.toolsAlsoAllow,
+      });
+      const overrideRequested = Boolean(params.provider || params.model);
+      const hasRequestScopeClient = Boolean(scope?.client);
+      let allowOverride =
+        hasRequestScopeClient && deps.canClientUseModelOverride(scope?.client ?? null);
+      let allowSyntheticModelOverride = false;
+      if (overrideRequested && !allowOverride && !hasRequestScopeClient) {
+        const fallbackAuth = deps.authorizeFallbackModelOverride({
+          pluginId: scope?.pluginId,
+          provider: params.provider,
+          model: params.model,
+        });
+        if (!fallbackAuth.allowed) {
+          throw new Error(fallbackAuth.reason);
+        }
+        allowOverride = true;
+        allowSyntheticModelOverride = true;
+      }
+      if (overrideRequested && !allowOverride) {
+        throw new Error("provider/model override is not authorized for this plugin subagent run.");
+      }
+      const trustedCompletionRequested =
+        Boolean(params.requesterSessionKey) ||
+        params.expectsCompletionMessage === true ||
+        params.approvalGrant !== undefined;
+      const canForwardTrustedCompletionContext = deps.canTrustedOfficialPluginRequestScopes({
+        pluginId,
+        pluginOrigin: scope?.pluginOrigin,
+        pluginTrustedOfficialInstall: scope?.pluginTrustedOfficialInstall,
+      });
+      if (trustedCompletionRequested && !canForwardTrustedCompletionContext) {
+        throw new Error(
+          "requesterSessionKey, expectsCompletionMessage, and approvalGrant are only available to bundled or trusted official plugins.",
+        );
+      }
+
+      const payload = await deps.dispatchGatewayMethod<{ runId?: string; runtime?: unknown }>(
+        "agent",
+        {
+          sessionKey: params.sessionKey,
+          message: params.message,
+          ...(canForwardTrustedCompletionContext && params.requesterSessionKey
+            ? { requesterSessionKey: params.requesterSessionKey }
+            : {}),
+          ...(canForwardTrustedCompletionContext && params.expectsCompletionMessage === true
+            ? { expectsCompletionMessage: true }
+            : {}),
+          ...(canForwardTrustedCompletionContext && params.approvalGrant !== undefined
+            ? { approvalGrant: params.approvalGrant }
+            : {}),
+          deliver: params.deliver ?? false,
+          ...(allowOverride && params.provider && { provider: params.provider }),
+          ...(allowOverride && params.model && { model: params.model }),
+          ...(params.extraSystemPrompt && { extraSystemPrompt: params.extraSystemPrompt }),
+          ...(params.lane && { lane: params.lane }),
+          ...(params.cwd && { cwd: params.cwd }),
+          ...(params.lightContext === true && { bootstrapContextMode: "lightweight" }),
+          idempotencyKey: params.idempotencyKey || randomUUID(),
+        },
+        {
+          allowSyntheticModelOverride,
+          agentRunTracking: "plugin_subagent",
+          ...(pluginId ? { pluginRuntimeOwnerId: pluginId } : {}),
+          ...(runtimePluginToolGrant ? { runtimePluginToolGrant } : {}),
+        },
+      );
+      const runId = payload?.runId;
+      if (typeof runId !== "string" || !runId) {
+        throw new Error("Gateway agent method returned an invalid runId.");
+      }
+      const runtime = normalizeSubagentRunRuntime(payload?.runtime);
+      return { runId, ...(runtime ? { runtime } : {}) };
+    },
+    async waitForRun(params) {
+      const payload = await deps.dispatchGatewayMethod<{ status?: string; error?: string }>(
+        "agent.wait",
+        {
+          runId: params.runId,
+          ...(params.timeoutMs != null && { timeoutMs: params.timeoutMs }),
+        },
+      );
+      let status = payload?.status;
+      if (status === "completed" || status === "succeeded") {
+        status = "ok";
+      } else if (status === "error" && payload?.error?.trim().toLowerCase() === "completed") {
+        status = "ok";
+      }
+      if (status !== "ok" && status !== "error" && status !== "timeout") {
+        throw new Error(`Gateway agent.wait returned unexpected status: ${payload?.status}`);
+      }
+      return {
+        status,
+        ...(status !== "ok" &&
+          typeof payload?.error === "string" &&
+          payload.error && { error: payload.error }),
+      };
+    },
+    getSessionMessages,
+    async deleteSession(params) {
+      const scope = deps.getPluginRuntimeGatewayRequestScope();
+      const pluginId =
+        typeof scope?.pluginId === "string" && scope.pluginId.trim()
+          ? scope.pluginId.trim()
+          : undefined;
+      const pluginOwnedCleanupOptions = pluginId
+        ? {
+            pluginRuntimeOwnerId: pluginId,
+            ...(!deps.hasAdminScope(scope?.client)
+              ? {
+                  forceSyntheticClient: true,
+                  syntheticScopes: [deps.adminScope],
+                }
+              : {}),
+          }
+        : undefined;
+      await deps.dispatchGatewayMethod(
+        "sessions.delete",
+        {
+          key: params.sessionKey,
+          deleteTranscript: params.deleteTranscript ?? true,
+        },
+        pluginOwnedCleanupOptions,
+      );
+    },
+  };
+}

--- a/src/gateway/server-plugins.subagent-ended-hook.test.ts
+++ b/src/gateway/server-plugins.subagent-ended-hook.test.ts
@@ -130,6 +130,7 @@ describe("createGatewaySubagentRuntime.run subagent_ended tracking (#59164)", ()
     const scope = {
       context: createTestContext("plugin-scope", createTestCfg()),
       pluginId: "loop-guard",
+      pluginTrustedOfficialInstall: true,
       isWebchatConnect: () => false,
     } satisfies PluginRuntimeGatewayRequestScope;
 
@@ -154,6 +155,32 @@ describe("createGatewaySubagentRuntime.run subagent_ended tracking (#59164)", ()
     });
     expect(request.client?.internal?.agentRunTracking).toBe("plugin_subagent");
     expect(request.client?.internal?.pluginRuntimeOwnerId).toBe("loop-guard");
+  });
+
+  test("rejects untrusted plugin completion and approval params", async () => {
+    const serverPlugins = await loadServerPlugins();
+    const gatewayScope = await loadGatewayScope();
+    const runtime = serverPlugins.createGatewaySubagentRuntime();
+
+    const scope = {
+      context: createTestContext("plugin-scope", createTestCfg()),
+      pluginId: "unknown-plugin",
+      isWebchatConnect: () => false,
+    } satisfies PluginRuntimeGatewayRequestScope;
+
+    await expect(
+      gatewayScope.withPluginRuntimeGatewayRequestScope(scope, () =>
+        runtime.run({
+          sessionKey: "agent:main:subagent:unknown-worker",
+          requesterSessionKey: "agent:main:feishu:direct:user",
+          expectsCompletionMessage: true,
+          message: "attempt completion binding",
+          deliver: false,
+        }),
+      ),
+    ).rejects.toThrow(/trusted official plugins/);
+
+    expect(handleGatewayRequest).not.toHaveBeenCalled();
   });
 
   test("does not dispatch when no runtime config is available", async () => {

--- a/src/gateway/server-plugins.subagent-ended-hook.test.ts
+++ b/src/gateway/server-plugins.subagent-ended-hook.test.ts
@@ -116,6 +116,46 @@ describe("createGatewaySubagentRuntime.run subagent_ended tracking (#59164)", ()
     expect(request.client?.internal?.pluginRuntimeOwnerId).toBe("memory-core");
   });
 
+  test("forwards trusted plugin subagent completion and approval params", async () => {
+    const serverPlugins = await loadServerPlugins();
+    const gatewayScope = await loadGatewayScope();
+    const runtime = serverPlugins.createGatewaySubagentRuntime();
+    const approvalGrant = {
+      kind: "loop_guard_inherited_approval",
+      approvalPolicy: "never",
+      sandbox: "danger-full-access",
+      expiresAt: Date.now() + 30_000,
+    };
+
+    const scope = {
+      context: createTestContext("plugin-scope", createTestCfg()),
+      pluginId: "loop-guard",
+      isWebchatConnect: () => false,
+    } satisfies PluginRuntimeGatewayRequestScope;
+
+    await gatewayScope.withPluginRuntimeGatewayRequestScope(scope, () =>
+      runtime.run({
+        sessionKey: "agent:main:subagent:loop-guard-worker",
+        requesterSessionKey: "agent:main:feishu:direct:user",
+        expectsCompletionMessage: true,
+        approvalGrant,
+        message: "continue after approval",
+        deliver: false,
+      }),
+    );
+
+    const request = lastGatewayRequest();
+    expect(request.req.method).toBe("agent");
+    expect(request.req.params).toMatchObject({
+      sessionKey: "agent:main:subagent:loop-guard-worker",
+      requesterSessionKey: "agent:main:feishu:direct:user",
+      expectsCompletionMessage: true,
+      approvalGrant,
+    });
+    expect(request.client?.internal?.agentRunTracking).toBe("plugin_subagent");
+    expect(request.client?.internal?.pluginRuntimeOwnerId).toBe("loop-guard");
+  });
+
   test("does not dispatch when no runtime config is available", async () => {
     const serverPlugins = await loadServerPlugins();
     const runtime = serverPlugins.createGatewaySubagentRuntime();

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -433,6 +433,11 @@ export function createGatewaySubagentRuntime(): PluginRuntime["subagent"] {
         {
           sessionKey: params.sessionKey,
           message: params.message,
+          ...(params.requesterSessionKey
+            ? { requesterSessionKey: params.requesterSessionKey }
+            : {}),
+          ...(params.expectsCompletionMessage === true ? { expectsCompletionMessage: true } : {}),
+          ...(params.approvalGrant !== undefined ? { approvalGrant: params.approvalGrant } : {}),
           deliver: params.deliver ?? false,
           ...(allowOverride && params.provider && { provider: params.provider }),
           ...(allowOverride && params.model && { model: params.model }),

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -41,6 +41,7 @@ import {
   resolvePluginSubagentToolsAlsoAllow,
 } from "./server-plugin-runtime-client.js";
 import { projectGatewayRuntimeNodes } from "./server-plugins-node-runtime.js";
+import { createGatewaySubagentRuntimeImpl } from "./server-plugins-subagent-runtime.js";
 
 export {
   clearFallbackGatewayContext,
@@ -367,156 +368,17 @@ export async function dispatchTrustedPluginGatewayMethod<T>(
   });
 }
 
-const PLUGIN_SUBAGENT_SESSION_MESSAGES_MAX_LIMIT = 1_000;
-
-function normalizeSubagentRunRuntime(
-  value: unknown,
-): Awaited<ReturnType<PluginRuntime["subagent"]["run"]>>["runtime"] {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return undefined;
-  }
-  const record = value as Record<string, unknown>;
-  const harness = typeof record.harness === "string" ? record.harness.trim() : "";
-  const provider = typeof record.provider === "string" ? record.provider.trim() : "";
-  const model = typeof record.model === "string" ? record.model.trim() : "";
-  return harness && provider && model ? { harness, provider, model } : undefined;
-}
-
 export function createGatewaySubagentRuntime(): PluginRuntime["subagent"] {
-  const getSessionMessages: PluginRuntime["subagent"]["getSessionMessages"] = async (params) => {
-    const limit =
-      params.limit == null || !Number.isFinite(params.limit)
-        ? undefined
-        : Math.min(
-            PLUGIN_SUBAGENT_SESSION_MESSAGES_MAX_LIMIT,
-            Math.max(1, Math.floor(params.limit)),
-          );
-    const payload = await dispatchGatewayMethod<{ messages?: unknown[] }>("sessions.get", {
-      key: params.sessionKey,
-      ...(limit != null && { limit }),
-    });
-    return { messages: Array.isArray(payload?.messages) ? payload.messages : [] };
-  };
-
-  return {
-    async run(params) {
-      const scope = getPluginRuntimeGatewayRequestScope();
-      const pluginId =
-        typeof scope?.pluginId === "string" && scope.pluginId.trim()
-          ? scope.pluginId.trim()
-          : undefined;
-      const runtimePluginToolGrant = resolvePluginSubagentToolsAlsoAllow({
-        pluginId,
-        toolsAlsoAllow: params.toolsAlsoAllow,
-      });
-      const overrideRequested = Boolean(params.provider || params.model);
-      const hasRequestScopeClient = Boolean(scope?.client);
-      let allowOverride = hasRequestScopeClient && canClientUseModelOverride(scope?.client ?? null);
-      let allowSyntheticModelOverride = false;
-      if (overrideRequested && !allowOverride && !hasRequestScopeClient) {
-        const fallbackAuth = authorizeFallbackModelOverride({
-          pluginId: scope?.pluginId,
-          provider: params.provider,
-          model: params.model,
-        });
-        if (!fallbackAuth.allowed) {
-          throw new Error(fallbackAuth.reason);
-        }
-        allowOverride = true;
-        allowSyntheticModelOverride = true;
-      }
-      if (overrideRequested && !allowOverride) {
-        throw new Error("provider/model override is not authorized for this plugin subagent run.");
-      }
-      const payload = await dispatchGatewayMethod<{ runId?: string; runtime?: unknown }>(
-        "agent",
-        {
-          sessionKey: params.sessionKey,
-          message: params.message,
-          ...(params.requesterSessionKey
-            ? { requesterSessionKey: params.requesterSessionKey }
-            : {}),
-          ...(params.expectsCompletionMessage === true ? { expectsCompletionMessage: true } : {}),
-          ...(params.approvalGrant !== undefined ? { approvalGrant: params.approvalGrant } : {}),
-          deliver: params.deliver ?? false,
-          ...(allowOverride && params.provider && { provider: params.provider }),
-          ...(allowOverride && params.model && { model: params.model }),
-          ...(params.extraSystemPrompt && { extraSystemPrompt: params.extraSystemPrompt }),
-          ...(params.lane && { lane: params.lane }),
-          ...(params.cwd && { cwd: params.cwd }),
-          ...(params.lightContext === true && { bootstrapContextMode: "lightweight" }),
-          // The gateway `agent` schema requires `idempotencyKey: NonEmptyString`,
-          // so fall back to a generated UUID when the caller omits it. Without
-          // this, plugin subagent runs (for example memory-core dreaming
-          // narrative) silently fail schema validation at the gateway.
-          idempotencyKey: params.idempotencyKey || randomUUID(),
-        },
-        {
-          allowSyntheticModelOverride,
-          agentRunTracking: "plugin_subagent",
-          ...(pluginId ? { pluginRuntimeOwnerId: pluginId } : {}),
-          ...(runtimePluginToolGrant ? { runtimePluginToolGrant } : {}),
-        },
-      );
-      const runId = payload?.runId;
-      if (typeof runId !== "string" || !runId) {
-        throw new Error("Gateway agent method returned an invalid runId.");
-      }
-      const runtime = normalizeSubagentRunRuntime(payload?.runtime);
-      return { runId, ...(runtime ? { runtime } : {}) };
-    },
-    async waitForRun(params) {
-      const payload = await dispatchGatewayMethod<{ status?: string; error?: string }>(
-        "agent.wait",
-        {
-          runId: params.runId,
-          ...(params.timeoutMs != null && { timeoutMs: params.timeoutMs }),
-        },
-      );
-      let status = payload?.status;
-      if (status === "completed" || status === "succeeded") {
-        status = "ok";
-      } else if (status === "error" && payload?.error?.trim().toLowerCase() === "completed") {
-        status = "ok";
-      }
-      if (status !== "ok" && status !== "error" && status !== "timeout") {
-        throw new Error(`Gateway agent.wait returned unexpected status: ${payload?.status}`);
-      }
-      return {
-        status,
-        ...(status !== "ok" &&
-          typeof payload?.error === "string" &&
-          payload.error && { error: payload.error }),
-      };
-    },
-    getSessionMessages,
-    async deleteSession(params) {
-      const scope = getPluginRuntimeGatewayRequestScope();
-      const pluginId =
-        typeof scope?.pluginId === "string" && scope.pluginId.trim()
-          ? scope.pluginId.trim()
-          : undefined;
-      const pluginOwnedCleanupOptions = pluginId
-        ? {
-            pluginRuntimeOwnerId: pluginId,
-            ...(!hasAdminScope(scope?.client)
-              ? {
-                  forceSyntheticClient: true,
-                  syntheticScopes: [ADMIN_SCOPE],
-                }
-              : {}),
-          }
-        : undefined;
-      await dispatchGatewayMethod(
-        "sessions.delete",
-        {
-          key: params.sessionKey,
-          deleteTranscript: params.deleteTranscript ?? true,
-        },
-        pluginOwnedCleanupOptions,
-      );
-    },
-  };
+  return createGatewaySubagentRuntimeImpl({
+    adminScope: ADMIN_SCOPE,
+    authorizeFallbackModelOverride,
+    canClientUseModelOverride,
+    canTrustedOfficialPluginRequestScopes,
+    dispatchGatewayMethod,
+    getPluginRuntimeGatewayRequestScope,
+    hasAdminScope,
+    resolvePluginSubagentToolsAlsoAllow,
+  });
 }
 
 export function createGatewayNodesRuntime(): PluginRuntime["nodes"] {

--- a/src/plugins/runtime/types.ts
+++ b/src/plugins/runtime/types.ts
@@ -15,6 +15,12 @@ type PluginRuntimeChannel = import("./types-channel.js").PluginRuntimeChannel;
 type SubagentRunParams = {
   sessionKey: string;
   message: string;
+  /** Requester session that should receive subagent lifecycle/completion messages. */
+  requesterSessionKey?: string;
+  /** When true, completion should be announced back to the requester session. */
+  expectsCompletionMessage?: boolean;
+  /** Trusted plugin-issued, run-scoped approval capability for native harnesses. */
+  approvalGrant?: unknown;
   /** Add exact tools registered by the calling plugin to the worker's normal tool surface. */
   toolsAlsoAllow?: string[];
   provider?: string;

--- a/src/system-agent/tui-backend.test.ts
+++ b/src/system-agent/tui-backend.test.ts
@@ -14,6 +14,10 @@ vi.mock("../plugins/providers.js", async (importOriginal) => ({
   resolveOwningPluginIdsForProviderRef: vi.fn(() => []),
 }));
 
+vi.mock("../agents/prepared-model-catalog.js", () => ({
+  loadPreparedModelCatalog: vi.fn(async () => []),
+}));
+
 const overview: SystemAgentOverview = {
   defaultAgentId: "main",
   defaultModel: "openai/gpt-5.5",


### PR DESCRIPTION
## What Problem This Solves

Plugin-owned subagent supervisors need a core path for approved handoffs: a plugin can start a worker subagent, preserve the requester session that should receive completion, and carry a short-lived approval capability into the native harness attempt.

Without this, plugins that supervise stuck work have to choose between losing completion delivery, dropping the human-approved execution grant, or patching bundled output locally. That is harder to audit than a narrow run-scoped gateway path.

## Summary

This PR lets trusted plugin-owned subagent runs carry the run-scoped context needed for approved handoffs and completion delivery:

- allow `PluginRuntime.subagent.run()` to pass `requesterSessionKey`, `expectsCompletionMessage`, and a trusted `approvalGrant`
- restrict those completion/approval fields to bundled or trusted official plugins; untrusted plugins can still run subagents, but cannot bind completion delivery or approval capabilities to arbitrary requester sessions
- register trusted plugin subagents against the requested source session when provided, instead of always treating the plugin owner session as the requester
- propagate `approvalGrant` through gateway run execution into embedded/native harness attempts
- keep `approvalGrant` scoped to authenticated `plugin_subagent` internal clients so public agent RPC callers cannot inject it into execution
- reduce expected completion wake fallback noise for `no_active_run`
- make plugin completion labels unique by appending a child-session suffix when needed
- regenerate the Swift gateway protocol model for the added agent params

## Security Notes

- Public/external agent requests may include an `approvalGrant`-shaped payload, but it is not propagated into the execution attempt unless the caller is an authenticated plugin subagent internal client.
- `requesterSessionKey`, `expectsCompletionMessage`, and `approvalGrant` are only forwarded from bundled or trusted official plugins.
- Untrusted plugin subagent requests that try to pass completion/approval routing fields are rejected before dispatch.
- `requesterSessionKey` and `expectsCompletionMessage` affect completion routing/announcement, not tool grants by themselves.
- This PR does not add a new channel UI or public approval command protocol. It only carries an already-issued, plugin-owned run-scoped capability through the existing subagent path.

## Evidence

Focused tests:

```bash
corepack pnpm test src/gateway/server-plugins.subagent-ended-hook.test.ts src/agents/subagent-announce.test.ts packages/gateway-protocol/src/schema/agent.test.ts
```

Result:

- 3 Vitest shards passed
- 36 tests passed

Lint / format / protocol checks:

```bash
node scripts/run-oxlint-shards.mjs --threads=8
corepack pnpm format:check
corepack pnpm test:bundled
node scripts/check-protocol-since.mjs
git diff --check
```

Result:

- oxlint shards passed
- format check passed
- bundled protocol tests passed: 191 tests
- protocol since guard passed: 0 new core methods use train 2026.7
- git diff whitespace check passed
