### PR TITLE
test: table-drive sibling policy guards

### DIFF
--- a/test/scripts/changed-lanes.test.ts
+++ b/test/scripts/changed-lanes.test.ts
@@ -74,6 +74,20 @@ const git = (cwd: string, args: string[]) =>
     env: createNestedGitEnv(),
   }).trim();
 
+function commitAll(cwd: string, message: string): void {
+  git(cwd, ["add", "."]);
+  git(cwd, [
+    "-c",
+    "user.email=test@example.com",
+    "-c",
+    "user.name=Test User",
+    "commit",
+    "-q",
+    "-m",
+    message,
+  ]);
+}
+
 function expectLanes(
   lanes: ReturnType<typeof createEmptyChangedLanes>,
   expected: Partial<ReturnType<typeof createEmptyChangedLanes>>,
@@ -91,11 +105,31 @@ function parseChangedLaneOutput(output: string): {
   };
 }
 
+function runChangedLanesCli(cwd: string, args: string[]) {
+  return parseChangedLaneOutput(
+    execFileSync(process.execPath, [path.join(repoRoot, "scripts", "changed-lanes.mjs"), ...args], {
+      cwd,
+      encoding: "utf8",
+      env: createNestedGitEnv(),
+    }),
+  );
+}
+
+function runRepoScript(script: string, args: string[], env = createNestedGitEnv()) {
+  return spawnSync(process.execPath, [script, ...args], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env,
+  });
+}
+
 function writeRepoFile(repoDir: string, filePath: string, contents: string): void {
   const absolutePath = path.join(repoDir, filePath);
   mkdirSync(path.dirname(absolutePath), { recursive: true });
   writeFileSync(absolutePath, contents, "utf8");
 }
+
+const prettyJson = (value: unknown) => `${JSON.stringify(value, null, 2)}\n`;
 
 // Executes the exact "format changed files" plan command with the repo-pinned oxfmt,
 // reconstructing `pnpm format:check <plan args>`. Guards the runtime verdict, not just
