### PR TITLE
fix(kilocode): discover models when HTTP proxy is required

### DIFF
--- a/extensions/kilocode/provider-models.proxy.test.ts
+++ b/extensions/kilocode/provider-models.proxy.test.ts
@@ -1,0 +1,55 @@
+// Kilocode proxy tests cover the live model discovery transport policy.
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const fetchWithSsrFGuardMock = vi.hoisted(() => vi.fn());
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("openclaw/plugin-sdk/ssrf-runtime")>()),
+  fetchWithSsrFGuard: fetchWithSsrFGuardMock,
+}));
+
+import { discoverKilocodeModels, KILOCODE_MODELS_URL } from "./provider-models.js";
+
+const ORIGINAL_VITEST = process.env.VITEST;
+const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
+
+function restoreEnv(key: "VITEST" | "NODE_ENV", value: string | undefined) {
+  if (value === undefined) {
+    delete process.env[key];
+  } else {
+    process.env[key] = value;
+  }
+}
+
+afterEach(() => {
+  restoreEnv("VITEST", ORIGINAL_VITEST);
+  restoreEnv("NODE_ENV", ORIGINAL_NODE_ENV);
+  fetchWithSsrFGuardMock.mockReset();
+  vi.restoreAllMocks();
+});
+
+describe("Kilocode model discovery proxy policy", () => {
+  it("allows the guarded gateway catalog request to use an eligible HTTP proxy", async () => {
+    // Kilocode's discovery short-circuit is `NODE_ENV === "test" || process.env.VITEST`,
+    // and any non-empty VITEST string (e.g. "false") is truthy, so it must be removed —
+    // not just reassigned — to exercise the real guarded-fetch path.
+    delete process.env.VITEST;
+    process.env.NODE_ENV = "development";
+    const release = vi.fn(async () => undefined);
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: new Response("unavailable", { status: 503 }),
+      release,
+      finalUrl: KILOCODE_MODELS_URL,
+    });
+
+    await discoverKilocodeModels();
+
+    expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mode: "trusted_env_proxy",
+        url: KILOCODE_MODELS_URL,
+      }),
+    );
+    expect(release).toHaveBeenCalledOnce();
+  });
+});

--- a/extensions/kilocode/provider-models.ts
+++ b/extensions/kilocode/provider-models.ts
@@ -1,4 +1,5 @@
 // Kilocode provider module implements model/runtime integration.
+import { withTrustedEnvProxyGuardedFetchMode } from "openclaw/plugin-sdk/fetch-runtime";
 import { readProviderJsonArrayFieldResponse } from "openclaw/plugin-sdk/provider-http";
 import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-shared";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
@@ -166,15 +167,17 @@ export async function discoverKilocodeModels(): Promise<ModelDefinitionConfig[]>
   }
 
   try {
-    const { response, release } = await fetchWithSsrFGuard({
-      url: KILOCODE_MODELS_URL,
-      init: {
-        headers: { Accept: "application/json" },
-      },
-      timeoutMs: DISCOVERY_TIMEOUT_MS,
-      policy: ssrfPolicyFromHttpBaseUrlAllowedHostname(KILOCODE_BASE_URL),
-      auditContext: "kilocode.model_discovery",
-    });
+    const { response, release } = await fetchWithSsrFGuard(
+      withTrustedEnvProxyGuardedFetchMode({
+        url: KILOCODE_MODELS_URL,
+        init: {
+          headers: { Accept: "application/json" },
+        },
+        timeoutMs: DISCOVERY_TIMEOUT_MS,
+        policy: ssrfPolicyFromHttpBaseUrlAllowedHostname(KILOCODE_BASE_URL),
+        auditContext: "kilocode.model_discovery",
+      }),
+    );
     try {
       if (!response.ok) {
         await response.body?.cancel().catch(() => undefined);


### PR DESCRIPTION
## What Problem This Solves

Kilocode live model discovery cannot reach its catalog when the environment
requires an HTTP proxy. `discoverKilocodeModels()`
(`extensions/kilocode/provider-models.ts`) calls the guarded fetch directly
without the trusted-environment-proxy preset, so the request runs in the
default `strict` guarded-fetch mode, which does not select the eligible
environment proxy. On a proxy-required network the catalog request fails and
discovery falls back — with a `log.warn` — to the hardcoded static catalog
(`buildStaticCatalog()`), so newly added or renamed gateway models never
appear and removed ones persist.

This is the same gap already fixed for sibling providers: `huggingface`
(#110924), `deepinfra` (#111428), `vercel-ai-gateway` (#111209), and `chutes`
(#111266). Kilocode was missed because its discovery calls the guard directly
rather than through an injectable fetch guard.

## Why This Change Was Made

The Kilocode catalog request now uses OpenClaw's existing
trusted-environment-proxy guarded-fetch preset
(`withTrustedEnvProxyGuardedFetchMode`), consistent with the sibling fixes. The
discovery timeout, SSRF policy, static fallback, and test-mode short-circuit
are unchanged. No injectable `fetchGuard` parameter is added: Kilocode calls
the guard directly (unlike `xai`/`openrouter`), so wrapping the existing
params object with the preset is the minimal change — the same call-site shape
used by the merged `huggingface` fix.

## User Impact

Operators running OpenClaw behind a required trusted environment proxy now get
Kilocode's live gateway catalog instead of only the static fallback list.
Users on a direct network are unaffected: the preset changes proxy
eligibility, not the direct-network path.

## Evidence

- Changed: `extensions/kilocode/provider-models.ts` (add the preset import,
  wrap the discovery params); new
  `extensions/kilocode/provider-models.proxy.test.ts`.
- New focused test (mirrors `extensions/chutes/models.proxy.test.ts`): exercises
  the real discovery fetch path and asserts the catalog request is issued with
  `mode: "trusted_env_proxy"` for the Kilocode URL.
  - Fail-before (unwrapped): the request carries no `trusted_env_proxy` mode →
    test red.
  - Pass-after (wrapped): green.
- Regression: full `extensions/kilocode` suite passes.
- `oxfmt` and `oxlint` clean on the changed files.
