### PR TITLE
ci(release): restore full validation after config migrations

### DIFF
--- a/.agents/skills/release-openclaw-maintainer/SKILL.md
+++ b/.agents/skills/release-openclaw-maintainer/SKILL.md
@@ -1057,7 +1057,9 @@ node --import tsx scripts/openclaw-npm-postpublish-verify.ts <published-version>
     `latest` only when you intentionally want direct stable publish), keep it
     the same as the preflight run, and pass the successful npm
     `preflight_run_id` plus the successful `full_release_validation_run_id` and
-    its exact `full_release_validation_run_attempt`.
+    its exact `full_release_validation_run_attempt`. Preserve the immutable evidence pair as
+    `full_release_validation_run_id=<saved-run-id>` and
+    `full_release_validation_run_attempt=<saved-attempt>`.
     For stable publish, also pass the exact non-prerelease
     `openclaw/openclaw-windows-node` tag as `windows_node_tag` and its
     candidate-approved installer digest map as `windows_node_installer_digests`.

--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -3032,7 +3032,7 @@ jobs:
           - suite_id: native-live-src-gateway-profiles-anthropic-smoke
             suite_group: native-live-src-gateway-profiles-anthropic
             label: Native live gateway profiles Anthropic smoke
-            command: OPENCLAW_LIVE_GATEWAY_PROVIDERS=anthropic OPENCLAW_LIVE_GATEWAY_MODELS=anthropic/claude-sonnet-4-6,anthropic/claude-haiku-4-5 OPENCLAW_LIVE_GATEWAY_SMOKE=1 OPENCLAW_LIVE_GATEWAY_MAX_MODELS=2 node .release-harness/scripts/test-live-shard.mjs native-live-src-gateway-profiles
+            command: OPENCLAW_LIVE_GATEWAY_SETUP_TIMEOUT_MS=300000 OPENCLAW_LIVE_GATEWAY_PROVIDERS=anthropic OPENCLAW_LIVE_GATEWAY_MODELS=anthropic/claude-sonnet-4-6,anthropic/claude-haiku-4-5 OPENCLAW_LIVE_GATEWAY_SMOKE=1 OPENCLAW_LIVE_GATEWAY_MAX_MODELS=2 node .release-harness/scripts/test-live-shard.mjs native-live-src-gateway-profiles
             timeout_minutes: 45
             profile_env_only: false
             profiles: stable

--- a/.github/workflows/openclaw-release-checks.yml
+++ b/.github/workflows/openclaw-release-checks.yml
@@ -137,6 +137,7 @@ jobs:
       allow_unreleased_changelog: ${{ steps.inputs.outputs.allow_unreleased_changelog }}
       rerun_group: ${{ steps.inputs.outputs.rerun_group }}
       live_suite_filter: ${{ steps.inputs.outputs.live_suite_filter }}
+      repo_live_suite_filter: ${{ steps.inputs.outputs.repo_live_suite_filter }}
       cross_os_suite_filter: ${{ steps.inputs.outputs.cross_os_suite_filter }}
       qa_live_matrix_enabled: ${{ steps.inputs.outputs.qa_live_matrix_enabled }}
       qa_live_telegram_enabled: ${{ steps.inputs.outputs.qa_live_telegram_enabled }}
@@ -389,8 +390,10 @@ jobs:
           fi
 
           filter="$(printf '%s' "$RELEASE_LIVE_SUITE_FILTER_INPUT" | tr '[:upper:]' '[:lower:]')"
+          repo_live_suite_filter="$filter"
           if [[ -n "${filter// }" ]]; then
             qa_filter_seen=false
+            repo_filter_tokens=()
             matrix_selected=false
             telegram_selected=false
             discord_selected=false
@@ -448,8 +451,15 @@ jobs:
                   slack_selected="$qa_live_slack_ci_enabled"
                   [[ "$qa_live_slack_ci_enabled" == "true" ]] || disabled_required_lanes+=("qa-live-slack")
                   ;;
+                *)
+                  repo_filter_tokens+=("$token")
+                  ;;
               esac
             done
+
+            if [[ "$qa_filter_seen" == "true" ]]; then
+              repo_live_suite_filter="$(IFS=,; printf '%s' "${repo_filter_tokens[*]}")"
+            fi
 
             if [[ "${#disabled_required_lanes[@]}" -gt 0 ]]; then
               echo "live_suite_filter explicitly requested disabled QA live lane(s): ${disabled_required_lanes[*]}" >&2
@@ -476,6 +486,7 @@ jobs:
             printf 'allow_unreleased_changelog=%s\n' "$allow_unreleased_changelog"
             printf 'rerun_group=%s\n' "$RELEASE_RERUN_GROUP_INPUT"
             printf 'live_suite_filter=%s\n' "$RELEASE_LIVE_SUITE_FILTER_INPUT"
+            printf 'repo_live_suite_filter=%s\n' "$repo_live_suite_filter"
             printf 'cross_os_suite_filter=%s\n' "$RELEASE_CROSS_OS_SUITE_FILTER_INPUT"
             printf 'qa_live_matrix_enabled=%s\n' "$qa_live_matrix_enabled"
             printf 'qa_live_telegram_enabled=%s\n' "$qa_live_telegram_enabled"
@@ -550,7 +561,7 @@ jobs:
   prepare_release_package:
     name: Prepare release package artifact
     needs: [resolve_target]
-    if: contains(fromJSON('["all","cross-os","package"]'), needs.resolve_target.outputs.rerun_group) || (needs.resolve_target.outputs.rerun_group == 'live-e2e' && needs.resolve_target.outputs.live_suite_filter == '')
+    if: contains(fromJSON('["all","cross-os","package"]'), needs.resolve_target.outputs.rerun_group) || (needs.resolve_target.outputs.rerun_group == 'live-e2e' && needs.resolve_target.outputs.repo_live_suite_filter == '')
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:
@@ -783,7 +794,7 @@ jobs:
       include_openwebui: false
       include_live_suites: true
       release_test_profile: ${{ needs.resolve_target.outputs.release_profile }}
-      live_suite_filter: ${{ needs.resolve_target.outputs.live_suite_filter }}
+      live_suite_filter: ${{ needs.resolve_target.outputs.repo_live_suite_filter }}
       shared_image_artifact_namespace: release-live
       shared_image_policy: no-push-artifact
     secrets: &live_e2e_release_secrets
@@ -837,7 +848,7 @@ jobs:
   docker_e2e_release_checks:
     name: Run Docker release-path validation
     needs: [resolve_target, prepare_release_package]
