### PR TITLE
test(macos): stabilize parallel Swift tests

### DIFF
--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeRuntimeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeRuntimeTests.swift
@@ -310,10 +310,10 @@ struct MacNodeRuntimeTests {
     }
 
     @Test func `Claude catalog worker propagates caller cancellation`() async {
-        let started = LockedCounter()
+        let started = DispatchSemaphore(value: 0)
         let worker = MacNodeClaudeSessionCatalogWorker(
             listOperation: { _ in
-                started.increment()
+                started.signal()
                 while !Task.isCancelled {
                     Thread.sleep(forTimeInterval: 0.001)
                 }
@@ -321,7 +321,10 @@ struct MacNodeRuntimeTests {
             },
             readOperation: { _ in "unused" })
         let task = Task { try await worker.list(paramsJSON: nil) }
-        #expect(await self.waitForCount(1, counter: started))
+        let operationStarted = await Task.detached {
+            started.wait(timeout: .now() + 5) == .success
+        }.value
+        #expect(operationStarted)
 
         task.cancel()
         await #expect(throws: CancellationError.self) {

--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeRuntimeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeRuntimeTests.swift
@@ -310,10 +310,10 @@ struct MacNodeRuntimeTests {
     }
 
     @Test func `Claude catalog worker propagates caller cancellation`() async {
-        let started = DispatchSemaphore(value: 0)
+        let started = AsyncStream<Void>.makeStream()
         let worker = MacNodeClaudeSessionCatalogWorker(
             listOperation: { _ in
-                started.signal()
+                started.continuation.yield()
                 while !Task.isCancelled {
                     Thread.sleep(forTimeInterval: 0.001)
                 }
@@ -321,10 +321,14 @@ struct MacNodeRuntimeTests {
             },
             readOperation: { _ in "unused" })
         let task = Task { try await worker.list(paramsJSON: nil) }
-        let operationStarted = await Task.detached {
-            started.wait(timeout: .now() + 5) == .success
-        }.value
-        #expect(operationStarted)
+        let watchdog = Task {
+            try? await Task.sleep(for: .seconds(5))
+            started.continuation.finish()
+        }
+        var iterator = started.stream.makeAsyncIterator()
+        #expect(await iterator.next() != nil)
+        watchdog.cancel()
+        started.continuation.finish()
 
         task.cancel()
         await #expect(throws: CancellationError.self) {

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
@@ -11,19 +11,19 @@ private actor ActivationMarkerObservation {
     private var observedDeadline: Date?
 
     func record(_ value: Bool) {
-        observed = value
+        self.observed = value
     }
 
     func value() -> Bool {
-        observed
+        self.observed
     }
 
     func record(deadline: Date?) {
-        observedDeadline = deadline
+        self.observedDeadline = deadline
     }
 
     func deadline() -> Date? {
-        observedDeadline
+        self.observedDeadline
     }
 }
 
@@ -32,15 +32,15 @@ private final class ActivationOwnerObservation: @unchecked Sendable {
     private var observedOwner: OnboardingSystemAgentResumeStore.ActivationOwner?
 
     func record(_ owner: OnboardingSystemAgentResumeStore.ActivationOwner?) {
-        lock.lock()
+        self.lock.lock()
         defer { self.lock.unlock() }
-        observedOwner = owner
+        self.observedOwner = owner
     }
 
     func value() -> OnboardingSystemAgentResumeStore.ActivationOwner? {
-        lock.lock()
+        self.lock.lock()
         defer { self.lock.unlock() }
-        return observedOwner
+        return self.observedOwner
     }
 }
 
@@ -49,10 +49,10 @@ private final class AISetupSocketGeneration: @unchecked Sendable {
     private var nextGeneration = 0
 
     func claim() -> Int {
-        lock.lock()
+        self.lock.lock()
         defer { self.lock.unlock() }
         defer { self.nextGeneration += 1 }
-        return nextGeneration
+        return self.nextGeneration
     }
 }
 
@@ -68,33 +68,32 @@ private final class AISetupGatewayConfig: @unchecked Sendable {
     }
 
     func setToken(_ token: String) {
-        lock.lock()
+        self.lock.lock()
         defer { self.lock.unlock() }
         self.token = token
-        switchTokenAfterReads = nil
+        self.switchTokenAfterReads = nil
     }
 
     func switchToken(to token: String, afterReads: Int) {
-        lock.lock()
+        self.lock.lock()
         defer { self.lock.unlock() }
-        switchTokenAfterReads = (remaining: afterReads, token: token)
+        self.switchTokenAfterReads = (remaining: afterReads, token: token)
     }
 
     func snapshot() -> GatewayConnection.Config {
-        lock.lock()
+        self.lock.lock()
         defer { self.lock.unlock() }
         if let pending = switchTokenAfterReads {
             if pending.remaining == 0 {
-                token = pending.token
-                switchTokenAfterReads = nil
+                self.token = pending.token
+                self.switchTokenAfterReads = nil
             } else {
-                switchTokenAfterReads = (
+                self.switchTokenAfterReads = (
                     remaining: pending.remaining - 1,
-                    token: pending.token
-                )
+                    token: pending.token)
             }
         }
-        return (url: url, token: token, password: nil)
+        return (url: self.url, token: self.token, password: nil)
     }
 }
 
@@ -107,15 +106,15 @@ private final class AISetupRouteIdentity: @unchecked Sendable {
     }
 
     func set(_ value: String) {
-        lock.lock()
+        self.lock.lock()
         defer { self.lock.unlock() }
         self.value = value
     }
 
     func snapshot() -> String {
-        lock.lock()
+        self.lock.lock()
         defer { self.lock.unlock() }
-        return value
+        return self.value
     }
 }
 
@@ -125,14 +124,14 @@ private actor AISetupRequestRecorder {
 
     func record(_ message: URLSessionWebSocketTask.Message) {
         guard let request = aiSetupRequest(from: message) else { return }
-        methods.append(request.method)
+        self.methods.append(request.method)
         if let apiKey = request.params["apiKey"] as? String {
-            apiKeys.append(apiKey)
+            self.apiKeys.append(apiKey)
         }
     }
 
     func snapshot() -> (methods: [String], apiKeys: [String]) {
-        (methods, apiKeys)
+        (self.methods, self.apiKeys)
     }
 }
 
@@ -143,26 +142,26 @@ private actor AISetupRequestGate {
     private var releaseWaiters: [CheckedContinuation<Void, Never>] = []
 
     func wait() async {
-        started = true
-        startWaiters.forEach { $0.resume() }
-        startWaiters.removeAll()
-        guard !released else { return }
+        self.started = true
+        self.startWaiters.forEach { $0.resume() }
+        self.startWaiters.removeAll()
+        guard !self.released else { return }
         await withCheckedContinuation { continuation in
             self.releaseWaiters.append(continuation)
         }
     }
 
     func waitUntilStarted() async {
-        guard !started else { return }
+        guard !self.started else { return }
         await withCheckedContinuation { continuation in
             self.startWaiters.append(continuation)
         }
     }
 
     func release() {
-        released = true
-        releaseWaiters.forEach { $0.resume() }
-        releaseWaiters.removeAll()
+        self.released = true
+        self.releaseWaiters.forEach { $0.resume() }
+        self.releaseWaiters.removeAll()
     }
 }
 
@@ -174,16 +173,16 @@ private actor AISetupConfigReadGate {
     private var releaseWaiters: [CheckedContinuation<Void, Never>] = []
 
     func armNextRead() {
-        blockNextRead = true
+        self.blockNextRead = true
     }
 
     func snapshotToken() async -> String {
-        if blockNextRead {
-            blockNextRead = false
-            blocked = true
-            blockedWaiters.forEach { $0.resume() }
-            blockedWaiters.removeAll()
-            if !released {
+        if self.blockNextRead {
+            self.blockNextRead = false
+            self.blocked = true
+            self.blockedWaiters.forEach { $0.resume() }
+            self.blockedWaiters.removeAll()
+            if !self.released {
                 await withCheckedContinuation { continuation in
                     self.releaseWaiters.append(continuation)
                 }
@@ -193,22 +192,22 @@ private actor AISetupConfigReadGate {
     }
 
     func waitUntilBlocked() async {
-        guard !blocked else { return }
+        guard !self.blocked else { return }
         await withCheckedContinuation { continuation in
             self.blockedWaiters.append(continuation)
         }
     }
 
     func release() {
-        released = true
-        releaseWaiters.forEach { $0.resume() }
-        releaseWaiters.removeAll()
+        self.released = true
+        self.releaseWaiters.forEach { $0.resume() }
+        self.releaseWaiters.removeAll()
     }
 }
 
 private func aiSetupRequest(
-    from message: URLSessionWebSocketTask.Message
-) -> (id: String, method: String, params: [String: Any])? {
+    from message: URLSessionWebSocketTask.Message) -> (id: String, method: String, params: [String: Any])?
+{
     let data: Data? = switch message {
     case let .data(data): data
     case let .string(string): string.data(using: .utf8)
@@ -225,8 +224,8 @@ private func aiSetupRequest(
 private func detectedSetupResponse(
     id: String,
     kind: String = "claude-cli",
-    modelRef: String = "claude-cli/claude-opus-4-8"
-) -> Data {
+    modelRef: String = "claude-cli/claude-opus-4-8") -> Data
+{
     Data(
         """
         {
@@ -252,22 +251,20 @@ private func detectedSetupResponse(
             "setupComplete": false
           }
         }
-        """.utf8
-    )
+        """.utf8)
 }
 
 private func successfulEmptyResponse(id: String) -> Data {
     Data(
         """
         {"type":"res","id":"\(id)","ok":true,"payload":{}}
-        """.utf8
-    )
+        """.utf8)
 }
 
 private func respondToAISetupHealth(
     task: GatewayTestWebSocketTask,
-    request: (id: String, method: String, params: [String: Any])
-) -> Bool {
+    request: (id: String, method: String, params: [String: Any])) -> Bool
+{
     guard request.method == "health" else { return false }
     task.emitReceiveSuccess(.data(successfulEmptyResponse(id: request.id)))
     return true
@@ -276,8 +273,8 @@ private func respondToAISetupHealth(
 private func respondToAISetupPreparation(
     task: GatewayTestWebSocketTask,
     request: (id: String, method: String, params: [String: Any]),
-    kind: String
-) -> Bool {
+    kind: String) -> Bool
+{
     if respondToAISetupHealth(task: task, request: request) {
         return true
     }
@@ -286,8 +283,7 @@ private func respondToAISetupPreparation(
     task.emitReceiveSuccess(.data(detectedSetupResponse(
         id: request.id,
         kind: kind,
-        modelRef: modelRef
-    )))
+        modelRef: modelRef)))
     return true
 }
 
@@ -299,17 +295,15 @@ private func actionableDetectedSetupResponse(id: String) -> Data {
 
 private func persistedDetectedSetupResponse(
     id: String,
-    configuredModel: String = "openai/gpt-5.5"
-) -> Data {
+    configuredModel: String = "openai/gpt-5.5") -> Data
+{
     let response = String(decoding: detectedSetupResponse(
         id: id,
         kind: "codex-cli",
-        modelRef: "openai/gpt-5.5"
-    ), as: UTF8.self)
+        modelRef: "openai/gpt-5.5"), as: UTF8.self)
         .replacingOccurrences(
             of: #""configuredModel": null"#,
-            with: #""configuredModel": "\#(configuredModel)""#
-        )
+            with: #""configuredModel": "\#(configuredModel)""#)
         .replacingOccurrences(of: #""setupComplete": false"#, with: #""setupComplete": true"#)
     return Data(response.utf8)
 }
@@ -328,8 +322,7 @@ private func missingConfiguredModelResponse(id: String) -> Data {
             "agents": [{ "id": "main" }]
           }
         }
-        """.utf8
-    )
+        """.utf8)
 }
 
 private func configuredModelResponse(id: String) -> Data {
@@ -349,15 +342,14 @@ private func configuredModelResponse(id: String) -> Data {
             }]
           }
         }
-        """.utf8
-    )
+        """.utf8)
 }
 
 private func waitForAISetupRequests(
     _ recorder: AISetupRequestRecorder,
-    count: Int
-) async -> (methods: [String], apiKeys: [String]) {
-    for _ in 0 ..< 200 {
+    count: Int) async -> (methods: [String], apiKeys: [String])
+{
+    for _ in 0..<200 {
         let snapshot = await recorder.snapshot()
         if snapshot.methods.count >= count {
             return snapshot
@@ -374,8 +366,8 @@ private func settleQueuedAISetupTasks() async {
 private func makeAISetupSession(
     recorder: AISetupRequestRecorder,
     indeterminateActivationAfterDispatch: Bool = false,
-    detectedKind: String = "claude-cli"
-) -> GatewayTestWebSocketSession {
+    detectedKind: String = "claude-cli") -> GatewayTestWebSocketSession
+{
     GatewayTestWebSocketSession(taskFactory: {
         GatewayTestWebSocketTask(sendHook: { task, message, sendIndex in
             guard sendIndex > 0, let request = aiSetupRequest(from: message) else { return }
@@ -391,8 +383,7 @@ private func makeAISetupSession(
                 task.emitReceiveSuccess(.data(detectedSetupResponse(
                     id: request.id,
                     kind: detectedKind,
-                    modelRef: modelRef
-                )))
+                    modelRef: modelRef)))
             case "openclaw.setup.activate":
                 if indeterminateActivationAfterDispatch {
                     task.emitReceiveSuccess(.data(indeterminateActivationResponse(id: request.id)))
@@ -410,8 +401,8 @@ private func makeRestartingAISetupSession(
     suiteName: String,
     recorder: AISetupRequestRecorder,
     ownerObservation: ActivationOwnerObservation,
-    postRestartConfiguredModel: String?
-) -> GatewayTestWebSocketSession {
+    postRestartConfiguredModel: String?) -> GatewayTestWebSocketSession
+{
     let socketGeneration = AISetupSocketGeneration()
     return GatewayTestWebSocketSession(taskFactory: {
         let generation = socketGeneration.claim()
@@ -427,14 +418,12 @@ private func makeRestartingAISetupSession(
                     task.emitReceiveSuccess(.data(detectedSetupResponse(
                         id: request.id,
                         kind: "codex-cli",
-                        modelRef: "openai/gpt-5.5"
-                    )))
+                        modelRef: "openai/gpt-5.5")))
                 case "openclaw.setup.activate":
                     let owner = UserDefaults(suiteName: suiteName).flatMap {
                         OnboardingSystemAgentResumeStore.activationOwner(
                             for: "local",
-                            defaults: $0
-                        )
+                            defaults: $0)
                     }
                     ownerObservation.record(owner)
                     task.emitReceiveFailure(URLError(.networkConnectionLost))
@@ -450,8 +439,7 @@ private func makeRestartingAISetupSession(
                 } ?? detectedSetupResponse(
                     id: request.id,
                     kind: "codex-cli",
-                    modelRef: "openai/gpt-5.5"
-                )
+                    modelRef: "openai/gpt-5.5")
                 task.emitReceiveSuccess(.data(response))
             case "openclaw.setup.verify":
                 task.emitReceiveSuccess(.data(verifiedSetupResponse(id: request.id)))
@@ -471,8 +459,7 @@ private func failedActivationResponse(id: String) -> Data {
           "ok": true,
           "payload": { "ok": false, "status": "auth", "error": "rejected" }
         }
-        """.utf8
-    )
+        """.utf8)
 }
 
 private func indeterminateActivationResponse(id: String) -> Data {
@@ -487,8 +474,7 @@ private func indeterminateActivationResponse(id: String) -> Data {
             "message": "Setup inference activation is indeterminate"
           }
         }
-        """.utf8
-    )
+        """.utf8)
 }
 
 private func verifiedSetupResponse(id: String) -> Data {
@@ -500,8 +486,7 @@ private func verifiedSetupResponse(id: String) -> Data {
           "ok": true,
           "payload": { "ok": true, "modelRef": "openai/gpt-5.5", "latencyMs": 42 }
         }
-        """.utf8
-    )
+        """.utf8)
 }
 
 private func rejectedSetupVerificationResponse(id: String) -> Data {
@@ -513,8 +498,7 @@ private func rejectedSetupVerificationResponse(id: String) -> Data {
           "ok": true,
           "payload": { "ok": false, "status": "auth", "error": "expired login" }
         }
-        """.utf8
-    )
+        """.utf8)
 }
 
 private func unavailableGatewayResponse(id: String) -> Data {
@@ -526,8 +510,7 @@ private func unavailableGatewayResponse(id: String) -> Data {
           "ok": false,
           "error": { "code": "UNAVAILABLE", "message": "temporary failure" }
         }
-        """.utf8
-    )
+        """.utf8)
 }
 
 @Suite(.serialized)
@@ -537,8 +520,7 @@ struct OnboardingAISetupTests {
         let failure = OnboardingAISetupModel.failure(
             label: "Codex CLI",
             status: "auth",
-            error: "Codex login expired (request 42)"
-        )
+            error: "Codex login expired (request 42)")
 
         #expect(failure.summary == "Codex CLI is installed, but the login didn’t work. Sign in again, then retry.")
         #expect(failure.detail == "Codex login expired (request 42)")
@@ -549,8 +531,7 @@ struct OnboardingAISetupTests {
         let failure = OnboardingAISetupModel.failure(
             label: "Codex CLI",
             status: "timeout",
-            error: "  "
-        )
+            error: "  ")
 
         #expect(failure.summary == "Codex CLI didn’t answer in time.")
         #expect(failure.detail == nil)
@@ -559,8 +540,7 @@ struct OnboardingAISetupTests {
 
     @Test func `transport failure preserves original detail`() {
         let failure = OnboardingAISetupModel.transportFailure(
-            "Gateway request failed: connection reset"
-        )
+            "Gateway request failed: connection reset")
 
         #expect(failure.summary == "The Gateway setup request failed. Show details to inspect or copy the error.")
         #expect(failure.detail == "Gateway request failed: connection reset")
@@ -571,8 +551,7 @@ struct OnboardingAISetupTests {
         let failure = OnboardingAISetupModel.failure(
             label: "Codex CLI",
             status: "unavailable",
-            error: rawDetail
-        )
+            error: rawDetail)
 
         #expect(failure.summary == "Codex CLI couldn’t complete the test. Show details to inspect or copy the error.")
         #expect(failure.detail == rawDetail.trimmingCharacters(in: .whitespacesAndNewlines))
@@ -611,8 +590,7 @@ struct OnboardingAISetupTests {
 
     @Test func `provider auth opens only safe external links`() {
         let safe = OnboardingProviderAuthLink.safeURL(
-            "https://auth.openai.com/oauth/authorize?client_id=test"
-        )
+            "https://auth.openai.com/oauth/authorize?client_id=test")
         #expect(safe?.host() == "auth.openai.com")
         #expect(OnboardingProviderAuthLink.safeURL("http://localhost:1455/callback") == nil)
         #expect(OnboardingProviderAuthLink.safeURL("file:///tmp/token") == nil)
@@ -630,15 +608,13 @@ struct OnboardingAISetupTests {
             icon: nil,
             website: nil,
             kind: "oauth",
-            featured: true
-        )
+            featured: true)
         model._test_setProviderAuth(option: option, sessionID: "finished-session")
 
         model._test_applyAuthWizardResult(
             done: true,
             status: "error",
-            error: "The authorization request was denied."
-        )
+            error: "The authorization request was denied.")
 
         #expect(model.activeAuthOption?.id == option.id)
         #expect(model.authError?.copyText == "The authorization request was denied.")
@@ -653,30 +629,25 @@ struct OnboardingAISetupTests {
     @Test func `provider auth mismatch cancels returned server session id`() {
         #expect(OnboardingAISetupModel.providerAuthCancellationSessionID(
             requested: "requested-session",
-            returned: "returned-server-session"
-        ) == "returned-server-session")
+            returned: "returned-server-session") == "returned-server-session")
         #expect(OnboardingAISetupModel.providerAuthCancellationSessionID(
             requested: "matching-session",
-            returned: "matching-session"
-        ) == nil)
+            returned: "matching-session") == nil)
     }
 
     @Test func `provider auth reconciliation only trusts its own completed flow`() {
         #expect(!OnboardingAISetupModel.canAcceptProviderAuthReconciliation(
             pending: false,
             setupComplete: true,
-            configuredModel: "openai/gpt-5.5"
-        ))
+            configuredModel: "openai/gpt-5.5"))
         #expect(!OnboardingAISetupModel.canAcceptProviderAuthReconciliation(
             pending: true,
             setupComplete: false,
