### PR TITLE
refactor: table-drive database-first legacy-store guard tests

### DIFF
--- a/test/scripts/check-database-first-legacy-stores.test.ts
+++ b/test/scripts/check-database-first-legacy-stores.test.ts
@@ -9,6 +9,25 @@ import {
   collectDatabaseFirstLegacyStoreViolations,
 } from "../../scripts/check-database-first-legacy-stores.mjs";
 
+type LegacyStoreViolations = ReturnType<typeof collectDatabaseFirstLegacyStoreViolations>;
+type UnnamedViolationCase = {
+  source: string;
+  filename: string;
+  expected: LegacyStoreViolations;
+};
+
+function sourceCase(source: TemplateStringsArray) {
+  return (filename: string, expected: LegacyStoreViolations): UnnamedViolationCase => ({
+    source: source.join(""),
+    filename,
+    expected,
+  });
+}
+
+function namedCases(cases: Record<string, UnnamedViolationCase>) {
+  return Object.entries(cases).map(([name, testCase]) => ({ name, ...testCase }));
+}
+
 describe("check-database-first-legacy-stores", () => {
   it("collects JavaScript runtime source files", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-db-first-guard-"));
@@ -97,9 +116,10 @@ describe("check-database-first-legacy-stores", () => {
     expect(violations).toEqual([]);
   });
 
-  it("terminates analysis for self-recursive helper wrappers", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+  // Core source analysis and initial legacy-store detection.
+  it.each(
+    namedCases({
+      "terminates analysis for self-recursive helper wrappers": sourceCase`
         function normalize(value: unknown): unknown {
           if (Array.isArray(value)) {
             return value.map((entry) => normalize(entry));
@@ -107,26 +127,19 @@ describe("check-database-first-legacy-stores", () => {
           return value;
         }
         normalize([]);
-      `,
-      "src/runtime/self-recursive-helper.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("flags runtime writes to legacy sessions.json stores", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/self-recursive-helper.ts", []),
+      "flags runtime writes to legacy sessions.json stores": sourceCase`
         import { promises as fs } from "node:fs";
         import path from "node:path";
         export async function save(dir: string) {
           await fs.writeFile(path.join(dir, "sessions.json"), "{}\\n", "utf8");
         }
-      `,
-      "src/runtime/session-writer.ts",
-    );
+      `("src/runtime/session-writer.ts", [{ kind: "legacy store filesystem write", line: 5 }]),
+    }),
+  )("$name", ({ source, filename, expected }) => {
+    const violations = collectDatabaseFirstLegacyStoreViolations(source, filename);
 
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 5 }]);
+    expect(violations).toEqual(expected);
   });
 
   it("keeps legacy restart sentinel filesystem access in its sole migration owner", () => {
@@ -155,360 +168,185 @@ describe("check-database-first-legacy-stores", () => {
     expect(migrationViolations).toEqual([]);
   });
 
-  it("flags legacy restart sentinel references outside the migration owner", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+  // Legacy paths and literal propagation.
+  it.each(
+    namedCases({
+      "flags legacy restart sentinel references outside the migration owner": sourceCase`
         const legacyPath = path.join(stateDir, "restart-sentinel.json");
         await readFile(legacyPath, "utf8");
-      `,
-      "src/commands/doctor/state-migrations.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy restart sentinel reference", line: 2 }]);
-  });
-
-  it("allows the CLI preflight to detect exact legacy restart sentinel inputs", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/commands/doctor/state-migrations.ts", [
+        { kind: "legacy restart sentinel reference", line: 2 },
+      ]),
+      "allows the CLI preflight to detect exact legacy restart sentinel inputs": sourceCase`
         [
           path.join(stateDir, "restart-sentinel.json"),
           path.join(stateDir, "restart-sentinel.json.doctor-importing"),
         ].some(fileOrDirExists);
-      `,
-      "src/cli/program/config-guard.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("flags direct legacy restart sentinel reads from the CLI preflight", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/cli/program/config-guard.ts", []),
+      "flags direct legacy restart sentinel reads from the CLI preflight": sourceCase`
         await readFile(path.join(stateDir, "restart-sentinel.json"), "utf8");
         await readFile(path.join(stateDir, "restart-sentinel.json.doctor-importing"), "utf8");
-      `,
-      "src/cli/program/config-guard.ts",
-    );
-
-    expect(violations).toEqual([
-      { kind: "legacy restart sentinel reference", line: 2 },
-      { kind: "legacy restart sentinel reference", line: 3 },
-    ]);
-  });
-
-  it("flags nested restart sentinel paths disguised as CLI preflight detection", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/cli/program/config-guard.ts", [
+        { kind: "legacy restart sentinel reference", line: 2 },
+        { kind: "legacy restart sentinel reference", line: 3 },
+      ]),
+      "flags nested restart sentinel paths disguised as CLI preflight detection": sourceCase`
         [path.join(stateDir, "archive/restart-sentinel.json")].some(fileOrDirExists);
-      `,
-      "src/cli/program/config-guard.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy restart sentinel reference", line: 2 }]);
-  });
-
-  it("flags retired Diffs viewer sidecar writes", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/cli/program/config-guard.ts", [
+        { kind: "legacy restart sentinel reference", line: 2 },
+      ]),
+      "flags retired Diffs viewer sidecar writes": sourceCase`
         import { promises as fs } from "node:fs";
         import path from "node:path";
         await fs.writeFile(path.join(root, id, "viewer.html"), html);
         await fs.writeFile(path.join(root, id, "meta.json"), metadata);
         await fs.writeFile(path.join(root, id, "file-meta.json"), metadata);
-      `,
-      "extensions/diffs/src/legacy-store.ts",
-    );
-
-    expect(violations).toEqual([
-      { kind: "legacy store filesystem write", line: 4 },
-      { kind: "legacy store filesystem write", line: 5 },
-      { kind: "legacy store filesystem write", line: 6 },
-    ]);
-  });
-
-  it("flags retired QMD file-lock sidecars", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("extensions/diffs/src/legacy-store.ts", [
+        { kind: "legacy store filesystem write", line: 4 },
+        { kind: "legacy store filesystem write", line: 5 },
+        { kind: "legacy store filesystem write", line: 6 },
+      ]),
+      "flags retired QMD file-lock sidecars": sourceCase`
         import { withFileLock } from "openclaw/plugin-sdk/file-lock";
         import path from "node:path";
         await withFileLock(path.join(stateDir, "qmd", "embed.lock"), options, task);
         await withFileLock(path.join(agentDir, "qmd-write.lock"), options, task);
-      `,
-      "extensions/memory-core/src/memory/qmd-locks.ts",
-    );
-
-    expect(violations).toEqual([
-      { kind: "legacy store filesystem write", line: 4 },
-      { kind: "legacy store filesystem write", line: 5 },
-    ]);
-  });
-
-  it("flags writes through local variables initialized from legacy store paths", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("extensions/memory-core/src/memory/qmd-locks.ts", [
+        { kind: "legacy store filesystem write", line: 4 },
+        { kind: "legacy store filesystem write", line: 5 },
+      ]),
+      "flags writes through local variables initialized from legacy store paths": sourceCase`
         import { promises as fs } from "node:fs";
         import path from "node:path";
         export async function save(dir: string) {
           const storePath = path.join(dir, "sessions.json");
           await fs.writeFile(storePath, "{}\\n", "utf8");
         }
-      `,
-      "src/runtime/session-writer.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 6 }]);
-  });
-
-  it("flags writes through property access on legacy path variables", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/session-writer.ts", [{ kind: "legacy store filesystem write", line: 6 }]),
+      "flags writes through property access on legacy path variables": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         const storePath = "sessions.json";
         await writeTextAtomic(storePath.toString(), "{}\\n");
-      `,
-      "src/runtime/legacy-path-property-access.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 4 }]);
-  });
-
-  it("flags legacy paths split across path.join segments", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/legacy-path-property-access.ts", [
+        { kind: "legacy store filesystem write", line: 4 },
+      ]),
+      "flags legacy paths split across path.join segments": sourceCase`
         import { promises as fs } from "node:fs";
         import path from "node:path";
         await fs.writeFile(path.join(stateDir, "cron", "jobs.json"), "{}\\n", "utf8");
         const sidecarPath = path.join(root, "plugin-state", "state.sqlite");
         await fs.writeFile(sidecarPath, "");
-      `,
-      "src/runtime/legacy-state.ts",
-    );
-
-    expect(violations).toEqual([
-      { kind: "legacy store filesystem write", line: 4 },
-      { kind: "legacy store filesystem write", line: 6 },
-    ]);
-  });
-
-  it("flags runtime writes to the retired TUI last-session store", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/legacy-state.ts", [
+        { kind: "legacy store filesystem write", line: 4 },
+        { kind: "legacy store filesystem write", line: 6 },
+      ]),
+      "flags runtime writes to the retired TUI last-session store": sourceCase`
         import { promises as fs } from "node:fs";
         import path from "node:path";
         await fs.writeFile(path.join(stateDir, "tui", "last-session.json"), "{}\\n");
-      `,
-      "src/tui/last-session-writer.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 4 }]);
-  });
-
-  it("flags runtime writes to the retired commitments JSON store", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/tui/last-session-writer.ts", [{ kind: "legacy store filesystem write", line: 4 }]),
+      "flags runtime writes to the retired commitments JSON store": sourceCase`
         import { promises as fs } from "node:fs";
         import path from "node:path";
         await fs.writeFile(path.join(stateDir, "commitments", "commitments.json"), "{}\\n");
-      `,
-      "src/commitments/file-store.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 4 }]);
-  });
-
-  it("flags runtime writes to retired core audit JSONL stores", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/commitments/file-store.ts", [{ kind: "legacy store filesystem write", line: 4 }]),
+      "flags runtime writes to retired core audit JSONL stores": sourceCase`
         import { promises as fs } from "node:fs";
         import path from "node:path";
         await fs.appendFile(path.join(stateDir, "logs", "config-audit.jsonl"), "{}\\n");
         await fs.appendFile(path.join(stateDir, "audit", "system-agent.jsonl"), "{}\\n");
-      `,
-      "src/infra/audit-writer.ts",
-    );
-
-    expect(violations).toEqual([
-      { kind: "legacy store filesystem write", line: 4 },
-      { kind: "legacy store filesystem write", line: 5 },
-    ]);
-  });
-
-  it("flags runtime writes to retired managed-image record JSON", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/infra/audit-writer.ts", [
+        { kind: "legacy store filesystem write", line: 4 },
+        { kind: "legacy store filesystem write", line: 5 },
+      ]),
+      "flags runtime writes to retired managed-image record JSON": sourceCase`
         import { promises as fs } from "node:fs";
         import path from "node:path";
         await fs.writeFile(path.join(stateDir, "media", "outgoing", "records", \`\${id}.json\`), "{}\n");
-      `,
-      "src/gateway/managed-image-file-store.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 4 }]);
-  });
-
-  it("flags runtime writes to retired Web Push JSON stores", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/gateway/managed-image-file-store.ts", [
+        { kind: "legacy store filesystem write", line: 4 },
+      ]),
+      "flags runtime writes to retired Web Push JSON stores": sourceCase`
         import { promises as fs } from "node:fs";
         import path from "node:path";
         await fs.writeFile(path.join(stateDir, "push", "web-push-subscriptions.json"), "{}\n");
         await fs.writeFile(path.join(stateDir, "push", "vapid-keys.json"), "{}\n");
-      `,
-      "src/infra/push-web-file-store.ts",
-    );
-
-    expect(violations).toEqual([
-      { kind: "legacy store filesystem write", line: 4 },
-      { kind: "legacy store filesystem write", line: 6 },
-    ]);
-  });
-
-  it("flags runtime writes to the retired APNs registration store", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/infra/push-web-file-store.ts", [
+        { kind: "legacy store filesystem write", line: 4 },
+        { kind: "legacy store filesystem write", line: 6 },
+      ]),
+      "flags runtime writes to the retired APNs registration store": sourceCase`
         import { promises as fs } from "node:fs";
         import path from "node:path";
         await fs.writeFile(path.join(stateDir, "push", "apns-registrations.json"), "{}\n");
-      `,
-      "src/infra/push-apns-file-store.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 4 }]);
-  });
-
-  it("flags runtime writes to the retired node-host JSON config", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/infra/push-apns-file-store.ts", [{ kind: "legacy store filesystem write", line: 4 }]),
+      "flags runtime writes to the retired node-host JSON config": sourceCase`
         import { promises as fs } from "node:fs";
         import path from "node:path";
         await fs.writeFile(path.join(stateDir, "node.json"), "{}\n");
-      `,
-      "src/node-host/config-file-store.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 4 }]);
-  });
-
-  it("flags runtime writes to retired workspace setup and attestation sidecars", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/node-host/config-file-store.ts", [{ kind: "legacy store filesystem write", line: 4 }]),
+      "flags runtime writes to retired workspace setup and attestation sidecars": sourceCase`
         import { promises as fs } from "node:fs";
         import path from "node:path";
         await fs.writeFile(path.join(workspaceDir, "openclaw-workspace-state.json"), "{}\\n");
         await fs.writeFile(path.join(workspaceDir, ".openclaw", "workspace-state.json"), "{}\\n");
         await fs.writeFile(path.join(stateDir, "workspace-attestations", \`\${workspaceKey}.attested\`), "ok\\n");
         await fs.writeFile(\`\${workspaceDir}.attested\`, "ok\\n");
-      `,
-      "src/agents/workspace-sidecar-store.ts",
-    );
-
-    expect(violations).toEqual([
-      { kind: "legacy store filesystem write", line: 4 },
-      { kind: "legacy store filesystem write", line: 5 },
-      { kind: "legacy store filesystem write", line: 6 },
-      { kind: "legacy store filesystem write", line: 7 },
-    ]);
-  });
-
-  it("flags runtime writes to the retired native hook relay JSON registry", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/agents/workspace-sidecar-store.ts", [
+        { kind: "legacy store filesystem write", line: 4 },
+        { kind: "legacy store filesystem write", line: 5 },
+        { kind: "legacy store filesystem write", line: 6 },
+        { kind: "legacy store filesystem write", line: 7 },
+      ]),
+      "flags runtime writes to the retired native hook relay JSON registry": sourceCase`
         import { promises as fs } from "node:fs";
         import path from "node:path";
         await fs.writeFile(path.join("/tmp", "openclaw-native-hook-relays-501", "relay.json"), "{}\n");
-      `,
-      "src/agents/harness/native-hook-relay-file-store.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 4 }]);
-  });
-
-  it("flags runtime writes to the retired subagent JSON registry", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/agents/harness/native-hook-relay-file-store.ts", [
+        { kind: "legacy store filesystem write", line: 4 },
+      ]),
+      "flags runtime writes to the retired subagent JSON registry": sourceCase`
         import { promises as fs } from "node:fs";
         import path from "node:path";
         await fs.writeFile(path.join(stateDir, "subagents", "runs.json"), "{}\n");
-      `,
-      "src/agents/subagent-registry-file-store.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 4 }]);
-  });
-
-  it("flags runtime writes to retired skill-upload staging", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/agents/subagent-registry-file-store.ts", [
+        { kind: "legacy store filesystem write", line: 4 },
+      ]),
+      "flags runtime writes to retired skill-upload staging": sourceCase`
         import { promises as fs } from "node:fs";
         import path from "node:path";
         await fs.writeFile(path.join(stateDir, "tmp", "skill-uploads", uploadId, "metadata.json"), "{}\n");
-      `,
-      "src/skills/lifecycle/upload-file-store.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 4 }]);
-  });
-
-  it("flags runtime writes to retired system-agent rescue approval stores", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/skills/lifecycle/upload-file-store.ts", [
+        { kind: "legacy store filesystem write", line: 4 },
+      ]),
+      "flags runtime writes to retired system-agent rescue approval stores": sourceCase`
         import { promises as fs } from "node:fs";
         import path from "node:path";
         await fs.writeFile(path.join(stateDir, "openclaw", "rescue-pending", \`\${key}.json\`), "{}\\n");
         await fs.writeFile(path.join(stateDir, "crestodian", "rescue-pending", "old.json"), "{}\\n");
-      `,
-      "src/system-agent/rescue-writer.ts",
-    );
-
-    expect(violations).toEqual([
-      { kind: "legacy store filesystem write", line: 4 },
-      { kind: "legacy store filesystem write", line: 5 },
-    ]);
-  });
-
-  it("flags legacy paths with dynamic agent id segments", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/system-agent/rescue-writer.ts", [
+        { kind: "legacy store filesystem write", line: 4 },
+        { kind: "legacy store filesystem write", line: 5 },
+      ]),
+      "flags legacy paths with dynamic agent id segments": sourceCase`
         import { promises as fs } from "node:fs";
         import path from "node:path";
         await fs.writeFile(path.join(stateDir, "agents", agentId, "agent", "auth.json"), "{}\\n");
-      `,
-      "src/runtime/dynamic-agent-auth.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 4 }]);
-  });
-
-  it("flags legacy paths with dynamic segments and constant filenames", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/dynamic-agent-auth.ts", [{ kind: "legacy store filesystem write", line: 4 }]),
+      "flags legacy paths with dynamic segments and constant filenames": sourceCase`
         import { promises as fs } from "node:fs";
         import path from "node:path";
         const AUTH_FILE = "auth.json";
         await fs.writeFile(path.join(stateDir, "agents", agentId, "agent", AUTH_FILE), "{}\\n");
-      `,
-      "src/runtime/dynamic-agent-auth-constant.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 5 }]);
-  });
-
-  it("flags legacy JSONL paths with dynamic template filenames", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/dynamic-agent-auth-constant.ts", [
+        { kind: "legacy store filesystem write", line: 5 },
+      ]),
+      "flags legacy JSONL paths with dynamic template filenames": sourceCase`
         import { promises as fs } from "node:fs";
         import path from "node:path";
         await fs.appendFile(path.join(stateDir, "cron", "runs", \`\${runId}.jsonl\`), "{}\\n");
-      `,
-      "src/runtime/dynamic-cron-run.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 4 }]);
-  });
-
-  it("flags legacy paths assembled from filename constants", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/dynamic-cron-run.ts", [{ kind: "legacy store filesystem write", line: 4 }]),
+      "flags legacy paths assembled from filename constants": sourceCase`
         import { promises as fs } from "node:fs";
         import path from "node:path";
         const STORE_FILE = "sessions.json";
@@ -518,38 +356,22 @@ describe("check-database-first-legacy-stores", () => {
         await fs.writeFile(storePath, "{}\\n", "utf8");
         await fs.writeFile(path.join(stateDir, "cron", JOBS_FILE), "{}\\n");
         await fs.writeFile(path.join(stateDir, "plugin-state", SQLITE_FILE), "");
-      `,
-      "src/runtime/constant-session-store.ts",
-    );
-
-    expect(violations).toEqual([
-      { kind: "legacy store filesystem write", line: 8 },
-      { kind: "legacy store filesystem write", line: 9 },
-      { kind: "legacy store filesystem write", line: 10 },
-    ]);
-  });
-
-  it("flags legacy paths assembled from template literal constants", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/constant-session-store.ts", [
+        { kind: "legacy store filesystem write", line: 8 },
+        { kind: "legacy store filesystem write", line: 9 },
+        { kind: "legacy store filesystem write", line: 10 },
+      ]),
+      "flags legacy paths assembled from template literal constants": sourceCase`
         import { promises as fs } from "node:fs";
         const sessionBase = "sessions";
         const cronRuns = "cron/runs";
         await fs.writeFile(\`\${sessionBase}.json\`, "{}\\n");
         await fs.appendFile(\`\${cronRuns}/job.jsonl\`, "{}\\n");
-      `,
-      "src/runtime/template-constant-legacy-store.ts",
-    );
-
-    expect(violations).toEqual([
-      { kind: "legacy store filesystem write", line: 5 },
-      { kind: "legacy store filesystem write", line: 6 },
-    ]);
-  });
-
-  it("does not leak conditional literal path constants", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/template-constant-legacy-store.ts", [
+        { kind: "legacy store filesystem write", line: 5 },
+        { kind: "legacy store filesystem write", line: 6 },
+      ]),
+      "does not leak conditional literal path constants": sourceCase`
         import { promises as fs } from "node:fs";
         import path from "node:path";
         const JOBS_FILE = "current.json";
@@ -558,16 +380,8 @@ describe("check-database-first-legacy-stores", () => {
           console.log(JOBS_FILE);
         }
         await fs.writeFile(path.join(stateDir, "cron", JOBS_FILE), "{}\\n");
-      `,
-      "src/runtime/conditional-literal-shadow.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("keeps conditional literal reassignment candidates", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/conditional-literal-shadow.ts", []),
+      "keeps conditional literal reassignment candidates": sourceCase`
         import { promises as fs } from "node:fs";
         import path from "node:path";
         let JOBS_FILE = "current.json";
@@ -575,16 +389,10 @@ describe("check-database-first-legacy-stores", () => {
           JOBS_FILE = "jobs.json";
         }
         await fs.writeFile(path.join(stateDir, "cron", JOBS_FILE), "{}\\n");
-      `,
-      "src/runtime/conditional-literal-reassignment.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 8 }]);
-  });
-
-  it("keeps known literal candidates when conditional reassignment is dynamic", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/conditional-literal-reassignment.ts", [
+        { kind: "legacy store filesystem write", line: 8 },
+      ]),
+      "keeps known literal candidates when conditional reassignment is dynamic": sourceCase`
         import { promises as fs } from "node:fs";
         import path from "node:path";
         let JOBS_FILE = "jobs.json";
@@ -592,16 +400,10 @@ describe("check-database-first-legacy-stores", () => {
           JOBS_FILE = getJobsFile();
         }
         await fs.writeFile(path.join(stateDir, "cron", JOBS_FILE), "{}\\n");
-      `,
-      "src/runtime/conditional-dynamic-literal-reassignment.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 8 }]);
-  });
-
-  it("drops stale literal candidates after exhaustive branch reassignment", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/conditional-dynamic-literal-reassignment.ts", [
+        { kind: "legacy store filesystem write", line: 8 },
+      ]),
+      "drops stale literal candidates after exhaustive branch reassignment": sourceCase`
         import { promises as fs } from "node:fs";
         import path from "node:path";
         let JOBS_FILE = "jobs.json";
@@ -611,16 +413,8 @@ describe("check-database-first-legacy-stores", () => {
           JOBS_FILE = "active.json";
         }
         await fs.writeFile(path.join(stateDir, "cron", JOBS_FILE), "{}\\n");
-      `,
-      "src/runtime/exhaustive-literal-reassignment.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("keeps known literal candidates after exhaustive dynamic branch reassignment", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/exhaustive-literal-reassignment.ts", []),
+      "keeps known literal candidates after exhaustive dynamic branch reassignment": sourceCase`
         import { promises as fs } from "node:fs";
         import path from "node:path";
         let JOBS_FILE = "current.json";
@@ -630,16 +424,10 @@ describe("check-database-first-legacy-stores", () => {
           JOBS_FILE = getJobsFile();
         }
         await fs.writeFile(path.join(stateDir, "cron", JOBS_FILE), "{}\\n");
-      `,
-      "src/runtime/exhaustive-dynamic-literal-reassignment.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 10 }]);
-  });
-
-  it("drops stale literal candidates after exhaustive dynamic branch reassignment", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/exhaustive-dynamic-literal-reassignment.ts", [
+        { kind: "legacy store filesystem write", line: 10 },
+      ]),
+      "drops stale literal candidates after exhaustive dynamic branch reassignment": sourceCase`
         import { promises as fs } from "node:fs";
         import path from "node:path";
         let JOBS_FILE = "jobs.json";
@@ -649,57 +437,39 @@ describe("check-database-first-legacy-stores", () => {
           JOBS_FILE = getJobsFile();
         }
         await fs.writeFile(path.join(stateDir, "cron", JOBS_FILE), "{}\\n");
-      `,
-      "src/runtime/exhaustive-dynamic-stale-literal-reassignment.ts",
-    );
+      `("src/runtime/exhaustive-dynamic-stale-literal-reassignment.ts", []),
+    }),
+  )("$name", ({ source, filename, expected }) => {
+    const violations = collectDatabaseFirstLegacyStoreViolations(source, filename);
 
-    expect(violations).toEqual([]);
+    expect(violations).toEqual(expected);
   });
 
-  it("flags imported and destructured fs write aliases", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+  // Filesystem bindings, aliases, and helper writes.
+  it.each(
+    namedCases({
+      "flags imported and destructured fs write aliases": sourceCase`
         import fs, { writeFile as persist } from "node:fs/promises";
         const { appendFile: append } = fs;
         await persist("sessions.json", "{}\\n", "utf8");
         await append("cron/runs/job.jsonl", "{}\\n");
-      `,
-      "src/runtime/aliased-fs.ts",
-    );
-
-    expect(violations).toEqual([
-      { kind: "legacy store filesystem write", line: 4 },
-      { kind: "legacy store filesystem write", line: 5 },
-    ]);
-  });
-
-  it("flags helper writes through namespace imports", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/aliased-fs.ts", [
+        { kind: "legacy store filesystem write", line: 4 },
+        { kind: "legacy store filesystem write", line: 5 },
+      ]),
+      "flags helper writes through namespace imports": sourceCase`
         import * as jsonFiles from "../infra/json-files.js";
         await jsonFiles.writeJson("sessions.json", {});
-      `,
-      "src/runtime/helper-namespace-write.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 3 }]);
-  });
-
-  it("flags private file store writes to legacy paths", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/helper-namespace-write.ts", [
+        { kind: "legacy store filesystem write", line: 3 },
+      ]),
+      "flags private file store writes to legacy paths": sourceCase`
         import { privateFileStore } from "openclaw/plugin-sdk/security-runtime";
         await privateFileStore(stateDir).writeJson("thread-bindings.json", {});
-      `,
-      "src/runtime/private-file-store-write.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 3 }]);
-  });
-
-  it("flags fs-safe factory aliases writing legacy paths", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/private-file-store-write.ts", [
+        { kind: "legacy store filesystem write", line: 3 },
+      ]),
+      "flags fs-safe factory aliases writing legacy paths": sourceCase`
         import { privateFileStore } from "openclaw/plugin-sdk/security-runtime";
         import * as fsSafe from "openclaw/plugin-sdk/security-runtime";
         const makePrivateStore = privateFileStore;
