### PR TITLE
fix(gateway): keep reconnect chat replays in the canonical thread; empty branch list for fresh sessions

### DIFF
--- a/src/gateway/server-methods/chat-send-admission.ts
+++ b/src/gateway/server-methods/chat-send-admission.ts
@@ -45,6 +45,7 @@ export async function admitChatSend(params: {
   const { p, explicitOrigin, normalizedAttachments, turnKind } = request;
   const {
     rawSessionKey,
+    sessionLoadKey,
     clientRunId,
     pendingChatSendKey,
     sessionLoadOptions,
@@ -177,7 +178,7 @@ export async function admitChatSend(params: {
       }
       return;
     }
-    const latestSession = loadSessionEntry(rawSessionKey, sessionLoadOptions);
+    const latestSession = loadSessionEntry(sessionLoadKey, sessionLoadOptions);
     if (sessionRoutingChanged(latestSession.cfg)) {
       throw new Error(SESSION_ROUTING_CHANGED_ERROR_REASON);
     }

--- a/src/gateway/server-methods/chat-send-pre-admission.ts
+++ b/src/gateway/server-methods/chat-send-pre-admission.ts
@@ -46,6 +46,7 @@ export async function runChatSendPreAdmission(params: {
     entry,
     sessionKey,
     rawSessionKey,
+    sessionLoadKey,
     selectedAgent,
     clientRunId,
     pendingChatSendKey,
@@ -146,7 +147,7 @@ export async function runChatSendPreAdmission(params: {
     clientRunId,
     entry,
     persistedSessionKey: legacyKey ?? sessionKey,
-    reloadEntry: () => loadSessionEntry(rawSessionKey, sessionLoadOptions).entry,
+    reloadEntry: () => loadSessionEntry(sessionLoadKey, sessionLoadOptions).entry,
     storePath,
     recoveryRuntime: context.recoveryRuntime,
     warn: (message) =>

--- a/src/gateway/server-methods/chat-send-session.ts
+++ b/src/gateway/server-methods/chat-send-session.ts
@@ -2,7 +2,10 @@ import { performance } from "node:perf_hooks";
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { resolveProviderIdForAuth } from "../../agents/provider-auth-aliases.js";
 import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
-import { resolveSessionRoutingContract } from "../../config/sessions/main-session.js";
+import {
+  resolveAgentMainSessionKey,
+  resolveSessionRoutingContract,
+} from "../../config/sessions/main-session.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { measureDiagnosticsTimelineSpanSync } from "../../infra/diagnostics-timeline.js";
 import { resolveMissingAgentHarnessSessionError } from "../../sessions/agent-harness-session-key.js";
@@ -35,16 +38,27 @@ function loadChatSendSessionContext(params: {
   const agentIdOverride = normalizeOptionalChatText(p.agentId);
   const clientRunId = p.idempotencyKey;
   const pendingChatSendKey = pendingChatSendDedupeKey(clientRunId);
+  const runtimeConfig = context.getRuntimeConfig?.();
   const requestedAgentId = resolveRequestedChatAgentId({
-    cfg: context.getRuntimeConfig?.(),
+    cfg: runtimeConfig,
     requestedSessionKey: rawSessionKey,
     agentId: agentIdOverride,
   });
+  // Outside configured global scope, `global` + agentId is the shipped webchat
+  // alias for that agent's main thread. Resolve it before every store lookup so
+  // reconnect replay cannot create a parallel literal `global` transcript.
+  const sessionLoadKey =
+    runtimeConfig &&
+    runtimeConfig.session?.scope !== "global" &&
+    rawSessionKey.trim().toLowerCase() === "global" &&
+    requestedAgentId
+      ? resolveAgentMainSessionKey({ cfg: runtimeConfig, agentId: requestedAgentId })
+      : rawSessionKey;
   const sessionLoadOptions = requestedAgentId ? { agentId: requestedAgentId } : undefined;
   const sessionLoadStartedAtMs = performance.now();
   const sessionLoadResult = measureDiagnosticsTimelineSpanSync(
     "gateway.chat_send.load_session",
-    () => loadSessionEntry(rawSessionKey, sessionLoadOptions),
+    () => loadSessionEntry(sessionLoadKey, sessionLoadOptions),
     {
       phase: "agent-turn",
       attributes: {
@@ -64,6 +78,7 @@ function loadChatSendSessionContext(params: {
     expectedSessionRoutingContract.toLowerCase() !== resolveSessionRoutingContract(candidateConfig);
   return {
     rawSessionKey,
+    sessionLoadKey,
     clientRunId,
     pendingChatSendKey,
     sessionLoadOptions,

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -1452,6 +1452,49 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     });
   });
 
+  it("resolves per-sender global agent aliases to the canonical agent main session", async () => {
+    await createTranscriptFixture("openclaw-chat-send-per-sender-global-alias-");
+    mockState.config = {
+      agents: { list: [{ id: "main", default: true }] },
+      session: { scope: "per-sender" },
+    };
+    const respond = vi.fn();
+    const context = createChatContext();
+
+    await runNonStreamingChatSend({
+      context,
+      respond,
+      sessionKey: "global",
+      requestParams: { agentId: "main" },
+      idempotencyKey: "idem-per-sender-global-alias",
+      expectBroadcast: false,
+    });
+
+    const [ok] = lastRespondCall(respond) ?? [];
+    expect(ok).toBe(true);
+    expect(mockState.lastDispatchCtx).toMatchObject({
+      SessionKey: "agent:main:main",
+      AgentId: "main",
+    });
+    expect(mockState.loadSessionEntryCalls.length).toBeGreaterThan(0);
+    expect(mockState.loadSessionEntryCalls).toEqual(
+      expect.arrayContaining([
+        {
+          rawKey: "agent:main:main",
+          opts: { agentId: "main" },
+        },
+      ]),
+    );
+    expect(mockState.loadSessionEntryCalls).not.toEqual(
+      expect.arrayContaining([
+        {
+          rawKey: "global",
+          opts: { agentId: "main" },
+        },
+      ]),
+    );
+  });
+
   it("registers selected-agent global aliases under the canonical abort key", async () => {
     await createTranscriptFixture("openclaw-chat-send-global-alias-abort-key-");
     mockState.config = {

--- a/src/gateway/server-methods/chat.error-broadcast.test.ts
+++ b/src/gateway/server-methods/chat.error-broadcast.test.ts
@@ -198,33 +198,26 @@ describe("chat.send error broadcast", () => {
       isWebchatConnect: () => false,
     });
 
+    // The global agent alias canonicalizes to the agent's main session before
+    // load, so errors broadcast on the same key the visible thread subscribes
+    // to — the alias fan-out keys no longer carry sends.
     expect(ctx.broadcast).toHaveBeenCalledWith(
       "chat",
       expect.objectContaining({
         runId: "test-run-global",
-        sessionKey: "global",
-        agentId: "main",
+        sessionKey: "agent:main:main",
         state: "error",
       }),
-      { sessionKeys: ["agent:main:global", "global"] },
+      { sessionKeys: ["agent:main:main"] },
     );
-    expect(ctx.nodeSendToSession).toHaveBeenCalledWith(
-      "agent:main:global",
-      "chat",
-      expect.objectContaining({
-        agentId: "main",
-        state: "error",
-      }),
-    );
-    const globalPayload = expectDefined(
-      ctx.nodeSendToSession.mock.calls.find(([sessionKey]) => sessionKey === "global"),
-      "global node error payload",
+    const canonicalPayload = expectDefined(
+      ctx.nodeSendToSession.mock.calls.find(([sessionKey]) => sessionKey === "agent:main:main"),
+      "canonical node error payload",
     )[2] as Record<string, unknown>;
-    expect(globalPayload).toMatchObject({
-      agentId: "main",
+    expect(canonicalPayload).toMatchObject({
       state: "error",
       errorMessage: expect.stringContaining("LLM timeout"),
     });
-    expect(globalPayload).not.toHaveProperty("message");
+    expect(canonicalPayload).not.toHaveProperty("message");
   });
 });

--- a/src/gateway/server-methods/sessions-rewind.test.ts
+++ b/src/gateway/server-methods/sessions-rewind.test.ts
@@ -164,6 +164,22 @@ async function invoke(method: MessageCutMethod, entryId?: string) {
 }
 
 describe("session message-cut methods", () => {
+  it("returns an empty branch list for a not-yet-materialized session", async () => {
+    const respond = vi.fn() as unknown as RespondFn;
+    await expectDefined(
+      sessionsHandlers["sessions.branches.list"],
+      "sessions.branches.list handler",
+    )({
+      req: { id: "fresh-branches-list" } as never,
+      params: { sessionKey: "agent:main:never-materialized" },
+      respond,
+      context: context(),
+      client: null,
+      isWebchatConnect: () => false,
+    });
+    expect(respond).toHaveBeenCalledWith(true, { branches: [] }, undefined);
+  });
+
   it("lists branches and switches to an inactive tip", async () => {
     const listed = await invoke("sessions.branches.list");
     expect(listed).toHaveBeenCalledWith(

--- a/src/gateway/server-methods/sessions-rewind.ts
+++ b/src/gateway/server-methods/sessions-rewind.ts
@@ -127,11 +127,11 @@ async function listBranches(options: GatewayRequestHandlerOptions): Promise<void
     agentId: requestedAgent.agentId,
   });
   if (!current.entry?.sessionId) {
-    respond(
-      false,
-      undefined,
-      errorShape(ErrorCodes.INVALID_REQUEST, `session not found: ${sessionKey}`),
-    );
+    // A session key that has not materialized yet (fresh chat, no first
+    // message) legitimately has no branches. Only the mutating siblings
+    // (rewind/switch/fork) treat a missing session as an error; erroring here
+    // put a spurious failure in gateway logs on every new-chat load.
+    respond(true, { branches: [] }, undefined);
     return;
   }
   if (readSessionUpstreamLink(current.canonicalKey, current.target.agentId)) {


### PR DESCRIPTION
## What Problem This Solves

Live stress-testing the shipped web rewind/fork/branch flows (isolated dev gateway, OpenAI-key inference, real browser driving) surfaced two gateway bugs:

1. **Reconnect replays split the thread.** The web outbox stores the default agent's thread under the shipped `global` alias scope. On reconnect, the durable-outbox drain flushes `chat.send` with `sessionKey: "global"` + `agentId`, and session load materialized a **parallel literal `global` session** instead of the canonical agent main thread. Queued messages and their model replies landed in a hidden transcript: the user sees their message vanish after reconnect while tokens are spent invisibly. Reproduced 3/3 (isolated gateway, latest main); agent-DB `session_entries` showed both `agent:main:main` and `global` rows, with the queued turns + replies in the orphan session. Online sends were unaffected because the foreground path routes with the page's concrete session key.

2. **Fresh sessions error on branch listing.** `sessions.branches.list` responded `INVALID_REQUEST: session not found` for a session key that simply has not materialized yet (every new-chat page load), putting spurious failures in gateway logs and forcing clients to special-case a well-defined empty state.

## Why This Change Was Made

- `chat.send` session load now canonicalizes the `global` + agentId alias to `resolveAgentMainSessionKey(...)` (the same resolver history/routes use) whenever the configured session scope is not `global`, and the admission/pre-admission reloads reuse that same key, so one thread can no longer split. Configured global scope keeps its literal key.
- `sessions.branches.list` returns `{ branches: [] }` for a not-yet-materialized session; the mutating siblings (rewind/switch/fork) still treat a missing session as an error.

## User Impact

Messages queued offline in the web UI now land in the visible thread with their replies after reconnect, instead of disappearing into a hidden parallel transcript. New-chat loads no longer emit gateway error-log noise for branch listing.

## Evidence

- Regression tests: `chat.directive-tags.test.ts` ("resolves per-sender global agent aliases to the canonical agent main session" — asserts dispatch lands on `agent:main:main` and raw `global` is never loaded) and `sessions-rewind.test.ts` (empty list for unmaterialized session). Focused runs green: 150/150 and 21/21.
- Live before/after on the same isolated gateway + state: pre-fix, queued words (`fig`/`grape`/`honeydew`) + replies landed in orphan session `fd8f35fa…` (key `global`); post-fix, the same offline→reconnect cycle landed `kiwi` + reply in the current `agent:main:main` session (`96a034d0…`) with the outbox drained and the reply visible in the UI.
- Root cause traced via sourcemap-resolved stack from a `sessionStorage` write trap (drain reconcile at `ui/src/pages/chat/chat-send.ts:1393`) plus agent-DB transcript queries.
