### PR TITLE
docs: fix control UI config example to use home directory expansion

### DIFF
--- a/docs/start/getting-started.md
+++ b/docs/start/getting-started.md
@@ -106,7 +106,7 @@ Then set:
   "gateway": {
     "controlUi": {
       "enabled": true,
-      "root": "$HOME/.openclaw/control-ui-custom"
+      "root": "~/.openclaw/control-ui-custom"
     }
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users following the "mount a custom Control UI build" example in the Getting Started guide would use a configuration value that does not resolve to their home directory.

## Why This Change Was Made

Updated the configuration example to use `~/.openclaw/control-ui-custom`, which is expanded by OpenClaw's path resolution. This keeps the documentation consistent with the supported configuration behavior.

## User Impact

Users can copy the example configuration directly and have the Control UI path resolve correctly to their home directory.

## Evidence

- Verified that `~` is expanded by OpenClaw's home directory resolution.
- Documentation-only change; no runtime code changes.