@@ -708,131 +478,71 @@ describe("check-database-first-legacy-stores", () => {
         await makePrivateStore(stateDir).writeJson("thread-bindings.json", {});
         await (await makeRoot(stateDir)).writeJson("plugin-binding-approvals.json", {});
         await makeFromNamespace(stateDir).writeJson("gateway-restart-intent.json", {});
-      `,
-      "src/runtime/fs-safe-factory-alias-write.ts",
-    );
-
-    expect(violations).toEqual([
-      { kind: "legacy store filesystem write", line: 7 },
-      { kind: "legacy store filesystem write", line: 8 },
-      { kind: "legacy store filesystem write", line: 9 },
-    ]);
-  });
-
-  it("flags fs-safe root writes to legacy paths", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/fs-safe-factory-alias-write.ts", [
+        { kind: "legacy store filesystem write", line: 7 },
+        { kind: "legacy store filesystem write", line: 8 },
+        { kind: "legacy store filesystem write", line: 9 },
+      ]),
+      "flags fs-safe root writes to legacy paths": sourceCase`
         import { root } from "openclaw/plugin-sdk/security-runtime";
         const state = await root(stateDir);
         await state.writeJson("plugin-binding-approvals.json", {});
         await (await root(stateDir)).writeJson("thread-bindings.json", {});
-      `,
-      "src/runtime/fs-safe-root-write.ts",
-    );
-
-    expect(violations).toEqual([
-      { kind: "legacy store filesystem write", line: 4 },
-      { kind: "legacy store filesystem write", line: 5 },
-    ]);
-  });
-
-  it("flags bare fs-safe package root writes to legacy paths", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/fs-safe-root-write.ts", [
+        { kind: "legacy store filesystem write", line: 4 },
+        { kind: "legacy store filesystem write", line: 5 },
+      ]),
+      "flags bare fs-safe package root writes to legacy paths": sourceCase`
         import { root } from "@openclaw/fs-safe";
         const state = await root(stateDir);
         await state.writeJson("thread-bindings.json", {});
-      `,
-      "src/runtime/bare-fs-safe-root-write.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 4 }]);
-  });
-
-  it("flags file access runtime root writes to legacy paths", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/bare-fs-safe-root-write.ts", [
+        { kind: "legacy store filesystem write", line: 4 },
+      ]),
+      "flags file access runtime root writes to legacy paths": sourceCase`
         import { root } from "openclaw/plugin-sdk/file-access-runtime";
         const state = await root(stateDir);
         await state.writeJson("thread-bindings.json", {});
-      `,
-      "extensions/example/src/runtime/file-access-root-write.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 4 }]);
-  });
-
-  it("flags fs-safe store root writes to legacy paths", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("extensions/example/src/runtime/file-access-root-write.ts", [
+        { kind: "legacy store filesystem write", line: 4 },
+      ]),
+      "flags fs-safe store root writes to legacy paths": sourceCase`
         import { privateFileStore } from "openclaw/plugin-sdk/security-runtime";
         const state = await privateFileStore(stateDir).root();
         await state.writeJson("thread-bindings.json", {});
         await (await privateFileStore(stateDir).root()).writeJson("plugin-binding-approvals.json", {});
-      `,
-      "src/runtime/fs-safe-store-root-write.ts",
-    );
-
-    expect(violations).toEqual([
-      { kind: "legacy store filesystem write", line: 4 },
-      { kind: "legacy store filesystem write", line: 5 },
-    ]);
-  });
-
-  it("allows fs-safe store reads from legacy paths", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/fs-safe-store-root-write.ts", [
+        { kind: "legacy store filesystem write", line: 4 },
+        { kind: "legacy store filesystem write", line: 5 },
+      ]),
+      "allows fs-safe store reads from legacy paths": sourceCase`
         import { privateFileStore } from "openclaw/plugin-sdk/security-runtime";
         const store = privateFileStore(stateDir);
         await store.readJson("thread-bindings.json");
-      `,
-      "src/runtime/private-file-store-read.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("flags fs-safe JSON store writes to legacy paths", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/private-file-store-read.ts", []),
+      "flags fs-safe JSON store writes to legacy paths": sourceCase`
         import { privateFileStore } from "openclaw/plugin-sdk/security-runtime";
         await privateFileStore(stateDir).json("thread-bindings.json").write({});
         const bindings = privateFileStore(stateDir).json("plugin-binding-approvals.json");
         await bindings.update((current) => current ?? {});
         await privateFileStore(stateDir).json("gateway-restart-intent.json").updateOr({}, (current) => current);
-      `,
-      "src/runtime/private-file-json-store-write.ts",
-    );
-
-    expect(violations).toEqual([
-      { kind: "legacy store filesystem write", line: 3 },
-      { kind: "legacy store filesystem write", line: 5 },
-      { kind: "legacy store filesystem write", line: 6 },
-    ]);
-  });
-
-  it("flags direct fs-safe package store writes to legacy paths", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/private-file-json-store-write.ts", [
+        { kind: "legacy store filesystem write", line: 3 },
+        { kind: "legacy store filesystem write", line: 5 },
+        { kind: "legacy store filesystem write", line: 6 },
+      ]),
+      "flags direct fs-safe package store writes to legacy paths": sourceCase`
         import { fileStore, jsonStore } from "@openclaw/fs-safe/store";
         await fileStore({ rootDir: stateDir }).writeJson("thread-bindings.json", {});
         const options = { filePath: "plugin-binding-approvals.json" };
         await jsonStore(options).write({});
         await jsonStore({ filePath: "gateway-restart-intent.json" }).update((current) => current ?? {});
-      `,
-      "src/runtime/direct-fs-safe-store-write.ts",
-    );
-
-    expect(violations).toEqual([
-      { kind: "legacy store filesystem write", line: 3 },
-      { kind: "legacy store filesystem write", line: 5 },
-      { kind: "legacy store filesystem write", line: 6 },
-    ]);
-  });
-
-  it("flags fs-safe store object aliases writing legacy paths", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/direct-fs-safe-store-write.ts", [
+        { kind: "legacy store filesystem write", line: 3 },
+        { kind: "legacy store filesystem write", line: 5 },
+        { kind: "legacy store filesystem write", line: 6 },
+      ]),
+      "flags fs-safe store object aliases writing legacy paths": sourceCase`
         import { privateFileStore } from "openclaw/plugin-sdk/security-runtime";
         const jsonBindings = privateFileStore(stateDir).json("plugin-binding-approvals.json");
         const stores = {
@@ -845,53 +555,31 @@ describe("check-database-first-legacy-stores", () => {
         stores.bindings = privateFileStore(stateDir).json("gateway-restart-intent.json");
         await stores.state.writeJson("thread-bindings.json", {});
         await stores.bindings.update((current) => current ?? {});
-      `,
-      "src/runtime/fs-safe-store-object-alias-write.ts",
-    );
-
-    expect(violations).toEqual([
-      { kind: "legacy store filesystem write", line: 8 },
-      { kind: "legacy store filesystem write", line: 9 },
-      { kind: "legacy store filesystem write", line: 13 },
-    ]);
-  });
-
-  it("flags fs-safe store object aliases copied through spreads and nested objects", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/fs-safe-store-object-alias-write.ts", [
+        { kind: "legacy store filesystem write", line: 8 },
+        { kind: "legacy store filesystem write", line: 9 },
+        { kind: "legacy store filesystem write", line: 13 },
+      ]),
+      "flags fs-safe store object aliases copied through spreads and nested objects": sourceCase`
         import { privateFileStore } from "openclaw/plugin-sdk/security-runtime";
         const base = { state: privateFileStore(stateDir) };
         const stores = { ...base };
         const nested = { inner: { bindings: privateFileStore(stateDir).json("plugin-binding-approvals.json") } };
         await stores.state.writeJson("thread-bindings.json", {});
         await nested.inner.bindings.write({});
-      `,
-      "src/runtime/fs-safe-store-spread-object-alias-write.ts",
-    );
-
-    expect(violations).toEqual([
-      { kind: "legacy store filesystem write", line: 6 },
-      { kind: "legacy store filesystem write", line: 7 },
-    ]);
-  });
-
-  it("flags fs-safe store object aliases assigned through nested object properties", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/fs-safe-store-spread-object-alias-write.ts", [
+        { kind: "legacy store filesystem write", line: 6 },
+        { kind: "legacy store filesystem write", line: 7 },
+      ]),
+      "flags fs-safe store object aliases assigned through nested object properties": sourceCase`
         import { privateFileStore } from "openclaw/plugin-sdk/security-runtime";
         const stores = {};
         stores.inner = { bindings: privateFileStore(stateDir).json("thread-bindings.json") };
         await stores.inner.bindings.write({});
-      `,
-      "src/runtime/assigned-nested-fs-safe-store-object-alias.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 5 }]);
-  });
-
-  it("flags fs-safe store object aliases copied through destructuring", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/assigned-nested-fs-safe-store-object-alias.ts", [
+        { kind: "legacy store filesystem write", line: 5 },
+      ]),
+      "flags fs-safe store object aliases copied through destructuring": sourceCase`
         import { privateFileStore } from "openclaw/plugin-sdk/security-runtime";
         const stores = { state: privateFileStore(stateDir) };
         const nested = { inner: { bindings: privateFileStore(stateDir).json("plugin-binding-approvals.json") } };
@@ -899,19 +587,11 @@ describe("check-database-first-legacy-stores", () => {
         const { inner: { bindings } } = nested;
         await state.writeJson("thread-bindings.json", {});
         await bindings.write({});
-      `,
-      "src/runtime/fs-safe-store-destructured-object-alias-write.ts",
-    );
-
-    expect(violations).toEqual([
-      { kind: "legacy store filesystem write", line: 7 },
-      { kind: "legacy store filesystem write", line: 8 },
-    ]);
-  });
-
-  it("clears fs-safe store object aliases after exhaustive property reassignment", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/fs-safe-store-destructured-object-alias-write.ts", [
+        { kind: "legacy store filesystem write", line: 7 },
+        { kind: "legacy store filesystem write", line: 8 },
+      ]),
+      "clears fs-safe store object aliases after exhaustive property reassignment": sourceCase`
         import { privateFileStore } from "openclaw/plugin-sdk/security-runtime";
         const stores = { state: privateFileStore(stateDir) };
         if (flag) {
@@ -920,16 +600,9 @@ describe("check-database-first-legacy-stores", () => {
           stores.state = customB;
         }
         await stores.state.writeJson("thread-bindings.json", {});
-      `,
-      "src/runtime/exhaustive-fs-safe-store-property-reassignment.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("clears nested fs-safe store object aliases after exhaustive property reassignment", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/exhaustive-fs-safe-store-property-reassignment.ts", []),
+      "clears nested fs-safe store object aliases after exhaustive property reassignment":
+        sourceCase`
         import { privateFileStore } from "openclaw/plugin-sdk/security-runtime";
         const stores = { inner: { bindings: privateFileStore(stateDir).json("thread-bindings.json") } };
         if (flag) {
@@ -938,16 +611,9 @@ describe("check-database-first-legacy-stores", () => {
           stores.inner = { bindings: customB };
         }
         await stores.inner.bindings.write({});
-      `,
-      "src/runtime/exhaustive-nested-fs-safe-store-property-reassignment.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("keeps fs-safe store object aliases when one exhaustive property branch remains a store", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/exhaustive-nested-fs-safe-store-property-reassignment.ts", []),
+      "keeps fs-safe store object aliases when one exhaustive property branch remains a store":
+        sourceCase`
         import { privateFileStore } from "openclaw/plugin-sdk/security-runtime";
         const stores = { state: customStore };
         if (flag) {
@@ -956,48 +622,26 @@ describe("check-database-first-legacy-stores", () => {
           stores.state = privateFileStore(stateDir);
         }
         await stores.state.writeJson("thread-bindings.json", {});
-      `,
-      "src/runtime/exhaustive-fs-safe-store-property-partial-reassignment.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 9 }]);
-  });
-
-  it("flags direct fs-safe package namespace store writes to legacy paths", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/exhaustive-fs-safe-store-property-partial-reassignment.ts", [
+          { kind: "legacy store filesystem write", line: 9 },
+        ]),
+      "flags direct fs-safe package namespace store writes to legacy paths": sourceCase`
         import * as fsSafeStore from "@openclaw/fs-safe/store";
         const store = fsSafeStore.fileStoreSync({ rootDir: stateDir });
         store.writeJson("thread-bindings.json", {});
         const bindings = fsSafeStore.jsonStore({ filePath: "plugin-binding-approvals.json" });
         await bindings.write({});
-      `,
-      "src/runtime/direct-fs-safe-store-namespace-write.ts",
-    );
-
-    expect(violations).toEqual([
-      { kind: "legacy store filesystem write", line: 4 },
-      { kind: "legacy store filesystem write", line: 6 },
-    ]);
-  });
-
-  it("allows fs-safe JSON store reads from legacy paths", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/direct-fs-safe-store-namespace-write.ts", [
+        { kind: "legacy store filesystem write", line: 4 },
+        { kind: "legacy store filesystem write", line: 6 },
+      ]),
+      "allows fs-safe JSON store reads from legacy paths": sourceCase`
         import { privateFileStore } from "openclaw/plugin-sdk/security-runtime";
         const bindings = privateFileStore(stateDir).json("thread-bindings.json");
         await bindings.read();
         await privateFileStore(stateDir).json("plugin-binding-approvals.json").readOr({});
-      `,
-      "src/runtime/private-file-json-store-read.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("clears fs-safe store aliases after exhaustive non-store reassignment", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/private-file-json-store-read.ts", []),
+      "clears fs-safe store aliases after exhaustive non-store reassignment": sourceCase`
         import { privateFileStore } from "openclaw/plugin-sdk/security-runtime";
         let store = privateFileStore(stateDir);
         if (flag) {
@@ -1006,16 +650,8 @@ describe("check-database-first-legacy-stores", () => {
           store = customB;
         }
         await store.writeJson("thread-bindings.json", {});
-      `,
-      "src/runtime/exhaustive-fs-safe-store-reassignment.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("keeps fs-safe store aliases when one exhaustive branch remains a store", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/exhaustive-fs-safe-store-reassignment.ts", []),
+      "keeps fs-safe store aliases when one exhaustive branch remains a store": sourceCase`
         import { privateFileStore } from "openclaw/plugin-sdk/security-runtime";
         let store = customStore;
         if (flag) {
@@ -1024,137 +660,67 @@ describe("check-database-first-legacy-stores", () => {
           store = privateFileStore(stateDir);
         }
         await store.writeJson("thread-bindings.json", {});
-      `,
-      "src/runtime/exhaustive-fs-safe-store-partial-reassignment.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 9 }]);
-  });
-
-  it("clears fs-safe namespace factory aliases after shadowing", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/exhaustive-fs-safe-store-partial-reassignment.ts", [
+        { kind: "legacy store filesystem write", line: 9 },
+      ]),
+      "clears fs-safe namespace factory aliases after shadowing": sourceCase`
         import * as fsSafe from "openclaw/plugin-sdk/security-runtime";
         async function save(fsSafe: { root(dir: string): Promise<{ writeJson(path: string): void }> }) {
           await (await fsSafe.root(stateDir)).writeJson("thread-bindings.json");
         }
-      `,
-      "src/runtime/fs-safe-namespace-shadow.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("ignores helper-like namespace imports from unrelated modules", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/fs-safe-namespace-shadow.ts", []),
+      "ignores helper-like namespace imports from unrelated modules": sourceCase`
         import * as runtime from "../runtime/json-output.js";
         runtime.writeJson("sessions.json", {});
-      `,
-      "src/runtime/unrelated-helper-namespace.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("ignores helper-like named imports from unrelated modules", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/unrelated-helper-namespace.ts", []),
+      "ignores helper-like named imports from unrelated modules": sourceCase`
         import { writeJson } from "../runtime/json-output.js";
         writeJson("sessions.json", {});
-      `,
-      "src/runtime/unrelated-helper-named-import.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("clears namespace helper aliases after shadowing", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/unrelated-helper-named-import.ts", []),
+      "clears namespace helper aliases after shadowing": sourceCase`
         import * as jsonFiles from "../infra/json-files.js";
         function save(jsonFiles: { writeJson(path: string, value: unknown): void }) {
           jsonFiles.writeJson("sessions.json", {});
         }
         save(customJsonFiles);
-      `,
-      "src/runtime/helper-namespace-shadow.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("allows read-only fs open calls and flags write modes", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/helper-namespace-shadow.ts", []),
+      "allows read-only fs open calls and flags write modes": sourceCase`
         import fs from "node:fs/promises";
         await fs.open("sessions.json");
         await fs.open("sessions.json", "r");
         await fs.open("sessions.json", "r+");
         await fs.open("sessions.json", "w");
-      `,
-      "src/runtime/open-flags.ts",
-    );
-
-    expect(violations).toEqual([
-      { kind: "legacy store filesystem write", line: 5 },
-      { kind: "legacy store filesystem write", line: 6 },
-    ]);
-  });
-
-  it("flags fs copy calls writing legacy store paths", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/open-flags.ts", [
+        { kind: "legacy store filesystem write", line: 5 },
+        { kind: "legacy store filesystem write", line: 6 },
+      ]),
+      "flags fs copy calls writing legacy store paths": sourceCase`
         import fs from "node:fs/promises";
         import syncFs from "node:fs";
         await fs.cp("source.json", "sessions.json");
         syncFs.cpSync("source.json", "cron/jobs.json");
-      `,
-      "src/runtime/fs-copy-legacy-store.ts",
-    );
-
-    expect(violations).toEqual([
-      { kind: "legacy store filesystem write", line: 4 },
-      { kind: "legacy store filesystem write", line: 5 },
-    ]);
-  });
-
-  it("allows fs copy calls reading from legacy store paths", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/fs-copy-legacy-store.ts", [
+        { kind: "legacy store filesystem write", line: 4 },
+        { kind: "legacy store filesystem write", line: 5 },
+      ]),
+      "allows fs copy calls reading from legacy store paths": sourceCase`
         import fs from "node:fs/promises";
         import syncFs from "node:fs";
         await fs.copyFile("sessions.json", "state/openclaw.sqlite.import");
         await fs.cp("cron/jobs.json", "state/openclaw.sqlite.import");
         syncFs.copyFileSync("auth-profiles.json", "state/openclaw.sqlite.import");
         syncFs.cpSync("cache/models.json", "state/openclaw.sqlite.import");
-      `,
-      "src/runtime/fs-copy-legacy-store-source.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("flags fs removal calls targeting legacy store paths", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/fs-copy-legacy-store-source.ts", []),
+      "flags fs removal calls targeting legacy store paths": sourceCase`
         import fs from "node:fs/promises";
         import syncFs from "node:fs";
         await fs.rm("sessions.json", { force: true });
         syncFs.unlinkSync("cron/jobs.json");
-      `,
-      "src/runtime/fs-remove-legacy-store.ts",
-    );
-
-    expect(violations).toEqual([
-      { kind: "legacy store filesystem write", line: 4 },
-      { kind: "legacy store filesystem write", line: 5 },
-    ]);
-  });
-
-  it("flags legacy paths destructured from for-of tuple entries", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/fs-remove-legacy-store.ts", [
+        { kind: "legacy store filesystem write", line: 4 },
+        { kind: "legacy store filesystem write", line: 5 },
+      ]),
+      "flags legacy paths destructured from for-of tuple entries": sourceCase`
         import path from "node:path";
         import { root as fsRoot } from "openclaw/plugin-sdk/security-runtime";
         const CLAIMS_DIGEST_PATH = ".openclaw-wiki/cache/claims.jsonl";
@@ -1164,16 +730,10 @@ describe("check-database-first-legacy-stores", () => {
           const root = await fsRoot(rootDir);
           await root.write(relativePath, content);
         }
-      `,
-      "src/runtime/for-of-destructured-legacy-path.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 9 }]);
-  });
-
-  it("applies open write-mode checks inside wrappers", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/for-of-destructured-legacy-path.ts", [
+        { kind: "legacy store filesystem write", line: 9 },
+      ]),
+      "applies open write-mode checks inside wrappers": sourceCase`
         import fs from "node:fs/promises";
         function read(path: string) {
           return fs.open(path, "r");
@@ -1183,134 +743,72 @@ describe("check-database-first-legacy-stores", () => {
         }
         await read("sessions.json");
         await write("sessions.json");
-      `,
-      "src/runtime/open-wrapper-flags.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 10 }]);
-  });
-
-  it("flags string-literal fs write aliases from destructuring", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/open-wrapper-flags.ts", [{ kind: "legacy store filesystem write", line: 10 }]),
+      "flags string-literal fs write aliases from destructuring": sourceCase`
         import fs from "node:fs/promises";
         const { "writeFile": persist } = fs;
         await persist("sessions.json", "{}\\n", "utf8");
-      `,
-      "src/runtime/string-literal-fs-alias.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 4 }]);
-  });
-
-  it("flags CommonJS fs write aliases", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/string-literal-fs-alias.ts", [
+        { kind: "legacy store filesystem write", line: 4 },
+      ]),
+      "flags CommonJS fs write aliases": sourceCase`
         const fs = require("node:fs");
         const { appendFileSync } = require("node:fs");
         fs.writeFileSync("sessions.json", "{}\\n");
         appendFileSync("cron/runs/job.jsonl", "{}\\n");
-      `,
-      "src/runtime/commonjs-fs-aliases.ts",
-    );
-
-    expect(violations).toEqual([
-      { kind: "legacy store filesystem write", line: 4 },
-      { kind: "legacy store filesystem write", line: 5 },
-    ]);
-  });
-
-  it("does not treat local require bindings as CommonJS fs", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/commonjs-fs-aliases.ts", [
+        { kind: "legacy store filesystem write", line: 4 },
+        { kind: "legacy store filesystem write", line: 5 },
+      ]),
+      "does not treat local require bindings as CommonJS fs": sourceCase`
         function save(require: (specifier: string) => { writeFileSync(path: string, value: string): void }) {
           const fs = require("node:fs");
           fs.writeFileSync("sessions.json", "");
         }
         save(customRequire);
-      `,
-      "src/runtime/local-require-binding.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("flags createRequire-backed CommonJS fs writes", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/local-require-binding.ts", []),
+      "flags createRequire-backed CommonJS fs writes": sourceCase`
         import { createRequire } from "node:module";
         const require = createRequire(import.meta.url);
         const fs = require("node:fs");
         fs.writeFileSync("sessions.json", "{}\\n");
-      `,
-      "src/runtime/create-require-fs.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 5 }]);
-  });
-
-  it("flags createRequire alias-backed CommonJS fs writes", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/create-require-fs.ts", [{ kind: "legacy store filesystem write", line: 5 }]),
+      "flags createRequire alias-backed CommonJS fs writes": sourceCase`
         import { createRequire } from "node:module";
         const req = createRequire(import.meta.url);
         const fs = req("node:fs");
         fs.writeFileSync("sessions.json", "{}\\n");
-      `,
-      "src/runtime/create-require-alias-fs.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 5 }]);
-  });
-
-  it("flags copied createRequire alias-backed CommonJS fs writes", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/create-require-alias-fs.ts", [
+        { kind: "legacy store filesystem write", line: 5 },
+      ]),
+      "flags copied createRequire alias-backed CommonJS fs writes": sourceCase`
         import { createRequire } from "node:module";
         const req = createRequire(import.meta.url);
         const req2 = req;
         const fs = req2("node:fs");
         fs.writeFileSync("sessions.json", "{}\\n");
-      `,
-      "src/runtime/copied-create-require-alias-fs.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 6 }]);
-  });
-
-  it("flags reassigned createRequire alias-backed CommonJS fs writes", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/copied-create-require-alias-fs.ts", [
+        { kind: "legacy store filesystem write", line: 6 },
+      ]),
+      "flags reassigned createRequire alias-backed CommonJS fs writes": sourceCase`
         import { createRequire } from "node:module";
         let req;
         req = createRequire(import.meta.url);
         const fs = req("node:fs");
         fs.writeFileSync("sessions.json", "{}\\n");
-      `,
-      "src/runtime/reassigned-create-require-alias-fs.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 6 }]);
-  });
-
-  it("flags reassigned createRequire aliases named require", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/reassigned-create-require-alias-fs.ts", [
+        { kind: "legacy store filesystem write", line: 6 },
+      ]),
+      "flags reassigned createRequire aliases named require": sourceCase`
         import { createRequire } from "node:module";
         let require;
         require = createRequire(import.meta.url);
         const fs = require("node:fs");
         fs.writeFileSync("sessions.json", "{}\\n");
-      `,
-      "src/runtime/reassigned-create-require-name.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 6 }]);
-  });
-
-  it("refreshes hoisted wrappers after createRequire alias reassignment", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/reassigned-create-require-name.ts", [
+        { kind: "legacy store filesystem write", line: 6 },
+      ]),
+      "refreshes hoisted wrappers after createRequire alias reassignment": sourceCase`
         import { createRequire } from "node:module";
         let req;
         function persist(filePath: string) {
@@ -1319,16 +817,10 @@ describe("check-database-first-legacy-stores", () => {
         }
         req = createRequire(import.meta.url);
         persist("sessions.json");
-      `,
-      "src/runtime/hoisted-wrapper-reassigned-create-require-alias.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 9 }]);
-  });
-
-  it("refreshes hoisted wrappers after nested createRequire alias reassignment", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/hoisted-wrapper-reassigned-create-require-alias.ts", [
+        { kind: "legacy store filesystem write", line: 9 },
+      ]),
+      "refreshes hoisted wrappers after nested createRequire alias reassignment": sourceCase`
         import { createRequire } from "node:module";
         let req;
         function persist(filePath: string) {
@@ -1339,16 +831,11 @@ describe("check-database-first-legacy-stores", () => {
           req = createRequire(import.meta.url);
         }
         persist("sessions.json");
-      `,
-      "src/runtime/hoisted-wrapper-nested-create-require-alias.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 11 }]);
-  });
-
-  it("refreshes block-scoped wrappers after nested outer createRequire alias reassignment", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/hoisted-wrapper-nested-create-require-alias.ts", [
+        { kind: "legacy store filesystem write", line: 11 },
+      ]),
+      "refreshes block-scoped wrappers after nested outer createRequire alias reassignment":
+        sourceCase`
         import { createRequire } from "node:module";
         let req;
         {
@@ -1361,16 +848,10 @@ describe("check-database-first-legacy-stores", () => {
           }
           persist("sessions.json");
         }
-      `,
-      "src/runtime/block-wrapper-nested-create-require-alias.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 12 }]);
-  });
-
-  it("refreshes escaped wrappers after outer createRequire alias reassignment", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/block-wrapper-nested-create-require-alias.ts", [
+          { kind: "legacy store filesystem write", line: 12 },
+        ]),
+      "refreshes escaped wrappers after outer createRequire alias reassignment": sourceCase`
         import { createRequire } from "node:module";
         let req;
         let persist;
@@ -1383,16 +864,11 @@ describe("check-database-first-legacy-stores", () => {
         }
         req = createRequire(import.meta.url);
         persist("sessions.json");
-      `,
-      "src/runtime/escaped-wrapper-create-require-alias.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 13 }]);
-  });
-
-  it("keeps escaped wrapper local require shadows after outer createRequire alias reassignment", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/escaped-wrapper-create-require-alias.ts", [
+        { kind: "legacy store filesystem write", line: 13 },
+      ]),
+      "keeps escaped wrapper local require shadows after outer createRequire alias reassignment":
+        sourceCase`
         import { createRequire } from "node:module";
         let req;
         let persist;
@@ -1406,16 +882,8 @@ describe("check-database-first-legacy-stores", () => {
         }
         req = createRequire(import.meta.url);
         persist("sessions.json");
-      `,
-      "src/runtime/escaped-wrapper-local-require-shadow.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("does not treat parameter shadows as createRequire aliases", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/escaped-wrapper-local-require-shadow.ts", []),
+      "does not treat parameter shadows as createRequire aliases": sourceCase`
         import { createRequire } from "node:module";
         const req = createRequire(import.meta.url);
         function save(req: (specifier: string) => { writeFileSync(path: string, value: string): void }) {
@@ -1423,16 +891,8 @@ describe("check-database-first-legacy-stores", () => {
           fs.writeFileSync("sessions.json", "");
         }
         save(customRequire);
-      `,
-      "src/runtime/create-require-parameter-shadow.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("does not treat shadowed createRequire bindings as Node require", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/create-require-parameter-shadow.ts", []),
+      "does not treat shadowed createRequire bindings as Node require": sourceCase`
         import { createRequire } from "node:module";
         function save(createRequire: (url: string) => (specifier: string) => { writeFileSync(path: string, value: string): void }) {
           const require = createRequire("custom");
@@ -1440,16 +900,8 @@ describe("check-database-first-legacy-stores", () => {
           fs.writeFileSync("sessions.json", "");
         }
         save(customCreateRequire);
-      `,
-      "src/runtime/shadowed-create-require.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("does not treat hoisted function createRequire shadows as Node require", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/shadowed-create-require.ts", []),
+      "does not treat hoisted function createRequire shadows as Node require": sourceCase`
         import { createRequire } from "node:module";
         function run() {
           function createRequire(url: string) {
@@ -1460,125 +912,65 @@ describe("check-database-first-legacy-stores", () => {
           fs.writeFileSync("sessions.json", "{}\\n");
         }
         run();
-      `,
-      "src/runtime/hoisted-create-require-shadow.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("flags CommonJS fs promises aliases", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/hoisted-create-require-shadow.ts", []),
+      "flags CommonJS fs promises aliases": sourceCase`
         const { promises: fs } = require("node:fs");
         const { promises } = require("node:fs");
         await fs.writeFile("sessions.json", "{}\\n");
         await promises.appendFile("cron/runs/job.jsonl", "{}\\n");
-      `,
-      "src/runtime/commonjs-fs-promises-aliases.ts",
-    );
-
-    expect(violations).toEqual([
-      { kind: "legacy store filesystem write", line: 4 },
-      { kind: "legacy store filesystem write", line: 5 },
-    ]);
-  });
-
-  it("flags nested CommonJS fs promises write aliases", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/commonjs-fs-promises-aliases.ts", [
+        { kind: "legacy store filesystem write", line: 4 },
+        { kind: "legacy store filesystem write", line: 5 },
+      ]),
+      "flags nested CommonJS fs promises write aliases": sourceCase`
         const { promises: { writeFile } } = require("node:fs");
         await writeFile("sessions.json", "{}\\n");
-      `,
-      "src/runtime/nested-commonjs-fs-promises-alias.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 3 }]);
-  });
-
-  it("flags inline CommonJS fs writes", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-commonjs-fs-promises-alias.ts", [
+        { kind: "legacy store filesystem write", line: 3 },
+      ]),
+      "flags inline CommonJS fs writes": sourceCase`
         require("node:fs").writeFileSync("sessions.json", "{}\\n");
         require("node:fs").promises.writeFile("cron/jobs.json", "{}\\n");
-      `,
-      "src/runtime/inline-commonjs-fs-write.ts",
-    );
-
-    expect(violations).toEqual([
-      { kind: "legacy store filesystem write", line: 2 },
-      { kind: "legacy store filesystem write", line: 3 },
-    ]);
-  });
-
-  it("flags bracketed fs writes", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/inline-commonjs-fs-write.ts", [
+        { kind: "legacy store filesystem write", line: 2 },
+        { kind: "legacy store filesystem write", line: 3 },
+      ]),
+      "flags bracketed fs writes": sourceCase`
         import fs from "node:fs";
         await fs["writeFile"]("sessions.json", "{}\\n");
         await fs.promises["writeFile"]("cron/runs/job.jsonl", "{}\\n");
         require("node:fs")["writeFileSync"]("sessions.json", "{}\\n");
-      `,
-      "src/runtime/bracketed-fs-writes.ts",
-    );
-
-    expect(violations).toEqual([
-      { kind: "legacy store filesystem write", line: 3 },
-      { kind: "legacy store filesystem write", line: 4 },
-      { kind: "legacy store filesystem write", line: 5 },
-    ]);
-  });
-
-  it("flags dynamic fs import writes", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/bracketed-fs-writes.ts", [
+        { kind: "legacy store filesystem write", line: 3 },
+        { kind: "legacy store filesystem write", line: 4 },
+        { kind: "legacy store filesystem write", line: 5 },
+      ]),
+      "flags dynamic fs import writes": sourceCase`
         const fs = await import("node:fs/promises");
         const nodeFs = await import("node:fs");
         await fs.writeFile("sessions.json", "{}\\n");
         await nodeFs.promises.appendFile("cron/runs/job.jsonl", "{}\\n");
-      `,
-      "src/runtime/dynamic-fs-import-write.ts",
-    );
-
-    expect(violations).toEqual([
-      { kind: "legacy store filesystem write", line: 4 },
-      { kind: "legacy store filesystem write", line: 5 },
-    ]);
-  });
-
-  it("flags dynamic fs import write aliases", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/dynamic-fs-import-write.ts", [
+        { kind: "legacy store filesystem write", line: 4 },
+        { kind: "legacy store filesystem write", line: 5 },
+      ]),
+      "flags dynamic fs import write aliases": sourceCase`
         const { writeFile } = await import("node:fs/promises");
         const { promises } = await import("node:fs");
         await writeFile("sessions.json", "{}\\n");
         await promises.appendFile("cron/runs/job.jsonl", "{}\\n");
-      `,
-      "src/runtime/dynamic-fs-import-aliases.ts",
-    );
-
-    expect(violations).toEqual([
-      { kind: "legacy store filesystem write", line: 4 },
-      { kind: "legacy store filesystem write", line: 5 },
-    ]);
-  });
-
-  it("flags dynamic fs import promise callback writes", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/dynamic-fs-import-aliases.ts", [
+        { kind: "legacy store filesystem write", line: 4 },
+        { kind: "legacy store filesystem write", line: 5 },
+      ]),
+      "flags dynamic fs import promise callback writes": sourceCase`
         await import("node:fs/promises").then((fs) =>
           fs.writeFile("sessions.json", "{}\\n"),
         );
-      `,
-      "src/runtime/dynamic-fs-import-promise-callback.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 3 }]);
-  });
-
-  it("flags destructured dynamic fs import promise callback writes", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/dynamic-fs-import-promise-callback.ts", [
+        { kind: "legacy store filesystem write", line: 3 },
+      ]),
+      "flags destructured dynamic fs import promise callback writes": sourceCase`
         await import("node:fs/promises").then(({ writeFile }) =>
           writeFile("sessions.json", "{}\\n"),
         );
@@ -1588,143 +980,83 @@ describe("check-database-first-legacy-stores", () => {
         await import("node:fs").then(({ promises: { writeFile: persist } }) =>
           persist("sessions.json", "{}\\n"),
         );
-      `,
-      "src/runtime/destructured-dynamic-fs-import-promise-callback.ts",
-    );
-
-    expect(violations).toEqual([
-      { kind: "legacy store filesystem write", line: 3 },
-      { kind: "legacy store filesystem write", line: 6 },
-      { kind: "legacy store filesystem write", line: 9 },
-    ]);
-  });
-
-  it("flags write aliases destructured from fs.promises", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/destructured-dynamic-fs-import-promise-callback.ts", [
+        { kind: "legacy store filesystem write", line: 3 },
+        { kind: "legacy store filesystem write", line: 6 },
+        { kind: "legacy store filesystem write", line: 9 },
+      ]),
+      "flags write aliases destructured from fs.promises": sourceCase`
         import * as fs from "node:fs";
         const { writeFile: persist } = fs.promises;
         const fsp = fs.promises;
         const { appendFile } = fsp;
         await persist("sessions.json", "{}\\n", "utf8");
         await appendFile("cron/runs/job.jsonl", "{}\\n");
-      `,
-      "src/runtime/fs-promises-aliases.ts",
-    );
-
-    expect(violations).toEqual([
-      { kind: "legacy store filesystem write", line: 6 },
-      { kind: "legacy store filesystem write", line: 7 },
-    ]);
-  });
-
-  it("flags fs write method aliases", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/fs-promises-aliases.ts", [
+        { kind: "legacy store filesystem write", line: 6 },
+        { kind: "legacy store filesystem write", line: 7 },
+      ]),
+      "flags fs write method aliases": sourceCase`
         import fs from "node:fs/promises";
         const persist = fs.writeFile;
         await persist("sessions.json", "{}\\n");
-      `,
-      "src/runtime/fs-write-method-alias.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 4 }]);
-  });
-
-  it("flags write aliases destructured from local fs module aliases", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/fs-write-method-alias.ts", [
+        { kind: "legacy store filesystem write", line: 4 },
+      ]),
+      "flags write aliases destructured from local fs module aliases": sourceCase`
         import fs from "node:fs/promises";
         {
           const storage = fs;
           const { writeFile } = storage;
           await writeFile("sessions.json", "{}\\n");
         }
-      `,
-      "src/runtime/local-fs-module-alias.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 6 }]);
-  });
-
-  it("flags nested write aliases destructured from local fs module aliases", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/local-fs-module-alias.ts", [
+        { kind: "legacy store filesystem write", line: 6 },
+      ]),
+      "flags nested write aliases destructured from local fs module aliases": sourceCase`
         const nodeFs = require("node:fs");
         const { promises: { writeFile } } = nodeFs;
         await writeFile("sessions.json", "{}\\n");
-      `,
-      "src/runtime/nested-local-fs-module-alias.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 4 }]);
-  });
-
-  it("clears fs module aliases after reassignment", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-local-fs-module-alias.ts", [
+        { kind: "legacy store filesystem write", line: 4 },
+      ]),
+      "clears fs module aliases after reassignment": sourceCase`
         import fs from "node:fs/promises";
         let writer = fs;
         writer = customWriter;
         await writer.writeFile("sessions.json", "{}\\n");
-      `,
-      "src/runtime/reassigned-fs-module-alias.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("uses branch-local fs module aliases after conditional assignment", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/reassigned-fs-module-alias.ts", []),
+      "uses branch-local fs module aliases after conditional assignment": sourceCase`
         import fs from "node:fs/promises";
         let writer;
         if (ready) {
           writer = fs;
           await writer.writeFile("sessions.json", "{}\\n");
         }
-      `,
-      "src/runtime/conditional-fs-module-alias.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 6 }]);
-  });
-
-  it("keeps fs module aliases after conditional assignment", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/conditional-fs-module-alias.ts", [
+        { kind: "legacy store filesystem write", line: 6 },
+      ]),
+      "keeps fs module aliases after conditional assignment": sourceCase`
         import fs from "node:fs/promises";
         let writer;
         if (ready) {
           writer = fs;
         }
         await writer.writeFile("sessions.json", "{}\\n");
-      `,
-      "src/runtime/conditional-retained-fs-module-alias.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 7 }]);
-  });
-
-  it("keeps fs write aliases after conditional assignment", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/conditional-retained-fs-module-alias.ts", [
+        { kind: "legacy store filesystem write", line: 7 },
+      ]),
+      "keeps fs write aliases after conditional assignment": sourceCase`
         import fs from "node:fs/promises";
         let persist;
         if (ready) {
           persist = fs.writeFile;
         }
         await persist("sessions.json", "{}\\n");
-      `,
-      "src/runtime/conditional-retained-fs-write-alias.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 7 }]);
-  });
-
-  it("clears fs module aliases after exhaustive conditional reassignment", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/conditional-retained-fs-write-alias.ts", [
+        { kind: "legacy store filesystem write", line: 7 },
+      ]),
+      "clears fs module aliases after exhaustive conditional reassignment": sourceCase`
         import fs from "node:fs/promises";
         let writer = fs;
         if (ready) {
@@ -1733,16 +1065,8 @@ describe("check-database-first-legacy-stores", () => {
           writer = otherWriter;
         }
         await writer.writeFile("sessions.json", "{}\\n");
-      `,
-      "src/runtime/exhaustive-reassigned-fs-module-alias.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("keeps uninitialized fs aliases assigned from nested blocks", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/exhaustive-reassigned-fs-module-alias.ts", []),
+      "keeps uninitialized fs aliases assigned from nested blocks": sourceCase`
         import fs from "node:fs/promises";
         let writer;
         let persist;
@@ -1752,122 +1076,64 @@ describe("check-database-first-legacy-stores", () => {
         }
         await writer.writeFile("sessions.json", "{}\\n");
         await persist("cron/jobs.json", "{}\\n");
-      `,
-      "src/runtime/nested-assigned-uninitialized-fs-aliases.ts",
-    );
-
-    expect(violations).toEqual([
-      { kind: "legacy store filesystem write", line: 9 },
-      { kind: "legacy store filesystem write", line: 10 },
-    ]);
-  });
-
-  it("flags fs write aliases stored on object properties", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-assigned-uninitialized-fs-aliases.ts", [
+        { kind: "legacy store filesystem write", line: 9 },
+        { kind: "legacy store filesystem write", line: 10 },
+      ]),
+      "flags fs write aliases stored on object properties": sourceCase`
         import fs from "node:fs/promises";
         const writer = { writeFile: fs.writeFile };
         await writer.writeFile("sessions.json", "{}\\n");
-      `,
-      "src/runtime/object-fs-write-alias.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 4 }]);
-  });
-
-  it("flags fs module handles stored on object properties", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/object-fs-write-alias.ts", [
+        { kind: "legacy store filesystem write", line: 4 },
+      ]),
+      "flags fs module handles stored on object properties": sourceCase`
         import fs from "node:fs/promises";
         const deps = { fs };
         const io = { storage: fs };
         await deps.fs.writeFile("sessions.json", "{}\\n");
         await io.storage.appendFile("cron/runs/job.jsonl", "{}\\n");
-      `,
-      "src/runtime/object-fs-module-alias.ts",
-    );
-
-    expect(violations).toEqual([
-      { kind: "legacy store filesystem write", line: 5 },
-      { kind: "legacy store filesystem write", line: 6 },
-    ]);
-  });
-
-  it("clears fs write object aliases after object reassignment", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/object-fs-module-alias.ts", [
+        { kind: "legacy store filesystem write", line: 5 },
+        { kind: "legacy store filesystem write", line: 6 },
+      ]),
+      "clears fs write object aliases after object reassignment": sourceCase`
         import fs from "node:fs/promises";
         let writer = { writeFile: fs.writeFile };
         writer = customWriter;
         await writer.writeFile("sessions.json", "{}\\n");
-      `,
-      "src/runtime/reassigned-object-fs-write-alias.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("clears fs module object aliases after object reassignment", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/reassigned-object-fs-write-alias.ts", []),
+      "clears fs module object aliases after object reassignment": sourceCase`
         import fs from "node:fs/promises";
         let deps = { fs };
         deps = customDeps;
         await deps.fs.writeFile("sessions.json", "{}\\n");
-      `,
-      "src/runtime/reassigned-object-fs-module-alias.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("flags fs write aliases assigned to object properties", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/reassigned-object-fs-module-alias.ts", []),
+      "flags fs write aliases assigned to object properties": sourceCase`
         import fs from "node:fs/promises";
         const writer: any = {};
         writer.writeFile = fs.writeFile;
         await writer.writeFile("sessions.json", "{}\\n");
-      `,
-      "src/runtime/assigned-object-fs-write-alias.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 5 }]);
-  });
-
-  it("flags fs module handles assigned to object properties", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/assigned-object-fs-write-alias.ts", [
+        { kind: "legacy store filesystem write", line: 5 },
+      ]),
+      "flags fs module handles assigned to object properties": sourceCase`
         import fs from "node:fs/promises";
         const deps: any = {};
         deps.fs = fs;
         await deps.fs.writeFile("sessions.json", "{}\\n");
-      `,
-      "src/runtime/assigned-object-fs-module-alias.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 5 }]);
-  });
-
-  it("uses branch-local fs object aliases after conditional reassignment", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/assigned-object-fs-module-alias.ts", [
+        { kind: "legacy store filesystem write", line: 5 },
+      ]),
+      "uses branch-local fs object aliases after conditional reassignment": sourceCase`
         import fs from "node:fs/promises";
         const writer = { writeFile: fs.writeFile };
         if (ready) {
           writer.writeFile = customSink;
           await writer.writeFile("sessions.json", "{}\\n");
         }
-      `,
-      "src/runtime/conditional-object-fs-write-alias-reassignment.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("does not leak local fs module aliases outside their scope", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/conditional-object-fs-write-alias-reassignment.ts", []),
+      "does not leak local fs module aliases outside their scope": sourceCase`
         import fs from "node:fs/promises";
         {
           const storage = fs;
@@ -1879,29 +1145,13 @@ describe("check-database-first-legacy-stores", () => {
           const { writeFile } = storage;
           await writeFile("sessions.json", "{}\\n");
         }
-      `,
-      "src/runtime/local-fs-module-alias-scope.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("flags legacy paths written through regular-file helpers", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/local-fs-module-alias-scope.ts", []),
+      "flags legacy paths written through regular-file helpers": sourceCase`
         import { appendRegularFile as appendSafe } from "openclaw/plugin-sdk/security-runtime";
         const filePath = "session.trajectory.jsonl";
         await appendSafe({ filePath, content: "{}\\n" });
-      `,
-      "src/runtime/regular-file-helper.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 4 }]);
-  });
-
-  it("flags legacy paths written through JSON and atomic helpers", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/regular-file-helper.ts", [{ kind: "legacy store filesystem write", line: 4 }]),
+      "flags legacy paths written through JSON and atomic helpers": sourceCase`
         import { writeJson, writeTextAtomic } from "../infra/json-files.js";
         import { replaceFileAtomicSync } from "../infra/replace-file.js";
         import { saveJsonFile, writeJsonFileAtomically } from "openclaw/plugin-sdk/json-store";
@@ -1910,23 +1160,15 @@ describe("check-database-first-legacy-stores", () => {
         replaceFileAtomicSync({ filePath: "plugin-state/state.sqlite", content: "" });
         await writeJsonFileAtomically("thread-bindings.json", {});
         saveJsonFile("plugin-binding-approvals.json", {});
-      `,
-      "src/runtime/write-helper-regressions.ts",
-    );
-
-    expect(violations).toEqual([
-      { kind: "legacy restart sentinel reference", line: 5 },
-      { kind: "legacy store filesystem write", line: 5 },
-      { kind: "legacy store filesystem write", line: 6 },
-      { kind: "legacy store filesystem write", line: 7 },
-      { kind: "legacy store filesystem write", line: 8 },
-      { kind: "legacy store filesystem write", line: 9 },
-    ]);
-  });
-
-  it("flags legacy paths passed through wrapper object properties", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/write-helper-regressions.ts", [
+        { kind: "legacy restart sentinel reference", line: 5 },
+        { kind: "legacy store filesystem write", line: 5 },
+        { kind: "legacy store filesystem write", line: 6 },
+        { kind: "legacy store filesystem write", line: 7 },
+        { kind: "legacy store filesystem write", line: 8 },
+        { kind: "legacy store filesystem write", line: 9 },
+      ]),
+      "flags legacy paths passed through wrapper object properties": sourceCase`
         import path from "node:path";
         import { writeTextAtomic } from "../infra/json-files.js";
         function persist(params: { filePath: string }) {
@@ -1934,16 +1176,10 @@ describe("check-database-first-legacy-stores", () => {
         }
         const ledgerPath = path.join(stateDir, "acp", "event-ledger.json");
         await persist({ filePath: ledgerPath });
-      `,
-      "src/runtime/object-property-wrapper.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 8 }]);
-  });
-
-  it("flags wrapper paths written through createRequire aliases", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/object-property-wrapper.ts", [
+        { kind: "legacy store filesystem write", line: 8 },
+      ]),
+      "flags wrapper paths written through createRequire aliases": sourceCase`
         import { createRequire } from "node:module";
         const req = createRequire(import.meta.url);
         function persist(filePath: string) {
@@ -1951,16 +1187,10 @@ describe("check-database-first-legacy-stores", () => {
           fs.writeFileSync(filePath, "{}\\n");
         }
         persist("sessions.json");
-      `,
-      "src/runtime/create-require-alias-wrapper.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 8 }]);
-  });
-
-  it("flags wrapper-local createRequire alias writes", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/create-require-alias-wrapper.ts", [
+        { kind: "legacy store filesystem write", line: 8 },
+      ]),
+      "flags wrapper-local createRequire alias writes": sourceCase`
         import { createRequire } from "node:module";
         function persist(filePath: string) {
           const req = createRequire(import.meta.url);
@@ -1968,16 +1198,10 @@ describe("check-database-first-legacy-stores", () => {
           fs.writeFileSync(filePath, "{}\\n");
         }
         persist("sessions.json");
-      `,
-      "src/runtime/wrapper-local-create-require-alias.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 8 }]);
-  });
-
-  it("flags wrapper-local copied createRequire aliases", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/wrapper-local-create-require-alias.ts", [
+        { kind: "legacy store filesystem write", line: 8 },
+      ]),
+      "flags wrapper-local copied createRequire aliases": sourceCase`
         import { createRequire } from "node:module";
         function persist(filePath: string) {
           const req = createRequire(import.meta.url);
@@ -1986,16 +1210,10 @@ describe("check-database-first-legacy-stores", () => {
           fs.writeFileSync(filePath, "{}\\n");
         }
         persist("sessions.json");
-      `,
-      "src/runtime/wrapper-copied-create-require-alias.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 9 }]);
-  });
-
-  it("flags wrapper-local createRequire aliases after local shadow reassignment", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/wrapper-copied-create-require-alias.ts", [
+        { kind: "legacy store filesystem write", line: 9 },
+      ]),
+      "flags wrapper-local createRequire aliases after local shadow reassignment": sourceCase`
         import { createRequire } from "node:module";
         const req = createRequire(import.meta.url);
         function persist(filePath: string) {
@@ -2005,16 +1223,10 @@ describe("check-database-first-legacy-stores", () => {
           fs.writeFileSync(filePath, "{}\\n");
         }
         persist("sessions.json");
-      `,
-      "src/runtime/wrapper-shadowed-reassigned-create-require-alias.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 10 }]);
-  });
-
-  it("flags wrapper-local reassigned createRequire aliases named require", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/wrapper-shadowed-reassigned-create-require-alias.ts", [
+        { kind: "legacy store filesystem write", line: 10 },
+      ]),
+      "flags wrapper-local reassigned createRequire aliases named require": sourceCase`
         import { createRequire } from "node:module";
         function persist(filePath: string) {
           let require;
@@ -2023,16 +1235,10 @@ describe("check-database-first-legacy-stores", () => {
           fs.writeFileSync(filePath, "{}\\n");
         }
         persist("sessions.json");
-      `,
-      "src/runtime/wrapper-reassigned-create-require-name.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 9 }]);
-  });
-
-  it("flags wrapper-local createRequire alias assignments inside blocks", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/wrapper-reassigned-create-require-name.ts", [
+        { kind: "legacy store filesystem write", line: 9 },
+      ]),
+      "flags wrapper-local createRequire alias assignments inside blocks": sourceCase`
         import { createRequire } from "node:module";
         function persist(filePath: string) {
           let req;
@@ -2043,16 +1249,10 @@ describe("check-database-first-legacy-stores", () => {
           fs.writeFileSync(filePath, "{}\\n");
         }
         persist("sessions.json");
-      `,
-      "src/runtime/wrapper-block-create-require-assignment.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 11 }]);
-  });
-
-  it("does not treat wrapper-shadowed createRequire parameters as Node createRequire", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/wrapper-block-create-require-assignment.ts", [
+        { kind: "legacy store filesystem write", line: 11 },
+      ]),
+      "does not treat wrapper-shadowed createRequire parameters as Node createRequire": sourceCase`
         function persist(
           filePath: string,
           createRequire: (url: string) => (specifier: string) => { writeFileSync(path: string, value: string): void },
@@ -2062,16 +1262,9 @@ describe("check-database-first-legacy-stores", () => {
           fs.writeFileSync(filePath, "{}\\n");
         }
         persist("sessions.json", customCreateRequire);
-      `,
-      "src/runtime/wrapper-shadowed-create-require.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("does not treat wrapper hoisted function createRequire shadows as Node createRequire", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/wrapper-shadowed-create-require.ts", []),
+      "does not treat wrapper hoisted function createRequire shadows as Node createRequire":
+        sourceCase`
         import { createRequire } from "node:module";
         function persist(filePath: string) {
           function createRequire(url: string) {
@@ -2082,16 +1275,8 @@ describe("check-database-first-legacy-stores", () => {
           fs.writeFileSync(filePath, "{}\\n");
         }
         persist("sessions.json");
-      `,
-      "src/runtime/wrapper-hoisted-create-require-shadow.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("keeps wrapper lexical createRequire aliases when call sites shadow them", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/wrapper-hoisted-create-require-shadow.ts", []),
+      "keeps wrapper lexical createRequire aliases when call sites shadow them": sourceCase`
         import { createRequire } from "node:module";
         const req = createRequire(import.meta.url);
         function persist(filePath: string) {
@@ -2102,16 +1287,10 @@ describe("check-database-first-legacy-stores", () => {
           const req = customRequire;
           persist("sessions.json");
         }
-      `,
-      "src/runtime/wrapper-lexical-create-require-alias.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 10 }]);
-  });
-
-  it("keeps wrapper-local createRequire calls when call sites shadow createRequire", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/wrapper-lexical-create-require-alias.ts", [
+        { kind: "legacy store filesystem write", line: 10 },
+      ]),
+      "keeps wrapper-local createRequire calls when call sites shadow createRequire": sourceCase`
         import { createRequire } from "node:module";
         function persist(filePath: string) {
           const req = createRequire(import.meta.url);
@@ -2122,16 +1301,10 @@ describe("check-database-first-legacy-stores", () => {
           const createRequire = customCreateRequire;
           persist("sessions.json");
         }
-      `,
-      "src/runtime/wrapper-create-require-call-site-shadow.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 10 }]);
-  });
-
-  it("flags exhaustive conditional createRequire alias assignments", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/wrapper-create-require-call-site-shadow.ts", [
+        { kind: "legacy store filesystem write", line: 10 },
+      ]),
+      "flags exhaustive conditional createRequire alias assignments": sourceCase`
         import { createRequire } from "node:module";
         let req;
         if (condition) {
@@ -2141,16 +1314,10 @@ describe("check-database-first-legacy-stores", () => {
         }
         const fs = req("node:fs");
         fs.writeFileSync("sessions.json", "{}\\n");
-      `,
-      "src/runtime/conditional-create-require-alias.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 10 }]);
-  });
-
-  it("refreshes hoisted wrappers after exhaustive createRequire alias branches", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/conditional-create-require-alias.ts", [
+        { kind: "legacy store filesystem write", line: 10 },
+      ]),
+      "refreshes hoisted wrappers after exhaustive createRequire alias branches": sourceCase`
         import { createRequire } from "node:module";
         let req;
         function persist(filePath: string) {
@@ -2163,16 +1330,10 @@ describe("check-database-first-legacy-stores", () => {
           req = createRequire(import.meta.url);
         }
         persist("sessions.json");
-      `,
-      "src/runtime/hoisted-wrapper-conditional-create-require-alias.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 13 }]);
-  });
-
-  it("keeps wrapper conditional createRequire alias branches", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/hoisted-wrapper-conditional-create-require-alias.ts", [
+        { kind: "legacy store filesystem write", line: 13 },
+      ]),
+      "keeps wrapper conditional createRequire alias branches": sourceCase`
         import { createRequire } from "node:module";
         function persist(filePath: string) {
           let req;
@@ -2185,16 +1346,20 @@ describe("check-database-first-legacy-stores", () => {
           fs.writeFileSync(filePath, "{}\\n");
         }
         persist("sessions.json");
-      `,
-      "src/runtime/wrapper-conditional-create-require-alias.ts",
-    );
+      `("src/runtime/wrapper-conditional-create-require-alias.ts", [
+        { kind: "legacy store filesystem write", line: 13 },
+      ]),
+    }),
+  )("$name", ({ source, filename, expected }) => {
+    const violations = collectDatabaseFirstLegacyStoreViolations(source, filename);
 
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 13 }]);
+    expect(violations).toEqual(expected);
   });
 
-  it("flags legacy paths passed through named wrapper options", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+  // Wrapper argument and default-value propagation.
+  it.each(
+    namedCases({
+      "flags legacy paths passed through named wrapper options": sourceCase`
         import { writeJson } from "../infra/json-files.js";
         function persist(options: { store: string }) {
           return writeJson(options.store, {});
@@ -2202,109 +1367,67 @@ describe("check-database-first-legacy-stores", () => {
         const store = "sessions.json";
         const params = { store };
         await persist(params);
-      `,
-      "src/runtime/named-wrapper-options.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 8 }]);
-  });
-
-  it("flags legacy paths read through chained wrapper option properties", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/named-wrapper-options.ts", [
+        { kind: "legacy store filesystem write", line: 8 },
+      ]),
+      "flags legacy paths read through chained wrapper option properties": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         function persist(params: { filePath: string }) {
           return writeTextAtomic(params.filePath.toString(), "{}\\n");
         }
         const options = { filePath: "sessions.json" };
         await persist(options);
-      `,
-      "src/runtime/chained-wrapper-option-path.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 7 }]);
-  });
-
-  it("flags legacy paths passed through destructured wrapper options", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/chained-wrapper-option-path.ts", [
+        { kind: "legacy store filesystem write", line: 7 },
+      ]),
+      "flags legacy paths passed through destructured wrapper options": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         function persist({ filePath }: { filePath: string }) {
           return writeTextAtomic(filePath, "{}\\n");
         }
         await persist({ filePath: "sessions.json" });
-      `,
-      "src/runtime/destructured-wrapper-options.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 6 }]);
-  });
-
-  it("flags legacy paths passed through nested destructured wrapper options", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/destructured-wrapper-options.ts", [
+        { kind: "legacy store filesystem write", line: 6 },
+      ]),
+      "flags legacy paths passed through nested destructured wrapper options": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         function persist({ paths: { filePath } }: { paths: { filePath: string } }) {
           return writeTextAtomic(filePath, "{}\\n");
         }
         await persist({ paths: { filePath: "sessions.json" } });
-      `,
-      "src/runtime/nested-destructured-wrapper-options.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 6 }]);
-  });
-
-  it("flags legacy paths from nested destructured wrapper option defaults", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-destructured-wrapper-options.ts", [
+        { kind: "legacy store filesystem write", line: 6 },
+      ]),
+      "flags legacy paths from nested destructured wrapper option defaults": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         function persist({ paths: { filePath = "sessions.json" } }: { paths: { filePath?: string } }) {
           return writeTextAtomic(filePath, "{}\\n");
         }
         await persist({ paths: {} });
-      `,
-      "src/runtime/nested-destructured-wrapper-option-default.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 6 }]);
-  });
-
-  it("flags nested parameter defaults from identifier-valued intermediate objects", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-destructured-wrapper-option-default.ts", [
+        { kind: "legacy store filesystem write", line: 6 },
+      ]),
+      "flags nested parameter defaults from identifier-valued intermediate objects": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         const paths = { filePath: "sessions.json" };
         function persist({ paths: { filePath } }: { paths: { filePath: string } } = { paths }) {
           return writeTextAtomic(filePath, "{}\\n");
         }
         await persist();
-      `,
-      "src/runtime/nested-parameter-default-identifier-intermediate.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 7 }]);
-  });
-
-  it("flags nested destructuring defaults from identifier-valued intermediate objects", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-parameter-default-identifier-intermediate.ts", [
+        { kind: "legacy store filesystem write", line: 7 },
+      ]),
+      "flags nested destructuring defaults from identifier-valued intermediate objects": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         const paths = {};
         function persist({ paths: { filePath = "sessions.json" } }: { paths: { filePath?: string } } = { paths }) {
           return writeTextAtomic(filePath, "{}\\n");
         }
         await persist();
-      `,
-      "src/runtime/nested-destructuring-default-identifier-intermediate.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 7 }]);
-  });
-
-  it("flags nested destructuring defaults from aliased known object literals", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-destructuring-default-identifier-intermediate.ts", [
+        { kind: "legacy store filesystem write", line: 7 },
+      ]),
+      "flags nested destructuring defaults from aliased known object literals": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         function persist({ paths: { filePath = "sessions.json" } }: { paths: { filePath?: string } }) {
           return writeTextAtomic(filePath, "{}\\n");
@@ -2312,31 +1435,19 @@ describe("check-database-first-legacy-stores", () => {
         const source = { paths: {} };
         const options = source;
         await persist(options);
-      `,
-      "src/runtime/nested-destructuring-default-aliased-known-object.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 8 }]);
-  });
-
-  it("flags nested destructuring defaults from parent binding defaults", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-destructuring-default-aliased-known-object.ts", [
+        { kind: "legacy store filesystem write", line: 8 },
+      ]),
+      "flags nested destructuring defaults from parent binding defaults": sourceCase`
         import { promises as fs } from "node:fs";
         function persist({ paths: { filePath } = { filePath: "sessions.json" } }) {
           return fs.writeFile(filePath, "{}\\n");
         }
         await persist({});
-      `,
-      "src/runtime/nested-destructuring-parent-binding-default.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 6 }]);
-  });
-
-  it("does not force nested destructured defaults for unknown intermediate properties", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-destructuring-parent-binding-default.ts", [
+        { kind: "legacy store filesystem write", line: 6 },
+      ]),
+      "does not force nested destructured defaults for unknown intermediate properties": sourceCase`
         import { promises as fs } from "node:fs";
         declare function loadPaths(): { filePath?: string };
         function persist({ paths: { filePath = "sessions.json" } }: { paths: { filePath?: string } }) {
@@ -2344,63 +1455,37 @@ describe("check-database-first-legacy-stores", () => {
         }
         const options = { paths: loadPaths() };
         await persist(options);
-      `,
-      "src/runtime/nested-destructured-wrapper-option-unknown-intermediate.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("flags defaults referencing earlier nested destructured identifier parameters", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-destructured-wrapper-option-unknown-intermediate.ts", []),
+      "flags defaults referencing earlier nested destructured identifier parameters": sourceCase`
         import { promises as fs } from "node:fs";
         function writePath({ paths: { filePath } }: { paths: { filePath: string } }, path = filePath) {
           return fs.writeFile(path, "{}\\n");
         }
         const options = { paths: { filePath: "sessions.json" } };
         await writePath(options);
-      `,
-      "src/runtime/nested-destructured-wrapper-earlier-identifier-default.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 7 }]);
-  });
-
-  it("flags defaults referencing earlier nested object parameter properties", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-destructured-wrapper-earlier-identifier-default.ts", [
+        { kind: "legacy store filesystem write", line: 7 },
+      ]),
+      "flags defaults referencing earlier nested object parameter properties": sourceCase`
         import { promises as fs } from "node:fs";
         function writePath(options: { paths: { filePath: string } }, path = options.paths.filePath) {
           return fs.writeFile(path, "{}\\n");
         }
         const options = { paths: { filePath: "sessions.json" } };
         await writePath(options);
-      `,
-      "src/runtime/nested-object-wrapper-earlier-property-default.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 7 }]);
-  });
-
-  it("flags legacy paths passed through positional wrapper parameters", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-object-wrapper-earlier-property-default.ts", [
+        { kind: "legacy store filesystem write", line: 7 },
+      ]),
+      "flags legacy paths passed through positional wrapper parameters": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         function persist(filePath: string) {
           return writeTextAtomic(filePath, "{}\\n");
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/positional-wrapper-path.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 6 }]);
-  });
-
-  it("flags defaulted wrapper parameters after optional safe assignments", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/positional-wrapper-path.ts", [
+        { kind: "legacy store filesystem write", line: 6 },
+      ]),
+      "flags defaulted wrapper parameters after optional safe assignments": sourceCase`
         import { promises as fs } from "node:fs";
         let filePath;
         if (useDb) filePath = currentSqlitePath;
@@ -2408,16 +1493,10 @@ describe("check-database-first-legacy-stores", () => {
           return fs.writeFile(path, "{}\\n");
         }
         await persist(filePath);
-      `,
-      "src/runtime/conditional-undefined-defaulted-wrapper-parameter.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 8 }]);
-  });
-
-  it("flags legacy paths forwarded through nested wrapper helpers", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/conditional-undefined-defaulted-wrapper-parameter.ts", [
+        { kind: "legacy store filesystem write", line: 8 },
+      ]),
+      "flags legacy paths forwarded through nested wrapper helpers": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           function inner(nextPath: string) {
@@ -2426,16 +1505,8 @@ describe("check-database-first-legacy-stores", () => {
           return inner(filePath);
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-wrapper-path.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 9 }]);
-  });
-
-  it("flags legacy paths captured by nested wrapper helpers", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-path.ts", [{ kind: "legacy store filesystem write", line: 9 }]),
+      "flags legacy paths captured by nested wrapper helpers": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           function inner() {
@@ -2444,16 +1515,10 @@ describe("check-database-first-legacy-stores", () => {
           return inner();
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-wrapper-closed-over-path.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 9 }]);
-  });
-
-  it("flags legacy paths captured by nested helpers and forwarded to outer wrappers", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-closed-over-path.ts", [
+        { kind: "legacy store filesystem write", line: 9 },
+      ]),
+      "flags legacy paths captured by nested helpers and forwarded to outer wrappers": sourceCase`
         import { promises as fs } from "node:fs";
         function writePath(path: string) {
           return fs.writeFile(path, "{}\\n");
@@ -2465,16 +1530,10 @@ describe("check-database-first-legacy-stores", () => {
           return inner();
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-helper-forwarded-to-outer-wrapper.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 12 }]);
-  });
-
-  it("keeps closed-over write aliases after loop-scoped shadows", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-helper-forwarded-to-outer-wrapper.ts", [
+        { kind: "legacy store filesystem write", line: 12 },
+      ]),
+      "keeps closed-over write aliases after loop-scoped shadows": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           const write = fs.writeFile;
@@ -2485,16 +1544,10 @@ describe("check-database-first-legacy-stores", () => {
           return inner();
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-wrapper-loop-shadowed-write-alias.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 11 }]);
-  });
-
-  it("flags legacy paths forwarded through nested helper parameter defaults", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-loop-shadowed-write-alias.ts", [
+        { kind: "legacy store filesystem write", line: 11 },
+      ]),
+      "flags legacy paths forwarded through nested helper parameter defaults": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           function inner(nextPath = filePath) {
@@ -2503,16 +1556,10 @@ describe("check-database-first-legacy-stores", () => {
           return inner();
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-helper-parameter-default.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 9 }]);
-  });
-
-  it("flags legacy paths written by callable nested helper parameter defaults", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-helper-parameter-default.ts", [
+        { kind: "legacy store filesystem write", line: 9 },
+      ]),
+      "flags legacy paths written by callable nested helper parameter defaults": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           function inner(save = () => fs.writeFile(filePath, "{}\\n")) {
@@ -2521,16 +1568,11 @@ describe("check-database-first-legacy-stores", () => {
           return inner();
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-helper-callable-parameter-default.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 9 }]);
-  });
-
-  it("does not use callable nested helper parameter defaults when callbacks are provided", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-helper-callable-parameter-default.ts", [
+        { kind: "legacy store filesystem write", line: 9 },
+      ]),
+      "does not use callable nested helper parameter defaults when callbacks are provided":
+        sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           function inner(save = () => fs.writeFile(filePath, "{}\\n")) {
@@ -2539,16 +1581,8 @@ describe("check-database-first-legacy-stores", () => {
           return inner(async () => {});
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-helper-callable-parameter-default-provided.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("flags legacy paths forwarded through undefined nested helper arguments", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-helper-callable-parameter-default-provided.ts", []),
+      "flags legacy paths forwarded through undefined nested helper arguments": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           function inner(nextPath = filePath) {
@@ -2557,16 +1591,10 @@ describe("check-database-first-legacy-stores", () => {
           return inner(undefined);
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-helper-undefined-parameter-default.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 9 }]);
-  });
-
-  it("flags legacy paths forwarded through void nested helper arguments", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-helper-undefined-parameter-default.ts", [
+        { kind: "legacy store filesystem write", line: 9 },
+      ]),
+      "flags legacy paths forwarded through void nested helper arguments": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           function inner(nextPath = filePath) {
@@ -2575,16 +1603,10 @@ describe("check-database-first-legacy-stores", () => {
           return inner(void 0);
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-helper-void-parameter-default.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 9 }]);
-  });
-
-  it("resolves nested helper parameter defaults in the helper scope", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-helper-void-parameter-default.ts", [
+        { kind: "legacy store filesystem write", line: 9 },
+      ]),
+      "resolves nested helper parameter defaults in the helper scope": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           function inner(filePath: string, nextPath = filePath) {
@@ -2593,16 +1615,8 @@ describe("check-database-first-legacy-stores", () => {
           return inner(currentSqlitePath);
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-helper-default-parameter-shadow.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("does not resolve top-level helper parameter defaults in the caller scope", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-helper-default-parameter-shadow.ts", []),
+      "does not resolve top-level helper parameter defaults in the caller scope": sourceCase`
         import { promises as fs } from "node:fs";
         const defaultPath = "current-state.json";
         function writePath(path = defaultPath) {
@@ -2612,16 +1626,8 @@ describe("check-database-first-legacy-stores", () => {
           return writePath();
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/top-level-helper-default-caller-shadow.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("does not resolve top-level helper object binding defaults in the caller scope", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/top-level-helper-default-caller-shadow.ts", []),
+      "does not resolve top-level helper object binding defaults in the caller scope": sourceCase`
         import { promises as fs } from "node:fs";
         const defaultPath = "current-state.json";
         function writePath({ path = defaultPath } = {}) {
@@ -2631,16 +1637,8 @@ describe("check-database-first-legacy-stores", () => {
           return writePath({});
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/top-level-helper-object-binding-default-caller-shadow.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("flags forwarded top-level helper object binding literal defaults", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/top-level-helper-object-binding-default-caller-shadow.ts", []),
+      "flags forwarded top-level helper object binding literal defaults": sourceCase`
         import { promises as fs } from "node:fs";
         function writePath({ path = "sessions.json" } = {}) {
           return fs.writeFile(path, "{}\\n");
@@ -2649,16 +1647,10 @@ describe("check-database-first-legacy-stores", () => {
           return writePath({});
         }
         await persist();
-      `,
-      "src/runtime/top-level-helper-object-binding-literal-default.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 7 }]);
-  });
-
-  it("does not resolve top-level helper expression defaults in the caller scope", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/top-level-helper-object-binding-literal-default.ts", [
+        { kind: "legacy store filesystem write", line: 7 },
+      ]),
+      "does not resolve top-level helper expression defaults in the caller scope": sourceCase`
         import { promises as fs } from "node:fs";
         const fallback = "current-state.json";
         function writePath(path = filePath ?? fallback) {
@@ -2668,16 +1660,8 @@ describe("check-database-first-legacy-stores", () => {
           return writePath();
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/top-level-helper-expression-default-caller-shadow.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("flags top-level helper expression defaults derived from earlier parameters", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/top-level-helper-expression-default-caller-shadow.ts", []),
+      "flags top-level helper expression defaults derived from earlier parameters": sourceCase`
         import { promises as fs } from "node:fs";
         const fallback = "current-state.json";
         function writePath(filePath: string, path = filePath ?? fallback) {
@@ -2687,47 +1671,32 @@ describe("check-database-first-legacy-stores", () => {
           return writePath(filePath);
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/top-level-helper-earlier-parameter-expression-default.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 10 }]);
-  });
-
-  it("flags direct top-level helper calls with defaults derived from earlier arguments", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/top-level-helper-earlier-parameter-expression-default.ts", [
+        { kind: "legacy store filesystem write", line: 10 },
+      ]),
+      "flags direct top-level helper calls with defaults derived from earlier arguments":
+        sourceCase`
         import { promises as fs } from "node:fs";
         const fallback = "current-state.json";
         function writePath(filePath: string, path = filePath ?? fallback) {
           return fs.writeFile(path, "{}\\n");
         }
         await writePath("sessions.json");
-      `,
-      "src/runtime/top-level-helper-direct-earlier-parameter-default.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 7 }]);
-  });
-
-  it("flags direct top-level helper calls with defaults from earlier destructured arguments", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/top-level-helper-direct-earlier-parameter-default.ts", [
+          { kind: "legacy store filesystem write", line: 7 },
+        ]),
+      "flags direct top-level helper calls with defaults from earlier destructured arguments":
+        sourceCase`
         import { promises as fs } from "node:fs";
         function writePath({ filePath }: { filePath: string }, path = filePath) {
           return fs.writeFile(path, "{}\\n");
         }
         await writePath({ filePath: "sessions.json" });
-      `,
-      "src/runtime/top-level-helper-direct-destructured-earlier-parameter-default.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 6 }]);
-  });
-
-  it("flags direct top-level helper calls with defaults from nested destructured arguments", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/top-level-helper-direct-destructured-earlier-parameter-default.ts", [
+          { kind: "legacy store filesystem write", line: 6 },
+        ]),
+      "flags direct top-level helper calls with defaults from nested destructured arguments":
+        sourceCase`
         import { promises as fs } from "node:fs";
         function writePath(
           { paths: { filePath } }: { paths: { filePath: string } },
@@ -2736,16 +1705,10 @@ describe("check-database-first-legacy-stores", () => {
           return fs.writeFile(path, "{}\\n");
         }
         await writePath({ paths: { filePath: "sessions.json" } });
-      `,
-      "src/runtime/top-level-helper-direct-nested-destructured-earlier-parameter-default.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 9 }]);
-  });
-
-  it("does not flag safe defaults that only inspect earlier legacy arguments", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/top-level-helper-direct-nested-destructured-earlier-parameter-default.ts", [
+          { kind: "legacy store filesystem write", line: 9 },
+        ]),
+      "does not flag safe defaults that only inspect earlier legacy arguments": sourceCase`
         import { promises as fs } from "node:fs";
         function writePath(
           filePath: string,
@@ -2754,63 +1717,39 @@ describe("check-database-first-legacy-stores", () => {
           return fs.writeFile(path, "{}\\n");
         }
         await writePath("sessions.json");
-      `,
-      "src/runtime/top-level-helper-safe-conditional-default.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("flags direct top-level helper calls with method defaults from earlier arguments", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/top-level-helper-safe-conditional-default.ts", []),
+      "flags direct top-level helper calls with method defaults from earlier arguments": sourceCase`
         import { promises as fs } from "node:fs";
         function writePath(filePath: string, path = filePath.replace(/\\.json$/, ".json")) {
           return fs.writeFile(path, "{}\\n");
         }
         await writePath("sessions.json");
-      `,
-      "src/runtime/top-level-helper-direct-method-earlier-parameter-default.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 6 }]);
-  });
-
-  it("flags direct top-level helper calls with comma defaults from earlier arguments", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/top-level-helper-direct-method-earlier-parameter-default.ts", [
+        { kind: "legacy store filesystem write", line: 6 },
+      ]),
+      "flags direct top-level helper calls with comma defaults from earlier arguments": sourceCase`
         import { promises as fs } from "node:fs";
         const safePath = "current-state.json";
         function writePath(filePath: string, path = (safePath, filePath)) {
           return fs.writeFile(path, "{}\\n");
         }
         await writePath("sessions.json");
-      `,
-      "src/runtime/top-level-helper-direct-comma-earlier-parameter-default.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 7 }]);
-  });
-
-  it("flags direct top-level helper calls with assignment defaults from earlier arguments", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/top-level-helper-direct-comma-earlier-parameter-default.ts", [
+        { kind: "legacy store filesystem write", line: 7 },
+      ]),
+      "flags direct top-level helper calls with assignment defaults from earlier arguments":
+        sourceCase`
         import { promises as fs } from "node:fs";
         let cached = "current-state.json";
         function writePath(filePath: string, path = (cached = filePath)) {
           return fs.writeFile(path, "{}\\n");
         }
         await writePath("sessions.json");
-      `,
-      "src/runtime/top-level-helper-direct-assignment-earlier-parameter-default.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 7 }]);
-  });
-
-  it("flags top-level helper object binding expression defaults derived from earlier parameters", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/top-level-helper-direct-assignment-earlier-parameter-default.ts", [
+          { kind: "legacy store filesystem write", line: 7 },
+        ]),
+      "flags top-level helper object binding expression defaults derived from earlier parameters":
+        sourceCase`
         import { promises as fs } from "node:fs";
         const fallback = "current-state.json";
         function writePath(filePath: string, { path = filePath ?? fallback } = {}) {
@@ -2820,95 +1759,59 @@ describe("check-database-first-legacy-stores", () => {
           return writePath(filePath, {});
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/top-level-helper-object-binding-earlier-parameter-expression-default.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 10 }]);
-  });
-
-  it("flags direct top-level helper calls with object binding defaults from earlier arguments", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/top-level-helper-object-binding-earlier-parameter-expression-default.ts", [
+          { kind: "legacy store filesystem write", line: 10 },
+        ]),
+      "flags direct top-level helper calls with object binding defaults from earlier arguments":
+        sourceCase`
         import { promises as fs } from "node:fs";
         const fallback = "current-state.json";
         function writePath(filePath: string, { path = filePath ?? fallback } = {}) {
           return fs.writeFile(path, "{}\\n");
         }
         await writePath("sessions.json");
-      `,
-      "src/runtime/top-level-helper-direct-object-binding-earlier-parameter-default.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 7 }]);
-  });
-
-  it("flags object binding defaults from missing properties on identifier arguments", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/top-level-helper-direct-object-binding-earlier-parameter-default.ts", [
+          { kind: "legacy store filesystem write", line: 7 },
+        ]),
+      "flags object binding defaults from missing properties on identifier arguments": sourceCase`
         import { promises as fs } from "node:fs";
         const options = {};
         function writePath(filePath: string, { path = filePath } = {}) {
           return fs.writeFile(path, "{}\\n");
         }
         await writePath("sessions.json", options);
-      `,
-      "src/runtime/top-level-helper-object-binding-missing-identifier-default.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 7 }]);
-  });
-
-  it("flags object binding defaults from undefined properties on identifier arguments", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/top-level-helper-object-binding-missing-identifier-default.ts", [
+        { kind: "legacy store filesystem write", line: 7 },
+      ]),
+      "flags object binding defaults from undefined properties on identifier arguments": sourceCase`
         import { promises as fs } from "node:fs";
         const options = { path: undefined };
         function writePath(filePath: string, { path = filePath } = {}) {
           return fs.writeFile(path, "{}\\n");
         }
         await writePath("sessions.json", options);
-      `,
-      "src/runtime/top-level-helper-object-binding-undefined-identifier-default.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 7 }]);
-  });
-
-  it("flags object binding defaults from undefined properties in parameter defaults", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/top-level-helper-object-binding-undefined-identifier-default.ts", [
+        { kind: "legacy store filesystem write", line: 7 },
+      ]),
+      "flags object binding defaults from undefined properties in parameter defaults": sourceCase`
         import { promises as fs } from "node:fs";
         function writePath({ path = "sessions.json" } = { path: undefined }) {
           return fs.writeFile(path, "{}\\n");
         }
         await writePath();
-      `,
-      "src/runtime/top-level-helper-object-binding-undefined-parameter-default.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 6 }]);
-  });
-
-  it("uses explicit safe properties on identifier arguments before object binding defaults", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/top-level-helper-object-binding-undefined-parameter-default.ts", [
+        { kind: "legacy store filesystem write", line: 6 },
+      ]),
+      "uses explicit safe properties on identifier arguments before object binding defaults":
+        sourceCase`
         import { promises as fs } from "node:fs";
         const options = { path: "current-state.json" };
         function writePath(filePath: string, { path = filePath } = {}) {
           return fs.writeFile(path, "{}\\n");
         }
         await writePath("sessions.json", options);
-      `,
-      "src/runtime/top-level-helper-object-binding-safe-identifier-property.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("does not force object binding defaults for unknown identifier arguments", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/top-level-helper-object-binding-safe-identifier-property.ts", []),
+      "does not force object binding defaults for unknown identifier arguments": sourceCase`
         import { promises as fs } from "node:fs";
         declare function loadOptions(): { path?: string };
         const options = loadOptions();
@@ -2916,16 +1819,9 @@ describe("check-database-first-legacy-stores", () => {
           return fs.writeFile(path, "{}\\n");
         }
         await writePath("sessions.json", options);
-      `,
-      "src/runtime/top-level-helper-object-binding-unknown-identifier-default.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("does not force object binding defaults for identifier arguments with unknown spreads", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/top-level-helper-object-binding-unknown-identifier-default.ts", []),
+      "does not force object binding defaults for identifier arguments with unknown spreads":
+        sourceCase`
         import { promises as fs } from "node:fs";
         declare const defaults: { path?: string };
         const options = { ...defaults };
@@ -2933,16 +1829,8 @@ describe("check-database-first-legacy-stores", () => {
           return fs.writeFile(path, "{}\\n");
         }
         await writePath("sessions.json", options);
-      `,
-      "src/runtime/top-level-helper-object-binding-unknown-spread-default.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("keeps explicit undefined object properties after exhaustive branch merges", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/top-level-helper-object-binding-unknown-spread-default.ts", []),
+      "keeps explicit undefined object properties after exhaustive branch merges": sourceCase`
         import { promises as fs } from "node:fs";
         function writePath(filePath: string, { path = filePath } = {}) {
           return fs.writeFile(path, "{}\\n");
@@ -2954,16 +1842,10 @@ describe("check-database-first-legacy-stores", () => {
           options.path = undefined;
         }
         await writePath("sessions.json", options);
-      `,
-      "src/runtime/top-level-helper-object-binding-branch-undefined-default.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 12 }]);
-  });
-
-  it("keeps maybe undefined object properties after exhaustive branch merges", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/top-level-helper-object-binding-branch-undefined-default.ts", [
+        { kind: "legacy store filesystem write", line: 12 },
+      ]),
+      "keeps maybe undefined object properties after exhaustive branch merges": sourceCase`
         import { promises as fs } from "node:fs";
         function writePath(filePath: string, { path = filePath } = {}) {
           return fs.writeFile(path, "{}\\n");
@@ -2975,16 +1857,10 @@ describe("check-database-first-legacy-stores", () => {
           options.path = "current-state.json";
         }
         await writePath("sessions.json", options);
-      `,
-      "src/runtime/top-level-helper-object-binding-branch-maybe-undefined-default.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 12 }]);
-  });
-
-  it("keeps known nested object literals after exhaustive branch merges", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/top-level-helper-object-binding-branch-maybe-undefined-default.ts", [
+        { kind: "legacy store filesystem write", line: 12 },
+      ]),
+      "keeps known nested object literals after exhaustive branch merges": sourceCase`
         import { promises as fs } from "node:fs";
         function writePath({ paths: { filePath = "sessions.json" } = {} }) {
           return fs.writeFile(filePath, "{}\\n");
@@ -2996,16 +1872,11 @@ describe("check-database-first-legacy-stores", () => {
           options = { paths: {} };
         }
         await writePath(options);
-      `,
-      "src/runtime/top-level-helper-object-binding-branch-known-nested-object.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 12 }]);
-  });
-
-  it("does not force object binding defaults after exhaustive unknown object branch merges", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/top-level-helper-object-binding-branch-known-nested-object.ts", [
+        { kind: "legacy store filesystem write", line: 12 },
+      ]),
+      "does not force object binding defaults after exhaustive unknown object branch merges":
+        sourceCase`
         import { promises as fs } from "node:fs";
         declare function loadOptions(): { path?: string };
         function writePath(filePath: string, { path = filePath } = {}) {
@@ -3018,16 +1889,8 @@ describe("check-database-first-legacy-stores", () => {
           options = loadOptions();
         }
         await writePath("sessions.json", options);
-      `,
-      "src/runtime/top-level-helper-object-binding-branch-unknown-default.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("does not force object binding defaults after optional unknown object rewrites", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/top-level-helper-object-binding-branch-unknown-default.ts", []),
+      "does not force object binding defaults after optional unknown object rewrites": sourceCase`
         import { promises as fs } from "node:fs";
         declare function loadOptions(): { path?: string };
         function writePath(filePath: string, { path = filePath } = {}) {
@@ -3038,16 +1901,8 @@ describe("check-database-first-legacy-stores", () => {
           options = {};
         }
         await writePath("sessions.json", options);
-      `,
-      "src/runtime/top-level-helper-object-binding-optional-unknown-rewrite-default.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("keeps known-missing object properties after exhaustive branch merges", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/top-level-helper-object-binding-optional-unknown-rewrite-default.ts", []),
+      "keeps known-missing object properties after exhaustive branch merges": sourceCase`
         import { promises as fs } from "node:fs";
         function writePath(filePath: string, { path = filePath } = {}) {
           return fs.writeFile(path, "{}\\n");
@@ -3059,31 +1914,19 @@ describe("check-database-first-legacy-stores", () => {
           options = {};
         }
         await writePath("sessions.json", options);
-      `,
-      "src/runtime/top-level-helper-object-binding-branch-known-missing-default.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 12 }]);
-  });
-
-  it("flags object binding defaults from earlier destructured arguments", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/top-level-helper-object-binding-branch-known-missing-default.ts", [
+        { kind: "legacy store filesystem write", line: 12 },
+      ]),
+      "flags object binding defaults from earlier destructured arguments": sourceCase`
         import { promises as fs } from "node:fs";
         function writePath({ filePath }: { filePath: string }, { path = filePath } = {}) {
           return fs.writeFile(path, "{}\\n");
         }
         await writePath({ filePath: "sessions.json" }, {});
-      `,
-      "src/runtime/top-level-helper-object-binding-destructured-earlier-parameter-default.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 6 }]);
-  });
-
-  it("flags object binding defaults from nested destructured arguments", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/top-level-helper-object-binding-destructured-earlier-parameter-default.ts", [
+        { kind: "legacy store filesystem write", line: 6 },
+      ]),
+      "flags object binding defaults from nested destructured arguments": sourceCase`
         import { promises as fs } from "node:fs";
         function writePath(
           { paths: { filePath } }: { paths: { filePath: string } },
@@ -3092,16 +1935,11 @@ describe("check-database-first-legacy-stores", () => {
           return fs.writeFile(path, "{}\\n");
         }
         await writePath({ paths: { filePath: "sessions.json" } }, {});
-      `,
-      "src/runtime/top-level-helper-object-binding-nested-destructured-earlier-parameter-default.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 9 }]);
-  });
-
-  it("does not scan unrelated object properties for earlier property defaults", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `(
+        "src/runtime/top-level-helper-object-binding-nested-destructured-earlier-parameter-default.ts",
+        [{ kind: "legacy store filesystem write", line: 9 }],
+      ),
+      "does not scan unrelated object properties for earlier property defaults": sourceCase`
         import { promises as fs } from "node:fs";
         function writePath(
           options: { currentPath: string; legacyPath: string },
@@ -3113,16 +1951,8 @@ describe("check-database-first-legacy-stores", () => {
           currentPath: "state/openclaw.sqlite",
           legacyPath: "sessions.json",
         });
-      `,
-      "src/runtime/top-level-helper-property-default-unrelated-legacy-property.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("does not scan unrelated object properties for bracket defaults", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/top-level-helper-property-default-unrelated-legacy-property.ts", []),
+      "does not scan unrelated object properties for bracket defaults": sourceCase`
         import { promises as fs } from "node:fs";
         function writePath(
           options: { currentPath: string; legacyPath: string },
@@ -3134,16 +1964,8 @@ describe("check-database-first-legacy-stores", () => {
           currentPath: "state/openclaw.sqlite",
           legacyPath: "sessions.json",
         });
-      `,
-      "src/runtime/top-level-helper-bracket-default-unrelated-legacy-property.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("flags direct top-level helper calls with nested property defaults", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/top-level-helper-bracket-default-unrelated-legacy-property.ts", []),
+      "flags direct top-level helper calls with nested property defaults": sourceCase`
         import { promises as fs } from "node:fs";
         function writePath(
           options: { paths: { filePath: string } },
@@ -3154,16 +1976,10 @@ describe("check-database-first-legacy-stores", () => {
         await writePath({
           paths: { filePath: "sessions.json" },
         });
-      `,
-      "src/runtime/top-level-helper-nested-property-default.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 9 }]);
-  });
-
-  it("flags direct top-level helper calls with nested bracket property defaults", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/top-level-helper-nested-property-default.ts", [
+        { kind: "legacy store filesystem write", line: 9 },
+      ]),
+      "flags direct top-level helper calls with nested bracket property defaults": sourceCase`
         import { promises as fs } from "node:fs";
         function writePath(
           options: { paths: { filePath: string } },
@@ -3174,16 +1990,10 @@ describe("check-database-first-legacy-stores", () => {
         await writePath({
           paths: { filePath: "sessions.json" },
         });
-      `,
-      "src/runtime/top-level-helper-nested-bracket-property-default.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 9 }]);
-  });
-
-  it("does not crash on unknown spreads in nested property defaults", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/top-level-helper-nested-bracket-property-default.ts", [
+        { kind: "legacy store filesystem write", line: 9 },
+      ]),
+      "does not crash on unknown spreads in nested property defaults": sourceCase`
         import { promises as fs } from "node:fs";
         declare const defaults: { paths?: { filePath: string } };
         function writePath(
@@ -3193,48 +2003,28 @@ describe("check-database-first-legacy-stores", () => {
           return fs.writeFile(path, "{}\\n");
         }
         await writePath({ ...defaults });
-      `,
-      "src/runtime/top-level-helper-nested-property-default-unknown-spread.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("keeps nested legacy paths before unknown outer spreads", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/top-level-helper-nested-property-default-unknown-spread.ts", []),
+      "keeps nested legacy paths before unknown outer spreads": sourceCase`
         import { promises as fs } from "node:fs";
         declare const options: { paths?: { filePath: string } };
         function persist({ paths: { filePath } }: { paths: { filePath: string } }) {
           return fs.writeFile(filePath, "{}\\n");
         }
         await persist({ paths: { filePath: "sessions.json" }, ...options });
-      `,
-      "src/runtime/nested-wrapper-path-before-unknown-spread.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 7 }]);
-  });
-
-  it("flags nested legacy paths passed through shorthand options", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-path-before-unknown-spread.ts", [
+        { kind: "legacy store filesystem write", line: 7 },
+      ]),
+      "flags nested legacy paths passed through shorthand options": sourceCase`
         import { promises as fs } from "node:fs";
         const paths = { filePath: "sessions.json" };
         function writePath(options: { paths: { filePath: string } }, path = options.paths.filePath) {
           return fs.writeFile(path, "{}\\n");
         }
         await writePath({ paths });
-      `,
-      "src/runtime/top-level-helper-nested-shorthand-options.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 7 }]);
-  });
-
-  it("flags nested legacy paths forwarded through identifier-valued object properties", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/top-level-helper-nested-shorthand-options.ts", [
+        { kind: "legacy store filesystem write", line: 7 },
+      ]),
+      "flags nested legacy paths forwarded through identifier-valued object properties": sourceCase`
         import { promises as fs } from "node:fs";
         function persist({ paths: { filePath } }: { paths: { filePath: string } }) {
           return fs.writeFile(filePath, "{}\\n");
@@ -3242,47 +2032,30 @@ describe("check-database-first-legacy-stores", () => {
         const paths = { filePath: "sessions.json" };
         const options = { paths };
         await persist(options);
-      `,
-      "src/runtime/nested-wrapper-identifier-valued-object-property.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 8 }]);
-  });
-
-  it("flags nested legacy paths hidden in intermediate option expressions", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-identifier-valued-object-property.ts", [
+        { kind: "legacy store filesystem write", line: 8 },
+      ]),
+      "flags nested legacy paths hidden in intermediate option expressions": sourceCase`
         import { promises as fs } from "node:fs";
         declare function makePaths(filePath: string): { filePath: string };
         function persist({ paths: { filePath } }: { paths: { filePath: string } }) {
           return fs.writeFile(filePath, "{}\\n");
         }
         await persist({ paths: makePaths("sessions.json") });
-      `,
-      "src/runtime/nested-wrapper-path-intermediate-expression.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 7 }]);
-  });
-
-  it("flags direct top-level helper calls with chained literal parameter defaults", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-path-intermediate-expression.ts", [
+        { kind: "legacy store filesystem write", line: 7 },
+      ]),
+      "flags direct top-level helper calls with chained literal parameter defaults": sourceCase`
         import { promises as fs } from "node:fs";
         function writePath(filePath = "sessions.json", path = filePath) {
           return fs.writeFile(path, "{}\\n");
         }
         await writePath();
-      `,
-      "src/runtime/top-level-helper-chained-literal-parameter-default.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 6 }]);
-  });
-
-  it("flags direct top-level helper calls with nested object literal parameter defaults", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/top-level-helper-chained-literal-parameter-default.ts", [
+        { kind: "legacy store filesystem write", line: 6 },
+      ]),
+      "flags direct top-level helper calls with nested object literal parameter defaults":
+        sourceCase`
         import { promises as fs } from "node:fs";
         function writePath(
           options = { paths: { filePath: "sessions.json" } },
@@ -3291,16 +2064,10 @@ describe("check-database-first-legacy-stores", () => {
           return fs.writeFile(path, "{}\\n");
         }
         await writePath();
-      `,
-      "src/runtime/top-level-helper-nested-object-literal-parameter-default.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 9 }]);
-  });
-
-  it("flags direct top-level helper calls with nested spread parameter defaults", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/top-level-helper-nested-object-literal-parameter-default.ts", [
+          { kind: "legacy store filesystem write", line: 9 },
+        ]),
+      "flags direct top-level helper calls with nested spread parameter defaults": sourceCase`
         import { promises as fs } from "node:fs";
         const defaults = { paths: { filePath: "sessions.json" } };
         function writePath(
@@ -3310,16 +2077,10 @@ describe("check-database-first-legacy-stores", () => {
           return fs.writeFile(path, "{}\\n");
         }
         await writePath();
-      `,
-      "src/runtime/top-level-helper-nested-spread-parameter-default.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 10 }]);
-  });
-
-  it("does not resolve top-level helper nested spread defaults in the caller scope", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/top-level-helper-nested-spread-parameter-default.ts", [
+        { kind: "legacy store filesystem write", line: 10 },
+      ]),
+      "does not resolve top-level helper nested spread defaults in the caller scope": sourceCase`
         import { promises as fs } from "node:fs";
         const defaults = { paths: { filePath: "current-state.json" } };
         function writePath(
@@ -3333,16 +2094,8 @@ describe("check-database-first-legacy-stores", () => {
           return writePath();
         }
         await persist();
-      `,
-      "src/runtime/top-level-helper-nested-spread-default-caller-shadow.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("does not resolve omitted earlier helper parameters in the caller scope", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/top-level-helper-nested-spread-default-caller-shadow.ts", []),
+      "does not resolve omitted earlier helper parameters in the caller scope": sourceCase`
         import { promises as fs } from "node:fs";
         function writePath(filePath?: string, path = filePath) {
           return fs.writeFile(path, "{}\\n");
@@ -3351,16 +2104,8 @@ describe("check-database-first-legacy-stores", () => {
           return writePath();
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/top-level-helper-omitted-earlier-default.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("does not resolve omitted earlier helper parameters in object binding defaults", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/top-level-helper-omitted-earlier-default.ts", []),
+      "does not resolve omitted earlier helper parameters in object binding defaults": sourceCase`
         import { promises as fs } from "node:fs";
         function writePath(filePath?: string, { path = filePath } = {}) {
           return fs.writeFile(path, "{}\\n");
@@ -3369,16 +2114,8 @@ describe("check-database-first-legacy-stores", () => {
           return writePath(undefined, {});
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/top-level-helper-object-binding-omitted-earlier-default.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("flags default expressions that combine multiple earlier parameters", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/top-level-helper-object-binding-omitted-earlier-default.ts", []),
+      "flags default expressions that combine multiple earlier parameters": sourceCase`
         import { promises as fs } from "node:fs";
         function writePath(prefix: string, filePath: string, path = prefix + filePath) {
           return fs.writeFile(path, "{}\\n");
@@ -3387,16 +2124,10 @@ describe("check-database-first-legacy-stores", () => {
           return writePath("state/", filePath);
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/top-level-helper-multiple-earlier-parameter-default.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 9 }]);
-  });
-
-  it("does not resolve top-level helper defaults in closed-over caller scope", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/top-level-helper-multiple-earlier-parameter-default.ts", [
+        { kind: "legacy store filesystem write", line: 9 },
+      ]),
+      "does not resolve top-level helper defaults in closed-over caller scope": sourceCase`
         import { promises as fs } from "node:fs";
         const defaultPath = "current-state.json";
         function writePath(path = defaultPath) {
@@ -3409,16 +2140,8 @@ describe("check-database-first-legacy-stores", () => {
           return inner();
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/top-level-helper-default-closed-over-caller-shadow.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("does not treat top-level helper aliases as closed over nested helpers", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/top-level-helper-default-closed-over-caller-shadow.ts", []),
+      "does not treat top-level helper aliases as closed over nested helpers": sourceCase`
         import { promises as fs } from "node:fs";
         const filePath = "current-state.json";
         function writeCurrent() {
@@ -3432,16 +2155,8 @@ describe("check-database-first-legacy-stores", () => {
           return inner();
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/top-level-helper-alias-module-path-shadow.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("does not resolve aliased top-level helper defaults in the caller scope", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/top-level-helper-alias-module-path-shadow.ts", []),
+      "does not resolve aliased top-level helper defaults in the caller scope": sourceCase`
         import { promises as fs } from "node:fs";
         const defaultPath = "current-state.json";
         function writePath(path = defaultPath) {
@@ -3452,16 +2167,18 @@ describe("check-database-first-legacy-stores", () => {
           return save();
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/top-level-helper-alias-default-caller-shadow.ts",
-    );
+      `("src/runtime/top-level-helper-alias-default-caller-shadow.ts", []),
+    }),
+  )("$name", ({ source, filename, expected }) => {
+    const violations = collectDatabaseFirstLegacyStoreViolations(source, filename);
 
-    expect(violations).toEqual([]);
+    expect(violations).toEqual(expected);
   });
 
-  it("flags legacy paths forwarded through nested helper object binding defaults", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+  // Nested helper capture and wrapper propagation.
+  it.each(
+    namedCases({
+      "flags legacy paths forwarded through nested helper object binding defaults": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           function inner({ path = filePath } = {}) {
@@ -3470,16 +2187,11 @@ describe("check-database-first-legacy-stores", () => {
           return inner();
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-helper-object-binding-default.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 9 }]);
-  });
-
-  it("does not use nested helper object binding defaults when a spread may provide the property", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-helper-object-binding-default.ts", [
+        { kind: "legacy store filesystem write", line: 9 },
+      ]),
+      "does not use nested helper object binding defaults when a spread may provide the property":
+        sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           const options = getOptions();
@@ -3489,16 +2201,8 @@ describe("check-database-first-legacy-stores", () => {
           return inner({ ...options });
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-helper-object-binding-default-unknown-spread.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("flags nested helper object binding defaults after known-empty object spreads", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-helper-object-binding-default-unknown-spread.ts", []),
+      "flags nested helper object binding defaults after known-empty object spreads": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           const defaults = {};
@@ -3508,16 +2212,10 @@ describe("check-database-first-legacy-stores", () => {
           return inner({ ...defaults, ...{} });
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-helper-object-binding-default-known-empty-spread.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 10 }]);
-  });
-
-  it("resolves nested helper object binding defaults in the helper scope", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-helper-object-binding-default-known-empty-spread.ts", [
+        { kind: "legacy store filesystem write", line: 10 },
+      ]),
+      "resolves nested helper object binding defaults in the helper scope": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           function inner(filePath: string, { path = filePath } = {}) {
@@ -3526,16 +2224,8 @@ describe("check-database-first-legacy-stores", () => {
           return inner(currentSqlitePath, {});
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-helper-object-binding-default-shadow.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("flags legacy paths forwarded through undefined nested helper object arguments", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-helper-object-binding-default-shadow.ts", []),
+      "flags legacy paths forwarded through undefined nested helper object arguments": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           function inner({ path = filePath } = {}) {
@@ -3544,16 +2234,11 @@ describe("check-database-first-legacy-stores", () => {
           return inner(undefined);
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-helper-undefined-object-binding-default.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 9 }]);
-  });
-
-  it("flags legacy paths forwarded through explicit undefined nested helper object properties", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-helper-undefined-object-binding-default.ts", [
+        { kind: "legacy store filesystem write", line: 9 },
+      ]),
+      "flags legacy paths forwarded through explicit undefined nested helper object properties":
+        sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           function inner({ path = filePath } = {}) {
@@ -3562,16 +2247,10 @@ describe("check-database-first-legacy-stores", () => {
           return inner({ path: undefined });
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-helper-undefined-object-property-default.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 9 }]);
-  });
-
-  it("flags legacy paths captured by nested helpers with local fs aliases", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-helper-undefined-object-property-default.ts", [
+          { kind: "legacy store filesystem write", line: 9 },
+        ]),
+      "flags legacy paths captured by nested helpers with local fs aliases": sourceCase`
         function persist(filePath: string) {
           function inner() {
             const fs = require("node:fs");
@@ -3580,16 +2259,11 @@ describe("check-database-first-legacy-stores", () => {
           return inner();
         }
         persist("sessions.json");
-      `,
-      "src/runtime/nested-wrapper-closed-over-local-fs.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 9 }]);
-  });
-
-  it("does not treat named function expression self-bindings as captured write aliases", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-closed-over-local-fs.ts", [
+        { kind: "legacy store filesystem write", line: 9 },
+      ]),
+      "does not treat named function expression self-bindings as captured write aliases":
+        sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           const writeFile = fs.writeFile;
@@ -3599,16 +2273,8 @@ describe("check-database-first-legacy-stores", () => {
           return inner();
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/named-function-expression-write-alias-shadow.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("flags legacy paths captured by defaulted destructured nested helpers", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/named-function-expression-write-alias-shadow.ts", []),
+      "flags legacy paths captured by defaulted destructured nested helpers": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           const writer = {};
@@ -3619,16 +2285,11 @@ describe("check-database-first-legacy-stores", () => {
           return inner();
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/defaulted-destructured-nested-helper.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 11 }]);
-  });
-
-  it("does not use nested helper destructuring defaults when safe callbacks are present", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/defaulted-destructured-nested-helper.ts", [
+        { kind: "legacy store filesystem write", line: 11 },
+      ]),
+      "does not use nested helper destructuring defaults when safe callbacks are present":
+        sourceCase`
         import { promises as fs } from "node:fs";
         const noopParam = async (_path: string) => {};
         function persist(filePath: string) {
@@ -3640,16 +2301,9 @@ describe("check-database-first-legacy-stores", () => {
           return inner();
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/present-safe-callback-nested-default.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("uses nested helper destructuring defaults when properties are explicitly undefined", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/present-safe-callback-nested-default.ts", []),
+      "uses nested helper destructuring defaults when properties are explicitly undefined":
+        sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           function inner() {
@@ -3660,16 +2314,10 @@ describe("check-database-first-legacy-stores", () => {
           return inner();
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/undefined-callback-nested-default.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 11 }]);
-  });
-
-  it("does not resolve outer object methods through local object shadows", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/undefined-callback-nested-default.ts", [
+          { kind: "legacy store filesystem write", line: 11 },
+        ]),
+      "does not resolve outer object methods through local object shadows": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           const writer = {
@@ -3685,16 +2333,8 @@ describe("check-database-first-legacy-stores", () => {
           return inner();
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/local-object-shadow-nested-method.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("keeps branch-only object methods inside closed-over nested helpers", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/local-object-shadow-nested-method.ts", []),
+      "keeps branch-only object methods inside closed-over nested helpers": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string, enabled: boolean) {
           function inner() {
@@ -3714,16 +2354,10 @@ describe("check-database-first-legacy-stores", () => {
           return inner();
         }
         await persist("sessions.json", true);
-      `,
-      "src/runtime/branch-only-closed-over-object-method.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 20 }]);
-  });
-
-  it("keeps branch-only property assigned methods inside closed-over nested helpers", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/branch-only-closed-over-object-method.ts", [
+        { kind: "legacy store filesystem write", line: 20 },
+      ]),
+      "keeps branch-only property assigned methods inside closed-over nested helpers": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string, enabled: boolean) {
           function inner() {
@@ -3738,16 +2372,11 @@ describe("check-database-first-legacy-stores", () => {
           return inner();
         }
         await persist("sessions.json", true);
-      `,
-      "src/runtime/branch-only-property-closed-over-object-method.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 15 }]);
-  });
-
-  it("flags legacy paths captured by nested helpers with branch-assigned write aliases", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/branch-only-property-closed-over-object-method.ts", [
+        { kind: "legacy store filesystem write", line: 15 },
+      ]),
+      "flags legacy paths captured by nested helpers with branch-assigned write aliases":
+        sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string, json: boolean) {
           function inner() {
@@ -3762,16 +2391,10 @@ describe("check-database-first-legacy-stores", () => {
           return inner();
         }
         await persist("sessions.json", true);
-      `,
-      "src/runtime/nested-wrapper-branch-assigned-write-alias.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 15 }]);
-  });
-
-  it("flags legacy paths captured by conditionally assigned nested helpers", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-branch-assigned-write-alias.ts", [
+          { kind: "legacy store filesystem write", line: 15 },
+        ]),
+      "flags legacy paths captured by conditionally assigned nested helpers": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string, json: boolean) {
           function inner() {
@@ -3786,16 +2409,10 @@ describe("check-database-first-legacy-stores", () => {
           return inner();
         }
         await persist("sessions.json", true);
-      `,
-      "src/runtime/conditionally-assigned-nested-helper.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 15 }]);
-  });
-
-  it("keeps legacy nested helpers after braceless optional reassignment", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/conditionally-assigned-nested-helper.ts", [
+        { kind: "legacy store filesystem write", line: 15 },
+      ]),
+      "keeps legacy nested helpers after braceless optional reassignment": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string, disabled: boolean) {
           function inner() {
@@ -3806,16 +2423,10 @@ describe("check-database-first-legacy-stores", () => {
           return inner();
         }
         await persist("sessions.json", false);
-      `,
-      "src/runtime/nested-wrapper-braceless-optional-reassignment.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 11 }]);
-  });
-
-  it("flags legacy paths captured by nested helpers with destructured fs aliases", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-braceless-optional-reassignment.ts", [
+        { kind: "legacy store filesystem write", line: 11 },
+      ]),
+      "flags legacy paths captured by nested helpers with destructured fs aliases": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           function inner() {
@@ -3825,16 +2436,10 @@ describe("check-database-first-legacy-stores", () => {
           return inner();
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-wrapper-closed-over-destructured-fs.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 10 }]);
-  });
-
-  it("ignores nested helpers with shadowed local require aliases", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-closed-over-destructured-fs.ts", [
+        { kind: "legacy store filesystem write", line: 10 },
+      ]),
+      "ignores nested helpers with shadowed local require aliases": sourceCase`
         function persist(filePath: string, customRequire: NodeRequire) {
           function inner() {
             const require = customRequire;
@@ -3844,16 +2449,8 @@ describe("check-database-first-legacy-stores", () => {
           return inner();
         }
         persist("sessions.json", customRequire);
-      `,
-      "src/runtime/nested-wrapper-shadowed-require.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("uses nested helper createRequire shadows from the helper definition", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-shadowed-require.ts", []),
+      "uses nested helper createRequire shadows from the helper definition": sourceCase`
         import { createRequire } from "node:module";
         function persist(filePath: string, customCreateRequire: typeof createRequire) {
           function inner() {
@@ -3867,16 +2464,10 @@ describe("check-database-first-legacy-stores", () => {
           }
         }
         persist("sessions.json", customCreateRequire);
-      `,
-      "src/runtime/nested-wrapper-create-require-definition-scope.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 14 }]);
-  });
-
-  it("does not treat named nested function expressions as closed-over path parameters", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-create-require-definition-scope.ts", [
+        { kind: "legacy store filesystem write", line: 14 },
+      ]),
+      "does not treat named nested function expressions as closed-over path parameters": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           const inner = function filePath() {
@@ -3885,16 +2476,8 @@ describe("check-database-first-legacy-stores", () => {
           return inner();
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-wrapper-named-function-expression.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("does not resolve locally shadowed nested helper calls to outer wrappers", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-named-function-expression.ts", []),
+      "does not resolve locally shadowed nested helper calls to outer wrappers": sourceCase`
         import { promises as fs } from "node:fs";
         function helper(filePath: string) {
           return fs.writeFile(filePath, "{}\\n");
@@ -3906,16 +2489,8 @@ describe("check-database-first-legacy-stores", () => {
           return inner(async () => {});
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-wrapper-shadowed-helper-call.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("flags legacy paths captured by branch-assigned nested helpers", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-shadowed-helper-call.ts", []),
+      "flags legacy paths captured by branch-assigned nested helpers": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string, useJson: boolean) {
           let inner;
@@ -3925,16 +2500,10 @@ describe("check-database-first-legacy-stores", () => {
           return inner();
         }
         await persist("sessions.json", true);
-      `,
-      "src/runtime/nested-wrapper-branch-assigned-closed-over-path.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 10 }]);
-  });
-
-  it("flags legacy paths captured through nested helper chains", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-branch-assigned-closed-over-path.ts", [
+        { kind: "legacy store filesystem write", line: 10 },
+      ]),
+      "flags legacy paths captured through nested helper chains": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           function inner() {
@@ -3946,16 +2515,10 @@ describe("check-database-first-legacy-stores", () => {
           return inner();
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-wrapper-helper-chain-closed-over-path.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 12 }]);
-  });
-
-  it("flags legacy paths captured through hoisted nested helper chains", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-helper-chain-closed-over-path.ts", [
+        { kind: "legacy store filesystem write", line: 12 },
+      ]),
+      "flags legacy paths captured through hoisted nested helper chains": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           function inner() {
@@ -3967,16 +2530,10 @@ describe("check-database-first-legacy-stores", () => {
           return inner();
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-wrapper-hoisted-helper-chain-closed-over-path.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 12 }]);
-  });
-
-  it("flags hoisted nested helpers that use write aliases declared later", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-hoisted-helper-chain-closed-over-path.ts", [
+        { kind: "legacy store filesystem write", line: 12 },
+      ]),
+      "flags hoisted nested helpers that use write aliases declared later": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           function inner() {
@@ -3989,16 +2546,10 @@ describe("check-database-first-legacy-stores", () => {
           return inner();
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-wrapper-hoisted-helper-late-alias.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 13 }]);
-  });
-
-  it("flags escaped nested helpers that use write aliases declared later", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-hoisted-helper-late-alias.ts", [
+        { kind: "legacy store filesystem write", line: 13 },
+      ]),
+      "flags escaped nested helpers that use write aliases declared later": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           let save;
@@ -4010,16 +2561,10 @@ describe("check-database-first-legacy-stores", () => {
           return save?.();
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-wrapper-escaped-late-write-alias.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 12 }]);
-  });
-
-  it("flags block-escaped nested helpers that use block write aliases declared later", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-escaped-late-write-alias.ts", [
+        { kind: "legacy store filesystem write", line: 12 },
+      ]),
+      "flags block-escaped nested helpers that use block write aliases declared later": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           function inner() {
@@ -4033,16 +2578,10 @@ describe("check-database-first-legacy-stores", () => {
           return inner();
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-wrapper-block-escaped-late-write-alias.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 14 }]);
-  });
-
-  it("flags var nested helpers declared in blocks", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-block-escaped-late-write-alias.ts", [
+        { kind: "legacy store filesystem write", line: 14 },
+      ]),
+      "flags var nested helpers declared in blocks": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           function inner() {
@@ -4054,16 +2593,10 @@ describe("check-database-first-legacy-stores", () => {
           return inner();
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-wrapper-var-block-helper.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 12 }]);
-  });
-
-  it("flags var nested helper object methods declared in blocks", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-var-block-helper.ts", [
+        { kind: "legacy store filesystem write", line: 12 },
+      ]),
+      "flags var nested helper object methods declared in blocks": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           function inner() {
@@ -4079,32 +2612,21 @@ describe("check-database-first-legacy-stores", () => {
           return inner();
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-wrapper-var-block-helper-object-method.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 16 }]);
-  });
-
-  it("flags nested helper defaults from object literal destructuring", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-var-block-helper-object-method.ts", [
+        { kind: "legacy store filesystem write", line: 16 },
+      ]),
+      "flags nested helper defaults from object literal destructuring": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           const { save = () => fs.writeFile(filePath, "{}\\n") } = {};
           return save();
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-wrapper-object-literal-destructuring-default.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 7 }]);
-  });
-
-  it("uses the last object literal property before nested helper destructuring defaults", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-object-literal-destructuring-default.ts", [
+        { kind: "legacy store filesystem write", line: 7 },
+      ]),
+      "uses the last object literal property before nested helper destructuring defaults":
+        sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           const safe = () => undefined;
@@ -4115,16 +2637,11 @@ describe("check-database-first-legacy-stores", () => {
           return save?.();
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-wrapper-object-literal-duplicate-default.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 11 }]);
-  });
-
-  it("does not use nested helper destructuring defaults when the last duplicate is safe", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-object-literal-duplicate-default.ts", [
+          { kind: "legacy store filesystem write", line: 11 },
+        ]),
+      "does not use nested helper destructuring defaults when the last duplicate is safe":
+        sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           const safe = () => undefined;
@@ -4135,16 +2652,9 @@ describe("check-database-first-legacy-stores", () => {
           return save?.();
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-wrapper-object-literal-duplicate-safe.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("does not use nested helper destructuring defaults when a spread may provide the property", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-object-literal-duplicate-safe.ts", []),
+      "does not use nested helper destructuring defaults when a spread may provide the property":
+        sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           const safe = async () => {};
@@ -4154,16 +2664,9 @@ describe("check-database-first-legacy-stores", () => {
           return save();
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-wrapper-object-literal-spread-safe.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("does not use nested helper destructuring defaults for untracked identifier spreads", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-object-literal-spread-safe.ts", []),
+      "does not use nested helper destructuring defaults for untracked identifier spreads":
+        sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           const defaults = getWriter();
@@ -4173,16 +2676,8 @@ describe("check-database-first-legacy-stores", () => {
           return save?.();
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-wrapper-object-literal-unknown-spread-default.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("keeps earlier wrapper properties through known-missing object spreads", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-object-literal-unknown-spread-default.ts", []),
+      "keeps earlier wrapper properties through known-missing object spreads": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           const save = () => fs.writeFile(filePath, "{}\\n");
@@ -4194,16 +2689,10 @@ describe("check-database-first-legacy-stores", () => {
           return inner();
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-wrapper-object-literal-known-missing-spread.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 12 }]);
-  });
-
-  it("uses nested helper destructuring defaults after known undefined object spreads", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-object-literal-known-missing-spread.ts", [
+        { kind: "legacy store filesystem write", line: 12 },
+      ]),
+      "uses nested helper destructuring defaults after known undefined object spreads": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           const defaults = { save: undefined };
@@ -4213,16 +2702,10 @@ describe("check-database-first-legacy-stores", () => {
           return save();
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-wrapper-object-literal-undefined-spread-default.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 10 }]);
-  });
-
-  it("flags var nested wrappers declared in blocks", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-object-literal-undefined-spread-default.ts", [
+        { kind: "legacy store filesystem write", line: 10 },
+      ]),
+      "flags var nested wrappers declared in blocks": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           {
@@ -4231,16 +2714,10 @@ describe("check-database-first-legacy-stores", () => {
           return inner(filePath);
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-wrapper-var-block-declaration.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 9 }]);
-  });
-
-  it("merges var nested wrapper declarations inside exhaustive branches", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-var-block-declaration.ts", [
+        { kind: "legacy store filesystem write", line: 9 },
+      ]),
+      "merges var nested wrapper declarations inside exhaustive branches": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string, enabled: boolean) {
           if (enabled) {
@@ -4251,16 +2728,11 @@ describe("check-database-first-legacy-stores", () => {
           return inner(filePath);
         }
         await persist("sessions.json", true);
-      `,
-      "src/runtime/nested-wrapper-var-branch-declaration.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 11 }]);
-  });
-
-  it("keeps prior var nested wrapper declarations after optional branch redeclarations", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-var-branch-declaration.ts", [
+        { kind: "legacy store filesystem write", line: 11 },
+      ]),
+      "keeps prior var nested wrapper declarations after optional branch redeclarations":
+        sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string, disabled: boolean) {
           var inner = (path: string) => fs.writeFile(path, "{}\\n");
@@ -4270,16 +2742,10 @@ describe("check-database-first-legacy-stores", () => {
           return inner(filePath);
         }
         await persist("sessions.json", false);
-      `,
-      "src/runtime/nested-wrapper-var-optional-branch-declaration.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 10 }]);
-  });
-
-  it("flags var nested wrapper destructuring defaults declared in blocks", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-var-optional-branch-declaration.ts", [
+          { kind: "legacy store filesystem write", line: 10 },
+        ]),
+      "flags var nested wrapper destructuring defaults declared in blocks": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           {
@@ -4288,16 +2754,10 @@ describe("check-database-first-legacy-stores", () => {
           return save(filePath);
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-wrapper-var-block-destructuring-default.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 9 }]);
-  });
-
-  it("flags legacy paths captured through sibling nested helper calls", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-var-block-destructuring-default.ts", [
+        { kind: "legacy store filesystem write", line: 9 },
+      ]),
+      "flags legacy paths captured through sibling nested helper calls": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           function save() {
@@ -4309,16 +2769,10 @@ describe("check-database-first-legacy-stores", () => {
           return inner();
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-wrapper-sibling-helper-call-closed-over-path.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 12 }]);
-  });
-
-  it("flags legacy paths forwarded through sibling nested helper parameters", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-sibling-helper-call-closed-over-path.ts", [
+        { kind: "legacy store filesystem write", line: 12 },
+      ]),
+      "flags legacy paths forwarded through sibling nested helper parameters": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           function inner(nextPath: string) {
@@ -4330,16 +2784,10 @@ describe("check-database-first-legacy-stores", () => {
           return inner(filePath);
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-wrapper-sibling-helper-forwarded-path.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 12 }]);
-  });
-
-  it("flags legacy paths captured through nested arrow helper chains", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-sibling-helper-forwarded-path.ts", [
+        { kind: "legacy store filesystem write", line: 12 },
+      ]),
+      "flags legacy paths captured through nested arrow helper chains": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           const inner = () => {
@@ -4349,16 +2797,10 @@ describe("check-database-first-legacy-stores", () => {
           return inner();
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-wrapper-arrow-helper-chain-closed-over-path.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 10 }]);
-  });
-
-  it("flags legacy paths captured through nested helper aliases", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-arrow-helper-chain-closed-over-path.ts", [
+        { kind: "legacy store filesystem write", line: 10 },
+      ]),
+      "flags legacy paths captured through nested helper aliases": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           function inner() {
@@ -4369,16 +2811,10 @@ describe("check-database-first-legacy-stores", () => {
           return inner();
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-wrapper-helper-alias-closed-over-path.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 11 }]);
-  });
-
-  it("flags legacy paths captured through nested object helper methods", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-helper-alias-closed-over-path.ts", [
+        { kind: "legacy store filesystem write", line: 11 },
+      ]),
+      "flags legacy paths captured through nested object helper methods": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           function inner() {
@@ -4392,16 +2828,10 @@ describe("check-database-first-legacy-stores", () => {
           return inner();
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-wrapper-object-helper-closed-over-path.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 14 }]);
-  });
-
-  it("flags legacy paths captured through nested object helper aliases", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-object-helper-closed-over-path.ts", [
+        { kind: "legacy store filesystem write", line: 14 },
+      ]),
+      "flags legacy paths captured through nested object helper aliases": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           function inner() {
@@ -4412,16 +2842,10 @@ describe("check-database-first-legacy-stores", () => {
           return inner();
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-wrapper-object-helper-alias-closed-over-path.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 11 }]);
-  });
-
-  it("does not treat nested function declaration shadows as captured write aliases", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-object-helper-alias-closed-over-path.ts", [
+        { kind: "legacy store filesystem write", line: 11 },
+      ]),
+      "does not treat nested function declaration shadows as captured write aliases": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           const write = fs.writeFile;
@@ -4432,16 +2856,8 @@ describe("check-database-first-legacy-stores", () => {
           return inner();
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-wrapper-function-declaration-write-shadow.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("does not treat nested helper parameters as captured write aliases", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-function-declaration-write-shadow.ts", []),
+      "does not treat nested helper parameters as captured write aliases": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string, customWrite: (value: string) => void) {
           const writeFile = fs.writeFile;
@@ -4451,32 +2867,18 @@ describe("check-database-first-legacy-stores", () => {
           return inner(customWrite);
         }
         await persist("sessions.json", customWrite);
-      `,
-      "src/runtime/nested-wrapper-parameter-write-alias-shadow.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("flags legacy paths forwarded through nested arrow helpers", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-parameter-write-alias-shadow.ts", []),
+      "flags legacy paths forwarded through nested arrow helpers": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           const inner = (nextPath: string) => fs.writeFile(nextPath, "{}\\n");
           return inner(filePath);
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-arrow-wrapper-path.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 7 }]);
-  });
-
-  it("flags legacy paths forwarded through nested object helper methods", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-arrow-wrapper-path.ts", [
+        { kind: "legacy store filesystem write", line: 7 },
+      ]),
+      "flags legacy paths forwarded through nested object helper methods": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           const writer = {
@@ -4487,16 +2889,10 @@ describe("check-database-first-legacy-stores", () => {
           return writer.inner(filePath);
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-object-wrapper-path.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 11 }]);
-  });
-
-  it("flags legacy paths forwarded through nested helper aliases", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-object-wrapper-path.ts", [
+        { kind: "legacy store filesystem write", line: 11 },
+      ]),
+      "flags legacy paths forwarded through nested helper aliases": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           function inner(nextPath: string) {
@@ -4506,16 +2902,10 @@ describe("check-database-first-legacy-stores", () => {
           return save(filePath);
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-wrapper-alias-path.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 10 }]);
-  });
-
-  it("flags legacy paths forwarded through assignment-defined nested helper aliases", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-alias-path.ts", [
+        { kind: "legacy store filesystem write", line: 10 },
+      ]),
+      "flags legacy paths forwarded through assignment-defined nested helper aliases": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           function inner() {
@@ -4526,16 +2916,10 @@ describe("check-database-first-legacy-stores", () => {
           return inner();
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-wrapper-assigned-alias-closed-over-path.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 11 }]);
-  });
-
-  it("flags enclosing helper assignments made inside nested helpers", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-assigned-alias-closed-over-path.ts", [
+        { kind: "legacy store filesystem write", line: 11 },
+      ]),
+      "flags enclosing helper assignments made inside nested helpers": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           let save;
@@ -4546,16 +2930,10 @@ describe("check-database-first-legacy-stores", () => {
           return save?.();
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-wrapper-enclosing-assigned-helper.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 11 }]);
-  });
-
-  it("flags legacy paths forwarded through extracted nested object helper methods", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-enclosing-assigned-helper.ts", [
+        { kind: "legacy store filesystem write", line: 11 },
+      ]),
+      "flags legacy paths forwarded through extracted nested object helper methods": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           const writer = {
@@ -4567,16 +2945,10 @@ describe("check-database-first-legacy-stores", () => {
           return save(filePath);
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-object-wrapper-alias-path.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 12 }]);
-  });
-
-  it("flags legacy paths forwarded through assignment-defined nested object helpers", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-object-wrapper-alias-path.ts", [
+        { kind: "legacy store filesystem write", line: 12 },
+      ]),
+      "flags legacy paths forwarded through assignment-defined nested object helpers": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           function inner() {
@@ -4587,16 +2959,10 @@ describe("check-database-first-legacy-stores", () => {
           return inner();
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-object-wrapper-assigned-alias-closed-over-path.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 11 }]);
-  });
-
-  it("merges closed-over var nested wrapper declarations inside exhaustive branches", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-object-wrapper-assigned-alias-closed-over-path.ts", [
+        { kind: "legacy store filesystem write", line: 11 },
+      ]),
+      "merges closed-over var nested wrapper declarations inside exhaustive branches": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string, enabled: boolean) {
           function inner() {
@@ -4610,16 +2976,10 @@ describe("check-database-first-legacy-stores", () => {
           return inner();
         }
         await persist("sessions.json", true);
-      `,
-      "src/runtime/nested-wrapper-var-branch-declaration-closed-over-path.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 14 }]);
-  });
-
-  it("merges closed-over var fs aliases declared inside optional branches", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-var-branch-declaration-closed-over-path.ts", [
+        { kind: "legacy store filesystem write", line: 14 },
+      ]),
+      "merges closed-over var fs aliases declared inside optional branches": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string, enabled: boolean) {
           function inner() {
@@ -4631,16 +2991,10 @@ describe("check-database-first-legacy-stores", () => {
           return inner();
         }
         await persist("sessions.json", true);
-      `,
-      "src/runtime/nested-wrapper-var-fs-alias-branch-closed-over-path.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 12 }]);
-  });
-
-  it("flags enclosing object helper assignments made inside nested helpers", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-var-fs-alias-branch-closed-over-path.ts", [
+        { kind: "legacy store filesystem write", line: 12 },
+      ]),
+      "flags enclosing object helper assignments made inside nested helpers": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           const writer: { save?: () => Promise<void> } = {};
@@ -4654,16 +3008,10 @@ describe("check-database-first-legacy-stores", () => {
           return inner();
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-object-wrapper-enclosing-assigned-helper.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 14 }]);
-  });
-
-  it("flags legacy paths forwarded through local nested object helper aliases", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-object-wrapper-enclosing-assigned-helper.ts", [
+        { kind: "legacy store filesystem write", line: 14 },
+      ]),
+      "flags legacy paths forwarded through local nested object helper aliases": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           function inner() {
@@ -4678,16 +3026,11 @@ describe("check-database-first-legacy-stores", () => {
           return inner();
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-object-wrapper-local-method-alias-closed-over-path.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 15 }]);
-  });
-
-  it("flags closed-over nested object helper methods copied through destructuring aliases", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-object-wrapper-local-method-alias-closed-over-path.ts", [
+        { kind: "legacy store filesystem write", line: 15 },
+      ]),
+      "flags closed-over nested object helper methods copied through destructuring aliases":
+        sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           function inner() {
@@ -4704,16 +3047,10 @@ describe("check-database-first-legacy-stores", () => {
           return inner();
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-object-wrapper-destructured-alias-closed-over-path.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 17 }]);
-  });
-
-  it("clears closed-over nested object helpers after exhaustive reassignment", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-object-wrapper-destructured-alias-closed-over-path.ts", [
+          { kind: "legacy store filesystem write", line: 17 },
+        ]),
+      "clears closed-over nested object helpers after exhaustive reassignment": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string, enabled: boolean) {
           function inner() {
@@ -4732,16 +3069,8 @@ describe("check-database-first-legacy-stores", () => {
           return inner();
         }
         await persist("sessions.json", true);
-      `,
-      "src/runtime/nested-object-wrapper-exhaustive-reassigned-safe.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("keeps closed-over nested helpers after optional branch assignment", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-object-wrapper-exhaustive-reassigned-safe.ts", []),
+      "keeps closed-over nested helpers after optional branch assignment": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string, enabled: boolean) {
           function inner() {
@@ -4754,16 +3083,10 @@ describe("check-database-first-legacy-stores", () => {
           return inner();
         }
         await persist("sessions.json", true);
-      `,
-      "src/runtime/nested-wrapper-optional-branch-assigned-helper.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 13 }]);
-  });
-
-  it("keeps closed-over nested helpers after loop assignment", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-optional-branch-assigned-helper.ts", [
+        { kind: "legacy store filesystem write", line: 13 },
+      ]),
+      "keeps closed-over nested helpers after loop assignment": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string, values: string[]) {
           function inner() {
@@ -4776,16 +3099,10 @@ describe("check-database-first-legacy-stores", () => {
           return inner();
         }
         await persist("sessions.json", ["{}\\n"]);
-      `,
-      "src/runtime/nested-wrapper-loop-assigned-helper.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 13 }]);
-  });
-
-  it("keeps closed-over nested helpers after optional while reassignment", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-loop-assigned-helper.ts", [
+        { kind: "legacy store filesystem write", line: 13 },
+      ]),
+      "keeps closed-over nested helpers after optional while reassignment": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string, disabled: boolean) {
           function inner() {
@@ -4798,16 +3115,10 @@ describe("check-database-first-legacy-stores", () => {
           return inner();
         }
         await persist("sessions.json", false);
-      `,
-      "src/runtime/nested-wrapper-while-reassigned-helper.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 13 }]);
-  });
-
-  it("keeps switch case closed-over nested helper shadows scoped", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-while-reassigned-helper.ts", [
+        { kind: "legacy store filesystem write", line: 13 },
+      ]),
+      "keeps switch case closed-over nested helper shadows scoped": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string, mode: string) {
           function inner() {
@@ -4822,16 +3133,10 @@ describe("check-database-first-legacy-stores", () => {
           return inner();
         }
         await persist("sessions.json", "on");
-      `,
-      "src/runtime/nested-wrapper-switch-case-shadow.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 15 }]);
-  });
-
-  it("flags nested helper declarations inside switch cases", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-switch-case-shadow.ts", [
+        { kind: "legacy store filesystem write", line: 15 },
+      ]),
+      "flags nested helper declarations inside switch cases": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string, mode: string) {
           switch (mode) {
@@ -4843,16 +3148,10 @@ describe("check-database-first-legacy-stores", () => {
           }
         }
         await persist("sessions.json", "legacy");
-      `,
-      "src/runtime/nested-wrapper-switch-case-helper.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 12 }]);
-  });
-
-  it("keeps closed-over nested helpers after try assignment", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-switch-case-helper.ts", [
+        { kind: "legacy store filesystem write", line: 12 },
+      ]),
+      "keeps closed-over nested helpers after try assignment": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           function inner() {
@@ -4865,16 +3164,10 @@ describe("check-database-first-legacy-stores", () => {
           return inner();
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-wrapper-try-assigned-helper.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 13 }]);
-  });
-
-  it("flags closed-over nested helper aliases to outer wrappers", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-try-assigned-helper.ts", [
+        { kind: "legacy store filesystem write", line: 13 },
+      ]),
+      "flags closed-over nested helper aliases to outer wrappers": sourceCase`
         import { promises as fs } from "node:fs";
         function writePath(path: string) {
           return fs.writeFile(path, "{}\\n");
@@ -4887,16 +3180,10 @@ describe("check-database-first-legacy-stores", () => {
           return inner();
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-wrapper-outer-wrapper-alias.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 13 }]);
-  });
-
-  it("flags closed-over nested helper parameter default writes", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-outer-wrapper-alias.ts", [
+        { kind: "legacy store filesystem write", line: 13 },
+      ]),
+      "flags closed-over nested helper parameter default writes": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           function inner(_ = fs.writeFile(filePath, "{}\\n")) {
@@ -4905,16 +3192,10 @@ describe("check-database-first-legacy-stores", () => {
           return inner();
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-wrapper-parameter-default-write.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 9 }]);
-  });
-
-  it("does not use outer write aliases shadowed later in closed-over helpers", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-parameter-default-write.ts", [
+        { kind: "legacy store filesystem write", line: 9 },
+      ]),
+      "does not use outer write aliases shadowed later in closed-over helpers": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           const write = fs.writeFile;
@@ -4926,16 +3207,8 @@ describe("check-database-first-legacy-stores", () => {
           return inner();
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-wrapper-later-write-alias-shadow.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("flags closed-over aliases to top-level wrappers with local metadata", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-later-write-alias-shadow.ts", []),
+      "flags closed-over aliases to top-level wrappers with local metadata": sourceCase`
         import { promises as fs } from "node:fs";
         function writePath(path: string) {
           let writer = {};
@@ -4950,16 +3223,10 @@ describe("check-database-first-legacy-stores", () => {
           return inner();
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-wrapper-top-level-wrapper-alias.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 15 }]);
-  });
-
-  it("flags closed-over aliases to top-level wrappers with module object metadata", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-top-level-wrapper-alias.ts", [
+        { kind: "legacy store filesystem write", line: 15 },
+      ]),
+      "flags closed-over aliases to top-level wrappers with module object metadata": sourceCase`
         import { promises as fs } from "node:fs";
         const writer = {};
         function writePath(path: string) {
@@ -4974,16 +3241,10 @@ describe("check-database-first-legacy-stores", () => {
           return inner();
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-wrapper-top-level-object-wrapper-alias.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 15 }]);
-  });
-
-  it("flags legacy paths forwarded through destructured local nested object helpers", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-top-level-object-wrapper-alias.ts", [
+        { kind: "legacy store filesystem write", line: 15 },
+      ]),
+      "flags legacy paths forwarded through destructured local nested object helpers": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           function inner() {
@@ -4998,16 +3259,10 @@ describe("check-database-first-legacy-stores", () => {
           return inner();
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-object-wrapper-local-method-destructure-closed-over-path.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 15 }]);
-  });
-
-  it("flags legacy paths forwarded through destructured nested object helper methods", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-object-wrapper-local-method-destructure-closed-over-path.ts", [
+        { kind: "legacy store filesystem write", line: 15 },
+      ]),
+      "flags legacy paths forwarded through destructured nested object helper methods": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           const writer = {
@@ -5019,16 +3274,10 @@ describe("check-database-first-legacy-stores", () => {
           return inner(filePath);
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-object-wrapper-destructure-path.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 12 }]);
-  });
-
-  it("flags legacy paths forwarded through renamed nested object helper methods", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-object-wrapper-destructure-path.ts", [
+        { kind: "legacy store filesystem write", line: 12 },
+      ]),
+      "flags legacy paths forwarded through renamed nested object helper methods": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           const writer = {
@@ -5040,16 +3289,10 @@ describe("check-database-first-legacy-stores", () => {
           return save(filePath);
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-object-wrapper-renamed-destructure-path.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 12 }]);
-  });
-
-  it("keeps nested wrapper assignments inside optional branches", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-object-wrapper-renamed-destructure-path.ts", [
+        { kind: "legacy store filesystem write", line: 12 },
+      ]),
+      "keeps nested wrapper assignments inside optional branches": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string, useJson: boolean) {
           let inner: (nextPath: string) => Promise<void>;
@@ -5059,16 +3302,10 @@ describe("check-database-first-legacy-stores", () => {
           return inner(filePath);
         }
         await persist("sessions.json", true);
-      `,
-      "src/runtime/nested-wrapper-optional-branch-assignment.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 10 }]);
-  });
-
-  it("keeps previous nested wrappers after optional safe reassignment", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-optional-branch-assignment.ts", [
+        { kind: "legacy store filesystem write", line: 10 },
+      ]),
+      "keeps previous nested wrappers after optional safe reassignment": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string, disabled: boolean) {
           let inner = (nextPath: string) => fs.writeFile(nextPath, "{}\\n");
@@ -5078,16 +3315,10 @@ describe("check-database-first-legacy-stores", () => {
           return inner(filePath);
         }
         await persist("sessions.json", false);
-      `,
-      "src/runtime/nested-wrapper-optional-safe-reassignment.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 10 }]);
-  });
-
-  it("keeps nested object wrapper assignments inside optional branches", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-optional-safe-reassignment.ts", [
+        { kind: "legacy store filesystem write", line: 10 },
+      ]),
+      "keeps nested object wrapper assignments inside optional branches": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string, useJson: boolean) {
           const writer: { inner?: (nextPath: string) => Promise<void> } = {};
@@ -5097,16 +3328,10 @@ describe("check-database-first-legacy-stores", () => {
           return writer.inner?.(filePath);
         }
         await persist("sessions.json", true);
-      `,
-      "src/runtime/nested-object-wrapper-optional-branch-assignment.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 10 }]);
-  });
-
-  it("keeps nested object wrapper methods from optional whole-object assignments", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-object-wrapper-optional-branch-assignment.ts", [
+        { kind: "legacy store filesystem write", line: 10 },
+      ]),
+      "keeps nested object wrapper methods from optional whole-object assignments": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string, useJson: boolean) {
           let writer: { inner?: (nextPath: string) => Promise<void> } = {};
@@ -5120,16 +3345,10 @@ describe("check-database-first-legacy-stores", () => {
           return writer.inner?.(filePath);
         }
         await persist("sessions.json", true);
-      `,
-      "src/runtime/nested-object-wrapper-optional-object-assignment.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 14 }]);
-  });
-
-  it("flags legacy paths after exhaustive nested wrapper assignments", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-object-wrapper-optional-object-assignment.ts", [
+        { kind: "legacy store filesystem write", line: 14 },
+      ]),
+      "flags legacy paths after exhaustive nested wrapper assignments": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string, useJson: boolean) {
           let inner: (nextPath: string) => Promise<void>;
@@ -5141,16 +3360,10 @@ describe("check-database-first-legacy-stores", () => {
           return inner(filePath);
         }
         await persist("sessions.json", true);
-      `,
-      "src/runtime/nested-wrapper-branch-assignment.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 12 }]);
-  });
-
-  it("flags legacy paths after nested wrapper assignments inside plain blocks", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-branch-assignment.ts", [
+        { kind: "legacy store filesystem write", line: 12 },
+      ]),
+      "flags legacy paths after nested wrapper assignments inside plain blocks": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           let inner: (nextPath: string) => Promise<void>;
@@ -5160,16 +3373,10 @@ describe("check-database-first-legacy-stores", () => {
           return inner(filePath);
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-wrapper-block-assignment.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 10 }]);
-  });
-
-  it("keeps exhaustive nested wrapper assignments inside plain blocks", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-block-assignment.ts", [
+        { kind: "legacy store filesystem write", line: 10 },
+      ]),
+      "keeps exhaustive nested wrapper assignments inside plain blocks": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string, useJson: boolean) {
           let inner: (nextPath: string) => Promise<void>;
@@ -5183,16 +3390,10 @@ describe("check-database-first-legacy-stores", () => {
           return inner(filePath);
         }
         await persist("sessions.json", true);
-      `,
-      "src/runtime/nested-wrapper-block-branch-assignment.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 14 }]);
-  });
-
-  it("does not leak branch-local nested wrapper shadows after exhaustive branches", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-block-branch-assignment.ts", [
+        { kind: "legacy store filesystem write", line: 14 },
+      ]),
+      "does not leak branch-local nested wrapper shadows after exhaustive branches": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string, useJson: boolean) {
           let inner = (_nextPath: string) => Promise.resolve();
@@ -5210,16 +3411,8 @@ describe("check-database-first-legacy-stores", () => {
           return inner(filePath);
         }
         await persist("sessions.json", true);
-      `,
-      "src/runtime/nested-wrapper-branch-local-shadow.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("refreshes block-local aliases for nested wrappers assigned to outer bindings", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-branch-local-shadow.ts", []),
+      "refreshes block-local aliases for nested wrappers assigned to outer bindings": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           let inner: (nextPath: string) => Promise<void>;
@@ -5230,16 +3423,10 @@ describe("check-database-first-legacy-stores", () => {
           return inner(filePath);
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-wrapper-block-local-late-alias.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 11 }]);
-  });
-
-  it("keeps escaped nested wrapper aliases isolated from sibling blocks", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-block-local-late-alias.ts", [
+        { kind: "legacy store filesystem write", line: 11 },
+      ]),
+      "keeps escaped nested wrapper aliases isolated from sibling blocks": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           let inner: (nextPath: string) => Promise<void>;
@@ -5253,16 +3440,10 @@ describe("check-database-first-legacy-stores", () => {
           return inner(filePath);
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-wrapper-sibling-block-alias-shadow.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 14 }]);
-  });
-
-  it("refreshes merged nested wrapper assignments after later aliases", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-sibling-block-alias-shadow.ts", [
+        { kind: "legacy store filesystem write", line: 14 },
+      ]),
+      "refreshes merged nested wrapper assignments after later aliases": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string, useJson: boolean) {
           let inner: (nextPath: string) => Promise<void>;
@@ -5275,16 +3456,10 @@ describe("check-database-first-legacy-stores", () => {
           return inner(filePath);
         }
         await persist("sessions.json", true);
-      `,
-      "src/runtime/nested-wrapper-branch-late-alias.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 13 }]);
-  });
-
-  it("refreshes branch-local aliases before merging nested wrapper assignments", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-branch-late-alias.ts", [
+        { kind: "legacy store filesystem write", line: 13 },
+      ]),
+      "refreshes branch-local aliases before merging nested wrapper assignments": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string, useJson: boolean) {
           let inner: (nextPath: string) => Promise<void>;
@@ -5298,16 +3473,10 @@ describe("check-database-first-legacy-stores", () => {
           return inner(filePath);
         }
         await persist("sessions.json", true);
-      `,
-      "src/runtime/nested-wrapper-branch-local-late-alias.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 14 }]);
-  });
-
-  it("flags legacy paths after exhaustive nested object wrapper assignments", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-branch-local-late-alias.ts", [
+        { kind: "legacy store filesystem write", line: 14 },
+      ]),
+      "flags legacy paths after exhaustive nested object wrapper assignments": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string, useJson: boolean) {
           let writer: { inner(nextPath: string): Promise<void> };
@@ -5327,16 +3496,10 @@ describe("check-database-first-legacy-stores", () => {
           return writer.inner(filePath);
         }
         await persist("sessions.json", true);
-      `,
-      "src/runtime/nested-object-wrapper-branch-assignment.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 20 }]);
-  });
-
-  it("clears stale nested object wrapper methods after exhaustive object reassignment", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-object-wrapper-branch-assignment.ts", [
+        { kind: "legacy store filesystem write", line: 20 },
+      ]),
+      "clears stale nested object wrapper methods after exhaustive object reassignment": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string, useJson: boolean) {
           let writer = {
@@ -5352,16 +3515,8 @@ describe("check-database-first-legacy-stores", () => {
           return writer.inner?.(filePath);
         }
         await persist("sessions.json", true);
-      `,
-      "src/runtime/nested-object-wrapper-exhaustive-object-reassignment.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("flags legacy paths after exhaustive nested object wrapper parameter assignments", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-object-wrapper-exhaustive-object-reassignment.ts", []),
+      "flags legacy paths after exhaustive nested object wrapper parameter assignments": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(
           filePath: string,
@@ -5376,16 +3531,10 @@ describe("check-database-first-legacy-stores", () => {
           return writer.inner?.(filePath);
         }
         await persist("sessions.json", {}, true);
-      `,
-      "src/runtime/nested-object-wrapper-parameter-branch-assignment.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 15 }]);
-  });
-
-  it("keeps block-local nested wrapper shadows scoped to their block", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-object-wrapper-parameter-branch-assignment.ts", [
+        { kind: "legacy store filesystem write", line: 15 },
+      ]),
+      "keeps block-local nested wrapper shadows scoped to their block": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           function inner(nextPath: string) {
@@ -5397,16 +3546,10 @@ describe("check-database-first-legacy-stores", () => {
           return inner(filePath);
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-wrapper-block-shadow.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 12 }]);
-  });
-
-  it("does not use outer nested wrappers for destructured parameter shadows", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-block-shadow.ts", [
+        { kind: "legacy store filesystem write", line: 12 },
+      ]),
+      "does not use outer nested wrappers for destructured parameter shadows": sourceCase`
         import { promises as fs } from "node:fs";
         function helper(nextPath: string) {
           return fs.writeFile(nextPath, "{}\\n");
@@ -5415,16 +3558,8 @@ describe("check-database-first-legacy-stores", () => {
           return helper(filePath);
         }
         await persist({ helper: async () => {} }, "sessions.json");
-      `,
-      "src/runtime/nested-wrapper-destructured-parameter-shadow.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("uses enclosing aliases when nested wrapper helpers are called", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-destructured-parameter-shadow.ts", []),
+      "uses enclosing aliases when nested wrapper helpers are called": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           const write = fs.writeFile;
@@ -5434,16 +3569,10 @@ describe("check-database-first-legacy-stores", () => {
           return inner(filePath);
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-wrapper-alias.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 10 }]);
-  });
-
-  it("does not use caller block shadows for nested wrapper helper aliases", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-alias.ts", [
+        { kind: "legacy store filesystem write", line: 10 },
+      ]),
+      "does not use caller block shadows for nested wrapper helper aliases": sourceCase`
         import { createRequire } from "node:module";
         const req = createRequire(import.meta.url);
         function persist(filePath: string, customRequire: NodeRequire) {
@@ -5457,16 +3586,21 @@ describe("check-database-first-legacy-stores", () => {
           }
         }
         await persist("sessions.json", require);
-      `,
-      "src/runtime/nested-wrapper-call-shadow.ts",
-    );
+      `("src/runtime/nested-wrapper-call-shadow.ts", [
+        { kind: "legacy store filesystem write", line: 14 },
+      ]),
+    }),
+  )("$name", ({ source, filename, expected }) => {
+    const violations = collectDatabaseFirstLegacyStoreViolations(source, filename);
 
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 14 }]);
+    expect(violations).toEqual(expected);
   });
 
