### PR TITLE
fix(ios): show full multiline Markdown list items

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -39291,7 +39291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 289,
+      "line": 292,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownBlockViews.swift",
       "source": "List item",
       "surface": "apple",
@@ -39299,7 +39299,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 292,
+      "line": 295,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownBlockViews.swift",
       "source": "Item",
       "surface": "apple",

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownBlockViews.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownBlockViews.swift
@@ -216,6 +216,9 @@ struct ChatMarkdownListView: View {
                         }
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
+                    // Grid cells otherwise accept compressed row proposals and ellipsize
+                    // wrapped text. Preserve the item's ideal height while still wrapping.
+                    .fixedSize(horizontal: false, vertical: true)
                 }
             }
         }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatMarkdownBlockSegmenterTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatMarkdownBlockSegmenterTests.swift
@@ -529,6 +529,15 @@ struct ChatMarkdownBlockSegmenterTests {
     }
 
     #if canImport(UIKit)
+    @MainActor private func fittedHeight(
+        _ view: some View,
+        width: CGFloat,
+        maximumHeight: CGFloat = 10_000) -> CGFloat
+    {
+        let controller = UIHostingController(rootView: view)
+        return controller.sizeThatFits(in: CGSize(width: width, height: maximumHeight)).height
+    }
+
     @Test @MainActor func `native list renderer builds on iOS across appearance and type size`() {
         let markdown = """
         9. **First** option
@@ -555,6 +564,41 @@ struct ChatMarkdownBlockSegmenterTests {
             window.makeKeyAndVisible()
             window.rootViewController?.view.layoutIfNeeded()
             windows.append(window)
+        }
+    }
+
+    @Test @MainActor func `native list items reject compressed multiline heights`() {
+        let samples = [
+            "The issue is not posted by an official OpenClaw organization account or a separate assistant account, so the complete author identity guidance must remain visible to the reader.",
+            "공개 이슈의 작성자에는 선택한 계정 이름이 표시되므로 회사 계정보다 개인 GitHub 계정을 사용하고 비밀번호를 공유하지 않아도 된다는 전체 안내가 화면에 보여야 합니다.",
+        ]
+
+        for width in [CGFloat(320), 768] {
+            for typeSize in [DynamicTypeSize.large, .accessibility2] {
+                for sample in samples {
+                    let prose = ChatMarkdownRenderer(
+                        text: sample,
+                        context: .assistant,
+                        variant: .standard,
+                        font: OpenClawChatTypography.body,
+                        textColor: OpenClawChatTheme.assistantText)
+                        .environment(\.dynamicTypeSize, typeSize)
+                    let list = ChatMarkdownRenderer(
+                        text: "- \(sample)",
+                        context: .assistant,
+                        variant: .standard,
+                        font: OpenClawChatTypography.body,
+                        textColor: OpenClawChatTheme.assistantText)
+                        .environment(\.dynamicTypeSize, typeSize)
+
+                    let proseHeight = self.fittedHeight(prose, width: width)
+                    let listHeight = self.fittedHeight(
+                        list,
+                        width: width,
+                        maximumHeight: proseHeight / 2)
+                    #expect(listHeight >= proseHeight)
+                }
+            }
         }
     }
     #endif


### PR DESCRIPTION
Closes #112688

AI-assisted: Codex helped identify, implement, test, and review this change. I reviewed and understand the resulting diff.

## What Problem This Solves

Fixes an issue where users reading completed assistant responses in the iOS app would see wrapped Markdown list items cut off with ellipses on iPhone and iPad. The hidden remainder could contain instructions or qualifications that were still present in the stored message but inaccessible in the app.

## Why This Change Was Made

The native list row now preserves the content cell's ideal vertical size while continuing to accept the available horizontal width, so text wraps instead of accepting a compressed Grid row proposal. The marker, nesting, and other Markdown rendering behavior remain unchanged.

The regression test measures the rendered SwiftUI height through `UIHostingController` across phone and iPad widths, standard and accessibility Dynamic Type, and long English and Korean content.

## User Impact

Completed Markdown list items now expand to show their full text on iPhone and iPad, including long localized content and larger accessibility text sizes.

## Evidence

Before the production fix, the new regression failed all 8 layout combinations. Representative measured heights included:

- list `43.33` vs prose `114.00`
- list `194.33` vs prose `392.67`
- list `36.67` vs prose `115.00`

After the fix:

- Final rebased iOS renderer suite: **95 tests passed** on an iOS 26.5 simulator.
- Full OpenClawKit iOS package suite: **1,152 tests passed across 86 suites**.
- macOS Markdown owner suite: **93 tests passed**.
- Native i18n inventory verification: passed; regenerated inventory is idempotent.
- SwiftFormat 0.62.1: **0/345 files require formatting**.
- SwiftLint 0.65.0: **0 violations across 345 files**.
- TruffleHog 3.95.9: clean.
- Final repository autoreview: no accepted/actionable findings; patch judged correct (0.96 confidence).

Test matrix for the new regression: widths `320` and `768` × Dynamic Type `.large` and `.accessibility2` × English and Korean samples.

Local environment notes:

- The whole-app scheme and generic iOS simulator build could not start because this Mac lacks the watchOS 26.5 runtime required by the embedded Watch app. The upstream `ios-build` lane has the complete Xcode/watchOS environment.
- A full macOS package run compiled the shared SwiftUI change but was interrupted after an unrelated gateway test remained in its reconnect loop for six minutes; the focused 93-test macOS owner suite passed afterward.
- The changed-scope wrapper correctly selected the native app lane but aborted before execution because the partial checkout's local Node 25.8.2 is below the repository's supported 25.9.0 minimum. Native formatting, lint, simulator tests, and package tests were run directly as listed above.
