### PR TITLE
fix(ui): keep case-distinct Matrix rooms in separate transcript cache entries

### DIFF
--- a/ui/src/pages/chat/session-message-cache.test.ts
+++ b/ui/src/pages/chat/session-message-cache.test.ts
@@ -29,6 +29,21 @@ function cacheChatMessages(
 }
 
 describe("session message cache", () => {
+  it("keeps case-distinct Matrix rooms in separate cache entries", () => {
+    const host = createHost();
+    const cache: ChatMessageCache = new Map();
+    const mixed = "agent:ops:matrix:channel:!MixedRoomAbCdEf:example.org";
+    const lowered = "agent:ops:matrix:channel:!mixedroomabcdef:example.org";
+
+    cacheChatMessages(cache, host, { sessionKey: mixed }, ["mixed room"]);
+
+    // Same key, exact case: the snapshot is found.
+    expect(readChatMessagesFromCache(cache, host, { sessionKey: mixed })).toEqual(["mixed room"]);
+    // Case-distinct room ID: must not see the other room's messages.
+    expect(readChatMessagesFromCache(cache, host, { sessionKey: lowered })).toEqual([]);
+    expect(readChatSessionSnapshot(cache, host, { sessionKey: lowered })).toBeNull();
+  });
+
   it("canonicalizes main aliases without crossing agent scopes", () => {
     const host = createHost();
     const cache: ChatMessageCache = new Map();

--- a/ui/src/pages/chat/session-message-cache.ts
+++ b/ui/src/pages/chat/session-message-cache.ts
@@ -3,13 +3,13 @@ import {
   DEFAULT_MAIN_KEY,
   isUiGlobalSessionKey,
   normalizeAgentId,
+  normalizeSessionKeyForUiComparison,
   parseAgentSessionKey,
   resolveUiConfiguredMainKey,
   resolveUiDefaultAgentId,
   resolveUiSelectedGlobalAgentId,
   type UiSessionDefaultsHost,
 } from "../../lib/sessions/session-key.ts";
-import { normalizeLowercaseStringOrEmpty } from "../../lib/string-coerce.ts";
 import type { ChatHistoryPagination } from "./chat-history-pagination.ts";
 import { readTranscriptSequence } from "./history-merge.ts";
 import { getSessionCacheValue, setSessionCacheValue } from "./session-cache.ts";
@@ -64,7 +64,14 @@ function resolveCacheAgentId(host: ChatMessageCacheHost, target: ChatMessageCach
 
 function resolveCanonicalSessionKey(host: ChatMessageCacheHost, sessionKey: string): string {
   const parsed = parseAgentSessionKey(sessionKey);
-  const normalized = normalizeLowercaseStringOrEmpty(parsed?.rest ?? sessionKey);
+  // Extract the rest from the raw key, not parsed.rest: parseAgentSessionKey
+  // lowercases the whole key up front, which would collapse case-distinct
+  // Matrix room IDs into one cache entry. The canonical UI normalizer then
+  // preserves the opaque provider tail.
+  const rawRest = parsed
+    ? sessionKey.split(":").filter(Boolean).slice(2).join(":")
+    : sessionKey;
+  const normalized = normalizeSessionKeyForUiComparison(rawRest);
   const configuredMainKey = resolveUiConfiguredMainKey(host);
   return isUiGlobalSessionKey(sessionKey) ||
     normalized === DEFAULT_MAIN_KEY ||

--- a/ui/src/pages/chat/session-message-cache.ts
+++ b/ui/src/pages/chat/session-message-cache.ts
@@ -68,9 +68,7 @@ function resolveCanonicalSessionKey(host: ChatMessageCacheHost, sessionKey: stri
   // lowercases the whole key up front, which would collapse case-distinct
   // Matrix room IDs into one cache entry. The canonical UI normalizer then
   // preserves the opaque provider tail.
-  const rawRest = parsed
-    ? sessionKey.split(":").filter(Boolean).slice(2).join(":")
-    : sessionKey;
+  const rawRest = parsed ? sessionKey.split(":").filter(Boolean).slice(2).join(":") : sessionKey;
   const normalized = normalizeSessionKeyForUiComparison(rawRest);
   const configuredMainKey = resolveUiConfiguredMainKey(host);
   return isUiGlobalSessionKey(sessionKey) ||


### PR DESCRIPTION
## What Problem This Solves

The transcript cache built its key through `parseAgentSessionKey`, which lowercases the whole session key up front. Two Matrix rooms whose IDs differ only by case (legal in the spec) then shared one cache entry, and a route switch briefly showed the other room's messages (#112749).

The canonicalizer now takes the session rest from the raw key (case intact) and runs it through `normalizeSessionKeyForUiComparison`, which preserves the opaque Matrix tail. That matches the case-preservation registry's semantics instead of fighting it.

## Evidence

A new case-distinct room regression: mixed-case write followed by a lowercase read must come back empty. Full suite `session-message-cache.test.ts` 13/13 and `ui/src/lib/sessions` 120/120 green. The unrelated `chat-state.test.ts` load failure is a missing `apps/` resource in my sparse checkout, not from this change.

Fixes #112749.
