### PR TITLE
feat(skills): install external skills.sh references

### DIFF
--- a/docs/clawhub/cli.md
+++ b/docs/clawhub/cli.md
@@ -22,6 +22,7 @@ Two command-line surfaces talk to ClawHub:
 openclaw skills search "calendar"
 openclaw skills install @owner/<slug>
 openclaw skills install @owner/<slug> --version <version> --global
+openclaw skills install skills-sh:<owner>/<repo>/<slug>
 openclaw skills update @owner/<slug>
 openclaw skills update --all --acknowledge-clawhub-risk
 openclaw skills verify @owner/<slug> --card
@@ -38,6 +39,12 @@ Skill installs target the active workspace `skills/` directory by default; add
 explicit `clawhub:` prefix to force ClawHub resolution over npm, git, or a
 local path. Full flag reference: [`openclaw skills`](/cli/skills) and
 [`openclaw plugins`](/cli/plugins).
+
+`skills-sh:` is an explicitly external catalog reference. OpenClaw sends it to
+ClawHub and installs the exact commit-pinned GitHub source returned by the
+resolver; it never downloads skill content from skills.sh directly. Unclaimed
+entries are labeled **Not scanned by ClawHub**. Claimed and ClawHub-scanned
+skills use the native `@owner/<slug>` form instead.
 
 ### Release trust
 

--- a/docs/cli/skills.md
+++ b/docs/cli/skills.md
@@ -27,6 +27,7 @@ openclaw skills search "calendar"
 openclaw skills search --limit 20 --json
 openclaw skills install @owner/<slug>
 openclaw skills install @owner/<slug> --version <version>
+openclaw skills install skills-sh:<owner>/<repo>/<slug>
 openclaw skills install git:owner/repo
 openclaw skills install git:owner/repo@main
 openclaw skills install ./path/to/skill --as custom-name
