### PR TITLE
fix(nextcloud-talk): reject reactions for disabled or unconfigured accounts

### DIFF
--- a/extensions/nextcloud-talk/src/message-actions.test.ts
+++ b/extensions/nextcloud-talk/src/message-actions.test.ts
@@ -144,6 +144,41 @@ describe("nextcloudTalkMessageActions", () => {
   describe("handleAction", () => {
     const cfg = {} as CoreConfig;
 
+    beforeEach(() => {
+      // Dispatch now resolves the account and enforces the same enabled+configured
+      // gate as describeMessageTool, so react tests need a configured account.
+      hoisted.resolveNextcloudTalkAccount.mockReturnValue(configuredAccount);
+    });
+
+    it("rejects a disabled account before reaching the sender", async () => {
+      hoisted.resolveNextcloudTalkAccount.mockReturnValue(disabledAccount);
+
+      await expect(
+        nextcloudTalkMessageActions.handleAction?.({
+          channel: "nextcloud-talk",
+          action: "react",
+          params: { to: "room:abc123", messageId: "1", emoji: "👍" },
+          cfg,
+          accountId: "work",
+        }),
+      ).rejects.toThrow(/is disabled or not configured/);
+      expect(hoisted.sendReactionNextcloudTalk).not.toHaveBeenCalled();
+    });
+
+    it("rejects an unconfigured account before reaching the sender", async () => {
+      hoisted.resolveNextcloudTalkAccount.mockReturnValue(unconfiguredAccount);
+
+      await expect(
+        nextcloudTalkMessageActions.handleAction?.({
+          channel: "nextcloud-talk",
+          action: "react",
+          params: { to: "room:abc123", messageId: "1", emoji: "👍" },
+          cfg,
+        }),
+      ).rejects.toThrow(/is disabled or not configured/);
+      expect(hoisted.sendReactionNextcloudTalk).not.toHaveBeenCalled();
+    });
+
     it("invokes sendReactionNextcloudTalk with normalized params for the react action", async () => {
       const result = await nextcloudTalkMessageActions.handleAction?.({
         channel: "nextcloud-talk",

--- a/extensions/nextcloud-talk/src/message-actions.ts
+++ b/extensions/nextcloud-talk/src/message-actions.ts
@@ -49,6 +49,18 @@ export const nextcloudTalkMessageActions: ChannelMessageActionAdapter = {
     }
 
     if (action === "react") {
+      // describeMessageTool only offers `react` for enabled, configured accounts.
+      // An explicit accountId can still target a disabled or uncredentialed
+      // account, so enforce the same gate at dispatch before it reaches the
+      // sender — otherwise a disabled account with leftover credentials still
+      // emits reactions.
+      const account = resolveNextcloudTalkAccount({ cfg: cfg as CoreConfig, accountId });
+      if (!isAccountConfigured(account)) {
+        throw new Error(
+          `Nextcloud Talk account "${account.accountId}" is disabled or not configured.`,
+        );
+      }
+
       const target = readStringParam(params, "to", {
         required: true,
         label: "to (room token)",


### PR DESCRIPTION
## What Problem This Solves

The Nextcloud Talk `react` message action dispatched straight to the sender without
re-checking the resolved account. A user who **disabled** their Nextcloud Talk account
(`channels.nextcloud-talk.enabled: false`) but left the `baseUrl`/`botSecret` in config
could therefore still have the `react` action emit reactions through that disabled
account — outbound traffic from a channel the user explicitly turned off.

`describeMessageTool` already hides the `react` tool when no account is enabled and
configured, but that only affects tool listing. `handleAction` receives its own `accountId`
and applied no equivalent account check, so a disabled-but-credentialed account was not
stopped before dispatch. The credential resolver (`resolveCredentials` in `send.ts`)
validates only `baseUrl`/`secret` presence, not `enabled`.

## Why This Change Was Made

The contract this restores is Nextcloud Talk's own: tool listing and direct dispatch
should agree about which accounts may act. This change resolves the account at the top of
the `react` branch and reuses the plugin's existing `isAccountConfigured` predicate
(`enabled && secret && baseUrl`) — the exact predicate `describeMessageTool` already uses
to decide whether to offer the tool. No second configuration model is introduced, and
`resolveCredentials` stays the credential-validation owner for the send path.

The same class of gap was fixed for Signal in #112607 (merged), which is precedent for
the shape rather than a replacement for this plugin-local fix.

## User Impact

A disabled Nextcloud Talk account with leftover credentials no longer emits reactions.
Reacting through a disabled or unconfigured account now throws
`Nextcloud Talk account "<id>" is disabled or not configured.` instead of reaching the API.
Enabled, configured accounts are unaffected.

## Real behavior proof

Behavior addressed: a Nextcloud Talk account with `enabled: false` and leftover
credentials still posts reactions to the provider when `react` is dispatched with an
explicit account.

Real environment tested: real Nextcloud **34.0.2.1** with the real Talk (spreed) app
**24.0.3**, a real Talk bot registered on the server (`occ talk:bot:install --feature
response --feature reaction`) and attached to a real conversation (`occ talk:bot:setup`),
real chat messages posted through the server's OCS chat API, Node v24.18.0. The harness
imports the production adapter and calls
`nextcloudTalkMessageActions.handleAction` directly under `tsx` — no vitest, no
`vi.mock`, no injected sender — so account resolution, signing, the SSRF-guarded fetch,
and the HTTP POST to `/ocs/v2.php/apps/spreed/api/v1/bot/{token}/reaction/{messageId}`
all run as shipped. After each scenario the harness reads the reaction map back from the
server (`GET /ocs/v2.php/apps/spreed/api/v1/reaction/{token}/{messageId}`), so the result
lines below are what Nextcloud itself recorded: `{"👍":["bots:… (Bot)"]}` means the
reaction really landed and the server attributed it to the bot.

Exact steps or command run after this patch: drop the throwaway proof harness
`nc-live-proof.mts` at the repo root and run the command below. The harness is not part of
this PR's diff; its full source is inlined underneath so the run is reproducible.

```
NC_BASE_URL=<nextcloud-url> NC_ROOM_TOKEN=<room> NC_BOT_SECRET=<bot-secret> \
NC_ADMIN_USER=<admin> NC_ADMIN_PASSWORD=<password> \
./node_modules/.bin/tsx nc-live-proof.mts
```

<details>
<summary>nc-live-proof.mts (proof harness, not part of the diff)</summary>

```ts
/**
 * Standalone live proof harness for PR #112675.
 *
 * Drives the production Nextcloud Talk message-action adapter
 * (`nextcloudTalkMessageActions.handleAction`) against a real Nextcloud server
 * with the real Talk (spreed) app and a real registered Talk bot. Nothing in
 * the dispatch path is mocked: real account resolution, real signature, real
 * SSRF-guarded fetch, real HTTP, real provider reaction API.
 *
 * Each scenario posts a fresh chat message through the server's OCS chat API,
 * then asks the production adapter to react to it, then reads the reaction
 * state back from the server. The server's own view of the message is the
 * evidence, not the harness's bookkeeping.
 *
 * Usage:
 *   NC_BASE_URL=... NC_BOT_SECRET=... NC_ROOM_TOKEN=... NC_ADMIN_USER=... \
 *   NC_ADMIN_PASSWORD=... ./node_modules/.bin/tsx nc-live-proof.mts
 */
import { nextcloudTalkMessageActions } from "./extensions/nextcloud-talk/src/message-actions.ts";
import type { CoreConfig } from "./extensions/nextcloud-talk/src/types.ts";

const baseUrl = requireEnv("NC_BASE_URL");
const botSecret = requireEnv("NC_BOT_SECRET");
const roomToken = requireEnv("NC_ROOM_TOKEN");
const adminUser = requireEnv("NC_ADMIN_USER");
const adminPassword = requireEnv("NC_ADMIN_PASSWORD");

function requireEnv(name: string): string {
  const value = process.env[name]?.trim();
  if (!value) {
    console.error(`missing required env ${name}`);
    process.exit(2);
  }
  return value;
}

const ocsHeaders = {
  "OCS-APIRequest": "true",
  Accept: "application/json",
  Authorization: `Basic ${Buffer.from(`${adminUser}:${adminPassword}`).toString("base64")}`,
};

/** Posts a chat message as the admin user and returns its server-assigned id. */
async function postMessage(text: string): Promise<string> {
  const response = await fetch(`${baseUrl}/ocs/v2.php/apps/spreed/api/v1/chat/${roomToken}`, {
    method: "POST",
    headers: { ...ocsHeaders, "Content-Type": "application/x-www-form-urlencoded" },
    body: new URLSearchParams({ message: text }),
  });
  const payload = (await response.json()) as { ocs: { data: { id: number } } };
  return String(payload.ocs.data.id);
}

/** Reads the server's reaction map for a message: emoji -> reacting actor ids. */
async function readReactions(messageId: string): Promise<Record<string, string[]>> {
  const response = await fetch(
    `${baseUrl}/ocs/v2.php/apps/spreed/api/v1/reaction/${roomToken}/${messageId}`,
    { headers: ocsHeaders },
  );
  if (response.status === 404) {
    return {};
  }
  const payload = (await response.json()) as {
    ocs: { data: Record<string, { actorType: string; actorDisplayName: string }[]> };
  };
  return Object.fromEntries(
    Object.entries(payload.ocs.data ?? {}).map(([reaction, actors]) => [
      reaction,
      actors.map((actor) => `${actor.actorType}:${actor.actorDisplayName}`),
    ]),
  );
}

type Scenario = {
  id: string;
  description: string;
  cfg: CoreConfig;
};

/** Config a user would have after turning the channel off but leaving credentials in place. */
function config(params: { enabled: boolean; withSecret: boolean }): CoreConfig {
  return {
    channels: {
      "nextcloud-talk": {
        enabled: params.enabled,
        baseUrl,
        ...(params.withSecret ? { botSecret } : {}),
        // Required for a loopback Nextcloud; production installs use a public host.
        network: { dangerouslyAllowPrivateNetwork: true },
      },
    },
  } as unknown as CoreConfig;
}

const scenarios: Scenario[] = [
  {
    id: "S1-disabled-account",
    description: "channel disabled (enabled:false) but baseUrl + botSecret still in config",
    cfg: config({ enabled: false, withSecret: true }),
  },
  {
    id: "S2-enabled-account-control",
    description: "control: enabled + fully configured account must still reach the provider",
    cfg: config({ enabled: true, withSecret: true }),
  },
  {
    id: "S3-unconfigured-account",
    description: "enabled but required configuration (bot secret) missing",
    cfg: config({ enabled: true, withSecret: false }),
  },
];

const emoji = "👍";

for (const scenario of scenarios) {
  const messageId = await postMessage(`proof message for ${scenario.id}`);
  const before = await readReactions(messageId);

  let outcome: string;
  try {
    const result = await nextcloudTalkMessageActions.handleAction?.({
      channel: "nextcloud-talk",
      action: "react",
      params: { to: `room:${roomToken}`, messageId, emoji },
      cfg: scenario.cfg,
      // The gap under test is the explicit-account path: describeMessageTool can
      // hide the tool, but a caller naming an accountId still reaches handleAction.
      accountId: "default",
    } as Parameters<NonNullable<typeof nextcloudTalkMessageActions.handleAction>>[0]);
    outcome = `returned ${JSON.stringify(result?.details ?? result)}`;
  } catch (error) {
    outcome = `threw ${error instanceof Error ? error.message : String(error)}`;
  }

  // Give the server a moment to persist the reaction before reading it back.
  await new Promise((resolve) => setTimeout(resolve, 300));
  const after = await readReactions(messageId);

  console.log(`--- ${scenario.id} — ${scenario.description}`);
  console.log(`    messageId          : ${messageId}`);
  console.log(`    handleAction       : ${outcome}`);
  console.log(`    reactions before   : ${JSON.stringify(before)}`);
  console.log(`    reactions on server: ${JSON.stringify(after)}`);
}
```

</details>

Before evidence (`extensions/nextcloud-talk/src/message-actions.ts` restored to
upstream/main `cd5a5ecb4c`, nothing else changed):

```
# capture: BEFORE (extensions/nextcloud-talk/src/message-actions.ts at upstream/main cd5a5ecb4c, nothing else changed)
# server : Nextcloud 34.0.2.1 / Talk (spreed) 24.0.3 / node v24.18.0
--- S1-disabled-account — channel disabled (enabled:false) but baseUrl + botSecret still in config
    messageId          : 25
    handleAction       : returned {"ok":true,"added":"👍"}
    reactions before   : {}
    reactions on server: {"👍":["bots:OpenClaw Proof Bot (Bot)"]}
--- S2-enabled-account-control — control: enabled + fully configured account must still reach the provider
    messageId          : 27
    handleAction       : returned {"ok":true,"added":"👍"}
    reactions before   : {}
    reactions on server: {"👍":["bots:OpenClaw Proof Bot (Bot)"]}
--- S3-unconfigured-account — enabled but required configuration (bot secret) missing
    messageId          : 29
    handleAction       : threw Nextcloud Talk bot secret missing for account "default" (set channels.nextcloud-talk.botSecret/botSecretFile or NEXTCLOUD_TALK_BOT_SECRET for default).
    reactions before   : {}
    reactions on server: {}
```

Evidence after fix (head `a410c911e5`):

```
# capture: AFTER (this PR, head a410c911e5e78b5b0a76e84779b9bcefbaffb544)
# server : Nextcloud 34.0.2.1 / Talk (spreed) 24.0.3 / node v24.18.0
--- S1-disabled-account — channel disabled (enabled:false) but baseUrl + botSecret still in config
    messageId          : 21
    handleAction       : threw Nextcloud Talk account "default" is disabled or not configured.
    reactions before   : {}
    reactions on server: {}
--- S2-enabled-account-control — control: enabled + fully configured account must still reach the provider
    messageId          : 22
    handleAction       : returned {"ok":true,"added":"👍"}
    reactions before   : {}
    reactions on server: {"👍":["bots:OpenClaw Proof Bot (Bot)"]}
--- S3-unconfigured-account — enabled but required configuration (bot secret) missing
    messageId          : 24
    handleAction       : threw Nextcloud Talk account "default" is disabled or not configured.
    reactions before   : {}
    reactions on server: {}
```

Observed result after fix: S1 flips — before the fix a channel the user had turned off
still posted a reaction that the real server accepted and attributed to the bot; after the
fix the dispatch throws and the server records no reaction for that message. S2 is
identical in both runs, so an enabled, configured account still reaches the provider and
the reaction still lands. S3 changes only which error is raised (credential error inside
the send path → explicit account gate); both refuse, and the new one names the real cause.

What was not tested: multi-account routing — the capture uses the single `default`
account, though the gate runs on whatever `resolveNextcloudTalkAccount` returns, which is
the same resolver `describeMessageTool` uses. Reaction removal (`params.remove === true`)
is rejected by a pre-existing guard and is untouched here.

Proof limitations or environment constraints: the test Nextcloud runs on loopback, so the
harness's own config object sets `network.dangerouslyAllowPrivateNetwork`. That is a
harness-side value only — this PR adds no config surface and changes no default, and the
flag reaches only the SSRF policy, never the account gate under test. Bot secret, admin
credentials, and the room token are redacted from the command above and appear nowhere in
the captured output.

## Evidence

Supplemental to the runtime capture above:

- New focused tests in `extensions/nextcloud-talk/src/message-actions.test.ts`:
  - `rejects a disabled account before reaching the sender` — disabled account
    (`enabled:false`, credentials present) → `handleAction` throws and
    `sendReactionNextcloudTalk` is **not** called.
  - `rejects an unconfigured account before reaching the sender` — required
    configuration missing → throws, sender not called.
- `vitest run extensions/nextcloud-talk/src/message-actions.test.ts` → 21 passed at head
  `a410c911e5`; the two new tests fail with the same file restored to `cd5a5ecb4c`
  (the disabled account resolves and `sendReactionNextcloudTalk` is called).

Rebased onto current main (`cd5a5ecb4c`) so the exact-head validation above is against
today's `main`.

Related: #112607