-            configuredModel: "openai/gpt-5.5"
-        ))
+            configuredModel: "openai/gpt-5.5"))
         #expect(OnboardingAISetupModel.canAcceptProviderAuthReconciliation(
             pending: true,
             setupComplete: true,
-            configuredModel: "openai/gpt-5.5"
-        ))
+            configuredModel: "openai/gpt-5.5"))
     }
 
     @Test func `codex activation covers install probe and finalization`() {
@@ -689,13 +660,11 @@ struct OnboardingAISetupTests {
         let legacy = OnboardingAISetupModel.activationParams(
             kind: "codex-cli",
             modelRef: "openai/gpt-5.5",
-            supportsExactModel: false
-        )
+            supportsExactModel: false)
         let capable = OnboardingAISetupModel.activationParams(
             kind: "codex-cli",
             modelRef: "openai/gpt-5.5",
-            supportsExactModel: true
-        )
+            supportsExactModel: true)
 
         #expect(legacy["kind"]?.value as? String == "codex-cli")
         #expect(legacy["modelRef"] == nil)
@@ -705,8 +674,7 @@ struct OnboardingAISetupTests {
         let local = OnboardingAISetupModel.activationParams(
             kind: "provider-auto:lmstudio",
             modelRef: "lmstudio/qwen-local",
-            supportsExactModel: true
-        )
+            supportsExactModel: true)
         #expect(local["kind"]?.value as? String == "provider-auto:lmstudio")
         #expect(local["modelRef"]?.value as? String == "lmstudio/qwen-local")
     }
@@ -715,9 +683,8 @@ struct OnboardingAISetupTests {
         let candidates = try JSONDecoder().decode(
             [OnboardingAISetupModel.UnavailableCandidate].self,
             from: Data(
-                #"[{"id":"pi-cli","label":"Pi CLI","detail":"installed","reason":"Not a setup route."},{"id":"opencode-cli","label":"OpenCode CLI","detail":"installed","reason":"Not a setup route."}]"#.utf8
-            )
-        )
+                #"[{"id":"pi-cli","label":"Pi CLI","detail":"installed","reason":"Not a setup route."},{"id":"opencode-cli","label":"OpenCode CLI","detail":"installed","reason":"Not a setup route."}]"#
+                    .utf8))
 
         #expect(candidates.map(\.id) == ["pi-cli", "opencode-cli"])
         #expect(candidates.map(\.label) == ["Pi CLI", "OpenCode CLI"])
@@ -730,8 +697,7 @@ struct OnboardingAISetupTests {
             {"ok":true,"modelRef":"openai/gpt-5.5","lines":[
               "Model: openai/gpt-5.5","  Plugin registry refresh failed: offline  ",""
             ]}
-            """#.utf8
-        )
+            """#.utf8)
         let result = try JSONDecoder().decode(OnboardingAISetupModel.ActivateResult.self, from: data)
         let model = OnboardingAISetupModel()
 
@@ -758,8 +724,7 @@ struct OnboardingAISetupTests {
              "snapshot":{"presence":[],"health":{},
                          "stateVersion":{"presence":0,"health":0},"uptimeMs":0},
              "auth":{},"policy":{}}
-            """#.utf8
-        )
+            """#.utf8)
         let hello = try JSONDecoder().decode(HelloOk.self, from: data)
 
         #expect(hello.supportsServerCapability(.systemAgentSetupModelRef))
@@ -770,35 +735,29 @@ struct OnboardingAISetupTests {
             method: "openclaw.setup.activate",
             code: "UNKNOWN_METHOD",
             message: "unknown method",
-            details: nil
-        )
+            details: nil)
         let invalidParams = GatewayResponseError(
             method: "openclaw.setup.activate",
             code: "INVALID_REQUEST",
             message: "invalid openclaw.setup.activate params: kind is required",
-            details: nil
-        )
+            details: nil)
         let indeterminate = GatewayResponseError(
             method: "openclaw.setup.activate",
             code: "UNAVAILABLE",
             message: "Setup inference activation is indeterminate",
-            details: nil
-        )
+            details: nil)
         let genericInvalidRequest = GatewayResponseError(
             method: "openclaw.setup.activate",
             code: "INVALID_REQUEST",
             message: "activation failed after dispatch",
-            details: nil
-        )
+            details: nil)
         let timeout = NSError(
             domain: "Gateway",
             code: 5,
-            userInfo: [NSLocalizedDescriptionKey: "gateway request timed out"]
-        )
+            userInfo: [NSLocalizedDescriptionKey: "gateway request timed out"])
         let decodeError = DecodingError.dataCorrupted(.init(
             codingPath: [],
-            debugDescription: "invalid activation response"
-        ))
+            debugDescription: "invalid activation response"))
 
         #expect(OnboardingAISetupModel.activationFailureIsDefinitive(unknownMethod))
         #expect(OnboardingAISetupModel.activationFailureIsDefinitive(invalidParams))
@@ -826,13 +785,11 @@ struct OnboardingAISetupTests {
         let url = try #require(URL(string: "ws://example.invalid"))
         let gateway = GatewayConnection(
             configProvider: { (url: url, token: nil, password: nil) },
-            sessionBox: WebSocketSessionBox(session: session)
-        )
+            sessionBox: WebSocketSessionBox(session: session))
         let model = OnboardingAISetupModel(
             gateway: gateway,
             defaults: defaults,
-            routeIdentityProvider: { "local" }
-        )
+            routeIdentityProvider: { "local" })
         var handedOff = false
         model.onConnected = { handedOff = true }
 
@@ -843,15 +800,13 @@ struct OnboardingAISetupTests {
         #expect(handedOff)
         #expect(OnboardingSystemAgentResumeStore.pendingState(
             for: "local",
-            defaults: defaults
-        ) == .completed)
+            defaults: defaults) == .completed)
 
         model.clearCompletedHandoffIfOwned()
 
         #expect(OnboardingSystemAgentResumeStore.pendingState(
             for: "local",
-            defaults: defaults
-        ) == .none)
+            defaults: defaults) == .none)
     }
 
     @Test func `adopts pending activation stored under the retired crestodian key`() throws {
@@ -866,8 +821,8 @@ struct OnboardingAISetupTests {
 
         guard case .activating = OnboardingSystemAgentResumeStore.pendingState(
             for: "local",
-            defaults: defaults
-        ) else {
+            defaults: defaults)
+        else {
             Issue.record("expected the retired-key activation lease to survive the rename")
             return
         }
@@ -885,18 +840,15 @@ struct OnboardingAISetupTests {
             suiteName: suiteName,
             recorder: recorder,
             ownerObservation: ownerObservation,
-            postRestartConfiguredModel: "openai/gpt-5.5"
-        )
+            postRestartConfiguredModel: "openai/gpt-5.5")
         let url = try #require(URL(string: "ws://example.invalid"))
         let gateway = GatewayConnection(
             configProvider: { (url: url, token: "route-token", password: nil) },
-            sessionBox: WebSocketSessionBox(session: session)
-        )
+            sessionBox: WebSocketSessionBox(session: session))
         let model = OnboardingAISetupModel(
             gateway: gateway,
             defaults: defaults,
-            routeIdentityProvider: { "local" }
-        )
+            routeIdentityProvider: { "local" })
         var handoffCount = 0
         model.onConnected = { handoffCount += 1 }
 
@@ -916,12 +868,10 @@ struct OnboardingAISetupTests {
         #expect(handoffCount == 1)
         #expect(OnboardingSystemAgentResumeStore.activationOwner(
             for: "local",
-            defaults: defaults
-        ) == activationOwner)
+            defaults: defaults) == activationOwner)
         #expect(OnboardingSystemAgentResumeStore.pendingState(
             for: "local",
-            defaults: defaults
-        ) == .completed)
+            defaults: defaults) == .completed)
     }
 
     @Test func `managed Gateway restart rejects mismatched persisted transition`() async throws {
@@ -934,18 +884,15 @@ struct OnboardingAISetupTests {
             suiteName: suiteName,
             recorder: recorder,
             ownerObservation: ownerObservation,
-            postRestartConfiguredModel: "anthropic/other-model"
-        )
+            postRestartConfiguredModel: "anthropic/other-model")
         let url = try #require(URL(string: "ws://example.invalid"))
         let gateway = GatewayConnection(
             configProvider: { (url: url, token: "route-token", password: nil) },
-            sessionBox: WebSocketSessionBox(session: session)
-        )
+            sessionBox: WebSocketSessionBox(session: session))
         let model = OnboardingAISetupModel(
             gateway: gateway,
             defaults: defaults,
-            routeIdentityProvider: { "local" }
-        )
+            routeIdentityProvider: { "local" })
         var handoffCount = 0
         model.onConnected = { handoffCount += 1 }
 