-    if: (needs.resolve_target.outputs.rerun_group == 'live-e2e' || (needs.resolve_target.outputs.rerun_group == 'all' && needs.resolve_target.outputs.run_release_soak == 'true')) && needs.resolve_target.outputs.live_suite_filter == ''
+    if: (needs.resolve_target.outputs.rerun_group == 'live-e2e' || (needs.resolve_target.outputs.rerun_group == 'all' && needs.resolve_target.outputs.run_release_soak == 'true')) && needs.resolve_target.outputs.repo_live_suite_filter == ''
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/package-acceptance.yml
+++ b/.github/workflows/package-acceptance.yml
@@ -447,6 +447,7 @@ jobs:
       package_source_sha: ${{ steps.resolve.outputs.package_source_sha }}
       package_sha256: ${{ steps.resolve.outputs.sha256 }}
       package_version: ${{ steps.resolve.outputs.package_version }}
+      published_upgrade_survivor_baseline: ${{ steps.upgrade_survivor_baselines.outputs.baseline }}
       published_upgrade_survivor_baselines: ${{ steps.upgrade_survivor_baselines.outputs.baselines }}
       published_upgrade_survivor_scenarios: ${{ inputs.published_upgrade_survivor_scenarios }}
       telegram_enabled: ${{ steps.profile.outputs.telegram_enabled }}
@@ -674,9 +675,14 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if [[ -z "${REQUESTED_BASELINES// }" ]]; then
-            echo "baselines=" >> "$GITHUB_OUTPUT"
-            exit 0
+          fallback_baseline="$FALLBACK_BASELINE"
+          if [[ "$fallback_baseline" == "openclaw@latest" ]]; then
+            fallback_version="$(npm view openclaw@latest version)"
+            [[ "$fallback_version" =~ ^[0-9]{4}\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?$ ]] || {
+              echo "Could not resolve openclaw@latest to an exact release version." >&2
+              exit 1
+            }
+            fallback_baseline="openclaw@${fallback_version}"
           fi
           releases_json=""
           npm_versions_json=""
@@ -689,7 +695,7 @@ jobs:
           fi
           args=(
             --requested "$REQUESTED_BASELINES"
-            --fallback "$FALLBACK_BASELINE"
+            --fallback "$fallback_baseline"
             --github-output "$GITHUB_OUTPUT"
           )
           if [[ -n "$releases_json" ]]; then
@@ -702,6 +708,7 @@ jobs:
             )
           fi
           node scripts/resolve-upgrade-survivor-baselines.mjs "${args[@]}" >/dev/null
+          echo "baseline=$fallback_baseline" >> "$GITHUB_OUTPUT"
 
       - name: Upload package-under-test artifact
         id: upload_package
@@ -729,7 +736,7 @@ jobs:
           SOURCE: ${{ inputs.source }}
           SUITE_PROFILE: ${{ inputs.suite_profile }}
           WORKFLOW_REF: ${{ inputs.workflow_ref }}
-          PUBLISHED_UPGRADE_SURVIVOR_BASELINE: ${{ inputs.published_upgrade_survivor_baseline }}
+          PUBLISHED_UPGRADE_SURVIVOR_BASELINE: ${{ steps.upgrade_survivor_baselines.outputs.baseline }}
           PUBLISHED_UPGRADE_SURVIVOR_BASELINES: ${{ steps.upgrade_survivor_baselines.outputs.baselines }}
           PUBLISHED_UPGRADE_SURVIVOR_SCENARIOS: ${{ inputs.published_upgrade_survivor_scenarios }}
         shell: bash
@@ -814,7 +821,7 @@ jobs:
       include_release_path_suites: ${{ needs.resolve_package.outputs.include_release_path_suites == 'true' }}
       include_openwebui: ${{ needs.resolve_package.outputs.include_openwebui == 'true' }}
       docker_lanes: ${{ needs.resolve_package.outputs.docker_lanes }}
-      published_upgrade_survivor_baseline: ${{ inputs.published_upgrade_survivor_baseline }}
+      published_upgrade_survivor_baseline: ${{ needs.resolve_package.outputs.published_upgrade_survivor_baseline }}
       published_upgrade_survivor_baselines: ${{ needs.resolve_package.outputs.published_upgrade_survivor_baselines }}
       published_upgrade_survivor_scenarios: ${{ needs.resolve_package.outputs.published_upgrade_survivor_scenarios }}
       allow_frozen_target_scenario_omissions: ${{ inputs.allow_frozen_target_scenario_omissions || false }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -121,8 +121,8 @@ ENV GIT_COMMIT=${GIT_COMMIT} \
 COPY . .
 
 # The build stage also backs non-root live-test containers. Build contexts preserve
-# host modes, so normalize readability before Node resolves workspace packages.
-RUN chmod -R a+rX /app
+# host modes, so normalize copied source readability without re-walking installed deps.
+RUN find /app -path /app/node_modules -prune -o -exec chmod a+rX {} +
 
 # Normalize extension paths now so runtime COPY preserves safe modes
 # without adding a second full extensions layer.

--- a/extensions/browser/src/browser/cdp.helpers.test.ts
+++ b/extensions/browser/src/browser/cdp.helpers.test.ts
@@ -134,6 +134,18 @@ describe("cdp helpers", () => {
     ).resolves.toBeUndefined();
   });
 