-  it("flags wrapper object binding defaults for explicit undefined forwarded properties", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+  // Wrapper parameter and body alias state.
+  it.each(
+    namedCases({
+      "flags wrapper object binding defaults for explicit undefined forwarded properties":
+        sourceCase`
         import { promises as fs } from "node:fs";
         function inner({ path }: { path: string }) {
           return fs.writeFile(path, "{}\\n");
@@ -5478,16 +3612,10 @@ describe("check-database-first-legacy-stores", () => {
           return forward({ path: undefined });
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/wrapper-forwarded-undefined-object-property-default.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 12 }]);
-  });
-
-  it("flags legacy paths from defaulted wrapper parameters", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/wrapper-forwarded-undefined-object-property-default.ts", [
+          { kind: "legacy store filesystem write", line: 12 },
+        ]),
+      "flags legacy paths from defaulted wrapper parameters": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         function persistPath(filePath = "sessions.json") {
           return writeTextAtomic(filePath, "{}\\n");
@@ -5504,54 +3632,30 @@ describe("check-database-first-legacy-stores", () => {
         persistDestructured({});
         persistDestructured({ filePath: undefined });
         persistDestructured({ filePath: currentSqlitePath });
-      `,
-      "src/runtime/defaulted-wrapper-paths.ts",
-    );
-
-    expect(violations).toEqual([
-      { kind: "legacy store filesystem write", line: 12 },
-      { kind: "legacy store filesystem write", line: 13 },
-      { kind: "legacy store filesystem write", line: 14 },
-      { kind: "legacy store filesystem write", line: 15 },
-      { kind: "legacy store filesystem write", line: 16 },
-    ]);
-  });
-
-  it("does not treat ambient declarations as undefined wrapper arguments", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/defaulted-wrapper-paths.ts", [
+        { kind: "legacy store filesystem write", line: 12 },
+        { kind: "legacy store filesystem write", line: 13 },
+        { kind: "legacy store filesystem write", line: 14 },
+        { kind: "legacy store filesystem write", line: 15 },
+        { kind: "legacy store filesystem write", line: 16 },
+      ]),
+      "does not treat ambient declarations as undefined wrapper arguments": sourceCase`
         import fs from "node:fs/promises";
         declare const provided: string;
         function persist(filePath = "sessions.json") {
           return fs.writeFile(filePath, "{}\\n");
         }
         await persist(provided);
-      `,
-      "src/runtime/ambient-defaulted-wrapper-path.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("clears wrapper object parameter paths after reassignment", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/ambient-defaulted-wrapper-path.ts", []),
+      "clears wrapper object parameter paths after reassignment": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         function persist(params: { filePath: string }) {
           params = { filePath: currentSqlitePath };
           return writeTextAtomic(params.filePath, "{}\\n");
         }
         await persist({ filePath: "sessions.json" });
