### PR TITLE
fix(auto-reply): match throttling transient errors in fallback-state regex

### DIFF
--- a/src/auto-reply/fallback-state.test.ts
+++ b/src/auto-reply/fallback-state.test.ts
@@ -112,6 +112,37 @@ describe("fallback-state", () => {
     expect(resolved.reasonSummary).toContain("Claude Max usage limit reached");
   });
 
+  it.each([
+    // 真实 AWS Bedrock fixture，provenance 可追溯:
+    //   src/agents/failover-error.test.ts:54（引用 AWS troubleshooting 文档）
+    //   src/agents/failover-error.test.ts:688 / provider-error-patterns.test.ts:153
+    "ThrottlingException: Your request was denied due to exceeding the account quotas for Amazon Bedrock.",
+    "ThrottlingException: Too many concurrent requests",
+  ])(
+    "preserves throttle-flavored transient details over the generic rate-limit label (%j)",
+    (error) => {
+      const resolved = resolveDemoFallbackTransition({
+        attempts: [{ ...baseAttempt, error }],
+      });
+
+      // 回归: TRANSIENT_ERROR_DETAIL_HINT_RE 必须命中 throttle 词族
+      // (throttle/throttling/throttled/ThrottlingException)。原先裸 `throttl\b`
+      // 仅匹配不存在的词干 "throttl"，真实 Bedrock 消息全部失配，详细预览被
+      // 塌缩成通用 "rate limit" 标签。修复后预览得以保留。
+      expect(resolved.reasonSummary).toContain("ThrottlingException");
+      expect(resolved.reasonSummary).not.toBe("rate limit");
+    },
+  );
+
+  it("still collapses to the reason label when a transient reason lacks any transient-detail hint", () => {
+    // 防止过度匹配: 修复不得让门控对无 transient 提示的文本也放行。
+    const resolved = resolveDemoFallbackTransition({
+      attempts: [{ ...baseAttempt, error: "Unauthorized: invalid API key" }],
+    });
+
+    expect(resolved.reasonSummary).toBe("rate limit");
+  });
+
   it("keeps truncated transient error details UTF-16 safe", () => {
     const detail = "x".repeat(68);
     const resolved = resolveDemoFallbackTransition({

--- a/src/auto-reply/fallback-state.ts
+++ b/src/auto-reply/fallback-state.ts
@@ -18,7 +18,7 @@ const TRANSIENT_FALLBACK_REASONS = new Set([
   "unclassified",
 ]);
 const TRANSIENT_ERROR_DETAIL_HINT_RE =
-  /\b(?:429|5\d\d|too many requests|usage limit|quota|try again in|retry[- ]after|seconds?|minutes?|hours?|temporarily unavailable|overloaded|service unavailable|throttl)\b/i;
+  /\b(?:429|5\d\d|too many requests|usage limit|quota|try again in|retry[- ]after|seconds?|minutes?|hours?|temporarily unavailable|overloaded|service unavailable|throttl\w*)\b/i;
 
 function truncateFallbackReasonPart(value: string, max = FALLBACK_REASON_PART_MAX): string {
   const text = value.replace(/\s+/g, " ").trim();


### PR DESCRIPTION

## What Problem This Solves

Fixes an issue where error messages containing "throttle", "throttled", "throttling", or "ThrottlingException" are silently collapsed to the generic label "rate limit" in model fallback notices, losing diagnostic detail.

When a provider returns a throttling error (e.g., AWS Bedrock `ThrottlingException: Too many concurrent requests`), the upstream classifier correctly classifies it as `reason = "rate_limit"`, but the fallback-state safety gate regex fails to detect the throttling signal. The error detail is hidden and the user sees only the generic "rate limit" reason.

## Why This Change Was Made

`TRANSIENT_ERROR_DETAIL_HINT_RE` in `src/auto-reply/fallback-state.ts` uses a `\b(?:...)\b` pattern to whitelist transient-looking error texts for detail exposure. One alternative, `throttl\b`, was intended to match all throttling variants (throttle, throttled, throttling, ThrottlingException) as a prefix, but the trailing `\b` word boundary breaks the match: in every real English inflection, `l` is followed by a word character (`e`, `i`, `e`), so `\b` never holds. The branch is dead code.

The fix changes `throttl\b` to `throttl\w*`, matching all word continuations of the "throttl" prefix. This follows the same prefix + optional suffix pattern already established in the same regex (`seconds?`, `minutes?`, `hours?`) and in a parallel safety gate elsewhere in the codebase (`rate[-\s]?limit(?:ed|ing)?` in `manager.backend-failover.ts`).

No changes to upstream classification, failover routing, or persisted session schema. The fix only affects the display path: matching errors now show their text instead of being collapsed to the generic reason label.

## User Impact

Users of providers that return throttling errors without additional transient keywords (e.g., "ThrottlingException: Too many concurrent requests" from AWS Bedrock) now see the specific error text in fallback notices instead of the generic "rate limit" label.

## Evidence

### Before fix (bug reproduction)

**Unit tests** — 2 newly added tests fail as expected:

```
FAIL  src/auto-reply/fallback-state.test.ts
  ✓ 17 passed
  ✗ preserves throttle-flavored transient details … ("ThrottlingException: … account quotas for Amazon Bedrock.")
  ✗ preserves throttle-flavored transient details … ("ThrottlingException: Too many concurrent requests")

  AssertionError: expected 'rate limit' to contain 'ThrottlingException'
```

**Real-behavior proof (MJS harness invoking real production code)** — full chain via `classifyProviderSpecificError` → `resolveFallbackTransition` → `TRANSIENT_ERROR_DETAIL_HINT_RE` + `formatRawAssistantErrorForUi`:

```
=== Real-behavior proof: fallback-state throttl regex (full chain) ===

[throttle msg1 (failover-error.test.ts:54)]
  error          = ThrottlingException: Your request was denied due to exceeding the account quotas for Amazon Bedrock.
  classify→reason = rate_limit  (upstream OK ✓ (bug not upstream))
  reasonSummary   = rate limit
  detail kept    = NO ✗ (collapsed to 'rate limit')

[throttle msg2 (failover-error.test.ts:688)]
  error          = ThrottlingException: Too many concurrent requests
  classify→reason = rate_limit  (upstream OK ✓ (bug not upstream))
  reasonSummary   = rate limit
  detail kept    = NO ✗ (collapsed to 'rate limit')

=== Verdict ===
BUG PRESENT: throttle classified rate_limit upstream, but fallback-state regex (throttl\b) dropped the detail → 'rate limit'
```

The MJS harness (`proof-fallback-throttle.mjs`, 5 files mirroring the established proof architecture in `scripts/proof-retry-session.mjs`) runs real production code paths:
- `classifyProviderSpecificError` from `src/agents/embedded-agent-helpers/provider-error-patterns.ts`
- `resolveFallbackTransition` from `src/auto-reply/fallback-state.ts`
- `formatRawAssistantErrorForUi` from `src/shared/assistant-error-format.ts`
- The only stubs are off-bug-path modules: the barrel's eager re-exports (replaced by thin re-export from the same source) and `areRuntimeModelRefsEquivalent` (used only for `fallbackActive`, not `reasonSummary`).

### After fix (verification)

**Unit tests** — 19/19 pass, including 3 new tests (2 positive, 1 negative):

```
✓ 19 passed (no regressions)
  ✓ preserves throttle-flavored transient details … (both Bedrock fixtures)
  ✓ still collapses to the reason label when a transient reason lacks any transient-detail hint
```

**Real-behavior proof** (exact terminal output):

```
=== Real-behavior proof: fallback-state throttl regex (full chain) ===

[throttle msg1 (failover-error.test.ts:54)]
  error          = ThrottlingException: Your request was denied due to exceeding the account quotas for Amazon Bedrock.
  classify→reason = rate_limit  (upstream OK ✓ (bug not upstream))
  reasonSummary   = ThrottlingException: Your request was denied due to exceeding the account quota…
  detail kept    = YES ✓

[throttle msg2 (failover-error.test.ts:688)]
  error          = ThrottlingException: Too many concurrent requests
  classify→reason = rate_limit  (upstream OK ✓ (bug not upstream))
  reasonSummary   = ThrottlingException: Too many concurrent requests
  detail kept    = YES ✓

=== Verdict ===
FIXED: throttle detail preserved through full real chain (throttl\w* matches)
```

**Checks**:
- `oxfmt` format check: ✅ All matched files use the correct format
- `oxlint` (212 rules): ✅ 0 warnings, 0 errors
- `tsgo:core` typecheck: ✅ EXIT 0
- `tsgo:core:test` typecheck: ✅ EXIT 0
- `tsgo:extensions:test` typecheck: ✅ EXIT 0
- `tsgo:test:root` typecheck: ✅ EXIT 0
- No existing tests regressed (all other test files use error messages without throttling keywords, or already matched via other regex alternatives)

### Fixture provenance

The test error messages are real AWS Bedrock `ThrottlingException` fixtures from the codebase's own test suite:
- `src/agents/failover-error.test.ts:54` — "ThrottlingException: Your request was denied due to exceeding the account quotas for Amazon Bedrock." (from AWS troubleshooting docs)
- `src/agents/failover-error.test.ts:688` — "ThrottlingException: Too many concurrent requests"

Messages of this form are produced by the Bedrock runtime at `extensions/amazon-bedrock/stream.runtime.ts:322-323` and flow through `model-fallback.ts` → `RuntimeFallbackAttempt` → `formatFallbackAttemptErrorPreview` in production.

---

This PR is AI-assisted. Analysis, implementation, and testing were performed using AI tools (opencode) with review by the author.
