### PR TITLE
fix(agents): prevent stuck recovery from aborting replacement runs

### DIFF
--- a/src/agents/embedded-agent-runner/run-state.ts
+++ b/src/agents/embedded-agent-runner/run-state.ts
@@ -70,6 +70,7 @@ const embeddedRunState = resolveGlobalSingleton(EMBEDDED_RUN_STATE_KEY, () => ({
   activeRuns: new Map<string, EmbeddedAgentQueueHandle>(),
   activeRunsByRunId: new Map<string, EmbeddedAgentQueueHandle>(),
   activeRunLifecycleGenerations: new WeakMap<EmbeddedAgentQueueHandle, string>(),
+  endedRunHandles: new WeakSet<EmbeddedAgentQueueHandle>(),
   retainedAbortabilityRunIds: new Set<string>(),
   snapshots: new Map<string, ActiveEmbeddedRunSnapshot>(),
   sessionIdsByKey: new Map<string, string>(),
@@ -92,6 +93,9 @@ const ACTIVE_EMBEDDED_RUN_LIFECYCLE_GENERATIONS =
     EmbeddedAgentQueueHandle,
     string
   >());
+export const ENDED_EMBEDDED_RUN_HANDLES =
+  embeddedRunState.endedRunHandles ??
+  (embeddedRunState.endedRunHandles = new WeakSet<EmbeddedAgentQueueHandle>());
 export const RETAINED_EMBEDDED_RUN_ABORTABILITY_RUN_IDS =
   embeddedRunState.retainedAbortabilityRunIds ??
   (embeddedRunState.retainedAbortabilityRunIds = new Set<string>());

--- a/src/agents/embedded-agent-runner/runs.abort-and-drain.test.ts
+++ b/src/agents/embedded-agent-runner/runs.abort-and-drain.test.ts
@@ -117,6 +117,29 @@ describe("abortAndDrainEmbeddedAgentRun", () => {
     expect(operation.result).toMatchObject({ kind: "failed", code: "run_failed" });
   });
 
+  it("force-clears a reply-only cron timeout without recording a user abort", async () => {
+    const sessionId = "session-reply-only-cron-timeout";
+    const sessionKey = "agent:reply-only-cron-timeout";
+    const operation = createReplyOperation({ sessionId, sessionKey, resetTriggered: false });
+    operation.setPhase("running");
+
+    await expect(
+      abortAndDrainEmbeddedAgentRun({
+        sessionId,
+        sessionKey,
+        forceClear: true,
+        reason: "cron_timeout",
+      }),
+    ).resolves.toEqual({
+      aborted: false,
+      drained: false,
+      forceCleared: true,
+    });
+
+    expect(operation.result).toMatchObject({ kind: "failed", code: "run_failed" });
+    expect(isReplyRunActiveForSessionId(sessionId)).toBe(false);
+  });
+
   it("does not force-clear a replacement reply operation", async () => {
     vi.useFakeTimers();
     const sessionId = "session-replacement-reply-operation";

--- a/src/agents/embedded-agent-runner/runs.abort-and-drain.test.ts
+++ b/src/agents/embedded-agent-runner/runs.abort-and-drain.test.ts
@@ -140,6 +140,28 @@ describe("abortAndDrainEmbeddedAgentRun", () => {
     expect(isReplyRunActiveForSessionId(sessionId)).toBe(false);
   });
 
+  it("aborts a reply-only run without force-clear as a restart", async () => {
+    const sessionId = "session-reply-only-abort";
+    const sessionKey = "agent:reply-only-abort";
+    const operation = createReplyOperation({ sessionId, sessionKey, resetTriggered: false });
+    operation.setPhase("running");
+
+    await expect(
+      abortAndDrainEmbeddedAgentRun({
+        sessionId,
+        sessionKey,
+        settleMs: 0,
+        reason: "test_timeout",
+      }),
+    ).resolves.toEqual({
+      aborted: true,
+      drained: false,
+      forceCleared: false,
+    });
+
+    expect(operation.result).toEqual({ kind: "aborted", code: "aborted_for_restart" });
+  });
+
   it("does not force-clear a replacement reply operation", async () => {
     vi.useFakeTimers();
     const sessionId = "session-replacement-reply-operation";

--- a/src/agents/embedded-agent-runner/runs.abort-and-drain.test.ts
+++ b/src/agents/embedded-agent-runner/runs.abort-and-drain.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createReplyOperation,
+  isReplyRunActiveForSessionId,
+} from "../../auto-reply/reply/reply-run-registry.js";
+import { testing as replyRunTesting } from "../../auto-reply/reply/reply-run-registry.test-support.js";
+import {
+  abortAndDrainEmbeddedAgentRun,
+  clearActiveEmbeddedRun,
+  isEmbeddedAgentRunHandleActive,
+  setActiveEmbeddedRun,
+} from "./runs.js";
+import { testing } from "./runs.test-support.js";
+
+type RunHandle = Parameters<typeof setActiveEmbeddedRun>[1];
+
+function createRunHandle(abort: () => void): RunHandle {
+  return {
+    abort,
+    isCompacting: () => false,
+    isStreaming: () => true,
+    queueMessage: async () => {},
+  };
+}
+
+describe("abortAndDrainEmbeddedAgentRun", () => {
+  afterEach(() => {
+    testing.resetActiveEmbeddedRuns();
+    replyRunTesting.resetReplyRunRegistry();
+    vi.useRealTimers();
+  });
+
+  it("does not abort or force-clear a replacement run during stuck recovery", async () => {
+    vi.useFakeTimers();
+    const staleAbort = vi.fn();
+    const replacementAbort = vi.fn();
+    const staleHandle = createRunHandle(staleAbort);
+    const replacementHandle = createRunHandle(replacementAbort);
+    setActiveEmbeddedRun("session-replaced-during-recovery", staleHandle, "agent:main");
+    staleAbort.mockImplementation(() => {
+      setActiveEmbeddedRun("session-replaced-during-recovery", replacementHandle, "agent:main");
+      clearActiveEmbeddedRun("session-replaced-during-recovery", staleHandle, "agent:main");
+    });
+
+    const resultPromise = abortAndDrainEmbeddedAgentRun({
+      sessionId: "session-replaced-during-recovery",
+      sessionKey: "agent:main",
+      settleMs: 100,
+      forceClear: true,
+      reason: "stuck_recovery",
+    });
+    await vi.advanceTimersByTimeAsync(100);
+
+    await expect(resultPromise).resolves.toEqual({
+      aborted: true,
+      drained: true,
+      forceCleared: false,
+    });
+    expect(staleAbort).toHaveBeenCalledOnce();
+    expect(replacementAbort).not.toHaveBeenCalled();
+    expect(isEmbeddedAgentRunHandleActive("session-replaced-during-recovery")).toBe(true);
+  });
+
+  it("does not report a replaced handle drained before its owner clears", async () => {
+    vi.useFakeTimers();
+    const sessionId = "session-replaced-before-old-owner-clears";
+    const sessionKey = "agent:replaced-before-old-owner-clears";
+    const replacementHandle = createRunHandle(vi.fn());
+    const staleHandle = createRunHandle(() => {
+      setActiveEmbeddedRun(sessionId, replacementHandle, sessionKey);
+    });
+    setActiveEmbeddedRun(sessionId, staleHandle, sessionKey);
+
+    const resultPromise = abortAndDrainEmbeddedAgentRun({
+      sessionId,
+      sessionKey,
+      settleMs: 100,
+      forceClear: true,
+      reason: "stuck_recovery",
+    });
+    await vi.advanceTimersByTimeAsync(100);
+
+    await expect(resultPromise).resolves.toEqual({
+      aborted: true,
+      drained: false,
+      forceCleared: false,
+    });
+    expect(isEmbeddedAgentRunHandleActive(sessionId)).toBe(true);
+  });
+
+  it("waits for the captured reply operation after its embedded handle clears", async () => {
+    vi.useFakeTimers();
+    const sessionId = "session-reply-owner-still-active";
+    const sessionKey = "agent:reply-owner-still-active";
+    const operation = createReplyOperation({ sessionId, sessionKey, resetTriggered: false });
+    operation.setPhase("running");
+    const handle = createRunHandle(() => {
+      clearActiveEmbeddedRun(sessionId, handle, sessionKey);
+    });
+    setActiveEmbeddedRun(sessionId, handle, sessionKey);
+
+    const resultPromise = abortAndDrainEmbeddedAgentRun({
+      sessionId,
+      sessionKey,
+      settleMs: 100,
+      forceClear: true,
+      reason: "cron_timeout",
+    });
+    await vi.advanceTimersByTimeAsync(100);
+
+    await expect(resultPromise).resolves.toEqual({
+      aborted: true,
+      drained: false,
+      forceCleared: true,
+    });
+    expect(isReplyRunActiveForSessionId(sessionId)).toBe(false);
+    expect(operation.result).toMatchObject({ kind: "failed", code: "run_failed" });
+  });
+
+  it("does not force-clear a replacement reply operation", async () => {
+    vi.useFakeTimers();
+    const sessionId = "session-replacement-reply-operation";
+    const sessionKey = "agent:replacement-reply-operation";
+    const originalOperation = createReplyOperation({
+      sessionId,
+      sessionKey,
+      resetTriggered: false,
+    });
+    originalOperation.setPhase("running");
+    let replacementOperation: ReturnType<typeof createReplyOperation> | undefined;
+    const handle = createRunHandle(() => {
+      originalOperation.complete();
+      replacementOperation = createReplyOperation({
+        sessionId,
+        sessionKey,
+        resetTriggered: false,
+      });
+      replacementOperation.setPhase("running");
+    });
+    setActiveEmbeddedRun(sessionId, handle, sessionKey);
+
+    const resultPromise = abortAndDrainEmbeddedAgentRun({
+      sessionId,
+      sessionKey,
+      settleMs: 100,
+      forceClear: true,
+      reason: "cron_timeout",
+    });
+    await vi.advanceTimersByTimeAsync(100);
+
+    await expect(resultPromise).resolves.toEqual({
+      aborted: true,
+      drained: false,
+      forceCleared: true,
+    });
+    expect(replacementOperation?.result).toBeNull();
+    expect(isReplyRunActiveForSessionId(sessionId)).toBe(true);
+  });
+});

--- a/src/agents/embedded-agent-runner/runs.ts
+++ b/src/agents/embedded-agent-runner/runs.ts
@@ -906,10 +906,6 @@ export async function abortAndDrainEmbeddedAgentRun(params: {
     (capturedHandle !== undefined &&
       ACTIVE_EMBEDDED_RUNS.get(params.sessionId) === capturedHandle &&
       abortEmbeddedAgentRun(params.sessionId)) ||
-    (capturedHandle === undefined &&
-      capturedReplyOperation !== undefined &&
-      isReplyOperationActive(capturedReplyOperation) &&
-      capturedReplyOperation.abortByUser()) ||
     expiredReplyRun;
   const drained = aborted
     ? await waitForEmbeddedAgentRunHandleEnd(capturedHandle, capturedReplyOperation, settleMs)

--- a/src/agents/embedded-agent-runner/runs.ts
+++ b/src/agents/embedded-agent-runner/runs.ts
@@ -902,10 +902,24 @@ export async function abortAndDrainEmbeddedAgentRun(params: {
     );
     return { aborted: true, drained, forceCleared: false };
   }
+  const replyOnlyForceCleared =
+    capturedHandle === undefined &&
+    capturedReplyOperation !== undefined &&
+    params.forceClear === true &&
+    isReplyOperationActive(capturedReplyOperation) &&
+    forceClearReplyOperation(
+      capturedReplyOperation,
+      new Error(`Embedded run force-cleared by ${params.reason ?? "abort"}`),
+    );
   const aborted =
     (capturedHandle !== undefined &&
       ACTIVE_EMBEDDED_RUNS.get(params.sessionId) === capturedHandle &&
       abortEmbeddedAgentRun(params.sessionId)) ||
+    (capturedHandle === undefined &&
+      !replyOnlyForceCleared &&
+      capturedReplyOperation !== undefined &&
+      isReplyOperationActive(capturedReplyOperation) &&
+      capturedReplyOperation.abortForRestart()) ||
     expiredReplyRun;
   const drained = aborted
     ? await waitForEmbeddedAgentRunHandleEnd(capturedHandle, capturedReplyOperation, settleMs)
@@ -915,7 +929,8 @@ export async function abortAndDrainEmbeddedAgentRun(params: {
       ? tryLoadForceClearSessionSnapshot(params.sessionKey)
       : undefined;
   const forceCleared =
-    params.forceClear === true && (!aborted || !drained)
+    replyOnlyForceCleared ||
+    (params.forceClear === true && (!aborted || !drained)
       ? forceClearEmbeddedAgentRun(
           params.sessionId,
           capturedHandle,
@@ -923,7 +938,7 @@ export async function abortAndDrainEmbeddedAgentRun(params: {
           params.sessionKey,
           params.reason,
         )
-      : false;
+      : false);
   if (forceCleared && params.sessionKey && persistenceSnapshot) {
     await persistForceClearedEmbeddedRunTerminalState({
       ...persistenceSnapshot,

--- a/src/agents/embedded-agent-runner/runs.ts
+++ b/src/agents/embedded-agent-runner/runs.ts
@@ -6,8 +6,9 @@ import path from "node:path";
 import {
   abortActiveReplyRuns,
   abortReplyRunBySessionId,
-  expireStaleReplyRunBySessionId,
+  expireStaleReplyOperation,
   forceClearReplyOperation,
+  isReplyOperationActive,
   isReplyRunEvidenceStaleBySessionId,
   isReplyRunActiveForSessionId,
   isReplyRunAbortableForCompaction,
@@ -50,6 +51,7 @@ import {
   ABANDONED_EMBEDDED_RUN_SESSION_IDS_BY_FILE,
   ABANDONED_EMBEDDED_RUN_SESSION_IDS_BY_KEY,
   EMBEDDED_RUN_WAITERS,
+  ENDED_EMBEDDED_RUN_HANDLES,
   getActiveEmbeddedRunCount,
   RETAINED_EMBEDDED_RUN_ABORTABILITY_RUN_IDS,
   setActiveEmbeddedRunLifecycleGeneration,
@@ -839,6 +841,29 @@ export async function waitForEmbeddedAgentRunEnd(
   return true;
 }
 
+async function waitForEmbeddedAgentRunHandleEnd(
+  handle: EmbeddedAgentQueueHandle | undefined,
+  replyOperation: ReplyOperation | undefined,
+  timeoutMs: number,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (true) {
+    const handleActive = handle !== undefined && !ENDED_EMBEDDED_RUN_HANDLES.has(handle);
+    const replyOperationActive =
+      replyOperation !== undefined && isReplyOperationActive(replyOperation);
+    if (!handleActive && !replyOperationActive) {
+      return true;
+    }
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) {
+      return false;
+    }
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, Math.min(remainingMs, 25));
+    });
+  }
+}
+
 export type AbortAndDrainEmbeddedAgentRunResult = {
   aborted: boolean;
   drained: boolean;
@@ -853,25 +878,42 @@ export async function abortAndDrainEmbeddedAgentRun(params: {
   reason?: string;
 }): Promise<AbortAndDrainEmbeddedAgentRunResult> {
   const settleMs = params.settleMs ?? 15_000;
-  const embeddedRunHandle = ACTIVE_EMBEDDED_RUNS.get(params.sessionId);
-  const replyOperation = resolveActiveReplyOperationForSessionId(params.sessionId);
+  // Recovery must stay bound to one run generation; a replacement under the
+  // same session id owns its own abort, drain, and cleanup lifecycle.
+  const capturedHandle = ACTIVE_EMBEDDED_RUNS.get(params.sessionId);
+  const capturedReplyOperation = resolveActiveReplyOperationForSessionId(params.sessionId);
   // Recovery is a staleness expiry: stamp run_stalled on the reply operation
   // BEFORE any handle abort, or the run loop's abort handler re-enters
   // abortByUser and misattributes the watchdog kill to the user.
   const expiredReplyRun =
     params.reason === "stuck_recovery" &&
-    expireStaleReplyRunBySessionId(params.sessionId, "stuck_recovery");
-  if (expiredReplyRun && !ACTIVE_EMBEDDED_RUNS.has(params.sessionId)) {
+    capturedReplyOperation !== undefined &&
+    expireStaleReplyOperation(capturedReplyOperation, "stuck_recovery");
+  if (expiredReplyRun && capturedHandle === undefined) {
     // Reply expiry aborts synchronously and clears registry ownership. Let the
     // command lane observe that abort before recovery decides whether to reset it.
     await new Promise<void>((resolve) => {
       setImmediate(resolve);
     });
-    const drained = await waitForEmbeddedAgentRunEnd(params.sessionId, settleMs);
+    const drained = await waitForEmbeddedAgentRunHandleEnd(
+      capturedHandle,
+      capturedReplyOperation,
+      settleMs,
+    );
     return { aborted: true, drained, forceCleared: false };
   }
-  const aborted = abortEmbeddedAgentRun(params.sessionId) || expiredReplyRun;
-  const drained = aborted ? await waitForEmbeddedAgentRunEnd(params.sessionId, settleMs) : false;
+  const aborted =
+    (capturedHandle !== undefined &&
+      ACTIVE_EMBEDDED_RUNS.get(params.sessionId) === capturedHandle &&
+      abortEmbeddedAgentRun(params.sessionId)) ||
+    (capturedHandle === undefined &&
+      capturedReplyOperation !== undefined &&
+      isReplyOperationActive(capturedReplyOperation) &&
+      capturedReplyOperation.abortByUser()) ||
+    expiredReplyRun;
+  const drained = aborted
+    ? await waitForEmbeddedAgentRunHandleEnd(capturedHandle, capturedReplyOperation, settleMs)
+    : false;
   const persistenceSnapshot =
     params.forceClear === true && params.sessionKey
       ? tryLoadForceClearSessionSnapshot(params.sessionKey)
@@ -880,8 +922,8 @@ export async function abortAndDrainEmbeddedAgentRun(params: {
     params.forceClear === true && (!aborted || !drained)
       ? forceClearEmbeddedAgentRun(
           params.sessionId,
-          embeddedRunHandle,
-          replyOperation,
+          capturedHandle,
+          capturedReplyOperation,
           params.sessionKey,
           params.reason,
         )
@@ -1016,6 +1058,7 @@ export function setActiveEmbeddedRun(
     clearEmbeddedRunAbortability(previousHandle, { retainFinalizing: true });
   }
   clearEmbeddedRunAbandonment({ sessionId, sessionKey, sessionFile });
+  ENDED_EMBEDDED_RUN_HANDLES.delete(handle);
   ACTIVE_EMBEDDED_RUNS.set(sessionId, handle);
   if (handle.runId) {
     ACTIVE_EMBEDDED_RUNS_BY_RUN_ID.set(handle.runId, handle);
@@ -1054,6 +1097,7 @@ export function clearActiveEmbeddedRun(
   sessionFile?: string,
   reason = "run_completed",
 ) {
+  ENDED_EMBEDDED_RUN_HANDLES.add(handle);
   const activeHandle = ACTIVE_EMBEDDED_RUNS.get(sessionId);
   if (activeHandle === undefined) {
     return;
@@ -1092,6 +1136,7 @@ function forceClearEmbeddedAgentRun(
   const handle = ACTIVE_EMBEDDED_RUNS.get(sessionId);
   if (handle && handle === expectedHandle) {
     ACTIVE_EMBEDDED_RUNS.delete(sessionId);
+    ENDED_EMBEDDED_RUN_HANDLES.add(handle);
     clearEmbeddedRunAbortability(handle);
     ACTIVE_EMBEDDED_RUN_SNAPSHOTS.delete(sessionId);
     clearActiveRunSessionKeys(sessionId, sessionKey);
@@ -1100,6 +1145,8 @@ function forceClearEmbeddedAgentRun(
     markDiagnosticEmbeddedRunEnded({ sessionId, sessionKey });
     notifyEmbeddedRunEnded(sessionId);
     cleared = true;
+  } else if (handle) {
+    diag.debug(`run force-clear skipped: sessionId=${sessionId} reason=handle_mismatch`);
   }
   const cause = new Error(`Embedded run force-cleared by ${reason}`);
   return (

--- a/src/auto-reply/reply/reply-run-registry.ts
+++ b/src/auto-reply/reply/reply-run-registry.ts
@@ -1093,14 +1093,6 @@ export function expireStaleReplyOperation(
   return expireReplyOperationByOperation.get(operation)?.(reason) ?? false;
 }
 
-export function expireStaleReplyRunBySessionId(
-  sessionId: string,
-  reason: ReplyOperationStaleReason,
-): boolean {
-  const operation = resolveReplyRunForCurrentSessionId(sessionId);
-  return operation ? expireStaleReplyOperation(operation, reason) : false;
-}
-
 // lastActivityAtMs is refreshed by agent events only; timers and user-message
 // injection never refresh it, so quiet runs age toward reclaim.
 export function isReplyRunEvidenceStale(operation: ReplyOperation): boolean {
@@ -1283,6 +1275,10 @@ export function queueReplyRunMessage(
   return true;
 }
 
+export function isReplyOperationActive(operation: ReplyOperation): boolean {
+  return replyRunState.activeRunsByKey.get(operation.key) === operation;
+}
+
 export function abortReplyRunBySessionId(sessionId: string): boolean {
   const operation = resolveReplyRunForCurrentSessionId(sessionId);
   if (!operation) {
@@ -1298,7 +1294,7 @@ export function resolveActiveReplyOperationForSessionId(
 }
 
 export function forceClearReplyOperation(operation: ReplyOperation, cause?: unknown): boolean {
-  if (replyRunState.activeRunsByKey.get(operation.key) !== operation) {
+  if (!isReplyOperationActive(operation)) {
     return false;
   }
   operation.fail("run_failed", cause);


### PR DESCRIPTION
Closes #104589

## What Problem This Solves

Stuck-session recovery could abort, drain, or force-clear a newer embedded-agent run or reply operation that replaced stale work under the same session ID.

## Why This Change Was Made

Recovery captures the active embedded-run handle and reply operation before cleanup, then applies abort, drain, and force-clear actions only to those captured identities. Replacement work registered during cleanup keeps its own lifecycle. Reply-only force-clear uses the captured operation and records the intended `run_failed` result without calling the user-abort path.

## User Impact

Stuck recovery removes stale work without terminating a same-session replacement run or reply operation that is already active.

## Evidence

Current head: `b612303f6db6aeac1e7d8b39d4669719c5299735`

Rebased onto current upstream/main: `b08569f6fdc130810ad73fcec34ebcee72fbe25f`

Changed files:

- `src/agents/embedded-agent-runner/run-state.ts`
- `src/agents/embedded-agent-runner/runs.ts`
- `src/agents/embedded-agent-runner/runs.abort-and-drain.test.ts`
- `src/auto-reply/reply/reply-run-registry.ts`

Local validation on this head:

- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/runs.abort-and-drain.test.ts src/agents/embedded-agent-runner/runs.test.ts src/auto-reply/reply/reply-run-registry.test.ts`
  - passed: 2 Vitest shards; auto-reply shard passed 51 tests, agents embedded-agent shard passed 55 tests
- `./node_modules/.bin/oxfmt --check --threads=1 src/agents/embedded-agent-runner/run-state.ts src/agents/embedded-agent-runner/runs.ts src/agents/embedded-agent-runner/runs.abort-and-drain.test.ts src/auto-reply/reply/reply-run-registry.ts`
  - passed: all matched files formatted
- `git diff --check upstream/main...HEAD`
  - passed

## After-Fix Runtime Proof

Verified against the production embedded-run and reply-run registries through `abortAndDrainEmbeddedAgentRun`, using a temporary proof test that was removed after execution and is not committed. The proof recreates both replacement handoffs:

- stale embedded handle abort synchronously registers a replacement handle under the same session ID
- stale embedded cleanup then tries to clear the old handle
- recovery must not abort or force-clear the replacement handle
- captured reply operation completes and registers a replacement reply operation under the same session ID
- force-clear must not stamp a terminal result on the replacement reply operation

Observed output from current head:

```text
current head: b612303f6db6aeac1e7d8b39d4669719c5299735
base upstream/main: b08569f6fdc130810ad73fcec34ebcee72fbe25f


 RUN  v4.1.10 /root/github/openclaw

stdout | ../../src/agents/embedded-agent-runner/runs.abort-and-drain.runtime-proof.tmp.test.ts > runtime proof for stuck recovery replacement ownership > prints after-fix stale-to-replacement handoff behavior
embedded stale abort count: 1
embedded replacement abort count: 0
embedded abortAndDrain result: {"aborted":true,"drained":true,"forceCleared":false}
embedded replacement active after recovery: true

stdout | ../../src/agents/embedded-agent-runner/runs.abort-and-drain.runtime-proof.tmp.test.ts > runtime proof for stuck recovery replacement ownership > prints after-fix stale-to-replacement handoff behavior
reply abortAndDrain result: {"aborted":true,"drained":false,"forceCleared":true}
replacement reply result: null
replacement reply active after force-clear: true

 ✓ |agents-core| ../../src/agents/embedded-agent-runner/runs.abort-and-drain.runtime-proof.tmp.test.ts > runtime proof for stuck recovery replacement ownership > prints after-fix stale-to-replacement handoff behavior 57ms
stdout | ../../src/agents/embedded-agent-runner/runs.abort-and-drain.runtime-proof.tmp.test.ts > runtime proof for stuck recovery replacement ownership > prints after-fix stale-to-replacement handoff behavior
embedded stale abort count: 1
embedded replacement abort count: 0
embedded abortAndDrain result: {"aborted":true,"drained":true,"forceCleared":false}
embedded replacement active after recovery: true

stdout | ../../src/agents/embedded-agent-runner/runs.abort-and-drain.runtime-proof.tmp.test.ts > runtime proof for stuck recovery replacement ownership > prints after-fix stale-to-replacement handoff behavior
reply abortAndDrain result: {"aborted":true,"drained":false,"forceCleared":true}
replacement reply result: null
replacement reply active after force-clear: true

 ✓ |agents-embedded-agent| ../../src/agents/embedded-agent-runner/runs.abort-and-drain.runtime-proof.tmp.test.ts > runtime proof for stuck recovery replacement ownership > prints after-fix stale-to-replacement handoff behavior 53ms

 Test Files  2 passed (2)
      Tests  2 passed (2)
   Start at  13:30:27
   Duration  7.65s (transform 3.55s, setup 1.07s, import 6.04s, tests 118ms, environment 0ms)
```

This demonstrates the after-fix behavior: stale recovery remains bound to the captured run generation, the replacement embedded handle is not aborted, and a replacement reply operation remains active with `result: null` after the stale operation is force-cleared.

## Review Notes

This PR was AI-assisted. I reviewed the recovery owner/caller paths and understand the captured-generation invariant implemented here.
