### PR TITLE
feat(hooks): make session-memory write directory configurable

### DIFF
--- a/src/hooks/bundled/session-memory/HOOK.md
+++ b/src/hooks/bundled/session-memory/HOOK.md
@@ -25,7 +25,7 @@ When you run `/new` or `/reset` to start a fresh session:
 1. **Finds the previous session** - Uses the pre-reset session entry to locate the correct transcript
 2. **Extracts conversation** - Reads the last N user/assistant messages from the session (default: 15, configurable)
 3. **Chooses filename slug** - Uses a local timestamp by default, or an LLM-generated description when `llmSlug` is enabled
-4. **Saves to memory** - Creates a new file at `<workspace>/memory/YYYY-MM-DD-HHMM.md` by default without delaying the `/new` or `/reset` reply
+4. **Saves to memory** - Creates a new file at `<workspace>/memory/YYYY-MM-DD-HHMM.md` by default (or under a configured `subdir`) without delaying the `/new` or `/reset` reply
 
 ## Output Format
 
@@ -61,11 +61,12 @@ When `llmSlug` is enabled, the hook uses your configured LLM provider to generat
 
 The hook supports optional configuration:
 
-| Option     | Type    | Default       | Description                                                                                 |
-| ---------- | ------- | ------------- | ------------------------------------------------------------------------------------------- |
-| `messages` | number  | 15            | Number of user/assistant messages to include in the memory file                             |
-| `llmSlug`  | boolean | false         | Use your configured model to generate descriptive filename slugs instead of timestamp slugs |
-| `model`    | string  | agent default | Configured alias, bare model ID on the default provider, or `provider/model` override       |
+| Option     | Type    | Default       | Description                                                                                                                                                         |
+| ---------- | ------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `messages` | number  | 15            | Number of user/assistant messages to include in the memory file                                                                                                     |
+| `llmSlug`  | boolean | false         | Use your configured model to generate descriptive filename slugs instead of timestamp slugs                                                                         |
+| `model`    | string  | agent default | Configured alias, bare model ID on the default provider, or `provider/model` override                                                                               |
+| `subdir`   | string  | `""`          | Sub-directory under `memory/` to write notes into. Supports `{YYYY}`, `{MM}`, `{YYYY-MM}` tokens from the note's local date. Default is the top level of `memory/`. |
 
 Example configuration:
 
@@ -78,13 +79,19 @@ Example configuration:
           "enabled": true,
           "messages": 25,
           "llmSlug": true,