@@ -967,8 +914,7 @@ struct OnboardingAISetupTests {
         #expect(OnboardingSystemAgentResumeStore.isOwned(
             by: activationOwner,
             for: "local",
-            defaults: defaults
-        ))
+            defaults: defaults))
         #expect(model.pendingActivationVerification)
         #expect(model.waitingForPendingActivationDeadline)
     }
@@ -990,41 +936,34 @@ struct OnboardingAISetupTests {
         let url = try #require(URL(string: "ws://example.invalid"))
         let gateway = GatewayConnection(
             configProvider: { (url: url, token: nil, password: nil) },
-            sessionBox: WebSocketSessionBox(session: session)
-        )
+            sessionBox: WebSocketSessionBox(session: session))
         let model = OnboardingAISetupModel(
             gateway: gateway,
             defaults: defaults,
-            routeIdentityProvider: { "local" }
-        )
+            routeIdentityProvider: { "local" })
 
         await model.detectAndAutoConnect()
         await model.activate(kind: "claude-cli")
         let completedOwner = try #require(OnboardingSystemAgentResumeStore.activationOwner(
             for: "local",
-            defaults: defaults
-        ))
+            defaults: defaults))
         let replacementOwner = OnboardingSystemAgentResumeStore.ActivationOwner(
             id: "replacement-activation",
-            routeFingerprint: completedOwner.routeFingerprint
-        )
+            routeFingerprint: completedOwner.routeFingerprint)
         OnboardingSystemAgentResumeStore.markPending(
             routeIdentity: "local",
             activationOwner: replacementOwner,
-            defaults: defaults
-        )
+            defaults: defaults)
 
         model.clearCompletedHandoffIfOwned()
 
         #expect(OnboardingSystemAgentResumeStore.isOwned(
             by: replacementOwner,
             for: "local",
-            defaults: defaults
-        ))
+            defaults: defaults))
         guard case .activating = OnboardingSystemAgentResumeStore.pendingState(
             for: "local",
-            defaults: defaults
-        )
+            defaults: defaults)
         else {
             Issue.record("expected replacement activation to retain its lease")
             return
@@ -1046,30 +985,25 @@ struct OnboardingAISetupTests {
                       let callbackDefaults = UserDefaults(suiteName: suiteName),
                       let originalOwner = OnboardingSystemAgentResumeStore.activationOwner(
                           for: "local",
-                          defaults: callbackDefaults
-                      )
+                          defaults: callbackDefaults)
                 else { return }
                 OnboardingSystemAgentResumeStore.markPending(
                     routeIdentity: "local",
                     activationOwner: .init(
                         id: replacementID,
-                        routeFingerprint: originalOwner.routeFingerprint
-                    ),
-                    defaults: callbackDefaults
-                )
+                        routeFingerprint: originalOwner.routeFingerprint),
+                    defaults: callbackDefaults)
                 task.emitReceiveSuccess(.data(verifiedSetupResponse(id: request.id)))
             })
         })
         let url = try #require(URL(string: "ws://example.invalid"))
         let gateway = GatewayConnection(
             configProvider: { (url: url, token: nil, password: nil) },
-            sessionBox: WebSocketSessionBox(session: session)
-        )
+            sessionBox: WebSocketSessionBox(session: session))
         let model = OnboardingAISetupModel(
             gateway: gateway,
             defaults: defaults,
-            routeIdentityProvider: { "local" }
-        )
+            routeIdentityProvider: { "local" })
         var handoffCount = 0
         model.onConnected = { handoffCount += 1 }
 
@@ -1081,12 +1015,10 @@ struct OnboardingAISetupTests {
         #expect(model.phase == .ready)
         #expect(OnboardingSystemAgentResumeStore.activationOwner(
             for: "local",
-            defaults: defaults
-        )?.id == replacementID)
+            defaults: defaults)?.id == replacementID)
         guard case .activating = OnboardingSystemAgentResumeStore.pendingState(
             for: "local",
-            defaults: defaults
-        )
+            defaults: defaults)
         else {
             Issue.record("expected replacement activation to retain its lease")
             return
@@ -1115,13 +1047,11 @@ struct OnboardingAISetupTests {
                 let token = await configGate.snapshotToken()
                 return (url: url, token: token, password: nil)
             },
-            sessionBox: WebSocketSessionBox(session: session)
-        )
+            sessionBox: WebSocketSessionBox(session: session))
         let model = OnboardingAISetupModel(
             gateway: gateway,
             defaults: defaults,
-            routeIdentityProvider: { "local" }
-        )
+            routeIdentityProvider: { "local" })
         var handoffCount = 0
         model.onConnected = { handoffCount += 1 }
 
@@ -1137,8 +1067,7 @@ struct OnboardingAISetupTests {
         #expect(handoffCount == 0)
         #expect(OnboardingSystemAgentResumeStore.isPending(
             for: "local",
-            defaults: defaults
-        ))
+            defaults: defaults))
     }
 
     @Test func `gateway change clears route-bound setup state`() {
@@ -1163,29 +1092,25 @@ struct OnboardingAISetupTests {
             expectedMode: .remote,
             currentMode: .remote,
             systemAgentResumePending: false,
-            setupOwnsInferenceTransition: false
-        ))
+            setupOwnsInferenceTransition: false))
         #expect(!OnboardingView.shouldOpenConfiguredGatewayDashboard(
             onboardingVisible: false,
             expectedMode: .remote,
             currentMode: .remote,
             systemAgentResumePending: false,
-            setupOwnsInferenceTransition: false
-        ))
+            setupOwnsInferenceTransition: false))
         #expect(!OnboardingView.shouldOpenConfiguredGatewayDashboard(
             onboardingVisible: true,
             expectedMode: .remote,
             currentMode: .local,
             systemAgentResumePending: false,
-            setupOwnsInferenceTransition: false
-        ))
+            setupOwnsInferenceTransition: false))
         #expect(!OnboardingView.shouldOpenConfiguredGatewayDashboard(
             onboardingVisible: true,
             expectedMode: .unconfigured,
             currentMode: .unconfigured,
             systemAgentResumePending: false,
-            setupOwnsInferenceTransition: false
-        ))
+            setupOwnsInferenceTransition: false))
     }
 
     @Test func `fresh inference transition owns the OpenClaw handoff`() {
@@ -1194,8 +1119,7 @@ struct OnboardingAISetupTests {
             expectedMode: .local,
             currentMode: .local,
             systemAgentResumePending: false,
-            setupOwnsInferenceTransition: true
-        ))
+            setupOwnsInferenceTransition: true))
     }
 
     @Test func `pending OpenClaw handoff cannot be mistaken for an existing install`() {
@@ -1204,8 +1128,7 @@ struct OnboardingAISetupTests {
             expectedMode: .local,
             currentMode: .local,
             systemAgentResumePending: true,
-            setupOwnsInferenceTransition: false
-        ))
+            setupOwnsInferenceTransition: false))
     }
 
     @Test func `configured model label stays pending until live verification`() async {
@@ -1248,12 +1171,10 @@ struct OnboardingAISetupTests {
         let url = try #require(URL(string: "ws://example.invalid"))
         let gateway = GatewayConnection(
             configProvider: { (url: url, token: nil, password: nil) },
-            sessionBox: WebSocketSessionBox(session: session)
-        )
+            sessionBox: WebSocketSessionBox(session: session))
         let model = OnboardingAISetupModel(
             gateway: gateway,
-            routeIdentityProvider: { "local" }
-        )
+            routeIdentityProvider: { "local" })
 
         model.resumeConfiguredInference(modelRef: "openai/gpt-5.5")
         await model.verifyPendingConfiguredInference()
@@ -1283,12 +1204,10 @@ struct OnboardingAISetupTests {
         let url = try #require(URL(string: "ws://example.invalid"))
         let gateway = GatewayConnection(
             configProvider: { (url: url, token: nil, password: nil) },
-            sessionBox: WebSocketSessionBox(session: session)
-        )
+            sessionBox: WebSocketSessionBox(session: session))
         let model = OnboardingAISetupModel(
             gateway: gateway,
-            routeIdentityProvider: { "local" }
-        )
+            routeIdentityProvider: { "local" })
         model.resumeConfiguredInference(modelRef: "openai/gpt-5.5")
 
         let first = Task { await model.verifyPendingConfiguredInference() }
@@ -1320,14 +1239,12 @@ struct OnboardingAISetupTests {
         let url = try #require(URL(string: "ws://example.invalid"))
         let gateway = GatewayConnection(
             configProvider: { (url: url, token: nil, password: nil) },
-            sessionBox: WebSocketSessionBox(session: session)
-        )
+            sessionBox: WebSocketSessionBox(session: session))
         let routeIdentity = AISetupRouteIdentity("remote:id:gateway-a")
         let model = OnboardingAISetupModel(
             gateway: gateway,
             defaults: defaults,
-            routeIdentityProvider: { routeIdentity.snapshot() }
-        )
+            routeIdentityProvider: { routeIdentity.snapshot() })
         model.onConnected = { routeIdentity.set("remote:id:gateway-b") }
 
         model.resumeConfiguredInference(modelRef: "openai/gpt-5.5")
@@ -1360,8 +1277,7 @@ struct OnboardingAISetupTests {
         let url = try #require(URL(string: "ws://example.invalid"))
         let gateway = GatewayConnection(
             configProvider: { (url: url, token: nil, password: nil) },
-            sessionBox: WebSocketSessionBox(session: session)
-        )
+            sessionBox: WebSocketSessionBox(session: session))
         let appState = AppState(preview: true)
         appState.connectionMode = .remote
         appState.remoteTransport = .direct
@@ -1369,8 +1285,7 @@ struct OnboardingAISetupTests {
         let view = OnboardingView(
             state: appState,
             aiSetupGateway: gateway,
-            aiSetupRouteIdentityProvider: { "remote:direct:example.invalid" }
-        )
+            aiSetupRouteIdentityProvider: { "remote:direct:example.invalid" })
         view.onboardingVisible = true
 
         view.aiSetup.startIfNeeded()
@@ -1401,13 +1316,11 @@ struct OnboardingAISetupTests {
         let url = try #require(URL(string: "ws://example.invalid"))
         let gateway = GatewayConnection(
             configProvider: { (url: url, token: nil, password: nil) },
-            sessionBox: WebSocketSessionBox(session: session)
-        )
+            sessionBox: WebSocketSessionBox(session: session))
         let model = OnboardingAISetupModel(
             gateway: gateway,
             defaults: defaults,
-            routeIdentityProvider: { "local" }
-        )
+            routeIdentityProvider: { "local" })
 
         model.resumeConfiguredInference(modelRef: "openai/gpt-5.5")
         let outcome = await model.verifyPendingConfiguredInference()
@@ -1442,28 +1355,23 @@ struct OnboardingAISetupTests {
         let url = try #require(URL(string: "ws://example.invalid"))
         let gateway = GatewayConnection(
             configProvider: { (url: url, token: "completed-route", password: nil) },
-            sessionBox: WebSocketSessionBox(session: session)
-        )
+            sessionBox: WebSocketSessionBox(session: session))
         let route = try #require(await gateway.captureRoute())
         let activationOwner = try OnboardingSystemAgentResumeStore.ActivationOwner(
             id: "completed-before-verification",
-            routeFingerprint: #require(route.activationOwnershipFingerprint)
-        )
+            routeFingerprint: #require(route.activationOwnershipFingerprint))
         OnboardingSystemAgentResumeStore.markPending(
             routeIdentity: "local",
             activationOwner: activationOwner,
-            defaults: defaults
-        )
+            defaults: defaults)
         #expect(OnboardingSystemAgentResumeStore.markCompleted(
             ifOwnedBy: "local",
             activationOwner: activationOwner,
-            defaults: defaults
-        ))
+            defaults: defaults))
         let model = OnboardingAISetupModel(
             gateway: gateway,
             defaults: defaults,
-            routeIdentityProvider: { "local" }
-        )
+            routeIdentityProvider: { "local" })
         model.resumeConfiguredInference(modelRef: "openai/gpt-5.5")
 
         let failedOutcome = await model.verifyPendingConfiguredInference()
@@ -1473,8 +1381,7 @@ struct OnboardingAISetupTests {
         #expect(!model.connected)
         #expect(OnboardingSystemAgentResumeStore.pendingState(
             for: "local",
-            defaults: defaults
-        ) == .completed)
+            defaults: defaults) == .completed)
 
         let retryOutcome = await model.verifyPendingConfiguredInference()
         let requests = await waitForAISetupRequests(recorder, count: 2)
@@ -1503,26 +1410,22 @@ struct OnboardingAISetupTests {
             configProvider: { (url: firstURL, token: "route-token", password: "route-password") },
             sessionBox: WebSocketSessionBox(session: GatewayTestWebSocketSession(taskFactory: {
                 GatewayTestWebSocketTask()
-            }))
-        )
+            })))
         let rebound = GatewayConnection(
             configProvider: { (url: reboundURL, token: "route-token", password: "route-password") },
             sessionBox: WebSocketSessionBox(session: GatewayTestWebSocketSession(taskFactory: {
                 GatewayTestWebSocketTask()
-            }))
-        )
+            })))
         let changedPassword = GatewayConnection(
             configProvider: { (url: reboundURL, token: "route-token", password: "replacement-password") },
             sessionBox: WebSocketSessionBox(session: GatewayTestWebSocketSession(taskFactory: {
                 GatewayTestWebSocketTask()
-            }))
-        )
+            })))
         let changedToken = GatewayConnection(
             configProvider: { (url: reboundURL, token: "replacement-token", password: "route-password") },
             sessionBox: WebSocketSessionBox(session: GatewayTestWebSocketSession(taskFactory: {
                 GatewayTestWebSocketTask()
-            }))
-        )
+            })))
         let firstRoute = try #require(await first.captureRoute())
         let reboundRoute = try #require(await rebound.captureRoute())
         let changedPasswordRoute = try #require(await changedPassword.captureRoute())