-      `,
-      "src/runtime/reassigned-wrapper-object-options.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("clears wrapper object parameter paths after nested block reassignment", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/reassigned-wrapper-object-options.ts", []),
+      "clears wrapper object parameter paths after nested block reassignment": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         function persist(params: { filePath: string }) {
           {
@@ -5560,16 +3664,8 @@ describe("check-database-first-legacy-stores", () => {
           return writeTextAtomic(params.filePath, "{}\\n");
         }
         await persist({ filePath: "sessions.json" });
-      `,
-      "src/runtime/nested-reassigned-wrapper-object-options.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("does not let block-local wrapper parameter shadows clear outer paths", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-reassigned-wrapper-object-options.ts", []),
+      "does not let block-local wrapper parameter shadows clear outer paths": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         function persist(params: { filePath: string }) {
           {
@@ -5579,112 +3675,64 @@ describe("check-database-first-legacy-stores", () => {
           return writeTextAtomic(params.filePath, "{}\\n");
         }
         await persist({ filePath: "sessions.json" });
-      `,
-      "src/runtime/block-local-wrapper-object-options-shadow.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 10 }]);
-  });
-
-  it("clears destructured wrapper option paths after reassignment", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/block-local-wrapper-object-options-shadow.ts", [
+        { kind: "legacy store filesystem write", line: 10 },
+      ]),
+      "clears destructured wrapper option paths after reassignment": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         function persist({ filePath }: { filePath: string }) {
           filePath = currentSqlitePath;
           return writeTextAtomic(filePath, "{}\\n");
         }
         await persist({ filePath: "sessions.json" });
-      `,
-      "src/runtime/reassigned-destructured-wrapper-options.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("clears wrapper object property paths after reassignment", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/reassigned-destructured-wrapper-options.ts", []),
+      "clears wrapper object property paths after reassignment": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         function persist(params: { filePath: string }) {
           params.filePath = currentSqlitePath;
           return writeTextAtomic(params.filePath, "{}\\n");
         }
         await persist({ filePath: "sessions.json" });
-      `,
-      "src/runtime/reassigned-wrapper-property-options.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("clears nested wrapper object property paths after reassignment", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/reassigned-wrapper-property-options.ts", []),
+      "clears nested wrapper object property paths after reassignment": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(params: { paths: { filePath: string } }) {
           params.paths.filePath = currentSqlitePath;
           return fs.writeFile(params.paths.filePath, "{}\\n");
         }
         await persist({ paths: { filePath: "sessions.json" } });
-      `,
-      "src/runtime/reassigned-nested-wrapper-property-options.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("updates wrapper object property paths after reassignment from another parameter", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/reassigned-nested-wrapper-property-options.ts", []),
+      "updates wrapper object property paths after reassignment from another parameter": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         function persist(params: { filePath: string }, legacy: { filePath: string }) {
           params.filePath = legacy.filePath;
           return writeTextAtomic(params.filePath, "{}\\n");
         }
         await persist({ filePath: currentSqlitePath }, { filePath: "sessions.json" });
-      `,
-      "src/runtime/reassigned-wrapper-property-from-parameter.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 7 }]);
-  });
-
-  it("keeps wrapper object property paths after conditional reassignment", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/reassigned-wrapper-property-from-parameter.ts", [
+        { kind: "legacy store filesystem write", line: 7 },
+      ]),
+      "keeps wrapper object property paths after conditional reassignment": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         function persist(params: { filePath: string }) {
           if (ready) params.filePath = currentSqlitePath;
           return writeTextAtomic(params.filePath, "{}\\n");
         }
         await persist({ filePath: "sessions.json" });
-      `,
-      "src/runtime/conditional-reassigned-wrapper-property-options.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 7 }]);
-  });
-
-  it("keeps wrapper object parameter paths after conditional reassignment", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/conditional-reassigned-wrapper-property-options.ts", [
+        { kind: "legacy store filesystem write", line: 7 },
+      ]),
+      "keeps wrapper object parameter paths after conditional reassignment": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         function persist(params: { filePath: string }) {
           if (ready) params = { filePath: currentSqlitePath };
           return writeTextAtomic(params.filePath, "{}\\n");
         }
         await persist({ filePath: "sessions.json" });