-          "model": "sonnet"
+          "model": "sonnet",
+          "subdir": "sessions/{YYYY-MM}"
         }
       }
     }
   }
 }
 ```
+
+With `subdir: "sessions/{YYYY-MM}"`, a note captured on 2026-01-16 is written to
+`<workspace>/memory/sessions/2026-01/2026-01-16-1430.md`, keeping the top level of
+`memory/` reserved for curated daily notes. The value is resolved relative to
+`memory/`; leading path traversal is stripped so writes stay inside the workspace.
 
 The hook automatically:
 

--- a/src/hooks/bundled/session-memory/handler.test.ts
+++ b/src/hooks/bundled/session-memory/handler.test.ts
@@ -434,6 +434,76 @@ describe("session-memory hook", () => {
     });
   });
 
+  it("writes into a configured subdir with date tokens", async () => {
+    await withEnvAsync({ TZ: "UTC" }, async () => {
+      const tempDir = await createCaseWorkspace("workspace");
+      const event = createHookEvent("command", "new", "agent:main:main", {
+        cfg: {
+          agents: { defaults: { workspace: tempDir } },
+          hooks: {
+            internal: {
+              entries: {
+                "session-memory": { enabled: true, subdir: "sessions/{YYYY-MM}" },
+              },
+            },
+          },
+        } satisfies OpenClawConfig,
+        previousSessionEntry: { sessionId: "subdir-session" },
+      });
+      event.timestamp = new Date("2026-01-01T04:30:15.000Z");
+
+      await handler(event);
+      await flushSessionMemoryWritesForTest();
+
+      const nestedDir = path.join(tempDir, "memory", "sessions", "2026-01");
+      await expect(fs.readdir(nestedDir)).resolves.toEqual(["2026-01-01-0430.md"]);
+
+      // Top level of memory/ stays free of session-note files.
+      const topLevel = await fs.readdir(path.join(tempDir, "memory"));
+      expect(topLevel.filter((entry) => entry.endsWith(".md"))).toEqual([]);
+    });
+  });
+
+  it("ignores subdir path traversal and stays inside memory/", async () => {
+    await withEnvAsync({ TZ: "UTC" }, async () => {
+      const tempDir = await createCaseWorkspace("workspace");
+      const event = createHookEvent("command", "new", "agent:main:main", {
+        cfg: {
+          agents: { defaults: { workspace: tempDir } },
+          hooks: {
+            internal: {
+              entries: {
+                "session-memory": { enabled: true, subdir: "../../escape" },
+              },
+            },
+          },
+        } satisfies OpenClawConfig,
+        previousSessionEntry: { sessionId: "traversal-session" },
+      });
+      event.timestamp = new Date("2026-01-01T04:30:15.000Z");
+
+      await handler(event);
+      await flushSessionMemoryWritesForTest();
+
+      // Leading `../` is stripped; the note lands under memory/escape, never above memory/.
+      await expect(fs.readdir(path.join(tempDir, "memory", "escape"))).resolves.toEqual([
+        "2026-01-01-0430.md",
+      ]);
+    });
+  });
+
+  it("keeps top-level behavior when subdir is unset (backward compatible)", async () => {
+    await withEnvAsync({ TZ: "UTC" }, async () => {
+      const tempDir = await createCaseWorkspace("workspace");
+      const { files } = await runNewWithPreviousSessionEntry({
+        tempDir,
+        timestamp: new Date("2026-01-01T04:30:15.000Z"),
+        previousSessionEntry: { sessionId: "no-subdir" },
+      });
+      expect(files).toEqual(["2026-01-01-0430.md"]);
+    });
+  });
+
   it("prefers workspaceDir from hook context when sessionKey points at main", async () => {
     const mainWorkspace = await createCaseWorkspace("workspace-main");
     const naviWorkspace = await createCaseWorkspace("workspace-navi");

--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -97,6 +97,29 @@ function formatLocalSessionTimestamp(date: Date): {
   };
 }
 
+/**
+ * Resolve the optional `subdir` hook option into a safe, relative memory
+ * sub-directory. Supports `{YYYY}`, `{MM}` and `{YYYY-MM}` tokens taken from the
+ * note's local date, so notes can be filed under e.g. `sessions/{YYYY-MM}`.
+ * Returns "" (top level, unchanged default) when unset. Any leading path
+ * traversal is stripped so the write can never escape `<workspace>/memory`.
+ */
+function resolveSessionMemorySubdir(subdir: unknown, localDate: string): string {
+  if (typeof subdir !== "string" || subdir.trim() === "") {
+    return "";
+  }
+  const [year = "", month = ""] = localDate.split("-");
+  const replaced = subdir
+    .replaceAll("{YYYY-MM}", `${year}-${month}`)
+    .replaceAll("{YYYY}", year)
+    .replaceAll("{MM}", month);
+  const normalized = path
+    .normalize(replaced)
+    .replace(/^(?:\.\.(?:[/\\]|$))+/, "")
+    .replace(/^[/\\]+/, "");
+  return normalized === "." || normalized === ".." ? "" : normalized;
+}
+
 async function resolveAvailableMemoryFilename(params: {
   memoryDir: string;
   dateStr: string;
@@ -188,13 +211,19 @@ async function saveSessionMemoryNow(event: Parameters<HookHandler>[0]): Promise<
       workspaceDir: contextWorkspaceDir,
       sessionKey: event.sessionKey,
     });
-    const memoryDir = path.join(workspaceDir, "memory");
-    await fs.mkdir(memoryDir, { recursive: true });
+    // Read hook config once; used for the write sub-directory and message count.
+    const hookConfig = resolveHookConfig(cfg, "session-memory");
 
     // Use the user's local timezone for memory artifact names and headings.
     const now = new Date(event.timestamp);
     const localTimestamp = formatLocalSessionTimestamp(now);
     const dateStr = localTimestamp.date;
+
+    // Optional configurable sub-directory (e.g. "sessions/{YYYY-MM}") keeps the
+    // top level of memory/ reserved for curated notes. Defaults to top level.
+    const subdir = resolveSessionMemorySubdir(hookConfig?.subdir, dateStr);
+    const memoryDir = path.join(workspaceDir, "memory", subdir);
+    await fs.mkdir(memoryDir, { recursive: true });
 
     // Generate descriptive slug from session when explicitly enabled
     // Prefer previousSessionEntry (old session before /new) over current (which may be empty)
@@ -237,7 +266,6 @@ async function saveSessionMemoryNow(event: Parameters<HookHandler>[0]): Promise<
     const sessionFile = currentSessionFile || undefined;
 
     // Read message count from hook config (default: 15)
-    const hookConfig = resolveHookConfig(cfg, "session-memory");
     const messageCount =
       typeof hookConfig?.messages === "number" && hookConfig.messages > 0
         ? hookConfig.messages


### PR DESCRIPTION
## What Problem This Solves
On active setups, the `session-memory` hook writes every `/new`/`/reset` note to the top
level of `<workspace>/memory/`, so hundreds of session-close dumps accumulate there and
dilute the curated daily-log recall surface. There is currently no supported way to redirect
them (only `messages`/`llmSlug`/`model` are configurable). This adds an optional `subdir` so
notes can live under e.g. `memory/sessions/YYYY-MM/` while the top level stays reserved for
curated notes. Mirrors the already-merged `messages` option (#2681 → #2732).

Closes #112701

## Behavior
- New option `subdir` (string), default `""` → **unchanged** top-level behavior (backward compatible).
- Tokens `{YYYY}`, `{MM}`, `{YYYY-MM}` resolved from the note's local date.
- Example: `subdir: "sessions/{YYYY-MM}"` → `memory/sessions/2026-01/2026-01-16-1430.md`.
- Leading path traversal in the value is stripped so writes stay inside `<workspace>/memory`.

## Implementation
- `handler.ts`: hoist the hook-config + local-timestamp reads above `memoryDir`, and add a small
  `resolveSessionMemorySubdir()` helper. No other write-path change (downstream already uses `memoryDir`).
- `HookConfig` already carries an index signature, so no schema/type change is required.
- `HOOK.md`: documents the option, tokens, and an example.

## Evidence
Focused unit tests added to `handler.test.ts` (subdir tokens, path-traversal safety, unchanged
default) and run locally against the real source:

```
$ pnpm exec vitest run src/hooks/bundled/session-memory/handler.test.ts
 Test Files  1 passed (1)
      Tests  32 passed (32)
```

`oxlint` on the changed handler reported no diagnostics. All other PR CI checks (check-lint,
check-prod-types, check-test-types, boundary and security jobs) are green on this PR.

Happy to adjust the option name or token syntax to match maintainer preference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