@@ -1561,8 +1464,7 @@ struct OnboardingAISetupTests {
 
         #expect(OnboardingSystemAgentResumeStore.pendingState(
             for: "local",
-            defaults: defaults
-        ) == .none)
+            defaults: defaults) == .none)
         #expect(defaults.object(forKey: onboardingSystemAgentPendingKey) == nil)
     }
 
@@ -1577,8 +1479,7 @@ struct OnboardingAISetupTests {
 
         #expect(OnboardingSystemAgentResumeStore.pendingState(
             for: "local",
-            defaults: defaults
-        ) == .none)
+            defaults: defaults) == .none)
         #expect(defaults.object(forKey: onboardingSystemAgentPendingKey) == nil)
     }
 
@@ -1593,14 +1494,11 @@ struct OnboardingAISetupTests {
             activationBindingKeyProvider: { nil },
             sessionBox: WebSocketSessionBox(session: makeAISetupSession(
                 recorder: recorder,
-                detectedKind: "codex-cli"
-            ))
-        )
+                detectedKind: "codex-cli")))
         let model = OnboardingAISetupModel(
             gateway: gateway,
             defaults: defaults,
-            routeIdentityProvider: { "local" }
-        )
+            routeIdentityProvider: { "local" })
 
         await model.detectAndAutoConnect()
         await model.activate(kind: "codex-cli")
@@ -1637,11 +1535,9 @@ struct OnboardingAISetupTests {
         #expect(OnboardingSystemAgentResumeStore.pendingState(
             for: "local",
             defaults: defaults,
-            now: now
-        ) == .activating(deadline: deadline))
+            now: now) == .activating(deadline: deadline))
         let migrated = try #require(
-            defaults.dictionary(forKey: onboardingSystemAgentPendingKey)
-        )
+            defaults.dictionary(forKey: onboardingSystemAgentPendingKey))
         let records = try #require(migrated["records"] as? [String: Any])
         let local = try #require(records["local"] as? [String: Any])
         #expect(migrated["version"] as? Int == 4)
@@ -1659,8 +1555,7 @@ struct OnboardingAISetupTests {
         let migrated = OnboardingSystemAgentResumeStore.pendingState(
             for: "local",
             defaults: defaults,
-            now: now
-        )
+            now: now)
         let deadline: Date? = if case let .activating(deadline) = migrated {
             deadline
         } else {
@@ -1669,19 +1564,16 @@ struct OnboardingAISetupTests {
         let leaseDeadline = try #require(deadline)
 
         #expect(leaseDeadline == now.addingTimeInterval(
-            OnboardingSystemAgentResumeStore.legacyActivationLeaseSeconds
-        ))
+            OnboardingSystemAgentResumeStore.legacyActivationLeaseSeconds))
         #expect(defaults.object(forKey: onboardingSystemAgentPendingKey) is [String: Any])
         #expect(OnboardingSystemAgentResumeStore.pendingState(
             for: "local",
             defaults: defaults,
-            now: now.addingTimeInterval(484)
-        ) == .activating(deadline: leaseDeadline))
+            now: now.addingTimeInterval(484)) == .activating(deadline: leaseDeadline))
         #expect(OnboardingSystemAgentResumeStore.pendingState(
             for: "local",
             defaults: defaults,
-            now: now.addingTimeInterval(486)
-        ) == .activationExpired)
+            now: now.addingTimeInterval(486)) == .activationExpired)
     }
 
     @Test func `missing model cannot start a second activation before pending deadline`() async throws {
@@ -1695,8 +1587,7 @@ struct OnboardingAISetupTests {
         OnboardingSystemAgentResumeStore.markPending(
             routeIdentity: routeIdentity,
             activationTimeoutMs: 30000,
-            defaults: defaults
-        )
+            defaults: defaults)
         let recorder = AISetupRequestRecorder()
         let session = GatewayTestWebSocketSession(taskFactory: {
             GatewayTestWebSocketTask(sendHook: { task, message, sendIndex in
@@ -1712,14 +1603,12 @@ struct OnboardingAISetupTests {
         })
         let gateway = GatewayConnection(
             configProvider: { (url: url, token: nil, password: nil) },
-            sessionBox: WebSocketSessionBox(session: session)
-        )
+            sessionBox: WebSocketSessionBox(session: session))
         let view = OnboardingView(
             state: appState,
             aiSetupGateway: gateway,
             systemAgentDefaults: defaults,
-            aiSetupRouteIdentityProvider: { routeIdentity }
-        )
+            aiSetupRouteIdentityProvider: { routeIdentity })
 
         let initialProbe = try #require(view.onboardingDidAppear())
         await initialProbe.value
@@ -1729,8 +1618,7 @@ struct OnboardingAISetupTests {
         #expect(view.aiSetup.waitingForPendingActivationDeadline)
         #expect(OnboardingSystemAgentResumeStore.isPending(
             for: routeIdentity,
-            defaults: defaults
-        ))
+            defaults: defaults))
         view.onboardingDidDisappear()
     }
 
@@ -1744,15 +1632,13 @@ struct OnboardingAISetupTests {
         let routeIdentity = OnboardingSystemAgentResumeStore.selectedRouteIdentity(state: appState)
         let activationOwner = OnboardingSystemAgentResumeStore.ActivationOwner(
             id: "expired-owner",
-            routeFingerprint: "selected-route"
-        )
+            routeFingerprint: "selected-route")
         OnboardingSystemAgentResumeStore.markPending(
             routeIdentity: routeIdentity,
             activationOwner: activationOwner,
             activationTimeoutMs: 0,
             defaults: defaults,
-            now: Date(timeIntervalSinceNow: -10)
-        )
+            now: Date(timeIntervalSinceNow: -10))
         let recorder = AISetupRequestRecorder()
         let markerObservation = ActivationMarkerObservation()
         let session = GatewayTestWebSocketSession(taskFactory: {
@@ -1769,8 +1655,7 @@ struct OnboardingAISetupTests {
                     if let callbackDefaults = UserDefaults(suiteName: suiteName) {
                         await markerObservation.record(!OnboardingSystemAgentResumeStore.isPending(
                             for: routeIdentity,
-                            defaults: callbackDefaults
-                        ))
+                            defaults: callbackDefaults))
                     }
                     task.emitReceiveSuccess(.data(actionableDetectedSetupResponse(id: request.id)))
                 case "openclaw.setup.activate":
@@ -1782,14 +1667,12 @@ struct OnboardingAISetupTests {
         })
         let gateway = GatewayConnection(
             configProvider: { (url: url, token: nil, password: nil) },
-            sessionBox: WebSocketSessionBox(session: session)
-        )
+            sessionBox: WebSocketSessionBox(session: session))
         let view = OnboardingView(
             state: appState,
             aiSetupGateway: gateway,
             systemAgentDefaults: defaults,
-            aiSetupRouteIdentityProvider: { routeIdentity }
-        )
+            aiSetupRouteIdentityProvider: { routeIdentity })
 
         let initialProbe = try #require(view.onboardingDidAppear())
         await initialProbe.value
@@ -1812,19 +1695,16 @@ struct OnboardingAISetupTests {
         let routeIdentity = "local"
         let originalOwner = OnboardingSystemAgentResumeStore.ActivationOwner(
             id: "expired-owner-a",
-            routeFingerprint: "selected-route"
-        )
+            routeFingerprint: "selected-route")
         let replacementOwner = OnboardingSystemAgentResumeStore.ActivationOwner(
             id: "expired-owner-b",
-            routeFingerprint: "selected-route"
-        )
+            routeFingerprint: "selected-route")
         OnboardingSystemAgentResumeStore.markPending(
             routeIdentity: routeIdentity,
             activationOwner: originalOwner,
             activationTimeoutMs: 0,
             defaults: defaults,
-            now: Date(timeIntervalSinceNow: -10)
-        )
+            now: Date(timeIntervalSinceNow: -10))
         let recorder = AISetupRequestRecorder()
         let session = GatewayTestWebSocketSession(taskFactory: {
             GatewayTestWebSocketTask(sendHook: { task, message, sendIndex in
@@ -1838,8 +1718,7 @@ struct OnboardingAISetupTests {
                             activationOwner: replacementOwner,
                             activationTimeoutMs: 0,
                             defaults: callbackDefaults,
-                            now: Date(timeIntervalSinceNow: -10)
-                        )
+                            now: Date(timeIntervalSinceNow: -10))
                     }
                     task.emitReceiveSuccess(.data(missingConfiguredModelResponse(id: request.id)))
                 case "openclaw.setup.detect":
@@ -1852,16 +1731,14 @@ struct OnboardingAISetupTests {
         let url = try #require(URL(string: "ws://localhost:18789"))
         let gateway = GatewayConnection(
             configProvider: { (url: url, token: nil, password: nil) },
-            sessionBox: WebSocketSessionBox(session: session)
-        )
+            sessionBox: WebSocketSessionBox(session: session))
         let appState = AppState(preview: true)
         appState.connectionMode = .local
         let view = OnboardingView(
             state: appState,
             aiSetupGateway: gateway,
             systemAgentDefaults: defaults,
-            aiSetupRouteIdentityProvider: { routeIdentity }
-        )
+            aiSetupRouteIdentityProvider: { routeIdentity })
 
         let initialProbe = try #require(view.onboardingDidAppear())
         await initialProbe.value
@@ -1871,12 +1748,10 @@ struct OnboardingAISetupTests {
         #expect(OnboardingSystemAgentResumeStore.isOwned(
             by: replacementOwner,
             for: routeIdentity,
-            defaults: defaults
-        ))
+            defaults: defaults))
         #expect(OnboardingSystemAgentResumeStore.pendingState(
             for: routeIdentity,
-            defaults: defaults
-        ) == .activationExpired)
+            defaults: defaults) == .activationExpired)
         #expect(view.aiSetup.phase == .idle)
         view.onboardingDidDisappear()
     }
@@ -1887,12 +1762,10 @@ struct OnboardingAISetupTests {
         defer { defaults.removePersistentDomain(forName: suiteName) }
         OnboardingSystemAgentResumeStore.markPending(
             routeIdentity: "local",
-            defaults: defaults
-        )
+            defaults: defaults)
         OnboardingSystemAgentResumeStore.markCompleted(
             ifOwnedBy: "local",
-            defaults: defaults
-        )
+            defaults: defaults)
         let recorder = AISetupRequestRecorder()
         let gate = AISetupRequestGate()
         let session = GatewayTestWebSocketSession(taskFactory: {
@@ -1913,22 +1786,19 @@ struct OnboardingAISetupTests {
         let url = try #require(URL(string: "ws://localhost:18789"))
         let gateway = GatewayConnection(
             configProvider: { (url: url, token: nil, password: nil) },
-            sessionBox: WebSocketSessionBox(session: session)
-        )
+            sessionBox: WebSocketSessionBox(session: session))
         let appState = AppState(preview: true)
         appState.connectionMode = .local
         let view = OnboardingView(
             state: appState,
             aiSetupGateway: gateway,
             systemAgentDefaults: defaults,
-            aiSetupRouteIdentityProvider: { "local" }
-        )
+            aiSetupRouteIdentityProvider: { "local" })
 
         let staleProbe = try #require(view.probeConfiguredGatewayForDashboard(
             startAISetupWhenMissing: true,
             knownVisible: true,
-            knownAISetupPage: true
-        ))
+            knownAISetupPage: true))
         await gate.waitUntilStarted()
         view.aiSetup.resumeConfiguredInference(modelRef: "openai/gpt-5.5")
         view.aiSetup.acceptVerifiedPendingInference(modelRef: "openai/gpt-5.5")
@@ -1940,8 +1810,7 @@ struct OnboardingAISetupTests {
         #expect(view.aiSetup.connected)
         #expect(OnboardingSystemAgentResumeStore.pendingState(
             for: "local",
-            defaults: defaults
-        ) == .completed)
+            defaults: defaults) == .completed)
         #expect(await (recorder.snapshot()).methods == ["agents.list"])
     }
 
@@ -1959,8 +1828,7 @@ struct OnboardingAISetupTests {
         let url = try #require(URL(string: "ws://localhost:18789"))
         let gateway = GatewayConnection(
             configProvider: { (url: url, token: nil, password: nil) },
-            sessionBox: WebSocketSessionBox(session: session)
-        )
+            sessionBox: WebSocketSessionBox(session: session))
         let appState = AppState(preview: true)
         appState.connectionMode = .local
         let view = OnboardingView(
@@ -1968,15 +1836,13 @@ struct OnboardingAISetupTests {
             aiSetupGateway: gateway,
             systemAgentDefaults: defaults,
             aiSetupRouteIdentityProvider: { "local" },
-            configuredGatewayProbeTimeoutMs: 1
-        )
+            configuredGatewayProbeTimeoutMs: 1)
         view.onboardingVisible = true
         view.currentPage = try #require(view.pageOrder.firstIndex(of: view.aiPageIndex))
 
         let probe = try #require(view.probeConfiguredGatewayForDashboard(
             startAISetupWhenMissing: true,
-            knownVisible: true
-        ))
+            knownVisible: true))
         await probe.value
         await settleQueuedAISetupTasks()
 
@@ -1997,8 +1863,7 @@ struct OnboardingAISetupTests {
         let url = try #require(URL(string: "ws://localhost:18789"))
         let gateway = GatewayConnection(
             configProvider: { (url: url, token: nil, password: nil) },
-            sessionBox: WebSocketSessionBox(session: session)
-        )
+            sessionBox: WebSocketSessionBox(session: session))
         let appState = AppState(preview: true)
         appState.connectionMode = .remote
         appState.remoteTransport = .direct
@@ -2011,8 +1876,7 @@ struct OnboardingAISetupTests {
             gatewaySelectionPersister: {
                 persistAttempts += 1
                 return false
-            }
-        )
+            })
         view.onboardingVisible = true
 
         let probe = view.probeConfiguredGatewayForDashboard(knownVisible: true)
