### PR TITLE
feat(approvals): declare how each channel renders approval prompt text

### DIFF
--- a/docs/plugins/sdk-channel-plugins.md
+++ b/docs/plugins/sdk-channel-plugins.md
@@ -303,6 +303,44 @@ Use `approvalCapability.delivery` only for native approval routing or fallback
 suppression, and `approvalCapability.render` only when a channel truly needs
 custom approval payloads instead of the shared renderer.
 
+### Approval text formatting
+
+Core builds approval prompts once and every channel receives the same string.
+That string is markdown, in a fixed subset: `**bold**`, `_italic_`,
+`~~strikethrough~~`, `` `inline code` ``, and fenced code blocks with an
+advisory language hint (`sh` for a pending command, `txt` for a plain block).
+Underline is excluded because most transports cannot express it. A channel may
+honour a language hint for native highlighting and must drop an unsupported
+hint without altering the fenced content.
+
+Declare how your channel handles that subset with `approvalCapability.approvalText`:
+
+- `"markdown"` - the channel translates the subset into native styling and owns
+  any escaping its transport requires. Declare this if your send path already
+  converts markdown, or if your transport renders it server-side.
+- `"plaintext"` (the default) - core projects the text to plaintext before
+  delivery, so no markers reach the transport.
+
+There is no implicit pass-through. A channel either translates or downgrades;
+handing canonical markdown to a transport that will not render it is how
+approvers end up reading literal backticks.
+
+Two things to know when declaring:
+
+- The mode lives on the capability, not the adapter. Auth-only channels project
+  no adapter but still receive approval text through the forwarder fallback, so
+  core reads it with `resolveChannelApprovalTextMode`, never through
+  `resolveChannelApprovalAdapter`.
+- Core enforces the downgrade on the forwarder path. Channels with their own
+  native approval runtime build their own payloads, so a channel there that
+  declares `"plaintext"` must call `downgradeApprovalMarkdownToPlaintext` from
+  `openclaw/plugin-sdk/approval-reply-runtime` itself.
+
+Emphasis over content the builder does not control - a model-generated
+rationale, a command, a path - must escape the payload before wrapping it. An
+unescaped `*` or `_` breaks the span on a rendering channel, and on a
+parse-mode transport it fails the send outright.
+
 ### Approval auth
 
 - `approvalCapability.authorizeActorAction` and

