### PR TITLE
feat(tasks): support atomic managed TaskFlow cancellation state

### DIFF
--- a/docs/automation/taskflow.md
+++ b/docs/automation/taskflow.md
@@ -26,7 +26,7 @@ A managed flow has a controller: plugin code that creates the flow through the p
 
 - Each step runs as a background task created under the flow; the flow's owner key and requester origin carry over to child tasks.
 - The controller advances the flow between `running`, `waiting`, and terminal states, and stores arbitrary JSON step state on the flow record.
-- Every mutation passes the flow's expected revision. A stale write is rejected as a revision conflict instead of clobbering newer state.
+- Every controller state mutation passes the flow's expected revision. A stale write is rejected as a revision conflict instead of clobbering newer state. Cancellation mutations can persist controller `stateJson` together with the native cancel intent or terminal `cancelled` projection.
 - Once cancellation is requested, new child tasks are refused, and the flow finalizes as `cancelled` when no child task remains active.
 
 Example: a weekly report flow that (1) gathers data, (2) generates the report, and (3) delivers it, one background task per step:
@@ -62,6 +62,8 @@ Flow records persist in the shared SQLite state database (`~/.openclaw/state/ope
 ## Cancel behavior
 
 `openclaw tasks flow cancel` sets a sticky cancel intent on the flow, cancels its active child tasks, and refuses new managed child tasks. Once no child task remains active, the flow finalizes as `cancelled` - immediately, or via the maintenance sweep if children take longer to settle. The intent is persisted, so a cancelled flow stays cancelled even if the gateway restarts before all child tasks have terminated.
+
+Plugin controllers can use `requestCancel(...)` to atomically persist the cancel intent and their latest `stateJson` under an expected revision. Once controller-owned child cleanup is complete, `finalizeCancel(...)` atomically persists the terminal `cancelled` projection, final state, and timestamps. Finalization is rejected until the cancel intent is durable and while any linked child still participates in cancellation. The async `cancel(...)` helper remains the higher-level operation for requesting cancellation and dispatching it to active linked tasks.
 
 ## CLI commands
 

--- a/docs/plugins/sdk-runtime.md
+++ b/docs/plugins/sdk-runtime.md
@@ -437,7 +437,31 @@ two-party event loops that do not go through the shared inbound reply runner.
       currentStep: "await-human-reply",
       waitJson: { kind: "reply", channel: "telegram" },
     });
+
+    if (!waiting.applied) {
+      throw new Error(`TaskFlow update failed: ${waiting.code}`);
+    }
+
+    const cancelRequested = taskFlow.requestCancel({
+      flowId: waiting.flow.flowId,
+      expectedRevision: waiting.flow.revision,
+      stateJson: { phase: "cancelling" },
+      cancelRequestedAt: Date.now(),
+    });
+
+    if (!cancelRequested.applied) {
+      throw new Error(`TaskFlow cancellation request failed: ${cancelRequested.code}`);
+    }
     ```
+
+    `requestCancel(...)` writes the native cancel intent and optional
+    `stateJson` in the same revision-checked mutation. After the controller has
+    settled its child work, `finalizeCancel(...)` writes `status: "cancelled"`,
+    the final `stateJson`, and cancellation timestamps in one mutation. It
+    rejects with `cancel_not_requested` until the intent is durable and with
+    `children_active` while any linked child still participates in cancellation.
+    Use the existing async `cancel({ flowId, cfg })` helper when OpenClaw should
+    request cancellation and dispatch cancellation to active linked tasks for you.
 
     Use `bindSession({ sessionKey, requesterOrigin })` when you already have a trusted OpenClaw session key from your own binding layer. Do not bind from raw user input.
 

--- a/extensions/lobster/src/taskflow-test-helpers.ts
+++ b/extensions/lobster/src/taskflow-test-helpers.ts
@@ -44,6 +44,7 @@ export function createFakeTaskFlow(overrides?: Partial<BoundTaskFlow>): BoundTas
       flow: { ...baseFlow, revision: input.expectedRevision + 1, status: "failed" as const },
     })),
     requestCancel: vi.fn(),
+    finalizeCancel: vi.fn(),
     cancel: vi.fn(),
     runTask: vi.fn(),
     ...overrides,

--- a/skills/taskflow/SKILL.md
+++ b/skills/taskflow/SKILL.md
@@ -46,14 +46,14 @@ Managed-flow lifecycle:
 3. `setWaiting(...)` when waiting on a person or an external system
 4. `resume(...)` when work can continue
 5. `finish(...)` or `fail(...)`