-      `,
-      "src/runtime/conditional-reassigned-wrapper-object-options.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 7 }]);
-  });
-
-  it("keeps wrapper object property paths after for-of reassignment", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/conditional-reassigned-wrapper-object-options.ts", [
+        { kind: "legacy store filesystem write", line: 7 },
+      ]),
+      "keeps wrapper object property paths after for-of reassignment": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         function persist(params: { filePath: string }) {
           for (const item of items) {
@@ -5693,16 +3741,10 @@ describe("check-database-first-legacy-stores", () => {
           return writeTextAtomic(params.filePath, "{}\\n");
         }
         await persist({ filePath: "sessions.json" });
-      `,
-      "src/runtime/for-of-reassigned-wrapper-property-options.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 9 }]);
-  });
-
-  it("keeps wrapper object property paths after try-block reassignment", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/for-of-reassigned-wrapper-property-options.ts", [
+        { kind: "legacy store filesystem write", line: 9 },
+      ]),
+      "keeps wrapper object property paths after try-block reassignment": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         function persist(params: { filePath: string }) {
           try {
@@ -5712,16 +3754,10 @@ describe("check-database-first-legacy-stores", () => {
           return writeTextAtomic(params.filePath, "{}\\n");
         }
         await persist({ filePath: "sessions.json" });
-      `,
-      "src/runtime/try-reassigned-wrapper-property-options.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 10 }]);
-  });
-
-  it("clears wrapper object property paths after exhaustive current-path assignments", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/try-reassigned-wrapper-property-options.ts", [
+        { kind: "legacy store filesystem write", line: 10 },
+      ]),
+      "clears wrapper object property paths after exhaustive current-path assignments": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         function persist(params: { filePath: string }) {
           if (ready) params.filePath = currentSqlitePath;
@@ -5729,16 +3765,9 @@ describe("check-database-first-legacy-stores", () => {
           return writeTextAtomic(params.filePath, "{}\\n");
         }
         await persist({ filePath: "sessions.json" });
-      `,
-      "src/runtime/exhaustive-current-wrapper-property-options.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("clears wrapper object parameter paths after exhaustive current-object assignments", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/exhaustive-current-wrapper-property-options.ts", []),
+      "clears wrapper object parameter paths after exhaustive current-object assignments":
+        sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         function persist(params: { filePath: string }) {
           if (ready) params = { filePath: currentSqlitePath };
@@ -5746,16 +3775,8 @@ describe("check-database-first-legacy-stores", () => {
           return writeTextAtomic(params.filePath, "{}\\n");
         }
         await persist({ filePath: "sessions.json" });
-      `,
-      "src/runtime/exhaustive-current-wrapper-object-options.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("flags wrapper object property paths after mixed exhaustive assignments", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/exhaustive-current-wrapper-object-options.ts", []),
+      "flags wrapper object property paths after mixed exhaustive assignments": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         function persist(params: { filePath: string }, legacy: { filePath: string }) {
           if (ready) params.filePath = currentSqlitePath;
@@ -5763,128 +3784,84 @@ describe("check-database-first-legacy-stores", () => {
           return writeTextAtomic(params.filePath, "{}\\n");
         }
         await persist({ filePath: currentSqlitePath }, { filePath: "sessions.json" });
-      `,
-      "src/runtime/exhaustive-mixed-wrapper-property-options.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 8 }]);
-  });
-
-  it("flags wrapper object property paths after conditional reassignment from another parameter", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/exhaustive-mixed-wrapper-property-options.ts", [
+        { kind: "legacy store filesystem write", line: 8 },
+      ]),
+      "flags wrapper object property paths after conditional reassignment from another parameter":
+        sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         function persist(params: { filePath: string }, legacy: { filePath: string }) {
           if (ready) params.filePath = legacy.filePath;
           return writeTextAtomic(params.filePath, "{}\\n");
         }
         await persist({ filePath: currentSqlitePath }, { filePath: "sessions.json" });
-      `,
-      "src/runtime/conditional-reassigned-wrapper-property-from-parameter.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 7 }]);
-  });
-
-  it("flags wrapper object paths after conditional reassignment from another parameter", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/conditional-reassigned-wrapper-property-from-parameter.ts", [
+          { kind: "legacy store filesystem write", line: 7 },
+        ]),
+      "flags wrapper object paths after conditional reassignment from another parameter":
+        sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         function persist(params: { filePath: string }, legacy: { filePath: string }) {
           if (ready) params = legacy;
           return writeTextAtomic(params.filePath, "{}\\n");
         }
         await persist({ filePath: currentSqlitePath }, { filePath: "sessions.json" });
-      `,
-      "src/runtime/conditional-reassigned-wrapper-object-from-parameter.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 7 }]);
-  });
-
-  it("flags destructured wrapper paths after conditional reassignment from another parameter", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/conditional-reassigned-wrapper-object-from-parameter.ts", [
+          { kind: "legacy store filesystem write", line: 7 },
+        ]),
+      "flags destructured wrapper paths after conditional reassignment from another parameter":
+        sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         function persist({ filePath }: { filePath: string }, legacy: { filePath: string }) {
           if (ready) filePath = legacy.filePath;
           return writeTextAtomic(filePath, "{}\\n");
         }
         await persist({ filePath: currentSqlitePath }, { filePath: "sessions.json" });
