### PR TITLE
fix(install): fail closed on missing git tags, never silent-downgrade

### DIFF
--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -1103,7 +1103,37 @@ checkout_git_openclaw_ref() {
     (( probe_status == 2 )) || fail "Could not resolve requested git ref: ${ref}"
   done
 
+  # Fail closed: never substitute an older base tag (for example v2026.7.1
+  # when the requested npm correction release is v2026.7.1-2).
+  if [[ "$ref" =~ ^v[0-9] ]]; then
+    fail "Requested git version not found: ${ref}. No matching GitHub tag for this version. Correction releases must publish an immutable tag that matches the npm version (for example v2026.7.1-2 for npm 2026.7.1-2). Publish the missing tag, or use --install-method npm."
+  fi
   fail "Requested git version not found: ${ref}"
+}
+
+# After checking out a version tag, require package.json to match exactly.
+assert_git_checkout_matches_ref() {
+  local repo_dir="$1"
+  local ref="$2"
+  local expected=""
+  local actual=""
+  local package_json="${repo_dir}/package.json"
+
+  if [[ ! "$ref" =~ ^v[0-9] ]]; then
+    return 0
+  fi
+
+  expected="${ref#v}"
+  if command -v node >/dev/null 2>&1 && [[ -f "$package_json" ]]; then
+    actual="$(node -e 'const fs=require("fs"); const p=JSON.parse(fs.readFileSync(process.argv[1],"utf8")); process.stdout.write(String(p.version||""));' "$package_json" 2>/dev/null || true)"
+  fi
+  if [[ -z "$actual" && -f "$package_json" ]]; then
+    actual="$(sed -n -E 's/^[[:space:]]*"version"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p' "$package_json" | head -n1)"
+  fi
+  actual="${actual:-unknown}"
+  if [[ "$actual" != "$expected" ]]; then
+    fail "Git checkout version mismatch for ${ref}: package.json is ${actual}, expected ${expected}. Refusing to continue with a different OpenClaw version than the resolved git ref."
+  fi
 }
 
 git_install_lockfile_flag() {
@@ -1608,7 +1638,7 @@ install_openclaw_from_git() {
   fi
 
   emit_json step name openclaw status start method git repo "$repo_url"
-  if [[ -d "$repo_dir/.git" ]]; then
+  if [[ -e "$repo_dir/.git" ]]; then
     log "Installing Openclaw from git checkout: ${repo_dir}"
   else
     log "Installing Openclaw from GitHub (${repo_url})..."
@@ -1623,7 +1653,7 @@ install_openclaw_from_git() {
     fail "Git checkout has no commit: ${repo_dir}. Move or remove this incomplete checkout, then retry."
   fi
 
-  if [[ -d "$repo_dir/.git" ]]; then
+  if [[ -e "$repo_dir/.git" ]]; then
     :
   elif [[ -d "$repo_dir" ]]; then
     if [[ -z "$(ls -A "$repo_dir" 2>/dev/null || true)" ]]; then
@@ -1642,23 +1672,27 @@ install_openclaw_from_git() {
   fi
 
   local git_ref
-  git_ref="$(resolve_git_openclaw_ref)"
-  if [[ -z "$(git -C "$repo_dir" status --porcelain 2>/dev/null || true)" ]]; then
+  # --no-git-update skips pull only. Dirty trees keep local work; clean trees
+  # still resolve/checkout/validate the requested release tag.
+  if [[ -e "$repo_dir/.git" && -n "$(git -C "$repo_dir" status --porcelain 2>/dev/null || true)" ]]; then
+    # Dirty tree: keep checkout; never resolve npm tag (fail-closed) when not updating.
+    log "Repo is dirty; skipping git checkout/update"
+    emit_json step name git-update status warn reason dirty
+    git_ref="$(git -C "$repo_dir" rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+    if [[ -z "$git_ref" || "$git_ref" == "HEAD" ]]; then
+      git_ref="$(git -C "$repo_dir" rev-parse --short HEAD 2>/dev/null || echo "HEAD")"
+    fi
+    log "Dirty checkout ref: ${git_ref}"
+  else
+    git_ref="$(resolve_git_openclaw_ref)"
     log "Using git ref: ${git_ref}"
     if [[ "$fresh_checkout" -eq 0 ]]; then
       emit_json step name git-update status start
     fi
     checkout_git_openclaw_ref "$repo_dir" "$git_ref"
+    assert_git_checkout_matches_ref "$repo_dir" "$git_ref"
     if [[ "$fresh_checkout" -eq 0 ]]; then
       emit_json step name git-update status ok
-    fi
-  else
-    log "Repo is dirty; skipping git checkout/update"
-    emit_json step name git-update status warn reason dirty
-    if git -C "$repo_dir" symbolic-ref --quiet HEAD >/dev/null; then
-      GIT_REF_KIND="moving"
-    else
-      GIT_REF_KIND="immutable"
     fi
   fi
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2731,7 +2731,14 @@ checkout_git_openclaw_ref() {
         fi
     done
 
+    # Fail closed: never substitute an older base tag (for example v2026.7.1
+    # when the requested npm correction release is v2026.7.1-2). That would
+    # silently install different code than the resolved registry version.
     ui_error "Requested git version not found: ${ref}"
+    if [[ "$ref" =~ ^v[0-9] ]]; then
+        ui_error "No matching GitHub tag for this version. Correction releases must publish an immutable tag that matches the npm version (for example v2026.7.1-2 for npm 2026.7.1-2)."
+        ui_error "Publish the missing tag, or use --install-method npm to install the registry package."
+    fi
     return 1
 }
 
@@ -2741,6 +2748,28 @@ git_install_lockfile_flag() {
     else
         echo "--frozen-lockfile"
     fi
+}
+
+# After checking out a version tag, require package.json to match exactly.
+# Prevents silent install of a different release if a wrong tag/commit is used.
+assert_git_checkout_matches_ref() {
+    local repo_dir="$1"
+    local ref="$2"
+    local expected=""
+    local actual=""
+
+    if [[ ! "$ref" =~ ^v[0-9] ]]; then
+        return 0
+    fi
+
+    expected="${ref#v}"
+    actual="$(openclaw_package_version "${repo_dir}/package.json")"
+    if [[ "$actual" != "$expected" ]]; then
+        ui_error "Git checkout version mismatch for ${ref}: package.json is ${actual}, expected ${expected}."
+        ui_error "Refusing to continue with a different OpenClaw version than the resolved git ref."
+        return 1
+    fi
+    return 0
 }
 
 validate_git_checkout_head() {
@@ -3265,7 +3294,7 @@ install_openclaw_from_git() {
         repo_dir="$(cd "$(dirname "$repo_dir")" && pwd -P)/$(basename "$repo_dir")"
     fi
 
-    if [[ -d "$repo_dir/.git" ]]; then
+    if [[ -e "$repo_dir/.git" ]]; then
         ui_info "Installing OpenClaw from git checkout: ${repo_dir}"
     else
         ui_info "Installing OpenClaw from GitHub (${repo_url})"
@@ -3285,17 +3314,24 @@ install_openclaw_from_git() {
     fi
 
     local git_ref
-    git_ref="$(resolve_git_openclaw_ref)"
-    if [[ -z "$(git -C "$repo_dir" status --porcelain 2>/dev/null || true)" ]]; then
+    # --no-git-update skips pull only (see checkout_git_openclaw_ref). Dirty
+    # trees keep the operator's work. Clean trees still resolve, check out, and
+    # validate the requested release so `--version vX --no-git-update` cannot
+    # silently build an unrelated HEAD.
+    if [[ -e "$repo_dir/.git" && -n "$(git -C "$repo_dir" status --porcelain 2>/dev/null || true)" ]]; then
+        # Dirty tree: keep the user's checkout. Do not call resolve_git_openclaw_ref
+        # (that fail-closes on missing release tags even when checkout is skipped).
+        ui_info "Repo has local changes; skipping git checkout/update"
+        git_ref="$(git -C "$repo_dir" rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+        if [[ -z "$git_ref" || "$git_ref" == "HEAD" ]]; then
+            git_ref="$(git -C "$repo_dir" rev-parse --short HEAD 2>/dev/null || echo "HEAD")"
+        fi
+        ui_info "Dirty checkout ref: ${git_ref}"
+    else
+        git_ref="$(resolve_git_openclaw_ref)"
         ui_info "Using git ref: ${git_ref}"
         checkout_git_openclaw_ref "$repo_dir" "$git_ref"
-    else
-        ui_info "Repo has local changes; skipping git checkout/update"
-        if git -C "$repo_dir" symbolic-ref --quiet HEAD >/dev/null; then
-            GIT_REF_KIND="moving"
-        else
-            GIT_REF_KIND="immutable"
-        fi
+        assert_git_checkout_matches_ref "$repo_dir" "$git_ref"
     fi
 
     cleanup_legacy_submodules "$repo_dir"

--- a/test/scripts/install-cli.test.ts
+++ b/test/scripts/install-cli.test.ts
@@ -996,6 +996,46 @@ describe("install-cli.sh", () => {
     expect(result.stdout).toContain("main=main");
   });
 
+  it("does not fall back to an older base tag for npm correction releases", () => {
+    expect(script).not.toContain("npm_republish_git_tag_fallback");
+    expect(script).toContain("Correction releases must publish an immutable tag");
+    expect(script).toContain("assert_git_checkout_matches_ref");
+    expect(script).toContain("--no-git-update skips pull only");
+    expect(script).toContain("still resolve/checkout/validate the requested release tag");
+  });
+
+  it("does not resolve npm release tags when the existing git checkout is dirty", () => {
+    expect(script).toContain("Dirty checkout ref:");
+    expect(script).toContain("never resolve npm tag");
+    expect(script).toMatch(/Repo is dirty; skipping git checkout\/update[\s\S]*Dirty checkout ref/);
+  });
+
+  it("asserts package.json version matches the checked-out version tag", () => {
+    const result = runInstallCliShell(`
+      set -euo pipefail
+      source "${SCRIPT_PATH}"
+      tmp="$(mktemp -d)"
+      printf '%s\\n' '{"name":"openclaw","version":"2026.7.1"}' > "$tmp/package.json"
+      set +e
+      (assert_git_checkout_matches_ref "$tmp" v2026.7.1-2)
+      mismatch=$?
+      set -e
+      printf 'mismatch=%s\\n' "$mismatch"
+      printf '%s\\n' '{"name":"openclaw","version":"2026.7.1-2"}' > "$tmp/package.json"
+      set +e
+      (assert_git_checkout_matches_ref "$tmp" v2026.7.1-2)
+      match=$?
+      set -e
+      printf 'match=%s\\n' "$match"
+      rm -rf "$tmp"
+    `);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("mismatch=1");
+    expect(result.stdout).toContain("match=0");
+    expect(result.stdout + result.stderr).toMatch(/version mismatch|expected 2026\.7\.1-2/i);
+  });
+
   it("keeps ref resolution and rebase failures explicit", () => {
     expect(script).toContain(
       'git -C "$repo_dir" fetch --no-tags origin "refs/heads/main:refs/remotes/origin/main"',

--- a/test/scripts/install-sh.test.ts
+++ b/test/scripts/install-sh.test.ts
@@ -3698,6 +3698,96 @@ EOF
     expect(result.stdout).toContain("main=main");
   });
 
+  it("does not fall back to an older base tag for npm correction releases", () => {
+    // Silent vX.Y.Z-N -> vX.Y.Z substitution installs different code than npm
+    // latest and was rejected (openclaw.ai#218 / openclaw#112754 review).
+    expect(script).not.toContain("npm_republish_git_tag_fallback");
+    expect(script).not.toMatch(/trying \$\{fallback_ref\}|trying v\$\{/);
+    expect(script).toContain("Correction releases must publish an immutable tag");
+    expect(script).toContain("assert_git_checkout_matches_ref");
+    expect(script).toContain("--no-git-update skips pull only");
+    expect(script).toContain("still resolve, check out, and");
+  });
+
+  it("does not resolve npm release tags when the existing git checkout is dirty", () => {
+    // Dirty trees skip checkout/update; resolving npm/latest first would fail-closed
+    // on missing tags even though the tree is intentionally left alone (#112754 P1).
+    expect(script).toContain("Dirty checkout ref:");
+    expect(script).toContain("Do not call resolve_git_openclaw_ref");
+    expect(script).toMatch(/local changes; skipping git checkout\/update[\s\S]*Dirty checkout ref/);
+  });
+
+  it("asserts package.json version matches the checked-out version tag", () => {
+    const home = (() => {
+      const result = runInstallShell(`
+        set -euo pipefail
+        source "${SCRIPT_PATH}"
+        tmp="$(mktemp -d)"
+        printf '%s\\n' '{"name":"openclaw","version":"2026.7.1"}' > "$tmp/package.json"
+        if assert_git_checkout_matches_ref "$tmp" v2026.7.1-2; then
+          printf 'mismatch_allowed=1\\n'
+        else
+          printf 'mismatch_rejected=1\\n'
+        fi
+        printf '%s\\n' '{"name":"openclaw","version":"2026.7.1-2"}' > "$tmp/package.json"
+        if assert_git_checkout_matches_ref "$tmp" v2026.7.1-2; then
+          printf 'match_ok=1\\n'
+        else
+          printf 'match_failed=1\\n'
+        fi
+        if assert_git_checkout_matches_ref "$tmp" main; then
+          printf 'main_skip=1\\n'
+        fi
+        rm -rf "$tmp"
+      `);
+      return result;
+    })();
+
+    expect(home.status).toBe(0);
+    expect(home.stdout).toContain("mismatch_rejected=1");
+    expect(home.stdout).not.toContain("mismatch_allowed=1");
+    expect(home.stdout).toContain("match_ok=1");
+    expect(home.stdout).toContain("main_skip=1");
+    expect(home.stderr + home.stdout).toMatch(/version mismatch|expected 2026\.7\.1-2/i);
+  });
+
+  it("fails closed when a version tag is missing instead of downgrading", () => {
+    const result = runInstallShell(`
+      set -euo pipefail
+      source "${SCRIPT_PATH}"
+      git() {
+        if [[ "$1" == "-C" && "$3" == "ls-remote" ]]; then
+          return 1
+        fi
+        if [[ "$1" == "-C" && "$3" == "fetch" ]]; then
+          return 0
+        fi
+        if [[ "$1" == "-C" && "$3" == "rev-parse" ]]; then
+          return 1
+        fi
+        return 1
+      }
+      run_quiet_step() {
+        shift
+        "$@"
+      }
+      ui_error() { printf 'error=%s\\n' "$*" >&2; }
+      ui_info() { printf 'info=%s\\n' "$*"; }
+      set +e
+      checkout_git_openclaw_ref /repo v2026.7.1-2
+      code=$?
+      set -e
+      printf 'exit=%s\\n' "$code"
+    `);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("exit=1");
+    expect(result.stderr + result.stdout).toMatch(
+      /Requested git version not found: v2026\.7\.1-2|Could not resolve requested git ref: v2026\.7\.1-2/,
+    );
+    expect(result.stderr + result.stdout).not.toMatch(/trying v2026\.7\.1[^-]/);
+  });
+
   it("keeps ref resolution and rebase failures explicit", () => {
     expect(script).toContain(
       'git -C "$repo_dir" fetch --no-tags origin "refs/heads/main:refs/remotes/origin/main"',


### PR DESCRIPTION
## What Problem This Solves

Git installs resolve `OPENCLAW_VERSION=latest` via the npm `latest` dist-tag. When that version is an npm correction release but GitHub has no matching tag, checkout must **fail closed** (never silent-downgrade). Dirty checkouts and `--no-git-update` must install the prepared tree **without** npm tag resolve. Detection must work for both normal `.git` directories and **git worktrees** (`.git` is a file).

Ref #144191

## Evidence

Dirty checkout on a real git worktree at tip `856ee6448eb2` (after-fix install path; `-e .git` worktree detection):

```console
$ OPENCLAW_INSTALL_SH_NO_RUN=1 bash -c 'source scripts/install.sh; install_openclaw_from_git /tmp/oc-112754-fresh'
· Installing OpenClaw from git checkout: /private/tmp/oc-112754-fresh
✓ Git already installed
✓ pnpm ready (pnpm)
· Repo has local changes; skipping git checkout/update
· Dirty checkout ref: fix/112754-install-tag-fallback
· Activating repo pnpm 11.15.1
· Installing dependencies
· Building UI
· Building OpenClaw
✓ OpenClaw wrapper installed to $HOME/.local/bin/openclaw
· This checkout uses pnpm — run pnpm install (or corepack pnpm install) for deps
```

Before the worktree fix, the same command printed `Installing OpenClaw from GitHub` and called `resolve_git_openclaw_ref` because `-d .git` is false for worktrees.

## Real behavior proof

- **Behavior or issue addressed:** Fail closed on missing tags / package mismatches; dirty and `--no-git-update` skip npm tag resolve; worktree checkouts count as git checkouts.
- **Real environment tested:** macOS arm64, worktree `/tmp/oc-112754-fresh` on PR tip `856ee6448eb2`; real dirty tree via proof marker file.
- **Exact steps or command run after this patch:** source `scripts/install.sh` with `OPENCLAW_INSTALL_SH_NO_RUN=1`; call production `install_openclaw_from_git` on the dirty worktree.
- **Evidence after fix:** terminal block above (dirty skip + install steps against preserved checkout; no tag resolve / no GitHub clone path).
- **Observed result after fix:** Worktree dirty path prints "Repo has local changes; skipping git checkout/update" and installs from the checkout instead of resolving npm tags.
- **What was not tested:** Full un-stubbed network `curl | bash` against production GitHub; publishing a real correction tag.

## Summary

- No silent downgrade on missing exact git tags
- package.json must match `v*` refs after checkout
- Dirty / `--no-git-update` skip npm tag resolve
- `-e .git` so git worktrees hit the same paths

## Related

Hosted-installer sync (if still needed) is a separate follow-up on the docs/install mirror. This PR does not close that tracker.

