### PR TITLE
fix(telegram): disable link previews in draft stream

### DIFF
--- a/.github/workflows/ci-build-artifacts-testbox.yml
+++ b/.github/workflows/ci-build-artifacts-testbox.yml
@@ -27,7 +27,7 @@ jobs:
     permissions:
       contents: read
     name: "build-artifacts"
-    runs-on: blacksmith-16vcpu-ubuntu-2404
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 35
     steps:
       - name: Begin Testbox
@@ -156,7 +156,7 @@ jobs:
       - name: Build dist on cache miss
         if: steps.dist-cache.outputs.cache-hit != 'true'
         env:
-          NODE_OPTIONS: --max-old-space-size=16384
+          NODE_OPTIONS: --max-old-space-size=8192
         run: pnpm build:ci-artifacts
 
       - name: Build Control UI on cache miss

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,6 @@ jobs:
         env:
           CHECKOUT_REPO: ${{ github.repository }}
           CHECKOUT_REF: ${{ inputs.target_ref || github.sha }}
-          CHECKOUT_EVENT_REF: ${{ github.ref }}
           CHECKOUT_FALLBACK_REF: ${{ github.sha }}
           GITHUB_EVENT_NAME: ${{ github.event_name }}
         run: |
@@ -153,29 +152,12 @@ jobs:
               sleep 5
             done
           }
-
-          # Manual release-gate runs commonly validate the workflow ref's exact SHA.
-          # Fetch the branch/tag ref first so GitHub does not have to negotiate an
-          # arbitrary SHA fetch, then verify the resolved commit stayed pinned.
-          checkout_ref="$CHECKOUT_REF"
-          requested_sha=""
-          if [[ "$CHECKOUT_REF" =~ ^[0-9a-f]{40}$ ]]; then
-            requested_sha="$CHECKOUT_REF"
-            if [[
-              "$GITHUB_EVENT_NAME" == "workflow_dispatch" &&
-              "$CHECKOUT_REF" == "$CHECKOUT_FALLBACK_REF" &&
-              -n "$CHECKOUT_EVENT_REF"
-            ]]; then
-              checkout_ref="$CHECKOUT_EVENT_REF"
-            fi
-          fi
-
-          if fetch_checkout_ref "$checkout_ref"; then
+          if fetch_checkout_ref "$CHECKOUT_REF"; then
             :
           else
             fetch_status="$?"
             if [ "$fetch_status" = "124" ] || [ "$fetch_status" = "137" ]; then
-              echo "::error::checkout fetch for '$checkout_ref' timed out"
+              echo "::error::checkout fetch for '$CHECKOUT_REF' timed out"
               exit "$fetch_status"
             fi
             if [ "$GITHUB_EVENT_NAME" != "workflow_dispatch" ] || [ "$CHECKOUT_REF" = "$CHECKOUT_FALLBACK_REF" ]; then
@@ -183,15 +165,6 @@ jobs:
             fi
             echo "::warning::workflow_dispatch target_ref '$CHECKOUT_REF' is unavailable; falling back to head SHA '$CHECKOUT_FALLBACK_REF'"
             fetch_checkout_ref "$CHECKOUT_FALLBACK_REF"
-          fi
-
-          if [ -n "$requested_sha" ]; then
-            resolved_sha="$(git -C "$GITHUB_WORKSPACE" rev-parse refs/remotes/origin/checkout)"
-            if [ "$resolved_sha" != "$requested_sha" ]; then
-              echo "::error::checkout ref '$checkout_ref' resolved to '$resolved_sha'," \
-                "expected '$requested_sha'" >&2
-              exit 1
-            fi
           fi
           git -C "$GITHUB_WORKSPACE" checkout --detach refs/remotes/origin/checkout
 
@@ -315,12 +288,7 @@ jobs:
           if (runNodeFull) {
             checksFastCoreTasks.push(
               { check_name: "checks-fast-bundled-protocol", runtime: "node", task: "bundled-protocol" },
-              {
-                check_name: "QA Smoke CI",
-                runtime: "node",
-                task: "qa-smoke-ci",
-                runner: "blacksmith-16vcpu-ubuntu-2404",
-              },
+              { check_name: "QA Smoke CI", runtime: "node", task: "qa-smoke-ci" },
               { check_name: "checks-fast-bun-launcher", runtime: "bun", task: "bun-launcher" },
             );
           } else {
@@ -423,10 +391,6 @@ jobs:
             );
           }
           EOF
-
-      - name: Check mobile protocol event coverage
-        if: ${{ steps.manifest.outputs.run_node == 'true' || steps.manifest.outputs.run_ios_build == 'true' || steps.manifest.outputs.run_android_job == 'true' }}
-        run: node scripts/check-protocol-event-coverage.mjs
 
   # Run dependency-free security checks in parallel with scope detection so the
   # main Node jobs do not have to wait for Python/pre-commit setup.
@@ -881,7 +845,7 @@ jobs:
     name: ${{ matrix.check_name }}
     needs: [preflight]
     if: needs.preflight.outputs.run_checks_fast_core == 'true'
-    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && (matrix.runner || 'blacksmith-4vcpu-ubuntu-2404') || 'ubuntu-24.04') }}
+    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && 'blacksmith-4vcpu-ubuntu-2404' || 'ubuntu-24.04') }}
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -908,17 +872,12 @@ jobs:
               ;;
             qa-smoke-ci)
               output_dir=".artifacts/qa-e2e/smoke-ci-profile"
-              package_dir=".artifacts/qa-e2e/smoke-ci-package"
               export OPENCLAW_BUILD_PRIVATE_QA=1
               export OPENCLAW_ENABLE_PRIVATE_QA_CLI=1
               export OPENCLAW_DISABLE_BUNDLED_PLUGINS=0
               export OPENCLAW_QA_REDACT_PUBLIC_METADATA=1
               export OPENCLAW_QA_TRANSPORT_READY_TIMEOUT_MS=180000
-              export NODE_OPTIONS=--max-old-space-size=16384
-              node scripts/package-openclaw-for-docker.mjs \
-                --output-dir "$package_dir" \
-                --output-name openclaw-current.tgz
-              export OPENCLAW_CURRENT_PACKAGE_TGZ="$PWD/$package_dir/openclaw-current.tgz"
+              NODE_OPTIONS=--max-old-space-size=8192 node scripts/build-all.mjs qaRuntime
               qa_exit_code=0
               pnpm openclaw qa run \
                 --repo-root . \
@@ -1222,6 +1181,8 @@ jobs:
               pnpm lint:auth:no-pairing-store-group
               pnpm lint:auth:pairing-account-scope
               pnpm check:import-cycles
+              # build-artifacts already runs the tsdown/runtime build for the same Node-relevant changes.
+              NODE_OPTIONS=--max-old-space-size=8192 pnpm build:plugin-sdk:strict-smoke
               ;;
             shrinkwrap)
               pnpm deps:shrinkwrap:check
@@ -1771,25 +1732,12 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: apps/macos/.build
-          key: ${{ runner.os }}-swift-build-v3-${{ steps.swift-toolchain.outputs.key }}-${{ hashFiles('apps/macos/Package.swift', 'apps/macos/Package.resolved', 'apps/macos/Sources/**', 'apps/macos/Tests/**', 'apps/shared/OpenClawKit/Package.swift', 'apps/shared/OpenClawKit/Sources/**', 'apps/swabble/Package.swift', 'apps/swabble/Sources/**') }}
+          key: ${{ runner.os }}-swift-build-v2-${{ steps.swift-toolchain.outputs.key }}-${{ hashFiles('apps/macos/Package.swift', 'apps/macos/Package.resolved', 'apps/macos/Sources/**', 'apps/macos/Tests/**', 'apps/shared/OpenClawKit/Package.swift', 'apps/shared/OpenClawKit/Sources/**', 'apps/swabble/Package.swift', 'apps/swabble/Sources/**') }}
           restore-keys: |
-            ${{ runner.os }}-swift-build-v3-${{ steps.swift-toolchain.outputs.key }}-
-
-      - name: Validate Swift build cache
-        id: validate-swift-build-cache
-        run: |
-          set -euo pipefail
-          cache_valid=true
-          sparkle_info="apps/macos/.build/artifacts/sparkle/Sparkle/Sparkle.xcframework/Info.plist"
-          if [[ -d apps/macos/.build && ! -f "$sparkle_info" ]]; then
-            echo "::warning::Swift build cache is missing Sparkle; resetting the local SwiftPM build directory."
-            swift package --package-path apps/macos reset
-            cache_valid=false
-          fi
-          echo "cache-valid=$cache_valid" >> "$GITHUB_OUTPUT"
+            ${{ runner.os }}-swift-build-v2-${{ steps.swift-toolchain.outputs.key }}-
 
       - name: Preserve Swift build cache hit
-        if: steps.swift-build-cache.outputs.cache-hit == 'true' && steps.validate-swift-build-cache.outputs.cache-valid == 'true'
+        if: steps.swift-build-cache.outputs.cache-hit == 'true'
         run: |
           set -euo pipefail
           # Exact source-hash cache hits already match these inputs; checkout
@@ -1823,13 +1771,7 @@ jobs:
             if swift build --package-path apps/macos --product OpenClaw --configuration release; then
               exit 0
             fi
-            if [[ "$attempt" -eq 3 ]]; then
-              break
-            fi
             echo "swift build failed (attempt $attempt/3). Retrying…"
-            # SwiftPM can invalidate a restored binary artifact while planning.
-            # Reset so the next attempt downloads a complete dependency graph.
-            swift package --package-path apps/macos reset
             sleep $((attempt * 20))
           done
           exit 1

--- a/.github/workflows/codeql-critical-quality.yml
+++ b/.github/workflows/codeql-critical-quality.yml
@@ -446,7 +446,6 @@ jobs:
           gh api --paginate "repos/${REPOSITORY}/pulls/${PR_NUMBER}/files" --jq '
             .[]
             | select(.filename | test("^(src/cli/gateway-cli/run-loop\\.ts|src/infra/(gateway-lock|jsonl-socket|push-apns-http2|ssh-tunnel)\\.ts|src/infra/net/|src/proxy-capture/|extensions/codex-supervisor/src/json-rpc-client\\.ts|extensions/irc/src/|extensions/qa-lab/src/|packages/net-policy/src/)"))
