### PR TITLE
fix(media): enforce local-media roots for relative source paths

### DIFF
--- a/src/gateway/managed-image-attachments.test.ts
+++ b/src/gateway/managed-image-attachments.test.ts
@@ -999,6 +999,26 @@ describe("createManagedOutgoingImageBlocks", () => {
     }
   });
 
+  it("rejects relative local image paths outside allowed roots", async () => {
+    const outsideDir = tempDirs.make("managed-image-relative-");
+    const outsidePath = path.join(outsideDir, "relative.png");
+    await fs.writeFile(outsidePath, Buffer.from(TINY_PNG_BASE64, "base64"));
+    const relativeMediaUrl = path.relative(process.cwd(), outsidePath);
+
+    try {
+      await expect(
+        createManagedOutgoingImageBlocks({
+          sessionKey: "agent:main:main",
+          mediaUrls: [relativeMediaUrl],
+          stateDir,
+          localRoots: [path.join(stateDir, "workspace")],
+        }),
+      ).rejects.toThrow(/could not be prepared/i);
+    } finally {
+      await fs.rm(outsideDir, { recursive: true, force: true });
+    }
+  });
+
   it("accepts local image paths inside allowed roots", async () => {
     const allowedDir = path.join(stateDir, "workspace", "uploads");
     const allowedPath = path.join(allowedDir, "inside.png");

--- a/src/media/local-media-path.test.ts
+++ b/src/media/local-media-path.test.ts
@@ -1,0 +1,26 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { resolveLocalMediaPath } from "./local-media-path.js";
+
+describe("resolveLocalMediaPath", () => {
+  it("resolves relative paths so local reads stay guarded", () => {
+    expect(resolveLocalMediaPath("photos/cat.png")).toBe(path.resolve("photos/cat.png"));
+    expect(resolveLocalMediaPath("../escape.png")).toBe(path.resolve("../escape.png"));
+    expect(resolveLocalMediaPath("./cat.png")).toBe(path.resolve("cat.png"));
+  });
+
+  it("resolves absolute paths", () => {
+    const absolute = path.resolve(path.sep, "tmp", "media", "cat.png");
+    expect(resolveLocalMediaPath(absolute)).toBe(absolute);
+  });
+
+  it("returns undefined for remote, data, and scheme-prefixed sources", () => {
+    expect(resolveLocalMediaPath("https://example.com/cat.png")).toBeUndefined();
+    expect(resolveLocalMediaPath("mxc://matrix.org/abc")).toBeUndefined();
+    expect(resolveLocalMediaPath("buffer://message-send/attachment")).toBeUndefined();
+    expect(resolveLocalMediaPath("data:image/png;base64,AAAA")).toBeUndefined();
+    expect(resolveLocalMediaPath("media://abc123")).toBeUndefined();
+    expect(resolveLocalMediaPath("")).toBeUndefined();
+    expect(resolveLocalMediaPath("   ")).toBeUndefined();
+  });
+});

--- a/src/media/local-media-path.ts
+++ b/src/media/local-media-path.ts
@@ -5,6 +5,7 @@ import { resolveUserPath } from "../utils.js";
 
 const DATA_URL_RE = /^data:/i;
 const WINDOWS_DRIVE_RE = /^[A-Za-z]:[\\/]/;
+const URL_SCHEME_RE = /^[a-z][a-z0-9+.-]*:/i;
 
 /** Resolves a media source to a local path when it is not a remote or data URL. */
 export function resolveLocalMediaPath(source: string): string | undefined {
@@ -25,5 +26,8 @@ export function resolveLocalMediaPath(source: string): string | undefined {
   if (path.isAbsolute(trimmed) || WINDOWS_DRIVE_RE.test(trimmed)) {
     return path.resolve(trimmed);
   }
-  return undefined;
+  if (URL_SCHEME_RE.test(trimmed)) {
+    return undefined;
+  }
+  return path.resolve(trimmed);
 }

--- a/src/media/local-roots.test.ts
+++ b/src/media/local-roots.test.ts
@@ -122,6 +122,15 @@ describe("local media roots", () => {
     expect(roots.map(normalizeHostPath)).not.toContain(normalizeHostPath("/"));
   });
 
+  it("adds the resolved parent for relative local media sources", () => {
+    const roots = appendLocalMediaParentRoots(["/tmp/base"], [path.join("nested", "photo.png")]);
+
+    expect(roots.map(normalizeHostPath)).toStrictEqual([
+      normalizeHostPath("/tmp/base"),
+      normalizeHostPath(path.resolve("nested")),
+    ]);
+  });
+
   it("does not widen local roots for pass-through media schemes", () => {
     const roots = appendLocalMediaParentRoots(
       ["/tmp/base"],


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the local-media root allowlist that protects outgoing managed image attachments is silently skipped for relative source paths. A relative `mediaUrl` (for example `photos/cat.png` or `../secret.png`) makes `resolveLocalMediaPath` return `undefined`, so `createManagedOutgoingImageBlocks` never calls `assertLocalMediaAllowed` and hands the raw path straight to `saveMediaSource`, which reads and ingests the file. Absolute and `file://` paths of the identical file are correctly checked against `localRoots` and rejected, so the containment guarantee depends on the caller's path format rather than the configured roots.

This is a defense-in-depth API-contract fix. Agent reply media is normalized to the workspace and `..`-rejected before reaching this helper, and no production caller currently passes raw agent-provided relative `mediaUrl` values in, so this is not reachable arbitrary file exfiltration today. The fix restores the invariant that any path this helper accepts as local is validated against the allowlist regardless of format.

## Why This Change Was Made

`resolveLocalMediaPath` is the single seam that both `createManagedOutgoingImageBlocks` (root enforcement) and `appendLocalMediaParentRoots` (root expansion) use to decide whether a source is a local file. Returning `undefined` for relative paths made both callers treat a real local file as "not a local path": enforcement was skipped and the raw string flowed to `saveMediaSource`. The change resolves relative paths against the current working directory (matching the existing `path.resolve` behavior for absolute paths) so the guard runs, while still returning `undefined` for genuine remote or scheme-prefixed sources (`https:`, `mxc:`, `buffer:`, `data:`, `media:`) so pass-through URLs are never mistaken for files.

## User Impact

Operators relying on `media.localRoots` to bound which local files outgoing managed images may read now get that boundary enforced uniformly, whether a caller supplies an absolute, `file://`, or relative path. There is no change for the supported remote and data-URL sources, and no new configuration or migration.

## Evidence

Root cause, `src/media/local-media-path.ts` on `origin/main` (5419a94587):

```ts
// before
  if (path.isAbsolute(trimmed) || WINDOWS_DRIVE_RE.test(trimmed)) {
    return path.resolve(trimmed);
  }
  return undefined; // relative path -> caller skips assertLocalMediaAllowed
```

Fix:

```ts
// after
  if (path.isAbsolute(trimmed) || WINDOWS_DRIVE_RE.test(trimmed)) {
    return path.resolve(trimmed);
  }
  if (URL_SCHEME_RE.test(trimmed)) {
    return undefined;
  }
  return path.resolve(trimmed);
```

### Real behavior proof

Behavior addressed: a relative `mediaUrl` pointing outside `localRoots` is ingested by `createManagedOutgoingImageBlocks` because the root check is skipped; it should be rejected like the absolute path of the same file.

Real environment tested: drove the real `createManagedOutgoingImageBlocks` gateway entry point (real `resolveLocalMediaPath`, real `assertLocalMediaAllowed`, real `saveMediaSource`, real filesystem; nothing mocked) on pristine `origin/main` 5419a94587 and on the patched tree. Identical inputs both runs: a PNG written to a temp directory outside `localRoots`, referenced by a path relative to the process working directory, with `localRoots` set to `<stateDir>/workspace`.

Exact steps or command run after this patch: a `tsx` driver calling `createManagedOutgoingImageBlocks({ sessionKey: "agent:main:main", mediaUrls: [relativePathOutsideRoots], stateDir, localRoots: [<stateDir>/workspace] })` and printing whether a block was prepared or the call was rejected.

Evidence after fix:
```
# BEFORE (pristine main 5419a94587)
RESULT: prepared 1 block(s) from a relative path outside localRoots (guard bypassed)
# AFTER (this patch, identical inputs)
RESULT: rejected relative path outside localRoots (Managed image attachment "outside.png" could not be prepared)
```

Observed result after fix: the identical relative path outside the allowlist is now rejected instead of read and ingested, matching how the absolute form of the same file is already handled.

What was not tested: no live channel send performed; the full package build was not run. Scope is the media path-resolution seam and its two callers.

### Verification

- `node scripts/run-vitest.mjs src/media/local-media-path.test.ts src/media/local-roots.test.ts src/gateway/managed-image-attachments.test.ts` (61 assertions passed; new cases fail on pristine main and pass with the patch)
- `oxlint` on the four changed files (clean)
- `oxfmt --check` on the four changed files (clean)
- `tsgo -p tsconfig.core.json` and `-p test/tsconfig/tsconfig.core.test.json`: no diagnostics in the changed files