@@ -2057,13 +1921,11 @@ struct OnboardingAISetupTests {
                 routeIdentity: "local",
                 activationTimeoutMs: markerPhase == "expired" ? 0 : 30000,
                 defaults: defaults,
-                now: markerPhase == "expired" ? Date(timeIntervalSinceNow: -10) : Date()
-            )
+                now: markerPhase == "expired" ? Date(timeIntervalSinceNow: -10) : Date())
             if markerPhase == "completed" {
                 OnboardingSystemAgentResumeStore.markCompleted(
                     ifOwnedBy: "local",
-                    defaults: defaults
-                )
+                    defaults: defaults)
             }
             let recorder = AISetupRequestRecorder()
             let session = GatewayTestWebSocketSession(taskFactory: {
@@ -2079,23 +1941,20 @@ struct OnboardingAISetupTests {
             let url = try #require(URL(string: "ws://localhost:18789"))
             let gateway = GatewayConnection(
                 configProvider: { (url: url, token: nil, password: nil) },
-                sessionBox: WebSocketSessionBox(session: session)
-            )
+                sessionBox: WebSocketSessionBox(session: session))
             let appState = AppState(preview: true)
             appState.connectionMode = .local
             let view = OnboardingView(
                 state: appState,
                 aiSetupGateway: gateway,
                 systemAgentDefaults: defaults,
-                aiSetupRouteIdentityProvider: { "local" }
-            )
+                aiSetupRouteIdentityProvider: { "local" })
             view.onboardingVisible = true
             view.currentPage = try #require(view.pageOrder.firstIndex(of: view.aiPageIndex))
 
             let probe = try #require(view.probeConfiguredGatewayForDashboard(
                 startAISetupWhenMissing: true,
-                knownVisible: true
-            ))
+                knownVisible: true))
             await probe.value
             await settleQueuedAISetupTasks()
 
@@ -2104,8 +1963,7 @@ struct OnboardingAISetupTests {
             #expect(view.aiSetup.configuredGatewayProbeUnavailable)
             let pendingState = OnboardingSystemAgentResumeStore.pendingState(
                 for: "local",
-                defaults: defaults
-            )
+                defaults: defaults)
             if markerPhase == "expired" {
                 #expect(pendingState == .activationExpired)
             } else {
@@ -2122,8 +1980,7 @@ struct OnboardingAISetupTests {
             #expect(view.aiSetup.configuredGatewayProbeUnavailable)
             #expect(OnboardingSystemAgentResumeStore.pendingState(
                 for: "local",
-                defaults: defaults
-            ) == pendingState)
+                defaults: defaults) == pendingState)
         }
     }
 
@@ -2156,16 +2013,14 @@ struct OnboardingAISetupTests {
         let url = try #require(URL(string: "ws://localhost:18789"))
         let gateway = GatewayConnection(
             configProvider: { (url: url, token: nil, password: nil) },
-            sessionBox: WebSocketSessionBox(session: session)
-        )
+            sessionBox: WebSocketSessionBox(session: session))
         let appState = AppState(preview: true)
         appState.connectionMode = .local
         let view = OnboardingView(
             state: appState,
             aiSetupGateway: gateway,
             systemAgentDefaults: defaults,
-            aiSetupRouteIdentityProvider: { "local" }
-        )
+            aiSetupRouteIdentityProvider: { "local" })
         view.onboardingVisible = true
         view.currentPage = try #require(view.pageOrder.firstIndex(of: view.aiPageIndex))
 
@@ -2175,8 +2030,7 @@ struct OnboardingAISetupTests {
 
         let unavailableProbe = try #require(view.probeConfiguredGatewayForDashboard(
             startAISetupWhenMissing: true,
-            knownVisible: true
-        ))
+            knownVisible: true))
         await unavailableProbe.value
         #expect(view.aiSetup.configuredGatewayProbeUnavailable)
         #expect(view.aiSetup.candidates.isEmpty)
@@ -2204,8 +2058,7 @@ struct OnboardingAISetupTests {
         OnboardingSystemAgentResumeStore.markPending(
             routeIdentity: "local",
             activationTimeoutMs: 30000,
-            defaults: defaults
-        )
+            defaults: defaults)
         let recorder = AISetupRequestRecorder()
         let session = GatewayTestWebSocketSession(taskFactory: {
             GatewayTestWebSocketTask(sendHook: { task, message, sendIndex in
@@ -2221,22 +2074,19 @@ struct OnboardingAISetupTests {
         let url = try #require(URL(string: "ws://localhost:18789"))
         let gateway = GatewayConnection(
             configProvider: { (url: url, token: nil, password: nil) },
-            sessionBox: WebSocketSessionBox(session: session)
-        )
+            sessionBox: WebSocketSessionBox(session: session))
         let appState = AppState(preview: true)
         appState.connectionMode = .local
         let view = OnboardingView(
             state: appState,
             aiSetupGateway: gateway,
             systemAgentDefaults: defaults,
-            aiSetupRouteIdentityProvider: { "local" }
-        )
+            aiSetupRouteIdentityProvider: { "local" })
 
         let unavailableProbe = try #require(view.probeConfiguredGatewayForDashboard(
             startAISetupWhenMissing: true,
             knownVisible: true,
-            knownAISetupPage: true
-        ))
+            knownAISetupPage: true))
         await unavailableProbe.value
         #expect(view.aiSetup.configuredGatewayProbeUnavailable)
 
@@ -2259,8 +2109,7 @@ struct OnboardingAISetupTests {
         OnboardingSystemAgentResumeStore.markPending(
             routeIdentity: "local",
             activationTimeoutMs: 30000,
-            defaults: defaults
-        )
+            defaults: defaults)
         let recorder = AISetupRequestRecorder()
         let session = GatewayTestWebSocketSession(taskFactory: {
             GatewayTestWebSocketTask(sendHook: { task, message, sendIndex in
@@ -2287,27 +2136,24 @@ struct OnboardingAISetupTests {
         })
         let gateway = GatewayConnection(
             configProvider: { (url: url, token: nil, password: nil) },
-            sessionBox: WebSocketSessionBox(session: session)
-        )
+            sessionBox: WebSocketSessionBox(session: session))
         let view = OnboardingView(
             state: appState,
             aiSetupGateway: gateway,
             systemAgentDefaults: defaults,
-            aiSetupRouteIdentityProvider: { "local" }
-        )
+            aiSetupRouteIdentityProvider: { "local" })
 
         let initialProbe = try #require(view.onboardingDidAppear())
         await initialProbe.value
         #expect(view.aiSetup.waitingForPendingActivationDeadline)
         let configuredProbe = try #require(
-            view.probeConfiguredGatewayForDashboard(knownVisible: true)
-        )
+            view.probeConfiguredGatewayForDashboard(knownVisible: true))
         await configuredProbe.value
-        for _ in 0 ..< 200 {
+        for _ in 0..<200 {
             if case .verified = OnboardingSystemAgentResumeStore.pendingState(
                 for: "local",
-                defaults: defaults
-            ) {
+                defaults: defaults)
+            {
                 break
             }
             try? await Task.sleep(nanoseconds: 5_000_000)
@@ -2326,8 +2172,8 @@ struct OnboardingAISetupTests {
         #expect({
             if case .verified = OnboardingSystemAgentResumeStore.pendingState(
                 for: "local",
-                defaults: defaults
-            ) {
+                defaults: defaults)
+            {
                 return true
             }
             return false
@@ -2337,8 +2183,8 @@ struct OnboardingAISetupTests {
 
     @Test(arguments: [false, true])
     func `replacement auth waits for active or verified owner deadline`(
-        wasVerified: Bool
-    ) async throws {
+        wasVerified: Bool) async throws
+    {
         let suiteName = "OnboardingReplacementAuthActiveLeaseTests-\(UUID().uuidString)"
         let defaults = try #require(UserDefaults(suiteName: suiteName))
         defer { defaults.removePersistentDomain(forName: suiteName) }
@@ -2347,31 +2193,27 @@ struct OnboardingAISetupTests {
             configProvider: { (url: url, token: "route-a", password: nil) },
             sessionBox: WebSocketSessionBox(session: GatewayTestWebSocketSession(taskFactory: {
                 GatewayTestWebSocketTask()
-            }))
-        )
+            })))
         let seedRoute = try #require(await seedGateway.captureRoute())
         let activationOwner = try OnboardingSystemAgentResumeStore.ActivationOwner(
             id: "active-before-auth-replacement",
-            routeFingerprint: #require(seedRoute.activationOwnershipFingerprint)
-        )
+            routeFingerprint: #require(seedRoute.activationOwnershipFingerprint))
         _ = try #require(OnboardingSystemAgentResumeStore.markPending(
             routeIdentity: "remote:ssh:stable-gateway",
             activationOwner: activationOwner,
             activationTimeoutMs: 30000,
-            defaults: defaults
-        ))
+            defaults: defaults))
         if wasVerified {
             OnboardingSystemAgentResumeStore.markVerified(
                 ifOwnedBy: "remote:ssh:stable-gateway",
                 activationOwner: activationOwner,
-                defaults: defaults
-            )
+                defaults: defaults)
         }
         let expectedDeadline: Date
         switch OnboardingSystemAgentResumeStore.pendingState(
             for: "remote:ssh:stable-gateway",
-            defaults: defaults
-        ) {
+            defaults: defaults)
+        {
         case let .activating(storedDeadline), let .verified(storedDeadline):
             expectedDeadline = storedDeadline
         case .activationExpired, .completed, .none:
@@ -2382,13 +2224,11 @@ struct OnboardingAISetupTests {
         let recorder = AISetupRequestRecorder()
         let replacementGateway = GatewayConnection(
             configProvider: { (url: url, token: "route-b", password: nil) },
-            sessionBox: WebSocketSessionBox(session: makeAISetupSession(recorder: recorder))
-        )
+            sessionBox: WebSocketSessionBox(session: makeAISetupSession(recorder: recorder)))
         let model = OnboardingAISetupModel(
             gateway: replacementGateway,
             defaults: defaults,
-            routeIdentityProvider: { "remote:ssh:stable-gateway" }
-        )
+            routeIdentityProvider: { "remote:ssh:stable-gateway" })
         var scheduledDeadlines: [Date] = []
         model.onPendingActivationDeadline = { scheduledDeadline, _ in
             scheduledDeadlines.append(scheduledDeadline)
@@ -2407,12 +2247,10 @@ struct OnboardingAISetupTests {
         #expect(scheduledDeadlines == [expectedDeadline])
         #expect(OnboardingSystemAgentResumeStore.activationOwner(
             for: "remote:ssh:stable-gateway",
-            defaults: defaults
-        ) == activationOwner)
+            defaults: defaults) == activationOwner)
         let pendingState = OnboardingSystemAgentResumeStore.pendingState(
             for: "remote:ssh:stable-gateway",
-            defaults: defaults
-        )
+            defaults: defaults)
         if wasVerified {
             guard case let .verified(storedDeadline) = pendingState else {
                 Issue.record("expected verified activation lease")
@@ -2453,30 +2291,25 @@ struct OnboardingAISetupTests {
         let url = try #require(URL(string: "ws://example.invalid"))
         let gateway = GatewayConnection(
             configProvider: { (url: url, token: nil, password: nil) },
-            sessionBox: WebSocketSessionBox(session: session)
-        )
+            sessionBox: WebSocketSessionBox(session: session))
         let route = try #require(await gateway.captureRoute())
         let activationOwner = try OnboardingSystemAgentResumeStore.ActivationOwner(
             id: "expired-activation",
-            routeFingerprint: #require(route.activationOwnershipFingerprint)
-        )
+            routeFingerprint: #require(route.activationOwnershipFingerprint))
         OnboardingSystemAgentResumeStore.markPending(
             routeIdentity: "local",
             activationOwner: activationOwner,
             activationTimeoutMs: 0,
             defaults: defaults,
-            now: Date(timeIntervalSinceNow: -10)
-        )
+            now: Date(timeIntervalSinceNow: -10))
         OnboardingSystemAgentResumeStore.markVerified(
             ifOwnedBy: "local",
             activationOwner: activationOwner,
-            defaults: defaults
-        )
+            defaults: defaults)
         let model = OnboardingAISetupModel(
             gateway: gateway,
             defaults: defaults,
-            routeIdentityProvider: { "local" }
-        )
+            routeIdentityProvider: { "local" })
         var handedOff = false
         model.onConnected = { handedOff = true }
 
@@ -2490,8 +2323,7 @@ struct OnboardingAISetupTests {
         #expect(requests.methods == ["openclaw.setup.verify", "openclaw.setup.detect"])
         #expect(OnboardingSystemAgentResumeStore.pendingState(
             for: "local",
-            defaults: defaults
-        ) == .none)
+            defaults: defaults) == .none)
     }
 
     @Test func `relaunch cannot reuse a completed receipt on replacement Gateway auth`() async throws {
@@ -2503,23 +2335,19 @@ struct OnboardingAISetupTests {
             configProvider: { (url: url, token: "route-a", password: nil) },
             sessionBox: WebSocketSessionBox(session: GatewayTestWebSocketSession(taskFactory: {
                 GatewayTestWebSocketTask()
-            }))
-        )
+            })))
         let seedRoute = try #require(await seedGateway.captureRoute())
         let activationOwner = try OnboardingSystemAgentResumeStore.ActivationOwner(
             id: "completed-activation",
-            routeFingerprint: #require(seedRoute.activationOwnershipFingerprint)
-        )
+            routeFingerprint: #require(seedRoute.activationOwnershipFingerprint))
         OnboardingSystemAgentResumeStore.markPending(
             routeIdentity: "local",
             activationOwner: activationOwner,
-            defaults: defaults
-        )
+            defaults: defaults)
         #expect(OnboardingSystemAgentResumeStore.markCompleted(
             ifOwnedBy: "local",
             activationOwner: activationOwner,
-            defaults: defaults
-        ))
+            defaults: defaults))
 
         let recorder = AISetupRequestRecorder()
         let gateway = GatewayConnection(
@@ -2535,13 +2363,11 @@ struct OnboardingAISetupTests {
                         task.emitReceiveSuccess(.data(detectedSetupResponse(id: request.id)))
                     }
                 })
-            }))
-        )
+            })))
         let relaunched = OnboardingAISetupModel(
             gateway: gateway,
             defaults: defaults,
-            routeIdentityProvider: { "local" }
-        )
+            routeIdentityProvider: { "local" })
 
         relaunched.resumeConfiguredInference(modelRef: "openai/gpt-5.5")
         let outcome = await relaunched.verifyPendingConfiguredInference()