-6. `requestCancel(...)` or `cancel(...)` when the whole job should stop
+6. `requestCancel(...)`, `finalizeCancel(...)`, or `cancel(...)` when the whole job should stop
 
 ## Design constraints
 
 - Use **managed** TaskFlows when your code owns the orchestration.
 - One-task **mirrored** flows are created by core runtime for detached ACP/subagent work; this skill is mainly about managed flows.
 - Treat `stateJson` as the persisted state bag. There is no separate `setFlowOutput` or `appendFlowOutput` API.
-- Every mutating method after creation is revision-checked. Carry forward the latest `flow.revision` after each successful mutation.
+- Every direct state mutation after creation is revision-checked. Carry forward the latest `flow.revision` after each successful mutation. The async `cancel(...)` orchestration helper is the exception because it may dispatch cancellation across multiple active child tasks.
 - `runTask(...)` links the child task to the flow. Use it instead of manually creating detached tasks when you want parent orchestration.
 
 ## Example shape
@@ -140,6 +140,8 @@ Use the flow runtime for state and task linkage. Keep decisions in the authoring
 - Put human-readable wait reasons in `blockedSummary` or structured wait metadata in `waitJson`.
 - Use `getTaskSummary(flowId)` when the orchestrator needs a compact health view of child work.
 - Use `requestCancel(...)` when a caller wants the flow to stop scheduling immediately.
+- Pass `stateJson` to `requestCancel(...)` when the controller checkpoint must be persisted with the cancel intent in the same revision-checked write.
+- Use `finalizeCancel(...)` only after `requestCancel(...)` has persisted cancel intent and controller-owned child cleanup has settled. It rejects while linked child work still participates in cancellation, then persists terminal `cancelled`, final `stateJson`, and timestamps in one revision-checked write.
 - Use `cancel(...)` when you also want active linked child tasks cancelled.
 
 ## Examples

--- a/src/plugin-sdk/test-helpers/plugin-runtime-mock.ts
+++ b/src/plugin-sdk/test-helpers/plugin-runtime-mock.ts
@@ -73,6 +73,7 @@ function createTaskFlowSessionMock() {
     finish: vi.fn(),
     fail: vi.fn(),
     requestCancel: vi.fn(),
+    finalizeCancel: vi.fn(),
     cancel: vi.fn(),
     runTask: vi.fn(),
   };

