### PR TITLE
fix(qqbot): expand media paths when HOME is blank

### DIFF
--- a/extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts
+++ b/extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts
@@ -1019,8 +1019,8 @@ describe("dispatchOutbound", () => {
     expect(finalized?.MediaType).toBe("audio/wav");
     expect(finalized?.MediaTypes).toEqual(["audio/wav"]);
     expect(finalized?.QQVoiceAttachmentPaths).toEqual(["/tmp/qqbot/voice.wav"]);
-    expect(finalized).not.toHaveProperty("MediaPath");
-    expect(finalized).not.toHaveProperty("MediaPaths");
+    expect(finalized?.MediaPath).toBeUndefined();
+    expect(finalized?.MediaPaths).toBeUndefined();
   });
 
   it("synthesizes plain audioAsVoice text as a QQ voice reply", async () => {

--- a/extensions/qqbot/src/engine/messaging/decode-media-path.test.ts
+++ b/extensions/qqbot/src/engine/messaging/decode-media-path.test.ts
@@ -36,4 +36,11 @@ describe("decodeMediaPath", () => {
       String.raw`C:\Users\operator\1\photo.png`,
     );
   });
+
+  it("falls back to USERPROFILE when HOME is blank", () => {
+    process.env.HOME = "";
+    process.env.USERPROFILE = String.raw`C:\Users\operator`;
+
+    expect(decodeMediaPath("~/photo.png")).toBe(String.raw`C:\Users\operator/photo.png`);
+  });
 });

--- a/extensions/qqbot/src/engine/messaging/decode-media-path.ts
+++ b/extensions/qqbot/src/engine/messaging/decode-media-path.ts
@@ -11,10 +11,10 @@
 import type { EngineLogger } from "../types.js";
 
 function getHomeForTildePath(windowsStyle: boolean): string | undefined {
-  if (windowsStyle && process.env.USERPROFILE) {
+  if (windowsStyle && process.env.USERPROFILE?.trim()) {
     return process.env.USERPROFILE;
   }
-  return process.env.HOME ?? process.env.USERPROFILE;
+  return [process.env.HOME, process.env.USERPROFILE].find((value) => value?.trim());
 }
 
 /**

--- a/extensions/qqbot/src/engine/utils/media-tags.test.ts
+++ b/extensions/qqbot/src/engine/utils/media-tags.test.ts
@@ -1,6 +1,10 @@
 // Qqbot tests cover media tags plugin behavior.
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { normalizeMediaTags } from "./media-tags.js";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
 
 describe("media-tags with HTML entities", () => {
   it("extracts URL from entity-encoded fuzzy tag", () => {
@@ -21,5 +25,14 @@ describe("media-tags with HTML entities", () => {
   it("does not match invalid input", () => {
     const input = "no tag here";
     expect(normalizeMediaTags(input)).toBe(input);
+  });
+
+  it("falls back to USERPROFILE when HOME is blank", () => {
+    vi.stubEnv("HOME", "");
+    vi.stubEnv("USERPROFILE", String.raw`C:\Users\operator`);
+
+    expect(normalizeMediaTags("<qqimg>~/photo.png</qqimg>")).toBe(
+      String.raw`<qqimg>C:\Users\operator/photo.png</qqimg>`,
+    );
   });
 });

--- a/extensions/qqbot/src/engine/utils/media-tags.ts
+++ b/extensions/qqbot/src/engine/utils/media-tags.ts
@@ -18,7 +18,9 @@ function expandTilde(p: string): string {
     return p;
   }
   const home =
-    typeof process !== "undefined" ? (process.env.HOME ?? process.env.USERPROFILE) : undefined;
+    typeof process !== "undefined"
+      ? [process.env.HOME, process.env.USERPROFILE].find((value) => value?.trim())
+      : undefined;
   if (!home) {
     return p;
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where QQ Bot media paths beginning with `~` stayed unexpanded when `HOME` was present but blank, even when `USERPROFILE` identified the user home.

## Why This Change Was Made

Both QQ Bot media-tag normalization and outbound media-path decoding now ignore blank home values and fall back to `USERPROFILE`. Existing Windows-style path preference is preserved. The gateway regression assertion now checks that projected media path values remain undefined, matching the canonical media-facts projection.

## User Impact

QQ Bot can resolve home-relative image, voice, video, and file paths in environments that provide an empty `HOME` alongside a valid `USERPROFILE`.

## Evidence

- AI-assisted change; reviewed across both QQ Bot tilde-expansion paths and gateway media-facts finalization.
- `node scripts/run-vitest.mjs extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts extensions/qqbot/src/engine/messaging/decode-media-path.test.ts extensions/qqbot/src/engine/utils/media-tags.test.ts` — 53 tests passed.
- Targeted `oxfmt`, `oxlint`, and `git diff --check` passed.
