### PR TITLE
refactor(cloud-workers): audit staged finalize fences

### DIFF
--- a/src/gateway/worker-environments/placement-dispatch.ts
+++ b/src/gateway/worker-environments/placement-dispatch.ts
@@ -425,7 +425,7 @@ export function createWorkerPlacementDispatchService(options: WorkerPlacementDis
           // An unstaged final-fence failure is retryable even after an unchanged
           // manifest commit; the journal remains authoritative for the next attempt.
           await cancelUnstagedFailedReclaim(
-            error instanceof WorkerWorkspaceFinalFenceError && error.retryableForReclaim,
+            error instanceof WorkerWorkspaceFinalFenceError && error.reclaimDisposition === "retry",
           ).catch(() => undefined);
           throw error;
         }

--- a/src/gateway/worker-environments/workspace-finalize.test.ts
+++ b/src/gateway/worker-environments/workspace-finalize.test.ts
@@ -43,8 +43,30 @@ describe("final worker workspace fences", () => {
         },
         { assertActive: async () => {}, resume: async () => {} },
       ),
-    ).rejects.toThrow("late remote write");
+    ).rejects.toMatchObject({
+      message: "late remote write",
+      reclaimDisposition: "preserve-result",
+    });
     expect(remoteVerifications).toBe(2);