@@ -69,8 +70,13 @@ openclaw skills workshop quarantine <proposal-id> --reason "Needs security revie
 ```
 
 `search`, `update`, and `verify` use ClawHub directly. `install @owner/<slug>`
-installs a ClawHub skill, `install git:owner/repo[@ref]` clones a Git skill,
-and `install ./path` copies a local skill directory. By default, `install`,
+installs a native ClawHub skill. `install skills-sh:<owner>/<repo>/<slug>` asks
+ClawHub to resolve an external listing to its exact synchronized GitHub commit;
+OpenClaw does not download from skills.sh. These entries are shown as
+**Not scanned by ClawHub**, and that trust state is preserved through updates
+and verification. Claimed or ClawHub-scanned skills use `@owner/<slug>`.
+`install git:owner/repo[@ref]` clones an unmanaged Git skill, and `install
+./path` copies a local skill directory. By default, `install`,
 `update`, and `verify` target the active workspace `skills/` directory; with
 `--global`, they target the shared managed skills directory. `list`/`info`/`check`
 still inspect the local skills visible to the current workspace and config.
@@ -97,7 +103,7 @@ Notes:
 | `install git:owner/repo[@ref]`   | Installs a Git skill. Branch refs may contain slashes, such as `git:owner/repo@feature/foo`.                                                                                                                                                                                      |
 | `install ./path/to/skill`        | Installs a local directory whose root contains `SKILL.md`.                                                                                                                                                                                                                        |
 | `install --as <slug>`            | Overrides the inferred slug for Git and local directory installs.                                                                                                                                                                                                                 |
-| `install --version <version>`    | Applies only to ClawHub skill refs.                                                                                                                                                                                                                                               |
+| `install --version <version>`    | Applies to native ClawHub skill refs, not `skills-sh:` refs; the mirrored reference already identifies the exact synchronized commit.                                                                                                                                             |
 | `install --force`                | Overwrites an existing workspace skill folder for the same slug.                                                                                                                                                                                                                  |
 | `install/update --force-install` | Installs a pending GitHub-backed ClawHub skill before ClawHub's scan completes.                                                                                                                                                                                                   |
 | `--global`                       | Targets the shared managed skills directory; cannot combine with `--agent <id>`.                                                                                                                                                                                                  |

--- a/docs/tools/skills.md
+++ b/docs/tools/skills.md
@@ -164,6 +164,7 @@ publish and sync.
 | Action                             | Command                                                |
 | ---------------------------------- | ------------------------------------------------------ |
 | Install a skill into the workspace | `openclaw skills install @owner/<slug>`                |
+| Install an external skills.sh ref  | `openclaw skills install skills-sh:owner/repo/slug`    |
 | Install from a Git repository      | `openclaw skills install git:owner/repo@ref`           |
 | Install a local skill directory    | `openclaw skills install ./path/to/skill --as my-tool` |
 | Install for all local agents       | `openclaw skills install @owner/<slug> --global`       |

--- a/src/cli/skills-cli.commands.test.ts
+++ b/src/cli/skills-cli.commands.test.ts
@@ -212,6 +212,8 @@ vi.mock("../skills/lifecycle/clawhub.js", () => ({
 }));
 
 vi.mock("../infra/clawhub.js", () => ({
+  CLAWHUB_SKILLS_SH_TRUST_LABEL: "Not scanned by ClawHub",
+  CLAWHUB_SKILLS_SH_TRUST_STATE: "not-scanned-by-clawhub",
   fetchClawHubSkillVerification: (...args: unknown[]) =>
     mocks.fetchClawHubSkillVerificationMock(...args),
   fetchClawHubSkillCard: (...args: unknown[]) => mocks.fetchClawHubSkillCardMock(...args),
@@ -394,6 +396,28 @@ describe("skills cli commands", () => {
     expect(runtimeLogs).toEqual(["legacy-calendar  Legacy Calendar"]);
   });
 
+  it("shows skills.sh entries in normal ClawHub search results", async () => {
+    searchSkillsFromClawHubMock.mockResolvedValue([
+      {
+        slug: "weather",
+        installRef: "skills-sh:openclaw/skills/weather",
+        trustState: "not-scanned-by-clawhub",
+        displayName: "Weather",
+        summary: "Forecast helpers",
+      },
+    ]);
+
+    await runCommand(["skills", "search", "weather"]);
+
+    expect(searchSkillsFromClawHubMock).toHaveBeenCalledWith({
+      query: "weather",
+      limit: undefined,
+    });
+    expect(runtimeLogs).toEqual([
+      "skills-sh:openclaw/skills/weather  Weather  Forecast helpers  Not scanned by ClawHub",
+    ]);
+  });
+
   it("keeps multiline ClawHub search metadata on one terminal line", async () => {
     searchSkillsFromClawHubMock.mockResolvedValue([
       {
@@ -486,6 +510,43 @@ describe("skills cli commands", () => {
         line.includes("Installed calendar@1.2.3 -> /tmp/workspace/skills/calendar"),
       ),
     ).toBe(true);
+  });
+
+  it("routes skills-sh refs through ClawHub without translating them", async () => {
+    const reference = "skills-sh:openclaw/skills/weather";
+    installSkillFromClawHubMock.mockResolvedValue({
+      ok: true,
+      slug: "weather",
+      version: "a".repeat(40),
+      targetDir: "/tmp/workspace/skills/weather",
+    });
+
+    await runCommand(["skills", "install", reference]);
+
+    expect(mockFirstObjectArg(installSkillFromClawHubMock).slug).toBe(reference);
+    expect(installSkillFromSourceMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects --version for skills-sh refs", async () => {
+    await expect(
+      runCommand(["skills", "install", "skills-sh:openclaw/skills/weather", "--version", "1.2.3"]),
+    ).rejects.toThrow("__exit__:1");
+
+    expect(runtimeErrors).toContain("--version is not supported for skills-sh references.");
+    expect(installSkillFromClawHubMock).not.toHaveBeenCalled();
+    expect(installSkillFromSourceMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects the legacy skills-sh slash syntax before network access", async () => {
+    await expect(
+      runCommand(["skills", "install", "skills-sh/openclaw/skills/weather"]),
+    ).rejects.toThrow("__exit__:1");
+
+    expect(runtimeErrors).toContain(
+      "Invalid skills.sh skill reference: skills-sh/openclaw/skills/weather",
+    );
+    expect(installSkillFromClawHubMock).not.toHaveBeenCalled();
+    expect(installSkillFromSourceMock).not.toHaveBeenCalled();
   });
 
   it("documents owner-qualified ClawHub install refs in command help", () => {

--- a/src/cli/skills-cli.ts
+++ b/src/cli/skills-cli.ts
@@ -16,6 +16,8 @@ import {
 import { getRuntimeConfig } from "../config/config.js";
 import { CLAWHUB_TRUST_ERROR_CODE } from "../infra/clawhub-install-trust.js";
 import {
+  CLAWHUB_SKILLS_SH_TRUST_LABEL,
+  CLAWHUB_SKILLS_SH_TRUST_STATE,
   fetchClawHubSkillCard,
   fetchClawHubSkillVerification,
   type ClawHubSkillVerificationResponse,
@@ -237,7 +239,16 @@ function buildSkillVerificationOutput(
         selector: target.resolution.selector,
         registry: target.resolution.registry,
         installedVersion: target.resolution.installedVersion,
+        ...(target.requestedReference ? { reference: target.requestedReference } : {}),
       },
+      ...(target.trustState
+        ? {
+            trust: {
+              state: target.trustState,
+              label: CLAWHUB_SKILLS_SH_TRUST_LABEL,
+            },
+          }
+        : {}),
       ...(verifiedSourceUrl ? { verifiedSourceUrl } : {}),
     },
   };
@@ -435,13 +446,24 @@ export function registerSkillsCli(program: Command) {
           return;
         }
         for (const entry of results) {
+          const installRef = normalizeOptionalString(entry.installRef);
           const ownerHandle = normalizeOptionalString(entry.ownerHandle);
           const slug = formatClawHubSearchText(entry.slug);
-          const skillRef = ownerHandle ? `@${formatClawHubSearchText(ownerHandle)}/${slug}` : slug;
+          const skillsShInstallRef =
+            installRef?.startsWith("skills-sh:") &&
+            entry.trustState === CLAWHUB_SKILLS_SH_TRUST_STATE
+              ? installRef
+              : undefined;
+          const skillRef = skillsShInstallRef
+            ? formatClawHubSearchText(skillsShInstallRef)
+            : ownerHandle
+              ? `@${formatClawHubSearchText(ownerHandle)}/${slug}`
+              : slug;
           const version = entry.version ? ` v${formatClawHubSearchText(entry.version)}` : "";
           const summary = entry.summary ? `  ${formatClawHubSearchText(entry.summary)}` : "";
           const displayName = formatClawHubSearchText(entry.displayName);
-          defaultRuntime.log(`${skillRef}${version}  ${displayName}${summary}`);
+          const trust = skillsShInstallRef ? `  ${CLAWHUB_SKILLS_SH_TRUST_LABEL}` : "";
+          defaultRuntime.log(`${skillRef}${version}  ${displayName}${summary}${trust}`);
         }
       } catch (err) {
         defaultRuntime.error(String(err));
@@ -454,7 +476,7 @@ export function registerSkillsCli(program: Command) {
     .description("Install a skill from ClawHub, git, or a local directory")
     .argument(
       "<skill-ref>",
-      "ClawHub skill ref (@owner/slug), git:<repo>, or local skill directory",
+      "ClawHub skill ref (@owner/slug or skills-sh:owner/repo/slug), git:<repo>, or local skill directory",
     )
     .option("--version <version>", "Install a specific version")
     .option("--force", "Overwrite an existing workspace skill", false)
@@ -471,7 +493,10 @@ export function registerSkillsCli(program: Command) {
     .option("--global", "Install into the shared managed skills directory", false)
     .option("--agent <id>", "Target agent workspace (defaults to cwd-inferred, then default agent)")
     .option("--as <slug>", "Install a git/local skill under this slug")
-    .addHelpText("after", "\nExamples:\n  openclaw skills install @owner/weather\n")
+    .addHelpText(
+      "after",
+      "\nExamples:\n  openclaw skills install @owner/weather\n  openclaw skills install skills-sh:owner/repo/weather\n",
+    )
     .action(
       async (
         slug: string,
@@ -490,6 +515,11 @@ export function registerSkillsCli(program: Command) {
         try {
           const workspaceDir = resolveClawHubTargetWorkspaceDir(command, opts);
           if (!workspaceDir) {
+            return;
+          }
+          if (slug.trim().startsWith("skills-sh/")) {
+            defaultRuntime.error(`Invalid skills.sh skill reference: ${slug}`);
+            defaultRuntime.exit(1);
             return;
           }
           if (isSkillSourceInstallSpec(slug)) {
@@ -522,6 +552,11 @@ export function registerSkillsCli(program: Command) {
             defaultRuntime.error(
               "--as is only supported for git and local directory skill installs.",
             );
+            defaultRuntime.exit(1);
+            return;
+          }
+          if (slug.trim().startsWith("skills-sh:") && opts.version) {
+            defaultRuntime.error("--version is not supported for skills-sh references.");
             defaultRuntime.exit(1);
             return;
           }
@@ -685,6 +720,9 @@ export function registerSkillsCli(program: Command) {
             const verification = await fetchClawHubSkillVerification({
               slug: target.slug,
               ...(target.ownerHandle ? { ownerHandle: target.ownerHandle } : {}),
+              ...(target.requestedReference
+                ? { requestedReference: target.requestedReference }
+                : {}),
               version: target.version,
               tag: target.tag,
               baseUrl: target.baseUrl,

--- a/src/cli/skills-cli.verify.test.ts
+++ b/src/cli/skills-cli.verify.test.ts
@@ -66,6 +66,8 @@ vi.mock("../agents/agent-scope.js", () => ({
 }));
 
 vi.mock("../infra/clawhub.js", () => ({
+  CLAWHUB_SKILLS_SH_TRUST_LABEL: "Not scanned by ClawHub",
+  CLAWHUB_SKILLS_SH_TRUST_STATE: "not-scanned-by-clawhub",
   downloadClawHubSkillArchive: mocks.noopAsync,
   fetchClawHubSkillCard: (...args: unknown[]) => mocks.fetchClawHubSkillCardMock(...args),
   fetchClawHubSkillDetail: mocks.noopAsync,
@@ -155,6 +157,125 @@ describe("skills verify CLI", () => {
       "utf8",
     );
   }
+
+  async function writeInstalledSkillsShSkill(
+    requestedReference = "skills-sh:patrick-erichsen/skills/html",
+  ) {
+    const trustState = "not-scanned-by-clawhub";
+    const installedVersion = "a".repeat(40);
+    const skillDir = path.join(workspaceDir, "skills", "html");
+    await fs.mkdir(path.join(skillDir, ".clawhub"), { recursive: true });
+    await fs.writeFile(path.join(skillDir, "SKILL.md"), "# HTML\n", "utf8");
+    await fs.writeFile(
+      path.join(skillDir, ".clawhub", "origin.json"),
+      `${JSON.stringify(
+        {
+          version: 1,
+          registry: "https://private.example.com/clawhub",
+          slug: "html",
+          requestedReference,
+          trustState,
+          installedVersion,
+          installedAt: 123,
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+    await fs.mkdir(path.join(workspaceDir, ".clawhub"), { recursive: true });
+    await fs.writeFile(
+      path.join(workspaceDir, ".clawhub", "lock.json"),
+      `${JSON.stringify(
+        {
+          version: 1,
+          skills: {
+            html: {
+              version: installedVersion,
+              installedAt: 123,
+              registry: "https://private.example.com/clawhub",
+              requestedReference,
+              trustState,
+            },
+          },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+    return { requestedReference, trustState };
+  }
+
+  function mockUnscannedSkillsShVerification() {
+    mocks.fetchClawHubSkillVerificationMock.mockResolvedValueOnce({
+      schema: "clawhub.skill.verify.v1",
+      ok: true,
+      decision: "unscanned",
+      reasons: ["security.not_scanned_by_clawhub"],
+      skill: { slug: "html" },
+      publisher: { handle: "patrick-erichsen" },
+      version: { version: "a".repeat(40) },
+      card: { available: true },
+      artifact: { sourceFingerprint: "source-fp" },
+      provenance: null,
+      security: { status: "not-scanned", passed: false },
+      signature: { status: "unsigned" },
+    });
+  }
+
+  it("verifies an installed skills.sh skill by its exact reference without a version selector", async () => {
+    const { requestedReference, trustState } = await writeInstalledSkillsShSkill();
+    mockUnscannedSkillsShVerification();
+
+    await expect(runCommand(["skills", "verify", requestedReference])).rejects.toThrow(
+      "__exit__:1",
+    );
+
+    expect(mocks.fetchClawHubSkillVerificationMock).toHaveBeenCalledWith({
+      slug: "html",
+      requestedReference,
+      version: undefined,
+      tag: undefined,
+      baseUrl: "https://private.example.com/clawhub",
+    });
+    const payload = JSON.parse(mocks.runtimeStdout.at(-1) ?? "{}") as {
+      openclaw?: { trust?: { state?: string; label?: string } };
+    };
+    expect(payload.openclaw?.trust).toEqual({
+      state: trustState,
+      label: "Not scanned by ClawHub",
+    });
+  });
+
+  it("rejects a different installed skills.sh reference before network verification", async () => {
+    await writeInstalledSkillsShSkill("skills-sh:owner-a/repo-a/html");
+
+    await expect(runCommand(["skills", "verify", "skills-sh:owner-b/repo-b/html"])).rejects.toThrow(
+      "__exit__:1",
+    );
+
+    expect(mocks.runtimeErrors).toContain(
+      'Skill "html" is not tracked from skills-sh:owner-b/repo-b/html.',
+    );
+    expect(mocks.fetchClawHubSkillVerificationMock).not.toHaveBeenCalled();
+  });
+
+  it("verifies an installed skills.sh skill by slug without a version selector", async () => {
+    const { requestedReference } = await writeInstalledSkillsShSkill();
+    mockUnscannedSkillsShVerification();
+
+    await expect(runCommand(["skills", "verify", "html"])).rejects.toThrow("__exit__:1");
+
+    expect(mocks.fetchClawHubSkillVerificationMock).toHaveBeenCalledWith({
+      slug: "html",
+      requestedReference,
+      version: undefined,
+      tag: undefined,
+      baseUrl: "https://private.example.com/clawhub",
+    });
+    expect(mocks.defaultRuntime.exit).toHaveBeenCalledWith(1);
+  });
 
   it("does not reject an installed bundle just because ClawHub generated skill-card.md", async () => {
     await writeInstalledGeneratedCardSkill();

--- a/src/infra/clawhub.test.ts
+++ b/src/infra/clawhub.test.ts
@@ -471,6 +471,31 @@ describe("clawhub helpers", () => {
     expect(fetchImpl).not.toHaveBeenCalled();
   });
 
+  it("preserves skills-sh references in install telemetry", async () => {
+    let body: unknown;
+
+    await reportClawHubSkillInstallTelemetry({
+      token: "token-123",
+      slug: "weather",
+      version: "a".repeat(40),
+      requestedReference: "skills-sh:openclaw/skills/weather",
+      trustState: "not-scanned-by-clawhub",
+      fetchImpl: async (_input, init) => {
+        expect(typeof init?.body).toBe("string");
+        body = JSON.parse(init?.body as string);
+        return new Response(null, { status: 200 });
+      },
+    });
+
+    expect(body).toMatchObject({
+      event: "install",
+      slug: "weather",
+      version: "a".repeat(40),
+      reference: "skills-sh:openclaw/skills/weather",
+      trustState: "not-scanned-by-clawhub",
+    });
+  });
+
   it("preserves the configured ClawHub base URL path prefix", async () => {
     process.env.OPENCLAW_CLAWHUB_URL = "https://internal.example.com/clawhub";
     let requestedUrl = "";
@@ -579,6 +604,39 @@ describe("clawhub helpers", () => {
     const url = new URL(requestedUrl);
     expect(url.pathname).toBe("/api/v1/skills/weather/install");
     expect(url.searchParams.get("ownerHandle")).toBe("demo-owner");
+  });
+
+  it("sends skills-sh references to the ClawHub install resolver", async () => {
+    let requestedUrl = "";
+    const reference = "skills-sh:openclaw/skills/weather";
+
+    await fetchClawHubSkillInstallResolution({
+      slug: "weather",
+      requestedReference: reference,
+      fetchImpl: async (input) => {
+        requestedUrl = input instanceof Request ? input.url : String(input);
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            slug: "weather",
+            installKind: "github",
+            trust: { state: "not-scanned-by-clawhub" },
+            github: {
+              repo: "openclaw/skills",
+              path: "skills/weather",
+              commit: "a".repeat(40),
+              contentHash: "sha256:approved",
+              sourceUrl: "https://github.com/openclaw/skills",
+            },
+          }),
+          { headers: { "content-type": "application/json" } },
+        );
+      },
+    });
+
+    const url = new URL(requestedUrl);
+    expect(url.pathname).toBe("/api/v1/skills/weather/install");
+    expect(url.searchParams.get("reference")).toBe(reference);
   });
 
   it("fetches skill verification reports and lets version take precedence over tag", async () => {

--- a/src/infra/clawhub.ts
+++ b/src/infra/clawhub.ts
@@ -267,9 +267,15 @@ export type ClawHubPackageSearchResult = {
   package: ClawHubPackageListItem;
 };
 
+export const CLAWHUB_SKILLS_SH_TRUST_STATE = "not-scanned-by-clawhub" as const;
+export const CLAWHUB_SKILLS_SH_TRUST_LABEL = "Not scanned by ClawHub" as const;
+export type ClawHubSkillsShTrustState = typeof CLAWHUB_SKILLS_SH_TRUST_STATE;
+
 export type ClawHubSkillSearchResult = {
   score: number;
   slug: string;
+  installRef?: string;
+  trustState?: ClawHubSkillsShTrustState;
   // Search may return the same slug for multiple publishers; exact install refs need this handle.
   ownerHandle?: string | null;
   displayName: string;
@@ -328,6 +334,9 @@ export type ClawHubSkillInstallResolutionResponse =
       channel?: string | null;
       isOfficial?: boolean | null;
       installKind: "github";
+      trust?: {
+        state: ClawHubSkillsShTrustState;
+      };
       /** Commit-pinned source approved by ClawHub's install resolver policy. */
       github: {
         repo: string;
@@ -1234,6 +1243,7 @@ export async function fetchClawHubSkillDetail(params: {
 export async function fetchClawHubSkillInstallResolution(params: {
   slug: string;
   ownerHandle?: string;
+  requestedReference?: string;
   baseUrl?: string;
   token?: string;
   timeoutMs?: number;
@@ -1248,6 +1258,7 @@ export async function fetchClawHubSkillInstallResolution(params: {
     fetchImpl: params.fetchImpl,
     search: {
       ownerHandle: params.ownerHandle,
+      reference: params.requestedReference,
       forceInstall: params.forceInstall ? "1" : undefined,
     },
   });
@@ -1265,6 +1276,7 @@ export async function fetchClawHubSkillInstallResolution(params: {
 export async function fetchClawHubSkillVerification(params: {
   slug: string;
   ownerHandle?: string;
+  requestedReference?: string;
   version?: string;
   tag?: string;
   baseUrl?: string;
@@ -1278,7 +1290,10 @@ export async function fetchClawHubSkillVerification(params: {
     token: params.token,
     timeoutMs: params.timeoutMs,
     fetchImpl: params.fetchImpl,
-    search: buildVersionOrTagSearch(params),
+    search: {
+      ...buildVersionOrTagSearch(params),
+      reference: params.requestedReference,
+    },
   });
 }
 
@@ -1599,6 +1614,8 @@ export async function reportClawHubSkillInstallTelemetry(params: {
   token?: string;
   slug: string;
   ownerHandle?: string;
+  requestedReference?: string;
+  trustState?: ClawHubSkillsShTrustState;
   version?: string | null;
   timeoutMs?: number;
   fetchImpl?: FetchLike;
@@ -1623,6 +1640,8 @@ export async function reportClawHubSkillInstallTelemetry(params: {
       event: "install",
       slug,
       ...(params.ownerHandle ? { ownerHandle: params.ownerHandle } : {}),
+      ...(params.requestedReference ? { reference: params.requestedReference } : {}),
+      ...(params.trustState ? { trustState: params.trustState } : {}),
       version: params.version ?? undefined,
     },
   });

--- a/src/skills/lifecycle/clawhub.test.ts
+++ b/src/skills/lifecycle/clawhub.test.ts
@@ -129,6 +129,8 @@ async function writeClawHubOriginFixture(params: {
   slug: string;
   originSlug?: string;
   ownerHandle?: string;
+  requestedReference?: string;
+  trustState?: string;
   registry?: string;
   installedVersion?: string;
   installedAt?: number;
@@ -147,6 +149,8 @@ async function writeClawHubOriginFixture(params: {
         registry,
         slug: params.originSlug ?? params.slug,
         ...(params.ownerHandle ? { ownerHandle: params.ownerHandle } : {}),
+        ...(params.requestedReference ? { requestedReference: params.requestedReference } : {}),
+        ...(params.trustState ? { trustState: params.trustState } : {}),
         installedVersion,
         installedAt,
       },
@@ -168,6 +172,10 @@ async function writeClawHubOriginFixture(params: {
               installedAt,
               registry,
               ...(params.ownerHandle ? { ownerHandle: params.ownerHandle } : {}),
+              ...(params.requestedReference
+                ? { requestedReference: params.requestedReference }
+                : {}),
+              ...(params.trustState ? { trustState: params.trustState } : {}),
             },
           },
         },
@@ -330,6 +338,196 @@ describe("skills-clawhub", () => {
       version: "1.0.0",
     });
   });
+
+  it("installs skills-sh references via a ClawHub-approved pinned GitHub commit", async () => {
+    const commit = "a".repeat(40);
+    const reference = "skills-sh:openclaw/skills/weather";
+    const trustState = "not-scanned-by-clawhub";
+    fetchClawHubSkillInstallResolutionMock.mockResolvedValueOnce({
+      ok: true,
+      slug: "weather",
+      installKind: "github",
+      trust: { state: trustState },
+      github: {
+        repo: "openclaw/skills",
+        path: "skills/weather",
+        commit,
+        trustState,
+        contentHash: "sha256:approved",
+        sourceUrl: `https://github.com/openclaw/skills/tree/${commit}/skills/weather`,
+      },
+    });
+    withExtractedArchiveRootMock.mockImplementationOnce(async (params) => {
+      expect(params.rootMarkers).toBeUndefined();
+      return await params.onExtracted("/tmp/extracted-github-repo");
+    });
+    installPackageDirMock.mockResolvedValueOnce({
+      ok: true,
+      targetDir: "/tmp/workspace/skills/weather",
+    });
+
+    const result = await installSkillFromClawHub({
+      workspaceDir: "/tmp/workspace",
+      slug: reference,
+    });
+
+    expect(fetchClawHubSkillInstallResolutionMock).toHaveBeenCalledWith({
+      slug: "weather",
+      baseUrl: undefined,
+      requestedReference: reference,
+    });
+    expect(downloadClawHubGitHubSkillArchiveMock).toHaveBeenCalledWith({
+      repo: "openclaw/skills",
+      commit,
+    });
+    expect(fetchClawHubSkillVerificationMock).toHaveBeenCalledWith({
+      slug: "weather",
+      requestedReference: reference,
+      version: undefined,
+      baseUrl: undefined,
+    });
+    expect(installPolicyInput()).toMatchObject({
+      requestedSpecifier: reference,
+      origin: {
+        slug: "weather",
+        version: commit,
+        repo: "openclaw/skills",
+        path: "skills/weather",
+        commit,
+      },
+    });
+    expectInstalledSkill(result, {
+      slug: "weather",
+      version: commit,
+      targetDir: "/tmp/workspace/skills/weather",
+    });
+    expect(result.warning).toBe("Not scanned by ClawHub");
+    expect(reportClawHubSkillInstallTelemetryMock).toHaveBeenCalledWith({
+      baseUrl: undefined,
+      slug: "weather",
+      version: commit,
+      requestedReference: reference,
+      trustState,
+    });
+  });
+
+  it("rejects a mutable GitHub ref for a skills-sh resolution before downloading", async () => {
+    fetchClawHubSkillInstallResolutionMock.mockResolvedValueOnce({
+      ok: true,
+      slug: "weather",
+      installKind: "github",
+      trust: { state: "not-scanned-by-clawhub" },
+      github: {
+        repo: "openclaw/skills",
+        path: "skills/weather",
+        commit: "main",
+        contentHash: "sha256:approved",
+        sourceUrl: "https://github.com/openclaw/skills/tree/main/skills/weather",
+      },
+    });
+
+    const result = await installSkillFromClawHub({
+      workspaceDir: "/tmp/workspace",
+      slug: "skills-sh:openclaw/skills/weather",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.ok ? "" : result.error).toContain("expected a full 40-character commit SHA");
+    expect(downloadClawHubGitHubSkillArchiveMock).not.toHaveBeenCalled();
+    expect(withExtractedArchiveRootMock).not.toHaveBeenCalled();
+    expect(installPackageDirMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    "skills-sh:",
+    "skills-sh/owner/repo/slug",
+    "skills-sh:owner/repo",
+    "skills-sh:owner/repo/slug/extra",
+    "skills-sh:-owner/repo/slug",
+    "skills-sh:owner/../slug",
+  ])("rejects invalid skills-sh reference %s before network access", async (reference) => {
+    const result = await installSkillFromClawHub({
+      workspaceDir: "/tmp/workspace",
+      slug: reference,
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: expect.stringContaining("Invalid skills.sh skill reference"),
+    });
+    expect(fetchClawHubSkillInstallResolutionMock).not.toHaveBeenCalled();
+    expect(downloadClawHubGitHubSkillArchiveMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects versions for skills-sh references before network access", async () => {
+    const result = await installSkillFromClawHub({
+      workspaceDir: "/tmp/workspace",
+      slug: "skills-sh:openclaw/skills/weather",
+      version: "1.2.3",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: "--version is not supported for skills-sh references.",
+    });
+    expect(fetchClawHubSkillInstallResolutionMock).not.toHaveBeenCalled();
+    expect(downloadClawHubSkillArchiveMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-GitHub resolutions for skills-sh references", async () => {
+    fetchClawHubSkillInstallResolutionMock.mockResolvedValueOnce({
+      ok: true,
+      slug: "weather",
+      installKind: "archive",
+      trust: { state: "not-scanned-by-clawhub" },
+      archive: {
+        version: "1.0.0",
+        downloadUrl: "https://clawhub.ai/api/v1/download?slug=weather&version=1.0.0",
+      },
+    });
+
+    const result = await installSkillFromClawHub({
+      workspaceDir: "/tmp/workspace",
+      slug: "skills-sh:openclaw/skills/weather",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: 'Skill "weather" did not resolve to an unscanned, commit-pinned GitHub source.',
+    });
+    expect(downloadClawHubSkillArchiveMock).not.toHaveBeenCalled();
+    expect(downloadClawHubGitHubSkillArchiveMock).not.toHaveBeenCalled();
+  });
+
+  it.each([undefined, { state: "scanned-by-clawhub" }])(
+    "rejects skills-sh resolutions without the external unscanned trust state",
+    async (trust) => {
+      fetchClawHubSkillInstallResolutionMock.mockResolvedValueOnce({
+        ok: true,
+        slug: "weather",
+        installKind: "github",
+        ...(trust ? { trust } : {}),
+        github: {
+          repo: "openclaw/skills",
+          path: "skills/weather",
+          commit: "a".repeat(40),
+          contentHash: "sha256:approved",
+          sourceUrl: "https://github.com/openclaw/skills",
+        },
+      });
+
+      const result = await installSkillFromClawHub({
+        workspaceDir: "/tmp/workspace",
+        slug: "skills-sh:openclaw/skills/weather",
+      });
+
+      expect(result).toEqual({
+        ok: false,
+        error: 'Skill "weather" did not resolve to an unscanned, commit-pinned GitHub source.',
+      });
+      expect(downloadClawHubGitHubSkillArchiveMock).not.toHaveBeenCalled();
+    },
+  );
 
   it("resolves an exact skill artifact without mutating the workspace", async () => {
     const integrity = `sha256-${Buffer.from("a".repeat(64), "hex").toString("base64")}`;
@@ -1598,24 +1796,32 @@ describe("skills-clawhub", () => {
     },
   );
 
-  it("updates owner-qualified ClawHub skills with the stored owner namespace", async () => {
+  it("updates skills.sh installs with the stored reference", async () => {
     const workspaceDir = await tempDirs.make("openclaw-owner-update-");
+    const commit = "b".repeat(40);
     await writeClawHubOriginFixture({
       workspaceDir,
       slug: "weather",
-      ownerHandle: "demo-owner",
+      requestedReference: "skills-sh:openclaw/skills/weather",
+      trustState: "not-scanned-by-clawhub",
       registry: "https://private.example.com/clawhub",
       installedVersion: "0.9.0",
     });
     fetchClawHubSkillInstallResolutionMock.mockResolvedValueOnce({
       ok: true,
       slug: "weather",
-      installKind: "archive",
-      archive: {
-        version: "1.0.0",
-        downloadUrl:
-          "https://private.example.com/clawhub/api/v1/download?slug=weather&ownerHandle=demo-owner&version=1.0.0",
+      installKind: "github",
+      trust: { state: "not-scanned-by-clawhub" },
+      github: {
+        repo: "openclaw/skills",
+        path: "skills/weather",
+        commit,
+        contentHash: "sha256:approved",
+        sourceUrl: `https://github.com/openclaw/skills/tree/${commit}/skills/weather`,
       },
+    });
+    withExtractedArchiveRootMock.mockImplementationOnce(async (params) => {
+      return await params.onExtracted("/tmp/extracted-github-repo");
     });
     installPackageDirMock.mockImplementationOnce(async (params: { targetDir: string }) => {
       await fs.mkdir(params.targetDir, { recursive: true });
@@ -1625,18 +1831,18 @@ describe("skills-clawhub", () => {
 
     const results = await updateSkillsFromClawHub({
       workspaceDir,
-      slug: "weather",
+      slug: "skills-sh:openclaw/skills/weather",
     });
 
     expect(fetchClawHubSkillInstallResolutionMock).toHaveBeenCalledWith({
       slug: "weather",
-      ownerHandle: "demo-owner",
+      requestedReference: "skills-sh:openclaw/skills/weather",
       baseUrl: "https://private.example.com/clawhub",
     });
     expect(fetchClawHubSkillVerificationMock).toHaveBeenCalledWith({
       slug: "weather",
-      ownerHandle: "demo-owner",
-      version: "1.0.0",
+      requestedReference: "skills-sh:openclaw/skills/weather",
+      version: undefined,
       baseUrl: "https://private.example.com/clawhub",
     });
     expect(results).toEqual([
@@ -1644,15 +1850,19 @@ describe("skills-clawhub", () => {
         ok: true,
         slug: "weather",
         previousVersion: "0.9.0",
-        version: "1.0.0",
+        version: commit,
         changed: true,
         targetDir: path.join(workspaceDir, "skills", "weather"),
+        warning: "Not scanned by ClawHub",
       },
     ]);
     const lock = JSON.parse(
       await fs.readFile(path.join(workspaceDir, ".clawhub", "lock.json"), "utf8"),
     ) as { skills: Record<string, Record<string, unknown>> };
-    expect(lock.skills.weather?.ownerHandle).toBe("demo-owner");
+    expect(lock.skills.weather).toMatchObject({
+      requestedReference: "skills-sh:openclaw/skills/weather",
+      trustState: "not-scanned-by-clawhub",
+    });
   });
 
   it("updates official publisher ClawHub skills without fetching security verdicts", async () => {
@@ -2119,12 +2329,14 @@ describe("skills-clawhub", () => {
   });
 
   describe("verification target resolution", () => {
-    it("uses installed origin registry and installed version by default", async () => {
+    it("preserves installed skills.sh references for verification", async () => {
       const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-skill-verify-"));
       try {
         const skillDir = await writeClawHubOriginFixture({
           workspaceDir,
           slug: "agentreceipt",
+          requestedReference: "skills-sh:openclaw/skills/agentreceipt",
+          trustState: "not-scanned-by-clawhub",
           registry: "https://private.example.com/clawhub/",
           installedVersion: "2.0.0",
         });
@@ -2132,13 +2344,15 @@ describe("skills-clawhub", () => {
         await expect(
           resolveClawHubSkillVerificationTarget({
             workspaceDir,
-            slug: "agentreceipt",
+            slug: "skills-sh:openclaw/skills/agentreceipt",
           }),
         ).resolves.toEqual({
           ok: true,
           slug: "agentreceipt",
+          requestedReference: "skills-sh:openclaw/skills/agentreceipt",
+          trustState: "not-scanned-by-clawhub",
           baseUrl: "https://private.example.com/clawhub",
-          version: "2.0.0",
+          version: undefined,
           tag: undefined,
           resolution: {
             source: "installed",
@@ -2152,6 +2366,77 @@ describe("skills-clawhub", () => {
         await fs.rm(workspaceDir, { recursive: true, force: true });
       }
     });
+
+    it("rejects a different installed skills.sh reference before verification", async () => {
+      const workspaceDir = await tempDirs.make("openclaw-skill-verify-");
+      await writeClawHubOriginFixture({
+        workspaceDir,
+        slug: "agentreceipt",
+        requestedReference: "skills-sh:owner-a/repo-a/agentreceipt",
+        trustState: "not-scanned-by-clawhub",
+        installedVersion: "a".repeat(40),
+      });
+
+      await expect(
+        resolveClawHubSkillVerificationTarget({
+          workspaceDir,
+          slug: "skills-sh:owner-b/repo-b/agentreceipt",
+        }),
+      ).resolves.toEqual({
+        ok: false,
+        error: 'Skill "agentreceipt" is not tracked from skills-sh:owner-b/repo-b/agentreceipt.',
+      });
+      expect(fetchClawHubSkillVerificationMock).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      { version: "2.0.0", tag: undefined },
+      { version: undefined, tag: "latest" },
+    ])(
+      "rejects selectors for exact skills.sh verification references",
+      async ({ version, tag }) => {
+        await expect(
+          resolveClawHubSkillVerificationTarget({
+            workspaceDir: "/tmp/workspace",
+            slug: "skills-sh:openclaw/skills/agentreceipt",
+            version,
+            tag,
+          }),
+        ).resolves.toEqual({
+          ok: false,
+          error: "--version and --tag are not supported for skills-sh references.",
+        });
+      },
+    );
+
+    it.each([
+      { version: "2.0.0", tag: undefined },
+      { version: undefined, tag: "latest" },
+    ])(
+      "rejects selectors when an installed skill is tracked from skills.sh",
+      async ({ version, tag }) => {
+        const workspaceDir = await tempDirs.make("openclaw-skill-verify-");
+        await writeClawHubOriginFixture({
+          workspaceDir,
+          slug: "agentreceipt",
+          requestedReference: "skills-sh:openclaw/skills/agentreceipt",
+          trustState: "not-scanned-by-clawhub",
+          installedVersion: "a".repeat(40),
+        });
+
+        await expect(
+          resolveClawHubSkillVerificationTarget({
+            workspaceDir,
+            slug: "agentreceipt",
+            version,
+            tag,
+          }),
+        ).resolves.toEqual({
+          ok: false,
+          error: "--version and --tag are not supported for skills-sh references.",
+        });
+      },
+    );
 
     it("uses installed owner namespace when resolving owner-qualified verification targets", async () => {
       const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-skill-verify-"));

--- a/src/skills/lifecycle/clawhub.ts
+++ b/src/skills/lifecycle/clawhub.ts
@@ -9,6 +9,8 @@ import {
   type ClawHubRiskAcknowledgementRequest,
 } from "../../infra/clawhub-install-trust.js";
 import {
+  CLAWHUB_SKILLS_SH_TRUST_LABEL,
+  CLAWHUB_SKILLS_SH_TRUST_STATE,
   downloadClawHubGitHubSkillArchive,
   downloadClawHubSkillArchive,
   downloadClawHubSkillArchiveUrl,
@@ -25,6 +27,7 @@ import {
   type ClawHubSkillInstallResolutionResponse,
   type ClawHubSkillSearchResult,
   type ClawHubSkillVerificationResponse,
+  type ClawHubSkillsShTrustState,
 } from "../../infra/clawhub.js";
 import { sha256Hex } from "../../infra/crypto-digest.js";
 import { formatErrorMessage } from "../../infra/errors.js";
@@ -76,6 +79,8 @@ type ClawHubSkillLockEntry = {
   installedAt: number;
   registry?: string;
   ownerHandle?: string;
+  requestedReference?: string;
+  trustState?: ClawHubSkillsShTrustState;
   sourceUrl?: string;
   artifact?: ClawHubSkillDownloadedArtifactLock;
   skillFile?: ClawHubSkillFileLock;
@@ -88,6 +93,8 @@ type ClawHubSkillOrigin = {
   registry: string;
   slug: string;
   ownerHandle?: string;
+  requestedReference?: string;
+  trustState?: ClawHubSkillsShTrustState;
   installedVersion: string;
   installedAt: number;
   sourceUrl?: string;
@@ -113,6 +120,8 @@ export type ClawHubSkillStatusLink =
       registry: string;
       slug: string;
       ownerHandle?: string;
+      requestedReference?: string;
+      trustState?: ClawHubSkillsShTrustState;
       installedVersion: string;
       installedAt: number;
       originPath: string;
@@ -176,9 +185,13 @@ type Logger = {
 type ClawHubSkillRef = {
   slug: string;
   ownerHandle?: string;
+  requestedReference?: string;
+  trustState?: ClawHubSkillsShTrustState;
 };
 
 const CLAWHUB_OWNER_HANDLE_PATTERN = /^[a-z0-9](?:[a-z0-9._-]{0,38}[a-z0-9])?$/;
+const GITHUB_OWNER_PATTERN = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/;
+const GITHUB_REPO_PATTERN = /^[A-Za-z0-9._-]{1,100}$/;
 
 function normalizeClawHubOwnerHandle(raw: string): string {
   const ownerHandle = raw.trim().toLowerCase();
@@ -190,6 +203,32 @@ function normalizeClawHubOwnerHandle(raw: string): string {
 
 function parseRequestedClawHubSkillRef(raw: string): ClawHubSkillRef {
   const value = raw.trim();
+  if (value.startsWith("skills-sh/")) {
+    throw new Error(`Invalid skills.sh skill reference: ${raw}`);
+  }
+  if (value.startsWith("skills-sh:")) {
+    const parts = value.slice("skills-sh:".length).split("/");
+    if (parts.length !== 3) {
+      throw new Error(`Invalid skills.sh skill reference: ${raw}`);
+    }
+    const [owner, repo, slug] = parts;
+    if (
+      !owner ||
+      !repo ||
+      !slug ||
+      !GITHUB_OWNER_PATTERN.test(owner) ||
+      !GITHUB_REPO_PATTERN.test(repo) ||
+      repo === "." ||
+      repo === ".."
+    ) {
+      throw new Error(`Invalid skills.sh skill reference: ${raw}`);
+    }
+    return {
+      slug: validateRequestedSkillSlug(slug),
+      requestedReference: value,
+      trustState: CLAWHUB_SKILLS_SH_TRUST_STATE,
+    };
+  }
   if (!value.startsWith("@")) {
     return { slug: validateRequestedSkillSlug(value) };
   }
@@ -217,9 +256,10 @@ async function resolveRequestedUpdateSlug(params: {
   lock: ClawHubSkillsLockfile;
 }): Promise<string> {
   const requested = params.requestedSlug.trim();
-  const requestedRef = requested.startsWith("@")
-    ? parseRequestedClawHubSkillRef(requested)
-    : { slug: normalizeTrackedSkillSlug(requested) };
+  const requestedRef =
+    requested.startsWith("@") || requested.startsWith("skills-sh:")
+      ? parseRequestedClawHubSkillRef(requested)
+      : { slug: normalizeTrackedSkillSlug(requested) };
   const trackedSlug = requestedRef.slug;
   const trackedTargetDir = resolveWorkspaceSkillInstallDir(params.workspaceDir, trackedSlug);
   const trackedOrigin = await readClawHubSkillOrigin(trackedTargetDir);
@@ -232,6 +272,16 @@ async function resolveRequestedUpdateSlug(params: {
         `Skill "${trackedSlug}" is tracked as ${trackedRef}, not @${requestedRef.ownerHandle}/${trackedSlug}.`,
       );
     }
+    const trackedRequestedReference =
+      trackedOrigin?.requestedReference ?? trackedLockEntry?.requestedReference;
+    if (
+      requestedRef.requestedReference &&
+      trackedRequestedReference !== requestedRef.requestedReference
+    ) {
+      throw new Error(
+        `Skill "${trackedSlug}" is not tracked from ${requestedRef.requestedReference}.`,
+      );
+    }
     return trackedSlug;
   }
   return validateRequestedSkillSlug(requestedRef.slug);
@@ -241,6 +291,8 @@ type ClawHubInstallParams = {
   workspaceDir: string;
   slug: string;
   ownerHandle?: string;
+  requestedReference?: string;
+  trustState?: ClawHubSkillsShTrustState;
   version?: string;
   expectedIntegrity?: string;
   baseUrl?: string;
@@ -337,6 +389,8 @@ type TrackedUpdateTarget =
       ok: true;
       slug: string;
       ownerHandle?: string;
+      requestedReference?: string;
+      trustState?: ClawHubSkillsShTrustState;
       baseUrl?: string;
       previousVersion: string | null;
     }
@@ -354,6 +408,8 @@ type ClawHubSkillVerificationTargetResult =
       ok: true;
       slug: string;
       ownerHandle?: string;
+      requestedReference?: string;
+      trustState?: ClawHubSkillsShTrustState;
       baseUrl: string;
       version: string | undefined;
       tag: string | undefined;
@@ -524,6 +580,7 @@ function snapshotClawHubSkillVerification(
 async function fetchInstallVerificationLock(params: {
   slug: string;
   ownerHandle?: string;
+  requestedReference?: string;
   version?: string;
   baseUrl?: string;
   logger?: Logger;
@@ -532,6 +589,7 @@ async function fetchInstallVerificationLock(params: {
     const verification = await fetchClawHubSkillVerification({
       slug: params.slug,
       ...(params.ownerHandle ? { ownerHandle: params.ownerHandle } : {}),
+      ...(params.requestedReference ? { requestedReference: params.requestedReference } : {}),
       version: params.version,
       baseUrl: params.baseUrl,
     });
@@ -669,6 +727,31 @@ function normalizeClawHubSkillOrigin(
         return null;
       }
     }
+    const requestedReferenceRaw = normalizeOptionalStringValue(
+      (raw as { requestedReference?: unknown }).requestedReference,
+    );
+    let requestedReference: string | undefined;
+    let trustState: ClawHubSkillsShTrustState | undefined;
+    if (requestedReferenceRaw) {
+      try {
+        const parsed = parseRequestedClawHubSkillRef(requestedReferenceRaw);
+        if (!parsed.requestedReference || parsed.slug !== raw.slug) {
+          return null;
+        }
+        requestedReference = parsed.requestedReference;
+        const rawTrustState = normalizeOptionalStringValue(
+          (raw as { trustState?: unknown }).trustState,
+        );
+        if (rawTrustState !== CLAWHUB_SKILLS_SH_TRUST_STATE) {
+          return null;
+        }
+        trustState = CLAWHUB_SKILLS_SH_TRUST_STATE;
+      } catch {
+        return null;
+      }
+    } else if ((raw as { trustState?: unknown }).trustState !== undefined) {
+      return null;
+    }
     const artifact = normalizeDownloadedArtifactLock((raw as { artifact?: unknown }).artifact);
     const skillFile = normalizeSkillFileLock((raw as { skillFile?: unknown }).skillFile);
     const fileTreeSha256 = normalizeOptionalStringValue(
@@ -679,6 +762,8 @@ function normalizeClawHubSkillOrigin(
       registry: normalizeStoredRegistry(raw.registry),
       slug: raw.slug,
       ...(ownerHandle ? { ownerHandle } : {}),
+      ...(requestedReference ? { requestedReference } : {}),
+      ...(trustState ? { trustState } : {}),
       installedVersion: raw.installedVersion,
       installedAt: raw.installedAt,
       ...(sourceUrl ? { sourceUrl } : {}),
@@ -898,11 +983,16 @@ export function resolveClawHubSkillStatusLinkSync(params: {
     locked.registry === undefined ? originRegistry : normalizeStoredRegistry(locked.registry);
   const lockedSourceUrl = normalizeOptionalStringValue(locked.sourceUrl);
   const lockedOwnerHandle = normalizeOptionalStringValue(locked.ownerHandle);
+  const lockedRequestedReference = normalizeOptionalStringValue(locked.requestedReference);
+  const lockedTrustState =
+    locked.trustState === CLAWHUB_SKILLS_SH_TRUST_STATE ? CLAWHUB_SKILLS_SH_TRUST_STATE : undefined;
   const lockedArtifact = normalizeDownloadedArtifactLock(locked.artifact);
   const lockedSkillFile = normalizeSkillFileLock(locked.skillFile);
   const lockedFileTreeSha256 = normalizeOptionalStringValue(locked.fileTreeSha256);
   const provenanceMatches =
     originRead.origin.ownerHandle === lockedOwnerHandle &&
+    originRead.origin.requestedReference === lockedRequestedReference &&
+    originRead.origin.trustState === lockedTrustState &&
     originRead.origin.sourceUrl === lockedSourceUrl &&
     originRead.origin.artifact?.kind === lockedArtifact?.kind &&
     originRead.origin.artifact?.sha256 === lockedArtifact?.sha256 &&
@@ -936,6 +1026,8 @@ export function resolveClawHubSkillStatusLinkSync(params: {
     registry: lockedRegistry,
     slug: trackedSlug,
     ...(lockedOwnerHandle ? { ownerHandle: lockedOwnerHandle } : {}),
+    ...(lockedRequestedReference ? { requestedReference: lockedRequestedReference } : {}),
+    ...(lockedTrustState ? { trustState: lockedTrustState } : {}),
     installedVersion: locked.version,
     installedAt: locked.installedAt,
     originPath: originRead.path,
@@ -1052,6 +1144,12 @@ export async function resolveClawHubSkillVerificationTarget(params: {
     }
 
     const requestedRef = parseRequestedClawHubSkillRef(params.slug);
+    if (requestedRef.requestedReference && (version || tag)) {
+      return {
+        ok: false,
+        error: "--version and --tag are not supported for skills-sh references.",
+      };
+    }
     const trackedSlug = requestedRef.slug;
     const skillDir = resolveWorkspaceSkillInstallDir(params.workspaceDir, trackedSlug);
     const originRead = await readClawHubSkillOriginStrict(skillDir);
@@ -1082,15 +1180,28 @@ export async function resolveClawHubSkillVerificationTarget(params: {
       const lockedRegistry =
         locked.registry === undefined ? originRegistry : normalizeStoredRegistry(locked.registry);
       const lockedOwnerHandle = normalizeOptionalStringValue(locked.ownerHandle);
+      const lockedRequestedReference = normalizeOptionalStringValue(locked.requestedReference);
+      const lockedTrustState =
+        locked.trustState === CLAWHUB_SKILLS_SH_TRUST_STATE
+          ? CLAWHUB_SKILLS_SH_TRUST_STATE
+          : undefined;
       if (
         locked.version !== originRead.origin.installedVersion ||
         locked.installedAt !== originRead.origin.installedAt ||
         lockedRegistry !== originRegistry ||
-        originRead.origin.ownerHandle !== lockedOwnerHandle
+        originRead.origin.ownerHandle !== lockedOwnerHandle ||
+        originRead.origin.requestedReference !== lockedRequestedReference ||
+        originRead.origin.trustState !== lockedTrustState
       ) {
         return {
           ok: false,
           error: `Skill "${trackedSlug}" ClawHub origin metadata does not match the workspace ClawHub lockfile. Reinstall it from ClawHub before verifying it as an installed ClawHub skill.`,
+        };
+      }
+      if (lockedRequestedReference && (version || tag)) {
+        return {
+          ok: false,
+          error: "--version and --tag are not supported for skills-sh references.",
         };
       }
       if (requestedRef.ownerHandle && lockedOwnerHandle !== requestedRef.ownerHandle) {
@@ -1100,18 +1211,34 @@ export async function resolveClawHubSkillVerificationTarget(params: {
           error: `Skill "${trackedSlug}" is tracked as ${trackedRef}, not @${requestedRef.ownerHandle}/${trackedSlug}.`,
         };
       }
+      if (
+        requestedRef.requestedReference &&
+        lockedRequestedReference !== requestedRef.requestedReference
+      ) {
+        return {
+          ok: false,
+          error: `Skill "${trackedSlug}" is not tracked from ${requestedRef.requestedReference}.`,
+        };
+      }
       const selector: ClawHubSkillVerificationSelector = version
         ? "version"
         : tag
           ? "tag"
           : "installed-version";
+      // ClawHub's skills.sh verify route accepts the catalog reference as its sole selector.
+      // It rejects version/tag; the stored commit remains local installed provenance.
+      const verificationVersion = lockedRequestedReference
+        ? undefined
+        : (version ?? (tag ? undefined : locked.version));
       return {
         ok: true,
         slug: trackedSlug,
         ...(lockedOwnerHandle ? { ownerHandle: lockedOwnerHandle } : {}),
+        ...(lockedRequestedReference ? { requestedReference: lockedRequestedReference } : {}),
+        ...(lockedTrustState ? { trustState: lockedTrustState } : {}),
         baseUrl: lockedRegistry,
-        version: version ?? (tag ? undefined : locked.version),
-        tag,
+        version: verificationVersion,
+        tag: lockedRequestedReference ? undefined : tag,
         resolution: {
           source: "installed",
           selector,
@@ -1142,6 +1269,10 @@ export async function resolveClawHubSkillVerificationTarget(params: {
       ok: true,
       slug: requestedRef.slug,
       ...(requestedRef.ownerHandle ? { ownerHandle: requestedRef.ownerHandle } : {}),
+      ...(requestedRef.requestedReference
+        ? { requestedReference: requestedRef.requestedReference }
+        : {}),
+      ...(requestedRef.trustState ? { trustState: requestedRef.trustState } : {}),
       baseUrl: registry,
       version,
       tag,
@@ -1252,10 +1383,14 @@ async function installGitHubResolution(params: {
   authority: "official" | "third-party";
   repo: string;
   commit: string;
+  requestedReference?: string;
+  trustState?: ClawHubSkillsShTrustState;
   force?: boolean;
   logger?: Logger;
   config?: OpenClawConfig;
 }) {
+  // Preserve the repository root for sourcePath selection. Root markers validate
+  // the selected skill directory afterward, so nested paths are not applied twice.
   return await withExtractedArchiveRoot({
     archivePath: params.archivePath,
     tempDirPrefix: "openclaw-skill-clawhub-github-",
@@ -1279,6 +1414,8 @@ async function installGitHubResolution(params: {
             repo: params.repo,
             path: params.sourcePath,
             commit: params.commit,
+            ...(params.requestedReference ? { reference: params.requestedReference } : {}),
+            ...(params.trustState ? { trustState: params.trustState } : {}),
           },
           source: {
             kind: "git",
@@ -1286,7 +1423,9 @@ async function installGitHubResolution(params: {
             mutable: false,
             network: true,
           },
-          requestedSpecifier: `clawhub:${formatClawHubSkillRef(params)}@${params.commit}`,
+          requestedSpecifier:
+            params.requestedReference ??
+            `clawhub:${formatClawHubSkillRef(params)}@${params.commit}`,
         },
         rootMarkers: CLAWHUB_SKILL_ARCHIVE_ROOT_MARKERS,
       }),
@@ -1409,10 +1548,23 @@ async function performClawHubSkillInstall(
         await fetchClawHubSkillInstallResolution({
           slug: params.slug,
           ...(params.ownerHandle ? { ownerHandle: params.ownerHandle } : {}),
+          ...(params.requestedReference ? { requestedReference: params.requestedReference } : {}),
           baseUrl: params.baseUrl,
           ...(params.forceInstall ? { forceInstall: true } : {}),
         }),
       );
+      if (params.requestedReference) {
+        if (
+          latestResolution.installKind !== "github" ||
+          latestResolution.trust?.state !== CLAWHUB_SKILLS_SH_TRUST_STATE
+        ) {
+          throw new Error(
+            `Skill "${params.slug}" did not resolve to an unscanned, commit-pinned GitHub source.`,
+          );
+        }
+        trustWarning = CLAWHUB_SKILLS_SH_TRUST_LABEL;
+        params.logger?.warn?.(CLAWHUB_SKILLS_SH_TRUST_LABEL);
+      }
       const resolutionOfficialClawHubSkill = isDefaultOfficialClawHubSkillSource({
         baseUrl: params.baseUrl,
         resolution: latestResolution,
@@ -1479,6 +1631,8 @@ async function performClawHubSkillInstall(
                 authority: officialClawHubSkill ? "official" : "third-party",
                 repo: latestResolution.github.repo,
                 commit: latestResolution.github.commit,
+                requestedReference: params.requestedReference,
+                trustState: params.trustState,
                 force: params.force,
                 logger: params.logger,
                 config: params.config,
@@ -1523,6 +1677,7 @@ async function performClawHubSkillInstall(
         fetchInstallVerificationLock({
           slug: params.slug,
           ...(params.ownerHandle ? { ownerHandle: params.ownerHandle } : {}),
+          ...(params.requestedReference ? { requestedReference: params.requestedReference } : {}),
           version: verificationVersion,
           baseUrl: params.baseUrl,
           logger: params.logger,
@@ -1536,6 +1691,8 @@ async function performClawHubSkillInstall(
         registry: resolveClawHubBaseUrl(params.baseUrl),
         slug: params.slug,
         ...(params.ownerHandle ? { ownerHandle: params.ownerHandle } : {}),
+        ...(params.requestedReference ? { requestedReference: params.requestedReference } : {}),
+        ...(params.trustState ? { trustState: params.trustState } : {}),
         installedVersion: version,
         installedAt,
         ...(sourceUrl ? { sourceUrl } : {}),
@@ -1549,6 +1706,8 @@ async function performClawHubSkillInstall(
         installedAt,
         registry: resolveClawHubBaseUrl(params.baseUrl),
         ...(params.ownerHandle ? { ownerHandle: params.ownerHandle } : {}),
+        ...(params.requestedReference ? { requestedReference: params.requestedReference } : {}),
+        ...(params.trustState ? { trustState: params.trustState } : {}),
         ...(sourceUrl ? { sourceUrl } : {}),
         artifact,
         ...(skillFile ? { skillFile } : {}),
@@ -1570,6 +1729,8 @@ async function performClawHubSkillInstall(
         slug: params.slug,
         ...(params.ownerHandle ? { ownerHandle: params.ownerHandle } : {}),
         version,
+        ...(params.requestedReference ? { requestedReference: params.requestedReference } : {}),
+        ...(params.trustState ? { trustState: params.trustState } : {}),
       }).catch(() => undefined);
 
       return {
@@ -1596,10 +1757,15 @@ async function installRequestedSkillFromClawHub(
 ): Promise<InstallClawHubSkillResult> {
   try {
     const ref = parseRequestedClawHubSkillRef(params.slug);
+    if (ref.requestedReference && params.version) {
+      throw new Error("--version is not supported for skills-sh references.");
+    }
     return await performClawHubSkillInstall({
       ...params,
       slug: ref.slug,
       ...(ref.ownerHandle ? { ownerHandle: ref.ownerHandle } : {}),
+      ...(ref.requestedReference ? { requestedReference: ref.requestedReference } : {}),
+      ...(ref.trustState ? { trustState: ref.trustState } : {}),
     });
   } catch (err) {
     return {
@@ -1768,10 +1934,14 @@ async function resolveTrackedUpdateTarget(params: {
   }
   const lockEntry = params.lock.skills[params.slug];
   const ownerHandle = origin?.ownerHandle ?? lockEntry?.ownerHandle;
+  const requestedReference = origin?.requestedReference ?? lockEntry?.requestedReference;
+  const trustState = origin?.trustState ?? lockEntry?.trustState;
   return {
     ok: true,
     slug: params.slug,
     ...(ownerHandle ? { ownerHandle } : {}),
+    ...(requestedReference ? { requestedReference } : {}),
+    ...(trustState ? { trustState } : {}),
     baseUrl: origin?.registry ?? params.baseUrl,
     previousVersion: origin?.installedVersion ?? lockEntry?.version ?? null,
   };
@@ -1853,6 +2023,8 @@ export async function updateSkillsFromClawHub(params: {
           workspaceDir: params.workspaceDir,
           slug: tracked.slug,
           ...(tracked.ownerHandle ? { ownerHandle: tracked.ownerHandle } : {}),
+          ...(tracked.requestedReference ? { requestedReference: tracked.requestedReference } : {}),
+          ...(tracked.trustState ? { trustState: tracked.trustState } : {}),
           baseUrl: tracked.baseUrl,
           force: true,
           forceInstall: params.forceInstall,


### PR DESCRIPTION
Related: #112547

## What Problem This Solves

Unclaimed skills.sh catalog entries need an explicit external install reference that preserves their provenance and clearly communicates that ClawHub has not scanned them.

## Why This Change Was Made

Adds `skills-sh:owner/repo/slug` as the sole external skills.sh CLI syntax. OpenClaw resolves it through ClawHub to a full commit-pinned GitHub descriptor, persists the original reference and `Not scanned by ClawHub` trust state through the lifecycle, and rejects the legacy slash form before network access. Native `@org/slug`, direct `git:`, bare slug, and local path behavior remain unchanged.

This replacement supersedes the slash-grammar implementation in #112547; that PR remains unmodified and must not merge.

Maintainer decision: the colon grammar is the intended public contract for unclaimed external skills.sh entries. Claimed/scanned skills remain native ClawHub references.

## User Impact

Users can install, update, verify, search for, and inspect mirrored unclaimed skills.sh entries with explicit external trust provenance. Claimed and scanned skills continue to use native ClawHub references.

## Evidence

Exact PR head: `6f0a1ded7326c8b5edc4a85029f990608c1c35f7`.

- Lifecycle tests: 94 passed
- ClawHub infra tests: 90 passed
- Skills CLI tests: 76 passed
- `pnpm docs:list`: passed
- `git diff --check`: passed
- Changed gate: passed on Blacksmith Testbox ([run 30154891781](https://github.com/openclaw/openclaw/actions/runs/30154891781)), including formatting, core and core-test typechecks, lint, dependency/state guards, and runtime import-cycle checks
- Exact-head hosted PR CI: green, including `openclaw/ci-gate`
- Autoreview: clean; no accepted/actionable findings
- Explicit coverage rejects `skills-sh/owner/repo/slug` before network access and rejects mutable GitHub refs before download
- AI-assisted; I understand and verified the implementation

Permanent Test and fresh isolated lifecycle proof on the exact head:

- Resolver environment SHA: `cb9c6d8381f82f6fe1d3df0e00064672e63c784c`
- `skills install skills-sh:patrick-erichsen/skills/html`: exit 0; displayed `Not scanned by ClawHub`
- `skills update html`: exit 0; retained exact commit `050daba89f6b6636470add5cb300aac46a412cf8`
- Direct colon-reference verify and installed bare-slug verify: expected exit 1 with byte-identical `ok:false`, `decision:fail`, `Not scanned by ClawHub` envelopes
- Origin, lock, and info retained the requested colon reference, Test registry, repo/path source URL, exact commit, source fingerprint `a47adb2c1ac33c088f664b5187971b63d2b958a7b9f01516d26005ca941a108f`, `source=skills.sh`, and `not-scanned-by-clawhub` trust
- Installed `SKILL.md`: 5,688 bytes, SHA-256 `42d2e89358ea927441dfede45c3b0cf89a21603bc7c32246f098d24a9cbea1ff`
- Separate isolated slash-form proof: exit 1 before network or writes; observer requests 0; no skill directory created

The detailed redacted command evidence is attached in the PR discussion. No release or production action is part of this PR.