-      `,
-      "src/runtime/conditional-reassigned-destructured-wrapper-options.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 7 }]);
-  });
-
-  it("flags legacy paths passed through locally destructured wrapper options", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/conditional-reassigned-destructured-wrapper-options.ts", [
+          { kind: "legacy store filesystem write", line: 7 },
+        ]),
+      "flags legacy paths passed through locally destructured wrapper options": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         function persist(params: { filePath: string }) {
           const { filePath } = params;
           return writeTextAtomic(filePath, "{}\\n");
         }
         await persist({ filePath: "sessions.json" });
-      `,
-      "src/runtime/local-destructured-wrapper-options.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 7 }]);
-  });
-
-  it("flags legacy paths passed through local wrapper property aliases", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/local-destructured-wrapper-options.ts", [
+        { kind: "legacy store filesystem write", line: 7 },
+      ]),
+      "flags legacy paths passed through local wrapper property aliases": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         function persist(params: { filePath: string }) {
           const filePath = params.filePath;
           return writeTextAtomic(filePath, "{}\\n");
         }
         await persist({ filePath: "sessions.json" });
-      `,
-      "src/runtime/local-property-alias-wrapper-options.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 7 }]);
-  });
-
-  it("flags legacy paths passed through local wrapper object aliases", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/local-property-alias-wrapper-options.ts", [
+        { kind: "legacy store filesystem write", line: 7 },
+      ]),
+      "flags legacy paths passed through local wrapper object aliases": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         function persist(params: { filePath: string }) {
           const target = params;
           return writeTextAtomic(target.filePath, "{}\\n");
         }
         await persist({ filePath: "sessions.json" });
-      `,
-      "src/runtime/local-object-alias-wrapper-options.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 7 }]);
-  });
-
-  it("flags wrapper object paths after reassignment from another parameter", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/local-object-alias-wrapper-options.ts", [
+        { kind: "legacy store filesystem write", line: 7 },
+      ]),
+      "flags wrapper object paths after reassignment from another parameter": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         function persist(params: { filePath: string }, legacy: { filePath: string }) {
           params = legacy;
           return writeTextAtomic(params.filePath, "{}\\n");
         }
         await persist({ filePath: currentSqlitePath }, { filePath: "sessions.json" });
-      `,
-      "src/runtime/reassigned-wrapper-object-from-parameter.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 7 }]);
-  });
-
-  it("flags wrapper object property paths after nested block reassignment from another parameter", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/reassigned-wrapper-object-from-parameter.ts", [
+        { kind: "legacy store filesystem write", line: 7 },
+      ]),
+      "flags wrapper object property paths after nested block reassignment from another parameter":
+        sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         function persist(params: { filePath: string }, legacy: { filePath: string }) {
           {
@@ -5893,16 +3870,11 @@ describe("check-database-first-legacy-stores", () => {
           return writeTextAtomic(params.filePath, "{}\\n");
         }
         await persist({ filePath: currentSqlitePath }, { filePath: "sessions.json" });
-      `,
-      "src/runtime/nested-block-reassigned-wrapper-property.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 9 }]);
-  });
-
-  it("flags wrapper destructured paths after nested block reassignment from another parameter", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-block-reassigned-wrapper-property.ts", [
+          { kind: "legacy store filesystem write", line: 9 },
+        ]),
+      "flags wrapper destructured paths after nested block reassignment from another parameter":
+        sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         function persist({ filePath }: { filePath: string }, legacy: { filePath: string }) {
           {
@@ -5911,16 +3883,10 @@ describe("check-database-first-legacy-stores", () => {
           return writeTextAtomic(filePath, "{}\\n");
         }
         await persist({ filePath: currentSqlitePath }, { filePath: "sessions.json" });
-      `,
-      "src/runtime/nested-block-reassigned-wrapper-destructured.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 9 }]);
-  });
-
-  it("does not leak block-local wrapper path aliases into the parent block", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-block-reassigned-wrapper-destructured.ts", [
+          { kind: "legacy store filesystem write", line: 9 },
+        ]),
+      "does not leak block-local wrapper path aliases into the parent block": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         function persist(params: { filePath: string }) {
           const filePath = currentSqlitePath;
@@ -5930,48 +3896,29 @@ describe("check-database-first-legacy-stores", () => {
           return writeTextAtomic(filePath, "{}\\n");
         }
         await persist({ filePath: "sessions.json" });
-      `,
-      "src/runtime/block-local-wrapper-path-alias.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("flags wrapper option paths written through body-local fs aliases", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/block-local-wrapper-path-alias.ts", []),
+      "flags wrapper option paths written through body-local fs aliases": sourceCase`
         import fs from "node:fs/promises";
         function persist(params: { filePath: string }) {
           const { writeFile } = fs;
           return writeFile(params.filePath, "{}\\n");
         }
         await persist({ filePath: "sessions.json" });
-      `,
-      "src/runtime/body-local-fs-alias-wrapper.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 7 }]);
-  });
-
-  it("flags wrapper option paths written through body-local fs method aliases", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/body-local-fs-alias-wrapper.ts", [
+        { kind: "legacy store filesystem write", line: 7 },
+      ]),
+      "flags wrapper option paths written through body-local fs method aliases": sourceCase`
         import fs from "node:fs/promises";
         function persist(params: { filePath: string }) {
           const save = fs.writeFile;
           return save(params.filePath, "{}\\n");
         }
         await persist({ filePath: "sessions.json" });
-      `,
-      "src/runtime/wrapper-body-local-fs-method-alias.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 7 }]);
-  });
-
-  it("flags wrapper option paths written through branch-assigned body-local fs aliases", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/wrapper-body-local-fs-method-alias.ts", [
+        { kind: "legacy store filesystem write", line: 7 },
+      ]),
+      "flags wrapper option paths written through branch-assigned body-local fs aliases":
+        sourceCase`
         import fs from "node:fs/promises";
         function persist(params: { filePath: string }, ready: boolean) {
           let write;
@@ -5983,16 +3930,10 @@ describe("check-database-first-legacy-stores", () => {
           return write(params.filePath, "{}\\n");
         }
         await persist({ filePath: "sessions.json" }, true);
-      `,
-      "src/runtime/branch-assigned-body-local-fs-alias-wrapper.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 12 }]);
-  });
-
-  it("flags nested wrapper helpers capturing branch-assigned body-local fs aliases", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/branch-assigned-body-local-fs-alias-wrapper.ts", [
+          { kind: "legacy store filesystem write", line: 12 },
+        ]),
+      "flags nested wrapper helpers capturing branch-assigned body-local fs aliases": sourceCase`
         import fs from "node:fs/promises";
         function persist(params: { filePath: string }, ready: boolean) {
           let write;
@@ -6007,48 +3948,31 @@ describe("check-database-first-legacy-stores", () => {
           return inner();
         }
         await persist({ filePath: "sessions.json" }, true);
-      `,
-      "src/runtime/nested-wrapper-branch-assigned-body-local-fs-alias.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 15 }]);
-  });
-
-  it("flags wrapper option paths written through body-local fs object aliases", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-branch-assigned-body-local-fs-alias.ts", [
+        { kind: "legacy store filesystem write", line: 15 },
+      ]),
+      "flags wrapper option paths written through body-local fs object aliases": sourceCase`
         import fs from "node:fs/promises";
         function persist(params: { filePath: string }) {
           const writer = { writeFile: fs.writeFile };
           return writer.writeFile(params.filePath, "{}\\n");
         }
         await persist({ filePath: "sessions.json" });
-      `,
-      "src/runtime/body-local-fs-object-alias-wrapper.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 7 }]);
-  });
-
-  it("flags wrapper option paths written through bracketed body-local fs object aliases", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/body-local-fs-object-alias-wrapper.ts", [
+        { kind: "legacy store filesystem write", line: 7 },
+      ]),
+      "flags wrapper option paths written through bracketed body-local fs object aliases":
+        sourceCase`
         import fs from "node:fs/promises";
         function persist(params: { filePath: string }) {
           const writer = { writeFile: fs.writeFile };
           return writer["writeFile"](params.filePath, "{}\\n");
         }
         await persist({ filePath: "sessions.json" });
-      `,
-      "src/runtime/body-local-bracket-fs-object-alias-wrapper.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 7 }]);
-  });
-
-  it("clears wrapper body fs object aliases after object reassignment", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/body-local-bracket-fs-object-alias-wrapper.ts", [
+          { kind: "legacy store filesystem write", line: 7 },
+        ]),
+      "clears wrapper body fs object aliases after object reassignment": sourceCase`
         import fs from "node:fs/promises";
         function persist(params: { filePath: string }) {
           let writer = { writeFile: fs.writeFile };
@@ -6056,16 +3980,8 @@ describe("check-database-first-legacy-stores", () => {
           return writer.writeFile(params.filePath, "{}\\n");
         }
         await persist({ filePath: "sessions.json" });
-      `,
-      "src/runtime/reassigned-body-local-fs-object-alias-wrapper.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("does not let block-local wrapper aliases mutate outer wrapper metadata", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/reassigned-body-local-fs-object-alias-wrapper.ts", []),
+      "does not let block-local wrapper aliases mutate outer wrapper metadata": sourceCase`
         import fs from "node:fs/promises";
         import { writeFile } from "../infra/custom-writer.js";
         function persist(params: { filePath: string }) {
@@ -6077,90 +3993,50 @@ describe("check-database-first-legacy-stores", () => {
           await save({ filePath: "sessions.json" });
         }
         await persist({ filePath: "cron/jobs.json" });
-      `,
-      "src/runtime/block-local-wrapper-alias-metadata.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("flags wrapper option paths written through fs.promises", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/block-local-wrapper-alias-metadata.ts", []),
+      "flags wrapper option paths written through fs.promises": sourceCase`
         import fs from "node:fs";
         function persist(params: { filePath: string }) {
           return fs.promises.writeFile(params.filePath, "{}\\n");
         }
         await persist({ filePath: "sessions.json" });
-      `,
-      "src/runtime/wrapper-fs-promises-write.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 6 }]);
-  });
-
-  it("flags wrapper option paths written through outer fs module object aliases", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/wrapper-fs-promises-write.ts", [
+        { kind: "legacy store filesystem write", line: 6 },
+      ]),
+      "flags wrapper option paths written through outer fs module object aliases": sourceCase`
         import fs from "node:fs/promises";
         const deps = { fs };
         function persist(params: { filePath: string }) {
           return deps.fs.writeFile(params.filePath, "{}\\n");
         }
         persist({ filePath: "sessions.json" });
-      `,
-      "src/runtime/wrapper-outer-fs-module-object-alias.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 7 }]);
-  });
-
-  it("flags wrapper option paths written through injected fs handles", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/wrapper-outer-fs-module-object-alias.ts", [
+        { kind: "legacy store filesystem write", line: 7 },
+      ]),
+      "flags wrapper option paths written through injected fs handles": sourceCase`
         function persist(deps: { fs: typeof import("node:fs") }, params: { filePath: string }) {
           return deps.fs.promises.writeFile(params.filePath, "{}\\n");
         }
         await persist(deps, { filePath: "sessions.json" });
-      `,
-      "src/runtime/wrapper-injected-fs-write.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 5 }]);
-  });
-
-  it("does not treat untyped wrapper fs properties as filesystem writes", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/wrapper-injected-fs-write.ts", [
+        { kind: "legacy store filesystem write", line: 5 },
+      ]),
+      "does not treat untyped wrapper fs properties as filesystem writes": sourceCase`
         function persist(deps: { fs: { promises: { writeFile: Function } } }, params: { filePath: string }) {
           return deps.fs.promises.writeFile(params.filePath, "{}\\n");
         }
         await persist(deps, { filePath: "sessions.json" });
-      `,
-      "src/runtime/wrapper-custom-fs-property.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("flags wrapper option paths written through CommonJS fs", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/wrapper-custom-fs-property.ts", []),
+      "flags wrapper option paths written through CommonJS fs": sourceCase`
         function persist(params: { filePath: string }) {
           const fs = require("node:fs");
           return fs.promises.writeFile(params.filePath, "{}\\n");
         }
         await persist({ filePath: "sessions.json" });
-      `,
-      "src/runtime/wrapper-commonjs-fs-write.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 6 }]);
-  });
-
-  it("flags wrapper options forwarded to filePath helper objects", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/wrapper-commonjs-fs-write.ts", [
+        { kind: "legacy store filesystem write", line: 6 },
+      ]),
+      "flags wrapper options forwarded to filePath helper objects": sourceCase`
         import { appendRegularFile, replaceFileAtomic } from "../infra/fs-safe.js";
         function append(options: { filePath: string; content: string }) {
           return appendRegularFile(options);
@@ -6170,19 +4046,11 @@ describe("check-database-first-legacy-stores", () => {
         }
         append({ filePath: "sessions.json", content: "{}\\n" });
         replace({ filePath: "plugin-state/state.sqlite", content: "" });
-      `,
-      "src/runtime/forwarded-filepath-helper-options.ts",
-    );
-
-    expect(violations).toEqual([
-      { kind: "legacy store filesystem write", line: 9 },
-      { kind: "legacy store filesystem write", line: 10 },
-    ]);
-  });
-
-  it("flags wrapper options forwarded through another wrapper", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/forwarded-filepath-helper-options.ts", [
+        { kind: "legacy store filesystem write", line: 9 },
+        { kind: "legacy store filesystem write", line: 10 },
+      ]),
+      "flags wrapper options forwarded through another wrapper": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         function persist(params: { filePath: string }) {
           return writeTextAtomic(params.filePath, "{}\\n");
@@ -6191,16 +4059,10 @@ describe("check-database-first-legacy-stores", () => {
           return persist(params);
         }
         save({ filePath: "sessions.json" });
-      `,
-      "src/runtime/transitive-wrapper-forwarding.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 9 }]);
-  });
-
-  it("flags wrapper options spread through another wrapper", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/transitive-wrapper-forwarding.ts", [
+        { kind: "legacy store filesystem write", line: 9 },
+      ]),
+      "flags wrapper options spread through another wrapper": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         function persist(params: { filePath: string }) {
           return writeTextAtomic(params.filePath, "{}\\n");
@@ -6209,16 +4071,10 @@ describe("check-database-first-legacy-stores", () => {
           return persist({ ...params });
         }
         save({ filePath: "sessions.json" });
-      `,
-      "src/runtime/transitive-wrapper-spread-forwarding.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 9 }]);
-  });
-
-  it("allows wrapper spread forwarding when a later property overrides the path", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/transitive-wrapper-spread-forwarding.ts", [
+        { kind: "legacy store filesystem write", line: 9 },
+      ]),
+      "allows wrapper spread forwarding when a later property overrides the path": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         function persist(params: { filePath: string }) {
           return writeTextAtomic(params.filePath, "{}\\n");
@@ -6227,16 +4083,8 @@ describe("check-database-first-legacy-stores", () => {
           return persist({ ...params, filePath: currentSqlitePath });
         }
         save({ filePath: "sessions.json" });
-      `,
-      "src/runtime/transitive-wrapper-spread-overridden-forwarding.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("flags wrapper spread forwarding when a later spread restores the path", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/transitive-wrapper-spread-overridden-forwarding.ts", []),
+      "flags wrapper spread forwarding when a later spread restores the path": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         function persist(params: { filePath: string }) {
           return writeTextAtomic(params.filePath, "{}\\n");
@@ -6245,16 +4093,10 @@ describe("check-database-first-legacy-stores", () => {
           return persist({ filePath: currentSqlitePath, ...params });
         }
         save({ filePath: "sessions.json" });
-      `,
-      "src/runtime/transitive-wrapper-spread-restored-forwarding.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 9 }]);
-  });
-
-  it("flags wrapper options renamed through another wrapper", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/transitive-wrapper-spread-restored-forwarding.ts", [
+        { kind: "legacy store filesystem write", line: 9 },
+      ]),
+      "flags wrapper options renamed through another wrapper": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         function persist(params: { filePath: string }) {
           return writeTextAtomic(params.filePath, "{}\\n");
@@ -6263,78 +4105,48 @@ describe("check-database-first-legacy-stores", () => {
           return persist({ filePath: params.storePath });
         }
         save({ storePath: "sessions.json" });
-      `,
-      "src/runtime/transitive-wrapper-renamed-forwarding.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 9 }]);
-  });
-
-  it("flags hoisted wrappers that use write aliases declared later", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/transitive-wrapper-renamed-forwarding.ts", [
+        { kind: "legacy store filesystem write", line: 9 },
+      ]),
+      "flags hoisted wrappers that use write aliases declared later": sourceCase`
         import fs from "node:fs/promises";
         function persist(params: { filePath: string }) {
           return writeFile(params.filePath, "{}\\n");
         }
         const { writeFile } = fs;
         await persist({ filePath: "sessions.json" });
-      `,
-      "src/runtime/late-alias-hoisted-wrapper.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 7 }]);
-  });
-
-  it("flags hoisted wrappers that use renamed write aliases declared later", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/late-alias-hoisted-wrapper.ts", [
+        { kind: "legacy store filesystem write", line: 7 },
+      ]),
+      "flags hoisted wrappers that use renamed write aliases declared later": sourceCase`
         import fs from "node:fs/promises";
         function persist(params: { filePath: string }) {
           return write(params.filePath, "{}\\n");
         }
         const { writeFile: write } = fs;
         await persist({ filePath: "sessions.json" });
-      `,
-      "src/runtime/late-renamed-alias-hoisted-wrapper.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 7 }]);
-  });
-
-  it("flags reassigned wrapper variables", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/late-renamed-alias-hoisted-wrapper.ts", [
+        { kind: "legacy store filesystem write", line: 7 },
+      ]),
+      "flags reassigned wrapper variables": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         let persist;
         persist = (params: { filePath: string }) => writeTextAtomic(params.filePath, "{}\\n");
         persist({ filePath: "sessions.json" });
-      `,
-      "src/runtime/reassigned-wrapper-variable.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 5 }]);
-  });
-
-  it("flags aliased wrapper variables", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/reassigned-wrapper-variable.ts", [
+        { kind: "legacy store filesystem write", line: 5 },
+      ]),
+      "flags aliased wrapper variables": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         function persist(params: { filePath: string }) {
           return writeTextAtomic(params.filePath, "{}\\n");
         }
         const save = persist;
         save({ filePath: "sessions.json" });
-      `,
-      "src/runtime/aliased-wrapper-variable.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 7 }]);
-  });
-
-  it("does not treat aliased top-level helpers as closing over wrapper parameters", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/aliased-wrapper-variable.ts", [
+        { kind: "legacy store filesystem write", line: 7 },
+      ]),
+      "does not treat aliased top-level helpers as closing over wrapper parameters": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         const filePath = "not-openclaw-state.txt";
         function helper() {
@@ -6345,16 +4157,18 @@ describe("check-database-first-legacy-stores", () => {
           return inner();
         }
         persist("sessions.json");
-      `,
-      "src/runtime/aliased-top-level-wrapper-closed-over-module-var.ts",
-    );
+      `("src/runtime/aliased-top-level-wrapper-closed-over-module-var.ts", []),
+    }),
+  )("$name", ({ source, filename, expected }) => {
+    const violations = collectDatabaseFirstLegacyStoreViolations(source, filename);
 
-    expect(violations).toEqual([]);
+    expect(violations).toEqual(expected);
   });
 
-  it("flags object method wrappers", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+  // Object-backed wrapper discovery and alias tracking.
+  it.each(
+    namedCases({
+      "flags object method wrappers": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         const writer = {
           persist(params: { filePath: string }) {
@@ -6362,63 +4176,39 @@ describe("check-database-first-legacy-stores", () => {
           },
         };
         writer.persist({ filePath: "sessions.json" });
-      `,
-      "src/runtime/object-method-wrapper.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 8 }]);
-  });
-
-  it("flags object property wrapper functions", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/object-method-wrapper.ts", [
+        { kind: "legacy store filesystem write", line: 8 },
+      ]),
+      "flags object property wrapper functions": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         const writer = {
           persist: (params: { filePath: string }) => writeTextAtomic(params.filePath, "{}\\n"),
         };
         writer["persist"]({ filePath: "sessions.json" });
-      `,
-      "src/runtime/object-property-wrapper-function.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 6 }]);
-  });
-
-  it("flags object wrapper shorthand aliases", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/object-property-wrapper-function.ts", [
+        { kind: "legacy store filesystem write", line: 6 },
+      ]),
+      "flags object wrapper shorthand aliases": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         function persist(params: { filePath: string }) {
           return writeTextAtomic(params.filePath, "{}\\n");
         }
         const writer = { persist };
         await writer.persist({ filePath: "sessions.json" });
-      `,
-      "src/runtime/object-wrapper-shorthand-alias.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 7 }]);
-  });
-
-  it("flags object wrapper property aliases", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/object-wrapper-shorthand-alias.ts", [
+        { kind: "legacy store filesystem write", line: 7 },
+      ]),
+      "flags object wrapper property aliases": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         function persist(params: { filePath: string }) {
           return writeTextAtomic(params.filePath, "{}\\n");
         }
         const writer = { save: persist };
         await writer.save({ filePath: "sessions.json" });