+  });
+
+  it("keeps unchanged reconciliation fence failures retryable", async () => {
+    await expect(
+      verifyReconciledWorkspaceFinal(
+        {
+          manifestRef: "sha256:" + "a".repeat(64),
+          changed: false,
+          verifyStable: async () => {
+            throw new Error("late remote write");
+          },
+          verifyLocalStable: async () => {},
+        },
+        { assertActive: async () => {}, resume: async () => {} },
+      ),
+    ).rejects.toMatchObject({
+      message: "late remote write",
+      reclaimDisposition: "retry",
+    });
   });
 
   it("publishes between remote stability fences under quiescence", async () => {
@@ -121,7 +143,10 @@ describe("final worker workspace fences", () => {
           resume: async () => {},
         },
       ),
-    ).rejects.toThrow("quiescence expired during finalization");
+    ).rejects.toMatchObject({
+      message: "quiescence expired during finalization",
+      reclaimDisposition: "preserve-result",
+    });
     expect(log).toEqual([
       "remote",
       "quiescence",
@@ -131,6 +156,33 @@ describe("final worker workspace fences", () => {
       "quiescence",
       "discard-prepared",
     ]);
+  });
+
+  it("rejects a late write enrolled by the pre-apply renewal before applying", async () => {
+    let remoteVerifications = 0;
+    const apply = vi.fn(async () => {});
+    await expect(
+      verifyReconciledWorkspaceFinal(
+        {
+          manifestRef: "sha256:" + "c".repeat(64),
+          changed: true,
+          verifyStable: async () => {
+            remoteVerifications += 1;
+            if (remoteVerifications === 2) {
+              throw new Error("writer mutated before SIGSTOP");
+            }
+          },
+          verifyLocalStable: async () => {},
+          applyPreparedStagedResult: apply,
+          publishStagedResult: async () => {},
+        },
+        { assertActive: async () => {}, resume: async () => {} },
+      ),
+    ).rejects.toMatchObject({
+      message: "writer mutated before SIGSTOP",
+      reclaimDisposition: "retry",
+    });
+    expect(apply).not.toHaveBeenCalled();
   });
 
   it("discards a prepared result when the final remote fence fails", async () => {

--- a/src/gateway/worker-environments/workspace-finalize.ts
+++ b/src/gateway/worker-environments/workspace-finalize.ts
@@ -5,25 +5,31 @@ import type {
 import type { WorkerWorkspaceApplyResult } from "./workspace-reconcile.js";
 
 export class WorkerWorkspaceFinalFenceError extends Error {
-  readonly retryableForReclaim: boolean;
+  readonly reclaimDisposition: "retry" | "preserve-result";
 
-  constructor(cause: unknown, options: { retryableForReclaim: boolean }) {
+  constructor(cause: unknown, reclaimDisposition: "retry" | "preserve-result") {
     super(cause instanceof Error ? cause.message : "Worker workspace quiescence failed", { cause });
     this.name = "WorkerWorkspaceFinalFenceError";
-    this.retryableForReclaim = options.retryableForReclaim;
+    this.reclaimDisposition = reclaimDisposition;
   }
 }
 
 async function runFinalFenceStep(
   operation: () => Promise<void>,
-  options: { retryableForReclaim: boolean },
+  reclaimDisposition: WorkerWorkspaceFinalFenceError["reclaimDisposition"],
 ): Promise<void> {
   try {
     await operation();
   } catch (error) {
-    throw new WorkerWorkspaceFinalFenceError(error, options);
+    throw new WorkerWorkspaceFinalFenceError(error, reclaimDisposition);
   }
 }
+
+const runRetryableFinalFenceStep = async (operation: () => Promise<void>): Promise<void> =>
+  await runFinalFenceStep(operation, "retry");
+
+const runResultPreservingFinalFenceStep = async (operation: () => Promise<void>): Promise<void> =>
+  await runFinalFenceStep(operation, "preserve-result");
 
 /** Rechecks both owners after renewing the remote quiescence lease. */
 export async function verifyReconciledWorkspaceFinal(
@@ -33,30 +39,18 @@ export async function verifyReconciledWorkspaceFinal(
   if (reconciliation.applyPreparedStagedResult && reconciliation.publishStagedResult) {
     try {
       // Fence the prepared remote capture before quiescence renewal can enroll late writers.
-      await runFinalFenceStep(async () => await reconciliation.verifyStable(), {
-        retryableForReclaim: true,
-      });
+      await runRetryableFinalFenceStep(async () => await reconciliation.verifyStable());
       // Renew quiescence and freeze any writers that appeared after the prepared capture.
-      await runFinalFenceStep(async () => await quiescence.assertActive(), {
-        retryableForReclaim: true,
-      });
-      // Recheck remote stability after renewal closes the late-writer race.
-      await runFinalFenceStep(async () => await reconciliation.verifyStable(), {
-        retryableForReclaim: true,
-      });
+      await runRetryableFinalFenceStep(async () => await quiescence.assertActive());
+      // Keep this fence: a late writer can mutate before renewal enrolls and SIGSTOPs it.
+      await runRetryableFinalFenceStep(async () => await reconciliation.verifyStable());
       await reconciliation.applyPreparedStagedResult();
       await reconciliation.verifyLocalStable();
       // Renew after apply so lease expiry cannot race the final publish gate.
-      await runFinalFenceStep(async () => await quiescence.assertActive(), {
-        retryableForReclaim: false,
-      });
+      await runResultPreservingFinalFenceStep(async () => await quiescence.assertActive());
       // Recheck the remote owner after apply before publishing the prepared result.
-      await runFinalFenceStep(async () => await reconciliation.verifyStable(), {
-        retryableForReclaim: false,
-      });
-      await runFinalFenceStep(async () => await reconciliation.verifyLocalStable(), {
-        retryableForReclaim: false,
-      });
+      await runResultPreservingFinalFenceStep(async () => await reconciliation.verifyStable());
+      await runResultPreservingFinalFenceStep(async () => await reconciliation.verifyLocalStable());
       await reconciliation.publishStagedResult();
       return reconciliation.getAppliedWorkspaceResult?.();
     } catch (error) {
@@ -64,15 +58,13 @@ export async function verifyReconciledWorkspaceFinal(
       throw error;
     }
   }
-  const retryableForReclaim = !reconciliation.changed;
-  await runFinalFenceStep(async () => await reconciliation.verifyStable(), { retryableForReclaim });
-  await runFinalFenceStep(async () => await reconciliation.verifyLocalStable(), {
-    retryableForReclaim,
-  });
-  await runFinalFenceStep(async () => await quiescence.assertActive(), { retryableForReclaim });
-  await runFinalFenceStep(async () => await reconciliation.verifyStable(), { retryableForReclaim });
-  await runFinalFenceStep(async () => await reconciliation.verifyLocalStable(), {
-    retryableForReclaim,
-  });
+  const runFenceStep = reconciliation.changed
+    ? runResultPreservingFinalFenceStep
+    : runRetryableFinalFenceStep;
+  await runFenceStep(async () => await reconciliation.verifyStable());
+  await runFenceStep(async () => await reconciliation.verifyLocalStable());
+  await runFenceStep(async () => await quiescence.assertActive());
+  await runFenceStep(async () => await reconciliation.verifyStable());
+  await runFenceStep(async () => await reconciliation.verifyLocalStable());
   return reconciliation.getAppliedWorkspaceResult?.();
 }


### PR DESCRIPTION
Related: #112646

AI-assisted: Codex implemented and reviewed this owner-approved follow-up.

## What Problem This Solves

The staged workspace-finalize ladder had a deliberately conservative second remote stability fence after its first quiescence renewal, but its exact necessity and the reclaim retry policy were difficult to audit. The fence helper also threaded a raw retry boolean through every guarded step, obscuring which failures may safely release an unstaged reclaim claim.

## Why This Change Was Made

The second pre-apply remote fence is kept. The audit found a real residual interval: a same-UID writer, including a process created by a control-tunnel reconnect, can appear after the first manifest verification and mutate the remote tree before the final renewal scan enrolls and sends it SIGSTOP. `assertActive()` may then succeed because it has restored quiescence, but that success does not prove the prepared snapshot survived enrollment unchanged. The retained `verifyStable()` is the only pre-apply check of that fact, and its comment now states this verdict directly.

The raw boolean plumbing is replaced by two typed fence runners. Failures now carry a `reclaimDisposition` discriminant of `retry` or `preserve-result`, and the single placement-dispatch read site retries only the former. No logging, auth, environment destruction, force-abandon, config, protocol, or storage behavior changed.

## User Impact

No user-visible behavior changes. This is an internal correctness audit and behavior-preserving refactor; the conservative remote mutation fence remains in place.

## Evidence

### Fence correctness argument

The quiescence lease records process PID/start-time identities, an identity-checked watchdog, and an expiry. Renewals are serialized by `renewalQueue`, require the same nonce and watchdog identity, verify already-recorded processes remain stopped, refresh the lease before and during the final scan, and confirm the final lease write is durable. The watchdog re-reads the lease at expiry so a racing renewal wins before SIGCONT. These rules make a successful renewal a strong proof that the processes it knows about are stopped when it returns.

That proof is not snapshot stability. In final mode, renewal repeatedly discovers same-UID candidates, first adds their identities to the durable lease, and then sends SIGSTOP. A candidate can write between the first `verifyStable()` and its discovery or between discovery and SIGSTOP. Tunnel reconnects are an explicit source of such late processes. The renewal still legitimately succeeds after stopping the writer, so the surrounding first verification plus `assertActive()` does not subsume the second verification. The second `verifyStable()` detects any mutation before `applyPreparedStagedResult()` can make the candidate locally authoritative.

Lease-expiry races do not remove that interval. The minimum remaining-time check, watchdog identity check, repeated refreshes, expiry re-read, and durable confirmation prevent a stale lease from being accepted; if a process resumes or appears while renewal restores the lease, it can still mutate before it is re-stopped. The second manifest verification is the data-integrity fence for that case.

Recovery also preserves the need for the fence. A new quiescence owner cleans an orphan nonce by terminating only the identity-matched old watchdog, resumes the old lease's recorded processes, and creates a fresh lease. Recovery then resolves any journal, re-reconciles the current remote tree, prepares a new candidate, and re-enters the same final ladder. A gateway crash before publication leaves the prepared ref non-authoritative; restart recovery either applies an already-published canonical result or re-enters this ladder while the environment remains authoritative. Each re-entry therefore has the same late-enrollment window, rather than proving the old prepared capture stayed stable.

Verdict: keep the second pre-apply `verifyStable()`.

### Retryability equivalence

Before:

- Staged pre-apply `verifyStable`, `assertActive`, `verifyStable`: retryable for reclaim.
- Staged post-apply `assertActive`, `verifyStable`, `verifyLocalStable`: not retryable; preserve the result fence.
- Non-staged five-step ladder: every fence failure retryable when `changed === false`, and not retryable when `changed === true`.

After:

- The same three staged pre-apply steps use `runRetryableFinalFenceStep` and emit `reclaimDisposition: retry`.
- The same three staged post-apply steps use `runResultPreservingFinalFenceStep` and emit `reclaimDisposition: preserve-result`.
- The non-staged ladder selects the retryable runner exactly when `changed === false`; otherwise it selects the result-preserving runner for all five steps.
- `placement-dispatch.ts` releases the unstaged claim exactly when the error is a final-fence error with disposition `retry`, identical to the prior true-boolean set.

### Validation

- `node scripts/run-vitest.mjs src/gateway/worker-environments/workspace-finalize.test.ts src/gateway/worker-environments/placement-dispatch-reclaim.test.ts src/gateway/worker-environments/placement-dispatch.test.ts`: 3 files passed, 57 tests passed, 8.61s.
- `node scripts/check-changed.mjs -- src/gateway/worker-environments/workspace-finalize.ts src/gateway/worker-environments/placement-dispatch.ts src/gateway/worker-environments/workspace-finalize.test.ts`: passed on Blacksmith Testbox; wrapper exit 0 in 5m49s. [Run](https://github.com/openclaw/openclaw/actions/runs/29953787404)
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`: clean, no accepted/actionable findings; patch correct at 0.98.
- `git diff --check`: passed.
