### PR TITLE
fix(googlechat): bypass proxies for spaced NO_PROXY hosts

### DIFF
--- a/extensions/googlechat/src/google-auth.runtime.test.ts
+++ b/extensions/googlechat/src/google-auth.runtime.test.ts
@@ -248,6 +248,28 @@ describe("googlechat google auth runtime", () => {
     expect(release).toHaveBeenCalledOnce();
   });
 
+  it("bypasses env proxy for whitespace-separated NO_PROXY hosts", async () => {
+    const release = vi.fn();
+    mocks.fetchWithSsrFGuard.mockResolvedValueOnce({
+      response: new Response("ok", { status: 200 }),
+      release,
+    });
+    vi.stubEnv("HTTPS_PROXY", "http://env-proxy.example:8080");
+    vi.stubEnv("NO_PROXY", "accounts.google.com oauth2.googleapis.com");
+
+    const guardedFetch = await createGoogleAuthTransportFetch();
+    await guardedFetch("https://oauth2.googleapis.com/token", {
+      method: "POST",
+    } as RequestInit);
+
+    expect(mocks.fetchWithSsrFGuard).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dispatcherPolicy: undefined,
+      }),
+    );
+    expect(release).toHaveBeenCalledOnce();
+  });
+
   it("releases guarded auth fetch resources even when callers do not consume the body", async () => {
     const release = vi.fn();
     mocks.fetchWithSsrFGuard.mockResolvedValueOnce({

--- a/extensions/googlechat/src/google-auth.runtime.ts
+++ b/extensions/googlechat/src/google-auth.runtime.ts
@@ -148,7 +148,7 @@ function resolveGoogleAuthEnvProxyUrl(protocol: "http" | "https"): string | unde
 
 function collectGoogleAuthNoProxyRules(noProxy: ProxyRule[] = []): ProxyRule[] {
   const rules = [...noProxy];
-  const envRules = (process.env.NO_PROXY ?? process.env.no_proxy)?.split(",") ?? [];
+  const envRules = (process.env.NO_PROXY ?? process.env.no_proxy)?.split(/[,\s]/) ?? [];
   for (const rule of envRules) {
     const trimmed = rule.trim();
     if (trimmed.length > 0) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Google Chat authentication requests would still use an environment proxy when `NO_PROXY` listed hosts with whitespace separators.

## Why This Change Was Made

Google Chat now tokenizes environment no-proxy rules with the same comma-or-whitespace contract used by Undici's `EnvHttpProxyAgent`. Explicit per-request no-proxy rules are unchanged.

## User Impact

Operators can use standard whitespace-separated `NO_PROXY` entries and expect Google authentication traffic for matching hosts to connect directly.

## Evidence

- AI-assisted change; reviewed against the owning runtime and Undici's installed proxy-agent implementation.
- `node scripts/run-vitest.mjs extensions/googlechat/src/google-auth.runtime.test.ts` — 19 tests passed.
- Targeted `oxfmt`, `oxlint`, and `git diff --check` passed.
- `check-changed` remote delegation was attempted but stopped before execution because pnpm wanted to rebuild the linked worktree dependency directory in a non-interactive session.