@@ -2552,8 +2378,7 @@ struct OnboardingAISetupTests {
         #expect(requests.methods == ["openclaw.setup.detect"])
         #expect(OnboardingSystemAgentResumeStore.pendingState(
             for: "local",
-            defaults: defaults
-        ) == .none)
+            defaults: defaults) == .none)
     }
 
     @Test func `relaunch cannot reuse a completed receipt after device token rotation`() async throws {
@@ -2573,8 +2398,7 @@ struct OnboardingAISetupTests {
                 deviceId: identity.deviceId,
                 role: "operator",
                 token: originalToken,
-                gatewayID: deviceAuthGatewayID
-            )
+                gatewayID: deviceAuthGatewayID)
             let replacementToken = "receipt-device-token-b"
             let url = try #require(URL(string: "ws://example.invalid"))
             let activationBindingKey = SymmetricKey(size: .bits256)
@@ -2591,47 +2415,38 @@ struct OnboardingAISetupTests {
                         let id = task.snapshotConnectRequestID() ?? "connect"
                         return .data(GatewayWebSocketTestSupport.connectOkData(
                             id: id,
-                            deviceToken: replacementToken
-                        ))
-                    }
-                )
+                            deviceToken: replacementToken))
+                    })
             })
             let seedGateway = GatewayConnection(
                 endpointProvider: {
                     GatewayConnection.EndpointSnapshot(
                         config: (url: url, token: nil, password: nil),
                         routeAuthority: nil,
-                        deviceAuthGatewayID: deviceAuthGatewayID
-                    )
+                        deviceAuthGatewayID: deviceAuthGatewayID)
                 },
                 activationBindingKeyProvider: { activationBindingKey },
-                sessionBox: WebSocketSessionBox(session: seedSession)
-            )
+                sessionBox: WebSocketSessionBox(session: seedSession))
             let seedLease = try await seedGateway.acquireServerLease()
             let activationOwner = try OnboardingSystemAgentResumeStore.ActivationOwner(
                 id: "completed-device-token-activation",
                 routeFingerprint: #require(await seedGateway.activationOwnershipFingerprint(
-                    ifCurrentServerLease: seedLease
-                ))
-            )
+                    ifCurrentServerLease: seedLease)))
             #expect(await seedGateway.authSource() == .deviceToken)
             OnboardingSystemAgentResumeStore.markPending(
                 routeIdentity: "local",
                 activationOwner: activationOwner,
-                defaults: defaults
-            )
+                defaults: defaults)
             #expect(OnboardingSystemAgentResumeStore.markCompleted(
                 ifOwnedBy: "local",
                 activationOwner: activationOwner,
-                defaults: defaults
-            ))
+                defaults: defaults))
             let persistedReceipt = String(describing: defaults.object(forKey: onboardingSystemAgentPendingKey))
             #expect(!persistedReceipt.contains(originalToken))
             #expect(DeviceAuthStore.loadToken(
                 deviceId: identity.deviceId,
                 role: "operator",
-                gatewayID: deviceAuthGatewayID
-            )?.token == replacementToken)
+                gatewayID: deviceAuthGatewayID)?.token == replacementToken)
             await seedGateway.shutdown()
 
             let recorder = AISetupRequestRecorder()
@@ -2640,17 +2455,14 @@ struct OnboardingAISetupTests {
                     GatewayConnection.EndpointSnapshot(
                         config: (url: url, token: nil, password: nil),
                         routeAuthority: nil,
-                        deviceAuthGatewayID: deviceAuthGatewayID
-                    )
+                        deviceAuthGatewayID: deviceAuthGatewayID)
                 },
                 activationBindingKeyProvider: { activationBindingKey },
-                sessionBox: WebSocketSessionBox(session: makeAISetupSession(recorder: recorder))
-            )
+                sessionBox: WebSocketSessionBox(session: makeAISetupSession(recorder: recorder)))
             let relaunched = OnboardingAISetupModel(
                 gateway: replacementGateway,
                 defaults: defaults,
-                routeIdentityProvider: { "local" }
-            )
+                routeIdentityProvider: { "local" })
 
             relaunched.resumeConfiguredInference(modelRef: "openai/gpt-5.5")
             let outcome = await relaunched.verifyPendingConfiguredInference()
@@ -2661,8 +2473,7 @@ struct OnboardingAISetupTests {
             #expect(requests.methods == ["openclaw.setup.detect"])
             #expect(OnboardingSystemAgentResumeStore.pendingState(
                 for: "local",
-                defaults: defaults
-            ) == .none)
+                defaults: defaults) == .none)
             #expect(!String(describing: defaults.object(forKey: onboardingSystemAgentPendingKey))
                 .contains(replacementToken))
             await replacementGateway.shutdown()
@@ -2690,51 +2501,42 @@ struct OnboardingAISetupTests {
                         if let callbackDefaults = UserDefaults(suiteName: suiteName),
                            let originalOwner = OnboardingSystemAgentResumeStore.activationOwner(
                                for: "local",
-                               defaults: callbackDefaults
-                           )
+                               defaults: callbackDefaults)
                         {
                             let replacementOwner = OnboardingSystemAgentResumeStore.ActivationOwner(
                                 id: replacementID,
-                                routeFingerprint: originalOwner.routeFingerprint
-                            )
+                                routeFingerprint: originalOwner.routeFingerprint)
                             OnboardingSystemAgentResumeStore.markPending(
                                 routeIdentity: "local",
                                 activationOwner: replacementOwner,
-                                defaults: callbackDefaults
-                            )
+                                defaults: callbackDefaults)
                             OnboardingSystemAgentResumeStore.markCompleted(
                                 ifOwnedBy: "local",
                                 activationOwner: replacementOwner,
-                                defaults: callbackDefaults
-                            )
+                                defaults: callbackDefaults)
                         }
                         task.emitReceiveSuccess(.data(verifiedSetupResponse(id: request.id)))
                     default:
                         break
                     }
                 })
-            }))
-        )
+            })))
         let route = try #require(await gateway.captureRoute())
         let activationOwner = try OnboardingSystemAgentResumeStore.ActivationOwner(
             id: "completed-before-relaunch",
-            routeFingerprint: #require(route.activationOwnershipFingerprint)
-        )
+            routeFingerprint: #require(route.activationOwnershipFingerprint))
         OnboardingSystemAgentResumeStore.markPending(
             routeIdentity: "local",
             activationOwner: activationOwner,
-            defaults: defaults
-        )
+            defaults: defaults)
         #expect(OnboardingSystemAgentResumeStore.markCompleted(
             ifOwnedBy: "local",
             activationOwner: activationOwner,
-            defaults: defaults
-        ))
+            defaults: defaults))
         let relaunched = OnboardingAISetupModel(
             gateway: gateway,
             defaults: defaults,
-            routeIdentityProvider: { "local" }
-        )
+            routeIdentityProvider: { "local" })
         var handoffCount = 0
         relaunched.onConnected = { handoffCount += 1 }
 
@@ -2748,12 +2550,10 @@ struct OnboardingAISetupTests {
         #expect(requests.methods == ["openclaw.setup.verify"])
         #expect(OnboardingSystemAgentResumeStore.activationOwner(
             for: "local",
-            defaults: defaults
-        )?.id == replacementID)
+            defaults: defaults)?.id == replacementID)
         #expect(OnboardingSystemAgentResumeStore.pendingState(
             for: "local",
-            defaults: defaults
-        ) == .completed)
+            defaults: defaults) == .completed)
     }
 
     @Test func `ownerless mutations cannot match an owned activation`() throws {
@@ -2762,41 +2562,35 @@ struct OnboardingAISetupTests {
         defer { defaults.removePersistentDomain(forName: suiteName) }
         let activationOwner = OnboardingSystemAgentResumeStore.ActivationOwner(
             id: "owned-activation",
-            routeFingerprint: "owned-route"
-        )
+            routeFingerprint: "owned-route")
         OnboardingSystemAgentResumeStore.markPending(
             routeIdentity: "local",
             activationOwner: activationOwner,
-            defaults: defaults
-        )
+            defaults: defaults)
 
         OnboardingSystemAgentResumeStore.markVerified(
             ifOwnedBy: "local",
-            defaults: defaults
-        )
+            defaults: defaults)
         #expect({
             if case .activating = OnboardingSystemAgentResumeStore.pendingState(
                 for: "local",
-                defaults: defaults
-            ) {
+                defaults: defaults)
+            {
                 return true
             }
             return false
         }())
         #expect(!OnboardingSystemAgentResumeStore.markCompleted(
             ifOwnedBy: "local",
-            defaults: defaults
-        ))
+            defaults: defaults))
 
         OnboardingSystemAgentResumeStore.clear(
             ifOwnedBy: "local",
-            defaults: defaults
-        )
+            defaults: defaults)
         #expect(OnboardingSystemAgentResumeStore.isOwned(
             by: activationOwner,
             for: "local",
-            defaults: defaults
-        ))
+            defaults: defaults))
     }
 
     @Test func `pending marker for another route is preserved`() throws {
@@ -2805,17 +2599,14 @@ struct OnboardingAISetupTests {
         defer { defaults.removePersistentDomain(forName: suiteName) }
         OnboardingSystemAgentResumeStore.markPending(
             routeIdentity: "remote:id:gateway-a",
-            defaults: defaults
-        )
+            defaults: defaults)
 
         #expect(!OnboardingSystemAgentResumeStore.isPending(
             for: "remote:id:gateway-b",
-            defaults: defaults
-        ))
+            defaults: defaults))
         #expect(OnboardingSystemAgentResumeStore.isPending(
             for: "remote:id:gateway-a",
-            defaults: defaults
-        ))
+            defaults: defaults))
     }
 
     @Test func `A to B to A preserves first activation lease`() throws {
@@ -2827,39 +2618,32 @@ struct OnboardingAISetupTests {
         OnboardingSystemAgentResumeStore.markPending(
             routeIdentity: "remote:id:gateway-a",
             defaults: defaults,
-            now: now
-        )
+            now: now)
         OnboardingSystemAgentResumeStore.markPending(
             routeIdentity: "remote:id:gateway-b",
             defaults: defaults,
-            now: now.addingTimeInterval(1)
-        )
+            now: now.addingTimeInterval(1))
 
         #expect(OnboardingSystemAgentResumeStore.isPending(
             for: "remote:id:gateway-a",
             defaults: defaults,
-            now: now.addingTimeInterval(2)
-        ))
+            now: now.addingTimeInterval(2)))
         #expect(OnboardingSystemAgentResumeStore.isPending(
             for: "remote:id:gateway-b",
             defaults: defaults,
-            now: now.addingTimeInterval(2)
-        ))
+            now: now.addingTimeInterval(2)))
 
         OnboardingSystemAgentResumeStore.clear(
             ifOwnedBy: "remote:id:gateway-b",
-            defaults: defaults
-        )
+            defaults: defaults)
         #expect(OnboardingSystemAgentResumeStore.isPending(
             for: "remote:id:gateway-a",
             defaults: defaults,
-            now: now.addingTimeInterval(2)
-        ))
+            now: now.addingTimeInterval(2)))
         #expect(!OnboardingSystemAgentResumeStore.isPending(
             for: "remote:id:gateway-b",
             defaults: defaults,
-            now: now.addingTimeInterval(2)
-        ))
+            now: now.addingTimeInterval(2)))
     }
 
     @Test func `route reset clears only current route lease`() throws {
@@ -2869,27 +2653,22 @@ struct OnboardingAISetupTests {
         let routeIdentity = AISetupRouteIdentity("remote:id:gateway-b")
         OnboardingSystemAgentResumeStore.markPending(
             routeIdentity: "remote:id:gateway-a",
-            defaults: defaults
-        )
+            defaults: defaults)
         OnboardingSystemAgentResumeStore.markPending(
             routeIdentity: "remote:id:gateway-b",
-            defaults: defaults
-        )
+            defaults: defaults)
         let model = OnboardingAISetupModel(
             defaults: defaults,
-            routeIdentityProvider: { routeIdentity.snapshot() }
-        )
+            routeIdentityProvider: { routeIdentity.snapshot() })
 
         model.resetForGatewayChange()
 
         #expect(OnboardingSystemAgentResumeStore.isPending(
             for: "remote:id:gateway-a",
-            defaults: defaults
-        ))
+            defaults: defaults))
         #expect(!OnboardingSystemAgentResumeStore.isPending(
             for: "remote:id:gateway-b",
-            defaults: defaults
-        ))
+            defaults: defaults))
     }
 
     @Test func `gateway selection reset preserves in flight lease`() throws {
@@ -2900,20 +2679,17 @@ struct OnboardingAISetupTests {
         appState.connectionMode = .local
         OnboardingSystemAgentResumeStore.markPending(
             routeIdentity: "local",
-            defaults: defaults
-        )
+            defaults: defaults)
         let view = OnboardingView(
             state: appState,
             systemAgentDefaults: defaults,
-            aiSetupRouteIdentityProvider: { "local" }
-        )
+            aiSetupRouteIdentityProvider: { "local" })
 
         view.resetGatewayBoundAIState()
 
         #expect(OnboardingSystemAgentResumeStore.isPending(
             for: "local",
-            defaults: defaults
-        ))
+            defaults: defaults))
     }
 
     @Test func `v1 route marker migrates without blocking another route`() throws {
@@ -2931,8 +2707,8 @@ struct OnboardingAISetupTests {
             if case .verified = OnboardingSystemAgentResumeStore.pendingState(
                 for: "remote:id:gateway-a",
                 defaults: defaults,
-                now: now
-            ) {
+                now: now)
+            {
                 return true
             }
             return false
@@ -2940,18 +2716,15 @@ struct OnboardingAISetupTests {
         OnboardingSystemAgentResumeStore.markPending(
             routeIdentity: "remote:id:gateway-b",
             defaults: defaults,
-            now: now
-        )
+            now: now)
         #expect(OnboardingSystemAgentResumeStore.isPending(
             for: "remote:id:gateway-a",
             defaults: defaults,
-            now: now
-        ))
+            now: now))
         #expect(OnboardingSystemAgentResumeStore.isPending(
             for: "remote:id:gateway-b",
             defaults: defaults,