--- a/src/plugins/runtime/runtime-taskflow.test.ts
+++ b/src/plugins/runtime/runtime-taskflow.test.ts
@@ -9,7 +9,13 @@ import {
 import { createRuntimeTaskFlow } from "./runtime-taskflow.js";
 
 type BoundTaskFlow = ReturnType<ReturnType<typeof createRuntimeTaskFlow>["bindSession"]>;
-type MutationName = "setWaiting" | "resume" | "finish" | "fail" | "requestCancel";
+type MutationName =
+  | "setWaiting"
+  | "resume"
+  | "finish"
+  | "fail"
+  | "requestCancel"
+  | "finalizeCancel";
 
 function requireCreatedFlow<T>(flow: T | null): T {
   if (!flow) {
@@ -185,7 +191,24 @@ describe("runtime TaskFlow", () => {
           },
           "failed",
         ],
-        ["requestCancel", { cancelRequestedAt: 60 }, "failed"],
+        [
+          "requestCancel",
+          {
+            stateJson: { phase: "cancelling" },
+            cancelRequestedAt: 60,
+            updatedAt: 61,
+          },
+          "failed",
+        ],
+        [
+          "finalizeCancel",
+          {
+            stateJson: { phase: "cancelled" },
+            updatedAt: 70,
+            endedAt: 71,
+          },
+          "cancelled",
+        ],
       ];
 
     for (const [index, [name, input, status]] of transitions.entries()) {
@@ -205,8 +228,12 @@ describe("runtime TaskFlow", () => {
         flowId: created.flowId,
         revision: index + 1,
       });
+      if (name === "requestCancel" || name === "finalizeCancel") {
+        expect(result.flow.currentStep, name).toBe("continue_work");
+      }
       expect(getTaskFlowById(created.flowId)?.revision, name).toBe(index + 1);
     }
+    expect(getTaskFlowById(created.flowId)?.cancelRequestedAt).toBe(60);
   });
 
   it("rejects invalid mutation targets before writing and preserves conflict mapping", () => {
@@ -220,9 +247,11 @@ describe("runtime TaskFlow", () => {
       }),
     );
 
-    const denied = otherTaskFlow.setWaiting({
+    const denied = otherTaskFlow.finalizeCancel({
       flowId: managed.flowId,
       expectedRevision: managed.revision,
+      stateJson: { phase: "must-not-write" },
+      endedAt: 21,
     });
     expect(denied).toEqual({ applied: false, code: "not_found" });
     expect(getTaskFlowById(managed.flowId)?.revision).toBe(0);
@@ -246,13 +275,112 @@ describe("runtime TaskFlow", () => {
     });
     expect(wrongMode).toMatchObject({ applied: false, code: "not_managed" });
 
-    const conflict = ownerTaskFlow.finish({ flowId: managed.flowId, expectedRevision: 1 });
+    const conflict = ownerTaskFlow.finalizeCancel({
+      flowId: managed.flowId,
+      expectedRevision: 1,
+      stateJson: { phase: "stale" },
+      endedAt: 31,
+    });
     expect(conflict).toMatchObject({ applied: false, code: "revision_conflict" });
     expect(getTaskFlowById(managed.flowId)).toMatchObject({
       revision: 0,
       status: "queued",
     });
     expect(getTaskFlowById(managed.flowId)?.endedAt).toBeUndefined();
+    expect(getTaskFlowById(managed.flowId)?.cancelRequestedAt).toBeUndefined();
+    expect(getTaskFlowById(managed.flowId)?.stateJson).toBeUndefined();
     expect(getTaskFlowById(mirrored.flowId)?.revision).toBe(0);
+  });
+
+  it("rejects terminal cancellation until intent is persisted and child work is settled", () => {
+    const taskFlow = createRuntimeTaskFlow().bindSession({ sessionKey: "agent:main:main" });
+    const managed = taskFlow.createManaged({
+      controllerId: "tests/runtime-taskflow/cancel-preconditions",
+      goal: "Settle child before terminal cancellation",
+    });
+
+    const withoutIntent = taskFlow.finalizeCancel({
+      flowId: managed.flowId,
+      expectedRevision: managed.revision,
+      stateJson: { phase: "must-not-finalize" },
+      endedAt: 20,
+    });
+    expect(withoutIntent).toMatchObject({
+      applied: false,
+      code: "cancel_not_requested",
+      current: { revision: 0, status: "queued" },
+    });
+
+    const child = taskFlow.runTask({
+      flowId: managed.flowId,
+      runtime: "acp",
+      childSessionKey: "agent:main:subagent:cancel-preconditions",
+      runId: "runtime-taskflow-cancel-preconditions",
+      task: "Finish cleanup first",
+      status: "running",
+      startedAt: 21,
+      lastEventAt: 21,
+    });
+    expect(child.created).toBe(true);
+    if (!child.created) {
+      throw new Error("expected child task creation to succeed");
+    }
+
+    const requested = taskFlow.requestCancel({
+      flowId: managed.flowId,
+      expectedRevision: child.flow.revision,
+      stateJson: { phase: "cancelling" },
+      cancelRequestedAt: 22,
+      updatedAt: 22,
+    });
+    expect(requested.applied).toBe(true);
+    if (!requested.applied) {
+      throw new Error("expected cancellation request to apply");
+    }
+
+    const childrenActive = taskFlow.finalizeCancel({
+      flowId: managed.flowId,
+      expectedRevision: requested.flow.revision,
+      stateJson: { phase: "must-not-finalize" },
+      endedAt: 23,
+    });
+    expect(childrenActive).toMatchObject({
+      applied: false,
+      code: "children_active",
+      current: {
+        revision: requested.flow.revision,
+        status: "queued",
+        stateJson: { phase: "cancelling" },
+        cancelRequestedAt: 22,
+      },
+    });
+    expect(getTaskFlowById(managed.flowId)).toMatchObject({
+      revision: requested.flow.revision,
+      status: "queued",
+      stateJson: { phase: "cancelling" },
+      cancelRequestedAt: 22,
+    });
+  });
+
+  it("keeps the existing active-child cancellation helper compatible", async () => {
+    const taskFlow = createRuntimeTaskFlow().bindSession({ sessionKey: "agent:main:main" });
+    const managed = taskFlow.createManaged({
+      controllerId: "tests/runtime-taskflow/legacy-cancel",
+      goal: "Cancel through the operator helper",
+    });
+
+    const result = await taskFlow.cancel({
+      flowId: managed.flowId,
+      cfg: {} as never,
+    });
+
+    expect(result).toMatchObject({
+      found: true,
+      cancelled: true,
+      flow: {
+        flowId: managed.flowId,
+        status: "cancelled",
+      },
+    });
   });
 });