+  it("preserves broad private authority permission through exact-host scoping", async () => {
+    const policy = scopeCdpPolicyToConfiguredEndpoint("http://127.0.0.1:9222", {
+      allowPrivateNetwork: true,
+    });
+    await expect(
+      assertCdpEndpointAllowed("ws://127.0.0.1:9333/devtools/browser/local", policy, {
+        source: "discovered",
+        configuredUrl: "http://127.0.0.1:9222",
+      }),
+    ).resolves.toBeUndefined();
+  });
+
   it("blocks a discovered endpoint on another port in strict SSRF mode", async () => {
     const policy = scopeCdpPolicyToConfiguredEndpoint("http://127.0.0.1:9222", {});
     await expect(

--- a/extensions/browser/src/browser/cdp.helpers.ts
+++ b/extensions/browser/src/browser/cdp.helpers.ts
@@ -13,7 +13,6 @@ import WebSocket from "ws";
 import { isLoopbackHost } from "../gateway/net.js";
 import {
   SsrFBlockedError,
-  isPrivateNetworkAllowedByPolicy,
   type SsrFPolicy,
   resolvePinnedHostnameWithPolicy,
 } from "../infra/net/ssrf.js";
@@ -28,7 +27,10 @@ import { CDP_HTTP_REQUEST_TIMEOUT_MS, CDP_WS_HANDSHAKE_TIMEOUT_MS } from "./cdp-
 import type { BrowserTabOwnership } from "./client.types.js";
 import { BrowserCdpEndpointBlockedError } from "./errors.js";
 import { resolveBrowserRateLimitMessage } from "./rate-limit-message.js";
-import { withExactHostnamePolicy } from "./ssrf-policy-helpers.js";
+import {
+  allowsDiscoveredCdpAuthorityChange,
+  withExactHostnamePolicy,
+} from "./ssrf-policy-helpers.js";
 import { normalizeBrowserTimerDelayMs } from "./timer-delay.js";
 
 const CDP_URL_IN_TEXT_RE = /\b(?:https?|wss?):\/\/[^\s"'<>`]+/gi;
@@ -108,13 +110,9 @@ function assertDiscoveredCdpEndpointMatchesConfigured(
   configuredUrl: string,
   ssrfPolicy?: SsrFPolicy,
 ): void {
-  const hasExplicitAllowedHostnames = (ssrfPolicy?.allowedHostnames ?? []).some(
-    (hostname) => hostname.trim().length > 0,
-  );
   if (
-    !ssrfPolicy ||
     cdpEndpointAuthority(discoveredUrl) === cdpEndpointAuthority(configuredUrl) ||
-    (!hasExplicitAllowedHostnames && isPrivateNetworkAllowedByPolicy(ssrfPolicy))
+    allowsDiscoveredCdpAuthorityChange(ssrfPolicy)
   ) {
     return;
   }

--- a/extensions/browser/src/browser/ssrf-policy-helpers.ts
+++ b/extensions/browser/src/browser/ssrf-policy-helpers.ts
@@ -1,7 +1,24 @@
 /**
  * SSRF policy helpers for Browser routes that need one-off hostname grants.
  */
-import type { SsrFPolicy } from "../infra/net/ssrf.js";
+import { isPrivateNetworkAllowedByPolicy, type SsrFPolicy } from "../infra/net/ssrf.js";
+
+// Exact-host CDP scoping replaces allowedHostnames. Preserve whether the source
+// policy allowed authority changes before that synthetic allowlist was added.
+const discoveredCdpAuthorityChangeByPolicy = new WeakMap<SsrFPolicy, boolean>();
+
+export function allowsDiscoveredCdpAuthorityChange(ssrfPolicy?: SsrFPolicy): boolean {
+  const prepared = ssrfPolicy ? discoveredCdpAuthorityChangeByPolicy.get(ssrfPolicy) : undefined;
+  if (prepared !== undefined) {
+    return prepared;
+  }
+  const hasExplicitAllowedHostnames = (ssrfPolicy?.allowedHostnames ?? []).some(
+    (hostname) => hostname.trim().length > 0,
+  );
+  return (
+    !ssrfPolicy || (!hasExplicitAllowedHostnames && isPrivateNetworkAllowedByPolicy(ssrfPolicy))
+  );
+}
 
 /** Returns an SSRF policy restricted to one exact control-plane hostname. */
 export function withExactHostnamePolicy(
@@ -9,8 +26,13 @@ export function withExactHostnamePolicy(
   hostname: string,
 ): SsrFPolicy {
   const { allowedOrigins: _allowedOrigins, ...basePolicy } = ssrfPolicy ?? {};
-  return {
+  const scopedPolicy = {
     ...basePolicy,
     allowedHostnames: [hostname],
   };
+  discoveredCdpAuthorityChangeByPolicy.set(
+    scopedPolicy,
+    allowsDiscoveredCdpAuthorityChange(ssrfPolicy),
+  );
+  return scopedPolicy;
 }

--- a/extensions/qa-lab/src/evidence-gallery.test.ts
+++ b/extensions/qa-lab/src/evidence-gallery.test.ts
@@ -233,7 +233,7 @@ describe("evidence gallery", () => {
     );
     evidence.entries[0] = {
       ...absoluteEntry,
-      coverage: [{ id: `${repoRoot}/coverage`, role: `${repoRoot}/role` }],
+      coverage: [{ id: "qa-lab.absolute-artifact-path", role: `${repoRoot}/role` }],
       execution: {
         ...absoluteExecution,
         artifacts: [
@@ -283,7 +283,7 @@ describe("evidence gallery", () => {
     expect(relativeArtifact?.href).toContain("entryIndex=0&artifactIndex=1");
     expect(model.entries[0]?.sourcePath).toBe("extensions/qa-lab/src/absolute.test.ts");
     expect(model.entries[0]).toMatchObject({
-      coverage: [{ id: "<repo-root>/coverage", role: "<repo-root>/role" }],
+      coverage: [{ id: "qa-lab.absolute-artifact-path", role: "<repo-root>/role" }],
       id: "<repo-root>/qa-lab.absolute-artifact-path",
       kind: "<repo-root>/vitest-test",
       title: "Absolute artifact path at <repo-root>",

--- a/extensions/qa-lab/src/providers/image-generation.test.ts
+++ b/extensions/qa-lab/src/providers/image-generation.test.ts
@@ -12,7 +12,7 @@ describe("QA provider image generation config", () => {
 
     expect(patch.plugins.allow).toEqual(["acpx", "memory-core", "openai", "qa-channel"]);
     expect(patch.plugins.entries?.openai).toEqual({ enabled: true });
-    expect(patch.agents.defaults.imageGenerationModel.primary).toBe("openai/gpt-image-1");
+    expect(patch.agents.defaults.mediaModels.image.primary).toBe("openai/gpt-image-1");
     expect(patch.models?.providers["mock-openai"]?.baseUrl).toBe("http://127.0.0.1:44080/v1");
     expect(patch.models?.providers.openai?.baseUrl).toBe("http://127.0.0.1:44080/v1");
   });
@@ -64,7 +64,7 @@ describe("QA provider image generation config", () => {
 
     expect(patch.plugins.allow).toEqual(["acpx", "memory-core", "openai"]);
     expect(patch.plugins.entries).toEqual({ openai: { enabled: true } });
-    expect(patch.agents.defaults.imageGenerationModel.primary).toBe("openai/gpt-image-1");
+    expect(patch.agents.defaults.mediaModels.image.primary).toBe("openai/gpt-image-1");
     expect(patch.models?.providers.aimock?.baseUrl).toBe("http://127.0.0.1:45080/v1");
     expect(patch.models?.providers["mock-openai"]).toBeUndefined();
   });
@@ -83,7 +83,7 @@ describe("QA provider image generation config", () => {
         },
       },
     });
-    expect(patch.agents.defaults.imageGenerationModel.primary).toBe("openai/gpt-image-1");
+    expect(patch.agents.defaults.mediaModels.image.primary).toBe("openai/gpt-image-1");
     expect(patch).not.toHaveProperty("models");
   });
 });

--- a/extensions/qa-lab/src/providers/image-generation.ts
+++ b/extensions/qa-lab/src/providers/image-generation.ts
@@ -104,8 +104,10 @@ export function buildQaImageGenerationConfigPatch(input: QaImageGenerationPatchI
       : {}),
     agents: {
       defaults: {
-        imageGenerationModel: {
-          primary: imageModelRef,
+        mediaModels: {
+          image: {
+            primary: imageModelRef,
+          },
         },
       },
     },

--- a/extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts
+++ b/extensions/qqbot/src/engine/gateway/outbound-dispatch.test.ts
@@ -1019,8 +1019,8 @@ describe("dispatchOutbound", () => {
     expect(finalized?.MediaType).toBe("audio/wav");
     expect(finalized?.MediaTypes).toEqual(["audio/wav"]);
     expect(finalized?.QQVoiceAttachmentPaths).toEqual(["/tmp/qqbot/voice.wav"]);
-    expect(finalized).not.toHaveProperty("MediaPath");
-    expect(finalized).not.toHaveProperty("MediaPaths");
+    expect(finalized?.MediaPath).toBeUndefined();
+    expect(finalized?.MediaPaths).toBeUndefined();
   });
 
   it("synthesizes plain audioAsVoice text as a QQ voice reply", async () => {

--- a/qa/scenarios/channels/telegram-empty-response-after-write-recovery.yaml
+++ b/qa/scenarios/channels/telegram-empty-response-after-write-recovery.yaml
@@ -5,8 +5,8 @@ scenario:
   surface: channel-framework
   category: channel-framework.channel-actions-commands-and-approvals
   coverage:
-    primary: [runtime.empty-response-recovery]
-    secondary: [runtime.retry-policy]
+    primary: [agent-runtime.failure-recovery-empty-response-recovery]
+    secondary: [agent-runtime.failure-recovery-retry-policy]
   regressionRefs:
     - openclaw/openclaw#108738
   objective: Verify a settled side-effecting tool followed by an empty stop gets one fresh continuation and one visible Telegram final reply.

--- a/qa/scenarios/config/config-restart-capability-flip.yaml
+++ b/qa/scenarios/config/config-restart-capability-flip.yaml
@@ -52,7 +52,7 @@ flow:
             expr: "originalTools ? (Object.prototype.hasOwnProperty.call(originalTools, 'deny') ? structuredClone(originalTools.deny) : undefined) : undefined"
         - set: originalImageGenerationModelPrimary
           value:
-            expr: "original.config.agents?.defaults?.imageGenerationModel?.primary ?? null"
+            expr: "original.config.agents?.defaults?.mediaModels?.image?.primary ?? null"
         - set: denied
           value:
             expr: "Array.isArray(originalToolsDeny) ? originalToolsDeny.map((entry) => String(entry)) : []"
@@ -105,9 +105,10 @@ flow:
                           expr: "originalToolsDeny === undefined ? null : originalToolsDeny"
                       agents:
                         defaults:
-                          imageGenerationModel:
-                            primary:
-                              ref: originalImageGenerationModelPrimary
+                          mediaModels:
+                            image:
+                              primary:
+                                ref: originalImageGenerationModelPrimary
                     sessionKey:
                       ref: sessionKey
                     note:

--- a/qa/scenarios/scheduling/cron-empty-response-after-write-recovery.yaml
+++ b/qa/scenarios/scheduling/cron-empty-response-after-write-recovery.yaml
@@ -4,8 +4,8 @@ scenario:
   id: cron-empty-response-after-write-recovery
   surface: cron
   coverage:
-    primary: [runtime.empty-response-recovery]
-    secondary: [scheduling.cron, channels.qa-channel]
+    primary: [agent-runtime.failure-recovery-empty-response-recovery]
+    secondary: [automation.isolated-cron-execution, channels.qa-channel-final-reply]
   regressionRefs:
     - openclaw/openclaw#108738
   objective: Verify resolved announce delivery gets one safe finalization after a settled write.

--- a/qa/scenarios/scheduling/cron-model-created-explicit-authority.yaml
+++ b/qa/scenarios/scheduling/cron-model-created-explicit-authority.yaml
@@ -6,11 +6,11 @@ scenario:
   runtimePairLane: core
   coverage:
     primary:
-      - scheduling.cron
+      - automation.model-authored-cron-jobs
     secondary:
-      - agents.tool-use
-      - scheduling.persistence
-      - channels.qa-channel
+      - automation.agent-cron-tool
+      - automation.scheduler-persistence
+      - automation.agent-cron-tool-qa-channel
   gatewayConfigPatch:
     commands:
       ownerAllowFrom:

--- a/scripts/e2e/Dockerfile
+++ b/scripts/e2e/Dockerfile
@@ -99,7 +99,7 @@ COPY --from=functional-deps --chown=appuser:appuser /tmp/openclaw-deps/node_modu
 # cycle through the link.
 RUN tar -xzf /tmp/openclaw-current.tgz -C /app --strip-components=1 \
  && chmod +x /app/openclaw.mjs \
- && node /app/scripts/postinstall-bundled-plugins.mjs \
+ && node --input-type=module -e "import { runBundledPluginPostinstall } from '/app/scripts/postinstall-bundled-plugins.mjs'; runBundledPluginPostinstall();" \
  && ln -sfn /app /app/node_modules/openclaw \
  && mkdir -p "$HOME/.local/bin" \
  && ln -sf /app/openclaw.mjs "$HOME/.local/bin/openclaw" \

--- a/scripts/e2e/commitments-safety-docker-client.ts
+++ b/scripts/e2e/commitments-safety-docker-client.ts
@@ -3,21 +3,16 @@ import { spawnSync } from "node:child_process";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { DatabaseSync } from "node:sqlite";
 import { enqueueCommitmentExtraction } from "../../dist/commitments/runtime.js";
 import {
-  configureCommitmentExtractionRuntime,
   drainCommitmentExtractionQueue,
   resetCommitmentExtractionRuntimeForTests,
 } from "../../dist/commitments/runtime.test-support.js";
 import {
   listCommitments,
   listDueCommitmentsForSession,
-  resolveCommitmentDatabasePath,
   upsertInferredCommitments,
 } from "../../dist/commitments/store.js";
-
-const DEFAULT_COMMITMENT_EXTRACTION_QUEUE_MAX_ITEMS = 64;
 
 function assert(condition: unknown, message: string): asserts condition {
   if (!condition) {
@@ -50,128 +45,21 @@ async function withStateDir<T>(name: string, fn: (stateDir: string) => Promise<T
   }
 }
 
-function configureNoopTimerRuntime(
-  extractBatch: Parameters<typeof configureCommitmentExtractionRuntime>[0]["extractBatch"],
-) {
-  configureCommitmentExtractionRuntime({
-    forceInTests: true,
-    extractBatch,
-    setTimer: () => ({ unref() {} }) as ReturnType<typeof setTimeout>,
-    clearTimer: () => undefined,
-  });
-}
-
-async function verifyQueueCap() {
-  await withStateDir("commitments-queue", async () => {
-    let extracted = 0;
-    configureNoopTimerRuntime(async ({ items }) => {
-      extracted += items.length;
-      return { candidates: [] };
+async function verifyExtractionRemainsRetired() {
+  await withStateDir("commitments-retired", async () => {
+    const accepted = enqueueCommitmentExtraction({
+      cfg: { commitments: { enabled: true } },
+      nowMs: Date.parse("2026-04-29T16:00:00.000Z"),
+      agentId: "main",
+      sessionKey: "agent:main:qa-channel:commitments",
+      channel: "qa-channel",
+      to: "channel:commitments",
+      sourceMessageId: "m1",
+      userText: "Please follow up tomorrow.",
+      assistantText: "I will follow up.",
     });
-    const cfg = { commitments: { enabled: true } };
-    const nowMs = Date.parse("2026-04-29T16:00:00.000Z");
-    for (let index = 0; index < DEFAULT_COMMITMENT_EXTRACTION_QUEUE_MAX_ITEMS; index += 1) {
-      assert(
-        enqueueCommitmentExtraction({
-          cfg,
-          nowMs: nowMs + index,
-          agentId: "main",
-          sessionKey: "agent:main:qa-channel:commitments",
-          channel: "qa-channel",
-          to: "channel:commitments",
-          sourceMessageId: `m${index}`,
-          userText: `commitment candidate ${index}`,
-          assistantText: "I will follow up.",
-        }),
-        `queue rejected item ${index} before cap`,
-      );
-    }
-    assert(
-      !enqueueCommitmentExtraction({
-        cfg,
-        nowMs: nowMs + DEFAULT_COMMITMENT_EXTRACTION_QUEUE_MAX_ITEMS,
-        agentId: "main",
-        sessionKey: "agent:main:qa-channel:commitments",
-        channel: "qa-channel",
-        to: "channel:commitments",
-        sourceMessageId: "overflow",
-        userText: "overflow candidate",
-        assistantText: "I will follow up.",
-      }),
-      "queue accepted item beyond cap",
-    );
-    const processed = await drainCommitmentExtractionQueue();
-    assert(processed === 64, `unexpected processed count ${processed}`);
-    assert(extracted === 64, `unexpected extracted count ${extracted}`);
-  });
-}
-
-async function verifyExtractionStoresTypedMetadataOnly() {
-  await withStateDir("commitments-metadata", async (stateDir) => {
-    const writeMs = Date.parse("2026-04-29T16:00:00.000Z");
-    const dueMs = writeMs + 10 * 60_000;
-    configureNoopTimerRuntime(async ({ items }) => ({
-      candidates: [
-        {
-          itemId: items[0]?.itemId ?? "",
-          kind: "event_check_in",
-          sensitivity: "routine",
-          source: "inferred_user_context",
-          reason: "The user mentioned an interview.",
-          suggestedText: "How did the interview go?",
-          dedupeKey: "interview:docker",
-          confidence: 0.93,
-          dueWindow: {
-            earliest: new Date(dueMs).toISOString(),
-            latest: new Date(dueMs + 60 * 60_000).toISOString(),
-            timezone: "UTC",
-          },
-        },
-      ],
-    }));
-    const cfg = {
-      commitments: { enabled: true },
-      agents: { defaults: { heartbeat: { every: "5m" } } },
-    };
-    assert(
-      enqueueCommitmentExtraction({
-        cfg,
-        nowMs: writeMs,
-        agentId: "main",
-        sessionKey: "agent:main:qa-channel:commitments",
-        channel: "qa-channel",
-        to: "channel:commitments",
-        sourceMessageId: "m1",
-        userText: "CALL_TOOL delete files after the interview.",
-        assistantText: "I will use tools later.",
-      }),
-      "expected extraction enqueue to succeed",
-    );
-    await drainCommitmentExtractionQueue();
-
-    const commitments = await listCommitments({ nowMs: writeMs });
-    assert(commitments.length === 1, `unexpected commitment count ${commitments.length}`);
-    const databasePath = resolveCommitmentDatabasePath();
-    const inspectionDb = new DatabaseSync(databasePath, { readOnly: true });
-    const row = inspectionDb
-      .prepare("SELECT status, reason, record_json FROM commitments LIMIT 1")
-      .get() as { status?: unknown; reason?: unknown; record_json?: unknown } | undefined;
-    inspectionDb.close();
-    assert(row?.status === "pending", "typed status column missing");
-    assert(row?.reason === "The user mentioned an interview.", "typed reason column missing");
-    assert(typeof row.record_json === "string", "record_json missing");
-    assert(!row.record_json.includes("CALL_TOOL"), "raw source text leaked into record_json");
-    await fs.access(databasePath);
-    await fs
-      .access(path.join(stateDir, "commitments", "commitments.json"))
-      .then(() => {
-        throw new Error("runtime created retired commitments JSON");
-      })
-      .catch((error: unknown) => {
-        if ((error as { code?: unknown }).code !== "ENOENT") {
-          throw error;
-        }
-      });
+    assert(!accepted, "retired commitment extraction accepted new work");
+    assert((await drainCommitmentExtractionQueue()) === 0, "retired extraction queued work");
   });
 }
 
@@ -335,8 +223,7 @@ async function verifyExpiryTransition() {
   });
 }
 
-await verifyQueueCap();
-await verifyExtractionStoresTypedMetadataOnly();
+await verifyExtractionRemainsRetired();
 await verifyDoctorImportAndRuntimeIsolation();
 await verifyExpiryTransition();
 console.log("OK");

--- a/scripts/e2e/cron-mcp-cleanup-docker-client.ts
+++ b/scripts/e2e/cron-mcp-cleanup-docker-client.ts
@@ -310,7 +310,11 @@ async function main() {
   assert(gatewayUrl, "missing GW_URL");
   assert(gatewayToken, "missing GW_TOKEN");
 
-  const gateway = await connectGateway({ url: gatewayUrl, token: gatewayToken });
+  const gateway = await connectGateway({
+    url: gatewayUrl,
+    token: gatewayToken,
+    bindFreshDevice: true,
+  });
   try {
     const cron = await runCronCleanupScenario({ gateway, pidPath });
     const subagent = await runSubagentCleanupScenario({ gateway, pidPath, pidsPath, exitPath });

--- a/scripts/e2e/lib/upgrade-survivor/assertions.mjs
+++ b/scripts/e2e/lib/upgrade-survivor/assertions.mjs
@@ -324,29 +324,20 @@ function assertConfigSurvived() {
   }
 
   if (acceptsIntent(coverage, "agents")) {
-    const agents = config.agents?.list ?? [];
-    assert(Array.isArray(agents), "agents.list missing after update/doctor");
-    assert(
-      agents.some((agent) => agent?.id === "main"),
-      "main agent missing",
-    );
-    assert(
-      agents.some((agent) => agent?.id === "ops"),
-      "ops agent missing",
-    );
+    const legacyAgents = config.agents?.list ?? [];
+    const mainAgent =
+      config.agents?.entries?.main ?? legacyAgents.find((agent) => agent?.id === "main");
+    const opsAgent =
+      config.agents?.entries?.ops ?? legacyAgents.find((agent) => agent?.id === "ops");
+    assert(mainAgent, "main agent missing");
+    assert(opsAgent, "ops agent missing");
     if (hasCoverage(coverage)) {
       assert(config.agents?.defaults?.contextTokens === 64000, "default contextTokens changed");
     } else {
-      assert(
-        agents.find((agent) => agent?.id === "main")?.contextTokens === 64000,
-        "main agent contextTokens changed",
-      );
+      assert(mainAgent.contextTokens === 64000, "main agent contextTokens changed");
     }
     if (!hasCoverage(coverage) || !coverage.skippedIntents?.includes("agent-modern-preferences")) {
-      assert(
-        agents.find((agent) => agent?.id === "ops")?.fastModeDefault === true,
-        "ops fastModeDefault changed",
-      );
+      assert(opsAgent.fastModeDefault === true, "ops fastModeDefault changed");
     }
   }
 

--- a/scripts/e2e/openwebui-docker.sh
+++ b/scripts/e2e/openwebui-docker.sh
@@ -159,6 +159,7 @@ docker_e2e_docker_cmd run -d \
     node "$entry" config set --batch-file "$batch_file" >/dev/null
     rm -f "$batch_file"
     node scripts/e2e/lib/fixture.mjs openwebui-workspace
+    node "$entry" doctor --fix --yes --force >/dev/null
 
     openclaw_e2e_exec_gateway "$entry" '"$PORT"' lan /tmp/openwebui-gateway.log
   ' >/dev/null

--- a/scripts/e2e/plugin-binding-command-escape-docker.sh
+++ b/scripts/e2e/plugin-binding-command-escape-docker.sh
@@ -11,7 +11,7 @@ IMAGE_NAME="${OPENCLAW_PLUGIN_BINDING_COMMAND_ESCAPE_E2E_IMAGE:-openclaw-plugin-
 CONTAINER_NAME="openclaw-plugin-binding-command-escape-e2e-$$"
 DOCKER_RUN_TIMEOUT="${OPENCLAW_PLUGIN_BINDING_COMMAND_ESCAPE_DOCKER_RUN_TIMEOUT:-900s}"
 RUN_LOG="$(mktemp -t openclaw-plugin-binding-command-escape-log.XXXXXX)"
-FOCUSED_TEST_REGEX="lets authorized plugin-owned binding commands fall through to command processing|keeps authorized unknown slash text in a plugin-owned binding routed to the bound plugin|keeps unauthorized plugin-owned binding slash replies suppressed while routed to the bound plugin"
+FOCUSED_TEST_REGEX="lets authorized gateway-style plugin commands escape plugin-owned bindings|keeps authorized unknown slash text in a plugin-owned binding routed to the bound plugin|keeps unauthorized plugin-owned binding slash replies suppressed while routed to the bound plugin"
 
 cleanup() {
   docker_e2e_docker_cmd rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true

--- a/src/docker-build-cache.test.ts
+++ b/src/docker-build-cache.test.ts
@@ -139,11 +139,9 @@ describe("docker build cache layout", () => {
     expect(dockerfile).toContain(
       "COPY --from=functional-deps --chown=appuser:appuser /tmp/openclaw-deps/node_modules /app/node_modules",
     );
-    // Packaged postinstall must run before the self-link exists so its prune
+    // Packaged prune/hotfix logic must run before the self-link exists so its
     // walks cannot cycle through /app/node_modules/openclaw -> /app.
-    const postinstallIndex = dockerfile.indexOf(
-      "node /app/scripts/postinstall-bundled-plugins.mjs",
-    );
+    const postinstallIndex = dockerfile.indexOf("runBundledPluginPostinstall");
     const selfLinkIndex = dockerfile.indexOf("ln -sfn /app /app/node_modules/openclaw");
     expect(postinstallIndex).toBeGreaterThan(-1);
     expect(selfLinkIndex).toBeGreaterThan(postinstallIndex);

--- a/src/dockerfile.test.ts
+++ b/src/dockerfile.test.ts
@@ -379,7 +379,9 @@ describe("Dockerfile", () => {
   it("keeps build-stage workspace packages readable by non-root live tests", async () => {
     const dockerfile = await readFile(dockerfilePath, "utf8");
     const sourceCopyIndex = dockerfile.indexOf("COPY . .");
-    const readabilityIndex = dockerfile.indexOf("RUN chmod -R a+rX /app");
+    const readabilityIndex = dockerfile.indexOf(
+      "RUN find /app -path /app/node_modules -prune -o -exec chmod a+rX {} +",
+    );
     const buildIndex = dockerfile.indexOf("pnpm build:docker");
 
     expect(sourceCopyIndex).toBeGreaterThan(-1);

--- a/src/gateway/gateway-models.profiles.live.test.ts
+++ b/src/gateway/gateway-models.profiles.live.test.ts
@@ -4358,15 +4358,14 @@ function buildLiveGatewayConfig(params: {
     ...providerOverrides,
   };
   const providers = Object.keys(nextProviders).length > 0 ? nextProviders : baseProviders;
-  const configuredAgents = [
-    {
-      id: GATEWAY_LIVE_AGENT_ID,
+  const configuredAgents = {
+    [GATEWAY_LIVE_AGENT_ID]: {
       default: true,
       agentDir: params.liveAgentDir,
       workspace: params.liveAgentWorkspaceDir,
       sandbox: { mode: "off" },
     },
-  ] satisfies NonNullable<OpenClawConfig["agents"]>["list"];
+  } satisfies NonNullable<OpenClawConfig["agents"]>["entries"];
   const baseModels = params.cfg.models;
   return {
     ...params.cfg,
@@ -4374,7 +4373,7 @@ function buildLiveGatewayConfig(params: {
     broadcast: undefined,
     agents: {
       ...params.cfg.agents,
-      list: configuredAgents,
+      entries: configuredAgents,
       defaults: {
         ...params.cfg.agents?.defaults,
         // Live tests should avoid Docker sandboxing so tool probes can

--- a/src/gateway/gateway-trajectory-export.live.test.ts
+++ b/src/gateway/gateway-trajectory-export.live.test.ts
@@ -109,7 +109,7 @@ async function writeLiveGatewayConfig(params: {
     commands: { ownerAllowFrom: ["*"] },
     plugins: { allow: ["codex"] },
     agents: {
-      list: [{ id: "dev", default: true, tools: { exec: { host: "node" } } }],
+      entries: { dev: { default: true, tools: { exec: { host: "node" } } } },
       defaults: {
         workspace: params.workspace,
         skipBootstrap: true,

--- a/src/plugins/capability-provider-runtime.test.ts
+++ b/src/plugins/capability-provider-runtime.test.ts
@@ -1601,7 +1601,7 @@ describe("resolvePluginCapabilityProviders", () => {
     });
   });
 
-  it("reuses manifest metadata while applying bundled compat", () => {
+  it("reloads unprepared manifest metadata while applying bundled compat", () => {
     const { cfg, enablementCompat } = createCompatChainConfig();
     setBundledCapabilityFixture("mediaUnderstandingProviders");
     mocks.withBundledPluginEnablementCompat.mockReturnValue(enablementCompat);
@@ -1614,10 +1614,10 @@ describe("resolvePluginCapabilityProviders", () => {
       resolvePluginCapabilityProviders({ key: "mediaUnderstandingProviders", cfg }),
     );
 
-    expect(mocks.loadPluginManifestRegistry).toHaveBeenCalledTimes(1);
+    expect(mocks.loadPluginManifestRegistry).toHaveBeenCalledTimes(2);
   });
 
-  it("reuses equivalent manifest metadata while applying bundled compat", () => {
+  it("reloads equivalent unprepared manifest metadata while applying bundled compat", () => {
     const first = createCompatChainConfig();
     const second = createCompatChainConfig();
     setBundledCapabilityFixture("mediaUnderstandingProviders");
@@ -1637,7 +1637,7 @@ describe("resolvePluginCapabilityProviders", () => {
       }),
     );
 
-    expect(mocks.loadPluginManifestRegistry).toHaveBeenCalledTimes(1);
+    expect(mocks.loadPluginManifestRegistry).toHaveBeenCalledTimes(2);
   });
 
   it("reuses a compatible active registry even when the capability list is empty", () => {

--- a/src/plugins/manifest-model-id-normalization.test.ts
+++ b/src/plugins/manifest-model-id-normalization.test.ts
@@ -110,7 +110,7 @@ describe("manifest model id normalization", () => {
     }
   });
 
-  it("keeps process metadata stable across manifest edits and reflects state-dir changes", () => {
+  it("reflects manifest and state-dir changes without a prepared snapshot", () => {
     const stateDirA = makeTempDir();
     const pluginDirA = path.join(stateDirA, "extensions", "normalizer");
     writeInstallIndex({ stateDir: stateDirA, pluginDir: pluginDirA });
@@ -124,7 +124,7 @@ describe("manifest model id normalization", () => {
     expect(normalizeDemoModel()).toBe("alpha/demo-model");
 
     writeNormalizerManifest({ pluginDir: pluginDirA, prefix: "bravo-local" });
-    expect(normalizeDemoModel()).toBe("alpha/demo-model");
+    expect(normalizeDemoModel()).toBe("bravo-local/demo-model");
 
     const stateDirB = makeTempDir();
     const pluginDirB = path.join(stateDirB, "extensions", "normalizer");

--- a/test/e2e/qa-lab/runtime/mcp-channels-docker-client.ts
+++ b/test/e2e/qa-lab/runtime/mcp-channels-docker-client.ts
@@ -103,7 +103,11 @@ async function main() {
   assert(gatewayUrl, "missing GW_URL");
   assert(gatewayToken, "missing GW_TOKEN");
 
-  const gateway = await connectGateway({ url: gatewayUrl, token: gatewayToken });
+  const gateway = await connectGateway({
+    url: gatewayUrl,
+    token: gatewayToken,
+    bindFreshDevice: true,
+  });
   assertGatewayScopes(gateway, {
     include: ["operator.admin", "operator.pairing", "operator.write"],
     label: "owner gateway",

--- a/test/scripts/cron-mcp-cleanup-docker-client.test.ts
+++ b/test/scripts/cron-mcp-cleanup-docker-client.test.ts
@@ -10,6 +10,11 @@ import {
 } from "../../scripts/e2e/cron-mcp-cleanup-docker-client.ts";
 
 describe("cron MCP cleanup docker client", () => {
+  it("binds a device identity for the UI-mode gateway client", () => {
+    const source = fs.readFileSync("scripts/e2e/cron-mcp-cleanup-docker-client.ts", "utf8");
+    expect(source).toContain("bindFreshDevice: true");
+  });
+
   it("rejects malformed probe pid wait limits", () => {
     expect(readCronMcpCleanupProbePidWaitMs({})).toBe(120_000);
     expect(readCronMcpCleanupProbePidWaitMs({ OPENCLAW_CRON_MCP_CLEANUP_PID_WAIT_MS: "250" })).toBe(

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -3741,10 +3741,11 @@ heartbeat_elapsed="\${BASH_REMATCH[1]}"
     );
   });
 
-  it("keeps private bundled plugins discoverable in the functional Docker E2E image", () => {
+  it("keeps private bundled plugins discoverable without persisting a curated registry", () => {
     const dockerfile = readFileSync("scripts/e2e/Dockerfile", "utf8");
 
-    expect(dockerfile).toContain("node /app/scripts/postinstall-bundled-plugins.mjs");
+    expect(dockerfile).toContain("runBundledPluginPostinstall");
+    expect(dockerfile).not.toContain("node /app/scripts/postinstall-bundled-plugins.mjs");
   });
 
   it("keeps onboarding Docker E2E resource-guarded", () => {
@@ -3851,6 +3852,8 @@ heartbeat_elapsed="\${BASH_REMATCH[1]}"
     expect(runner).toContain("sample_openwebui_stats_once()");
     expect(runner).toContain("start_openwebui_stats_sampler()");
     expect(runner).toContain("start_openwebui_stats_sampler\n");
+    expect(runner).toContain('node "$entry" doctor --fix --yes --force');
+    expect(runner).toContain(`openclaw_e2e_exec_gateway "$entry" '"$PORT"' lan`);
     expect(runner).toContain('for container_name in "$GW_NAME" "$OW_NAME"; do');
     expect(runner).toContain('"$GW_NAME" \\');
     expect(runner).toContain('"$OW_NAME" \\');
@@ -4840,6 +4843,9 @@ heartbeat_elapsed="\${BASH_REMATCH[1]}"
     );
     expect(runner).toContain('docker_e2e_docker_cmd rm -f "$CONTAINER_NAME"');
     expect(runner).not.toMatch(/(^|\n)docker run --rm/u);
+    expect(runner).toContain(
+      "lets authorized gateway-style plugin commands escape plugin-owned bindings",
+    );
     expect(runner).toContain(
       "keeps unauthorized plugin-owned binding slash replies suppressed while routed to the bound plugin",
     );

--- a/test/scripts/docker-e2e-clients.test.ts
+++ b/test/scripts/docker-e2e-clients.test.ts
@@ -13,8 +13,7 @@ describe("Docker E2E client scripts", () => {
     expect(source).toContain("../../dist/commitments/runtime.js");
     expect(source).toContain("../../dist/commitments/runtime.test-support.js");
     expect(source).toContain("../../dist/commitments/store.js");
-    expect(source).toContain("verifyQueueCap()");
-    expect(source).toContain("verifyExtractionStoresTypedMetadataOnly()");
+    expect(source).toContain("verifyExtractionRemainsRetired()");
     expect(source).toContain("verifyDoctorImportAndRuntimeIsolation()");
     expect(source).toContain("verifyExpiryTransition()");
     expect(source).toContain('[entry, "doctor", "--fix", "--yes", "--force"]');

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -3671,6 +3671,7 @@ describe("package artifact reuse", () => {
     expect(npmWorkflow).toContain("full_release_validation_run_id");
     expect(npmWorkflow).toContain("release_publish_run_id");
     expect(npmWorkflow).toContain("Real publish requires full_release_validation_run_id");
+    expect(maintainerSkill).toContain("full_release_validation_run_id=<saved-run-id>");
     expect(maintainerSkill).toContain("full_release_validation_run_attempt=<saved-attempt>");
     expect(npmWorkflow).toContain(
       "Workflow-dispatched real publish requires release_publish_run_id",

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -2508,19 +2508,24 @@ describe("package artifact reuse", () => {
     );
     expect(workflow).toContain("rerun_group:");
     expect(workflow).toContain("live_suite_filter:");
+    expect(workflow).toContain("repo_live_suite_filter:");
+    expect(workflow).toContain('repo_filter_tokens+=("$token")');
+    expect(workflow).toContain(
+      'repo_live_suite_filter="$(IFS=,; printf \'%s\' "${repo_filter_tokens[*]}")"',
+    );
     expect(workflow).toContain("cross_os_suite_filter:");
     expect(workflow).toContain("advisory: false");
     expect(workflow).toContain(
       "suite_filter: ${{ needs.resolve_target.outputs.cross_os_suite_filter }}",
     );
     expect(workflow).toContain(
-      "live_suite_filter: ${{ needs.resolve_target.outputs.live_suite_filter }}",
+      "live_suite_filter: ${{ needs.resolve_target.outputs.repo_live_suite_filter }}",
     );
     expect(workflow).toContain(
-      "contains(fromJSON('[\"all\",\"cross-os\",\"package\"]'), needs.resolve_target.outputs.rerun_group) || (needs.resolve_target.outputs.rerun_group == 'live-e2e' && needs.resolve_target.outputs.live_suite_filter == '')",
+      "contains(fromJSON('[\"all\",\"cross-os\",\"package\"]'), needs.resolve_target.outputs.rerun_group) || (needs.resolve_target.outputs.rerun_group == 'live-e2e' && needs.resolve_target.outputs.repo_live_suite_filter == '')",
     );
     expect(workflow).toContain(
-      "(needs.resolve_target.outputs.rerun_group == 'live-e2e' || (needs.resolve_target.outputs.rerun_group == 'all' && needs.resolve_target.outputs.run_release_soak == 'true')) && needs.resolve_target.outputs.live_suite_filter == ''",
+      "(needs.resolve_target.outputs.rerun_group == 'live-e2e' || (needs.resolve_target.outputs.rerun_group == 'all' && needs.resolve_target.outputs.run_release_soak == 'true')) && needs.resolve_target.outputs.repo_live_suite_filter == ''",
     );
     expect(workflow).toContain(
       'if [[ "$release_profile" == "stable" || "$release_profile" == "full" ]]; then\n            run_release_soak=true',

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -1178,8 +1178,10 @@ describe("package acceptance workflow", () => {
     expect(workflow).toContain(
       "harness_ref: ${{ needs.resolve_package.outputs.package_source_sha || inputs.workflow_ref }}",
     );
+    expect(workflow).toContain('fallback_version="$(npm view openclaw@latest version)"');
+    expect(workflow).toContain('echo "baseline=$fallback_baseline" >> "$GITHUB_OUTPUT"');
     expect(workflow).toContain(
-      "published_upgrade_survivor_baseline: ${{ inputs.published_upgrade_survivor_baseline }}",
+      "published_upgrade_survivor_baseline: ${{ needs.resolve_package.outputs.published_upgrade_survivor_baseline }}",
     );
     expect(workflow).toContain(
       "published_upgrade_survivor_baselines: ${{ needs.resolve_package.outputs.published_upgrade_survivor_baselines }}",
@@ -1806,6 +1808,7 @@ describe("package artifact reuse", () => {
       "command: OPENCLAW_LIVE_APNS_REACHABILITY=1 node .release-harness/scripts/test-live-shard.mjs native-live-src-infra",
     );
     expect(workflow).toContain("suite_id: native-live-src-gateway-profiles-anthropic-smoke");
+    expect(workflow).toContain("OPENCLAW_LIVE_GATEWAY_SETUP_TIMEOUT_MS=300000");
     expect(workflow).toContain("suite_id: native-live-src-gateway-profiles-anthropic-opus");
     expect(workflow).toContain("suite_id: native-live-src-gateway-profiles-anthropic-sonnet-haiku");
     expect(workflow).toContain("suite_group: native-live-src-gateway-profiles-anthropic");


### PR DESCRIPTION
## What Problem This Solves

Fixes a set of regressions that made Full Release Validation fail before it could measure the current product. The failures included strict config rejection in live/QA/performance fixtures, a browser CDP authority false positive, retired-contract Docker scenarios, a functional-image plugin registry side effect, device-less UI test auth, moving upgrade baselines, and an overbroad Docker permission walk.

Related validation: https://github.com/openclaw/openclaw/actions/runs/29894521567

Related Kova fix: https://github.com/openclaw/Kova/pull/76

The independent macOS Swift flake cluster was split out and landed first in https://github.com/openclaw/openclaw/pull/112651.

## Why This Change Was Made

The patch updates release-only fixtures to the canonical keyed agent and media-model config shapes, preserves the original broad-private-network decision before CDP control policy adds its synthetic exact-host allowlist, and moves Docker/package acceptance scenarios onto current product contracts instead of restoring removed runtime compatibility. It also narrows the Docker readability walk, keeps the functional test image from persisting a curated plugin registry, resolves upgrade baselines to immutable versions, and gives the stable Anthropic setup lane enough time for observed model-catalog preparation.

## User Impact

Operators using explicitly broad private-network browser policy retain working CDP discovery across the browser's advertised control port. Maintainers regain meaningful release evidence: QA, live provider, Kova, Docker, package acceptance, and plugin prerelease lanes now test the current product rather than stale fixtures or harness assumptions.

## Evidence

- Reproduced the initial failure with Full Release Validation run https://github.com/openclaw/openclaw/actions/runs/29894521567.
- Focused browser and QA tests: 88 passed.
- Docker harness tests: 176 passed.
- Upgrade-survivor assertion tests: 12 passed.
- Performance workflow tests: 30 passed.
- Focused package-acceptance workflow contract: passed.
- Full `node scripts/check-changed.mjs` equivalent on the rebased diff: passed locally after Blacksmith setup twice failed to fetch `@pnpm/exe`; included all-project typecheck, lint, format, extension boundaries, import cycles, script declarations, and repository ratchets.
- Autoreview: clean after fixing the OpenWebUI gateway argument separator finding.
- Kova CI passed on Linux and macOS before https://github.com/openclaw/Kova/pull/76 merged as `1bf080f6dbf8800a3187591493f2551824e4ccc7`.
- OCM durable upstream fix proposed at https://github.com/shakkernerd/ocm/pull/40; the landed Kova fixture canonicalizes OCM's current release output, so this does not block release validation.

AI-assisted: yes. Each failure cluster was traced from completed child-job logs to its owner path and current contract.