@@ -130,46 +164,16 @@ function createSyntheticMergeRepo(prefix: string): { dir: string; staleBase: str
   const dir = makeTempRepoRoot(tempDirs, prefix);
   git(dir, ["init", "-q", "--initial-branch=main"]);
   writeRepoFile(dir, "README.md", "base\n");
-  git(dir, ["add", "."]);
-  git(dir, [
-    "-c",
-    "user.email=test@example.com",
-    "-c",
-    "user.name=Test User",
-    "commit",
-    "-q",
-    "-m",
-    "base",
-  ]);
+  commitAll(dir, "base");
   const staleBase = git(dir, ["rev-parse", "HEAD"]);
 
   git(dir, ["switch", "-q", "-c", "feature"]);
   writeRepoFile(dir, "src/pr.ts", "export const pr = true;\n");
-  git(dir, ["add", "."]);
-  git(dir, [
-    "-c",
-    "user.email=test@example.com",
-    "-c",
-    "user.name=Test User",
-    "commit",
-    "-q",
-    "-m",
-    "feature",
-  ]);
+  commitAll(dir, "feature");
 
   git(dir, ["switch", "-q", "main"]);
   writeRepoFile(dir, "src/main-only.ts", "export const mainOnly = true;\n");
-  git(dir, ["add", "."]);
-  git(dir, [
-    "-c",
-    "user.email=test@example.com",
-    "-c",
-    "user.name=Test User",
-    "commit",
-    "-q",
-    "-m",
-    "main only",
-  ]);
+  commitAll(dir, "main only");
   git(dir, [
     "-c",
     "user.email=test@example.com",
@@ -183,6 +187,25 @@ function createSyntheticMergeRepo(prefix: string): { dir: string; staleBase: str
   ]);
 
   return { dir, staleBase };
+}
+
+function classifyPackageJsonChange(
+  prefix: string,
+  before: Record<string, unknown>,
+  after: Record<string, unknown>,
+) {
+  const dir = makeTempRepoRoot(tempDirs, prefix);
+  git(dir, ["init", "-q", "--initial-branch=main"]);
+  writeRepoFile(dir, "package.json", prettyJson(before));
+  commitAll(dir, "initial");
+  writeRepoFile(dir, "package.json", prettyJson(after));
+
+  const output = execFileSync(
+    process.execPath,
+    [path.join(repoRoot, "scripts", "changed-lanes.mjs"), "--json", "--base", "HEAD"],
+    { cwd: dir, encoding: "utf8", env: createNestedGitEnv() },
+  );
+  return parseChangedLaneOutput(output);
 }
 
 afterEach(() => {
@@ -215,37 +238,36 @@ describe("scripts/changed-lanes", () => {
     ).toBe(false);
   });
 
-  it("prints changed lane help without treating --help as a changed path", () => {
-    const result = spawnSync(process.execPath, ["scripts/changed-lanes.mjs", "--help"], {
-      cwd: repoRoot,
-      encoding: "utf8",
-      env: createNestedGitEnv(),
+  it.each([
+    {
+      name: "prints changed lane help without treating --help as a changed path",
+      script: "scripts/changed-lanes.mjs",
+      expected: {
+        contains: "Usage: node scripts/changed-lanes.mjs",
+        excludes: "--help: unknown surface",
+      },
+    },
+    {
+      name: "prints changed check help without running the changed gate",
+      script: "scripts/check-changed.mjs",
+      expected: { contains: "Usage: node scripts/check-changed.mjs", excludes: "[check:changed]" },
+    },
+  ])("$name", ({ script, expected }) => {
+    const result = runRepoScript(script, ["--help"], {
+      ...createNestedGitEnv(),
+      OPENCLAW_TESTBOX: "1",
     });
 
     expect(result.status).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).toContain("Usage: node scripts/changed-lanes.mjs");
-    expect(result.stdout).not.toContain("--help: unknown surface");
-  });
-
-  it("prints changed check help without running the changed gate", () => {
-    const result = spawnSync(process.execPath, ["scripts/check-changed.mjs", "--help"], {
-      cwd: repoRoot,
-      encoding: "utf8",
-      env: { ...createNestedGitEnv(), OPENCLAW_TESTBOX: "1" },
-    });
-
-    expect(result.status).toBe(0);
-    expect(result.stderr).toBe("");
-    expect(result.stdout).toContain("Usage: node scripts/check-changed.mjs");
-    expect(result.stdout).not.toContain("[check:changed]");
+    expect(result.stdout).toContain(expected.contains);
+    expect(result.stdout).not.toContain(expected.excludes);
   });
 
   it("exits cleanly for no changes without local dependencies", () => {
-    const result = spawnSync(process.execPath, ["scripts/check-changed.mjs", "--no-changes"], {
-      cwd: repoRoot,
-      encoding: "utf8",
-      env: { ...createNestedGitEnv(), PATH: "/nonexistent" },
+    const result = runRepoScript("scripts/check-changed.mjs", ["--no-changes"], {
+      ...createNestedGitEnv(),
+      PATH: "/nonexistent",
     });
 
     expect(result.status).toBe(0);
@@ -257,17 +279,7 @@ describe("scripts/changed-lanes", () => {
     const dir = makeTempRepoRoot(tempDirs, "openclaw-check-changed-missing-base-");
     git(dir, ["init", "-q", "--initial-branch=main"]);
     writeFileSync(path.join(dir, "README.md"), "initial\n", "utf8");
-    git(dir, ["add", "README.md"]);
-    git(dir, [
-      "-c",
-      "user.email=test@example.com",
-      "-c",
-      "user.name=Test User",
-      "commit",
-      "-q",
-      "-m",
-      "initial",
-    ]);
+    commitAll(dir, "initial");
     const binDir = path.join(dir, "bin");
     mkdirSync(binDir, { recursive: true });
     writeFileSync(path.join(binDir, "pnpm"), "#!/bin/sh\nexit 0\n", { mode: 0o755 });
@@ -294,17 +306,7 @@ describe("scripts/changed-lanes", () => {
     const dir = makeTempRepoRoot(tempDirs, "openclaw-check-changed-metadata-missing-base-");
     git(dir, ["init", "-q", "--initial-branch=main"]);
     writeFileSync(path.join(dir, "README.md"), "initial\n", "utf8");
-    git(dir, ["add", "README.md"]);
-    git(dir, [
-      "-c",
-      "user.email=test@example.com",
-      "-c",
-      "user.name=Test User",
-      "commit",
-      "-q",
-      "-m",
-      "initial",
-    ]);
+    commitAll(dir, "initial");
     writeRepoFile(dir, "node_modules/.modules.yaml", "layoutVersion: 5\n");
     writeRepoFile(dir, "node_modules/.bin/oxfmt", "#!/bin/sh\n");
     writeRepoFile(dir, "node_modules/typescript/package.json", '{"name":"typescript"}\n');
@@ -333,43 +335,36 @@ describe("scripts/changed-lanes", () => {
     expect(result.stderr).toContain("delegating to Blacksmith Testbox");
   });
 
-  it("rejects unknown changed lane options before treating them as paths", () => {
-    const result = spawnSync(process.execPath, ["scripts/changed-lanes.mjs", "--jsno"], {
-      cwd: repoRoot,
-      encoding: "utf8",
-      env: createNestedGitEnv(),
+  it.each([
+    {
+      name: "rejects unknown changed lane options before treating them as paths",
+      script: "scripts/changed-lanes.mjs",
+      option: "--jsno",
+      expected: { stderr: "Unknown option: --jsno", excludes: [] },
+    },
+    {
+      name: "rejects unknown changed check options before treating them as paths",
+      script: "scripts/check-changed.mjs",
+      option: "--dr-run",
+      expected: { stderr: "Unknown option: --dr-run", excludes: ["[check:changed]"] },
+    },
+  ])("$name", ({ script, option, expected }) => {
+    const result = runRepoScript(script, [option], {
+      ...createNestedGitEnv(),
+      OPENCLAW_TESTBOX: "1",
     });
 
     expect(result.status).toBe(1);
     expect(result.stdout).toBe("");
-    expect(result.stderr.trim()).toBe("Unknown option: --jsno");
+    expect(result.stderr.trim()).toBe(expected.stderr);
     expect(result.stderr).not.toContain("\n    at ");
-  });
-
-  it("rejects unknown changed check options before treating them as paths", () => {
-    const result = spawnSync(process.execPath, ["scripts/check-changed.mjs", "--dr-run"], {
-      cwd: repoRoot,
-      encoding: "utf8",
-      env: { ...createNestedGitEnv(), OPENCLAW_TESTBOX: "1" },
-    });
-
-    expect(result.status).toBe(1);
-    expect(result.stdout).toBe("");
-    expect(result.stderr.trim()).toBe("Unknown option: --dr-run");
-    expect(result.stderr).not.toContain("\n    at ");
-    expect(result.stderr).not.toContain("[check:changed]");
+    for (const excluded of expected.excludes) {
+      expect(result.stderr).not.toContain(excluded);
+    }
   });
 
   it("still accepts dash-prefixed explicit changed paths after the separator", () => {
-    const result = spawnSync(
-      process.execPath,
-      ["scripts/changed-lanes.mjs", "--json", "--", "--github-output"],
-      {
-        cwd: repoRoot,
-        encoding: "utf8",
-        env: createNestedGitEnv(),
-      },
-    );
+    const result = runRepoScript("scripts/changed-lanes.mjs", ["--json", "--", "--github-output"]);
 
     expect(result.status).toBe(0);
     expect(result.stderr).toBe("");
@@ -389,15 +384,11 @@ describe("scripts/changed-lanes", () => {
   });
 
   it("prints changed check dry-run commands", () => {
-    const result = spawnSync(
-      process.execPath,
-      ["scripts/check-changed.mjs", "--dry-run", "--", "extensions/lmstudio/src/api.ts"],
-      {
-        cwd: repoRoot,
-        encoding: "utf8",
-        env: createNestedGitEnv(),
-      },
-    );
+    const result = runRepoScript("scripts/check-changed.mjs", [
+      "--dry-run",
+      "--",
+      "extensions/lmstudio/src/api.ts",
+    ]);
 
     expect(result.status).toBe(0);
     expect(result.stderr).toContain("[check:changed:dry-run] lanes=extensions, extensionTests");
@@ -410,32 +401,12 @@ describe("scripts/changed-lanes", () => {
     const dir = makeTempRepoRoot(tempDirs, "openclaw-changed-lanes-");
     git(dir, ["init", "-q", "--initial-branch=main"]);
     writeFileSync(path.join(dir, "README.md"), "initial\n", "utf8");
-    git(dir, ["add", "README.md"]);
-    git(dir, [
-      "-c",
-      "user.email=test@example.com",
-      "-c",
-      "user.name=Test User",
-      "commit",
-      "-q",
-      "-m",
-      "initial",
-    ]);
+    commitAll(dir, "initial");
 
     mkdirSync(path.join(dir, "scripts"), { recursive: true });
     writeFileSync(path.join(dir, "scripts", "new-check.mjs"), "export {};\n", "utf8");
 
-    const output = execFileSync(
-      process.execPath,
-      [path.join(repoRoot, "scripts", "changed-lanes.mjs"), "--json", "--base", "HEAD"],
-      {
-        cwd: dir,
-        encoding: "utf8",
-        env: createNestedGitEnv(),
-      },
-    );
-
-    const result = parseChangedLaneOutput(output);
+    const result = runChangedLanesCli(dir, ["--json", "--base", "HEAD"]);
 
     expect(result.paths).toEqual(["scripts/new-check.mjs"]);
     expectLanes(result.lanes, { tooling: true });
@@ -445,33 +416,13 @@ describe("scripts/changed-lanes", () => {
     const dir = makeTempRepoRoot(tempDirs, "openclaw-changed-lanes-no-merge-base-");
     git(dir, ["init", "-q", "--initial-branch=main"]);
     writeFileSync(path.join(dir, "README.md"), "initial\n", "utf8");
-    git(dir, ["add", "README.md"]);
-    git(dir, [
-      "-c",
-      "user.email=test@example.com",
-      "-c",
-      "user.name=Test User",
-      "commit",
-      "-q",
-      "-m",
-      "initial",
-    ]);
+    commitAll(dir, "initial");
     git(dir, ["update-ref", "refs/remotes/origin/main", "HEAD"]);
     git(dir, ["switch", "-q", "--orphan", "feature"]);
     writeFileSync(path.join(dir, "README.md"), "initial\n", "utf8");
     mkdirSync(path.join(dir, "src"), { recursive: true });
     writeFileSync(path.join(dir, "src", "committed.ts"), "export const committed = 1;\n", "utf8");
-    git(dir, ["add", "README.md", "src/committed.ts"]);
-    git(dir, [
-      "-c",
-      "user.email=test@example.com",
-      "-c",
-      "user.name=Test User",
-      "commit",
-      "-q",
-      "-m",
-      "feature base",
-    ]);
+    commitAll(dir, "feature base");
     writeFileSync(path.join(dir, "src", "feature.ts"), "export const value = 1;\n", "utf8");
 
     expect(
@@ -489,17 +440,7 @@ describe("scripts/changed-lanes", () => {
     for (let index = 0; index < 250; index += 1) {
       writeFileSync(path.join(dir, `baseline-${index}.txt`), "baseline\n", "utf8");
     }
-    git(dir, ["add", "."]);
-    git(dir, [
-      "-c",
-      "user.email=test@example.com",
-      "-c",
-      "user.name=Test User",
-      "commit",
-      "-q",
-      "-m",
-      "initial",
-    ]);
+    commitAll(dir, "initial");
     git(dir, ["update-ref", "refs/remotes/origin/main", "HEAD"]);
     git(dir, ["switch", "-q", "--orphan", "feature"]);
     git(dir, [
@@ -541,31 +482,11 @@ describe("scripts/changed-lanes", () => {
     const dir = makeTempRepoRoot(tempDirs, "openclaw-changed-lanes-added-format-");
     git(dir, ["init", "-q", "--initial-branch=main"]);
     writeRepoFile(dir, "README.md", "initial\n");
-    git(dir, ["add", "."]);
-    git(dir, [
-      "-c",
-      "user.email=test@example.com",
-      "-c",
-      "user.name=Test User",
-      "commit",
-      "-q",
-      "-m",
-      "initial",
-    ]);
+    commitAll(dir, "initial");
     git(dir, ["update-ref", "refs/remotes/origin/main", "HEAD"]);
     git(dir, ["switch", "-q", "-c", "feature"]);
     writeRepoFile(dir, "src/committed.test.ts", "export const committed={value:1};\n");
-    git(dir, ["add", "src/committed.test.ts"]);
-    git(dir, [
-      "-c",
-      "user.email=test@example.com",
-      "-c",
-      "user.name=Test User",
-      "commit",
-      "-q",
-      "-m",
-      "add test",
-    ]);
+    commitAll(dir, "add test");
     writeRepoFile(dir, "src/untracked.test.ts", "export const untracked={value:1};\n");
     writeRepoFile(dir, "--help", "ignored\n");
 
@@ -591,17 +512,7 @@ describe("scripts/changed-lanes", () => {
     git(dir, ["init", "-q", "--initial-branch=main"]);
     writeRepoFile(dir, "src/modified.ts", "export const modified = { value: 1 };\n");
     writeRepoFile(dir, "src/removed.ts", "export const removed = { value: 1 };\n");
-    git(dir, ["add", "."]);
-    git(dir, [
-      "-c",
-      "user.email=test@example.com",
-      "-c",
-      "user.name=Test User",
-      "commit",
-      "-q",
-      "-m",
-      "initial",
-    ]);
+    commitAll(dir, "initial");
     writeRepoFile(dir, "src/added.test.ts", "export const added={value:1};\n");
     writeRepoFile(dir, "src/modified.ts", "export const modified={value:2};\n");
     git(dir, ["add", "src/added.test.ts", "src/modified.ts"]);
@@ -676,33 +587,13 @@ describe("scripts/changed-lanes", () => {
     git(dir, ["init", "-q", "--initial-branch=main"]);
     writeFileSync(path.join(dir, ".gitignore"), ".crabbox/\n", "utf8");
     writeFileSync(path.join(dir, "README.md"), "initial\n", "utf8");
-    git(dir, ["add", ".gitignore", "README.md"]);
-    git(dir, [
-      "-c",
-      "user.email=test@example.com",
-      "-c",
-      "user.name=Test User",
-      "commit",
-      "-q",
-      "-m",
-      "initial",
-    ]);
+    commitAll(dir, "initial");
 
     mkdirSync(path.join(dir, ".crabbox"), { recursive: true });
     writeFileSync(path.join(dir, ".crabbox", "capture-files.txt"), "stdout.log\n", "utf8");
     writeFileSync(path.join(dir, ".crabbox", "capture-manifest.txt"), "stdout.log\t12\n", "utf8");
 
-    const output = execFileSync(
-      process.execPath,
-      [path.join(repoRoot, "scripts", "changed-lanes.mjs"), "--json", "--base", "HEAD"],
-      {
-        cwd: dir,
-        encoding: "utf8",
-        env: createNestedGitEnv(),
-      },
-    );
-
-    const result = parseChangedLaneOutput(output);
+    const result = runChangedLanesCli(dir, ["--json", "--base", "HEAD"]);
 
     expect(result.paths).toEqual([]);
     expectLanes(result.lanes, {});
@@ -717,31 +608,11 @@ describe("scripts/changed-lanes", () => {
       "export const value = 1;\n",
       "utf8",
     );
-    git(dir, ["add", "src/shared/obsolete.ts"]);
-    git(dir, [
-      "-c",
-      "user.email=test@example.com",
-      "-c",
-      "user.name=Test User",
-      "commit",
-      "-q",
-      "-m",
-      "initial",
-    ]);
+    commitAll(dir, "initial");
 
     unlinkSync(path.join(dir, "src", "shared", "obsolete.ts"));
 
-    const output = execFileSync(
-      process.execPath,
-      [path.join(repoRoot, "scripts", "changed-lanes.mjs"), "--json", "--base", "HEAD"],
-      {
-        cwd: dir,
-        encoding: "utf8",
-        env: createNestedGitEnv(),
-      },
-    );
-
-    const result = parseChangedLaneOutput(output);
+    const result = runChangedLanesCli(dir, ["--json", "--base", "HEAD"]);
 
     expect(result.paths).toEqual(["src/shared/obsolete.ts"]);
     expectLanes(result.lanes, { core: true, coreTests: true });
@@ -756,32 +627,12 @@ describe("scripts/changed-lanes", () => {
       "export const value = 1;\n",
       "utf8",
     );
-    git(dir, ["add", "src/shared/obsolete.ts"]);
-    git(dir, [
-      "-c",
-      "user.email=test@example.com",
-      "-c",
-      "user.name=Test User",
-      "commit",
-      "-q",
-      "-m",
-      "initial",
-    ]);
+    commitAll(dir, "initial");
 
     unlinkSync(path.join(dir, "src", "shared", "obsolete.ts"));
     git(dir, ["add", "src/shared/obsolete.ts"]);
 
-    const output = execFileSync(
-      process.execPath,
-      [path.join(repoRoot, "scripts", "changed-lanes.mjs"), "--json", "--staged"],
-      {
-        cwd: dir,
-        encoding: "utf8",
-        env: createNestedGitEnv(),
-      },
-    );
-
-    const result = parseChangedLaneOutput(output);
+    const result = runChangedLanesCli(dir, ["--json", "--staged"]);
 
     expect(result.paths).toEqual(["src/shared/obsolete.ts"]);
     expectLanes(result.lanes, { core: true, coreTests: true });
@@ -846,30 +697,33 @@ describe("scripts/changed-lanes", () => {
     });
   });
 
-  it("routes UI production changes to UI prod and core test lanes", () => {
-    const result = detectChangedLanes(["ui/src/app.ts"]);
-    const plan = createChangedCheckPlan(result, { env: { PATH: "/usr/bin" } });
+  it.each([
+    {
+      name: "routes UI production changes to UI prod and core test lanes",
+      path: "ui/src/app.ts",
+      expected: {
+        includes: ["tsgo:ui", "tsgo:core:test", "lint:ui:i18n"],
+        excludes: ["tsgo:core"],
+      },
+    },
+    {
+      name: "routes the UI production config to UI prod and core test lanes",
+      path: "tsconfig.ui.json",
+      expected: { includes: ["tsgo:ui", "tsgo:core:test"], excludes: [] },
+    },
+  ])("$name", ({ path: changedPath, expected }) => {
+    const result = detectChangedLanes([changedPath]);
+    const commands = createChangedCheckPlan(result, {
+      env: { PATH: "/usr/bin" },
+    }).commands.map((command) => command.args[0]);
 
-    expectLanes(result.lanes, {
-      coreTests: true,
-      ui: true,
-    });
-    expect(plan.commands.map((command) => command.args[0])).toContain("tsgo:ui");
-    expect(plan.commands.map((command) => command.args[0])).toContain("tsgo:core:test");
-    expect(plan.commands.map((command) => command.args[0])).toContain("lint:ui:i18n");
-    expect(plan.commands.map((command) => command.args[0])).not.toContain("tsgo:core");
-  });
-
-  it("routes the UI production config to UI prod and core test lanes", () => {
-    const result = detectChangedLanes(["tsconfig.ui.json"]);
-    const plan = createChangedCheckPlan(result, { env: { PATH: "/usr/bin" } });
-
-    expectLanes(result.lanes, {
-      coreTests: true,
-      ui: true,
-    });
-    expect(plan.commands.map((command) => command.args[0])).toContain("tsgo:ui");
-    expect(plan.commands.map((command) => command.args[0])).toContain("tsgo:core:test");
+    expectLanes(result.lanes, { coreTests: true, ui: true });
+    for (const command of expected.includes) {
+      expect(commands).toContain(command);
+    }
+    for (const command of expected.excludes) {
+      expect(commands).not.toContain(command);
+    }
   });
 
   it.each([
@@ -965,74 +819,48 @@ describe("scripts/changed-lanes", () => {
     ).toBeNull();
   });
 
-  it("targets small core lint diffs", () => {
-    expect(
-      createTargetedCoreLintCommand(
-        [
-          ".github/workflows/ci.yml",
-          "scripts/check-changed.mjs",
-          "src/agents/auth-profiles/usage.ts",
-          "test/scripts/changed-lanes.test.ts",
-        ],
-        { PATH: "/usr/bin" },
-        { fileExists: () => true },
-      ),
-    ).toEqual({
-      name: "lint core changed file",
-      bin: "node",
-      args: [
-        "scripts/run-oxlint.mjs",
-        "--tsconfig",
-        "config/tsconfig/oxlint.core.json",
-        "src/agents/auth-profiles/usage.ts",
-      ],
-      env: {
-        PATH: "/usr/bin",
-      },
-    });
-  });
-
-  it("targets small extension lint diffs", () => {
-    expect(
-      createTargetedExtensionLintCommand(
-        ["extensions/lmstudio/src/api.ts", "docs/help/testing.md"],
-        { PATH: "/usr/bin" },
-        { fileExists: () => true },
-      ),
-    ).toEqual({
-      name: "lint extension changed file",
-      bin: "node",
-      args: [
-        "scripts/run-oxlint.mjs",
-        "--tsconfig",
-        "config/tsconfig/oxlint.extensions.json",
-        "extensions/lmstudio/src/api.ts",
-      ],
-      env: {
-        PATH: "/usr/bin",
-      },
-    });
-  });
-
-  it("targets small script lint diffs", () => {
-    expect(
-      createTargetedScriptLintCommand(
-        ["scripts/check-changed.mjs", "test/scripts/changed-lanes.test.ts"],
-        { PATH: "/usr/bin" },
-        { fileExists: () => true },
-      ),
-    ).toEqual({
-      name: "lint script changed file",
-      bin: "node",
-      args: [
-        "scripts/run-oxlint.mjs",
-        "--tsconfig",
-        "config/tsconfig/oxlint.scripts.json",
+  it.each([
+    {
+      name: "targets small core lint diffs",
+      create: createTargetedCoreLintCommand,
+      targets: [
+        ".github/workflows/ci.yml",
         "scripts/check-changed.mjs",
+        "src/agents/auth-profiles/usage.ts",
+        "test/scripts/changed-lanes.test.ts",
       ],
-      env: {
-        PATH: "/usr/bin",
+      expected: {
+        name: "lint core changed file",
+        tsconfig: "config/tsconfig/oxlint.core.json",
+        path: "src/agents/auth-profiles/usage.ts",
       },
+    },
+    {
+      name: "targets small extension lint diffs",
+      create: createTargetedExtensionLintCommand,
+      targets: ["extensions/lmstudio/src/api.ts", "docs/help/testing.md"],
+      expected: {
+        name: "lint extension changed file",
+        tsconfig: "config/tsconfig/oxlint.extensions.json",
+        path: "extensions/lmstudio/src/api.ts",
+      },
+    },
+    {
+      name: "targets small script lint diffs",
+      create: createTargetedScriptLintCommand,
+      targets: ["scripts/check-changed.mjs", "test/scripts/changed-lanes.test.ts"],
+      expected: {
+        name: "lint script changed file",
+        tsconfig: "config/tsconfig/oxlint.scripts.json",
+        path: "scripts/check-changed.mjs",
+      },
+    },
+  ])("$name", ({ create, targets, expected }) => {
+    expect(create(targets, { PATH: "/usr/bin" }, { fileExists: () => true })).toEqual({
+      name: expected.name,
+      bin: "node",
+      args: ["scripts/run-oxlint.mjs", "--tsconfig", expected.tsconfig, expected.path],
+      env: { PATH: "/usr/bin" },
     });
   });
 
@@ -1192,17 +1020,7 @@ describe("scripts/changed-lanes", () => {
     const dir = makeTempRepoRoot(tempDirs, "openclaw-check-changed-staged-delegate-");
     git(dir, ["init", "-q", "--initial-branch=main"]);
     writeFileSync(path.join(dir, "README.md"), "initial\n", "utf8");
-    git(dir, ["add", "README.md"]);
-    git(dir, [
-      "-c",
-      "user.email=test@example.com",
-      "-c",
-      "user.name=Test User",
-      "commit",
-      "-q",
-      "-m",
-      "initial",
-    ]);
+    commitAll(dir, "initial");
     mkdirSync(path.join(dir, "src"), { recursive: true });
     writeFileSync(path.join(dir, "src", "staged.ts"), "export const staged = 1;\n", "utf8");
     git(dir, ["add", "src/staged.ts"]);
@@ -1223,17 +1041,7 @@ describe("scripts/changed-lanes", () => {
     const dir = makeTempRepoRoot(tempDirs, "openclaw-check-changed-empty-staged-delegate-");
     git(dir, ["init", "-q", "--initial-branch=main"]);
     writeFileSync(path.join(dir, "README.md"), "initial\n", "utf8");
-    git(dir, ["add", "README.md"]);
-    git(dir, [
-      "-c",
-      "user.email=test@example.com",
-      "-c",
-      "user.name=Test User",
-      "commit",
-      "-q",
-      "-m",
-      "initial",
-    ]);
+    commitAll(dir, "initial");
     mkdirSync(path.join(dir, "src"), { recursive: true });
     writeFileSync(path.join(dir, "src", "unstaged.ts"), "export const unstaged = 1;\n", "utf8");
 
@@ -1281,49 +1089,45 @@ describe("scripts/changed-lanes", () => {
     });
   });
 
-  it("routes core test-only changes to core test lanes only", () => {
-    const result = detectChangedLanes([
-      "packages/normalization-core/src/string-normalization.test.ts",
-    ]);
+  it.each([
+    {
+      name: "routes core test-only changes to core test lanes only",
+      path: "packages/normalization-core/src/string-normalization.test.ts",
+      expected: {
+        lanes: { coreTests: true },
+        includes: ["tsgo:core:test"],
+        excludes: ["tsgo:core"],
+      },
+    },
+    {
+      name: "routes extension production changes to extension prod and extension test lanes",
+      path: "extensions/lmstudio/src/api.ts",
+      expected: {
+        lanes: { extensions: true, extensionTests: true },
+        includes: ["tsgo:extensions", "tsgo:extensions:test"],
+        excludes: [],
+      },
+    },
+    {
+      name: "routes extension test-only changes to extension test lanes only",
+      path: "extensions/discord/src/index.test.ts",
+      expected: {
+        lanes: { extensionTests: true },
+        includes: ["tsgo:extensions:test"],
+        excludes: ["tsgo:extensions"],
+      },
+    },
+  ])("$name", ({ path: changedPath, expected }) => {
+    const result = detectChangedLanes([changedPath]);
+    const commands = createChangedCheckPlan(result).commands.map((command) => command.args[0]);
 
-    expectLanes(result.lanes, {
-      coreTests: true,
-    });
-    expect(createChangedCheckPlan(result).commands.map((command) => command.args[0])).toContain(
-      "tsgo:core:test",
-    );
-    expect(createChangedCheckPlan(result).commands.map((command) => command.args[0])).not.toContain(
-      "tsgo:core",
-    );
-  });
-
-  it("routes extension production changes to extension prod and extension test lanes", () => {
-    const result = detectChangedLanes(["extensions/lmstudio/src/api.ts"]);
-
-    expectLanes(result.lanes, {
-      extensions: true,
-      extensionTests: true,
-    });
-    expect(createChangedCheckPlan(result).commands.map((command) => command.args[0])).toContain(
-      "tsgo:extensions",
-    );
-    expect(createChangedCheckPlan(result).commands.map((command) => command.args[0])).toContain(
-      "tsgo:extensions:test",
-    );
-  });
-
-  it("routes extension test-only changes to extension test lanes only", () => {
-    const result = detectChangedLanes(["extensions/discord/src/index.test.ts"]);
-
-    expectLanes(result.lanes, {
-      extensionTests: true,
-    });
-    expect(createChangedCheckPlan(result).commands.map((command) => command.args[0])).toContain(
-      "tsgo:extensions:test",
-    );
-    expect(createChangedCheckPlan(result).commands.map((command) => command.args[0])).not.toContain(
-      "tsgo:extensions",
-    );
+    expectLanes(result.lanes, expected.lanes);
+    for (const command of expected.includes) {
+      expect(commands).toContain(command);
+    }
+    for (const command of expected.excludes) {
+      expect(commands).not.toContain(command);
+    }
   });
 
   it("expands public core/plugin contracts to extension validation", () => {
@@ -1350,77 +1154,67 @@ describe("scripts/changed-lanes", () => {
     expect(plan.commands.map((command) => command.args[0])).not.toContain("test");
   });
 
-  it("routes gitignore changes to tooling instead of all lanes", () => {
-    const result = detectChangedLanes([".gitignore"]);
-    const plan = createChangedCheckPlan(result);
+  it.each([
+    {
+      name: "routes gitignore changes to tooling instead of all lanes",
+      paths: [".gitignore"],
+      excludesTests: true,
+    },
+    {
+      name: "routes root hygiene config changes to tooling instead of all lanes",
+      paths: [
+        ".dockerignore",
+        ".jscpd.json",
+        ".npmignore",
+        ".pre-commit-config.yaml",
+        ".swiftformat",
+        ".swiftlint.yml",
+        "Makefile",
+        "config/knip.config.ts",
+        "config/markdownlint-cli2.jsonc",
+        "config/shellcheckrc",
+        "config/swiftformat",
+        "config/swiftlint.yml",
+        "deploy/fly.private.toml",
+        "docker-setup.sh",
+        "openclaw.podman.env",
+        "setup-podman.sh",
+        "skills/pyproject.toml",
+      ],
+      excludesTests: true,
+    },
+    {
+      name: "routes VS Code workspace settings to tooling instead of all lanes",
+      paths: [".vscode/settings.json", ".vscode/extensions.json"],
+      excludesTests: true,
+    },
+    {
+      name: "routes legacy root sandbox Dockerfile moves to tooling instead of all lanes",
+      paths: [
+        "Dockerfile.sandbox",
+        "Dockerfile.sandbox-browser",
+        "Dockerfile.sandbox-common",
+        "scripts/docker/sandbox/Dockerfile",
+        "scripts/docker/sandbox/Dockerfile.browser",
+        "scripts/docker/sandbox/Dockerfile.common",
+      ],
+      excludesTests: true,
+    },
+    {
+      name: "routes legacy root asset deletions as tooling during root cleanup",
+      paths: ["assets/avatar-placeholder.svg", "assets/chrome-extension/icons/icon128.png"],
+      excludesTests: false,
+    },
+  ])("$name", ({ paths, excludesTests }) => {
+    const result = detectChangedLanes(paths);
+    const commands = createChangedCheckPlan(result).commands.map((command) => command.args[0]);
 
-    expectLanes(result.lanes, {
-      tooling: true,
-    });
-    expect(plan.commands.map((command) => command.args[0])).toContain("lint:scripts");
-    expect(plan.commands.map((command) => command.args[0])).not.toContain("tsgo:all");
-    expect(plan.commands.map((command) => command.args[0])).not.toContain("test");
-  });
-
-  it("routes root hygiene config changes to tooling instead of all lanes", () => {
-    const result = detectChangedLanes([
-      ".dockerignore",
-      ".jscpd.json",
-      ".npmignore",
-      ".pre-commit-config.yaml",
-      ".swiftformat",
-      ".swiftlint.yml",
-      "Makefile",
-      "config/knip.config.ts",
-      "config/markdownlint-cli2.jsonc",
-      "config/shellcheckrc",
-      "config/swiftformat",
-      "config/swiftlint.yml",
-      "deploy/fly.private.toml",
-      "docker-setup.sh",
-      "openclaw.podman.env",
-      "setup-podman.sh",
-      "skills/pyproject.toml",
-    ]);
-    const plan = createChangedCheckPlan(result);
-
-    expectLanes(result.lanes, {
-      tooling: true,
-    });
-    expect(plan.commands.map((command) => command.args[0])).toContain("lint:scripts");
-    expect(plan.commands.map((command) => command.args[0])).not.toContain("tsgo:all");
-    expect(plan.commands.map((command) => command.args[0])).not.toContain("test");
-  });
-
-  it("routes VS Code workspace settings to tooling instead of all lanes", () => {
-    const result = detectChangedLanes([".vscode/settings.json", ".vscode/extensions.json"]);
-    const plan = createChangedCheckPlan(result);
-
-    expectLanes(result.lanes, {
-      tooling: true,
-    });
-    expect(plan.commands.map((command) => command.args[0])).toContain("lint:scripts");
-    expect(plan.commands.map((command) => command.args[0])).not.toContain("tsgo:all");
-    expect(plan.commands.map((command) => command.args[0])).not.toContain("test");
-  });
-
-  it("routes legacy root sandbox Dockerfile moves to tooling instead of all lanes", () => {
-    const result = detectChangedLanes([
-      "Dockerfile.sandbox",
-      "Dockerfile.sandbox-browser",
-      "Dockerfile.sandbox-common",
-      "scripts/docker/sandbox/Dockerfile",
-      "scripts/docker/sandbox/Dockerfile.browser",
-      "scripts/docker/sandbox/Dockerfile.common",
-    ]);
-    const plan = createChangedCheckPlan(result);
-
-    expectLanes(result.lanes, {
-      tooling: true,
-    });
-    expect(plan.commands.map((command) => command.args[0])).toContain("lint:scripts");
-    expect(plan.commands.map((command) => command.args[0])).not.toContain("tsgo:all");
-    expect(plan.commands.map((command) => command.args[0])).not.toContain("test");
+    expectLanes(result.lanes, { tooling: true });
+    expect(commands).toContain("lint:scripts");
+    expect(commands).not.toContain("tsgo:all");
+    if (excludesTests) {
+      expect(commands).not.toContain("test");
+    }
   });
 
   it("routes live Docker ACP tooling changes through a focused gate", () => {
@@ -1481,34 +1275,20 @@ describe("scripts/changed-lanes", () => {
   });
 
   it("routes live Docker package script-only changes through the focused gate", () => {
-    const before = `${JSON.stringify(
-      {
-        name: "fixture",
-        scripts: {
-          "test:docker:all": "node scripts/test-docker-all.mjs",
-        },
-        dependencies: {
-          leftpad: "1.0.0",
-        },
+    const before = prettyJson({
+      name: "fixture",
+      scripts: { "test:docker:all": "node scripts/test-docker-all.mjs" },
+      dependencies: { leftpad: "1.0.0" },
+    });
+    const after = prettyJson({
+      name: "fixture",
+      scripts: {
+        "test:docker:all": "node scripts/test-docker-all.mjs",
+        "test:docker:live-acp-bind:droid":
+          "OPENCLAW_LIVE_ACP_BIND_AGENT=droid bash scripts/test-live-acp-bind-docker.sh",
       },
-      null,
-      2,
-    )}\n`;
-    const after = `${JSON.stringify(
-      {
-        name: "fixture",
-        scripts: {
-          "test:docker:all": "node scripts/test-docker-all.mjs",
-          "test:docker:live-acp-bind:droid":
-            "OPENCLAW_LIVE_ACP_BIND_AGENT=droid bash scripts/test-live-acp-bind-docker.sh",
-        },
-        dependencies: {
-          leftpad: "1.0.0",
-        },
-      },
-      null,
-      2,
-    )}\n`;
+      dependencies: { leftpad: "1.0.0" },
+    });
 
     expect(isLiveDockerPackageScriptOnlyChange(before, after)).toBe(true);
 
@@ -1523,175 +1303,78 @@ describe("scripts/changed-lanes", () => {
     expect(plan.commands.map((command) => command.name)).toContain("live Docker scheduler dry run");
   });
 
-  it("classifies live Docker package script changes from the git diff", () => {
-    const dir = makeTempRepoRoot(tempDirs, "openclaw-live-docker-package-");
-    git(dir, ["init", "-q", "--initial-branch=main"]);
-    writeFileSync(
-      path.join(dir, "package.json"),
-      `${JSON.stringify(
-        {
-          name: "fixture",
-          scripts: {
-            "test:docker:all": "node scripts/test-docker-all.mjs",
-          },
-        },
-        null,
-        2,
-      )}\n`,
-      "utf8",
-    );
-    git(dir, ["add", "package.json"]);
-    git(dir, [
-      "-c",
-      "user.email=test@example.com",
-      "-c",
-      "user.name=Test User",
-      "commit",
-      "-q",
-      "-m",
-      "initial",
-    ]);
-
-    writeFileSync(
-      path.join(dir, "package.json"),
-      `${JSON.stringify(
-        {
-          name: "fixture",
-          scripts: {
-            "test:docker:all": "node scripts/test-docker-all.mjs",
-            "test:docker:live-acp-bind:droid":
-              "OPENCLAW_LIVE_ACP_BIND_AGENT=droid bash scripts/test-live-acp-bind-docker.sh",
-          },
-        },
-        null,
-        2,
-      )}\n`,
-      "utf8",
-    );
-
-    const output = execFileSync(
-      process.execPath,
-      [path.join(repoRoot, "scripts", "changed-lanes.mjs"), "--json", "--base", "HEAD"],
-      {
-        cwd: dir,
-        encoding: "utf8",
-        env: createNestedGitEnv(),
+  it.each([
+    {
+      name: "classifies live Docker package script changes from the git diff",
+      prefix: "openclaw-live-docker-package-",
+      before: {
+        name: "fixture",
+        scripts: { "test:docker:all": "node scripts/test-docker-all.mjs" },
       },
-    );
-
-    const result = parseChangedLaneOutput(output);
-
-    expect(result.paths).toEqual(["package.json"]);
-    expectLanes(result.lanes, { liveDockerTooling: true });
-  });
-
-  it("classifies normal package script changes from the git diff", () => {
-    const dir = makeTempRepoRoot(tempDirs, "openclaw-package-scripts-");
-    git(dir, ["init", "-q", "--initial-branch=main"]);
-    writeFileSync(
-      path.join(dir, "package.json"),
-      `${JSON.stringify(
-        {
-          name: "fixture",
-          scripts: {
-            test: "node scripts/test-projects.mjs",
-          },
-          dependencies: {
-            leftpad: "1.0.0",
-          },
-        },
-        null,
-        2,
-      )}\n`,
-      "utf8",
-    );
-    git(dir, ["add", "package.json"]);
-    git(dir, [
-      "-c",
-      "user.email=test@example.com",
-      "-c",
-      "user.name=Test User",
-      "commit",
-      "-q",
-      "-m",
-      "initial",
-    ]);
-
-    writeFileSync(
-      path.join(dir, "package.json"),
-      `${JSON.stringify(
-        {
-          name: "fixture",
-          scripts: {
-            test: "node scripts/test-projects.mjs",
-            "test:profile": "node scripts/profile-tests.mjs",
-          },
-          dependencies: {
-            leftpad: "1.0.0",
-          },
-        },
-        null,
-        2,
-      )}\n`,
-      "utf8",
-    );
-
-    const output = execFileSync(
-      process.execPath,
-      [path.join(repoRoot, "scripts", "changed-lanes.mjs"), "--json", "--base", "HEAD"],
-      {
-        cwd: dir,
-        encoding: "utf8",
-        env: createNestedGitEnv(),
-      },
-    );
-
-    const result = parseChangedLaneOutput(output);
-
-    expect(result.paths).toEqual(["package.json"]);
-    expectLanes(result.lanes, { tooling: true });
-  });
-
-  it("keeps non-script package changes off the live Docker focused gate", () => {
-    const before = `${JSON.stringify(
-      { name: "fixture", scripts: {}, dependencies: { leftpad: "1.0.0" } },
-      null,
-      2,
-    )}\n`;
-    const after = `${JSON.stringify(
-      {
+      after: {
         name: "fixture",
         scripts: {
+          "test:docker:all": "node scripts/test-docker-all.mjs",
           "test:docker:live-acp-bind:droid":
             "OPENCLAW_LIVE_ACP_BIND_AGENT=droid bash scripts/test-live-acp-bind-docker.sh",
         },
-        dependencies: { leftpad: "1.0.1" },
       },
-      null,
-      2,
-    )}\n`;
+      expected: { liveDockerTooling: true },
+    },
+    {
+      name: "classifies normal package script changes from the git diff",
+      prefix: "openclaw-package-scripts-",
+      before: {
+        name: "fixture",
+        scripts: { test: "node scripts/test-projects.mjs" },
+        dependencies: { leftpad: "1.0.0" },
+      },
+      after: {
+        name: "fixture",
+        scripts: {
+          test: "node scripts/test-projects.mjs",
+          "test:profile": "node scripts/profile-tests.mjs",
+        },
+        dependencies: { leftpad: "1.0.0" },
+      },
+      expected: { tooling: true },
+    },
+  ])("$name", ({ prefix, before, after, expected }) => {
+    const result = classifyPackageJsonChange(prefix, before, after);
+
+    expect(result.paths).toEqual(["package.json"]);
+    expectLanes(result.lanes, expected);
+  });
+
+  it("keeps non-script package changes off the live Docker focused gate", () => {
+    const before = prettyJson({
+      name: "fixture",
+      scripts: {},
+      dependencies: { leftpad: "1.0.0" },
+    });
+    const after = prettyJson({
+      name: "fixture",
+      scripts: {
+        "test:docker:live-acp-bind:droid":
+          "OPENCLAW_LIVE_ACP_BIND_AGENT=droid bash scripts/test-live-acp-bind-docker.sh",
+      },
+      dependencies: { leftpad: "1.0.1" },
+    });
 
     expect(isLiveDockerPackageScriptOnlyChange(before, after)).toBe(false);
   });
 
   it("routes package script-only changes through the tooling gate", () => {
-    const before = `${JSON.stringify(
-      { name: "fixture", scripts: { test: "node test.js" }, dependencies: { leftpad: "1.0.0" } },
-      null,
-      2,
-    )}\n`;
-    const after = `${JSON.stringify(
-      {
-        name: "fixture",
-        scripts: {
-          test: "node test.js",
-          "test:profile": "node scripts/profile-tests.mjs",
-        },
-        dependencies: { leftpad: "1.0.0" },
-      },
-      null,
-      2,
-    )}\n`;
+    const before = prettyJson({
+      name: "fixture",
+      scripts: { test: "node test.js" },
+      dependencies: { leftpad: "1.0.0" },
+    });
+    const after = prettyJson({
+      name: "fixture",
+      scripts: { test: "node test.js", "test:profile": "node scripts/profile-tests.mjs" },
+      dependencies: { leftpad: "1.0.0" },
+    });
 
     expect(isPackageScriptOnlyChange(before, after)).toBe(true);
 
@@ -1791,92 +1474,94 @@ describe("scripts/changed-lanes", () => {
     expect(plan.commands.map((command) => command.args[0])).not.toContain("deps:shrinkwrap:check");
   });
 
-  it("runs prompt snapshot drift checks for prompt snapshot generator surfaces", () => {
-    expect(
-      shouldRunPromptSnapshotCheck([
+  it.each([
+    {
+      name: "runs prompt snapshot drift checks for prompt snapshot generator surfaces",
+      predicate: shouldRunPromptSnapshotCheck,
+      predicatePaths: [
         "scripts/generate-prompt-snapshots.ts",
         "test/helpers/agents/happy-path-prompt-snapshots.ts",
         "test/fixtures/agents/prompt-snapshots/runtime-happy-path/telegram-direct-codex-message-tool.md",
-      ]),
-    ).toBe(true);
-
-    const result = detectChangedLanes(["test/helpers/agents/happy-path-prompt-snapshots.ts"]);
-    const plan = createChangedCheckPlan(result);
-
-    expect(plan.commands).toContainEqual({
-      name: "prompt snapshot drift",
-      args: ["prompt:snapshots:check"],
-    });
-    expect(plan.commands).toContainEqual(
-      expect.objectContaining({
-        name: "prompt snapshot owner test",
-        args: ["test:serial", "test/scripts/prompt-snapshots.test.ts"],
-      }),
-    );
-  });
-
-  it("runs the prompt snapshot owner test for model fixture generator surfaces", () => {
-    expect(
-      shouldRunPromptSnapshotOwnerTest([
+      ],
+      changedPath: "test/helpers/agents/happy-path-prompt-snapshots.ts",
+      expected: {
+        exact: [{ name: "prompt snapshot drift", args: ["prompt:snapshots:check"] }],
+        partial: [
+          {
+            name: "prompt snapshot owner test",
+            args: ["test:serial", "test/scripts/prompt-snapshots.test.ts"],
+          },
+        ],
+      },
+    },
+    {
+      name: "runs the prompt snapshot owner test for model fixture generator surfaces",
+      predicate: shouldRunPromptSnapshotOwnerTest,
+      predicatePaths: [
         "scripts/sync-codex-model-prompt-fixture.ts",
         "test/fixtures/agents/prompt-snapshots/codex-model-catalog/gpt-5.5.pragmatic.source.json",
-      ]),
-    ).toBe(true);
-
-    const result = detectChangedLanes(["scripts/sync-codex-model-prompt-fixture.ts"]);
-    const plan = createChangedCheckPlan(result);
-
-    expect(plan.commands).toContainEqual(
-      expect.objectContaining({
-        name: "prompt snapshot owner test",
-        args: ["test:serial", "test/scripts/prompt-snapshots.test.ts"],
-      }),
-    );
-  });
-
-  it("runs runtime sidecar baseline checks for baseline owner surfaces", () => {
-    expect(
-      shouldRunRuntimeSidecarBaselineCheck([
+      ],
+      changedPath: "scripts/sync-codex-model-prompt-fixture.ts",
+      expected: {
+        exact: [],
+        partial: [
+          {
+            name: "prompt snapshot owner test",
+            args: ["test:serial", "test/scripts/prompt-snapshots.test.ts"],
+          },
+        ],
+      },
+    },
+    {
+      name: "runs runtime sidecar baseline checks for baseline owner surfaces",
+      predicate: shouldRunRuntimeSidecarBaselineCheck,
+      predicatePaths: [
         "scripts/generate-runtime-sidecar-paths-baseline.ts",
         "scripts/lib/bundled-runtime-sidecar-paths.json",
         "src/plugins/runtime-sidecar-paths-baseline.ts",
         "src/plugins/runtime-sidecar-paths.ts",
-      ]),
-    ).toBe(true);
-
-    const result = detectChangedLanes(["scripts/lib/bundled-runtime-sidecar-paths.json"]);
-    const plan = createChangedCheckPlan(result);
-
-    expect(plan.commands).toContainEqual({
-      name: "runtime sidecar baseline",
-      args: ["runtime-sidecars:check"],
-    });
-    expect(plan.commands).toContainEqual(
-      expect.objectContaining({
-        name: "runtime sidecar owner test",
-        args: ["test:serial", "src/plugins/bundled-plugin-metadata.test.ts"],
-      }),
-    );
-  });
-
-  it("runs SQLite sessions/transcripts schema baseline checks for baseline owner surfaces", () => {
-    expect(
-      shouldRunSqliteSessionSchemaBaselineCheck([
+      ],
+      changedPath: "scripts/lib/bundled-runtime-sidecar-paths.json",
+      expected: {
+        exact: [{ name: "runtime sidecar baseline", args: ["runtime-sidecars:check"] }],
+        partial: [
+          {
+            name: "runtime sidecar owner test",
+            args: ["test:serial", "src/plugins/bundled-plugin-metadata.test.ts"],
+          },
+        ],
+      },
+    },
+    {
+      name: "runs SQLite sessions/transcripts schema baseline checks for baseline owner surfaces",
+      predicate: shouldRunSqliteSessionSchemaBaselineCheck,
+      predicatePaths: [
         "src/state/openclaw-agent-schema.sql",
         "scripts/generate-sqlite-session-schema-baseline.ts",
         "scripts/lib/sqlite-session-schema-baseline.ts",
         "test/scripts/sqlite-session-schema-baseline.test.ts",
         "docs/.generated/sqlite-session-transcript-schema-baseline.sha256",
-      ]),
-    ).toBe(true);
-
-    const result = detectChangedLanes(["src/state/openclaw-agent-schema.sql"]);
-    const plan = createChangedCheckPlan(result);
-
-    expect(plan.commands).toContainEqual({
-      name: "SQLite sessions/transcripts schema baseline",
-      args: ["sqlite:sessions-schema:check"],
-    });
+      ],
+      changedPath: "src/state/openclaw-agent-schema.sql",
+      expected: {
+        exact: [
+          {
+            name: "SQLite sessions/transcripts schema baseline",
+            args: ["sqlite:sessions-schema:check"],
+          },
+        ],
+        partial: [],
+      },
+    },
+  ])("$name", ({ predicate, predicatePaths, changedPath, expected }) => {
+    expect(predicate(predicatePaths)).toBe(true);
+    const commands = createChangedCheckPlan(detectChangedLanes([changedPath])).commands;
+    for (const command of expected.exact) {
+      expect(commands).toContainEqual(command);
+    }
+    for (const command of expected.partial) {
+      expect(commands).toContainEqual(expect.objectContaining(command));
+    }
   });
 
   it("runs Plugin SDK API checks for transitive public contract changes", () => {
@@ -1981,17 +1666,7 @@ describe("scripts/changed-lanes", () => {
       `${JSON.stringify({ name: "fixture", version: "2026.4.20", dependencies: { leftpad: "1.0.0" } }, null, 2)}\n`,
       "utf8",
     );
-    git(dir, ["add", "package.json"]);
-    git(dir, [
-      "-c",
-      "user.email=test@example.com",
-      "-c",
-      "user.name=Test User",
-      "commit",
-      "-q",
-      "-m",
-      "initial",
-    ]);
+    commitAll(dir, "initial");
 
     writeFileSync(
       path.join(dir, "package.json"),
@@ -2198,20 +1873,6 @@ describe("scripts/changed-lanes", () => {
     expect(plan.commands.map((command) => command.name)).not.toContain("macOS app CI tests");
   });
 
-  it("routes legacy root asset deletions as tooling during root cleanup", () => {
-    const result = detectChangedLanes([
-      "assets/avatar-placeholder.svg",
-      "assets/chrome-extension/icons/icon128.png",
-    ]);
-    const plan = createChangedCheckPlan(result);
-
-    expectLanes(result.lanes, {
-      tooling: true,
-    });
-    expect(plan.commands.map((command) => command.args[0])).toContain("lint:scripts");
-    expect(plan.commands.map((command) => command.args[0])).not.toContain("tsgo:all");
-  });
-
   it("routes A2UI bundle source changes as extension changes", () => {
     const result = detectChangedLanes([
       "extensions/canvas/src/host/a2ui-app/bootstrap.js",
@@ -2272,20 +1933,37 @@ describe("scripts/changed-lanes", () => {
     );
   });
 
-  it("keeps shared Vitest wiring changes out of check test execution", () => {
-    const result = detectChangedLanes(["test/vitest/vitest.shared.config.ts"]);
-    const plan = createChangedCheckPlan(result);
+  it.each([
+    {
+      name: "keeps shared Vitest wiring changes out of check test execution",
+      paths: ["test/vitest/vitest.shared.config.ts"],
+      expected: "lint:scripts",
+    },
+    {
+      name: "keeps setup changes out of check test execution",
+      paths: ["test/setup.ts"],
+      expected: "lint:scripts",
+    },
+    {
+      name: "does not route generated plugin bundle artifacts as direct Vitest targets",
+      paths: [
+        "extensions/demo/src/host/assets/.bundle.hash",
+        "extensions/canvas/scripts/bundle-a2ui.test.ts",
+      ],
+      expected: "tsgo:extensions",
+    },
+    {
+      name: "routes changed extension Vitest configs to only their owning shard",
+      paths: ["test/vitest/vitest.extension-discord.config.ts"],
+      expected: "lint:scripts",
+    },
+  ])("$name", ({ paths, expected }) => {
+    const commands = createChangedCheckPlan(detectChangedLanes(paths)).commands.map(
+      (command) => command.args[0],
+    );
 
-    expect(plan.commands.map((command) => command.args[0])).toContain("lint:scripts");
-    expect(plan.commands.map((command) => command.args[0])).not.toContain("test");
-  });
-
-  it("keeps setup changes out of check test execution", () => {
-    const result = detectChangedLanes(["test/setup.ts"]);
-    const plan = createChangedCheckPlan(result);
-
-    expect(plan.commands.map((command) => command.args[0])).toContain("lint:scripts");
-    expect(plan.commands.map((command) => command.args[0])).not.toContain("test");
+    expect(commands).toContain(expected);
+    expect(commands).not.toContain("test");
   });
 
   it("adds the warning-only temp creation report for changed test paths", () => {
@@ -2302,32 +1980,36 @@ describe("scripts/changed-lanes", () => {
     });
   });
 
-  it("adds the max-lines suppression ratchet with worktree and staged bases", () => {
+  it.each([
+    {
+      name: "adds the max-lines suppression ratchet with worktree and staged bases",
+      commandName: "max-lines suppression ratchet",
+      worktreeOptions: { base: "main", head: "feature" },
+      expected: {
+        worktree: ["check:max-lines-ratchet", "--base", "main"],
+        staged: ["check:max-lines-ratchet", "--staged", "--base", "HEAD"],
+      },
+    },
+    {
+      name: "adds the environment variable count ratchet for production source",
+      commandName: "environment variable count ratchet",
+      worktreeOptions: { base: "main" },
+      expected: {
+        worktree: ["check:env-var-count", "--base", "main"],
+        staged: ["check:env-var-count", "--staged", "--base", "HEAD"],
+      },
+    },
+  ])("$name", ({ commandName, worktreeOptions, expected }) => {
     const result = detectChangedLanes(["src/runtime.ts"]);
-    const worktreePlan = createChangedCheckPlan(result, { base: "main", head: "feature" });
+    const worktreePlan = createChangedCheckPlan(result, worktreeOptions);
     const stagedPlan = createChangedCheckPlan(result, { staged: true });
 
-    expect(
-      worktreePlan.commands.find((command) => command.name === "max-lines suppression ratchet"),
-    ).toMatchObject({ args: ["check:max-lines-ratchet", "--base", "main"] });
-    expect(
-      stagedPlan.commands.find((command) => command.name === "max-lines suppression ratchet"),
-    ).toMatchObject({ args: ["check:max-lines-ratchet", "--staged", "--base", "HEAD"] });
-  });
-
-  it("adds the environment variable count ratchet for production source", () => {
-    const result = detectChangedLanes(["src/runtime.ts"]);
-    const worktreePlan = createChangedCheckPlan(result, { base: "main" });
-    const stagedPlan = createChangedCheckPlan(result, { staged: true });
-
-    expect(
-      worktreePlan.commands.find(
-        (command) => command.name === "environment variable count ratchet",
-      ),
-    ).toMatchObject({ args: ["check:env-var-count", "--base", "main"] });
-    expect(
-      stagedPlan.commands.find((command) => command.name === "environment variable count ratchet"),
-    ).toMatchObject({ args: ["check:env-var-count", "--staged", "--base", "HEAD"] });
+    expect(worktreePlan.commands.find((command) => command.name === commandName)).toMatchObject({
+      args: expected.worktree,
+    });
+    expect(stagedPlan.commands.find((command) => command.name === commandName)).toMatchObject({
+      args: expected.staged,
+    });
   });
 
   it("keeps the temp creation report out of non-test changed paths", () => {
@@ -2338,25 +2020,6 @@ describe("scripts/changed-lanes", () => {
     expect(plan.commands.map((command) => command.name)).not.toContain(
       "test temp creation report (warning-only)",
     );
-  });
-
-  it("does not route generated plugin bundle artifacts as direct Vitest targets", () => {
-    const result = detectChangedLanes([
-      "extensions/demo/src/host/assets/.bundle.hash",
-      "extensions/canvas/scripts/bundle-a2ui.test.ts",
-    ]);
-    const plan = createChangedCheckPlan(result);
-
-    expect(plan.commands.map((command) => command.args[0])).toContain("tsgo:extensions");
-    expect(plan.commands.map((command) => command.args[0])).not.toContain("test");
-  });
-
-  it("routes changed extension Vitest configs to only their owning shard", () => {
-    const result = detectChangedLanes(["test/vitest/vitest.extension-discord.config.ts"]);
-    const plan = createChangedCheckPlan(result);
-
-    expect(plan.commands.map((command) => command.args[0])).toContain("lint:scripts");
-    expect(plan.commands.map((command) => command.args[0])).not.toContain("test");
   });
 
   it("keeps an empty changed path list as a no-op", () => {

--- a/test/scripts/openclaw-cross-os-release-checks.test.ts
+++ b/test/scripts/openclaw-cross-os-release-checks.test.ts
@@ -158,6 +158,24 @@ async function waitForExit(
   });
 }
 
+function withTempDir<T>(prefix: string, run: (dir: string) => T): T {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  try {
+    return run(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+async function withTempDirAsync<T>(prefix: string, run: (dir: string) => Promise<T>): Promise<T> {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  try {
+    return await run(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
 describe("scripts/openclaw-cross-os-release-checks", () => {
   it("keeps dashboard smoke patient enough for cold packaged gateway startup", () => {
     expect(CROSS_OS_DASHBOARD_SMOKE_TIMEOUT_MS).toBeGreaterThanOrEqual(120_000);
@@ -388,8 +406,7 @@ describe("scripts/openclaw-cross-os-release-checks", () => {
   });
 
   it("accepts OK agent output from the captured log when stdout is empty", () => {
-    const dir = mkdtempSync(join(tmpdir(), "openclaw-cross-os-agent-output-"));
-    try {
+    withTempDir("openclaw-cross-os-agent-output-", (dir) => {
       const logPath = join(dir, "agent.log");
       writeFileSync(
         logPath,
@@ -403,14 +420,11 @@ describe("scripts/openclaw-cross-os-release-checks", () => {
       );
 
       expect(agentOutputHasExpectedOkMarker("", { logPath })).toBe(true);
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
+    });
   });
 
   it("ignores stale OK markers outside the recent agent log tail", () => {
-    const dir = mkdtempSync(join(tmpdir(), "openclaw-cross-os-agent-output-tail-"));
-    try {
+    withTempDir("openclaw-cross-os-agent-output-tail-", (dir) => {
       const logPath = join(dir, "agent.log");
       writeFileSync(
         logPath,
@@ -426,48 +440,22 @@ describe("scripts/openclaw-cross-os-release-checks", () => {
       );
 
       expect(agentOutputHasExpectedOkMarker("", { logPath })).toBe(false);
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
+    });
   });
 
   it("retries transient agent-turn failures", () => {
-    expect(
-      shouldRetryCrossOsAgentTurnError(
-        new Error("Agent output did not contain the expected OK marker."),
-      ),
-    ).toBe(true);
-    expect(
-      shouldRetryCrossOsAgentTurnError(
-        new Error(
-          "The model did not produce a response before the model idle timeout. Please try again.",
-        ),
-      ),
-    ).toBe(true);
-    expect(
-      shouldRetryCrossOsAgentTurnError(
-        new Error("gateway request timeout for agent after 210000ms"),
-      ),
-    ).toBe(true);
-    expect(
-      shouldRetryCrossOsAgentTurnError(
-        new Error("Command timed out and could not be terminated cleanly"),
-      ),
-    ).toBe(true);
-    expect(
-      shouldRetryCrossOsAgentTurnError(
-        new Error(
-          "GatewayClientRequestError: FailoverError: Rate limit reached for gpt-5.5: code=rate_limit_exceeded",
-        ),
-      ),
-    ).toBe(true);
-    expect(
-      shouldRetryCrossOsAgentTurnError(
-        new Error(
-          "OpenAI image generation failed (HTTP 503): upstream connect error or disconnect/reset before headers. reset reason: connection timeout",
-        ),
-      ),
-    ).toBe(true);
+    const messages = [
+      "Agent output did not contain the expected OK marker.",
+      "The model did not produce a response before the model idle timeout. Please try again.",
+      "gateway request timeout for agent after 210000ms",
+      "Command timed out and could not be terminated cleanly",
+      "GatewayClientRequestError: FailoverError: Rate limit reached for gpt-5.5: code=rate_limit_exceeded",
+      "OpenAI image generation failed (HTTP 503): upstream connect error or disconnect/reset before headers. reset reason: connection timeout",
+    ];
+
+    expect(messages.map((message) => shouldRetryCrossOsAgentTurnError(new Error(message)))).toEqual(
+      messages.map(() => true),
+    );
   });
 
   it("requires explicit opt-in before cross-OS agent turns become optional", () => {
@@ -481,8 +469,7 @@ describe("scripts/openclaw-cross-os-release-checks", () => {
   });
 
   it("skips optional live agent turns only for model availability failures", () => {
-    const dir = mkdtempSync(join(tmpdir(), "openclaw-cross-os-agent-skip-"));
-    try {
+    withTempDir("openclaw-cross-os-agent-skip-", (dir) => {
       const logPath = join(dir, "agent.log");
       writeFileSync(
         logPath,
@@ -516,14 +503,11 @@ describe("scripts/openclaw-cross-os-release-checks", () => {
           join(dir, "missing.log"),
         ),
       ).toBe(false);
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
+    });
   });
 
   it("does not classify stale timeout logs as current optional agent-turn failures", () => {
-    const dir = mkdtempSync(join(tmpdir(), "openclaw-cross-os-agent-skip-tail-"));
-    try {
+    withTempDir("openclaw-cross-os-agent-skip-tail-", (dir) => {
       const logPath = join(dir, "agent.log");
       writeFileSync(
         logPath,
@@ -543,14 +527,11 @@ describe("scripts/openclaw-cross-os-release-checks", () => {
           logPath,
         ),
       ).toBe(false);
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
+    });
   });
 
   it("only skips opted-in cross-OS live agent turns after retry exhaustion", () => {
-    const dir = mkdtempSync(join(tmpdir(), "openclaw-cross-os-agent-skip-retry-"));
-    try {
+    withTempDir("openclaw-cross-os-agent-skip-retry-", (dir) => {
       const logPath = join(dir, "agent.log");
       const error = new Error("gateway request timeout for agent after 210000ms");
 
@@ -583,9 +564,7 @@ describe("scripts/openclaw-cross-os-release-checks", () => {
       expect(readFileSync(logPath, "utf8")).toContain(
         "skipping optional cross-OS live agent turn after retryable failure",
       );
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
+    });
   });
 
   it("allows cross-OS provider smoke models to use faster CI overrides", () => {
@@ -709,8 +688,7 @@ describe("scripts/openclaw-cross-os-release-checks", () => {
   });
 
   it("falls back to pnpm pack for historical refs without the Docker package helper", () => {
-    const dir = mkdtempSync(join(tmpdir(), "openclaw-cross-os-pack-command-"));
-    try {
+    withTempDir("openclaw-cross-os-pack-command-", (dir) => {
       const packDir = join(dir, "out");
       const fallback = resolvePackageCandidatePackCommand(dir, packDir);
 
@@ -730,9 +708,7 @@ describe("scripts/openclaw-cross-os-release-checks", () => {
         command: process.execPath,
         kind: "docker-helper",
       });
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
+    });
   });
 
   it("keeps the Windows packaged-upgrade fallback install out of npm lifecycle scripts", () => {
@@ -826,14 +802,27 @@ describe("scripts/openclaw-cross-os-release-checks", () => {
   });
 
   it("detects release refs and keeps branch refs out of release-only logic", () => {
-    expect(looksLikeReleaseVersionRef("2026.4.5")).toBe(true);
-    expect(looksLikeReleaseVersionRef("refs/tags/v2026.4.5-beta.1")).toBe(true);
-    expect(looksLikeReleaseVersionRef("v2026.4.5-beta.1")).toBe(true);
-    expect(looksLikeReleaseVersionRef("refs/tags/v2026.4.5-alpha.1")).toBe(true);
-    expect(looksLikeReleaseVersionRef("v2026.4.5-alpha.1")).toBe(true);
-    expect(looksLikeReleaseVersionRef("v2026.4.7-1")).toBe(true);
-    expect(looksLikeReleaseVersionRef("main")).toBe(false);
-    expect(looksLikeReleaseVersionRef("codex/cross-os-release-checks")).toBe(false);
+    const inputs = [
+      "2026.4.5",
+      "refs/tags/v2026.4.5-beta.1",
+      "v2026.4.5-beta.1",
+      "refs/tags/v2026.4.5-alpha.1",
+      "v2026.4.5-alpha.1",
+      "v2026.4.7-1",
+      "main",
+      "codex/cross-os-release-checks",
+    ];
+
+    expect(inputs.map(looksLikeReleaseVersionRef)).toEqual([
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false,
+      false,
+    ]);
   });
 
   it("normalizes full Git refs before suite and update decisions", () => {
@@ -854,37 +843,29 @@ describe("scripts/openclaw-cross-os-release-checks", () => {
     expect(shouldRunMainChannelDevUpdate("refs/tags/main")).toBe(false);
   });
 
-  it("skips the dev-update suite for immutable release refs", () => {
-    expect(resolveRequestedSuites("both", "v2026.4.5")).toEqual([
-      "packaged-fresh",
-      "installer-fresh",
-      "packaged-upgrade",
-    ]);
-  });
-
-  it("skips dev-update for non-main branch validation refs", () => {
-    expect(resolveRequestedSuites("both", "codex/cross-os-release-checks")).toEqual([
-      "packaged-fresh",
-      "installer-fresh",
-      "packaged-upgrade",
-    ]);
-  });
-
-  it("keeps dev-update enabled for main validation refs", () => {
-    expect(resolveRequestedSuites("both", "main")).toEqual([
-      "packaged-fresh",
-      "installer-fresh",
-      "packaged-upgrade",
-      "dev-update",
-    ]);
-  });
-
-  it("skips dev-update for pinned commit refs", () => {
-    expect(resolveRequestedSuites("both", "08753a1d793c040b101c8a26c43445dbbab14995")).toEqual([
-      "packaged-fresh",
-      "installer-fresh",
-      "packaged-upgrade",
-    ]);
+  it.each([
+    {
+      name: "skips the dev-update suite for immutable release refs",
+      input: "v2026.4.5",
+      expected: ["packaged-fresh", "installer-fresh", "packaged-upgrade"],
+    },
+    {
+      name: "skips dev-update for non-main branch validation refs",
+      input: "codex/cross-os-release-checks",
+      expected: ["packaged-fresh", "installer-fresh", "packaged-upgrade"],
+    },
+    {
+      name: "keeps dev-update enabled for main validation refs",
+      input: "main",
+      expected: ["packaged-fresh", "installer-fresh", "packaged-upgrade", "dev-update"],
+    },
+    {
+      name: "skips dev-update for pinned commit refs",
+      input: "08753a1d793c040b101c8a26c43445dbbab14995",
+      expected: ["packaged-fresh", "installer-fresh", "packaged-upgrade"],
+    },
+  ])("$name", ({ input, expected }) => {
+    expect(resolveRequestedSuites("both", input)).toEqual(expected);
   });
 
   it("builds a suite-aware runner matrix with the beefy Windows default", () => {
@@ -1178,16 +1159,37 @@ describe("scripts/openclaw-cross-os-release-checks", () => {
     expect(serverSource).not.toContain("readFileSync(params.filePath)");
   });
 
-  it("uses the published installer URLs for native installer lanes", () => {
-    expect(resolvePublishedInstallerUrl("darwin")).toBe("https://openclaw.ai/install.sh");
-    expect(resolvePublishedInstallerUrl("linux")).toBe("https://openclaw.ai/install.sh");
-    expect(resolvePublishedInstallerUrl("win32")).toBe("https://openclaw.ai/install.ps1");
-  });
-
-  it("uses managed gateway services only on native Windows runners", () => {
-    expect(shouldUseManagedGatewayService("win32")).toBe(true);
-    expect(shouldUseManagedGatewayService("darwin")).toBe(false);
-    expect(shouldUseManagedGatewayService("linux")).toBe(false);
+  it.each([
+    {
+      name: "uses the published installer URLs for native installer lanes",
+      decide: resolvePublishedInstallerUrl,
+      inputs: ["darwin", "linux", "win32"] as const,
+      expected: [
+        "https://openclaw.ai/install.sh",
+        "https://openclaw.ai/install.sh",
+        "https://openclaw.ai/install.ps1",
+      ],
+    },
+    {
+      name: "uses managed gateway services only on native Windows runners",
+      decide: shouldUseManagedGatewayService,
+      inputs: ["win32", "darwin", "linux"] as const,
+      expected: [true, false, false],
+    },
+    {
+      name: "stops the managed gateway before the manual fallback only on Windows",
+      decide: shouldStopManagedGatewayBeforeManualFallback,
+      inputs: ["win32", "darwin", "linux"] as const,
+      expected: [true, false, false],
+    },
+    {
+      name: "skips daemon health during installed onboarding only on native Windows",
+      decide: shouldSkipInstallerDaemonHealthCheck,
+      inputs: ["win32", "darwin", "linux"] as const,
+      expected: [true, false, false],
+    },
+  ])("$name", ({ decide, inputs, expected }) => {
+    expect(inputs.map((platform) => decide(platform))).toEqual(expected);
   });
 
   it("skips workspace bootstrap during release onboarding", () => {
@@ -1225,18 +1227,6 @@ describe("scripts/openclaw-cross-os-release-checks", () => {
     expect(shouldUseManagedGatewayForInstallerRuntime("darwin")).toBe(false);
   });
 
-  it("stops the managed gateway before the manual fallback only on Windows", () => {
-    expect(shouldStopManagedGatewayBeforeManualFallback("win32")).toBe(true);
-    expect(shouldStopManagedGatewayBeforeManualFallback("darwin")).toBe(false);
-    expect(shouldStopManagedGatewayBeforeManualFallback("linux")).toBe(false);
-  });
-
-  it("skips daemon health during installed onboarding only on native Windows", () => {
-    expect(shouldSkipInstallerDaemonHealthCheck("win32")).toBe(true);
-    expect(shouldSkipInstallerDaemonHealthCheck("darwin")).toBe(false);
-    expect(shouldSkipInstallerDaemonHealthCheck("linux")).toBe(false);
-  });
-
   it("runs the installed browser override import smoke only on native Windows", () => {
     expect(shouldRunWindowsInstalledBrowserOverrideImportSmoke("win32")).toBe(true);
     expect(shouldRunWindowsInstalledBrowserOverrideImportSmoke("darwin")).toBe(false);
@@ -1260,29 +1250,35 @@ describe("scripts/openclaw-cross-os-release-checks", () => {
     );
   });
 
-  it("normalizes Windows installed CLI paths to the cmd shim", () => {
-    expect(
-      normalizeWindowsInstalledCliPath(
+  it.each([
+    {
+      name: "normalizes Windows installed CLI paths to the cmd shim",
+      decide: normalizeWindowsInstalledCliPath,
+      inputs: [
         String.raw`C:\Users\runner\AppData\Roaming\npm\openclaw.ps1`,
-      ),
-    ).toBe(String.raw`C:\Users\runner\AppData\Roaming\npm\openclaw.cmd`);
-    expect(
-      normalizeWindowsInstalledCliPath(
         String.raw`C:\Users\runner\AppData\Roaming\npm\openclaw.cmd`,
-      ),
-    ).toBe(String.raw`C:\Users\runner\AppData\Roaming\npm\openclaw.cmd`);
-  });
-
-  it("normalizes generic Windows PowerShell shims to cmd shims", () => {
-    expect(normalizeWindowsCommandShimPath(String.raw`C:\Program Files\nodejs\pnpm.ps1`)).toBe(
-      String.raw`C:\Program Files\nodejs\pnpm.cmd`,
-    );
-    expect(normalizeWindowsCommandShimPath(String.raw`C:\Program Files\nodejs\corepack.ps1`)).toBe(
-      String.raw`C:\Program Files\nodejs\corepack.cmd`,
-    );
-    expect(normalizeWindowsCommandShimPath(String.raw`C:\Program Files\nodejs\node.exe`)).toBe(
-      String.raw`C:\Program Files\nodejs\node.exe`,
-    );
+      ],
+      expected: [
+        String.raw`C:\Users\runner\AppData\Roaming\npm\openclaw.cmd`,
+        String.raw`C:\Users\runner\AppData\Roaming\npm\openclaw.cmd`,
+      ],
+    },
+    {
+      name: "normalizes generic Windows PowerShell shims to cmd shims",
+      decide: normalizeWindowsCommandShimPath,
+      inputs: [
+        String.raw`C:\Program Files\nodejs\pnpm.ps1`,
+        String.raw`C:\Program Files\nodejs\corepack.ps1`,
+        String.raw`C:\Program Files\nodejs\node.exe`,
+      ],
+      expected: [
+        String.raw`C:\Program Files\nodejs\pnpm.cmd`,
+        String.raw`C:\Program Files\nodejs\corepack.cmd`,
+        String.raw`C:\Program Files\nodejs\node.exe`,
+      ],
+    },
+  ])("$name", ({ decide, inputs, expected }) => {
+    expect(inputs.map((input) => decide(input))).toEqual(expected);
   });
 
   it("wraps Windows cmd shims without Node shell argv", () => {
@@ -1358,8 +1354,7 @@ describe("scripts/openclaw-cross-os-release-checks", () => {
   });
 
   it("runs resolved command invocations and writes command logs", async () => {
-    const dir = mkdtempSync(join(tmpdir(), "openclaw-cross-os-run-command-"));
-    try {
+    await withTempDirAsync("openclaw-cross-os-run-command-", async (dir) => {
       const logPath = join(dir, "command.log");
       const result = await runCommand(process.execPath, ["-e", "process.stdout.write('ok')"], {
         cwd: dir,
@@ -1373,14 +1368,11 @@ describe("scripts/openclaw-cross-os-release-checks", () => {
         stderr: "",
       });
       expect(readFileSync(logPath, "utf8")).toContain("start command=");
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
+    });
   });
 
   it("bounds retained command output while preserving full command logs", async () => {
-    const dir = mkdtempSync(join(tmpdir(), "openclaw-cross-os-run-command-output-"));
-    try {
+    await withTempDirAsync("openclaw-cross-os-run-command-output-", async (dir) => {
       const logPath = join(dir, "command.log");
       const result = await runCommand(
         process.execPath,
@@ -1404,14 +1396,11 @@ describe("scripts/openclaw-cross-os-release-checks", () => {
       const log = readFileSync(logPath, "utf8");
       expect(log).toContain("old-middle-recent");
       expect(log).toContain("err-old-err-recent");
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
+    });
   });
 
   it("flushes command logs before resolving", async () => {
-    const dir = mkdtempSync(join(tmpdir(), "openclaw-cross-os-run-command-flush-"));
-    try {
+    await withTempDirAsync("openclaw-cross-os-run-command-flush-", async (dir) => {
       const logPath = join(dir, "flush.log");
       const marker = `flush-start-${"x".repeat(128 * 1024)}-flush-end`;
 
@@ -1433,14 +1422,11 @@ describe("scripts/openclaw-cross-os-release-checks", () => {
       );
 
       expect(readFileSync(logPath, "utf8")).toContain(marker);
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
+    });
   });
 
   it("reads npm debug logs from the Windows cache root", () => {
-    const dir = mkdtempSync(join(tmpdir(), "openclaw-cross-os-npm-debug-"));
-    try {
+    withTempDir("openclaw-cross-os-npm-debug-", (dir) => {
       const homeDir = join(dir, "home");
       const localAppData = join(homeDir, "AppData", "Local");
       const logsDir = join(localAppData, "npm-cache", "_logs");
@@ -1456,14 +1442,11 @@ describe("scripts/openclaw-cross-os-release-checks", () => {
         appendLatestNpmDebugLogTail(homeDir, logPath, { LOCALAPPDATA: localAppData }, "win32"),
       ).toContain("windows log");
       expect(readFileSync(logPath, "utf8")).toContain("windows log");
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
+    });
   });
 
   it("prefers npm configured log directories over cache defaults", () => {
-    const dir = mkdtempSync(join(tmpdir(), "openclaw-cross-os-npm-logs-dir-"));
-    try {
+    withTempDir("openclaw-cross-os-npm-logs-dir-", (dir) => {
       const homeDir = join(dir, "home");
       const logsDir = join(dir, "custom-logs");
       const logPath = join(dir, "install.log");
@@ -1486,14 +1469,11 @@ describe("scripts/openclaw-cross-os-release-checks", () => {
         appendLatestNpmDebugLogTail(homeDir, logPath, { npm_config_logs_dir: logsDir }),
       ).toContain("custom log");
       expect(readFileSync(logPath, "utf8")).toContain("custom log");
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
+    });
   });
 
   it("keeps npm debug log collection best-effort", () => {
-    const dir = mkdtempSync(join(tmpdir(), "openclaw-cross-os-npm-debug-best-effort-"));
-    try {
+    withTempDir("openclaw-cross-os-npm-debug-best-effort-", (dir) => {
       const homeDir = join(dir, "home");
       const logPath = join(dir, "install.log");
       const logsDir = join(dir, "not-a-directory");
@@ -1504,14 +1484,11 @@ describe("scripts/openclaw-cross-os-release-checks", () => {
         "",
       );
       expect(readFileSync(logPath, "utf8")).toBe("install failed\n");
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
+    });
   });
 
   it("resolves relative npm log config from the install working directory", () => {
-    const dir = mkdtempSync(join(tmpdir(), "openclaw-cross-os-npm-relative-logs-"));
-    try {
+    withTempDir("openclaw-cross-os-npm-relative-logs-", (dir) => {
       const homeDir = join(dir, "home");
       const logsDir = join(homeDir, "relative-logs");
       const cacheLogsDir = join(homeDir, "relative-cache", "_logs");
@@ -1524,9 +1501,7 @@ describe("scripts/openclaw-cross-os-release-checks", () => {
       expect(resolveNpmDebugLogDirs(homeDir, { npm_config_cache: "relative-cache" })).toContain(
         cacheLogsDir,
       );
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
+    });
   });
 
   it("kills timed-out command process groups", async () => {
@@ -1845,12 +1820,14 @@ describe("scripts/openclaw-cross-os-release-checks", () => {
   });
 
   it("keeps the dev-update lane for main only", () => {
-    expect(shouldRunMainChannelDevUpdate("main")).toBe(true);
-    expect(shouldRunMainChannelDevUpdate("08753a1d793c040b101c8a26c43445dbbab14995")).toBe(false);
-    expect(shouldRunMainChannelDevUpdate(" codex/cross-os-release-checks-full-native-e2e ")).toBe(
-      false,
-    );
-    expect(shouldRunMainChannelDevUpdate("v2026.4.14")).toBe(false);
+    const inputs = [
+      "main",
+      "08753a1d793c040b101c8a26c43445dbbab14995",
+      " codex/cross-os-release-checks-full-native-e2e ",
+      "v2026.4.14",
+    ];
+
+    expect(inputs.map(shouldRunMainChannelDevUpdate)).toEqual([true, false, false, false]);
   });
 
   it("verifies main dev updates against the prepared source sha when available", () => {
@@ -1883,58 +1860,38 @@ describe("scripts/openclaw-cross-os-release-checks", () => {
     });
   });
 
-  it("rejects a successful packaged update followed by an old self-swapped process import miss", () => {
+  it.each([
+    {
+      name: "rejects a successful packaged update followed by an old self-swapped process import miss",
+      input: { installedVersion: "2026.4.27", stepExitCode: 0 },
+      expected: /Packaged upgrade failed/u,
+    },
+    {
+      name: "rejects packaged update failures before the candidate package lands",
+      input: { installedVersion: "2026.4.26", stepExitCode: 0 },
+      expected: /Packaged upgrade failed/u,
+    },
+    {
+      name: "rejects packaged update failures with unsuccessful update steps",
+      input: { installedVersion: "2026.4.27", stepExitCode: 1 },
+      expected: /Packaged upgrade failed/u,
+    },
+  ])("$name", ({ input, expected }) => {
     expect(() =>
       verifyPackagedUpgradeUpdateResult(
         {
           exitCode: 1,
           stdout: JSON.stringify({
             status: "ok",
-            after: { version: "2026.4.27" },
-            steps: [{ name: "global update", exitCode: 0 }],
+            after: { version: input.installedVersion },
+            steps: [{ name: "global update", exitCode: input.stepExitCode }],
           }),
           stderr:
             "[openclaw] Failed to start CLI: Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/tmp/prefix/lib/node_modules/openclaw/dist/memory-state-old.js'",
         },
         { candidateVersion: "2026.4.27" },
       ),
-    ).toThrow(/Packaged upgrade failed/u);
-  });
-
-  it("rejects packaged update failures before the candidate package lands", () => {
-    expect(() =>
-      verifyPackagedUpgradeUpdateResult(
-        {
-          exitCode: 1,
-          stdout: JSON.stringify({
-            status: "ok",
-            after: { version: "2026.4.26" },
-            steps: [{ name: "global update", exitCode: 0 }],
-          }),
-          stderr:
-            "[openclaw] Failed to start CLI: Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/tmp/prefix/lib/node_modules/openclaw/dist/memory-state-old.js'",
-        },
-        { candidateVersion: "2026.4.27" },
-      ),
-    ).toThrow(/Packaged upgrade failed/u);
-  });
-
-  it("rejects packaged update failures with unsuccessful update steps", () => {
-    expect(() =>
-      verifyPackagedUpgradeUpdateResult(
-        {
-          exitCode: 1,
-          stdout: JSON.stringify({
-            status: "ok",
-            after: { version: "2026.4.27" },
-            steps: [{ name: "global update", exitCode: 1 }],
-          }),
-          stderr:
-            "[openclaw] Failed to start CLI: Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/tmp/prefix/lib/node_modules/openclaw/dist/memory-state-old.js'",
-        },
-        { candidateVersion: "2026.4.27" },
-      ),
-    ).toThrow(/Packaged upgrade failed/u);
+    ).toThrow(expected);
   });
 
   it("recognizes the shipped Windows updater native-module backup cleanup failure", () => {
@@ -2063,8 +2020,7 @@ describe("scripts/openclaw-cross-os-release-checks", () => {
   });
 
   it("reads an installed baseline version without requiring build metadata", () => {
-    const prefixDir = mkdtempSync(join(tmpdir(), "openclaw-cross-os-installed-version-"));
-    try {
+    withTempDir("openclaw-cross-os-installed-version-", (prefixDir) => {
       const packageRoot =
         process.platform === "win32"
           ? join(prefixDir, "node_modules", "openclaw")
@@ -2080,14 +2036,11 @@ describe("scripts/openclaw-cross-os-release-checks", () => {
       );
 
       expect(readInstalledVersion(prefixDir)).toBe("2026.4.10");
-    } finally {
-      rmSync(prefixDir, { recursive: true, force: true });
-    }
+    });
   });
 
   it("treats missing package scripts as optional in older refs", () => {
-    const packageRoot = mkdtempSync(join(tmpdir(), "openclaw-cross-os-scripts-"));
-    try {
+    withTempDir("openclaw-cross-os-scripts-", (packageRoot) => {
       writeFileSync(
         join(packageRoot, "package.json"),
         JSON.stringify({
@@ -2101,14 +2054,11 @@ describe("scripts/openclaw-cross-os-release-checks", () => {
 
       expect(packageHasScript(packageRoot, "build")).toBe(true);
       expect(packageHasScript(packageRoot, "ui:build")).toBe(false);
-    } finally {
-      rmSync(packageRoot, { recursive: true, force: true });
-    }
+    });
   });
 
   it("rejects legacy plugin dependency staging debris before candidate inventory generation", async () => {
-    const packageRoot = mkdtempSync(join(tmpdir(), "openclaw-cross-os-stage-debris-"));
-    try {
+    await withTempDirAsync("openclaw-cross-os-stage-debris-", async (packageRoot) => {
       mkdirSync(
         join(packageRoot, "dist", "Extensions", "demo", ".OpenClaw-Install-Stage", "node_modules"),
         { recursive: true },
@@ -2125,14 +2075,11 @@ describe("scripts/openclaw-cross-os-release-checks", () => {
           logPath: join(packageRoot, "npm-pack-dry-run.log"),
         }),
       ).rejects.toThrow("unexpected legacy plugin dependency staging debris");
-    } finally {
-      rmSync(packageRoot, { recursive: true, force: true });
-    }
+    });
   });
 
   it("omits local build metadata from candidate package inventories", async () => {
-    const packageRoot = mkdtempSync(join(tmpdir(), "openclaw-cross-os-local-stamps-"));
-    try {
+    await withTempDirAsync("openclaw-cross-os-local-stamps-", async (packageRoot) => {
       mkdirSync(join(packageRoot, "dist"), { recursive: true });
       writeFileSync(
         join(packageRoot, "package.json"),
@@ -2152,86 +2099,43 @@ describe("scripts/openclaw-cross-os-release-checks", () => {
       expect(
         JSON.parse(readFileSync(join(packageRoot, "dist", "postinstall-inventory.json"), "utf8")),
       ).toEqual(["dist/index.js"]);
-    } finally {
-      rmSync(packageRoot, { recursive: true, force: true });
-    }
+    });
   });
 
-  it("accepts a git main dev-channel update status payload", () => {
-    expect(
-      verifyDevUpdateStatus(
-        JSON.stringify({
-          update: {
-            installKind: "git",
-            git: {
-              branch: "main",
-            },
-          },
-          channel: {
-            value: "dev",
-          },
-        }),
-      ),
-    ).toBeUndefined();
-  });
+  it.each([
+    {
+      name: "accepts a git main dev-channel update status payload",
+      input: { branch: "main" },
+      expected: undefined,
+    },
+    {
+      name: "accepts a git dev-channel payload for a requested non-main branch",
+      input: {
+        branch: "codex/cross-os-release-checks-full-native-e2e",
+        sha: "08753a1d793c040b101c8a26c43445dbbab14995",
+      },
+      ref: "codex/cross-os-release-checks-full-native-e2e",
+      expected: undefined,
+    },
+    {
+      name: "accepts a git dev-channel payload pinned to a prepared source sha",
+      input: { branch: "main", sha: "08753a1d793c040b101c8a26c43445dbbab14995" },
+      ref: "08753a1d793c040b101c8a26c43445dbbab14995",
+      expected: undefined,
+    },
+    {
+      name: "accepts uppercase requested commit shas when update status reports lowercase",
+      input: { sha: "08753a1d793c040b101c8a26c43445dbbab14995" },
+      ref: "08753A1D793C040B101C8A26C43445DBBAB14995",
+      expected: undefined,
+    },
+  ])("$name", ({ input, ref, expected }) => {
+    const payload = JSON.stringify({
+      update: { installKind: "git", git: input },
+      channel: { value: "dev" },
+    });
 
-  it("accepts a git dev-channel payload for a requested non-main branch", () => {
-    expect(
-      verifyDevUpdateStatus(
-        JSON.stringify({
-          update: {
-            installKind: "git",
-            git: {
-              branch: "codex/cross-os-release-checks-full-native-e2e",
-              sha: "08753a1d793c040b101c8a26c43445dbbab14995",
-            },
-          },
-          channel: {
-            value: "dev",
-          },
-        }),
-        { ref: "codex/cross-os-release-checks-full-native-e2e" },
-      ),
-    ).toBeUndefined();
-  });
-
-  it("accepts a git dev-channel payload pinned to a prepared source sha", () => {
-    expect(
-      verifyDevUpdateStatus(
-        JSON.stringify({
-          update: {
-            installKind: "git",
-            git: {
-              branch: "main",
-              sha: "08753a1d793c040b101c8a26c43445dbbab14995",
-            },
-          },
-          channel: {
-            value: "dev",
-          },
-        }),
-        { ref: "08753a1d793c040b101c8a26c43445dbbab14995" },
-      ),
-    ).toBeUndefined();
-  });
-
-  it("accepts uppercase requested commit shas when update status reports lowercase", () => {
-    expect(
-      verifyDevUpdateStatus(
-        JSON.stringify({
-          update: {
-            installKind: "git",
-            git: {
-              sha: "08753a1d793c040b101c8a26c43445dbbab14995",
-            },
-          },
-          channel: {
-            value: "dev",
-          },
-        }),
-        { ref: "08753A1D793C040B101C8A26C43445DBBAB14995" },
-      ),
-    ).toBeUndefined();
+    expect(verifyDevUpdateStatus(payload, ref ? { ref } : undefined)).toBe(expected);
   });
 
   it("rejects update status payloads that are not on dev/main git", () => {


### PR DESCRIPTION
## What Problem This Solves

The policy-guard suites repeated Git repository setup, package-diff setup, routing expectations, platform decisions, and temporary-directory cleanup across one-off tests. That made already-large test files harder to scan and maintain.

## Why This Change Was Made

This refactors the genuinely same-shape cases in `changed-lanes.test.ts` and `openclaw-cross-os-release-checks.test.ts` into named `it.each` rows and file-local fixture helpers. Every original test name, input fixture, assertion outcome, and cleanup boundary remains covered. The dependency-pin and package-patch suites were inspected but intentionally left unchanged because their four/five cases exercise distinct repository states; a table would hide rather than remove complexity.

The remaining large cross-OS cases are process, signal, socket, and filesystem lifecycle scenarios, so they remain plain `it()` tests. Likewise, staged/worktree Git-state tests stay explicit.

## User Impact

None. This is a behavior-neutral test-only refactor; guarded scripts and product code are unchanged.

## Evidence

- LOC: production `+0/-0`; tests `+723/-1156`; net `-433` across 2 files.
- `test/scripts/changed-lanes.test.ts`: 2,423 -> 2,086 lines; 110 tests before and after.
- `test/scripts/openclaw-cross-os-release-checks.test.ts`: 2,254 -> 2,158 lines; 108 tests before and after.
- `node scripts/check-changed.mjs -- test/scripts/changed-lanes.test.ts test/scripts/openclaw-cross-os-release-checks.test.ts` — [Testbox green](https://github.com/openclaw/openclaw/actions/runs/29957182418) (format, guards, test-root typecheck, scripts lint).
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` — clean; no accepted/actionable findings.
- [Exact-head CI green](https://github.com/openclaw/openclaw/actions/runs/29958581525) on `e0e759a2e0a948e1c45e4c9d50578da2f71b4a1a`.

Focused output (redacted; current patch content is unchanged by the clean rebase):

```text
$ node scripts/run-vitest.mjs test/scripts/changed-lanes.test.ts
Test Files  1 passed (1)
Tests       110 passed (110)
[test] passed 1 Vitest shard

$ node scripts/run-vitest.mjs test/scripts/openclaw-cross-os-release-checks.test.ts
Test Files  1 passed (1)
Tests       108 passed (108)
[test] passed 1 Vitest shard
```

ClawSweeper rank-up disposition: inspectable focused output and linked current-head CI are included above. The branch was cleanly rebased onto `origin/main` before preparation, then the rebased head passed exact-head CI. Later main movement is advisory under the repository landing policy and is intentionally not chased with another full-gate cycle.