--- a/src/plugins/runtime/runtime-taskflow.ts
+++ b/src/plugins/runtime/runtime-taskflow.ts
@@ -2,6 +2,7 @@
 import {
   cancelFlowByIdForOwner,
   getFlowTaskSummary,
+  hasPendingFlowCancellationTasks,
   runTaskInFlowForOwner,
 } from "../../tasks/task-executor.js";
 import {
@@ -14,6 +15,7 @@ import type { TaskFlowRecord } from "../../tasks/task-flow-registry.types.js";
 import {
   createManagedTaskFlow,
   failFlow,
+  finalizeFlowCancel,
   finishFlow,
   type TaskFlowUpdateResult,
   requestFlowCancel,
@@ -220,7 +222,23 @@ function createBoundTaskFlowRuntime(params: {
           requestFlowCancel({
             flowId,
             expectedRevision: input.expectedRevision,
+            stateJson: input.stateJson,
             cancelRequestedAt: input.cancelRequestedAt,
+            updatedAt: input.updatedAt,
+          }),
+      }),
+    finalizeCancel: (input) =>
+      applyManagedFlowMutationForOwner({
+        flowId: input.flowId,
+        ownerKey,
+        mutate: (flowId) =>
+          finalizeFlowCancel({
+            flowId,
+            expectedRevision: input.expectedRevision,
+            stateJson: input.stateJson,
+            updatedAt: input.updatedAt,
+            endedAt: input.endedAt,
+            hasPendingTasks: hasPendingFlowCancellationTasks,
           }),
       }),
     cancel: ({ flowId, cfg }) =>

--- a/src/plugins/runtime/runtime-taskflow.types.ts
+++ b/src/plugins/runtime/runtime-taskflow.types.ts
@@ -20,7 +20,9 @@ type ManagedTaskFlowMutationErrorCode =
   | "not_found"
   | "not_managed"
   | "revision_conflict"
-  | "persist_failed";
+  | "persist_failed"
+  | "cancel_not_requested"
+  | "children_active";
 
 export type ManagedTaskFlowMutationResult =
   | {
@@ -115,7 +117,16 @@ export type BoundTaskFlowRuntime = {
   requestCancel: (params: {
     flowId: string;
     expectedRevision: number;
+    stateJson?: JsonValue | null;
     cancelRequestedAt?: number;
+    updatedAt?: number;
+  }) => ManagedTaskFlowMutationResult;
+  finalizeCancel: (params: {
+    flowId: string;
+    expectedRevision: number;
+    stateJson?: JsonValue | null;
+    updatedAt?: number;
+    endedAt?: number;
   }) => ManagedTaskFlowMutationResult;
   cancel: (params: { flowId: string; cfg: OpenClawConfig }) => Promise<BoundTaskFlowCancelResult>;
   runTask: (params: {

--- a/src/tasks/task-executor.ts
+++ b/src/tasks/task-executor.ts
@@ -35,9 +35,9 @@ import type { TaskFlowRecord } from "./task-flow-registry.types.js";
 import {
   createTaskFlowForTask,
   deleteTaskFlowRecordById,
+  finalizeFlowCancel,
   getTaskFlowById,
   requestFlowCancel,
-  updateFlowRecordByIdExpectedRevision,
 } from "./task-flow-runtime-internal.js";
 import { summarizeTaskRecords } from "./task-registry.summary.js";
 import type {
@@ -116,6 +116,10 @@ export function createQueuedTaskRun(params: DetachedTaskCreateParams): TaskRecor
 
 export function getFlowTaskSummary(flowId: string): TaskRegistrySummary {
   return summarizeTaskRecords(listTasksForFlowId(flowId));
+}
+
+export function hasPendingFlowCancellationTasks(flowId: string): boolean {
+  return listTasksForFlowId(flowId).some(isTaskFlowCancellationPending);
 }
 
 export function createRunningTaskRun(params: DetachedRunningTaskCreateParams): TaskRecord | null {
@@ -268,6 +272,10 @@ function describeFlowUpdateFailure(
       return "Flow changed while cancellation was in progress.";
     case "persist_failed":
       return "Flow persistence failed.";
+    case "cancel_not_requested":
+      return "Flow cancellation has not been requested.";
+    case "children_active":
+      return "One or more child tasks are still active.";
     case "not_found":
       return "Flow not found.";
     default:
@@ -279,17 +287,12 @@ function cancelManagedFlowAfterChildrenSettle(
   flow: TaskFlowRecord,
   endedAt: number,
 ): TaskFlowRecord | FlowUpdateFailure {
-  const result = updateFlowRecordByIdExpectedRevision({
+  const result = finalizeFlowCancel({
     flowId: flow.flowId,
     expectedRevision: flow.revision,
-    patch: {
-      status: "cancelled",
-      blockedTaskId: null,
-      blockedSummary: null,
-      waitJson: null,
-      endedAt,
-      updatedAt: endedAt,
-    },
+    endedAt,
+    updatedAt: endedAt,
+    hasPendingTasks: hasPendingFlowCancellationTasks,
   });
   if (result.applied) {
     return result.flow;

--- a/src/tasks/task-flow-registry.maintenance.ts
+++ b/src/tasks/task-flow-registry.maintenance.ts
@@ -8,6 +8,7 @@ import {
 } from "./task-flow-registry.audit.js";
 import {
   deleteTaskFlowRecordById,
+  finalizeFlowCancel,
   getTaskFlowById,
   getTaskFlowRegistryRestoreFailure,
   listTaskFlowRecords,
@@ -74,17 +75,12 @@ function finalizeCancelledFlow(flow: TaskFlowRecord, now: number): boolean {
   let current = flow;
   for (let attempt = 0; attempt < 2; attempt += 1) {
     const endedAt = Math.max(now, current.updatedAt, current.cancelRequestedAt ?? now);
-    const result = updateFlowRecordByIdExpectedRevision({
+    const result = finalizeFlowCancel({
       flowId: current.flowId,
       expectedRevision: current.revision,
-      patch: {
-        status: "cancelled",
-        blockedTaskId: null,
-        blockedSummary: null,
-        waitJson: null,
-        endedAt,
-        updatedAt: endedAt,
-      },
+      endedAt,
+      updatedAt: endedAt,
+      hasPendingTasks: hasActiveLinkedTasks,
     });
     if (result.applied) {
       return true;

--- a/src/tasks/task-flow-registry.store.test.ts
+++ b/src/tasks/task-flow-registry.store.test.ts
@@ -241,6 +241,7 @@ describe("task-flow-registry store runtime", () => {
       const cancelRequested = requestFlowCancel({
         flowId: created.flowId,
         expectedRevision: waiting.flow.revision,
+        stateJson: { phase: "cancelling" },
         cancelRequestedAt: 444,
       });
       expect(cancelRequested.applied).toBe(true);
@@ -254,7 +255,7 @@ describe("task-flow-registry store runtime", () => {
       expect(restored?.revision).toBe(2);
       expect(restored?.status).toBe("waiting");
       expect(restored?.currentStep).toBe("ask_user");
-      expect(restored?.stateJson).toEqual({ phase: "ask_user" });
+      expect(restored?.stateJson).toEqual({ phase: "cancelling" });
       expect(restored?.waitJson).toEqual({ kind: "external_event", topic: "forum" });
       expect(restored?.cancelRequestedAt).toBe(444);
     });

--- a/src/tasks/task-flow-registry.test.ts
+++ b/src/tasks/task-flow-registry.test.ts
@@ -7,6 +7,7 @@ import {
   deleteTaskFlowRecordById,
   getTaskFlowRegistryRestoreFailure,
   failFlow,
+  finalizeFlowCancel,
   getTaskFlowById,
   listTaskFlowRecords,
   requestFlowCancel,
@@ -390,6 +391,181 @@ describe("task-flow-registry", () => {
       revision: 0,
       status: "queued",
     });
+  });
+
+  it("persists cancel intent and controller state in one revision-checked write", () => {
+    const upsertFlow = vi.fn();
+    configureTaskFlowRegistryRuntime({
+      store: {
+        loadSnapshot: () => ({ flows: new Map() }),
+        saveSnapshot: () => {},
+        upsertFlow,
+      },
+    });
+    const created = createManagedTaskFlow({
+      ownerKey: "agent:main:main",
+      controllerId: "tests/atomic-cancel-request",
+      goal: "Persist cancellation state",
+      stateJson: { phase: "running" },
+    });
+    upsertFlow.mockClear();
+
+    const requested = requestFlowCancel({
+      flowId: created.flowId,
+      expectedRevision: created.revision,
+      stateJson: { phase: "cancelling", checkpoint: 4 },
+      cancelRequestedAt: 40,
+      updatedAt: 41,
+    });
+
+    expect(requested.applied).toBe(true);
+    expect(upsertFlow).toHaveBeenCalledTimes(1);
+    expect(upsertFlow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        flowId: created.flowId,
+        revision: 1,
+        stateJson: { phase: "cancelling", checkpoint: 4 },
+        cancelRequestedAt: 40,
+        updatedAt: 41,
+      }),
+    );
+
+    const conflict = requestFlowCancel({
+      flowId: created.flowId,
+      expectedRevision: created.revision,
+      stateJson: { phase: "stale" },
+      cancelRequestedAt: 50,
+    });
+
+    expect(conflict).toMatchObject({ applied: false, reason: "revision_conflict" });
+    expect(upsertFlow).toHaveBeenCalledTimes(1);
+    expect(getTaskFlowById(created.flowId)).toMatchObject({
+      revision: 1,
+      stateJson: { phase: "cancelling", checkpoint: 4 },
+      cancelRequestedAt: 40,
+      updatedAt: 41,
+    });
+  });
+
+  it("requires persisted cancel intent and settled children before terminal cancellation", () => {
+    const upsertFlow = vi.fn();
+    configureTaskFlowRegistryRuntime({
+      store: {
+        loadSnapshot: () => ({ flows: new Map() }),
+        saveSnapshot: () => {},
+        upsertFlow,
+      },
+    });
+    const created = createManagedTaskFlow({
+      ownerKey: "agent:main:main",
+      controllerId: "tests/atomic-cancel-preconditions",
+      goal: "Enforce cancellation preconditions",
+      stateJson: { phase: "running" },
+    });
+    upsertFlow.mockClear();
+
+    const withoutIntent = finalizeFlowCancel({
+      flowId: created.flowId,
+      expectedRevision: created.revision,
+      stateJson: { phase: "must-not-finalize" },
+      endedAt: 40,
+      hasPendingTasks: () => false,
+    });
+
+    expect(withoutIntent).toMatchObject({
+      applied: false,
+      reason: "cancel_not_requested",
+      current: { revision: 0, status: "queued", stateJson: { phase: "running" } },
+    });
+    expect(upsertFlow).not.toHaveBeenCalled();
+
+    const requested = requestFlowCancel({
+      flowId: created.flowId,
+      expectedRevision: created.revision,
+      stateJson: { phase: "cancelling" },
+      cancelRequestedAt: 50,
+      updatedAt: 51,
+    });
+    expect(requested.applied).toBe(true);
+    if (!requested.applied) {
+      throw new Error("expected cancellation request to apply");
+    }
+    upsertFlow.mockClear();
+
+    const childrenActive = finalizeFlowCancel({
+      flowId: created.flowId,
+      expectedRevision: requested.flow.revision,
+      stateJson: { phase: "must-not-finalize" },
+      endedAt: 60,
+      hasPendingTasks: () => true,
+    });
+
+    expect(childrenActive).toMatchObject({
+      applied: false,
+      reason: "children_active",
+      current: {
+        revision: requested.flow.revision,
+        status: "queued",
+        stateJson: { phase: "cancelling" },
+        cancelRequestedAt: 50,
+      },
+    });
+    expect(upsertFlow).not.toHaveBeenCalled();
+    expect(getTaskFlowById(created.flowId)).toMatchObject({
+      revision: requested.flow.revision,
+      status: "queued",
+      stateJson: { phase: "cancelling" },
+      cancelRequestedAt: 50,
+    });
+  });
+
+  it("persists the complete terminal cancellation projection in one write", () => {
+    const upsertFlow = vi.fn();
+    configureTaskFlowRegistryRuntime({
+      store: {
+        loadSnapshot: () => ({ flows: new Map() }),
+        saveSnapshot: () => {},
+        upsertFlow,
+      },
+    });
+    const created = createManagedTaskFlow({
+      ownerKey: "agent:main:main",
+      controllerId: "tests/atomic-cancel-finalize",
+      goal: "Finalize cancellation state",
+      status: "blocked",
+      stateJson: { phase: "cancelling" },
+      waitJson: { kind: "task", taskId: "task-1" },
+      blockedTaskId: "task-1",
+      blockedSummary: "Stopping child task",
+      cancelRequestedAt: 50,
+    });
+    upsertFlow.mockClear();
+
+    const finalized = finalizeFlowCancel({
+      flowId: created.flowId,
+      expectedRevision: created.revision,
+      stateJson: { phase: "cancelled", checkpoint: 5 },
+      updatedAt: 60,
+      endedAt: 61,
+      hasPendingTasks: () => false,
+    });
+
+    expect(finalized.applied).toBe(true);
+    expect(upsertFlow).toHaveBeenCalledTimes(1);
+    expect(upsertFlow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        flowId: created.flowId,
+        revision: 1,
+        status: "cancelled",
+        stateJson: { phase: "cancelled", checkpoint: 5 },
+        waitJson: null,
+        blockedTaskId: undefined,
+        blockedSummary: undefined,
+        cancelRequestedAt: 50,
+        updatedAt: 60,
+        endedAt: 61,
+      }),
+    );
   });
 
   it("does not throw or delete memory when flow delete persistence fails", () => {

--- a/src/tasks/task-flow-registry.ts
+++ b/src/tasks/task-flow-registry.ts
@@ -93,7 +93,12 @@ export type TaskFlowUpdateResult =
     }
   | {
       applied: false;
-      reason: "not_found" | "revision_conflict" | "persist_failed";
+      reason:
+        | "not_found"
+        | "revision_conflict"
+        | "persist_failed"
+        | "cancel_not_requested"
+        | "children_active";
       current?: TaskFlowRecord;
     };
 
@@ -538,10 +543,16 @@ function updateFlowRecordByIdUnchecked(
   return writeFlowRecord(applyFlowPatch(current, patch), current);
 }
 
-export function updateFlowRecordByIdExpectedRevision(params: {
+function updateFlowRecordByIdExpectedRevisionWithPatch(params: {
   flowId: string;
   expectedRevision: number;
-  patch: FlowRecordPatch;
+  validate?: (
+    current: TaskFlowRecord,
+  ) => Extract<
+    Exclude<TaskFlowUpdateResult, { applied: true }>["reason"],
+    "cancel_not_requested" | "children_active"
+  > | null;
+  createPatch: (current: TaskFlowRecord) => FlowRecordPatch;
 }): TaskFlowUpdateResult {
   ensureTaskFlowRegistryReady();
   const current = flows.get(params.flowId);
@@ -558,7 +569,15 @@ export function updateFlowRecordByIdExpectedRevision(params: {
       current: cloneFlowRecord(current),
     };
   }
-  const flow = writeFlowRecord(applyFlowPatch(current, params.patch), current);
+  const validationFailure = params.validate?.(current);
+  if (validationFailure) {
+    return {
+      applied: false,
+      reason: validationFailure,
+      current: cloneFlowRecord(current),
+    };
+  }
+  const flow = writeFlowRecord(applyFlowPatch(current, params.createPatch(current)), current);
   if (!flow) {
     return {
       applied: false,
@@ -570,6 +589,18 @@ export function updateFlowRecordByIdExpectedRevision(params: {
     applied: true,
     flow,
   };
+}
+
+export function updateFlowRecordByIdExpectedRevision(params: {
+  flowId: string;
+  expectedRevision: number;
+  patch: FlowRecordPatch;
+}): TaskFlowUpdateResult {
+  return updateFlowRecordByIdExpectedRevisionWithPatch({
+    flowId: params.flowId,
+    expectedRevision: params.expectedRevision,
+    createPatch: () => params.patch,
+  });
 }
 
 export function setFlowWaiting(params: {
@@ -681,15 +712,52 @@ export function failFlow(params: {
 export function requestFlowCancel(params: {
   flowId: string;
   expectedRevision: number;
+  stateJson?: JsonValue | null;
   cancelRequestedAt?: number;
   updatedAt?: number;
 }): TaskFlowUpdateResult {
+  const cancelRequestedAt = params.cancelRequestedAt ?? params.updatedAt ?? Date.now();
   return updateFlowRecordByIdExpectedRevision({
     flowId: params.flowId,
     expectedRevision: params.expectedRevision,
     patch: {
-      cancelRequestedAt: params.cancelRequestedAt ?? params.updatedAt ?? Date.now(),
+      stateJson: params.stateJson,
+      cancelRequestedAt,
       updatedAt: params.updatedAt,
+    },
+  });
+}
+
+export function finalizeFlowCancel(params: {
+  flowId: string;
+  expectedRevision: number;
+  stateJson?: JsonValue | null;
+  updatedAt?: number;
+  endedAt?: number;
+  hasPendingTasks: (flowId: string) => boolean;
+}): TaskFlowUpdateResult {
+  return updateFlowRecordByIdExpectedRevisionWithPatch({
+    flowId: params.flowId,
+    expectedRevision: params.expectedRevision,
+    validate: (current) => {
+      if (current.cancelRequestedAt == null) {
+        return "cancel_not_requested";
+      }
+      return params.hasPendingTasks(current.flowId) ? "children_active" : null;
+    },
+    createPatch: (current) => {
+      const cancelRequestedAt = current.cancelRequestedAt!;
+      const endedAt = params.endedAt ?? params.updatedAt ?? cancelRequestedAt;
+      return {
+        status: "cancelled",
+        stateJson: params.stateJson,
+        waitJson: null,
+        blockedTaskId: null,
+        blockedSummary: null,
+        cancelRequestedAt,
+        endedAt,
+        updatedAt: params.updatedAt ?? endedAt,
+      };
     },
   });
 }

--- a/src/tasks/task-flow-runtime-internal.ts
+++ b/src/tasks/task-flow-runtime-internal.ts
@@ -5,6 +5,7 @@ export {
   deleteTaskFlowRecordById,
   ensureTaskFlowRegistryReady,
   failFlow,
+  finalizeFlowCancel,
   finishFlow,
   getTaskFlowById,
   listTaskFlowRecords,
@@ -14,7 +15,6 @@ export {
   resumeFlow,
   setFlowWaiting,
   syncFlowFromTaskResult,
-  updateFlowRecordByIdExpectedRevision,
 } from "./task-flow-registry.js";
 
 export type { TaskFlowUpdateResult } from "./task-flow-registry.js";

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -42,9 +42,9 @@ import {
 import type { TaskFlowRecord } from "./task-flow-registry.types.js";
 import {
   ensureTaskFlowRegistryReady,
+  finalizeFlowCancel,
   getTaskFlowById,
   syncFlowFromTaskResult,
-  updateFlowRecordByIdExpectedRevision,
 } from "./task-flow-runtime-internal.js";
 import type { TaskRegistryControlRuntime } from "./task-registry-control.types.js";
 import {
@@ -1089,17 +1089,13 @@ function syncManagedFlowCancellationFromTask(task: TaskRecord): void {
   }
   const endedAt = task.endedAt ?? task.lastEventAt ?? Date.now();
   for (let attempt = 0; attempt < 2; attempt += 1) {
-    const result = updateFlowRecordByIdExpectedRevision({
+    const result = finalizeFlowCancel({
       flowId,
       expectedRevision: flow.revision,
-      patch: {
-        status: "cancelled",
-        blockedTaskId: null,
-        blockedSummary: null,
-        waitJson: null,
-        endedAt,
-        updatedAt: endedAt,
-      },
+      endedAt,
+      updatedAt: endedAt,
+      hasPendingTasks: (candidateFlowId) =>
+        listTasksForFlowId(candidateFlowId).some(isTaskFlowCancellationPending),
     });
     if (result.applied || result.reason === "not_found") {
       return;


### PR DESCRIPTION
Closes #112708

AI-assisted. I reviewed the implementation, invariants, and validation evidence.

## What Problem This Solves

Managed TaskFlow controllers cannot currently persist their durable `stateJson` atomically with native cancellation state. `requestCancel(...)` supports revision checking but not controller state, while terminal cancellation does not expose caller-supplied `expectedRevision` or `stateJson`. A crash or CAS conflict between split writes can therefore leave controller state and native status at different revisions.

## Why This Change Was Made

This adds two owner-bound exact-revision cancellation mutations:

- `requestCancel(...)` now writes optional `stateJson` with native cancel intent;
- `finalizeCancel(...)` writes optional `stateJson` with terminal native `cancelled` status and timestamps.

Both use the existing single TaskFlow record write and revision machinery. Existing async `cancel({ flowId, cfg })` behavior remains available and now reuses the same terminal finalizer. There is no schema migration or second ledger.

## User Impact

Plugin authors can implement crash-safe managed workflow cancellation without faking cancellation as failure or maintaining separate durable state. Wrong-owner and stale-revision attempts remain no-write failures, and existing callers keep their current cancellation-dispatch behavior.

## Evidence

- Focused cancellation suite: 190 tests passed across runtime binding, registry persistence, audit, maintenance, executor, and task-registry tests.
- `pnpm plugin-sdk:surface:check`: passed.
- Local changed-file validation (`pnpm check:changed` child lane): passed, including core and extension typechecks plus Oxlint.
- `pnpm deadcode:full`: passed.
- `pnpm exec oxfmt --check ...` for all changed source, test, skill, and docs files: passed.
- `git diff --check`: passed.
- Independent review found no high or medium runtime issue. Its one low documentation finding was fixed by narrowing the mutation result before accessing `.flow`.
- Added assertions for atomic `stateJson`, stale-revision no-write, owner binding, terminal `cancelled`, existing helper compatibility, and `currentStep` preservation.
- Review feedback addressed: `finalizeCancel(...)` now requires previously persisted cancel intent and rejects with no write while linked child cancellation is still pending.
- Upstream GitHub CI: full matrix and `openclaw/ci-gate` passed for `9214b3628b2` ([run 29945989019](https://github.com/openclaw/openclaw/actions/runs/29945989019)).
- No UI change, so screenshots are not applicable.