-            now: now
-        ))
+            now: now))
     }
 
     @Test func `fallback remote route identity omits auth but preserves endpoint`() {
@@ -2960,29 +2733,25 @@ struct OnboardingAISetupTests {
             preferredGatewayID: nil,
             remoteTransport: .direct,
             remoteURL: "wss://user:secret@gateway.example.test/path?tenant=team-a&token=secret#fragment",
-            remoteTarget: ""
-        )
+            remoteTarget: "")
         let cleanIdentity = OnboardingSystemAgentResumeStore.routeIdentity(
             connectionMode: .remote,
             preferredGatewayID: nil,
             remoteTransport: .direct,
             remoteURL: "wss://gateway.example.test/path?tenant=team-a",
-            remoteTarget: ""
-        )
+            remoteTarget: "")
         let otherEndpointIdentity = OnboardingSystemAgentResumeStore.routeIdentity(
             connectionMode: .remote,
             preferredGatewayID: nil,
             remoteTransport: .direct,
             remoteURL: "wss://gateway.example.test/other",
-            remoteTarget: ""
-        )
+            remoteTarget: "")
         let otherQueryIdentity = OnboardingSystemAgentResumeStore.routeIdentity(
             connectionMode: .remote,
             preferredGatewayID: nil,
             remoteTransport: .direct,
             remoteURL: "wss://gateway.example.test/path?tenant=team-b",
-            remoteTarget: ""
-        )
+            remoteTarget: "")
 
         #expect(authenticatedIdentity?.hasPrefix("remote:direct:") == true)
         #expect(authenticatedIdentity?.contains("secret") == false)
@@ -2999,32 +2768,28 @@ struct OnboardingAISetupTests {
             remoteTransport: .direct,
             remoteURL: "",
             remoteTarget: "",
-            localStateDir: URL(fileURLWithPath: "/tmp/openclaw-state-a")
-        )
+            localStateDir: URL(fileURLWithPath: "/tmp/openclaw-state-a"))
         let localB = OnboardingSystemAgentResumeStore.routeIdentity(
             connectionMode: .local,
             preferredGatewayID: nil,
             remoteTransport: .direct,
             remoteURL: "",
             remoteTarget: "",
-            localStateDir: URL(fileURLWithPath: "/tmp/openclaw-state-b")
-        )
+            localStateDir: URL(fileURLWithPath: "/tmp/openclaw-state-b"))
         let sshA = OnboardingSystemAgentResumeStore.routeIdentity(
             connectionMode: .remote,
             preferredGatewayID: nil,
             remoteTransport: .ssh,
             remoteURL: "",
             remoteTarget: "user@gateway.example.test",
-            sshRemotePort: 18789
-        )
+            sshRemotePort: 18789)
         let sshB = OnboardingSystemAgentResumeStore.routeIdentity(
             connectionMode: .remote,
             preferredGatewayID: nil,
             remoteTransport: .ssh,
             remoteURL: "",
             remoteTarget: "user@gateway.example.test",
-            sshRemotePort: 18790
-        )
+            sshRemotePort: 18790)
 
         #expect(localA?.hasPrefix("local:") == true)
         #expect(localA != localB)
@@ -3037,15 +2802,13 @@ struct OnboardingAISetupTests {
             preferredGatewayID: nil,
             remoteTransport: .direct,
             remoteURL: "ws://localhost",
-            remoteTarget: ""
-        )
+            remoteTarget: "")
         let afterPersistence = OnboardingSystemAgentResumeStore.routeIdentity(
             connectionMode: .remote,
             preferredGatewayID: nil,
             remoteTransport: .direct,
             remoteURL: "ws://localhost:18789",
-            remoteTarget: ""
-        )
+            remoteTarget: "")
 
         #expect(beforePersistence == afterPersistence)
     }
@@ -3066,23 +2829,19 @@ struct OnboardingAISetupTests {
                     requestDefaults.map {
                         OnboardingSystemAgentResumeStore.isPending(
                             for: "local",
-                            defaults: $0
-                        )
-                    } == true
-                )
+                            defaults: $0)
+                    } == true)
                 task.emitReceiveSuccess(.data(failedActivationResponse(id: request.id)))
             })
         })
         let url = try #require(URL(string: "ws://example.invalid"))
         let gateway = GatewayConnection(
             configProvider: { (url: url, token: nil, password: nil) },
-            sessionBox: WebSocketSessionBox(session: session)
-        )
+            sessionBox: WebSocketSessionBox(session: session))
         let model = OnboardingAISetupModel(
             gateway: gateway,
             defaults: defaults,
-            routeIdentityProvider: { "local" }
-        )
+            routeIdentityProvider: { "local" })
 
         await model.detectAndAutoConnect()
         await model.activate(kind: "codex-cli")
@@ -3101,14 +2860,12 @@ struct OnboardingAISetupTests {
         let session = makeAISetupSession(recorder: recorder)
         let gateway = GatewayConnection(
             configProvider: { config.snapshot() },
-            sessionBox: WebSocketSessionBox(session: session)
-        )
+            sessionBox: WebSocketSessionBox(session: session))
         let routeIdentity = AISetupRouteIdentity("remote:id:gateway-a")
         let model = OnboardingAISetupModel(
             gateway: gateway,
             defaults: defaults,
-            routeIdentityProvider: { routeIdentity.snapshot() }
-        )
+            routeIdentityProvider: { routeIdentity.snapshot() })
 
         model.startIfNeeded()
         model.resetForGatewayChange()
@@ -3132,14 +2889,12 @@ struct OnboardingAISetupTests {
         let recorder = AISetupRequestRecorder()
         let gateway = GatewayConnection(
             configProvider: { config.snapshot() },
-            sessionBox: WebSocketSessionBox(session: makeAISetupSession(recorder: recorder))
-        )
+            sessionBox: WebSocketSessionBox(session: makeAISetupSession(recorder: recorder)))
         let routeIdentity = AISetupRouteIdentity("remote:id:gateway-a")
         let model = OnboardingAISetupModel(
             gateway: gateway,
             defaults: defaults,
-            routeIdentityProvider: { routeIdentity.snapshot() }
-        )
+            routeIdentityProvider: { routeIdentity.snapshot() })
         await model.detectAndAutoConnect()
 
         model.userSelect(kind: "claude-cli")
@@ -3152,8 +2907,7 @@ struct OnboardingAISetupTests {
         #expect(requests.methods == ["openclaw.setup.detect"])
         #expect(!OnboardingSystemAgentResumeStore.isPending(
             for: "remote:id:gateway-b",
-            defaults: defaults
-        ))
+            defaults: defaults))
         #expect(model.phase == .idle)
     }
 
@@ -3166,14 +2920,12 @@ struct OnboardingAISetupTests {
         let recorder = AISetupRequestRecorder()
         let gateway = GatewayConnection(
             configProvider: { config.snapshot() },
-            sessionBox: WebSocketSessionBox(session: makeAISetupSession(recorder: recorder))
-        )
+            sessionBox: WebSocketSessionBox(session: makeAISetupSession(recorder: recorder)))
         let routeIdentity = AISetupRouteIdentity("remote:id:gateway-a")
         let model = OnboardingAISetupModel(
             gateway: gateway,
             defaults: defaults,
-            routeIdentityProvider: { routeIdentity.snapshot() }
-        )
+            routeIdentityProvider: { routeIdentity.snapshot() })
         await model.detectAndAutoConnect()
         model.manualProviderID = "openai-api-key"
         model.manualKey = "old-route-secret"
@@ -3189,39 +2941,42 @@ struct OnboardingAISetupTests {
         #expect(!requests.apiKeys.contains("old-route-secret"))
         #expect(!OnboardingSystemAgentResumeStore.isPending(
             for: "remote:id:gateway-b",
-            defaults: defaults
-        ))
+            defaults: defaults))
         #expect(!model.manualTesting)
     }
 
     @Test func `automatic activation rejects an auth-token change before dispatch`() async throws {
-        let suiteName = "OnboardingAutomaticActivationTokenTests-\(UUID().uuidString)"
-        let defaults = try #require(UserDefaults(suiteName: suiteName))
-        defer { defaults.removePersistentDomain(forName: suiteName) }
-        let url = try #require(URL(string: "ws://example.invalid"))
-        let config = AISetupGatewayConfig(url: url, token: "token-a")
-        let recorder = AISetupRequestRecorder()
-        let gateway = GatewayConnection(
-            configProvider: { config.snapshot() },
-            sessionBox: WebSocketSessionBox(session: makeAISetupSession(
-                recorder: recorder,
-                detectedKind: "codex-cli"
-            ))
-        )
-        let model = OnboardingAISetupModel(
-            gateway: gateway,
-            defaults: defaults,
-            routeIdentityProvider: { "local" }
-        )
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
 
-        await model.detectAndAutoConnect()
-        config.switchToken(to: "token-b", afterReads: 2)
-        await model.activate(kind: "codex-cli")
+        try await DeviceIdentityStore.withStateDirectory(tempDir) {
+            let suiteName = "OnboardingAutomaticActivationTokenTests-\(UUID().uuidString)"
+            let defaults = try #require(UserDefaults(suiteName: suiteName))
+            defer { defaults.removePersistentDomain(forName: suiteName) }
+            let url = try #require(URL(string: "ws://example.invalid"))
+            let config = AISetupGatewayConfig(url: url, token: "token-a")
+            let recorder = AISetupRequestRecorder()
+            let gateway = GatewayConnection(
+                configProvider: { config.snapshot() },
+                sessionBox: WebSocketSessionBox(session: makeAISetupSession(
+                    recorder: recorder,
+                    detectedKind: "codex-cli")))
+            let model = OnboardingAISetupModel(
+                gateway: gateway,
+                defaults: defaults,
+                routeIdentityProvider: { "local" })
 
-        #expect(await (recorder.snapshot()).methods == ["openclaw.setup.detect"])
-        #expect(!OnboardingSystemAgentResumeStore.isPending(for: "local", defaults: defaults))
-        #expect(!model.pendingActivationVerification)
-        #expect(model.phase == .ready)
+            await model.detectAndAutoConnect()
+            config.switchToken(to: "token-b", afterReads: 2)
+            await model.activate(kind: "codex-cli")
+
+            #expect(await (recorder.snapshot()).methods == ["openclaw.setup.detect"])
+            #expect(!OnboardingSystemAgentResumeStore.isPending(for: "local", defaults: defaults))
+            #expect(!model.pendingActivationVerification)
+            #expect(model.phase == .ready)
+        }
     }
 
     @Test func `manual activation rejects an auth-token change before sending the key`() async throws {
@@ -3233,20 +2988,18 @@ struct OnboardingAISetupTests {
         let recorder = AISetupRequestRecorder()
         let gateway = GatewayConnection(
             configProvider: { config.snapshot() },
-            sessionBox: WebSocketSessionBox(session: makeAISetupSession(recorder: recorder))
-        )
+            sessionBox: WebSocketSessionBox(session: makeAISetupSession(recorder: recorder)))
         let model = OnboardingAISetupModel(
             gateway: gateway,
             defaults: defaults,
-            routeIdentityProvider: { "local" }
-        )
+            routeIdentityProvider: { "local" })
         await model.detectAndAutoConnect()
         model.manualProviderID = "openai-api-key"
         model.manualKey = "must-not-send"
         config.switchToken(to: "token-b", afterReads: 2)
 
         model.submitManualKey()
-        for _ in 0 ..< 200 {
+        for _ in 0..<200 {
             guard model.manualTesting else { break }
             try? await Task.sleep(nanoseconds: 5_000_000)
         }
@@ -3277,8 +3030,8 @@ struct OnboardingAISetupTests {
                 if respondToAISetupPreparation(
                     task: task,
                     request: request,
-                    kind: "codex-cli"
-                ) {
+                    kind: "codex-cli")
+                {
                     return
                 }
                 guard request.method == "openclaw.setup.activate" else { return }
@@ -3288,13 +3041,11 @@ struct OnboardingAISetupTests {
         })
         let gateway = GatewayConnection(
             configProvider: { config.snapshot() },
-            sessionBox: WebSocketSessionBox(session: session)
-        )
+            sessionBox: WebSocketSessionBox(session: session))
         let model = OnboardingAISetupModel(
             gateway: gateway,
             defaults: defaults,
-            routeIdentityProvider: { "local" }
-        )
+            routeIdentityProvider: { "local" })
         var scheduledDeadlines: [(deadline: Date, routeIdentity: String)] = []
         model.onPendingActivationDeadline = { deadline, routeIdentity in
             scheduledDeadlines.append((deadline, routeIdentity))
@@ -3337,13 +3088,11 @@ struct OnboardingAISetupTests {
                     await recorder.record(message)
                     task.emitReceiveSuccess(.data(indeterminateActivationResponse(id: request.id)))
                 })
-            }))
-        )
+            })))
         let model = OnboardingAISetupModel(
             gateway: gateway,
             defaults: defaults,
-            routeIdentityProvider: { "local" }
-        )
+            routeIdentityProvider: { "local" })
         var scheduledRoutes: [String] = []
         model.onPendingActivationDeadline = { _, routeIdentity in
             scheduledRoutes.append(routeIdentity)
@@ -3379,31 +3128,26 @@ struct OnboardingAISetupTests {
                     if let callbackDefaults = UserDefaults(suiteName: suiteName) {
                         let pendingState = OnboardingSystemAgentResumeStore.pendingState(
                             for: "local",
-                            defaults: callbackDefaults
-                        )
+                            defaults: callbackDefaults)
                         if case let .activating(deadline) = pendingState {
                             await markerObservation.record(deadline: deadline)
                         }
                         OnboardingSystemAgentResumeStore.clear(
                             ifOwnedBy: "local",
-                            defaults: callbackDefaults
-                        )
+                            defaults: callbackDefaults)
                     }
                     task.emitReceiveSuccess(.data(indeterminateActivationResponse(id: request.id)))
                 })
-            }))
-        )
+            })))
         let model = OnboardingAISetupModel(
             gateway: gateway,
             defaults: defaults,
-            routeIdentityProvider: { "local" }
-        )
+            routeIdentityProvider: { "local" })
         var scheduledDeadlines: [(deadline: Date, routeIdentity: String)] = []
         model.onPendingActivationDeadline = { deadline, routeIdentity in
             #expect(OnboardingSystemAgentResumeStore.isPending(
                 for: routeIdentity,
-                defaults: defaults
-            ))
+                defaults: defaults))
             scheduledDeadlines.append((deadline, routeIdentity))
         }
 
