### PR TITLE
fix(agents): resolve shell snapshots when HOME is blank

### DIFF
--- a/src/agents/shell-snapshot.test.ts
+++ b/src/agents/shell-snapshot.test.ts
@@ -7,7 +7,7 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveStateDir } from "../config/paths.js";
 import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
-import { maybeWrapCommandWithShellSnapshot } from "./shell-snapshot.js";
+import { maybeWrapCommandWithShellSnapshot, resolveTrustedShellHome } from "./shell-snapshot.js";
 import { getBashShellConfig, getShellConfig } from "./shell-utils.js";
 
 const isWin = process.platform === "win32";
@@ -68,6 +68,12 @@ function setSnapshotStateForTest(
 describe("exec shell snapshots", () => {
   const tempDirs: string[] = [];
   let envSnapshot: ReturnType<typeof captureEnv>;
+
+  it("falls back from a blank HOME to USERPROFILE", () => {
+    expect(
+      resolveTrustedShellHome({ HOME: "", USERPROFILE: "C:\\Users\\operator" }, () => "/os/home"),
+    ).toBe("C:\\Users\\operator");
+  });
 
   beforeEach(() => {
     envSnapshot = captureEnv([

--- a/src/agents/shell-snapshot.test.ts
+++ b/src/agents/shell-snapshot.test.ts
@@ -7,7 +7,7 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveStateDir } from "../config/paths.js";
 import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
-import { maybeWrapCommandWithShellSnapshot, resolveTrustedShellHome } from "./shell-snapshot.js";
+import { maybeWrapCommandWithShellSnapshot } from "./shell-snapshot.js";
 import { getBashShellConfig, getShellConfig } from "./shell-utils.js";
 
 const isWin = process.platform === "win32";
@@ -68,12 +68,6 @@ function setSnapshotStateForTest(
 describe("exec shell snapshots", () => {
   const tempDirs: string[] = [];
   let envSnapshot: ReturnType<typeof captureEnv>;
-
-  it("falls back from a blank HOME to USERPROFILE", () => {
-    expect(
-      resolveTrustedShellHome({ HOME: "", USERPROFILE: "C:\\Users\\operator" }, () => "/os/home"),
-    ).toBe("C:\\Users\\operator");
-  });
 
   beforeEach(() => {
     envSnapshot = captureEnv([

--- a/src/agents/shell-snapshot.ts
+++ b/src/agents/shell-snapshot.ts
@@ -139,7 +139,7 @@ function buildSnapshotKey(opts: ShellSnapshotWrapOptions): string {
         shell: opts.shell,
         shellArgs: opts.shellArgs,
         cwd: path.resolve(opts.cwd),
-        home: getTrustedShellHome(),
+        home: resolveTrustedShellHome(),
         stateDir: resolveStateDir(process.env),
         env: buildSafeEnvSignature(process.env),
         startup: buildStartupSignature(opts.shell),
@@ -158,7 +158,7 @@ function buildSafeEnvSignature(
 
 function buildStartupSignature(shell: string): Array<[string, number, number] | [string, null]> {
   const shellName = path.basename(shell);
-  const home = getTrustedShellHome();
+  const home = resolveTrustedShellHome();
   const zdotdir = process.env.ZDOTDIR?.trim() || home;
   const candidates =
     shellName === "zsh"
@@ -176,8 +176,11 @@ function buildStartupSignature(shell: string): Array<[string, number, number] | 
   });
 }
 
-function getTrustedShellHome(): string {
-  return process.env.HOME ?? process.env.USERPROFILE ?? os.homedir();
+export function resolveTrustedShellHome(
+  env: NodeJS.ProcessEnv = process.env,
+  homedir: () => string = os.homedir,
+): string {
+  return [env.HOME, env.USERPROFILE].find((value) => value?.trim()) ?? homedir();
 }
 
 async function createShellSnapshot(

--- a/src/agents/shell-snapshot.ts
+++ b/src/agents/shell-snapshot.ts
@@ -10,6 +10,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { resolveStateDir } from "../config/paths.js";
+import { resolveRequiredOsHomeDir } from "../infra/home-dir.js";
 import { killProcessTree } from "../process/kill-tree.js";
 
 const SNAPSHOT_VERSION = 1;
@@ -139,7 +140,7 @@ function buildSnapshotKey(opts: ShellSnapshotWrapOptions): string {
         shell: opts.shell,
         shellArgs: opts.shellArgs,
         cwd: path.resolve(opts.cwd),
-        home: resolveTrustedShellHome(),
+        home: resolveRequiredOsHomeDir(),
         stateDir: resolveStateDir(process.env),
         env: buildSafeEnvSignature(process.env),
         startup: buildStartupSignature(opts.shell),
@@ -158,7 +159,7 @@ function buildSafeEnvSignature(
 
 function buildStartupSignature(shell: string): Array<[string, number, number] | [string, null]> {
   const shellName = path.basename(shell);
-  const home = resolveTrustedShellHome();
+  const home = resolveRequiredOsHomeDir();
   const zdotdir = process.env.ZDOTDIR?.trim() || home;
   const candidates =
     shellName === "zsh"
@@ -174,13 +175,6 @@ function buildStartupSignature(shell: string): Array<[string, number, number] | 
       return [candidate, null];
     }
   });
-}
-
-export function resolveTrustedShellHome(
-  env: NodeJS.ProcessEnv = process.env,
-  homedir: () => string = os.homedir,
-): string {
-  return [env.HOME, env.USERPROFILE].find((value) => value?.trim()) ?? homedir();
 }
 
 async function createShellSnapshot(

--- a/src/infra/home-dir.test.ts
+++ b/src/infra/home-dir.test.ts
@@ -187,6 +187,18 @@ describe("resolveRequiredHomeDir", () => {
 });
 
 describe("resolveOsHomeDir", () => {
+  it("falls back to USERPROFILE when HOME is blank", () => {
+    expect(
+      resolveOsHomeDir(
+        {
+          HOME: "   ",
+          USERPROFILE: " C:/Users/alice ",
+        } as NodeJS.ProcessEnv,
+        () => "/fallback",
+      ),
+    ).toBe(path.resolve("C:/Users/alice"));
+  });
+
   it("ignores OPENCLAW_HOME and uses HOME", () => {
     expect(
       resolveOsHomeDir(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where shell snapshot startup files could be resolved relative to the current directory when `HOME` was present but blank.

## Why This Change Was Made

Shell snapshot keying and startup-file discovery now reuse the canonical OS-home resolver. It ignores blank values, falls back to `USERPROFILE`, and then uses the operating-system home directory without introducing a test-only production export.

## User Impact

Shell snapshots no longer miss the user's startup configuration—or inspect a current-directory `.bashrc`—because an inherited `HOME` value is blank.

## Evidence

- AI-assisted change; reviewed across snapshot keying, startup signature construction, canonical home resolution, and capture environment setup.
- `node scripts/run-vitest.mjs src/infra/home-dir.test.ts` — 30 tests passed, including blank-`HOME` fallback to `USERPROFILE`.
- Targeted `oxfmt`, `oxlint`, and `git diff --check` passed.
- The full shell-snapshot file has one Windows-only local failure because `/bin/bash` is unavailable; the changed canonical home-resolution suite passes locally and Linux CI is authoritative for snapshot execution.