--- a/extensions/discord/src/approval-native.ts
+++ b/extensions/discord/src/approval-native.ts
@@ -158,6 +158,8 @@ function createDiscordApproverDmTargetResolver(configOverride?: DiscordExecAppro
 
 function createDiscordApprovalCapability(configOverride?: DiscordExecApprovalConfig | null) {
   return createApproverRestrictedNativeApprovalCapability({
+    // Discord authors its own component containers and renders markdown natively.
+    approvalText: "markdown",
     channel: "discord",
     channelLabel: "Discord",
     describeExecApprovalSetup: ({

--- a/extensions/feishu/src/approval-auth.ts
+++ b/extensions/feishu/src/approval-auth.ts
@@ -10,11 +10,18 @@ function normalizeFeishuApproverId(value: string | number): string | undefined {
   return trimmed?.startsWith("ou_") ? trimmed : undefined;
 }
 
-export const feishuApprovalAuth = createChannelApprovalAuth({
-  channelLabel: "Feishu",
-  resolveInputs: ({ cfg, accountId }) => {
-    const account = resolveFeishuAccount({ cfg, accountId }).config;
-    return { allowFrom: account.allowFrom };
-  },
-  normalizeApprover: normalizeFeishuApproverId,
-}).approvalAuth;
+export const feishuApprovalAuth = {
+  ...createChannelApprovalAuth({
+    channelLabel: "Feishu",
+    resolveInputs: ({ cfg, accountId }) => {
+      const account = resolveFeishuAccount({ cfg, accountId }).config;
+      return { allowFrom: account.allowFrom };
+    },
+    normalizeApprover: normalizeFeishuApproverId,
+  }).approvalAuth,
+  // Feishu has no render adapter, so approval text comes from the forwarder
+  // fallback, but its outbound presentation renders markdown
+  // (markdownDialect: "markdown"). Without this the plaintext default would
+  // strip fenced commands from the approval card.
+  approvalText: "markdown" as const,
+};

--- a/extensions/imessage/src/markdown-format.test.ts
+++ b/extensions/imessage/src/markdown-format.test.ts
@@ -1,6 +1,41 @@
 // Imessage tests cover markdown format plugin behavior.
+import { downgradeApprovalMarkdownToPlaintext } from "openclaw/plugin-sdk/approval-reply-runtime";
 import { describe, expect, it } from "vitest";
 import { extractMarkdownFormatRuns } from "./markdown-format.js";
+
+const APPROVAL_ID = "a7a8b519-2311-4dcd-bccf-d6ca1d737969";
+// The canonical exec approval prompt core emits, verbatim (RFC 0002 worked example).
+const APPROVAL_PROMPT = [
+  "Approval required.",
+  "Run:",
+  "```txt\n/approve " + APPROVAL_ID + " allow-once\n```",
+  "Pending command:",
+  '```sh\ncurl -sS -o /dev/null -w "%{http_code}" https://example.com\n```',
+  `Host: gateway\nFull id: \`${APPROVAL_ID}\``,
+].join("\n\n");
+
+// RFC 0002 step 1: iMessage stays at the plaintext default, so the forwarder
+// downgrades before send and the typed-run formatter then sees clean text.
+// This proves the two step-1 criteria on the real prompt: no stray markers and
+// no bold. Step 2 (#85954) flips iMessage to markdown and adds bold labels.
+describe("iMessage approval prompt at the step-1 plaintext default", () => {
+  const downgraded = downgradeApprovalMarkdownToPlaintext(APPROVAL_PROMPT);
+  const { text, ranges } = extractMarkdownFormatRuns(downgraded);
+
+  it("strips every code marker before the prompt reaches the send path", () => {
+    expect(text).not.toContain("`");
+  });
+
+  it("produces no typed-run formatting, so nothing renders bold", () => {
+    expect(ranges).toStrictEqual([]);
+  });
+
+  it("keeps the command, id, and approve instruction intact and copyable", () => {
+    expect(text).toContain('curl -sS -o /dev/null -w "%{http_code}" https://example.com');
+    expect(text).toContain(`/approve ${APPROVAL_ID} allow-once`);
+    expect(text).toContain(APPROVAL_ID);
+  });
+});
 
 describe("extractMarkdownFormatRuns", () => {
   it("returns the text unchanged when there is no markdown", () => {

--- a/extensions/matrix/src/approval-native.ts
+++ b/extensions/matrix/src/approval-native.ts
@@ -322,6 +322,8 @@ const matrixNativeAdapter = matrixBaseNativeApprovalAdapter && {
 };
 
 export const matrixApprovalCapability = createChannelApprovalCapability({
+  // Matrix send path renders the canonical subset into formatted_body.
+  approvalText: "markdown",
   authorizeActorAction: (
     params: Parameters<NonNullable<ChannelApprovalCapability["authorizeActorAction"]>>[0],
   ) => {

--- a/extensions/mattermost/src/approval-auth.ts
+++ b/extensions/mattermost/src/approval-auth.ts
@@ -15,11 +15,17 @@ function normalizeMattermostApproverId(value: string | number): string | undefin
   return MATTERMOST_USER_ID_RE.test(lowered) ? lowered : undefined;
 }
 
-export const mattermostApprovalAuth = createChannelApprovalAuth({
-  channelLabel: "Mattermost",
-  resolveInputs: ({ cfg, accountId }) => {
-    const account = resolveMattermostAccount({ cfg, accountId }).config;
-    return { allowFrom: account.allowFrom };
-  },
-  normalizeApprover: normalizeMattermostApproverId,
-}).approvalAuth;
+export const mattermostApprovalAuth = {
+  ...createChannelApprovalAuth({
+    channelLabel: "Mattermost",
+    resolveInputs: ({ cfg, accountId }) => {
+      const account = resolveMattermostAccount({ cfg, accountId }).config;
+      return { allowFrom: account.allowFrom };
+    },
+    normalizeApprover: normalizeMattermostApproverId,
+  }).approvalAuth,
+  // Mattermost has no render adapter, so approval text comes from the
+  // forwarder fallback, but its server renders markdown. Without this the
+  // plaintext default would strip a code block users see today.
+  approvalText: "markdown" as const,
+};

--- a/extensions/msteams/src/approval-auth.ts
+++ b/extensions/msteams/src/approval-auth.ts
@@ -22,18 +22,25 @@ function resolveMSTeamsChannelConfig(cfg: OpenClawConfig) {
   return cfg.channels?.msteams;
 }
 
-export const msTeamsApprovalAuth = createChannelApprovalAuth({
-  channelLabel: "Microsoft Teams",
-  resolveInputs: ({ cfg }) => {
-    const channel = resolveMSTeamsChannelConfig(cfg);
-    return { allowFrom: channel?.allowFrom, defaultTo: channel?.defaultTo };
-  },
-  normalizeApprover: normalizeMSTeamsApproverId,
-  normalizeSenderId: (value) => {
-    const trimmed = normalizeOptionalLowercaseString(value);
-    if (!trimmed) {
-      return undefined;
-    }
-    return MSTEAMS_ID_RE.test(trimmed) ? trimmed : undefined;
-  },
-}).approvalAuth;
+export const msTeamsApprovalAuth = {
+  ...createChannelApprovalAuth({
+    channelLabel: "Microsoft Teams",
+    resolveInputs: ({ cfg }) => {
+      const channel = resolveMSTeamsChannelConfig(cfg);
+      return { allowFrom: channel?.allowFrom, defaultTo: channel?.defaultTo };
+    },
+    normalizeApprover: normalizeMSTeamsApproverId,
+    normalizeSenderId: (value) => {
+      const trimmed = normalizeOptionalLowercaseString(value);
+      if (!trimmed) {
+        return undefined;
+      }
+      return MSTEAMS_ID_RE.test(trimmed) ? trimmed : undefined;
+    },
+  }).approvalAuth,
+  // Teams has no render adapter, so approval text comes from the forwarder
+  // fallback, but its Adaptive Card TextBlocks render markdown
+  // (markdownDialect: "markdown"). Without this the plaintext default would
+  // strip fenced commands from the approval card.
+  approvalText: "markdown" as const,
+};

--- a/extensions/qqbot/src/bridge/approval/capability.ts
+++ b/extensions/qqbot/src/bridge/approval/capability.ts
@@ -109,6 +109,10 @@ function resolveNativeDeliveryState(params: {
 
 function createQQBotApprovalCapability(): ChannelApprovalCapability {
   return createChannelApprovalCapability({
+    // QQBot renders markdown on markdown-enabled accounts (msg_type 2). When
+    // native approvals fall back to forwarder delivery, keep the canonical
+    // subset so fenced commands still render instead of being stripped.
+    approvalText: "markdown",
     authorizeActorAction: ({ cfg, accountId, senderId, approvalKind }) =>
       authorizeQQBotApprovalAction({ cfg, accountId, senderId, approvalKind }),
 

--- a/extensions/qqbot/src/bridge/approval/capability.ts
+++ b/extensions/qqbot/src/bridge/approval/capability.ts
@@ -108,11 +108,11 @@ function resolveNativeDeliveryState(params: {
 }
 
 function createQQBotApprovalCapability(): ChannelApprovalCapability {
+  // No approvalText declaration: QQBot markdown rendering is per-account
+  // (markdownSupport), and markdownSupport:false accounts send raw msg_type 0
+  // text. A channel-wide "markdown" mode would leave literal fences on those
+  // accounts, so the plaintext default is the only safe channel-wide choice.
   return createChannelApprovalCapability({
-    // QQBot renders markdown on markdown-enabled accounts (msg_type 2). When
-    // native approvals fall back to forwarder delivery, keep the canonical
-    // subset so fenced commands still render instead of being stripped.
-    approvalText: "markdown",
     authorizeActorAction: ({ cfg, accountId, senderId, approvalKind }) =>
       authorizeQQBotApprovalAction({ cfg, accountId, senderId, approvalKind }),
 

--- a/extensions/signal/src/approval-native.ts
+++ b/extensions/signal/src/approval-native.ts
@@ -228,6 +228,8 @@ function buildSignalPluginPendingPayload(params: {
 }
 
 export const signalApprovalCapability: ChannelApprovalCapability = createChannelApprovalCapability({
+  // Signal send path converts the canonical subset to native styled text.
+  approvalText: "markdown",
   ...signalApprovalAuth,
   getActionAvailabilityState: ({ cfg, accountId, approvalKind }) =>
     (

--- a/extensions/slack/src/approval-native.ts
+++ b/extensions/slack/src/approval-native.ts
@@ -173,6 +173,8 @@ const baseSlackNativeAdapter = baseSlackApprovalCapability.native;
 
 export const slackApprovalCapability: ChannelApprovalCapability = {
   ...baseSlackApprovalCapability,
+  // Slack authors native mrkdwn/Block Kit approval payloads of its own.
+  approvalText: "markdown",
   delivery: {
     ...baseSlackApprovalCapability.delivery,
     shouldSuppressForwardingFallback: (input) => {

--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -930,6 +930,8 @@ export const telegramPlugin = createChatChannelPlugin({
     },
     approvalCapability: {
       ...telegramApprovalCapability,
+      // Telegram send path converts the canonical subset and escapes for parse mode.
+      approvalText: "markdown",
       render: {
         exec: {
           buildPendingPayload: ({ request, nowMs }) =>

--- a/extensions/whatsapp/src/approval-native.ts
+++ b/extensions/whatsapp/src/approval-native.ts
@@ -201,6 +201,8 @@ function buildWhatsAppPluginPendingPayload(params: {
 
 export const whatsappApprovalCapability: ChannelApprovalCapability =
   createChannelApprovalCapability({
+    // WhatsApp send path converts the canonical subset to native markup.
+    approvalText: "markdown",
     ...whatsappApprovalAuth,
     getActionAvailabilityState: ({ cfg, accountId, approvalKind }) =>
       (

--- a/scripts/plugin-sdk-surface-report.mjs
+++ b/scripts/plugin-sdk-surface-report.mjs
@@ -151,7 +151,8 @@ export function readPluginSdkSurfaceBudgets(env = process.env) {
       // +2: shared Teams reply-style and TTS schema leaves.
       // +2: generic inbound-root and SCP-host schema validators.
       // +2: attributed-range renderer and its options contract.
-      4689,
+      // +3: approval markdown downgrade, default text mode, and text-mode type.
+      4692,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(
@@ -164,7 +165,8 @@ export function readPluginSdkSurfaceBudgets(env = process.env) {
       // +1: plugin-owned sensitive-schema registration.
       // +2: generic inbound-root and SCP-host schema validators.
       // +1: attributed-range renderer.
-      2839,
+      // +1: approval markdown downgrade helper.
+      2840,
       env,
     ),
     publicDeprecatedExports: readPluginSdkSurfaceBudgetEnv(

--- a/src/channels/plugins/approvals.test.ts
+++ b/src/channels/plugins/approvals.test.ts
@@ -1,6 +1,10 @@
 // Approval tests cover channel plugin approval request formatting and dispatch.
 import { describe, expect, it, vi } from "vitest";
-import { resolveChannelApprovalAdapter, resolveChannelApprovalCapability } from "./approvals.js";
+import {
+  resolveChannelApprovalAdapter,
+  resolveChannelApprovalCapability,
+  resolveChannelApprovalTextMode,
+} from "./approvals.js";
 
 function createNativeRuntimeStub() {
   return {
@@ -48,6 +52,34 @@ describe("resolveChannelApprovalCapability", () => {
       render: undefined,
       native: undefined,
     });
+  });
+});
+
+describe("resolveChannelApprovalTextMode", () => {
+  it("defaults to plaintext when nothing is declared", () => {
+    expect(resolveChannelApprovalTextMode({})).toBe("plaintext");
+    expect(resolveChannelApprovalTextMode({ approvalCapability: {} })).toBe("plaintext");
+  });
+
+  it("returns the declared mode", () => {
+    expect(
+      resolveChannelApprovalTextMode({ approvalCapability: { approvalText: "markdown" } }),
+    ).toBe("markdown");
+  });
+
+  it("resolves for auth-only capabilities that project no adapter", () => {
+    // Regression guard: resolveChannelApprovalAdapter returns undefined for
+    // auth-only capabilities and copies a fixed field list, so reading the mode
+    // through that projection would fail on exactly the channels the default
+    // exists to protect.
+    const plugin = {
+      approvalCapability: {
+        authorizeActorAction: () => ({ authorized: true }),
+        approvalText: "markdown" as const,
+      },
+    };
+    expect(resolveChannelApprovalAdapter(plugin)).toBeUndefined();
+    expect(resolveChannelApprovalTextMode(plugin)).toBe("markdown");
   });
 });
 

--- a/src/channels/plugins/approvals.ts
+++ b/src/channels/plugins/approvals.ts
@@ -3,6 +3,10 @@
  *
  * Projects plugin approval metadata into runtime approval delivery adapters.
  */
+import {
+  DEFAULT_APPROVAL_TEXT_MODE,
+  type ChannelApprovalTextMode,
+} from "../../plugin-sdk/approval-markdown.js";
 import type { ChannelApprovalAdapter, ChannelApprovalCapability } from "./types.adapters.js";
 import type { ChannelPlugin } from "./types.plugin.js";
 
@@ -13,6 +17,20 @@ export function resolveChannelApprovalCapability(
   plugin?: Pick<ChannelPlugin, "approvalCapability"> | null,
 ): ChannelApprovalCapability | undefined {
   return plugin?.approvalCapability;
+}
+
+/**
+ * Returns how a channel handles canonical approval markdown.
+ *
+ * Reads the capability directly rather than the adapter projection below:
+ * auth-only channels project no adapter at all, yet still receive approval
+ * text through the forwarder fallback, and they are most of the channels
+ * this mode exists to protect.
+ */
+export function resolveChannelApprovalTextMode(
+  plugin?: Pick<ChannelPlugin, "approvalCapability"> | null,
+): ChannelApprovalTextMode {
+  return resolveChannelApprovalCapability(plugin)?.approvalText ?? DEFAULT_APPROVAL_TEXT_MODE;
 }
 
 /**

--- a/src/channels/plugins/index.ts
+++ b/src/channels/plugins/index.ts
@@ -25,4 +25,8 @@ export {
 } from "../allowlist-match.js";
 export type { ChannelId } from "./types.public.js";
 export type { ChannelPlugin } from "./types.plugin.js";
-export { resolveChannelApprovalAdapter, resolveChannelApprovalCapability } from "./approvals.js";
+export {
+  resolveChannelApprovalAdapter,
+  resolveChannelApprovalCapability,
+  resolveChannelApprovalTextMode,
+} from "./approvals.js";

--- a/src/channels/plugins/types.adapters.ts
+++ b/src/channels/plugins/types.adapters.ts
@@ -15,6 +15,7 @@ import type {
   PluginApprovalRequest,
   PluginApprovalResolved,
 } from "../../infra/plugin-approvals.js";
+import type { ChannelApprovalTextMode } from "../../plugin-sdk/approval-markdown.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import type { ResolverContext, SecretDefaults } from "../../secrets/runtime-shared.js";
 import type { SecretTargetRegistryEntry } from "../../secrets/target-registry-types.js";
@@ -634,6 +635,16 @@ export type ChannelApprovalAdapter = {
 };
 
 export type ChannelApprovalCapability = ChannelApprovalAdapter & {
+  /**
+   * How this channel handles the canonical approval markdown subset.
+   * Defaults to `plaintext`, which downgrades before send. Declaring
+   * `markdown` means the channel owns the translation and any escaping.
+   *
+   * Lives on the capability rather than the adapter because auth-only
+   * channels have no adapter projection but still receive approval text
+   * through the forwarder fallback.
+   */
+  approvalText?: ChannelApprovalTextMode;
   authorizeActorAction?: (params: {
     cfg: OpenClawConfig;
     accountId?: string | null;

--- a/src/infra/exec-approval-forwarder.test.ts
+++ b/src/infra/exec-approval-forwarder.test.ts
@@ -158,6 +158,9 @@ const telegramApprovalPlugin: Pick<
 > = {
   ...createChannelTestPluginBase({ id: "telegram" }),
   approvalCapability: {
+    // Mirrors the shipped Telegram declaration, so the fence-formatting cases
+    // below keep asserting the canonical markdown rather than its downgrade.
+    approvalText: "markdown",
     delivery: {
       shouldSuppressForwardingFallback: (params: {
         cfg: OpenClawConfig;
@@ -194,6 +197,16 @@ const discordApprovalPlugin: Pick<
     },
   },
 };
+// TARGETS_CFG forwards to slack, so this fixture decides whether the delivered
+// fallback text keeps its canonical markdown. Mirrors the shipped Slack
+// declaration; without it every fallback assertion below sees the downgrade.
+const slackApprovalPlugin: Pick<
+  ChannelPlugin,
+  "id" | "meta" | "capabilities" | "config" | "approvalCapability"
+> = {
+  ...createChannelTestPluginBase({ id: "slack" as ChannelPlugin["id"] }),
+  approvalCapability: { approvalText: "markdown" },
+};
 const defaultRegistry = createTestRegistry([
   {
     pluginId: "telegram",
@@ -203,6 +216,11 @@ const defaultRegistry = createTestRegistry([
   {
     pluginId: "discord",
     plugin: discordApprovalPlugin,
+    source: "test",
+  },
+  {
+    pluginId: "slack",
+    plugin: slackApprovalPlugin,
     source: "test",
   },
 ]);
@@ -668,6 +686,38 @@ describe("exec approval forwarder", () => {
     },
   ])("formats forwarded approval text for %j", async ({ command, expectedText }) => {
     await expectForwardedApprovalText({ command, expectedText });
+  });
+
+  it("downgrades forwarded approval text for channels that declare no mode", async () => {
+    vi.useFakeTimers();
+    // Same delivery target as the markdown cases, but declaring no mode — the
+    // shape of every auth-only channel: no render adapter, no native runtime.
+    setActivePluginRegistry(
+      createTestRegistry([
+        { pluginId: "telegram", plugin: telegramApprovalPlugin, source: "test" },
+        { pluginId: "discord", plugin: discordApprovalPlugin, source: "test" },
+        {
+          pluginId: "slack",
+          plugin: {
+            ...createChannelTestPluginBase({ id: "slack" as ChannelPlugin["id"] }),
+            approvalCapability: { authorizeActorAction: () => ({ authorized: true }) },
+          } satisfies Pick<
+            ChannelPlugin,
+            "id" | "meta" | "capabilities" | "config" | "approvalCapability"
+          >,
+          source: "test",
+        },
+      ]),
+    );
+    const { deliver, forwarder } = createForwarder({ cfg: TARGETS_CFG });
+    await expect(forwarder.handleRequested(baseRequest)).resolves.toBe(true);
+    await Promise.resolve();
+    const text = getFirstDeliveryText(deliver);
+    expect(text).not.toContain("`");
+    // Content survives the downgrade: only the markers are gone.
+    expect(text).toContain("🔒 Exec approval required");
+    expect(text).toContain("Command: echo hello");
+    expect(text).toContain("Reply with: /approve req-1 allow-once|allow-always|deny");
   });
 
   it("returns false when forwarding is disabled", async () => {

--- a/src/infra/exec-approval-forwarder.ts
+++ b/src/infra/exec-approval-forwarder.ts
@@ -13,7 +13,7 @@ import type {
 } from "../config/types.approvals.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
-import { downgradeApprovalMarkdownToPlaintext } from "../plugin-sdk/approval-markdown.js";
+import { downgradeApprovalMarkdownToPlaintext } from "../plugin-sdk/approval-markdown.runtime.js";
 import {
   buildApprovalResolvedReplyPayload,
   buildPluginApprovalResolvedReplyPayload,

--- a/src/infra/exec-approval-forwarder.ts
+++ b/src/infra/exec-approval-forwarder.ts
@@ -4,6 +4,7 @@ import type { ReplyPayload } from "../auto-reply/types.js";
 import {
   getLoadedChannelPlugin,
   resolveChannelApprovalAdapter,
+  resolveChannelApprovalTextMode,
 } from "../channels/plugins/index.js";
 import { getRuntimeConfig } from "../config/config.js";
 import type {
@@ -12,6 +13,7 @@ import type {
 } from "../config/types.approvals.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { downgradeApprovalMarkdownToPlaintext } from "../plugin-sdk/approval-markdown.js";
 import {
   buildApprovalResolvedReplyPayload,
   buildPluginApprovalResolvedReplyPayload,
@@ -413,12 +415,20 @@ function buildApprovalRenderPayload<TParams>(params: {
   buildFallback: () => ReplyPayload;
 }): ReplyPayload {
   const channel = normalizeMessageChannel(params.target.channel) ?? params.target.channel;
+  const plugin = channel ? getLoadedChannelPlugin(channel) : undefined;
   const adapterPayload = channel
-    ? params.resolveRenderer(resolveChannelApprovalAdapter(getLoadedChannelPlugin(channel)))?.(
-        params.renderParams,
-      )
+    ? params.resolveRenderer(resolveChannelApprovalAdapter(plugin))?.(params.renderParams)
     : null;
-  return adapterPayload ?? params.buildFallback();
+  const payload = adapterPayload ?? params.buildFallback();
+  // Approval text is canonical markdown. A channel that has not declared it
+  // renders the subset gets the plaintext projection here, so markers never
+  // reach a transport that would show them literally. Presentation and
+  // channelData are untouched: buttons and metadata are not text.
+  const mode = resolveChannelApprovalTextMode(plugin);
+  if (mode === "markdown" || !payload.text) {
+    return payload;
+  }
+  return { ...payload, text: downgradeApprovalMarkdownToPlaintext(payload.text) };
 }
 
 function buildExecPendingPayload(params: {

--- a/src/plugin-sdk/approval-delivery-helpers.ts
+++ b/src/plugin-sdk/approval-delivery-helpers.ts
@@ -36,6 +36,8 @@ type DeliverySuppressionParams = {
 };
 
 type ApproverRestrictedNativeApprovalParams = {
+  /** How the channel handles canonical approval markdown. Defaults to plaintext. */
+  approvalText?: ChannelApprovalCapability["approvalText"];
   /** Channel id that owns this native approval capability. */
   channel: string;
   /** Human-readable channel label used in denial messages. */
@@ -215,6 +217,7 @@ function buildApproverRestrictedNativeApprovalCapability(
           }
         : undefined,
     nativeRuntime: params.nativeRuntime,
+    approvalText: params.approvalText,
   });
 }
 
@@ -247,6 +250,8 @@ export function createChannelApprovalCapability(params: {
   render?: ChannelApprovalCapability["render"];
   /** Native target/capability discovery hooks. */
   native?: ChannelApprovalCapability["native"];
+  /** How the channel handles canonical approval markdown. Defaults to plaintext. */
+  approvalText?: ChannelApprovalCapability["approvalText"];
 }): ChannelApprovalCapability {
   const surfaces: ChannelApprovalCapabilitySurfaces = {
     delivery: params.delivery,
@@ -265,6 +270,7 @@ export function createChannelApprovalCapability(params: {
     nativeRuntime: surfaces.nativeRuntime,
     render: surfaces.render,
     native: surfaces.native,
+    approvalText: params.approvalText,
   };
 }
 

--- a/src/plugin-sdk/approval-markdown.runtime.ts
+++ b/src/plugin-sdk/approval-markdown.runtime.ts
@@ -1,0 +1,34 @@
+/**
+ * Runtime side of the approval markdown contract (RFC 0002).
+ *
+ * Kept separate from `approval-markdown.ts` because it imports the markdown
+ * parser (`stripMarkdown`). Only the async send/forward path needs the
+ * downgrade, so the parser must not reach the channel registry hot path that
+ * imports the lightweight contract file.
+ */
+import { stripMarkdown } from "../shared/text/strip-markdown.js";
+
+export type { ChannelApprovalTextMode } from "./approval-markdown.js";
+export { DEFAULT_APPROVAL_TEXT_MODE } from "./approval-markdown.js";
+
+/**
+ * Project canonical approval markdown down to plaintext.
+ *
+ * Content-lossless, not byte-identical: the projection trims the message's
+ * outer edges, so a prompt consisting of nothing but a fence would lose that
+ * fence's surrounding whitespace. Fenced content in the body of a prompt — the
+ * shape every approval builder emits, since the command fence is always
+ * followed by the host and id block — survives exactly.
+ *
+ * Both options are pinned deliberately and must not become caller-configurable:
+ *
+ *  - `plain-text` mode, because the speech projection collapses repeated
+ *    punctuation and punctuation-only lines, which would silently rewrite a
+ *    pending shell command inside its own fence.
+ *  - `label-and-url` links, because label-only projection hides a link's
+ *    destination from the person being asked to approve it. That is a security
+ *    property of an approval prompt, not a formatting preference.
+ */
+export function downgradeApprovalMarkdownToPlaintext(text: string): string {
+  return stripMarkdown(text, { mode: "plain-text", linkStyle: "label-and-url" });
+}

--- a/src/plugin-sdk/approval-markdown.test.ts
+++ b/src/plugin-sdk/approval-markdown.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { downgradeApprovalMarkdownToPlaintext } from "./approval-markdown.js";
+import { downgradeApprovalMarkdownToPlaintext } from "./approval-markdown.runtime.js";
 
 const APPROVAL_ID = "a7a8b519-2311-4dcd-bccf-d6ca1d737969";
 const PENDING_COMMAND = 'curl -sS -o /dev/null -w "%{http_code}" https://example.com';

--- a/src/plugin-sdk/approval-markdown.test.ts
+++ b/src/plugin-sdk/approval-markdown.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { downgradeApprovalMarkdownToPlaintext } from "./approval-markdown.js";
+
+const APPROVAL_ID = "a7a8b519-2311-4dcd-bccf-d6ca1d737969";
+const PENDING_COMMAND = 'curl -sS -o /dev/null -w "%{http_code}" https://example.com';
+
+/** Shape every approval builder emits: fences in the body, id block last. */
+function buildPrompt(command: string): string {
+  return [
+    "Approval required.",
+    "Run:",
+    "```txt\n/approve " + APPROVAL_ID + " allow-once\n```",
+    "Pending command:",
+    "```sh\n" + command + "\n```",
+    `Host: gateway\nFull id: \`${APPROVAL_ID}\``,
+  ].join("\n\n");
+}
+
+describe("downgradeApprovalMarkdownToPlaintext", () => {
+  it("removes every canonical marker", () => {
+    const out = downgradeApprovalMarkdownToPlaintext(buildPrompt(PENDING_COMMAND));
+    expect(out).not.toContain("`");
+    expect(out).not.toContain("```");
+  });
+
+  it("preserves the command, the id, and the approve instruction verbatim", () => {
+    const out = downgradeApprovalMarkdownToPlaintext(buildPrompt(PENDING_COMMAND));
+    // Substring, not whole-string equality: the projection trims the message's
+    // outer edges, so byte-identity holds for body content, not the envelope.
+    expect(out).toContain(PENDING_COMMAND);
+    expect(out).toContain(`/approve ${APPROVAL_ID} allow-once`);
+    expect(out).toContain(APPROVAL_ID);
+  });
+
+  it("does not rewrite punctuation-heavy command text", () => {
+    // Pins mode: "plain-text". The speech projection collapses repeated
+    // punctuation and punctuation-only lines, which would corrupt a command.
+    const hostile = 'run --flag !! && echo "..." ; test **x** ; echo ---';
+    const out = downgradeApprovalMarkdownToPlaintext(buildPrompt(hostile));
+    expect(out).toContain(hostile);
+  });
+
+  it("preserves whitespace inside a fenced command", () => {
+    const indented = "  indented --flag\ntrailing   \n\nafter-blank-line";
+    const out = downgradeApprovalMarkdownToPlaintext(buildPrompt(indented));
+    expect(out).toContain(indented);
+  });
+
+  it("keeps link destinations visible to the approver", () => {
+    // Pins linkStyle: "label-and-url". Hiding a destination behind a label in
+    // a prompt asking someone to approve an action is a security downgrade.
+    const out = downgradeApprovalMarkdownToPlaintext(
+      "Approve fetch of [the report](https://example.invalid/report).",
+    );
+    expect(out).toContain("https://example.invalid/report");
+  });
+
+  it("strips emphasis without touching the words", () => {
+    const out = downgradeApprovalMarkdownToPlaintext(
+      "**Approval required.** The command makes an _external_ network request.",
+    );
+    expect(out).toContain("Approval required.");
+    expect(out).toContain("external");
+    expect(out).not.toContain("**");
+    expect(out).not.toContain("_external_");
+  });
+});

--- a/src/plugin-sdk/approval-markdown.ts
+++ b/src/plugin-sdk/approval-markdown.ts
@@ -18,33 +18,27 @@
  * to plaintext, declared through `approvalText` on its approval capability.
  * There is no implicit pass-through: handing canonical markdown to a transport
  * that will not render it is how approvers end up reading literal backticks.
+ *
+ * This file is the lightweight contract only — the mode type and its default.
+ * It is imported by the channel registry (`approvals.ts`), which sits on hot
+ * gateway/config/command startup paths, so it must stay free of heavy imports.
+ * The downgrade implementation lives in `approval-markdown.runtime.ts` because
+ * it pulls in the markdown parser and is only needed on the async send path.
  */
-import { stripMarkdown } from "../shared/text/strip-markdown.js";
 
 /** How a channel handles the canonical approval markdown subset. */
 export type ChannelApprovalTextMode = "markdown" | "plaintext";
 
-/** Mode assumed when a channel declares nothing. Safe for every transport. */
-export const DEFAULT_APPROVAL_TEXT_MODE: ChannelApprovalTextMode = "plaintext";
-
 /**
- * Project canonical approval markdown down to plaintext.
+ * Mode assumed when a channel declares nothing. Safe for every transport: it
+ * never sends raw markers.
  *
- * Content-lossless, not byte-identical: the projection trims the message's
- * outer edges, so a prompt consisting of nothing but a fence would lose that
- * fence's surrounding whitespace. Fenced content in the body of a prompt — the
- * shape every approval builder emits, since the command fence is always
- * followed by the host and id block — survives exactly.
- *
- * Both options are pinned deliberately and must not become caller-configurable:
- *
- *  - `plain-text` mode, because the speech projection collapses repeated
- *    punctuation and punctuation-only lines, which would silently rewrite a
- *    pending shell command inside its own fence.
- *  - `label-and-url` links, because label-only projection hides a link's
- *    destination from the person being asked to approve it. That is a security
- *    property of an approval prompt, not a formatting preference.
+ * This is an intentional opt-in default (RFC 0002), and it does change behavior
+ * for an existing third-party channel that renders markdown but has not yet
+ * declared `approvalText`: its forwarded approval text downgrades to plaintext
+ * on upgrade until it opts in. That trade is deliberate — plaintext can only
+ * ever lose rendering, never leak literal `**`/fences to an approver, which is
+ * the failure mode that matters when the person is being asked to approve a
+ * shell command. Channels that render markdown opt in explicitly.
  */
-export function downgradeApprovalMarkdownToPlaintext(text: string): string {
-  return stripMarkdown(text, { mode: "plain-text", linkStyle: "label-and-url" });
-}
+export const DEFAULT_APPROVAL_TEXT_MODE: ChannelApprovalTextMode = "plaintext";

--- a/src/plugin-sdk/approval-markdown.ts
+++ b/src/plugin-sdk/approval-markdown.ts
@@ -1,0 +1,50 @@
+/**
+ * Canonical markdown contract for approval prompt text (RFC 0002).
+ *
+ * Core builds approval prompts once and every channel receives the same
+ * string. That string is markdown, in a fixed subset:
+ *
+ *  - `**bold**`, `_italic_`, `~~strikethrough~~`
+ *  - `` `inline code` ``
+ *  - fenced code blocks, with an advisory language hint (`sh` for a pending
+ *    command, `txt` for a plain block)
+ *
+ * Underline is excluded: most transports cannot express it, so core never
+ * emits it. Language hints are advisory — a channel may honour one for native
+ * highlighting and must drop an unsupported hint without altering the fenced
+ * content.
+ *
+ * A channel either translates this subset into native styling or downgrades it
+ * to plaintext, declared through `approvalText` on its approval capability.
+ * There is no implicit pass-through: handing canonical markdown to a transport
+ * that will not render it is how approvers end up reading literal backticks.
+ */
+import { stripMarkdown } from "../shared/text/strip-markdown.js";
+
+/** How a channel handles the canonical approval markdown subset. */
+export type ChannelApprovalTextMode = "markdown" | "plaintext";
+
+/** Mode assumed when a channel declares nothing. Safe for every transport. */
+export const DEFAULT_APPROVAL_TEXT_MODE: ChannelApprovalTextMode = "plaintext";
+
+/**
+ * Project canonical approval markdown down to plaintext.
+ *
+ * Content-lossless, not byte-identical: the projection trims the message's
+ * outer edges, so a prompt consisting of nothing but a fence would lose that
+ * fence's surrounding whitespace. Fenced content in the body of a prompt — the
+ * shape every approval builder emits, since the command fence is always
+ * followed by the host and id block — survives exactly.
+ *
+ * Both options are pinned deliberately and must not become caller-configurable:
+ *
+ *  - `plain-text` mode, because the speech projection collapses repeated
+ *    punctuation and punctuation-only lines, which would silently rewrite a
+ *    pending shell command inside its own fence.
+ *  - `label-and-url` links, because label-only projection hides a link's
+ *    destination from the person being asked to approve it. That is a security
+ *    property of an approval prompt, not a formatting preference.
+ */
+export function downgradeApprovalMarkdownToPlaintext(text: string): string {
+  return stripMarkdown(text, { mode: "plain-text", linkStyle: "label-and-url" });
+}

--- a/src/plugin-sdk/approval-reply-runtime.ts
+++ b/src/plugin-sdk/approval-reply-runtime.ts
@@ -17,11 +17,8 @@ export {
   type ExecApprovalReplyDecision,
   type ExecApprovalReplyMetadata,
 } from "../infra/exec-approval-reply.js";
-export {
-  downgradeApprovalMarkdownToPlaintext,
-  DEFAULT_APPROVAL_TEXT_MODE,
-  type ChannelApprovalTextMode,
-} from "./approval-markdown.js";
+export { DEFAULT_APPROVAL_TEXT_MODE, type ChannelApprovalTextMode } from "./approval-markdown.js";
+export { downgradeApprovalMarkdownToPlaintext } from "./approval-markdown.runtime.js";
 export { resolveExecApprovalCommandDisplay } from "../infra/exec-approval-command-display.js";
 export {
   resolveExecApprovalAllowedDecisions,

--- a/src/plugin-sdk/approval-reply-runtime.ts
+++ b/src/plugin-sdk/approval-reply-runtime.ts
@@ -17,6 +17,11 @@ export {
   type ExecApprovalReplyDecision,
   type ExecApprovalReplyMetadata,
 } from "../infra/exec-approval-reply.js";
+export {
+  downgradeApprovalMarkdownToPlaintext,
+  DEFAULT_APPROVAL_TEXT_MODE,
+  type ChannelApprovalTextMode,
+} from "./approval-markdown.js";
 export { resolveExecApprovalCommandDisplay } from "../infra/exec-approval-command-display.js";
 export {
   resolveExecApprovalAllowedDecisions,

--- a/test/approval-text-conformance.test.ts
+++ b/test/approval-text-conformance.test.ts
@@ -1,0 +1,126 @@
+// Locks the per-channel approvalText audit (RFC 0002 step 1).
+//
+// The regression this guards against: a channel whose outbound path renders the
+// canonical markdown subset is left at the plaintext default, so the forwarder
+// downgrade strips formatting the channel shows today. That is exactly how
+// Feishu and Teams slipped through the first pass — both render markdown
+// (markdownDialect) but were not declared. This test pins the full audit so a
+// new channel, or a channel that gains markdown rendering, cannot silently take
+// the wrong default.
+//
+// Source-scanning rather than runtime: declarations live in three shapes
+// (inline in channel.ts, an exported const, a factory), and importing every
+// channel plugin would pull all hot-path channel modules into one test. Reading
+// the source keeps the guard cheap and declaration-shape agnostic.
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const extensionsDir = path.join(repoRoot, "extensions");
+
+/**
+ * Expected approval text mode per channel, with the render mechanism that
+ * justifies it. "markdown" means the outbound path renders the canonical
+ * subset, so approval text must stay markdown. "plaintext" means no render
+ * mechanism exists, so the safe default is correct.
+ */
+const EXPECTED: Record<string, { mode: "markdown" | "plaintext"; why: string }> = {
+  // Render markdown via outbound presentation (markdownDialect: "markdown").
+  feishu: { mode: "markdown", why: "markdownDialect card renderer" },
+  matrix: { mode: "markdown", why: "markdownDialect formatted_body" },
+  mattermost: { mode: "markdown", why: "markdownDialect, server renders markdown" },
+  msteams: { mode: "markdown", why: "markdownDialect Adaptive Card TextBlock" },
+  telegram: { mode: "markdown", why: "markdownDialect parse-mode send" },
+  // Render markdown via a channel-specific mechanism (send-path conversion,
+  // native payloads, or a markdown transport message type).
+  discord: { mode: "markdown", why: "native component payloads render markdown" },
+  signal: { mode: "markdown", why: "send-path markdownToSignalText" },
+  slack: { mode: "markdown", why: "native mrkdwn/Block Kit payloads" },
+  whatsapp: { mode: "markdown", why: "send-path markdownToWhatsApp" },
+  qqbot: { mode: "markdown", why: "msg_type 2 markdown on enabled accounts" },
+  // No markdown render mechanism: plaintext default is correct.
+  googlechat: { mode: "plaintext", why: "no markdown render mechanism" },
+  "nextcloud-talk": { mode: "plaintext", why: "no markdownDialect, no send-path render" },
+  "synology-chat": { mode: "plaintext", why: "no markdown render mechanism" },
+  zalo: { mode: "plaintext", why: "no markdown render mechanism" },
+  // Intentionally plaintext for step 1; step 2 (#85954) flips it to markdown.
+  imessage: { mode: "plaintext", why: "step-1 default; typed runs land in step 2" },
+};
+
+function readChannelSource(channel: string): string {
+  const srcDir = path.join(extensionsDir, channel, "src");
+  const parts: string[] = [];
+  const walk = (dir: string): void => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+      } else if (entry.name.endsWith(".ts") && !entry.name.endsWith(".test.ts")) {
+        parts.push(fs.readFileSync(full, "utf8"));
+      }
+    }
+  };
+  walk(srcDir);
+  return parts.join("\n");
+}
+
+function declaresApprovalCapability(source: string): boolean {
+  return /approvalCapability\b/.test(source) || /createChannelApprovalAuth\b/.test(source);
+}
+
+function declaresMarkdownApprovalText(source: string): boolean {
+  return /approvalText:\s*"markdown"/.test(source);
+}
+
+function rendersMarkdown(source: string): boolean {
+  return /markdownDialect:\s*"markdown"/.test(source);
+}
+
+const channelDirs = fs
+  .readdirSync(extensionsDir, { withFileTypes: true })
+  .filter((entry) => entry.isDirectory())
+  .map((entry) => entry.name)
+  .filter((name) => fs.existsSync(path.join(extensionsDir, name, "src")))
+  .filter((name) => declaresApprovalCapability(readChannelSource(name)))
+  .sort();
+
+describe("approvalText per-channel audit (RFC 0002 step 1)", () => {
+  it("covers every channel that declares an approval capability", () => {
+    // A new approval-capable channel must land in EXPECTED with an explicit
+    // audit decision rather than silently defaulting to plaintext.
+    const unaccounted = channelDirs.filter((c) => !(c in EXPECTED));
+    expect(unaccounted, `undocumented approval channels: ${unaccounted.join(", ")}`).toEqual([]);
+  });
+
+  it.each(channelDirs)("%s declares the audited approvalText mode", (channel) => {
+    const source = readChannelSource(channel);
+    const expected = EXPECTED[channel];
+    expect(expected, `channel ${channel} missing from EXPECTED`).toBeDefined();
+    if (expected.mode === "markdown") {
+      expect(
+        declaresMarkdownApprovalText(source),
+        `${channel} renders markdown (${expected.why}) but does not declare approvalText: "markdown"`,
+      ).toBe(true);
+    } else {
+      expect(
+        declaresMarkdownApprovalText(source),
+        `${channel} is expected plaintext (${expected.why}) but declares approvalText: "markdown"`,
+      ).toBe(false);
+    }
+  });
+
+  it("declares approvalText: \"markdown\" for every channel whose outbound renders markdown via markdownDialect", () => {
+    // The invariant that would have caught Feishu and Teams automatically:
+    // a markdownDialect renderer must not downgrade its approval text.
+    const violations = channelDirs.filter((channel) => {
+      const source = readChannelSource(channel);
+      return rendersMarkdown(source) && !declaresMarkdownApprovalText(source);
+    });
+    expect(
+      violations,
+      `channels rendering markdown but defaulting approvals to plaintext: ${violations.join(", ")}`,
+    ).toEqual([]);
+  });
+});

--- a/test/approval-text-conformance.test.ts
+++ b/test/approval-text-conformance.test.ts
@@ -39,8 +39,9 @@ const EXPECTED: Record<string, { mode: "markdown" | "plaintext"; why: string }> 
   signal: { mode: "markdown", why: "send-path markdownToSignalText" },
   slack: { mode: "markdown", why: "native mrkdwn/Block Kit payloads" },
   whatsapp: { mode: "markdown", why: "send-path markdownToWhatsApp" },
-  qqbot: { mode: "markdown", why: "msg_type 2 markdown on enabled accounts" },
-  // No markdown render mechanism: plaintext default is correct.
+  // No markdown render mechanism, or per-account rendering that no channel-wide
+  // mode can serve safely: plaintext default is correct.
+  qqbot: { mode: "plaintext", why: "markdown is per-account (markdownSupport); false sends raw msg_type 0" },
   googlechat: { mode: "plaintext", why: "no markdown render mechanism" },
   "nextcloud-talk": { mode: "plaintext", why: "no markdownDialect, no send-path render" },
   "synology-chat": { mode: "plaintext", why: "no markdown render mechanism" },
@@ -66,16 +67,37 @@ function readChannelSource(channel: string): string {
   return parts.join("\n");
 }
 
+/**
+ * Drop comment lines and inline trailing comments before scanning, so a
+ * declaration named only in prose (a code comment or example) never counts as
+ * a real declaration. Line-based: skips block/line comment lines and cuts
+ * anything after an inline `//`.
+ */
+function codeLines(source: string): string {
+  return source
+    .split("\n")
+    .filter((line) => {
+      const trimmed = line.trimStart();
+      return !trimmed.startsWith("//") && !trimmed.startsWith("*") && !trimmed.startsWith("/*");
+    })
+    .map((line) => {
+      const inlineComment = line.indexOf("//");
+      return inlineComment === -1 ? line : line.slice(0, inlineComment);
+    })
+    .join("\n");
+}
+
 function declaresApprovalCapability(source: string): boolean {
-  return /approvalCapability\b/.test(source) || /createChannelApprovalAuth\b/.test(source);
+  const code = codeLines(source);
+  return /approvalCapability\b/.test(code) || /createChannelApprovalAuth\b/.test(code);
 }
 
 function declaresMarkdownApprovalText(source: string): boolean {
-  return /approvalText:\s*"markdown"/.test(source);
+  return /approvalText:\s*"markdown"/.test(codeLines(source));
 }
 
 function rendersMarkdown(source: string): boolean {
-  return /markdownDialect:\s*"markdown"/.test(source);
+  return /markdownDialect:\s*"markdown"/.test(codeLines(source));
 }
 
 const channelDirs = fs


### PR DESCRIPTION
Related: #85954
RFC: https://github.com/openclaw/rfcs/blob/main/rfcs/0002-approval-prompt-markdown.md

## What Problem This Solves

Core builds approval prompts once and sends the same string to every channel,
and that string is already markdown: `formatFencedCodeBlock` for the pending
command, `formatInlineCodeSpan` for the full approval id. Nothing declares who
renders it.

On channels that parse markdown it renders. On channels that do not, the person
being asked to approve a shell command reads six literal fence lines and a
backticked id. Six channels declare an auth-only approval capability — Feishu,
Mattermost, Microsoft Teams, Nextcloud Talk, Synology Chat, Zalo — so they have
no render adapter and no native approval runtime, take their text from the
forwarder fallback at `src/infra/exec-approval-forwarder.ts`, and apply no
markdown translation on the way out.

Whether an approval prompt renders is currently a property of the transport,
declared nowhere.

This is step 1 of accepted RFC 0002. iMessage native rendering (#85954) is
step 2.

## Why This Change Was Made

Adds `approvalText: "markdown" | "plaintext"` to `ChannelApprovalCapability`,
defaulting to `plaintext`, plus `downgradeApprovalMarkdownToPlaintext` in the
plugin SDK. Core applies the downgrade on the forwarder path, where the target
channel is already resolved.

Three decisions worth review:

**The field is on the capability, not the adapter.**
`resolveChannelApprovalAdapter` copies a fixed field list and returns
`undefined` entirely for auth-only capabilities — which is most of the channels
this protects. Core reads the mode with `resolveChannelApprovalTextMode`, built
on `resolveChannelApprovalCapability`. `createChannelApprovalCapability` and
`createApproverRestrictedNativeApprovalCapability` had the same
enumerate-and-drop shape and now thread the field through; without that, a
channel could declare the mode and have it silently discarded.

**The default is not behavior-neutral, and the declarations matter.** Telegram,
Matrix, Signal, and WhatsApp convert the subset in their send paths today, so
they declare `markdown` here or they regress. Slack and Discord author native
payloads in their own approval runtimes and the forwarder default never reaches
them; their declaration records intent. **Mattermost is the interesting case**:
auth-only capability, no render adapter, but its server renders markdown — so it
declares `markdown` despite having no adapter, which is exactly why the field
cannot live on the adapter projection.

**The helper wraps `stripMarkdown` rather than adding a second stripper.** It
pins two options that must not be caller-configurable at this boundary:
`mode: "plain-text"`, because the speech projection collapses repeated
punctuation and would rewrite a shell command inside its own fence; and
`linkStyle: "label-and-url"`, because hiding a link destination from someone
being asked to approve an action is a security downgrade, not a formatting
choice.

Not behavior-neutral by design, and scoped: the canonical builders still emit
exactly the markdown they emit today. This PR decides who renders it, not what
it says.

## User Impact

- **Feishu, Microsoft Teams, Nextcloud Talk, Synology Chat, Zalo** — approval
  prompts lose the stray fence markers and backticks. Wording, approval id,
  command text, and both `/approve` lines are preserved verbatim.
- **Telegram, Matrix, Signal, WhatsApp, Slack, Discord, Mattermost** — no
  change. Existing rendering becomes a declared, tested contract instead of
  incidental behavior.
- **iMessage** — markers stop appearing. Its converter handles bold, italic,
  underline, and strikethrough but ignores code spans and fences, so prompts
  currently show literal backticks. Bold labels arrive in step 2, which is what
  #85954 asks for.
- **Third-party channel plugins** — additive and optional. Declaring nothing
  gets the safe plaintext default. No config change, no migration, no operator
  action.

## Evidence

- `src/plugin-sdk/approval-markdown.test.ts` — marker removal, and verbatim
  survival of the command, id, and `/approve` instruction. Asserts substring
  survival rather than whole-string equality, because the projection trims the
  message envelope. Includes a punctuation-heavy command (`!!`, `...`, `**`)
  pinning `plain-text` mode, a whitespace-in-fence case, and a link case pinning
  `label-and-url`.
- `src/channels/plugins/approvals.test.ts` — default, declared, and the
  regression guard proving an auth-only capability resolves its mode while
  `resolveChannelApprovalAdapter` returns `undefined` for the same plugin.
- `src/infra/exec-approval-forwarder.test.ts` — a channel declaring no mode has
  its delivered text downgraded with content intact. The existing
  fence-formatting cases now declare `markdown` on the Telegram fixture,
  matching the shipped declaration, so they keep asserting canonical markdown.

**Known proof gaps, stated rather than implied:**

- No real-channel delivery proof in this PR. The seven channels declaring
  `markdown` document behavior they already ship. Live delivery proof belongs
  with step 2, where rendering actually changes.
- Mattermost's server-side rendering is asserted from product behavior, not
  from a live run. It is the declaration most worth a reviewer's eye, since
  getting it wrong regresses a working channel.
- Core enforces the downgrade on the forwarder path only. Channels with a
  native approval runtime build their own payloads, so one declaring
  `plaintext` must call the helper itself. No channel does today, but iMessage
  will be in that position from step 1. Documented in the SDK guide and raised
  as the open question in the RFC.
