### PR TITLE
ci: update Kova release fixture pin

### DIFF
--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -50,7 +50,7 @@ on:
       kova_ref:
         description: openclaw/Kova Git ref to install
         required: false
-        default: f3d037b5b8aacd6adf8ef1dd2ea4c1d778ec7c6c
+        default: 1bf080f6dbf8800a3187591493f2551824e4ccc7
         type: string
       dispatch_id:
         description: Optional parent workflow dispatch identifier
@@ -154,7 +154,7 @@ jobs:
             include_filters: "scenario:agent-cold-warm-message"
             expected_release_entries: "agent-cold-warm-message:mock-openai-provider"
     env:
-      KOVA_REF: ${{ inputs.kova_ref || 'f3d037b5b8aacd6adf8ef1dd2ea4c1d778ec7c6c' }}
+      KOVA_REF: ${{ inputs.kova_ref || '1bf080f6dbf8800a3187591493f2551824e4ccc7' }}
       KOVA_HOME: ${{ github.workspace }}/.artifacts/kova/home/${{ matrix.lane }}
       PERFORMANCE_HELPER_DIR: ${{ github.workspace }}/.artifacts/performance-workflow
       REPORT_DIR: ${{ github.workspace }}/.artifacts/kova/reports/${{ matrix.lane }}

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -83,7 +83,7 @@ describe("OpenClaw performance workflow", () => {
 
   it("pins the Kova evaluator with release validation contracts", () => {
     const workflow = readFileSync(WORKFLOW, "utf8");
-    const kovaRef = "f3d037b5b8aacd6adf8ef1dd2ea4c1d778ec7c6c";
+    const kovaRef = "1bf080f6dbf8800a3187591493f2551824e4ccc7";
     const install = findStep("Install OCM and Kova");
     const installRun = install.run ?? "";
 


### PR DESCRIPTION
## What Problem This Solves

Resolves a release-performance validation failure where Kova provisioned retired OpenClaw config keys, causing every mock performance scenario to stop before measurement.

## Why This Change Was Made

Updates both immutable Kova references in the performance workflow to the merged canonical-config repair from openclaw/Kova#76. The workflow remains pinned to an exact reviewed commit; no release-candidate product code changes.

## User Impact

No direct user-visible change. Release performance validation can measure current OpenClaw builds again instead of rejecting obsolete fixture configuration.

## Evidence

- Failing performance run: https://github.com/openclaw/openclaw/actions/runs/29935697276
- Kova repair: https://github.com/openclaw/Kova/pull/76 at `1bf080f6dbf8800a3187591493f2551824e4ccc7`, with Linux and macOS CI green
- `node scripts/run-vitest.mjs test/scripts/openclaw-performance-workflow.test.ts` — 30 passed
- `actionlint .github/workflows/openclaw-performance.yml` — passed
- `git diff --check` — passed
- Autoreview — clean, no accepted/actionable findings

AI-assisted: yes. The change and evidence were reviewed by the submitting maintainer.