-            | select(.filename | test("(^|/)[^/]+\\.(?:e2e\\.)?test\\.tsx?$") | not)
             | .filename as $file
             | (.patch // "")
             | split("\n")[]

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,28 +17,7 @@ on:
       - ".github/actions/**"
       - ".github/codeql/**"
       - ".github/workflows/**"
-      - "extensions/acpx/src/**"
-      - "extensions/bonjour/src/advertiser.ts"
-      - "extensions/browser/src/browser/chrome-mcp.ts"
-      - "extensions/browser/src/browser/chrome.executables.ts"
-      - "extensions/browser/src/browser/chrome.ts"
-      - "extensions/codex/src/app-server/sandbox-exec-server/**"
-      - "extensions/codex/src/app-server/transport-stdio.ts"
-      - "extensions/codex/src/node-cli-sessions.ts"
-      - "extensions/codex-supervisor/src/json-rpc-client.ts"
-      - "extensions/file-transfer/src/**"
-      - "extensions/google-meet/src/**"
-      - "extensions/imessage/src/**"
-      - "extensions/memory-core/src/memory/qmd-manager.ts"
-      - "extensions/memory-wiki/src/obsidian.ts"
-      - "extensions/microsoft-foundry/cli.ts"
-      - "extensions/ollama/src/wsl2-crash-loop-check.ts"
-      - "extensions/qa-lab/src/**"
-      - "extensions/signal/src/daemon.ts"
-      - "extensions/tts-local-cli/speech-provider.ts"
-      - "extensions/voice-call/src/**"
       - "packages/**"
-      - "scripts/**"
       - "src/**"
   push:
     branches:
@@ -88,11 +67,6 @@ jobs:
             runs_on: ubuntu-24.04
             timeout_minutes: 25
             config_file: ./.github/codeql/codeql-mcp-process-tool-boundary-critical-security.yml
-          - language: javascript-typescript
-            category: process-exec-boundary
-            runs_on: ubuntu-24.04
-            timeout_minutes: 25
-            config_file: ./.github/codeql/codeql-process-exec-boundary-critical-security.yml
           - language: javascript-typescript
             category: plugin-trust-boundary
             runs_on: ubuntu-24.04

--- a/.github/workflows/control-ui-locale-refresh.yml
+++ b/.github/workflows/control-ui-locale-refresh.yml
@@ -124,162 +124,51 @@ jobs:
 
       - name: Ensure translation provider secrets exist
         env:
-          OPENCLAW_DOCS_I18N_OPENAI_API_KEY: ${{ secrets.OPENCLAW_DOCS_I18N_OPENAI_API_KEY }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENCLAW_DOCS_I18N_OPENAI_API_KEY || secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
           set -euo pipefail
-          if [ -z "${OPENCLAW_DOCS_I18N_OPENAI_API_KEY:-}" ] && [ -z "${OPENAI_API_KEY:-}" ] && [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+          if [ -z "${OPENAI_API_KEY:-}" ] && [ -z "${ANTHROPIC_API_KEY:-}" ]; then
             echo "Missing OPENCLAW_DOCS_I18N_OPENAI_API_KEY, OPENAI_API_KEY, or ANTHROPIC_API_KEY secret."
             exit 1
           fi
 
       - name: Refresh control UI locale files
         env:
-          OPENCLAW_DOCS_I18N_OPENAI_API_KEY: ${{ secrets.OPENCLAW_DOCS_I18N_OPENAI_API_KEY }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENCLAW_DOCS_I18N_OPENAI_API_KEY || secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          ANTHROPIC_MODEL: claude-opus-4-8
-          OPENAI_MODEL: ${{ vars.OPENCLAW_CI_OPENAI_MODEL_BARE || 'gpt-5.5' }}
+          OPENCLAW_CONTROL_UI_I18N_PROVIDER: ${{ secrets.ANTHROPIC_API_KEY != '' && 'anthropic' || 'openai' }}
+          OPENCLAW_CONTROL_UI_I18N_MODEL: ${{ secrets.ANTHROPIC_API_KEY != '' && 'claude-opus-4-8' || vars.OPENCLAW_CI_OPENAI_MODEL_BARE }}
           OPENCLAW_CONTROL_UI_I18N_THINKING: low
-          OPENCLAW_CONTROL_UI_I18N_AUTH_OPTIONAL: "0"
+          OPENCLAW_CONTROL_UI_I18N_AUTH_OPTIONAL: "1"
           LOCALE: ${{ matrix.locale }}
-        run: |
-          set -euo pipefail
+        run: node --import tsx scripts/control-ui-i18n.ts sync --locale "${LOCALE}" --write
 
-          run_refresh() {
-            local provider="$1"
-            local model="$2"
-            local openai_api_key="${3-}"
-            if [ "$provider" = "openai" ]; then
-              OPENAI_API_KEY="$openai_api_key" \
-                OPENCLAW_CONTROL_UI_I18N_PROVIDER="$provider" \
-                OPENCLAW_CONTROL_UI_I18N_MODEL="$model" \
-                node --import tsx scripts/control-ui-i18n.ts sync --locale "${LOCALE}" --write
-              return
-            fi
-            OPENCLAW_CONTROL_UI_I18N_PROVIDER="$provider" \
-              OPENCLAW_CONTROL_UI_I18N_MODEL="$model" \
-              node --import tsx scripts/control-ui-i18n.ts sync --locale "${LOCALE}" --write
-          }
-
-          run_openai_refresh() {
-            local status=1
-            if [ -n "${OPENCLAW_DOCS_I18N_OPENAI_API_KEY:-}" ]; then
-              set +e
-              run_refresh openai "${OPENAI_MODEL}" "${OPENCLAW_DOCS_I18N_OPENAI_API_KEY}"
-              status="$?"
-              set -e
-              if [ "$status" -eq 0 ]; then
-                return 0
-              fi
-              if [ -z "${OPENAI_API_KEY:-}" ] || [ "${OPENAI_API_KEY}" = "${OPENCLAW_DOCS_I18N_OPENAI_API_KEY}" ]; then
-                return "$status"
-              fi
-              echo "::warning::Docs OpenAI control UI locale refresh key failed for ${LOCALE}; retrying with repository OpenAI key."
-            fi
-            if [ -z "${OPENAI_API_KEY:-}" ]; then
-              return "$status"
-            fi
-            run_refresh openai "${OPENAI_MODEL}" "${OPENAI_API_KEY}"
-          }
-
-          if [ -n "${ANTHROPIC_API_KEY:-}" ]; then
-            set +e
-            run_refresh anthropic "${ANTHROPIC_MODEL}"
-            status="$?"
-            set -e
-            if [ "$status" -eq 0 ]; then
-              exit 0
-            fi
-            if [ -z "${OPENCLAW_DOCS_I18N_OPENAI_API_KEY:-}" ] && [ -z "${OPENAI_API_KEY:-}" ]; then
-              exit "$status"
-            fi
-            echo "::warning::Anthropic control UI locale refresh failed for ${LOCALE}; retrying with OpenAI."
-          fi
-
-          run_openai_refresh
-
-      - name: Prepare locale artifact
+      - name: Commit and push locale updates
         env:
           LOCALE: ${{ matrix.locale }}
-        run: |
-          set -euo pipefail
-          artifact_dir="${RUNNER_TEMP}/control-ui-locale-${LOCALE}"
-          mkdir -p "${artifact_dir}"
-          git add -A ui/src/i18n
-          git diff --cached --binary --full-index -- ui/src/i18n > "${artifact_dir}/${LOCALE}.patch"
-
-      - name: Upload locale artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: control-ui-locale-${{ matrix.locale }}
-          path: ${{ runner.temp }}/control-ui-locale-${{ matrix.locale }}/${{ matrix.locale }}.patch
-          if-no-files-found: error
-          retention-days: 1
-
-  finalize:
-    name: Commit control UI locale refresh
-    needs: refresh
-    if: needs.refresh.result == 'success'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-        with:
-          fetch-depth: 0
-          persist-credentials: true
-          submodules: false
-
-      - name: Download locale artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          pattern: control-ui-locale-*
-          path: ${{ runner.temp }}/control-ui-locale-artifacts
-          merge-multiple: true
-
-      - name: Apply locale artifacts
-        run: |
-          set -euo pipefail
-          while IFS= read -r patch; do
-            if [ -s "${patch}" ]; then
-              git apply "${patch}"
-            fi
-          done < <(find "${RUNNER_TEMP}/control-ui-locale-artifacts" -type f -name '*.patch' | sort)
-
-      - name: Setup Node environment
-        uses: ./.github/actions/setup-node-env
-        with:
-          install-bun: "false"
-
-      - name: Validate control UI locale refresh
-        run: node --import tsx scripts/control-ui-i18n.ts check
-
-      - name: Commit and push aggregate locale refresh
-        env:
           TARGET_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           set -euo pipefail
-          if ! git status --porcelain -- ui/src/i18n | grep -q .; then
-            echo "No control UI locale changes."
+          if git diff --quiet -- ui/src/i18n; then
+            echo "No control UI locale changes for ${LOCALE}."
             exit 0
           fi
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add -A ui/src/i18n
-          git commit --no-verify -m "chore(ui): refresh control ui locales"
+          git commit --no-verify -m "chore(ui): refresh ${LOCALE} control ui locale"
 
           for attempt in 1 2 3 4 5; do
             git fetch origin "${TARGET_BRANCH}"
-            git rebase "origin/${TARGET_BRANCH}"
+            git rebase --autostash "origin/${TARGET_BRANCH}"
             if git push origin HEAD:"${TARGET_BRANCH}"; then
               exit 0
             fi
-            git rebase --abort >/dev/null 2>&1 || true
-            echo "Aggregate push attempt ${attempt} failed; retrying."
+            echo "Push attempt ${attempt} for ${LOCALE} failed; retrying."
             sleep $((attempt * 2))
           done
 
-          echo "Failed to push aggregate control UI locale update after retries."
+          echo "Failed to push ${LOCALE} locale update after retries."
           exit 1

--- a/.github/workflows/docs-sync-publish.yml
+++ b/.github/workflows/docs-sync-publish.yml
@@ -38,7 +38,6 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           repository: openclaw/clawhub
-          ref: main
           path: clawhub-source
           fetch-depth: 1
           persist-credentials: false

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,7 +40,6 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           repository: openclaw/clawhub
-          ref: main
           path: clawhub-source
           fetch-depth: 1
           persist-credentials: false

--- a/.github/workflows/full-release-validation.yml
+++ b/.github/workflows/full-release-validation.yml
@@ -1132,8 +1132,8 @@ jobs:
             head_sha="$(jq -r '.headSha // ""' <<< "$run_json")"
             echo "${label}: ${status}/${conclusion} attempt ${attempt} head ${head_sha}: ${url}"
 
-            if [[ ( "$CHILD_WORKFLOW_REF" == release-ci/* || "$CHILD_WORKFLOW_REF" =~ ^extended-stable/[0-9]{4}\.([1-9]|1[0-2])\.33$ ) && -n "${TARGET_SHA// }" && "$head_sha" != "$TARGET_SHA" ]]; then
-              echo "::error::${label} child run used ${head_sha}, expected ${TARGET_SHA}. Dispatch Full Release Validation from a release-ci or extended-stable ref pinned to the target SHA, not a moving branch."
+            if [[ "$CHILD_WORKFLOW_REF" == release-ci/* && -n "${TARGET_SHA// }" && "$head_sha" != "$TARGET_SHA" ]]; then
+              echo "::error::${label} child run used ${head_sha}, expected ${TARGET_SHA}. Dispatch Full Release Validation from a ref pinned to the target SHA, not a moving branch."
               return 1
             fi
 

--- a/.github/workflows/ios-periphery.yml
+++ b/.github/workflows/ios-periphery.yml
@@ -102,7 +102,6 @@ jobs:
           set -euo pipefail
           ./scripts/ios-configure-signing.sh
           ./scripts/ios-write-version-xcconfig.sh
-          node scripts/ios-write-swift-filelist.mjs
           cd apps/ios
           xcodegen generate
 

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -33,26 +33,27 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        if: secrets.GH_APP_PRIVATE_KEY != ''
         id: app-token
         continue-on-error: true
         with:
           app-id: "2729701"
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        if: secrets.GH_APP_PRIVATE_KEY_FALLBACK != '' && steps.app-token.outcome == 'failure'
         id: app-token-fallback
-        if: steps.app-token.outcome == 'failure'
         with:
           app-id: "2971289"
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY_FALLBACK }}
       - uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6
         with:
           configuration-path: .github/labeler.yml
-          repo-token: ${{ steps.app-token.outputs.token || steps.app-token-fallback.outputs.token }}
+          repo-token: ${{ steps.app-token.outputs.token || steps.app-token-fallback.outputs.token || github.token }}
           sync-labels: true
       - name: Apply PR size label
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
-          github-token: ${{ steps.app-token.outputs.token || steps.app-token-fallback.outputs.token }}
+          github-token: ${{ steps.app-token.outputs.token || steps.app-token-fallback.outputs.token || github.token }}
           script: |
             const pullRequest = context.payload.pull_request;
             if (!pullRequest) {
@@ -141,7 +142,7 @@ jobs:
       - name: Apply maintainer or trusted-contributor label
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
-          github-token: ${{ steps.app-token.outputs.token || steps.app-token-fallback.outputs.token }}
+          github-token: ${{ steps.app-token.outputs.token || steps.app-token-fallback.outputs.token || github.token }}
           script: |
             const login = context.payload.pull_request?.user?.login;
             if (!login) {

--- a/.github/workflows/mantis-slack-desktop-smoke.yml
+++ b/.github/workflows/mantis-slack-desktop-smoke.yml
@@ -364,6 +364,7 @@ jobs:
           checkpoint_required=false
           if [[ "$APPROVAL_CHECKPOINTS" == "true" ]]; then
             evidence_summary="Mantis ran Slack native approval QA inside a Crabbox Linux VNC desktop, rendered pending/resolved approval checkpoints from the Slack API messages, and stored Slack QA artifacts."
+            expected_result="Slack native exec and plugin approval checkpoints pass"
             screenshot_required=false
             desktop_capture_inline=false
             if [[ "$status" == "pass" ]]; then
@@ -372,10 +373,8 @@ jobs:
             checkpoint_scenarios=()
             if [[ "$scenario_label" == "approval-checkpoints" ]]; then
               checkpoint_scenarios=("slack-approval-exec-native" "slack-approval-plugin-native")
-              expected_result="Slack native exec and plugin approval checkpoints pass"
             else
               checkpoint_scenarios=("$scenario_label")
-              expected_result="Slack approval checkpoint passes for $scenario_label"
             fi
             checkpoint_scenarios_json="$(printf '%s\n' "${checkpoint_scenarios[@]}" | jq -R . | jq -s .)"
             checkpoint_artifacts="$(
@@ -384,16 +383,12 @@ jobs:
                 --argjson scenario_ids "$checkpoint_scenarios_json" \
                 '
                   def scenario_kind($id):
-                    if ($id | endswith("-exec-native")) then "exec"
-                    elif ($id | endswith("-plugin-native")) then "plugin"
+                    if $id == "slack-approval-exec-native" then "exec"
+                    elif $id == "slack-approval-plugin-native" then "plugin"
                     else error("unsupported approval checkpoint scenario: \($id)")
                     end;
                   def scenario_title($id):
-                    if ($id | startswith("slack-codex-")) then
-                      "Codex \(scenario_kind($id))"
-                    elif scenario_kind($id) == "exec" then "Exec"
-                    else "Plugin"
-                    end;
+                    if scenario_kind($id) == "exec" then "Exec" else "Plugin" end;
                   [
                     $scenario_ids[] as $id
                     | ["pending", "resolved"][] as $state

--- a/.github/workflows/native-app-locale-refresh.yml
+++ b/.github/workflows/native-app-locale-refresh.yml
@@ -71,167 +71,51 @@ jobs:
 
       - name: Ensure translation provider secrets exist
         env:
-          OPENCLAW_DOCS_I18N_OPENAI_API_KEY: ${{ secrets.OPENCLAW_DOCS_I18N_OPENAI_API_KEY }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENCLAW_DOCS_I18N_OPENAI_API_KEY || secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
           set -euo pipefail
-          if [ -z "${OPENCLAW_DOCS_I18N_OPENAI_API_KEY:-}" ] && [ -z "${OPENAI_API_KEY:-}" ] && [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+          if [ -z "${OPENAI_API_KEY:-}" ] && [ -z "${ANTHROPIC_API_KEY:-}" ]; then
             echo "Missing OPENCLAW_DOCS_I18N_OPENAI_API_KEY, OPENAI_API_KEY, or ANTHROPIC_API_KEY secret."
             exit 1
           fi
 
       - name: Refresh native locale artifact
         env:
-          OPENCLAW_DOCS_I18N_OPENAI_API_KEY: ${{ secrets.OPENCLAW_DOCS_I18N_OPENAI_API_KEY }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENCLAW_DOCS_I18N_OPENAI_API_KEY || secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          ANTHROPIC_MODEL: claude-opus-4-8
-          OPENAI_MODEL: ${{ vars.OPENCLAW_CI_OPENAI_MODEL_BARE || 'gpt-5.5' }}
+          OPENCLAW_CONTROL_UI_I18N_PROVIDER: ${{ secrets.ANTHROPIC_API_KEY != '' && 'anthropic' || 'openai' }}
+          OPENCLAW_CONTROL_UI_I18N_MODEL: ${{ secrets.ANTHROPIC_API_KEY != '' && 'claude-opus-4-8' || vars.OPENCLAW_CI_OPENAI_MODEL_BARE }}
           OPENCLAW_CONTROL_UI_I18N_THINKING: low
           OPENCLAW_CONTROL_UI_I18N_AUTH_OPTIONAL: "0"
           LOCALE: ${{ matrix.locale }}
-        run: |
-          set -euo pipefail
+        run: node --import tsx scripts/native-app-i18n.ts sync --write --locale "${LOCALE}"
 
-          run_refresh() {
-            local provider="$1"
-            local model="$2"
-            local openai_api_key="${3-}"
-            if [ "$provider" = "openai" ]; then
-              OPENAI_API_KEY="$openai_api_key" \
-                OPENCLAW_CONTROL_UI_I18N_PROVIDER="$provider" \
-                OPENCLAW_CONTROL_UI_I18N_MODEL="$model" \
-                node --import tsx scripts/native-app-i18n.ts sync --write --locale "${LOCALE}"
-              return
-            fi
-            OPENCLAW_CONTROL_UI_I18N_PROVIDER="$provider" \
-              OPENCLAW_CONTROL_UI_I18N_MODEL="$model" \
-              node --import tsx scripts/native-app-i18n.ts sync --write --locale "${LOCALE}"
-          }
-
-          run_openai_refresh() {
-            local status=1
-            if [ -n "${OPENCLAW_DOCS_I18N_OPENAI_API_KEY:-}" ]; then
-              set +e
-              run_refresh openai "${OPENAI_MODEL}" "${OPENCLAW_DOCS_I18N_OPENAI_API_KEY}"
-              status="$?"
-              set -e
-              if [ "$status" -eq 0 ]; then
-                return 0
-              fi
-              if [ -z "${OPENAI_API_KEY:-}" ] || [ "${OPENAI_API_KEY}" = "${OPENCLAW_DOCS_I18N_OPENAI_API_KEY}" ]; then
-                return "$status"
-              fi
-              echo "::warning::Docs OpenAI native locale refresh key failed for ${LOCALE}; retrying with repository OpenAI key."
-            fi
-            if [ -z "${OPENAI_API_KEY:-}" ]; then
-              return "$status"
-            fi
-            run_refresh openai "${OPENAI_MODEL}" "${OPENAI_API_KEY}"
-          }
-
-          if [ -n "${ANTHROPIC_API_KEY:-}" ]; then
-            set +e
-            run_refresh anthropic "${ANTHROPIC_MODEL}"
-            status="$?"
-            set -e
-            if [ "$status" -eq 0 ]; then
-              exit 0
-            fi
-            if [ -z "${OPENCLAW_DOCS_I18N_OPENAI_API_KEY:-}" ] && [ -z "${OPENAI_API_KEY:-}" ]; then
-              exit "$status"
-            fi
-            echo "::warning::Anthropic native locale refresh failed for ${LOCALE}; retrying with OpenAI."
-          fi
-
-          run_openai_refresh
-
-      - name: Prepare locale artifact
+      - name: Commit and push locale artifact
         env:
           LOCALE: ${{ matrix.locale }}
-        run: |
-          set -euo pipefail
-          artifact_dir="${RUNNER_TEMP}/native-locale-${LOCALE}"
-          mkdir -p "${artifact_dir}"
-          git add -A apps/.i18n/native
-          git diff --cached --binary --full-index -- apps/.i18n/native > "${artifact_dir}/${LOCALE}.patch"
-
-      - name: Upload locale artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: native-locale-${{ matrix.locale }}
-          path: ${{ runner.temp }}/native-locale-${{ matrix.locale }}/${{ matrix.locale }}.patch
-          if-no-files-found: error
-          retention-days: 1
-
-  finalize:
-    name: Commit native locale refresh
-    needs: refresh
-    if: needs.refresh.result == 'success'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-        with:
-          fetch-depth: 0
-          persist-credentials: true
-          submodules: false
-
-      - name: Download locale artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          pattern: native-locale-*
-          path: ${{ runner.temp }}/native-locale-artifacts
-          merge-multiple: true
-
-      - name: Apply locale artifacts
-        run: |
-          set -euo pipefail
-          while IFS= read -r patch; do
-            if [ -s "${patch}" ]; then
-              git apply "${patch}"
-            fi
-          done < <(find "${RUNNER_TEMP}/native-locale-artifacts" -type f -name '*.patch' | sort)
-
-      - name: Setup Node environment
-        uses: ./.github/actions/setup-node-env
-        with:
-          install-bun: "false"
-
-      # Every worker observes the same source inventory. Generate it once here
-      # so locale patches remain independent and can be applied sequentially.
-      - name: Refresh shared native inventory
-        run: node --import tsx scripts/native-app-i18n.ts sync --write
-
-      - name: Validate native locale refresh
-        run: node --import tsx scripts/native-app-i18n.ts check
-
-      - name: Commit and push aggregate locale refresh
-        env:
           TARGET_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           set -euo pipefail
           if ! git status --porcelain -- apps/.i18n/native apps/.i18n/native-source.json | grep -q .; then
-            echo "No native locale changes."
+            echo "No native locale changes for ${LOCALE}."
             exit 0
           fi
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add -A apps/.i18n/native apps/.i18n/native-source.json
-          git commit --no-verify -m "chore(i18n): refresh native locales"
+          git commit --no-verify -m "chore(i18n): refresh native ${LOCALE} locale"
 
           for attempt in 1 2 3 4 5; do
             git fetch origin "${TARGET_BRANCH}"
-            git rebase "origin/${TARGET_BRANCH}"
+            git rebase --autostash "origin/${TARGET_BRANCH}"
             if git push origin HEAD:"${TARGET_BRANCH}"; then
               exit 0
             fi
-            git rebase --abort >/dev/null 2>&1 || true
-            echo "Aggregate push attempt ${attempt} failed; retrying."
+            echo "Push attempt ${attempt} for ${LOCALE} failed; retrying."
             sleep $((attempt * 2))
           done
 
-          echo "Failed to push aggregate native locale update after retries."
+          echo "Failed to push ${LOCALE} native locale update after retries."
           exit 1

--- a/.github/workflows/openclaw-npm-release.yml
+++ b/.github/workflows/openclaw-npm-release.yml
@@ -24,10 +24,6 @@ on:
         description: Approved OpenClaw Release Publish workflow run id
         required: false
         type: string
-      plugin_npm_run_id:
-        description: Successful Plugin NPM Release run id for the exact extended-stable branch and release SHA
-        required: false
-        type: string
       npm_dist_tag:
         description: npm dist-tag to publish to
         required: true
@@ -37,12 +33,6 @@ on:
           - alpha
           - beta
           - latest
-          - extended-stable
-      bypass_extended_stable_guard:
-        description: Testing only; relax the extended-stable patch and protected-main month policy on the canonical extended-stable branch
-        required: true
-        default: false
-        type: boolean
 
 concurrency:
   group: ${{ github.event_name == 'workflow_dispatch' && inputs.preflight_only && format('openclaw-npm-release-{0}-{1}-preflight', inputs.tag, inputs.npm_dist_tag) || github.event_name == 'workflow_dispatch' && format('openclaw-npm-release-{0}-{1}-publish-{2}', inputs.tag, inputs.npm_dist_tag, github.run_id) || format('openclaw-npm-release-{0}', github.ref) }}
@@ -130,14 +120,6 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           install-bun: "true"
 
-      - name: Validate npm release request
-        env:
-          BYPASS_EXTENDED_STABLE_GUARD: ${{ inputs.bypass_extended_stable_guard }}
-          RELEASE_NPM_DIST_TAG: ${{ inputs.npm_dist_tag }}
-          RELEASE_TAG: ${{ inputs.tag }}
-          NPM_WORKFLOW_REF: ${{ github.ref }}
-        run: node scripts/openclaw-npm-extended-stable-release.mjs validate-request
-
       - name: Ensure version is not already published
         env:
           PREFLIGHT_ONLY: ${{ inputs.preflight_only }}
@@ -173,23 +155,6 @@ jobs:
 
       - name: Build
         run: pnpm build
-
-      - name: Pack AI runtime package
-        id: ai_runtime_tarballs
-        run: |
-          set -euo pipefail
-          PACKAGE_VERSION="$(node -p "require('./package.json').version")"
-          package_version="$(node -p "require('./packages/ai/package.json').version")"
-          if [[ "$package_version" != "$PACKAGE_VERSION" ]]; then
-            echo "packages/ai version ${package_version} does not match openclaw ${PACKAGE_VERSION}." >&2
-            exit 1
-          fi
-          ARTIFACT_DIR="$RUNNER_TEMP/openclaw-ai-runtime-packages"
-          rm -rf "$ARTIFACT_DIR"
-          mkdir -p "$ARTIFACT_DIR"
-          pnpm --dir packages/ai pack --pack-destination "$ARTIFACT_DIR"
-          (cd "$ARTIFACT_DIR" && sha256sum ./*.tgz > SHA256SUMS)
-          echo "dir=$ARTIFACT_DIR" >> "$GITHUB_OUTPUT"
 
       - name: Build Control UI
         run: pnpm ui:build
@@ -254,11 +219,10 @@ jobs:
           RELEASE_REF: ${{ inputs.tag }}
           RELEASE_NPM_DIST_TAG: ${{ inputs.npm_dist_tag }}
           DEPENDENCY_EVIDENCE_DIR: ${{ steps.dependency_evidence.outputs.dir }}
-          AI_RUNTIME_TARBALL_DIR: ${{ steps.ai_runtime_tarballs.outputs.dir }}
         run: |
           set -euo pipefail
           PACK_OUTPUT="$RUNNER_TEMP/npm-pack-output.txt"
-          pnpm pack --json 2>&1 | tee "$PACK_OUTPUT"
+          npm pack --json 2>&1 | tee "$PACK_OUTPUT"
           PACK_NAME="$(node - "$PACK_OUTPUT" <<'NODE'
           const fs = require("node:fs");
           const path = require("node:path");
@@ -266,23 +230,19 @@ jobs:
 
           function resolveTarballFileName(value) {
             const fileName = typeof value === "string" ? value.trim() : "";
-            const resolved = path.resolve(fileName);
             if (
               !fileName.endsWith(".tgz") ||
               fileName.includes("\0") ||
               fileName !== path.basename(fileName) ||
-              fileName !== path.win32.basename(fileName) ||
-              path.dirname(resolved) !== process.cwd()
+              fileName !== path.win32.basename(fileName)
             ) {
               console.error(`npm pack reported unsafe tarball filename ${JSON.stringify(fileName)}.`);
               process.exit(1);
             }
-            return path.basename(resolved);
+            return fileName;
           }
 
-          function jsonEndFrom(start) {
-            const opening = input[start];
-            const closing = opening === "[" ? "]" : "}";
+          function arrayEndFrom(start) {
             let depth = 0;
             let inString = false;
             let escape = false;
@@ -300,9 +260,9 @@ jobs:
               }
               if (char === "\"") {
                 inString = true;
-              } else if (char === opening) {
+              } else if (char === "[") {
                 depth += 1;
-              } else if (char === closing) {
+              } else if (char === "]") {
                 depth -= 1;
                 if (depth === 0) {
                   return i + 1;
@@ -312,15 +272,15 @@ jobs:
             return -1;
           }
 
-          for (const match of input.matchAll(/[\[{]/g)) {
+          for (const match of input.matchAll(/\[/g)) {
             const start = match.index;
-            const end = jsonEndFrom(start);
+            const end = arrayEndFrom(start);
             if (end === -1) {
               continue;
             }
             try {
               const parsed = JSON.parse(input.slice(start, end));
-              const first = Array.isArray(parsed) ? parsed[0] : parsed;
+              const first = Array.isArray(parsed) ? parsed[0] : null;
               if (first && Object.prototype.hasOwnProperty.call(first, "filename")) {
                 process.stdout.write(resolveTarballFileName(first.filename));
                 process.exit(0);
@@ -352,8 +312,6 @@ jobs:
           rm -rf "$ARTIFACT_DIR"
           mkdir -p "$ARTIFACT_DIR"
           cp "$PACK_PATH" "$ARTIFACT_DIR/"
-          cp "$AI_RUNTIME_TARBALL_DIR"/*.tgz "$ARTIFACT_DIR/"
-          cp "$AI_RUNTIME_TARBALL_DIR/SHA256SUMS" "$ARTIFACT_DIR/ai-runtime-SHA256SUMS"
           cp -R "$DEPENDENCY_EVIDENCE_DIR" "$ARTIFACT_DIR/dependency-evidence"
           printf '%s\n' "$RELEASE_TAG" > "$ARTIFACT_DIR/release-tag.txt"
           printf '%s\n' "$RELEASE_SHA" > "$ARTIFACT_DIR/release-sha.txt"
@@ -386,16 +344,14 @@ jobs:
           PREFLIGHT_ARTIFACT_DIR: ${{ steps.packed_tarball.outputs.dir }}
         run: |
           set -euo pipefail
-          TARBALL_PATH="$(find "$PREFLIGHT_ARTIFACT_DIR" -maxdepth 1 -type f -name 'openclaw-[0-9]*.tgz' -print | sort | tail -n 1)"
+          TARBALL_PATH="$(find "$PREFLIGHT_ARTIFACT_DIR" -maxdepth 1 -type f -name '*.tgz' -print | sort | tail -n 1)"
           if [[ -z "$TARBALL_PATH" ]]; then
             echo "Prepared preflight tarball not found." >&2
             ls -la "$PREFLIGHT_ARTIFACT_DIR" >&2 || true
             exit 1
           fi
           PACKAGE_VERSION="$(node -p "require('./package.json').version")"
-          AI_TARBALL="$(find "$PREFLIGHT_ARTIFACT_DIR" -maxdepth 1 -type f -name 'openclaw-ai-*.tgz' -print | head -n 1)"
-          node --import tsx scripts/openclaw-npm-prepublish-verify.ts \
-            "$TARBALL_PATH" "$PACKAGE_VERSION" "$AI_TARBALL"
+          node --import tsx scripts/openclaw-npm-prepublish-verify.ts "$TARBALL_PATH" "$PACKAGE_VERSION"
 
       - name: Upload dependency release evidence
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -439,14 +395,6 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Validate npm release request
-        env:
-          BYPASS_EXTENDED_STABLE_GUARD: ${{ inputs.bypass_extended_stable_guard }}
-          RELEASE_NPM_DIST_TAG: ${{ inputs.npm_dist_tag }}
-          RELEASE_TAG: ${{ inputs.tag }}
-          NPM_WORKFLOW_REF: ${{ github.ref }}
-        run: node scripts/openclaw-npm-extended-stable-release.mjs validate-request
-
       - name: Require trusted workflow ref for publish
         env:
           RELEASE_TAG: ${{ inputs.tag }}
@@ -455,15 +403,11 @@ jobs:
         run: |
           set -euo pipefail
           tideclaw_alpha_publish=false
-          extended_stable_publish=false
           if [[ "${RELEASE_TAG}" == *"-alpha."* && "${RELEASE_NPM_DIST_TAG}" == "alpha" && "${WORKFLOW_REF}" =~ ^refs/heads/tideclaw/alpha/[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{4}Z$ ]]; then
             tideclaw_alpha_publish=true
           fi
-          if [[ "${RELEASE_NPM_DIST_TAG}" == "extended-stable" && "${WORKFLOW_REF}" == refs/heads/extended-stable/* ]]; then
-            extended_stable_publish=true
-          fi
-          if [[ "${WORKFLOW_REF}" != "refs/heads/main" ]] && [[ ! "${WORKFLOW_REF}" =~ ^refs/heads/release/[0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*$ ]] && [[ "${tideclaw_alpha_publish}" != "true" ]] && [[ "${extended_stable_publish}" != "true" ]]; then
-            echo "Real publish runs must be dispatched from main, release/YYYY.M.PATCH, the exact validated extended-stable branch, or a Tideclaw alpha branch for alpha prereleases. Use preflight_only=true for other branch validation."
+          if [[ "${WORKFLOW_REF}" != "refs/heads/main" ]] && [[ ! "${WORKFLOW_REF}" =~ ^refs/heads/release/[0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*$ ]] && [[ "${tideclaw_alpha_publish}" != "true" ]]; then
+            echo "Real publish runs must be dispatched from main, release/YYYY.M.PATCH, or a Tideclaw alpha branch for alpha prereleases. Use preflight_only=true for other branch validation."
             exit 1
           fi
 
@@ -473,7 +417,6 @@ jobs:
           RELEASE_NPM_DIST_TAG: ${{ inputs.npm_dist_tag }}
           PREFLIGHT_RUN_ID: ${{ inputs.preflight_run_id }}
           FULL_RELEASE_VALIDATION_RUN_ID: ${{ inputs.full_release_validation_run_id }}
-          PLUGIN_NPM_RUN_ID: ${{ inputs.plugin_npm_run_id }}
           RELEASE_PUBLISH_RUN_ID: ${{ inputs.release_publish_run_id }}
         run: |
           set -euo pipefail
@@ -488,10 +431,6 @@ jobs:
               echo "Real publish requires full_release_validation_run_id from a successful Full Release Validation run." >&2
               exit 1
             fi
-          fi
-          if [[ "${RELEASE_NPM_DIST_TAG}" == "extended-stable" && -z "${PLUGIN_NPM_RUN_ID// }" ]]; then
-            echo "Extended-stable publish requires plugin_npm_run_id from a successful Plugin NPM Release run." >&2
-            exit 1
           fi
           if [[ -z "${RELEASE_PUBLISH_RUN_ID// }" && "${GITHUB_ACTOR}" == "github-actions[bot]" ]]; then
             echo "Workflow-dispatched real publish requires release_publish_run_id from the approved OpenClaw Release Publish workflow." >&2
@@ -602,45 +541,20 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           PREFLIGHT_RUN_ID: ${{ inputs.preflight_run_id }}
-          RELEASE_NPM_DIST_TAG: ${{ inputs.npm_dist_tag }}
-          EXPECTED_EXTENDED_STABLE_BRANCH: ${{ github.ref_name }}
-          RUN_KIND: preflight
         run: |
           set -euo pipefail
-          EXPECTED_RELEASE_SHA="$(git rev-parse HEAD)"
-          export EXPECTED_RELEASE_SHA
-          RUN_JSON="$(gh run view "$PREFLIGHT_RUN_ID" --repo "$GITHUB_REPOSITORY" --json workflowName,headBranch,headSha,event,conclusion,url)"
-          printf '%s' "$RUN_JSON" | node scripts/openclaw-npm-extended-stable-release.mjs verify-run
+          RUN_JSON="$(gh run view "$PREFLIGHT_RUN_ID" --repo "$GITHUB_REPOSITORY" --json workflowName,headBranch,event,conclusion,url)"
+          printf '%s' "$RUN_JSON" | node -e 'const fs = require("node:fs"); const run = JSON.parse(fs.readFileSync(0, "utf8")); const checks = [["workflowName", "OpenClaw NPM Release"], ["event", "workflow_dispatch"], ["conclusion", "success"]]; for (const [key, expected] of checks) { if (run[key] !== expected) { console.error(`Referenced npm preflight run ${process.env.PREFLIGHT_RUN_ID} must have ${key}=${expected}, got ${run[key] ?? "<missing>"}.`); process.exit(1); } } console.log(`Using npm preflight run ${process.env.PREFLIGHT_RUN_ID} from ${run.headBranch}: ${run.url}`);'
 
       - name: Verify full release validation run metadata
         if: ${{ inputs.full_release_validation_run_id != '' }}
         env:
           GH_TOKEN: ${{ github.token }}
           FULL_RELEASE_VALIDATION_RUN_ID: ${{ inputs.full_release_validation_run_id }}
-          RELEASE_NPM_DIST_TAG: ${{ inputs.npm_dist_tag }}
-          EXPECTED_EXTENDED_STABLE_BRANCH: ${{ github.ref_name }}
-          RUN_KIND: validation
         run: |
           set -euo pipefail
-          EXPECTED_RELEASE_SHA="$(git rev-parse HEAD)"
-          export EXPECTED_RELEASE_SHA
-          RUN_JSON="$(gh run view "$FULL_RELEASE_VALIDATION_RUN_ID" --repo "$GITHUB_REPOSITORY" --json workflowName,headBranch,headSha,event,status,conclusion,url)"
-          printf '%s' "$RUN_JSON" | node scripts/openclaw-npm-extended-stable-release.mjs verify-run
-
-      - name: Verify plugin npm release run metadata
-        if: ${{ inputs.npm_dist_tag == 'extended-stable' }}
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PLUGIN_NPM_RUN_ID: ${{ inputs.plugin_npm_run_id }}
-          RELEASE_NPM_DIST_TAG: ${{ inputs.npm_dist_tag }}
-          EXPECTED_EXTENDED_STABLE_BRANCH: ${{ github.ref_name }}
-          RUN_KIND: plugin
-        run: |
-          set -euo pipefail
-          EXPECTED_RELEASE_SHA="$(git rev-parse HEAD)"
-          export EXPECTED_RELEASE_SHA
-          RUN_JSON="$(gh run view "$PLUGIN_NPM_RUN_ID" --repo "$GITHUB_REPOSITORY" --json workflowName,displayTitle,headBranch,headSha,event,status,conclusion,url)"
-          printf '%s' "$RUN_JSON" | node scripts/openclaw-npm-extended-stable-release.mjs verify-run
+          RUN_JSON="$(gh run view "$FULL_RELEASE_VALIDATION_RUN_ID" --repo "$GITHUB_REPOSITORY" --json workflowName,headBranch,event,status,conclusion,url)"
+          printf '%s' "$RUN_JSON" | node -e 'const fs = require("node:fs"); const run = JSON.parse(fs.readFileSync(0, "utf8")); const checks = [["workflowName", "Full Release Validation"], ["event", "workflow_dispatch"], ["status", "completed"], ["conclusion", "success"]]; for (const [key, expected] of checks) { if (run[key] !== expected) { console.error(`Referenced full release validation run ${process.env.FULL_RELEASE_VALIDATION_RUN_ID} must have ${key}=${expected}, got ${run[key] ?? "<missing>"}.`); process.exit(1); } } console.log(`Using full release validation run ${process.env.FULL_RELEASE_VALIDATION_RUN_ID} from ${run.headBranch}: ${run.url}`);'
 
       - name: Download prepared npm tarball
         env:
@@ -722,7 +636,6 @@ jobs:
           pnpm release:openclaw:npm:check
 
       - name: Verify prepared tarball provenance
-        id: preflight_provenance
         env:
           RELEASE_TAG: ${{ inputs.tag }}
           RELEASE_NPM_DIST_TAG: ${{ inputs.npm_dist_tag }}
@@ -740,11 +653,6 @@ jobs:
           ARTIFACT_RELEASE_NPM_DIST_TAG="$(jq -r '.npmDistTag // ""' "$MANIFEST_FILE")"
           ARTIFACT_TARBALL_NAME="$(jq -r '.tarballName // ""' "$MANIFEST_FILE")"
           ARTIFACT_TARBALL_SHA256="$(jq -r '.tarballSha256 // ""' "$MANIFEST_FILE")"
-          if [[ -z "$ARTIFACT_TARBALL_NAME" || "$ARTIFACT_TARBALL_NAME" != "$(basename -- "$ARTIFACT_TARBALL_NAME")" || "$ARTIFACT_TARBALL_NAME" != *.tgz ]]; then
-            echo "Prepared preflight tarball name is unsafe: $ARTIFACT_TARBALL_NAME" >&2
-            exit 1
-          fi
-          ARTIFACT_TARBALL_PATH="preflight-tarball/$ARTIFACT_TARBALL_NAME"
           if [[ "$ARTIFACT_RELEASE_TAG" != "$RELEASE_TAG" ]]; then
             echo "Prepared preflight tag mismatch: expected $RELEASE_TAG, got $ARTIFACT_RELEASE_TAG" >&2
             exit 1
@@ -757,30 +665,20 @@ jobs:
             echo "Prepared preflight npm dist-tag mismatch: expected $RELEASE_NPM_DIST_TAG, got $ARTIFACT_RELEASE_NPM_DIST_TAG" >&2
             exit 1
           fi
-          if [[ ! -f "$ARTIFACT_TARBALL_PATH" ]]; then
+          if [[ -z "$ARTIFACT_TARBALL_NAME" || ! -f "preflight-tarball/$ARTIFACT_TARBALL_NAME" ]]; then
             echo "Prepared preflight tarball named in manifest is missing: $ARTIFACT_TARBALL_NAME" >&2
             exit 1
           fi
-          actual_tarball_sha256="$(sha256sum "$ARTIFACT_TARBALL_PATH" | awk '{print $1}')"
+          actual_tarball_sha256="$(sha256sum "preflight-tarball/$ARTIFACT_TARBALL_NAME" | awk '{print $1}')"
           if [[ "$actual_tarball_sha256" != "$ARTIFACT_TARBALL_SHA256" ]]; then
             echo "Prepared preflight tarball digest mismatch." >&2
             exit 1
           fi
-          if [[ ! -f preflight-tarball/ai-runtime-SHA256SUMS ]]; then
-            echo "Prepared AI runtime dependency checksums are missing." >&2
-            exit 1
-          fi
-          (cd preflight-tarball && sha256sum -c ai-runtime-SHA256SUMS)
-          echo "tarball_name=$ARTIFACT_TARBALL_NAME" >> "$GITHUB_OUTPUT"
-          echo "tarball_sha256=$ARTIFACT_TARBALL_SHA256" >> "$GITHUB_OUTPUT"
-          echo "tarball_path=$ARTIFACT_TARBALL_PATH" >> "$GITHUB_OUTPUT"
 
       - name: Verify full release validation target
         if: ${{ inputs.full_release_validation_run_id != '' }}
         env:
           RELEASE_TAG: ${{ inputs.tag }}
-          RELEASE_NPM_DIST_TAG: ${{ inputs.npm_dist_tag }}
-          EXPECTED_WORKFLOW_REF: ${{ github.ref_name }}
         run: |
           set -euo pipefail
           EXPECTED_RELEASE_SHA="$(git rev-parse HEAD)"
@@ -790,11 +688,19 @@ jobs:
             ls -la full-release-validation >&2 || true
             exit 1
           fi
-          export EXPECTED_RELEASE_SHA MANIFEST_FILE
-          node scripts/openclaw-npm-extended-stable-release.mjs verify-manifest
+          WORKFLOW_NAME="$(jq -r '.workflowName // ""' "$MANIFEST_FILE")"
+          TARGET_SHA="$(jq -r '.targetSha // ""' "$MANIFEST_FILE")"
           RERUN_GROUP="$(jq -r '.rerunGroup // ""' "$MANIFEST_FILE")"
           RUN_RELEASE_SOAK="$(jq -r '.runReleaseSoak // ""' "$MANIFEST_FILE")"
           PERFORMANCE_BLOCKING="$(jq -r '.controls.performanceBlocking // false' "$MANIFEST_FILE")"
+          if [[ "$WORKFLOW_NAME" != "Full Release Validation" ]]; then
+            echo "Full release validation manifest workflow mismatch: $WORKFLOW_NAME" >&2
+            exit 1
+          fi
+          if [[ "$TARGET_SHA" != "$EXPECTED_RELEASE_SHA" ]]; then
+            echo "Full release validation target SHA mismatch: expected $EXPECTED_RELEASE_SHA, got $TARGET_SHA" >&2
+            exit 1
+          fi
           if [[ "$RERUN_GROUP" != "all" ]]; then
             echo "Full release validation must run rerun_group=all before npm publish; got $RERUN_GROUP" >&2
             exit 1
@@ -808,97 +714,27 @@ jobs:
             exit 1
           fi
 
-      - name: Recheck npm release request
-        env:
-          BYPASS_EXTENDED_STABLE_GUARD: ${{ inputs.bypass_extended_stable_guard }}
-          RELEASE_NPM_DIST_TAG: ${{ inputs.npm_dist_tag }}
-          RELEASE_TAG: ${{ inputs.tag }}
-          NPM_WORKFLOW_REF: ${{ github.ref }}
-        run: node scripts/openclaw-npm-extended-stable-release.mjs validate-request
-
-      - name: Capture previous extended-stable selector
-        id: previous_extended_stable
-        if: ${{ inputs.npm_dist_tag == 'extended-stable' }}
-        run: node scripts/openclaw-npm-extended-stable-release.mjs capture-selector
+      - name: Resolve publish tarball
+        id: publish_tarball
+        run: |
+          set -euo pipefail
+          TARBALL_PATH="$(find preflight-tarball -type f -name '*.tgz' -print | sort | tail -n 1)"
+          if [[ -z "$TARBALL_PATH" ]]; then
+            echo "Prepared preflight tarball not found." >&2
+            ls -la preflight-tarball >&2 || true
+            exit 1
+          fi
+          echo "path=$TARBALL_PATH" >> "$GITHUB_OUTPUT"
 
       - name: Publish
-        id: publish
         env:
-          BYPASS_EXTENDED_STABLE_GUARD: ${{ inputs.bypass_extended_stable_guard }}
           OPENCLAW_PREPACK_PREPARED: "1"
           OPENCLAW_NPM_PUBLISH_TAG: ${{ inputs.npm_dist_tag }}
-          PUBLISH_TARBALL_PATH: ${{ steps.preflight_provenance.outputs.tarball_path }}
+          PUBLISH_TARBALL_PATH: ${{ steps.publish_tarball.outputs.path }}
         run: |
           set -euo pipefail
           publish_target="${PUBLISH_TARBALL_PATH}"
           if [[ -n "${publish_target}" ]]; then
             publish_target="./${publish_target}"
           fi
-          publish_if_missing() {
-            local package_name="$1"
-            local tarball_path="$2"
-            local package_version
-            if [[ -z "$tarball_path" || ! -f "$tarball_path" ]]; then
-              echo "Prepared tarball for ${package_name} was not found." >&2
-              exit 1
-            fi
-            package_version="$(node -p "require('./package.json').version")"
-            if npm view "${package_name}@${package_version}" version >/dev/null 2>&1; then
-              echo "${package_name}@${package_version} is already published; reusing it."
-              return 0
-            fi
-            bash scripts/openclaw-npm-publish.sh --publish "./${tarball_path}"
-          }
-          publish_if_missing "@openclaw/ai" "$(find preflight-tarball -type f -name 'openclaw-ai-*.tgz' -print | head -n 1)"
           bash scripts/openclaw-npm-publish.sh --publish "${publish_target}"
-
-      - name: Verify extended-stable registry readback
-        id: extended_stable_readback
-        if: ${{ success() && inputs.npm_dist_tag == 'extended-stable' }}
-        env:
-          EXPECTED_VERSION: ${{ inputs.tag }}
-        run: node scripts/openclaw-npm-extended-stable-release.mjs verify-readback
-
-      - name: Summarize extended-stable npm publication
-        if: ${{ always() && inputs.npm_dist_tag == 'extended-stable' }}
-        env:
-          BYPASS_EXTENDED_STABLE_GUARD: ${{ inputs.bypass_extended_stable_guard }}
-          RELEASE_TAG: ${{ inputs.tag }}
-          RELEASE_SHA: ${{ github.sha }}
-          EXTENDED_STABLE_BRANCH: ${{ github.ref_name }}
-          PREFLIGHT_RUN_ID: ${{ inputs.preflight_run_id }}
-          FULL_RELEASE_VALIDATION_RUN_ID: ${{ inputs.full_release_validation_run_id }}
-          TARBALL_NAME: ${{ steps.preflight_provenance.outputs.tarball_name }}
-          TARBALL_SHA256: ${{ steps.preflight_provenance.outputs.tarball_sha256 }}
-          SELECTOR_CAPTURE_OUTCOME: ${{ steps.previous_extended_stable.outcome }}
-          PREVIOUS_EXTENDED_STABLE: ${{ steps.previous_extended_stable.outputs.previous }}
-          PUBLISH_OUTCOME: ${{ steps.publish.outcome }}
-          EXACT_READBACK: ${{ steps.extended_stable_readback.outputs.exact_version }}
-          SELECTOR_READBACK: ${{ steps.extended_stable_readback.outputs.extended_stable_selector }}
-          READBACK_OUTCOME: ${{ steps.extended_stable_readback.outcome }}
-        run: |
-          set -euo pipefail
-          release_version="${RELEASE_TAG#v}"
-          {
-            echo "## npm extended-stable publication"
-            echo "- Package: openclaw@${release_version}"
-            echo "- Extended-stable guard bypass: ${BYPASS_EXTENDED_STABLE_GUARD}"
-            echo "- Extended-stable branch: ${EXTENDED_STABLE_BRANCH}"
-            echo "- Release tag: ${RELEASE_TAG}"
-            echo "- Release SHA: ${RELEASE_SHA}"
-            echo "- npm preflight run: ${PREFLIGHT_RUN_ID}"
-            echo "- Full Release Validation run: ${FULL_RELEASE_VALIDATION_RUN_ID}"
-            echo "- Tarball: ${TARBALL_NAME:-unavailable}"
-            echo "- Tarball SHA-256: ${TARBALL_SHA256:-unavailable}"
-            echo "- Previous openclaw@extended-stable: ${PREVIOUS_EXTENDED_STABLE:-unavailable}"
-            echo "- npm publish outcome: ${PUBLISH_OUTCOME}"
-            echo "- Exact-version readback: ${EXACT_READBACK:-unavailable}"
-            echo "- Extended-stable selector readback: ${SELECTOR_READBACK:-unavailable}"
-            echo "- Registry readback outcome: ${READBACK_OUTCOME}"
-            if [[ "$SELECTOR_CAPTURE_OUTCOME" != "success" ]]; then
-              echo "- Selector capture failed; npm publish did not run and no repair is required because npm was unchanged."
-            else
-              repair_command="$(EXPECTED_VERSION="$RELEASE_TAG" node scripts/openclaw-npm-extended-stable-release.mjs repair-command)"
-              echo "- Repair command: \`${repair_command}\`"
-            fi
-          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/openclaw-release-checks.yml
+++ b/.github/workflows/openclaw-release-checks.yml
@@ -137,8 +137,8 @@ jobs:
               tideclaw_alpha_check=true
             fi
           fi
-          if [[ "${WORKFLOW_REF}" != "refs/heads/main" ]] && [[ ! "${WORKFLOW_REF}" =~ ^refs/heads/release/[0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*$ ]] && [[ ! "${WORKFLOW_REF}" =~ ^refs/heads/release-ci/[0-9a-f]{12}-[0-9]+$ ]] && [[ ! "${WORKFLOW_REF}" =~ ^refs/heads/extended-stable/[0-9]{4}\.([1-9]|1[0-2])\.33$ ]] && [[ "${tideclaw_alpha_check}" != "true" ]]; then
-            echo "Release checks must be dispatched from main, release/YYYY.M.PATCH, extended-stable/YYYY.M.33, a Full Release Validation release-ci/<sha>-<timestamp> ref, or a Tideclaw alpha branch for alpha prereleases." >&2
+          if [[ "${WORKFLOW_REF}" != "refs/heads/main" ]] && [[ ! "${WORKFLOW_REF}" =~ ^refs/heads/release/[0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*$ ]] && [[ ! "${WORKFLOW_REF}" =~ ^refs/heads/release-ci/[0-9a-f]{12}-[0-9]+$ ]] && [[ "${tideclaw_alpha_check}" != "true" ]]; then
+            echo "Release checks must be dispatched from main, release/YYYY.M.PATCH, a Full Release Validation release-ci/<sha>-<timestamp> ref, or a Tideclaw alpha branch for alpha prereleases." >&2
             exit 1
           fi
 
@@ -538,7 +538,7 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           install-bun: "true"
-          install-deps: "true"
+          install-deps: "false"
 
       - name: Resolve release package artifact
         id: package

--- a/.github/workflows/plugin-npm-release.yml
+++ b/.github/workflows/plugin-npm-release.yml
@@ -1,5 +1,4 @@
 name: Plugin NPM Release
-run-name: ${{ github.event_name == 'workflow_dispatch' && format('Plugin NPM Release [{0}] {1}', inputs.npm_dist_tag, inputs.ref) || format('Plugin NPM Release [default] {0}', github.sha) }}
 
 on:
   push:
@@ -9,7 +8,6 @@ on:
       - ".github/workflows/plugin-npm-release.yml"
       - "extensions/**"
       - "package.json"
-      - "scripts/lib/npm-publish-plan.mjs"
       - "scripts/lib/plugin-npm-package-manifest.mjs"
       - "scripts/lib/plugin-npm-release.ts"
       - "scripts/plugin-npm-publish.sh"
@@ -27,7 +25,7 @@ on:
           - selected
           - all-publishable
       ref:
-        description: Commit SHA on main, a release branch, the canonical extended-stable branch, or the matching Tideclaw alpha branch to publish from
+        description: Commit SHA on main, a release branch, or the matching Tideclaw alpha branch to publish from
         required: true
         type: string
       plugins:
@@ -38,14 +36,6 @@ on:
         description: Approved OpenClaw Release Publish workflow run id
         required: false
         type: string
-      npm_dist_tag:
-        description: Optional npm dist-tag override
-        required: true
-        default: default
-        type: choice
-        options:
-          - default
-          - extended-stable
 
 concurrency:
   group: plugin-npm-release-${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref }}
@@ -65,7 +55,6 @@ jobs:
       has_candidates: ${{ steps.plan.outputs.has_candidates }}
       candidate_count: ${{ steps.plan.outputs.candidate_count }}
       matrix: ${{ steps.plan.outputs.matrix }}
-      all_matrix: ${{ steps.plan.outputs.all_matrix }}
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -86,37 +75,9 @@ jobs:
 
       - name: Validate ref is on a trusted publish branch
         env:
-          NPM_DIST_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.npm_dist_tag || 'default' }}
-          PUBLISH_SCOPE: ${{ github.event_name == 'workflow_dispatch' && inputs.publish_scope || '' }}
-          RELEASE_PLUGINS: ${{ github.event_name == 'workflow_dispatch' && inputs.plugins || '' }}
-          SOURCE_REF: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.sha }}
           WORKFLOW_REF: ${{ github.ref }}
         run: |
           set -euo pipefail
-          if [[ "${NPM_DIST_TAG}" == "extended-stable" ]]; then
-            if [[ "${PUBLISH_SCOPE}" != "all-publishable" || -n "${RELEASE_PLUGINS// }" ]]; then
-              echo "Extended-stable plugin publication requires publish_scope=all-publishable without an explicit plugin list." >&2
-              exit 1
-            fi
-            if [[ ! "${SOURCE_REF}" =~ ^[0-9a-f]{40}$ ]] || [[ "$(git rev-parse HEAD)" != "$(git rev-parse "${SOURCE_REF}^{commit}")" ]]; then
-              echo "Extended-stable plugin publication requires ref to be the exact 40-character source SHA." >&2
-              exit 1
-            fi
-            package_version="$(node -p "require('./package.json').version")"
-            if [[ ! "${package_version}" =~ ^([0-9]{4})\.([1-9]|1[0-2])\.([1-9][0-9]*)$ ]] || (( 10#${BASH_REMATCH[3]:-0} < 33 )); then
-              echo "Extended-stable plugin publication requires a final YYYY.M.PATCH version with PATCH >= 33." >&2
-              exit 1
-            fi
-            release_year="${BASH_REMATCH[1]}"
-            release_month="${BASH_REMATCH[2]}"
-            extended_stable_branch="extended-stable/${release_year}.${release_month}.33"
-            git fetch --no-tags origin "+refs/heads/${extended_stable_branch}:refs/remotes/origin/${extended_stable_branch}"
-            if [[ "${WORKFLOW_REF}" == "refs/heads/${extended_stable_branch}" ]] && [[ "$(git rev-parse HEAD)" == "$(git rev-parse "refs/remotes/origin/${extended_stable_branch}")" ]]; then
-              exit 0
-            fi
-            echo "Extended-stable plugin npm publishes must run from ${extended_stable_branch} at its exact branch tip." >&2
-            exit 1
-          fi
           git fetch --no-tags origin \
             +refs/heads/main:refs/remotes/origin/main \
             '+refs/heads/release/*:refs/remotes/origin/release/*'
@@ -144,16 +105,12 @@ jobs:
           RELEASE_PLUGINS: ${{ github.event_name == 'workflow_dispatch' && inputs.plugins || '' }}
           BASE_REF: ${{ github.event_name != 'workflow_dispatch' && github.event.before || '' }}
           HEAD_REF: ${{ steps.ref.outputs.sha }}
-          NPM_DIST_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.npm_dist_tag || 'default' }}
         run: |
           set -euo pipefail
           if [[ -n "${PUBLISH_SCOPE}" ]]; then
             release_args=(--selection-mode "${PUBLISH_SCOPE}")
             if [[ -n "${RELEASE_PLUGINS}" ]]; then
               release_args+=(--plugins "${RELEASE_PLUGINS}")
-            fi
-            if [[ "${NPM_DIST_TAG}" == "extended-stable" ]]; then
-              release_args+=(--npm-dist-tag "${NPM_DIST_TAG}")
             fi
             pnpm release:plugins:npm:check -- "${release_args[@]}"
           elif [[ -n "${BASE_REF}" ]]; then
@@ -169,7 +126,6 @@ jobs:
           RELEASE_PLUGINS: ${{ github.event_name == 'workflow_dispatch' && inputs.plugins || '' }}
           BASE_REF: ${{ github.event_name != 'workflow_dispatch' && github.event.before || '' }}
           HEAD_REF: ${{ steps.ref.outputs.sha }}
-          NPM_DIST_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.npm_dist_tag || 'default' }}
         run: |
           set -euo pipefail
           mkdir -p .local
@@ -177,9 +133,6 @@ jobs:
             plan_args=(--selection-mode "${PUBLISH_SCOPE}")
             if [[ -n "${RELEASE_PLUGINS}" ]]; then
               plan_args+=(--plugins "${RELEASE_PLUGINS}")
-            fi
-            if [[ "${NPM_DIST_TAG}" == "extended-stable" ]]; then
-              plan_args+=(--npm-dist-tag "${NPM_DIST_TAG}")
             fi
             node --import tsx scripts/plugin-npm-release-plan.ts "${plan_args[@]}" > .local/plugin-npm-release-plan.json
           elif [[ -n "${BASE_REF}" ]]; then
@@ -196,13 +149,11 @@ jobs:
             has_candidates="true"
           fi
           matrix_json="$(jq -c '.candidates' .local/plugin-npm-release-plan.json)"
-          all_matrix_json="$(jq -c '.all' .local/plugin-npm-release-plan.json)"
 
           {
             echo "candidate_count=${candidate_count}"
             echo "has_candidates=${has_candidates}"
             echo "matrix=${matrix_json}"
-            echo "all_matrix=${all_matrix_json}"
           } >> "$GITHUB_OUTPUT"
 
           echo "Plugin release candidates:"
@@ -286,13 +237,9 @@ jobs:
           install-bun: "false"
 
       - name: Preview publish command
-        env:
-          OPENCLAW_PLUGIN_NPM_PUBLISH_TAG: ${{ inputs.npm_dist_tag == 'extended-stable' && inputs.npm_dist_tag || '' }}
         run: bash scripts/plugin-npm-publish.sh --dry-run "${{ matrix.plugin.packageDir }}"
 
       - name: Preview npm pack contents
-        env:
-          OPENCLAW_PLUGIN_NPM_PUBLISH_TAG: ${{ inputs.npm_dist_tag == 'extended-stable' && inputs.npm_dist_tag || '' }}
         run: bash scripts/plugin-npm-publish.sh --pack-dry-run "${{ matrix.plugin.packageDir }}"
 
   publish_plugins_npm:
@@ -339,10 +286,9 @@ jobs:
       - name: Publish
         if: steps.npm_package_version.outputs.already_published != 'true'
         env:
-          NODE_AUTH_TOKEN: ${{ inputs.npm_dist_tag != 'extended-stable' && secrets.NPM_TOKEN || '' }}
-          NPM_TOKEN: ${{ inputs.npm_dist_tag != 'extended-stable' && secrets.NPM_TOKEN || '' }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           OPENCLAW_NPM_PUBLISH_AUTH_MODE: trusted-publisher
-          OPENCLAW_PLUGIN_NPM_PUBLISH_TAG: ${{ inputs.npm_dist_tag == 'extended-stable' && inputs.npm_dist_tag || '' }}
         run: bash scripts/plugin-npm-publish.sh --publish "${{ matrix.plugin.packageDir }}"
 
       - name: Verify published runtime
@@ -350,50 +296,3 @@ jobs:
           PACKAGE_NAME: ${{ matrix.plugin.packageName }}
           PACKAGE_VERSION: ${{ matrix.plugin.version }}
         run: node scripts/verify-plugin-npm-published-runtime.mjs "${PACKAGE_NAME}@${PACKAGE_VERSION}"
-
-  verify_plugins_npm:
-    needs: [preview_plugins_npm, publish_plugins_npm]
-    if: ${{ always() && github.event_name == 'workflow_dispatch' && inputs.npm_dist_tag == 'extended-stable' && needs.preview_plugins_npm.result == 'success' && (needs.publish_plugins_npm.result == 'success' || (needs.preview_plugins_npm.outputs.has_candidates == 'false' && needs.publish_plugins_npm.result == 'skipped')) }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        plugin: ${{ fromJson(needs.preview_plugins_npm.outputs.all_matrix) }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-        with:
-          persist-credentials: false
-          ref: ${{ needs.preview_plugins_npm.outputs.ref_revision }}
-          fetch-depth: 1
-
-      - name: Setup Node environment
-        uses: ./.github/actions/setup-node-env
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          install-bun: "false"
-
-      - name: Verify complete plugin registry readback
-        env:
-          PACKAGE_NAME: ${{ matrix.plugin.packageName }}
-          PACKAGE_VERSION: ${{ matrix.plugin.version }}
-        run: |
-          set -euo pipefail
-          exact_version=missing
-          tagged_version=missing
-          for attempt in {1..12}; do
-            exact_version="$(npm view "${PACKAGE_NAME}@${PACKAGE_VERSION}" version 2>/dev/null || true)"
-            tagged_version="$(npm view "${PACKAGE_NAME}@extended-stable" version 2>/dev/null || true)"
-            if [[ "${exact_version}" == "${PACKAGE_VERSION}" && "${tagged_version}" == "${PACKAGE_VERSION}" ]]; then
-              echo "Verified ${PACKAGE_NAME}@${PACKAGE_VERSION} and @extended-stable."
-              exit 0
-            fi
-            if [[ "${attempt}" != "12" ]]; then
-              sleep 10
-            fi
-          done
-          echo "npm registry did not converge for ${PACKAGE_NAME}@${PACKAGE_VERSION} (exact=${exact_version:-missing}, extended-stable=${tagged_version:-missing})." >&2
-          echo "This OIDC-only source workflow does not mutate tags on an already-published package; use credential-isolated release tooling for manual tag repair." >&2
-          exit 1

--- a/.github/workflows/security-sensitive-guard.yml
+++ b/.github/workflows/security-sensitive-guard.yml
@@ -9,6 +9,11 @@ permissions:
   pull-requests: write
   issues: write
 
+env:
+  # Temporary rollout bridge for PRs opened before this workflow's script landed.
+  # Remove once the pre-rollout PR set has drained.
+  OPENCLAW_SECURITY_SENSITIVE_GUARD_ROLLOUT_SHA: 5d9c010628ea4de3492a12e32f9be5b8c5dfa9ed
+
 concurrency:
   group: security-sensitive-guard-${{ github.event.pull_request.number }}
   cancel-in-progress: true
@@ -19,13 +24,40 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
+      - name: Check security-sensitive guard rollout eligibility
+        id: rollout
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          status="$(
+            gh api \
+              "repos/${GITHUB_REPOSITORY}/compare/${OPENCLAW_SECURITY_SENSITIVE_GUARD_ROLLOUT_SHA}...${PR_BASE_SHA}" \
+              --jq '.status'
+          )"
+          case "$status" in
+            ahead|identical)
+              echo "ready=true" >> "$GITHUB_OUTPUT"
+              ;;
+            behind|diverged)
+              echo "ready=false" >> "$GITHUB_OUTPUT"
+              echo "::notice::Skipping security-sensitive guard for a PR base that predates rollout commit ${OPENCLAW_SECURITY_SENSITIVE_GUARD_ROLLOUT_SHA}."
+              ;;
+            *)
+              echo "Unexpected compare status for security-sensitive guard rollout: $status" >&2
+              exit 1
+              ;;
+          esac
+
       - name: Check out trusted base workflow scripts
+        if: steps.rollout.outputs.ready == 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ github.workflow_sha }}
           persist-credentials: false
 
       - name: Detect security-sensitive changes
+        if: steps.rollout.outputs.ready == 'true'
         env:
           GITHUB_TOKEN: ${{ github.token }}
           OPENCLAW_SECURITY_APPROVERS: vincentkoc,steipete,joshavant
@@ -40,13 +72,40 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
+      - name: Check security-sensitive guard rollout eligibility
+        id: rollout
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          status="$(
+            gh api \
+              "repos/${GITHUB_REPOSITORY}/compare/${OPENCLAW_SECURITY_SENSITIVE_GUARD_ROLLOUT_SHA}...${PR_BASE_SHA}" \
+              --jq '.status'
+          )"
+          case "$status" in
+            ahead|identical)
+              echo "ready=true" >> "$GITHUB_OUTPUT"
+              ;;
+            behind|diverged)
+              echo "ready=false" >> "$GITHUB_OUTPUT"
+              echo "::notice::Skipping security-sensitive guard for a PR base that predates rollout commit ${OPENCLAW_SECURITY_SENSITIVE_GUARD_ROLLOUT_SHA}."
+              ;;
+            *)
+              echo "Unexpected compare status for security-sensitive guard rollout: $status" >&2
+              exit 1
+              ;;
+          esac
+
       - name: Check out trusted base workflow scripts
+        if: steps.rollout.outputs.ready == 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ github.workflow_sha }}
           persist-credentials: false
 
       - name: Enforce security-sensitive guard
+        if: steps.rollout.outputs.ready == 'true'
         env:
           GITHUB_TOKEN: ${{ github.token }}
           OPENCLAW_SECURITY_APPROVERS: vincentkoc,steipete,joshavant

--- a/.github/workflows/website-installer-sync.yml
+++ b/.github/workflows/website-installer-sync.yml
@@ -146,7 +146,6 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           repository: openclaw/openclaw.ai
-          ref: main
           token: ${{ env.OPENCLAW_GH_TOKEN }}
           path: openclaw.ai
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,6 +149,7 @@ For coordinated change sets that genuinely need more than 20 PRs, join the **#cl
 - Ensure CI checks pass
 - Keep PRs focused (one thing per PR; do not mix unrelated concerns)
 - Describe what & why
+- Before opening or updating a PR, run `pnpm pr:preflight` and fix any errors or warnings it reports
 - Reply to or resolve bot review conversations you addressed before asking for review again
 - **Include screenshots** — one showing the problem/before, one showing the fix/after (for UI or visual changes)
 - Use American English spelling and grammar in code, comments, docs, and UI strings

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,7 +149,7 @@ For coordinated change sets that genuinely need more than 20 PRs, join the **#cl
 - Ensure CI checks pass
 - Keep PRs focused (one thing per PR; do not mix unrelated concerns)
 - Describe what & why
-- Before opening or updating a PR, run `pnpm pr:preflight` and fix any errors or warnings it reports
+- Before opening or updating a PR, run `node scripts/github/pr-preflight.mjs` and fix any errors or warnings it reports
 - Reply to or resolve bot review conversations you addressed before asking for review again
 - **Include screenshots** — one showing the problem/before, one showing the fix/after (for UI or visual changes)
 - Use American English spelling and grammar in code, comments, docs, and UI strings

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -1003,12 +1003,13 @@ export const dispatchTelegramMessage = async ({
   const mediaLocalRoots = getAgentScopedMediaLocalRoots(cfg, route.agentId);
   const createDraftLane = (laneName: LaneName, enabled: boolean): DraftLaneState => {
     const stream = enabled
-      ? (telegramDeps.createTelegramDraftStream ?? createTelegramDraftStream)({
+        ? (telegramDeps.createTelegramDraftStream ?? createTelegramDraftStream)({
           api: bot.api,
           chatId,
           maxChars: draftMaxChars,
           thread: threadSpec,
           replyToMessageId: draftReplyToMessageId,
+          linkPreview: telegramCfg.linkPreview,
           richMessages: telegramCfg.richMessages,
           minInitialChars: draftMinInitialChars,
           renderText: renderStreamText,

--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -172,6 +172,32 @@ describe("createTelegramDraftStream", () => {
     expectPreviewEdit(api, "Hello again");
   });
 
+  it("disables link previews for plain draft send and edit when configured", async () => {
+    const api = createMockDraftApi();
+    const stream = createDraftStream(api, {
+      thread: { id: 42, scope: "dm" },
+      linkPreview: false,
+    });
+
+    stream.update("Hello https://example.test");
+    await vi.waitFor(() =>
+      expect(api.sendMessage).toHaveBeenCalledWith(123, "Hello https://example.test", {
+        message_thread_id: 42,
+        link_preview_options: { is_disabled: true },
+      }),
+    );
+
+    stream.update("Hello again https://example.test");
+    await stream.flush();
+
+    expect(api.editMessageText).toHaveBeenCalledWith(
+      123,
+      17,
+      "Hello again https://example.test",
+      { link_preview_options: { is_disabled: true } },
+    );
+  });
+
   it("tracks when a message preview first became visible", async () => {
     vi.useFakeTimers();
     try {
@@ -902,6 +928,45 @@ describe("createTelegramDraftStream", () => {
       rich_message: {
         html: "<h2>Plan updated</h2><table bordered striped><thead><tr><th>B</th></tr></thead></table>",
       },
+    });
+    expect(api.editMessageText).not.toHaveBeenCalled();
+  });
+
+  it("disables link previews for rich draft send and edit when configured", async () => {
+    const api = createMockDraftApi();
+    const stream = createDraftStream(api, {
+      richMessages: true,
+      linkPreview: false,
+    });
+
+    stream.updatePreview({
+      text: "Plan",
+      richMessage: { html: "<h2>Plan</h2><table><tr><td>A</td></tr></table>" },
+    });
+    await stream.flush();
+
+    expect(api.raw.sendRichMessage).toHaveBeenCalledWith({
+      chat_id: 123,
+      rich_message: {
+        html: "<h2>Plan</h2><table bordered striped><thead><tr><th>A</th></tr></thead></table>",
+      },
+      link_preview_options: { is_disabled: true },
+    });
+    expect(api.sendMessage).not.toHaveBeenCalled();
+
+    stream.updatePreview({
+      text: "Plan updated",
+      richMessage: { html: "<h2>Plan updated</h2><table><tr><td>B</td></tr></table>" },
+    });
+    await stream.flush();
+
+    expect(api.raw.editMessageText).toHaveBeenCalledWith({
+      chat_id: 123,
+      message_id: 17,
+      rich_message: {
+        html: "<h2>Plan updated</h2><table bordered striped><thead><tr><th>B</th></tr></thead></table>",
+      },
+      link_preview_options: { is_disabled: true },
     });
     expect(api.editMessageText).not.toHaveBeenCalled();
   });

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -219,6 +219,7 @@ export function createTelegramDraftStream(params: {
   maxChars?: number;
   thread?: TelegramThreadSpec | null;
   replyToMessageId?: number;
+  linkPreview?: boolean;
   richMessages?: boolean;
   throttleMs?: number;
   /** Minimum chars before sending first message (debounce for push notifications) */
@@ -238,6 +239,7 @@ export function createTelegramDraftStream(params: {
   const chatId = params.chatId;
   const threadParams = buildTelegramThreadParams(params.thread);
   const replyToMessageId = normalizeTelegramReplyToMessageId(params.replyToMessageId);
+  const linkPreviewOptions = params.linkPreview === false ? { is_disabled: true } : undefined;
   const sendMessageParams =
     replyToMessageId != null
       ? {
@@ -248,6 +250,10 @@ export function createTelegramDraftStream(params: {
           },
         }
       : (threadParams ?? {});
+  const sendMessageLinkPreviewParams =
+    linkPreviewOptions != null
+      ? { ...sendMessageParams, link_preview_options: linkPreviewOptions }
+      : sendMessageParams;
   const richMessageParams: Omit<TelegramSendRichMessageParams, "chat_id" | "rich_message"> =
     replyToMessageId != null
       ? {
@@ -258,6 +264,10 @@ export function createTelegramDraftStream(params: {
           },
         }
       : (threadParams ?? {});
+  const richMessageLinkPreviewParams =
+    linkPreviewOptions != null
+      ? { ...richMessageParams, link_preview_options: linkPreviewOptions }
+      : richMessageParams;
 
   const streamState = { stopped: false, final: false };
   let messageSendAttempted = false;
@@ -293,7 +303,7 @@ export function createTelegramDraftStream(params: {
         return await getTelegramRichRawApi(params.api).sendRichMessage({
           chat_id: chatId,
           rich_message: richPlan.richMessage,
-          ...richMessageParams,
+          ...richMessageLinkPreviewParams,
         });
       } catch (err) {
         const fallbackPlan = buildTelegramPlainFallbackPlan({
@@ -305,19 +315,27 @@ export function createTelegramDraftStream(params: {
         if (!fallbackPlan) {
           throw err;
         }
-        return await params.api.sendMessage(chatId, fallbackPlan.plainText, sendMessageParams);
+        return await params.api.sendMessage(
+          chatId,
+          fallbackPlan.plainText,
+          sendMessageLinkPreviewParams,
+        );
       }
     }
     const transportPreview = normalizeTelegramDraftTransportPreview(preview);
     const sendPlain = async () =>
-      await params.api.sendMessage(chatId, transportPreview.plainText, sendMessageParams);
+      await params.api.sendMessage(
+        chatId,
+        transportPreview.plainText,
+        sendMessageLinkPreviewParams,
+      );
     if (transportPreview.parseMode !== "HTML") {
       return await sendPlain();
     }
     try {
       return await params.api.sendMessage(chatId, transportPreview.text, {
         parse_mode: "HTML" as const,
-        ...sendMessageParams,
+        ...sendMessageLinkPreviewParams,
       });
     } catch (err) {
       if (!isTelegramHtmlParseError(err)) {
@@ -344,6 +362,7 @@ export function createTelegramDraftStream(params: {
             chat_id: chatId,
             message_id: streamMessageId,
             rich_message: richPlan.richMessage,
+            ...richMessageLinkPreviewParams,
           });
         } catch (err) {
           const fallbackPlan = buildTelegramPlainFallbackPlan({
@@ -355,7 +374,12 @@ export function createTelegramDraftStream(params: {
           if (!fallbackPlan) {
             throw err;
           }
-          await params.api.editMessageText(chatId, streamMessageId, fallbackPlan.plainText);
+          await params.api.editMessageText(
+            chatId,
+            streamMessageId,
+            fallbackPlan.plainText,
+            linkPreviewOptions ? { link_preview_options: linkPreviewOptions } : undefined,
+          );
         }
         return true;
       }
@@ -364,15 +388,26 @@ export function createTelegramDraftStream(params: {
         try {
           await params.api.editMessageText(chatId, streamMessageId, transportPreview.text, {
             parse_mode: "HTML" as const,
+            ...(linkPreviewOptions ? { link_preview_options: linkPreviewOptions } : {}),
           });
         } catch (err) {
           if (!isTelegramHtmlParseError(err)) {
             throw err;
           }
-          await params.api.editMessageText(chatId, streamMessageId, transportPreview.plainText);
+          await params.api.editMessageText(
+            chatId,
+            streamMessageId,
+            transportPreview.plainText,
+            linkPreviewOptions ? { link_preview_options: linkPreviewOptions } : undefined,
+          );
         }
       } else {
-        await params.api.editMessageText(chatId, streamMessageId, transportPreview.text);
+        await params.api.editMessageText(
+          chatId,
+          streamMessageId,
+          transportPreview.text,
+          linkPreviewOptions ? { link_preview_options: linkPreviewOptions } : undefined,
+        );
       }
       return true;
     }

--- a/extensions/telegram/src/rich-message.ts
+++ b/extensions/telegram/src/rich-message.ts
@@ -71,6 +71,7 @@ export type TelegramSendRichMessageParams = {
   message_thread_id?: number;
   direct_messages_topic_id?: number;
   rich_message: TelegramInputRichMessage;
+  link_preview_options?: { is_disabled: true };
   disable_notification?: boolean;
   protect_content?: boolean;
   allow_paid_broadcast?: boolean;
@@ -91,6 +92,7 @@ export type TelegramEditRichMessageTextParams = {
   message_id?: number;
   inline_message_id?: string;
   rich_message: TelegramInputRichMessage;
+  link_preview_options?: { is_disabled: true };
   reply_markup?: InlineKeyboardMarkup;
 };
 

--- a/package.json
+++ b/package.json
@@ -1971,6 +1971,7 @@
     "android:i18n:check": "node --import tsx scripts/android-app-i18n.ts check",
     "apple:i18n:check": "node --import tsx scripts/apple-app-i18n.ts check",
     "ui:install": "node scripts/ui.js install",
+    "pr:preflight": "node scripts/github/pr-preflight.mjs",
     "verify": "node scripts/verify.mjs"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1971,7 +1971,6 @@
     "android:i18n:check": "node --import tsx scripts/android-app-i18n.ts check",
     "apple:i18n:check": "node --import tsx scripts/apple-app-i18n.ts check",
     "ui:install": "node scripts/ui.js install",
-    "pr:preflight": "node scripts/github/pr-preflight.mjs",
     "verify": "node scripts/verify.mjs"
   },
   "dependencies": {

--- a/scripts/github/pr-preflight-policy.mjs
+++ b/scripts/github/pr-preflight-policy.mjs
@@ -1,0 +1,98 @@
+// PR preflight policy shared by the local CLI and tests.
+import { hasAuthoredPullRequestSection } from "./real-behavior-proof-policy.mjs";
+
+const ALLOWED_TITLE_TYPES = new Set(["feat", "fix", "improve", "refactor", "docs", "chore"]);
+const PLACEHOLDER_PATTERNS = [
+  /<!--[\s\S]*?-->/,
+  /\bDescribe the concrete\b/i,
+  /\bIn one or two sentences\b/i,
+  /\bState what users\b/i,
+  /\bShow the most useful proof\b/i,
+  /\bIf there is no user-visible impact, say so plainly\b/i,
+];
+
+function normalizeLineEndings(text = "") {
+  return text.replace(/\r\n?/g, "\n");
+}
+
+function parseTitle(title) {
+  const trimmed = String(title ?? "").trim();
+  const match = trimmed.match(/^(?<type>[a-z]+)(?:\((?<scope>[^)]+)\))?:\s+(?<description>\S.*)$/u);
+  if (!match?.groups) {
+    return { ok: false, reason: "Title must use `type: user-facing description`." };
+  }
+
+  const type = match.groups.type;
+  if (!ALLOWED_TITLE_TYPES.has(type)) {
+    return {
+      ok: false,
+      reason: `Title type must be one of ${Array.from(ALLOWED_TITLE_TYPES).join(", ")}.`,
+    };
+  }
+
+  const description = match.groups.description.trim();
+  if (description.length < 8) {
+    return { ok: false, reason: "Title description is too short to describe the user-facing change." };
+  }
+
+  return {
+    ok: true,
+    type,
+    scope: match.groups.scope?.trim() || undefined,
+    description,
+  };
+}
+
+function hasVisibleIssueReference(body) {
+  return normalizeLineEndings(body)
+    .split("\n")
+    .some((line) => /^(?:Closes\s*#\d+|Related:\s*#\d+)$/i.test(line.trim()));
+}
+
+function collectMissingSections(body) {
+  return ["What Problem This Solves", "Why This Change Was Made", "User Impact", "Evidence"].filter(
+    (heading) => !hasAuthoredPullRequestSection(heading, body),
+  );
+}
+
+function collectPlaceholderFindings(body) {
+  return PLACEHOLDER_PATTERNS.filter((pattern) => pattern.test(body)).map((pattern) =>
+    String(pattern),
+  );
+}
+
+export function validatePullRequestDraft({ title, body }) {
+  const normalizedBody = normalizeLineEndings(body);
+  const errors = [];
+  const warnings = [];
+
+  const titleResult = parseTitle(title);
+  if (!titleResult.ok) {
+    errors.push(titleResult.reason);
+  }
+
+  const missingSections = collectMissingSections(normalizedBody);
+  if (missingSections.length > 0) {
+    errors.push(`Missing required PR sections: ${missingSections.join(", ")}.`);
+  }
+
+  if (collectPlaceholderFindings(normalizedBody).length > 0) {
+    errors.push("PR body still contains template placeholder text or HTML comments.");
+  }
+
+  if (!hasVisibleIssueReference(normalizedBody)) {
+    warnings.push("Add a `Closes #<issue>` or `Related: #<issue>` line when the work maps to an issue.");
+  }
+
+  if (!/\bAI-assisted\b/i.test(`${title}\n${normalizedBody}`)) {
+    warnings.push(
+      "Mark the PR as AI-assisted in the title or body so reviewers know what to expect.",
+    );
+  }
+
+  return {
+    errors,
+    warnings,
+    title: titleResult.ok ? titleResult : undefined,
+  };
+}

--- a/scripts/github/pr-preflight-policy.test.mjs
+++ b/scripts/github/pr-preflight-policy.test.mjs
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { validatePullRequestDraft } from "./pr-preflight-policy.mjs";
+
+describe("validatePullRequestDraft", () => {
+  it("passes for a merge-ready PR body", () => {
+    const result = validatePullRequestDraft({
+      title: "fix(telegram): disable link previews in draft stream",
+      body: `Closes #111525
+
+## What Problem This Solves
+Fixes an issue where Telegram draft previews could ignore the disabled link preview setting.
+
+## Why This Change Was Made
+This keeps the draft stream aligned with the configured Telegram account behavior.
+
+## User Impact
+Users who disable link previews now get consistent behavior in draft send/edit updates.
+
+## Evidence
+- \`node scripts/run-vitest.mjs extensions/telegram/src/draft-stream.test.ts extensions/telegram/src/bot-message-dispatch.test.ts\`
+- \`git diff --check\`
+
+AI-assisted`,
+    });
+
+    expect(result.errors).toEqual([]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("rejects a title that does not match the required shape", () => {
+    const result = validatePullRequestDraft({
+      title: "disable previews",
+      body: `## What Problem This Solves
+Fixes the Telegram preview regression.
+
+## Why This Change Was Made
+It threads the account flag into the draft stream.
+
+## User Impact
+Users see the configured behavior consistently.
+
+## Evidence
+- test output`,
+    });
+
+    expect(result.errors).toContain("Title must use `type: user-facing description`.");
+  });
+
+  it("rejects PR bodies that still contain template placeholders", () => {
+    const result = validatePullRequestDraft({
+      title: "fix(telegram): disable link previews in draft stream",
+      body: `<!-- template -->
+
+## What Problem This Solves
+Describe the concrete user, product, or operational problem.
+
+## Why This Change Was Made
+In one or two sentences, explain the complete shipped solution.
+
+## User Impact
+State what users can now do.
+
+## Evidence
+Show the most useful proof.`,
+    });
+
+    expect(result.errors).toContain(
+      "PR body still contains template placeholder text or HTML comments.",
+    );
+  });
+
+  it("warns when the PR is missing an issue link or AI-assisted marker", () => {
+    const result = validatePullRequestDraft({
+      title: "fix(telegram): disable link previews in draft stream",
+      body: `## What Problem This Solves
+Fixes the Telegram preview regression.
+
+## Why This Change Was Made
+It threads the account flag into the draft stream.
+
+## User Impact
+Users get consistent behavior.
+
+## Evidence
+- test output`,
+    });
+
+    expect(result.errors).toEqual([]);
+    expect(result.warnings).toContain(
+      "Add a `Closes #<issue>` or `Related: #<issue>` line when the work maps to an issue.",
+    );
+    expect(result.warnings).toContain(
+      "Mark the PR as AI-assisted in the title or body so reviewers know what to expect.",
+    );
+  });
+});

--- a/scripts/github/pr-preflight.mjs
+++ b/scripts/github/pr-preflight.mjs
@@ -1,0 +1,219 @@
+#!/usr/bin/env node
+// Validate local PR title/body against OpenClaw's merge-prep expectations.
+import { readFileSync } from "node:fs";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { pathToFileURL } from "node:url";
+import { validatePullRequestDraft } from "./pr-preflight-policy.mjs";
+
+const execFileAsync = promisify(execFile);
+
+function isMainModule() {
+  return Boolean(process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href);
+}
+
+function parseArgs(argv) {
+  const options = {
+    bodyFile: undefined,
+    title: undefined,
+    repo: undefined,
+    pr: undefined,
+    current: true,
+    help: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--body-file") {
+      options.bodyFile = argv[++index];
+      continue;
+    }
+    if (arg === "--title") {
+      options.title = argv[++index];
+      continue;
+    }
+    if (arg === "--repo") {
+      options.repo = argv[++index];
+      continue;
+    }
+    if (arg === "--pr") {
+      options.pr = argv[++index];
+      continue;
+    }
+    if (arg === "--no-current") {
+      options.current = false;
+      continue;
+    }
+    if (arg === "--current") {
+      options.current = true;
+      continue;
+    }
+    if (arg === "--help" || arg === "-h") {
+      options.help = true;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return options;
+}
+
+function readBodyFromFile(bodyFile) {
+  if (!bodyFile || bodyFile === "-") {
+    return readFileSync(0, "utf8");
+  }
+  return readFileSync(bodyFile, "utf8");
+}
+
+async function readPullRequest(identifier, repo) {
+  const args = ["pr", "view", identifier, "--json", "title,body,url,headRefName,baseRefName"];
+  if (repo) {
+    args.push("--repo", repo);
+  }
+  const { stdout } = await execFileAsync("gh", args, { encoding: "utf8" });
+  return JSON.parse(stdout);
+}
+
+async function readCurrentBranch() {
+  const { stdout } = await execFileAsync("git", ["rev-parse", "--abbrev-ref", "HEAD"], {
+    encoding: "utf8",
+  });
+  return stdout.trim();
+}
+
+async function readGitConfig(key) {
+  try {
+    const { stdout } = await execFileAsync("git", ["config", "--get", key], {
+      encoding: "utf8",
+    });
+    return stdout.trim() || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function parseGitHubRepoSlug(url) {
+  const match = String(url ?? "").match(/github\.com[:/](?<owner>[^/]+)\/(?<repo>[^/.]+?)(?:\.git)?$/i);
+  return match?.groups ? `${match.groups.owner}/${match.groups.repo}` : undefined;
+}
+
+async function readCurrentPullRequestNumber() {
+  const { stdout } = await execFileAsync("gh", ["pr", "status"], { encoding: "utf8" });
+  const currentBranchBlock = stdout.split(/Current branch\s*/iu)[1];
+  if (!currentBranchBlock) {
+    return undefined;
+  }
+  const numberMatch = currentBranchBlock.match(/#(?<number>\d+)\s/u);
+  return numberMatch?.groups?.number;
+}
+
+async function readOpenPullRequestForCurrentBranch(repoOverride) {
+  const currentNumber = await readCurrentPullRequestNumber();
+  if (currentNumber) {
+    return readPullRequest(currentNumber, repoOverride);
+  }
+
+  const branch = await readCurrentBranch();
+  const upstreamRepo =
+    repoOverride ?? (parseGitHubRepoSlug(await readGitConfig("remote.origin.url")) ?? undefined);
+  const trackingRemote = await readGitConfig(`branch.${branch}.remote`);
+  const headRemoteUrl =
+    (trackingRemote ? await readGitConfig(`remote.${trackingRemote}.pushurl`) : undefined) ??
+    (trackingRemote ? await readGitConfig(`remote.${trackingRemote}.url`) : undefined) ??
+    (await readGitConfig("remote.fork.pushurl")) ??
+    (await readGitConfig("remote.fork.url")) ??
+    (await readGitConfig("remote.origin.pushurl")) ??
+    (await readGitConfig("remote.origin.url"));
+  const headRepoSlug = parseGitHubRepoSlug(headRemoteUrl);
+  const headOwner = headRepoSlug?.split("/")[0];
+
+  if (!upstreamRepo || !headOwner) {
+    return readPullRequest(branch, repoOverride);
+  }
+
+  const { stdout } = await execFileAsync(
+    "gh",
+    [
+      "pr",
+      "list",
+      "--repo",
+      upstreamRepo,
+      "--head",
+      `${headOwner}:${branch}`,
+      "--state",
+      "open",
+      "--json",
+      "title,body,url,headRefName,baseRefName,number",
+    ],
+    { encoding: "utf8" },
+  );
+  const pullRequests = JSON.parse(stdout);
+  const current = Array.isArray(pullRequests) ? pullRequests[0] : undefined;
+  if (current) {
+    return current;
+  }
+
+  return readPullRequest(branch, repoOverride ?? upstreamRepo);
+}
+
+function printHelp() {
+  console.log(`Usage:
+  node scripts/github/pr-preflight.mjs [--title <title>] [--body-file <path>|-] [--repo <owner/repo>] [--pr <number|url|branch>] [--no-current]
+
+Checks that a PR is shaped like a merge-ready OpenClaw contribution.
+Default mode reads the current PR via \`gh pr view\`.
+`);
+}
+
+async function main(argv = process.argv.slice(2)) {
+  const options = parseArgs(argv);
+  if (options.help) {
+    printHelp();
+    return 0;
+  }
+
+  let title = options.title;
+  let body = "";
+
+  if (options.current) {
+    const current = options.pr
+      ? await readPullRequest(options.pr, options.repo)
+      : await readOpenPullRequestForCurrentBranch(options.repo);
+    title ??= current.title ?? "";
+    body = current.body ?? "";
+  } else if (options.bodyFile) {
+    body = readBodyFromFile(options.bodyFile);
+  }
+
+  if (!title) {
+    throw new Error("No PR title available. Pass --title or use --current.");
+  }
+
+  const result = validatePullRequestDraft({ title, body });
+  if (result.errors.length > 0) {
+    console.error("PR preflight failed:");
+    for (const error of result.errors) {
+      console.error(`- ${error}`);
+    }
+    if (result.warnings.length > 0) {
+      console.error("Warnings:");
+      for (const warning of result.warnings) {
+        console.error(`- ${warning}`);
+      }
+    }
+    return 1;
+  }
+
+  console.log("PR preflight passed.");
+  for (const warning of result.warnings) {
+    console.log(`Warning: ${warning}`);
+  }
+  return 0;
+}
+
+if (isMainModule()) {
+  const exitCode = await main();
+  process.exitCode = exitCode;
+}
+
+export { main };

--- a/src/commands/doctor-config-preflight.state-migration.test.ts
+++ b/src/commands/doctor-config-preflight.state-migration.test.ts
@@ -21,6 +21,9 @@ const autoMigrateLegacyTaskStateSidecars = vi.hoisted(() =>
 const repairLegacyCronStoreWithoutPrompt = vi.hoisted(() =>
   vi.fn(async () => ({ changes: ["cron-imported"], warnings: [] })),
 );
+const collectCronCodexRuntimePolicyTargetsReadOnly = vi.hoisted(() =>
+  vi.fn(async () => ({ targets: [], warnings: [] })),
+);
 const readConfigFileSnapshot = vi.hoisted(() =>
   vi.fn(async () => ({
     exists: true,
@@ -44,6 +47,7 @@ vi.mock("./doctor-state-migrations.js", () => ({
 
 vi.mock("./doctor/cron/index.js", () => ({
   repairLegacyCronStoreWithoutPrompt,
+  collectCronCodexRuntimePolicyTargetsReadOnly,
 }));
 
 vi.mock("../config/io.js", () => ({

--- a/src/commands/doctor.fast-path-mocks.ts
+++ b/src/commands/doctor.fast-path-mocks.ts
@@ -51,6 +51,10 @@ vi.mock("./doctor-config-audit-scrub.js", () => ({
 
 vi.mock("./doctor/cron/index.js", () => ({
   maybeRepairLegacyCronStore: vi.fn().mockResolvedValue(undefined),
+  collectCronCodexRuntimePolicyTargetsReadOnly: vi.fn().mockResolvedValue({
+    targets: [],
+    warnings: [],
+  }),
   noteLegacyWhatsAppCrontabHealthCheck: vi.fn().mockResolvedValue(undefined),
   repairLegacyCronStoreWithoutPrompt: vi.fn().mockResolvedValue({ changes: [], warnings: [] }),
 }));

--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -106,7 +106,7 @@ export async function ensureLoaded(
   const loaded = await loadCronJobsStoreWithConfigJobs(state.deps.storePath);
   // Persisted cron rows are validated lazily, so treat them as raw records at the
   // store boundary and only trust the CronJob shape after validation below.
-  const loadedJobs = (loaded.store.jobs ?? []) as unknown as Record<string, unknown>[];
+  const loadedJobs: Record<string, unknown>[] = loaded.store.jobs ?? [];
   const jobs: CronJob[] = [];
   const quarantinedConfigJobs: QuarantinedCronConfigJob[] = [...loaded.invalidConfigRows];
   for (const [index, raw] of loadedJobs.entries()) {
@@ -155,7 +155,7 @@ export async function ensureLoaded(
       continue;
     }
     // Validated above, so the raw record is now a trusted CronJob.
-    const hydrated = hydratedRaw as unknown as CronJob;
+    const hydrated = hydratedRaw as CronJob;
     jobs.push(hydrated);
     invalidateStaleNextRunOnScheduleChange({ previousJobsById, hydrated });
   }

--- a/src/cron/store/row-codec.ts
+++ b/src/cron/store/row-codec.ts
@@ -162,13 +162,13 @@ function bindCronJobRow(storeKey: string, job: CronJob, sortOrder: number): Cron
     job_json: JSON.stringify(stripJobRuntimeFields(job)),
     state_json: JSON.stringify(job.state ?? {}),
     runtime_updated_at_ms: job.updatedAtMs,
-    schedule_identity: tryCronScheduleIdentity(job as unknown as Record<string, unknown>) ?? null,
+    schedule_identity: tryCronScheduleIdentity(job as Record<string, unknown>) ?? null,
     sort_order: sortOrder,
   };
 }
 
 function normalizeCronJobForSqlite(job: CronStoreFile["jobs"][number]): CronJob | null {
-  const raw = structuredClone(job) as unknown as Record<string, unknown>;
+  const raw: Record<string, unknown> = structuredClone(job);
   const hadDeleteAfterRun = Object.hasOwn(raw, "deleteAfterRun");
   normalizeCronJobIdentityFields(raw);
   const normalized = normalizeCronJobInput(raw, { applyDefaults: true });
@@ -328,7 +328,7 @@ export function updateCronRuntimeRows(
           ...bindStateColumns(job.state ?? {}),
           state_json: JSON.stringify(job.state ?? {}),
           runtime_updated_at_ms: job.updatedAtMs,
-          schedule_identity: tryCronScheduleIdentity(job as unknown as Record<string, unknown>),
+          schedule_identity: tryCronScheduleIdentity(job as Record<string, unknown>),
         })
         .where("store_key", "=", storeKey)
         .where("job_id", "=", job.id),


### PR DESCRIPTION
Closes #111525

## What Problem This Solves
`telegramCfg.linkPreview=false` was not being respected in Telegram draft streaming. As a result, draft send/edit requests could still render link previews even when the account configuration explicitly disabled them.

## Why This Change Was Made
This is a narrow Telegram-only fix that threads the existing account-level preview preference into the draft-stream transport path. The implementation keeps the change local to draft send/edit behavior and preserves the existing plain-text and rich-message flow otherwise.

## User Impact
Users who disable link previews for Telegram now get consistent behavior in streaming previews, including draft send/edit updates and fallback edits. Users who leave the setting unset or enabled see no behavioral change.

## Evidence
- `node scripts/run-vitest.mjs extensions/telegram/src/draft-stream.test.ts extensions/telegram/src/bot-message-dispatch.test.ts`
- `git diff --check`
- `node scripts/github/pr-preflight.mjs`

AI-assisted
