### PR TITLE
perf(models): scope provider-filtered catalog discovery

### DIFF
--- a/src/agents/models-config.providers.implicit.ts
+++ b/src/agents/models-config.providers.implicit.ts
@@ -21,6 +21,7 @@ import {
 } from "../plugins/provider-discovery.js";
 import { resolveOwningPluginIdsForProviderRef } from "../plugins/providers.js";
 import { ensureAuthProfileStore } from "./auth-profiles/store.js";
+import type { AuthProfileStore } from "./auth-profiles/types.js";
 import {
   isNonSecretApiKeyMarker,
   resolveNonEnvSecretRefApiKeyMarker,
@@ -53,6 +54,7 @@ const PLUGIN_DISCOVERY_ORDERS = ["simple", "profile", "paired", "late"] as const
 
 type ImplicitProviderParams = {
   agentDir: string;
+  authStore?: AuthProfileStore;
   config?: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
   workspaceDir?: string;
@@ -538,7 +540,7 @@ export async function resolveImplicitProviders(
 ): Promise<NonNullable<OpenClawConfig["models"]>["providers"]> {
   const providers: Record<string, ProviderConfig> = {};
   const env = params.env ?? process.env;
-  let authStore: ReturnType<typeof ensureAuthProfileStore> | undefined;
+  let authStore = params.authStore;
   const getAuthStore = () =>
     (authStore ??= ensureAuthProfileStore(params.agentDir, {
       allowKeychainPrompt: false,

--- a/src/commands/models.list.e2e.test.ts
+++ b/src/commands/models.list.e2e.test.ts
@@ -640,7 +640,7 @@ describe("models list/status", () => {
     );
 
     const payload = parseJsonLog(runtime);
-    expect(loadModelCatalog).toHaveBeenCalledOnce();
+    expect(loadModelCatalog).not.toHaveBeenCalled();
     expect(payload.models).toHaveLength(1);
     const model = payload.models[0];
     expect(model.key).toBe("moonshot/kimi-k2.6");

--- a/src/commands/models/list.provider-catalog.test.ts
+++ b/src/commands/models/list.provider-catalog.test.ts
@@ -1,11 +1,31 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
+  loadAuthStore: vi.fn(() => ({ version: 1, profiles: {} })),
+  loadMetadata: vi.fn(),
   loadOwner: vi.fn(),
+  resolveImplicitProviders: vi.fn(),
+  resolveProviderOwners: vi.fn(),
+}));
+
+vi.mock("../../agents/auth-profiles/store.js", () => ({
+  loadAuthProfileStoreForSecretsRuntime: mocks.loadAuthStore,
+}));
+
+vi.mock("../../agents/models-config.providers.implicit.js", () => ({
+  resolveImplicitProviders: mocks.resolveImplicitProviders,
 }));
 
 vi.mock("../../agents/prepared-model-catalog.js", () => ({
   loadPreparedModelCatalogOwnerSnapshot: mocks.loadOwner,
+}));
+
+vi.mock("../../plugins/manifest-contract-eligibility.js", () => ({
+  loadManifestMetadataSnapshot: mocks.loadMetadata,
+}));
+
+vi.mock("../../plugins/providers.js", () => ({
+  resolveOwningPluginIdsForProviderRef: mocks.resolveProviderOwners,
 }));
 
 import {
@@ -24,20 +44,95 @@ function ownerSnapshot(modelCatalog: unknown, metadataSnapshot = emptyMetadataSn
   };
 }
 
-describe("lifecycle-owned model-list provider catalog", () => {
+describe("model-list provider catalog", () => {
   beforeEach(() => {
+    mocks.loadAuthStore.mockClear();
+    mocks.loadMetadata.mockReset();
+    mocks.loadMetadata.mockReturnValue(emptyMetadataSnapshot);
     mocks.loadOwner.mockReset();
+    mocks.resolveImplicitProviders.mockReset();
+    mocks.resolveProviderOwners.mockReset();
   });
 
-  it("projects a provider from the lifecycle owner", async () => {
+  it("projects a filtered provider through targeted plugin discovery", async () => {
+    mocks.resolveImplicitProviders.mockResolvedValue({
+      moonshot: {
+        baseUrl: "https://api.moonshot.ai",
+        api: "openai-completions",
+        models: [{ id: "kimi-k2.6", name: "Kimi K2.6", contextWindow: 262_144 }],
+      },
+    });
+
+    await expect(
+      loadProviderCatalogModelsForList({
+        cfg: {},
+        agentDir: "/tmp/agent",
+        providerFilter: "moonshot",
+      }),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        provider: "moonshot",
+        id: "kimi-k2.6",
+        name: "Kimi K2.6",
+        contextWindow: 262_144,
+        maxTokens: 200_000,
+      }),
+    ]);
+    expect(mocks.resolveImplicitProviders).toHaveBeenCalledWith(
+      expect.objectContaining({
+        authStore: { version: 1, profiles: {} },
+        providerDiscoveryProviderIds: ["moonshot"],
+      }),
+    );
+    expect(mocks.loadAuthStore).toHaveBeenCalledWith("/tmp/agent", {
+      config: {},
+      externalCliProviderIds: ["moonshot"],
+    });
+    expect(mocks.loadOwner).not.toHaveBeenCalled();
+  });
+
+  it("resolves the effective agent context for filtered discovery", async () => {
+    const cfg = {
+      agents: {
+        list: [
+          {
+            id: "worker",
+            agentDir: "/tmp/model-list-worker-agent",
+            workspace: "/tmp/model-list-worker-workspace",
+          },
+        ],
+      },
+    };
+    mocks.resolveImplicitProviders.mockResolvedValue({ moonshot: { models: [] } });
+
+    await loadProviderCatalogModelsForList({
+      cfg,
+      agentId: "worker",
+      providerFilter: "moonshot",
+    });
+
+    expect(mocks.loadMetadata).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: cfg,
+        workspaceDir: "/tmp/model-list-worker-workspace",
+      }),
+    );
+    expect(mocks.loadAuthStore).toHaveBeenCalledWith("/tmp/model-list-worker-agent", {
+      config: cfg,
+      externalCliProviderIds: ["moonshot"],
+    });
+    expect(mocks.resolveImplicitProviders).toHaveBeenCalledWith(
+      expect.objectContaining({ agentDir: "/tmp/model-list-worker-agent" }),
+    );
+  });
+
+  it("keeps unfiltered runtime output on the lifecycle owner", async () => {
     mocks.loadOwner.mockResolvedValue(
       ownerSnapshot({
         entries: [
           { provider: "moonshot", id: "kimi-k2.6", name: "Kimi K2.6" },
-          { provider: "openai", id: "gpt-5.4", name: "GPT-5.4" },
           { provider: "ollama", id: "local-model", name: "Local Model" },
         ],
-        staticEntries: [{ provider: "moonshot", id: "kimi-static", name: "Kimi Static" }],
         routeVariants: [],
       }),
     );
@@ -46,18 +141,12 @@ describe("lifecycle-owned model-list provider catalog", () => {
       loadProviderCatalogModelsForList({
         cfg: {},
         agentDir: "/tmp/agent",
-        providerFilter: "moonshot",
-      }),
-    ).resolves.toEqual([{ provider: "moonshot", id: "kimi-k2.6", name: "Kimi K2.6" }]);
-    await expect(
-      loadProviderCatalogModelsForList({
-        cfg: {},
-        agentDir: "/tmp/agent",
       }),
     ).resolves.not.toContainEqual(expect.objectContaining({ provider: "ollama" }));
   });
 
-  it("keeps static provider-hook rows separate from the full runtime catalog", async () => {
+  it("keeps static provider-hook rows separate from runtime ownership", async () => {
+    mocks.resolveProviderOwners.mockReturnValue([]);
     mocks.loadOwner.mockResolvedValue(
       ownerSnapshot({
         entries: [{ provider: "moonshot", id: "kimi-runtime", name: "Kimi Runtime" }],
@@ -97,14 +186,9 @@ describe("lifecycle-owned model-list provider catalog", () => {
     expect(mocks.loadOwner).toHaveBeenCalledWith(expect.objectContaining({ readOnly: true }));
   });
 
-  it("activates one prepared owner when no generation is published", async () => {
+  it("uses manifest ownership without activating a prepared runtime", async () => {
     const env = { OPENCLAW_STATE_DIR: "/tmp/model-list-state" };
-    mocks.loadOwner.mockResolvedValue(
-      ownerSnapshot({
-        entries: [{ provider: "moonshot", id: "kimi-k2.6", name: "Kimi K2.6" }],
-        routeVariants: [],
-      }),
-    );
+    mocks.resolveProviderOwners.mockReturnValue(["moonshot"]);
 
     await expect(
       hasProviderRuntimeCatalogForFilter({
@@ -115,12 +199,10 @@ describe("lifecycle-owned model-list provider catalog", () => {
         providerFilter: "moonshot",
       }),
     ).resolves.toBe(true);
-    expect(mocks.loadOwner).toHaveBeenCalledWith({
-      config: {},
-      agentId: "worker",
-      agentDir: "/tmp/agent",
-      env,
-    });
+    expect(mocks.resolveProviderOwners).toHaveBeenCalledWith(
+      expect.objectContaining({ provider: "moonshot", env }),
+    );
+    expect(mocks.loadOwner).not.toHaveBeenCalled();
   });
 
   it("derives the matching directory for an explicit agent", async () => {
@@ -152,6 +234,38 @@ describe("lifecycle-owned model-list provider catalog", () => {
     );
   });
 
+  it("resolves provider aliases without a caller-supplied metadata snapshot", async () => {
+    mocks.loadMetadata.mockReturnValue({
+      manifestRegistry: {
+        plugins: [
+          {
+            id: "moonshot",
+            modelCatalog: {
+              aliases: { kimi: { provider: "moonshot" } },
+            },
+          },
+        ],
+      },
+    });
+    mocks.resolveImplicitProviders.mockResolvedValue({
+      moonshot: {
+        baseUrl: "https://api.moonshot.ai",
+        api: "openai-completions",
+        models: [{ id: "kimi-k2.6", name: "Kimi K2.6" }],
+      },
+    });
+
+    await loadProviderCatalogModelsForList({
+      cfg: {},
+      agentDir: "/tmp/agent",
+      providerFilter: "kimi",
+    });
+
+    expect(mocks.resolveImplicitProviders).toHaveBeenCalledWith(
+      expect.objectContaining({ providerDiscoveryProviderIds: ["moonshot"] }),
+    );
+  });
+
   it("matches provider aliases from the captured metadata generation", async () => {
     const metadataSnapshot = {
       manifestRegistry: {
@@ -165,23 +279,26 @@ describe("lifecycle-owned model-list provider catalog", () => {
         ],
       },
     } as never;
-    mocks.loadOwner.mockResolvedValue(
-      ownerSnapshot(
-        {
-          entries: [{ provider: "moonshot", id: "kimi-k2.6", name: "Kimi K2.6" }],
-          staticEntries: [{ provider: "moonshot", id: "kimi-static", name: "Kimi Static" }],
-          routeVariants: [],
-        },
-        metadataSnapshot,
-      ),
-    );
+    mocks.resolveImplicitProviders.mockResolvedValue({
+      moonshot: {
+        baseUrl: "https://api.moonshot.ai",
+        api: "openai-completions",
+        models: [{ id: "kimi-k2.6", name: "Kimi K2.6" }],
+      },
+    });
 
     await expect(
       loadProviderCatalogModelsForList({
         cfg: {},
         agentDir: "/tmp/agent",
         providerFilter: "kimi",
+        metadataSnapshot,
       }),
-    ).resolves.toEqual([{ provider: "moonshot", id: "kimi-k2.6", name: "Kimi K2.6" }]);
+    ).resolves.toEqual([
+      expect.objectContaining({ provider: "moonshot", id: "kimi-k2.6", name: "Kimi K2.6" }),
+    ]);
+    expect(mocks.resolveImplicitProviders).toHaveBeenCalledWith(
+      expect.objectContaining({ providerDiscoveryProviderIds: ["moonshot"] }),
+    );
   });
 });

--- a/src/commands/models/list.provider-catalog.test.ts
+++ b/src/commands/models/list.provider-catalog.test.ts
@@ -5,7 +5,6 @@ const mocks = vi.hoisted(() => ({
   loadMetadata: vi.fn(),
   loadOwner: vi.fn(),
   resolveImplicitProviders: vi.fn(),
-  resolveProviderOwners: vi.fn(),
 }));
 
 vi.mock("../../agents/auth-profiles/store.js", () => ({
@@ -24,17 +23,35 @@ vi.mock("../../plugins/manifest-contract-eligibility.js", () => ({
   loadManifestMetadataSnapshot: mocks.loadMetadata,
 }));
 
-vi.mock("../../plugins/providers.js", () => ({
-  resolveOwningPluginIdsForProviderRef: mocks.resolveProviderOwners,
-}));
-
 import {
   hasProviderRuntimeCatalogForFilter,
   hasProviderStaticCatalogForFilter,
   loadProviderCatalogModelsForList,
 } from "./list.provider-catalog.js";
 
-const emptyMetadataSnapshot = { manifestRegistry: { plugins: [] } } as never;
+const emptyMetadataSnapshot = {
+  manifestRegistry: { plugins: [] },
+  owners: {
+    channels: new Map(),
+    channelConfigs: new Map(),
+    providers: new Map(),
+    modelCatalogProviders: new Map(),
+    cliBackends: new Map(),
+    setupProviders: new Map(),
+    commandAliases: new Map(),
+    contracts: new Map(),
+  },
+} as never;
+
+function metadataWithCatalogOwner(provider: string, pluginId: string) {
+  return {
+    ...emptyMetadataSnapshot,
+    owners: {
+      ...emptyMetadataSnapshot.owners,
+      modelCatalogProviders: new Map([[provider, [pluginId]]]),
+    },
+  } as never;
+}
 
 function ownerSnapshot(modelCatalog: unknown, metadataSnapshot = emptyMetadataSnapshot) {
   return {
@@ -51,7 +68,6 @@ describe("model-list provider catalog", () => {
     mocks.loadMetadata.mockReturnValue(emptyMetadataSnapshot);
     mocks.loadOwner.mockReset();
     mocks.resolveImplicitProviders.mockReset();
-    mocks.resolveProviderOwners.mockReset();
   });
 
   it("projects a filtered provider through targeted plugin discovery", async () => {
@@ -146,7 +162,6 @@ describe("model-list provider catalog", () => {
   });
 
   it("keeps static provider-hook rows separate from runtime ownership", async () => {
-    mocks.resolveProviderOwners.mockReturnValue([]);
     mocks.loadOwner.mockResolvedValue(
       ownerSnapshot({
         entries: [{ provider: "moonshot", id: "kimi-runtime", name: "Kimi Runtime" }],
@@ -186,9 +201,9 @@ describe("model-list provider catalog", () => {
     expect(mocks.loadOwner).toHaveBeenCalledWith(expect.objectContaining({ readOnly: true }));
   });
 
-  it("uses manifest ownership without activating a prepared runtime", async () => {
+  it("uses model-catalog manifest ownership without activating a prepared runtime", async () => {
     const env = { OPENCLAW_STATE_DIR: "/tmp/model-list-state" };
-    mocks.resolveProviderOwners.mockReturnValue(["moonshot"]);
+    mocks.loadMetadata.mockReturnValue(metadataWithCatalogOwner("moonshot", "moonshot"));
 
     await expect(
       hasProviderRuntimeCatalogForFilter({
@@ -199,10 +214,26 @@ describe("model-list provider catalog", () => {
         providerFilter: "moonshot",
       }),
     ).resolves.toBe(true);
-    expect(mocks.resolveProviderOwners).toHaveBeenCalledWith(
-      expect.objectContaining({ provider: "moonshot", env }),
-    );
     expect(mocks.loadOwner).not.toHaveBeenCalled();
+  });
+
+  it("does not treat generic provider ownership as runtime catalog ownership", async () => {
+    mocks.loadMetadata.mockReturnValue({
+      ...emptyMetadataSnapshot,
+      owners: {
+        ...emptyMetadataSnapshot.owners,
+        providers: new Map([["auth-only", ["auth-only"]]]),
+        cliBackends: new Map([["auth-only", ["auth-only"]]]),
+      },
+    });
+
+    await expect(
+      hasProviderRuntimeCatalogForFilter({
+        cfg: {},
+        agentDir: "/tmp/agent",
+        providerFilter: "auth-only",
+      }),
+    ).resolves.toBe(false);
   });
 
   it("derives the matching directory for an explicit agent", async () => {

--- a/src/commands/models/list.provider-catalog.test.ts
+++ b/src/commands/models/list.provider-catalog.test.ts
@@ -1,4 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  PluginMetadataSnapshot,
+  PluginMetadataSnapshotOwnerMaps,
+} from "../../plugins/plugin-metadata-snapshot.types.js";
 
 const mocks = vi.hoisted(() => ({
   loadAuthStore: vi.fn(() => ({ version: 1, profiles: {} })),
@@ -29,28 +33,30 @@ import {
   loadProviderCatalogModelsForList,
 } from "./list.provider-catalog.js";
 
+const emptyOwners: PluginMetadataSnapshotOwnerMaps = {
+  channels: new Map(),
+  channelConfigs: new Map(),
+  providers: new Map(),
+  modelCatalogProviders: new Map(),
+  cliBackends: new Map(),
+  setupProviders: new Map(),
+  commandAliases: new Map(),
+  contracts: new Map(),
+};
+
 const emptyMetadataSnapshot = {
   manifestRegistry: { plugins: [] },
-  owners: {
-    channels: new Map(),
-    channelConfigs: new Map(),
-    providers: new Map(),
-    modelCatalogProviders: new Map(),
-    cliBackends: new Map(),
-    setupProviders: new Map(),
-    commandAliases: new Map(),
-    contracts: new Map(),
-  },
-} as never;
+  owners: emptyOwners,
+} as unknown as PluginMetadataSnapshot;
 
-function metadataWithCatalogOwner(provider: string, pluginId: string) {
+function metadataWithCatalogOwner(provider: string, pluginId: string): PluginMetadataSnapshot {
   return {
     ...emptyMetadataSnapshot,
     owners: {
-      ...emptyMetadataSnapshot.owners,
+      ...emptyOwners,
       modelCatalogProviders: new Map([[provider, [pluginId]]]),
     },
-  } as never;
+  };
 }
 
 function ownerSnapshot(modelCatalog: unknown, metadataSnapshot = emptyMetadataSnapshot) {

--- a/src/commands/models/list.provider-catalog.ts
+++ b/src/commands/models/list.provider-catalog.ts
@@ -1,16 +1,28 @@
-/** Lifecycle-owned provider catalog projection for model-list output. */
+/** Provider catalog projection for model-list output. */
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
-import { resolveAgentDir, resolveDefaultAgentDir } from "../../agents/agent-scope.js";
+import {
+  resolveAgentDir,
+  resolveAgentWorkspaceDir,
+  resolveDefaultAgentDir,
+  resolveDefaultAgentId,
+} from "../../agents/agent-scope.js";
+import { loadAuthProfileStoreForSecretsRuntime } from "../../agents/auth-profiles/store.js";
+import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
+import { buildInlineProviderModels } from "../../agents/embedded-agent-runner/model.inline-provider.js";
+import { resolveImplicitProviders } from "../../agents/models-config.providers.implicit.js";
 import { loadPreparedModelCatalogOwnerSnapshot } from "../../agents/prepared-model-catalog.js";
+import { resolveDefaultAgentWorkspaceDir } from "../../agents/workspace.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { Model } from "../../llm/types.js";
+import { loadManifestMetadataSnapshot } from "../../plugins/manifest-contract-eligibility.js";
 import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
+import { resolveOwningPluginIdsForProviderRef } from "../../plugins/providers.js";
 import { canonicalizeModelCatalogProviderAlias } from "./provider-aliases.js";
 
 type ProviderCatalogListParams = {
   cfg: OpenClawConfig;
   agentId?: string;
-  agentDir: string;
+  agentDir?: string;
   env?: NodeJS.ProcessEnv;
   providerFilter?: string;
   staticOnly?: boolean;
@@ -26,7 +38,7 @@ async function loadProviderCatalogSnapshot(
   const input = {
     config: params.cfg,
     ...(params.agentId ? { agentId: params.agentId } : {}),
-    agentDir: params.agentDir,
+    agentDir: resolveProviderCatalogAgentDir(params),
     ...(params.metadataSnapshot?.workspaceDir
       ? { workspaceDir: params.metadataSnapshot.workspaceDir }
       : {}),
@@ -38,7 +50,7 @@ async function loadProviderCatalogSnapshot(
 
 function resolveProviderFilter(
   params: ProviderCatalogListParams,
-  metadataSnapshot: PluginMetadataSnapshot,
+  metadataSnapshot?: PluginMetadataSnapshot,
 ): string {
   const providerFilter = normalizeProviderId(params.providerFilter ?? "");
   return providerFilter
@@ -49,6 +61,22 @@ function resolveProviderFilter(
         }),
       )
     : providerFilter;
+}
+
+function resolveProviderCatalogMetadataSnapshot(
+  params: ProviderCatalogListParams,
+): PluginMetadataSnapshot {
+  if (params.metadataSnapshot) {
+    return params.metadataSnapshot;
+  }
+  const agentId = params.agentId ?? resolveDefaultAgentId(params.cfg);
+  const workspaceDir =
+    resolveAgentWorkspaceDir(params.cfg, agentId) ?? resolveDefaultAgentWorkspaceDir();
+  return loadManifestMetadataSnapshot({
+    config: params.cfg,
+    env: params.env ?? process.env,
+    workspaceDir,
+  });
 }
 
 function resolveProviderCatalogAgentDir(
@@ -62,20 +90,69 @@ function resolveProviderCatalogAgentDir(
   );
 }
 
-/** Returns true when the prepared generation contains rows for a provider filter. */
+function completeCatalogModel(model: ReturnType<typeof buildInlineProviderModels>[number]): Model {
+  const contextWindow = model.contextWindow ?? DEFAULT_CONTEXT_TOKENS;
+  return {
+    ...model,
+    name: model.name || model.id,
+    api: model.api ?? "openai-responses",
+    baseUrl: model.baseUrl ?? "",
+    reasoning: model.reasoning ?? false,
+    input: model.input ?? ["text"],
+    cost: model.cost ?? { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow,
+    maxTokens: model.maxTokens ?? DEFAULT_CONTEXT_TOKENS,
+  } as Model;
+}
+
+async function loadScopedProviderCatalogModels(
+  params: ProviderCatalogListParams,
+): Promise<Model[]> {
+  const metadataSnapshot = resolveProviderCatalogMetadataSnapshot(params);
+  const providerFilter = resolveProviderFilter(params, metadataSnapshot);
+  if (!providerFilter) {
+    return [];
+  }
+  const agentDir = resolveProviderCatalogAgentDir(params);
+  const providers = await resolveImplicitProviders({
+    agentDir,
+    authStore: loadAuthProfileStoreForSecretsRuntime(agentDir, {
+      config: params.cfg,
+      externalCliProviderIds: [providerFilter],
+    }),
+    config: params.cfg,
+    explicitProviders: params.cfg.models?.providers ?? null,
+    providerDiscoveryProviderIds: [providerFilter],
+    ...(params.env ? { env: params.env } : {}),
+    ...(metadataSnapshot.workspaceDir ? { workspaceDir: metadataSnapshot.workspaceDir } : {}),
+    pluginMetadataSnapshot: metadataSnapshot,
+  });
+  return buildInlineProviderModels(providers ?? {})
+    .filter((model) => normalizeProviderId(model.provider) === providerFilter)
+    .map(completeCatalogModel);
+}
+
+/** Returns true when manifest ownership exposes a runtime catalog for the provider filter. */
 export async function hasProviderRuntimeCatalogForFilter(
   params: Omit<ProviderCatalogListParams, "agentDir"> & { agentDir?: string },
 ): Promise<boolean> {
-  const owner = await loadProviderCatalogSnapshot({
+  const resolvedParams = {
     ...params,
     agentDir: resolveProviderCatalogAgentDir(params),
-  });
-  const providerFilter = resolveProviderFilter(
-    { ...params, agentDir: owner.agentDir },
-    owner.metadataSnapshot,
-  );
-  return owner.modelCatalog.entries.some(
-    (entry) => normalizeProviderId(entry.provider) === providerFilter,
+  };
+  const metadataSnapshot = resolveProviderCatalogMetadataSnapshot(resolvedParams);
+  const providerFilter = resolveProviderFilter(resolvedParams, metadataSnapshot);
+  if (!providerFilter) {
+    return false;
+  }
+  return Boolean(
+    resolveOwningPluginIdsForProviderRef({
+      provider: providerFilter,
+      config: params.cfg,
+      ...(metadataSnapshot.workspaceDir ? { workspaceDir: metadataSnapshot.workspaceDir } : {}),
+      ...(params.env ? { env: params.env } : {}),
+      metadataSnapshot,
+    })?.length,
   );
 }
 
@@ -98,6 +175,9 @@ export async function hasProviderStaticCatalogForFilter(
 export async function loadProviderCatalogModelsForList(
   params: ProviderCatalogListParams,
 ): Promise<Model[]> {
+  if (params.providerFilter && params.staticOnly !== true) {
+    return await loadScopedProviderCatalogModels(params);
+  }
   const owner = await loadProviderCatalogSnapshot(params, {
     readOnly: params.staticOnly === true,
   });

--- a/src/commands/models/list.provider-catalog.ts
+++ b/src/commands/models/list.provider-catalog.ts
@@ -16,7 +16,6 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { Model } from "../../llm/types.js";
 import { loadManifestMetadataSnapshot } from "../../plugins/manifest-contract-eligibility.js";
 import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
-import { resolveOwningPluginIdsForProviderRef } from "../../plugins/providers.js";
 import { canonicalizeModelCatalogProviderAlias } from "./provider-aliases.js";
 
 type ProviderCatalogListParams = {
@@ -145,15 +144,7 @@ export async function hasProviderRuntimeCatalogForFilter(
   if (!providerFilter) {
     return false;
   }
-  return Boolean(
-    resolveOwningPluginIdsForProviderRef({
-      provider: providerFilter,
-      config: params.cfg,
-      ...(metadataSnapshot.workspaceDir ? { workspaceDir: metadataSnapshot.workspaceDir } : {}),
-      ...(params.env ? { env: params.env } : {}),
-      metadataSnapshot,
-    })?.length,
-  );
+  return Boolean(metadataSnapshot.owners.modelCatalogProviders.get(providerFilter)?.length);
 }
 
 /** Returns true when the prepared generation captured static provider-hook rows. */


### PR DESCRIPTION
## What Problem This Solves

`openclaw models list --provider <id>` activated the complete prepared model runtime before it could determine whether the requested provider had catalog rows. In a source checkout with the bundled plugin set, provider planning took roughly 253 seconds and repeatedly scanned plugin metadata, making a filtered list appear hung.

## Why This Change Was Made

Provider-filtered listing already knows the requested provider and has a manifest metadata snapshot. This change uses the manifest's dedicated `modelCatalogProviders` ownership map to decide whether targeted runtime discovery is appropriate, then activates only that provider's owner. It preserves the lifecycle-owned path for unfiltered and static catalog views.

The targeted path carries forward the selected agent directory and workspace, canonical provider aliases, and a read-only auth snapshot including provider-scoped external CLI profiles. Discovered provider config is normalized into the same complete model shape used by list rows.

## User Impact

Provider-filtered model listing no longer cold-loads every provider plugin. In the Ollama reproduction, the source-planning phase dropped from about 253 seconds to about 3.3 seconds. The complete source-checkout command returned the signed-in local/cloud catalog in about 38–43 seconds, with the remaining time attributable to TypeScript source startup.

No configuration or output contract changes are intended. Unfiltered listing, static catalog rows, aliases, external auth profiles, and registry fallback behavior remain supported.

## Evidence

- Real signed-in Ollama hybrid route on macOS:
  - `ollama/glm-5.1:cloud`: `contextWindow=202752`, no effective `contextTokens` cap.
  - `ollama/qwen3:0.6b`: `contextWindow=40960`, `contextTokens=32768`.
  - Both rows reported available and not missing.
- Focused provider-catalog regression tests cover targeted discovery, effective agent directory/workspace, aliases with and without a supplied snapshot, external auth injection, static catalogs, and model-catalog-specific ownership.
- Focused E2E and provider-discovery suites passed on Blacksmith Testbox during development.
- `pnpm check:changed` and `pnpm build` passed on Blacksmith Testbox before the final model-catalog ownership narrowing; the exact committed-head rerun is attached to this PR/branch validation.
- Final Codex autoreview after the ownership correction: clean, no accepted/actionable findings.
- `git diff --check` passes.