-      `,
-      "src/runtime/object-wrapper-property-alias.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 7 }]);
-  });
-
-  it("flags object wrapper methods copied through property access aliases", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/object-wrapper-property-alias.ts", [
+        { kind: "legacy store filesystem write", line: 7 },
+      ]),
+      "flags object wrapper methods copied through property access aliases": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           const writer = {
@@ -6430,16 +4220,10 @@ describe("check-database-first-legacy-stores", () => {
           return proxy.save(filePath);
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/object-wrapper-property-access-alias.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 12 }]);
-  });
-
-  it("flags object wrapper methods copied through whole-object aliases", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/object-wrapper-property-access-alias.ts", [
+        { kind: "legacy store filesystem write", line: 12 },
+      ]),
+      "flags object wrapper methods copied through whole-object aliases": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           const writer = {
@@ -6451,16 +4235,10 @@ describe("check-database-first-legacy-stores", () => {
           return proxy.save(filePath);
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/object-wrapper-whole-object-alias.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 12 }]);
-  });
-
-  it("flags nested object wrapper methods copied through property access aliases", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/object-wrapper-whole-object-alias.ts", [
+        { kind: "legacy store filesystem write", line: 12 },
+      ]),
+      "flags nested object wrapper methods copied through property access aliases": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           const writer = {
@@ -6474,16 +4252,10 @@ describe("check-database-first-legacy-stores", () => {
           return nested.save(filePath);
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-object-wrapper-property-access-alias.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 14 }]);
-  });
-
-  it("flags destructured object wrapper methods from deep property paths", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-object-wrapper-property-access-alias.ts", [
+        { kind: "legacy store filesystem write", line: 14 },
+      ]),
+      "flags destructured object wrapper methods from deep property paths": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           const holder = {
@@ -6499,16 +4271,10 @@ describe("check-database-first-legacy-stores", () => {
           return save();
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/deep-object-wrapper-destructured-method.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 16 }]);
-  });
-
-  it("flags nested object wrapper methods copied through destructuring aliases", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/deep-object-wrapper-destructured-method.ts", [
+        { kind: "legacy store filesystem write", line: 16 },
+      ]),
+      "flags nested object wrapper methods copied through destructuring aliases": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           const writer = {
@@ -6522,16 +4288,10 @@ describe("check-database-first-legacy-stores", () => {
           return nested.save();
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-object-wrapper-destructured-alias.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 14 }]);
-  });
-
-  it("flags nested object wrapper methods copied through identifier-valued properties", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-object-wrapper-destructured-alias.ts", [
+        { kind: "legacy store filesystem write", line: 14 },
+      ]),
+      "flags nested object wrapper methods copied through identifier-valued properties": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           const nested = {
@@ -6543,16 +4303,10 @@ describe("check-database-first-legacy-stores", () => {
           return writer.nested.save();
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-object-wrapper-identifier-property-alias.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 12 }]);
-  });
-
-  it("clears stale nested object wrapper methods after object literal overwrites", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-object-wrapper-identifier-property-alias.ts", [
+        { kind: "legacy store filesystem write", line: 12 },
+      ]),
+      "clears stale nested object wrapper methods after object literal overwrites": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           const writer = {
@@ -6566,16 +4320,8 @@ describe("check-database-first-legacy-stores", () => {
           return writer.nested.save(filePath);
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-object-wrapper-literal-overwrite.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("flags object wrapper methods copied through object spreads", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-object-wrapper-literal-overwrite.ts", []),
+      "flags object wrapper methods copied through object spreads": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           const writer = {
@@ -6587,16 +4333,10 @@ describe("check-database-first-legacy-stores", () => {
           return proxy.save(filePath);
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/object-wrapper-object-spread-alias.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 12 }]);
-  });
-
-  it("flags nested object wrapper methods", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/object-wrapper-object-spread-alias.ts", [
+        { kind: "legacy store filesystem write", line: 12 },
+      ]),
+      "flags nested object wrapper methods": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           const writer = {
@@ -6609,16 +4349,10 @@ describe("check-database-first-legacy-stores", () => {
           return writer.nested.save();
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-object-wrapper-method.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 13 }]);
-  });
-
-  it("flags top-level nested object wrapper methods", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-object-wrapper-method.ts", [
+        { kind: "legacy store filesystem write", line: 13 },
+      ]),
+      "flags top-level nested object wrapper methods": sourceCase`
         import { promises as fs } from "node:fs";
         const writer = {
           nested: {
@@ -6628,16 +4362,11 @@ describe("check-database-first-legacy-stores", () => {
           },
         };
         await writer.nested.save("sessions.json");
-      `,
-      "src/runtime/top-level-nested-object-wrapper-method.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 10 }]);
-  });
-
-  it("flags top-level nested object wrapper methods copied through shorthand properties", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/top-level-nested-object-wrapper-method.ts", [
+        { kind: "legacy store filesystem write", line: 10 },
+      ]),
+      "flags top-level nested object wrapper methods copied through shorthand properties":
+        sourceCase`
         import { promises as fs } from "node:fs";
         const nested = {
           save(filePath: string) {
@@ -6646,16 +4375,11 @@ describe("check-database-first-legacy-stores", () => {
         };
         const writer = { nested };
         await writer.nested.save("sessions.json");
-      `,
-      "src/runtime/top-level-nested-object-wrapper-shorthand.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 9 }]);
-  });
-
-  it("flags top-level nested object wrapper methods copied through identifier properties", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/top-level-nested-object-wrapper-shorthand.ts", [
+          { kind: "legacy store filesystem write", line: 9 },
+        ]),
+      "flags top-level nested object wrapper methods copied through identifier properties":
+        sourceCase`
         import { promises as fs } from "node:fs";
         const nested = {
           save(filePath: string) {
@@ -6664,16 +4388,11 @@ describe("check-database-first-legacy-stores", () => {
         };
         const writer = { child: nested };
         await writer.child.save("sessions.json");
-      `,
-      "src/runtime/top-level-nested-object-wrapper-identifier-property.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 9 }]);
-  });
-
-  it("flags top-level nested object wrapper methods copied through property access aliases", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/top-level-nested-object-wrapper-identifier-property.ts", [
+          { kind: "legacy store filesystem write", line: 9 },
+        ]),
+      "flags top-level nested object wrapper methods copied through property access aliases":
+        sourceCase`
         import { promises as fs } from "node:fs";
         const writer = {
           nested: {
@@ -6684,32 +4403,18 @@ describe("check-database-first-legacy-stores", () => {
         };
         const child = writer.nested;
         await child.save("sessions.json");
-      `,
-      "src/runtime/top-level-nested-object-wrapper-property-access-alias.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 11 }]);
-  });
-
-  it("clears top-level object wrapper methods overwritten with undefined", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/top-level-nested-object-wrapper-property-access-alias.ts", [
+          { kind: "legacy store filesystem write", line: 11 },
+        ]),
+      "clears top-level object wrapper methods overwritten with undefined": sourceCase`
         import { promises as fs } from "node:fs";
         function save(filePath: string) {
           return fs.writeFile(filePath, "{}\\n");
         }
         const writer = { save, save: undefined };
         await writer.save?.("sessions.json");
-      `,
-      "src/runtime/top-level-object-wrapper-undefined-overwrite.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("clears top-level nested object wrapper methods overwritten with undefined", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/top-level-object-wrapper-undefined-overwrite.ts", []),
+      "clears top-level nested object wrapper methods overwritten with undefined": sourceCase`
         import { promises as fs } from "node:fs";
         const writer = {
           nested: {
@@ -6720,16 +4425,8 @@ describe("check-database-first-legacy-stores", () => {
           nested: undefined,
         };
         await writer.nested?.save?.("sessions.json");
-      `,
-      "src/runtime/top-level-nested-object-wrapper-undefined-overwrite.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("does not copy object wrapper methods from shadowed objects", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/top-level-nested-object-wrapper-undefined-overwrite.ts", []),
+      "does not copy object wrapper methods from shadowed objects": sourceCase`
         import { promises as fs } from "node:fs";
         const writer = {
           save(filePath: string) {
@@ -6741,16 +4438,8 @@ describe("check-database-first-legacy-stores", () => {
           const alias = writer;
           await alias.save?.("sessions.json");
         }
-      `,
-      "src/runtime/shadowed-object-wrapper-method-alias.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("flags nested object wrapper methods assigned through object properties", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/shadowed-object-wrapper-method-alias.ts", []),
+      "flags nested object wrapper methods assigned through object properties": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           const writer: any = {};
@@ -6762,16 +4451,11 @@ describe("check-database-first-legacy-stores", () => {
           return writer.nested.save();
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-object-wrapper-property-object-assignment.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 12 }]);
-  });
-
-  it("flags top-level nested object wrapper methods assigned through object properties", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-object-wrapper-property-object-assignment.ts", [
+        { kind: "legacy store filesystem write", line: 12 },
+      ]),
+      "flags top-level nested object wrapper methods assigned through object properties":
+        sourceCase`
         import { promises as fs } from "node:fs";
         const writer: any = {};
         writer.nested = {
@@ -6780,16 +4464,10 @@ describe("check-database-first-legacy-stores", () => {
           },
         };
         await writer.nested.save("sessions.json");
-      `,
-      "src/runtime/top-level-nested-object-wrapper-property-object-assignment.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 9 }]);
-  });
-
-  it("flags nested object wrapper methods assigned through deep object properties", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/top-level-nested-object-wrapper-property-object-assignment.ts", [
+          { kind: "legacy store filesystem write", line: 9 },
+        ]),
+      "flags nested object wrapper methods assigned through deep object properties": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           const writer: any = { nested: {} };
@@ -6797,16 +4475,10 @@ describe("check-database-first-legacy-stores", () => {
           return writer.nested.save();
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-object-wrapper-deep-property-assignment.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 8 }]);
-  });
-
-  it("clears stale nested object wrapper methods after property reassignment", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-object-wrapper-deep-property-assignment.ts", [
+        { kind: "legacy store filesystem write", line: 8 },
+      ]),
+      "clears stale nested object wrapper methods after property reassignment": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           const writer: any = {
@@ -6820,16 +4492,8 @@ describe("check-database-first-legacy-stores", () => {
           return writer.nested.save?.();
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-object-wrapper-property-object-reassignment.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("clears object wrapper property aliases overwritten with undefined", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-object-wrapper-property-object-reassignment.ts", []),
+      "clears object wrapper property aliases overwritten with undefined": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           const save = () => fs.writeFile(filePath, "{}\\n");
@@ -6837,16 +4501,8 @@ describe("check-database-first-legacy-stores", () => {
           return writer.save?.();
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/object-wrapper-property-undefined-overwrite.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("flags object wrapper methods assigned after declaration", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/object-wrapper-property-undefined-overwrite.ts", []),
+      "flags object wrapper methods assigned after declaration": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         let writer: any = {};
         writer = {
@@ -6855,16 +4511,10 @@ describe("check-database-first-legacy-stores", () => {
           },
         };
         await writer.persist({ filePath: "sessions.json" });
-      `,
-      "src/runtime/assigned-object-wrapper-method.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 9 }]);
-  });
-
-  it("clears object wrapper metadata after object reassignment", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/assigned-object-wrapper-method.ts", [
+        { kind: "legacy store filesystem write", line: 9 },
+      ]),
+      "clears object wrapper metadata after object reassignment": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         let writer: any = {
           persist(params: { filePath: string }) {
@@ -6873,16 +4523,8 @@ describe("check-database-first-legacy-stores", () => {
         };
         writer = customWriter;
         await writer.persist({ filePath: "sessions.json" });
-      `,
-      "src/runtime/reassigned-object-wrapper-method.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("uses branch-local object wrapper metadata after conditional reassignment", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/reassigned-object-wrapper-method.ts", []),
+      "uses branch-local object wrapper metadata after conditional reassignment": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         const writer: any = {
           persist(params: { filePath: string }) {
@@ -6893,30 +4535,16 @@ describe("check-database-first-legacy-stores", () => {
           writer.persist = customPersist;
           await writer.persist({ filePath: "sessions.json" });
         }
-      `,
-      "src/runtime/conditional-object-wrapper-reassignment.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("flags object wrapper property assignments", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/conditional-object-wrapper-reassignment.ts", []),
+      "flags object wrapper property assignments": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         const writer: any = {};
         writer.persist = (params: { filePath: string }) => writeTextAtomic(params.filePath, "{}\\n");
         await writer.persist({ filePath: "sessions.json" });
-      `,
-      "src/runtime/object-wrapper-property-assignment.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 5 }]);
-  });
-
-  it("flags nested object wrapper methods copied through property access spreads", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/object-wrapper-property-assignment.ts", [
+        { kind: "legacy store filesystem write", line: 5 },
+      ]),
+      "flags nested object wrapper methods copied through property access spreads": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         const writer: any = {
           nested: {
@@ -6927,16 +4555,10 @@ describe("check-database-first-legacy-stores", () => {
         };
         const copy = { ...writer.nested };
         await copy.save({ filePath: "sessions.json" });
-      `,
-      "src/runtime/nested-object-wrapper-property-access-spread.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 11 }]);
-  });
-
-  it("flags extracted object wrapper methods", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-object-wrapper-property-access-spread.ts", [
+        { kind: "legacy store filesystem write", line: 11 },
+      ]),
+      "flags extracted object wrapper methods": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         const writer = {
           persist(params: { filePath: string }) {
@@ -6945,16 +4567,10 @@ describe("check-database-first-legacy-stores", () => {
         };
         const save = writer.persist;
         await save({ filePath: "sessions.json" });
-      `,
-      "src/runtime/extracted-object-wrapper-method.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 9 }]);
-  });
-
-  it("flags extracted bracket object wrapper methods", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/extracted-object-wrapper-method.ts", [
+        { kind: "legacy store filesystem write", line: 9 },
+      ]),
+      "flags extracted bracket object wrapper methods": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         const writer = {
           persist(params: { filePath: string }) {
@@ -6963,16 +4579,10 @@ describe("check-database-first-legacy-stores", () => {
         };
         const save = writer["persist"];
         await save({ filePath: "sessions.json" });
-      `,
-      "src/runtime/extracted-bracket-object-wrapper-method.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 9 }]);
-  });
-
-  it("flags reassigned aliases from object wrapper methods", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/extracted-bracket-object-wrapper-method.ts", [
+        { kind: "legacy store filesystem write", line: 9 },
+      ]),
+      "flags reassigned aliases from object wrapper methods": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         const writer = {
           persist(params: { filePath: string }) {
@@ -6982,16 +4592,10 @@ describe("check-database-first-legacy-stores", () => {
         let save;
         save = writer.persist;
         await save({ filePath: "sessions.json" });
-      `,
-      "src/runtime/reassigned-object-wrapper-method-alias.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 10 }]);
-  });
-
-  it("flags destructured object wrapper methods", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/reassigned-object-wrapper-method-alias.ts", [
+        { kind: "legacy store filesystem write", line: 10 },
+      ]),
+      "flags destructured object wrapper methods": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         const writer = {
           persist(params: { filePath: string }) {
@@ -7000,16 +4604,10 @@ describe("check-database-first-legacy-stores", () => {
         };
         const { persist } = writer;
         await persist({ filePath: "sessions.json" });
-      `,
-      "src/runtime/destructured-object-wrapper-method.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 9 }]);
-  });
-
-  it("flags renamed destructured object wrapper methods", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/destructured-object-wrapper-method.ts", [
+        { kind: "legacy store filesystem write", line: 9 },
+      ]),
+      "flags renamed destructured object wrapper methods": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         const writer = {
           persist(params: { filePath: string }) {
@@ -7018,16 +4616,10 @@ describe("check-database-first-legacy-stores", () => {
         };
         const { persist: save } = writer;
         await save({ filePath: "sessions.json" });
-      `,
-      "src/runtime/renamed-destructured-object-wrapper-method.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 9 }]);
-  });
-
-  it("flags defaulted destructured object wrapper methods", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/renamed-destructured-object-wrapper-method.ts", [
+        { kind: "legacy store filesystem write", line: 9 },
+      ]),
+      "flags defaulted destructured object wrapper methods": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           const writer = {};
@@ -7035,16 +4627,10 @@ describe("check-database-first-legacy-stores", () => {
           return save();
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/defaulted-destructured-object-wrapper-method.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 8 }]);
-  });
-
-  it("does not use destructured wrapper defaults when safe callbacks are present", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/defaulted-destructured-object-wrapper-method.ts", [
+        { kind: "legacy store filesystem write", line: 8 },
+      ]),
+      "does not use destructured wrapper defaults when safe callbacks are present": sourceCase`
         import { promises as fs } from "node:fs";
         const noopParam = async (_path: string) => {};
         function persist(filePath: string) {
@@ -7053,16 +4639,8 @@ describe("check-database-first-legacy-stores", () => {
           return save(filePath);
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/present-safe-callback-destructured-default.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("uses destructured wrapper defaults when properties are explicitly undefined", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/present-safe-callback-destructured-default.ts", []),
+      "uses destructured wrapper defaults when properties are explicitly undefined": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string) {
           const writer = { save: undefined };
@@ -7070,16 +4648,10 @@ describe("check-database-first-legacy-stores", () => {
           return save();
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/undefined-callback-destructured-default.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 8 }]);
-  });
-
-  it("uses destructured wrapper defaults when properties are aliased undefined", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/undefined-callback-destructured-default.ts", [
+        { kind: "legacy store filesystem write", line: 8 },
+      ]),
+      "uses destructured wrapper defaults when properties are aliased undefined": sourceCase`
         import { promises as fs } from "node:fs";
         const absent = undefined;
         function persist(filePath: string) {
@@ -7088,16 +4660,10 @@ describe("check-database-first-legacy-stores", () => {
           return save();
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/aliased-undefined-callback-destructured-default.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 9 }]);
-  });
-
-  it("does not use destructured wrapper defaults after unknown spreads", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/aliased-undefined-callback-destructured-default.ts", [
+        { kind: "legacy store filesystem write", line: 9 },
+      ]),
+      "does not use destructured wrapper defaults after unknown spreads": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string, options: { save?: () => Promise<void> }) {
           const writer = { save: undefined, ...options };
@@ -7105,16 +4671,8 @@ describe("check-database-first-legacy-stores", () => {
           return save();
         }
         await persist("sessions.json", { save: async () => {} });
-      `,
-      "src/runtime/object-wrapper-destructuring-default-unknown-spread.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("does not force destructured wrapper defaults from unknown spread objects", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/object-wrapper-destructuring-default-unknown-spread.ts", []),
+      "does not force destructured wrapper defaults from unknown spread objects": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string, defaults: { save?: () => Promise<void> }) {
           const writer = { ...defaults };
@@ -7122,16 +4680,9 @@ describe("check-database-first-legacy-stores", () => {
           return save();
         }
         await persist("sessions.json", { save: async () => {} });
-      `,
-      "src/runtime/object-wrapper-destructuring-default-unknown-spread-object.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("does not force closed-over destructured wrapper defaults from unknown spread objects", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/object-wrapper-destructuring-default-unknown-spread-object.ts", []),
+      "does not force closed-over destructured wrapper defaults from unknown spread objects":
+        sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string, defaults: { save?: () => Promise<void> }) {
           function inner() {
@@ -7142,16 +4693,11 @@ describe("check-database-first-legacy-stores", () => {
           return inner();
         }
         await persist("sessions.json", { save: async () => {} });
-      `,
-      "src/runtime/object-wrapper-destructuring-default-unknown-spread-object-closed-over.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("keeps branch-only object wrapper methods after exhaustive merge", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `(
+          "src/runtime/object-wrapper-destructuring-default-unknown-spread-object-closed-over.ts",
+          [],
+        ),
+      "keeps branch-only object wrapper methods after exhaustive merge": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string, enabled: boolean) {
           let writer = {};
@@ -7168,16 +4714,11 @@ describe("check-database-first-legacy-stores", () => {
           return save();
         }
         await persist("sessions.json", true);
-      `,
-      "src/runtime/branch-only-object-wrapper-method.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 17 }]);
-  });
-
-  it("keeps branch-only property assigned object wrapper methods after exhaustive merge", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/branch-only-object-wrapper-method.ts", [
+        { kind: "legacy store filesystem write", line: 17 },
+      ]),
+      "keeps branch-only property assigned object wrapper methods after exhaustive merge":
+        sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string, enabled: boolean) {
           let writer = {};
@@ -7189,16 +4730,10 @@ describe("check-database-first-legacy-stores", () => {
           return writer.save?.();
         }
         await persist("sessions.json", true);
-      `,
-      "src/runtime/branch-only-property-object-wrapper-method.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 12 }]);
-  });
-
-  it("keeps prior nested wrapper values when only one branch assigns", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/branch-only-property-object-wrapper-method.ts", [
+          { kind: "legacy store filesystem write", line: 12 },
+        ]),
+      "keeps prior nested wrapper values when only one branch assigns": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(filePath: string, disabled: boolean) {
           let save = (nextPath: string) => fs.writeFile(nextPath, "{}\\n");
@@ -7209,59 +4744,31 @@ describe("check-database-first-legacy-stores", () => {
           return save(filePath);
         }
         await persist("sessions.json", false);
-      `,
-      "src/runtime/prior-wrapper-value-branch-assignment.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 11 }]);
-  });
-
-  it("clears wrapper metadata after non-wrapper reassignment", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/prior-wrapper-value-branch-assignment.ts", [
+        { kind: "legacy store filesystem write", line: 11 },
+      ]),
+      "clears wrapper metadata after non-wrapper reassignment": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         let persist = (params: { filePath: string }) => writeTextAtomic(params.filePath, "{}\\n");
         persist = customSink;
         persist({ filePath: "sessions.json" });
-      `,
-      "src/runtime/cleared-wrapper-variable.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("keeps wrapper metadata after conditional non-wrapper reassignment", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/cleared-wrapper-variable.ts", []),
+      "keeps wrapper metadata after conditional non-wrapper reassignment": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         let persist = (params: { filePath: string }) => writeTextAtomic(params.filePath, "{}\\n");
         if (ready) persist = customSink;
         persist({ filePath: "sessions.json" });
-      `,
-      "src/runtime/conditional-cleared-wrapper-variable.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 5 }]);
-  });
-
-  it("clears wrapper metadata after exhaustive non-wrapper reassignments", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/conditional-cleared-wrapper-variable.ts", [
+        { kind: "legacy store filesystem write", line: 5 },
+      ]),
+      "clears wrapper metadata after exhaustive non-wrapper reassignments": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         let persist = (params: { filePath: string }) => writeTextAtomic(params.filePath, "{}\\n");
         if (ready) persist = customSink;
         else persist = customSink;
         persist({ filePath: "sessions.json" });
-      `,
-      "src/runtime/exhaustive-cleared-wrapper-variable.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("keeps wrapper metadata after try-block non-wrapper reassignment", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/exhaustive-cleared-wrapper-variable.ts", []),
+      "keeps wrapper metadata after try-block non-wrapper reassignment": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         let persist = (params: { filePath: string }) => writeTextAtomic(params.filePath, "{}\\n");
         try {
@@ -7269,45 +4776,35 @@ describe("check-database-first-legacy-stores", () => {
           persist = customSink;
         } catch {}
         persist({ filePath: "sessions.json" });
-      `,
-      "src/runtime/try-cleared-wrapper-variable.ts",
-    );
+      `("src/runtime/try-cleared-wrapper-variable.ts", [
+        { kind: "legacy store filesystem write", line: 8 },
+      ]),
+    }),
+  )("$name", ({ source, filename, expected }) => {
+    const violations = collectDatabaseFirstLegacyStoreViolations(source, filename);
 
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 8 }]);
+    expect(violations).toEqual(expected);
   });
 
-  it("flags wrapper option paths read through bracket property access", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+  // Tracked object paths, destructuring, and shadowing.
+  it.each(
+    namedCases({
+      "flags wrapper option paths read through bracket property access": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         function persist(params: { filePath: string }) {
           return writeTextAtomic(params["filePath"], "{}\\n");
         }
         persist({ filePath: "sessions.json" });
-      `,
-      "src/runtime/bracket-wrapper-property.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 6 }]);
-  });
-
-  it("does not treat custom writeFile methods as wrapper filesystem writes", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/bracket-wrapper-property.ts", [
+        { kind: "legacy store filesystem write", line: 6 },
+      ]),
+      "does not treat custom writeFile methods as wrapper filesystem writes": sourceCase`
         function persist(writer: { writeFile: (path: string, content: string) => void }, params: { filePath: string }) {
           return writer.writeFile(params.filePath, "{}\\n");
         }
         persist(customWriter, { filePath: "sessions.json" });
-      `,
-      "src/runtime/custom-writer-method-wrapper.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("does not use outer wrapper metadata for shadowed wrapper names", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/custom-writer-method-wrapper.ts", []),
+      "does not use outer wrapper metadata for shadowed wrapper names": sourceCase`
         import { writeJson } from "../infra/json-files.js";
         function persist(options: { store: string }) {
           return writeJson(options.store, {});
@@ -7318,16 +4815,8 @@ describe("check-database-first-legacy-stores", () => {
           }
           await persist({ store: "sessions.json" });
         }
-      `,
-      "src/runtime/shadowed-wrapper-options.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("does not let loop-scoped wrapper names shadow outer wrappers", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/shadowed-wrapper-options.ts", []),
+      "does not let loop-scoped wrapper names shadow outer wrappers": sourceCase`
         import { writeJson } from "../infra/json-files.js";
         function persist(options: { store: string }) {
           return writeJson(options.store, {});
@@ -7336,16 +4825,10 @@ describe("check-database-first-legacy-stores", () => {
           await persist(currentOptions);
         }
         await persist({ store: "sessions.json" });
-      `,
-      "src/runtime/loop-scoped-wrapper-name.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 9 }]);
-  });
-
-  it("does not use outer wrapper metadata for destructured parameter wrapper names", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/loop-scoped-wrapper-name.ts", [
+        { kind: "legacy store filesystem write", line: 9 },
+      ]),
+      "does not use outer wrapper metadata for destructured parameter wrapper names": sourceCase`
         import { writeJson } from "../infra/json-files.js";
         function persist(options: { store: string }) {
           return writeJson(options.store, {});
@@ -7353,113 +4836,55 @@ describe("check-database-first-legacy-stores", () => {
         function caller({ persist }: { persist: (options: { store: string }) => void }) {
           persist({ store: "sessions.json" });
         }
-      `,
-      "src/runtime/destructured-wrapper-name-parameter.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("does not treat sibling object metadata as the wrapper path property", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/destructured-wrapper-name-parameter.ts", []),
+      "does not treat sibling object metadata as the wrapper path property": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         function persist(params: { filePath: string }) {
           return writeTextAtomic(params.filePath, "{}\\n");
         }
         const params = { label: "sessions.json", filePath: currentSqlitePath };
         await persist(params);
-      `,
-      "src/runtime/current-path-sibling-metadata.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("does not treat custom writeFile methods as direct filesystem writes", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/current-path-sibling-metadata.ts", []),
+      "does not treat custom writeFile methods as direct filesystem writes": sourceCase`
         const params = { filePath: "sessions.json" };
         await customWriter.writeFile(params.filePath, "{}\\n");
-      `,
-      "src/runtime/custom-writer-method.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("flags legacy paths written through injected fs handles", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/custom-writer-method.ts", []),
+      "flags legacy paths written through injected fs handles": sourceCase`
         const storePath = "sessions.json";
         const params: { deps: { fs: typeof import("node:fs") } } = { deps };
         await params.deps.fs.promises.writeFile(storePath, "{}\\n");
-      `,
-      "src/runtime/injected-fs-write.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 4 }]);
-  });
-
-  it("does not treat custom fs properties as direct filesystem writes", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/injected-fs-write.ts", [{ kind: "legacy store filesystem write", line: 4 }]),
+      "does not treat custom fs properties as direct filesystem writes": sourceCase`
         const storePath = "sessions.json";
         await client.fs.promises.writeFile(storePath, "{}\\n");
-      `,
-      "src/runtime/custom-fs-property.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("updates object path metadata after property assignment", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/custom-fs-property.ts", []),
+      "updates object path metadata after property assignment": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         const params = { filePath: currentSqlitePath };
         params.filePath = "sessions.json";
         writeTextAtomic(params.filePath, "{}\\n");
-      `,
-      "src/runtime/assigned-object-path.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 5 }]);
-  });
-
-  it("updates object path metadata after bracket property assignment", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/assigned-object-path.ts", [
+        { kind: "legacy store filesystem write", line: 5 },
+      ]),
+      "updates object path metadata after bracket property assignment": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         const params = { filePath: currentSqlitePath };
         params["filePath"] = "sessions.json";
         writeTextAtomic(params["filePath"], "{}\\n");
-      `,
-      "src/runtime/bracket-assigned-object-path.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 5 }]);
-  });
-
-  it("updates outer object path metadata after nested property assignment", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/bracket-assigned-object-path.ts", [
+        { kind: "legacy store filesystem write", line: 5 },
+      ]),
+      "updates outer object path metadata after nested property assignment": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         const params = { filePath: currentSqlitePath };
         {
           params.filePath = "sessions.json";
         }
         writeTextAtomic(params.filePath, "{}\\n");
-      `,
-      "src/runtime/nested-assigned-object-path.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 7 }]);
-  });
-
-  it("flags nested property assignments forwarded through option objects", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-assigned-object-path.ts", [
+        { kind: "legacy store filesystem write", line: 7 },
+      ]),
+      "flags nested property assignments forwarded through option objects": sourceCase`
         import { promises as fs } from "node:fs";
         function persist({ paths: { filePath } }: { paths: { filePath: string } }) {
           return fs.writeFile(filePath, "{}\\n");
@@ -7467,30 +4892,18 @@ describe("check-database-first-legacy-stores", () => {
         const options = { paths: {} };
         options.paths.filePath = "sessions.json";
         await persist(options);
-      `,
-      "src/runtime/nested-wrapper-option-property-assignment.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 8 }]);
-  });
-
-  it("flags nested property assignments read directly by filesystem writes", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-option-property-assignment.ts", [
+        { kind: "legacy store filesystem write", line: 8 },
+      ]),
+      "flags nested property assignments read directly by filesystem writes": sourceCase`
         import { promises as fs } from "node:fs";
         const options = { paths: {} };
         options.paths.filePath = "sessions.json";
         await fs.writeFile(options.paths.filePath, "{}\\n");
-      `,
-      "src/runtime/nested-direct-property-assignment.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 5 }]);
-  });
-
-  it("flags nested parent object assignments forwarded through option objects", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-direct-property-assignment.ts", [
+        { kind: "legacy store filesystem write", line: 5 },
+      ]),
+      "flags nested parent object assignments forwarded through option objects": sourceCase`
         import { promises as fs } from "node:fs";
         function persist({ paths: { filePath } }: { paths: { filePath: string } }) {
           return fs.writeFile(filePath, "{}\\n");
@@ -7498,16 +4911,10 @@ describe("check-database-first-legacy-stores", () => {
         const options = { paths: {} };
         options.paths = { filePath: "sessions.json" };
         await persist(options);
-      `,
-      "src/runtime/nested-wrapper-option-parent-assignment.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 8 }]);
-  });
-
-  it("flags nested defaults after parent object property assignments", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-option-parent-assignment.ts", [
+        { kind: "legacy store filesystem write", line: 8 },
+      ]),
+      "flags nested defaults after parent object property assignments": sourceCase`
         import { promises as fs } from "node:fs";
         function persist({ paths: { filePath = "sessions.json" } }: { paths: { filePath?: string } }) {
           return fs.writeFile(filePath, "{}\\n");
@@ -7515,16 +4922,10 @@ describe("check-database-first-legacy-stores", () => {
         const options = {};
         options.paths = {};
         await persist(options);
-      `,
-      "src/runtime/nested-wrapper-option-parent-known-empty-assignment.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 8 }]);
-  });
-
-  it("clears nested path metadata after parent object assignments", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-option-parent-known-empty-assignment.ts", [
+        { kind: "legacy store filesystem write", line: 8 },
+      ]),
+      "clears nested path metadata after parent object assignments": sourceCase`
         import { promises as fs } from "node:fs";
         function persist({ paths: { filePath } }: { paths: { filePath: string } }) {
           return fs.writeFile(filePath, "{}\\n");
@@ -7532,16 +4933,9 @@ describe("check-database-first-legacy-stores", () => {
         const options = { paths: { filePath: "sessions.json" } };
         options.paths = { filePath: "current-state.json" };
         await persist(options);
-      `,
-      "src/runtime/nested-wrapper-option-parent-current-assignment.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("keeps maybe missing nested properties after conditional parent object assignments", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-option-parent-current-assignment.ts", []),
+      "keeps maybe missing nested properties after conditional parent object assignments":
+        sourceCase`
         import { promises as fs } from "node:fs";
         function persist({ paths: { filePath = "sessions.json" } }: { paths: { filePath?: string } }) {
           return fs.writeFile(filePath, "{}\\n");
@@ -7551,44 +4945,24 @@ describe("check-database-first-legacy-stores", () => {
           options.paths = {};
         }
         await persist(options);
-      `,
-      "src/runtime/conditional-nested-parent-missing-property.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 10 }]);
-  });
-
-  it("clears object path metadata after current-path assignment", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/conditional-nested-parent-missing-property.ts", [
+          { kind: "legacy store filesystem write", line: 10 },
+        ]),
+      "clears object path metadata after current-path assignment": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         const params = { filePath: "sessions.json" };
         params.filePath = currentSqlitePath;
         writeTextAtomic(params.filePath, "{}\\n");
-      `,
-      "src/runtime/reassigned-object-path.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("keeps legacy object metadata after conditional current-path assignment", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/reassigned-object-path.ts", []),
+      "keeps legacy object metadata after conditional current-path assignment": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         const params = { filePath: "sessions.json" };
         if (ready) params.filePath = currentSqlitePath;
         writeTextAtomic(params.filePath, "{}\\n");
-      `,
-      "src/runtime/conditional-current-object-path.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 5 }]);
-  });
-
-  it("keeps maybe missing properties after conditional safe property assignments", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/conditional-current-object-path.ts", [
+        { kind: "legacy store filesystem write", line: 5 },
+      ]),
+      "keeps maybe missing properties after conditional safe property assignments": sourceCase`
         import { promises as fs } from "node:fs";
         const options = {};
         if (ready) options.path = currentSqlitePath;
@@ -7596,78 +4970,46 @@ describe("check-database-first-legacy-stores", () => {
           return fs.writeFile(path, "{}\\n");
         }
         await writePath("sessions.json", options);
-      `,
-      "src/runtime/conditional-safe-property-missing-default.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 8 }]);
-  });
-
-  it("keeps legacy object metadata after loop current-path assignment", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/conditional-safe-property-missing-default.ts", [
+        { kind: "legacy store filesystem write", line: 8 },
+      ]),
+      "keeps legacy object metadata after loop current-path assignment": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         const params = { filePath: "sessions.json" };
         while (ready) params.filePath = currentSqlitePath;
         writeTextAtomic(params.filePath, "{}\\n");
-      `,
-      "src/runtime/loop-current-object-path.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 5 }]);
-  });
-
-  it("does not let for-loop object bindings clear outer object metadata", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/loop-current-object-path.ts", [
+        { kind: "legacy store filesystem write", line: 5 },
+      ]),
+      "does not let for-loop object bindings clear outer object metadata": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         const params = { filePath: "sessions.json" };
         for (const params = { filePath: currentSqlitePath }; ready; advance()) {
           await use(params);
         }
         writeTextAtomic(params.filePath, "{}\\n");
-      `,
-      "src/runtime/for-loop-object-shadow.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 7 }]);
-  });
-
-  it("does not leak for-loop legacy object bindings after the loop", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/for-loop-object-shadow.ts", [
+        { kind: "legacy store filesystem write", line: 7 },
+      ]),
+      "does not leak for-loop legacy object bindings after the loop": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         const params = { filePath: currentSqlitePath };
         for (const params = { filePath: "sessions.json" }; ready; advance()) {
           await use(params);
         }
         writeTextAtomic(params.filePath, "{}\\n");
-      `,
-      "src/runtime/for-loop-legacy-object-shadow.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("keeps legacy object metadata after conditional current-object assignment", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/for-loop-legacy-object-shadow.ts", []),
+      "keeps legacy object metadata after conditional current-object assignment": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         let params = { filePath: "sessions.json" };
         if (ready) {
           params = { filePath: currentSqlitePath };
         }
         writeTextAtomic(params.filePath, "{}\\n");
-      `,
-      "src/runtime/conditional-current-object.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 7 }]);
-  });
-
-  it("clears object metadata after exhaustive current-object assignments", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/conditional-current-object.ts", [
+        { kind: "legacy store filesystem write", line: 7 },
+      ]),
+      "clears object metadata after exhaustive current-object assignments": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         let params = { filePath: "sessions.json" };
         if (ready) {
@@ -7676,16 +5018,9 @@ describe("check-database-first-legacy-stores", () => {
           params = { filePath: currentSqlitePath };
         }
         writeTextAtomic(params.filePath, "{}\\n");
-      `,
-      "src/runtime/exhaustive-current-object.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("keeps outer object metadata after optional exhaustive current-object assignments", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/exhaustive-current-object.ts", []),
+      "keeps outer object metadata after optional exhaustive current-object assignments":
+        sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         let params = { filePath: "sessions.json" };
         if (ready) {
@@ -7696,16 +5031,10 @@ describe("check-database-first-legacy-stores", () => {
           }
         }
         writeTextAtomic(params.filePath, "{}\\n");
-      `,
-      "src/runtime/optional-exhaustive-current-object.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 11 }]);
-  });
-
-  it("allows branch-local writes after nested exhaustive current-object assignments", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/optional-exhaustive-current-object.ts", [
+          { kind: "legacy store filesystem write", line: 11 },
+        ]),
+      "allows branch-local writes after nested exhaustive current-object assignments": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         let params = { filePath: "sessions.json" };
         if (ready) {
@@ -7716,16 +5045,8 @@ describe("check-database-first-legacy-stores", () => {
           }
           writeTextAtomic(params.filePath, "{}\\n");
         }
-      `,
-      "src/runtime/branch-local-exhaustive-current-object.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("keeps object metadata when one exhaustive branch keeps a legacy object", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/branch-local-exhaustive-current-object.ts", []),
+      "keeps object metadata when one exhaustive branch keeps a legacy object": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         let params = { filePath: "sessions.json" };
         if (ready) {
@@ -7734,16 +5055,10 @@ describe("check-database-first-legacy-stores", () => {
           params = { filePath: "sessions.json" };
         }
         writeTextAtomic(params.filePath, "{}\\n");
-      `,
-      "src/runtime/exhaustive-mixed-object.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 9 }]);
-  });
-
-  it("clears object property metadata after exhaustive current-path assignments", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/exhaustive-mixed-object.ts", [
+        { kind: "legacy store filesystem write", line: 9 },
+      ]),
+      "clears object property metadata after exhaustive current-path assignments": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         const params = { filePath: "sessions.json" };
         if (ready) {
@@ -7752,16 +5067,8 @@ describe("check-database-first-legacy-stores", () => {
           params.filePath = currentSqlitePath;
         }
         writeTextAtomic(params.filePath, "{}\\n");
-      `,
-      "src/runtime/exhaustive-current-object-property.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("keeps legacy object metadata after try-block current-object assignment", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/exhaustive-current-object-property.ts", []),
+      "keeps legacy object metadata after try-block current-object assignment": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         let params = { filePath: "sessions.json" };
         try {
@@ -7769,118 +5076,59 @@ describe("check-database-first-legacy-stores", () => {
           params = { filePath: currentSqlitePath };
         } catch {}
         writeTextAtomic(params.filePath, "{}\\n");
-      `,
-      "src/runtime/try-current-object.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 8 }]);
-  });
-
-  it("clears outer object path metadata after nested current-path assignment", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/try-current-object.ts", [{ kind: "legacy store filesystem write", line: 8 }]),
+      "clears outer object path metadata after nested current-path assignment": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         const params = { filePath: "sessions.json" };
         {
           params.filePath = currentSqlitePath;
         }
         writeTextAtomic(params.filePath, "{}\\n");
-      `,
-      "src/runtime/nested-reassigned-object-path.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("allows in-branch writes after object property reassignment to the current path", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-reassigned-object-path.ts", []),
+      "allows in-branch writes after object property reassignment to the current path": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         const params = { filePath: "sessions.json" };
         if (ready) {
           params.filePath = currentSqlitePath;
           writeTextAtomic(params.filePath, "{}\\n");
         }
-      `,
-      "src/runtime/branch-reassigned-object-property.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("updates object path metadata after whole-object assignment", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/branch-reassigned-object-property.ts", []),
+      "updates object path metadata after whole-object assignment": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         let params = { filePath: currentSqlitePath };
         params = { filePath: "sessions.json" };
         writeTextAtomic(params.filePath, "{}\\n");
-      `,
-      "src/runtime/reassigned-object.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 5 }]);
-  });
-
-  it("clears object path metadata after whole-object current-path assignment", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/reassigned-object.ts", [{ kind: "legacy store filesystem write", line: 5 }]),
+      "clears object path metadata after whole-object current-path assignment": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         let params = { filePath: "sessions.json" };
         params = { filePath: currentSqlitePath };
         writeTextAtomic(params.filePath, "{}\\n");
-      `,
-      "src/runtime/reassigned-current-object.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("flags legacy paths destructured from tracked object properties", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/reassigned-current-object.ts", []),
+      "flags legacy paths destructured from tracked object properties": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         const params = { filePath: "sessions.json" };
         const { filePath } = params;
         writeTextAtomic(filePath, "{}\\n");
-      `,
-      "src/runtime/destructured-tracked-object-path.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 5 }]);
-  });
-
-  it("flags legacy paths from nested destructured object properties", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/destructured-tracked-object-path.ts", [
+        { kind: "legacy store filesystem write", line: 5 },
+      ]),
+      "flags legacy paths from nested destructured object properties": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         const params = { nested: { filePath: "sessions.json" } };
         const { nested: { filePath } } = params;
         writeTextAtomic(filePath, "{}\\n");
-      `,
-      "src/runtime/nested-destructured-tracked-object-path.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 5 }]);
-  });
-
-  it("uses tracked nested current paths before destructured defaults", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-destructured-tracked-object-path.ts", [
+        { kind: "legacy store filesystem write", line: 5 },
+      ]),
+      "uses tracked nested current paths before destructured defaults": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         const params = { nested: { filePath: currentSqlitePath } };
         const { nested: { filePath = "sessions.json" } } = params;
         writeTextAtomic(filePath, "{}\\n");
-      `,
-      "src/runtime/nested-destructured-current-object-path.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("flags nested defaults after conditional whole-object rewrites omit safe properties", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-destructured-current-object-path.ts", []),
+      "flags nested defaults after conditional whole-object rewrites omit safe properties":
+        sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         function persist({ paths: { filePath = "sessions.json" } }: { paths: { filePath?: string } }) {
           return writeTextAtomic(filePath, "{}\\n");
@@ -7890,16 +5138,11 @@ describe("check-database-first-legacy-stores", () => {
           options = { paths: {} };
         }
         await persist(options);
-      `,
-      "src/runtime/conditional-whole-object-rewrite-nested-default.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 10 }]);
-  });
-
-  it("flags nested defaults after conditional whole-object rewrites from known aliases", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/conditional-whole-object-rewrite-nested-default.ts", [
+          { kind: "legacy store filesystem write", line: 10 },
+        ]),
+      "flags nested defaults after conditional whole-object rewrites from known aliases":
+        sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         function persist({ paths: { filePath = "sessions.json" } }: { paths: { filePath?: string } }) {
           return writeTextAtomic(filePath, "{}\\n");
@@ -7910,98 +5153,54 @@ describe("check-database-first-legacy-stores", () => {
           options = source;
         }
         await persist(options);
-      `,
-      "src/runtime/conditional-whole-object-rewrite-alias-nested-default.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 11 }]);
-  });
-
-  it("flags legacy paths from destructured default values", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/conditional-whole-object-rewrite-alias-nested-default.ts", [
+          { kind: "legacy store filesystem write", line: 11 },
+        ]),
+      "flags legacy paths from destructured default values": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         const params = {};
         const { filePath = "sessions.json" } = params;
         writeTextAtomic(filePath, "{}\\n");
-      `,
-      "src/runtime/destructured-default-object-path.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 5 }]);
-  });
-
-  it("flags legacy paths from inline object destructured default values", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/destructured-default-object-path.ts", [
+        { kind: "legacy store filesystem write", line: 5 },
+      ]),
+      "flags legacy paths from inline object destructured default values": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         const { filePath = "sessions.json" } = {};
         writeTextAtomic(filePath, "{}\\n");
-      `,
-      "src/runtime/inline-destructured-default-object-path.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 4 }]);
-  });
-
-  it("flags legacy paths from inline destructured object descendants", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/inline-destructured-default-object-path.ts", [
+        { kind: "legacy store filesystem write", line: 4 },
+      ]),
+      "flags legacy paths from inline destructured object descendants": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         const { paths } = { paths: { filePath: "sessions.json" } };
         writeTextAtomic(paths.filePath, "{}\\n");
-      `,
-      "src/runtime/inline-destructured-object-descendant-path.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 4 }]);
-  });
-
-  it("flags legacy paths destructured from tracked nested properties", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/inline-destructured-object-descendant-path.ts", [
+        { kind: "legacy store filesystem write", line: 4 },
+      ]),
+      "flags legacy paths destructured from tracked nested properties": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         const options = { paths: { filePath: "sessions.json" } };
         const { filePath } = options.paths;
         writeTextAtomic(filePath, "{}\\n");
-      `,
-      "src/runtime/destructured-tracked-nested-property-path.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 5 }]);
-  });
-
-  it("does not force inline object destructured defaults after unknown spreads", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/destructured-tracked-nested-property-path.ts", [
+        { kind: "legacy store filesystem write", line: 5 },
+      ]),
+      "does not force inline object destructured defaults after unknown spreads": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         declare const defaults: { filePath?: string };
         const { filePath = "sessions.json" } = { ...defaults };
         writeTextAtomic(filePath, "{}\\n");
-      `,
-      "src/runtime/inline-destructured-default-unknown-spread.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("flags destructured defaults from explicitly undefined tracked properties", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/inline-destructured-default-unknown-spread.ts", []),
+      "flags destructured defaults from explicitly undefined tracked properties": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         const params = { filePath: undefined };
         const { filePath = "sessions.json" } = params;
         writeTextAtomic(filePath, "{}\\n");
-      `,
-      "src/runtime/destructured-default-explicit-undefined-object-path.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 5 }]);
-  });
-
-  it("flags wrapper defaults from destructured missing tracked properties", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/destructured-default-explicit-undefined-object-path.ts", [
+        { kind: "legacy store filesystem write", line: 5 },
+      ]),
+      "flags wrapper defaults from destructured missing tracked properties": sourceCase`
         import { promises as fs } from "node:fs";
         const params = {};
         function persist({ path = "sessions.json" }: { path?: string }) {
@@ -8009,61 +5208,35 @@ describe("check-database-first-legacy-stores", () => {
         }
         const { filePath } = params;
         await persist({ path: filePath });
-      `,
-      "src/runtime/destructured-missing-property-wrapper-default.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 8 }]);
-  });
-
-  it("flags wrapper defaults from inline destructured missing properties", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/destructured-missing-property-wrapper-default.ts", [
+        { kind: "legacy store filesystem write", line: 8 },
+      ]),
+      "flags wrapper defaults from inline destructured missing properties": sourceCase`
         import { promises as fs } from "node:fs";
         function persist({ path = "sessions.json" }: { path?: string }) {
           return fs.writeFile(path, "{}\\n");
         }
         const { filePath } = {};
         await persist({ path: filePath });
-      `,
-      "src/runtime/inline-destructured-missing-property-wrapper-default.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 7 }]);
-  });
-
-  it("flags destructured defaults from aliased undefined tracked properties", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/inline-destructured-missing-property-wrapper-default.ts", [
+        { kind: "legacy store filesystem write", line: 7 },
+      ]),
+      "flags destructured defaults from aliased undefined tracked properties": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         const absent = undefined;
         const params = { filePath: absent };
         const { filePath = "sessions.json" } = params;
         writeTextAtomic(filePath, "{}\\n");
-      `,
-      "src/runtime/destructured-default-aliased-undefined-object-path.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 6 }]);
-  });
-
-  it("uses tracked object properties before destructured defaults", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/destructured-default-aliased-undefined-object-path.ts", [
+        { kind: "legacy store filesystem write", line: 6 },
+      ]),
+      "uses tracked object properties before destructured defaults": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         const params = { filePath: currentSqlitePath };
         const { filePath = "sessions.json" } = params;
         writeTextAtomic(filePath, "{}\\n");
-      `,
-      "src/runtime/destructured-default-current-object-path.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("flags wrapper shorthand options destructured from tracked object properties", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/destructured-default-current-object-path.ts", []),
+      "flags wrapper shorthand options destructured from tracked object properties": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         function persist(params: { filePath: string }) {
           return writeTextAtomic(params.filePath, "{}\\n");
@@ -8071,31 +5244,17 @@ describe("check-database-first-legacy-stores", () => {
         const params = { filePath: "sessions.json" };
         const { filePath } = params;
         persist({ filePath });
-      `,
-      "src/runtime/destructured-shorthand-wrapper-path.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 8 }]);
-  });
-
-  it("does not treat unrelated property names as destructured wrapper paths", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/destructured-shorthand-wrapper-path.ts", [
+        { kind: "legacy store filesystem write", line: 8 },
+      ]),
+      "does not treat unrelated property names as destructured wrapper paths": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         function persist({ filePath }: { filePath: string }) {
           return writeTextAtomic(current.filePath, "{}\\n");
         }
         await persist({ filePath: "sessions.json" });
-      `,
-      "src/runtime/unrelated-property-name-wrapper.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("flags wrapper option paths forwarded through object aliases", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/unrelated-property-name-wrapper.ts", []),
+      "flags wrapper option paths forwarded through object aliases": sourceCase`
         import { writeJson } from "../infra/json-files.js";
         function persist(options: { store: string }) {
           return writeJson(options.store, {});
@@ -8103,16 +5262,10 @@ describe("check-database-first-legacy-stores", () => {
         const params = { store: "sessions.json" };
         const forwarded = params;
         await persist(forwarded);
-      `,
-      "src/runtime/forwarded-wrapper-options.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 8 }]);
-  });
-
-  it("flags wrapper option paths forwarded through destructured object aliases", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/forwarded-wrapper-options.ts", [
+        { kind: "legacy store filesystem write", line: 8 },
+      ]),
+      "flags wrapper option paths forwarded through destructured object aliases": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         function persist(params: { paths: { filePath: string } }) {
           return writeTextAtomic(params.paths.filePath, "{}\\n");
@@ -8120,16 +5273,10 @@ describe("check-database-first-legacy-stores", () => {
         const options = { paths: { filePath: "sessions.json" } };
         const { paths } = options;
         await persist({ paths });
-      `,
-      "src/runtime/wrapper-option-path-destructured-object-alias.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 8 }]);
-  });
-
-  it("does not treat sibling nested properties as wrapper option paths", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/wrapper-option-path-destructured-object-alias.ts", [
+        { kind: "legacy store filesystem write", line: 8 },
+      ]),
+      "does not treat sibling nested properties as wrapper option paths": sourceCase`
         import { promises as fs } from "node:fs";
         function persist(params: { paths: { filePath: string; legacyPath: string } }) {
           return fs.writeFile(params.paths.filePath, "{}\\n");
@@ -8141,16 +5288,8 @@ describe("check-database-first-legacy-stores", () => {
           },
         };
         await persist(options);
-      `,
-      "src/runtime/wrapper-option-path-nested-sibling-property.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("clears nested wrapper option paths after object literal spread overwrites", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/wrapper-option-path-nested-sibling-property.ts", []),
+      "clears nested wrapper option paths after object literal spread overwrites": sourceCase`
         import { promises as fs } from "node:fs";
         function persist({ paths: { filePath = currentSqlitePath } = {} }) {
           return fs.writeFile(filePath, "{}\\n");
@@ -8160,16 +5299,8 @@ describe("check-database-first-legacy-stores", () => {
           ...{ paths: {} },
         };
         await persist(params);
-      `,
-      "src/runtime/wrapper-option-path-object-spread-overwrite.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("clears known nested wrapper option paths after parent rewrites", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/wrapper-option-path-object-spread-overwrite.ts", []),
+      "clears known nested wrapper option paths after parent rewrites": sourceCase`
         import { promises as fs } from "node:fs";
         declare function loadNested(): { filePath?: string };
         function persist({ paths: { nested: { filePath = "sessions.json" } = {} } }) {
@@ -8178,16 +5309,8 @@ describe("check-database-first-legacy-stores", () => {
         const options = { paths: { nested: {} } };
         options.paths = { nested: loadNested() };
         await persist(options);
-      `,
-      "src/runtime/wrapper-option-path-parent-rewrite-unknown-nested.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("flags wrapper option paths forwarded through object spreads", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/wrapper-option-path-parent-rewrite-unknown-nested.ts", []),
+      "flags wrapper option paths forwarded through object spreads": sourceCase`
         import { writeJson } from "../infra/json-files.js";
         function persist(options: { store: string }) {
           return writeJson(options.store, {});
@@ -8195,16 +5318,10 @@ describe("check-database-first-legacy-stores", () => {
         const params = { store: "sessions.json" };
         const forwarded = { ...params };
         await persist(forwarded);
-      `,
-      "src/runtime/spread-wrapper-options.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 8 }]);
-  });
-
-  it("flags wrapper option paths passed through inline object spreads", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/spread-wrapper-options.ts", [
+        { kind: "legacy store filesystem write", line: 8 },
+      ]),
+      "flags wrapper option paths passed through inline object spreads": sourceCase`
         import { writeJson } from "../infra/json-files.js";
         function persist(options: { store: string }) {
           return writeJson(options.store, {});
@@ -8212,19 +5329,11 @@ describe("check-database-first-legacy-stores", () => {
         const params = { store: "sessions.json" };
         await persist({ ...params });
         await persist({ store: currentSqlitePath, ...params });
-      `,
-      "src/runtime/inline-spread-wrapper-options.ts",
-    );
-
-    expect(violations).toEqual([
-      { kind: "legacy store filesystem write", line: 7 },
-      { kind: "legacy store filesystem write", line: 8 },
-    ]);
-  });
-
-  it("flags wrapper option paths passed through inline object literal spreads", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/inline-spread-wrapper-options.ts", [
+        { kind: "legacy store filesystem write", line: 7 },
+        { kind: "legacy store filesystem write", line: 8 },
+      ]),
+      "flags wrapper option paths passed through inline object literal spreads": sourceCase`
         import { writeJson } from "../infra/json-files.js";
         function persist(options: { store: string }) {
           return writeJson(options.store, {});
@@ -8232,67 +5341,37 @@ describe("check-database-first-legacy-stores", () => {
         await persist({ ...{ store: "sessions.json" } });
         const params = { ...{ store: "sessions.json" } };
         await persist(params);
-      `,
-      "src/runtime/inline-object-literal-spread-wrapper-options.ts",
-    );
-
-    expect(violations).toEqual([
-      { kind: "legacy store filesystem write", line: 6 },
-      { kind: "legacy store filesystem write", line: 8 },
-    ]);
-  });
-
-  it("allows inline object spreads when a later property overrides the legacy path", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/inline-object-literal-spread-wrapper-options.ts", [
+        { kind: "legacy store filesystem write", line: 6 },
+        { kind: "legacy store filesystem write", line: 8 },
+      ]),
+      "allows inline object spreads when a later property overrides the legacy path": sourceCase`
         import { writeJson } from "../infra/json-files.js";
         function persist(options: { store: string }) {
           return writeJson(options.store, {});
         }
         const params = { store: "sessions.json" };
         await persist({ ...params, store: currentSqlitePath });
-      `,
-      "src/runtime/inline-spread-wrapper-options.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("allows inline object literal spreads when a later property overrides the legacy path", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/inline-spread-wrapper-options.ts", []),
+      "allows inline object literal spreads when a later property overrides the legacy path":
+        sourceCase`
         import { writeJson } from "../infra/json-files.js";
         function persist(options: { store: string }) {
           return writeJson(options.store, {});
         }
         await persist({ ...{ store: "sessions.json" }, store: currentSqlitePath });
         await persist({ store: "sessions.json", ...{ store: currentSqlitePath } });
-      `,
-      "src/runtime/inline-object-literal-spread-current-wrapper-options.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("allows inline object spreads when a later spread overrides the legacy path", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/inline-object-literal-spread-current-wrapper-options.ts", []),
+      "allows inline object spreads when a later spread overrides the legacy path": sourceCase`
         import { writeJson } from "../infra/json-files.js";
         function persist(options: { store: string }) {
           return writeJson(options.store, {});
         }
         const currentOptions = { store: currentSqlitePath };
         await persist({ store: "sessions.json", ...currentOptions });
-      `,
-      "src/runtime/inline-current-spread-wrapper-options.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("allows nested inline object spreads when a later spread overrides the legacy path", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/inline-current-spread-wrapper-options.ts", []),
+      "allows nested inline object spreads when a later spread overrides the legacy path":
+        sourceCase`
         import { writeJson } from "../infra/json-files.js";
         function persist({ paths: { filePath } }: { paths: { filePath: string } }) {
           return writeJson(filePath, {});
@@ -8301,16 +5380,8 @@ describe("check-database-first-legacy-stores", () => {
           paths: { filePath: "sessions.json" },
           ...{ paths: { filePath: currentSqlitePath } },
         });
-      `,
-      "src/runtime/nested-inline-current-spread-wrapper-options.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("does not copy wrapper option metadata from shadowed source objects", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-inline-current-spread-wrapper-options.ts", []),
+      "does not copy wrapper option metadata from shadowed source objects": sourceCase`
         import { writeJson } from "../infra/json-files.js";
         function persist(options: { store: string }) {
           return writeJson(options.store, {});
@@ -8321,31 +5392,15 @@ describe("check-database-first-legacy-stores", () => {
           const forwarded = params;
           await persist(forwarded);
         }
-      `,
-      "src/runtime/shadowed-forwarded-wrapper-options.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("does not treat shadowed fs alias names as wrapper filesystem writes", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/shadowed-forwarded-wrapper-options.ts", []),
+      "does not treat shadowed fs alias names as wrapper filesystem writes": sourceCase`
         import { writeFile } from "node:fs/promises";
         function persist(writeFile: (path: string, value: string) => void, params: { filePath: string }) {
           return writeFile(params.filePath, "{}\\n");
         }
         await persist(customSink, { filePath: "sessions.json" });
-      `,
-      "src/runtime/shadowed-fs-alias-wrapper.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("does not treat block-shadowed fs alias names as wrapper filesystem writes", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/shadowed-fs-alias-wrapper.ts", []),
+      "does not treat block-shadowed fs alias names as wrapper filesystem writes": sourceCase`
         import { writeFile } from "node:fs/promises";
         {
           const writeFile = customSink;
@@ -8354,16 +5409,9 @@ describe("check-database-first-legacy-stores", () => {
           }
           persist({ filePath: "sessions.json" });
         }
-      `,
-      "src/runtime/block-shadowed-fs-alias-wrapper.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("does not treat destructures from shadowed fs module names as wrapper filesystem writes", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/block-shadowed-fs-alias-wrapper.ts", []),
+      "does not treat destructures from shadowed fs module names as wrapper filesystem writes":
+        sourceCase`
         import fs from "node:fs/promises";
         function persist(params: { filePath: string }) {
           const fs = customFs;
@@ -8371,16 +5419,8 @@ describe("check-database-first-legacy-stores", () => {
           return writeFile(params.filePath, "{}\\n");
         }
         persist({ filePath: "sessions.json" });
-      `,
-      "src/runtime/shadowed-fs-module-wrapper.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("does not treat shadowed wrapper parameter objects as argument paths", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/shadowed-fs-module-wrapper.ts", []),
+      "does not treat shadowed wrapper parameter objects as argument paths": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         function persist(params: { filePath: string }) {
           {
@@ -8389,32 +5429,16 @@ describe("check-database-first-legacy-stores", () => {
           }
         }
         await persist({ filePath: "sessions.json" });
-      `,
-      "src/runtime/shadowed-wrapper-parameter-object.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("does not keep object metadata for uninitialized local shadows", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/shadowed-wrapper-parameter-object.ts", []),
+      "does not keep object metadata for uninitialized local shadows": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         const params = { filePath: "sessions.json" };
         {
           let params;
           writeTextAtomic(params.filePath, "{}\\n");
         }
-      `,
-      "src/runtime/uninitialized-object-shadow.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("keeps catch binding shadows scoped to the catch block", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/uninitialized-object-shadow.ts", []),
+      "keeps catch binding shadows scoped to the catch block": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         const params = { filePath: "sessions.json" };
         try {
@@ -8423,16 +5447,8 @@ describe("check-database-first-legacy-stores", () => {
           writeTextAtomic(params.filePath, "{}\\n");
         }
         writeTextAtomic(params.filePath, "{}\\n");
-      `,
-      "src/runtime/catch-object-shadow.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 9 }]);
-  });
-
-  it("keeps closed-over catch binding shadows scoped to the catch block", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/catch-object-shadow.ts", [{ kind: "legacy store filesystem write", line: 9 }]),
+      "keeps closed-over catch binding shadows scoped to the catch block": sourceCase`
         import fs from "node:fs/promises";
         function persist(filePath: string) {
           function inner() {
@@ -8446,16 +5462,10 @@ describe("check-database-first-legacy-stores", () => {
           return inner();
         }
         await persist("sessions.json");
-      `,
-      "src/runtime/nested-wrapper-catch-shadow.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 14 }]);
-  });
-
-  it("keeps wrapper catch binding shadows scoped to the catch block", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/nested-wrapper-catch-shadow.ts", [
+        { kind: "legacy store filesystem write", line: 14 },
+      ]),
+      "keeps wrapper catch binding shadows scoped to the catch block": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         function persist(params: { filePath: string }) {
           try {
@@ -8466,32 +5476,18 @@ describe("check-database-first-legacy-stores", () => {
           writeTextAtomic(params.filePath, "{}\\n");
         }
         persist({ filePath: "sessions.json" });
-      `,
-      "src/runtime/wrapper-catch-object-shadow.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 11 }]);
-  });
-
-  it("does not keep object metadata for destructured local shadows", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/wrapper-catch-object-shadow.ts", [
+        { kind: "legacy store filesystem write", line: 11 },
+      ]),
+      "does not keep object metadata for destructured local shadows": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         const params = { filePath: "sessions.json" };
         {
           const { params } = source;
           writeTextAtomic(params.filePath, "{}\\n");
         }
-      `,
-      "src/runtime/destructured-object-shadow.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("does not let unrelated nested fs aliases mark custom writes", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/destructured-object-shadow.ts", []),
+      "does not let unrelated nested fs aliases mark custom writes": sourceCase`
         import fs from "node:fs/promises";
         import { writeFile } from "./custom-writer.js";
         await writeFile("sessions.json", "{}\\n");
@@ -8499,16 +5495,8 @@ describe("check-database-first-legacy-stores", () => {
           const { writeFile } = fs;
           return writeFile(currentSqlitePath, "{}\\n");
         }
-      `,
-      "src/runtime/custom-writer-shadow.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("does not use caller block fs aliases for outer wrapper bodies", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/custom-writer-shadow.ts", []),
+      "does not use caller block fs aliases for outer wrapper bodies": sourceCase`
         import fs from "node:fs/promises";
         import { writeFile } from "./custom-writer.js";
         function persist(params: { filePath: string }) {
@@ -8518,16 +5506,8 @@ describe("check-database-first-legacy-stores", () => {
           const { writeFile } = fs;
           await persist({ filePath: "sessions.json" });
         }
-      `,
-      "src/runtime/caller-block-alias-wrapper.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("does not leak block-scoped fs aliases across wrapper body scopes", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/caller-block-alias-wrapper.ts", []),
+      "does not leak block-scoped fs aliases across wrapper body scopes": sourceCase`
         import fs from "node:fs/promises";
         function persist(params: { filePath: string }) {
           {
@@ -8537,16 +5517,8 @@ describe("check-database-first-legacy-stores", () => {
           return writeFile(params.filePath, "{}\\n");
         }
         await persist({ filePath: "sessions.json" });
-      `,
-      "src/runtime/block-scoped-fs-alias-wrapper.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("ignores shadowed destructured wrapper option names", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/block-scoped-fs-alias-wrapper.ts", []),
+      "ignores shadowed destructured wrapper option names": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         function persist({ filePath }: { filePath: string }) {
           {
@@ -8555,16 +5527,8 @@ describe("check-database-first-legacy-stores", () => {
           }
         }
         await persist({ filePath: "sessions.json" });
-      `,
-      "src/runtime/shadowed-destructured-wrapper-options.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("keeps earlier destructured wrapper option uses before later shadowing", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/shadowed-destructured-wrapper-options.ts", []),
+      "keeps earlier destructured wrapper option uses before later shadowing": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         function persist({ filePath }: { filePath: string }) {
           writeTextAtomic(filePath, "{}\\n");
@@ -8573,16 +5537,10 @@ describe("check-database-first-legacy-stores", () => {
           }
         }
         await persist({ filePath: "sessions.json" });
-      `,
-      "src/runtime/late-shadowed-destructured-wrapper-options.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 9 }]);
-  });
-
-  it("does not leak legacy path variable names across lexical scopes", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/late-shadowed-destructured-wrapper-options.ts", [
+        { kind: "legacy store filesystem write", line: 9 },
+      ]),
+      "does not leak legacy path variable names across lexical scopes": sourceCase`
         import { promises as fs } from "node:fs";
         {
           const storePath = "sessions.json";
@@ -8590,84 +5548,57 @@ describe("check-database-first-legacy-stores", () => {
         export async function save(storePath: string) {
           await fs.writeFile(storePath, "{}\\n", "utf8");
         }
-      `,
-      "src/runtime/current-store-writer.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("lets inner bindings shadow outer legacy path variables", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/current-store-writer.ts", []),
+      "lets inner bindings shadow outer legacy path variables": sourceCase`
         import { promises as fs } from "node:fs";
         const storePath = "sessions.json";
         {
           const storePath = currentSqlitePath;
           await fs.writeFile(storePath, "{}\\n", "utf8");
         }
-      `,
-      "src/runtime/current-store-writer.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("lets inner object properties shadow outer legacy path properties", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/current-store-writer.ts", []),
+      "lets inner object properties shadow outer legacy path properties": sourceCase`
         import { writeTextAtomic } from "../infra/json-files.js";
         const params = { filePath: "sessions.json" };
         {
           const params = { filePath: currentSqlitePath };
           await writeTextAtomic(params.filePath, "{}\\n");
         }
-      `,
-      "src/runtime/current-store-writer.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("ignores legacy filenames in write payloads", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/runtime/current-store-writer.ts", []),
+      "ignores legacy filenames in write payloads": sourceCase`
         import { promises as fs } from "node:fs";
         await fs.writeFile(reportPath, "sessions.json\\n", "utf8");
         await fs.appendFile(currentLogPath, "cron/runs/job.jsonl\\n", "utf8");
-      `,
-      "src/runtime/report-writer.ts",
-    );
+      `("src/runtime/report-writer.ts", []),
+    }),
+  )("$name", ({ source, filename, expected }) => {
+    const violations = collectDatabaseFirstLegacyStoreViolations(source, filename);
 
-    expect(violations).toEqual([]);
+    expect(violations).toEqual(expected);
   });
 
-  it("flags runtime writes to sidecar SQLite and JSONL stores", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+  // Current-debt and migration-owner policy.
+  it.each(
+    namedCases({
+      "flags runtime writes to sidecar SQLite and JSONL stores": sourceCase`
         import fs from "node:fs";
         fs.appendFileSync("cron/runs/job.jsonl", "{}\\n");
         fs.writeFileSync("plugin-state/state.sqlite", "");
-      `,
-      "extensions/example/src/store.ts",
-    );
-
-    expect(violations).toEqual([
-      { kind: "legacy store filesystem write", line: 3 },
-      { kind: "legacy store filesystem write", line: 4 },
-    ]);
-  });
-
-  it("flags new writes in current legacy-debt files", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("extensions/example/src/store.ts", [
+        { kind: "legacy store filesystem write", line: 3 },
+        { kind: "legacy store filesystem write", line: 4 },
+      ]),
+      "flags new writes in current legacy-debt files": sourceCase`
         import fs from "node:fs";
         fs.writeFileSync("sessions.json", "{}\\n");
-      `,
-      "extensions/memory-wiki/src/compile.ts",
-    );
+      `("extensions/memory-wiki/src/compile.ts", [
+        { kind: "legacy store filesystem write", line: 3 },
+      ]),
+    }),
+  )("$name", ({ source, filename, expected }) => {
+    const violations = collectDatabaseFirstLegacyStoreViolations(source, filename);
 
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 3 }]);
+    expect(violations).toEqual(expected);
   });
 
   it("flags changed writes on current legacy-debt lines", () => {
@@ -8695,44 +5626,30 @@ describe("check-database-first-legacy-stores", () => {
     expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 3 }]);
   });
 
-  it("allows doctor and migration owners to import or archive legacy files", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+  // Migration-owner allowlists and runtime exclusions.
+  it.each(
+    namedCases({
+      "allows doctor and migration owners to import or archive legacy files": sourceCase`
         import { promises as fs } from "node:fs";
         await fs.rename("cron/jobs.json", "cron/jobs.json.migrated");
         await fs.writeFile("sessions.json", "{}\\n", "utf8");
-      `,
-      "src/commands/doctor/cron/legacy-store-migration.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("blocks runtime writes to the retired device identity file", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/commands/doctor/cron/legacy-store-migration.ts", []),
+      "blocks runtime writes to the retired device identity file": sourceCase`
         import fs from "node:fs";
         fs.writeFileSync(path.join(stateDir, "identity/device.json"), "{}\\n");
-      `,
-      "src/infra/device-identity.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 3 }]);
-  });
-
-  it("allows only the device identity migration owner to retire its legacy source", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/infra/device-identity.ts", [{ kind: "legacy store filesystem write", line: 3 }]),
+      "allows only the device identity migration owner to retire its legacy source": sourceCase`
         import fs from "node:fs";
         fs.renameSync(
           path.join(stateDir, "identity/device.json"),
           path.join(stateDir, "identity/device.json.doctor-importing"),
         );
-      `,
-      "src/infra/state-migrations.device-identity.ts",
-    );
+      `("src/infra/state-migrations.device-identity.ts", []),
+    }),
+  )("$name", ({ source, filename, expected }) => {
+    const violations = collectDatabaseFirstLegacyStoreViolations(source, filename);
 
-    expect(violations).toEqual([]);
+    expect(violations).toEqual(expected);
   });
 
   it("keeps legacy PortGuardian filenames inside the native migration owner", () => {
@@ -8749,69 +5666,41 @@ describe("check-database-first-legacy-stores", () => {
     expect(migrationViolations).toEqual([]);
   });
 
-  it("allows the workspace Doctor migration owner to claim legacy sidecars", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+  // Doctor, plugin, QA, and transcript owner boundaries.
+  it.each(
+    namedCases({
+      "allows the workspace Doctor migration owner to claim legacy sidecars": sourceCase`
         import { promises as fs } from "node:fs";
         await fs.rename("openclaw-workspace-state.json", "openclaw-workspace-state.json.doctor-importing");
         await fs.rename("workspace.attested", "workspace.attested.doctor-importing");
-      `,
-      "src/infra/state-migrations.workspace-setup.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("allows plugin doctor migration owners to archive legacy files", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("src/infra/state-migrations.workspace-setup.ts", []),
+      "allows plugin doctor migration owners to archive legacy files": sourceCase`
         import { promises as fs } from "node:fs";
         const statePath = "plugin-state/state.sqlite";
         await fs.rename(statePath, "plugin-state/state.sqlite.migrated");
-      `,
-      "extensions/example/doctor-contract-api.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("flags extension runtime writes under migration-like directories", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("extensions/example/doctor-contract-api.ts", []),
+      "flags extension runtime writes under migration-like directories": sourceCase`
         import { promises as fs } from "node:fs";
         await fs.writeFile("sessions.json", "{}\\n", "utf8");
-      `,
-      "extensions/example/src/migrations/runtime.ts",
-    );
-
-    expect(violations).toEqual([{ kind: "legacy store filesystem write", line: 3 }]);
-  });
-
-  it("allows exact QA fixture owners to materialize legacy files", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("extensions/example/src/migrations/runtime.ts", [
+        { kind: "legacy store filesystem write", line: 3 },
+      ]),
+      "allows exact QA fixture owners to materialize legacy files": sourceCase`
         import { promises as fs } from "node:fs";
         const authStorePath = "auth-profiles.json";
         await fs.writeFile(authStorePath, "{}\\n", "utf8");
-      `,
-      "extensions/qa-lab/src/providers/shared/auth-store.ts",
-    );
-
-    expect(violations).toEqual([]);
-  });
-
-  it("flags legacy transcript bridge markers in runtime source", () => {
-    const violations = collectDatabaseFirstLegacyStoreViolations(
-      `
+      `("extensions/qa-lab/src/providers/shared/auth-store.ts", []),
+      "flags legacy transcript bridge markers in runtime source": sourceCase`
         export const transcriptLocator = "sqlite-transcript://session";
         export const dynamicLocator = \`sqlite-transcript://\${sessionId}\`;
-      `,
-      "src/runtime/transcript-bridge.ts",
-    );
+      `("src/runtime/transcript-bridge.ts", [
+        { kind: "legacy transcript bridge marker", line: 2 },
+        { kind: "legacy transcript bridge marker", line: 3 },
+      ]),
+    }),
+  )("$name", ({ source, filename, expected }) => {
+    const violations = collectDatabaseFirstLegacyStoreViolations(source, filename);
 
-    expect(violations).toEqual([
-      { kind: "legacy transcript bridge marker", line: 2 },
-      { kind: "legacy transcript bridge marker", line: 3 },
-    ]);
+    expect(violations).toEqual(expected);
   });
 });


### PR DESCRIPTION
## What Problem This Solves

The database-first legacy-store guard test had grown to 8,817 lines across 490 individually wrapped cases, making the guard expensive to review and maintain even though 483 cases shared the same collect-and-compare structure.

## Why This Change Was Made

This refactors the repeated cases into named `it.each` tables grouped by rule family. Small local helpers preserve each row as `{ name, source, filename, expected }` while keeping the source fixtures readable; the two filesystem-heavy tests and five genuinely different cases remain plain tests. The production guard is unchanged.

## User Impact

No user-visible behavior changes. Maintainers keep the same 490-case coverage with a 35.3% smaller test file and precise per-case failure names.

AI-assisted implementation; the resulting helper and every transformed fixture were reviewed and mechanically compared against the original cases.

## Evidence

- LOC: test `+1862/-4973`, net `-3111`; production `+0/-0`. File size: 8,817 -> 5,706 lines (35.3% reduction).
- Test count: 490 before, 490 after.
- `node scripts/run-vitest.mjs test/scripts/check-database-first-legacy-stores.test.ts` — 1 file passed, 490 tests passed.
- `node scripts/check-changed.mjs -- test/scripts/check-database-first-legacy-stores.test.ts` — delegated Blacksmith Testbox gate passed (`exitCode: 0`), including test-root typecheck, formatting, guards, and scripts lint.
- `git diff --check` — passed.
- `oxfmt --check test/scripts/check-database-first-legacy-stores.test.ts` — passed.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output` — clean; no accepted/actionable findings.
- Mechanical equivalence audit: 483 table cases plus 7 plain tests; zero name, source-template, filename, or expected-array mismatches against the original file.
- Final-head CI: https://github.com/openclaw/openclaw/actions/runs/29958231111 — passed on `c84c4acf5a7bd62369100be332e5be1d216a6886` after the fresh-main rebase.

### Focused test transcript

```text
$ git rev-parse HEAD
c84c4acf5a7bd62369100be332e5be1d216a6886
$ node scripts/run-vitest.mjs test/scripts/check-database-first-legacy-stores.test.ts
[test] starting test/vitest/vitest.tooling.config.ts
Test Files  1 passed (1)
Tests       490 passed (490)
[test] passed 1 Vitest shard in 3.68s
```