@@ -3420,8 +3164,7 @@ struct OnboardingAISetupTests {
         let originalDeadline = try #require(await markerObservation.deadline())
         let restoredState = OnboardingSystemAgentResumeStore.pendingState(
             for: "local",
-            defaults: defaults
-        )
+            defaults: defaults)
         guard case let .activating(restoredDeadline) = restoredState else {
             Issue.record("expected restored activation marker")
             return
@@ -3430,8 +3173,7 @@ struct OnboardingAISetupTests {
 
         let relaunched = OnboardingAISetupModel(
             defaults: defaults,
-            routeIdentityProvider: { "local" }
-        )
+            routeIdentityProvider: { "local" })
         relaunched.waitForPendingActivationDeadline()
         #expect(relaunched.waitingForPendingActivationDeadline)
         #expect(relaunched.pendingActivationVerification == false)
@@ -3459,8 +3201,7 @@ struct OnboardingAISetupTests {
                         if let callbackDefaults = UserDefaults(suiteName: suiteName) {
                             OnboardingSystemAgentResumeStore.clear(
                                 ifOwnedBy: "local",
-                                defaults: callbackDefaults
-                            )
+                                defaults: callbackDefaults)
                         }
                         task.emitReceiveSuccess(.data(indeterminateActivationResponse(id: request.id)))
                     case "agents.list":
@@ -3471,20 +3212,17 @@ struct OnboardingAISetupTests {
                         task.emitReceiveSuccess(.data(detectedSetupResponse(
                             id: request.id,
                             kind: "codex-cli",
-                            modelRef: "openai/gpt-5.5"
-                        )))
+                            modelRef: "openai/gpt-5.5")))
                     default:
                         break
                     }
                 })
-            }))
-        )
+            })))
         let view = OnboardingView(
             state: appState,
             aiSetupGateway: gateway,
             systemAgentDefaults: defaults,
-            aiSetupRouteIdentityProvider: { "local" }
-        )
+            aiSetupRouteIdentityProvider: { "local" })
         view.onboardingVisible = true
         var scheduledDeadlines: [Date] = []
         var handoffCount = 0
@@ -3502,8 +3240,7 @@ struct OnboardingAISetupTests {
         let initialRecheck = try #require(view.probeConfiguredGatewayForDashboard(
             startAISetupWhenMissing: true,
             knownVisible: true,
-            knownAISetupPage: true
-        ))
+            knownAISetupPage: true))
         await initialRecheck.value
         let requests = await waitForAISetupRequests(recorder, count: 4)
         await settleQueuedAISetupTasks()
@@ -3519,8 +3256,8 @@ struct OnboardingAISetupTests {
         #expect({
             if case .verified = OnboardingSystemAgentResumeStore.pendingState(
                 for: "local",
-                defaults: defaults
-            ) {
+                defaults: defaults)
+            {
                 return true
             }
             return false
@@ -3528,20 +3265,17 @@ struct OnboardingAISetupTests {
 
         let activationOwner = try #require(OnboardingSystemAgentResumeStore.activationOwner(
             for: "local",
-            defaults: defaults
-        ))
+            defaults: defaults))
         OnboardingSystemAgentResumeStore.markPending(
             routeIdentity: "local",
             activationOwner: activationOwner,
             activationTimeoutMs: 0,
             defaults: defaults,
-            now: Date(timeIntervalSinceNow: -10)
-        )
+            now: Date(timeIntervalSinceNow: -10))
         let deadlineRecheck = try #require(view.probeConfiguredGatewayForDashboard(
             startAISetupWhenMissing: true,
             knownVisible: true,
-            knownAISetupPage: true
-        ))
+            knownAISetupPage: true))
         await deadlineRecheck.value
         let completedRequests = await waitForAISetupRequests(recorder, count: 7)
         await settleQueuedAISetupTasks()
@@ -3562,8 +3296,7 @@ struct OnboardingAISetupTests {
         #expect(handoffCount == 0)
         #expect(OnboardingSystemAgentResumeStore.pendingState(
             for: "local",
-            defaults: defaults
-        ) == .none)
+            defaults: defaults) == .none)
         view.onboardingDidDisappear()
     }
 
@@ -3587,16 +3320,14 @@ struct OnboardingAISetupTests {
                     if let requestDefaults = UserDefaults(suiteName: suiteName),
                        let activationOwner = OnboardingSystemAgentResumeStore.activationOwner(
                            for: "local",
-                           defaults: requestDefaults
-                       )
+                           defaults: requestDefaults)
                     {
                         OnboardingSystemAgentResumeStore.markPending(
                             routeIdentity: "local",
                             activationOwner: activationOwner,
                             activationTimeoutMs: 0,
                             defaults: requestDefaults,
-                            now: Date(timeIntervalSinceNow: -10)
-                        )
+                            now: Date(timeIntervalSinceNow: -10))
                     }
                     task.emitReceiveSuccess(.data(indeterminateActivationResponse(id: request.id)))
                 case "agents.list":
@@ -3610,14 +3341,12 @@ struct OnboardingAISetupTests {
         })
         let gateway = GatewayConnection(
             configProvider: { (url: url, token: nil, password: nil) },
-            sessionBox: WebSocketSessionBox(session: session)
-        )
+            sessionBox: WebSocketSessionBox(session: session))
         let view = OnboardingView(
             state: appState,
             aiSetupGateway: gateway,
             systemAgentDefaults: defaults,
-            aiSetupRouteIdentityProvider: { "local" }
-        )
+            aiSetupRouteIdentityProvider: { "local" })
         var recheckTask: Task<Void, Never>?
         var recheckRoute: String?
         view.aiSetup.onPendingActivationDeadline = { _, routeIdentity in
@@ -3625,8 +3354,7 @@ struct OnboardingAISetupTests {
             recheckTask = view.probeConfiguredGatewayForDashboard(
                 startAISetupWhenMissing: true,
                 knownVisible: true,
-                knownAISetupPage: true
-            )
+                knownAISetupPage: true)
         }
 
         await view.aiSetup.detectAndAutoConnect()
@@ -3647,8 +3375,7 @@ struct OnboardingAISetupTests {
         #expect(!view.aiSetup.waitingForPendingActivationDeadline)
         #expect(OnboardingSystemAgentResumeStore.pendingState(
             for: "local",
-            defaults: defaults
-        ) == .none)
+            defaults: defaults) == .none)
         view.onboardingDidDisappear()
     }
 
@@ -3662,14 +3389,11 @@ struct OnboardingAISetupTests {
             configProvider: { (url: url, token: nil, password: nil) },
             sessionBox: WebSocketSessionBox(session: makeAISetupSession(
                 recorder: recorder,
-                indeterminateActivationAfterDispatch: true
-            ))
-        )
+                indeterminateActivationAfterDispatch: true)))
         let model = OnboardingAISetupModel(
             gateway: gateway,
             defaults: defaults,
-            routeIdentityProvider: { "local" }
-        )
+            routeIdentityProvider: { "local" })
         await model.detectAndAutoConnect()
         model.manualProviderID = "openai-api-key"
         model.manualKey = "temporary-key"
@@ -3680,7 +3404,7 @@ struct OnboardingAISetupTests {
 
         model.submitManualKey()
         // The full suite can starve MainActor work; wait for state instead of a one-second budget.
-        for _ in 0 ..< 2000 {
+        for _ in 0..<2000 {
             if !model.manualTesting, model.waitingForPendingActivationDeadline {
                 break
             }
@@ -3715,34 +3439,30 @@ struct OnboardingAISetupTests {
         let url = try #require(URL(string: "ws://example.invalid"))
         let gateway = GatewayConnection(
             configProvider: { (url: url, token: nil, password: nil) },
-            sessionBox: WebSocketSessionBox(session: session)
-        )
+            sessionBox: WebSocketSessionBox(session: session))
         let model = OnboardingAISetupModel(
             gateway: gateway,
             defaults: defaults,
-            routeIdentityProvider: { "remote:id:gateway-a" }
-        )
+            routeIdentityProvider: { "remote:id:gateway-a" })
 
         await model.detectAndAutoConnect()
         let staleActivation = Task { await model.activate(kind: "codex-cli") }
         while !OnboardingSystemAgentResumeStore.isPending(
             for: "remote:id:gateway-a",
-            defaults: defaults
-        ) {
+            defaults: defaults)
+        {
             await Task.yield()
         }
         model.resetForGatewayChange()
         OnboardingSystemAgentResumeStore.markPending(
             routeIdentity: "remote:id:gateway-b",
-            defaults: defaults
-        )
+            defaults: defaults)
         staleActivation.cancel()
         await staleActivation.value
 
         #expect(OnboardingSystemAgentResumeStore.isPending(
             for: "remote:id:gateway-b",
-            defaults: defaults
-        ))
+            defaults: defaults))
     }
 
     @Test func `configured resume preserves marker until route reset`() throws {
@@ -3751,8 +3471,7 @@ struct OnboardingAISetupTests {
         defer { defaults.removePersistentDomain(forName: suiteName) }
         let model = OnboardingAISetupModel(
             defaults: defaults,
-            routeIdentityProvider: { "local" }
-        )
+            routeIdentityProvider: { "local" })
         OnboardingSystemAgentResumeStore.markPending(routeIdentity: "local", defaults: defaults)
 
         model.resumeConfiguredInference(modelRef: "openai/gpt-5.5")

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingMemoryImportTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingMemoryImportTests.swift
@@ -1,7 +1,7 @@
 import Foundation
-import OpenClawKit
 import Testing
 @testable import OpenClaw
+@testable import OpenClawKit
 
 private struct MemoryImportWireRequest: Sendable {
     let id: String

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingMemoryImportTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingMemoryImportTests.swift
@@ -273,6 +273,16 @@ private func makeMemoryImportGateway(
 @Suite(.serialized)
 @MainActor
 struct OnboardingMemoryImportTests {
+    private func withTemporaryStateDir<T>(_ operation: () async throws -> T) async throws -> T {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        return try await DeviceIdentityStore.withStateDirectory(tempDir) {
+            try await operation()
+        }
+    }
+
     @Test func `plan maps planned and already imported memories into an offer`() async throws {
         let url = try #require(URL(string: "ws://memory.test"))
         let gateway = makeMemoryImportGateway(
@@ -401,38 +411,48 @@ struct OnboardingMemoryImportTests {
         #expect(broken.inlineError?.contains("inconsistent") == true)
     }
 
-    @Test func `foreign agent and duplicate provider identities reject the plan`() async throws {
-        let url = try #require(URL(string: "ws://memory.test"))
-        let counter = MemoryImportApplyCounter()
-        let gateway = makeMemoryImportGateway(
-            configProvider: { (url: url, token: nil, password: nil) },
-            responder: { task, request in
-                let payload: String
-                if request.method == "migrations.memory.plan" {
-                    let attempt = await counter.next(for: "plan")
-                    payload = attempt == 1
+    @Test func `foreign agent identity rejects the plan`() async throws {
+        try await self.withTemporaryStateDir {
+            let url = try #require(URL(string: "ws://memory.test"))
+            let gateway = makeMemoryImportGateway(
+                configProvider: { (url: url, token: nil, password: nil) },
+                responder: { task, request in
+                    let payload = request.method == "migrations.memory.plan"
                         ? #"{"agentId":"other","workspace":"/tmp/workspace","providers":[]}"#
-                        : memoryImportDuplicateProviderPlanPayload
-                } else {
-                    payload = "{}"
-                }
-                task.emitReceiveSuccess(.data(memoryImportOK(id: request.id, payload: payload)))
-            })
-        let model = OnboardingMemoryImportModel()
+                        : "{}"
+                    task.emitReceiveSuccess(.data(memoryImportOK(id: request.id, payload: payload)))
+                })
+            let model = OnboardingMemoryImportModel()
 
-        await model.startPlanning(gateway: gateway, agentId: "main")
-        guard case let .failed(agentMessage) = model.phase else {
-            Issue.record("Expected foreign-agent plan failure")
-            return
+            await model.startPlanning(gateway: gateway, agentId: "main")
+            guard case let .failed(message) = model.phase else {
+                Issue.record("Expected foreign-agent plan failure")
+                return
+            }
+            #expect(message.contains("different agent"))
         }
-        #expect(agentMessage.contains("different agent"))
+    }
 
-        await model.startPlanning(gateway: gateway, agentId: "main")
-        guard case let .failed(providerMessage) = model.phase else {
-            Issue.record("Expected duplicate-provider plan failure")
-            return
+    @Test func `duplicate provider identity rejects the plan`() async throws {
+        try await self.withTemporaryStateDir {
+            let url = try #require(URL(string: "ws://memory.test"))
+            let gateway = makeMemoryImportGateway(
+                configProvider: { (url: url, token: nil, password: nil) },
+                responder: { task, request in
+                    let payload = request.method == "migrations.memory.plan"
+                        ? memoryImportDuplicateProviderPlanPayload
+                        : "{}"
+                    task.emitReceiveSuccess(.data(memoryImportOK(id: request.id, payload: payload)))
+                })
+            let model = OnboardingMemoryImportModel()
+
+            await model.startPlanning(gateway: gateway, agentId: "main")
+            guard case let .failed(message) = model.phase else {
+                Issue.record("Expected duplicate-provider plan failure")
+                return
+            }
+            #expect(message.contains("invalid memory provider"))
         }
-        #expect(providerMessage.contains("invalid memory provider"))
     }
 
     @Test func `default agent id feeds the plan request`() async throws {


### PR DESCRIPTION
## What Problem This Solves

Fixes a macOS CI flake cluster where parallel Swift tests intermittently failed in unrelated onboarding and catalog-worker cases during full release validation. The failures came from shared persisted device-identity state and scheduler-dependent polling, and different tests failed across retries.

Related validation: https://github.com/openclaw/openclaw/actions/runs/29894590588

## Why This Change Was Made

The gateway-backed onboarding tests now isolate device identity in unique temporary state directories, the combined memory-import rejection test is split so one setup failure cannot shift a later response, and the Claude catalog cancellation test uses an explicit bounded start barrier instead of relying on repeated `Task.yield()`. The touched Swift test files are normalized with the repository SwiftFormat configuration in the same dedicated PR.

## User Impact

No product behavior changes. Release and pull-request CI should stop failing nondeterministically when the macOS test package runs in parallel.

## Evidence

- `swiftformat --config config/swiftformat apps/macos/Tests/OpenClawIPCTests/MacNodeRuntimeTests.swift apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift apps/macos/Tests/OpenClawIPCTests/OnboardingMemoryImportTests.swift`
- Autoreview: clean, no accepted/actionable findings.
- Focused local `swift test` was blocked before project compilation because the selected Command Line Tools SDK lacks the `SwiftUIMacros` and `PreviewsMacros` plugins. Exact-head macOS CI is the authoritative proof for this PR.

AI-assisted: yes. The changes and failure logs were reviewed against the production ownership paths.
